### PR TITLE
feat(jellycompat): BoxSet collections, genre-by-name, and airtight ABS media exclusion

### DIFF
--- a/internal/catalog/access_filter.go
+++ b/internal/catalog/access_filter.go
@@ -25,6 +25,11 @@ type AccessFilter struct {
 	// given (case-insensitive) prefix. Pushed into the SQL WHERE clause so
 	// the predicate can use idx_media_items_sort_key.
 	NamePrefix string
+	// ExcludedMediaTypes lists media_items.type values the viewer's surface
+	// never exposes (e.g. the Jellyfin compat layer excludes "audiobook" and
+	// "podcast" — they're served by the ABS-compat API instead). Applied by
+	// every query builder that consumes an AccessFilter.
+	ExcludedMediaTypes []string
 }
 
 func applyAccessFilter(alias string, filter AccessFilter, conditions *[]string, args *[]any, argIdx *int) {
@@ -37,6 +42,11 @@ func applyAccessFilter(alias string, filter AccessFilter, conditions *[]string, 
 			*args = append(*args, allowedRatings)
 			*argIdx = *argIdx + 1
 		}
+	}
+	if len(filter.ExcludedMediaTypes) > 0 {
+		*conditions = append(*conditions, fmt.Sprintf("NOT (%s.type = ANY($%d))", alias, *argIdx))
+		*args = append(*args, filter.ExcludedMediaTypes)
+		*argIdx = *argIdx + 1
 	}
 }
 

--- a/internal/catalog/favorites_browse.go
+++ b/internal/catalog/favorites_browse.go
@@ -24,8 +24,9 @@ type BrowseFavoritesFilters struct {
 	AllowedLibraryIDs  []int  // nil = no allowlist, []int{} = empty result
 	DisabledLibraryIDs []int  // user-disabled libraries to exclude
 	MaxContentRating   string
-	SortField          string // "added_at" (default), "title"/"sort_title", "year", "release_date"
-	SortOrder          string // "asc" or "desc" (default desc)
+	ExcludedMediaTypes []string // media types the caller's surface never exposes
+	SortField          string   // "added_at" (default), "title"/"sort_title", "year", "release_date"
+	SortOrder          string   // "asc" or "desc" (default desc)
 	Limit              int
 	Offset             int
 }
@@ -230,7 +231,7 @@ func buildBrowseFavoritesPlan(f BrowseFavoritesFilters) (browseFavoritesPlan, er
 		argIdx++
 	}
 
-	applyAccessFilter("mi", AccessFilter{MaxContentRating: f.MaxContentRating}, &conditions, &args, &argIdx)
+	applyAccessFilter("mi", AccessFilter{MaxContentRating: f.MaxContentRating, ExcludedMediaTypes: f.ExcludedMediaTypes}, &conditions, &args, &argIdx)
 
 	orderBy := buildBrowseFavoritesOrderBy(f.SortField, f.SortOrder)
 

--- a/internal/catalog/item_repo.go
+++ b/internal/catalog/item_repo.go
@@ -620,9 +620,9 @@ func (r *ItemRepository) buildGetByIDsWithAccessSQL(contentIDs []string, access 
 		argIdx++
 	}
 
-	// Apply MaxContentRating like applyAccessFilter does.
+	// Apply MaxContentRating and type exclusions like applyAccessFilter does.
 	var ratingConditions []string
-	applyAccessFilter("mi", AccessFilter{MaxContentRating: access.MaxContentRating}, &ratingConditions, &args, &argIdx)
+	applyAccessFilter("mi", AccessFilter{MaxContentRating: access.MaxContentRating, ExcludedMediaTypes: access.ExcludedMediaTypes}, &ratingConditions, &args, &argIdx)
 	for _, c := range ratingConditions {
 		sql += " AND " + c
 	}
@@ -947,7 +947,7 @@ func (r *ItemRepository) buildSearchSQL(query string, itemTypes []string, limit,
 	if needsLibJoin {
 		fromClause = "media_items mi JOIN media_item_libraries mil ON mi.content_id = mil.content_id"
 	}
-	applyAccessFilter("mi", AccessFilter{MaxContentRating: filter.MaxContentRating}, &conditions, &args, &argIdx)
+	applyAccessFilter("mi", AccessFilter{MaxContentRating: filter.MaxContentRating, ExcludedMediaTypes: filter.ExcludedMediaTypes}, &conditions, &args, &argIdx)
 
 	whereClause := "WHERE " + strings.Join(conditions, " AND ")
 
@@ -1161,7 +1161,7 @@ func (r *ItemRepository) EnsureAccessible(ctx context.Context, contentID string,
 		fromClause = "media_items mi JOIN media_item_libraries mil ON mi.content_id = mil.content_id"
 	}
 
-	applyAccessFilter("mi", AccessFilter{MaxContentRating: filter.MaxContentRating}, &conditions, &args, &argIdx)
+	applyAccessFilter("mi", AccessFilter{MaxContentRating: filter.MaxContentRating, ExcludedMediaTypes: filter.ExcludedMediaTypes}, &conditions, &args, &argIdx)
 
 	query := fmt.Sprintf("SELECT 1 FROM %s WHERE %s LIMIT 1", fromClause, strings.Join(conditions, " AND "))
 	var found int

--- a/internal/jellycompat/audiobook_exclusion_test.go
+++ b/internal/jellycompat/audiobook_exclusion_test.go
@@ -22,6 +22,9 @@ func TestCompatScopedTypes(t *testing.T) {
 		{" Audiobook ", compatNoMatchType},
 		{"podcast", compatNoMatchType},
 		{"movie,podcast", "movie"},
+		// Non-video types outside the allowlist are dropped, not passed through.
+		{"musicalbum", compatNoMatchType},
+		{"movie,musicalbum", "movie"},
 	}
 	for _, tc := range cases {
 		if got := compatScopedTypes(tc.in); got != tc.want {
@@ -79,6 +82,24 @@ func TestCompatAccessFilterResolverStampsExclusions(t *testing.T) {
 		}
 		if !found {
 			t.Fatalf("expected %q in ExcludedMediaTypes, got %v", want, resolved.ExcludedMediaTypes)
+		}
+	}
+
+	// Pre-existing exclusions from the base resolver are preserved AND the
+	// compat exclusions are merged in (not conditionally skipped).
+	withExisting := func(context.Context, int, string) catalog.AccessFilter {
+		return catalog.AccessFilter{ExcludedMediaTypes: []string{"livetv"}}
+	}
+	resolved = compatAccessFilterResolver(withExisting)(context.Background(), 1, "p1")
+	for _, want := range []string{"livetv", "audiobook", "podcast"} {
+		found := false
+		for _, got := range resolved.ExcludedMediaTypes {
+			if got == want {
+				found = true
+			}
+		}
+		if !found {
+			t.Fatalf("expected %q in merged ExcludedMediaTypes, got %v", want, resolved.ExcludedMediaTypes)
 		}
 	}
 }

--- a/internal/jellycompat/audiobook_exclusion_test.go
+++ b/internal/jellycompat/audiobook_exclusion_test.go
@@ -1,0 +1,150 @@
+package jellycompat
+
+import (
+	"context"
+	"net/url"
+	"testing"
+
+	"github.com/Silo-Server/silo-server/internal/catalog"
+	"github.com/Silo-Server/silo-server/internal/models"
+)
+
+func TestCompatScopedTypes(t *testing.T) {
+	cases := []struct {
+		in   string
+		want string
+	}{
+		{"", compatVideoTypes},
+		{"movie", "movie"},
+		{"movie,series", "movie,series"},
+		{"audiobook", compatNoMatchType},
+		{"movie,audiobook", "movie"},
+		{" Audiobook ", compatNoMatchType},
+	}
+	for _, tc := range cases {
+		if got := compatScopedTypes(tc.in); got != tc.want {
+			t.Errorf("compatScopedTypes(%q) = %q, want %q", tc.in, got, tc.want)
+		}
+	}
+}
+
+func TestCompatScopedSearchTypes(t *testing.T) {
+	if got := compatScopedSearchTypes(nil); len(got) != 3 {
+		t.Fatalf("expected video type default, got %v", got)
+	}
+	got := compatScopedSearchTypes([]string{"movie", "audiobook"})
+	if len(got) != 1 || got[0] != "movie" {
+		t.Fatalf("expected [movie], got %v", got)
+	}
+	got = compatScopedSearchTypes([]string{"audiobook"})
+	if len(got) != 1 || got[0] != compatNoMatchType {
+		t.Fatalf("expected no-match sentinel, got %v", got)
+	}
+}
+
+func TestIsAudiobookLibraryType(t *testing.T) {
+	for _, val := range []string{"audiobooks", "audiobook", " Audiobooks "} {
+		if !isAudiobookLibraryType(val) {
+			t.Errorf("expected %q to be an audiobook library type", val)
+		}
+	}
+	for _, val := range []string{"movies", "series", "mixed", ""} {
+		if isAudiobookLibraryType(val) {
+			t.Errorf("expected %q to not be an audiobook library type", val)
+		}
+	}
+}
+
+// scopeFakeFolderRepo returns a fixed folder list.
+type scopeFakeFolderRepo struct {
+	folders []*models.MediaFolder
+}
+
+func (f *scopeFakeFolderRepo) GetEnabled(context.Context) ([]*models.MediaFolder, error) {
+	return f.folders, nil
+}
+
+func (f *scopeFakeFolderRepo) ListByIDs(_ context.Context, ids []int) ([]*models.MediaFolder, error) {
+	out := make([]*models.MediaFolder, 0, len(ids))
+	for _, folder := range f.folders {
+		for _, id := range ids {
+			if folder.ID == id {
+				out = append(out, folder)
+			}
+		}
+	}
+	return out, nil
+}
+
+func TestListUserLibrariesExcludesAudiobookFolders(t *testing.T) {
+	svc := &directContentService{
+		folderRepo: &scopeFakeFolderRepo{folders: []*models.MediaFolder{
+			{ID: 1, Name: "Movies", Type: "movies", Enabled: true},
+			{ID: 2, Name: "Audiobooks", Type: "audiobooks", Enabled: true},
+			{ID: 3, Name: "Shows", Type: "series", Enabled: true},
+			{ID: 4, Name: "Legacy Books", Type: "audiobook", Enabled: true},
+		}},
+	}
+
+	libraries, err := svc.ListUserLibraries(context.Background(), &Session{StreamAppUserID: 1, ProfileID: "p1"})
+	if err != nil {
+		t.Fatalf("ListUserLibraries: %v", err)
+	}
+	if len(libraries) != 2 {
+		t.Fatalf("expected 2 libraries, got %d: %+v", len(libraries), libraries)
+	}
+	for _, lib := range libraries {
+		if lib.Name == "Audiobooks" || lib.Name == "Legacy Books" {
+			t.Fatalf("audiobook library %q leaked into compat views", lib.Name)
+		}
+	}
+}
+
+// scopeFakeBrowseSource captures the filters passed to BrowsePage.
+type scopeFakeBrowseSource struct {
+	lastFilters catalog.BrowseFilters
+}
+
+func (f *scopeFakeBrowseSource) BrowsePage(_ context.Context, filters catalog.BrowseFilters, _ bool) (*catalog.BrowseResult, error) {
+	f.lastFilters = filters
+	return &catalog.BrowseResult{Items: []*models.MediaItem{}, Total: 0, HasMore: false}, nil
+}
+
+func (f *scopeFakeBrowseSource) ListGenres(_ context.Context, filters catalog.BrowseFilters) ([]string, error) {
+	f.lastFilters = filters
+	return []string{}, nil
+}
+
+func TestBrowseItemsDefaultsToVideoTypeScope(t *testing.T) {
+	browse := &scopeFakeBrowseSource{}
+	svc := &directContentService{browseRepo: browse}
+	session := &Session{StreamAppUserID: 1, ProfileID: "p1"}
+
+	if _, err := svc.BrowseItems(context.Background(), session, url.Values{}); err != nil {
+		t.Fatalf("BrowseItems: %v", err)
+	}
+	if browse.lastFilters.Type != compatVideoTypes {
+		t.Fatalf("expected default type scope %q, got %q", compatVideoTypes, browse.lastFilters.Type)
+	}
+
+	params := url.Values{}
+	params.Set("type", "movie")
+	if _, err := svc.BrowseItems(context.Background(), session, params); err != nil {
+		t.Fatalf("BrowseItems: %v", err)
+	}
+	if browse.lastFilters.Type != "movie" {
+		t.Fatalf("expected explicit type to pass through, got %q", browse.lastFilters.Type)
+	}
+}
+
+func TestListItemFiltersDefaultsToVideoTypeScope(t *testing.T) {
+	browse := &scopeFakeBrowseSource{}
+	svc := &directContentService{browseRepo: browse}
+
+	if _, err := svc.ListItemFilters(context.Background(), &Session{StreamAppUserID: 1, ProfileID: "p1"}, url.Values{}); err != nil {
+		t.Fatalf("ListItemFilters: %v", err)
+	}
+	if browse.lastFilters.Type != compatVideoTypes {
+		t.Fatalf("expected genre listing scoped to %q, got %q", compatVideoTypes, browse.lastFilters.Type)
+	}
+}

--- a/internal/jellycompat/audiobook_exclusion_test.go
+++ b/internal/jellycompat/audiobook_exclusion_test.go
@@ -20,6 +20,8 @@ func TestCompatScopedTypes(t *testing.T) {
 		{"audiobook", compatNoMatchType},
 		{"movie,audiobook", "movie"},
 		{" Audiobook ", compatNoMatchType},
+		{"podcast", compatNoMatchType},
+		{"movie,podcast", "movie"},
 	}
 	for _, tc := range cases {
 		if got := compatScopedTypes(tc.in); got != tc.want {
@@ -42,15 +44,41 @@ func TestCompatScopedSearchTypes(t *testing.T) {
 	}
 }
 
-func TestIsAudiobookLibraryType(t *testing.T) {
-	for _, val := range []string{"audiobooks", "audiobook", " Audiobooks "} {
-		if !isAudiobookLibraryType(val) {
-			t.Errorf("expected %q to be an audiobook library type", val)
+func TestIsCompatHiddenLibraryType(t *testing.T) {
+	for _, val := range []string{"audiobooks", "audiobook", " Audiobooks ", "podcast", "podcasts"} {
+		if !isCompatHiddenLibraryType(val) {
+			t.Errorf("expected %q to be hidden from the compat surface", val)
 		}
 	}
 	for _, val := range []string{"movies", "series", "mixed", ""} {
-		if isAudiobookLibraryType(val) {
-			t.Errorf("expected %q to not be an audiobook library type", val)
+		if isCompatHiddenLibraryType(val) {
+			t.Errorf("expected %q to be visible on the compat surface", val)
+		}
+	}
+}
+
+func TestCompatAccessFilterResolverStampsExclusions(t *testing.T) {
+	resolved := compatAccessFilterResolver(nil)(context.Background(), 1, "p1")
+	if len(resolved.ExcludedMediaTypes) == 0 {
+		t.Fatalf("expected exclusions on nil base resolver, got %+v", resolved)
+	}
+
+	base := func(context.Context, int, string) catalog.AccessFilter {
+		return catalog.AccessFilter{MaxContentRating: "PG-13"}
+	}
+	resolved = compatAccessFilterResolver(base)(context.Background(), 1, "p1")
+	if resolved.MaxContentRating != "PG-13" {
+		t.Fatalf("expected base filter fields preserved, got %+v", resolved)
+	}
+	for _, want := range []string{"audiobook", "podcast"} {
+		found := false
+		for _, got := range resolved.ExcludedMediaTypes {
+			if got == want {
+				found = true
+			}
+		}
+		if !found {
+			t.Fatalf("expected %q in ExcludedMediaTypes, got %v", want, resolved.ExcludedMediaTypes)
 		}
 	}
 }
@@ -76,13 +104,14 @@ func (f *scopeFakeFolderRepo) ListByIDs(_ context.Context, ids []int) ([]*models
 	return out, nil
 }
 
-func TestListUserLibrariesExcludesAudiobookFolders(t *testing.T) {
+func TestListUserLibrariesExcludesABSFolders(t *testing.T) {
 	svc := &directContentService{
 		folderRepo: &scopeFakeFolderRepo{folders: []*models.MediaFolder{
 			{ID: 1, Name: "Movies", Type: "movies", Enabled: true},
 			{ID: 2, Name: "Audiobooks", Type: "audiobooks", Enabled: true},
 			{ID: 3, Name: "Shows", Type: "series", Enabled: true},
 			{ID: 4, Name: "Legacy Books", Type: "audiobook", Enabled: true},
+			{ID: 5, Name: "Podcasts", Type: "podcasts", Enabled: true},
 		}},
 	}
 
@@ -94,8 +123,8 @@ func TestListUserLibrariesExcludesAudiobookFolders(t *testing.T) {
 		t.Fatalf("expected 2 libraries, got %d: %+v", len(libraries), libraries)
 	}
 	for _, lib := range libraries {
-		if lib.Name == "Audiobooks" || lib.Name == "Legacy Books" {
-			t.Fatalf("audiobook library %q leaked into compat views", lib.Name)
+		if lib.Name != "Movies" && lib.Name != "Shows" {
+			t.Fatalf("ABS-surface library %q leaked into compat views", lib.Name)
 		}
 	}
 }

--- a/internal/jellycompat/auth_test.go
+++ b/internal/jellycompat/auth_test.go
@@ -130,9 +130,9 @@ func TestPlaybackSessionAuth_CaseInsensitivePlaySessionId(t *testing.T) {
 	mw := PlaybackSessionAuth(sessions, playbackStore, nil)
 
 	cases := []struct {
-		name      string
-		rawQuery  string
-		wantCode  int
+		name     string
+		rawQuery string
+		wantCode int
 	}{
 		// Wholphin's jellyfin-sdk-kotlin direct-play URL: lowercase playSessionId,
 		// no api_key and no auth header. Previously 401'd (case-sensitive lookup).

--- a/internal/jellycompat/batch_loaders.go
+++ b/internal/jellycompat/batch_loaders.go
@@ -56,8 +56,7 @@ func (h *ItemsHandler) fetchCompatItemsByContentIDs(ctx context.Context, session
 
 	access := h.resolveAccessFilter(ctx, session)
 	fromClause := "media_items mi"
-	// Audiobooks are never exposed on the Jellyfin compat surface.
-	conditions := []string{"mi.content_id = ANY($1)", "mi.type <> 'audiobook'"}
+	conditions := []string{"mi.content_id = ANY($1)"}
 	args := []any{normalized}
 	argIdx := 2
 
@@ -127,10 +126,6 @@ func (h *ItemsHandler) fetchCompatItemsByContentIDsFallback(ctx context.Context,
 		return nil, err
 	}
 	for _, item := range items {
-		// Audiobooks are never exposed on the Jellyfin compat surface.
-		if strings.EqualFold(item.Type, "audiobook") {
-			continue
-		}
 		listItem := mediaItemToListItem(item)
 		h.presignCompatListItem(ctx, &listItem)
 		result[item.ContentID] = listItem

--- a/internal/jellycompat/batch_loaders.go
+++ b/internal/jellycompat/batch_loaders.go
@@ -56,7 +56,8 @@ func (h *ItemsHandler) fetchCompatItemsByContentIDs(ctx context.Context, session
 
 	access := h.resolveAccessFilter(ctx, session)
 	fromClause := "media_items mi"
-	conditions := []string{"mi.content_id = ANY($1)"}
+	// Audiobooks are never exposed on the Jellyfin compat surface.
+	conditions := []string{"mi.content_id = ANY($1)", "mi.type <> 'audiobook'"}
 	args := []any{normalized}
 	argIdx := 2
 
@@ -126,6 +127,10 @@ func (h *ItemsHandler) fetchCompatItemsByContentIDsFallback(ctx context.Context,
 		return nil, err
 	}
 	for _, item := range items {
+		// Audiobooks are never exposed on the Jellyfin compat surface.
+		if strings.EqualFold(item.Type, "audiobook") {
+			continue
+		}
 		listItem := mediaItemToListItem(item)
 		h.presignCompatListItem(ctx, &listItem)
 		result[item.ContentID] = listItem

--- a/internal/jellycompat/content_direct.go
+++ b/internal/jellycompat/content_direct.go
@@ -36,6 +36,72 @@ const (
 	compatBrowseMaxLimit   = 1000
 )
 
+// compatVideoTypes is the media_items type scope the Jellyfin compat surface
+// exposes when a request carries no explicit type filter. Silo serves
+// audiobooks through the audiobookshelf-compat API instead, so audiobook rows
+// must never leak into jellycompat responses.
+const compatVideoTypes = "movie,series,episode"
+
+// compatVideoTypeList is compatVideoTypes as a slice for APIs that take
+// []string (e.g. ItemRepository.Search).
+var compatVideoTypeList = []string{"movie", "series", "episode"}
+
+// isAudiobookLibraryType reports whether a media folder type marks an
+// audiobook library ('audiobooks' is canonical, 'audiobook' is legacy —
+// mirrors internal/audiobooks/media_store.go).
+func isAudiobookLibraryType(folderType string) bool {
+	switch strings.ToLower(strings.TrimSpace(folderType)) {
+	case "audiobooks", "audiobook":
+		return true
+	}
+	return false
+}
+
+// compatNoMatchType is a sentinel media type that matches no media_items row.
+// Used when a caller's explicit type filter reduces to nothing exposable so
+// the query returns empty instead of silently broadening to all video types.
+const compatNoMatchType = "__compat_none__"
+
+// compatScopedTypes clamps a catalog type filter to the video types the
+// Jellyfin compat surface exposes. An empty filter defaults to all video
+// types; explicit filters keep their entries minus "audiobook".
+func compatScopedTypes(raw string) string {
+	raw = strings.TrimSpace(raw)
+	if raw == "" {
+		return compatVideoTypes
+	}
+	kept := make([]string, 0, 4)
+	for part := range strings.SplitSeq(raw, ",") {
+		t := strings.ToLower(strings.TrimSpace(part))
+		if t == "" || t == "audiobook" {
+			continue
+		}
+		kept = append(kept, t)
+	}
+	if len(kept) == 0 {
+		return compatNoMatchType
+	}
+	return strings.Join(kept, ",")
+}
+
+// compatScopedSearchTypes is compatScopedTypes for []string item-type filters.
+func compatScopedSearchTypes(itemTypes []string) []string {
+	if len(itemTypes) == 0 {
+		return compatVideoTypeList
+	}
+	kept := make([]string, 0, len(itemTypes))
+	for _, t := range itemTypes {
+		if strings.EqualFold(strings.TrimSpace(t), "audiobook") {
+			continue
+		}
+		kept = append(kept, t)
+	}
+	if len(kept) == 0 {
+		return []string{compatNoMatchType}
+	}
+	return kept
+}
+
 // itemAccessSource is the subset of *catalog.ItemRepository that
 // directContentService season/episode handlers rely on. Defined as an
 // interface so tests can substitute a stub without standing up a Postgres
@@ -168,6 +234,10 @@ func (s *directContentService) ListUserLibraries(ctx context.Context, session *S
 		if _, ok := disabled[f.ID]; ok {
 			continue
 		}
+		// Audiobook libraries are served by the ABS-compat API, never here.
+		if isAudiobookLibraryType(f.Type) {
+			continue
+		}
 		lib := upstreamUserLibrary{
 			ID:         f.ID,
 			Name:       f.Name,
@@ -212,7 +282,7 @@ func (s *directContentService) BrowseItems(ctx context.Context, session *Session
 	}
 
 	filters := catalog.BrowseFilters{
-		Type:               params.Get("type"),
+		Type:               compatScopedTypes(params.Get("type")),
 		Genre:              params.Get("genre"),
 		NamePrefix:         params.Get("name_prefix"),
 		ContentIDs:         contentIDs,
@@ -335,7 +405,7 @@ func parseContentIDParam(raw string) []string {
 func (s *directContentService) SearchItems(ctx context.Context, session *Session, query string, itemTypes []string, limit, offset int, libraryID *int) (*upstreamBrowseResponse, error) {
 	filter := applyCompatPresentationLibrary(s.resolveFilter(ctx, session), libraryID)
 
-	items, total, err := s.itemRepo.Search(ctx, query, itemTypes, limit, offset, filter)
+	items, total, err := s.itemRepo.Search(ctx, query, compatScopedSearchTypes(itemTypes), limit, offset, filter)
 	if err != nil {
 		return nil, fmt.Errorf("search items: %w", err)
 	}
@@ -365,6 +435,11 @@ func (s *directContentService) GetItemDetail(ctx context.Context, session *Sessi
 	detail, err := s.detailSvc.GetItemDetail(ctx, contentID, filter)
 	if err != nil {
 		return nil, wrapCatalogError(err)
+	}
+	// Audiobooks are not exposed on the Jellyfin compat surface (this guard
+	// also blocks PlaybackInfo, which resolves items through GetItemDetail).
+	if strings.EqualFold(detail.Type, "audiobook") {
+		return nil, &HTTPError{StatusCode: 404, Message: "item not found"}
 	}
 
 	result := itemDetailToUpstream(detail)
@@ -550,7 +625,7 @@ func (s *directContentService) ListItemFilters(ctx context.Context, session *Ses
 	filter := s.resolveFilter(ctx, session)
 
 	filters := catalog.BrowseFilters{
-		Type:               params.Get("type"),
+		Type:               compatScopedTypes(params.Get("type")),
 		LibraryID:          catalog.ParseIntParam(params.Get("library_id")),
 		LibraryIDs:         filter.AllowedLibraryIDs,
 		DisabledLibraryIDs: filter.DisabledLibraryIDs,

--- a/internal/jellycompat/content_direct.go
+++ b/internal/jellycompat/content_direct.go
@@ -74,13 +74,26 @@ func isCompatHiddenLibraryType(folderType string) bool {
 	return false
 }
 
-// withCompatAccessExclusions stamps the compat surface's media-type
-// exclusions onto a resolved access filter. Centralizing the exclusion here
-// lets catalog query builders enforce it everywhere an AccessFilter flows.
+// withCompatAccessExclusions merges the compat surface's media-type
+// exclusions into a resolved access filter, preserving any exclusions the
+// base resolver already supplied. Centralizing the exclusion here lets
+// catalog query builders enforce it everywhere an AccessFilter flows.
 func withCompatAccessExclusions(filter catalog.AccessFilter) catalog.AccessFilter {
-	if len(filter.ExcludedMediaTypes) == 0 {
-		filter.ExcludedMediaTypes = compatExcludedMediaTypes
+	merged := make([]string, 0, len(filter.ExcludedMediaTypes)+len(compatExcludedMediaTypes))
+	merged = append(merged, filter.ExcludedMediaTypes...)
+	for _, excluded := range compatExcludedMediaTypes {
+		present := false
+		for _, existing := range merged {
+			if strings.EqualFold(existing, excluded) {
+				present = true
+				break
+			}
+		}
+		if !present {
+			merged = append(merged, excluded)
+		}
 	}
+	filter.ExcludedMediaTypes = merged
 	return filter
 }
 
@@ -101,10 +114,20 @@ func compatAccessFilterResolver(base AccessFilterResolver) AccessFilterResolver 
 // the query returns empty instead of silently broadening to all video types.
 const compatNoMatchType = "__compat_none__"
 
+// compatAllowedTypeSet is the closed set of catalog types an explicit compat
+// type filter may pass through ("season" matches no media_items row but is
+// kept so season-typed filters keep their empty-result semantics).
+var compatAllowedTypeSet = map[string]struct{}{
+	"movie":   {},
+	"series":  {},
+	"episode": {},
+	"season":  {},
+}
+
 // compatScopedSearchTypes clamps an item-type filter to the types the compat
 // surface exposes: empty defaults to all video types, explicit filters keep
-// their entries minus excluded ones, and a filter that reduces to nothing
-// returns the no-match sentinel.
+// only allowlisted entries, and a filter that reduces to nothing returns the
+// no-match sentinel.
 func compatScopedSearchTypes(itemTypes []string) []string {
 	if len(itemTypes) == 0 {
 		return compatVideoTypeList
@@ -112,7 +135,7 @@ func compatScopedSearchTypes(itemTypes []string) []string {
 	kept := make([]string, 0, len(itemTypes))
 	for _, t := range itemTypes {
 		t = strings.ToLower(strings.TrimSpace(t))
-		if t == "" || isCompatExcludedMediaType(t) {
+		if _, ok := compatAllowedTypeSet[t]; !ok {
 			continue
 		}
 		kept = append(kept, t)

--- a/internal/jellycompat/content_direct.go
+++ b/internal/jellycompat/content_direct.go
@@ -38,23 +38,62 @@ const (
 
 // compatVideoTypes is the media_items type scope the Jellyfin compat surface
 // exposes when a request carries no explicit type filter. Silo serves
-// audiobooks through the audiobookshelf-compat API instead, so audiobook rows
-// must never leak into jellycompat responses.
+// audiobooks and podcasts through the audiobookshelf-compat API instead, so
+// those rows must never leak into jellycompat responses.
 const compatVideoTypes = "movie,series,episode"
 
 // compatVideoTypeList is compatVideoTypes as a slice for APIs that take
 // []string (e.g. ItemRepository.Search).
-var compatVideoTypeList = []string{"movie", "series", "episode"}
+var compatVideoTypeList = strings.Split(compatVideoTypes, ",")
 
-// isAudiobookLibraryType reports whether a media folder type marks an
-// audiobook library ('audiobooks' is canonical, 'audiobook' is legacy —
-// mirrors internal/audiobooks/media_store.go).
-func isAudiobookLibraryType(folderType string) bool {
+// compatExcludedMediaTypes lists the media_items.type values the Jellyfin
+// compat surface never exposes. Injected into every catalog.AccessFilter the
+// compat layer resolves (see withCompatAccessExclusions) so access-filtered
+// queries — search, favorites, recommendations, detail, batch hydration —
+// inherit the exclusion without per-call-site guards.
+var compatExcludedMediaTypes = []string{"audiobook", "podcast"}
+
+func isCompatExcludedMediaType(mediaType string) bool {
+	for _, excluded := range compatExcludedMediaTypes {
+		if strings.EqualFold(strings.TrimSpace(mediaType), excluded) {
+			return true
+		}
+	}
+	return false
+}
+
+// isCompatHiddenLibraryType reports whether a media folder type marks a
+// library the Jellyfin compat surface hides. Audiobook ('audiobooks'
+// canonical, 'audiobook' legacy — mirrors internal/audiobooks/media_store.go)
+// and podcast libraries are served by the ABS-compat API instead.
+func isCompatHiddenLibraryType(folderType string) bool {
 	switch strings.ToLower(strings.TrimSpace(folderType)) {
-	case "audiobooks", "audiobook":
+	case "audiobooks", "audiobook", "podcasts", "podcast":
 		return true
 	}
 	return false
+}
+
+// withCompatAccessExclusions stamps the compat surface's media-type
+// exclusions onto a resolved access filter. Centralizing the exclusion here
+// lets catalog query builders enforce it everywhere an AccessFilter flows.
+func withCompatAccessExclusions(filter catalog.AccessFilter) catalog.AccessFilter {
+	if len(filter.ExcludedMediaTypes) == 0 {
+		filter.ExcludedMediaTypes = compatExcludedMediaTypes
+	}
+	return filter
+}
+
+// compatAccessFilterResolver wraps an AccessFilterResolver so every filter it
+// returns carries the compat media-type exclusions. A nil base resolver still
+// yields exclusion-only filters.
+func compatAccessFilterResolver(base AccessFilterResolver) AccessFilterResolver {
+	return func(ctx context.Context, userID int, profileID string) catalog.AccessFilter {
+		if base == nil {
+			return withCompatAccessExclusions(catalog.AccessFilter{})
+		}
+		return withCompatAccessExclusions(base(ctx, userID, profileID))
+	}
 }
 
 // compatNoMatchType is a sentinel media type that matches no media_items row.
@@ -62,36 +101,18 @@ func isAudiobookLibraryType(folderType string) bool {
 // the query returns empty instead of silently broadening to all video types.
 const compatNoMatchType = "__compat_none__"
 
-// compatScopedTypes clamps a catalog type filter to the video types the
-// Jellyfin compat surface exposes. An empty filter defaults to all video
-// types; explicit filters keep their entries minus "audiobook".
-func compatScopedTypes(raw string) string {
-	raw = strings.TrimSpace(raw)
-	if raw == "" {
-		return compatVideoTypes
-	}
-	kept := make([]string, 0, 4)
-	for part := range strings.SplitSeq(raw, ",") {
-		t := strings.ToLower(strings.TrimSpace(part))
-		if t == "" || t == "audiobook" {
-			continue
-		}
-		kept = append(kept, t)
-	}
-	if len(kept) == 0 {
-		return compatNoMatchType
-	}
-	return strings.Join(kept, ",")
-}
-
-// compatScopedSearchTypes is compatScopedTypes for []string item-type filters.
+// compatScopedSearchTypes clamps an item-type filter to the types the compat
+// surface exposes: empty defaults to all video types, explicit filters keep
+// their entries minus excluded ones, and a filter that reduces to nothing
+// returns the no-match sentinel.
 func compatScopedSearchTypes(itemTypes []string) []string {
 	if len(itemTypes) == 0 {
 		return compatVideoTypeList
 	}
 	kept := make([]string, 0, len(itemTypes))
 	for _, t := range itemTypes {
-		if strings.EqualFold(strings.TrimSpace(t), "audiobook") {
+		t = strings.ToLower(strings.TrimSpace(t))
+		if t == "" || isCompatExcludedMediaType(t) {
 			continue
 		}
 		kept = append(kept, t)
@@ -100,6 +121,15 @@ func compatScopedSearchTypes(itemTypes []string) []string {
 		return []string{compatNoMatchType}
 	}
 	return kept
+}
+
+// compatScopedTypes is compatScopedSearchTypes for comma-separated filters.
+func compatScopedTypes(raw string) string {
+	raw = strings.TrimSpace(raw)
+	if raw == "" {
+		return compatVideoTypes
+	}
+	return strings.Join(compatScopedSearchTypes(strings.Split(raw, ",")), ",")
 }
 
 // itemAccessSource is the subset of *catalog.ItemRepository that
@@ -176,9 +206,9 @@ func newDirectContentService(
 
 func (s *directContentService) resolveFilter(ctx context.Context, session *Session) catalog.AccessFilter {
 	if s.accessFilter != nil {
-		return s.accessFilter(ctx, session.StreamAppUserID, session.ProfileID)
+		return withCompatAccessExclusions(s.accessFilter(ctx, session.StreamAppUserID, session.ProfileID))
 	}
-	return catalog.AccessFilter{}
+	return withCompatAccessExclusions(catalog.AccessFilter{})
 }
 
 func applyCompatPresentationLibrary(filter catalog.AccessFilter, libraryID *int) catalog.AccessFilter {
@@ -234,8 +264,9 @@ func (s *directContentService) ListUserLibraries(ctx context.Context, session *S
 		if _, ok := disabled[f.ID]; ok {
 			continue
 		}
-		// Audiobook libraries are served by the ABS-compat API, never here.
-		if isAudiobookLibraryType(f.Type) {
+		// Audiobook and podcast libraries are served by the ABS-compat API,
+		// never here.
+		if isCompatHiddenLibraryType(f.Type) {
 			continue
 		}
 		lib := upstreamUserLibrary{
@@ -436,9 +467,10 @@ func (s *directContentService) GetItemDetail(ctx context.Context, session *Sessi
 	if err != nil {
 		return nil, wrapCatalogError(err)
 	}
-	// Audiobooks are not exposed on the Jellyfin compat surface (this guard
-	// also blocks PlaybackInfo, which resolves items through GetItemDetail).
-	if strings.EqualFold(detail.Type, "audiobook") {
+	// ABS-surface media types are not exposed on the Jellyfin compat surface
+	// (this guard also blocks PlaybackInfo, which resolves items through
+	// GetItemDetail).
+	if isCompatExcludedMediaType(detail.Type) {
 		return nil, &HTTPError{StatusCode: 404, Message: "item not found"}
 	}
 

--- a/internal/jellycompat/handlers_collections.go
+++ b/internal/jellycompat/handlers_collections.go
@@ -1,0 +1,309 @@
+package jellycompat
+
+import (
+	"context"
+	"net/http"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/Silo-Server/silo-server/internal/catalog"
+	"github.com/Silo-Server/silo-server/internal/models"
+)
+
+// collectionSource is the subset of *catalog.LibraryCollectionRepository the
+// compat layer relies on to expose library collections as Jellyfin BoxSets.
+type collectionSource interface {
+	ListAll(ctx context.Context, libraryID *int, opts catalog.ListLibraryCollectionsOptions) ([]*models.LibraryCollection, error)
+	GetByID(ctx context.Context, id string) (*models.LibraryCollection, error)
+	ListItems(ctx context.Context, collectionID string) ([]*models.LibraryCollectionItem, error)
+}
+
+// visibleLibraryIDs returns the set of library IDs the session may see on the
+// compat surface (access-filtered and audiobook-excluded by ListUserLibraries).
+func (h *ItemsHandler) visibleLibraryIDs(ctx context.Context, session *Session) (map[int]struct{}, error) {
+	libraries, err := h.content.ListUserLibraries(ctx, session)
+	if err != nil {
+		return nil, err
+	}
+	visible := make(map[int]struct{}, len(libraries))
+	for _, lib := range libraries {
+		visible[lib.ID] = struct{}{}
+	}
+	return visible, nil
+}
+
+// collectionVisible reports whether any of the collection's libraries is
+// visible to the session. Collections scoped only to hidden or audiobook
+// libraries stay off the compat surface.
+func collectionVisible(c *models.LibraryCollection, visible map[int]struct{}) bool {
+	if len(c.LibraryIDs) == 0 {
+		_, ok := visible[c.LibraryID]
+		return ok
+	}
+	for _, id := range c.LibraryIDs {
+		if _, ok := visible[id]; ok {
+			return true
+		}
+	}
+	return false
+}
+
+// boxSetFromCollection maps a library collection to a Jellyfin BoxSet DTO and
+// seeds the image cache so /Items/{id}/Images/Primary can serve the poster.
+func (h *ItemsHandler) boxSetFromCollection(ctx context.Context, c *models.LibraryCollection) baseItemDTO {
+	routeID := h.codec.EncodeStringID(EncodedIDCollection, c.ID)
+	imgTags := map[string]string{}
+	if posterURL := h.presignCollectionPoster(ctx, c.PosterURL); posterURL != "" {
+		if h.images != nil {
+			h.images.RememberSized(routeID, "Primary", posterURL, compatCardImageSize)
+		}
+		imgTags["Primary"] = tagValue(posterURL)
+	}
+	dto := baseItemDTO{
+		ID:                 routeID,
+		Type:               "BoxSet",
+		IsFolder:           true,
+		Name:               c.Title,
+		ServerID:           h.mapper.serverID,
+		Overview:           c.Description,
+		SortName:           strings.ToLower(c.Title),
+		ChildCount:         c.ItemCount,
+		RecursiveItemCount: c.ItemCount,
+		ImageTags:          imgTags,
+		UserData: &itemUserDataDTO{
+			Key:    routeID,
+			ItemID: routeID,
+		},
+	}
+	if backdropURL := h.presignCollectionPoster(ctx, c.BackdropURL); backdropURL != "" {
+		if h.images != nil {
+			h.images.RememberSized(routeID, "Backdrop", backdropURL, compatCardImageSize)
+		}
+		dto.BackdropImageTags = []string{tagValue(backdropURL)}
+	}
+	return dto
+}
+
+// presignCollectionPoster resolves a collection artwork reference to a
+// fetchable URL. Collection posters are stored as S3 keys in the
+// general-purpose bucket (same bucket as library posters); absolute and
+// app-relative references pass through untouched.
+func (h *ItemsHandler) presignCollectionPoster(ctx context.Context, path string) string {
+	path = strings.TrimSpace(path)
+	if path == "" {
+		return ""
+	}
+	if strings.HasPrefix(path, "http://") || strings.HasPrefix(path, "https://") {
+		return path
+	}
+	if h.posterPresigner == nil || strings.HasPrefix(path, "/") {
+		return ""
+	}
+	ttl := h.presignTTL
+	if ttl <= 0 {
+		ttl = 4 * time.Hour
+	}
+	url, err := h.posterPresigner.PresignGetURL(ctx, h.posterPresigner.Bucket(), path, ttl)
+	if err != nil {
+		return ""
+	}
+	return url
+}
+
+// handleBoxSetsList serves GET /Items with IncludeItemTypes=BoxSet by listing
+// visible library collections, optionally scoped to one library via ParentId.
+func (h *ItemsHandler) handleBoxSetsList(w http.ResponseWriter, r *http.Request, session *Session, query itemsQuery) {
+	empty := queryResultDTO{Items: []baseItemDTO{}, TotalRecordCount: 0, StartIndex: query.startIndex}
+	if h.collections == nil {
+		writeJSON(w, http.StatusOK, empty)
+		return
+	}
+
+	visible, err := h.visibleLibraryIDs(r.Context(), session)
+	if err != nil {
+		writeCompatUpstreamError(w, err)
+		return
+	}
+
+	var libFilter *int
+	if query.parentLibraryID > 0 {
+		if _, ok := visible[query.parentLibraryID]; !ok {
+			writeJSON(w, http.StatusOK, empty)
+			return
+		}
+		libFilter = &query.parentLibraryID
+	}
+
+	collections, err := h.collections.ListAll(r.Context(), libFilter, catalog.ListLibraryCollectionsOptions{})
+	if err != nil {
+		writeCompatUpstreamError(w, err)
+		return
+	}
+
+	searchTerm := strings.ToLower(strings.TrimSpace(query.searchTerm))
+	items := make([]baseItemDTO, 0, len(collections))
+	for _, c := range collections {
+		if !collectionVisible(c, visible) {
+			continue
+		}
+		if searchTerm != "" && !strings.Contains(strings.ToLower(c.Title), searchTerm) {
+			continue
+		}
+		if query.namePrefix != "" && !strings.HasPrefix(strings.ToLower(c.Title), strings.ToLower(query.namePrefix)) {
+			continue
+		}
+		items = append(items, h.boxSetFromCollection(r.Context(), c))
+	}
+
+	if query.sort == "sort_title" {
+		ascending := query.order != "desc"
+		sortBaseItemsByName(items, ascending)
+	}
+
+	total := len(items)
+	writeJSON(w, http.StatusOK, queryResultDTO{
+		Items:            sliceBaseItems(items, query.startIndex, query.limit),
+		TotalRecordCount: total,
+		StartIndex:       query.startIndex,
+	})
+}
+
+func sortBaseItemsByName(items []baseItemDTO, ascending bool) {
+	sort.SliceStable(items, func(i, j int) bool {
+		a, b := strings.ToLower(items[i].Name), strings.ToLower(items[j].Name)
+		if ascending {
+			return a < b
+		}
+		return a > b
+	})
+}
+
+// handleBoxSetItem serves GET /Items/{id} when the ID decodes as a collection.
+func (h *ItemsHandler) handleBoxSetItem(w http.ResponseWriter, r *http.Request, session *Session, collectionID string) {
+	if h.collections == nil {
+		writeError(w, http.StatusNotFound, "NotFound", "Item not found")
+		return
+	}
+	collection, err := h.collections.GetByID(r.Context(), collectionID)
+	if err != nil || collection == nil {
+		writeError(w, http.StatusNotFound, "NotFound", "Item not found")
+		return
+	}
+	visible, err := h.visibleLibraryIDs(r.Context(), session)
+	if err != nil {
+		writeCompatUpstreamError(w, err)
+		return
+	}
+	if !collectionVisible(collection, visible) || !strings.EqualFold(collection.Visibility, "visible") {
+		writeError(w, http.StatusNotFound, "NotFound", "Item not found")
+		return
+	}
+	writeJSON(w, http.StatusOK, h.boxSetFromCollection(r.Context(), collection))
+}
+
+// handleBoxSetChildren serves GET /Items?ParentId={boxsetId} by hydrating the
+// collection's members. Without an explicit SortBy the curated collection
+// position order is preserved; an explicit SortBy delegates ordering and
+// paging to the catalog browse path.
+func (h *ItemsHandler) handleBoxSetChildren(w http.ResponseWriter, r *http.Request, session *Session, query itemsQuery) {
+	empty := queryResultDTO{Items: []baseItemDTO{}, TotalRecordCount: 0, StartIndex: query.startIndex}
+	if h.collections == nil {
+		writeJSON(w, http.StatusOK, empty)
+		return
+	}
+
+	collection, err := h.collections.GetByID(r.Context(), query.parentCollectionID)
+	if err != nil || collection == nil {
+		writeJSON(w, http.StatusOK, empty)
+		return
+	}
+	visible, err := h.visibleLibraryIDs(r.Context(), session)
+	if err != nil {
+		writeCompatUpstreamError(w, err)
+		return
+	}
+	if !collectionVisible(collection, visible) || !strings.EqualFold(collection.Visibility, "visible") {
+		writeJSON(w, http.StatusOK, empty)
+		return
+	}
+
+	members, err := h.collections.ListItems(r.Context(), collection.ID)
+	if err != nil {
+		writeCompatUpstreamError(w, err)
+		return
+	}
+	contentIDs := make([]string, 0, len(members))
+	for _, member := range members {
+		contentIDs = append(contentIDs, member.MediaItemID)
+	}
+	if len(contentIDs) == 0 {
+		writeJSON(w, http.StatusOK, empty)
+		return
+	}
+
+	routeID := h.codec.EncodeStringID(EncodedIDCollection, collection.ID)
+
+	if query.sortExplicit {
+		// Catalog handles ordering and paging; the member list acts as an
+		// access-filtered allowlist.
+		params := buildBrowseParams(query)
+		params.Set("content_ids", strings.Join(contentIDs, ","))
+		result, browseErr := h.content.BrowseItems(r.Context(), session, params)
+		if browseErr != nil {
+			writeCompatUpstreamError(w, browseErr)
+			return
+		}
+		h.rememberListImages(result.Items)
+		favorites, progress, stateErr := resolveUserStateForContentIDs(r.Context(), session, h.userData, contentIDsFromListItems(result.Items))
+		if stateErr != nil {
+			writeCompatUpstreamError(w, stateErr)
+			return
+		}
+		items := make([]baseItemDTO, 0, len(result.Items))
+		for _, item := range result.Items {
+			dto := h.mapper.itemFromList(item, favorites[item.ContentID], progress[item.ContentID], query.requestedFields)
+			dto.ParentID = routeID
+			items = append(items, dto)
+		}
+		applyImageTypeLimit(items, query.imageTypeLimit)
+		writeJSON(w, http.StatusOK, queryResultDTO{
+			Items:            items,
+			TotalRecordCount: result.Total,
+			StartIndex:       query.startIndex,
+		})
+		return
+	}
+
+	// Position order: hydrate every member (collections are capped well below
+	// the browse limit), rebuild curated order, then page locally.
+	itemsByID, err := h.fetchCompatItemsByContentIDs(r.Context(), session, contentIDs, nil)
+	if err != nil {
+		writeCompatUpstreamError(w, err)
+		return
+	}
+	ordered := make([]upstreamListItem, 0, len(contentIDs))
+	for _, contentID := range contentIDs {
+		if item, ok := itemsByID[contentID]; ok {
+			ordered = append(ordered, item)
+		}
+	}
+	h.rememberListImages(ordered)
+	favorites, progress, err := resolveUserStateForContentIDs(r.Context(), session, h.userData, contentIDsFromListItems(ordered))
+	if err != nil {
+		writeCompatUpstreamError(w, err)
+		return
+	}
+	items := make([]baseItemDTO, 0, len(ordered))
+	for _, item := range ordered {
+		dto := h.mapper.itemFromList(item, favorites[item.ContentID], progress[item.ContentID], query.requestedFields)
+		dto.ParentID = routeID
+		items = append(items, dto)
+	}
+	applyImageTypeLimit(items, query.imageTypeLimit)
+	writeJSON(w, http.StatusOK, queryResultDTO{
+		Items:            sliceBaseItems(items, query.startIndex, query.limit),
+		TotalRecordCount: len(items),
+		StartIndex:       query.startIndex,
+	})
+}

--- a/internal/jellycompat/handlers_collections.go
+++ b/internal/jellycompat/handlers_collections.go
@@ -2,6 +2,7 @@ package jellycompat
 
 import (
 	"context"
+	"errors"
 	"net/http"
 	"sort"
 	"strings"
@@ -19,11 +20,11 @@ type collectionSource interface {
 	ListItems(ctx context.Context, collectionID string) ([]*models.LibraryCollectionItem, error)
 }
 
-// visibleLibraryIDs returns the set of library IDs the session may see on the
-// compat surface (access-filtered and ABS-library-excluded by
+// visibleLibraryIDSet returns the set of library IDs the session may see on
+// the compat surface (access-filtered and ABS-library-excluded by
 // ListUserLibraries).
-func (h *ItemsHandler) visibleLibraryIDs(ctx context.Context, session *Session) (map[int]struct{}, error) {
-	libraries, err := h.content.ListUserLibraries(ctx, session)
+func visibleLibraryIDSet(ctx context.Context, content ContentService, session *Session) (map[int]struct{}, error) {
+	libraries, err := content.ListUserLibraries(ctx, session)
 	if err != nil {
 		return nil, err
 	}
@@ -32,6 +33,10 @@ func (h *ItemsHandler) visibleLibraryIDs(ctx context.Context, session *Session) 
 		visible[lib.ID] = struct{}{}
 	}
 	return visible, nil
+}
+
+func (h *ItemsHandler) visibleLibraryIDs(ctx context.Context, session *Session) (map[int]struct{}, error) {
+	return visibleLibraryIDSet(ctx, h.content, session)
 }
 
 // collectionVisible reports whether any of the collection's libraries is
@@ -52,16 +57,20 @@ func collectionVisible(c *models.LibraryCollection, visible map[int]struct{}) bo
 
 // loadVisibleCollection fetches a collection and applies the compat
 // visibility rules. Returns (nil, nil) when the collection does not exist or
-// the session may not see it.
+// the session may not see it; infrastructure errors propagate so transient
+// failures don't masquerade as 404s.
 func (h *ItemsHandler) loadVisibleCollection(ctx context.Context, session *Session, collectionID string) (*models.LibraryCollection, error) {
 	if h.collections == nil {
 		return nil, nil
 	}
 	collection, err := h.collections.GetByID(ctx, collectionID)
-	if err != nil || collection == nil {
-		return nil, nil
+	if err != nil {
+		if errors.Is(err, catalog.ErrLibraryCollectionNotFound) {
+			return nil, nil
+		}
+		return nil, err
 	}
-	if !strings.EqualFold(collection.Visibility, "visible") {
+	if collection == nil || !strings.EqualFold(collection.Visibility, "visible") {
 		return nil, nil
 	}
 	visible, err := h.visibleLibraryIDs(ctx, session)

--- a/internal/jellycompat/handlers_collections.go
+++ b/internal/jellycompat/handlers_collections.go
@@ -20,7 +20,8 @@ type collectionSource interface {
 }
 
 // visibleLibraryIDs returns the set of library IDs the session may see on the
-// compat surface (access-filtered and audiobook-excluded by ListUserLibraries).
+// compat surface (access-filtered and ABS-library-excluded by
+// ListUserLibraries).
 func (h *ItemsHandler) visibleLibraryIDs(ctx context.Context, session *Session) (map[int]struct{}, error) {
 	libraries, err := h.content.ListUserLibraries(ctx, session)
 	if err != nil {
@@ -34,7 +35,7 @@ func (h *ItemsHandler) visibleLibraryIDs(ctx context.Context, session *Session) 
 }
 
 // collectionVisible reports whether any of the collection's libraries is
-// visible to the session. Collections scoped only to hidden or audiobook
+// visible to the session. Collections scoped only to hidden or ABS-surface
 // libraries stay off the compat surface.
 func collectionVisible(c *models.LibraryCollection, visible map[int]struct{}) bool {
 	if len(c.LibraryIDs) == 0 {
@@ -49,8 +50,34 @@ func collectionVisible(c *models.LibraryCollection, visible map[int]struct{}) bo
 	return false
 }
 
-// boxSetFromCollection maps a library collection to a Jellyfin BoxSet DTO and
-// seeds the image cache so /Items/{id}/Images/Primary can serve the poster.
+// loadVisibleCollection fetches a collection and applies the compat
+// visibility rules. Returns (nil, nil) when the collection does not exist or
+// the session may not see it.
+func (h *ItemsHandler) loadVisibleCollection(ctx context.Context, session *Session, collectionID string) (*models.LibraryCollection, error) {
+	if h.collections == nil {
+		return nil, nil
+	}
+	collection, err := h.collections.GetByID(ctx, collectionID)
+	if err != nil || collection == nil {
+		return nil, nil
+	}
+	if !strings.EqualFold(collection.Visibility, "visible") {
+		return nil, nil
+	}
+	visible, err := h.visibleLibraryIDs(ctx, session)
+	if err != nil {
+		return nil, err
+	}
+	if !collectionVisible(collection, visible) {
+		return nil, nil
+	}
+	return collection, nil
+}
+
+// boxSetFromCollection maps a library collection to a Jellyfin BoxSet DTO.
+// Image tags are signed from the stable artwork key (like library views) so
+// they survive restarts and presign rotation; the in-memory image cache is
+// seeded as the warm path.
 func (h *ItemsHandler) boxSetFromCollection(ctx context.Context, c *models.LibraryCollection) baseItemDTO {
 	routeID := h.codec.EncodeStringID(EncodedIDCollection, c.ID)
 	imgTags := map[string]string{}
@@ -58,7 +85,10 @@ func (h *ItemsHandler) boxSetFromCollection(ctx context.Context, c *models.Libra
 		if h.images != nil {
 			h.images.RememberSized(routeID, "Primary", posterURL, compatCardImageSize)
 		}
-		imgTags["Primary"] = tagValue(posterURL)
+		imgTags["Primary"] = h.mapper.imageTagSigner.Tag(
+			imageTagSeed(routeID, "Primary", compatCardImageSize, c.PosterURL, "", time.Time{}),
+			posterURL,
+		)
 	}
 	dto := baseItemDTO{
 		ID:                 routeID,
@@ -80,7 +110,10 @@ func (h *ItemsHandler) boxSetFromCollection(ctx context.Context, c *models.Libra
 		if h.images != nil {
 			h.images.RememberSized(routeID, "Backdrop", backdropURL, compatCardImageSize)
 		}
-		dto.BackdropImageTags = []string{tagValue(backdropURL)}
+		dto.BackdropImageTags = []string{h.mapper.imageTagSigner.Tag(
+			imageTagSeed(routeID, "Backdrop", compatCardImageSize, c.BackdropURL, "", time.Time{}),
+			backdropURL,
+		)}
 	}
 	return dto
 }
@@ -88,16 +121,17 @@ func (h *ItemsHandler) boxSetFromCollection(ctx context.Context, c *models.Libra
 // presignCollectionPoster resolves a collection artwork reference to a
 // fetchable URL. Collection posters are stored as S3 keys in the
 // general-purpose bucket (same bucket as library posters); absolute and
-// app-relative references pass through untouched.
+// app-relative references pass through untouched (matching the main API's
+// presignGPURL semantics).
 func (h *ItemsHandler) presignCollectionPoster(ctx context.Context, path string) string {
 	path = strings.TrimSpace(path)
 	if path == "" {
 		return ""
 	}
-	if strings.HasPrefix(path, "http://") || strings.HasPrefix(path, "https://") {
+	if strings.HasPrefix(path, "http://") || strings.HasPrefix(path, "https://") || strings.HasPrefix(path, "/") {
 		return path
 	}
-	if h.posterPresigner == nil || strings.HasPrefix(path, "/") {
+	if h.posterPresigner == nil {
 		return ""
 	}
 	ttl := h.presignTTL
@@ -111,12 +145,33 @@ func (h *ItemsHandler) presignCollectionPoster(ctx context.Context, path string)
 	return url
 }
 
+// boxSetsByIDs maps the given collection IDs to BoxSet DTOs, skipping any the
+// session may not see. Used by /Items?Ids= re-hydration.
+func (h *ItemsHandler) boxSetsByIDs(ctx context.Context, session *Session, collectionIDs []string) ([]baseItemDTO, error) {
+	if len(collectionIDs) == 0 || h.collections == nil {
+		return nil, nil
+	}
+	items := make([]baseItemDTO, 0, len(collectionIDs))
+	for _, id := range collectionIDs {
+		collection, err := h.loadVisibleCollection(ctx, session, id)
+		if err != nil {
+			return nil, err
+		}
+		if collection == nil {
+			continue
+		}
+		items = append(items, h.boxSetFromCollection(ctx, collection))
+	}
+	return items, nil
+}
+
 // handleBoxSetsList serves GET /Items with IncludeItemTypes=BoxSet by listing
 // visible library collections, optionally scoped to one library via ParentId.
+// Filtering, sorting, and paging happen on the lightweight collection rows;
+// DTOs (with artwork presigning) are built only for the returned page.
 func (h *ItemsHandler) handleBoxSetsList(w http.ResponseWriter, r *http.Request, session *Session, query itemsQuery) {
-	empty := queryResultDTO{Items: []baseItemDTO{}, TotalRecordCount: 0, StartIndex: query.startIndex}
 	if h.collections == nil {
-		writeJSON(w, http.StatusOK, empty)
+		writeJSON(w, http.StatusOK, emptyQueryResult(query.startIndex))
 		return
 	}
 
@@ -129,7 +184,7 @@ func (h *ItemsHandler) handleBoxSetsList(w http.ResponseWriter, r *http.Request,
 	var libFilter *int
 	if query.parentLibraryID > 0 {
 		if _, ok := visible[query.parentLibraryID]; !ok {
-			writeJSON(w, http.StatusOK, empty)
+			writeJSON(w, http.StatusOK, emptyQueryResult(query.startIndex))
 			return
 		}
 		libFilter = &query.parentLibraryID
@@ -142,60 +197,69 @@ func (h *ItemsHandler) handleBoxSetsList(w http.ResponseWriter, r *http.Request,
 	}
 
 	searchTerm := strings.ToLower(strings.TrimSpace(query.searchTerm))
-	items := make([]baseItemDTO, 0, len(collections))
+	namePrefix := strings.ToLower(query.namePrefix)
+	matched := make([]*models.LibraryCollection, 0, len(collections))
 	for _, c := range collections {
 		if !collectionVisible(c, visible) {
 			continue
 		}
-		if searchTerm != "" && !strings.Contains(strings.ToLower(c.Title), searchTerm) {
+		title := strings.ToLower(c.Title)
+		if searchTerm != "" && !strings.Contains(title, searchTerm) {
 			continue
 		}
-		if query.namePrefix != "" && !strings.HasPrefix(strings.ToLower(c.Title), strings.ToLower(query.namePrefix)) {
+		if namePrefix != "" && !strings.HasPrefix(title, namePrefix) {
 			continue
 		}
-		items = append(items, h.boxSetFromCollection(r.Context(), c))
+		matched = append(matched, c)
 	}
 
 	if query.sort == "sort_title" {
 		ascending := query.order != "desc"
-		sortBaseItemsByName(items, ascending)
+		sort.SliceStable(matched, func(i, j int) bool {
+			a, b := strings.ToLower(matched[i].Title), strings.ToLower(matched[j].Title)
+			if ascending {
+				return a < b
+			}
+			return a > b
+		})
 	}
 
-	total := len(items)
+	page := slicePage(matched, query.startIndex, query.limit)
+	items := make([]baseItemDTO, 0, len(page))
+	for _, c := range page {
+		items = append(items, h.boxSetFromCollection(r.Context(), c))
+	}
 	writeJSON(w, http.StatusOK, queryResultDTO{
-		Items:            sliceBaseItems(items, query.startIndex, query.limit),
-		TotalRecordCount: total,
+		Items:            items,
+		TotalRecordCount: len(matched),
 		StartIndex:       query.startIndex,
 	})
 }
 
-func sortBaseItemsByName(items []baseItemDTO, ascending bool) {
-	sort.SliceStable(items, func(i, j int) bool {
-		a, b := strings.ToLower(items[i].Name), strings.ToLower(items[j].Name)
-		if ascending {
-			return a < b
-		}
-		return a > b
-	})
+// slicePage returns the [startIndex, startIndex+limit) window of items;
+// limit <= 0 means no cap.
+func slicePage[T any](items []T, startIndex, limit int) []T {
+	if startIndex < 0 {
+		startIndex = 0
+	}
+	if startIndex >= len(items) {
+		return nil
+	}
+	if limit <= 0 {
+		limit = len(items)
+	}
+	end := min(startIndex+limit, len(items))
+	return items[startIndex:end]
 }
 
 // handleBoxSetItem serves GET /Items/{id} when the ID decodes as a collection.
 func (h *ItemsHandler) handleBoxSetItem(w http.ResponseWriter, r *http.Request, session *Session, collectionID string) {
-	if h.collections == nil {
-		writeError(w, http.StatusNotFound, "NotFound", "Item not found")
-		return
-	}
-	collection, err := h.collections.GetByID(r.Context(), collectionID)
-	if err != nil || collection == nil {
-		writeError(w, http.StatusNotFound, "NotFound", "Item not found")
-		return
-	}
-	visible, err := h.visibleLibraryIDs(r.Context(), session)
+	collection, err := h.loadVisibleCollection(r.Context(), session, collectionID)
 	if err != nil {
 		writeCompatUpstreamError(w, err)
 		return
 	}
-	if !collectionVisible(collection, visible) || !strings.EqualFold(collection.Visibility, "visible") {
+	if collection == nil {
 		writeError(w, http.StatusNotFound, "NotFound", "Item not found")
 		return
 	}
@@ -207,24 +271,13 @@ func (h *ItemsHandler) handleBoxSetItem(w http.ResponseWriter, r *http.Request, 
 // position order is preserved; an explicit SortBy delegates ordering and
 // paging to the catalog browse path.
 func (h *ItemsHandler) handleBoxSetChildren(w http.ResponseWriter, r *http.Request, session *Session, query itemsQuery) {
-	empty := queryResultDTO{Items: []baseItemDTO{}, TotalRecordCount: 0, StartIndex: query.startIndex}
-	if h.collections == nil {
-		writeJSON(w, http.StatusOK, empty)
-		return
-	}
-
-	collection, err := h.collections.GetByID(r.Context(), query.parentCollectionID)
-	if err != nil || collection == nil {
-		writeJSON(w, http.StatusOK, empty)
-		return
-	}
-	visible, err := h.visibleLibraryIDs(r.Context(), session)
+	collection, err := h.loadVisibleCollection(r.Context(), session, query.parentCollectionID)
 	if err != nil {
 		writeCompatUpstreamError(w, err)
 		return
 	}
-	if !collectionVisible(collection, visible) || !strings.EqualFold(collection.Visibility, "visible") {
-		writeJSON(w, http.StatusOK, empty)
+	if collection == nil {
+		writeJSON(w, http.StatusOK, emptyQueryResult(query.startIndex))
 		return
 	}
 
@@ -238,7 +291,7 @@ func (h *ItemsHandler) handleBoxSetChildren(w http.ResponseWriter, r *http.Reque
 		contentIDs = append(contentIDs, member.MediaItemID)
 	}
 	if len(contentIDs) == 0 {
-		writeJSON(w, http.StatusOK, empty)
+		writeJSON(w, http.StatusOK, emptyQueryResult(query.startIndex))
 		return
 	}
 
@@ -254,29 +307,13 @@ func (h *ItemsHandler) handleBoxSetChildren(w http.ResponseWriter, r *http.Reque
 			writeCompatUpstreamError(w, browseErr)
 			return
 		}
-		h.rememberListImages(result.Items)
-		favorites, progress, stateErr := resolveUserStateForContentIDs(r.Context(), session, h.userData, contentIDsFromListItems(result.Items))
-		if stateErr != nil {
-			writeCompatUpstreamError(w, stateErr)
-			return
-		}
-		items := make([]baseItemDTO, 0, len(result.Items))
-		for _, item := range result.Items {
-			dto := h.mapper.itemFromList(item, favorites[item.ContentID], progress[item.ContentID], query.requestedFields)
-			dto.ParentID = routeID
-			items = append(items, dto)
-		}
-		applyImageTypeLimit(items, query.imageTypeLimit)
-		writeJSON(w, http.StatusOK, queryResultDTO{
-			Items:            items,
-			TotalRecordCount: result.Total,
-			StartIndex:       query.startIndex,
-		})
+		h.writeCollectionItemsPage(w, r, session, query, routeID, result.Items, result.Total)
 		return
 	}
 
-	// Position order: hydrate every member (collections are capped well below
-	// the browse limit), rebuild curated order, then page locally.
+	// Position order: hydrate the surviving members (collections are capped
+	// well below the browse limit), rebuild curated order, then page locally
+	// before building DTOs.
 	itemsByID, err := h.fetchCompatItemsByContentIDs(r.Context(), session, contentIDs, nil)
 	if err != nil {
 		writeCompatUpstreamError(w, err)
@@ -288,22 +325,29 @@ func (h *ItemsHandler) handleBoxSetChildren(w http.ResponseWriter, r *http.Reque
 			ordered = append(ordered, item)
 		}
 	}
-	h.rememberListImages(ordered)
-	favorites, progress, err := resolveUserStateForContentIDs(r.Context(), session, h.userData, contentIDsFromListItems(ordered))
+	page := slicePage(ordered, query.startIndex, query.limit)
+	h.writeCollectionItemsPage(w, r, session, query, routeID, page, len(ordered))
+}
+
+// writeCollectionItemsPage hydrates user state for one page of collection
+// members and writes the /Items result with ParentId stamped on each child.
+func (h *ItemsHandler) writeCollectionItemsPage(w http.ResponseWriter, r *http.Request, session *Session, query itemsQuery, routeID string, listItems []upstreamListItem, total int) {
+	h.rememberListImages(listItems)
+	favorites, progress, err := resolveUserStateForContentIDs(r.Context(), session, h.userData, contentIDsFromListItems(listItems))
 	if err != nil {
 		writeCompatUpstreamError(w, err)
 		return
 	}
-	items := make([]baseItemDTO, 0, len(ordered))
-	for _, item := range ordered {
+	items := make([]baseItemDTO, 0, len(listItems))
+	for _, item := range listItems {
 		dto := h.mapper.itemFromList(item, favorites[item.ContentID], progress[item.ContentID], query.requestedFields)
 		dto.ParentID = routeID
 		items = append(items, dto)
 	}
 	applyImageTypeLimit(items, query.imageTypeLimit)
 	writeJSON(w, http.StatusOK, queryResultDTO{
-		Items:            sliceBaseItems(items, query.startIndex, query.limit),
-		TotalRecordCount: len(items),
+		Items:            items,
+		TotalRecordCount: total,
 		StartIndex:       query.startIndex,
 	})
 }

--- a/internal/jellycompat/handlers_collections_test.go
+++ b/internal/jellycompat/handlers_collections_test.go
@@ -1,0 +1,322 @@
+package jellycompat
+
+import (
+	"context"
+	"encoding/json"
+	"net/http/httptest"
+	"net/url"
+	"testing"
+	"time"
+
+	"github.com/go-chi/chi/v5"
+
+	"github.com/Silo-Server/silo-server/internal/catalog"
+	"github.com/Silo-Server/silo-server/internal/config"
+	"github.com/Silo-Server/silo-server/internal/models"
+)
+
+// fakeCollectionSource is an in-memory collectionSource.
+type fakeCollectionSource struct {
+	collections []*models.LibraryCollection
+	items       map[string][]*models.LibraryCollectionItem
+	listAllLib  *int
+}
+
+func (f *fakeCollectionSource) ListAll(_ context.Context, libraryID *int, _ catalog.ListLibraryCollectionsOptions) ([]*models.LibraryCollection, error) {
+	f.listAllLib = libraryID
+	out := make([]*models.LibraryCollection, 0, len(f.collections))
+	for _, c := range f.collections {
+		if libraryID != nil && !collectionInLibrary(c, *libraryID) {
+			continue
+		}
+		if c.Visibility != "visible" {
+			continue
+		}
+		out = append(out, c)
+	}
+	return out, nil
+}
+
+func collectionInLibrary(c *models.LibraryCollection, libraryID int) bool {
+	if len(c.LibraryIDs) == 0 {
+		return c.LibraryID == libraryID
+	}
+	for _, id := range c.LibraryIDs {
+		if id == libraryID {
+			return true
+		}
+	}
+	return false
+}
+
+func (f *fakeCollectionSource) GetByID(_ context.Context, id string) (*models.LibraryCollection, error) {
+	for _, c := range f.collections {
+		if c.ID == id {
+			return c, nil
+		}
+	}
+	return nil, nil
+}
+
+func (f *fakeCollectionSource) ListItems(_ context.Context, collectionID string) ([]*models.LibraryCollectionItem, error) {
+	return f.items[collectionID], nil
+}
+
+// librariesContentService serves a fixed library list; other methods panic.
+type librariesContentService struct {
+	countingContentService
+	libraries []upstreamUserLibrary
+}
+
+func (s *librariesContentService) ListUserLibraries(context.Context, *Session) ([]upstreamUserLibrary, error) {
+	out := make([]upstreamUserLibrary, len(s.libraries))
+	copy(out, s.libraries)
+	return out, nil
+}
+
+// fakeBatchItemRepo backs the compatPool()==nil hydration fallback.
+type fakeBatchItemRepo struct {
+	items map[string]*models.MediaItem
+}
+
+func (f *fakeBatchItemRepo) GetByIDs(_ context.Context, contentIDs []string) ([]*models.MediaItem, error) {
+	return f.byIDs(contentIDs), nil
+}
+
+func (f *fakeBatchItemRepo) GetByIDsWithAccess(_ context.Context, contentIDs []string, _ catalog.AccessFilter) ([]*models.MediaItem, error) {
+	return f.byIDs(contentIDs), nil
+}
+
+func (f *fakeBatchItemRepo) GetItemsInLibrary(_ context.Context, contentIDs []string, _ int) (map[string]bool, error) {
+	out := make(map[string]bool, len(contentIDs))
+	for _, id := range contentIDs {
+		out[id] = true
+	}
+	return out, nil
+}
+
+func (f *fakeBatchItemRepo) byIDs(contentIDs []string) []*models.MediaItem {
+	out := make([]*models.MediaItem, 0, len(contentIDs))
+	for _, id := range contentIDs {
+		if item, ok := f.items[id]; ok {
+			out = append(out, item)
+		}
+	}
+	return out
+}
+
+func newCollectionsTestHandler(collections *fakeCollectionSource, libraries []upstreamUserLibrary, itemRepo itemRepoForBatchLoader) *ItemsHandler {
+	codec := NewResourceIDCodec()
+	return &ItemsHandler{
+		content:     &librariesContentService{libraries: libraries},
+		userData:    &mockUserDataService{},
+		codec:       codec,
+		mapper:      newMapper(codec, &config.Config{}),
+		images:      NewImageCache(time.Hour, time.Now),
+		collections: collections,
+		itemRepo:    itemRepo,
+	}
+}
+
+func collectionsTestSession() *Session {
+	return &Session{StreamAppUserID: 1, ProfileID: "profile-1"}
+}
+
+func performItemsRequest(t *testing.T, h *ItemsHandler, target string) queryResultDTO {
+	t.Helper()
+	req := httptest.NewRequest("GET", target, nil)
+	req = req.WithContext(context.WithValue(req.Context(), compatSessionKey, collectionsTestSession()))
+	rec := httptest.NewRecorder()
+	h.HandleItems(rec, req)
+	if rec.Code != 200 {
+		t.Fatalf("expected 200, got %d: %s", rec.Code, rec.Body.String())
+	}
+	var result queryResultDTO
+	if err := json.Unmarshal(rec.Body.Bytes(), &result); err != nil {
+		t.Fatalf("unmarshal response: %v", err)
+	}
+	return result
+}
+
+func TestHandleItems_BoxSetListingFiltersHiddenLibraries(t *testing.T) {
+	collections := &fakeCollectionSource{
+		collections: []*models.LibraryCollection{
+			{ID: "101", LibraryID: 1, Title: "Marvel", Visibility: "visible", ItemCount: 3},
+			{ID: "102", LibraryID: 2, Title: "Audiobook Picks", Visibility: "visible", ItemCount: 5},
+			{ID: "103", LibraryID: 1, Title: "Hidden", Visibility: "hidden", ItemCount: 2},
+		},
+	}
+	// Library 2 is not visible (e.g. audiobook library, excluded upstream).
+	h := newCollectionsTestHandler(collections, []upstreamUserLibrary{{ID: 1, Name: "Movies", Type: "movies"}}, nil)
+
+	result := performItemsRequest(t, h, "/Items?IncludeItemTypes=BoxSet&Recursive=true")
+	if result.TotalRecordCount != 1 || len(result.Items) != 1 {
+		t.Fatalf("expected exactly the Marvel collection, got %+v", result.Items)
+	}
+	item := result.Items[0]
+	if item.Type != "BoxSet" || item.Name != "Marvel" || !item.IsFolder || item.ChildCount != 3 {
+		t.Fatalf("unexpected BoxSet DTO: %+v", item)
+	}
+}
+
+func TestHandleItems_BoxSetListingScopedToParentLibrary(t *testing.T) {
+	collections := &fakeCollectionSource{
+		collections: []*models.LibraryCollection{
+			{ID: "101", LibraryID: 1, Title: "Marvel", Visibility: "visible"},
+			{ID: "104", LibraryID: 3, Title: "Shows Sets", Visibility: "visible"},
+		},
+	}
+	h := newCollectionsTestHandler(collections, []upstreamUserLibrary{
+		{ID: 1, Name: "Movies", Type: "movies"},
+		{ID: 3, Name: "Shows", Type: "series"},
+	}, nil)
+
+	parentID := h.codec.EncodeIntID(EncodedIDLibrary, 3)
+	result := performItemsRequest(t, h, "/Items?IncludeItemTypes=BoxSet&ParentId="+parentID)
+	if len(result.Items) != 1 || result.Items[0].Name != "Shows Sets" {
+		t.Fatalf("expected library-scoped collection list, got %+v", result.Items)
+	}
+	if collections.listAllLib == nil || *collections.listAllLib != 3 {
+		t.Fatalf("expected ListAll scoped to library 3, got %v", collections.listAllLib)
+	}
+}
+
+func TestHandleItems_BoxSetChildrenPreservePositionOrder(t *testing.T) {
+	collections := &fakeCollectionSource{
+		collections: []*models.LibraryCollection{
+			{ID: "101", LibraryID: 1, Title: "Marvel", Visibility: "visible"},
+		},
+		items: map[string][]*models.LibraryCollectionItem{
+			"101": {
+				{CollectionID: "101", MediaItemID: "m-2", Position: 0},
+				{CollectionID: "101", MediaItemID: "m-1", Position: 1},
+				{CollectionID: "101", MediaItemID: "m-3", Position: 2},
+			},
+		},
+	}
+	itemRepo := &fakeBatchItemRepo{items: map[string]*models.MediaItem{
+		"m-1": {ContentID: "m-1", Type: "movie", Title: "Iron Man"},
+		"m-2": {ContentID: "m-2", Type: "movie", Title: "Captain America"},
+		"m-3": {ContentID: "m-3", Type: "movie", Title: "Thor"},
+	}}
+	h := newCollectionsTestHandler(collections, []upstreamUserLibrary{{ID: 1, Name: "Movies", Type: "movies"}}, itemRepo)
+
+	parentID := h.codec.EncodeStringID(EncodedIDCollection, "101")
+	result := performItemsRequest(t, h, "/Items?ParentId="+parentID)
+	if len(result.Items) != 3 {
+		t.Fatalf("expected 3 children, got %d", len(result.Items))
+	}
+	gotNames := []string{result.Items[0].Name, result.Items[1].Name, result.Items[2].Name}
+	wantNames := []string{"Captain America", "Iron Man", "Thor"}
+	for i := range wantNames {
+		if gotNames[i] != wantNames[i] {
+			t.Fatalf("expected curated order %v, got %v", wantNames, gotNames)
+		}
+	}
+	if result.Items[0].ParentID != parentID {
+		t.Fatalf("expected ParentId %s, got %s", parentID, result.Items[0].ParentID)
+	}
+}
+
+func TestHandleItems_BoxSetChildrenPagination(t *testing.T) {
+	collections := &fakeCollectionSource{
+		collections: []*models.LibraryCollection{
+			{ID: "101", LibraryID: 1, Title: "Marvel", Visibility: "visible"},
+		},
+		items: map[string][]*models.LibraryCollectionItem{
+			"101": {
+				{CollectionID: "101", MediaItemID: "m-1", Position: 0},
+				{CollectionID: "101", MediaItemID: "m-2", Position: 1},
+				{CollectionID: "101", MediaItemID: "m-3", Position: 2},
+			},
+		},
+	}
+	itemRepo := &fakeBatchItemRepo{items: map[string]*models.MediaItem{
+		"m-1": {ContentID: "m-1", Type: "movie", Title: "One"},
+		"m-2": {ContentID: "m-2", Type: "movie", Title: "Two"},
+		"m-3": {ContentID: "m-3", Type: "movie", Title: "Three"},
+	}}
+	h := newCollectionsTestHandler(collections, []upstreamUserLibrary{{ID: 1, Name: "Movies", Type: "movies"}}, itemRepo)
+
+	parentID := h.codec.EncodeStringID(EncodedIDCollection, "101")
+	result := performItemsRequest(t, h, "/Items?ParentId="+parentID+"&StartIndex=1&Limit=1")
+	if result.TotalRecordCount != 3 {
+		t.Fatalf("expected total 3, got %d", result.TotalRecordCount)
+	}
+	if len(result.Items) != 1 || result.Items[0].Name != "Two" {
+		t.Fatalf("expected page [Two], got %+v", result.Items)
+	}
+}
+
+func TestHandleItem_BoxSetDetailAndHiddenCollection(t *testing.T) {
+	collections := &fakeCollectionSource{
+		collections: []*models.LibraryCollection{
+			{ID: "101", LibraryID: 1, Title: "Marvel", Visibility: "visible", ItemCount: 4, Description: "Heroes"},
+			{ID: "103", LibraryID: 1, Title: "Hidden", Visibility: "hidden"},
+		},
+	}
+	h := newCollectionsTestHandler(collections, []upstreamUserLibrary{{ID: 1, Name: "Movies", Type: "movies"}}, nil)
+
+	router := chi.NewRouter()
+	router.Get("/Items/{id}", h.HandleItem)
+
+	routeID := h.codec.EncodeStringID(EncodedIDCollection, "101")
+	req := httptest.NewRequest("GET", "/Items/"+routeID, nil)
+	req = req.WithContext(context.WithValue(req.Context(), compatSessionKey, collectionsTestSession()))
+	rec := httptest.NewRecorder()
+	router.ServeHTTP(rec, req)
+	if rec.Code != 200 {
+		t.Fatalf("expected 200 for visible collection, got %d", rec.Code)
+	}
+	var dto baseItemDTO
+	if err := json.Unmarshal(rec.Body.Bytes(), &dto); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if dto.Type != "BoxSet" || dto.Name != "Marvel" || dto.Overview != "Heroes" || dto.ChildCount != 4 {
+		t.Fatalf("unexpected detail DTO: %+v", dto)
+	}
+
+	hiddenID := h.codec.EncodeStringID(EncodedIDCollection, "103")
+	req = httptest.NewRequest("GET", "/Items/"+hiddenID, nil)
+	req = req.WithContext(context.WithValue(req.Context(), compatSessionKey, collectionsTestSession()))
+	rec = httptest.NewRecorder()
+	router.ServeHTTP(rec, req)
+	if rec.Code != 404 {
+		t.Fatalf("expected 404 for hidden collection, got %d", rec.Code)
+	}
+}
+
+func TestHandleItems_UnmappedTypeFilterReturnsEmpty(t *testing.T) {
+	h := newCollectionsTestHandler(&fakeCollectionSource{}, []upstreamUserLibrary{{ID: 1, Name: "Movies", Type: "movies"}}, nil)
+
+	result := performItemsRequest(t, h, "/Items?IncludeItemTypes=Playlist")
+	if result.TotalRecordCount != 0 || len(result.Items) != 0 {
+		t.Fatalf("expected empty result for unmapped type filter, got %+v", result)
+	}
+}
+
+func TestParseItemsQuery_BoxSetFlags(t *testing.T) {
+	codec := NewResourceIDCodec()
+
+	req := httptest.NewRequest("GET", "/Items?IncludeItemTypes=BoxSet", nil)
+	query := parseItemsQuery(req, codec)
+	if !query.wantsBoxSets || len(query.itemTypes) != 0 || !query.hasItemTypeFilter {
+		t.Fatalf("expected BoxSet flags, got %+v", query)
+	}
+
+	collectionID := codec.EncodeStringID(EncodedIDCollection, "555")
+	req = httptest.NewRequest("GET", "/Items?ParentId="+url.QueryEscape(collectionID), nil)
+	query = parseItemsQuery(req, codec)
+	if query.parentCollectionID != "555" {
+		t.Fatalf("expected parentCollectionID 555, got %q", query.parentCollectionID)
+	}
+	if query.sortExplicit {
+		t.Fatalf("expected sortExplicit=false without SortBy")
+	}
+
+	req = httptest.NewRequest("GET", "/Items?SortBy=SortName", nil)
+	query = parseItemsQuery(req, codec)
+	if !query.sortExplicit {
+		t.Fatalf("expected sortExplicit=true with SortBy")
+	}
+}

--- a/internal/jellycompat/handlers_collections_test.go
+++ b/internal/jellycompat/handlers_collections_test.go
@@ -295,6 +295,60 @@ func TestHandleItems_UnmappedTypeFilterReturnsEmpty(t *testing.T) {
 	}
 }
 
+func TestHandleItems_BoxSetWithUserStateFilterReturnsEmpty(t *testing.T) {
+	collections := &fakeCollectionSource{
+		collections: []*models.LibraryCollection{
+			{ID: "101", LibraryID: 1, Title: "Marvel", Visibility: "visible"},
+		},
+	}
+	h := newCollectionsTestHandler(collections, []upstreamUserLibrary{{ID: 1, Name: "Movies", Type: "movies"}}, nil)
+
+	// Collections carry no favorite/played state; user-state-filtered BoxSet
+	// queries must stay empty (jellyfin-web Favorites tab relies on this).
+	for _, target := range []string{
+		"/Items?IncludeItemTypes=BoxSet&Filters=IsFavorite",
+		"/Items?IncludeItemTypes=BoxSet&Filters=IsResumable",
+		"/Items?IncludeItemTypes=BoxSet&IsPlayed=true",
+	} {
+		result := performItemsRequest(t, h, target)
+		if result.TotalRecordCount != 0 || len(result.Items) != 0 {
+			t.Fatalf("%s: expected empty result, got %+v", target, result.Items)
+		}
+	}
+}
+
+func TestHandleItems_CollectionFolderTypeReturnsViews(t *testing.T) {
+	h := newCollectionsTestHandler(&fakeCollectionSource{}, []upstreamUserLibrary{
+		{ID: 1, Name: "Movies", Type: "movies"},
+		{ID: 3, Name: "Shows", Type: "series"},
+	}, nil)
+
+	result := performItemsRequest(t, h, "/Items?IncludeItemTypes=CollectionFolder")
+	if len(result.Items) != 2 {
+		t.Fatalf("expected 2 library views, got %+v", result.Items)
+	}
+	for _, item := range result.Items {
+		if item.Type != "CollectionFolder" {
+			t.Fatalf("expected CollectionFolder items, got %+v", item)
+		}
+	}
+}
+
+func TestHandleItems_SpecificIdsIncludeBoxSets(t *testing.T) {
+	collections := &fakeCollectionSource{
+		collections: []*models.LibraryCollection{
+			{ID: "101", LibraryID: 1, Title: "Marvel", Visibility: "visible", ItemCount: 2},
+		},
+	}
+	h := newCollectionsTestHandler(collections, []upstreamUserLibrary{{ID: 1, Name: "Movies", Type: "movies"}}, nil)
+
+	boxSetID := h.codec.EncodeStringID(EncodedIDCollection, "101")
+	result := performItemsRequest(t, h, "/Items?Ids="+url.QueryEscape(boxSetID))
+	if len(result.Items) != 1 || result.Items[0].Type != "BoxSet" || result.Items[0].Name != "Marvel" {
+		t.Fatalf("expected the BoxSet DTO for Ids= re-hydration, got %+v", result.Items)
+	}
+}
+
 func TestParseItemsQuery_BoxSetFlags(t *testing.T) {
 	codec := NewResourceIDCodec()
 

--- a/internal/jellycompat/handlers_genres_test.go
+++ b/internal/jellycompat/handlers_genres_test.go
@@ -1,0 +1,64 @@
+package jellycompat
+
+import (
+	"context"
+	"encoding/json"
+	"net/http/httptest"
+	"net/url"
+	"testing"
+	"time"
+
+	"github.com/go-chi/chi/v5"
+
+	"github.com/Silo-Server/silo-server/internal/config"
+)
+
+// genresContentService serves fixed genre filters; other methods panic.
+type genresContentService struct {
+	countingContentService
+	genres []string
+}
+
+func (s *genresContentService) ListItemFilters(context.Context, *Session, url.Values) (*upstreamItemFiltersResponse, error) {
+	return &upstreamItemFiltersResponse{Genres: s.genres}, nil
+}
+
+func TestHandleGenreByName(t *testing.T) {
+	codec := NewResourceIDCodec()
+	h := &ItemsHandler{
+		content:  &genresContentService{genres: []string{"Action", "Science Fiction"}},
+		userData: &mockUserDataService{},
+		codec:    codec,
+		mapper:   newMapper(codec, &config.Config{}),
+		images:   NewImageCache(time.Hour, time.Now),
+	}
+
+	router := chi.NewRouter()
+	router.Get("/Genres/{name}", h.HandleGenreByName)
+
+	req := httptest.NewRequest("GET", "/Genres/"+url.PathEscape("science fiction"), nil)
+	req = req.WithContext(context.WithValue(req.Context(), compatSessionKey, &Session{StreamAppUserID: 1, ProfileID: "p1"}))
+	rec := httptest.NewRecorder()
+	router.ServeHTTP(rec, req)
+	if rec.Code != 200 {
+		t.Fatalf("expected 200, got %d: %s", rec.Code, rec.Body.String())
+	}
+	var dto baseItemDTO
+	if err := json.Unmarshal(rec.Body.Bytes(), &dto); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if dto.Type != "Genre" || dto.Name != "Science Fiction" {
+		t.Fatalf("expected canonical genre DTO, got %+v", dto)
+	}
+	if dto.ID != codec.EncodeStringID(EncodedIDGenre, "Science Fiction") {
+		t.Fatalf("genre ID does not round-trip: %q", dto.ID)
+	}
+
+	req = httptest.NewRequest("GET", "/Genres/Nope", nil)
+	req = req.WithContext(context.WithValue(req.Context(), compatSessionKey, &Session{StreamAppUserID: 1, ProfileID: "p1"}))
+	rec = httptest.NewRecorder()
+	router.ServeHTTP(rec, req)
+	if rec.Code != 404 {
+		t.Fatalf("expected 404 for unknown genre, got %d", rec.Code)
+	}
+}

--- a/internal/jellycompat/handlers_images.go
+++ b/internal/jellycompat/handlers_images.go
@@ -125,7 +125,7 @@ func (h *ImagesHandler) HandleItemImage(w http.ResponseWriter, r *http.Request) 
 	}
 
 	if collectionID, err := h.codec.DecodeStringID(EncodedIDCollection, routeID); err == nil {
-		h.handleCollectionImage(w, r, routeID, imageType, imageSize, collectionID)
+		h.handleCollectionImage(w, r, session, routeID, imageType, imageSize, collectionID)
 		return
 	}
 
@@ -327,14 +327,32 @@ func (h *ImagesHandler) resolveCollectionImageURLFromTag(ctx context.Context, ro
 	return catalog.ResolvedImageURL{URL: imageURL}, true, nil
 }
 
-// handleCollectionImage serves session-authenticated BoxSet artwork.
-func (h *ImagesHandler) handleCollectionImage(w http.ResponseWriter, r *http.Request, routeID, imageType, imageSize, collectionID string) {
+// handleCollectionImage serves session-authenticated BoxSet artwork, applying
+// the same visibility rules as the BoxSet item endpoints.
+func (h *ImagesHandler) handleCollectionImage(w http.ResponseWriter, r *http.Request, session *Session, routeID, imageType, imageSize, collectionID string) {
 	if h.collections == nil {
 		writeError(w, http.StatusNotFound, "NotFound", "Item not found")
 		return
 	}
 	collection, err := h.collections.GetByID(r.Context(), collectionID)
-	if err != nil || collection == nil {
+	if err != nil {
+		if errors.Is(err, catalog.ErrLibraryCollectionNotFound) {
+			writeError(w, http.StatusNotFound, "NotFound", "Item not found")
+			return
+		}
+		writeCompatUpstreamError(w, err)
+		return
+	}
+	if collection == nil || !strings.EqualFold(collection.Visibility, "visible") {
+		writeError(w, http.StatusNotFound, "NotFound", "Item not found")
+		return
+	}
+	visible, err := visibleLibraryIDSet(r.Context(), h.content, session)
+	if err != nil {
+		writeCompatUpstreamError(w, err)
+		return
+	}
+	if !collectionVisible(collection, visible) {
 		writeError(w, http.StatusNotFound, "NotFound", "Item not found")
 		return
 	}

--- a/internal/jellycompat/handlers_images.go
+++ b/internal/jellycompat/handlers_images.go
@@ -30,6 +30,9 @@ type ImagesHandler struct {
 	presignTTL   time.Duration
 	imageTags    *imageTagSigner
 	httpClient   *http.Client
+	// collections is optional; when set, BoxSet (library collection) artwork
+	// resolves durably instead of depending on the in-memory image cache.
+	collections collectionSource
 }
 
 type imageItemRepository interface {
@@ -118,6 +121,11 @@ func (h *ImagesHandler) HandleItemImage(w http.ResponseWriter, r *http.Request) 
 	// Try decoding as a person ID first.
 	if personID, err := h.codec.DecodeIntID(EncodedIDPerson, routeID); err == nil {
 		h.handlePersonImage(w, r, routeID, imageType, personID)
+		return
+	}
+
+	if collectionID, err := h.codec.DecodeStringID(EncodedIDCollection, routeID); err == nil {
+		h.handleCollectionImage(w, r, routeID, imageType, imageSize, collectionID)
 		return
 	}
 
@@ -258,11 +266,85 @@ func (h *ImagesHandler) resolveItemImageURLFromTag(ctx context.Context, routeID,
 	if libraryID, err := h.codec.DecodeIntID(EncodedIDLibrary, routeID); err == nil {
 		return h.resolveLibraryImageURLFromTag(ctx, routeID, int(libraryID), imageType, imageSize, tag)
 	}
+	if collectionID, err := h.codec.DecodeStringID(EncodedIDCollection, routeID); err == nil {
+		return h.resolveCollectionImageURLFromTag(ctx, routeID, collectionID, imageType, tag)
+	}
 	contentID, err := decodeContentID(h.codec, routeID)
 	if err != nil {
 		return catalog.ResolvedImageURL{}, false, nil
 	}
 	return h.resolveItemImageURLFromReposWithoutSession(ctx, routeID, contentID, imageType, imageSize, tag)
+}
+
+// collectionArtworkKey returns the stored artwork reference for the requested
+// compat image type ("" when the collection has none of that type).
+func collectionArtworkKey(c *models.LibraryCollection, imageType string) string {
+	switch imageType {
+	case "Primary":
+		return c.PosterURL
+	case "Backdrop":
+		return c.BackdropURL
+	}
+	return ""
+}
+
+// presignCollectionArtwork resolves a collection artwork reference like the
+// main API's presignGPURL: absolute and app-relative references pass through,
+// bare keys presign against the general-purpose bucket.
+func (h *ImagesHandler) presignCollectionArtwork(ctx context.Context, path string) string {
+	path = strings.TrimSpace(path)
+	if path == "" {
+		return ""
+	}
+	if strings.HasPrefix(path, "http://") || strings.HasPrefix(path, "https://") || strings.HasPrefix(path, "/") {
+		return path
+	}
+	return h.presignLibraryPosterURL(ctx, path)
+}
+
+// resolveCollectionImageURLFromTag serves tag-authenticated BoxSet artwork.
+// The tag must match the stable seed boxSetFromCollection signs.
+func (h *ImagesHandler) resolveCollectionImageURLFromTag(ctx context.Context, routeID, collectionID, imageType, tag string) (catalog.ResolvedImageURL, bool, error) {
+	if h.collections == nil {
+		return catalog.ResolvedImageURL{}, false, nil
+	}
+	collection, err := h.collections.GetByID(ctx, collectionID)
+	if err != nil || collection == nil {
+		return catalog.ResolvedImageURL{}, false, nil
+	}
+	key := collectionArtworkKey(collection, imageType)
+	if key == "" || !h.imageTags.Equal(
+		imageTagSeed(routeID, imageType, compatCardImageSize, key, "", time.Time{}),
+		"",
+		tag,
+	) {
+		return catalog.ResolvedImageURL{}, false, nil
+	}
+	imageURL := h.presignCollectionArtwork(ctx, key)
+	if imageURL == "" {
+		return catalog.ResolvedImageURL{}, false, nil
+	}
+	return catalog.ResolvedImageURL{URL: imageURL}, true, nil
+}
+
+// handleCollectionImage serves session-authenticated BoxSet artwork.
+func (h *ImagesHandler) handleCollectionImage(w http.ResponseWriter, r *http.Request, routeID, imageType, imageSize, collectionID string) {
+	if h.collections == nil {
+		writeError(w, http.StatusNotFound, "NotFound", "Item not found")
+		return
+	}
+	collection, err := h.collections.GetByID(r.Context(), collectionID)
+	if err != nil || collection == nil {
+		writeError(w, http.StatusNotFound, "NotFound", "Item not found")
+		return
+	}
+	imageURL := h.presignCollectionArtwork(r.Context(), collectionArtworkKey(collection, imageType))
+	if imageURL == "" {
+		writeError(w, http.StatusNotFound, "NotFound", "Image not found")
+		return
+	}
+	h.images.RememberSized(routeID, imageType, imageURL, imageSize)
+	h.serveImageURL(w, r, imageURL)
 }
 
 func (h *ImagesHandler) resolveLibraryImageURLFromTag(ctx context.Context, routeID string, libraryID int, imageType, _ string, tag string) (catalog.ResolvedImageURL, bool, error) {

--- a/internal/jellycompat/handlers_items.go
+++ b/internal/jellycompat/handlers_items.go
@@ -135,13 +135,25 @@ func (h *ItemsHandler) HandleItems(w http.ResponseWriter, r *http.Request) {
 
 	query := parseItemsQuery(r, h.codec)
 	switch {
-	case len(query.specificIDs) > 0:
+	case len(query.specificIDs) > 0 || len(query.specificCollectionIDs) > 0:
 		h.handleSpecificItems(w, r, session, query)
 	case query.parentCollectionID != "":
 		h.handleBoxSetChildren(w, r, session, query)
-	case query.wantsBoxSets && len(query.itemTypes) == 0:
-		// IncludeItemTypes=BoxSet (alone): list library collections.
-		h.handleBoxSetsList(w, r, session, query)
+	case query.hasItemTypeFilter && len(query.itemTypes) == 0:
+		// Every requested type is one catalog browse cannot serve. BoxSet has
+		// its own listing (unless a user-state filter applies — collections
+		// carry no favorite/played state, so those return empty, matching the
+		// pre-existing favorites guard); CollectionFolder means the library
+		// views; anything else (Playlist, MusicAlbum, ...) is empty.
+		hasUserStateFilter := query.isFavorite || query.isResumable || query.isPlayed != nil
+		switch {
+		case query.wantsBoxSets && !hasUserStateFilter:
+			h.handleBoxSetsList(w, r, session, query)
+		case query.wantsViews && !hasUserStateFilter && query.searchTerm == "":
+			h.handleViewsResponse(w, r, session)
+		default:
+			writeJSON(w, http.StatusOK, emptyQueryResult(query.startIndex))
+		}
 	case query.isResumable:
 		h.handleResumeResponse(w, r, session, query)
 	case query.isPlayed != nil && *query.isPlayed:
@@ -152,15 +164,6 @@ func (h *ItemsHandler) HandleItems(w http.ResponseWriter, r *http.Request) {
 		h.handleFavoriteItems(w, r, session, query)
 	case isSeasonChildItemsQuery(query):
 		h.handleSeasonChildItems(w, r, session, query)
-	case query.hasItemTypeFilter && len(query.itemTypes) == 0:
-		// Client requested only types compat doesn't expose (e.g. Playlist,
-		// MusicAlbum): return empty rather than falling through to a views or
-		// browse response of the wrong type.
-		writeJSON(w, http.StatusOK, queryResultDTO{
-			Items:            []baseItemDTO{},
-			TotalRecordCount: 0,
-			StartIndex:       query.startIndex,
-		})
 	case query.parentLibraryID == 0 && len(query.itemTypes) == 0:
 		// No ParentId and no type filter: return top-level library views.
 		// Jellyfin clients (e.g. Findroid "My Media") call GET /Items?userId=...
@@ -168,6 +171,15 @@ func (h *ItemsHandler) HandleItems(w http.ResponseWriter, r *http.Request) {
 		h.handleViewsResponse(w, r, session)
 	default:
 		h.handleBrowseItems(w, r, session, query)
+	}
+}
+
+// emptyQueryResult is the canonical empty /Items page.
+func emptyQueryResult(startIndex int) queryResultDTO {
+	return queryResultDTO{
+		Items:            []baseItemDTO{},
+		TotalRecordCount: 0,
+		StartIndex:       startIndex,
 	}
 }
 
@@ -1579,6 +1591,7 @@ func (h *ItemsHandler) handleFavoriteItems(w http.ResponseWriter, r *http.Reques
 			AllowedLibraryIDs:  access.AllowedLibraryIDs,
 			DisabledLibraryIDs: access.DisabledLibraryIDs,
 			MaxContentRating:   clampMaxContentRating(access.MaxContentRating, query.maxOfficialRating),
+			ExcludedMediaTypes: access.ExcludedMediaTypes,
 			SortField:          query.sort,
 			SortOrder:          query.order,
 			Limit:              query.limit,
@@ -1782,6 +1795,16 @@ func (h *ItemsHandler) handleSpecificItems(w http.ResponseWriter, r *http.Reques
 		h.appendDownloadedSubtitlesToDetailDTO(r.Context(), detail.ContentID, detail.Versions, &dto)
 		items = append(items, dto)
 	}
+
+	// Ids= may also reference collections (BoxSet route IDs handed out by the
+	// collections listing); append their DTOs so clients can re-hydrate them.
+	boxSets, err := h.boxSetsByIDs(r.Context(), session, query.specificCollectionIDs)
+	if err != nil {
+		writeCompatUpstreamError(w, err)
+		return
+	}
+	items = append(items, boxSets...)
+
 	writeJSON(w, http.StatusOK, queryResultDTO{
 		Items:            items,
 		TotalRecordCount: len(items),
@@ -2069,9 +2092,9 @@ func (h *ItemsHandler) hydrateProgressItems(ctx context.Context, session *Sessio
 
 func (h *ItemsHandler) resolveAccessFilter(ctx context.Context, session *Session) catalog.AccessFilter {
 	if h.accessFilter != nil {
-		return h.accessFilter(ctx, session.StreamAppUserID, session.ProfileID)
+		return withCompatAccessExclusions(h.accessFilter(ctx, session.StreamAppUserID, session.ProfileID))
 	}
-	return catalog.AccessFilter{}
+	return withCompatAccessExclusions(catalog.AccessFilter{})
 }
 
 func (h *ItemsHandler) presignCompatListItem(ctx context.Context, item *upstreamListItem) {

--- a/internal/jellycompat/handlers_items.go
+++ b/internal/jellycompat/handlers_items.go
@@ -41,6 +41,11 @@ type ItemsHandler struct {
 	accessFilter AccessFilterResolver
 	subtitleRepo subtitles.Repository
 	recommender  recommendations.Recommender
+	// collections is optional; when set, library collections are exposed as
+	// Jellyfin BoxSets. posterPresigner/presignTTL resolve their artwork keys.
+	collections     collectionSource
+	posterPresigner LibraryPosterPresigner
+	presignTTL      time.Duration
 	// FileResolver is optional; when set, /MediaSegments returns real intro/
 	// credits/recap/preview segments for any file that has them.
 	FileResolver FilePathResolver
@@ -132,6 +137,11 @@ func (h *ItemsHandler) HandleItems(w http.ResponseWriter, r *http.Request) {
 	switch {
 	case len(query.specificIDs) > 0:
 		h.handleSpecificItems(w, r, session, query)
+	case query.parentCollectionID != "":
+		h.handleBoxSetChildren(w, r, session, query)
+	case query.wantsBoxSets && len(query.itemTypes) == 0:
+		// IncludeItemTypes=BoxSet (alone): list library collections.
+		h.handleBoxSetsList(w, r, session, query)
 	case query.isResumable:
 		h.handleResumeResponse(w, r, session, query)
 	case query.isPlayed != nil && *query.isPlayed:
@@ -142,6 +152,15 @@ func (h *ItemsHandler) HandleItems(w http.ResponseWriter, r *http.Request) {
 		h.handleFavoriteItems(w, r, session, query)
 	case isSeasonChildItemsQuery(query):
 		h.handleSeasonChildItems(w, r, session, query)
+	case query.hasItemTypeFilter && len(query.itemTypes) == 0:
+		// Client requested only types compat doesn't expose (e.g. Playlist,
+		// MusicAlbum): return empty rather than falling through to a views or
+		// browse response of the wrong type.
+		writeJSON(w, http.StatusOK, queryResultDTO{
+			Items:            []baseItemDTO{},
+			TotalRecordCount: 0,
+			StartIndex:       query.startIndex,
+		})
 	case query.parentLibraryID == 0 && len(query.itemTypes) == 0:
 		// No ParentId and no type filter: return top-level library views.
 		// Jellyfin clients (e.g. Findroid "My Media") call GET /Items?userId=...
@@ -181,6 +200,11 @@ func (h *ItemsHandler) HandleItem(w http.ResponseWriter, r *http.Request) {
 	// CollectionFolder items using the library UUID from /UserViews.
 	if libraryID, err := h.codec.DecodeIntID(EncodedIDLibrary, rawID); err == nil {
 		h.handleLibraryItem(w, r, session, int(libraryID))
+		return
+	}
+
+	if collectionID, err := h.codec.DecodeStringID(EncodedIDCollection, rawID); err == nil {
+		h.handleBoxSetItem(w, r, session, collectionID)
 		return
 	}
 
@@ -900,6 +924,46 @@ func (h *ItemsHandler) HandleGenres(w http.ResponseWriter, r *http.Request) {
 		TotalRecordCount: len(items),
 		StartIndex:       0,
 	})
+}
+
+// HandleGenreByName serves GET /Genres/{name}. Jellyfin addresses genres by
+// (URL-escaped) display name; clients use the returned Id for GenreIds= item
+// queries.
+func (h *ItemsHandler) HandleGenreByName(w http.ResponseWriter, r *http.Request) {
+	session := SessionFromContext(r.Context())
+	if session == nil {
+		writeError(w, http.StatusUnauthorized, "Unauthorized", "Missing authentication token")
+		return
+	}
+
+	name := strings.TrimSpace(chi.URLParam(r, "name"))
+	if decoded, err := url.PathUnescape(name); err == nil {
+		name = strings.TrimSpace(decoded)
+	}
+	if name == "" {
+		writeError(w, http.StatusNotFound, "NotFound", "Genre not found")
+		return
+	}
+
+	// Confirm the genre exists within the caller's visible scope so the
+	// response carries the canonical casing.
+	filters, err := h.content.ListItemFilters(r.Context(), session, urlValuesFromItemsQuery(parseItemsQuery(r, h.codec)))
+	if err != nil {
+		writeCompatUpstreamError(w, err)
+		return
+	}
+	for _, genre := range filters.Genres {
+		if strings.EqualFold(strings.TrimSpace(genre), name) {
+			writeJSON(w, http.StatusOK, baseItemDTO{
+				ID:       h.codec.EncodeStringID(EncodedIDGenre, genre),
+				Type:     "Genre",
+				Name:     genre,
+				ServerID: h.mapper.serverID,
+			})
+			return
+		}
+	}
+	writeError(w, http.StatusNotFound, "NotFound", "Genre not found")
 }
 
 // HandleSeasons serves GET /Shows/{id}/Seasons.

--- a/internal/jellycompat/idcodec.go
+++ b/internal/jellycompat/idcodec.go
@@ -22,6 +22,7 @@ const (
 	EncodedIDStudio      EncodedIDType = 7
 	EncodedIDPerson      EncodedIDType = 8
 	EncodedIDImageProxy  EncodedIDType = 9
+	EncodedIDCollection  EncodedIDType = 10
 )
 
 var (
@@ -33,6 +34,7 @@ var (
 		EncodedIDGenre:       uuid.MustParse("c0cbb8ea-8331-52c0-b160-15e7cf899fb0"),
 		EncodedIDStudio:      uuid.MustParse("23712982-b769-592d-9360-b4d3f39654db"),
 		EncodedIDPerson:      uuid.MustParse("a4e7c1d6-3b8f-5a2e-9c01-7d6f4e8b2a13"),
+		EncodedIDCollection:  uuid.MustParse("7f3c2a91-5b64-5c1d-8e07-9a2f4d6b1c35"),
 	}
 )
 

--- a/internal/jellycompat/query.go
+++ b/internal/jellycompat/query.go
@@ -20,12 +20,15 @@ type itemsQuery struct {
 	maxOfficialRating      string
 	parentLibraryID        int
 	parentItemID           string
+	parentCollectionID     string
 	specificIDs            []string
 	itemTypes              []string
 	genreName              string
 	isFavorite             bool
 	isResumable            bool
 	hasItemTypeFilter      bool // true when IncludeItemTypes was present in the request
+	wantsBoxSets           bool // true when IncludeItemTypes contains BoxSet
+	sortExplicit           bool // true when SortBy was present in the request
 	needsDetailFields      bool // true when requested Fields include detail-level data (e.g. MediaSources)
 	itemType               string
 	sort                   string
@@ -57,6 +60,8 @@ func parseItemsQuery(r *http.Request, codec *ResourceIDCodec) itemsQuery {
 	if parentID := strings.TrimSpace(q.Get("ParentId")); parentID != "" {
 		if libraryID, err := codec.DecodeIntID(EncodedIDLibrary, parentID); err == nil {
 			result.parentLibraryID = int(libraryID)
+		} else if collectionID, collErr := codec.DecodeStringID(EncodedIDCollection, parentID); collErr == nil && collectionID != "" {
+			result.parentCollectionID = collectionID
 		} else if contentID, itemErr := decodeItemID(codec, parentID); itemErr == nil && contentID != "" {
 			result.parentItemID = contentID
 		}
@@ -96,6 +101,8 @@ func parseItemsQuery(r *http.Request, codec *ResourceIDCodec) itemsQuery {
 	rawItemTypes := q.Values("IncludeItemTypes")
 	result.hasItemTypeFilter = len(rawItemTypes) > 0 && strings.TrimSpace(strings.Join(rawItemTypes, "")) != ""
 	result.itemTypes = mapIncludeItemTypes(rawItemTypes)
+	result.wantsBoxSets = includeItemTypesContain(rawItemTypes, "boxset")
+	result.sortExplicit = strings.TrimSpace(q.Get("SortBy")) != ""
 	if len(result.itemTypes) > 0 {
 		result.itemType = result.itemTypes[0]
 	}
@@ -314,6 +321,20 @@ func mapIncludeItemTypes(rawValues []string) []string {
 		}
 	}
 	return result
+}
+
+// includeItemTypesContain reports whether a raw IncludeItemTypes value list
+// contains the given (lowercase) type, before mapIncludeItemTypes drops
+// entries it cannot map to catalog types (e.g. BoxSet).
+func includeItemTypesContain(rawValues []string, target string) bool {
+	for _, raw := range rawValues {
+		for part := range strings.SplitSeq(raw, ",") {
+			if strings.ToLower(strings.TrimSpace(part)) == target {
+				return true
+			}
+		}
+	}
+	return false
 }
 
 func parseMediaTypes(rawValues []string) []string {

--- a/internal/jellycompat/query.go
+++ b/internal/jellycompat/query.go
@@ -22,12 +22,14 @@ type itemsQuery struct {
 	parentItemID           string
 	parentCollectionID     string
 	specificIDs            []string
+	specificCollectionIDs  []string
 	itemTypes              []string
 	genreName              string
 	isFavorite             bool
 	isResumable            bool
 	hasItemTypeFilter      bool // true when IncludeItemTypes was present in the request
 	wantsBoxSets           bool // true when IncludeItemTypes contains BoxSet
+	wantsViews             bool // true when IncludeItemTypes contains CollectionFolder
 	sortExplicit           bool // true when SortBy was present in the request
 	needsDetailFields      bool // true when requested Fields include detail-level data (e.g. MediaSources)
 	itemType               string
@@ -70,8 +72,11 @@ func parseItemsQuery(r *http.Request, codec *ResourceIDCodec) itemsQuery {
 	if ids := strings.TrimSpace(q.Get("Ids")); ids != "" {
 		parts := strings.SplitSeq(ids, ",")
 		for part := range parts {
-			if decoded, err := decodeItemID(codec, strings.TrimSpace(part)); err == nil && decoded != "" {
+			raw := strings.TrimSpace(part)
+			if decoded, err := decodeItemID(codec, raw); err == nil && decoded != "" {
 				result.specificIDs = append(result.specificIDs, decoded)
+			} else if collectionID, collErr := codec.DecodeStringID(EncodedIDCollection, raw); collErr == nil && collectionID != "" {
+				result.specificCollectionIDs = append(result.specificCollectionIDs, collectionID)
 			}
 		}
 	}
@@ -102,6 +107,7 @@ func parseItemsQuery(r *http.Request, codec *ResourceIDCodec) itemsQuery {
 	result.hasItemTypeFilter = len(rawItemTypes) > 0 && strings.TrimSpace(strings.Join(rawItemTypes, "")) != ""
 	result.itemTypes = mapIncludeItemTypes(rawItemTypes)
 	result.wantsBoxSets = includeItemTypesContain(rawItemTypes, "boxset")
+	result.wantsViews = includeItemTypesContain(rawItemTypes, "collectionfolder")
 	result.sortExplicit = strings.TrimSpace(q.Get("SortBy")) != ""
 	if len(result.itemTypes) > 0 {
 		result.itemType = result.itemTypes[0]

--- a/internal/jellycompat/router.go
+++ b/internal/jellycompat/router.go
@@ -106,6 +106,7 @@ func NewRouter(deps Dependencies) chi.Router {
 		playbackHandler.S3Bucket = deps.S3Bucket
 	}
 	imagesHandler := NewImagesHandler(deps.ContentService, deps.IDCodec, deps.SessionStore, deps.ImageCache, deps.PersonRepo, deps.DetailSvc, deps.ItemRepo, deps.FolderRepo, deps.SeasonRepo, deps.EpisodeRepo, deps.AccessFilterFn, deps.PosterPresigner, deps.PresignTTL, deps.JWTSecret, deps.HTTPClient)
+	imagesHandler.collections = itemsHandler.collections
 	displayPrefsHandler := NewDisplayPreferencesHandler(deps.UserStoreProvider)
 	recsHandler := NewRecommendationsHandler(deps.Recommender, deps.ItemRepo, deps.ContentService, deps.UserDataService, deps.IDCodec, deps.Config, deps.AccessFilterFn)
 
@@ -237,6 +238,10 @@ func withDefaults(deps Dependencies) Dependencies {
 	if deps.Now == nil {
 		deps.Now = timeNow
 	}
+	// Stamp the compat surface's media-type exclusions onto every resolved
+	// access filter so all consumers (content service, items/images handlers,
+	// recommendations) inherit them without per-call-site guards.
+	deps.AccessFilterFn = compatAccessFilterResolver(deps.AccessFilterFn)
 	if deps.JWTSecret == "" && deps.Config != nil {
 		deps.JWTSecret = deps.Config.Auth.JWTSecret
 	}

--- a/internal/jellycompat/router.go
+++ b/internal/jellycompat/router.go
@@ -75,6 +75,11 @@ func NewRouter(deps Dependencies) chi.Router {
 	}
 	itemsHandler := NewItemsHandler(deps.ContentService, deps.UserDataService, deps.IDCodec, deps.Config, deps.ImageCache, nextUpRepo, deps.BrowseRepo, deps.PersonRepo, deps.DetailSvc, deps.ItemRepo, deps.EpisodeRepo, deps.AccessFilterFn, subtitleRepo)
 	itemsHandler.recommender = deps.Recommender
+	if deps.DB != nil {
+		itemsHandler.collections = catalog.NewLibraryCollectionRepository(deps.DB)
+	}
+	itemsHandler.posterPresigner = deps.PosterPresigner
+	itemsHandler.presignTTL = deps.PresignTTL
 	autoscanHandler := NewAutoscanHandler(deps.FolderRepo, deps.ScanQueue, deps.IDCodec, itemsHandler)
 	adminAPIKeyAuth := NewAdminAPIKeyAuthenticator(deps.APIKeyValidator, deps.APIKeyUserLoader, deps.UserStoreProvider, deps.Now)
 	autoscanVirtualFoldersRegistered := false
@@ -156,6 +161,7 @@ func NewRouter(deps Dependencies) chi.Router {
 			r.Get("/Users/{userId}/Items/Resume", itemsHandler.HandleResume)
 			r.Get("/Users/{userId}/Items/{id}", itemsHandler.HandleItem)
 			r.Get("/Genres", itemsHandler.HandleGenres)
+			r.Get("/Genres/{name}", itemsHandler.HandleGenreByName)
 			r.Get("/Shows/{id}/Seasons", itemsHandler.HandleSeasons)
 			r.Get("/Shows/{id}/Episodes", itemsHandler.HandleEpisodes)
 			r.Get("/Shows/NextUp", itemsHandler.HandleNextUp)

--- a/internal/jellycompat/userdata_direct.go
+++ b/internal/jellycompat/userdata_direct.go
@@ -69,6 +69,11 @@ func (s *directUserDataService) ListFavorites(ctx context.Context, session *Sess
 	// Build a map for ordering by the original favorites list order
 	itemMap := make(map[string]*upstreamListItem, len(items))
 	for _, mi := range items {
+		// Favorites are shared with the ABS surface; its media types are
+		// never exposed here (they would 404 on detail/PlaybackInfo).
+		if isCompatExcludedMediaType(mi.Type) {
+			continue
+		}
 		li := mediaItemToListItem(mi)
 		li.PosterURL = compatPresignImage(s.detailSvc, ctx, li.PosterURL, "poster", compatCardImageSize)
 		li.BackdropURL = compatPresignImage(s.detailSvc, ctx, li.BackdropURL, "backdrop", compatCardImageSize)

--- a/internal/jellycompat/userdata_direct.go
+++ b/internal/jellycompat/userdata_direct.go
@@ -47,7 +47,12 @@ func (s *directUserDataService) ListFavorites(ctx context.Context, session *Sess
 		return nil, fmt.Errorf("open user store: %w", err)
 	}
 
-	favorites, err := store.ListFavorites(ctx, session.ProfileID, limit, offset)
+	// ABS-surface favorites (audiobooks/podcasts) are filtered out below, so
+	// the limit/offset window must apply to the *filtered* list — a raw
+	// store-level window would shift or shrink the visible page. Over-fetch
+	// the raw rows, filter, then window.
+	scanLimit := min(max((limit+offset)*2, 200), 10000)
+	favorites, err := store.ListFavorites(ctx, session.ProfileID, scanLimit, 0)
 	if err != nil {
 		return nil, fmt.Errorf("list favorites: %w", err)
 	}
@@ -75,17 +80,25 @@ func (s *directUserDataService) ListFavorites(ctx context.Context, session *Sess
 			continue
 		}
 		li := mediaItemToListItem(mi)
-		li.PosterURL = compatPresignImage(s.detailSvc, ctx, li.PosterURL, "poster", compatCardImageSize)
-		li.BackdropURL = compatPresignImage(s.detailSvc, ctx, li.BackdropURL, "backdrop", compatCardImageSize)
-		li.LogoURL = compatPresignImage(s.detailSvc, ctx, li.LogoURL, "logo", compatCardImageSize)
 		itemMap[mi.ContentID] = &li
 	}
 
-	result := make([]upstreamListItem, 0, len(contentIDs))
+	ordered := make([]upstreamListItem, 0, len(contentIDs))
 	for _, id := range contentIDs {
 		if li, ok := itemMap[id]; ok {
-			result = append(result, *li)
+			ordered = append(ordered, *li)
 		}
+	}
+
+	// Presign artwork only for the page being returned.
+	result := slicePage(ordered, offset, limit)
+	for i := range result {
+		result[i].PosterURL = compatPresignImage(s.detailSvc, ctx, result[i].PosterURL, "poster", compatCardImageSize)
+		result[i].BackdropURL = compatPresignImage(s.detailSvc, ctx, result[i].BackdropURL, "backdrop", compatCardImageSize)
+		result[i].LogoURL = compatPresignImage(s.detailSvc, ctx, result[i].LogoURL, "logo", compatCardImageSize)
+	}
+	if result == nil {
+		result = []upstreamListItem{}
 	}
 	return result, nil
 }


### PR DESCRIPTION
## Problem

The Jellyfin compat API was missing endpoints clients use for browsing, and leaked ABS-surface content:

- **Collections/BoxSets were not implemented** — `IncludeItemTypes=BoxSet` fell through to a full library browse, and collection IDs were unaddressable.
- **Audiobook (and podcast) libraries were fully exposed** through Views, browse, search, detail, and PlaybackInfo, even though those media are served by the audiobookshelf-compat API.
- `/Genres/{name}` was unregistered.

## What changed

**BoxSets** — `LibraryCollection` is now exposed as Jellyfin BoxSets: `IncludeItemTypes=BoxSet` listing (optionally scoped by `ParentId` library, with SearchTerm/NameStartsWith/SortName support), `/Items/{id}` detail, `ParentId={boxset}` children preserving curated position order (explicit `SortBy` delegates ordering/paging to catalog), `Ids=` re-hydration, and durable artwork (stable signed tags from the artwork key + a collections fallback in the images handler, so posters survive restarts and presign rotation). Listing filters/sorts/pages the lightweight rows before building DTOs, so a `Limit=24` page over hundreds of collections doesn't presign every poster.

**ABS media exclusion** — implemented at the access-filter layer rather than per endpoint: `catalog.AccessFilter` gained `ExcludedMediaTypes`, enforced by `applyAccessFilter` and threaded through `Search`, `GetByIDsWithAccess`, `EnsureAccessible`, and `BrowseFavorites`. The compat router stamps `audiobook` + `podcast` exclusions onto every resolved filter in one place (`withDefaults`), so favorites, recommendations, images, and future data paths inherit the exclusion. Audiobook/podcast libraries are hidden from Views/VirtualFolders, and browse/genre listings clamp to video types.

**Dispatch correctness** — `/Items` requests whose `IncludeItemTypes` map to nothing exposable return empty instead of falling through to views/browse; `CollectionFolder` still returns library views; BoxSet listings don't hijack `Filters=IsFavorite/IsResumable/IsPlayed` queries (they return empty, matching prior behavior).

**Genres** — `GET /Genres/{name}` resolves canonical casing scoped to the caller's visible libraries; `GenreIds=`/`ParentId` filtering verified covered by existing paths.

## Why this approach

A review pass on the first commit found the per-call-site exclusion pattern had already missed three paths (favorites, recommendations, item images) within the same PR — moving the exclusion into `AccessFilter` makes it structural instead of a convention every new endpoint must remember.

## Testing

- New unit tests: BoxSet listing/visibility/scoping, children position-order + pagination, detail + hidden-collection 404, `Ids=` re-hydration, user-state-filtered BoxSet queries, CollectionFolder views, unmapped-type empty results, type-scope clamps, hidden-library exclusion, access-filter wrapper, `/Genres/{name}`.
- Full `./internal/...` suite green; `go vet` + gofmt clean.
- Deployed to the dev server (`make dev-deploy`) and verified on an Nvidia Shield Jellyfin client: audiobook library hidden, collections/genres browsable, streaming intact.

## Risks / follow-ups

- Mixed `IncludeItemTypes=Movie,BoxSet` does not interleave collections with movies (real Jellyfin merges both); needs cross-source pagination, documented at the dispatch site.
- Non-numeric route IDs have a theoretical 1/256 first-byte collision with the new collection ID kind; all current IDs are numeric snowflakes, so this is latent.
- `ListAll(nil)` for collections is heavier than needed for the compat listing (counts members per request); a slim list query or short-TTL cache is a possible follow-up if collection counts grow.

## AI-use disclosure

Implemented by Claude Code (Fable 5) under human direction, including a multi-agent review pass whose findings were fixed in the second commit; human-validated on the dev server and Shield client.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Jellyfin-compatible collections/BoxSet support with metadata, stable IDs and collection artwork routes (presigned images)
  * New genre-by-name endpoint for compat layer

* **Behavior Changes**
  * Compat media-type filtering now consistently hides audiobooks/podcasts across browse, search, favorites, item detail (404 for excluded types) and user favorites pagination

* **Tests**
  * Added tests covering collections, genre browsing, compat media-type exclusions and related behaviors
<!-- end of auto-generated comment: release notes by coderabbit.ai -->