### PR TITLE
[codex] fix ASS subtitle font loading

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -48,7 +48,7 @@ RUN apt-get update && \
     echo "deb [signed-by=/usr/share/keyrings/jellyfin.gpg arch=${TARGETARCH}] https://repo.jellyfin.org/debian bookworm main" \
       > /etc/apt/sources.list.d/jellyfin.list && \
     apt-get update && \
-    apt-get install -y --no-install-recommends jellyfin-ffmpeg7 libvips42 && \
+    apt-get install -y --no-install-recommends jellyfin-ffmpeg7 libvips42 fonts-noto-core fonts-noto-cjk && \
     apt-get purge -y gnupg && apt-get autoremove -y && \
     rm -rf /var/lib/apt/lists/*
 RUN mkdir -p /tmp/silo-transcode

--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -53,7 +53,7 @@ RUN apt-get update && \
     echo "deb [signed-by=/usr/share/keyrings/jellyfin.gpg arch=${TARGETARCH}] https://repo.jellyfin.org/debian bookworm main" \
       > /etc/apt/sources.list.d/jellyfin.list && \
     apt-get update && \
-    apt-get install -y --no-install-recommends jellyfin-ffmpeg7 libvips42 && \
+    apt-get install -y --no-install-recommends jellyfin-ffmpeg7 libvips42 fonts-noto-core fonts-noto-cjk && \
     apt-get purge -y gnupg && apt-get autoremove -y && \
     rm -rf /var/lib/apt/lists/*
 RUN mkdir -p /tmp/silo-transcode

--- a/internal/api/handlers/playback.go
+++ b/internal/api/handlers/playback.go
@@ -305,6 +305,7 @@ type subtitleURL struct {
 	Forced          bool   `json:"forced"`
 	HearingImpaired bool   `json:"hearing_impaired"`
 	URL             string `json:"url"`
+	FontBundleURL   string `json:"font_bundle_url,omitempty"`
 }
 
 // changeAudioRequest represents the JSON body for PATCH /playback/{session_id}/audio.
@@ -1459,6 +1460,7 @@ func buildSubtitleURLs(sessionID string, file *models.MediaFile, downloaded []su
 			Forced:          track.Forced,
 			HearingImpaired: track.HearingImpaired,
 			URL:             fmt.Sprintf("/stream/%s/subtitles/%d%s", sessionID, embeddedOffset+i, subtitleURLExt(track.Codec)),
+			FontBundleURL:   subtitleFontBundleURL(sessionID, embeddedOffset+i, track.Codec),
 		})
 	}
 
@@ -1476,6 +1478,13 @@ func buildSubtitleURLs(sessionID string, file *models.MediaFile, downloaded []su
 	}
 
 	return urls
+}
+
+func subtitleFontBundleURL(sessionID string, trackIndex int, codec string) string {
+	if !playback.IsASS(codec) {
+		return ""
+	}
+	return fmt.Sprintf("/stream/%s/subtitles/%d/fonts", sessionID, trackIndex)
 }
 
 func firstNonEmptyString(values ...string) string {

--- a/internal/api/handlers/playback.go
+++ b/internal/api/handlers/playback.go
@@ -1404,7 +1404,11 @@ func (h *PlaybackHandler) HandleStartPlayback(w http.ResponseWriter, r *http.Req
 					if resp.SubtitleURLs[i].Source == "embedded" {
 						// Pass the ffmpeg-relative subtitle stream index to the proxy.
 						embeddedIdx := resp.SubtitleURLs[i].Index - embeddedOffset
-						resp.SubtitleURLs[i].URL = proxyNode.URL + "/stream/subtitles/" + token + "/" + strconv.Itoa(embeddedIdx) + subtitleURLExt(resp.SubtitleURLs[i].Codec)
+						proxySubtitleURL := proxyNode.URL + "/stream/subtitles/" + token + "/" + strconv.Itoa(embeddedIdx)
+						resp.SubtitleURLs[i].URL = proxySubtitleURL + subtitleURLExt(resp.SubtitleURLs[i].Codec)
+						if resp.SubtitleURLs[i].FontBundleURL != "" {
+							resp.SubtitleURLs[i].FontBundleURL = proxySubtitleURL + "/fonts"
+						}
 					}
 				}
 			}

--- a/internal/api/handlers/stream.go
+++ b/internal/api/handlers/stream.go
@@ -2,7 +2,6 @@ package handlers
 
 import (
 	"context"
-	"encoding/base64"
 	"encoding/json"
 	"errors"
 	"log/slog"
@@ -18,11 +17,6 @@ import (
 	"github.com/Silo-Server/silo-server/internal/playback"
 	"github.com/Silo-Server/silo-server/internal/subtitles"
 )
-
-type subtitleFontResponse struct {
-	Name string `json:"name"`
-	Data string `json:"data"`
-}
 
 // FilePathResolver looks up a media file by its ID.
 type FilePathResolver interface {
@@ -334,17 +328,10 @@ func (h *StreamHandler) HandleSubtitleFonts(w http.ResponseWriter, r *http.Reque
 		return
 	}
 
-	resp := make([]subtitleFontResponse, 0, len(fonts))
-	for _, font := range fonts {
-		resp = append(resp, subtitleFontResponse{
-			Name: font.Name,
-			Data: base64.StdEncoding.EncodeToString(font.Data),
-		})
-	}
-
 	w.Header().Set("Content-Type", "application/json")
+	w.Header().Set("Access-Control-Allow-Origin", "*")
 	w.Header().Set("Cache-Control", "no-store")
-	if err := json.NewEncoder(w).Encode(resp); err != nil {
+	if err := json.NewEncoder(w).Encode(playback.EncodeSubtitleFontBundle(fonts)); err != nil {
 		slog.WarnContext(r.Context(), "subtitle font response encode failed", "error", err)
 	}
 }

--- a/internal/api/handlers/stream.go
+++ b/internal/api/handlers/stream.go
@@ -2,6 +2,8 @@ package handlers
 
 import (
 	"context"
+	"encoding/base64"
+	"encoding/json"
 	"errors"
 	"log/slog"
 	"net/http"
@@ -16,6 +18,11 @@ import (
 	"github.com/Silo-Server/silo-server/internal/playback"
 	"github.com/Silo-Server/silo-server/internal/subtitles"
 )
+
+type subtitleFontResponse struct {
+	Name string `json:"name"`
+	Data string `json:"data"`
+}
 
 // FilePathResolver looks up a media file by its ID.
 type FilePathResolver interface {
@@ -260,6 +267,86 @@ func (h *StreamHandler) HandleSubtitle(w http.ResponseWriter, r *http.Request) {
 	}
 
 	writeError(w, http.StatusNotFound, "not_found", "Subtitle track not found")
+}
+
+// HandleSubtitleFonts extracts embedded container font attachments for ASS/SSA
+// playback. The web player loads these bytes into JASSUB before creating the
+// renderer so libass can resolve script font names deterministically.
+func (h *StreamHandler) HandleSubtitleFonts(w http.ResponseWriter, r *http.Request) {
+	userID := apimw.GetUserID(r.Context())
+	if userID == 0 {
+		writeError(w, http.StatusUnauthorized, "unauthorized", "Authentication required")
+		return
+	}
+
+	sessionID := chi.URLParam(r, "session_id")
+	if sessionID == "" {
+		writeError(w, http.StatusBadRequest, "bad_request", "Session ID is required")
+		return
+	}
+	setPlaybackSessionLogContext(r, sessionID)
+
+	session, err := h.sessionMgr.GetSession(sessionID)
+	if err != nil {
+		writePlaybackSessionNotFound(w)
+		return
+	}
+	if session.UserID != userID {
+		writeError(w, http.StatusForbidden, "forbidden", "Session belongs to another user")
+		return
+	}
+
+	file, err := h.fileResolver.GetByID(r.Context(), session.MediaFileID)
+	if err != nil {
+		writeError(w, http.StatusNotFound, "not_found", "Media file not found")
+		return
+	}
+	if file == nil {
+		writeError(w, http.StatusNotFound, "not_found", "Media file not found")
+		return
+	}
+
+	trackParam := chi.URLParam(r, "track")
+	trackIndex, _, err := playback.ParseSubtitleTrackParam(trackParam)
+	if err != nil {
+		writeError(w, http.StatusBadRequest, "bad_request", "Invalid subtitle track index")
+		return
+	}
+
+	embeddedIndex := trackIndex - len(file.ExternalSubtitles)
+	if embeddedIndex < 0 || embeddedIndex >= len(file.SubtitleTracks) {
+		writeError(w, http.StatusNotFound, "not_found", "Embedded subtitle track not found")
+		return
+	}
+	if !playback.IsASS(file.SubtitleTracks[embeddedIndex].Codec) {
+		writeError(w, http.StatusBadRequest, "bad_request", "Subtitle font bundles are only available for ASS/SSA tracks")
+		return
+	}
+
+	fonts, err := playback.ExtractAttachedSubtitleFonts(r.Context(), file.FilePath, h.FFmpegPath)
+	if err != nil {
+		slog.WarnContext(r.Context(), "subtitle font extraction failed",
+			"file_id", file.ID,
+			"track", trackIndex,
+			"error", err,
+		)
+		writeError(w, http.StatusInternalServerError, "font_extract_failed", "Failed to extract subtitle fonts")
+		return
+	}
+
+	resp := make([]subtitleFontResponse, 0, len(fonts))
+	for _, font := range fonts {
+		resp = append(resp, subtitleFontResponse{
+			Name: font.Name,
+			Data: base64.StdEncoding.EncodeToString(font.Data),
+		})
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	w.Header().Set("Cache-Control", "no-store")
+	if err := json.NewEncoder(w).Encode(resp); err != nil {
+		slog.WarnContext(r.Context(), "subtitle font response encode failed", "error", err)
+	}
 }
 
 func (h *StreamHandler) syncSessionsNow(ctx context.Context, reason string) {

--- a/internal/api/handlers/stream.go
+++ b/internal/api/handlers/stream.go
@@ -299,6 +299,13 @@ func (h *StreamHandler) HandleSubtitleFonts(w http.ResponseWriter, r *http.Reque
 		writeError(w, http.StatusNotFound, "not_found", "Media file not found")
 		return
 	}
+	if err := preflightPlaybackFile(r.Context(), file, h.MissingMarker, h.EventsHub); err != nil {
+		if isPlaybackFileMissing(err) {
+			h.abortPlaybackSession(r.Context(), session)
+		}
+		writePlaybackFilePreflightError(w, err)
+		return
+	}
 
 	trackParam := chi.URLParam(r, "track")
 	trackIndex, _, err := playback.ParseSubtitleTrackParam(trackParam)

--- a/internal/api/router.go
+++ b/internal/api/router.go
@@ -1672,6 +1672,7 @@ func NewRouter(deps Dependencies) chi.Router {
 					r.Get("/stream/{session_id}", streamHandler.HandleStream)
 					r.Head("/stream/{session_id}", streamHandler.HandleStream)
 					r.Get("/stream/{session_id}/subtitles/{track}", streamHandler.HandleSubtitle)
+					r.Get("/stream/{session_id}/subtitles/{track}/fonts", streamHandler.HandleSubtitleFonts)
 				}
 
 				// Download routes.

--- a/internal/playback/subtitle_fonts.go
+++ b/internal/playback/subtitle_fonts.go
@@ -1,0 +1,207 @@
+package playback
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+)
+
+const (
+	maxSubtitleFontAttachments = 32
+	maxSubtitleFontBytes       = 32 << 20 // 32 MiB
+)
+
+// SubtitleFontAttachment is a font attached to a media container for ASS/SSA
+// subtitle rendering.
+type SubtitleFontAttachment struct {
+	Name string
+	Data []byte
+}
+
+type attachmentProbeOutput struct {
+	Streams []attachmentProbeStream `json:"streams"`
+}
+
+type attachmentProbeStream struct {
+	Index     int               `json:"index"`
+	CodecName string            `json:"codec_name"`
+	CodecType string            `json:"codec_type"`
+	Tags      map[string]string `json:"tags"`
+}
+
+// ExtractAttachedSubtitleFonts extracts font attachments from a media file.
+// Matroska ASS releases commonly include the exact fonts needed by the script;
+// loading them into JASSUB is the closest browser equivalent to libass on a
+// native player.
+func ExtractAttachedSubtitleFonts(ctx context.Context, inputPath string, ffmpegPath string) ([]SubtitleFontAttachment, error) {
+	if strings.TrimSpace(inputPath) == "" {
+		return nil, fmt.Errorf("subtitle fonts: input path is required")
+	}
+
+	streams, err := probeFontAttachmentStreams(ctx, inputPath, ffprobePathFromFFmpeg(ffmpegPath))
+	if err != nil {
+		return nil, err
+	}
+	if len(streams) == 0 {
+		return nil, nil
+	}
+	if len(streams) > maxSubtitleFontAttachments {
+		streams = streams[:maxSubtitleFontAttachments]
+	}
+
+	tmpDir, err := os.MkdirTemp("", "silo-subtitle-fonts-*")
+	if err != nil {
+		return nil, fmt.Errorf("subtitle fonts: create temp dir: %w", err)
+	}
+	defer os.RemoveAll(tmpDir)
+
+	args := []string{"-hide_banner", "-nostats", "-loglevel", "error"}
+	outputNames := make([]string, 0, len(streams))
+	for i, stream := range streams {
+		name := fmt.Sprintf("attachment-%d%s", i, fontAttachmentExt(stream))
+		outputNames = append(outputNames, name)
+		args = append(args, fmt.Sprintf("-dump_attachment:%d", stream.Index), name)
+	}
+	args = append(args, "-i", inputPath, "-map", "0:t?", "-c", "copy", "-f", "null", "-")
+
+	bin := ffmpegPath
+	if strings.TrimSpace(bin) == "" {
+		bin = "ffmpeg"
+	}
+	cmd := exec.CommandContext(ctx, bin, args...)
+	cmd.Dir = tmpDir
+	stderr, err := cmd.CombinedOutput()
+	if err != nil {
+		return nil, fmt.Errorf("subtitle fonts: extract attachments: %w (stderr: %s)", err, truncateStderr(string(stderr)))
+	}
+
+	var total int64
+	fonts := make([]SubtitleFontAttachment, 0, len(streams))
+	for i, name := range outputNames {
+		path := filepath.Join(tmpDir, name)
+		info, err := os.Stat(path)
+		if err != nil {
+			return nil, fmt.Errorf("subtitle fonts: read extracted attachment %q: %w", name, err)
+		}
+		total += info.Size()
+		if total > maxSubtitleFontBytes {
+			return nil, fmt.Errorf("subtitle fonts: attached font data exceeds %d bytes", maxSubtitleFontBytes)
+		}
+
+		data, err := os.ReadFile(path)
+		if err != nil {
+			return nil, fmt.Errorf("subtitle fonts: read extracted attachment %q: %w", name, err)
+		}
+		fonts = append(fonts, SubtitleFontAttachment{
+			Name: safeAttachmentDisplayName(streams[i], name),
+			Data: data,
+		})
+	}
+
+	return fonts, nil
+}
+
+func probeFontAttachmentStreams(ctx context.Context, inputPath string, ffprobePath string) ([]attachmentProbeStream, error) {
+	bin := ffprobePath
+	if strings.TrimSpace(bin) == "" {
+		bin = "ffprobe"
+	}
+	cmd := exec.CommandContext(ctx, bin,
+		"-v", "error",
+		"-select_streams", "t",
+		"-show_entries", "stream=index,codec_name,codec_type:stream_tags=filename,mimetype",
+		"-of", "json",
+		inputPath,
+	)
+	out, err := cmd.Output()
+	if err != nil {
+		return nil, fmt.Errorf("subtitle fonts: probe attachments: %w", err)
+	}
+
+	var probed attachmentProbeOutput
+	if err := json.Unmarshal(out, &probed); err != nil {
+		return nil, fmt.Errorf("subtitle fonts: parse attachment probe: %w", err)
+	}
+
+	streams := make([]attachmentProbeStream, 0, len(probed.Streams))
+	for _, stream := range probed.Streams {
+		if isFontAttachment(stream) {
+			streams = append(streams, stream)
+		}
+	}
+	return streams, nil
+}
+
+func isFontAttachment(stream attachmentProbeStream) bool {
+	if strings.ToLower(stream.CodecType) != "attachment" {
+		return false
+	}
+	codec := strings.ToLower(stream.CodecName)
+	switch codec {
+	case "ttf", "otf", "ttc", "otc", "woff", "woff2":
+		return true
+	}
+	filename := strings.ToLower(stream.Tags["filename"])
+	switch filepath.Ext(filename) {
+	case ".ttf", ".otf", ".ttc", ".otc", ".woff", ".woff2":
+		return true
+	}
+	mimetype := strings.ToLower(stream.Tags["mimetype"])
+	return strings.Contains(mimetype, "font") ||
+		strings.Contains(mimetype, "truetype") ||
+		strings.Contains(mimetype, "opentype") ||
+		strings.Contains(mimetype, "woff")
+}
+
+func fontAttachmentExt(stream attachmentProbeStream) string {
+	if ext := strings.ToLower(filepath.Ext(stream.Tags["filename"])); isSupportedFontExt(ext) {
+		return ext
+	}
+	switch strings.ToLower(stream.CodecName) {
+	case "ttf":
+		return ".ttf"
+	case "otf":
+		return ".otf"
+	case "ttc":
+		return ".ttc"
+	case "otc":
+		return ".otc"
+	case "woff":
+		return ".woff"
+	case "woff2":
+		return ".woff2"
+	default:
+		return ".font"
+	}
+}
+
+func isSupportedFontExt(ext string) bool {
+	switch ext {
+	case ".ttf", ".otf", ".ttc", ".otc", ".woff", ".woff2":
+		return true
+	default:
+		return false
+	}
+}
+
+func safeAttachmentDisplayName(stream attachmentProbeStream, fallback string) string {
+	name := filepath.Base(stream.Tags["filename"])
+	if name == "." || name == string(filepath.Separator) || strings.TrimSpace(name) == "" {
+		return fallback
+	}
+	return name
+}
+
+func ffprobePathFromFFmpeg(ffmpegPath string) string {
+	if strings.TrimSpace(ffmpegPath) == "" {
+		return "ffprobe"
+	}
+	if i := strings.LastIndex(ffmpegPath, "ffmpeg"); i >= 0 {
+		return ffmpegPath[:i] + "ffprobe" + ffmpegPath[i+len("ffmpeg"):]
+	}
+	return "ffprobe"
+}

--- a/internal/playback/subtitle_fonts.go
+++ b/internal/playback/subtitle_fonts.go
@@ -1,10 +1,12 @@
 package playback
 
 import (
+	"bytes"
 	"context"
+	"encoding/base64"
 	"encoding/json"
 	"fmt"
-	"os"
+	"io"
 	"os/exec"
 	"path/filepath"
 	"strings"
@@ -20,6 +22,12 @@ const (
 type SubtitleFontAttachment struct {
 	Name string
 	Data []byte
+}
+
+// SubtitleFontBundleItem is the JSON-safe representation sent to web players.
+type SubtitleFontBundleItem struct {
+	Name string `json:"name"`
+	Data string `json:"data"`
 }
 
 type attachmentProbeOutput struct {
@@ -53,56 +61,98 @@ func ExtractAttachedSubtitleFonts(ctx context.Context, inputPath string, ffmpegP
 		streams = streams[:maxSubtitleFontAttachments]
 	}
 
-	tmpDir, err := os.MkdirTemp("", "silo-subtitle-fonts-*")
-	if err != nil {
-		return nil, fmt.Errorf("subtitle fonts: create temp dir: %w", err)
-	}
-	defer os.RemoveAll(tmpDir)
-
-	args := []string{"-hide_banner", "-nostats", "-loglevel", "error"}
-	outputNames := make([]string, 0, len(streams))
-	for i, stream := range streams {
-		name := fmt.Sprintf("attachment-%d%s", i, fontAttachmentExt(stream))
-		outputNames = append(outputNames, name)
-		args = append(args, fmt.Sprintf("-dump_attachment:%d", stream.Index), name)
-	}
-	args = append(args, "-i", inputPath, "-map", "0:t?", "-c", "copy", "-f", "null", "-")
-
 	bin := ffmpegPath
 	if strings.TrimSpace(bin) == "" {
 		bin = "ffmpeg"
 	}
-	cmd := exec.CommandContext(ctx, bin, args...)
-	cmd.Dir = tmpDir
-	stderr, err := cmd.CombinedOutput()
-	if err != nil {
-		return nil, fmt.Errorf("subtitle fonts: extract attachments: %w (stderr: %s)", err, truncateStderr(string(stderr)))
-	}
 
 	var total int64
 	fonts := make([]SubtitleFontAttachment, 0, len(streams))
-	for i, name := range outputNames {
-		path := filepath.Join(tmpDir, name)
-		info, err := os.Stat(path)
+	for i, stream := range streams {
+		fallbackName := fmt.Sprintf("attachment-%d%s", i, fontAttachmentExt(stream))
+		remaining := maxSubtitleFontBytes - total
+		data, err := extractFontAttachment(ctx, inputPath, bin, stream, fallbackName, remaining)
 		if err != nil {
-			return nil, fmt.Errorf("subtitle fonts: read extracted attachment %q: %w", name, err)
+			return nil, err
 		}
-		total += info.Size()
+		total += int64(len(data))
 		if total > maxSubtitleFontBytes {
 			return nil, fmt.Errorf("subtitle fonts: attached font data exceeds %d bytes", maxSubtitleFontBytes)
 		}
-
-		data, err := os.ReadFile(path)
-		if err != nil {
-			return nil, fmt.Errorf("subtitle fonts: read extracted attachment %q: %w", name, err)
-		}
 		fonts = append(fonts, SubtitleFontAttachment{
-			Name: safeAttachmentDisplayName(streams[i], name),
+			Name: safeAttachmentDisplayName(stream, fallbackName),
 			Data: data,
 		})
 	}
 
 	return fonts, nil
+}
+
+// EncodeSubtitleFontBundle converts raw font attachments to base64 JSON items.
+func EncodeSubtitleFontBundle(fonts []SubtitleFontAttachment) []SubtitleFontBundleItem {
+	items := make([]SubtitleFontBundleItem, 0, len(fonts))
+	for _, font := range fonts {
+		items = append(items, SubtitleFontBundleItem{
+			Name: font.Name,
+			Data: base64.StdEncoding.EncodeToString(font.Data),
+		})
+	}
+	return items
+}
+
+func extractFontAttachment(ctx context.Context, inputPath string, ffmpegPath string, stream attachmentProbeStream, name string, maxBytes int64) ([]byte, error) {
+	if maxBytes <= 0 {
+		return nil, fmt.Errorf("subtitle fonts: attached font data exceeds %d bytes", maxSubtitleFontBytes)
+	}
+
+	cmdCtx, cancel := context.WithCancel(ctx)
+	defer cancel()
+
+	args := []string{
+		"-hide_banner", "-nostats", "-loglevel", "error",
+		fmt.Sprintf("-dump_attachment:%d", stream.Index), "pipe:1",
+		"-i", inputPath,
+		"-map", "0:t?",
+		"-c", "copy",
+		"-f", "null", "-",
+	}
+	cmd := exec.CommandContext(cmdCtx, ffmpegPath, args...)
+	stdout, err := cmd.StdoutPipe()
+	if err != nil {
+		return nil, fmt.Errorf("subtitle fonts: open attachment pipe %q: %w", name, err)
+	}
+	var stderr strings.Builder
+	cmd.Stderr = &stderr
+
+	if err := cmd.Start(); err != nil {
+		return nil, fmt.Errorf("subtitle fonts: start attachment extract %q: %w", name, err)
+	}
+
+	var buf bytes.Buffer
+	_, copyErr := io.Copy(&buf, &io.LimitedReader{R: stdout, N: maxBytes + 1})
+	tooLarge := int64(buf.Len()) > maxBytes
+	if tooLarge {
+		cancel()
+		if cmd.Process != nil {
+			_ = cmd.Process.Kill()
+		}
+	}
+
+	waitErr := cmd.Wait()
+	if tooLarge {
+		return nil, fmt.Errorf("subtitle fonts: attached font data exceeds %d bytes", maxSubtitleFontBytes)
+	}
+	if copyErr != nil {
+		return nil, fmt.Errorf("subtitle fonts: read attachment %q: %w", name, copyErr)
+	}
+	if waitErr != nil {
+		if ctx.Err() != nil {
+			return nil, ctx.Err()
+		}
+		return nil, fmt.Errorf("subtitle fonts: extract attachment %q: %w (stderr: %s)",
+			name, waitErr, truncateStderr(stderr.String()))
+	}
+	return buf.Bytes(), nil
 }
 
 func probeFontAttachmentStreams(ctx context.Context, inputPath string, ffprobePath string) ([]attachmentProbeStream, error) {

--- a/internal/playback/subtitle_fonts.go
+++ b/internal/playback/subtitle_fonts.go
@@ -247,11 +247,13 @@ func safeAttachmentDisplayName(stream attachmentProbeStream, fallback string) st
 }
 
 func ffprobePathFromFFmpeg(ffmpegPath string) string {
-	if strings.TrimSpace(ffmpegPath) == "" {
+	ffmpegPath = strings.TrimSpace(ffmpegPath)
+	if ffmpegPath == "" {
 		return "ffprobe"
 	}
-	if i := strings.LastIndex(ffmpegPath, "ffmpeg"); i >= 0 {
-		return ffmpegPath[:i] + "ffprobe" + ffmpegPath[i+len("ffmpeg"):]
+	base := filepath.Base(ffmpegPath)
+	if i := strings.LastIndex(base, "ffmpeg"); i >= 0 {
+		return filepath.Join(filepath.Dir(ffmpegPath), base[:i]+"ffprobe"+base[i+len("ffmpeg"):])
 	}
 	return "ffprobe"
 }

--- a/internal/playback/subtitle_fonts_test.go
+++ b/internal/playback/subtitle_fonts_test.go
@@ -67,6 +67,19 @@ printf '12345'
 	}
 }
 
+func TestFFprobePathFromFFmpegRewritesOnlyBasename(t *testing.T) {
+	got := ffprobePathFromFFmpeg(filepath.Join("tmp", "ffmpeg-tools", "ffmpeg"))
+	want := filepath.Join("tmp", "ffmpeg-tools", "ffprobe")
+	if got != want {
+		t.Fatalf("ffprobePathFromFFmpeg basename path = %q, want %q", got, want)
+	}
+
+	got = ffprobePathFromFFmpeg(filepath.Join("tmp", "ffmpeg-tools", "custom"))
+	if got != "ffprobe" {
+		t.Fatalf("ffprobePathFromFFmpeg custom basename = %q, want ffprobe", got)
+	}
+}
+
 func writeExecutable(t *testing.T, path string, content string) {
 	t.Helper()
 	if err := os.WriteFile(path, []byte(content), 0o755); err != nil {

--- a/internal/playback/subtitle_fonts_test.go
+++ b/internal/playback/subtitle_fonts_test.go
@@ -1,0 +1,75 @@
+package playback
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+)
+
+func TestExtractAttachedSubtitleFontsUsesBoundedStdoutExtraction(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("shell script test helper is unix-only")
+	}
+
+	dir := t.TempDir()
+	ffmpegPath := filepath.Join(dir, "ffmpeg")
+	writeExecutable(t, filepath.Join(dir, "ffprobe"), `#!/bin/sh
+cat <<'JSON'
+{"streams":[{"index":2,"codec_name":"ttf","codec_type":"attachment","tags":{"filename":"MyFont.ttf","mimetype":"font/ttf"}}]}
+JSON
+`)
+	writeExecutable(t, ffmpegPath, `#!/bin/sh
+printf 'fontdata'
+`)
+
+	fonts, err := ExtractAttachedSubtitleFonts(context.Background(), "input.mkv", ffmpegPath)
+	if err != nil {
+		t.Fatalf("ExtractAttachedSubtitleFonts returned error: %v", err)
+	}
+	if len(fonts) != 1 {
+		t.Fatalf("font count = %d, want 1", len(fonts))
+	}
+	if fonts[0].Name != "MyFont.ttf" {
+		t.Fatalf("font name = %q, want MyFont.ttf", fonts[0].Name)
+	}
+	if string(fonts[0].Data) != "fontdata" {
+		t.Fatalf("font data = %q, want fontdata", string(fonts[0].Data))
+	}
+}
+
+func TestExtractFontAttachmentRejectsOverLimitData(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("shell script test helper is unix-only")
+	}
+
+	dir := t.TempDir()
+	ffmpegPath := filepath.Join(dir, "ffmpeg")
+	writeExecutable(t, ffmpegPath, `#!/bin/sh
+printf '12345'
+`)
+
+	_, err := extractFontAttachment(
+		context.Background(),
+		"input.mkv",
+		ffmpegPath,
+		attachmentProbeStream{Index: 2},
+		"font.ttf",
+		4,
+	)
+	if err == nil {
+		t.Fatal("expected size limit error, got nil")
+	}
+	if !strings.Contains(err.Error(), "attached font data exceeds") {
+		t.Fatalf("error = %q, want attached font data limit", err.Error())
+	}
+}
+
+func writeExecutable(t *testing.T, path string, content string) {
+	t.Helper()
+	if err := os.WriteFile(path, []byte(content), 0o755); err != nil {
+		t.Fatalf("write %s: %v", path, err)
+	}
+}

--- a/internal/proxy/server.go
+++ b/internal/proxy/server.go
@@ -54,6 +54,7 @@ func (s *Server) Handler() http.Handler {
 	r.Head("/stream/transcode/{token}/master.m3u8", s.handleTranscodeManifest)
 	r.Get("/stream/transcode/{token}/master.m3u8", s.handleTranscodeManifest)
 	r.Get("/stream/transcode/{token}/segment/{name}", s.handleTranscodeSegment)
+	r.Get("/stream/subtitles/{token}/{track}/fonts", s.handleSubtitleFonts)
 	r.Get("/stream/subtitles/{token}/{track}", s.handleSubtitle)
 
 	// Admin routes — bearer-auth protected.
@@ -201,6 +202,33 @@ func (s *Server) handleSubtitle(w http.ResponseWriter, r *http.Request) {
 	}
 
 	playback.ServeSubtitle(w, vtt, "vtt")
+}
+
+func (s *Server) handleSubtitleFonts(w http.ResponseWriter, r *http.Request) {
+	claims := s.verifyToken(w, r)
+	if claims == nil {
+		return
+	}
+	cfg := s.watcher.Config()
+	trackParam := chi.URLParam(r, "track")
+	trackIndex, _, err := playback.ParseSubtitleTrackParam(trackParam)
+	if err != nil {
+		http.Error(w, "invalid subtitle index", http.StatusBadRequest)
+		return
+	}
+
+	fonts, err := playback.ExtractAttachedSubtitleFonts(r.Context(), claims.MediaPath, cfg.Playback.FFmpegPath)
+	if err != nil {
+		slog.Error("extract subtitle fonts", "error", err, "track", trackIndex, "path", claims.MediaPath, "playback_session_id", claims.SessionID)
+		http.Error(w, "subtitle font extraction failed", http.StatusInternalServerError)
+		return
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	w.Header().Set("Cache-Control", "no-store")
+	if err := json.NewEncoder(w).Encode(playback.EncodeSubtitleFontBundle(fonts)); err != nil {
+		slog.Warn("subtitle font response encode failed", "error", err, "playback_session_id", claims.SessionID)
+	}
 }
 
 // proxyToTranscodeNode forwards the request to the transcode node specified in the claims.

--- a/web/package.json
+++ b/web/package.json
@@ -19,6 +19,8 @@
     "@dnd-kit/core": "^6.3.1",
     "@dnd-kit/sortable": "^10.0.0",
     "@dnd-kit/utilities": "^3.2.2",
+    "@fontsource/noto-sans-arabic": "^5.2.10",
+    "@fontsource/noto-sans-thai": "^5.2.8",
     "@tanstack/react-query": "^5.90.21",
     "@tanstack/react-virtual": "^3.13.19",
     "class-variance-authority": "^0.7.1",

--- a/web/pnpm-lock.yaml
+++ b/web/pnpm-lock.yaml
@@ -25,6 +25,12 @@ importers:
       '@dnd-kit/utilities':
         specifier: ^3.2.2
         version: 3.2.2(react@19.2.4)
+      '@fontsource/noto-sans-arabic':
+        specifier: ^5.2.10
+        version: 5.2.10
+      '@fontsource/noto-sans-thai':
+        specifier: ^5.2.8
+        version: 5.2.8
       '@tanstack/react-query':
         specifier: ^5.90.21
         version: 5.90.21(react@19.2.4)
@@ -529,6 +535,12 @@ packages:
 
   '@floating-ui/utils@0.2.11':
     resolution: {integrity: sha512-RiB/yIh78pcIxl6lLMG0CgBXAZ2Y0eVHqMPYugu+9U0AeT6YBeiJpf7lbdJNIugFP5SIjwNRgo4DhR1Qxi26Gg==}
+
+  '@fontsource/noto-sans-arabic@5.2.10':
+    resolution: {integrity: sha512-Hgj3NwQJ0NquIADW3hFboFjsts4UvEOJQ8tOX0bhQZgpNKHsMawjv/1SZnq0QvRbP6efHTZM/A1k7tdy9S6sbA==}
+
+  '@fontsource/noto-sans-thai@5.2.8':
+    resolution: {integrity: sha512-HUQAxOzclod9PXQx4uMoGRAsor+64snW91QuBg39jT9lbsp7jJx1i3jAtHPJ7mQxHEHnhRjNp54fb8GqPPC6zg==}
 
   '@humanfs/core@0.19.1':
     resolution: {integrity: sha512-5DyQ4+1JEUzejeK1JGICcideyfUbGixgS9jNgex5nqkW+cY7WZhxBigmieN5Qnw9ZosSNVC9KQKyb+GUaGyKUA==}
@@ -3223,6 +3235,10 @@ snapshots:
       react-dom: 19.2.4(react@19.2.4)
 
   '@floating-ui/utils@0.2.11': {}
+
+  '@fontsource/noto-sans-arabic@5.2.10': {}
+
+  '@fontsource/noto-sans-thai@5.2.8': {}
 
   '@humanfs/core@0.19.1': {}
 

--- a/web/src/player/hooks/useASSSubtitles.test.tsx
+++ b/web/src/player/hooks/useASSSubtitles.test.tsx
@@ -1,0 +1,178 @@
+import type { RefObject } from "react";
+import { renderHook, waitFor } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { useASSSubtitles } from "./useASSSubtitles";
+import type { PlayerSubtitleInfo } from "../types";
+
+// Capture the options every JASSUB instance is constructed with.
+const constructorOpts: Array<Record<string, unknown>> = [];
+
+vi.mock("jassub", () => {
+  class MockJASSUB {
+    timeOffset = 0;
+    ready = Promise.resolve();
+    renderer = { setTrackByUrl: vi.fn().mockResolvedValue(undefined) };
+    constructor(opts: Record<string, unknown>) {
+      constructorOpts.push(opts);
+    }
+    resize = vi.fn().mockResolvedValue(undefined);
+    destroy = vi.fn();
+  }
+  return { default: MockJASSUB };
+});
+
+function makeVideoRef(): RefObject<HTMLVideoElement | null> {
+  return { current: document.createElement("video") };
+}
+
+const arabicTrack: PlayerSubtitleInfo = {
+  index: 5,
+  language: "ara",
+  codec: "ass",
+  label: "Arabic",
+  source: "embedded",
+  url: "/api/v1/playback/x/subtitles/5.ass",
+};
+
+const thaiTrack: PlayerSubtitleInfo = {
+  index: 7,
+  language: "",
+  codec: "ass",
+  label: "Thai",
+  source: "embedded",
+  url: "/api/v1/playback/x/subtitles/7.ass",
+};
+
+const germanTrack: PlayerSubtitleInfo = {
+  index: 6,
+  language: "ger",
+  codec: "ass",
+  label: "German",
+  source: "embedded",
+  url: "/api/v1/playback/x/subtitles/6.ass",
+};
+
+const attachedFontTrack: PlayerSubtitleInfo = {
+  ...germanTrack,
+  index: 8,
+  language: "eng",
+  url: "/api/v1/playback/x/subtitles/8.ass",
+  font_bundle_url: "/api/v1/stream/x/subtitles/8/fonts",
+};
+
+function mockFetchResponse(text: string): Response {
+  return {
+    ok: true,
+    status: 200,
+    text: vi.fn().mockResolvedValue(text),
+    arrayBuffer: vi.fn().mockResolvedValue(new ArrayBuffer(8)),
+    json: vi.fn().mockResolvedValue([]),
+  } as unknown as Response;
+}
+
+function mockFontBundleResponse(bytes: string): Response {
+  return {
+    ok: true,
+    status: 200,
+    json: vi.fn().mockResolvedValue([{ name: "Attached.ttf", data: btoa(bytes) }]),
+  } as unknown as Response;
+}
+
+beforeEach(() => {
+  constructorOpts.length = 0;
+  vi.stubGlobal("fetch", vi.fn().mockResolvedValue(mockFetchResponse("")));
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe("useASSSubtitles font fallback", () => {
+  it("uses an Arabic-capable defaultFont for an Arabic ASS track", async () => {
+    renderHook(() => useASSSubtitles(makeVideoRef(), [arabicTrack], 5, false, 0, 0));
+
+    await waitFor(() => expect(constructorOpts).toHaveLength(1));
+
+    const opts = constructorOpts[0]!;
+    // libass only renders missing glyphs with the default font, so Arabic
+    // coverage depends on defaultFont pointing at an Arabic font.
+    expect(opts.defaultFont).toBe("noto sans arabic");
+    expect(opts.fonts).toEqual(expect.arrayContaining([expect.any(Uint8Array)]));
+  });
+
+  it("uses a Thai-capable defaultFont for a Thai ASS track", async () => {
+    vi.mocked(fetch).mockResolvedValueOnce(
+      mockFetchResponse(
+        [
+          "[V4+ Styles]",
+          "Format: Name, Fontname, Fontsize",
+          "Style: Default,Trebuchet MS,48",
+          "[Events]",
+          "Dialogue: 0,0:00:01.00,0:00:02.00,Default,,0,0,0,,{\\fnTrebuchet MS}สวัสดี!",
+        ].join("\n"),
+      ),
+    );
+
+    renderHook(() => useASSSubtitles(makeVideoRef(), [thaiTrack], 7, false, 0, 0));
+
+    await waitFor(() => expect(constructorOpts).toHaveLength(1));
+
+    const opts = constructorOpts[0]!;
+    expect(opts.defaultFont).toBe("noto sans thai");
+    expect(opts.fonts).toEqual(expect.arrayContaining([expect.any(Uint8Array)]));
+    expect(opts.subContent).toContain("Style: Default,noto sans thai,48");
+    expect(opts.subContent).toContain("{\\fnnoto sans thai}สวัสดี!");
+    expect(opts.subContent).not.toContain("Trebuchet MS");
+  });
+
+  it("keeps JASSUB's built-in default for a Latin (German) ASS track", async () => {
+    renderHook(() => useASSSubtitles(makeVideoRef(), [germanTrack], 6, false, 0, 0));
+
+    await waitFor(() => expect(constructorOpts).toHaveLength(1));
+
+    const opts = constructorOpts[0]!;
+    expect(opts.defaultFont).toBeUndefined();
+    expect(opts.fonts).toBeUndefined();
+  });
+
+  it("passes fetched ASS content into JASSUB", async () => {
+    vi.mocked(fetch).mockResolvedValueOnce(
+      mockFetchResponse("[Events]\nDialogue: 0,0:00:01.00,0:00:02.00,Default,,0,0,0,,Hello"),
+    );
+
+    renderHook(() => useASSSubtitles(makeVideoRef(), [germanTrack], 6, false, 0, 0));
+
+    await waitFor(() => expect(constructorOpts).toHaveLength(1));
+
+    expect(constructorOpts[0]!.subContent).toContain("Dialogue:");
+    expect(constructorOpts[0]!.subUrl).toBeUndefined();
+  });
+
+  it("preloads embedded ASS font bundle bytes when the track advertises them", async () => {
+    vi.mocked(fetch).mockImplementation((input) => {
+      const url = String(input);
+      if (url.endsWith("/fonts")) {
+        return Promise.resolve(mockFontBundleResponse("font-data"));
+      }
+      return Promise.resolve(
+        mockFetchResponse("[Events]\nDialogue: 0,0:00:01.00,0:00:02.00,Default,,0,0,0,,Hello"),
+      );
+    });
+
+    renderHook(() => useASSSubtitles(makeVideoRef(), [attachedFontTrack], 8, false, 0, 0));
+
+    await waitFor(() => expect(constructorOpts).toHaveLength(1));
+
+    const opts = constructorOpts[0]!;
+    expect(opts.defaultFont).toBeUndefined();
+    expect(opts.fonts).toEqual([expect.any(Uint8Array)]);
+  });
+
+  it("disables local font probing to avoid permission-related console noise", async () => {
+    renderHook(() => useASSSubtitles(makeVideoRef(), [arabicTrack], 5, false, 0, 0));
+
+    await waitFor(() => expect(constructorOpts).toHaveLength(1));
+
+    expect(constructorOpts[0]!.queryFonts).toBe(false);
+  });
+});

--- a/web/src/player/hooks/useASSSubtitles.ts
+++ b/web/src/player/hooks/useASSSubtitles.ts
@@ -2,6 +2,12 @@ import { useEffect, useRef } from "react";
 import type JASSUB from "jassub";
 import type { PlayerSubtitleInfo } from "../types";
 import { isASSCodec } from "../utils/assSubtitles";
+import {
+  fallbackFontForSubtitle,
+  forceASSFontFamily,
+  loadSubtitleFontBundle,
+  loadSubtitleFallbackFontData,
+} from "../utils/subtitleFonts";
 
 /**
  * Manages client-side ASS/SSA subtitle rendering via JASSUB (libass WASM).
@@ -40,6 +46,8 @@ export function useASSSubtitles(
 
   const isASS = activeSub !== null && isASSCodec(activeSub.codec);
   const activeUrl = isASS ? activeSub.url : null;
+  const activeLanguage = isASS ? activeSub.language : "";
+  const activeFontBundleUrl = isASS ? activeSub.font_bundle_url : undefined;
 
   // Main effect: create/destroy JASSUB based on active track.
   useEffect(() => {
@@ -56,6 +64,7 @@ export function useASSSubtitles(
     }
 
     let cancelled = false;
+    const controller = new AbortController();
 
     async function initJASSUB() {
       if (!video || cancelled) return;
@@ -68,25 +77,81 @@ export function useASSSubtitles(
       const JASSUBClass = await jassubImportRef.current;
       if (cancelled) return;
 
-      // If an existing instance is already attached, reuse it by switching
-      // the track URL. Snapshot to a local variable to avoid null deref if
-      // the ref is cleared between awaits.
-      const existing = jassubRef.current;
-      if (existing) {
-        existing.timeOffset = streamOriginRef.current;
-        await existing.ready;
-        if (!cancelled) {
-          await existing.renderer.setTrackByUrl(activeUrl!);
+      let subContent: string;
+      let attachedFontData: Uint8Array[] = [];
+      try {
+        const [response, loadedAttachedFontData] = await Promise.all([
+          fetch(activeUrl!, { signal: controller.signal }),
+          activeFontBundleUrl
+            ? loadSubtitleFontBundle(activeFontBundleUrl, controller.signal).catch((err) => {
+                if ((err as Error).name !== "AbortError") {
+                  console.error(
+                    `[useASSSubtitles] Failed to load subtitle font bundle ${activeFontBundleUrl}:`,
+                    err,
+                  );
+                }
+                return [];
+              })
+            : Promise.resolve([]),
+        ]);
+        if (!response.ok) {
+          throw new Error(`HTTP ${response.status}`);
+        }
+        subContent = await response.text();
+        attachedFontData = loadedAttachedFontData;
+      } catch (err) {
+        if (!cancelled && (err as Error).name !== "AbortError") {
+          console.error(`[useASSSubtitles] Failed to fetch ${activeUrl}:`, err);
         }
         return;
       }
 
       if (cancelled) return;
 
+      // libass renders missing glyphs with its *default* font — it does not
+      // search other loaded fonts for coverage. JASSUB's built-in default
+      // (Liberation Sans) lacks many non-Latin glyphs, so for those scripts we
+      // point `defaultFont` at a font that covers them, chosen by track metadata
+      // first and subtitle text as a fallback. Each track switch destroys and
+      // rebuilds the instance, so this stays in sync per track.
+      const fallbackFont = fallbackFontForSubtitle(activeLanguage, subContent);
+
+      let fallbackFontData: Uint8Array[] | null = null;
+      if (fallbackFont) {
+        try {
+          fallbackFontData = await loadSubtitleFallbackFontData(fallbackFont);
+        } catch (err) {
+          if (!cancelled) {
+            console.error(
+              `[useASSSubtitles] Failed to load fallback font ${fallbackFont.family}:`,
+              err,
+            );
+          }
+        }
+      }
+
+      if (cancelled) return;
+
+      const renderedSubContent =
+        fallbackFont && fallbackFontData
+          ? forceASSFontFamily(subContent, fallbackFont.family)
+          : subContent;
+      const fonts = [...attachedFontData, ...(fallbackFontData ?? [])];
+
       const instance = new JASSUBClass({
         video,
-        subUrl: activeUrl!,
+        subContent: renderedSubContent,
         timeOffset: streamOriginRef.current,
+        // The browser Local Font Access API is inconsistent and permissioned.
+        // Letting JASSUB probe it produces noisy console warnings for common ASS
+        // style fonts without making playback reliable across clients.
+        queryFonts: false,
+        ...(fonts.length > 0
+          ? {
+              fonts,
+              ...(fallbackFont && { defaultFont: fallbackFont.family }),
+            }
+          : {}),
       });
 
       // Guard against the effect being cleaned up while the constructor ran.
@@ -102,6 +167,7 @@ export function useASSSubtitles(
 
     return () => {
       cancelled = true;
+      controller.abort();
       // Destroy the current instance if the effect is being torn down
       // (e.g. track switch or unmount). This covers the common case where
       // initJASSUB has already completed and stored the instance.
@@ -113,7 +179,7 @@ export function useASSSubtitles(
     // videoRef is a stable ref object. streamOriginSeconds is read from
     // streamOriginRef inside the async function to always get the latest value.
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [activeUrl, isDetached]);
+  }, [activeUrl, activeLanguage, activeFontBundleUrl, isDetached]);
 
   // Update JASSUB's time offset when either the media timeline remaps or
   // the user nudges subtitle sync. Avoids destroying and recreating the

--- a/web/src/player/hooks/usePlaybackSession.ts
+++ b/web/src/player/hooks/usePlaybackSession.ts
@@ -316,6 +316,9 @@ export function usePlaybackSession(
         subtitleUrls: (session.subtitle_urls ?? []).map((s) => ({
           ...s,
           url: buildStreamUrl(config.apiBaseUrl, s.url, token, "direct", 0),
+          font_bundle_url: s.font_bundle_url
+            ? buildStreamUrl(config.apiBaseUrl, s.font_bundle_url, token, "direct", 0)
+            : undefined,
         })),
         playbackInfo: session.playback_info ?? null,
         loading: false,

--- a/web/src/player/types.ts
+++ b/web/src/player/types.ts
@@ -124,6 +124,12 @@ export interface PlayerSubtitleInfo {
   hearing_impaired?: boolean;
   url: string;
   /**
+   * Optional endpoint returning base64-encoded container font attachments for
+   * ASS/SSA rendering. Present for embedded ASS tracks when the backend can
+   * extract attachments from the source media file.
+   */
+  font_bundle_url?: string;
+  /**
    * When true, this is an in-progress AI translation whose cues arrive over the
    * realtime websocket rather than from `url`. `useSubtitleTracks` feeds it from
    * the `liveCues` source instead of fetching.

--- a/web/src/player/utils/subtitleFonts.ts
+++ b/web/src/player/utils/subtitleFonts.ts
@@ -76,7 +76,15 @@ export function fallbackFontForSubtitle(
 }
 
 const fontDataCache = new Map<string, Promise<Uint8Array[]>>();
-const fontBundleCache = new Map<string, Promise<Uint8Array[]>>();
+const MAX_FONT_BUNDLE_CACHE_ENTRIES = 4;
+const MAX_FONT_BUNDLE_CACHE_BYTES = 64 * 1024 * 1024;
+
+interface FontBundleCacheEntry {
+  promise: Promise<Uint8Array[]>;
+  bytes: number;
+}
+
+const fontBundleCache = new Map<string, FontBundleCacheEntry>();
 
 interface SubtitleFontBundleItem {
   name: string;
@@ -105,8 +113,16 @@ export function loadSubtitleFallbackFontData(font: SubtitleFallbackFont): Promis
 
 export function loadSubtitleFontBundle(url: string, signal?: AbortSignal): Promise<Uint8Array[]> {
   const cached = fontBundleCache.get(url);
-  if (cached) return cached;
+  if (cached) {
+    fontBundleCache.delete(url);
+    fontBundleCache.set(url, cached);
+    return cached.promise;
+  }
 
+  const entry: FontBundleCacheEntry = {
+    promise: Promise.resolve([]),
+    bytes: 0,
+  };
   const promise = fetch(url, { signal })
     .then(async (response) => {
       if (!response.ok) {
@@ -114,15 +130,51 @@ export function loadSubtitleFontBundle(url: string, signal?: AbortSignal): Promi
       }
       return (await response.json()) as SubtitleFontBundleItem[];
     })
-    .then((items) => items.map((item) => base64ToBytes(item.data)));
+    .then((items) => items.map((item) => base64ToBytes(item.data)))
+    .then((fonts) => {
+      entry.bytes = totalByteLength(fonts);
+      if (entry.bytes > MAX_FONT_BUNDLE_CACHE_BYTES) {
+        fontBundleCache.delete(url);
+      } else {
+        evictFontBundleCache();
+      }
+      return fonts;
+    });
 
   // Do not poison the cache with transient network errors or aborted requests.
   const cachedPromise = promise.catch((err) => {
     fontBundleCache.delete(url);
     throw err;
   });
-  fontBundleCache.set(url, cachedPromise);
+  entry.promise = cachedPromise;
+  fontBundleCache.set(url, entry);
+  evictFontBundleCache();
   return cachedPromise;
+}
+
+function totalByteLength(chunks: Uint8Array[]): number {
+  return chunks.reduce((total, chunk) => total + chunk.byteLength, 0);
+}
+
+function evictFontBundleCache(): void {
+  while (fontBundleCache.size > MAX_FONT_BUNDLE_CACHE_ENTRIES) {
+    const oldest = fontBundleCache.keys().next().value;
+    if (!oldest) return;
+    fontBundleCache.delete(oldest);
+  }
+
+  let total = 0;
+  for (const entry of fontBundleCache.values()) {
+    total += entry.bytes;
+  }
+
+  while (total > MAX_FONT_BUNDLE_CACHE_BYTES) {
+    const oldest = fontBundleCache.entries().next().value;
+    if (!oldest) return;
+    const [url, entry] = oldest;
+    fontBundleCache.delete(url);
+    total -= entry.bytes;
+  }
 }
 
 function base64ToBytes(value: string): Uint8Array {

--- a/web/src/player/utils/subtitleFonts.ts
+++ b/web/src/player/utils/subtitleFonts.ts
@@ -1,0 +1,180 @@
+import notoSansArabicUrl from "@fontsource/noto-sans-arabic/files/noto-sans-arabic-arabic-400-normal.woff?url";
+import notoSansArabicLatinExtUrl from "@fontsource/noto-sans-arabic/files/noto-sans-arabic-latin-ext-400-normal.woff?url";
+import notoSansArabicLatinUrl from "@fontsource/noto-sans-arabic/files/noto-sans-arabic-latin-400-normal.woff?url";
+import notoSansThaiLatinExtUrl from "@fontsource/noto-sans-thai/files/noto-sans-thai-latin-ext-400-normal.woff?url";
+import notoSansThaiLatinUrl from "@fontsource/noto-sans-thai/files/noto-sans-thai-latin-400-normal.woff?url";
+import notoSansThaiUrl from "@fontsource/noto-sans-thai/files/noto-sans-thai-thai-400-normal.woff?url";
+
+/**
+ * A fallback font for a writing system that JASSUB's built-in default
+ * (Liberation Sans, Latin-only) cannot render.
+ *
+ * JASSUB/libass renders missing glyphs with its `defaultFont` — the font used
+ * whenever a subtitle style's named font is absent OR lacks glyphs for the text
+ * being drawn. This libass build does NOT search other loaded fonts for glyph
+ * coverage, so merely adding a font (via `fonts`/`availableFonts`) does nothing
+ * unless a style names it; the font has to be the `defaultFont`. A single font
+ * can't cover every script, so we pick the default per track/script.
+ */
+export interface SubtitleFallbackFont {
+  /** Font family key, lower-cased to match JASSUB's case-insensitive lookup. */
+  family: string;
+  /** Font file URLs preloaded into JASSUB for this family. */
+  urls: string[];
+}
+
+const NOTO_SANS_ARABIC: SubtitleFallbackFont = {
+  family: "noto sans arabic",
+  urls: [notoSansArabicUrl, notoSansArabicLatinUrl, notoSansArabicLatinExtUrl],
+};
+
+const NOTO_SANS_THAI: SubtitleFallbackFont = {
+  family: "noto sans thai",
+  urls: [notoSansThaiUrl, notoSansThaiLatinUrl, notoSansThaiLatinExtUrl],
+};
+
+// Normalized ISO-639 language code (2- and 3-letter forms) -> fallback font
+// whose script the Latin default cannot render. Prefer per-language gating like
+// this over a single global default, especially for large CJK fonts.
+const FALLBACK_BY_LANGUAGE: Record<string, SubtitleFallbackFont> = {
+  ar: NOTO_SANS_ARABIC,
+  ara: NOTO_SANS_ARABIC,
+  th: NOTO_SANS_THAI,
+  tha: NOTO_SANS_THAI,
+};
+
+const FALLBACK_BY_SCRIPT: Array<{ pattern: RegExp; font: SubtitleFallbackFont }> = [
+  // Arabic, Arabic Supplement, Arabic Extended-A, Arabic Presentation Forms.
+  {
+    pattern: /[\u0600-\u06ff\u0750-\u077f\u08a0-\u08ff\ufb50-\ufdff\ufe70-\ufeff]/,
+    font: NOTO_SANS_ARABIC,
+  },
+  { pattern: /[\u0e00-\u0e7f]/, font: NOTO_SANS_THAI },
+];
+
+/**
+ * Returns the font to use as JASSUB's `defaultFont` for a subtitle track in the
+ * given language, or null to keep JASSUB's built-in Latin default.
+ */
+export function fallbackFontForLanguage(language: string | undefined): SubtitleFallbackFont | null {
+  if (!language) return null;
+  return FALLBACK_BY_LANGUAGE[language.toLowerCase()] ?? null;
+}
+
+/**
+ * Returns a fallback font by explicit language first, then by scanning subtitle
+ * text for scripts that need a non-Latin default.
+ */
+export function fallbackFontForSubtitle(
+  language: string | undefined,
+  subtitleContent: string,
+): SubtitleFallbackFont | null {
+  const languageFont = fallbackFontForLanguage(language);
+  if (languageFont) return languageFont;
+
+  return FALLBACK_BY_SCRIPT.find(({ pattern }) => pattern.test(subtitleContent))?.font ?? null;
+}
+
+const fontDataCache = new Map<string, Promise<Uint8Array[]>>();
+const fontBundleCache = new Map<string, Promise<Uint8Array[]>>();
+
+interface SubtitleFontBundleItem {
+  name: string;
+  data: string;
+}
+
+export function loadSubtitleFallbackFontData(font: SubtitleFallbackFont): Promise<Uint8Array[]> {
+  const cached = fontDataCache.get(font.family);
+  if (cached) return cached;
+
+  const promise = Promise.all(
+    font.urls.map(async (url) => {
+      const response = await fetch(url);
+      if (!response.ok) {
+        throw new Error(`HTTP ${response.status}`);
+      }
+      return new Uint8Array(await response.arrayBuffer());
+    }),
+  ).catch((err) => {
+    fontDataCache.delete(font.family);
+    throw err;
+  });
+  fontDataCache.set(font.family, promise);
+  return promise;
+}
+
+export function loadSubtitleFontBundle(url: string, signal?: AbortSignal): Promise<Uint8Array[]> {
+  const cached = fontBundleCache.get(url);
+  if (cached) return cached;
+
+  const promise = fetch(url, { signal })
+    .then(async (response) => {
+      if (!response.ok) {
+        throw new Error(`HTTP ${response.status}`);
+      }
+      return (await response.json()) as SubtitleFontBundleItem[];
+    })
+    .then((items) => items.map((item) => base64ToBytes(item.data)));
+
+  // Do not poison the cache with transient network errors or aborted requests.
+  const cachedPromise = promise.catch((err) => {
+    fontBundleCache.delete(url);
+    throw err;
+  });
+  fontBundleCache.set(url, cachedPromise);
+  return cachedPromise;
+}
+
+function base64ToBytes(value: string): Uint8Array {
+  const binary = atob(value);
+  const bytes = new Uint8Array(binary.length);
+  for (let i = 0; i < binary.length; i += 1) {
+    bytes[i] = binary.charCodeAt(i);
+  }
+  return bytes;
+}
+
+/**
+ * Forces ASS style font names and inline \fn overrides to the selected fallback
+ * family. Without this, libass repeatedly asks for unavailable style fonts such
+ * as Trebuchet MS before falling back, which both logs noisily and can leave
+ * non-Latin glyphs boxed if fallback fonts are not loaded yet.
+ */
+export function forceASSFontFamily(content: string, family: string): string {
+  const normalized = content.replace(/\r\n/g, "\n").replace(/\r/g, "\n");
+  let inStyleSection = false;
+  let fontNameIndex = -1;
+
+  return normalized
+    .split("\n")
+    .map((line) => {
+      const section = line.match(/^\s*\[([^\]]+)]\s*$/);
+      if (section) {
+        const sectionName = section[1]!.trim().toLowerCase();
+        inStyleSection = sectionName === "v4+ styles" || sectionName === "v4 styles";
+        fontNameIndex = -1;
+        return line;
+      }
+
+      if (inStyleSection) {
+        const format = line.match(/^(\s*Format\s*:\s*)(.*)$/i);
+        if (format) {
+          const fields = format[2]!.split(",").map((field) => field.trim().toLowerCase());
+          fontNameIndex = fields.indexOf("fontname");
+          return line;
+        }
+
+        const style = line.match(/^(\s*Style\s*:\s*)(.*)$/i);
+        if (style && fontNameIndex >= 0) {
+          const fields = style[2]!.split(",");
+          if (fontNameIndex < fields.length) {
+            fields[fontNameIndex] = family;
+          }
+          return `${style[1]}${fields.join(",")}`;
+        }
+      }
+
+      return line.replace(/\\fn[^\\}]*/g, `\\fn${family}`);
+    })
+    .join("\n");
+}


### PR DESCRIPTION
## Summary

Fixes ASS/SSA subtitle rendering for non-Latin scripts in the web player by making fonts explicit instead of relying on browser/local font probing.

- Advertise a `font_bundle_url` for embedded ASS/SSA tracks and add an authenticated stream endpoint that extracts font attachments from the source container.
- Preload embedded font attachment bytes and deterministic Noto Arabic/Thai fallback font bytes before constructing JASSUB.
- Detect Arabic/Thai by language metadata or subtitle script content, rewrite ASS style font names and inline `\fn` overrides to the selected fallback, and disable JASSUB local font probing to reduce `fontselect` console noise.
- Add web unit coverage for Arabic fallback, Thai fallback/style rewrite, embedded font bundles, ASS content loading, and disabled local probing.
- Install Noto core/CJK fonts in server images for server-side subtitle paths.

## Root Cause

JASSUB/libass only renders missing glyphs through its configured default font and logs fontselect misses while trying to resolve style fonts such as `Trebuchet MS`. Loading random extra fonts is not enough unless libass can actually select them. Thai tracks rendered as boxes because the default font did not cover Thai, and Arabic could still box for glyphs outside the available fallback set.

## Validation

- `pnpm exec vitest run src/player/hooks/useASSSubtitles.test.tsx`
- `pnpm exec eslint src/player/hooks/useASSSubtitles.ts src/player/hooks/useASSSubtitles.test.tsx src/player/utils/subtitleFonts.ts src/player/types.ts src/player/hooks/usePlaybackSession.ts`
- `pnpm exec tsc -b`
- `pnpm exec vite build`
- `go test ./...`
- `git diff --check`

## Notes

Real-media playback should still be checked against the Arabic/Thai samples that exposed the issue, especially embedded fonts in MKV releases.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Serve downloadable font bundles for embedded ASS/SSA subtitle tracks.
  * Player can load bundled fonts and apply forced fallback fonts for ASS rendering.

* **Enhancements**
  * Automatic fallback selection for Arabic and Thai; local font probing disabled for safer behavior.
  * Runtime images include additional Noto font packages.

* **Tests**
  * Added tests covering font extraction and player font handling.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Silo-Server/silo-server/pull/28?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->