### PR TITLE
[codex] show plugin OAuth providers on login

### DIFF
--- a/internal/api/handlers/auth.go
+++ b/internal/api/handlers/auth.go
@@ -17,9 +17,10 @@ import (
 
 // AuthHandler handles authentication-related HTTP endpoints.
 type AuthHandler struct {
-	service *auth.Service
-	jwt     *auth.JWTService
-	device  *auth.DeviceLoginService
+	service              *auth.Service
+	jwt                  *auth.JWTService
+	device               *auth.DeviceLoginService
+	oauthRoutesAvailable bool
 }
 
 // NewAuthHandler creates a new AuthHandler backed by the given auth, JWT,
@@ -30,6 +31,13 @@ func NewAuthHandler(service *auth.Service, jwt *auth.JWTService, device *auth.De
 		jwt:     jwt,
 		device:  device,
 	}
+}
+
+// SetOAuthRoutesAvailable controls whether OAuth login providers are
+// advertised by /auth/providers. The router only mounts OAuth routes when the
+// server has enough configuration to complete the flow.
+func (h *AuthHandler) SetOAuthRoutesAvailable(available bool) {
+	h.oauthRoutesAvailable = available
 }
 
 // --- Request/Response types ---
@@ -181,6 +189,9 @@ func (h *AuthHandler) HandleProviders(w http.ResponseWriter, r *http.Request) {
 	providers := h.service.ListProviders()
 	response := make([]authProviderResponse, 0, len(providers))
 	for _, provider := range providers {
+		if provider.Mode == "oauth" && !h.oauthRoutesAvailable {
+			continue
+		}
 		response = append(response, authProviderResponse{
 			ID:             provider.ID,
 			DisplayName:    provider.DisplayName,

--- a/internal/api/handlers/auth_providers_test.go
+++ b/internal/api/handlers/auth_providers_test.go
@@ -1,0 +1,97 @@
+package handlers
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/Silo-Server/silo-server/internal/auth"
+	"github.com/Silo-Server/silo-server/internal/models"
+)
+
+type stubLoginProvider struct{}
+
+func (stubLoginProvider) Authenticate(context.Context, auth.Credentials) (*models.User, error) {
+	return nil, auth.ErrInvalidCredentials
+}
+
+func (stubLoginProvider) ValidateSession(context.Context, string) (bool, error) {
+	return false, nil
+}
+
+func newAuthProviderHandlerForTest(oauthRoutesAvailable bool) *AuthHandler {
+	service := auth.NewService(nil, nil, nil, nil, nil, nil, nil)
+	provider := stubLoginProvider{}
+
+	service.RegisterProvider(auth.LoginProviderInfo{
+		ID:          "local",
+		DisplayName: "Local",
+		Mode:        "credentials",
+		Default:     true,
+	}, provider)
+	service.RegisterProvider(auth.LoginProviderInfo{
+		ID:             "plugin:41:oidc",
+		DisplayName:    "OIDC",
+		Mode:           "oauth",
+		InstallationID: 41,
+	}, provider)
+
+	handler := NewAuthHandler(service, nil, nil)
+	handler.SetOAuthRoutesAvailable(oauthRoutesAvailable)
+	return handler
+}
+
+func readProviderResponse(t *testing.T, handler *AuthHandler) []authProviderResponse {
+	t.Helper()
+
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/auth/providers", nil)
+	handler.HandleProviders(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d", rec.Code, http.StatusOK)
+	}
+
+	var providers []authProviderResponse
+	if err := json.NewDecoder(rec.Body).Decode(&providers); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	return providers
+}
+
+func TestAuthProvidersHideOAuthWhenOAuthRoutesUnavailable(t *testing.T) {
+	providers := readProviderResponse(t, newAuthProviderHandlerForTest(false))
+
+	if len(providers) != 1 {
+		t.Fatalf("provider count = %d, want 1: %#v", len(providers), providers)
+	}
+	if providers[0].ID != "local" {
+		t.Fatalf("provider ID = %q, want local", providers[0].ID)
+	}
+}
+
+func TestAuthProvidersIncludeOAuthWhenOAuthRoutesAvailable(t *testing.T) {
+	providers := readProviderResponse(t, newAuthProviderHandlerForTest(true))
+
+	if len(providers) != 2 {
+		t.Fatalf("provider count = %d, want 2: %#v", len(providers), providers)
+	}
+
+	var foundOAuth bool
+	for _, provider := range providers {
+		if provider.ID == "plugin:41:oidc" {
+			foundOAuth = true
+			if provider.Mode != "oauth" {
+				t.Fatalf("OAuth provider mode = %q, want oauth", provider.Mode)
+			}
+			if provider.InstallationID != 41 {
+				t.Fatalf("OAuth provider installation ID = %d, want 41", provider.InstallationID)
+			}
+		}
+	}
+	if !foundOAuth {
+		t.Fatalf("OAuth provider missing from response: %#v", providers)
+	}
+}

--- a/internal/api/router.go
+++ b/internal/api/router.go
@@ -1161,6 +1161,7 @@ func NewRouter(deps Dependencies) chi.Router {
 					StateTTL:        10 * time.Minute,
 				})
 			}
+			authHandler.SetOAuthRoutesAvailable(oauthHandler != nil)
 
 			r.Route("/auth", func(r chi.Router) {
 				if deps.RateLimitMW != nil {

--- a/web/src/hooks/AuthProvider.test.tsx
+++ b/web/src/hooks/AuthProvider.test.tsx
@@ -1,0 +1,91 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import type { ReactNode } from "react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import type { AuthProviderOption, SetupStatusResponse } from "@/api/types";
+import { storage } from "@/utils/storage";
+import { AuthProvider, useAuth } from "./useAuth";
+
+const apiMock = vi.hoisted(() => vi.fn());
+const bootstrapAccessTokenMock = vi.hoisted(() => vi.fn());
+const getAccessTokenMock = vi.hoisted(() => vi.fn());
+const onProfileUnverifiedMock = vi.hoisted(() => vi.fn());
+const restoreUserSessionMock = vi.hoisted(() => vi.fn());
+const setAccessTokenMock = vi.hoisted(() => vi.fn());
+const setProfileIdMock = vi.hoisted(() => vi.fn());
+const setProfileTokenMock = vi.hoisted(() => vi.fn());
+const setRefreshTokenMock = vi.hoisted(() => vi.fn());
+
+vi.mock("@/api/client", async () => {
+  const actual = await vi.importActual<typeof import("@/api/client")>("@/api/client");
+
+  return {
+    ...actual,
+    api: apiMock,
+    bootstrapAccessToken: bootstrapAccessTokenMock,
+    getAccessToken: getAccessTokenMock,
+    onProfileUnverified: onProfileUnverifiedMock,
+    restoreUserSession: restoreUserSessionMock,
+    setAccessToken: setAccessTokenMock,
+    setProfileId: setProfileIdMock,
+    setProfileToken: setProfileTokenMock,
+    setRefreshToken: setRefreshTokenMock,
+  };
+});
+
+function renderWithAuthProvider(children: ReactNode) {
+  return render(<AuthProvider>{children}</AuthProvider>);
+}
+
+function ProviderProbe() {
+  const { providers, setupLoading } = useAuth();
+
+  return (
+    <div data-testid="providers">
+      {setupLoading ? "loading" : providers.map((entry) => `${entry.id}:${entry.mode}`).join(",")}
+    </div>
+  );
+}
+
+describe("AuthProvider", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    Object.values(storage.KEYS).forEach((key) => storage.remove(key));
+
+    bootstrapAccessTokenMock.mockResolvedValue(false);
+    getAccessTokenMock.mockReturnValue(null);
+    restoreUserSessionMock.mockResolvedValue(null);
+  });
+
+  it("preserves OAuth login providers returned by the auth providers endpoint", async () => {
+    const providers: AuthProviderOption[] = [
+      { id: "local", display_name: "Local", mode: "credentials", default: true },
+      {
+        id: "plugin:41:oidc",
+        display_name: "OIDC",
+        mode: "oauth",
+        default: false,
+        installation_id: 41,
+      },
+    ];
+
+    apiMock.mockImplementation(
+      (path: string): Promise<SetupStatusResponse | AuthProviderOption[]> => {
+        if (path === "/auth/setup") {
+          return Promise.resolve({ needs_setup: false });
+        }
+        if (path === "/auth/providers") {
+          return Promise.resolve(providers);
+        }
+        return Promise.reject(new Error(`unexpected API call: ${path}`));
+      },
+    );
+
+    renderWithAuthProvider(<ProviderProbe />);
+
+    await waitFor(() => {
+      expect(screen.getByTestId("providers")).toHaveTextContent("local:credentials");
+      expect(screen.getByTestId("providers")).toHaveTextContent("plugin:41:oidc:oauth");
+    });
+  });
+});

--- a/web/src/hooks/useAuth.tsx
+++ b/web/src/hooks/useAuth.tsx
@@ -358,7 +358,7 @@ export function AuthProvider({ children }: { children: ReactNode }) {
           return;
         }
         setSetupRequired(status.needs_setup);
-        setProviders((availableProviders ?? []).filter((entry) => entry.mode === "credentials"));
+        setProviders(availableProviders ?? []);
       } catch {
         if (!cancelled) {
           setSetupRequired(false);


### PR DESCRIPTION
## Summary

Fixes #30 by preserving usable providers returned from `/api/v1/auth/providers` in the web auth context. `Login.tsx` already separates credential and OAuth providers, but the auth hook was filtering the list down to credential providers before the login page could render OAuth sign-in buttons.

This also keeps the backend provider list aligned with route availability: OAuth providers are only advertised when the router actually mounted the `/api/v1/auth/oauth/{installation_id}/init` flow. Servers without `SILO_PUBLIC_URL` configured will not show unusable OAuth buttons.

## Impact

Custom auth plugins that declare OAuth-only login now appear on the login screen when OAuth is configured and submit through `/api/v1/auth/oauth/{installation_id}/init` as intended. If OAuth routes are unavailable, those providers stay hidden instead of leading users to a 404.

@thezak48 could you test this PR with your custom OAuth plugin and confirm the sign-in option now appears and starts the OAuth flow correctly on a server with `SILO_PUBLIC_URL` configured?

## Validation

- `go test ./internal/api/handlers`
- `go test ./internal/api`
- `pnpm --dir web exec vitest run src/hooks/AuthProvider.test.tsx src/hooks/useAuth.test.ts`
- `pnpm --dir web exec prettier --check src/hooks/AuthProvider.test.tsx src/hooks/useAuth.tsx`
- `pnpm --dir web exec tsc -b --pretty false`
- Previous changed-file ESLint check: `pnpm --dir web exec eslint src/hooks/useAuth.tsx src/hooks/AuthProvider.test.tsx`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Authentication providers are now correctly filtered based on OAuth route availability. OAuth providers are hidden when routes are unavailable and displayed when available.
  * Provider list during setup now includes all available authentication methods.

* **Tests**
  * Added test coverage for authentication provider filtering behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->