### PR TITLE
fix(jellycompat): fill large browse pages

### DIFF
--- a/internal/catalog/browse.go
+++ b/internal/catalog/browse.go
@@ -33,6 +33,7 @@ type BrowseFilters struct {
 	Sort               string   // created_at, release_date, rating_imdb, rating_tmdb, year, sort_title, recently_added
 	Order              string   // asc, desc
 	Limit              int
+	MaxLimit           int // optional caller-specific cap; zero keeps the default browse cap
 	Offset             int
 	SnapshotAt         *time.Time // pagination fence: exclude items created after this timestamp
 }
@@ -77,7 +78,7 @@ func (r *BrowseRepository) browse(ctx context.Context, filters BrowseFilters, in
 		return &BrowseResult{Items: []*models.MediaItem{}, Total: 0, HasMore: false}, nil
 	}
 
-	dataQuery, queryArgs := plan.pagedSQL(includeTotal)
+	dataQuery, queryArgs := plan.pagedSQL(false)
 	rows, err := r.pool.Query(ctx, dataQuery, queryArgs...)
 	if err != nil {
 		return nil, fmt.Errorf("browsing media items: %w", err)
@@ -88,32 +89,31 @@ func (r *BrowseRepository) browse(ctx context.Context, filters BrowseFilters, in
 		items []*models.MediaItem
 		total int
 	)
-	if includeTotal {
-		items, total, err = scanBrowseItemsWithTotal(rows)
-	} else {
-		items, err = scanBrowseItems(rows)
-	}
+	items, err = scanBrowseItems(rows)
 	if err != nil {
 		return nil, err
 	}
 
 	hasMore := false
+	hasExtraRow := len(items) > plan.limit
+	if hasExtraRow {
+		items = items[:plan.limit]
+	}
 	if includeTotal {
-		// COUNT(*) OVER () emits no rows when the data SELECT is empty, so
-		// total stays 0 even when the broader result set has matching rows
-		// (e.g. OFFSET past the last page). Re-query the count to give
-		// callers the real total. Skip when offset == 0 because in that
-		// case an empty page genuinely means total = 0.
-		if len(items) == 0 && plan.offset > 0 {
+		switch {
+		case plan.offset == 0 && len(items) == 0:
+			total = 0
+		case !hasExtraRow && len(items) > 0:
+			total = plan.offset + len(items)
+		default:
 			countSQL, countArgs := plan.countSQL()
 			if err := r.pool.QueryRow(ctx, countSQL, countArgs...).Scan(&total); err != nil {
-				return nil, fmt.Errorf("count fallback for empty browse page: %w", err)
+				return nil, fmt.Errorf("count browse page: %w", err)
 			}
 		}
 		hasMore = total > plan.offset+plan.limit
-	} else if len(items) > plan.limit {
+	} else if hasExtraRow {
 		hasMore = true
-		items = items[:plan.limit]
 	}
 
 	return &BrowseResult{
@@ -151,12 +151,9 @@ type browseQueryPlan struct {
 
 // countSQL renders a count-only query that returns the total number of rows
 // matching the plan's FROM/WHERE/GROUP BY, ignoring LIMIT/OFFSET/ORDER BY.
-// Used as a fallback when pagedSQL(true) returned an empty page past offset 0:
-// COUNT(*) OVER () emits no rows when the data SELECT is empty, so the
-// caller would otherwise see total=0 even when the broader result set has
-// matching rows. Wraps the inner query in `SELECT COUNT(*) FROM (...) sub`
-// so any GROUP BY in the inner query is preserved (we count groups, matching
-// what COUNT(*) OVER () would compute).
+// Used by exact-total callers so the data SELECT can remain a pure page query.
+// Wraps the inner query in `SELECT COUNT(*) FROM (...) sub` so any GROUP BY in
+// the inner query is preserved.
 //
 // Binds only p.args (FROM/WHERE/GROUP BY values). orderArgs are deliberately
 // excluded — the count SQL has no ORDER BY clause to reference them, and
@@ -172,16 +169,12 @@ func (p browseQueryPlan) countSQL() (string, []any) {
 }
 
 // pagedSQL renders the final paged SELECT and returns it together with the
-// fully-bound arg list. When includeTotal is true the SELECT list is appended
-// with COUNT(*) OVER () AS total_count so the caller can read the total from
-// the first scanned row in a single round trip. When includeTotal is false the
-// caller has already requested a single-pass page, so we ask for one extra row
-// to detect whether more pages exist without an exact count.
-func (p browseQueryPlan) pagedSQL(includeTotal bool) (string, []any) {
+// fully-bound arg list. The query always asks for one extra row so callers can
+// detect whether more pages exist without coupling the sorted page fetch to an
+// exact count.
+func (p browseQueryPlan) pagedSQL(_ bool) (string, []any) {
 	queryLimit := p.limit
-	if !includeTotal {
-		queryLimit++
-	}
+	queryLimit++
 	// Bind order: where/from args, then order-by args, then LIMIT, then OFFSET.
 	// limitArgIdx is computed by buildBrowsePlan after consuming order args, so
 	// it correctly points at LIMIT after the orderArgs are bound below.
@@ -191,9 +184,6 @@ func (p browseQueryPlan) pagedSQL(includeTotal bool) (string, []any) {
 	offsetArgIdx := p.limitArgIdx + 1
 
 	selectList := p.selectClause
-	if includeTotal {
-		selectList += ", COUNT(*) OVER () AS total_count"
-	}
 	sql := fmt.Sprintf(
 		"SELECT %s FROM %s %s %s %s LIMIT $%d OFFSET $%d",
 		selectList, p.fromClause, p.whereClause, p.groupByClause, p.orderBy,
@@ -212,8 +202,12 @@ func (r *BrowseRepository) buildBrowsePlan(filters BrowseFilters) (browseQueryPl
 	if filters.Limit <= 0 {
 		filters.Limit = 20
 	}
-	if filters.Limit > 100 {
-		filters.Limit = 100
+	maxLimit := filters.MaxLimit
+	if maxLimit <= 0 {
+		maxLimit = 100
+	}
+	if filters.Limit > maxLimit {
+		filters.Limit = maxLimit
 	}
 	if filters.Offset < 0 {
 		filters.Offset = 0
@@ -367,7 +361,7 @@ func (r *BrowseRepository) buildBrowsePlan(filters BrowseFilters) (browseQueryPl
 	// bind only its FROM/WHERE/GROUP BY values; pagedSQL binds them together.
 	// argIdx still advances past them so limitArgIdx points at the right
 	// LIMIT placeholder once orderArgs are bound positionally before LIMIT.
-	orderBy, orderArgs := buildOrderByPlan(filters.Sort, filters.Order, filters.SnapshotAt, argIdx, singleLibraryNoDedup)
+	orderBy, orderArgs := buildOrderByPlan(filters.Sort, filters.Order, filters.SnapshotAt, argIdx, singleLibraryNoDedup, browseFiltersAreMovieOnly(filters))
 	argIdx += len(orderArgs)
 
 	selectClause := browseItemColumns("mi")
@@ -932,81 +926,13 @@ func scanBrowseItems(rows pgx.Rows) ([]*models.MediaItem, error) {
 	return items, nil
 }
 
-// scanBrowseItemsWithTotal scans rows that include a trailing total_count column
-// emitted by COUNT(*) OVER (). Used by browse() in the includeTotal path so we
-// don't fire a separate count query.
-func scanBrowseItemsWithTotal(rows pgx.Rows) ([]*models.MediaItem, int, error) {
-	var (
-		items []*models.MediaItem
-		total int
-	)
-	for rows.Next() {
-		var item models.MediaItem
-		var rowTotal int
-		err := rows.Scan(
-			&item.ContentID,
-			&item.Type,
-			&item.Title,
-			&item.SortTitle,
-			&item.OriginalTitle,
-			&item.Year,
-			&item.Genres,
-			&item.ContentRating,
-			&item.Runtime,
-			&item.Overview,
-			&item.Tagline,
-			&item.RatingIMDB,
-			&item.RatingTMDB,
-			&item.RatingRTCritic,
-			&item.RatingRTAudience,
-			&item.ImdbID,
-			&item.TmdbID,
-			&item.TvdbID,
-			&item.PosterPath,
-			&item.PosterThumbhash,
-			&item.BackdropPath,
-			&item.BackdropThumbhash,
-			&item.LogoPath,
-			&item.MetadataS3Path,
-			&item.MetadataEtag,
-			&item.SeasonCount,
-			&item.Studios,
-			&item.Networks,
-			&item.Countries,
-			&item.Keywords,
-			&item.OriginalLanguage,
-			&item.ReleaseDate,
-			&item.FirstAirDate,
-			&item.LastAirDate,
-			&item.ShowStatus,
-			&item.MatchedAt,
-			&item.EpisodeMetadataIncomplete,
-			&item.EpisodeMetadataLastCheckedAt,
-			&item.Status,
-			&item.CreatedAt,
-			&item.UpdatedAt,
-			&item.AddedAt,
-			&rowTotal,
-		)
-		if err != nil {
-			return nil, 0, fmt.Errorf("scanning browse item row with total: %w", err)
-		}
-		items = append(items, &item)
-		total = rowTotal
-	}
-	if err := rows.Err(); err != nil {
-		return nil, 0, fmt.Errorf("iterating browse item rows: %w", err)
-	}
-	return items, total, nil
-}
-
 // buildOrderBy constructs the ORDER BY clause from sort and order parameters.
 func buildOrderBy(sort, order string) string {
-	clause, _ := buildOrderByPlan(sort, order, nil, 0, false)
+	clause, _ := buildOrderByPlan(sort, order, nil, 0, false, false)
 	return clause
 }
 
-func buildOrderByPlan(sort, order string, snapshot *time.Time, argIdx int, singleLibraryNoDedup bool) (string, []any) {
+func buildOrderByPlan(sort, order string, snapshot *time.Time, argIdx int, singleLibraryNoDedup bool, movieOnly bool) (string, []any) {
 	direction := "DESC"
 	if strings.EqualFold(order, "asc") {
 		direction = "ASC"
@@ -1027,6 +953,9 @@ func buildOrderByPlan(sort, order string, snapshot *time.Time, argIdx int, singl
 		}
 		return "ORDER BY RANDOM()", nil
 	case "release_date":
+		if movieOnly {
+			return fmt.Sprintf("ORDER BY mi.release_date %s%s, mi.content_id ASC", direction, nullsClause), nil
+		}
 		return fmt.Sprintf(
 			"ORDER BY COALESCE(mi.release_date::text, NULLIF(BTRIM(mi.first_air_date), '')) %s%s, mi.content_id ASC",
 			direction,
@@ -1065,6 +994,11 @@ func buildOrderByPlan(sort, order string, snapshot *time.Time, argIdx int, singl
 	default:
 		return fmt.Sprintf("ORDER BY mi.created_at %s, mi.content_id ASC", direction), nil
 	}
+}
+
+func browseFiltersAreMovieOnly(filters BrowseFilters) bool {
+	types := splitTypes(filters.Type)
+	return len(types) == 1 && types[0] == "movie"
 }
 
 // ParseContentRatings splits a comma-separated content rating string into

--- a/internal/catalog/browse_orderby_test.go
+++ b/internal/catalog/browse_orderby_test.go
@@ -42,3 +42,26 @@ func TestBuildOrderBy_LastAirDateReadsDenormColumn(t *testing.T) {
 		t.Fatalf("expected sparse last_air_date sort to push missing items last, got %q", got)
 	}
 }
+
+func TestBrowsePlan_ReleaseDateMovieOnlyUsesIndexedDateColumn(t *testing.T) {
+	repo := &BrowseRepository{}
+	plan, earlyEmpty, err := repo.buildBrowsePlan(BrowseFilters{
+		Type:  "movie",
+		Sort:  "release_date",
+		Order: "desc",
+		Limit: 1000,
+	})
+	if err != nil {
+		t.Fatalf("buildBrowsePlan error: %v", err)
+	}
+	if earlyEmpty {
+		t.Fatal("did not expect early empty result")
+	}
+	if strings.Contains(plan.orderBy, "COALESCE(") || strings.Contains(plan.orderBy, "::text") {
+		t.Fatalf("movie-only release_date sort must use the indexed date column, got %q", plan.orderBy)
+	}
+	want := "ORDER BY mi.release_date DESC NULLS LAST, mi.content_id ASC"
+	if plan.orderBy != want {
+		t.Fatalf("orderBy = %q, want %q", plan.orderBy, want)
+	}
+}

--- a/internal/catalog/window_count_test.go
+++ b/internal/catalog/window_count_test.go
@@ -41,9 +41,11 @@ func TestQueryExecutor_PreviewPage_SkipTotal_OmitsWindowCount(t *testing.T) {
 	}
 }
 
-// TestBrowseRepository_browse_UsesWindowCount asserts that buildBrowsePlan +
-// pagedSQL emit COUNT(*) OVER () in the data SELECT when includeTotal is true.
-func TestBrowseRepository_browse_UsesWindowCount(t *testing.T) {
+// TestBrowseRepository_browse_ExactTotalOmitsWindowCount asserts that
+// buildBrowsePlan + pagedSQL keep the data SELECT free of COUNT(*) OVER ().
+// BrowsePage runs the exact count separately when needed so large ordered
+// catalogs can use top-N/index plans for the page fetch.
+func TestBrowseRepository_browse_ExactTotalOmitsWindowCount(t *testing.T) {
 	repo := &BrowseRepository{}
 	plan, earlyEmpty, err := repo.buildBrowsePlan(BrowseFilters{Limit: 20})
 	if err != nil {
@@ -53,8 +55,8 @@ func TestBrowseRepository_browse_UsesWindowCount(t *testing.T) {
 		t.Fatalf("did not expect early empty result for default filters")
 	}
 	sql, _ := plan.pagedSQL(true)
-	if !strings.Contains(sql, "COUNT(*) OVER ()") {
-		t.Fatalf("expected COUNT(*) OVER () for single-pass browse count; got:\n%s", sql)
+	if strings.Contains(sql, "COUNT(*) OVER ()") {
+		t.Fatalf("exact browse totals must omit COUNT(*) OVER (); got:\n%s", sql)
 	}
 }
 
@@ -72,6 +74,31 @@ func TestBrowseRepository_browse_SkipTotal_OmitsWindowCount(t *testing.T) {
 	sql, _ := plan.pagedSQL(false)
 	if strings.Contains(sql, "COUNT(*) OVER ()") {
 		t.Fatalf("SkipTotal must omit COUNT(*) OVER (); got:\n%s", sql)
+	}
+}
+
+func TestBrowseRepository_browse_MaxLimitAllowsCallerSpecificLargePages(t *testing.T) {
+	repo := &BrowseRepository{}
+	plan, earlyEmpty, err := repo.buildBrowsePlan(BrowseFilters{Limit: 1000, MaxLimit: 1000})
+	if err != nil {
+		t.Fatalf("buildBrowsePlan error: %v", err)
+	}
+	if earlyEmpty {
+		t.Fatalf("did not expect early empty result")
+	}
+	if plan.limit != 1000 {
+		t.Fatalf("plan limit = %d, want 1000", plan.limit)
+	}
+
+	defaultPlan, earlyEmpty, err := repo.buildBrowsePlan(BrowseFilters{Limit: 1000})
+	if err != nil {
+		t.Fatalf("buildBrowsePlan default cap error: %v", err)
+	}
+	if earlyEmpty {
+		t.Fatalf("did not expect early empty result for default cap")
+	}
+	if defaultPlan.limit != 100 {
+		t.Fatalf("default plan limit = %d, want 100", defaultPlan.limit)
 	}
 }
 

--- a/internal/jellycompat/content_direct.go
+++ b/internal/jellycompat/content_direct.go
@@ -27,9 +27,14 @@ type LibraryPosterPresigner interface {
 // directContentService relies on. Defined as an interface so tests can
 // substitute a stub without standing up a Postgres pool.
 type browseSource interface {
-	Browse(ctx context.Context, filters catalog.BrowseFilters) (*catalog.BrowseResult, error)
+	BrowsePage(ctx context.Context, filters catalog.BrowseFilters, includeTotal bool) (*catalog.BrowseResult, error)
 	ListGenres(ctx context.Context, filters catalog.BrowseFilters) ([]string, error)
 }
+
+const (
+	compatBrowseChunkLimit = 100
+	compatBrowseMaxLimit   = 1000
+)
 
 // itemAccessSource is the subset of *catalog.ItemRepository that
 // directContentService season/episode handlers rely on. Defined as an
@@ -165,17 +170,23 @@ func (s *directContentService) BrowseItems(ctx context.Context, session *Session
 	filter := s.resolveFilter(ctx, session)
 	isPlayedFilter := params.Get("is_played") // "", "true", or "false"
 	contentIDs := parseContentIDParam(params.Get("content_ids"))
+	includeTotal := parseBool(params.Get("include_total"), true)
 
 	requestedLimit := catalog.ParseIntParam(params.Get("limit"))
 	if requestedLimit <= 0 {
 		requestedLimit = 24
 	}
-	requestedOffset := catalog.ParseIntParam(params.Get("offset"))
+	if requestedLimit > compatBrowseMaxLimit {
+		requestedLimit = compatBrowseMaxLimit
+	}
+	requestedOffset := max(catalog.ParseIntParam(params.Get("offset")), 0)
 
-	// When filtering by played status, over-fetch to compensate for filtered-out items.
 	fetchLimit := requestedLimit
 	if isPlayedFilter != "" {
-		fetchLimit = min(requestedLimit*3, 100)
+		// Played status is a profile overlay, so browse over-fetches bounded
+		// chunks and filters them locally instead of asking catalog for every
+		// row in a large library.
+		fetchLimit = min(max(requestedLimit*3, compatBrowseChunkLimit), compatBrowseMaxLimit)
 	}
 
 	filters := catalog.BrowseFilters{
@@ -191,19 +202,31 @@ func (s *directContentService) BrowseItems(ctx context.Context, session *Session
 		Sort:               params.Get("sort"),
 		Order:              params.Get("order"),
 		Limit:              fetchLimit,
+		MaxLimit:           compatBrowseMaxLimit,
 		Offset:             requestedOffset,
 	}
 
 	var collected []upstreamListItem
 	totalFromCatalog := 0
-	maxIterations := 5
+	totalKnown := false
+	hasMore := false
+	scannedRows := 0
+	maxScannedRows := requestedLimit
+	if isPlayedFilter != "" {
+		maxScannedRows = max(requestedLimit*5, compatBrowseChunkLimit)
+	}
 
-	for range maxIterations {
-		result, err := s.browseRepo.Browse(ctx, filters)
+	for len(collected) < requestedLimit && scannedRows < maxScannedRows {
+		wantTotal := includeTotal && !totalKnown
+		result, err := s.browseRepo.BrowsePage(ctx, filters, wantTotal)
 		if err != nil {
 			return nil, fmt.Errorf("browse items: %w", err)
 		}
-		totalFromCatalog = result.Total
+		if wantTotal {
+			totalFromCatalog = result.Total
+			totalKnown = true
+		}
+		hasMore = result.HasMore
 
 		batch := make([]upstreamListItem, 0, len(result.Items))
 		for _, mi := range result.Items {
@@ -232,21 +255,24 @@ func (s *directContentService) BrowseItems(ctx context.Context, session *Session
 			collected = append(collected, batch...)
 		}
 
-		// Stop if we have enough or catalog is exhausted.
-		if len(collected) >= requestedLimit || len(result.Items) < filters.Limit {
+		scannedRows += len(result.Items)
+		if len(result.Items) == 0 || !result.HasMore {
 			break
 		}
-		filters.Offset += filters.Limit
+		filters.Offset += len(result.Items)
 	}
 
 	// Trim to requested limit.
 	if len(collected) > requestedLimit {
 		collected = collected[:requestedLimit]
 	}
+	if totalKnown {
+		hasMore = totalFromCatalog > requestedOffset+requestedLimit
+	}
 
 	return &upstreamBrowseResponse{
 		Total:   totalFromCatalog,
-		HasMore: totalFromCatalog > requestedOffset+requestedLimit,
+		HasMore: hasMore,
 		Items:   collected,
 	}, nil
 }

--- a/internal/jellycompat/content_direct.go
+++ b/internal/jellycompat/content_direct.go
@@ -235,10 +235,9 @@ func (s *directContentService) BrowseItems(ctx context.Context, session *Session
 					mi = localized
 				}
 			}
-			item := mediaItemToListItem(mi)
-			s.presignListItem(ctx, &item)
-			batch = append(batch, item)
+			batch = append(batch, mediaItemToListItem(mi))
 		}
+		s.presignListItems(ctx, batch)
 		if isPlayedFilter != "" {
 			// Need user data to filter by played status. The handler's
 			// resolveUserStateForContentIDs call covers UserData on the wire
@@ -313,10 +312,9 @@ func (s *directContentService) SearchItems(ctx context.Context, session *Session
 				mi = localized
 			}
 		}
-		item := mediaItemToListItem(mi)
-		s.presignListItem(ctx, &item)
-		listItems = append(listItems, item)
+		listItems = append(listItems, mediaItemToListItem(mi))
 	}
+	s.presignListItems(ctx, listItems)
 	s.enrichListItemsUserData(ctx, session, listItems)
 
 	return &upstreamBrowseResponse{
@@ -652,6 +650,39 @@ func seasonUserDataFromProgress(progress userstore.WatchProgress) *catalog.Seaso
 // --- Image URL presigning helpers ---
 
 func (s *directContentService) presignListItem(ctx context.Context, item *upstreamListItem) {
+	if item == nil {
+		return
+	}
+	items := []upstreamListItem{*item}
+	s.presignListItems(ctx, items)
+	*item = items[0]
+}
+
+func (s *directContentService) presignListItems(ctx context.Context, items []upstreamListItem) {
+	if len(items) == 0 {
+		return
+	}
+	for i := range items {
+		ensureListItemImagePaths(&items[i])
+	}
+	if s.detailSvc == nil {
+		return
+	}
+
+	posterURLs := s.detailSvc.PresignImageURLsWithExpiry(ctx, collectListImagePaths(items, func(item upstreamListItem) string { return item.PosterURL }), "poster", compatCardImageSize)
+	backdropURLs := s.detailSvc.PresignImageURLsWithExpiry(ctx, collectListImagePaths(items, func(item upstreamListItem) string { return item.BackdropURL }), "backdrop", compatCardImageSize)
+	logoURLs := s.detailSvc.PresignImageURLsWithExpiry(ctx, collectListImagePaths(items, func(item upstreamListItem) string { return item.LogoURL }), "logo", compatCardImageSize)
+	stillURLs := s.detailSvc.PresignImageURLsWithExpiry(ctx, collectListImagePaths(items, func(item upstreamListItem) string { return item.StillURL }), "still", compatCardImageSize)
+
+	for i := range items {
+		items[i].PosterURL = resolvedListImageURL(posterURLs, items[i].PosterURL)
+		items[i].BackdropURL = resolvedListImageURL(backdropURLs, items[i].BackdropURL)
+		items[i].LogoURL = resolvedListImageURL(logoURLs, items[i].LogoURL)
+		items[i].StillURL = resolvedListImageURL(stillURLs, items[i].StillURL)
+	}
+}
+
+func ensureListItemImagePaths(item *upstreamListItem) {
 	if item.PosterPath == "" {
 		item.PosterPath = item.PosterURL
 	}
@@ -664,10 +695,33 @@ func (s *directContentService) presignListItem(ctx context.Context, item *upstre
 	if item.StillPath == "" {
 		item.StillPath = item.StillURL
 	}
-	item.PosterURL = compatPresignImage(s.detailSvc, ctx, item.PosterURL, "poster", compatCardImageSize)
-	item.BackdropURL = compatPresignImage(s.detailSvc, ctx, item.BackdropURL, "backdrop", compatCardImageSize)
-	item.LogoURL = compatPresignImage(s.detailSvc, ctx, item.LogoURL, "logo", compatCardImageSize)
-	item.StillURL = compatPresignImage(s.detailSvc, ctx, item.StillURL, "still", compatCardImageSize)
+}
+
+func collectListImagePaths(items []upstreamListItem, pick func(upstreamListItem) string) []string {
+	paths := make([]string, 0, len(items))
+	seen := make(map[string]struct{}, len(items))
+	for _, item := range items {
+		path := pick(item)
+		if path == "" {
+			continue
+		}
+		if _, ok := seen[path]; ok {
+			continue
+		}
+		seen[path] = struct{}{}
+		paths = append(paths, path)
+	}
+	return paths
+}
+
+func resolvedListImageURL(resolved map[string]catalog.ResolvedImageURL, path string) string {
+	if path == "" {
+		return ""
+	}
+	if value, ok := resolved[path]; ok {
+		return value.URL
+	}
+	return ""
 }
 
 func (s *directContentService) presignSeason(ctx context.Context, season *upstreamSeason) {

--- a/internal/jellycompat/content_direct_test.go
+++ b/internal/jellycompat/content_direct_test.go
@@ -2,6 +2,7 @@ package jellycompat
 
 import (
 	"context"
+	"fmt"
 	"net/url"
 	"testing"
 	"time"
@@ -329,10 +330,28 @@ func (s *progressCountingStore) DeleteLibraryPlaybackPreference(context.Context,
 type stubBrowseSource struct {
 	items []*models.MediaItem
 	total int
+	calls []stubBrowseCall
 }
 
-func (s *stubBrowseSource) Browse(_ context.Context, _ catalog.BrowseFilters) (*catalog.BrowseResult, error) {
-	return &catalog.BrowseResult{Items: s.items, Total: s.total}, nil
+type stubBrowseCall struct {
+	filters      catalog.BrowseFilters
+	includeTotal bool
+}
+
+func (s *stubBrowseSource) BrowsePage(_ context.Context, filters catalog.BrowseFilters, includeTotal bool) (*catalog.BrowseResult, error) {
+	s.calls = append(s.calls, stubBrowseCall{filters: filters, includeTotal: includeTotal})
+
+	start := min(max(filters.Offset, 0), len(s.items))
+	end := min(start+max(filters.Limit, 0), len(s.items))
+	total := 0
+	if includeTotal {
+		total = s.total
+	}
+	return &catalog.BrowseResult{
+		Items:   append([]*models.MediaItem(nil), s.items[start:end]...),
+		Total:   total,
+		HasMore: end < len(s.items),
+	}, nil
 }
 
 func (s *stubBrowseSource) ListGenres(_ context.Context, _ catalog.BrowseFilters) ([]string, error) {
@@ -413,6 +432,84 @@ func TestBrowseItems_FetchesProgressWhenPlayedFilterSet(t *testing.T) {
 	}
 }
 
+func TestBrowseItems_FillsLargeJellyfinLimitInSingleCatalogPage(t *testing.T) {
+	provider := newProgressCountingStoreProvider()
+	browse := &stubBrowseSource{
+		items: makeBrowseTestMediaItems(400),
+		total: 400,
+	}
+	svc := newDirectContentServiceForTest(browse, provider)
+
+	session := &Session{StreamAppUserID: 1, ProfileID: "profile-1"}
+	params := url.Values{}
+	params.Set("limit", "250")
+	params.Set("offset", "10")
+	params.Set("include_total", "true")
+
+	result, err := svc.BrowseItems(context.Background(), session, params)
+	if err != nil {
+		t.Fatalf("BrowseItems returned error: %v", err)
+	}
+	if got, want := len(result.Items), 250; got != want {
+		t.Fatalf("items length = %d, want %d", got, want)
+	}
+	if result.Total != 400 {
+		t.Fatalf("Total = %d, want 400", result.Total)
+	}
+	if !result.HasMore {
+		t.Fatal("HasMore = false, want true")
+	}
+	if got, want := len(browse.calls), 1; got != want {
+		t.Fatalf("BrowsePage calls = %d, want %d", got, want)
+	}
+
+	call := browse.calls[0]
+	if call.filters.Limit != 250 {
+		t.Fatalf("Limit = %d, want 250", call.filters.Limit)
+	}
+	if call.filters.MaxLimit != compatBrowseMaxLimit {
+		t.Fatalf("MaxLimit = %d, want %d", call.filters.MaxLimit, compatBrowseMaxLimit)
+	}
+	if call.filters.Offset != 10 {
+		t.Fatalf("Offset = %d, want 10", call.filters.Offset)
+	}
+	if !call.includeTotal {
+		t.Fatal("includeTotal = false, want true")
+	}
+}
+
+func TestBrowseItems_HonorsIncludeTotalFalse(t *testing.T) {
+	browse := &stubBrowseSource{
+		items: makeBrowseTestMediaItems(300),
+		total: 300,
+	}
+	svc := newDirectContentServiceForTest(browse, nil)
+
+	session := &Session{StreamAppUserID: 1, ProfileID: "profile-1"}
+	params := url.Values{}
+	params.Set("limit", "150")
+	params.Set("include_total", "false")
+
+	result, err := svc.BrowseItems(context.Background(), session, params)
+	if err != nil {
+		t.Fatalf("BrowseItems returned error: %v", err)
+	}
+	if got, want := len(result.Items), 150; got != want {
+		t.Fatalf("items length = %d, want %d", got, want)
+	}
+	if result.Total != 0 {
+		t.Fatalf("Total = %d, want 0 when include_total=false", result.Total)
+	}
+	if got, want := len(browse.calls), 1; got != want {
+		t.Fatalf("BrowsePage calls = %d, want %d", got, want)
+	}
+	for i, call := range browse.calls {
+		if call.includeTotal {
+			t.Fatalf("call %d includeTotal = true, want false", i)
+		}
+	}
+}
+
 // TestEnrichListItemsUserData_BatchesIntoSingleFetch verifies that
 // enrichListItemsUserData makes exactly one batched ListProgressByMediaItems
 // call regardless of batch size — not N+1 per-item fetches.
@@ -436,4 +533,16 @@ func TestEnrichListItemsUserData_BatchesIntoSingleFetch(t *testing.T) {
 		t.Fatalf("ListProgressByMediaItems should receive all %d ids in one batch; got %d",
 			want, got)
 	}
+}
+
+func makeBrowseTestMediaItems(count int) []*models.MediaItem {
+	items := make([]*models.MediaItem, 0, count)
+	for i := range count {
+		items = append(items, &models.MediaItem{
+			ContentID: fmt.Sprintf("movie-%03d", i),
+			Type:      "movie",
+			Title:     fmt.Sprintf("Movie %03d", i),
+		})
+	}
+	return items
 }

--- a/internal/jellycompat/content_direct_test.go
+++ b/internal/jellycompat/content_direct_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"net/url"
+	"slices"
 	"testing"
 	"time"
 
@@ -54,6 +55,95 @@ func TestItemEtagIncludesPremiereDate(t *testing.T) {
 
 	if itemEtag(base) == itemEtag(updated) {
 		t.Fatal("expected date changes to alter the compat item etag")
+	}
+}
+
+type countingCompatImageResolver struct {
+	singleCalls int
+	batchCalls  int
+	variants    []string
+	paths       []string
+}
+
+func (r *countingCompatImageResolver) ResolveImageURL(_ context.Context, path string, variant string) string {
+	r.singleCalls++
+	return "single:" + variant + ":" + path
+}
+
+func (r *countingCompatImageResolver) ResolveImageURLs(_ context.Context, paths []string, variant string) map[string]string {
+	resolved := r.ResolveImageURLsWithExpiry(context.Background(), paths, variant)
+	urls := make(map[string]string, len(resolved))
+	for path, value := range resolved {
+		urls[path] = value.URL
+	}
+	return urls
+}
+
+func (r *countingCompatImageResolver) ResolveImageURLWithExpiry(_ context.Context, path string, variant string) catalog.ResolvedImageURL {
+	r.singleCalls++
+	return catalog.ResolvedImageURL{URL: "single:" + variant + ":" + path}
+}
+
+func (r *countingCompatImageResolver) ResolveImageURLsWithExpiry(_ context.Context, paths []string, variant string) map[string]catalog.ResolvedImageURL {
+	r.batchCalls++
+	r.variants = append(r.variants, variant)
+	r.paths = append(r.paths, paths...)
+	resolved := make(map[string]catalog.ResolvedImageURL, len(paths))
+	for _, path := range paths {
+		resolved[path] = catalog.ResolvedImageURL{URL: "batch:" + variant + ":" + path}
+	}
+	return resolved
+}
+
+func TestPresignListItemsBatchResolvesImages(t *testing.T) {
+	resolver := &countingCompatImageResolver{}
+	detailSvc := &catalog.DetailService{}
+	detailSvc.SetImageResolver(resolver)
+	svc := &directContentService{detailSvc: detailSvc}
+
+	items := []upstreamListItem{
+		{
+			ContentID:   "movie-1",
+			PosterURL:   "plug://poster-1",
+			BackdropURL: "plug://backdrop-1",
+			LogoURL:     "plug://logo-1",
+		},
+		{
+			ContentID: "movie-2",
+			PosterURL: "plug://poster-2",
+			StillURL:  "plug://still-2",
+		},
+	}
+
+	svc.presignListItems(context.Background(), items)
+
+	if resolver.singleCalls != 0 {
+		t.Fatalf("single image resolver calls = %d, want 0", resolver.singleCalls)
+	}
+	if resolver.batchCalls != 4 {
+		t.Fatalf("batch image resolver calls = %d, want 4", resolver.batchCalls)
+	}
+	for _, variant := range resolver.variants {
+		if variant != "card" {
+			t.Fatalf("batch variant = %q, want card", variant)
+		}
+	}
+	for _, path := range []string{"plug://poster-1", "plug://poster-2", "plug://backdrop-1", "plug://logo-1", "plug://still-2"} {
+		if !slices.Contains(resolver.paths, path) {
+			t.Fatalf("batch paths %v missing %q", resolver.paths, path)
+		}
+	}
+	if items[0].PosterPath != "plug://poster-1" {
+		t.Fatalf("PosterPath = %q, want original path", items[0].PosterPath)
+	}
+	if got := items[0].PosterURL; got != "batch:card:plug://poster-1" {
+		t.Fatalf("PosterURL = %q", got)
+	}
+	if got := items[0].BackdropURL; got != "batch:card:plug://backdrop-1" {
+		t.Fatalf("BackdropURL = %q", got)
+	}
+	if got := items[1].StillURL; got != "batch:card:plug://still-2" {
+		t.Fatalf("StillURL = %q", got)
 	}
 }
 

--- a/internal/jellycompat/query.go
+++ b/internal/jellycompat/query.go
@@ -197,6 +197,7 @@ func buildBrowseParams(query itemsQuery) url.Values {
 	if query.order != "" {
 		params.Set("order", query.order)
 	}
+	params.Set("include_total", strconv.FormatBool(query.enableTotalRecordCount))
 	if query.personID > 0 {
 		params.Set("person_id", strconv.FormatInt(query.personID, 10))
 	}

--- a/internal/jellycompat/query_test.go
+++ b/internal/jellycompat/query_test.go
@@ -29,6 +29,17 @@ func TestParseItemsQueryAcceptsIsFavoriteParam(t *testing.T) {
 	}
 }
 
+func TestBuildBrowseParamsPropagatesEnableTotalRecordCount(t *testing.T) {
+	req := httptest.NewRequest("GET", "/Items?EnableTotalRecordCount=false", nil)
+
+	query := parseItemsQuery(req, NewResourceIDCodec())
+	params := buildBrowseParams(query)
+
+	if got := params.Get("include_total"); got != "false" {
+		t.Fatalf("include_total = %q, want false", got)
+	}
+}
+
 func TestMapSortByReleaseDate(t *testing.T) {
 	tests := []string{
 		"PremiereDate",

--- a/internal/jellycompat/router.go
+++ b/internal/jellycompat/router.go
@@ -39,6 +39,7 @@ func NewRouter(deps Dependencies) chi.Router {
 		MaxAge:           86400,
 	}))
 	r.Use(normalizeCompatPathMiddleware)
+	r.Use(middleware.Compress(5, "application/json"))
 	if debugPath := os.Getenv("JELLYCOMPAT_DEBUG_LOG"); debugPath != "" {
 		rotator := &lumberjack.Logger{
 			Filename:   debugPath,

--- a/internal/jellycompat/router_test.go
+++ b/internal/jellycompat/router_test.go
@@ -1,0 +1,46 @@
+package jellycompat
+
+import (
+	"compress/gzip"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/Silo-Server/silo-server/internal/config"
+)
+
+func TestRouterCompressesJSONResponses(t *testing.T) {
+	cfg, err := config.LoadFromDB(map[string]string{})
+	if err != nil {
+		t.Fatalf("LoadFromDB: %v", err)
+	}
+	router := NewRouter(Dependencies{Config: cfg})
+
+	req := httptest.NewRequest(http.MethodGet, "/System/Info/Public", nil)
+	req.Header.Set("Accept-Encoding", "gzip")
+	rec := httptest.NewRecorder()
+
+	router.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d", rec.Code, http.StatusOK)
+	}
+	if got := rec.Header().Get("Content-Encoding"); got != "gzip" {
+		t.Fatalf("Content-Encoding = %q, want gzip", got)
+	}
+
+	reader, err := gzip.NewReader(rec.Body)
+	if err != nil {
+		t.Fatalf("gzip reader: %v", err)
+	}
+	defer reader.Close()
+	body, err := io.ReadAll(reader)
+	if err != nil {
+		t.Fatalf("read compressed body: %v", err)
+	}
+	if !strings.Contains(string(body), `"ProductName":"Jellyfin Server"`) {
+		t.Fatalf("unexpected response body %q", string(body))
+	}
+}

--- a/migrations/174_movie_release_date_desc_index.down.sql
+++ b/migrations/174_movie_release_date_desc_index.down.sql
@@ -1,0 +1,1 @@
+DROP INDEX IF EXISTS public.idx_media_items_movie_release_date_desc_content;

--- a/migrations/174_movie_release_date_desc_index.up.sql
+++ b/migrations/174_movie_release_date_desc_index.up.sql
@@ -1,0 +1,3 @@
+CREATE INDEX IF NOT EXISTS idx_media_items_movie_release_date_desc_content
+ON public.media_items USING btree (release_date DESC NULLS LAST, content_id ASC)
+WHERE type = 'movie';


### PR DESCRIPTION
## Summary

Fixes UHF-style Jellyfin compatibility `/Items` browse requests that ask for large pages and deep `StartIndex` offsets, such as `Limit=1000&StartIndex=1925000&SortBy=PremiereDate`.

## Root Cause

The Jellyfin compatibility layer passed the client limit into catalog browse, but catalog silently capped pages at 100. That under-filled large Jellyfin pages and forced clients to do much more pagination work. The movie `PremiereDate` sort also used a text `COALESCE(...)` expression, which prevented the large-offset movie browse path from using a release-date btree index effectively.

## Changes

- Propagate `EnableTotalRecordCount` into the direct Jellyfin browse adapter.
- Let Jellycompat explicitly request up to 1000 catalog rows for compatibility browse pages while preserving the default 100-row cap for native catalog callers.
- Keep exact totals out of the sorted page query; exact counts use the separate count query path or are inferred when safe.
- Make movie-only `PremiereDate` browse order by `mi.release_date` directly.
- Add `idx_media_items_movie_release_date_desc_content` for movie release-date deep paging.
- Add regression coverage for large compatibility pages, `include_total=false`, caller-specific catalog caps, and the movie-only release-date SQL shape.

## Validation

- `go test ./internal/jellycompat ./internal/catalog`

## AI Use

Implemented with AI assistance.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Performance Improvements**
  * Added response compression for API payloads
  * Optimized movie browse queries with efficient release date sorting
  * Implemented batch image resolution for faster content loading

* **API Enhancements**
  * Browse pagination now supports configurable maximum page limits
  * Improved total record count reporting with optional calculation modes

<!-- end of auto-generated comment: release notes by coderabbit.ai -->