### PR TITLE
feat(auth): make usernames and emails case-insensitive

### DIFF
--- a/internal/api/handlers/admin.go
+++ b/internal/api/handlers/admin.go
@@ -373,6 +373,9 @@ func (h *AdminHandler) HandleCreateUser(w http.ResponseWriter, r *http.Request) 
 		return
 	}
 
+	req.Username = auth.NormalizeUsername(req.Username)
+	req.Email = auth.NormalizeEmail(req.Email)
+
 	if req.Username == "" || req.Email == "" || req.Password == "" || req.Role == "" {
 		writeError(w, http.StatusBadRequest, "bad_request", "Username, email, password, and role are required")
 		return

--- a/internal/api/handlers/auth.go
+++ b/internal/api/handlers/auth.go
@@ -214,6 +214,9 @@ func (h *AuthHandler) HandleSetup(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	req.Username = auth.NormalizeUsername(req.Username)
+	req.Email = auth.NormalizeEmail(req.Email)
+
 	if req.Username == "" || req.Email == "" || req.Password == "" {
 		writeError(w, http.StatusBadRequest, "bad_request", "Username, email, and password are required")
 		return
@@ -446,6 +449,9 @@ func (h *AuthHandler) HandleSignup(w http.ResponseWriter, r *http.Request) {
 		writeError(w, http.StatusBadRequest, "bad_request", "Invalid request body")
 		return
 	}
+
+	req.Username = auth.NormalizeUsername(req.Username)
+	req.Email = auth.NormalizeEmail(req.Email)
 
 	if req.Username == "" || req.Email == "" || req.Password == "" || req.InviteCode == "" {
 		writeError(w, http.StatusBadRequest, "bad_request", "Username, email, password, and invite code are required")

--- a/internal/auth/normalize.go
+++ b/internal/auth/normalize.go
@@ -1,0 +1,17 @@
+package auth
+
+import "strings"
+
+// NormalizeUsername canonicalizes a username for storage and lookup by trimming
+// surrounding whitespace. Case is preserved for display; case-insensitive
+// matching is enforced by the citext column type in the database.
+func NormalizeUsername(username string) string {
+	return strings.TrimSpace(username)
+}
+
+// NormalizeEmail canonicalizes an email for storage and lookup by trimming
+// surrounding whitespace. Case is preserved (not lowercased); case-insensitive
+// matching is enforced by the citext column type in the database.
+func NormalizeEmail(email string) string {
+	return strings.TrimSpace(email)
+}

--- a/internal/auth/normalize_test.go
+++ b/internal/auth/normalize_test.go
@@ -1,0 +1,46 @@
+package auth
+
+import "testing"
+
+func TestNormalizeUsername(t *testing.T) {
+	cases := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{"trims surrounding spaces", "  john  ", "john"},
+		{"trims tabs and newlines", "\t john\n", "john"},
+		{"preserves internal spacing", "john doe", "john doe"},
+		{"preserves case", "JohnDoe", "JohnDoe"},
+		{"whitespace only becomes empty", "   ", ""},
+		{"already clean is unchanged", "john", "john"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := NormalizeUsername(tc.in); got != tc.want {
+				t.Errorf("NormalizeUsername(%q) = %q, want %q", tc.in, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestNormalizeEmail(t *testing.T) {
+	cases := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{"trims surrounding spaces", "  user@example.com  ", "user@example.com"},
+		{"trims tabs and newlines", "\tuser@example.com\n", "user@example.com"},
+		{"preserves case (not lowercased)", "User@Example.COM", "User@Example.COM"},
+		{"whitespace only becomes empty", "  ", ""},
+		{"already clean is unchanged", "user@example.com", "user@example.com"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := NormalizeEmail(tc.in); got != tc.want {
+				t.Errorf("NormalizeEmail(%q) = %q, want %q", tc.in, got, tc.want)
+			}
+		})
+	}
+}

--- a/internal/auth/repository.go
+++ b/internal/auth/repository.go
@@ -142,8 +142,8 @@ func (r *UserRepository) Create(ctx context.Context, input models.CreateUserInpu
 
 	cols := []string{"email", "username", "password_hash", "local_password_login_enabled", "role", "permissions", "library_ids", "max_playback_quality"}
 	args := []any{
-		input.Email,
-		input.Username,
+		NormalizeEmail(input.Email),
+		NormalizeUsername(input.Username),
 		string(hash),
 		localPasswordLoginEnabled,
 		input.Role,
@@ -205,16 +205,16 @@ func (r *UserRepository) GetByID(ctx context.Context, id int) (*models.User, err
 	return scanUser(r.pool.QueryRow(ctx, query, id))
 }
 
-// GetByUsername retrieves a user by their username.
+// GetByUsername retrieves a user by their username (case-insensitive).
 func (r *UserRepository) GetByUsername(ctx context.Context, username string) (*models.User, error) {
 	query := `SELECT ` + allColumns + ` FROM users WHERE username = $1`
-	return scanUser(r.pool.QueryRow(ctx, query, username))
+	return scanUser(r.pool.QueryRow(ctx, query, NormalizeUsername(username)))
 }
 
-// GetByEmail retrieves a user by their email address.
+// GetByEmail retrieves a user by their email address (case-insensitive).
 func (r *UserRepository) GetByEmail(ctx context.Context, email string) (*models.User, error) {
 	query := `SELECT ` + allColumns + ` FROM users WHERE email = $1`
-	return scanUser(r.pool.QueryRow(ctx, query, email))
+	return scanUser(r.pool.QueryRow(ctx, query, NormalizeEmail(email)))
 }
 
 // Update modifies a user's fields. Only non-nil fields in the input are updated.
@@ -226,12 +226,12 @@ func (r *UserRepository) Update(ctx context.Context, id int, input models.Update
 
 	if input.Email != nil {
 		setClauses = append(setClauses, fmt.Sprintf("email = $%d", argIndex))
-		args = append(args, *input.Email)
+		args = append(args, NormalizeEmail(*input.Email))
 		argIndex++
 	}
 	if input.Username != nil {
 		setClauses = append(setClauses, fmt.Sprintf("username = $%d", argIndex))
-		args = append(args, *input.Username)
+		args = append(args, NormalizeUsername(*input.Username))
 		argIndex++
 	}
 	if input.Password != nil {

--- a/migrations/165_case_insensitive_username_email.down.sql
+++ b/migrations/165_case_insensitive_username_email.down.sql
@@ -1,0 +1,6 @@
+-- Revert username/email to case-sensitive text. The citext extension is left
+-- installed: dropping it is unnecessary and would fail if any other object
+-- ever depends on it.
+ALTER TABLE public.users
+    ALTER COLUMN username TYPE text USING username::text,
+    ALTER COLUMN email TYPE text USING email::text;

--- a/migrations/165_case_insensitive_username_email.up.sql
+++ b/migrations/165_case_insensitive_username_email.up.sql
@@ -1,0 +1,9 @@
+-- Make user login identifiers case-insensitive. The citext column type compares
+-- case-insensitively, so the existing users_username_key / users_email_key unique
+-- indexes are rebuilt as case-insensitive and WHERE username = $1 / email = $1
+-- lookups match regardless of case. Original casing is preserved for display.
+CREATE EXTENSION IF NOT EXISTS citext;
+
+ALTER TABLE public.users
+    ALTER COLUMN username TYPE citext USING username::citext,
+    ALTER COLUMN email TYPE citext USING email::citext;


### PR DESCRIPTION
## Summary
- Convert `users.username` and `users.email` to PostgreSQL `citext` (migration **165**) so login identifiers compare case-insensitively while preserving original casing for display.
- Add `auth.NormalizeUsername`/`NormalizeEmail` (trim-only, case preserved), applied at the repository chokepoints and before validation in create paths.

## Problem
Usernames/emails were case-sensitive `text` with case-sensitive unique constraints, so `John` and `john` were distinct accounts and a user could not log in unless the casing matched what they registered with.

## Approach & why
- **`citext`** over a `LOWER()` functional index or storing lowercased values: it makes the existing `users_username_key` / `users_email_key` unique indexes case-insensitive automatically and needs **no change to the lookup queries** (`WHERE username = $1` resolves as citext), while preserving display casing.
- Normalization lives in **one `auth` helper**, enforced at the four repository methods (`Create`, `Update`, `GetByUsername`, `GetByEmail`) where every read/write path converges. The three create handlers (Setup, Signup, admin CreateUser) also normalize before their existing required-field checks, so whitespace-only input is rejected at the boundary.
- **Email** is included alongside username — same latent issue, and case-insensitive email is conventional.

## Migration / rollout
- Migration is numbered **165** deliberately: `feat/audiobooks` already occupies 163/164 and the runner dedupes by version *number*, so 163 would have been silently skipped on the (audiobooks-lineage) dev DB and collided at merge.
- Applies automatically on server startup. The down migration reverts to `text` (intentionally leaves the `citext` extension installed).
- Pre-flight on dev: **0 case-collisions across 69 users**. ⚠️ Re-run the collision check before applying anywhere with real data — if case-variant duplicates exist, the unique-index rebuild fails inside the migration's transaction (safe rollback, but blocks the migration until resolved).

## Risks / follow-up
- **No client (Android/Apple) changes**: pure server-side leniency, no API contract change.
- `citext` case-folding is locale-dependent for non-ASCII; ASCII identifiers are exactly case-insensitive.

## Test plan
- [x] `go build ./...`, `go vet`, `gofmt`, and `go test` for `internal/auth`, `internal/api/handlers`, `internal/jellycompat` — all clean
- [x] Unit tests for `NormalizeUsername`/`NormalizeEmail`
- [x] Non-destructive dev DB dry-run: `ADMIN`/`admin`/`AdMiN` resolve to the same row; case-variant insert rejected by `users_username_key`; down migration reverts to `text`
- [ ] Deploy to dev and confirm a real case-insensitive login end-to-end

## AI-use disclosure
Implemented with Claude Code (Claude Opus). Design, migration, code, and dev verification were AI-assisted and human-reviewed.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core identity storage and login matching; migration can block on pre-existing case-colliding username/email pairs when unique indexes are rebuilt.
> 
> **Overview**
> Usernames and emails become **case-insensitive** for login and uniqueness while **display casing is kept**. Migration **165** enables PostgreSQL `citext` on `users.username` and `users.email`, so existing unique indexes and `WHERE username = $1` / `email = $1` lookups compare without caring about case.
> 
> New `auth.NormalizeUsername` and `auth.NormalizeEmail` **trim surrounding whitespace only** (no lowercasing). They run in `UserRepository` on create, update, and get-by-username/email, and on **setup**, **signup**, and **admin create user** before required-field validation so whitespace-only identifiers fail at the API boundary.
> 
> Unit tests cover the normalizers. **Rollout risk:** if production already has case-variant duplicates, rebuilding unique indexes can fail until those rows are merged or renamed.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ea2c637db5b39df1df96225df9b2351dc4eb01b4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Usernames and emails are now automatically trimmed of surrounding whitespace during account signup, initial setup, and admin user creation.
  * User login identifiers are now handled case-insensitively—usernames and emails can be entered in any case, while original casing is preserved for display.

* **Tests**
  * Added comprehensive tests for username and email normalization functionality.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Silo-Server/silo-server/pull/22?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->