### PR TITLE
feat(security): encrypt server-owned credentials at rest (#45)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -49,6 +49,16 @@ POSTGRES_SHM_SIZE=8gb
 # Optional NVIDIA override controls (used by docker-compose.nvidia.yml).
 # NVIDIA_GPU_COUNT=1
 
+# REQUIRED: master key for at-rest credential encryption. Silo refuses to start
+# without it. Integration API keys, S3 keys, and other server-owned secrets are
+# encrypted under a key derived from this value, so it must be at least 32
+# characters and kept secret. Generate one with:
+#   openssl rand -base64 48
+# Back it up SEPARATELY from your database dumps (treat it like a CA private
+# key): losing it makes every encrypted secret unrecoverable. See
+# docs/architecture/secret-encryption.md.
+# SECRET_KEY=replace-with-output-of-openssl-rand-base64-48
+
 # Run from source / advanced overrides
 # Only DATABASE_URL is required when running Silo outside the default docker compose stack.
 # DATABASE_URL=postgres://silo:password@localhost:5432/silo

--- a/cmd/silo/main.go
+++ b/cmd/silo/main.go
@@ -77,6 +77,7 @@ import (
 	"github.com/Silo-Server/silo-server/internal/s3client"
 	"github.com/Silo-Server/silo-server/internal/scanner"
 	"github.com/Silo-Server/silo-server/internal/scanqueue"
+	"github.com/Silo-Server/silo-server/internal/secret"
 	"github.com/Silo-Server/silo-server/internal/sections"
 	"github.com/Silo-Server/silo-server/internal/server"
 	"github.com/Silo-Server/silo-server/internal/subtitles"
@@ -141,7 +142,7 @@ func mustGetSetting(store interface {
 func configureOperationalLogging(
 	ctx context.Context,
 	pool *pgxpool.Pool,
-	settingsRepo *catalog.ServerSettingsRepo,
+	settingsRepo catalog.SettingsStore,
 	redisCfg config.RedisConfig,
 	logStreamHub *logstream.Hub,
 	baseHandler slog.Handler,
@@ -252,6 +253,34 @@ func maybeApplyPostgresTuning(ctx context.Context, pool *pgxpool.Pool, appMaxCon
 	}
 }
 
+// runCredentialBackfills sweeps any plaintext server-owned credential to
+// ciphertext on the primary (migration-running) node. All passes are
+// best-effort: a failed row leaves the prior plaintext (no new exposure) and
+// still reads via the read-path pass-through, so a backfill error must never
+// block boot. The sensitive-settings pass runs first so the arr
+// resolve-then-encrypt pass sees consistent referenced settings.
+func runCredentialBackfills(ctx context.Context, pool *pgxpool.Pool, cipher *secret.Cipher, settings *catalog.EncryptedSettingsRepo) {
+	settingsN, err := settings.BackfillSensitiveSettings(ctx)
+	if err != nil {
+		slog.Error("secret backfill: sensitive settings", "error", err)
+	}
+	columnsN, err := secret.BackfillColumns(ctx, pool, cipher, secret.ColumnBackfillTargets())
+	if err != nil {
+		slog.Error("secret backfill: credential columns", "error", err)
+	}
+	// The arr resolver is the encrypting settings decorator: it decrypts a
+	// sensitive target (e.g. requests.radarr.api_key) or passes through a
+	// plaintext custom key, exactly replicating the deleted resolveAPIKey.
+	arrN, err := secret.BackfillReferencedColumns(ctx, pool, cipher, settings.Get, secret.ArrKeyBackfillTargets())
+	if err != nil {
+		slog.Error("secret backfill: arr api keys", "error", err)
+	}
+	if total := settingsN + columnsN + arrN; total > 0 {
+		slog.Info("secret backfill: encrypted plaintext credentials at rest",
+			"settings", settingsN, "columns", columnsN, "arr_keys", arrN, "total", total)
+	}
+}
+
 func main() {
 	envFile := flag.String("env", ".env", "path to .env bootstrap file")
 	migrateOnly := flag.Bool("migrate-only", false, "apply database migrations and exit")
@@ -264,6 +293,15 @@ func main() {
 	bc, err := config.LoadBootstrap(*envFile)
 	if err != nil {
 		log.Fatalf("bootstrap: %v", err)
+	}
+
+	// Construct the at-rest credential cipher from SECRET_KEY immediately after
+	// bootstrap, before any settings repo is built. It is threaded explicitly as
+	// a dependency into every repo that stores a server-owned secret — never a
+	// package-level global.
+	dataCipher, err := secret.New(bc.SecretKey)
+	if err != nil {
+		log.Fatalf("secret cipher: %v", err)
 	}
 
 	// Step 2: Connect to PostgreSQL (bootstrap pool with default max connections)
@@ -314,7 +352,11 @@ func main() {
 	// Run migrations only for integrated/api modes. Proxy and transcode nodes
 	// should never alter the schema — they may scale independently and would
 	// race or apply migrations before the primary node is deliberately upgraded.
-	if bc.Mode == "integrated" || bc.Mode == "api" || bc.Mode == "" {
+	// The same gate decides whether this node runs the credential-encryption
+	// backfills: only the primary (migration-running) node sweeps plaintext to
+	// ciphertext; secondary nodes read whatever the primary encrypted.
+	isPrimaryNode := bc.Mode == "integrated" || bc.Mode == "api" || bc.Mode == ""
+	if isPrimaryNode {
 		migCtx, migCancel := context.WithTimeout(ctx, 5*time.Minute)
 		if migErr := database.RunMigrations(migCtx, pool, migrations.FS, "sql"); migErr != nil {
 			migCancel()
@@ -324,8 +366,14 @@ func main() {
 		slog.Info("database migrations applied")
 	}
 
-	// Step 3: Load settings from DB
-	settingsRepo := catalog.NewServerSettingsRepo(pool)
+	// Step 3: Load settings from DB. settingsRepo is the encrypting decorator so
+	// every consumer (config.LoadFromDB, admin, ABS, watchers) transparently sees
+	// plaintext while sensitive keys rest as ciphertext. The settings backfill
+	// (run after migrations, before this GetAll) is wired further below.
+	settingsRepo := catalog.NewEncryptedSettingsRepo(catalog.NewServerSettingsRepo(pool), dataCipher)
+	if isPrimaryNode {
+		runCredentialBackfills(ctx, pool, dataCipher, settingsRepo)
+	}
 	settings, err := settingsRepo.GetAll(ctx)
 	if err != nil {
 		log.Fatalf("loading settings: %v", err)
@@ -396,7 +444,9 @@ func main() {
 			log.Fatalf("recreating pool with configured max_connections: %v", err)
 		}
 	}
-	settingsRepo = catalog.NewServerSettingsRepo(pool)
+	// Re-wrap with the encrypting decorator so the recreated pool's settings repo
+	// still encrypts/decrypts — no raw settings repo may escape into later wiring.
+	settingsRepo = catalog.NewEncryptedSettingsRepo(catalog.NewServerSettingsRepo(pool), dataCipher)
 	nodeID := resolveNodeIdentity()
 
 	// Step 9: Validate
@@ -460,7 +510,7 @@ func main() {
 			DatabaseURL: cfg.Database.URL,
 			JFListen:    cfg.JellyfinCompat.Listen,
 		}
-		watcher := nodeconfig.NewWatcher(pool, eventBus, bootstrap)
+		watcher := nodeconfig.NewWatcher(pool, dataCipher, eventBus, bootstrap)
 		if err := watcher.Start(appCtx); err != nil {
 			slog.Error("config watcher start failed", "error", err)
 			os.Exit(1)
@@ -519,6 +569,7 @@ func main() {
 		BootstrapSensitiveValues:     bootstrapSensitiveValues,
 		AppContext:                   appCtx,
 		DB:                           pool,
+		SecretCipher:                 dataCipher,
 		EventBus:                     eventBus,
 		LogStreamHub:                 logStreamHub,
 		RealtimeHub:                  realtimeHub,
@@ -595,7 +646,7 @@ func main() {
 			log.Fatalf("register watch provider: %v", err)
 		}
 		watchProviderService = watchsync.NewService(
-			watchsync.NewPostgresRepository(deps.DB),
+			watchsync.NewPostgresRepository(deps.DB, deps.SecretCipher),
 			watchProviderRegistry,
 		)
 		deps.WatchProviderService = watchProviderService
@@ -1180,7 +1231,7 @@ func main() {
 		deps.UserStoreProvider = userStoreProvider
 	}
 	if watchProviderService != nil {
-		historyRepo := historyimport.NewRepository(deps.DB)
+		historyRepo := historyimport.NewRepository(deps.DB, deps.SecretCipher)
 		historyIdentity := watchstate.NewStableIdentityResolver(itemRepo, episodeRepo, catalog.NewProviderIDRepository(deps.DB))
 		watchProviderService.
 			WithMatcher(historyimport.NewMatcher(historyRepo)).
@@ -1479,14 +1530,13 @@ func main() {
 			taskMgr.Register(tasks.NewSyncWatchProvidersTask(watchProviderService))
 		}
 		requestReconcileSvc := mediarequests.NewService(
-			mediarequests.NewRepository(deps.DB),
+			mediarequests.NewRepository(deps.DB, deps.SecretCipher),
 			nil,
 			mediarequests.NewCatalogPresence(
 				catalog.NewItemRepository(deps.DB),
 				catalog.NewProviderIDRepository(deps.DB),
 			),
 		)
-		requestReconcileSvc.SetSecretResolver(settingsRepo)
 		requestReconcileSvc.SetFulfillmentAdapters(radarr.NewClient(nil), sonarr.NewClient(nil))
 		if userStoreProvider != nil {
 			reconcileResolver := access.NewResolver(
@@ -1498,7 +1548,7 @@ func main() {
 		}
 		taskMgr.Register(tasks.NewReconcileRequestsTask(requestReconcileSvc, 100))
 		if deps.FolderRepo != nil && deps.LibraryScanQueue != nil && pluginService != nil && pluginInstallationStore != nil {
-			autoscanRepo := autoscan.NewRepository(deps.DB)
+			autoscanRepo := autoscan.NewRepository(deps.DB, deps.SecretCipher)
 			if err := autoscanRepo.MarkInterruptedEvents(appCtx); err != nil {
 				slog.Warn("autoscan: failed to mark interrupted polls", "err", err)
 			}
@@ -1506,8 +1556,7 @@ func main() {
 				autoscanRepo,
 				pluginService,
 				pluginInstallationStore,
-				mediarequests.NewRepository(deps.DB),
-				settingsRepo,
+				mediarequests.NewRepository(deps.DB, deps.SecretCipher),
 				deps.FolderRepo,
 				deps.LibraryScanQueue,
 				deps.RedisClient,
@@ -1827,6 +1876,7 @@ func main() {
 		compatDeps := jellycompat.Dependencies{
 			Config:           cfg,
 			DB:               deps.DB,
+			SecretCipher:     dataCipher,
 			ClientIPResolver: ipResolver,
 			ProxyPool:        deps.ProxyPool,
 			TranscodePool:    deps.TranscodePool,
@@ -1880,7 +1930,7 @@ func main() {
 				compatDeps.FileResolver = deps.FileRepo
 			}
 
-			compatDeps.SubtitleRepo = subtitles.NewPgRepository(deps.DB)
+			compatDeps.SubtitleRepo = subtitles.NewPgRepository(deps.DB, deps.SecretCipher)
 
 			// Construct auth service for jellycompat login.
 			userRepo := auth.NewUserRepository(deps.DB)
@@ -2380,7 +2430,7 @@ func mapFolderTypeToMediaType(t string) string {
 // exposes Get) to the audiobooks.SettingsReader interface (which
 // requires GetString). The two signatures are identical modulo name.
 type audiobooksSettingsAdapter struct {
-	repo *catalog.ServerSettingsRepo
+	repo catalog.SettingsStore
 }
 
 func (a *audiobooksSettingsAdapter) GetString(ctx context.Context, key string) (string, error) {

--- a/cmd/silo/main.go
+++ b/cmd/silo/main.go
@@ -268,6 +268,10 @@ func runCredentialBackfills(ctx context.Context, pool *pgxpool.Pool, cipher *sec
 	if err != nil {
 		slog.Error("secret backfill: credential columns", "error", err)
 	}
+	historyServersN, err := historyimport.NewRepository(pool, cipher).BackfillSessionServerSecrets(ctx)
+	if err != nil {
+		slog.Error("secret backfill: history import session server credentials", "error", err)
+	}
 	// The arr resolver is the encrypting settings decorator: it decrypts a
 	// sensitive target (e.g. requests.radarr.api_key) or passes through a
 	// plaintext custom key, exactly replicating the deleted resolveAPIKey.
@@ -275,9 +279,9 @@ func runCredentialBackfills(ctx context.Context, pool *pgxpool.Pool, cipher *sec
 	if err != nil {
 		slog.Error("secret backfill: arr api keys", "error", err)
 	}
-	if total := settingsN + columnsN + arrN; total > 0 {
+	if total := settingsN + columnsN + historyServersN + arrN; total > 0 {
 		slog.Info("secret backfill: encrypted plaintext credentials at rest",
-			"settings", settingsN, "columns", columnsN, "arr_keys", arrN, "total", total)
+			"settings", settingsN, "columns", columnsN, "history_session_servers", historyServersN, "arr_keys", arrN, "total", total)
 	}
 }
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -36,6 +36,11 @@ services:
     restart: unless-stopped
     environment:
       MODE: integrated
+      # Master key for at-rest credential encryption. Required — the server
+      # refuses to start without it. Generate with: openssl rand -base64 48
+      # Back it up SEPARATELY from your database dumps; losing it makes encrypted
+      # secrets unrecoverable. See docs/architecture/secret-encryption.md.
+      SECRET_KEY: ${SECRET_KEY:?Set SECRET_KEY in .env — generate one with openssl rand -base64 48}
       DATABASE_URL: postgres://${POSTGRES_USER:-silo}:${POSTGRES_PASSWORD:-silo}@postgres:5432/${POSTGRES_DB:-silo}?sslmode=disable
       REDIS_URL: redis://redis:6379
       SILO_PLUGIN_CACHE_DIR: /var/lib/silo/plugins
@@ -71,6 +76,8 @@ services:
   #   profiles: [proxy]
   #   environment:
   #     MODE: proxy
+  #     # Must be the SAME SECRET_KEY as the primary node (shared encrypted data).
+  #     SECRET_KEY: ${SECRET_KEY:?Set SECRET_KEY in .env — generate one with openssl rand -base64 48}
   #     DATABASE_URL: postgres://${POSTGRES_USER:-silo}:${POSTGRES_PASSWORD:-silo}@postgres:5432/${POSTGRES_DB:-silo}?sslmode=disable
   #     REDIS_URL: redis://redis:6379
   #     PORT: "8080"
@@ -95,6 +102,8 @@ services:
   #   profiles: [transcode]
   #   environment:
   #     MODE: transcode
+  #     # Must be the SAME SECRET_KEY as the primary node (shared encrypted data).
+  #     SECRET_KEY: ${SECRET_KEY:?Set SECRET_KEY in .env — generate one with openssl rand -base64 48}
   #     DATABASE_URL: postgres://${POSTGRES_USER:-silo}:${POSTGRES_PASSWORD:-silo}@postgres:5432/${POSTGRES_DB:-silo}?sslmode=disable
   #     REDIS_URL: redis://redis:6379
   #     SILO_PLUGIN_CACHE_DIR: /var/lib/silo/plugins

--- a/docs/architecture/secret-encryption.md
+++ b/docs/architecture/secret-encryption.md
@@ -1,0 +1,140 @@
+# At-rest credential encryption
+
+Silo encrypts third-party integration credentials and other server-owned secrets
+at rest. Sonarr/Radarr API keys, S3 keys, watch-sync OAuth tokens, the
+Audiobookshelf-compat signing key, and the sensitive `server_settings` entries
+are stored as ciphertext in PostgreSQL and decrypted only in memory. The key that
+protects them lives **outside** the database, so a full DB dump or compromise
+does not expose the secrets.
+
+## How it works
+
+- **Cipher:** AES-256-GCM with a random 12-byte nonce per value. Implemented in
+  `internal/secret`.
+- **Key derivation:** the data key is HKDF-SHA256–derived from the `SECRET_KEY`
+  environment variable with a versioned domain label. `SECRET_KEY` is the
+  encryption root; it is never stored in the database.
+- **Envelope:** every ciphertext is stored as `enc:v1:<base64url(nonce‖sealed)>`.
+  The `enc:v1:` prefix is the version marker (see *Key rotation* below).
+- **Row binding (AAD):** each ciphertext is GCM-bound to its logical row via
+  additional-authenticated data — `table:column:<pk>` for per-row columns,
+  `server_settings:<key>` for settings. A DB-write attacker therefore cannot move
+  a credential blob from one row/column to another: decrypting under a different
+  binding fails authentication.
+- **Read path:** an empty value stays empty; a non-`enc:v1:` value is treated as
+  legacy plaintext and passed through unchanged (so a not-yet-migrated row keeps
+  working); an `enc:v1:` value is decrypted and **any** failure (wrong key,
+  tampering, truncation) is surfaced as an error — it is never silently used as a
+  credential.
+
+## SECRET_KEY
+
+`SECRET_KEY` is **required**. The server refuses to start without it (it fatals
+in `config.LoadBootstrap`), and it must be at least 32 characters.
+
+Generate one with:
+
+```bash
+openssl rand -base64 48
+```
+
+Set it in the deployment environment (or in `.env` for source/dev runs, which
+`godotenv` loads at startup). See `.env.example`.
+
+### Back it up — separately from the database
+
+Treat `SECRET_KEY` like a CA private key:
+
+- **Store it outside your database backups.** A DB dump contains only ciphertext;
+  the value of at-rest encryption is entirely lost if the key travels with the
+  dump.
+- Keep it in a secrets manager / sealed secret / password manager, not in the
+  repo or in the same bucket as your Postgres backups.
+- Rotating the *deployment* (new host, restored DB) requires the **same**
+  `SECRET_KEY`. Restoring a database backup onto a node with a different
+  `SECRET_KEY` makes every encrypted secret unreadable.
+
+### Key loss
+
+If `SECRET_KEY` is lost, the encrypted secrets are **unrecoverable** — that is the
+point of keeping the key out of the database. Recovery means re-entering the
+affected credentials:
+
+- Re-enter Sonarr/Radarr and Autoscan API keys, S3 keys, watch-sync connections,
+  history-import tokens, and subtitle provider credentials.
+- `auth.jwt_secret` becomes unreadable, so all existing sessions are invalid and
+  users must log in again (a new secret is generated on next boot if the row is
+  cleared — see below).
+
+## Rollout (automatic backfill)
+
+On the first boot after deploying this change, the primary (migration-running)
+node runs an idempotent, best-effort startup backfill that encrypts any
+remaining plaintext in place:
+
+1. sensitive `server_settings` keys,
+2. the per-table credential columns (subtitles, watch-sync, webhook-sync,
+   history-import),
+3. the two arr `api_key_ref` columns — these are **resolved-then-encrypted**: a
+   legacy row that held a `server_settings` reference (e.g.
+   `requests.radarr.api_key`) is collapsed to the real credential before being
+   encrypted.
+
+The backfill is safe to run repeatedly: already-encrypted values are skipped, and
+a per-row guard makes concurrent multi-node boots converge without
+double-encrypting. A failed row is logged and left as plaintext (no new exposure)
+rather than blocking boot. Proxy/transcode nodes skip the backfill; they read
+whatever the primary encrypted. No manual steps are required.
+
+## Rollback / downgrade hazard
+
+Downgrading to a binary that predates this change is **not** safe while secrets
+are encrypted, because the old binary has no read path: it would read
+`enc:v1:auth.jwt_secret` as a literal JWT secret (invalidating all sessions) and
+read `enc:v1:`-prefixed integration keys as garbage credentials.
+
+To downgrade safely you must first return the affected values to plaintext, for
+example:
+
+- Decrypt the sensitive `server_settings` back to plaintext (run a one-off that
+  reads each via the encrypting repo and writes the plaintext via the raw repo),
+  **or**
+- At minimum, clear `auth.jwt_secret` so the older binary regenerates a fresh
+  plaintext one (this still logs everyone out), and re-enter any integration
+  credentials as plaintext.
+
+There is no automatic "decrypt everything" downgrade path in this release; plan
+downgrades accordingly.
+
+## Key rotation (future)
+
+The `enc:v1:` envelope and the HKDF domain label are versioned. A future rotation
+would introduce `enc:v2:` with a new derived key (and `Decrypt` already dispatches
+on the version, returning an explicit error for an unknown version). Rotation is
+out of scope for this release; the versioning exists so it can be added without a
+data migration of the envelope format.
+
+## Scope and known gaps
+
+Covered: arr (Requests + Autoscan) API keys, S3 keys, all sensitive
+`server_settings`, watch-sync tokens, webhook-sync `access_token`,
+history-import admin/session tokens, subtitle provider `api_key`/`password`,
+the Jellyfin-compat session's bridged Silo access/refresh tokens
+(`jellycompat_sessions.streamapp_access_token` / `streamapp_refresh_token`), and
+the ABS signing key.
+
+Deliberately **not** encrypted (tracked as follow-ups):
+
+- **Equality-looked-up secrets** — these are matched by exact value
+  (`WHERE … = $1`), and AES-GCM is randomized, so encrypting them would break the
+  lookup. They need a deterministic **blind-index hash** column instead:
+  `api_keys.api_key`, `webhook_sync_connections.webhook_secret`,
+  `jellycompat_sessions.token`, and `watch_together_rooms.join_token`.
+- **Plugin runtime config** — `plugin_runtime_configs.config_value` is opaque
+  plugin-defined JSONB whose secret fields are manifest-declared and whose runtime
+  lives in a separate repo; encrypting it correctly needs a coordinated,
+  manifest-aware design.
+
+Excluded (not a gap): `plex_sync_connections.*` is a dead table (zero Go
+references); `oauth_completion.token_ciphertext` is already AES-GCM;
+`users.password_hash` and the `*_hash` columns are already hashed.

--- a/docs/architecture/secret-encryption.md
+++ b/docs/architecture/secret-encryption.md
@@ -74,7 +74,8 @@ remaining plaintext in place:
 
 1. sensitive `server_settings` keys,
 2. the per-table credential columns (subtitles, watch-sync, webhook-sync,
-   history-import),
+   history-import, including temporary server-list credentials stored in
+   session JSON),
 3. the two arr `api_key_ref` columns — these are **resolved-then-encrypted**: a
    legacy row that held a `server_settings` reference (e.g.
    `requests.radarr.api_key`) is collapsed to the real credential before being
@@ -118,7 +119,8 @@ data migration of the envelope format.
 
 Covered: arr (Requests + Autoscan) API keys, S3 keys, all sensitive
 `server_settings`, watch-sync tokens, webhook-sync `access_token`,
-history-import admin/session tokens, subtitle provider `api_key`/`password`,
+history-import admin/session tokens and temporary server-list credentials,
+subtitle provider `api_key`/`password`,
 the Jellyfin-compat session's bridged Silo access/refresh tokens
 (`jellycompat_sessions.streamapp_access_token` / `streamapp_refresh_token`), and
 the ABS signing key.

--- a/internal/api/autoscan_wiring.go
+++ b/internal/api/autoscan_wiring.go
@@ -20,12 +20,13 @@ type autoscanQueuer = autoscan.Queuer
 
 // RequestIntegrationLookup adapts the Requests repository to the autoscan
 // connection resolver's RequestIntegrationLookup: it resolves a soft-linked
-// Requests integration to its base URL and (write-only) api-key ref.
+// Requests integration to its base URL and api key (the repo decrypts the key
+// on read, so this returns plaintext).
 type RequestIntegrationLookup struct {
 	Repo *mediarequests.Repository
 }
 
-func (l RequestIntegrationLookup) Get(ctx context.Context, integrationID string) (baseURL, apiKeyRef string, err error) {
+func (l RequestIntegrationLookup) Get(ctx context.Context, integrationID string) (baseURL, apiKey string, err error) {
 	integration, err := l.Repo.GetIntegration(ctx, integrationID)
 	if err != nil {
 		return "", "", err
@@ -125,27 +126,22 @@ func scanSourceDisplayName(pluginID string, c *plugins.Capability) string {
 	}
 }
 
-// AutoscanSecretResolver resolves an encrypted api-key reference to plaintext.
-// It is satisfied by the server settings repo (Get(ctx, key) (string, error)).
-type AutoscanSecretResolver interface {
-	Get(ctx context.Context, ref string) (string, error)
-}
-
 // BuildAutoscanService wires the v2 autoscan engine from its concrete
 // dependencies. Both the HTTP router (manual trigger) and the background poll
 // task share this constructor so the adapter wiring lives in exactly one place.
+// Credentials are now decrypted inline by the autoscan/requests repos, so there
+// is no separate secret resolver to thread.
 func BuildAutoscanService(
 	repo *autoscan.Repository,
 	pluginService *plugins.Service,
 	installationStore *plugins.InstallationStore,
 	requestsRepo *mediarequests.Repository,
-	secrets AutoscanSecretResolver,
 	folderRepo *catalog.FolderRepository,
 	queue autoscanQueuer,
 	redisClient *redis.Client,
 ) *autoscan.Service {
 	provider := autoscan.NewPluginProvider(PluginScanSourceAdapter{pluginService})
-	connRes := autoscan.NewConnectionResolver(RequestIntegrationLookup{requestsRepo}, secrets)
+	connRes := autoscan.NewConnectionResolver(RequestIntegrationLookup{requestsRepo})
 	svc := autoscan.NewService(
 		repo,
 		provider,

--- a/internal/api/handlers/admin.go
+++ b/internal/api/handlers/admin.go
@@ -1137,29 +1137,10 @@ func (h *AdminHandler) HandleUpdateItemMetadata(w http.ResponseWriter, r *http.R
 
 // --- Server Settings endpoints ---
 
-var sensitiveSettingKeys = map[string]bool{
-	"auth.jwt_secret":                      true,
-	"s3.public_access_key":                 true,
-	"s3.public_secret_key":                 true,
-	"s3.public_token_secret":               true,
-	"s3.private_access_key":                true,
-	"s3.private_secret_key":                true,
-	"s3.user_db_access_key":                true,
-	"s3.user_db_secret_key":                true,
-	"redis.url":                            true,
-	"recommendations.openai_api_key":       true,
-	"recommendations.embedding_auth_token": true,
-	"tmdb.api_key":                         true,
-	"introdb.api_key":                      true,
-	"mdblist.api_key":                      true,
-	"requests.radarr.api_key":              true,
-	"requests.sonarr.api_key":              true,
-	"subtitle_ai.api_key":                  true,
-	"watchsync.trakt.client_id":            true,
-	"watchsync.trakt.client_secret":        true,
-	"watchsync.simkl.client_id":            true,
-	"watchsync.simkl.client_secret":        true,
-}
+// sensitiveSettingKeys is the audited allowlist of secret-bearing settings
+// keys, shared with the at-rest encryption decorator so redaction and
+// encryption can never drift apart. See catalog.SensitiveSettingKeys.
+var sensitiveSettingKeys = catalog.SensitiveSettingKeys
 
 // HandleGetSettings handles GET /admin/settings.
 func (h *AdminHandler) HandleGetSettings(w http.ResponseWriter, r *http.Request) {

--- a/internal/api/handlers/sections.go
+++ b/internal/api/handlers/sections.go
@@ -32,7 +32,7 @@ type SectionHandler struct {
 	StoreProvider  userstore.UserStoreProvider
 	UserRepo       *auth.UserRepository
 	DetailSvc      *catalog.DetailService
-	Settings       *catalog.ServerSettingsRepo
+	Settings       catalog.SettingsStore
 	CollectionRepo *catalog.LibraryCollectionRepository
 }
 

--- a/internal/api/handlers/sections_settings.go
+++ b/internal/api/handlers/sections_settings.go
@@ -13,7 +13,7 @@ const SectionsAllowProfileCustomSettingKey = "sections.allow_profile_custom_sect
 
 // SectionSettingsHandler exposes GET/PUT for the sections-related server setting.
 type SectionSettingsHandler struct {
-	Settings *catalog.ServerSettingsRepo
+	Settings catalog.SettingsStore
 }
 
 type sectionsSettingResponse struct {

--- a/internal/api/router.go
+++ b/internal/api/router.go
@@ -53,6 +53,7 @@ import (
 	"github.com/Silo-Server/silo-server/internal/s3client"
 	"github.com/Silo-Server/silo-server/internal/scanner"
 	"github.com/Silo-Server/silo-server/internal/scanqueue"
+	"github.com/Silo-Server/silo-server/internal/secret"
 	"github.com/Silo-Server/silo-server/internal/sections"
 	"github.com/Silo-Server/silo-server/internal/subtitles"
 	subtitleai "github.com/Silo-Server/silo-server/internal/subtitles/ai"
@@ -76,6 +77,7 @@ type Dependencies struct {
 	BootstrapSensitiveValues     map[string]string
 	AppContext                   context.Context
 	DB                           *pgxpool.Pool
+	SecretCipher                 *secret.Cipher // at-rest credential cipher (required when DB is set)
 	FrontendFS                   fs.FS
 	S3Public                     *s3client.Client                 // public assets bucket client (may be nil)
 	S3Private                    *s3client.Client                 // private internal bucket client (may be nil)
@@ -223,9 +225,11 @@ func NewRouter(deps Dependencies) chi.Router {
 	healthHandler := handlers.NewHealthHandler(healthServerName, healthServerID)
 
 	// Build server settings repo if DB is available (needed by auth and admin).
-	var settingsRepo *catalog.ServerSettingsRepo
+	// Wrap it in the encrypting decorator so sensitive keys rest as ciphertext
+	// and every consumer transparently reads plaintext.
+	var settingsRepo catalog.SettingsStore
 	if deps.DB != nil {
-		settingsRepo = catalog.NewServerSettingsRepo(deps.DB)
+		settingsRepo = catalog.NewEncryptedSettingsRepo(catalog.NewServerSettingsRepo(deps.DB), deps.SecretCipher)
 	}
 
 	// Build auth handler and auth middleware if DB and config are available.
@@ -431,27 +435,25 @@ func NewRouter(deps Dependencies) chi.Router {
 		if deps.Config != nil {
 			tmdbAPIKey = deps.Config.TMDBAPIKey
 		}
-		requestsRepo := mediarequests.NewRepository(deps.DB)
+		requestsRepo := mediarequests.NewRepository(deps.DB, deps.SecretCipher)
 		requestSvc := mediarequests.NewService(
 			requestsRepo,
 			tmdb.NewClient(tmdbAPIKey, 40),
 			mediarequests.NewCatalogPresence(itemRepo, providerIDRepo),
 		)
-		requestSvc.SetSecretResolver(settingsRepo)
 		requestSvc.SetFulfillmentAdapters(radarr.NewClient(nil), sonarr.NewClient(nil))
 		if viewerResolver != nil {
 			requestSvc.SetEntitlementResolver(mediarequests.NewAccessEntitlements(viewerResolver))
 		}
 		requestHandler = handlers.NewRequestsHandler(requestSvc)
 
-		autoscanRepo := autoscan.NewRepository(deps.DB)
+		autoscanRepo := autoscan.NewRepository(deps.DB, deps.SecretCipher)
 		if deps.FolderRepo != nil && deps.LibraryScanQueue != nil && deps.PluginService != nil {
 			autoscanSvc := BuildAutoscanService(
 				autoscanRepo,
 				deps.PluginService,
 				plugins.NewInstallationStore(deps.DB),
 				requestsRepo,
-				settingsRepo,
 				deps.FolderRepo,
 				deps.LibraryScanQueue,
 				deps.RedisClient,
@@ -566,7 +568,7 @@ func NewRouter(deps Dependencies) chi.Router {
 	// Create subtitleRepo early — only needs DB, shared with playback handler and subtitle search handler.
 	var subtitleRepo *subtitles.PgRepository
 	if deps.DB != nil {
-		subtitleRepo = subtitles.NewPgRepository(deps.DB)
+		subtitleRepo = subtitles.NewPgRepository(deps.DB, deps.SecretCipher)
 	}
 
 	// Notifier that pushes "subtitle ready" events to active sessions when an AI
@@ -1000,6 +1002,7 @@ func NewRouter(deps Dependencies) chi.Router {
 			libraryCollectionService.TraktTokenResolver = &traktCollectionTokenResolver{
 				pool:     deps.DB,
 				settings: settingsRepo,
+				cipher:   deps.SecretCipher,
 				provider: watchtrakt.NewProvider(nil, ""),
 			}
 		}
@@ -1159,7 +1162,7 @@ func NewRouter(deps Dependencies) chi.Router {
 	var historyImportHandler *handlers.HistoryImportHandler
 	var historyImportSvc *historyimport.Service
 	if deps.DB != nil {
-		historyRepo := historyimport.NewRepository(deps.DB)
+		historyRepo := historyimport.NewRepository(deps.DB, deps.SecretCipher)
 		historyImportSvc = historyimport.NewService(deps.AppContext, historyRepo, deps.UserStoreProvider)
 		historyIdentity := watchstate.NewStableIdentityResolver(itemRepo, episodeRepo, providerIDRepo)
 		historyImportSvc.SetStableIdentityResolver(historyIdentity)
@@ -1168,7 +1171,7 @@ func NewRouter(deps Dependencies) chi.Router {
 		}
 		historyImportHandler = handlers.NewHistoryImportHandler(historyImportSvc)
 		if deps.UserStoreProvider != nil {
-			webhookSyncSvc := webhooksync.NewService(webhooksync.NewRepository(deps.DB), historyRepo, deps.UserStoreProvider)
+			webhookSyncSvc := webhooksync.NewService(webhooksync.NewRepository(deps.DB, deps.SecretCipher), historyRepo, deps.UserStoreProvider)
 			webhookSyncSvc.SetStableIdentityResolver(historyIdentity)
 			webhookSyncHandler = handlers.NewWebhookSyncHandler(webhookSyncSvc)
 		}

--- a/internal/api/trakt_collection_token_resolver.go
+++ b/internal/api/trakt_collection_token_resolver.go
@@ -11,13 +11,15 @@ import (
 	"github.com/jackc/pgx/v5/pgxpool"
 
 	"github.com/Silo-Server/silo-server/internal/catalog"
+	"github.com/Silo-Server/silo-server/internal/secret"
 	"github.com/Silo-Server/silo-server/internal/watchsync"
 	watchtrakt "github.com/Silo-Server/silo-server/internal/watchsync/providers/trakt"
 )
 
 type traktCollectionTokenResolver struct {
 	pool     *pgxpool.Pool
-	settings *catalog.ServerSettingsRepo
+	settings catalog.SettingsStore // encrypting decorator: decrypts trakt client_secret
+	cipher   *secret.Cipher        // decrypts watch_provider_connections tokens read via raw SQL
 	provider *watchtrakt.Provider
 }
 
@@ -97,7 +99,7 @@ func (r *traktCollectionTokenResolver) loadConnection(ctx context.Context, profi
 		LIMIT 1
 	`, profileID)
 	var conn watchsync.Connection
-	if err := row.Scan(
+	err := row.Scan(
 		&conn.ID,
 		&conn.Provider,
 		&conn.UserID,
@@ -107,24 +109,45 @@ func (r *traktCollectionTokenResolver) loadConnection(ctx context.Context, profi
 		&conn.AccessToken,
 		&conn.RefreshToken,
 		&conn.TokenExpiresAt,
-	); err != nil {
+	)
+	if err != nil {
 		if errors.Is(err, pgx.ErrNoRows) {
 			return watchsync.Connection{}, errors.New("trakt connection not found for profile")
 		}
 		return watchsync.Connection{}, fmt.Errorf("load trakt connection: %w", err)
 	}
+	// This resolver reads watch_provider_connections directly (bypassing the
+	// watchsync repo), so it must apply the same at-rest decryption the repo
+	// does, bound to the same connection identity (watchsync.TokenAAD).
+	if conn.AccessToken, err = r.cipher.DecryptIfEncrypted(conn.AccessToken, watchsync.TokenAAD("access_token", conn.Provider, conn.UserID, conn.ProfileID)); err != nil {
+		return watchsync.Connection{}, fmt.Errorf("decrypt trakt access token: %w", err)
+	}
+	if conn.RefreshToken, err = r.cipher.DecryptIfEncrypted(conn.RefreshToken, watchsync.TokenAAD("refresh_token", conn.Provider, conn.UserID, conn.ProfileID)); err != nil {
+		return watchsync.Connection{}, fmt.Errorf("decrypt trakt refresh token: %w", err)
+	}
 	return conn, nil
 }
 
 func (r *traktCollectionTokenResolver) updateTokens(ctx context.Context, conn watchsync.Connection) error {
-	_, err := r.pool.Exec(ctx, `
+	// Encrypt the refreshed tokens inline, bound to the connection identity, so
+	// the raw-SQL write matches what the watchsync repo (and this resolver's read
+	// path) store.
+	accessToken, err := r.cipher.Encrypt(conn.AccessToken, watchsync.TokenAAD("access_token", conn.Provider, conn.UserID, conn.ProfileID))
+	if err != nil {
+		return fmt.Errorf("encrypt trakt access token: %w", err)
+	}
+	refreshToken, err := r.cipher.Encrypt(conn.RefreshToken, watchsync.TokenAAD("refresh_token", conn.Provider, conn.UserID, conn.ProfileID))
+	if err != nil {
+		return fmt.Errorf("encrypt trakt refresh token: %w", err)
+	}
+	_, err = r.pool.Exec(ctx, `
 		UPDATE watch_provider_connections
 		SET access_token = $2,
 		    refresh_token = $3,
 		    token_expires_at = $4,
 		    updated_at = now()
 		WHERE id = $1::uuid
-	`, conn.ID, conn.AccessToken, conn.RefreshToken, conn.TokenExpiresAt)
+	`, conn.ID, accessToken, refreshToken, conn.TokenExpiresAt)
 	if err != nil {
 		return fmt.Errorf("update refreshed trakt connection tokens: %w", err)
 	}

--- a/internal/audiobooks/config.go
+++ b/internal/audiobooks/config.go
@@ -13,16 +13,20 @@ import (
 )
 
 const (
-	absJWTSecretKey          = "audiobooks.abs.jwt_secret"
-	absDefaultAccessTTL      = 24 * time.Hour
-	absDefaultRefreshTTL     = 30 * 24 * time.Hour
+	absJWTSecretKey      = "audiobooks.abs.jwt_secret"
+	absDefaultAccessTTL  = 24 * time.Hour
+	absDefaultRefreshTTL = 30 * 24 * time.Hour
 )
 
 // ABSConfigProvider implements abs.ConfigProvider using silo's server_settings
 // table. The ABS JWT secret is generated once on first read and persisted for
 // the lifetime of the deployment.
 type ABSConfigProvider struct {
-	Settings *catalog.ServerSettingsRepo
+	// Settings is the encrypting settings decorator in production, so the ABS
+	// JWT secret (a SensitiveSettingKey) rests as ciphertext and is transparently
+	// decrypted here. Typed as the interface so both the raw repo and the
+	// decorator satisfy it.
+	Settings catalog.SettingsStore
 
 	// secretCache holds the generated secret so we only hit the DB once per
 	// process lifetime. Protected by mu.

--- a/internal/audiobooks/service.go
+++ b/internal/audiobooks/service.go
@@ -42,8 +42,8 @@ type ABSHandlerDeps struct {
 	Pool           *pgxpool.Pool
 	Items          *catalog.ItemRepository
 	Files          *scanner.FileRepository
-	Settings       *catalog.ServerSettingsRepo
-	Auth           absAuthAdapter // see BuildABSHandler below
+	Settings       catalog.SettingsStore // encrypting decorator in production
+	Auth           absAuthAdapter        // see BuildABSHandler below
 	AccessResolver abs.AccessResolver
 	// Recs is the recommendations repository used to power the
 	// /items/{id}/similar endpoint via embedding nearest-neighbor search.

--- a/internal/autoscan/connection.go
+++ b/internal/autoscan/connection.go
@@ -13,31 +13,27 @@ type ResolvedConnection struct {
 }
 
 // RequestIntegrationLookup resolves a soft-linked Requests integration to its
-// base URL and encrypted api-key reference.
+// base URL and (already-decrypted) api key.
 type RequestIntegrationLookup interface {
-	Get(ctx context.Context, integrationID string) (baseURL, apiKeyRef string, err error)
-}
-
-// SecretResolver resolves an encrypted api-key reference to its plaintext value.
-type SecretResolver interface {
-	Get(ctx context.Context, ref string) (string, error)
+	Get(ctx context.Context, integrationID string) (baseURL, apiKey string, err error)
 }
 
 type ConnectionResolver struct {
 	requests RequestIntegrationLookup
-	secrets  SecretResolver
 }
 
-func NewConnectionResolver(r RequestIntegrationLookup, s SecretResolver) *ConnectionResolver {
-	return &ConnectionResolver{requests: r, secrets: s}
+func NewConnectionResolver(r RequestIntegrationLookup) *ConnectionResolver {
+	return &ConnectionResolver{requests: r}
 }
 
 // Resolve turns a stored Connection into concrete credentials. When the
-// connection is linked to a Requests integration the live base URL + key ref are
-// read from there; otherwise the connection's own fields are used. The api-key
-// ref is then resolved to plaintext via the secrets resolver.
+// connection is linked to a Requests integration the live base URL + key are
+// read from there (the Requests repo decrypts it); otherwise the connection's
+// own fields are used (the autoscan repo already decrypted api_key_ref on read).
+// Either way the returned key is plaintext — there is no longer a separate
+// secret-resolution step.
 func (cr *ConnectionResolver) Resolve(ctx context.Context, c Connection) (ResolvedConnection, error) {
-	baseURL, apiKeyRef := c.BaseURL, c.APIKeyRef
+	baseURL, apiKey := c.BaseURL, c.APIKeyRef
 	// A pointer-to-empty-string request_integration_id is NOT a live link (it can
 	// arise from a both-NULL orphan or a stripped link). Treat empty/whitespace as
 	// "no link" so we don't call requests.Get("") and use the connection's own
@@ -46,21 +42,11 @@ func (cr *ConnectionResolver) Resolve(ctx context.Context, c Connection) (Resolv
 		if cr.requests == nil {
 			return ResolvedConnection{}, fmt.Errorf("autoscan: linked requests integration %q: no lookup configured", *c.RequestIntegrationID)
 		}
-		u, ref, err := cr.requests.Get(ctx, *c.RequestIntegrationID)
+		u, key, err := cr.requests.Get(ctx, *c.RequestIntegrationID)
 		if err != nil {
 			return ResolvedConnection{}, fmt.Errorf("autoscan: linked requests integration %q: %w", *c.RequestIntegrationID, err)
 		}
-		baseURL, apiKeyRef = u, ref
+		baseURL, apiKey = u, key
 	}
-	apiKey := strings.TrimSpace(apiKeyRef)
-	if cr.secrets != nil && apiKey != "" {
-		resolved, err := cr.secrets.Get(ctx, apiKey)
-		if err != nil {
-			return ResolvedConnection{}, fmt.Errorf("autoscan: resolve api key: %w", err)
-		}
-		if resolved = strings.TrimSpace(resolved); resolved != "" {
-			apiKey = resolved
-		}
-	}
-	return ResolvedConnection{BaseURL: baseURL, APIKey: apiKey}, nil
+	return ResolvedConnection{BaseURL: baseURL, APIKey: strings.TrimSpace(apiKey)}, nil
 }

--- a/internal/autoscan/connection_test.go
+++ b/internal/autoscan/connection_test.go
@@ -6,9 +6,10 @@ import (
 	"testing"
 )
 
-// fakeRequestLookup implements RequestIntegrationLookup from a static map.
+// fakeRequestLookup implements RequestIntegrationLookup from a static map. The
+// returned apiKey is already plaintext (the Requests repo decrypts on read).
 type fakeRequestLookup struct {
-	entries map[string]struct{ baseURL, apiKeyRef string }
+	entries map[string]struct{ baseURL, apiKey string }
 	err     error
 }
 
@@ -20,30 +21,17 @@ func (f fakeRequestLookup) Get(_ context.Context, id string) (string, string, er
 	if !ok {
 		return "", "", errors.New("integration not found: " + id)
 	}
-	return e.baseURL, e.apiKeyRef, nil
-}
-
-// fakeSecrets implements SecretResolver from a static map; unknown refs resolve
-// to empty (so the ref itself is used).
-type fakeSecrets struct {
-	values map[string]string
-	err    error
-}
-
-func (f fakeSecrets) Get(_ context.Context, ref string) (string, error) {
-	if f.err != nil {
-		return "", f.err
-	}
-	return f.values[ref], nil
+	return e.baseURL, e.apiKey, nil
 }
 
 func TestResolveConnectionOwnCredentials(t *testing.T) {
-	secrets := fakeSecrets{values: map[string]string{"ownref": "OWNKEY"}}
-	r := NewConnectionResolver(fakeRequestLookup{}, secrets)
+	// The autoscan repo already decrypted api_key_ref, so the connection carries
+	// the literal key; Resolve returns it verbatim (trimmed).
+	r := NewConnectionResolver(fakeRequestLookup{})
 
 	got, err := r.Resolve(context.Background(), Connection{
 		BaseURL:   "http://own:8989",
-		APIKeyRef: "ownref",
+		APIKeyRef: "OWNKEY",
 	})
 	if err != nil {
 		t.Fatalf("Resolve own: %v", err)
@@ -54,11 +42,10 @@ func TestResolveConnectionOwnCredentials(t *testing.T) {
 }
 
 func TestResolveConnectionLinked(t *testing.T) {
-	lookup := fakeRequestLookup{entries: map[string]struct{ baseURL, apiKeyRef string }{
-		"req-1": {baseURL: "http://req:7878", apiKeyRef: "rk"},
+	lookup := fakeRequestLookup{entries: map[string]struct{ baseURL, apiKey string }{
+		"req-1": {baseURL: "http://req:7878", apiKey: "REQKEY"},
 	}}
-	secrets := fakeSecrets{values: map[string]string{"rk": "REQKEY"}}
-	r := NewConnectionResolver(lookup, secrets)
+	r := NewConnectionResolver(lookup)
 
 	id := "req-1"
 	got, err := r.Resolve(context.Background(), Connection{RequestIntegrationID: &id})
@@ -71,7 +58,7 @@ func TestResolveConnectionLinked(t *testing.T) {
 }
 
 func TestResolveConnectionLinkedMissingErrors(t *testing.T) {
-	r := NewConnectionResolver(fakeRequestLookup{}, fakeSecrets{})
+	r := NewConnectionResolver(fakeRequestLookup{})
 	id := "gone"
 	if _, err := r.Resolve(context.Background(), Connection{RequestIntegrationID: &id}); err == nil {
 		t.Fatal("expected error when linked Requests integration is missing")
@@ -79,7 +66,7 @@ func TestResolveConnectionLinkedMissingErrors(t *testing.T) {
 }
 
 func TestResolveConnectionLinkedLookupErrors(t *testing.T) {
-	r := NewConnectionResolver(fakeRequestLookup{err: errors.New("boom")}, fakeSecrets{})
+	r := NewConnectionResolver(fakeRequestLookup{err: errors.New("boom")})
 	id := "req-1"
 	if _, err := r.Resolve(context.Background(), Connection{RequestIntegrationID: &id}); err == nil {
 		t.Fatal("expected error when the lookup itself fails")
@@ -92,13 +79,12 @@ func TestResolveConnectionEmptyIntegrationIDIsNotALink(t *testing.T) {
 	// requests.Get(""). The lookup here errors on any call, so reaching it fails.
 	r := NewConnectionResolver(
 		fakeRequestLookup{err: errors.New("lookup must not be called")},
-		fakeSecrets{values: map[string]string{"ownref": "OWNKEY"}},
 	)
 	for _, empty := range []string{"", "   "} {
 		id := empty
 		got, err := r.Resolve(context.Background(), Connection{
 			BaseURL:              "http://own:8989",
-			APIKeyRef:            "ownref",
+			APIKeyRef:            "OWNKEY",
 			RequestIntegrationID: &id,
 		})
 		if err != nil {
@@ -110,20 +96,18 @@ func TestResolveConnectionEmptyIntegrationIDIsNotALink(t *testing.T) {
 	}
 }
 
-func TestResolveConnectionTrimsAndFallsBackOnEmptySecret(t *testing.T) {
-	// Whitespace-padded ref; secret resolves to whitespace-only -> fall back to
-	// the trimmed ref (parity with requests.resolveAPIKey).
-	secrets := fakeSecrets{values: map[string]string{"ownref": "   "}}
-	r := NewConnectionResolver(fakeRequestLookup{}, secrets)
+func TestResolveConnectionTrimsKey(t *testing.T) {
+	// Resolve trims surrounding whitespace from the (decrypted) key.
+	r := NewConnectionResolver(fakeRequestLookup{})
 
 	got, err := r.Resolve(context.Background(), Connection{
 		BaseURL:   "http://own:8989",
-		APIKeyRef: "  ownref  ",
+		APIKeyRef: "  OWNKEY  ",
 	})
 	if err != nil {
 		t.Fatalf("Resolve: %v", err)
 	}
-	if got.APIKey != "ownref" {
-		t.Fatalf("expected trimmed ref fallback, got %q", got.APIKey)
+	if got.APIKey != "OWNKEY" {
+		t.Fatalf("expected trimmed key, got %q", got.APIKey)
 	}
 }

--- a/internal/autoscan/repository.go
+++ b/internal/autoscan/repository.go
@@ -9,14 +9,38 @@ import (
 	"time"
 	"unicode/utf8"
 
+	"github.com/google/uuid"
 	"github.com/jackc/pgx/v5"
 	"github.com/jackc/pgx/v5/pgconn"
 	"github.com/jackc/pgx/v5/pgxpool"
+
+	"github.com/Silo-Server/silo-server/internal/secret"
 )
 
-type Repository struct{ pool *pgxpool.Pool }
+type Repository struct {
+	pool   *pgxpool.Pool
+	cipher *secret.Cipher
+}
 
-func NewRepository(pool *pgxpool.Pool) *Repository { return &Repository{pool: pool} }
+func NewRepository(pool *pgxpool.Pool, cipher *secret.Cipher) *Repository {
+	return &Repository{pool: pool, cipher: cipher}
+}
+
+// connectionAPIKeyAAD binds an autoscan_connections api_key_ref ciphertext to
+// its row id.
+func connectionAPIKeyAAD(id string) string {
+	return secret.RowAAD("autoscan_connections", "api_key_ref", id)
+}
+
+// encryptAPIKey encrypts a non-empty, trimmed key bound to the connection id;
+// an empty key returns "" so NULL/keep-existing semantics are preserved.
+func (r *Repository) encryptAPIKey(id, apiKey string) (string, error) {
+	apiKey = strings.TrimSpace(apiKey)
+	if apiKey == "" {
+		return "", nil
+	}
+	return r.cipher.Encrypt(apiKey, connectionAPIKeyAAD(id))
+}
 
 // --- Settings ---
 
@@ -64,7 +88,7 @@ func (r *Repository) UpdateSettings(ctx context.Context, s Settings) (Settings, 
 
 const connectionColumns = `id, name, kind, base_url, api_key_ref, request_integration_id`
 
-func scanConnection(row interface{ Scan(...any) error }) (Connection, error) {
+func (r *Repository) scanConnection(row interface{ Scan(...any) error }) (Connection, error) {
 	var c Connection
 	var baseURL, apiKeyRef, reqIntegrationID *string
 	if err := row.Scan(&c.ID, &c.Name, &c.Kind, &baseURL, &apiKeyRef, &reqIntegrationID); err != nil {
@@ -77,6 +101,13 @@ func scanConnection(row interface{ Scan(...any) error }) (Connection, error) {
 		c.APIKeyRef = *apiKeyRef
 	}
 	c.RequestIntegrationID = reqIntegrationID
+	// Decrypt the stored key (read-path contract): legacy plaintext passes
+	// through, enc:v1: decrypts, corrupt ciphertext errors.
+	apiKey, err := r.cipher.DecryptIfEncrypted(c.APIKeyRef, connectionAPIKeyAAD(c.ID))
+	if err != nil {
+		return Connection{}, fmt.Errorf("decrypt autoscan connection %s api key: %w", c.ID, err)
+	}
+	c.APIKeyRef = apiKey
 	return c, nil
 }
 
@@ -89,12 +120,22 @@ func nullable(s string) any {
 }
 
 func (r *Repository) CreateConnection(ctx context.Context, c Connection) (Connection, error) {
+	// Generate the id in Go (rather than the DB default) so the api_key_ref
+	// ciphertext can be AAD-bound to the row id at insert time.
+	id := strings.TrimSpace(c.ID)
+	if id == "" {
+		id = uuid.NewString()
+	}
+	apiKeyRef, err := r.encryptAPIKey(id, c.APIKeyRef)
+	if err != nil {
+		return Connection{}, fmt.Errorf("encrypt autoscan api key: %w", err)
+	}
 	row := r.pool.QueryRow(ctx, `
-		INSERT INTO autoscan_connections (name, kind, base_url, api_key_ref, request_integration_id)
-		VALUES ($1, $2, $3, $4, $5)
+		INSERT INTO autoscan_connections (id, name, kind, base_url, api_key_ref, request_integration_id)
+		VALUES ($1, $2, $3, $4, $5, $6)
 		RETURNING `+connectionColumns,
-		c.Name, c.Kind, nullable(c.BaseURL), nullable(c.APIKeyRef), c.RequestIntegrationID)
-	out, err := scanConnection(row)
+		id, c.Name, c.Kind, nullable(c.BaseURL), nullable(apiKeyRef), c.RequestIntegrationID)
+	out, err := r.scanConnection(row)
 	if err != nil {
 		return Connection{}, fmt.Errorf("create autoscan connection: %w", err)
 	}
@@ -108,6 +149,11 @@ func (r *Repository) UpdateConnection(ctx context.Context, c Connection) (Connec
 	// next poll. Mirrors requests.UpdateIntegration's CASE-WHEN keep-semantics.
 	// Pass the raw trimmed string (not nullable()) so the empty-string sentinel
 	// reaches the CASE.
+	// Encrypt the incoming key; an empty result preserves the keep-existing CASE.
+	apiKeyRef, err := r.encryptAPIKey(c.ID, c.APIKeyRef)
+	if err != nil {
+		return Connection{}, fmt.Errorf("encrypt autoscan api key: %w", err)
+	}
 	row := r.pool.QueryRow(ctx, `
 		UPDATE autoscan_connections
 		SET name = $2, kind = $3, base_url = $4,
@@ -115,8 +161,8 @@ func (r *Repository) UpdateConnection(ctx context.Context, c Connection) (Connec
 		    request_integration_id = $6, updated_at = now()
 		WHERE id = $1
 		RETURNING `+connectionColumns,
-		c.ID, c.Name, c.Kind, nullable(c.BaseURL), c.APIKeyRef, c.RequestIntegrationID)
-	out, err := scanConnection(row)
+		c.ID, c.Name, c.Kind, nullable(c.BaseURL), apiKeyRef, c.RequestIntegrationID)
+	out, err := r.scanConnection(row)
 	if err != nil {
 		if errors.Is(err, pgx.ErrNoRows) {
 			return Connection{}, fmt.Errorf("%w: connection %s", ErrNotFound, c.ID)
@@ -151,7 +197,7 @@ func (r *Repository) ListConnections(ctx context.Context) ([]Connection, error) 
 	defer rows.Close()
 	var out []Connection
 	for rows.Next() {
-		c, err := scanConnection(rows)
+		c, err := r.scanConnection(rows)
 		if err != nil {
 			return nil, err
 		}
@@ -163,7 +209,7 @@ func (r *Repository) ListConnections(ctx context.Context) ([]Connection, error) 
 func (r *Repository) GetConnection(ctx context.Context, id string) (Connection, error) {
 	row := r.pool.QueryRow(ctx, `SELECT `+connectionColumns+`
 		FROM autoscan_connections WHERE id = $1`, id)
-	c, err := scanConnection(row)
+	c, err := r.scanConnection(row)
 	if err != nil {
 		if errors.Is(err, pgx.ErrNoRows) {
 			return Connection{}, fmt.Errorf("%w: connection %s", ErrNotFound, id)

--- a/internal/catalog/encrypted_settings_repo.go
+++ b/internal/catalog/encrypted_settings_repo.go
@@ -1,0 +1,194 @@
+package catalog
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"sort"
+
+	"github.com/Silo-Server/silo-server/internal/secret"
+)
+
+// SettingsStore is the read/write surface over server_settings shared by the
+// raw *ServerSettingsRepo and the *EncryptedSettingsRepo decorator. Consumers
+// depend on this interface (rather than the concrete repo) so they
+// transparently gain at-rest encryption for sensitive keys once the decorator
+// is wired in.
+type SettingsStore interface {
+	Get(ctx context.Context, key string) (string, error)
+	Set(ctx context.Context, key, value string) error
+	GetAll(ctx context.Context) (map[string]string, error)
+}
+
+// SensitiveSettingKeys is the single source of truth for which server_settings
+// keys hold secrets. It drives BOTH at-rest encryption (the decorator encrypts
+// these on write, decrypts them on read) AND admin-API redaction, so the two
+// can never drift apart.
+//
+// It was audited from the config loader's real inputs
+// (internal/config/db_loader.go), the admin redaction map, and the other known
+// server_settings consumers — the Audiobookshelf-compat JWT secret
+// (internal/audiobooks/config.go), the watch-sync OAuth client config
+// (internal/watchsync/service.go), and the legacy single-instance arr keys —
+// including the legacy aliases still read as fallbacks (s3.operational_*,
+// recommendations.openai_api_key) and redis.sentinel_password, which the old
+// redaction map omitted.
+//
+// Adding a key here is only safe when every reader of that key goes through a
+// cipher-aware path (the decorator, or a repo that calls
+// secret.Cipher.DecryptIfEncrypted with secret.SettingsAAD). A raw SQL reader
+// would otherwise see ciphertext after the backfill.
+var SensitiveSettingKeys = map[string]bool{
+	// Core auth signing secret — no longer the encryption root (SECRET_KEY is),
+	// and now itself encrypted at rest under SECRET_KEY.
+	"auth.jwt_secret": true,
+	// Audiobookshelf-compat HMAC signing key (generated + persisted as hex).
+	"audiobooks.abs.jwt_secret": true,
+
+	// S3 — public assets, private internal, user DB, plus the legacy
+	// "operational" aliases db_loader still reads as fallbacks (L155-192;
+	// migration 086 copied but did not delete them).
+	"s3.public_access_key":        true,
+	"s3.public_secret_key":        true,
+	"s3.public_token_secret":      true,
+	"s3.private_access_key":       true,
+	"s3.private_secret_key":       true,
+	"s3.user_db_access_key":       true,
+	"s3.user_db_secret_key":       true,
+	"s3.operational_access_key":   true,
+	"s3.operational_secret_key":   true,
+	"s3.operational_token_secret": true,
+
+	// Redis — url may embed credentials (redis://:pass@host); sentinel_password
+	// is read at db_loader L334 and was MISSING from the old redaction map.
+	"redis.url":               true,
+	"redis.sentinel_password": true,
+
+	// Metadata / list-provider API keys.
+	"tmdb.api_key":    true,
+	"mdblist.api_key": true,
+	"introdb.api_key": true,
+
+	// Subtitle AI (on-demand translation) API key.
+	"subtitle_ai.api_key": true,
+
+	// Recommendations embedding auth (+ legacy openai alias at db_loader L409).
+	"recommendations.embedding_auth_token": true,
+	"recommendations.openai_api_key":       true,
+
+	// Watch-sync OAuth client credentials. The client_id entries are low-value
+	// but kept as a harmless safe superset and to match existing redaction.
+	"watchsync.trakt.client_id":     true,
+	"watchsync.trakt.client_secret": true,
+	"watchsync.simkl.client_id":     true,
+	"watchsync.simkl.client_secret": true,
+
+	// Legacy single-instance arr keys (superseded by per-integration rows, but
+	// still referenced by older request_integrations rows until backfilled).
+	"requests.radarr.api_key": true,
+	"requests.sonarr.api_key": true,
+}
+
+// EncryptedSettingsRepo decorates a raw settings store, transparently
+// encrypting the SensitiveSettingKeys on write and decrypting them on read.
+// config.LoadFromDB and every other consumer keep seeing plaintext while the
+// values rest as ciphertext in the database, GCM-bound to their key.
+type EncryptedSettingsRepo struct {
+	// inner is the RAW store (no encryption). It must never be another
+	// EncryptedSettingsRepo, or writes would double-encrypt.
+	inner  SettingsStore
+	cipher *secret.Cipher
+}
+
+// NewEncryptedSettingsRepo wraps a raw settings store with the cipher. Pass the
+// concrete *ServerSettingsRepo (or an in-memory fake in tests) as inner.
+func NewEncryptedSettingsRepo(inner SettingsStore, cipher *secret.Cipher) *EncryptedSettingsRepo {
+	return &EncryptedSettingsRepo{inner: inner, cipher: cipher}
+}
+
+var _ SettingsStore = (*EncryptedSettingsRepo)(nil)
+
+// Set encrypts a sensitive, non-empty value (AAD-bound to its key) before
+// delegating to the raw store; non-sensitive keys and empty values delegate
+// unchanged. Encrypting an empty value is a no-op, so an absent secret stays an
+// empty column rather than an envelope.
+func (r *EncryptedSettingsRepo) Set(ctx context.Context, key, value string) error {
+	if SensitiveSettingKeys[key] && value != "" {
+		ct, err := r.cipher.Encrypt(value, secret.SettingsAAD(key))
+		if err != nil {
+			return fmt.Errorf("encrypt setting %q: %w", key, err)
+		}
+		value = ct
+	}
+	return r.inner.Set(ctx, key, value)
+}
+
+// Get reads a value and applies the read-path contract: legacy plaintext passes
+// through, an enc:v1: value is decrypted, and a corrupt ciphertext errors.
+func (r *EncryptedSettingsRepo) Get(ctx context.Context, key string) (string, error) {
+	value, err := r.inner.Get(ctx, key)
+	if err != nil {
+		return "", err
+	}
+	out, err := r.cipher.DecryptIfEncrypted(value, secret.SettingsAAD(key))
+	if err != nil {
+		return "", fmt.Errorf("decrypt setting %q: %w", key, err)
+	}
+	return out, nil
+}
+
+// GetAll reads every setting and decrypts any enc:v1: value in place, so
+// callers (notably config.LoadFromDB) receive a fully plaintext map.
+func (r *EncryptedSettingsRepo) GetAll(ctx context.Context) (map[string]string, error) {
+	all, err := r.inner.GetAll(ctx)
+	if err != nil {
+		return nil, err
+	}
+	for key, value := range all {
+		out, derr := r.cipher.DecryptIfEncrypted(value, secret.SettingsAAD(key))
+		if derr != nil {
+			return nil, fmt.Errorf("decrypt setting %q: %w", key, derr)
+		}
+		all[key] = out
+	}
+	return all, nil
+}
+
+// BackfillSensitiveSettings encrypts any plaintext value currently stored under
+// a sensitive key. It is idempotent (already-encrypted and empty values are
+// skipped) and best-effort: per-key failures are collected and returned but do
+// not abort the sweep, so one unreadable row cannot block startup. Returns the
+// number of keys newly encrypted.
+func (r *EncryptedSettingsRepo) BackfillSensitiveSettings(ctx context.Context) (int, error) {
+	keys := make([]string, 0, len(SensitiveSettingKeys))
+	for key := range SensitiveSettingKeys {
+		keys = append(keys, key)
+	}
+	sort.Strings(keys) // deterministic order for logs and tests
+
+	encrypted := 0
+	var errs []error
+	for _, key := range keys {
+		// Read the RAW inner value (not through this decorator) so we can tell
+		// plaintext from an already-encrypted envelope.
+		raw, err := r.inner.Get(ctx, key)
+		if err != nil {
+			errs = append(errs, fmt.Errorf("read %q: %w", key, err))
+			continue
+		}
+		if raw == "" || secret.IsEncrypted(raw) {
+			continue
+		}
+		ct, err := r.cipher.Encrypt(raw, secret.SettingsAAD(key))
+		if err != nil {
+			errs = append(errs, fmt.Errorf("encrypt %q: %w", key, err))
+			continue
+		}
+		if err := r.inner.Set(ctx, key, ct); err != nil {
+			errs = append(errs, fmt.Errorf("write %q: %w", key, err))
+			continue
+		}
+		encrypted++
+	}
+	return encrypted, errors.Join(errs...)
+}

--- a/internal/catalog/encrypted_settings_repo_test.go
+++ b/internal/catalog/encrypted_settings_repo_test.go
@@ -1,0 +1,210 @@
+package catalog
+
+import (
+	"context"
+	"crypto/rand"
+	"testing"
+
+	"github.com/Silo-Server/silo-server/internal/secret"
+)
+
+// memSettings is an in-memory raw SettingsStore for DB-free decorator tests.
+type memSettings struct{ m map[string]string }
+
+func newMemSettings() *memSettings { return &memSettings{m: map[string]string{}} }
+
+func (s *memSettings) Get(_ context.Context, key string) (string, error) { return s.m[key], nil }
+func (s *memSettings) Set(_ context.Context, key, value string) error {
+	s.m[key] = value
+	return nil
+}
+func (s *memSettings) GetAll(_ context.Context) (map[string]string, error) {
+	out := make(map[string]string, len(s.m))
+	for k, v := range s.m {
+		out[k] = v
+	}
+	return out, nil
+}
+
+func newCipher(t *testing.T) *secret.Cipher {
+	t.Helper()
+	key := make([]byte, 48)
+	if _, err := rand.Read(key); err != nil {
+		t.Fatalf("rand: %v", err)
+	}
+	c, err := secret.New(key)
+	if err != nil {
+		t.Fatalf("secret.New: %v", err)
+	}
+	return c
+}
+
+func pickSensitiveKey() string {
+	for k := range SensitiveSettingKeys {
+		return k
+	}
+	return "auth.jwt_secret"
+}
+
+func TestEncryptedSettings_SensitiveRoundTrip(t *testing.T) {
+	ctx := context.Background()
+	raw := newMemSettings()
+	dec := NewEncryptedSettingsRepo(raw, newCipher(t))
+
+	const key = "tmdb.api_key"
+	const plain = "tmdb-secret-key-value"
+	if err := dec.Set(ctx, key, plain); err != nil {
+		t.Fatalf("Set: %v", err)
+	}
+	// Raw store must hold ciphertext.
+	if got := raw.m[key]; !secret.IsEncrypted(got) {
+		t.Fatalf("raw store value = %q, want enc:v1: ciphertext", got)
+	}
+	// Decorator Get must return plaintext.
+	got, err := dec.Get(ctx, key)
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+	if got != plain {
+		t.Fatalf("Get = %q, want %q", got, plain)
+	}
+}
+
+func TestEncryptedSettings_NonSensitivePassthrough(t *testing.T) {
+	ctx := context.Background()
+	raw := newMemSettings()
+	dec := NewEncryptedSettingsRepo(raw, newCipher(t))
+
+	const key = "server.log_level"
+	if SensitiveSettingKeys[key] {
+		t.Fatalf("precondition: %q must be non-sensitive", key)
+	}
+	if err := dec.Set(ctx, key, "debug"); err != nil {
+		t.Fatalf("Set: %v", err)
+	}
+	if got := raw.m[key]; got != "debug" {
+		t.Fatalf("non-sensitive raw value = %q, want plaintext 'debug'", got)
+	}
+}
+
+func TestEncryptedSettings_LegacyPlaintextPassthrough(t *testing.T) {
+	ctx := context.Background()
+	raw := newMemSettings()
+	dec := NewEncryptedSettingsRepo(raw, newCipher(t))
+
+	// Simulate a pre-encryption row: a sensitive key holding raw plaintext.
+	raw.m["tmdb.api_key"] = "legacy-plaintext"
+	got, err := dec.Get(ctx, "tmdb.api_key")
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+	if got != "legacy-plaintext" {
+		t.Fatalf("legacy plaintext Get = %q, want pass-through", got)
+	}
+}
+
+func TestEncryptedSettings_EmptySensitiveStaysEmpty(t *testing.T) {
+	ctx := context.Background()
+	raw := newMemSettings()
+	dec := NewEncryptedSettingsRepo(raw, newCipher(t))
+	if err := dec.Set(ctx, "tmdb.api_key", ""); err != nil {
+		t.Fatalf("Set: %v", err)
+	}
+	if got := raw.m["tmdb.api_key"]; got != "" {
+		t.Fatalf("empty sensitive value stored as %q, want empty (no envelope)", got)
+	}
+}
+
+func TestEncryptedSettings_GetAllDecrypts(t *testing.T) {
+	ctx := context.Background()
+	raw := newMemSettings()
+	dec := NewEncryptedSettingsRepo(raw, newCipher(t))
+
+	if err := dec.Set(ctx, "tmdb.api_key", "k1"); err != nil {
+		t.Fatalf("Set: %v", err)
+	}
+	if err := dec.Set(ctx, "server.mode", "integrated"); err != nil {
+		t.Fatalf("Set: %v", err)
+	}
+	all, err := dec.GetAll(ctx)
+	if err != nil {
+		t.Fatalf("GetAll: %v", err)
+	}
+	if all["tmdb.api_key"] != "k1" {
+		t.Fatalf("GetAll sensitive = %q, want decrypted 'k1'", all["tmdb.api_key"])
+	}
+	if all["server.mode"] != "integrated" {
+		t.Fatalf("GetAll non-sensitive = %q", all["server.mode"])
+	}
+}
+
+// TestSensitiveSettingKeys_Audited locks the audited allowlist: a dropped key is
+// a plaintext leak (and breaks redaction), so the critical secrets must stay
+// present, while values that are NOT secrets must stay absent (encrypting them
+// would corrupt config reads).
+func TestSensitiveSettingKeys_Audited(t *testing.T) {
+	mustHave := []string{
+		"auth.jwt_secret",
+		"audiobooks.abs.jwt_secret",
+		"s3.public_secret_key",
+		"s3.operational_secret_key", // legacy alias still read as a fallback
+		"redis.sentinel_password",   // was missing from the old redaction map
+		"recommendations.openai_api_key",
+		"tmdb.api_key",
+		"requests.radarr.api_key",
+		"requests.sonarr.api_key",
+		"watchsync.trakt.client_secret",
+	}
+	for _, k := range mustHave {
+		if !SensitiveSettingKeys[k] {
+			t.Errorf("SensitiveSettingKeys missing critical secret key %q", k)
+		}
+	}
+	mustNotHave := []string{
+		"server.mode",
+		"server.log_level",
+		"database.max_connections",
+		"jellyfin_compat.server_id",
+	}
+	for _, k := range mustNotHave {
+		if SensitiveSettingKeys[k] {
+			t.Errorf("SensitiveSettingKeys must not contain non-secret key %q", k)
+		}
+	}
+}
+
+func TestEncryptedSettings_BackfillIdempotent(t *testing.T) {
+	ctx := context.Background()
+	raw := newMemSettings()
+	dec := NewEncryptedSettingsRepo(raw, newCipher(t))
+
+	key := pickSensitiveKey()
+	raw.m[key] = "plaintext-secret"     // legacy row
+	raw.m["server.mode"] = "integrated" // non-sensitive, must be left alone
+
+	n, err := dec.BackfillSensitiveSettings(ctx)
+	if err != nil {
+		t.Fatalf("backfill: %v", err)
+	}
+	if n != 1 {
+		t.Fatalf("backfill encrypted %d, want 1", n)
+	}
+	if !secret.IsEncrypted(raw.m[key]) {
+		t.Fatalf("after backfill raw[%q] = %q, want ciphertext", key, raw.m[key])
+	}
+	if raw.m["server.mode"] != "integrated" {
+		t.Fatalf("backfill mutated non-sensitive key: %q", raw.m["server.mode"])
+	}
+	// Decryptable back to the original.
+	if got, _ := dec.Get(ctx, key); got != "plaintext-secret" {
+		t.Fatalf("post-backfill Get = %q, want original", got)
+	}
+	// Second run is a no-op.
+	n2, err := dec.BackfillSensitiveSettings(ctx)
+	if err != nil {
+		t.Fatalf("backfill 2: %v", err)
+	}
+	if n2 != 0 {
+		t.Fatalf("second backfill encrypted %d, want 0 (no double-encrypt)", n2)
+	}
+}

--- a/internal/config/bootstrap.go
+++ b/internal/config/bootstrap.go
@@ -7,6 +7,11 @@ import (
 	"github.com/joho/godotenv"
 )
 
+// minSecretKeyLen is the minimum acceptable SECRET_KEY length (in characters).
+// It mirrors secret.MinMasterKeyLen; the package is not imported here to keep
+// the bootstrap loader dependency-free, so the two constants must stay in sync.
+const minSecretKeyLen = 32
+
 // BootstrapConfig holds the minimal config needed before database connection.
 type BootstrapConfig struct {
 	DatabaseURL string
@@ -14,6 +19,10 @@ type BootstrapConfig struct {
 	Listen      string
 	JFListen    string
 	Mode        string
+	// SecretKey is the master key (raw SECRET_KEY env value) from which the
+	// at-rest credential cipher derives its data key. It lives outside Postgres
+	// so encrypted secrets survive a full database compromise/dump.
+	SecretKey []byte
 }
 
 // LoadBootstrap loads bootstrap configuration from a .env file (if it exists)
@@ -26,6 +35,15 @@ func LoadBootstrap(envFile string) (*BootstrapConfig, error) {
 	dbURL := os.Getenv("DATABASE_URL")
 	if dbURL == "" {
 		return nil, fmt.Errorf("DATABASE_URL is required (set in .env or environment)")
+	}
+
+	// SECRET_KEY is the at-rest encryption master key. It is required: the server
+	// must never fall back to a zero key or a key derived from another value, or
+	// encrypted credentials would not survive a database dump. godotenv has
+	// already loaded .env above, so dev sets it there.
+	secretKey := os.Getenv("SECRET_KEY")
+	if len(secretKey) < minSecretKeyLen {
+		return nil, fmt.Errorf("SECRET_KEY is required (>=%d chars); generate one with: openssl rand -base64 48", minSecretKeyLen)
 	}
 
 	port := os.Getenv("PORT")
@@ -51,5 +69,6 @@ func LoadBootstrap(envFile string) (*BootstrapConfig, error) {
 		Listen:      ":" + port,
 		JFListen:    ":" + jfPort,
 		Mode:        mode,
+		SecretKey:   []byte(secretKey),
 	}, nil
 }

--- a/internal/historyimport/repo.go
+++ b/internal/historyimport/repo.go
@@ -41,11 +41,123 @@ func NewRepository(pool *pgxpool.Pool, cipher *secret.Cipher) *Repository {
 func sourceAdminTokenAAD(sourceID int) string {
 	return secret.RowAAD("history_import_sources", "admin_token", strconv.Itoa(sourceID))
 }
+func connectServerAccessKeyAAD(sessionID string, index int, server ConnectServer) string {
+	return secret.RowAAD("history_import_connect_sessions", "servers_json.access_key", sessionID+":"+strconv.Itoa(index)+":"+server.ID)
+}
 func connectSessionTokenAAD(sessionID string) string {
 	return secret.RowAAD("history_import_connect_sessions", "connect_access_token", sessionID)
 }
+func plexServerAccessTokenAAD(sessionID string, index int, server PlexServer) string {
+	return secret.RowAAD("history_import_plex_sessions", "servers_json.access_token", sessionID+":"+strconv.Itoa(index)+":"+server.ClientIdentifier)
+}
 func plexSessionTokenAAD(sessionID string) string {
 	return secret.RowAAD("history_import_plex_sessions", "auth_token", sessionID)
+}
+
+func (r *Repository) encryptSourceAdminToken(sourceID int, token string) (string, error) {
+	return r.cipher.Encrypt(token, sourceAdminTokenAAD(sourceID))
+}
+
+func (r *Repository) encryptConnectServers(sessionID string, servers []ConnectServer) ([]ConnectServer, error) {
+	out := append([]ConnectServer(nil), servers...)
+	for i := range out {
+		if out[i].AccessKey == "" {
+			continue
+		}
+		accessKey, err := r.cipher.Encrypt(out[i].AccessKey, connectServerAccessKeyAAD(sessionID, i, out[i]))
+		if err != nil {
+			return nil, fmt.Errorf("encrypt connect server access key: %w", err)
+		}
+		out[i].AccessKey = accessKey
+	}
+	return out, nil
+}
+
+func (r *Repository) encryptPlaintextConnectServers(sessionID string, servers []ConnectServer) ([]ConnectServer, bool, error) {
+	out := append([]ConnectServer(nil), servers...)
+	changed := false
+	for i := range out {
+		accessKey, didChange, err := r.cipher.EncryptIfPlaintext(out[i].AccessKey, connectServerAccessKeyAAD(sessionID, i, out[i]))
+		if err != nil {
+			return nil, false, fmt.Errorf("encrypt connect server access key: %w", err)
+		}
+		if didChange {
+			out[i].AccessKey = accessKey
+			changed = true
+		}
+	}
+	return out, changed, nil
+}
+
+func (r *Repository) decryptConnectServers(sessionID string, servers []ConnectServer) ([]ConnectServer, error) {
+	out := append([]ConnectServer(nil), servers...)
+	for i := range out {
+		accessKey, err := r.cipher.DecryptIfEncrypted(out[i].AccessKey, connectServerAccessKeyAAD(sessionID, i, out[i]))
+		if err != nil {
+			return nil, fmt.Errorf("decrypt connect server access key: %w", err)
+		}
+		out[i].AccessKey = accessKey
+	}
+	return out, nil
+}
+
+func (r *Repository) marshalConnectServersForWrite(sessionID string, servers []ConnectServer) ([]byte, error) {
+	encrypted, err := r.encryptConnectServers(sessionID, servers)
+	if err != nil {
+		return nil, err
+	}
+	return json.Marshal(encrypted)
+}
+
+func (r *Repository) encryptPlexServers(sessionID string, servers []PlexServer) ([]PlexServer, error) {
+	out := append([]PlexServer(nil), servers...)
+	for i := range out {
+		if out[i].AccessToken == "" {
+			continue
+		}
+		accessToken, err := r.cipher.Encrypt(out[i].AccessToken, plexServerAccessTokenAAD(sessionID, i, out[i]))
+		if err != nil {
+			return nil, fmt.Errorf("encrypt plex server access token: %w", err)
+		}
+		out[i].AccessToken = accessToken
+	}
+	return out, nil
+}
+
+func (r *Repository) encryptPlaintextPlexServers(sessionID string, servers []PlexServer) ([]PlexServer, bool, error) {
+	out := append([]PlexServer(nil), servers...)
+	changed := false
+	for i := range out {
+		accessToken, didChange, err := r.cipher.EncryptIfPlaintext(out[i].AccessToken, plexServerAccessTokenAAD(sessionID, i, out[i]))
+		if err != nil {
+			return nil, false, fmt.Errorf("encrypt plex server access token: %w", err)
+		}
+		if didChange {
+			out[i].AccessToken = accessToken
+			changed = true
+		}
+	}
+	return out, changed, nil
+}
+
+func (r *Repository) decryptPlexServers(sessionID string, servers []PlexServer) ([]PlexServer, error) {
+	out := append([]PlexServer(nil), servers...)
+	for i := range out {
+		accessToken, err := r.cipher.DecryptIfEncrypted(out[i].AccessToken, plexServerAccessTokenAAD(sessionID, i, out[i]))
+		if err != nil {
+			return nil, fmt.Errorf("decrypt plex server access token: %w", err)
+		}
+		out[i].AccessToken = accessToken
+	}
+	return out, nil
+}
+
+func (r *Repository) marshalPlexServersForWrite(sessionID string, servers []PlexServer) ([]byte, error) {
+	encrypted, err := r.encryptPlexServers(sessionID, servers)
+	if err != nil {
+		return nil, err
+	}
+	return json.Marshal(encrypted)
 }
 
 func (r *Repository) ListEnabledSources(ctx context.Context) ([]Source, error) {
@@ -95,19 +207,43 @@ func (r *Repository) GetSourceByID(ctx context.Context, id int) (*Source, error)
 }
 
 func (r *Repository) CreateSource(ctx context.Context, input CreateSourceInput) (*Source, error) {
-	row := r.pool.QueryRow(ctx, `
-		INSERT INTO history_import_sources (name, source_type, base_url, system_id, enabled, sort_order,
-		                                    admin_token)
-		VALUES ($1, $2, $3, NULLIF($4, ''), $5, $6, NULLIF($7, ''))
+	tx, err := r.pool.Begin(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("begin creating history import source: %w", err)
+	}
+	defer tx.Rollback(ctx)
+
+	row := tx.QueryRow(ctx, `
+		INSERT INTO history_import_sources (name, source_type, base_url, system_id, enabled, sort_order)
+		VALUES ($1, $2, $3, NULLIF($4, ''), $5, $6)
 		RETURNING id, name, source_type, base_url, COALESCE(system_id, ''), enabled, sort_order,
 		          (admin_token IS NOT NULL) AS has_admin_token,
 		          created_at, updated_at`,
 		input.Name, input.SourceType, input.BaseURL, input.SystemID, input.Enabled, input.SortOrder,
-		input.AdminToken,
 	)
 	source, err := scanSource(row)
 	if err != nil {
 		return nil, fmt.Errorf("creating history import source: %w", err)
+	}
+	if input.AdminToken != "" {
+		encryptedToken, err := r.encryptSourceAdminToken(source.ID, input.AdminToken)
+		if err != nil {
+			return nil, fmt.Errorf("encrypt admin token for source %d: %w", source.ID, err)
+		}
+		result, err := tx.Exec(ctx, `
+			UPDATE history_import_sources
+			SET admin_token = $2, updated_at = NOW()
+			WHERE id = $1`, source.ID, encryptedToken)
+		if err != nil {
+			return nil, fmt.Errorf("setting admin token for source %d: %w", source.ID, err)
+		}
+		if result.RowsAffected() == 0 {
+			return nil, ErrSourceNotFound
+		}
+		source.HasAdminToken = true
+	}
+	if err := tx.Commit(ctx); err != nil {
+		return nil, fmt.Errorf("commit creating history import source: %w", err)
 	}
 	return source, nil
 }
@@ -150,7 +286,7 @@ func (r *Repository) DeleteSource(ctx context.Context, id int) error {
 }
 
 func (r *Repository) CreateConnectSession(ctx context.Context, session ConnectSession) (*ConnectSession, error) {
-	serversJSON, err := json.Marshal(session.Servers)
+	serversJSON, err := r.marshalConnectServersForWrite(session.ID, session.Servers)
 	if err != nil {
 		return nil, fmt.Errorf("marshaling connect servers: %w", err)
 	}
@@ -218,7 +354,7 @@ func (r *Repository) DeleteExpiredConnectSessions(ctx context.Context) error {
 }
 
 func (r *Repository) CreatePlexSession(ctx context.Context, session PlexSession) (*PlexSession, error) {
-	serversJSON, err := json.Marshal(session.Servers)
+	serversJSON, err := r.marshalPlexServersForWrite(session.ID, session.Servers)
 	if err != nil {
 		return nil, fmt.Errorf("marshaling plex servers: %w", err)
 	}
@@ -262,7 +398,7 @@ func (r *Repository) GetPlexSession(ctx context.Context, userID int, sessionID s
 }
 
 func (r *Repository) UpdatePlexSessionAuth(ctx context.Context, sessionID, authToken string, servers []PlexServer) error {
-	serversJSON, err := json.Marshal(servers)
+	serversJSON, err := r.marshalPlexServersForWrite(sessionID, servers)
 	if err != nil {
 		return fmt.Errorf("marshaling plex servers: %w", err)
 	}
@@ -305,6 +441,136 @@ func (r *Repository) DeleteExpiredPlexSessions(ctx context.Context) error {
 		return fmt.Errorf("deleting expired plex sessions: %w", err)
 	}
 	return nil
+}
+
+// BackfillSessionServerSecrets encrypts credentials nested inside history-import
+// session server JSON. The top-level session token columns are handled by the
+// generic column backfill, but Emby Connect access keys and Plex per-server
+// access tokens live inside servers_json and need a typed JSON pass.
+func (r *Repository) BackfillSessionServerSecrets(ctx context.Context) (int, error) {
+	connectN, connectErr := r.backfillConnectSessionServerSecrets(ctx)
+	plexN, plexErr := r.backfillPlexSessionServerSecrets(ctx)
+	return connectN + plexN, errors.Join(connectErr, plexErr)
+}
+
+func (r *Repository) backfillConnectSessionServerSecrets(ctx context.Context) (int, error) {
+	rows, err := r.pool.Query(ctx, `
+		SELECT id, servers_json::text
+		FROM history_import_connect_sessions
+		WHERE servers_json <> '[]'::jsonb`)
+	if err != nil {
+		return 0, fmt.Errorf("select connect sessions: %w", err)
+	}
+	type rec struct{ id, raw string }
+	var recs []rec
+	for rows.Next() {
+		var r rec
+		if err := rows.Scan(&r.id, &r.raw); err != nil {
+			rows.Close()
+			return 0, fmt.Errorf("scan connect session: %w", err)
+		}
+		recs = append(recs, r)
+	}
+	rows.Close()
+	if err := rows.Err(); err != nil {
+		return 0, fmt.Errorf("iterate connect sessions: %w", err)
+	}
+
+	count := 0
+	var errs []error
+	for _, rec := range recs {
+		var servers []ConnectServer
+		if err := json.Unmarshal([]byte(rec.raw), &servers); err != nil {
+			errs = append(errs, fmt.Errorf("decode connect session %s servers: %w", rec.id, err))
+			continue
+		}
+		encrypted, changed, err := r.encryptPlaintextConnectServers(rec.id, servers)
+		if err != nil {
+			errs = append(errs, fmt.Errorf("encrypt connect session %s servers: %w", rec.id, err))
+			continue
+		}
+		if !changed {
+			continue
+		}
+		body, err := json.Marshal(encrypted)
+		if err != nil {
+			errs = append(errs, fmt.Errorf("encode connect session %s servers: %w", rec.id, err))
+			continue
+		}
+		tag, err := r.pool.Exec(ctx, `
+			UPDATE history_import_connect_sessions
+			SET servers_json = $2::jsonb, updated_at = NOW()
+			WHERE id = $1 AND servers_json = $3::jsonb`,
+			rec.id, string(body), rec.raw)
+		if err != nil {
+			errs = append(errs, fmt.Errorf("update connect session %s servers: %w", rec.id, err))
+			continue
+		}
+		if tag.RowsAffected() > 0 {
+			count++
+		}
+	}
+	return count, errors.Join(errs...)
+}
+
+func (r *Repository) backfillPlexSessionServerSecrets(ctx context.Context) (int, error) {
+	rows, err := r.pool.Query(ctx, `
+		SELECT id, servers_json::text
+		FROM history_import_plex_sessions
+		WHERE servers_json <> '[]'::jsonb`)
+	if err != nil {
+		return 0, fmt.Errorf("select plex sessions: %w", err)
+	}
+	type rec struct{ id, raw string }
+	var recs []rec
+	for rows.Next() {
+		var r rec
+		if err := rows.Scan(&r.id, &r.raw); err != nil {
+			rows.Close()
+			return 0, fmt.Errorf("scan plex session: %w", err)
+		}
+		recs = append(recs, r)
+	}
+	rows.Close()
+	if err := rows.Err(); err != nil {
+		return 0, fmt.Errorf("iterate plex sessions: %w", err)
+	}
+
+	count := 0
+	var errs []error
+	for _, rec := range recs {
+		var servers []PlexServer
+		if err := json.Unmarshal([]byte(rec.raw), &servers); err != nil {
+			errs = append(errs, fmt.Errorf("decode plex session %s servers: %w", rec.id, err))
+			continue
+		}
+		encrypted, changed, err := r.encryptPlaintextPlexServers(rec.id, servers)
+		if err != nil {
+			errs = append(errs, fmt.Errorf("encrypt plex session %s servers: %w", rec.id, err))
+			continue
+		}
+		if !changed {
+			continue
+		}
+		body, err := json.Marshal(encrypted)
+		if err != nil {
+			errs = append(errs, fmt.Errorf("encode plex session %s servers: %w", rec.id, err))
+			continue
+		}
+		tag, err := r.pool.Exec(ctx, `
+			UPDATE history_import_plex_sessions
+			SET servers_json = $2::jsonb, updated_at = NOW()
+			WHERE id = $1 AND servers_json = $3::jsonb`,
+			rec.id, string(body), rec.raw)
+		if err != nil {
+			errs = append(errs, fmt.Errorf("update plex session %s servers: %w", rec.id, err))
+			continue
+		}
+		if tag.RowsAffected() > 0 {
+			count++
+		}
+	}
+	return count, errors.Join(errs...)
 }
 
 func (r *Repository) ProfileExistsForUser(ctx context.Context, userID int, profileID string) (bool, error) {
@@ -815,6 +1081,10 @@ func (r *Repository) scanConnectSession(scanner interface{ Scan(dest ...any) err
 		if err := json.Unmarshal(serversJSON, &session.Servers); err != nil {
 			return nil, fmt.Errorf("unmarshaling connect session servers: %w", err)
 		}
+		session.Servers, err = r.decryptConnectServers(session.ID, session.Servers)
+		if err != nil {
+			return nil, err
+		}
 	}
 	return &session, nil
 }
@@ -975,6 +1245,10 @@ func (r *Repository) scanPlexSession(scanner interface{ Scan(dest ...any) error 
 	if len(serversJSON) > 0 {
 		if err := json.Unmarshal(serversJSON, &session.Servers); err != nil {
 			return nil, fmt.Errorf("unmarshaling plex session servers: %w", err)
+		}
+		session.Servers, err = r.decryptPlexServers(session.ID, session.Servers)
+		if err != nil {
+			return nil, err
 		}
 	}
 	return &session, nil

--- a/internal/historyimport/repo.go
+++ b/internal/historyimport/repo.go
@@ -6,11 +6,14 @@ import (
 	"errors"
 	"fmt"
 	"sort"
+	"strconv"
 	"time"
 
 	"github.com/google/uuid"
 	"github.com/jackc/pgx/v5"
 	"github.com/jackc/pgx/v5/pgxpool"
+
+	"github.com/Silo-Server/silo-server/internal/secret"
 )
 
 var (
@@ -26,11 +29,23 @@ var (
 )
 
 type Repository struct {
-	pool *pgxpool.Pool
+	pool   *pgxpool.Pool
+	cipher *secret.Cipher
 }
 
-func NewRepository(pool *pgxpool.Pool) *Repository {
-	return &Repository{pool: pool}
+func NewRepository(pool *pgxpool.Pool, cipher *secret.Cipher) *Repository {
+	return &Repository{pool: pool, cipher: cipher}
+}
+
+// AAD builders binding each history-import secret column to its row id.
+func sourceAdminTokenAAD(sourceID int) string {
+	return secret.RowAAD("history_import_sources", "admin_token", strconv.Itoa(sourceID))
+}
+func connectSessionTokenAAD(sessionID string) string {
+	return secret.RowAAD("history_import_connect_sessions", "connect_access_token", sessionID)
+}
+func plexSessionTokenAAD(sessionID string) string {
+	return secret.RowAAD("history_import_plex_sessions", "auth_token", sessionID)
 }
 
 func (r *Repository) ListEnabledSources(ctx context.Context) ([]Source, error) {
@@ -139,14 +154,18 @@ func (r *Repository) CreateConnectSession(ctx context.Context, session ConnectSe
 	if err != nil {
 		return nil, fmt.Errorf("marshaling connect servers: %w", err)
 	}
+	accessToken, err := r.cipher.Encrypt(session.ConnectAccessToken, connectSessionTokenAAD(session.ID))
+	if err != nil {
+		return nil, fmt.Errorf("encrypt connect access token: %w", err)
+	}
 	row := r.pool.QueryRow(ctx, `
 		INSERT INTO history_import_connect_sessions (
 			id, user_id, connect_user_id, connect_access_token, servers_json, expires_at
 		) VALUES ($1, $2, $3, $4, $5, $6)
 		RETURNING id, user_id, connect_user_id, connect_access_token, servers_json, expires_at, consumed_at, created_at, updated_at`,
-		session.ID, session.UserID, session.ConnectUserID, session.ConnectAccessToken, serversJSON, session.ExpiresAt,
+		session.ID, session.UserID, session.ConnectUserID, accessToken, serversJSON, session.ExpiresAt,
 	)
-	stored, err := scanConnectSession(row)
+	stored, err := r.scanConnectSession(row)
 	if err != nil {
 		return nil, fmt.Errorf("creating connect session: %w", err)
 	}
@@ -158,7 +177,7 @@ func (r *Repository) GetConnectSession(ctx context.Context, userID int, sessionI
 		SELECT id, user_id, connect_user_id, connect_access_token, servers_json, expires_at, consumed_at, created_at, updated_at
 		FROM history_import_connect_sessions
 		WHERE id = $1 AND user_id = $2`, sessionID, userID)
-	session, err := scanConnectSession(row)
+	session, err := r.scanConnectSession(row)
 	if errors.Is(err, pgx.ErrNoRows) {
 		return nil, ErrConnectSessionNotFound
 	}
@@ -203,14 +222,18 @@ func (r *Repository) CreatePlexSession(ctx context.Context, session PlexSession)
 	if err != nil {
 		return nil, fmt.Errorf("marshaling plex servers: %w", err)
 	}
+	authToken, err := r.cipher.Encrypt(session.AuthToken, plexSessionTokenAAD(session.ID))
+	if err != nil {
+		return nil, fmt.Errorf("encrypt plex auth token: %w", err)
+	}
 	row := r.pool.QueryRow(ctx, `
 		INSERT INTO history_import_plex_sessions (
 			id, user_id, pin_id, pin_code, auth_token, servers_json, expires_at
 		) VALUES ($1, $2, $3, $4, $5, $6, $7)
 		RETURNING id, user_id, pin_id, pin_code, auth_token, servers_json, expires_at, consumed_at, created_at, updated_at`,
-		session.ID, session.UserID, session.PinID, session.PinCode, nilIfEmpty(session.AuthToken), serversJSON, session.ExpiresAt,
+		session.ID, session.UserID, session.PinID, session.PinCode, nilIfEmpty(authToken), serversJSON, session.ExpiresAt,
 	)
-	stored, err := scanPlexSession(row)
+	stored, err := r.scanPlexSession(row)
 	if err != nil {
 		return nil, fmt.Errorf("creating plex session: %w", err)
 	}
@@ -222,7 +245,7 @@ func (r *Repository) GetPlexSession(ctx context.Context, userID int, sessionID s
 		SELECT id, user_id, pin_id, pin_code, COALESCE(auth_token, ''), servers_json, expires_at, consumed_at, created_at, updated_at
 		FROM history_import_plex_sessions
 		WHERE id = $1 AND user_id = $2`, sessionID, userID)
-	session, err := scanPlexSession(row)
+	session, err := r.scanPlexSession(row)
 	if errors.Is(err, pgx.ErrNoRows) {
 		return nil, ErrPlexSessionNotFound
 	}
@@ -243,10 +266,14 @@ func (r *Repository) UpdatePlexSessionAuth(ctx context.Context, sessionID, authT
 	if err != nil {
 		return fmt.Errorf("marshaling plex servers: %w", err)
 	}
+	encryptedToken, err := r.cipher.Encrypt(authToken, plexSessionTokenAAD(sessionID))
+	if err != nil {
+		return fmt.Errorf("encrypt plex auth token: %w", err)
+	}
 	result, err := r.pool.Exec(ctx, `
 		UPDATE history_import_plex_sessions
 		SET auth_token = $2, servers_json = $3, updated_at = NOW()
-		WHERE id = $1`, sessionID, authToken, serversJSON)
+		WHERE id = $1`, sessionID, encryptedToken, serversJSON)
 	if err != nil {
 		return fmt.Errorf("updating plex session auth %s: %w", sessionID, err)
 	}
@@ -770,7 +797,7 @@ func scanSources(rows pgx.Rows) ([]Source, error) {
 	return sources, rows.Err()
 }
 
-func scanConnectSession(scanner interface{ Scan(dest ...any) error }) (*ConnectSession, error) {
+func (r *Repository) scanConnectSession(scanner interface{ Scan(dest ...any) error }) (*ConnectSession, error) {
 	var session ConnectSession
 	var serversJSON []byte
 	if err := scanner.Scan(
@@ -779,6 +806,11 @@ func scanConnectSession(scanner interface{ Scan(dest ...any) error }) (*ConnectS
 	); err != nil {
 		return nil, err
 	}
+	token, err := r.cipher.DecryptIfEncrypted(session.ConnectAccessToken, connectSessionTokenAAD(session.ID))
+	if err != nil {
+		return nil, fmt.Errorf("decrypt connect access token: %w", err)
+	}
+	session.ConnectAccessToken = token
 	if len(serversJSON) > 0 {
 		if err := json.Unmarshal(serversJSON, &session.Servers); err != nil {
 			return nil, fmt.Errorf("unmarshaling connect session servers: %w", err)
@@ -921,7 +953,7 @@ func nonNilUnmatchedSamples(values []UnmatchedSample) []UnmatchedSample {
 	return values
 }
 
-func scanPlexSession(scanner interface{ Scan(dest ...any) error }) (*PlexSession, error) {
+func (r *Repository) scanPlexSession(scanner interface{ Scan(dest ...any) error }) (*PlexSession, error) {
 	var session PlexSession
 	var authToken *string
 	var serversJSON []byte
@@ -935,6 +967,11 @@ func scanPlexSession(scanner interface{ Scan(dest ...any) error }) (*PlexSession
 	if authToken != nil {
 		session.AuthToken = *authToken
 	}
+	token, err := r.cipher.DecryptIfEncrypted(session.AuthToken, plexSessionTokenAAD(session.ID))
+	if err != nil {
+		return nil, fmt.Errorf("decrypt plex auth token: %w", err)
+	}
+	session.AuthToken = token
 	if len(serversJSON) > 0 {
 		if err := json.Unmarshal(serversJSON, &session.Servers); err != nil {
 			return nil, fmt.Errorf("unmarshaling plex session servers: %w", err)

--- a/internal/historyimport/repo_admin.go
+++ b/internal/historyimport/repo_admin.go
@@ -21,10 +21,14 @@ var (
 
 // SetSourceAdminToken stores an admin token for the given source.
 func (r *Repository) SetSourceAdminToken(ctx context.Context, sourceID int, token string) error {
+	encryptedToken, err := r.cipher.Encrypt(token, sourceAdminTokenAAD(sourceID))
+	if err != nil {
+		return fmt.Errorf("encrypt admin token for source %d: %w", sourceID, err)
+	}
 	result, err := r.pool.Exec(ctx, `
 		UPDATE history_import_sources
 		SET admin_token = $2, updated_at = NOW()
-		WHERE id = $1`, sourceID, token)
+		WHERE id = $1`, sourceID, encryptedToken)
 	if err != nil {
 		return fmt.Errorf("setting admin token for source %d: %w", sourceID, err)
 	}
@@ -72,6 +76,10 @@ func (r *Repository) GetSourceWithAdminToken(ctx context.Context, sourceID int) 
 	}
 	if err != nil {
 		return nil, "", fmt.Errorf("getting source %d with admin token: %w", sourceID, err)
+	}
+	adminToken, err = r.cipher.DecryptIfEncrypted(adminToken, sourceAdminTokenAAD(sourceID))
+	if err != nil {
+		return nil, "", fmt.Errorf("decrypt admin token for source %d: %w", sourceID, err)
 	}
 	return &s, adminToken, nil
 }

--- a/internal/historyimport/repo_admin.go
+++ b/internal/historyimport/repo_admin.go
@@ -21,7 +21,7 @@ var (
 
 // SetSourceAdminToken stores an admin token for the given source.
 func (r *Repository) SetSourceAdminToken(ctx context.Context, sourceID int, token string) error {
-	encryptedToken, err := r.cipher.Encrypt(token, sourceAdminTokenAAD(sourceID))
+	encryptedToken, err := r.encryptSourceAdminToken(sourceID, token)
 	if err != nil {
 		return fmt.Errorf("encrypt admin token for source %d: %w", sourceID, err)
 	}

--- a/internal/historyimport/repo_test.go
+++ b/internal/historyimport/repo_test.go
@@ -1,6 +1,7 @@
 package historyimport
 
 import (
+	"bytes"
 	"crypto/rand"
 	"encoding/json"
 	"fmt"
@@ -25,8 +26,9 @@ func newTestRepo(t *testing.T) *Repository {
 }
 
 type plexSessionScannerStub struct {
-	authToken *string
-	servers   []PlexServer
+	authToken  *string
+	servers    []PlexServer
+	serversRaw []byte
 }
 
 func (s plexSessionScannerStub) Scan(dest ...any) error {
@@ -69,9 +71,13 @@ func (s plexSessionScannerStub) Scan(dest ...any) error {
 		return fmt.Errorf("dest[4] type = %T, want *string or **string", dest[4])
 	}
 
-	serversJSON, err := json.Marshal(s.servers)
-	if err != nil {
-		return err
+	serversJSON := s.serversRaw
+	if serversJSON == nil {
+		var err error
+		serversJSON, err = json.Marshal(s.servers)
+		if err != nil {
+			return err
+		}
 	}
 	serversDest, ok := dest[5].(*[]byte)
 	if !ok {
@@ -134,5 +140,170 @@ func TestScanPlexSession_AllowsNullAuthToken(t *testing.T) {
 	}
 	if session.Servers[0].ClientIdentifier != "server-1" {
 		t.Fatalf("session.Servers[0].ClientIdentifier = %q, want server-1", session.Servers[0].ClientIdentifier)
+	}
+	if session.Servers[0].AccessToken != "server-token" {
+		t.Fatalf("session.Servers[0].AccessToken = %q, want server-token", session.Servers[0].AccessToken)
+	}
+}
+
+type connectSessionScannerStub struct {
+	accessToken string
+	servers     []ConnectServer
+	serversRaw  []byte
+}
+
+func (s connectSessionScannerStub) Scan(dest ...any) error {
+	if len(dest) != 9 {
+		return fmt.Errorf("unexpected scan dest count: %d", len(dest))
+	}
+
+	id, ok := dest[0].(*string)
+	if !ok {
+		return fmt.Errorf("dest[0] type = %T, want *string", dest[0])
+	}
+	*id = "connect-session-1"
+
+	userID, ok := dest[1].(*int)
+	if !ok {
+		return fmt.Errorf("dest[1] type = %T, want *int", dest[1])
+	}
+	*userID = 42
+
+	connectUserID, ok := dest[2].(*string)
+	if !ok {
+		return fmt.Errorf("dest[2] type = %T, want *string", dest[2])
+	}
+	*connectUserID = "connect-user-1"
+
+	accessToken, ok := dest[3].(*string)
+	if !ok {
+		return fmt.Errorf("dest[3] type = %T, want *string", dest[3])
+	}
+	*accessToken = s.accessToken
+
+	serversJSON := s.serversRaw
+	if serversJSON == nil {
+		var err error
+		serversJSON, err = json.Marshal(s.servers)
+		if err != nil {
+			return err
+		}
+	}
+	serversDest, ok := dest[4].(*[]byte)
+	if !ok {
+		return fmt.Errorf("dest[4] type = %T, want *[]byte", dest[4])
+	}
+	*serversDest = serversJSON
+
+	expiresAt, ok := dest[5].(*time.Time)
+	if !ok {
+		return fmt.Errorf("dest[5] type = %T, want *time.Time", dest[5])
+	}
+	*expiresAt = time.Date(2026, time.April, 1, 13, 0, 0, 0, time.UTC)
+
+	consumedAt, ok := dest[6].(**time.Time)
+	if !ok {
+		return fmt.Errorf("dest[6] type = %T, want **time.Time", dest[6])
+	}
+	*consumedAt = nil
+
+	createdAt, ok := dest[7].(*time.Time)
+	if !ok {
+		return fmt.Errorf("dest[7] type = %T, want *time.Time", dest[7])
+	}
+	*createdAt = time.Date(2026, time.April, 1, 12, 0, 0, 0, time.UTC)
+
+	updatedAt, ok := dest[8].(*time.Time)
+	if !ok {
+		return fmt.Errorf("dest[8] type = %T, want *time.Time", dest[8])
+	}
+	*updatedAt = time.Date(2026, time.April, 1, 12, 30, 0, 0, time.UTC)
+
+	return nil
+}
+
+func TestConnectSessionServersEncryptedAtRestAndDecryptedOnRead(t *testing.T) {
+	t.Parallel()
+
+	repo := newTestRepo(t)
+	servers := []ConnectServer{{
+		ID:           "emby-server-1",
+		Name:         "Emby Server",
+		AccessKey:    "server-access-key",
+		URL:          "https://emby.example",
+		HasRemoteURL: true,
+	}}
+	raw, err := repo.marshalConnectServersForWrite("connect-session-1", servers)
+	if err != nil {
+		t.Fatalf("marshalConnectServersForWrite: %v", err)
+	}
+	if bytes.Contains(raw, []byte("server-access-key")) {
+		t.Fatalf("stored connect servers JSON leaked access key: %s", raw)
+	}
+
+	session, err := repo.scanConnectSession(connectSessionScannerStub{
+		accessToken: "connect-token",
+		serversRaw:  raw,
+	})
+	if err != nil {
+		t.Fatalf("scanConnectSession: %v", err)
+	}
+	if got := session.Servers[0].AccessKey; got != "server-access-key" {
+		t.Fatalf("session.Servers[0].AccessKey = %q, want server-access-key", got)
+	}
+}
+
+func TestPlexSessionServersEncryptedAtRestAndDecryptedOnRead(t *testing.T) {
+	t.Parallel()
+
+	repo := newTestRepo(t)
+	servers := []PlexServer{{
+		Name:             "Plex Server",
+		ClientIdentifier: "server-1",
+		AccessToken:      "server-token",
+		RemoteURL:        "https://plex.example",
+		Owned:            true,
+		HasRemoteURL:     true,
+	}}
+	raw, err := repo.marshalPlexServersForWrite("plex-session-1", servers)
+	if err != nil {
+		t.Fatalf("marshalPlexServersForWrite: %v", err)
+	}
+	if bytes.Contains(raw, []byte("server-token")) {
+		t.Fatalf("stored plex servers JSON leaked access token: %s", raw)
+	}
+
+	session, err := repo.scanPlexSession(plexSessionScannerStub{
+		authToken:  nil,
+		serversRaw: raw,
+	})
+	if err != nil {
+		t.Fatalf("scanPlexSession: %v", err)
+	}
+	if got := session.Servers[0].AccessToken; got != "server-token" {
+		t.Fatalf("session.Servers[0].AccessToken = %q, want server-token", got)
+	}
+}
+
+func TestSourceAdminTokenEncryptionUsesSourceAAD(t *testing.T) {
+	t.Parallel()
+
+	repo := newTestRepo(t)
+	ciphertext, err := repo.encryptSourceAdminToken(42, "admin-token")
+	if err != nil {
+		t.Fatalf("encryptSourceAdminToken: %v", err)
+	}
+	if ciphertext == "admin-token" || bytes.Contains([]byte(ciphertext), []byte("admin-token")) {
+		t.Fatalf("encrypted admin token leaked plaintext: %q", ciphertext)
+	}
+	plaintext, err := repo.cipher.Decrypt(ciphertext, sourceAdminTokenAAD(42))
+	if err != nil {
+		t.Fatalf("decrypt with matching source AAD: %v", err)
+	}
+	if plaintext != "admin-token" {
+		t.Fatalf("decrypted admin token = %q, want admin-token", plaintext)
+	}
+	if _, err := repo.cipher.Decrypt(ciphertext, sourceAdminTokenAAD(43)); err == nil {
+		t.Fatalf("decrypt with different source AAD succeeded, want authentication failure")
 	}
 }

--- a/internal/historyimport/repo_test.go
+++ b/internal/historyimport/repo_test.go
@@ -1,11 +1,28 @@
 package historyimport
 
 import (
+	"crypto/rand"
 	"encoding/json"
 	"fmt"
 	"testing"
 	"time"
+
+	"github.com/Silo-Server/silo-server/internal/secret"
 )
+
+// newTestRepo builds a Repository with a real cipher for scan-method tests.
+func newTestRepo(t *testing.T) *Repository {
+	t.Helper()
+	key := make([]byte, 48)
+	if _, err := rand.Read(key); err != nil {
+		t.Fatalf("rand: %v", err)
+	}
+	c, err := secret.New(key)
+	if err != nil {
+		t.Fatalf("secret.New: %v", err)
+	}
+	return &Repository{cipher: c}
+}
 
 type plexSessionScannerStub struct {
 	authToken *string
@@ -92,7 +109,7 @@ func (s plexSessionScannerStub) Scan(dest ...any) error {
 func TestScanPlexSession_AllowsNullAuthToken(t *testing.T) {
 	t.Parallel()
 
-	session, err := scanPlexSession(plexSessionScannerStub{
+	session, err := newTestRepo(t).scanPlexSession(plexSessionScannerStub{
 		authToken: nil,
 		servers: []PlexServer{{
 			Name:             "Plex Server",

--- a/internal/jellycompat/router.go
+++ b/internal/jellycompat/router.go
@@ -70,7 +70,7 @@ func NewRouter(deps Dependencies) chi.Router {
 	if deps.SubtitleRepo != nil {
 		subtitleRepo = deps.SubtitleRepo
 	} else if deps.DB != nil {
-		subtitleRepo = subtitles.NewPgRepository(deps.DB)
+		subtitleRepo = subtitles.NewPgRepository(deps.DB, deps.SecretCipher)
 	}
 	itemsHandler := NewItemsHandler(deps.ContentService, deps.UserDataService, deps.IDCodec, deps.Config, deps.ImageCache, nextUpRepo, deps.BrowseRepo, deps.PersonRepo, deps.DetailSvc, deps.ItemRepo, deps.EpisodeRepo, deps.AccessFilterFn, subtitleRepo)
 	itemsHandler.recommender = deps.Recommender
@@ -241,7 +241,7 @@ func withDefaults(deps Dependencies) Dependencies {
 			deps.SessionStore = NewPersistentSessionStore(
 				deps.Config.JellyfinCompat.SessionTTL,
 				deps.Now,
-				NewSessionRepository(deps.DB),
+				NewSessionRepository(deps.DB, deps.SecretCipher),
 			)
 		} else {
 			deps.SessionStore = NewSessionStore(deps.Config.JellyfinCompat.SessionTTL, deps.Now)

--- a/internal/jellycompat/server.go
+++ b/internal/jellycompat/server.go
@@ -16,6 +16,7 @@ import (
 	"github.com/Silo-Server/silo-server/internal/nodepool"
 	"github.com/Silo-Server/silo-server/internal/recommendations"
 	"github.com/Silo-Server/silo-server/internal/scantrigger"
+	"github.com/Silo-Server/silo-server/internal/secret"
 	"github.com/Silo-Server/silo-server/internal/subtitles"
 	"github.com/Silo-Server/silo-server/internal/userstore"
 )
@@ -24,6 +25,7 @@ import (
 type Dependencies struct {
 	Config           *config.Config
 	DB               *pgxpool.Pool
+	SecretCipher     *secret.Cipher // at-rest credential cipher (required when DB is set)
 	ClientIPResolver *clientip.Resolver
 	HTTPClient       *http.Client
 	Now              func() time.Time
@@ -132,7 +134,7 @@ func (s *Server) SessionStore() *SessionStore {
 // Call this once after constructing the server; goroutines stop when ctx is cancelled.
 func (s *Server) StartBackgroundTasks(ctx context.Context) {
 	if s.deps.DB != nil {
-		repo := NewSessionRepository(s.deps.DB)
+		repo := NewSessionRepository(s.deps.DB, s.deps.SecretCipher)
 		StartSessionCleanup(ctx, repo, 1*time.Hour)
 	}
 }

--- a/internal/jellycompat/session_repository.go
+++ b/internal/jellycompat/session_repository.go
@@ -9,21 +9,32 @@ import (
 	"github.com/google/uuid"
 	"github.com/jackc/pgx/v5"
 	"github.com/jackc/pgx/v5/pgxpool"
+
+	"github.com/Silo-Server/silo-server/internal/secret"
 )
 
 const jellycompatSessionColumns = `token, username, account_username, profile_id, profile_name, pseudo_user_id, streamapp_user_id, streamapp_access_token, streamapp_refresh_token, streamapp_token_expiry, created_at, expires_at`
 
 // SessionRepository persists compat sessions in PostgreSQL.
 type SessionRepository struct {
-	pool *pgxpool.Pool
+	pool   *pgxpool.Pool
+	cipher *secret.Cipher
 }
 
 // NewSessionRepository creates a new compat session repository.
-func NewSessionRepository(pool *pgxpool.Pool) *SessionRepository {
-	return &SessionRepository{pool: pool}
+func NewSessionRepository(pool *pgxpool.Pool, cipher *secret.Cipher) *SessionRepository {
+	return &SessionRepository{pool: pool, cipher: cipher}
 }
 
-func scanCompatSession(row pgx.Row) (*Session, error) {
+// jellycompatTokenAAD binds a streamapp_* token ciphertext to its session row,
+// keyed by the session token (the table's primary key). The session token
+// itself is not encrypted (it is matched by value on lookup), so it is a stable,
+// known identifier on both the read and write paths.
+func jellycompatTokenAAD(column, token string) string {
+	return secret.RowAAD("jellycompat_sessions", column, token)
+}
+
+func (r *SessionRepository) scanCompatSession(row pgx.Row) (*Session, error) {
 	var session Session
 	err := row.Scan(
 		&session.Token,
@@ -45,6 +56,13 @@ func scanCompatSession(row pgx.Row) (*Session, error) {
 		}
 		return nil, fmt.Errorf("scan compat session: %w", err)
 	}
+	// Decrypt the bridged Silo access/refresh tokens (read-path contract).
+	if session.StreamAppAccessToken, err = r.cipher.DecryptIfEncrypted(session.StreamAppAccessToken, jellycompatTokenAAD("streamapp_access_token", session.Token)); err != nil {
+		return nil, fmt.Errorf("decrypt streamapp access token: %w", err)
+	}
+	if session.StreamAppRefreshToken, err = r.cipher.DecryptIfEncrypted(session.StreamAppRefreshToken, jellycompatTokenAAD("streamapp_refresh_token", session.Token)); err != nil {
+		return nil, fmt.Errorf("decrypt streamapp refresh token: %w", err)
+	}
 	return &session, nil
 }
 
@@ -54,7 +72,16 @@ func (r *SessionRepository) Upsert(ctx context.Context, session Session) error {
 		session.Token = uuid.NewString()
 	}
 
-	_, err := r.pool.Exec(ctx, `
+	accessToken, err := r.cipher.Encrypt(session.StreamAppAccessToken, jellycompatTokenAAD("streamapp_access_token", session.Token))
+	if err != nil {
+		return fmt.Errorf("encrypt streamapp access token: %w", err)
+	}
+	refreshToken, err := r.cipher.Encrypt(session.StreamAppRefreshToken, jellycompatTokenAAD("streamapp_refresh_token", session.Token))
+	if err != nil {
+		return fmt.Errorf("encrypt streamapp refresh token: %w", err)
+	}
+
+	_, err = r.pool.Exec(ctx, `
 		INSERT INTO jellycompat_sessions (
 			token, username, account_username, profile_id, profile_name, pseudo_user_id,
 			streamapp_user_id, streamapp_access_token, streamapp_refresh_token,
@@ -84,8 +111,8 @@ func (r *SessionRepository) Upsert(ctx context.Context, session Session) error {
 		session.ProfileName,
 		session.PseudoUserID,
 		session.StreamAppUserID,
-		session.StreamAppAccessToken,
-		session.StreamAppRefreshToken,
+		accessToken,
+		refreshToken,
 		session.StreamAppTokenExpiry,
 		session.CreatedAt,
 		session.ExpiresAt,
@@ -98,7 +125,7 @@ func (r *SessionRepository) Upsert(ctx context.Context, session Session) error {
 
 // GetByToken loads an active compat session by token.
 func (r *SessionRepository) GetByToken(ctx context.Context, token string, now time.Time) (*Session, error) {
-	return scanCompatSession(r.pool.QueryRow(ctx,
+	return r.scanCompatSession(r.pool.QueryRow(ctx,
 		`SELECT `+jellycompatSessionColumns+`
 		FROM jellycompat_sessions
 		WHERE token = $1 AND expires_at > $2`,

--- a/internal/nodeconfig/watcher.go
+++ b/internal/nodeconfig/watcher.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/Silo-Server/silo-server/internal/cache"
 	"github.com/Silo-Server/silo-server/internal/config"
+	"github.com/Silo-Server/silo-server/internal/secret"
 )
 
 // BootstrapOverrides holds values from env/CLI that must survive config
@@ -29,16 +30,21 @@ type Watcher struct {
 	mu        sync.RWMutex
 	cfg       *config.Config
 	pool      *pgxpool.Pool
+	cipher    *secret.Cipher
 	eventBus  cache.EventBus
 	bootstrap BootstrapOverrides
 	onChange  []func(old, updated *config.Config)
 	reloadCh  chan struct{} // buffered(1), event bus writes here
 }
 
-// NewWatcher creates a new config watcher. Call Start to begin watching.
-func NewWatcher(pool *pgxpool.Pool, eventBus cache.EventBus, bootstrap BootstrapOverrides) *Watcher {
+// NewWatcher creates a new config watcher. Call Start to begin watching. The
+// cipher decrypts sensitive server_settings values (read here via raw SQL)
+// before they reach config.LoadFromDB, so a hot reload never feeds ciphertext
+// into the live config (which would, e.g., break JWT validation).
+func NewWatcher(pool *pgxpool.Pool, cipher *secret.Cipher, eventBus cache.EventBus, bootstrap BootstrapOverrides) *Watcher {
 	return &Watcher{
 		pool:      pool,
+		cipher:    cipher,
 		eventBus:  eventBus,
 		bootstrap: bootstrap,
 		reloadCh:  make(chan struct{}, 1),
@@ -114,7 +120,14 @@ func (w *Watcher) reload(ctx context.Context) error {
 		if err := rows.Scan(&k, &v); err != nil {
 			return fmt.Errorf("scan server_settings row: %w", err)
 		}
-		m[k] = v
+		// Decrypt sensitive keys (read-path contract: legacy plaintext passes
+		// through, enc:v1: values decrypt, corrupt ciphertext errors) so
+		// LoadFromDB always sees plaintext.
+		decrypted, derr := w.cipher.DecryptIfEncrypted(v, secret.SettingsAAD(k))
+		if derr != nil {
+			return fmt.Errorf("decrypt server_settings %q: %w", k, derr)
+		}
+		m[k] = decrypted
 	}
 	if err := rows.Err(); err != nil {
 		return fmt.Errorf("iterate server_settings: %w", err)

--- a/internal/requests/repository.go
+++ b/internal/requests/repository.go
@@ -13,14 +13,33 @@ import (
 	"github.com/jackc/pgx/v5"
 	"github.com/jackc/pgx/v5/pgconn"
 	"github.com/jackc/pgx/v5/pgxpool"
+
+	"github.com/Silo-Server/silo-server/internal/secret"
 )
 
 type Repository struct {
-	pool *pgxpool.Pool
+	pool   *pgxpool.Pool
+	cipher *secret.Cipher
 }
 
-func NewRepository(pool *pgxpool.Pool) *Repository {
-	return &Repository{pool: pool}
+func NewRepository(pool *pgxpool.Pool, cipher *secret.Cipher) *Repository {
+	return &Repository{pool: pool, cipher: cipher}
+}
+
+// apiKeyAAD binds a request_integrations api_key_ref ciphertext to its row.
+func apiKeyAAD(id string) string {
+	return secret.RowAAD("request_integrations", "api_key_ref", id)
+}
+
+// encryptAPIKey encrypts a non-empty, trimmed API key bound to the integration
+// id. An empty key returns "" so the update path's keep-existing CASE sentinel
+// still fires (and an absent key stays absent).
+func (r *Repository) encryptAPIKey(id, apiKey string) (string, error) {
+	apiKey = strings.TrimSpace(apiKey)
+	if apiKey == "" {
+		return "", nil
+	}
+	return r.cipher.Encrypt(apiKey, apiKeyAAD(id))
 }
 
 func (r *Repository) GetSettings(ctx context.Context) (Settings, error) {
@@ -466,7 +485,7 @@ func (r *Repository) ListIntegrations(ctx context.Context) ([]Integration, error
 
 	var out []Integration
 	for rows.Next() {
-		integration, err := scanIntegration(rows)
+		integration, err := r.scanIntegration(rows)
 		if err != nil {
 			return nil, err
 		}
@@ -481,7 +500,7 @@ func (r *Repository) ListIntegrations(ctx context.Context) ([]Integration, error
 func (r *Repository) GetIntegration(ctx context.Context, id string) (*Integration, error) {
 	row := r.pool.QueryRow(ctx, `SELECT `+integrationColumns+
 		` FROM request_integrations WHERE id = $1`, id)
-	i, err := scanIntegration(row)
+	i, err := r.scanIntegration(row)
 	if err != nil {
 		if errors.Is(err, pgx.ErrNoRows) {
 			return nil, ErrNotFound
@@ -510,6 +529,10 @@ func (r *Repository) insertIntegration(ctx context.Context, exec requestExecutor
 	if err != nil {
 		return nil, fmt.Errorf("marshal options: %w", err)
 	}
+	apiKeyRef, err := r.encryptAPIKey(i.ID, i.APIKeyRef)
+	if err != nil {
+		return nil, fmt.Errorf("encrypt api key: %w", err)
+	}
 	row := exec.QueryRow(ctx, `
 		INSERT INTO request_integrations (
 			id, kind, name, enabled, base_url, api_key_ref, root_folder,
@@ -519,11 +542,11 @@ func (r *Repository) insertIntegration(ctx context.Context, exec requestExecutor
 		VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12,$13,$14,$15,$16,$17, now())
 		RETURNING `+integrationColumns,
 		i.ID, i.Kind, strings.TrimSpace(i.Name), i.Enabled, strings.TrimSpace(i.BaseURL),
-		strings.TrimSpace(i.APIKeyRef), strings.TrimSpace(i.RootFolder), i.QualityProfileID,
+		apiKeyRef, strings.TrimSpace(i.RootFolder), i.QualityProfileID,
 		int32Slice(i.Tags), i.Is4K, i.IsDefault, i.IsDefault4K, i.AnimeEnabled,
 		i.AnimeQualityProfileID, strings.TrimSpace(i.AnimeRootFolder), int32Slice(i.AnimeTags),
 		options)
-	out, err := scanIntegration(row)
+	out, err := r.scanIntegration(row)
 	if err != nil {
 		return nil, fmt.Errorf("create request integration: %w", err)
 	}
@@ -540,6 +563,12 @@ func (r *Repository) updateIntegration(ctx context.Context, exec requestExecutor
 	if err != nil {
 		return nil, fmt.Errorf("marshal options: %w", err)
 	}
+	// Encrypt the incoming key; an empty result preserves the keep-existing CASE
+	// (a blank edit leaves the stored key untouched).
+	apiKeyRef, err := r.encryptAPIKey(i.ID, i.APIKeyRef)
+	if err != nil {
+		return nil, fmt.Errorf("encrypt api key: %w", err)
+	}
 	row := exec.QueryRow(ctx, `
 		UPDATE request_integrations SET
 			name=$2, enabled=$3, base_url=$4,
@@ -551,11 +580,11 @@ func (r *Repository) updateIntegration(ctx context.Context, exec requestExecutor
 		WHERE id=$1
 		RETURNING `+integrationColumns,
 		i.ID, strings.TrimSpace(i.Name), i.Enabled, strings.TrimSpace(i.BaseURL),
-		strings.TrimSpace(i.APIKeyRef), strings.TrimSpace(i.RootFolder), i.QualityProfileID,
+		apiKeyRef, strings.TrimSpace(i.RootFolder), i.QualityProfileID,
 		int32Slice(i.Tags), i.Is4K, i.IsDefault, i.IsDefault4K, i.AnimeEnabled,
 		i.AnimeQualityProfileID, strings.TrimSpace(i.AnimeRootFolder), int32Slice(i.AnimeTags),
 		options)
-	out, err := scanIntegration(row)
+	out, err := r.scanIntegration(row)
 	if err != nil {
 		if errors.Is(err, pgx.ErrNoRows) {
 			return nil, ErrNotFound
@@ -763,7 +792,7 @@ type integrationScanner interface {
 	Scan(dest ...any) error
 }
 
-func scanIntegration(row integrationScanner) (Integration, error) {
+func (r *Repository) scanIntegration(row integrationScanner) (Integration, error) {
 	var i Integration
 	var quality, animeQuality sql.NullInt64
 	var tags, animeTags []int32
@@ -777,6 +806,14 @@ func scanIntegration(row integrationScanner) (Integration, error) {
 	); err != nil {
 		return Integration{}, err
 	}
+	// Decrypt the stored api key (read-path contract: legacy plaintext passes
+	// through, enc:v1: values decrypt, corrupt ciphertext errors). Callers
+	// receive the literal key — there is no longer a ref/literal ambiguity.
+	apiKey, err := r.cipher.DecryptIfEncrypted(i.APIKeyRef, apiKeyAAD(i.ID))
+	if err != nil {
+		return Integration{}, fmt.Errorf("decrypt request integration %s api key: %w", i.ID, err)
+	}
+	i.APIKeyRef = apiKey
 	if quality.Valid {
 		v := int(quality.Int64)
 		i.QualityProfileID = &v

--- a/internal/requests/service.go
+++ b/internal/requests/service.go
@@ -27,10 +27,6 @@ type TMDBExternalIDClient interface {
 
 const externalIDHydrationConcurrency = 4
 
-type SecretResolver interface {
-	Get(ctx context.Context, key string) (string, error)
-}
-
 type MovieFulfillmentAdapter interface {
 	SubmitMovie(ctx context.Context, req Request, integration Integration) (FulfillmentResult, error)
 }
@@ -66,7 +62,6 @@ type Service struct {
 	store         Store
 	tmdb          TMDBClient
 	presence      PresenceResolver
-	secrets       SecretResolver
 	movieAdapter  MovieFulfillmentAdapter
 	seriesAdapter SeriesFulfillmentAdapter
 	entitlements  EntitlementResolver
@@ -89,10 +84,6 @@ func NewService(store Store, tmdbClient TMDBClient, presence PresenceResolver) *
 		presence: presence,
 		Now:      func() time.Time { return time.Now().UTC() },
 	}
-}
-
-func (s *Service) SetSecretResolver(resolver SecretResolver) {
-	s.secrets = resolver
 }
 
 func (s *Service) SetFulfillmentAdapters(movie MovieFulfillmentAdapter, series SeriesFulfillmentAdapter) {
@@ -858,12 +849,9 @@ func (s *Service) LoadIntegrationOptions(ctx context.Context, viewer Viewer, int
 	if strings.TrimSpace(normalized.APIKeyRef) == "" {
 		return nil, fmt.Errorf("%w: api_key_ref is required", ErrInvalidInput)
 	}
+	// APIKeyRef is already the literal key: a saved instance was decrypted by
+	// GetIntegration above; a new instance carries the key the admin just typed.
 	resolved := normalized
-	apiKey, err := s.resolveAPIKey(ctx, resolved)
-	if err != nil {
-		return nil, err
-	}
-	resolved.APIKeyRef = apiKey
 
 	switch resolved.Kind {
 	case "radarr":
@@ -1200,15 +1188,10 @@ func (s *Service) submitApprovedRequest(ctx context.Context, req Request, actor 
 // the request aggregate). Returns the latest request snapshot.
 func (s *Service) submitPlannedTarget(ctx context.Context, req Request, pt plannedTarget, actor Viewer) (*Request, error) {
 	resolved := resolveInstance(pt)
-	apiKey, err := s.resolveAPIKey(ctx, resolved)
-	if err != nil || apiKey == "" {
-		msg := "missing api key"
-		if err != nil {
-			msg = err.Error()
-		}
-		return s.createFailedTarget(ctx, req, pt, resolved, msg, actor)
+	// The repo already decrypted the stored key; a blank one means unconfigured.
+	if strings.TrimSpace(resolved.APIKeyRef) == "" {
+		return s.createFailedTarget(ctx, req, pt, resolved, "missing api key", actor)
 	}
-	resolved.APIKeyRef = apiKey
 
 	target, err := s.store.CreateTarget(ctx, Target{
 		RequestID: req.ID, IntegrationID: resolved.ID, IntegrationKind: resolved.Kind,
@@ -1338,11 +1321,10 @@ func (s *Service) reconcileRequest(ctx context.Context, req Request) (reconcileC
 		if !ok {
 			continue
 		}
-		apiKey, err := s.resolveAPIKey(ctx, in)
-		if err != nil || apiKey == "" {
+		// in.APIKeyRef was decrypted by ListIntegrations; skip if unconfigured.
+		if strings.TrimSpace(in.APIKeyRef) == "" {
 			continue
 		}
-		in.APIKeyRef = apiKey
 		probe := req
 		probe.ExternalID = t.ExternalID
 		st, err := s.checkFulfillmentStatus(ctx, probe, in)
@@ -1429,22 +1411,6 @@ func (s *Service) checkFulfillmentStatus(ctx context.Context, req Request, resol
 	default:
 		return FulfillmentStatus{}, nil
 	}
-}
-
-func (s *Service) resolveAPIKey(ctx context.Context, integration Integration) (string, error) {
-	value := strings.TrimSpace(integration.APIKeyRef)
-	if value == "" || s.secrets == nil {
-		return value, nil
-	}
-	resolved, err := s.secrets.Get(ctx, value)
-	if err != nil {
-		return "", err
-	}
-	resolved = strings.TrimSpace(resolved)
-	if resolved == "" {
-		return value, nil
-	}
-	return resolved, nil
 }
 
 func integrationIsConfigured(integration Integration) bool {

--- a/internal/requests/service_test.go
+++ b/internal/requests/service_test.go
@@ -177,7 +177,6 @@ func TestCreateRequestAutoApprovesWithConfiguredIntegration(t *testing.T) {
 		ExternalStatus:  "queued",
 	}}
 	service := newTestService(store)
-	service.SetSecretResolver(fakeSecrets{"request.radarr.api_key": "radarr-key"})
 	service.SetFulfillmentAdapters(adapter, nil)
 
 	req, err := service.CreateRequest(context.Background(), testViewer(1), CreateRequestInput{
@@ -195,39 +194,6 @@ func TestCreateRequestAutoApprovesWithConfiguredIntegration(t *testing.T) {
 	}
 }
 
-func TestCreateRequestAutoApprovalSecretFailureMarksTargetFailed(t *testing.T) {
-	store := newFakeStore()
-	store.settings.RequestsEnabled = true
-	store.settings.GlobalAutoApprovalEnabled = true
-	qualityProfileID := 1
-	store.integrations = []Integration{{
-		Kind:             "radarr",
-		Enabled:          true,
-		IsDefault:        true,
-		BaseURL:          "http://radarr.local",
-		APIKeyRef:        "requests.radarr.api_key",
-		RootFolder:       "/movies",
-		QualityProfileID: &qualityProfileID,
-	}}
-	service := newTestService(store)
-	service.SetSecretResolver(fakeSecretError{err: errors.New("secret lookup unavailable")})
-	service.SetFulfillmentAdapters(&fakeMovieAdapter{}, nil)
-
-	req, err := service.CreateRequest(context.Background(), testViewer(1), CreateRequestInput{
-		MediaType: MediaTypeMovie,
-		TMDBID:    550,
-		Title:     "Fight Club",
-	})
-	if err != nil {
-		t.Fatalf("CreateRequest returned error: %v", err)
-	}
-	// The auto-approval gate no longer resolves secrets; submission does. A
-	// secret-resolution failure now surfaces as a failed fulfillment target.
-	if req.Outcome != OutcomeFailed {
-		t.Fatalf("outcome = %q, want failed (secret resolution failed during submit)", req.Outcome)
-	}
-}
-
 func TestCreateRequestAutoApprovalSubmitsMovie(t *testing.T) {
 	store := newFakeStore()
 	store.settings.RequestsEnabled = true
@@ -238,7 +204,7 @@ func TestCreateRequestAutoApprovalSubmitsMovie(t *testing.T) {
 		Enabled:          true,
 		IsDefault:        true,
 		BaseURL:          "http://radarr.local",
-		APIKeyRef:        "requests.radarr.api_key",
+		APIKeyRef:        "radarr-key",
 		RootFolder:       "/movies",
 		QualityProfileID: &qualityProfileID,
 	}}
@@ -248,7 +214,6 @@ func TestCreateRequestAutoApprovalSubmitsMovie(t *testing.T) {
 		ExternalStatus:  "queued",
 	}}
 	service := newTestService(store)
-	service.SetSecretResolver(fakeSecrets{"requests.radarr.api_key": "radarr-key"})
 	service.SetFulfillmentAdapters(adapter, nil)
 
 	req, err := service.CreateRequest(context.Background(), testViewer(1), CreateRequestInput{
@@ -265,8 +230,10 @@ func TestCreateRequestAutoApprovalSubmitsMovie(t *testing.T) {
 	if adapter.calls != 1 {
 		t.Fatalf("adapter calls = %d, want 1", adapter.calls)
 	}
+	// The repo decrypts api_key_ref on read, so the adapter receives the literal
+	// key verbatim — no resolver indirection.
 	if got := adapter.gotIntegration.APIKeyRef; got != "radarr-key" {
-		t.Fatalf("adapter api key = %q, want resolved key", got)
+		t.Fatalf("adapter api key = %q, want radarr-key", got)
 	}
 }
 
@@ -1771,18 +1738,4 @@ func TestSubmitApprovedFansOutDualQuality(t *testing.T) {
 	if len(rec.ids) != 2 {
 		t.Fatalf("expected 2 submissions (hd+uhd), got %d: %v", len(rec.ids), rec.ids)
 	}
-}
-
-type fakeSecrets map[string]string
-
-func (f fakeSecrets) Get(_ context.Context, key string) (string, error) {
-	return f[key], nil
-}
-
-type fakeSecretError struct {
-	err error
-}
-
-func (f fakeSecretError) Get(context.Context, string) (string, error) {
-	return "", f.err
 }

--- a/internal/secret/backfill.go
+++ b/internal/secret/backfill.go
@@ -1,0 +1,247 @@
+package secret
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgconn"
+)
+
+// Executor is the minimal database surface the backfill needs; *pgxpool.Pool
+// satisfies it.
+type Executor interface {
+	Query(ctx context.Context, sql string, args ...any) (pgx.Rows, error)
+	Exec(ctx context.Context, sql string, args ...any) (pgconn.CommandTag, error)
+}
+
+// BackfillTarget describes one literal-credential column to sweep from plaintext
+// to ciphertext in place. All field values are compile-time constants (table,
+// column, and SQL key expressions), never user input, so interpolating them into
+// the statements is safe.
+type BackfillTarget struct {
+	// Table is the owning table, e.g. "subtitle_provider_config".
+	Table string
+	// Column is the secret column, e.g. "api_key".
+	Column string
+	// KeyExpr is the SQL expression selecting the row's stable update key, used
+	// in the UPDATE ... WHERE. Defaults to "id" when empty. It is rendered to
+	// text for comparison, e.g. "id::text" or "provider_name".
+	KeyExpr string
+	// AADExpr is the SQL expression producing the AAD pk part. Empty means use
+	// KeyExpr. For tables whose token AAD binds to a business key rather than the
+	// surrogate id (watch_provider_connections), this differs from KeyExpr.
+	AADExpr string
+}
+
+func (t BackfillTarget) keyExpr() string {
+	if t.KeyExpr == "" {
+		return "id"
+	}
+	return t.KeyExpr
+}
+
+func (t BackfillTarget) aadExpr() string {
+	if t.AADExpr == "" {
+		return t.keyExpr()
+	}
+	return t.AADExpr
+}
+
+// ColumnBackfillTargets is the set of literal-credential columns the startup
+// backfill encrypts in place. The two arr api_key_ref columns are NOT here: they
+// may hold a legacy server_settings reference rather than a literal key and need
+// the separate resolve-then-encrypt path. The AAD expressions must match the
+// repos' read-path AAD (secret.RowAAD with the same id string) exactly, or reads
+// would fail to decrypt.
+func ColumnBackfillTargets() []BackfillTarget {
+	const watchTupleAAD = "provider || ':' || user_id::text || ':' || profile_id"
+	return []BackfillTarget{
+		// Subtitles — AAD keyed by provider_name.
+		{Table: "subtitle_provider_config", Column: "api_key", KeyExpr: "provider_name"},
+		{Table: "subtitle_provider_config", Column: "password", KeyExpr: "provider_name"},
+		// Watch-sync — AAD keyed by the (provider, user_id, profile_id) tuple to
+		// match watchsync.TokenAAD (the id is DB-assigned on upsert).
+		{Table: "watch_provider_connections", Column: "access_token", KeyExpr: "id::text", AADExpr: watchTupleAAD},
+		{Table: "watch_provider_connections", Column: "refresh_token", KeyExpr: "id::text", AADExpr: watchTupleAAD},
+		// Webhook-sync — only access_token (webhook_secret is equality-looked-up).
+		{Table: "webhook_sync_connections", Column: "access_token", KeyExpr: "id::text"},
+		// History import — admin token + session tokens, keyed by row id.
+		{Table: "history_import_sources", Column: "admin_token", KeyExpr: "id::text"},
+		{Table: "history_import_connect_sessions", Column: "connect_access_token", KeyExpr: "id::text"},
+		{Table: "history_import_plex_sessions", Column: "auth_token", KeyExpr: "id::text"},
+		// Jellyfin-compat sessions — bridged Silo access/refresh tokens, keyed by
+		// the session token (the table's primary key; itself left in plaintext).
+		{Table: "jellycompat_sessions", Column: "streamapp_access_token", KeyExpr: "token"},
+		{Table: "jellycompat_sessions", Column: "streamapp_refresh_token", KeyExpr: "token"},
+	}
+}
+
+// BackfillColumns encrypts every plaintext value across the given targets in
+// place. It is idempotent (rows already carrying an enc:v1: envelope are skipped
+// by the SELECT filter, and the UPDATE's "AND col = original" guard makes
+// concurrent multi-node boots converge without double-encrypting) and
+// best-effort: per-row and per-target failures are collected and returned but
+// never abort the sweep. Returns the count of newly encrypted rows.
+func BackfillColumns(ctx context.Context, db Executor, cipher *Cipher, targets []BackfillTarget) (int, error) {
+	total := 0
+	var errs []error
+	for _, t := range targets {
+		n, err := backfillTarget(ctx, db, cipher, t)
+		total += n
+		if err != nil {
+			errs = append(errs, fmt.Errorf("%s.%s: %w", t.Table, t.Column, err))
+		}
+	}
+	return total, errors.Join(errs...)
+}
+
+// candidate is one plaintext row to encrypt.
+type candidate struct {
+	key   string // update WHERE key (rendered text)
+	aadID string // AAD pk part
+	value string // current plaintext value
+}
+
+func backfillTarget(ctx context.Context, db Executor, cipher *Cipher, t BackfillTarget) (int, error) {
+	// Select candidates first (can't UPDATE while iterating the same rows).
+	selectSQL := fmt.Sprintf(
+		`SELECT %s, %s, %s FROM %s WHERE %s IS NOT NULL AND %s <> '' AND %s NOT LIKE 'enc:v1:%%'`,
+		t.keyExpr(), t.aadExpr(), t.Column, t.Table, t.Column, t.Column, t.Column,
+	)
+	rows, err := db.Query(ctx, selectSQL)
+	if err != nil {
+		return 0, fmt.Errorf("select candidates: %w", err)
+	}
+	var candidates []candidate
+	for rows.Next() {
+		var c candidate
+		if err := rows.Scan(&c.key, &c.aadID, &c.value); err != nil {
+			rows.Close()
+			return 0, fmt.Errorf("scan candidate: %w", err)
+		}
+		candidates = append(candidates, c)
+	}
+	rows.Close()
+	if err := rows.Err(); err != nil {
+		return 0, fmt.Errorf("iterate candidates: %w", err)
+	}
+
+	updateSQL := fmt.Sprintf(
+		`UPDATE %s SET %s = $1 WHERE %s = $2 AND %s = $3`,
+		t.Table, t.Column, t.keyExpr(), t.Column,
+	)
+	count := 0
+	var errs []error
+	for _, c := range candidates {
+		ct, changed, err := cipher.EncryptIfPlaintext(c.value, RowAAD(t.Table, t.Column, c.aadID))
+		if err != nil {
+			errs = append(errs, fmt.Errorf("encrypt key=%s: %w", c.key, err))
+			continue
+		}
+		if !changed {
+			continue
+		}
+		tag, err := db.Exec(ctx, updateSQL, ct, c.key, c.value)
+		if err != nil {
+			errs = append(errs, fmt.Errorf("update key=%s: %w", c.key, err))
+			continue
+		}
+		if tag.RowsAffected() > 0 {
+			count++
+		}
+	}
+	return count, errors.Join(errs...)
+}
+
+// ReferenceResolver resolves a legacy api_key_ref value that may be a
+// server_settings key name into the real credential. It returns "" when the
+// value is not a known reference (i.e. the row already holds a literal key). In
+// production this is the EncryptedSettingsRepo's Get, which decrypts a sensitive
+// target and passes through a plaintext custom key.
+type ReferenceResolver func(ctx context.Context, ref string) (string, error)
+
+// ArrKeyBackfillTargets are the two arr api_key_ref columns that need the
+// resolve-then-encrypt path (their legacy rows may reference server_settings).
+func ArrKeyBackfillTargets() []BackfillTarget {
+	return []BackfillTarget{
+		{Table: "request_integrations", Column: "api_key_ref", KeyExpr: "id::text"},
+		{Table: "autoscan_connections", Column: "api_key_ref", KeyExpr: "id::text"},
+	}
+}
+
+// BackfillReferencedColumns encrypts the arr api_key_ref columns, first
+// collapsing any legacy server_settings reference to the real credential. For
+// each not-yet-encrypted row it calls resolve(value): a non-empty result means
+// the row held a reference (encrypt the resolved credential), otherwise the row
+// held a literal key (encrypt the value). Run this AFTER the sensitive-settings
+// backfill so referenced settings are already consistent. Idempotent and
+// best-effort. Returns the count of newly encrypted rows.
+func BackfillReferencedColumns(ctx context.Context, db Executor, cipher *Cipher, resolve ReferenceResolver, targets []BackfillTarget) (int, error) {
+	total := 0
+	var errs []error
+	for _, t := range targets {
+		n, err := backfillReferencedTarget(ctx, db, cipher, resolve, t)
+		total += n
+		if err != nil {
+			errs = append(errs, fmt.Errorf("%s.%s: %w", t.Table, t.Column, err))
+		}
+	}
+	return total, errors.Join(errs...)
+}
+
+func backfillReferencedTarget(ctx context.Context, db Executor, cipher *Cipher, resolve ReferenceResolver, t BackfillTarget) (int, error) {
+	selectSQL := fmt.Sprintf(
+		`SELECT %s, %s FROM %s WHERE %s IS NOT NULL AND %s <> '' AND %s NOT LIKE 'enc:v1:%%'`,
+		t.keyExpr(), t.Column, t.Table, t.Column, t.Column, t.Column,
+	)
+	rows, err := db.Query(ctx, selectSQL)
+	if err != nil {
+		return 0, fmt.Errorf("select candidates: %w", err)
+	}
+	type rec struct{ key, value string }
+	var recs []rec
+	for rows.Next() {
+		var r rec
+		if err := rows.Scan(&r.key, &r.value); err != nil {
+			rows.Close()
+			return 0, fmt.Errorf("scan candidate: %w", err)
+		}
+		recs = append(recs, r)
+	}
+	rows.Close()
+	if err := rows.Err(); err != nil {
+		return 0, fmt.Errorf("iterate candidates: %w", err)
+	}
+
+	updateSQL := fmt.Sprintf(
+		`UPDATE %s SET %s = $1 WHERE %s = $2 AND %s = $3`,
+		t.Table, t.Column, t.keyExpr(), t.Column,
+	)
+	count := 0
+	var errs []error
+	for _, r := range recs {
+		credential := r.value
+		if resolved, err := resolve(ctx, r.value); err != nil {
+			errs = append(errs, fmt.Errorf("resolve key=%s: %w", r.key, err))
+			continue
+		} else if resolved != "" {
+			credential = resolved // the row held a reference, not a literal key
+		}
+		ct, err := cipher.Encrypt(credential, RowAAD(t.Table, t.Column, r.key))
+		if err != nil {
+			errs = append(errs, fmt.Errorf("encrypt key=%s: %w", r.key, err))
+			continue
+		}
+		tag, err := db.Exec(ctx, updateSQL, ct, r.key, r.value)
+		if err != nil {
+			errs = append(errs, fmt.Errorf("update key=%s: %w", r.key, err))
+			continue
+		}
+		if tag.RowsAffected() > 0 {
+			count++
+		}
+	}
+	return count, errors.Join(errs...)
+}

--- a/internal/secret/backfill_test.go
+++ b/internal/secret/backfill_test.go
@@ -1,0 +1,144 @@
+package secret
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgconn"
+)
+
+// fakeRows yields preset all-string rows for the backfill SELECT.
+type fakeRows struct {
+	rows [][]string
+	i    int
+}
+
+func (f *fakeRows) Next() bool { f.i++; return f.i <= len(f.rows) }
+func (f *fakeRows) Scan(dest ...any) error {
+	row := f.rows[f.i-1]
+	if len(dest) != len(row) {
+		return fmt.Errorf("fakeRows: scan into %d dests, row has %d", len(dest), len(row))
+	}
+	for j, d := range dest {
+		p, ok := d.(*string)
+		if !ok {
+			return fmt.Errorf("fakeRows: dest %d is %T, want *string", j, d)
+		}
+		*p = row[j]
+	}
+	return nil
+}
+func (f *fakeRows) Close()                                       {}
+func (f *fakeRows) Err() error                                   { return nil }
+func (f *fakeRows) CommandTag() pgconn.CommandTag                { return pgconn.CommandTag{} }
+func (f *fakeRows) FieldDescriptions() []pgconn.FieldDescription { return nil }
+func (f *fakeRows) Values() ([]any, error)                       { return nil, nil }
+func (f *fakeRows) RawValues() [][]byte                          { return nil }
+func (f *fakeRows) Conn() *pgx.Conn                              { return nil }
+
+type capturedExec struct {
+	args []any
+}
+
+// fakeExec returns a fixed candidate set from Query and captures every Exec.
+type fakeExec struct {
+	rows  [][]string
+	execs []capturedExec
+}
+
+func (f *fakeExec) Query(context.Context, string, ...any) (pgx.Rows, error) {
+	return &fakeRows{rows: f.rows}, nil
+}
+func (f *fakeExec) Exec(_ context.Context, _ string, args ...any) (pgconn.CommandTag, error) {
+	f.execs = append(f.execs, capturedExec{args: args})
+	return pgconn.NewCommandTag("UPDATE 1"), nil
+}
+
+func TestBackfillColumns_EncryptsBindsAndSkipsEncrypted(t *testing.T) {
+	c := newTestCipher(t)
+	target := BackfillTarget{Table: "subtitle_provider_config", Column: "api_key", KeyExpr: "provider_name"}
+
+	// Pre-encrypted row must be skipped by the in-loop EncryptIfPlaintext guard.
+	preEnc, err := c.Encrypt("already", RowAAD(target.Table, target.Column, "opensubtitles"))
+	if err != nil {
+		t.Fatalf("seed encrypt: %v", err)
+	}
+	db := &fakeExec{rows: [][]string{
+		// {key, aadID, value}; for this target aadID == key (provider_name).
+		{"subdl", "subdl", "plain-subdl-key"},
+		{"opensubtitles", "opensubtitles", preEnc},
+	}}
+
+	n, err := BackfillColumns(context.Background(), db, c, []BackfillTarget{target})
+	if err != nil {
+		t.Fatalf("BackfillColumns: %v", err)
+	}
+	if n != 1 {
+		t.Fatalf("encrypted = %d, want 1 (pre-encrypted row skipped)", n)
+	}
+	if len(db.execs) != 1 {
+		t.Fatalf("exec count = %d, want 1", len(db.execs))
+	}
+	// args: [ciphertext, key, originalValue]
+	got := db.execs[0].args
+	ct, key, orig := got[0].(string), got[1].(string), got[2].(string)
+	if key != "subdl" || orig != "plain-subdl-key" {
+		t.Fatalf("update bound key=%q orig=%q", key, orig)
+	}
+	if !IsEncrypted(ct) {
+		t.Fatalf("update value %q is not enc:v1:", ct)
+	}
+	// Ciphertext must decrypt under the row-bound AAD back to the original.
+	plain, err := c.Decrypt(ct, RowAAD(target.Table, target.Column, key))
+	if err != nil || plain != "plain-subdl-key" {
+		t.Fatalf("decrypt = (%q, %v), want original", plain, err)
+	}
+}
+
+func TestBackfillReferencedColumns_ResolveThenEncrypt(t *testing.T) {
+	c := newTestCipher(t)
+	target := BackfillTarget{Table: "request_integrations", Column: "api_key_ref", KeyExpr: "id::text"}
+
+	// resolve mimics the settings decorator: a known settings key resolves to the
+	// real credential; anything else is a literal (returns "").
+	resolve := func(_ context.Context, ref string) (string, error) {
+		if ref == "requests.radarr.api_key" {
+			return "REAL-RADARR-KEY", nil
+		}
+		return "", nil
+	}
+	db := &fakeExec{rows: [][]string{
+		{"int-1", "requests.radarr.api_key"}, // a reference → encrypt the resolved key
+		{"int-2", "literal-key-xyz"},         // a literal → encrypt the value itself
+	}}
+
+	n, err := BackfillReferencedColumns(context.Background(), db, c, resolve, []BackfillTarget{target})
+	if err != nil {
+		t.Fatalf("BackfillReferencedColumns: %v", err)
+	}
+	if n != 2 || len(db.execs) != 2 {
+		t.Fatalf("encrypted=%d execs=%d, want 2/2", n, len(db.execs))
+	}
+
+	want := map[string]string{
+		"int-1": "REAL-RADARR-KEY", // resolved, not the setting name
+		"int-2": "literal-key-xyz",
+	}
+	for _, e := range db.execs {
+		ct, key, orig := e.args[0].(string), e.args[1].(string), e.args[2].(string)
+		plain, err := c.Decrypt(ct, RowAAD(target.Table, target.Column, key))
+		if err != nil {
+			t.Fatalf("decrypt for %s: %v", key, err)
+		}
+		if plain != want[key] {
+			t.Fatalf("row %s encrypted %q, want %q", key, plain, want[key])
+		}
+		// The UPDATE guard ($3) must be the ORIGINAL stored value so concurrent
+		// boots converge (the reference name for int-1, the literal for int-2).
+		if key == "int-1" && orig != "requests.radarr.api_key" {
+			t.Fatalf("int-1 guard = %q, want the original reference", orig)
+		}
+	}
+}

--- a/internal/secret/cipher.go
+++ b/internal/secret/cipher.go
@@ -1,0 +1,204 @@
+// Package secret provides at-rest symmetric encryption for server-owned
+// credentials (arr API keys, S3 keys, sensitive server_settings, per-table
+// access tokens). Callers store the resulting ciphertext directly in the column
+// that previously held the plaintext credential and decrypt on read, so the
+// secret never lives in the database as naked text.
+//
+// The one primitive everything reuses is AES-256-GCM with a random 12-byte
+// nonce and a versioned envelope (enc:v1:<base64url(nonce‖sealed)>). The 32-byte
+// data key is HKDF-SHA256 derived from a master key (the SECRET_KEY env value)
+// with a domain-separation label, so the key that protects the data lives
+// outside Postgres and encrypted secrets survive a full database dump.
+//
+// Each ciphertext is GCM-bound to its logical row via additional-authenticated
+// data (AAD) — "table:column:<pk>" (or "server_settings:<key>") — so a
+// DB-write attacker cannot transplant a credential blob into another row or
+// column: decrypting with a different AAD fails authentication.
+package secret
+
+import (
+	"crypto/aes"
+	"crypto/cipher"
+	"crypto/hkdf"
+	"crypto/rand"
+	"crypto/sha256"
+	"encoding/base64"
+	"errors"
+	"fmt"
+	"strings"
+)
+
+const (
+	// envelopePrefix tags a value as v1 ciphertext. It is exactly 7 ASCII
+	// characters, is not valid base64url, and does not collide with any real
+	// credential prefix (sa_ tokens, UUIDs, JWTs, URLs, integers) in practice.
+	envelopePrefix = "enc:v1:"
+
+	// hkdfInfo domain-separates the derived data key from any other use of the
+	// master key. Bump it alongside the envelope version on a future key
+	// rotation (enc:v2: with "silo/data-encryption/v2").
+	hkdfInfo = "silo/data-encryption/v1"
+
+	// MinMasterKeyLen is the minimum acceptable master-key length in bytes. The
+	// bootstrap loader enforces the same floor on SECRET_KEY before New is ever
+	// called.
+	MinMasterKeyLen = 32
+
+	// dataKeyLen is the AES-256 key size.
+	dataKeyLen = 32
+)
+
+// ErrUnknownVersion is returned by Decrypt when the envelope carries a version
+// this build does not understand. It is the forward-compatibility hook for a
+// future enc:v2: key rotation: an older binary surfaces an explicit error
+// instead of silently mishandling a newer ciphertext.
+var ErrUnknownVersion = errors.New("secret: unknown ciphertext version")
+
+// Cipher encrypts and decrypts short credential strings with AES-256-GCM. The
+// data key is derived once in New and the AEAD is built once and reused, so the
+// hot path is a single Seal/Open with no per-call key schedule. A Cipher is
+// safe for concurrent use by multiple goroutines.
+type Cipher struct {
+	gcm cipher.AEAD
+}
+
+// New derives a Cipher from the master key (the raw SECRET_KEY value). The key
+// must be at least MinMasterKeyLen bytes; New returns an error otherwise so a
+// short or empty key can never silently produce a weak cipher.
+func New(masterKey []byte) (*Cipher, error) {
+	if len(masterKey) < MinMasterKeyLen {
+		return nil, fmt.Errorf("secret: master key must be at least %d bytes, got %d", MinMasterKeyLen, len(masterKey))
+	}
+	dataKey, err := hkdf.Key(sha256.New, masterKey, nil /* salt */, hkdfInfo, dataKeyLen)
+	if err != nil {
+		return nil, fmt.Errorf("secret: derive data key: %w", err)
+	}
+	block, err := aes.NewCipher(dataKey)
+	if err != nil {
+		return nil, fmt.Errorf("secret: new aes cipher: %w", err)
+	}
+	gcm, err := cipher.NewGCM(block)
+	if err != nil {
+		return nil, fmt.Errorf("secret: new gcm: %w", err)
+	}
+	return &Cipher{gcm: gcm}, nil
+}
+
+// Encrypt seals plaintext under the data key, binding the ciphertext to aad (the
+// row-identity string the matching Decrypt must supply). An empty plaintext
+// returns ("", nil): an empty secret is never wrapped in an envelope, so an
+// absent credential stays an empty column value. The result is
+// enc:v1:<base64url(nonce‖sealed)>.
+func (c *Cipher) Encrypt(plaintext, aad string) (string, error) {
+	if plaintext == "" {
+		return "", nil
+	}
+	nonce := make([]byte, c.gcm.NonceSize())
+	if _, err := rand.Read(nonce); err != nil {
+		return "", fmt.Errorf("secret: read nonce: %w", err)
+	}
+	// Seal appends the ciphertext to nonce, so the returned slice is nonce‖sealed.
+	sealed := c.gcm.Seal(nonce, nonce, []byte(plaintext), []byte(aad))
+	return envelopePrefix + base64.RawURLEncoding.EncodeToString(sealed), nil
+}
+
+// Decrypt opens an enc:v1: envelope produced by Encrypt with the same aad. Any
+// failure — unknown version, malformed base64, truncation, tampering, the wrong
+// key, or an aad mismatch — returns an error. Decrypt never falls back to
+// returning the input ciphertext or an empty string; passing through
+// non-prefixed legacy plaintext is the caller's responsibility (the read-path
+// contract), not Decrypt's.
+func (c *Cipher) Decrypt(ciphertext, aad string) (string, error) {
+	// Parse "enc:<version>:<body>" and dispatch on the version so a future
+	// enc:v2: can be added without touching existing call sites.
+	parts := strings.SplitN(ciphertext, ":", 3)
+	if len(parts) != 3 || parts[0] != "enc" {
+		return "", fmt.Errorf("secret: not an enc envelope")
+	}
+	switch parts[1] {
+	case "v1":
+		return c.openV1(parts[2], aad)
+	default:
+		return "", fmt.Errorf("%w: %q", ErrUnknownVersion, parts[1])
+	}
+}
+
+// openV1 decodes and authenticates a v1 body (the part after "enc:v1:").
+func (c *Cipher) openV1(encoded, aad string) (string, error) {
+	sealed, err := base64.RawURLEncoding.DecodeString(encoded)
+	if err != nil {
+		return "", fmt.Errorf("secret: decode ciphertext: %w", err)
+	}
+	nonceSize := c.gcm.NonceSize()
+	if len(sealed) < nonceSize {
+		return "", fmt.Errorf("secret: ciphertext too short")
+	}
+	nonce, body := sealed[:nonceSize], sealed[nonceSize:]
+	plaintext, err := c.gcm.Open(nil, nonce, body, []byte(aad))
+	if err != nil {
+		return "", fmt.Errorf("secret: authenticate ciphertext: %w", err)
+	}
+	return string(plaintext), nil
+}
+
+// IsEncrypted reports whether s carries the v1 envelope prefix. It is a cheap
+// prefix check, not a validity check: a value that begins with enc:v1: but
+// holds a corrupt body still reports true here and then fails Decrypt — it never
+// silently degrades to being used as a plaintext credential.
+func IsEncrypted(s string) bool {
+	return strings.HasPrefix(s, envelopePrefix)
+}
+
+// DecryptIfEncrypted is the canonical read-path primitive shared by every
+// decrypt site (the settings decorator and the per-table repos). It implements
+// the read-path contract:
+//
+//  1. an empty value returns "" unchanged;
+//  2. a non-enveloped (legacy plaintext) value is returned unchanged — during
+//     the backfill window a not-yet-encrypted credential is no worse than today;
+//  3. an enc:v1: value is decrypted, and any failure (wrong key, tamper,
+//     truncation) is returned, never swallowed and never returned as the
+//     ciphertext string.
+//
+// This reconciles best-effort backfill (a skipped/failed row stays readable as
+// plaintext) with the hard guarantee that a real enc:v1: value never silently
+// degrades into using ciphertext as a credential.
+func (c *Cipher) DecryptIfEncrypted(value, aad string) (string, error) {
+	if value == "" || !IsEncrypted(value) {
+		return value, nil
+	}
+	return c.Decrypt(value, aad)
+}
+
+// SettingsAAD returns the additional-authenticated-data string binding a
+// server_settings ciphertext to its key. Read and write sites must both use it
+// so the AAD matches; centralizing it here keeps the convention typo-proof
+// across the settings decorator, the config watcher, and other settings
+// readers.
+func SettingsAAD(key string) string {
+	return "server_settings:" + key
+}
+
+// RowAAD returns the additional-authenticated-data string binding a ciphertext
+// to one logical row: table:column:<pk>. Binding to row identity stops a
+// DB-write attacker from transplanting a credential blob into another row or
+// column — decrypting with a different (table, column, pk) fails authentication.
+func RowAAD(table, column, pk string) string {
+	return table + ":" + column + ":" + pk
+}
+
+// EncryptIfPlaintext encrypts s only when it is non-empty, non-encrypted
+// plaintext, returning (ciphertext, true, nil). An already-encrypted or empty
+// value is returned unchanged with changed=false. This is the idempotent
+// primitive the startup backfill uses to sweep a column without ever
+// double-encrypting an already-wrapped value.
+func (c *Cipher) EncryptIfPlaintext(s, aad string) (string, bool, error) {
+	if s == "" || IsEncrypted(s) {
+		return s, false, nil
+	}
+	ct, err := c.Encrypt(s, aad)
+	if err != nil {
+		return s, false, err
+	}
+	return ct, true, nil
+}

--- a/internal/secret/cipher_test.go
+++ b/internal/secret/cipher_test.go
@@ -1,0 +1,255 @@
+package secret
+
+import (
+	"crypto/rand"
+	"encoding/base64"
+	"errors"
+	"strings"
+	"testing"
+)
+
+// testKey returns a deterministic-length master key suitable for New.
+func testKey(t *testing.T) []byte {
+	t.Helper()
+	key := make([]byte, 48)
+	if _, err := rand.Read(key); err != nil {
+		t.Fatalf("read key: %v", err)
+	}
+	return key
+}
+
+func newTestCipher(t *testing.T) *Cipher {
+	t.Helper()
+	c, err := New(testKey(t))
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	return c
+}
+
+func TestEncryptDecryptRoundTrip(t *testing.T) {
+	c := newTestCipher(t)
+	const (
+		plaintext = "sk-radarr-0123456789abcdef"
+		aad       = "request_integrations:api_key_ref:abc123"
+	)
+	ct, err := c.Encrypt(plaintext, aad)
+	if err != nil {
+		t.Fatalf("Encrypt: %v", err)
+	}
+	if !strings.HasPrefix(ct, "enc:v1:") {
+		t.Fatalf("ciphertext missing enc:v1: prefix: %q", ct)
+	}
+	if !IsEncrypted(ct) {
+		t.Fatalf("IsEncrypted(%q) = false, want true", ct)
+	}
+	got, err := c.Decrypt(ct, aad)
+	if err != nil {
+		t.Fatalf("Decrypt: %v", err)
+	}
+	if got != plaintext {
+		t.Fatalf("round-trip = %q, want %q", got, plaintext)
+	}
+}
+
+func TestEncryptEmptyReturnsEmpty(t *testing.T) {
+	c := newTestCipher(t)
+	ct, err := c.Encrypt("", "any:aad")
+	if err != nil {
+		t.Fatalf("Encrypt empty: %v", err)
+	}
+	if ct != "" {
+		t.Fatalf("Encrypt(\"\") = %q, want empty (no envelope for an empty secret)", ct)
+	}
+}
+
+func TestEncryptNonDeterministic(t *testing.T) {
+	c := newTestCipher(t)
+	const plaintext, aad = "same-secret", "t:c:1"
+	a, err := c.Encrypt(plaintext, aad)
+	if err != nil {
+		t.Fatalf("Encrypt a: %v", err)
+	}
+	b, err := c.Encrypt(plaintext, aad)
+	if err != nil {
+		t.Fatalf("Encrypt b: %v", err)
+	}
+	if a == b {
+		t.Fatalf("two encryptions of the same plaintext+aad were identical; random nonce not applied")
+	}
+	// Both must still decrypt back to the same plaintext.
+	for _, ct := range []string{a, b} {
+		got, err := c.Decrypt(ct, aad)
+		if err != nil || got != plaintext {
+			t.Fatalf("Decrypt(%q) = (%q, %v), want (%q, nil)", ct, got, err, plaintext)
+		}
+	}
+}
+
+func TestDecryptTamperRejected(t *testing.T) {
+	c := newTestCipher(t)
+	const aad = "t:c:1"
+	ct, err := c.Encrypt("secret", aad)
+	if err != nil {
+		t.Fatalf("Encrypt: %v", err)
+	}
+	// Decode the body, flip a byte, re-encode, reattach the envelope.
+	body := strings.TrimPrefix(ct, "enc:v1:")
+	raw, err := base64.RawURLEncoding.DecodeString(body)
+	if err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	raw[len(raw)-1] ^= 0xFF
+	tampered := "enc:v1:" + base64.RawURLEncoding.EncodeToString(raw)
+	if _, err := c.Decrypt(tampered, aad); err == nil {
+		t.Fatalf("Decrypt of tampered ciphertext succeeded, want error")
+	}
+}
+
+func TestDecryptAADMismatchRejected(t *testing.T) {
+	c := newTestCipher(t)
+	ct, err := c.Encrypt("secret", "t:c:1")
+	if err != nil {
+		t.Fatalf("Encrypt: %v", err)
+	}
+	if _, err := c.Decrypt(ct, "t:c:2"); err == nil {
+		t.Fatalf("Decrypt with mismatched AAD succeeded, want error (row binding broken)")
+	}
+}
+
+func TestDecryptWrongKeyRejected(t *testing.T) {
+	a := newTestCipher(t)
+	b := newTestCipher(t)
+	const aad = "t:c:1"
+	ct, err := a.Encrypt("secret", aad)
+	if err != nil {
+		t.Fatalf("Encrypt: %v", err)
+	}
+	if _, err := b.Decrypt(ct, aad); err == nil {
+		t.Fatalf("Decrypt with the wrong key succeeded, want error")
+	}
+}
+
+func TestNewRejectsShortKey(t *testing.T) {
+	if _, err := New(make([]byte, MinMasterKeyLen-1)); err == nil {
+		t.Fatalf("New with a %d-byte key succeeded, want error", MinMasterKeyLen-1)
+	}
+	if _, err := New(nil); err == nil {
+		t.Fatalf("New(nil) succeeded, want error")
+	}
+	if _, err := New(make([]byte, MinMasterKeyLen)); err != nil {
+		t.Fatalf("New with a %d-byte key failed: %v", MinMasterKeyLen, err)
+	}
+}
+
+func TestIsEncrypted(t *testing.T) {
+	cases := map[string]bool{
+		"enc:v1:x":   true,
+		"sa_abc":     false,
+		"":           false,
+		"ENC:V1:x":   false,
+		"enc:v1":     false,
+		"plain text": false,
+	}
+	for in, want := range cases {
+		if got := IsEncrypted(in); got != want {
+			t.Errorf("IsEncrypted(%q) = %v, want %v", in, got, want)
+		}
+	}
+}
+
+func TestDecryptUnknownVersion(t *testing.T) {
+	c := newTestCipher(t)
+	_, err := c.Decrypt("enc:v99:"+base64.RawURLEncoding.EncodeToString([]byte("whatever")), "t:c:1")
+	if !errors.Is(err, ErrUnknownVersion) {
+		t.Fatalf("Decrypt of enc:v99: returned %v, want ErrUnknownVersion", err)
+	}
+}
+
+func TestDecryptNonEnvelopeErrors(t *testing.T) {
+	c := newTestCipher(t)
+	// A non-prefixed legacy value is the caller's pass-through responsibility, but
+	// Decrypt itself must reject it rather than echo it back.
+	if _, err := c.Decrypt("plaintext-not-an-envelope", "t:c:1"); err == nil {
+		t.Fatalf("Decrypt of a non-envelope value succeeded, want error")
+	}
+}
+
+func TestDecryptShortCiphertext(t *testing.T) {
+	c := newTestCipher(t)
+	// Valid base64url but fewer bytes than the GCM nonce.
+	short := "enc:v1:" + base64.RawURLEncoding.EncodeToString([]byte("ab"))
+	if _, err := c.Decrypt(short, "t:c:1"); err == nil {
+		t.Fatalf("Decrypt of a too-short ciphertext succeeded, want error")
+	}
+}
+
+func TestDecryptIfEncrypted(t *testing.T) {
+	c := newTestCipher(t)
+	const aad = "server_settings:tmdb.api_key"
+
+	// Empty passes through.
+	if got, err := c.DecryptIfEncrypted("", aad); err != nil || got != "" {
+		t.Fatalf("DecryptIfEncrypted(\"\") = (%q, %v), want (\"\", nil)", got, err)
+	}
+	// Legacy plaintext passes through unchanged.
+	if got, err := c.DecryptIfEncrypted("legacy-plaintext-key", aad); err != nil || got != "legacy-plaintext-key" {
+		t.Fatalf("DecryptIfEncrypted(plaintext) = (%q, %v), want pass-through", got, err)
+	}
+	// A real enc:v1: value is decrypted.
+	ct, err := c.Encrypt("real-secret", aad)
+	if err != nil {
+		t.Fatalf("Encrypt: %v", err)
+	}
+	if got, err := c.DecryptIfEncrypted(ct, aad); err != nil || got != "real-secret" {
+		t.Fatalf("DecryptIfEncrypted(ct) = (%q, %v), want (\"real-secret\", nil)", got, err)
+	}
+	// A corrupt enc:v1: value errors — never falls back to the ciphertext.
+	if _, err := c.DecryptIfEncrypted(ct, "server_settings:wrong.key"); err == nil {
+		t.Fatalf("DecryptIfEncrypted with wrong AAD succeeded, want error")
+	}
+}
+
+func TestAADHelpers(t *testing.T) {
+	if got := SettingsAAD("auth.jwt_secret"); got != "server_settings:auth.jwt_secret" {
+		t.Errorf("SettingsAAD = %q", got)
+	}
+	if got := RowAAD("request_integrations", "api_key_ref", "abc"); got != "request_integrations:api_key_ref:abc" {
+		t.Errorf("RowAAD = %q", got)
+	}
+}
+
+func TestEncryptIfPlaintextIdempotent(t *testing.T) {
+	c := newTestCipher(t)
+	const aad = "t:c:1"
+
+	// First call encrypts.
+	ct, changed, err := c.EncryptIfPlaintext("secret", aad)
+	if err != nil {
+		t.Fatalf("EncryptIfPlaintext: %v", err)
+	}
+	if !changed {
+		t.Fatalf("first EncryptIfPlaintext reported changed=false, want true")
+	}
+	if !IsEncrypted(ct) {
+		t.Fatalf("EncryptIfPlaintext did not produce an envelope: %q", ct)
+	}
+
+	// Second call is a no-op on the already-encrypted value.
+	ct2, changed2, err := c.EncryptIfPlaintext(ct, aad)
+	if err != nil {
+		t.Fatalf("EncryptIfPlaintext (2nd): %v", err)
+	}
+	if changed2 {
+		t.Fatalf("second EncryptIfPlaintext reported changed=true, want false (double-encrypt)")
+	}
+	if ct2 != ct {
+		t.Fatalf("second EncryptIfPlaintext mutated the value: %q -> %q", ct, ct2)
+	}
+
+	// Empty is a no-op too.
+	got, changed3, err := c.EncryptIfPlaintext("", aad)
+	if err != nil || changed3 || got != "" {
+		t.Fatalf("EncryptIfPlaintext(\"\") = (%q, %v, %v), want (\"\", false, nil)", got, changed3, err)
+	}
+}

--- a/internal/subtitles/pgrepo.go
+++ b/internal/subtitles/pgrepo.go
@@ -8,16 +8,44 @@ import (
 
 	"github.com/jackc/pgx/v5"
 	"github.com/jackc/pgx/v5/pgxpool"
+
+	"github.com/Silo-Server/silo-server/internal/secret"
 )
 
 // PgRepository implements Repository using PostgreSQL.
 type PgRepository struct {
-	pool *pgxpool.Pool
+	pool   *pgxpool.Pool
+	cipher *secret.Cipher
 }
 
 // NewPgRepository creates a new PostgreSQL repository.
-func NewPgRepository(pool *pgxpool.Pool) *PgRepository {
-	return &PgRepository{pool: pool}
+func NewPgRepository(pool *pgxpool.Pool, cipher *secret.Cipher) *PgRepository {
+	return &PgRepository{pool: pool, cipher: cipher}
+}
+
+// providerSecretAAD binds a subtitle_provider_config secret column to its row
+// (keyed by provider_name).
+func (r *PgRepository) providerSecretAAD(column, providerName string) string {
+	return secret.RowAAD("subtitle_provider_config", column, providerName)
+}
+
+// decryptProviderConfig applies the read-path contract to the api_key and
+// password columns (username is not a secret) and (re)derives the Has* flags
+// from the decrypted values.
+func (r *PgRepository) decryptProviderConfig(cfg *ProviderConfig) error {
+	apiKey, err := r.cipher.DecryptIfEncrypted(cfg.APIKey, r.providerSecretAAD("api_key", cfg.ProviderName))
+	if err != nil {
+		return fmt.Errorf("decrypt subtitle api key for %s: %w", cfg.ProviderName, err)
+	}
+	cfg.APIKey = apiKey
+	password, err := r.cipher.DecryptIfEncrypted(cfg.Password, r.providerSecretAAD("password", cfg.ProviderName))
+	if err != nil {
+		return fmt.Errorf("decrypt subtitle password for %s: %w", cfg.ProviderName, err)
+	}
+	cfg.Password = password
+	cfg.HasAPIKey = cfg.APIKey != ""
+	cfg.HasCredentials = cfg.Username != "" && cfg.Password != ""
+	return nil
 }
 
 func (r *PgRepository) InsertDownloadedSubtitle(ctx context.Context, sub *DownloadedSubtitle) error {
@@ -146,8 +174,9 @@ func (r *PgRepository) ListProviderConfigs(ctx context.Context) ([]ProviderConfi
 			&cfg.Username, &cfg.Password, &cfg.UpdatedAt); err != nil {
 			return nil, fmt.Errorf("scan provider config: %w", err)
 		}
-		cfg.HasAPIKey = cfg.APIKey != ""
-		cfg.HasCredentials = cfg.Username != "" && cfg.Password != ""
+		if err := r.decryptProviderConfig(&cfg); err != nil {
+			return nil, err
+		}
 		configs = append(configs, cfg)
 	}
 	return configs, rows.Err()
@@ -166,14 +195,25 @@ func (r *PgRepository) GetProviderConfig(ctx context.Context, providerName strin
 	if err != nil {
 		return nil, fmt.Errorf("get provider config: %w", err)
 	}
-	cfg.HasAPIKey = cfg.APIKey != ""
-	cfg.HasCredentials = cfg.Username != "" && cfg.Password != ""
+	if err := r.decryptProviderConfig(&cfg); err != nil {
+		return nil, err
+	}
 	return &cfg, nil
 }
 
 func (r *PgRepository) UpsertProviderConfig(ctx context.Context, cfg *ProviderConfig) error {
+	// Encrypt the secret columns; an empty result preserves the keep-existing
+	// CASE (toggling enabled with blank creds leaves stored creds intact).
+	apiKey, err := r.cipher.Encrypt(cfg.APIKey, r.providerSecretAAD("api_key", cfg.ProviderName))
+	if err != nil {
+		return fmt.Errorf("encrypt subtitle api key: %w", err)
+	}
+	password, err := r.cipher.Encrypt(cfg.Password, r.providerSecretAAD("password", cfg.ProviderName))
+	if err != nil {
+		return fmt.Errorf("encrypt subtitle password: %w", err)
+	}
 	// Only overwrite credentials when non-empty, so toggling enabled doesn't wipe them.
-	_, err := r.pool.Exec(ctx,
+	_, err = r.pool.Exec(ctx,
 		`INSERT INTO subtitle_provider_config (provider_name, enabled, api_key, username, password, updated_at)
 		VALUES ($1, $2, $3, $4, $5, NOW())
 		ON CONFLICT (provider_name) DO UPDATE SET
@@ -182,7 +222,7 @@ func (r *PgRepository) UpsertProviderConfig(ctx context.Context, cfg *ProviderCo
 			username = CASE WHEN EXCLUDED.username = '' THEN subtitle_provider_config.username ELSE EXCLUDED.username END,
 			password = CASE WHEN EXCLUDED.password = '' THEN subtitle_provider_config.password ELSE EXCLUDED.password END,
 			updated_at = NOW()`,
-		cfg.ProviderName, cfg.Enabled, cfg.APIKey, cfg.Username, cfg.Password)
+		cfg.ProviderName, cfg.Enabled, apiKey, cfg.Username, password)
 	if err != nil {
 		return fmt.Errorf("upsert provider config: %w", err)
 	}

--- a/internal/watchsync/repository.go
+++ b/internal/watchsync/repository.go
@@ -5,10 +5,13 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"strconv"
 	"time"
 
 	"github.com/jackc/pgx/v5"
 	"github.com/jackc/pgx/v5/pgxpool"
+
+	"github.com/Silo-Server/silo-server/internal/secret"
 )
 
 type Repository interface {
@@ -45,11 +48,22 @@ type Repository interface {
 }
 
 type PostgresRepository struct {
-	pool *pgxpool.Pool
+	pool   *pgxpool.Pool
+	cipher *secret.Cipher
 }
 
-func NewPostgresRepository(pool *pgxpool.Pool) *PostgresRepository {
-	return &PostgresRepository{pool: pool}
+func NewPostgresRepository(pool *pgxpool.Pool, cipher *secret.Cipher) *PostgresRepository {
+	return &PostgresRepository{pool: pool, cipher: cipher}
+}
+
+// TokenAAD binds an access/refresh token ciphertext to its connection. It uses
+// the stable UNIQUE business key (provider, user_id, profile_id) rather than the
+// surrogate id, because UpsertConnection lets Postgres assign/keep the id (ON
+// CONFLICT), so the id is not known before the write — the tuple is, and it
+// identifies the row just as uniquely. Exported so the (raw-SQL) Trakt
+// collection-token resolver binds tokens identically.
+func TokenAAD(column, provider string, userID int, profileID string) string {
+	return secret.RowAAD("watch_provider_connections", column, provider+":"+strconv.Itoa(userID)+":"+profileID)
 }
 
 func (r *PostgresRepository) GetServerSetting(ctx context.Context, key string) (string, error) {
@@ -61,7 +75,14 @@ func (r *PostgresRepository) GetServerSetting(ctx context.Context, key string) (
 	if err != nil {
 		return "", fmt.Errorf("server_settings get %q: %w", key, err)
 	}
-	return value, nil
+	// This repo reads watchsync.<provider>.client_id/client_secret (sensitive
+	// settings) directly, bypassing the settings decorator, so apply the same
+	// read-path decryption here.
+	out, err := r.cipher.DecryptIfEncrypted(value, secret.SettingsAAD(key))
+	if err != nil {
+		return "", fmt.Errorf("decrypt server_settings %q: %w", key, err)
+	}
+	return out, nil
 }
 
 func (r *PostgresRepository) UpsertAuthSession(
@@ -126,6 +147,14 @@ func (r *PostgresRepository) GetAuthSession(ctx context.Context, id string) (Dev
 }
 
 func (r *PostgresRepository) UpsertConnection(ctx context.Context, conn Connection) (Connection, error) {
+	accessToken, err := r.cipher.Encrypt(conn.AccessToken, TokenAAD("access_token", conn.Provider, conn.UserID, conn.ProfileID))
+	if err != nil {
+		return Connection{}, fmt.Errorf("encrypt watch access token: %w", err)
+	}
+	refreshToken, err := r.cipher.Encrypt(conn.RefreshToken, TokenAAD("refresh_token", conn.Provider, conn.UserID, conn.ProfileID))
+	if err != nil {
+		return Connection{}, fmt.Errorf("encrypt watch refresh token: %w", err)
+	}
 	row := r.pool.QueryRow(ctx, `
 		INSERT INTO watch_provider_connections (
 			id, provider, user_id, profile_id, provider_account_id, provider_username,
@@ -176,8 +205,8 @@ func (r *PostgresRepository) UpsertConnection(ctx context.Context, conn Connecti
 		conn.ProfileID,
 		conn.ProviderAccountID,
 		conn.ProviderUsername,
-		conn.AccessToken,
-		conn.RefreshToken,
+		accessToken,
+		refreshToken,
 		conn.TokenExpiresAt,
 		conn.ImportWatchedEnabled,
 		conn.ImportProgressEnabled,
@@ -195,7 +224,7 @@ func (r *PostgresRepository) UpsertConnection(ctx context.Context, conn Connecti
 		conn.LastError,
 		encodeSyncCursors(conn.SyncCursors),
 	)
-	saved, err := scanConnection(row)
+	saved, err := r.scanConnection(row)
 	if err != nil {
 		return Connection{}, fmt.Errorf("upsert watch provider connection: %w", err)
 	}
@@ -219,7 +248,7 @@ func (r *PostgresRepository) GetConnection(
 		FROM watch_provider_connections
 		WHERE provider = $1 AND user_id = $2 AND profile_id = $3
 	`, provider, userID, profileID)
-	conn, err := scanConnection(row)
+	conn, err := r.scanConnection(row)
 	if errors.Is(err, pgx.ErrNoRows) {
 		return Connection{}, false, nil
 	}
@@ -241,7 +270,7 @@ func (r *PostgresRepository) GetConnectionByID(ctx context.Context, id string) (
 		FROM watch_provider_connections
 		WHERE id = $1::uuid
 	`, id)
-	conn, err := scanConnection(row)
+	conn, err := r.scanConnection(row)
 	if errors.Is(err, pgx.ErrNoRows) {
 		return Connection{}, false, nil
 	}
@@ -300,7 +329,7 @@ func (r *PostgresRepository) ListConnectionsDueForSync(
 
 	var conns []Connection
 	for rows.Next() {
-		conn, scanErr := scanConnection(rows)
+		conn, scanErr := r.scanConnection(rows)
 		if scanErr != nil {
 			return nil, fmt.Errorf("scan due watch provider connection: %w", scanErr)
 		}
@@ -509,7 +538,7 @@ func (r *PostgresRepository) ListLocalWatchEventConnections(
 
 	var conns []Connection
 	for rows.Next() {
-		conn, scanErr := scanConnection(rows)
+		conn, scanErr := r.scanConnection(rows)
 		if scanErr != nil {
 			return nil, fmt.Errorf("scan local watch event connection: %w", scanErr)
 		}
@@ -555,7 +584,7 @@ func (r *PostgresRepository) ListFavoriteEventConnections(
 
 	var conns []Connection
 	for rows.Next() {
-		conn, scanErr := scanConnection(rows)
+		conn, scanErr := r.scanConnection(rows)
 		if scanErr != nil {
 			return nil, fmt.Errorf("scan favorite event connection: %w", scanErr)
 		}
@@ -862,7 +891,7 @@ func (r *PostgresRepository) ListScrobbleConnections(ctx context.Context, userID
 	defer rows.Close()
 	var conns []Connection
 	for rows.Next() {
-		conn, err := scanConnection(rows)
+		conn, err := r.scanConnection(rows)
 		if err != nil {
 			return nil, fmt.Errorf("scan scrobble connection: %w", err)
 		}
@@ -1033,7 +1062,7 @@ func scanSyncRun(row pgx.Row) (SyncRun, error) {
 	return run, nil
 }
 
-func scanConnection(row pgx.Row) (Connection, error) {
+func (r *PostgresRepository) scanConnection(row pgx.Row) (Connection, error) {
 	var conn Connection
 	var rawSyncCursors []byte
 	err := row.Scan(
@@ -1066,6 +1095,14 @@ func scanConnection(row pgx.Row) (Connection, error) {
 	)
 	if err != nil {
 		return Connection{}, err
+	}
+	// Decrypt the tokens (read-path contract), bound to the connection's stable
+	// business key — matching TokenAAD on the write path.
+	if conn.AccessToken, err = r.cipher.DecryptIfEncrypted(conn.AccessToken, TokenAAD("access_token", conn.Provider, conn.UserID, conn.ProfileID)); err != nil {
+		return Connection{}, fmt.Errorf("decrypt watch access token: %w", err)
+	}
+	if conn.RefreshToken, err = r.cipher.DecryptIfEncrypted(conn.RefreshToken, TokenAAD("refresh_token", conn.Provider, conn.UserID, conn.ProfileID)); err != nil {
+		return Connection{}, fmt.Errorf("decrypt watch refresh token: %w", err)
 	}
 	conn.SyncCursors = decodeSyncCursors(rawSyncCursors)
 	return conn, nil

--- a/internal/webhooksync/repo.go
+++ b/internal/webhooksync/repo.go
@@ -7,16 +7,28 @@ import (
 
 	"github.com/jackc/pgx/v5"
 	"github.com/jackc/pgx/v5/pgxpool"
+
+	"github.com/Silo-Server/silo-server/internal/secret"
 )
 
 var ErrConnectionNotFound = errors.New("webhook sync connection not found")
 
 type Repository struct {
-	pool *pgxpool.Pool
+	pool   *pgxpool.Pool
+	cipher *secret.Cipher
 }
 
-func NewRepository(pool *pgxpool.Pool) *Repository {
-	return &Repository{pool: pool}
+func NewRepository(pool *pgxpool.Pool, cipher *secret.Cipher) *Repository {
+	return &Repository{pool: pool, cipher: cipher}
+}
+
+// webhookTokenAAD binds a webhook_sync_connections access_token ciphertext to
+// its row. Defined at package scope so the secret package reference is isolated
+// from GetConnectionBySecret, whose parameter shadows the import name.
+// (webhook_secret is NOT encrypted — it is matched by exact value in
+// GetConnectionBySecret and is carved out for a separate hashing follow-up.)
+func webhookTokenAAD(id string) string {
+	return secret.RowAAD("webhook_sync_connections", "access_token", id)
 }
 
 func (r *Repository) ProfileExistsForUser(ctx context.Context, userID int, profileID string) (bool, error) {
@@ -31,6 +43,10 @@ func (r *Repository) ProfileExistsForUser(ctx context.Context, userID int, profi
 }
 
 func (r *Repository) CreateConnection(ctx context.Context, conn Connection) (*Connection, error) {
+	accessToken, err := r.cipher.Encrypt(conn.AccessToken, webhookTokenAAD(conn.ID))
+	if err != nil {
+		return nil, fmt.Errorf("encrypt webhook access token: %w", err)
+	}
 	row := r.pool.QueryRow(ctx, `
 		INSERT INTO webhook_sync_connections (
 			id, user_id, provider, server_id, server_name, base_url, access_token, default_profile_id, webhook_secret
@@ -39,9 +55,9 @@ func (r *Repository) CreateConnection(ctx context.Context, conn Connection) (*Co
 		          webhook_secret, account_discovery_available,
 		          last_webhook_received_at, last_webhook_error_at, COALESCE(last_webhook_error_message, ''),
 		          created_at, updated_at`,
-		conn.ID, conn.UserID, conn.Provider, conn.ServerID, conn.ServerName, conn.BaseURL, conn.AccessToken, conn.DefaultProfileID, conn.WebhookSecret,
+		conn.ID, conn.UserID, conn.Provider, conn.ServerID, conn.ServerName, conn.BaseURL, accessToken, conn.DefaultProfileID, conn.WebhookSecret,
 	)
-	return scanConnection(row)
+	return r.scanConnection(row)
 }
 
 func (r *Repository) ListConnections(ctx context.Context, userID int) ([]Connection, error) {
@@ -72,6 +88,9 @@ func (r *Repository) ListConnections(ctx context.Context, userID int) ([]Connect
 		); err != nil {
 			return nil, fmt.Errorf("scanning webhook sync connection: %w", err)
 		}
+		if c.AccessToken, err = r.cipher.DecryptIfEncrypted(c.AccessToken, webhookTokenAAD(c.ID)); err != nil {
+			return nil, fmt.Errorf("decrypt webhook access token: %w", err)
+		}
 		out = append(out, c)
 	}
 	if err := rows.Err(); err != nil {
@@ -88,7 +107,7 @@ func (r *Repository) GetConnection(ctx context.Context, userID int, id string) (
 		       created_at, updated_at
 		FROM webhook_sync_connections
 		WHERE id = $1 AND user_id = $2`, id, userID)
-	return scanConnection(row)
+	return r.scanConnection(row)
 }
 
 func (r *Repository) GetConnectionBySecret(ctx context.Context, secret string) (*Connection, error) {
@@ -99,10 +118,10 @@ func (r *Repository) GetConnectionBySecret(ctx context.Context, secret string) (
 		       created_at, updated_at
 		FROM webhook_sync_connections
 		WHERE webhook_secret = $1`, secret)
-	return scanConnection(row)
+	return r.scanConnection(row)
 }
 
-func scanConnection(row pgx.Row) (*Connection, error) {
+func (r *Repository) scanConnection(row pgx.Row) (*Connection, error) {
 	var c Connection
 	if err := row.Scan(
 		&c.ID, &c.UserID, &c.Provider, &c.ServerID, &c.ServerName, &c.BaseURL, &c.AccessToken, &c.DefaultProfileID,
@@ -115,6 +134,13 @@ func scanConnection(row pgx.Row) (*Connection, error) {
 		}
 		return nil, fmt.Errorf("scanning webhook sync connection: %w", err)
 	}
+	// Decrypt the access token (read-path). webhook_secret is intentionally left
+	// as-is (equality-looked-up; carved out for the hashing follow-up).
+	token, err := r.cipher.DecryptIfEncrypted(c.AccessToken, webhookTokenAAD(c.ID))
+	if err != nil {
+		return nil, fmt.Errorf("decrypt webhook access token: %w", err)
+	}
+	c.AccessToken = token
 	return &c, nil
 }
 
@@ -131,7 +157,7 @@ func (r *Repository) UpdateConnection(ctx context.Context, userID int, id string
 		          created_at, updated_at`,
 		id, userID, input.ServerName, input.DefaultProfileID,
 	)
-	return scanConnection(row)
+	return r.scanConnection(row)
 }
 
 func (r *Repository) DeleteConnection(ctx context.Context, userID int, id string) error {


### PR DESCRIPTION
## Problem

Third-party integration credentials and other server-owned secrets are stored in PostgreSQL as plaintext — Sonarr/Radarr API keys, S3 keys, watch-sync OAuth tokens, history-import tokens, the ABS signing key, and a dozen sensitive `server_settings`. A DB dump or compromise exposes all of them. The two arr `api_key_ref` columns were additionally resolved through a plaintext `server_settings` key/value store with an ambiguous ref-vs-literal fallback.

Implements the plan for [issue #45](https://github.com/Silo-Server/silo-server/issues/45).

## Approach

A new `internal/secret` package owns one primitive: **AES-256-GCM** with a random 12-byte nonce, a versioned `enc:v1:` envelope, and a data key **HKDF-SHA256-derived from a required `SECRET_KEY`** env var (so the key lives outside Postgres and secrets survive a full DB dump). Every ciphertext is GCM-bound to its row via **AAD** (`table:column:<pk>`, or `server_settings:<key>`), so a DB-write attacker can't transplant a credential blob between rows.

- **`SECRET_KEY` required at bootstrap** (fatals if absent/<32 chars); the cipher is constructed once and threaded as an explicit dependency — never a global.
- **`server_settings`:** an `EncryptedSettingsRepo` decorator transparently encrypts the audited `SensitiveSettingKeys` (now the single source of truth for both encryption *and* admin redaction). The config hot-reload watcher and watch-sync's raw settings reads decrypt too.
- **Arr keys** inline-encrypted; the ambiguous `SecretResolver` indirection deleted from `requests`/`autoscan`.
- **Per-table columns** encrypted with encrypt-on-write / decrypt-on-read and a row-bound AAD: subtitles (`api_key`/`password`), watch-sync (`access_token`/`refresh_token`), webhook-sync (`access_token`), history-import (admin + session tokens), and the jellycompat session's bridged Silo access/refresh tokens.
- **Idempotent startup backfill** (best-effort, primary-node gated) sweeps existing plaintext to ciphertext, with a resolve-then-encrypt path for the legacy arr references.

**No schema migration** — every target column is already `text` and now holds ciphertext; the backfill is pure Go. **No client/frontend changes** — API responses already mask these to `has_*` booleans.

## Read-path contract

Empty → empty; legacy plaintext passes through unchanged (backfill window); an `enc:v1:` value is decrypted and any failure (wrong key/tamper/truncation) is propagated, never swallowed or used as ciphertext.

## Risks / operations

- **`SECRET_KEY` must be set and backed up separately from DB dumps** (treat like a CA private key). Loss makes encrypted secrets unrecoverable. **Downgrade hazard:** an older binary would read `enc:v1:auth.jwt_secret` as a literal JWT secret. Full operator runbook in `docs/architecture/secret-encryption.md`.

## Out of scope (follow-ups)

- **Equality-looked-up secrets** (`api_keys.api_key`, `webhook_sync_connections.webhook_secret`, `jellycompat_sessions.token`, `watch_together_rooms.join_token`) — matched by exact value, so they need a deterministic **blind-index hash**, not randomized encryption.
- **`plugin_runtime_configs.config_value`** — cross-repo (`Silo`) + manifest-driven; needs a coordinated design.

## Testing

`go build ./...`, `go vet ./...`, gofmt clean, `make verify-local-paths`, and unit tests across `secret` (cipher round-trip/tamper/AAD/version/idempotency + backfill resolve-then-encrypt), the settings decorator, and all touched repos. No frontend changes. New code is lint-clean (pre-existing repo lint debt untouched).

## AI-use disclosure

Implemented by Claude Code (Opus 4.8) from the attached plan.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * At-rest encryption for sensitive server credentials in the database with automatic, idempotent backfill on startup (best-effort, primary node only).

* **Documentation**
  * Added a detailed architecture guide covering the encryption design, envelope format, and operational guidance.

* **Chores**
  * A SECRET_KEY environment variable is now required at startup; see docs for generation, minimum length, and backup guidance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->