### PR TITLE
fix(web): drop backdrop-blur from Pill card overlay preset (scroll perf)

### DIFF
--- a/web/src/lib/overlays/presets.ts
+++ b/web/src/lib/overlays/presets.ts
@@ -60,7 +60,7 @@ export const OVERLAY_PRESETS: Record<PresetId, OverlayPreset> = {
     label: "Pill",
     description: "Larger pill with more padding. Works well with icons.",
     badgeClass:
-      "rounded-full border border-white/15 px-2.5 py-1 text-[10px] font-semibold tracking-wide uppercase leading-none backdrop-blur-sm",
+      "rounded-full border border-white/15 px-2.5 py-1 text-[10px] font-semibold tracking-wide uppercase leading-none",
     badgeStyle: (accent) => ({
       background: accent
         ? `color-mix(in srgb, ${accent} 20%, rgba(20,20,30,0.7))`


### PR DESCRIPTION
## Problem

The **Pill** card-overlay preset is the only one of the five presets that includes `backdrop-blur-sm` (`backdrop-filter: blur(4px)`) on its badge class:

```
web/src/lib/overlays/presets.ts
pill.badgeClass: "... uppercase leading-none backdrop-blur-sm"
```

`backdrop-filter` is one of the most expensive CSS properties. Each badge that uses it forces its own compositing layer and must re-sample + Gaussian-blur the pixels behind it on **every repaint — including every scroll frame**, because the poster art behind the badge moves while scrolling.

`CardOverlays` renders one `<span>` per enabled badge, drawn from a registry of ~24 badge types. A typical library grid (50–100 cards × 2–4 badges each) produces **hundreds of live `backdrop-filter` layers re-blurring on every scroll tick**, which causes severe scroll/interaction jank. It was reported in the wild on Chrome / Windows 11 (integrated-GPU / software compositing — the worst case for backdrop-filter). The other four presets, which have no `backdrop-blur`, are unaffected.

## Fix

Remove `backdrop-blur-sm` from the Pill `badgeClass`. The blur is also effectively invisible: the Pill background is already `rgba(20,20,30,0.7)` (70% opaque), so you can barely see through it to perceive any blur. Dropping it has no meaningful visual impact while eliminating the per-frame GPU cost. Shape, padding, border, and icon behavior are unchanged.

## Verification

Built and deployed to a production instance, then verified in the served bundle that the Pill class no longer carries `backdrop-blur` while the preset is otherwise intact. With the Pill theme selected, scrolling a large library grid in Chrome on Windows went from janky to smooth. Confirmed by the original reporter.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Adjusted pill badge styling to remove backdrop blur effect for a cleaner visual appearance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->