### PR TITLE
fix(catalog): return user_data for audiobooks on /watch/{id}

### DIFF
--- a/internal/api/handlers/items.go
+++ b/internal/api/handlers/items.go
@@ -387,7 +387,7 @@ func (h *ItemsHandler) HandleGetWatchDetail(w http.ResponseWriter, r *http.Reque
 		}
 	}
 
-	if detail.Type == "movie" || detail.Type == "episode" || detail.Type == "ebook" {
+	if detail.Type == "movie" || detail.Type == "episode" || detail.Type == "ebook" || detail.Type == "audiobook" {
 		detail.UserData = h.getLeafUserData(r, detail.ContentID, detail.Type)
 		applyEffectiveEditionPreference(detail.UserData, &detail.EffectiveVersionEditionKey)
 	}

--- a/internal/api/handlers/items_user_data_test.go
+++ b/internal/api/handlers/items_user_data_test.go
@@ -1,12 +1,14 @@
 package handlers
 
 import (
+	"context"
 	"net/http/httptest"
 	"testing"
 	"time"
 
 	apimw "github.com/Silo-Server/silo-server/internal/api/middleware"
 	"github.com/Silo-Server/silo-server/internal/auth"
+	"github.com/Silo-Server/silo-server/internal/userstore"
 )
 
 func TestGetLeafUserDataUsesEbookReaderProgress(t *testing.T) {
@@ -43,5 +45,29 @@ func TestGetLeafUserDataUsesEbookReaderProgress(t *testing.T) {
 	complete := handler.getLeafUserData(req, "ebook-complete", "ebook")
 	if complete == nil || !complete.Played || complete.IsInProgress {
 		t.Fatalf("completed ebook user data = %#v", complete)
+	}
+}
+
+// Audiobooks resolve user_data through the same watch-progress store as
+// movies/episodes (not the ebook reader store), so an in-progress audiobook
+// reports its saved position_seconds — which is what lets the player resume.
+func TestGetLeafUserDataReturnsAudiobookProgress(t *testing.T) {
+	store := newPlaybackTestStore(t)
+	if err := store.SetProgress(context.Background(), "profile-1", "audiobook-1", 1234, 5000, userstore.ProgressThresholds{}); err != nil {
+		t.Fatalf("seed progress: %v", err)
+	}
+	handler := &ItemsHandler{storeProvider: testUserStoreProvider{store: store}}
+
+	req := httptest.NewRequest("GET", "/watch/audiobook-1", nil)
+	ctx := apimw.SetClaims(req.Context(), &auth.Claims{UserID: 1})
+	ctx = apimw.SetProfileID(ctx, "profile-1")
+	req = req.WithContext(ctx)
+
+	progress := handler.getLeafUserData(req, "audiobook-1", "audiobook")
+	if progress == nil {
+		t.Fatal("audiobook user data = nil, want saved progress")
+	}
+	if progress.PositionSeconds != 1234 {
+		t.Fatalf("PositionSeconds = %v, want 1234", progress.PositionSeconds)
 	}
 }


### PR DESCRIPTION
## Problem
An audiobook fetched via `GET /api/v1/watch/{id}` returned `user_data` with null/zero `position_seconds`, so clients could not resume from the saved position — even though audiobook progress is recorded the same way as video.

## Cause
`HandleGetWatchDetail` populated `user_data` only for `movie` / `episode` / `ebook`. The sibling `GET /api/v1/catalog/items/{id}` path (`enrichItemDetail`) already includes `"audiobook"`, so the two endpoints were inconsistent.

## Fix
Add `audiobook` to the type gate so `/watch/{id}` exposes the saved `position_seconds`, matching `/catalog/items/{id}`. The underlying `getLeafUserData` path is identical to movie/episode (reads `user_watch_progress` via `GetProgress`).

## Test
Adds `TestGetLeafUserDataReturnsAudiobookProgress` — seeds an in-progress audiobook and asserts the returned `user_data` carries the saved `position_seconds`.

## Notes
Server half of the audiobook resume fix; the Android client change (audiobook player consuming `user_data.position_seconds` like the video player) is tracked separately in silo-android.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Extended user data enrichment and edition preference handling to audiobook content, ensuring audiobook progress tracking now works consistently with other media types.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->