### PR TITLE
docs(process): v1 scope-lock process — proposal template, CODEOWNERS gate, agent instructions

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,2 @@
+# v1 scope lock — changes to the lock artifact require maintainer review
+/docs/architecture/v1-scope.md @Quick104

--- a/.github/ISSUE_TEMPLATE/v1-capability-proposal.yml
+++ b/.github/ISSUE_TEMPLATE/v1-capability-proposal.yml
@@ -1,0 +1,56 @@
+name: v1 capability proposal
+description: Propose a user-facing capability for the Silo v1 scope lock
+title: "[v1] <capability name>"
+labels: ["epic", "v1-proposed"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        One proposal per **user-facing capability** (e.g. "Manga library type", "Transcoded playback"),
+        not per PR or per endpoint. Locked capabilities are what the client teams plan against —
+        the **API surface** section is mandatory for a capability to be lockable.
+        Scope state and lock rules: `docs/architecture/v1-scope.md`.
+  - type: textarea
+    id: summary
+    attributes:
+      label: Summary
+      description: One paragraph, user-facing language. What can a user do when this ships?
+    validations:
+      required: true
+  - type: textarea
+    id: value
+    attributes:
+      label: User value / why v1
+      description: Why does v1 need this rather than v1.1?
+    validations:
+      required: true
+  - type: textarea
+    id: api-surface
+    attributes:
+      label: API surface
+      description: >
+        Endpoints/payloads clients will call (method + path + notable request/response fields).
+        Plain list now; OpenAPI pointers once the #135 tooling lands. A capability cannot be
+        Locked without this section filled in.
+      placeholder: |
+        GET  /api/v1/manga/{seriesId}/chapters — list chapters (id, index, volume, read_state)
+        POST /api/v1/watch-progress — records reading progress (existing endpoint, new item type)
+    validations:
+      required: true
+  - type: textarea
+    id: client-impact
+    attributes:
+      label: Client impact (android / apple / web)
+      description: What must each client build to surface this capability? "None" is a valid answer per client.
+    validations:
+      required: true
+  - type: dropdown
+    id: size
+    attributes:
+      label: Rough size (server-side)
+      options:
+        - S
+        - M
+        - L
+    validations:
+      required: true

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -88,3 +88,21 @@ Recent history follows Conventional Commit-style subjects such as `feat(playback
 - Silo separates login accounts (`users`) from household profiles; multiple profiles on one account share the same `user_id`.
 - Profile `is_primary` marks the household parent for that account; it is not the same as server-wide `admin` role on the user account.
 - Point the Vite dev frontend at a remote backend with `VITE_API_PROXY_TARGET` in `web/.env.local` (or inline) when running `make dev-frontend`; the frontend calls relative `/api` URLs proxied by Vite.
+
+## Silo v1 Process (scope lock & API rules)
+
+Silo is working toward a locked v1 feature set so client teams can plan against a stable core. These rules apply to every change.
+
+**Scope gate.** Before implementing a new user-facing capability, check `docs/architecture/v1-scope.md`. If the capability is not listed there — or the file says scope is not yet locked — do NOT open a feature PR. File a **v1 capability proposal** issue (template in this repo) and wait for triage. Bug fixes, refactors, and work on already-locked capabilities proceed normally.
+
+**API rules — additive-only within `/api/v1`.**
+- Never rename or remove a response field, change a field's type, or repurpose a status code on an existing endpoint.
+- New functionality adds new fields/endpoints; removals go through the existing Deprecation/Sunset header flow only.
+- New features expose capability endpoints (feature detection) rather than relying on version sniffing.
+- Contract strategy and tooling: issue #135.
+
+**PR requirements.**
+- Link the capability epic or sub-issue the PR serves (`Part of #NNN`). PRs with no linked scope item will be questioned at review.
+- One concern per PR; Conventional Commit subject; AI-use disclosure in the PR body.
+
+**Pre-push checklist.** `make lint` · `cd web && pnpm run lint && pnpm run format:check` · `make verify-local-paths` · Go tests in a libvips-capable container (a bare-host `go test ./...` silently skips CGO packages, including `internal/api/handlers`).

--- a/docs/architecture/v1-scope.md
+++ b/docs/architecture/v1-scope.md
@@ -1,0 +1,19 @@
+# Silo v1 Scope
+
+**Status: NOT LOCKED — proposal window open.**
+
+Propose capabilities with the **v1 capability proposal** issue template; triage happens on the
+[Silo v1 project](https://github.com/orgs/Silo-Server/projects/5).
+
+When the scope locks, this file becomes the source of truth and will contain:
+
+1. **Locked capabilities** — a table of capability epics (issue links) with one-line scope statements.
+2. **API policy** — additive-only within `/api/v1` (no field renames/removals, no type changes,
+   no status-code repurposing; removals only via the Deprecation/Sunset header flow; capability
+   endpoints for feature detection). Contract tooling: #135.
+3. **Amendment rules** — after lock, this file changes only via PR with code-owner review.
+   An amendment PR is the exception process: it must say what changes, why it cannot wait
+   for v1.1, and what it displaces.
+
+Until lock: treat any capability not tracked as `Proposed`/`Locked` on the project as out of scope
+for feature PRs (see the scope gate in `CLAUDE.md`).


### PR DESCRIPTION
Implements the process layer of the v1 feature-lock planner (tracker: https://github.com/orgs/Silo-Server/projects/5):

- **`.github/ISSUE_TEMPLATE/v1-capability-proposal.yml`** — uniform capability proposals (summary, user value, mandatory API surface, client impact, size); auto-labels `epic` + `v1-proposed` so proposals flow onto the project automatically.
- **`docs/architecture/v1-scope.md`** — stub lock artifact (status: NOT LOCKED). At lock time this becomes the source of truth: the locked capability table + additive-only API policy + amendment rules. Post-lock changes only via PR.
- **`.github/CODEOWNERS`** — @Quick104 review required on the lock artifact (approver list extensible here). Note: enforcement needs a branch protection/ruleset on `main` with "require review from code owners" — without it this file is advisory.
- **`AGENTS.md`** (and `CLAUDE.md` via its symlink) — new "Silo v1 Process" section: scope gate (capability not in v1-scope.md → file a proposal, not a PR), additive-only `/api/v1` rules, PR requirements, pre-push checklist — encoded where coding agents read them, since most contributions are agent-driven.

Relates to #135 (API contract strategy — the other half of the lock; the additive-only policy here summarizes its consensus approach).

AI-use disclosure: drafted by Claude Code per the approved planner design; human-reviewed before submission.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Introduced v1 scope governance documentation including scope lock mechanism and amendment process.
  * Added new issue template for proposing v1 capabilities with standardized fields for overview, user value, and sizing.
  * Documented v1 API rules emphasizing additive-only changes and pre-push verification checklist.

* **Chores**
  * Established v1 scope gate requiring capability proposals for new user-facing features.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->