### PR TITLE
ci(v1): auto-label [v1] proposals + drop premature epic label

### DIFF
--- a/.github/ISSUE_TEMPLATE/v1-capability-proposal.yml
+++ b/.github/ISSUE_TEMPLATE/v1-capability-proposal.yml
@@ -1,7 +1,7 @@
 name: v1 capability proposal
 description: Propose a user-facing capability for the Silo v1 scope lock
 title: "[v1] <capability name>"
-labels: ["epic", "v1-proposed"]
+labels: ["v1-proposed"]
 body:
   - type: markdown
     attributes:

--- a/.github/workflows/v1-proposal-labeler.yml
+++ b/.github/workflows/v1-proposal-labeler.yml
@@ -1,0 +1,26 @@
+name: v1 proposal labeler
+
+# The issue form applies `v1-proposed` automatically, but only for submissions
+# through the web form. Contributors filing via the API/CLI (or from a fork)
+# cannot apply labels without triage/write access, so their proposals would land
+# unlabeled and never auto-add to the Silo v1 project. This stamps `v1-proposed`
+# on any issue whose title starts with `[v1]`, regardless of who filed it.
+
+on:
+  issues:
+    types: [opened]
+
+permissions:
+  issues: write
+
+jobs:
+  label:
+    if: startsWith(github.event.issue.title, '[v1]')
+    runs-on: ubuntu-latest
+    steps:
+      - name: Apply v1-proposed
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          ISSUE_NUMBER: ${{ github.event.issue.number }}
+          REPO: ${{ github.repository }}
+        run: gh issue edit "$ISSUE_NUMBER" --repo "$REPO" --add-label v1-proposed


### PR DESCRIPTION
Follow-up to #145, closing two gaps in the proposal flow.

**Problem 1 — proposals from forks/CLI never reach the board.** The issue form applies `v1-proposed` only for web-form submissions. Contributors filing via the API/CLI, or from a fork (i.e. most contributors), lack the triage/write permission needed to apply labels, so `gh issue create --label` is silently dropped — the proposal lands unlabeled and never auto-adds to the [Silo v1 project](https://github.com/orgs/Silo-Server/projects/5).

**Fix:** `.github/workflows/v1-proposal-labeler.yml` — on `issues: opened`, if the title starts with `[v1]`, apply `v1-proposed` using the repo's `GITHUB_TOKEN` (which always has `issues: write`). Works regardless of the filer's permission or tool. Title is only read in the `if:` condition (not a shell context); the `run` step interpolates only the issue number and repo slug via `env:`, per Actions injection-safety guidance.

**Problem 2 — `epic` applied at filing is premature.** A fresh proposal is a *candidate*; one triaged to Stretch/Out-of-scope was never an epic. `epic`-ness belongs at acceptance/lock (better expressed via the Epic issue *type*, alongside `v1` + milestone), not at filing.

**Fix:** drop `epic` from the proposal template's auto-labels — a fresh proposal now carries only `v1-proposed`.

AI-use disclosure: authored by Claude Code per the approved v1-planner design; human-reviewed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Automated issue labeling for v1 capability proposals. Issues starting with `[v1]` are now automatically tagged with the `v1-proposed` label, streamlining issue management workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->