### PR TITLE
fix(metadata): record post-refresh stale IDs against the canonical item

### DIFF
--- a/internal/metadata/refresh_followup_test.go
+++ b/internal/metadata/refresh_followup_test.go
@@ -1,0 +1,22 @@
+package metadata
+
+import "testing"
+
+func TestRefreshFollowUpContentID(t *testing.T) {
+	// After a refresh, follow-up writes (stale-ID clear/record, debt sync) must
+	// target the canonical content ID the item was persisted/merged into, not
+	// the requested ID — which may have been deleted when the item was
+	// canonicalized into an existing one during mergeAndPersist.
+	if got := refreshFollowUpContentID("req", nil); got != "req" {
+		t.Fatalf("nil result: got %q, want %q", got, "req")
+	}
+	if got := refreshFollowUpContentID("req", &ProcessResult{ContentID: ""}); got != "req" {
+		t.Fatalf("empty result id: got %q, want %q", got, "req")
+	}
+	if got := refreshFollowUpContentID("req", &ProcessResult{ContentID: "   "}); got != "req" {
+		t.Fatalf("blank result id: got %q, want %q", got, "req")
+	}
+	if got := refreshFollowUpContentID("req", &ProcessResult{ContentID: "canonical"}); got != "canonical" {
+		t.Fatalf("canonicalized result id: got %q, want %q", got, "canonical")
+	}
+}

--- a/internal/metadata/service.go
+++ b/internal/metadata/service.go
@@ -1210,18 +1210,28 @@ func (s *MetadataService) processInternal(ctx context.Context, req ProcessReques
 
 	// Refresh stale ID records on successful refresh: clear anything resolved,
 	// then keep only the providers that still 404ed during this run.
-	if s.staleIDRepo != nil && req.ContentID != "" {
-		if delErr := s.staleIDRepo.DeleteByContentID(ctx, req.ContentID); delErr != nil {
+	// Stale-ID follow-up targets the canonical content ID the item was
+	// persisted/merged into. When mergeAndPersist canonicalizes this item into
+	// an existing one, req.ContentID is the now-deleted source: clearing or
+	// recording stale IDs against it would touch nothing (or FK-violate), so
+	// the still-404ing providers must be recorded on result.ContentID instead.
+	// provider404s is only allocated when req.ContentID was set (the refresh
+	// targeted a known item). Guarding on it preserves the original gating so a
+	// content-id-less refresh that canonicalizes into an existing item does not
+	// wipe that item's stale rows without re-recording any.
+	followUpContentID := refreshFollowUpContentID(req.ContentID, result)
+	if s.staleIDRepo != nil && followUpContentID != "" && provider404s != nil {
+		if delErr := s.staleIDRepo.DeleteByContentID(ctx, followUpContentID); delErr != nil {
 			slog.Warn("metadata: failed to clear stale IDs after refresh",
-				"content_id", req.ContentID, "error", delErr)
+				"content_id", followUpContentID, "error", delErr)
 		}
 		for slug, providerID := range provider404s {
 			if providerID == "" {
 				continue
 			}
-			if upsertErr := s.staleIDRepo.Upsert(ctx, req.ContentID, slug, providerID); upsertErr != nil {
+			if upsertErr := s.staleIDRepo.Upsert(ctx, followUpContentID, slug, providerID); upsertErr != nil {
 				slog.Warn("metadata: failed to persist stale provider ID after partial refresh",
-					"content_id", req.ContentID,
+					"content_id", followUpContentID,
 					"provider", slug,
 					"provider_id", providerID,
 					"error", upsertErr)
@@ -1237,6 +1247,19 @@ func (s *MetadataService) processInternal(ctx context.Context, req ProcessReques
 	}
 
 	return result, nil
+}
+
+// refreshFollowUpContentID returns the content ID that a completed refresh's
+// follow-up writes (stale-ID clear/record, debt sync) should target: the
+// canonical ID the item was persisted or merged into when available, falling
+// back to the requested ID. mergeAndPersist can canonicalize an item into an
+// existing one, deleting the requested ID, so follow-up writes keyed on
+// req.ContentID would miss the surviving item.
+func refreshFollowUpContentID(reqContentID string, result *ProcessResult) string {
+	if result != nil && strings.TrimSpace(result.ContentID) != "" {
+		return result.ContentID
+	}
+	return reqContentID
 }
 
 // mergeAndPersist handles the final merge into existing item and DB persistence.


### PR DESCRIPTION
## Problem
`processInternal` cleared and re-recorded stale provider IDs against `req.ContentID` after `mergeAndPersist`. But `mergeAndPersist` can canonicalize the item into an existing one (provider-ID dedup), deleting `req.ContentID` and returning a different `result.ContentID`. In that case the post-merge `DeleteByContentID`/`Upsert` targeted the now-deleted source: the upsert hit the `stale_media_ids` content_id foreign key and the still-404ing providers were never recorded on the surviving canonical item — so the same providers get re-attempted (and re-404) on every subsequent refresh.

## Approach
Target the canonical ID (`result.ContentID`, falling back to `req.ContentID`) for the stale-ID follow-up via a small `refreshFollowUpContentID` helper — matching what the adjacent refresh-debt sync already uses (`result.ContentID`).

## Risks / follow-up
Low. When no canonicalization occurs, `result.ContentID == req.ContentID` and behavior is unchanged. This is a pre-existing caller-side issue surfaced during review of the stale-ID FK-violation fix (#37); it addresses the root cause of that race.

## Verification
`go test ./internal/metadata/` and `go vet ./internal/metadata/` pass. The id-selection helper is unit-tested (nil / empty / blank / canonicalized). Note: the end-to-end wiring in `processInternal` is not covered by a test — the repo has no DB integration harness for that path.

## AI-use disclosure
Implemented with Claude Code (Opus 4.8), TDD, surfaced by a multi-agent review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed follow-up logic so stale external identifiers are written against the canonical content identifier after merge/persist, keeping stale ID records associated with the surviving consolidated item.

* **Tests**
  * Added unit test coverage for follow-up content ID resolution, including fallbacks when result data is missing, empty, or whitespace-only.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->