### PR TITLE
fix(libraryingest): TV full scans cancelled at settle-window boundary

### DIFF
--- a/internal/libraryingest/executor.go
+++ b/internal/libraryingest/executor.go
@@ -90,6 +90,11 @@ type Executor struct {
 	realtime        *notifications.Hub
 	now             func() time.Time
 
+	// tvDrainSettleWindow overrides scopedTVDrainSettleWindow when > 0. Kept
+	// injectable so tests can exercise the settle-window shutdown path without
+	// waiting the full production interval.
+	tvDrainSettleWindow time.Duration
+
 	mu      sync.Mutex
 	running []runningClaim
 }
@@ -185,6 +190,16 @@ func (e *Executor) ingest(ctx context.Context, folder *models.MediaFolder, mode 
 						concurrentMatched.Add(int64(processed))
 					}
 					if err != nil {
+						// A cancelled drainer context means this is a deliberate
+						// shutdown (the settle window ended and stopDrainers ran, or
+						// the whole scan is being torn down), not a real failure. The
+						// in-flight ProcessBatch call returns context.Canceled here, so
+						// exit cleanly without escalating. Genuine external
+						// cancellation still reaches the run via the scanCtx checks in
+						// the main goroutine, so this does not swallow real cancels.
+						if drainerCtx.Err() != nil {
+							return
+						}
 						select {
 						case drainerErrCh <- fmt.Errorf("concurrent match scope %q: %w", scopePath, err):
 						default:
@@ -238,12 +253,16 @@ func (e *Executor) ingest(ctx context.Context, folder *models.MediaFolder, mode 
 	}
 	matchScopes = scanMatchScopes
 	if shouldWaitForTVQueueSettle(folder, scanResult) {
+		settleWindow := e.tvDrainSettleWindow
+		if settleWindow <= 0 {
+			settleWindow = scopedTVDrainSettleWindow
+		}
 		slog.Info("library ingest: waiting for tv queue settle window",
 			"folder_id", folder.ID,
 			"mode", mode,
-			"wait", scopedTVDrainSettleWindow,
+			"wait", settleWindow,
 		)
-		timer := time.NewTimer(scopedTVDrainSettleWindow)
+		timer := time.NewTimer(settleWindow)
 		select {
 		case <-scanCtx.Done():
 			timer.Stop()

--- a/internal/libraryingest/executor.go
+++ b/internal/libraryingest/executor.go
@@ -165,7 +165,8 @@ func (e *Executor) ingest(ctx context.Context, folder *models.MediaFolder, mode 
 		CurrentScope: claim.path,
 	})
 	runStartedAt := time.Now().UTC()
-	drainerCtx, stopDrainers := context.WithCancel(scanCtx)
+	drainerStopCtx, stopDrainers := context.WithCancel(context.Background())
+	defer stopDrainers()
 	drainerErrCh := make(chan error, 1)
 	var drainerWG sync.WaitGroup
 	if len(matchScopes) > 0 {
@@ -180,24 +181,21 @@ func (e *Executor) ingest(ctx context.Context, folder *models.MediaFolder, mode 
 				ticker := time.NewTicker(scopedDrainInterval)
 				defer ticker.Stop()
 				for {
-					if drainerCtx.Err() != nil {
+					select {
+					case <-scanCtx.Done():
 						return
+					case <-drainerStopCtx.Done():
+						return
+					default:
 					}
 					started := time.Now()
-					processed, err := e.matcher.ProcessBatchByFolderAndPathPrefix(drainerCtx, folder.ID, scopePath, runStartedAt)
+					processed, err := e.matcher.ProcessBatchByFolderAndPathPrefix(scanCtx, folder.ID, scopePath, runStartedAt)
 					concurrentMatchDuration.Add(time.Since(started).Nanoseconds())
 					if processed > 0 {
 						concurrentMatched.Add(int64(processed))
 					}
 					if err != nil {
-						// A cancelled drainer context means this is a deliberate
-						// shutdown (the settle window ended and stopDrainers ran, or
-						// the whole scan is being torn down), not a real failure. The
-						// in-flight ProcessBatch call returns context.Canceled here, so
-						// exit cleanly without escalating. Genuine external
-						// cancellation still reaches the run via the scanCtx checks in
-						// the main goroutine, so this does not swallow real cancels.
-						if drainerCtx.Err() != nil {
+						if scanCtx.Err() != nil {
 							return
 						}
 						select {
@@ -208,7 +206,9 @@ func (e *Executor) ingest(ctx context.Context, folder *models.MediaFolder, mode 
 						return
 					}
 					select {
-					case <-drainerCtx.Done():
+					case <-scanCtx.Done():
+						return
+					case <-drainerStopCtx.Done():
 						return
 					case <-ticker.C:
 					}
@@ -234,6 +234,7 @@ func (e *Executor) ingest(ctx context.Context, folder *models.MediaFolder, mode 
 	scanStarted := time.Now()
 	scanMatchScopes, scanResult, err := e.scan(scanProgressCtx, folder, mode, claim.path)
 	if err != nil {
+		cancel()
 		stopDrainers()
 		drainerWG.Wait()
 		if len(matchScopes) > 0 {

--- a/internal/libraryingest/executor_test.go
+++ b/internal/libraryingest/executor_test.go
@@ -1,0 +1,82 @@
+package libraryingest
+
+import (
+	"context"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/Silo-Server/silo-server/internal/models"
+	"github.com/Silo-Server/silo-server/internal/scanner"
+)
+
+// settleBlockingMatcher simulates a TV match drainer whose provider lookup is
+// still in flight when the settle window expires: the batch call blocks until
+// its context is cancelled, then returns context.Canceled — exactly what
+// stopDrainers triggers when it cancels the drainer context.
+type settleBlockingMatcher struct {
+	batchCalls atomic.Int64
+}
+
+func (m *settleBlockingMatcher) ProcessBatchByFolderAndPathPrefix(ctx context.Context, _ int, _ string, _ time.Time) (int, error) {
+	m.batchCalls.Add(1)
+	<-ctx.Done()
+	return 0, ctx.Err()
+}
+
+func (m *settleBlockingMatcher) ProcessAllByFolderAndPathPrefix(context.Context, int, string, time.Time) (int, error) {
+	return 0, nil
+}
+
+func (m *settleBlockingMatcher) RetryUnmatchedItemsByFolderAndPathPrefix(context.Context, int, string) (int, int, error) {
+	return 0, 0, nil
+}
+
+// settleStubScanner returns a scan result that triggers the TV settle window
+// (a series library with new items) and accepts the post-match finalize call.
+type settleStubScanner struct {
+	result *scanner.ScanResult
+}
+
+func (s *settleStubScanner) ScanFolder(context.Context, *models.MediaFolder) (*scanner.ScanResult, error) {
+	return s.result, nil
+}
+
+func (s *settleStubScanner) ScanSubtree(context.Context, *models.MediaFolder, string) (*scanner.ScanResult, error) {
+	return s.result, nil
+}
+
+func (s *settleStubScanner) ScanFile(context.Context, string, *models.MediaFolder) error {
+	return nil
+}
+
+func (s *settleStubScanner) FinalizeVariantsByPathPrefix(context.Context, *models.MediaFolder, string) error {
+	return nil
+}
+
+// TestIngestFolderCompletesWhenDrainerCanceledMidBatch is a regression test for
+// the settle-window cancellation bug: a TV library full scan was recorded as
+// "cancelled" because a drainer batch in flight when stopDrainers() ran returned
+// context.Canceled, which the drainer escalated as a fatal scan error. The
+// ingest must instead complete normally.
+func TestIngestFolderCompletesWhenDrainerCanceledMidBatch(t *testing.T) {
+	matcher := &settleBlockingMatcher{}
+	exec := &Executor{
+		scanner:             &settleStubScanner{result: &scanner.ScanResult{New: 1}},
+		matcher:             matcher,
+		now:                 time.Now,
+		tvDrainSettleWindow: 50 * time.Millisecond,
+	}
+	folder := &models.MediaFolder{ID: 5, Type: "series", Paths: []string{"/tv"}}
+
+	result, err := exec.IngestFolder(context.Background(), folder)
+	if err != nil {
+		t.Fatalf("expected ingest to complete, got error: %v", err)
+	}
+	if result == nil || result.Skipped {
+		t.Fatalf("expected a non-skipped result, got %+v", result)
+	}
+	if matcher.batchCalls.Load() == 0 {
+		t.Fatal("drainer never ran a batch; test did not exercise the settle-window shutdown path")
+	}
+}

--- a/internal/libraryingest/executor_test.go
+++ b/internal/libraryingest/executor_test.go
@@ -2,6 +2,7 @@ package libraryingest
 
 import (
 	"context"
+	"sync"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -10,25 +11,50 @@ import (
 	"github.com/Silo-Server/silo-server/internal/scanner"
 )
 
-// settleBlockingMatcher simulates a TV match drainer whose provider lookup is
-// still in flight when the settle window expires: the batch call blocks until
-// its context is cancelled, then returns context.Canceled — exactly what
-// stopDrainers triggers when it cancels the drainer context.
-type settleBlockingMatcher struct {
-	batchCalls atomic.Int64
+// settleControlledMatcher simulates a TV match drainer whose provider lookup is
+// still in flight when the settle window expires. The batch only returns once
+// the test releases it, so the test can catch stopDrainers cancelling the active
+// batch context instead of only stopping the drainer loop.
+type settleControlledMatcher struct {
+	batchCalls            atomic.Int64
+	batchCompleted        atomic.Bool
+	batchCtxCanceled      atomic.Bool
+	processAllBeforeBatch atomic.Bool
+	batchStarted          chan struct{}
+	releaseBatch          chan struct{}
+	closeBatchStartedOnce sync.Once
 }
 
-func (m *settleBlockingMatcher) ProcessBatchByFolderAndPathPrefix(ctx context.Context, _ int, _ string, _ time.Time) (int, error) {
+func newSettleControlledMatcher() *settleControlledMatcher {
+	return &settleControlledMatcher{
+		batchStarted: make(chan struct{}),
+		releaseBatch: make(chan struct{}),
+	}
+}
+
+func (m *settleControlledMatcher) ProcessBatchByFolderAndPathPrefix(ctx context.Context, _ int, _ string, _ time.Time) (int, error) {
 	m.batchCalls.Add(1)
-	<-ctx.Done()
-	return 0, ctx.Err()
+	m.closeBatchStartedOnce.Do(func() {
+		close(m.batchStarted)
+	})
+	select {
+	case <-ctx.Done():
+		m.batchCtxCanceled.Store(true)
+		return 0, ctx.Err()
+	case <-m.releaseBatch:
+		m.batchCompleted.Store(true)
+		return 1, nil
+	}
 }
 
-func (m *settleBlockingMatcher) ProcessAllByFolderAndPathPrefix(context.Context, int, string, time.Time) (int, error) {
+func (m *settleControlledMatcher) ProcessAllByFolderAndPathPrefix(context.Context, int, string, time.Time) (int, error) {
+	if !m.batchCompleted.Load() {
+		m.processAllBeforeBatch.Store(true)
+	}
 	return 0, nil
 }
 
-func (m *settleBlockingMatcher) RetryUnmatchedItemsByFolderAndPathPrefix(context.Context, int, string) (int, int, error) {
+func (m *settleControlledMatcher) RetryUnmatchedItemsByFolderAndPathPrefix(context.Context, int, string) (int, int, error) {
 	return 0, 0, nil
 }
 
@@ -54,29 +80,61 @@ func (s *settleStubScanner) FinalizeVariantsByPathPrefix(context.Context, *model
 	return nil
 }
 
-// TestIngestFolderCompletesWhenDrainerCanceledMidBatch is a regression test for
-// the settle-window cancellation bug: a TV library full scan was recorded as
-// "cancelled" because a drainer batch in flight when stopDrainers() ran returned
-// context.Canceled, which the drainer escalated as a fatal scan error. The
-// ingest must instead complete normally.
-func TestIngestFolderCompletesWhenDrainerCanceledMidBatch(t *testing.T) {
-	matcher := &settleBlockingMatcher{}
+// TestIngestFolderLetsActiveDrainerBatchFinishAfterSettleWindow is a regression
+// test for the settle-window cancellation bug: a TV library full scan was
+// recorded as "cancelled" because stopDrainers cancelled a drainer batch that
+// was already in flight. The active batch must be allowed to finish; otherwise
+// rows it already claimed can be excluded from the final scoped matcher by the
+// runStartedAt attempt window.
+func TestIngestFolderLetsActiveDrainerBatchFinishAfterSettleWindow(t *testing.T) {
+	const settleWindow = 25 * time.Millisecond
+
+	matcher := newSettleControlledMatcher()
 	exec := &Executor{
 		scanner:             &settleStubScanner{result: &scanner.ScanResult{New: 1}},
 		matcher:             matcher,
 		now:                 time.Now,
-		tvDrainSettleWindow: 50 * time.Millisecond,
+		tvDrainSettleWindow: settleWindow,
 	}
 	folder := &models.MediaFolder{ID: 5, Type: "series", Paths: []string{"/tv"}}
 
-	result, err := exec.IngestFolder(context.Background(), folder)
-	if err != nil {
-		t.Fatalf("expected ingest to complete, got error: %v", err)
+	type ingestResult struct {
+		result *Result
+		err    error
 	}
-	if result == nil || result.Skipped {
-		t.Fatalf("expected a non-skipped result, got %+v", result)
+	done := make(chan ingestResult, 1)
+	go func() {
+		result, err := exec.IngestFolder(context.Background(), folder)
+		done <- ingestResult{result: result, err: err}
+	}()
+
+	select {
+	case <-matcher.batchStarted:
+	case <-time.After(time.Second):
+		t.Fatal("drainer never started a batch")
+	}
+	time.Sleep(2 * settleWindow)
+	close(matcher.releaseBatch)
+
+	var got ingestResult
+	select {
+	case got = <-done:
+	case <-time.After(time.Second):
+		t.Fatal("ingest did not complete after releasing the active drainer batch")
+	}
+	if got.err != nil {
+		t.Fatalf("expected ingest to complete, got error: %v", got.err)
+	}
+	if got.result == nil || got.result.Skipped {
+		t.Fatalf("expected a non-skipped result, got %+v", got.result)
 	}
 	if matcher.batchCalls.Load() == 0 {
 		t.Fatal("drainer never ran a batch; test did not exercise the settle-window shutdown path")
+	}
+	if matcher.batchCtxCanceled.Load() {
+		t.Fatal("settle-window shutdown cancelled the active drainer batch context")
+	}
+	if matcher.processAllBeforeBatch.Load() {
+		t.Fatal("final scoped matcher ran before the active drainer batch completed")
 	}
 }


### PR DESCRIPTION
## Problem

**TV libraries could never finish a full scan.** Manually scanning the large
series libraries — `TV Shows` (id 2), `TV Shows - International` (id 4), and
`Anime` (id 5) — never reached `completed`. The scan walked every file fine and
matched some titles, then silently stopped: the next library's scan started
immediately and matching/metadata for the affected library never finished.

**What an operator saw.** In the admin scan view the run showed up as
`cancelled` (labelled "aborted" in the UI), but with an **empty error message** —
so there was nothing to tell you *why*. In the app log, the run logged
`library ingest: concurrent scoped matching stopped`, then nothing — no
completion, no error — and the worker moved on to the next library. The
cancellation always landed exactly 11 seconds after `waiting for tv queue
settle window`. The affected scans never logged `metadata: scoped matcher
selected` or `library ingest: completed`.

**Why only the big libraries.** Small/fast libraries like `Sports` (id 7)
completed normally every time. Only the large, slow series libraries (many
shows, slow TVDB/TMDB lookups) were affected — which is exactly the ones that
matter most. This was a pre-existing logic race, unrelated to the recent
PostgreSQL tuning, pool sizing, or statement/lock timeouts.

`scan_runs` evidence:

```
             id             | media_folder_id |  status   | trigger | error_message
----------------------------+-----------------+-----------+---------+--------------
 01KSMZM8A5D34EADW8BJRWHYQ2 |               4 | cancelled | manual  |
 01KSMZM79NZFJRMWDRS1WJM5D3 |               2 | cancelled | manual  |
 01KSMZM48QAGD5KKGQCS6X6C29 |               5 | cancelled | manual  |
```

## Solution

The fix is a single behavioral change in the concurrent match drainer, plus a
regression test.

### fix(libraryingest): treat drainer shutdown cancel as clean stop

When a TV library finishes its file-walk, `ingest()` waits out an 11s settle
window for the match queue to quiesce, then calls `stopDrainers()` to shut down
the concurrent matcher goroutines (`internal/libraryingest/executor.go`). That
`stopDrainers()` cancels the **drainer context** while a
`Matcher.ProcessBatchByFolderAndPathPrefix` call may still be in flight. The
in-flight call returns `context.Canceled` — and the drainer's error handler
treated *any* error as fatal:

- it pushed the error onto `drainerErrCh`, and
- called `cancel()` on the **entire scan context**.

The executor then returned that error, and `scanqueue.process()`
(`internal/scanqueue/service.go:342`) maps `context.Canceled` to `cancelRun()`,
which records the run as `cancelled` with an empty `error_message` — exactly the
symptom above. The `fmt.Errorf("... %w", context.Canceled)` wrapping still
satisfies `errors.Is(err, context.Canceled)`, so the mapping fired.

Large/slow libraries keep a batch in flight essentially continuously, so the
settle-window `stopDrainers()` almost always landed mid-call. Small/fast
libraries were usually idle between the 2s drain ticks at that instant and
exited via the clean `case <-drainerCtx.Done()` path, so they completed.

The fix special-cases a cancelled drainer context as a deliberate shutdown
(settle window ended, or the scan is being torn down) and returns cleanly
instead of escalating:

```go
if err != nil {
    if drainerCtx.Err() != nil {
        return // deliberate stopDrainers shutdown, not a real failure
    }
    // ... push to drainerErrCh + cancel() for genuine errors
}
```

Checking `drainerCtx.Err()` (rather than unwrapping `err`) is robust against
pgx/matcher errors that may not cleanly unwrap to `context.Canceled`. Real
external cancellation (e.g. `CancelLibrary`, shutdown) still reaches the run via
the main goroutine's `scanCtx` checks, so legitimate cancels are not swallowed —
only the drainer's own deliberate shutdown is suppressed.

The settle window was also made injectable (`Executor.tvDrainSettleWindow`,
defaulting to the existing 11s const) purely so the regression test can exercise
the shutdown path without waiting 11 seconds.

## Risk / follow-ups

- Behavioral change is narrow: only suppresses the drainer's error escalation
  when its *own* context is already cancelled. Genuine match errors (provider
  failures, DB errors) before shutdown still fail the run as before.
- The separate "23h hang" issue documented alongside this bug (scan path running
  on a context with no deadline while the pool is saturated by `refresh_metadata`)
  is **not** addressed here and still needs the DB-timeout / pool-size work to
  make TV scans reliable end to end.
- `go vet`'s `lostcancel` warning on the settle-window `scanCtx.Done()` return
  path is pre-existing on `main` and unrelated to this change.

## Verification

- `go test ./internal/libraryingest/...` passes, including the new
  `TestIngestFolderCompletesWhenDrainerCanceledMidBatch`.
- Confirmed the test reproduces the bug: against the old handler it fails with
  `expected ingest to complete, got error: concurrent match scope "/tv": context canceled`; with the fix it passes and the run completes.
- `gofmt` clean on both changed files.
- `go build ./internal/libraryingest/...` clean. (A full `go build ./...`
  requires `web/dist`, built by `make build`; unrelated to this change.)
- Manual (recommended before merge): rebuild and restart `silo`, manually scan
  libraries 2/4/5, confirm `metadata: scoped matcher selected` +
  `library ingest: completed` appear and `scan_runs.status = completed`.

## AI-use disclosure

Diagnosed and implemented with assistance from Claude Code.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * The TV queue settle window can now be customized via settings.

* **Bug Fixes**
  * Improved shutdown behavior to avoid treating intentional cancellations as errors and to ensure real errors still stop runs.
  * Active background processing is allowed to finish after the settle window before shutdown completes.

* **Tests**
  * Added a regression test verifying settle-window behavior and graceful completion of active work.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Silo-Server/silo-server/pull/15?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->