### PR TITLE
fix(web): make pre-merge frontend checks pass at HEAD (prettier drift + 15 stale tests)

### DIFF
--- a/web/src/components/EpisodeRow.test.tsx
+++ b/web/src/components/EpisodeRow.test.tsx
@@ -56,6 +56,6 @@ describe("EpisodeRow", () => {
       </MemoryRouter>,
     );
 
-    expect(markup).toContain("text-green-500");
+    expect(markup).toContain("text-success");
   });
 });

--- a/web/src/components/ImpersonationBanner.test.tsx
+++ b/web/src/components/ImpersonationBanner.test.tsx
@@ -10,17 +10,17 @@ describe("ImpersonationBanner", () => {
       <ImpersonationBanner userName="target-user" impersonatorName="admin-user" onEnd={onEnd} />,
     );
 
-    expect(markup).toContain("Impersonating");
+    expect(markup).toContain("Viewing as");
     expect(markup).toContain("target-user");
     expect(markup).toContain("admin-user");
-    expect(markup).toContain("End impersonation");
+    expect(markup).toContain("End impersonation session");
   });
 
-  it("offsets banner content on desktop so the app sidebar does not cover it", () => {
+  it("stays pinned above the page content while scrolling", () => {
     const markup = renderToStaticMarkup(
       <ImpersonationBanner userName="target-user" impersonatorName="admin-user" onEnd={() => {}} />,
     );
 
-    expect(markup).toContain("lg:pl-[292px]");
+    expect(markup).toContain("sticky top-0");
   });
 });

--- a/web/src/components/SectionRow.test.tsx
+++ b/web/src/components/SectionRow.test.tsx
@@ -42,6 +42,10 @@ vi.mock("@/components/MediaItemMenu", () => ({
   default: () => <div>More actions</div>,
 }));
 
+vi.mock("@/playback/watchPlaybackContext", () => ({
+  useWatchPlaybackController: () => ({ startPlayback: () => {} }),
+}));
+
 vi.mock("@/hooks/queries/sidebarPins", () => ({
   useToggleSidebarPin: () => ({
     togglePin: mockTogglePin,

--- a/web/src/components/ServerActivity.tsx
+++ b/web/src/components/ServerActivity.tsx
@@ -132,7 +132,7 @@ export default function ServerActivity({ hideWhenEmpty = false }: ServerActivity
           )}
           {showConnectionProblem && (
             <span
-              className="absolute -right-0.5 -bottom-0.5 h-2.5 w-2.5 rounded-full bg-red-500 ring-2 ring-background"
+              className="ring-background absolute -right-0.5 -bottom-0.5 h-2.5 w-2.5 rounded-full bg-red-500 ring-2"
               aria-hidden="true"
             />
           )}

--- a/web/src/components/admin/TaskStatusBadge.tsx
+++ b/web/src/components/admin/TaskStatusBadge.tsx
@@ -1,11 +1,6 @@
 import type { ExecutionResult } from "@/api/types";
 import { Badge } from "@/components/ui/badge";
-import {
-  Tooltip,
-  TooltipContent,
-  TooltipProvider,
-  TooltipTrigger,
-} from "@/components/ui/tooltip";
+import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@/components/ui/tooltip";
 import { cn } from "@/lib/utils";
 
 interface TaskStatusBadgeProps {

--- a/web/src/components/catalog/CatalogFiltersPanel.tsx
+++ b/web/src/components/catalog/CatalogFiltersPanel.tsx
@@ -53,7 +53,9 @@ export default function CatalogFiltersPanel({
   const qd = state.query_definition ?? createEmptyQueryDefinition();
   const guidedState = useMemo(() => queryDefinitionToGuidedState(qd), [qd]);
   const isAudiobookLibrary =
-    libraryType === "audiobook" || libraryType === "audiobooks" || guidedState.mediaScope === "audiobook";
+    libraryType === "audiobook" ||
+    libraryType === "audiobooks" ||
+    guidedState.mediaScope === "audiobook";
   const badges = useMemo(
     () => getActiveFilterBadges(guidedState, { isAudiobookLibrary }),
     [guidedState, isAudiobookLibrary],

--- a/web/src/components/collections/ManualCollectionItemsEditor.tsx
+++ b/web/src/components/collections/ManualCollectionItemsEditor.tsx
@@ -3,11 +3,7 @@ import { useQuery } from "@tanstack/react-query";
 import { GripVertical, Loader2, Plus, Search, Trash2 } from "lucide-react";
 
 import { DndContext } from "@dnd-kit/core";
-import {
-  SortableContext,
-  verticalListSortingStrategy,
-  useSortable,
-} from "@dnd-kit/sortable";
+import { SortableContext, verticalListSortingStrategy, useSortable } from "@dnd-kit/sortable";
 import { CSS } from "@dnd-kit/utilities";
 
 import type { BrowseItem, CollectionItem } from "@/api/types";

--- a/web/src/components/overlays/CardOverlays.tsx
+++ b/web/src/components/overlays/CardOverlays.tsx
@@ -52,8 +52,7 @@ function resolveBadge(
   if (!label) return null;
   const dynamicIcon = def.getIcon ? def.getIcon(data) : null;
   const candidateIcon = dynamicIcon ?? def.iconId ?? null;
-  const showIcon =
-    def.iconCapable && candidateIcon !== null && (itemShowIcon ?? preset.preferIcon);
+  const showIcon = def.iconCapable && candidateIcon !== null && (itemShowIcon ?? preset.preferIcon);
   return {
     def,
     label,

--- a/web/src/components/overlays/OverlayPreviewCard.tsx
+++ b/web/src/components/overlays/OverlayPreviewCard.tsx
@@ -27,7 +27,7 @@ export function OverlayPreviewCard({
     <div
       className={`bg-muted/40 relative mx-auto aspect-[2/3] ${sizeClass} overflow-hidden rounded-xl border`}
     >
-      <div className="text-muted-foreground/30 flex h-full items-center justify-center text-xs font-medium uppercase tracking-wider">
+      <div className="text-muted-foreground/30 flex h-full items-center justify-center text-xs font-medium tracking-wider uppercase">
         {variant === "show" ? "Show preview" : "Movie preview"}
       </div>
       <CardOverlays data={data} prefs={prefs} />

--- a/web/src/components/profiles/HouseholdStreamsPanel.tsx
+++ b/web/src/components/profiles/HouseholdStreamsPanel.tsx
@@ -33,11 +33,7 @@ function formatElapsed(startedAt: string): string {
 }
 
 function streamMeta(session: AdminSession): string {
-  return [
-    formatElapsed(session.started_at),
-    session.client_ip,
-    session.node_display_name,
-  ]
+  return [formatElapsed(session.started_at), session.client_ip, session.node_display_name]
     .filter(Boolean)
     .join(" · ");
 }

--- a/web/src/hooks/queries/mediaSurfaceRefresh.test.ts
+++ b/web/src/hooks/queries/mediaSurfaceRefresh.test.ts
@@ -179,9 +179,7 @@ describe("invalidateMediaSurfaceQueries", () => {
       };
     };
 
-    expect(
-      queryClient.getQueryData<CachedHomeSection>(sectionKeys.homeItems("continue")),
-    ).toEqual({
+    expect(queryClient.getQueryData<CachedHomeSection>(sectionKeys.homeItems("continue"))).toEqual({
       section: {
         id: "continue",
         section_type: "continue_watching",

--- a/web/src/hooks/useOverlayPrefs.ts
+++ b/web/src/hooks/useOverlayPrefs.ts
@@ -3,11 +3,7 @@ import { useQuery } from "@tanstack/react-query";
 import { api } from "@/api/client";
 import { useSetting, useSetSetting } from "@/hooks/queries/settings";
 import { settingsKeys } from "@/hooks/queries/keys";
-import {
-  parseOverlayPrefs,
-  serializeOverlayPrefs,
-  type CardOverlayPrefs,
-} from "@/lib/overlays";
+import { parseOverlayPrefs, serializeOverlayPrefs, type CardOverlayPrefs } from "@/lib/overlays";
 
 const SETTING_KEY = "card_overlays";
 

--- a/web/src/hooks/useSortableList.ts
+++ b/web/src/hooks/useSortableList.ts
@@ -1,12 +1,6 @@
 import { useMemo } from "react";
 
-import {
-  KeyboardSensor,
-  PointerSensor,
-  closestCenter,
-  useSensor,
-  useSensors,
-} from "@dnd-kit/core";
+import { KeyboardSensor, PointerSensor, closestCenter, useSensor, useSensors } from "@dnd-kit/core";
 import type { DragEndEvent } from "@dnd-kit/core";
 import { arrayMove, sortableKeyboardCoordinates } from "@dnd-kit/sortable";
 

--- a/web/src/lib/mediaNavigation.test.ts
+++ b/web/src/lib/mediaNavigation.test.ts
@@ -4,8 +4,6 @@ import { buildMediaPlayHref } from "./mediaNavigation";
 
 describe("buildMediaPlayHref", () => {
   it("routes podcasts to item detail instead of video watch", () => {
-    expect(buildMediaPlayHref({ contentId: "podcast-1", type: "podcast" })).toBe(
-      "/item/podcast-1",
-    );
+    expect(buildMediaPlayHref({ contentId: "podcast-1", type: "podcast" })).toBe("/item/podcast-1");
   });
 });

--- a/web/src/lib/mediaNavigation.ts
+++ b/web/src/lib/mediaNavigation.ts
@@ -19,7 +19,10 @@ function appendQuery(base: string, params: Record<string, string | number | bool
   return suffix ? `${base}?${suffix}` : base;
 }
 
-export function buildItemHref({ contentId, libraryId }: Pick<MediaHrefInput, "contentId" | "libraryId">) {
+export function buildItemHref({
+  contentId,
+  libraryId,
+}: Pick<MediaHrefInput, "contentId" | "libraryId">) {
   return appendQuery(`/item/${contentId}`, { libraryId });
 }
 

--- a/web/src/lib/overlays/index.ts
+++ b/web/src/lib/overlays/index.ts
@@ -25,16 +25,8 @@ export {
   orderedOverlaysForPosition,
   isOverlaySuppressed,
 } from "./schema";
-export {
-  OVERLAY_PRESETS,
-  PRESET_IDS,
-  getPreset,
-  ACCENT_PALETTE,
-} from "./presets";
+export { OVERLAY_PRESETS, PRESET_IDS, getPreset, ACCENT_PALETTE } from "./presets";
 export { POSITION_OPTIONS, CATEGORY_GROUPS, CATEGORY_META } from "./ui-constants";
 export { OverlayIcon } from "./icons";
-export {
-  overlayDataFromBrowseItem,
-  overlayDataFromSectionItem,
-} from "./extractors";
+export { overlayDataFromBrowseItem, overlayDataFromSectionItem } from "./extractors";
 export { SAMPLE_MOVIE_DATA, SAMPLE_SHOW_DATA } from "./sample-data";

--- a/web/src/lib/overlays/presets.ts
+++ b/web/src/lib/overlays/presets.ts
@@ -30,9 +30,7 @@ export const OVERLAY_PRESETS: Record<PresetId, OverlayPreset> = {
     badgeClass:
       "rounded-full border border-white/15 px-2 py-0.5 text-[10px] font-semibold tracking-wide uppercase leading-none",
     badgeStyle: (accent) => ({
-      background: accent
-        ? `color-mix(in srgb, ${accent} 28%, rgba(0,0,0,0.6))`
-        : "rgba(0,0,0,0.6)",
+      background: accent ? `color-mix(in srgb, ${accent} 28%, rgba(0,0,0,0.6))` : "rgba(0,0,0,0.6)",
       color: "white",
     }),
     iconSize: 11,
@@ -90,7 +88,13 @@ export const OVERLAY_PRESETS: Record<PresetId, OverlayPreset> = {
   },
 };
 
-export const PRESET_IDS = ["minimal", "classic", "vibrant", "pill", "square"] as const satisfies readonly PresetId[];
+export const PRESET_IDS = [
+  "minimal",
+  "classic",
+  "vibrant",
+  "pill",
+  "square",
+] as const satisfies readonly PresetId[];
 
 export function getPreset(id: PresetId): OverlayPreset {
   return OVERLAY_PRESETS[id] ?? OVERLAY_PRESETS.classic;

--- a/web/src/lib/overlays/registry/tech.ts
+++ b/web/src/lib/overlays/registry/tech.ts
@@ -16,7 +16,7 @@ function hdrIcon(value: string | undefined): OverlayIconId | null {
 function prettyResolution(value: string | undefined): string | null {
   if (!value) return null;
   const v = value.toLowerCase().trim();
-  if (v === "" ) return null;
+  if (v === "") return null;
   if (v === "2160p" || v === "4k" || v === "uhd") return "4K";
   if (v === "4320p" || v === "8k") return "8K";
   if (/^\d+p$/.test(v)) return v;
@@ -70,7 +70,7 @@ export const TECH_OVERLAYS: readonly OverlayDef[] = [
     id: "resolution_hdr",
     category: "tech",
     label: "Resolution + HDR (combined)",
-    description: "Single badge combining resolution and dynamic range (e.g. \"4K DV\", \"1080p HDR\")",
+    description: 'Single badge combining resolution and dynamic range (e.g. "4K DV", "1080p HDR")',
     defaultPosition: "top-left",
     defaultEnabled: false,
     iconCapable: true,

--- a/web/src/lib/overlays/schema.ts
+++ b/web/src/lib/overlays/schema.ts
@@ -49,7 +49,9 @@ function applyItemPatch(
 // buildItems is the single registry pass shared by both migration paths and
 // the default-prefs builder. It produces a complete items map: every overlay
 // id gets either a patched entry (when source has it) or a fresh default.
-function buildItems(source: Record<string, unknown> | undefined): Record<OverlayId, OverlayItemConfig> {
+function buildItems(
+  source: Record<string, unknown> | undefined,
+): Record<OverlayId, OverlayItemConfig> {
   const items = {} as Record<OverlayId, OverlayItemConfig>;
   for (const def of OVERLAY_REGISTRY) {
     const base: OverlayItemConfig = { enabled: def.defaultEnabled, position: def.defaultPosition };
@@ -68,7 +70,8 @@ function migrateFromV1(parsed: Record<string, unknown>): CardOverlayPrefs {
 
 function parseV2(parsed: Record<string, unknown>): CardOverlayPrefs {
   const items = parsed.items;
-  const sourceItems = items && typeof items === "object" ? (items as Record<string, unknown>) : undefined;
+  const sourceItems =
+    items && typeof items === "object" ? (items as Record<string, unknown>) : undefined;
   return {
     version: 2,
     preset: isValidPreset(parsed.preset) ? parsed.preset : "classic",
@@ -114,10 +117,7 @@ export function isOverlaySuppressed(id: OverlayId, prefs: CardOverlayPrefs): boo
 
 // Returns enabled overlays for a position, in the user's chosen order
 // (falling back to registry order for any unranked ids).
-export function orderedOverlaysForPosition(
-  prefs: CardOverlayPrefs,
-  position: OverlayPosition,
-) {
+export function orderedOverlaysForPosition(prefs: CardOverlayPrefs, position: OverlayPosition) {
   const enabled = OVERLAY_REGISTRY.filter(
     (def) =>
       prefs.items[def.id]?.enabled &&
@@ -126,7 +126,5 @@ export function orderedOverlaysForPosition(
   );
   if (prefs.order.length === 0) return enabled;
   const orderIndex = new Map<OverlayId, number>(prefs.order.map((id, i) => [id, i]));
-  return [...enabled].sort(
-    (a, b) => (orderIndex.get(a.id) ?? 999) - (orderIndex.get(b.id) ?? 999),
-  );
+  return [...enabled].sort((a, b) => (orderIndex.get(a.id) ?? 999) - (orderIndex.get(b.id) ?? 999));
 }

--- a/web/src/lib/profile-management.test.ts
+++ b/web/src/lib/profile-management.test.ts
@@ -94,7 +94,7 @@ describe("profile-management", () => {
       clearKidsPreset(
         createProfileDraft(
           makeProfile({
-            avatar: avatarPresetRef("adventurer"),
+            avatar: avatarPresetRef("dicebear:identicon:swift-fox"),
             is_child: true,
             max_content_rating: "PG",
             library_restrictions_enabled: true,
@@ -104,7 +104,7 @@ describe("profile-management", () => {
         ),
       ),
     ).toMatchObject({
-      avatarPreset: "adventurer",
+      avatarPreset: "dicebear:identicon:swift-fox",
       isChild: false,
       maxContentRating: "",
       maxPlaybackQuality: "any",

--- a/web/src/pages/AdminHistoryImport.tsx
+++ b/web/src/pages/AdminHistoryImport.tsx
@@ -1030,9 +1030,7 @@ function MappingsSection({
                     <ArrowRight className="h-3.5 w-3.5" />
                   </TableCell>
                   <TableCell>
-                    <p className="text-sm">
-                      {m.silo_username || `User ${m.silo_user_id}`}
-                    </p>
+                    <p className="text-sm">{m.silo_username || `User ${m.silo_user_id}`}</p>
                     {m.silo_profile_name && (
                       <p className="text-muted-foreground text-xs">{m.silo_profile_name}</p>
                     )}

--- a/web/src/pages/ItemDetail/AudiobookContent.test.tsx
+++ b/web/src/pages/ItemDetail/AudiobookContent.test.tsx
@@ -7,7 +7,13 @@ import type { ItemDetail } from "@/api/types";
 
 const mocks = vi.hoisted(() => ({
   controller: null as null | {
-    active: null | { contentId: string; playing: boolean; currentTime: number; duration: number; hasFile: boolean };
+    active: null | {
+      contentId: string;
+      playing: boolean;
+      currentTime: number;
+      duration: number;
+      hasFile: boolean;
+    };
     activeRequest: null | { contentId: string };
     isBackgroundBarVisible: boolean;
     startPlayback: ReturnType<typeof vi.fn>;

--- a/web/src/pages/ItemDetail/SeriesContent.test.tsx
+++ b/web/src/pages/ItemDetail/SeriesContent.test.tsx
@@ -1,4 +1,5 @@
 import type { ReactNode } from "react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { renderToStaticMarkup } from "react-dom/server";
 import { MemoryRouter } from "react-router";
 import { beforeEach, describe, expect, it, vi } from "vitest";
@@ -27,7 +28,7 @@ const mocks = vi.hoisted(() => {
     useSeasons: vi.fn(),
     useItemEpisodes: vi.fn(),
     useContinueWatching: vi.fn(),
-    useRating: vi.fn(),
+    useSimilarItems: vi.fn(),
     useSetRating: vi.fn(),
     useDeleteRating: vi.fn(),
     setRatingMutate: vi.fn(),
@@ -37,6 +38,7 @@ const mocks = vi.hoisted(() => {
 
 vi.mock("@/hooks/useAuth", () => ({
   useAuth: mocks.useAuth,
+  useOptionalAuth: mocks.useAuth,
 }));
 
 vi.mock("@/hooks/queries/favorites", () => ({
@@ -63,8 +65,15 @@ vi.mock("@/hooks/queries/progress", () => ({
   useContinueWatching: mocks.useContinueWatching,
 }));
 
+vi.mock("@/hooks/queries/recommendations", () => ({
+  useSimilarItems: mocks.useSimilarItems,
+}));
+
+vi.mock("@/playback/watchPlaybackContext", () => ({
+  useWatchPlaybackController: () => ({ startPlayback: () => {} }),
+}));
+
 vi.mock("@/hooks/queries/ratings", () => ({
-  useRating: mocks.useRating,
   useSetRating: mocks.useSetRating,
   useDeleteRating: mocks.useDeleteRating,
 }));
@@ -160,6 +169,7 @@ function makeSeriesItem(
     subtitles: [],
     intro: null,
     credits: null,
+    user_rating: 4,
     ...overrides,
     release_date: overrides.release_date ?? null,
   };
@@ -182,16 +192,18 @@ describe("SeriesContent", () => {
       data: { episodes: [{ content_id: "episode-1" }] },
     });
     mocks.useContinueWatching.mockReturnValue({ items: [] });
-    mocks.useRating.mockReturnValue({ data: { rating: 4, rated_at: "2026-03-22T00:00:00Z" } });
+    mocks.useSimilarItems.mockReturnValue({ data: undefined, isLoading: false });
     mocks.useSetRating.mockReturnValue({ mutate: mocks.setRatingMutate });
     mocks.useDeleteRating.mockReturnValue({ mutate: mocks.deleteRatingMutate });
   });
 
   it("passes rating state and change handler to ActionBar", () => {
     renderToStaticMarkup(
-      <MemoryRouter initialEntries={["/item/series-1"]}>
-        <SeriesContent item={makeSeriesItem()} />
-      </MemoryRouter>,
+      <QueryClientProvider client={new QueryClient()}>
+        <MemoryRouter initialEntries={["/item/series-1"]}>
+          <SeriesContent item={makeSeriesItem()} />
+        </MemoryRouter>
+      </QueryClientProvider>,
     );
 
     expect(mocks.capturedActionBarProps.value).toMatchObject({
@@ -202,9 +214,11 @@ describe("SeriesContent", () => {
 
   it("sets and clears ratings through the existing mutations", () => {
     renderToStaticMarkup(
-      <MemoryRouter initialEntries={["/item/series-1"]}>
-        <SeriesContent item={makeSeriesItem()} />
-      </MemoryRouter>,
+      <QueryClientProvider client={new QueryClient()}>
+        <MemoryRouter initialEntries={["/item/series-1"]}>
+          <SeriesContent item={makeSeriesItem()} />
+        </MemoryRouter>
+      </QueryClientProvider>,
     );
 
     const onRatingChange = mocks.capturedActionBarProps.value?.onRatingChange as

--- a/web/src/pages/settings/CardOverlaySettings.tsx
+++ b/web/src/pages/settings/CardOverlaySettings.tsx
@@ -29,11 +29,7 @@ import {
   SelectTrigger,
   SelectValue,
 } from "@/components/ui/select";
-import {
-  Popover,
-  PopoverContent,
-  PopoverTrigger,
-} from "@/components/ui/popover";
+import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 
 interface SettingRowProps {
@@ -84,7 +80,7 @@ function AccentSwatch({ value, defaultValue, disabled, onChange }: AccentSwatchP
       </PopoverTrigger>
       <PopoverContent align="end" className="w-[200px] p-3">
         <div className="space-y-2">
-          <div className="text-xs font-medium uppercase tracking-wide">Accent color</div>
+          <div className="text-xs font-medium tracking-wide uppercase">Accent color</div>
           <div className="grid grid-cols-6 gap-1.5">
             {ACCENT_PALETTE.map((color) => (
               <button
@@ -256,9 +252,7 @@ function PresetPicker({ value, onChange }: PresetPickerProps) {
             </div>
             <div>
               <div className="text-sm font-medium">{preset.label}</div>
-              <div className="text-muted-foreground text-xs leading-snug">
-                {preset.description}
-              </div>
+              <div className="text-muted-foreground text-xs leading-snug">{preset.description}</div>
             </div>
           </button>
         );
@@ -284,8 +278,8 @@ export default function CardOverlaySettings() {
       <div className="space-y-3">
         <h2 className="text-2xl font-semibold tracking-tight sm:text-3xl">Card Overlays</h2>
         <p className="text-muted-foreground max-w-2xl text-sm leading-relaxed">
-          Choose which badges appear on poster cards, where they sit, and how they look. Inspired
-          by Kometa.
+          Choose which badges appear on poster cards, where they sit, and how they look. Inspired by
+          Kometa.
         </p>
       </div>
 
@@ -356,26 +350,23 @@ export default function CardOverlaySettings() {
                 onChange={(next) => handleUpdate({ ...displayPrefs, preset: next })}
               />
             </SettingsGroup>
-            <SettingsGroup
-              title="How styling works"
-              description="Where to find what."
-            >
+            <SettingsGroup title="How styling works" description="Where to find what.">
               <ul className="text-muted-foreground list-disc space-y-1 pl-5 text-sm">
                 <li>
                   <strong className="text-foreground">Preset</strong> sets the badge shape,
                   background, font, and whether icons show by default.
                 </li>
                 <li>
-                  <strong className="text-foreground">Accent color</strong> (per overlay) tints
-                  that badge — gold for IMDb, red for RT, etc.
+                  <strong className="text-foreground">Accent color</strong> (per overlay) tints that
+                  badge — gold for IMDb, red for RT, etc.
                 </li>
                 <li>
                   <strong className="text-foreground">Icon toggle</strong> (per overlay) overrides
                   the preset's icon default for a single overlay.
                 </li>
                 <li>
-                  <strong className="text-foreground">Position</strong> picks which corner the
-                  badge sits in. Multiple badges in the same corner stack vertically.
+                  <strong className="text-foreground">Position</strong> picks which corner the badge
+                  sits in. Multiple badges in the same corner stack vertically.
                 </li>
               </ul>
             </SettingsGroup>

--- a/web/src/pages/settings/ProfilesSettings.test.tsx
+++ b/web/src/pages/settings/ProfilesSettings.test.tsx
@@ -21,6 +21,7 @@ vi.mock("@/hooks/queries/profiles", () => ({
     isPending: false,
     mutate: (...args: unknown[]) => mocks.deleteMutate(...args),
   }),
+  useHouseholdSessions: () => ({ data: [], isLoading: false, isFetching: false }),
 }));
 
 vi.mock("@/hooks/queries/libraries", () => ({


### PR DESCRIPTION
## Problem

The frontend verification commands required before merge requests were failing at HEAD on `main`, independent of any feature work:

- `cd web && pnpm run format:check` reported style issues in 19 files
- `cd web && pnpm run test` had 15 failing tests across 6 files

## What changed

**Commit 1 — formatting only.** Checked first whether the drift came from a prettier version bump: prettier has been pinned at 3.8.1 in `web/pnpm-lock.yaml` since the initial migration (only react-router and vitest were bumped since), so the 19 files were simply committed unformatted. Ran `pnpm run format`; whitespace/wrapping changes only.

**Commit 2 — test files only, no component changes.** The failing tests were committed already out of sync with the components they render (none of those components changed after the initial migration), so the current components are the source of truth:

- `SectionRow.test.tsx` / `SeriesContent.test.tsx`: mock `@/playback/watchPlaybackContext` (ContinueWatchingCard and MediaItemMenu require the watch playback controller — same pattern as ContinueWatchingCard's own tests), mock the new `useSimilarItems` hook, add `useOptionalAuth` to the auth mock, and wrap renders in `QueryClientProvider` for MediaItemMenu's query hooks
- `SeriesContent.test.tsx`: the component reads the rating from `item.user_rating` now (the `useRating` hook no longer exists), so the fixture sets `user_rating: 4` and the stale mock is removed
- `ProfilesSettings.test.tsx`: add `useHouseholdSessions` to the `@/hooks/queries/profiles` mock for the new `HouseholdStreamsPanel`
- `ImpersonationBanner.test.tsx`: the banner was redesigned ("Viewing as" label, full-width sticky bar, no `lg:pl-[292px]` sidebar offset); the obsolete offset test now asserts the sticky positioning instead
- `EpisodeRow.test.tsx`: the watched indicator uses the `text-success` design token instead of `text-green-500`
- `profile-management.test.ts`: `"adventurer"` is no longer a resolvable avatar preset after the move to DiceBear-style refs (it round-trips to `""`); switched to a valid `dicebear:identicon:swift-fox` ref, preserving the test's intent that `clearKidsPreset` leaves the avatar untouched

## Verification

- `pnpm run test`: 838/838 pass (was 823/838)
- `pnpm run format:check`: clean
- `pnpm run lint`: 0 errors (140 pre-existing warnings, untouched)
- `make verify-local-paths`: clean

## Risks / notes

No production code changes — formatting and test harnesses only. AI-use disclosure: authored with Claude Code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated test assertions and mocks for improved test coverage across components and hooks, including playback context, household sessions, and profile management scenarios.

* **Style**
  * Reorganized CSS class ordering for the connection status indicator and overlay label styling.

* **Refactor**
  * Consolidated imports and reformatted code expressions across multiple components and hooks for consistency.
  * Refined icon computation logic in overlay badge resolution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->