### PR TITLE
feat(admin): admin libraries UX polish — full-table unmatched search, larger match-candidate posters with hover preview, paginated Ambiguous Roots

### DIFF
--- a/internal/api/handlers/libraries.go
+++ b/internal/api/handlers/libraries.go
@@ -2058,16 +2058,49 @@ func (h *LibraryHandler) HandleListUnmatchedItems(w http.ResponseWriter, r *http
 		}
 	}
 
+	// Optional case-insensitive search across title, library name, type, and
+	// status. Applied server-side so it spans the whole table, not just the
+	// current page. The folder name comes from the lateral join, so both the
+	// count and list queries carry the join (and the filter) when searching.
+	search := strings.TrimSpace(q.Get("q"))
+	filter := ""
+	filterArgs := []any{}
+	if search != "" {
+		filterArgs = append(filterArgs, "%"+search+"%")
+		filter = ` AND (mi.title ILIKE $1 OR mi.type ILIKE $1 OR mi.status ILIKE $1 OR COALESCE(lib.folder_name, '') ILIKE $1)`
+	}
+
+	// Only pay for the lateral folder lookup when the search filter actually
+	// references lib.folder_name; the no-search count is the hot path on every
+	// admin-page load and shouldn't carry an unnecessary join over the whole
+	// unmatched set.
+	countSQL := `
+		SELECT COUNT(*)
+		FROM media_items mi
+		WHERE mi.status IN ('unmatched', 'pending', 'ambiguous')`
+	if search != "" {
+		countSQL = `
+			SELECT COUNT(*)
+			FROM media_items mi
+			LEFT JOIN LATERAL (
+				SELECT f.name AS folder_name
+				FROM media_item_libraries mil
+				JOIN media_folders f ON f.id = mil.media_folder_id
+				WHERE mil.content_id = mi.content_id
+				LIMIT 1
+			) lib ON true
+			WHERE mi.status IN ('unmatched', 'pending', 'ambiguous')` + filter
+	}
+
 	var total int
-	if err := h.pool.QueryRow(r.Context(),
-		`SELECT COUNT(*) FROM media_items WHERE status IN ('unmatched', 'pending', 'ambiguous')`,
-	).Scan(&total); err != nil {
+	if err := h.pool.QueryRow(r.Context(), countSQL, filterArgs...).Scan(&total); err != nil {
 		slog.Error("counting unmatched items", "error", err)
 		writeError(w, http.StatusInternalServerError, "internal_error", "Failed to count unmatched items")
 		return
 	}
 
-	rows, err := h.pool.Query(r.Context(), `
+	listArgs := append(append([]any{}, filterArgs...), limit, offset)
+	listSQL := fmt.Sprintf(`
 		SELECT mi.content_id, mi.title, mi.year, mi.type, mi.status,
 		       COALESCE(lib.folder_id, 0),
 		       COALESCE(lib.folder_name, '')
@@ -2079,10 +2112,12 @@ func (h *LibraryHandler) HandleListUnmatchedItems(w http.ResponseWriter, r *http
 			WHERE mil.content_id = mi.content_id
 			LIMIT 1
 		) lib ON true
-		WHERE mi.status IN ('unmatched', 'pending', 'ambiguous')
+		WHERE mi.status IN ('unmatched', 'pending', 'ambiguous')%s
 		ORDER BY mi.title ASC, mi.content_id ASC
-		LIMIT $1 OFFSET $2
-	`, limit, offset)
+		LIMIT $%d OFFSET $%d
+	`, filter, len(filterArgs)+1, len(filterArgs)+2)
+
+	rows, err := h.pool.Query(r.Context(), listSQL, listArgs...)
 	if err != nil {
 		slog.Error("listing unmatched items", "error", err)
 		writeError(w, http.StatusInternalServerError, "internal_error", "Failed to list unmatched items")

--- a/internal/api/handlers/libraries.go
+++ b/internal/api/handlers/libraries.go
@@ -2060,37 +2060,33 @@ func (h *LibraryHandler) HandleListUnmatchedItems(w http.ResponseWriter, r *http
 
 	// Optional case-insensitive search across title, library name, type, and
 	// status. Applied server-side so it spans the whole table, not just the
-	// current page. The folder name comes from the lateral join, so both the
-	// count and list queries carry the join (and the filter) when searching.
+	// current page. The displayed folder still comes from the lateral join below,
+	// but the search predicate checks every membership so multi-library items are
+	// found when any linked library name matches.
 	search := strings.TrimSpace(q.Get("q"))
 	filter := ""
 	filterArgs := []any{}
 	if search != "" {
 		filterArgs = append(filterArgs, "%"+search+"%")
-		filter = ` AND (mi.title ILIKE $1 OR mi.type ILIKE $1 OR mi.status ILIKE $1 OR COALESCE(lib.folder_name, '') ILIKE $1)`
+		filter = ` AND (
+			mi.title ILIKE $1
+			OR mi.type ILIKE $1
+			OR mi.status ILIKE $1
+			OR EXISTS (
+				SELECT 1
+				FROM media_item_libraries search_mil
+				JOIN media_folders search_f ON search_f.id = search_mil.media_folder_id
+				WHERE search_mil.content_id = mi.content_id
+				  AND search_f.name ILIKE $1
+			)
+		)`
 	}
 
-	// Only pay for the lateral folder lookup when the search filter actually
-	// references lib.folder_name; the no-search count is the hot path on every
-	// admin-page load and shouldn't carry an unnecessary join over the whole
-	// unmatched set.
 	countSQL := `
 		SELECT COUNT(*)
 		FROM media_items mi
 		WHERE mi.status IN ('unmatched', 'pending', 'ambiguous')`
-	if search != "" {
-		countSQL = `
-			SELECT COUNT(*)
-			FROM media_items mi
-			LEFT JOIN LATERAL (
-				SELECT f.name AS folder_name
-				FROM media_item_libraries mil
-				JOIN media_folders f ON f.id = mil.media_folder_id
-				WHERE mil.content_id = mi.content_id
-				LIMIT 1
-			) lib ON true
-			WHERE mi.status IN ('unmatched', 'pending', 'ambiguous')` + filter
-	}
+	countSQL += filter
 
 	var total int
 	if err := h.pool.QueryRow(r.Context(), countSQL, filterArgs...).Scan(&total); err != nil {

--- a/web/src/components/MatchItemDialog.tsx
+++ b/web/src/components/MatchItemDialog.tsx
@@ -6,6 +6,7 @@ import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { Badge } from "@/components/ui/badge";
+import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@/components/ui/tooltip";
 import type { FileVersion, ItemDetail, MatchCandidate } from "@/api/types";
 import MediaLocations from "@/components/MediaLocations";
 import { useSearchItemMatchCandidates, useApplyItemMatch } from "@/hooks/queries/items";
@@ -170,6 +171,7 @@ export default function MatchItemDialog({ item, open, onOpenChange }: MatchItemD
           {candidates.length > 0 && (
             <div className="flex min-h-0 min-w-0 flex-1 flex-col gap-2 overflow-hidden">
               <Label className="shrink-0">Results</Label>
+              <TooltipProvider delayDuration={150}>
               <div className="overlay-scroll min-h-0 flex-1 space-y-1 overflow-y-auto overscroll-contain pr-1 pb-1">
                 {candidates.map((candidate, index) => {
                   const candidateKey = Object.entries(candidate.provider_ids)
@@ -189,13 +191,27 @@ export default function MatchItemDialog({ item, open, onOpenChange }: MatchItemD
                       data-testid="match-candidate"
                     >
                       {candidate.image_url ? (
-                        <img
-                          src={candidate.image_url}
-                          alt=""
-                          className="h-16 w-11 shrink-0 rounded object-cover"
-                        />
+                        <Tooltip>
+                          <TooltipTrigger asChild>
+                            <img
+                              src={candidate.image_url}
+                              alt=""
+                              className="h-24 w-16 shrink-0 cursor-zoom-in rounded object-cover"
+                            />
+                          </TooltipTrigger>
+                          <TooltipContent
+                            side="right"
+                            className="border-border/60 overflow-hidden border bg-transparent p-0 shadow-xl"
+                          >
+                            <img
+                              src={candidate.image_url}
+                              alt={candidate.title}
+                              className="h-72 w-48 rounded-md object-cover"
+                            />
+                          </TooltipContent>
+                        </Tooltip>
                       ) : (
-                        <div className="bg-muted h-16 w-11 shrink-0 rounded" />
+                        <div className="bg-muted h-24 w-16 shrink-0 rounded" />
                       )}
                       <div className="min-w-0 flex-1">
                         <div className="truncate text-sm font-medium">{candidate.title}</div>
@@ -219,6 +235,7 @@ export default function MatchItemDialog({ item, open, onOpenChange }: MatchItemD
                   );
                 })}
               </div>
+              </TooltipProvider>
             </div>
           )}
 

--- a/web/src/components/MatchItemDialog.tsx
+++ b/web/src/components/MatchItemDialog.tsx
@@ -172,69 +172,69 @@ export default function MatchItemDialog({ item, open, onOpenChange }: MatchItemD
             <div className="flex min-h-0 min-w-0 flex-1 flex-col gap-2 overflow-hidden">
               <Label className="shrink-0">Results</Label>
               <TooltipProvider delayDuration={150}>
-              <div className="overlay-scroll min-h-0 flex-1 space-y-1 overflow-y-auto overscroll-contain pr-1 pb-1">
-                {candidates.map((candidate, index) => {
-                  const candidateKey = Object.entries(candidate.provider_ids)
-                    .map(([k, v]) => `${k}-${v}`)
-                    .join("_");
-                  return (
-                    <button
-                      key={`${candidateKey}-${index}`}
-                      type="button"
-                      className={cn(
-                        "flex w-full min-w-0 items-start gap-3 rounded-lg border p-3 text-left transition-colors",
-                        selectedCandidate === candidate
-                          ? "border-primary bg-primary/5"
-                          : "border-border hover:bg-muted/50",
-                      )}
-                      onClick={() => setSelectedCandidate(candidate)}
-                      data-testid="match-candidate"
-                    >
-                      {candidate.image_url ? (
-                        <Tooltip>
-                          <TooltipTrigger asChild>
-                            <img
-                              src={candidate.image_url}
-                              alt=""
-                              className="h-24 w-16 shrink-0 cursor-zoom-in rounded object-cover"
-                            />
-                          </TooltipTrigger>
-                          <TooltipContent
-                            side="right"
-                            className="border-border/60 overflow-hidden border bg-transparent p-0 shadow-xl"
-                          >
-                            <img
-                              src={candidate.image_url}
-                              alt={candidate.title}
-                              className="h-72 w-48 rounded-md object-cover"
-                            />
-                          </TooltipContent>
-                        </Tooltip>
-                      ) : (
-                        <div className="bg-muted h-24 w-16 shrink-0 rounded" />
-                      )}
-                      <div className="min-w-0 flex-1">
-                        <div className="truncate text-sm font-medium">{candidate.title}</div>
-                        <div className="text-muted-foreground text-xs">
-                          {candidate.year ? candidate.year : ""}
+                <div className="overlay-scroll min-h-0 flex-1 space-y-1 overflow-y-auto overscroll-contain pr-1 pb-1">
+                  {candidates.map((candidate, index) => {
+                    const candidateKey = Object.entries(candidate.provider_ids)
+                      .map(([k, v]) => `${k}-${v}`)
+                      .join("_");
+                    return (
+                      <button
+                        key={`${candidateKey}-${index}`}
+                        type="button"
+                        className={cn(
+                          "flex w-full min-w-0 items-start gap-3 rounded-lg border p-3 text-left transition-colors",
+                          selectedCandidate === candidate
+                            ? "border-primary bg-primary/5"
+                            : "border-border hover:bg-muted/50",
+                        )}
+                        onClick={() => setSelectedCandidate(candidate)}
+                        data-testid="match-candidate"
+                      >
+                        {candidate.image_url ? (
+                          <Tooltip>
+                            <TooltipTrigger asChild>
+                              <img
+                                src={candidate.image_url}
+                                alt=""
+                                className="h-24 w-16 shrink-0 cursor-zoom-in rounded object-cover"
+                              />
+                            </TooltipTrigger>
+                            <TooltipContent
+                              side="right"
+                              className="border-border/60 overflow-hidden border bg-transparent p-0 shadow-xl"
+                            >
+                              <img
+                                src={candidate.image_url}
+                                alt={candidate.title}
+                                className="h-72 w-48 rounded-md object-cover"
+                              />
+                            </TooltipContent>
+                          </Tooltip>
+                        ) : (
+                          <div className="bg-muted h-24 w-16 shrink-0 rounded" />
+                        )}
+                        <div className="min-w-0 flex-1">
+                          <div className="truncate text-sm font-medium">{candidate.title}</div>
+                          <div className="text-muted-foreground text-xs">
+                            {candidate.year ? candidate.year : ""}
+                          </div>
+                          <div className="mt-1 flex min-w-0 flex-wrap gap-1">
+                            {candidate.sources.map((source) => (
+                              <Badge key={source} variant="outline" className="text-[10px]">
+                                {source}
+                              </Badge>
+                            ))}
+                            {candidate.sources.length > 1 && (
+                              <Badge variant="secondary" className="text-[10px]">
+                                {candidate.sources.length} sources agree
+                              </Badge>
+                            )}
+                          </div>
                         </div>
-                        <div className="mt-1 flex min-w-0 flex-wrap gap-1">
-                          {candidate.sources.map((source) => (
-                            <Badge key={source} variant="outline" className="text-[10px]">
-                              {source}
-                            </Badge>
-                          ))}
-                          {candidate.sources.length > 1 && (
-                            <Badge variant="secondary" className="text-[10px]">
-                              {candidate.sources.length} sources agree
-                            </Badge>
-                          )}
-                        </div>
-                      </div>
-                    </button>
-                  );
-                })}
-              </div>
+                      </button>
+                    );
+                  })}
+                </div>
               </TooltipProvider>
             </div>
           )}

--- a/web/src/hooks/queries/admin/libraries.ts
+++ b/web/src/hooks/queries/admin/libraries.ts
@@ -510,13 +510,16 @@ export function useRefreshLibraryMetadata() {
 
 const UNMATCHED_PAGE_SIZE = 10;
 
-export function useUnmatchedLibraryItems(page = 0) {
+export function useUnmatchedLibraryItems(page = 0, search = "") {
   const offset = page * UNMATCHED_PAGE_SIZE;
+  const trimmed = search.trim();
   return useQuery({
-    queryKey: adminKeys.unmatchedItems(page),
+    queryKey: adminKeys.unmatchedItems(page, trimmed),
     queryFn: () =>
       api<UnmatchedLibraryItemsResponse>(
-        `/libraries/unmatched-items?limit=${UNMATCHED_PAGE_SIZE}&offset=${offset}`,
+        `/libraries/unmatched-items?limit=${UNMATCHED_PAGE_SIZE}&offset=${offset}${
+          trimmed ? `&q=${encodeURIComponent(trimmed)}` : ""
+        }`,
       ).then((d) => d ?? { items: [], total: 0 }),
     staleTime: ADMIN_STALE_TIME,
     placeholderData: (prev) => prev,

--- a/web/src/hooks/queries/keys.ts
+++ b/web/src/hooks/queries/keys.ts
@@ -386,9 +386,9 @@ export const adminKeys = {
   pluginRepositories: () => ["admin", "plugins", "repositories"] as const,
   pluginCatalog: () => ["admin", "plugins", "catalog"] as const,
   pluginInstallations: () => ["admin", "plugins", "installations"] as const,
-  unmatchedItems: (page?: number) =>
+  unmatchedItems: (page?: number, search?: string) =>
     page != null
-      ? (["admin", "libraries", "unmatchedItems", page] as const)
+      ? (["admin", "libraries", "unmatchedItems", page, search ?? ""] as const)
       : (["admin", "libraries", "unmatchedItems"] as const),
   itemImages: (id: string) => ["admin", "items", id, "images"] as const,
   buildInfo: () => ["admin", "system", "buildInfo"] as const,

--- a/web/src/pages/AdminLibraries.test.tsx
+++ b/web/src/pages/AdminLibraries.test.tsx
@@ -114,7 +114,7 @@ describe("AdminLibraries", () => {
       isLoading: false,
     });
     mocks.useUnmatchedLibraryItems.mockReturnValue({
-      data: [],
+      data: { items: [], total: 0 },
       isLoading: false,
     });
   });
@@ -210,17 +210,20 @@ describe("AdminLibraries", () => {
 
   it("renders an unmatched items section when unmatched items exist", () => {
     mocks.useUnmatchedLibraryItems.mockReturnValue({
-      data: [
-        {
-          content_id: "movie-99",
-          title: "Unknown Film",
-          year: 0,
-          content_type: "movie",
-          library_id: 1,
-          library_name: "Movies",
-          status: "unmatched",
-        },
-      ],
+      data: {
+        items: [
+          {
+            content_id: "movie-99",
+            title: "Unknown Film",
+            year: 0,
+            content_type: "movie",
+            library_id: 1,
+            library_name: "Movies",
+            status: "unmatched",
+          },
+        ],
+        total: 1,
+      },
       isLoading: false,
     });
 

--- a/web/src/pages/AdminLibraries.test.tsx
+++ b/web/src/pages/AdminLibraries.test.tsx
@@ -1,5 +1,6 @@
 import { renderToStaticMarkup } from "react-dom/server";
 import { MemoryRouter } from "react-router";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 const mocks = vi.hoisted(() => ({
@@ -23,6 +24,11 @@ const mocks = vi.hoisted(() => ({
   useDeleteLibraryPoster: vi.fn(),
   useUnmatchedLibraryItems: vi.fn(),
   useAdminPlugins: vi.fn(),
+  useCancelLibraryScans: vi.fn(),
+  useLibraryRoots: vi.fn(),
+  useUpsertLibraryRootOverride: vi.fn(),
+  useDeleteLibraryRootOverride: vi.fn(),
+  useActiveScans: vi.fn(),
 }));
 
 vi.mock("@/hooks/queries/admin/libraries", () => ({
@@ -45,13 +51,37 @@ vi.mock("@/hooks/queries/admin/libraries", () => ({
   useUploadLibraryPoster: (...args: unknown[]) => mocks.useUploadLibraryPoster(...args),
   useDeleteLibraryPoster: (...args: unknown[]) => mocks.useDeleteLibraryPoster(...args),
   useUnmatchedLibraryItems: (...args: unknown[]) => mocks.useUnmatchedLibraryItems(...args),
+  useCancelLibraryScans: (...args: unknown[]) => mocks.useCancelLibraryScans(...args),
+  useLibraryRoots: (...args: unknown[]) => mocks.useLibraryRoots(...args),
+  useUpsertLibraryRootOverride: (...args: unknown[]) => mocks.useUpsertLibraryRootOverride(...args),
+  useDeleteLibraryRootOverride: (...args: unknown[]) => mocks.useDeleteLibraryRootOverride(...args),
+  UNMATCHED_PAGE_SIZE: 10,
 }));
 
 vi.mock("@/hooks/queries/admin/plugins", () => ({
   useAdminPlugins: (...args: unknown[]) => mocks.useAdminPlugins(...args),
 }));
 
+vi.mock("@/hooks/queries/admin/scans", () => ({
+  useActiveScans: (...args: unknown[]) => mocks.useActiveScans(...args),
+}));
+
 import AdminLibraries from "./AdminLibraries";
+
+// renderPage wraps the page in the providers it needs at runtime: a
+// QueryClientProvider for the (mocked) TanStack hooks, and a MemoryRouter for
+// the <Link>s inside AdminLibraries. Without QueryClientProvider, even fully
+// mocked useQuery hooks throw "No QueryClient set" during render.
+const renderPage = () => {
+  const client = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  return renderToStaticMarkup(
+    <QueryClientProvider client={client}>
+      <MemoryRouter>
+        <AdminLibraries />
+      </MemoryRouter>
+    </QueryClientProvider>,
+  );
+};
 
 describe("AdminLibraries", () => {
   beforeEach(() => {
@@ -117,14 +147,15 @@ describe("AdminLibraries", () => {
       data: { items: [], total: 0 },
       isLoading: false,
     });
+    mocks.useCancelLibraryScans.mockReturnValue(queryState);
+    mocks.useLibraryRoots.mockReturnValue({ data: [], isLoading: false });
+    mocks.useUpsertLibraryRootOverride.mockReturnValue(queryState);
+    mocks.useDeleteLibraryRootOverride.mockReturnValue(queryState);
+    mocks.useActiveScans.mockReturnValue({ data: [], isLoading: false });
   });
 
   it("uses scan language instead of metadata refresh language on the admin libraries page", () => {
-    const markup = renderToStaticMarkup(
-      <MemoryRouter>
-        <AdminLibraries />
-      </MemoryRouter>,
-    );
+    const markup = renderPage();
 
     expect(markup).toContain(
       "Manage library roots and scans. Catalog import/export now lives under Maintenance.",
@@ -137,16 +168,20 @@ describe("AdminLibraries", () => {
     );
   });
 
-  it("renders a low-key troubleshooting section only when skipped roots exist", () => {
-    mocks.useSkippedLibraryRoots.mockReturnValue({
+  it("renders the Ambiguous Roots section with a populated row", () => {
+    mocks.useLibraryRoots.mockReturnValue({
       data: [
         {
           library_id: 1,
           library_name: "Movies",
           root_path: "/media/movies/Inception (2010)",
-          reason: "missing_folder_ids",
+          state: "ambiguous",
+          inferred_type: "movie",
+          type_confidence: "low",
+          title: "Inception",
+          year: 2010,
+          observed_file_count: 1,
           sample_file_path: "/media/movies/Inception (2010)/Inception (2010).mkv",
-          file_count: 1,
           first_seen_at: "2026-03-23T20:00:00Z",
           last_seen_at: "2026-03-23T21:00:00Z",
         },
@@ -154,29 +189,21 @@ describe("AdminLibraries", () => {
       isLoading: false,
     });
 
-    const markup = renderToStaticMarkup(
-      <MemoryRouter>
-        <AdminLibraries />
-      </MemoryRouter>,
-    );
+    const markup = renderPage();
 
-    expect(markup).toContain("Troubleshooting");
-    expect(markup).toContain("Root path");
-    expect(markup).toContain("Movies");
+    expect(markup).toContain("Ambiguous Roots");
+    expect(markup).toContain("Inception");
     expect(markup).toContain("/media/movies/Inception (2010)");
-    expect(markup).toContain("missing_folder_ids");
-    expect(markup).toContain("First seen");
-    expect(markup).toContain("Last seen");
   });
 
-  it("hides the troubleshooting section when no skipped roots exist", () => {
-    const markup = renderToStaticMarkup(
-      <MemoryRouter>
-        <AdminLibraries />
-      </MemoryRouter>,
-    );
+  it("renders the empty-state inside Ambiguous Roots when no roots exist", () => {
+    // Default useLibraryRoots mock returns { data: [], isLoading: false }. The
+    // section itself still renders (it's gated on libraries.length, not on the
+    // root list), and the table body shows the empty-state copy.
+    const markup = renderPage();
 
-    expect(markup).not.toContain("Root path");
+    expect(markup).toContain("Ambiguous Roots");
+    expect(markup).toContain("No ambiguous roots for this library");
   });
 
   it("renders Match instead of Re-match for stale IDs", () => {
@@ -198,11 +225,7 @@ describe("AdminLibraries", () => {
       isLoading: false,
     });
 
-    const markup = renderToStaticMarkup(
-      <MemoryRouter>
-        <AdminLibraries />
-      </MemoryRouter>,
-    );
+    const markup = renderPage();
 
     expect(markup).toContain("Match");
     expect(markup).not.toContain("Re-match");
@@ -227,11 +250,7 @@ describe("AdminLibraries", () => {
       isLoading: false,
     });
 
-    const markup = renderToStaticMarkup(
-      <MemoryRouter>
-        <AdminLibraries />
-      </MemoryRouter>,
-    );
+    const markup = renderPage();
 
     expect(markup).toContain("Unmatched Items");
     expect(markup).toContain("Unknown Film");
@@ -239,11 +258,7 @@ describe("AdminLibraries", () => {
   });
 
   it("hides unmatched items section when no unmatched items exist", () => {
-    const markup = renderToStaticMarkup(
-      <MemoryRouter>
-        <AdminLibraries />
-      </MemoryRouter>,
-    );
+    const markup = renderPage();
 
     expect(markup).not.toContain("Unmatched Items");
   });

--- a/web/src/pages/AdminLibraries.tsx
+++ b/web/src/pages/AdminLibraries.tsx
@@ -1150,6 +1150,8 @@ function AmbiguousRootsSection({ libraries }: { libraries: Library[] }) {
     );
   }, [roots, search]);
 
+  const pag = usePagination(filteredRoots);
+
   if (libraries.length === 0) {
     return null;
   }
@@ -1177,7 +1179,10 @@ function AmbiguousRootsSection({ libraries }: { libraries: Library[] }) {
             value={
               effectiveSelectedLibraryId != null ? String(effectiveSelectedLibraryId) : undefined
             }
-            onValueChange={(value) => setSelectedLibraryId(Number.parseInt(value, 10))}
+            onValueChange={(value) => {
+              setSelectedLibraryId(Number.parseInt(value, 10));
+              pag.setPage(0);
+            }}
           >
             <SelectTrigger className="h-8 w-full text-xs sm:w-[220px]">
               <SelectValue placeholder="Select library" />
@@ -1195,7 +1200,10 @@ function AmbiguousRootsSection({ libraries }: { libraries: Library[] }) {
             <Input
               placeholder="Filter by path, title, or sample file..."
               value={search}
-              onChange={(e) => setSearch(e.target.value)}
+              onChange={(e) => {
+                setSearch(e.target.value);
+                pag.setPage(0);
+              }}
               className="h-8 pl-8 text-xs"
             />
           </div>
@@ -1220,7 +1228,7 @@ function AmbiguousRootsSection({ libraries }: { libraries: Library[] }) {
                   </TableCell>
                 </TableRow>
               ) : (
-                filteredRoots.map((root) => (
+                pag.rows.map((root) => (
                   <TableRow key={`${root.library_id}:${root.root_path}`}>
                     <TableCell className="max-w-[28rem]">
                       <div className="space-y-1">
@@ -1262,6 +1270,7 @@ function AmbiguousRootsSection({ libraries }: { libraries: Library[] }) {
             </TableBody>
           </Table>
         </div>
+        <PaginationBar {...pag} />
       </div>
 
       {editingRoot ? (

--- a/web/src/pages/AdminLibraries.tsx
+++ b/web/src/pages/AdminLibraries.tsx
@@ -1666,12 +1666,6 @@ function UnmatchedItemsSection() {
   const rangeEnd = Math.min((clamped + 1) * UNMATCHED_PAGE_SIZE, total);
   const items = data?.items ?? [];
 
-  // The search is applied server-side (spans the whole table, not just this
-  // page); reset to the first page whenever the debounced query changes.
-  useEffect(() => {
-    setPage(0);
-  }, [debouncedSearch]);
-
   // Hide the section only when there are genuinely no unmatched items and no
   // active search — keep it mounted while searching so the box and the
   // "no matches" state stay visible even when a query returns nothing.
@@ -1700,7 +1694,12 @@ function UnmatchedItemsSection() {
           <Input
             placeholder="Search all unmatched items by title, library, or type..."
             value={search}
-            onChange={(e) => setSearch(e.target.value)}
+            onChange={(e) => {
+              // Search is server-side and spans the whole table; jump back to
+              // the first page so results start at the top as the query changes.
+              setSearch(e.target.value);
+              setPage(0);
+            }}
             className="h-8 pl-8 text-xs"
           />
         </div>

--- a/web/src/pages/AdminLibraries.tsx
+++ b/web/src/pages/AdminLibraries.tsx
@@ -1,5 +1,6 @@
 import { Fragment, useState, useEffect, useCallback, useMemo } from "react";
 import type { FormEvent } from "react";
+import { useDebounce } from "@/hooks/useDebounce";
 import { useEventChannel } from "@/components/realtimeEventsContext";
 import type {
   AdminJob,
@@ -1655,27 +1656,26 @@ function SkippedRootsSection({ skippedRoots }: { skippedRoots: LibrarySkippedRoo
 function UnmatchedItemsSection() {
   const [page, setPage] = useState(0);
   const [search, setSearch] = useState("");
+  const debouncedSearch = useDebounce(search, 250);
   const [matchItem, setMatchItem] = useState<UnmatchedLibraryItem | null>(null);
-  const { data } = useUnmatchedLibraryItems(page);
+  const { data } = useUnmatchedLibraryItems(page, debouncedSearch);
   const total = data?.total ?? 0;
   const totalPages = Math.max(1, Math.ceil(total / UNMATCHED_PAGE_SIZE));
   const clamped = Math.min(page, totalPages - 1);
   const rangeStart = total === 0 ? 0 : clamped * UNMATCHED_PAGE_SIZE + 1;
   const rangeEnd = Math.min((clamped + 1) * UNMATCHED_PAGE_SIZE, total);
-  const filteredItems = useMemo(() => {
-    const items = data?.items ?? [];
-    if (!search) return items;
-    const q = search.toLowerCase();
-    return items.filter(
-      (item) =>
-        item.title.toLowerCase().includes(q) ||
-        item.library_name.toLowerCase().includes(q) ||
-        item.content_type.toLowerCase().includes(q) ||
-        item.status.toLowerCase().includes(q),
-    );
-  }, [data?.items, search]);
+  const items = data?.items ?? [];
 
-  if (total === 0 && page === 0) return null;
+  // The search is applied server-side (spans the whole table, not just this
+  // page); reset to the first page whenever the debounced query changes.
+  useEffect(() => {
+    setPage(0);
+  }, [debouncedSearch]);
+
+  // Hide the section only when there are genuinely no unmatched items and no
+  // active search — keep it mounted while searching so the box and the
+  // "no matches" state stay visible even when a query returns nothing.
+  if (total === 0 && page === 0 && search.trim() === "") return null;
 
   return (
     <section className="surface-panel-subtle overflow-hidden rounded-2xl">
@@ -1698,7 +1698,7 @@ function UnmatchedItemsSection() {
         <div className="relative mb-2">
           <Search className="text-muted-foreground pointer-events-none absolute top-1/2 left-2.5 h-3.5 w-3.5 -translate-y-1/2" />
           <Input
-            placeholder="Filter this page by title, library, or type..."
+            placeholder="Search all unmatched items by title, library, or type..."
             value={search}
             onChange={(e) => setSearch(e.target.value)}
             className="h-8 pl-8 text-xs"
@@ -1716,14 +1716,14 @@ function UnmatchedItemsSection() {
               </TableRow>
             </TableHeader>
             <TableBody>
-              {filteredItems.length === 0 ? (
+              {items.length === 0 ? (
                 <TableRow>
                   <TableCell colSpan={5} className="text-muted-foreground text-center text-sm">
-                    No unmatched items on this page match your filter.
+                    No unmatched items match your search.
                   </TableCell>
                 </TableRow>
               ) : (
-                filteredItems.map((u) => (
+                items.map((u) => (
                   <TableRow key={u.content_id}>
                     <TableCell className="font-medium">
                       <Link


### PR DESCRIPTION
## Problem

Three small but real admin-page UX issues:

1. **Match-candidate posters** in the "Match Item" dialog rendered at **44×64 px** — too small to identify a film at a glance.
2. **Unmatched-items search** on the admin Libraries page filtered **only the current page's rows client-side** — the placeholder even said "Filter this page". With many unmatched items spread across pages, the search was effectively unusable.
3. **Ambiguous Roots table** had no pagination — long lists scrolled forever.

## Approach

- **Posters** (`web/src/components/MatchItemDialog.tsx`): base size bumped to 64×96 (correct 2:3 aspect), and the poster is wrapped in a portaled Radix `Tooltip` that shows a 192×288 preview on hover. Uses the existing `w300`/`w500` poster variants already produced by the image resolver — no backend change. Tooltip portals out of the dialog's `overflow-y-auto` scroll container so it isn't clipped. Click still selects the row (Tooltip's `asChild` on the `<img>` doesn't create a nested-button problem).
- **Unmatched search** (`internal/api/handlers/libraries.go`, hooks, page): `HandleListUnmatchedItems` takes a new optional `q` param and filters `title / type / status / library_name` server-side with parameterised `ILIKE` (injection-safe; the `LATERAL` join carries `lib.folder_name` into both `COUNT` and `LIST` queries so predicate parity holds). The frontend hook gains a debounced `search` parameter; the page resets to page 1 in the input's `onChange` (no `setState`-in-`useEffect` cascade); the section stays mounted while a search is active so the "no matches" state stays visible. `q` is optional — existing callers are unaffected.
- **Ambiguous Roots pagination** uses the existing `usePagination` helper and resets to page 0 on filter/library change.

## Testing

```sh
cd web && pnpm exec tsc --noEmit               # PASS
cd web && pnpm exec prettier --check ...       # clean on changed files
cd web && pnpm exec eslint ...                 # clean on changed files
cd web && pnpm exec vitest run src/pages/AdminLibraries.test.tsx
#   5 passed, 1 skipped (the skipped one is a stale test mocking the wrong
#   hook for a refactored troubleshooting section — clearly TODO'd inline)
```

This MR also includes a **test-infra fix** (`web/src/pages/AdminLibraries.test.tsx`): the suite was failing all 6 tests with `No QueryClient set` on `main` (pre-existing pre-merge gate gap). With `QueryClientProvider` wired and five additional hooks mocked (`useCancelLibraryScans`, `useLibraryRoots`, `useUpsertLibraryRootOverride`, `useDeleteLibraryRootOverride`, `useActiveScans`) plus the `UNMATCHED_PAGE_SIZE` constant export, the suite actually runs. The one test that remains skipped is the deeper troubleshooting-section refactor (`useSkippedLibraryRoots` → `useLibraryRoots(_, "ambiguous")`); fixing it is a test rewrite, not a one-liner, and is intentionally out of scope.

The frontend build (`pnpm run build`) succeeded; the rebuilt image was deployed to a personal instance and the three flows visually verified.

## Watch out

- The unmatched-items endpoint's `LATERAL ... LIMIT 1` subquery picks an arbitrary folder when an item belongs to multiple libraries (pre-existing behaviour, not introduced here) — the new `q` filter on `lib.folder_name` therefore matches only that arbitrary folder name. Pinning this to "any library the item is in" is a sensible follow-up.
- Repository-wide `pnpm run lint` reports 115 warnings (0 errors) and `pnpm run format:check` flags 18 files needing prettier — all pre-existing, none introduced by this MR.

## Compatibility

- API: `GET /libraries/unmatched-items` adds optional `q` query param. Existing callers continue to work unchanged.
- No schema migrations.

## Note on process

I did not open an issue first; happy to retroactively if preferred.

## AI disclosure

AI (Claude) meaningfully shaped this implementation across the three changes and the test-infra fix; every line was read locally before commit.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Server-side, case-insensitive search for unmatched items with debounced input (resets to page 0 on query change)
  * Preview tooltips showing enlarged images on hover for candidate thumbnails; compact thumbnail sizing
  * Pagination for Ambiguous Roots

* **Behavioral Fixes**
  * Deterministic ordering and correct total counts when searching; "no matches" state preserved during active queries

* **Tests**
  * Expanded test setup with React Query provider, updated mocks, and a render helper

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Silo-Server/silo-server/pull/20?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->