### PR TITLE
feat(ebooks): extract local covers during scan

### DIFF
--- a/internal/catalog/item_repo.go
+++ b/internal/catalog/item_repo.go
@@ -70,12 +70,21 @@ const itemColumns = `content_id, type, title, sort_title, default_metadata_langu
 	content_rating, runtime, overview, tagline,
 	rating_imdb, rating_tmdb, rating_rt_critic, rating_rt_audience,
 	imdb_id, tmdb_id, tvdb_id,
-	poster_path, poster_thumbhash, backdrop_path, backdrop_thumbhash, logo_path,
-	metadata_s3_path, metadata_etag, season_count,
+	COALESCE(poster_path, ''), COALESCE(poster_thumbhash, ''), COALESCE(backdrop_path, ''), COALESCE(backdrop_thumbhash, ''), COALESCE(logo_path, ''),
+	COALESCE(metadata_s3_path, ''), COALESCE(metadata_etag, ''), season_count,
 	studios, networks, countries, keywords, original_language, release_date::text, first_air_date, last_air_date, air_time, air_timezone,
 	show_status,
 	matched_at, last_refreshed, refresh_failures,
 	episode_metadata_incomplete, episode_metadata_last_checked_at, locked_fields, status, created_at, updated_at`
+
+func qualifiedNullableStringColumn(alias, col string) string {
+	switch col {
+	case "poster_path", "poster_thumbhash", "backdrop_path", "backdrop_thumbhash", "logo_path", "metadata_s3_path", "metadata_etag":
+		return fmt.Sprintf("COALESCE(%s.%s, '')", alias, col)
+	default:
+		return alias + "." + col
+	}
+}
 
 func qualifiedItemColumns(alias string) string {
 	cols := []string{
@@ -92,7 +101,7 @@ func qualifiedItemColumns(alias string) string {
 	}
 	prefixed := make([]string, len(cols))
 	for i, col := range cols {
-		prefixed[i] = alias + "." + col
+		prefixed[i] = qualifiedNullableStringColumn(alias, col)
 	}
 	return strings.Join(prefixed, ", ")
 }
@@ -116,7 +125,7 @@ func qualifiedListItemColumns(alias string) string {
 			prefixed[i] = effectiveLastAirDateExpr(alias)
 			continue
 		}
-		prefixed[i] = alias + "." + col
+		prefixed[i] = qualifiedNullableStringColumn(alias, col)
 	}
 	return strings.Join(prefixed, ", ")
 }

--- a/internal/catalog/item_repo.go
+++ b/internal/catalog/item_repo.go
@@ -35,6 +35,26 @@ func NewItemRepository(pool *pgxpool.Pool) *ItemRepository {
 	return &ItemRepository{pool: pool}
 }
 
+// GetPosterPath returns the current poster path for a media item. Missing or
+// NULL poster values are returned as an empty string.
+func (r *ItemRepository) GetPosterPath(ctx context.Context, contentID string) (string, error) {
+	if r == nil || r.pool == nil {
+		return "", ErrItemNotFound
+	}
+	var posterPath string
+	if err := r.pool.QueryRow(ctx, `
+		SELECT COALESCE(poster_path, '')
+		FROM media_items
+		WHERE content_id = $1
+	`, contentID).Scan(&posterPath); err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return "", ErrItemNotFound
+		}
+		return "", fmt.Errorf("getting media item poster path: %w", err)
+	}
+	return posterPath, nil
+}
+
 // overviewMatchFloor is the minimum ts_rank_cd score an overview-only match
 // must achieve to be returned when no title FTS match exists in the candidate
 // set. The overview tsvector is built without setweight(), so PostgreSQL's

--- a/internal/catalog/item_repo.go
+++ b/internal/catalog/item_repo.go
@@ -35,24 +35,47 @@ func NewItemRepository(pool *pgxpool.Pool) *ItemRepository {
 	return &ItemRepository{pool: pool}
 }
 
-// GetPosterPath returns the current poster path for a media item. Missing or
-// NULL poster values are returned as an empty string.
-func (r *ItemRepository) GetPosterPath(ctx context.Context, contentID string) (string, error) {
+// GetPoster returns the current poster path and thumbhash for a media item.
+// Missing or NULL values are returned as empty strings.
+func (r *ItemRepository) GetPoster(ctx context.Context, contentID string) (posterPath string, posterThumbhash string, err error) {
 	if r == nil || r.pool == nil {
-		return "", ErrItemNotFound
+		return "", "", ErrItemNotFound
 	}
-	var posterPath string
 	if err := r.pool.QueryRow(ctx, `
-		SELECT COALESCE(poster_path, '')
+		SELECT COALESCE(poster_path, ''), COALESCE(poster_thumbhash, '')
 		FROM media_items
 		WHERE content_id = $1
-	`, contentID).Scan(&posterPath); err != nil {
+	`, contentID).Scan(&posterPath, &posterThumbhash); err != nil {
 		if errors.Is(err, pgx.ErrNoRows) {
-			return "", ErrItemNotFound
+			return "", "", ErrItemNotFound
 		}
-		return "", fmt.Errorf("getting media item poster path: %w", err)
+		return "", "", fmt.Errorf("getting media item poster: %w", err)
 	}
-	return posterPath, nil
+	return posterPath, posterThumbhash, nil
+}
+
+// SetLocalPoster records a locally extracted poster without ever overwriting
+// provider or manually applied artwork: the row is updated only when the item
+// has no poster yet or its current poster lives under localPrefix. The
+// condition is evaluated atomically in SQL so concurrent metadata writers
+// (e.g. the ebook enrichment sweep) cannot be clobbered between a read and a
+// write. Returns true when a row was updated.
+func (r *ItemRepository) SetLocalPoster(ctx context.Context, contentID, posterPath, thumbhash, localPrefix string) (bool, error) {
+	if r == nil || r.pool == nil {
+		return false, ErrItemNotFound
+	}
+	tag, err := r.pool.Exec(ctx, `
+		UPDATE media_items
+		SET poster_path = $2,
+		    poster_thumbhash = NULLIF($3, ''),
+		    updated_at = NOW()
+		WHERE content_id = $1
+		  AND (poster_path IS NULL OR poster_path = '' OR poster_path LIKE $4 || '%')
+	`, contentID, posterPath, thumbhash, localPrefix)
+	if err != nil {
+		return false, fmt.Errorf("setting local poster: %w", err)
+	}
+	return tag.RowsAffected() > 0, nil
 }
 
 // overviewMatchFloor is the minimum ts_rank_cd score an overview-only match

--- a/internal/scanner/ebook.go
+++ b/internal/scanner/ebook.go
@@ -8,7 +8,9 @@ import (
 	"html"
 	"io"
 	"os"
+	"path"
 	"path/filepath"
+	"sort"
 	"strconv"
 	"strings"
 	"time"
@@ -319,6 +321,9 @@ func parseEbookEPUB(path string) (parsedEbook, error) {
 	if err := parseEPUBOPFMetadata(opf, &book); err != nil {
 		return book, err
 	}
+	if cover, err := extractEPUBCover(&reader.Reader, opfPath, opf); err == nil {
+		book.Cover = cover
+	}
 	return book, nil
 }
 
@@ -364,16 +369,26 @@ func parseEbookCBZ(path string) (parsedEbook, error) {
 	}
 	defer reader.Close()
 
+	var pages []*zip.File
 	for _, file := range reader.File {
 		if isComicArchivePage(file.Name) {
 			book.PageCount++
+			pages = append(pages, file)
+		}
+	}
+	sort.Slice(pages, func(i, j int) bool {
+		return normalizedArchivePath(pages[i].Name) < normalizedArchivePath(pages[j].Name)
+	})
+	if len(pages) > 0 {
+		if cover, err := readArchiveImageCover(pages[0]); err == nil {
+			book.Cover = cover
 		}
 	}
 	return book, nil
 }
 
 func isComicArchivePage(name string) bool {
-	clean := strings.TrimSpace(strings.ReplaceAll(name, "\\", "/"))
+	clean := normalizedArchivePath(name)
 	if clean == "" || strings.HasSuffix(clean, "/") {
 		return false
 	}
@@ -393,6 +408,38 @@ func isComicArchivePage(name string) bool {
 	default:
 		return false
 	}
+}
+
+func normalizedArchivePath(name string) string {
+	return strings.TrimSpace(strings.ReplaceAll(name, "\\", "/"))
+}
+
+func readArchiveImageCover(file *zip.File) (*parsedEbookCover, error) {
+	if file == nil {
+		return nil, fmt.Errorf("nil archive image")
+	}
+	if file.UncompressedSize64 > maxEPUBMetadataEntrySize {
+		return nil, fmt.Errorf("archive cover entry too large: %s", file.Name)
+	}
+	entry, err := file.Open()
+	if err != nil {
+		return nil, err
+	}
+	defer entry.Close()
+	data, err := io.ReadAll(io.LimitReader(entry, maxEPUBMetadataEntrySize+1))
+	if err != nil {
+		return nil, err
+	}
+	if len(data) > maxEPUBMetadataEntrySize {
+		return nil, fmt.Errorf("archive cover entry too large: %s", file.Name)
+	}
+	if len(data) == 0 {
+		return nil, fmt.Errorf("archive cover entry empty: %s", file.Name)
+	}
+	return &parsedEbookCover{
+		ContentType: ebookImageContentType(file.Name),
+		Bytes:       data,
+	}, nil
 }
 
 func parseEbookFB2Reader(reader io.Reader, format string) (parsedEbook, error) {
@@ -666,6 +713,132 @@ func parseEPUBOPFMetadata(opf []byte, book *parsedEbook) error {
 		}
 	}
 	return nil
+}
+
+func extractEPUBCover(reader *zip.Reader, opfPath string, opf []byte) (*parsedEbookCover, error) {
+	var parsed struct {
+		Metadata struct {
+			Meta []struct {
+				Name    string `xml:"name,attr"`
+				Content string `xml:"content,attr"`
+			} `xml:"meta"`
+		} `xml:"metadata"`
+		Manifest struct {
+			Items []struct {
+				ID         string `xml:"id,attr"`
+				Href       string `xml:"href,attr"`
+				MediaType  string `xml:"media-type,attr"`
+				Properties string `xml:"properties,attr"`
+			} `xml:"item"`
+		} `xml:"manifest"`
+	}
+	if err := xml.Unmarshal(opf, &parsed); err != nil {
+		return nil, err
+	}
+
+	coverID := ""
+	for _, meta := range parsed.Metadata.Meta {
+		if strings.EqualFold(strings.TrimSpace(meta.Name), "cover") {
+			coverID = strings.TrimSpace(meta.Content)
+			break
+		}
+	}
+
+	var coverHref string
+	var coverType string
+	for _, item := range parsed.Manifest.Items {
+		id := strings.TrimSpace(item.ID)
+		props := strings.Fields(strings.ToLower(item.Properties))
+		isCover := coverID != "" && id == coverID
+		for _, prop := range props {
+			if prop == "cover-image" {
+				isCover = true
+				break
+			}
+		}
+		if !isCover {
+			continue
+		}
+		coverHref = strings.TrimSpace(item.Href)
+		coverType = strings.TrimSpace(item.MediaType)
+		break
+	}
+	if coverHref == "" {
+		return nil, fmt.Errorf("epub cover not referenced")
+	}
+
+	coverPath := resolveEPUBRelativePath(opfPath, coverHref)
+	data, err := readEPUBZipEntry(reader, coverPath)
+	if err != nil {
+		return nil, err
+	}
+	if coverType == "" {
+		coverType = ebookImageContentType(coverPath)
+	}
+	return &parsedEbookCover{ContentType: coverType, Bytes: data}, nil
+}
+
+func resolveEPUBRelativePath(baseFile string, href string) string {
+	cleanHref := strings.TrimSpace(href)
+	if decoded, err := urlPathUnescape(cleanHref); err == nil {
+		cleanHref = decoded
+	}
+	baseDir := path.Dir(strings.ReplaceAll(baseFile, "\\", "/"))
+	if baseDir == "." || strings.HasPrefix(cleanHref, "/") {
+		baseDir = ""
+	}
+	return strings.TrimPrefix(path.Clean(path.Join(baseDir, cleanHref)), "/")
+}
+
+func urlPathUnescape(value string) (string, error) {
+	var out strings.Builder
+	for i := 0; i < len(value); i++ {
+		if value[i] != '%' || i+2 >= len(value) {
+			out.WriteByte(value[i])
+			continue
+		}
+		hi := fromHex(value[i+1])
+		lo := fromHex(value[i+2])
+		if hi < 0 || lo < 0 {
+			out.WriteByte(value[i])
+			continue
+		}
+		out.WriteByte(byte(hi<<4 | lo))
+		i += 2
+	}
+	return out.String(), nil
+}
+
+func fromHex(b byte) int {
+	switch {
+	case b >= '0' && b <= '9':
+		return int(b - '0')
+	case b >= 'a' && b <= 'f':
+		return int(b-'a') + 10
+	case b >= 'A' && b <= 'F':
+		return int(b-'A') + 10
+	default:
+		return -1
+	}
+}
+
+func ebookImageContentType(name string) string {
+	switch strings.ToLower(filepath.Ext(name)) {
+	case ".jpg", ".jpeg":
+		return "image/jpeg"
+	case ".png":
+		return "image/png"
+	case ".webp":
+		return "image/webp"
+	case ".gif":
+		return "image/gif"
+	case ".avif":
+		return "image/avif"
+	case ".bmp":
+		return "image/bmp"
+	default:
+		return "application/octet-stream"
+	}
 }
 
 func parseEbookDate(value string) (time.Time, bool) {

--- a/internal/scanner/ebook.go
+++ b/internal/scanner/ebook.go
@@ -16,6 +16,9 @@ import (
 	"time"
 
 	xhtml "golang.org/x/net/html"
+	"golang.org/x/text/encoding"
+	"golang.org/x/text/encoding/charmap"
+	textunicode "golang.org/x/text/encoding/unicode"
 )
 
 const maxEPUBMetadataEntrySize = 8 * 1024 * 1024
@@ -525,28 +528,70 @@ func parsePDFInfoFields(data []byte) map[string]string {
 	return fields
 }
 
+func decodeEbookXML(data []byte, v any) error {
+	data = normalizeEbookXMLVersion(data)
+	decoder := xml.NewDecoder(bytes.NewReader(data))
+	decoder.CharsetReader = ebookXMLCharsetReader
+	return decoder.Decode(v)
+}
+
+func normalizeEbookXMLVersion(data []byte) []byte {
+	for _, needle := range []string{`version="1.1"`, `version='1.1'`} {
+		idx := bytes.Index(data, []byte(needle))
+		if idx < 0 || idx > 128 {
+			continue
+		}
+		out := append([]byte(nil), data...)
+		copy(out[idx:], strings.Replace(needle, "1.1", "1.0", 1))
+		return out
+	}
+	return data
+}
+
+func ebookXMLCharsetReader(charset string, input io.Reader) (io.Reader, error) {
+	name := strings.ToLower(strings.TrimSpace(charset))
+	var enc encoding.Encoding
+	switch name {
+	case "", "utf-8", "utf8":
+		return input, nil
+	case "iso-8859-1", "latin1", "latin-1":
+		enc = charmap.ISO8859_1
+	case "windows-1252", "cp1252":
+		enc = charmap.Windows1252
+	case "utf-16", "utf16":
+		enc = textunicode.UTF16(textunicode.BigEndian, textunicode.ExpectBOM)
+	case "utf-16be", "utf16be":
+		enc = textunicode.UTF16(textunicode.BigEndian, textunicode.IgnoreBOM)
+	case "utf-16le", "utf16le":
+		enc = textunicode.UTF16(textunicode.LittleEndian, textunicode.IgnoreBOM)
+	default:
+		return nil, fmt.Errorf("unsupported ebook XML encoding %q", charset)
+	}
+	return enc.NewDecoder().Reader(input), nil
+}
+
 func readPDFLiteralString(data []byte) (string, bool) {
 	if len(data) == 0 || data[0] != '(' {
 		return "", false
 	}
-	var out strings.Builder
+	var out []byte
 	depth := 1
 	escaped := false
 	for _, b := range data[1:] {
 		if escaped {
 			switch b {
 			case 'n':
-				out.WriteByte('\n')
+				out = append(out, '\n')
 			case 'r':
-				out.WriteByte('\r')
+				out = append(out, '\r')
 			case 't':
-				out.WriteByte('\t')
+				out = append(out, '\t')
 			case 'b':
-				out.WriteByte('\b')
+				out = append(out, '\b')
 			case 'f':
-				out.WriteByte('\f')
+				out = append(out, '\f')
 			default:
-				out.WriteByte(b)
+				out = append(out, b)
 			}
 			escaped = false
 			continue
@@ -556,18 +601,38 @@ func readPDFLiteralString(data []byte) (string, bool) {
 			escaped = true
 		case '(':
 			depth++
-			out.WriteByte(b)
+			out = append(out, b)
 		case ')':
 			depth--
 			if depth == 0 {
-				return strings.TrimSpace(out.String()), true
+				return strings.TrimSpace(decodePDFLiteralBytes(out)), true
 			}
-			out.WriteByte(b)
+			out = append(out, b)
 		default:
-			out.WriteByte(b)
+			out = append(out, b)
 		}
 	}
 	return "", false
+}
+
+func decodePDFLiteralBytes(data []byte) string {
+	if len(data) == 0 {
+		return ""
+	}
+	switch {
+	case bytes.HasPrefix(data, []byte{0xfe, 0xff}):
+		if decoded, err := textunicode.UTF16(textunicode.BigEndian, textunicode.ExpectBOM).NewDecoder().Bytes(data); err == nil {
+			return string(decoded)
+		}
+	case bytes.HasPrefix(data, []byte{0xff, 0xfe}):
+		if decoded, err := textunicode.UTF16(textunicode.LittleEndian, textunicode.ExpectBOM).NewDecoder().Bytes(data); err == nil {
+			return string(decoded)
+		}
+	}
+	if decoded, err := charmap.Windows1252.NewDecoder().Bytes(data); err == nil {
+		return string(decoded)
+	}
+	return strings.ToValidUTF8(string(data), "")
 }
 
 func splitEbookAuthors(value string) []string {
@@ -646,7 +711,7 @@ func epubOPFPath(container []byte) (string, error) {
 			FullPath string `xml:"full-path,attr"`
 		} `xml:"rootfiles>rootfile"`
 	}
-	if err := xml.Unmarshal(container, &parsed); err != nil {
+	if err := decodeEbookXML(container, &parsed); err != nil {
 		return "", err
 	}
 	for _, rootfile := range parsed.Rootfiles {
@@ -676,7 +741,7 @@ func parseEPUBOPFMetadata(opf []byte, book *parsedEbook) error {
 			} `xml:"meta"`
 		} `xml:"metadata"`
 	}
-	if err := xml.Unmarshal(opf, &parsed); err != nil {
+	if err := decodeEbookXML(opf, &parsed); err != nil {
 		return err
 	}
 	book.Title = firstNonEmpty(parsed.Metadata.Titles...)
@@ -732,7 +797,7 @@ func extractEPUBCover(reader *zip.Reader, opfPath string, opf []byte) (*parsedEb
 			} `xml:"item"`
 		} `xml:"manifest"`
 	}
-	if err := xml.Unmarshal(opf, &parsed); err != nil {
+	if err := decodeEbookXML(opf, &parsed); err != nil {
 		return nil, err
 	}
 

--- a/internal/scanner/ebook.go
+++ b/internal/scanner/ebook.go
@@ -3,6 +3,7 @@ package scanner
 import (
 	"archive/zip"
 	"bytes"
+	"encoding/hex"
 	"encoding/xml"
 	"fmt"
 	"html"
@@ -517,10 +518,10 @@ func parsePDFInfoFields(data []byte) map[string]string {
 			continue
 		}
 		rest := bytes.TrimLeft(data[idx+len(token):], " \t\r\n")
-		if len(rest) == 0 || rest[0] != '(' {
+		if len(rest) == 0 {
 			continue
 		}
-		value, ok := readPDFLiteralString(rest)
+		value, ok := readPDFString(rest)
 		if ok {
 			fields[key] = value
 		}
@@ -570,6 +571,20 @@ func ebookXMLCharsetReader(charset string, input io.Reader) (io.Reader, error) {
 	return enc.NewDecoder().Reader(input), nil
 }
 
+func readPDFString(data []byte) (string, bool) {
+	switch data[0] {
+	case '(':
+		return readPDFLiteralString(data)
+	case '<':
+		if len(data) > 1 && data[1] == '<' {
+			return "", false
+		}
+		return readPDFHexString(data)
+	default:
+		return "", false
+	}
+}
+
 func readPDFLiteralString(data []byte) (string, bool) {
 	if len(data) == 0 || data[0] != '(' {
 		return "", false
@@ -613,6 +628,36 @@ func readPDFLiteralString(data []byte) (string, bool) {
 		}
 	}
 	return "", false
+}
+
+func readPDFHexString(data []byte) (string, bool) {
+	if len(data) == 0 || data[0] != '<' {
+		return "", false
+	}
+	end := bytes.IndexByte(data[1:], '>')
+	if end < 0 {
+		return "", false
+	}
+	raw := data[1 : end+1]
+	var cleaned []byte
+	for _, b := range raw {
+		switch {
+		case b == ' ' || b == '\t' || b == '\r' || b == '\n':
+			continue
+		case (b >= '0' && b <= '9') || (b >= 'a' && b <= 'f') || (b >= 'A' && b <= 'F'):
+			cleaned = append(cleaned, b)
+		default:
+			return "", false
+		}
+	}
+	if len(cleaned)%2 == 1 {
+		cleaned = append(cleaned, '0')
+	}
+	decoded := make([]byte, hex.DecodedLen(len(cleaned)))
+	if _, err := hex.Decode(decoded, cleaned); err != nil {
+		return "", false
+	}
+	return strings.TrimSpace(decodePDFLiteralBytes(decoded)), true
 }
 
 func decodePDFLiteralBytes(data []byte) string {
@@ -665,17 +710,17 @@ func parsePDFDate(value string) (time.Time, bool) {
 	}
 	value = strings.TrimSuffix(value, "Z")
 	if len(value) >= 14 {
-		if t, err := time.Parse("20060102150405", value[:14]); err == nil {
+		if t, err := time.Parse("20060102150405", value[:14]); err == nil && t.Year() > 0 {
 			return t, true
 		}
 	}
 	if len(value) >= 8 {
-		if t, err := time.Parse("20060102", value[:8]); err == nil {
+		if t, err := time.Parse("20060102", value[:8]); err == nil && t.Year() > 0 {
 			return t, true
 		}
 	}
 	if len(value) >= 4 {
-		if t, err := time.Parse("2006", value[:4]); err == nil {
+		if t, err := time.Parse("2006", value[:4]); err == nil && t.Year() > 0 {
 			return t, true
 		}
 	}

--- a/internal/scanner/ebook.go
+++ b/internal/scanner/ebook.go
@@ -11,13 +11,14 @@ import (
 	"os"
 	"path"
 	"path/filepath"
-	"sort"
 	"strconv"
 	"strings"
 	"time"
+	"unicode"
+	"unicode/utf8"
 
 	xhtml "golang.org/x/net/html"
-	"golang.org/x/text/encoding"
+	"golang.org/x/net/html/charset"
 	"golang.org/x/text/encoding/charmap"
 	textunicode "golang.org/x/text/encoding/unicode"
 )
@@ -373,22 +374,67 @@ func parseEbookCBZ(path string) (parsedEbook, error) {
 	}
 	defer reader.Close()
 
-	var pages []*zip.File
+	var coverPage *zip.File
+	var coverKey string
 	for _, file := range reader.File {
-		if isComicArchivePage(file.Name) {
-			book.PageCount++
-			pages = append(pages, file)
+		if !isComicArchivePage(file.Name) {
+			continue
+		}
+		book.PageCount++
+		key := normalizedArchivePath(file.Name)
+		if coverPage == nil || naturalPathLess(key, coverKey) {
+			coverPage, coverKey = file, key
 		}
 	}
-	sort.Slice(pages, func(i, j int) bool {
-		return normalizedArchivePath(pages[i].Name) < normalizedArchivePath(pages[j].Name)
-	})
-	if len(pages) > 0 {
-		if cover, err := readArchiveImageCover(pages[0]); err == nil {
+	if coverPage != nil {
+		if cover, err := readArchiveImageCover(coverPage); err == nil {
 			book.Cover = cover
 		}
 	}
 	return book, nil
+}
+
+// naturalPathLess orders archive entry names case-insensitively with digit
+// runs compared numerically, so unpadded page numbers ("2.jpg" before
+// "10.jpg") and chapter directories ("ch2/" before "ch10/") sort in reading
+// order instead of byte order.
+func naturalPathLess(a, b string) bool {
+	for len(a) > 0 && len(b) > 0 {
+		if isASCIIDigit(a[0]) && isASCIIDigit(b[0]) {
+			aRun, aRest := splitDigitRun(a)
+			bRun, bRest := splitDigitRun(b)
+			aNum := strings.TrimLeft(aRun, "0")
+			bNum := strings.TrimLeft(bRun, "0")
+			if len(aNum) != len(bNum) {
+				return len(aNum) < len(bNum)
+			}
+			if aNum != bNum {
+				return aNum < bNum
+			}
+			a, b = aRest, bRest
+			continue
+		}
+		ar, aSize := utf8.DecodeRuneInString(a)
+		br, bSize := utf8.DecodeRuneInString(b)
+		al, bl := unicode.ToLower(ar), unicode.ToLower(br)
+		if al != bl {
+			return al < bl
+		}
+		a, b = a[aSize:], b[bSize:]
+	}
+	return len(a) < len(b)
+}
+
+func isASCIIDigit(b byte) bool {
+	return b >= '0' && b <= '9'
+}
+
+func splitDigitRun(s string) (run string, rest string) {
+	i := 0
+	for i < len(s) && isASCIIDigit(s[i]) {
+		i++
+	}
+	return s[:i], s[i:]
 }
 
 func isComicArchivePage(name string) bool {
@@ -476,7 +522,9 @@ func parseEbookFB2Reader(reader io.Reader, format string) (parsedEbook, error) {
 			} `xml:"publish-info"`
 		} `xml:"description"`
 	}
-	if err := xml.NewDecoder(reader).Decode(&fb2); err != nil {
+	decoder := xml.NewDecoder(reader)
+	decoder.CharsetReader = ebookXMLCharsetReader
+	if err := decoder.Decode(&fb2); err != nil {
 		return book, err
 	}
 
@@ -549,26 +597,16 @@ func normalizeEbookXMLVersion(data []byte) []byte {
 	return data
 }
 
-func ebookXMLCharsetReader(charset string, input io.Reader) (io.Reader, error) {
-	name := strings.ToLower(strings.TrimSpace(charset))
-	var enc encoding.Encoding
-	switch name {
-	case "", "utf-8", "utf8":
+func ebookXMLCharsetReader(label string, input io.Reader) (io.Reader, error) {
+	name := strings.ToLower(strings.TrimSpace(label))
+	if name == "" || name == "utf-8" || name == "utf8" {
 		return input, nil
-	case "iso-8859-1", "latin1", "latin-1":
-		enc = charmap.ISO8859_1
-	case "windows-1252", "cp1252":
-		enc = charmap.Windows1252
-	case "utf-16", "utf16":
-		enc = textunicode.UTF16(textunicode.BigEndian, textunicode.ExpectBOM)
-	case "utf-16be", "utf16be":
-		enc = textunicode.UTF16(textunicode.BigEndian, textunicode.IgnoreBOM)
-	case "utf-16le", "utf16le":
-		enc = textunicode.UTF16(textunicode.LittleEndian, textunicode.IgnoreBOM)
-	default:
-		return nil, fmt.Errorf("unsupported ebook XML encoding %q", charset)
 	}
-	return enc.NewDecoder().Reader(input), nil
+	reader, err := charset.NewReaderLabel(name, input)
+	if err != nil {
+		return nil, fmt.Errorf("unsupported ebook XML encoding %q: %w", label, err)
+	}
+	return reader, nil
 }
 
 func readPDFString(data []byte) (string, bool) {
@@ -673,6 +711,14 @@ func decodePDFLiteralBytes(data []byte) string {
 		if decoded, err := textunicode.UTF16(textunicode.LittleEndian, textunicode.ExpectBOM).NewDecoder().Bytes(data); err == nil {
 			return string(decoded)
 		}
+	}
+	// The PDF spec says non-UTF-16 strings are PDFDocEncoding, but real-world
+	// producers commonly emit UTF-8 (PDF 2.0 even allows a UTF-8 BOM). Only
+	// fall back to the Windows-1252 approximation for non-UTF-8 bytes so
+	// UTF-8 metadata is not mojibaked.
+	data = bytes.TrimPrefix(data, []byte{0xef, 0xbb, 0xbf})
+	if utf8.Valid(data) {
+		return string(data)
 	}
 	if decoded, err := charmap.Windows1252.NewDecoder().Bytes(data); err == nil {
 		return string(decoded)
@@ -854,24 +900,33 @@ func extractEPUBCover(reader *zip.Reader, opfPath string, opf []byte) (*parsedEb
 		}
 	}
 
+	// An EPUB3 properties="cover-image" item is authoritative; the EPUB2
+	// <meta name="cover"> id frequently points at the XHTML cover *page*
+	// rather than the image, so it ranks lower and non-image manifest items
+	// are skipped entirely instead of shadowing a later real cover image.
 	var coverHref string
 	var coverType string
+	coverRank := 0
 	for _, item := range parsed.Manifest.Items {
-		id := strings.TrimSpace(item.ID)
-		props := strings.Fields(strings.ToLower(item.Properties))
-		isCover := coverID != "" && id == coverID
-		for _, prop := range props {
+		rank := 0
+		for _, prop := range strings.Fields(strings.ToLower(item.Properties)) {
 			if prop == "cover-image" {
-				isCover = true
+				rank = 2
 				break
 			}
 		}
-		if !isCover {
+		if rank == 0 && coverID != "" && strings.TrimSpace(item.ID) == coverID {
+			rank = 1
+		}
+		if rank <= coverRank || !isEPUBImageManifestItem(item.MediaType, item.Href) {
 			continue
 		}
 		coverHref = strings.TrimSpace(item.Href)
 		coverType = strings.TrimSpace(item.MediaType)
-		break
+		coverRank = rank
+		if coverRank == 2 {
+			break
+		}
 	}
 	if coverHref == "" {
 		return nil, fmt.Errorf("epub cover not referenced")
@@ -886,6 +941,14 @@ func extractEPUBCover(reader *zip.Reader, opfPath string, opf []byte) (*parsedEb
 		coverType = ebookImageContentType(coverPath)
 	}
 	return &parsedEbookCover{ContentType: coverType, Bytes: data}, nil
+}
+
+func isEPUBImageManifestItem(mediaType, href string) bool {
+	mt := strings.ToLower(strings.TrimSpace(mediaType))
+	if mt != "" {
+		return strings.HasPrefix(mt, "image/")
+	}
+	return ebookImageContentType(href) != "application/octet-stream"
 }
 
 func resolveEPUBRelativePath(baseFile string, href string) string {

--- a/internal/scanner/ebook_scan.go
+++ b/internal/scanner/ebook_scan.go
@@ -9,11 +9,13 @@ import (
 	"log/slog"
 	"os"
 	"path/filepath"
+	"sort"
 	"strconv"
 	"strings"
 	"sync"
 	"sync/atomic"
 	"time"
+	"unicode"
 
 	"github.com/Silo-Server/silo-server/internal/catalog"
 	"github.com/Silo-Server/silo-server/internal/idgen"
@@ -90,6 +92,7 @@ func (s *Scanner) scanEbookPaths(ctx context.Context, folder *models.MediaFolder
 	reportEbookScanProgress(ctx, folder.ID, len(candidates), 0, 0, 0)
 
 	ch := make(chan string, workers*2)
+	groupLocks := newEbookGroupLocks()
 	var (
 		wg        sync.WaitGroup
 		processed int64
@@ -108,7 +111,7 @@ func (s *Scanner) scanEbookPaths(ctx context.Context, folder *models.MediaFolder
 				if ctx.Err() != nil {
 					return
 				}
-				if err := s.reconcileEbookFile(ctx, folder, path, &skipped); err != nil {
+				if err := s.reconcileEbookFile(ctx, folder, path, &skipped, groupLocks); err != nil {
 					if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
 						failMu.Lock()
 						if cancelErr == nil {
@@ -193,7 +196,7 @@ func reportEbookScanProgress(ctx context.Context, folderID int, total, processed
 	})
 }
 
-func (s *Scanner) reconcileEbookFile(ctx context.Context, folder *models.MediaFolder, filePath string, skipped *int64) error {
+func (s *Scanner) reconcileEbookFile(ctx context.Context, folder *models.MediaFolder, filePath string, skipped *int64, groupLocks *ebookGroupLocks) error {
 	info, err := os.Stat(filePath)
 	if err != nil {
 		if errors.Is(err, os.ErrNotExist) {
@@ -223,6 +226,9 @@ func (s *Scanner) reconcileEbookFile(ctx context.Context, folder *models.MediaFo
 	if parsed.Title == "" {
 		parsed.Title = strings.TrimSuffix(filepath.Base(filePath), filepath.Ext(filePath))
 	}
+
+	unlock := groupLocks.lock(ebookContentGroupKey(&parsed, filePath))
+	defer unlock()
 
 	contentID, err := s.upsertEbookMediaItem(ctx, folder.ID, filePath, &parsed)
 	if err != nil {
@@ -315,6 +321,16 @@ func (s *Scanner) upsertEbookMediaItem(ctx context.Context, folderID int, filePa
 		return existingID, nil
 	}
 	if existing := s.findEbookByFilePath(ctx, filePath); existing != nil {
+		applyEbookToMediaItem(existing, book)
+		if existing.SortTitle == "" {
+			existing.SortTitle = titleutil.DeriveDefaultSortTitle(existing.Title)
+		}
+		if err := s.itemRepo.Upsert(ctx, existing); err != nil {
+			return "", err
+		}
+		return existing.ContentID, nil
+	}
+	if existing := s.findEbookByContentGroupKey(ctx, folderID, ebookContentGroupKey(book, filePath)); existing != nil {
 		applyEbookToMediaItem(existing, book)
 		if existing.SortTitle == "" {
 			existing.SortTitle = titleutil.DeriveDefaultSortTitle(existing.Title)
@@ -449,6 +465,34 @@ func (s *Scanner) findEbookByFilePath(ctx context.Context, filePath string) *mod
 	return items[0]
 }
 
+func (s *Scanner) findEbookByContentGroupKey(ctx context.Context, folderID int, groupKey string) *models.MediaItem {
+	if s.fileRepo == nil || s.itemRepo == nil || strings.TrimSpace(groupKey) == "" {
+		return nil
+	}
+	var existingID string
+	err := s.fileRepo.Pool().QueryRow(ctx, `
+		SELECT mf.content_id
+		FROM media_files mf
+		JOIN media_items mi ON mi.content_id = mf.content_id
+		WHERE mf.media_folder_id = $1
+		  AND mf.group_key_version = 1
+		  AND mf.content_group_key = $2
+		  AND mf.missing_since IS NULL
+		  AND mi.type = 'ebook'
+		ORDER BY CASE WHEN lower(trim(mi.status)) = 'matched' THEN 0 ELSE 1 END,
+		         mf.id ASC
+		LIMIT 1
+	`, folderID, groupKey).Scan(&existingID)
+	if err != nil || existingID == "" {
+		return nil
+	}
+	items, err := s.itemRepo.GetByIDs(ctx, []string{existingID})
+	if err != nil || len(items) == 0 {
+		return nil
+	}
+	return items[0]
+}
+
 func (s *Scanner) upsertEbookMediaFile(ctx context.Context, folder *models.MediaFolder, contentID string, filePath string, size int64, modifiedAt time.Time, book *parsedEbook) error {
 	mf := buildEbookMediaFile(folder, contentID, filePath, size, modifiedAt, book)
 	if _, err := s.fileRepo.Upsert(ctx, mf); err != nil {
@@ -463,7 +507,7 @@ func buildEbookMediaFile(folder *models.MediaFolder, contentID string, filePath 
 		MediaFolderID:      folder.ID,
 		CanonicalRootPath:  filePath,
 		ObservedRootPath:   filePath,
-		ContentGroupKey:    contentID,
+		ContentGroupKey:    ebookContentGroupKey(book, filePath),
 		GroupKeyVersion:    1,
 		BaseTitle:          book.Title,
 		BaseYear:           book.Year,
@@ -476,6 +520,112 @@ func buildEbookMediaFile(folder *models.MediaFolder, contentID string, filePath 
 		Duration:           book.PageCount,
 		ProbeSource:        "local",
 	}
+}
+
+func ebookContentGroupKey(book *parsedEbook, filePath string) string {
+	if book != nil {
+		if isbn := normalizeEbookISBN(book.ISBN); isbn != "" {
+			return "ebook:isbn:" + isbn
+		}
+	}
+
+	title := ""
+	authors := []string(nil)
+	if book != nil {
+		title = strings.TrimSpace(book.Title)
+		authors = book.Authors
+	}
+	if title == "" {
+		title = ebookTitleFromPath(filePath)
+	}
+	normalizedTitle := normalizeEbookIdentityPart(title)
+	if normalizedTitle == "" {
+		cleanPath := strings.TrimSpace(filepath.Clean(filePath))
+		if cleanPath == "." {
+			return ""
+		}
+		return "ebook:path:" + cleanPath
+	}
+
+	normalizedAuthors := make([]string, 0, len(authors))
+	seenAuthors := make(map[string]struct{}, len(authors))
+	for _, author := range authors {
+		normalized := normalizeEbookIdentityPart(author)
+		if normalized == "" {
+			continue
+		}
+		if _, ok := seenAuthors[normalized]; ok {
+			continue
+		}
+		seenAuthors[normalized] = struct{}{}
+		normalizedAuthors = append(normalizedAuthors, normalized)
+	}
+	sort.Strings(normalizedAuthors)
+	if len(normalizedAuthors) > 0 {
+		return "ebook:title_author:" + normalizedTitle + "|" + strings.Join(normalizedAuthors, ",")
+	}
+
+	dir := strings.TrimSpace(filepath.Clean(filepath.Dir(filePath)))
+	if dir == "." {
+		dir = ""
+	}
+	return "ebook:title:" + normalizedTitle + "|dir:" + normalizeEbookIdentityPart(dir)
+}
+
+func ebookTitleFromPath(filePath string) string {
+	base := filepath.Base(filePath)
+	if base == "." || base == string(filepath.Separator) {
+		return ""
+	}
+	if format := ebookFileFormat(base); format != "" {
+		return strings.TrimSuffix(base, format)
+	}
+	return strings.TrimSuffix(base, filepath.Ext(base))
+}
+
+func normalizeEbookIdentityPart(value string) string {
+	value = strings.ToLower(strings.TrimSpace(value))
+	var b strings.Builder
+	previousSpace := false
+	for _, r := range value {
+		if unicode.IsLetter(r) || unicode.IsDigit(r) {
+			b.WriteRune(r)
+			previousSpace = false
+			continue
+		}
+		if unicode.IsSpace(r) || r == '&' || r == '-' || r == '_' || r == ':' || r == '/' || r == '\\' || r == ',' || r == '.' {
+			if b.Len() > 0 && !previousSpace {
+				b.WriteByte(' ')
+				previousSpace = true
+			}
+		}
+	}
+	return strings.TrimSpace(b.String())
+}
+
+type ebookGroupLocks struct {
+	mu    sync.Mutex
+	locks map[string]*sync.Mutex
+}
+
+func newEbookGroupLocks() *ebookGroupLocks {
+	return &ebookGroupLocks{locks: make(map[string]*sync.Mutex)}
+}
+
+func (l *ebookGroupLocks) lock(key string) func() {
+	if l == nil || strings.TrimSpace(key) == "" {
+		return func() {}
+	}
+	l.mu.Lock()
+	groupLock := l.locks[key]
+	if groupLock == nil {
+		groupLock = &sync.Mutex{}
+		l.locks[key] = groupLock
+	}
+	l.mu.Unlock()
+
+	groupLock.Lock()
+	return groupLock.Unlock
 }
 
 type ebookCoverMetadataStore interface {

--- a/internal/scanner/ebook_scan.go
+++ b/internal/scanner/ebook_scan.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"io"
 	"io/fs"
 	"log/slog"
 	"os"
@@ -229,6 +230,14 @@ func (s *Scanner) reconcileEbookFile(ctx context.Context, folder *models.MediaFo
 	}
 	if err := s.upsertEbookMediaFile(ctx, folder, contentID, filePath, size, modifiedAt, &parsed); err != nil {
 		return fmt.Errorf("upsert ebook file: %w", err)
+	}
+	if err := applyEbookSidecarCover(ctx, s.itemRepo, s.imageCacher, contentID, filePath); err != nil {
+		slog.Warn("ebook scan: sidecar cover upload failed",
+			"folder_id", folder.ID,
+			"content_id", contentID,
+			"path", filePath,
+			"error", err,
+		)
 	}
 	if err := applyEbookEmbeddedCover(ctx, s.itemRepo, s.imageCacher, contentID, &parsed); err != nil {
 		slog.Warn("ebook scan: embedded cover upload failed",
@@ -478,6 +487,24 @@ func applyEbookEmbeddedCover(ctx context.Context, store ebookCoverMetadataStore,
 	if store == nil || cacher == nil || contentID == "" || book == nil || book.Cover == nil || len(book.Cover.Bytes) == 0 {
 		return nil
 	}
+	return cacheEbookCoverBytes(ctx, store, cacher, contentID, book.Cover.Bytes)
+}
+
+func applyEbookSidecarCover(ctx context.Context, store ebookCoverMetadataStore, cacher ebookCoverCacher, contentID string, ebookFilePath string) error {
+	if store == nil || cacher == nil || contentID == "" || ebookFilePath == "" {
+		return nil
+	}
+	cover, _, err := findSidecarBookCover(filepath.Dir(ebookFilePath))
+	if err != nil || cover == nil {
+		return err
+	}
+	return cacheEbookCoverBytes(ctx, store, cacher, contentID, cover.Bytes)
+}
+
+func cacheEbookCoverBytes(ctx context.Context, store ebookCoverMetadataStore, cacher ebookCoverCacher, contentID string, data []byte) error {
+	if len(data) == 0 {
+		return nil
+	}
 	items, err := store.GetByIDs(ctx, []string{contentID})
 	if err != nil {
 		return fmt.Errorf("get ebook media item for cover: %w", err)
@@ -485,7 +512,7 @@ func applyEbookEmbeddedCover(ctx context.Context, store ebookCoverMetadataStore,
 	if len(items) > 0 && items[0] != nil && strings.TrimSpace(items[0].PosterPath) != "" {
 		return nil
 	}
-	basePath, ext, thumbhash, err := cacher.CacheEbookCover(ctx, book.Cover.Bytes, contentID)
+	basePath, ext, thumbhash, err := cacher.CacheEbookCover(ctx, data, contentID)
 	if err != nil {
 		return err
 	}
@@ -495,6 +522,69 @@ func applyEbookEmbeddedCover(ctx context.Context, store ebookCoverMetadataStore,
 		update.PosterThumbhash = &thumbhash
 	}
 	return store.UpdateMetadata(ctx, contentID, update)
+}
+
+var sidecarCoverNames = []string{"cover", "folder", "front", "poster", "thumbnail"}
+var sidecarCoverExtensions = []string{".jpg", ".jpeg", ".png", ".webp", ".avif", ".gif", ".bmp"}
+
+func findSidecarBookCover(dir string) (*parsedEbookCover, string, error) {
+	if dir == "" {
+		return nil, "", nil
+	}
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		return nil, "", err
+	}
+	byName := make(map[string]string, len(entries))
+	for _, entry := range entries {
+		if entry.IsDir() {
+			continue
+		}
+		byName[strings.ToLower(entry.Name())] = filepath.Join(dir, entry.Name())
+	}
+	for _, name := range sidecarCoverNames {
+		for _, ext := range sidecarCoverExtensions {
+			path := byName[name+ext]
+			if path == "" {
+				continue
+			}
+			data, err := readSidecarCover(path)
+			if err != nil {
+				return nil, path, err
+			}
+			return &parsedEbookCover{
+				ContentType: ebookImageContentType(path),
+				Bytes:       data,
+			}, path, nil
+		}
+	}
+	return nil, "", nil
+}
+
+func readSidecarCover(path string) ([]byte, error) {
+	file, err := os.Open(path)
+	if err != nil {
+		return nil, err
+	}
+	defer file.Close()
+	info, err := file.Stat()
+	if err != nil {
+		return nil, err
+	}
+	if info.Size() > maxEPUBMetadataEntrySize {
+		return nil, fmt.Errorf("sidecar cover too large: %s", path)
+	}
+	data, err := io.ReadAll(io.LimitReader(file, maxEPUBMetadataEntrySize+1))
+	if err != nil {
+		return nil, err
+	}
+	if len(data) > maxEPUBMetadataEntrySize {
+		return nil, fmt.Errorf("sidecar cover too large: %s", path)
+	}
+	if len(data) == 0 {
+		return nil, fmt.Errorf("sidecar cover empty: %s", path)
+	}
+	return data, nil
 }
 
 func insertEbookLibraryMembership(ctx context.Context, exec ebookSQLExecutor, contentID string, folderID int) error {

--- a/internal/scanner/ebook_scan.go
+++ b/internal/scanner/ebook_scan.go
@@ -479,7 +479,7 @@ func buildEbookMediaFile(folder *models.MediaFolder, contentID string, filePath 
 }
 
 type ebookCoverMetadataStore interface {
-	GetByIDs(ctx context.Context, ids []string) ([]*models.MediaItem, error)
+	GetPosterPath(ctx context.Context, contentID string) (string, error)
 	UpdateMetadata(ctx context.Context, contentID string, upd *catalog.MetadataUpdate) error
 }
 
@@ -505,11 +505,11 @@ func cacheEbookCoverBytes(ctx context.Context, store ebookCoverMetadataStore, ca
 	if len(data) == 0 {
 		return nil
 	}
-	items, err := store.GetByIDs(ctx, []string{contentID})
+	existingPosterPath, err := store.GetPosterPath(ctx, contentID)
 	if err != nil {
-		return fmt.Errorf("get ebook media item for cover: %w", err)
+		return fmt.Errorf("get ebook poster path for cover: %w", err)
 	}
-	if len(items) > 0 && items[0] != nil && strings.TrimSpace(items[0].PosterPath) != "" {
+	if strings.TrimSpace(existingPosterPath) != "" {
 		return nil
 	}
 	basePath, ext, thumbhash, err := cacher.CacheEbookCover(ctx, data, contentID)

--- a/internal/scanner/ebook_scan.go
+++ b/internal/scanner/ebook_scan.go
@@ -17,8 +17,8 @@ import (
 	"time"
 	"unicode"
 
-	"github.com/Silo-Server/silo-server/internal/catalog"
 	"github.com/Silo-Server/silo-server/internal/idgen"
+	"github.com/Silo-Server/silo-server/internal/imageutil"
 	"github.com/Silo-Server/silo-server/internal/models"
 	"github.com/Silo-Server/silo-server/internal/titleutil"
 	"github.com/jackc/pgx/v5"
@@ -224,29 +224,22 @@ func (s *Scanner) reconcileEbookFile(ctx context.Context, folder *models.MediaFo
 		return fmt.Errorf("parse ebook file %s: %w", filePath, err)
 	}
 	if parsed.Title == "" {
-		parsed.Title = strings.TrimSuffix(filepath.Base(filePath), filepath.Ext(filePath))
+		parsed.Title = ebookTitleFromPath(filePath)
 	}
 
-	unlock := groupLocks.lock(ebookContentGroupKey(&parsed, filePath))
+	groupKey := ebookContentGroupKey(&parsed, filePath)
+	unlock := groupLocks.lock(groupKey)
 	defer unlock()
 
-	contentID, err := s.upsertEbookMediaItem(ctx, folder.ID, filePath, &parsed)
+	contentID, err := s.upsertEbookMediaItem(ctx, folder.ID, filePath, &parsed, groupKey)
 	if err != nil {
 		return fmt.Errorf("upsert ebook item: %w", err)
 	}
-	if err := s.upsertEbookMediaFile(ctx, folder, contentID, filePath, size, modifiedAt, &parsed); err != nil {
+	if err := s.upsertEbookMediaFile(ctx, folder, contentID, filePath, size, modifiedAt, &parsed, groupKey); err != nil {
 		return fmt.Errorf("upsert ebook file: %w", err)
 	}
-	if err := applyEbookSidecarCover(ctx, s.itemRepo, s.imageCacher, contentID, filePath); err != nil {
-		slog.Warn("ebook scan: sidecar cover upload failed",
-			"folder_id", folder.ID,
-			"content_id", contentID,
-			"path", filePath,
-			"error", err,
-		)
-	}
-	if err := applyEbookEmbeddedCover(ctx, s.itemRepo, s.imageCacher, contentID, &parsed); err != nil {
-		slog.Warn("ebook scan: embedded cover upload failed",
+	if err := applyEbookLocalCover(ctx, s.itemRepo, s.imageCacher, contentID, filePath, &parsed); err != nil {
+		slog.Warn("ebook scan: local cover upload failed",
 			"folder_id", folder.ID,
 			"content_id", contentID,
 			"path", filePath,
@@ -295,6 +288,12 @@ func (s *Scanner) ebookFileShouldSkip(ctx context.Context, folder *models.MediaF
 	if mf.ContentID == "" {
 		return false, nil
 	}
+	if mf.GroupKeyVersion != ebookGroupKeyVersion {
+		// The grouping scheme changed since this row was written; reprocess
+		// once so the stored key is rewritten under the current scheme and
+		// sibling-format lookups can find it again.
+		return false, nil
+	}
 	statuses, err := s.itemRepo.GetStatusByIDs(ctx, []string{mf.ContentID})
 	if err != nil {
 		return false, fmt.Errorf("get item status: %w", err)
@@ -302,7 +301,7 @@ func (s *Scanner) ebookFileShouldSkip(ctx context.Context, folder *models.MediaF
 	return !strings.EqualFold(strings.TrimSpace(statuses[mf.ContentID]), "unmatched"), nil
 }
 
-func (s *Scanner) upsertEbookMediaItem(ctx context.Context, folderID int, filePath string, book *parsedEbook) (string, error) {
+func (s *Scanner) upsertEbookMediaItem(ctx context.Context, folderID int, filePath string, book *parsedEbook, groupKey string) (string, error) {
 	if s.itemRepo == nil {
 		return "", fmt.Errorf("itemRepo not configured on Scanner")
 	}
@@ -330,7 +329,13 @@ func (s *Scanner) upsertEbookMediaItem(ctx context.Context, folderID int, filePa
 		}
 		return existing.ContentID, nil
 	}
-	if existing := s.findEbookByContentGroupKey(ctx, folderID, ebookContentGroupKey(book, filePath)); existing != nil {
+	if existing := s.findEbookByContentGroupKey(ctx, folderID, groupKey, book.Format, filePath); existing != nil {
+		// The sibling file joins the group either way, but curated metadata
+		// on a provider-matched item must not be clobbered by whatever this
+		// file happens to embed.
+		if strings.EqualFold(strings.TrimSpace(existing.Status), "matched") {
+			return existing.ContentID, nil
+		}
 		applyEbookToMediaItem(existing, book)
 		if existing.SortTitle == "" {
 			existing.SortTitle = titleutil.DeriveDefaultSortTitle(existing.Title)
@@ -367,7 +372,7 @@ func resolveEbookMediaItem(
 
 	cleanTitle := strings.TrimSpace(book.Title)
 	if cleanTitle == "" {
-		cleanTitle = strings.TrimSuffix(filepath.Base(filePath), filepath.Ext(filePath))
+		cleanTitle = ebookTitleFromPath(filePath)
 	}
 	return createEbookMediaItem(ctx, itemWriter, book, cleanTitle)
 }
@@ -465,7 +470,13 @@ func (s *Scanner) findEbookByFilePath(ctx context.Context, filePath string) *mod
 	return items[0]
 }
 
-func (s *Scanner) findEbookByContentGroupKey(ctx context.Context, folderID int, groupKey string) *models.MediaItem {
+// findEbookByContentGroupKey locates an existing item that a sibling format of
+// the same book should join. Grouping merges *different* formats only: an item
+// that already owns another file of the same format is excluded, so two
+// distinct books whose sparse metadata collides on the same key (e.g. every
+// volume carrying the series name as its title) stay separate items instead of
+// silently merging.
+func (s *Scanner) findEbookByContentGroupKey(ctx context.Context, folderID int, groupKey string, format string, filePath string) *models.MediaItem {
 	if s.fileRepo == nil || s.itemRepo == nil || strings.TrimSpace(groupKey) == "" {
 		return nil
 	}
@@ -475,14 +486,21 @@ func (s *Scanner) findEbookByContentGroupKey(ctx context.Context, folderID int, 
 		FROM media_files mf
 		JOIN media_items mi ON mi.content_id = mf.content_id
 		WHERE mf.media_folder_id = $1
-		  AND mf.group_key_version = 1
-		  AND mf.content_group_key = $2
+		  AND mf.group_key_version = $2
+		  AND mf.content_group_key = $3
 		  AND mf.missing_since IS NULL
 		  AND mi.type = 'ebook'
+		  AND NOT EXISTS (
+			SELECT 1 FROM media_files dup
+			WHERE dup.content_id = mf.content_id
+			  AND dup.missing_since IS NULL
+			  AND lower(dup.container) = lower($4)
+			  AND dup.file_path <> $5
+		  )
 		ORDER BY CASE WHEN lower(trim(mi.status)) = 'matched' THEN 0 ELSE 1 END,
 		         mf.id ASC
 		LIMIT 1
-	`, folderID, groupKey).Scan(&existingID)
+	`, folderID, ebookGroupKeyVersion, groupKey, format, filePath).Scan(&existingID)
 	if err != nil || existingID == "" {
 		return nil
 	}
@@ -493,22 +511,28 @@ func (s *Scanner) findEbookByContentGroupKey(ctx context.Context, folderID int, 
 	return items[0]
 }
 
-func (s *Scanner) upsertEbookMediaFile(ctx context.Context, folder *models.MediaFolder, contentID string, filePath string, size int64, modifiedAt time.Time, book *parsedEbook) error {
-	mf := buildEbookMediaFile(folder, contentID, filePath, size, modifiedAt, book)
+// ebookGroupKeyVersion versions the ebookContentGroupKey scheme. Bump it
+// whenever the key shape changes so rows keyed under an older scheme are
+// reprocessed and re-keyed (see ebookFileShouldSkip) instead of silently never
+// matching sibling-format lookups again.
+const ebookGroupKeyVersion = 2
+
+func (s *Scanner) upsertEbookMediaFile(ctx context.Context, folder *models.MediaFolder, contentID string, filePath string, size int64, modifiedAt time.Time, book *parsedEbook, groupKey string) error {
+	mf := buildEbookMediaFile(folder, contentID, filePath, size, modifiedAt, book, groupKey)
 	if _, err := s.fileRepo.Upsert(ctx, mf); err != nil {
 		return fmt.Errorf("upsert media file %s: %w", filePath, err)
 	}
 	return nil
 }
 
-func buildEbookMediaFile(folder *models.MediaFolder, contentID string, filePath string, size int64, modifiedAt time.Time, book *parsedEbook) models.MediaFile {
+func buildEbookMediaFile(folder *models.MediaFolder, contentID string, filePath string, size int64, modifiedAt time.Time, book *parsedEbook, groupKey string) models.MediaFile {
 	return models.MediaFile{
 		ContentID:          contentID,
 		MediaFolderID:      folder.ID,
 		CanonicalRootPath:  filePath,
 		ObservedRootPath:   filePath,
-		ContentGroupKey:    ebookContentGroupKey(book, filePath),
-		GroupKeyVersion:    1,
+		ContentGroupKey:    groupKey,
+		GroupKeyVersion:    ebookGroupKeyVersion,
 		BaseTitle:          book.Title,
 		BaseYear:           book.Year,
 		BaseType:           "ebook",
@@ -577,8 +601,10 @@ func ebookTitleFromPath(filePath string) string {
 	if base == "." || base == string(filepath.Separator) {
 		return ""
 	}
-	if format := ebookFileFormat(base); format != "" {
-		return strings.TrimSuffix(base, format)
+	// ".fb2.zip" is a double extension that filepath.Ext (and the
+	// normalized ".fbz" format token) would leave half-stripped.
+	if strings.HasSuffix(strings.ToLower(base), ".fb2.zip") {
+		return base[:len(base)-len(".fb2.zip")]
 	}
 	return strings.TrimSuffix(base, filepath.Ext(base))
 }
@@ -628,85 +654,129 @@ func (l *ebookGroupLocks) lock(key string) func() {
 	return groupLock.Unlock
 }
 
+// localEbookPosterPrefix mirrors the storage layout produced by
+// imagecache.CacheEbookCover ("local/ebooks/{contentID}/poster/..."); it marks
+// posters this pipeline owns and is therefore allowed to refresh.
+const localEbookPosterPrefix = "local/ebooks/"
+
 type ebookCoverMetadataStore interface {
-	GetPosterPath(ctx context.Context, contentID string) (string, error)
-	UpdateMetadata(ctx context.Context, contentID string, upd *catalog.MetadataUpdate) error
+	GetPoster(ctx context.Context, contentID string) (posterPath string, posterThumbhash string, err error)
+	SetLocalPoster(ctx context.Context, contentID, posterPath, thumbhash, localPrefix string) (bool, error)
 }
 
-func applyEbookEmbeddedCover(ctx context.Context, store ebookCoverMetadataStore, cacher ebookCoverCacher, contentID string, book *parsedEbook) error {
-	if store == nil || cacher == nil || contentID == "" || book == nil || book.Cover == nil || len(book.Cover.Bytes) == 0 {
+// applyEbookLocalCover records the best locally available cover for the file:
+// a sidecar image that belongs to this book wins over the embedded cover, and
+// exactly one cover is applied per reconcile. A sidecar discovery error does
+// not block the embedded fallback.
+func applyEbookLocalCover(ctx context.Context, store ebookCoverMetadataStore, cacher ebookCoverCacher, contentID string, ebookFilePath string, book *parsedEbook) error {
+	if store == nil || cacher == nil || contentID == "" {
 		return nil
 	}
-	return cacheEbookCoverBytes(ctx, store, cacher, contentID, book.Cover.Bytes)
-}
-
-func applyEbookSidecarCover(ctx context.Context, store ebookCoverMetadataStore, cacher ebookCoverCacher, contentID string, ebookFilePath string) error {
-	if store == nil || cacher == nil || contentID == "" || ebookFilePath == "" {
-		return nil
+	var data []byte
+	var sidecarErr error
+	if ebookFilePath != "" {
+		cover, _, err := findSidecarBookCover(ebookFilePath)
+		if err != nil {
+			sidecarErr = err
+		} else if cover != nil {
+			data = cover.Bytes
+		}
 	}
-	cover, _, err := findSidecarBookCover(filepath.Dir(ebookFilePath))
-	if err != nil || cover == nil {
-		return err
+	if len(data) == 0 && book != nil && book.Cover != nil {
+		data = book.Cover.Bytes
 	}
-	return cacheEbookCoverBytes(ctx, store, cacher, contentID, cover.Bytes)
+	if len(data) == 0 {
+		return sidecarErr
+	}
+	return errors.Join(sidecarErr, cacheEbookCoverBytes(ctx, store, cacher, contentID, data))
 }
 
 func cacheEbookCoverBytes(ctx context.Context, store ebookCoverMetadataStore, cacher ebookCoverCacher, contentID string, data []byte) error {
 	if len(data) == 0 {
 		return nil
 	}
-	existingPosterPath, err := store.GetPosterPath(ctx, contentID)
+	existingPath, existingThumbhash, err := store.GetPoster(ctx, contentID)
 	if err != nil {
-		return fmt.Errorf("get ebook poster path for cover: %w", err)
+		return fmt.Errorf("get ebook poster for cover: %w", err)
 	}
-	if strings.TrimSpace(existingPosterPath) != "" {
-		return nil
+	existingPath = strings.TrimSpace(existingPath)
+	if existingPath != "" {
+		// Provider or manually applied artwork always wins over scan covers.
+		if !strings.HasPrefix(existingPath, localEbookPosterPrefix) {
+			return nil
+		}
+		// Re-extracted bytes of an unchanged cover hash identically; skip
+		// the variant regeneration and upload churn. A replaced cover hashes
+		// differently and falls through to refresh the stale poster.
+		if thumbhash, err := imageutil.Thumbhash(data); err == nil && thumbhash == existingThumbhash {
+			return nil
+		}
 	}
 	basePath, ext, thumbhash, err := cacher.CacheEbookCover(ctx, data, contentID)
 	if err != nil {
 		return err
 	}
 	posterPath := strings.TrimRight(basePath, "/") + "/original" + ext
-	update := &catalog.MetadataUpdate{PosterPath: &posterPath}
-	if thumbhash != "" {
-		update.PosterThumbhash = &thumbhash
+	if _, err := store.SetLocalPoster(ctx, contentID, posterPath, thumbhash, localEbookPosterPrefix); err != nil {
+		return fmt.Errorf("set ebook local poster: %w", err)
 	}
-	return store.UpdateMetadata(ctx, contentID, update)
+	return nil
 }
 
 var sidecarCoverNames = []string{"cover", "folder", "front", "poster", "thumbnail"}
 var sidecarCoverExtensions = []string{".jpg", ".jpeg", ".png", ".webp", ".avif", ".gif", ".bmp"}
 
-func findSidecarBookCover(dir string) (*parsedEbookCover, string, error) {
-	if dir == "" {
+// findSidecarBookCover looks for cover art next to the ebook file. An image
+// named after the book file always belongs to it; the generic artwork names
+// (cover.jpg, folder.png, ...) are trusted only when this is the directory's
+// sole ebook, so one cover.jpg in a flat multi-book folder is not applied to
+// every book in it.
+func findSidecarBookCover(ebookFilePath string) (*parsedEbookCover, string, error) {
+	if ebookFilePath == "" {
 		return nil, "", nil
 	}
-	entries, err := os.ReadDir(dir)
+	entries, err := os.ReadDir(filepath.Dir(ebookFilePath))
 	if err != nil {
 		return nil, "", err
 	}
 	byName := make(map[string]string, len(entries))
+	ebookCount := 0
 	for _, entry := range entries {
 		if entry.IsDir() {
 			continue
 		}
-		byName[strings.ToLower(entry.Name())] = filepath.Join(dir, entry.Name())
-	}
-	for _, name := range sidecarCoverNames {
-		for _, ext := range sidecarCoverExtensions {
-			path := byName[name+ext]
-			if path == "" {
-				continue
-			}
-			data, err := readSidecarCover(path)
-			if err != nil {
-				return nil, path, err
-			}
-			return &parsedEbookCover{
-				ContentType: ebookImageContentType(path),
-				Bytes:       data,
-			}, path, nil
+		if SupportsEbookFile(entry.Name()) {
+			ebookCount++
 		}
+		byName[strings.ToLower(entry.Name())] = filepath.Join(filepath.Dir(ebookFilePath), entry.Name())
+	}
+
+	var candidates []string
+	if base := strings.ToLower(ebookTitleFromPath(ebookFilePath)); base != "" {
+		for _, ext := range sidecarCoverExtensions {
+			candidates = append(candidates, base+ext)
+		}
+	}
+	if ebookCount <= 1 {
+		for _, name := range sidecarCoverNames {
+			for _, ext := range sidecarCoverExtensions {
+				candidates = append(candidates, name+ext)
+			}
+		}
+	}
+	for _, candidate := range candidates {
+		path := byName[candidate]
+		if path == "" {
+			continue
+		}
+		data, err := readSidecarCover(path)
+		if err != nil {
+			return nil, path, err
+		}
+		return &parsedEbookCover{
+			ContentType: ebookImageContentType(path),
+			Bytes:       data,
+		}, path, nil
 	}
 	return nil, "", nil
 }

--- a/internal/scanner/ebook_test.go
+++ b/internal/scanner/ebook_test.go
@@ -487,6 +487,32 @@ func TestParseEbookPDFInfoMetadataDecodesUTF16BELiterals(t *testing.T) {
 	}
 }
 
+func TestParseEbookPDFInfoMetadataDecodesHexStrings(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "book.pdf")
+	if err := os.WriteFile(path, []byte(`%PDF-1.7
+1 0 obj
+<< /Title <FEFF00480065007800200042006F006F006B>
+   /Author <41646120577269746572>
+   /CreationDate (0000-01-01)
+>>
+endobj
+%%EOF`), 0o644); err != nil {
+		t.Fatalf("write pdf: %v", err)
+	}
+
+	got, err := parseEbookFile(path)
+	if err != nil {
+		t.Fatalf("parseEbookFile: %v", err)
+	}
+
+	if got.Title != "Hex Book" || strings.Join(got.Authors, ", ") != "Ada Writer" {
+		t.Fatalf("PDF hex metadata = title %q authors %v", got.Title, got.Authors)
+	}
+	if got.Year != 0 || !got.PublishedAt.IsZero() {
+		t.Fatalf("bad PDF date produced year/date = %d/%v, want ignored", got.Year, got.PublishedAt)
+	}
+}
+
 func TestParseEbookCBZPageCount(t *testing.T) {
 	path := filepath.Join(t.TempDir(), "comic.cbz")
 	file, err := os.Create(path)

--- a/internal/scanner/ebook_test.go
+++ b/internal/scanner/ebook_test.go
@@ -223,6 +223,25 @@ func TestParseEbookEPUBMetadataReadsISBNFromMetaTags(t *testing.T) {
 	}
 }
 
+func TestParseEbookEPUBExtractsManifestCover(t *testing.T) {
+	path := writeTestEPUBWithCover(t, "Images/cover.jpg", "image/jpeg", []byte("epub-cover-bytes"))
+
+	got, err := parseEbookFile(path)
+	if err != nil {
+		t.Fatalf("parseEbookFile: %v", err)
+	}
+
+	if got.Cover == nil {
+		t.Fatal("Cover = nil, want embedded EPUB cover")
+	}
+	if got.Cover.ContentType != "image/jpeg" {
+		t.Fatalf("Cover.ContentType = %q, want image/jpeg", got.Cover.ContentType)
+	}
+	if string(got.Cover.Bytes) != "epub-cover-bytes" {
+		t.Fatalf("Cover.Bytes = %q, want EPUB cover bytes", string(got.Cover.Bytes))
+	}
+}
+
 func TestReadEPUBZipEntryRejectsOversizedEntry(t *testing.T) {
 	path := filepath.Join(t.TempDir(), "large.epub")
 	file, err := os.Create(path)
@@ -452,6 +471,52 @@ func TestParseEbookCBZPageCount(t *testing.T) {
 	}
 	if got.PageCount != 3 {
 		t.Fatalf("PageCount = %d, want 3", got.PageCount)
+	}
+}
+
+func TestParseEbookCBZExtractsFirstReadablePageAsCover(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "comic.cbz")
+	file, err := os.Create(path)
+	if err != nil {
+		t.Fatalf("create cbz: %v", err)
+	}
+	zw := zip.NewWriter(file)
+	for _, entry := range []struct {
+		name string
+		body []byte
+	}{
+		{name: "Comic/002.png", body: []byte("second-page")},
+		{name: "Comic/001.jpg", body: []byte("first-page")},
+		{name: "Comic/notes.txt", body: []byte("ignored")},
+	} {
+		w, err := zw.Create(entry.name)
+		if err != nil {
+			t.Fatalf("create zip entry %s: %v", entry.name, err)
+		}
+		if _, err := w.Write(entry.body); err != nil {
+			t.Fatalf("write zip entry %s: %v", entry.name, err)
+		}
+	}
+	if err := zw.Close(); err != nil {
+		t.Fatalf("close zip: %v", err)
+	}
+	if err := file.Close(); err != nil {
+		t.Fatalf("close cbz: %v", err)
+	}
+
+	got, err := parseEbookFile(path)
+	if err != nil {
+		t.Fatalf("parseEbookFile: %v", err)
+	}
+
+	if got.Cover == nil {
+		t.Fatal("Cover = nil, want first CBZ page as cover")
+	}
+	if got.Cover.ContentType != "image/jpeg" {
+		t.Fatalf("Cover.ContentType = %q, want image/jpeg", got.Cover.ContentType)
+	}
+	if string(got.Cover.Bytes) != "first-page" {
+		t.Fatalf("Cover.Bytes = %q, want first page bytes", string(got.Cover.Bytes))
 	}
 }
 
@@ -802,6 +867,30 @@ func TestApplyEbookEmbeddedCoverPreservesExistingPoster(t *testing.T) {
 	}
 }
 
+func TestApplyEbookSidecarCoverCachesSameDirectoryCover(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "book.epub"), []byte("book"), 0o644); err != nil {
+		t.Fatalf("write ebook: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "cover.jpg"), []byte("ebook-sidecar-cover"), 0o644); err != nil {
+		t.Fatalf("write cover: %v", err)
+	}
+	cacher := &fakeEbookCoverCacher{}
+	updater := &fakeEbookMetadataUpdater{}
+
+	err := applyEbookSidecarCover(context.Background(), updater, cacher, "content-1", filepath.Join(dir, "book.epub"))
+	if err != nil {
+		t.Fatalf("applyEbookSidecarCover: %v", err)
+	}
+
+	if cacher.calls != 1 || string(cacher.data) != "ebook-sidecar-cover" {
+		t.Fatalf("cache call = calls %d data %q", cacher.calls, string(cacher.data))
+	}
+	if updater.update == nil || updater.update.PosterPath == nil || *updater.update.PosterPath != "local/ebooks/content-1/poster/original.webp" {
+		t.Fatalf("poster update = %#v", updater.update)
+	}
+}
+
 func TestScanEbookPersistenceSQLWritesLibraryMembershipAndISBNOnly(t *testing.T) {
 	ctx := context.Background()
 	exec := &recordingEbookExecutor{}
@@ -942,6 +1031,51 @@ func writeTestEPUBWithDescriptionAndMeta(t *testing.T, identifiers []string, des
 `+extraMetaXML+`
   </metadata>
 </package>`)
+	if err := zw.Close(); err != nil {
+		t.Fatalf("close zip: %v", err)
+	}
+	if err := file.Close(); err != nil {
+		t.Fatalf("close epub: %v", err)
+	}
+	return path
+}
+
+func writeTestEPUBWithCover(t *testing.T, coverHref string, coverType string, coverBytes []byte) string {
+	t.Helper()
+
+	path := filepath.Join(t.TempDir(), "book.epub")
+	file, err := os.Create(path)
+	if err != nil {
+		t.Fatalf("create epub: %v", err)
+	}
+	zw := zip.NewWriter(file)
+	add := func(name string, body []byte) {
+		t.Helper()
+		w, err := zw.Create(name)
+		if err != nil {
+			t.Fatalf("create zip entry %s: %v", name, err)
+		}
+		if _, err := w.Write(body); err != nil {
+			t.Fatalf("write zip entry %s: %v", name, err)
+		}
+	}
+	add("META-INF/container.xml", []byte(`<?xml version="1.0"?>
+<container version="1.0" xmlns="urn:oasis:names:tc:opendocument:xmlns:container">
+  <rootfiles>
+    <rootfile full-path="OPS/content.opf" media-type="application/oebps-package+xml"/>
+  </rootfiles>
+</container>`))
+	add("OPS/content.opf", []byte(`<?xml version="1.0" encoding="UTF-8"?>
+<package xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:opf="http://www.idpf.org/2007/opf">
+  <metadata>
+    <dc:title>The Test Ebook</dc:title>
+    <meta name="cover" content="cover-image"/>
+  </metadata>
+  <manifest>
+    <item id="cover-image" href="`+coverHref+`" media-type="`+coverType+`"/>
+  </manifest>
+</package>`))
+	add("OPS/"+coverHref, coverBytes)
 	if err := zw.Close(); err != nil {
 		t.Fatalf("close zip: %v", err)
 	}

--- a/internal/scanner/ebook_test.go
+++ b/internal/scanner/ebook_test.go
@@ -223,6 +223,41 @@ func TestParseEbookEPUBMetadataReadsISBNFromMetaTags(t *testing.T) {
 	}
 }
 
+func TestParseEbookEPUBMetadataHandlesLatin1OPF(t *testing.T) {
+	path := writeTestEPUBWithOPFBytes(t, []byte("<?xml version=\"1.0\" encoding=\"iso-8859-1\"?>\n"+
+		"<package xmlns:dc=\"http://purl.org/dc/elements/1.1/\"><metadata>"+
+		"<dc:title>Caf\xe9 Society</dc:title>"+
+		"<dc:creator>Fran\xe7ois Author</dc:creator>"+
+		"<dc:publisher>Cr\xe8me Press</dc:publisher>"+
+		"</metadata></package>"))
+
+	got, err := parseEbookFile(path)
+	if err != nil {
+		t.Fatalf("parseEbookFile: %v", err)
+	}
+
+	if got.Title != "Café Society" || strings.Join(got.Authors, ", ") != "François Author" || got.Publisher != "Crème Press" {
+		t.Fatalf("parsed latin1 metadata = title %q authors %v publisher %q", got.Title, got.Authors, got.Publisher)
+	}
+}
+
+func TestParseEbookEPUBMetadataAllowsXMLVersion11(t *testing.T) {
+	path := writeTestEPUBWithOPFBytes(t, []byte(`<?xml version="1.1" encoding="UTF-8"?>
+<package xmlns:dc="http://purl.org/dc/elements/1.1/"><metadata>
+  <dc:title>Versioned Ebook</dc:title>
+  <dc:creator>Ada Writer</dc:creator>
+</metadata></package>`))
+
+	got, err := parseEbookFile(path)
+	if err != nil {
+		t.Fatalf("parseEbookFile: %v", err)
+	}
+
+	if got.Title != "Versioned Ebook" || strings.Join(got.Authors, ", ") != "Ada Writer" {
+		t.Fatalf("parsed XML 1.1 metadata = title %q authors %v", got.Title, got.Authors)
+	}
+}
+
 func TestParseEbookEPUBExtractsManifestCover(t *testing.T) {
 	path := writeTestEPUBWithCover(t, "Images/cover.jpg", "image/jpeg", []byte("epub-cover-bytes"))
 
@@ -429,6 +464,26 @@ trailer
 	}
 	if strings.Join(got.Genres, ", ") != "science fiction, adventure" {
 		t.Fatalf("Genres = %v, want science fiction and adventure", got.Genres)
+	}
+}
+
+func TestParseEbookPDFInfoMetadataDecodesUTF16BELiterals(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "book.pdf")
+	if err := os.WriteFile(path, []byte("%PDF-1.7\n"+
+		"1 0 obj\n"+
+		"<< /Title (\xfe\xff\x00C\x00a\x00f\x00e)\n"+
+		"   /Author (\xfe\xff\x00T\x00h\x00o\x00m\x00a\x00s\x00 \x00D\x00 \x00S\x00e\x00e\x00l\x00e\x00y)\n"+
+		">>\nendobj\n%%EOF"), 0o644); err != nil {
+		t.Fatalf("write pdf: %v", err)
+	}
+
+	got, err := parseEbookFile(path)
+	if err != nil {
+		t.Fatalf("parseEbookFile: %v", err)
+	}
+
+	if got.Title != "Cafe" || strings.Join(got.Authors, ", ") != "Thomas D Seeley" {
+		t.Fatalf("PDF metadata = title %q authors %v, want decoded UTF-16BE", got.Title, got.Authors)
 	}
 }
 
@@ -1085,6 +1140,41 @@ func writeTestEPUBWithDescriptionAndMeta(t *testing.T, identifiers []string, des
 `+extraMetaXML+`
   </metadata>
 </package>`)
+	if err := zw.Close(); err != nil {
+		t.Fatalf("close zip: %v", err)
+	}
+	if err := file.Close(); err != nil {
+		t.Fatalf("close epub: %v", err)
+	}
+	return path
+}
+
+func writeTestEPUBWithOPFBytes(t *testing.T, opf []byte) string {
+	t.Helper()
+
+	path := filepath.Join(t.TempDir(), "book.epub")
+	file, err := os.Create(path)
+	if err != nil {
+		t.Fatalf("create epub: %v", err)
+	}
+	zw := zip.NewWriter(file)
+	add := func(name string, body []byte) {
+		t.Helper()
+		w, err := zw.Create(name)
+		if err != nil {
+			t.Fatalf("create zip entry %s: %v", name, err)
+		}
+		if _, err := w.Write(body); err != nil {
+			t.Fatalf("write zip entry %s: %v", name, err)
+		}
+	}
+	add("META-INF/container.xml", []byte(`<?xml version="1.0"?>
+<container version="1.0" xmlns="urn:oasis:names:tc:opendocument:xmlns:container">
+  <rootfiles>
+    <rootfile full-path="OPS/content.opf" media-type="application/oebps-package+xml"/>
+  </rootfiles>
+</container>`))
+	add("OPS/content.opf", opf)
 	if err := zw.Close(); err != nil {
 		t.Fatalf("close zip: %v", err)
 	}

--- a/internal/scanner/ebook_test.go
+++ b/internal/scanner/ebook_test.go
@@ -626,6 +626,57 @@ func TestEbookIdentityConfidenceReflectsMetadataCompleteness(t *testing.T) {
 	}
 }
 
+func TestEbookContentGroupKeyGroupsMultipleSiblingFormatsByTitleAuthor(t *testing.T) {
+	want := ebookContentGroupKey(&parsedEbook{
+		Format:  "epub",
+		Title:   " The Test Ebook ",
+		Authors: []string{"Ada Writer", "Ben Author"},
+	}, "/library/Ada Writer/The Test Ebook.epub")
+	if want == "" {
+		t.Fatal("ebookContentGroupKey returned blank")
+	}
+	for _, tc := range []struct {
+		format string
+		path   string
+	}{
+		{format: "mobi", path: "/library/Ada Writer/The Test Ebook.mobi"},
+		{format: "azw3", path: "/library/Ada Writer/The Test Ebook.azw3"},
+		{format: "pdf", path: "/library/Ada Writer/The Test Ebook.pdf"},
+		{format: "fb2", path: "/library/Ada Writer/The Test Ebook.fb2"},
+	} {
+		got := ebookContentGroupKey(&parsedEbook{
+			Format:  tc.format,
+			Title:   "The Test Ebook",
+			Authors: []string{"ben author", "ada writer"},
+		}, tc.path)
+		if got != want {
+			t.Fatalf("%s content group key = %q, want %q", tc.format, got, want)
+		}
+		if strings.Contains(got, tc.format) {
+			t.Fatalf("content group key should not include file format %q: %q", tc.format, got)
+		}
+	}
+}
+
+func TestEbookContentGroupKeyPrefersISBNAcrossTitleVariants(t *testing.T) {
+	first := ebookContentGroupKey(&parsedEbook{
+		Format:  "epub",
+		Title:   "The Test Ebook",
+		Authors: []string{"Ada Writer"},
+		ISBN:    "9780306406157",
+	}, "/library/Ada Writer/The Test Ebook.epub")
+	second := ebookContentGroupKey(&parsedEbook{
+		Format:  "pdf",
+		Title:   "The Test Ebook: Revised Edition",
+		Authors: []string{"Someone Else"},
+		ISBN:    "9780306406157",
+	}, "/library/Other Name.pdf")
+
+	if first != second {
+		t.Fatalf("ISBN-backed content group keys differ: %q != %q", first, second)
+	}
+}
+
 func TestResolveEbookMediaItemCreatesNewWhenRootHasNoClaim(t *testing.T) {
 	finder := &fakeRootContentFinder{}
 	writer := &fakeFilesystemItemWriter{}
@@ -814,6 +865,9 @@ func TestScanEbookBuildMediaFileSetsCorePersistenceFields(t *testing.T) {
 	}
 	if got.CanonicalRootPath != "/library/Book.epub" || got.ObservedRootPath != "/library/Book.epub" || got.FilePath != "/library/Book.epub" {
 		t.Fatalf("ebook paths = canonical %q observed %q file %q", got.CanonicalRootPath, got.ObservedRootPath, got.FilePath)
+	}
+	if got.ContentGroupKey != "ebook:isbn:9780306406157" {
+		t.Fatalf("ContentGroupKey = %q, want ISBN-backed ebook group", got.ContentGroupKey)
 	}
 	if got.FileSize != 1234 || got.FileModifiedAt == nil || !got.FileModifiedAt.Equal(modifiedAt) {
 		t.Fatalf("file facts = size %d modified %v", got.FileSize, got.FileModifiedAt)

--- a/internal/scanner/ebook_test.go
+++ b/internal/scanner/ebook_test.go
@@ -54,15 +54,15 @@ func (f *fakeEbookCoverCacher) CacheEbookCover(_ context.Context, data []byte, c
 }
 
 type fakeEbookMetadataUpdater struct {
-	items     []*models.MediaItem
-	getErr    error
-	contentID string
-	update    *catalog.MetadataUpdate
-	err       error
+	posterPath string
+	getErr     error
+	contentID  string
+	update     *catalog.MetadataUpdate
+	err        error
 }
 
-func (f *fakeEbookMetadataUpdater) GetByIDs(_ context.Context, _ []string) ([]*models.MediaItem, error) {
-	return f.items, f.getErr
+func (f *fakeEbookMetadataUpdater) GetPosterPath(_ context.Context, _ string) (string, error) {
+	return f.posterPath, f.getErr
 }
 
 func (f *fakeEbookMetadataUpdater) UpdateMetadata(_ context.Context, contentID string, update *catalog.MetadataUpdate) error {
@@ -850,7 +850,7 @@ func TestApplyEbookEmbeddedCoverCachesAndUpdatesPoster(t *testing.T) {
 
 func TestApplyEbookEmbeddedCoverPreservesExistingPoster(t *testing.T) {
 	cacher := &fakeEbookCoverCacher{}
-	updater := &fakeEbookMetadataUpdater{items: []*models.MediaItem{{ContentID: "content-1", PosterPath: "provider/poster.webp"}}}
+	updater := &fakeEbookMetadataUpdater{posterPath: "provider/poster.webp"}
 
 	err := applyEbookEmbeddedCover(context.Background(), updater, cacher, "content-1", &parsedEbook{
 		Cover: &parsedEbookCover{Bytes: []byte("cover-bytes")},

--- a/internal/scanner/ebook_test.go
+++ b/internal/scanner/ebook_test.go
@@ -10,7 +10,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/Silo-Server/silo-server/internal/catalog"
 	"github.com/Silo-Server/silo-server/internal/models"
 	"github.com/jackc/pgx/v5"
 	"github.com/jackc/pgx/v5/pgconn"
@@ -54,21 +53,28 @@ func (f *fakeEbookCoverCacher) CacheEbookCover(_ context.Context, data []byte, c
 }
 
 type fakeEbookMetadataUpdater struct {
-	posterPath string
-	getErr     error
-	contentID  string
-	update     *catalog.MetadataUpdate
-	err        error
+	posterPath      string
+	posterThumbhash string
+	getErr          error
+	contentID       string
+	setPosterPath   string
+	setThumbhash    string
+	setPrefix       string
+	setCalls        int
+	err             error
 }
 
-func (f *fakeEbookMetadataUpdater) GetPosterPath(_ context.Context, _ string) (string, error) {
-	return f.posterPath, f.getErr
+func (f *fakeEbookMetadataUpdater) GetPoster(_ context.Context, _ string) (string, string, error) {
+	return f.posterPath, f.posterThumbhash, f.getErr
 }
 
-func (f *fakeEbookMetadataUpdater) UpdateMetadata(_ context.Context, contentID string, update *catalog.MetadataUpdate) error {
+func (f *fakeEbookMetadataUpdater) SetLocalPoster(_ context.Context, contentID, posterPath, thumbhash, localPrefix string) (bool, error) {
+	f.setCalls++
 	f.contentID = contentID
-	f.update = update
-	return f.err
+	f.setPosterPath = posterPath
+	f.setThumbhash = thumbhash
+	f.setPrefix = localPrefix
+	return f.err == nil, f.err
 }
 
 func TestSupportsEbookFile(t *testing.T) {
@@ -241,6 +247,23 @@ func TestParseEbookEPUBMetadataHandlesLatin1OPF(t *testing.T) {
 	}
 }
 
+func TestParseEbookEPUBMetadataHandlesWindows1251OPF(t *testing.T) {
+	path := writeTestEPUBWithOPFBytes(t, []byte("<?xml version=\"1.0\" encoding=\"windows-1251\"?>\n"+
+		"<package xmlns:dc=\"http://purl.org/dc/elements/1.1/\"><metadata>"+
+		"<dc:title>\xc2\xee\xe9\xed\xe0 \xe8 \xec\xe8\xf0</dc:title>"+
+		"<dc:creator>\xd2\xee\xeb\xf1\xf2\xee\xe9</dc:creator>"+
+		"</metadata></package>"))
+
+	got, err := parseEbookFile(path)
+	if err != nil {
+		t.Fatalf("parseEbookFile: %v", err)
+	}
+
+	if got.Title != "Война и мир" || strings.Join(got.Authors, ", ") != "Толстой" {
+		t.Fatalf("parsed windows-1251 metadata = title %q authors %v", got.Title, got.Authors)
+	}
+}
+
 func TestParseEbookEPUBMetadataAllowsXMLVersion11(t *testing.T) {
 	path := writeTestEPUBWithOPFBytes(t, []byte(`<?xml version="1.1" encoding="UTF-8"?>
 <package xmlns:dc="http://purl.org/dc/elements/1.1/"><metadata>
@@ -274,6 +297,64 @@ func TestParseEbookEPUBExtractsManifestCover(t *testing.T) {
 	}
 	if string(got.Cover.Bytes) != "epub-cover-bytes" {
 		t.Fatalf("Cover.Bytes = %q, want EPUB cover bytes", string(got.Cover.Bytes))
+	}
+}
+
+func TestParseEbookEPUBCoverSkipsXHTMLCoverPage(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "book.epub")
+	file, err := os.Create(path)
+	if err != nil {
+		t.Fatalf("create epub: %v", err)
+	}
+	zw := zip.NewWriter(file)
+	add := func(name, body string) {
+		t.Helper()
+		w, err := zw.Create(name)
+		if err != nil {
+			t.Fatalf("create zip entry %s: %v", name, err)
+		}
+		if _, err := w.Write([]byte(body)); err != nil {
+			t.Fatalf("write zip entry %s: %v", name, err)
+		}
+	}
+	add("META-INF/container.xml", `<?xml version="1.0"?>
+<container version="1.0" xmlns="urn:oasis:names:tc:opendocument:xmlns:container">
+  <rootfiles>
+    <rootfile full-path="OPS/content.opf" media-type="application/oebps-package+xml"/>
+  </rootfiles>
+</container>`)
+	// EPUB2-style meta cover pointing at the XHTML cover *page*, with the
+	// real image declared later via properties="cover-image".
+	add("OPS/content.opf", `<?xml version="1.0" encoding="UTF-8"?>
+<package xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:opf="http://www.idpf.org/2007/opf">
+  <metadata>
+    <dc:title>The Test Ebook</dc:title>
+    <meta name="cover" content="cover"/>
+  </metadata>
+  <manifest>
+    <item id="cover" href="cover.xhtml" media-type="application/xhtml+xml"/>
+    <item id="cover-img" href="Images/cover.jpg" media-type="image/jpeg" properties="cover-image"/>
+  </manifest>
+</package>`)
+	add("OPS/cover.xhtml", "<html><body><img src='Images/cover.jpg'/></body></html>")
+	add("OPS/Images/cover.jpg", "real-cover-bytes")
+	if err := zw.Close(); err != nil {
+		t.Fatalf("close zip: %v", err)
+	}
+	if err := file.Close(); err != nil {
+		t.Fatalf("close epub: %v", err)
+	}
+
+	got, err := parseEbookFile(path)
+	if err != nil {
+		t.Fatalf("parseEbookFile: %v", err)
+	}
+
+	if got.Cover == nil {
+		t.Fatal("Cover = nil, want cover-image manifest item")
+	}
+	if got.Cover.ContentType != "image/jpeg" || string(got.Cover.Bytes) != "real-cover-bytes" {
+		t.Fatalf("Cover = %q/%q, want the image item, not the XHTML cover page", got.Cover.ContentType, string(got.Cover.Bytes))
 	}
 }
 
@@ -487,6 +568,48 @@ func TestParseEbookPDFInfoMetadataDecodesUTF16BELiterals(t *testing.T) {
 	}
 }
 
+func TestParseEbookPDFInfoMetadataPreservesUTF8Literals(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "book.pdf")
+	if err := os.WriteFile(path, []byte("%PDF-1.7\n"+
+		"1 0 obj\n"+
+		"<< /Title (Caf\xc3\xa9 Society)\n"+
+		"   /Author (\xef\xbb\xbfFran\xc3\xa7ois Author)\n"+
+		">>\nendobj\n%%EOF"), 0o644); err != nil {
+		t.Fatalf("write pdf: %v", err)
+	}
+
+	got, err := parseEbookFile(path)
+	if err != nil {
+		t.Fatalf("parseEbookFile: %v", err)
+	}
+
+	if got.Title != "Café Society" {
+		t.Fatalf("Title = %q, want UTF-8 literal preserved without Windows-1252 mojibake", got.Title)
+	}
+	if strings.Join(got.Authors, ", ") != "François Author" {
+		t.Fatalf("Authors = %v, want UTF-8 BOM stripped and bytes preserved", got.Authors)
+	}
+}
+
+func TestParseEbookPDFInfoMetadataFallsBackToWindows1252(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "book.pdf")
+	if err := os.WriteFile(path, []byte("%PDF-1.7\n"+
+		"1 0 obj\n"+
+		"<< /Title (Caf\xe9 Society)\n"+
+		">>\nendobj\n%%EOF"), 0o644); err != nil {
+		t.Fatalf("write pdf: %v", err)
+	}
+
+	got, err := parseEbookFile(path)
+	if err != nil {
+		t.Fatalf("parseEbookFile: %v", err)
+	}
+
+	if got.Title != "Café Society" {
+		t.Fatalf("Title = %q, want Windows-1252 fallback for non-UTF-8 literal", got.Title)
+	}
+}
+
 func TestParseEbookPDFInfoMetadataDecodesHexStrings(t *testing.T) {
 	path := filepath.Join(t.TempDir(), "book.pdf")
 	if err := os.WriteFile(path, []byte(`%PDF-1.7
@@ -598,6 +721,62 @@ func TestParseEbookCBZExtractsFirstReadablePageAsCover(t *testing.T) {
 	}
 	if string(got.Cover.Bytes) != "first-page" {
 		t.Fatalf("Cover.Bytes = %q, want first page bytes", string(got.Cover.Bytes))
+	}
+}
+
+func TestParseEbookCBZPicksNaturallyFirstPageAsCover(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "comic.cbz")
+	file, err := os.Create(path)
+	if err != nil {
+		t.Fatalf("create cbz: %v", err)
+	}
+	zw := zip.NewWriter(file)
+	for _, entry := range []struct {
+		name string
+		body string
+	}{
+		{name: "ch10/page10.jpg", body: "chapter-ten"},
+		{name: "ch2/page2.jpg", body: "chapter-two"},
+	} {
+		w, err := zw.Create(entry.name)
+		if err != nil {
+			t.Fatalf("create zip entry %s: %v", entry.name, err)
+		}
+		if _, err := w.Write([]byte(entry.body)); err != nil {
+			t.Fatalf("write zip entry %s: %v", entry.name, err)
+		}
+	}
+	if err := zw.Close(); err != nil {
+		t.Fatalf("close zip: %v", err)
+	}
+	if err := file.Close(); err != nil {
+		t.Fatalf("close cbz: %v", err)
+	}
+
+	got, err := parseEbookFile(path)
+	if err != nil {
+		t.Fatalf("parseEbookFile: %v", err)
+	}
+
+	if got.Cover == nil {
+		t.Fatal("Cover = nil, want first page in natural order")
+	}
+	if string(got.Cover.Bytes) != "chapter-two" {
+		t.Fatalf("Cover.Bytes = %q, want ch2 before ch10 (natural order, not byte order)", string(got.Cover.Bytes))
+	}
+}
+
+func TestEbookTitleFromPathStripsCompoundFB2Extension(t *testing.T) {
+	cases := map[string]string{
+		"/lib/Anna Karenina.fb2.zip": "Anna Karenina",
+		"/lib/Anna Karenina.FB2.ZIP": "Anna Karenina",
+		"/lib/Book.epub":             "Book",
+		"/lib/vol.1.pdf":             "vol.1",
+	}
+	for path, want := range cases {
+		if got := ebookTitleFromPath(path); got != want {
+			t.Errorf("ebookTitleFromPath(%q) = %q, want %q", path, got, want)
+		}
 	}
 }
 
@@ -934,7 +1113,7 @@ func TestScanEbookBuildMediaFileSetsCorePersistenceFields(t *testing.T) {
 	modifiedAt := time.Date(2026, 6, 8, 12, 0, 0, 0, time.UTC)
 	book := &parsedEbook{Format: "epub", Title: "Book", Authors: []string{"Author"}, Year: 2024, ISBN: "9780306406157", PageCount: 321}
 
-	got := buildEbookMediaFile(&models.MediaFolder{ID: 44}, "content-1", "/library/Book.epub", 1234, modifiedAt, book)
+	got := buildEbookMediaFile(&models.MediaFolder{ID: 44}, "content-1", "/library/Book.epub", 1234, modifiedAt, book, ebookContentGroupKey(book, "/library/Book.epub"))
 	if got.ContentID != "content-1" || got.MediaFolderID != 44 {
 		t.Fatalf("ids = %q/%d, want content-1/44", got.ContentID, got.MediaFolderID)
 	}
@@ -950,59 +1129,87 @@ func TestScanEbookBuildMediaFileSetsCorePersistenceFields(t *testing.T) {
 	if got.ContentGroupKey != "ebook:isbn:9780306406157" {
 		t.Fatalf("ContentGroupKey = %q, want ISBN-backed ebook group", got.ContentGroupKey)
 	}
+	if got.GroupKeyVersion != ebookGroupKeyVersion {
+		t.Fatalf("GroupKeyVersion = %d, want %d", got.GroupKeyVersion, ebookGroupKeyVersion)
+	}
 	if got.FileSize != 1234 || got.FileModifiedAt == nil || !got.FileModifiedAt.Equal(modifiedAt) {
 		t.Fatalf("file facts = size %d modified %v", got.FileSize, got.FileModifiedAt)
 	}
 }
 
-func TestApplyEbookEmbeddedCoverCachesAndUpdatesPoster(t *testing.T) {
+func TestApplyEbookLocalCoverCachesEmbeddedAndSetsPoster(t *testing.T) {
 	cacher := &fakeEbookCoverCacher{}
 	updater := &fakeEbookMetadataUpdater{}
 
-	err := applyEbookEmbeddedCover(context.Background(), updater, cacher, "content-1", &parsedEbook{
+	err := applyEbookLocalCover(context.Background(), updater, cacher, "content-1", filepath.Join(t.TempDir(), "book.epub"), &parsedEbook{
 		Cover: &parsedEbookCover{
 			ContentType: "image/jpeg",
 			Bytes:       []byte("cover-bytes"),
 		},
 	})
 	if err != nil {
-		t.Fatalf("applyEbookEmbeddedCover: %v", err)
+		t.Fatalf("applyEbookLocalCover: %v", err)
 	}
 
 	if cacher.calls != 1 || cacher.contentID != "content-1" || string(cacher.data) != "cover-bytes" {
 		t.Fatalf("cache call = calls %d content %q data %q", cacher.calls, cacher.contentID, string(cacher.data))
 	}
-	if updater.contentID != "content-1" || updater.update == nil {
-		t.Fatalf("update call = content %q update %#v", updater.contentID, updater.update)
+	if updater.setCalls != 1 || updater.contentID != "content-1" {
+		t.Fatalf("set call = calls %d content %q", updater.setCalls, updater.contentID)
 	}
-	if updater.update.PosterPath == nil || *updater.update.PosterPath != "local/ebooks/content-1/poster/original.webp" {
-		t.Fatalf("poster path = %#v", updater.update.PosterPath)
+	if updater.setPosterPath != "local/ebooks/content-1/poster/original.webp" {
+		t.Fatalf("poster path = %q", updater.setPosterPath)
 	}
-	if updater.update.PosterThumbhash == nil || *updater.update.PosterThumbhash != "thumb" {
-		t.Fatalf("poster thumbhash = %#v", updater.update.PosterThumbhash)
+	if updater.setThumbhash != "thumb" {
+		t.Fatalf("poster thumbhash = %q", updater.setThumbhash)
+	}
+	if updater.setPrefix != localEbookPosterPrefix {
+		t.Fatalf("local prefix = %q, want %q", updater.setPrefix, localEbookPosterPrefix)
 	}
 }
 
-func TestApplyEbookEmbeddedCoverPreservesExistingPoster(t *testing.T) {
+func TestApplyEbookLocalCoverPreservesProviderPoster(t *testing.T) {
 	cacher := &fakeEbookCoverCacher{}
-	updater := &fakeEbookMetadataUpdater{posterPath: "provider/poster.webp"}
+	updater := &fakeEbookMetadataUpdater{posterPath: "ebook-metadata/ebooks/content-1/poster/original.webp"}
 
-	err := applyEbookEmbeddedCover(context.Background(), updater, cacher, "content-1", &parsedEbook{
+	err := applyEbookLocalCover(context.Background(), updater, cacher, "content-1", filepath.Join(t.TempDir(), "book.epub"), &parsedEbook{
 		Cover: &parsedEbookCover{Bytes: []byte("cover-bytes")},
 	})
 	if err != nil {
-		t.Fatalf("applyEbookEmbeddedCover: %v", err)
+		t.Fatalf("applyEbookLocalCover: %v", err)
 	}
 
 	if cacher.calls != 0 {
 		t.Fatalf("cache calls = %d, want 0", cacher.calls)
 	}
-	if updater.update != nil {
-		t.Fatalf("unexpected update = %#v", updater.update)
+	if updater.setCalls != 0 {
+		t.Fatalf("set calls = %d, want 0", updater.setCalls)
 	}
 }
 
-func TestApplyEbookSidecarCoverCachesSameDirectoryCover(t *testing.T) {
+func TestApplyEbookLocalCoverRefreshesStaleLocalPoster(t *testing.T) {
+	cacher := &fakeEbookCoverCacher{}
+	updater := &fakeEbookMetadataUpdater{
+		posterPath:      "local/ebooks/content-1/poster/original.webp",
+		posterThumbhash: "stale-thumb",
+	}
+
+	err := applyEbookLocalCover(context.Background(), updater, cacher, "content-1", filepath.Join(t.TempDir(), "book.epub"), &parsedEbook{
+		Cover: &parsedEbookCover{Bytes: []byte("replacement-cover-bytes")},
+	})
+	if err != nil {
+		t.Fatalf("applyEbookLocalCover: %v", err)
+	}
+
+	if cacher.calls != 1 || string(cacher.data) != "replacement-cover-bytes" {
+		t.Fatalf("cache call = calls %d data %q, want refresh of locally owned poster", cacher.calls, string(cacher.data))
+	}
+	if updater.setCalls != 1 {
+		t.Fatalf("set calls = %d, want 1", updater.setCalls)
+	}
+}
+
+func TestApplyEbookLocalCoverPrefersSidecarOverEmbedded(t *testing.T) {
 	dir := t.TempDir()
 	if err := os.WriteFile(filepath.Join(dir, "book.epub"), []byte("book"), 0o644); err != nil {
 		t.Fatalf("write ebook: %v", err)
@@ -1013,16 +1220,49 @@ func TestApplyEbookSidecarCoverCachesSameDirectoryCover(t *testing.T) {
 	cacher := &fakeEbookCoverCacher{}
 	updater := &fakeEbookMetadataUpdater{}
 
-	err := applyEbookSidecarCover(context.Background(), updater, cacher, "content-1", filepath.Join(dir, "book.epub"))
+	err := applyEbookLocalCover(context.Background(), updater, cacher, "content-1", filepath.Join(dir, "book.epub"), &parsedEbook{
+		Cover: &parsedEbookCover{Bytes: []byte("embedded-cover")},
+	})
 	if err != nil {
-		t.Fatalf("applyEbookSidecarCover: %v", err)
+		t.Fatalf("applyEbookLocalCover: %v", err)
 	}
 
 	if cacher.calls != 1 || string(cacher.data) != "ebook-sidecar-cover" {
-		t.Fatalf("cache call = calls %d data %q", cacher.calls, string(cacher.data))
+		t.Fatalf("cache call = calls %d data %q, want sidecar bytes", cacher.calls, string(cacher.data))
 	}
-	if updater.update == nil || updater.update.PosterPath == nil || *updater.update.PosterPath != "local/ebooks/content-1/poster/original.webp" {
-		t.Fatalf("poster update = %#v", updater.update)
+	if updater.setCalls != 1 || updater.setPosterPath != "local/ebooks/content-1/poster/original.webp" {
+		t.Fatalf("poster update = calls %d path %q", updater.setCalls, updater.setPosterPath)
+	}
+}
+
+func TestFindSidecarBookCoverIgnoresGenericNamesInMultiBookDirectories(t *testing.T) {
+	dir := t.TempDir()
+	for _, name := range []string{"alpha.epub", "beta.epub"} {
+		if err := os.WriteFile(filepath.Join(dir, name), []byte("book"), 0o644); err != nil {
+			t.Fatalf("write ebook %s: %v", name, err)
+		}
+	}
+	if err := os.WriteFile(filepath.Join(dir, "cover.jpg"), []byte("shared-cover"), 0o644); err != nil {
+		t.Fatalf("write cover: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "beta.jpg"), []byte("beta-cover"), 0o644); err != nil {
+		t.Fatalf("write cover: %v", err)
+	}
+
+	cover, _, err := findSidecarBookCover(filepath.Join(dir, "alpha.epub"))
+	if err != nil {
+		t.Fatalf("findSidecarBookCover(alpha): %v", err)
+	}
+	if cover != nil {
+		t.Fatalf("alpha cover = %q, want none (generic cover.jpg must not claim every book)", string(cover.Bytes))
+	}
+
+	cover, _, err = findSidecarBookCover(filepath.Join(dir, "beta.epub"))
+	if err != nil {
+		t.Fatalf("findSidecarBookCover(beta): %v", err)
+	}
+	if cover == nil || string(cover.Bytes) != "beta-cover" {
+		t.Fatalf("beta cover = %v, want filename-matched beta.jpg", cover)
 	}
 }
 


### PR DESCRIPTION
## Summary
- Extract EPUB manifest covers into ebook posters during scan.
- Use the first readable CBZ page as a poster.
- Pick up same-directory ebook sidecar covers like cover.jpg, folder.png, front.webp, poster.jpg, and thumbnail.png.

## Test Plan
- [x] go test ./internal/scanner -count=1