### PR TITLE
Polish ebook download file labels

### DIFF
--- a/web/src/components/DownloadVersionPicker.test.tsx
+++ b/web/src/components/DownloadVersionPicker.test.tsx
@@ -41,4 +41,22 @@ describe("DownloadVersionPicker", () => {
     expect(screen.getByText("Larger files require more storage space.")).toBeTruthy();
     expect(screen.queryByText("Higher quality files require more storage space.")).toBeNull();
   });
+
+  it("describes download choices as files instead of versions", () => {
+    render(
+      <DownloadVersionPicker
+        open
+        onOpenChange={() => undefined}
+        title="A Psalm for the Wild-Built"
+        versions={[version({ file_id: 1, container: "epub", file_size: 512 * 1024 })]}
+      />,
+    );
+
+    expect(
+      screen.getByText("Choose a file to download. Make sure you have enough disk space."),
+    ).toBeTruthy();
+    expect(
+      screen.queryByText("Choose a version to download. Make sure you have enough disk space."),
+    ).toBeNull();
+  });
 });

--- a/web/src/components/DownloadVersionPicker.test.tsx
+++ b/web/src/components/DownloadVersionPicker.test.tsx
@@ -1,0 +1,44 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import type { FileVersion } from "@/api/types";
+
+import DownloadVersionPicker from "./DownloadVersionPicker";
+
+vi.mock("@/hooks/queries/downloads", () => ({
+  buildDirectDownloadUrl: (fileId: number) => `/api/downloads/files/${fileId}`,
+}));
+
+function version(overrides: Partial<FileVersion>): FileVersion {
+  return {
+    file_id: overrides.file_id ?? 1,
+    file_name: overrides.file_name,
+    file_path: overrides.file_path,
+    resolution: overrides.resolution ?? "",
+    codec_video: overrides.codec_video ?? "",
+    codec_audio: overrides.codec_audio ?? "",
+    hdr: overrides.hdr ?? false,
+    container: overrides.container ?? "",
+    file_size: overrides.file_size ?? 0,
+    duration: overrides.duration ?? 0,
+    bitrate: overrides.bitrate ?? 0,
+  };
+}
+
+describe("DownloadVersionPicker", () => {
+  it("uses file-size copy instead of quality copy for multi-file downloads", () => {
+    render(
+      <DownloadVersionPicker
+        open
+        onOpenChange={() => undefined}
+        title="A Psalm for the Wild-Built"
+        versions={[
+          version({ file_id: 1, container: "epub", file_size: 512 * 1024 }),
+          version({ file_id: 2, container: "pdf", file_size: 2 * 1024 * 1024 }),
+        ]}
+      />,
+    );
+
+    expect(screen.getByText("Larger files require more storage space.")).toBeTruthy();
+    expect(screen.queryByText("Higher quality files require more storage space.")).toBeNull();
+  });
+});

--- a/web/src/components/DownloadVersionPicker.tsx
+++ b/web/src/components/DownloadVersionPicker.tsx
@@ -94,9 +94,7 @@ export default function DownloadVersionPicker({
         </div>
 
         {sorted.length > 1 && (
-          <p className="text-muted-foreground text-xs">
-            Higher quality files require more storage space.
-          </p>
+          <p className="text-muted-foreground text-xs">Larger files require more storage space.</p>
         )}
       </DialogContent>
     </Dialog>

--- a/web/src/components/DownloadVersionPicker.tsx
+++ b/web/src/components/DownloadVersionPicker.tsx
@@ -60,7 +60,7 @@ export default function DownloadVersionPicker({
         <DialogHeader>
           <DialogTitle>Download{title ? `: ${title}` : ""}</DialogTitle>
           <DialogDescription>
-            Choose a version to download. Make sure you have enough disk space.
+            Choose a file to download. Make sure you have enough disk space.
           </DialogDescription>
         </DialogHeader>
 

--- a/web/src/pages/ItemDetail/components/VersionFlyout.test.ts
+++ b/web/src/pages/ItemDetail/components/VersionFlyout.test.ts
@@ -73,6 +73,19 @@ describe("buildQualitySummary", () => {
     });
     expect(buildQualitySummary(version)).toBe("2160p · HEVC · HDR · Atmos");
   });
+
+  it("falls back to container for ebook-style files without video quality", () => {
+    const version = makeVersion({
+      resolution: "",
+      codec_video: "",
+      codec_audio: "",
+      hdr: false,
+      container: "epub",
+      file_name: "A Psalm for the Wild-Built.epub",
+    });
+
+    expect(buildQualitySummary(version)).toBe("EPUB");
+  });
 });
 
 describe("buildDetailLine", () => {

--- a/web/src/pages/ItemDetail/components/VersionFlyout.tsx
+++ b/web/src/pages/ItemDetail/components/VersionFlyout.tsx
@@ -19,6 +19,9 @@ export function buildQualitySummary(version: FileVersion): string {
   if (version.codec_video) parts.push(version.codec_video.toUpperCase());
   if (version.hdr) parts.push("HDR");
   if (version.codec_audio) parts.push(mapAudioLabel(version.codec_audio));
+  if (parts.length === 0 && version.container) {
+    parts.push(version.container.toUpperCase());
+  }
 
   return parts.join(" · ");
 }


### PR DESCRIPTION
## Summary
- Fall back to file container labels when a media file has no video quality metadata, so ebook files show formats like `EPUB` or `PDF`.
- Replace video-oriented download helper text with file-size-oriented copy.
- Use file-oriented wording in the download dialog description.

## Test Plan
- [x] pnpm --dir web test src/pages/ItemDetail/components/VersionFlyout.test.ts src/components/DownloadVersionPicker.test.tsx
- [x] pnpm --dir web exec tsc -p tsconfig.json --noEmit
- [x] git diff --check

## Stack
- Stacked on #83 (`work/ebook-catalog-detail-support`). This PR contains ebook/download file-label and dialog copy polish.
