### PR TITLE
fix(jellycompat): include Wholphin display preference dimensions

### DIFF
--- a/internal/jellycompat/handlers_displayprefs.go
+++ b/internal/jellycompat/handlers_displayprefs.go
@@ -14,16 +14,18 @@ import (
 
 // displayPreferencesDTO mirrors Jellyfin's DisplayPreferences response.
 type displayPreferencesDTO struct {
-	ID               string            `json:"Id"`
-	SortBy           string            `json:"SortBy"`
-	SortOrder        string            `json:"SortOrder"`
-	RememberIndexing bool              `json:"RememberIndexing"`
-	RememberSorting  bool              `json:"RememberSorting"`
-	ScrollDirection  string            `json:"ScrollDirection"`
-	ShowBackdrop     bool              `json:"ShowBackdrop"`
-	ShowSidebar      bool              `json:"ShowSidebar"`
-	Client           string            `json:"Client"`
-	CustomPrefs      map[string]string `json:"CustomPrefs"`
+	ID                 string            `json:"Id"`
+	SortBy             string            `json:"SortBy"`
+	SortOrder          string            `json:"SortOrder"`
+	RememberIndexing   bool              `json:"RememberIndexing"`
+	RememberSorting    bool              `json:"RememberSorting"`
+	ScrollDirection    string            `json:"ScrollDirection"`
+	ShowBackdrop       bool              `json:"ShowBackdrop"`
+	ShowSidebar        bool              `json:"ShowSidebar"`
+	PrimaryImageHeight int               `json:"PrimaryImageHeight"`
+	PrimaryImageWidth  int               `json:"PrimaryImageWidth"`
+	Client             string            `json:"Client"`
+	CustomPrefs        map[string]string `json:"CustomPrefs"`
 }
 
 // DisplayPreferencesHandler serves Jellyfin display preferences endpoints,

--- a/internal/jellycompat/handlers_displayprefs_test.go
+++ b/internal/jellycompat/handlers_displayprefs_test.go
@@ -1,0 +1,27 @@
+package jellycompat
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+func TestDefaultDisplayPreferencesIncludesRequiredImageDimensions(t *testing.T) {
+	dto := defaultDisplayPreferences("default", "Wholphin")
+
+	body, err := json.Marshal(dto)
+	if err != nil {
+		t.Fatalf("marshal default display preferences: %v", err)
+	}
+
+	var raw map[string]any
+	if err := json.Unmarshal(body, &raw); err != nil {
+		t.Fatalf("unmarshal default display preferences: %v", err)
+	}
+
+	if _, ok := raw["PrimaryImageHeight"]; !ok {
+		t.Fatal("PrimaryImageHeight missing from display preferences JSON")
+	}
+	if _, ok := raw["PrimaryImageWidth"]; !ok {
+		t.Fatal("PrimaryImageWidth missing from display preferences JSON")
+	}
+}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved Jellyfin client compatibility by adding support for image dimension preferences in display settings. Jellyfin clients can now properly handle and persist image height and width parameters.

* **Tests**
  * Added test coverage to verify that image dimension preferences are correctly included in default display settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->