### PR TITLE
fix(metadata): don't promote season/episode 404s to item-level stale provider IDs

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 A self-hosted media streaming server with a React frontend and Go backend. Supports direct play, remuxing, and hardware-accelerated transcoding. Compatible with Jellyfin/Emby clients (VidHub, Findroid) via a built-in compatibility layer.
 
+Join the community on [Discord](https://discord.gg/4RxuUQAEnW).
+
 ## Deploy with Docker (recommended)
 
 The easiest way to run Silo is with Docker Compose. The default stack assumes you do not already have PostgreSQL and Redis available, so it bundles PostgreSQL, Redis, FFmpeg, and the application for a one-command start.

--- a/internal/metadata/service.go
+++ b/internal/metadata/service.go
@@ -1137,7 +1137,12 @@ func (s *MetadataService) processInternal(ctx context.Context, req ProcessReques
 				Language:    req.Language,
 			})
 			if err != nil {
-				if handleProvider404(provider404s, accumulatedIDs, p.Slug(), err,
+				// Pass nil for provider404s: a 404 fetching seasons is a
+				// child-resource failure (e.g. TMDB returns 404 for /tv/{id}/season/0
+				// when a series has no specials season). It must not be recorded
+				// as an item-level stale provider ID — matches the pattern used
+				// by fetchTargetSeasonResults.
+				if handleProvider404(nil, accumulatedIDs, p.Slug(), err,
 					"content_id", req.ContentID,
 					"season", 0,
 				) {
@@ -1170,7 +1175,11 @@ func (s *MetadataService) processInternal(ctx context.Context, req ProcessReques
 						Language:     req.Language,
 					})
 					if err != nil {
-						if handleProvider404(provider404s, accumulatedIDs, p.Slug(), err,
+						// Pass nil for provider404s: episode 404s are normal
+						// (e.g. TMDB returns 404 for episodes that haven't
+						// aired yet). They must not be recorded as item-level
+						// stale provider IDs — matches fetchTargetEpisodeResults.
+						if handleProvider404(nil, accumulatedIDs, p.Slug(), err,
 							"content_id", req.ContentID,
 							"season", season.SeasonNumber,
 						) {


### PR DESCRIPTION
## Summary

The main-refresh path in `MetadataService.processInternal` passes `provider404s` to `handleProvider404` for **season** and **episode** fetch errors. Since `handleProvider404` records the item's provider ID as stale whenever `provider404s != nil`, a 404 fetching seasons or episodes promotes the *item* itself to stale — even though the 404 is a child-resource failure (TMDB returns 404 for `/tv/{id}/season/0` when the series has no specials season; for episodes that haven't aired yet; etc.).

The equivalent **target**-refresh paths (`fetchTargetSeasonResults` and `fetchTargetEpisodeResults`) already pass `nil` for this exact reason. This PR brings the main-refresh path in line with the existing target-refresh pattern.

## Diff

Two call sites in `internal/metadata/service.go`:

| Line | Resource | Before | After |
|---|---|---|---|
| 1140 | Seasons (main refresh) | `handleProvider404(provider404s, ...)` | `handleProvider404(nil, ...)` |
| 1173 | Episodes (main refresh) | `handleProvider404(provider404s, ...)` | `handleProvider404(nil, ...)` |

For reference, the already-correct sites that this fix matches:
- `service.go:2305` — `fetchTargetSeasonResults`, already passes `nil`
- `service.go:2339` — `fetchTargetEpisodeResults`, already passes `nil`

## Observed impact

On our deployment, the bug caused **13,524 series items** to have their `media_items.tmdb_id` cleared and recorded as stale during a single library refresh sweep — every series whose TMDB entry doesn't have a "specials" season (most anime, many older shows) was affected. Once recorded, `suppressRecordedStaleProviderIDs` locked the items out of future TMDB enrichment, so subsequent refreshes couldn't self-heal even when TVDB supplied a working TMDB cross-reference.

The bug is fully reproducible. Live log capture during a refresh sweep:

```
provider=tmdb content_id=... season=0 provider_id=62913 error="...tmdb: HTTP 404..."
provider=tmdb content_id=... season=0 provider_id=72511 error="...tmdb: HTTP 404..."
provider=tmdb content_id=... season=0 provider_id=75778 error="...tmdb: HTTP 404..."
```

Every single 404 has `season=0`. Direct curl tests confirm:

```
id=68417: GET /tv/68417 → 200   /season/0 → 404   /season/1 → 200
id=76645: GET /tv/76645 → 200   /season/0 → 404   /season/1 → 200
id=80836: GET /tv/80836 → 200   /season/0 → 404   /season/1 → 200
id=43249: GET /tv/43249 → 200   /season/0 → 200   /season/1 → 200
id=110126: GET /tv/110126 → 200   /season/0 → 404   /season/1 → 200
```

The TMDB IDs themselves are valid. Only the specials-season fetch 404s.

## Why this regressed

The target-refresh paths (lines 2305/2339) already use `nil` for season/episode child fetches. The main-refresh paths (lines 1140/1173) still passed `provider404s`. Looks like a previous half-finished cleanup — the fix was applied to one branch of the code path but not propagated to the symmetric branch.

## Related

Issue [Silo-Server/silo-plugin-tmdb#2](https://github.com/Silo-Server/silo-plugin-tmdb/issues/2) — symptom report. The TMDB plugin itself is fine; the bug is in silo-server's classification of child-resource 404s.

## Suggested follow-up (out of scope for this PR)

The asymmetry between `processInternal` (~lines 870-1240) and `fetchTargetSeasonResults` / `fetchTargetEpisodeResults` (~lines 2280-2350) means the same child-fetch logic exists in two places that have drifted apart once already. Worth either (a) consolidating into a shared helper, or (b) making `handleProvider404`'s "should I record this as stale" signal explicit instead of a load-bearing nil-check on `provider404s`. Both would prevent this class of bug.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved metadata handling when seasons and episodes cannot be fetched from certain providers, preventing incorrect stale data from being recorded or propagated.

* **Documentation**
  * Added a "Join the community" call-to-action linking to Discord near the top of the README.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->