### PR TITLE
fix(catalog): use semi-joins for discovery library scope

### DIFF
--- a/internal/catalog/discovery_repo.go
+++ b/internal/catalog/discovery_repo.go
@@ -288,6 +288,14 @@ func appendDiscoveryLibraryScope(
 
 	// buildLibraryScopeJoin uses semi-joins: disabled libraries are an item-level
 	// exclusion, matching the rest of catalog access filtering and avoiding row fanout.
+	if filter.AllowedLibraryIDs == nil && len(filter.DisabledLibraryIDs) > 0 {
+		// In deny-only mode, require at least one library membership. Without this,
+		// stale or provisional media_items rows with no membership pass NOT EXISTS.
+		*conditions = append(*conditions,
+			"EXISTS (SELECT 1 FROM media_item_libraries mil_scope_any WHERE mil_scope_any.content_id = mi.content_id)",
+		)
+	}
+
 	whereSQL, scopeArgs, ok := buildLibraryScopeJoin(
 		filter.AllowedLibraryIDs,
 		filter.DisabledLibraryIDs,

--- a/internal/catalog/discovery_repo.go
+++ b/internal/catalog/discovery_repo.go
@@ -28,71 +28,53 @@ type RatingFilter struct {
 	Min float64
 	// Limit caps the number of rows returned. Zero or negative means no limit.
 	Limit int
-	// LibraryID, when non-nil, restricts results to items in that library via
-	// the media_item_libraries junction table.
+	// LibraryID, when non-nil, restricts results to items in that library.
 	LibraryID *int
 	// Filter carries viewer-level access constraints (content rating ceiling,
 	// allowed/disabled library sets).
 	Filter AccessFilter
 }
 
-// ListByRatingThreshold returns media items whose rating_imdb is >= f.Min,
-// ordered by rating_imdb DESC NULLS LAST.  Items without an IMDb rating are
-// always excluded.
-func (r *DiscoveryRepository) ListByRatingThreshold(ctx context.Context, f RatingFilter) ([]*models.MediaItem, error) {
+// buildRatingThresholdQuery builds the SQL statement and bind args for ListByRatingThreshold.
+// It returns an empty query string when access rules exclude every
+// library, signalling the caller to skip the query and return no rows.
+func buildRatingThresholdQuery(f RatingFilter) (string, []any) {
 	var conditions []string
 	var args []any
 	argIdx := 1
 
-	// IMDb rating threshold — NULL ratings are excluded implicitly by >=.
+	// IMDb rating threshold - NULL ratings are excluded implicitly by >=.
 	conditions = append(conditions, fmt.Sprintf("mi.rating_imdb >= $%d", argIdx))
 	args = append(args, f.Min)
 	argIdx++
 
-	// Optional single-library pin.
-	fromClause := "media_items mi"
-	if f.LibraryID != nil {
-		fromClause = "media_items mi JOIN media_item_libraries mil ON mi.content_id = mil.content_id"
-		conditions = append(conditions, fmt.Sprintf("mil.media_folder_id = $%d", argIdx))
-		args = append(args, *f.LibraryID)
-		argIdx++
-	} else if f.Filter.AllowedLibraryIDs != nil || len(f.Filter.DisabledLibraryIDs) > 0 {
-		fromClause = "media_items mi JOIN media_item_libraries mil ON mi.content_id = mil.content_id"
-		if f.Filter.AllowedLibraryIDs != nil {
-			if len(f.Filter.AllowedLibraryIDs) == 0 {
-				return []*models.MediaItem{}, nil
-			}
-			placeholders := make([]string, len(f.Filter.AllowedLibraryIDs))
-			for i, id := range f.Filter.AllowedLibraryIDs {
-				placeholders[i] = fmt.Sprintf("$%d", argIdx)
-				args = append(args, id)
-				argIdx++
-			}
-			conditions = append(conditions, fmt.Sprintf("mil.media_folder_id IN (%s)", strings.Join(placeholders, ", ")))
-		}
-		if len(f.Filter.DisabledLibraryIDs) > 0 {
-			placeholders := make([]string, len(f.Filter.DisabledLibraryIDs))
-			for i, id := range f.Filter.DisabledLibraryIDs {
-				placeholders[i] = fmt.Sprintf("$%d", argIdx)
-				args = append(args, id)
-				argIdx++
-			}
-			conditions = append(conditions, fmt.Sprintf("mil.media_folder_id NOT IN (%s)", strings.Join(placeholders, ", ")))
-		}
+	if ok := appendDiscoveryLibraryScope(&conditions, &args, &argIdx, f.LibraryID, f.Filter); !ok {
+		return "", nil
 	}
 
 	applyAccessFilter("mi", f.Filter, &conditions, &args, &argIdx)
 
 	query := fmt.Sprintf(
-		"SELECT %s FROM %s WHERE %s ORDER BY mi.rating_imdb DESC NULLS LAST, mi.content_id ASC",
-		itemColumns,
-		fromClause,
+		"SELECT %s FROM media_items mi WHERE %s ORDER BY mi.rating_imdb DESC NULLS LAST, mi.content_id ASC",
+		qualifiedItemColumns("mi"),
 		strings.Join(conditions, " AND "),
 	)
 
 	if f.Limit > 0 {
 		query += fmt.Sprintf(" LIMIT $%d", argIdx)
 		args = append(args, f.Limit)
+	}
+
+	return query, args
+}
+
+// ListByRatingThreshold returns media items whose rating_imdb is >= f.Min,
+// ordered by rating_imdb DESC NULLS LAST.  Items without an IMDb rating are
+// always excluded.
+func (r *DiscoveryRepository) ListByRatingThreshold(ctx context.Context, f RatingFilter) ([]*models.MediaItem, error) {
+	query, args := buildRatingThresholdQuery(f)
+	if query == "" {
+		return []*models.MediaItem{}, nil
 	}
 
 	rows, err := r.pool.Query(ctx, query, args...)
@@ -122,6 +104,50 @@ type UnplayedFilter struct {
 	Filter AccessFilter
 }
 
+// buildUnplayedHighRatedQuery builds the SQL statement and bind args for ListUnplayedHighRated.
+// It returns an empty query string when access rules exclude every
+// library, signalling the caller to skip the query and return no rows.
+func buildUnplayedHighRatedQuery(f UnplayedFilter) (string, []any) {
+	var conditions []string
+	var args []any
+	argIdx := 1
+
+	// IMDb rating threshold.
+	conditions = append(conditions, fmt.Sprintf("mi.rating_imdb >= $%d", argIdx))
+	args = append(args, f.MinRating)
+	argIdx++
+
+	// Items the user has any watch history entry for are excluded.
+	conditions = append(conditions, fmt.Sprintf(`NOT EXISTS (
+		SELECT 1
+		FROM user_watch_history uwh
+		WHERE uwh.user_id = $%d
+		  AND uwh.profile_id = $%d
+		  AND uwh.media_item_id = mi.content_id
+	)`, argIdx, argIdx+1))
+	args = append(args, f.UserID, f.ProfileID)
+	argIdx += 2
+
+	if ok := appendDiscoveryLibraryScope(&conditions, &args, &argIdx, nil, f.Filter); !ok {
+		return "", nil
+	}
+
+	applyAccessFilter("mi", f.Filter, &conditions, &args, &argIdx)
+
+	query := fmt.Sprintf(
+		"SELECT %s FROM media_items mi WHERE %s ORDER BY mi.rating_imdb DESC NULLS LAST, mi.content_id ASC",
+		qualifiedItemColumns("mi"),
+		strings.Join(conditions, " AND "),
+	)
+
+	if f.Limit > 0 {
+		query += fmt.Sprintf(" LIMIT $%d", argIdx)
+		args = append(args, f.Limit)
+	}
+
+	return query, args
+}
+
 // ListUnplayedHighRated returns high-rated items that the given user/profile has
 // never started watching.  "Never started" means no row exists in
 // user_watch_history for (user_id, profile_id, media_item_id), regardless of
@@ -133,67 +159,9 @@ func (r *DiscoveryRepository) ListUnplayedHighRated(ctx context.Context, f Unpla
 		return nil, fmt.Errorf("ListUnplayedHighRated: UserID and ProfileID are required")
 	}
 
-	var conditions []string
-	var args []any
-	argIdx := 1
-
-	// IMDb rating threshold.
-	conditions = append(conditions, fmt.Sprintf("mi.rating_imdb >= $%d", argIdx))
-	args = append(args, f.MinRating)
-	argIdx++
-
-	// LEFT JOIN exclusion: items the user has any watch history entry for are excluded.
-	// We use a NOT EXISTS subquery rather than an outer join so it composes cleanly
-	// with library access conditions on the main query.
-	conditions = append(conditions, fmt.Sprintf(`NOT EXISTS (
-		SELECT 1
-		FROM user_watch_history uwh
-		WHERE uwh.user_id = $%d
-		  AND uwh.profile_id = $%d
-		  AND uwh.media_item_id = mi.content_id
-	)`, argIdx, argIdx+1))
-	args = append(args, f.UserID, f.ProfileID)
-	argIdx += 2
-
-	// Library access control.
-	fromClause := "media_items mi"
-	if f.Filter.AllowedLibraryIDs != nil || len(f.Filter.DisabledLibraryIDs) > 0 {
-		fromClause = "media_items mi JOIN media_item_libraries mil ON mi.content_id = mil.content_id"
-		if f.Filter.AllowedLibraryIDs != nil {
-			if len(f.Filter.AllowedLibraryIDs) == 0 {
-				return []*models.MediaItem{}, nil
-			}
-			placeholders := make([]string, len(f.Filter.AllowedLibraryIDs))
-			for i, id := range f.Filter.AllowedLibraryIDs {
-				placeholders[i] = fmt.Sprintf("$%d", argIdx)
-				args = append(args, id)
-				argIdx++
-			}
-			conditions = append(conditions, fmt.Sprintf("mil.media_folder_id IN (%s)", strings.Join(placeholders, ", ")))
-		}
-		if len(f.Filter.DisabledLibraryIDs) > 0 {
-			placeholders := make([]string, len(f.Filter.DisabledLibraryIDs))
-			for i, id := range f.Filter.DisabledLibraryIDs {
-				placeholders[i] = fmt.Sprintf("$%d", argIdx)
-				args = append(args, id)
-				argIdx++
-			}
-			conditions = append(conditions, fmt.Sprintf("mil.media_folder_id NOT IN (%s)", strings.Join(placeholders, ", ")))
-		}
-	}
-
-	applyAccessFilter("mi", f.Filter, &conditions, &args, &argIdx)
-
-	query := fmt.Sprintf(
-		"SELECT %s FROM %s WHERE %s ORDER BY mi.rating_imdb DESC NULLS LAST, mi.content_id ASC",
-		itemColumns,
-		fromClause,
-		strings.Join(conditions, " AND "),
-	)
-
-	if f.Limit > 0 {
-		query += fmt.Sprintf(" LIMIT $%d", argIdx)
-		args = append(args, f.Limit)
+	query, args := buildUnplayedHighRatedQuery(f)
+	if query == "" {
+		return []*models.MediaItem{}, nil
 	}
 
 	rows, err := r.pool.Query(ctx, query, args...)
@@ -225,13 +193,10 @@ type ForgottenFavoritesFilter struct {
 	Filter AccessFilter
 }
 
-// ListForgottenFavorites returns high-rated items (rating_imdb >= 7.0) that the
-// user/profile either has never watched OR last watched more than LookbackDays
-// ago.  Results are ordered by rating_imdb DESC NULLS LAST.
-func (r *DiscoveryRepository) ListForgottenFavorites(ctx context.Context, f ForgottenFavoritesFilter) ([]*models.MediaItem, error) {
-	if f.UserID <= 0 || strings.TrimSpace(f.ProfileID) == "" {
-		return nil, fmt.Errorf("ListForgottenFavorites: UserID and ProfileID are required")
-	}
+// buildForgottenFavoritesQuery builds the SQL statement and bind args for ListForgottenFavorites.
+// It returns an empty query string when access rules exclude every
+// library, signalling the caller to skip the query and return no rows.
+func buildForgottenFavoritesQuery(f ForgottenFavoritesFilter) (string, []any) {
 	if f.LookbackDays <= 0 {
 		f.LookbackDays = 365
 	}
@@ -255,45 +220,36 @@ func (r *DiscoveryRepository) ListForgottenFavorites(ctx context.Context, f Forg
 	args = append(args, f.UserID, f.ProfileID, f.LookbackDays)
 	argIdx += 3
 
-	// Library access control.
-	fromClause := "media_items mi"
-	if f.Filter.AllowedLibraryIDs != nil || len(f.Filter.DisabledLibraryIDs) > 0 {
-		fromClause = "media_items mi JOIN media_item_libraries mil ON mi.content_id = mil.content_id"
-		if f.Filter.AllowedLibraryIDs != nil {
-			if len(f.Filter.AllowedLibraryIDs) == 0 {
-				return []*models.MediaItem{}, nil
-			}
-			placeholders := make([]string, len(f.Filter.AllowedLibraryIDs))
-			for i, id := range f.Filter.AllowedLibraryIDs {
-				placeholders[i] = fmt.Sprintf("$%d", argIdx)
-				args = append(args, id)
-				argIdx++
-			}
-			conditions = append(conditions, fmt.Sprintf("mil.media_folder_id IN (%s)", strings.Join(placeholders, ", ")))
-		}
-		if len(f.Filter.DisabledLibraryIDs) > 0 {
-			placeholders := make([]string, len(f.Filter.DisabledLibraryIDs))
-			for i, id := range f.Filter.DisabledLibraryIDs {
-				placeholders[i] = fmt.Sprintf("$%d", argIdx)
-				args = append(args, id)
-				argIdx++
-			}
-			conditions = append(conditions, fmt.Sprintf("mil.media_folder_id NOT IN (%s)", strings.Join(placeholders, ", ")))
-		}
+	if ok := appendDiscoveryLibraryScope(&conditions, &args, &argIdx, nil, f.Filter); !ok {
+		return "", nil
 	}
 
 	applyAccessFilter("mi", f.Filter, &conditions, &args, &argIdx)
 
 	query := fmt.Sprintf(
-		"SELECT %s FROM %s WHERE %s ORDER BY mi.rating_imdb DESC NULLS LAST, mi.content_id ASC",
-		itemColumns,
-		fromClause,
+		"SELECT %s FROM media_items mi WHERE %s ORDER BY mi.rating_imdb DESC NULLS LAST, mi.content_id ASC",
+		qualifiedItemColumns("mi"),
 		strings.Join(conditions, " AND "),
 	)
 
 	if f.Limit > 0 {
 		query += fmt.Sprintf(" LIMIT $%d", argIdx)
 		args = append(args, f.Limit)
+	}
+
+	return query, args
+}
+
+// ListForgottenFavorites returns high-rated items (rating_imdb >= 7.0) that the
+// user/profile either has never watched OR last watched more than LookbackDays
+// ago.  Results are ordered by rating_imdb DESC NULLS LAST.
+func (r *DiscoveryRepository) ListForgottenFavorites(ctx context.Context, f ForgottenFavoritesFilter) ([]*models.MediaItem, error) {
+	if f.UserID <= 0 || strings.TrimSpace(f.ProfileID) == "" {
+		return nil, fmt.Errorf("ListForgottenFavorites: UserID and ProfileID are required")
+	}
+	query, args := buildForgottenFavoritesQuery(f)
+	if query == "" {
+		return []*models.MediaItem{}, nil
 	}
 
 	rows, err := r.pool.Query(ctx, query, args...)
@@ -307,4 +263,42 @@ func (r *DiscoveryRepository) ListForgottenFavorites(ctx context.Context, f Forg
 		return nil, err
 	}
 	return items, nil
+}
+
+func appendDiscoveryLibraryScope(
+	conditions *[]string,
+	args *[]any,
+	argIdx *int,
+	libraryID *int,
+	filter AccessFilter,
+) bool {
+	if libraryID != nil {
+		whereSQL, scopeArgs, ok := buildLibraryScopeJoin([]int{*libraryID}, nil, *argIdx, "", "mi.content_id")
+		if ok {
+			*conditions = append(*conditions, whereSQL)
+			*args = append(*args, scopeArgs...)
+			*argIdx += len(scopeArgs)
+		}
+		return true
+	}
+
+	if filter.AllowedLibraryIDs != nil && len(filter.AllowedLibraryIDs) == 0 {
+		return false
+	}
+
+	// buildLibraryScopeJoin uses semi-joins: disabled libraries are an item-level
+	// exclusion, matching the rest of catalog access filtering and avoiding row fanout.
+	whereSQL, scopeArgs, ok := buildLibraryScopeJoin(
+		filter.AllowedLibraryIDs,
+		filter.DisabledLibraryIDs,
+		*argIdx,
+		"",
+		"mi.content_id",
+	)
+	if ok {
+		*conditions = append(*conditions, whereSQL)
+		*args = append(*args, scopeArgs...)
+		*argIdx += len(scopeArgs)
+	}
+	return true
 }

--- a/internal/catalog/discovery_repo_test.go
+++ b/internal/catalog/discovery_repo_test.go
@@ -409,6 +409,7 @@ func TestDiscoveryQueries_DisabledLibrariesUseNotExists(t *testing.T) {
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
 			assertNoLibraryJoin(t, tc.query)
+			assertDenyOnlyRequiresLibraryMembership(t, tc.query)
 			if !strings.Contains(tc.query, "NOT EXISTS (SELECT 1 FROM media_item_libraries mil_scope_out") {
 				t.Fatalf("expected disabled library NOT EXISTS predicate, got:\n%s", tc.query)
 			}
@@ -427,6 +428,17 @@ func assertNoLibraryJoin(t *testing.T, query string) {
 	t.Helper()
 	if strings.Contains(query, "JOIN media_item_libraries") {
 		t.Fatalf("plain library JOIN can fan out discovery rows, got:\n%s", query)
+	}
+}
+
+func assertDenyOnlyRequiresLibraryMembership(t *testing.T, query string) {
+	t.Helper()
+	membershipPredicate := "EXISTS (SELECT 1 FROM media_item_libraries mil_scope_any WHERE mil_scope_any.content_id = mi.content_id)"
+	if !strings.Contains(query, membershipPredicate) {
+		t.Fatalf("deny-only library filters must require positive library membership, got:\n%s", query)
+	}
+	if strings.Contains(query, "mil_scope_any.media_folder_id") {
+		t.Fatalf("positive membership predicate should not bind a specific library, got:\n%s", query)
 	}
 }
 

--- a/internal/catalog/discovery_repo_test.go
+++ b/internal/catalog/discovery_repo_test.go
@@ -4,138 +4,11 @@ package catalog
 // discovery_repo.go using the same pure-unit approach used throughout this
 // package: build a query string and assert that key fragments are present,
 // without needing a live database.
-//
-// The helpers themselves execute against a real pool; integration coverage is
-// provided by whichever recipe resolver exercises them in higher-level tests.
 
 import (
 	"strings"
 	"testing"
 )
-
-// buildRatingThresholdQuery is the testable extraction of the SQL generation
-// logic from ListByRatingThreshold so we can inspect it without a pool.
-func buildRatingThresholdQuery(f RatingFilter) (string, []any) {
-	var conditions []string
-	var args []any
-	argIdx := 1
-
-	conditions = append(conditions, "mi.rating_imdb >= $1")
-	args = append(args, f.Min)
-	argIdx++
-
-	fromClause := "media_items mi"
-	if f.LibraryID != nil {
-		fromClause = "media_items mi JOIN media_item_libraries mil ON mi.content_id = mil.content_id"
-		conditions = append(conditions, "mil.media_folder_id = $2")
-		args = append(args, *f.LibraryID)
-		argIdx++
-	} else if f.Filter.AllowedLibraryIDs != nil || len(f.Filter.DisabledLibraryIDs) > 0 {
-		fromClause = "media_items mi JOIN media_item_libraries mil ON mi.content_id = mil.content_id"
-		if f.Filter.AllowedLibraryIDs != nil {
-			if len(f.Filter.AllowedLibraryIDs) == 0 {
-				return "", nil // early empty
-			}
-			placeholders := make([]string, len(f.Filter.AllowedLibraryIDs))
-			for i, id := range f.Filter.AllowedLibraryIDs {
-				placeholders[i] = "$" + itoa(argIdx)
-				args = append(args, id)
-				argIdx++
-			}
-			conditions = append(conditions, "mil.media_folder_id IN ("+strings.Join(placeholders, ", ")+")")
-		}
-		if len(f.Filter.DisabledLibraryIDs) > 0 {
-			placeholders := make([]string, len(f.Filter.DisabledLibraryIDs))
-			for i, id := range f.Filter.DisabledLibraryIDs {
-				placeholders[i] = "$" + itoa(argIdx)
-				args = append(args, id)
-				argIdx++
-			}
-			conditions = append(conditions, "mil.media_folder_id NOT IN ("+strings.Join(placeholders, ", ")+")")
-		}
-	}
-
-	applyAccessFilter("mi", f.Filter, &conditions, &args, &argIdx)
-
-	query := "SELECT " + itemColumns + " FROM " + fromClause +
-		" WHERE " + strings.Join(conditions, " AND ") +
-		" ORDER BY mi.rating_imdb DESC NULLS LAST, mi.content_id ASC"
-
-	if f.Limit > 0 {
-		query += " LIMIT $" + itoa(argIdx)
-		args = append(args, f.Limit)
-	}
-	return query, args
-}
-
-// buildUnplayedHighRatedQuery mirrors the SQL-building portion of
-// ListUnplayedHighRated for unit testing.
-func buildUnplayedHighRatedQuery(f UnplayedFilter) (string, []any) {
-	var conditions []string
-	var args []any
-	argIdx := 1
-
-	conditions = append(conditions, "mi.rating_imdb >= $1")
-	args = append(args, f.MinRating)
-	argIdx++
-
-	conditions = append(conditions, "NOT EXISTS (\n\t\tSELECT 1\n\t\tFROM user_watch_history uwh\n\t\tWHERE uwh.user_id = $"+itoa(argIdx)+"\n\t\t  AND uwh.profile_id = $"+itoa(argIdx+1)+"\n\t\t  AND uwh.media_item_id = mi.content_id\n\t)")
-	args = append(args, f.UserID, f.ProfileID)
-	argIdx += 2
-
-	fromClause := "media_items mi"
-	if f.Filter.AllowedLibraryIDs != nil || len(f.Filter.DisabledLibraryIDs) > 0 {
-		fromClause = "media_items mi JOIN media_item_libraries mil ON mi.content_id = mil.content_id"
-		if f.Filter.AllowedLibraryIDs != nil {
-			if len(f.Filter.AllowedLibraryIDs) == 0 {
-				return "", nil // early empty
-			}
-			placeholders := make([]string, len(f.Filter.AllowedLibraryIDs))
-			for i, id := range f.Filter.AllowedLibraryIDs {
-				placeholders[i] = "$" + itoa(argIdx)
-				args = append(args, id)
-				argIdx++
-			}
-			conditions = append(conditions, "mil.media_folder_id IN ("+strings.Join(placeholders, ", ")+")")
-		}
-		if len(f.Filter.DisabledLibraryIDs) > 0 {
-			placeholders := make([]string, len(f.Filter.DisabledLibraryIDs))
-			for i, id := range f.Filter.DisabledLibraryIDs {
-				placeholders[i] = "$" + itoa(argIdx)
-				args = append(args, id)
-				argIdx++
-			}
-			conditions = append(conditions, "mil.media_folder_id NOT IN ("+strings.Join(placeholders, ", ")+")")
-		}
-	}
-
-	applyAccessFilter("mi", f.Filter, &conditions, &args, &argIdx)
-
-	query := "SELECT " + itemColumns + " FROM " + fromClause +
-		" WHERE " + strings.Join(conditions, " AND ") +
-		" ORDER BY mi.rating_imdb DESC NULLS LAST, mi.content_id ASC"
-
-	if f.Limit > 0 {
-		query += " LIMIT $" + itoa(argIdx)
-		args = append(args, f.Limit)
-	}
-	return query, args
-}
-
-// itoa is a local helper to avoid importing strconv.
-func itoa(n int) string {
-	if n == 0 {
-		return "0"
-	}
-	buf := [20]byte{}
-	pos := len(buf)
-	for n > 0 {
-		pos--
-		buf[pos] = byte('0' + n%10)
-		n /= 10
-	}
-	return string(buf[pos:])
-}
 
 // ---------------------------------------------------------------------------
 // ListByRatingThreshold SQL generation tests
@@ -147,6 +20,7 @@ func TestRatingThreshold_BasicQuery(t *testing.T) {
 		Limit: 20,
 	})
 
+	assertQualifiedItemSelect(t, query)
 	if !strings.Contains(query, "mi.rating_imdb >= $1") {
 		t.Fatalf("expected rating threshold predicate, got:\n%s", query)
 	}
@@ -181,25 +55,24 @@ func TestRatingThreshold_NoLimitOmitsClause(t *testing.T) {
 	}
 }
 
-func TestRatingThreshold_LibraryIDJoin(t *testing.T) {
+func TestRatingThreshold_LibraryIDUsesSemiJoin(t *testing.T) {
 	libID := 42
 	query, args := buildRatingThresholdQuery(RatingFilter{
 		Min:       7.0,
 		LibraryID: &libID,
 	})
 
-	if !strings.Contains(query, "JOIN media_item_libraries mil") {
-		t.Fatalf("expected library join, got:\n%s", query)
+	assertNoLibraryJoin(t, query)
+	if !strings.Contains(query, "EXISTS (SELECT 1 FROM media_item_libraries mil_scope_in") {
+		t.Fatalf("expected library EXISTS predicate, got:\n%s", query)
 	}
-	if !strings.Contains(query, "mil.media_folder_id = $2") {
-		t.Fatalf("expected media_folder_id predicate at $2, got:\n%s", query)
+	if !strings.Contains(query, "mil_scope_in.media_folder_id = ANY($2)") {
+		t.Fatalf("expected library id predicate at $2, got:\n%s", query)
 	}
 	if len(args) != 2 {
-		t.Fatalf("expected 2 args (min + library id), got %d", len(args))
+		t.Fatalf("expected 2 args (min + library id slice), got %d", len(args))
 	}
-	if args[1] != 42 {
-		t.Fatalf("expected library id 42 at args[1], got %v", args[1])
-	}
+	assertIntSliceArg(t, args, 1, []int{42})
 }
 
 func TestRatingThreshold_AllowedLibraries(t *testing.T) {
@@ -210,18 +83,20 @@ func TestRatingThreshold_AllowedLibraries(t *testing.T) {
 		},
 	})
 
-	if !strings.Contains(query, "JOIN media_item_libraries mil") {
-		t.Fatalf("expected library join, got:\n%s", query)
+	assertNoLibraryJoin(t, query)
+	if !strings.Contains(query, "EXISTS (SELECT 1 FROM media_item_libraries mil_scope_in") {
+		t.Fatalf("expected allowed library EXISTS predicate, got:\n%s", query)
 	}
-	if !strings.Contains(query, "mil.media_folder_id IN ($2, $3)") {
-		t.Fatalf("expected allowed library IN clause, got:\n%s", query)
+	if !strings.Contains(query, "mil_scope_in.media_folder_id = ANY($2)") {
+		t.Fatalf("expected allowed library ANY clause, got:\n%s", query)
 	}
-	if len(args) != 3 {
-		t.Fatalf("expected 3 args, got %d: %v", len(args), args)
+	if len(args) != 2 {
+		t.Fatalf("expected 2 args, got %d: %v", len(args), args)
 	}
+	assertIntSliceArg(t, args, 1, []int{1, 2})
 }
 
-func TestRatingThreshold_DisabledLibraries(t *testing.T) {
+func TestRatingThreshold_DisabledLibrariesUseItemLevelExclusion(t *testing.T) {
 	query, args := buildRatingThresholdQuery(RatingFilter{
 		Min: 7.0,
 		Filter: AccessFilter{
@@ -229,19 +104,24 @@ func TestRatingThreshold_DisabledLibraries(t *testing.T) {
 		},
 	})
 
-	if !strings.Contains(query, "mil.media_folder_id NOT IN ($2)") {
-		t.Fatalf("expected disabled library NOT IN clause, got:\n%s", query)
+	assertNoLibraryJoin(t, query)
+	if !strings.Contains(query, "NOT EXISTS (SELECT 1 FROM media_item_libraries mil_scope_out") {
+		t.Fatalf("expected disabled library NOT EXISTS predicate, got:\n%s", query)
+	}
+	if !strings.Contains(query, "mil_scope_out.media_folder_id = ANY($2)") {
+		t.Fatalf("expected disabled library ANY clause, got:\n%s", query)
 	}
 	if len(args) != 2 {
 		t.Fatalf("expected 2 args, got %d: %v", len(args), args)
 	}
+	assertIntSliceArg(t, args, 1, []int{99})
 }
 
 func TestRatingThreshold_EmptyAllowedLibrariesReturnsEmptyQuery(t *testing.T) {
 	query, _ := buildRatingThresholdQuery(RatingFilter{
 		Min: 7.0,
 		Filter: AccessFilter{
-			AllowedLibraryIDs: []int{}, // empty slice → early return
+			AllowedLibraryIDs: []int{},
 		},
 	})
 	if query != "" {
@@ -261,6 +141,7 @@ func TestUnplayedHighRated_BasicQuery(t *testing.T) {
 		ProfileID: "profile-abc",
 	})
 
+	assertQualifiedItemSelect(t, query)
 	if !strings.Contains(query, "mi.rating_imdb >= $1") {
 		t.Fatalf("expected rating threshold predicate, got:\n%s", query)
 	}
@@ -301,14 +182,14 @@ func TestUnplayedHighRated_NoLimitOmitsClause(t *testing.T) {
 	}
 }
 
-func TestUnplayedHighRated_NoLibraryJoin(t *testing.T) {
+func TestUnplayedHighRated_NoLibraryScope(t *testing.T) {
 	query, _ := buildUnplayedHighRatedQuery(UnplayedFilter{
 		MinRating: 7.0,
 		UserID:    1,
 		ProfileID: "p",
 	})
-	if strings.Contains(query, "JOIN media_item_libraries") {
-		t.Fatalf("expected no library join when no library filter is set, got:\n%s", query)
+	if strings.Contains(query, "media_item_libraries") {
+		t.Fatalf("expected no library scope when no library filter is set, got:\n%s", query)
 	}
 }
 
@@ -322,15 +203,17 @@ func TestUnplayedHighRated_AllowedLibraries(t *testing.T) {
 		},
 	})
 
-	if !strings.Contains(query, "JOIN media_item_libraries mil") {
-		t.Fatalf("expected library join, got:\n%s", query)
+	assertNoLibraryJoin(t, query)
+	if !strings.Contains(query, "EXISTS (SELECT 1 FROM media_item_libraries mil_scope_in") {
+		t.Fatalf("expected allowed library EXISTS predicate, got:\n%s", query)
 	}
-	if !strings.Contains(query, "mil.media_folder_id IN ($4, $5)") {
-		t.Fatalf("expected allowed library IN clause at $4,$5, got:\n%s", query)
+	if !strings.Contains(query, "mil_scope_in.media_folder_id = ANY($4)") {
+		t.Fatalf("expected allowed library ANY clause at $4, got:\n%s", query)
 	}
-	if len(args) != 5 {
-		t.Fatalf("expected 5 args, got %d: %v", len(args), args)
+	if len(args) != 4 {
+		t.Fatalf("expected 4 args, got %d: %v", len(args), args)
 	}
+	assertIntSliceArg(t, args, 3, []int{10, 11})
 }
 
 func TestUnplayedHighRated_EmptyAllowedLibrariesReturnsEmptyQuery(t *testing.T) {
@@ -359,8 +242,6 @@ func TestUnplayedHighRated_ContentRatingFilter(t *testing.T) {
 		t.Fatalf("expected content_rating = ANY filter, got:\n%s", query)
 	}
 	// args: minRating, userID, profileID, then content rating slice (one arg).
-	// Task 5.1 converted the rating ladder from IN ($N, $N+1, ...) to
-	// = ANY($N) with a single bound slice arg.
 	if len(args) != 4 {
 		t.Fatalf("expected exactly 4 args (minRating, userID, profileID, rating slice); got %d: %v", len(args), args)
 	}
@@ -370,62 +251,6 @@ func TestUnplayedHighRated_ContentRatingFilter(t *testing.T) {
 // ListForgottenFavorites SQL generation tests
 // ---------------------------------------------------------------------------
 
-// buildForgottenFavoritesQuery is the testable extraction of the SQL
-// generation logic from ListForgottenFavorites.
-func buildForgottenFavoritesQuery(f ForgottenFavoritesFilter) (string, []any) {
-	if f.LookbackDays <= 0 {
-		f.LookbackDays = 365
-	}
-
-	var conditions []string
-	var args []any
-	argIdx := 1
-
-	conditions = append(conditions, "mi.rating_imdb >= 7.0")
-
-	conditions = append(conditions, "NOT EXISTS (\n\t\tSELECT 1\n\t\tFROM user_watch_history uwh\n\t\tWHERE uwh.user_id = $"+itoa(argIdx)+"\n\t\t  AND uwh.profile_id = $"+itoa(argIdx+1)+"\n\t\t  AND uwh.media_item_id = mi.content_id\n\t\t  AND uwh.watched_at >= NOW() - ($"+itoa(argIdx+2)+" || ' days')::interval\n\t)")
-	args = append(args, f.UserID, f.ProfileID, f.LookbackDays)
-	argIdx += 3
-
-	fromClause := "media_items mi"
-	if f.Filter.AllowedLibraryIDs != nil || len(f.Filter.DisabledLibraryIDs) > 0 {
-		fromClause = "media_items mi JOIN media_item_libraries mil ON mi.content_id = mil.content_id"
-		if f.Filter.AllowedLibraryIDs != nil {
-			if len(f.Filter.AllowedLibraryIDs) == 0 {
-				return "", nil // early empty
-			}
-			placeholders := make([]string, len(f.Filter.AllowedLibraryIDs))
-			for i, id := range f.Filter.AllowedLibraryIDs {
-				placeholders[i] = "$" + itoa(argIdx)
-				args = append(args, id)
-				argIdx++
-			}
-			conditions = append(conditions, "mil.media_folder_id IN ("+strings.Join(placeholders, ", ")+")")
-		}
-		if len(f.Filter.DisabledLibraryIDs) > 0 {
-			placeholders := make([]string, len(f.Filter.DisabledLibraryIDs))
-			for i, id := range f.Filter.DisabledLibraryIDs {
-				placeholders[i] = "$" + itoa(argIdx)
-				args = append(args, id)
-				argIdx++
-			}
-			conditions = append(conditions, "mil.media_folder_id NOT IN ("+strings.Join(placeholders, ", ")+")")
-		}
-	}
-
-	applyAccessFilter("mi", f.Filter, &conditions, &args, &argIdx)
-
-	query := "SELECT " + itemColumns + " FROM " + fromClause +
-		" WHERE " + strings.Join(conditions, " AND ") +
-		" ORDER BY mi.rating_imdb DESC NULLS LAST, mi.content_id ASC"
-
-	if f.Limit > 0 {
-		query += " LIMIT $" + itoa(argIdx)
-		args = append(args, f.Limit)
-	}
-	return query, args
-}
-
 func TestForgottenFavorites_BasicQuery(t *testing.T) {
 	query, args := buildForgottenFavoritesQuery(ForgottenFavoritesFilter{
 		LookbackDays: 365,
@@ -434,6 +259,7 @@ func TestForgottenFavorites_BasicQuery(t *testing.T) {
 		ProfileID:    "profile-xyz",
 	})
 
+	assertQualifiedItemSelect(t, query)
 	if !strings.Contains(query, "mi.rating_imdb >= 7.0") {
 		t.Fatalf("expected 7.0 rating floor, got:\n%s", query)
 	}
@@ -477,14 +303,14 @@ func TestForgottenFavorites_NoLimitOmitsClause(t *testing.T) {
 	}
 }
 
-func TestForgottenFavorites_NoLibraryJoin(t *testing.T) {
+func TestForgottenFavorites_NoLibraryScope(t *testing.T) {
 	query, _ := buildForgottenFavoritesQuery(ForgottenFavoritesFilter{
 		LookbackDays: 365,
 		UserID:       1,
 		ProfileID:    "p",
 	})
-	if strings.Contains(query, "JOIN media_item_libraries") {
-		t.Fatalf("expected no library join when no library filter is set, got:\n%s", query)
+	if strings.Contains(query, "media_item_libraries") {
+		t.Fatalf("expected no library scope when no library filter is set, got:\n%s", query)
 	}
 }
 
@@ -498,15 +324,17 @@ func TestForgottenFavorites_AllowedLibraries(t *testing.T) {
 		},
 	})
 
-	if !strings.Contains(query, "JOIN media_item_libraries mil") {
-		t.Fatalf("expected library join, got:\n%s", query)
+	assertNoLibraryJoin(t, query)
+	if !strings.Contains(query, "EXISTS (SELECT 1 FROM media_item_libraries mil_scope_in") {
+		t.Fatalf("expected allowed library EXISTS predicate, got:\n%s", query)
 	}
-	if !strings.Contains(query, "mil.media_folder_id IN ($4, $5)") {
-		t.Fatalf("expected allowed library IN clause at $4,$5, got:\n%s", query)
+	if !strings.Contains(query, "mil_scope_in.media_folder_id = ANY($4)") {
+		t.Fatalf("expected allowed library ANY clause at $4, got:\n%s", query)
 	}
-	if len(args) != 5 {
-		t.Fatalf("expected 5 args, got %d: %v", len(args), args)
+	if len(args) != 4 {
+		t.Fatalf("expected 4 args, got %d: %v", len(args), args)
 	}
+	assertIntSliceArg(t, args, 3, []int{10, 11})
 }
 
 func TestForgottenFavorites_EmptyAllowedLibrariesReturnsEmptyQuery(t *testing.T) {
@@ -525,14 +353,13 @@ func TestForgottenFavorites_EmptyAllowedLibrariesReturnsEmptyQuery(t *testing.T)
 
 func TestForgottenFavorites_DefaultLookbackApplied(t *testing.T) {
 	query, args := buildForgottenFavoritesQuery(ForgottenFavoritesFilter{
-		LookbackDays: 0, // should default to 365
+		LookbackDays: 0,
 		UserID:       1,
 		ProfileID:    "p",
 	})
 	if !strings.Contains(query, "NOT EXISTS") {
 		t.Fatalf("expected NOT EXISTS subquery, got:\n%s", query)
 	}
-	// args[2] should be the defaulted lookback value (365).
 	if len(args) < 3 {
 		t.Fatalf("expected at least 3 args, got %d", len(args))
 	}
@@ -540,3 +367,86 @@ func TestForgottenFavorites_DefaultLookbackApplied(t *testing.T) {
 		t.Fatalf("expected lookback default 365, got %v", args[2])
 	}
 }
+
+func TestDiscoveryQueries_QualifyContentIDAndAvoidLibraryJoin(t *testing.T) {
+	restricted := AccessFilter{AllowedLibraryIDs: []int{1, 2}}
+
+	cases := []struct {
+		name  string
+		query string
+	}{
+		{"rating_threshold", mustQuery(buildRatingThresholdQuery(RatingFilter{Min: 7, Filter: restricted}))},
+		{"unplayed_high_rated", mustQuery(buildUnplayedHighRatedQuery(UnplayedFilter{MinRating: 7, UserID: 1, ProfileID: "p", Filter: restricted}))},
+		{"forgotten_favorites", mustQuery(buildForgottenFavoritesQuery(ForgottenFavoritesFilter{UserID: 1, ProfileID: "p", LookbackDays: 365, Filter: restricted}))},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			assertQualifiedItemSelect(t, tc.query)
+			assertNoLibraryJoin(t, tc.query)
+			if !strings.Contains(tc.query, "EXISTS (SELECT 1 FROM media_item_libraries mil_scope_in") {
+				t.Fatalf("expected allowed library EXISTS predicate, got:\n%s", tc.query)
+			}
+			if strings.Contains(tc.query, "SELECT content_id,") {
+				t.Fatalf("SELECT list uses an unqualified content_id, got:\n%s", tc.query)
+			}
+		})
+	}
+}
+
+func TestDiscoveryQueries_DisabledLibrariesUseNotExists(t *testing.T) {
+	filter := AccessFilter{DisabledLibraryIDs: []int{9}}
+
+	cases := []struct {
+		name  string
+		query string
+	}{
+		{"rating_threshold", mustQuery(buildRatingThresholdQuery(RatingFilter{Min: 7, Filter: filter}))},
+		{"unplayed_high_rated", mustQuery(buildUnplayedHighRatedQuery(UnplayedFilter{MinRating: 7, UserID: 1, ProfileID: "p", Filter: filter}))},
+		{"forgotten_favorites", mustQuery(buildForgottenFavoritesQuery(ForgottenFavoritesFilter{UserID: 1, ProfileID: "p", LookbackDays: 365, Filter: filter}))},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			assertNoLibraryJoin(t, tc.query)
+			if !strings.Contains(tc.query, "NOT EXISTS (SELECT 1 FROM media_item_libraries mil_scope_out") {
+				t.Fatalf("expected disabled library NOT EXISTS predicate, got:\n%s", tc.query)
+			}
+		})
+	}
+}
+
+func assertQualifiedItemSelect(t *testing.T, query string) {
+	t.Helper()
+	if !strings.HasPrefix(query, "SELECT mi.content_id,") {
+		t.Fatalf("SELECT list is not qualified with the mi alias, got:\n%s", query)
+	}
+}
+
+func assertNoLibraryJoin(t *testing.T, query string) {
+	t.Helper()
+	if strings.Contains(query, "JOIN media_item_libraries") {
+		t.Fatalf("plain library JOIN can fan out discovery rows, got:\n%s", query)
+	}
+}
+
+func assertIntSliceArg(t *testing.T, args []any, idx int, want []int) {
+	t.Helper()
+	if idx >= len(args) {
+		t.Fatalf("missing arg %d in %v", idx, args)
+	}
+	got, ok := args[idx].([]int)
+	if !ok {
+		t.Fatalf("arg %d has type %T, want []int", idx, args[idx])
+	}
+	if len(got) != len(want) {
+		t.Fatalf("arg %d = %v, want %v", idx, got, want)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("arg %d = %v, want %v", idx, got, want)
+		}
+	}
+}
+
+func mustQuery(query string, _ []any) string { return query }

--- a/internal/catalog/folder_repo.go
+++ b/internal/catalog/folder_repo.go
@@ -716,12 +716,12 @@ const collectOrphanedProvisionalIDsByContentIDSQL = `
 	SELECT mi.content_id
 	FROM public.media_items mi
 	WHERE mi.content_id = ANY($1)
-	  AND ` + orphanedMediaItemSafetyConditions
+	  AND ` + orphanedProvisionalMediaItemConditions
 
 const deleteOrphanedProvisionalIDsByContentIDSQL = `
 	DELETE FROM public.media_items mi
 	WHERE mi.content_id = ANY($1)
-	  AND ` + orphanedMediaItemSafetyConditions
+	  AND ` + orphanedProvisionalMediaItemConditions
 
 func (r *FolderRepository) deleteOrphanedItemsByContentID(ctx context.Context, contentIDs []string) (int, []string, error) {
 	if len(contentIDs) == 0 {


### PR DESCRIPTION
## Summary

- Qualify discovery SELECT projections with the `mi` alias so library-scoped discovery queries no longer hit ambiguous `content_id` references.
- Replace direct `media_item_libraries` joins in discovery queries with the existing `buildLibraryScopeJoin` semi-join helper to avoid multi-library row fanout.
- Keep empty allowed-library semantics, and make disabled-library filtering an item-level exclusion matching the rest of catalog access filtering.
- Reuse the full provisional orphan predicate for late orphan collect/delete cleanup.

Supersedes #80.

## Root Cause

The discovery queries for hidden gems, critically acclaimed, and forgotten favorites could join `media_item_libraries` for library-scoped viewers while selecting the unqualified `itemColumns` projection. Since both `media_items` and `media_item_libraries` expose `content_id`, PostgreSQL can reject those queries with `SQLSTATE 42702`.

The direct join form also fans out items that belong to multiple matching libraries, which can duplicate rows and interact badly with limits. The new shape keeps `media_items mi` as the only outer relation and scopes libraries with `EXISTS` / `NOT EXISTS` predicates.

## Validation

- `go test ./internal/catalog -run 'Discovery|RatingThreshold|Unplayed|ForgottenFavorites|TestLateOrphanCleanupUsesProvisionalSafetyPredicate' -count=1`
- `go test ./internal/catalog -count=1`
- `git diff --check`
- Dev deployment validation on `100.86.116.20`:
  - `/api/v1/ready` returned OK.
  - The old bad SQL shape reproduced `ERROR: column reference "content_id" is ambiguous`.
  - The fixed discovery query shapes executed successfully.
  - `GET /api/v1/home/sections` returned 200 for a restricted profile.
  - `GET /api/v1/home/sections/127245166910046212/items` returned 200 for `hidden_gems`.
  - Logs after the requests had no `SQLSTATE 42702`, no ambiguous `content_id`, and no affected discovery fetch errors.
  - Fanout check: old qualified join returned 150,967 rows / 147,493 unique items; new `EXISTS` shape returned 147,493 rows / 147,493 unique items.

## AI Use

Implemented with Codex.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Optimized discovery query performance and library access filtering logic.
  * Improved orphaned media item cleanup process.

* **Tests**
  * Expanded test coverage for discovery features with enhanced validation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->