### PR TITLE
[codex] Fix Next Up anchor query

### DIFF
--- a/internal/catalog/nextup_repo.go
+++ b/internal/catalog/nextup_repo.go
@@ -52,34 +52,12 @@ func (r *NextUpRepository) ListNextUp(ctx context.Context, q NextUpQuery) ([]Nex
 		return nil, nil
 	}
 
-	store, err := r.storeProvider.ForUser(ctx, q.UserID)
-	if err != nil {
-		return nil, fmt.Errorf("getting user store: %w", err)
-	}
-
-	// Get recently completed episodes (limit 100 for performance)
-	completedEntries, err := store.ListProgress(ctx, q.ProfileID, "completed", 100, 0)
-	if err != nil {
-		return nil, fmt.Errorf("listing completed progress: %w", err)
-	}
-	if len(completedEntries) == 0 {
-		if q.EnableResumable {
-			return r.listResumableFirstEpisodes(ctx, q)
-		}
-		return nil, nil
-	}
-
-	completedIDs := make([]string, 0, len(completedEntries))
-	for _, entry := range completedEntries {
-		completedIDs = append(completedIDs, entry.MediaItemID)
-	}
-
 	limit := q.Limit
 	if limit <= 0 {
 		limit = 20
 	}
 
-	query, args := buildListNextUpQuery(q, completedIDs, limit)
+	query, args := buildListNextUpQuery(q, limit)
 
 	rows, err := r.pool.Query(ctx, query, args...)
 	if err != nil {
@@ -131,9 +109,9 @@ func (r *NextUpRepository) ListNextUp(ctx context.Context, q NextUpQuery) ([]Nex
 	return results, nil
 }
 
-func buildListNextUpQuery(q NextUpQuery, completedIDs []string, limit int) (string, []interface{}) {
-	args := []interface{}{q.UserID, q.ProfileID, completedIDs, limit}
-	argIdx := 5
+func buildListNextUpQuery(q NextUpQuery, limit int) (string, []interface{}) {
+	args := []interface{}{q.UserID, q.ProfileID, limit}
+	argIdx := 4
 
 	seriesFilter := ""
 	if q.SeriesID != "" {
@@ -188,10 +166,17 @@ func buildListNextUpQuery(q NextUpQuery, completedIDs []string, limit int) (stri
 			WHERE uwp.user_id = $1
 			  AND uwp.profile_id = $2
 			  AND uwp.completed = TRUE
-			  AND uwp.media_item_id = ANY($3)
+			  AND NOT EXISTS (
+				  SELECT 1
+				  FROM user_history_hidden_items hhi
+				  WHERE hhi.user_id = uwp.user_id
+				    AND hhi.profile_id = uwp.profile_id
+				    AND hhi.media_item_id = uwp.media_item_id
+				    AND uwp.updated_at <= hhi.hidden_before
+			  )
 			  %s
 			  %s
-			ORDER BY e.series_id, uwp.updated_at DESC
+			ORDER BY e.series_id, uwp.updated_at DESC, e.season_number DESC, e.episode_number DESC
 		)
 		%s
 		SELECT
@@ -219,7 +204,7 @@ func buildListNextUpQuery(q NextUpQuery, completedIDs []string, limit int) (stri
 			LIMIT 1
 		) next_ep ON true
 		ORDER BY es.updated_at DESC
-		LIMIT $4`, seriesFilter, dateCutoffFilter, inProgressExclusion, sourceTable)
+		LIMIT $3`, seriesFilter, dateCutoffFilter, inProgressExclusion, sourceTable)
 
 	return query, args
 }

--- a/internal/catalog/nextup_repo_test.go
+++ b/internal/catalog/nextup_repo_test.go
@@ -11,13 +11,17 @@ func TestBuildListNextUpQuery_PrefersRecentCompletedOverOlderPartialProgress(t *
 	query, args := buildListNextUpQuery(NextUpQuery{
 		UserID:    7,
 		ProfileID: "profile-1",
-	}, []string{"ep-19", "ep-20"}, 20)
+	}, 20)
 
 	expectedFragments := []string{
 		"eligible_series AS (",
 		"uwp_ip.completed = FALSE",
 		"e_ip.series_id = ce.series_id",
 		"uwp_ip.updated_at > ce.updated_at",
+		"FROM user_history_hidden_items hhi",
+		"uwp.updated_at <= hhi.hidden_before",
+		"ORDER BY e.series_id, uwp.updated_at DESC, e.season_number DESC, e.episode_number DESC",
+		"LIMIT $3",
 	}
 	for _, fragment := range expectedFragments {
 		if !strings.Contains(query, fragment) {
@@ -25,7 +29,11 @@ func TestBuildListNextUpQuery_PrefersRecentCompletedOverOlderPartialProgress(t *
 		}
 	}
 
-	if len(args) != 4 {
+	if strings.Contains(query, "uwp.media_item_id = ANY") {
+		t.Fatalf("query must not cap completed progress before deriving series anchors, got:\n%s", query)
+	}
+
+	if len(args) != 3 {
 		t.Fatalf("expected default arg count, got %d", len(args))
 	}
 }
@@ -37,7 +45,7 @@ func TestBuildListNextUpQuery_EnableResumableSkipsSeriesSuppressionCTE(t *testin
 		UserID:          7,
 		ProfileID:       "profile-1",
 		EnableResumable: true,
-	}, []string{"ep-20"}, 20)
+	}, 20)
 
 	if strings.Contains(query, "eligible_series AS (") {
 		t.Fatalf("expected resumable query to skip eligible_series suppression CTE, got:\n%s", query)


### PR DESCRIPTION
## Summary
- Remove the 100-row completed-progress pre-cap from the Next Up anchor query.
- Derive the latest completed episode anchor per series inside SQL, then apply the requested result limit after valid next-up candidates are found.
- Preserve hidden-history suppression and existing in-progress newer-than-anchor suppression behavior.

## Root Cause
Next Up previously loaded only the 100 most recent completed progress rows before grouping by series. Large imported histories could have those rows dominated by fully-watched series, causing the section to return no candidates even when older completed series had valid next episodes.

## Validation
- `go test ./internal/catalog`
- `go test ./internal/sections`
- Verified the rewritten SQL returns 9 Next Up candidates for dev user 182.
- Deployed to the dev server with `make dev-deploy`; `/api/v1/ready` returned `{"status":"ok"}`.

## AI Use
Implemented with Codex.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed an issue where episodes marked as hidden in user profiles were not being properly excluded from "Next Up" recommendations. Hidden content is now correctly filtered based on individual viewing preferences, ensuring personalized suggestions accurately respect user-defined content restrictions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->