### PR TITLE
fix(api): allow HEAD on /api/v1/direct-download

### DIFF
--- a/internal/api/router.go
+++ b/internal/api/router.go
@@ -1547,6 +1547,7 @@ func NewRouter(deps Dependencies) chi.Router {
 					r.Get("/{id}/file", downloadHandler.HandleDownloadFile)
 				})
 				r.Get("/direct-download", downloadHandler.HandleDirectDownload)
+				r.Head("/direct-download", downloadHandler.HandleDirectDownload)
 
 				// Recipe gallery catalog (no profile required — purely static metadata).
 				recipeHandler := &handlers.RecipeHandler{}


### PR DESCRIPTION
## Summary
- Firefox issues a `HEAD /api/v1/direct-download` before starting a download. The route only registered `GET`, so HEAD returned **405 Method Not Allowed** and the browser aborted the download.
- Register `r.Head("/direct-download", ...)` alongside the existing `r.Get(...)`, pointing at the same handler. Mirrors the pattern already used by `/stream/{session_id}` (router.go:1537-1538).
- No handler changes needed — `ServeDirect` is built on `http.ServeContent` / `ServeFile`, which handle HEAD natively (headers without body).

## Test plan
- [x] Reproduced in prod logs: `HEAD /api/v1/direct-download → 405` from Firefox, no subsequent GET (download aborted)
- [x] After fix: `HEAD` is accepted; browser-initiated download from the web UI completes
- [ ] Confirm mobile clients (ktor-client) `POST /api/v1/downloads` flow unaffected (separate code path)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added HEAD request support for the direct download endpoint, allowing clients to check resource metadata and availability without downloading content.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Silo-Server/silo-server/pull/5?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->