### PR TITLE
Add ebook metadata enrichment

### DIFF
--- a/cmd/silo/main.go
+++ b/cmd/silo/main.go
@@ -47,6 +47,7 @@ import (
 	"github.com/Silo-Server/silo-server/internal/clientip"
 	"github.com/Silo-Server/silo-server/internal/config"
 	"github.com/Silo-Server/silo-server/internal/database"
+	"github.com/Silo-Server/silo-server/internal/ebooks"
 	evt "github.com/Silo-Server/silo-server/internal/events"
 	"github.com/Silo-Server/silo-server/internal/historyimport"
 	"github.com/Silo-Server/silo-server/internal/imagecache"
@@ -888,6 +889,7 @@ func main() {
 	var seasonRepo *catalog.SeasonRepository
 	var episodeRepo *catalog.EpisodeRepository
 	var audiobookEnricher *audiobooks.Enricher
+	var ebookEnricher *ebooks.Enricher
 	if needsWorkers && deps.DB != nil && deps.FileRepo != nil {
 		chainRepo := metadata.NewChainRepository(deps.DB)
 		skippedRootRepo = metadata.NewSkippedRootRepository(deps.DB)
@@ -969,6 +971,14 @@ func main() {
 			personRepo,
 			providerIDRepo,
 		)
+		ebookEnricher = ebooks.NewEnricher(
+			deps.DB,
+			chainRepo,
+			pluginResolver,
+			itemRepo,
+			personRepo,
+			providerIDRepo,
+		)
 
 		// Always wire the image resolver so plugin-prefixed URLs (e.g.
 		// metadb://) can be resolved to presigned HTTP URLs in API responses.
@@ -990,6 +1000,9 @@ func main() {
 			if audiobookEnricher != nil {
 				audiobookEnricher.SetImageCacher(imageCacher)
 				audiobookEnricher.SetFFmpegPath(scanner.FFmpegPathFromFFprobe(scanner.FFprobePathFromFFmpeg(cfg.Playback.FFmpegPath)))
+			}
+			if ebookEnricher != nil {
+				ebookEnricher.SetImageCacher(imageCacher)
 			}
 		}
 
@@ -1533,6 +1546,9 @@ func main() {
 		taskMgr.Register(tasks.NewSyncPodcastFeedsTask(podcastfeed.New(), podcastfeed.NewDBStore(deps.DB)))
 		if audiobookEnricher != nil {
 			taskMgr.Register(tasks.NewSyncAudiobookMetadataTask(audiobookEnricher))
+		}
+		if ebookEnricher != nil {
+			taskMgr.Register(tasks.NewSyncEbookMetadataTask(ebookEnricher))
 		}
 		if pluginInstallationStore != nil && pluginRuntimeConfigStore != nil && pluginService != nil {
 			pluginTasks, err := plugins.NewTaskRegistryWithTypedResolver(pluginInstallationStore, pluginRuntimeConfigStore, pluginService).Tasks(appCtx)

--- a/internal/api/handlers/libraries.go
+++ b/internal/api/handlers/libraries.go
@@ -2029,18 +2029,8 @@ func (h *LibraryHandler) seedDefaultChain(ctx context.Context, libraryType strin
 		return nil
 	}
 
-	// Determine which content levels apply.
-	var levels []string
-	switch libraryType {
-	case "series":
-		levels = []string{"series", "season", "episode"}
-	case "movies", "movie":
-		levels = []string{"movie"}
-	case "audiobooks", "audiobook":
-		levels = []string{"audiobook"}
-	case "mixed":
-		levels = []string{"movie", "series", "season", "episode", "audiobook"}
-	default:
+	levels := metadataContentLevelsForLibraryType(libraryType)
+	if len(levels) == 0 {
 		return nil
 	}
 
@@ -2091,6 +2081,23 @@ func (h *LibraryHandler) seedDefaultChain(ctx context.Context, libraryType strin
 	}
 
 	return entries
+}
+
+func metadataContentLevelsForLibraryType(libraryType string) []string {
+	switch libraryType {
+	case "series":
+		return []string{"series", "season", "episode"}
+	case "movies", "movie":
+		return []string{"movie"}
+	case "audiobooks", "audiobook":
+		return []string{"audiobook"}
+	case "ebooks", "ebook":
+		return []string{"ebook"}
+	case "mixed":
+		return []string{"movie", "series", "season", "episode", "audiobook", "ebook"}
+	default:
+		return nil
+	}
 }
 
 // HandleListStaleIDs handles GET /libraries/stale-ids.

--- a/internal/api/handlers/libraries_metadata_levels_test.go
+++ b/internal/api/handlers/libraries_metadata_levels_test.go
@@ -1,0 +1,26 @@
+package handlers
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestMetadataContentLevelsForLibraryTypeIncludesEbooks(t *testing.T) {
+	cases := []struct {
+		name        string
+		libraryType string
+		want        []string
+	}{
+		{name: "plural ebooks", libraryType: "ebooks", want: []string{"ebook"}},
+		{name: "singular ebook", libraryType: "ebook", want: []string{"ebook"}},
+		{name: "mixed includes ebook", libraryType: "mixed", want: []string{"movie", "series", "season", "episode", "audiobook", "ebook"}},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := metadataContentLevelsForLibraryType(tc.libraryType); !reflect.DeepEqual(got, tc.want) {
+				t.Fatalf("metadataContentLevelsForLibraryType(%q) = %#v, want %#v", tc.libraryType, got, tc.want)
+			}
+		})
+	}
+}

--- a/internal/ebooks/enrichment.go
+++ b/internal/ebooks/enrichment.go
@@ -1,0 +1,581 @@
+package ebooks
+
+// Enricher periodically enriches ebook media_items that are missing metadata
+// by querying the configured metadata-provider chain for each item's library
+// folder.
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"os"
+	"strconv"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"time"
+
+	"github.com/jackc/pgx/v5/pgxpool"
+
+	"github.com/Silo-Server/silo-server/internal/catalog"
+	"github.com/Silo-Server/silo-server/internal/metadata"
+	"github.com/Silo-Server/silo-server/internal/models"
+)
+
+const (
+	ebookMetadataImageProviderID = "ebook-metadata"
+
+	defaultEnrichBatchSize = 50
+	defaultEnrichWorkers   = 4
+)
+
+func ebookContentType() string {
+	return "ebook"
+}
+
+func ebookEnrichWorkers() int {
+	n := defaultEnrichWorkers
+	if v := os.Getenv("SILO_EBOOK_ENRICH_WORKERS"); v != "" {
+		if parsed, err := strconv.Atoi(v); err == nil && parsed > 0 {
+			n = parsed
+		}
+	}
+	if n > defaultEnrichBatchSize {
+		n = defaultEnrichBatchSize
+	}
+	return n
+}
+
+type enrichmentItemRow struct {
+	ContentID   string
+	Title       string
+	Year        int
+	FolderID    int
+	Language    string
+	Author      string
+	ProviderIDs map[string]string
+}
+
+// Enricher drives the ebook metadata enrichment sweep.
+type Enricher struct {
+	pool        *pgxpool.Pool
+	chainRepo   *metadata.ChainRepository
+	resolver    *metadata.PluginResolverAdapter
+	itemRepo    *catalog.ItemRepository
+	personRepo  *catalog.PersonRepository
+	providerIDs *catalog.ProviderIDRepository
+	imageCacher metadata.ImageCacher
+	batchSize   int
+	workers     int
+}
+
+func NewEnricher(
+	pool *pgxpool.Pool,
+	chainRepo *metadata.ChainRepository,
+	resolver *metadata.PluginResolverAdapter,
+	itemRepo *catalog.ItemRepository,
+	personRepo *catalog.PersonRepository,
+	providerIDs *catalog.ProviderIDRepository,
+) *Enricher {
+	return &Enricher{
+		pool:        pool,
+		chainRepo:   chainRepo,
+		resolver:    resolver,
+		itemRepo:    itemRepo,
+		personRepo:  personRepo,
+		providerIDs: providerIDs,
+		batchSize:   defaultEnrichBatchSize,
+		workers:     ebookEnrichWorkers(),
+	}
+}
+
+func (e *Enricher) SetImageCacher(cacher metadata.ImageCacher) {
+	if e == nil {
+		return
+	}
+	e.imageCacher = cacher
+}
+
+func (e *Enricher) Run(ctx context.Context) (int, error) {
+	if e == nil || e.pool == nil || e.chainRepo == nil {
+		return 0, nil
+	}
+
+	items, err := e.claimBatch(ctx)
+	if err != nil {
+		return 0, fmt.Errorf("ebook enrichment: claim batch: %w", err)
+	}
+	if len(items) == 0 {
+		return 0, nil
+	}
+
+	slog.Info("ebook enrichment: sweep started",
+		"count", len(items),
+		"workers", e.workers,
+	)
+
+	enriched := e.runBatch(ctx, items, e.enrichItem)
+
+	slog.Info("ebook enrichment: sweep complete",
+		"attempted", len(items),
+		"enriched", enriched,
+	)
+	return enriched, nil
+}
+
+func (e *Enricher) runBatch(ctx context.Context, items []enrichmentItemRow, enrichFn func(context.Context, enrichmentItemRow) error) int {
+	workers := e.workers
+	if workers <= 0 {
+		workers = 1
+	}
+	if workers > len(items) {
+		workers = len(items)
+	}
+
+	ch := make(chan enrichmentItemRow, workers)
+	var (
+		wg       sync.WaitGroup
+		enriched int64
+	)
+	for i := 0; i < workers; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for item := range ch {
+				if ctx.Err() != nil {
+					continue
+				}
+				if err := enrichFn(ctx, item); err != nil {
+					slog.Warn("ebook enrichment: item failed",
+						"content_id", item.ContentID,
+						"title", item.Title,
+						"error", err,
+					)
+					continue
+				}
+				atomic.AddInt64(&enriched, 1)
+			}
+		}()
+	}
+	for _, item := range items {
+		if ctx.Err() != nil {
+			break
+		}
+		ch <- item
+	}
+	close(ch)
+	wg.Wait()
+	return int(enriched)
+}
+
+func (e *Enricher) claimBatch(ctx context.Context) ([]enrichmentItemRow, error) {
+	rows, err := e.pool.Query(ctx, `
+		SELECT
+			mi.content_id,
+			mi.title,
+			mi.year,
+			COALESCE(mil.media_folder_id, 0) AS folder_id,
+			COALESCE(mf.metadata_language, 'en') AS language,
+			COALESCE(
+				(SELECT p.name
+				 FROM item_people ip
+				 JOIN people p ON p.id = ip.person_id
+				 WHERE ip.content_id = mi.content_id
+				   AND ip.kind = 7
+				 ORDER BY ip.sort_order, ip.id
+				 LIMIT 1),
+				''
+			) AS author
+		FROM media_items mi
+		LEFT JOIN media_item_libraries mil ON mil.content_id = mi.content_id
+		LEFT JOIN media_folders mf ON mf.id = mil.media_folder_id
+		WHERE mi.type = 'ebook'
+		  AND (mi.poster_path IS NULL OR mi.poster_path = '')
+		  AND mi.last_refreshed IS NULL
+		ORDER BY mi.created_at ASC
+		LIMIT $1
+	`, e.batchSize)
+	if err != nil {
+		return nil, fmt.Errorf("querying unenriched ebooks: %w", err)
+	}
+	defer rows.Close()
+
+	var items []enrichmentItemRow
+	seen := make(map[string]struct{})
+	for rows.Next() {
+		var item enrichmentItemRow
+		if err := rows.Scan(
+			&item.ContentID,
+			&item.Title,
+			&item.Year,
+			&item.FolderID,
+			&item.Language,
+			&item.Author,
+		); err != nil {
+			return nil, fmt.Errorf("scanning ebook enrichment row: %w", err)
+		}
+		if _, dup := seen[item.ContentID]; dup {
+			continue
+		}
+		seen[item.ContentID] = struct{}{}
+		items = append(items, item)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("iterating ebook enrichment rows: %w", err)
+	}
+
+	if e.providerIDs != nil {
+		for i := range items {
+			pids, err := e.providerIDs.GetByContentID(ctx, items[i].ContentID)
+			if err == nil {
+				items[i].ProviderIDs = providerIDMapFromRows(pids)
+			}
+		}
+	}
+
+	return items, nil
+}
+
+func (e *Enricher) enrichItem(ctx context.Context, item enrichmentItemRow) error {
+	if item.FolderID == 0 {
+		slog.Debug("ebook enrichment: item has no library folder, skipping",
+			"content_id", item.ContentID,
+			"title", item.Title,
+		)
+		return e.stampLastRefreshed(ctx, item.ContentID)
+	}
+
+	providers, err := metadata.ResolveChain(ctx, item.FolderID, ebookContentType(), e.chainRepo, e.resolver)
+	if err != nil {
+		return fmt.Errorf("resolving ebook chain for folder %d: %w", item.FolderID, err)
+	}
+	if len(providers) == 0 {
+		slog.Debug("ebook enrichment: no providers in chain",
+			"content_id", item.ContentID,
+			"folder_id", item.FolderID,
+		)
+		return e.stampLastRefreshed(ctx, item.ContentID)
+	}
+
+	accumulatedIDs := make(map[string]string, len(item.ProviderIDs))
+	for k, v := range item.ProviderIDs {
+		accumulatedIDs[k] = v
+	}
+
+	searchQuery := metadata.SearchQuery{
+		Title:       item.Title,
+		Year:        item.Year,
+		ContentType: ebookContentType(),
+		ProviderIDs: accumulatedIDs,
+		Language:    item.Language,
+	}
+
+	for _, p := range providers {
+		sp, ok := p.(metadata.SearchProvider)
+		if !ok {
+			continue
+		}
+		results, searchErr := sp.Search(ctx, searchQuery)
+		if searchErr != nil {
+			slog.Warn("ebook enrichment: search error",
+				"provider", p.Slug(),
+				"content_id", item.ContentID,
+				"error", searchErr,
+			)
+			continue
+		}
+		if len(results) == 0 {
+			continue
+		}
+		for k, v := range results[0].ProviderIDs {
+			if v != "" {
+				if _, exists := accumulatedIDs[k]; !exists {
+					accumulatedIDs[k] = v
+				}
+			}
+		}
+		slog.Debug("ebook enrichment: search result",
+			"provider", p.Slug(),
+			"content_id", item.ContentID,
+			"matched_ids", accumulatedIDs,
+		)
+	}
+
+	accumulator := &metadata.MetadataResult{
+		ProviderIDs: accumulatedIDs,
+	}
+
+	for _, p := range providers {
+		mp, ok := p.(metadata.MetadataProvider)
+		if !ok {
+			continue
+		}
+		result, getErr := mp.GetMetadata(ctx, metadata.MetadataRequest{
+			ProviderIDs: accumulatedIDs,
+			ContentType: ebookContentType(),
+			Language:    item.Language,
+		})
+		if getErr != nil {
+			slog.Warn("ebook enrichment: GetMetadata error",
+				"provider", p.Slug(),
+				"content_id", item.ContentID,
+				"error", getErr,
+			)
+			continue
+		}
+		if result == nil || !result.HasMetadata {
+			continue
+		}
+		mergeEnrichmentProviderIDs(accumulator, result)
+		accumulatedIDs = accumulator.ProviderIDs
+		metadata.MergeMetadata(result, accumulator, nil, metadata.MergeFillEmpty)
+
+		slog.Debug("ebook enrichment: metadata received",
+			"provider", p.Slug(),
+			"content_id", item.ContentID,
+			"has_poster", result.PosterPath != "",
+			"has_overview", result.Overview != "",
+		)
+	}
+
+	if !accumulator.HasMetadata && accumulator.PosterPath == "" && accumulator.Overview == "" {
+		slog.Info("ebook enrichment: no metadata found",
+			"content_id", item.ContentID,
+			"title", item.Title,
+		)
+		return e.stampLastRefreshed(ctx, item.ContentID)
+	}
+
+	e.cacheRemotePoster(ctx, item.ContentID, accumulator)
+
+	if err := e.persist(ctx, item.ContentID, accumulatedIDs, accumulator); err != nil {
+		return fmt.Errorf("persisting enrichment for %s: %w", item.ContentID, err)
+	}
+
+	slog.Info("ebook enrichment: enriched",
+		"content_id", item.ContentID,
+		"title", item.Title,
+		"poster", accumulator.PosterPath != "",
+		"overview", accumulator.Overview != "",
+		"people", len(filterEbookPeople(accumulator.People)),
+	)
+
+	return nil
+}
+
+func (e *Enricher) cacheRemotePoster(ctx context.Context, contentID string, result *metadata.MetadataResult) {
+	if e == nil || result == nil || result.PosterPath == "" {
+		return
+	}
+	if !strings.HasPrefix(result.PosterPath, "http://") && !strings.HasPrefix(result.PosterPath, "https://") {
+		return
+	}
+	if e.imageCacher == nil {
+		return
+	}
+
+	cached, err := e.imageCacher.CacheImage(ctx, metadata.CacheImageRequest{
+		SourceURL:   result.PosterPath,
+		ProviderID:  ebookMetadataImageProviderID,
+		ContentType: "ebooks",
+		ContentID:   contentID,
+		ImageType:   metadata.ImagePoster,
+	})
+	if err != nil {
+		slog.Warn("ebook enrichment: poster cache failed, keeping provider URL",
+			"content_id", contentID,
+			"url", result.PosterPath,
+			"error", err,
+		)
+		return
+	}
+
+	if storedPath := cachedOriginalImagePath(cached.BasePath, cached.Ext); storedPath != "" {
+		result.PosterPath = storedPath
+	}
+	if cached.Thumbhash != "" {
+		result.PosterThumbhash = cached.Thumbhash
+	}
+}
+
+func cachedOriginalImagePath(basePath, ext string) string {
+	if basePath == "" {
+		return ""
+	}
+	if strings.Contains(basePath, "/original.") {
+		return basePath
+	}
+	if ext == "" {
+		ext = ".jpg"
+	}
+	return strings.TrimRight(basePath, "/") + "/original" + ext
+}
+
+func (e *Enricher) persist(ctx context.Context, contentID string, providerIDs map[string]string, result *metadata.MetadataResult) error {
+	upd := &catalog.MetadataUpdate{}
+
+	if result.PosterPath != "" {
+		upd.PosterPath = &result.PosterPath
+	}
+	if result.PosterThumbhash != "" {
+		upd.PosterThumbhash = &result.PosterThumbhash
+	}
+	if result.BackdropPath != "" {
+		upd.BackdropPath = &result.BackdropPath
+	}
+	if result.BackdropThumbhash != "" {
+		upd.BackdropThumbhash = &result.BackdropThumbhash
+	}
+	if result.LogoPath != "" {
+		upd.LogoPath = &result.LogoPath
+	}
+	if result.Overview != "" {
+		upd.Overview = &result.Overview
+	}
+	if result.Tagline != "" {
+		upd.Tagline = &result.Tagline
+	}
+	if result.ReleaseDate != "" {
+		upd.ReleaseDate = &result.ReleaseDate
+	}
+	if len(result.Genres) > 0 {
+		genres := append([]string(nil), result.Genres...)
+		upd.Genres = &genres
+	}
+	if len(result.Studios) > 0 {
+		studios := append([]string(nil), result.Studios...)
+		upd.Studios = &studios
+	}
+	if result.ContentRating != "" {
+		upd.ContentRating = &result.ContentRating
+	}
+	if result.Runtime > 0 {
+		upd.Runtime = &result.Runtime
+	}
+	if result.Year > 0 {
+		upd.Year = &result.Year
+	}
+
+	if e.providerIDs != nil && len(providerIDs) > 0 {
+		if err := e.providerIDs.ReplaceByContentID(ctx, contentID, providerIDs); err != nil {
+			slog.Warn("ebook enrichment: failed to persist provider IDs",
+				"content_id", contentID,
+				"error", err,
+			)
+		}
+	}
+
+	if err := e.updateMetadataAndTimestamps(ctx, contentID, upd); err != nil {
+		return err
+	}
+
+	authors := filterEbookPeople(result.People)
+	if len(authors) > 0 && e.personRepo != nil && e.itemRepo != nil {
+		if err := e.persistPeople(ctx, contentID, authors); err != nil {
+			slog.Warn("ebook enrichment: failed to persist people",
+				"content_id", contentID,
+				"error", err,
+			)
+		}
+	}
+
+	return nil
+}
+
+func (e *Enricher) updateMetadataAndTimestamps(ctx context.Context, contentID string, upd *catalog.MetadataUpdate) error {
+	if e.itemRepo == nil {
+		return nil
+	}
+	if err := e.itemRepo.UpdateMetadata(ctx, contentID, upd); err != nil {
+		return fmt.Errorf("UpdateMetadata: %w", err)
+	}
+	return e.stampLastRefreshed(ctx, contentID)
+}
+
+func (e *Enricher) stampLastRefreshed(ctx context.Context, contentID string) error {
+	if e.pool == nil {
+		return nil
+	}
+	now := time.Now().UTC()
+	_, err := e.pool.Exec(ctx, `
+		UPDATE media_items
+		SET last_refreshed = $1,
+		    matched_at = COALESCE(matched_at, $1),
+		    status = CASE WHEN status = 'pending' THEN 'matched' ELSE status END
+		WHERE content_id = $2
+	`, now, contentID)
+	return err
+}
+
+func (e *Enricher) persistPeople(ctx context.Context, contentID string, people []models.ItemPerson) error {
+	people = filterEbookPeople(people)
+	if len(people) == 0 {
+		return nil
+	}
+
+	persons := make([]models.Person, len(people))
+	for i := range people {
+		persons[i] = people[i].Person
+	}
+
+	personIDs, err := e.personRepo.BatchFindOrCreate(ctx, persons)
+	if err != nil {
+		return fmt.Errorf("BatchFindOrCreate people: %w", err)
+	}
+
+	linked := make([]models.ItemPerson, 0, len(people))
+	for i := range people {
+		if i >= len(personIDs) || personIDs[i] == 0 {
+			continue
+		}
+		ip := people[i]
+		ip.Person.ID = personIDs[i]
+		linked = append(linked, ip)
+	}
+
+	if len(linked) == 0 {
+		return nil
+	}
+	return e.itemRepo.ReplacePeople(ctx, contentID, linked)
+}
+
+func filterEbookPeople(people []models.ItemPerson) []models.ItemPerson {
+	authors := make([]models.ItemPerson, 0, len(people))
+	for _, person := range people {
+		if person.Kind != models.PersonKindAuthor {
+			continue
+		}
+		person.SortOrder = len(authors)
+		authors = append(authors, person)
+	}
+	return authors
+}
+
+func mergeEnrichmentProviderIDs(dst *metadata.MetadataResult, src *metadata.MetadataResult) {
+	if src == nil || len(src.ProviderIDs) == 0 {
+		return
+	}
+	if dst.ProviderIDs == nil {
+		dst.ProviderIDs = make(map[string]string, len(src.ProviderIDs))
+	}
+	for k, v := range src.ProviderIDs {
+		if v != "" {
+			if _, exists := dst.ProviderIDs[k]; !exists {
+				dst.ProviderIDs[k] = v
+			}
+		}
+	}
+}
+
+func providerIDMapFromRows(rows []*models.MediaItemProviderID) map[string]string {
+	if len(rows) == 0 {
+		return nil
+	}
+	m := make(map[string]string, len(rows))
+	for _, r := range rows {
+		if r != nil && strings.TrimSpace(r.Provider) != "" && strings.TrimSpace(r.ProviderID) != "" {
+			m[strings.TrimSpace(r.Provider)] = strings.TrimSpace(r.ProviderID)
+		}
+	}
+	return m
+}

--- a/internal/ebooks/enrichment.go
+++ b/internal/ebooks/enrichment.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 	"log/slog"
 	"os"
+	"reflect"
 	"strconv"
 	"strings"
 	"sync"
@@ -370,7 +371,7 @@ func (e *Enricher) cacheRemotePoster(ctx context.Context, contentID string, resu
 	if !strings.HasPrefix(result.PosterPath, "http://") && !strings.HasPrefix(result.PosterPath, "https://") {
 		return
 	}
-	if e.imageCacher == nil {
+	if isNilImageCacher(e.imageCacher) {
 		return
 	}
 
@@ -389,12 +390,32 @@ func (e *Enricher) cacheRemotePoster(ctx context.Context, contentID string, resu
 		)
 		return
 	}
+	if cached == nil {
+		slog.Warn("ebook enrichment: poster cache returned no result, keeping provider URL",
+			"content_id", contentID,
+			"url", result.PosterPath,
+		)
+		return
+	}
 
 	if storedPath := cachedOriginalImagePath(cached.BasePath, cached.Ext); storedPath != "" {
 		result.PosterPath = storedPath
 	}
 	if cached.Thumbhash != "" {
 		result.PosterThumbhash = cached.Thumbhash
+	}
+}
+
+func isNilImageCacher(cacher metadata.ImageCacher) bool {
+	if cacher == nil {
+		return true
+	}
+	value := reflect.ValueOf(cacher)
+	switch value.Kind() {
+	case reflect.Chan, reflect.Func, reflect.Interface, reflect.Map, reflect.Ptr, reflect.Slice:
+		return value.IsNil()
+	default:
+		return false
 	}
 }
 

--- a/internal/ebooks/enrichment_test.go
+++ b/internal/ebooks/enrichment_test.go
@@ -1,0 +1,167 @@
+package ebooks
+
+import (
+	"context"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/Silo-Server/silo-server/internal/metadata"
+	"github.com/Silo-Server/silo-server/internal/models"
+)
+
+func TestEbookContentType(t *testing.T) {
+	if got := ebookContentType(); got != "ebook" {
+		t.Fatalf("ebookContentType() = %q, want ebook", got)
+	}
+}
+
+func TestFilterEbookPeopleKeepsAuthorsOnly(t *testing.T) {
+	people := []models.ItemPerson{
+		{Person: models.Person{Name: "Author One"}, Kind: models.PersonKindAuthor, SortOrder: 7},
+		{Person: models.Person{Name: "Narrator One"}, Kind: models.PersonKindNarrator, SortOrder: 8},
+		{Person: models.Person{Name: "Writer One"}, Kind: models.PersonKindWriter, SortOrder: 9},
+		{Person: models.Person{Name: "Author Two"}, Kind: models.PersonKindAuthor, SortOrder: 10},
+	}
+
+	got := filterEbookPeople(people)
+
+	if len(got) != 2 {
+		t.Fatalf("filtered people len = %d, want 2: %+v", len(got), got)
+	}
+	for i, p := range got {
+		if p.Kind != models.PersonKindAuthor {
+			t.Fatalf("filtered[%d].Kind = %v, want author", i, p.Kind)
+		}
+		if p.SortOrder != i {
+			t.Fatalf("filtered[%d].SortOrder = %d, want %d", i, p.SortOrder, i)
+		}
+	}
+	if got[0].Person.Name != "Author One" || got[1].Person.Name != "Author Two" {
+		t.Fatalf("filtered author order = %+v", got)
+	}
+}
+
+func TestEbookEnrichWorkersFromEnv(t *testing.T) {
+	t.Setenv("SILO_EBOOK_ENRICH_WORKERS", "12")
+	if got := ebookEnrichWorkers(); got != 12 {
+		t.Fatalf("ebookEnrichWorkers() = %d, want 12", got)
+	}
+
+	t.Setenv("SILO_EBOOK_ENRICH_WORKERS", "0")
+	if got := ebookEnrichWorkers(); got != defaultEnrichWorkers {
+		t.Fatalf("ebookEnrichWorkers() with zero = %d, want default %d", got, defaultEnrichWorkers)
+	}
+
+	t.Setenv("SILO_EBOOK_ENRICH_WORKERS", "999")
+	if got := ebookEnrichWorkers(); got != defaultEnrichBatchSize {
+		t.Fatalf("ebookEnrichWorkers() capped = %d, want %d", got, defaultEnrichBatchSize)
+	}
+}
+
+func TestEnricherRunFansOut(t *testing.T) {
+	const wantWorkers = 4
+	const itemCount = 16
+
+	items := make([]enrichmentItemRow, itemCount)
+	for i := range items {
+		items[i] = enrichmentItemRow{ContentID: "test", Title: "t"}
+	}
+
+	var inFlight int32
+	var maxInFlight int32
+	var signaled int32
+	var wg sync.WaitGroup
+	wg.Add(wantWorkers)
+	gate := make(chan struct{})
+
+	enrich := func(ctx context.Context, item enrichmentItemRow) error {
+		cur := atomic.AddInt32(&inFlight, 1)
+		defer atomic.AddInt32(&inFlight, -1)
+		for {
+			prev := atomic.LoadInt32(&maxInFlight)
+			if cur <= prev || atomic.CompareAndSwapInt32(&maxInFlight, prev, cur) {
+				break
+			}
+		}
+		if atomic.AddInt32(&signaled, 1) <= wantWorkers {
+			wg.Done()
+		}
+		select {
+		case <-gate:
+		case <-time.After(2 * time.Second):
+		}
+		return nil
+	}
+
+	go func() {
+		wg.Wait()
+		close(gate)
+	}()
+
+	e := &Enricher{workers: wantWorkers, batchSize: itemCount}
+	e.runBatch(context.Background(), items, enrich)
+
+	if got := atomic.LoadInt32(&maxInFlight); got < wantWorkers {
+		t.Errorf("max in-flight = %d, want >= %d", got, wantWorkers)
+	}
+}
+
+func TestCacheRemotePosterCachesProviderURL(t *testing.T) {
+	cacher := &fakeEbookImageCacher{}
+	e := &Enricher{imageCacher: cacher}
+	result := &metadata.MetadataResult{
+		PosterPath: "https://example.test/book.jpg",
+	}
+
+	e.cacheRemotePoster(context.Background(), "content-1", result)
+
+	if cacher.calls != 1 {
+		t.Fatalf("CacheImage calls = %d, want 1", cacher.calls)
+	}
+	if cacher.req.ProviderID != ebookMetadataImageProviderID {
+		t.Fatalf("ProviderID = %q, want %q", cacher.req.ProviderID, ebookMetadataImageProviderID)
+	}
+	if cacher.req.ContentType != "ebooks" || cacher.req.ContentID != "content-1" {
+		t.Fatalf("cache target = %q/%q", cacher.req.ContentType, cacher.req.ContentID)
+	}
+	if result.PosterPath != "ebook-metadata/ebooks/content-1/poster/original.webp" {
+		t.Fatalf("PosterPath = %q", result.PosterPath)
+	}
+	if result.PosterThumbhash != "thumb" {
+		t.Fatalf("PosterThumbhash = %q", result.PosterThumbhash)
+	}
+}
+
+func TestMergeEnrichmentProviderIDsKeepsExistingIDs(t *testing.T) {
+	dst := &metadata.MetadataResult{ProviderIDs: map[string]string{"isbn": "9780306406157"}}
+	src := &metadata.MetadataResult{ProviderIDs: map[string]string{"isbn": "new", "openlibrary": "OL1M", "empty": ""}}
+
+	mergeEnrichmentProviderIDs(dst, src)
+
+	if got := dst.ProviderIDs["isbn"]; got != "9780306406157" {
+		t.Fatalf("isbn = %q, want original", got)
+	}
+	if got := dst.ProviderIDs["openlibrary"]; got != "OL1M" {
+		t.Fatalf("openlibrary = %q, want OL1M", got)
+	}
+	if _, exists := dst.ProviderIDs["empty"]; exists {
+		t.Fatal("empty provider ID should not be merged")
+	}
+}
+
+type fakeEbookImageCacher struct {
+	calls int
+	req   metadata.CacheImageRequest
+}
+
+func (f *fakeEbookImageCacher) CacheImage(_ context.Context, req metadata.CacheImageRequest) (*metadata.CacheImageResult, error) {
+	f.calls++
+	f.req = req
+	return &metadata.CacheImageResult{
+		BasePath:  req.ProviderID + "/" + req.ContentType + "/" + req.ContentID + "/poster",
+		Thumbhash: "thumb",
+		Ext:       ".webp",
+	}, nil
+}

--- a/internal/ebooks/enrichment_test.go
+++ b/internal/ebooks/enrichment_test.go
@@ -2,6 +2,7 @@ package ebooks
 
 import (
 	"context"
+	"errors"
 	"sync"
 	"sync/atomic"
 	"testing"
@@ -134,6 +135,84 @@ func TestCacheRemotePosterCachesProviderURL(t *testing.T) {
 	}
 }
 
+func TestCacheRemotePosterSkipsNilCacher(t *testing.T) {
+	e := &Enricher{}
+	result := &metadata.MetadataResult{
+		PosterPath: "https://example.test/book.jpg",
+	}
+
+	e.cacheRemotePoster(context.Background(), "content-1", result)
+
+	if result.PosterPath != "https://example.test/book.jpg" {
+		t.Fatalf("PosterPath = %q, want provider URL preserved", result.PosterPath)
+	}
+}
+
+func TestCacheRemotePosterSkipsTypedNilCacher(t *testing.T) {
+	var cacher *fakeEbookImageCacher
+	e := &Enricher{imageCacher: cacher}
+	result := &metadata.MetadataResult{
+		PosterPath: "https://example.test/book.jpg",
+	}
+
+	e.cacheRemotePoster(context.Background(), "content-1", result)
+
+	if result.PosterPath != "https://example.test/book.jpg" {
+		t.Fatalf("PosterPath = %q, want provider URL preserved", result.PosterPath)
+	}
+}
+
+func TestCacheRemotePosterSkipsAlreadyCachedPath(t *testing.T) {
+	cacher := &fakeEbookImageCacher{}
+	e := &Enricher{imageCacher: cacher}
+	result := &metadata.MetadataResult{
+		PosterPath: "local/ebooks/content-1/poster/original.webp",
+	}
+
+	e.cacheRemotePoster(context.Background(), "content-1", result)
+
+	if cacher.calls != 0 {
+		t.Fatalf("CacheImage calls = %d, want 0", cacher.calls)
+	}
+	if result.PosterPath != "local/ebooks/content-1/poster/original.webp" {
+		t.Fatalf("PosterPath = %q", result.PosterPath)
+	}
+}
+
+func TestCacheRemotePosterPreservesProviderURLOnCacheError(t *testing.T) {
+	cacher := &fakeEbookImageCacher{err: errors.New("cache failed")}
+	e := &Enricher{imageCacher: cacher}
+	result := &metadata.MetadataResult{
+		PosterPath: "https://example.test/book.jpg",
+	}
+
+	e.cacheRemotePoster(context.Background(), "content-1", result)
+
+	if cacher.calls != 1 {
+		t.Fatalf("CacheImage calls = %d, want 1", cacher.calls)
+	}
+	if result.PosterPath != "https://example.test/book.jpg" {
+		t.Fatalf("PosterPath = %q, want provider URL preserved", result.PosterPath)
+	}
+}
+
+func TestCacheRemotePosterPreservesProviderURLOnNilCacheResult(t *testing.T) {
+	cacher := &fakeEbookImageCacher{returnNil: true}
+	e := &Enricher{imageCacher: cacher}
+	result := &metadata.MetadataResult{
+		PosterPath: "https://example.test/book.jpg",
+	}
+
+	e.cacheRemotePoster(context.Background(), "content-1", result)
+
+	if cacher.calls != 1 {
+		t.Fatalf("CacheImage calls = %d, want 1", cacher.calls)
+	}
+	if result.PosterPath != "https://example.test/book.jpg" {
+		t.Fatalf("PosterPath = %q, want provider URL preserved", result.PosterPath)
+	}
+}
+
 func TestMergeEnrichmentProviderIDsKeepsExistingIDs(t *testing.T) {
 	dst := &metadata.MetadataResult{ProviderIDs: map[string]string{"isbn": "9780306406157"}}
 	src := &metadata.MetadataResult{ProviderIDs: map[string]string{"isbn": "new", "openlibrary": "OL1M", "empty": ""}}
@@ -152,13 +231,21 @@ func TestMergeEnrichmentProviderIDsKeepsExistingIDs(t *testing.T) {
 }
 
 type fakeEbookImageCacher struct {
-	calls int
-	req   metadata.CacheImageRequest
+	calls     int
+	req       metadata.CacheImageRequest
+	err       error
+	returnNil bool
 }
 
 func (f *fakeEbookImageCacher) CacheImage(_ context.Context, req metadata.CacheImageRequest) (*metadata.CacheImageResult, error) {
 	f.calls++
 	f.req = req
+	if f.err != nil {
+		return nil, f.err
+	}
+	if f.returnNil {
+		return nil, nil
+	}
 	return &metadata.CacheImageResult{
 		BasePath:  req.ProviderID + "/" + req.ContentType + "/" + req.ContentID + "/poster",
 		Thumbhash: "thumb",

--- a/internal/taskmanager/tasks/sync_ebook_metadata.go
+++ b/internal/taskmanager/tasks/sync_ebook_metadata.go
@@ -1,0 +1,56 @@
+package tasks
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+
+	"github.com/Silo-Server/silo-server/internal/taskmanager"
+)
+
+type ebookMetadataEnricher interface {
+	Run(ctx context.Context) (int, error)
+}
+
+// SyncEbookMetadataTask runs the periodic ebook enrichment sweep.
+// It calls ebooks.Enricher.Run() which selects unenriched ebook media_items,
+// resolves the per-folder metadata-provider chain at content_level='ebook',
+// and writes results back to the database.
+type SyncEbookMetadataTask struct {
+	enricher ebookMetadataEnricher
+}
+
+// NewSyncEbookMetadataTask constructs the task.
+func NewSyncEbookMetadataTask(enricher ebookMetadataEnricher) *SyncEbookMetadataTask {
+	return &SyncEbookMetadataTask{enricher: enricher}
+}
+
+func (t *SyncEbookMetadataTask) Key() string  { return "sync_ebook_metadata" }
+func (t *SyncEbookMetadataTask) Name() string { return "Sync Ebook Metadata" }
+func (t *SyncEbookMetadataTask) Description() string {
+	return "Fetches metadata (cover art, overview, authors) for ebooks that have not yet been enriched"
+}
+func (t *SyncEbookMetadataTask) Category() taskmanager.TaskCategory {
+	return taskmanager.TaskCategoryMetadata
+}
+func (t *SyncEbookMetadataTask) IsHidden() bool { return false }
+
+func (t *SyncEbookMetadataTask) DefaultTriggers() []taskmanager.TriggerConfig {
+	return []taskmanager.TriggerConfig{
+		{Type: taskmanager.TriggerTypeInterval, IntervalMs: 5 * 60 * 1000},
+	}
+}
+
+func (t *SyncEbookMetadataTask) Execute(ctx context.Context, progress taskmanager.ProgressReporter) error {
+	progress.Report(0, "Scanning for unenriched ebooks")
+
+	enriched, err := t.enricher.Run(ctx)
+	if err != nil {
+		return fmt.Errorf("ebook metadata sync: %w", err)
+	}
+
+	result, _ := json.Marshal(map[string]int{"items_enriched": enriched})
+	progress.SetResultData(result)
+	progress.Report(100, fmt.Sprintf("Ebook metadata sync complete (%d items enriched)", enriched))
+	return nil
+}

--- a/internal/taskmanager/tasks/sync_ebook_metadata_test.go
+++ b/internal/taskmanager/tasks/sync_ebook_metadata_test.go
@@ -1,0 +1,92 @@
+package tasks
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/Silo-Server/silo-server/internal/taskmanager"
+)
+
+type fakeEbookMetadataEnricher struct {
+	enriched int
+	err      error
+	called   bool
+}
+
+func (f *fakeEbookMetadataEnricher) Run(context.Context) (int, error) {
+	f.called = true
+	return f.enriched, f.err
+}
+
+type ebookMetadataProgressReporter struct {
+	messages []string
+	result   json.RawMessage
+}
+
+func (p *ebookMetadataProgressReporter) Report(_ float64, message string) {
+	p.messages = append(p.messages, message)
+}
+
+func (p *ebookMetadataProgressReporter) SetResultData(data json.RawMessage) {
+	p.result = data
+}
+
+func TestSyncEbookMetadataTaskProperties(t *testing.T) {
+	task := NewSyncEbookMetadataTask(&fakeEbookMetadataEnricher{})
+
+	if task.Key() != "sync_ebook_metadata" {
+		t.Fatalf("Key() = %q, want sync_ebook_metadata", task.Key())
+	}
+	if task.Name() != "Sync Ebook Metadata" {
+		t.Fatalf("Name() = %q, want Sync Ebook Metadata", task.Name())
+	}
+	if task.Category() != taskmanager.TaskCategoryMetadata {
+		t.Fatalf("Category() = %q, want %q", task.Category(), taskmanager.TaskCategoryMetadata)
+	}
+	if task.IsHidden() {
+		t.Fatal("IsHidden() = true, want false")
+	}
+	triggers := task.DefaultTriggers()
+	if len(triggers) != 1 || triggers[0].Type != taskmanager.TriggerTypeInterval || triggers[0].IntervalMs != 5*60*1000 {
+		t.Fatalf("DefaultTriggers() = %#v, want one 5 minute interval", triggers)
+	}
+	if strings.Contains(strings.ToLower(task.Description()), "narrator") {
+		t.Fatalf("Description() mentions narrator: %q", task.Description())
+	}
+}
+
+func TestSyncEbookMetadataTaskExecuteReportsResult(t *testing.T) {
+	enricher := &fakeEbookMetadataEnricher{enriched: 3}
+	task := NewSyncEbookMetadataTask(enricher)
+	progress := &ebookMetadataProgressReporter{}
+
+	if err := task.Execute(context.Background(), progress); err != nil {
+		t.Fatalf("Execute() error = %v", err)
+	}
+	if !enricher.called {
+		t.Fatal("enricher was not called")
+	}
+	var result map[string]int
+	if err := json.Unmarshal(progress.result, &result); err != nil {
+		t.Fatalf("result data JSON error: %v", err)
+	}
+	if result["items_enriched"] != 3 {
+		t.Fatalf("items_enriched = %d, want 3", result["items_enriched"])
+	}
+	if len(progress.messages) == 0 || !strings.Contains(progress.messages[len(progress.messages)-1], "3 items enriched") {
+		t.Fatalf("progress messages = %#v, want completion count", progress.messages)
+	}
+}
+
+func TestSyncEbookMetadataTaskExecuteWrapsError(t *testing.T) {
+	enricher := &fakeEbookMetadataEnricher{err: errors.New("boom")}
+	task := NewSyncEbookMetadataTask(enricher)
+
+	err := task.Execute(context.Background(), &ebookMetadataProgressReporter{})
+	if err == nil || !strings.Contains(err.Error(), "ebook metadata sync") {
+		t.Fatalf("Execute() error = %v, want wrapped ebook metadata sync error", err)
+	}
+}

--- a/web/src/components/admin/libraries/LibraryForm.test.tsx
+++ b/web/src/components/admin/libraries/LibraryForm.test.tsx
@@ -1,0 +1,21 @@
+import { describe, expect, it } from "vitest";
+
+import { contentLevelsForType } from "./LibraryForm";
+
+describe("contentLevelsForType", () => {
+  it("maps ebook libraries to the ebook metadata content level", () => {
+    expect(contentLevelsForType("ebooks")).toEqual(["ebook"]);
+    expect(contentLevelsForType("ebook")).toEqual(["ebook"]);
+  });
+
+  it("includes ebook metadata providers for mixed libraries", () => {
+    expect(contentLevelsForType("mixed")).toEqual([
+      "movie",
+      "series",
+      "season",
+      "episode",
+      "audiobook",
+      "ebook",
+    ]);
+  });
+});

--- a/web/src/components/admin/libraries/LibraryForm.tsx
+++ b/web/src/components/admin/libraries/LibraryForm.tsx
@@ -59,16 +59,19 @@ export interface LibraryFormProps {
   extraContent?: ReactNode;
 }
 
-function contentLevelsForType(libraryType: string): string[] {
+export function contentLevelsForType(libraryType: string): string[] {
   switch (libraryType) {
     case "series":
       return ["series", "season", "episode"];
     case "movies":
       return ["movie"];
     case "mixed":
-      return ["movie", "series", "season", "episode"];
+      return ["movie", "series", "season", "episode", "audiobook", "ebook"];
     case "audiobooks":
       return ["audiobook"];
+    case "ebooks":
+    case "ebook":
+      return ["ebook"];
     case "podcasts":
       return ["podcast", "podcast_episode"];
     default:
@@ -474,6 +477,7 @@ export function LibraryForm({
               <SelectItem value="series">Series</SelectItem>
               <SelectItem value="mixed">Mixed</SelectItem>
               <SelectItem value="audiobooks">Audiobooks</SelectItem>
+              <SelectItem value="ebooks">Ebooks</SelectItem>
               <SelectItem value="podcasts">Podcasts</SelectItem>
             </SelectContent>
           </Select>


### PR DESCRIPTION
## Summary
- Add the core ebook metadata enricher package, mirroring the audiobook enrichment path while using ebook content-level metadata lookup.
- Persist provider identifiers and author-only people credits for ebook metadata results.
- Register the scheduled ebook metadata sync task and wire it through `cmd/silo/main.go` with the shared plugin chain/resolver and image cacher.
- Expose `ebooks` as an admin library type and seed/default metadata chains with the `ebook` content level.

## Test Plan
- [x] go test ./internal/ebooks -count=1
- [x] go test ./internal/taskmanager/tasks -run 'TestSyncEbookMetadataTask' -count=1
- [x] go test ./internal/taskmanager/tasks ./internal/ebooks -count=1
- [x] go test ./internal/scanner ./internal/ebooks ./internal/taskmanager/tasks -count=1
- [x] go test ./internal/api/handlers ./internal/scanner ./internal/ebooks ./internal/taskmanager/tasks -count=1
- [x] pnpm --dir web exec tsc -p tsconfig.json --noEmit
- [x] pnpm --dir web test src/components/admin/libraries/LibraryForm.test.tsx
- [x] rg -n "ebook_details|silo-plugin-ebooks|PersonKindNarrator|asin" internal/scanner/ebook.go internal/scanner/ebook_scan.go internal/ebooks/enrichment.go -S
- [ ] go test ./internal/catalog ./internal/metadata ./cmd/silo -count=1 (blocked locally by existing/baseline issues: `cmd/silo` cannot compile because `web/embed.go:5:12: pattern all:dist: no matching files found`; `internal/catalog` fails `TestLateOrphanCleanupUsesProvisionalSafetyPredicate`; `internal/metadata` passes)

## Stack
- Stacked on #81 (`work/ebooks-foundation-main`) so this PR contains ebook metadata enrichment, scheduled task wiring, and admin library metadata-chain setup only.
