### PR TITLE
fix(partman): self-heal default-partition conflicts instead of crash-looping

### DIFF
--- a/cmd/silo/main.go
+++ b/cmd/silo/main.go
@@ -165,7 +165,10 @@ func configureOperationalLogging(
 	}
 	opsPM := partman.NewManager(pool, "operational_logs", partman.Daily, 3)
 	if err := opsPM.EnsureFuturePartitions(ctx); err != nil {
-		log.Fatalf("ensure operational log partitions: %v", err)
+		// Non-fatal: a partition hiccup must not crash-loop the server (see the
+		// operational_logs partition incident). Writes fall back to the default
+		// partition and the periodic cleanup retries EnsureFuturePartitions.
+		slog.Warn("ensure operational log partitions; continuing in degraded mode", "error", err)
 	}
 
 	var operationalWriter opslog.Writer
@@ -1473,7 +1476,9 @@ func main() {
 	}
 	activityPM := partman.NewManager(pool, "activity_log", partman.Weekly, 2)
 	if err := activityPM.EnsureFuturePartitions(appCtx); err != nil {
-		log.Fatalf("ensure activity log partitions: %v", err)
+		// Non-fatal: see the operational_logs partition incident. Writes fall
+		// back to the default partition and periodic cleanup retries.
+		slog.Warn("ensure activity log partitions; continuing in degraded mode", "error", err)
 	}
 	var activityWriter activitylog.Writer
 	activityConsumer := activitylog.NewConsumer(pool, nil, logStreamHub)

--- a/internal/partman/partman.go
+++ b/internal/partman/partman.go
@@ -106,6 +106,20 @@ func (m *Manager) healDefaultConflict(ctx context.Context, name string, lower, u
 	}
 	defer func() { _ = tx.Rollback(ctx) }()
 
+	// Block concurrent writes to the default partition for the duration of the
+	// heal. The missing partition is the current period, so live writers are
+	// actively routing rows into default; without this lock a row committed
+	// between the drain and the attach re-triggers the same check violation and
+	// rolls the whole heal back. Locking only the default leaf (not the parent)
+	// keeps the rest of the table readable and writable; tuple routing must
+	// lock the leaf to insert, so this is sufficient.
+	if _, err := tx.Exec(ctx, fmt.Sprintf(
+		`LOCK TABLE public.%s IN ACCESS EXCLUSIVE MODE`,
+		quoteIdent(defaultTable),
+	)); err != nil {
+		return fmt.Errorf("lock default partition: %w", err)
+	}
+
 	// Standalone table matching the parent's columns. INCLUDING DEFAULTS is
 	// deliberately the only option: it must NOT copy the parent's identity, so
 	// the preserved rows insert with their original ids instead of regenerating.

--- a/internal/partman/partman.go
+++ b/internal/partman/partman.go
@@ -2,14 +2,22 @@ package partman
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"regexp"
 	"sort"
 	"strings"
 	"time"
 
+	"github.com/jackc/pgx/v5/pgconn"
 	"github.com/jackc/pgx/v5/pgxpool"
 )
+
+// pgCheckViolation is the SQLSTATE Postgres returns when CREATE … PARTITION OF
+// (or ATTACH PARTITION) would move rows out of the default partition — i.e. the
+// default partition already holds a row that belongs in the new partition's
+// range. See incident docs/continuum-to-silo-postgres-migration.md.
+const pgCheckViolation = "23514"
 
 const deleteBatchSize = 10000
 
@@ -48,15 +56,97 @@ func (m *Manager) EnsureFuturePartitions(ctx context.Context) error {
 		lower := m.granularity.addPeriods(start, i)
 		upper := m.granularity.next(lower)
 		name := m.partitionName(lower)
-		if _, err := m.pool.Exec(ctx, fmt.Sprintf(
+		_, err := m.pool.Exec(ctx, fmt.Sprintf(
 			`CREATE TABLE IF NOT EXISTS public.%s PARTITION OF public.%s FOR VALUES FROM (%s) TO (%s)`,
 			quoteIdent(name),
 			quoteIdent(m.table),
 			quoteLiteralTimestamp(lower),
 			quoteLiteralTimestamp(upper),
-		)); err != nil {
+		))
+		if err == nil {
+			continue
+		}
+
+		// The create fails with a check_violation only when the default
+		// partition already holds rows that belong in this partition's range.
+		// Rather than treating that as fatal (the crash-loop in the incident),
+		// drain those rows out of default and attach the partition so the rows
+		// land where they belong. Any other error is genuine and propagates.
+		var pgErr *pgconn.PgError
+		if !errors.As(err, &pgErr) || pgErr.Code != pgCheckViolation {
 			return fmt.Errorf("create partition %s: %w", name, err)
 		}
+		if healErr := m.healDefaultConflict(ctx, name, lower, upper); healErr != nil {
+			return fmt.Errorf("create partition %s: heal default conflict: %w", name, healErr)
+		}
+	}
+
+	return nil
+}
+
+// healDefaultConflict recovers from the case where CREATE … PARTITION OF failed
+// because the default partition holds rows belonging in [lower, upper). It moves
+// exactly those rows out of the default partition and attaches a fresh partition
+// for the range, preserving every row (including its original id).
+//
+// The entire operation runs in a single transaction: a standalone table is
+// created (without copying the parent's identity, so original ids re-insert
+// cleanly), the conflicting rows are moved into it with a DELETE … RETURNING,
+// and it is then ATTACHed — Postgres re-scans the now-drained default partition
+// and the attach succeeds. If any step fails (including the re-insert), the
+// transaction rolls back atomically: the rows return to the default partition
+// untouched and no partition is created, so the caller can safely retry later.
+// No row is ever destroyed.
+func (m *Manager) healDefaultConflict(ctx context.Context, name string, lower, upper time.Time) error {
+	defaultTable := m.defaultPartitionName()
+
+	tx, err := m.pool.Begin(ctx)
+	if err != nil {
+		return fmt.Errorf("begin: %w", err)
+	}
+	defer func() { _ = tx.Rollback(ctx) }()
+
+	// Standalone table matching the parent's columns. INCLUDING DEFAULTS is
+	// deliberately the only option: it must NOT copy the parent's identity, so
+	// the preserved rows insert with their original ids instead of regenerating.
+	if _, err := tx.Exec(ctx, fmt.Sprintf(
+		`CREATE TABLE public.%s (LIKE public.%s INCLUDING DEFAULTS)`,
+		quoteIdent(name),
+		quoteIdent(m.table),
+	)); err != nil {
+		return fmt.Errorf("create standalone table: %w", err)
+	}
+
+	// Move the conflicting rows out of default into the standalone table in one
+	// statement. RETURNING * preserves parent column order, matching the LIKE.
+	if _, err := tx.Exec(ctx, fmt.Sprintf(`
+		WITH moved AS (
+			DELETE FROM public.%s
+			WHERE "timestamp" >= $1 AND "timestamp" < $2
+			RETURNING *
+		)
+		INSERT INTO public.%s SELECT * FROM moved
+	`,
+		quoteIdent(defaultTable),
+		quoteIdent(name),
+	), lower.UTC(), upper.UTC()); err != nil {
+		return fmt.Errorf("drain default rows: %w", err)
+	}
+
+	// Attach. Postgres re-scans the default partition to confirm no row still
+	// falls in [lower, upper); the drain above makes that pass.
+	if _, err := tx.Exec(ctx, fmt.Sprintf(
+		`ALTER TABLE public.%s ATTACH PARTITION public.%s FOR VALUES FROM (%s) TO (%s)`,
+		quoteIdent(m.table),
+		quoteIdent(name),
+		quoteLiteralTimestamp(lower),
+		quoteLiteralTimestamp(upper),
+	)); err != nil {
+		return fmt.Errorf("attach partition: %w", err)
+	}
+
+	if err := tx.Commit(ctx); err != nil {
+		return fmt.Errorf("commit: %w", err)
 	}
 
 	return nil


### PR DESCRIPTION
## Problem

**Silo crash-loops on startup when a daily log partition can't be created.**

On server startup, the operational-log and activity-log subsystems provision a
date-ranged partition for the current day. If the catch-all *default* partition
already holds even a single row whose timestamp belongs in the day being
created, PostgreSQL refuses to create the new partition. Until now the server
treated that refusal as fatal: it logged and exited. With `restart: unless-stopped`,
that turned into an endless restart loop with no in-app recovery — the only way
out was for an operator to manually `TRUNCATE` the default partition by hand.

This was observed on a real deployment immediately after migrating a database
onto the current `main`: the server came up, applied all migrations cleanly,
then crash-looped every few seconds with:

```
ensure operational log partitions: create partition operational_logs_p_20260612:
ERROR: updated partition constraint for default partition "operational_logs_default"
would be violated by some row (SQLSTATE 23514)
```

The instance was fully down — no admin UI, no playback, no API — purely because
of one stray row in a bookkeeping partition.

## Solution

### fix(partman): self-heal default-partition conflicts instead of crash-looping

When `CREATE ... PARTITION OF` fails with SQLSTATE `23514` (check_violation),
`EnsureFuturePartitions` now self-heals instead of giving up
(`internal/partman/partman.go`). In a single transaction it:

1. Creates a standalone table matching the parent, deliberately **without**
   copying identity, so the original ids re-insert cleanly.
2. `DELETE ... RETURNING` the in-range rows out of the default partition into
   that standalone table.
3. `ATTACH`es it as the partition for the target range.

Because all three steps share one transaction, any failure rolls back
atomically: the rows return to the default partition untouched, no partition is
created, and the next cleanup tick simply retries. No row is ever destroyed.

Both startup call sites — operational_logs and activity_log — are downgraded
from `log.Fatalf` to a warning (`cmd/silo/main.go`), so even an unforeseen
partitioning hiccup now degrades to writing into the default partition rather
than taking the whole server down.

This approach was chosen over alternatives (e.g. pre-truncating the default
partition, or simply ignoring the error) because it is **non-destructive and
correct under load**: it moves exactly the conflicting rows, preserves their
ids, and is safe to retry.

## Risk / follow-ups

- The self-heal runs inside the partition-maintenance path; if the default
  partition holds a very large number of in-range rows, the drain+attach
  transaction will be correspondingly larger. In practice the default partition
  should only ever hold a small number of stray/edge rows, so this is expected
  to be cheap.
- Only the `23514` case is special-cased; other partition-creation failures
  still surface as warnings (no longer fatal) and are retried on the next tick.
- No schema migration is involved; this is purely runtime partition maintenance.

## Verification

- `go build ./...` succeeds; image built and deployed as `silo:local`.
- Reproduced the original crash-loop on a live deployment running this branch's
  parent commit (current `main`): server restart-looped on the `23514` error
  above with `RestartCount` climbing.
- After applying this fix and recreating the container: server reaches
  `healthy` with `restarts=0`, `/api/v1/health` returns `HTTP 200`, and the
  logs show the maintenance path completing normally
  (`opslog dropped expired partitions ...`) with today's partition and indexes
  created. No `23514` / fatal lines after boot.

## AI-use disclosure

Investigation, diff authoring assistance, and live-deployment verification were
carried out with AI assistance (Claude Code), per the repository's
merge-request guidelines.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Startup now tolerates partition-setup issues: logs warnings and continues in a degraded mode instead of aborting, reducing downtime.
  * Added automatic partition conflict recovery: conflicting rows are relocated and partitions attached to enable successful partition initialization without data loss.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->