### PR TITLE
Fix late orphan provisional cleanup guard

### DIFF
--- a/internal/catalog/folder_repo.go
+++ b/internal/catalog/folder_repo.go
@@ -716,12 +716,12 @@ const collectOrphanedProvisionalIDsByContentIDSQL = `
 	SELECT mi.content_id
 	FROM public.media_items mi
 	WHERE mi.content_id = ANY($1)
-	  AND ` + orphanedMediaItemSafetyConditions
+	  AND ` + orphanedProvisionalMediaItemConditions
 
 const deleteOrphanedProvisionalIDsByContentIDSQL = `
 	DELETE FROM public.media_items mi
 	WHERE mi.content_id = ANY($1)
-	  AND ` + orphanedMediaItemSafetyConditions
+	  AND ` + orphanedProvisionalMediaItemConditions
 
 func (r *FolderRepository) deleteOrphanedItemsByContentID(ctx context.Context, contentIDs []string) (int, []string, error) {
 	if len(contentIDs) == 0 {


### PR DESCRIPTION
## Summary
- Reuse the full provisional media-item predicate for late orphan collect/delete queries after folder membership deletion.
- Keeps matched media items from being eligible for the provisional-only late orphan cleanup path.

## Test Plan
- [x] go test ./internal/catalog -run TestLateOrphanCleanupUsesProvisionalSafetyPredicate -count=1 -v
- [x] go test ./internal/catalog -count=1
- [x] git diff --check
