### PR TITLE
Use file wording in download dialog

### DIFF
--- a/web/src/components/DownloadVersionPicker.test.tsx
+++ b/web/src/components/DownloadVersionPicker.test.tsx
@@ -41,4 +41,22 @@ describe("DownloadVersionPicker", () => {
     expect(screen.getByText("Larger files require more storage space.")).toBeTruthy();
     expect(screen.queryByText("Higher quality files require more storage space.")).toBeNull();
   });
+
+  it("describes download choices as files instead of versions", () => {
+    render(
+      <DownloadVersionPicker
+        open
+        onOpenChange={() => undefined}
+        title="A Psalm for the Wild-Built"
+        versions={[version({ file_id: 1, container: "epub", file_size: 512 * 1024 })]}
+      />,
+    );
+
+    expect(
+      screen.getByText("Choose a file to download. Make sure you have enough disk space."),
+    ).toBeTruthy();
+    expect(
+      screen.queryByText("Choose a version to download. Make sure you have enough disk space."),
+    ).toBeNull();
+  });
 });

--- a/web/src/components/DownloadVersionPicker.tsx
+++ b/web/src/components/DownloadVersionPicker.tsx
@@ -60,7 +60,7 @@ export default function DownloadVersionPicker({
         <DialogHeader>
           <DialogTitle>Download{title ? `: ${title}` : ""}</DialogTitle>
           <DialogDescription>
-            Choose a version to download. Make sure you have enough disk space.
+            Choose a file to download. Make sure you have enough disk space.
           </DialogDescription>
         </DialogHeader>
 


### PR DESCRIPTION
## Summary
- Change the download dialog description from version-oriented wording to file-oriented wording.
- Extend the download dialog test to cover the copy.

## Test Plan
- [x] pnpm --dir web test src/components/DownloadVersionPicker.test.tsx
- [x] pnpm --dir web exec tsc -p tsconfig.json --noEmit
- [x] git diff --check

## Stack
- Stacked on #85 (`work/ebook-download-copy-polish`). This PR contains only download dialog file-wording polish.
