### PR TITLE
feat(notifications): notify requesters of request status changes

### DIFF
--- a/internal/api/router.go
+++ b/internal/api/router.go
@@ -531,10 +531,11 @@ func NewRouter(deps Dependencies) chi.Router {
 		if viewerResolver != nil {
 			requestSvc.SetEntitlementResolver(mediarequests.NewAccessEntitlements(viewerResolver))
 		}
-		// Server-channel broadcast of request lifecycle events (submitted /
-		// approved / declined). Fulfilled rides the reconcile service's
+		// Request lifecycle notifications (submitted / approved / declined):
+		// server-channel broadcasts plus personal deliveries to the requester
+		// on approve/decline. Fulfilled rides the reconcile service's
 		// fulfillment notifier instead.
-		if lifecycle := notifications.NewServerChannelLifecycleNotifier(deps.Notifications); lifecycle != nil {
+		if lifecycle := notifications.NewRequestLifecycleNotifier(deps.Notifications); lifecycle != nil {
 			requestSvc.SetLifecycleNotifier(lifecycle)
 		}
 		requestHandler = handlers.NewRequestsHandler(requestSvc)

--- a/internal/notifications/account_channel_engine.go
+++ b/internal/notifications/account_channel_engine.go
@@ -25,6 +25,16 @@ const (
 	ChannelModePerEpisodeAndDigest = "per_episode_and_digest"
 )
 
+// transactionalDeliveryTypes are the delivery types that bypass digest
+// batching: digest-mode recipients receive them in a prompt early send (the
+// off-schedule leg in processRecipient) instead of waiting for the digest
+// hour. The repo's HasTransactional* queries and the channels'
+// hasTransactionalPendingSince implementations filter on this list.
+var transactionalDeliveryTypes = []string{
+	DeliveryTypeRequestApproved,
+	DeliveryTypeRequestDeclined,
+}
+
 // ValidChannelMode reports whether mode is a recognized account-channel mode.
 func ValidChannelMode(mode string) bool {
 	switch mode {
@@ -166,6 +176,12 @@ type accountChannel[K comparable] interface {
 	// past the watermark, so idle recipients don't open a claim transaction
 	// every pass.
 	hasPendingSince(ctx context.Context, key K, since Cursor) (bool, error)
+	// hasTransactionalPendingSince cheaply reports whether the recipient has
+	// transactional deliveries (request-status notices; see
+	// transactionalDeliveryTypes) past the watermark. Digest-mode recipients
+	// with transactional rows pending get an early send instead of waiting
+	// for the digest hour.
+	hasTransactionalPendingSince(ctx context.Context, key K, since Cursor) (bool, error)
 	// listSince returns the recipient's deliveries newer than the watermark,
 	// ascending, inside the claim transaction. A non-zero until excludes rows
 	// created at or after it (the digest window's exclusive upper edge).
@@ -293,7 +309,20 @@ func (w *accountChannelWorker[K]) runPass(ctx context.Context) {
 			}
 		case ChannelModeDailyDigest:
 			if !digestDue {
-				continue
+				// Transactional notices bypass the digest schedule: a pending
+				// request-status row makes the recipient eligible for a
+				// prompt early send (the off-schedule leg in
+				// processRecipient).
+				pending, err := w.channel.hasTransactionalPendingSince(ctx, rec.Key,
+					Cursor{CreatedAt: rec.WatermarkCreatedAt, ID: rec.WatermarkID})
+				if err != nil {
+					w.logger.Warn("channel pass: transactional pending check failed",
+						"recipient", rec.Key, "error", err)
+					continue
+				}
+				if !pending {
+					continue
+				}
 			}
 		default:
 			continue
@@ -354,7 +383,20 @@ func (w *accountChannelWorker[K]) processRecipient(ctx context.Context, rec acco
 	case ChannelModePerEpisode:
 	case ChannelModeDailyDigest:
 		if !digestDue {
-			return nil
+			// Off-schedule transactional leg: request-status notices must not
+			// wait for the digest hour. The send flushes the pending window
+			// with digest rendering but leaves last_digest_at alone, so the
+			// daily schedule is unaffected and tomorrow's digest covers only
+			// rows past this send's watermark. Re-derived under the lock: the
+			// pre-scan signal may predate another node's send.
+			pending, err := w.channel.hasTransactionalPendingSince(ctx, rec.Key, since)
+			if err != nil {
+				return err
+			}
+			if !pending {
+				return nil
+			}
+			break
 		}
 		now := w.now()
 		digestAt = &now

--- a/internal/notifications/delivery_repo.go
+++ b/internal/notifications/delivery_repo.go
@@ -283,6 +283,24 @@ func (r *DeliveryRepository) HasForUserSince(ctx context.Context, userID int, si
 	return exists, nil
 }
 
+// HasTransactionalForUserSince reports whether the account has any
+// transactional delivery (digest-bypassing request-status notice; see
+// transactionalDeliveryTypes) newer than the given watermark.
+func (r *DeliveryRepository) HasTransactionalForUserSince(ctx context.Context, userID int, since Cursor) (bool, error) {
+	var exists bool
+	err := r.pool.QueryRow(ctx, `
+		SELECT EXISTS (
+			SELECT 1 FROM notification_deliveries
+			WHERE user_id = $1 AND (created_at, id) > ($2, $3) AND type = ANY($4)
+		)`,
+		userID, since.CreatedAt, since.ID, transactionalDeliveryTypes,
+	).Scan(&exists)
+	if err != nil {
+		return false, fmt.Errorf("check transactional deliveries since watermark: %w", err)
+	}
+	return exists, nil
+}
+
 // ListForProfileSince returns the profile's deliveries newer than the
 // watermark, ascending. A non-zero until excludes rows created at or after it
 // (digest window upper edge). Runs inside the channel worker's claim
@@ -318,6 +336,24 @@ func (r *DeliveryRepository) HasForProfileSince(ctx context.Context, profileID s
 	).Scan(&exists)
 	if err != nil {
 		return false, fmt.Errorf("check profile deliveries since watermark: %w", err)
+	}
+	return exists, nil
+}
+
+// HasTransactionalForProfileSince reports whether the profile has any
+// transactional delivery (digest-bypassing request-status notice; see
+// transactionalDeliveryTypes) newer than the given watermark.
+func (r *DeliveryRepository) HasTransactionalForProfileSince(ctx context.Context, profileID string, since Cursor) (bool, error) {
+	var exists bool
+	err := r.pool.QueryRow(ctx, `
+		SELECT EXISTS (
+			SELECT 1 FROM notification_deliveries
+			WHERE profile_id = $1 AND (created_at, id) > ($2, $3) AND type = ANY($4)
+		)`,
+		profileID, since.CreatedAt, since.ID, transactionalDeliveryTypes,
+	).Scan(&exists)
+	if err != nil {
+		return false, fmt.Errorf("check profile transactional deliveries since watermark: %w", err)
 	}
 	return exists, nil
 }

--- a/internal/notifications/discord_dm.go
+++ b/internal/notifications/discord_dm.go
@@ -76,6 +76,10 @@ func (c *discordChannel) hasPendingSince(ctx context.Context, userID int, since 
 	return c.deliveries.HasForUserSince(ctx, userID, since)
 }
 
+func (c *discordChannel) hasTransactionalPendingSince(ctx context.Context, userID int, since Cursor) (bool, error) {
+	return c.deliveries.HasTransactionalForUserSince(ctx, userID, since)
+}
+
 func (c *discordChannel) listSince(ctx context.Context, tx pgx.Tx, userID int, since Cursor, until time.Time, limit int) ([]DeliveryRow, error) {
 	return c.deliveries.ListForUserSince(ctx, tx, userID, since, until, limit)
 }

--- a/internal/notifications/email_compose.go
+++ b/internal/notifications/email_compose.go
@@ -75,10 +75,12 @@ func collateEmailItems(rows []DeliveryRow) emailItems {
 			}
 			items.series[idx].episodes = append(items.series[idx].episodes, row)
 			items.episodes++
-		case DeliveryTypeRequestFulfilled:
-			key := parseRequestFulfilledFlags(row.ReasonFlags).RequestID
-			if key == "" {
-				key = row.ID
+		case DeliveryTypeRequestFulfilled, DeliveryTypeRequestApproved, DeliveryTypeRequestDeclined:
+			// Key by (type, request): one request may legitimately produce an
+			// approved row and a fulfilled row in the same window.
+			key := row.ID
+			if requestID := parseRequestFlags(row.ReasonFlags).RequestID; requestID != "" {
+				key = row.Type + ":" + requestID
 			}
 			if _, ok := seenRequests[key]; ok {
 				continue
@@ -130,12 +132,46 @@ func episodeLine(row DeliveryRow) string {
 	}
 }
 
-// requestLine renders one fulfilled-request entry.
+// requestLine renders one request-status entry. Fulfilled rows carry the
+// catalog title via the join; approved/declined rows carry it in the flags.
 func requestLine(row DeliveryRow) string {
-	if row.SeriesTitle != "" {
-		return row.SeriesTitle + " is now available"
+	flags := parseRequestFlags(row.ReasonFlags)
+	title := row.SeriesTitle
+	if title == "" {
+		title = flags.Title
 	}
-	return "Your media request is now available"
+	switch row.Type {
+	case DeliveryTypeRequestApproved:
+		if title != "" {
+			return "Your request for " + title + " was approved"
+		}
+		return "Your media request was approved"
+	case DeliveryTypeRequestDeclined:
+		line := "Your media request was declined"
+		if title != "" {
+			line = "Your request for " + title + " was declined"
+		}
+		if flags.Reason != "" {
+			line += " — " + flags.Reason
+		}
+		return line
+	default:
+		if title != "" {
+			return title + " is now available"
+		}
+		return "Your media request is now available"
+	}
+}
+
+// requestsAllFulfilled reports whether every collated request row is a
+// fulfillment; it drives the "requests ready" vs "request updates" copy.
+func requestsAllFulfilled(items emailItems) bool {
+	for _, row := range items.requests {
+		if row.Type != DeliveryTypeRequestFulfilled {
+			return false
+		}
+	}
+	return true
 }
 
 // otherLine renders operational and unknown delivery types generically.
@@ -161,7 +197,11 @@ func emailSubject(mode string, items emailItems) string {
 		parts = append(parts, countPart(items.episodes, "new episode", "new episodes"))
 	}
 	if len(items.requests) > 0 {
-		parts = append(parts, countPart(len(items.requests), "request ready", "requests ready"))
+		singular, plural := "request update", "request updates"
+		if requestsAllFulfilled(items) {
+			singular, plural = "request ready", "requests ready"
+		}
+		parts = append(parts, countPart(len(items.requests), singular, plural))
 	}
 	if len(items.others) > 0 {
 		parts = append(parts, countPart(len(items.others), "update", "updates"))
@@ -285,7 +325,11 @@ func composeNotificationEmail(mode string, rows []DeliveryRow, opts emailCompose
 		closeList()
 	}
 	if len(items.requests) > 0 && rendered < emailMaxItemsRendered {
-		writeHeading("Requests ready", "")
+		heading := "Request updates"
+		if requestsAllFulfilled(items) {
+			heading = "Requests ready"
+		}
+		writeHeading(heading, "")
 		openList()
 		for _, row := range items.requests {
 			seriesID := ""

--- a/internal/notifications/email_digest.go
+++ b/internal/notifications/email_digest.go
@@ -52,6 +52,10 @@ func (c *emailChannel) hasPendingSince(ctx context.Context, profileID string, si
 	return c.deliveries.HasForProfileSince(ctx, profileID, since)
 }
 
+func (c *emailChannel) hasTransactionalPendingSince(ctx context.Context, profileID string, since Cursor) (bool, error) {
+	return c.deliveries.HasTransactionalForProfileSince(ctx, profileID, since)
+}
+
 func (c *emailChannel) listSince(ctx context.Context, tx pgx.Tx, profileID string, since Cursor, until time.Time, limit int) ([]DeliveryRow, error) {
 	return c.deliveries.ListForProfileSince(ctx, tx, profileID, since, until, limit)
 }

--- a/internal/notifications/email_logic_test.go
+++ b/internal/notifications/email_logic_test.go
@@ -152,6 +152,49 @@ func TestEmailSubject(t *testing.T) {
 	}
 }
 
+func TestCollateEmailItemsKeepsLifecycleAndFulfilledForSameRequest(t *testing.T) {
+	// One request can produce an approved row and a fulfilled row in the same
+	// window; both must render.
+	rows := []DeliveryRow{
+		requestDeclinedTestRow(),
+		requestFulfilledTestRow(), // different request id is irrelevant; types differ
+		{Delivery: Delivery{
+			ID:          "01APPROVED",
+			Type:        DeliveryTypeRequestApproved,
+			ReasonFlags: []byte(`{"request_id":"01REQ","media_type":"movie","title":"Dune"}`),
+		}},
+	}
+	items := collateEmailItems(rows)
+	if len(items.requests) != 3 {
+		t.Fatalf("expected 3 request rows (distinct types), got %d", len(items.requests))
+	}
+	if requestsAllFulfilled(items) {
+		t.Fatal("mixed request rows must not report all-fulfilled")
+	}
+}
+
+func TestRequestLineLifecycle(t *testing.T) {
+	declined := requestDeclinedTestRow()
+	if got := requestLine(declined); got != "Your request for Dune was declined — Already available in 4K" {
+		t.Fatalf("unexpected declined line %q", got)
+	}
+	approved := requestDeclinedTestRow()
+	approved.Type = DeliveryTypeRequestApproved
+	approved.ReasonFlags = []byte(`{"request_id":"01REQ","title":"Dune"}`)
+	if got := requestLine(approved); got != "Your request for Dune was approved" {
+		t.Fatalf("unexpected approved line %q", got)
+	}
+
+	subject := emailSubject(EmailModePerEpisode, collateEmailItems([]DeliveryRow{approved}))
+	if subject != "Your request for Dune was approved" {
+		t.Fatalf("unexpected single-update subject %q", subject)
+	}
+	mixed := collateEmailItems([]DeliveryRow{approved, requestFulfilledTestRow()})
+	if got := emailSubject(EmailModeDailyDigest, mixed); got != "Silo daily digest: 2 request updates" {
+		t.Fatalf("unexpected mixed subject %q", got)
+	}
+}
+
 func TestComposeNotificationEmailLinks(t *testing.T) {
 	rows := []DeliveryRow{emailEpisodeRow("01A", "p1", "ep-1", 2, 3)}
 

--- a/internal/notifications/request_notifier.go
+++ b/internal/notifications/request_notifier.go
@@ -4,35 +4,58 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"time"
 
 	"github.com/Silo-Server/silo-server/internal/requests"
 	"github.com/oklog/ulid/v2"
 )
 
-// DeliveryTypeRequestFulfilled is the operational notice posted to the
-// requesting profile once its media request is present in the catalog
-// (docs/superpowers/plans/notifications/06, item 2). Its reason_flags carry
-// {"request_id","tmdb_id","media_type"} instead of reason booleans; a partial
-// unique index on (profile_id, request_id) makes the insert idempotent, and
+// Request lifecycle delivery types posted to the requesting profile. Their
+// reason_flags carry RequestFlags instead of reason booleans; partial unique
+// indexes per (profile_id, request_id, type) make the inserts idempotent, and
 // the per-webhook notify_requests flag gates the webhook channel.
-const DeliveryTypeRequestFulfilled = "request.fulfilled"
+const (
+	// DeliveryTypeRequestFulfilled is the operational notice posted once the
+	// requested media is present in the catalog
+	// (docs/superpowers/plans/notifications/06, item 2).
+	DeliveryTypeRequestFulfilled = "request.fulfilled"
+	// DeliveryTypeRequestApproved notifies the requesting profile that an
+	// admin (or auto-approval) approved their request.
+	DeliveryTypeRequestApproved = "request.approved"
+	// DeliveryTypeRequestDeclined notifies the requesting profile that an
+	// admin declined their request.
+	DeliveryTypeRequestDeclined = "request.declined"
+)
 
-// RequestFulfilledFlags is the decoded reason_flags shape for
-// request.fulfilled deliveries.
-type RequestFulfilledFlags struct {
+// RequestFlags is the decoded reason_flags shape for request.* deliveries.
+// Fulfilled rows carry only the identifiers (the catalog join renders their
+// display fields); approved/declined rows have no catalog item yet, so the
+// title rides along.
+type RequestFlags struct {
 	RequestID string `json:"request_id"`
 	TMDBID    int    `json:"tmdb_id"`
 	MediaType string `json:"media_type"`
+	Title     string `json:"title,omitempty"`
+	Year      int    `json:"year,omitempty"`
+	// Reason is the admin's decline message, when one was given.
+	Reason string `json:"reason,omitempty"`
 }
 
-// parseRequestFulfilledFlags decodes a request.fulfilled delivery's
-// reason_flags; other types decode to the zero value.
-func parseRequestFulfilledFlags(raw []byte) RequestFulfilledFlags {
-	var flags RequestFulfilledFlags
+// parseRequestFlags decodes a request.* delivery's reason_flags; other types
+// decode to the zero value.
+func parseRequestFlags(raw []byte) RequestFlags {
+	var flags RequestFlags
 	if len(raw) > 0 {
 		_ = json.Unmarshal(raw, &flags)
 	}
 	return flags
+}
+
+// isRequestLifecycleType reports whether the delivery is a request-status
+// notice rendered from RequestFlags alone (no catalog join exists yet).
+func isRequestLifecycleType(deliveryType string) bool {
+	return deliveryType == DeliveryTypeRequestApproved ||
+		deliveryType == DeliveryTypeRequestDeclined
 }
 
 // RequestFulfillmentNotifier adapts the notification system to
@@ -73,7 +96,7 @@ func (n *RequestFulfillmentNotifier) NotifyFulfilled(ctx context.Context, req re
 	if !prefs.Enabled {
 		return nil
 	}
-	flags, err := json.Marshal(RequestFulfilledFlags{
+	flags, err := json.Marshal(RequestFlags{
 		RequestID: req.ID,
 		TMDBID:    req.TMDBID,
 		MediaType: string(req.MediaType),
@@ -90,6 +113,106 @@ func (n *RequestFulfillmentNotifier) NotifyFulfilled(ctx context.Context, req re
 		ReasonFlags: flags,
 	}
 	_, err = n.system.DispatchOperational(ctx, delivery, OperationalDispatch{
+		WebhookFilter: func(hook Webhook) bool { return hook.NotifyRequests },
+	})
+	return err
+}
+
+// requestLifecycleDispatchTimeout bounds one detached lifecycle dispatch.
+const requestLifecycleDispatchTimeout = 30 * time.Second
+
+// RequestLifecycleNotifier adapts request lifecycle transitions (submitted,
+// approved, declined) to notifications: community server-channel posts for
+// every event, plus a personal delivery to the requesting profile for
+// approved and declined. Fulfillment stays on RequestFulfillmentNotifier,
+// whose presence-checked flow runs on the reconcile service. Dispatch is
+// detached and best-effort per the requests.LifecycleNotifier contract: a
+// transition never waits on or fails because of notifications.
+type RequestLifecycleNotifier struct {
+	system *System
+}
+
+// NewRequestLifecycleNotifier creates the adapter; returns nil when there is
+// no notification system. Server-channel posts inside it degrade to no-ops
+// when server channels are unconfigured (no at-rest cipher); the personal
+// delivery path has no such dependency.
+func NewRequestLifecycleNotifier(system *System) *RequestLifecycleNotifier {
+	if system == nil {
+		return nil
+	}
+	return &RequestLifecycleNotifier{system: system}
+}
+
+// RequestSubmitted implements requests.LifecycleNotifier. Submission posts to
+// server channels only: the requester performed the action themselves, so a
+// personal confirmation would be noise.
+func (n *RequestLifecycleNotifier) RequestSubmitted(ctx context.Context, req requests.Request) {
+	n.system.PostServerChannelRequestEvent(ctx, ServerChannelEventRequestSubmitted, requestEventInfoFor(req))
+}
+
+// RequestApproved implements requests.LifecycleNotifier.
+func (n *RequestLifecycleNotifier) RequestApproved(ctx context.Context, req requests.Request) {
+	n.system.PostServerChannelRequestEvent(ctx, ServerChannelEventRequestApproved, requestEventInfoFor(req))
+	n.dispatchPersonal(ctx, req, DeliveryTypeRequestApproved)
+}
+
+// RequestDeclined implements requests.LifecycleNotifier.
+func (n *RequestLifecycleNotifier) RequestDeclined(ctx context.Context, req requests.Request) {
+	n.system.PostServerChannelRequestEvent(ctx, ServerChannelEventRequestDeclined, requestEventInfoFor(req))
+	n.dispatchPersonal(ctx, req, DeliveryTypeRequestDeclined)
+}
+
+// dispatchPersonal creates the requester's personal delivery on a detached
+// goroutine: the lifecycle contract requires non-blocking dispatch, and the
+// caller's context ends with its HTTP request.
+func (n *RequestLifecycleNotifier) dispatchPersonal(ctx context.Context, req requests.Request, deliveryType string) {
+	dispatchCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), requestLifecycleDispatchTimeout)
+	go func() {
+		defer cancel()
+		if err := n.system.dispatchRequestLifecycle(dispatchCtx, req, deliveryType); err != nil {
+			n.system.logger.Warn("request lifecycle delivery failed",
+				"request_id", req.ID, "type", deliveryType, "error", err)
+		}
+	}()
+}
+
+// dispatchRequestLifecycle creates one durable request-status delivery for
+// the requesting profile across all channels. Mirrors the fulfilled path:
+// gated on attribution and the profile's master toggle, idempotent per
+// (profile, request, type) via the partial unique index.
+func (s *System) dispatchRequestLifecycle(ctx context.Context, req requests.Request, deliveryType string) error {
+	if req.RequestedByProfileID == "" || req.RequestedByUserID <= 0 {
+		return nil // requests without attribution have no recipient
+	}
+	prefs, err := s.Preferences.Get(ctx, req.RequestedByProfileID)
+	if err != nil {
+		return err
+	}
+	if !prefs.Enabled {
+		return nil
+	}
+	flags := RequestFlags{
+		RequestID: req.ID,
+		TMDBID:    req.TMDBID,
+		MediaType: string(req.MediaType),
+		Title:     req.Title,
+		Reason:    req.DeclineReason,
+	}
+	if req.Year != nil {
+		flags.Year = *req.Year
+	}
+	encoded, err := json.Marshal(flags)
+	if err != nil {
+		return fmt.Errorf("marshal request lifecycle flags: %w", err)
+	}
+	delivery := Delivery{
+		ID:          ulid.Make().String(),
+		UserID:      req.RequestedByUserID,
+		ProfileID:   req.RequestedByProfileID,
+		Type:        deliveryType,
+		ReasonFlags: encoded,
+	}
+	_, err = s.DispatchOperational(ctx, delivery, OperationalDispatch{
 		WebhookFilter: func(hook Webhook) bool { return hook.NotifyRequests },
 	})
 	return err

--- a/internal/notifications/server_channel_logic_test.go
+++ b/internal/notifications/server_channel_logic_test.go
@@ -354,6 +354,11 @@ func TestBuildServerChannelRequestPayloads(t *testing.T) {
 	if len(embed.Fields) != 2 || embed.Fields[1].Value != "quick" {
 		t.Fatalf("unexpected fields %+v", embed.Fields)
 	}
+	// Without a resolved Discord identity there is no mention.
+	if discord.Content != "" || discord.AllowedMentions != nil {
+		t.Fatalf("unexpected mention without discord id: content=%q mentions=%+v",
+			discord.Content, discord.AllowedMentions)
+	}
 
 	generic, err := BuildServerChannelRequestGeneric(ServerChannelEventRequestDeclined, info, "chan-1")
 	if err != nil {
@@ -366,6 +371,52 @@ func TestBuildServerChannelRequestPayloads(t *testing.T) {
 	if decoded.Event != ServerChannelEventRequestDeclined || decoded.Request.ID != "req-1" ||
 		decoded.Request.RequesterName != "quick" {
 		t.Fatalf("unexpected generic body %+v", decoded)
+	}
+}
+
+func TestBuildServerChannelRequestDiscordMentionsRequester(t *testing.T) {
+	info := RequestEventInfo{
+		RequestID:          "req-1",
+		TMDBID:             42,
+		MediaType:          "movie",
+		Title:              testMovieTitle,
+		RequesterName:      "quick",
+		RequesterUserID:    7,
+		RequesterDiscordID: "123456789",
+	}
+
+	body, err := BuildServerChannelRequestDiscord(ServerChannelEventRequestApproved, info)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var discord discordWebhookBody
+	if err := json.Unmarshal(body, &discord); err != nil {
+		t.Fatal(err)
+	}
+	if discord.Content != "<@123456789>" {
+		t.Fatalf("unexpected content %q", discord.Content)
+	}
+	if discord.AllowedMentions == nil ||
+		len(discord.AllowedMentions.Users) != 1 || discord.AllowedMentions.Users[0] != "123456789" {
+		t.Fatalf("unexpected allowed mentions %+v", discord.AllowedMentions)
+	}
+	// Parse must serialize as an empty list (not be omitted) so Discord's
+	// implicit mention parsing stays disabled.
+	if !strings.Contains(string(body), `"parse":[]`) {
+		t.Fatalf("allowed_mentions.parse not serialized: %s", body)
+	}
+	// The embed keeps the plain username; only the content line pings.
+	if len(discord.Embeds) != 1 || discord.Embeds[0].Fields[1].Value != "quick" {
+		t.Fatalf("unexpected embed fields %+v", discord.Embeds)
+	}
+
+	// The generic payload never carries the Discord identity.
+	generic, err := BuildServerChannelRequestGeneric(ServerChannelEventRequestApproved, info, "chan-1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if strings.Contains(string(generic), "123456789") {
+		t.Fatalf("discord id leaked into generic payload: %s", generic)
 	}
 }
 

--- a/internal/notifications/server_channel_payload.go
+++ b/internal/notifications/server_channel_payload.go
@@ -360,7 +360,18 @@ func BuildServerChannelRequestDiscord(event string, info RequestEventInfo) ([]by
 		embed.Thumbnail = &discordEmbedMedia{URL: poster}
 	}
 	enforceDiscordTotalLimit(&embed)
-	return json.Marshal(discordWebhookBody{Embeds: []discordEmbed{embed}, Username: siloSenderName})
+	body := discordWebhookBody{Embeds: []discordEmbed{embed}, Username: siloSenderName}
+	// A mention only pings from message content, never from inside an embed,
+	// so the tag rides above the embed; the embed field keeps the plain
+	// username so the post stays readable when the user left the guild.
+	if info.RequesterDiscordID != "" {
+		body.Content = "<@" + info.RequesterDiscordID + ">"
+		body.AllowedMentions = &discordAllowedMentions{
+			Parse: []string{},
+			Users: []string{info.RequesterDiscordID},
+		}
+	}
+	return json.Marshal(body)
 }
 
 // serverChannelRequestBody is the canonical generic-webhook JSON for one

--- a/internal/notifications/server_channel_request_notifier.go
+++ b/internal/notifications/server_channel_request_notifier.go
@@ -12,55 +12,18 @@ import (
 // theoretical worst case; in practice a couple of channels are subscribed).
 const serverChannelRequestPostTimeout = 60 * time.Second
 
-// ServerChannelLifecycleNotifier adapts request lifecycle transitions to
-// server-channel posts. Sends are detached and best-effort: the request flow
-// never waits on or fails because of a broadcast destination.
-type ServerChannelLifecycleNotifier struct {
-	system *System
-}
-
-// NewServerChannelLifecycleNotifier creates the adapter; returns nil when the
-// system has no server-channel support (no at-rest cipher).
-func NewServerChannelLifecycleNotifier(system *System) *ServerChannelLifecycleNotifier {
-	if system == nil || system.serverChannelWorker == nil {
-		return nil
-	}
-	return &ServerChannelLifecycleNotifier{system: system}
-}
-
-// RequestSubmitted implements requests.LifecycleNotifier.
-func (n *ServerChannelLifecycleNotifier) RequestSubmitted(ctx context.Context, req requests.Request) {
-	n.post(ctx, ServerChannelEventRequestSubmitted, req)
-}
-
-// RequestApproved implements requests.LifecycleNotifier.
-func (n *ServerChannelLifecycleNotifier) RequestApproved(ctx context.Context, req requests.Request) {
-	n.post(ctx, ServerChannelEventRequestApproved, req)
-}
-
-// RequestDeclined implements requests.LifecycleNotifier.
-func (n *ServerChannelLifecycleNotifier) RequestDeclined(ctx context.Context, req requests.Request) {
-	n.post(ctx, ServerChannelEventRequestDeclined, req)
-}
-
-func (n *ServerChannelLifecycleNotifier) post(ctx context.Context, event string, req requests.Request) {
-	if n == nil || n.system == nil {
-		return
-	}
-	n.system.PostServerChannelRequestEvent(ctx, event, requestEventInfoFor(req))
-}
-
 // requestEventInfoFor converts a request into the payload-layer shape.
 func requestEventInfoFor(req requests.Request) RequestEventInfo {
 	info := RequestEventInfo{
-		RequestID:     req.ID,
-		TMDBID:        req.TMDBID,
-		IMDBID:        req.IMDbID,
-		MediaType:     string(req.MediaType),
-		Title:         req.Title,
-		Overview:      req.Overview,
-		PosterPath:    req.PosterPath,
-		RequesterName: req.RequesterUsername,
+		RequestID:       req.ID,
+		TMDBID:          req.TMDBID,
+		IMDBID:          req.IMDbID,
+		MediaType:       string(req.MediaType),
+		Title:           req.Title,
+		Overview:        req.Overview,
+		PosterPath:      req.PosterPath,
+		RequesterName:   req.RequesterUsername,
+		RequesterUserID: req.RequestedByUserID,
 	}
 	if req.Year != nil {
 		info.Year = *req.Year
@@ -85,4 +48,23 @@ func (s *System) PostServerChannelRequestEvent(ctx context.Context, event string
 		defer cancel()
 		s.serverChannelWorker.PostRequestEvent(postCtx, event, info)
 	}()
+}
+
+// requesterDiscordID resolves a requester's OAuth-linked Discord user id for
+// @mentions in server-channel request posts. Empty when the admin has not
+// enabled requester mentions, the account never linked Discord, or the lookup
+// fails — the post then falls back to the plain username. Wired into the
+// sweep worker, which calls it only when a Discord channel is about to
+// receive the event.
+func (s *System) requesterDiscordID(ctx context.Context, userID int) string {
+	if userID <= 0 || s.DiscordPrefs == nil || !s.Settings.ServerChannelMentionRequesters(ctx) {
+		return ""
+	}
+	prefs, err := s.DiscordPrefs.Get(ctx, userID)
+	if err != nil {
+		s.logger.Warn("server channel request post: discord identity lookup failed",
+			"user_id", userID, "error", err)
+		return ""
+	}
+	return prefs.DiscordUserID
 }

--- a/internal/notifications/server_channel_types.go
+++ b/internal/notifications/server_channel_types.go
@@ -101,4 +101,12 @@ type RequestEventInfo struct {
 	Overview      string
 	PosterPath    string // raw TMDB image path ("/abc.jpg") from discovery
 	RequesterName string
+	// RequesterUserID is the requesting login account; 0 for requests
+	// without one. The sweep worker resolves it to the linked Discord
+	// identity just before a Discord channel receives the event.
+	RequesterUserID int
+	// RequesterDiscordID is the requester's OAuth-linked Discord user id,
+	// filled in by the worker only when the admin enabled requester
+	// mentions. Empty renders the plain RequesterName with no mention.
+	RequesterDiscordID string
 }

--- a/internal/notifications/server_channel_worker.go
+++ b/internal/notifications/server_channel_worker.go
@@ -31,6 +31,11 @@ type serverChannelWorker struct {
 	// posterURL picks the artwork URL Discord embeds may carry. Wired by
 	// NewSystem after construction; nil renders embeds without images.
 	posterURL func(ctx context.Context, posterPath, posterSourcePath string) string
+	// requesterDiscordID resolves a request's requester to their linked
+	// Discord user id for @mentions (System.requesterDiscordID, which owns
+	// the admin-setting gate). Wired by NewSystem after construction; nil or
+	// empty results post without a mention.
+	requesterDiscordID func(ctx context.Context, userID int) string
 
 	// Short-lived cache behind requestEventChannels.
 	requestChannelsMu        sync.Mutex
@@ -330,6 +335,7 @@ func (w *serverChannelWorker) PostRequestEvent(ctx context.Context, event string
 		info.PosterPath = ""
 	}
 	now := time.Now()
+	mentionResolved := false
 	for _, ch := range channels {
 		if ctx.Err() != nil {
 			return
@@ -339,6 +345,15 @@ func (w *serverChannelWorker) PostRequestEvent(ctx context.Context, event string
 		}
 		if !channelRetryEligible(now, ch.LastAttemptAt, ch.ConsecutiveFailures) {
 			continue
+		}
+		// Resolve the requester's Discord identity at most once per event,
+		// and only when a Discord channel is actually about to receive it —
+		// the common no-subscriber case must stay query-free.
+		if ch.Type == WebhookTypeDiscord && !mentionResolved {
+			mentionResolved = true
+			if w.requesterDiscordID != nil {
+				info.RequesterDiscordID = w.requesterDiscordID(ctx, info.RequesterUserID)
+			}
 		}
 		result := w.sender.sendRequest(ctx, &ch, event, info)
 		if result.OK {

--- a/internal/notifications/settings.go
+++ b/internal/notifications/settings.go
@@ -47,8 +47,9 @@ const (
 	SettingDiscordDigestHour      = "notifications.discord.digest_hour"
 	SettingDiscordPosterMode      = "notifications.discord.poster_mode"
 
-	SettingServerChannelsEnabled      = "notifications.server_channels_enabled"
-	SettingServerChannelsBatchSeconds = "notifications.server_channels.batch_seconds"
+	SettingServerChannelsEnabled          = "notifications.server_channels_enabled"
+	SettingServerChannelsBatchSeconds     = "notifications.server_channels.batch_seconds"
+	SettingServerChannelMentionRequesters = "notifications.server_channels.mention_requesters"
 
 	// Discord application credentials live under the discord.* namespace
 	// (admin-configured, alongside email.smtp_*). The secret and bot token
@@ -329,6 +330,14 @@ func (s *Settings) DiscordDigestHour(ctx context.Context) int {
 // admin, so creating a channel is itself the opt-in act.
 func (s *Settings) ServerChannelsEnabled(ctx context.Context) bool {
 	return s.boolSetting(ctx, SettingServerChannelsEnabled, true)
+}
+
+// ServerChannelMentionRequesters controls whether server-channel request
+// posts to Discord destinations @mention the requesting user (when that
+// account has linked Discord). Opt-in: a mention pings the user, which an
+// admin must choose deliberately for a shared channel.
+func (s *Settings) ServerChannelMentionRequesters(ctx context.Context) bool {
+	return s.boolSetting(ctx, SettingServerChannelMentionRequesters, false)
 }
 
 // ServerChannelsBatchWindow is how old a release event must be before the

--- a/internal/notifications/system.go
+++ b/internal/notifications/system.go
@@ -236,6 +236,7 @@ func NewSystem(
 	discordChannelInst.posterURL = system.discordPosterURL
 	if serverChannelSweep != nil {
 		serverChannelSweep.posterURL = system.discordPosterURL
+		serverChannelSweep.requesterDiscordID = system.requesterDiscordID
 	}
 	if webPushSenderInst != nil {
 		webPushSenderInst.payload = system.PayloadForRow

--- a/internal/notifications/webhook_logic_test.go
+++ b/internal/notifications/webhook_logic_test.go
@@ -385,6 +385,106 @@ func TestGenericWebhookPayloadRequestFulfilled(t *testing.T) {
 	}
 }
 
+func requestDeclinedTestRow() DeliveryRow {
+	return DeliveryRow{
+		Delivery: Delivery{
+			ID:        "01DECLINED",
+			ProfileID: "profile-1",
+			Type:      DeliveryTypeRequestDeclined,
+			ReasonFlags: []byte(`{"request_id":"01REQ","tmdb_id":438631,"media_type":"movie",` +
+				`"title":"Dune","year":2021,"reason":"Already available in 4K"}`),
+			CreatedAt: time.Date(2026, 6, 12, 12, 0, 0, 0, time.UTC),
+		},
+	}
+}
+
+func TestBuildDiscordWebhookPayloadRequestLifecycle(t *testing.T) {
+	payload, err := BuildDiscordWebhookPayload(requestDeclinedTestRow(), false)
+	if err != nil {
+		t.Fatalf("build failed: %v", err)
+	}
+	var body struct {
+		Embeds []discordEmbed `json:"embeds"`
+	}
+	if err := json.Unmarshal(payload, &body); err != nil {
+		t.Fatalf("payload is not valid JSON: %v", err)
+	}
+	if len(body.Embeds) != 1 {
+		t.Fatalf("unexpected body shape: %+v", body)
+	}
+	embed := body.Embeds[0]
+	// No catalog join exists for declined requests; title and link come from
+	// the reason flags.
+	if embed.Title != "Dune (2021)" {
+		t.Fatalf("unexpected title %q", embed.Title)
+	}
+	if embed.Author == nil || embed.Author.Name != "Your request was declined on Silo" {
+		t.Fatalf("unexpected author %+v", embed.Author)
+	}
+	if embed.URL != "https://www.themoviedb.org/movie/438631" {
+		t.Fatalf("unexpected title URL %q", embed.URL)
+	}
+	if embed.Color != serverChannelColorDeclined {
+		t.Fatalf("unexpected color %d", embed.Color)
+	}
+	if len(embed.Fields) != 2 ||
+		embed.Fields[0].Name != "Type" || embed.Fields[0].Value != "Movie" ||
+		embed.Fields[1].Name != "Reason" || embed.Fields[1].Value != "Already available in 4K" {
+		t.Fatalf("expected Type and Reason fields, got %+v", embed.Fields)
+	}
+
+	approved := requestDeclinedTestRow()
+	approved.Type = DeliveryTypeRequestApproved
+	payload, err = BuildDiscordWebhookPayload(approved, false)
+	if err != nil {
+		t.Fatalf("build failed: %v", err)
+	}
+	if err := json.Unmarshal(payload, &body); err != nil {
+		t.Fatalf("payload is not valid JSON: %v", err)
+	}
+	embed = body.Embeds[0]
+	if embed.Author == nil || embed.Author.Name != "Your request was approved on Silo" {
+		t.Fatalf("unexpected author %+v", embed.Author)
+	}
+	if embed.Color != serverChannelColorApproved {
+		t.Fatalf("unexpected color %d", embed.Color)
+	}
+	// The decline reason must not leak into approved embeds.
+	for _, field := range embed.Fields {
+		if field.Name == "Reason" {
+			t.Fatalf("approved embed must not carry a decline reason: %+v", embed.Fields)
+		}
+	}
+}
+
+func TestGenericWebhookPayloadRequestDeclined(t *testing.T) {
+	payload, err := BuildGenericWebhookPayload(requestDeclinedTestRow(), "hook-1", false)
+	if err != nil {
+		t.Fatalf("build failed: %v", err)
+	}
+	var body struct {
+		Type    string `json:"type"`
+		Request *struct {
+			ID        string `json:"id"`
+			TMDBID    int    `json:"tmdb_id"`
+			MediaType string `json:"media_type"`
+			Title     string `json:"title"`
+			Year      int    `json:"year"`
+			Reason    string `json:"reason"`
+		} `json:"request"`
+	}
+	if err := json.Unmarshal(payload, &body); err != nil {
+		t.Fatalf("payload is not valid JSON: %v", err)
+	}
+	if body.Type != DeliveryTypeRequestDeclined {
+		t.Fatalf("unexpected type %q", body.Type)
+	}
+	if body.Request == nil || body.Request.ID != "01REQ" || body.Request.Title != "Dune" ||
+		body.Request.Year != 2021 || body.Request.Reason != "Already available in 4K" {
+		t.Fatalf("unexpected request block: %+v", body.Request)
+	}
+}
+
 func TestBuildDiscordWebhookPayloadTestMarker(t *testing.T) {
 	payload, err := BuildDiscordWebhookPayload(webhookTestRow(), true)
 	if err != nil {

--- a/internal/notifications/webhook_payload_discord.go
+++ b/internal/notifications/webhook_payload_discord.go
@@ -63,10 +63,20 @@ type discordEmbed struct {
 	Fields      []discordEmbedField `json:"fields,omitempty"`
 }
 
+// discordAllowedMentions whitelists exactly what a message's content may
+// ping. Parse always serializes (an empty list disables Discord's implicit
+// mention parsing), so content assembled from user-derived text can never
+// ping roles or @everyone.
+type discordAllowedMentions struct {
+	Parse []string `json:"parse"`
+	Users []string `json:"users,omitempty"`
+}
+
 type discordWebhookBody struct {
-	Content  string         `json:"content,omitempty"`
-	Embeds   []discordEmbed `json:"embeds"`
-	Username string         `json:"username"`
+	Content         string                  `json:"content,omitempty"`
+	Embeds          []discordEmbed          `json:"embeds"`
+	Username        string                  `json:"username"`
+	AllowedMentions *discordAllowedMentions `json:"allowed_mentions,omitempty"`
 }
 
 // BuildDiscordWebhookPayload renders a delivery as a Discord webhook body.
@@ -118,6 +128,10 @@ func discordEmbedAuthorLine(deliveryType string) string {
 		return "New episode on Silo"
 	case DeliveryTypeRequestFulfilled:
 		return "Your request is now available on Silo"
+	case DeliveryTypeRequestApproved:
+		return "Your request was approved on Silo"
+	case DeliveryTypeRequestDeclined:
+		return "Your request was declined on Silo"
 	default:
 		return genericNotificationTitle
 	}
@@ -151,7 +165,19 @@ func buildDiscordEmbed(row DeliveryRow, test bool) discordEmbed {
 	if row.Type == DeliveryTypeEpisodeAvailable && row.EpisodeOverview != "" {
 		overview = row.EpisodeOverview
 	}
+	isRequestType := row.Type == DeliveryTypeRequestFulfilled || isRequestLifecycleType(row.Type)
+	var requestFlags RequestFlags
+	if isRequestType {
+		requestFlags = parseRequestFlags(row.ReasonFlags)
+	}
 	ids := providerIDs{MediaType: row.MediaType, IMDB: row.IMDBID, TMDB: row.TMDBID, TVDB: row.TVDBID}
+	if isRequestLifecycleType(row.Type) {
+		// No catalog join; derive the provider link from the request flags.
+		ids = providerIDs{MediaType: requestFlags.MediaType}
+		if requestFlags.TMDBID > 0 {
+			ids.TMDB = fmt.Sprintf("%d", requestFlags.TMDBID)
+		}
+	}
 
 	fields := make([]discordEmbedField, 0, 3)
 	if labels := reasonLabelList(flags); len(labels) > 0 {
@@ -161,10 +187,16 @@ func buildDiscordEmbed(row DeliveryRow, test bool) discordEmbed {
 			Inline: true,
 		})
 	}
-	if row.Type == DeliveryTypeRequestFulfilled {
-		if mediaType := requestMediaTypeLabel(row.ReasonFlags); mediaType != "" {
+	if isRequestType {
+		if mediaType := mediaTypeLabel(requestFlags.MediaType); mediaType != "" {
 			fields = append(fields, discordEmbedField{Name: "Type", Value: mediaType, Inline: true})
 		}
+	}
+	if row.Type == DeliveryTypeRequestDeclined && requestFlags.Reason != "" {
+		fields = append(fields, discordEmbedField{
+			Name:  "Reason",
+			Value: truncateWithEllipsis(requestFlags.Reason, discordFieldValueLimit),
+		})
 	}
 	if rating := ratingLabel(row.RatingIMDB, row.RatingTMDB); rating != "" {
 		fields = append(fields, discordEmbedField{Name: "Rating", Value: rating, Inline: true})
@@ -173,11 +205,18 @@ func buildDiscordEmbed(row DeliveryRow, test bool) discordEmbed {
 		fields = append(fields, discordEmbedField{Name: "Genres", Value: genres, Inline: true})
 	}
 
+	color := discordEmbedColor(flags)
+	switch row.Type {
+	case DeliveryTypeRequestApproved:
+		color = serverChannelColorApproved
+	case DeliveryTypeRequestDeclined:
+		color = serverChannelColorDeclined
+	}
 	embed := discordEmbed{
 		Title:       title,
 		URL:         ids.titleURL(),
 		Description: embedDescription(overview, ids),
-		Color:       discordEmbedColor(flags),
+		Color:       color,
 		Author:      &discordEmbedAuthor{Name: discordEmbedAuthorLine(row.Type)},
 		Footer:      &discordEmbedFooter{Text: discordEmbedFooterText(row.ContentRating, test)},
 		Fields:      fields,
@@ -201,6 +240,14 @@ func discordEmbedTitle(row DeliveryRow) string {
 			return titleWithYear(row.SeriesTitle, row.Year)
 		}
 		return "Request fulfilled"
+	case DeliveryTypeRequestApproved, DeliveryTypeRequestDeclined:
+		// No catalog join exists for an unfulfilled request; the title rides
+		// in the reason flags.
+		flags := parseRequestFlags(row.ReasonFlags)
+		if flags.Title != "" {
+			return titleWithYear(flags.Title, flags.Year)
+		}
+		return "Media request"
 	case DeliveryTypeEpisodeAvailable:
 		// Falls out of the switch into the episode title assembly below.
 	default:
@@ -222,12 +269,6 @@ func discordEmbedTitle(row DeliveryRow) string {
 	default:
 		return series
 	}
-}
-
-// requestMediaTypeLabel renders a request.fulfilled delivery's media type as
-// a display label; unknown values render nothing.
-func requestMediaTypeLabel(reasonFlags []byte) string {
-	return mediaTypeLabel(parseRequestFulfilledFlags(reasonFlags).MediaType)
 }
 
 func discordEmbedColor(flags ReasonFlags) int {

--- a/internal/notifications/webhook_payload_generic.go
+++ b/internal/notifications/webhook_payload_generic.go
@@ -28,8 +28,10 @@ type genericWebhookBody struct {
 	Reasons    ReasonFlags            `json:"reason_flags"`
 	Series     *genericWebhookSeries  `json:"series,omitempty"`
 	Episode    *genericWebhookEpisode `json:"episode,omitempty"`
-	// Request is present for request.fulfilled deliveries; the catalog item is
-	// in Series (movies included — the field carries the matched item).
+	// Request is present for request.* deliveries. For request.fulfilled the
+	// catalog item is in Series (movies included — the field carries the
+	// matched item); approved/declined have no catalog item yet, so the
+	// request's own title rides here.
 	Request *genericWebhookRequest `json:"request,omitempty"`
 }
 
@@ -49,6 +51,9 @@ type genericWebhookRequest struct {
 	ID        string `json:"id"`
 	TMDBID    int    `json:"tmdb_id,omitempty"`
 	MediaType string `json:"media_type,omitempty"`
+	Title     string `json:"title,omitempty"`
+	Year      int    `json:"year,omitempty"`
+	Reason    string `json:"reason,omitempty"`
 }
 
 // BuildGenericWebhookPayload renders a delivery as canonical Silo JSON. Pure
@@ -81,12 +86,16 @@ func BuildGenericWebhookPayload(row DeliveryRow, webhookID string, test bool) ([
 			EpisodeNumber: row.EpisodeNumber,
 		}
 	}
-	if row.Type == DeliveryTypeRequestFulfilled {
-		flags := parseRequestFulfilledFlags(row.ReasonFlags)
+	switch row.Type {
+	case DeliveryTypeRequestFulfilled, DeliveryTypeRequestApproved, DeliveryTypeRequestDeclined:
+		flags := parseRequestFlags(row.ReasonFlags)
 		body.Request = &genericWebhookRequest{
 			ID:        flags.RequestID,
 			TMDBID:    flags.TMDBID,
 			MediaType: flags.MediaType,
+			Title:     flags.Title,
+			Year:      flags.Year,
+			Reason:    flags.Reason,
 		}
 	}
 	return json.Marshal(body)

--- a/internal/notifications/webpush_sender.go
+++ b/internal/notifications/webpush_sender.go
@@ -91,6 +91,23 @@ func buildWebPushPayload(row DeliveryRow, posterURL string) ([]byte, error) {
 			payload.URL = "/item/" + *row.SeriesID
 		}
 		payload.Icon = posterURL
+	case DeliveryTypeRequestApproved:
+		flags := parseRequestFlags(row.ReasonFlags)
+		payload.Title = "Your request was approved"
+		if flags.Title != "" {
+			payload.Title = flags.Title + " was approved"
+		}
+		payload.Body = "Your media request was approved."
+	case DeliveryTypeRequestDeclined:
+		flags := parseRequestFlags(row.ReasonFlags)
+		payload.Title = "Your request was declined"
+		if flags.Title != "" {
+			payload.Title = flags.Title + " was declined"
+		}
+		payload.Body = "Your media request was declined."
+		if flags.Reason != "" {
+			payload.Body = "Reason: " + flags.Reason
+		}
 	case DeliveryTypeWebhookAutoDisabled:
 		payload.Title = "A webhook stopped working"
 		payload.Body = "Open notification settings to fix it."

--- a/internal/requests/service.go
+++ b/internal/requests/service.go
@@ -625,6 +625,7 @@ func (s *Service) Decline(ctx context.Context, viewer Viewer, id, reason string)
 	if err != nil {
 		return nil, err
 	}
+	declined.DeclineReason = strings.TrimSpace(reason)
 	s.notifyLifecycle(ctx, *declined, LifecycleNotifier.RequestDeclined)
 	return declined, nil
 }

--- a/internal/requests/types.go
+++ b/internal/requests/types.go
@@ -124,34 +124,38 @@ type EffectivePolicy struct {
 }
 
 type Request struct {
-	ID                   string     `json:"id"`
-	Provider             string     `json:"provider"`
-	MediaType            MediaType  `json:"media_type"`
-	TMDBID               int        `json:"tmdb_id"`
-	TVDBID               *int       `json:"tvdb_id,omitempty"`
-	IMDbID               string     `json:"imdb_id,omitempty"`
-	Title                string     `json:"title"`
-	Year                 *int       `json:"year,omitempty"`
-	Overview             string     `json:"overview,omitempty"`
-	PosterPath           string     `json:"poster_path,omitempty"`
-	BackdropPath         string     `json:"backdrop_path,omitempty"`
-	Status               Status     `json:"status"`
-	Outcome              Outcome    `json:"outcome"`
-	RequestedByUserID    int        `json:"requested_by_user_id,omitempty"`
-	RequestedByProfileID string     `json:"requested_by_profile_id,omitempty"`
-	RequesterEmail       string     `json:"-"`
-	RequesterUsername    string     `json:"-"`
-	IntegrationKind      string     `json:"integration_kind,omitempty"`
-	IsAnime              bool       `json:"is_anime"`
-	Targets              []Target   `json:"targets,omitempty"`
-	ExternalID           string     `json:"external_id,omitempty"`
-	ExternalStatus       string     `json:"external_status,omitempty"`
-	LibraryContentID     string     `json:"library_content_id,omitempty"`
-	LastError            string     `json:"last_error,omitempty"`
-	CreatedAt            time.Time  `json:"created_at"`
-	UpdatedAt            time.Time  `json:"updated_at"`
-	ApprovedAt           *time.Time `json:"approved_at,omitempty"`
-	CompletedAt          *time.Time `json:"completed_at,omitempty"`
+	ID                   string    `json:"id"`
+	Provider             string    `json:"provider"`
+	MediaType            MediaType `json:"media_type"`
+	TMDBID               int       `json:"tmdb_id"`
+	TVDBID               *int      `json:"tvdb_id,omitempty"`
+	IMDbID               string    `json:"imdb_id,omitempty"`
+	Title                string    `json:"title"`
+	Year                 *int      `json:"year,omitempty"`
+	Overview             string    `json:"overview,omitempty"`
+	PosterPath           string    `json:"poster_path,omitempty"`
+	BackdropPath         string    `json:"backdrop_path,omitempty"`
+	Status               Status    `json:"status"`
+	Outcome              Outcome   `json:"outcome"`
+	RequestedByUserID    int       `json:"requested_by_user_id,omitempty"`
+	RequestedByProfileID string    `json:"requested_by_profile_id,omitempty"`
+	RequesterEmail       string    `json:"-"`
+	RequesterUsername    string    `json:"-"`
+	// DeclineReason is the admin's decline message, populated transiently for
+	// the lifecycle notifier (the durable copy lives in the request event
+	// record, not on this row).
+	DeclineReason    string     `json:"-"`
+	IntegrationKind  string     `json:"integration_kind,omitempty"`
+	IsAnime          bool       `json:"is_anime"`
+	Targets          []Target   `json:"targets,omitempty"`
+	ExternalID       string     `json:"external_id,omitempty"`
+	ExternalStatus   string     `json:"external_status,omitempty"`
+	LibraryContentID string     `json:"library_content_id,omitempty"`
+	LastError        string     `json:"last_error,omitempty"`
+	CreatedAt        time.Time  `json:"created_at"`
+	UpdatedAt        time.Time  `json:"updated_at"`
+	ApprovedAt       *time.Time `json:"approved_at,omitempty"`
+	CompletedAt      *time.Time `json:"completed_at,omitempty"`
 }
 
 type RequestEvent struct {

--- a/migrations/sql/20260612100000_request_lifecycle_notifications.sql
+++ b/migrations/sql/20260612100000_request_lifecycle_notifications.sql
@@ -1,0 +1,16 @@
+-- +goose Up
+-- +goose StatementBegin
+-- request.approved / request.declined notifications: notify the requesting
+-- profile when an admin (or auto-approval) resolves their request.
+-- At-most-once per (profile, request, type): the operational insert path uses
+-- ON CONFLICT DO NOTHING, so an API retry or multi-node race dedupes here
+-- instead of double-notifying. Mirrors the request.fulfilled index.
+CREATE UNIQUE INDEX notification_deliveries_profile_request_lifecycle_key
+    ON public.notification_deliveries (profile_id, (reason_flags->>'request_id'), type)
+    WHERE type IN ('request.approved', 'request.declined');
+-- +goose StatementEnd
+
+-- +goose Down
+-- +goose StatementBegin
+DROP INDEX IF EXISTS public.notification_deliveries_profile_request_lifecycle_key;
+-- +goose StatementEnd

--- a/web/src/api/types.ts
+++ b/web/src/api/types.ts
@@ -2230,10 +2230,14 @@ export interface NotificationReasonFlags {
   watchlist?: boolean;
   continue_watching?: boolean;
   next_up?: boolean;
-  // request.fulfilled operational payload
+  // request.* operational payload (title/year/reason ride on
+  // request.approved / request.declined, which have no catalog item yet)
   request_id?: string;
   tmdb_id?: number;
   media_type?: string;
+  title?: string;
+  year?: number;
+  reason?: string;
 }
 
 export interface AppNotification {

--- a/web/src/components/RealtimeEventsProvider.tsx
+++ b/web/src/components/RealtimeEventsProvider.tsx
@@ -536,6 +536,18 @@ export function RealtimeEventsProvider({ children }: { children: ReactNode }) {
             : "Your request is now available",
           { description: "Your media request has arrived in the library." },
         );
+      } else if (
+        notification.type === "request.approved" ||
+        notification.type === "request.declined"
+      ) {
+        const verb = notification.type === "request.approved" ? "approved" : "declined";
+        const title = notification.reason_flags?.title;
+        toast(title ? `Request ${verb}: ${title}` : `Your request was ${verb}`, {
+          description:
+            notification.type === "request.declined"
+              ? notification.reason_flags?.reason
+              : undefined,
+        });
       }
       return;
     }

--- a/web/src/lib/adminSettingsSearch.ts
+++ b/web/src/lib/adminSettingsSearch.ts
@@ -297,6 +297,7 @@ export const ADMIN_SETTINGS_GROUPS: AdminSettingsSearchGroup[] = [
           "Allow Private Destinations",
           "Server Channels",
           "Batch Window (seconds)",
+          "Mention Requesters on Discord",
           "Settle Delay (seconds)",
           "Max Series Burst",
           "Max Event Age (hours)",

--- a/web/src/pages/Notifications.tsx
+++ b/web/src/pages/Notifications.tsx
@@ -50,6 +50,9 @@ function notificationTitle(notification: AppNotification): string {
   if (notification.type === "request.fulfilled") {
     return notification.series_title || "Request available";
   }
+  if (notification.type === "request.approved" || notification.type === "request.declined") {
+    return notification.reason_flags?.title || "Media request";
+  }
   // Unknown types render with a generic fallback by design — the type
   // registry is extensible.
   return "Notification";
@@ -69,6 +72,13 @@ function notificationDescription(notification: AppNotification): string {
       : mediaType === "series"
         ? "Your requested series is now available"
         : "Your request is now available";
+  }
+  if (notification.type === "request.approved") {
+    return "Your request was approved";
+  }
+  if (notification.type === "request.declined") {
+    const reason = notification.reason_flags?.reason;
+    return reason ? `Your request was declined — ${reason}` : "Your request was declined";
   }
   return notification.type;
 }

--- a/web/src/pages/admin-settings/NotificationsAdminSettings.tsx
+++ b/web/src/pages/admin-settings/NotificationsAdminSettings.tsx
@@ -56,6 +56,7 @@ const KEYS = [
   "notifications.discord.poster_mode",
   "notifications.server_channels_enabled",
   "notifications.server_channels.batch_seconds",
+  "notifications.server_channels.mention_requesters",
   "discord.client_id",
   "discord.client_secret",
   "discord.bot_token",
@@ -764,6 +765,15 @@ export default function NotificationsAdminSettings() {
                 type="number"
                 value={numberValue("notifications.server_channels.batch_seconds", "300")}
                 onChange={(v) => form.setValue("notifications.server_channels.batch_seconds", v)}
+              />
+              <SettingField
+                label="Mention Requesters on Discord"
+                hint="Request posts to Discord destinations @mention the requesting user when their account has linked Discord (in user notification settings). Unlinked accounts show their Silo username without a mention."
+                type="toggle"
+                value={form.getValue("notifications.server_channels.mention_requesters")}
+                onChange={(v) =>
+                  form.setValue("notifications.server_channels.mention_requesters", v)
+                }
               />
               <div className="pt-3">
                 <ServerNotificationChannels />


### PR DESCRIPTION
## Problem

Request lifecycle events were community-facing only: submitted/approved/declined posted to admin server channels, and only *fulfilled* reached the requester personally. A user whose request was approved or declined never heard about it unless they checked the requests page. Server-channel request posts also had no way to tag the requesting user on Discord.

## What this does

**Personal approved/declined notifications.** New `request.approved` / `request.declined` delivery types ride the existing operational dispatch path to the requesting profile — inbox, websocket toast, email, Discord DM, personal webhooks (gated by the existing per-webhook `notify_requests` flag), and web push. *Submitted* deliberately stays broadcast-only: the requester performed that action themselves. Since no catalog item exists pre-fulfillment, title/year/decline-reason travel in `reason_flags` and every renderer reads them from there. The admin's decline reason is shown on all channels.

**Immediate delivery, even for digest users.** Request status changes are transactional: a digest-mode recipient with one pending gets an off-schedule early send within seconds instead of waiting for the digest hour. The early send keeps full watermark durability and does not stamp `last_digest_at`, so the daily schedule is unaffected. Applies to both Discord DMs and email via the shared account-channel engine; per-episode recipients were already immediate via the dispatch nudge.

**Requester @mentions in server channels.** Opt-in server setting (`notifications.server_channels.mention_requesters`, default off, in the Server Channels admin card): Discord request posts @mention the requester via their OAuth-linked Discord identity. Resolved lazily in the sweep worker only when a Discord destination is about to receive the event, pinged via content-level mention with pinned `allowed_mentions` (embed mentions never ping; implicit parsing stays disabled so user-derived text can never ping roles/@everyone). Unlinked accounts fall back to the plain username; the Discord ID never leaks into generic webhook payloads.

**Dedupe migration.** `20260612100000_request_lifecycle_notifications.sql` adds a partial unique index per (profile, request, type), mirroring the fulfilled pattern, so API retries or multi-node races can't double-notify.

## Why this approach

Extending the delivery pipeline (rather than a Discord-specific side channel) lights up every notification channel at once and inherits the existing durability, dedupe, and preference gating. The transactional early-send is expressed at the engine level so both account channels share it and future transactional types just join the list.

## Risks / follow-ups

- `silo-android` / `silo-apple` render the two new inbox types with their generic fallback until they add them (type strings + `reason_flags` documented in `web/src/api/types.ts`).
- `request.fulfilled` keeps its current digest-mode timing; making it transactional is a one-line change if desired.
- Decline reason reaches the notifier via a transient `Request.DeclineReason` field; the durable copy remains in `media_request_events`.

## Testing

- New unit tests: Discord embed + generic webhook rendering for approved/declined (incl. reason field and no-leak assertions), email collation/dedupe across mixed request types, subject lines, server-channel mention payload (`allowed_mentions` pinning, plain-username fallback).
- Full `internal/...` test sweep, `go vet`, `gofmt`, web ESLint/Prettier/tsc, and all 1059 web tests pass.

## AI use

Implemented with Claude Code (design discussed and decided with the maintainer; all code AI-written, human-reviewed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Request approved and declined notifications alongside fulfillment notifications
  * Optional Discord mentions for request approvals and declines
  * Transactional notifications bypass daily digest waiting period
  * Email notifications distinguish between approved, declined, and fulfilled requests with distinct messaging
  * Toast notifications in the web interface for request status changes

* **Improvements**
  * Richer notification context includes request titles, years, and decline reasons

<!-- end of auto-generated comment: release notes by coderabbit.ai -->