### PR TITLE
fix(scanner): skip misplaced TV episodes in movie libraries

### DIFF
--- a/internal/metadata/movie_match_queue_repo.go
+++ b/internal/metadata/movie_match_queue_repo.go
@@ -43,6 +43,31 @@ func requirePositiveMovieQueueID(label string, value int) error {
 	return nil
 }
 
+// movieQueueFileEligibleCond is the predicate deciding whether a media file
+// belongs in the movie match queue. Queries embedding it must alias
+// media_files as mf, media_folders as folders, and media_items as mi.
+//
+// Files beneath a root skipped as misplaced series are excluded durably:
+// their content_id is never set, so without the exclusion every library sync
+// would re-enqueue them only for the worker to skip them again.
+const movieQueueFileEligibleCond = `folders.enabled = true
+	  AND (
+		lower(trim(folders.type)) IN ('movie', 'movies') OR
+		(lower(trim(folders.type)) = 'mixed' AND lower(trim(mf.base_type)) = 'movie')
+	  )
+	  AND mf.missing_since IS NULL
+	  AND (
+		mf.content_id IS NULL OR mf.content_id = '' OR
+		lower(trim(COALESCE(mi.status, ''))) IN ('pending', 'unmatched', 'ambiguous')
+	  )
+	  AND NOT EXISTS (
+		SELECT 1
+		FROM skipped_media_roots sr
+		WHERE sr.media_folder_id = mf.media_folder_id
+		  AND sr.reason = '` + skippedReasonSeriesInMovieLibrary + `'
+		  AND strpos(mf.file_path, sr.root_path || '/') = 1
+	  )`
+
 func (r *MovieMatchQueueRepository) EnqueueMovieFile(ctx context.Context, fileID int) error {
 	if err := r.requireConfigured(); err != nil {
 		return err
@@ -73,16 +98,7 @@ func (r *MovieMatchQueueRepository) EnqueueMovieFile(ctx context.Context, fileID
 		JOIN media_folders folders ON folders.id = mf.media_folder_id
 		LEFT JOIN media_items mi ON mi.content_id = mf.content_id
 		WHERE mf.id = $1
-		  AND folders.enabled = true
-		  AND (
-			lower(trim(folders.type)) IN ('movie', 'movies') OR
-			(lower(trim(folders.type)) = 'mixed' AND lower(trim(mf.base_type)) = 'movie')
-		  )
-		  AND mf.missing_since IS NULL
-		  AND (
-			mf.content_id IS NULL OR mf.content_id = '' OR
-			lower(trim(COALESCE(mi.status, ''))) IN ('pending', 'unmatched', 'ambiguous')
-		  )
+		  AND `+movieQueueFileEligibleCond+`
 		ON CONFLICT (media_file_id) DO UPDATE
 		SET media_folder_id = EXCLUDED.media_folder_id,
 			available_at = GREATEST(movie_match_queue.available_at, EXCLUDED.available_at),
@@ -100,16 +116,7 @@ func (r *MovieMatchQueueRepository) EnqueueMovieFile(ctx context.Context, fileID
 			JOIN media_folders folders ON folders.id = mf.media_folder_id
 			LEFT JOIN media_items mi ON mi.content_id = mf.content_id
 			WHERE mf.id = q.media_file_id
-			  AND folders.enabled = true
-			  AND (
-				lower(trim(folders.type)) IN ('movie', 'movies') OR
-				(lower(trim(folders.type)) = 'mixed' AND lower(trim(mf.base_type)) = 'movie')
-			  )
-			  AND mf.missing_since IS NULL
-			  AND (
-				mf.content_id IS NULL OR mf.content_id = '' OR
-				lower(trim(COALESCE(mi.status, ''))) IN ('pending', 'unmatched', 'ambiguous')
-			  )
+			  AND `+movieQueueFileEligibleCond+`
 		  )
 	`, fileID); err != nil {
 		return fmt.Errorf("deleting stale movie queue row: %w", err)
@@ -151,16 +158,7 @@ func (r *MovieMatchQueueRepository) SyncForFolder(ctx context.Context, folderID 
 		JOIN media_folders folders ON folders.id = mf.media_folder_id
 		LEFT JOIN media_items mi ON mi.content_id = mf.content_id
 		WHERE mf.media_folder_id = $1
-		  AND folders.enabled = true
-		  AND (
-			lower(trim(folders.type)) IN ('movie', 'movies') OR
-			(lower(trim(folders.type)) = 'mixed' AND lower(trim(mf.base_type)) = 'movie')
-		  )
-		  AND mf.missing_since IS NULL
-		  AND (
-			mf.content_id IS NULL OR mf.content_id = '' OR
-			lower(trim(COALESCE(mi.status, ''))) IN ('pending', 'unmatched', 'ambiguous')
-		  )
+		  AND `+movieQueueFileEligibleCond+`
 		ON CONFLICT (media_file_id) DO UPDATE
 		SET media_folder_id = EXCLUDED.media_folder_id,
 			available_at = GREATEST(movie_match_queue.available_at, EXCLUDED.available_at),
@@ -178,16 +176,7 @@ func (r *MovieMatchQueueRepository) SyncForFolder(ctx context.Context, folderID 
 			JOIN media_folders folders ON folders.id = mf.media_folder_id
 			LEFT JOIN media_items mi ON mi.content_id = mf.content_id
 			WHERE mf.id = q.media_file_id
-			  AND folders.enabled = true
-			  AND (
-				lower(trim(folders.type)) IN ('movie', 'movies') OR
-				(lower(trim(folders.type)) = 'mixed' AND lower(trim(mf.base_type)) = 'movie')
-			  )
-			  AND mf.missing_since IS NULL
-			  AND (
-				mf.content_id IS NULL OR mf.content_id = '' OR
-				lower(trim(COALESCE(mi.status, ''))) IN ('pending', 'unmatched', 'ambiguous')
-			  )
+			  AND `+movieQueueFileEligibleCond+`
 		  )
 	`, folderID); err != nil {
 		return fmt.Errorf("deleting stale movie queue rows for folder: %w", err)
@@ -234,19 +223,10 @@ func (r *MovieMatchQueueRepository) SyncInScope(ctx context.Context, folderID in
 		JOIN media_folders folders ON folders.id = mf.media_folder_id
 		LEFT JOIN media_items mi ON mi.content_id = mf.content_id
 		WHERE mf.media_folder_id = $1
-		  AND folders.enabled = true
-		  AND (
-			lower(trim(folders.type)) IN ('movie', 'movies') OR
-			(lower(trim(folders.type)) = 'mixed' AND lower(trim(mf.base_type)) = 'movie')
-		  )
-		  AND mf.missing_since IS NULL
+		  AND `+movieQueueFileEligibleCond+`
 		  AND (
 			mf.file_path = $2 OR
 			mf.file_path LIKE $3 ESCAPE '\'
-		  )
-		  AND (
-			mf.content_id IS NULL OR mf.content_id = '' OR
-			lower(trim(COALESCE(mi.status, ''))) IN ('pending', 'unmatched', 'ambiguous')
 		  )
 		ON CONFLICT (media_file_id) DO UPDATE
 		SET media_folder_id = EXCLUDED.media_folder_id,
@@ -281,16 +261,7 @@ func (r *MovieMatchQueueRepository) SyncInScope(ctx context.Context, folderID in
 			JOIN media_folders folders ON folders.id = mf.media_folder_id
 			LEFT JOIN media_items mi ON mi.content_id = mf.content_id
 			WHERE mf.id = q.media_file_id
-			  AND folders.enabled = true
-			  AND (
-				lower(trim(folders.type)) IN ('movie', 'movies') OR
-				(lower(trim(folders.type)) = 'mixed' AND lower(trim(mf.base_type)) = 'movie')
-			  )
-			  AND mf.missing_since IS NULL
-			  AND (
-				mf.content_id IS NULL OR mf.content_id = '' OR
-				lower(trim(COALESCE(mi.status, ''))) IN ('pending', 'unmatched', 'ambiguous')
-			  )
+			  AND `+movieQueueFileEligibleCond+`
 		  )
 	`, folderID, scopePath, scopeLike); err != nil {
 		return fmt.Errorf("deleting stale movie queue rows in scope: %w", err)
@@ -318,16 +289,7 @@ func (r *MovieMatchQueueRepository) Claim(ctx context.Context, limit int) ([]*mo
 			JOIN media_folders folders ON folders.id = mf.media_folder_id
 			LEFT JOIN media_items mi ON mi.content_id = mf.content_id
 			WHERE q.available_at <= NOW()
-			  AND folders.enabled = true
-			  AND (
-				lower(trim(folders.type)) IN ('movie', 'movies') OR
-				(lower(trim(folders.type)) = 'mixed' AND lower(trim(mf.base_type)) = 'movie')
-			  )
-			  AND mf.missing_since IS NULL
-			  AND (
-				mf.content_id IS NULL OR mf.content_id = '' OR
-				lower(trim(COALESCE(mi.status, ''))) IN ('pending', 'unmatched', 'ambiguous')
-			  )
+			  AND `+movieQueueFileEligibleCond+`
 			ORDER BY q.available_at ASC, q.last_attempted_at ASC NULLS FIRST, q.media_file_id ASC
 			LIMIT $1
 			FOR UPDATE OF q SKIP LOCKED
@@ -389,19 +351,10 @@ func (r *MovieMatchQueueRepository) ClaimByFolderAndPathPrefix(
 			LEFT JOIN media_items mi ON mi.content_id = mf.content_id
 			WHERE q.media_folder_id = $1
 			  AND q.available_at <= NOW()
-			  AND folders.enabled = true
-			  AND (
-				lower(trim(folders.type)) IN ('movie', 'movies') OR
-				(lower(trim(folders.type)) = 'mixed' AND lower(trim(mf.base_type)) = 'movie')
-			  )
-			  AND mf.missing_since IS NULL
+			  AND `+movieQueueFileEligibleCond+`
 			  AND (
 				mf.file_path = $2 OR
 				mf.file_path LIKE $3 ESCAPE '\'
-			  )
-			  AND (
-				mf.content_id IS NULL OR mf.content_id = '' OR
-				lower(trim(COALESCE(mi.status, ''))) IN ('pending', 'unmatched', 'ambiguous')
 			  )
 			  AND ($4::timestamptz IS NULL OR q.last_attempted_at IS NULL OR q.last_attempted_at < $4)
 			ORDER BY q.available_at ASC, q.last_attempted_at ASC NULLS FIRST, q.media_file_id ASC

--- a/internal/metadata/service.go
+++ b/internal/metadata/service.go
@@ -3897,6 +3897,37 @@ func (s *MetadataService) createOrFindSkeleton(ctx context.Context, file *models
 			}
 		}
 	}
+	// Misplaced-TV guard: a strict movie-type library should never turn a TV
+	// episode living inside a "Season NN/" (or "Specials") directory into a
+	// per-episode "Season NN" movie item. Such trees are series dropped into a
+	// movie library (e.g. fan supercut packs) and never match a movie provider;
+	// creating an item per episode just pollutes the catalog. Record the root
+	// for admin visibility and skip skeleton creation. "mixed" libraries are
+	// left untouched because they legitimately host series.
+	//
+	// This fires on the structural signal alone (season dir + SxxExx), even when
+	// a provider id was parsed — a "Season NN" folder otherwise yields a bogus
+	// id (the season number, e.g. tmdb="01"), so effectiveExternalIDs must NOT
+	// gate the skip.
+	if libNorm := strings.ToLower(strings.TrimSpace(libraryType)); (libNorm == "movie" || libNorm == "movies") &&
+		naming.IsMisplacedSeriesFile(file.FilePath) {
+		if s != nil && s.skippedRootRepo != nil {
+			if err := s.skippedRootRepo.Upsert(ctx, models.SkippedMediaRoot{
+				MediaFolderID:  folderID,
+				RootPath:       observedRootPath,
+				Reason:         "series_in_movie_library",
+				SampleFilePath: file.FilePath,
+				FileCount:      1,
+			}); err != nil {
+				slog.Warn("metadata: failed to record misplaced-series root",
+					"folder_id", folderID,
+					"root_path", observedRootPath,
+					"error", err)
+			}
+		}
+		res.ItemStatus = "skipped"
+		return res, nil
+	}
 	if effectiveExternalIDs == nil {
 		// Record for admin diagnostics only — no longer bail out.
 		if s != nil && s.skippedRootRepo != nil {

--- a/internal/metadata/service.go
+++ b/internal/metadata/service.go
@@ -143,7 +143,7 @@ type metadataObservedLocationRepo interface {
 // creation for legacy diagnostics. The concrete *SkippedRootRepository
 // satisfies this interface.
 type metadataSkippedRootRepo interface {
-	Upsert(ctx context.Context, root models.SkippedMediaRoot) error
+	UpsertObservedFile(ctx context.Context, folderID int, rootPath, reason, sampleFilePath string) error
 	Delete(ctx context.Context, folderID int, rootPath string) error
 }
 
@@ -3749,6 +3749,7 @@ func (s *MetadataService) createOrFindSkeleton(ctx context.Context, file *models
 	if err != nil {
 		return nil, err
 	}
+	libraryTypeNorm := strings.ToLower(strings.TrimSpace(libraryType))
 
 	contentRootPath := filepath.Dir(file.FilePath)
 	if file.CanonicalRootPath != "" {
@@ -3842,7 +3843,7 @@ func (s *MetadataService) createOrFindSkeleton(ctx context.Context, file *models
 		}
 	}
 	if res.Type == "" {
-		switch strings.ToLower(strings.TrimSpace(libraryType)) {
+		switch libraryTypeNorm {
 		case "series", "tv", "show", "tvshows":
 			res.Type = "series"
 		case "movie", "movies":
@@ -3902,48 +3903,24 @@ func (s *MetadataService) createOrFindSkeleton(ctx context.Context, file *models
 	// per-episode "Season NN" movie item. Such trees are series dropped into a
 	// movie library (e.g. fan supercut packs) and never match a movie provider;
 	// creating an item per episode just pollutes the catalog. Record the root
-	// for admin visibility and skip skeleton creation. "mixed" libraries are
-	// left untouched because they legitimately host series.
+	// for admin visibility and skip skeleton creation; the movie match queue
+	// excludes files beneath such roots so they are not re-enqueued on every
+	// sync (see movieQueueFileEligibleCond). "mixed" libraries are left
+	// untouched because they legitimately host series.
 	//
 	// This fires on the structural signal alone (season dir + SxxExx), even when
 	// a provider id was parsed — a "Season NN" folder otherwise yields a bogus
 	// id (the season number, e.g. tmdb="01"), so effectiveExternalIDs must NOT
 	// gate the skip.
-	if libNorm := strings.ToLower(strings.TrimSpace(libraryType)); (libNorm == "movie" || libNorm == "movies") &&
+	if (libraryTypeNorm == "movie" || libraryTypeNorm == "movies") &&
 		naming.IsMisplacedSeriesFile(file.FilePath) {
-		if s != nil && s.skippedRootRepo != nil {
-			if err := s.skippedRootRepo.Upsert(ctx, models.SkippedMediaRoot{
-				MediaFolderID:  folderID,
-				RootPath:       observedRootPath,
-				Reason:         "series_in_movie_library",
-				SampleFilePath: file.FilePath,
-				FileCount:      1,
-			}); err != nil {
-				slog.Warn("metadata: failed to record misplaced-series root",
-					"folder_id", folderID,
-					"root_path", observedRootPath,
-					"error", err)
-			}
-		}
+		s.recordSkippedRoot(ctx, folderID, observedRootPath, skippedReasonSeriesInMovieLibrary, file.FilePath)
 		res.ItemStatus = "skipped"
 		return res, nil
 	}
 	if effectiveExternalIDs == nil {
 		// Record for admin diagnostics only — no longer bail out.
-		if s != nil && s.skippedRootRepo != nil {
-			if err := s.skippedRootRepo.Upsert(ctx, models.SkippedMediaRoot{
-				MediaFolderID:  folderID,
-				RootPath:       observedRootPath,
-				Reason:         "missing_folder_ids",
-				SampleFilePath: file.FilePath,
-				FileCount:      1,
-			}); err != nil {
-				slog.Warn("metadata: failed to record skipped root",
-					"folder_id", folderID,
-					"root_path", observedRootPath,
-					"error", err)
-			}
-		}
+		s.recordSkippedRoot(ctx, folderID, observedRootPath, skippedReasonMissingFolderIDs, file.FilePath)
 	}
 
 	unlockDedup := s.lockDedupKey(dedupKeyForSkeleton(
@@ -4155,6 +4132,22 @@ func (s *MetadataService) folderTypeForSkeleton(ctx context.Context, folderID in
 		return "", fmt.Errorf("folder %d is disabled for skeleton creation", folderID)
 	}
 	return folder.Type, nil
+}
+
+// recordSkippedRoot records the root of file for admin diagnostics in
+// skipped_media_roots. Failures are logged and swallowed: diagnostics must
+// never block skeleton creation.
+func (s *MetadataService) recordSkippedRoot(ctx context.Context, folderID int, rootPath, reason, sampleFilePath string) {
+	if s == nil || s.skippedRootRepo == nil {
+		return
+	}
+	if err := s.skippedRootRepo.UpsertObservedFile(ctx, folderID, rootPath, reason, sampleFilePath); err != nil {
+		slog.Warn("metadata: failed to record skipped root",
+			"folder_id", folderID,
+			"root_path", rootPath,
+			"reason", reason,
+			"error", err)
+	}
 }
 
 func (s *MetadataService) deleteCreatedSkeleton(ctx context.Context, contentID string) error {

--- a/internal/metadata/service_test.go
+++ b/internal/metadata/service_test.go
@@ -786,11 +786,17 @@ func newFakeSkippedRootRepo() *fakeSkippedRootRepo {
 	return &fakeSkippedRootRepo{skipped: make(map[string]models.SkippedMediaRoot)}
 }
 
-func (r *fakeSkippedRootRepo) Upsert(_ context.Context, root models.SkippedMediaRoot) error {
+func (r *fakeSkippedRootRepo) UpsertObservedFile(_ context.Context, folderID int, rootPath, reason, sampleFilePath string) error {
 	r.mu.Lock()
 	defer r.mu.Unlock()
-	key := fmt.Sprintf("%d:%s", root.MediaFolderID, root.RootPath)
-	r.skipped[key] = root
+	key := fmt.Sprintf("%d:%s", folderID, rootPath)
+	r.skipped[key] = models.SkippedMediaRoot{
+		MediaFolderID:  folderID,
+		RootPath:       rootPath,
+		Reason:         reason,
+		SampleFilePath: sampleFilePath,
+		FileCount:      1,
+	}
 	return nil
 }
 

--- a/internal/metadata/skipped_root_repo.go
+++ b/internal/metadata/skipped_root_repo.go
@@ -11,6 +11,17 @@ import (
 	"github.com/Silo-Server/silo-server/internal/models"
 )
 
+const (
+	// skippedReasonSeriesInMovieLibrary marks roots holding TV episodes dropped
+	// into a strict movie library. The movie match queue durably excludes files
+	// beneath such roots (see movieQueueFileEligibleCond); deleting the row
+	// makes the files eligible for matching again.
+	skippedReasonSeriesInMovieLibrary = "series_in_movie_library"
+	// skippedReasonMissingFolderIDs marks roots whose folder names carry no
+	// provider IDs. Recorded for diagnostics only; matching still proceeds.
+	skippedReasonMissingFolderIDs = "missing_folder_ids"
+)
+
 // SkippedRootRepository persists media roots that were skipped during scans.
 type SkippedRootRepository struct {
 	pool *pgxpool.Pool
@@ -87,6 +98,38 @@ func (r *SkippedRootRepository) Upsert(ctx context.Context, root models.SkippedM
 	)
 	if err != nil {
 		return fmt.Errorf("upserting skipped media root: %w", err)
+	}
+	return nil
+}
+
+// UpsertObservedFile records a skipped media root observed through a single
+// file, deriving file_count from the media_files currently present beneath the
+// root. Unlike Upsert, repeated per-file calls stay accurate and idempotent: a
+// 34-episode pack converges on file_count=34 instead of overwriting it with
+// each caller's partial count.
+func (r *SkippedRootRepository) UpsertObservedFile(ctx context.Context, folderID int, rootPath, reason, sampleFilePath string) error {
+	query := `
+		INSERT INTO skipped_media_roots (
+			media_folder_id, root_path, reason, sample_file_path, file_count, first_seen_at, last_seen_at
+		)
+		VALUES ($1, $2, $3, $4,
+			GREATEST(1, (
+				SELECT COUNT(*)
+				FROM media_files mf
+				WHERE mf.media_folder_id = $1
+				  AND mf.missing_since IS NULL
+				  AND strpos(mf.file_path, $2 || '/') = 1
+			)),
+			NOW(), NOW())
+		ON CONFLICT (media_folder_id, root_path) DO UPDATE
+		SET reason = EXCLUDED.reason,
+			sample_file_path = EXCLUDED.sample_file_path,
+			file_count = EXCLUDED.file_count,
+			last_seen_at = NOW()
+	`
+	_, err := r.pool.Exec(ctx, query, folderID, filepath.Clean(rootPath), reason, sampleFilePath)
+	if err != nil {
+		return fmt.Errorf("upserting observed skipped media root: %w", err)
 	}
 	return nil
 }

--- a/internal/metadata/worker.go
+++ b/internal/metadata/worker.go
@@ -623,7 +623,9 @@ func (w *MatchWorker) processQueuedMovieFile(ctx context.Context, file *models.M
 	if skeleton != nil && skeleton.ItemStatus == "skipped" {
 		// Deliberately skipped during skeleton creation (e.g. a misplaced TV
 		// episode inside a movie library): no item is created on purpose.
-		// Dequeue so the file is not retried forever.
+		// Dequeue immediately; the recorded skipped root keeps the file out of
+		// future enqueues (see movieQueueFileEligibleCond), so this drains rows
+		// claimed before the skipped root was recorded.
 		if err := w.movieClaimer.Delete(ctx, file.ID); err != nil {
 			slog.Warn("metadata: failed to delete skipped movie queue row",
 				"file_id", file.ID,

--- a/internal/metadata/worker.go
+++ b/internal/metadata/worker.go
@@ -620,6 +620,20 @@ func (w *MatchWorker) processQueuedMovieFile(ctx context.Context, file *models.M
 		)
 		return false
 	}
+	if skeleton != nil && skeleton.ItemStatus == "skipped" {
+		// Deliberately skipped during skeleton creation (e.g. a misplaced TV
+		// episode inside a movie library): no item is created on purpose.
+		// Dequeue so the file is not retried forever.
+		if err := w.movieClaimer.Delete(ctx, file.ID); err != nil {
+			slog.Warn("metadata: failed to delete skipped movie queue row",
+				"file_id", file.ID,
+				"path", file.FilePath,
+				"error", err,
+			)
+			return false
+		}
+		return true
+	}
 	if skeleton == nil || strings.TrimSpace(skeleton.ContentID) == "" {
 		if updateErr := w.movieClaimer.UpdateError(ctx, file.ID, truncateSeriesQueueError("movie queue claimed without a content id")); updateErr != nil {
 			slog.Warn("metadata: failed to update movie queue error",

--- a/internal/naming/misplaced_series_test.go
+++ b/internal/naming/misplaced_series_test.go
@@ -1,0 +1,35 @@
+package naming
+
+import "testing"
+
+func TestIsMisplacedSeriesFile(t *testing.T) {
+	cases := []struct {
+		name string
+		path string
+		want bool
+	}{
+		// Misplaced TV show in a movie library: Season dir + SxxExx file.
+		{"bleach supercut", `/mnt/unionfs/movies/anime-dub/Bleach Supercuts/Season 01/Bleach Supercuts S01E01 - Ichigo.mkv`, true},
+		{"bleach last ep", `/mnt/unionfs/movies/anime-dub/Bleach Supercuts/Season 01/Bleach Supercuts S01E34- Goodbye.mkv`, true},
+		{"specials dir", `/mnt/unionfs/movies/anime/Some Show/Specials/Some Show S00E02 - OVA.mkv`, true},
+		{"extras dir", `/mnt/unionfs/movies/anime/Some Show/Extras/Some Show S00E03 - Bonus.mkv`, true},
+		{"lowercase season", `/x/movies/Show/season 2/Show s02e05.mkv`, true},
+
+		// Legit movies whose release filenames merely contain an SxxExx substring
+		// but sit in a proper "Title (Year)/" folder — must NOT be flagged.
+		{"fired up", `/mnt/unionfs/movies/alt-cuts/1080p/Fired Up! (2009)/101.Dalmatian.Street.S01E09-E10.Perfect.Match.1080p.mkv`, false},
+		{"puppet master", `/mnt/unionfs/movies/alt-cuts/1080p/Puppet Master (1989)/Transformers.Armada.S01E43.Puppet.1080p.mkv`, false},
+		{"k seven", `/mnt/unionfs/movies/anime/K Seven Stories Movie 1 RB Blaze (2018) {tmdb-483452}/K (2012) - S00E05 - R-B Blaze.mkv`, false},
+
+		// Ordinary movie, no episode pattern at all.
+		{"plain movie", `/mnt/unionfs/movies/00s/Heat (1995) {tmdb-949}/Heat (1995).mkv`, false},
+		// Episode pattern but no season/specials directory (loose dump) — not our
+		// case here; left to the existing ambiguity heuristic, so NOT flagged.
+		{"loose episode no season dir", `/mnt/unionfs/movies/anime/Whatever S01E02.mkv`, false},
+	}
+	for _, tc := range cases {
+		if got := IsMisplacedSeriesFile(tc.path); got != tc.want {
+			t.Errorf("%s: IsMisplacedSeriesFile(%q) = %v, want %v", tc.name, tc.path, got, tc.want)
+		}
+	}
+}

--- a/internal/naming/root_inference.go
+++ b/internal/naming/root_inference.go
@@ -365,6 +365,33 @@ func detectInferSeasonStructure(parts []string, allowNumeric bool) bool {
 	return false
 }
 
+// IsMisplacedSeriesFile reports whether filePath is a TV episode that lives
+// inside an explicit "Season NN/" (or "Specials"/"Extras") directory. Such a
+// file is a series structure dropped into a movie-type library (e.g. a fan
+// "supercuts" pack): a movie library would otherwise turn every episode into a
+// bogus per-episode "Season NN" movie that never matches a movie provider.
+//
+// The check is intentionally strict — it requires BOTH an SxxExx pattern in the
+// file name AND an explicit season/specials ancestor directory — so legitimate
+// movies that merely carry an episode-like substring in their release name
+// (e.g. "...S01E43..." inside a "Title (Year)/" folder) are never flagged.
+func IsMisplacedSeriesFile(filePath string) bool {
+	clean := filepath.Clean(filePath)
+	baseName := filepath.Base(clean)
+	nameNoExt := strings.TrimSuffix(baseName, filepath.Ext(baseName))
+	if !inferSeasonEpisodeRe.MatchString(nameNoExt) {
+		return false
+	}
+	parts := strings.Split(filepath.ToSlash(clean), "/")
+	for _, part := range parts[:max(len(parts)-1, 0)] {
+		segment := filepath.Base(part)
+		if inferSeasonDirRe.MatchString(segment) || inferSpecialsDirRe.MatchString(segment) {
+			return true
+		}
+	}
+	return false
+}
+
 func detectInferMovieFolderEvidence(parentBase string, nameNoExt string, hasSeasonStructure bool) bool {
 	if hasSeasonStructure {
 		return false

--- a/internal/naming/root_inference.go
+++ b/internal/naming/root_inference.go
@@ -384,8 +384,7 @@ func IsMisplacedSeriesFile(filePath string) bool {
 	}
 	parts := strings.Split(filepath.ToSlash(clean), "/")
 	for _, part := range parts[:max(len(parts)-1, 0)] {
-		segment := filepath.Base(part)
-		if inferSeasonDirRe.MatchString(segment) || inferSpecialsDirRe.MatchString(segment) {
+		if inferSeasonDirRe.MatchString(part) || inferSpecialsDirRe.MatchString(part) {
 			return true
 		}
 	}


### PR DESCRIPTION
## Problem

In a **movie-type library**, a TV show laid out as `Show/Season NN/SxxExx.mkv` (for example a fan "supercuts" pack dropped into an anime-movies folder) is turned into **one bogus movie item per episode**, every one titled after the season folder — e.g. 34 separate items all named **"Season 01"**. They pile up on *Recently Added*, never match a movie provider, and clicking one opens a "movie" that is really an episode.

Root cause: the movie skeleton path treats every file as a movie. A `Season NN` folder even parses a bogus provider id (the season number becomes `tmdb="01"`), so the items aren't even caught as ID-less.

## Fix

- **`naming.IsMisplacedSeriesFile`** — detects a file that has an `SxxExx` name **and** lives inside an explicit `Season NN`/`Specials` (or `Extras`) directory. Deliberately strict: it requires *both* signals so a movie whose release name merely contains an `SxxExx` substring (e.g. `...S01E43...` inside a `Title (Year)/` folder) is **not** affected.
- **`createOrFindSkeleton`** — in a strict movie/`movies` library, such a file is recorded as a skipped root (`reason=series_in_movie_library`) and **no item is created**. The check runs on the structural signal alone, *not* gated on missing provider ids (a `Season NN` folder otherwise yields the bogus `tmdb="01"`). `mixed` libraries are left untouched since they legitimately host series.
- **Movie match-queue worker** — dequeues files the skeleton step deliberately skips (`ItemStatus=="skipped"`) instead of erroring with *"movie queue claimed without a content id"* and retrying forever.

## Verification

- New unit test `internal/naming/misplaced_series_test.go` covers the misplaced-TV case and the legit-`SxxExx`-movie case; `go test ./internal/naming/ ./internal/metadata/` passes.
- Deployed to a live instance: the 34 junk "Season 01" items disappeared and **do not return on rescan**; a `skipped_media_roots` row is recorded; the queue drains cleanly with no retry/error spam; and the legitimate movies in the same library that merely have `SxxExx` in their filename (inside `Title (Year)/` folders) are untouched and still matched.

---
*Built with AI assistance (per CONTRIBUTING) — investigated against the live `naming`/scanner code, verified with unit tests and on a production deploy before submitting.*


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Added detection for TV series files incorrectly placed in movie library locations. When detected, these files are now automatically skipped from processing instead of causing errors, and their locations are recorded for user reference.

* **Tests**
  * Added test coverage for TV episode file detection including various naming patterns and directory structures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->