### PR TITLE
fix(web): vitest 4 compatible fetch spy in recipes.test

### DIFF
--- a/web/src/lib/recipes.test.ts
+++ b/web/src/lib/recipes.test.ts
@@ -2,12 +2,12 @@ import { describe, it, expect, vi, beforeEach } from "vitest";
 import { fetchRecipeCatalog, fetchCandidates, previewSection } from "./recipes";
 
 beforeEach(() => {
-  vi.spyOn(global, "fetch" as never).mockReset();
+  vi.spyOn(globalThis, "fetch").mockReset();
 });
 
 describe("recipes API client", () => {
   it("fetchRecipeCatalog returns categories", async () => {
-    vi.spyOn(global, "fetch" as never).mockResolvedValue({
+    vi.spyOn(globalThis, "fetch").mockResolvedValue({
       ok: true,
       status: 200,
       text: async () =>
@@ -19,7 +19,7 @@ describe("recipes API client", () => {
   });
 
   it("fetchCandidates returns candidate list", async () => {
-    vi.spyOn(global, "fetch" as never).mockResolvedValue({
+    vi.spyOn(globalThis, "fetch").mockResolvedValue({
       ok: true,
       status: 200,
       text: async () =>
@@ -33,7 +33,7 @@ describe("recipes API client", () => {
   });
 
   it("previewSection POSTs body and returns items", async () => {
-    vi.spyOn(global, "fetch" as never).mockResolvedValue({
+    vi.spyOn(globalThis, "fetch").mockResolvedValue({
       ok: true,
       status: 200,
       text: async () => JSON.stringify({ items: [{ content_id: "x" }], total_count: 1 }),


### PR DESCRIPTION
## Summary

`origin/main` currently fails `pnpm test` after the vitest 4.1.0 bump. `recipes.test.ts` casts the fetch spy with `vi.spyOn(global, "fetch" as never)`, which vitest 4's stricter typings reject, breaking the build.

This swaps the four occurrences to `vi.spyOn(globalThis, "fetch")`, which type-checks cleanly under vitest 4 and is the idiomatic form.

Isolated hotfix — no behavior change, one file, four lines. Splitting it out so the broken `main` is un-blocked independently of any in-flight feature work.

## Test Plan

- [x] `cd web && pnpm exec vitest run src/lib/recipes.test.ts` → 3/3 pass on vitest 4.1.0
- [ ] CI green on the PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

No user-facing changes in this release. This update includes internal testing infrastructure improvements with no impact on functionality or user experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->