### PR TITLE
fix(jellycompat): enforce allow_4k_transcode

### DIFF
--- a/internal/jellycompat/audio_selection_test.go
+++ b/internal/jellycompat/audio_selection_test.go
@@ -142,6 +142,7 @@ func TestBuildPlaybackSource_SeedsRequestedAudioStreamIndex(t *testing.T) {
 		version,
 		DeviceProfile{},
 		playbackInfoRequest{AudioStreamIndex: compatIntValuePtr(requestedAudioStreamIndex)},
+		true,
 	)
 
 	if source.SelectedAudioStreamIndex == nil {

--- a/internal/jellycompat/handlers_playback.go
+++ b/internal/jellycompat/handlers_playback.go
@@ -20,6 +20,7 @@ import (
 
 	"github.com/go-chi/chi/v5"
 
+	"github.com/Silo-Server/silo-server/internal/access"
 	"github.com/Silo-Server/silo-server/internal/catalog"
 	"github.com/Silo-Server/silo-server/internal/config"
 	"github.com/Silo-Server/silo-server/internal/models"
@@ -152,6 +153,22 @@ func (h *PlaybackHandler) playbackThresholds(ctx context.Context) userstore.Prog
 		}
 	}
 	return t
+}
+
+var errTranscode4KDisallowed = errors.New("4k video transcode disallowed by server settings")
+
+// allow4KVideoTranscode reads the allow_4k_transcode server setting,
+// defaulting to deny like the native playback handler.
+func (h *PlaybackHandler) allow4KVideoTranscode(ctx context.Context) bool {
+	if h.SettingsRepo == nil {
+		return false
+	}
+	v, _ := h.SettingsRepo.Get(ctx, "allow_4k_transcode")
+	return v == "true"
+}
+
+func is4KResolution(res string) bool {
+	return access.CompareQuality(res, "2160p") >= 0
 }
 
 // NewPlaybackHandler creates a playback handler.
@@ -300,6 +317,9 @@ func (h *PlaybackHandler) startRemoteTranscode(
 	initialSeekSeconds float64,
 	transcodeNodeURL string,
 ) error {
+	if !source.TranscodeAudio && is4KResolution(source.Version.Resolution) && !h.allow4KVideoTranscode(ctx) {
+		return errTranscode4KDisallowed
+	}
 	if d := float64(source.Version.Duration); d > 0 && initialSeekSeconds > d {
 		initialSeekSeconds = d
 	}
@@ -416,8 +436,9 @@ func (h *PlaybackHandler) HandlePlaybackInfo(w http.ResponseWriter, r *http.Requ
 	sources := make([]PlaybackMediaSource, 0, len(detail.Versions))
 	sourceDTOs := make([]mediaSourceDTO, 0, len(detail.Versions))
 
+	allow4KTranscode := h.allow4KVideoTranscode(r.Context())
 	for _, version := range detail.Versions {
-		source := h.buildPlaybackSource(routeItemID, playSessionID, version, profile, req)
+		source := h.buildPlaybackSource(routeItemID, playSessionID, version, profile, req, allow4KTranscode)
 		if req.MediaSourceID != "" && source.ID != req.MediaSourceID {
 			continue
 		}
@@ -513,6 +534,7 @@ func (h *PlaybackHandler) buildPlaybackSource(
 	version catalog.FileVersion,
 	profile DeviceProfile,
 	req playbackInfoRequest,
+	allow4KTranscode bool,
 ) PlaybackMediaSource {
 	sourceID := h.codec.EncodeIntID(EncodedIDMediaSource, int64(version.FileID))
 	enableDirectPlay := boolDefault(req.EnableDirectPlay, true)
@@ -531,6 +553,12 @@ func (h *PlaybackHandler) buildPlaybackSource(
 		allowAudioCopy &&
 		audioSupported
 	supportsTranscoding := boolDefault(req.EnableTranscoding, true) && profile.SupportsTranscoding(version)
+	// Don't offer full video encodes of 4K sources when allow_4k_transcode is
+	// off. Audio-only transcodes (transcodeAudio) stream-copy the video and
+	// stay available.
+	if supportsTranscoding && !transcodeAudio && !allow4KTranscode && is4KResolution(version.Resolution) {
+		supportsTranscoding = false
+	}
 
 	audioIndex := defaultAudioStreamIndex(version)
 	subtitleIndex := defaultSubtitleStreamIndex(version)

--- a/internal/jellycompat/playback_4k_test.go
+++ b/internal/jellycompat/playback_4k_test.go
@@ -8,10 +8,16 @@ import (
 	"github.com/Silo-Server/silo-server/internal/catalog"
 )
 
-type stubSettingsReader map[string]string
+type stubSettingsReader struct {
+	values map[string]string
+	err    error
+}
 
 func (s stubSettingsReader) Get(_ context.Context, key string) (string, error) {
-	return s[key], nil
+	if s.err != nil {
+		return "", s.err
+	}
+	return s.values[key], nil
 }
 
 func TestAllow4KVideoTranscode(t *testing.T) {
@@ -22,8 +28,9 @@ func TestAllow4KVideoTranscode(t *testing.T) {
 	}{
 		{name: "nil repo defaults to deny", repo: nil, want: false},
 		{name: "unset defaults to deny", repo: stubSettingsReader{}, want: false},
-		{name: "explicit false denies", repo: stubSettingsReader{"allow_4k_transcode": "false"}, want: false},
-		{name: "explicit true allows", repo: stubSettingsReader{"allow_4k_transcode": "true"}, want: true},
+		{name: "read error defaults to deny", repo: stubSettingsReader{err: errors.New("read failed")}, want: false},
+		{name: "explicit false denies", repo: stubSettingsReader{values: map[string]string{"allow_4k_transcode": "false"}}, want: false},
+		{name: "explicit true allows", repo: stubSettingsReader{values: map[string]string{"allow_4k_transcode": "true"}}, want: true},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/internal/jellycompat/playback_4k_test.go
+++ b/internal/jellycompat/playback_4k_test.go
@@ -1,0 +1,158 @@
+package jellycompat
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/Silo-Server/silo-server/internal/catalog"
+)
+
+type stubSettingsReader map[string]string
+
+func (s stubSettingsReader) Get(_ context.Context, key string) (string, error) {
+	return s[key], nil
+}
+
+func TestAllow4KVideoTranscode(t *testing.T) {
+	tests := []struct {
+		name string
+		repo SettingsReader
+		want bool
+	}{
+		{name: "nil repo defaults to deny", repo: nil, want: false},
+		{name: "unset defaults to deny", repo: stubSettingsReader{}, want: false},
+		{name: "explicit false denies", repo: stubSettingsReader{"allow_4k_transcode": "false"}, want: false},
+		{name: "explicit true allows", repo: stubSettingsReader{"allow_4k_transcode": "true"}, want: true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			h := &PlaybackHandler{SettingsRepo: tt.repo}
+			if got := h.allow4KVideoTranscode(context.Background()); got != tt.want {
+				t.Errorf("allow4KVideoTranscode() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestIs4KResolution(t *testing.T) {
+	for res, want := range map[string]bool{
+		"2160p": true,
+		"4320p": true,
+		"1080p": false,
+		"720p":  false,
+		"":      false,
+	} {
+		if got := is4KResolution(res); got != want {
+			t.Errorf("is4KResolution(%q) = %v, want %v", res, got, want)
+		}
+	}
+}
+
+func TestBuildPlaybackSource4KVideoTranscodeGate(t *testing.T) {
+	version4K := catalog.FileVersion{
+		FileID:     1,
+		Resolution: "2160p",
+		CodecVideo: "hevc",
+		CodecAudio: "eac3",
+		Container:  "mkv",
+	}
+	version1080 := version4K
+	version1080.Resolution = "1080p"
+
+	// Can only decode h264: HEVC versions need a full video transcode.
+	h264Only := DeviceProfile{
+		DirectPlayProfiles: []DirectPlayProfile{
+			{Type: "Video", Container: "mp4", VideoCodec: "h264", AudioCodec: "aac"},
+		},
+	}
+	// Decodes HEVC but not EAC3: transcoding path stream-copies the video.
+	hevcNoEac3 := DeviceProfile{
+		DirectPlayProfiles: []DirectPlayProfile{
+			{Type: "Video", Container: "mp4", VideoCodec: "h264,hevc", AudioCodec: "aac"},
+		},
+	}
+
+	tests := []struct {
+		name               string
+		version            catalog.FileVersion
+		profile            DeviceProfile
+		allow4K            bool
+		wantTranscoding    bool
+		wantTranscodeAudio bool
+	}{
+		{
+			name:            "4K video transcode blocked when disallowed",
+			version:         version4K,
+			profile:         h264Only,
+			allow4K:         false,
+			wantTranscoding: false,
+		},
+		{
+			name:            "4K video transcode offered when allowed",
+			version:         version4K,
+			profile:         h264Only,
+			allow4K:         true,
+			wantTranscoding: true,
+		},
+		{
+			name:               "4K audio-only transcode (video copy) stays allowed",
+			version:            version4K,
+			profile:            hevcNoEac3,
+			allow4K:            false,
+			wantTranscoding:    true,
+			wantTranscodeAudio: true,
+		},
+		{
+			name:            "non-4K video transcode unaffected",
+			version:         version1080,
+			profile:         h264Only,
+			allow4K:         false,
+			wantTranscoding: true,
+		},
+	}
+
+	h := &PlaybackHandler{codec: NewResourceIDCodec()}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			source := h.buildPlaybackSource("item", "ps", tt.version, tt.profile, playbackInfoRequest{}, tt.allow4K)
+			if source.SupportsTranscoding != tt.wantTranscoding {
+				t.Errorf("SupportsTranscoding = %v, want %v", source.SupportsTranscoding, tt.wantTranscoding)
+			}
+			if source.TranscodeAudio != tt.wantTranscodeAudio {
+				t.Errorf("TranscodeAudio = %v, want %v", source.TranscodeAudio, tt.wantTranscodeAudio)
+			}
+		})
+	}
+}
+
+func TestEnsureTranscodeSession4KGuard(t *testing.T) {
+	h := &PlaybackHandler{} // nil SettingsRepo: 4K video transcodes denied
+
+	source := PlaybackMediaSource{
+		FileID:  1,
+		Version: catalog.FileVersion{FileID: 1, Resolution: "2160p", CodecVideo: "hevc"},
+	}
+	if _, err := h.ensureTranscodeSession(context.Background(), "ps", "session", source); !errors.Is(err, errTranscode4KDisallowed) {
+		t.Errorf("ensureTranscodeSession() error = %v, want errTranscode4KDisallowed", err)
+	}
+
+	// Video-copy sessions pass the guard (and fail later on the missing file
+	// resolver, which is fine for this test).
+	source.TranscodeAudio = true
+	if _, err := h.ensureTranscodeSession(context.Background(), "ps", "session", source); errors.Is(err, errTranscode4KDisallowed) {
+		t.Error("ensureTranscodeSession() blocked a video-copy session")
+	}
+}
+
+func TestStartRemoteTranscode4KGuard(t *testing.T) {
+	h := &PlaybackHandler{} // nil SettingsRepo: 4K video transcodes denied
+
+	source := PlaybackMediaSource{
+		FileID:  1,
+		Version: catalog.FileVersion{FileID: 1, Resolution: "2160p", CodecVideo: "hevc"},
+	}
+	if err := h.startRemoteTranscode(context.Background(), "session", source, nil, 0, "http://node"); !errors.Is(err, errTranscode4KDisallowed) {
+		t.Errorf("startRemoteTranscode() error = %v, want errTranscode4KDisallowed", err)
+	}
+}

--- a/internal/jellycompat/streams.go
+++ b/internal/jellycompat/streams.go
@@ -165,6 +165,10 @@ func (h *PlaybackHandler) HandleMasterManifest(w http.ResponseWriter, r *http.Re
 					return
 				}
 				if err := h.startRemoteTranscode(r.Context(), playSession.UpstreamSessionID, *source, file, playSession.InitialSeekSeconds, tcNode.URL); err != nil {
+					if errors.Is(err, errTranscode4KDisallowed) {
+						writeError(w, http.StatusForbidden, "Forbidden", "4K video transcoding is disabled on this server")
+						return
+					}
 					writeError(w, http.StatusBadGateway, "TranscodeStartFailed", "Transcode node rejected the request")
 					return
 				}
@@ -182,6 +186,10 @@ func (h *PlaybackHandler) HandleMasterManifest(w http.ResponseWriter, r *http.Re
 	// Ensure the transcode process is running.
 	_, err = h.ensureTranscodeManifest(r.Context(), session, playSession.ID, *source)
 	if err != nil {
+		if errors.Is(err, errTranscode4KDisallowed) {
+			writeError(w, http.StatusForbidden, "Forbidden", "4K video transcoding is disabled on this server")
+			return
+		}
 		if errors.Is(err, playback.ErrManifestNotReady) {
 			writeError(w, http.StatusServiceUnavailable, "NotReady", "Transcode playlist not ready")
 			return
@@ -228,6 +236,10 @@ func (h *PlaybackHandler) HandleHLSManifest(w http.ResponseWriter, r *http.Reque
 	// Ensure the transcode process is running.
 	_, err := h.ensureTranscodeManifest(r.Context(), session, playSession.ID, *source)
 	if err != nil {
+		if errors.Is(err, errTranscode4KDisallowed) {
+			writeError(w, http.StatusForbidden, "Forbidden", "4K video transcoding is disabled on this server")
+			return
+		}
 		if errors.Is(err, playback.ErrManifestNotReady) {
 			writeError(w, http.StatusServiceUnavailable, "NotReady", "Transcode playlist not ready")
 			return
@@ -810,6 +822,9 @@ func (h *PlaybackHandler) ensureTranscodeSession(ctx context.Context, playSessio
 	if existing := h.getTranscodeSession(upstreamSessionID); existing != nil {
 		return existing, nil
 	}
+	if !source.TranscodeAudio && is4KResolution(source.Version.Resolution) && !h.allow4KVideoTranscode(ctx) {
+		return nil, errTranscode4KDisallowed
+	}
 	if h.fileResolver == nil {
 		return nil, fmt.Errorf("file resolver not available")
 	}
@@ -1019,8 +1034,9 @@ func (h *PlaybackHandler) createStaticPlaySession(ctx context.Context, session *
 
 	playSessionID := h.codec.EncodeStringID(EncodedIDPlaySession, uuidNewString())
 	sources := make([]PlaybackMediaSource, 0, len(detail.Versions))
+	allow4KTranscode := h.allow4KVideoTranscode(ctx)
 	for _, version := range detail.Versions {
-		source := h.buildPlaybackSource(routeID, playSessionID, version, DeviceProfile{}, playbackInfoRequest{})
+		source := h.buildPlaybackSource(routeID, playSessionID, version, DeviceProfile{}, playbackInfoRequest{}, allow4KTranscode)
 		sources = append(sources, source)
 	}
 


### PR DESCRIPTION
Fixes #64.

The jellycompat layer never consulted `allow_4k_transcode`, so any Jellyfin client whose device profile couldn't direct play a 4K file got a full video encode of the 4K source, regardless of the setting (full background and repro in #64).

## What this does

Negotiation (`buildPlaybackSource`): when the setting is off and the version is 4K, `SupportsTranscoding` is forced to false so PlaybackInfo doesn't offer a `TranscodingUrl` for that source. Clients then fall back to a lower-resolution version or direct play on their own, which matches what the native resolver does by skipping 4K files during version selection.

Enforcement (`ensureTranscodeSession`, `startRemoteTranscode`): same check before starting ffmpeg locally or on a transcode node, returning an error so a hand-built `master.m3u8` request can't get around the negotiation. The manifest handlers map it to a 403 instead of a generic 500.

Deliberately exempt, matching the native guard's video-copy exemption:

- `TranscodeAudio` sessions (video copy + audio to AAC) stay allowed for 4K. This is the common browser case (HEVC decodes natively, EAC3/TrueHD doesn't) and blocking it would make 4K with surround audio unplayable in browsers.
- Seek restarts need no extra guard: `TranscodeSession.Restart` reuses the original opts, so a copy session can't escalate to an encode.

Default matches native: nil/unset settings repo means 4K video transcodes are denied.

One deliberate difference: the resolution check follows the native resolver's `is4K` (`>= 2160p`, so 4320p is covered too) rather than the native start guard's exact `"2160p"` comparison. Blocking 4K but allowing 8K didn't seem intended.

## Testing

- Unit tests for the negotiation gate (blocked / allowed / audio-copy exempt / non-4K untouched), the settings read, and both start guards. `go test` passes for the jellycompat and playback packages, golangci-lint clean on the touched package.
- Tested live on my server (the #64 setup): with the patch, PlaybackInfo returns the 2160p source with `SupportsTranscoding: false` for an h264-only profile, requesting its master.m3u8 returns 403, real clients fall back to the 1080p version on their own, and 4K video-copy remux sessions (Chrome/Firefox with surround audio) keep working.

Per the contributing guidelines: implemented with AI assistance (same as the investigation in #64). I've read the diff and verified the behavior on a live deployment myself.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added server-side control to restrict 4K video transcoding when the `allow_4k_transcode` setting is disabled.
  * System now returns a 403 Forbidden response when 4K video transcoding is attempted but disallowed by policy.
  * Audio-only transcoding remains available regardless of 4K video transcoding settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->