### PR TITLE
fix(catalog) Improve library browsing state, sort metadata, and stale refresh behavior

### DIFF
--- a/internal/api/handlers/catalog.go
+++ b/internal/api/handlers/catalog.go
@@ -77,6 +77,14 @@ func (h *CatalogHandler) HandleGetCatalog(w http.ResponseWriter, r *http.Request
 	overlaySummaries := h.itemsH.listOverlaySummaries(r.Context(), result.Items, h.itemsH.accessFilter(r))
 	userStates := h.itemsH.listItemUserStates(r, result.Items)
 	episodeMetadata := h.itemsH.listEpisodeBrowseMetadata(r.Context(), result.Items)
+	sortField := catalog.NormalizeQuerySort(req.Query.Sort).Field
+	sortMetrics := h.itemsH.listSortMetrics(
+		r.Context(),
+		result.Items,
+		sortField,
+		h.itemsH.accessFilter(r),
+		overlaySummaries,
+	)
 	items := make([]itemListResponse, 0, len(result.Items))
 	for _, item := range result.Items {
 		resp := h.itemsH.toItemListResponseWithOverlay(
@@ -90,6 +98,7 @@ func (h *CatalogHandler) HandleGetCatalog(w http.ResponseWriter, r *http.Request
 			resp.SeasonNumber = meta.SeasonNumber
 			resp.EpisodeNumber = meta.EpisodeNumber
 		}
+		resp.SortMetrics = sortMetrics[item.ContentID]
 		items = append(items, resp)
 	}
 

--- a/internal/api/handlers/catalog.go
+++ b/internal/api/handlers/catalog.go
@@ -78,12 +78,15 @@ func (h *CatalogHandler) HandleGetCatalog(w http.ResponseWriter, r *http.Request
 	userStates := h.itemsH.listItemUserStates(r, result.Items)
 	episodeMetadata := h.itemsH.listEpisodeBrowseMetadata(r.Context(), result.Items)
 	sortField := catalog.NormalizeQuerySort(req.Query.Sort).Field
+	store, profileID, _ := h.itemsH.userStoreForRequest(r)
 	sortMetrics := h.itemsH.listSortMetrics(
 		r.Context(),
 		result.Items,
 		sortField,
 		h.itemsH.accessFilter(r),
 		overlaySummaries,
+		store,
+		profileID,
 	)
 	items := make([]itemListResponse, 0, len(result.Items))
 	for _, item := range result.Items {

--- a/internal/api/handlers/items.go
+++ b/internal/api/handlers/items.go
@@ -847,6 +847,8 @@ func (h *ItemsHandler) listSortMetrics(
 	sortField string,
 	filter catalog.AccessFilter,
 	overlaySummaries map[string]*models.OverlaySummary,
+	store userstore.UserStore,
+	profileID string,
 ) map[string]*sortMetricsResponse {
 	metrics := make(map[string]*sortMetricsResponse, len(items))
 	switch sortField {
@@ -885,8 +887,130 @@ func (h *ItemsHandler) listSortMetrics(
 				metrics[contentID] = &sortMetricsResponse{BitrateKbps: &value}
 			}
 		}
+	case "progress", "date_viewed", "plays":
+		h.listUserSortMetrics(ctx, items, sortField, store, profileID, metrics)
 	}
 	return metrics
+}
+
+func (h *ItemsHandler) listUserSortMetrics(
+	ctx context.Context,
+	items []*models.MediaItem,
+	sortField string,
+	store userstore.UserStore,
+	profileID string,
+	metrics map[string]*sortMetricsResponse,
+) {
+	if store == nil || profileID == "" || len(items) == 0 {
+		return
+	}
+	contentIDs := uniqueItemContentIDs(items)
+	if len(contentIDs) == 0 {
+		return
+	}
+
+	progressMap, err := store.ListProgressByMediaItems(ctx, profileID, contentIDs)
+	if err != nil {
+		return
+	}
+
+	switch sortField {
+	case "progress":
+		for _, item := range items {
+			if item == nil || item.ContentID == "" {
+				continue
+			}
+			progress, ok := progressMap[item.ContentID]
+			if !ok || progress.Completed || progress.PositionSeconds <= 0 || progress.DurationSeconds <= 0 {
+				continue
+			}
+			ratio := progress.PositionSeconds / progress.DurationSeconds
+			metrics[item.ContentID] = &sortMetricsResponse{ProgressRatio: &ratio}
+		}
+	case "date_viewed", "plays":
+		history, err := listCompletedHistoryForItems(ctx, store, profileID, contentIDs)
+		if err != nil {
+			return
+		}
+		historyCounts := make(map[string]int, len(contentIDs))
+		historyViewedAt := make(map[string]string, len(contentIDs))
+		for _, entry := range history {
+			if entry.MediaItemID == "" {
+				continue
+			}
+			historyCounts[entry.MediaItemID]++
+			if entry.WatchedAt > historyViewedAt[entry.MediaItemID] {
+				historyViewedAt[entry.MediaItemID] = entry.WatchedAt
+			}
+		}
+		for _, item := range items {
+			if item == nil || item.ContentID == "" {
+				continue
+			}
+			resp := &sortMetricsResponse{}
+			if sortField == "date_viewed" {
+				viewedAt := historyViewedAt[item.ContentID]
+				if progress, ok := progressMap[item.ContentID]; ok && progress.Completed && progress.UpdatedAt > viewedAt {
+					viewedAt = progress.UpdatedAt
+				}
+				if viewedAt == "" {
+					continue
+				}
+				resp.ViewedAt = viewedAt
+			} else {
+				playCount := historyCounts[item.ContentID]
+				if progress, ok := progressMap[item.ContentID]; ok && progress.Completed && playCount < 1 {
+					playCount = 1
+				}
+				if playCount <= 0 {
+					continue
+				}
+				resp.PlayCount = &playCount
+			}
+			metrics[item.ContentID] = resp
+		}
+	}
+}
+
+func uniqueItemContentIDs(items []*models.MediaItem) []string {
+	contentIDs := make([]string, 0, len(items))
+	seen := make(map[string]struct{}, len(items))
+	for _, item := range items {
+		if item == nil || item.ContentID == "" {
+			continue
+		}
+		if _, ok := seen[item.ContentID]; ok {
+			continue
+		}
+		seen[item.ContentID] = struct{}{}
+		contentIDs = append(contentIDs, item.ContentID)
+	}
+	return contentIDs
+}
+
+func listCompletedHistoryForItems(
+	ctx context.Context,
+	store userstore.UserStore,
+	profileID string,
+	contentIDs []string,
+) ([]userstore.WatchHistoryEntry, error) {
+	const pageSize = 500
+	var all []userstore.WatchHistoryEntry
+	for offset := 0; ; offset += pageSize {
+		page, err := store.ListCompletedHistory(ctx, userstore.CompletedHistoryQuery{
+			ProfileID:    profileID,
+			MediaItemIDs: contentIDs,
+			Limit:        pageSize,
+			Offset:       offset,
+		})
+		if err != nil {
+			return nil, err
+		}
+		all = append(all, page...)
+		if len(page) < pageSize {
+			return all, nil
+		}
+	}
 }
 
 func (h *ItemsHandler) listBrowseItemFiles(ctx context.Context, items []*models.MediaItem, filter catalog.AccessFilter) map[string][]*models.MediaFile {

--- a/internal/api/handlers/items.go
+++ b/internal/api/handlers/items.go
@@ -34,6 +34,10 @@ type EpisodeFileProvider interface {
 	ListByContentIDs(ctx context.Context, contentIDs []string) (map[string][]*models.MediaFile, error)
 }
 
+type batchEpisodeFileProvider interface {
+	ListByEpisodeIDs(ctx context.Context, episodeIDs []string) (map[string][]*models.MediaFile, error)
+}
+
 type MetadataRefreshRequester interface {
 	RequestStaleMetadataRefresh(ctx context.Context, targetType, contentID string) error
 }
@@ -209,7 +213,18 @@ type itemListResponse struct {
 	LastAirDate       *string                `json:"last_air_date,omitempty"`
 	AddedAt           *time.Time             `json:"added_at,omitempty"`
 	OverlaySummary    *models.OverlaySummary `json:"overlay_summary,omitempty"`
+	SortMetrics       *sortMetricsResponse   `json:"sort_metrics,omitempty"`
 	UserState         *itemUserStateResponse `json:"user_state,omitempty"`
+}
+
+type sortMetricsResponse struct {
+	ReleaseDate    *string  `json:"release_date,omitempty"`
+	RuntimeMinutes *int     `json:"runtime_minutes,omitempty"`
+	Resolution     string   `json:"resolution,omitempty"`
+	BitrateKbps    *int     `json:"bitrate_kbps,omitempty"`
+	ProgressRatio  *float64 `json:"progress_ratio,omitempty"`
+	ViewedAt       string   `json:"viewed_at,omitempty"`
+	PlayCount      *int     `json:"play_count,omitempty"`
 }
 
 // browseResponse is the paginated response for the /items endpoint.
@@ -817,7 +832,71 @@ func (h *ItemsHandler) listOverlaySummaries(ctx context.Context, items []*models
 		return summaries
 	}
 
+	groupedFiles := h.listBrowseItemFiles(ctx, items, filter)
+	for contentID, files := range groupedFiles {
+		if summary := overlays.BuildSummary(files); summary != nil {
+			summaries[contentID] = summary
+		}
+	}
+	return summaries
+}
+
+func (h *ItemsHandler) listSortMetrics(
+	ctx context.Context,
+	items []*models.MediaItem,
+	sortField string,
+	filter catalog.AccessFilter,
+	overlaySummaries map[string]*models.OverlaySummary,
+) map[string]*sortMetricsResponse {
+	metrics := make(map[string]*sortMetricsResponse, len(items))
+	switch sortField {
+	case "release_date":
+		for _, item := range items {
+			if item == nil {
+				continue
+			}
+			releaseDate := firstNonBlankPtr(item.ReleaseDate, item.FirstAirDate)
+			if releaseDate != nil {
+				metrics[item.ContentID] = &sortMetricsResponse{ReleaseDate: releaseDate}
+			}
+		}
+	case "runtime":
+		for _, item := range items {
+			if item == nil || item.Runtime <= 0 {
+				continue
+			}
+			runtimeMinutes := item.Runtime
+			metrics[item.ContentID] = &sortMetricsResponse{RuntimeMinutes: &runtimeMinutes}
+		}
+	case "resolution":
+		for _, item := range items {
+			if item == nil {
+				continue
+			}
+			if summary := overlaySummaries[item.ContentID]; summary != nil && strings.TrimSpace(summary.Resolution) != "" {
+				metrics[item.ContentID] = &sortMetricsResponse{Resolution: summary.Resolution}
+			}
+		}
+	case "bitrate":
+		groupedFiles := h.listBrowseItemFiles(ctx, items, filter)
+		for contentID, files := range groupedFiles {
+			if bitrate := maxFileBitrate(files); bitrate > 0 {
+				value := bitrate
+				metrics[contentID] = &sortMetricsResponse{BitrateKbps: &value}
+			}
+		}
+	}
+	return metrics
+}
+
+func (h *ItemsHandler) listBrowseItemFiles(ctx context.Context, items []*models.MediaItem, filter catalog.AccessFilter) map[string][]*models.MediaFile {
+	grouped := make(map[string][]*models.MediaFile, len(items))
+	if h.fileRepo == nil || len(items) == 0 {
+		return grouped
+	}
+
 	contentIDs := make([]string, 0, len(items))
+	episodeIDs := make([]string, 0)
 	seen := make(map[string]struct{}, len(items))
 	for _, item := range items {
 		if item == nil || item.ContentID == "" {
@@ -827,23 +906,55 @@ func (h *ItemsHandler) listOverlaySummaries(ctx context.Context, items []*models
 			continue
 		}
 		seen[item.ContentID] = struct{}{}
-		contentIDs = append(contentIDs, item.ContentID)
-	}
-	if len(contentIDs) == 0 {
-		return summaries
-	}
-
-	groupedFiles, err := h.fileRepo.ListByContentIDs(ctx, contentIDs)
-	if err != nil {
-		return summaries
-	}
-	for contentID, files := range groupedFiles {
-		files = catalog.FilterMediaFilesByAccess(files, filter)
-		if summary := overlays.BuildSummary(files); summary != nil {
-			summaries[contentID] = summary
+		if item.Type == "episode" {
+			episodeIDs = append(episodeIDs, item.ContentID)
+		} else {
+			contentIDs = append(contentIDs, item.ContentID)
 		}
 	}
-	return summaries
+
+	if len(contentIDs) > 0 {
+		contentFiles, err := h.fileRepo.ListByContentIDs(ctx, contentIDs)
+		if err == nil {
+			for contentID, files := range contentFiles {
+				grouped[contentID] = catalog.FilterMediaFilesByAccess(files, filter)
+			}
+		}
+	}
+
+	if len(episodeIDs) > 0 {
+		if batchProvider, ok := h.fileRepo.(batchEpisodeFileProvider); ok {
+			episodeFiles, err := batchProvider.ListByEpisodeIDs(ctx, episodeIDs)
+			if err == nil {
+				for episodeID, files := range episodeFiles {
+					grouped[episodeID] = catalog.FilterMediaFilesByAccess(files, filter)
+				}
+			}
+		}
+	}
+
+	return grouped
+}
+
+func firstNonBlankPtr(values ...*string) *string {
+	for _, value := range values {
+		if value == nil || strings.TrimSpace(*value) == "" {
+			continue
+		}
+		copyValue := *value
+		return &copyValue
+	}
+	return nil
+}
+
+func maxFileBitrate(files []*models.MediaFile) int {
+	maxBitrate := 0
+	for _, file := range files {
+		if file != nil && file.Bitrate > maxBitrate {
+			maxBitrate = file.Bitrate
+		}
+	}
+	return maxBitrate
 }
 
 // toSeasonResponse converts a Season model to an API response.

--- a/internal/api/handlers/items_sort_metrics_test.go
+++ b/internal/api/handlers/items_sort_metrics_test.go
@@ -1,0 +1,59 @@
+package handlers
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/Silo-Server/silo-server/internal/catalog"
+	"github.com/Silo-Server/silo-server/internal/models"
+	"github.com/Silo-Server/silo-server/internal/userstore"
+)
+
+func TestListSortMetricsIncludesUserStateSorts(t *testing.T) {
+	ctx := context.Background()
+	store := newProfileTestStore(t)
+	items := []*models.MediaItem{
+		{ContentID: "movie-progress", Type: "movie", Title: "Progress"},
+		{ContentID: "movie-viewed", Type: "movie", Title: "Viewed"},
+		{ContentID: "movie-plays", Type: "movie", Title: "Plays"},
+	}
+	handler := &ItemsHandler{}
+
+	if err := store.SetProgress(ctx, "profile-1", "movie-progress", 900, 3600, userstore.ProgressThresholds{}); err != nil {
+		t.Fatalf("SetProgress(progress): %v", err)
+	}
+	completedAt := time.Date(2026, 5, 29, 18, 30, 0, 0, time.UTC)
+	if err := store.SetProgressAt(ctx, "profile-1", "movie-viewed", 3600, 3600, true, completedAt); err != nil {
+		t.Fatalf("SetProgressAt(viewed): %v", err)
+	}
+	for _, watchedAt := range []string{"2026-05-27T10:00:00Z", "2026-05-28T10:00:00Z"} {
+		if err := store.AddHistory(ctx, userstore.WatchHistoryEntry{
+			ProfileID:       "profile-1",
+			MediaItemID:     "movie-plays",
+			WatchedAt:       watchedAt,
+			DurationSeconds: 3600,
+			Completed:       true,
+			Source:          userstore.WatchHistorySourcePlayback,
+		}); err != nil {
+			t.Fatalf("AddHistory(%s): %v", watchedAt, err)
+		}
+	}
+
+	progressMetrics := handler.listSortMetrics(ctx, items, "progress", catalog.AccessFilter{}, nil, store, "profile-1")
+	progress := progressMetrics["movie-progress"]
+	if progress == nil || progress.ProgressRatio == nil || *progress.ProgressRatio != 0.25 {
+		t.Fatalf("progress metrics = %#v", progress)
+	}
+
+	viewedMetrics := handler.listSortMetrics(ctx, items, "date_viewed", catalog.AccessFilter{}, nil, store, "profile-1")
+	if got := viewedMetrics["movie-viewed"]; got == nil || got.ViewedAt != "2026-05-29T18:30:00Z" {
+		t.Fatalf("viewed metrics = %#v", got)
+	}
+
+	playsMetrics := handler.listSortMetrics(ctx, items, "plays", catalog.AccessFilter{}, nil, store, "profile-1")
+	plays := playsMetrics["movie-plays"]
+	if plays == nil || plays.PlayCount == nil || *plays.PlayCount != 2 {
+		t.Fatalf("plays metrics = %#v", plays)
+	}
+}

--- a/internal/api/handlers/people.go
+++ b/internal/api/handlers/people.go
@@ -133,9 +133,9 @@ func (h *PeopleHandler) HandleGetPerson(w http.ResponseWriter, r *http.Request) 
 		return
 	}
 
-	personValue := h.refreshPersonOnViewIfDue(r.Context(), *person)
+	h.enqueuePersonRefreshIfDue(*person)
 
-	writeJSON(w, http.StatusOK, h.toResponse(r.Context(), personValue))
+	writeJSON(w, http.StatusOK, h.toResponse(r.Context(), *person))
 }
 
 // HandleRefreshPerson serves POST /api/v1/people/:id/refresh.
@@ -369,42 +369,12 @@ func (h *PeopleHandler) enqueuePersonRefreshIfDue(person models.Person) {
 	}
 
 	if personMetadataIncomplete(person) {
-		h.refreshQueue.Enqueue(person.ID)
 		return
 	}
 
 	if person.UpdatedAt.Before(time.Now().Add(-personMetadataStaleAfter)) {
 		h.refreshQueue.Enqueue(person.ID)
 	}
-}
-
-func (h *PeopleHandler) refreshPersonOnViewIfDue(ctx context.Context, person models.Person) models.Person {
-	if !personHasRefreshableProviderID(person) {
-		return person
-	}
-
-	if !personMetadataIncomplete(person) {
-		h.enqueuePersonRefreshIfDue(person)
-		return person
-	}
-
-	if h.refresher == nil {
-		h.enqueuePersonRefreshIfDue(person)
-		return person
-	}
-
-	refreshCtx, cancel := context.WithTimeout(ctx, 2*time.Minute)
-	defer cancel()
-
-	refreshed, err := h.refresher.RefreshPerson(refreshCtx, person.ID)
-	if err != nil {
-		slog.Warn("people: automatic person refresh failed", "id", person.ID, "error", err)
-		return person
-	}
-	if refreshed == nil {
-		return person
-	}
-	return *refreshed
 }
 
 func personHasRefreshableProviderID(person models.Person) bool {

--- a/internal/api/handlers/people.go
+++ b/internal/api/handlers/people.go
@@ -133,9 +133,9 @@ func (h *PeopleHandler) HandleGetPerson(w http.ResponseWriter, r *http.Request) 
 		return
 	}
 
-	h.enqueuePersonRefreshIfDue(*person)
+	personValue := h.refreshPersonOnViewIfDue(r.Context(), *person)
 
-	writeJSON(w, http.StatusOK, h.toResponse(r.Context(), *person))
+	writeJSON(w, http.StatusOK, h.toResponse(r.Context(), personValue))
 }
 
 // HandleRefreshPerson serves POST /api/v1/people/:id/refresh.
@@ -376,6 +376,35 @@ func (h *PeopleHandler) enqueuePersonRefreshIfDue(person models.Person) {
 	if person.UpdatedAt.Before(time.Now().Add(-personMetadataStaleAfter)) {
 		h.refreshQueue.Enqueue(person.ID)
 	}
+}
+
+func (h *PeopleHandler) refreshPersonOnViewIfDue(ctx context.Context, person models.Person) models.Person {
+	if !personHasRefreshableProviderID(person) {
+		return person
+	}
+
+	if !personMetadataIncomplete(person) {
+		h.enqueuePersonRefreshIfDue(person)
+		return person
+	}
+
+	if h.refresher == nil {
+		h.enqueuePersonRefreshIfDue(person)
+		return person
+	}
+
+	refreshCtx, cancel := context.WithTimeout(ctx, 2*time.Minute)
+	defer cancel()
+
+	refreshed, err := h.refresher.RefreshPerson(refreshCtx, person.ID)
+	if err != nil {
+		slog.Warn("people: automatic person refresh failed", "id", person.ID, "error", err)
+		return person
+	}
+	if refreshed == nil {
+		return person
+	}
+	return *refreshed
 }
 
 func personHasRefreshableProviderID(person models.Person) bool {

--- a/internal/api/handlers/people.go
+++ b/internal/api/handlers/people.go
@@ -39,6 +39,8 @@ var personRefreshRate = ratelimit.Rate{
 	Burst:             10,
 }
 
+const personMetadataStaleAfter = 90 * 24 * time.Hour
+
 // PeopleHandler serves person-related API endpoints.
 type PeopleHandler struct {
 	personRepo      peopleRepository
@@ -130,6 +132,8 @@ func (h *PeopleHandler) HandleGetPerson(w http.ResponseWriter, r *http.Request) 
 		writeError(w, http.StatusNotFound, "not_found", "person not found")
 		return
 	}
+
+	h.enqueuePersonRefreshIfDue(*person)
 
 	writeJSON(w, http.StatusOK, h.toResponse(r.Context(), *person))
 }
@@ -357,6 +361,29 @@ func (h *PeopleHandler) toResponse(ctx context.Context, p models.Person) personR
 		resp.PhotoThumbhash = p.PhotoThumbhash
 	}
 	return resp
+}
+
+func (h *PeopleHandler) enqueuePersonRefreshIfDue(person models.Person) {
+	if h.refreshQueue == nil || !personHasRefreshableProviderID(person) {
+		return
+	}
+
+	if personMetadataIncomplete(person) {
+		h.refreshQueue.Enqueue(person.ID)
+		return
+	}
+
+	if person.UpdatedAt.Before(time.Now().Add(-personMetadataStaleAfter)) {
+		h.refreshQueue.Enqueue(person.ID)
+	}
+}
+
+func personHasRefreshableProviderID(person models.Person) bool {
+	return person.TmdbID != "" || person.ImdbID != "" || person.TvdbID != ""
+}
+
+func personMetadataIncomplete(person models.Person) bool {
+	return person.Bio == "" || person.PhotoPath == "" || person.PhotoPath == "-" || person.BirthDate == nil
 }
 
 func parseOptionalPersonDate(raw string) (*time.Time, error) {

--- a/internal/api/handlers/settings.go
+++ b/internal/api/handlers/settings.go
@@ -16,6 +16,10 @@ import (
 )
 
 const subtitleAppearanceSettingKey = "subtitle_appearance"
+const (
+	libraryPageStateSettingKey         = "ui.library_page_state"
+	rememberLibraryPageStateSettingKey = "ui.remember_library_page_state"
+)
 
 const (
 	deviceIDHeader       = "X-Silo-Device-Id"
@@ -155,6 +159,16 @@ var settingsRegistry = map[string]settingSpec{
 		Scope:        scopeDevice,
 		DefaultValue: "",
 		Validate:     validateJSONSetting(subtitleAppearanceSettingKey),
+	},
+	libraryPageStateSettingKey: {
+		Scope:        scopeDevice,
+		DefaultValue: "",
+		Validate:     validateJSONSetting(libraryPageStateSettingKey),
+	},
+	rememberLibraryPageStateSettingKey: {
+		Scope:        scopeDevice,
+		DefaultValue: "true",
+		Validate:     validateBoolSetting(rememberLibraryPageStateSettingKey),
 	},
 	"player.hdr_enabled": {
 		Scope:        scopeDevice,

--- a/internal/api/handlers/settings_device_test.go
+++ b/internal/api/handlers/settings_device_test.go
@@ -176,7 +176,7 @@ func TestGetEffectiveSettingsResolvesUserDeviceAndDefaultSources(t *testing.T) {
 	handler := NewSettingsHandler(testUserStoreProvider{store: store})
 	req := httptest.NewRequest(
 		http.MethodGet,
-		"/settings/effective?keys=playback.preferred_quality,player.playback_speed,player.hdr_enabled",
+		"/settings/effective?keys=playback.preferred_quality,player.playback_speed,player.hdr_enabled,ui.remember_library_page_state",
 		nil,
 	)
 	req.Header.Set(deviceIDHeader, "apple-tv")
@@ -192,7 +192,7 @@ func TestGetEffectiveSettingsResolvesUserDeviceAndDefaultSources(t *testing.T) {
 	if err := json.NewDecoder(rec.Body).Decode(&resp); err != nil {
 		t.Fatalf("decode: %v", err)
 	}
-	if len(resp.Settings) != 3 {
+	if len(resp.Settings) != 4 {
 		t.Fatalf("settings len = %d", len(resp.Settings))
 	}
 	byKey := make(map[string]effectiveSettingResponse, len(resp.Settings))
@@ -207,6 +207,9 @@ func TestGetEffectiveSettingsResolvesUserDeviceAndDefaultSources(t *testing.T) {
 	}
 	if got := byKey["player.hdr_enabled"]; got.EffectiveValue != "true" || got.Source != "default" {
 		t.Fatalf("hdr_enabled = %#v", got)
+	}
+	if got := byKey[rememberLibraryPageStateSettingKey]; got.EffectiveValue != "true" || got.Source != "default" {
+		t.Fatalf("remember_library_page_state = %#v", got)
 	}
 }
 
@@ -227,6 +230,129 @@ func TestGenericSettingsRejectInvalidRegisteredValues(t *testing.T) {
 
 	if rec.Code != http.StatusBadRequest {
 		t.Fatalf("status = %d body=%s", rec.Code, rec.Body.String())
+	}
+}
+
+func TestLibraryPageStateIsDeviceScopedJSONSetting(t *testing.T) {
+	store := newProfileTestStore(t)
+	handler := NewSettingsHandler(testUserStoreProvider{store: store})
+
+	req := httptest.NewRequest(
+		http.MethodPut,
+		"/settings/device/ui.library_page_state",
+		bytes.NewBufferString(`{"value":"{\"version\":1,\"libraries\":{\"7\":{\"search\":\"tab=library\"}}}"}`),
+	)
+	req = withRouteParams(req, map[string]string{"key": libraryPageStateSettingKey})
+	req.Header.Set(deviceIDHeader, "browser")
+	req = req.WithContext(apimw.SetProfileID(apimw.SetClaims(req.Context(), &auth.Claims{UserID: 7}), "profile-1"))
+	rec := httptest.NewRecorder()
+
+	handler.HandleSetDeviceSetting(rec, req)
+
+	if rec.Code != http.StatusNoContent {
+		t.Fatalf("status = %d body=%s", rec.Code, rec.Body.String())
+	}
+	entry, err := store.GetDeviceSetting(context.Background(), "profile-1", "browser", libraryPageStateSettingKey)
+	if err != nil {
+		t.Fatalf("GetDeviceSetting: %v", err)
+	}
+	if entry == nil || !strings.Contains(entry.Value, `"tab=library"`) {
+		t.Fatalf("entry = %#v", entry)
+	}
+}
+
+func TestLibraryPageStateRejectsInvalidJSONAndUserScope(t *testing.T) {
+	store := newProfileTestStore(t)
+	handler := NewSettingsHandler(testUserStoreProvider{store: store})
+
+	req := httptest.NewRequest(
+		http.MethodPut,
+		"/settings/device/ui.library_page_state",
+		bytes.NewBufferString(`{"value":"not json"}`),
+	)
+	req = withRouteParams(req, map[string]string{"key": libraryPageStateSettingKey})
+	req.Header.Set(deviceIDHeader, "browser")
+	req = req.WithContext(apimw.SetProfileID(apimw.SetClaims(req.Context(), &auth.Claims{UserID: 7}), "profile-1"))
+	rec := httptest.NewRecorder()
+
+	handler.HandleSetDeviceSetting(rec, req)
+
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("invalid JSON status = %d body=%s", rec.Code, rec.Body.String())
+	}
+
+	req = httptest.NewRequest(
+		http.MethodPut,
+		"/settings/ui.library_page_state",
+		bytes.NewBufferString(`{"value":"{\"version\":1,\"libraries\":{}}"}`),
+	)
+	req = withRouteParams(req, map[string]string{"key": libraryPageStateSettingKey})
+	req = req.WithContext(apimw.SetClaims(req.Context(), &auth.Claims{UserID: 7}))
+	rec = httptest.NewRecorder()
+
+	handler.HandleSetSetting(rec, req)
+
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("user-scope status = %d body=%s", rec.Code, rec.Body.String())
+	}
+}
+
+func TestRememberLibraryPageStateIsDeviceScopedBoolSetting(t *testing.T) {
+	store := newProfileTestStore(t)
+	handler := NewSettingsHandler(testUserStoreProvider{store: store})
+
+	req := httptest.NewRequest(
+		http.MethodPut,
+		"/settings/device/ui.remember_library_page_state",
+		bytes.NewBufferString(`{"value":"false"}`),
+	)
+	req = withRouteParams(req, map[string]string{"key": rememberLibraryPageStateSettingKey})
+	req.Header.Set(deviceIDHeader, "browser")
+	req = req.WithContext(apimw.SetProfileID(apimw.SetClaims(req.Context(), &auth.Claims{UserID: 7}), "profile-1"))
+	rec := httptest.NewRecorder()
+
+	handler.HandleSetDeviceSetting(rec, req)
+
+	if rec.Code != http.StatusNoContent {
+		t.Fatalf("status = %d body=%s", rec.Code, rec.Body.String())
+	}
+	entry, err := store.GetDeviceSetting(context.Background(), "profile-1", "browser", rememberLibraryPageStateSettingKey)
+	if err != nil {
+		t.Fatalf("GetDeviceSetting: %v", err)
+	}
+	if entry == nil || entry.Value != "false" {
+		t.Fatalf("entry = %#v", entry)
+	}
+
+	req = httptest.NewRequest(
+		http.MethodPut,
+		"/settings/device/ui.remember_library_page_state",
+		bytes.NewBufferString(`{"value":"maybe"}`),
+	)
+	req = withRouteParams(req, map[string]string{"key": rememberLibraryPageStateSettingKey})
+	req.Header.Set(deviceIDHeader, "browser")
+	req = req.WithContext(apimw.SetProfileID(apimw.SetClaims(req.Context(), &auth.Claims{UserID: 7}), "profile-1"))
+	rec = httptest.NewRecorder()
+
+	handler.HandleSetDeviceSetting(rec, req)
+
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("invalid bool status = %d body=%s", rec.Code, rec.Body.String())
+	}
+
+	req = httptest.NewRequest(
+		http.MethodPut,
+		"/settings/ui.remember_library_page_state",
+		bytes.NewBufferString(`{"value":"false"}`),
+	)
+	req = withRouteParams(req, map[string]string{"key": rememberLibraryPageStateSettingKey})
+	req = req.WithContext(apimw.SetClaims(req.Context(), &auth.Claims{UserID: 7}))
+	rec = httptest.NewRecorder()
+
+	handler.HandleSetSetting(rec, req)
+
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("user-scope status = %d body=%s", rec.Code, rec.Body.String())
 	}
 }
 

--- a/internal/scanner/file_repo.go
+++ b/internal/scanner/file_repo.go
@@ -1963,6 +1963,33 @@ func (r *FileRepository) ListByContentIDs(ctx context.Context, contentIDs []stri
 	return grouped, nil
 }
 
+// ListByEpisodeIDs returns media files grouped by episode ID for the given
+// episode IDs, excluding files that are marked missing.
+func (r *FileRepository) ListByEpisodeIDs(ctx context.Context, episodeIDs []string) (map[string][]*models.MediaFile, error) {
+	grouped := make(map[string][]*models.MediaFile, len(episodeIDs))
+	if len(episodeIDs) == 0 {
+		return grouped, nil
+	}
+
+	query := `SELECT ` + fileColumns + ` FROM media_files
+		WHERE episode_id = ANY($1) AND missing_since IS NULL
+		ORDER BY episode_id ASC, id ASC`
+	rows, err := r.pool.Query(ctx, query, episodeIDs)
+	if err != nil {
+		return nil, fmt.Errorf("querying files by episode_ids: %w", err)
+	}
+	defer rows.Close()
+
+	files, err := scanMediaFiles(rows)
+	if err != nil {
+		return nil, err
+	}
+	for _, file := range files {
+		grouped[file.EpisodeID] = append(grouped[file.EpisodeID], file)
+	}
+	return grouped, nil
+}
+
 // UpdateContentID sets the content_id on a media file, linking it to a matched
 // media item. This is called by the matcher after a successful resolution.
 func (r *FileRepository) UpdateContentID(ctx context.Context, fileID int, contentID string) error {

--- a/web/src/api/types.ts
+++ b/web/src/api/types.ts
@@ -596,6 +596,16 @@ export interface MediaItemUserState {
   in_watchlist: boolean;
 }
 
+export interface BrowseItemSortMetrics {
+  release_date?: string;
+  runtime_minutes?: number;
+  resolution?: string;
+  bitrate_kbps?: number;
+  progress_ratio?: number;
+  viewed_at?: string;
+  play_count?: number;
+}
+
 export interface BrowseItem {
   content_id: string;
   type: "movie" | "series" | "season" | "episode";
@@ -625,6 +635,7 @@ export interface BrowseItem {
   release_date?: string | null;
   last_air_date?: string | null;
   overlay_summary?: OverlaySummary | null;
+  sort_metrics?: BrowseItemSortMetrics | null;
   user_state?: MediaItemUserState;
 }
 

--- a/web/src/components/AppSidebar.test.tsx
+++ b/web/src/components/AppSidebar.test.tsx
@@ -1,3 +1,5 @@
+// @vitest-environment node
+
 import type { ReactNode } from "react";
 import { renderToStaticMarkup } from "react-dom/server";
 import { MemoryRouter, Route, Routes } from "react-router";
@@ -44,6 +46,12 @@ vi.mock("@/hooks/queries/sidebarPins", () => ({
 vi.mock("@/hooks/queries/pluginSettings", () => ({
   usePluginSettingsList: () => ({
     data: { installations: [] },
+  }),
+}));
+
+vi.mock("@/hooks/queries/useRequests", () => ({
+  useRequestFeatureStatus: () => ({
+    data: { requests_enabled: false },
   }),
 }));
 
@@ -131,6 +139,12 @@ describe("AppSidebar", () => {
 
     expect(markup).toContain("text-sidebar-accent-foreground bg-sidebar-accent");
     expect(markup).not.toContain("text-sidebar-primary-foreground bg-sidebar-accent");
+  });
+
+  it("preserves the current library query when linking to the active library", () => {
+    const markup = renderSidebar("/library/7?tab=library&sort=year&order=desc");
+
+    expect(markup).toContain('href="/library/7?tab=library&amp;sort=year&amp;order=desc"');
   });
 
   it("keeps collapsed navigation rows left-anchored instead of centering icons", () => {

--- a/web/src/components/AppSidebar.tsx
+++ b/web/src/components/AppSidebar.tsx
@@ -68,6 +68,13 @@ function getLibraryIcon(type: string) {
   }
 }
 
+function getLibraryIdFromPathname(pathname: string): number | null {
+  const match = pathname.match(/^\/library\/(\d+)(?:\/|$)/);
+  if (!match) return null;
+  const id = Number(match[1]);
+  return Number.isInteger(id) && id > 0 ? id : null;
+}
+
 function SidebarLabel({ children, show }: { children: ReactNode; show: boolean }) {
   return (
     <span
@@ -187,13 +194,15 @@ export default function AppSidebar({ onNavigate, collapsed = false }: AppSidebar
         : null,
     [location.pathname, location.search],
   );
-  const activeLibraryId = params.libraryId
-    ? Number(params.libraryId)
-    : catalogState?.source === "section" && catalogState.scope === "library"
-      ? (catalogState.library_id ?? null)
-      : catalogState?.source === "library_collection"
-        ? (catalogState.library_id ?? null)
-        : null;
+  const activeLibraryId =
+    params.libraryId && Number.isInteger(Number(params.libraryId))
+      ? Number(params.libraryId)
+      : (getLibraryIdFromPathname(location.pathname) ??
+        (catalogState?.source === "section" && catalogState.scope === "library"
+          ? (catalogState.library_id ?? null)
+          : catalogState?.source === "library_collection"
+            ? (catalogState.library_id ?? null)
+            : null));
   // Hover-to-expand when collapsed (150ms enter delay prevents accidental expansion)
   const [hovered, setHovered] = useState(false);
   const [profileMenuOpen, setProfileMenuOpen] = useState(false);
@@ -338,8 +347,12 @@ export default function AppSidebar({ onNavigate, collapsed = false }: AppSidebar
             {(showLabels ? librariesExpanded : true) && (
               <ul className="list-none space-y-0.5">
                 {libraries.map((lib) => {
-                  const href = `/library/${lib.id}`;
+                  const baseHref = `/library/${lib.id}`;
                   const active = activeLibraryId === lib.id;
+                  const href =
+                    active && location.pathname === baseHref
+                      ? `${baseHref}${location.search}`
+                      : baseHref;
                   const libraryPins = pins[String(lib.id)] ?? [];
                   const hasPins = libraryPins.length > 0;
                   const isExpanded = hasPins && !expandedLibraries.has(lib.id);

--- a/web/src/components/ItemCard.test.tsx
+++ b/web/src/components/ItemCard.test.tsx
@@ -61,6 +61,98 @@ describe("ItemCard SortMeta", () => {
     expect(markup).toContain("2023");
   });
 
+  it("renders content rating when sorted by content_rating", () => {
+    const markup = renderCard({
+      sortField: "content_rating",
+      item: baseItem,
+    });
+
+    expect(markup).toContain("TV-MA");
+  });
+
+  it("renders runtime when sorted by runtime", () => {
+    const markup = renderCard({
+      sortField: "runtime",
+      item: {
+        ...baseItem,
+        runtime: 95,
+      },
+    });
+
+    expect(markup).toContain("1h 35m");
+  });
+
+  it("renders non-IMDb ratings for matching rating sorts", () => {
+    const tmdbMarkup = renderCard({
+      sortField: "rating_tmdb",
+      item: {
+        ...baseItem,
+        rating_tmdb: 8.2,
+      },
+    });
+    const criticMarkup = renderCard({
+      sortField: "rating_rt_critic",
+      item: {
+        ...baseItem,
+        rating_rt_critic: 96,
+      },
+    });
+
+    expect(tmdbMarkup).toContain("8.2 / 10");
+    expect(criticMarkup).toContain("96%");
+  });
+
+  it("renders resolution when sorted by resolution", () => {
+    const markup = renderCard({
+      sortField: "resolution",
+      item: {
+        ...baseItem,
+        overlay_summary: {
+          resolution: "2160p",
+        },
+      },
+    });
+
+    expect(markup).toContain("2160p");
+  });
+
+  it("renders episode sort metadata when an active sort has a value", () => {
+    const markup = renderCard({
+      sortField: "release_date",
+      item: {
+        ...baseItem,
+        content_id: "episode-1",
+        type: "episode",
+        title: "Long, Long Time",
+        series_title: "The Last of Us",
+        season_number: 1,
+        episode_number: 3,
+        release_date: "2023-01-29",
+      },
+    });
+
+    expect(markup).toContain("Jan");
+    expect(markup).toContain("2023");
+    expect(markup).not.toContain("S01E03");
+  });
+
+  it("keeps episode code when sorted by title", () => {
+    const markup = renderCard({
+      sortField: "title",
+      item: {
+        ...baseItem,
+        content_id: "episode-1",
+        type: "episode",
+        title: "Long, Long Time",
+        series_title: "The Last of Us",
+        season_number: 1,
+        episode_number: 3,
+      },
+    });
+
+    expect(markup).toContain("S01E03");
+  });
+
   it("renders episode cards with series context when available", () => {
     const markup = renderCard({
       item: {

--- a/web/src/components/ItemCard.tsx
+++ b/web/src/components/ItemCard.tsx
@@ -9,11 +9,14 @@ import CardOverlays from "@/components/overlays/CardOverlays";
 import { overlayDataFromBrowseItem, type CardOverlayPrefs } from "@/lib/overlays";
 import { buildEpisodeCardLabels } from "@/lib/episodeCardLabels";
 
+const DATE_ONLY_PATTERN = /^\d{4}-\d{2}-\d{2}$/;
+
 function formatDate(value?: string | null) {
   if (!value) {
     return null;
   }
-  return new Date(value).toLocaleDateString(undefined, {
+  const date = new Date(DATE_ONLY_PATTERN.test(value) ? `${value}T00:00:00` : value);
+  return date.toLocaleDateString(undefined, {
     year: "numeric",
     month: "short",
     day: "numeric",

--- a/web/src/components/ItemCard.tsx
+++ b/web/src/components/ItemCard.tsx
@@ -9,12 +9,53 @@ import CardOverlays from "@/components/overlays/CardOverlays";
 import { overlayDataFromBrowseItem, type CardOverlayPrefs } from "@/lib/overlays";
 import { buildEpisodeCardLabels } from "@/lib/episodeCardLabels";
 
+function formatDate(value?: string | null) {
+  if (!value) {
+    return null;
+  }
+  return new Date(value).toLocaleDateString(undefined, {
+    year: "numeric",
+    month: "short",
+    day: "numeric",
+  });
+}
+
+function formatRuntime(minutes?: number | null) {
+  if (!minutes || minutes <= 0) {
+    return null;
+  }
+  const hours = Math.floor(minutes / 60);
+  const remainingMinutes = minutes % 60;
+  if (hours === 0) {
+    return `${remainingMinutes}m`;
+  }
+  return remainingMinutes === 0 ? `${hours}h` : `${hours}h ${remainingMinutes}m`;
+}
+
+function formatRating(value?: number | null, max = 10) {
+  return value != null ? `${value.toFixed(1)} / ${max}` : null;
+}
+
+function formatPercent(value?: number | null) {
+  return value != null ? `${value}%` : null;
+}
+
+function formatBitrate(kbps?: number | null) {
+  if (!kbps || kbps <= 0) {
+    return null;
+  }
+  return `${kbps.toLocaleString()} kbps`;
+}
+
+function formatProgress(ratio?: number | null) {
+  if (ratio == null) {
+    return null;
+  }
+  return `${Math.round(Math.max(0, Math.min(1, ratio)) * 100)}%`;
+}
+
 function SortMeta({ item, sortField }: { item: BrowseItem; sortField?: string }) {
   const episodeLabels = buildEpisodeCardLabels(item);
-  if (episodeLabels) {
-    return <>{episodeLabels.episodeCode}</>;
-  }
-
   const defaultLabel = [item.year || "", item.type === "series" ? "Series" : ""]
     .filter(Boolean)
     .join(" · ");
@@ -25,6 +66,19 @@ function SortMeta({ item, sortField }: { item: BrowseItem; sortField?: string })
       const ago = item.added_at ? timeAgo(item.added_at) : null;
       return <>{ago ?? defaultLabel}</>;
     }
+    case "title":
+      if (episodeLabels) {
+        return <>{episodeLabels.episodeCode}</>;
+      }
+      return <>{defaultLabel}</>;
+    case "year":
+      return <>{item.year || defaultLabel}</>;
+    case "content_rating":
+      return <>{item.content_rating || defaultLabel}</>;
+    case "runtime":
+      return (
+        <>{formatRuntime(item.sort_metrics?.runtime_minutes ?? item.runtime) ?? defaultLabel}</>
+      );
     case "rating_imdb":
       return item.rating_imdb != null ? (
         <>
@@ -33,31 +87,34 @@ function SortMeta({ item, sortField }: { item: BrowseItem; sortField?: string })
       ) : (
         <>{defaultLabel}</>
       );
+    case "rating_tmdb":
+      return <>{formatRating(item.rating_tmdb) ?? defaultLabel}</>;
+    case "rating_rt_critic":
+      return <>{formatPercent(item.rating_rt_critic) ?? defaultLabel}</>;
+    case "rating_rt_audience":
+      return <>{formatPercent(item.rating_rt_audience) ?? defaultLabel}</>;
     case "release_date":
-      return item.release_date ? (
-        <>
-          {new Date(item.release_date).toLocaleDateString(undefined, {
-            year: "numeric",
-            month: "short",
-            day: "numeric",
-          })}
-        </>
-      ) : (
-        <>{defaultLabel}</>
+      return (
+        <>{formatDate(item.sort_metrics?.release_date ?? item.release_date) ?? defaultLabel}</>
       );
     case "last_air_date":
-      return item.last_air_date ? (
-        <>
-          {new Date(item.last_air_date).toLocaleDateString(undefined, {
-            year: "numeric",
-            month: "short",
-            day: "numeric",
-          })}
-        </>
-      ) : (
-        <>{defaultLabel}</>
+      return <>{formatDate(item.last_air_date) ?? defaultLabel}</>;
+    case "resolution":
+      return (
+        <>{item.sort_metrics?.resolution || item.overlay_summary?.resolution || defaultLabel}</>
       );
+    case "bitrate":
+      return <>{formatBitrate(item.sort_metrics?.bitrate_kbps) ?? defaultLabel}</>;
+    case "progress":
+      return <>{formatProgress(item.sort_metrics?.progress_ratio) ?? defaultLabel}</>;
+    case "date_viewed":
+      return <>{formatDate(item.sort_metrics?.viewed_at) ?? defaultLabel}</>;
+    case "plays":
+      return <>{item.sort_metrics?.play_count ?? defaultLabel}</>;
     default:
+      if (episodeLabels) {
+        return <>{episodeLabels.episodeCode}</>;
+      }
       return <>{defaultLabel}</>;
   }
 }

--- a/web/src/components/settings/SettingRow.tsx
+++ b/web/src/components/settings/SettingRow.tsx
@@ -1,0 +1,25 @@
+import { useId, type ReactNode } from "react";
+
+import { Label } from "@/components/ui/label";
+
+interface SettingRowProps {
+  label: string;
+  description: string;
+  control: (id: string) => ReactNode;
+}
+
+export function SettingRow({ label, description, control }: SettingRowProps) {
+  const id = useId();
+
+  return (
+    <div className="border-border/50 grid gap-3 border-t pt-4 first:border-t-0 first:pt-0 md:grid-cols-[minmax(0,1fr)_auto] md:items-center">
+      <div className="min-w-0 space-y-1">
+        <Label htmlFor={id} className="text-sm font-medium">
+          {label}
+        </Label>
+        <p className="text-muted-foreground text-[13px] leading-relaxed">{description}</p>
+      </div>
+      <div className="flex md:justify-end">{control(id)}</div>
+    </div>
+  );
+}

--- a/web/src/hooks/queries/catalog.test.tsx
+++ b/web/src/hooks/queries/catalog.test.tsx
@@ -132,6 +132,43 @@ describe("useCatalogWindow", () => {
     expect(markup).toContain('data-total="360"');
   });
 
+  it("does not count empty buffered pages as loaded items when total is omitted", () => {
+    const state = createCatalogSearchState("query", { library_id: 7 });
+    const limit = 60;
+
+    function Harness() {
+      const result = useCatalogWindow(state, { limit, includeTotal: false });
+      return <div data-total={result.data.totalItems} />;
+    }
+
+    mocks.useQuery.mockReturnValue({
+      data: {
+        ...makePage(0, 3),
+        total: 0,
+        total_exact: false,
+        has_more: false,
+        snapshot: "2026-01-01T00:00:00Z",
+      },
+      isLoading: false,
+    });
+    mocks.useQueries.mockReturnValue([
+      {
+        data: {
+          ...makePage(60, 0),
+          total: 0,
+          total_exact: false,
+          has_more: false,
+          items: [],
+        },
+        isLoading: false,
+      },
+    ]);
+
+    const markup = renderToStaticMarkup(<Harness />);
+
+    expect(markup).toContain('data-total="3"');
+  });
+
   it("requests follow-on pages for non-snapshot sources after page 0 loads", () => {
     const state = createCatalogSearchState("history");
     const limit = 60;

--- a/web/src/hooks/queries/catalog.ts
+++ b/web/src/hooks/queries/catalog.ts
@@ -197,7 +197,9 @@ export function useCatalogWindow(
     let highestPageIndex = -1;
     let highestPageHasMore = false;
     pageResults.forEach((page, pageIndex) => {
-      maxLoadedEnd = Math.max(maxLoadedEnd, pageIndex * limit + page.items.length);
+      if (page.items.length > 0) {
+        maxLoadedEnd = Math.max(maxLoadedEnd, pageIndex * limit + page.items.length);
+      }
       if (pageIndex >= highestPageIndex) {
         highestPageIndex = pageIndex;
         highestPageHasMore = page.has_more;

--- a/web/src/hooks/queries/libraryPageState.test.ts
+++ b/web/src/hooks/queries/libraryPageState.test.ts
@@ -1,0 +1,75 @@
+// @vitest-environment node
+
+import { describe, expect, it } from "vitest";
+
+import {
+  parseLibraryPageStatePreference,
+  serializeLibraryPageStatePreference,
+  updateLibraryPageStatePreference,
+} from "./libraryPageState";
+
+describe("library page state preference helpers", () => {
+  it("parses valid preferences", () => {
+    expect(
+      parseLibraryPageStatePreference(
+        JSON.stringify({
+          version: 1,
+          libraries: {
+            "7": { search: "tab=library&sort=year" },
+          },
+        }),
+      ),
+    ).toEqual({
+      version: 1,
+      libraries: {
+        "7": { search: "tab=library&sort=year" },
+      },
+    });
+  });
+
+  it("ignores malformed, wrong-version, and non-string entries", () => {
+    expect(parseLibraryPageStatePreference("not json")).toEqual({ version: 1, libraries: {} });
+    expect(parseLibraryPageStatePreference(JSON.stringify({ version: 2, libraries: {} }))).toEqual({
+      version: 1,
+      libraries: {},
+    });
+    expect(
+      parseLibraryPageStatePreference(
+        JSON.stringify({
+          version: 1,
+          libraries: {
+            "7": { search: 42 },
+            nope: { search: "tab=library" },
+            "9": { search: "tab=collections" },
+          },
+        }),
+      ),
+    ).toEqual({
+      version: 1,
+      libraries: {
+        "9": { search: "tab=collections" },
+      },
+    });
+  });
+
+  it("updates and serializes per-library entries", () => {
+    const next = updateLibraryPageStatePreference(
+      {
+        version: 1,
+        libraries: {
+          "1": { search: "tab=collections" },
+        },
+      },
+      7,
+      "tab=library&sort=year",
+    );
+
+    expect(JSON.parse(serializeLibraryPageStatePreference(next))).toEqual({
+      version: 1,
+      libraries: {
+        "1": { search: "tab=collections" },
+        "7": { search: "tab=library&sort=year" },
+      },
+    });
+  });
+});

--- a/web/src/hooks/queries/libraryPageState.ts
+++ b/web/src/hooks/queries/libraryPageState.ts
@@ -1,0 +1,109 @@
+import { useCallback, useMemo } from "react";
+import {
+  useDeviceSetting,
+  useEffectiveSettings,
+  useSetDeviceSetting,
+} from "@/hooks/queries/settings";
+import { storage } from "@/utils/storage";
+
+export const LIBRARY_PAGE_STATE_SETTING_KEY = "ui.library_page_state";
+export const REMEMBER_LIBRARY_PAGE_STATE_SETTING_KEY = "ui.remember_library_page_state";
+
+export interface LibraryPageStatePreference {
+  version: 1;
+  libraries: Record<string, { search: string }>;
+}
+
+export function parseLibraryPageStatePreference(
+  raw: string | null | undefined,
+): LibraryPageStatePreference {
+  if (!raw) {
+    return createEmptyLibraryPageStatePreference();
+  }
+  try {
+    const value = JSON.parse(raw) as unknown;
+    if (!value || typeof value !== "object" || Array.isArray(value)) {
+      return createEmptyLibraryPageStatePreference();
+    }
+    const maybePreference = value as {
+      version?: unknown;
+      libraries?: unknown;
+    };
+    if (maybePreference.version !== 1 || !maybePreference.libraries) {
+      return createEmptyLibraryPageStatePreference();
+    }
+    if (typeof maybePreference.libraries !== "object" || Array.isArray(maybePreference.libraries)) {
+      return createEmptyLibraryPageStatePreference();
+    }
+
+    const libraries: LibraryPageStatePreference["libraries"] = {};
+    Object.entries(maybePreference.libraries).forEach(([libraryId, entry]) => {
+      if (!/^\d+$/.test(libraryId) || !entry || typeof entry !== "object" || Array.isArray(entry)) {
+        return;
+      }
+      const search = (entry as { search?: unknown }).search;
+      if (typeof search !== "string") {
+        return;
+      }
+      libraries[libraryId] = { search };
+    });
+
+    return { version: 1, libraries };
+  } catch {
+    return createEmptyLibraryPageStatePreference();
+  }
+}
+
+export function serializeLibraryPageStatePreference(
+  preference: LibraryPageStatePreference,
+): string {
+  return JSON.stringify(preference);
+}
+
+export function updateLibraryPageStatePreference(
+  preference: LibraryPageStatePreference,
+  libraryId: number,
+  search: string,
+): LibraryPageStatePreference {
+  return {
+    version: 1,
+    libraries: {
+      ...preference.libraries,
+      [String(libraryId)]: { search },
+    },
+  };
+}
+
+function createEmptyLibraryPageStatePreference(): LibraryPageStatePreference {
+  return { version: 1, libraries: {} };
+}
+
+export function useLibraryPageStatePreference() {
+  const profileId = storage.get(storage.KEYS.PROFILE_ID);
+  const setting = useDeviceSetting(profileId, LIBRARY_PAGE_STATE_SETTING_KEY);
+  const rememberSetting = useEffectiveSettings(profileId, [
+    REMEMBER_LIBRARY_PAGE_STATE_SETTING_KEY,
+  ]);
+  const mutation = useSetDeviceSetting();
+  const { mutate } = mutation;
+  const preference = useMemo(() => parseLibraryPageStatePreference(setting.data), [setting.data]);
+  const rememberEnabled =
+    rememberSetting.data?.[REMEMBER_LIBRARY_PAGE_STATE_SETTING_KEY]?.effective_value !== "false";
+  const saveLibrarySearch = useCallback(
+    (libraryId: number, search: string) => {
+      const nextPreference = updateLibraryPageStatePreference(preference, libraryId, search);
+      mutate({
+        key: LIBRARY_PAGE_STATE_SETTING_KEY,
+        value: serializeLibraryPageStatePreference(nextPreference),
+      });
+    },
+    [mutate, preference],
+  );
+
+  return {
+    isLoading: setting.isLoading || rememberSetting.isLoading,
+    preference,
+    rememberEnabled,
+    saveLibrarySearch,
+  };
+}

--- a/web/src/lib/settingsManifest.ts
+++ b/web/src/lib/settingsManifest.ts
@@ -129,6 +129,15 @@ const definitions: SettingDefinition[] = [
     summary: (value) => (value ? "Custom subtitle appearance" : "Using fallback"),
   },
   {
+    key: "ui.remember_library_page_state",
+    scope: "device",
+    label: "Remember library pages",
+    description:
+      "Return each library to the last tab, sort, and filters used on this profile and device.",
+    control: "switch",
+    defaultValue: "true",
+  },
+  {
     key: "player.hdr_enabled",
     scope: "device",
     label: "HDR enabled",

--- a/web/src/pages/LibraryPage.tsx
+++ b/web/src/pages/LibraryPage.tsx
@@ -30,6 +30,7 @@ export default function LibraryPage() {
   } = useLibraryPageStatePreference();
   const savedStateHydratedLibraryIdRef = useRef<number | null>(null);
   const applyingSavedSearchParamsRef = useRef<string | null>(null);
+  const applyingSavedSearchParamsLibraryIdRef = useRef<number | null>(null);
 
   const id = Number(libraryId);
   const library = libraries?.find((l) => l.id === id);
@@ -88,7 +89,8 @@ export default function LibraryPage() {
     savedStateHydratedLibraryIdRef.current = id;
     const nextSearchParams = applySavedLibraryPageSearchParams(searchParams, savedLibrarySearch);
     if (nextSearchParams.toString() !== searchParams.toString()) {
-      applyingSavedSearchParamsRef.current = nextSearchParams.toString();
+      applyingSavedSearchParamsRef.current = serializeLibraryPageSearchParams(nextSearchParams);
+      applyingSavedSearchParamsLibraryIdRef.current = id;
       setSearchParams(nextSearchParams, { replace: true });
     }
   }, [
@@ -105,6 +107,11 @@ export default function LibraryPage() {
   useEffect(() => {
     if (!libraryType || shouldApplySavedLibrarySearch) {
       return;
+    }
+
+    if (applyingSavedSearchParamsLibraryIdRef.current !== id) {
+      applyingSavedSearchParamsRef.current = null;
+      applyingSavedSearchParamsLibraryIdRef.current = id;
     }
 
     const normalizedSearchParams = updateLibraryPageSearchParams(
@@ -147,15 +154,15 @@ export default function LibraryPage() {
       return;
     }
 
-    const search = serializeLibraryPageSearchParams(normalizedSearchParams);
+    const canonicalSearch = serializeLibraryPageSearchParams(normalizedSearchParams);
     if (applyingSavedSearchParamsRef.current != null) {
-      if (applyingSavedSearchParamsRef.current === normalizedSearchParams.toString()) {
+      if (applyingSavedSearchParamsRef.current === canonicalSearch) {
         applyingSavedSearchParamsRef.current = null;
       }
       return;
     }
-    if (savedLibrarySearch !== search) {
-      saveLibrarySearch(id, search);
+    if (savedLibrarySearch !== canonicalSearch) {
+      saveLibrarySearch(id, canonicalSearch);
     }
   }, [
     activeTab,

--- a/web/src/pages/LibraryPage.tsx
+++ b/web/src/pages/LibraryPage.tsx
@@ -38,6 +38,23 @@ export default function LibraryPage() {
     Number.isFinite(id) && id > 0
       ? libraryPageStatePreference.libraries[String(id)]?.search
       : undefined;
+  const shouldApplySavedLibrarySearch =
+    Boolean(libraryType) &&
+    Number.isFinite(id) &&
+    id > 0 &&
+    !libraryPageStateLoading &&
+    rememberLibraryPageState &&
+    savedStateHydratedLibraryIdRef.current !== id &&
+    savedLibrarySearch != null &&
+    !hasLibraryPageSearchParams(searchParams) &&
+    savedLibrarySearch !== serializeLibraryPageSearchParams(searchParams);
+  const shouldWaitForSavedLibrarySearch =
+    Boolean(libraryType) &&
+    Number.isFinite(id) &&
+    id > 0 &&
+    libraryPageStateLoading &&
+    savedStateHydratedLibraryIdRef.current !== id &&
+    !hasLibraryPageSearchParams(searchParams);
   const { activeTab, browseType, queryDefinition } = parseLibraryPageState(
     searchParams,
     libraryType,
@@ -62,20 +79,13 @@ export default function LibraryPage() {
       id <= 0 ||
       libraryPageStateLoading ||
       !rememberLibraryPageState ||
-      savedStateHydratedLibraryIdRef.current === id
+      savedStateHydratedLibraryIdRef.current === id ||
+      !shouldApplySavedLibrarySearch
     ) {
       return;
     }
 
     savedStateHydratedLibraryIdRef.current = id;
-    if (
-      savedLibrarySearch == null ||
-      hasLibraryPageSearchParams(searchParams) ||
-      savedLibrarySearch === serializeLibraryPageSearchParams(searchParams)
-    ) {
-      return;
-    }
-
     const nextSearchParams = applySavedLibraryPageSearchParams(searchParams, savedLibrarySearch);
     if (nextSearchParams.toString() !== searchParams.toString()) {
       applyingSavedSearchParamsRef.current = nextSearchParams.toString();
@@ -89,10 +99,11 @@ export default function LibraryPage() {
     savedLibrarySearch,
     searchParams,
     setSearchParams,
+    shouldApplySavedLibrarySearch,
   ]);
 
   useEffect(() => {
-    if (!libraryType) {
+    if (!libraryType || shouldApplySavedLibrarySearch) {
       return;
     }
 
@@ -105,7 +116,15 @@ export default function LibraryPage() {
     if (normalizedSearchParams.toString() !== searchParams.toString()) {
       setSearchParams(normalizedSearchParams, { replace: true });
     }
-  }, [activeTab, browseType, queryDefinition, libraryType, searchParams, setSearchParams]);
+  }, [
+    activeTab,
+    browseType,
+    queryDefinition,
+    libraryType,
+    searchParams,
+    setSearchParams,
+    shouldApplySavedLibrarySearch,
+  ]);
 
   useEffect(() => {
     if (
@@ -113,7 +132,8 @@ export default function LibraryPage() {
       !Number.isFinite(id) ||
       id <= 0 ||
       libraryPageStateLoading ||
-      !rememberLibraryPageState
+      !rememberLibraryPageState ||
+      shouldApplySavedLibrarySearch
     ) {
       return;
     }
@@ -148,6 +168,7 @@ export default function LibraryPage() {
     saveLibrarySearch,
     savedLibrarySearch,
     searchParams,
+    shouldApplySavedLibrarySearch,
   ]);
 
   const handleTabChange = (value: string) => {
@@ -190,7 +211,7 @@ export default function LibraryPage() {
     setSearchParams(nextSearchParams);
   };
 
-  if (isLoading) {
+  if (isLoading || shouldWaitForSavedLibrarySearch || shouldApplySavedLibrarySearch) {
     return (
       <div className="h-full px-4 py-4 sm:px-6 sm:py-6 lg:px-10 xl:px-12">
         <Skeleton className="mb-6 h-10 w-48" />

--- a/web/src/pages/LibraryPage.tsx
+++ b/web/src/pages/LibraryPage.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import { Link, useParams, useSearchParams } from "react-router";
 import type { QueryDefinition } from "@/api/types";
 import { Tabs, TabsContent } from "@/components/ui/tabs";
@@ -9,16 +9,35 @@ import { useDocumentTitle } from "@/hooks/useDocumentTitle";
 import LibraryRecommended from "./LibraryRecommended";
 import LibraryBrowse from "./LibraryBrowse";
 import LibraryCollections from "./LibraryCollections";
-import { parseLibraryPageState, updateLibraryPageSearchParams } from "./libraryPageSearchParams";
+import { useLibraryPageStatePreference } from "@/hooks/queries/libraryPageState";
+import {
+  applySavedLibraryPageSearchParams,
+  hasLibraryPageSearchParams,
+  parseLibraryPageState,
+  serializeLibraryPageSearchParams,
+  updateLibraryPageSearchParams,
+} from "./libraryPageSearchParams";
 
 export default function LibraryPage() {
   const { libraryId } = useParams<{ libraryId: string }>();
   const [searchParams, setSearchParams] = useSearchParams();
   const { data: libraries, isLoading } = useUserLibraries();
+  const {
+    isLoading: libraryPageStateLoading,
+    preference: libraryPageStatePreference,
+    rememberEnabled: rememberLibraryPageState,
+    saveLibrarySearch,
+  } = useLibraryPageStatePreference();
+  const savedStateHydratedLibraryIdRef = useRef<number | null>(null);
+  const applyingSavedSearchParamsRef = useRef<string | null>(null);
 
   const id = Number(libraryId);
   const library = libraries?.find((l) => l.id === id);
   const libraryType = library?.type ?? "";
+  const savedLibrarySearch =
+    Number.isFinite(id) && id > 0
+      ? libraryPageStatePreference.libraries[String(id)]?.search
+      : undefined;
   const { activeTab, browseType, queryDefinition } = parseLibraryPageState(
     searchParams,
     libraryType,
@@ -37,6 +56,42 @@ export default function LibraryPage() {
   useDocumentTitle(library?.name ?? "Library");
 
   useEffect(() => {
+    if (
+      !libraryType ||
+      !Number.isFinite(id) ||
+      id <= 0 ||
+      libraryPageStateLoading ||
+      !rememberLibraryPageState ||
+      savedStateHydratedLibraryIdRef.current === id
+    ) {
+      return;
+    }
+
+    savedStateHydratedLibraryIdRef.current = id;
+    if (
+      savedLibrarySearch == null ||
+      hasLibraryPageSearchParams(searchParams) ||
+      savedLibrarySearch === serializeLibraryPageSearchParams(searchParams)
+    ) {
+      return;
+    }
+
+    const nextSearchParams = applySavedLibraryPageSearchParams(searchParams, savedLibrarySearch);
+    if (nextSearchParams.toString() !== searchParams.toString()) {
+      applyingSavedSearchParamsRef.current = nextSearchParams.toString();
+      setSearchParams(nextSearchParams, { replace: true });
+    }
+  }, [
+    id,
+    libraryPageStateLoading,
+    libraryType,
+    rememberLibraryPageState,
+    savedLibrarySearch,
+    searchParams,
+    setSearchParams,
+  ]);
+
+  useEffect(() => {
     if (!libraryType) {
       return;
     }
@@ -51,6 +106,49 @@ export default function LibraryPage() {
       setSearchParams(normalizedSearchParams, { replace: true });
     }
   }, [activeTab, browseType, queryDefinition, libraryType, searchParams, setSearchParams]);
+
+  useEffect(() => {
+    if (
+      !libraryType ||
+      !Number.isFinite(id) ||
+      id <= 0 ||
+      libraryPageStateLoading ||
+      !rememberLibraryPageState
+    ) {
+      return;
+    }
+
+    const normalizedSearchParams = updateLibraryPageSearchParams(
+      searchParams,
+      { activeTab, browseType, queryDefinition },
+      libraryType,
+    );
+    if (normalizedSearchParams.toString() !== searchParams.toString()) {
+      return;
+    }
+
+    const search = serializeLibraryPageSearchParams(normalizedSearchParams);
+    if (applyingSavedSearchParamsRef.current != null) {
+      if (applyingSavedSearchParamsRef.current === normalizedSearchParams.toString()) {
+        applyingSavedSearchParamsRef.current = null;
+      }
+      return;
+    }
+    if (savedLibrarySearch !== search) {
+      saveLibrarySearch(id, search);
+    }
+  }, [
+    activeTab,
+    browseType,
+    id,
+    libraryPageStateLoading,
+    libraryType,
+    queryDefinition,
+    rememberLibraryPageState,
+    saveLibrarySearch,
+    savedLibrarySearch,
+    searchParams,
+  ]);
 
   const handleTabChange = (value: string) => {
     const nextSearchParams = updateLibraryPageSearchParams(

--- a/web/src/pages/PersonDetail.tsx
+++ b/web/src/pages/PersonDetail.tsx
@@ -4,7 +4,7 @@ import { useQuery } from "@tanstack/react-query";
 import { Pencil, RefreshCw } from "lucide-react";
 
 import { getPerson } from "@/api/client";
-import { createEmptyQueryDefinition } from "@/api/types";
+import { createEmptyQueryDefinition, type Person } from "@/api/types";
 import type { CatalogSearchState } from "@/pages/catalogSearchParams";
 import EditPersonDialog from "@/components/EditPersonDialog";
 import ItemGrid from "@/components/ItemGrid";
@@ -25,6 +25,7 @@ export default function PersonDetail() {
   const { id } = useParams<{ id: string }>();
   const [typeFilter, setTypeFilter] = useState<TypeFilter>("all");
   const [editOpen, setEditOpen] = useState(false);
+  const autoRefreshWindowRef = useRef<{ personId: number; until: number } | null>(null);
   const { user } = useAuth();
   const isAdmin = user?.role === "admin";
   const refreshMutation = useRefreshPerson(id, isAdmin);
@@ -33,6 +34,21 @@ export default function PersonDetail() {
     queryKey: personKeys.detail(id!),
     queryFn: () => getPerson(id!),
     enabled: !!id,
+    refetchInterval: (query) => {
+      const data = query.state.data;
+      if (!data || !isPersonMetadataIncomplete(data)) {
+        autoRefreshWindowRef.current = null;
+        return false;
+      }
+
+      const current = autoRefreshWindowRef.current;
+      if (!current || current.personId !== data.id) {
+        autoRefreshWindowRef.current = { personId: data.id, until: Date.now() + 30_000 };
+        return 3_000;
+      }
+
+      return Date.now() < current.until ? 3_000 : false;
+    },
   });
 
   useDocumentTitle(person?.name ?? "Person");
@@ -210,6 +226,10 @@ export default function PersonDetail() {
       ) : null}
     </div>
   );
+}
+
+function isPersonMetadataIncomplete(person: Person) {
+  return !person.bio || !person.photo_url || !person.birth_date;
 }
 
 function PersonDetailSkeleton() {

--- a/web/src/pages/PersonDetail.tsx
+++ b/web/src/pages/PersonDetail.tsx
@@ -26,6 +26,7 @@ export default function PersonDetail() {
   const [typeFilter, setTypeFilter] = useState<TypeFilter>("all");
   const [editOpen, setEditOpen] = useState(false);
   const autoRefreshWindowRef = useRef<{ personId: number; until: number } | null>(null);
+  const autoRefreshRequestedPersonIdRef = useRef<number | null>(null);
   const { user } = useAuth();
   const isAdmin = user?.role === "admin";
   const refreshMutation = useRefreshPerson(id, isAdmin);
@@ -52,6 +53,17 @@ export default function PersonDetail() {
   });
 
   useDocumentTitle(person?.name ?? "Person");
+
+  useEffect(() => {
+    if (!person || !user || !isPersonMetadataIncomplete(person)) {
+      return;
+    }
+    if (autoRefreshRequestedPersonIdRef.current === person.id || refreshMutation.isPending) {
+      return;
+    }
+    autoRefreshRequestedPersonIdRef.current = person.id;
+    refreshMutation.mutate();
+  }, [person, refreshMutation, user]);
 
   const catalogState: CatalogSearchState = useMemo(
     () => ({

--- a/web/src/pages/libraryPageSearchParams.test.ts
+++ b/web/src/pages/libraryPageSearchParams.test.ts
@@ -1,6 +1,14 @@
+// @vitest-environment node
+
 import { describe, expect, it } from "vitest";
 
-import { updateLibraryPageSearchParams, parseLibraryPageState } from "./libraryPageSearchParams";
+import {
+  applySavedLibraryPageSearchParams,
+  hasLibraryPageSearchParams,
+  parseLibraryPageState,
+  serializeLibraryPageSearchParams,
+  updateLibraryPageSearchParams,
+} from "./libraryPageSearchParams";
 
 function params(search: string) {
   return new URLSearchParams(search);
@@ -298,6 +306,46 @@ describe("updateLibraryPageSearchParams", () => {
       foo: "bar",
       tab: "library",
       type: "episode",
+    });
+  });
+});
+
+describe("library page saved state helpers", () => {
+  it("detects explicit library state params", () => {
+    expect(hasLibraryPageSearchParams(params(""))).toBe(false);
+    expect(hasLibraryPageSearchParams(params("foo=bar"))).toBe(false);
+    expect(hasLibraryPageSearchParams(params("tab=collections"))).toBe(true);
+    expect(hasLibraryPageSearchParams(params("sort=year"))).toBe(true);
+    expect(hasLibraryPageSearchParams(params("groups[0][rules][0][field]=genre"))).toBe(true);
+  });
+
+  it("serializes only library state params", () => {
+    const serialized = serializeLibraryPageSearchParams(
+      params(
+        "foo=bar&tab=library&sort=year&order=desc&groups[0][match]=all&groups[0][rules][0][field]=genre",
+      ),
+    );
+
+    expect(Object.fromEntries(new URLSearchParams(serialized).entries())).toEqual({
+      tab: "library",
+      sort: "year",
+      order: "desc",
+      "groups[0][match]": "all",
+      "groups[0][rules][0][field]": "genre",
+    });
+  });
+
+  it("applies saved library state while preserving unrelated params", () => {
+    const next = applySavedLibraryPageSearchParams(
+      params("foo=bar"),
+      "tab=library&sort=year&order=desc",
+    );
+
+    expect(asObject(next)).toEqual({
+      foo: "bar",
+      tab: "library",
+      sort: "year",
+      order: "desc",
     });
   });
 });

--- a/web/src/pages/libraryPageSearchParams.ts
+++ b/web/src/pages/libraryPageSearchParams.ts
@@ -258,9 +258,7 @@ export function parseLibraryPageState(
   const mediaScopeParam = readString(searchParams.get("type"));
   const mediaScope =
     libraryType === "mixed" &&
-    (mediaScopeParam === "movie" ||
-      mediaScopeParam === "series" ||
-      mediaScopeParam === "episode")
+    (mediaScopeParam === "movie" || mediaScopeParam === "series" || mediaScopeParam === "episode")
       ? mediaScopeParam
       : undefined;
   const sortRelevanceScope =
@@ -290,6 +288,20 @@ export function parseLibraryPageState(
   };
 }
 
+export function hasLibraryPageSearchParams(searchParams: URLSearchParams): boolean {
+  for (const key of searchParams.keys()) {
+    if (
+      LIBRARY_QUERY_KEYS.has(key) ||
+      GROUP_MATCH_PATTERN.test(key) ||
+      GROUP_RULE_PATTERN.test(key) ||
+      GROUP_RULE_VALUE_PATTERN.test(key)
+    ) {
+      return true;
+    }
+  }
+  return false;
+}
+
 function deleteLibraryQueryParams(nextSearchParams: URLSearchParams) {
   for (const key of Array.from(nextSearchParams.keys())) {
     if (
@@ -301,6 +313,34 @@ function deleteLibraryQueryParams(nextSearchParams: URLSearchParams) {
       nextSearchParams.delete(key);
     }
   }
+}
+
+export function serializeLibraryPageSearchParams(searchParams: URLSearchParams): string {
+  const librarySearchParams = new URLSearchParams(searchParams);
+  for (const key of Array.from(librarySearchParams.keys())) {
+    if (
+      !LIBRARY_QUERY_KEYS.has(key) &&
+      !GROUP_MATCH_PATTERN.test(key) &&
+      !GROUP_RULE_PATTERN.test(key) &&
+      !GROUP_RULE_VALUE_PATTERN.test(key)
+    ) {
+      librarySearchParams.delete(key);
+    }
+  }
+  return librarySearchParams.toString();
+}
+
+export function applySavedLibraryPageSearchParams(
+  currentSearchParams: URLSearchParams,
+  savedSearch: string,
+): URLSearchParams {
+  const nextSearchParams = new URLSearchParams(currentSearchParams);
+  deleteLibraryQueryParams(nextSearchParams);
+  const savedSearchParams = new URLSearchParams(savedSearch);
+  savedSearchParams.forEach((value, key) => {
+    nextSearchParams.append(key, value);
+  });
+  return nextSearchParams;
 }
 
 export function updateLibraryPageSearchParams(

--- a/web/src/pages/settings/LibrarySettings.test.tsx
+++ b/web/src/pages/settings/LibrarySettings.test.tsx
@@ -1,3 +1,5 @@
+// @vitest-environment node
+
 import { renderToStaticMarkup } from "react-dom/server";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
@@ -12,7 +14,10 @@ const mocks = vi.hoisted(() => ({
   useAvailableUserLibraries: vi.fn(),
   useCurrentProfile: vi.fn(),
   useLibraryPlaybackPreferences: vi.fn(),
+  useDeleteDeviceSetting: vi.fn(),
+  useEffectiveSettings: vi.fn(),
   useSetting: vi.fn(),
+  useSetDeviceSetting: vi.fn(),
   useSetSetting: vi.fn(),
 }));
 
@@ -34,7 +39,10 @@ vi.mock("@/hooks/queries/settings", async () => {
 
   return {
     ...actual,
+    useDeleteDeviceSetting: (...args: unknown[]) => mocks.useDeleteDeviceSetting(...args),
+    useEffectiveSettings: (...args: unknown[]) => mocks.useEffectiveSettings(...args),
     useSetting: (...args: unknown[]) => mocks.useSetting(...args),
+    useSetDeviceSetting: (...args: unknown[]) => mocks.useSetDeviceSetting(...args),
     useSetSetting: (...args: unknown[]) => mocks.useSetSetting(...args),
   };
 });
@@ -183,7 +191,10 @@ describe("LibrarySettings", () => {
     mocks.useAvailableUserLibraries.mockReset();
     mocks.useCurrentProfile.mockReset();
     mocks.useLibraryPlaybackPreferences.mockReset();
+    mocks.useDeleteDeviceSetting.mockReset();
+    mocks.useEffectiveSettings.mockReset();
     mocks.useSetting.mockReset();
+    mocks.useSetDeviceSetting.mockReset();
     mocks.useSetSetting.mockReset();
 
     mocks.useAvailableUserLibraries.mockReturnValue({
@@ -198,9 +209,21 @@ describe("LibrarySettings", () => {
       data: [],
       isLoading: false,
     });
+    mocks.useDeleteDeviceSetting.mockReturnValue({
+      isPending: false,
+      mutateAsync: vi.fn(),
+    });
+    mocks.useEffectiveSettings.mockReturnValue({
+      data: {},
+      isLoading: false,
+    });
     mocks.useSetting.mockReturnValue({
       data: null,
       isLoading: false,
+    });
+    mocks.useSetDeviceSetting.mockReturnValue({
+      isPending: false,
+      mutateAsync: vi.fn(),
     });
     mocks.useSetSetting.mockReturnValue({
       isPending: false,
@@ -212,7 +235,8 @@ describe("LibrarySettings", () => {
     const markup = renderToStaticMarkup(<LibrarySettings />);
 
     expect(markup).toContain("Uses profile defaults");
-    expect(markup).toContain("Playback");
+    expect(markup).toContain("Remember library pages");
+    expect(markup).toContain("Edit playback overrides");
   });
 
   it("renders the playback override summary for libraries with saved defaults", () => {

--- a/web/src/pages/settings/LibrarySettings.tsx
+++ b/web/src/pages/settings/LibrarySettings.tsx
@@ -1,6 +1,8 @@
 import { useEffect, useId, useState, type ReactNode } from "react";
 import type { LibraryPlaybackPreference, Profile, UserLibrary } from "@/api/types";
 import { Badge } from "@/components/ui/badge";
+import { SettingRow } from "@/components/settings/SettingRow";
+import { SettingsGroup } from "@/components/settings/SettingsGroup";
 import { Button } from "@/components/ui/button";
 import { Label } from "@/components/ui/label";
 import {
@@ -27,7 +29,17 @@ import {
   serializeLibraryOrder,
   useAvailableUserLibraries,
 } from "@/hooks/queries/libraries";
-import { useSetting, useSetSetting } from "@/hooks/queries/settings";
+import {
+  useDeleteDeviceSetting,
+  useEffectiveSettings,
+  useSetting,
+  useSetDeviceSetting,
+  useSetSetting,
+} from "@/hooks/queries/settings";
+import {
+  LIBRARY_PAGE_STATE_SETTING_KEY,
+  REMEMBER_LIBRARY_PAGE_STATE_SETTING_KEY,
+} from "@/hooks/queries/libraryPageState";
 import {
   buildInheritedLanguageLabel,
   buildInheritedShowForcedSubtitlesLabel,
@@ -73,6 +85,49 @@ import { CSS } from "@dnd-kit/utilities";
 function sortLibrariesByOrder(libraries: UserLibrary[], ids: number[]) {
   const selected = new Set(ids);
   return libraries.filter((library) => selected.has(library.id)).map((library) => library.id);
+}
+
+function RememberLibraryPageStateSetting({ profileId }: { profileId: string }) {
+  const { data: effective = {} } = useEffectiveSettings(profileId, [
+    REMEMBER_LIBRARY_PAGE_STATE_SETTING_KEY,
+  ]);
+  const setDeviceSetting = useSetDeviceSetting();
+  const deleteDeviceSetting = useDeleteDeviceSetting();
+  const rememberLibraryPages =
+    effective[REMEMBER_LIBRARY_PAGE_STATE_SETTING_KEY]?.effective_value !== "false";
+  const pending = setDeviceSetting.isPending || deleteDeviceSetting.isPending;
+
+  async function handleChange(checked: boolean) {
+    try {
+      if (checked) {
+        await deleteDeviceSetting.mutateAsync({ key: REMEMBER_LIBRARY_PAGE_STATE_SETTING_KEY });
+      } else {
+        await deleteDeviceSetting.mutateAsync({ key: LIBRARY_PAGE_STATE_SETTING_KEY });
+        await setDeviceSetting.mutateAsync({
+          key: REMEMBER_LIBRARY_PAGE_STATE_SETTING_KEY,
+          value: "false",
+        });
+      }
+      toast.success("Library page preference saved");
+    } catch {
+      toast.error("Failed to save library page preference");
+    }
+  }
+
+  return (
+    <SettingRow
+      label="Remember library pages"
+      description="Return each library to the last tab, sort, and filters used on this profile and device."
+      control={(id) => (
+        <Switch
+          id={id}
+          checked={rememberLibraryPages}
+          disabled={pending}
+          onCheckedChange={handleChange}
+        />
+      )}
+    />
+  );
 }
 
 function PlaybackField({
@@ -497,6 +552,13 @@ export default function LibrarySettings() {
           library.
         </p>
       </div>
+
+      <SettingsGroup
+        title="Browsing"
+        description="These preferences apply to this profile on the current device."
+      >
+        <RememberLibraryPageStateSetting profileId={currentProfile.id} />
+      </SettingsGroup>
 
       <div className="surface-panel-subtle flex flex-col gap-4 rounded-[1.4rem] p-4 sm:flex-row sm:items-center sm:justify-between">
         <p className="text-muted-foreground text-sm leading-relaxed">

--- a/web/src/pages/settings/PlaybackSettings.tsx
+++ b/web/src/pages/settings/PlaybackSettings.tsx
@@ -1,5 +1,3 @@
-import { useId, type ReactNode } from "react";
-
 import { getProfileToken } from "@/api/client";
 import { useAuth } from "@/hooks/useAuth";
 import { useUpdateProfile } from "@/hooks/queries/profiles";
@@ -11,8 +9,8 @@ import {
   useSetting,
 } from "@/hooks/queries/settings";
 import { SettingsGroup } from "@/components/settings/SettingsGroup";
+import { SettingRow } from "@/components/settings/SettingRow";
 import { Button } from "@/components/ui/button";
-import { Label } from "@/components/ui/label";
 import { Switch } from "@/components/ui/switch";
 import {
   Select,
@@ -25,28 +23,6 @@ import { LANGUAGE_OPTIONS } from "@/lib/settingsManifest";
 import { toast } from "sonner";
 
 const AUTO_PLAY_NEXT_KEY = "playback.auto_play_next";
-
-interface SettingRowProps {
-  label: string;
-  description: string;
-  control: (id: string) => ReactNode;
-}
-
-function SettingRow({ label, description, control }: SettingRowProps) {
-  const id = useId();
-
-  return (
-    <div className="border-border/50 grid gap-3 border-t pt-4 first:border-t-0 first:pt-0 md:grid-cols-[minmax(0,1fr)_auto] md:items-center">
-      <div className="min-w-0 space-y-1">
-        <Label htmlFor={id} className="text-sm font-medium">
-          {label}
-        </Label>
-        <p className="text-muted-foreground text-[13px] leading-relaxed">{description}</p>
-      </div>
-      <div className="flex md:justify-end">{control(id)}</div>
-    </div>
-  );
-}
 
 function AutoPlayNextSetting({ profileId }: { profileId: string }) {
   const { data: effective = {} } = useEffectiveSettings(profileId, [AUTO_PLAY_NEXT_KEY]);


### PR DESCRIPTION
## Summary

This PR improves a few rough edges in the web library/catalog experience:

- shows richer sort-specific metadata on item cards
- remembers per-library browse state on a per-device basis
- preserves the active library query when using the sidebar
- avoids showing extra skeleton rows after short catalog result pages
- refreshes stale or incomplete person metadata when a person page is viewed

## New Features

### Sort metadata on item cards

Catalog item cards now show metadata that matches the active sort field, including runtime, content rating, release date, resolution, TMDB/Rotten Tomatoes ratings, bitrate, progress, play count, and viewed date when available.

The backend now includes `sort_metrics` for catalog responses where the current sort needs data that is not already present on the base item payload.

### Remember library page state

Library pages can now remember per-library browse state, including tab, sort, order, media type, and filter query params. This is stored as a device-scoped setting so different browsers/devices can keep their own library browsing context.

A new “Remember library pages” setting was added under library settings, along with reusable settings row UI shared by the library/playback settings pages.

## Fixes

### Avoid stale skeleton rows after short result pages

Catalog windowing no longer treats empty buffered pages as loaded item ranges when totals are omitted. This prevents the UI from showing skeleton placeholders past the real end of short result sets.

### Preserve active library query from sidebar

When the current sidebar library item links back to the active library route, it now preserves the current query string instead of resetting the library view.

### Refresh stale person metadata on view

Person detail requests now enqueue a metadata refresh when a person has refreshable provider IDs and the local metadata is stale or incomplete.

## Test Coverage

Most test changes extend existing colocated tests, matching the repository’s current style:

- `ItemCard.test.tsx` covers sort-specific card metadata and episode fallback labels.
- `catalog.test.tsx` covers the short-result skeleton regression.
- `AppSidebar.test.tsx` covers preserving the active library query.
- `settings_device_test.go` covers the new device-scoped settings validation and storage behavior.
- `libraryPageSearchParams.test.ts` covers saved-state query detection, serialization, and application.
- `LibrarySettings.test.tsx` keeps the settings page smoke coverage current.
- `libraryPageState.test.ts` is the one new test file; it covers the new preference parser/serializer/update helper because that helper owns versioning and malformed-input fallback behavior.

## Validation

Pending before merge:

- `go test ./internal/api/handlers ./internal/scanner/...`
- `cd web && pnpm test -- --run`
- `cd web && pnpm run lint`
- `cd web && pnpm run format:check`
- `make verify-local-paths`

## Risks / Follow-ups

- Person metadata refresh is queued opportunistically on view; if refresh volume becomes noisy, this may need tighter throttling or repo-level freshness checks.
- Library page state is intentionally device-scoped, so users should expect different saved views across browsers/devices.
- Client-visible catalog response types gained optional `sort_metrics`; native clients may choose to ignore it or adopt it later.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Item cards show richer sort metrics (resolution, runtime, bitrate, ratings, progress/plays, viewed date).
  * Library pages persist per-device search/tab/sort and can restore them automatically.
  * New "Remember library pages" preference to control per-device persistence.
  * Person pages auto-refresh metadata when details are incomplete.

* **Bug Fixes**
  * Fixed catalog pagination to ignore empty buffered pages.
  * Improved sidebar active-library detection and library-link query preservation.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Silo-Server/silo-server/pull/26?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->