### PR TITLE
[codex] keep plugin auto-provision passwords bcrypt-safe

### DIFF
--- a/internal/auth/plugin_provider.go
+++ b/internal/auth/plugin_provider.go
@@ -279,7 +279,7 @@ func (p *PluginProvider) autoProvisionUser(
 }
 
 func randomPluginOnlyPassword() (string, error) {
-	buf := make([]byte, 32)
+	buf := make([]byte, 24)
 	if _, err := rand.Read(buf); err != nil {
 		return "", err
 	}

--- a/internal/auth/plugin_provider_test.go
+++ b/internal/auth/plugin_provider_test.go
@@ -1,0 +1,21 @@
+package auth
+
+import (
+	"testing"
+
+	"golang.org/x/crypto/bcrypt"
+)
+
+func TestRandomPluginOnlyPasswordFitsBcryptLimit(t *testing.T) {
+	password, err := randomPluginOnlyPassword()
+	if err != nil {
+		t.Fatalf("randomPluginOnlyPassword() error = %v", err)
+	}
+
+	if len(password) > 72 {
+		t.Fatalf("password length = %d, want <= 72", len(password))
+	}
+	if _, err := bcrypt.GenerateFromPassword([]byte(password), bcrypt.DefaultCost); err != nil {
+		t.Fatalf("bcrypt.GenerateFromPassword() error = %v", err)
+	}
+}


### PR DESCRIPTION
## Summary

Fixes #31 by reducing the random byte payload used by `randomPluginOnlyPassword()` from 32 bytes to 24 bytes before hex encoding.

The generated plugin-only password changes from `plugin-only-` + 64 hex chars, 76 bytes total, to `plugin-only-` + 48 hex chars, 60 bytes total. That keeps the value below bcrypt's 72-byte input limit while preserving enough entropy for an internal password that is never meant for local login.

## Relationship to #30

This is related to the same plugin OAuth sign-in surface, but it is a separate backend auto-provisioning failure. #30 handled whether OAuth providers appear on the login page; this fixes first-time OAuth account creation once the OAuth flow completes.

## Validation

- `go test ./internal/auth`
- `go test ./internal/api/handlers`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Adjusted plugin password generation to ensure compatibility with bcrypt's character limit, preventing potential hashing failures.

* **Tests**
  * Added validation test to confirm generated plugin passwords fit within bcrypt's 72-character input limit and hash successfully.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->