### PR TITLE
feat(requests): add media request system

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -1,0 +1,4 @@
+#!/usr/bin/env sh
+set -eu
+
+scripts/check-local-path-leaks.sh --cached

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -3,6 +3,8 @@
 ## Project Structure & Module Organization
 `cmd/silo` contains the main server entrypoint. Backend code lives in `internal/`, organized by domain (`api`, `catalog`, `metadata`, `playback`, `scanner`, `jellycompat`, etc.); keep new code in the package that owns the behavior instead of creating catch-all helpers. Database changes belong in `migrations/` as paired numbered `.up.sql` and `.down.sql` files. The React frontend lives in `web/src/`, with feature code split across `components/`, `pages/`, `hooks/`, `player/`, and `lib/`. Reference material belongs in `docs/architecture/` or `docs/superpowers/{specs,plans}/`; ad hoc SQL helpers live in `scripts/`.
 
+When creating or editing `docs/superpowers/specs/` or `docs/superpowers/plans/`, never include local absolute filesystem paths or transient worktree IDs. Use repository-relative paths and wording like "Commands assume the repository root is the cwd."
+
 This repository is a VERY EARLY WIP. Proposing sweeping changes that improve long-term maintainability is encouraged.
 
 

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: frontend build dev-frontend dev-backend dev-proxy dev-transcode lint clean jellyfin-web-bundle migrate-continuum-check
+.PHONY: frontend build dev-frontend dev-backend dev-proxy dev-transcode lint clean jellyfin-web-bundle migrate-continuum-check verify-local-paths install-hooks
 
 GIT_COMMON_DIR := $(strip $(shell git rev-parse --git-common-dir 2>/dev/null))
 MAIN_CHECKOUT_ROOT := $(if $(GIT_COMMON_DIR),$(abspath $(GIT_COMMON_DIR)/..))
@@ -42,6 +42,14 @@ dev-transcode:
 lint:
 	golangci-lint run
 	cd web && pnpm run lint
+
+# Check committed content for local machine path leaks.
+verify-local-paths:
+	scripts/check-local-path-leaks.sh
+
+# Install repo-local git hooks for this checkout/worktree.
+install-hooks:
+	git config core.hooksPath .githooks
 
 # Fetch and build the pinned Jellyfin Web bundle
 jellyfin-web-bundle:

--- a/scripts/check-local-path-leaks.sh
+++ b/scripts/check-local-path-leaks.sh
@@ -1,0 +1,64 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+usage() {
+	printf 'usage: %s [--cached]\n' "${0##*/}" >&2
+}
+
+cached=0
+case "${1:-}" in
+	"")
+		;;
+	--cached)
+		cached=1
+		;;
+	-h|--help)
+		usage
+		exit 0
+		;;
+	*)
+		usage
+		exit 2
+		;;
+esac
+
+repo_root=$(git rev-parse --show-toplevel)
+cd "$repo_root"
+
+failed=0
+t3_worktree_dir='\.t3'/'worktrees'
+t3_worktree_id_prefix='t3''code-'
+
+check_pattern() {
+	local label=$1
+	local pattern=$2
+	shift 2
+
+	local matches
+	if [[ "$cached" -eq 1 ]]; then
+		matches=$(git grep --cached -n -I -E "$pattern" -- "$@" 2>/dev/null) || return 0
+	else
+		matches=$(git grep -n -I -E "$pattern" -- "$@" 2>/dev/null) || return 0
+	fi
+
+	if [[ -n "$matches" ]]; then
+		printf '%s\n' "local path leak check failed: $label" >&2
+		printf '%s\n\n' "$matches" >&2
+		failed=1
+	fi
+}
+
+check_pattern \
+	"T3 worktree path or generated worktree id" \
+	"(${t3_worktree_dir}|/Users/[^[:space:]]*/${t3_worktree_dir}/|${t3_worktree_id_prefix}[0-9a-f]{8})" \
+	.
+
+check_pattern \
+	"absolute /Users path in generated superpowers docs" \
+	'/Users/[^[:space:]]+' \
+	docs/superpowers/specs docs/superpowers/plans
+
+if [[ "$failed" -ne 0 ]]; then
+	printf '%s\n' "Remove local machine paths from committed content. Use repository-relative paths instead." >&2
+	exit 1
+fi


### PR DESCRIPTION
## Summary
- Introduce an end-to-end media requests system: TMDB-backed search/discovery/detail APIs, a quota-aware request service, Radarr/Sonarr fulfillment, and a reconcile-requests background task.
- Build the user-facing Requests experience: `/requests` discovery + search + "Yours" tabs, request detail page, and admin queue/settings/limits surfaces.
- Layer curated Studios, Networks, and Genres discovery on top of the request stack using duotone TMDB logos and fixed logo paths instead of per-request logo lookups.

## Test plan
- go test ./internal/requests ./internal/metadata/tmdb ./internal/api/handlers
- Manually exercised /requests: verified discovery carousels render, browse routes for studios/networks/genres work, and request cards show the correct state ribbons and dimming.

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Touches authenticated APIs, admin settings for external arr API keys, fulfillment/reconciliation, and a large new domain surface area with quota and request-state rules.
> 
> **Overview**
> Adds a **media request system** end-to-end: new `internal/requests` service and HTTP handlers for TMDB search/discovery/detail, creating and listing requests, admin approve/decline/retry, settings, per-user limits, and Radarr/Sonarr integrations (including sensitive setting keys). **TMDB client** gains search, discovery sections, paginated discover with companies/networks, media detail, and company/network lookups. **API router** wires profile `/requests/*` and admin request routes; **server startup** registers a reconcile-requests background task.
> 
> **Brand discovery** on top of requests: bundled studios/networks/genres, list + browse APIs, and browse routes ordered before generic discover paths. **Web** adds Requests, RequestBrowse, detail routes, brand carousels, and clears request queries on profile change.
> 
> **Repo hygiene**: pre-commit hook and `make verify-local-paths` / `install-hooks` to block local filesystem paths in commits; **AGENTS.md** documents the same for superpowers docs. Large **specs/plans** describe the request system and studios/networks/genres design (documentation only in this diff).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 30396df0d82aee864a6fbb73aba991ffbab27def. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Full media request system: discovery/search/detail, create requests, lifecycle (pending→approved→queued→downloading→completed).
  * Browse-by-brand carousels and browse pages for studios, networks, and genres.
  * Radarr & Sonarr fulfillment integrations and background reconciliation worker to update request status.
  * Admin Requests UI: queue, global settings, integrations, per-user limits; API keys now hidden from settings responses.

* **Style/UX**
  * New Request pages/components and downloading shimmer; clears request cache on profile change/logout.

* **Documentation**
  * Detailed specs and implementation plans for the request system and browse design.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Silo-Server/silo-server/pull/6?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->