### PR TITLE
feat(config): live admin settings + truthful restart-required banner

### DIFF
--- a/cmd/silo/main.go
+++ b/cmd/silo/main.go
@@ -744,6 +744,9 @@ func main() {
 
 		ffprobePath := scanner.FFprobePathFromFFmpeg(cfg.Playback.FFmpegPath)
 		s := scanner.NewScanner(fileRepo, ffprobePath, deps.S3Public, cfg.Scanner.Workers, cfg.Scanner.EmptyTrashAfterScan)
+		configWatcher.OnChange(func(_, updated *config.Config) {
+			s.SetWorkers(updated.Scanner.Workers)
+		})
 		deps.Scanner = s
 		deps.ProbeEnsurer = scanner.NewPlaybackProbeEnsurer(fileRepo, ffprobePath, 10*time.Second)
 		slog.Info("scanner initialized")
@@ -1081,6 +1084,9 @@ func main() {
 			imageCacher := imagecache.New(deps.S3Public)
 			metadataService.SetImageCacher(imageCacher)
 			metadataService.SetAutoCacheImages(cfg.Metadata.CacheImages)
+			configWatcher.OnChange(func(_, updated *config.Config) {
+				metadataService.SetAutoCacheImages(updated.Metadata.CacheImages)
+			})
 			if deps.Scanner != nil {
 				deps.Scanner.SetImageCacher(imageCacher)
 			}
@@ -1098,6 +1104,10 @@ func main() {
 		}
 
 		matchWorker = metadata.NewMatchWorker(metadataService, deps.FileRepo, cfg.Matcher.Workers, cfg.Matcher.BatchSize, 30*time.Second)
+		mwForReload := matchWorker
+		configWatcher.OnChange(func(_, updated *config.Config) {
+			mwForReload.SetConcurrency(updated.Matcher.Workers, updated.Matcher.BatchSize)
+		})
 		matchWorker.SetRealtimeHub(deps.RealtimeHub)
 		if movieQueueRepo != nil {
 			matchWorker.SetMovieFileClaimer(movieQueueRepo)
@@ -1532,6 +1542,10 @@ func main() {
 			deps.UserCollectionSync = userSync
 			deps.UserCollectionScheduler = userCollectionScheduler
 			deps.MDBListClient = mdblist.NewClient(cfg.MDBListAPIKey, nil)
+			mdblistForReload := deps.MDBListClient
+			configWatcher.OnChange(func(_, updated *config.Config) {
+				mdblistForReload.SetAPIKey(updated.MDBListAPIKey)
+			})
 		}
 	}
 

--- a/cmd/silo/main.go
+++ b/cmd/silo/main.go
@@ -554,6 +554,22 @@ func main() {
 		return
 	}
 
+	// Hot-reload config watcher for integrated/api mode. Reloads on
+	// EventSettingsChanged (Redis) with a 60s poll fallback, so settings
+	// changes apply without restart even on Redis-less deployments. The
+	// watcher's config supersedes the startup snapshot from here on.
+	configWatcher := nodeconfig.NewWatcher(pool, dataCipher, eventBus, nodeconfig.BootstrapOverrides{
+		Listen:      bc.Listen,
+		Mode:        bc.Mode,
+		DatabaseURL: bc.DatabaseURL,
+		JFListen:    bc.JFListen,
+		RedisURL:    bc.RedisURL,
+	})
+	if err := configWatcher.Start(appCtx); err != nil {
+		log.Fatalf("config watcher start: %v", err)
+	}
+	cfg = configWatcher.Config()
+
 	// Determine which components to initialize based on mode.
 	needsS3 := mode == "integrated" || mode == "api"
 	needsScanner := mode == "integrated" || mode == "api"
@@ -569,6 +585,8 @@ func main() {
 
 	deps := api.Dependencies{
 		Config:                       cfg,
+		LiveConfig:                   configWatcher.Config,
+		OnConfigChange:               configWatcher.OnChange,
 		BootstrapSensitiveConfigured: bootstrapSensitiveConfigured,
 		BootstrapSensitiveValues:     bootstrapSensitiveValues,
 		AppContext:                   appCtx,
@@ -588,6 +606,12 @@ func main() {
 			}
 			restartReqCh <- struct{}{}
 			return nil
+		},
+		OnServerSettingUpdated: func(_ context.Context, _, _ string) {
+			// Nudge the hot-reload watcher so same-process settings changes
+			// apply immediately even without Redis (the event bus is a no-op
+			// then, leaving only the 60s poll).
+			configWatcher.RequestReload()
 		},
 	}
 	audiobooksService := audiobooks.New(&audiobooksSettingsAdapter{repo: settingsRepo})
@@ -1896,6 +1920,7 @@ func main() {
 	if (mode == "integrated" || mode == "api") && cfg.JellyfinCompat.Listen != "" {
 		compatDeps := jellycompat.Dependencies{
 			Config:           cfg,
+			LiveConfig:       configWatcher.Config,
 			DB:               deps.DB,
 			SecretCipher:     dataCipher,
 			ClientIPResolver: ipResolver,

--- a/cmd/silo/main.go
+++ b/cmd/silo/main.go
@@ -512,6 +512,7 @@ func main() {
 			Mode:        cfg.Server.Mode,
 			DatabaseURL: cfg.Database.URL,
 			JFListen:    cfg.JellyfinCompat.Listen,
+			RedisURL:    bc.RedisURL,
 		}
 		watcher := nodeconfig.NewWatcher(pool, dataCipher, eventBus, bootstrap)
 		if err := watcher.Start(appCtx); err != nil {

--- a/cmd/silo/main.go
+++ b/cmd/silo/main.go
@@ -1668,6 +1668,9 @@ func main() {
 			cfg.Auth.AccessTokenExpiry,
 			cfg.Auth.RefreshTokenExpiry,
 		)
+		configWatcher.OnChange(func(_, updated *config.Config) {
+			absJWTService.SetExpiries(updated.Auth.AccessTokenExpiry, updated.Auth.RefreshTokenExpiry)
+		})
 		absAuthSvc := auth.NewService(
 			auth.NewLocalProvider(absUserRepo, absSessionRepo),
 			absJWTService,
@@ -2000,6 +2003,9 @@ func main() {
 				cfg.Auth.AccessTokenExpiry,
 				cfg.Auth.RefreshTokenExpiry,
 			)
+			configWatcher.OnChange(func(_, updated *config.Config) {
+				jwtService.SetExpiries(updated.Auth.AccessTokenExpiry, updated.Auth.RefreshTokenExpiry)
+			})
 			provider := auth.NewLocalProvider(userRepo, sessionRepo)
 			compatDeps.AuthService = auth.NewService(provider, jwtService, sessionRepo, userRepo, nil, nil, nil)
 

--- a/cmd/silo/main.go
+++ b/cmd/silo/main.go
@@ -120,12 +120,25 @@ func resolvePluginCacheDir() string {
 	return filepath.Join(os.TempDir(), "silo-plugins")
 }
 
-func buildBaseHandler(format string, level slog.Level) slog.Handler {
+func buildBaseHandler(format string, level slog.Leveler) slog.Handler {
 	opts := &slog.HandlerOptions{Level: level}
 	if strings.EqualFold(format, "json") {
 		return slog.NewJSONHandler(os.Stderr, opts)
 	}
 	return slog.NewTextHandler(os.Stderr, opts)
+}
+
+func parseLogLevel(level string) slog.Level {
+	switch strings.ToLower(level) {
+	case "debug":
+		return slog.LevelDebug
+	case "warn", "warning":
+		return slog.LevelWarn
+	case "error":
+		return slog.LevelError
+	default:
+		return slog.LevelInfo
+	}
 }
 
 func mustGetSetting(store interface {
@@ -144,8 +157,7 @@ func configureOperationalLogging(
 	settingsRepo catalog.SettingsStore,
 	redisCfg config.RedisConfig,
 	logStreamHub *logstream.Hub,
-	baseHandler slog.Handler,
-	logQuiet string,
+	filteredHandler slog.Handler,
 	nodeID string,
 ) (opslog.Writer, *opslog.Repo, *partman.Manager) {
 	if err := opslog.SeedDefaults(ctx, settingsRepo); err != nil {
@@ -182,7 +194,6 @@ func configureOperationalLogging(
 		opsCaptureLevel = slog.LevelError
 	}
 
-	filteredHandler := logfilter.New(baseHandler, logQuiet)
 	slog.SetDefault(slog.New(opslog.NewHandler(filteredHandler, operationalWriter, opsCaptureLevel, nodeID)))
 
 	return operationalWriter, opslog.NewRepo(pool), opsPM
@@ -457,20 +468,14 @@ func main() {
 		log.Fatalf("config validation: %v", err)
 	}
 
-	// Step 10: Configure log level
-	var slogLevel slog.Level
-	switch strings.ToLower(cfg.Server.LogLevel) {
-	case "debug":
-		slogLevel = slog.LevelDebug
-	case "warn", "warning":
-		slogLevel = slog.LevelWarn
-	case "error":
-		slogLevel = slog.LevelError
-	default:
-		slogLevel = slog.LevelInfo
-	}
-	baseHandler := buildBaseHandler(cfg.Server.LogFormat, slogLevel)
-	slog.SetDefault(slog.New(logfilter.New(baseHandler, cfg.Server.LogQuiet)))
+	// Step 10: Configure log level. The level var and quiet filter are
+	// shared with the operational-logging handler chain and hot-reloaded by
+	// the config watcher in integrated mode.
+	logLevelVar := new(slog.LevelVar)
+	logLevelVar.Set(parseLogLevel(cfg.Server.LogLevel))
+	baseHandler := buildBaseHandler(cfg.Server.LogFormat, logLevelVar)
+	quietFilter := logfilter.New(baseHandler, cfg.Server.LogQuiet)
+	slog.SetDefault(slog.New(quietFilter))
 
 	mode := cfg.Server.Mode
 	maybeApplyPostgresTuning(ctx, pool, cfg.Database.MaxConnections, mode)
@@ -492,7 +497,7 @@ func main() {
 	}
 	eventsHub := realtimeHub.EventsHub()
 	scanRegistry := evt.NewScanRegistry()
-	operationalWriter, opsRepo, opsPM := configureOperationalLogging(appCtx, pool, settingsRepo, cfg.Redis, logStreamHub, baseHandler, cfg.Server.LogQuiet, nodeID)
+	operationalWriter, opsRepo, opsPM := configureOperationalLogging(appCtx, pool, settingsRepo, cfg.Redis, logStreamHub, quietFilter, nodeID)
 	defer func() {
 		if err := eventBus.Close(); err != nil {
 			slog.Warn("event bus close error", "error", err)
@@ -569,6 +574,13 @@ func main() {
 		log.Fatalf("config watcher start: %v", err)
 	}
 	cfg = configWatcher.Config()
+
+	// Apply server.log_level / server.log_quiet changes live. Both feed the
+	// shared level var and quiet filter inside the default logger chain.
+	configWatcher.OnChange(func(_, updated *config.Config) {
+		logLevelVar.Set(parseLogLevel(updated.Server.LogLevel))
+		quietFilter.SetQuiet(updated.Server.LogQuiet)
+	})
 
 	// Determine which components to initialize based on mode.
 	needsS3 := mode == "integrated" || mode == "api"

--- a/internal/ai/llm/client.go
+++ b/internal/ai/llm/client.go
@@ -16,6 +16,7 @@ import (
 	"net/http"
 	"strconv"
 	"strings"
+	"sync/atomic"
 	"time"
 )
 
@@ -56,8 +57,11 @@ func (c Config) ASRConfigured() bool { return c.asrBaseURL() != "" && c.ASRModel
 // Client is a minimal OpenAI-compatible API client with shared retry/backoff
 // conventions (429 with Retry-After, 5xx, transport errors, and gateway "200
 // with embedded error object" responses are retried; other 4xx fail fast).
+// The config is held behind an atomic pointer so admin settings changes apply
+// to subsequent requests without rebuilding the client; each request snapshots
+// the config once so its URL, key, and model stay consistent.
 type Client struct {
-	cfg Config
+	cfg atomic.Pointer[Config]
 	// chatHTTP caps a single chat completion at 10 minutes. asrHTTP has no
 	// client-level timeout: a transcription upload's deadline is set per request
 	// (sized to the chunk duration), which a client timeout would silently cap.
@@ -67,11 +71,23 @@ type Client struct {
 
 // NewClient builds a client from the endpoint config.
 func NewClient(cfg Config) *Client {
-	return &Client{
-		cfg:      cfg,
+	c := &Client{
 		chatHTTP: &http.Client{Timeout: 10 * time.Minute},
 		asrHTTP:  &http.Client{},
 	}
+	c.UpdateConfig(cfg)
+	return c
+}
+
+// UpdateConfig swaps the endpoint config. Safe for concurrent use; in-flight
+// requests finish with the config they started with.
+func (c *Client) UpdateConfig(cfg Config) {
+	c.cfg.Store(&cfg)
+}
+
+// Config returns a snapshot of the current endpoint config.
+func (c *Client) Config() Config {
+	return *c.cfg.Load()
 }
 
 // Message is one chat-completions message.
@@ -107,8 +123,9 @@ type chatCompletionResponse struct {
 // When jsonObject is true it requests response_format=json_object; providers
 // that ignore the field still work because the prompt itself demands JSON.
 func (c *Client) Chat(ctx context.Context, messages []Message, jsonObject bool) (string, error) {
+	cfg := c.Config()
 	reqBody := chatCompletionRequest{
-		Model:       c.cfg.ChatModel,
+		Model:       cfg.ChatModel,
 		Messages:    messages,
 		Temperature: 0.2,
 	}
@@ -121,7 +138,7 @@ func (c *Client) Chat(ctx context.Context, messages []Message, jsonObject bool) 
 		return "", fmt.Errorf("marshal chat request: %w", err)
 	}
 
-	url := endpointURL(c.cfg.BaseURL, "chat/completions")
+	url := endpointURL(cfg.BaseURL, "chat/completions")
 
 	var content string
 	err = c.doWithRetry(ctx, c.chatHTTP, "chat API",
@@ -131,8 +148,8 @@ func (c *Client) Chat(ctx context.Context, messages []Message, jsonObject bool) 
 				return nil, fmt.Errorf("create request: %w", reqErr)
 			}
 			httpReq.Header.Set("Content-Type", "application/json")
-			if c.cfg.APIKey != "" {
-				httpReq.Header.Set("Authorization", "Bearer "+c.cfg.APIKey)
+			if cfg.APIKey != "" {
+				httpReq.Header.Set("Authorization", "Bearer "+cfg.APIKey)
 			}
 			return httpReq, nil
 		},
@@ -147,7 +164,7 @@ func (c *Client) Chat(ctx context.Context, messages []Message, jsonObject bool) 
 			}
 			if len(parsed.Choices) == 0 || parsed.Choices[0].Message.Content == "" {
 				slog.Warn("AI chat returned no choices, retrying",
-					"model", c.cfg.ChatModel, "response_bytes", len(respBody))
+					"model", cfg.ChatModel, "response_bytes", len(respBody))
 				return fmt.Errorf("chat API returned no choices")
 			}
 			content = parsed.Choices[0].Message.Content

--- a/internal/ai/llm/transcribe.go
+++ b/internal/ai/llm/transcribe.go
@@ -142,12 +142,13 @@ func hostMatchesAny(baseURL string, hosts []string) bool {
 // configured), using the OpenAI-compatible /v1/audio/transcriptions API with
 // response_format=verbose_json for segment timestamps.
 func (c *Client) Transcribe(ctx context.Context, req TranscribeRequest) (*Transcription, error) {
-	if !c.cfg.ASRConfigured() {
+	cfg := c.Config()
+	if !cfg.ASRConfigured() {
 		return nil, fmt.Errorf("transcription endpoint is not configured")
 	}
-	if IsChatOnlyGateway(c.cfg.asrBaseURL()) {
+	if IsChatOnlyGateway(cfg.asrBaseURL()) {
 		return nil, fmt.Errorf("the configured transcription endpoint (%s) cannot produce timestamped transcriptions; "+
-			"set a Whisper-compatible Transcription base URL under Admin Settings → AI Services", c.cfg.asrBaseURL())
+			"set a Whisper-compatible Transcription base URL under Admin Settings → AI Services", cfg.asrBaseURL())
 	}
 	if len(req.Audio) == 0 {
 		return nil, fmt.Errorf("no audio data to transcribe")
@@ -160,7 +161,7 @@ func (c *Client) Transcribe(ctx context.Context, req TranscribeRequest) (*Transc
 	ctx, cancel := context.WithTimeout(ctx, timeout)
 	defer cancel()
 
-	url := endpointURL(c.cfg.asrBaseURL(), "audio/transcriptions")
+	url := endpointURL(cfg.asrBaseURL(), "audio/transcriptions")
 
 	var result *Transcription
 	doErr := c.doWithRetry(ctx, c.asrHTTP, "transcription API",
@@ -175,7 +176,7 @@ func (c *Client) Transcribe(ctx context.Context, req TranscribeRequest) (*Transc
 				return nil, fmt.Errorf("write multipart audio: %w", err)
 			}
 			fields := [][2]string{
-				{"model", c.cfg.ASRModel},
+				{"model", cfg.ASRModel},
 				{"response_format", "verbose_json"},
 				{"temperature", "0"},
 				// Word timings let cue building split paragraph-length
@@ -187,7 +188,7 @@ func (c *Client) Transcribe(ctx context.Context, req TranscribeRequest) (*Transc
 			if req.Language != "" {
 				fields = append(fields, [2]string{"language", req.Language})
 			}
-			if !hostMatchesAny(c.cfg.asrBaseURL(), strictHostedASRHosts) {
+			if !hostMatchesAny(cfg.asrBaseURL(), strictHostedASRHosts) {
 				fields = append(fields, [2]string{"vad_filter", "true"})
 			}
 			for _, f := range fields {
@@ -204,7 +205,7 @@ func (c *Client) Transcribe(ctx context.Context, req TranscribeRequest) (*Transc
 				return nil, fmt.Errorf("create request: %w", err)
 			}
 			httpReq.Header.Set("Content-Type", w.FormDataContentType())
-			if key := c.cfg.asrAPIKey(); key != "" {
+			if key := cfg.asrAPIKey(); key != "" {
 				httpReq.Header.Set("Authorization", "Bearer "+key)
 			}
 			return httpReq, nil
@@ -219,7 +220,7 @@ func (c *Client) Transcribe(ctx context.Context, req TranscribeRequest) (*Transc
 			}
 			if parsed.Segments == nil {
 				return &permanentError{err: fmt.Errorf(
-					"transcription endpoint did not return verbose_json segments (model %q); a verbose_json-capable Whisper endpoint is required", c.cfg.ASRModel)}
+					"transcription endpoint did not return verbose_json segments (model %q); a verbose_json-capable Whisper endpoint is required", cfg.ASRModel)}
 			}
 			out := &Transcription{Language: parsed.Language}
 			for _, s := range *parsed.Segments {

--- a/internal/api/handlers/admin.go
+++ b/internal/api/handlers/admin.go
@@ -27,6 +27,7 @@ import (
 	"github.com/Silo-Server/silo-server/internal/cache"
 	"github.com/Silo-Server/silo-server/internal/catalog"
 	"github.com/Silo-Server/silo-server/internal/clientip"
+	"github.com/Silo-Server/silo-server/internal/config"
 	"github.com/Silo-Server/silo-server/internal/markers"
 	"github.com/Silo-Server/silo-server/internal/models"
 	"github.com/Silo-Server/silo-server/internal/notifications"
@@ -1217,6 +1218,9 @@ func (h *AdminHandler) HandleGetSensitiveStatus(w http.ResponseWriter, r *http.R
 type adminSettingResponse struct {
 	Key   string `json:"key"`
 	Value string `json:"value"`
+	// RestartRequired reports whether the saved value only takes effect
+	// after a server restart (set on update responses only).
+	RestartRequired bool `json:"restart_required,omitempty"`
 }
 
 type adminSettingsListResponse struct {
@@ -2145,9 +2149,10 @@ func (h *AdminHandler) HandleUpdateSetting(w http.ResponseWriter, r *http.Reques
 		h.OnServerSettingUpdated(r.Context(), key, req.Value)
 	}
 
+	restartRequired := config.RestartRequired(key)
 	if sensitiveSettingKeys[key] {
-		writeJSON(w, http.StatusOK, adminSettingResponse{Key: key})
+		writeJSON(w, http.StatusOK, adminSettingResponse{Key: key, RestartRequired: restartRequired})
 		return
 	}
-	writeJSON(w, http.StatusOK, adminSettingResponse{Key: key, Value: req.Value})
+	writeJSON(w, http.StatusOK, adminSettingResponse{Key: key, Value: req.Value, RestartRequired: restartRequired})
 }

--- a/internal/api/handlers/admin_settings_checks_test.go
+++ b/internal/api/handlers/admin_settings_checks_test.go
@@ -326,6 +326,47 @@ func TestAdminUpdateSettingRedactsSensitiveSetting(t *testing.T) {
 	}
 }
 
+func TestAdminUpdateSettingReportsRestartRequired(t *testing.T) {
+	cases := []struct {
+		key             string
+		value           string
+		restartRequired bool
+	}{
+		// Infrastructure settings are captured at startup.
+		{key: "database.max_connections", value: "40", restartRequired: true},
+		{key: "s3.public_bucket", value: "assets", restartRequired: true},
+		// Branding is read live from the settings repo per request.
+		{key: "branding.server_name", value: "Casa", restartRequired: false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.key, func(t *testing.T) {
+			settings := &fakeServerSettingsStore{}
+			handler := &AdminHandler{SettingsRepo: settings}
+
+			req := httptest.NewRequest(
+				http.MethodPut,
+				"/admin/settings/"+tc.key,
+				strings.NewReader(`{"value":"`+tc.value+`"}`),
+			)
+			req = withChiParam(req, "key", tc.key)
+			rec := httptest.NewRecorder()
+
+			handler.HandleUpdateSetting(rec, req)
+
+			if rec.Code != http.StatusOK {
+				t.Fatalf("status = %d, want 200; body=%s", rec.Code, rec.Body.String())
+			}
+			var resp adminSettingResponse
+			if err := json.NewDecoder(rec.Body).Decode(&resp); err != nil {
+				t.Fatalf("decode response: %v", err)
+			}
+			if resp.RestartRequired != tc.restartRequired {
+				t.Fatalf("restart_required = %v, want %v", resp.RestartRequired, tc.restartRequired)
+			}
+		})
+	}
+}
+
 func performSettingsCheckRequest(
 	t *testing.T,
 	handler *AdminHandler,

--- a/internal/api/handlers/playback.go
+++ b/internal/api/handlers/playback.go
@@ -22,6 +22,7 @@ import (
 	apimw "github.com/Silo-Server/silo-server/internal/api/middleware"
 	"github.com/Silo-Server/silo-server/internal/catalog"
 	"github.com/Silo-Server/silo-server/internal/clientip"
+	"github.com/Silo-Server/silo-server/internal/config"
 	evt "github.com/Silo-Server/silo-server/internal/events"
 	"github.com/Silo-Server/silo-server/internal/markers"
 	"github.com/Silo-Server/silo-server/internal/models"
@@ -129,11 +130,12 @@ type PlaybackHandler struct {
 	RealtimeHub             *playback.RealtimeHub
 	CommandTracker          *playback.CommandTracker
 	CommandDispatcher       *playback.CommandDispatcher
-	FFmpegPath              string
-	HWAccel                 string
-	HWDevice                string
-	TranscodeDir            string
-	FFmpegLogSink           playback.FFmpegLogSink
+	// PlaybackConfig returns the current playback config (ffmpeg path,
+	// hwaccel, transcode dir). Wired to the live config in integrated mode
+	// so admin changes apply to newly started transcodes. Read it through
+	// playbackConfig(), which falls back to defaults when unset.
+	PlaybackConfig func() config.PlaybackConfig
+	FFmpegLogSink  playback.FFmpegLogSink
 	transcodeMu             sync.RWMutex
 	transcodes              map[string]*playback.TranscodeSession
 	realtimeCommandMu       sync.Mutex
@@ -156,7 +158,6 @@ type sessionExpirationHookSetter interface {
 func NewPlaybackHandler(sessionMgr SessionManagerInterface, opts ...FilePathResolver) *PlaybackHandler {
 	h := &PlaybackHandler{
 		sessionMgr:       sessionMgr,
-		TranscodeDir:     filepath.Join(os.TempDir(), "silo-transcode"),
 		transcodes:       make(map[string]*playback.TranscodeSession),
 		realtimeCommands: make(map[string]playbackCommandRecord),
 	}
@@ -179,6 +180,15 @@ func (h *PlaybackHandler) SetProfileRefreshRequester(requester ProfileRefreshReq
 	h.profileRefreshRequester = requester
 }
 
+// playbackConfig returns the current playback config, falling back to the
+// default transcode dir when no provider is wired (tests, minimal setups).
+func (h *PlaybackHandler) playbackConfig() config.PlaybackConfig {
+	if h.PlaybackConfig != nil {
+		return h.PlaybackConfig()
+	}
+	return config.PlaybackConfig{TranscodeDir: filepath.Join(os.TempDir(), "silo-transcode")}
+}
+
 // CleanupOrphanedTranscodes removes stale per-session temp directories for
 // transcodes that are no longer tracked in memory.
 func (h *PlaybackHandler) CleanupOrphanedTranscodes() (int, error) {
@@ -189,7 +199,7 @@ func (h *PlaybackHandler) CleanupOrphanedTranscodes() (int, error) {
 	}
 	h.transcodeMu.RUnlock()
 
-	return playback.CleanupOrphanedTranscodeDirs(h.TranscodeDir, active)
+	return playback.CleanupOrphanedTranscodeDirs(h.playbackConfig().TranscodeDir, active)
 }
 
 // playbackThresholds reads the playback.watched_threshold and
@@ -2064,7 +2074,7 @@ func (h *PlaybackHandler) HandleStartTranscode(w http.ResponseWriter, r *http.Re
 			TargetCodecAudio:   req.TargetCodecAudio,
 			TargetBitrateKbps:  req.TargetBitrateKbps,
 			SegmentDuration:    req.SegmentDuration,
-			HWAccel:            h.HWAccel,
+			HWAccel:            h.playbackConfig().HWAccel,
 			AudioTrackIndex:    session.AudioTrackIndex,
 			SubtitleTrackIndex: req.SubtitleTrackIndex,
 			SubtitleBurnIn:     req.SubtitleBurnIn,
@@ -2130,14 +2140,17 @@ func (h *PlaybackHandler) HandleStartTranscode(w http.ResponseWriter, r *http.Re
 			"No transcode node is available and local transcode fallback is disabled")
 		return
 	}
-	if err := os.MkdirAll(h.TranscodeDir, 0o755); err != nil {
+	// Snapshot once so the directory, ffmpeg path, and hwaccel of this
+	// session stay consistent even if the config reloads mid-start.
+	playbackCfg := h.playbackConfig()
+	if err := os.MkdirAll(playbackCfg.TranscodeDir, 0o755); err != nil {
 		writeError(w, http.StatusInternalServerError, "internal_error", "Failed to prepare transcode directory")
 		return
 	}
 
 	transcodeSession, err := playback.StartTranscode(context.WithoutCancel(r.Context()), playback.TranscodeOpts{
 		InputPath:          file.FilePath,
-		OutputDir:          filepath.Join(h.TranscodeDir, req.SessionID),
+		OutputDir:          filepath.Join(playbackCfg.TranscodeDir, req.SessionID),
 		SessionID:          req.SessionID,
 		SourceVideoCodec:   file.CodecVideo,
 		SeekSeconds:        req.SeekSeconds,
@@ -2147,9 +2160,9 @@ func (h *PlaybackHandler) HandleStartTranscode(w http.ResponseWriter, r *http.Re
 		TargetCodecAudio:   req.TargetCodecAudio,
 		TargetBitrateKbps:  req.TargetBitrateKbps,
 		SegmentDuration:    req.SegmentDuration,
-		FFmpegPath:         h.FFmpegPath,
-		HWAccel:            h.HWAccel,
-		HWDevice:           h.HWDevice,
+		FFmpegPath:         playbackCfg.FFmpegPath,
+		HWAccel:            playbackCfg.HWAccel,
+		HWDevice:           playbackCfg.HWDevice,
 		AudioTrackIndex:    session.AudioTrackIndex,
 		SubtitleTrackIndex: req.SubtitleTrackIndex,
 		SubtitleBurnIn:     req.SubtitleBurnIn,

--- a/internal/api/handlers/playback.go
+++ b/internal/api/handlers/playback.go
@@ -181,12 +181,16 @@ func (h *PlaybackHandler) SetProfileRefreshRequester(requester ProfileRefreshReq
 }
 
 // playbackConfig returns the current playback config, falling back to the
-// default transcode dir when no provider is wired (tests, minimal setups).
+// same defaults as config loading (transcode enabled, temp transcode dir)
+// when no provider is wired (tests, minimal setups).
 func (h *PlaybackHandler) playbackConfig() config.PlaybackConfig {
 	if h.PlaybackConfig != nil {
 		return h.PlaybackConfig()
 	}
-	return config.PlaybackConfig{TranscodeDir: filepath.Join(os.TempDir(), "silo-transcode")}
+	return config.PlaybackConfig{
+		TranscodeEnabled: true,
+		TranscodeDir:     filepath.Join(os.TempDir(), "silo-transcode"),
+	}
 }
 
 // CleanupOrphanedTranscodes removes stale per-session temp directories for
@@ -624,9 +628,9 @@ func normalizeAudioTrackIndex(file *models.MediaFile, audioTrackIndex int) int {
 	return directPlayAudioTrackIndex(file)
 }
 
-func playbackAdminSettingsFromRequest(ctx context.Context, repo PlaybackSettingsReader) playback.AdminSettings {
+func playbackAdminSettingsFromRequest(ctx context.Context, repo PlaybackSettingsReader, transcodeEnabled bool) playback.AdminSettings {
 	settings := playback.AdminSettings{
-		TranscodeEnabled: true,
+		TranscodeEnabled: transcodeEnabled,
 	}
 	if repo != nil {
 		if v, _ := repo.Get(ctx, "allow_4k_transcode"); v == "true" {
@@ -671,7 +675,7 @@ func (h *PlaybackHandler) resolveCapabilityPlaybackSelection(
 	}
 
 	audioTrackIndex = normalizeAudioTrackIndex(requestedFile, audioTrackIndex)
-	adminSettings := playbackAdminSettingsFromRequest(ctx, h.SettingsRepo)
+	adminSettings := playbackAdminSettingsFromRequest(ctx, h.SettingsRepo, h.playbackConfig().TranscodeEnabled)
 	method, transcodeAudio := resolvePlaybackMethodForFile(requestedFile, req, audioTrackIndex, adminSettings)
 
 	if requestedFile.Resolution == "2160p" &&

--- a/internal/api/handlers/playback_test.go
+++ b/internal/api/handlers/playback_test.go
@@ -18,6 +18,7 @@ import (
 	apimw "github.com/Silo-Server/silo-server/internal/api/middleware"
 	"github.com/Silo-Server/silo-server/internal/auth"
 	"github.com/Silo-Server/silo-server/internal/catalog"
+	"github.com/Silo-Server/silo-server/internal/config"
 	"github.com/Silo-Server/silo-server/internal/models"
 	"github.com/Silo-Server/silo-server/internal/nodepool"
 	"github.com/Silo-Server/silo-server/internal/playback"
@@ -180,6 +181,12 @@ func writePlaybackTestFFmpeg(t *testing.T) string {
 		t.Fatalf("write fake ffmpeg: %v", err)
 	}
 	return path
+}
+
+func playbackTestConfig(ffmpegPath, transcodeDir string) func() config.PlaybackConfig {
+	return func() config.PlaybackConfig {
+		return config.PlaybackConfig{FFmpegPath: ffmpegPath, TranscodeDir: transcodeDir}
+	}
 }
 
 func writePlaybackTestMediaFile(t *testing.T, name string) string {
@@ -1173,8 +1180,7 @@ func TestHandleStartTranscode_LocalPathPropagatesSelectedAudioTrack(t *testing.T
 
 	handler := NewPlaybackHandler(sessionMgr, testPlaybackFileResolver{file: file})
 	handler.ItemAccess = allowAllPlaybackItemAccess{}
-	handler.FFmpegPath = writePlaybackTestFFmpeg(t)
-	handler.TranscodeDir = t.TempDir()
+	handler.PlaybackConfig = playbackTestConfig(writePlaybackTestFFmpeg(t), t.TempDir())
 
 	req := httptest.NewRequest("POST", "/api/v1/playback/start", strings.NewReader(`{"file_id":42,"profile_id":"profile-1","audio_track_index":1,"codecs_video":["h264"],"codecs_audio":["aac"],"containers":["mp4"],"max_resolution":"2160p","hdr":false}`))
 	req = req.WithContext(newAuthorizedPlaybackContext())
@@ -1239,8 +1245,7 @@ func TestHandleStartTranscode_MPEG2SeekedCopyRemainsCopyVideo(t *testing.T) {
 
 	handler := NewPlaybackHandler(sessionMgr, testPlaybackFileResolver{file: file})
 	handler.ItemAccess = allowAllPlaybackItemAccess{}
-	handler.FFmpegPath = writePlaybackTestFFmpeg(t)
-	handler.TranscodeDir = t.TempDir()
+	handler.PlaybackConfig = playbackTestConfig(writePlaybackTestFFmpeg(t), t.TempDir())
 
 	transcodeReq := httptest.NewRequest(
 		"POST",
@@ -1403,7 +1408,7 @@ func TestHandleStartTranscode_KeepsSessionWhenStartupFailsForNonMissingReason(t 
 	handler.ItemAccess = allowAllPlaybackItemAccess{}
 	handler.SessionSyncer = syncer
 	handler.AdminStore = adminStore
-	handler.TranscodeDir = writePlaybackTestMediaFile(t, "occupied-transcode-dir")
+	handler.PlaybackConfig = playbackTestConfig("", writePlaybackTestMediaFile(t, "occupied-transcode-dir"))
 
 	startReq := httptest.NewRequest("POST", "/api/v1/playback/start", strings.NewReader(`{"file_id":42,"profile_id":"profile-1","codecs_video":["h264"],"codecs_audio":["aac"],"containers":["mp4"],"max_resolution":"2160p","hdr":false}`))
 	startReq = startReq.WithContext(newAuthorizedPlaybackContext())

--- a/internal/api/handlers/playback_test.go
+++ b/internal/api/handlers/playback_test.go
@@ -185,7 +185,11 @@ func writePlaybackTestFFmpeg(t *testing.T) string {
 
 func playbackTestConfig(ffmpegPath, transcodeDir string) func() config.PlaybackConfig {
 	return func() config.PlaybackConfig {
-		return config.PlaybackConfig{FFmpegPath: ffmpegPath, TranscodeDir: transcodeDir}
+		return config.PlaybackConfig{
+			FFmpegPath:       ffmpegPath,
+			TranscodeDir:     transcodeDir,
+			TranscodeEnabled: true,
+		}
 	}
 }
 

--- a/internal/api/handlers/stream.go
+++ b/internal/api/handlers/stream.go
@@ -12,6 +12,7 @@ import (
 	"github.com/go-chi/chi/v5"
 
 	apimw "github.com/Silo-Server/silo-server/internal/api/middleware"
+	"github.com/Silo-Server/silo-server/internal/config"
 	evt "github.com/Silo-Server/silo-server/internal/events"
 	"github.com/Silo-Server/silo-server/internal/models"
 	"github.com/Silo-Server/silo-server/internal/playback"
@@ -31,10 +32,20 @@ type StreamHandler struct {
 	EventsHub     *evt.Hub
 	AdminStore    PlaybackAdminStore
 	SessionSyncer PlaybackSessionSyncer
-	FFmpegPath    string
-	SubtitleRepo  subtitles.Repository // optional; enables S3-sourced subtitles
-	S3Client      subtitles.S3Client   // optional; needed for fetching S3 subtitles
-	S3Bucket      string               // bucket for subtitle storage
+	// PlaybackConfig returns the current playback config; read it through
+	// ffmpegPath(). May be nil (tests).
+	PlaybackConfig func() config.PlaybackConfig
+	SubtitleRepo   subtitles.Repository // optional; enables S3-sourced subtitles
+	S3Client       subtitles.S3Client   // optional; needed for fetching S3 subtitles
+	S3Bucket       string               // bucket for subtitle storage
+}
+
+// ffmpegPath returns the currently configured ffmpeg binary path.
+func (h *StreamHandler) ffmpegPath() string {
+	if h.PlaybackConfig != nil {
+		return h.PlaybackConfig().FFmpegPath
+	}
+	return ""
 }
 
 // NewStreamHandler creates a new StreamHandler backed by the given session
@@ -193,7 +204,7 @@ func (h *StreamHandler) HandleSubtitle(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 
-		vttData, err := playback.LoadExternalSubtitleAsVTT(r.Context(), sub.Path, sub.Format, h.FFmpegPath)
+		vttData, err := playback.LoadExternalSubtitleAsVTT(r.Context(), sub.Path, sub.Format, h.ffmpegPath())
 		if err != nil {
 			writeError(w, http.StatusInternalServerError, "internal_error",
 				"Failed to load external subtitle")
@@ -324,7 +335,7 @@ func (h *StreamHandler) HandleSubtitleFonts(w http.ResponseWriter, r *http.Reque
 		return
 	}
 
-	fonts, err := playback.ExtractAttachedSubtitleFonts(r.Context(), file.FilePath, h.FFmpegPath)
+	fonts, err := playback.ExtractAttachedSubtitleFonts(r.Context(), file.FilePath, h.ffmpegPath())
 	if err != nil {
 		slog.WarnContext(r.Context(), "subtitle font extraction failed",
 			"file_id", file.ID,
@@ -437,7 +448,7 @@ func (h *StreamHandler) streamEmbeddedSubtitle(w http.ResponseWriter, r *http.Re
 		SourceCodec:     track.Codec,
 		SeekSeconds:     seek,
 		DurationSeconds: duration,
-		FFmpegPath:      h.FFmpegPath,
+		FFmpegPath:      h.ffmpegPath(),
 		Writer:          w,
 	})
 	if err != nil {

--- a/internal/api/router.go
+++ b/internal/api/router.go
@@ -939,58 +939,40 @@ func NewRouter(deps Dependencies) chi.Router {
 	// the existing subtitle pipeline with no client changes.
 	// Shared AI endpoint client + dispatch semaphore: subtitle translation/ASR
 	// and metadata translation draw from one client and one concurrency bound.
+	// Connection settings, models, toggles, and quotas hot-reload through
+	// OnConfigChange; only the semaphore size (ai.max_concurrent_jobs) is
+	// fixed at construction.
 	var aiClient *llm.Client
 	var aiSem chan struct{}
 	if deps.Config != nil {
-		aiClient = llm.NewClient(llm.Config{
-			BaseURL:    deps.Config.AI.BaseURL,
-			APIKey:     deps.Config.AI.APIKey,
-			ChatModel:  deps.Config.AI.ChatModel,
-			ASRBaseURL: deps.Config.AI.ASRBaseURL,
-			ASRAPIKey:  deps.Config.AI.ASRAPIKey,
-			ASRModel:   deps.Config.AI.ASRModel,
-		})
+		aiClient = llm.NewClient(llmConfigFromServer(deps.Config))
 		aiSem = jobrunner.NewSemaphore(deps.Config.AI.MaxConcurrentJobs)
+		if deps.OnConfigChange != nil {
+			clientForReload := aiClient
+			deps.OnConfigChange(func(_, updated *config.Config) {
+				clientForReload.UpdateConfig(llmConfigFromServer(updated))
+			})
+		}
 	}
 
 	var subtitleAIHandler *handlers.SubtitleAIHandler
 	if subtitleManager != nil && subtitleRepo != nil && deps.FileRepo != nil && deps.DB != nil && deps.Config != nil {
-		// A chat-only gateway (e.g. OpenRouter) cannot produce timestamped
-		// transcriptions; disable ASR rather than let every job fail. The
-		// settings API rejects such values for the ASR URL, but the chat base
-		// URL legitimately may be one — this catches the blank-ASR-URL
-		// fallback case.
-		transcribeEnabled := deps.Config.SubtitleAI.TranscribeEnabled
-		effectiveASRBase := deps.Config.AI.ASRBaseURL
-		if effectiveASRBase == "" {
-			effectiveASRBase = deps.Config.AI.BaseURL
-		}
-		if transcribeEnabled && llm.IsChatOnlyGateway(effectiveASRBase) {
-			slog.Warn("subtitle transcription disabled: the effective transcription endpoint is a chat-only gateway; "+
-				"set a Whisper-compatible Transcription base URL in AI Services", "endpoint", effectiveASRBase)
-			transcribeEnabled = false
-		}
-		aiCfg := subtitleai.Config{
-			Configured:            deps.Config.AI.BaseURL != "",
-			TranslateEnabled:      deps.Config.SubtitleAI.Enabled,
-			TranscribeEnabled:     transcribeEnabled,
-			ChatModel:             deps.Config.AI.ChatModel,
-			ASRModel:              deps.Config.AI.ASRModel,
-			BatchSize:             deps.Config.SubtitleAI.BatchSize,
-			ContextNeighbors:      deps.Config.SubtitleAI.ContextNeighbors,
-			TranscribeQuotaJobs:   deps.Config.SubtitleAI.TranscribeQuotaJobs,
-			TranscribeQuotaPeriod: deps.Config.SubtitleAI.TranscribeQuotaPeriod,
+		aiCfg, disabledGateway := effectiveSubtitleAIConfig(deps.Config)
+		if disabledGateway != "" {
+			warnChatOnlyGateway(disabledGateway)
 		}
 		var aiNotifier subtitleai.Notifier
 		if subtitleAINotifier != nil {
 			aiNotifier = subtitleAINotifier
 		}
+		aiTranslator := subtitleai.NewLLMTranslator(aiClient, aiCfg.BatchSize, aiCfg.ContextNeighbors)
+		aiTranscriber := subtitleai.NewWhisperTranscriber(aiClient, deps.Config.Playback.FFmpegPath, deps.Config.SubtitleAI.ASRChunkSeconds)
 		aiService := subtitleai.NewService(
 			deps.AppContext,
 			aiCfg,
 			subtitleai.NewPgJobRepository(deps.DB),
-			subtitleai.NewLLMTranslator(aiClient, aiCfg.BatchSize, aiCfg.ContextNeighbors),
-			subtitleai.NewWhisperTranscriber(aiClient, deps.Config.Playback.FFmpegPath, deps.Config.SubtitleAI.ASRChunkSeconds),
+			aiTranslator,
+			aiTranscriber,
 			subtitleManager,
 			subtitleRepo,
 			deps.FileRepo,
@@ -1000,6 +982,21 @@ func NewRouter(deps Dependencies) chi.Router {
 			aiSem,
 		)
 		aiService.Recover()
+		if deps.OnConfigChange != nil {
+			deps.OnConfigChange(func(old, updated *config.Config) {
+				newCfg, newDisabled := effectiveSubtitleAIConfig(updated)
+				aiService.UpdateConfig(newCfg)
+				aiTranslator.SetBatching(updated.SubtitleAI.BatchSize, updated.SubtitleAI.ContextNeighbors)
+				aiTranscriber.SetExtraction(updated.Playback.FFmpegPath, updated.SubtitleAI.ASRChunkSeconds)
+				// Warn only when the gateway-disable condition newly appears,
+				// not on every unrelated settings change.
+				if newDisabled != "" && old != nil {
+					if _, oldDisabled := effectiveSubtitleAIConfig(old); oldDisabled == "" {
+						warnChatOnlyGateway(newDisabled)
+					}
+				}
+			})
+		}
 		subtitleAIHandler = handlers.NewSubtitleAIHandler(aiService)
 		subtitleAIHandler.StoreProvider = deps.UserStoreProvider
 	}
@@ -1010,12 +1007,7 @@ func NewRouter(deps Dependencies) chi.Router {
 		mtRepo := metadatatranslation.NewPgRepository(deps.DB)
 		mtService := metadatatranslation.NewService(
 			deps.AppContext,
-			metadatatranslation.Config{
-				Enabled:    deps.Config.MetadataAI.Enabled,
-				Configured: deps.Config.AI.BaseURL != "",
-				ChatModel:  deps.Config.AI.ChatModel,
-				OnView:     deps.Config.MetadataAI.OnView,
-			},
+			metadataAIConfigFromServer(deps.Config),
 			mtRepo,
 			mtRepo,
 			&metadatatranslation.CatalogLocalizationStore{
@@ -1028,6 +1020,11 @@ func NewRouter(deps Dependencies) chi.Router {
 			slog.Default(),
 		)
 		mtService.Recover()
+		if deps.OnConfigChange != nil {
+			deps.OnConfigChange(func(_, updated *config.Config) {
+				mtService.UpdateConfig(metadataAIConfigFromServer(updated))
+			})
+		}
 		metadataAIHandler = handlers.NewMetadataAIHandler(mtService)
 		// Wire the refresh fallback: libraries with auto_translate_metadata get
 		// missing localizations filled after each metadata refresh.
@@ -2685,4 +2682,64 @@ func (a *traktCollectionAdapter) GetCollectionPreset(ctx context.Context, preset
 		}
 	}
 	return entries, nil
+}
+
+// llmConfigFromServer derives the shared AI client config from the server
+// config. Used at construction and again on every config reload.
+func llmConfigFromServer(cfg *config.Config) llm.Config {
+	return llm.Config{
+		BaseURL:    cfg.AI.BaseURL,
+		APIKey:     cfg.AI.APIKey,
+		ChatModel:  cfg.AI.ChatModel,
+		ASRBaseURL: cfg.AI.ASRBaseURL,
+		ASRAPIKey:  cfg.AI.ASRAPIKey,
+		ASRModel:   cfg.AI.ASRModel,
+	}
+}
+
+// effectiveSubtitleAIConfig derives the subtitle AI service config from the
+// server config. A chat-only gateway (e.g. OpenRouter) cannot produce
+// timestamped transcriptions, so transcription is disabled rather than
+// letting every job fail; the settings API rejects such values for the ASR
+// URL, but the chat base URL legitimately may be one — this catches the
+// blank-ASR-URL fallback case. The second return is the offending endpoint
+// when that guard fired, empty otherwise.
+func effectiveSubtitleAIConfig(cfg *config.Config) (subtitleai.Config, string) {
+	transcribeEnabled := cfg.SubtitleAI.TranscribeEnabled
+	effectiveASRBase := cfg.AI.ASRBaseURL
+	if effectiveASRBase == "" {
+		effectiveASRBase = cfg.AI.BaseURL
+	}
+	disabledGateway := ""
+	if transcribeEnabled && llm.IsChatOnlyGateway(effectiveASRBase) {
+		transcribeEnabled = false
+		disabledGateway = effectiveASRBase
+	}
+	return subtitleai.Config{
+		Configured:            cfg.AI.BaseURL != "",
+		TranslateEnabled:      cfg.SubtitleAI.Enabled,
+		TranscribeEnabled:     transcribeEnabled,
+		ChatModel:             cfg.AI.ChatModel,
+		ASRModel:              cfg.AI.ASRModel,
+		BatchSize:             cfg.SubtitleAI.BatchSize,
+		ContextNeighbors:      cfg.SubtitleAI.ContextNeighbors,
+		TranscribeQuotaJobs:   cfg.SubtitleAI.TranscribeQuotaJobs,
+		TranscribeQuotaPeriod: cfg.SubtitleAI.TranscribeQuotaPeriod,
+	}, disabledGateway
+}
+
+func warnChatOnlyGateway(endpoint string) {
+	slog.Warn("subtitle transcription disabled: the effective transcription endpoint is a chat-only gateway; "+
+		"set a Whisper-compatible Transcription base URL in AI Services", "endpoint", endpoint)
+}
+
+// metadataAIConfigFromServer derives the metadata translation service config
+// from the server config. Used at construction and on every config reload.
+func metadataAIConfigFromServer(cfg *config.Config) metadatatranslation.Config {
+	return metadatatranslation.Config{
+		Enabled:    cfg.MetadataAI.Enabled,
+		Configured: cfg.AI.BaseURL != "",
+		ChatModel:  cfg.AI.ChatModel,
+		OnView:     cfg.MetadataAI.OnView,
+	}
 }

--- a/internal/api/router.go
+++ b/internal/api/router.go
@@ -279,6 +279,12 @@ func NewRouter(deps Dependencies) chi.Router {
 			deps.Config.Auth.AccessTokenExpiry,
 			deps.Config.Auth.RefreshTokenExpiry,
 		)
+		if deps.OnConfigChange != nil {
+			jwtForReload := jwtService
+			deps.OnConfigChange(func(_, updated *config.Config) {
+				jwtForReload.SetExpiries(updated.Auth.AccessTokenExpiry, updated.Auth.RefreshTokenExpiry)
+			})
+		}
 		provider := auth.NewLocalProvider(userRepo, sessionRepo)
 		authService = auth.NewService(
 			provider,

--- a/internal/api/router.go
+++ b/internal/api/router.go
@@ -73,7 +73,13 @@ import (
 
 // Dependencies holds all shared dependencies that handlers need.
 type Dependencies struct {
-	Config                       *config.Config
+	Config *config.Config
+	// LiveConfig returns the current hot-reloaded config. May be nil (tests,
+	// worker modes); read through CurrentConfig(), which falls back to Config.
+	LiveConfig func() *config.Config
+	// OnConfigChange registers a callback fired after a live config reload
+	// actually changes the config. May be nil when hot reload is not wired.
+	OnConfigChange               func(fn func(old, updated *config.Config))
 	BootstrapSensitiveConfigured map[string]bool
 	BootstrapSensitiveValues     map[string]string
 	AppContext                   context.Context
@@ -175,6 +181,17 @@ type Dependencies struct {
 // Using an interface avoids a direct import of the abs sub-package from router.go.
 type absHandler interface {
 	Mount(r chi.Router)
+}
+
+// CurrentConfig returns the live config when hot reload is wired, falling
+// back to the startup snapshot otherwise.
+func (d *Dependencies) CurrentConfig() *config.Config {
+	if d.LiveConfig != nil {
+		if cfg := d.LiveConfig(); cfg != nil {
+			return cfg
+		}
+	}
+	return d.Config
 }
 
 // NewRouter creates a chi.Router with all middleware and routes mounted

--- a/internal/api/router.go
+++ b/internal/api/router.go
@@ -686,13 +686,13 @@ func NewRouter(deps Dependencies) chi.Router {
 			playbackHandler.JWTSecret = deps.Config.Auth.JWTSecret
 		}
 		if deps.Config != nil {
-			playbackHandler.FFmpegPath = deps.Config.Playback.FFmpegPath
-			playbackHandler.HWAccel = deps.Config.Playback.HWAccel
-			playbackHandler.TranscodeDir = deps.Config.Playback.TranscodeDir
+			playbackHandler.PlaybackConfig = func() config.PlaybackConfig {
+				return deps.CurrentConfig().Playback
+			}
 			if cleaned, err := playbackHandler.CleanupOrphanedTranscodes(); err != nil {
-				slog.Warn("playback transcode cleanup failed", "dir", playbackHandler.TranscodeDir, "error", err)
+				slog.Warn("playback transcode cleanup failed", "dir", deps.Config.Playback.TranscodeDir, "error", err)
 			} else if cleaned > 0 {
-				slog.Info("playback transcode cleanup removed orphaned dirs", "dir", playbackHandler.TranscodeDir, "count", cleaned)
+				slog.Info("playback transcode cleanup removed orphaned dirs", "dir", deps.Config.Playback.TranscodeDir, "count", cleaned)
 			}
 		}
 		playbackHandler.ProbeEnsurer = deps.ProbeEnsurer
@@ -755,7 +755,9 @@ func NewRouter(deps Dependencies) chi.Router {
 		streamHandler.S3Bucket = deps.S3Public.Bucket()
 	}
 	if streamHandler != nil && deps.Config != nil {
-		streamHandler.FFmpegPath = deps.Config.Playback.FFmpegPath
+		streamHandler.PlaybackConfig = func() config.PlaybackConfig {
+			return deps.CurrentConfig().Playback
+		}
 	}
 
 	serverControlHandler := handlers.NewServerControlHandler(deps.RequestServerRestart, playbackCommandDispatcher)

--- a/internal/auth/jwt.go
+++ b/internal/auth/jwt.go
@@ -3,6 +3,7 @@ package auth
 import (
 	"errors"
 	"fmt"
+	"sync/atomic"
 	"time"
 
 	"github.com/golang-jwt/jwt/v5"
@@ -36,29 +37,37 @@ const (
 const PluginAccessCookieName = "silo_plugin_access"
 
 // JWTService handles JWT token generation and validation using HMAC-SHA256.
+// The expiry durations are atomics so they can be hot-reloaded from admin
+// settings while tokens are being generated; the secret is fixed for the
+// service lifetime (changing it would invalidate every outstanding token).
 type JWTService struct {
 	secret        []byte
-	accessExpiry  time.Duration
-	refreshExpiry time.Duration
+	accessExpiry  atomic.Int64 // nanoseconds
+	refreshExpiry atomic.Int64 // nanoseconds
 }
 
 // NewJWTService creates a new JWTService with the given secret and expiry durations.
 func NewJWTService(secret string, accessExpiry, refreshExpiry time.Duration) *JWTService {
-	return &JWTService{
-		secret:        []byte(secret),
-		accessExpiry:  accessExpiry,
-		refreshExpiry: refreshExpiry,
-	}
+	j := &JWTService{secret: []byte(secret)}
+	j.SetExpiries(accessExpiry, refreshExpiry)
+	return j
+}
+
+// SetExpiries updates the token expiry durations. Safe for concurrent use;
+// applies to tokens generated afterwards.
+func (j *JWTService) SetExpiries(access, refresh time.Duration) {
+	j.accessExpiry.Store(int64(access))
+	j.refreshExpiry.Store(int64(refresh))
 }
 
 // AccessExpiry returns the configured access token expiry duration.
 func (j *JWTService) AccessExpiry() time.Duration {
-	return j.accessExpiry
+	return time.Duration(j.accessExpiry.Load())
 }
 
 // RefreshExpiry returns the configured refresh token expiry duration.
 func (j *JWTService) RefreshExpiry() time.Duration {
-	return j.refreshExpiry
+	return time.Duration(j.refreshExpiry.Load())
 }
 
 // GenerateAccessToken creates a signed JWT access token with the configured
@@ -93,11 +102,11 @@ func (j *JWTService) GeneratePluginAccessToken(userID int, role, sessionID strin
 }
 
 func (j *JWTService) generateAccessToken(claims Claims) (string, error) {
-	return j.generateToken(claims, TokenTypeAccess, j.accessExpiry)
+	return j.generateToken(claims, TokenTypeAccess, j.AccessExpiry())
 }
 
 func (j *JWTService) generateRefreshToken(claims Claims) (string, error) {
-	return j.generateToken(claims, TokenTypeRefresh, j.refreshExpiry)
+	return j.generateToken(claims, TokenTypeRefresh, j.RefreshExpiry())
 }
 
 // generateToken creates a signed JWT with the given claims and expiry duration.

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -127,16 +127,15 @@ type userDBConfigRaw struct {
 
 // ScannerConfig holds media scanner settings.
 type ScannerConfig struct {
-	FileRemovalGrace       time.Duration `yaml:"-"`
-	Workers                int           `yaml:"workers"`
-	MaxConcurrentLibraries int           `yaml:"max_concurrent_libraries"`
-	MaxConcurrentScoped    int           `yaml:"max_concurrent_scoped"`
-	EmptyTrashAfterScan    bool          `yaml:"-"`
+	Workers                int  `yaml:"workers"`
+	MaxConcurrentLibraries int  `yaml:"max_concurrent_libraries"`
+	MaxConcurrentScoped    int  `yaml:"max_concurrent_scoped"`
+	EmptyTrashAfterScan    bool `yaml:"-"`
 }
 
 // scannerConfigRaw is the raw YAML representation with duration strings.
 type scannerConfigRaw struct {
-	FileRemovalGrace       string `yaml:"file_removal_grace"`
+	FileRemovalGrace       string `yaml:"file_removal_grace"` // legacy; preserved on YAML import only
 	Workers                int    `yaml:"workers"`
 	MaxConcurrentLibraries int    `yaml:"max_concurrent_libraries"`
 	MaxConcurrentScoped    int    `yaml:"max_concurrent_scoped"`
@@ -165,9 +164,6 @@ type PlaybackConfig struct {
 	ChapterThumbnailExecution    string `yaml:"chapter_thumbnail_execution"`
 	ChapterThumbnailNodeCapacity int    `yaml:"chapter_thumbnail_node_capacity"`
 	TranscodeEnabled             bool   `yaml:"transcode_enabled"`
-	AllowHEVCEncoding            bool   `yaml:"allow_hevc_encoding"`
-	TranscodeAheadSegments       int    `yaml:"transcode_ahead_segments"`
-	SegmentDuration              int    `yaml:"segment_duration"`
 }
 
 // RedisConfig holds Redis connection settings.
@@ -414,7 +410,6 @@ func setDefaults() *configRaw {
 			StaleGraceSeconds: 120,
 		},
 		Scanner: scannerConfigRaw{
-			FileRemovalGrace:       "24h",
 			Workers:                8,
 			MaxConcurrentLibraries: 1,
 			MaxConcurrentScoped:    2,
@@ -432,9 +427,6 @@ func setDefaults() *configRaw {
 			ChapterThumbnailExecution:    "local",
 			ChapterThumbnailNodeCapacity: 1,
 			TranscodeEnabled:             true,
-			AllowHEVCEncoding:            false,
-			TranscodeAheadSegments:       30,
-			SegmentDuration:              6,
 		},
 		RateLimit: RateLimitConfig{
 			Enabled: true,

--- a/internal/config/db_loader.go
+++ b/internal/config/db_loader.go
@@ -253,11 +253,6 @@ func LoadFromDB(m map[string]string) (*Config, error) {
 		return nil, err
 	}
 	cfg.Scanner.MaxConcurrentScoped = maxConcurrentScoped
-	fileRemovalGrace, err := durationOr(m, "scanner.file_removal_grace", 24*time.Hour)
-	if err != nil {
-		return nil, err
-	}
-	cfg.Scanner.FileRemovalGrace = fileRemovalGrace
 	emptyTrash, err := boolOr(m, "scanner.empty_trash_after_scan", true)
 	if err != nil {
 		return nil, err
@@ -315,21 +310,6 @@ func LoadFromDB(m map[string]string) (*Config, error) {
 		return nil, err
 	}
 	cfg.Playback.TranscodeEnabled = transcodeEnabled
-	allowHEVC, err := boolOr(m, "playback.allow_hevc_encoding", false)
-	if err != nil {
-		return nil, err
-	}
-	cfg.Playback.AllowHEVCEncoding = allowHEVC
-	transcodeAheadSegments, err := intOr(m, "playback.transcode_ahead_segments", 30)
-	if err != nil {
-		return nil, err
-	}
-	cfg.Playback.TranscodeAheadSegments = transcodeAheadSegments
-	segmentDuration, err := intOr(m, "playback.segment_duration", 6)
-	if err != nil {
-		return nil, err
-	}
-	cfg.Playback.SegmentDuration = segmentDuration
 
 	// Redis
 	cfg.Redis.URL = stringOr(m, "redis.url", "")

--- a/internal/config/restart_keys.go
+++ b/internal/config/restart_keys.go
@@ -13,12 +13,11 @@ import "strings"
 // remove its key here — the admin UI restart banner is driven by this
 // registry.
 var restartRequiredKeys = map[string]bool{
-	// Process & logging.
+	// Process & logging. log_level/log_quiet hot-reload via the config
+	// watcher (shared slog.LevelVar + logfilter.SetQuiet).
 	"server.listen":        true,
 	"server.mode":          true,
 	"server.log_format":    true,
-	"server.log_level":     true, // until logging conversion lands
-	"server.log_quiet":     true, // until logging conversion lands
 	"opslog.capture_level": true,
 
 	// Auth. The JWT secret is baked into token services and stream signers;

--- a/internal/config/restart_keys.go
+++ b/internal/config/restart_keys.go
@@ -41,21 +41,17 @@ var restartRequiredKeys = map[string]bool{
 	"playback.hw_device":                 true,
 	"playback.chapter_thumbnail_workers": true,
 
-	// Scanner / matcher / metadata worker pools and toggles captured at
-	// construction.
-	"scanner.workers":                      true, // until scanner conversion lands
+	// Scanner / matcher toggles captured at construction. Worker counts,
+	// batch size, metadata.cache_images, and mdblist.api_key hot-reload via
+	// atomic setters wired to the config watcher.
 	"scanner.max_concurrent_libraries":     true,
 	"scanner.max_concurrent_scoped":        true,
 	"scanner.empty_trash_after_scan":       true,
-	"matcher.workers":                      true, // until matcher conversion lands
-	"matcher.batch_size":                   true, // until matcher conversion lands
 	"matcher.enable_tv_series_root_queue":  true,
 	"matcher.enable_tv_series_group_queue": true,
-	"metadata.cache_images":                true, // until metadata conversion lands
 
 	// External API clients built once at startup.
-	"tmdb.api_key":    true,
-	"mdblist.api_key": true, // until mdblist conversion lands
+	"tmdb.api_key": true,
 
 	// Compat listeners and session stores.
 	"audiobookshelf_compat.enabled": true,

--- a/internal/config/restart_keys.go
+++ b/internal/config/restart_keys.go
@@ -21,10 +21,8 @@ var restartRequiredKeys = map[string]bool{
 	"opslog.capture_level": true,
 
 	// Auth. The JWT secret is baked into token services and stream signers;
-	// expiries are frozen until the JWT conversion lands.
-	"auth.jwt_secret":           true,
-	"auth.access_token_expiry":  true,
-	"auth.refresh_token_expiry": true,
+	// the expiry durations hot-reload (new tokens only).
+	"auth.jwt_secret": true,
 
 	// Rate limiting gates middleware construction; tier/limit values inside
 	// the dedicated /admin/rate-limits endpoint hot-reload and report their

--- a/internal/config/restart_keys.go
+++ b/internal/config/restart_keys.go
@@ -65,29 +65,12 @@ var restartRequiredKeys = map[string]bool{
 	"jellyfin_compat.session_ttl":          true,
 	"jellyfin_compat.playback_session_ttl": true,
 
-	// AI clients and job services built once at startup (the semaphore for
-	// max_concurrent_jobs is a fixed-capacity channel). Legacy subtitle_ai.*
-	// connection aliases classify identically to their ai.* counterparts.
-	"ai.base_url":                         true,
-	"ai.api_key":                          true,
-	"ai.chat_model":                       true,
-	"ai.asr_base_url":                     true,
-	"ai.asr_api_key":                      true,
-	"ai.asr_model":                        true,
-	"ai.max_concurrent_jobs":              true,
-	"subtitle_ai.base_url":                true,
-	"subtitle_ai.api_key":                 true,
-	"subtitle_ai.chat_model":              true,
-	"subtitle_ai.max_concurrent_jobs":     true,
-	"subtitle_ai.enabled":                 true,
-	"subtitle_ai.transcribe_enabled":      true,
-	"subtitle_ai.batch_size":              true,
-	"subtitle_ai.context_neighbors":       true,
-	"subtitle_ai.asr_chunk_seconds":       true,
-	"subtitle_ai.transcribe_quota_jobs":   true,
-	"subtitle_ai.transcribe_quota_period": true,
-	"metadata_ai.enabled":                 true,
-	"metadata_ai.on_view":                 true,
+	// AI: connection settings, models, toggles, and quotas hot-reload via
+	// UpdateConfig/setters wired to the config watcher. Only the dispatch
+	// semaphore (ai.max_concurrent_jobs, plus its legacy alias) is a
+	// fixed-capacity channel sized at construction.
+	"ai.max_concurrent_jobs":          true,
+	"subtitle_ai.max_concurrent_jobs": true,
 }
 
 // restartRequiredPrefixes covers whole namespaces of infrastructure settings:

--- a/internal/config/restart_keys.go
+++ b/internal/config/restart_keys.go
@@ -1,0 +1,121 @@
+package config
+
+import "strings"
+
+// restartRequiredKeys lists server_settings keys whose values are captured at
+// process startup (listeners, connection pools, HTTP clients, worker pools)
+// and cannot take effect until the server restarts.
+//
+// Keys absent from this map and from restartRequiredPrefixes apply without a
+// restart: they are either read live from the settings repo at request time
+// (overlays, branding, markers, download.*, ...) or hot-reloaded through the
+// nodeconfig watcher. When converting a frozen consumer to the live config,
+// remove its key here — the admin UI restart banner is driven by this
+// registry.
+var restartRequiredKeys = map[string]bool{
+	// Process & logging.
+	"server.listen":        true,
+	"server.mode":          true,
+	"server.log_format":    true,
+	"server.log_level":     true, // until logging conversion lands
+	"server.log_quiet":     true, // until logging conversion lands
+	"opslog.capture_level": true,
+
+	// Auth. The JWT secret is baked into token services and stream signers;
+	// expiries are frozen until the JWT conversion lands.
+	"auth.jwt_secret":           true,
+	"auth.access_token_expiry":  true,
+	"auth.refresh_token_expiry": true,
+
+	// Rate limiting gates middleware construction; tier/limit values inside
+	// the dedicated /admin/rate-limits endpoint hot-reload and report their
+	// own restart state.
+	"ratelimit.enabled": true,
+	"ratelimit.backend": true,
+
+	// Playback transcode infrastructure. ffmpeg path and hwaccel feed several
+	// startup-built consumers (stream handler, scanner ffprobe, chapter
+	// thumbnails, audiobook enricher); the chapter-thumbnail worker pool is
+	// sized at construction.
+	"playback.ffmpeg_path":               true,
+	"playback.hw_accel":                  true,
+	"playback.hw_device":                 true,
+	"playback.transcode_dir":             true, // until playback conversion lands
+	"playback.chapter_thumbnail_workers": true,
+
+	// Scanner / matcher / metadata worker pools and toggles captured at
+	// construction.
+	"scanner.workers":                      true, // until scanner conversion lands
+	"scanner.max_concurrent_libraries":     true,
+	"scanner.max_concurrent_scoped":        true,
+	"scanner.empty_trash_after_scan":       true,
+	"matcher.workers":                      true, // until matcher conversion lands
+	"matcher.batch_size":                   true, // until matcher conversion lands
+	"matcher.enable_tv_series_root_queue":  true,
+	"matcher.enable_tv_series_group_queue": true,
+	"metadata.cache_images":                true, // until metadata conversion lands
+
+	// External API clients built once at startup.
+	"tmdb.api_key":    true,
+	"mdblist.api_key": true, // until mdblist conversion lands
+
+	// Compat listeners and session stores.
+	"audiobookshelf_compat.enabled":           true,
+	"jellyfin_compat.listen":                  true,
+	"jellyfin_compat.public_url":              true, // until jellycompat conversion lands
+	"jellyfin_compat.server_name":             true, // until jellycompat conversion lands
+	"jellyfin_compat.emulated_server_version": true, // until jellycompat conversion lands
+	"jellyfin_compat.server_id":               true,
+	"jellyfin_compat.web_version":             true,
+	"jellyfin_compat.web_dir":                 true,
+	"jellyfin_compat.session_ttl":             true,
+	"jellyfin_compat.playback_session_ttl":    true,
+
+	// AI clients and job services built once at startup (the semaphore for
+	// max_concurrent_jobs is a fixed-capacity channel). Legacy subtitle_ai.*
+	// connection aliases classify identically to their ai.* counterparts.
+	"ai.base_url":                         true,
+	"ai.api_key":                          true,
+	"ai.chat_model":                       true,
+	"ai.asr_base_url":                     true,
+	"ai.asr_api_key":                      true,
+	"ai.asr_model":                        true,
+	"ai.max_concurrent_jobs":              true,
+	"subtitle_ai.base_url":                true,
+	"subtitle_ai.api_key":                 true,
+	"subtitle_ai.chat_model":              true,
+	"subtitle_ai.max_concurrent_jobs":     true,
+	"subtitle_ai.enabled":                 true,
+	"subtitle_ai.transcribe_enabled":      true,
+	"subtitle_ai.batch_size":              true,
+	"subtitle_ai.context_neighbors":       true,
+	"subtitle_ai.asr_chunk_seconds":       true,
+	"subtitle_ai.transcribe_quota_jobs":   true,
+	"subtitle_ai.transcribe_quota_period": true,
+	"metadata_ai.enabled":                 true,
+	"metadata_ai.on_view":                 true,
+}
+
+// restartRequiredPrefixes covers whole namespaces of infrastructure settings:
+// connection pools and storage clients that are constructed once at startup.
+var restartRequiredPrefixes = []string{
+	"database.",
+	"userdb.",
+	"s3.",
+	"redis.",
+	"recommendations.",
+}
+
+// RestartRequired reports whether changing the given server_settings key
+// requires a server restart to take effect.
+func RestartRequired(key string) bool {
+	if restartRequiredKeys[key] {
+		return true
+	}
+	for _, prefix := range restartRequiredPrefixes {
+		if strings.HasPrefix(key, prefix) {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/config/restart_keys.go
+++ b/internal/config/restart_keys.go
@@ -30,14 +30,15 @@ var restartRequiredKeys = map[string]bool{
 	"ratelimit.enabled": true,
 	"ratelimit.backend": true,
 
-	// Playback transcode infrastructure. ffmpeg path and hwaccel feed several
-	// startup-built consumers (stream handler, scanner ffprobe, chapter
-	// thumbnails, audiobook enricher); the chapter-thumbnail worker pool is
-	// sized at construction.
+	// Playback transcode infrastructure. The playback/stream handlers read
+	// ffmpeg path and hwaccel live (new transcode sessions), but several
+	// startup-built consumers still freeze them (scanner ffprobe, chapter
+	// thumbnails, audiobook enricher) — keep restart-required until those
+	// convert. transcode_dir is fully live (only the playback handler reads
+	// it). The chapter-thumbnail worker pool is sized at construction.
 	"playback.ffmpeg_path":               true,
 	"playback.hw_accel":                  true,
 	"playback.hw_device":                 true,
-	"playback.transcode_dir":             true, // until playback conversion lands
 	"playback.chapter_thumbnail_workers": true,
 
 	// Scanner / matcher / metadata worker pools and toggles captured at

--- a/internal/config/restart_keys.go
+++ b/internal/config/restart_keys.go
@@ -58,16 +58,16 @@ var restartRequiredKeys = map[string]bool{
 	"mdblist.api_key": true, // until mdblist conversion lands
 
 	// Compat listeners and session stores.
-	"audiobookshelf_compat.enabled":           true,
-	"jellyfin_compat.listen":                  true,
-	"jellyfin_compat.public_url":              true, // until jellycompat conversion lands
-	"jellyfin_compat.server_name":             true, // until jellycompat conversion lands
-	"jellyfin_compat.emulated_server_version": true, // until jellycompat conversion lands
-	"jellyfin_compat.server_id":               true,
-	"jellyfin_compat.web_version":             true,
-	"jellyfin_compat.web_dir":                 true,
-	"jellyfin_compat.session_ttl":             true,
-	"jellyfin_compat.playback_session_ttl":    true,
+	"audiobookshelf_compat.enabled": true,
+	// public_url / server_name / emulated_server_version are read live per
+	// request; server_id is generate-once and baked into the resource
+	// mapper; the session TTLs are baked into store constructors.
+	"jellyfin_compat.listen":               true,
+	"jellyfin_compat.server_id":            true,
+	"jellyfin_compat.web_version":          true,
+	"jellyfin_compat.web_dir":              true,
+	"jellyfin_compat.session_ttl":          true,
+	"jellyfin_compat.playback_session_ttl": true,
 
 	// AI clients and job services built once at startup (the semaphore for
 	// max_concurrent_jobs is a fixed-capacity channel). Legacy subtitle_ai.*

--- a/internal/config/restart_keys_test.go
+++ b/internal/config/restart_keys_test.go
@@ -18,8 +18,11 @@ func TestRestartRequired(t *testing.T) {
 		{"redis.url", true},
 		{"recommendations.enabled", true},
 		// Legacy AI aliases classify like their canonical keys.
-		{"subtitle_ai.base_url", true},
 		{"subtitle_ai.max_concurrent_jobs", true},
+		{"subtitle_ai.base_url", false}, // like ai.base_url — hot-reloaded
+		{"ai.api_key", false},
+		{"subtitle_ai.enabled", false},
+		{"metadata_ai.on_view", false},
 		// Live settings read from the settings repo per request.
 		{"branding.server_name", false},
 		{"overlays.enabled", false},

--- a/internal/config/restart_keys_test.go
+++ b/internal/config/restart_keys_test.go
@@ -1,0 +1,38 @@
+package config
+
+import "testing"
+
+func TestRestartRequired(t *testing.T) {
+	cases := []struct {
+		key  string
+		want bool
+	}{
+		// Explicit infrastructure keys.
+		{"server.listen", true},
+		{"auth.jwt_secret", true},
+		{"ratelimit.backend", true},
+		// Prefix-covered namespaces.
+		{"database.max_connections", true},
+		{"userdb.backend", true},
+		{"s3.public_endpoint", true},
+		{"redis.url", true},
+		{"recommendations.enabled", true},
+		// Legacy AI aliases classify like their canonical keys.
+		{"subtitle_ai.base_url", true},
+		{"subtitle_ai.max_concurrent_jobs", true},
+		// Live settings read from the settings repo per request.
+		{"branding.server_name", false},
+		{"overlays.enabled", false},
+		{"markers.mode", false},
+		{"download.enabled", false},
+		{"allow_4k_transcode", false},
+		{"defaults.card_overlays", false},
+		// Unknown keys default to live.
+		{"some.future_setting", false},
+	}
+	for _, tc := range cases {
+		if got := RestartRequired(tc.key); got != tc.want {
+			t.Errorf("RestartRequired(%q) = %v, want %v", tc.key, got, tc.want)
+		}
+	}
+}

--- a/internal/config/yaml_import.go
+++ b/internal/config/yaml_import.go
@@ -181,13 +181,6 @@ func YAMLToSettingsMap(path string) (map[string]string, error) {
 		m["playback.chapter_thumbnail_node_capacity"] = strconv.Itoa(raw.Playback.ChapterThumbnailNodeCapacity)
 	}
 	m["playback.transcode_enabled"] = strconv.FormatBool(raw.Playback.TranscodeEnabled)
-	m["playback.allow_hevc_encoding"] = strconv.FormatBool(raw.Playback.AllowHEVCEncoding)
-	if raw.Playback.TranscodeAheadSegments != 0 {
-		m["playback.transcode_ahead_segments"] = strconv.Itoa(raw.Playback.TranscodeAheadSegments)
-	}
-	if raw.Playback.SegmentDuration != 0 {
-		m["playback.segment_duration"] = strconv.Itoa(raw.Playback.SegmentDuration)
-	}
 
 	// Redis
 	m["redis.url"] = raw.Redis.URL

--- a/internal/jellycompat/auth_api_key_session_test.go
+++ b/internal/jellycompat/auth_api_key_session_test.go
@@ -315,7 +315,7 @@ func TestValidatePseudoUser(t *testing.T) {
 }
 
 func TestHandleUsers_ReturnsCallerAsSingleElement(t *testing.T) {
-	h := NewAuthHandler(&config.Config{}, nil, nil)
+	h := NewAuthHandler(func() *config.Config { return &config.Config{} }, nil, nil)
 	session := &Session{PseudoUserID: PseudoUserID(2, "p1"), Username: "admin"}
 
 	req := httptest.NewRequest(http.MethodGet, "/Users", nil)
@@ -342,7 +342,7 @@ func TestHandleUsers_ReturnsCallerAsSingleElement(t *testing.T) {
 }
 
 func TestHandleUsers_RequiresSession(t *testing.T) {
-	h := NewAuthHandler(&config.Config{}, nil, nil)
+	h := NewAuthHandler(func() *config.Config { return &config.Config{} }, nil, nil)
 	rec := httptest.NewRecorder()
 	h.HandleUsers(rec, httptest.NewRequest(http.MethodGet, "/Users", nil))
 	if rec.Code != http.StatusUnauthorized {

--- a/internal/jellycompat/handlers_auth.go
+++ b/internal/jellycompat/handlers_auth.go
@@ -115,13 +115,14 @@ type loginResolver interface {
 
 // AuthHandler serves Jellyfin login/current-user routes.
 type AuthHandler struct {
-	cfg           *config.Config
+	cfg           func() *config.Config
 	loginResolver loginResolver
 	authenticator *Authenticator
 }
 
-// NewAuthHandler creates a new auth handler.
-func NewAuthHandler(cfg *config.Config, loginResolver loginResolver, authenticator *Authenticator) *AuthHandler {
+// NewAuthHandler creates a new auth handler. The config provider is invoked
+// per request so compat setting changes apply without restart.
+func NewAuthHandler(cfg func() *config.Config, loginResolver loginResolver, authenticator *Authenticator) *AuthHandler {
 	return &AuthHandler{
 		cfg:           cfg,
 		loginResolver: loginResolver,
@@ -160,7 +161,7 @@ func (h *AuthHandler) HandleAuthenticateByName(w http.ResponseWriter, r *http.Re
 
 	writeJSON(w, http.StatusOK, authenticateByNameResponse{
 		AccessToken: session.Token,
-		ServerID:    h.cfg.JellyfinCompat.ServerID,
+		ServerID:    h.cfg().JellyfinCompat.ServerID,
 		User:        h.userDTO(session),
 		SessionInfo: h.sessionInfo(session),
 	})
@@ -225,7 +226,7 @@ func (h *AuthHandler) userDTO(session *Session) userDTOResponse {
 	return userDTOResponse{
 		ID:                        session.PseudoUserID.String(),
 		Name:                      name,
-		ServerID:                  h.cfg.JellyfinCompat.ServerID,
+		ServerID:                  h.cfg().JellyfinCompat.ServerID,
 		HasPassword:               true,
 		HasConfiguredPassword:     true,
 		HasConfiguredEasyPassword: false,
@@ -299,6 +300,6 @@ func (h *AuthHandler) sessionInfo(session *Session) *sessionInfoResponse {
 		SupportsRemoteControl: true,
 		HasCustomDeviceName:   false,
 		SupportedCommands:     []string{},
-		ServerID:              h.cfg.JellyfinCompat.ServerID,
+		ServerID:              h.cfg().JellyfinCompat.ServerID,
 	}
 }

--- a/internal/jellycompat/handlers_system.go
+++ b/internal/jellycompat/handlers_system.go
@@ -27,11 +27,13 @@ type endpointInfoResponse struct {
 
 // SystemHandler serves Jellyfin setup/system endpoints.
 type SystemHandler struct {
-	cfg *config.Config
+	cfg func() *config.Config
 }
 
-// NewSystemHandler creates a new system handler.
-func NewSystemHandler(cfg *config.Config) *SystemHandler {
+// NewSystemHandler creates a new system handler. The config provider is
+// invoked per request so public URL / server name / emulated version
+// changes apply without restart.
+func NewSystemHandler(cfg func() *config.Config) *SystemHandler {
 	return &SystemHandler{cfg: cfg}
 }
 
@@ -60,7 +62,7 @@ func (h *SystemHandler) HandleEndpoint(w http.ResponseWriter, r *http.Request) {
 	writeJSON(w, http.StatusOK, endpointInfoResponse{
 		IsLocal:     true,
 		IsInNetwork: true,
-		Address:     h.cfg.JellyfinCompat.PublicURL,
+		Address:     h.cfg().JellyfinCompat.PublicURL,
 	})
 }
 
@@ -71,11 +73,11 @@ func (h *SystemHandler) HandlePing(w http.ResponseWriter, r *http.Request) {
 
 func (h *SystemHandler) systemInfo() publicSystemInfoResponse {
 	return publicSystemInfoResponse{
-		LocalAddress:           h.cfg.JellyfinCompat.PublicURL,
-		ServerName:             h.cfg.JellyfinCompat.ServerName,
-		Version:                h.cfg.JellyfinCompat.EmulatedServerVersion,
+		LocalAddress:           h.cfg().JellyfinCompat.PublicURL,
+		ServerName:             h.cfg().JellyfinCompat.ServerName,
+		Version:                h.cfg().JellyfinCompat.EmulatedServerVersion,
 		ProductName:            "Jellyfin Server",
-		ID:                     h.cfg.JellyfinCompat.ServerID,
+		ID:                     h.cfg().JellyfinCompat.ServerID,
 		StartupWizardCompleted: true,
 	}
 }

--- a/internal/jellycompat/router.go
+++ b/internal/jellycompat/router.go
@@ -61,12 +61,12 @@ func NewRouter(deps Dependencies) chi.Router {
 	r.Use(requestLoggerMiddleware)
 	r.Use(middleware.Recoverer)
 
-	systemHandler := NewSystemHandler(deps.Config)
+	systemHandler := NewSystemHandler(deps.CurrentConfig)
 	webFS, err := resolveCompatWebFS(deps)
 	if err != nil {
 		slog.Error("jellycompat web bundle unavailable", "error", err)
 	}
-	authHandler := NewAuthHandler(deps.Config, deps.LoginResolver, deps.Authenticator)
+	authHandler := NewAuthHandler(deps.CurrentConfig, deps.LoginResolver, deps.Authenticator)
 	nextUpRepo := catalog.NewNextUpRepository(deps.DB, deps.UserStoreProvider)
 	var subtitleRepo subtitles.Repository
 	if deps.SubtitleRepo != nil {

--- a/internal/jellycompat/server.go
+++ b/internal/jellycompat/server.go
@@ -23,7 +23,10 @@ import (
 
 // Dependencies holds the pluggable pieces used by the compat server.
 type Dependencies struct {
-	Config           *config.Config
+	Config *config.Config
+	// LiveConfig returns the current hot-reloaded config. May be nil (tests,
+	// worker modes); read through CurrentConfig(), which falls back to Config.
+	LiveConfig       func() *config.Config
 	DB               *pgxpool.Pool
 	SecretCipher     *secret.Cipher // at-rest credential cipher (required when DB is set)
 	ClientIPResolver *clientip.Resolver
@@ -82,6 +85,17 @@ type Dependencies struct {
 	SubtitleRepo subtitles.Repository // optional; downloaded subtitle support
 	S3Client     subtitles.S3Client   // optional
 	S3Bucket     string               // optional
+}
+
+// CurrentConfig returns the live config when hot reload is wired, falling
+// back to the startup snapshot otherwise.
+func (d *Dependencies) CurrentConfig() *config.Config {
+	if d.LiveConfig != nil {
+		if cfg := d.LiveConfig(); cfg != nil {
+			return cfg
+		}
+	}
+	return d.Config
 }
 
 // Server wraps the compat HTTP handler.

--- a/internal/logfilter/handler.go
+++ b/internal/logfilter/handler.go
@@ -4,23 +4,43 @@ import (
 	"context"
 	"log/slog"
 	"strings"
+	"sync/atomic"
 )
 
 // Handler wraps an slog.Handler and drops records whose message starts
 // with any of the configured quiet prefixes (e.g. "metadata:").
+//
+// The prefix list is shared through an atomic pointer so SetQuiet applies
+// to every clone produced by WithAttrs/WithGroup, and is safe to call
+// concurrently with logging.
 type Handler struct {
 	inner    slog.Handler
-	prefixes []string
+	prefixes *atomic.Pointer[[]string]
 }
 
 // New returns a Handler that delegates to inner but silences messages
 // matching any prefix in quietCSV (comma-separated, e.g. "metadata,scanner").
 // A colon+space is appended automatically: "metadata" silences "metadata: ...".
-// If quietCSV is empty, the inner handler is returned directly.
-func New(inner slog.Handler, quietCSV string) slog.Handler {
+// The Handler is always returned (even for an empty quietCSV) so the quiet
+// list can be changed later via SetQuiet.
+func New(inner slog.Handler, quietCSV string) *Handler {
+	prefixes := &atomic.Pointer[[]string]{}
+	parsed := parseQuiet(quietCSV)
+	prefixes.Store(&parsed)
+	return &Handler{inner: inner, prefixes: prefixes}
+}
+
+// SetQuiet replaces the quiet prefix list. It applies immediately to this
+// handler and every WithAttrs/WithGroup clone derived from it.
+func (h *Handler) SetQuiet(quietCSV string) {
+	parsed := parseQuiet(quietCSV)
+	h.prefixes.Store(&parsed)
+}
+
+func parseQuiet(quietCSV string) []string {
 	trimmed := strings.TrimSpace(quietCSV)
 	if trimmed == "" {
-		return inner
+		return nil
 	}
 	parts := strings.Split(trimmed, ",")
 	prefixes := make([]string, 0, len(parts))
@@ -30,10 +50,7 @@ func New(inner slog.Handler, quietCSV string) slog.Handler {
 			prefixes = append(prefixes, p+":")
 		}
 	}
-	if len(prefixes) == 0 {
-		return inner
-	}
-	return &Handler{inner: inner, prefixes: prefixes}
+	return prefixes
 }
 
 func (h *Handler) Enabled(ctx context.Context, level slog.Level) bool {
@@ -42,7 +59,7 @@ func (h *Handler) Enabled(ctx context.Context, level slog.Level) bool {
 
 func (h *Handler) Handle(ctx context.Context, r slog.Record) error {
 	msg := r.Message
-	for _, prefix := range h.prefixes {
+	for _, prefix := range *h.prefixes.Load() {
 		if strings.HasPrefix(msg, prefix) {
 			return nil
 		}

--- a/internal/logfilter/handler_test.go
+++ b/internal/logfilter/handler_test.go
@@ -1,0 +1,65 @@
+package logfilter
+
+import (
+	"bytes"
+	"log/slog"
+	"strings"
+	"testing"
+)
+
+func newCapture() (*Handler, *bytes.Buffer) {
+	buf := &bytes.Buffer{}
+	h := New(slog.NewTextHandler(buf, nil), "")
+	return h, buf
+}
+
+func TestHandlerFiltersConfiguredPrefixes(t *testing.T) {
+	buf := &bytes.Buffer{}
+	h := New(slog.NewTextHandler(buf, nil), "metadata, scanner")
+	logger := slog.New(h)
+
+	logger.Info("metadata: cached image")
+	logger.Info("scanner: walked folder")
+	logger.Info("playback: session started")
+
+	out := buf.String()
+	if strings.Contains(out, "metadata:") || strings.Contains(out, "scanner:") {
+		t.Fatalf("quiet-prefixed messages leaked: %s", out)
+	}
+	if !strings.Contains(out, "playback: session started") {
+		t.Fatalf("unrelated message was dropped: %s", out)
+	}
+}
+
+func TestSetQuietAppliesToClones(t *testing.T) {
+	h, buf := newCapture()
+
+	// Clone first (as slog.With does), then change the quiet list — the
+	// clone must see the update because the prefix list is shared.
+	clone := slog.New(h.WithAttrs([]slog.Attr{slog.String("node", "a")}))
+	clone.Info("metadata: before quiet")
+	h.SetQuiet("metadata")
+	clone.Info("metadata: after quiet")
+	clone.Info("other: still logged")
+
+	out := buf.String()
+	if !strings.Contains(out, "metadata: before quiet") {
+		t.Fatalf("message before SetQuiet was dropped: %s", out)
+	}
+	if strings.Contains(out, "metadata: after quiet") {
+		t.Fatalf("clone did not pick up SetQuiet: %s", out)
+	}
+	if !strings.Contains(out, "other: still logged") {
+		t.Fatalf("unrelated message was dropped: %s", out)
+	}
+}
+
+func TestEmptyQuietPassesEverything(t *testing.T) {
+	h, buf := newCapture()
+	logger := slog.New(h)
+
+	logger.Info("metadata: not quiet by default")
+	if !strings.Contains(buf.String(), "metadata: not quiet by default") {
+		t.Fatalf("empty quiet list dropped a message: %s", buf.String())
+	}
+}

--- a/internal/mdblist/discovery.go
+++ b/internal/mdblist/discovery.go
@@ -12,6 +12,7 @@ import (
 	"net/http"
 	"net/url"
 	"strings"
+	"sync/atomic"
 	"time"
 )
 
@@ -38,9 +39,10 @@ type ListSummary struct {
 }
 
 // Client wraps a single MDBList apikey. Construct one per server config; it
-// is safe for concurrent use because http.Client is.
+// is safe for concurrent use because http.Client is. The apikey is atomic so
+// admin settings changes apply to subsequent requests without restart.
 type Client struct {
-	apiKey  string
+	apiKey  atomic.Pointer[string]
 	baseURL string
 	http    *http.Client
 }
@@ -51,16 +53,31 @@ func NewClient(apiKey string, httpClient *http.Client) *Client {
 	if httpClient == nil {
 		httpClient = &http.Client{Timeout: 10 * time.Second}
 	}
-	return &Client{
-		apiKey:  strings.TrimSpace(apiKey),
+	c := &Client{
 		baseURL: defaultBaseURL,
 		http:    httpClient,
 	}
+	c.SetAPIKey(apiKey)
+	return c
+}
+
+// SetAPIKey replaces the apikey used for subsequent requests. Safe for
+// concurrent use.
+func (c *Client) SetAPIKey(apiKey string) {
+	trimmed := strings.TrimSpace(apiKey)
+	c.apiKey.Store(&trimmed)
+}
+
+func (c *Client) currentAPIKey() string {
+	if key := c.apiKey.Load(); key != nil {
+		return *key
+	}
+	return ""
 }
 
 // Configured reports whether the client has an apikey set.
 func (c *Client) Configured() bool {
-	return c.apiKey != ""
+	return c.currentAPIKey() != ""
 }
 
 // Search returns lists whose title matches query.
@@ -70,7 +87,7 @@ func (c *Client) Search(ctx context.Context, query string) ([]ListSummary, error
 		return nil, fmt.Errorf("query is required")
 	}
 	q := url.Values{}
-	q.Set("apikey", c.apiKey)
+	q.Set("apikey", c.currentAPIKey())
 	q.Set("query", query)
 	return c.fetchLists(ctx, "/lists/search", q)
 }
@@ -78,7 +95,7 @@ func (c *Client) Search(ctx context.Context, query string) ([]ListSummary, error
 // Top returns the public top lists ranked by Trakt likes.
 func (c *Client) Top(ctx context.Context) ([]ListSummary, error) {
 	q := url.Values{}
-	q.Set("apikey", c.apiKey)
+	q.Set("apikey", c.currentAPIKey())
 	return c.fetchLists(ctx, "/lists/top", q)
 }
 

--- a/internal/metadata/service.go
+++ b/internal/metadata/service.go
@@ -11,6 +11,7 @@ import (
 	"strconv"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/Silo-Server/silo-server/internal/catalog"
@@ -308,7 +309,7 @@ type MetadataService struct {
 	seriesWork      map[string]*seriesEpisodeWork
 	hooks           metadataServiceHooks
 	imageCacher     ImageCacher
-	autoCacheImages bool
+	autoCacheImages atomic.Bool // hot-reloaded from metadata.cache_images
 	imageResolver   interface {
 		ResolveImageURL(ctx context.Context, path string, variant string) string
 	}
@@ -435,9 +436,9 @@ func (s *MetadataService) SetImageCacher(c ImageCacher) {
 
 // SetAutoCacheImages controls whether refresh pipelines automatically cache
 // provider images into object storage. Explicit admin image applies still use
-// the configured image cacher when available.
+// the configured image cacher when available. Safe for concurrent use.
 func (s *MetadataService) SetAutoCacheImages(enabled bool) {
-	s.autoCacheImages = enabled
+	s.autoCacheImages.Store(enabled)
 }
 
 // SetImageResolver sets the resolver used to convert plugin-prefixed image
@@ -1479,7 +1480,7 @@ func (s *MetadataService) mergeAndPersist(
 	}
 
 	// Cache images to S3 if enabled.
-	if s.autoCacheImages && s.imageCacher != nil && isCanonicalWrite {
+	if s.autoCacheImages.Load() && s.imageCacher != nil && isCanonicalWrite {
 		s.cacheItemImages(ctx, item, images)
 	}
 
@@ -2461,7 +2462,7 @@ func (s *MetadataService) fetchTargetEpisodeResults(ctx context.Context, provide
 // provider primaryProviderID happens to prefer. Failures are logged and
 // the original path is kept.
 func (s *MetadataService) cacheSeriesChildImages(ctx context.Context, series *models.MediaItem, providerIDs map[string]string, seasons []SeasonResult, episodes []EpisodeResult) {
-	if s == nil || !s.autoCacheImages || s.imageCacher == nil || series == nil {
+	if s == nil || !s.autoCacheImages.Load() || s.imageCacher == nil || series == nil {
 		return
 	}
 	fallbackProvider := primaryProviderID(providerIDs)

--- a/internal/metadata/translation/service.go
+++ b/internal/metadata/translation/service.go
@@ -7,6 +7,7 @@ import (
 	"log/slog"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/Silo-Server/silo-server/internal/ai/jobrunner"
@@ -47,13 +48,26 @@ const onViewFailureCooldown = 15 * time.Minute
 // provenance-aware persistence. Lifecycle mechanics are delegated to the
 // shared jobrunner.
 type Service struct {
-	cfg     Config
+	// cfg is behind an atomic pointer so admin settings changes apply to
+	// subsequent enqueues/view checks without rebuilding the service.
+	cfg     atomic.Pointer[Config]
 	repo    JobRepository
 	content ContentReader
 	locs    LocalizationStore
 	chat    aitranslate.ChatFn
 	runner  *jobrunner.Runner
 	logger  *slog.Logger
+}
+
+// UpdateConfig swaps the service config. Safe for concurrent use; running
+// jobs finish with the config they started with.
+func (s *Service) UpdateConfig(cfg Config) {
+	s.cfg.Store(&cfg)
+}
+
+// config returns a snapshot of the current service config.
+func (s *Service) config() Config {
+	return *s.cfg.Load()
 }
 
 // NewService wires a metadata translation service. sem is the dispatch
@@ -71,8 +85,7 @@ func NewService(
 	if logger == nil {
 		logger = slog.Default()
 	}
-	return &Service{
-		cfg:     cfg,
+	s := &Service{
 		repo:    repo,
 		content: content,
 		locs:    locs,
@@ -80,10 +93,12 @@ func NewService(
 		runner:  jobrunner.New(appCtx, sem, repo, "metadata translation", logger),
 		logger:  logger,
 	}
+	s.UpdateConfig(cfg)
+	return s
 }
 
 // Enabled reports whether metadata translation can currently run.
-func (s *Service) Enabled() bool { return s.cfg.Ready() }
+func (s *Service) Enabled() bool { return s.config().Ready() }
 
 // Recover clears jobs orphaned by a crashed worker and starts a background
 // reaper that keeps doing so. Call once at startup.
@@ -92,7 +107,7 @@ func (s *Service) Recover() { s.runner.Recover() }
 // Enqueue validates and queues a job, returning immediately. If an identical
 // job is already pending or running, that job is returned instead of a new one.
 func (s *Service) Enqueue(ctx context.Context, req JobRequest) (*Job, error) {
-	if !s.cfg.Ready() {
+	if !s.config().Ready() {
 		return nil, ErrNotConfigured
 	}
 	if req.TargetKind == "" {
@@ -112,7 +127,7 @@ func (s *Service) Enqueue(ctx context.Context, req JobRequest) (*Job, error) {
 	}
 	req.TargetLanguage = target
 
-	key := idempotencyKey(req.TargetKind, req.ContentID, req.TargetLanguage, s.cfg.ChatModel)
+	key := idempotencyKey(req.TargetKind, req.ContentID, req.TargetLanguage, s.config().ChatModel)
 	if existing, err := s.repo.GetActiveJobByIdempotencyKey(ctx, key); err != nil {
 		return nil, err
 	} else if existing != nil {
@@ -125,7 +140,7 @@ func (s *Service) Enqueue(ctx context.Context, req JobRequest) (*Job, error) {
 		IncludeChildren: req.IncludeChildren,
 		TargetLanguage:  req.TargetLanguage,
 		Engine:          "openai",
-		Model:           s.cfg.ChatModel,
+		Model:           s.config().ChatModel,
 		Status:          jobrunner.StatusPending,
 		ProgressMessage: "Queued",
 		Force:           req.Force,
@@ -151,7 +166,7 @@ func (s *Service) Enqueue(ctx context.Context, req JobRequest) (*Job, error) {
 // loop re-checks per field, so fully translated items never reach the model.
 // Errors are logged, never returned: a refresh must not fail on this.
 func (s *Service) AutoEnqueue(ctx context.Context, itemContentID, language string) {
-	if !s.cfg.Ready() {
+	if !s.config().Ready() {
 		return
 	}
 	target, err := subtitles.NormalizeLanguageCode(language)
@@ -179,7 +194,7 @@ func (s *Service) AutoEnqueue(ctx context.Context, itemContentID, language strin
 }
 
 // OnViewMode exposes the viewer-triggered translation mode for status probes.
-func (s *Service) OnViewMode() string { return s.cfg.OnViewMode() }
+func (s *Service) OnViewMode() string { return s.config().OnViewMode() }
 
 // RequestOnView is the viewer-triggered enqueue path (detail-page button or
 // auto-on-view). On top of the normal pipeline it suppresses retries for a
@@ -187,7 +202,7 @@ func (s *Service) OnViewMode() string { return s.cfg.OnViewMode() }
 // page views must never hammer a broken endpoint. Returns the resulting job
 // (which may be the in-flight or recently failed one).
 func (s *Service) RequestOnView(ctx context.Context, contentID, targetLanguage string, requestedBy *int) (*Job, error) {
-	if s.cfg.OnViewMode() == "off" {
+	if s.config().OnViewMode() == "off" {
 		return nil, ErrNotConfigured
 	}
 	target, err := subtitles.NormalizeLanguageCode(targetLanguage)

--- a/internal/metadata/worker.go
+++ b/internal/metadata/worker.go
@@ -27,10 +27,30 @@ type MatchWorker struct {
 	seriesClaimer           SeriesRootClaimer
 	enableTVSeriesRootQueue bool
 	realtimeHub             *notifications.Hub
-	workers                 int
-	batchSize               int
-	interval                time.Duration
+	// workers/batchSize are atomics so admin settings changes can resize the
+	// pool while the long-running match loop reads them each cycle.
+	workers   atomic.Int32
+	batchSize atomic.Int32
+	interval  time.Duration
 }
+
+// SetConcurrency updates the worker pool size and claim batch size. Safe for
+// concurrent use; the next match cycle picks the new values up. Out-of-range
+// values are ignored.
+func (w *MatchWorker) SetConcurrency(workers, batchSize int) {
+	if w == nil {
+		return
+	}
+	if workers >= 1 {
+		w.workers.Store(int32(workers))
+	}
+	if batchSize > 0 {
+		w.batchSize.Store(int32(batchSize))
+	}
+}
+
+func (w *MatchWorker) workerCount() int    { return int(w.workers.Load()) }
+func (w *MatchWorker) claimBatchSize() int { return int(w.batchSize.Load()) }
 
 type NonSeriesFileClaimer interface {
 	ClaimUnmatchedNonSeries(ctx context.Context, limit int) ([]*models.MediaFile, error)
@@ -77,14 +97,14 @@ func NewMatchWorker(service *MetadataService, fileLister UnmatchedFileLister, wo
 	if service != nil {
 		itemLister = service.itemRepo
 	}
-	return &MatchWorker{
+	w := &MatchWorker{
 		service:    service,
 		fileLister: fileLister,
 		itemLister: itemLister,
-		workers:    workers,
-		batchSize:  batchSize,
 		interval:   interval,
 	}
+	w.SetConcurrency(workers, batchSize)
+	return w
 }
 
 // SetSeriesRootClaimer enables native TV root-backed matching when enabled is true.
@@ -130,7 +150,7 @@ func (w *MatchWorker) Run(ctx context.Context) {
 // processUnmatched fetches a batch of unmatched files and processes them.
 func (w *MatchWorker) processUnmatched(ctx context.Context) {
 	if w.enableTVSeriesRootQueue && w.seriesClaimer != nil {
-		jobs, err := w.seriesClaimer.Claim(ctx, w.batchSize)
+		jobs, err := w.seriesClaimer.Claim(ctx, w.claimBatchSize())
 		if err != nil {
 			slog.Error("metadata: failed to claim unmatched series roots", "error", err)
 		} else if len(jobs) > 0 {
@@ -142,7 +162,7 @@ func (w *MatchWorker) processUnmatched(ctx context.Context) {
 	}
 
 	if w.movieClaimer != nil {
-		files, err := w.movieClaimer.Claim(ctx, w.batchSize)
+		files, err := w.movieClaimer.Claim(ctx, w.claimBatchSize())
 		if err != nil {
 			slog.Error("metadata: failed to claim queued movie files", "error", err)
 		} else if len(files) > 0 {
@@ -350,7 +370,7 @@ func (w *MatchWorker) ProcessFile(ctx context.Context, file *models.MediaFile) {
 // number of files processed.
 func (w *MatchWorker) ProcessBatch(ctx context.Context) (processed int, err error) {
 	if w.enableTVSeriesRootQueue && w.seriesClaimer != nil {
-		jobs, err := w.seriesClaimer.Claim(ctx, w.batchSize)
+		jobs, err := w.seriesClaimer.Claim(ctx, w.claimBatchSize())
 		if err != nil {
 			return 0, err
 		}
@@ -359,7 +379,7 @@ func (w *MatchWorker) ProcessBatch(ctx context.Context) (processed int, err erro
 		}
 	}
 	if w.movieClaimer != nil {
-		files, err := w.movieClaimer.Claim(ctx, w.batchSize)
+		files, err := w.movieClaimer.Claim(ctx, w.claimBatchSize())
 		if err != nil {
 			return 0, err
 		}
@@ -387,7 +407,7 @@ func (w *MatchWorker) ProcessBatchByFolderAndPathPrefix(ctx context.Context, fol
 		return 0, err
 	}
 	if useSeriesQueue {
-		jobs, err := w.seriesClaimer.ClaimByFolderAndPathPrefix(ctx, folderID, pathPrefix, w.batchSize, attemptBefore)
+		jobs, err := w.seriesClaimer.ClaimByFolderAndPathPrefix(ctx, folderID, pathPrefix, w.claimBatchSize(), attemptBefore)
 		if err != nil {
 			return 0, err
 		}
@@ -400,7 +420,7 @@ func (w *MatchWorker) ProcessBatchByFolderAndPathPrefix(ctx context.Context, fol
 		return processed, nil
 	}
 	if useMovieQueue {
-		files, err := w.movieClaimer.ClaimByFolderAndPathPrefix(ctx, folderID, pathPrefix, w.batchSize, attemptBefore)
+		files, err := w.movieClaimer.ClaimByFolderAndPathPrefix(ctx, folderID, pathPrefix, w.claimBatchSize(), attemptBefore)
 		if err != nil {
 			return 0, err
 		}
@@ -442,7 +462,7 @@ func (w *MatchWorker) ProcessAllByFolderAndPathPrefix(ctx context.Context, folde
 		}
 
 		if useSeriesQueue {
-			jobs, err := w.seriesClaimer.ClaimByFolderAndPathPrefix(ctx, folderID, pathPrefix, w.batchSize, attemptBefore)
+			jobs, err := w.seriesClaimer.ClaimByFolderAndPathPrefix(ctx, folderID, pathPrefix, w.claimBatchSize(), attemptBefore)
 			if err != nil {
 				return processed, err
 			}
@@ -456,7 +476,7 @@ func (w *MatchWorker) ProcessAllByFolderAndPathPrefix(ctx context.Context, folde
 			}
 		}
 		if useMovieQueue {
-			files, err := w.movieClaimer.ClaimByFolderAndPathPrefix(ctx, folderID, pathPrefix, w.batchSize, attemptBefore)
+			files, err := w.movieClaimer.ClaimByFolderAndPathPrefix(ctx, folderID, pathPrefix, w.claimBatchSize(), attemptBefore)
 			if err != nil {
 				return processed, err
 			}
@@ -502,7 +522,7 @@ func (w *MatchWorker) processFiles(ctx context.Context, files []*models.MediaFil
 		processed           atomic.Int64
 		deferredSeriesLinks sync.Map
 	)
-	for i := 0; i < w.workers; i++ {
+	for i := 0; i < w.workerCount(); i++ {
 		wg.Go(func() {
 			for file := range fileChan {
 				if ctx.Err() != nil {
@@ -578,7 +598,7 @@ func (w *MatchWorker) processQueuedMovieFiles(ctx context.Context, files []*mode
 		processed atomic.Int64
 		folders   sync.Map
 	)
-	for i := 0; i < w.workers; i++ {
+	for i := 0; i < w.workerCount(); i++ {
 		wg.Go(func() {
 			for file := range fileChan {
 				if ctx.Err() != nil {
@@ -806,7 +826,7 @@ func (w *MatchWorker) processSeriesRoots(ctx context.Context, jobs []models.Seri
 		firstErrMu sync.Mutex
 		folders    sync.Map
 	)
-	for i := 0; i < w.workers; i++ {
+	for i := 0; i < w.workerCount(); i++ {
 		wg.Go(func() {
 			for job := range jobChan {
 				if runCtx.Err() != nil {
@@ -1159,17 +1179,17 @@ func (w *MatchWorker) queueUsageForFolder(ctx context.Context, folderID int) (us
 func (w *MatchWorker) claimBackgroundFiles(ctx context.Context) ([]*models.MediaFile, error) {
 	if w.enableTVSeriesRootQueue && w.movieClaimer != nil {
 		if claimer, ok := w.fileLister.(MixedFileClaimer); ok {
-			return claimer.ClaimUnmatchedMixed(ctx, w.batchSize)
+			return claimer.ClaimUnmatchedMixed(ctx, w.claimBatchSize())
 		}
 		return nil, fmt.Errorf("mixed-library file claimer is not configured")
 	}
 	if w.enableTVSeriesRootQueue {
 		if claimer, ok := w.fileLister.(NonSeriesFileClaimer); ok {
-			return claimer.ClaimUnmatchedNonSeries(ctx, w.batchSize)
+			return claimer.ClaimUnmatchedNonSeries(ctx, w.claimBatchSize())
 		}
 		return nil, fmt.Errorf("non-series file claimer is not configured")
 	}
-	return w.fileLister.ClaimUnmatched(ctx, w.batchSize)
+	return w.fileLister.ClaimUnmatched(ctx, w.claimBatchSize())
 }
 
 type scopedFallbackClaimMode int
@@ -1195,16 +1215,16 @@ func (w *MatchWorker) claimScopedFiles(ctx context.Context, folderID int, pathPr
 	switch mode {
 	case scopedFallbackMixed:
 		if claimer, ok := w.fileLister.(MixedFileClaimer); ok {
-			return claimer.ClaimUnmatchedMixedByFolderAndPathPrefix(ctx, folderID, pathPrefix, w.batchSize, attemptBefore)
+			return claimer.ClaimUnmatchedMixedByFolderAndPathPrefix(ctx, folderID, pathPrefix, w.claimBatchSize(), attemptBefore)
 		}
 		return nil, fmt.Errorf("mixed-library file claimer is not configured")
 	case scopedFallbackNonSeries:
 		if claimer, ok := w.fileLister.(NonSeriesFileClaimer); ok {
-			return claimer.ClaimUnmatchedNonSeriesByFolderAndPathPrefix(ctx, folderID, pathPrefix, w.batchSize, attemptBefore)
+			return claimer.ClaimUnmatchedNonSeriesByFolderAndPathPrefix(ctx, folderID, pathPrefix, w.claimBatchSize(), attemptBefore)
 		}
 		return nil, fmt.Errorf("non-series file claimer is not configured")
 	default:
-		return w.fileLister.ClaimUnmatchedByFolderAndPathPrefix(ctx, folderID, pathPrefix, w.batchSize, attemptBefore)
+		return w.fileLister.ClaimUnmatchedByFolderAndPathPrefix(ctx, folderID, pathPrefix, w.claimBatchSize(), attemptBefore)
 	}
 }
 

--- a/internal/nodeconfig/watcher.go
+++ b/internal/nodeconfig/watcher.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"log/slog"
+	"reflect"
 	"sync"
 	"time"
 
@@ -22,6 +23,7 @@ type BootstrapOverrides struct {
 	Mode        string // from MODE env
 	DatabaseURL string // from DATABASE_URL env
 	JFListen    string // from JF_PORT env
+	RedisURL    string // from REDIS_URL env
 }
 
 // Watcher watches for configuration changes in the database and
@@ -59,8 +61,10 @@ func (w *Watcher) Config() *config.Config {
 	return w.cfg
 }
 
-// OnChange registers a callback invoked after a config swap.
-// The callback receives the old and new config. Must be called before Start.
+// OnChange registers a callback invoked after a config swap whose new value
+// differs from the old one. The callback receives the old and new config.
+// Safe to call before or after Start; callbacks registered after Start only
+// see reloads that happen after registration.
 func (w *Watcher) OnChange(fn func(old, updated *config.Config)) {
 	w.mu.Lock()
 	defer w.mu.Unlock()
@@ -97,6 +101,18 @@ func (w *Watcher) ForceReload(ctx context.Context) error {
 	return w.reload(ctx)
 }
 
+// RequestReload asks the poll goroutine to reload soon. Non-blocking and
+// coalescing — safe to call from request handlers. Unlike ForceReload, the
+// reload runs on the poll goroutine, so concurrent requests can never swap a
+// stale snapshot over a newer one.
+func (w *Watcher) RequestReload() {
+	select {
+	case w.reloadCh <- struct{}{}:
+	default:
+		// Already pending — coalesce.
+	}
+}
+
 // SetConfigForTest sets the config directly without loading from DB.
 // This is intended for use in tests only.
 func (w *Watcher) SetConfigForTest(cfg *config.Config) {
@@ -108,9 +124,18 @@ func (w *Watcher) SetConfigForTest(cfg *config.Config) {
 // reload fetches all settings from the database, builds a new Config,
 // applies bootstrap overrides, and atomically swaps the config pointer.
 func (w *Watcher) reload(ctx context.Context) error {
+	m, err := w.fetchSettings(ctx)
+	if err != nil {
+		return err
+	}
+	return w.applySettings(m)
+}
+
+// fetchSettings reads all server_settings rows and decrypts sensitive values.
+func (w *Watcher) fetchSettings(ctx context.Context) (map[string]string, error) {
 	rows, err := w.pool.Query(ctx, "SELECT key, value FROM server_settings")
 	if err != nil {
-		return fmt.Errorf("query server_settings: %w", err)
+		return nil, fmt.Errorf("query server_settings: %w", err)
 	}
 	defer rows.Close()
 
@@ -118,21 +143,27 @@ func (w *Watcher) reload(ctx context.Context) error {
 	for rows.Next() {
 		var k, v string
 		if err := rows.Scan(&k, &v); err != nil {
-			return fmt.Errorf("scan server_settings row: %w", err)
+			return nil, fmt.Errorf("scan server_settings row: %w", err)
 		}
 		// Decrypt sensitive keys (read-path contract: legacy plaintext passes
 		// through, enc:v1: values decrypt, corrupt ciphertext errors) so
 		// LoadFromDB always sees plaintext.
 		decrypted, derr := w.cipher.DecryptIfEncrypted(v, secret.SettingsAAD(k))
 		if derr != nil {
-			return fmt.Errorf("decrypt server_settings %q: %w", k, derr)
+			return nil, fmt.Errorf("decrypt server_settings %q: %w", k, derr)
 		}
 		m[k] = decrypted
 	}
 	if err := rows.Err(); err != nil {
-		return fmt.Errorf("iterate server_settings: %w", err)
+		return nil, fmt.Errorf("iterate server_settings: %w", err)
 	}
+	return m, nil
+}
 
+// applySettings builds a Config from a plaintext settings map, re-applies
+// bootstrap overrides, swaps the config pointer, and notifies OnChange
+// callbacks when the config actually changed.
+func (w *Watcher) applySettings(m map[string]string) error {
 	newCfg, err := config.LoadFromDB(m)
 	if err != nil {
 		return fmt.Errorf("parse config: %w", err)
@@ -151,6 +182,9 @@ func (w *Watcher) reload(ctx context.Context) error {
 	if w.bootstrap.JFListen != "" {
 		newCfg.JellyfinCompat.Listen = w.bootstrap.JFListen
 	}
+	if w.bootstrap.RedisURL != "" {
+		newCfg.Redis.URL = w.bootstrap.RedisURL
+	}
 
 	w.mu.Lock()
 	old := w.cfg
@@ -158,6 +192,12 @@ func (w *Watcher) reload(ctx context.Context) error {
 	callbacks := make([]func(old, updated *config.Config), len(w.onChange))
 	copy(callbacks, w.onChange)
 	w.mu.Unlock()
+
+	// The poll path reloads every 60s regardless of whether anything changed;
+	// don't fire callbacks (which may rebuild clients or log) on no-op swaps.
+	if old != nil && reflect.DeepEqual(*old, *newCfg) {
+		return nil
+	}
 
 	for _, fn := range callbacks {
 		fn(old, newCfg)

--- a/internal/nodeconfig/watcher_test.go
+++ b/internal/nodeconfig/watcher_test.go
@@ -1,0 +1,103 @@
+package nodeconfig
+
+import (
+	"testing"
+
+	"github.com/Silo-Server/silo-server/internal/config"
+)
+
+func newTestWatcher(t *testing.T, bootstrap BootstrapOverrides) *Watcher {
+	t.Helper()
+	return NewWatcher(nil, nil, nil, bootstrap)
+}
+
+func TestApplySettingsSkipsCallbacksOnNoopReload(t *testing.T) {
+	w := newTestWatcher(t, BootstrapOverrides{})
+
+	var calls int
+	w.OnChange(func(old, updated *config.Config) {
+		calls++
+	})
+
+	settings := map[string]string{"server.log_level": "debug"}
+	if err := w.applySettings(settings); err != nil {
+		t.Fatalf("first apply: %v", err)
+	}
+	if calls != 1 {
+		t.Fatalf("after initial apply: calls = %d, want 1", calls)
+	}
+
+	// Same settings again — pointer swaps, but callbacks must not fire.
+	if err := w.applySettings(settings); err != nil {
+		t.Fatalf("second apply: %v", err)
+	}
+	if calls != 1 {
+		t.Fatalf("after no-op apply: calls = %d, want 1", calls)
+	}
+
+	// A real change fires callbacks again.
+	if err := w.applySettings(map[string]string{"server.log_level": "warn"}); err != nil {
+		t.Fatalf("third apply: %v", err)
+	}
+	if calls != 2 {
+		t.Fatalf("after changed apply: calls = %d, want 2", calls)
+	}
+}
+
+func TestApplySettingsReappliesBootstrapOverrides(t *testing.T) {
+	w := newTestWatcher(t, BootstrapOverrides{
+		Listen:   ":9999",
+		RedisURL: "redis://env-host:6379",
+	})
+
+	err := w.applySettings(map[string]string{
+		"server.listen": ":8080",
+		"redis.url":     "redis://db-host:6379",
+	})
+	if err != nil {
+		t.Fatalf("apply: %v", err)
+	}
+
+	cfg := w.Config()
+	if cfg.Server.Listen != ":9999" {
+		t.Errorf("Listen = %q, want bootstrap override %q", cfg.Server.Listen, ":9999")
+	}
+	if cfg.Redis.URL != "redis://env-host:6379" {
+		t.Errorf("Redis.URL = %q, want bootstrap override %q", cfg.Redis.URL, "redis://env-host:6379")
+	}
+}
+
+func TestRequestReloadCoalesces(t *testing.T) {
+	w := newTestWatcher(t, BootstrapOverrides{})
+
+	// Multiple requests without a draining poll goroutine must neither block
+	// nor queue more than one pending reload.
+	w.RequestReload()
+	w.RequestReload()
+	w.RequestReload()
+
+	if got := len(w.reloadCh); got != 1 {
+		t.Fatalf("pending reloads = %d, want 1 (coalesced)", got)
+	}
+}
+
+func TestOnChangeAfterFirstApplySeesLaterChanges(t *testing.T) {
+	w := newTestWatcher(t, BootstrapOverrides{})
+
+	if err := w.applySettings(map[string]string{"server.log_level": "info"}); err != nil {
+		t.Fatalf("initial apply: %v", err)
+	}
+
+	var gotOld, gotNew string
+	w.OnChange(func(old, updated *config.Config) {
+		gotOld = old.Server.LogLevel
+		gotNew = updated.Server.LogLevel
+	})
+
+	if err := w.applySettings(map[string]string{"server.log_level": "error"}); err != nil {
+		t.Fatalf("second apply: %v", err)
+	}
+	if gotOld != "info" || gotNew != "error" {
+		t.Errorf("callback saw old=%q new=%q, want old=info new=error", gotOld, gotNew)
+	}
+}

--- a/internal/playback/resolver.go
+++ b/internal/playback/resolver.go
@@ -36,9 +36,8 @@ type ClientCapabilities struct {
 
 // AdminSettings controls server-side playback constraints.
 type AdminSettings struct {
-	TranscodeEnabled  bool
-	Allow4KTranscode  bool
-	AllowHEVCEncoding bool
+	TranscodeEnabled bool
+	Allow4KTranscode bool
 }
 
 // PlayDecision is the result of resolving how to play a file.

--- a/internal/playback/resolver_test.go
+++ b/internal/playback/resolver_test.go
@@ -19,9 +19,8 @@ func defaultCaps() playback.ClientCapabilities {
 
 func defaultSettings() playback.AdminSettings {
 	return playback.AdminSettings{
-		TranscodeEnabled:  true,
-		Allow4KTranscode:  false,
-		AllowHEVCEncoding: false,
+		TranscodeEnabled: true,
+		Allow4KTranscode: false,
 	}
 }
 

--- a/internal/scanner/scanner.go
+++ b/internal/scanner/scanner.go
@@ -118,10 +118,12 @@ type Scanner struct {
 	itemRepo            *catalog.ItemRepository
 	personRepo          *catalog.PersonRepository
 	episodeRepo         *catalog.EpisodeRepository
-	ffprobePath         string
-	s3Client            *s3client.Client // public assets bucket (may be nil)
-	imageCacher         scannerImageCacher
-	workers             int
+	ffprobePath string
+	s3Client    *s3client.Client // public assets bucket (may be nil)
+	imageCacher scannerImageCacher
+	// workers is atomic so admin settings changes can resize the per-scan
+	// worker pool while a scan is running (applies to the next scan).
+	workers             atomic.Int32
 	emptyTrashAfterScan bool
 	markerFetcher       func(context.Context, string) *IntroCreditsMarkers
 	metadataQueue       MetadataQueueProducer
@@ -138,6 +140,17 @@ func (s *Scanner) SetImageCacher(cacher scannerImageCacher) {
 	}
 	s.imageCacher = cacher
 }
+
+// SetWorkers updates the scan worker pool size. Safe for concurrent use; the
+// next scan run picks the new value up. Values below 1 are ignored.
+func (s *Scanner) SetWorkers(workers int) {
+	if s == nil || workers < 1 {
+		return
+	}
+	s.workers.Store(int32(workers))
+}
+
+func (s *Scanner) workerCount() int { return int(s.workers.Load()) }
 
 const scanProgressLogInterval = 10 * time.Second
 
@@ -167,7 +180,7 @@ func NewScanner(fileRepo *FileRepository, ffprobePath string, s3Client *s3client
 	if workers < 1 {
 		workers = 8
 	}
-	return &Scanner{
+	s := &Scanner{
 		fileRepo:            fileRepo,
 		rootSnapshotRepo:    NewScannedRootRepository(fileRepo.Pool()),
 		groupSnapshotRepo:   NewScannedGroupRepository(fileRepo.Pool()),
@@ -183,10 +196,11 @@ func NewScanner(fileRepo *FileRepository, ffprobePath string, s3Client *s3client
 		episodeRepo:         catalog.NewEpisodeRepository(fileRepo.Pool()),
 		ffprobePath:         ffprobePath,
 		s3Client:            s3Client,
-		workers:             workers,
 		emptyTrashAfterScan: emptyTrashAfterScan,
 		markerFetcher:       nil,
 	}
+	s.SetWorkers(workers)
+	return s
 }
 
 // SetSeriesQueueSyncer installs the optional pending-series root queue synchronizer.
@@ -682,11 +696,11 @@ func (s *Scanner) scanPaths(
 
 	// Phase 2: Process files concurrently with a worker pool.
 	var wg sync.WaitGroup
-	pathCh := make(chan string, s.workers)
+	pathCh := make(chan string, s.workerCount())
 	var newCount, updatedCount, unchangedCount, errorCount, processedCount atomic.Int64
 	subtitleCache := newExternalSubtitleDirCache()
 
-	for range s.workers {
+	for range s.workerCount() {
 		wg.Go(func() {
 			for path := range pathCh {
 				if ctx.Err() != nil {
@@ -1159,11 +1173,11 @@ func (s *Scanner) scanScope(
 	}
 
 	var wg sync.WaitGroup
-	pathCh := make(chan string, s.workers)
+	pathCh := make(chan string, s.workerCount())
 	var newCount, updatedCount, unchangedCount, errorCount, processedCount atomic.Int64
 	subtitleCache := newExternalSubtitleDirCache()
 
-	for range s.workers {
+	for range s.workerCount() {
 		wg.Go(func() {
 			for path := range pathCh {
 				if ctx.Err() != nil {

--- a/internal/subtitles/ai/quota.go
+++ b/internal/subtitles/ai/quota.go
@@ -83,23 +83,24 @@ type QuotaStatus struct {
 // insert-time enforcement runs, so the number shown always matches the
 // number enforced.
 func (s *Service) TranscribeQuota(ctx context.Context, userID int, exempt bool) (QuotaStatus, error) {
-	if exempt || s.cfg.TranscribeQuotaJobs <= 0 {
+	cfg := s.config()
+	if exempt || cfg.TranscribeQuotaJobs <= 0 {
 		return QuotaStatus{}, nil
 	}
-	used, err := s.repo.CountTranscribeJobsByUserSince(ctx, userID, s.quotaWindowStart())
+	used, err := s.repo.CountTranscribeJobsByUserSince(ctx, userID, quotaWindowStart(cfg))
 	if err != nil {
 		return QuotaStatus{}, err
 	}
-	remaining := s.cfg.TranscribeQuotaJobs - used
+	remaining := cfg.TranscribeQuotaJobs - used
 	if remaining < 0 {
 		remaining = 0
 	}
 	return QuotaStatus{
 		Limited:   true,
-		Limit:     s.cfg.TranscribeQuotaJobs,
+		Limit:     cfg.TranscribeQuotaJobs,
 		Used:      used,
 		Remaining: remaining,
-		Period:    s.cfg.TranscribeQuotaPeriod,
+		Period:    cfg.TranscribeQuotaPeriod,
 	}, nil
 }
 
@@ -111,17 +112,18 @@ func (s *Service) transcribeQuotaSpec(req JobRequest) *JobQuota {
 	if !req.Kind.IsTranscribe() || req.QuotaExempt || req.RequestedBy == nil {
 		return nil
 	}
-	if s.cfg.TranscribeQuotaJobs <= 0 {
+	cfg := s.config()
+	if cfg.TranscribeQuotaJobs <= 0 {
 		return nil
 	}
 	return &JobQuota{
 		UserID: *req.RequestedBy,
-		Limit:  s.cfg.TranscribeQuotaJobs,
-		Since:  s.quotaWindowStart(),
-		Period: s.cfg.TranscribeQuotaPeriod,
+		Limit:  cfg.TranscribeQuotaJobs,
+		Since:  quotaWindowStart(cfg),
+		Period: cfg.TranscribeQuotaPeriod,
 	}
 }
 
-func (s *Service) quotaWindowStart() time.Time {
-	return time.Now().Add(-QuotaPeriodWindow(s.cfg.TranscribeQuotaPeriod))
+func quotaWindowStart(cfg Config) time.Time {
+	return time.Now().Add(-QuotaPeriodWindow(cfg.TranscribeQuotaPeriod))
 }

--- a/internal/subtitles/ai/service.go
+++ b/internal/subtitles/ai/service.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"sort"
 	"strings"
+	"sync/atomic"
 	"time"
 
 	"github.com/Silo-Server/silo-server/internal/ai/jobrunner"
@@ -60,7 +61,9 @@ type SubtitleLister interface {
 // dispatch, heartbeat, stale-job reaping, cancellation) are delegated to the
 // shared jobrunner so they stay identical across Silo's AI job services.
 type Service struct {
-	cfg         Config
+	// cfg is behind an atomic pointer so admin settings changes apply to
+	// subsequent enqueues/quota checks without rebuilding the service.
+	cfg         atomic.Pointer[Config]
 	repo        JobRepository
 	translator  Translator
 	transcriber Transcriber // optional; nil disables ASR kinds
@@ -71,6 +74,17 @@ type Service struct {
 	ffmpegPath  string
 	logger      *slog.Logger
 	runner      *jobrunner.Runner
+}
+
+// UpdateConfig swaps the service config. Safe for concurrent use; running
+// jobs finish with the config they started with.
+func (s *Service) UpdateConfig(cfg Config) {
+	s.cfg.Store(&cfg)
+}
+
+// config returns a snapshot of the current service config.
+func (s *Service) config() Config {
+	return *s.cfg.Load()
 }
 
 // NewService wires a translation service. notifier may be nil. appCtx is the
@@ -96,8 +110,7 @@ func NewService(
 	if logger == nil {
 		logger = slog.Default()
 	}
-	return &Service{
-		cfg:         cfg,
+	s := &Service{
 		repo:        repo,
 		translator:  translator,
 		transcriber: transcriber,
@@ -109,14 +122,16 @@ func NewService(
 		logger:      logger,
 		runner:      jobrunner.New(appCtx, sem, repo, "subtitle ai", logger),
 	}
+	s.UpdateConfig(cfg)
+	return s
 }
 
 // Enabled reports whether translation can currently run.
-func (s *Service) Enabled() bool { return s.cfg.TranslateReady() }
+func (s *Service) Enabled() bool { return s.config().TranslateReady() }
 
 // TranscribeEnabled reports whether ASR subtitle generation can currently run.
 func (s *Service) TranscribeEnabled() bool {
-	return s.cfg.TranscribeReady() && s.transcriber != nil
+	return s.config().TranscribeReady() && s.transcriber != nil
 }
 
 // Recover clears jobs orphaned by a crashed worker and starts a background
@@ -131,22 +146,25 @@ func (s *Service) Enqueue(ctx context.Context, req JobRequest) (*Job, error) {
 	if req.Kind == "" {
 		req.Kind = JobKindTranslate
 	}
-	jobModel := s.cfg.ChatModel
+	// Snapshot once so the job's model provenance is internally consistent
+	// even if the config reloads mid-enqueue.
+	cfg := s.config()
+	jobModel := cfg.ChatModel
 	switch req.Kind {
 	case JobKindTranslate:
-		if !s.cfg.TranslateReady() {
+		if !cfg.TranslateReady() {
 			return nil, ErrEngineNotConfigured
 		}
 	case JobKindTranscribe:
-		if !s.TranscribeEnabled() {
+		if !cfg.TranscribeReady() || s.transcriber == nil {
 			return nil, ErrEngineNotConfigured
 		}
-		jobModel = s.cfg.ASRModel
+		jobModel = cfg.ASRModel
 	case JobKindTranscribeTranslate:
-		if !s.TranscribeEnabled() || !s.cfg.TranslateReady() {
+		if !cfg.TranscribeReady() || s.transcriber == nil || !cfg.TranslateReady() {
 			return nil, ErrEngineNotConfigured
 		}
-		jobModel = s.cfg.ASRModel + "+" + s.cfg.ChatModel
+		jobModel = cfg.ASRModel + "+" + cfg.ChatModel
 	default:
 		return nil, fmt.Errorf("%w: unsupported job kind %q", ErrInvalidRequest, req.Kind)
 	}

--- a/internal/subtitles/ai/transcriber.go
+++ b/internal/subtitles/ai/transcriber.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"sync/atomic"
 	"time"
 	"unicode/utf8"
 
@@ -69,9 +70,11 @@ type audioTranscriber interface {
 // a word straddling a boundary can be clipped — accepted v1 limitation, noted
 // for a silence-aligned follow-up.
 type WhisperTranscriber struct {
-	client       audioTranscriber
-	ffmpegPath   string
-	chunkSeconds int
+	client audioTranscriber
+	// ffmpegPath/chunkSeconds are atomics so admin settings changes apply to
+	// jobs started afterwards; each job snapshots them once at start.
+	ffmpegPath   atomic.Pointer[string]
+	chunkSeconds atomic.Int32
 	// extract and probeOffset are playback helpers, injectable for tests.
 	extract     func(ctx context.Context, filePath string, audioTrackIndex int, dir, ffmpegPath string, chunkSeconds int) ([]playback.AudioChunk, error)
 	probeOffset func(ctx context.Context, filePath string, audioTrackIndex int, ffmpegPath string) float64
@@ -81,16 +84,24 @@ type WhisperTranscriber struct {
 // chunkSeconds outside [minASRChunkSeconds, defaultASRChunkSeconds] falls
 // back to the default (longer chunks would exceed upload limits).
 func NewWhisperTranscriber(client *llm.Client, ffmpegPath string, chunkSeconds int) *WhisperTranscriber {
+	t := &WhisperTranscriber{
+		client:      client,
+		extract:     playback.ExtractAudioChunks,
+		probeOffset: playback.ProbeAudioStartOffset,
+	}
+	t.SetExtraction(ffmpegPath, chunkSeconds)
+	return t
+}
+
+// SetExtraction updates the ffmpeg path and ASR chunk duration used by jobs
+// started afterwards. Safe for concurrent use; out-of-range chunk durations
+// fall back to the default, matching construction.
+func (t *WhisperTranscriber) SetExtraction(ffmpegPath string, chunkSeconds int) {
 	if chunkSeconds < minASRChunkSeconds || chunkSeconds > defaultASRChunkSeconds {
 		chunkSeconds = defaultASRChunkSeconds
 	}
-	return &WhisperTranscriber{
-		client:       client,
-		ffmpegPath:   ffmpegPath,
-		chunkSeconds: chunkSeconds,
-		extract:      playback.ExtractAudioChunks,
-		probeOffset:  playback.ProbeAudioStartOffset,
-	}
+	t.ffmpegPath.Store(&ffmpegPath)
+	t.chunkSeconds.Store(int32(chunkSeconds))
 }
 
 // Transcribe implements Transcriber. The returned cues are NOT sorted (they
@@ -105,7 +116,12 @@ func (t *WhisperTranscriber) Transcribe(ctx context.Context, req TranscribeJobRe
 	}
 	defer os.RemoveAll(dir)
 
-	chunks, err := t.extract(ctx, req.FilePath, req.AudioTrackIndex, dir, t.ffmpegPath, t.chunkSeconds)
+	// Snapshot once so the whole job extracts and times chunks consistently
+	// even if the config reloads mid-job.
+	ffmpegPath := *t.ffmpegPath.Load()
+	chunkSeconds := int(t.chunkSeconds.Load())
+
+	chunks, err := t.extract(ctx, req.FilePath, req.AudioTrackIndex, dir, ffmpegPath, chunkSeconds)
 	if err != nil {
 		return nil, "", err
 	}
@@ -113,10 +129,10 @@ func (t *WhisperTranscriber) Transcribe(ctx context.Context, req TranscribeJobRe
 	// Audio streams can start after the container's timeline origin (TS
 	// remuxes especially); Whisper times are relative to the first audio
 	// sample, so the delta is a constant sync error unless added back.
-	startOffset := t.probeOffset(ctx, req.FilePath, req.AudioTrackIndex, t.ffmpegPath)
+	startOffset := t.probeOffset(ctx, req.FilePath, req.AudioTrackIndex, ffmpegPath)
 
 	order := chunkOrderForPosition(chunks, req.StartPosition)
-	timeout := time.Duration(t.chunkSeconds*asrChunkTimeoutFactor) * time.Second
+	timeout := time.Duration(chunkSeconds*asrChunkTimeoutFactor) * time.Second
 
 	var all []SubtitleCue
 	detected := ""

--- a/internal/subtitles/ai/transcriber_test.go
+++ b/internal/subtitles/ai/transcriber_test.go
@@ -57,12 +57,13 @@ func evenStarts(n int) []float64 {
 }
 
 func newTestTranscriber(client *fakeASRClient, chunks int, recordDir *string) *WhisperTranscriber {
-	return &WhisperTranscriber{
-		client:       client,
-		chunkSeconds: 600,
-		extract:      stubExtract(evenStarts(chunks), recordDir),
-		probeOffset:  func(context.Context, string, int, string) float64 { return 0 },
+	tr := &WhisperTranscriber{
+		client:      client,
+		extract:     stubExtract(evenStarts(chunks), recordDir),
+		probeOffset: func(context.Context, string, int, string) float64 { return 0 },
 	}
+	tr.SetExtraction("", 600)
+	return tr
 }
 
 func TestTranscribeOffsetsTimestampsByChunkStart(t *testing.T) {
@@ -338,12 +339,12 @@ func TestTranscribeUsesExactChunkStartsAndAudioOffset(t *testing.T) {
 		},
 	}
 	tr := &WhisperTranscriber{
-		client:       client,
-		chunkSeconds: 600,
+		client: client,
 		// The second chunk really starts at 600.5s, not 600s.
 		extract:     stubExtract([]float64{0, 600.5}, &dir),
 		probeOffset: func(context.Context, string, int, string) float64 { return 1.25 },
 	}
+	tr.SetExtraction("", 600)
 
 	cues, _, err := tr.Transcribe(context.Background(), TranscribeJobRequest{FilePath: "/x.mkv"}, nil)
 	if err != nil {

--- a/internal/subtitles/ai/translator.go
+++ b/internal/subtitles/ai/translator.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"strconv"
 	"strings"
+	"sync/atomic"
 
 	"github.com/Silo-Server/silo-server/internal/ai/llm"
 	aitranslate "github.com/Silo-Server/silo-server/internal/ai/translate"
@@ -17,25 +18,34 @@ import (
 // untranslated context so the model can keep scene continuity across batch
 // boundaries.
 type LLMTranslator struct {
-	client           *llm.Client
-	batchSize        int
-	contextNeighbors int
+	client *llm.Client
+	// batching is atomic so admin settings changes apply to jobs started
+	// afterwards without rebuilding the translator.
+	batchSize        atomic.Int32
+	contextNeighbors atomic.Int32
 }
 
 // NewLLMTranslator builds a translator. batchSize and contextNeighbors fall
 // back to sane defaults when non-positive.
 func NewLLMTranslator(client *llm.Client, batchSize, contextNeighbors int) *LLMTranslator {
+	t := &LLMTranslator{client: client}
+	t.SetBatching(batchSize, contextNeighbors)
+	return t
+}
+
+// SetBatching updates the translation batch size and context-neighbor count.
+// Safe for concurrent use; jobs started afterwards pick the new values up.
+// Non-positive batch sizes and negative neighbor counts fall back to the
+// same defaults as construction.
+func (t *LLMTranslator) SetBatching(batchSize, contextNeighbors int) {
 	if batchSize <= 0 {
 		batchSize = 40
 	}
 	if contextNeighbors < 0 {
 		contextNeighbors = 0
 	}
-	return &LLMTranslator{
-		client:           client,
-		batchSize:        batchSize,
-		contextNeighbors: contextNeighbors,
-	}
+	t.batchSize.Store(int32(batchSize))
+	t.contextNeighbors.Store(int32(contextNeighbors))
 }
 
 // Translate implements Translator.
@@ -76,8 +86,8 @@ func (t *LLMTranslator) Translate(ctx context.Context, req TranslateRequest, onB
 		SystemPrompt:     translationSystemPrompt(srcName, tgtName),
 		TargetName:       tgtName,
 		EntryNoun:        "cues",
-		BatchSize:        t.batchSize,
-		ContextNeighbors: t.contextNeighbors,
+		BatchSize:        int(t.batchSize.Load()),
+		ContextNeighbors: int(t.contextNeighbors.Load()),
 	}, func(batch []aitranslate.Segment, done, totalSegs int) {
 		// Batches are sequential ranges, so this batch covers [done-len, done).
 		start := done - len(batch)

--- a/web/src/api/types.ts
+++ b/web/src/api/types.ts
@@ -3415,6 +3415,15 @@ export interface RateLimitUpdateResponse {
   restart_required?: boolean;
 }
 
+/** Response of PUT /admin/settings/{key}. */
+export interface AdminSettingUpdateResponse {
+  key: string;
+  /** Empty for sensitive keys. */
+  value?: string;
+  /** True when the saved value only takes effect after a server restart. */
+  restart_required?: boolean;
+}
+
 // IP visibility
 export interface UserIPEntry {
   client_ip: string;

--- a/web/src/hooks/queries/admin/settings.ts
+++ b/web/src/hooks/queries/admin/settings.ts
@@ -1,6 +1,10 @@
 import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
 import { api } from "@/api/client";
-import type { AdminSettingsConnectionCheckRequest, ConnectionCheckResponse } from "@/api/types";
+import type {
+  AdminSettingUpdateResponse,
+  AdminSettingsConnectionCheckRequest,
+  ConnectionCheckResponse,
+} from "@/api/types";
 import { adminKeys } from "../keys";
 import { toast } from "sonner";
 
@@ -23,7 +27,7 @@ export function useUpdateServerSetting() {
   const queryClient = useQueryClient();
   return useMutation({
     mutationFn: ({ key, value }: { key: string; value: string }) =>
-      api(`/admin/settings/${key}`, {
+      api<AdminSettingUpdateResponse>(`/admin/settings/${key}`, {
         method: "PUT",
         body: JSON.stringify({ value }),
       }),

--- a/web/src/hooks/useSettingsForm.test.ts
+++ b/web/src/hooks/useSettingsForm.test.ts
@@ -1,0 +1,70 @@
+// @vitest-environment jsdom
+
+import { act, cleanup, renderHook } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { useSettingsForm } from "./useSettingsForm";
+
+const { mutateAsync } = vi.hoisted(() => ({ mutateAsync: vi.fn() }));
+
+// Stable identities: useSettingsForm's sync effect depends on the settings
+// object and keys array (pages memoize keys), so fresh objects per render
+// would loop forever.
+const KEYS = ["branding.server_name", "database.max_connections"];
+const settingsData = { "branding.server_name": "Silo", "database.max_connections": "20" };
+const sensitiveData = { configured: [], managed_by_env: [] };
+
+vi.mock("@/hooks/queries/admin/settings", () => ({
+  useAdminServerSettings: () => ({ data: settingsData, isLoading: false }),
+  useAdminSensitiveStatus: () => ({ data: sensitiveData }),
+  useUpdateServerSetting: () => ({ mutateAsync, isPending: false }),
+}));
+
+afterEach(() => {
+  cleanup();
+  mutateAsync.mockReset();
+});
+
+describe("useSettingsForm save()", () => {
+  it("does not flag a restart when no saved key requires one", async () => {
+    mutateAsync.mockResolvedValue({ key: "branding.server_name", restart_required: false });
+
+    const { result } = renderHook(() => useSettingsForm({ keys: KEYS }));
+
+    act(() => {
+      result.current.setValue("branding.server_name", "Casa");
+    });
+    await act(async () => {
+      await result.current.save();
+    });
+
+    expect(mutateAsync).toHaveBeenCalledWith({ key: "branding.server_name", value: "Casa" });
+    expect(result.current.restartRequired).toBe(false);
+  });
+
+  it("flags a restart when any saved key requires one, and keeps it flagged", async () => {
+    mutateAsync.mockImplementation(({ key }: { key: string }) =>
+      Promise.resolve({ key, restart_required: key === "database.max_connections" }),
+    );
+
+    const { result } = renderHook(() => useSettingsForm({ keys: KEYS }));
+
+    act(() => {
+      result.current.setValue("branding.server_name", "Casa");
+      result.current.setValue("database.max_connections", "40");
+    });
+    await act(async () => {
+      await result.current.save();
+    });
+    expect(result.current.restartRequired).toBe(true);
+
+    // A later save of a live-applied key must not clear the pending restart.
+    act(() => {
+      result.current.setValue("branding.server_name", "Villa");
+    });
+    await act(async () => {
+      await result.current.save();
+    });
+    expect(result.current.restartRequired).toBe(true);
+  });
+});

--- a/web/src/hooks/useSettingsForm.ts
+++ b/web/src/hooks/useSettingsForm.ts
@@ -61,9 +61,14 @@ export function useSettingsForm({ keys }: UseSettingsFormOptions) {
     const promises = Array.from(dirty).map((key) =>
       updateSetting.mutateAsync({ key, value: localValues[key] ?? "" }),
     );
-    await Promise.all(promises);
+    const results = await Promise.all(promises);
     setDirty(new Set());
-    setRestartRequired(true);
+    // The backend reports per key whether a restart is needed; most settings
+    // hot-reload. Once a restart-required key was saved, keep the banner up
+    // until the server actually restarts.
+    if (results.some((r) => r?.restart_required)) {
+      setRestartRequired(true);
+    }
   }, [dirty, localValues, updateSetting]);
 
   const discard = useCallback(() => {

--- a/web/src/pages/admin-settings/DownloadSettings.tsx
+++ b/web/src/pages/admin-settings/DownloadSettings.tsx
@@ -80,7 +80,7 @@ export default function DownloadSettings() {
         onSave={form.save}
         onDiscard={form.discard}
         isSaving={form.isSaving}
-        restartRequired={false}
+        restartRequired={form.restartRequired}
       />
     </div>
   );

--- a/web/src/pages/admin-settings/OverlaySettings.tsx
+++ b/web/src/pages/admin-settings/OverlaySettings.tsx
@@ -180,7 +180,7 @@ export default function OverlaySettings() {
         onSave={form.save}
         onDiscard={form.discard}
         isSaving={form.isSaving}
-        restartRequired={false}
+        restartRequired={form.restartRequired}
       />
     </div>
   );

--- a/web/src/pages/admin-settings/PlaybackSettings.tsx
+++ b/web/src/pages/admin-settings/PlaybackSettings.tsx
@@ -11,12 +11,9 @@ const KEYS = [
   "playback.hw_accel",
   "playback.transcode_enabled",
   "playback.local_transcode_fallback",
-  "playback.allow_hevc_encoding",
   "allow_4k_transcode",
   "enable_transcode_throttle",
   "transcode_throttle_seconds",
-  "playback.transcode_ahead_segments",
-  "playback.segment_duration",
   "playback.chapter_thumbnail_workers",
   "playback.chapter_thumbnail_execution",
   "playback.chapter_thumbnail_node_capacity",
@@ -96,12 +93,6 @@ export default function PlaybackSettings() {
             onChange={(v) => form.setValue("playback.local_transcode_fallback", v)}
           />
           <SettingField
-            label="Allow HEVC Encoding"
-            type="toggle"
-            value={form.getValue("playback.allow_hevc_encoding")}
-            onChange={(v) => form.setValue("playback.allow_hevc_encoding", v)}
-          />
-          <SettingField
             label="Allow 4K Transcoding"
             type="toggle"
             value={form.getValue("allow_4k_transcode")}
@@ -125,18 +116,6 @@ export default function PlaybackSettings() {
         </FieldGroup>
 
         <FieldGroup label="Segments">
-          <SettingField
-            label="Transcode Ahead Segments"
-            type="number"
-            value={form.getValue("playback.transcode_ahead_segments")}
-            onChange={(v) => form.setValue("playback.transcode_ahead_segments", v)}
-          />
-          <SettingField
-            label="Segment Duration"
-            type="number"
-            value={form.getValue("playback.segment_duration")}
-            onChange={(v) => form.setValue("playback.segment_duration", v)}
-          />
           <SettingField
             label="Chapter Thumbnail Workers"
             type="number"

--- a/web/src/pages/admin-settings/ScannerSettings.tsx
+++ b/web/src/pages/admin-settings/ScannerSettings.tsx
@@ -5,13 +5,7 @@ import { SaveBar } from "./SaveBar";
 import { FieldGroup } from "./FieldGroup";
 import { Skeleton } from "@/components/ui/skeleton";
 
-const KEYS = [
-  "scanner.workers",
-  "scanner.file_removal_grace",
-  "matcher.workers",
-  "matcher.batch_size",
-  "metadata.cache_images",
-];
+const KEYS = ["scanner.workers", "matcher.workers", "matcher.batch_size", "metadata.cache_images"];
 
 export default function ScannerSettings() {
   const form = useSettingsForm({ keys: useMemo(() => KEYS, []) });
@@ -52,13 +46,6 @@ export default function ScannerSettings() {
             type="number"
             value={form.getValue("scanner.workers")}
             onChange={(v) => form.setValue("scanner.workers", v)}
-          />
-          <SettingField
-            label="File Removal Grace"
-            type="duration"
-            hint="e.g. 24h"
-            value={form.getValue("scanner.file_removal_grace")}
-            onChange={(v) => form.setValue("scanner.file_removal_grace", v)}
           />
         </FieldGroup>
 


### PR DESCRIPTION
## Problem

Every save in the admin settings UI showed "restart required" because `useSettingsForm.save()` set the flag unconditionally — the backend was never asked. Auditing every key showed the reality was worse in both directions: ~20 settings were already applied live (the banner was just wrong), ~25 were frozen at startup for no structural reason, and 5 settings were wired to nothing at all (saving + restarting changed no behavior). Only the infrastructure settings (DB pool, S3 clients, Redis, userdb backend, listeners) genuinely need a restart.

## Approach

The hot-reload machinery already existed — `nodeconfig.Watcher` reloads config on `EventSettingsChanged` + a 60s poll with an atomic pointer swap — but was only wired into the proxy/transcode worker modes. This PR extends it to integrated mode and converts consumers incrementally (one commit per area, each shrinking the restart-required registry):

1. **Watcher hardening** — non-blocking `RequestReload()` (avoids a stale-swap race that `ForceReload` from request handlers would allow), deep-equal guard so the 60s poll doesn't fire callbacks on no-op reloads, `RedisURL` bootstrap override (a reload previously clobbered an env-provided Redis URL).
2. **Integrated-mode wiring** — watcher started in integrated/api mode; `LiveConfig`/`OnConfigChange` func-typed fields on `api.Dependencies` and `jellycompat.Dependencies` (nil falls back to the startup snapshot, keeping tests/workers unchanged); settings saves nudge the watcher directly so changes apply instantly even without Redis.
3. **Truthful banner** — central registry (`internal/config/restart_keys.go`); `PUT /admin/settings/{key}` returns `restart_required`; the UI raises the banner only when a saved key needs it.
4. **Conversions** — pull-based (read live config at use time) for handlers that already see `*config.Config` (playback, jellycompat); push-based atomic setters wired to `OnConfigChange` for decoupled packages (llm client, subtitle/metadata AI services, scanner, matcher, mdblist, slog LevelVar, logfilter). Per-use snapshots keep a single request/job internally consistent across reloads.

Now live without restart: log level/quiet, token expiries (new tokens), jellycompat identity fields, transcode dir + per-session ffmpeg/hwaccel, scanner/matcher concurrency, `metadata.cache_images`, MDBList key, and the entire AI Services page except `ai.max_concurrent_jobs` (fixed-capacity semaphore). Still restart-required: `database.*`, `userdb.*`, `s3.*`, `redis.*`, ratelimit backend, JWT secret, compat listeners/session TTLs, `tmdb.api_key`, `recommendations.*`, chapter-thumbnail workers.

## Bugs found and fixed along the way

- `playback.hw_device` was parsed but never wired in integrated mode — local transcodes always ran with an empty HW device while transcode nodes honored it.
- `playback.transcode_enabled` did nothing: the resolver received a hardcoded `true`. Now wired and live.
- Dead knobs removed from UI + config (`playback.allow_hevc_encoding`, `playback.transcode_ahead_segments`, `playback.segment_duration`, `scanner.file_removal_grace`) — none had any consumer. YAML import still tolerates the legacy keys.

## Risks / notes for review

- The restart-key registry is the contract: a key wrongly absent from it would show "applied live" while actually frozen. It was built from a full consumer audit and starts conservative; please flag anything you know to be frozen that isn't listed.
- Converted fields use atomics (`atomic.Pointer`/`Int32`/`Bool`) — no plain field writes from reload callbacks; all touched packages pass `go test -race`.
- Without Redis, UI saves apply instantly (the save handler nudges the watcher); direct DB edits take up to 60s (poll).
- `ffmpeg_path`/`hw_accel` stay restart-required despite the playback handler reading them live, because scanner ffprobe, chapter thumbnails, and the audiobook enricher still freeze them at startup — converting those is natural follow-up work.
- UI change is subtle: the restart banner in admin settings now appears only for restart-required keys; `DownloadSettings`/`OverlaySettings` lost their hardcoded `restartRequired={false}` special-casing.

## Verification

`go build ./...`, `go vet ./...`, `go test -race` across all touched packages (nodeconfig, auth, jellycompat, scanner, metadata/*, mdblist, subtitles/ai, ai/*, logfilter, api/*, config), web `eslint` + `prettier --check` + vitest (incl. new tests for the banner aggregation, logfilter prefix swapping, and watcher coalescing/no-op suppression), `make verify-local-paths`. golangci-lint was not available locally — relying on CI for that gate.

## AI use

Implemented end-to-end with Claude Code (audit, plan, implementation, tests), human-directed and reviewed per commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Configuration hot-reload support for logging level, worker counts, image caching, API keys, and token expiry settings without requiring restart
  * Admin API now indicates which settings require server restart

* **UI/UX Improvements**
  * Settings pages display actual restart requirements based on configuration changes
  * Playback settings updated with 4K transcoding and throttle options
  * Simplified scanner settings UI

* **Configuration Updates**
  * Removed deprecated transcoding and scanner configuration options

<!-- end of auto-generated comment: release notes by coderabbit.ai -->