### PR TITLE
fix(onboarding): reuse admin library setup flow

### DIFF
--- a/web/src/components/admin/libraries/LibraryForm.tsx
+++ b/web/src/components/admin/libraries/LibraryForm.tsx
@@ -1,0 +1,562 @@
+import { useMemo, useState } from "react";
+import type { FormEvent, ReactNode } from "react";
+import {
+  ArrowDown,
+  ArrowUp,
+  ChevronDown,
+  ChevronRight,
+  FolderOpen,
+  Plus,
+  Trash2,
+} from "lucide-react";
+
+import type { CreateLibraryRequest, Library } from "@/api/types";
+import { Button } from "@/components/ui/button";
+import FolderBrowser from "@/components/FolderBrowser";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import PathAutocompleteInput from "@/components/PathAutocompleteInput";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import { Switch } from "@/components/ui/switch";
+import {
+  useCreateLibrary,
+  useLibraryProviders,
+  useSetLibraryProviders,
+  useUpdateLibrary,
+} from "@/hooks/queries/admin/libraries";
+import { useAdminPlugins } from "@/hooks/queries/admin/plugins";
+import { cn } from "@/lib/utils";
+import { LANGUAGES } from "@/player/utils/languageNames";
+
+type LevelChainItem = {
+  plugin_installation_id: number;
+  capability_id: string;
+  provider_slug: string;
+  enabled: boolean;
+};
+
+type MetadataProvider = {
+  plugin_installation_id: number;
+  capability_id: string;
+  slug: string;
+  defaultPriority: Record<string, number>;
+};
+
+export interface LibraryFormProps {
+  library: Library | null;
+  chapterThumbnailsSupported: boolean;
+  onClose?: () => void;
+  onSaved?: (library: Library) => void;
+  resetAfterCreate?: boolean;
+  submitLabel?: string;
+  savingLabel?: string;
+  extraContent?: ReactNode;
+}
+
+function contentLevelsForType(libraryType: string): string[] {
+  switch (libraryType) {
+    case "series":
+      return ["series", "season", "episode"];
+    case "movies":
+      return ["movie"];
+    case "mixed":
+      return ["movie", "series", "season", "episode"];
+    default:
+      return [];
+  }
+}
+
+function buildDefaultLevelChains(
+  metadataProviders: MetadataProvider[],
+  libraryType: string,
+): Record<string, LevelChainItem[]> {
+  const defaultChain: Record<string, LevelChainItem[]> = {};
+  for (const level of contentLevelsForType(libraryType)) {
+    const sorted = [...metadataProviders].sort((a, b) => {
+      const pa = a.defaultPriority[level] ?? 0;
+      const pb = b.defaultPriority[level] ?? 0;
+      if ((pa === 0) !== (pb === 0)) return pa === 0 ? 1 : -1;
+      return pa - pb;
+    });
+    defaultChain[level] = sorted.map((provider) => ({
+      plugin_installation_id: provider.plugin_installation_id,
+      capability_id: provider.capability_id,
+      provider_slug: provider.slug,
+      enabled: (provider.defaultPriority[level] ?? 0) > 0,
+    }));
+  }
+  return defaultChain;
+}
+
+function buildLevelChainsFromServer(
+  currentChain: {
+    levels?: Record<
+      string,
+      Array<{
+        plugin_installation_id: number;
+        capability_id: string;
+        provider_slug: string;
+        enabled: boolean;
+      }>
+    >;
+  } | null,
+  metadataProviders: MetadataProvider[],
+  libraryType: string,
+): Record<string, LevelChainItem[]> {
+  const mapped: Record<string, LevelChainItem[]> = {};
+  if (currentChain?.levels) {
+    for (const [level, entries] of Object.entries(currentChain.levels)) {
+      mapped[level] = entries.map((entry) => ({
+        plugin_installation_id: entry.plugin_installation_id,
+        capability_id: entry.capability_id,
+        provider_slug: entry.provider_slug,
+        enabled: entry.enabled,
+      }));
+    }
+  }
+
+  const defaults = buildDefaultLevelChains(metadataProviders, libraryType);
+  for (const level of contentLevelsForType(libraryType)) {
+    if (!mapped[level] || mapped[level].length === 0) {
+      mapped[level] = defaults[level] ?? [];
+    }
+  }
+  return mapped;
+}
+
+function contentLevelLabel(level: string): string {
+  return level.charAt(0).toUpperCase() + level.slice(1);
+}
+
+function buildProviderChainBody(activeLevelChains: Record<string, LevelChainItem[]>) {
+  return {
+    levels: Object.fromEntries(
+      Object.entries(activeLevelChains).map(([level, items]) => [
+        level,
+        items.map((item, i) => ({
+          plugin_installation_id: item.plugin_installation_id,
+          capability_id: item.capability_id,
+          priority: i,
+          enabled: item.enabled,
+        })),
+      ]),
+    ),
+  };
+}
+
+function ProviderLevelSection({
+  level,
+  items,
+  onReorder,
+  onToggleEnabled,
+}: {
+  level: string;
+  items: LevelChainItem[];
+  onReorder: (items: LevelChainItem[]) => void;
+  onToggleEnabled: (index: number) => void;
+}) {
+  const [collapsed, setCollapsed] = useState(false);
+
+  const moveItem = (index: number, direction: -1 | 1) => {
+    const newItems = [...items];
+    const target = index + direction;
+    if (target < 0 || target >= newItems.length) return;
+    [newItems[index], newItems[target]] = [newItems[target]!, newItems[index]!];
+    onReorder(newItems);
+  };
+
+  return (
+    <div className="mb-3">
+      <button
+        type="button"
+        onClick={() => setCollapsed(!collapsed)}
+        className="text-primary hover:text-primary/80 mb-1.5 flex items-center gap-1.5 text-xs font-semibold tracking-wider uppercase"
+      >
+        {collapsed ? <ChevronRight className="h-3 w-3" /> : <ChevronDown className="h-3 w-3" />}
+        {contentLevelLabel(level)}
+      </button>
+      {!collapsed && (
+        <div className="flex flex-col gap-1">
+          {items.map((item, i) => (
+            <div
+              key={`${item.plugin_installation_id}:${item.capability_id}`}
+              className={cn(
+                "flex items-center gap-2 rounded-md border px-2.5 py-1.5 text-sm",
+                item.enabled
+                  ? "border-border bg-muted text-foreground"
+                  : "border-border/50 bg-muted/30 text-muted-foreground",
+              )}
+            >
+              <input
+                type="checkbox"
+                checked={item.enabled}
+                onChange={() => onToggleEnabled(i)}
+                className="h-3.5 w-3.5"
+                style={{ accentColor: "var(--primary)" }}
+              />
+              <span className="flex-1 font-mono text-xs">{item.provider_slug}</span>
+              <div className="flex gap-0.5">
+                <Button
+                  type="button"
+                  variant="ghost"
+                  size="icon"
+                  className="h-5 w-5"
+                  disabled={i === 0}
+                  onClick={() => moveItem(i, -1)}
+                >
+                  <ArrowUp className="h-2.5 w-2.5" />
+                </Button>
+                <Button
+                  type="button"
+                  variant="ghost"
+                  size="icon"
+                  className="h-5 w-5"
+                  disabled={i === items.length - 1}
+                  onClick={() => moveItem(i, 1)}
+                >
+                  <ArrowDown className="h-2.5 w-2.5" />
+                </Button>
+              </div>
+              <span className="text-muted-foreground/70 font-mono text-[10px]">{i + 1}</span>
+            </div>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}
+
+export function LibraryForm({
+  library,
+  chapterThumbnailsSupported,
+  onClose,
+  onSaved,
+  resetAfterCreate = false,
+  submitLabel = "Save",
+  savingLabel = "Saving...",
+  extraContent,
+}: LibraryFormProps) {
+  const [name, setName] = useState(library?.name ?? "");
+  const [paths, setPaths] = useState<string[]>(library?.paths?.length ? library.paths : [""]);
+  const [type, setType] = useState(library?.type ?? "movies");
+  const [enabled, setEnabled] = useState(library?.enabled ?? true);
+  const [metadataLanguage, setMetadataLanguage] = useState(library?.metadata_language ?? "en");
+  const [chapterThumbnailsEnabled, setChapterThumbnailsEnabled] = useState(
+    library?.chapter_thumbnails_enabled ?? false,
+  );
+  const [introDetectionEnabled, setIntroDetectionEnabled] = useState(
+    library?.intro_detection_enabled ?? false,
+  );
+  const [levelChains, setLevelChains] = useState<Record<string, LevelChainItem[]>>({});
+  const [chainDirty, setChainDirty] = useState(false);
+  const [browserOpen, setBrowserOpen] = useState(false);
+
+  const createMutation = useCreateLibrary();
+  const updateMutation = useUpdateLibrary();
+  const setChainMutation = useSetLibraryProviders();
+  const { installations } = useAdminPlugins();
+  const { data: currentChain } = useLibraryProviders(library?.id ?? null);
+
+  const metadataProviders = useMemo(() => {
+    const result: MetadataProvider[] = [];
+    for (const inst of installations) {
+      if (!inst.enabled) continue;
+      for (const cap of inst.capabilities ?? []) {
+        if (cap.type === "metadata_provider.v1") {
+          const dp =
+            (cap.metadata?.default_priority as Record<string, number>) ??
+            ((cap.metadata?.metadata as Record<string, unknown>)?.default_priority as Record<
+              string,
+              number
+            >) ??
+            {};
+          result.push({
+            plugin_installation_id: inst.id,
+            capability_id: cap.id,
+            slug: cap.display_name || cap.id,
+            defaultPriority: dp,
+          });
+        }
+      }
+    }
+    return result;
+  }, [installations]);
+
+  const isPending =
+    createMutation.isPending || updateMutation.isPending || setChainMutation.isPending;
+
+  const defaultLevelChains = useMemo(
+    () => buildDefaultLevelChains(metadataProviders, type),
+    [metadataProviders, type],
+  );
+  const resolvedLevelChains = useMemo(() => {
+    if (!library) {
+      return defaultLevelChains;
+    }
+    if (currentChain === undefined) {
+      return levelChains;
+    }
+    return buildLevelChainsFromServer(currentChain, metadataProviders, type);
+  }, [currentChain, defaultLevelChains, levelChains, library, metadataProviders, type]);
+  const activeLevelChains = chainDirty ? levelChains : resolvedLevelChains;
+
+  function updatePath(index: number, value: string) {
+    const next = [...paths];
+    next[index] = value;
+    setPaths(next);
+  }
+
+  function addPath() {
+    setPaths([...paths, ""]);
+  }
+
+  function removePath(index: number) {
+    setPaths(paths.filter((_, i) => i !== index));
+  }
+
+  function handleBrowseSelect(selectedPaths: string[]) {
+    const merged = [...paths.filter((path) => path.trim())];
+    for (const selectedPath of selectedPaths) {
+      if (!merged.includes(selectedPath)) {
+        merged.push(selectedPath);
+      }
+    }
+    setPaths(merged.length > 0 ? merged : [""]);
+    setBrowserOpen(false);
+  }
+
+  function handleTypeChange(newType: string) {
+    setType(newType);
+    if (!library) {
+      setLevelChains(buildDefaultLevelChains(metadataProviders, newType));
+      setChainDirty(true);
+    }
+  }
+
+  function finishCreate(created: Library) {
+    onSaved?.(created);
+    if (resetAfterCreate) {
+      setName("");
+      setPaths([""]);
+    } else {
+      onClose?.();
+    }
+  }
+
+  async function handleSubmit(e: FormEvent) {
+    e.preventDefault();
+    const filteredPaths = paths.filter((p) => p.trim());
+    if (filteredPaths.length === 0) return;
+
+    const body: CreateLibraryRequest = {
+      name,
+      paths: filteredPaths,
+      type,
+      enabled,
+      metadata_language: metadataLanguage,
+      chapter_thumbnails_enabled: chapterThumbnailsEnabled,
+      intro_detection_enabled: introDetectionEnabled,
+    };
+
+    if (library) {
+      updateMutation.mutate(
+        { id: library.id, body },
+        {
+          onSuccess: () => {
+            if (chainDirty) {
+              setChainMutation.mutate(
+                {
+                  id: library.id,
+                  body: buildProviderChainBody(activeLevelChains),
+                },
+                { onSuccess: () => onClose?.() },
+              );
+            } else {
+              onClose?.();
+            }
+          },
+        },
+      );
+      return;
+    }
+
+    createMutation.mutate(body, {
+      onSuccess: (created) => {
+        if (chainDirty) {
+          setChainMutation.mutate(
+            {
+              id: created.id,
+              body: buildProviderChainBody(activeLevelChains),
+            },
+            { onSuccess: () => finishCreate(created) },
+          );
+        } else {
+          finishCreate(created);
+        }
+      },
+    });
+  }
+
+  return (
+    <form onSubmit={handleSubmit} className="space-y-3">
+      <div className="grid grid-cols-[1fr_auto] items-end gap-3">
+        <div className="space-y-1.5">
+          <Label>Name</Label>
+          <Input value={name} onChange={(e) => setName(e.target.value)} required />
+        </div>
+        <div className="flex items-center gap-2 pb-0.5">
+          <Switch id="enabled-switch" checked={enabled} onCheckedChange={setEnabled} />
+          <Label htmlFor="enabled-switch" className="text-muted-foreground text-xs">
+            Enabled
+          </Label>
+        </div>
+      </div>
+      <div className="space-y-1.5">
+        <Label>Paths</Label>
+        {paths.map((p, i) => (
+          <div key={i} className="flex gap-1">
+            <PathAutocompleteInput
+              value={p}
+              onValueChange={(value) => updatePath(i, value)}
+              placeholder="/mnt/media/movies"
+              required
+            />
+            {paths.length > 1 && (
+              <Button
+                type="button"
+                variant="ghost"
+                size="icon"
+                className="h-9 w-9 shrink-0"
+                onClick={() => removePath(i)}
+              >
+                <Trash2 className="h-3.5 w-3.5" />
+              </Button>
+            )}
+          </div>
+        ))}
+        <div className="flex gap-1">
+          <Button type="button" variant="outline" size="sm" onClick={addPath}>
+            <Plus className="mr-1 h-3.5 w-3.5" /> Add Path
+          </Button>
+          <Button type="button" variant="outline" size="sm" onClick={() => setBrowserOpen(true)}>
+            <FolderOpen className="mr-1 h-3.5 w-3.5" /> Browse
+          </Button>
+        </div>
+        <FolderBrowser
+          open={browserOpen}
+          onOpenChange={setBrowserOpen}
+          onSelect={handleBrowseSelect}
+          existingPaths={paths.filter((path) => path.trim())}
+        />
+      </div>
+      <div className="grid grid-cols-2 items-end gap-3">
+        <div className="space-y-1.5">
+          <Label>Type</Label>
+          <Select value={type} onValueChange={handleTypeChange}>
+            <SelectTrigger>
+              <SelectValue />
+            </SelectTrigger>
+            <SelectContent>
+              <SelectItem value="movies">Movies</SelectItem>
+              <SelectItem value="series">Series</SelectItem>
+              <SelectItem value="mixed">Mixed</SelectItem>
+            </SelectContent>
+          </Select>
+        </div>
+        <div className="space-y-1.5">
+          <Label>Metadata Language</Label>
+          <Select value={metadataLanguage} onValueChange={setMetadataLanguage}>
+            <SelectTrigger>
+              <SelectValue />
+            </SelectTrigger>
+            <SelectContent>
+              {LANGUAGES.map((lang) => (
+                <SelectItem key={lang.code} value={lang.code}>
+                  {lang.label}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+        </div>
+      </div>
+      <div className="rounded-xl border border-white/10 bg-white/5 p-3">
+        <div className="flex items-start justify-between gap-3">
+          <div className="space-y-1">
+            <Label htmlFor="chapter-thumbnails-switch">Generate chapter thumbnails</Label>
+            <p className="text-xs text-white/60">
+              Stores chapter preview images in the configured public asset S3 bucket. Chapter
+              markers and chapter menus still work without thumbnails.
+            </p>
+            {!chapterThumbnailsSupported ? (
+              <p className="text-xs text-amber-300">
+                Public asset S3 storage is required before this can be enabled.
+              </p>
+            ) : null}
+          </div>
+          <Switch
+            id="chapter-thumbnails-switch"
+            checked={chapterThumbnailsEnabled}
+            disabled={!chapterThumbnailsSupported}
+            onCheckedChange={setChapterThumbnailsEnabled}
+          />
+        </div>
+      </div>
+      <div className="rounded-xl border border-white/10 bg-white/5 p-3">
+        <div className="flex items-start justify-between gap-3">
+          <div className="space-y-1">
+            <Label htmlFor="intro-detection-switch">Detect intro markers</Label>
+            <p className="text-xs text-white/60">
+              Runs background audio analysis for episodes in this library. Embedded intro chapters
+              are used when available.
+            </p>
+          </div>
+          <Switch
+            id="intro-detection-switch"
+            checked={introDetectionEnabled}
+            onCheckedChange={setIntroDetectionEnabled}
+          />
+        </div>
+      </div>
+      {extraContent}
+
+      {contentLevelsForType(type).length > 0 && (
+        <div className="mt-4 border-t border-white/10 pt-4">
+          <h3 className="mb-3 text-sm font-semibold text-white">Metadata Providers</h3>
+          {contentLevelsForType(type).map((level) => {
+            const items = activeLevelChains[level] ?? [];
+            return (
+              <ProviderLevelSection
+                key={level}
+                level={level}
+                items={items}
+                onReorder={(newItems) => {
+                  setLevelChains({ ...activeLevelChains, [level]: newItems });
+                  setChainDirty(true);
+                }}
+                onToggleEnabled={(index) => {
+                  setLevelChains((prev) => {
+                    const source = prev[level] ?? activeLevelChains[level] ?? [];
+                    const updated = [...source];
+                    updated[index] = { ...updated[index]!, enabled: !updated[index]!.enabled };
+                    return { ...prev, [level]: updated };
+                  });
+                  setChainDirty(true);
+                }}
+              />
+            );
+          })}
+        </div>
+      )}
+
+      <Button type="submit" className="w-full" disabled={isPending}>
+        {isPending ? savingLabel : submitLabel}
+      </Button>
+    </form>
+  );
+}

--- a/web/src/pages/AdminLibraries.tsx
+++ b/web/src/pages/AdminLibraries.tsx
@@ -1,10 +1,9 @@
 import { Fragment, useState, useEffect, useCallback, useMemo, useRef } from "react";
-import type { FormEvent, ReactNode } from "react";
+import type { ReactNode } from "react";
 import { useDebounce } from "@/hooks/useDebounce";
 import { useEventChannel } from "@/components/realtimeEventsContext";
 import type {
   AdminJob,
-  CreateLibraryRequest,
   Library,
   LibraryMetadataMatchQueueStatus,
   LibraryMountCheckResponse,
@@ -24,8 +23,6 @@ import {
   useDeleteLibraryRootOverride,
   useStaleMediaIDs,
   useCheckLibraryMount,
-  useCreateLibrary,
-  useUpdateLibrary,
   useDeleteLibrary,
   useScanLibrary,
   useScanAllLibraries,
@@ -33,9 +30,7 @@ import {
   useRefreshLibraryMetadata,
   useCancelAdminJob,
   useConfirmEmptyRootCleanup,
-  useLibraryProviders,
   useLibraryMetadataMatchQueues,
-  useSetLibraryProviders,
   useUploadLibraryPoster,
   useDeleteLibraryPoster,
   useUnmatchedLibraryItems,
@@ -44,12 +39,11 @@ import {
 import { useActiveScans } from "@/hooks/queries/admin/scans";
 import { buildLibraryReorderEntries } from "./adminLibraryOrder";
 import MatchItemDialog from "@/components/MatchItemDialog";
-import { useAdminPlugins } from "@/hooks/queries/admin/plugins";
+import { LibraryForm } from "@/components/admin/libraries/LibraryForm";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { Badge } from "@/components/ui/badge";
-import { Switch } from "@/components/ui/switch";
 import {
   Table,
   TableBody,
@@ -74,7 +68,6 @@ import {
   SelectTrigger,
   SelectValue,
 } from "@/components/ui/select";
-import { LANGUAGES } from "@/player/utils/languageNames";
 import { Link } from "react-router";
 import {
   Plus,
@@ -84,8 +77,6 @@ import {
   ScanLine,
   DatabaseBackup,
   CheckCircle2,
-  ArrowUp,
-  ArrowDown,
   GripVertical,
   Wrench,
   HardDrive,
@@ -103,8 +94,6 @@ import {
   FolderOpen,
 } from "lucide-react";
 import { ConfirmDialog } from "@/components/ConfirmDialog";
-import FolderBrowser from "@/components/FolderBrowser";
-import PathAutocompleteInput from "@/components/PathAutocompleteInput";
 import { cn } from "@/lib/utils";
 import { toast } from "sonner";
 import { getLibraryRefreshLibraryID } from "@/lib/adminJobs";
@@ -403,6 +392,13 @@ export default function AdminLibraries() {
                   setDialogOpen(false);
                   setEditingLib(null);
                 }}
+                extraContent={
+                  editingLib ? (
+                    <div>
+                      <LibraryPosterSection library={editingLib} />
+                    </div>
+                  ) : null
+                }
               />
             </DialogContent>
           </Dialog>
@@ -2116,533 +2112,6 @@ function StaleIDsSection({ staleIDs }: { staleIDs: StaleMediaID[] }) {
         />
       )}
     </CollapsibleDiagnosticsSection>
-  );
-}
-
-type LevelChainItem = {
-  plugin_installation_id: number;
-  capability_id: string;
-  provider_slug: string;
-  enabled: boolean;
-};
-
-function contentLevelsForType(libraryType: string): string[] {
-  switch (libraryType) {
-    case "series":
-      return ["series", "season", "episode"];
-    case "movies":
-      return ["movie"];
-    case "mixed":
-      return ["movie", "series", "season", "episode"];
-    default:
-      return [];
-  }
-}
-
-function buildDefaultLevelChains(
-  metadataProviders: Array<{
-    plugin_installation_id: number;
-    capability_id: string;
-    slug: string;
-    defaultPriority: Record<string, number>;
-  }>,
-  libraryType: string,
-): Record<string, LevelChainItem[]> {
-  const defaultChain: Record<string, LevelChainItem[]> = {};
-  for (const level of contentLevelsForType(libraryType)) {
-    const sorted = [...metadataProviders].sort((a, b) => {
-      const pa = a.defaultPriority[level] ?? 0;
-      const pb = b.defaultPriority[level] ?? 0;
-      if ((pa === 0) !== (pb === 0)) return pa === 0 ? 1 : -1;
-      return pa - pb;
-    });
-    defaultChain[level] = sorted.map((provider) => ({
-      plugin_installation_id: provider.plugin_installation_id,
-      capability_id: provider.capability_id,
-      provider_slug: provider.slug,
-      enabled: (provider.defaultPriority[level] ?? 0) > 0,
-    }));
-  }
-  return defaultChain;
-}
-
-function buildLevelChainsFromServer(
-  currentChain: {
-    levels?: Record<
-      string,
-      Array<{
-        plugin_installation_id: number;
-        capability_id: string;
-        provider_slug: string;
-        enabled: boolean;
-      }>
-    >;
-  } | null,
-  metadataProviders: Array<{
-    plugin_installation_id: number;
-    capability_id: string;
-    slug: string;
-    defaultPriority: Record<string, number>;
-  }>,
-  libraryType: string,
-): Record<string, LevelChainItem[]> {
-  const mapped: Record<string, LevelChainItem[]> = {};
-  if (currentChain?.levels) {
-    for (const [level, entries] of Object.entries(currentChain.levels)) {
-      mapped[level] = entries.map((entry) => ({
-        plugin_installation_id: entry.plugin_installation_id,
-        capability_id: entry.capability_id,
-        provider_slug: entry.provider_slug,
-        enabled: entry.enabled,
-      }));
-    }
-  }
-
-  const defaults = buildDefaultLevelChains(metadataProviders, libraryType);
-  for (const level of contentLevelsForType(libraryType)) {
-    if (!mapped[level] || mapped[level].length === 0) {
-      mapped[level] = defaults[level] ?? [];
-    }
-  }
-  return mapped;
-}
-
-function contentLevelLabel(level: string): string {
-  return level.charAt(0).toUpperCase() + level.slice(1);
-}
-
-function ProviderLevelSection({
-  level,
-  items,
-  onReorder,
-  onToggleEnabled,
-}: {
-  level: string;
-  items: LevelChainItem[];
-  onReorder: (items: LevelChainItem[]) => void;
-  onToggleEnabled: (index: number) => void;
-}) {
-  const [collapsed, setCollapsed] = useState(false);
-
-  const moveItem = (index: number, direction: -1 | 1) => {
-    const newItems = [...items];
-    const target = index + direction;
-    if (target < 0 || target >= newItems.length) return;
-    [newItems[index], newItems[target]] = [newItems[target]!, newItems[index]!];
-    onReorder(newItems);
-  };
-
-  return (
-    <div className="mb-3">
-      <button
-        type="button"
-        onClick={() => setCollapsed(!collapsed)}
-        className="text-primary hover:text-primary/80 mb-1.5 flex items-center gap-1.5 text-xs font-semibold tracking-wider uppercase"
-      >
-        {collapsed ? <ChevronRight className="h-3 w-3" /> : <ChevronDown className="h-3 w-3" />}
-        {contentLevelLabel(level)}
-      </button>
-      {!collapsed && (
-        <div className="flex flex-col gap-1">
-          {items.map((item, i) => (
-            <div
-              key={`${item.plugin_installation_id}:${item.capability_id}`}
-              className={cn(
-                "flex items-center gap-2 rounded-md border px-2.5 py-1.5 text-sm",
-                item.enabled
-                  ? "border-border bg-muted text-foreground"
-                  : "border-border/50 bg-muted/30 text-muted-foreground",
-              )}
-            >
-              <input
-                type="checkbox"
-                checked={item.enabled}
-                onChange={() => onToggleEnabled(i)}
-                className="h-3.5 w-3.5"
-                style={{ accentColor: "var(--primary)" }}
-              />
-              <span className="flex-1 font-mono text-xs">{item.provider_slug}</span>
-              <div className="flex gap-0.5">
-                <Button
-                  type="button"
-                  variant="ghost"
-                  size="icon"
-                  className="h-5 w-5"
-                  disabled={i === 0}
-                  onClick={() => moveItem(i, -1)}
-                >
-                  <ArrowUp className="h-2.5 w-2.5" />
-                </Button>
-                <Button
-                  type="button"
-                  variant="ghost"
-                  size="icon"
-                  className="h-5 w-5"
-                  disabled={i === items.length - 1}
-                  onClick={() => moveItem(i, 1)}
-                >
-                  <ArrowDown className="h-2.5 w-2.5" />
-                </Button>
-              </div>
-              <span className="text-muted-foreground/70 font-mono text-[10px]">{i + 1}</span>
-            </div>
-          ))}
-        </div>
-      )}
-    </div>
-  );
-}
-
-function LibraryForm({
-  library,
-  chapterThumbnailsSupported,
-  onClose,
-}: {
-  library: Library | null;
-  chapterThumbnailsSupported: boolean;
-  onClose: () => void;
-}) {
-  const [name, setName] = useState(library?.name ?? "");
-  const [paths, setPaths] = useState<string[]>(library?.paths?.length ? library.paths : [""]);
-  const [type, setType] = useState(library?.type ?? "movies");
-  const [enabled, setEnabled] = useState(library?.enabled ?? true);
-  const [metadataLanguage, setMetadataLanguage] = useState(library?.metadata_language ?? "en");
-  const [chapterThumbnailsEnabled, setChapterThumbnailsEnabled] = useState(
-    library?.chapter_thumbnails_enabled ?? false,
-  );
-  const [introDetectionEnabled, setIntroDetectionEnabled] = useState(
-    library?.intro_detection_enabled ?? false,
-  );
-  const [levelChains, setLevelChains] = useState<Record<string, LevelChainItem[]>>({});
-  const [chainDirty, setChainDirty] = useState(false);
-  const [browserOpen, setBrowserOpen] = useState(false);
-
-  const createMutation = useCreateLibrary();
-  const updateMutation = useUpdateLibrary();
-  const setChainMutation = useSetLibraryProviders();
-  const { installations } = useAdminPlugins();
-  const { data: currentChain } = useLibraryProviders(library?.id ?? null);
-
-  // Derive available metadata providers from plugin installations with metadata_provider.v1 capabilities,
-  // sorted by their declared default_priority for the current library type.
-  const metadataProviders = useMemo(() => {
-    const result: Array<{
-      plugin_installation_id: number;
-      capability_id: string;
-      slug: string;
-      defaultPriority: Record<string, number>;
-    }> = [];
-    for (const inst of installations) {
-      if (!inst.enabled) continue;
-      for (const cap of inst.capabilities ?? []) {
-        if (cap.type === "metadata_provider.v1") {
-          const dp =
-            (cap.metadata?.default_priority as Record<string, number>) ??
-            ((cap.metadata?.metadata as Record<string, unknown>)?.default_priority as Record<
-              string,
-              number
-            >) ??
-            {};
-          result.push({
-            plugin_installation_id: inst.id,
-            capability_id: cap.id,
-            slug: cap.display_name || cap.id,
-            defaultPriority: dp,
-          });
-        }
-      }
-    }
-    return result;
-  }, [installations]);
-
-  const isPending =
-    createMutation.isPending || updateMutation.isPending || setChainMutation.isPending;
-
-  const defaultLevelChains = useMemo(
-    () => buildDefaultLevelChains(metadataProviders, type),
-    [metadataProviders, type],
-  );
-  const resolvedLevelChains = useMemo(() => {
-    if (!library) {
-      return defaultLevelChains;
-    }
-    if (currentChain === undefined) {
-      return levelChains;
-    }
-    return buildLevelChainsFromServer(currentChain, metadataProviders, type);
-  }, [currentChain, defaultLevelChains, levelChains, library, metadataProviders, type]);
-  const activeLevelChains = chainDirty ? levelChains : resolvedLevelChains;
-
-  function updatePath(index: number, value: string) {
-    const next = [...paths];
-    next[index] = value;
-    setPaths(next);
-  }
-
-  function addPath() {
-    setPaths([...paths, ""]);
-  }
-
-  function removePath(index: number) {
-    setPaths(paths.filter((_, i) => i !== index));
-  }
-
-  function handleBrowseSelect(selectedPaths: string[]) {
-    const merged = [...paths.filter((path) => path.trim())];
-    for (const selectedPath of selectedPaths) {
-      if (!merged.includes(selectedPath)) {
-        merged.push(selectedPath);
-      }
-    }
-    setPaths(merged.length > 0 ? merged : [""]);
-    setBrowserOpen(false);
-  }
-
-  function handleTypeChange(newType: string) {
-    setType(newType);
-    if (!library) {
-      setLevelChains(buildDefaultLevelChains(metadataProviders, newType));
-      setChainDirty(true);
-    }
-  }
-
-  async function handleSubmit(e: FormEvent) {
-    e.preventDefault();
-    const filteredPaths = paths.filter((p) => p.trim());
-    if (filteredPaths.length === 0) return;
-
-    const body: CreateLibraryRequest = {
-      name,
-      paths: filteredPaths,
-      type,
-      enabled,
-      metadata_language: metadataLanguage,
-      chapter_thumbnails_enabled: chapterThumbnailsEnabled,
-      intro_detection_enabled: introDetectionEnabled,
-    };
-
-    if (library) {
-      updateMutation.mutate(
-        { id: library.id, body },
-        {
-          onSuccess: () => {
-            if (chainDirty) {
-              setChainMutation.mutate(
-                {
-                  id: library.id,
-                  body: {
-                    levels: Object.fromEntries(
-                      Object.entries(activeLevelChains).map(([level, items]) => [
-                        level,
-                        items.map((item, i) => ({
-                          plugin_installation_id: item.plugin_installation_id,
-                          capability_id: item.capability_id,
-                          priority: i,
-                          enabled: item.enabled,
-                        })),
-                      ]),
-                    ),
-                  },
-                },
-                { onSuccess: onClose },
-              );
-            } else {
-              onClose();
-            }
-          },
-        },
-      );
-    } else {
-      createMutation.mutate(body, {
-        onSuccess: (created) => {
-          if (chainDirty) {
-            setChainMutation.mutate(
-              {
-                id: created.id,
-                body: {
-                  levels: Object.fromEntries(
-                    Object.entries(activeLevelChains).map(([level, items]) => [
-                      level,
-                      items.map((item, i) => ({
-                        plugin_installation_id: item.plugin_installation_id,
-                        capability_id: item.capability_id,
-                        priority: i,
-                        enabled: item.enabled,
-                      })),
-                    ]),
-                  ),
-                },
-              },
-              { onSuccess: onClose },
-            );
-          } else {
-            onClose();
-          }
-        },
-      });
-    }
-  }
-
-  return (
-    <form onSubmit={handleSubmit} className="space-y-3">
-      <div className="grid grid-cols-[1fr_auto] items-end gap-3">
-        <div className="space-y-1.5">
-          <Label>Name</Label>
-          <Input value={name} onChange={(e) => setName(e.target.value)} required />
-        </div>
-        <div className="flex items-center gap-2 pb-0.5">
-          <Switch id="enabled-switch" checked={enabled} onCheckedChange={setEnabled} />
-          <Label htmlFor="enabled-switch" className="text-muted-foreground text-xs">
-            Enabled
-          </Label>
-        </div>
-      </div>
-      <div className="space-y-1.5">
-        <Label>Paths</Label>
-        {paths.map((p, i) => (
-          <div key={i} className="flex gap-1">
-            <PathAutocompleteInput
-              value={p}
-              onValueChange={(value) => updatePath(i, value)}
-              placeholder="/mnt/media/movies"
-              required
-            />
-            {paths.length > 1 && (
-              <Button
-                type="button"
-                variant="ghost"
-                size="icon"
-                className="h-9 w-9 shrink-0"
-                onClick={() => removePath(i)}
-              >
-                <Trash2 className="h-3.5 w-3.5" />
-              </Button>
-            )}
-          </div>
-        ))}
-        <div className="flex gap-1">
-          <Button type="button" variant="outline" size="sm" onClick={addPath}>
-            <Plus className="mr-1 h-3.5 w-3.5" /> Add Path
-          </Button>
-          <Button type="button" variant="outline" size="sm" onClick={() => setBrowserOpen(true)}>
-            <FolderOpen className="mr-1 h-3.5 w-3.5" /> Browse
-          </Button>
-        </div>
-        <FolderBrowser
-          open={browserOpen}
-          onOpenChange={setBrowserOpen}
-          onSelect={handleBrowseSelect}
-          existingPaths={paths.filter((path) => path.trim())}
-        />
-      </div>
-      <div className="grid grid-cols-2 items-end gap-3">
-        <div className="space-y-1.5">
-          <Label>Type</Label>
-          <Select value={type} onValueChange={handleTypeChange}>
-            <SelectTrigger>
-              <SelectValue />
-            </SelectTrigger>
-            <SelectContent>
-              <SelectItem value="movies">Movies</SelectItem>
-              <SelectItem value="series">Series</SelectItem>
-              <SelectItem value="mixed">Mixed</SelectItem>
-            </SelectContent>
-          </Select>
-        </div>
-        <div className="space-y-1.5">
-          <Label>Metadata Language</Label>
-          <Select value={metadataLanguage} onValueChange={setMetadataLanguage}>
-            <SelectTrigger>
-              <SelectValue />
-            </SelectTrigger>
-            <SelectContent>
-              {LANGUAGES.map((lang) => (
-                <SelectItem key={lang.code} value={lang.code}>
-                  {lang.label}
-                </SelectItem>
-              ))}
-            </SelectContent>
-          </Select>
-        </div>
-      </div>
-      <div className="rounded-xl border border-white/10 bg-white/5 p-3">
-        <div className="flex items-start justify-between gap-3">
-          <div className="space-y-1">
-            <Label htmlFor="chapter-thumbnails-switch">Generate chapter thumbnails</Label>
-            <p className="text-xs text-white/60">
-              Stores chapter preview images in the configured public asset S3 bucket. Chapter
-              markers and chapter menus still work without thumbnails.
-            </p>
-            {!chapterThumbnailsSupported ? (
-              <p className="text-xs text-amber-300">
-                Public asset S3 storage is required before this can be enabled.
-              </p>
-            ) : null}
-          </div>
-          <Switch
-            id="chapter-thumbnails-switch"
-            checked={chapterThumbnailsEnabled}
-            disabled={!chapterThumbnailsSupported}
-            onCheckedChange={setChapterThumbnailsEnabled}
-          />
-        </div>
-      </div>
-      <div className="rounded-xl border border-white/10 bg-white/5 p-3">
-        <div className="flex items-start justify-between gap-3">
-          <div className="space-y-1">
-            <Label htmlFor="intro-detection-switch">Detect intro markers</Label>
-            <p className="text-xs text-white/60">
-              Runs background audio analysis for episodes in this library. Embedded intro chapters
-              are used when available.
-            </p>
-          </div>
-          <Switch
-            id="intro-detection-switch"
-            checked={introDetectionEnabled}
-            onCheckedChange={setIntroDetectionEnabled}
-          />
-        </div>
-      </div>
-      {library && (
-        <div>
-          <LibraryPosterSection library={library} />
-        </div>
-      )}
-
-      {/* Per-level Metadata Provider Sections */}
-      {contentLevelsForType(type).length > 0 && (
-        <div className="mt-4 border-t border-white/10 pt-4">
-          <h3 className="mb-3 text-sm font-semibold text-white">Metadata Providers</h3>
-          {contentLevelsForType(type).map((level) => {
-            const items = activeLevelChains[level] ?? [];
-            return (
-              <ProviderLevelSection
-                key={level}
-                level={level}
-                items={items}
-                onReorder={(newItems) => {
-                  setLevelChains({ ...activeLevelChains, [level]: newItems });
-                  setChainDirty(true);
-                }}
-                onToggleEnabled={(index) => {
-                  setLevelChains((prev) => {
-                    const source = prev[level] ?? activeLevelChains[level] ?? [];
-                    const updated = [...source];
-                    updated[index] = { ...updated[index]!, enabled: !updated[index]!.enabled };
-                    return { ...prev, [level]: updated };
-                  });
-                  setChainDirty(true);
-                }}
-              />
-            );
-          })}
-        </div>
-      )}
-
-      <Button type="submit" className="w-full" disabled={isPending}>
-        {isPending ? "Saving..." : "Save"}
-      </Button>
-    </form>
   );
 }
 

--- a/web/src/pages/setup-wizard/WizardContext.tsx
+++ b/web/src/pages/setup-wizard/WizardContext.tsx
@@ -4,36 +4,13 @@ import { useQuery } from "@tanstack/react-query";
 import { api } from "@/api/client";
 import type { Library, Profile } from "@/api/types";
 import { useAuth } from "@/hooks/useAuth";
-
-const SKIPPABLE_STEPS = [
-  "library",
-  "server",
-  "integrations",
-  "downloads",
-  "recommendations",
-] as const;
-export type SkippableStep = (typeof SKIPPABLE_STEPS)[number];
-
-const STORAGE_KEYS: Record<SkippableStep, string> = {
-  library: "setup_wizard_skip_library",
-  server: "setup_wizard_server_done",
-  integrations: "setup_wizard_integrations_done",
-  downloads: "setup_wizard_downloads_done",
-  recommendations: "setup_wizard_recommendations_done",
-};
-
-function readFlag(step: SkippableStep): boolean {
-  if (typeof window === "undefined") return false;
-  return window.localStorage.getItem(STORAGE_KEYS[step]) === "true";
-}
-
-function writeFlag(step: SkippableStep, value: boolean) {
-  if (value) {
-    window.localStorage.setItem(STORAGE_KEYS[step], "true");
-  } else {
-    window.localStorage.removeItem(STORAGE_KEYS[step]);
-  }
-}
+import {
+  clearSetupWizardStorage,
+  createEmptySetupWizardFlags,
+  readSetupWizardFlags,
+  type SkippableStep,
+  writeSetupWizardFlag,
+} from "./setupStorage";
 
 interface WizardContextValue {
   // Auth-derived
@@ -54,6 +31,7 @@ interface WizardContextValue {
   // Step completion flags
   stepDone: Record<SkippableStep, boolean>;
   markDone: (step: SkippableStep) => void;
+  clearProgress: () => void;
 }
 
 const WizardCtx = createContext<WizardContextValue | null>(null);
@@ -76,11 +54,11 @@ export function WizardProvider({ children }: { children: ReactNode }) {
   const isAdmin = user?.role === "admin";
 
   const [stepDone, setStepDone] = useState<Record<SkippableStep, boolean>>(() => {
-    const flags = {} as Record<SkippableStep, boolean>;
-    for (const step of SKIPPABLE_STEPS) {
-      flags[step] = readFlag(step);
+    if (setupRequired && !user) {
+      clearSetupWizardStorage();
+      return createEmptySetupWizardFlags();
     }
-    return flags;
+    return readSetupWizardFlags();
   });
 
   const profilesQuery = useQuery({
@@ -100,8 +78,13 @@ export function WizardProvider({ children }: { children: ReactNode }) {
   });
 
   const markDone = useCallback((step: SkippableStep) => {
-    writeFlag(step, true);
+    writeSetupWizardFlag(step, true);
     setStepDone((prev) => ({ ...prev, [step]: true }));
+  }, []);
+
+  const clearProgress = useCallback(() => {
+    clearSetupWizardStorage();
+    setStepDone(createEmptySetupWizardFlags());
   }, []);
 
   return (
@@ -120,6 +103,7 @@ export function WizardProvider({ children }: { children: ReactNode }) {
         refetchLibraries: () => void librariesQuery.refetch(),
         stepDone,
         markDone,
+        clearProgress,
       }}
     >
       {children}

--- a/web/src/pages/setup-wizard/setupStorage.ts
+++ b/web/src/pages/setup-wizard/setupStorage.ts
@@ -1,0 +1,68 @@
+export const SKIPPABLE_STEPS = [
+  "library",
+  "server",
+  "integrations",
+  "downloads",
+  "recommendations",
+] as const;
+
+export type SkippableStep = (typeof SKIPPABLE_STEPS)[number];
+
+export const SETUP_WIZARD_STORAGE_KEYS: Record<SkippableStep, string> = {
+  library: "setup_wizard_skip_library",
+  server: "setup_wizard_server_done",
+  integrations: "setup_wizard_integrations_done",
+  downloads: "setup_wizard_downloads_done",
+  recommendations: "setup_wizard_recommendations_done",
+};
+
+function withLocalStorage<T>(callback: (storage: Storage) => T, fallback: T): T {
+  if (typeof window === "undefined") return fallback;
+
+  try {
+    return callback(window.localStorage);
+  } catch {
+    return fallback;
+  }
+}
+
+export function createEmptySetupWizardFlags(): Record<SkippableStep, boolean> {
+  const flags = {} as Record<SkippableStep, boolean>;
+  for (const step of SKIPPABLE_STEPS) {
+    flags[step] = false;
+  }
+  return flags;
+}
+
+export function readSetupWizardFlag(step: SkippableStep): boolean {
+  return withLocalStorage(
+    (storage) => storage.getItem(SETUP_WIZARD_STORAGE_KEYS[step]) === "true",
+    false,
+  );
+}
+
+export function readSetupWizardFlags(): Record<SkippableStep, boolean> {
+  const flags = createEmptySetupWizardFlags();
+  for (const step of SKIPPABLE_STEPS) {
+    flags[step] = readSetupWizardFlag(step);
+  }
+  return flags;
+}
+
+export function writeSetupWizardFlag(step: SkippableStep, value: boolean) {
+  withLocalStorage((storage) => {
+    if (value) {
+      storage.setItem(SETUP_WIZARD_STORAGE_KEYS[step], "true");
+    } else {
+      storage.removeItem(SETUP_WIZARD_STORAGE_KEYS[step]);
+    }
+  }, undefined);
+}
+
+export function clearSetupWizardStorage() {
+  withLocalStorage((storage) => {
+    for (const key of Object.values(SETUP_WIZARD_STORAGE_KEYS)) {
+      storage.removeItem(key);
+    }
+  }, undefined);
+}

--- a/web/src/pages/setup-wizard/steps/LibraryStep.tsx
+++ b/web/src/pages/setup-wizard/steps/LibraryStep.tsx
@@ -1,142 +1,58 @@
-import { useState } from "react";
-import type { FormEvent } from "react";
-import { api } from "@/api/client";
-import type { CreateLibraryRequest, Library } from "@/api/types";
+import { LibraryForm } from "@/components/admin/libraries/LibraryForm";
 import { Button } from "@/components/ui/button";
-import { Input } from "@/components/ui/input";
-import { Label } from "@/components/ui/label";
-import { Switch } from "@/components/ui/switch";
-import {
-  Select,
-  SelectContent,
-  SelectItem,
-  SelectTrigger,
-  SelectValue,
-} from "@/components/ui/select";
-import { LANGUAGES } from "@/player/utils/languageNames";
 import { toast } from "sonner";
 import { useWizardContext } from "../WizardContext";
 
 export function LibraryStep() {
-  const { markDone, refetchLibraries } = useWizardContext();
-  const [libraryName, setLibraryName] = useState("Main Library");
-  const [libraryPath, setLibraryPath] = useState("");
-  const [libraryType, setLibraryType] = useState("movies");
-  const [metadataLanguage, setMetadataLanguage] = useState("en");
-  const [scanAfterCreate, setScanAfterCreate] = useState(true);
-  const [submitting, setSubmitting] = useState(false);
-
-  async function handleSubmit(e: FormEvent) {
-    e.preventDefault();
-    setSubmitting(true);
-    try {
-      const body: CreateLibraryRequest = {
-        name: libraryName,
-        type: libraryType,
-        paths: [libraryPath],
-        metadata_language: metadataLanguage,
-      };
-      const created = await api<Library>("/libraries", {
-        method: "POST",
-        body: JSON.stringify(body),
-      });
-
-      if (scanAfterCreate) {
-        await api("/scan", {
-          method: "POST",
-          body: JSON.stringify({ library_id: created.id }),
-        });
-      }
-
-      refetchLibraries();
-      toast.success(scanAfterCreate ? "Library created and scan started" : "Library created");
-    } catch (err) {
-      toast.error(err instanceof Error ? err.message : "Failed to create library");
-    } finally {
-      setSubmitting(false);
-    }
-  }
+  const { libraries, markDone, refetchLibraries } = useWizardContext();
 
   function handleSkip() {
     markDone("library");
     toast.success("Library setup skipped");
   }
 
+  function handleLibrarySaved() {
+    refetchLibraries();
+  }
+
   return (
-    <form onSubmit={handleSubmit} className="space-y-4">
-      <div className="grid gap-3 sm:grid-cols-3">
-        <div className="space-y-1.5">
-          <Label htmlFor="setup-library-name" className="text-xs">
-            Name
-          </Label>
-          <Input
-            id="setup-library-name"
-            value={libraryName}
-            onChange={(e) => setLibraryName(e.target.value)}
-            required
-          />
+    <div className="space-y-5">
+      {libraries.length > 0 && (
+        <div className="border-foreground/[0.07] bg-foreground/[0.03] space-y-2 rounded-xl border p-4">
+          <p className="text-muted-foreground text-xs font-semibold tracking-[0.1em] uppercase">
+            Added libraries
+          </p>
+          <div className="space-y-2">
+            {libraries.map((library) => (
+              <div key={library.id} className="text-sm">
+                <div className="font-medium">{library.name}</div>
+                <div className="text-muted-foreground text-xs">
+                  {library.type} · {library.paths.length}{" "}
+                  {library.paths.length === 1 ? "path" : "paths"}
+                </div>
+              </div>
+            ))}
+          </div>
         </div>
-        <div className="space-y-1.5">
-          <Label htmlFor="setup-library-type" className="text-xs">
-            Type
-          </Label>
-          <Select value={libraryType} onValueChange={setLibraryType}>
-            <SelectTrigger id="setup-library-type">
-              <SelectValue />
-            </SelectTrigger>
-            <SelectContent>
-              <SelectItem value="movies">Movies</SelectItem>
-              <SelectItem value="series">Series</SelectItem>
-              <SelectItem value="mixed">Mixed</SelectItem>
-            </SelectContent>
-          </Select>
-        </div>
-        <div className="space-y-1.5">
-          <Label htmlFor="setup-metadata-lang">Metadata Language</Label>
-          <Select value={metadataLanguage} onValueChange={setMetadataLanguage}>
-            <SelectTrigger id="setup-metadata-lang">
-              <SelectValue />
-            </SelectTrigger>
-            <SelectContent>
-              {LANGUAGES.map((lang) => (
-                <SelectItem key={lang.code} value={lang.code}>
-                  {lang.label}
-                </SelectItem>
-              ))}
-            </SelectContent>
-          </Select>
-        </div>
-      </div>
-      <div className="space-y-1.5">
-        <Label htmlFor="setup-library-path" className="text-xs">
-          Path
-        </Label>
-        <Input
-          id="setup-library-path"
-          value={libraryPath}
-          onChange={(e) => setLibraryPath(e.target.value)}
-          placeholder="/media/movies"
-          required
-        />
-      </div>
-      <div className="flex items-center gap-2">
-        <Switch
-          id="setup-library-scan"
-          checked={scanAfterCreate}
-          onCheckedChange={setScanAfterCreate}
-        />
-        <Label htmlFor="setup-library-scan" className="text-xs">
-          Scan after creating
-        </Label>
-      </div>
+      )}
+
+      <LibraryForm
+        library={null}
+        chapterThumbnailsSupported={libraries[0]?.chapter_thumbnails_supported ?? true}
+        onSaved={handleLibrarySaved}
+        resetAfterCreate
+        submitLabel="Add library"
+        savingLabel="Adding..."
+      />
+
       <div className="flex gap-3 pt-3">
-        <Button type="submit" disabled={submitting}>
-          {submitting ? "Creating..." : "Create library"}
+        <Button type="button" onClick={() => markDone("library")} disabled={libraries.length === 0}>
+          Continue
         </Button>
-        <Button type="button" variant="ghost" onClick={handleSkip} disabled={submitting}>
+        <Button type="button" variant="ghost" onClick={handleSkip}>
           Skip
         </Button>
       </div>
-    </form>
+    </div>
   );
 }

--- a/web/src/pages/setup-wizard/steps/NodesFinishStep.tsx
+++ b/web/src/pages/setup-wizard/steps/NodesFinishStep.tsx
@@ -101,7 +101,7 @@ function AddNodeForm({ onAdded }: { onAdded: (node: AddedNode) => void }) {
 
 export function NodesFinishStep() {
   const navigate = useNavigate();
-  const { profile, profiles, selectProfile } = useWizardContext();
+  const { clearProgress, profile, profiles, selectProfile } = useWizardContext();
   const [finishing, setFinishing] = useState(false);
   const [addedNodes, setAddedNodes] = useState<AddedNode[]>([]);
   const [showNodeForm, setShowNodeForm] = useState(false);
@@ -110,17 +110,23 @@ export function NodesFinishStep() {
     setAddedNodes((prev) => [...prev, node]);
   }
 
-  async function handleFinish() {
-    setFinishing(true);
-    try {
-      const chosenProfile = profile ?? profiles[0] ?? null;
-      if (chosenProfile && !profile) {
-        selectProfile(chosenProfile);
-      }
-      navigate("/");
-    } finally {
-      setFinishing(false);
+  function completeSetup(destination: string) {
+    const chosenProfile = profile ?? profiles[0] ?? null;
+    if (chosenProfile && !profile) {
+      selectProfile(chosenProfile);
     }
+    clearProgress();
+    navigate(destination);
+  }
+
+  function handleFinish() {
+    setFinishing(true);
+    completeSetup("/");
+  }
+
+  function handleGoToAdmin() {
+    setFinishing(true);
+    completeSetup("/admin/libraries");
   }
 
   return (
@@ -162,7 +168,8 @@ export function NodesFinishStep() {
         <Button
           type="button"
           variant="secondary"
-          onClick={() => navigate("/admin/libraries")}
+          onClick={handleGoToAdmin}
+          disabled={finishing}
           className="sm:flex-1"
         >
           Go to admin

--- a/web/src/pages/setup-wizard/useWizardSteps.ts
+++ b/web/src/pages/setup-wizard/useWizardSteps.ts
@@ -18,12 +18,11 @@ export type WizardStepId =
   | "nodes";
 
 export function useWizardSteps() {
-  const { user, profiles, libraries, stepDone } = useWizardContext();
+  const { user, profiles, stepDone } = useWizardContext();
 
   const accountComplete = !!user;
   const profileComplete = profiles.length > 0;
-  const libraryComplete = libraries.length > 0;
-  const libraryDone = libraryComplete || stepDone.library;
+  const libraryDone = stepDone.library;
 
   const currentStep: WizardStepId = !accountComplete
     ? "account"


### PR DESCRIPTION
## Summary
- Extract the library create/edit form into a shared admin component and reuse it in the onboarding wizard.
- Update onboarding library setup to support browse, metadata provider configuration, multiple library additions, and an explicit continue step.
- Clear setup wizard local storage when onboarding completes so a later fresh setup in the same browser starts from the beginning.
- Keep admin-only poster upload in the admin page while sharing the rest of the library form behavior.

## Testing
- TypeScript build passed.
- Changed-file ESLint passed with only the existing repo warnings.
- Verified the reset database path restores `needs_setup: true` for onboarding.