### PR TITLE
feat(audiobooks): redesign audiobook library around resume and series progression

### DIFF
--- a/internal/api/handlers/audiobook_groups.go
+++ b/internal/api/handlers/audiobook_groups.go
@@ -1,0 +1,108 @@
+package handlers
+
+import (
+	"net/http"
+	"strconv"
+	"strings"
+
+	"github.com/Silo-Server/silo-server/internal/catalog"
+)
+
+type audiobookGroupResponse struct {
+	Name                 string   `json:"name"`
+	ItemCount            int      `json:"item_count"`
+	TotalDurationSeconds int64    `json:"total_duration_seconds"`
+	InProgressCount      int      `json:"in_progress_count"`
+	FinishedCount        int      `json:"finished_count"`
+	PosterURLs           []string `json:"poster_urls"`
+}
+
+type audiobookGroupsResponse struct {
+	Total  int                      `json:"total"`
+	Groups []audiobookGroupResponse `json:"groups"`
+}
+
+// HandleGetAudiobookGroups — GET /api/v1/catalog/audiobook-groups
+//
+// Grouped browse for audiobook libraries: authors, narrators, or series with
+// aggregate stats (book count, total duration, per-profile progress counts)
+// and up to four poster URLs for cover stacks. Query parameters:
+// library_id=<id> (required), group_by=author|narrator|series (required),
+// sort=name|count|duration (default name), limit, offset.
+//
+// Group names round-trip into the corresponding catalog filter fields
+// (author / narrator / series), which match case-insensitively.
+func (h *CatalogHandler) HandleGetAudiobookGroups(w http.ResponseWriter, r *http.Request) {
+	if h == nil || h.itemsH == nil || h.itemsH.browseRepo == nil {
+		writeError(w, http.StatusInternalServerError, "internal_error", "Catalog is not configured")
+		return
+	}
+
+	libraryID, err := strconv.Atoi(strings.TrimSpace(r.URL.Query().Get("library_id")))
+	if err != nil || libraryID <= 0 {
+		writeError(w, http.StatusBadRequest, "bad_request", "library_id must be a positive integer")
+		return
+	}
+
+	groupBy, ok := catalog.ParseAudiobookGroupBy(r.URL.Query().Get("group_by"))
+	if !ok {
+		writeError(w, http.StatusBadRequest, "bad_request", "group_by must be one of author, narrator, series")
+		return
+	}
+
+	sort := strings.ToLower(strings.TrimSpace(r.URL.Query().Get("sort")))
+	switch sort {
+	case "", "name", "count", "duration":
+	default:
+		writeError(w, http.StatusBadRequest, "bad_request", "sort must be one of name, count, duration")
+		return
+	}
+
+	limit := 200
+	if raw := strings.TrimSpace(r.URL.Query().Get("limit")); raw != "" {
+		n, parseErr := strconv.Atoi(raw)
+		if parseErr != nil || n <= 0 {
+			writeError(w, http.StatusBadRequest, "bad_request", "limit must be a positive integer")
+			return
+		}
+		limit = n
+	}
+	offset := max(catalog.ParseIntParam(r.URL.Query().Get("offset")), 0)
+
+	groups, total, err := catalog.ListAudiobookGroups(
+		r.Context(),
+		h.itemsH.browseRepo.Pool(),
+		catalog.AudiobookGroupsQuery{
+			LibraryID: libraryID,
+			GroupBy:   groupBy,
+			Sort:      sort,
+			Limit:     limit,
+			Offset:    offset,
+		},
+		h.itemsH.accessFilter(r),
+	)
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, "internal_error", "Failed to list audiobook groups")
+		return
+	}
+
+	resp := audiobookGroupsResponse{Total: total, Groups: make([]audiobookGroupResponse, 0, len(groups))}
+	for _, g := range groups {
+		posterURLs := make([]string, 0, len(g.PosterPaths))
+		for _, path := range g.PosterPaths {
+			if url := h.itemsH.presignURL(r, cardThumbnailPath(path), "card"); url != "" {
+				posterURLs = append(posterURLs, url)
+			}
+		}
+		resp.Groups = append(resp.Groups, audiobookGroupResponse{
+			Name:                 g.Name,
+			ItemCount:            g.ItemCount,
+			TotalDurationSeconds: g.TotalDurationSeconds,
+			InProgressCount:      g.InProgressCount,
+			FinishedCount:        g.FinishedCount,
+			PosterURLs:           posterURLs,
+		})
+	}
+
+	writeJSON(w, http.StatusOK, resp)
+}

--- a/internal/api/router.go
+++ b/internal/api/router.go
@@ -923,6 +923,7 @@ func NewRouter(deps Dependencies) chi.Router {
 		sectionFetcher.StoreProvider = deps.UserStoreProvider
 		sectionFetcher.CollectionRepo = catalog.NewLibraryCollectionRepository(deps.DB)
 		sectionFetcher.NextUpRepo = catalog.NewNextUpRepository(deps.DB, deps.UserStoreProvider)
+		sectionFetcher.AudiobookNextRepo = catalog.NewAudiobookNextRepository(deps.DB)
 		if deps.DB != nil {
 			sectionFetcher.RecommendationRepo = recommendations.NewRepo(deps.DB)
 			if ratingsRepo != nil {
@@ -1111,6 +1112,7 @@ func NewRouter(deps Dependencies) chi.Router {
 			recsFetcher := sections.NewFetcher(deps.DB)
 			recsFetcher.StoreProvider = deps.UserStoreProvider
 			recsFetcher.NextUpRepo = catalog.NewNextUpRepository(deps.DB, deps.UserStoreProvider)
+			recsFetcher.AudiobookNextRepo = catalog.NewAudiobookNextRepository(deps.DB)
 			recsHandler.Fetcher = recsFetcher
 			recsHandler.WatchTonightFetcher = recsFetcher
 		}
@@ -1419,6 +1421,7 @@ func NewRouter(deps Dependencies) chi.Router {
 					r.Get("/catalog", catalogHandler.HandleGetCatalog)
 					r.Get("/catalog/filters", catalogHandler.HandleGetCatalogFilters)
 					r.Get("/catalog/filters/search", catalogHandler.HandleGetCatalogFacetSearch)
+					r.Get("/catalog/audiobook-groups", catalogHandler.HandleGetAudiobookGroups)
 					r.Post("/catalog/query", catalogHandler.HandlePostCatalogQuery)
 					if catalogResourceHandler != nil {
 						r.Get("/catalog/items/{id}", catalogResourceHandler.HandleGetItemDetail)

--- a/internal/catalog/audiobook_groups.go
+++ b/internal/catalog/audiobook_groups.go
@@ -1,0 +1,201 @@
+package catalog
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/jackc/pgx/v5/pgxpool"
+
+	"github.com/Silo-Server/silo-server/internal/models"
+)
+
+// AudiobookGroupBy enumerates the supported audiobook grouping axes.
+type AudiobookGroupBy string
+
+const (
+	AudiobookGroupByAuthor   AudiobookGroupBy = "author"
+	AudiobookGroupByNarrator AudiobookGroupBy = "narrator"
+	AudiobookGroupBySeries   AudiobookGroupBy = "series"
+)
+
+// ParseAudiobookGroupBy validates a group_by request parameter.
+func ParseAudiobookGroupBy(raw string) (AudiobookGroupBy, bool) {
+	switch AudiobookGroupBy(strings.ToLower(strings.TrimSpace(raw))) {
+	case AudiobookGroupByAuthor:
+		return AudiobookGroupByAuthor, true
+	case AudiobookGroupByNarrator:
+		return AudiobookGroupByNarrator, true
+	case AudiobookGroupBySeries:
+		return AudiobookGroupBySeries, true
+	default:
+		return "", false
+	}
+}
+
+// AudiobookGroupsQuery controls the grouped audiobook browse lookup.
+type AudiobookGroupsQuery struct {
+	LibraryID int
+	GroupBy   AudiobookGroupBy
+	// Sort is one of "name" (default), "count", "duration".
+	Sort   string
+	Limit  int
+	Offset int
+}
+
+// AudiobookGroup is one grouped browse row: an author, narrator, or series
+// with aggregate stats over the audiobooks visible to the viewer.
+type AudiobookGroup struct {
+	Name                 string
+	ItemCount            int
+	TotalDurationSeconds int64
+	InProgressCount      int
+	FinishedCount        int
+	// PosterPaths holds up to four raw poster paths for cover stacks; the
+	// API layer presigns them.
+	PosterPaths []string
+}
+
+// ListAudiobookGroups returns grouped browse rows for an audiobook library.
+// Groups are aggregated per person name (authors/narrators) or per series
+// name, matching the case-insensitive semantics of the corresponding catalog
+// filters, so a group name can be fed straight back into an author/narrator/
+// series filter rule. Progress counts are scoped to the requesting profile via
+// filter.UserID / filter.ProfileID.
+func ListAudiobookGroups(ctx context.Context, pool *pgxpool.Pool, q AudiobookGroupsQuery, filter AccessFilter) ([]AudiobookGroup, int, error) {
+	if pool == nil {
+		return nil, 0, fmt.Errorf("audiobook groups: no database pool")
+	}
+	if q.LibraryID <= 0 {
+		return nil, 0, fmt.Errorf("audiobook groups: library id is required")
+	}
+
+	limit := q.Limit
+	if limit <= 0 {
+		limit = 200
+	}
+	if limit > 500 {
+		limit = 500
+	}
+	offset := max(q.Offset, 0)
+
+	args := []any{q.LibraryID}
+	argIdx := 2
+
+	conditions := []string{
+		"mi.type = 'audiobook'",
+		"mil.media_folder_id = $1",
+	}
+	if !appendAudiobookItemAccessConditions("mi", filter, &conditions, &args, &argIdx) {
+		return []AudiobookGroup{}, 0, nil
+	}
+
+	var joinClause, nameExpr, groupExpr, posterOrder string
+	switch q.GroupBy {
+	case AudiobookGroupByAuthor, AudiobookGroupByNarrator:
+		kind := models.PersonKindAuthor
+		if q.GroupBy == AudiobookGroupByNarrator {
+			kind = models.PersonKindNarrator
+		}
+		joinClause = fmt.Sprintf(`JOIN item_people ip ON ip.content_id = b.content_id AND ip.kind = $%d
+			JOIN people p ON p.id = ip.person_id`, argIdx)
+		args = append(args, int(kind))
+		argIdx++
+		nameExpr = "MIN(BTRIM(p.name))"
+		groupExpr = "LOWER(BTRIM(p.name))"
+		posterOrder = "b.sort_title"
+	case AudiobookGroupBySeries:
+		joinClause = "JOIN audiobook_series s ON s.content_id = b.content_id"
+		nameExpr = "MIN(BTRIM(s.series_name))"
+		groupExpr = "LOWER(BTRIM(s.series_name))"
+		posterOrder = "s.series_index NULLS LAST, b.sort_title"
+	default:
+		return nil, 0, fmt.Errorf("audiobook groups: unsupported group_by %q", q.GroupBy)
+	}
+
+	userArg := fmt.Sprintf("$%d", argIdx)
+	args = append(args, filter.UserID)
+	argIdx++
+	profileArg := fmt.Sprintf("$%d", argIdx)
+	args = append(args, filter.ProfileID)
+	argIdx++
+
+	var orderClause string
+	switch strings.ToLower(strings.TrimSpace(q.Sort)) {
+	case "", "name":
+		orderClause = "LOWER(name)"
+	case "count":
+		orderClause = "item_count DESC, LOWER(name)"
+	case "duration":
+		orderClause = "total_duration_seconds DESC, LOWER(name)"
+	default:
+		return nil, 0, fmt.Errorf("audiobook groups: unsupported sort %q", q.Sort)
+	}
+
+	query := fmt.Sprintf(`
+		WITH books AS (
+			SELECT
+				mi.content_id,
+				mi.poster_path,
+				mi.sort_title,
+				COALESCE((
+					SELECT SUM(mf.duration)
+					FROM media_files mf
+					WHERE mf.content_id = mi.content_id AND mf.missing_since IS NULL
+				), 0) AS duration_seconds
+			FROM media_items mi
+			JOIN media_item_libraries mil ON mil.content_id = mi.content_id
+			WHERE %s
+		),
+		grouped AS (
+			SELECT
+				%s AS name,
+				COUNT(*)::int AS item_count,
+				COALESCE(SUM(b.duration_seconds), 0)::bigint AS total_duration_seconds,
+				COUNT(*) FILTER (WHERE uwp.media_item_id IS NOT NULL AND NOT uwp.completed)::int AS in_progress_count,
+				COUNT(*) FILTER (WHERE uwp.completed)::int AS finished_count,
+				(ARRAY_AGG(b.poster_path ORDER BY %s) FILTER (WHERE NULLIF(b.poster_path, '') IS NOT NULL))[1:4] AS poster_paths
+			FROM books b
+			%s
+			LEFT JOIN user_watch_progress uwp
+			       ON uwp.media_item_id = b.content_id
+			      AND uwp.user_id = %s
+			      AND uwp.profile_id = %s
+			GROUP BY %s
+		)
+		SELECT name, item_count, total_duration_seconds, in_progress_count, finished_count, poster_paths,
+		       COUNT(*) OVER ()::int AS total_groups
+		FROM grouped
+		ORDER BY %s
+		LIMIT $%d OFFSET $%d`,
+		strings.Join(conditions, " AND "),
+		nameExpr, posterOrder, joinClause, userArg, profileArg, groupExpr, orderClause,
+		argIdx, argIdx+1,
+	)
+	args = append(args, limit, offset)
+
+	rows, err := pool.Query(ctx, query, args...)
+	if err != nil {
+		return nil, 0, fmt.Errorf("querying audiobook groups: %w", err)
+	}
+	defer rows.Close()
+
+	total := 0
+	groups := make([]AudiobookGroup, 0, limit)
+	for rows.Next() {
+		var g AudiobookGroup
+		var posterPaths []string
+		if err := rows.Scan(&g.Name, &g.ItemCount, &g.TotalDurationSeconds, &g.InProgressCount, &g.FinishedCount, &posterPaths, &total); err != nil {
+			return nil, 0, fmt.Errorf("scanning audiobook group: %w", err)
+		}
+		if posterPaths == nil {
+			posterPaths = []string{}
+		}
+		g.PosterPaths = posterPaths
+		groups = append(groups, g)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, 0, fmt.Errorf("iterating audiobook groups: %w", err)
+	}
+	return groups, total, nil
+}

--- a/internal/catalog/audiobook_next_repo.go
+++ b/internal/catalog/audiobook_next_repo.go
@@ -1,0 +1,120 @@
+package catalog
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/jackc/pgx/v5/pgxpool"
+)
+
+// NextInSeriesQuery controls the audiobook next-in-series lookup.
+type NextInSeriesQuery struct {
+	UserID    int
+	ProfileID string
+	Limit     int
+}
+
+// NextInSeriesResult is one row from the next-in-series query: the next
+// unstarted audiobook in a series the profile has finished a book of.
+type NextInSeriesResult struct {
+	ContentID      string
+	SeriesName     string
+	SeriesIndex    *float64
+	LastFinishedAt time.Time
+}
+
+// AudiobookNextRepository queries audiobook series progression for the
+// next_in_series section.
+type AudiobookNextRepository struct {
+	pool *pgxpool.Pool
+}
+
+// NewAudiobookNextRepository creates an AudiobookNextRepository.
+func NewAudiobookNextRepository(pool *pgxpool.Pool) *AudiobookNextRepository {
+	return &AudiobookNextRepository{pool: pool}
+}
+
+// ListNextInSeries returns, for each audiobook series the profile has finished
+// at least one book of, the lowest-indexed later book the profile has not
+// started yet. Series surface in most-recently-finished order. Books already
+// in progress are excluded — they belong to Continue Listening, not here.
+//
+// Library scoping and access filtering are applied by the caller when
+// resolving content IDs to items (mirrors NextUpRepository.ListNextUp).
+func (r *AudiobookNextRepository) ListNextInSeries(ctx context.Context, q NextInSeriesQuery) ([]NextInSeriesResult, error) {
+	if r == nil || r.pool == nil || q.UserID <= 0 || q.ProfileID == "" {
+		return nil, nil
+	}
+
+	limit := q.Limit
+	if limit <= 0 {
+		limit = 20
+	}
+
+	const query = `
+		WITH finished_series AS (
+			SELECT
+				LOWER(BTRIM(s.series_name)) AS series_key,
+				MIN(BTRIM(s.series_name)) AS series_name,
+				MAX(s.series_index) AS max_finished_index,
+				MAX(uwp.updated_at) AS last_finished_at
+			FROM user_watch_progress uwp
+			JOIN audiobook_series s ON s.content_id = uwp.media_item_id
+			JOIN media_items mi ON mi.content_id = uwp.media_item_id
+			WHERE uwp.user_id = $1
+			  AND uwp.profile_id = $2
+			  AND uwp.completed = TRUE
+			  AND mi.type = 'audiobook'
+			  AND s.series_index IS NOT NULL
+			GROUP BY LOWER(BTRIM(s.series_name))
+		)
+		SELECT
+			next_book.content_id,
+			fs.series_name,
+			next_book.series_index,
+			fs.last_finished_at
+		FROM finished_series fs
+		JOIN LATERAL (
+			SELECT m.content_id, s2.series_index
+			FROM audiobook_series s2
+			JOIN media_items m ON m.content_id = s2.content_id
+			WHERE LOWER(BTRIM(s2.series_name)) = fs.series_key
+			  AND s2.series_index IS NOT NULL
+			  AND s2.series_index > fs.max_finished_index
+			  AND m.type = 'audiobook'
+			  AND EXISTS (
+				  SELECT 1 FROM media_files mf
+				  WHERE mf.content_id = m.content_id AND mf.missing_since IS NULL
+			  )
+			  AND NOT EXISTS (
+				  SELECT 1 FROM user_watch_progress uwp2
+				  WHERE uwp2.user_id = $1
+				    AND uwp2.profile_id = $2
+				    AND uwp2.media_item_id = m.content_id
+			  )
+			ORDER BY s2.series_index, LOWER(m.sort_title)
+			LIMIT 1
+		) next_book ON true
+		ORDER BY fs.last_finished_at DESC
+		LIMIT $3`
+
+	rows, err := r.pool.Query(ctx, query, q.UserID, q.ProfileID, limit)
+	if err != nil {
+		return nil, fmt.Errorf("querying next-in-series audiobooks: %w", err)
+	}
+	defer rows.Close()
+
+	var results []NextInSeriesResult
+	for rows.Next() {
+		var res NextInSeriesResult
+		if err := rows.Scan(&res.ContentID, &res.SeriesName, &res.SeriesIndex, &res.LastFinishedAt); err != nil {
+			return nil, fmt.Errorf("scanning next-in-series row: %w", err)
+		}
+		results = append(results, res)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("iterating next-in-series rows: %w", err)
+	}
+	return results, nil
+}

--- a/internal/catalog/audiobook_next_repo.go
+++ b/internal/catalog/audiobook_next_repo.go
@@ -13,6 +13,13 @@ type NextInSeriesQuery struct {
 	UserID    int
 	ProfileID string
 	Limit     int
+	// LibraryID / LibraryIDs / DisabledLibraryIDs scope the candidate books in
+	// SQL. Without this, a profile whose recently finished series live in a
+	// different library would consume the LIMIT with candidates the caller
+	// then filters out, starving a library-scoped section.
+	LibraryID          *int
+	LibraryIDs         []int
+	DisabledLibraryIDs []int
 }
 
 // NextInSeriesResult is one row from the next-in-series query: the next
@@ -40,8 +47,9 @@ func NewAudiobookNextRepository(pool *pgxpool.Pool) *AudiobookNextRepository {
 // started yet. Series surface in most-recently-finished order. Books already
 // in progress are excluded — they belong to Continue Listening, not here.
 //
-// Library scoping and access filtering are applied by the caller when
-// resolving content IDs to items (mirrors NextUpRepository.ListNextUp).
+// Candidate books are library-scoped in SQL (see NextInSeriesQuery); remaining
+// access filtering (content rating) is applied by the caller when resolving
+// content IDs to items.
 func (r *AudiobookNextRepository) ListNextInSeries(ctx context.Context, q NextInSeriesQuery) ([]NextInSeriesResult, error) {
 	if r == nil || r.pool == nil || q.UserID <= 0 || q.ProfileID == "" {
 		return nil, nil
@@ -52,7 +60,41 @@ func (r *AudiobookNextRepository) ListNextInSeries(ctx context.Context, q NextIn
 		limit = 20
 	}
 
-	const query = `
+	args := []any{q.UserID, q.ProfileID}
+	argIdx := 3
+	candidateScope := ""
+	if q.LibraryID != nil {
+		candidateScope += fmt.Sprintf(`
+			  AND EXISTS (
+				  SELECT 1 FROM media_item_libraries mil
+				  WHERE mil.content_id = m.content_id AND mil.media_folder_id = $%d
+			  )`, argIdx)
+		args = append(args, *q.LibraryID)
+		argIdx++
+	} else if q.LibraryIDs != nil {
+		if len(q.LibraryIDs) == 0 {
+			return nil, nil
+		}
+		candidateScope += fmt.Sprintf(`
+			  AND EXISTS (
+				  SELECT 1 FROM media_item_libraries mil
+				  WHERE mil.content_id = m.content_id AND mil.media_folder_id = ANY($%d)
+			  )`, argIdx)
+		args = append(args, q.LibraryIDs)
+		argIdx++
+	}
+	if len(q.DisabledLibraryIDs) > 0 {
+		candidateScope += fmt.Sprintf(`
+			  AND NOT EXISTS (
+				  SELECT 1 FROM media_item_libraries mil_disabled
+				  WHERE mil_disabled.content_id = m.content_id
+				    AND mil_disabled.media_folder_id = ANY($%d)
+			  )`, argIdx)
+		args = append(args, q.DisabledLibraryIDs)
+		argIdx++
+	}
+
+	query := fmt.Sprintf(`
 		WITH finished_series AS (
 			SELECT
 				LOWER(BTRIM(s.series_name)) AS series_key,
@@ -92,14 +134,15 @@ func (r *AudiobookNextRepository) ListNextInSeries(ctx context.Context, q NextIn
 				  WHERE uwp2.user_id = $1
 				    AND uwp2.profile_id = $2
 				    AND uwp2.media_item_id = m.content_id
-			  )
+			  )%s
 			ORDER BY s2.series_index, LOWER(m.sort_title)
 			LIMIT 1
 		) next_book ON true
 		ORDER BY fs.last_finished_at DESC
-		LIMIT $3`
+		LIMIT $%d`, candidateScope, argIdx)
+	args = append(args, limit)
 
-	rows, err := r.pool.Query(ctx, query, q.UserID, q.ProfileID, limit)
+	rows, err := r.pool.Query(ctx, query, args...)
 	if err != nil {
 		return nil, fmt.Errorf("querying next-in-series audiobooks: %w", err)
 	}

--- a/internal/sections/defaults.go
+++ b/internal/sections/defaults.go
@@ -189,12 +189,15 @@ func DefaultLibrarySectionsForType(libraryID *int, libraryType string) []*PageSe
 			{ID: "default-random-tv", Scope: "library", LibraryID: libraryID, Position: 5, SectionType: SectionRandom, Title: "Random Picks", ItemLimit: 20, Config: defaultMediaScopeConfig("series"), Enabled: true},
 		}
 	case "audiobooks", "audiobook":
+		// Continue Listening is featured: the library Home tab renders it as
+		// the "Now Listening" resume hero instead of a backdrop carousel.
 		return []*PageSection{
-			{ID: "default-continue-listening", Scope: "library", LibraryID: libraryID, Position: 0, SectionType: SectionContinueWatching, Title: "Continue Listening", ItemLimit: 20, Config: ContinueTypeConfig(ContinueTypeListening), Enabled: true},
-			{ID: "default-recently-added-audiobooks", Scope: "library", LibraryID: libraryID, Position: 1, SectionType: SectionRecentlyAdded, Title: "Recently Added Audiobooks", ItemLimit: 20, Config: defaultMediaScopeConfig("audiobook"), Enabled: true},
-			{ID: "default-recently-released-audiobooks", Scope: "library", LibraryID: libraryID, Position: 2, SectionType: SectionRecentlyReleased, Title: "Recently Released Audiobooks", ItemLimit: 20, Config: defaultMediaScopeConfig("audiobook"), Enabled: true},
-			{ID: "default-recommended-for-you", Scope: "library", LibraryID: libraryID, Position: 3, SectionType: SectionRecommendedForYou, Title: "Recommended for You", ItemLimit: 20, Config: emptyCfg, Enabled: true},
-			{ID: "default-random-audiobooks", Scope: "library", LibraryID: libraryID, Position: 4, SectionType: SectionRandom, Title: "Random Picks", ItemLimit: 20, Config: defaultMediaScopeConfig("audiobook"), Enabled: true},
+			{ID: "default-continue-listening", Scope: "library", LibraryID: libraryID, Position: 0, SectionType: SectionContinueWatching, Title: "Continue Listening", Featured: true, ItemLimit: 20, Config: ContinueTypeConfig(ContinueTypeListening), Enabled: true},
+			{ID: "default-next-in-series", Scope: "library", LibraryID: libraryID, Position: 1, SectionType: SectionNextInSeries, Title: "Next in Your Series", ItemLimit: 20, Config: emptyCfg, Enabled: true},
+			{ID: "default-recently-added-audiobooks", Scope: "library", LibraryID: libraryID, Position: 2, SectionType: SectionRecentlyAdded, Title: "Recently Added Audiobooks", ItemLimit: 20, Config: defaultMediaScopeConfig("audiobook"), Enabled: true},
+			{ID: "default-recently-released-audiobooks", Scope: "library", LibraryID: libraryID, Position: 3, SectionType: SectionRecentlyReleased, Title: "Recently Released Audiobooks", ItemLimit: 20, Config: defaultMediaScopeConfig("audiobook"), Enabled: true},
+			{ID: "default-recommended-for-you", Scope: "library", LibraryID: libraryID, Position: 4, SectionType: SectionRecommendedForYou, Title: "Recommended for You", ItemLimit: 20, Config: emptyCfg, Enabled: true},
+			{ID: "default-random-audiobooks", Scope: "library", LibraryID: libraryID, Position: 5, SectionType: SectionRandom, Title: "Random Picks", ItemLimit: 20, Config: defaultMediaScopeConfig("audiobook"), Enabled: true},
 		}
 	default:
 		return DefaultLibrarySections(libraryID)

--- a/internal/sections/defaults_test.go
+++ b/internal/sections/defaults_test.go
@@ -261,8 +261,8 @@ func TestDefaultLibrarySectionsForTypeAudiobooks(t *testing.T) {
 	libraryID := 10
 	got := DefaultLibrarySectionsForType(&libraryID, "audiobooks")
 
-	if len(got) != 5 {
-		t.Fatalf("expected 5 audiobook default sections, got %d", len(got))
+	if len(got) != 6 {
+		t.Fatalf("expected 6 audiobook default sections, got %d", len(got))
 	}
 
 	tests := []struct {
@@ -271,12 +271,14 @@ func TestDefaultLibrarySectionsForTypeAudiobooks(t *testing.T) {
 		sectionType SectionType
 		title       string
 		position    int
+		featured    bool
 	}{
-		{index: 0, id: "default-continue-listening", sectionType: SectionContinueWatching, title: "Continue Listening", position: 0},
-		{index: 1, id: "default-recently-added-audiobooks", sectionType: SectionRecentlyAdded, title: "Recently Added Audiobooks", position: 1},
-		{index: 2, id: "default-recently-released-audiobooks", sectionType: SectionRecentlyReleased, title: "Recently Released Audiobooks", position: 2},
-		{index: 3, id: "default-recommended-for-you", sectionType: SectionRecommendedForYou, title: "Recommended for You", position: 3},
-		{index: 4, id: "default-random-audiobooks", sectionType: SectionRandom, title: "Random Picks", position: 4},
+		{index: 0, id: "default-continue-listening", sectionType: SectionContinueWatching, title: "Continue Listening", position: 0, featured: true},
+		{index: 1, id: "default-next-in-series", sectionType: SectionNextInSeries, title: "Next in Your Series", position: 1},
+		{index: 2, id: "default-recently-added-audiobooks", sectionType: SectionRecentlyAdded, title: "Recently Added Audiobooks", position: 2},
+		{index: 3, id: "default-recently-released-audiobooks", sectionType: SectionRecentlyReleased, title: "Recently Released Audiobooks", position: 3},
+		{index: 4, id: "default-recommended-for-you", sectionType: SectionRecommendedForYou, title: "Recommended for You", position: 4},
+		{index: 5, id: "default-random-audiobooks", sectionType: SectionRandom, title: "Random Picks", position: 5},
 	}
 
 	for _, tt := range tests {
@@ -293,26 +295,27 @@ func TestDefaultLibrarySectionsForTypeAudiobooks(t *testing.T) {
 		if section.Position != tt.position {
 			t.Fatalf("section %d position = %d, want %d", tt.index, section.Position, tt.position)
 		}
-		if section.Featured {
-			t.Fatalf("section %d featured = true, want false", tt.index)
+		if section.Featured != tt.featured {
+			t.Fatalf("section %d featured = %v, want %v", tt.index, section.Featured, tt.featured)
 		}
 	}
 	assertContinueType(t, got[0].Config, ContinueTypeListening)
 
-	assertQueryDefinition(t, got[1].Config, catalog.QueryDefinition{
-		MediaScope: "audiobook",
-		Match:      "all",
-		Groups:     []catalog.QueryGroup{},
-		Sort:       catalog.QuerySort{Field: "added_at", Order: "desc"},
-	})
+	assertEmptyJSON(t, got[1].Config)
 	assertQueryDefinition(t, got[2].Config, catalog.QueryDefinition{
 		MediaScope: "audiobook",
 		Match:      "all",
 		Groups:     []catalog.QueryGroup{},
 		Sort:       catalog.QuerySort{Field: "added_at", Order: "desc"},
 	})
-	assertEmptyJSON(t, got[3].Config)
-	assertQueryDefinition(t, got[4].Config, catalog.QueryDefinition{
+	assertQueryDefinition(t, got[3].Config, catalog.QueryDefinition{
+		MediaScope: "audiobook",
+		Match:      "all",
+		Groups:     []catalog.QueryGroup{},
+		Sort:       catalog.QuerySort{Field: "added_at", Order: "desc"},
+	})
+	assertEmptyJSON(t, got[4].Config)
+	assertQueryDefinition(t, got[5].Config, catalog.QueryDefinition{
 		MediaScope: "audiobook",
 		Match:      "all",
 		Groups:     []catalog.QueryGroup{},

--- a/internal/sections/fetcher.go
+++ b/internal/sections/fetcher.go
@@ -74,6 +74,7 @@ type Fetcher struct {
 	RecommendationRepo   *recommendations.Repo // retained for non-reader call sites
 	RecommendationReader recommendationReader
 	NextUpRepo           *catalog.NextUpRepository
+	AudiobookNextRepo    *catalog.AudiobookNextRepository
 
 	// TrendingSnapshots reads the persisted external-trending snapshots that
 	// back the trending_discover section. Nil renders that section empty.
@@ -253,6 +254,10 @@ func (f *Fetcher) FetchOne(ctx context.Context, resolved ResolvedSection, librar
 	}
 	if resolved.SectionType == SectionNextUp {
 		result, err = f.fetchNextUpSection(ctx, resolved, libraryID, libraryIDs, userID, profileID, filter)
+		return result, err
+	}
+	if resolved.SectionType == SectionNextInSeries {
+		result, err = f.fetchNextInSeriesSection(ctx, resolved, libraryID, libraryIDs, userID, profileID, filter)
 		return result, err
 	}
 	if resolved.SectionType == SectionEditorialSpotlight {
@@ -636,6 +641,91 @@ func (f *Fetcher) FetchNextUpItems(ctx context.Context, userID int, profileID st
 	}
 
 	return orderedItems, meta, nil
+}
+
+// fetchNextInSeriesSection surfaces the next unstarted audiobook per series
+// the profile has finished a book of. Candidates come from AudiobookNextRepo;
+// library scoping and access filtering happen while resolving candidate IDs to
+// items, so candidates outside the section's libraries simply drop out. The
+// candidate query over-fetches to compensate for that post-resolution trim.
+func (f *Fetcher) fetchNextInSeriesSection(ctx context.Context, resolved ResolvedSection, libraryID *int, libraryIDs []int, userID int, profileID string, filter catalog.AccessFilter) (SectionWithItems, error) {
+	emptyResult := SectionWithItems{
+		ResolvedSection: resolved,
+		Items:           []*models.MediaItem{},
+		TotalCount:      0,
+		ItemMeta:        map[string]SectionItemMeta{},
+	}
+
+	if f.AudiobookNextRepo == nil || userID <= 0 || profileID == "" {
+		return emptyResult, nil
+	}
+
+	limit := resolved.ItemLimit
+	if limit <= 0 {
+		limit = 20
+	}
+	candidateLimit := limit * 3
+	if candidateLimit > 100 {
+		candidateLimit = 100
+	}
+
+	results, err := f.AudiobookNextRepo.ListNextInSeries(ctx, catalog.NextInSeriesQuery{
+		UserID:    userID,
+		ProfileID: profileID,
+		Limit:     candidateLimit,
+	})
+	if err != nil {
+		return SectionWithItems{}, err
+	}
+	if len(results) == 0 {
+		return emptyResult, nil
+	}
+
+	contentIDs := make([]string, len(results))
+	for i, res := range results {
+		contentIDs[i] = res.ContentID
+	}
+
+	items, err := f.fetchItemsByContentIDs(ctx, contentIDs, libraryID, libraryIDs, filter)
+	if err != nil {
+		return SectionWithItems{}, fmt.Errorf("fetching next-in-series items: %w", err)
+	}
+
+	itemByID := make(map[string]*models.MediaItem, len(items))
+	for _, item := range items {
+		itemByID[item.ContentID] = item
+	}
+
+	meta := make(map[string]SectionItemMeta, len(results))
+	ordered := make([]*models.MediaItem, 0, limit)
+	for _, res := range results {
+		if len(ordered) >= limit {
+			break
+		}
+		item, ok := itemByID[res.ContentID]
+		if !ok {
+			continue
+		}
+		m := SectionItemMeta{
+			SeriesTitle:   res.SeriesName,
+			ItemSource:    "next_in_series",
+			SortTimestamp: res.LastFinishedAt,
+		}
+		if res.SeriesIndex != nil {
+			if n := int(*res.SeriesIndex); float64(n) == *res.SeriesIndex {
+				m.Badges = append(m.Badges, fmt.Sprintf("Book %d", n))
+			}
+		}
+		meta[res.ContentID] = m
+		ordered = append(ordered, item)
+	}
+
+	return SectionWithItems{
+		ResolvedSection: resolved,
+		Items:           ordered,
+		TotalCount:      len(ordered),
+		ItemMeta:        meta,
+	}, nil
 }
 
 func collapseContinueWatchingSeriesCandidates(items []*models.MediaItem, meta map[string]SectionItemMeta) []*models.MediaItem {

--- a/internal/sections/fetcher.go
+++ b/internal/sections/fetcher.go
@@ -644,10 +644,12 @@ func (f *Fetcher) FetchNextUpItems(ctx context.Context, userID int, profileID st
 }
 
 // fetchNextInSeriesSection surfaces the next unstarted audiobook per series
-// the profile has finished a book of. Candidates come from AudiobookNextRepo;
-// library scoping and access filtering happen while resolving candidate IDs to
-// items, so candidates outside the section's libraries simply drop out. The
-// candidate query over-fetches to compensate for that post-resolution trim.
+// the profile has finished a book of. Candidates come from AudiobookNextRepo
+// with library scoping pushed into the SQL — otherwise finished series whose
+// next book lives in another library would consume the candidate limit and
+// starve a library-scoped section. Content-rating access filtering happens
+// while resolving candidate IDs to items, so the candidate query still
+// over-fetches to compensate for that post-resolution trim.
 func (f *Fetcher) fetchNextInSeriesSection(ctx context.Context, resolved ResolvedSection, libraryID *int, libraryIDs []int, userID int, profileID string, filter catalog.AccessFilter) (SectionWithItems, error) {
 	emptyResult := SectionWithItems{
 		ResolvedSection: resolved,
@@ -670,9 +672,12 @@ func (f *Fetcher) fetchNextInSeriesSection(ctx context.Context, resolved Resolve
 	}
 
 	results, err := f.AudiobookNextRepo.ListNextInSeries(ctx, catalog.NextInSeriesQuery{
-		UserID:    userID,
-		ProfileID: profileID,
-		Limit:     candidateLimit,
+		UserID:             userID,
+		ProfileID:          profileID,
+		Limit:              candidateLimit,
+		LibraryID:          libraryID,
+		LibraryIDs:         effectiveFetchLibraryIDs(libraryIDs, filter),
+		DisabledLibraryIDs: filter.DisabledLibraryIDs,
 	})
 	if err != nil {
 		return SectionWithItems{}, err

--- a/internal/sections/recipe_equivalence_test.go
+++ b/internal/sections/recipe_equivalence_test.go
@@ -22,8 +22,8 @@ func TestRecipeDispatchEquivalence(t *testing.T) {
 	}
 
 	// Each type that has a no-DB-required short-circuit in FetchOne (continue_watching with no
-	// store, next_up with no repo) should resolve without error.
-	for _, typ := range []string{"continue_watching", "next_up"} {
+	// store, next_up / next_in_series with no repo) should resolve without error.
+	for _, typ := range []string{"continue_watching", "next_up", "next_in_series"} {
 		rec, ok := recipes.Get(typ)
 		if !ok {
 			t.Fatalf("recipe %q missing", typ)

--- a/internal/sections/recipes/library_staples.go
+++ b/internal/sections/recipes/library_staples.go
@@ -95,6 +95,7 @@ func init() {
 		},
 	})
 	Register(&libStaple{typ: "next_up", displayName: "On Deck", icon: "📺", descShort: "Next episodes ready to watch.", cacheTTL: time.Minute})
+	Register(&libStaple{typ: "next_in_series", displayName: "Next in Series", icon: "📚", descShort: "The next audiobook in series you've finished.", cacheTTL: time.Minute})
 	Register(&libStaple{typ: "watchlist", displayName: "Watchlist", icon: "🔖", descShort: "Items you've saved to watch.", cacheTTL: time.Minute})
 	Register(&libStaple{typ: "favorites", displayName: "Favorites", icon: "⭐", descShort: "Your favorites.", cacheTTL: time.Minute})
 	Register(&libStaple{typ: "random", displayName: "Surprise Me", icon: "🎲", descShort: "A random selection from your library.", cacheTTL: 5 * time.Minute})

--- a/internal/sections/types.go
+++ b/internal/sections/types.go
@@ -26,6 +26,7 @@ const (
 	SectionSimilarUsersLiked   SectionType = "similar_users_liked"
 	SectionTasteMatch          SectionType = "taste_match"
 	SectionNextUp              SectionType = "next_up"
+	SectionNextInSeries        SectionType = "next_in_series"
 	SectionHiddenGems          SectionType = "hidden_gems"
 	SectionCriticallyAcclaimed SectionType = "critically_acclaimed"
 	SectionAwardWinners        SectionType = "award_winners"
@@ -61,6 +62,7 @@ var ValidSectionTypes = map[SectionType]bool{
 	SectionSimilarUsersLiked:   true,
 	SectionTasteMatch:          true,
 	SectionNextUp:              true,
+	SectionNextInSeries:        true,
 	SectionHiddenGems:          true,
 	SectionCriticallyAcclaimed: true,
 	SectionAwardWinners:        true,

--- a/migrations/sql/20260609222830_audiobook_library_home_redesign.sql
+++ b/migrations/sql/20260609222830_audiobook_library_home_redesign.sql
@@ -1,0 +1,119 @@
+-- +goose Up
+-- +goose StatementBegin
+-- Audiobook library Home redesign: the Continue Listening section becomes the
+-- featured "Now Listening" resume hero, and a next_in_series row surfaces the
+-- next unstarted book in series the profile has finished.
+--
+-- Mark the first continue-listening section of each audiobook library as
+-- featured, but only when the admin has not already featured something else in
+-- that library's layout.
+WITH target AS (
+    SELECT DISTINCT ON (ps.library_id) ps.id
+    FROM page_sections ps
+    JOIN media_folders mf ON mf.id = ps.library_id
+    WHERE ps.scope = 'library'
+      AND lower(mf.type) IN ('audiobook', 'audiobooks')
+      AND ps.section_type = 'continue_watching'
+      AND ps.config->>'continue_type' = 'listening'
+      AND NOT EXISTS (
+          SELECT 1 FROM page_sections f
+          WHERE f.scope = 'library'
+            AND f.library_id = ps.library_id
+            AND f.featured
+      )
+    ORDER BY ps.library_id, ps.position ASC
+)
+UPDATE page_sections ps
+SET featured = TRUE,
+    updated_at = NOW()
+FROM target t
+WHERE ps.id = t.id;
+-- +goose StatementEnd
+
+-- +goose StatementBegin
+-- Insert a next_in_series section into each audiobook library that lacks one,
+-- directly after its continue-listening section (or at the end of the layout
+-- when no continue-listening section exists).
+WITH anchors AS (
+    SELECT DISTINCT ON (ps.library_id)
+        ps.library_id,
+        ps.position + 1 AS insert_position
+    FROM page_sections ps
+    JOIN media_folders mf ON mf.id = ps.library_id
+    WHERE ps.scope = 'library'
+      AND lower(mf.type) IN ('audiobook', 'audiobooks')
+      AND ps.section_type = 'continue_watching'
+      AND ps.config->>'continue_type' = 'listening'
+    ORDER BY ps.library_id, ps.position ASC
+),
+targets AS (
+    SELECT
+        mf.id AS library_id,
+        COALESCE(
+            a.insert_position,
+            (
+                SELECT COALESCE(MAX(p2.position) + 1, 0)
+                FROM page_sections p2
+                WHERE p2.scope = 'library' AND p2.library_id = mf.id
+            )
+        ) AS insert_position
+    FROM media_folders mf
+    LEFT JOIN anchors a ON a.library_id = mf.id
+    WHERE lower(mf.type) IN ('audiobook', 'audiobooks')
+      AND NOT EXISTS (
+          SELECT 1 FROM page_sections e
+          WHERE e.scope = 'library'
+            AND e.library_id = mf.id
+            AND e.section_type = 'next_in_series'
+      )
+),
+shifted AS (
+    UPDATE page_sections ps
+    SET position = ps.position + 1,
+        updated_at = NOW()
+    FROM targets t
+    WHERE ps.scope = 'library'
+      AND ps.library_id = t.library_id
+      AND ps.position >= t.insert_position
+    RETURNING 1
+)
+INSERT INTO page_sections (
+    id, scope, library_id, position, section_type, title, featured,
+    item_limit, config, enabled, created_at, updated_at
+)
+SELECT
+    gen_random_uuid()::text,
+    'library',
+    t.library_id,
+    t.insert_position,
+    'next_in_series',
+    'Next in Your Series',
+    false,
+    20,
+    '{}'::jsonb,
+    true,
+    NOW(),
+    NOW()
+FROM targets t;
+-- +goose StatementEnd
+
+-- +goose Down
+-- +goose StatementBegin
+DELETE FROM page_sections ps
+USING media_folders mf
+WHERE ps.scope = 'library'
+  AND ps.library_id = mf.id
+  AND lower(mf.type) IN ('audiobook', 'audiobooks')
+  AND ps.section_type = 'next_in_series';
+
+UPDATE page_sections ps
+SET featured = FALSE,
+    updated_at = NOW()
+FROM media_folders mf
+WHERE ps.scope = 'library'
+  AND ps.library_id = mf.id
+  AND lower(mf.type) IN ('audiobook', 'audiobooks')
+  AND ps.section_type = 'continue_watching'
+  AND ps.config->>'continue_type' = 'listening'
+  AND ps.featured;
+-- +goose StatementEnd

--- a/migrations/sql/20260609222830_audiobook_library_home_redesign.sql
+++ b/migrations/sql/20260609222830_audiobook_library_home_redesign.sql
@@ -4,6 +4,9 @@
 -- featured "Now Listening" resume hero, and a next_in_series row surfaces the
 -- next unstarted book in series the profile has finished.
 --
+-- Rows touched here carry a marker key in config so the Down migration can
+-- revert exactly what this migration changed and nothing else.
+--
 -- Mark the first continue-listening section of each audiobook library as
 -- featured, but only when the admin has not already featured something else in
 -- that library's layout.
@@ -15,6 +18,7 @@ WITH target AS (
       AND lower(mf.type) IN ('audiobook', 'audiobooks')
       AND ps.section_type = 'continue_watching'
       AND ps.config->>'continue_type' = 'listening'
+      AND NOT ps.featured
       AND NOT EXISTS (
           SELECT 1 FROM page_sections f
           WHERE f.scope = 'library'
@@ -25,6 +29,7 @@ WITH target AS (
 )
 UPDATE page_sections ps
 SET featured = TRUE,
+    config = ps.config || '{"featured_by_migration":"20260609222830"}'::jsonb,
     updated_at = NOW()
 FROM target t
 WHERE ps.id = t.id;
@@ -90,7 +95,7 @@ SELECT
     'Next in Your Series',
     false,
     20,
-    '{}'::jsonb,
+    '{"seeded_by_migration":"20260609222830"}'::jsonb,
     true,
     NOW(),
     NOW()
@@ -99,21 +104,19 @@ FROM targets t;
 
 -- +goose Down
 -- +goose StatementBegin
-DELETE FROM page_sections ps
-USING media_folders mf
-WHERE ps.scope = 'library'
-  AND ps.library_id = mf.id
-  AND lower(mf.type) IN ('audiobook', 'audiobooks')
-  AND ps.section_type = 'next_in_series';
+-- Revert only the rows the Up migration touched, identified by the marker
+-- keys it wrote. Admin-created next_in_series sections and sections featured
+-- before (or after) the upgrade are left alone.
+DELETE FROM page_sections
+WHERE scope = 'library'
+  AND section_type = 'next_in_series'
+  AND config->>'seeded_by_migration' = '20260609222830';
 
-UPDATE page_sections ps
+UPDATE page_sections
 SET featured = FALSE,
+    config = config - 'featured_by_migration',
     updated_at = NOW()
-FROM media_folders mf
-WHERE ps.scope = 'library'
-  AND ps.library_id = mf.id
-  AND lower(mf.type) IN ('audiobook', 'audiobooks')
-  AND ps.section_type = 'continue_watching'
-  AND ps.config->>'continue_type' = 'listening'
-  AND ps.featured;
+WHERE scope = 'library'
+  AND section_type = 'continue_watching'
+  AND config->>'featured_by_migration' = '20260609222830';
 -- +goose StatementEnd

--- a/web/src/api/types.ts
+++ b/web/src/api/types.ts
@@ -726,6 +726,23 @@ export interface CatalogFiltersResponse extends ItemFiltersResponse {
   series?: string[];
 }
 
+// Grouped audiobook browse (Library tab Authors / Narrators / Series axes).
+// `name` round-trips into the matching catalog filter field (author /
+// narrator / series), which match case-insensitively.
+export interface AudiobookGroup {
+  name: string;
+  item_count: number;
+  total_duration_seconds: number;
+  in_progress_count: number;
+  finished_count: number;
+  poster_urls: string[];
+}
+
+export interface AudiobookGroupsResponse {
+  total: number;
+  groups: AudiobookGroup[];
+}
+
 // Item Detail
 export interface FileVersion {
   file_id: number;

--- a/web/src/components/ContinueWatchingCard.tsx
+++ b/web/src/components/ContinueWatchingCard.tsx
@@ -7,6 +7,7 @@ import type { ProgressEntry } from "@/api/types";
 import MediaItemMenu from "@/components/MediaItemMenu";
 import CardOverlays from "@/components/overlays/CardOverlays";
 import { overlayDataFromSectionItem, type CardOverlayPrefs } from "@/lib/overlays";
+import { formatListeningTimeLeft } from "@/lib/audiobooks/duration";
 import { upcomingBadgeClass, upcomingBadgeLabel } from "@/lib/upcomingEventPresentation";
 import { useWatchPlaybackController } from "@/playback/watchPlaybackContext";
 import { parseWatchHref } from "@/pages/watchRouteHelpers";
@@ -123,7 +124,9 @@ export default function ContinueWatchingCard(props: ContinueWatchingCardProps) {
       ? null
       : "Next Episode"
     : card.durationSeconds > 0
-      ? `${Math.round((card.durationSeconds - card.positionSeconds) / 60)} min left`
+      ? card.type === "audiobook"
+        ? formatListeningTimeLeft(card.positionSeconds, card.durationSeconds)
+        : `${Math.round((card.durationSeconds - card.positionSeconds) / 60)} min left`
       : "\u00A0";
   const handleWatchClick = useCallback(
     (event: React.MouseEvent<HTMLAnchorElement>) => {

--- a/web/src/components/LibraryHeader.tsx
+++ b/web/src/components/LibraryHeader.tsx
@@ -1,11 +1,14 @@
 import { useEffect, useState } from "react";
 import { Tabs as TabsPrimitive } from "radix-ui";
 import { cn } from "@/lib/utils";
+import { isAudiobookLibraryType } from "@/pages/libraryPageSearchParams";
 
 type LibraryTab = "recommended" | "library" | "collections";
 
 interface LibraryHeaderProps {
   libraryName: string;
+  /** Library type ("movies", "series", "audiobooks", ...); drives tab labels. */
+  libraryType?: string;
   /**
    * When true, the header renders transparently to sit over a hero backdrop,
    * and switches to a glass surface once the user scrolls past a threshold.
@@ -22,14 +25,23 @@ const TAB_LABELS: Record<LibraryTab, string> = {
   collections: "Collections",
 };
 
+// Audiobook libraries open on a resume-first deck rather than a discovery
+// feed, so "Recommended" would mislabel what the tab actually shows.
+const AUDIOBOOK_TAB_LABELS: Record<LibraryTab, string> = {
+  ...TAB_LABELS,
+  recommended: "Home",
+};
+
 /** Scroll distance (in px) at which an overlay header switches to glass. */
 const GLASS_THRESHOLD_PX = 160;
 
 export default function LibraryHeader({
   libraryName,
+  libraryType = "",
   overlay = false,
   availableTabs = DEFAULT_TABS,
 }: LibraryHeaderProps) {
+  const tabLabels = isAudiobookLibraryType(libraryType) ? AUDIOBOOK_TAB_LABELS : TAB_LABELS;
   const [pastThreshold, setPastThreshold] = useState(false);
 
   useEffect(() => {
@@ -62,7 +74,7 @@ export default function LibraryHeader({
       <TabsPrimitive.List className="marquee-tab-bar" aria-label="Library view">
         {availableTabs.map((tab) => (
           <TabsPrimitive.Trigger key={tab} value={tab} className="marquee-tab-trigger">
-            {TAB_LABELS[tab]}
+            {tabLabels[tab]}
           </TabsPrimitive.Trigger>
         ))}
       </TabsPrimitive.List>

--- a/web/src/components/NowListeningHero.tsx
+++ b/web/src/components/NowListeningHero.tsx
@@ -1,0 +1,239 @@
+import { useMemo, type MouseEvent } from "react";
+import { Link } from "react-router";
+import { Info, Pause, Play } from "lucide-react";
+import type { ResolvedSection } from "@/api/types";
+import ContinueWatchingCard from "@/components/ContinueWatchingCard";
+import MediaCarousel from "@/components/MediaCarousel";
+import { useCatalogItemDetail } from "@/hooks/queries/catalogRead";
+import { useAmbientColor } from "@/hooks/useAmbientColor";
+import { useOverlayPrefs } from "@/hooks/useOverlayPrefs";
+import { buildChapterList, findChapterAt, totalAudiobookDuration } from "@/lib/audiobooks/chapters";
+import { formatHoursMinutes, formatListeningTimeLeft } from "@/lib/audiobooks/duration";
+import { audiobookFilesFromVersions } from "@/lib/audiobooks/files";
+import { buildItemHref, buildMediaPlayHref } from "@/lib/mediaNavigation";
+import { decodeThumbhash } from "@/lib/thumbhash";
+import { useAudiobookPlaybackController } from "@/pages/audiobooks/player/audiobookPlaybackContext";
+
+interface NowListeningHeroProps {
+  /** A resolved continue-listening section; items are in-progress audiobooks. */
+  section: ResolvedSection;
+  libraryId?: number;
+}
+
+function namesFromPeople(people: Array<{ name?: string }> | undefined): string | undefined {
+  const names = (people ?? [])
+    .map((person) => person.name?.trim())
+    .filter(Boolean)
+    .join(", ");
+  return names || undefined;
+}
+
+/**
+ * The audiobook library "hero": instead of a backdrop carousel (audiobooks
+ * have square covers and no backdrops), the featured continue-listening
+ * section renders as a resume deck for the most recent in-progress book —
+ * cover, chapter position, hours left, and a Resume button — followed by a
+ * row with the rest of the in-progress books.
+ */
+export default function NowListeningHero({ section, libraryId }: NowListeningHeroProps) {
+  const deck = section.items[0];
+  const rest = section.items.slice(1);
+  const { prefs: overlayPrefs } = useOverlayPrefs();
+  const audiobookPlayback = useAudiobookPlaybackController();
+  // The section payload has no chapters or credits; the item detail fills in
+  // author/narrator, chapter marks, and the files needed for one-click resume.
+  const { data: detail } = useCatalogItemDetail(deck?.content_id, libraryId);
+  useAmbientColor(deck?.poster_thumbhash);
+
+  const files = useMemo(
+    () => (detail?.type === "audiobook" ? audiobookFilesFromVersions(detail.versions) : []),
+    [detail],
+  );
+  const chapters = useMemo(() => buildChapterList(files), [files]);
+
+  if (!deck) return null;
+
+  const detailProgress =
+    detail?.user_data && "position_seconds" in detail.user_data ? detail.user_data : undefined;
+  const isActive = audiobookPlayback?.active?.contentId === deck.content_id;
+  const isActivePlaying = isActive && Boolean(audiobookPlayback?.active?.playing);
+  const livePosition = isActive ? (audiobookPlayback?.active?.currentTime ?? null) : null;
+  const positionSeconds =
+    livePosition ?? detailProgress?.position_seconds ?? deck.position_seconds ?? 0;
+  const durationSeconds =
+    detail?.audiobook?.total_duration_seconds ||
+    totalAudiobookDuration(files) ||
+    deck.duration_seconds ||
+    0;
+
+  const author = namesFromPeople(detail?.audiobook?.authors);
+  const narrator = namesFromPeople(detail?.audiobook?.narrators);
+  const chapter = chapters.length > 0 ? findChapterAt(chapters, positionSeconds) : null;
+  const progressPercent =
+    durationSeconds > 0 ? Math.min((positionSeconds / durationSeconds) * 100, 100) : 0;
+  const timeLeft = formatListeningTimeLeft(positionSeconds, durationSeconds);
+  const chapterLine = chapter
+    ? `Chapter ${chapter.index} of ${chapters.length}` +
+      (chapter.label && chapter.label !== `Chapter ${chapter.index}` ? ` · ${chapter.label}` : "")
+    : durationSeconds > 0
+      ? formatHoursMinutes(durationSeconds)
+      : "";
+
+  const playHref = buildMediaPlayHref({
+    contentId: deck.content_id,
+    type: deck.type,
+    libraryId,
+  });
+  const itemHref = buildItemHref({ contentId: deck.content_id, libraryId });
+  const thumbhashUrl = deck.poster_thumbhash ? decodeThumbhash(deck.poster_thumbhash) : "";
+
+  const handleResumeClick = (event: MouseEvent<HTMLAnchorElement>) => {
+    if (isActive) {
+      event.preventDefault();
+      audiobookPlayback?.toggleActivePlayback();
+      return;
+    }
+    if (files.length > 0 && audiobookPlayback) {
+      event.preventDefault();
+      audiobookPlayback.startPlayback({
+        contentId: deck.content_id,
+        title: deck.title,
+        author,
+        narrator,
+        posterUrl: deck.poster_url,
+        files,
+        initialPositionSeconds: positionSeconds > 0 ? positionSeconds : 0,
+      });
+    }
+    // Without files yet (detail still loading), fall through to the detail
+    // page link, which auto-starts playback via ?play=1.
+  };
+
+  const resumeLabel = isActivePlaying ? "Pause" : positionSeconds > 0 ? "Resume" : "Listen";
+
+  return (
+    <>
+      <section
+        className="relative -mt-[96px] w-full overflow-hidden sm:-mt-[104px]"
+        aria-label="Now listening"
+      >
+        {/* The book's own cover, blurred, stands in for a backdrop and warms
+            the section with the cover's palette alongside the ambient glow. */}
+        <div
+          className="absolute inset-0"
+          style={
+            thumbhashUrl
+              ? { backgroundImage: `url(${thumbhashUrl})`, backgroundSize: "cover" }
+              : undefined
+          }
+        >
+          {deck.poster_url && (
+            <img
+              src={deck.poster_url}
+              alt=""
+              aria-hidden="true"
+              className="h-full w-full scale-110 object-cover blur-3xl brightness-[0.45] saturate-[1.15]"
+            />
+          )}
+        </div>
+        <div className="hero-top-scrim" />
+        <div className="hero-gradient-strong" />
+        <div className="ambient-glow" />
+
+        <div className="relative z-10 px-4 pt-28 pb-10 sm:px-6 sm:pt-32 sm:pb-12 lg:px-10 xl:px-12">
+          <div className="flex max-w-[1380px] flex-col gap-6 sm:flex-row sm:items-center sm:gap-10">
+            <Link
+              to={itemHref}
+              className="block w-36 shrink-0 self-start sm:w-48 sm:self-center lg:w-56"
+            >
+              <div
+                className="bg-muted aspect-square overflow-hidden rounded-2xl shadow-2xl"
+                style={
+                  thumbhashUrl
+                    ? { backgroundImage: `url(${thumbhashUrl})`, backgroundSize: "cover" }
+                    : undefined
+                }
+              >
+                {deck.poster_url && (
+                  <img
+                    src={deck.poster_url}
+                    alt={deck.title}
+                    className="h-full w-full object-cover"
+                  />
+                )}
+              </div>
+            </Link>
+
+            <div className="min-w-0 flex-1">
+              <p className="hero-eyebrow mb-3">
+                <span className="hero-eyebrow-strong">Now Listening</span>
+              </p>
+              <h1
+                className="font-display max-w-3xl text-3xl font-extrabold tracking-[-0.03em] text-balance sm:text-4xl lg:text-5xl"
+                style={{ textShadow: "var(--hero-text-shadow, none)" }}
+              >
+                {deck.title}
+              </h1>
+              {(author || narrator) && (
+                <p className="text-foreground/70 mt-2 max-w-2xl truncate text-sm sm:text-base">
+                  {author}
+                  {author && narrator ? " · " : ""}
+                  {narrator && `Narrated by ${narrator}`}
+                </p>
+              )}
+
+              <div className="mt-6 max-w-xl">
+                <div className="h-1.5 w-full overflow-hidden rounded-full bg-white/15">
+                  <div
+                    className="bg-primary h-full rounded-full transition-[width] duration-[--duration-normal]"
+                    style={{ width: `${progressPercent}%` }}
+                  />
+                </div>
+                <div className="mt-2 flex items-baseline justify-between gap-3 text-xs sm:text-sm">
+                  <span className="text-foreground/60 truncate">{chapterLine}</span>
+                  {timeLeft && <span className="text-foreground/85 shrink-0">{timeLeft}</span>}
+                </div>
+              </div>
+
+              <div className="mt-6 flex flex-wrap items-center gap-3">
+                <Link
+                  to={playHref}
+                  onClick={handleResumeClick}
+                  className="pill pill-primary transition-colors duration-[--duration-fast]"
+                >
+                  {isActivePlaying ? (
+                    <Pause className="h-4 w-4 fill-current" />
+                  ) : (
+                    <Play className="h-4 w-4 fill-current" />
+                  )}
+                  {resumeLabel}
+                </Link>
+                <Link
+                  to={itemHref}
+                  className="pill pill-glass transition-colors duration-[--duration-fast]"
+                >
+                  <Info className="h-4 w-4" />
+                  More Info
+                </Link>
+              </div>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      {rest.length > 0 && (
+        <MediaCarousel title={section.title}>
+          {rest.map((item) => (
+            <ContinueWatchingCard
+              key={item.content_id}
+              sectionItem={item}
+              libraryId={libraryId}
+              overlayPrefs={overlayPrefs}
+              variant="poster"
+            />
+          ))}
+        </MediaCarousel>
+      )}
+    </>
+  );
+}

--- a/web/src/components/NowListeningHero.tsx
+++ b/web/src/components/NowListeningHero.tsx
@@ -42,11 +42,19 @@ export default function NowListeningHero({ section, libraryId }: NowListeningHer
   const audiobookPlayback = useAudiobookPlaybackController();
   // The section payload has no chapters or credits; the item detail fills in
   // author/narrator, chapter marks, and the files needed for one-click resume.
-  const { data: detail } = useCatalogItemDetail(deck?.content_id, libraryId);
+  const { data: fetchedDetail } = useCatalogItemDetail(deck?.content_id, libraryId);
   useAmbientColor(deck?.poster_thumbhash);
 
+  // The detail query keeps previous data while a new deck item loads, so a
+  // Resume click in that window could start the new book with the previous
+  // book's files. Only trust a detail payload that matches the deck item.
+  const detail =
+    fetchedDetail?.type === "audiobook" && fetchedDetail.content_id === deck?.content_id
+      ? fetchedDetail
+      : undefined;
+
   const files = useMemo(
-    () => (detail?.type === "audiobook" ? audiobookFilesFromVersions(detail.versions) : []),
+    () => (detail ? audiobookFilesFromVersions(detail.versions) : []),
     [detail],
   );
   const chapters = useMemo(() => buildChapterList(files), [files]);

--- a/web/src/components/SectionItemCard.tsx
+++ b/web/src/components/SectionItemCard.tsx
@@ -122,6 +122,12 @@ export default function SectionItemCard({ item, libraryId }: SectionItemCardProp
               {episodeLabels.episodeCode}
             </div>
           </>
+        ) : item.item_source === "next_in_series" && item.series_title ? (
+          <div className="text-muted-foreground mt-1 truncate text-[11px] font-medium tracking-[0.14em] uppercase">
+            {[item.badges?.find((badge) => badge.startsWith("Book ")), item.series_title]
+              .filter(Boolean)
+              .join(" · ")}
+          </div>
         ) : (
           <div className="text-muted-foreground mt-1 text-[11px] font-medium tracking-[0.14em] uppercase">
             {item.year ? `${item.year}` : ""} {item.type === "series" ? "Series" : ""}

--- a/web/src/components/SectionRow.tsx
+++ b/web/src/components/SectionRow.tsx
@@ -84,13 +84,14 @@ export default function SectionRow({ section, libraryId }: SectionRowProps) {
     >
       {section.section_type === "continue_watching" || section.section_type === "next_up"
         ? (() => {
-            // Continue Watching with only movies looks better as vertical posters.
-            // Mixed content or episodes (incl. Next Up) keep the wide variant so episode
-            // stills are shown with their natural 16:9 framing.
+            // Continue Watching with only movies and/or audiobooks looks better
+            // as upright covers (audiobook covers render square within the
+            // poster variant). Episodes (incl. Next Up) keep the wide variant
+            // so stills are shown with their natural 16:9 framing.
             const cardVariant: "wide" | "poster" =
               section.section_type === "continue_watching" &&
               section.items.length > 0 &&
-              section.items.every((it) => it.type === "movie")
+              section.items.every((it) => it.type === "movie" || it.type === "audiobook")
                 ? "poster"
                 : "wide";
             return section.items.map((item) => (

--- a/web/src/components/audiobooks/AudiobookGroupsView.tsx
+++ b/web/src/components/audiobooks/AudiobookGroupsView.tsx
@@ -1,0 +1,232 @@
+import { useMemo, useState } from "react";
+import { ChevronRight } from "lucide-react";
+import type { AudiobookGroup } from "@/api/types";
+import { Input } from "@/components/ui/input";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import { Skeleton } from "@/components/ui/skeleton";
+import {
+  useAudiobookGroups,
+  type AudiobookGroupBy,
+  type AudiobookGroupSort,
+} from "@/hooks/queries/audiobookGroups";
+import { formatHoursMinutes } from "@/lib/audiobooks/duration";
+
+interface AudiobookGroupsViewProps {
+  libraryId: number;
+  groupBy: AudiobookGroupBy;
+  /** Called with the group name; the parent applies it as a Books filter. */
+  onSelectGroup: (name: string) => void;
+}
+
+const GROUP_NOUN: Record<AudiobookGroupBy, string> = {
+  author: "authors",
+  narrator: "narrators",
+  series: "series",
+};
+
+function groupStats(group: AudiobookGroup): string {
+  const parts = [
+    `${group.item_count} ${group.item_count === 1 ? "book" : "books"}`,
+    formatHoursMinutes(group.total_duration_seconds),
+  ];
+  if (group.in_progress_count > 0) {
+    parts.push(`${group.in_progress_count} in progress`);
+  } else if (group.finished_count > 0 && group.finished_count === group.item_count) {
+    parts.push("all finished");
+  } else if (group.finished_count > 0) {
+    parts.push(`${group.finished_count} finished`);
+  }
+  return parts.join(" · ");
+}
+
+function groupInitials(name: string): string {
+  return name
+    .split(/\s+/)
+    .filter(Boolean)
+    .slice(0, 2)
+    .map((part) => part[0]?.toUpperCase() ?? "")
+    .join("");
+}
+
+/** Up to three overlapping square covers; falls back to an initials tile. */
+function CoverStack({ group, large }: { group: AudiobookGroup; large?: boolean }) {
+  const posters = group.poster_urls.slice(0, 3);
+  if (posters.length === 0) {
+    return (
+      <div
+        className={`bg-surface-raised text-muted-foreground flex shrink-0 items-center justify-center font-semibold ${
+          large ? "aspect-square w-full rounded-xl text-2xl" : "h-14 w-14 rounded-lg text-sm"
+        }`}
+      >
+        {groupInitials(group.name)}
+      </div>
+    );
+  }
+
+  if (!large) {
+    return (
+      <div className="flex shrink-0 -space-x-7">
+        {posters.map((url, i) => (
+          <img
+            key={url}
+            src={url}
+            alt=""
+            loading="lazy"
+            className="border-background h-14 w-14 rounded-lg border object-cover shadow-md"
+            style={{ zIndex: posters.length - i }}
+          />
+        ))}
+      </div>
+    );
+  }
+
+  return (
+    <div className="relative aspect-square w-full">
+      {posters
+        .slice()
+        .reverse()
+        .map((url, i) => {
+          // Render back-to-front; the first poster ends up on top, upright.
+          const depth = posters.length - 1 - i;
+          return (
+            <img
+              key={url}
+              src={url}
+              alt=""
+              loading="lazy"
+              className="absolute inset-0 h-full w-full rounded-xl object-cover shadow-lg transition-transform duration-[--duration-fast]"
+              style={{
+                transform:
+                  depth === 0 ? undefined : `rotate(${depth * 3}deg) translateX(${depth * 4}px)`,
+              }}
+            />
+          );
+        })}
+    </div>
+  );
+}
+
+/**
+ * Grouped Library-tab browse for audiobook libraries: Authors and Narrators
+ * render as rows with cover stacks and listening stats; Series render as a
+ * card grid. Selecting a group drops back into the Books grid filtered to it.
+ */
+export default function AudiobookGroupsView({
+  libraryId,
+  groupBy,
+  onSelectGroup,
+}: AudiobookGroupsViewProps) {
+  // Authors/narrators default to most-books-first (collection heavy hitters);
+  // series read more naturally alphabetized.
+  const [sort, setSort] = useState<AudiobookGroupSort>(groupBy === "series" ? "name" : "count");
+  const [filter, setFilter] = useState("");
+  const { data, isLoading } = useAudiobookGroups(libraryId, groupBy, sort);
+
+  const groups = useMemo(() => {
+    const all = data?.groups ?? [];
+    const needle = filter.trim().toLowerCase();
+    if (!needle) return all;
+    return all.filter((group) => group.name.toLowerCase().includes(needle));
+  }, [data?.groups, filter]);
+
+  const noun = GROUP_NOUN[groupBy];
+  const isSeries = groupBy === "series";
+
+  return (
+    <div className="space-y-5">
+      <div className="flex flex-wrap items-center gap-3">
+        <Input
+          value={filter}
+          onChange={(event) => setFilter(event.target.value)}
+          placeholder={`Filter ${noun}…`}
+          className="w-full max-w-xs"
+        />
+        <Select value={sort} onValueChange={(value) => setSort(value as AudiobookGroupSort)}>
+          <SelectTrigger className="w-[160px]">
+            <SelectValue />
+          </SelectTrigger>
+          <SelectContent>
+            <SelectItem value="name">Name</SelectItem>
+            <SelectItem value="count">Most books</SelectItem>
+            <SelectItem value="duration">Longest</SelectItem>
+          </SelectContent>
+        </Select>
+        {data && (
+          <span className="text-muted-foreground ml-auto text-sm">
+            {groups.length === data.total ? data.total : `${groups.length} of ${data.total}`} {noun}
+          </span>
+        )}
+      </div>
+
+      {isLoading ? (
+        isSeries ? (
+          <div className="grid grid-cols-2 gap-4 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-5 xl:grid-cols-6">
+            {Array.from({ length: 12 }).map((_, i) => (
+              <div key={i}>
+                <Skeleton className="aspect-square w-full rounded-xl" />
+                <Skeleton className="mt-2 h-4 w-3/4 rounded" />
+              </div>
+            ))}
+          </div>
+        ) : (
+          <div className="grid grid-cols-1 gap-3 md:grid-cols-2 xl:grid-cols-3">
+            {Array.from({ length: 9 }).map((_, i) => (
+              <Skeleton key={i} className="h-20 rounded-xl" />
+            ))}
+          </div>
+        )
+      ) : groups.length === 0 ? (
+        <p className="text-muted-foreground py-10 text-center text-sm">
+          {filter ? `No ${noun} match “${filter}”.` : `No ${noun} found in this library.`}
+        </p>
+      ) : isSeries ? (
+        <div className="grid grid-cols-2 gap-4 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-5 xl:grid-cols-6">
+          {groups.map((group) => (
+            <button
+              key={group.name}
+              type="button"
+              onClick={() => onSelectGroup(group.name)}
+              className="group/series text-left"
+            >
+              <div className="transition-transform duration-[--duration-fast] group-hover/series:scale-[1.02]">
+                <CoverStack group={group} large />
+              </div>
+              <div className="mt-2.5 truncate px-0.5 text-[14px] font-semibold tracking-tight">
+                {group.name}
+              </div>
+              <div className="text-muted-foreground truncate px-0.5 text-xs">
+                {groupStats(group)}
+              </div>
+            </button>
+          ))}
+        </div>
+      ) : (
+        <div className="grid grid-cols-1 gap-3 md:grid-cols-2 xl:grid-cols-3">
+          {groups.map((group) => (
+            <button
+              key={group.name}
+              type="button"
+              onClick={() => onSelectGroup(group.name)}
+              className="surface-panel hover:bg-muted/40 flex items-center gap-4 rounded-xl border-0 px-4 py-3 text-left transition-colors duration-[--duration-fast]"
+            >
+              <CoverStack group={group} />
+              <div className="min-w-0 flex-1">
+                <div className="truncate text-sm font-semibold">{group.name}</div>
+                <div className="text-muted-foreground mt-0.5 truncate text-xs">
+                  {groupStats(group)}
+                </div>
+              </div>
+              <ChevronRight className="text-muted-foreground/50 h-4 w-4 shrink-0" />
+            </button>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/web/src/hooks/queries/audiobookGroups.ts
+++ b/web/src/hooks/queries/audiobookGroups.ts
@@ -1,0 +1,39 @@
+import { keepPreviousData, useQuery } from "@tanstack/react-query";
+
+import { api } from "@/api/client";
+import type { AudiobookGroupsResponse } from "@/api/types";
+import { catalogKeys } from "./keys";
+
+export type AudiobookGroupBy = "author" | "narrator" | "series";
+export type AudiobookGroupSort = "name" | "count" | "duration";
+
+const GROUPS_FETCH_LIMIT = 500;
+
+export async function fetchAudiobookGroups(
+  libraryId: number,
+  groupBy: AudiobookGroupBy,
+  sort: AudiobookGroupSort,
+  options?: RequestInit,
+): Promise<AudiobookGroupsResponse> {
+  const params = new URLSearchParams({
+    library_id: String(libraryId),
+    group_by: groupBy,
+    sort,
+    limit: String(GROUPS_FETCH_LIMIT),
+  });
+  return api<AudiobookGroupsResponse>(`/catalog/audiobook-groups?${params.toString()}`, options);
+}
+
+export function useAudiobookGroups(
+  libraryId: number,
+  groupBy: AudiobookGroupBy,
+  sort: AudiobookGroupSort,
+) {
+  return useQuery({
+    queryKey: catalogKeys.audiobookGroups(libraryId, groupBy, sort),
+    queryFn: () => fetchAudiobookGroups(libraryId, groupBy, sort),
+    enabled: libraryId > 0,
+    staleTime: 60_000,
+    placeholderData: keepPreviousData,
+  });
+}

--- a/web/src/hooks/queries/audiobookGroups.ts
+++ b/web/src/hooks/queries/audiobookGroups.ts
@@ -7,7 +7,11 @@ import { catalogKeys } from "./keys";
 export type AudiobookGroupBy = "author" | "narrator" | "series";
 export type AudiobookGroupSort = "name" | "count" | "duration";
 
-const GROUPS_FETCH_LIMIT = 500;
+// The server caps a single page at 500 groups; page until the reported total
+// is reached so client-side filtering sees the complete list. The page cap
+// bounds the worst case (pathological libraries) at 20 requests / 10k groups.
+const GROUPS_PAGE_SIZE = 500;
+const GROUPS_MAX_PAGES = 20;
 
 export async function fetchAudiobookGroups(
   libraryId: number,
@@ -15,13 +19,29 @@ export async function fetchAudiobookGroups(
   sort: AudiobookGroupSort,
   options?: RequestInit,
 ): Promise<AudiobookGroupsResponse> {
-  const params = new URLSearchParams({
-    library_id: String(libraryId),
-    group_by: groupBy,
-    sort,
-    limit: String(GROUPS_FETCH_LIMIT),
-  });
-  return api<AudiobookGroupsResponse>(`/catalog/audiobook-groups?${params.toString()}`, options);
+  const groups: AudiobookGroupsResponse["groups"] = [];
+  let total = 0;
+
+  for (let page = 0; page < GROUPS_MAX_PAGES; page++) {
+    const params = new URLSearchParams({
+      library_id: String(libraryId),
+      group_by: groupBy,
+      sort,
+      limit: String(GROUPS_PAGE_SIZE),
+      offset: String(page * GROUPS_PAGE_SIZE),
+    });
+    const response = await api<AudiobookGroupsResponse>(
+      `/catalog/audiobook-groups?${params.toString()}`,
+      options,
+    );
+    groups.push(...response.groups);
+    total = response.total;
+    if (response.groups.length === 0 || groups.length >= total) {
+      break;
+    }
+  }
+
+  return { total, groups };
 }
 
 export function useAudiobookGroups(

--- a/web/src/hooks/queries/catalog.ts
+++ b/web/src/hooks/queries/catalog.ts
@@ -131,10 +131,16 @@ export function createCatalogSearchState(
 
 export function useCatalogWindow(
   state: CatalogSearchState,
-  options: { limit?: number; visibleRange?: [number, number]; includeTotal?: boolean } = {},
+  options: {
+    limit?: number;
+    visibleRange?: [number, number];
+    includeTotal?: boolean;
+    enabled?: boolean;
+  } = {},
 ) {
   const limit = options.limit ?? 60;
   const includeTotal = options.includeTotal ?? true;
+  const enabled = options.enabled ?? true;
   const page0Params = catalogParamsForKey(state, limit, includeTotal);
   const remainingPageParams = catalogParamsForKey(state, limit, false);
   const visibleRange = options.visibleRange ?? [0, limit - 1];
@@ -150,10 +156,11 @@ export function useCatalogWindow(
     queryFn: ({ signal }: { signal: AbortSignal }) =>
       fetchCatalogPage(state, limit, 0, { signal }, includeTotal),
     staleTime: 10 * 60 * 1000,
+    enabled,
   });
 
   const snapshot = page0Result.data?.snapshot;
-  const canFetchRemainingPages = page0Result.data !== undefined;
+  const canFetchRemainingPages = enabled && page0Result.data !== undefined;
 
   const remainingPageIndices = useMemo(() => {
     const indices = new Set<number>();

--- a/web/src/hooks/queries/keys.ts
+++ b/web/src/hooks/queries/keys.ts
@@ -63,6 +63,8 @@ export const catalogKeys = {
   itemDetail: (id: string, libraryId?: number) =>
     ["catalog", "items", id, "detail", libraryId ?? "default"] as const,
   itemVersions: (id: string) => ["catalog", "items", id, "versions"] as const,
+  audiobookGroups: (libraryId: number, groupBy: string, sort: string) =>
+    ["catalog", "audiobookGroups", libraryId, groupBy, sort] as const,
   itemEpisodes: (id: string, libraryId?: number) =>
     ["catalog", "items", id, "episodes", libraryId ?? "default"] as const,
   seriesSeasons: (seriesId: string, libraryId?: number) =>

--- a/web/src/lib/audiobooks/chapters.ts
+++ b/web/src/lib/audiobooks/chapters.ts
@@ -1,0 +1,48 @@
+import type { AudiobookChapter, AudiobookFile } from "@/lib/audiobooks/types";
+
+export interface ChapterListEntry {
+  chapter: AudiobookChapter;
+  absoluteStart: number;
+  fileId: number;
+  label: string;
+}
+
+/**
+ * Flattens the per-file chapter lists of a multi-file audiobook into a single
+ * list with absolute start offsets across the whole book.
+ */
+export function buildChapterList(files: AudiobookFile[]): ChapterListEntry[] {
+  const result: ChapterListEntry[] = [];
+  let offset = 0;
+  for (const file of files) {
+    for (const chapter of file.chapters ?? []) {
+      result.push({
+        chapter,
+        absoluteStart: offset + chapter.start_seconds,
+        fileId: file.id,
+        label: chapter.title || `Chapter ${chapter.index + 1}`,
+      });
+    }
+    offset += file.duration_seconds ?? 0;
+  }
+  return result;
+}
+
+/** Returns the chapter containing the given absolute position, 1-indexed. */
+export function findChapterAt(
+  chapters: ChapterListEntry[],
+  seconds: number,
+): { label: string; index: number } | null {
+  for (let i = chapters.length - 1; i >= 0; i--) {
+    const chapter = chapters[i];
+    if (chapter && seconds >= chapter.absoluteStart) {
+      return { label: chapter.label, index: i + 1 };
+    }
+  }
+  return chapters[0] ? { label: chapters[0].label, index: 1 } : null;
+}
+
+/** Total duration of a multi-file audiobook in seconds. */
+export function totalAudiobookDuration(files: AudiobookFile[]): number {
+  return files.reduce((acc, file) => acc + (file.duration_seconds ?? 0), 0);
+}

--- a/web/src/lib/audiobooks/duration.ts
+++ b/web/src/lib/audiobooks/duration.ts
@@ -1,0 +1,37 @@
+/**
+ * Listening-time formatting for audiobooks. Audiobooks are hours long, so time
+ * is framed in "hr/min" units ("27 hr 14 min") rather than the "52:30" or
+ * "112 min" framings used for video runtimes.
+ */
+
+/** "27 hr 14 min", "3 hr", "45 min"; durations under a minute round up. */
+export function formatHoursMinutes(totalSeconds: number): string {
+  if (!Number.isFinite(totalSeconds) || totalSeconds <= 0) {
+    return "0 min";
+  }
+  const totalMinutes = Math.round(totalSeconds / 60);
+  if (totalMinutes < 1) {
+    return "1 min";
+  }
+  const hours = Math.floor(totalMinutes / 60);
+  const minutes = totalMinutes % 60;
+  if (hours <= 0) {
+    return `${minutes} min`;
+  }
+  if (minutes === 0) {
+    return `${hours} hr`;
+  }
+  return `${hours} hr ${minutes} min`;
+}
+
+/** "27 hr 14 min left" for an in-progress listen; null without a duration. */
+export function formatListeningTimeLeft(
+  positionSeconds: number | undefined,
+  durationSeconds: number | undefined,
+): string | null {
+  if (!durationSeconds || durationSeconds <= 0) {
+    return null;
+  }
+  const remaining = Math.max(durationSeconds - (positionSeconds ?? 0), 0);
+  return `${formatHoursMinutes(remaining)} left`;
+}

--- a/web/src/lib/audiobooks/files.ts
+++ b/web/src/lib/audiobooks/files.ts
@@ -1,0 +1,12 @@
+import type { ItemDetail } from "@/api/types";
+import type { AudiobookFile } from "@/lib/audiobooks/types";
+
+/** Maps an item detail's file versions to playable audiobook files. */
+export function audiobookFilesFromVersions(versions: ItemDetail["versions"]): AudiobookFile[] {
+  return (versions ?? []).map((version) => ({
+    id: version.file_id,
+    path: version.file_path ?? version.file_name ?? "",
+    duration_seconds: version.duration ?? 0,
+    chapters: version.chapters ?? [],
+  }));
+}

--- a/web/src/lib/sectionTypes.ts
+++ b/web/src/lib/sectionTypes.ts
@@ -10,6 +10,7 @@ export const SECTION_TYPES = [
   { value: "similar_users_liked", label: "Profiles Like You Enjoyed" },
   { value: "taste_match", label: "Top Picks Today" },
   { value: "next_up", label: "On Deck" },
+  { value: "next_in_series", label: "Next in Series" },
   { value: "watchlist", label: "Watchlist" },
   { value: "favorites", label: "Favorites" },
   { value: "collection", label: "Collection" },

--- a/web/src/pages/ItemDetail/AudiobookContent.tsx
+++ b/web/src/pages/ItemDetail/AudiobookContent.tsx
@@ -10,7 +10,9 @@ import { NarratorPicker } from "@/pages/audiobooks/components/NarratorPicker";
 import { RelatedRail } from "@/pages/audiobooks/components/RelatedRail";
 import DetailHero from "@/pages/ItemDetail/DetailHero";
 import MetadataBadges from "@/pages/ItemDetail/components/MetadataBadges";
-import type { AudiobookChapter, AudiobookFile } from "@/lib/audiobooks/types";
+import type { AudiobookFile } from "@/lib/audiobooks/types";
+import { buildChapterList, findChapterAt, totalAudiobookDuration } from "@/lib/audiobooks/chapters";
+import { audiobookFilesFromVersions } from "@/lib/audiobooks/files";
 import { useAudiobookPlaybackController } from "@/pages/audiobooks/player/audiobookPlaybackContext";
 
 function formatSeconds(totalSeconds: number): string {
@@ -25,50 +27,6 @@ function formatSeconds(totalSeconds: number): string {
     return `${m}m ${String(s).padStart(2, "0")}s`;
   }
   return `${s}s`;
-}
-
-function totalDuration(files: AudiobookFile[]): number {
-  return files.reduce((acc, file) => acc + (file.duration_seconds ?? 0), 0);
-}
-
-function findChapterAt(
-  chapters: ReturnType<typeof buildChapterList>,
-  seconds: number,
-): { label: string; index: number } | null {
-  for (let i = chapters.length - 1; i >= 0; i--) {
-    const chapter = chapters[i];
-    if (chapter && seconds >= chapter.absoluteStart) {
-      return { label: chapter.label, index: i + 1 };
-    }
-  }
-  return chapters[0] ? { label: chapters[0].label, index: 1 } : null;
-}
-
-function buildChapterList(files: AudiobookFile[]): Array<{
-  chapter: AudiobookChapter;
-  absoluteStart: number;
-  fileId: number;
-  label: string;
-}> {
-  const result: Array<{
-    chapter: AudiobookChapter;
-    absoluteStart: number;
-    fileId: number;
-    label: string;
-  }> = [];
-  let offset = 0;
-  for (const file of files) {
-    for (const chapter of file.chapters ?? []) {
-      result.push({
-        chapter,
-        absoluteStart: offset + chapter.start_seconds,
-        fileId: file.id,
-        label: chapter.title || `Chapter ${chapter.index + 1}`,
-      });
-    }
-    offset += file.duration_seconds ?? 0;
-  }
-  return result;
 }
 
 function leafUserData(userData: ItemDetail["user_data"]): LeafItemUserData | undefined {
@@ -116,13 +74,7 @@ export default function AudiobookContent({
   const audiobookPlayback = useAudiobookPlaybackController();
 
   const files = useMemo<AudiobookFile[]>(
-    () =>
-      (item.versions ?? []).map((version) => ({
-        id: version.file_id,
-        path: version.file_path ?? version.file_name ?? "",
-        duration_seconds: version.duration ?? 0,
-        chapters: version.chapters ?? [],
-      })),
+    () => audiobookFilesFromVersions(item.versions),
     [item.versions],
   );
 
@@ -133,7 +85,9 @@ export default function AudiobookContent({
   const progress = leafUserData(item.user_data);
   const resumeSeconds = progress?.position_seconds ?? 0;
   const durationTotal =
-    item.audiobook?.total_duration_seconds || progress?.duration_seconds || totalDuration(files);
+    item.audiobook?.total_duration_seconds ||
+    progress?.duration_seconds ||
+    totalAudiobookDuration(files);
   const hasProgress = Boolean(
     progress &&
     resumeSeconds > 0 &&

--- a/web/src/pages/LibraryBrowse.test.tsx
+++ b/web/src/pages/LibraryBrowse.test.tsx
@@ -188,7 +188,7 @@ describe("LibraryBrowse", () => {
       <LibraryBrowse
         libraryId={10}
         libraryType="audiobooks"
-        browseType="series"
+        browseType="books"
         queryDefinition={{
           library_ids: [],
           match: "all",

--- a/web/src/pages/LibraryBrowse.tsx
+++ b/web/src/pages/LibraryBrowse.tsx
@@ -1,10 +1,13 @@
 import { useCallback, useEffect, useRef, useState } from "react";
 
 import { normalizeQueryDefinition, type QueryDefinition } from "@/api/types";
+import AudiobookGroupsView from "@/components/audiobooks/AudiobookGroupsView";
 import CatalogFiltersPanel from "@/components/catalog/CatalogFiltersPanel";
 import ItemGrid from "@/components/ItemGrid";
 import ScrollToTopButton from "@/components/ScrollToTopButton";
 import { useCatalogWindow } from "@/hooks/queries/catalog";
+import type { AudiobookGroupBy } from "@/hooks/queries/audiobookGroups";
+import { cn } from "@/lib/utils";
 import { normalizeQuerySortForScope, type QuerySortRelevanceScope } from "@/lib/querySortOptions";
 import type { CatalogSearchState } from "@/pages/catalogSearchParams";
 import {
@@ -14,15 +17,84 @@ import {
   SelectTrigger,
   SelectValue,
 } from "@/components/ui/select";
-import type { LibraryBrowseType } from "./libraryPageSearchParams";
+import {
+  AUDIOBOOK_BROWSE_AXES,
+  audiobookBrowseAxisFromBrowseType,
+  isAudiobookLibraryType,
+  type AudiobookBrowseAxis,
+  type LibraryBrowseType,
+} from "./libraryPageSearchParams";
 
 interface LibraryBrowseProps {
   libraryId: number;
   libraryType: string;
   browseType: LibraryBrowseType;
   queryDefinition: QueryDefinition;
-  onBrowseTypeChange: (browseType: LibraryBrowseType) => void;
+  onBrowseTypeChange: (
+    browseType: LibraryBrowseType,
+    nextQueryDefinition?: QueryDefinition,
+  ) => void;
   onQueryDefinitionChange: (queryDefinition: QueryDefinition) => void;
+}
+
+const AXIS_LABELS: Record<AudiobookBrowseAxis, string> = {
+  books: "Books",
+  series: "Series",
+  authors: "Authors",
+  narrators: "Narrators",
+};
+
+const AXIS_GROUP_BY: Record<Exclude<AudiobookBrowseAxis, "books">, AudiobookGroupBy> = {
+  series: "series",
+  authors: "author",
+  narrators: "narrator",
+};
+
+const AXIS_FILTER_FIELD: Record<Exclude<AudiobookBrowseAxis, "books">, string> = {
+  series: "series",
+  authors: "author",
+  narrators: "narrator",
+};
+
+function AudiobookAxisTabs({
+  value,
+  onChange,
+}: {
+  value: AudiobookBrowseAxis;
+  onChange: (axis: AudiobookBrowseAxis) => void;
+}) {
+  return (
+    <div
+      role="radiogroup"
+      aria-label="Browse audiobooks by"
+      className="surface-panel inline-flex items-center gap-1 rounded-full p-1"
+    >
+      {AUDIOBOOK_BROWSE_AXES.map((axis) => {
+        const isActive = axis === value;
+        return (
+          <button
+            key={axis}
+            type="button"
+            role="radio"
+            aria-checked={isActive}
+            onClick={() => {
+              if (!isActive) {
+                onChange(axis);
+              }
+            }}
+            className={cn(
+              "rounded-full px-4 py-1.5 text-sm font-medium transition-colors",
+              isActive
+                ? "bg-primary text-primary-foreground"
+                : "text-muted-foreground hover:text-foreground",
+            )}
+          >
+            {AXIS_LABELS[axis]}
+          </button>
+        );
+      })}
+    </div>
+  );
 }
 
 function getLibrarySortRelevanceScope(
@@ -46,10 +118,6 @@ function getLibrarySortRelevanceScope(
     return mediaScope;
   }
   return "all";
-}
-
-function isAudiobookLibraryType(libraryType: string): boolean {
-  return libraryType === "audiobook" || libraryType === "audiobooks";
 }
 
 export default function LibraryBrowse({
@@ -109,6 +177,11 @@ export default function LibraryBrowse({
 
   useEffect(() => () => clearTimeout(debounceRef.current), []);
 
+  const audiobookAxis = isAudiobookLibraryType(libraryType)
+    ? audiobookBrowseAxisFromBrowseType(browseType)
+    : null;
+  const isGroupedAxis = audiobookAxis != null && audiobookAxis !== "books";
+
   const state: CatalogSearchState = {
     source: "query",
     library_id: libraryId,
@@ -120,10 +193,41 @@ export default function LibraryBrowse({
     limit,
     includeTotal: false,
     visibleRange,
+    enabled: !isGroupedAxis,
   });
   const totalItems = catalogQuery.data?.totalItems ?? 0;
   const pages = catalogQuery.data?.pages ?? new Map();
   const isLoading = catalogQuery.isLoading;
+
+  if (isGroupedAxis) {
+    const groupedAxis = audiobookAxis as Exclude<AudiobookBrowseAxis, "books">;
+    return (
+      <div className="space-y-5 py-2 sm:space-y-6">
+        <AudiobookAxisTabs value={groupedAxis} onChange={(axis) => onBrowseTypeChange(axis)} />
+        <AudiobookGroupsView
+          key={groupedAxis}
+          libraryId={libraryId}
+          groupBy={AXIS_GROUP_BY[groupedAxis]}
+          onSelectGroup={(name) =>
+            // Drop into the Books grid filtered to the selected group. The
+            // group name round-trips through the matching filter field, which
+            // the backend matches case-insensitively.
+            onBrowseTypeChange("books", {
+              ...queryDefinition,
+              library_ids: [],
+              groups: [
+                {
+                  match: "all",
+                  rules: [{ field: AXIS_FILTER_FIELD[groupedAxis], op: "is", value: name }],
+                },
+              ],
+            })
+          }
+        />
+        <ScrollToTopButton />
+      </div>
+    );
+  }
 
   return (
     <div className="space-y-5 py-2 sm:space-y-6">
@@ -144,6 +248,9 @@ export default function LibraryBrowse({
           </Select>
         </div>
       ) : null}
+      {audiobookAxis != null && (
+        <AudiobookAxisTabs value={audiobookAxis} onChange={(axis) => onBrowseTypeChange(axis)} />
+      )}
       <CatalogFiltersPanel
         state={state}
         onStateChange={(nextState) =>

--- a/web/src/pages/LibraryPage.tsx
+++ b/web/src/pages/LibraryPage.tsx
@@ -16,6 +16,7 @@ import {
   parseLibraryPageState,
   serializeLibraryPageSearchParams,
   updateLibraryPageSearchParams,
+  type LibraryBrowseType,
 } from "./libraryPageSearchParams";
 
 export default function LibraryPage() {
@@ -205,13 +206,16 @@ export default function LibraryPage() {
     setSearchParams(nextSearchParams);
   };
 
-  const handleBrowseTypeChange = (nextBrowseType: "series" | "episode") => {
+  const handleBrowseTypeChange = (
+    nextBrowseType: LibraryBrowseType,
+    nextQueryDefinition?: QueryDefinition,
+  ) => {
     const nextSearchParams = updateLibraryPageSearchParams(
       searchParams,
       {
         activeTab: "library",
         browseType: nextBrowseType,
-        queryDefinition,
+        queryDefinition: nextQueryDefinition ?? queryDefinition,
       },
       libraryType,
     );
@@ -254,9 +258,13 @@ export default function LibraryPage() {
   return (
     <div className="relative">
       <Tabs value={activeTab} onValueChange={handleTabChange}>
-        <LibraryHeader libraryName={library.name} overlay={useOverlay} />
+        <LibraryHeader libraryName={library.name} libraryType={libraryType} overlay={useOverlay} />
         <TabsContent value="recommended" className="mt-0">
-          <LibraryRecommended libraryId={id} onHeroStateChange={handleHeroStateChange} />
+          <LibraryRecommended
+            libraryId={id}
+            libraryType={libraryType}
+            onHeroStateChange={handleHeroStateChange}
+          />
         </TabsContent>
         <TabsContent value="library" className="mt-0">
           <div className="px-4 py-4 sm:px-6 sm:py-6 lg:px-10 xl:px-12">

--- a/web/src/pages/LibraryRecommended.tsx
+++ b/web/src/pages/LibraryRecommended.tsx
@@ -8,6 +8,7 @@ import MediaCarousel from "@/components/MediaCarousel";
 import ItemCard from "@/components/ItemCard";
 import { useOverlayPrefs } from "@/hooks/useOverlayPrefs";
 import HeroBanner from "@/components/HeroBanner";
+import NowListeningHero from "@/components/NowListeningHero";
 import SectionRow from "@/components/SectionRow";
 import { Skeleton } from "@/components/ui/skeleton";
 import { HERO_BANNER_SIZE_TALL } from "@/lib/design-system";
@@ -15,9 +16,12 @@ import { sectionKeys } from "@/hooks/queries/keys";
 import { planNextHomeSectionBatch } from "./homeSectionQueue";
 import { buildHomeSectionViewModel, type HomeSectionSlot } from "./homeSectionState";
 import { collectCachedHomeSections } from "./homeSectionCache";
+import { isAudiobookLibraryType } from "./libraryPageSearchParams";
 
 interface LibraryRecommendedProps {
   libraryId: number;
+  /** Library type ("movies", "series", "audiobooks", ...); drives the hero style. */
+  libraryType?: string;
   /**
    * Reports whether the page is currently rendering a hero banner (i.e. a
    * featured section resolved with items). Parent uses this to decide whether
@@ -31,6 +35,7 @@ const MAX_CONCURRENT_SECTION_REQUESTS = 4;
 
 export default function LibraryRecommended({
   libraryId,
+  libraryType = "",
   onHeroStateChange,
 }: LibraryRecommendedProps) {
   const queryClient = useQueryClient();
@@ -183,7 +188,7 @@ export default function LibraryRecommended({
 
   return (
     <div className="space-y-10 sm:space-y-12">
-      {renderHeroSlot(viewModel.hero, retrySection, libraryId)}
+      {renderHeroSlot(viewModel.hero, retrySection, libraryId, libraryType)}
       {viewModel.rows.map((slot) => {
         if (slot.state === "empty") {
           return null;
@@ -213,10 +218,17 @@ function renderHeroSlot(
   hero: HomeSectionSlot | null,
   retrySection: (sectionId: string) => void,
   libraryId: number,
+  libraryType: string,
 ) {
   if (!hero) return null;
 
   if (hero.state === "ready" && hero.section) {
+    // Audiobook libraries feature their continue-listening section, rendered
+    // as a resume deck — square covers have no backdrop to feed the cinematic
+    // carousel hero.
+    if (isAudiobookLibraryType(libraryType) && hero.section.section_type === "continue_watching") {
+      return <NowListeningHero section={hero.section} libraryId={libraryId} />;
+    }
     return (
       <HeroBanner
         items={hero.section.items}

--- a/web/src/pages/libraryPageSearchParams.test.ts
+++ b/web/src/pages/libraryPageSearchParams.test.ts
@@ -340,7 +340,7 @@ describe("updateLibraryPageSearchParams", () => {
       params("foo=bar"),
       {
         activeTab: "library",
-        browseType: "series",
+        browseType: "books",
         queryDefinition: {
           library_ids: [],
           media_scope: "audiobook",
@@ -358,6 +358,36 @@ describe("updateLibraryPageSearchParams", () => {
       sort: "author",
       order: "asc",
     });
+  });
+
+  it("round-trips audiobook browse axes through the type param", () => {
+    for (const axis of ["series", "authors", "narrators"] as const) {
+      const next = updateLibraryPageSearchParams(
+        params(""),
+        {
+          activeTab: "library",
+          browseType: axis,
+          queryDefinition: {
+            library_ids: [],
+            media_scope: "audiobook",
+            match: "all",
+            groups: [],
+            sort: { field: "title", order: "asc" },
+          },
+        },
+        "audiobooks",
+      );
+
+      expect(next.get("type")).toBe(axis);
+      expect(parseLibraryPageState(next, "audiobooks").browseType).toBe(axis);
+    }
+  });
+
+  it("defaults audiobook libraries to the books axis for unknown type values", () => {
+    const state = parseLibraryPageState(params("tab=library&type=episode"), "audiobooks");
+
+    expect(state.browseType).toBe("books");
+    expect(state.queryDefinition.media_scope).toBe("audiobook");
   });
 });
 

--- a/web/src/pages/libraryPageSearchParams.ts
+++ b/web/src/pages/libraryPageSearchParams.ts
@@ -12,7 +12,21 @@ import {
 } from "@/lib/querySortOptions";
 
 export type LibraryPageTab = "recommended" | "library" | "collections";
-export type LibraryBrowseType = "series" | "episode";
+// "series" | "episode" are the series-library browse modes; "books" |
+// "series" | "authors" | "narrators" are the audiobook-library browse axes
+// ("series" is shared — its meaning follows the library type).
+export type LibraryBrowseType = "series" | "episode" | "books" | "authors" | "narrators";
+
+export const AUDIOBOOK_BROWSE_AXES = ["books", "series", "authors", "narrators"] as const;
+export type AudiobookBrowseAxis = (typeof AUDIOBOOK_BROWSE_AXES)[number];
+
+export function audiobookBrowseAxisFromBrowseType(
+  browseType: LibraryBrowseType,
+): AudiobookBrowseAxis {
+  return browseType === "series" || browseType === "authors" || browseType === "narrators"
+    ? browseType
+    : "books";
+}
 
 export interface LibraryPageState {
   activeTab: LibraryPageTab;
@@ -59,6 +73,10 @@ function parseSeriesLibraryBrowseType(value: string | undefined): LibraryBrowseT
   return value === "episode" ? "episode" : "series";
 }
 
+function parseAudiobookLibraryBrowseType(value: string | undefined): LibraryBrowseType {
+  return value === "series" || value === "authors" || value === "narrators" ? value : "books";
+}
+
 function getLibrarySortRelevanceScope(
   libraryType: string,
   mediaScope?: QueryDefinition["media_scope"],
@@ -82,7 +100,7 @@ function getLibrarySortRelevanceScope(
   return "all";
 }
 
-function isAudiobookLibraryType(libraryType: string): boolean {
+export function isAudiobookLibraryType(libraryType: string): boolean {
   return libraryType === "audiobook" || libraryType === "audiobooks";
 }
 
@@ -257,7 +275,9 @@ export function parseLibraryPageState(
   const browseType =
     libraryType === "series"
       ? parseSeriesLibraryBrowseType(readString(searchParams.get("type")))
-      : "series";
+      : isAudiobookLibraryType(libraryType)
+        ? parseAudiobookLibraryBrowseType(readString(searchParams.get("type")))
+        : "series";
   const defaultQueryDefinition = createDefaultLibraryQueryDefinition();
   if (activeTab !== "library") {
     return {
@@ -395,6 +415,14 @@ export function updateLibraryPageSearchParams(
   if (libraryType === "series") {
     if (state.browseType === "episode") {
       nextSearchParams.set("type", "episode");
+    }
+  } else if (isAudiobookLibraryType(libraryType)) {
+    if (
+      state.browseType === "series" ||
+      state.browseType === "authors" ||
+      state.browseType === "narrators"
+    ) {
+      nextSearchParams.set("type", state.browseType);
     }
   } else if (libraryType === "mixed" && queryDefinition.media_scope) {
     nextSearchParams.set("type", queryDefinition.media_scope);


### PR DESCRIPTION
## Problem

Audiobook libraries reuse the video-shaped library page wholesale: a cinematic backdrop-carousel hero (audiobooks have square covers and no backdrops to fill it), default sections copied from the movie list, and a browse grid where the axes audiobook listeners actually navigate by — author, narrator, series — are buried as filters. The usage pattern is inverted from movies: ~90% of opens are "resume the book I'm in," and the next pick is driven by series order and author/narrator loyalty, not genre browsing.

## Approach

Keep the Home / Library / Collections architecture; replace what fills it for audiobook libraries.

**Home tab**
- The continue-listening section is now `featured` in audiobook library defaults and renders as a new `NowListeningHero`: a resume deck for the most recent in-progress book (square cover as blurred backdrop, ambient color from the cover, chapter position like "Chapter 32 of 75 · The Tower", hours left, one-click Resume), with the remaining in-progress books as the row beneath.
- New `next_in_series` section type (backend + recipe registration): per series the profile has finished a book of, surface the lowest-indexed later book not yet started, ordered by most recent finish. Cards show a "Book N · Series Name" eyebrow. This is the audiobook equivalent of TV's On Deck.
- Tab label is "Home" instead of "Recommended" for audiobook libraries.

**Library tab**
- New Books / Series / Authors / Narrators browse axes (persisted via the existing `type` search param, mirroring the series-library Series/Episodes toggle).
- Backed by a new `GET /api/v1/catalog/audiobook-groups` endpoint: groups by author/narrator/series with book count, total duration, per-profile in-progress/finished counts, and up to four poster URLs for cover stacks. Selecting a group drops into the Books grid with the matching author/narrator/series filter applied (names match case-insensitively, same semantics as the facet filters).

**Migration**
- `20260609222830_audiobook_library_home_redesign.sql` upgrades existing audiobook libraries: features the first continue-listening section (only when the admin hasn't already featured something) and inserts a next-in-series section after it (only when none exists). Fresh libraries get the new defaults from `DefaultLibrarySectionsForType`.

**Shared cleanup**
- Chapter-list building, version→file mapping, and hr/min duration formatting extracted to `web/src/lib/audiobooks/` and reused by `AudiobookContent`, `NowListeningHero`, and the continue cards (previously duplicated inline).
- Audiobooks in continue rows now render as square covers (poster variant) instead of cropped 16:9, with "3 hr 2 min left" formatting.
- `useCatalogWindow` gains an `enabled` option so grouped axis views don't fetch the books grid behind themselves.

## Risks / follow-up

- **Client repos**: `next_in_series` sections and the grouped browse endpoint are new client-visible API surface. silo-android and silo-apple need follow-up to render them; until then they should tolerate the unknown section type (it resolves like any other section).
- `next_in_series` has no dismissal surface yet (next_up has one); can be added if "stop suggesting this series" demand shows up.
- Series identity is keyed on `LOWER(BTRIM(series_name))`, consistent with the existing facet and filter behavior — books missing `series_index` are excluded from progression.
- Pre-existing on main and untouched here: 15 frontend test failures and prettier drift in 19 files (verified failing at HEAD; tracked separately).

## Testing

- `GOWORK=off go test ./internal/...` passes (playback GPU-probe tests flake under parallel load on the dev Mac, pass in isolation — unrelated).
- `tsc -b`, ESLint (0 errors), prettier on touched files, `pnpm run build`, and `make verify-local-paths` all clean.
- Updated `defaults_test.go`, `recipe_equivalence_test.go`, `libraryPageSearchParams.test.ts` (axis round-trip + unknown-value fallback), `LibraryBrowse.test.tsx`.
- No screenshots: implemented in a headless worktree against the design mockup; happy to attach once it's running on dev.

## AI use

Implemented end-to-end by Claude (Fable 5) via Claude Code, from a design direction approved by the maintainer; design exploration, code, migration, and tests are AI-authored and locally verified as above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Grouped audiobook browsing (author, narrator, series) with a dedicated browse view and pagination
  * "Next in Your Series" section showing next unread book in series you’ve started/finished
  * New "Now Listening" hero with chapter-aware resume controls and per-item listening-time display
  * Utilities for audiobook chapters/files and listening-time formatting

* **UI/UX Improvements**
  * Audiobook library home redesign: featured continue-listening and reordered sections
  * Tab label and card display refinements for audiobook libraries

* **Tests**
  * Updated audiobook-related tests and defaults to reflect new sections and behaviors
<!-- end of auto-generated comment: release notes by coderabbit.ai -->