### PR TITLE
fix(jellycompat): enforce account-level library restrictions

### DIFF
--- a/cmd/silo/main.go
+++ b/cmd/silo/main.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"crypto/rand"
 	"encoding/base64"
-	"encoding/json"
 	"flag"
 	"fmt"
 	"io/fs"
@@ -1793,47 +1792,17 @@ func main() {
 			provider := auth.NewLocalProvider(userRepo, sessionRepo)
 			compatDeps.AuthService = auth.NewService(provider, jwtService, sessionRepo, userRepo, nil, nil, nil)
 
-			// Access filter resolver for profile-scoped library access.
-			compatDeps.AccessFilterFn = func(ctx context.Context, userID int, profileID string) catalog.AccessFilter {
-				if userStoreProvider == nil {
-					return catalog.AccessFilter{}
-				}
-				store, err := userStoreProvider.ForUser(ctx, userID)
-				if err != nil {
-					return catalog.AccessFilter{}
-				}
-				profile, err := store.GetProfile(ctx, profileID)
-				if err != nil || profile == nil {
-					return catalog.AccessFilter{}
-				}
-				filter := catalog.AccessFilter{
-					MaxContentRating: profile.MaxContentRating,
-				}
-				if profile.LibraryRestrictionsEnabled && len(profile.AllowedLibraryIDs) > 0 {
-					filter.AllowedLibraryIDs = profile.AllowedLibraryIDs
-				}
-				// Apply user-disabled library IDs.
-				if raw, err := store.GetSetting(ctx, "disabled_library_ids"); err == nil && raw != "" {
-					var disabled []int
-					if json.Unmarshal([]byte(raw), &disabled) == nil && len(disabled) > 0 {
-						if filter.AllowedLibraryIDs != nil {
-							filtered := make([]int, 0, len(filter.AllowedLibraryIDs))
-							disSet := make(map[int]struct{}, len(disabled))
-							for _, id := range disabled {
-								disSet[id] = struct{}{}
-							}
-							for _, id := range filter.AllowedLibraryIDs {
-								if _, ok := disSet[id]; !ok {
-									filtered = append(filtered, id)
-								}
-							}
-							filter.AllowedLibraryIDs = filtered
-						} else {
-							filter.DisabledLibraryIDs = disabled
-						}
-					}
-				}
-				return filter
+			// Access filter resolver for viewer-scoped library access.
+			// Backed by the shared access.Resolver so account-level library
+			// restrictions (users.library_ids), profile restrictions,
+			// user-disabled libraries, and rating/quality ceilings apply to
+			// the compat API exactly as they do to the native API.
+			if userStoreProvider != nil {
+				compatDeps.AccessFilterFn = jellycompat.NewScopeAccessFilter(access.NewResolver(
+					userRepo,
+					userStoreProvider,
+					nil, // profile tokens unused: compat login already verifies PINs
+				))
 			}
 		}
 

--- a/internal/jellycompat/access_filter.go
+++ b/internal/jellycompat/access_filter.go
@@ -1,0 +1,54 @@
+package jellycompat
+
+import (
+	"context"
+	"log/slog"
+
+	"github.com/Silo-Server/silo-server/internal/access"
+	"github.com/Silo-Server/silo-server/internal/catalog"
+)
+
+// ScopeResolver resolves a viewer request into an effective access scope.
+// Implemented by *access.Resolver.
+type ScopeResolver interface {
+	Resolve(ctx context.Context, input access.ResolveInput) (access.Scope, error)
+}
+
+// NewScopeAccessFilter returns an AccessFilterResolver backed by the shared
+// access scope resolver, so account-level library restrictions
+// (users.library_ids), profile library restrictions, user-disabled
+// libraries, content-rating ceilings, and playback-quality ceilings all
+// apply to the Jellyfin-compat API exactly as they do to the native API.
+//
+// PIN verification is skipped because compat login already verified the
+// profile PIN (password#pin convention). Resolution failures fail closed:
+// the viewer gets an empty library allowlist rather than full access.
+func NewScopeAccessFilter(resolver ScopeResolver) AccessFilterResolver {
+	return func(ctx context.Context, userID int, profileID string) catalog.AccessFilter {
+		scope, err := resolver.Resolve(ctx, access.ResolveInput{
+			UserID:              userID,
+			ProfileID:           profileID,
+			SkipPINVerification: true,
+		})
+		if err != nil {
+			slog.Warn("jellycompat: access scope resolution failed; denying library access",
+				"user_id", userID,
+				"profile_id", profileID,
+				"error", err,
+			)
+			return catalog.AccessFilter{
+				AllowedLibraryIDs: []int{},
+				UserID:            userID,
+				ProfileID:         profileID,
+			}
+		}
+		return catalog.AccessFilter{
+			AllowedLibraryIDs:  scope.AllowedLibraryIDs,
+			DisabledLibraryIDs: scope.DisabledLibraryIDs,
+			MaxContentRating:   scope.MaxContentRating,
+			MaxPlaybackQuality: scope.MaxPlaybackQuality,
+			UserID:             userID,
+			ProfileID:          profileID,
+		}
+	}
+}

--- a/internal/jellycompat/access_filter_test.go
+++ b/internal/jellycompat/access_filter_test.go
@@ -1,0 +1,102 @@
+package jellycompat
+
+import (
+	"context"
+	"errors"
+	"reflect"
+	"testing"
+
+	"github.com/Silo-Server/silo-server/internal/access"
+)
+
+type stubScopeResolver struct {
+	scope access.Scope
+	err   error
+	input access.ResolveInput
+}
+
+func (s *stubScopeResolver) Resolve(_ context.Context, input access.ResolveInput) (access.Scope, error) {
+	s.input = input
+	return s.scope, s.err
+}
+
+func TestScopeAccessFilterMapsScope(t *testing.T) {
+	resolver := &stubScopeResolver{
+		scope: access.Scope{
+			UserID:              7,
+			ProfileID:           "profile-1",
+			AllowedLibraryIDs:   []int{2, 19},
+			LibrariesRestricted: true,
+			MaxContentRating:    "PG-13",
+			MaxPlaybackQuality:  "1080p",
+		},
+	}
+
+	filter := NewScopeAccessFilter(resolver)(context.Background(), 7, "profile-1")
+
+	if !resolver.input.SkipPINVerification {
+		t.Fatal("expected SkipPINVerification=true (PIN is verified at compat login)")
+	}
+	if resolver.input.UserID != 7 || resolver.input.ProfileID != "profile-1" {
+		t.Fatalf("unexpected resolve input: %+v", resolver.input)
+	}
+	if !reflect.DeepEqual(filter.AllowedLibraryIDs, []int{2, 19}) {
+		t.Fatalf("AllowedLibraryIDs = %v, want [2 19]", filter.AllowedLibraryIDs)
+	}
+	if filter.MaxContentRating != "PG-13" {
+		t.Fatalf("MaxContentRating = %q, want PG-13", filter.MaxContentRating)
+	}
+	if filter.MaxPlaybackQuality != "1080p" {
+		t.Fatalf("MaxPlaybackQuality = %q, want 1080p", filter.MaxPlaybackQuality)
+	}
+	if filter.UserID != 7 || filter.ProfileID != "profile-1" {
+		t.Fatalf("identity not propagated: %+v", filter)
+	}
+}
+
+func TestScopeAccessFilterUnrestrictedScope(t *testing.T) {
+	resolver := &stubScopeResolver{
+		scope: access.Scope{
+			UserID:             1,
+			DisabledLibraryIDs: []int{7},
+		},
+	}
+
+	filter := NewScopeAccessFilter(resolver)(context.Background(), 1, "profile-1")
+
+	if filter.AllowedLibraryIDs != nil {
+		t.Fatalf("AllowedLibraryIDs = %v, want nil (unrestricted)", filter.AllowedLibraryIDs)
+	}
+	if !reflect.DeepEqual(filter.DisabledLibraryIDs, []int{7}) {
+		t.Fatalf("DisabledLibraryIDs = %v, want [7]", filter.DisabledLibraryIDs)
+	}
+}
+
+func TestScopeAccessFilterFailsClosed(t *testing.T) {
+	resolver := &stubScopeResolver{err: errors.New("boom")}
+
+	filter := NewScopeAccessFilter(resolver)(context.Background(), 7, "profile-1")
+
+	if filter.AllowedLibraryIDs == nil || len(filter.AllowedLibraryIDs) != 0 {
+		t.Fatalf("AllowedLibraryIDs = %v, want empty non-nil allowlist (deny all)", filter.AllowedLibraryIDs)
+	}
+}
+
+func TestListUserLibrariesEmptyAllowlistDeniesAll(t *testing.T) {
+	svc := &directContentService{
+		accessFilter: NewScopeAccessFilter(&stubScopeResolver{
+			scope: access.Scope{
+				AllowedLibraryIDs:   []int{},
+				LibrariesRestricted: true,
+			},
+		}),
+	}
+
+	libraries, err := svc.ListUserLibraries(context.Background(), &Session{StreamAppUserID: 7, ProfileID: "profile-1"})
+	if err != nil {
+		t.Fatalf("ListUserLibraries: %v", err)
+	}
+	if len(libraries) != 0 {
+		t.Fatalf("got %d libraries, want 0 for empty allowlist", len(libraries))
+	}
+}

--- a/internal/jellycompat/access_filter_test.go
+++ b/internal/jellycompat/access_filter_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 
 	"github.com/Silo-Server/silo-server/internal/access"
+	"github.com/Silo-Server/silo-server/internal/models"
 )
 
 type stubScopeResolver struct {
@@ -79,6 +80,80 @@ func TestScopeAccessFilterFailsClosed(t *testing.T) {
 
 	if filter.AllowedLibraryIDs == nil || len(filter.AllowedLibraryIDs) != 0 {
 		t.Fatalf("AllowedLibraryIDs = %v, want empty non-nil allowlist (deny all)", filter.AllowedLibraryIDs)
+	}
+}
+
+type stubFolderSource struct {
+	enabled       []*models.MediaFolder
+	byIDs         []*models.MediaFolder
+	listByIDsArgs []int
+}
+
+func (s *stubFolderSource) GetEnabled(context.Context) ([]*models.MediaFolder, error) {
+	return s.enabled, nil
+}
+
+func (s *stubFolderSource) ListByIDs(_ context.Context, ids []int) ([]*models.MediaFolder, error) {
+	s.listByIDsArgs = ids
+	return s.byIDs, nil
+}
+
+func TestListUserLibrariesRestrictedAllowlist(t *testing.T) {
+	folders := &stubFolderSource{
+		byIDs: []*models.MediaFolder{
+			{ID: 2, Name: "TV Shows", Type: "series"},
+			{ID: 19, Name: "Movies", Type: "movies"},
+		},
+	}
+	svc := &directContentService{
+		folderRepo: folders,
+		accessFilter: NewScopeAccessFilter(&stubScopeResolver{
+			scope: access.Scope{
+				AllowedLibraryIDs:   []int{2, 19},
+				LibrariesRestricted: true,
+			},
+		}),
+	}
+
+	libraries, err := svc.ListUserLibraries(context.Background(), &Session{StreamAppUserID: 7, ProfileID: "profile-1"})
+	if err != nil {
+		t.Fatalf("ListUserLibraries: %v", err)
+	}
+	if !reflect.DeepEqual(folders.listByIDsArgs, []int{2, 19}) {
+		t.Fatalf("ListByIDs called with %v, want [2 19]", folders.listByIDsArgs)
+	}
+	if len(libraries) != 2 {
+		t.Fatalf("got %d libraries, want 2", len(libraries))
+	}
+}
+
+func TestListUserLibrariesFiltersDisabled(t *testing.T) {
+	svc := &directContentService{
+		folderRepo: &stubFolderSource{
+			enabled: []*models.MediaFolder{
+				{ID: 2, Name: "TV Shows", Type: "series"},
+				{ID: 7, Name: "XXX", Type: "movies"},
+				{ID: 19, Name: "Movies", Type: "movies"},
+			},
+		},
+		accessFilter: NewScopeAccessFilter(&stubScopeResolver{
+			scope: access.Scope{
+				DisabledLibraryIDs: []int{7},
+			},
+		}),
+	}
+
+	libraries, err := svc.ListUserLibraries(context.Background(), &Session{StreamAppUserID: 1, ProfileID: "profile-1"})
+	if err != nil {
+		t.Fatalf("ListUserLibraries: %v", err)
+	}
+	if len(libraries) != 2 {
+		t.Fatalf("got %d libraries, want 2 (disabled library not filtered)", len(libraries))
+	}
+	for _, lib := range libraries {
+		if lib.ID == 7 {
+			t.Fatal("user-disabled library 7 still present in views list")
+		}
 	}
 }
 

--- a/internal/jellycompat/content_direct.go
+++ b/internal/jellycompat/content_direct.go
@@ -135,7 +135,12 @@ func (s *directContentService) ListUserLibraries(ctx context.Context, session *S
 
 	var folders []*models.MediaFolder
 	var err error
-	if len(filter.AllowedLibraryIDs) > 0 {
+	if filter.AllowedLibraryIDs != nil {
+		// A non-nil allowlist means the viewer is restricted; an empty
+		// allowlist grants access to no libraries at all.
+		if len(filter.AllowedLibraryIDs) == 0 {
+			return []upstreamUserLibrary{}, nil
+		}
 		folders, err = s.folderRepo.ListByIDs(ctx, filter.AllowedLibraryIDs)
 	} else {
 		folders, err = s.folderRepo.GetEnabled(ctx)
@@ -144,8 +149,16 @@ func (s *directContentService) ListUserLibraries(ctx context.Context, session *S
 		return nil, fmt.Errorf("list libraries: %w", err)
 	}
 
+	disabled := make(map[int]struct{}, len(filter.DisabledLibraryIDs))
+	for _, id := range filter.DisabledLibraryIDs {
+		disabled[id] = struct{}{}
+	}
+
 	libraries := make([]upstreamUserLibrary, 0, len(folders))
 	for _, f := range folders {
+		if _, ok := disabled[f.ID]; ok {
+			continue
+		}
 		lib := upstreamUserLibrary{
 			ID:         f.ID,
 			Name:       f.Name,

--- a/internal/jellycompat/content_direct.go
+++ b/internal/jellycompat/content_direct.go
@@ -46,6 +46,14 @@ type itemAccessSource interface {
 	GetByIDs(ctx context.Context, contentIDs []string) ([]*models.MediaItem, error)
 }
 
+// folderListSource is the subset of *catalog.FolderRepository that
+// directContentService relies on. Defined as an interface so tests can
+// substitute a stub without standing up a Postgres pool.
+type folderListSource interface {
+	GetEnabled(ctx context.Context) ([]*models.MediaFolder, error)
+	ListByIDs(ctx context.Context, ids []int) ([]*models.MediaFolder, error)
+}
+
 // seasonListSource is the subset of *catalog.SeasonRepository that
 // directContentService relies on.
 type seasonListSource interface {
@@ -70,7 +78,7 @@ type directContentService struct {
 	seasonRepo      seasonListSource
 	episodeRepo     episodeListSource
 	detailSvc       *catalog.DetailService
-	folderRepo      *catalog.FolderRepository
+	folderRepo      folderListSource
 	storeProvider   userstore.UserStoreProvider
 	accessFilter    AccessFilterResolver
 	posterPresigner LibraryPosterPresigner
@@ -83,7 +91,7 @@ func newDirectContentService(
 	seasonRepo *catalog.SeasonRepository,
 	episodeRepo *catalog.EpisodeRepository,
 	detailSvc *catalog.DetailService,
-	folderRepo *catalog.FolderRepository,
+	folderRepo folderListSource,
 	storeProvider userstore.UserStoreProvider,
 	accessFilter AccessFilterResolver,
 ) *directContentService {


### PR DESCRIPTION
Fixes #71.

## Problem

The Jellyfin-compat API ignores account-level library restrictions (`users.library_ids`).
The compat `AccessFilterFn` wired up in `cmd/silo/main.go` was a hand-rolled partial
re-implementation of the access policy that only considered:

- profile-level restrictions (`profile.library_restrictions_enabled` + allowed ids), and
- the viewer's own `disabled_library_ids` setting.

It never loaded the user row, so the admin-assigned per-account library allowlist —
the primary mechanism for restricting what a user can see — was silently dropped.
Every compat session (Infuse, Findroid, VidHub, jellyfin-web, …) could list, browse,
search, and play items from **all** enabled libraries, including libraries the admin
had explicitly not granted to that account. The native API applies these restrictions
correctly via `access.Resolver`, so the two APIs disagreed about the same viewer.

Additional smaller gaps in the same code path:

- a profile restricted to *zero* libraries was treated as unrestricted
  (`len > 0` check), both in the filter construction and in
  `ListUserLibraries`;
- `MaxPlaybackQuality` ceilings (account and profile) were never propagated
  to the compat filter;
- any error while resolving the policy (store unavailable, profile deleted
  mid-session) failed **open**, returning an unrestricted filter;
- `ListUserLibraries` never applied `DisabledLibraryIDs`, so an unrestricted
  user's hidden libraries still appeared as compat views.

## Fix

Replace the duplicated closure with the shared `access.Resolver` — the same
component the native API and the requests entitlement path already use — via a
new `jellycompat.NewScopeAccessFilter(resolver)` adapter:

- account `library_ids` ∩ profile restrictions ∩ user-disabled libraries now
  apply to every compat surface that consumes the access filter (views,
  virtual folders, browse, search, item detail, images, recommendations,
  playback);
- `MaxContentRating` and `MaxPlaybackQuality` ceilings propagate like on the
  native API;
- PIN verification is skipped (`SkipPINVerification: true`) because compat
  login already verifies profile PINs via the `password#pin` convention;
- resolution failures now fail **closed** (empty allowlist) instead of open;
- `ListUserLibraries` distinguishes nil (unrestricted) from empty
  (restricted-to-nothing) allowlists and filters disabled libraries.

## Anything to watch out for

- **Playback-quality ceilings now apply to the compat API.** Previously
  `users.max_playback_quality` / profile quality caps were only enforced on
  the native API; compat clients (Infuse, Findroid, VidHub, …) saw and played
  every file version. After this change a capped viewer loses access to
  file versions above their ceiling on compat clients too — same behavior
  as the native API. Deployments that relied (accidentally) on the compat
  API ignoring quality caps will see capped users restricted there as well.
- **Access-policy resolution failures now deny instead of allow.** If the
  user store is unavailable or a session references a deleted profile, the
  viewer gets an empty library allowlist for that request instead of an
  unrestricted catalog.
- **A profile restricted to zero libraries now sees zero libraries** on the
  compat API (previously: all libraries).

## How it was tested

- new unit tests: scope→filter mapping, unrestricted pass-through,
  fail-closed on resolver error, empty-allowlist `ListUserLibraries`;
- `go build ./cmd/... ./internal/...`, `go vet`, full
  `go test ./internal/jellycompat/` pass;
- verified live on a production deployment: a restricted user
  (`library_ids` excluding one library) no longer sees the withheld library
  via `/Users/{id}/Views` or search on the compat API; toggling the library
  in the account's allowlist removes/restores it on the compat layer
  immediately, and an unrestricted admin account still sees everything.

Implementation was AI-assisted (Claude); I've read the full diff, and the behavior was verified live before submitting.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved enforcement of content rating restrictions and library access controls for user profiles
  * Enhanced access filtering logic with more robust error handling to ensure consistent application of restrictions
  * Strengthened security posture by ensuring the system properly denies access when content restrictions cannot be verified

<!-- end of auto-generated comment: release notes by coderabbit.ai -->