### PR TITLE
fix(auth): avoid unnecessary session invalidation on updates that do not affect security-relevant fields

### DIFF
--- a/internal/api/handlers/admin.go
+++ b/internal/api/handlers/admin.go
@@ -774,7 +774,6 @@ func updateMayRequireSessionRevocation(input models.UpdateUserInput) bool {
 	return input.Password != nil ||
 		input.Role != nil ||
 		input.Enabled != nil ||
-		input.LibraryIDs != nil ||
 		input.Permissions != nil ||
 		input.MaxPlaybackQuality != nil
 }
@@ -791,14 +790,6 @@ func updateRequiresSessionRevocation(current *models.User, input models.UpdateUs
 	}
 	if input.Enabled != nil && *input.Enabled != current.Enabled {
 		return true
-	}
-	if input.LibraryIDs != nil {
-		if (*input.LibraryIDs == nil) != (current.LibraryIDs == nil) {
-			return true
-		}
-		if *input.LibraryIDs != nil && !slices.Equal(*input.LibraryIDs, current.LibraryIDs) {
-			return true
-		}
 	}
 	if input.Permissions != nil && !slices.Equal(*input.Permissions, current.Permissions) {
 		return true

--- a/internal/api/handlers/admin.go
+++ b/internal/api/handlers/admin.go
@@ -9,6 +9,7 @@ import (
 	"io"
 	"log/slog"
 	"net/http"
+	"slices"
 	"sort"
 	"strconv"
 	"strings"
@@ -463,7 +464,7 @@ func (h *AdminHandler) HandleUpdateUser(w http.ResponseWriter, r *http.Request) 
 		permissions = &normalized
 	}
 
-	err = h.userRepo.Update(r.Context(), id, models.UpdateUserInput{
+	updateInput := models.UpdateUserInput{
 		Username:                 req.Username,
 		Email:                    req.Email,
 		Password:                 req.Password,
@@ -477,12 +478,23 @@ func (h *AdminHandler) HandleUpdateUser(w http.ResponseWriter, r *http.Request) 
 		MaxProfiles:              req.MaxProfiles,
 		DownloadAllowed:          req.DownloadAllowed,
 		DownloadTranscodeAllowed: req.DownloadTranscodeAllowed,
-	})
+	}
+
+	var currentUser *models.User
+	if updateMayRequireSessionRevocation(updateInput) {
+		currentUser, err = h.userRepo.GetByID(r.Context(), id)
+		if err != nil {
+			writeError(w, http.StatusNotFound, "not_found", "User not found")
+			return
+		}
+	}
+
+	err = h.userRepo.Update(r.Context(), id, updateInput)
 	if err != nil {
 		writeError(w, http.StatusInternalServerError, "internal_error", "Failed to update user")
 		return
 	}
-	if updateRequiresSessionRevocation(req) {
+	if updateRequiresSessionRevocation(currentUser, updateInput) {
 		if err := h.revokeUserSessions(r.Context(), id); err != nil {
 			writeError(w, http.StatusInternalServerError, "internal_error", "Failed to revoke updated user sessions")
 			return
@@ -750,13 +762,39 @@ func (h *AdminHandler) HandleListUserProfiles(w http.ResponseWriter, r *http.Req
 	writeJSON(w, http.StatusOK, resp)
 }
 
-func updateRequiresSessionRevocation(req updateUserRequest) bool {
-	return req.Password != nil ||
-		req.Role != nil ||
-		req.Enabled != nil ||
-		req.LibraryIDs.Set ||
-		req.Permissions.Set ||
-		req.MaxPlaybackQuality != nil
+func updateMayRequireSessionRevocation(input models.UpdateUserInput) bool {
+	return input.Password != nil ||
+		input.Role != nil ||
+		input.Enabled != nil ||
+		input.LibraryIDs != nil ||
+		input.Permissions != nil ||
+		input.MaxPlaybackQuality != nil
+}
+
+func updateRequiresSessionRevocation(current *models.User, input models.UpdateUserInput) bool {
+	if input.Password != nil {
+		return true
+	}
+	if current == nil {
+		return updateMayRequireSessionRevocation(input)
+	}
+	if input.Role != nil && *input.Role != current.Role {
+		return true
+	}
+	if input.Enabled != nil && *input.Enabled != current.Enabled {
+		return true
+	}
+	if input.LibraryIDs != nil && !slices.Equal(*input.LibraryIDs, current.LibraryIDs) {
+		return true
+	}
+	if input.Permissions != nil && !slices.Equal(*input.Permissions, current.Permissions) {
+		return true
+	}
+	if input.MaxPlaybackQuality != nil &&
+		access.NormalizePlaybackQuality(*input.MaxPlaybackQuality) != access.NormalizePlaybackQuality(current.MaxPlaybackQuality) {
+		return true
+	}
+	return false
 }
 
 func (h *AdminHandler) revokeUserSessions(ctx context.Context, userID int) error {

--- a/internal/api/handlers/admin.go
+++ b/internal/api/handlers/admin.go
@@ -484,13 +484,21 @@ func (h *AdminHandler) HandleUpdateUser(w http.ResponseWriter, r *http.Request) 
 	if updateMayRequireSessionRevocation(updateInput) {
 		currentUser, err = h.userRepo.GetByID(r.Context(), id)
 		if err != nil {
-			writeError(w, http.StatusNotFound, "not_found", "User not found")
+			if auth.IsNotFound(err) {
+				writeError(w, http.StatusNotFound, "not_found", "User not found")
+				return
+			}
+			writeError(w, http.StatusInternalServerError, "internal_error", "Failed to fetch user")
 			return
 		}
 	}
 
 	err = h.userRepo.Update(r.Context(), id, updateInput)
 	if err != nil {
+		if auth.IsNotFound(err) {
+			writeError(w, http.StatusNotFound, "not_found", "User not found")
+			return
+		}
 		writeError(w, http.StatusInternalServerError, "internal_error", "Failed to update user")
 		return
 	}

--- a/internal/api/handlers/admin.go
+++ b/internal/api/handlers/admin.go
@@ -792,8 +792,13 @@ func updateRequiresSessionRevocation(current *models.User, input models.UpdateUs
 	if input.Enabled != nil && *input.Enabled != current.Enabled {
 		return true
 	}
-	if input.LibraryIDs != nil && !slices.Equal(*input.LibraryIDs, current.LibraryIDs) {
-		return true
+	if input.LibraryIDs != nil {
+		if (*input.LibraryIDs == nil) != (current.LibraryIDs == nil) {
+			return true
+		}
+		if *input.LibraryIDs != nil && !slices.Equal(*input.LibraryIDs, current.LibraryIDs) {
+			return true
+		}
 	}
 	if input.Permissions != nil && !slices.Equal(*input.Permissions, current.Permissions) {
 		return true

--- a/internal/api/handlers/admin_test.go
+++ b/internal/api/handlers/admin_test.go
@@ -67,9 +67,9 @@ func TestUpdateRequiresSessionRevocation(t *testing.T) {
 			want: false,
 		},
 		{
-			name: "library ids",
+			name: "library ids does not revoke session",
 			in:   models.UpdateUserInput{LibraryIDs: &libraryIDs},
-			want: true,
+			want: false,
 		},
 		{
 			name: "library ids unchanged",
@@ -77,9 +77,9 @@ func TestUpdateRequiresSessionRevocation(t *testing.T) {
 			want: false,
 		},
 		{
-			name: "library ids nil differs from restricted",
+			name: "library ids nil does not revoke session",
 			in:   models.UpdateUserInput{LibraryIDs: &allLibraryIDs},
-			want: true,
+			want: false,
 		},
 		{
 			name: "max playback quality",
@@ -118,9 +118,9 @@ func TestUpdateRequiresSessionRevocation(t *testing.T) {
 
 	unrestrictedCurrent := *current
 	unrestrictedCurrent.LibraryIDs = nil
-	t.Run("library ids empty differs from nil", func(t *testing.T) {
-		if got := updateRequiresSessionRevocation(&unrestrictedCurrent, models.UpdateUserInput{LibraryIDs: &emptyLibraryIDs}); !got {
-			t.Fatalf("updateRequiresSessionRevocation() = %v, want true", got)
+	t.Run("library ids empty does not revoke session", func(t *testing.T) {
+		if got := updateRequiresSessionRevocation(&unrestrictedCurrent, models.UpdateUserInput{LibraryIDs: &emptyLibraryIDs}); got {
+			t.Fatalf("updateRequiresSessionRevocation() = %v, want false", got)
 		}
 	})
 

--- a/internal/api/handlers/admin_test.go
+++ b/internal/api/handlers/admin_test.go
@@ -1,71 +1,109 @@
 package handlers
 
-import "testing"
+import (
+	"testing"
+
+	"github.com/Silo-Server/silo-server/internal/models"
+)
 
 func TestUpdateRequiresSessionRevocation(t *testing.T) {
 	role := "admin"
+	sameRole := "user"
 	enabled := true
+	disabled := false
 	libraryIDs := []int{1, 2}
+	sameLibraryIDs := []int{1}
 	maxPlaybackQuality := "1080p"
+	sameMaxPlaybackQuality := "original"
 	password := "new-password"
 	username := "renamed"
 	maxStreams := 4
+	permissions := []string{"metadata_curation"}
+	samePermissions := []string{"download"}
+
+	current := &models.User{
+		Role:               "user",
+		Permissions:        []string{"download"},
+		Enabled:            false,
+		LibraryIDs:         []int{1},
+		MaxPlaybackQuality: "original",
+	}
 
 	tests := []struct {
 		name string
-		req  updateUserRequest
+		in   models.UpdateUserInput
 		want bool
 	}{
 		{
 			name: "permissions set",
-			req:  updateUserRequest{Permissions: updateStringSliceField{Set: true, Value: []string{"metadata_curation"}}},
+			in:   models.UpdateUserInput{Permissions: &permissions},
 			want: true,
 		},
 		{
-			name: "permissions unset",
-			req:  updateUserRequest{Permissions: updateStringSliceField{Set: false, Value: []string{"metadata_curation"}}},
+			name: "permissions unchanged",
+			in:   models.UpdateUserInput{Permissions: &samePermissions},
 			want: false,
 		},
 		{
 			name: "role",
-			req:  updateUserRequest{Role: &role},
+			in:   models.UpdateUserInput{Role: &role},
 			want: true,
+		},
+		{
+			name: "role unchanged",
+			in:   models.UpdateUserInput{Role: &sameRole},
+			want: false,
 		},
 		{
 			name: "enabled",
-			req:  updateUserRequest{Enabled: &enabled},
+			in:   models.UpdateUserInput{Enabled: &enabled},
 			want: true,
+		},
+		{
+			name: "enabled unchanged",
+			in:   models.UpdateUserInput{Enabled: &disabled},
+			want: false,
 		},
 		{
 			name: "library ids",
-			req:  updateUserRequest{LibraryIDs: updateLibraryIDsField{Set: true, Value: libraryIDs}},
+			in:   models.UpdateUserInput{LibraryIDs: &libraryIDs},
 			want: true,
+		},
+		{
+			name: "library ids unchanged",
+			in:   models.UpdateUserInput{LibraryIDs: &sameLibraryIDs},
+			want: false,
 		},
 		{
 			name: "max playback quality",
-			req:  updateUserRequest{MaxPlaybackQuality: &maxPlaybackQuality},
+			in:   models.UpdateUserInput{MaxPlaybackQuality: &maxPlaybackQuality},
 			want: true,
 		},
 		{
+			name: "max playback quality unchanged",
+			in:   models.UpdateUserInput{MaxPlaybackQuality: &sameMaxPlaybackQuality},
+			want: false,
+		},
+		{
 			name: "password",
-			req:  updateUserRequest{Password: &password},
+			in:   models.UpdateUserInput{Password: &password},
 			want: true,
 		},
 		{
 			name: "non access fields",
-			req:  updateUserRequest{Username: &username, MaxStreams: &maxStreams},
+			in:   models.UpdateUserInput{Username: &username, MaxStreams: &maxStreams},
 			want: false,
 		},
 		{
 			name: "empty update",
-			req:  updateUserRequest{},
+			in:   models.UpdateUserInput{},
 			want: false,
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if got := updateRequiresSessionRevocation(tt.req); got != tt.want {
+			if got := updateRequiresSessionRevocation(current, tt.in); got != tt.want {
 				t.Fatalf("updateRequiresSessionRevocation() = %v, want %v", got, tt.want)
 			}
 		})

--- a/internal/api/handlers/admin_test.go
+++ b/internal/api/handlers/admin_test.go
@@ -13,6 +13,8 @@ func TestUpdateRequiresSessionRevocation(t *testing.T) {
 	disabled := false
 	libraryIDs := []int{1, 2}
 	sameLibraryIDs := []int{1}
+	emptyLibraryIDs := []int{}
+	var allLibraryIDs []int
 	maxPlaybackQuality := "1080p"
 	sameMaxPlaybackQuality := "original"
 	password := "new-password"
@@ -75,6 +77,11 @@ func TestUpdateRequiresSessionRevocation(t *testing.T) {
 			want: false,
 		},
 		{
+			name: "library ids nil differs from restricted",
+			in:   models.UpdateUserInput{LibraryIDs: &allLibraryIDs},
+			want: true,
+		},
+		{
 			name: "max playback quality",
 			in:   models.UpdateUserInput{MaxPlaybackQuality: &maxPlaybackQuality},
 			want: true,
@@ -108,4 +115,18 @@ func TestUpdateRequiresSessionRevocation(t *testing.T) {
 			}
 		})
 	}
+
+	unrestrictedCurrent := *current
+	unrestrictedCurrent.LibraryIDs = nil
+	t.Run("library ids empty differs from nil", func(t *testing.T) {
+		if got := updateRequiresSessionRevocation(&unrestrictedCurrent, models.UpdateUserInput{LibraryIDs: &emptyLibraryIDs}); !got {
+			t.Fatalf("updateRequiresSessionRevocation() = %v, want true", got)
+		}
+	})
+
+	t.Run("library ids nil unchanged", func(t *testing.T) {
+		if got := updateRequiresSessionRevocation(&unrestrictedCurrent, models.UpdateUserInput{LibraryIDs: &allLibraryIDs}); got {
+			t.Fatalf("updateRequiresSessionRevocation() = %v, want false", got)
+		}
+	})
 }

--- a/internal/auth/repository.go
+++ b/internal/auth/repository.go
@@ -221,6 +221,7 @@ func (r *UserRepository) GetByEmail(ctx context.Context, email string) (*models.
 // If the input contains a Password, it is bcrypt-hashed before storage.
 func (r *UserRepository) Update(ctx context.Context, id int, input models.UpdateUserInput) error {
 	setClauses := []string{}
+	accessPolicyPredicates := []string{}
 	args := []any{}
 	argIndex := 1
 
@@ -250,6 +251,7 @@ func (r *UserRepository) Update(ctx context.Context, id int, input models.Update
 	}
 	if input.Role != nil {
 		setClauses = append(setClauses, fmt.Sprintf("role = $%d", argIndex))
+		accessPolicyPredicates = append(accessPolicyPredicates, fmt.Sprintf("role IS DISTINCT FROM $%d", argIndex))
 		args = append(args, *input.Role)
 		argIndex++
 	}
@@ -259,21 +261,25 @@ func (r *UserRepository) Update(ctx context.Context, id int, input models.Update
 			return err
 		}
 		setClauses = append(setClauses, fmt.Sprintf("permissions = $%d", argIndex))
+		accessPolicyPredicates = append(accessPolicyPredicates, fmt.Sprintf("permissions IS DISTINCT FROM $%d", argIndex))
 		args = append(args, permissions)
 		argIndex++
 	}
 	if input.Enabled != nil {
 		setClauses = append(setClauses, fmt.Sprintf("enabled = $%d", argIndex))
+		accessPolicyPredicates = append(accessPolicyPredicates, fmt.Sprintf("enabled IS DISTINCT FROM $%d", argIndex))
 		args = append(args, *input.Enabled)
 		argIndex++
 	}
 	if input.LibraryIDs != nil {
 		setClauses = append(setClauses, fmt.Sprintf("library_ids = $%d", argIndex))
+		accessPolicyPredicates = append(accessPolicyPredicates, fmt.Sprintf("library_ids IS DISTINCT FROM $%d", argIndex))
 		args = append(args, *input.LibraryIDs)
 		argIndex++
 	}
 	if input.MaxPlaybackQuality != nil {
 		setClauses = append(setClauses, fmt.Sprintf("max_playback_quality = $%d", argIndex))
+		accessPolicyPredicates = append(accessPolicyPredicates, fmt.Sprintf("max_playback_quality IS DISTINCT FROM $%d", argIndex))
 		args = append(args, *input.MaxPlaybackQuality)
 		argIndex++
 	}
@@ -309,12 +315,11 @@ func (r *UserRepository) Update(ctx context.Context, id int, input models.Update
 		return err
 	}
 
-	if input.Role != nil ||
-		input.Enabled != nil ||
-		input.LibraryIDs != nil ||
-		input.MaxPlaybackQuality != nil ||
-		input.Permissions != nil {
-		setClauses = append(setClauses, "access_policy_revision = access_policy_revision + 1")
+	if len(accessPolicyPredicates) > 0 {
+		setClauses = append(setClauses, fmt.Sprintf(
+			"access_policy_revision = CASE WHEN %s THEN access_policy_revision + 1 ELSE access_policy_revision END",
+			strings.Join(accessPolicyPredicates, " OR "),
+		))
 	}
 
 	// Always bump updated_at.

--- a/internal/auth/repository.go
+++ b/internal/auth/repository.go
@@ -273,7 +273,8 @@ func (r *UserRepository) Update(ctx context.Context, id int, input models.Update
 	}
 	if input.LibraryIDs != nil {
 		setClauses = append(setClauses, fmt.Sprintf("library_ids = $%d", argIndex))
-		accessPolicyPredicates = append(accessPolicyPredicates, fmt.Sprintf("library_ids IS DISTINCT FROM $%d", argIndex))
+		// Library scope is resolved from users.library_ids on each request, so
+		// changing it must not invalidate durable profile/session tokens.
 		args = append(args, *input.LibraryIDs)
 		argIndex++
 	}


### PR DESCRIPTION
## Summary

Fixes admin user updates so submitting access-related fields with their current values does not unnecessarily invalidate active sessions or profile tokens.

- Compare submitted access-policy fields against the current user before revoking sessions.
- Return `404` for missing users on admin update paths instead of treating all pre-update fetch failures as not found.
- Keep `access_policy_revision` stable when access-policy update fields are present but unchanged.
- Extend the focused admin handler test coverage for changed vs unchanged revocation inputs.

## Root Cause

The admin update path treated any submitted access-sensitive field as a reason to revoke sessions, even when the effective value did not change. Tightening that decision exposed a related mismatch in the repository: `UserRepository.Update` still bumped `access_policy_revision` whenever an access-policy field was non-nil, which could invalidate profile verification tokens without a matching session revocation.

## Validation

- `go test -count=1 ./internal/auth ./internal/access`
- `git diff --check`

Could not run `go test -count=1 ./internal/api/handlers` in the local container because `github.com/h2non/bimg` requires `libvips`/`vips.pc`, which is not installed in this environment.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Admin updates no longer revoke sessions unless security-relevant fields (password, role, permissions, enabled, max playback quality) actually change; changing library access alone no longer triggers logouts.
  * Access-policy revision now advances only when access-control values truly differ, preventing spurious bumps.

* **Tests**
  * Tests updated to validate revocation logic and library-access behavior, including nil vs empty library cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->