### PR TITLE
fix(player): flip ASS subtitle delay sign to match VTT semantics

### DIFF
--- a/web/src/player/hooks/useASSSubtitles.test.tsx
+++ b/web/src/player/hooks/useASSSubtitles.test.tsx
@@ -4,8 +4,10 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { useASSSubtitles } from "./useASSSubtitles";
 import type { PlayerSubtitleInfo } from "../types";
 
-// Capture the options every JASSUB instance is constructed with.
+// Capture the options every JASSUB instance is constructed with, plus the
+// instances themselves so tests can observe later timeOffset updates.
 const constructorOpts: Array<Record<string, unknown>> = [];
+const instances: Array<{ timeOffset: number }> = [];
 
 vi.mock("jassub", () => {
   class MockJASSUB {
@@ -14,6 +16,8 @@ vi.mock("jassub", () => {
     renderer = { setTrackByUrl: vi.fn().mockResolvedValue(undefined) };
     constructor(opts: Record<string, unknown>) {
       constructorOpts.push(opts);
+      this.timeOffset = (opts.timeOffset as number) ?? 0;
+      instances.push(this);
     }
     resize = vi.fn().mockResolvedValue(undefined);
     destroy = vi.fn();
@@ -80,6 +84,7 @@ function mockFontBundleResponse(bytes: string): Response {
 
 beforeEach(() => {
   constructorOpts.length = 0;
+  instances.length = 0;
   vi.stubGlobal("fetch", vi.fn().mockResolvedValue(mockFetchResponse("")));
 });
 
@@ -174,5 +179,46 @@ describe("useASSSubtitles font fallback", () => {
     await waitFor(() => expect(constructorOpts).toHaveLength(1));
 
     expect(constructorOpts[0]!.queryFonts).toBe(false);
+  });
+});
+
+describe("useASSSubtitles time offset", () => {
+  // JASSUB renders the ASS event matching `video.currentTime + timeOffset`,
+  // so an event at source time S appears at video time S - timeOffset.
+  // Positive user delay means "show subtitles later" (VTTCue semantics in
+  // useSubtitleTracks shifts cues by `start - origin + delay`), which for
+  // JASSUB requires SUBTRACTING the delay from the stream origin.
+
+  it("subtracts a positive user delay from the constructed timeOffset", async () => {
+    renderHook(() => useASSSubtitles(makeVideoRef(), [germanTrack], 6, false, 30, 2000));
+
+    await waitFor(() => expect(constructorOpts).toHaveLength(1));
+
+    // origin 30s, +2000ms delay → event at source time S renders at video
+    // time S - 28 = (S - 30) + 2, i.e. 2s later than the undelayed position.
+    expect(constructorOpts[0]!.timeOffset).toBe(28);
+  });
+
+  it("adds a negative user delay to the constructed timeOffset", async () => {
+    renderHook(() => useASSSubtitles(makeVideoRef(), [germanTrack], 6, false, 30, -2000));
+
+    await waitFor(() => expect(constructorOpts).toHaveLength(1));
+
+    expect(constructorOpts[0]!.timeOffset).toBe(32);
+  });
+
+  it("updates the live instance's timeOffset when the delay changes", async () => {
+    const videoRef = makeVideoRef();
+    const { rerender } = renderHook(
+      ({ delay }) => useASSSubtitles(videoRef, [germanTrack], 6, false, 30, delay),
+      { initialProps: { delay: 0 } },
+    );
+
+    await waitFor(() => expect(instances).toHaveLength(1));
+    expect(instances[0]!.timeOffset).toBe(30);
+
+    rerender({ delay: 2000 });
+
+    await waitFor(() => expect(instances[0]!.timeOffset).toBe(28));
   });
 });

--- a/web/src/player/hooks/useASSSubtitles.ts
+++ b/web/src/player/hooks/useASSSubtitles.ts
@@ -31,10 +31,13 @@ export function useASSSubtitles(
 ): { isActive: boolean } {
   const jassubRef = useRef<JASSUB | null>(null);
   const jassubImportRef = useRef<Promise<typeof JASSUB> | null>(null);
-  // Effective JASSUB time offset. `streamOriginSeconds` accounts for HLS
-  // PTS rebasing; the user-facing delay (ms → s) adds on top. Positive
-  // delay = subtitles shown later, matching VTTCue semantics.
-  const effectiveOffset = streamOriginSeconds + subtitleDelayMs / 1000;
+  // Effective JASSUB time offset. JASSUB renders the ASS event matching
+  // `video.currentTime + timeOffset`, so an event at source time S appears
+  // at video time S - timeOffset. `streamOriginSeconds` accounts for HLS
+  // PTS rebasing; the user-facing delay (ms → s) must be SUBTRACTED so that
+  // positive delay = subtitles shown later, matching the VTT path's
+  // `start - origin + delay` cue shift.
+  const effectiveOffset = streamOriginSeconds - subtitleDelayMs / 1000;
   const streamOriginRef = useRef(effectiveOffset);
   streamOriginRef.current = effectiveOffset;
 


### PR DESCRIPTION
## Problem

The user-facing subtitle delay had an inverted sign for ASS/SSA tracks. `useASSSubtitles` computed the JASSUB offset as `streamOriginSeconds + subtitleDelayMs / 1000`, but JASSUB renders the ASS event matching `video.currentTime + timeOffset` (sole use site: `renderer._draw(mediaTime + this.timeOffset)` in `jassub/dist/jassub.js`), so an event at source time S appears at video time `S - timeOffset`. Adding the delay therefore showed ASS subtitles **earlier** on positive delay, while:

- the VTT path (`useSubtitleTracks`) shifts cues by `start - origin + delay` → **later**,
- the subtitle menu labels the `+` button "later",
- the hook's own comment claimed VTTCue semantics.

At +2000ms delay, an ASS track diverged from an SRT track of the same content by a full 4 seconds.

## Fix

- Compute the offset as `streamOriginSeconds - subtitleDelayMs / 1000` so positive delay shows subtitles later, matching the VTT path exactly.
- Rewrite the comment to state the actual JASSUB render equation instead of the incorrect VTTCue claim.
- Add unit tests asserting the constructed `timeOffset` for positive and negative delays, and that a delay change updates the live JASSUB instance's `timeOffset` without rebuilding it.

## Verification

- Verified against the shipped JASSUB source: `timeOffset` has exactly one consumer, `_draw(mediaTime + timeOffset)`, where `mediaTime` is the presented frame time from `requestVideoFrameCallback` — the sign math is unambiguous.
- `pnpm vitest run src/player/hooks/useASSSubtitles.test.tsx`: 9/9 pass.
- ESLint clean on touched files; `prettier --check` passes.

## Notes for reviewers

- If the Android/Apple clients render ASS through libass with a similar offset-plus-delay computation, they may carry the same inverted sign and are worth a quick audit (not checked in this PR).
- AI use: this change was authored with Claude Code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed subtitle delay calculation to ensure proper synchronization. Positive delays now correctly shift subtitle timing forward, resolving timing misalignment issues between subtitles and video playback.

* **Tests**
  * Expanded test suite with new cases for subtitle offset functionality, verifying correct delay calculations and dynamic updates to synchronization timing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->