### PR TITLE
fix(jellycompat): serve real MediaSources on Resume/NextUp pages

### DIFF
--- a/internal/jellycompat/handlers_items.go
+++ b/internal/jellycompat/handlers_items.go
@@ -1183,33 +1183,67 @@ func (h *ItemsHandler) writeNextUpResponse(w http.ResponseWriter, r *http.Reques
 		return
 	}
 
+	// The scan stays on list-level data (per-item GetItemDetail fanout over
+	// the FULL next-up list was 5N DB roundtrips for users with long lists);
+	// only the sliced page below is upgraded to detail when the client asked
+	// for detail-level Fields — see upgradeProgressPageToDetail for why the
+	// listing's MediaSources are load-bearing for Infuse/SenPlayer.
+	pageIDs := make([]string, 0, len(results))
 	items := make([]baseItemDTO, 0, len(results))
 	for _, res := range results {
 		target, ok := episodeTargets[res.ContentID]
 		if !ok {
 			continue
 		}
-		// NextUp deliberately serves list-level data even when the client
-		// requests Fields=People|Chapters|MediaStreams|MediaSources, mirroring
-		// the Resume hydrator (handlers_items.go ~L1721). Per-item
-		// GetItemDetail fanout was 5N DB roundtrips for users with long
-		// next-up lists, and the detail data was never load-bearing for the
-		// row UX — clients refetch MediaSources via /Items/{id}/PlaybackInfo
-		// on play.
 		dto := h.mapper.itemFromList(target.Item, favorites[res.ContentID], progress[res.ContentID], query.requestedFields)
 		h.applyCompatEpisodeTarget(&dto, target)
 		stubDetailListFields(&dto, query.requestedFields)
+		pageIDs = append(pageIDs, res.ContentID)
 		items = append(items, dto)
 	}
 
 	total := len(items)
 	items = sliceBaseItems(items, query.startIndex, query.limit)
+	pageIDs = slicePageIDs(pageIDs, query.startIndex, query.limit)
+	if query.needsDetailFields {
+		for i := range items {
+			if i >= maxDetailUpgrades || i >= len(pageIDs) {
+				break
+			}
+			detail, detailErr := h.content.GetItemDetail(r.Context(), session, pageIDs[i], nil)
+			if detailErr != nil {
+				continue
+			}
+			h.rememberDetailImages(*detail)
+			dto := h.mapper.itemFromDetailWithFields(*detail, favorites[pageIDs[i]], progress[pageIDs[i]], query.requestedFields)
+			if target, ok := episodeTargets[pageIDs[i]]; ok {
+				h.applyCompatEpisodeTarget(&dto, target)
+			}
+			items[i] = dto
+		}
+	}
 	applyImageTypeLimit(items, query.imageTypeLimit)
 	writeJSON(w, http.StatusOK, queryResultDTO{
 		Items:            items,
 		TotalRecordCount: total,
 		StartIndex:       query.startIndex,
 	})
+}
+
+// slicePageIDs applies sliceBaseItems' bounds to the parallel content-id
+// slice so page positions stay aligned after StartIndex/Limit slicing.
+func slicePageIDs(ids []string, startIndex, limit int) []string {
+	if startIndex < 0 {
+		startIndex = 0
+	}
+	if startIndex >= len(ids) {
+		return []string{}
+	}
+	if limit <= 0 {
+		limit = len(ids)
+	}
+	end := min(startIndex+limit, len(ids))
+	return ids[startIndex:end]
 }
 
 // HandleUpcoming serves GET /Shows/Upcoming.
@@ -1722,9 +1756,19 @@ func (h *ItemsHandler) handleResumeResponse(w http.ResponseWriter, r *http.Reque
 }
 
 type progressHydratedItem struct {
-	itemType string
-	dto      baseItemDTO
+	itemType   string
+	contentID  string
+	isFavorite bool
+	entry      upstreamProgress
+	target     *compatEpisodeTarget
+	dto        baseItemDTO
 }
+
+// maxDetailUpgrades caps how many returned-page items get re-mapped through
+// the per-item detail path when the client requested detail-level Fields.
+// Entries past the cap keep their stubbed list-level DTO. Guardrail against
+// absurd client limits — normal Resume/NextUp requests are 20-40 items.
+const maxDetailUpgrades = 100
 
 func (h *ItemsHandler) loadProgressPage(ctx context.Context, session *Session, status string, query itemsQuery, typeSet map[string]bool, libraryID *int) ([]baseItemDTO, int, error) {
 	if len(typeSet) == 0 && libraryID == nil && !query.enableTotalRecordCount {
@@ -1733,7 +1777,7 @@ func (h *ItemsHandler) loadProgressPage(ctx context.Context, session *Session, s
 			batchSize = 48
 		}
 
-		result := make([]baseItemDTO, 0, query.limit)
+		result := make([]progressHydratedItem, 0, query.limit)
 		offset := query.startIndex
 		for {
 			progressEntries, err := h.userData.ListProgress(ctx, session, status, batchSize, offset)
@@ -1752,14 +1796,14 @@ func (h *ItemsHandler) loadProgressPage(ctx context.Context, session *Session, s
 				if len(result) >= query.limit {
 					break
 				}
-				result = append(result, item.dto)
+				result = append(result, item)
 			}
 			if len(result) >= query.limit || len(progressEntries) < batchSize {
 				break
 			}
 			offset += len(progressEntries)
 		}
-		return result, 0, nil
+		return h.finishProgressPage(ctx, session, result, query, libraryID), 0, nil
 	}
 
 	batchSize := min(max(query.limit*3, 48), 200)
@@ -1767,7 +1811,7 @@ func (h *ItemsHandler) loadProgressPage(ctx context.Context, session *Session, s
 		batchSize = 48
 	}
 
-	items := make([]baseItemDTO, 0, query.limit)
+	items := make([]progressHydratedItem, 0, query.limit)
 	matchedCount := 0
 	offset := 0
 
@@ -1789,7 +1833,7 @@ func (h *ItemsHandler) loadProgressPage(ctx context.Context, session *Session, s
 				continue
 			}
 			if matchedCount >= query.startIndex && len(items) < query.limit {
-				items = append(items, item.dto)
+				items = append(items, item)
 			}
 			matchedCount++
 		}
@@ -1807,7 +1851,49 @@ func (h *ItemsHandler) loadProgressPage(ctx context.Context, session *Session, s
 	if query.enableTotalRecordCount {
 		total = matchedCount
 	}
-	return items, total, nil
+	return h.finishProgressPage(ctx, session, items, query, libraryID), total, nil
+}
+
+// finishProgressPage upgrades the returned page to detail-mapped DTOs when
+// the client asked for detail-level Fields, then unwraps to the DTO slice.
+func (h *ItemsHandler) finishProgressPage(ctx context.Context, session *Session, page []progressHydratedItem, query itemsQuery, libraryID *int) []baseItemDTO {
+	h.upgradeProgressPageToDetail(ctx, session, page, query, libraryID)
+	dtos := make([]baseItemDTO, 0, len(page))
+	for _, item := range page {
+		dtos = append(dtos, item.dto)
+	}
+	return dtos
+}
+
+// upgradeProgressPageToDetail re-maps the returned page of progress rows
+// through the detail path when the client requested detail-level Fields
+// (e.g. MediaSources). The scan loop in loadProgressPage stays on list-level
+// data so type filtering over long in-progress lists never fans out — the
+// per-ENTRY fanout was the 38s timeout in error-report-2026-05-08.md §6 —
+// but the returned page is bounded by the request limit, so this costs the
+// same as HandleLatest's existing per-item detail path. The listing's
+// MediaSources ARE load-bearing for some clients: Infuse and SenPlayer build
+// their Continue Watching rows from them and discard entries served only the
+// list-level stub.
+func (h *ItemsHandler) upgradeProgressPageToDetail(ctx context.Context, session *Session, page []progressHydratedItem, query itemsQuery, libraryID *int) {
+	if !query.needsDetailFields {
+		return
+	}
+	for i := range page {
+		if i >= maxDetailUpgrades {
+			break
+		}
+		detail, err := h.content.GetItemDetail(ctx, session, page[i].contentID, libraryID)
+		if err != nil {
+			continue
+		}
+		h.rememberDetailImages(*detail)
+		dto := h.mapper.itemFromDetailWithFields(*detail, page[i].isFavorite, &page[i].entry, query.requestedFields)
+		if page[i].target != nil {
+			h.applyCompatEpisodeTarget(&dto, *page[i].target)
+		}
+		page[i].dto = dto
+	}
 }
 
 func (h *ItemsHandler) hydrateProgressItems(ctx context.Context, session *Session, entries []upstreamProgress, fields map[string]bool, libraryID *int) ([]progressHydratedItem, error) {
@@ -1843,8 +1929,11 @@ func (h *ItemsHandler) hydrateProgressItems(ctx context.Context, session *Sessio
 			dto := h.mapper.itemFromList(item, favorites[entry.MediaItemID], &entry, fields)
 			stubDetailListFields(&dto, fields)
 			result = append(result, progressHydratedItem{
-				itemType: strings.ToLower(item.Type),
-				dto:      dto,
+				itemType:   strings.ToLower(item.Type),
+				contentID:  entry.MediaItemID,
+				isFavorite: favorites[entry.MediaItemID],
+				entry:      entry,
+				dto:        dto,
 			})
 			continue
 		}
@@ -1853,8 +1942,12 @@ func (h *ItemsHandler) hydrateProgressItems(ctx context.Context, session *Sessio
 			h.applyCompatEpisodeTarget(&dto, target)
 			stubDetailListFields(&dto, fields)
 			result = append(result, progressHydratedItem{
-				itemType: "episode",
-				dto:      dto,
+				itemType:   "episode",
+				contentID:  entry.MediaItemID,
+				isFavorite: favorites[entry.MediaItemID],
+				entry:      entry,
+				target:     &target,
+				dto:        dto,
 			})
 		}
 	}

--- a/internal/jellycompat/hydrate_progress_no_detail_test.go
+++ b/internal/jellycompat/hydrate_progress_no_detail_test.go
@@ -25,11 +25,11 @@ func (s *panicOnGetItemDetailContent) GetItemDetail(_ context.Context, _ *Sessio
 // Fields=People|Chapters|MediaStreams|MediaSources, producing the 38s timeout
 // observed in production for users with large in-progress lists.
 //
-// The function now serves list-level data unconditionally and stubs the four
-// detail-only fields with empty (but non-nil) collections via
-// stubDetailListFields. Standard Jellyfin clients refetch MediaSources via
-// /Items/{id}/PlaybackInfo on play, so the detail data was never load-bearing
-// for the Resume row UX.
+// hydrateProgressItems is the SCAN phase and must stay detail-free: it runs
+// over up to 200 entries per loop iteration purely for type filtering. The
+// detail data clients need (real MediaSources — load-bearing for Infuse and
+// SenPlayer Continue Watching rows) is served by upgradeProgressPageToDetail,
+// which runs only on the returned page, bounded by the request limit.
 func TestHydrateProgressItems_DoesNotCallGetItemDetail(t *testing.T) {
 	codec := NewResourceIDCodec()
 

--- a/internal/jellycompat/mapping.go
+++ b/internal/jellycompat/mapping.go
@@ -204,8 +204,11 @@ func (m *mapper) itemFromList(item upstreamListItem, isFavorite bool, progress *
 // The values are minimal: each carries the required (non-omitempty) fields
 // only. Clients that consume this data downstream will see a single source
 // with a stub ID, a single Video stream at index 0, and a single placeholder
-// person; standard Jellyfin clients refetch real MediaSources via
-// /Items/{id}/PlaybackInfo on play, so this stub is never load-bearing.
+// person. The stub is a FALLBACK, not a no-op: Infuse and SenPlayer build
+// their Continue Watching rows from the listing's MediaSources, so pages
+// within the detail-upgrade cap get real sources (upgradeProgressPageToDetail)
+// and only overflow/error entries see the stub — which must therefore still
+// look playable and serialize collections as empty, never null.
 var (
 	stubDetailPerson      = personDTO{ID: "0", Name: ""}
 	stubDetailMediaSource = mediaSourceDTO{ID: "0"}
@@ -214,10 +217,11 @@ var (
 
 // stubDetailListFields sets the four detail-only fields on a list-mapped DTO
 // to single-element placeholder slices when the client requested them via
-// Fields=People|Chapters|MediaStreams|MediaSources. Used by the Resume
-// hydrator, which deliberately skips per-item GetItemDetail fanout; clients
-// that need real MediaSources refetch them via /Items/{id}/PlaybackInfo on
-// play.
+// Fields=People|Chapters|MediaStreams|MediaSources. Used by the Resume/NextUp
+// scan phase, which deliberately skips per-item GetItemDetail fanout; the
+// returned page is then re-mapped through the real detail path
+// (upgradeProgressPageToDetail), so these stubs reach clients only for
+// entries past the detail-upgrade cap or whose detail fetch failed.
 func stubDetailListFields(dto *baseItemDTO, fields map[string]bool) {
 	if len(fields) == 0 {
 		return
@@ -234,7 +238,31 @@ func stubDetailListFields(dto *baseItemDTO, fields map[string]bool) {
 		dto.MediaStreams = []mediaStreamDTO{stubDetailMediaStream}
 	}
 	if fields["mediasources"] && dto.MediaSources == nil {
-		dto.MediaSources = []mediaSourceDTO{stubDetailMediaSource}
+		// The stub must still look PLAYABLE: some clients (SenPlayer) decide
+		// whether to render a Resume row entry from the listing's
+		// MediaSources, and an all-false playability stub makes them drop
+		// every item. Keep the stub ID ("0" — never a registered media source
+		// owner) but mirror the shape detailMediaSourceDTO produces; the real
+		// source set is still refetched via /Items/{id}/PlaybackInfo on play.
+		src := stubDetailMediaSource
+		src.Protocol = "File"
+		src.Type = "Default"
+		src.VideoType = "VideoFile"
+		src.Name = dto.Name
+		src.RunTimeTicks = dto.RunTimeTicks
+		src.SupportsTranscoding = true
+		src.SupportsDirectStream = true
+		src.SupportsDirectPlay = true
+		src.SupportsProbing = true
+		src.TranscodingSubProtocol = "hls"
+		src.MediaStreams = []mediaStreamDTO{stubDetailMediaStream}
+		// Real servers never serialize these as JSON null (always []/{});
+		// strict client deserializers fail the whole response on a null
+		// array, which empties the Resume/NextUp rows entirely.
+		src.Formats = []string{}
+		src.RequiredHTTPHeaders = map[string]string{}
+		src.MediaAttachments = []map[string]any{}
+		dto.MediaSources = []mediaSourceDTO{src}
 	}
 }
 

--- a/internal/jellycompat/mapping_stub_detail_fields_test.go
+++ b/internal/jellycompat/mapping_stub_detail_fields_test.go
@@ -157,3 +157,59 @@ func TestStubDetailListFields_FreshChapterMapPerCall(t *testing.T) {
 		t.Errorf("mutating dto a's chapter map leaked into dto b: b.Chapters[0][Name] = %v", got)
 	}
 }
+
+// TestStubDetailListFields_MediaSourceStubLooksPlayable locks in that the
+// MediaSources stub advertises playability. Some clients (SenPlayer) decide
+// whether to render a Resume row entry from the listing's MediaSources; an
+// all-false playability stub made them drop every entry (the Continue
+// Watching row showed empty while item-page resume worked fine).
+func TestStubDetailListFields_MediaSourceStubLooksPlayable(t *testing.T) {
+	dto := baseItemDTO{Name: "Pilot", RunTimeTicks: 34800000000}
+	stubDetailListFields(&dto, map[string]bool{"mediasources": true})
+
+	if len(dto.MediaSources) != 1 {
+		t.Fatalf("MediaSources = %v, want single-element slice", dto.MediaSources)
+	}
+	src := dto.MediaSources[0]
+	if !src.SupportsDirectPlay || !src.SupportsDirectStream || !src.SupportsTranscoding || !src.SupportsProbing {
+		t.Errorf("stub source must advertise playability; got %+v", src)
+	}
+	if src.ID != "0" {
+		t.Errorf("stub source ID = %q, want \"0\" (never a registered media source owner)", src.ID)
+	}
+	if src.Name != "Pilot" || src.RunTimeTicks != 34800000000 {
+		t.Errorf("stub source should mirror item Name/RunTimeTicks; got Name=%q ticks=%d", src.Name, src.RunTimeTicks)
+	}
+	if len(src.MediaStreams) != 1 {
+		t.Errorf("stub source should nest a stream stub; got %v", src.MediaStreams)
+	}
+	// Null arrays (vs empty) break strict client deserializers — real servers
+	// always serialize these as []/{}.
+	if src.Formats == nil || src.RequiredHTTPHeaders == nil || src.MediaAttachments == nil {
+		t.Errorf("stub source must not serialize null collections; got Formats=%v RequiredHTTPHeaders=%v MediaAttachments=%v",
+			src.Formats, src.RequiredHTTPHeaders, src.MediaAttachments)
+	}
+}
+
+// TestStubDetailListFields_FreshMediaSourcePerCall guards against reference
+// sharing across responses: the stub is built by copying the package-level
+// stubDetailMediaSource value, which only stays safe while that var's
+// reference-typed fields (slices/maps) remain nil. Mirrors the existing
+// chapter-map guard.
+func TestStubDetailListFields_FreshMediaSourcePerCall(t *testing.T) {
+	a := baseItemDTO{}
+	b := baseItemDTO{}
+	fields := map[string]bool{"mediasources": true}
+
+	stubDetailListFields(&a, fields)
+	stubDetailListFields(&b, fields)
+
+	a.MediaSources[0].RequiredHTTPHeaders["X-Mutated"] = "by-a"
+	a.MediaSources[0].MediaStreams[0].Index = 99
+	if len(b.MediaSources[0].RequiredHTTPHeaders) != 0 {
+		t.Error("mutating dto a's RequiredHTTPHeaders leaked into dto b")
+	}
+	if b.MediaSources[0].MediaStreams[0].Index == 99 {
+		t.Error("mutating dto a's nested stream leaked into dto b")
+	}
+}

--- a/internal/jellycompat/slice_page_ids_test.go
+++ b/internal/jellycompat/slice_page_ids_test.go
@@ -1,0 +1,51 @@
+package jellycompat
+
+import "testing"
+
+// TestSlicePageIDs locks slicePageIDs to sliceBaseItems' exact bounds
+// semantics — the two slice the same page in parallel in
+// writeNextUpResponse, and any divergence would attach detail upgrades to
+// the wrong DTOs.
+func TestSlicePageIDs(t *testing.T) {
+	ids := []string{"a", "b", "c", "d"}
+	cases := []struct {
+		name       string
+		startIndex int
+		limit      int
+		want       []string
+	}{
+		{"plain page", 0, 2, []string{"a", "b"}},
+		{"offset page", 1, 2, []string{"b", "c"}},
+		{"limit past end clamps", 2, 10, []string{"c", "d"}},
+		{"start past end is empty", 9, 2, []string{}},
+		{"zero limit returns rest", 1, 0, []string{"b", "c", "d"}},
+		{"negative start clamps to zero", -3, 2, []string{"a", "b"}},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := slicePageIDs(ids, tc.startIndex, tc.limit)
+			if len(got) != len(tc.want) {
+				t.Fatalf("len = %d, want %d (%v)", len(got), len(tc.want), got)
+			}
+			for i := range got {
+				if got[i] != tc.want[i] {
+					t.Errorf("got[%d] = %q, want %q", i, got[i], tc.want[i])
+				}
+			}
+			// Mirror against sliceBaseItems on a same-length DTO slice.
+			dtos := make([]baseItemDTO, len(ids))
+			for i := range ids {
+				dtos[i] = baseItemDTO{ID: ids[i]}
+			}
+			sliced := sliceBaseItems(dtos, tc.startIndex, tc.limit)
+			if len(sliced) != len(got) {
+				t.Fatalf("sliceBaseItems len %d diverges from slicePageIDs len %d", len(sliced), len(got))
+			}
+			for i := range sliced {
+				if sliced[i].ID != got[i] {
+					t.Errorf("alignment broken at %d: dto %q vs id %q", i, sliced[i].ID, got[i])
+				}
+			}
+		})
+	}
+}


### PR DESCRIPTION
Fixes #67

### What problem does this solve

Continue Watching renders empty in Infuse and SenPlayer (details + evidence in the issue). Both clients build their rows from the **listing's** MediaSources; `/UserItems/Resume` and `/Shows/NextUp` serve a stub (`Id:"0"`, all playability flags false, `null` collections) whenever the client requests `Fields=MediaSources`, so they discard the entire response. Verified by request logs: Infuse received 15 valid resume items and fetched images for 0 of them, while rendering `/Items/Latest` (real detail path, same `fields=`) normally.

### Why this approach

The stub exists for a good reason — the old per-entry `GetItemDetail` fanout over the full in-progress list caused the 38s timeout (error-report-2026-05-08 §6). That fix is preserved: the scan loop (`hydrateProgressItems`, up to 200 entries per iteration for type filtering) stays strictly list-level, and the existing no-detail regression test still pins that.

What changes: the **returned page** (bounded by the request limit, hard cap 100) is re-mapped through the per-item detail path when the client asked for detail-level Fields — the exact pattern `HandleLatest` already uses for the same Fields. Clients that don't request detail fields (jellyfin-web, Streamyfin) take the unchanged zero-cost path.

The stub remains as fallback for entries past the cap or whose detail fetch fails, and is made honest: playable flags, `Name`/`RunTimeTicks`, nested stream, and `Formats`/`RequiredHttpHeaders`/`MediaAttachments` as empty collections instead of JSON `null` (real Jellyfin/Emby never serialize null arrays; strict client decoders fail the whole body on them).

### How it was tested

- `go test ./internal/jellycompat/...` green; new tests: `TestSlicePageIDs` (pins items/pageIDs slice alignment against `sliceBaseItems`), stub playability + non-null-collections + mutation-leak guards; the no-detail scan test's doc updated to describe the two-phase design.
- Deployed on a production server (~182k items): Infuse and SenPlayer Continue Watching confirmed rendering by their users; 40-item Resume page with full detail fields serves in ~100–135 ms; zero 5xx.

### Anything to watch out for

- `maxDetailUpgrades=100` means a client requesting `limit>100` with detail fields gets stubs past 100 — documented in code, intentional.
- NextUp uses parallel `items`/`pageIDs` slices; alignment is guaranteed by building both in the same loop with the same skip condition and is test-pinned.

Implementation was AI-assisted (Claude); I've read the full diff, and the change was verified live against real Infuse/SenPlayer clients before submitting.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Performance**
  * Optimized progress and resume pagination to limit unnecessary detail upgrades, improving load times for large libraries.
  * Refined progress item processing for more efficient type filtering.

* **Bug Fixes**
  * Enhanced media source fallback handling to prevent client-side deserialization issues and ensure better compatibility across different clients.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->