### PR TITLE
fix(progress): re-enter Continue Watching when re-watching a finished item

### DIFF
--- a/internal/userdb/helpers.go
+++ b/internal/userdb/helpers.go
@@ -11,7 +11,9 @@ func generateUUID() string {
 	return uuid.New().String()
 }
 
-// nowUTC returns the current time in ISO 8601 format (UTC).
-func nowUTC() string {
+// nowUTC returns the current time in ISO 8601 format (UTC). It is a package
+// var so tests can pin the clock (e.g. to exercise the rewatch time-gap guard
+// deterministically).
+var nowUTC = func() string {
 	return time.Now().UTC().Format(time.RFC3339)
 }

--- a/internal/userdb/progress.go
+++ b/internal/userdb/progress.go
@@ -20,15 +20,39 @@ type WatchHistoryEntry = userstore.WatchHistoryEntry
 // The position is only updated if the new value is greater than the existing one.
 // The completed flag is set to true when position/duration exceeds the watched threshold.
 func UpdateProgress(db *sql.DB, profileID, mediaItemID string, position, duration float64, thresholds userstore.ProgressThresholds) error {
+	if duration > 0 && position > 0 && position/duration < userstore.MinResumeFraction(thresholds.MinResumePct) {
+		return nil
+	}
 	now := nowUTC()
+	// Mirrors the Postgres pgstore UpdateProgress: position moves forward via
+	// MAX, completed latches one-way TRUE — EXCEPT a genuine rewatch of a
+	// finished item (an early-position heartbeat, below RestartDetectFraction
+	// of the runtime, landing on an already-completed row at least
+	// RestartMinGapSeconds later) releases the latch and adopts the fresh
+	// resume point so the item re-enters "Continue Watching". The time gap
+	// rejects stale heartbeats from a concurrent/offline session that arrive
+	// just after completion. julianday() diffs are in days → *86400 = seconds.
 	query := `
 		INSERT INTO watch_progress (profile_id, media_item_id, position_seconds, duration_seconds, completed, updated_at)
 		VALUES (?, ?, ?, ?, ?, ?)
 		ON CONFLICT(profile_id, media_item_id) DO UPDATE SET
-			position_seconds = MAX(excluded.position_seconds, watch_progress.position_seconds),
+			position_seconds = CASE
+				WHEN excluded.completed = 0
+					AND watch_progress.completed = 1
+					AND excluded.position_seconds < MAX(excluded.duration_seconds, watch_progress.duration_seconds) * ?
+					AND (julianday(excluded.updated_at) - julianday(watch_progress.updated_at)) * 86400.0 > ?
+					THEN excluded.position_seconds
+				ELSE MAX(excluded.position_seconds, watch_progress.position_seconds)
+			END,
 			duration_seconds = excluded.duration_seconds,
-			completed = CASE WHEN excluded.completed = 1
-				THEN 1 ELSE watch_progress.completed END,
+			completed = CASE
+				WHEN excluded.completed = 1 THEN 1
+				WHEN watch_progress.completed = 1
+					AND excluded.position_seconds < MAX(excluded.duration_seconds, watch_progress.duration_seconds) * ?
+					AND (julianday(excluded.updated_at) - julianday(watch_progress.updated_at)) * 86400.0 > ?
+					THEN 0
+				ELSE watch_progress.completed
+			END,
 			updated_at = excluded.updated_at
 	`
 	completed := false
@@ -36,7 +60,9 @@ func UpdateProgress(db *sql.DB, profileID, mediaItemID string, position, duratio
 		completed = true
 		position = duration // match MarkWatched() — reset so no stale resume point
 	}
-	_, err := db.Exec(query, profileID, mediaItemID, position, duration, completed, now)
+	_, err := db.Exec(query, profileID, mediaItemID, position, duration, completed, now,
+		userstore.RestartDetectFraction, userstore.RestartMinGapSeconds,
+		userstore.RestartDetectFraction, userstore.RestartMinGapSeconds)
 	if err != nil {
 		return fmt.Errorf("updating progress: %w", err)
 	}

--- a/internal/userdb/progress_test.go
+++ b/internal/userdb/progress_test.go
@@ -315,3 +315,173 @@ func TestClearProgressBatch_CompactsDirtyInput(t *testing.T) {
 		t.Fatalf("watch_progress row count = %d, want 1", count)
 	}
 }
+
+// newProgressDB opens an in-memory SQLite DB with the schema initialised.
+func newProgressDB(t *testing.T) *sql.DB {
+	t.Helper()
+	db, err := sql.Open("sqlite3", ":memory:")
+	if err != nil {
+		t.Fatalf("open sqlite: %v", err)
+	}
+	t.Cleanup(func() { db.Close() })
+	if err := InitSchema(db); err != nil {
+		t.Fatalf("InitSchema: %v", err)
+	}
+	return db
+}
+
+// seedProgressRow inserts/overwrites a watch_progress row with an explicit
+// updated_at so the RestartMinGapSeconds time-guard can be exercised
+// deterministically.
+func seedProgressRow(t *testing.T, db *sql.DB, profileID, itemID string, pos, dur float64, completed bool, updatedAt time.Time) {
+	t.Helper()
+	_, err := db.Exec(`
+		INSERT INTO watch_progress (profile_id, media_item_id, position_seconds, duration_seconds, completed, updated_at)
+		VALUES (?, ?, ?, ?, ?, ?)
+		ON CONFLICT(profile_id, media_item_id) DO UPDATE SET
+			position_seconds = excluded.position_seconds,
+			duration_seconds = excluded.duration_seconds,
+			completed = excluded.completed,
+			updated_at = excluded.updated_at`,
+		profileID, itemID, pos, dur, completed, updatedAt.UTC().Format(time.RFC3339))
+	if err != nil {
+		t.Fatalf("seed row: %v", err)
+	}
+}
+
+func mustGetProgress(t *testing.T, db *sql.DB, profileID, itemID string) *WatchProgress {
+	t.Helper()
+	wp, err := GetProgress(db, profileID, itemID)
+	if err != nil {
+		t.Fatalf("GetProgress: %v", err)
+	}
+	if wp == nil {
+		t.Fatalf("GetProgress(%s) = nil, want row", itemID)
+	}
+	return wp
+}
+
+// TestUpdateProgress_RewatchRestartDetect pins the rewatch latch-release
+// behaviour added to fix "Continue Watching" not showing re-watched items.
+// A finished item must re-enter the in-progress set (completed=false) when an
+// early-position heartbeat arrives well after completion, while genuine
+// completions, late heartbeats, and recent-completion stale heartbeats must NOT
+// release the latch.
+func TestUpdateProgress_RewatchRestartDetect(t *testing.T) {
+	// Pin the clock so the RestartMinGapSeconds time-gap guard is exercised
+	// deterministically: UpdateProgress stamps rows with this fixed "now", and
+	// the seed timestamps below are positioned relative to it.
+	fixedNow := time.Date(2026, 6, 9, 12, 0, 0, 0, time.UTC)
+	origNow := nowUTC
+	nowUTC = func() string { return fixedNow.Format(time.RFC3339) }
+	t.Cleanup(func() { nowUTC = origNow })
+
+	th := userstore.ProgressThresholds{WatchedPct: 90, MinResumePct: 5}
+	old := fixedNow.Add(-2 * time.Minute) // > RestartMinGapSeconds before fixedNow
+
+	t.Run("in_progress row stays in progress", func(t *testing.T) {
+		db := newProgressDB(t)
+		seedProgressRow(t, db, "p", "m", 300, 3600, false, old)
+		if err := UpdateProgress(db, "p", "m", 600, 3600, th); err != nil {
+			t.Fatalf("UpdateProgress: %v", err)
+		}
+		wp := mustGetProgress(t, db, "p", "m")
+		if wp.Completed || wp.PositionSeconds != 600 {
+			t.Fatalf("got completed=%v pos=%v, want completed=false pos=600", wp.Completed, wp.PositionSeconds)
+		}
+	})
+
+	t.Run("rewatch releases latch and adopts fresh position", func(t *testing.T) {
+		db := newProgressDB(t)
+		seedProgressRow(t, db, "p", "m", 7200, 7200, true, old)
+		// 600/7200 = 8.3%: above the 5% min-resume floor, below the 50%
+		// restart-detect threshold -> genuine rewatch, releases the latch.
+		if err := UpdateProgress(db, "p", "m", 600, 7200, th); err != nil {
+			t.Fatalf("UpdateProgress: %v", err)
+		}
+		wp := mustGetProgress(t, db, "p", "m")
+		if wp.Completed || wp.PositionSeconds != 600 {
+			t.Fatalf("got completed=%v pos=%v, want completed=false pos=600", wp.Completed, wp.PositionSeconds)
+		}
+	})
+
+	t.Run("late heartbeat does not release latch", func(t *testing.T) {
+		db := newProgressDB(t)
+		seedProgressRow(t, db, "p", "m", 7200, 7200, true, old)
+		// 5000/7200 = 69% > RestartDetectFraction (50%) -> not a restart.
+		if err := UpdateProgress(db, "p", "m", 5000, 7200, th); err != nil {
+			t.Fatalf("UpdateProgress: %v", err)
+		}
+		wp := mustGetProgress(t, db, "p", "m")
+		if !wp.Completed || wp.PositionSeconds != 7200 {
+			t.Fatalf("got completed=%v pos=%v, want completed=true pos=7200", wp.Completed, wp.PositionSeconds)
+		}
+	})
+
+	t.Run("recent completion blocks restart (time guard)", func(t *testing.T) {
+		db := newProgressDB(t)
+		recent := fixedNow.Add(-5 * time.Second) // < RestartMinGapSeconds before fixedNow
+		seedProgressRow(t, db, "p", "m", 7200, 7200, true, recent)
+		// Early position but only seconds after completion -> stale heartbeat,
+		// must NOT release the latch.
+		if err := UpdateProgress(db, "p", "m", 300, 7200, th); err != nil {
+			t.Fatalf("UpdateProgress: %v", err)
+		}
+		wp := mustGetProgress(t, db, "p", "m")
+		if !wp.Completed || wp.PositionSeconds != 7200 {
+			t.Fatalf("got completed=%v pos=%v, want completed=true pos=7200 (time guard)", wp.Completed, wp.PositionSeconds)
+		}
+	})
+
+	t.Run("completion still latches forward", func(t *testing.T) {
+		db := newProgressDB(t)
+		seedProgressRow(t, db, "p", "m", 300, 7200, false, old)
+		// 6600/7200 = 91.7% > WatchedFraction (90%) -> completes.
+		if err := UpdateProgress(db, "p", "m", 6600, 7200, th); err != nil {
+			t.Fatalf("UpdateProgress: %v", err)
+		}
+		wp := mustGetProgress(t, db, "p", "m")
+		if !wp.Completed || wp.PositionSeconds != 7200 {
+			t.Fatalf("got completed=%v pos=%v, want completed=true pos=7200", wp.Completed, wp.PositionSeconds)
+		}
+	})
+
+	t.Run("multi-version duration change uses GREATEST duration", func(t *testing.T) {
+		db := newProgressDB(t)
+		seedProgressRow(t, db, "p", "m", 7200, 7200, true, old)
+		// Director's cut: 4000 < MAX(9000,7200)*0.5 = 4500 -> restart.
+		if err := UpdateProgress(db, "p", "m", 4000, 9000, th); err != nil {
+			t.Fatalf("UpdateProgress: %v", err)
+		}
+		wp := mustGetProgress(t, db, "p", "m")
+		if wp.Completed || wp.PositionSeconds != 4000 {
+			t.Fatalf("got completed=%v pos=%v, want completed=false pos=4000", wp.Completed, wp.PositionSeconds)
+		}
+	})
+
+	t.Run("stored duration zero falls back to heartbeat duration", func(t *testing.T) {
+		db := newProgressDB(t)
+		seedProgressRow(t, db, "p", "m", 0, 0, true, old)
+		// 300/3600 = 8.3% passes min-resume; 300 < MAX(3600,0)*0.5 = 1800 -> restart.
+		if err := UpdateProgress(db, "p", "m", 300, 3600, th); err != nil {
+			t.Fatalf("UpdateProgress: %v", err)
+		}
+		wp := mustGetProgress(t, db, "p", "m")
+		if wp.Completed || wp.PositionSeconds != 300 {
+			t.Fatalf("got completed=%v pos=%v, want completed=false pos=300", wp.Completed, wp.PositionSeconds)
+		}
+	})
+
+	t.Run("below min-resume heartbeat is discarded", func(t *testing.T) {
+		db := newProgressDB(t)
+		seedProgressRow(t, db, "p", "m", 7200, 7200, true, old)
+		// 100/7200 = 1.4% < MinResumeFraction (5%) -> early return, no write.
+		if err := UpdateProgress(db, "p", "m", 100, 7200, th); err != nil {
+			t.Fatalf("UpdateProgress: %v", err)
+		}
+		wp := mustGetProgress(t, db, "p", "m")
+		if !wp.Completed || wp.PositionSeconds != 7200 {
+			t.Fatalf("got completed=%v pos=%v, want unchanged completed=true pos=7200", wp.Completed, wp.PositionSeconds)
+		}
+	})
+}

--- a/internal/userstore/pgstore/progress.go
+++ b/internal/userstore/pgstore/progress.go
@@ -64,12 +64,36 @@ func (s *PostgresUserStore) UpdateProgress(ctx context.Context, profileID, media
 		INSERT INTO user_watch_progress (user_id, profile_id, media_item_id, position_seconds, duration_seconds, completed, updated_at)
 		VALUES ($1, $2, $3, $4, $5, $6, $7)
 		ON CONFLICT(user_id, profile_id, media_item_id) DO UPDATE SET
-			position_seconds = GREATEST(excluded.position_seconds, user_watch_progress.position_seconds),
+			position_seconds = CASE
+				-- Re-watch of a finished item: an early-position heartbeat
+				-- (below RestartDetectFraction of the runtime) lands on a row
+				-- already completed, at least RestartMinGapSeconds after it was
+				-- finished. Adopt the fresh resume point instead of keeping the
+				-- stale end-of-file position so "Continue Watching" resumes
+				-- correctly. The time gap rejects stale heartbeats from a
+				-- concurrent/offline session arriving just after completion.
+				WHEN NOT excluded.completed
+					AND user_watch_progress.completed
+					AND excluded.position_seconds < GREATEST(excluded.duration_seconds, user_watch_progress.duration_seconds) * $8
+					AND excluded.updated_at - user_watch_progress.updated_at > make_interval(secs => $9)
+					THEN excluded.position_seconds
+				ELSE GREATEST(excluded.position_seconds, user_watch_progress.position_seconds)
+			END,
 			duration_seconds = excluded.duration_seconds,
-			completed = CASE WHEN excluded.completed
-				THEN TRUE ELSE user_watch_progress.completed END,
+			completed = CASE
+				WHEN excluded.completed THEN TRUE
+				-- Same re-watch signal releases the completed latch so the
+				-- item re-enters "Continue Watching". Only fires on an already
+				-- completed row; in-progress rows keep their prior semantics.
+				WHEN user_watch_progress.completed
+					AND excluded.position_seconds < GREATEST(excluded.duration_seconds, user_watch_progress.duration_seconds) * $8
+					AND excluded.updated_at - user_watch_progress.updated_at > make_interval(secs => $9)
+					THEN FALSE
+				ELSE user_watch_progress.completed
+			END,
 			updated_at = excluded.updated_at`,
 		s.userID, profileID, mediaItemID, position, duration, completed, now,
+		userstore.RestartDetectFraction, userstore.RestartMinGapSeconds,
 	)
 	if err != nil {
 		return fmt.Errorf("updating progress: %w", err)

--- a/internal/userstore/threshold.go
+++ b/internal/userstore/threshold.go
@@ -7,6 +7,21 @@ type ProgressThresholds struct {
 	MinResumePct int // discard progress below this % (default 5)
 }
 
+// RestartDetectFraction is the position fraction below which an in-progress
+// heartbeat landing on an already-completed row is treated as a genuine
+// rewatch-from-the-start (releasing the completed latch) rather than a stale
+// late heartbeat. The midpoint (0.5) sits well clear of both the min-resume
+// (5%) and watched (90%) thresholds, giving a wide, unambiguous detection band.
+const RestartDetectFraction = 0.5
+
+// RestartMinGapSeconds is the minimum elapsed time between a completed row's
+// last update and a new early-position heartbeat before the completed latch is
+// released. It guards against a stale heartbeat from a concurrent/offline
+// session (which lands within seconds of the completion event) spuriously
+// un-completing an item; a genuine rewatch's first qualifying heartbeat (past
+// the 5% min-resume floor) arrives minutes later.
+const RestartMinGapSeconds = 60
+
 // WatchedFraction converts a watched-threshold percentage (e.g. 90) to a
 // fraction (0.9). If pct <= 0, returns the default of 0.9 (90%).
 func WatchedFraction(pct int) float64 {


### PR DESCRIPTION
## Problem

Re-watching an already-finished item never re-enters the **Continue Watching** row until the user manually marks it *unwatched*.

The row is built by `ListProgress(profileID, "in_progress")`, whose SQL filters `user_watch_progress` to `WHERE completed = FALSE`. But the playback heartbeat path (`UpdateProgress`, used by both the native player and the jellycompat stream handler) latched `completed` one-way:

```sql
completed = CASE WHEN excluded.completed THEN TRUE ELSE user_watch_progress.completed END,
position_seconds = GREATEST(excluded.position_seconds, user_watch_progress.position_seconds)
```

Once an item is finished (`completed = TRUE`, position reset to duration), starting it again reports a fresh low position — but the `CASE` keeps `completed = TRUE` and `GREATEST` keeps the old end-of-file position, so the re-watch is invisible to the in-progress query forever. Only `ClearProgress`/`ClearProgressBatch` (mark-unwatched) releases the latch.

## Fix

In `UpdateProgress`, release the latch and adopt the fresh resume point when an early-position heartbeat lands on an already-completed row — gated by two guards:

- **Fraction guard** (`RestartDetectFraction = 0.5`): the incoming position must be below 50% of the max known runtime, distinguishing a genuine rewatch-from-the-start from a brief end-of-file seek. `GREATEST/MAX(excluded, stored)` duration handles multi-version/edition rewatches where the runtime differs.
- **Time-gap guard** (`RestartMinGapSeconds = 60`): at least 60s must have elapsed since the row was last updated, rejecting a stale heartbeat from a concurrent/offline session arriving just after completion.

Both guards are AND-ed, so any failure (including a NULL `julianday` in the SQLite path) defaults to keeping the item completed — the conservative choice.

Scoped to `UpdateProgress` only. In-progress rows (`completed = FALSE`) are provably unchanged (both new branches require `completed = TRUE`), and existing finished rows are untouched until actually re-watched.

The SQLite `userdb` store gets the same logic, plus the min-resume early-return guard it was previously missing (silent divergence from the Postgres store).

## Testing

- New table-driven tests (`internal/userdb`): in-progress unchanged, rewatch releases latch + adopts position, late heartbeat (>50%) does not release, recent completion (<60s) blocked by the time guard, completion still latches, multi-version duration via `MAX`, zero stored duration fallback, below-min-resume discard. `go test ./internal/userdb/ ./internal/userstore/...` passes; `go build` clean; `gofmt` clean.
- Postgres CASE logic validated against a live populated catalog; deployed and confirmed fixing the reported behavior.

---
AI-assisted: implementation and tests were written with Claude and reviewed line-by-line by me.