### PR TITLE
Add ebook catalog, detail, and download support

### DIFF
--- a/internal/catalog/browse.go
+++ b/internal/catalog/browse.go
@@ -759,9 +759,9 @@ func listDistinctPeopleByKindWithSource(
 }
 
 // listDistinctAudiobookSeriesWithSource returns distinct series_name values
-// from audiobook_series joined onto the scoped result set. Names are trimmed
+// from the active book series table joined onto the scoped result set. Names are trimmed
 // and case-folded for sort so the picker doesn't show duplicates that differ
-// only by whitespace or casing — the literal trimmed series_name is still
+// only by whitespace or casing; the literal trimmed series_name is still
 // returned so existing rules continue to match.
 //
 // The DISTINCT happens in an inline subquery (rather than directly on the
@@ -783,14 +783,14 @@ func listDistinctAudiobookSeriesWithSource(
 		SELECT name FROM (
 			SELECT DISTINCT BTRIM(s.series_name) AS name
 			FROM %s
-			JOIN audiobook_series s ON s.content_id = mi.content_id
+			JOIN %s s ON s.content_id = mi.content_id
 			%s
 			  AND s.series_name IS NOT NULL
 			  AND BTRIM(s.series_name) <> ''
 		) names
 		ORDER BY LOWER(name) ASC
 		LIMIT %d
-	`, fromClause, browseFilterPrefix(whereClause), catalogFacetMaxValues)
+	`, fromClause, bookSeriesTableForMediaScope(mediaScope), browseFilterPrefix(whereClause), catalogFacetMaxValues)
 	return queryDistinctStrings(ctx, pool, query, args)
 }
 
@@ -946,7 +946,7 @@ func searchDistinctAudiobookSeriesWithSource(
 		SELECT name FROM (
 			SELECT DISTINCT BTRIM(s.series_name) AS name
 			FROM %s
-			JOIN audiobook_series s ON s.content_id = mi.content_id
+			JOIN %s s ON s.content_id = mi.content_id
 			%s
 			  AND s.series_name IS NOT NULL
 			  AND BTRIM(s.series_name) <> ''
@@ -954,8 +954,15 @@ func searchDistinctAudiobookSeriesWithSource(
 		) names
 		ORDER BY LOWER(name) ASC
 		LIMIT %d
-	`, fromClause, browseFilterPrefix(whereClause), prefixIdx, limit+1)
+	`, fromClause, bookSeriesTableForMediaScope(mediaScope), browseFilterPrefix(whereClause), prefixIdx, limit+1)
 	return queryFacetSearchResults(ctx, pool, query, args, limit)
+}
+
+func bookSeriesTableForMediaScope(mediaScope string) string {
+	if mediaScope == "ebook" {
+		return "ebook_series"
+	}
+	return "audiobook_series"
 }
 
 // queryFacetSearchResults executes a facet search query that was built

--- a/internal/catalog/catalog_parser.go
+++ b/internal/catalog/catalog_parser.go
@@ -390,7 +390,7 @@ func normalizeCatalogMatch(raw string) string {
 
 func parseCatalogMediaScope(raw string) string {
 	switch strings.ToLower(strings.TrimSpace(raw)) {
-	case "movie", "series", "episode", "audiobook":
+	case "movie", "series", "episode", "audiobook", "ebook":
 		return strings.ToLower(strings.TrimSpace(raw))
 	default:
 		return ""

--- a/internal/catalog/catalog_parser_test.go
+++ b/internal/catalog/catalog_parser_test.go
@@ -1,0 +1,9 @@
+package catalog
+
+import "testing"
+
+func TestParseCatalogMediaScope_AllowsEbook(t *testing.T) {
+	if got := parseCatalogMediaScope(" ebook "); got != "ebook" {
+		t.Fatalf("expected ebook media scope, got %q", got)
+	}
+}

--- a/internal/catalog/catalog_resolver.go
+++ b/internal/catalog/catalog_resolver.go
@@ -39,10 +39,9 @@ type CatalogFiltersResult struct {
 	Resolutions       []string
 	AudioLanguages    []string
 	SubtitleLanguages []string
-	// Authors, Narrators and Series are audiobook-native facets. Populated
-	// whenever the scope contains audiobook items; empty for video-only
-	// scopes. They share the item_people / audiobook_series tables so
-	// callers don't need to switch on media type.
+	// Authors, Narrators and Series are book-native facets. Authors and
+	// Narrators use item_people; Series uses the active book series table.
+	// Video-only scopes return these empty.
 	Authors   []string
 	Narrators []string
 	Series    []string
@@ -64,8 +63,8 @@ type facetFetcher interface {
 	// PeopleByKind returns distinct people names for the given PersonKind
 	// across the scoped result set. Used for Authors / Narrators facets.
 	PeopleByKind(ctx context.Context, kind models.PersonKind, filters BrowseFilters, baseRelation string, mediaScope string) ([]string, error)
-	// AudiobookSeries returns distinct series_name values from
-	// audiobook_series joined onto the scoped result set.
+	// AudiobookSeries returns distinct series_name values from the active
+	// book series table joined onto the scoped result set.
 	AudiobookSeries(ctx context.Context, filters BrowseFilters, baseRelation string, mediaScope string) ([]string, error)
 	// SearchDistinctArrayColumn prefix-searches an array-column facet
 	// (genres, studios, networks, countries). Returns up to limit
@@ -1090,8 +1089,9 @@ func validateCatalogOverlayQuery(searchQuery string, def QueryDefinition, ruleFi
 		def.MediaScope != "movie" &&
 		def.MediaScope != "series" &&
 		def.MediaScope != "episode" &&
-		def.MediaScope != "audiobook" {
-		return fmt.Errorf("%w: media_scope must be 'movie', 'series', 'episode', or 'audiobook'", ErrInvalidCatalogRequest)
+		def.MediaScope != "audiobook" &&
+		def.MediaScope != "ebook" {
+		return fmt.Errorf("%w: media_scope must be 'movie', 'series', 'episode', 'audiobook', or 'ebook'", ErrInvalidCatalogRequest)
 	}
 	if def.Match != "" && def.Match != "all" && def.Match != "any" {
 		return fmt.Errorf("%w: match must be 'all' or 'any'", ErrInvalidCatalogRequest)

--- a/internal/catalog/catalog_resolver_test.go
+++ b/internal/catalog/catalog_resolver_test.go
@@ -39,6 +39,21 @@ func TestValidateCatalogQueryRequest_AllowsEpisodeMediaScope(t *testing.T) {
 	}
 }
 
+func TestValidateCatalogQueryRequest_AllowsEbookMediaScope(t *testing.T) {
+	req := CatalogRequest{
+		Source: CatalogSourceQuery,
+		Query: QueryDefinition{
+			MediaScope: "ebook",
+			Match:      "all",
+			Sort:       QuerySort{Field: "title", Order: "asc"},
+		},
+	}
+
+	if err := validateCatalogQueryRequest(req, true); err != nil {
+		t.Fatalf("expected ebook media scope to be accepted, got %v", err)
+	}
+}
+
 func TestValidateCatalogQueryRequest_AllowsAddedAtFilter(t *testing.T) {
 	req := CatalogRequest{
 		Source: CatalogSourceQuery,

--- a/internal/catalog/query_builder.go
+++ b/internal/catalog/query_builder.go
@@ -298,7 +298,8 @@ func (qb *QueryBuilder) BuildSortPlan(sortConfig QuerySort) (QuerySortPlan, erro
 		return plan, nil
 	case "series":
 		plan.Joins = []string{fmt.Sprintf(
-			"LEFT JOIN audiobook_series sort_series ON sort_series.content_id = %s.content_id",
+			"LEFT JOIN %s sort_series ON sort_series.content_id = %s.content_id",
+			qb.bookSeriesTable(),
 			qb.alias,
 		)}
 		// Sort by series name primarily, then by series_index so books
@@ -385,7 +386,7 @@ func (qb *QueryBuilder) buildRule(rule QueryRule) (string, error) {
 	case "narrator":
 		return qb.buildPersonClause(models.PersonKindNarrator, rule)
 	case "series":
-		return qb.buildAudiobookSeriesClause(rule)
+		return qb.buildBookSeriesClause(rule)
 	case "watched":
 		return qb.buildWatchedClause(rule)
 	case "favorited":
@@ -502,14 +503,21 @@ func (qb *QueryBuilder) personKindSortJoin(kind models.PersonKind, alias string)
 	)
 }
 
-func (qb *QueryBuilder) buildAudiobookSeriesClause(rule QueryRule) (string, error) {
+func (qb *QueryBuilder) bookSeriesTable() string {
+	if qb.mediaScope == "ebook" {
+		return "ebook_series"
+	}
+	return "audiobook_series"
+}
+
+func (qb *QueryBuilder) buildBookSeriesClause(rule QueryRule) (string, error) {
 	qb.args = append(qb.args, rule.Value)
 	clause := fmt.Sprintf(`EXISTS (
 		SELECT 1
-		FROM audiobook_series s
+		FROM %s s
 		WHERE s.content_id = %s.content_id
 		  AND LOWER(BTRIM(s.series_name)) = LOWER(BTRIM($%d))
-	)`, qb.alias, qb.argIdx)
+)`, qb.bookSeriesTable(), qb.alias, qb.argIdx)
 	qb.argIdx++
 	if rule.Op == "is_not" {
 		return "NOT (" + clause + ")", nil

--- a/internal/catalog/query_builder_test.go
+++ b/internal/catalog/query_builder_test.go
@@ -531,6 +531,26 @@ func TestBuild_SeriesClauseJoinsAudiobookSeries(t *testing.T) {
 	}
 }
 
+func TestBuild_SeriesClauseJoinsEbookSeriesForEbookScope(t *testing.T) {
+	clause, args, err := NewQueryBuilder("mi").
+		WithMediaScope("ebook").
+		Build(QueryDefinition{
+			Match: "all",
+			Groups: []QueryGroup{
+				{Match: "all", Rules: []QueryRule{{Field: "series", Op: "is", Value: "Wayfarers"}}},
+			},
+		})
+	if err != nil {
+		t.Fatalf("Build returned error: %v", err)
+	}
+	if len(args) != 1 || args[0] != "Wayfarers" {
+		t.Fatalf("expected series arg, got %v", args)
+	}
+	if !strings.Contains(clause, "FROM ebook_series s") {
+		t.Fatalf("expected ebook_series join in series clause, got %q", clause)
+	}
+}
+
 func TestBuildSortPlan_AuthorJoinsLateralOnPersonKindAuthor(t *testing.T) {
 	plan, err := NewQueryBuilder("mi").BuildSortPlan(QuerySort{Field: "author", Order: "asc"})
 	if err != nil {
@@ -573,6 +593,18 @@ func TestBuildSortPlan_SeriesOrdersByNameThenIndex(t *testing.T) {
 	if !strings.Contains(plan.OrderBy, "sort_series.series_name ASC NULLS LAST") ||
 		!strings.Contains(plan.OrderBy, "sort_series.series_index ASC NULLS LAST") {
 		t.Fatalf("expected name+index ordering with NULLS LAST, got %q", plan.OrderBy)
+	}
+}
+
+func TestBuildSortPlan_SeriesUsesEbookSeriesForEbookScope(t *testing.T) {
+	plan, err := NewQueryBuilder("mi").
+		WithMediaScope("ebook").
+		BuildSortPlan(QuerySort{Field: "series", Order: "asc"})
+	if err != nil {
+		t.Fatalf("BuildSortPlan(series) returned error: %v", err)
+	}
+	if len(plan.Joins) != 1 || !strings.Contains(plan.Joins[0], "ebook_series sort_series") {
+		t.Fatalf("expected LEFT JOIN ebook_series, got %v", plan.Joins)
 	}
 }
 

--- a/internal/catalog/query_definition.go
+++ b/internal/catalog/query_definition.go
@@ -186,8 +186,9 @@ func (q QueryDefinition) ValidateWithOptions(allowPersonalizedSorts, allowPerson
 		normalized.MediaScope != "movie" &&
 		normalized.MediaScope != "series" &&
 		normalized.MediaScope != "episode" &&
-		normalized.MediaScope != "audiobook" {
-		return fmt.Errorf("media_scope must be 'movie', 'series', 'episode', or 'audiobook'")
+		normalized.MediaScope != "audiobook" &&
+		normalized.MediaScope != "ebook" {
+		return fmt.Errorf("media_scope must be 'movie', 'series', 'episode', 'audiobook', or 'ebook'")
 	}
 
 	if normalized.Match != "all" && normalized.Match != "any" {

--- a/internal/catalog/query_definition_test.go
+++ b/internal/catalog/query_definition_test.go
@@ -72,6 +72,18 @@ func TestValidate_AudiobookMediaScope(t *testing.T) {
 	}
 }
 
+func TestValidate_EbookMediaScope(t *testing.T) {
+	qd := QueryDefinition{
+		MediaScope: "ebook",
+		Match:      "all",
+		Groups:     []QueryGroup{},
+		Sort:       QuerySort{Field: "title", Order: "asc"},
+	}
+	if err := qd.Validate(); err != nil {
+		t.Fatalf("expected ebook media scope to be valid, got %v", err)
+	}
+}
+
 func TestValidateWithSortScope_RejectsPersonalizedSortWithoutProfileScope(t *testing.T) {
 	qd := QueryDefinition{
 		Match:  "all",

--- a/web/src/api/types.ts
+++ b/web/src/api/types.ts
@@ -648,7 +648,7 @@ export interface BrowseItemSortMetrics {
 
 export interface BrowseItem {
   content_id: string;
-  type: "movie" | "series" | "season" | "episode" | "audiobook";
+  type: "movie" | "series" | "season" | "episode" | "audiobook" | "ebook";
   title: string;
   series_title?: string;
   season_number?: number | null;
@@ -917,7 +917,7 @@ export type SetMarkersRequest = Partial<Record<MarkerKind, MarkerSegmentInput | 
 
 export interface ItemDetail {
   content_id: string;
-  type: "movie" | "series" | "season" | "episode" | "audiobook" | "podcast";
+  type: "movie" | "series" | "season" | "episode" | "audiobook" | "ebook" | "podcast";
   status?: "pending" | "matched" | "unmatched" | "ambiguous";
 
   // Metadata (served inline from Postgres).
@@ -1170,7 +1170,7 @@ export interface QuerySort {
 
 export interface QueryDefinition {
   library_ids: number[];
-  media_scope?: "movie" | "series" | "episode" | "audiobook";
+  media_scope?: "movie" | "series" | "episode" | "audiobook" | "ebook";
   match: "all" | "any";
   groups: QueryGroup[];
   sort: QuerySort;
@@ -2948,7 +2948,7 @@ export interface SectionItemUpcomingEvent {
 
 export interface SectionItem {
   content_id: string;
-  type: "movie" | "series" | "season" | "episode" | "audiobook";
+  type: "movie" | "series" | "season" | "episode" | "audiobook" | "ebook";
   title: string;
   series_id?: string;
   series_title?: string;
@@ -3108,7 +3108,8 @@ export function normalizeQueryDefinition(value?: QueryDefinitionInput | null): Q
       value?.media_scope === "movie" ||
       value?.media_scope === "series" ||
       value?.media_scope === "episode" ||
-      value?.media_scope === "audiobook"
+      value?.media_scope === "audiobook" ||
+      value?.media_scope === "ebook"
         ? value.media_scope
         : undefined,
     match: value?.match === "any" ? "any" : "all",
@@ -3170,7 +3171,9 @@ export function queryDefinitionFromSectionConfig(
           ? "episode"
           : config.media_scope === "audiobook" || config.filter_type === "audiobook"
             ? "audiobook"
-            : undefined;
+            : config.media_scope === "ebook" || config.filter_type === "ebook"
+              ? "ebook"
+              : undefined;
 
   const legacySortField = typeof config.sort === "string" ? config.sort : undefined;
   const legacySortOrder = typeof config.order === "string" ? config.order : undefined;

--- a/web/src/components/DownloadVersionPicker.test.tsx
+++ b/web/src/components/DownloadVersionPicker.test.tsx
@@ -41,4 +41,22 @@ describe("DownloadVersionPicker", () => {
     expect(screen.getByText("Larger files require more storage space.")).toBeTruthy();
     expect(screen.queryByText("Higher quality files require more storage space.")).toBeNull();
   });
+
+  it("describes download choices as files instead of versions", () => {
+    render(
+      <DownloadVersionPicker
+        open
+        onOpenChange={() => undefined}
+        title="A Psalm for the Wild-Built"
+        versions={[version({ file_id: 1, container: "epub", file_size: 512 * 1024 })]}
+      />,
+    );
+
+    expect(
+      screen.getByText("Choose a file to download. Make sure you have enough disk space."),
+    ).toBeTruthy();
+    expect(
+      screen.queryByText("Choose a version to download. Make sure you have enough disk space."),
+    ).toBeNull();
+  });
 });

--- a/web/src/components/DownloadVersionPicker.test.tsx
+++ b/web/src/components/DownloadVersionPicker.test.tsx
@@ -1,0 +1,44 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import type { FileVersion } from "@/api/types";
+
+import DownloadVersionPicker from "./DownloadVersionPicker";
+
+vi.mock("@/hooks/queries/downloads", () => ({
+  buildDirectDownloadUrl: (fileId: number) => `/api/downloads/files/${fileId}`,
+}));
+
+function version(overrides: Partial<FileVersion>): FileVersion {
+  return {
+    file_id: overrides.file_id ?? 1,
+    file_name: overrides.file_name,
+    file_path: overrides.file_path,
+    resolution: overrides.resolution ?? "",
+    codec_video: overrides.codec_video ?? "",
+    codec_audio: overrides.codec_audio ?? "",
+    hdr: overrides.hdr ?? false,
+    container: overrides.container ?? "",
+    file_size: overrides.file_size ?? 0,
+    duration: overrides.duration ?? 0,
+    bitrate: overrides.bitrate ?? 0,
+  };
+}
+
+describe("DownloadVersionPicker", () => {
+  it("uses file-size copy instead of quality copy for multi-file downloads", () => {
+    render(
+      <DownloadVersionPicker
+        open
+        onOpenChange={() => undefined}
+        title="A Psalm for the Wild-Built"
+        versions={[
+          version({ file_id: 1, container: "epub", file_size: 512 * 1024 }),
+          version({ file_id: 2, container: "pdf", file_size: 2 * 1024 * 1024 }),
+        ]}
+      />,
+    );
+
+    expect(screen.getByText("Larger files require more storage space.")).toBeTruthy();
+    expect(screen.queryByText("Higher quality files require more storage space.")).toBeNull();
+  });
+});

--- a/web/src/components/DownloadVersionPicker.tsx
+++ b/web/src/components/DownloadVersionPicker.tsx
@@ -94,9 +94,7 @@ export default function DownloadVersionPicker({
         </div>
 
         {sorted.length > 1 && (
-          <p className="text-muted-foreground text-xs">
-            Higher quality files require more storage space.
-          </p>
+          <p className="text-muted-foreground text-xs">Larger files require more storage space.</p>
         )}
       </DialogContent>
     </Dialog>

--- a/web/src/components/DownloadVersionPicker.tsx
+++ b/web/src/components/DownloadVersionPicker.tsx
@@ -60,7 +60,7 @@ export default function DownloadVersionPicker({
         <DialogHeader>
           <DialogTitle>Download{title ? `: ${title}` : ""}</DialogTitle>
           <DialogDescription>
-            Choose a version to download. Make sure you have enough disk space.
+            Choose a file to download. Make sure you have enough disk space.
           </DialogDescription>
         </DialogHeader>
 

--- a/web/src/components/catalog/CatalogFilterBar.test.tsx
+++ b/web/src/components/catalog/CatalogFilterBar.test.tsx
@@ -1,0 +1,9 @@
+import { describe, expect, it } from "vitest";
+
+import { CATALOG_MEDIA_SCOPE_OPTIONS } from "./CatalogFilterBar";
+
+describe("CatalogFilterBar", () => {
+  it("offers ebook media scope in the selector", () => {
+    expect(CATALOG_MEDIA_SCOPE_OPTIONS).toContainEqual({ value: "ebook", label: "Ebooks" });
+  });
+});

--- a/web/src/components/catalog/CatalogFilterBar.tsx
+++ b/web/src/components/catalog/CatalogFilterBar.tsx
@@ -30,6 +30,15 @@ interface CatalogFilterBarProps {
   resultCountLoading?: boolean;
 }
 
+export const CATALOG_MEDIA_SCOPE_OPTIONS = [
+  { value: "all", label: "All Media" },
+  { value: "movie", label: "Movies" },
+  { value: "series", label: "Series" },
+  { value: "episode", label: "Episodes" },
+  { value: "audiobook", label: "Audiobooks" },
+  { value: "ebook", label: "Ebooks" },
+] as const;
+
 export default function CatalogFilterBar({
   state,
   onUpdate,
@@ -72,11 +81,11 @@ export default function CatalogFilterBar({
             <SelectValue />
           </SelectTrigger>
           <SelectContent>
-            <SelectItem value="all">All Media</SelectItem>
-            <SelectItem value="movie">Movies</SelectItem>
-            <SelectItem value="series">Series</SelectItem>
-            <SelectItem value="episode">Episodes</SelectItem>
-            <SelectItem value="audiobook">Audiobooks</SelectItem>
+            {CATALOG_MEDIA_SCOPE_OPTIONS.map((option) => (
+              <SelectItem key={option.value} value={option.value}>
+                {option.label}
+              </SelectItem>
+            ))}
           </SelectContent>
         </Select>
       ) : null}

--- a/web/src/components/collections/CollectionGuidedRulesEditor.tsx
+++ b/web/src/components/collections/CollectionGuidedRulesEditor.tsx
@@ -40,7 +40,7 @@ const DECADE_OPTIONS = Array.from({ length: 15 }, (_, index) => 2030 - index * 1
 
 /** Flat form state that maps 1-to-1 with friendly form fields. */
 export interface GuidedFormState {
-  mediaScope: "all" | "movie" | "series" | "episode" | "audiobook";
+  mediaScope: "all" | "movie" | "series" | "episode" | "audiobook" | "ebook";
   libraryIds: number[];
   genres: string[];
   decade: string;
@@ -486,6 +486,8 @@ export default function CollectionGuidedRulesEditor({
                   <SelectItem value="movie">Movies</SelectItem>
                   <SelectItem value="series">Series</SelectItem>
                   <SelectItem value="episode">Episodes</SelectItem>
+                  <SelectItem value="audiobook">Audiobooks</SelectItem>
+                  <SelectItem value="ebook">Ebooks</SelectItem>
                 </SelectContent>
               </Select>
             </div>

--- a/web/src/components/collections/CollectionRulesEditor.tsx
+++ b/web/src/components/collections/CollectionRulesEditor.tsx
@@ -70,7 +70,7 @@ export default function CollectionRulesEditor({
                     media_scope:
                       next === "all"
                         ? undefined
-                        : (next as "movie" | "series" | "episode" | "audiobook"),
+                        : (next as "movie" | "series" | "episode" | "audiobook" | "ebook"),
                     sort: nextSort,
                   });
                 }}
@@ -85,6 +85,7 @@ export default function CollectionRulesEditor({
                   <SelectItem value="series">Series</SelectItem>
                   <SelectItem value="episode">Episodes</SelectItem>
                   <SelectItem value="audiobook">Audiobooks</SelectItem>
+                  <SelectItem value="ebook">Ebooks</SelectItem>
                 </SelectContent>
               </Select>
             </div>

--- a/web/src/components/sections/EditableSectionRows.tsx
+++ b/web/src/components/sections/EditableSectionRows.tsx
@@ -65,6 +65,7 @@ export function SectionSummaryBadges({
       {queryDefinition.media_scope === "audiobook" ? (
         <Badge variant="outline">Audiobooks</Badge>
       ) : null}
+      {queryDefinition.media_scope === "ebook" ? <Badge variant="outline">Ebooks</Badge> : null}
       {libraries
         ? queryDefinition.library_ids.map((libraryId) => {
             const library = libraries.find((entry) => entry.id === libraryId);

--- a/web/src/components/sections/SectionEditorDrawer.tsx
+++ b/web/src/components/sections/SectionEditorDrawer.tsx
@@ -479,7 +479,7 @@ export default function SectionEditorDrawer(props: SectionEditorDrawerProps) {
                         media_scope:
                           value === "all"
                             ? undefined
-                            : (value as "movie" | "series" | "episode" | "audiobook"),
+                            : (value as "movie" | "series" | "episode" | "audiobook" | "ebook"),
                       })
                     }
                   >
@@ -492,6 +492,7 @@ export default function SectionEditorDrawer(props: SectionEditorDrawerProps) {
                       <SelectItem value="series">Series</SelectItem>
                       <SelectItem value="episode">Episodes</SelectItem>
                       <SelectItem value="audiobook">Audiobooks</SelectItem>
+                      <SelectItem value="ebook">Ebooks</SelectItem>
                     </SelectContent>
                   </Select>
                 </div>

--- a/web/src/lib/querySortOptions.test.ts
+++ b/web/src/lib/querySortOptions.test.ts
@@ -1,0 +1,13 @@
+import { describe, expect, it } from "vitest";
+
+import { getQuerySortOptions } from "./querySortOptions";
+
+describe("getQuerySortOptions", () => {
+  it("allows ebook book-native sorts without enabling narrator", () => {
+    const fields = getQuerySortOptions({ relevanceScope: "ebook" }).map((option) => option.value);
+
+    expect(fields).toContain("author");
+    expect(fields).toContain("series");
+    expect(fields).not.toContain("narrator");
+  });
+});

--- a/web/src/lib/querySortOptions.ts
+++ b/web/src/lib/querySortOptions.ts
@@ -1,5 +1,11 @@
 export type QuerySortOrder = "asc" | "desc";
-export type QuerySortRelevanceScope = "movie" | "series" | "episode" | "audiobook" | "all";
+export type QuerySortRelevanceScope =
+  | "movie"
+  | "series"
+  | "episode"
+  | "audiobook"
+  | "ebook"
+  | "all";
 export type QuerySortField =
   | "title"
   | "added_at"
@@ -53,11 +59,11 @@ interface QuerySortLike {
 // ALL_VIDEO_SCOPES is the universe of video-side scopes — used as the
 // baseline for the "all" relevance scope (mixed libraries / episode
 // browse mode) so that sorts limited to series+episode are still
-// filtered out as not universally applicable. Audiobook is explicit
-// opt-in: a sort field must list "audiobook" in its applicableMediaScopes
-// to be eligible for an audiobook-only library.
+// filtered out as not universally applicable. Book scopes are explicit
+// opt-in: a sort field must list "audiobook" or "ebook" in its
+// applicableMediaScopes to be eligible for book-only libraries.
 const ALL_VIDEO_SCOPES: ApplicableMediaScope[] = ["movie", "series", "episode"];
-const ALL_MEDIA_SCOPES: ApplicableMediaScope[] = [...ALL_VIDEO_SCOPES, "audiobook"];
+const ALL_MEDIA_SCOPES: ApplicableMediaScope[] = [...ALL_VIDEO_SCOPES, "audiobook", "ebook"];
 
 export const QUERY_SORT_OPTIONS: QuerySortOption[] = [
   {
@@ -173,16 +179,15 @@ export const QUERY_SORT_OPTIONS: QuerySortOption[] = [
     personalized: true,
     applicableMediaScopes: ALL_MEDIA_SCOPES,
   },
-  // Audiobook-native sorts. Author / Narrator use alphabetically-first
-  // person name per item; Series uses audiobook_series.series_name with
-  // series_index breaking ties so books within a series come back in
-  // narrative order.
+  // Book-native sorts. Author is shared by audiobooks and ebooks; narrator
+  // remains audiobook-only. Series is shared by the audiobook_series and
+  // ebook_series joins on the backend.
   {
     value: "author",
     label: "Author",
     defaultOrder: "asc",
     personalized: false,
-    applicableMediaScopes: ["audiobook"],
+    applicableMediaScopes: ["audiobook", "ebook"],
   },
   {
     value: "narrator",
@@ -196,7 +201,7 @@ export const QUERY_SORT_OPTIONS: QuerySortOption[] = [
     label: "Series",
     defaultOrder: "asc",
     personalized: false,
-    applicableMediaScopes: ["audiobook"],
+    applicableMediaScopes: ["audiobook", "ebook"],
   },
 ];
 
@@ -220,7 +225,7 @@ function optionMatchesRelevanceScope(
   }
   // "all" — applies to mixed libraries and the episode browse mode.
   // Match the historical baseline (universal across all video scopes)
-  // so series-only sorts still get normalized away. Audiobook scope is
+  // so series-only sorts still get normalized away. Book scopes are
   // intentionally not part of this baseline; see ALL_VIDEO_SCOPES.
   if (relevanceScope === "all") {
     return ALL_VIDEO_SCOPES.every((scope) => option.applicableMediaScopes.includes(scope));

--- a/web/src/pages/ItemDetail/EbookContent.tsx
+++ b/web/src/pages/ItemDetail/EbookContent.tsx
@@ -1,0 +1,94 @@
+import { useState } from "react";
+import { Download } from "lucide-react";
+import type { ItemDetail } from "@/api/types";
+import DownloadVersionPicker from "@/components/DownloadVersionPicker";
+import MediaLocations from "@/components/MediaLocations";
+import PageBack from "@/components/PageBack";
+import { Button } from "@/components/ui/button";
+import { useAuth } from "@/hooks/useAuth";
+import { useAmbientColor } from "@/hooks/useAmbientColor";
+import DetailHero from "./DetailHero";
+import MetadataBadges from "./components/MetadataBadges";
+import ScoreRow from "./components/ScoreRow";
+
+function authorNames(item: ItemDetail): string[] {
+  return (item.crew ?? [])
+    .filter((credit) => credit.job === "Author")
+    .map((credit) => credit.name)
+    .filter((name) => name.trim() !== "");
+}
+
+export default function EbookContent({ item }: { item: ItemDetail & { type: "ebook" } }) {
+  useAmbientColor(item.poster_thumbhash);
+  const { user } = useAuth();
+  const [downloadOpen, setDownloadOpen] = useState(false);
+  const authors = authorNames(item);
+  const publisher = (item.studios ?? [])[0];
+  const year = item.year ? String(item.year) : "";
+  const canDownload = Boolean(user?.download_allowed && item.versions.length > 0);
+
+  return (
+    <div>
+      <DetailHero
+        title={item.title}
+        topNav={<PageBack />}
+        context="Ebook"
+        studioLabel={publisher}
+        backdropUrl={item.backdrop_url}
+        backdropThumbhash={item.backdrop_thumbhash}
+        posterUrl={item.poster_url}
+        posterThumbhash={item.poster_thumbhash}
+        metadata={
+          <MetadataBadges
+            year={year || undefined}
+            contentRating={item.content_rating || undefined}
+          />
+        }
+        scoreRow={
+          <ScoreRow
+            ratingImdb={item.rating_imdb}
+            ratingRtCritic={item.rating_rt_critic}
+            ratingRtAudience={item.rating_rt_audience}
+          />
+        }
+        overview={item.overview}
+        crewLine={
+          authors.length > 0 ? (
+            <div className="text-muted-foreground text-[13px]">
+              <span className="text-muted-foreground/60">By </span>
+              <span className="text-foreground/70 font-medium">{authors.join(", ")}</span>
+            </div>
+          ) : undefined
+        }
+        genres={item.genres}
+        actions={
+          canDownload ? (
+            <Button
+              type="button"
+              className="h-11 gap-2.5 rounded-full px-6 text-[15px] font-bold tracking-wide shadow-md"
+              onClick={() => setDownloadOpen(true)}
+            >
+              <Download className="size-[18px]" />
+              Download
+            </Button>
+          ) : undefined
+        }
+      />
+
+      <div className="page-shell space-y-12 py-10 sm:space-y-14">
+        <MediaLocations
+          title="Files"
+          versions={item.versions}
+          emptyMessage="No ebook files found."
+        />
+      </div>
+
+      <DownloadVersionPicker
+        open={downloadOpen}
+        onOpenChange={setDownloadOpen}
+        versions={item.versions}
+        title={item.title}
+      />
+    </div>
+  );
+}

--- a/web/src/pages/ItemDetail/components/VersionFlyout.test.ts
+++ b/web/src/pages/ItemDetail/components/VersionFlyout.test.ts
@@ -73,6 +73,19 @@ describe("buildQualitySummary", () => {
     });
     expect(buildQualitySummary(version)).toBe("2160p · HEVC · HDR · Atmos");
   });
+
+  it("falls back to container for ebook-style files without video quality", () => {
+    const version = makeVersion({
+      resolution: "",
+      codec_video: "",
+      codec_audio: "",
+      hdr: false,
+      container: "epub",
+      file_name: "A Psalm for the Wild-Built.epub",
+    });
+
+    expect(buildQualitySummary(version)).toBe("EPUB");
+  });
 });
 
 describe("buildDetailLine", () => {

--- a/web/src/pages/ItemDetail/components/VersionFlyout.tsx
+++ b/web/src/pages/ItemDetail/components/VersionFlyout.tsx
@@ -19,6 +19,9 @@ export function buildQualitySummary(version: FileVersion): string {
   if (version.codec_video) parts.push(version.codec_video.toUpperCase());
   if (version.hdr) parts.push("HDR");
   if (version.codec_audio) parts.push(mapAudioLabel(version.codec_audio));
+  if (parts.length === 0 && version.container) {
+    parts.push(version.container.toUpperCase());
+  }
 
   return parts.join(" · ");
 }

--- a/web/src/pages/ItemDetail/index.test.tsx
+++ b/web/src/pages/ItemDetail/index.test.tsx
@@ -37,6 +37,14 @@ vi.mock("@/pages/ItemDetail/EpisodeContent", () => ({
   default: () => <div>Episode</div>,
 }));
 
+vi.mock("@/pages/ItemDetail/AudiobookContent", () => ({
+  default: () => <div>Audiobook</div>,
+}));
+
+vi.mock("@/pages/ItemDetail/EbookContent", () => ({
+  default: ({ item }: { item: { title: string } }) => <div>Ebook: {item.title}</div>,
+}));
+
 import ItemDetail from "./index";
 
 describe("ItemDetail", () => {
@@ -55,5 +63,17 @@ describe("ItemDetail", () => {
 
     expect(markup).toContain("Catalog Detail");
     expect(mocks.useCatalogItemDetail).toHaveBeenCalledWith("movie-123", undefined);
+  });
+
+  it("routes ebook items to ebook detail content", () => {
+    mocks.useCatalogItemDetail.mockReturnValue({
+      data: { content_id: "ebook-123", title: "A Psalm for the Wild-Built", type: "ebook" },
+      isLoading: false,
+      error: null,
+    });
+
+    const markup = renderToStaticMarkup(<ItemDetail />);
+
+    expect(markup).toContain("Ebook: A Psalm for the Wild-Built");
   });
 });

--- a/web/src/pages/ItemDetail/index.tsx
+++ b/web/src/pages/ItemDetail/index.tsx
@@ -10,6 +10,7 @@ import SeriesContent from "@/pages/ItemDetail/SeriesContent";
 import SeasonContent from "@/pages/ItemDetail/SeasonContent";
 import EpisodeContent from "@/pages/ItemDetail/EpisodeContent";
 import AudiobookContent from "@/pages/ItemDetail/AudiobookContent";
+import EbookContent from "@/pages/ItemDetail/EbookContent";
 import {
   CastSkeleton,
   CrewSkeleton,
@@ -103,6 +104,8 @@ export default function ItemDetail() {
       return (
         <AudiobookContent item={item as ItemDetail & { type: "audiobook" }} libraryId={libraryId} />
       );
+    case "ebook":
+      return <EbookContent item={item as ItemDetail & { type: "ebook" }} />;
     case "podcast":
       return <Navigate to={`/podcasts/show/${item.content_id}`} replace />;
     default:

--- a/web/src/pages/LibraryBrowse.test.tsx
+++ b/web/src/pages/LibraryBrowse.test.tsx
@@ -206,4 +206,28 @@ describe("LibraryBrowse", () => {
     expect(state.library_id).toBe(10);
     expect(state.query_definition.media_scope).toBe("audiobook");
   });
+
+  it("uses ebook media scope for ebook libraries", () => {
+    renderToStaticMarkup(
+      <LibraryBrowse
+        libraryId={11}
+        libraryType="ebooks"
+        browseType="series"
+        queryDefinition={{
+          library_ids: [],
+          match: "all",
+          groups: [],
+          sort: { field: "title", order: "asc" },
+        }}
+        onBrowseTypeChange={() => {}}
+        onQueryDefinitionChange={() => {}}
+      />,
+    );
+
+    const [state] = mocks.useCatalogWindow.mock.calls[
+      mocks.useCatalogWindow.mock.calls.length - 1
+    ] as [CatalogSearchState, Record<string, unknown>];
+    expect(state.library_id).toBe(11);
+    expect(state.query_definition.media_scope).toBe("ebook");
+  });
 });

--- a/web/src/pages/LibraryBrowse.tsx
+++ b/web/src/pages/LibraryBrowse.tsx
@@ -32,16 +32,20 @@ function getLibrarySortRelevanceScope(
   if (libraryType === "movie" || libraryType === "series") {
     return libraryType;
   }
-  // The DB stores audiobook library type as the plural "audiobooks";
-  // the sort scope is the singular "audiobook" (matches QueryDefinition.media_scope).
+  // The DB stores book library types as plurals; sort scopes are singular
+  // values matching QueryDefinition.media_scope.
   if (libraryType === "audiobook" || libraryType === "audiobooks") {
     return "audiobook";
+  }
+  if (libraryType === "ebook" || libraryType === "ebooks") {
+    return "ebook";
   }
   if (
     mediaScope === "movie" ||
     mediaScope === "series" ||
     mediaScope === "episode" ||
-    mediaScope === "audiobook"
+    mediaScope === "audiobook" ||
+    mediaScope === "ebook"
   ) {
     return mediaScope;
   }
@@ -50,6 +54,10 @@ function getLibrarySortRelevanceScope(
 
 function isAudiobookLibraryType(libraryType: string): boolean {
   return libraryType === "audiobook" || libraryType === "audiobooks";
+}
+
+function isEbookLibraryType(libraryType: string): boolean {
+  return libraryType === "ebook" || libraryType === "ebooks";
 }
 
 export default function LibraryBrowse({
@@ -73,7 +81,9 @@ export default function LibraryBrowse({
         ? queryDefinition.media_scope
         : isAudiobookLibraryType(libraryType)
           ? "audiobook"
-          : libraryType === "movie"
+          : isEbookLibraryType(libraryType)
+            ? "ebook"
+            : libraryType === "movie"
             ? libraryType
             : undefined,
     sort: normalizeQuerySortForScope(queryDefinition.sort, {

--- a/web/src/pages/catalogSearchParams.test.ts
+++ b/web/src/pages/catalogSearchParams.test.ts
@@ -39,6 +39,13 @@ describe("parseCatalogSearchParams", () => {
     expect(state.query_definition.sort).toEqual({ field: "title", order: "asc" });
   });
 
+  it("keeps ebook media scope from catalog URLs", () => {
+    const state = parseCatalogSearchParams(params("source=query&type=ebook&sort=author"));
+
+    expect(state.query_definition.media_scope).toBe("ebook");
+    expect(state.query_definition.sort).toEqual({ field: "author", order: "asc" });
+  });
+
   it("parses person catalog sources with overlays", () => {
     const state = parseCatalogSearchParams(
       params(

--- a/web/src/pages/catalogSearchParams.ts
+++ b/web/src/pages/catalogSearchParams.ts
@@ -135,7 +135,11 @@ export function parseCatalogSearchParams(searchParams: URLSearchParams): Catalog
   baseState.query_definition = normalizeQueryDefinition({
     library_ids: baseState.library_id ? [baseState.library_id] : [],
     media_scope:
-      type === "movie" || type === "series" || type === "episode" || type === "audiobook"
+      type === "movie" ||
+      type === "series" ||
+      type === "episode" ||
+      type === "audiobook" ||
+      type === "ebook"
         ? type
         : undefined,
     match: searchParams.get("match") === "any" ? "any" : "all",

--- a/web/src/pages/libraryPageSearchParams.test.ts
+++ b/web/src/pages/libraryPageSearchParams.test.ts
@@ -142,6 +142,14 @@ describe("parseLibraryPageState", () => {
     expect(state.queryDefinition.sort).toEqual({ field: "author", order: "asc" });
   });
 
+  it("preserves ebook scope for mixed library filters", () => {
+    const state = parseLibraryPageState(params("tab=library&type=ebook&sort=author"), "mixed");
+
+    expect(state.activeTab).toBe("library");
+    expect(state.queryDefinition.media_scope).toBe("ebook");
+    expect(state.queryDefinition.sort).toEqual({ field: "author", order: "asc" });
+  });
+
   it("accepts grouped query params and canonical sorts", () => {
     const state = parseLibraryPageState(
       params(
@@ -201,6 +209,13 @@ describe("parseLibraryPageState", () => {
     );
     expect(state.queryDefinition.media_scope).toBe("audiobook");
     expect(state.queryDefinition.sort).toEqual({ field: "runtime", order: "desc" });
+  });
+
+  it("uses ebook scope for ebook libraries", () => {
+    const state = parseLibraryPageState(params("tab=library&sort=author&order=asc"), "ebooks");
+
+    expect(state.queryDefinition.media_scope).toBe("ebook");
+    expect(state.queryDefinition.sort).toEqual({ field: "author", order: "asc" });
   });
 
   it("normalizes legacy sort aliases to canonical values", () => {

--- a/web/src/pages/libraryPageSearchParams.ts
+++ b/web/src/pages/libraryPageSearchParams.ts
@@ -66,16 +66,20 @@ function getLibrarySortRelevanceScope(
   if (libraryType === "movie" || libraryType === "series") {
     return libraryType;
   }
-  // The DB stores audiobook library type as the plural "audiobooks";
-  // the sort scope is the singular "audiobook" (matches QueryDefinition.media_scope).
+  // The DB stores book library types as plurals; sort scopes are singular
+  // values matching QueryDefinition.media_scope.
   if (libraryType === "audiobook" || libraryType === "audiobooks") {
     return "audiobook";
+  }
+  if (libraryType === "ebook" || libraryType === "ebooks") {
+    return "ebook";
   }
   if (
     mediaScope === "movie" ||
     mediaScope === "series" ||
     mediaScope === "episode" ||
-    mediaScope === "audiobook"
+    mediaScope === "audiobook" ||
+    mediaScope === "ebook"
   ) {
     return mediaScope;
   }
@@ -84,6 +88,10 @@ function getLibrarySortRelevanceScope(
 
 function isAudiobookLibraryType(libraryType: string): boolean {
   return libraryType === "audiobook" || libraryType === "audiobooks";
+}
+
+function isEbookLibraryType(libraryType: string): boolean {
+  return libraryType === "ebook" || libraryType === "ebooks";
 }
 
 function readString(value: string | null): string | undefined {
@@ -275,11 +283,14 @@ export function parseLibraryPageState(
     (mediaScopeParam === "movie" ||
       mediaScopeParam === "series" ||
       mediaScopeParam === "episode" ||
-      mediaScopeParam === "audiobook")
+      mediaScopeParam === "audiobook" ||
+      mediaScopeParam === "ebook")
       ? mediaScopeParam
       : isAudiobookLibraryType(libraryType)
         ? "audiobook"
-        : undefined;
+        : isEbookLibraryType(libraryType)
+          ? "ebook"
+          : undefined;
   const sortRelevanceScope =
     libraryType === "series" && browseType === "episode"
       ? "all"


### PR DESCRIPTION
## Summary
- Add ebook catalog scope support so ebook libraries can be queried and browsed alongside existing media types.
- Add the ebook item detail surface with file/download access instead of playback controls.
- Polish ebook download/version labels so EPUB/PDF-style files are labeled by format, file size, and language.

## Test Plan
- pnpm --dir web exec vitest run src/pages/ItemDetail/components/VersionFlyout.test.ts src/components/DownloadVersionPicker.test.tsx
