### PR TITLE
fix(playback): avoid restarting active transcodes

### DIFF
--- a/internal/api/handlers/playback.go
+++ b/internal/api/handlers/playback.go
@@ -2257,6 +2257,7 @@ func (h *PlaybackHandler) HandleGetTranscodeSegment(w http.ResponseWriter, r *ht
 				"start_segment_number", decision.Progress.StartSegmentNumber,
 				"last_produced_age_ms", lastProducedAgeMS,
 				"wait_timeout_ms", decision.WaitTimeout.Milliseconds(),
+				"restart_on_timeout", decision.RestartOnTimeout,
 				"reason", decision.Reason,
 				"session", sessionID,
 				"playback_session_id", sessionID,
@@ -2270,6 +2271,7 @@ func (h *PlaybackHandler) HandleGetTranscodeSegment(w http.ResponseWriter, r *ht
 					"start_segment_number", decision.Progress.StartSegmentNumber,
 					"last_produced_age_ms", lastProducedAgeMS,
 					"wait_timeout_ms", decision.WaitTimeout.Milliseconds(),
+					"restart_on_timeout", decision.RestartOnTimeout,
 					"reason", decision.Reason,
 					"session", sessionID,
 					"playback_session_id", sessionID,
@@ -2284,6 +2286,7 @@ func (h *PlaybackHandler) HandleGetTranscodeSegment(w http.ResponseWriter, r *ht
 						"start_segment_number", decision.Progress.StartSegmentNumber,
 						"last_produced_age_ms", lastProducedAgeMS,
 						"wait_timeout_ms", decision.WaitTimeout.Milliseconds(),
+						"restart_on_timeout", decision.RestartOnTimeout,
 						"reason", decision.Reason,
 						"session", sessionID,
 						"playback_session_id", sessionID,
@@ -2295,7 +2298,7 @@ func (h *PlaybackHandler) HandleGetTranscodeSegment(w http.ResponseWriter, r *ht
 			// active encode range), either restart at the exact manifest-derived
 			// timeline position or return 404 for copy-mode segments outside the
 			// current manifest window.
-			if err != nil && errors.Is(err, playback.ErrSegmentNotFound) {
+			if err != nil && errors.Is(err, playback.ErrSegmentNotFound) && decision.RestartOnTimeout {
 				seekSeconds, ok, seekErr := transcodeSession.RestartSeekTarget(segNum)
 				if seekErr != nil && !errors.Is(seekErr, playback.ErrManifestNotReady) {
 					slog.Error("resolve transcode seek target", "error", seekErr, "segment", segmentName, "session", sessionID, "playback_session_id", sessionID)
@@ -2310,6 +2313,7 @@ func (h *PlaybackHandler) HandleGetTranscodeSegment(w http.ResponseWriter, r *ht
 						"start_segment_number", decision.Progress.StartSegmentNumber,
 						"last_produced_age_ms", lastProducedAgeMS,
 						"wait_timeout_ms", decision.WaitTimeout.Milliseconds(),
+						"restart_on_timeout", decision.RestartOnTimeout,
 						"reason", decision.Reason,
 						"seek_seconds", seekSeconds,
 						"session", sessionID,

--- a/internal/jellycompat/streams.go
+++ b/internal/jellycompat/streams.go
@@ -337,7 +337,7 @@ func (h *PlaybackHandler) HandleHLSSegment(w http.ResponseWriter, r *http.Reques
 				}
 			}
 
-			if err != nil && errors.Is(err, playback.ErrSegmentNotFound) {
+			if err != nil && errors.Is(err, playback.ErrSegmentNotFound) && decision.RestartOnTimeout {
 				seekSeconds, ok, seekErr := transcodeSession.RestartSeekTarget(segNum)
 				if seekErr != nil && !errors.Is(seekErr, playback.ErrManifestNotReady) {
 					slog.Error("resolve transcode seek target",

--- a/internal/playback/transcode.go
+++ b/internal/playback/transcode.go
@@ -93,10 +93,11 @@ type SegmentProgress struct {
 // SegmentRecoveryDecision tells the segment handler whether to briefly wait
 // for ffmpeg or seek-restart immediately.
 type SegmentRecoveryDecision struct {
-	Wait        bool
-	WaitTimeout time.Duration
-	Reason      string
-	Progress    SegmentProgress
+	Wait             bool
+	WaitTimeout      time.Duration
+	RestartOnTimeout bool
+	Reason           string
+	Progress         SegmentProgress
 }
 
 // defaultSegmentDuration is the segment length when not specified. Short
@@ -109,6 +110,7 @@ const maxPersistedFFmpegChars = 2000
 
 const (
 	maxSequentialMissingSegments = 2
+	activeSegmentWait            = 12 * time.Second
 	segmentWaitGrace             = 1500 * time.Millisecond
 	maxSegmentWait               = 6 * time.Second
 	minSegmentWait               = 3 * time.Second
@@ -1096,8 +1098,9 @@ func (s *TranscodeSession) SegmentProgress(time.Time) SegmentProgress {
 func (s *TranscodeSession) SegmentRecoveryDecision(segNum int, now time.Time) SegmentRecoveryDecision {
 	progress := s.SegmentProgress(now)
 	decision := SegmentRecoveryDecision{
-		WaitTimeout: segmentWaitTimeout(progress.SegmentDuration),
-		Progress:    progress,
+		WaitTimeout:      segmentWaitTimeout(progress.SegmentDuration),
+		RestartOnTimeout: true,
+		Progress:         progress,
 	}
 
 	switch {
@@ -1112,6 +1115,8 @@ func (s *TranscodeSession) SegmentRecoveryDecision(segNum int, now time.Time) Se
 	case !progress.HasManifest:
 		if segNum <= progress.StartSegmentNumber+1 {
 			decision.Wait = true
+			decision.WaitTimeout = activeSegmentWait
+			decision.RestartOnTimeout = false
 			decision.Reason = "startup_manifest_not_ready"
 		} else {
 			decision.Reason = "startup_request_beyond_window"
@@ -1122,6 +1127,8 @@ func (s *TranscodeSession) SegmentRecoveryDecision(segNum int, now time.Time) Se
 		decision.Reason = "produced_output_stale"
 	default:
 		decision.Wait = true
+		decision.WaitTimeout = activeSegmentWait
+		decision.RestartOnTimeout = false
 		decision.Reason = "near_produced_head"
 	}
 

--- a/internal/playback/transcode_manifest_test.go
+++ b/internal/playback/transcode_manifest_test.go
@@ -486,11 +486,43 @@ func TestSegmentRecoveryDecisionWaitsForFreshNextSegment(t *testing.T) {
 	if !decision.Wait {
 		t.Fatalf("Wait = false, want true (reason=%s)", decision.Reason)
 	}
-	if decision.WaitTimeout != 3500*time.Millisecond {
-		t.Fatalf("WaitTimeout = %s, want 3.5s", decision.WaitTimeout)
+	if decision.WaitTimeout != 12*time.Second {
+		t.Fatalf("WaitTimeout = %s, want 12s", decision.WaitTimeout)
 	}
 	if decision.Reason != "near_produced_head" {
 		t.Fatalf("Reason = %q, want near_produced_head", decision.Reason)
+	}
+	if decision.RestartOnTimeout {
+		t.Fatal("RestartOnTimeout = true, want false")
+	}
+}
+
+func TestSegmentRecoveryDecisionUsesLongerWaitForStartupSegment(t *testing.T) {
+	tempDir := t.TempDir()
+	now := time.Now()
+
+	session := &TranscodeSession{
+		outputDir: tempDir,
+		running:   true,
+		opts: TranscodeOpts{
+			TargetCodecVideo:   "h264",
+			SegmentDuration:    2,
+			StartSegmentNumber: 0,
+		},
+	}
+
+	decision := session.SegmentRecoveryDecision(0, now)
+	if !decision.Wait {
+		t.Fatalf("Wait = false, want true (reason=%s)", decision.Reason)
+	}
+	if decision.WaitTimeout != 12*time.Second {
+		t.Fatalf("WaitTimeout = %s, want 12s", decision.WaitTimeout)
+	}
+	if decision.Reason != "startup_manifest_not_ready" {
+		t.Fatalf("Reason = %q, want startup_manifest_not_ready", decision.Reason)
+	}
+	if decision.RestartOnTimeout {
+		t.Fatal("RestartOnTimeout = true, want false")
 	}
 }
 
@@ -515,6 +547,9 @@ func TestSegmentRecoveryDecisionRestartsWhenProducedOutputIsStale(t *testing.T) 
 	decision := session.SegmentRecoveryDecision(226, now)
 	if decision.Wait {
 		t.Fatal("Wait = true, want false")
+	}
+	if !decision.RestartOnTimeout {
+		t.Fatal("RestartOnTimeout = false, want true")
 	}
 	if decision.Reason != "produced_output_stale" {
 		t.Fatalf("Reason = %q, want produced_output_stale", decision.Reason)

--- a/internal/transcodenode/server.go
+++ b/internal/transcodenode/server.go
@@ -377,7 +377,7 @@ func (s *Server) handleSegment(w http.ResponseWriter, r *http.Request) {
 				}
 			}
 
-			if err != nil && err == playback.ErrSegmentNotFound {
+			if err != nil && err == playback.ErrSegmentNotFound && decision.RestartOnTimeout {
 				seekSeconds, ok, seekErr := session.RestartSeekTarget(segNum)
 				if seekErr != nil && !errors.Is(seekErr, playback.ErrManifestNotReady) {
 					slog.Error("resolve transcode node seek target", "error", seekErr, "segment", name, "session", sessionID, "playback_session_id", sessionID)


### PR DESCRIPTION
## Summary

- add a restart-on-timeout decision so active transcodes can wait without forcing an ffmpeg seek restart
- give startup/current-head segment requests a modest 12s grace window while preserving restarts for stale output and jump-ahead cases
- include `restart_on_timeout` in playback segment logs and cover the recovery decisions with tests

## Context

This is a playback resiliency improvement. It avoids amplifying transient startup/current-head segment delays by restarting ffmpeg while it is still actively producing output. It is not framed as the root-cause fix for the recent slow-playback incident; that was resolved by fixing the ns18 VLAN 400 jumbo path.

## Test Plan

- [x] `go test ./internal/playback ./internal/api/handlers -count=1`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved transcode segment recovery: refined timeout behavior to control when automatic restarts occur vs. waiting, reducing unnecessary restarts during startup and near live head.
  * Added logging to surface the restart-on-timeout decision in missing-segment recovery paths.

* **Tests**
  * Updated segment recovery tests to reflect the new wait-time and restart-on-timeout behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->