### PR TITLE
feat(autoscan): periodic Radarr/Sonarr import + rename rescans

### DIFF
--- a/cmd/silo/main.go
+++ b/cmd/silo/main.go
@@ -35,6 +35,7 @@ import (
 	"github.com/Silo-Server/silo-server/internal/api"
 	"github.com/Silo-Server/silo-server/internal/api/handlers"
 	"github.com/Silo-Server/silo-server/internal/auth"
+	"github.com/Silo-Server/silo-server/internal/autoscan"
 	"github.com/Silo-Server/silo-server/internal/cache"
 	"github.com/Silo-Server/silo-server/internal/catalog"
 	"github.com/Silo-Server/silo-server/internal/catalogseed"
@@ -73,6 +74,7 @@ import (
 	"github.com/Silo-Server/silo-server/internal/s3client"
 	"github.com/Silo-Server/silo-server/internal/scanner"
 	"github.com/Silo-Server/silo-server/internal/scanqueue"
+	"github.com/Silo-Server/silo-server/internal/scantrigger"
 	"github.com/Silo-Server/silo-server/internal/sections"
 	"github.com/Silo-Server/silo-server/internal/server"
 	"github.com/Silo-Server/silo-server/internal/subtitles"
@@ -1330,6 +1332,17 @@ func main() {
 			requestReconcileSvc.SetEntitlementResolver(mediarequests.NewAccessEntitlements(reconcileResolver))
 		}
 		taskMgr.Register(tasks.NewReconcileRequestsTask(requestReconcileSvc, 100))
+		if deps.FolderRepo != nil && deps.LibraryScanQueue != nil {
+			autoscanSvc := autoscan.NewService(
+				autoscan.NewRepository(deps.DB),
+				autoscan.NewArrHistoryClient(nil),
+				scantrigger.NewResolver(deps.FolderRepo),
+				deps.LibraryScanQueue,
+				autoscan.NewRedisSuppressor(deps.RedisClient),
+				settingsRepo,
+			)
+			taskMgr.Register(tasks.NewAutoscanPollTask(autoscanSvc, autoscanSvc.PollIntervalMinutes(appCtx)))
+		}
 		reconcileProviderIDRepo := catalog.NewProviderIDRepository(deps.DB)
 		reconcileEpisodeRepo := catalog.NewEpisodeRepository(deps.DB)
 		historyResolver := watchstate.NewStableIdentityResolver(nil, reconcileEpisodeRepo, reconcileProviderIDRepo)

--- a/docs/superpowers/plans/2026-06-02-autoscan-arr-polling.md
+++ b/docs/superpowers/plans/2026-06-02-autoscan-arr-polling.md
@@ -1,0 +1,1198 @@
+# Autoscan Arr Polling Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** A periodic task that polls autoscan-enabled Radarr/Sonarr instances for imported files and enqueues targeted Silo library scans for the affected folders.
+
+**Architecture:** A new `internal/autoscan` package: a `Repository` (settings + sources, joining `request_integrations` for URL/key/kind), a `HistoryClient` (reuses `arrclient` to read `/api/v3/history/since`), pure path-rewrite/dedupe helpers, and a `Service.PollOnce` that resolves imported paths via the existing `scantrigger.Resolver` and enqueues into the existing `scanqueue`, with a Redis suppression key to avoid re-scanning a folder back-to-back. Runs as a `taskmanager.Task`.
+
+**Tech Stack:** Go (pgx, `github.com/redis/go-redis/v9`, standard `testing`/`httptest`), PostgreSQL (paired numbered migrations), React/TypeScript.
+
+**Spec:** `docs/superpowers/specs/2026-06-02-autoscan-arr-polling-design.md`
+
+**Commands assume the repository root is the cwd.** Go tests: `go test ./internal/autoscan/...`. Full lint: `make lint`. Frontend: `cd web && pnpm run lint`. The Go toolchain may be at `/tmp/go/bin` — prepend it to `PATH` if `go` is not found. Use the project's disposable test DB for migrations; never touch a live database.
+
+---
+
+## Phase 0 — Branch
+
+- [ ] **Step 0.1: Confirm feature branch**
+
+```bash
+git rev-parse --abbrev-ref HEAD   # expect: feat/autoscan-arr-polling
+```
+If not on it: `git checkout main && git pull && git checkout -b feat/autoscan-arr-polling`.
+
+---
+
+## Phase 1 — Data model
+
+### Task 1: Migration
+
+**Files:**
+- Create: `migrations/<NNN>_autoscan.up.sql`
+- Create: `migrations/<NNN>_autoscan.down.sql`
+
+`<NNN>` is the next sequential migration number. Find it with:
+```bash
+ls migrations/ | grep -oE '^[0-9]+' | sort -n | tail -1
+```
+Use that number + 1 (zero-padded to the same width as neighbors).
+
+- [ ] **Step 1.1: Write the up migration**
+
+```sql
+CREATE TABLE IF NOT EXISTS public.autoscan_settings (
+    id boolean PRIMARY KEY DEFAULT true,
+    enabled boolean NOT NULL DEFAULT false,
+    poll_interval_minutes integer NOT NULL DEFAULT 10,
+    debounce_seconds integer NOT NULL DEFAULT 60,
+    created_at timestamp with time zone DEFAULT now() NOT NULL,
+    updated_at timestamp with time zone DEFAULT now() NOT NULL,
+    CONSTRAINT autoscan_settings_singleton CHECK (id),
+    CONSTRAINT autoscan_settings_interval_positive CHECK (poll_interval_minutes > 0),
+    CONSTRAINT autoscan_settings_debounce_nonneg CHECK (debounce_seconds >= 0)
+);
+
+INSERT INTO public.autoscan_settings (id) VALUES (true) ON CONFLICT (id) DO NOTHING;
+
+CREATE TABLE IF NOT EXISTS public.autoscan_sources (
+    integration_id text PRIMARY KEY
+        REFERENCES public.request_integrations(id) ON DELETE CASCADE,
+    enabled boolean NOT NULL DEFAULT false,
+    path_rewrites jsonb NOT NULL DEFAULT '[]'::jsonb,
+    last_poll_at timestamp with time zone,
+    created_at timestamp with time zone DEFAULT now() NOT NULL,
+    updated_at timestamp with time zone DEFAULT now() NOT NULL
+);
+```
+
+- [ ] **Step 1.2: Write the down migration**
+
+```sql
+DROP TABLE IF EXISTS public.autoscan_sources;
+DROP TABLE IF EXISTS public.autoscan_settings;
+```
+
+- [ ] **Step 1.3: Verify on the disposable DB**
+
+Apply all migrations (including this one) to the throwaway DB used in prior plans, then:
+```bash
+# (reset throwaway DB to baseline + run migrations via the project's migrate path)
+psql "$CI_DATABASE_URL" -c "\d public.autoscan_sources"
+psql "$CI_DATABASE_URL" -c "\d public.autoscan_settings"
+```
+Expected: both tables exist; `autoscan_sources.integration_id` FKs `request_integrations` with `ON DELETE CASCADE`. Also apply the `.down.sql` and confirm it drops cleanly.
+
+- [ ] **Step 1.4: Commit**
+
+```bash
+git add migrations/<NNN>_autoscan.up.sql migrations/<NNN>_autoscan.down.sql
+git commit -m "feat(autoscan): settings and sources schema"
+```
+
+### Task 2: Go types
+
+**Files:**
+- Create: `internal/autoscan/types.go`
+
+- [ ] **Step 2.1: Write the types**
+
+```go
+package autoscan
+
+import "time"
+
+// Settings is the global autoscan configuration (singleton row).
+type Settings struct {
+	Enabled             bool      `json:"enabled"`
+	PollIntervalMinutes int       `json:"poll_interval_minutes"`
+	DebounceSeconds     int       `json:"debounce_seconds"`
+	UpdatedAt           time.Time `json:"updated_at"`
+}
+
+// PathRewrite is an optional prefix translation from an arr path to a Silo path.
+type PathRewrite struct {
+	From string `json:"from"`
+	To   string `json:"to"`
+}
+
+// Source is an autoscan-enabled Radarr/Sonarr instance. Kind/BaseURL/APIKeyRef/Name
+// are read from request_integrations; the rest live in autoscan_sources.
+type Source struct {
+	IntegrationID string        `json:"integration_id"`
+	Kind          string        `json:"kind"`
+	Name          string        `json:"name"`
+	BaseURL       string        `json:"-"`
+	APIKeyRef     string        `json:"-"`
+	Enabled       bool          `json:"enabled"`
+	PathRewrites  []PathRewrite `json:"path_rewrites"`
+	LastPollAt    *time.Time    `json:"last_poll_at,omitempty"`
+}
+
+// SourceUpdate is the admin-editable subset of a source.
+type SourceUpdate struct {
+	Enabled      bool          `json:"enabled"`
+	PathRewrites []PathRewrite `json:"path_rewrites"`
+}
+```
+
+- [ ] **Step 2.2: Build + commit**
+
+```bash
+go build ./internal/autoscan/... && git add internal/autoscan/types.go && git commit -m "feat(autoscan): core types"
+```
+
+---
+
+## Phase 2 — Pure helpers (path rewrite + dedupe)
+
+### Task 3: Path rewrite
+
+**Files:**
+- Create: `internal/autoscan/rewrite.go`
+- Create: `internal/autoscan/rewrite_test.go`
+
+- [ ] **Step 3.1: Write the failing test**
+
+```go
+package autoscan
+
+import "testing"
+
+func TestApplyRewrites(t *testing.T) {
+	rw := []PathRewrite{{From: "/data/media", To: "/mnt/media"}}
+	cases := []struct{ in, want string }{
+		{"/data/media/Movies/Dune/Dune.mkv", "/mnt/media/Movies/Dune/Dune.mkv"}, // prefix match
+		{"/other/path/file.mkv", "/other/path/file.mkv"},                         // no match -> passthrough
+	}
+	for _, tc := range cases {
+		if got := applyRewrites(tc.in, rw); got != tc.want {
+			t.Fatalf("applyRewrites(%q) = %q, want %q", tc.in, got, tc.want)
+		}
+	}
+	// first match wins
+	multi := []PathRewrite{{From: "/data", To: "/A"}, {From: "/data/media", To: "/B"}}
+	if got := applyRewrites("/data/media/x", multi); got != "/A/media/x" {
+		t.Fatalf("first-match: got %q", got)
+	}
+	// empty rewrites -> passthrough
+	if got := applyRewrites("/data/media/x", nil); got != "/data/media/x" {
+		t.Fatalf("nil rewrites: got %q", got)
+	}
+}
+```
+
+- [ ] **Step 3.2: Run it — expect failure**
+
+```bash
+go test ./internal/autoscan/ -run TestApplyRewrites -v
+```
+Expected: FAIL (`applyRewrites` undefined).
+
+- [ ] **Step 3.3: Implement**
+
+`internal/autoscan/rewrite.go`:
+```go
+package autoscan
+
+import "strings"
+
+// applyRewrites returns path with the first matching prefix rewrite applied,
+// or path unchanged when none match.
+func applyRewrites(path string, rewrites []PathRewrite) string {
+	for _, rw := range rewrites {
+		from := strings.TrimSpace(rw.From)
+		if from == "" {
+			continue
+		}
+		if strings.HasPrefix(path, from) {
+			return strings.TrimSpace(rw.To) + strings.TrimPrefix(path, from)
+		}
+	}
+	return path
+}
+```
+
+- [ ] **Step 3.4: Run it — expect pass; commit**
+
+```bash
+go test ./internal/autoscan/ -run TestApplyRewrites -v
+git add internal/autoscan/rewrite.go internal/autoscan/rewrite_test.go
+git commit -m "feat(autoscan): path rewrite helper"
+```
+
+### Task 4: Dedupe imported paths to unique parent folders
+
+**Files:**
+- Create: `internal/autoscan/dedupe.go`
+- Create: `internal/autoscan/dedupe_test.go`
+
+- [ ] **Step 4.1: Write the failing test**
+
+```go
+package autoscan
+
+import (
+	"reflect"
+	"sort"
+	"testing"
+)
+
+func TestUniqueParentDirs(t *testing.T) {
+	in := []string{
+		"/mnt/media/Show/Season 01/E01.mkv",
+		"/mnt/media/Show/Season 01/E02.mkv", // same dir -> collapse
+		"/mnt/media/Movie/Movie.mkv",
+		"", // empty -> ignored
+	}
+	got := uniqueParentDirs(in)
+	sort.Strings(got)
+	want := []string{"/mnt/media/Movie", "/mnt/media/Show/Season 01"}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("uniqueParentDirs = %v, want %v", got, want)
+	}
+}
+```
+
+- [ ] **Step 4.2: Run it — expect failure**
+
+```bash
+go test ./internal/autoscan/ -run TestUniqueParentDirs -v
+```
+Expected: FAIL (`uniqueParentDirs` undefined).
+
+- [ ] **Step 4.3: Implement**
+
+`internal/autoscan/dedupe.go`:
+```go
+package autoscan
+
+import "path/filepath"
+
+// uniqueParentDirs maps imported file paths to their distinct parent directories,
+// dropping empties. A season's episodes in one folder collapse to one entry.
+func uniqueParentDirs(paths []string) []string {
+	seen := make(map[string]struct{})
+	var out []string
+	for _, p := range paths {
+		if p == "" {
+			continue
+		}
+		dir := filepath.Dir(p)
+		if _, ok := seen[dir]; ok {
+			continue
+		}
+		seen[dir] = struct{}{}
+		out = append(out, dir)
+	}
+	return out
+}
+```
+
+- [ ] **Step 4.4: Run it — expect pass; commit**
+
+```bash
+go test ./internal/autoscan/ -run TestUniqueParentDirs -v
+git add internal/autoscan/dedupe.go internal/autoscan/dedupe_test.go
+git commit -m "feat(autoscan): dedupe imported paths to parent folders"
+```
+
+---
+
+## Phase 3 — Arr history client
+
+### Task 5: ImportedPaths from /api/v3/history/since
+
+**Files:**
+- Create: `internal/autoscan/history.go`
+- Create: `internal/autoscan/history_test.go`
+
+- [ ] **Step 5.1: Write the failing test (httptest)**
+
+```go
+package autoscan
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"sort"
+	"testing"
+	"time"
+)
+
+func TestArrHistoryImportedPaths(t *testing.T) {
+	// Both Radarr and Sonarr return history records with a string eventType and
+	// data.importedPath on downloadFolderImported events.
+	body := `[
+	  {"eventType":"downloadFolderImported","data":{"importedPath":"/mnt/media/Movies/Dune (2021)/Dune.mkv"}},
+	  {"eventType":"grabbed","data":{"importedPath":"/should/be/ignored"}},
+	  {"eventType":"downloadFolderImported","data":{"importedPath":"/mnt/media/Show/S01/E01.mkv"}}
+	]`
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/api/v3/history/since" {
+			t.Errorf("unexpected path %s", r.URL.Path)
+		}
+		if r.URL.Query().Get("date") == "" {
+			t.Errorf("missing date param")
+		}
+		if r.Header.Get("X-Api-Key") != "k" {
+			t.Errorf("missing api key header")
+		}
+		_, _ = w.Write([]byte(body))
+	}))
+	defer srv.Close()
+
+	c := NewArrHistoryClient(nil)
+	paths, err := c.ImportedPaths(context.Background(), srv.URL, "k", time.Unix(0, 0).UTC())
+	if err != nil {
+		t.Fatalf("ImportedPaths: %v", err)
+	}
+	sort.Strings(paths)
+	want := []string{"/mnt/media/Movies/Dune (2021)/Dune.mkv", "/mnt/media/Show/S01/E01.mkv"}
+	if len(paths) != 2 || paths[0] != want[0] || paths[1] != want[1] {
+		t.Fatalf("ImportedPaths = %v, want %v", paths, want)
+	}
+}
+```
+
+> Verify the `arrclient` sets the API key as the `X-Api-Key` header (read `internal/requests/arrclient/client.go` `DoJSON`). If it uses a query param instead, adjust the test's assertion to match — do not change the client.
+
+- [ ] **Step 5.2: Run it — expect failure**
+
+```bash
+go test ./internal/autoscan/ -run TestArrHistoryImportedPaths -v
+```
+Expected: FAIL (`NewArrHistoryClient` undefined).
+
+- [ ] **Step 5.3: Implement**
+
+`internal/autoscan/history.go`:
+```go
+package autoscan
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/url"
+	"time"
+
+	"github.com/Silo-Server/silo-server/internal/requests/arrclient"
+)
+
+// HistoryClient reads recently-imported file paths from a Radarr/Sonarr instance.
+type HistoryClient interface {
+	ImportedPaths(ctx context.Context, baseURL, apiKey string, since time.Time) ([]string, error)
+}
+
+type historyRecord struct {
+	EventType string `json:"eventType"`
+	Data      struct {
+		ImportedPath string `json:"importedPath"`
+	} `json:"data"`
+}
+
+const importedEventType = "downloadFolderImported"
+
+type arrHistoryClient struct {
+	httpClient *http.Client
+}
+
+// NewArrHistoryClient returns a HistoryClient backed by the shared arrclient.
+func NewArrHistoryClient(httpClient *http.Client) HistoryClient {
+	return &arrHistoryClient{httpClient: httpClient}
+}
+
+func (c *arrHistoryClient) ImportedPaths(ctx context.Context, baseURL, apiKey string, since time.Time) ([]string, error) {
+	client := arrclient.New(baseURL, apiKey, c.httpClient)
+	q := url.Values{}
+	q.Set("date", since.UTC().Format(time.RFC3339))
+	var records []historyRecord
+	if err := client.GetJSON(ctx, "/api/v3/history/since?"+q.Encode(), &records); err != nil {
+		return nil, fmt.Errorf("autoscan: poll history: %w", err)
+	}
+	var paths []string
+	for _, rec := range records {
+		if rec.EventType != importedEventType {
+			continue
+		}
+		if rec.Data.ImportedPath != "" {
+			paths = append(paths, rec.Data.ImportedPath)
+		}
+	}
+	return paths, nil
+}
+```
+
+- [ ] **Step 5.4: Run it — expect pass; commit**
+
+```bash
+go test ./internal/autoscan/ -run TestArrHistoryImportedPaths -v
+git add internal/autoscan/history.go internal/autoscan/history_test.go
+git commit -m "feat(autoscan): arr import-history client"
+```
+
+---
+
+## Phase 4 — Repository
+
+### Task 6: autoscan repository
+
+**Files:**
+- Create: `internal/autoscan/repository.go`
+
+- [ ] **Step 6.1: Implement the repository**
+
+```go
+package autoscan
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"time"
+
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgxpool"
+)
+
+type Repository struct{ pool *pgxpool.Pool }
+
+func NewRepository(pool *pgxpool.Pool) *Repository { return &Repository{pool: pool} }
+
+func (r *Repository) GetSettings(ctx context.Context) (Settings, error) {
+	var s Settings
+	err := r.pool.QueryRow(ctx, `
+		SELECT enabled, poll_interval_minutes, debounce_seconds, updated_at
+		FROM autoscan_settings WHERE id = true`).
+		Scan(&s.Enabled, &s.PollIntervalMinutes, &s.DebounceSeconds, &s.UpdatedAt)
+	if err != nil {
+		return Settings{}, fmt.Errorf("get autoscan settings: %w", err)
+	}
+	return s, nil
+}
+
+func (r *Repository) UpdateSettings(ctx context.Context, s Settings) (Settings, error) {
+	var out Settings
+	err := r.pool.QueryRow(ctx, `
+		UPDATE autoscan_settings
+		SET enabled = $1, poll_interval_minutes = $2, debounce_seconds = $3, updated_at = now()
+		WHERE id = true
+		RETURNING enabled, poll_interval_minutes, debounce_seconds, updated_at`,
+		s.Enabled, s.PollIntervalMinutes, s.DebounceSeconds).
+		Scan(&out.Enabled, &out.PollIntervalMinutes, &out.DebounceSeconds, &out.UpdatedAt)
+	if err != nil {
+		return Settings{}, fmt.Errorf("update autoscan settings: %w", err)
+	}
+	return out, nil
+}
+
+// sourceColumns selects an autoscan source joined with its request_integrations row.
+// LEFT JOIN so a source row whose instance was deleted still surfaces (it will be
+// pruned by the FK cascade in practice, but the join stays defensive).
+const sourceSelect = `
+	SELECT ri.id, ri.kind, ri.name, ri.base_url, ri.api_key_ref,
+	       COALESCE(s.enabled, false), COALESCE(s.path_rewrites, '[]'::jsonb), s.last_poll_at
+	FROM request_integrations ri
+	LEFT JOIN autoscan_sources s ON s.integration_id = ri.id`
+
+func scanSource(row interface{ Scan(...any) error }) (Source, error) {
+	var src Source
+	var rewritesRaw []byte
+	var lastPoll *time.Time
+	if err := row.Scan(&src.IntegrationID, &src.Kind, &src.Name, &src.BaseURL, &src.APIKeyRef,
+		&src.Enabled, &rewritesRaw, &lastPoll); err != nil {
+		return Source{}, err
+	}
+	if len(rewritesRaw) > 0 {
+		if err := json.Unmarshal(rewritesRaw, &src.PathRewrites); err != nil {
+			return Source{}, fmt.Errorf("unmarshal path_rewrites for %s: %w", src.IntegrationID, err)
+		}
+	}
+	src.LastPollAt = lastPoll
+	return src, nil
+}
+
+// ListAllSources returns every Radarr/Sonarr instance with its autoscan state
+// (for the admin UI — includes disabled).
+func (r *Repository) ListAllSources(ctx context.Context) ([]Source, error) {
+	rows, err := r.pool.Query(ctx, sourceSelect+` ORDER BY ri.kind, ri.name`)
+	if err != nil {
+		return nil, fmt.Errorf("list autoscan sources: %w", err)
+	}
+	defer rows.Close()
+	var out []Source
+	for rows.Next() {
+		src, err := scanSource(rows)
+		if err != nil {
+			return nil, err
+		}
+		out = append(out, src)
+	}
+	return out, rows.Err()
+}
+
+// ListEnabledSources returns only autoscan-enabled instances whose underlying
+// integration is itself enabled (the poll set).
+func (r *Repository) ListEnabledSources(ctx context.Context) ([]Source, error) {
+	rows, err := r.pool.Query(ctx, sourceSelect+
+		` WHERE s.enabled = true AND ri.enabled = true ORDER BY ri.kind, ri.name`)
+	if err != nil {
+		return nil, fmt.Errorf("list enabled autoscan sources: %w", err)
+	}
+	defer rows.Close()
+	var out []Source
+	for rows.Next() {
+		src, err := scanSource(rows)
+		if err != nil {
+			return nil, err
+		}
+		out = append(out, src)
+	}
+	return out, rows.Err()
+}
+
+// UpsertSource sets the per-instance autoscan toggle + rewrites.
+func (r *Repository) UpsertSource(ctx context.Context, integrationID string, u SourceUpdate) (*Source, error) {
+	rewrites, err := json.Marshal(u.PathRewrites)
+	if err != nil {
+		return nil, fmt.Errorf("marshal path_rewrites: %w", err)
+	}
+	if u.PathRewrites == nil {
+		rewrites = []byte("[]")
+	}
+	if _, err := r.pool.Exec(ctx, `
+		INSERT INTO autoscan_sources (integration_id, enabled, path_rewrites, updated_at)
+		VALUES ($1, $2, $3, now())
+		ON CONFLICT (integration_id) DO UPDATE SET
+			enabled = EXCLUDED.enabled,
+			path_rewrites = EXCLUDED.path_rewrites,
+			updated_at = now()`,
+		integrationID, u.Enabled, rewrites); err != nil {
+		return nil, fmt.Errorf("upsert autoscan source: %w", err)
+	}
+	row := r.pool.QueryRow(ctx, sourceSelect+` WHERE ri.id = $1`, integrationID)
+	src, err := scanSource(row)
+	if err != nil {
+		if err == pgx.ErrNoRows {
+			return nil, fmt.Errorf("integration not found: %s", integrationID)
+		}
+		return nil, err
+	}
+	return &src, nil
+}
+
+// AdvanceLastPoll sets last_poll_at for a source (creating the row if needed).
+func (r *Repository) AdvanceLastPoll(ctx context.Context, integrationID string, at time.Time) error {
+	_, err := r.pool.Exec(ctx, `
+		INSERT INTO autoscan_sources (integration_id, last_poll_at, updated_at)
+		VALUES ($1, $2, now())
+		ON CONFLICT (integration_id) DO UPDATE SET last_poll_at = $2, updated_at = now()`,
+		integrationID, at)
+	if err != nil {
+		return fmt.Errorf("advance autoscan last_poll: %w", err)
+	}
+	return nil
+}
+```
+
+- [ ] **Step 6.2: Build + commit**
+
+```bash
+go build ./internal/autoscan/...
+git add internal/autoscan/repository.go
+git commit -m "feat(autoscan): settings + sources repository"
+```
+
+> The repository is exercised end-to-end by the `PollOnce` service tests (Task 8) via a fake store, and by the migration check (Task 1). A DB-backed repo test is optional; if the project has a Postgres test harness, add `repository_test.go` mirroring the requests repo tests.
+
+---
+
+## Phase 5 — Service
+
+### Task 7: Suppression (Redis) seam
+
+**Files:**
+- Create: `internal/autoscan/suppress.go`
+
+- [ ] **Step 7.1: Implement the suppressor**
+
+```go
+package autoscan
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/redis/go-redis/v9"
+)
+
+// Suppressor prevents re-enqueuing a scan for the same folder within a window.
+type Suppressor interface {
+	// ShouldScan atomically claims the folder for scanning: returns true and sets
+	// a TTL key if no claim exists, false if a recent claim is still live.
+	ShouldScan(ctx context.Context, folderID int, ttl time.Duration) (bool, error)
+}
+
+type redisSuppressor struct{ client *redis.Client }
+
+func NewRedisSuppressor(client *redis.Client) Suppressor { return &redisSuppressor{client: client} }
+
+func (s *redisSuppressor) ShouldScan(ctx context.Context, folderID int, ttl time.Duration) (bool, error) {
+	if s.client == nil || ttl <= 0 {
+		return true, nil // no suppression configured -> always scan
+	}
+	key := fmt.Sprintf("autoscan:scanned:%d", folderID)
+	ok, err := s.client.SetNX(ctx, key, "1", ttl).Result()
+	if err != nil {
+		return true, nil // fail open: a Redis hiccup should not block scanning
+	}
+	return ok, nil
+}
+```
+
+- [ ] **Step 7.2: Build + commit**
+
+```bash
+go build ./internal/autoscan/...
+git add internal/autoscan/suppress.go
+git commit -m "feat(autoscan): redis scan-suppression seam"
+```
+
+### Task 8: Service.PollOnce
+
+**Files:**
+- Create: `internal/autoscan/service.go`
+- Create: `internal/autoscan/service_test.go`
+
+- [ ] **Step 8.1: Write the failing test**
+
+```go
+package autoscan
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/Silo-Server/silo-server/internal/models"
+	"github.com/Silo-Server/silo-server/internal/scantrigger"
+)
+
+type fakeStore struct {
+	settings  Settings
+	sources   []Source
+	advanced  map[string]time.Time
+}
+
+func (f *fakeStore) GetSettings(context.Context) (Settings, error)        { return f.settings, nil }
+func (f *fakeStore) ListEnabledSources(context.Context) ([]Source, error) { return f.sources, nil }
+func (f *fakeStore) AdvanceLastPoll(_ context.Context, id string, at time.Time) error {
+	if f.advanced == nil {
+		f.advanced = map[string]time.Time{}
+	}
+	f.advanced[id] = at
+	return nil
+}
+
+type fakeHistory struct {
+	paths map[string][]string // baseURL -> imported paths
+	err   error
+}
+
+func (f *fakeHistory) ImportedPaths(_ context.Context, baseURL, _ string, _ time.Time) ([]string, error) {
+	if f.err != nil {
+		return nil, f.err
+	}
+	return f.paths[baseURL], nil
+}
+
+type fakeResolver struct{}
+
+func (fakeResolver) Resolve(_ context.Context, req scantrigger.Request) (*scantrigger.Target, error) {
+	// Resolve any /mnt/media path to folder 7; anything else is unresolvable.
+	if len(req.Path) >= 11 && req.Path[:11] == "/mnt/media/" {
+		return &scantrigger.Target{Folder: &models.MediaFolder{ID: 7}, Mode: scantrigger.ModeSubtree, Path: req.Path, Trigger: req.Trigger}, nil
+	}
+	return nil, nil
+}
+
+type recordingQueuer struct{ enqueued []scantrigger.Target }
+
+func (q *recordingQueuer) EnqueueScans(_ context.Context, targets []scantrigger.Target) error {
+	q.enqueued = append(q.enqueued, targets...)
+	return nil
+}
+
+type allowSuppressor struct{}
+
+func (allowSuppressor) ShouldScan(context.Context, int, time.Duration) (bool, error) { return true, nil }
+
+func TestPollOnceEnqueuesDedupedFolders(t *testing.T) {
+	store := &fakeStore{
+		settings: Settings{Enabled: true, PollIntervalMinutes: 10, DebounceSeconds: 60},
+		sources: []Source{{
+			IntegrationID: "i1", Kind: "sonarr", BaseURL: "http://sonarr", APIKeyRef: "k", Enabled: true,
+		}},
+	}
+	hist := &fakeHistory{paths: map[string][]string{
+		"http://sonarr": {
+			"/mnt/media/Show/S01/E01.mkv",
+			"/mnt/media/Show/S01/E02.mkv", // same folder -> dedup
+			"/outside/lib/x.mkv",          // unresolvable -> skipped
+		},
+	}}
+	q := &recordingQueuer{}
+	svc := NewService(store, hist, fakeResolver{}, q, allowSuppressor{}, nil)
+	if err := svc.PollOnce(context.Background()); err != nil {
+		t.Fatalf("PollOnce: %v", err)
+	}
+	if len(q.enqueued) != 1 {
+		t.Fatalf("expected 1 deduped folder scan, got %d: %+v", len(q.enqueued), q.enqueued)
+	}
+	if q.enqueued[0].Trigger != "autoscan" || q.enqueued[0].Folder.ID != 7 {
+		t.Fatalf("unexpected target: %+v", q.enqueued[0])
+	}
+	if _, ok := store.advanced["i1"]; !ok {
+		t.Fatalf("expected last_poll advanced for i1")
+	}
+}
+
+func TestPollOnceDisabledNoop(t *testing.T) {
+	store := &fakeStore{settings: Settings{Enabled: false}}
+	q := &recordingQueuer{}
+	svc := NewService(store, &fakeHistory{}, fakeResolver{}, q, allowSuppressor{}, nil)
+	if err := svc.PollOnce(context.Background()); err != nil {
+		t.Fatalf("PollOnce: %v", err)
+	}
+	if len(q.enqueued) != 0 {
+		t.Fatalf("disabled autoscan should enqueue nothing, got %d", len(q.enqueued))
+	}
+}
+```
+
+- [ ] **Step 8.2: Run it — expect failure**
+
+```bash
+go test ./internal/autoscan/ -run TestPollOnce -v
+```
+Expected: FAIL (`NewService` undefined).
+
+- [ ] **Step 8.3: Implement**
+
+`internal/autoscan/service.go`:
+```go
+package autoscan
+
+import (
+	"context"
+	"log/slog"
+	"time"
+
+	"github.com/Silo-Server/silo-server/internal/scantrigger"
+)
+
+const scanTrigger = "autoscan"
+
+// Store is the persistence the service needs.
+type Store interface {
+	GetSettings(ctx context.Context) (Settings, error)
+	ListEnabledSources(ctx context.Context) ([]Source, error)
+	AdvanceLastPoll(ctx context.Context, integrationID string, at time.Time) error
+}
+
+// Resolver maps a filesystem path to a Silo scan target.
+type Resolver interface {
+	Resolve(ctx context.Context, req scantrigger.Request) (*scantrigger.Target, error)
+}
+
+// Queuer enqueues resolved scan targets.
+type Queuer interface {
+	EnqueueScans(ctx context.Context, targets []scantrigger.Target) error
+}
+
+// SecretResolver decrypts an api_key_ref into a usable key.
+type SecretResolver interface {
+	Get(ctx context.Context, key string) (string, error)
+}
+
+type Service struct {
+	store    Store
+	history  HistoryClient
+	resolver Resolver
+	queue    Queuer
+	suppress Suppressor
+	secrets  SecretResolver
+	now      func() time.Time
+}
+
+func NewService(store Store, history HistoryClient, resolver Resolver, queue Queuer, suppress Suppressor, secrets SecretResolver) *Service {
+	return &Service{
+		store: store, history: history, resolver: resolver, queue: queue,
+		suppress: suppress, secrets: secrets,
+		now: func() time.Time { return time.Now().UTC() },
+	}
+}
+
+// PollOnce runs one autoscan cycle. Per-source failures are logged and skipped;
+// only the overall settings/listing errors propagate.
+func (s *Service) PollOnce(ctx context.Context) error {
+	settings, err := s.store.GetSettings(ctx)
+	if err != nil {
+		return err
+	}
+	if !settings.Enabled {
+		return nil
+	}
+	sources, err := s.store.ListEnabledSources(ctx)
+	if err != nil {
+		return err
+	}
+	ttl := time.Duration(settings.DebounceSeconds) * time.Second
+
+	for _, src := range sources {
+		cycleStart := s.now()
+		// First enable: last_poll_at null -> floor at cycleStart (don't replay history).
+		since := cycleStart
+		if src.LastPollAt != nil {
+			since = *src.LastPollAt
+		}
+
+		apiKey := src.APIKeyRef
+		if s.secrets != nil && apiKey != "" {
+			if resolved, rerr := s.secrets.Get(ctx, apiKey); rerr == nil && resolved != "" {
+				apiKey = resolved
+			}
+		}
+
+		paths, perr := s.history.ImportedPaths(ctx, src.BaseURL, apiKey, since)
+		if perr != nil {
+			slog.WarnContext(ctx, "autoscan: source poll failed", "integration_id", src.IntegrationID, "err", perr)
+			continue // do not advance last_poll -> retry window next cycle
+		}
+
+		// rewrite -> dedupe -> resolve -> suppress -> enqueue
+		rewritten := make([]string, 0, len(paths))
+		for _, p := range paths {
+			rewritten = append(rewritten, applyRewrites(p, src.PathRewrites))
+		}
+		var targets []scantrigger.Target
+		for _, dir := range uniqueParentDirs(rewritten) {
+			target, rerr := s.resolver.Resolve(ctx, scantrigger.Request{Path: dir, Trigger: scanTrigger})
+			if rerr != nil {
+				slog.WarnContext(ctx, "autoscan: resolve failed", "path", dir, "err", rerr)
+				continue
+			}
+			if target == nil || target.Folder == nil {
+				continue // outside Silo's media folders
+			}
+			ok, serr := s.suppress.ShouldScan(ctx, target.Folder.ID, ttl)
+			if serr != nil || !ok {
+				continue
+			}
+			target.Trigger = scanTrigger
+			targets = append(targets, *target)
+		}
+		if len(targets) > 0 {
+			if eerr := s.queue.EnqueueScans(ctx, targets); eerr != nil {
+				slog.WarnContext(ctx, "autoscan: enqueue failed", "integration_id", src.IntegrationID, "err", eerr)
+				continue // do not advance -> retry
+			}
+		}
+		if aerr := s.store.AdvanceLastPoll(ctx, src.IntegrationID, cycleStart); aerr != nil {
+			slog.WarnContext(ctx, "autoscan: advance last_poll failed", "integration_id", src.IntegrationID, "err", aerr)
+		}
+	}
+	return nil
+}
+```
+
+- [ ] **Step 8.4: Run tests — expect pass**
+
+```bash
+go test ./internal/autoscan/... -v
+```
+Expected: all PASS. (`Service.PollOnce`, rewrite, dedupe, history.)
+
+- [ ] **Step 8.5: Commit**
+
+```bash
+git add internal/autoscan/service.go internal/autoscan/service_test.go
+git commit -m "feat(autoscan): PollOnce poll cycle"
+```
+
+---
+
+## Phase 6 — Task + wiring
+
+### Task 9: Poll task + main.go wiring
+
+**Files:**
+- Create: `internal/taskmanager/tasks/autoscan_poll.go`
+- Modify: `cmd/silo/main.go` (construct the service + register the task)
+- Modify: `internal/api/router.go` (if the service/handler is built there instead)
+
+- [ ] **Step 9.1: Implement the task** (mirror `reconcile_requests.go`)
+
+```go
+package tasks
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/Silo-Server/silo-server/internal/taskmanager"
+)
+
+type AutoscanPoller interface {
+	PollOnce(ctx context.Context) error
+	PollIntervalMinutes(ctx context.Context) int
+}
+
+type AutoscanPollTask struct {
+	poller          AutoscanPoller
+	intervalMinutes int
+}
+
+func NewAutoscanPollTask(poller AutoscanPoller, intervalMinutes int) *AutoscanPollTask {
+	if intervalMinutes <= 0 {
+		intervalMinutes = 10
+	}
+	return &AutoscanPollTask{poller: poller, intervalMinutes: intervalMinutes}
+}
+
+func (t *AutoscanPollTask) Key() string  { return "autoscan_poll" }
+func (t *AutoscanPollTask) Name() string { return "Autoscan Poll" }
+func (t *AutoscanPollTask) Description() string {
+	return "Polls autoscan-enabled Radarr/Sonarr instances for imported files and scans the affected folders"
+}
+func (t *AutoscanPollTask) Category() taskmanager.TaskCategory { return taskmanager.TaskCategoryLibrary }
+func (t *AutoscanPollTask) IsHidden() bool                     { return false }
+
+func (t *AutoscanPollTask) DefaultTriggers() []taskmanager.TriggerConfig {
+	return []taskmanager.TriggerConfig{
+		{Type: taskmanager.TriggerTypeInterval, IntervalMs: int64(t.intervalMinutes) * 60 * 1000},
+	}
+}
+
+func (t *AutoscanPollTask) Execute(ctx context.Context, progress taskmanager.ProgressReporter) error {
+	progress.Report(0, "Polling arr instances")
+	if t.poller == nil {
+		progress.Report(100, "Autoscan unavailable")
+		return nil
+	}
+	if err := t.poller.PollOnce(ctx); err != nil {
+		return fmt.Errorf("autoscan poll: %w", err)
+	}
+	progress.Report(100, "Autoscan poll complete")
+	return nil
+}
+```
+
+> Add a `PollIntervalMinutes(ctx)` helper to the autoscan `Service` (reads `GetSettings`, falls back to 10) so `main.go` can seed `DefaultTriggers`. Keep it tolerant of errors (return 10 on failure).
+
+- [ ] **Step 9.2: Construct the service and register the task in `main.go`**
+
+Find where `libraryScanQueue` (`deps.LibraryScanQueue`), `deps.FolderRepo`, `deps.RedisClient`, `settingsRepo`, and `taskMgr.Register(...)` are in scope (around the other `taskMgr.Register` calls). Build:
+
+```go
+autoscanResolver := scantrigger.NewResolver(deps.FolderRepo) // FolderRepo satisfies scantrigger.FolderRepository
+autoscanSvc := autoscan.NewService(
+	autoscan.NewRepository(deps.DB),
+	autoscan.NewArrHistoryClient(nil),
+	autoscanResolver,
+	deps.LibraryScanQueue, // *scanqueue.Service satisfies autoscan.Queuer (EnqueueScans)
+	autoscan.NewRedisSuppressor(deps.RedisClient),
+	settingsRepo,          // ServerSettingsRepo satisfies autoscan.SecretResolver (Get)
+)
+taskMgr.Register(tasks.NewAutoscanPollTask(autoscanSvc, autoscanSvc.PollIntervalMinutes(ctx)))
+```
+
+Guard each dependency for nil exactly like neighboring registrations (e.g. only register when `deps.FolderRepo != nil && deps.LibraryScanQueue != nil`). If `scantrigger.NewResolver` needs a concrete repo type, pass `deps.FolderRepo` (it already satisfies `GetByID`/`List`). Confirm `*scanqueue.Service` has `EnqueueScans(ctx, []scantrigger.Target) error` (it does) so it satisfies `autoscan.Queuer`.
+
+- [ ] **Step 9.3: Build the whole server**
+
+```bash
+go build ./...   # requires libvips locally; if unavailable, build ./internal/... ./cmd/... minus the bimg-dependent packages, and rely on CI/Docker for the full build
+go vet ./internal/autoscan/... ./internal/taskmanager/...
+```
+Expected: autoscan + taskmanager packages build/vet clean.
+
+- [ ] **Step 9.4: Commit**
+
+```bash
+git add internal/taskmanager/tasks/autoscan_poll.go cmd/silo/main.go
+git commit -m "feat(autoscan): poll task and wiring"
+```
+
+---
+
+## Phase 7 — Admin API
+
+### Task 10: Autoscan handlers + routes
+
+**Files:**
+- Create: `internal/api/handlers/autoscan.go`
+- Create: `internal/api/handlers/autoscan_test.go`
+- Modify: `internal/api/router.go` (mount routes)
+
+- [ ] **Step 10.1: Service methods the handler needs**
+
+Add to `internal/autoscan/service.go` (admin-facing, thin wrappers over the repo; the service already holds the store as the narrow `Store` interface — widen the concrete service to also expose these by holding the `*Repository` or adding methods to `Store`). Simplest: have the handler take the `*autoscan.Repository` directly for reads/writes and the `*autoscan.Service` for `PollOnce`. Implement handler methods:
+- `GET /autoscan/settings` → `repo.GetSettings`
+- `PUT /autoscan/settings` → validate (`poll_interval_minutes > 0`, `debounce_seconds >= 0`) → `repo.UpdateSettings`
+- `GET /autoscan/sources` → `repo.ListAllSources` (map to a response that omits `BaseURL`/`APIKeyRef` — they have `json:"-"` already, so the `Source` struct is safe to return directly)
+- `PUT /autoscan/sources/{id}` → decode `SourceUpdate` → `repo.UpsertSource`
+- `POST /autoscan/trigger` → `service.PollOnce` (run in a short-lived goroutine or inline; return 202)
+- `GET /autoscan/status` → `{enabled, sources:[{integration_id, name, last_poll_at}]}` from `repo.GetSettings` + `repo.ListAllSources`
+
+Follow the existing admin handler style in `internal/api/handlers/requests.go` (viewer/admin extraction, `writeJSON`, error mapping helper, chi `URLParam`).
+
+- [ ] **Step 10.2: Mount routes in `router.go`**
+
+Near the request-integration routes (admin group), add:
+```go
+autoscanHandler := handlers.NewAutoscanHandler(autoscanRepo, autoscanSvc)
+r.Route("/autoscan", func(r chi.Router) {
+	r.Get("/settings", autoscanHandler.HandleGetSettings)
+	r.Put("/settings", autoscanHandler.HandleUpdateSettings)
+	r.Get("/sources", autoscanHandler.HandleListSources)
+	r.Put("/sources/{id}", autoscanHandler.HandleUpsertSource)
+	r.Post("/trigger", autoscanHandler.HandleTrigger)
+	r.Get("/status", autoscanHandler.HandleStatus)
+})
+```
+Apply the same admin auth + a rate limiter on `/trigger` (tight per-admin cap) consistent with other admin mutation routes.
+
+- [ ] **Step 10.3: Handler test**
+
+Add `autoscan_test.go` with a fake repo/service asserting: GET settings returns JSON; PUT validates a non-positive interval (400); `/sources` response never contains `base_url`/`api_key_ref`; `/trigger` invokes `PollOnce`. Mirror `requests_test.go`'s fake-service pattern.
+
+- [ ] **Step 10.4: Build (handlers pkg needs libvips — verify in Docker/CI), gofmt, commit**
+
+```bash
+gofmt -l internal/api/handlers/autoscan.go internal/api/router.go
+git add internal/api/handlers/autoscan.go internal/api/handlers/autoscan_test.go internal/api/router.go
+git commit -m "feat(autoscan): admin API endpoints"
+```
+
+---
+
+## Phase 8 — Frontend
+
+> Follow existing patterns in `web/src/pages/AdminRequests.tsx`, `web/src/api/types.ts`, and `web/src/hooks/queries/useRequests.ts`. Each task ends with `cd web && pnpm exec tsc -b` (the REAL typecheck — `tsc --noEmit` checks nothing), `pnpm run lint`, `pnpm exec prettier --check <files>`.
+
+### Task 11: Types + hooks
+
+**Files:**
+- Modify: `web/src/api/types.ts`
+- Create: `web/src/hooks/queries/useAutoscan.ts`
+
+- [ ] **Step 11.1: Types**
+
+Add to `types.ts`:
+```ts
+export interface AutoscanSettings {
+  enabled: boolean;
+  poll_interval_minutes: number;
+  debounce_seconds: number;
+  updated_at?: string;
+}
+export interface AutoscanPathRewrite {
+  from: string;
+  to: string;
+}
+export interface AutoscanSource {
+  integration_id: string;
+  kind: string;
+  name: string;
+  enabled: boolean;
+  path_rewrites: AutoscanPathRewrite[];
+  last_poll_at?: string | null;
+}
+```
+
+- [ ] **Step 11.2: Hooks**
+
+`useAutoscan.ts`: `useAutoscanSettings()` (GET `/admin/autoscan/settings`), `useUpdateAutoscanSettings()` (PUT), `useAutoscanSources()` (GET `/admin/autoscan/sources`), `useUpdateAutoscanSource()` (PUT `/admin/autoscan/sources/{id}`), `useTriggerAutoscan()` (POST `/admin/autoscan/trigger`). Match the mutation/query/invalidation/toast conventions in `useRequests.ts`.
+
+- [ ] **Step 11.3: Lint + commit**
+
+```bash
+cd web && pnpm exec tsc -b && pnpm run lint && pnpm exec prettier --check src/api/types.ts src/hooks/queries/useAutoscan.ts
+git add web/src/api/types.ts web/src/hooks/queries/useAutoscan.ts
+git commit -m "feat(web): autoscan types and hooks"
+```
+
+### Task 12: Autoscan tab
+
+**Files:**
+- Modify: `web/src/pages/AdminRequests.tsx`
+
+- [ ] **Step 12.1: Add the tab**
+
+Add `"autoscan"` to `ADMIN_REQUEST_TABS`, a `<TabsTrigger value="autoscan">Autoscan</TabsTrigger>`, and a `<TabsContent value="autoscan"><AutoscanTab /></TabsContent>`. Implement `AutoscanTab`:
+- Global settings card: enable `SwitchField`, poll-interval `Input` (number, min 1), debounce-seconds `Input` (number, min 0), Save button (`useUpdateAutoscanSettings`).
+- Per-source list (`useAutoscanSources`): one row per instance — name + kind badge, an autoscan `SwitchField`, a collapsible path-rewrite editor (add/remove `from → to` rows), read-only "Last polled" (`last_poll_at`), and a Save button (`useUpdateAutoscanSource`).
+- A "Poll now" button (`useTriggerAutoscan`) with a success toast.
+
+Reuse `Field`, `SwitchField`, `Input`, `Button`, `Badge` already in the file.
+
+- [ ] **Step 12.2: Lint + commit**
+
+```bash
+cd web && pnpm exec tsc -b && pnpm run lint && pnpm exec prettier --check src/pages/AdminRequests.tsx
+git add web/src/pages/AdminRequests.tsx
+git commit -m "feat(web): autoscan admin tab"
+```
+
+---
+
+## Phase 9 — Verification
+
+### Task 13: Full verification
+
+- [ ] **Step 13.1: Go**
+
+```bash
+go test ./internal/autoscan/... ./internal/taskmanager/... 2>&1 | tail
+go vet ./internal/autoscan/...
+gofmt -l internal/autoscan internal/taskmanager/tasks/autoscan_poll.go
+```
+Expected: all tests pass; vet + gofmt clean.
+
+- [ ] **Step 13.2: Frontend**
+
+```bash
+cd web && pnpm exec tsc -b && pnpm run lint && pnpm run format:check
+```
+
+- [ ] **Step 13.3: Docker build (closes the libvips gap)**
+
+```bash
+docker build --build-arg BUILD_REVISION=$(git rev-parse HEAD) --build-arg BUILD_DIRTY=false -t silo-server:autoscan .
+```
+Expected: exit 0 (proves the handlers package + full vite build compile).
+
+- [ ] **Step 13.4: Smoke (optional, local deploy)**
+
+Enable autoscan in the Autoscan tab, toggle a Radarr/Sonarr source on, import something in that arr (or "Poll now"), and confirm a scan with `trigger=autoscan` appears in the scan history and the folder is scanned.
+
+- [ ] **Step 13.5: `make verify-local-paths`**
+
+```bash
+make verify-local-paths
+```
+
+---
+
+## Self-review notes (resolved)
+
+- **Spec §1 data model** → Tasks 1–2, 6. **§2 poll cycle** → Task 8. **§3 path resolution** → Tasks 3, 4, 8 (reuses `scantrigger`/`scanqueue` unchanged). **§4 scheduling** → Task 9. **§5 API/UI** → Tasks 10–12. **§6 testing** → Tasks 3,4,5,8,10,11,12 + Task 13.
+- **First-enable floor** (spec §2.3.3): `since = cycleStart` when `LastPollAt == nil` (Task 8.3) — does not replay history.
+- **Reuse, not duplicate**: history client uses `arrclient`; resolution uses `scantrigger.Resolver`; enqueue uses `scanqueue` (`autoscan.Queuer` is satisfied by `*scanqueue.Service`). Credentials come from `request_integrations` via the join (Task 6) + the shared `SecretResolver` (Task 8).
+- **No fan-out guard / retry queue** by design — per-source failure skips advancing `last_poll_at` so the window retries (Task 8.3).
+- **Type consistency**: `Source`, `Settings`, `SourceUpdate`, `PathRewrite`, `HistoryClient.ImportedPaths`, `Suppressor.ShouldScan`, `Service.PollOnce`, `Store`/`Resolver`/`Queuer`/`SecretResolver` interfaces are used consistently across Tasks 2–10.

--- a/docs/superpowers/plans/2026-06-02-autoscan-rewrite-sync.md
+++ b/docs/superpowers/plans/2026-06-02-autoscan-rewrite-sync.md
@@ -1,0 +1,694 @@
+# Autoscan Rewrite-Sync Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** A "Sync rewrites from arr" action that suggests autoscan `path_rewrites` for an instance by matching its arr root folders to Silo media folders on shared trailing path segments, previewed and committed by the admin.
+
+**Architecture:** A pure `suggestRewrites` matcher in `internal/autoscan`, a `Service.SuggestRewrites` method backed by two new injected deps (an arr root-folder client and a Silo folder lister), one read-only admin endpoint returning a preview, and a "Sync from arr" button in the existing Autoscan tab that merges proposals into the editor (admin saves via the existing per-source PUT). Manual rewrites stay the source of truth.
+
+**Tech Stack:** Go (standard `testing`), React/TypeScript.
+
+**Spec:** `docs/superpowers/specs/2026-06-02-autoscan-rewrite-sync-design.md`
+
+**Commands assume the repository root is the cwd.** Go tests: `go test ./internal/autoscan/...`. Frontend: `cd web && pnpm exec tsc -b && pnpm run lint`. The Go toolchain may be at `/tmp/go/bin` — prepend to `PATH` if `go` is missing. `internal/api`/`internal/api/handlers` cannot be compiled without libvips; verify those via `gofmt` + the Docker build.
+
+---
+
+## Phase 0 — Branch
+
+- [ ] **Step 0.1: Confirm branch**
+
+```bash
+git rev-parse --abbrev-ref HEAD   # expect: feat/autoscan-arr-polling
+```
+This feature extends the autoscan branch. If you're elsewhere: `git checkout feat/autoscan-arr-polling`.
+
+---
+
+## Phase 1 — Core matcher (pure, TDD)
+
+### Task 1: suggestRewrites + types
+
+**Files:**
+- Create: `internal/autoscan/suggest.go`
+- Create: `internal/autoscan/suggest_test.go`
+
+- [ ] **Step 1.1: Write the failing test**
+
+`internal/autoscan/suggest_test.go`:
+```go
+package autoscan
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestSuggestRewrites(t *testing.T) {
+	silo := []string{
+		"/mnt/media/happy/storage2/tvshows1",
+		"/mnt/media/happy4k/4ktv7",
+		"/mnt/media/storage/Anime/Subs",
+		"/mnt/media/storage/Anime2/Subs",
+		"/library/Films",
+		"/tank/television/Show",
+	}
+
+	t.Run("multi-segment unique match", func(t *testing.T) {
+		got := suggestRewrites([]string{"/mnt/happy/storage2/tvshows1"}, silo, nil)
+		if len(got.Proposed) != 1 || got.Proposed[0].To != "/mnt/media/happy/storage2/tvshows1" || got.Proposed[0].MatchDepth != 2 {
+			t.Fatalf("proposed=%+v", got.Proposed)
+		}
+	})
+
+	t.Run("single-segment unique match (different parents)", func(t *testing.T) {
+		got := suggestRewrites([]string{"/mnt/kodama/storage2/4ktv7"}, silo, nil)
+		if len(got.Proposed) != 1 || got.Proposed[0].To != "/mnt/media/happy4k/4ktv7" || got.Proposed[0].MatchDepth != 1 {
+			t.Fatalf("proposed=%+v", got.Proposed)
+		}
+	})
+
+	t.Run("longest-suffix disambiguation", func(t *testing.T) {
+		got := suggestRewrites([]string{"/mnt/kodama/storage1/Anime/Subs"}, silo, nil)
+		if len(got.Proposed) != 1 || got.Proposed[0].To != "/mnt/media/storage/Anime/Subs" || got.Proposed[0].MatchDepth != 2 {
+			t.Fatalf("expected Anime/Subs (depth 2), got %+v", got.Proposed)
+		}
+		if len(got.Ambiguous) != 0 {
+			t.Fatalf("should not be ambiguous: %+v", got.Ambiguous)
+		}
+	})
+
+	t.Run("unmatched when no shared segment", func(t *testing.T) {
+		got := suggestRewrites([]string{"/data/Movies"}, silo, nil)
+		if len(got.Unmatched) != 1 || got.Unmatched[0] != "/data/Movies" || len(got.Proposed) != 0 {
+			t.Fatalf("got=%+v", got)
+		}
+	})
+
+	t.Run("leaf match across unlike layouts", func(t *testing.T) {
+		got := suggestRewrites([]string{"/srv/tv/Show"}, silo, nil)
+		if len(got.Proposed) != 1 || got.Proposed[0].To != "/tank/television/Show" {
+			t.Fatalf("got=%+v", got)
+		}
+	})
+
+	t.Run("ambiguous tie", func(t *testing.T) {
+		// a root whose only shared segment is "Subs" ties two folders
+		got := suggestRewrites([]string{"/foo/bar/Subs"}, silo, nil)
+		if len(got.Ambiguous) != 1 || len(got.Ambiguous[0].Candidates) != 2 {
+			t.Fatalf("expected ambiguous with 2 candidates, got %+v", got.Ambiguous)
+		}
+	})
+
+	t.Run("covered by existing rule", func(t *testing.T) {
+		existing := []PathRewrite{{From: "/mnt/happy", To: "/mnt/media/happy"}}
+		got := suggestRewrites([]string{"/mnt/happy/storage2/tvshows1"}, silo, existing)
+		if len(got.Covered) != 1 || len(got.Proposed) != 0 {
+			t.Fatalf("expected covered, got %+v", got)
+		}
+	})
+
+	t.Run("normalization: trailing slash, backslashes, dup slashes", func(t *testing.T) {
+		got := suggestRewrites([]string{`\mnt\happy\\storage2\tvshows1\`}, silo, nil)
+		if len(got.Proposed) != 1 || got.Proposed[0].From != "/mnt/happy/storage2/tvshows1" || got.Proposed[0].To != "/mnt/media/happy/storage2/tvshows1" {
+			t.Fatalf("normalization failed: %+v", got.Proposed)
+		}
+	})
+}
+
+func TestCommonSuffixLen(t *testing.T) {
+	cases := []struct {
+		a, b []string
+		want int
+	}{
+		{[]string{"a", "b", "c"}, []string{"x", "b", "c"}, 2},
+		{[]string{"4ktv7"}, []string{"happy4k", "4ktv7"}, 1},
+		{[]string{"4ktv7"}, []string{"4ktv70"}, 0}, // full-segment, not substring
+		{[]string{"a"}, []string{"b"}, 0},
+	}
+	for _, tc := range cases {
+		if got := commonSuffixLen(tc.a, tc.b); got != tc.want {
+			t.Fatalf("commonSuffixLen(%v,%v)=%d want %d", tc.a, tc.b, got, tc.want)
+		}
+	}
+}
+```
+
+- [ ] **Step 1.2: Run it — expect failure**
+
+```bash
+go test ./internal/autoscan/ -run 'TestSuggestRewrites|TestCommonSuffixLen' -v
+```
+Expected: FAIL (`suggestRewrites` undefined).
+
+- [ ] **Step 1.3: Implement** `internal/autoscan/suggest.go`:
+```go
+package autoscan
+
+import "strings"
+
+// RewriteSuggestions is the result of matching arr root folders to Silo folders.
+type RewriteSuggestions struct {
+	Proposed  []ProposedRewrite `json:"proposed"`
+	Unmatched []string          `json:"unmatched"`
+	Ambiguous []AmbiguousRoot   `json:"ambiguous"`
+	Covered   []string          `json:"covered"`
+}
+
+// ProposedRewrite is a suggested rewrite plus its confidence (shared trailing segments).
+type ProposedRewrite struct {
+	From       string `json:"from"`
+	To         string `json:"to"`
+	MatchDepth int    `json:"match_depth"`
+}
+
+// AmbiguousRoot is an arr root that tied across multiple Silo folders.
+type AmbiguousRoot struct {
+	Root       string   `json:"root"`
+	Candidates []string `json:"candidates"`
+}
+
+// normalizePath makes a path comparable: backslashes -> '/', collapse duplicate
+// slashes, strip a trailing slash (but keep a bare "/").
+func normalizePath(p string) string {
+	p = normalizeSeparators(strings.TrimSpace(p))
+	for strings.Contains(p, "//") {
+		p = strings.ReplaceAll(p, "//", "/")
+	}
+	if len(p) > 1 {
+		p = strings.TrimRight(p, "/")
+	}
+	return p
+}
+
+func segments(p string) []string {
+	p = strings.Trim(p, "/")
+	if p == "" {
+		return nil
+	}
+	return strings.Split(p, "/")
+}
+
+// commonSuffixLen counts equal trailing segments (full-segment equality).
+func commonSuffixLen(a, b []string) int {
+	i, j, n := len(a)-1, len(b)-1, 0
+	for i >= 0 && j >= 0 && a[i] == b[j] {
+		n++
+		i--
+		j--
+	}
+	return n
+}
+
+// coveredBy reports whether an existing rewrite already matches root (same
+// boundary rule as applyRewrites).
+func coveredBy(root string, existing []PathRewrite) bool {
+	for _, rw := range existing {
+		from := strings.TrimRight(strings.TrimSpace(rw.From), "/")
+		if from == "" {
+			continue
+		}
+		if root == from || strings.HasPrefix(root, from+"/") {
+			return true
+		}
+	}
+	return false
+}
+
+// suggestRewrites matches each arr root to the Silo folder sharing the most
+// trailing path segments (unique winner). Roots already handled by an existing
+// rewrite are reported as Covered; roots with no shared segment as Unmatched;
+// ties as Ambiguous. Pure: no I/O, no deployment constants.
+func suggestRewrites(arrRoots, siloFolderPaths []string, existing []PathRewrite) RewriteSuggestions {
+	siloNorm := make([]string, 0, len(siloFolderPaths))
+	siloSegs := make([][]string, 0, len(siloFolderPaths))
+	for _, p := range siloFolderPaths {
+		n := normalizePath(p)
+		if n == "" {
+			continue
+		}
+		siloNorm = append(siloNorm, n)
+		siloSegs = append(siloSegs, segments(n))
+	}
+
+	var out RewriteSuggestions
+	for _, raw := range arrRoots {
+		root := normalizePath(raw)
+		if root == "" {
+			continue
+		}
+		if coveredBy(root, existing) {
+			out.Covered = append(out.Covered, root)
+			continue
+		}
+		rootSegs := segments(root)
+		best := 0
+		var winners []string
+		for i, segs := range siloSegs {
+			n := commonSuffixLen(rootSegs, segs)
+			if n == 0 {
+				continue
+			}
+			if n > best {
+				best, winners = n, []string{siloNorm[i]}
+			} else if n == best {
+				winners = append(winners, siloNorm[i])
+			}
+		}
+		switch {
+		case best == 0:
+			out.Unmatched = append(out.Unmatched, root)
+		case len(winners) == 1:
+			out.Proposed = append(out.Proposed, ProposedRewrite{From: root, To: winners[0], MatchDepth: best})
+		default:
+			out.Ambiguous = append(out.Ambiguous, AmbiguousRoot{Root: root, Candidates: winners})
+		}
+	}
+	return out
+}
+```
+
+- [ ] **Step 1.4: Run it — expect pass; commit**
+
+```bash
+go test ./internal/autoscan/ -run 'TestSuggestRewrites|TestCommonSuffixLen' -v
+gofmt -l internal/autoscan/suggest.go internal/autoscan/suggest_test.go
+git add internal/autoscan/suggest.go internal/autoscan/suggest_test.go
+git commit -m "feat(autoscan): suffix-match rewrite suggester"
+```
+
+---
+
+## Phase 2 — Service support
+
+### Task 2: Repository.GetSource
+
+**Files:**
+- Modify: `internal/autoscan/repository.go`
+
+- [ ] **Step 2.1: Implement** `GetSource` (single-source join, includes disabled). Add after `ListEnabledSources`:
+```go
+// GetSource returns one instance's autoscan state joined with its
+// request_integrations row (kind/base_url/api_key_ref), regardless of enabled.
+func (r *Repository) GetSource(ctx context.Context, integrationID string) (*Source, error) {
+	row := r.pool.QueryRow(ctx, sourceSelect+` WHERE ri.id = $1`, integrationID)
+	src, err := scanSource(row)
+	if err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return nil, fmt.Errorf("%w: %s", ErrIntegrationNotFound, integrationID)
+		}
+		return nil, fmt.Errorf("get autoscan source: %w", err)
+	}
+	return &src, nil
+}
+```
+(`errors`, `pgx`, `fmt`, `ErrIntegrationNotFound`, and `sourceSelect`/`scanSource` already exist in the file.)
+
+- [ ] **Step 2.2: Build + commit**
+
+```bash
+go build ./internal/autoscan/... && go test ./internal/autoscan/...
+git add internal/autoscan/repository.go
+git commit -m "feat(autoscan): GetSource single-source lookup"
+```
+
+### Task 3: RootFolderClient + FolderLister adapters
+
+**Files:**
+- Create: `internal/autoscan/suggest_deps.go`
+
+- [ ] **Step 3.1: Implement the two adapters + interfaces**
+```go
+package autoscan
+
+import (
+	"context"
+	"net/http"
+
+	"github.com/Silo-Server/silo-server/internal/catalog"
+	"github.com/Silo-Server/silo-server/internal/requests/arrclient"
+)
+
+// RootFolderClient lists a Radarr/Sonarr instance's configured root folder paths.
+type RootFolderClient interface {
+	RootFolders(ctx context.Context, baseURL, apiKey string) ([]string, error)
+}
+
+// FolderLister lists every Silo media-folder path.
+type FolderLister interface {
+	ListFolderPaths(ctx context.Context) ([]string, error)
+}
+
+type arrRootFolderClient struct{ httpClient *http.Client }
+
+// NewArrRootFolderClient returns a RootFolderClient backed by the shared arrclient.
+func NewArrRootFolderClient(httpClient *http.Client) RootFolderClient {
+	return &arrRootFolderClient{httpClient: httpClient}
+}
+
+func (c *arrRootFolderClient) RootFolders(ctx context.Context, baseURL, apiKey string) ([]string, error) {
+	client := arrclient.New(baseURL, apiKey, c.httpClient)
+	folders, err := arrclient.ListRootFolders(ctx, client)
+	if err != nil {
+		return nil, err
+	}
+	paths := make([]string, 0, len(folders))
+	for _, f := range folders {
+		if f.Path != "" {
+			paths = append(paths, f.Path)
+		}
+	}
+	return paths, nil
+}
+
+type catalogFolderLister struct{ repo *catalog.FolderRepository }
+
+// NewCatalogFolderLister adapts catalog.FolderRepository to FolderLister.
+func NewCatalogFolderLister(repo *catalog.FolderRepository) FolderLister {
+	return &catalogFolderLister{repo: repo}
+}
+
+func (l *catalogFolderLister) ListFolderPaths(ctx context.Context) ([]string, error) {
+	folders, err := l.repo.List(ctx)
+	if err != nil {
+		return nil, err
+	}
+	var paths []string
+	for _, f := range folders {
+		paths = append(paths, f.Paths...)
+	}
+	return paths, nil
+}
+```
+Note: `autoscan` already depends on `catalog` (via `scantrigger`) and on `requests/arrclient` (via `history.go`), so these imports add no new module-level coupling and no cycle (`catalog` does not import `autoscan`).
+
+- [ ] **Step 3.2: Build + commit**
+
+```bash
+go build ./internal/autoscan/...
+git add internal/autoscan/suggest_deps.go
+git commit -m "feat(autoscan): arr root-folder client + Silo folder lister"
+```
+
+### Task 4: Service.SuggestRewrites
+
+**Files:**
+- Modify: `internal/autoscan/service.go`
+- Modify: `internal/autoscan/service_test.go`
+
+- [ ] **Step 4.1: Write the failing test** (append to `service_test.go`):
+```go
+type fakeRootFolders struct {
+	paths []string
+	err   error
+}
+
+func (f fakeRootFolders) RootFolders(context.Context, string, string) ([]string, error) {
+	return f.paths, f.err
+}
+
+type fakeFolderLister struct{ paths []string }
+
+func (f fakeFolderLister) ListFolderPaths(context.Context) ([]string, error) { return f.paths, nil }
+
+type sourceGetterStore struct {
+	fakeStore
+	src *Source
+}
+
+func (s *sourceGetterStore) GetSource(context.Context, string) (*Source, error) { return s.src, nil }
+
+func TestSuggestRewritesService(t *testing.T) {
+	store := &sourceGetterStore{src: &Source{IntegrationID: "i1", Kind: "sonarr", BaseURL: "http://x", APIKeyRef: "k"}}
+	svc := NewService(store, &fakeHistory{}, fakeResolver{}, &recordingQueuer{}, allowSuppressor{}, nil)
+	svc.SetRewriteResolvers(
+		fakeRootFolders{paths: []string{"/mnt/happy/storage2/tvshows1", "/data/Movies"}},
+		fakeFolderLister{paths: []string{"/mnt/media/happy/storage2/tvshows1"}},
+	)
+	got, err := svc.SuggestRewrites(context.Background(), "i1")
+	if err != nil {
+		t.Fatalf("SuggestRewrites: %v", err)
+	}
+	if len(got.Proposed) != 1 || got.Proposed[0].To != "/mnt/media/happy/storage2/tvshows1" {
+		t.Fatalf("proposed=%+v", got.Proposed)
+	}
+	if len(got.Unmatched) != 1 || got.Unmatched[0] != "/data/Movies" {
+		t.Fatalf("unmatched=%+v", got.Unmatched)
+	}
+}
+```
+> The `Store` interface needs a `GetSource` method so the service can call it. Add `GetSource(ctx context.Context, integrationID string) (*Source, error)` to the `Store` interface in `service.go`. `*Repository` already implements it (Task 2). The test's `sourceGetterStore` embeds the existing `fakeStore` and adds `GetSource`. If `fakeStore` does not satisfy the widened interface on its own, that's fine — only `sourceGetterStore` is used here; but ensure the package still compiles (other tests construct `fakeStore` directly and pass it where `Store` is required — add a `GetSource` method to `fakeStore` returning `(nil, nil)` so it still satisfies `Store`).
+
+- [ ] **Step 4.2: Run it — expect failure**
+
+```bash
+go test ./internal/autoscan/ -run TestSuggestRewritesService -v
+```
+Expected: FAIL (`SetRewriteResolvers`/`SuggestRewrites` undefined).
+
+- [ ] **Step 4.3: Implement** in `service.go`. Add fields + setter + method, and add `GetSource` to `Store`:
+```go
+// add to the Store interface:
+//   GetSource(ctx context.Context, integrationID string) (*Source, error)
+
+// add fields to Service struct:
+//   rootFolders RootFolderClient
+//   folders     FolderLister
+
+// SetRewriteResolvers wires the deps used by SuggestRewrites (optional; only the
+// admin-facing service needs them).
+func (s *Service) SetRewriteResolvers(rootFolders RootFolderClient, folders FolderLister) {
+	s.rootFolders = rootFolders
+	s.folders = folders
+}
+
+// SuggestRewrites matches an instance's arr root folders to Silo media folders.
+func (s *Service) SuggestRewrites(ctx context.Context, integrationID string) (RewriteSuggestions, error) {
+	if s.rootFolders == nil || s.folders == nil {
+		return RewriteSuggestions{}, fmt.Errorf("autoscan: rewrite suggestion not configured")
+	}
+	src, err := s.store.GetSource(ctx, integrationID)
+	if err != nil {
+		return RewriteSuggestions{}, err
+	}
+	apiKey := src.APIKeyRef
+	if s.secrets != nil && apiKey != "" {
+		if resolved, rerr := s.secrets.Get(ctx, apiKey); rerr == nil && resolved != "" {
+			apiKey = resolved
+		}
+	}
+	arrRoots, err := s.rootFolders.RootFolders(ctx, src.BaseURL, apiKey)
+	if err != nil {
+		return RewriteSuggestions{}, fmt.Errorf("autoscan: list arr root folders: %w", err)
+	}
+	siloPaths, err := s.folders.ListFolderPaths(ctx)
+	if err != nil {
+		return RewriteSuggestions{}, fmt.Errorf("autoscan: list silo folders: %w", err)
+	}
+	return suggestRewrites(arrRoots, siloPaths, src.PathRewrites), nil
+}
+```
+Add `GetSource` to `fakeStore` in `service_test.go` (`func (f *fakeStore) GetSource(context.Context, string) (*Source, error) { return nil, nil }`).
+
+- [ ] **Step 4.4: Run tests — expect pass; commit**
+
+```bash
+go test ./internal/autoscan/...
+gofmt -l internal/autoscan/service.go internal/autoscan/service_test.go
+git add internal/autoscan/service.go internal/autoscan/service_test.go
+git commit -m "feat(autoscan): Service.SuggestRewrites"
+```
+
+---
+
+## Phase 3 — API endpoint
+
+### Task 5: Handler + route
+
+**Files:**
+- Modify: `internal/api/handlers/autoscan.go`
+- Modify: `internal/api/router.go`
+- Modify: `internal/api/handlers/autoscan_test.go`
+
+- [ ] **Step 5.1: Extend the handler's service interface + add the handler method**
+
+In `autoscan.go`, add `SuggestRewrites` to the `autoscanTriggerer` interface:
+```go
+type autoscanTriggerer interface {
+	PollOnce(ctx context.Context) error
+	SuggestRewrites(ctx context.Context, integrationID string) (autoscan.RewriteSuggestions, error)
+}
+```
+Add the handler:
+```go
+func (h *AutoscanHandler) HandleRewriteSuggestions(w http.ResponseWriter, r *http.Request) {
+	id := strings.TrimSpace(chi.URLParam(r, "id"))
+	suggestions, err := h.svc.SuggestRewrites(r.Context(), id)
+	if err != nil {
+		if errors.Is(err, autoscan.ErrIntegrationNotFound) {
+			writeError(w, http.StatusNotFound, "not_found", "Autoscan source not found")
+			return
+		}
+		// arr unreachable / bad key / folder list failure
+		writeError(w, http.StatusBadGateway, "arr_unreachable", "Could not load root folders from the arr instance")
+		return
+	}
+	writeJSON(w, http.StatusOK, suggestions)
+}
+```
+(`errors`, `autoscan`, `chi`, `strings`, `writeError`, `writeJSON` already imported.)
+
+- [ ] **Step 5.2: Mount the route** in `router.go`, inside the autoscan route block:
+```go
+r.Get("/autoscan/sources/{id}/rewrite-suggestions", autoscanHandler.HandleRewriteSuggestions)
+```
+
+- [ ] **Step 5.3: Wire the service deps** in `router.go` where `autoscanSvc` is built (after `autoscan.NewService(...)`):
+```go
+autoscanSvc.SetRewriteResolvers(
+	autoscan.NewArrRootFolderClient(nil),
+	autoscan.NewCatalogFolderLister(deps.FolderRepo),
+)
+```
+(This is inside the existing `if deps.FolderRepo != nil && deps.LibraryScanQueue != nil` block, so `deps.FolderRepo` is non-nil here.)
+
+- [ ] **Step 5.4: Update the handler test fake**
+
+In `autoscan_test.go`, the fake satisfying `autoscanTriggerer` (e.g. `fakeAutoscanTriggerer`) gains:
+```go
+func (f *fakeAutoscanTriggerer) SuggestRewrites(context.Context, string) (autoscan.RewriteSuggestions, error) {
+	return autoscan.RewriteSuggestions{}, nil
+}
+```
+Add a test asserting `HandleRewriteSuggestions` returns 200 with JSON for a known id (mirror the existing handler tests).
+
+- [ ] **Step 5.5: Verify (limited) + commit**
+
+```bash
+export PATH=$PATH:/tmp/go/bin
+go vet ./internal/autoscan/...
+gofmt -l internal/api/handlers/autoscan.go internal/api/router.go internal/api/handlers/autoscan_test.go
+# internal/api cannot compile here (libvips) — Docker verifies later.
+git add internal/api/handlers/autoscan.go internal/api/router.go internal/api/handlers/autoscan_test.go
+git commit -m "feat(autoscan): rewrite-suggestions endpoint"
+```
+
+---
+
+## Phase 4 — Frontend
+
+### Task 6: Types + hook
+
+**Files:**
+- Modify: `web/src/api/types.ts`
+- Modify: `web/src/hooks/queries/useAutoscan.ts`
+
+- [ ] **Step 6.1: Types** — add to `types.ts`:
+```ts
+export interface AutoscanProposedRewrite {
+  from: string;
+  to: string;
+  match_depth: number;
+}
+export interface AutoscanAmbiguousRoot {
+  root: string;
+  candidates: string[];
+}
+export interface AutoscanRewriteSuggestions {
+  proposed: AutoscanProposedRewrite[];
+  unmatched: string[];
+  ambiguous: AutoscanAmbiguousRoot[];
+  covered: string[];
+}
+```
+
+- [ ] **Step 6.2: Hook** — add to `useAutoscan.ts` a mutation that fetches suggestions for an id:
+```ts
+export function useAutoscanRewriteSuggestions() {
+  return useMutation({
+    mutationFn: (id: string) =>
+      api<AutoscanRewriteSuggestions>(`/admin/autoscan/sources/${id}/rewrite-suggestions`),
+    onError: (err) =>
+      toast.error(err instanceof Error ? err.message : "Could not sync rewrites from the arr instance"),
+  });
+}
+```
+Match the import/`api`/`toast`/`useMutation` conventions already in the file (it imports `api` and `toast` already; reuse them; import the new type).
+
+- [ ] **Step 6.3: Lint + commit**
+
+```bash
+cd web && pnpm exec tsc -b && pnpm run lint && pnpm exec prettier --check src/api/types.ts src/hooks/queries/useAutoscan.ts
+git add web/src/api/types.ts web/src/hooks/queries/useAutoscan.ts
+git commit -m "feat(web): autoscan rewrite-suggestions types and hook"
+```
+
+### Task 7: Sync button + preview in AutoscanSourceEditor
+
+**Files:**
+- Modify: `web/src/pages/AdminRequests.tsx`
+
+- [ ] **Step 7.1: Add the button + preview**
+
+In `AutoscanSourceEditor`:
+- Call `const suggest = useAutoscanRewriteSuggestions();` and add local state `const [preview, setPreview] = useState<AutoscanRewriteSuggestions | null>(null);` and `const [selected, setSelected] = useState<Set<string>>(new Set());`.
+- Add a **"Sync from arr"** `Button` beside Save: `onClick={async () => { const s = await suggest.mutateAsync(source.integration_id); setPreview(s); setSelected(new Set(s.proposed.map((p) => p.from))); }}` (disabled while `suggest.isPending`).
+- When `preview` is set, render a panel (reuse the file's `Dialog` or an inline bordered panel) with three sections:
+  - **Proposed:** each `proposed[]` row — a checkbox bound to `selected.has(p.from)` (toggle updates the set), `from → to`, and a `Badge` showing confidence: `match_depth >= 2 ? "${match_depth} segments" : "1 segment — weak"` (destructive/secondary variant for weak).
+  - **Unmatched:** muted list of `unmatched[]` ("no Silo match — add manually if needed").
+  - **Ambiguous:** list of `ambiguous[]` (`root` + its `candidates` joined) — info only.
+  - An **"Add selected to rewrites"** button that merges the checked proposals into the editor's existing rewrites state, deduped by `from` (skip any whose `from` already exists), then `setPreview(null)`. Do NOT auto-save — the admin then clicks the existing **Save**.
+- Keep the existing manual path-rewrite editor unchanged; sync only appends rows to it.
+
+Reuse existing `Button`/`Badge`/`Field`/`Dialog` primitives and the editor's existing rewrites-state setter.
+
+- [ ] **Step 7.2: Lint + commit**
+
+```bash
+cd web && pnpm exec tsc -b && pnpm run lint && pnpm exec prettier --check src/pages/AdminRequests.tsx
+git add web/src/pages/AdminRequests.tsx
+git commit -m "feat(web): autoscan sync-rewrites preview"
+```
+
+---
+
+## Phase 5 — Verification
+
+### Task 8: Full verification
+
+- [ ] **Step 8.1: Go**
+
+```bash
+export PATH=$PATH:/tmp/go/bin
+go test ./internal/autoscan/... 2>&1 | tail
+go vet ./internal/autoscan/...
+gofmt -l internal/autoscan internal/api/handlers/autoscan.go internal/api/router.go
+```
+Expected: all pass; vet/gofmt clean.
+
+- [ ] **Step 8.2: Frontend**
+
+```bash
+cd web && pnpm exec tsc -b && pnpm run lint && pnpm run format:check
+```
+
+- [ ] **Step 8.3: Docker build (closes the libvips gap)**
+
+```bash
+docker build --build-arg BUILD_REVISION=$(git rev-parse HEAD) --build-arg BUILD_DIRTY=false -t silo-server:autoscan .
+```
+Expected: exit 0 (handlers + router + frontend compile).
+
+- [ ] **Step 8.4: Smoke (optional)**
+
+On a deploy with arr instances configured: open an instance in the Autoscan tab, click **Sync from arr**, confirm the preview shows proposed (with confidence) + unmatched + ambiguous, "Add selected" appends deduped rows, and Save persists them.
+
+---
+
+## Self-review notes (resolved)
+
+- **Spec §1 matcher** → Task 1 (incl. normalization, covered-first, suffix depth, unlike-deployment fixtures). **§2 endpoint/service** → Tasks 2–5 (`GetSource`, `RootFolderClient`/`FolderLister`, `SuggestRewrites`, endpoint, 404/502 mapping). **§3 frontend** → Tasks 6–7. **§4 testing** → Tasks 1,4,5 + Task 8.
+- **Manual-preserving**: sync only *appends* deduped rows to the editor; the admin saves via the existing `PUT` (Task 7). Never auto-writes.
+- **Generic**: `suggestRewrites` takes plain string slices, no deployment constants; tests include `/data/Movies` and `/srv/tv` fixtures (Task 1).
+- **Optional deps**: `SetRewriteResolvers` keeps `main.go`'s poll service untouched; `SuggestRewrites` errors if unset (Task 4).
+- **Type consistency**: `RewriteSuggestions`/`ProposedRewrite`/`AmbiguousRoot` (Go) ↔ `AutoscanRewriteSuggestions`/`AutoscanProposedRewrite`/`AutoscanAmbiguousRoot` (TS); `match_depth` JSON tag matches.

--- a/docs/superpowers/specs/2026-06-02-autoscan-arr-polling-design.md
+++ b/docs/superpowers/specs/2026-06-02-autoscan-arr-polling-design.md
@@ -1,0 +1,222 @@
+# Autoscan: Polling Radarr/Sonarr to Trigger Targeted Library Scans
+
+**Status:** Design approved, ready for implementation plan
+**Date:** 2026-06-02
+**Area:** new `internal/autoscan`, `internal/taskmanager/tasks`, `migrations/`, `internal/api`, `web/src/pages/AdminRequests.tsx`
+
+## Summary
+
+Silo currently learns about new media via scheduled/manual library scans. When
+Radarr/Sonarr import a download, the new file only appears in Silo on the next
+scan. This adds an **autoscan poller**: a periodic background task that polls the
+configured Radarr/Sonarr instances for newly-imported files and enqueues
+**targeted folder scans** into Silo's existing scan queue, so requested (and
+non-requested) content shows up promptly.
+
+The design follows the established autoscan pattern — poll arr import history,
+translate the imported paths, and trigger targeted scans — but kept deliberately
+simple. That pattern is normally built to orchestrate scans across many separate
+media-server boxes, which needs a bounded fan-out guard and a retry queue. Silo
+is a single service scanning *itself*, so the cross-node fan-out machinery is
+unnecessary — imported paths become folder jobs in Silo's own worker-bounded
+`scanqueue`.
+
+## Goals
+
+- Poll autoscan-enabled Radarr/Sonarr instances on an interval for import events.
+- Translate arr import paths into Silo media folders and enqueue targeted scans.
+- Reuse the Radarr/Sonarr instances already configured for requests
+  (`request_integrations`) — no duplicate URLs/keys.
+- Coalesce bursts (a season's episodes) into minimal redundant scans.
+- Admin-configurable: global enable, interval, debounce, per-instance toggle,
+  optional path rewrites, on-demand "poll now".
+
+## Non-Goals
+
+- No cross-node scan fan-out or bounded-concurrency semaphore (single service;
+  the `scanqueue` workers are the bound).
+- No separate retry queue (a failed source poll simply does not advance its
+  high-water mark, so the next cycle retries the window).
+- No arr webhook/"Connect" push integration (polling only, as requested; webhook
+  push is a possible future add-on).
+- No separate autoscan source credential store — sources are existing
+  `request_integrations`.
+
+## Background
+
+- **`internal/scantrigger`** already maps a filesystem path to a Silo
+  `MediaFolder` and scan path: `Resolver.Resolve(Request{Path}) -> Target{Folder,
+  Mode, Path}` (via `LongestMatchingRoot` / `MatchFolderForPath`).
+- **`internal/scanqueue`** executes scans through a worker-bounded queue:
+  `Queuer.EnqueueScan(ctx, folderID, mode, path, trigger)` /
+  `EnqueueScans(targets)`.
+- **`internal/requests/arrclient`** is a thin Radarr/Sonarr HTTP client
+  (`New(baseURL, apiKey, httpClient)`, `GetJSON`, `DoJSON`) — reused for the new
+  history call.
+- **`request_integrations`** holds each instance's `id`, `kind`, `base_url`, and
+  Fernet-encrypted `api_key_ref`, resolved via the same secret resolver the
+  request service uses.
+- The **task manager** runs periodic tasks via the `taskmanager.Task` interface
+  with interval `DefaultTriggers()` (e.g. `ReconcileRequestsTask`).
+
+## Design
+
+### 1. Data model & config
+
+A new `internal/autoscan` package owns its own schema; `request_integrations`
+stays focused on fulfillment.
+
+**`autoscan_settings`** (singleton, mirrors `request_settings`):
+
+| column | type / default | purpose |
+|---|---|---|
+| `id` | bool PK default true, singleton CHECK | |
+| `enabled` | bool, default false | master on/off |
+| `poll_interval_minutes` | int, default 10 | poll task interval |
+| `debounce_seconds` | int, default 60 | folder re-scan suppression window |
+| `created_at`, `updated_at` | timestamptz | |
+
+**`autoscan_sources`** (one row per autoscan-enabled instance):
+
+| column | type | purpose |
+|---|---|---|
+| `integration_id` | text PK → `request_integrations(id)` ON DELETE CASCADE | the source instance |
+| `enabled` | bool, default false | per-instance autoscan toggle |
+| `path_rewrites` | jsonb, default `[]` | `[{from, to}]` prefix overrides |
+| `last_poll_at` | timestamptz, null | `history/since` high-water mark |
+| `created_at`, `updated_at` | timestamptz | |
+
+**Reused, not duplicated:** `base_url` / `api_key_ref` come from
+`request_integrations`. Debounce/suppression state lives in **Redis**
+(`autoscan:scanned:{folder_id}`, TTL = `debounce_seconds`), not Postgres.
+
+### 2. Poll cycle
+
+`autoscan.Service.PollOnce(ctx)` (invoked by the periodic task):
+
+1. Load `autoscan_settings`; if `!enabled`, return immediately (no-op).
+2. Load `autoscan_sources WHERE enabled`, joined to `request_integrations` for
+   `kind` / `base_url` / `api_key_ref`.
+3. For each source (sequential — a handful of instances):
+   1. Decrypt the API key via the secret resolver.
+   2. Record `cycleStart := now`.
+   3. `arrclient.GetJSON("/api/v3/history/since?date={last_poll_at}&eventType=downloadFolderImported")`
+      — both Radarr and Sonarr expose this. `last_poll_at` null → a sane floor
+      (do not scan all history on first enable; floor at `cycleStart`).
+   4. Extract the imported **file path** per event (Radarr: movie file path;
+      Sonarr: episode file `outputPath`); take its **parent directory**.
+   5. On success, advance that source's `last_poll_at = cycleStart`. On failure
+      (arr unreachable, decode error), log and **do not** advance — next cycle
+      retries the window.
+4. For each extracted directory: apply path rewrites (§3), resolve via
+   `scantrigger.Resolver` → `Target{Folder, Mode, Path}`. Unresolvable paths
+   (outside Silo's media folders) are logged and skipped.
+5. **Dedupe to unique folders** for this cycle; for each, check the Redis
+   suppression key — if absent, `EnqueueScan(..., trigger="autoscan")` and set
+   the key with TTL `debounce_seconds`; if present, skip (already scanned this
+   window).
+
+**Debounce rationale:** because the poller batches a whole interval of imports
+per `history/since` call, within-cycle folder dedup does most of the work. The
+Redis suppression key only prevents re-enqueuing the same folder on back-to-back
+cycles. Silo's scanner is idempotent, so a season importing across two cycles
+simply gets a second (cheap) scan that picks up the rest. This is simpler than a
+"collect-expired" debounce plus a retry queue, which the polling + idempotent
+re-scan model makes unnecessary.
+
+### 3. Path resolution & scan enqueue
+
+A small pipeline in front of the existing scan plumbing — no new scan logic:
+
+1. **Rewrite** (per source, optional): apply the first matching `path_rewrites`
+   entry as a prefix replacement (e.g. `/data/media -> /mnt/media`). No rewrites
+   → path used as-is (shared-mount common case).
+2. **Resolve** via `scantrigger.Resolver.Resolve(Request{Path: rewrittenDir})`
+   → `Target{Folder, Mode, Path}`. No matching media folder → log + skip.
+3. **Enqueue** deduped targets via `scanqueue` `EnqueueScans` with
+   `trigger="autoscan"` (attributable in scan history, flows through the same
+   worker-bounded queue).
+
+### 4. Scheduling & concurrency
+
+- **`internal/taskmanager/tasks/autoscan_poll.go`** implements `taskmanager.Task`
+  (`Key: "autoscan_poll"`, name/description/category, `DefaultTriggers` = interval
+  trigger seeded from `poll_interval_minutes`). Its run body calls
+  `autoscan.Service.PollOnce(ctx)`.
+- **Disabled = cheap no-op:** the task stays registered; `PollOnce` returns early
+  when `enabled` is false. Toggling autoscan never (de)registers tasks.
+- **Interval changes:** updating `poll_interval_minutes` reconfigures the task's
+  interval trigger via the task manager's existing trigger-config path; if a live
+  update is unavailable it applies on next start.
+- **No overlap, no semaphore:** the task manager serializes a task's executions;
+  sources are polled sequentially; scan execution is bounded by `scanqueue`. The
+  single-service simplification: no bounded-fan-out semaphore is needed.
+- **Primary/integrated server only** (same as the request reconcile task), not on
+  standalone transcode/proxy worker nodes.
+
+### 5. Admin API & UI
+
+**API** (admin-gated, `/api/v1/admin/autoscan`, mirroring the request-settings
+handlers; never echoes API keys):
+
+- `GET/PUT /autoscan/settings` — `{enabled, poll_interval_minutes, debounce_seconds}`
+- `GET /autoscan/sources` — per autoscan-eligible instance (joined from
+  `request_integrations`): `{integration_id, name, kind, enabled, path_rewrites,
+  last_poll_at}`
+- `PUT /autoscan/sources/{integration_id}` — set `{enabled, path_rewrites}`
+- `POST /autoscan/trigger` — run `PollOnce` once on demand; tight per-admin rate
+  limit so it cannot hammer the arr instances
+- `GET /autoscan/status` — `{enabled, per-source last_poll_at, last scan summary}`
+
+**UI:** a new **"Autoscan" tab** in `web/src/pages/AdminRequests.tsx` (alongside
+Queue / Settings / Integrations / User Overrides):
+
+- Global controls: enable switch, poll interval, debounce window.
+- Per-source list — one row per Radarr/Sonarr instance with an autoscan toggle,
+  an optional `from → to` path-rewrite editor, and a read-only "last polled".
+- A **"Poll now"** button → `POST /autoscan/trigger`.
+
+Rate limits and admin-auth follow Silo's existing request-admin conventions.
+
+### 6. Testing
+
+- **Path rewrite:** prefix replacement, first-match ordering, no-match
+  passthrough, trailing-slash handling.
+- **arr history client:** table-driven `httptest` fixtures for both Radarr and
+  Sonarr import-event JSON shapes; asserts the correct file path is extracted and
+  its parent folder taken.
+- **Dedupe + suppression:** many paths in one folder → one target; folder with a
+  live suppression key skipped; absent/expired key enqueues.
+- **`PollOnce` (integration seam):** fakes for source store, arr history client,
+  `scantrigger.Resolver`, `scanqueue.Queuer`, Redis — asserts deduped folder
+  scans enqueued with `trigger="autoscan"`, `last_poll_at` advanced on success,
+  **not** advanced on per-source failure, clean no-op when disabled.
+- **Unresolvable path:** logged + skipped, never enqueued or fatal.
+- **Repository / migration:** `autoscan_settings` singleton + `autoscan_sources`
+  CRUD and the `request_integrations` join; migration applies + rolls back
+  (sidecar table, `ON DELETE CASCADE`).
+- **Frontend:** Autoscan tab renders, per-source toggle / path-rewrite editor
+  round-trips, "Poll now" calls the trigger endpoint.
+
+## Risks & open considerations
+
+- **First-enable floor:** `last_poll_at` null must floor at "now" (not epoch) so
+  enabling autoscan doesn't enqueue a scan for every historical import.
+- **history/since shape differences:** Radarr vs Sonarr import-event payloads
+  differ; the path extraction is per-kind and covered by fixtures.
+- **Path rewrites vs scantrigger roots:** if neither rewrites nor Silo's media
+  folders match the arr path, the import is silently skipped (logged) — this is
+  the expected "content outside Silo's libraries" behavior, but a misconfigured
+  rewrite will look like "autoscan does nothing"; the `last_poll_at` + status
+  endpoint and skip logs are the debugging surface.
+- **Idempotent re-scan:** relies on Silo's scanner being safe to run repeatedly
+  on a folder (it is — re-scan finds new files).
+
+## References
+
+- Existing Silo plumbing reused by this design: `internal/scantrigger/scantrigger.go`,
+  `internal/scanqueue/`, `internal/requests/arrclient/`,
+  `internal/taskmanager/tasks/reconcile_requests.go`
+- Prior art: the general autoscan pattern (poll arr import history → translate
+  paths → trigger targeted scans). Silo's variant drops the cross-node fan-out
+  guard and retry queue, which only a multi-box orchestrator needs.

--- a/docs/superpowers/specs/2026-06-02-autoscan-rewrite-sync-design.md
+++ b/docs/superpowers/specs/2026-06-02-autoscan-rewrite-sync-design.md
@@ -1,0 +1,173 @@
+# Autoscan: Sync Path Rewrites from Arr Root Folders
+
+**Status:** Design approved, ready for implementation plan
+**Date:** 2026-06-02
+**Area:** `internal/autoscan`, `internal/api`, `web/src/pages/AdminRequests.tsx`
+**Extends:** the autoscan feature (`docs/superpowers/specs/2026-06-02-autoscan-arr-polling-design.md`)
+
+## Summary
+
+Autoscan resolves an imported file path against Silo's media folders, but
+Radarr/Sonarr often report files under paths that differ from how Silo mounts
+the same content — so operators must hand-author per-root `path_rewrites`. For a
+multi-instance, many-root deployment this can be dozens of rows.
+
+This adds a **"Sync rewrites from arr"** convenience: for one instance, query its
+root folders, match each root to a Silo media folder by **shared trailing path
+segments**, and present the resulting `{from, to}` rewrites as a **preview** the
+admin reviews and commits. Manual rewrites remain the source of truth; sync only
+*fills the editor* — nothing persists until the admin saves.
+
+The matcher is purely structural (no assumptions about any particular path
+layout) so it helps any deployment whose arr and Silo share folder names at some
+depth, and degrades gracefully (no shared names → "unmatched" → manual entry)
+when they do not.
+
+## Goals
+
+- One-click suggestion of `path_rewrites` for an instance from its arr root folders.
+- Correct disambiguation when multiple Silo folders share a leaf name.
+- Preview-then-commit: the admin sees proposed/unmatched/ambiguous and saves
+  through the existing per-source save. Manual rows are never removed or overwritten.
+- Deployment-agnostic: no hard-coded paths; works for any structure; surfaces
+  match confidence so weak matches can be rejected.
+
+## Non-Goals
+
+- No automatic/background writing of rewrites — the admin always commits.
+- No new persistence path — apply is the existing `PUT /sources/{id}`.
+- No case-insensitive matching (case-sensitive segments; correct on Linux). A
+  toggle can be added later if needed.
+- No "sync all instances at once" — per-instance, matching the editor UI.
+
+## Design
+
+### 1. Matching function (core, pure)
+
+A single side-effect-free function in `internal/autoscan`:
+
+```go
+func suggestRewrites(arrRoots []string, siloFolderPaths []string, existing []PathRewrite) RewriteSuggestions
+```
+
+```go
+type RewriteSuggestions struct {
+    Proposed  []ProposedRewrite `json:"proposed"`
+    Unmatched []string          `json:"unmatched"`
+    Ambiguous []AmbiguousRoot   `json:"ambiguous"`
+    Covered   []string          `json:"covered"`
+}
+type ProposedRewrite struct {
+    From       string `json:"from"`         // arr root
+    To         string `json:"to"`           // matched Silo folder path
+    MatchDepth int    `json:"match_depth"`  // trailing segments shared (confidence)
+}
+type AmbiguousRoot struct {
+    Root       string   `json:"root"`
+    Candidates []string `json:"candidates"`
+}
+```
+
+**Normalization** (applied to every path before comparison): backslashes → `/`
+(reuse `normalizeSeparators`), strip a trailing `/`, collapse duplicate slashes.
+This makes any path format (POSIX, Windows, single- or many-root) comparable.
+
+**Per arr root:**
+1. **Covered-first:** if any `existing` rewrite's `From` already matches the root
+   (exact, or root starts with `From + "/"`, using the same boundary rule as
+   `applyRewrites`), classify as **Covered** and skip — so sync never re-proposes
+   what a manual or broad rule already handles.
+2. Split both the root and each Silo folder path into segments; compute the
+   **longest common trailing-segment suffix** (full-segment equality, so `4ktv7`
+   does not match `4ktv70`).
+3. Among Silo folders, take the maximum suffix length `> 0` and the folders that
+   achieve it:
+   - exactly one → **Proposed** `{From: root, To: folder, MatchDepth: n}`
+   - more than one → **Ambiguous** `{root, candidates}`
+   - zero → **Unmatched**
+
+No deployment constants appear in the function; it operates only on the string
+slices it is given.
+
+### 2. Preview endpoint & service
+
+**Endpoint:** `GET /api/v1/admin/autoscan/sources/{id}/rewrite-suggestions` →
+`RewriteSuggestions` JSON (admin-gated, like the other autoscan routes).
+
+**Service method** `Service.SuggestRewrites(ctx, integrationID) (RewriteSuggestions, error)`:
+1. `Repository.GetSource(id)` — a new single-source variant of the existing join
+   that returns `kind`/`base_url`/`api_key_ref`/`path_rewrites` even when the
+   source is disabled. Not found → `ErrIntegrationNotFound`.
+2. Decrypt the API key via the existing `SecretResolver`.
+3. `RootFolderClient.RootFolders(ctx, baseURL, apiKey)` → arr root paths.
+4. `FolderLister.ListFolderPaths(ctx)` → all Silo media-folder paths.
+5. Return `suggestRewrites(arrRoots, siloPaths, source.PathRewrites)`.
+
+**Two new narrow `Service` dependencies** (injected like `history`/`resolver`):
+- `RootFolderClient.RootFolders(ctx, baseURL, apiKey string) ([]string, error)` —
+  an `arrclient`-backed impl reusing `arrclient.ListRootFolders` (returns paths only).
+- `FolderLister.ListFolderPaths(ctx) ([]string, error)` — a thin adapter over
+  `catalog.FolderRepository.List()` flattening each folder's `Paths`.
+
+**Wiring:** both constructed where the autoscan handler is built in `router.go`
+(`deps.FolderRepo` already in scope; the arr client is trivial). The handler's
+service interface gains `SuggestRewrites`.
+
+**Errors:** instance not found → 404; arr unreachable / bad key → 502 with the
+arr error surfaced; Silo folder-list failure → 500.
+
+No new write path — the frontend merges `proposed` into the editor and the admin
+saves via the existing `PUT /sources/{id}`.
+
+### 3. Frontend (preview UI)
+
+In `AutoscanSourceEditor` (`web/src/pages/AdminRequests.tsx`), add a **"Sync from
+arr"** button beside Save. On click, a new hook
+(`useAutoscanRewriteSuggestions`) calls the endpoint and opens a preview panel:
+
+- **Proposed** — each row: `From → To` + a **confidence badge** from `match_depth`
+  (e.g. "3 segments" strong, "1 segment — weak"), with a checkbox (default checked).
+- **Unmatched** — info-only list of arr roots with no Silo match ("add manually").
+- **Ambiguous** — arr root + candidate Silo paths (info-only; admin adds a manual row).
+
+**"Add selected to rewrites"** merges the checked proposals into the editor's
+existing rewrite rows, **deduped by `from`, never removing manual rows**. The
+admin then clicks the normal **Save**. New types in `web/src/api/types.ts`
+(`AutoscanRewriteSuggestions`, `ProposedRewrite`, `AmbiguousRoot`) and hook in
+`web/src/hooks/queries/useAutoscan.ts`. Reuse existing
+`Button`/`Badge`/`Dialog`/`Field` primitives.
+
+### 4. Testing
+
+- **`suggestRewrites`** — table-driven, fixtures spanning layouts: multi-segment
+  match, single-segment unique, longest-suffix disambiguation (`Anime/Subs` vs
+  `Anime2/Subs`), unmatched (no shared segment), already-covered via a broad
+  prefix rule, an ambiguous tie, plus **unlike-this-deployment** cases
+  (`/data/Movies` arr vs `/library/Films` Silo → unmatched; `/srv/tv/Show` vs
+  `/tank/television/Show` → leaf match) and normalization (trailing slash,
+  backslashes, duplicate slashes).
+- **`Service.SuggestRewrites`** — fakes for source store / `RootFolderClient` /
+  `FolderLister` / secrets: asserts proposed/unmatched/ambiguous; arr-unreachable
+  surfaces the error.
+- **Handler** — returns the JSON; 404 for missing instance; 502 when the arr is
+  unreachable.
+- **Frontend** — the button hits the endpoint; the preview renders all three
+  buckets with confidence badges; "Add selected" merges deduped rows; Save
+  persists via the existing mutation.
+
+## Risks & open considerations
+
+- **Weak (1-segment) matches** can be coincidental across very different layouts;
+  mitigated by surfacing `match_depth` so the admin rejects them before saving.
+- **Case-sensitivity** means case-mismatched mounts produce Unmatched rather than
+  a wrong auto-match — a deliberate safe default; revisit only if requested.
+- **Arr reachability** is required for sync (unlike the rest of autoscan which
+  polls on a schedule); a 502 with the arr error tells the admin to check the
+  instance, and manual entry still works.
+
+## References
+
+- Reused: `internal/requests/arrclient.ListRootFolders`,
+  `internal/catalog/FolderRepository.List`, `internal/autoscan` (`PathRewrite`,
+  `normalizeSeparators`, `Repository`, `Service`, the existing
+  `PUT /autoscan/sources/{id}` save).

--- a/internal/api/handlers/autoscan.go
+++ b/internal/api/handlers/autoscan.go
@@ -140,8 +140,16 @@ type autoscanStatusResponse struct {
 
 func (h *AutoscanHandler) HandleStatus(w http.ResponseWriter, r *http.Request) {
 	ctx := r.Context()
-	s, _ := h.repo.GetSettings(ctx)
-	sources, _ := h.repo.ListAllSources(ctx)
+	s, err := h.repo.GetSettings(ctx)
+	if err != nil {
+		writeAutoscanError(w, err)
+		return
+	}
+	sources, err := h.repo.ListAllSources(ctx)
+	if err != nil {
+		writeAutoscanError(w, err)
+		return
+	}
 	trimmed := make([]autoscanStatusSource, 0, len(sources))
 	for _, src := range sources {
 		trimmed = append(trimmed, autoscanStatusSource{

--- a/internal/api/handlers/autoscan.go
+++ b/internal/api/handlers/autoscan.go
@@ -26,6 +26,7 @@ type autoscanStore interface {
 // autoscanTriggerer is the subset of *autoscan.Service the handler needs.
 type autoscanTriggerer interface {
 	PollOnce(ctx context.Context) error
+	SuggestRewrites(ctx context.Context, integrationID string) (autoscan.RewriteSuggestions, error)
 }
 
 // triggerUpdater reconfigures a task's schedule (satisfied by *taskmanager.TaskManager).
@@ -125,6 +126,20 @@ func (h *AutoscanHandler) HandleTrigger(w http.ResponseWriter, r *http.Request) 
 	writeJSON(w, http.StatusAccepted, struct {
 		Status string `json:"status"`
 	}{Status: "ok"})
+}
+
+func (h *AutoscanHandler) HandleRewriteSuggestions(w http.ResponseWriter, r *http.Request) {
+	id := strings.TrimSpace(chi.URLParam(r, "id"))
+	suggestions, err := h.svc.SuggestRewrites(r.Context(), id)
+	if err != nil {
+		if errors.Is(err, autoscan.ErrIntegrationNotFound) {
+			writeError(w, http.StatusNotFound, "not_found", "Autoscan source not found")
+			return
+		}
+		writeError(w, http.StatusBadGateway, "arr_unreachable", "Could not load root folders from the arr instance")
+		return
+	}
+	writeJSON(w, http.StatusOK, suggestions)
 }
 
 type autoscanStatusSource struct {

--- a/internal/api/handlers/autoscan.go
+++ b/internal/api/handlers/autoscan.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"log/slog"
 	"net/http"
 	"strings"
 	"time"
@@ -11,6 +12,7 @@ import (
 	"github.com/go-chi/chi/v5"
 
 	"github.com/Silo-Server/silo-server/internal/autoscan"
+	"github.com/Silo-Server/silo-server/internal/taskmanager"
 )
 
 // autoscanStore is the subset of *autoscan.Repository the handler needs.
@@ -26,14 +28,20 @@ type autoscanTriggerer interface {
 	PollOnce(ctx context.Context) error
 }
 
-// AutoscanHandler serves the admin-only autoscan settings/sources/trigger API.
-type AutoscanHandler struct {
-	repo autoscanStore
-	svc  autoscanTriggerer
+// triggerUpdater reconfigures a task's schedule (satisfied by *taskmanager.TaskManager).
+type triggerUpdater interface {
+	UpdateTriggers(key string, triggerConfigs []taskmanager.TriggerConfig) error
 }
 
-func NewAutoscanHandler(repo autoscanStore, svc autoscanTriggerer) *AutoscanHandler {
-	return &AutoscanHandler{repo: repo, svc: svc}
+// AutoscanHandler serves the admin-only autoscan settings/sources/trigger API.
+type AutoscanHandler struct {
+	repo     autoscanStore
+	svc      autoscanTriggerer
+	triggers triggerUpdater
+}
+
+func NewAutoscanHandler(repo autoscanStore, svc autoscanTriggerer, triggers triggerUpdater) *AutoscanHandler {
+	return &AutoscanHandler{repo: repo, svc: svc, triggers: triggers}
 }
 
 func (h *AutoscanHandler) HandleGetSettings(w http.ResponseWriter, r *http.Request) {
@@ -63,6 +71,14 @@ func (h *AutoscanHandler) HandleUpdateSettings(w http.ResponseWriter, r *http.Re
 	if err != nil {
 		writeAutoscanError(w, err)
 		return
+	}
+	if h.triggers != nil {
+		intervalMs := int64(updated.PollIntervalMinutes) * 60 * 1000
+		if terr := h.triggers.UpdateTriggers("autoscan_poll", []taskmanager.TriggerConfig{
+			{Type: taskmanager.TriggerTypeInterval, IntervalMs: intervalMs},
+		}); terr != nil {
+			slog.WarnContext(r.Context(), "autoscan: update trigger failed", "err", terr)
+		}
 	}
 	writeJSON(w, http.StatusOK, updated)
 }

--- a/internal/api/handlers/autoscan.go
+++ b/internal/api/handlers/autoscan.go
@@ -113,10 +113,15 @@ func (h *AutoscanHandler) HandleUpsertSource(w http.ResponseWriter, r *http.Requ
 }
 
 func (h *AutoscanHandler) HandleTrigger(w http.ResponseWriter, r *http.Request) {
-	if err := h.svc.PollOnce(r.Context()); err != nil {
-		writeAutoscanError(w, err)
-		return
-	}
+	// Run the poll detached: don't block the request on a full cycle, and don't
+	// tie the poll to the request context (which is cancelled once we respond).
+	go func() {
+		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
+		defer cancel()
+		if err := h.svc.PollOnce(ctx); err != nil {
+			slog.WarnContext(ctx, "autoscan: manual poll failed", "err", err)
+		}
+	}()
 	writeJSON(w, http.StatusAccepted, struct {
 		Status string `json:"status"`
 	}{Status: "ok"})

--- a/internal/api/handlers/autoscan.go
+++ b/internal/api/handlers/autoscan.go
@@ -1,0 +1,151 @@
+package handlers
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/go-chi/chi/v5"
+
+	"github.com/Silo-Server/silo-server/internal/autoscan"
+)
+
+// autoscanStore is the subset of *autoscan.Repository the handler needs.
+type autoscanStore interface {
+	GetSettings(ctx context.Context) (autoscan.Settings, error)
+	UpdateSettings(ctx context.Context, s autoscan.Settings) (autoscan.Settings, error)
+	ListAllSources(ctx context.Context) ([]autoscan.Source, error)
+	UpsertSource(ctx context.Context, integrationID string, u autoscan.SourceUpdate) (*autoscan.Source, error)
+}
+
+// autoscanTriggerer is the subset of *autoscan.Service the handler needs.
+type autoscanTriggerer interface {
+	PollOnce(ctx context.Context) error
+}
+
+// AutoscanHandler serves the admin-only autoscan settings/sources/trigger API.
+type AutoscanHandler struct {
+	repo autoscanStore
+	svc  autoscanTriggerer
+}
+
+func NewAutoscanHandler(repo autoscanStore, svc autoscanTriggerer) *AutoscanHandler {
+	return &AutoscanHandler{repo: repo, svc: svc}
+}
+
+func (h *AutoscanHandler) HandleGetSettings(w http.ResponseWriter, r *http.Request) {
+	settings, err := h.repo.GetSettings(r.Context())
+	if err != nil {
+		writeAutoscanError(w, err)
+		return
+	}
+	writeJSON(w, http.StatusOK, settings)
+}
+
+func (h *AutoscanHandler) HandleUpdateSettings(w http.ResponseWriter, r *http.Request) {
+	var s autoscan.Settings
+	if err := json.NewDecoder(r.Body).Decode(&s); err != nil {
+		writeError(w, http.StatusBadRequest, "bad_request", "Invalid request body")
+		return
+	}
+	if s.PollIntervalMinutes <= 0 {
+		writeError(w, http.StatusBadRequest, "bad_request", "poll_interval_minutes must be greater than 0")
+		return
+	}
+	if s.DebounceSeconds < 0 {
+		writeError(w, http.StatusBadRequest, "bad_request", "debounce_seconds must be 0 or greater")
+		return
+	}
+	updated, err := h.repo.UpdateSettings(r.Context(), s)
+	if err != nil {
+		writeAutoscanError(w, err)
+		return
+	}
+	writeJSON(w, http.StatusOK, updated)
+}
+
+func (h *AutoscanHandler) HandleListSources(w http.ResponseWriter, r *http.Request) {
+	sources, err := h.repo.ListAllSources(r.Context())
+	if err != nil {
+		writeAutoscanError(w, err)
+		return
+	}
+	if sources == nil {
+		sources = []autoscan.Source{}
+	}
+	writeJSON(w, http.StatusOK, struct {
+		Sources []autoscan.Source `json:"sources"`
+	}{Sources: sources})
+}
+
+func (h *AutoscanHandler) HandleUpsertSource(w http.ResponseWriter, r *http.Request) {
+	id := strings.TrimSpace(chi.URLParam(r, "id"))
+	var update autoscan.SourceUpdate
+	if err := json.NewDecoder(r.Body).Decode(&update); err != nil {
+		writeError(w, http.StatusBadRequest, "bad_request", "Invalid request body")
+		return
+	}
+	source, err := h.repo.UpsertSource(r.Context(), id, update)
+	if err != nil {
+		writeAutoscanError(w, err)
+		return
+	}
+	writeJSON(w, http.StatusOK, source)
+}
+
+func (h *AutoscanHandler) HandleTrigger(w http.ResponseWriter, r *http.Request) {
+	if err := h.svc.PollOnce(r.Context()); err != nil {
+		writeAutoscanError(w, err)
+		return
+	}
+	writeJSON(w, http.StatusAccepted, struct {
+		Status string `json:"status"`
+	}{Status: "ok"})
+}
+
+type autoscanStatusSource struct {
+	IntegrationID string     `json:"integration_id"`
+	Name          string     `json:"name"`
+	LastPollAt    *time.Time `json:"last_poll_at,omitempty"`
+}
+
+type autoscanStatusResponse struct {
+	Enabled bool                   `json:"enabled"`
+	Sources []autoscanStatusSource `json:"sources"`
+}
+
+func (h *AutoscanHandler) HandleStatus(w http.ResponseWriter, r *http.Request) {
+	ctx := r.Context()
+	s, _ := h.repo.GetSettings(ctx)
+	sources, _ := h.repo.ListAllSources(ctx)
+	trimmed := make([]autoscanStatusSource, 0, len(sources))
+	for _, src := range sources {
+		trimmed = append(trimmed, autoscanStatusSource{
+			IntegrationID: src.IntegrationID,
+			Name:          src.Name,
+			LastPollAt:    src.LastPollAt,
+		})
+	}
+	writeJSON(w, http.StatusOK, autoscanStatusResponse{
+		Enabled: s.Enabled,
+		Sources: trimmed,
+	})
+}
+
+// writeAutoscanError maps autoscan repository/service errors to HTTP status
+// codes. The repository has no exported sentinel errors; the only domain error
+// it surfaces is a missing integration on upsert, reported as "integration not
+// found: <id>", so we detect that by message and map it to 404. Everything else
+// is an internal failure.
+func writeAutoscanError(w http.ResponseWriter, err error) {
+	if err == nil {
+		return
+	}
+	if strings.Contains(err.Error(), "not found") {
+		writeError(w, http.StatusNotFound, "not_found", "Autoscan source not found")
+		return
+	}
+	writeError(w, http.StatusInternalServerError, "internal_error", "Autoscan operation failed")
+}

--- a/internal/api/handlers/autoscan.go
+++ b/internal/api/handlers/autoscan.go
@@ -3,6 +3,7 @@ package handlers
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"net/http"
 	"strings"
 	"time"
@@ -135,15 +136,12 @@ func (h *AutoscanHandler) HandleStatus(w http.ResponseWriter, r *http.Request) {
 }
 
 // writeAutoscanError maps autoscan repository/service errors to HTTP status
-// codes. The repository has no exported sentinel errors; the only domain error
-// it surfaces is a missing integration on upsert, reported as "integration not
-// found: <id>", so we detect that by message and map it to 404. Everything else
-// is an internal failure.
+// codes: a missing integration on upsert maps to 404, everything else to 500.
 func writeAutoscanError(w http.ResponseWriter, err error) {
 	if err == nil {
 		return
 	}
-	if strings.Contains(err.Error(), "not found") {
+	if errors.Is(err, autoscan.ErrIntegrationNotFound) {
 		writeError(w, http.StatusNotFound, "not_found", "Autoscan source not found")
 		return
 	}

--- a/internal/api/handlers/autoscan_test.go
+++ b/internal/api/handlers/autoscan_test.go
@@ -52,10 +52,20 @@ func (f *fakeAutoscanStore) UpsertSource(_ context.Context, id string, u autosca
 type fakeAutoscanTriggerer struct {
 	called bool
 	err    error
+	// done, when non-nil, receives once PollOnce runs. HandleTrigger dispatches
+	// PollOnce on a detached goroutine, so tests synchronize on this instead of
+	// reading `called` straight after the handler returns (which races the
+	// goroutine and is also an unsynchronized read of `called`). The channel
+	// send happens-before the test's receive, so reading `called` afterwards is
+	// race-free.
+	done chan struct{}
 }
 
 func (f *fakeAutoscanTriggerer) PollOnce(context.Context) error {
 	f.called = true
+	if f.done != nil {
+		f.done <- struct{}{}
+	}
 	return f.err
 }
 
@@ -152,17 +162,24 @@ func TestAutoscanHandleUpsertSourceNotFoundReturns404(t *testing.T) {
 }
 
 func TestAutoscanHandleTriggerInvokesPollOnce(t *testing.T) {
-	trig := &fakeAutoscanTriggerer{}
+	trig := &fakeAutoscanTriggerer{done: make(chan struct{}, 1)}
 	h := NewAutoscanHandler(&fakeAutoscanStore{}, trig, nil)
 
 	rec := httptest.NewRecorder()
 	h.HandleTrigger(rec, httptest.NewRequest("POST", "/api/v1/admin/autoscan/trigger", nil))
 
-	if !trig.called {
-		t.Fatal("PollOnce was not invoked")
-	}
+	// The handler responds immediately and runs PollOnce on a detached
+	// goroutine; wait (bounded) for that goroutine to fire.
 	if rec.Code != http.StatusAccepted {
 		t.Fatalf("status = %d, want 202", rec.Code)
+	}
+	select {
+	case <-trig.done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("PollOnce was not invoked within timeout")
+	}
+	if !trig.called {
+		t.Fatal("PollOnce was not invoked")
 	}
 }
 

--- a/internal/api/handlers/autoscan_test.go
+++ b/internal/api/handlers/autoscan_test.go
@@ -1,0 +1,201 @@
+package handlers
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/Silo-Server/silo-server/internal/autoscan"
+)
+
+type fakeAutoscanStore struct {
+	getSettingsFn    func() (autoscan.Settings, error)
+	updateSettingsFn func(autoscan.Settings) (autoscan.Settings, error)
+	listSourcesFn    func() ([]autoscan.Source, error)
+	upsertSourceFn   func(string, autoscan.SourceUpdate) (*autoscan.Source, error)
+}
+
+func (f *fakeAutoscanStore) GetSettings(context.Context) (autoscan.Settings, error) {
+	if f.getSettingsFn != nil {
+		return f.getSettingsFn()
+	}
+	return autoscan.Settings{}, nil
+}
+
+func (f *fakeAutoscanStore) UpdateSettings(_ context.Context, s autoscan.Settings) (autoscan.Settings, error) {
+	if f.updateSettingsFn != nil {
+		return f.updateSettingsFn(s)
+	}
+	return s, nil
+}
+
+func (f *fakeAutoscanStore) ListAllSources(context.Context) ([]autoscan.Source, error) {
+	if f.listSourcesFn != nil {
+		return f.listSourcesFn()
+	}
+	return nil, nil
+}
+
+func (f *fakeAutoscanStore) UpsertSource(_ context.Context, id string, u autoscan.SourceUpdate) (*autoscan.Source, error) {
+	if f.upsertSourceFn != nil {
+		return f.upsertSourceFn(id, u)
+	}
+	return &autoscan.Source{IntegrationID: id, Enabled: u.Enabled, PathRewrites: u.PathRewrites}, nil
+}
+
+type fakeAutoscanTriggerer struct {
+	called bool
+	err    error
+}
+
+func (f *fakeAutoscanTriggerer) PollOnce(context.Context) error {
+	f.called = true
+	return f.err
+}
+
+func TestAutoscanHandleGetSettingsReturnsJSON(t *testing.T) {
+	store := &fakeAutoscanStore{
+		getSettingsFn: func() (autoscan.Settings, error) {
+			return autoscan.Settings{Enabled: true, PollIntervalMinutes: 5, DebounceSeconds: 30}, nil
+		},
+	}
+	h := NewAutoscanHandler(store, &fakeAutoscanTriggerer{})
+
+	rec := httptest.NewRecorder()
+	h.HandleGetSettings(rec, httptest.NewRequest("GET", "/api/v1/admin/autoscan/settings", nil))
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200", rec.Code)
+	}
+	var body autoscan.Settings
+	if err := json.NewDecoder(rec.Body).Decode(&body); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if !body.Enabled || body.PollIntervalMinutes != 5 {
+		t.Errorf("settings = %+v", body)
+	}
+}
+
+func TestAutoscanHandleUpdateSettingsRejectsZeroInterval(t *testing.T) {
+	h := NewAutoscanHandler(&fakeAutoscanStore{}, &fakeAutoscanTriggerer{})
+
+	req := httptest.NewRequest("PUT", "/api/v1/admin/autoscan/settings",
+		strings.NewReader(`{"enabled":true,"poll_interval_minutes":0,"debounce_seconds":10}`))
+	rec := httptest.NewRecorder()
+	h.HandleUpdateSettings(rec, req)
+
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d, want 400; body=%s", rec.Code, rec.Body.String())
+	}
+}
+
+func TestAutoscanHandleListSourcesOmitsSecrets(t *testing.T) {
+	now := time.Now()
+	store := &fakeAutoscanStore{
+		listSourcesFn: func() ([]autoscan.Source, error) {
+			return []autoscan.Source{
+				{
+					IntegrationID: "radarr-1",
+					Kind:          "radarr",
+					Name:          "Radarr",
+					BaseURL:       "http://radarr.internal:7878",
+					APIKeyRef:     "secret-ref-xyz",
+					Enabled:       true,
+					LastPollAt:    &now,
+				},
+			}, nil
+		},
+	}
+	h := NewAutoscanHandler(store, &fakeAutoscanTriggerer{})
+
+	rec := httptest.NewRecorder()
+	h.HandleListSources(rec, httptest.NewRequest("GET", "/api/v1/admin/autoscan/sources", nil))
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200", rec.Code)
+	}
+	raw := rec.Body.String()
+	if strings.Contains(raw, "base_url") || strings.Contains(raw, "radarr.internal") {
+		t.Errorf("response leaks base_url: %s", raw)
+	}
+	if strings.Contains(raw, "api_key_ref") || strings.Contains(raw, "secret-ref-xyz") {
+		t.Errorf("response leaks api_key_ref: %s", raw)
+	}
+}
+
+func TestAutoscanHandleUpsertSourceNotFoundReturns404(t *testing.T) {
+	store := &fakeAutoscanStore{
+		upsertSourceFn: func(string, autoscan.SourceUpdate) (*autoscan.Source, error) {
+			return nil, errIntegrationNotFound
+		},
+	}
+	h := NewAutoscanHandler(store, &fakeAutoscanTriggerer{})
+
+	req := httptest.NewRequest("PUT", "/api/v1/admin/autoscan/sources/missing",
+		strings.NewReader(`{"enabled":true,"path_rewrites":[]}`))
+	rec := httptest.NewRecorder()
+	h.HandleUpsertSource(rec, req)
+
+	if rec.Code != http.StatusNotFound {
+		t.Fatalf("status = %d, want 404; body=%s", rec.Code, rec.Body.String())
+	}
+}
+
+func TestAutoscanHandleTriggerInvokesPollOnce(t *testing.T) {
+	trig := &fakeAutoscanTriggerer{}
+	h := NewAutoscanHandler(&fakeAutoscanStore{}, trig)
+
+	rec := httptest.NewRecorder()
+	h.HandleTrigger(rec, httptest.NewRequest("POST", "/api/v1/admin/autoscan/trigger", nil))
+
+	if !trig.called {
+		t.Fatal("PollOnce was not invoked")
+	}
+	if rec.Code != http.StatusAccepted {
+		t.Fatalf("status = %d, want 202", rec.Code)
+	}
+}
+
+func TestAutoscanHandleStatusReturnsTrimmedSources(t *testing.T) {
+	store := &fakeAutoscanStore{
+		getSettingsFn: func() (autoscan.Settings, error) {
+			return autoscan.Settings{Enabled: true}, nil
+		},
+		listSourcesFn: func() ([]autoscan.Source, error) {
+			return []autoscan.Source{
+				{IntegrationID: "radarr-1", Name: "Radarr", BaseURL: "http://x:7878", APIKeyRef: "k"},
+			}, nil
+		},
+	}
+	h := NewAutoscanHandler(store, &fakeAutoscanTriggerer{})
+
+	rec := httptest.NewRecorder()
+	h.HandleStatus(rec, httptest.NewRequest("GET", "/api/v1/admin/autoscan/status", nil))
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200", rec.Code)
+	}
+	raw := rec.Body.String()
+	if strings.Contains(raw, "base_url") || strings.Contains(raw, "api_key_ref") {
+		t.Errorf("status leaks secrets: %s", raw)
+	}
+	var body autoscanStatusResponse
+	if err := json.NewDecoder(rec.Body).Decode(&body); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if !body.Enabled || len(body.Sources) != 1 || body.Sources[0].IntegrationID != "radarr-1" {
+		t.Errorf("status = %+v", body)
+	}
+}
+
+// errIntegrationNotFound mirrors the repository's "integration not found"
+// message so the handler's substring-based 404 mapping is exercised.
+var errIntegrationNotFound = &autoscanTestError{"integration not found: missing"}
+
+type autoscanTestError struct{ msg string }
+
+func (e *autoscanTestError) Error() string { return e.msg }

--- a/internal/api/handlers/autoscan_test.go
+++ b/internal/api/handlers/autoscan_test.go
@@ -9,6 +9,8 @@ import (
 	"testing"
 	"time"
 
+	"github.com/go-chi/chi/v5"
+
 	"github.com/Silo-Server/silo-server/internal/autoscan"
 )
 
@@ -55,6 +57,10 @@ type fakeAutoscanTriggerer struct {
 func (f *fakeAutoscanTriggerer) PollOnce(context.Context) error {
 	f.called = true
 	return f.err
+}
+
+func (f *fakeAutoscanTriggerer) SuggestRewrites(context.Context, string) (autoscan.RewriteSuggestions, error) {
+	return autoscan.RewriteSuggestions{}, nil
 }
 
 func TestAutoscanHandleGetSettingsReturnsJSON(t *testing.T) {
@@ -192,10 +198,26 @@ func TestAutoscanHandleStatusReturnsTrimmedSources(t *testing.T) {
 	}
 }
 
-// errIntegrationNotFound mirrors the repository's "integration not found"
-// message so the handler's substring-based 404 mapping is exercised.
-var errIntegrationNotFound = &autoscanTestError{"integration not found: missing"}
+func TestAutoscanHandleRewriteSuggestions(t *testing.T) {
+	h := NewAutoscanHandler(&fakeAutoscanStore{}, &fakeAutoscanTriggerer{}, nil)
 
-type autoscanTestError struct{ msg string }
+	req := httptest.NewRequest("GET", "/api/v1/admin/autoscan/sources/radarr-1/rewrite-suggestions", nil)
+	routeCtx := chi.NewRouteContext()
+	routeCtx.URLParams.Add("id", "radarr-1")
+	req = req.WithContext(context.WithValue(req.Context(), chi.RouteCtxKey, routeCtx))
+	rec := httptest.NewRecorder()
 
-func (e *autoscanTestError) Error() string { return e.msg }
+	h.HandleRewriteSuggestions(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200; body=%s", rec.Code, rec.Body.String())
+	}
+	var body autoscan.RewriteSuggestions
+	if err := json.NewDecoder(rec.Body).Decode(&body); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+}
+
+// errIntegrationNotFound is the repository's sentinel, so the handler's
+// errors.Is-based 404 mapping is exercised.
+var errIntegrationNotFound = autoscan.ErrIntegrationNotFound

--- a/internal/api/handlers/autoscan_test.go
+++ b/internal/api/handlers/autoscan_test.go
@@ -63,7 +63,7 @@ func TestAutoscanHandleGetSettingsReturnsJSON(t *testing.T) {
 			return autoscan.Settings{Enabled: true, PollIntervalMinutes: 5, DebounceSeconds: 30}, nil
 		},
 	}
-	h := NewAutoscanHandler(store, &fakeAutoscanTriggerer{})
+	h := NewAutoscanHandler(store, &fakeAutoscanTriggerer{}, nil)
 
 	rec := httptest.NewRecorder()
 	h.HandleGetSettings(rec, httptest.NewRequest("GET", "/api/v1/admin/autoscan/settings", nil))
@@ -81,7 +81,7 @@ func TestAutoscanHandleGetSettingsReturnsJSON(t *testing.T) {
 }
 
 func TestAutoscanHandleUpdateSettingsRejectsZeroInterval(t *testing.T) {
-	h := NewAutoscanHandler(&fakeAutoscanStore{}, &fakeAutoscanTriggerer{})
+	h := NewAutoscanHandler(&fakeAutoscanStore{}, &fakeAutoscanTriggerer{}, nil)
 
 	req := httptest.NewRequest("PUT", "/api/v1/admin/autoscan/settings",
 		strings.NewReader(`{"enabled":true,"poll_interval_minutes":0,"debounce_seconds":10}`))
@@ -110,7 +110,7 @@ func TestAutoscanHandleListSourcesOmitsSecrets(t *testing.T) {
 			}, nil
 		},
 	}
-	h := NewAutoscanHandler(store, &fakeAutoscanTriggerer{})
+	h := NewAutoscanHandler(store, &fakeAutoscanTriggerer{}, nil)
 
 	rec := httptest.NewRecorder()
 	h.HandleListSources(rec, httptest.NewRequest("GET", "/api/v1/admin/autoscan/sources", nil))
@@ -133,7 +133,7 @@ func TestAutoscanHandleUpsertSourceNotFoundReturns404(t *testing.T) {
 			return nil, errIntegrationNotFound
 		},
 	}
-	h := NewAutoscanHandler(store, &fakeAutoscanTriggerer{})
+	h := NewAutoscanHandler(store, &fakeAutoscanTriggerer{}, nil)
 
 	req := httptest.NewRequest("PUT", "/api/v1/admin/autoscan/sources/missing",
 		strings.NewReader(`{"enabled":true,"path_rewrites":[]}`))
@@ -147,7 +147,7 @@ func TestAutoscanHandleUpsertSourceNotFoundReturns404(t *testing.T) {
 
 func TestAutoscanHandleTriggerInvokesPollOnce(t *testing.T) {
 	trig := &fakeAutoscanTriggerer{}
-	h := NewAutoscanHandler(&fakeAutoscanStore{}, trig)
+	h := NewAutoscanHandler(&fakeAutoscanStore{}, trig, nil)
 
 	rec := httptest.NewRecorder()
 	h.HandleTrigger(rec, httptest.NewRequest("POST", "/api/v1/admin/autoscan/trigger", nil))
@@ -171,7 +171,7 @@ func TestAutoscanHandleStatusReturnsTrimmedSources(t *testing.T) {
 			}, nil
 		},
 	}
-	h := NewAutoscanHandler(store, &fakeAutoscanTriggerer{})
+	h := NewAutoscanHandler(store, &fakeAutoscanTriggerer{}, nil)
 
 	rec := httptest.NewRecorder()
 	h.HandleStatus(rec, httptest.NewRequest("GET", "/api/v1/admin/autoscan/status", nil))

--- a/internal/api/router.go
+++ b/internal/api/router.go
@@ -23,6 +23,7 @@ import (
 	"github.com/Silo-Server/silo-server/internal/api/handlers"
 	apimw "github.com/Silo-Server/silo-server/internal/api/middleware"
 	"github.com/Silo-Server/silo-server/internal/auth"
+	"github.com/Silo-Server/silo-server/internal/autoscan"
 	"github.com/Silo-Server/silo-server/internal/cache"
 	"github.com/Silo-Server/silo-server/internal/catalog"
 	"github.com/Silo-Server/silo-server/internal/catalogseed"
@@ -52,6 +53,7 @@ import (
 	"github.com/Silo-Server/silo-server/internal/s3client"
 	"github.com/Silo-Server/silo-server/internal/scanner"
 	"github.com/Silo-Server/silo-server/internal/scanqueue"
+	"github.com/Silo-Server/silo-server/internal/scantrigger"
 	"github.com/Silo-Server/silo-server/internal/sections"
 	"github.com/Silo-Server/silo-server/internal/subtitles"
 	subtitleai "github.com/Silo-Server/silo-server/internal/subtitles/ai"
@@ -340,6 +342,7 @@ func NewRouter(deps Dependencies) chi.Router {
 	var calendarRepo *catalog.CalendarRepository
 	var webhookSyncHandler *handlers.WebhookSyncHandler
 	var requestHandler *handlers.RequestsHandler
+	var autoscanHandler *handlers.AutoscanHandler
 	if deps.DB != nil {
 		browseRepo := catalog.NewBrowseRepository(deps.DB)
 		itemRepo = catalog.NewItemRepository(deps.DB)
@@ -414,6 +417,19 @@ func NewRouter(deps Dependencies) chi.Router {
 			requestSvc.SetEntitlementResolver(mediarequests.NewAccessEntitlements(viewerResolver))
 		}
 		requestHandler = handlers.NewRequestsHandler(requestSvc)
+
+		autoscanRepo := autoscan.NewRepository(deps.DB)
+		if deps.FolderRepo != nil && deps.LibraryScanQueue != nil {
+			autoscanSvc := autoscan.NewService(
+				autoscanRepo,
+				autoscan.NewArrHistoryClient(nil),
+				scantrigger.NewResolver(deps.FolderRepo),
+				deps.LibraryScanQueue,
+				autoscan.NewRedisSuppressor(deps.RedisClient),
+				settingsRepo,
+			)
+			autoscanHandler = handlers.NewAutoscanHandler(autoscanRepo, autoscanSvc)
+		}
 
 		if deps.PersonRepo != nil {
 			peopleHandler = handlers.NewPeopleHandler(deps.PersonRepo, browseRepo, itemRepo, detailSvc)
@@ -2047,6 +2063,15 @@ func NewRouter(deps Dependencies) chi.Router {
 								r.Put("/request-integrations/{id}", requestHandler.HandleUpdateIntegration)
 								r.Delete("/request-integrations/{id}", requestHandler.HandleDeleteIntegration)
 								r.Post("/request-integrations/{id}/options", requestHandler.HandleLoadIntegrationOptions)
+							}
+
+							if autoscanHandler != nil {
+								r.Get("/autoscan/settings", autoscanHandler.HandleGetSettings)
+								r.Put("/autoscan/settings", autoscanHandler.HandleUpdateSettings)
+								r.Get("/autoscan/sources", autoscanHandler.HandleListSources)
+								r.Put("/autoscan/sources/{id}", autoscanHandler.HandleUpsertSource)
+								r.Post("/autoscan/trigger", autoscanHandler.HandleTrigger)
+								r.Get("/autoscan/status", autoscanHandler.HandleStatus)
 							}
 
 							if deps.ActivityLogRepo != nil {

--- a/internal/api/router.go
+++ b/internal/api/router.go
@@ -428,6 +428,10 @@ func NewRouter(deps Dependencies) chi.Router {
 				autoscan.NewRedisSuppressor(deps.RedisClient),
 				settingsRepo,
 			)
+			autoscanSvc.SetRewriteResolvers(
+				autoscan.NewArrRootFolderClient(nil),
+				autoscan.NewCatalogFolderLister(deps.FolderRepo),
+			)
 			autoscanHandler = handlers.NewAutoscanHandler(autoscanRepo, autoscanSvc, deps.TaskManager)
 		}
 
@@ -2072,6 +2076,7 @@ func NewRouter(deps Dependencies) chi.Router {
 								r.Put("/autoscan/sources/{id}", autoscanHandler.HandleUpsertSource)
 								r.Post("/autoscan/trigger", autoscanHandler.HandleTrigger)
 								r.Get("/autoscan/status", autoscanHandler.HandleStatus)
+								r.Get("/autoscan/sources/{id}/rewrite-suggestions", autoscanHandler.HandleRewriteSuggestions)
 							}
 
 							if deps.ActivityLogRepo != nil {

--- a/internal/api/router.go
+++ b/internal/api/router.go
@@ -428,7 +428,7 @@ func NewRouter(deps Dependencies) chi.Router {
 				autoscan.NewRedisSuppressor(deps.RedisClient),
 				settingsRepo,
 			)
-			autoscanHandler = handlers.NewAutoscanHandler(autoscanRepo, autoscanSvc)
+			autoscanHandler = handlers.NewAutoscanHandler(autoscanRepo, autoscanSvc, deps.TaskManager)
 		}
 
 		if deps.PersonRepo != nil {

--- a/internal/autoscan/dedupe.go
+++ b/internal/autoscan/dedupe.go
@@ -1,0 +1,22 @@
+package autoscan
+
+import "path/filepath"
+
+// uniqueParentDirs maps imported file paths to their distinct parent directories,
+// dropping empties. A season's episodes in one folder collapse to one entry.
+func uniqueParentDirs(paths []string) []string {
+	seen := make(map[string]struct{})
+	var out []string
+	for _, p := range paths {
+		if p == "" {
+			continue
+		}
+		dir := filepath.Dir(p)
+		if _, ok := seen[dir]; ok {
+			continue
+		}
+		seen[dir] = struct{}{}
+		out = append(out, dir)
+	}
+	return out
+}

--- a/internal/autoscan/dedupe_test.go
+++ b/internal/autoscan/dedupe_test.go
@@ -1,0 +1,22 @@
+package autoscan
+
+import (
+	"reflect"
+	"sort"
+	"testing"
+)
+
+func TestUniqueParentDirs(t *testing.T) {
+	in := []string{
+		"/mnt/media/Show/Season 01/E01.mkv",
+		"/mnt/media/Show/Season 01/E02.mkv",
+		"/mnt/media/Movie/Movie.mkv",
+		"",
+	}
+	got := uniqueParentDirs(in)
+	sort.Strings(got)
+	want := []string{"/mnt/media/Movie", "/mnt/media/Show/Season 01"}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("uniqueParentDirs = %v, want %v", got, want)
+	}
+}

--- a/internal/autoscan/errors.go
+++ b/internal/autoscan/errors.go
@@ -1,0 +1,7 @@
+package autoscan
+
+import "errors"
+
+// ErrIntegrationNotFound is returned when an autoscan operation references a
+// request integration that does not exist.
+var ErrIntegrationNotFound = errors.New("autoscan: integration not found")

--- a/internal/autoscan/history.go
+++ b/internal/autoscan/history.go
@@ -10,19 +10,27 @@ import (
 	"github.com/Silo-Server/silo-server/internal/requests/arrclient"
 )
 
-// HistoryClient reads recently-imported file paths from a Radarr/Sonarr instance.
+// HistoryClient reads recently-changed file paths from a Radarr/Sonarr instance:
+// newly-imported files plus renamed files (both their old and new paths), so the
+// affected library folders can be rescanned.
 type HistoryClient interface {
-	ImportedPaths(ctx context.Context, baseURL, apiKey string, since time.Time) ([]string, error)
+	ChangedPaths(ctx context.Context, baseURL, apiKey string, since time.Time) ([]string, error)
 }
 
 type historyRecord struct {
 	EventType string `json:"eventType"`
 	Data      struct {
-		ImportedPath string `json:"importedPath"`
+		ImportedPath string `json:"importedPath"` // downloadFolderImported: new file
+		Path         string `json:"path"`         // *FileRenamed: new path
+		SourcePath   string `json:"sourcePath"`   // *FileRenamed: old path
 	} `json:"data"`
 }
 
-const importedEventType = "downloadFolderImported"
+const (
+	eventImported       = "downloadFolderImported"
+	eventEpisodeRenamed = "episodeFileRenamed"
+	eventMovieRenamed   = "movieFileRenamed"
+)
 
 type arrHistoryClient struct {
 	httpClient *http.Client
@@ -33,7 +41,12 @@ func NewArrHistoryClient(httpClient *http.Client) HistoryClient {
 	return &arrHistoryClient{httpClient: httpClient}
 }
 
-func (c *arrHistoryClient) ImportedPaths(ctx context.Context, baseURL, apiKey string, since time.Time) ([]string, error) {
+// ChangedPaths returns file paths whose library folder should be rescanned:
+// imported files, and for renames both the new and old paths (a rename can move
+// a file between folders, so both parents may need scanning). Delete events are
+// intentionally not handled — upgrade-deletes are already covered by the paired
+// import, and standalone deletes carry no file path in arr history.
+func (c *arrHistoryClient) ChangedPaths(ctx context.Context, baseURL, apiKey string, since time.Time) ([]string, error) {
 	client := arrclient.New(baseURL, apiKey, c.httpClient)
 	q := url.Values{}
 	q.Set("date", since.UTC().Format(time.RFC3339))
@@ -43,11 +56,18 @@ func (c *arrHistoryClient) ImportedPaths(ctx context.Context, baseURL, apiKey st
 	}
 	var paths []string
 	for _, rec := range records {
-		if rec.EventType != importedEventType {
-			continue
-		}
-		if rec.Data.ImportedPath != "" {
-			paths = append(paths, rec.Data.ImportedPath)
+		switch rec.EventType {
+		case eventImported:
+			if rec.Data.ImportedPath != "" {
+				paths = append(paths, rec.Data.ImportedPath)
+			}
+		case eventEpisodeRenamed, eventMovieRenamed:
+			if rec.Data.Path != "" {
+				paths = append(paths, rec.Data.Path)
+			}
+			if rec.Data.SourcePath != "" {
+				paths = append(paths, rec.Data.SourcePath)
+			}
 		}
 	}
 	return paths, nil

--- a/internal/autoscan/history.go
+++ b/internal/autoscan/history.go
@@ -1,0 +1,54 @@
+package autoscan
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/url"
+	"time"
+
+	"github.com/Silo-Server/silo-server/internal/requests/arrclient"
+)
+
+// HistoryClient reads recently-imported file paths from a Radarr/Sonarr instance.
+type HistoryClient interface {
+	ImportedPaths(ctx context.Context, baseURL, apiKey string, since time.Time) ([]string, error)
+}
+
+type historyRecord struct {
+	EventType string `json:"eventType"`
+	Data      struct {
+		ImportedPath string `json:"importedPath"`
+	} `json:"data"`
+}
+
+const importedEventType = "downloadFolderImported"
+
+type arrHistoryClient struct {
+	httpClient *http.Client
+}
+
+// NewArrHistoryClient returns a HistoryClient backed by the shared arrclient.
+func NewArrHistoryClient(httpClient *http.Client) HistoryClient {
+	return &arrHistoryClient{httpClient: httpClient}
+}
+
+func (c *arrHistoryClient) ImportedPaths(ctx context.Context, baseURL, apiKey string, since time.Time) ([]string, error) {
+	client := arrclient.New(baseURL, apiKey, c.httpClient)
+	q := url.Values{}
+	q.Set("date", since.UTC().Format(time.RFC3339))
+	var records []historyRecord
+	if err := client.GetJSON(ctx, "/api/v3/history/since?"+q.Encode(), &records); err != nil {
+		return nil, fmt.Errorf("autoscan: poll history: %w", err)
+	}
+	var paths []string
+	for _, rec := range records {
+		if rec.EventType != importedEventType {
+			continue
+		}
+		if rec.Data.ImportedPath != "" {
+			paths = append(paths, rec.Data.ImportedPath)
+		}
+	}
+	return paths, nil
+}

--- a/internal/autoscan/history_test.go
+++ b/internal/autoscan/history_test.go
@@ -1,0 +1,43 @@
+package autoscan
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"sort"
+	"testing"
+	"time"
+)
+
+func TestArrHistoryImportedPaths(t *testing.T) {
+	body := `[
+	  {"eventType":"downloadFolderImported","data":{"importedPath":"/mnt/media/Movies/Dune (2021)/Dune.mkv"}},
+	  {"eventType":"grabbed","data":{"importedPath":"/should/be/ignored"}},
+	  {"eventType":"downloadFolderImported","data":{"importedPath":"/mnt/media/Show/S01/E01.mkv"}}
+	]`
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/api/v3/history/since" {
+			t.Errorf("unexpected path %s", r.URL.Path)
+		}
+		if r.URL.Query().Get("date") == "" {
+			t.Errorf("missing date param")
+		}
+		// AUTH ASSERTION: arrclient uses X-Api-Key header (confirmed in client.go:97).
+		if r.Header.Get("X-Api-Key") != "k" {
+			t.Errorf("missing/incorrect api key header")
+		}
+		_, _ = w.Write([]byte(body))
+	}))
+	defer srv.Close()
+
+	c := NewArrHistoryClient(nil)
+	paths, err := c.ImportedPaths(context.Background(), srv.URL, "k", time.Unix(0, 0).UTC())
+	if err != nil {
+		t.Fatalf("ImportedPaths: %v", err)
+	}
+	sort.Strings(paths)
+	want := []string{"/mnt/media/Movies/Dune (2021)/Dune.mkv", "/mnt/media/Show/S01/E01.mkv"}
+	if len(paths) != 2 || paths[0] != want[0] || paths[1] != want[1] {
+		t.Fatalf("ImportedPaths = %v, want %v", paths, want)
+	}
+}

--- a/internal/autoscan/history_test.go
+++ b/internal/autoscan/history_test.go
@@ -9,11 +9,15 @@ import (
 	"time"
 )
 
-func TestArrHistoryImportedPaths(t *testing.T) {
+func TestArrHistoryChangedPaths(t *testing.T) {
+	// imports contribute importedPath; renames contribute both new path and old
+	// sourcePath; unrelated events (grabbed, episodeFileDeleted) are ignored.
 	body := `[
 	  {"eventType":"downloadFolderImported","data":{"importedPath":"/mnt/media/Movies/Dune (2021)/Dune.mkv"}},
 	  {"eventType":"grabbed","data":{"importedPath":"/should/be/ignored"}},
-	  {"eventType":"downloadFolderImported","data":{"importedPath":"/mnt/media/Show/S01/E01.mkv"}}
+	  {"eventType":"episodeFileRenamed","data":{"path":"/mnt/media/Show/S01/E01 new.mkv","sourcePath":"/mnt/media/Show/S01/E01 old.mkv"}},
+	  {"eventType":"movieFileRenamed","data":{"path":"/mnt/media/Movies/Heat/Heat new.mkv","sourcePath":"/mnt/media/Movies/Heat/Heat old.mkv"}},
+	  {"eventType":"episodeFileDeleted","data":{"reason":"Upgrade"}}
 	]`
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.URL.Path != "/api/v3/history/since" {
@@ -31,13 +35,24 @@ func TestArrHistoryImportedPaths(t *testing.T) {
 	defer srv.Close()
 
 	c := NewArrHistoryClient(nil)
-	paths, err := c.ImportedPaths(context.Background(), srv.URL, "k", time.Unix(0, 0).UTC())
+	paths, err := c.ChangedPaths(context.Background(), srv.URL, "k", time.Unix(0, 0).UTC())
 	if err != nil {
-		t.Fatalf("ImportedPaths: %v", err)
+		t.Fatalf("ChangedPaths: %v", err)
 	}
 	sort.Strings(paths)
-	want := []string{"/mnt/media/Movies/Dune (2021)/Dune.mkv", "/mnt/media/Show/S01/E01.mkv"}
-	if len(paths) != 2 || paths[0] != want[0] || paths[1] != want[1] {
-		t.Fatalf("ImportedPaths = %v, want %v", paths, want)
+	want := []string{
+		"/mnt/media/Movies/Dune (2021)/Dune.mkv",
+		"/mnt/media/Movies/Heat/Heat new.mkv",
+		"/mnt/media/Movies/Heat/Heat old.mkv",
+		"/mnt/media/Show/S01/E01 new.mkv",
+		"/mnt/media/Show/S01/E01 old.mkv",
+	}
+	if len(paths) != len(want) {
+		t.Fatalf("ChangedPaths = %v, want %v", paths, want)
+	}
+	for i := range want {
+		if paths[i] != want[i] {
+			t.Fatalf("ChangedPaths = %v, want %v", paths, want)
+		}
 	}
 }

--- a/internal/autoscan/repository.go
+++ b/internal/autoscan/repository.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgconn"
 	"github.com/jackc/pgx/v5/pgxpool"
 )
 
@@ -121,6 +122,12 @@ func (r *Repository) UpsertSource(ctx context.Context, integrationID string, u S
 			path_rewrites = EXCLUDED.path_rewrites,
 			updated_at = now()`,
 		integrationID, u.Enabled, rewrites); err != nil {
+		// A non-existent integration trips the FK constraint (SQLSTATE 23503);
+		// surface it as a 404 rather than a 500.
+		var pgErr *pgconn.PgError
+		if errors.As(err, &pgErr) && pgErr.Code == "23503" {
+			return nil, fmt.Errorf("%w: %s", ErrIntegrationNotFound, integrationID)
+		}
 		return nil, fmt.Errorf("upsert autoscan source: %w", err)
 	}
 	row := r.pool.QueryRow(ctx, sourceSelect+` WHERE ri.id = $1`, integrationID)
@@ -139,7 +146,9 @@ func (r *Repository) AdvanceLastPoll(ctx context.Context, integrationID string, 
 	_, err := r.pool.Exec(ctx, `
 		INSERT INTO autoscan_sources (integration_id, last_poll_at, updated_at)
 		VALUES ($1, $2, now())
-		ON CONFLICT (integration_id) DO UPDATE SET last_poll_at = $2, updated_at = now()`,
+		ON CONFLICT (integration_id) DO UPDATE SET
+			last_poll_at = GREATEST(autoscan_sources.last_poll_at, $2),
+			updated_at = now()`,
 		integrationID, at)
 	if err != nil {
 		return fmt.Errorf("advance autoscan last_poll: %w", err)

--- a/internal/autoscan/repository.go
+++ b/internal/autoscan/repository.go
@@ -3,6 +3,7 @@ package autoscan
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"time"
 
@@ -125,8 +126,8 @@ func (r *Repository) UpsertSource(ctx context.Context, integrationID string, u S
 	row := r.pool.QueryRow(ctx, sourceSelect+` WHERE ri.id = $1`, integrationID)
 	src, err := scanSource(row)
 	if err != nil {
-		if err == pgx.ErrNoRows {
-			return nil, fmt.Errorf("integration not found: %s", integrationID)
+		if errors.Is(err, pgx.ErrNoRows) {
+			return nil, fmt.Errorf("%w: %s", ErrIntegrationNotFound, integrationID)
 		}
 		return nil, err
 	}

--- a/internal/autoscan/repository.go
+++ b/internal/autoscan/repository.go
@@ -66,6 +66,20 @@ func scanSource(row interface{ Scan(...any) error }) (Source, error) {
 	return src, nil
 }
 
+// GetSource returns one instance's autoscan state joined with its
+// request_integrations row (kind/base_url/api_key_ref), regardless of enabled.
+func (r *Repository) GetSource(ctx context.Context, integrationID string) (*Source, error) {
+	row := r.pool.QueryRow(ctx, sourceSelect+` WHERE ri.id = $1`, integrationID)
+	src, err := scanSource(row)
+	if err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return nil, fmt.Errorf("%w: %s", ErrIntegrationNotFound, integrationID)
+		}
+		return nil, fmt.Errorf("get autoscan source: %w", err)
+	}
+	return &src, nil
+}
+
 // ListAllSources returns every Radarr/Sonarr instance with its autoscan state
 // (admin UI — includes disabled).
 func (r *Repository) ListAllSources(ctx context.Context) ([]Source, error) {

--- a/internal/autoscan/repository.go
+++ b/internal/autoscan/repository.go
@@ -1,0 +1,147 @@
+package autoscan
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"time"
+
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgxpool"
+)
+
+type Repository struct{ pool *pgxpool.Pool }
+
+func NewRepository(pool *pgxpool.Pool) *Repository { return &Repository{pool: pool} }
+
+func (r *Repository) GetSettings(ctx context.Context) (Settings, error) {
+	var s Settings
+	err := r.pool.QueryRow(ctx, `
+		SELECT enabled, poll_interval_minutes, debounce_seconds, updated_at
+		FROM autoscan_settings WHERE id = true`).
+		Scan(&s.Enabled, &s.PollIntervalMinutes, &s.DebounceSeconds, &s.UpdatedAt)
+	if err != nil {
+		return Settings{}, fmt.Errorf("get autoscan settings: %w", err)
+	}
+	return s, nil
+}
+
+func (r *Repository) UpdateSettings(ctx context.Context, s Settings) (Settings, error) {
+	var out Settings
+	err := r.pool.QueryRow(ctx, `
+		UPDATE autoscan_settings
+		SET enabled = $1, poll_interval_minutes = $2, debounce_seconds = $3, updated_at = now()
+		WHERE id = true
+		RETURNING enabled, poll_interval_minutes, debounce_seconds, updated_at`,
+		s.Enabled, s.PollIntervalMinutes, s.DebounceSeconds).
+		Scan(&out.Enabled, &out.PollIntervalMinutes, &out.DebounceSeconds, &out.UpdatedAt)
+	if err != nil {
+		return Settings{}, fmt.Errorf("update autoscan settings: %w", err)
+	}
+	return out, nil
+}
+
+const sourceSelect = `
+	SELECT ri.id, ri.kind, ri.name, ri.base_url, ri.api_key_ref,
+	       COALESCE(s.enabled, false), COALESCE(s.path_rewrites, '[]'::jsonb), s.last_poll_at
+	FROM request_integrations ri
+	LEFT JOIN autoscan_sources s ON s.integration_id = ri.id`
+
+func scanSource(row interface{ Scan(...any) error }) (Source, error) {
+	var src Source
+	var rewritesRaw []byte
+	var lastPoll *time.Time
+	if err := row.Scan(&src.IntegrationID, &src.Kind, &src.Name, &src.BaseURL, &src.APIKeyRef,
+		&src.Enabled, &rewritesRaw, &lastPoll); err != nil {
+		return Source{}, err
+	}
+	if len(rewritesRaw) > 0 {
+		if err := json.Unmarshal(rewritesRaw, &src.PathRewrites); err != nil {
+			return Source{}, fmt.Errorf("unmarshal path_rewrites for %s: %w", src.IntegrationID, err)
+		}
+	}
+	src.LastPollAt = lastPoll
+	return src, nil
+}
+
+// ListAllSources returns every Radarr/Sonarr instance with its autoscan state
+// (admin UI — includes disabled).
+func (r *Repository) ListAllSources(ctx context.Context) ([]Source, error) {
+	rows, err := r.pool.Query(ctx, sourceSelect+` ORDER BY ri.kind, ri.name`)
+	if err != nil {
+		return nil, fmt.Errorf("list autoscan sources: %w", err)
+	}
+	defer rows.Close()
+	var out []Source
+	for rows.Next() {
+		src, err := scanSource(rows)
+		if err != nil {
+			return nil, err
+		}
+		out = append(out, src)
+	}
+	return out, rows.Err()
+}
+
+// ListEnabledSources returns only autoscan-enabled instances whose integration is
+// itself enabled (the poll set).
+func (r *Repository) ListEnabledSources(ctx context.Context) ([]Source, error) {
+	rows, err := r.pool.Query(ctx, sourceSelect+
+		` WHERE s.enabled = true AND ri.enabled = true ORDER BY ri.kind, ri.name`)
+	if err != nil {
+		return nil, fmt.Errorf("list enabled autoscan sources: %w", err)
+	}
+	defer rows.Close()
+	var out []Source
+	for rows.Next() {
+		src, err := scanSource(rows)
+		if err != nil {
+			return nil, err
+		}
+		out = append(out, src)
+	}
+	return out, rows.Err()
+}
+
+// UpsertSource sets the per-instance autoscan toggle + rewrites.
+func (r *Repository) UpsertSource(ctx context.Context, integrationID string, u SourceUpdate) (*Source, error) {
+	rewrites, err := json.Marshal(u.PathRewrites)
+	if err != nil {
+		return nil, fmt.Errorf("marshal path_rewrites: %w", err)
+	}
+	if u.PathRewrites == nil {
+		rewrites = []byte("[]")
+	}
+	if _, err := r.pool.Exec(ctx, `
+		INSERT INTO autoscan_sources (integration_id, enabled, path_rewrites, updated_at)
+		VALUES ($1, $2, $3, now())
+		ON CONFLICT (integration_id) DO UPDATE SET
+			enabled = EXCLUDED.enabled,
+			path_rewrites = EXCLUDED.path_rewrites,
+			updated_at = now()`,
+		integrationID, u.Enabled, rewrites); err != nil {
+		return nil, fmt.Errorf("upsert autoscan source: %w", err)
+	}
+	row := r.pool.QueryRow(ctx, sourceSelect+` WHERE ri.id = $1`, integrationID)
+	src, err := scanSource(row)
+	if err != nil {
+		if err == pgx.ErrNoRows {
+			return nil, fmt.Errorf("integration not found: %s", integrationID)
+		}
+		return nil, err
+	}
+	return &src, nil
+}
+
+// AdvanceLastPoll sets last_poll_at for a source (creating the row if needed).
+func (r *Repository) AdvanceLastPoll(ctx context.Context, integrationID string, at time.Time) error {
+	_, err := r.pool.Exec(ctx, `
+		INSERT INTO autoscan_sources (integration_id, last_poll_at, updated_at)
+		VALUES ($1, $2, now())
+		ON CONFLICT (integration_id) DO UPDATE SET last_poll_at = $2, updated_at = now()`,
+		integrationID, at)
+	if err != nil {
+		return fmt.Errorf("advance autoscan last_poll: %w", err)
+	}
+	return nil
+}

--- a/internal/autoscan/rewrite.go
+++ b/internal/autoscan/rewrite.go
@@ -10,8 +10,11 @@ func applyRewrites(path string, rewrites []PathRewrite) string {
 		if from == "" {
 			continue
 		}
-		if strings.HasPrefix(path, from) {
-			return strings.TrimSpace(rw.To) + strings.TrimPrefix(path, from)
+		// Match only at a path-segment boundary: exact, or prefix followed by '/'.
+		// This prevents From="/data/media" from rewriting "/data/media2/x".
+		trimmed := strings.TrimSuffix(from, "/")
+		if path == trimmed || strings.HasPrefix(path, trimmed+"/") {
+			return strings.TrimSpace(rw.To) + strings.TrimPrefix(path, trimmed)
 		}
 	}
 	return path

--- a/internal/autoscan/rewrite.go
+++ b/internal/autoscan/rewrite.go
@@ -2,6 +2,13 @@ package autoscan
 
 import "strings"
 
+// normalizeSeparators converts Windows backslash separators to forward slashes
+// so paths from a Windows-hosted arr resolve on the Linux host. (filepath.ToSlash
+// is a no-op on Linux, so the replacement is explicit.)
+func normalizeSeparators(path string) string {
+	return strings.ReplaceAll(path, "\\", "/")
+}
+
 // applyRewrites returns path with the first matching prefix rewrite applied,
 // or path unchanged when none match.
 func applyRewrites(path string, rewrites []PathRewrite) string {

--- a/internal/autoscan/rewrite.go
+++ b/internal/autoscan/rewrite.go
@@ -1,0 +1,18 @@
+package autoscan
+
+import "strings"
+
+// applyRewrites returns path with the first matching prefix rewrite applied,
+// or path unchanged when none match.
+func applyRewrites(path string, rewrites []PathRewrite) string {
+	for _, rw := range rewrites {
+		from := strings.TrimSpace(rw.From)
+		if from == "" {
+			continue
+		}
+		if strings.HasPrefix(path, from) {
+			return strings.TrimSpace(rw.To) + strings.TrimPrefix(path, from)
+		}
+	}
+	return path
+}

--- a/internal/autoscan/rewrite_test.go
+++ b/internal/autoscan/rewrite_test.go
@@ -33,3 +33,18 @@ func TestApplyRewrites(t *testing.T) {
 		t.Fatalf("boundary: exact /data/media -> /mnt, got %q", got)
 	}
 }
+
+func TestNormalizeSeparators(t *testing.T) {
+	if got := normalizeSeparators(`C:\Media\Movies\Dune\Dune.mkv`); got != "C:/Media/Movies/Dune/Dune.mkv" {
+		t.Fatalf("normalizeSeparators(windows) = %q", got)
+	}
+	// POSIX paths are unchanged.
+	if got := normalizeSeparators("/mnt/media/x.mkv"); got != "/mnt/media/x.mkv" {
+		t.Fatalf("normalizeSeparators(posix) = %q", got)
+	}
+	// A normalized Windows path then rewrites + dedupes on the Linux host.
+	rw := []PathRewrite{{From: "C:/Media", To: "/mnt/media"}}
+	if got := applyRewrites(normalizeSeparators(`C:\Media\ShowA\S01\E01.mkv`), rw); got != "/mnt/media/ShowA/S01/E01.mkv" {
+		t.Fatalf("windows rewrite = %q", got)
+	}
+}

--- a/internal/autoscan/rewrite_test.go
+++ b/internal/autoscan/rewrite_test.go
@@ -1,0 +1,23 @@
+package autoscan
+
+import "testing"
+
+func TestApplyRewrites(t *testing.T) {
+	rw := []PathRewrite{{From: "/data/media", To: "/mnt/media"}}
+	cases := []struct{ in, want string }{
+		{"/data/media/Movies/Dune/Dune.mkv", "/mnt/media/Movies/Dune/Dune.mkv"},
+		{"/other/path/file.mkv", "/other/path/file.mkv"},
+	}
+	for _, tc := range cases {
+		if got := applyRewrites(tc.in, rw); got != tc.want {
+			t.Fatalf("applyRewrites(%q) = %q, want %q", tc.in, got, tc.want)
+		}
+	}
+	multi := []PathRewrite{{From: "/data", To: "/A"}, {From: "/data/media", To: "/B"}}
+	if got := applyRewrites("/data/media/x", multi); got != "/A/media/x" {
+		t.Fatalf("first-match: got %q", got)
+	}
+	if got := applyRewrites("/data/media/x", nil); got != "/data/media/x" {
+		t.Fatalf("nil rewrites: got %q", got)
+	}
+}

--- a/internal/autoscan/rewrite_test.go
+++ b/internal/autoscan/rewrite_test.go
@@ -20,4 +20,16 @@ func TestApplyRewrites(t *testing.T) {
 	if got := applyRewrites("/data/media/x", nil); got != "/data/media/x" {
 		t.Fatalf("nil rewrites: got %q", got)
 	}
+
+	// Segment-boundary matching: a sibling dir sharing the prefix must NOT match.
+	boundary := []PathRewrite{{From: "/data/media", To: "/mnt"}}
+	if got := applyRewrites("/data/media2/x", boundary); got != "/data/media2/x" {
+		t.Fatalf("boundary: /data/media2/x must not rewrite, got %q", got)
+	}
+	if got := applyRewrites("/data/media/x", boundary); got != "/mnt/x" {
+		t.Fatalf("boundary: /data/media/x -> /mnt/x, got %q", got)
+	}
+	if got := applyRewrites("/data/media", boundary); got != "/mnt" {
+		t.Fatalf("boundary: exact /data/media -> /mnt, got %q", got)
+	}
 }

--- a/internal/autoscan/service.go
+++ b/internal/autoscan/service.go
@@ -104,7 +104,10 @@ func (s *Service) PollOnce(ctx context.Context) error {
 
 		rewritten := make([]string, 0, len(paths))
 		for _, p := range paths {
-			rewritten = append(rewritten, applyRewrites(p, src.PathRewrites))
+			// Normalize Windows separators so an arr running on Windows (reporting
+			// C:\Media\... paths) still rewrites/resolves on the Linux host. Path
+			// rewrites and Silo media folders are expected to use forward slashes.
+			rewritten = append(rewritten, applyRewrites(normalizeSeparators(p), src.PathRewrites))
 		}
 		var targets []scantrigger.Target
 		var claimed []string

--- a/internal/autoscan/service.go
+++ b/internal/autoscan/service.go
@@ -2,6 +2,8 @@ package autoscan
 
 import (
 	"context"
+	"errors"
+	"fmt"
 	"log/slog"
 	"time"
 
@@ -9,6 +11,11 @@ import (
 )
 
 const scanTrigger = "autoscan"
+
+const (
+	pollOverlap = 2 * time.Minute // re-poll a small overlap so boundary events aren't missed
+	maxLookback = 24 * time.Hour  // cap the window so a long outage can't produce an oversized response
+)
 
 type Store interface {
 	GetSettings(ctx context.Context) (Settings, error)
@@ -69,6 +76,13 @@ func (s *Service) PollOnce(ctx context.Context) error {
 		if src.LastPollAt != nil {
 			since = *src.LastPollAt
 		}
+		// Overlap buffer absorbs clock skew so boundary events aren't missed.
+		since = since.Add(-pollOverlap)
+		// Floor the window so a long outage can't produce an oversized history
+		// response that arrclient truncates (permanent stall otherwise).
+		if floor := cycleStart.Add(-maxLookback); since.Before(floor) {
+			since = floor
+		}
 
 		apiKey := src.APIKeyRef
 		if s.secrets != nil && apiKey != "" {
@@ -93,30 +107,39 @@ func (s *Service) PollOnce(ctx context.Context) error {
 			rewritten = append(rewritten, applyRewrites(p, src.PathRewrites))
 		}
 		var targets []scantrigger.Target
-		var claimed []int
+		var claimed []string
 		for _, dir := range uniqueParentDirs(rewritten) {
 			target, rerr := s.resolver.Resolve(ctx, scantrigger.Request{Path: dir, Trigger: scanTrigger})
 			if rerr != nil {
+				var reqErr *scantrigger.RequestError
+				if errors.As(rerr, &reqErr) {
+					// Path outside Silo's media folders (or otherwise unresolvable)
+					// — an expected skip, not an error worth logging every cycle.
+					continue
+				}
 				slog.WarnContext(ctx, "autoscan: resolve failed", "path", dir, "err", rerr)
 				continue
 			}
 			if target == nil || target.Folder == nil {
 				continue
 			}
-			ok, serr := s.suppress.ShouldScan(ctx, target.Folder.ID, ttl)
+			// Key on (folder, path) to match the scanqueue dedup granularity so two
+			// distinct subtrees under one library folder are not collapsed.
+			key := fmt.Sprintf("%d|%s", target.Folder.ID, target.Path)
+			ok, serr := s.suppress.ShouldScan(ctx, key, ttl)
 			if serr != nil || !ok {
 				continue
 			}
 			target.Trigger = scanTrigger
 			targets = append(targets, *target)
-			claimed = append(claimed, target.Folder.ID)
+			claimed = append(claimed, key)
 		}
 		if len(targets) > 0 {
 			if eerr := s.queue.EnqueueScans(ctx, targets); eerr != nil {
 				slog.WarnContext(ctx, "autoscan: enqueue failed", "integration_id", src.IntegrationID, "err", eerr)
-				for _, folderID := range claimed {
-					if rerr := s.suppress.Release(ctx, folderID); rerr != nil {
-						slog.WarnContext(ctx, "autoscan: release claim failed", "folder_id", folderID, "err", rerr)
+				for _, k := range claimed {
+					if rerr := s.suppress.Release(ctx, k); rerr != nil {
+						slog.WarnContext(ctx, "autoscan: release claim failed", "key", k, "err", rerr)
 					}
 				}
 				continue

--- a/internal/autoscan/service.go
+++ b/internal/autoscan/service.go
@@ -72,7 +72,12 @@ func (s *Service) PollOnce(ctx context.Context) error {
 
 		apiKey := src.APIKeyRef
 		if s.secrets != nil && apiKey != "" {
-			if resolved, rerr := s.secrets.Get(ctx, apiKey); rerr == nil && resolved != "" {
+			resolved, rerr := s.secrets.Get(ctx, apiKey)
+			if rerr != nil {
+				slog.WarnContext(ctx, "autoscan: resolve api key failed", "integration_id", src.IntegrationID, "err", rerr)
+				continue
+			}
+			if resolved != "" {
 				apiKey = resolved
 			}
 		}
@@ -88,6 +93,7 @@ func (s *Service) PollOnce(ctx context.Context) error {
 			rewritten = append(rewritten, applyRewrites(p, src.PathRewrites))
 		}
 		var targets []scantrigger.Target
+		var claimed []int
 		for _, dir := range uniqueParentDirs(rewritten) {
 			target, rerr := s.resolver.Resolve(ctx, scantrigger.Request{Path: dir, Trigger: scanTrigger})
 			if rerr != nil {
@@ -103,10 +109,16 @@ func (s *Service) PollOnce(ctx context.Context) error {
 			}
 			target.Trigger = scanTrigger
 			targets = append(targets, *target)
+			claimed = append(claimed, target.Folder.ID)
 		}
 		if len(targets) > 0 {
 			if eerr := s.queue.EnqueueScans(ctx, targets); eerr != nil {
 				slog.WarnContext(ctx, "autoscan: enqueue failed", "integration_id", src.IntegrationID, "err", eerr)
+				for _, folderID := range claimed {
+					if rerr := s.suppress.Release(ctx, folderID); rerr != nil {
+						slog.WarnContext(ctx, "autoscan: release claim failed", "folder_id", folderID, "err", rerr)
+					}
+				}
 				continue
 			}
 		}

--- a/internal/autoscan/service.go
+++ b/internal/autoscan/service.go
@@ -1,0 +1,127 @@
+package autoscan
+
+import (
+	"context"
+	"log/slog"
+	"time"
+
+	"github.com/Silo-Server/silo-server/internal/scantrigger"
+)
+
+const scanTrigger = "autoscan"
+
+type Store interface {
+	GetSettings(ctx context.Context) (Settings, error)
+	ListEnabledSources(ctx context.Context) ([]Source, error)
+	AdvanceLastPoll(ctx context.Context, integrationID string, at time.Time) error
+}
+
+type Resolver interface {
+	Resolve(ctx context.Context, req scantrigger.Request) (*scantrigger.Target, error)
+}
+
+type Queuer interface {
+	EnqueueScans(ctx context.Context, targets []scantrigger.Target) error
+}
+
+type SecretResolver interface {
+	Get(ctx context.Context, key string) (string, error)
+}
+
+type Service struct {
+	store    Store
+	history  HistoryClient
+	resolver Resolver
+	queue    Queuer
+	suppress Suppressor
+	secrets  SecretResolver
+	now      func() time.Time
+}
+
+func NewService(store Store, history HistoryClient, resolver Resolver, queue Queuer, suppress Suppressor, secrets SecretResolver) *Service {
+	return &Service{
+		store: store, history: history, resolver: resolver, queue: queue,
+		suppress: suppress, secrets: secrets,
+		now: func() time.Time { return time.Now().UTC() },
+	}
+}
+
+// PollOnce runs one autoscan cycle. Per-source failures are logged and skipped;
+// only settings/listing errors propagate.
+func (s *Service) PollOnce(ctx context.Context) error {
+	settings, err := s.store.GetSettings(ctx)
+	if err != nil {
+		return err
+	}
+	if !settings.Enabled {
+		return nil
+	}
+	sources, err := s.store.ListEnabledSources(ctx)
+	if err != nil {
+		return err
+	}
+	ttl := time.Duration(settings.DebounceSeconds) * time.Second
+
+	for _, src := range sources {
+		cycleStart := s.now()
+		// First enable: last_poll_at null -> floor at cycleStart (don't replay history).
+		since := cycleStart
+		if src.LastPollAt != nil {
+			since = *src.LastPollAt
+		}
+
+		apiKey := src.APIKeyRef
+		if s.secrets != nil && apiKey != "" {
+			if resolved, rerr := s.secrets.Get(ctx, apiKey); rerr == nil && resolved != "" {
+				apiKey = resolved
+			}
+		}
+
+		paths, perr := s.history.ImportedPaths(ctx, src.BaseURL, apiKey, since)
+		if perr != nil {
+			slog.WarnContext(ctx, "autoscan: source poll failed", "integration_id", src.IntegrationID, "err", perr)
+			continue
+		}
+
+		rewritten := make([]string, 0, len(paths))
+		for _, p := range paths {
+			rewritten = append(rewritten, applyRewrites(p, src.PathRewrites))
+		}
+		var targets []scantrigger.Target
+		for _, dir := range uniqueParentDirs(rewritten) {
+			target, rerr := s.resolver.Resolve(ctx, scantrigger.Request{Path: dir, Trigger: scanTrigger})
+			if rerr != nil {
+				slog.WarnContext(ctx, "autoscan: resolve failed", "path", dir, "err", rerr)
+				continue
+			}
+			if target == nil || target.Folder == nil {
+				continue
+			}
+			ok, serr := s.suppress.ShouldScan(ctx, target.Folder.ID, ttl)
+			if serr != nil || !ok {
+				continue
+			}
+			target.Trigger = scanTrigger
+			targets = append(targets, *target)
+		}
+		if len(targets) > 0 {
+			if eerr := s.queue.EnqueueScans(ctx, targets); eerr != nil {
+				slog.WarnContext(ctx, "autoscan: enqueue failed", "integration_id", src.IntegrationID, "err", eerr)
+				continue
+			}
+		}
+		if aerr := s.store.AdvanceLastPoll(ctx, src.IntegrationID, cycleStart); aerr != nil {
+			slog.WarnContext(ctx, "autoscan: advance last_poll failed", "integration_id", src.IntegrationID, "err", aerr)
+		}
+	}
+	return nil
+}
+
+// PollIntervalMinutes reads the configured interval, defaulting to 10 on error.
+func (s *Service) PollIntervalMinutes(ctx context.Context) int {
+	settings, err := s.store.GetSettings(ctx)
+	if err != nil || settings.PollIntervalMinutes <= 0 {
+		return 10
+	}
+	return settings.PollIntervalMinutes
+}

--- a/internal/autoscan/service.go
+++ b/internal/autoscan/service.go
@@ -99,7 +99,7 @@ func (s *Service) PollOnce(ctx context.Context) error {
 			}
 		}
 
-		paths, perr := s.history.ImportedPaths(ctx, src.BaseURL, apiKey, since)
+		paths, perr := s.history.ChangedPaths(ctx, src.BaseURL, apiKey, since)
 		if perr != nil {
 			slog.WarnContext(ctx, "autoscan: source poll failed", "integration_id", src.IntegrationID, "err", perr)
 			continue

--- a/internal/autoscan/service.go
+++ b/internal/autoscan/service.go
@@ -21,6 +21,7 @@ type Store interface {
 	GetSettings(ctx context.Context) (Settings, error)
 	ListEnabledSources(ctx context.Context) ([]Source, error)
 	AdvanceLastPoll(ctx context.Context, integrationID string, at time.Time) error
+	GetSource(ctx context.Context, integrationID string) (*Source, error)
 }
 
 type Resolver interface {
@@ -36,13 +37,15 @@ type SecretResolver interface {
 }
 
 type Service struct {
-	store    Store
-	history  HistoryClient
-	resolver Resolver
-	queue    Queuer
-	suppress Suppressor
-	secrets  SecretResolver
-	now      func() time.Time
+	store       Store
+	history     HistoryClient
+	resolver    Resolver
+	queue       Queuer
+	suppress    Suppressor
+	secrets     SecretResolver
+	now         func() time.Time
+	rootFolders RootFolderClient
+	folders     FolderLister
 }
 
 func NewService(store Store, history HistoryClient, resolver Resolver, queue Queuer, suppress Suppressor, secrets SecretResolver) *Service {
@@ -162,4 +165,37 @@ func (s *Service) PollIntervalMinutes(ctx context.Context) int {
 		return 10
 	}
 	return settings.PollIntervalMinutes
+}
+
+// SetRewriteResolvers wires the deps used by SuggestRewrites (optional; only the
+// admin-facing service needs them).
+func (s *Service) SetRewriteResolvers(rootFolders RootFolderClient, folders FolderLister) {
+	s.rootFolders = rootFolders
+	s.folders = folders
+}
+
+// SuggestRewrites matches an instance's arr root folders to Silo media folders.
+func (s *Service) SuggestRewrites(ctx context.Context, integrationID string) (RewriteSuggestions, error) {
+	if s.rootFolders == nil || s.folders == nil {
+		return RewriteSuggestions{}, fmt.Errorf("autoscan: rewrite suggestion not configured")
+	}
+	src, err := s.store.GetSource(ctx, integrationID)
+	if err != nil {
+		return RewriteSuggestions{}, err
+	}
+	apiKey := src.APIKeyRef
+	if s.secrets != nil && apiKey != "" {
+		if resolved, rerr := s.secrets.Get(ctx, apiKey); rerr == nil && resolved != "" {
+			apiKey = resolved
+		}
+	}
+	arrRoots, err := s.rootFolders.RootFolders(ctx, src.BaseURL, apiKey)
+	if err != nil {
+		return RewriteSuggestions{}, fmt.Errorf("autoscan: list arr root folders: %w", err)
+	}
+	siloPaths, err := s.folders.ListFolderPaths(ctx)
+	if err != nil {
+		return RewriteSuggestions{}, fmt.Errorf("autoscan: list silo folders: %w", err)
+	}
+	return suggestRewrites(arrRoots, siloPaths, src.PathRewrites), nil
 }

--- a/internal/autoscan/service_test.go
+++ b/internal/autoscan/service_test.go
@@ -55,22 +55,22 @@ func (q *recordingQueuer) EnqueueScans(_ context.Context, targets []scantrigger.
 
 type allowSuppressor struct{}
 
-func (allowSuppressor) ShouldScan(context.Context, int, time.Duration) (bool, error) {
+func (allowSuppressor) ShouldScan(context.Context, string, time.Duration) (bool, error) {
 	return true, nil
 }
-func (allowSuppressor) Release(context.Context, int) error { return nil }
+func (allowSuppressor) Release(context.Context, string) error { return nil }
 
 type recordingSuppressor struct {
-	claimed  []int
-	released []int
+	claimed  []string
+	released []string
 }
 
-func (s *recordingSuppressor) ShouldScan(_ context.Context, folderID int, _ time.Duration) (bool, error) {
-	s.claimed = append(s.claimed, folderID)
+func (s *recordingSuppressor) ShouldScan(_ context.Context, key string, _ time.Duration) (bool, error) {
+	s.claimed = append(s.claimed, key)
 	return true, nil
 }
-func (s *recordingSuppressor) Release(_ context.Context, folderID int) error {
-	s.released = append(s.released, folderID)
+func (s *recordingSuppressor) Release(_ context.Context, key string) error {
+	s.released = append(s.released, key)
 	return nil
 }
 
@@ -107,6 +107,39 @@ func TestPollOnceEnqueuesDedupedFolders(t *testing.T) {
 	}
 	if _, ok := store.advanced["i1"]; !ok {
 		t.Fatalf("expected last_poll advanced for i1")
+	}
+}
+
+func TestPollOnceScansDistinctPathsUnderSameFolder(t *testing.T) {
+	// Two imported subtrees resolve to the SAME folder ID (7) but DIFFERENT
+	// target paths. Keying suppression on folder ID alone would drop the second;
+	// keying on (folder, path) must scan both.
+	store := &fakeStore{
+		settings: Settings{Enabled: true, PollIntervalMinutes: 10, DebounceSeconds: 60},
+		sources: []Source{{
+			IntegrationID: "i1", Kind: "sonarr", BaseURL: "http://sonarr", APIKeyRef: "k", Enabled: true,
+		}},
+	}
+	hist := &fakeHistory{paths: map[string][]string{
+		"http://sonarr": {
+			"/mnt/media/ShowA/S01/E01.mkv",
+			"/mnt/media/ShowB/S01/E01.mkv",
+		},
+	}}
+	q := &recordingQueuer{}
+	sup := &recordingSuppressor{}
+	svc := NewService(store, hist, fakeResolver{}, q, sup, nil)
+	if err := svc.PollOnce(context.Background()); err != nil {
+		t.Fatalf("PollOnce: %v", err)
+	}
+	if len(q.enqueued) != 2 {
+		t.Fatalf("expected 2 enqueued targets (distinct paths), got %d: %+v", len(q.enqueued), q.enqueued)
+	}
+	if len(sup.claimed) != 2 {
+		t.Fatalf("expected 2 claimed keys, got %d: %v", len(sup.claimed), sup.claimed)
+	}
+	if sup.claimed[0] == sup.claimed[1] {
+		t.Fatalf("expected distinct claimed keys, both were %q", sup.claimed[0])
 	}
 }
 

--- a/internal/autoscan/service_test.go
+++ b/internal/autoscan/service_test.go
@@ -58,6 +58,27 @@ type allowSuppressor struct{}
 func (allowSuppressor) ShouldScan(context.Context, int, time.Duration) (bool, error) {
 	return true, nil
 }
+func (allowSuppressor) Release(context.Context, int) error { return nil }
+
+type recordingSuppressor struct {
+	claimed  []int
+	released []int
+}
+
+func (s *recordingSuppressor) ShouldScan(_ context.Context, folderID int, _ time.Duration) (bool, error) {
+	s.claimed = append(s.claimed, folderID)
+	return true, nil
+}
+func (s *recordingSuppressor) Release(_ context.Context, folderID int) error {
+	s.released = append(s.released, folderID)
+	return nil
+}
+
+type failingQueuer struct{}
+
+func (failingQueuer) EnqueueScans(context.Context, []scantrigger.Target) error {
+	return context.DeadlineExceeded
+}
 
 func TestPollOnceEnqueuesDedupedFolders(t *testing.T) {
 	store := &fakeStore{
@@ -114,5 +135,24 @@ func TestPollOnceSourceFailureDoesNotAdvance(t *testing.T) {
 	}
 	if _, ok := store.advanced["i1"]; ok {
 		t.Fatalf("last_poll must NOT advance on source failure")
+	}
+}
+
+func TestPollOnceReleasesClaimOnEnqueueFailure(t *testing.T) {
+	store := &fakeStore{
+		settings: Settings{Enabled: true, PollIntervalMinutes: 10, DebounceSeconds: 60},
+		sources:  []Source{{IntegrationID: "i1", BaseURL: "http://x", APIKeyRef: "k", Enabled: true}},
+	}
+	hist := &fakeHistory{paths: map[string][]string{"http://x": {"/mnt/media/Show/S01/E01.mkv"}}}
+	sup := &recordingSuppressor{}
+	svc := NewService(store, hist, fakeResolver{}, failingQueuer{}, sup, nil)
+	if err := svc.PollOnce(context.Background()); err != nil {
+		t.Fatalf("PollOnce: %v", err)
+	}
+	if len(sup.claimed) != 1 || len(sup.released) != 1 || sup.released[0] != sup.claimed[0] {
+		t.Fatalf("expected claimed folder to be released, claimed=%v released=%v", sup.claimed, sup.released)
+	}
+	if _, ok := store.advanced["i1"]; ok {
+		t.Fatalf("last_poll must NOT advance when enqueue fails")
 	}
 }

--- a/internal/autoscan/service_test.go
+++ b/internal/autoscan/service_test.go
@@ -171,6 +171,8 @@ func TestPollOnceSourceFailureDoesNotAdvance(t *testing.T) {
 	}
 }
 
+func (f *fakeStore) GetSource(context.Context, string) (*Source, error) { return nil, nil }
+
 func TestPollOnceReleasesClaimOnEnqueueFailure(t *testing.T) {
 	store := &fakeStore{
 		settings: Settings{Enabled: true, PollIntervalMinutes: 10, DebounceSeconds: 60},
@@ -187,5 +189,44 @@ func TestPollOnceReleasesClaimOnEnqueueFailure(t *testing.T) {
 	}
 	if _, ok := store.advanced["i1"]; ok {
 		t.Fatalf("last_poll must NOT advance when enqueue fails")
+	}
+}
+
+type fakeRootFolders struct {
+	paths []string
+	err   error
+}
+
+func (f fakeRootFolders) RootFolders(context.Context, string, string) ([]string, error) {
+	return f.paths, f.err
+}
+
+type fakeFolderLister struct{ paths []string }
+
+func (f fakeFolderLister) ListFolderPaths(context.Context) ([]string, error) { return f.paths, nil }
+
+type sourceGetterStore struct {
+	fakeStore
+	src *Source
+}
+
+func (s *sourceGetterStore) GetSource(context.Context, string) (*Source, error) { return s.src, nil }
+
+func TestSuggestRewritesService(t *testing.T) {
+	store := &sourceGetterStore{src: &Source{IntegrationID: "i1", Kind: "sonarr", BaseURL: "http://x", APIKeyRef: "k"}}
+	svc := NewService(store, &fakeHistory{}, fakeResolver{}, &recordingQueuer{}, allowSuppressor{}, nil)
+	svc.SetRewriteResolvers(
+		fakeRootFolders{paths: []string{"/mnt/happy/storage2/tvshows1", "/data/Movies"}},
+		fakeFolderLister{paths: []string{"/mnt/media/happy/storage2/tvshows1"}},
+	)
+	got, err := svc.SuggestRewrites(context.Background(), "i1")
+	if err != nil {
+		t.Fatalf("SuggestRewrites: %v", err)
+	}
+	if len(got.Proposed) != 1 || got.Proposed[0].To != "/mnt/media/happy/storage2/tvshows1" {
+		t.Fatalf("proposed=%+v", got.Proposed)
+	}
+	if len(got.Unmatched) != 1 || got.Unmatched[0] != "/data/Movies" {
+		t.Fatalf("unmatched=%+v", got.Unmatched)
 	}
 }

--- a/internal/autoscan/service_test.go
+++ b/internal/autoscan/service_test.go
@@ -30,7 +30,7 @@ type fakeHistory struct {
 	err   error
 }
 
-func (f *fakeHistory) ImportedPaths(_ context.Context, baseURL, _ string, _ time.Time) ([]string, error) {
+func (f *fakeHistory) ChangedPaths(_ context.Context, baseURL, _ string, _ time.Time) ([]string, error) {
 	if f.err != nil {
 		return nil, f.err
 	}

--- a/internal/autoscan/service_test.go
+++ b/internal/autoscan/service_test.go
@@ -1,0 +1,118 @@
+package autoscan
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/Silo-Server/silo-server/internal/models"
+	"github.com/Silo-Server/silo-server/internal/scantrigger"
+)
+
+type fakeStore struct {
+	settings Settings
+	sources  []Source
+	advanced map[string]time.Time
+}
+
+func (f *fakeStore) GetSettings(context.Context) (Settings, error)        { return f.settings, nil }
+func (f *fakeStore) ListEnabledSources(context.Context) ([]Source, error) { return f.sources, nil }
+func (f *fakeStore) AdvanceLastPoll(_ context.Context, id string, at time.Time) error {
+	if f.advanced == nil {
+		f.advanced = map[string]time.Time{}
+	}
+	f.advanced[id] = at
+	return nil
+}
+
+type fakeHistory struct {
+	paths map[string][]string
+	err   error
+}
+
+func (f *fakeHistory) ImportedPaths(_ context.Context, baseURL, _ string, _ time.Time) ([]string, error) {
+	if f.err != nil {
+		return nil, f.err
+	}
+	return f.paths[baseURL], nil
+}
+
+type fakeResolver struct{}
+
+func (fakeResolver) Resolve(_ context.Context, req scantrigger.Request) (*scantrigger.Target, error) {
+	if len(req.Path) >= 11 && req.Path[:11] == "/mnt/media/" {
+		return &scantrigger.Target{Folder: &models.MediaFolder{ID: 7}, Mode: scantrigger.ModeSubtree, Path: req.Path, Trigger: req.Trigger}, nil
+	}
+	return nil, nil
+}
+
+type recordingQueuer struct{ enqueued []scantrigger.Target }
+
+func (q *recordingQueuer) EnqueueScans(_ context.Context, targets []scantrigger.Target) error {
+	q.enqueued = append(q.enqueued, targets...)
+	return nil
+}
+
+type allowSuppressor struct{}
+
+func (allowSuppressor) ShouldScan(context.Context, int, time.Duration) (bool, error) {
+	return true, nil
+}
+
+func TestPollOnceEnqueuesDedupedFolders(t *testing.T) {
+	store := &fakeStore{
+		settings: Settings{Enabled: true, PollIntervalMinutes: 10, DebounceSeconds: 60},
+		sources: []Source{{
+			IntegrationID: "i1", Kind: "sonarr", BaseURL: "http://sonarr", APIKeyRef: "k", Enabled: true,
+		}},
+	}
+	hist := &fakeHistory{paths: map[string][]string{
+		"http://sonarr": {
+			"/mnt/media/Show/S01/E01.mkv",
+			"/mnt/media/Show/S01/E02.mkv",
+			"/outside/lib/x.mkv",
+		},
+	}}
+	q := &recordingQueuer{}
+	svc := NewService(store, hist, fakeResolver{}, q, allowSuppressor{}, nil)
+	if err := svc.PollOnce(context.Background()); err != nil {
+		t.Fatalf("PollOnce: %v", err)
+	}
+	if len(q.enqueued) != 1 {
+		t.Fatalf("expected 1 deduped folder scan, got %d: %+v", len(q.enqueued), q.enqueued)
+	}
+	if q.enqueued[0].Trigger != "autoscan" || q.enqueued[0].Folder.ID != 7 {
+		t.Fatalf("unexpected target: %+v", q.enqueued[0])
+	}
+	if _, ok := store.advanced["i1"]; !ok {
+		t.Fatalf("expected last_poll advanced for i1")
+	}
+}
+
+func TestPollOnceDisabledNoop(t *testing.T) {
+	store := &fakeStore{settings: Settings{Enabled: false}}
+	q := &recordingQueuer{}
+	svc := NewService(store, &fakeHistory{}, fakeResolver{}, q, allowSuppressor{}, nil)
+	if err := svc.PollOnce(context.Background()); err != nil {
+		t.Fatalf("PollOnce: %v", err)
+	}
+	if len(q.enqueued) != 0 {
+		t.Fatalf("disabled autoscan should enqueue nothing, got %d", len(q.enqueued))
+	}
+}
+
+func TestPollOnceSourceFailureDoesNotAdvance(t *testing.T) {
+	store := &fakeStore{
+		settings: Settings{Enabled: true, PollIntervalMinutes: 10, DebounceSeconds: 60},
+		sources:  []Source{{IntegrationID: "i1", BaseURL: "http://x", APIKeyRef: "k", Enabled: true}},
+	}
+	hist := &fakeHistory{err: context.DeadlineExceeded}
+	q := &recordingQueuer{}
+	svc := NewService(store, hist, fakeResolver{}, q, allowSuppressor{}, nil)
+	if err := svc.PollOnce(context.Background()); err != nil {
+		t.Fatalf("PollOnce should not propagate per-source error: %v", err)
+	}
+	if _, ok := store.advanced["i1"]; ok {
+		t.Fatalf("last_poll must NOT advance on source failure")
+	}
+}

--- a/internal/autoscan/suggest.go
+++ b/internal/autoscan/suggest.go
@@ -90,7 +90,14 @@ func suggestRewrites(arrRoots, siloFolderPaths []string, existing []PathRewrite)
 		siloSegs = append(siloSegs, segments(n))
 	}
 
-	var out RewriteSuggestions
+	// Initialize to non-nil so the JSON response always has arrays ([]) rather
+	// than null — the frontend maps over these directly.
+	out := RewriteSuggestions{
+		Proposed:  []ProposedRewrite{},
+		Unmatched: []string{},
+		Ambiguous: []AmbiguousRoot{},
+		Covered:   []string{},
+	}
 	rootSeen := make(map[string]struct{})
 	for _, raw := range arrRoots {
 		root := normalizePath(raw)

--- a/internal/autoscan/suggest.go
+++ b/internal/autoscan/suggest.go
@@ -56,10 +56,11 @@ func commonSuffixLen(a, b []string) int {
 }
 
 // coveredBy reports whether an existing rewrite already matches root (same
-// boundary rule as applyRewrites).
+// boundary rule as applyRewrites). The existing From is normalized too, so a
+// stored Windows/dup-slash rewrite still covers a normalized root.
 func coveredBy(root string, existing []PathRewrite) bool {
 	for _, rw := range existing {
-		from := strings.TrimRight(strings.TrimSpace(rw.From), "/")
+		from := normalizePath(rw.From)
 		if from == "" {
 			continue
 		}
@@ -75,21 +76,31 @@ func coveredBy(root string, existing []PathRewrite) bool {
 func suggestRewrites(arrRoots, siloFolderPaths []string, existing []PathRewrite) RewriteSuggestions {
 	siloNorm := make([]string, 0, len(siloFolderPaths))
 	siloSegs := make([][]string, 0, len(siloFolderPaths))
+	siloSeen := make(map[string]struct{})
 	for _, p := range siloFolderPaths {
 		n := normalizePath(p)
 		if n == "" {
 			continue
 		}
+		if _, dup := siloSeen[n]; dup { // dedup Silo paths so candidates are distinct
+			continue
+		}
+		siloSeen[n] = struct{}{}
 		siloNorm = append(siloNorm, n)
 		siloSegs = append(siloSegs, segments(n))
 	}
 
 	var out RewriteSuggestions
+	rootSeen := make(map[string]struct{})
 	for _, raw := range arrRoots {
 		root := normalizePath(raw)
 		if root == "" {
 			continue
 		}
+		if _, dup := rootSeen[root]; dup { // dedup arr roots that normalize alike
+			continue
+		}
+		rootSeen[root] = struct{}{}
 		if coveredBy(root, existing) {
 			out.Covered = append(out.Covered, root)
 			continue
@@ -112,6 +123,9 @@ func suggestRewrites(arrRoots, siloFolderPaths []string, existing []PathRewrite)
 		case best == 0:
 			out.Unmatched = append(out.Unmatched, root)
 		case len(winners) == 1:
+			if winners[0] == root {
+				continue // arr path already equals the Silo path — no rewrite needed
+			}
 			out.Proposed = append(out.Proposed, ProposedRewrite{From: root, To: winners[0], MatchDepth: best})
 		default:
 			out.Ambiguous = append(out.Ambiguous, AmbiguousRoot{Root: root, Candidates: winners})

--- a/internal/autoscan/suggest.go
+++ b/internal/autoscan/suggest.go
@@ -1,0 +1,121 @@
+package autoscan
+
+import "strings"
+
+// RewriteSuggestions is the result of matching arr root folders to Silo folders.
+type RewriteSuggestions struct {
+	Proposed  []ProposedRewrite `json:"proposed"`
+	Unmatched []string          `json:"unmatched"`
+	Ambiguous []AmbiguousRoot   `json:"ambiguous"`
+	Covered   []string          `json:"covered"`
+}
+
+// ProposedRewrite is a suggested rewrite plus its confidence (shared trailing segments).
+type ProposedRewrite struct {
+	From       string `json:"from"`
+	To         string `json:"to"`
+	MatchDepth int    `json:"match_depth"`
+}
+
+// AmbiguousRoot is an arr root that tied across multiple Silo folders.
+type AmbiguousRoot struct {
+	Root       string   `json:"root"`
+	Candidates []string `json:"candidates"`
+}
+
+// normalizePath makes a path comparable: backslashes -> '/', collapse duplicate
+// slashes, strip a trailing slash (but keep a bare "/").
+func normalizePath(p string) string {
+	p = normalizeSeparators(strings.TrimSpace(p))
+	for strings.Contains(p, "//") {
+		p = strings.ReplaceAll(p, "//", "/")
+	}
+	if len(p) > 1 {
+		p = strings.TrimRight(p, "/")
+	}
+	return p
+}
+
+func segments(p string) []string {
+	p = strings.Trim(p, "/")
+	if p == "" {
+		return nil
+	}
+	return strings.Split(p, "/")
+}
+
+// commonSuffixLen counts equal trailing segments (full-segment equality).
+func commonSuffixLen(a, b []string) int {
+	i, j, n := len(a)-1, len(b)-1, 0
+	for i >= 0 && j >= 0 && a[i] == b[j] {
+		n++
+		i--
+		j--
+	}
+	return n
+}
+
+// coveredBy reports whether an existing rewrite already matches root (same
+// boundary rule as applyRewrites).
+func coveredBy(root string, existing []PathRewrite) bool {
+	for _, rw := range existing {
+		from := strings.TrimRight(strings.TrimSpace(rw.From), "/")
+		if from == "" {
+			continue
+		}
+		if root == from || strings.HasPrefix(root, from+"/") {
+			return true
+		}
+	}
+	return false
+}
+
+// suggestRewrites matches each arr root to the Silo folder sharing the most
+// trailing path segments (unique winner). Pure: no I/O, no deployment constants.
+func suggestRewrites(arrRoots, siloFolderPaths []string, existing []PathRewrite) RewriteSuggestions {
+	siloNorm := make([]string, 0, len(siloFolderPaths))
+	siloSegs := make([][]string, 0, len(siloFolderPaths))
+	for _, p := range siloFolderPaths {
+		n := normalizePath(p)
+		if n == "" {
+			continue
+		}
+		siloNorm = append(siloNorm, n)
+		siloSegs = append(siloSegs, segments(n))
+	}
+
+	var out RewriteSuggestions
+	for _, raw := range arrRoots {
+		root := normalizePath(raw)
+		if root == "" {
+			continue
+		}
+		if coveredBy(root, existing) {
+			out.Covered = append(out.Covered, root)
+			continue
+		}
+		rootSegs := segments(root)
+		best := 0
+		var winners []string
+		for i, segs := range siloSegs {
+			n := commonSuffixLen(rootSegs, segs)
+			if n == 0 {
+				continue
+			}
+			if n > best {
+				best, winners = n, []string{siloNorm[i]}
+			} else if n == best {
+				winners = append(winners, siloNorm[i])
+			}
+		}
+		switch {
+		case best == 0:
+			out.Unmatched = append(out.Unmatched, root)
+		case len(winners) == 1:
+			out.Proposed = append(out.Proposed, ProposedRewrite{From: root, To: winners[0], MatchDepth: best})
+		default:
+			out.Ambiguous = append(out.Ambiguous, AmbiguousRoot{Root: root, Candidates: winners})
+		}
+	}
+	return out
+}

--- a/internal/autoscan/suggest_deps.go
+++ b/internal/autoscan/suggest_deps.go
@@ -1,0 +1,60 @@
+package autoscan
+
+import (
+	"context"
+	"net/http"
+
+	"github.com/Silo-Server/silo-server/internal/catalog"
+	"github.com/Silo-Server/silo-server/internal/requests/arrclient"
+)
+
+// RootFolderClient lists a Radarr/Sonarr instance's configured root folder paths.
+type RootFolderClient interface {
+	RootFolders(ctx context.Context, baseURL, apiKey string) ([]string, error)
+}
+
+// FolderLister lists every Silo media-folder path.
+type FolderLister interface {
+	ListFolderPaths(ctx context.Context) ([]string, error)
+}
+
+type arrRootFolderClient struct{ httpClient *http.Client }
+
+// NewArrRootFolderClient returns a RootFolderClient backed by the shared arrclient.
+func NewArrRootFolderClient(httpClient *http.Client) RootFolderClient {
+	return &arrRootFolderClient{httpClient: httpClient}
+}
+
+func (c *arrRootFolderClient) RootFolders(ctx context.Context, baseURL, apiKey string) ([]string, error) {
+	client := arrclient.New(baseURL, apiKey, c.httpClient)
+	folders, err := arrclient.ListRootFolders(ctx, client)
+	if err != nil {
+		return nil, err
+	}
+	paths := make([]string, 0, len(folders))
+	for _, f := range folders {
+		if f.Path != "" {
+			paths = append(paths, f.Path)
+		}
+	}
+	return paths, nil
+}
+
+type catalogFolderLister struct{ repo *catalog.FolderRepository }
+
+// NewCatalogFolderLister adapts catalog.FolderRepository to FolderLister.
+func NewCatalogFolderLister(repo *catalog.FolderRepository) FolderLister {
+	return &catalogFolderLister{repo: repo}
+}
+
+func (l *catalogFolderLister) ListFolderPaths(ctx context.Context) ([]string, error) {
+	folders, err := l.repo.List(ctx)
+	if err != nil {
+		return nil, err
+	}
+	var paths []string
+	for _, f := range folders {
+		paths = append(paths, f.Paths...)
+	}
+	return paths, nil
+}

--- a/internal/autoscan/suggest_deps.go
+++ b/internal/autoscan/suggest_deps.go
@@ -3,10 +3,16 @@ package autoscan
 import (
 	"context"
 	"net/http"
+	"time"
 
 	"github.com/Silo-Server/silo-server/internal/catalog"
 	"github.com/Silo-Server/silo-server/internal/requests/arrclient"
 )
+
+// rootFolderTimeout is generous: Radarr/Sonarr compute unmappedFolders by
+// scanning every root folder (often slow network shares), so a large library's
+// /api/v3/rootfolder can take 20-30s+ — well past arrclient's 30s default.
+const rootFolderTimeout = 2 * time.Minute
 
 // RootFolderClient lists a Radarr/Sonarr instance's configured root folder paths.
 type RootFolderClient interface {
@@ -21,7 +27,11 @@ type FolderLister interface {
 type arrRootFolderClient struct{ httpClient *http.Client }
 
 // NewArrRootFolderClient returns a RootFolderClient backed by the shared arrclient.
+// When no client is given it uses a long timeout, since the root-folder scan is slow.
 func NewArrRootFolderClient(httpClient *http.Client) RootFolderClient {
+	if httpClient == nil {
+		httpClient = &http.Client{Timeout: rootFolderTimeout}
+	}
 	return &arrRootFolderClient{httpClient: httpClient}
 }
 

--- a/internal/autoscan/suggest_test.go
+++ b/internal/autoscan/suggest_test.go
@@ -1,0 +1,94 @@
+package autoscan
+
+import (
+	"testing"
+)
+
+func TestSuggestRewrites(t *testing.T) {
+	silo := []string{
+		"/mnt/media/happy/storage2/tvshows1",
+		"/mnt/media/happy4k/4ktv7",
+		"/mnt/media/storage/Anime/Subs",
+		"/mnt/media/storage/Anime2/Subs",
+		"/library/Films",
+		"/tank/television/Show",
+	}
+
+	t.Run("multi-segment unique match", func(t *testing.T) {
+		got := suggestRewrites([]string{"/mnt/happy/storage2/tvshows1"}, silo, nil)
+		// shares trailing happy/storage2/tvshows1 = 3 segments
+		if len(got.Proposed) != 1 || got.Proposed[0].To != "/mnt/media/happy/storage2/tvshows1" || got.Proposed[0].MatchDepth != 3 {
+			t.Fatalf("proposed=%+v", got.Proposed)
+		}
+	})
+
+	t.Run("single-segment unique match (different parents)", func(t *testing.T) {
+		got := suggestRewrites([]string{"/mnt/kodama/storage2/4ktv7"}, silo, nil)
+		if len(got.Proposed) != 1 || got.Proposed[0].To != "/mnt/media/happy4k/4ktv7" || got.Proposed[0].MatchDepth != 1 {
+			t.Fatalf("proposed=%+v", got.Proposed)
+		}
+	})
+
+	t.Run("longest-suffix disambiguation", func(t *testing.T) {
+		got := suggestRewrites([]string{"/mnt/kodama/storage1/Anime/Subs"}, silo, nil)
+		if len(got.Proposed) != 1 || got.Proposed[0].To != "/mnt/media/storage/Anime/Subs" || got.Proposed[0].MatchDepth != 2 {
+			t.Fatalf("expected Anime/Subs (depth 2), got %+v", got.Proposed)
+		}
+		if len(got.Ambiguous) != 0 {
+			t.Fatalf("should not be ambiguous: %+v", got.Ambiguous)
+		}
+	})
+
+	t.Run("unmatched when no shared segment", func(t *testing.T) {
+		got := suggestRewrites([]string{"/data/Movies"}, silo, nil)
+		if len(got.Unmatched) != 1 || got.Unmatched[0] != "/data/Movies" || len(got.Proposed) != 0 {
+			t.Fatalf("got=%+v", got)
+		}
+	})
+
+	t.Run("leaf match across unlike layouts", func(t *testing.T) {
+		got := suggestRewrites([]string{"/srv/tv/Show"}, silo, nil)
+		if len(got.Proposed) != 1 || got.Proposed[0].To != "/tank/television/Show" {
+			t.Fatalf("got=%+v", got)
+		}
+	})
+
+	t.Run("ambiguous tie", func(t *testing.T) {
+		got := suggestRewrites([]string{"/foo/bar/Subs"}, silo, nil)
+		if len(got.Ambiguous) != 1 || len(got.Ambiguous[0].Candidates) != 2 {
+			t.Fatalf("expected ambiguous with 2 candidates, got %+v", got.Ambiguous)
+		}
+	})
+
+	t.Run("covered by existing rule", func(t *testing.T) {
+		existing := []PathRewrite{{From: "/mnt/happy", To: "/mnt/media/happy"}}
+		got := suggestRewrites([]string{"/mnt/happy/storage2/tvshows1"}, silo, existing)
+		if len(got.Covered) != 1 || len(got.Proposed) != 0 {
+			t.Fatalf("expected covered, got %+v", got)
+		}
+	})
+
+	t.Run("normalization: trailing slash, backslashes, dup slashes", func(t *testing.T) {
+		got := suggestRewrites([]string{`\mnt\happy\\storage2\tvshows1\`}, silo, nil)
+		if len(got.Proposed) != 1 || got.Proposed[0].From != "/mnt/happy/storage2/tvshows1" || got.Proposed[0].To != "/mnt/media/happy/storage2/tvshows1" {
+			t.Fatalf("normalization failed: %+v", got.Proposed)
+		}
+	})
+}
+
+func TestCommonSuffixLen(t *testing.T) {
+	cases := []struct {
+		a, b []string
+		want int
+	}{
+		{[]string{"a", "b", "c"}, []string{"x", "b", "c"}, 2},
+		{[]string{"4ktv7"}, []string{"happy4k", "4ktv7"}, 1},
+		{[]string{"4ktv7"}, []string{"4ktv70"}, 0},
+		{[]string{"a"}, []string{"b"}, 0},
+	}
+	for _, tc := range cases {
+		if got := commonSuffixLen(tc.a, tc.b); got != tc.want {
+			t.Fatalf("commonSuffixLen(%v,%v)=%d want %d", tc.a, tc.b, got, tc.want)
+		}
+	}
+}

--- a/internal/autoscan/suggest_test.go
+++ b/internal/autoscan/suggest_test.go
@@ -106,6 +106,13 @@ func TestSuggestRewrites(t *testing.T) {
 	})
 }
 
+func TestSuggestRewritesNeverNilSlices(t *testing.T) {
+	got := suggestRewrites(nil, nil, nil)
+	if got.Proposed == nil || got.Unmatched == nil || got.Ambiguous == nil || got.Covered == nil {
+		t.Fatalf("slices must be non-nil so JSON serializes [] not null: %+v", got)
+	}
+}
+
 func TestCommonSuffixLen(t *testing.T) {
 	cases := []struct {
 		a, b []string

--- a/internal/autoscan/suggest_test.go
+++ b/internal/autoscan/suggest_test.go
@@ -74,6 +74,36 @@ func TestSuggestRewrites(t *testing.T) {
 			t.Fatalf("normalization failed: %+v", got.Proposed)
 		}
 	})
+
+	t.Run("covered by a Windows-style existing rule (normalized)", func(t *testing.T) {
+		existing := []PathRewrite{{From: `\mnt\happy`, To: "/mnt/media/happy"}}
+		got := suggestRewrites([]string{"/mnt/happy/storage2/tvshows1"}, silo, existing)
+		if len(got.Covered) != 1 || len(got.Proposed) != 0 {
+			t.Fatalf("backslash From should cover the root: %+v", got)
+		}
+	})
+
+	t.Run("duplicate arr roots collapse to one proposal", func(t *testing.T) {
+		got := suggestRewrites([]string{"/mnt/happy/storage2/tvshows1", "/mnt/happy/storage2/tvshows1/"}, silo, nil)
+		if len(got.Proposed) != 1 {
+			t.Fatalf("dup roots should yield 1 proposal, got %+v", got.Proposed)
+		}
+	})
+
+	t.Run("no-op (arr path equals Silo path) is not proposed", func(t *testing.T) {
+		got := suggestRewrites([]string{"/library/Films"}, silo, nil)
+		if len(got.Proposed) != 0 || len(got.Unmatched) != 0 {
+			t.Fatalf("from==to should be skipped, got %+v", got)
+		}
+	})
+
+	t.Run("duplicate Silo paths do not create duplicate candidates", func(t *testing.T) {
+		dupSilo := []string{"/mnt/media/storage/Anime/Subs", "/mnt/media/storage/Anime/Subs"}
+		got := suggestRewrites([]string{"/mnt/kodama/storage1/Anime/Subs"}, dupSilo, nil)
+		if len(got.Proposed) != 1 || len(got.Ambiguous) != 0 {
+			t.Fatalf("dup silo paths should still be a unique match, got %+v", got)
+		}
+	})
 }
 
 func TestCommonSuffixLen(t *testing.T) {

--- a/internal/autoscan/suppress.go
+++ b/internal/autoscan/suppress.go
@@ -13,6 +13,8 @@ type Suppressor interface {
 	// ShouldScan atomically claims the folder for scanning: returns true and sets
 	// a TTL key if no claim exists, false if a recent claim is still live.
 	ShouldScan(ctx context.Context, folderID int, ttl time.Duration) (bool, error)
+	// Release drops a suppression claim (used when the scan enqueue fails).
+	Release(ctx context.Context, folderID int) error
 }
 
 type redisSuppressor struct{ client *redis.Client }
@@ -29,4 +31,11 @@ func (s *redisSuppressor) ShouldScan(ctx context.Context, folderID int, ttl time
 		return true, nil // fail open: a Redis hiccup should not block scanning
 	}
 	return ok, nil
+}
+
+func (s *redisSuppressor) Release(ctx context.Context, folderID int) error {
+	if s.client == nil {
+		return nil
+	}
+	return s.client.Del(ctx, fmt.Sprintf("autoscan:scanned:%d", folderID)).Err()
 }

--- a/internal/autoscan/suppress.go
+++ b/internal/autoscan/suppress.go
@@ -2,40 +2,42 @@ package autoscan
 
 import (
 	"context"
-	"fmt"
 	"time"
 
 	"github.com/redis/go-redis/v9"
 )
 
-// Suppressor prevents re-enqueuing a scan for the same folder within a window.
+// Suppressor prevents re-enqueuing a scan for the same (folder, path) target
+// within a window. The key must match the scanqueue dedup granularity
+// (folder ID + path) so two distinct subtrees under one library folder are
+// not collapsed into a single suppression claim.
 type Suppressor interface {
-	// ShouldScan atomically claims the folder for scanning: returns true and sets
+	// ShouldScan atomically claims the target for scanning: returns true and sets
 	// a TTL key if no claim exists, false if a recent claim is still live.
-	ShouldScan(ctx context.Context, folderID int, ttl time.Duration) (bool, error)
+	ShouldScan(ctx context.Context, key string, ttl time.Duration) (bool, error)
 	// Release drops a suppression claim (used when the scan enqueue fails).
-	Release(ctx context.Context, folderID int) error
+	Release(ctx context.Context, key string) error
 }
 
 type redisSuppressor struct{ client *redis.Client }
 
 func NewRedisSuppressor(client *redis.Client) Suppressor { return &redisSuppressor{client: client} }
 
-func (s *redisSuppressor) ShouldScan(ctx context.Context, folderID int, ttl time.Duration) (bool, error) {
+func (s *redisSuppressor) ShouldScan(ctx context.Context, key string, ttl time.Duration) (bool, error) {
 	if s.client == nil || ttl <= 0 {
 		return true, nil // no suppression configured -> always scan
 	}
-	key := fmt.Sprintf("autoscan:scanned:%d", folderID)
-	ok, err := s.client.SetNX(ctx, key, "1", ttl).Result()
+	redisKey := "autoscan:scanned:" + key
+	ok, err := s.client.SetNX(ctx, redisKey, "1", ttl).Result()
 	if err != nil {
 		return true, nil // fail open: a Redis hiccup should not block scanning
 	}
 	return ok, nil
 }
 
-func (s *redisSuppressor) Release(ctx context.Context, folderID int) error {
+func (s *redisSuppressor) Release(ctx context.Context, key string) error {
 	if s.client == nil {
 		return nil
 	}
-	return s.client.Del(ctx, fmt.Sprintf("autoscan:scanned:%d", folderID)).Err()
+	return s.client.Del(ctx, "autoscan:scanned:"+key).Err()
 }

--- a/internal/autoscan/suppress.go
+++ b/internal/autoscan/suppress.go
@@ -1,0 +1,32 @@
+package autoscan
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/redis/go-redis/v9"
+)
+
+// Suppressor prevents re-enqueuing a scan for the same folder within a window.
+type Suppressor interface {
+	// ShouldScan atomically claims the folder for scanning: returns true and sets
+	// a TTL key if no claim exists, false if a recent claim is still live.
+	ShouldScan(ctx context.Context, folderID int, ttl time.Duration) (bool, error)
+}
+
+type redisSuppressor struct{ client *redis.Client }
+
+func NewRedisSuppressor(client *redis.Client) Suppressor { return &redisSuppressor{client: client} }
+
+func (s *redisSuppressor) ShouldScan(ctx context.Context, folderID int, ttl time.Duration) (bool, error) {
+	if s.client == nil || ttl <= 0 {
+		return true, nil // no suppression configured -> always scan
+	}
+	key := fmt.Sprintf("autoscan:scanned:%d", folderID)
+	ok, err := s.client.SetNX(ctx, key, "1", ttl).Result()
+	if err != nil {
+		return true, nil // fail open: a Redis hiccup should not block scanning
+	}
+	return ok, nil
+}

--- a/internal/autoscan/types.go
+++ b/internal/autoscan/types.go
@@ -1,0 +1,36 @@
+package autoscan
+
+import "time"
+
+// Settings is the global autoscan configuration (singleton row).
+type Settings struct {
+	Enabled             bool      `json:"enabled"`
+	PollIntervalMinutes int       `json:"poll_interval_minutes"`
+	DebounceSeconds     int       `json:"debounce_seconds"`
+	UpdatedAt           time.Time `json:"updated_at"`
+}
+
+// PathRewrite is an optional prefix translation from an arr path to a Silo path.
+type PathRewrite struct {
+	From string `json:"from"`
+	To   string `json:"to"`
+}
+
+// Source is an autoscan-enabled Radarr/Sonarr instance. Kind/BaseURL/APIKeyRef/Name
+// are read from request_integrations; the rest live in autoscan_sources.
+type Source struct {
+	IntegrationID string        `json:"integration_id"`
+	Kind          string        `json:"kind"`
+	Name          string        `json:"name"`
+	BaseURL       string        `json:"-"`
+	APIKeyRef     string        `json:"-"`
+	Enabled       bool          `json:"enabled"`
+	PathRewrites  []PathRewrite `json:"path_rewrites"`
+	LastPollAt    *time.Time    `json:"last_poll_at,omitempty"`
+}
+
+// SourceUpdate is the admin-editable subset of a source.
+type SourceUpdate struct {
+	Enabled      bool          `json:"enabled"`
+	PathRewrites []PathRewrite `json:"path_rewrites"`
+}

--- a/internal/taskmanager/tasks/autoscan_poll.go
+++ b/internal/taskmanager/tasks/autoscan_poll.go
@@ -1,0 +1,53 @@
+package tasks
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/Silo-Server/silo-server/internal/taskmanager"
+)
+
+type AutoscanPoller interface {
+	PollOnce(ctx context.Context) error
+}
+
+type AutoscanPollTask struct {
+	poller          AutoscanPoller
+	intervalMinutes int
+}
+
+func NewAutoscanPollTask(poller AutoscanPoller, intervalMinutes int) *AutoscanPollTask {
+	if intervalMinutes <= 0 {
+		intervalMinutes = 10
+	}
+	return &AutoscanPollTask{poller: poller, intervalMinutes: intervalMinutes}
+}
+
+func (t *AutoscanPollTask) Key() string  { return "autoscan_poll" }
+func (t *AutoscanPollTask) Name() string { return "Autoscan Poll" }
+func (t *AutoscanPollTask) Description() string {
+	return "Polls autoscan-enabled Radarr/Sonarr instances for imported files and scans the affected folders"
+}
+func (t *AutoscanPollTask) Category() taskmanager.TaskCategory {
+	return taskmanager.TaskCategoryLibrary
+}
+func (t *AutoscanPollTask) IsHidden() bool { return false }
+
+func (t *AutoscanPollTask) DefaultTriggers() []taskmanager.TriggerConfig {
+	return []taskmanager.TriggerConfig{
+		{Type: taskmanager.TriggerTypeInterval, IntervalMs: int64(t.intervalMinutes) * 60 * 1000},
+	}
+}
+
+func (t *AutoscanPollTask) Execute(ctx context.Context, progress taskmanager.ProgressReporter) error {
+	progress.Report(0, "Polling arr instances")
+	if t.poller == nil {
+		progress.Report(100, "Autoscan unavailable")
+		return nil
+	}
+	if err := t.poller.PollOnce(ctx); err != nil {
+		return fmt.Errorf("autoscan poll: %w", err)
+	}
+	progress.Report(100, "Autoscan poll complete")
+	return nil
+}

--- a/migrations/171_autoscan.down.sql
+++ b/migrations/171_autoscan.down.sql
@@ -1,0 +1,2 @@
+DROP TABLE IF EXISTS public.autoscan_sources;
+DROP TABLE IF EXISTS public.autoscan_settings;

--- a/migrations/171_autoscan.up.sql
+++ b/migrations/171_autoscan.up.sql
@@ -1,0 +1,23 @@
+CREATE TABLE IF NOT EXISTS public.autoscan_settings (
+    id boolean PRIMARY KEY DEFAULT true,
+    enabled boolean NOT NULL DEFAULT false,
+    poll_interval_minutes integer NOT NULL DEFAULT 10,
+    debounce_seconds integer NOT NULL DEFAULT 60,
+    created_at timestamp with time zone DEFAULT now() NOT NULL,
+    updated_at timestamp with time zone DEFAULT now() NOT NULL,
+    CONSTRAINT autoscan_settings_singleton CHECK (id),
+    CONSTRAINT autoscan_settings_interval_positive CHECK (poll_interval_minutes > 0),
+    CONSTRAINT autoscan_settings_debounce_nonneg CHECK (debounce_seconds >= 0)
+);
+
+INSERT INTO public.autoscan_settings (id) VALUES (true) ON CONFLICT (id) DO NOTHING;
+
+CREATE TABLE IF NOT EXISTS public.autoscan_sources (
+    integration_id text PRIMARY KEY
+        REFERENCES public.request_integrations(id) ON DELETE CASCADE,
+    enabled boolean NOT NULL DEFAULT false,
+    path_rewrites jsonb NOT NULL DEFAULT '[]'::jsonb,
+    last_poll_at timestamp with time zone,
+    created_at timestamp with time zone DEFAULT now() NOT NULL,
+    updated_at timestamp with time zone DEFAULT now() NOT NULL
+);

--- a/web/src/api/types.ts
+++ b/web/src/api/types.ts
@@ -1660,6 +1660,31 @@ export interface RequestIntegrationsResponse {
   integrations: RequestIntegration[];
 }
 
+export interface AutoscanSettings {
+  enabled: boolean;
+  poll_interval_minutes: number;
+  debounce_seconds: number;
+  updated_at?: string;
+}
+
+export interface AutoscanPathRewrite {
+  from: string;
+  to: string;
+}
+
+export interface AutoscanSource {
+  integration_id: string;
+  kind: string;
+  name: string;
+  enabled: boolean;
+  path_rewrites: AutoscanPathRewrite[];
+  last_poll_at?: string | null;
+}
+
+export interface AutoscanSourcesResponse {
+  sources: AutoscanSource[];
+}
+
 export interface RequestListParams {
   status?: MediaRequestStatus | "all";
   outcome?: MediaRequestOutcome | "all";

--- a/web/src/api/types.ts
+++ b/web/src/api/types.ts
@@ -1685,6 +1685,24 @@ export interface AutoscanSourcesResponse {
   sources: AutoscanSource[];
 }
 
+export interface AutoscanProposedRewrite {
+  from: string;
+  to: string;
+  match_depth: number;
+}
+
+export interface AutoscanAmbiguousRoot {
+  root: string;
+  candidates: string[];
+}
+
+export interface AutoscanRewriteSuggestions {
+  proposed: AutoscanProposedRewrite[];
+  unmatched: string[];
+  ambiguous: AutoscanAmbiguousRoot[];
+  covered: string[];
+}
+
 export interface RequestListParams {
   status?: MediaRequestStatus | "all";
   outcome?: MediaRequestOutcome | "all";

--- a/web/src/hooks/queries/keys.ts
+++ b/web/src/hooks/queries/keys.ts
@@ -393,4 +393,6 @@ export const adminKeys = {
   itemImages: (id: string) => ["admin", "items", id, "images"] as const,
   buildInfo: () => ["admin", "system", "buildInfo"] as const,
   hwAccel: () => ["admin", "system", "hwAccel"] as const,
+  autoscanSettings: () => ["admin", "autoscan", "settings"] as const,
+  autoscanSources: () => ["admin", "autoscan", "sources"] as const,
 };

--- a/web/src/hooks/queries/useAutoscan.ts
+++ b/web/src/hooks/queries/useAutoscan.ts
@@ -6,6 +6,7 @@ import type {
   AutoscanSource,
   AutoscanSourcesResponse,
   AutoscanPathRewrite,
+  AutoscanRewriteSuggestions,
 } from "@/api/types";
 import { adminKeys } from "./keys";
 
@@ -67,6 +68,19 @@ export function useUpdateAutoscanSource() {
     onError: (err) => {
       toast.error(err instanceof Error ? err.message : "Failed to save autoscan source");
     },
+  });
+}
+
+export function useAutoscanRewriteSuggestions() {
+  return useMutation({
+    mutationFn: (id: string) =>
+      api<AutoscanRewriteSuggestions>(
+        `/admin/autoscan/sources/${encodeURIComponent(id)}/rewrite-suggestions`,
+      ),
+    onError: (err) =>
+      toast.error(
+        err instanceof Error ? err.message : "Could not sync rewrites from the arr instance",
+      ),
   });
 }
 

--- a/web/src/hooks/queries/useAutoscan.ts
+++ b/web/src/hooks/queries/useAutoscan.ts
@@ -1,0 +1,86 @@
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { toast } from "sonner";
+import { api } from "@/api/client";
+import type {
+  AutoscanSettings,
+  AutoscanSource,
+  AutoscanSourcesResponse,
+  AutoscanPathRewrite,
+} from "@/api/types";
+import { adminKeys } from "./keys";
+
+const AUTOSCAN_STALE_TIME = 30_000;
+
+export function useAutoscanSettings() {
+  return useQuery({
+    queryKey: adminKeys.autoscanSettings(),
+    queryFn: () => api<AutoscanSettings>("/admin/autoscan/settings"),
+    staleTime: AUTOSCAN_STALE_TIME,
+  });
+}
+
+export function useUpdateAutoscanSettings() {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: (body: AutoscanSettings) =>
+      api<AutoscanSettings>("/admin/autoscan/settings", {
+        method: "PUT",
+        body: JSON.stringify(body),
+      }),
+    onSuccess: () => {
+      toast.success("Autoscan settings saved");
+      queryClient.invalidateQueries({ queryKey: adminKeys.autoscanSettings() });
+    },
+    onError: (err) => {
+      toast.error(err instanceof Error ? err.message : "Failed to save autoscan settings");
+    },
+  });
+}
+
+export function useAutoscanSources() {
+  return useQuery({
+    queryKey: adminKeys.autoscanSources(),
+    queryFn: () =>
+      api<AutoscanSourcesResponse>("/admin/autoscan/sources").then((data) => data.sources ?? []),
+    staleTime: AUTOSCAN_STALE_TIME,
+  });
+}
+
+export function useUpdateAutoscanSource() {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: ({
+      id,
+      body,
+    }: {
+      id: string;
+      body: { enabled: boolean; path_rewrites: AutoscanPathRewrite[] };
+    }) =>
+      api<AutoscanSource>(`/admin/autoscan/sources/${encodeURIComponent(id)}`, {
+        method: "PUT",
+        body: JSON.stringify(body),
+      }),
+    onSuccess: () => {
+      toast.success("Autoscan source saved");
+      queryClient.invalidateQueries({ queryKey: adminKeys.autoscanSources() });
+    },
+    onError: (err) => {
+      toast.error(err instanceof Error ? err.message : "Failed to save autoscan source");
+    },
+  });
+}
+
+export function useTriggerAutoscan() {
+  return useMutation({
+    mutationFn: () =>
+      api<{ status: string }>("/admin/autoscan/trigger", {
+        method: "POST",
+      }),
+    onSuccess: () => {
+      toast.success("Autoscan triggered");
+    },
+    onError: (err) => {
+      toast.error(err instanceof Error ? err.message : "Failed to trigger autoscan");
+    },
+  });
+}

--- a/web/src/pages/AdminRequests.tsx
+++ b/web/src/pages/AdminRequests.tsx
@@ -16,6 +16,9 @@ import {
   X,
 } from "lucide-react";
 import type {
+  AutoscanPathRewrite,
+  AutoscanSettings,
+  AutoscanSource,
   MediaRequest,
   MediaRequestOutcome,
   MediaRequestStatus,
@@ -59,6 +62,13 @@ import {
 } from "@/components/ui/table";
 import { useAdminUsers } from "@/hooks/queries/admin/users";
 import {
+  useAutoscanSettings,
+  useAutoscanSources,
+  useTriggerAutoscan,
+  useUpdateAutoscanSettings,
+  useUpdateAutoscanSource,
+} from "@/hooks/queries/useAutoscan";
+import {
   useAdminMediaRequests,
   useApproveMediaRequest,
   useCreateRequestIntegration,
@@ -87,7 +97,7 @@ import {
 type StatusFilter = MediaRequestStatus | "all";
 type OutcomeFilter = MediaRequestOutcome | "all";
 
-const ADMIN_REQUEST_TABS = ["queue", "settings", "integrations", "overrides"] as const;
+const ADMIN_REQUEST_TABS = ["queue", "settings", "integrations", "autoscan", "overrides"] as const;
 type AdminRequestTab = (typeof ADMIN_REQUEST_TABS)[number];
 
 function normalizeAdminRequestTab(value: string | null): AdminRequestTab {
@@ -131,6 +141,7 @@ export default function AdminRequests() {
           <TabsTrigger value="queue">Queue</TabsTrigger>
           <TabsTrigger value="settings">Settings</TabsTrigger>
           <TabsTrigger value="integrations">Integrations</TabsTrigger>
+          <TabsTrigger value="autoscan">Autoscan</TabsTrigger>
           <TabsTrigger value="overrides">User Overrides</TabsTrigger>
         </TabsList>
         <TabsContent value="queue">
@@ -141,6 +152,9 @@ export default function AdminRequests() {
         </TabsContent>
         <TabsContent value="integrations">
           <RequestIntegrationsTab />
+        </TabsContent>
+        <TabsContent value="autoscan">
+          <AutoscanTab />
         </TabsContent>
         <TabsContent value="overrides">
           <UserOverridesTab />
@@ -1282,6 +1296,269 @@ function toggleTag(current: string, tagID: number): string {
   const tags = parseTags(current);
   const next = tags.includes(tagID) ? tags.filter((tag) => tag !== tagID) : [...tags, tagID];
   return next.join(", ");
+}
+
+type AutoscanSettingsFormState = {
+  enabled: boolean;
+  poll_interval_minutes: string;
+  debounce_seconds: string;
+  updated_at: string;
+};
+
+function AutoscanTab() {
+  return (
+    <div className="space-y-8">
+      <AutoscanSettingsCard />
+      <AutoscanSourcesSection />
+    </div>
+  );
+}
+
+function AutoscanSettingsCard() {
+  const settings = useAutoscanSettings();
+
+  if (settings.isLoading) return <RowsSkeleton />;
+  if (settings.isError) {
+    return <EmptyPanel title="Settings failed" detail="Autoscan settings could not be loaded." />;
+  }
+  if (!settings.data) {
+    return <EmptyPanel title="No settings" detail="Autoscan settings are not available." />;
+  }
+
+  return (
+    <AutoscanSettingsForm key={settings.data.updated_at ?? "settings"} settings={settings.data} />
+  );
+}
+
+function AutoscanSettingsForm({ settings }: { settings: AutoscanSettings }) {
+  const updateSettings = useUpdateAutoscanSettings();
+  const triggerAutoscan = useTriggerAutoscan();
+  const [form, setForm] = useState<AutoscanSettingsFormState>(() => ({
+    enabled: settings.enabled,
+    poll_interval_minutes: String(settings.poll_interval_minutes),
+    debounce_seconds: String(settings.debounce_seconds),
+    updated_at: settings.updated_at ?? "",
+  }));
+
+  function saveSettings() {
+    updateSettings.mutate({
+      enabled: form.enabled,
+      poll_interval_minutes: Math.max(1, Number(form.poll_interval_minutes) || 10),
+      debounce_seconds: Math.max(0, Number(form.debounce_seconds) || 0),
+      updated_at: form.updated_at || undefined,
+    });
+  }
+
+  return (
+    <div className="border-border bg-card max-w-3xl space-y-5 rounded-lg border p-5">
+      <div className="flex flex-wrap items-center justify-between gap-3">
+        <div className="flex items-center gap-2">
+          <RefreshCw className="text-primary h-4 w-4" />
+          <h2 className="text-lg font-semibold tracking-normal">Autoscan</h2>
+        </div>
+        <Button
+          type="button"
+          variant="outline"
+          size="sm"
+          onClick={() => triggerAutoscan.mutate()}
+          disabled={triggerAutoscan.isPending}
+        >
+          <RefreshCw className="h-4 w-4" />
+          Poll now
+        </Button>
+      </div>
+
+      <div className="grid gap-4 sm:grid-cols-2">
+        <div className="sm:col-span-2">
+          <SwitchField
+            label="Autoscan enabled"
+            description="Poll Radarr and Sonarr instances and rescan affected library paths automatically."
+            checked={form.enabled}
+            onCheckedChange={(enabled) => setForm((current) => ({ ...current, enabled }))}
+          />
+        </div>
+        <Field label="Poll interval (minutes)">
+          <Input
+            type="number"
+            min={1}
+            value={form.poll_interval_minutes}
+            onChange={(event) =>
+              setForm((current) => ({ ...current, poll_interval_minutes: event.target.value }))
+            }
+          />
+        </Field>
+        <Field label="Debounce (seconds)">
+          <Input
+            type="number"
+            min={0}
+            value={form.debounce_seconds}
+            onChange={(event) =>
+              setForm((current) => ({ ...current, debounce_seconds: event.target.value }))
+            }
+          />
+        </Field>
+      </div>
+
+      <Button onClick={saveSettings} disabled={updateSettings.isPending}>
+        <Save className="h-4 w-4" />
+        Save Settings
+      </Button>
+    </div>
+  );
+}
+
+function AutoscanSourcesSection() {
+  const sources = useAutoscanSources();
+
+  if (sources.isLoading) return <RowsSkeleton />;
+  if (sources.isError) {
+    return <EmptyPanel title="Sources failed" detail="Autoscan sources could not be loaded." />;
+  }
+
+  const list = sources.data ?? [];
+  if (list.length === 0) {
+    return (
+      <EmptyPanel
+        title="No instances"
+        detail="Add a Radarr or Sonarr instance in the Integrations tab first."
+      />
+    );
+  }
+
+  return (
+    <div className="space-y-4">
+      <h2 className="text-lg font-semibold tracking-normal">Instances</h2>
+      <div className="grid gap-4 xl:grid-cols-2">
+        {list.map((source) => (
+          <AutoscanSourceEditor key={source.integration_id} source={source} />
+        ))}
+      </div>
+    </div>
+  );
+}
+
+function AutoscanSourceEditor({ source }: { source: AutoscanSource }) {
+  const updateSource = useUpdateAutoscanSource();
+  const [enabled, setEnabled] = useState(source.enabled);
+  const [rewrites, setRewrites] = useState<AutoscanPathRewrite[]>(() =>
+    source.path_rewrites.map((rewrite) => ({ ...rewrite })),
+  );
+  const [rewritesOpen, setRewritesOpen] = useState(source.path_rewrites.length > 0);
+  const rewritesPanelID = useId();
+
+  function updateRewrite(index: number, patch: Partial<AutoscanPathRewrite>) {
+    setRewrites((current) =>
+      current.map((rewrite, i) => (i === index ? { ...rewrite, ...patch } : rewrite)),
+    );
+  }
+
+  function addRewrite() {
+    setRewrites((current) => [...current, { from: "", to: "" }]);
+  }
+
+  function removeRewrite(index: number) {
+    setRewrites((current) => current.filter((_, i) => i !== index));
+  }
+
+  function handleSave() {
+    const path_rewrites = rewrites
+      .map((rewrite) => ({ from: rewrite.from.trim(), to: rewrite.to.trim() }))
+      .filter((rewrite) => rewrite.from.length > 0 || rewrite.to.length > 0);
+    updateSource.mutate({ id: source.integration_id, body: { enabled, path_rewrites } });
+  }
+
+  return (
+    <div className="border-border bg-card space-y-5 rounded-lg border p-5">
+      <div className="flex flex-wrap items-center justify-between gap-3">
+        <div className="flex items-center gap-2">
+          <Plug className="text-primary h-4 w-4" />
+          <h2 className="text-lg font-semibold tracking-normal">{source.name}</h2>
+          <Badge variant="secondary">{source.kind}</Badge>
+        </div>
+      </div>
+
+      <SwitchField label="Autoscan" checked={enabled} onCheckedChange={setEnabled} />
+
+      <Field label="Last polled">
+        <p className="text-muted-foreground text-sm">
+          {formatAutoscanPollDate(source.last_poll_at)}
+        </p>
+      </Field>
+
+      <div className="border-border space-y-4 rounded-lg border p-3">
+        <button
+          type="button"
+          className="flex w-full items-center justify-between gap-2 text-left"
+          onClick={() => setRewritesOpen((open) => !open)}
+          aria-expanded={rewritesOpen}
+          aria-controls={rewritesPanelID}
+        >
+          <div className="flex items-center gap-2">
+            {rewritesOpen ? (
+              <ChevronDown className="h-4 w-4" />
+            ) : (
+              <ChevronRight className="h-4 w-4" />
+            )}
+            <span className="text-sm font-medium">Path rewrites</span>
+            {rewrites.length > 0 ? <Badge variant="secondary">{rewrites.length}</Badge> : null}
+          </div>
+        </button>
+        {rewritesOpen ? (
+          <div id={rewritesPanelID} className="space-y-3" role="region" aria-label="Path rewrites">
+            {rewrites.length === 0 ? (
+              <p className="text-muted-foreground text-xs">
+                No path rewrites. Map remote paths to local library paths.
+              </p>
+            ) : (
+              rewrites.map((rewrite, index) => (
+                <div key={index} className="flex items-end gap-2">
+                  <Field label="From">
+                    <Input
+                      value={rewrite.from}
+                      onChange={(event) => updateRewrite(index, { from: event.target.value })}
+                      placeholder="/remote/media"
+                    />
+                  </Field>
+                  <Field label="To">
+                    <Input
+                      value={rewrite.to}
+                      onChange={(event) => updateRewrite(index, { to: event.target.value })}
+                      placeholder="/media"
+                    />
+                  </Field>
+                  <Button
+                    type="button"
+                    variant="ghost"
+                    size="icon"
+                    onClick={() => removeRewrite(index)}
+                    aria-label="Remove rewrite"
+                  >
+                    <X className="h-4 w-4" />
+                  </Button>
+                </div>
+              ))
+            )}
+            <Button type="button" variant="outline" size="sm" onClick={addRewrite}>
+              <Plus className="h-4 w-4" />
+              Add rewrite
+            </Button>
+          </div>
+        ) : null}
+      </div>
+
+      <Button type="button" onClick={handleSave} disabled={updateSource.isPending}>
+        <Save className="h-4 w-4" />
+        Save
+      </Button>
+    </div>
+  );
+}
+
+function formatAutoscanPollDate(value: string | null | undefined): string {
+  if (!value) return "Never";
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) return value;
+  return date.toLocaleString();
 }
 
 type UserLimitFormState = {

--- a/web/src/pages/AdminRequests.tsx
+++ b/web/src/pages/AdminRequests.tsx
@@ -1569,10 +1569,26 @@ function AutoscanSourceEditor({ source }: { source: AutoscanSource }) {
                 </div>
               ))
             )}
-            <Button type="button" variant="outline" size="sm" onClick={addRewrite}>
-              <Plus className="h-4 w-4" />
-              Add rewrite
-            </Button>
+            <div className="flex flex-wrap gap-2">
+              <Button type="button" variant="outline" size="sm" onClick={addRewrite}>
+                <Plus className="h-4 w-4" />
+                Add rewrite
+              </Button>
+              <Button
+                type="button"
+                variant="outline"
+                size="sm"
+                disabled={suggest.isPending}
+                onClick={async () => {
+                  const s = await suggest.mutateAsync(source.integration_id);
+                  setPreview(s);
+                  setSelected(new Set((s.proposed ?? []).map((p) => p.from)));
+                }}
+              >
+                <RefreshCw className="h-4 w-4" />
+                Sync rewrites
+              </Button>
+            </div>
           </div>
         ) : null}
       </div>
@@ -1649,19 +1665,6 @@ function AutoscanSourceEditor({ source }: { source: AutoscanSource }) {
         <Button type="button" onClick={handleSave} disabled={updateSource.isPending}>
           <Save className="h-4 w-4" />
           Save
-        </Button>
-        <Button
-          type="button"
-          variant="outline"
-          disabled={suggest.isPending}
-          onClick={async () => {
-            const s = await suggest.mutateAsync(source.integration_id);
-            setPreview(s);
-            setSelected(new Set(s.proposed.map((p) => p.from)));
-          }}
-        >
-          <RefreshCw className="h-4 w-4" />
-          Sync from arr
         </Button>
       </div>
     </div>

--- a/web/src/pages/AdminRequests.tsx
+++ b/web/src/pages/AdminRequests.tsx
@@ -1430,7 +1430,10 @@ function AutoscanSourcesSection() {
       <h2 className="text-lg font-semibold tracking-normal">Instances</h2>
       <div className="grid gap-4 xl:grid-cols-2">
         {list.map((source) => (
-          <AutoscanSourceEditor key={source.integration_id} source={source} />
+          <AutoscanSourceEditor
+            key={`${source.integration_id}:${source.enabled}:${JSON.stringify(source.path_rewrites)}`}
+            source={source}
+          />
         ))}
       </div>
     </div>

--- a/web/src/pages/AdminRequests.tsx
+++ b/web/src/pages/AdminRequests.tsx
@@ -1449,7 +1449,7 @@ function AutoscanSourceEditor({ source }: { source: AutoscanSource }) {
   const [rewrites, setRewrites] = useState<AutoscanPathRewrite[]>(() =>
     source.path_rewrites.map((rewrite) => ({ ...rewrite })),
   );
-  const [rewritesOpen, setRewritesOpen] = useState(source.path_rewrites.length > 0);
+  const [rewritesOpen, setRewritesOpen] = useState(false);
   const [preview, setPreview] = useState<AutoscanRewriteSuggestions | null>(null);
   const [selected, setSelected] = useState<Set<string>>(new Set());
   const rewritesPanelID = useId();
@@ -1585,8 +1585,8 @@ function AutoscanSourceEditor({ source }: { source: AutoscanSource }) {
                   setSelected(new Set((s.proposed ?? []).map((p) => p.from)));
                 }}
               >
-                <RefreshCw className="h-4 w-4" />
-                Sync rewrites
+                <RefreshCw className={`h-4 w-4 ${suggest.isPending ? "animate-spin" : ""}`} />
+                {suggest.isPending ? "Syncing…" : "Sync rewrites"}
               </Button>
             </div>
           </div>

--- a/web/src/pages/AdminRequests.tsx
+++ b/web/src/pages/AdminRequests.tsx
@@ -17,6 +17,7 @@ import {
 } from "lucide-react";
 import type {
   AutoscanPathRewrite,
+  AutoscanRewriteSuggestions,
   AutoscanSettings,
   AutoscanSource,
   MediaRequest,
@@ -62,6 +63,7 @@ import {
 } from "@/components/ui/table";
 import { useAdminUsers } from "@/hooks/queries/admin/users";
 import {
+  useAutoscanRewriteSuggestions,
   useAutoscanSettings,
   useAutoscanSources,
   useTriggerAutoscan,
@@ -1442,11 +1444,14 @@ function AutoscanSourcesSection() {
 
 function AutoscanSourceEditor({ source }: { source: AutoscanSource }) {
   const updateSource = useUpdateAutoscanSource();
+  const suggest = useAutoscanRewriteSuggestions();
   const [enabled, setEnabled] = useState(source.enabled);
   const [rewrites, setRewrites] = useState<AutoscanPathRewrite[]>(() =>
     source.path_rewrites.map((rewrite) => ({ ...rewrite })),
   );
   const [rewritesOpen, setRewritesOpen] = useState(source.path_rewrites.length > 0);
+  const [preview, setPreview] = useState<AutoscanRewriteSuggestions | null>(null);
+  const [selected, setSelected] = useState<Set<string>>(new Set());
   const rewritesPanelID = useId();
 
   function updateRewrite(index: number, patch: Partial<AutoscanPathRewrite>) {
@@ -1468,6 +1473,29 @@ function AutoscanSourceEditor({ source }: { source: AutoscanSource }) {
       .map((rewrite) => ({ from: rewrite.from.trim(), to: rewrite.to.trim() }))
       .filter((rewrite) => rewrite.from.length > 0 || rewrite.to.length > 0);
     updateSource.mutate({ id: source.integration_id, body: { enabled, path_rewrites } });
+  }
+
+  function toggleSelected(from: string) {
+    setSelected((current) => {
+      const next = new Set(current);
+      if (next.has(from)) {
+        next.delete(from);
+      } else {
+        next.add(from);
+      }
+      return next;
+    });
+  }
+
+  function addSelectedToRewrites() {
+    if (!preview) return;
+    const existingFroms = new Set(rewrites.map((rewrite) => rewrite.from));
+    const additions = preview.proposed
+      .filter((proposal) => selected.has(proposal.from) && !existingFroms.has(proposal.from))
+      .map((proposal) => ({ from: proposal.from, to: proposal.to }));
+    setRewrites([...rewrites, ...additions]);
+    setRewritesOpen(true);
+    setPreview(null);
   }
 
   return (
@@ -1549,10 +1577,93 @@ function AutoscanSourceEditor({ source }: { source: AutoscanSource }) {
         ) : null}
       </div>
 
-      <Button type="button" onClick={handleSave} disabled={updateSource.isPending}>
-        <Save className="h-4 w-4" />
-        Save
-      </Button>
+      {preview ? (
+        <div
+          className="border-border space-y-4 rounded-lg border p-3"
+          role="region"
+          aria-label="Rewrite suggestions"
+        >
+          <div className="space-y-2">
+            <p className="text-sm font-medium">Proposed</p>
+            {preview.proposed.length === 0 ? (
+              <p className="text-muted-foreground text-xs">No proposed rewrites.</p>
+            ) : (
+              preview.proposed.map((proposal) => (
+                <label key={proposal.from} className="flex items-center gap-2 text-sm">
+                  <input
+                    type="checkbox"
+                    checked={selected.has(proposal.from)}
+                    onChange={() => toggleSelected(proposal.from)}
+                  />
+                  <span className="font-mono text-xs">
+                    {proposal.from} → {proposal.to}
+                  </span>
+                  {proposal.match_depth >= 2 ? (
+                    <Badge variant="secondary">{`${proposal.match_depth} segments`}</Badge>
+                  ) : (
+                    <Badge variant="destructive">1 segment — weak</Badge>
+                  )}
+                </label>
+              ))
+            )}
+          </div>
+
+          {preview.unmatched.length > 0 ? (
+            <div className="space-y-1">
+              <p className="text-sm font-medium">No Silo match (add manually if needed)</p>
+              <ul className="text-muted-foreground space-y-0.5 text-xs">
+                {preview.unmatched.map((path) => (
+                  <li key={path} className="font-mono">
+                    {path}
+                  </li>
+                ))}
+              </ul>
+            </div>
+          ) : null}
+
+          {preview.ambiguous.length > 0 ? (
+            <div className="space-y-1">
+              <p className="text-sm font-medium">Ambiguous (pick one manually)</p>
+              <ul className="text-muted-foreground space-y-0.5 text-xs">
+                {preview.ambiguous.map((entry) => (
+                  <li key={entry.root} className="font-mono">
+                    {`${entry.root} → ${entry.candidates.join(", ")}`}
+                  </li>
+                ))}
+              </ul>
+            </div>
+          ) : null}
+
+          <div className="flex flex-wrap gap-2">
+            <Button type="button" size="sm" onClick={addSelectedToRewrites}>
+              Add selected to rewrites
+            </Button>
+            <Button type="button" variant="outline" size="sm" onClick={() => setPreview(null)}>
+              Cancel
+            </Button>
+          </div>
+        </div>
+      ) : null}
+
+      <div className="flex flex-wrap gap-2">
+        <Button type="button" onClick={handleSave} disabled={updateSource.isPending}>
+          <Save className="h-4 w-4" />
+          Save
+        </Button>
+        <Button
+          type="button"
+          variant="outline"
+          disabled={suggest.isPending}
+          onClick={async () => {
+            const s = await suggest.mutateAsync(source.integration_id);
+            setPreview(s);
+            setSelected(new Set(s.proposed.map((p) => p.from)));
+          }}
+        >
+          <RefreshCw className="h-4 w-4" />
+          Sync from arr
+        </Button>
+      </div>
     </div>
   );
 }


### PR DESCRIPTION
## Summary

Adds **Autoscan**: a periodic poller that watches each configured Radarr/Sonarr instance's history for changes and triggers targeted Silo library rescans, so newly-imported or renamed files appear without waiting for a full scan.

The feature reuses the existing `request_integrations` rows as its arr sources (no second place to configure server URLs/keys) and is **off by default** — operators opt in per instance from the Requests admin surface.

Three layers, built bottom-up:

1. **Polling core** — every N minutes, for each enabled source, read `/api/v3/history/since`, map arr-side paths to Silo paths via per-instance path rewrites, dedup to parent folders, and enqueue scans through the existing `scantrigger` → `scanqueue` pipeline. Redis-backed debounce suppresses repeat scans of the same `(folder, path)` within a TTL.
2. **Rewrite-sync** — a convenience that queries an instance's arr root folders and suffix-matches each to a Silo media folder to propose path rewrites. Additive and manual-preserving: synced rows never overwrite operator-entered rewrites; the operator stays the source of truth.
3. **Rename-handling** — history polling also surfaces `episodeFileRenamed` / `movieFileRenamed` events (both the new path and the old `sourcePath`), since a rename moves a file with no import event and can cross folders.

## Why this approach

- **Reuses request integrations as sources.** Arr base URL + Fernet-encrypted API key already live in `request_integrations`; Autoscan references them by FK (`ON DELETE CASCADE`) instead of duplicating credential storage.
- **Targeted scans, not full rescans.** Resolving each changed path to its owning `MediaFolder` and enqueueing a subtree/file scan keeps the feature cheap under load — consistent with the repo's performance-first priority.
- **Generic, no deployment constants.** Path rewrites and suffix-matching are driven entirely by what each arr instance and the Silo catalog report at runtime; nothing about any specific host topology is baked in.

## Schema

`migrations/171_autoscan.{up,down}.sql` (no collision — `main` tops out at 170):

- `autoscan_settings` — singleton row (`id boolean PRIMARY KEY CHECK (id)`): `enabled`, `poll_interval_minutes` (CHECK > 0), `debounce_seconds` (CHECK >= 0). Seeded disabled.
- `autoscan_sources` — `integration_id` PK/FK → `request_integrations(id)` `ON DELETE CASCADE`; `enabled`, `path_rewrites jsonb`, `last_poll_at`.

## API (admin-gated, under `/admin`)

| Method | Path | Purpose |
|--------|------|---------|
| GET    | `/admin/autoscan/settings` | read global settings |
| PUT    | `/admin/autoscan/settings` | update settings |
| GET    | `/admin/autoscan/sources` | list sources (joined to integrations) |
| PUT    | `/admin/autoscan/sources/{id}` | upsert per-source enable + rewrites |
| POST   | `/admin/autoscan/trigger` | run one poll cycle now (async, 202) |
| GET    | `/admin/autoscan/status` | poll/interval status |
| GET    | `/admin/autoscan/sources/{id}/rewrite-suggestions` | suggest rewrites from arr root folders |

## Frontend

New **Autoscan** tab in the Requests admin page (`AdminRequests.tsx`): global enable + interval/debounce, per-source enable, and a collapsible path-rewrite editor with a "Sync rewrites" action that previews proposed / unmatched / ambiguous / already-covered matches before applying. Types + React Query hooks in `web/src/api/types.ts` and `web/src/hooks/queries/useAutoscan.ts`.

## Testing

- Go unit tests across `internal/autoscan`: poll cycle (dedup, distinct-paths-same-folder, disabled no-op, source-failure-doesn't-advance, release-claim-on-enqueue-failure), history parsing (imports + renames, ignores unrelated events), suffix-match suggester (unique/ambiguous/covered/no-op/normalization), rewrite + dedupe helpers, and handler tests (`FK → 404`, trigger dispatch).
- **Full Go suite green — 59 packages, 0 failures, including `-race`.** Note: the autoscan handler tests live in `internal/api/handlers`, which links libvips via CGO; run tests in an environment with `libvips-dev` (CI / the Docker `golang:1.26` build stage). A bare host without it reports `[build failed]` for those packages and skips their tests.
- `go vet` + `gofmt` clean.

## Risks / follow-ups

- Poll window is bounded (overlap buffer + 24h max-lookback floor) so a long outage can't produce an oversized history response; worst case is a missed pre-window change, recoverable by a manual scan.
- Client repos (`silo-android`, `silo-apple`) need no changes — admin-only server feature, no client-visible API surface.

## Note on the diff

This branch was cut before the vitest-4 hotfix (#42) merged, so the diff includes one unrelated file, `web/src/lib/recipes.test.ts`. That is the exact change in #42; once #42 merges and this branch is rebased onto `main`, git drops it as a duplicate. It does not double-apply.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * **Autoscan**: Automatically triggers library scans when new media is detected from enabled integrations
  * Added Autoscan admin tab with global settings (enable/disable, poll interval, debounce), per-source configuration, manual trigger, and status display
  * **Path rewrite suggestions** to help map import paths to media folders
<!-- end of auto-generated comment: release notes by coderabbit.ai -->