### PR TITLE
fix(catalog): alias COALESCE-wrapped columns in search CTE

### DIFF
--- a/internal/catalog/item_repo.go
+++ b/internal/catalog/item_repo.go
@@ -106,6 +106,35 @@ func qualifiedItemColumns(alias string) string {
 	return strings.Join(prefixed, ", ")
 }
 
+// qualifiedItemColumnsAliased is qualifiedItemColumns with each COALESCE-wrapped
+// column aliased back to its bare name (Postgres otherwise names the projection
+// "coalesce"). Use it for a CTE SELECT list whose columns are referenced by name
+// in an outer query; qualifiedItemColumns is for GROUP BY, where "expr AS name"
+// is invalid.
+func qualifiedItemColumnsAliased(alias string) string {
+	cols := []string{
+		"content_id", "type", "title", "sort_title", "default_metadata_language", "original_title", "year", "genres",
+		"content_rating", "runtime", "overview", "tagline",
+		"rating_imdb", "rating_tmdb", "rating_rt_critic", "rating_rt_audience",
+		"imdb_id", "tmdb_id", "tvdb_id",
+		"poster_path", "poster_thumbhash", "backdrop_path", "backdrop_thumbhash", "logo_path",
+		"metadata_s3_path", "metadata_etag", "season_count",
+		"studios", "networks", "countries", "keywords", "original_language", "release_date::text", "first_air_date", "last_air_date", "air_time", "air_timezone",
+		"show_status",
+		"matched_at", "last_refreshed", "refresh_failures",
+		"episode_metadata_incomplete", "episode_metadata_last_checked_at", "locked_fields", "status", "created_at", "updated_at",
+	}
+	prefixed := make([]string, len(cols))
+	for i, col := range cols {
+		expr := qualifiedNullableStringColumn(alias, col)
+		if expr != alias+"."+col {
+			expr += " AS " + col
+		}
+		prefixed[i] = expr
+	}
+	return strings.Join(prefixed, ", ")
+}
+
 func qualifiedListItemColumns(alias string) string {
 	cols := []string{
 		"content_id", "type", "title", "sort_title", "default_metadata_language", "original_title", "year", "genres",
@@ -987,6 +1016,9 @@ func (r *ItemRepository) buildSearchSQL(query string, itemTypes []string, limit,
 	// Use qualified column names inside the CTE to avoid ambiguity when
 	// the FROM clause includes a JOIN to media_item_libraries.
 	qualifiedCols := qualifiedItemColumns("mi")
+	// The CTE SELECT aliases columns so the outer SELECT can reference them by
+	// name; GROUP BY below uses the unaliased qualifiedCols.
+	selectCols := qualifiedItemColumnsAliased("mi")
 	scoredCTE := fmt.Sprintf(`
 		WITH scored AS (
 			SELECT
@@ -1013,7 +1045,7 @@ func (r *ItemRepository) buildSearchSQL(query string, itemTypes []string, limit,
 			%s
 			GROUP BY %s
 		)
-	`, qualifiedCols, exactTitleMatch, contiguousTitleMatch, yearIdx, yearIdx, titleVector, titleQuery, overviewVector, phraseIdx, titleVector, phraseIdx, fromClause, whereClause, qualifiedCols)
+	`, selectCols, exactTitleMatch, contiguousTitleMatch, yearIdx, yearIdx, titleVector, titleQuery, overviewVector, phraseIdx, titleVector, phraseIdx, fromClause, whereClause, qualifiedCols)
 
 	// COUNT(*) OVER () runs after the GROUP BY in the scored CTE collapses
 	// duplicates from the library JOIN, so the window count preserves the


### PR DESCRIPTION
## Problem

Every text search (`GET /api/v1/catalog?q=...`) returns **HTTP 500**:

```
catalog: resolve failed
  err_msg="searching catalog items: searching media items:
           ERROR: column \"poster_path\" does not exist (SQLSTATE 42703)"
```

Catalog **browse** (no `q`) is unaffected — only the text-search path breaks.

## Root cause

#96 changed `qualifiedItemColumns` to wrap nullable string columns in `COALESCE(...)` (e.g. `COALESCE(mi.poster_path, '')`).

`buildSearchSQL` projects those columns inside the `scored` CTE. Postgres names an **unaliased** `COALESCE(...)` projection `coalesce`, not `poster_path`. The outer `SELECT` then references `itemColumns` by name (e.g. `COALESCE(poster_path, '')`) against the `scored` CTE — which no longer has a `poster_path` column → `42703`.

Minimal repro:

```sql
WITH scored AS (SELECT content_id, COALESCE(mi.poster_path,'') FROM media_items mi LIMIT 1)
SELECT COALESCE(poster_path,'') FROM scored;
-- ERROR: column "poster_path" does not exist
```

## Fix

Add `qualifiedItemColumnsAliased`, which aliases the COALESCE-wrapped columns back to their bare names (`COALESCE(mi.poster_path, '') AS poster_path`), and use it for the **CTE SELECT list only**. `GROUP BY` keeps the unaliased `qualifiedItemColumns`, because `expr AS name` is invalid in `GROUP BY`.

The aliasing is driven off `qualifiedNullableStringColumn`, so it stays correct automatically if more COALESCE-wrapped columns are added later. Non-wrapped columns (including `release_date::text`) are left untouched.

## Testing

- `go vet ./internal/catalog/` clean; `go test ./internal/catalog/` passes.
- Verified live against a populated catalog (~189k items): `q=batman`, `q=the matrix`, `q=inception` all return 200 with correctly-ranked results; no more `42703`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed search result ranking and scoring to ensure accurate retrieval and display of results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->