### PR TITLE
feat(catalog): deterministic cross-server content_id

### DIFF
--- a/cmd/silo/main.go
+++ b/cmd/silo/main.go
@@ -332,7 +332,7 @@ func main() {
 	slog.Info("connected to PostgreSQL")
 
 	if *migrateStatus {
-		migCtx, migCancel := context.WithTimeout(ctx, 5*time.Minute)
+		migCtx, migCancel := database.MigrationContext(ctx)
 		statuses, statusErr := database.MigrationStatuses(migCtx, pool, migrations.FS, "sql")
 		migCancel()
 		if statusErr != nil {
@@ -357,7 +357,7 @@ func main() {
 	}
 
 	if *migrateOnly {
-		migCtx, migCancel := context.WithTimeout(ctx, 5*time.Minute)
+		migCtx, migCancel := database.MigrationContext(ctx)
 		migErr := database.RunMigrations(migCtx, pool, migrations.FS, "sql")
 		migCancel()
 		if migErr != nil {
@@ -375,7 +375,7 @@ func main() {
 	// ciphertext; secondary nodes read whatever the primary encrypted.
 	isPrimaryNode := bc.Mode == "integrated" || bc.Mode == "api" || bc.Mode == ""
 	if isPrimaryNode {
-		migCtx, migCancel := context.WithTimeout(ctx, 5*time.Minute)
+		migCtx, migCancel := database.MigrationContext(ctx)
 		if migErr := database.RunMigrations(migCtx, pool, migrations.FS, "sql"); migErr != nil {
 			migCancel()
 			log.Fatalf("failed to run migrations: %v", migErr)

--- a/docs/architecture/deterministic-content-id.md
+++ b/docs/architecture/deterministic-content-id.md
@@ -86,7 +86,7 @@ movie-<provider>-<id>                  movie-tmdb-228064
 series-<provider>-<id>                 series-tvdb-296762
 season-<provider>-<seriesId>-<n>       season-tvdb-296762-1
 episode-<provider>-<seriesId>-<s>-<e>  episode-tvdb-296762-1-5
-local-<hex128>                         local-<sha256(path)[:16]>
+local-<hex112>                         local-<sha256(path)[:14]>
 ```
 
 The component separator is `-`, an [RFC 3986](https://www.rfc-editor.org/rfc/rfc3986#section-2.3)
@@ -328,11 +328,18 @@ are the robust result, not absolute tps.*
   for the COLLATE rewrite + remap — run off-peak; very large installs (10–50M
   rows) should use the batched procedure noted in the migration header.
 - **`local-` uses the absolute path,** so a same-server remount re-IDs local
-  items. Acceptable for the best-effort local namespace.
-- **Client-visible id churn.** `jellycompat` hashes `content_id` into the
+  items. Acceptable for the best-effort local namespace. The hash is 112 bits
+  (`sha256(path)[:14]`) so a `local-` id packs losslessly into a compat UUID
+  (see below).
+- **Client-visible id churn.** `jellycompat` encodes `content_id` into the
   client-facing UUID, so item ids seen by Android/Apple/Jellyfin clients change at
   migration (caches/resume keyed on item id reset once). **silo-android** and
-  **silo-apple** should be made aware; server-side state is fully remapped.
+  **silo-apple** should be made aware; server-side state is fully remapped. The
+  encoding is *reversible* — a structured or local `content_id` is bit-packed
+  into the UUID (`contentid.Pack`/`Unpack`), not hashed into a lookup table — so
+  a compat item id decodes by pure computation and is stable across server
+  restarts and across instances. Only arbitrary names (genres, studios) and the
+  rare `content_id` too large to pack still use the in-memory hash map.
 
 ---
 

--- a/docs/architecture/deterministic-content-id.md
+++ b/docs/architecture/deterministic-content-id.md
@@ -277,9 +277,9 @@ for. ✓ = has the property, ✗ = lacks it.
 | Key scheme | Index size | µs / probe | vs today | Cross-server deterministic | Zero-join show transform | Human-readable |
 | ---------- | ---------- | ---------- | -------- | :------------------------: | :----------------------: | :------------: |
 | Sonyflake text, `en_US.utf8` *(today)* | 74 MB | 5.05 | 1.00× | ✗ | ✗ | ✗ |
-| **Structured + `COLLATE "C"` (this PR)** | 84 MB | **1.86** | **2.71×** | ✓ | ✓ | ✓ |
 | 128-bit hash `bytea(16)` | 74 MB | 1.80 | 2.81× | ✓ | ✗ | ✗ |
 | `bigint` surrogate | 41 MB | 1.23 | 4.11× | ✗ | ✗ | ✗ |
+| **Structured + `COLLATE "C"` (this PR)** | 84 MB | **1.86** | **2.71×** | ✓ | ✓ | ✓ |
 
 The structured key lands within 3% of a 128-bit hash and is the **only all-✓
 row**. The two faster schemes each give up something load-bearing:

--- a/docs/architecture/deterministic-content-id.md
+++ b/docs/architecture/deterministic-content-id.md
@@ -270,16 +270,29 @@ remap + `COLLATE "C"`. **Every metric improves.**
 
 **`content_id` index-probe cost** — 300k forced point lookups over 1.9M keys:
 
-| Key scheme | Index size | µs / probe | vs today |
-| ---------- | ---------- | ---------- | -------- |
-| Sonyflake text, `en_US.utf8` *(today)* | 74 MB | 5.05 | 1.00× |
-| **Structured + `COLLATE "C"` (this PR)** | 84 MB | **1.86** | **2.71×** |
-| 128-bit hash `bytea(16)` | 74 MB | 1.80 | 2.81× |
-| `bigint` surrogate | 41 MB | 1.23 | 4.11× |
+The last three columns are *why* the faster schemes were rejected: speed alone
+isn't the goal — the scheme has to carry the properties the whole feature exists
+for. ✓ = has the property, ✗ = lacks it.
 
-The structured key lands within 3% of a 128-bit hash while staying
-human-readable, cross-server deterministic, and supporting the zero-join
-episode→series transform. Index grows ~14%, immaterial.
+| Key scheme | Index size | µs / probe | vs today | Cross-server deterministic | Zero-join show transform | Human-readable |
+| ---------- | ---------- | ---------- | -------- | :------------------------: | :----------------------: | :------------: |
+| Sonyflake text, `en_US.utf8` *(today)* | 74 MB | 5.05 | 1.00× | ✗ | ✗ | ✗ |
+| **Structured + `COLLATE "C"` (this PR)** | 84 MB | **1.86** | **2.71×** | ✓ | ✓ | ✓ |
+| 128-bit hash `bytea(16)` | 74 MB | 1.80 | 2.81× | ✓ | ✗ | ✗ |
+| `bigint` surrogate | 41 MB | 1.23 | 4.11× | ✗ | ✗ | ✗ |
+
+The structured key lands within 3% of a 128-bit hash and is the **only all-✓
+row**. The two faster schemes each give up something load-bearing:
+
+- **128-bit hash** is cross-server deterministic (it hashes the same natural
+  key), but an opaque digest can't be string-transformed, so episode→series
+  needs a catalog join (no zero-join hot path), and it isn't legible in logs,
+  URLs, or `psql`.
+- **`bigint` surrogate** is just the status quo's narrow integer: fast because
+  it's 8 bytes, but per-server (not reproducible elsewhere), no embedded anchor
+  to transform, and not meaningful to a human.
+
+Index grows ~14% (84 vs 74 MB), immaterial.
 
 **Real history-page query** — heaviest profile (25,384 rows):
 

--- a/docs/architecture/deterministic-content-id.md
+++ b/docs/architecture/deterministic-content-id.md
@@ -81,7 +81,7 @@ separate, deferred concern.
 
 ### Format (SchemeVersion 1)
 
-```
+```text
 movie-<provider>-<id>                  movie-tmdb-228064
 series-<provider>-<id>                 series-tvdb-296762
 season-<provider>-<seriesId>-<n>       season-tvdb-296762-1
@@ -125,7 +125,7 @@ episode IDs (often missing). Because `episode-<provider>-<seriesId>-<s>-<e>`
 embeds the series anchor, the series id is a pure **string transform** of the
 episode id — no catalog lookup:
 
-```
+```text
 episode-tvdb-296762-1-5   →   series-tvdb-296762
 movie-tmdb-228064         →   movie-tmdb-228064   (movies/series: unchanged)
 ```
@@ -179,7 +179,7 @@ and only learns its provider IDs later when the match worker confirms a result. 
 single gate in `mergeAndPersist` (`canonicalizeLocalContentID`) promotes the
 placeholder at first confirmed match:
 
-```
+```text
 SCAN a new file                          ← unchanged, still no network call
       ▼
 createOrFindSkeleton ──► tag?  YES ► movie-tmdb-123   NO ► local-<hash>
@@ -367,5 +367,3 @@ Retained so the decision isn't re-litigated:
 - **File-level deterministic id (`media_files`).** Deferred, not rejected — lower
   value (no metadata/watch state hangs off it), with open problems (server-local
   mount anchors, same-file-in-two-libraries). A complement, out of scope here.
-</content>
-</invoke>

--- a/docs/architecture/deterministic-content-id.md
+++ b/docs/architecture/deterministic-content-id.md
@@ -1,0 +1,358 @@
+# Deterministic, Cross-Server `content_id`
+
+**Status:** Implemented (branch `feat/deterministic-content-id`)
+**Scope:** catalog / scanner / metadata
+**Key code:** `internal/contentid`, `internal/metadata/service.go`,
+`internal/catalog/history_source.go`,
+`migrations/sql/20260612130000_deterministic_content_id.sql`,
+`migrations/sql/20260614120000_content_id_online_reid.sql`
+
+This is the dev-facing reference for *why* `content_id` is what it is and *how*
+it works. It merges the original design spec, the implementation notes, and the
+PR write-up into one place.
+
+---
+
+## 1. The problem
+
+`content_id` is the anchor almost everything hangs off: artwork, metadata, watch
+history, progress, favorites, ratings, collections, credits. Historically it was
+a **Sonyflake** — a locally generated, time-ordered random number minted at scan
+time.
+
+That means the *same* movie matched on two servers (or re-imported into a fresh
+instance) gets a **different** id each time. Consequence: two servers holding the
+identical title share *none* of that state. Run more than one Silo, or try to
+sync a profile's history between servers, and the same film shows up as a
+stranger on the other side — no resume point, no watched flags, no ratings. There
+was no stable identity to build any cross-server feature on.
+
+We want: **the same logical title produces the same `content_id` on every server,
+every time**, derived from a globally stable anchor (the provider IDs already in
+the library), and **stable across file renames/re-encodes** so linked state
+survives.
+
+---
+
+## 2. The decision
+
+Make `content_id` a **deterministic, provider-derived, structured natural key**,
+stored as **`text COLLATE "C"`**:
+
+| Item | `content_id` |
+| ---- | ------------ |
+| Movie | `movie-tmdb-228064` (fallback `movie-imdb-tt2413338`) |
+| Series | `series-tvdb-296762` |
+| Season | `season-tvdb-296762-1` |
+| Episode | `episode-tvdb-296762-1-5` |
+| Unmatched / local | `local-<128-bit path hash, hex>` |
+
+Why this shape:
+
+- **Collision-free with no hashing.** Provider IDs are unique by construction, so
+  this is a natural key, not a surrogate — there is no "how many bits" question
+  and no birthday bound.
+- **No column-type migration.** It stays `text`, so the wide soft-reference graph
+  keeps working; only the *values* are remapped, not the type.
+- **Debuggable.** A row's identity is legible in logs and queries, and the
+  scanner's match step becomes a direct PK lookup ("do I already have
+  `movie-tmdb-228064`?") instead of a join through `media_item_provider_ids`.
+- **Stable** across renames/re-encodes — a movie keeps its tmdb id.
+
+### Why `content_id`, not a file-level id
+
+Two distinct identities at different granularities, not to be conflated:
+
+- **`content_id`** — the *logical* item (movie/series/season/episode). One id,
+  *many* files (1080p + 4K + cuts; a series owns thousands of episode files).
+- **`media_files.id`** — one *physical* file; a per-server serial that only
+  answers "which file on disk."
+
+`content_id` is the high-value target (35 FKs + ~25 unconstrained soft references
+point at it). Its stability requirement is the *opposite* of a file id's: a file
+id *should* change on rename; a `content_id` must *not*, or every server would
+drop a title's watch history on a routine rename. That's why it's anchored on
+rename-invariant provider IDs, never a path or file hash. File-level dedup is a
+separate, deferred concern.
+
+---
+
+## 3. How the id is derived
+
+### Format (SchemeVersion 1)
+
+```
+movie-<provider>-<id>                  movie-tmdb-228064
+series-<provider>-<id>                 series-tvdb-296762
+season-<provider>-<seriesId>-<n>       season-tvdb-296762-1
+episode-<provider>-<seriesId>-<s>-<e>  episode-tvdb-296762-1-5
+local-<hex128>                         local-<sha256(path)[:16]>
+```
+
+The component separator is `-`, an [RFC 3986](https://www.rfc-editor.org/rfc/rfc3986#section-2.3)
+*unreserved* character. Every component is `[a-z0-9]+` (or `tt` + digits for
+IMDb), so `-` is an unambiguous delimiter, and because it never needs
+percent-encoding the id doubles as its own tidy URL path segment
+(`/item/series-tvdb-296762`) — identical to what is stored in the database, so
+there is no encode/decode boundary and an operator can grep the value straight
+out of a URL or log. (`:` would be legal in a path too, but `encodeURIComponent`
+escapes it to `%3A`; an unreserved separator sidesteps that entirely.)
+
+- The leading entity-type token domain-separates namespaces, so a movie and an
+  episode can never alias on a coincidental number.
+- IDs are normalized: lowercase scheme tokens, whitespace trimmed, IMDb keeps its
+  `tt` prefix verbatim.
+
+### Frozen provider precedence
+
+Each item anchors on **one** canonical provider, chosen by fixed precedence so
+two servers that see the same tags pick the same anchor:
+
+- **Movies:** `tmdb → imdb → tvdb`
+- **Series / Season / Episode:** `tvdb → tmdb → imdb` (TVDB is episode-canonical)
+
+Precedence **and** exact string format are frozen behind a code constant
+(`contentid.SchemeVersion = 1`), *not* a DB column — any scheme change forces a
+full remap that normalizes every row at once, so there is never a mixed-version
+population. Staleness is recoverable by recomputing the expected id from the
+provider columns and comparing.
+
+### The load-bearing invariant: the show falls out of the episode id
+
+Season/episode ids compose from the **series anchor + season/episode numbers**
+(both present in filenames and universally available), *not* their own provider
+episode IDs (often missing). Because `episode-<provider>-<seriesId>-<s>-<e>`
+embeds the series anchor, the series id is a pure **string transform** of the
+episode id — no catalog lookup:
+
+```
+episode-tvdb-296762-1-5   →   series-tvdb-296762
+movie-tmdb-228064         →   movie-tmdb-228064   (movies/series: unchanged)
+```
+
+This is relied on by the hot watch-history query (§5). The format must never
+break it. (`contentid.SeriesIDFromContentID` is the canonical transform.)
+
+### Where the anchor comes from
+
+For tagged libraries the IDs are in the folder/file name
+(`{imdb-tt2413338} {tmdb-228064}`), so both servers derive the same id **from the
+path string at scan time, with no API call**. The denormalized
+`media_items.{tmdb,imdb,tvdb}_id` columns and the `media_item_provider_ids` link
+table are the other sources. `content_id` is *derived from* the link table, not a
+replacement — keep the full provider-ID set indexed.
+
+---
+
+## 4. What was built
+
+| Area | File(s) | Summary |
+| ---- | ------- | ------- |
+| Derivation core | `internal/contentid/contentid.go` | `ForMovie`/`ForSeries`/`ForSeason`/`ForEpisode`/`ForLocal`, `SeriesIDFromContentID`, `IsProviderAnchored`/`IsLocal`, `SchemeVersion`, frozen precedence, normalization. |
+| Generation wiring | `internal/metadata/service.go` | `deriveLogicalContentID`/`deriveSeasonContentID`/`deriveEpisodeContentID` replace `idgen.NextID()` at every mint site (skeleton, provider-match, explicit/implicit seasons, episodes, scanner fallback). |
+| Re-ID on match | `internal/metadata/canonicalize.go` | Promotes a `local-` placeholder to its deterministic id at first confirmed match. |
+| Hot query | `internal/catalog/history_source.go` | Watch-history `display_id` resolves the show via the string transform for anchored episodes; skips the `episodes_pkey` probe. |
+| Value-remap migration | `migrations/sql/20260612130000_deterministic_content_id.sql` | Collision-safe Sonyflake → structured remap across the whole reference graph + `COLLATE "C"`, with rollback. |
+| Online re-ID migration | `migrations/sql/20260614120000_content_id_online_reid.sql` | Adds `silo_rename_content_id` + `ON UPDATE CASCADE` to the content-id FK family. |
+
+### Generation: determinism at scan time
+
+The scanner already parses provider tags from names, so `createOrFindSkeleton`
+derives `movie-tmdb-…`/`series-tvdb-…` immediately — two servers seeing the same
+tags mint the same id with no provider API call. This is the primary target
+(Radarr/Sonarr/Plex-tagged libraries). Untagged new items get a path-derived
+`local-` id keyed on the **file path** (not the folder), so distinct pre-merge
+skeletons in a shared folder stay separate while being stable across rescans.
+
+Same-server convergence is preserved by the existing dedup
+(`findExistingByProviderIDs`) plus `UpsertTx`'s
+`ON CONFLICT (content_id) DO UPDATE` backstop.
+
+Non-movie/series items (audiobook/ebook/podcast) and anchorless items **stay on
+Sonyflake** — there's no stable cross-server anchor to derive from, so changing
+them gains nothing.
+
+### Re-ID on match: untagged items converge later
+
+A tagged file is born with the right id; an *untagged* file gets a `local-` id
+and only learns its provider IDs later when the match worker confirms a result. A
+single gate in `mergeAndPersist` (`canonicalizeLocalContentID`) promotes the
+placeholder at first confirmed match:
+
+```
+SCAN a new file                          ← unchanged, still no network call
+      ▼
+createOrFindSkeleton ──► tag?  YES ► movie-tmdb-123   NO ► local-<hash>
+      ▼
+(later) match worker → mergeAndPersist → canonicalizeLocalContentID
+      │  Is the id still local- AND do we now have provider IDs?
+      │     no  → do nothing
+      │     yes → Does a row already sit at movie-tmdb-123?
+      │              yes → MERGE this row into it (rebindItemToExistingItem)
+      │              no  → RENAME local-<hash> → movie-tmdb-123
+      ▼                      └─ DB auto-moves child rows (ON UPDATE CASCADE)
+rest of mergeAndPersist runs with the corrected id
+```
+
+The guard is a single `IsLocal` prefix check, so tagged content and all refreshes
+pay nothing; the promotion is self-healing (a partial run re-runs on the next
+match). The rename primitive `silo_rename_content_id` reuses the migration's
+catalog-driven column enumeration so the two stay in lockstep.
+`ON UPDATE CASCADE` only fires when a `content_id` actually changes (essentially
+never outside this promotion), so there is no steady-state cost.
+
+### The migration
+
+The column **type does not change** (`text` → `text COLLATE "C"`); the **values**
+are remapped via add-then-swap, not in-place PK mutation. It dynamically
+enumerates the reference graph (the three PKs, every FK child from
+`pg_constraint`, and soft-reference columns by name — **65 columns** on the real
+schema), drops/recreates FKs and triggers, and retains a `content_id_migration_map`
+audit table for rollback.
+
+**Collisions are never merged.** If two items derive to the same key, or a key is
+already taken, those rows keep their Sonyflake id and are flagged `collision` in
+the map — the migration can never violate a PK or silently drop a row. Collision
+status **cascades** from a series to its seasons/episodes (otherwise a uniquely
+numbered episode under a colliding series would get an `episode-…` key whose
+embedded series anchor points at a non-existent row).
+
+`COLLATE "C"` is applied to every referencing column in the same migration so
+join keys match on both type and collation.
+
+---
+
+## 5. Why `COLLATE "C"` is mandatory
+
+Provider-derived IDs are pure ASCII, but `content_id` inherits the DB default
+`en_US.utf8` collation. The design **regresses without `COLLATE "C"`**:
+
+- For **equality / hash joins** (the watch-history join), `en_US.utf8` is
+  deterministic so PostgreSQL already compares raw bytes — collation is
+  irrelevant.
+- For **ordering** comparisons (B-tree descent on PK probes, `ORDER BY`, range
+  scans), `en_US.utf8` invokes libc `strcoll` while `C` is a plain `memcmp`.
+- Structured keys share long prefixes (`episode-tvdb-296762-…`), which makes
+  `strcoll` *worse* than on 18-digit Sonyflake strings — so a structured key
+  under `en_US.utf8` is *slower* than the status quo. Under `C` it's ~3–5×
+  faster.
+
+So `COLLATE "C"` is load-bearing, not a free upgrade.
+
+### The hot query
+
+The watch-history page query (`history_source.go`) resolves each history row's
+episode key to its series, then inner-joins `media_items`, deduped over the
+profile's *entire* history. Two facts:
+
+- `DISTINCT ON` can't short-circuit on `LIMIT` — cost is **O(history size)** with
+  PK probes per row, not O(page).
+- The structured id lets us **delete the `LEFT JOIN episodes`** that existed only
+  to fetch `series_id`: for anchored episode ids the show is a string transform.
+  The join is null-poisoned for anchored ids (`= NULL` is an unsatisfiable b-tree
+  scan key) so the planner never descends `episodes_pkey` for them. Legacy/`local-`
+  ids still fall through the join.
+
+The remaining `JOIN media_items` stays — it's for access/library filtering, not
+the show id. Reducing full-history scans to O(page) for the heaviest profiles is
+follow-up work (a per-`(profile, display_id)` summary table), not part of this
+change.
+
+---
+
+## 6. Performance — measured at production scale
+
+Measured on an isolated, prod-tuned PostgreSQL 18 instance (`shared_buffers=4GB`)
+loaded with an **exact-cardinality copy of production**: 184k items, 1.93M
+episodes, 775k watch-history rows / 1,622 profiles. "Before" reproduces
+production today (Sonyflake, `en_US.utf8`); "after" applies the structured-key
+remap + `COLLATE "C"`. **Every metric improves.**
+
+**`content_id` index-probe cost** — 300k forced point lookups over 1.9M keys:
+
+| Key scheme | Index size | µs / probe | vs today |
+| ---------- | ---------- | ---------- | -------- |
+| Sonyflake text, `en_US.utf8` *(today)* | 74 MB | 5.05 | 1.00× |
+| **Structured + `COLLATE "C"` (this PR)** | 84 MB | **1.86** | **2.71×** |
+| 128-bit hash `bytea(16)` | 74 MB | 1.80 | 2.81× |
+| `bigint` surrogate | 41 MB | 1.23 | 4.11× |
+
+The structured key lands within 3% of a 128-bit hash while staying
+human-readable, cross-server deterministic, and supporting the zero-join
+episode→series transform. Index grows ~14%, immaterial.
+
+**Real history-page query** — heaviest profile (25,384 rows):
+
+| State | Latency | `episodes_pkey` probes | Speedup |
+| ----- | ------- | ---------------------- | ------- |
+| Before | 385 ms | 25,348 | 1.00× |
+| **This PR** | **150 ms** | **2,775** | **2.57×** |
+
+**Concurrency** (`pgbench`, 150 real profiles): at 100 concurrent users,
+**311 ms / 321 tps → 181 ms / 551 tps** — 1.7× throughput, 42% lower tail
+latency. Comparison cost is pure CPU, so cheaper `COLLATE "C"` comparisons raise
+the throughput ceiling under load.
+
+*Caveat: warmed (dataset fits in `shared_buffers`); the before/after **ratios**
+are the robust result, not absolute tps.*
+
+---
+
+## 7. Known limitations / follow-ups
+
+- **Untagged series children.** A series that accumulated season/episode rows
+  *before* it matched keeps those children on Sonyflake until a follow-up
+  `recomposeSeriesChildIDs` pass re-derives them. Rare at first match (children
+  usually don't exist yet); not yet wired.
+- **Cross-provider reconciliation.** A series tagged tmdb-only on one server and
+  tvdb-only on another still diverges — both paths derive from the denormalized
+  provider columns. Proper fix: consult `media_item_provider_ids` before walking
+  the precedence list.
+- **O(history) query shape.** The watch-history `DISTINCT ON` over full history is
+  the real liability at concurrency; the string transform removes a probe but not
+  the full scan. The O(page) summary table is the fix, deferred.
+- **Migration at scale.** Runs in one transaction holding `AccessExclusive` locks
+  for the COLLATE rewrite + remap — run off-peak; very large installs (10–50M
+  rows) should use the batched procedure noted in the migration header.
+- **`local-` uses the absolute path,** so a same-server remount re-IDs local
+  items. Acceptable for the best-effort local namespace.
+- **Client-visible id churn.** `jellycompat` hashes `content_id` into the
+  client-facing UUID, so item ids seen by Android/Apple/Jellyfin clients change at
+  migration (caches/resume keyed on item id reset once). **silo-android** and
+  **silo-apple** should be made aware; server-side state is fully remapped.
+
+---
+
+## 8. Prior art
+
+- **Plex:** logical identity is a provider-namespaced GUID (`plex://movie/…`,
+  `com.plexapp.agents.imdb://tt…`) — exactly this shape. (Its per-server integer
+  `ratingKey` is the non-portable counterexample we avoid.)
+- **Jellyfin / Emby:** store namespaced provider IDs and match on them; item GUIDs
+  are deterministic. Same principle — anchor identity on the provider, not a
+  per-server sequence.
+
+---
+
+## Appendix — alternatives rejected
+
+Retained so the decision isn't re-litigated:
+
+- **Keep Sonyflake.** Non-deterministic per server — the entire problem.
+- **Hash provider tuple → `uuid` (128-bit).** Collision resistance is unnecessary
+  (input is already unique), the id becomes opaque, and it forces a `text → uuid`
+  migration across 35 FKs + ~25 soft refs whose failure mode is a seq-scan cliff
+  (miss one column → `uuid = text` per-row cast → index disabled). Pays a large
+  migration cost for an ~8-byte width win that only matters at a 50M-row ceiling.
+- **Hash provider tuple → `text` hex.** Opaque like the uuid, large like the
+  natural key — no reason to pick it over the legible structured key.
+- **Path or content hash.** A title spans many files at many paths (no single path
+  to hash), and the hash changes on rename — the opposite of the stability
+  requirement. Only appropriate for *file-level* identity.
+- **Pack provider + numeric id into `bigint`.** Variable-width provider numbers
+  and S/E packing make the encoding brittle; not worth it over a legible key.
+- **File-level deterministic id (`media_files`).** Deferred, not rejected — lower
+  value (no metadata/watch state hangs off it), with open problems (server-local
+  mount anchors, same-file-in-two-libraries). A complement, out of scope here.
+</content>
+</invoke>

--- a/internal/catalog/history_source.go
+++ b/internal/catalog/history_source.go
@@ -209,7 +209,7 @@ func buildHistoryDisplayBaseQuery(access AccessFilter, snapshot *time.Time) (str
 	// display_id resolves a history row (which may be an episode) to its shown
 	// item (the series, for episodes). For provider-anchored episode ids the
 	// series is a pure string transform of the id (the format invariant), so we
-	// skip the episodes_pkey probe entirely. Legacy Sonyflake and local: episode
+	// skip the episodes_pkey probe entirely. Legacy Sonyflake and local episode
 	// ids carry no embedded anchor, so they still fall back to the episodes
 	// lookup. The join key is null-poisoned for anchored ids (= NULL is an
 	// unsatisfiable b-tree scan key, so the planner never descends the index for
@@ -222,7 +222,7 @@ func buildHistoryDisplayBaseQuery(access AccessFilter, snapshot *time.Time) (str
 
 	// Null-poison the episodes join key for fully-formed anchored episode ids so
 	// the planner skips the episodes_pkey probe for them; everything else (legacy
-	// Sonyflake, local:, malformed) still falls back to the lookup.
+	// Sonyflake, local, malformed) still falls back to the lookup.
 	episodeJoinKey := fmt.Sprintf(
 		"CASE WHEN %s THEN NULL ELSE h.media_item_id END",
 		anchoredEpisodePredicate("h.media_item_id"),
@@ -247,34 +247,35 @@ func buildHistoryDisplayBaseQuery(access AccessFilter, snapshot *time.Time) (str
 
 // anchoredEpisodePredicate is the SQL boolean that is TRUE only for a
 // fully-formed provider-anchored episode content_id —
-// episode:<provider>:<seriesId>:<season>:<episode>, i.e. five non-empty
-// colon-separated components. It deliberately rejects a broader shape like
-// 'episode:broken': matching that on the prefix alone would transform it into
-// 'series:broken:' and skip the episodes fallback, so the row would vanish at
-// the media_items join. split_part is IMMUTABLE.
+// episode-<provider>-<seriesId>-<season>-<episode>, i.e. five non-empty
+// "-"-separated components. It deliberately rejects a broader shape like
+// 'episode-broken': matching that on the prefix alone would transform it into
+// 'series-broken-' and skip the episodes fallback, so the row would vanish at
+// the media_items join. split_part is IMMUTABLE. The "-" delimiter matches the
+// content_id format (internal/contentid); keep the two in lockstep.
 func anchoredEpisodePredicate(col string) string {
 	return fmt.Sprintf(
-		`%[1]s LIKE 'episode:%%' `+
-			`AND split_part(%[1]s, ':', 2) <> '' `+
-			`AND split_part(%[1]s, ':', 3) <> '' `+
-			`AND split_part(%[1]s, ':', 4) <> '' `+
-			`AND split_part(%[1]s, ':', 5) <> ''`,
+		`%[1]s LIKE 'episode-%%' `+
+			`AND split_part(%[1]s, '-', 2) <> '' `+
+			`AND split_part(%[1]s, '-', 3) <> '' `+
+			`AND split_part(%[1]s, '-', 4) <> '' `+
+			`AND split_part(%[1]s, '-', 5) <> ''`,
 		col,
 	)
 }
 
 // seriesFromAnchoredEpisodeExpr returns a SQL expression that recovers a show's
 // content_id from a provider-anchored episode content_id by pure string
-// transform — episode:<p>:<sid>:<s>:<e> -> series:<p>:<sid> — per the format
+// transform — episode-<p>-<sid>-<s>-<e> -> series-<p>-<sid> — per the format
 // invariant in docs/architecture/deterministic-content-id.md. It yields NULL
 // for any id that is not a fully-formed provider-anchored episode (movies,
-// series, local:, legacy Sonyflake, or malformed episode ids), so callers
+// series, local, legacy Sonyflake, or malformed episode ids), so callers
 // COALESCE to the episodes-table lookup for those. split_part/||/CASE are all
 // IMMUTABLE.
 func seriesFromAnchoredEpisodeExpr(col string) string {
 	return fmt.Sprintf(
 		`CASE WHEN %[2]s `+
-			`THEN 'series:' || split_part(%[1]s, ':', 2) || ':' || split_part(%[1]s, ':', 3) END`,
+			`THEN 'series-' || split_part(%[1]s, '-', 2) || '-' || split_part(%[1]s, '-', 3) END`,
 		col,
 		anchoredEpisodePredicate(col),
 	)

--- a/internal/catalog/history_source.go
+++ b/internal/catalog/history_source.go
@@ -206,16 +206,47 @@ func buildHistoryDisplayBaseQuery(access AccessFilter, snapshot *time.Time) (str
 
 	ApplySectionAccessFilter("mi", access, &conditions, &args, &argIdx)
 
+	// display_id resolves a history row (which may be an episode) to its shown
+	// item (the series, for episodes). For provider-anchored episode ids the
+	// series is a pure string transform of the id (the format invariant), so we
+	// skip the episodes_pkey probe entirely. Legacy Sonyflake and local: episode
+	// ids carry no embedded anchor, so they still fall back to the episodes
+	// lookup. The join key is null-poisoned for anchored ids (= NULL is an
+	// unsatisfiable b-tree scan key, so the planner never descends the index for
+	// them) — an outer-only predicate like NOT LIKE would not actually skip the
+	// probe.
+	displayIDExpr := fmt.Sprintf(
+		"COALESCE(%s, NULLIF(e.series_id, ''), h.media_item_id)",
+		seriesFromAnchoredEpisodeExpr("h.media_item_id"),
+	)
+
 	return fmt.Sprintf(
 		`SELECT DISTINCT ON (history_events.display_id) history_events.display_id, history_events.watched_at
 		FROM (
-			SELECT COALESCE(NULLIF(e.series_id, ''), h.media_item_id) AS display_id, h.watched_at
+			SELECT %[1]s AS display_id, h.watched_at
 			FROM user_watch_history h
-			LEFT JOIN episodes e ON e.content_id = h.media_item_id
-			JOIN media_items mi ON mi.content_id = COALESCE(NULLIF(e.series_id, ''), h.media_item_id)
-			WHERE %s
+			LEFT JOIN episodes e
+				ON e.content_id = CASE WHEN h.media_item_id LIKE 'episode:%%' THEN NULL ELSE h.media_item_id END
+			JOIN media_items mi ON mi.content_id = %[1]s
+			WHERE %[2]s
 		) history_events
 		ORDER BY history_events.display_id ASC, history_events.watched_at DESC`,
+		displayIDExpr,
 		strings.Join(conditions, " AND "),
 	), args
+}
+
+// seriesFromAnchoredEpisodeExpr returns a SQL expression that recovers a show's
+// content_id from a provider-anchored episode content_id by pure string
+// transform — episode:<p>:<sid>:<s>:<e> -> series:<p>:<sid> — per the format
+// invariant in docs/architecture/deterministic-content-id.md. It yields NULL
+// for any id that is not a provider-anchored episode (movies, series, local: or
+// legacy Sonyflake episode ids), so callers COALESCE to the episodes-table
+// lookup for those. split_part/||/CASE are all IMMUTABLE.
+func seriesFromAnchoredEpisodeExpr(col string) string {
+	return fmt.Sprintf(
+		`CASE WHEN %[1]s LIKE 'episode:%%' `+
+			`THEN 'series:' || split_part(%[1]s, ':', 2) || ':' || split_part(%[1]s, ':', 3) END`,
+		col,
+	)
 }

--- a/internal/catalog/history_source.go
+++ b/internal/catalog/history_source.go
@@ -220,33 +220,62 @@ func buildHistoryDisplayBaseQuery(access AccessFilter, snapshot *time.Time) (str
 		seriesFromAnchoredEpisodeExpr("h.media_item_id"),
 	)
 
+	// Null-poison the episodes join key for fully-formed anchored episode ids so
+	// the planner skips the episodes_pkey probe for them; everything else (legacy
+	// Sonyflake, local:, malformed) still falls back to the lookup.
+	episodeJoinKey := fmt.Sprintf(
+		"CASE WHEN %s THEN NULL ELSE h.media_item_id END",
+		anchoredEpisodePredicate("h.media_item_id"),
+	)
+
 	return fmt.Sprintf(
 		`SELECT DISTINCT ON (history_events.display_id) history_events.display_id, history_events.watched_at
 		FROM (
 			SELECT %[1]s AS display_id, h.watched_at
 			FROM user_watch_history h
 			LEFT JOIN episodes e
-				ON e.content_id = CASE WHEN h.media_item_id LIKE 'episode:%%' THEN NULL ELSE h.media_item_id END
+				ON e.content_id = %[3]s
 			JOIN media_items mi ON mi.content_id = %[1]s
 			WHERE %[2]s
 		) history_events
 		ORDER BY history_events.display_id ASC, history_events.watched_at DESC`,
 		displayIDExpr,
 		strings.Join(conditions, " AND "),
+		episodeJoinKey,
 	), args
+}
+
+// anchoredEpisodePredicate is the SQL boolean that is TRUE only for a
+// fully-formed provider-anchored episode content_id —
+// episode:<provider>:<seriesId>:<season>:<episode>, i.e. five non-empty
+// colon-separated components. It deliberately rejects a broader shape like
+// 'episode:broken': matching that on the prefix alone would transform it into
+// 'series:broken:' and skip the episodes fallback, so the row would vanish at
+// the media_items join. split_part is IMMUTABLE.
+func anchoredEpisodePredicate(col string) string {
+	return fmt.Sprintf(
+		`%[1]s LIKE 'episode:%%' `+
+			`AND split_part(%[1]s, ':', 2) <> '' `+
+			`AND split_part(%[1]s, ':', 3) <> '' `+
+			`AND split_part(%[1]s, ':', 4) <> '' `+
+			`AND split_part(%[1]s, ':', 5) <> ''`,
+		col,
+	)
 }
 
 // seriesFromAnchoredEpisodeExpr returns a SQL expression that recovers a show's
 // content_id from a provider-anchored episode content_id by pure string
 // transform — episode:<p>:<sid>:<s>:<e> -> series:<p>:<sid> — per the format
 // invariant in docs/architecture/deterministic-content-id.md. It yields NULL
-// for any id that is not a provider-anchored episode (movies, series, local: or
-// legacy Sonyflake episode ids), so callers COALESCE to the episodes-table
-// lookup for those. split_part/||/CASE are all IMMUTABLE.
+// for any id that is not a fully-formed provider-anchored episode (movies,
+// series, local:, legacy Sonyflake, or malformed episode ids), so callers
+// COALESCE to the episodes-table lookup for those. split_part/||/CASE are all
+// IMMUTABLE.
 func seriesFromAnchoredEpisodeExpr(col string) string {
 	return fmt.Sprintf(
-		`CASE WHEN %[1]s LIKE 'episode:%%' `+
+		`CASE WHEN %[2]s `+
 			`THEN 'series:' || split_part(%[1]s, ':', 2) || ':' || split_part(%[1]s, ':', 3) END`,
 		col,
+		anchoredEpisodePredicate(col),
 	)
 }

--- a/internal/catalog/history_source_test.go
+++ b/internal/catalog/history_source_test.go
@@ -45,9 +45,9 @@ func TestBuildHistoryDisplayBaseQueryIncludesSnapshotAndLibraryAccess(t *testing
 		// Anchored episode ids resolve their show by string transform; the
 		// episodes probe is null-poisoned (skipped) for them and kept only for
 		// non-anchored (legacy/local/malformed) ids. The predicate requires the
-		// full five-part episode form, not just the 'episode:' prefix.
-		"LEFT JOIN episodes e\n\t\t\t\tON e.content_id = CASE WHEN h.media_item_id LIKE 'episode:%' AND split_part(h.media_item_id, ':', 2) <> '' AND split_part(h.media_item_id, ':', 3) <> '' AND split_part(h.media_item_id, ':', 4) <> '' AND split_part(h.media_item_id, ':', 5) <> '' THEN NULL ELSE h.media_item_id END",
-		"split_part(h.media_item_id, ':', 2)",
+		// full five-part episode form, not just the 'episode-' prefix.
+		"LEFT JOIN episodes e\n\t\t\t\tON e.content_id = CASE WHEN h.media_item_id LIKE 'episode-%' AND split_part(h.media_item_id, '-', 2) <> '' AND split_part(h.media_item_id, '-', 3) <> '' AND split_part(h.media_item_id, '-', 4) <> '' AND split_part(h.media_item_id, '-', 5) <> '' THEN NULL ELSE h.media_item_id END",
+		"split_part(h.media_item_id, '-', 2)",
 		"JOIN media_items mi ON mi.content_id = COALESCE(",
 	}
 	for _, fragment := range expectedFragments {

--- a/internal/catalog/history_source_test.go
+++ b/internal/catalog/history_source_test.go
@@ -44,8 +44,9 @@ func TestBuildHistoryDisplayBaseQueryIncludesSnapshotAndLibraryAccess(t *testing
 		"mi.content_rating = ANY($",
 		// Anchored episode ids resolve their show by string transform; the
 		// episodes probe is null-poisoned (skipped) for them and kept only for
-		// non-anchored (legacy/local) ids.
-		"LEFT JOIN episodes e\n\t\t\t\tON e.content_id = CASE WHEN h.media_item_id LIKE 'episode:%' THEN NULL ELSE h.media_item_id END",
+		// non-anchored (legacy/local/malformed) ids. The predicate requires the
+		// full five-part episode form, not just the 'episode:' prefix.
+		"LEFT JOIN episodes e\n\t\t\t\tON e.content_id = CASE WHEN h.media_item_id LIKE 'episode:%' AND split_part(h.media_item_id, ':', 2) <> '' AND split_part(h.media_item_id, ':', 3) <> '' AND split_part(h.media_item_id, ':', 4) <> '' AND split_part(h.media_item_id, ':', 5) <> '' THEN NULL ELSE h.media_item_id END",
 		"split_part(h.media_item_id, ':', 2)",
 		"JOIN media_items mi ON mi.content_id = COALESCE(",
 	}

--- a/internal/catalog/history_source_test.go
+++ b/internal/catalog/history_source_test.go
@@ -42,8 +42,12 @@ func TestBuildHistoryDisplayBaseQueryIncludesSnapshotAndLibraryAccess(t *testing
 		"media_item_libraries mil_disabled",
 		"media_folder_id = ANY($5)",
 		"mi.content_rating = ANY($",
-		"LEFT JOIN episodes e ON e.content_id = h.media_item_id",
-		"JOIN media_items mi ON mi.content_id = COALESCE(NULLIF(e.series_id, ''), h.media_item_id)",
+		// Anchored episode ids resolve their show by string transform; the
+		// episodes probe is null-poisoned (skipped) for them and kept only for
+		// non-anchored (legacy/local) ids.
+		"LEFT JOIN episodes e\n\t\t\t\tON e.content_id = CASE WHEN h.media_item_id LIKE 'episode:%' THEN NULL ELSE h.media_item_id END",
+		"split_part(h.media_item_id, ':', 2)",
+		"JOIN media_items mi ON mi.content_id = COALESCE(",
 	}
 	for _, fragment := range expectedFragments {
 		if !strings.Contains(query, fragment) {

--- a/internal/contentid/binary.go
+++ b/internal/contentid/binary.go
@@ -1,0 +1,261 @@
+package contentid
+
+import (
+	"encoding/binary"
+	"encoding/hex"
+	"strconv"
+	"strings"
+)
+
+// Reversible binary content_id codec. Pack encodes a structured or local
+// content_id into at most 15 bytes; Unpack is its exact inverse. The Jellyfin
+// compatibility layer uses this to pack a content_id into a client-facing UUID
+// (1 kind byte + 15 payload bytes) with no side lookup table, so a compat item
+// id decodes correctly even after a server restart (see
+// docs/architecture/deterministic-content-id.md and internal/jellycompat).
+//
+// Byte 0 is a non-zero format tag. That is what lets the compat layer tell a
+// packed content_id apart from the legacy numeric UUID encoding, whose
+// corresponding byte is always zero.
+//
+//	movie / series: [tag][provider][uvarint digitCount][uvarint value]
+//	season:         ... + [uvarint season]
+//	episode:        ... + [uvarint season][uvarint episode]
+//	local:          [tagLocal][localHashLen raw hash bytes]
+//
+// digitCount records the width of the provider id's numeric part so leading
+// zeros survive (e.g. imdb tt0944947); value is that part as an integer. The
+// structured forms are self-delimiting (uvarints), so the compat layer may
+// zero-pad the packed bytes to fill the UUID and Unpack ignores the padding. The
+// local form instead fills the payload exactly (1 + localHashLen == 15), so it
+// needs no length prefix. Provider ids that overflow uint64 return ok=false, and
+// the caller falls back to its opaque encoding.
+const (
+	tagMovie   byte = 0xC0
+	tagSeries  byte = 0xC1
+	tagSeason  byte = 0xC2
+	tagEpisode byte = 0xC3
+	tagLocal   byte = 0xC4
+)
+
+// localHashLen is the byte width of the local- path hash. It fills the compat
+// UUID payload exactly after the 1-byte tag (1 + localHashLen == 15), which lets
+// the local form round-trip without a length prefix. ForLocal emits exactly this
+// many bytes; the two are in lockstep.
+const localHashLen = 14
+
+func providerToCode(p string) (byte, bool) {
+	switch p {
+	case ProviderTMDB:
+		return 1, true
+	case ProviderIMDB:
+		return 2, true
+	case ProviderTVDB:
+		return 3, true
+	}
+	return 0, false
+}
+
+func codeToProvider(c byte) (string, bool) {
+	switch c {
+	case 1:
+		return ProviderTMDB, true
+	case 2:
+		return ProviderIMDB, true
+	case 3:
+		return ProviderTVDB, true
+	}
+	return "", false
+}
+
+// Pack encodes a structured (movie/series/season/episode) or local content_id
+// into its compact binary form. It returns ok=false for legacy numeric ids,
+// provider ids too large for uint64, and anything malformed — the caller falls
+// back to its numeric/opaque encoding for those.
+func Pack(contentID string) ([]byte, bool) {
+	id := strings.TrimSpace(contentID)
+
+	if rest, ok := strings.CutPrefix(id, kindLocal+sep); ok {
+		raw, err := hex.DecodeString(rest)
+		if err != nil || len(raw) != localHashLen {
+			return nil, false
+		}
+		out := make([]byte, 0, 1+localHashLen)
+		out = append(out, tagLocal)
+		out = append(out, raw...)
+		return out, true
+	}
+
+	parts := strings.Split(id, sep)
+	switch parts[0] {
+	case kindMovie, kindSeries:
+		if len(parts) != 3 {
+			return nil, false
+		}
+		tag := tagMovie
+		if parts[0] == kindSeries {
+			tag = tagSeries
+		}
+		return packAnchored(tag, parts[1], parts[2], nil)
+	case kindSeason:
+		if len(parts) != 4 {
+			return nil, false
+		}
+		nums, ok := parseNums(parts[3:])
+		if !ok {
+			return nil, false
+		}
+		return packAnchored(tagSeason, parts[1], parts[2], nums)
+	case kindEpisode:
+		if len(parts) != 5 {
+			return nil, false
+		}
+		nums, ok := parseNums(parts[3:])
+		if !ok {
+			return nil, false
+		}
+		return packAnchored(tagEpisode, parts[1], parts[2], nums)
+	}
+	return nil, false
+}
+
+// Unpack reverses Pack. It fails closed (ok=false) on any byte sequence Pack
+// could not have produced, including trailing data after a complete structured
+// id (the compat layer's zero padding is ignored, not rejected).
+func Unpack(data []byte) (string, bool) {
+	if len(data) == 0 {
+		return "", false
+	}
+	tag, body := data[0], data[1:]
+
+	if tag == tagLocal {
+		if len(body) < localHashLen {
+			return "", false
+		}
+		return kindLocal + sep + hex.EncodeToString(body[:localHashLen]), true
+	}
+
+	var kind string
+	var nNums int
+	switch tag {
+	case tagMovie:
+		kind = kindMovie
+	case tagSeries:
+		kind = kindSeries
+	case tagSeason:
+		kind, nNums = kindSeason, 1
+	case tagEpisode:
+		kind, nNums = kindEpisode, 2
+	default:
+		return "", false
+	}
+
+	if len(body) == 0 {
+		return "", false
+	}
+	provider, ok := codeToProvider(body[0])
+	if !ok {
+		return "", false
+	}
+	body = body[1:]
+
+	digitCount, value, body, ok := readUvarint2(body)
+	if !ok || digitCount == 0 || digitCount > 64 {
+		return "", false
+	}
+
+	nums := make([]uint64, nNums)
+	for i := range nums {
+		v, n := binary.Uvarint(body)
+		if n <= 0 {
+			return "", false
+		}
+		nums[i] = v
+		body = body[n:]
+	}
+
+	digits := padDigits(value, int(digitCount))
+	idStr := digits
+	if provider == ProviderIMDB {
+		idStr = "tt" + digits
+	}
+
+	var sb strings.Builder
+	sb.WriteString(kind)
+	sb.WriteString(sep)
+	sb.WriteString(provider)
+	sb.WriteString(sep)
+	sb.WriteString(idStr)
+	for _, nm := range nums {
+		sb.WriteString(sep)
+		sb.WriteString(strconv.FormatUint(nm, 10))
+	}
+	return sb.String(), true
+}
+
+// packAnchored serializes a provider-anchored content_id's components. nums
+// carries the trailing season (and episode) numbers, if any.
+func packAnchored(tag byte, provider, idStr string, nums []uint64) ([]byte, bool) {
+	code, ok := providerToCode(provider)
+	if !ok {
+		return nil, false
+	}
+	normalized, ok := normalizeProviderID(provider, idStr)
+	if !ok {
+		return nil, false
+	}
+	digits := normalized
+	if provider == ProviderIMDB {
+		digits = strings.TrimPrefix(normalized, "tt")
+	}
+	value, err := strconv.ParseUint(digits, 10, 64)
+	if err != nil {
+		return nil, false // too large for uint64 — caller falls back
+	}
+	out := make([]byte, 0, 16)
+	out = append(out, tag, code)
+	out = binary.AppendUvarint(out, uint64(len(digits)))
+	out = binary.AppendUvarint(out, value)
+	for _, n := range nums {
+		out = binary.AppendUvarint(out, n)
+	}
+	return out, true
+}
+
+func parseNums(strs []string) ([]uint64, bool) {
+	out := make([]uint64, len(strs))
+	for i, s := range strs {
+		if !numericIDPattern.MatchString(s) {
+			return nil, false
+		}
+		v, err := strconv.ParseUint(s, 10, 64)
+		if err != nil {
+			return nil, false
+		}
+		out[i] = v
+	}
+	return out, true
+}
+
+// readUvarint2 reads two consecutive uvarints, returning the remaining bytes.
+func readUvarint2(body []byte) (a, b uint64, rest []byte, ok bool) {
+	a, n := binary.Uvarint(body)
+	if n <= 0 {
+		return 0, 0, nil, false
+	}
+	body = body[n:]
+	b, n = binary.Uvarint(body)
+	if n <= 0 {
+		return 0, 0, nil, false
+	}
+	return a, b, body[n:], true
+}
+
+// padDigits renders v as a base-10 string left-padded with zeros to width.
+func padDigits(v uint64, width int) string {
+	s := strconv.FormatUint(v, 10)
+	if len(s) >= width {
+		return s
+	}
+	return strings.Repeat("0", width-len(s)) + s
+}

--- a/internal/contentid/binary.go
+++ b/internal/contentid/binary.go
@@ -120,8 +120,9 @@ func Pack(contentID string) ([]byte, bool) {
 }
 
 // Unpack reverses Pack. It fails closed (ok=false) on any byte sequence Pack
-// could not have produced, including trailing data after a complete structured
-// id (the compat layer's zero padding is ignored, not rejected).
+// could not have produced. Trailing zero padding after a complete structured id
+// is ignored (the compat layer pads the packed bytes to fill the UUID); the
+// fixed-length local form has no padding and is matched exactly.
 func Unpack(data []byte) (string, bool) {
 	if len(data) == 0 {
 		return "", false
@@ -129,10 +130,12 @@ func Unpack(data []byte) (string, bool) {
 	tag, body := data[0], data[1:]
 
 	if tag == tagLocal {
-		if len(body) < localHashLen {
+		// The local form fills the payload exactly, so its body must be exactly
+		// localHashLen — reject any other length, including trailing bytes.
+		if len(body) != localHashLen {
 			return "", false
 		}
-		return kindLocal + sep + hex.EncodeToString(body[:localHashLen]), true
+		return kindLocal + sep + hex.EncodeToString(body), true
 	}
 
 	var kind string

--- a/internal/contentid/binary_test.go
+++ b/internal/contentid/binary_test.go
@@ -79,3 +79,19 @@ func TestUnpackRejectsGarbage(t *testing.T) {
 		}
 	}
 }
+
+// TestUnpackLocalRequiresExactLength: unlike the padded structured forms, the
+// local form fills the payload exactly, so its body must be exactly
+// localHashLen. Trailing or missing bytes are non-canonical and must fail closed.
+func TestUnpackLocalRequiresExactLength(t *testing.T) {
+	exact := append([]byte{tagLocal}, make([]byte, localHashLen)...)
+	if _, ok := Unpack(exact); !ok {
+		t.Fatalf("Unpack(exact-length local body) = false, want true")
+	}
+	for _, n := range []int{localHashLen - 1, localHashLen + 1} {
+		b := append([]byte{tagLocal}, make([]byte, n)...)
+		if id, ok := Unpack(b); ok {
+			t.Fatalf("Unpack(local body len %d) = (%q, true), want fail-closed", n, id)
+		}
+	}
+}

--- a/internal/contentid/binary_test.go
+++ b/internal/contentid/binary_test.go
@@ -1,0 +1,81 @@
+package contentid
+
+import (
+	"strings"
+	"testing"
+)
+
+// TestPackUnpackRoundTrip is the load-bearing property for the reversible
+// jellycompat codec: every provider-anchored and local content_id must survive
+// Pack -> Unpack unchanged, and the packed form must fit the 15-byte budget a
+// compat UUID leaves after its 1-byte kind prefix. This is what lets the compat
+// layer decode an item id with no lookup table, so it stays correct across
+// server restarts.
+func TestPackUnpackRoundTrip(t *testing.T) {
+	ids := []string{
+		"movie-tmdb-228064",
+		"movie-imdb-tt2413338",
+		"movie-imdb-tt0944947", // leading zero must be preserved
+		"movie-tvdb-12345",
+		"series-tvdb-296762",
+		"series-tmdb-1399",
+		"series-imdb-tt0944947",
+		"season-tvdb-296762-1",
+		"season-tvdb-296762-0", // specials
+		"episode-tvdb-296762-1-5",
+		"episode-imdb-tt0944947-2-10",
+		"episode-tmdb-1399-10-100",
+		// 14-byte (28 hex) local hash — the post-change ForLocal width.
+		"local-0123456789abcdef0123456789ab",
+		ForLocal("/media/movies/Home Video.mkv"),
+	}
+	for _, id := range ids {
+		data, ok := Pack(id)
+		if !ok {
+			t.Fatalf("Pack(%q) ok=false, want true", id)
+		}
+		if len(data) > 15 {
+			t.Fatalf("Pack(%q) = %d bytes, exceeds 15-byte compat budget", id, len(data))
+		}
+		got, ok := Unpack(data)
+		if !ok || got != id {
+			t.Fatalf("round trip %q -> %x -> (%q,%v)", id, data, got, ok)
+		}
+	}
+}
+
+// TestPackRejectsNonContentID: Pack handles only the structured and local
+// namespaces. Legacy numeric Sonyflake ids and anything malformed return
+// ok=false so the caller falls back to its numeric/opaque path.
+func TestPackRejectsNonContentID(t *testing.T) {
+	for _, id := range []string{
+		"",
+		"1234567890123456", // legacy Sonyflake
+		"garbage",
+		"movie-bogus-x",       // invalid provider id
+		"episode-tvdb-296762", // truncated (missing season/episode)
+		"movie-",
+		"local-",    // empty hash
+		"local-xyz", // non-hex hash
+	} {
+		if data, ok := Pack(id); ok {
+			t.Fatalf("Pack(%q) = (%x, true), want ok=false", id, data)
+		}
+	}
+}
+
+// TestUnpackRejectsGarbage: Unpack must fail closed on bytes that were not
+// produced by Pack rather than returning a plausible-looking id.
+func TestUnpackRejectsGarbage(t *testing.T) {
+	for _, b := range [][]byte{
+		nil,
+		{},
+		{0x00},
+		{0xff, 0xff, 0xff},
+		[]byte(strings.Repeat("\x01", 15)),
+	} {
+		if id, ok := Unpack(b); ok {
+			t.Fatalf("Unpack(%x) = (%q, true), want ok=false", b, id)
+		}
+	}
+}

--- a/internal/contentid/contentid.go
+++ b/internal/contentid/contentid.go
@@ -10,15 +10,21 @@
 // This package replaces that with a structured natural key derived from the
 // provider IDs already embedded in the library:
 //
-//	movie:<provider>:<id>                      e.g. movie:tmdb:228064
-//	series:<provider>:<id>                     e.g. series:tvdb:296762
-//	season:<provider>:<seriesId>:<seasonNo>    e.g. season:tvdb:296762:1
-//	episode:<provider>:<seriesId>:<s>:<e>      e.g. episode:tvdb:296762:1:5
-//	local:<hex128>                             unmatched / local fallback
+//	movie-<provider>-<id>                      e.g. movie-tmdb-228064
+//	series-<provider>-<id>                     e.g. series-tvdb-296762
+//	season-<provider>-<seriesId>-<seasonNo>    e.g. season-tvdb-296762-1
+//	episode-<provider>-<seriesId>-<s>-<e>      e.g. episode-tvdb-296762-1-5
+//	local-<hex128>                             unmatched / local fallback
 //
 // Provider IDs are unique by construction, so the value is collision-free with
 // no hashing. The leading entity-type token domain-separates the namespaces so
 // a movie and an episode can never alias on a coincidental number.
+//
+// The component separator is "-" (an RFC 3986 unreserved character) rather than
+// ":". Every component is [a-z0-9]+ (or "tt"+digits for IMDb), so "-" is an
+// unambiguous delimiter, and because it needs no percent-encoding the id is its
+// own tidy URL path segment — /item/series-tvdb-296762, identical to what is
+// stored in the database (no encode/decode, greppable as-is). See sep.
 //
 // Load-bearing format invariant: an episode/season ID embeds its series anchor,
 // so the series content_id is always a pure string transform of the
@@ -44,6 +50,16 @@ import (
 // not a per-row column: content_id has no lasting mixed-version population
 // because any scheme change normalizes every row at once.
 const SchemeVersion = 1
+
+// sep joins the components of a content_id. It is an RFC 3986 unreserved
+// character, so a content_id is URL-safe verbatim (encodeURIComponent is a
+// no-op) and survives as a clean path segment with no percent-encoding. It is
+// part of the frozen format (SchemeVersion) and mirrored by the literal
+// delimiters in 20260612130000_deterministic_content_id.sql and the split_part
+// transform in internal/catalog/history_source.go — changing it here without
+// changing those re-IDs items inconsistently. No component ever contains it
+// (all are [a-z0-9]+ / "tt"+digits), so it is an unambiguous delimiter.
+const sep = "-"
 
 // Entity-type tokens. These domain-separate the provider-number namespaces.
 const (
@@ -148,7 +164,7 @@ func ForMovie(ids ProviderIDs) (string, bool) {
 	if !ok {
 		return "", false
 	}
-	return kindMovie + ":" + provider + ":" + id, true
+	return kindMovie + sep + provider + sep + id, true
 }
 
 // ForSeries returns the deterministic content_id for a series, or ("", false)
@@ -158,22 +174,22 @@ func ForSeries(ids ProviderIDs) (string, bool) {
 	if !ok {
 		return "", false
 	}
-	return kindSeries + ":" + provider + ":" + id, true
+	return kindSeries + sep + provider + sep + id, true
 }
 
-// seriesBody returns the "<provider>:<id>" portion of a provider-anchored series
-// content_id, e.g. "tvdb:296762" for "series:tvdb:296762". Returns ok=false for
-// any id that is not a provider-anchored series (local: series, legacy Sonyflake
+// seriesBody returns the "<provider>-<id>" portion of a provider-anchored series
+// content_id, e.g. "tvdb-296762" for "series-tvdb-296762". Returns ok=false for
+// any id that is not a provider-anchored series (local series, legacy Sonyflake
 // ids, etc.) so seasons/episodes correctly fall back instead of composing a
 // malformed key.
 func seriesBody(seriesContentID string) (string, bool) {
-	rest, ok := strings.CutPrefix(strings.TrimSpace(seriesContentID), kindSeries+":")
+	rest, ok := strings.CutPrefix(strings.TrimSpace(seriesContentID), kindSeries+sep)
 	if !ok || rest == "" {
 		return "", false
 	}
-	// Guard the format invariant: exactly "<provider>:<id>" with a known,
+	// Guard the format invariant: exactly "<provider>-<id>" with a known,
 	// validated provider and id. Anything else cannot anchor children.
-	parts := strings.Split(rest, ":")
+	parts := strings.Split(rest, sep)
 	if len(parts) != 2 {
 		return "", false
 	}
@@ -192,7 +208,7 @@ func ForSeason(seriesContentID string, seasonNumber int) (string, bool) {
 	if !ok {
 		return "", false
 	}
-	return kindSeason + ":" + body + ":" + strconv.Itoa(seasonNumber), true
+	return kindSeason + sep + body + sep + strconv.Itoa(seasonNumber), true
 }
 
 // ForEpisode composes an episode content_id from its parent series content_id
@@ -205,11 +221,11 @@ func ForEpisode(seriesContentID string, seasonNumber, episodeNumber int) (string
 	if !ok {
 		return "", false
 	}
-	return kindEpisode + ":" + body + ":" +
-		strconv.Itoa(seasonNumber) + ":" + strconv.Itoa(episodeNumber), true
+	return kindEpisode + sep + body + sep +
+		strconv.Itoa(seasonNumber) + sep + strconv.Itoa(episodeNumber), true
 }
 
-// ForLocal returns a content_id in the disjoint "local:" namespace for an item
+// ForLocal returns a content_id in the disjoint "local-" namespace for an item
 // with no provider anchor, derived from a normalized path so the same library
 // on the same server stays stable across rescans. It can never collide with a
 // provider-derived id. An item's local id changes if it is later matched to a
@@ -221,44 +237,44 @@ func ForEpisode(seriesContentID string, seasonNumber, episodeNumber int) (string
 func ForLocal(path string) string {
 	normalized := norm.NFC.String(strings.TrimSpace(path))
 	sum := sha256.Sum256([]byte(normalized))
-	return kindLocal + ":" + hex.EncodeToString(sum[:16])
+	return kindLocal + sep + hex.EncodeToString(sum[:16])
 }
 
 // SeriesIDFromContentID derives the owning series content_id from an episode or
 // season content_id by pure string transform — no catalog lookup — per the
 // format invariant. For a movie or series id it returns the id unchanged (a
 // movie is its own display item; a series id is already a series id). For a
-// local: episode/season (no embedded series anchor) or any unrecognized id it
+// local episode/season (no embedded series anchor) or any unrecognized id it
 // returns ok=false, signaling the caller to fall back to a resolved lookup.
 //
-//	episode:tvdb:296762:1:5 -> series:tvdb:296762
-//	season:tvdb:296762:1    -> series:tvdb:296762
-//	movie:tmdb:228064       -> movie:tmdb:228064  (unchanged)
-//	series:tvdb:296762      -> series:tvdb:296762  (unchanged)
+//	episode-tvdb-296762-1-5 -> series-tvdb-296762
+//	season-tvdb-296762-1    -> series-tvdb-296762
+//	movie-tmdb-228064       -> movie-tmdb-228064  (unchanged)
+//	series-tvdb-296762      -> series-tvdb-296762  (unchanged)
 func SeriesIDFromContentID(contentID string) (string, bool) {
 	id := strings.TrimSpace(contentID)
-	if strings.HasPrefix(id, kindMovie+":") || strings.HasPrefix(id, kindSeries+":") {
+	if strings.HasPrefix(id, kindMovie+sep) || strings.HasPrefix(id, kindSeries+sep) {
 		// A movie is its own display item; a series id is already a series id.
-		// Still require the anchor to be well-formed so a truncated "series:"
+		// Still require the anchor to be well-formed so a truncated "series-"
 		// cannot pass through unchanged.
 		if !IsProviderAnchored(id) {
 			return "", false
 		}
 		return id, true
 	}
-	// episode/season carry an embedded "<provider>:<seriesId>" anchor; recover it
+	// episode/season carry an embedded "<provider>-<seriesId>" anchor; recover it
 	// by pure string transform. parseAnchored enforces the full per-kind arity, so
-	// a truncated "episode:tvdb:296762" (missing season/episode) fails closed
+	// a truncated "episode-tvdb-296762" (missing season/episode) fails closed
 	// rather than aliasing onto a series.
 	if provider, seriesID, ok := parseAnchored(id); ok {
-		return kindSeries + ":" + provider + ":" + seriesID, true
+		return kindSeries + sep + provider + sep + seriesID, true
 	}
-	// local: ids and legacy Sonyflake ids have no embedded anchor.
+	// local ids and legacy Sonyflake ids have no embedded anchor.
 	return "", false
 }
 
 // IsProviderAnchored reports whether the content_id is a fully-formed
-// provider-derived key (movie/series/season/episode), as opposed to a local: id,
+// provider-derived key (movie/series/season/episode), as opposed to a local id,
 // a legacy Sonyflake id, or a truncated/malformed anchor. Used by migration and
 // diagnostics to tell remappable items apart.
 func IsProviderAnchored(contentID string) bool {
@@ -270,27 +286,27 @@ func IsProviderAnchored(contentID string) bool {
 // per-kind arity and component shape, returning the canonical (provider,
 // seriesId-or-id) anchor when it is well-formed:
 //
-//	movie:<p>:<id>                 -> (p, id)
-//	series:<p>:<id>                -> (p, id)
-//	season:<p>:<sid>:<n>           -> (p, sid)   n must be a base-10 integer
-//	episode:<p>:<sid>:<s>:<e>      -> (p, sid)   s,e must be base-10 integers
+//	movie-<p>-<id>                 -> (p, id)
+//	series-<p>-<id>                -> (p, id)
+//	season-<p>-<sid>-<n>           -> (p, sid)   n must be a base-10 integer
+//	episode-<p>-<sid>-<s>-<e>      -> (p, sid)   s,e must be base-10 integers
 //
 // It fails closed for any other shape (wrong part count, non-numeric
-// season/episode, unknown/invalid provider id, local: or legacy ids).
+// season/episode, unknown/invalid provider id, local or legacy ids).
 func parseAnchored(id string) (provider, seriesID string, ok bool) {
-	kind, rest, found := strings.Cut(id, ":")
+	kind, rest, found := strings.Cut(id, sep)
 	if !found {
 		return "", "", false
 	}
-	parts := strings.Split(rest, ":")
+	parts := strings.Split(rest, sep)
 	var wantParts int
 	switch kind {
 	case kindMovie, kindSeries:
-		wantParts = 2 // <provider>:<id>
+		wantParts = 2 // <provider>-<id>
 	case kindSeason:
-		wantParts = 3 // <provider>:<seriesId>:<seasonNo>
+		wantParts = 3 // <provider>-<seriesId>-<seasonNo>
 	case kindEpisode:
-		wantParts = 4 // <provider>:<seriesId>:<seasonNo>:<episodeNo>
+		wantParts = 4 // <provider>-<seriesId>-<seasonNo>-<episodeNo>
 	default:
 		return "", "", false
 	}
@@ -309,7 +325,7 @@ func parseAnchored(id string) (provider, seriesID string, ok bool) {
 	return parts[0], parts[1], true
 }
 
-// IsLocal reports whether the content_id is in the local: fallback namespace.
+// IsLocal reports whether the content_id is in the local fallback namespace.
 func IsLocal(contentID string) bool {
-	return strings.HasPrefix(strings.TrimSpace(contentID), kindLocal+":")
+	return strings.HasPrefix(strings.TrimSpace(contentID), kindLocal+sep)
 }

--- a/internal/contentid/contentid.go
+++ b/internal/contentid/contentid.go
@@ -1,0 +1,282 @@
+// Package contentid derives deterministic, cross-server stable content IDs for
+// logical media items (movies, series, seasons, episodes).
+//
+// Historically every logical item was minted a Sonyflake ID — a locally
+// generated, time-ordered number that differs per server for the same title.
+// content_id is the anchor that artwork, metadata, watch history, progress,
+// favorites, ratings, collections and credits hang off, so a per-server ID
+// means two servers holding the same movie cannot share any of that state.
+//
+// This package replaces that with a structured natural key derived from the
+// provider IDs already embedded in the library:
+//
+//	movie:<provider>:<id>                      e.g. movie:tmdb:228064
+//	series:<provider>:<id>                     e.g. series:tvdb:296762
+//	season:<provider>:<seriesId>:<seasonNo>    e.g. season:tvdb:296762:1
+//	episode:<provider>:<seriesId>:<s>:<e>      e.g. episode:tvdb:296762:1:5
+//	local:<hex128>                             unmatched / local fallback
+//
+// Provider IDs are unique by construction, so the value is collision-free with
+// no hashing. The leading entity-type token domain-separates the namespaces so
+// a movie and an episode can never alias on a coincidental number.
+//
+// Load-bearing format invariant: an episode/season ID embeds its series anchor,
+// so the series content_id is always a pure string transform of the
+// episode/season ID (see SeriesIDFromContentID). The watch-history query relies
+// on this to resolve a show without an episodes table lookup. Never break it.
+//
+// See docs/architecture/deterministic-content-id.md for the full rationale.
+package contentid
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"regexp"
+	"strconv"
+	"strings"
+
+	"golang.org/x/text/unicode/norm"
+)
+
+// SchemeVersion freezes the provider precedence and the exact string format.
+// Changing either re-IDs items, so it is a deliberate, rare event that forces a
+// full remap (see the migration machinery). It is intentionally a code constant,
+// not a per-row column: content_id has no lasting mixed-version population
+// because any scheme change normalizes every row at once.
+const SchemeVersion = 1
+
+// Entity-type tokens. These domain-separate the provider-number namespaces.
+const (
+	kindMovie   = "movie"
+	kindSeries  = "series"
+	kindSeason  = "season"
+	kindEpisode = "episode"
+	kindLocal   = "local"
+)
+
+// Canonical provider tokens.
+const (
+	ProviderTMDB = "tmdb"
+	ProviderIMDB = "imdb"
+	ProviderTVDB = "tvdb"
+)
+
+// MovieProviderPrecedence and SeriesProviderPrecedence freeze, per the scheme
+// version, which provider anchors a logical item when more than one tag is
+// present. Two servers that both see the tags therefore pick the same anchor.
+//
+//   - Movies prefer TMDB (the richest movie source).
+//   - Series/Season/Episode prefer TVDB (the traditional episode-canonical
+//     source).
+var (
+	MovieProviderPrecedence  = []string{ProviderTMDB, ProviderIMDB, ProviderTVDB}
+	SeriesProviderPrecedence = []string{ProviderTVDB, ProviderTMDB, ProviderIMDB}
+)
+
+// ProviderIDs carries the raw provider identifiers for an item as found on the
+// denormalized columns or parsed from folder/file tags. Empty fields are
+// ignored.
+type ProviderIDs struct {
+	Tmdb string
+	Imdb string
+	Tvdb string
+}
+
+func (p ProviderIDs) get(provider string) string {
+	switch provider {
+	case ProviderTMDB:
+		return p.Tmdb
+	case ProviderIMDB:
+		return p.Imdb
+	case ProviderTVDB:
+		return p.Tvdb
+	}
+	return ""
+}
+
+// numericIDPattern validates a tmdb/tvdb id: a non-empty run of digits.
+var numericIDPattern = regexp.MustCompile(`^[0-9]+$`)
+
+// imdbIDPattern validates an imdb id: the literal "tt" followed by digits.
+var imdbIDPattern = regexp.MustCompile(`^tt[0-9]+$`)
+
+// normalizeProviderID normalizes and validates a provider id for use in a
+// content_id. Returns the normalized id and whether it is usable. IMDb ids are
+// lowercased and must retain their "tt" prefix; tmdb/tvdb ids must be a bare
+// run of digits with no leading-zero rewriting (the provider's canonical form).
+func normalizeProviderID(provider, raw string) (string, bool) {
+	id := strings.TrimSpace(raw)
+	if id == "" {
+		return "", false
+	}
+	switch provider {
+	case ProviderIMDB:
+		id = strings.ToLower(id)
+		if !imdbIDPattern.MatchString(id) {
+			return "", false
+		}
+		return id, true
+	case ProviderTMDB, ProviderTVDB:
+		if !numericIDPattern.MatchString(id) {
+			return "", false
+		}
+		return id, true
+	default:
+		return "", false
+	}
+}
+
+// anchor picks the canonical (provider, id) for an item under the given
+// precedence, returning ok=false when no usable provider id is present.
+func anchor(ids ProviderIDs, precedence []string) (provider, id string, ok bool) {
+	for _, p := range precedence {
+		if norm, valid := normalizeProviderID(p, ids.get(p)); valid {
+			return p, norm, true
+		}
+	}
+	return "", "", false
+}
+
+// ForMovie returns the deterministic content_id for a movie, or ("", false) if
+// no provider anchor is present (the caller should fall back to ForLocal).
+func ForMovie(ids ProviderIDs) (string, bool) {
+	provider, id, ok := anchor(ids, MovieProviderPrecedence)
+	if !ok {
+		return "", false
+	}
+	return kindMovie + ":" + provider + ":" + id, true
+}
+
+// ForSeries returns the deterministic content_id for a series, or ("", false)
+// if no provider anchor is present.
+func ForSeries(ids ProviderIDs) (string, bool) {
+	provider, id, ok := anchor(ids, SeriesProviderPrecedence)
+	if !ok {
+		return "", false
+	}
+	return kindSeries + ":" + provider + ":" + id, true
+}
+
+// seriesBody returns the "<provider>:<id>" portion of a provider-anchored series
+// content_id, e.g. "tvdb:296762" for "series:tvdb:296762". Returns ok=false for
+// any id that is not a provider-anchored series (local: series, legacy Sonyflake
+// ids, etc.) so seasons/episodes correctly fall back instead of composing a
+// malformed key.
+func seriesBody(seriesContentID string) (string, bool) {
+	rest, ok := strings.CutPrefix(strings.TrimSpace(seriesContentID), kindSeries+":")
+	if !ok || rest == "" {
+		return "", false
+	}
+	// Guard the format invariant: exactly "<provider>:<id>" with a known,
+	// validated provider and id. Anything else cannot anchor children.
+	parts := strings.Split(rest, ":")
+	if len(parts) != 2 {
+		return "", false
+	}
+	if _, valid := normalizeProviderID(parts[0], parts[1]); !valid {
+		return "", false
+	}
+	return rest, true
+}
+
+// ForSeason composes a season content_id from its parent series content_id and
+// the season number. It relies on the format invariant: the season key embeds
+// the series anchor. Returns ("", false) when the series is not provider-
+// anchored, so the caller falls back to a local/legacy id.
+func ForSeason(seriesContentID string, seasonNumber int) (string, bool) {
+	body, ok := seriesBody(seriesContentID)
+	if !ok {
+		return "", false
+	}
+	return kindSeason + ":" + body + ":" + strconv.Itoa(seasonNumber), true
+}
+
+// ForEpisode composes an episode content_id from its parent series content_id
+// and the season/episode numbers. Episodes compose from the series anchor plus
+// numbers (both universally present in filenames), not their own provider
+// episode IDs which are often missing. Returns ("", false) when the series is
+// not provider-anchored.
+func ForEpisode(seriesContentID string, seasonNumber, episodeNumber int) (string, bool) {
+	body, ok := seriesBody(seriesContentID)
+	if !ok {
+		return "", false
+	}
+	return kindEpisode + ":" + body + ":" +
+		strconv.Itoa(seasonNumber) + ":" + strconv.Itoa(episodeNumber), true
+}
+
+// ForLocal returns a content_id in the disjoint "local:" namespace for an item
+// with no provider anchor, derived from a normalized path so the same library
+// on the same server stays stable across rescans. It can never collide with a
+// provider-derived id. An item's local id changes if it is later matched to a
+// provider — rare, and such items seldom carry watch state.
+//
+// The path is NFC-normalized and trimmed before hashing; the hash is the first
+// 128 bits of SHA-256, hex-encoded (32 chars). Cross-server stability for local
+// items is best-effort only (paths differ between servers).
+func ForLocal(path string) string {
+	normalized := norm.NFC.String(strings.TrimSpace(path))
+	sum := sha256.Sum256([]byte(normalized))
+	return kindLocal + ":" + hex.EncodeToString(sum[:16])
+}
+
+// SeriesIDFromContentID derives the owning series content_id from an episode or
+// season content_id by pure string transform — no catalog lookup — per the
+// format invariant. For a movie or series id it returns the id unchanged (a
+// movie is its own display item; a series id is already a series id). For a
+// local: episode/season (no embedded series anchor) or any unrecognized id it
+// returns ok=false, signaling the caller to fall back to a resolved lookup.
+//
+//	episode:tvdb:296762:1:5 -> series:tvdb:296762
+//	season:tvdb:296762:1    -> series:tvdb:296762
+//	movie:tmdb:228064       -> movie:tmdb:228064  (unchanged)
+//	series:tvdb:296762      -> series:tvdb:296762  (unchanged)
+func SeriesIDFromContentID(contentID string) (string, bool) {
+	id := strings.TrimSpace(contentID)
+	switch {
+	case strings.HasPrefix(id, kindMovie+":"), strings.HasPrefix(id, kindSeries+":"):
+		return id, true
+	case strings.HasPrefix(id, kindEpisode+":"), strings.HasPrefix(id, kindSeason+":"):
+		// Drop the kind token, keep "<provider>:<seriesId>" (the first two
+		// remaining components), re-prefix with "series:".
+		rest := id[strings.IndexByte(id, ':')+1:]
+		parts := strings.SplitN(rest, ":", 3)
+		if len(parts) < 2 {
+			return "", false
+		}
+		if _, valid := normalizeProviderID(parts[0], parts[1]); !valid {
+			return "", false
+		}
+		return kindSeries + ":" + parts[0] + ":" + parts[1], true
+	default:
+		// local: ids and legacy Sonyflake ids have no embedded anchor.
+		return "", false
+	}
+}
+
+// IsProviderAnchored reports whether the content_id is a provider-derived key
+// (movie/series/season/episode), as opposed to a local: id or a legacy
+// Sonyflake id. Used by migration and diagnostics to tell remappable items
+// apart.
+func IsProviderAnchored(contentID string) bool {
+	id := strings.TrimSpace(contentID)
+	for _, kind := range []string{kindMovie, kindSeries, kindSeason, kindEpisode} {
+		if strings.HasPrefix(id, kind+":") {
+			rest := id[len(kind)+1:]
+			parts := strings.SplitN(rest, ":", 3)
+			if len(parts) < 2 {
+				return false
+			}
+			if _, valid := normalizeProviderID(parts[0], parts[1]); valid {
+				return true
+			}
+			return false
+		}
+	}
+	return false
+}
+
+// IsLocal reports whether the content_id is in the local: fallback namespace.
+func IsLocal(contentID string) bool {
+	return strings.HasPrefix(strings.TrimSpace(contentID), kindLocal+":")
+}

--- a/internal/contentid/contentid.go
+++ b/internal/contentid/contentid.go
@@ -14,7 +14,7 @@
 //	series-<provider>-<id>                     e.g. series-tvdb-296762
 //	season-<provider>-<seriesId>-<seasonNo>    e.g. season-tvdb-296762-1
 //	episode-<provider>-<seriesId>-<s>-<e>      e.g. episode-tvdb-296762-1-5
-//	local-<hex128>                             unmatched / local fallback
+//	local-<hex112>                             unmatched / local fallback
 //
 // Provider IDs are unique by construction, so the value is collision-free with
 // no hashing. The leading entity-type token domain-separates the namespaces so
@@ -232,12 +232,14 @@ func ForEpisode(seriesContentID string, seasonNumber, episodeNumber int) (string
 // provider — rare, and such items seldom carry watch state.
 //
 // The path is NFC-normalized and trimmed before hashing; the hash is the first
-// 128 bits of SHA-256, hex-encoded (32 chars). Cross-server stability for local
-// items is best-effort only (paths differ between servers).
+// localHashLen bytes (112 bits) of SHA-256, hex-encoded. That width is chosen so
+// the id packs losslessly into a Jellyfin-compat UUID (see Pack); 112 bits is
+// far beyond any single server's local-item count. Cross-server stability for
+// local items is best-effort only (paths differ between servers).
 func ForLocal(path string) string {
 	normalized := norm.NFC.String(strings.TrimSpace(path))
 	sum := sha256.Sum256([]byte(normalized))
-	return kindLocal + sep + hex.EncodeToString(sum[:16])
+	return kindLocal + sep + hex.EncodeToString(sum[:localHashLen])
 }
 
 // SeriesIDFromContentID derives the owning series content_id from an episode or

--- a/internal/contentid/contentid.go
+++ b/internal/contentid/contentid.go
@@ -61,16 +61,20 @@ const (
 	ProviderTVDB = "tvdb"
 )
 
-// MovieProviderPrecedence and SeriesProviderPrecedence freeze, per the scheme
+// movieProviderPrecedence and seriesProviderPrecedence freeze, per the scheme
 // version, which provider anchors a logical item when more than one tag is
 // present. Two servers that both see the tags therefore pick the same anchor.
+// They are unexported and never returned by reference: the precedence is part of
+// SchemeVersion and is mirrored by the hard-coded order in
+// 20260612130000_deterministic_content_id.sql, so a stray runtime mutation would
+// silently mint ids that no longer match the migration.
 //
 //   - Movies prefer TMDB (the richest movie source).
 //   - Series/Season/Episode prefer TVDB (the traditional episode-canonical
 //     source).
 var (
-	MovieProviderPrecedence  = []string{ProviderTMDB, ProviderIMDB, ProviderTVDB}
-	SeriesProviderPrecedence = []string{ProviderTVDB, ProviderTMDB, ProviderIMDB}
+	movieProviderPrecedence  = []string{ProviderTMDB, ProviderIMDB, ProviderTVDB}
+	seriesProviderPrecedence = []string{ProviderTVDB, ProviderTMDB, ProviderIMDB}
 )
 
 // ProviderIDs carries the raw provider identifiers for an item as found on the
@@ -140,7 +144,7 @@ func anchor(ids ProviderIDs, precedence []string) (provider, id string, ok bool)
 // ForMovie returns the deterministic content_id for a movie, or ("", false) if
 // no provider anchor is present (the caller should fall back to ForLocal).
 func ForMovie(ids ProviderIDs) (string, bool) {
-	provider, id, ok := anchor(ids, MovieProviderPrecedence)
+	provider, id, ok := anchor(ids, movieProviderPrecedence)
 	if !ok {
 		return "", false
 	}
@@ -150,7 +154,7 @@ func ForMovie(ids ProviderIDs) (string, bool) {
 // ForSeries returns the deterministic content_id for a series, or ("", false)
 // if no provider anchor is present.
 func ForSeries(ids ProviderIDs) (string, bool) {
-	provider, id, ok := anchor(ids, SeriesProviderPrecedence)
+	provider, id, ok := anchor(ids, seriesProviderPrecedence)
 	if !ok {
 		return "", false
 	}
@@ -233,47 +237,76 @@ func ForLocal(path string) string {
 //	series:tvdb:296762      -> series:tvdb:296762  (unchanged)
 func SeriesIDFromContentID(contentID string) (string, bool) {
 	id := strings.TrimSpace(contentID)
-	switch {
-	case strings.HasPrefix(id, kindMovie+":"), strings.HasPrefix(id, kindSeries+":"):
+	if strings.HasPrefix(id, kindMovie+":") || strings.HasPrefix(id, kindSeries+":") {
+		// A movie is its own display item; a series id is already a series id.
+		// Still require the anchor to be well-formed so a truncated "series:"
+		// cannot pass through unchanged.
+		if !IsProviderAnchored(id) {
+			return "", false
+		}
 		return id, true
-	case strings.HasPrefix(id, kindEpisode+":"), strings.HasPrefix(id, kindSeason+":"):
-		// Drop the kind token, keep "<provider>:<seriesId>" (the first two
-		// remaining components), re-prefix with "series:".
-		rest := id[strings.IndexByte(id, ':')+1:]
-		parts := strings.SplitN(rest, ":", 3)
-		if len(parts) < 2 {
-			return "", false
-		}
-		if _, valid := normalizeProviderID(parts[0], parts[1]); !valid {
-			return "", false
-		}
-		return kindSeries + ":" + parts[0] + ":" + parts[1], true
-	default:
-		// local: ids and legacy Sonyflake ids have no embedded anchor.
-		return "", false
 	}
+	// episode/season carry an embedded "<provider>:<seriesId>" anchor; recover it
+	// by pure string transform. parseAnchored enforces the full per-kind arity, so
+	// a truncated "episode:tvdb:296762" (missing season/episode) fails closed
+	// rather than aliasing onto a series.
+	if provider, seriesID, ok := parseAnchored(id); ok {
+		return kindSeries + ":" + provider + ":" + seriesID, true
+	}
+	// local: ids and legacy Sonyflake ids have no embedded anchor.
+	return "", false
 }
 
-// IsProviderAnchored reports whether the content_id is a provider-derived key
-// (movie/series/season/episode), as opposed to a local: id or a legacy
-// Sonyflake id. Used by migration and diagnostics to tell remappable items
-// apart.
+// IsProviderAnchored reports whether the content_id is a fully-formed
+// provider-derived key (movie/series/season/episode), as opposed to a local: id,
+// a legacy Sonyflake id, or a truncated/malformed anchor. Used by migration and
+// diagnostics to tell remappable items apart.
 func IsProviderAnchored(contentID string) bool {
-	id := strings.TrimSpace(contentID)
-	for _, kind := range []string{kindMovie, kindSeries, kindSeason, kindEpisode} {
-		if strings.HasPrefix(id, kind+":") {
-			rest := id[len(kind)+1:]
-			parts := strings.SplitN(rest, ":", 3)
-			if len(parts) < 2 {
-				return false
-			}
-			if _, valid := normalizeProviderID(parts[0], parts[1]); valid {
-				return true
-			}
-			return false
+	_, _, ok := parseAnchored(strings.TrimSpace(contentID))
+	return ok
+}
+
+// parseAnchored validates a provider-anchored content_id against the exact
+// per-kind arity and component shape, returning the canonical (provider,
+// seriesId-or-id) anchor when it is well-formed:
+//
+//	movie:<p>:<id>                 -> (p, id)
+//	series:<p>:<id>                -> (p, id)
+//	season:<p>:<sid>:<n>           -> (p, sid)   n must be a base-10 integer
+//	episode:<p>:<sid>:<s>:<e>      -> (p, sid)   s,e must be base-10 integers
+//
+// It fails closed for any other shape (wrong part count, non-numeric
+// season/episode, unknown/invalid provider id, local: or legacy ids).
+func parseAnchored(id string) (provider, seriesID string, ok bool) {
+	kind, rest, found := strings.Cut(id, ":")
+	if !found {
+		return "", "", false
+	}
+	parts := strings.Split(rest, ":")
+	var wantParts int
+	switch kind {
+	case kindMovie, kindSeries:
+		wantParts = 2 // <provider>:<id>
+	case kindSeason:
+		wantParts = 3 // <provider>:<seriesId>:<seasonNo>
+	case kindEpisode:
+		wantParts = 4 // <provider>:<seriesId>:<seasonNo>:<episodeNo>
+	default:
+		return "", "", false
+	}
+	if len(parts) != wantParts {
+		return "", "", false
+	}
+	if _, valid := normalizeProviderID(parts[0], parts[1]); !valid {
+		return "", "", false
+	}
+	// The trailing season/episode numbers must be base-10 integers.
+	for _, n := range parts[2:] {
+		if !numericIDPattern.MatchString(n) {
+			return "", "", false
 		}
 	}
-	return false
+	return parts[0], parts[1], true
 }
 
 // IsLocal reports whether the content_id is in the local: fallback namespace.

--- a/internal/contentid/contentid_test.go
+++ b/internal/contentid/contentid_test.go
@@ -9,15 +9,15 @@ func TestForMovie(t *testing.T) {
 		want string
 		ok   bool
 	}{
-		{"tmdb wins", ProviderIDs{Tmdb: "228064", Imdb: "tt2413338", Tvdb: "5"}, "movie:tmdb:228064", true},
-		{"imdb fallback", ProviderIDs{Imdb: "tt2413338"}, "movie:imdb:tt2413338", true},
-		{"tvdb last", ProviderIDs{Tvdb: "12345"}, "movie:tvdb:12345", true},
-		{"imdb uppercase normalized", ProviderIDs{Imdb: "TT2413338"}, "movie:imdb:tt2413338", true},
-		{"whitespace trimmed", ProviderIDs{Tmdb: "  228064 "}, "movie:tmdb:228064", true},
+		{"tmdb wins", ProviderIDs{Tmdb: "228064", Imdb: "tt2413338", Tvdb: "5"}, "movie-tmdb-228064", true},
+		{"imdb fallback", ProviderIDs{Imdb: "tt2413338"}, "movie-imdb-tt2413338", true},
+		{"tvdb last", ProviderIDs{Tvdb: "12345"}, "movie-tvdb-12345", true},
+		{"imdb uppercase normalized", ProviderIDs{Imdb: "TT2413338"}, "movie-imdb-tt2413338", true},
+		{"whitespace trimmed", ProviderIDs{Tmdb: "  228064 "}, "movie-tmdb-228064", true},
 		{"no ids", ProviderIDs{}, "", false},
 		{"invalid imdb only", ProviderIDs{Imdb: "12345"}, "", false},
 		{"invalid tmdb non-numeric", ProviderIDs{Tmdb: "abc"}, "", false},
-		{"invalid tmdb falls through to imdb", ProviderIDs{Tmdb: "abc", Imdb: "tt99"}, "movie:imdb:tt99", true},
+		{"invalid tmdb falls through to imdb", ProviderIDs{Tmdb: "abc", Imdb: "tt99"}, "movie-imdb-tt99", true},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -36,9 +36,9 @@ func TestForSeries(t *testing.T) {
 		want string
 		ok   bool
 	}{
-		{"tvdb wins for series", ProviderIDs{Tmdb: "1", Tvdb: "296762", Imdb: "tt1"}, "series:tvdb:296762", true},
-		{"tmdb fallback", ProviderIDs{Tmdb: "1399"}, "series:tmdb:1399", true},
-		{"imdb last", ProviderIDs{Imdb: "tt0944947"}, "series:imdb:tt0944947", true},
+		{"tvdb wins for series", ProviderIDs{Tmdb: "1", Tvdb: "296762", Imdb: "tt1"}, "series-tvdb-296762", true},
+		{"tmdb fallback", ProviderIDs{Tmdb: "1399"}, "series-tmdb-1399", true},
+		{"imdb last", ProviderIDs{Imdb: "tt0944947"}, "series-imdb-tt0944947", true},
 		{"none", ProviderIDs{}, "", false},
 	}
 	for _, tt := range tests {
@@ -52,24 +52,24 @@ func TestForSeries(t *testing.T) {
 }
 
 func TestForSeasonAndEpisode(t *testing.T) {
-	series := "series:tvdb:296762"
+	series := "series-tvdb-296762"
 
 	gotSeason, ok := ForSeason(series, 1)
-	if !ok || gotSeason != "season:tvdb:296762:1" {
+	if !ok || gotSeason != "season-tvdb-296762-1" {
 		t.Fatalf("ForSeason = (%q,%v)", gotSeason, ok)
 	}
 	gotEp, ok := ForEpisode(series, 1, 5)
-	if !ok || gotEp != "episode:tvdb:296762:1:5" {
+	if !ok || gotEp != "episode-tvdb-296762-1-5" {
 		t.Fatalf("ForEpisode = (%q,%v)", gotEp, ok)
 	}
 
 	// Season 0 (Specials) and zero episode numbers compose fine.
-	if got, ok := ForSeason(series, 0); !ok || got != "season:tvdb:296762:0" {
+	if got, ok := ForSeason(series, 0); !ok || got != "season-tvdb-296762-0" {
 		t.Fatalf("ForSeason specials = (%q,%v)", got, ok)
 	}
 
 	// Non-anchored parents fall back (ok=false).
-	for _, parent := range []string{"local:deadbeef", "1234567890", "series:", "series:bogus:xyz", ""} {
+	for _, parent := range []string{"local-deadbeef", "1234567890", "series-", "series-bogus-xyz", ""} {
 		if got, ok := ForSeason(parent, 1); ok {
 			t.Fatalf("ForSeason(%q) unexpectedly ok with %q", parent, got)
 		}
@@ -88,7 +88,7 @@ func TestForLocal(t *testing.T) {
 	if !IsLocal(a) {
 		t.Fatalf("ForLocal output %q not recognized as local", a)
 	}
-	if len(a) != len("local:")+32 {
+	if len(a) != len("local-")+32 {
 		t.Fatalf("ForLocal width unexpected: %q (len %d)", a, len(a))
 	}
 	// Whitespace differences normalize to the same id.
@@ -107,23 +107,23 @@ func TestSeriesIDFromContentID(t *testing.T) {
 		want string
 		ok   bool
 	}{
-		{"episode:tvdb:296762:1:5", "series:tvdb:296762", true},
-		{"season:tvdb:296762:1", "series:tvdb:296762", true},
-		{"episode:imdb:tt0944947:2:10", "series:imdb:tt0944947", true},
-		{"movie:tmdb:228064", "movie:tmdb:228064", true}, // unchanged
-		{"series:tvdb:296762", "series:tvdb:296762", true},
-		{"local:deadbeefdeadbeefdeadbeefdeadbeef", "", false},
+		{"episode-tvdb-296762-1-5", "series-tvdb-296762", true},
+		{"season-tvdb-296762-1", "series-tvdb-296762", true},
+		{"episode-imdb-tt0944947-2-10", "series-imdb-tt0944947", true},
+		{"movie-tmdb-228064", "movie-tmdb-228064", true}, // unchanged
+		{"series-tvdb-296762", "series-tvdb-296762", true},
+		{"local-deadbeefdeadbeefdeadbeefdeadbeef", "", false},
 		{"1234567890123456", "", false}, // legacy sonyflake
-		{"episode:bogus:xx:1:1", "", false},
-		{"episode:tvdb", "", false},
+		{"episode-bogus-xx-1-1", "", false},
+		{"episode-tvdb", "", false},
 		// Truncated/malformed anchors must fail closed, not masquerade as a
 		// valid series anchor (regression: these previously slipped through).
-		{"episode:tvdb:296762", "", false},     // missing season/episode
-		{"episode:tvdb:296762:1", "", false},   // missing episode
-		{"season:tvdb:296762", "", false},      // missing season number
-		{"episode:tvdb:296762:1:x", "", false}, // non-numeric episode
-		{"season:tvdb:296762:x", "", false},    // non-numeric season
-		{"series:tvdb:296762:1", "", false},    // over-long series anchor
+		{"episode-tvdb-296762", "", false},     // missing season/episode
+		{"episode-tvdb-296762-1", "", false},   // missing episode
+		{"season-tvdb-296762", "", false},      // missing season number
+		{"episode-tvdb-296762-1-x", "", false}, // non-numeric episode
+		{"season-tvdb-296762-x", "", false},    // non-numeric season
+		{"series-tvdb-296762-1", "", false},    // over-long series anchor
 	}
 	for _, tt := range tests {
 		got, ok := SeriesIDFromContentID(tt.in)
@@ -138,7 +138,7 @@ func TestSeriesIDFromContentID(t *testing.T) {
 // the children were composed from. This is what lets the watch-history query
 // drop the episodes join.
 func TestSeriesTransformMatchesComposition(t *testing.T) {
-	for _, series := range []string{"series:tvdb:296762", "series:tmdb:1399", "series:imdb:tt0944947"} {
+	for _, series := range []string{"series-tvdb-296762", "series-tmdb-1399", "series-imdb-tt0944947"} {
 		ep, ok := ForEpisode(series, 3, 7)
 		if !ok {
 			t.Fatalf("ForEpisode(%q) not ok", series)
@@ -159,17 +159,17 @@ func TestSeriesTransformMatchesComposition(t *testing.T) {
 }
 
 func TestIsProviderAnchored(t *testing.T) {
-	anchored := []string{"movie:tmdb:1", "series:tvdb:2", "season:tvdb:2:1", "episode:imdb:tt3:1:1"}
+	anchored := []string{"movie-tmdb-1", "series-tvdb-2", "season-tvdb-2-1", "episode-imdb-tt3-1-1"}
 	for _, id := range anchored {
 		if !IsProviderAnchored(id) {
 			t.Fatalf("IsProviderAnchored(%q) = false, want true", id)
 		}
 	}
 	notAnchored := []string{
-		"local:abc", "1234567890", "movie:bogus:x", "movie:tmdb:", "", "movie:",
+		"local-abc", "1234567890", "movie-bogus-x", "movie-tmdb-", "", "movie-",
 		// Truncated season/episode and non-numeric suffixes must fail closed.
-		"season:tvdb:2", "episode:tvdb:2", "episode:tvdb:2:1", "episode:imdb:tt3:1:x",
-		"season:tvdb:2:x", "series:tvdb:2:1",
+		"season-tvdb-2", "episode-tvdb-2", "episode-tvdb-2-1", "episode-imdb-tt3-1-x",
+		"season-tvdb-2-x", "series-tvdb-2-1",
 	}
 	for _, id := range notAnchored {
 		if IsProviderAnchored(id) {

--- a/internal/contentid/contentid_test.go
+++ b/internal/contentid/contentid_test.go
@@ -88,7 +88,7 @@ func TestForLocal(t *testing.T) {
 	if !IsLocal(a) {
 		t.Fatalf("ForLocal output %q not recognized as local", a)
 	}
-	if len(a) != len("local-")+32 {
+	if len(a) != len("local-")+2*localHashLen {
 		t.Fatalf("ForLocal width unexpected: %q (len %d)", a, len(a))
 	}
 	// Whitespace differences normalize to the same id.

--- a/internal/contentid/contentid_test.go
+++ b/internal/contentid/contentid_test.go
@@ -1,0 +1,166 @@
+package contentid
+
+import "testing"
+
+func TestForMovie(t *testing.T) {
+	tests := []struct {
+		name string
+		ids  ProviderIDs
+		want string
+		ok   bool
+	}{
+		{"tmdb wins", ProviderIDs{Tmdb: "228064", Imdb: "tt2413338", Tvdb: "5"}, "movie:tmdb:228064", true},
+		{"imdb fallback", ProviderIDs{Imdb: "tt2413338"}, "movie:imdb:tt2413338", true},
+		{"tvdb last", ProviderIDs{Tvdb: "12345"}, "movie:tvdb:12345", true},
+		{"imdb uppercase normalized", ProviderIDs{Imdb: "TT2413338"}, "movie:imdb:tt2413338", true},
+		{"whitespace trimmed", ProviderIDs{Tmdb: "  228064 "}, "movie:tmdb:228064", true},
+		{"no ids", ProviderIDs{}, "", false},
+		{"invalid imdb only", ProviderIDs{Imdb: "12345"}, "", false},
+		{"invalid tmdb non-numeric", ProviderIDs{Tmdb: "abc"}, "", false},
+		{"invalid tmdb falls through to imdb", ProviderIDs{Tmdb: "abc", Imdb: "tt99"}, "movie:imdb:tt99", true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, ok := ForMovie(tt.ids)
+			if got != tt.want || ok != tt.ok {
+				t.Fatalf("ForMovie(%+v) = (%q,%v), want (%q,%v)", tt.ids, got, ok, tt.want, tt.ok)
+			}
+		})
+	}
+}
+
+func TestForSeries(t *testing.T) {
+	tests := []struct {
+		name string
+		ids  ProviderIDs
+		want string
+		ok   bool
+	}{
+		{"tvdb wins for series", ProviderIDs{Tmdb: "1", Tvdb: "296762", Imdb: "tt1"}, "series:tvdb:296762", true},
+		{"tmdb fallback", ProviderIDs{Tmdb: "1399"}, "series:tmdb:1399", true},
+		{"imdb last", ProviderIDs{Imdb: "tt0944947"}, "series:imdb:tt0944947", true},
+		{"none", ProviderIDs{}, "", false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, ok := ForSeries(tt.ids)
+			if got != tt.want || ok != tt.ok {
+				t.Fatalf("ForSeries(%+v) = (%q,%v), want (%q,%v)", tt.ids, got, ok, tt.want, tt.ok)
+			}
+		})
+	}
+}
+
+func TestForSeasonAndEpisode(t *testing.T) {
+	series := "series:tvdb:296762"
+
+	gotSeason, ok := ForSeason(series, 1)
+	if !ok || gotSeason != "season:tvdb:296762:1" {
+		t.Fatalf("ForSeason = (%q,%v)", gotSeason, ok)
+	}
+	gotEp, ok := ForEpisode(series, 1, 5)
+	if !ok || gotEp != "episode:tvdb:296762:1:5" {
+		t.Fatalf("ForEpisode = (%q,%v)", gotEp, ok)
+	}
+
+	// Season 0 (Specials) and zero episode numbers compose fine.
+	if got, ok := ForSeason(series, 0); !ok || got != "season:tvdb:296762:0" {
+		t.Fatalf("ForSeason specials = (%q,%v)", got, ok)
+	}
+
+	// Non-anchored parents fall back (ok=false).
+	for _, parent := range []string{"local:deadbeef", "1234567890", "series:", "series:bogus:xyz", ""} {
+		if got, ok := ForSeason(parent, 1); ok {
+			t.Fatalf("ForSeason(%q) unexpectedly ok with %q", parent, got)
+		}
+		if got, ok := ForEpisode(parent, 1, 1); ok {
+			t.Fatalf("ForEpisode(%q) unexpectedly ok with %q", parent, got)
+		}
+	}
+}
+
+func TestForLocal(t *testing.T) {
+	a := ForLocal("/media/movies/Home Video.mkv")
+	b := ForLocal("/media/movies/Home Video.mkv")
+	if a != b {
+		t.Fatalf("ForLocal not deterministic: %q vs %q", a, b)
+	}
+	if !IsLocal(a) {
+		t.Fatalf("ForLocal output %q not recognized as local", a)
+	}
+	if len(a) != len("local:")+32 {
+		t.Fatalf("ForLocal width unexpected: %q (len %d)", a, len(a))
+	}
+	// Whitespace differences normalize to the same id.
+	if ForLocal("  /x ") != ForLocal("/x") {
+		t.Fatalf("ForLocal whitespace not normalized")
+	}
+	// Distinct paths produce distinct ids.
+	if ForLocal("/a") == ForLocal("/b") {
+		t.Fatalf("ForLocal collision on distinct paths")
+	}
+}
+
+func TestSeriesIDFromContentID(t *testing.T) {
+	tests := []struct {
+		in   string
+		want string
+		ok   bool
+	}{
+		{"episode:tvdb:296762:1:5", "series:tvdb:296762", true},
+		{"season:tvdb:296762:1", "series:tvdb:296762", true},
+		{"episode:imdb:tt0944947:2:10", "series:imdb:tt0944947", true},
+		{"movie:tmdb:228064", "movie:tmdb:228064", true}, // unchanged
+		{"series:tvdb:296762", "series:tvdb:296762", true},
+		{"local:deadbeefdeadbeefdeadbeefdeadbeef", "", false},
+		{"1234567890123456", "", false}, // legacy sonyflake
+		{"episode:bogus:xx:1:1", "", false},
+		{"episode:tvdb", "", false},
+	}
+	for _, tt := range tests {
+		got, ok := SeriesIDFromContentID(tt.in)
+		if got != tt.want || ok != tt.ok {
+			t.Fatalf("SeriesIDFromContentID(%q) = (%q,%v), want (%q,%v)", tt.in, got, ok, tt.want, tt.ok)
+		}
+	}
+}
+
+// TestSeriesTransformMatchesComposition is the load-bearing invariant: the
+// series id derived from a composed episode/season id must equal the series id
+// the children were composed from. This is what lets the watch-history query
+// drop the episodes join.
+func TestSeriesTransformMatchesComposition(t *testing.T) {
+	for _, series := range []string{"series:tvdb:296762", "series:tmdb:1399", "series:imdb:tt0944947"} {
+		ep, ok := ForEpisode(series, 3, 7)
+		if !ok {
+			t.Fatalf("ForEpisode(%q) not ok", series)
+		}
+		back, ok := SeriesIDFromContentID(ep)
+		if !ok || back != series {
+			t.Fatalf("round trip failed: %q -> %q -> (%q,%v)", series, ep, back, ok)
+		}
+		se, ok := ForSeason(series, 3)
+		if !ok {
+			t.Fatalf("ForSeason(%q) not ok", series)
+		}
+		back, ok = SeriesIDFromContentID(se)
+		if !ok || back != series {
+			t.Fatalf("season round trip failed: %q -> %q -> (%q,%v)", series, se, back, ok)
+		}
+	}
+}
+
+func TestIsProviderAnchored(t *testing.T) {
+	anchored := []string{"movie:tmdb:1", "series:tvdb:2", "season:tvdb:2:1", "episode:imdb:tt3:1:1"}
+	for _, id := range anchored {
+		if !IsProviderAnchored(id) {
+			t.Fatalf("IsProviderAnchored(%q) = false, want true", id)
+		}
+	}
+	notAnchored := []string{"local:abc", "1234567890", "movie:bogus:x", "movie:tmdb:", "", "movie:"}
+	for _, id := range notAnchored {
+		if IsProviderAnchored(id) {
+			t.Fatalf("IsProviderAnchored(%q) = true, want false", id)
+		}
+	}
+}

--- a/internal/contentid/contentid_test.go
+++ b/internal/contentid/contentid_test.go
@@ -116,6 +116,14 @@ func TestSeriesIDFromContentID(t *testing.T) {
 		{"1234567890123456", "", false}, // legacy sonyflake
 		{"episode:bogus:xx:1:1", "", false},
 		{"episode:tvdb", "", false},
+		// Truncated/malformed anchors must fail closed, not masquerade as a
+		// valid series anchor (regression: these previously slipped through).
+		{"episode:tvdb:296762", "", false},     // missing season/episode
+		{"episode:tvdb:296762:1", "", false},   // missing episode
+		{"season:tvdb:296762", "", false},      // missing season number
+		{"episode:tvdb:296762:1:x", "", false}, // non-numeric episode
+		{"season:tvdb:296762:x", "", false},    // non-numeric season
+		{"series:tvdb:296762:1", "", false},    // over-long series anchor
 	}
 	for _, tt := range tests {
 		got, ok := SeriesIDFromContentID(tt.in)
@@ -157,7 +165,12 @@ func TestIsProviderAnchored(t *testing.T) {
 			t.Fatalf("IsProviderAnchored(%q) = false, want true", id)
 		}
 	}
-	notAnchored := []string{"local:abc", "1234567890", "movie:bogus:x", "movie:tmdb:", "", "movie:"}
+	notAnchored := []string{
+		"local:abc", "1234567890", "movie:bogus:x", "movie:tmdb:", "", "movie:",
+		// Truncated season/episode and non-numeric suffixes must fail closed.
+		"season:tvdb:2", "episode:tvdb:2", "episode:tvdb:2:1", "episode:imdb:tt3:1:x",
+		"season:tvdb:2:x", "series:tvdb:2:1",
+	}
 	for _, id := range notAnchored {
 		if IsProviderAnchored(id) {
 			t.Fatalf("IsProviderAnchored(%q) = true, want false", id)

--- a/internal/database/migrate.go
+++ b/internal/database/migrate.go
@@ -5,6 +5,9 @@ import (
 	"database/sql"
 	"fmt"
 	"io/fs"
+	"log/slog"
+	"os"
+	"strings"
 	"time"
 
 	"github.com/jackc/pgx/v5/pgxpool"
@@ -16,7 +19,44 @@ import (
 const (
 	schemaMigrationsLockID int64 = 8_034_219_741
 	gooseVersionTable            = "public.goose_db_version"
+
+	// migrationTimeoutEnv configures how long a migration run may take.
+	migrationTimeoutEnv     = "SILO_MIGRATE_TIMEOUT"
+	defaultMigrationTimeout = 5 * time.Minute
 )
+
+// MigrationTimeout returns the deadline budget for a migration run. It is
+// configurable via SILO_MIGRATE_TIMEOUT (a Go duration such as "60m"). A value
+// of 0 or negative disables the deadline entirely — appropriate for a one-off
+// heavy data migration (e.g. a full-table COLLATE rewrite + value remap) that
+// legitimately runs longer than any fixed cap and must not be abandoned
+// mid-flight, since an abandoned run leaves an orphaned backend holding
+// AccessExclusive locks while the next boot retries. Unset or unparseable falls
+// back to defaultMigrationTimeout, preserving prior behavior.
+func MigrationTimeout() time.Duration {
+	raw := strings.TrimSpace(os.Getenv(migrationTimeoutEnv))
+	if raw == "" {
+		return defaultMigrationTimeout
+	}
+	d, err := time.ParseDuration(raw)
+	if err != nil {
+		slog.Warn("invalid migration timeout; using default",
+			"env", migrationTimeoutEnv, "value", raw,
+			"default", defaultMigrationTimeout.String(), "error", err)
+		return defaultMigrationTimeout
+	}
+	return d
+}
+
+// MigrationContext derives the context for a migration run, honoring
+// MigrationTimeout. A non-positive timeout yields a cancelable context with no
+// deadline. The caller must always invoke the returned CancelFunc.
+func MigrationContext(ctx context.Context) (context.Context, context.CancelFunc) {
+	if d := MigrationTimeout(); d > 0 {
+		return context.WithTimeout(ctx, d)
+	}
+	return context.WithCancel(ctx)
+}
 
 // RunMigrations applies all pending Goose migrations from fsys/dir.
 func RunMigrations(ctx context.Context, pool *pgxpool.Pool, fsys fs.FS, dir string) error {

--- a/internal/database/migrate_timeout_test.go
+++ b/internal/database/migrate_timeout_test.go
@@ -1,0 +1,57 @@
+package database
+
+import (
+	"context"
+	"testing"
+	"time"
+)
+
+func TestMigrationTimeout(t *testing.T) {
+	tests := []struct {
+		name string
+		env  string
+		set  bool
+		want time.Duration
+	}{
+		{"unset defaults to 5m", "", false, 5 * time.Minute},
+		{"empty defaults to 5m", "", true, 5 * time.Minute},
+		{"explicit 60m", "60m", true, 60 * time.Minute},
+		{"seconds", "90s", true, 90 * time.Second},
+		{"zero disables", "0", true, 0},
+		{"whitespace trimmed", "  30m  ", true, 30 * time.Minute},
+		{"invalid falls back to 5m", "not-a-duration", true, 5 * time.Minute},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if tt.set {
+				t.Setenv("SILO_MIGRATE_TIMEOUT", tt.env)
+			} else {
+				// Ensure no ambient value leaks in.
+				t.Setenv("SILO_MIGRATE_TIMEOUT", "")
+			}
+			if got := MigrationTimeout(); got != tt.want {
+				t.Fatalf("MigrationTimeout() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestMigrationContextDeadline(t *testing.T) {
+	// A positive timeout yields a context with a deadline.
+	t.Setenv("SILO_MIGRATE_TIMEOUT", "50ms")
+	ctx, cancel := MigrationContext(context.Background())
+	defer cancel()
+	if _, ok := ctx.Deadline(); !ok {
+		t.Fatal("expected a deadline with a positive timeout")
+	}
+}
+
+func TestMigrationContextNoDeadline(t *testing.T) {
+	// Zero disables the deadline entirely (for one-off heavy migrations).
+	t.Setenv("SILO_MIGRATE_TIMEOUT", "0")
+	ctx, cancel := MigrationContext(context.Background())
+	defer cancel()
+	if deadline, ok := ctx.Deadline(); ok {
+		t.Fatalf("expected no deadline with timeout 0, got %v", deadline)
+	}
+}

--- a/internal/jellycompat/idcodec.go
+++ b/internal/jellycompat/idcodec.go
@@ -7,6 +7,8 @@ import (
 	"sync"
 
 	"github.com/google/uuid"
+
+	"github.com/Silo-Server/silo-server/internal/contentid"
 )
 
 // EncodedIDType distinguishes packed compat UUIDs.
@@ -79,9 +81,22 @@ func EncodeNumericID(kind EncodedIDType, value uint64) uuid.UUID {
 }
 
 // EncodeStringID encodes a Silo identifier into a Jellyfin UUID string.
+//
+// Content-id kinds (item, season) whose value is a structured or local
+// content_id are packed into the UUID reversibly (see contentid.Pack), so they
+// decode with no lookup table and survive a server restart. Numeric ids keep
+// their stateless numeric packing. Everything else — arbitrary names such as
+// genres and studios, and the rare content_id too large to pack — falls back to
+// a hashed UUID recorded in the reverse map.
 func (c *ResourceIDCodec) EncodeStringID(kind EncodedIDType, value string) string {
 	if numeric, err := strconv.ParseUint(value, 10, 64); err == nil {
 		return EncodeNumericID(kind, numeric).String()
+	}
+
+	if isContentIDKind(kind) {
+		if packed, ok := packContentIDUUID(kind, value); ok {
+			return packed.String()
+		}
 	}
 
 	namespace, ok := stringIDNamespaces[kind]
@@ -103,7 +118,18 @@ func (c *ResourceIDCodec) EncodeIntID(kind EncodedIDType, value int64) string {
 }
 
 // DecodeStringID decodes a compat UUID back to the original native string ID.
+//
+// A reversibly packed content_id is decoded first (and re-packed to confirm the
+// UUID genuinely came from the packer, so an opaque id whose bytes merely happen
+// to parse is rejected), then the stateless numeric encoding, then the reverse
+// map for hashed ids.
 func (c *ResourceIDCodec) DecodeStringID(kind EncodedIDType, raw string) (string, error) {
+	if isContentIDKind(kind) {
+		if id, ok := unpackContentIDUUID(kind, raw); ok {
+			return id, nil
+		}
+	}
+
 	if decoded, err := DecodeID(raw); err == nil && decoded.Type == kind {
 		return strconv.FormatUint(decoded.Value, 10), nil
 	}
@@ -115,6 +141,48 @@ func (c *ResourceIDCodec) DecodeStringID(kind EncodedIDType, raw string) (string
 		return "", fmt.Errorf("unknown compat id %q", raw)
 	}
 	return registered.value, nil
+}
+
+// isContentIDKind reports whether a compat id kind carries a Silo content_id (as
+// opposed to an arbitrary name like a genre or studio). Only these kinds use the
+// reversible content_id packing; everything else keeps the opaque hash + map.
+func isContentIDKind(kind EncodedIDType) bool {
+	return kind == EncodedIDItem || kind == EncodedIDSeason
+}
+
+// packContentIDUUID packs a structured or local content_id into a compat UUID:
+// byte 0 is the kind and bytes 1..15 hold contentid.Pack output, zero-padded.
+// The pack format tag at byte 1 is always non-zero, which distinguishes a packed
+// UUID from the numeric encoding (whose byte 1 is zero). ok=false when the id
+// does not pack within the 15-byte payload.
+func packContentIDUUID(kind EncodedIDType, contentID string) (uuid.UUID, bool) {
+	payload, ok := contentid.Pack(contentID)
+	if !ok || len(payload) > 15 {
+		return uuid.UUID{}, false
+	}
+	var u uuid.UUID
+	u[0] = byte(kind)
+	copy(u[1:], payload)
+	return u, true
+}
+
+// unpackContentIDUUID reverses packContentIDUUID. It re-packs the decoded id and
+// compares, so a UUID that was not produced by the packer (e.g. an opaque SHA1
+// id whose bytes happen to parse) is rejected and the caller falls through to
+// the reverse map.
+func unpackContentIDUUID(kind EncodedIDType, raw string) (string, bool) {
+	u, err := uuid.Parse(raw)
+	if err != nil || u[0] != byte(kind) || u[1] == 0 {
+		return "", false
+	}
+	id, ok := contentid.Unpack(u[1:])
+	if !ok {
+		return "", false
+	}
+	if check, ok := packContentIDUUID(kind, id); !ok || check != u {
+		return "", false
+	}
+	return id, true
 }
 
 // DecodeIntID decodes a compat UUID back to a native integer ID.

--- a/internal/jellycompat/idcodec_test.go
+++ b/internal/jellycompat/idcodec_test.go
@@ -1,0 +1,63 @@
+package jellycompat
+
+import (
+	"testing"
+
+	"github.com/Silo-Server/silo-server/internal/contentid"
+)
+
+// TestContentIDDecodesWithoutSharedState is the core of the restart-safety fix:
+// encoding and decoding run on DIFFERENT codec instances, modeling a server
+// restart where the decoder's in-memory reverse map is empty. A structured
+// content_id must still decode, because it is packed into the UUID reversibly
+// rather than hashed into a side table.
+func TestContentIDDecodesWithoutSharedState(t *testing.T) {
+	cases := []struct {
+		kind EncodedIDType
+		id   string
+	}{
+		{EncodedIDItem, "movie-tmdb-228064"},
+		{EncodedIDItem, "movie-imdb-tt2413338"},
+		{EncodedIDItem, "series-tvdb-296762"},
+		{EncodedIDItem, "episode-tvdb-296762-1-5"},
+		{EncodedIDItem, contentid.ForLocal("/media/movies/Home Video.mkv")},
+		{EncodedIDSeason, "season-tvdb-296762-1"},
+	}
+	for _, tc := range cases {
+		enc := NewResourceIDCodec()
+		dec := NewResourceIDCodec() // fresh instance: cold reverse map
+		u := enc.EncodeStringID(tc.kind, tc.id)
+		got, err := dec.DecodeStringID(tc.kind, u)
+		if err != nil {
+			t.Fatalf("DecodeStringID(%d, %q) on fresh codec: %v (id %q)", tc.kind, u, err, tc.id)
+		}
+		if got != tc.id {
+			t.Fatalf("round trip across instances: %q -> %q -> %q", tc.id, u, got)
+		}
+	}
+}
+
+// TestLegacyNumericContentIDRoundTrips guards the unchanged path: non-anchored
+// items (audiobooks, collisions, unmatched) keep their numeric Sonyflake
+// content_id, which was already encoded statelessly and must stay that way.
+func TestLegacyNumericContentIDRoundTrips(t *testing.T) {
+	const legacy = "1234567890123456"
+	u := NewResourceIDCodec().EncodeStringID(EncodedIDItem, legacy)
+	got, err := NewResourceIDCodec().DecodeStringID(EncodedIDItem, u)
+	if err != nil || got != legacy {
+		t.Fatalf("legacy numeric round trip = (%q, %v), want (%q, nil)", got, err, legacy)
+	}
+}
+
+// TestGenreNameStillUsesReverseMap guards that arbitrary string ids (genre
+// names, etc.) are untouched by the content_id packing and still round-trip
+// within a single codec instance via the reverse map.
+func TestGenreNameStillUsesReverseMap(t *testing.T) {
+	c := NewResourceIDCodec()
+	const genre = "Science Fiction"
+	u := c.EncodeStringID(EncodedIDGenre, genre)
+	got, err := c.DecodeStringID(EncodedIDGenre, u)
+	if err != nil || got != genre {
+		t.Fatalf("genre round trip = (%q, %v), want (%q, nil)", got, err, genre)
+	}
+}

--- a/internal/metadata/canonicalize.go
+++ b/internal/metadata/canonicalize.go
@@ -2,8 +2,10 @@ package metadata
 
 import (
 	"context"
+	"errors"
 	"fmt"
 
+	"github.com/Silo-Server/silo-server/internal/catalog"
 	"github.com/Silo-Server/silo-server/internal/contentid"
 )
 
@@ -17,7 +19,7 @@ func providerIDsStruct(m map[string]string) contentid.ProviderIDs {
 	}
 }
 
-// canonicalizeLocalContentID promotes a local: skeleton to its deterministic,
+// canonicalizeLocalContentID promotes a local skeleton to its deterministic,
 // provider-anchored content_id once a confirmed match has supplied provider IDs
 // (the untagged-then-matched re-ID). It returns the canonical id, which equals
 // from when there is nothing to do.
@@ -38,7 +40,7 @@ func providerIDsStruct(m map[string]string) contentid.ProviderIDs {
 // merge branch on the next pass.
 //
 // Note: a series that already had season/episode rows before it matched keeps
-// those children on their Sonyflake ids (ForSeason/ForEpisode need a series:
+// those children on their Sonyflake ids (ForSeason/ForEpisode need a series
 // anchor). At first match the children usually do not exist yet, so this is
 // rare; re-deriving them is a deferred follow-up (recomposeSeriesChildIDs).
 func (s *MetadataService) canonicalizeLocalContentID(
@@ -52,7 +54,7 @@ func (s *MetadataService) canonicalizeLocalContentID(
 	}
 
 	// Derive with no path fallback: we only want a provider-anchored id here, not
-	// another local: value.
+	// another local value.
 	target, err := deriveLogicalContentID(itemType, ids, "")
 	if err != nil {
 		return "", err
@@ -61,12 +63,24 @@ func (s *MetadataService) canonicalizeLocalContentID(
 		return from, nil
 	}
 
-	// A row already at the target id is the same logical item; merge onto it.
-	if existing, err := s.itemRepo.GetByID(ctx, target); err == nil && existing != nil {
-		if err := s.rebindItemToExistingItem(ctx, from, target, false); err != nil {
+	// Look up the target, distinguishing "free" (not-found) from a transient
+	// failure. Treating a real error as "target free" would fall through to the
+	// rename path and surface as a misleading unique-constraint conflict instead
+	// of a retryable error.
+	existing, err := s.itemRepo.GetByID(ctx, target)
+	switch {
+	case err == nil && existing != nil:
+		// A row already at the target id is the same logical item; merge onto it.
+		// allowMatchedSource: this also runs when refreshing an already-matched
+		// local item, so the source row may be 'matched'; we still consolidate it
+		// onto the canonical target rather than orphaning a duplicate. Safe under
+		// the provider-dedup lock the caller holds.
+		if err := s.rebindItemToExistingItem(ctx, from, target, true); err != nil {
 			return "", fmt.Errorf("merging local item %s into %s: %w", from, target, err)
 		}
 		return target, nil
+	case err != nil && !errors.Is(err, catalog.ErrItemNotFound):
+		return "", fmt.Errorf("looking up canonical target %s: %w", target, err)
 	}
 
 	// Target free: pure value-move.

--- a/internal/metadata/canonicalize.go
+++ b/internal/metadata/canonicalize.go
@@ -1,0 +1,92 @@
+package metadata
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/Silo-Server/silo-server/internal/contentid"
+)
+
+// providerIDsStruct adapts the denormalized provider-id map carried on a
+// MetadataResult to the contentid.ProviderIDs shape used for id derivation.
+func providerIDsStruct(m map[string]string) contentid.ProviderIDs {
+	return contentid.ProviderIDs{
+		Tmdb: m["tmdb"],
+		Imdb: m["imdb"],
+		Tvdb: m["tvdb"],
+	}
+}
+
+// canonicalizeLocalContentID promotes a local: skeleton to its deterministic,
+// provider-anchored content_id once a confirmed match has supplied provider IDs
+// (the untagged-then-matched re-ID). It returns the canonical id, which equals
+// from when there is nothing to do.
+//
+// Tagged content and every refresh hit only the IsLocal guard, so the common
+// path is free. When there is work to do, the promotion is one of:
+//
+//   - target already taken: the two are the same logical item, so merge this
+//     skeleton onto the existing row using the shared rebind machinery; or
+//   - target free: rename in place. FK children move via ON UPDATE CASCADE (see
+//     migration 20260614120000_content_id_online_reid), so for a fresh skeleton
+//     this is a handful of rows, not the full-table remap the bulk migration does.
+//
+// It must run with the provider-dedup lock held (mergeAndPersist holds it), so a
+// concurrent match of the same title cannot claim the target underneath us. The
+// rename is self-healing: if it loses a rare race with skeleton creation and the
+// unique constraint fires, the match returns an error, retries, and takes the
+// merge branch on the next pass.
+//
+// Note: a series that already had season/episode rows before it matched keeps
+// those children on their Sonyflake ids (ForSeason/ForEpisode need a series:
+// anchor). At first match the children usually do not exist yet, so this is
+// rare; re-deriving them is a deferred follow-up (recomposeSeriesChildIDs).
+func (s *MetadataService) canonicalizeLocalContentID(
+	ctx context.Context,
+	from string,
+	ids contentid.ProviderIDs,
+	itemType string,
+) (string, error) {
+	if s == nil || !contentid.IsLocal(from) {
+		return from, nil
+	}
+
+	// Derive with no path fallback: we only want a provider-anchored id here, not
+	// another local: value.
+	target, err := deriveLogicalContentID(itemType, ids, "")
+	if err != nil {
+		return "", err
+	}
+	if !contentid.IsProviderAnchored(target) || target == from {
+		return from, nil
+	}
+
+	// A row already at the target id is the same logical item; merge onto it.
+	if existing, err := s.itemRepo.GetByID(ctx, target); err == nil && existing != nil {
+		if err := s.rebindItemToExistingItem(ctx, from, target, false); err != nil {
+			return "", fmt.Errorf("merging local item %s into %s: %w", from, target, err)
+		}
+		return target, nil
+	}
+
+	// Target free: pure value-move.
+	if err := s.renameContentID(ctx, from, target); err != nil {
+		return "", err
+	}
+	return target, nil
+}
+
+// renameContentID moves a single content_id value (a media item, season or
+// episode) to a new, currently-free id. FK children follow via ON UPDATE
+// CASCADE; the silo_rename_content_id function also sweeps the unconstrained
+// soft references. The function body runs as one statement, so the move is
+// atomic.
+func (s *MetadataService) renameContentID(ctx context.Context, from, to string) error {
+	if s.dbPool == nil {
+		return fmt.Errorf("rename content id requires database pool")
+	}
+	if _, err := s.dbPool.Exec(ctx, `SELECT silo_rename_content_id($1, $2)`, from, to); err != nil {
+		return fmt.Errorf("rename content_id %s -> %s: %w", from, to, err)
+	}
+	return nil
+}

--- a/internal/metadata/service.go
+++ b/internal/metadata/service.go
@@ -1417,6 +1417,33 @@ func (s *MetadataService) mergeAndPersist(
 			}
 		}
 	}
+
+	// Promote a local: skeleton to its deterministic provider-anchored id now
+	// that the match supplied provider IDs (the untagged-then-matched re-ID).
+	// Runs under the provider-dedup lock acquired above, so the target id cannot
+	// be claimed underneath us; movies and first-match series move a handful of
+	// rows. Placed before the durableIDs merge below so the canonical row's
+	// provider IDs are folded into the accumulator. See canonicalizeLocalContentID.
+	if !isNew && contentid.IsLocal(contentID) {
+		canonical, err := s.canonicalizeLocalContentID(
+			ctx, contentID, providerIDsStruct(accumulator.ProviderIDs), contentType)
+		if err != nil {
+			return nil, fmt.Errorf("canonicalize local content id: %w", err)
+		}
+		if canonical != contentID {
+			contentID = canonical
+			existingItem, err = s.itemRepo.GetByID(ctx, contentID)
+			if err != nil {
+				return nil, fmt.Errorf("loading canonicalized item: %w", err)
+			}
+			locked = intSliceToFields(existingItem.LockedFields)
+			durableIDs, err = s.loadDurableProviderIDs(ctx, contentID)
+			if err != nil {
+				return nil, err
+			}
+		}
+	}
+
 	if len(durableIDs) > 0 {
 		if accumulator.ProviderIDs == nil {
 			accumulator.ProviderIDs = make(map[string]string, len(durableIDs))

--- a/internal/metadata/service.go
+++ b/internal/metadata/service.go
@@ -15,6 +15,7 @@ import (
 	"time"
 
 	"github.com/Silo-Server/silo-server/internal/catalog"
+	"github.com/Silo-Server/silo-server/internal/contentid"
 	"github.com/Silo-Server/silo-server/internal/idgen"
 	"github.com/Silo-Server/silo-server/internal/lang"
 	"github.com/Silo-Server/silo-server/internal/models"
@@ -1491,8 +1492,15 @@ func (s *MetadataService) mergeAndPersist(
 	}
 
 	if isNew && contentID == "" {
+		// A confirmed provider match carries provider IDs, so this derives a
+		// deterministic movie:/series: id; it only falls back when the match
+		// somehow lacks all anchors.
 		var genErr error
-		contentID, genErr = generateContentID()
+		contentID, genErr = deriveLogicalContentID(
+			item.Type,
+			contentid.ProviderIDs{Tmdb: item.TmdbID, Imdb: item.ImdbID, Tvdb: item.TvdbID},
+			"",
+		)
 		if genErr != nil {
 			return nil, fmt.Errorf("generate content id: %w", genErr)
 		}
@@ -2944,7 +2952,7 @@ func (s *MetadataService) persistSeasonsAndEpisodes(
 					dbSeason.DefaultMetadataLanguage = existingSeason.DefaultMetadataLanguage
 				}
 			} else {
-				sid, genErr := idgen.NextID()
+				sid, genErr := deriveSeasonContentID(seriesID, providerSeason.SeasonNumber)
 				if genErr != nil {
 					slog.Warn("metadata: failed to generate season id",
 						"series_id", seriesID, "season", season.SeasonNumber, "error", genErr)
@@ -3029,7 +3037,7 @@ func (s *MetadataService) persistSeasonsAndEpisodes(
 					seasonModel.PosterThumbhash = existingSeason.PosterThumbhash
 				}
 			} else {
-				sid, genErr := idgen.NextID()
+				sid, genErr := deriveSeasonContentID(seriesID, ep.SeasonNumber)
 				if genErr != nil {
 					slog.Warn("metadata: failed to generate implicit season id",
 						"series_id", seriesID, "season", ep.SeasonNumber, "error", genErr)
@@ -3093,7 +3101,7 @@ func (s *MetadataService) persistSeasonsAndEpisodes(
 					dbEp.StillThumbhash = existingEpisode.StillThumbhash
 				}
 			} else {
-				eid, genErr := idgen.NextID()
+				eid, genErr := deriveEpisodeContentID(seriesID, providerEpisode.SeasonNumber, providerEpisode.EpisodeNumber)
 				if genErr != nil {
 					slog.Warn("metadata: failed to generate episode id",
 						"series_id", seriesID, "season", ep.SeasonNumber,
@@ -3196,7 +3204,7 @@ func (s *MetadataService) synthesizeFallbackSeriesStructure(ctx context.Context,
 				seasonID = existingSeason.ContentID
 				seasonIDs[seasonNum] = seasonID
 			case errors.Is(err, catalog.ErrSeasonNotFound):
-				seasonID, err = idgen.NextID()
+				seasonID, err = deriveSeasonContentID(seriesID, seasonNum)
 				if err != nil {
 					return fmt.Errorf("generating fallback season id: %w", err)
 				}
@@ -3229,7 +3237,7 @@ func (s *MetadataService) synthesizeFallbackSeriesStructure(ctx context.Context,
 			}
 			continue
 		case errors.Is(err, catalog.ErrEpisodeNotFound):
-			episodeID, err := idgen.NextID()
+			episodeID, err := deriveEpisodeContentID(seriesID, seasonNum, episodeNum)
 			if err != nil {
 				return fmt.Errorf("generating fallback episode id: %w", err)
 			}
@@ -4083,7 +4091,20 @@ func (s *MetadataService) createOrFindSkeleton(ctx context.Context, file *models
 	if _, err := s.folderTypeForSkeleton(ctx, folderID); err != nil {
 		return nil, err
 	}
-	contentID, err := generateContentID()
+	// Derive a deterministic content_id from the structured provider tags the
+	// scanner already parsed from the folder/file name (the common case for
+	// Radarr/Sonarr/Plex-tagged libraries), so two servers seeing the same tags
+	// mint the same id at scan time with no provider API call. Untagged files
+	// fall back to a per-file local: id (keyed on the file path, not the folder)
+	// so distinct skeletons in a shared folder stay separate until the dedup
+	// machinery confirms a real shared identity — matching the pre-existing
+	// one-skeleton-per-file behavior while staying stable across rescans.
+	localAnchorPath := firstNonEmpty(file.FilePath, contentRootPath, observedRootPath)
+	contentID, err := deriveLogicalContentID(
+		res.Type,
+		contentid.ProviderIDs{Tmdb: res.TmdbID, Imdb: res.ImdbID, Tvdb: res.TvdbID},
+		localAnchorPath,
+	)
 	if err != nil {
 		return nil, fmt.Errorf("generate content id: %w", err)
 	}
@@ -5393,8 +5414,83 @@ func ImageTypeFromString(s string) ImageType {
 	}
 }
 
+// generateContentID mints a content_id when no deterministic anchor is
+// available (non movie/series item types, or items with neither provider tags
+// nor a path to hash). Provider-anchored movies/series should go through
+// deriveLogicalContentID so the same title yields the same id on every server.
 func generateContentID() (string, error) {
 	return idgen.NextID()
+}
+
+// deriveLogicalContentID computes a deterministic, cross-server stable
+// content_id for a movie or series from its provider IDs (see the contentid
+// package). When no provider anchor is present it falls back to a local: id
+// derived from fallbackPath so the item stays stable across rescans on this
+// server; with neither, it falls back to a Sonyflake id. Item types other than
+// movie/series are out of the deterministic scheme's scope and always get a
+// Sonyflake id.
+func deriveLogicalContentID(itemType string, ids contentid.ProviderIDs, fallbackPath string) (string, error) {
+	switch normalizeItemTypeForContentID(itemType) {
+	case "movie":
+		if id, ok := contentid.ForMovie(ids); ok {
+			return id, nil
+		}
+		if strings.TrimSpace(fallbackPath) != "" {
+			return contentid.ForLocal(fallbackPath), nil
+		}
+	case "series":
+		if id, ok := contentid.ForSeries(ids); ok {
+			return id, nil
+		}
+		if strings.TrimSpace(fallbackPath) != "" {
+			return contentid.ForLocal(fallbackPath), nil
+		}
+	}
+	return generateContentID()
+}
+
+// deriveSeasonContentID composes a deterministic season content_id from its
+// parent series content_id. When the series is provider-anchored the season id
+// embeds the series anchor (the load-bearing format invariant); otherwise it
+// falls back to a Sonyflake id so legacy/local series keep working.
+func deriveSeasonContentID(seriesContentID string, seasonNumber int) (string, error) {
+	if id, ok := contentid.ForSeason(seriesContentID, seasonNumber); ok {
+		return id, nil
+	}
+	return generateContentID()
+}
+
+// deriveEpisodeContentID composes a deterministic episode content_id from its
+// parent series content_id plus the season/episode numbers, falling back to a
+// Sonyflake id when the series is not provider-anchored.
+func deriveEpisodeContentID(seriesContentID string, seasonNumber, episodeNumber int) (string, error) {
+	if id, ok := contentid.ForEpisode(seriesContentID, seasonNumber, episodeNumber); ok {
+		return id, nil
+	}
+	return generateContentID()
+}
+
+// firstNonEmpty returns the first non-blank string, or "" if all are blank.
+func firstNonEmpty(values ...string) string {
+	for _, v := range values {
+		if strings.TrimSpace(v) != "" {
+			return v
+		}
+	}
+	return ""
+}
+
+// normalizeItemTypeForContentID maps the media_items.type values onto the two
+// entity kinds the deterministic scheme covers.
+func normalizeItemTypeForContentID(itemType string) string {
+	switch strings.ToLower(strings.TrimSpace(itemType)) {
+	case "movie", "movies":
+		return "movie"
+	case "series", "show", "tv":
+		return "series"
+	default:
+		return ""
+	}
 }
 
 func searchResultConflictsWithTrustedIDs(hintedIDs, candidateIDs map[string]string) bool {

--- a/migrations/sql/20260612130000_deterministic_content_id.sql
+++ b/migrations/sql/20260612130000_deterministic_content_id.sql
@@ -8,14 +8,16 @@
 -- keeps working; only the values and collation change.
 --
 -- Mapping rules (kept in lockstep with internal/contentid; SchemeVersion = 1):
---   movies   anchor precedence tmdb -> imdb -> tvdb  => movie:<provider>:<id>
---   series   anchor precedence tvdb -> tmdb -> imdb  => series:<provider>:<id>
---   seasons  compose from the series anchor          => season:<provider>:<sid>:<n>
---   episodes compose from the series anchor          => episode:<provider>:<sid>:<s>:<e>
--- Items with no usable provider anchor (and all item types other than
--- movie/series, e.g. audiobook/ebook/podcast) keep their existing Sonyflake id:
--- there is no stable cross-server anchor to derive from, so changing them gains
--- nothing. New unmatched movies/series instead get a path-derived local: id at
+--   movies   anchor precedence tmdb -> imdb -> tvdb  => movie-<provider>-<id>
+--   series   anchor precedence tvdb -> tmdb -> imdb  => series-<provider>-<id>
+--   seasons  compose from the series anchor          => season-<provider>-<sid>-<n>
+--   episodes compose from the series anchor          => episode-<provider>-<sid>-<s>-<e>
+-- The "-" component separator is an RFC 3986 unreserved char, so the id needs no
+-- URL encoding (see internal/contentid). Items with no usable provider anchor
+-- (and all item types other than movie/series, e.g. audiobook/ebook/podcast)
+-- keep their existing Sonyflake id: there is no stable cross-server anchor to
+-- derive from, so changing them gains nothing. New unmatched movies/series
+-- instead get a path-derived local- id at
 -- scan time (handled in Go, not here).
 --
 -- Safety: collisions (two ids deriving to the same key, or a key already taken
@@ -50,15 +52,15 @@ FROM (
         CASE
             WHEN lower(mi.type) IN ('movie', 'movies') THEN
                 CASE
-                    WHEN nullif(btrim(mi.tmdb_id, E' \t\n\r\f'), '') ~ '^[0-9]+$'      THEN 'movie:tmdb:' || btrim(mi.tmdb_id, E' \t\n\r\f')
-                    WHEN lower(btrim(mi.imdb_id, E' \t\n\r\f')) ~ '^tt[0-9]+$'         THEN 'movie:imdb:' || lower(btrim(mi.imdb_id, E' \t\n\r\f'))
-                    WHEN nullif(btrim(mi.tvdb_id, E' \t\n\r\f'), '') ~ '^[0-9]+$'      THEN 'movie:tvdb:' || btrim(mi.tvdb_id, E' \t\n\r\f')
+                    WHEN nullif(btrim(mi.tmdb_id, E' \t\n\r\f'), '') ~ '^[0-9]+$'      THEN 'movie-tmdb-' || btrim(mi.tmdb_id, E' \t\n\r\f')
+                    WHEN lower(btrim(mi.imdb_id, E' \t\n\r\f')) ~ '^tt[0-9]+$'         THEN 'movie-imdb-' || lower(btrim(mi.imdb_id, E' \t\n\r\f'))
+                    WHEN nullif(btrim(mi.tvdb_id, E' \t\n\r\f'), '') ~ '^[0-9]+$'      THEN 'movie-tvdb-' || btrim(mi.tvdb_id, E' \t\n\r\f')
                 END
             WHEN lower(mi.type) IN ('series', 'show', 'tv') THEN
                 CASE
-                    WHEN nullif(btrim(mi.tvdb_id, E' \t\n\r\f'), '') ~ '^[0-9]+$'      THEN 'series:tvdb:' || btrim(mi.tvdb_id, E' \t\n\r\f')
-                    WHEN nullif(btrim(mi.tmdb_id, E' \t\n\r\f'), '') ~ '^[0-9]+$'      THEN 'series:tmdb:' || btrim(mi.tmdb_id, E' \t\n\r\f')
-                    WHEN lower(btrim(mi.imdb_id, E' \t\n\r\f')) ~ '^tt[0-9]+$'         THEN 'series:imdb:' || lower(btrim(mi.imdb_id, E' \t\n\r\f'))
+                    WHEN nullif(btrim(mi.tvdb_id, E' \t\n\r\f'), '') ~ '^[0-9]+$'      THEN 'series-tvdb-' || btrim(mi.tvdb_id, E' \t\n\r\f')
+                    WHEN nullif(btrim(mi.tmdb_id, E' \t\n\r\f'), '') ~ '^[0-9]+$'      THEN 'series-tmdb-' || btrim(mi.tmdb_id, E' \t\n\r\f')
+                    WHEN lower(btrim(mi.imdb_id, E' \t\n\r\f')) ~ '^tt[0-9]+$'         THEN 'series-imdb-' || lower(btrim(mi.imdb_id, E' \t\n\r\f'))
                 END
         END AS new_id
     FROM media_items mi
@@ -72,25 +74,25 @@ WHERE d.new_id IS NOT NULL
 INSERT INTO content_id_migration_map (old_id, new_id, entity)
 SELECT
     s.content_id,
-    'season:' || split_part(m.new_id, ':', 2) || ':' || split_part(m.new_id, ':', 3)
-        || ':' || s.season_number,
+    'season-' || split_part(m.new_id, '-', 2) || '-' || split_part(m.new_id, '-', 3)
+        || '-' || s.season_number,
     'season'
 FROM seasons s
 JOIN content_id_migration_map m
     ON m.old_id = s.series_id AND m.entity = 'media_item'
-WHERE m.new_id LIKE 'series:%';
+WHERE m.new_id LIKE 'series-%';
 
 -- Step 2c: episodes compose from the series anchor + season/episode numbers.
 INSERT INTO content_id_migration_map (old_id, new_id, entity)
 SELECT
     e.content_id,
-    'episode:' || split_part(m.new_id, ':', 2) || ':' || split_part(m.new_id, ':', 3)
-        || ':' || e.season_number || ':' || e.episode_number,
+    'episode-' || split_part(m.new_id, '-', 2) || '-' || split_part(m.new_id, '-', 3)
+        || '-' || e.season_number || '-' || e.episode_number,
     'episode'
 FROM episodes e
 JOIN content_id_migration_map m
     ON m.old_id = e.series_id AND m.entity = 'media_item'
-WHERE m.new_id LIKE 'series:%';
+WHERE m.new_id LIKE 'series-%';
 
 -- Step 3: collision detection. Never remap into a key that is claimed twice, or
 -- one already occupied by a row that is NOT being remapped (a pre-existing
@@ -114,7 +116,7 @@ WHERE m.status = 'mapped'
   );
 
 -- Cascade collisions from a series to its children. A season/episode key embeds
--- the series anchor (season:<p>:<sid>:..., episode:<p>:<sid>:...), so if the
+-- the series anchor (season-<p>-<sid>-..., episode-<p>-<sid>-...), so if the
 -- series itself was left on Sonyflake (collision), remapping a child would point
 -- the embedded anchor at a series row that no longer exists under that key —
 -- orphaning the child and dropping its rows from the anchor-derived history
@@ -281,7 +283,7 @@ END $$;
 -- user_watch_history backing a "by show" display_id. It is intentionally NOT
 -- created here: the current hot query (full-history DISTINCT ON) cannot use it
 -- (its display_id references the joined episodes table and it lacks watched_at),
--- and it would index the wrong value for legacy/local: episode rows (§9.2.5).
+-- and it would index the wrong value for legacy/local episode rows (§9.2.5).
 -- It belongs with the O(page) summary-table work (§9.2.3) that actually reads
 -- it, using a resolved display_id that handles those rows correctly. Adding it
 -- now would be pure write-amplification on every watch event with no reader.

--- a/migrations/sql/20260612130000_deterministic_content_id.sql
+++ b/migrations/sql/20260612130000_deterministic_content_id.sql
@@ -1,0 +1,390 @@
+-- Deterministic, cross-server content_id (see
+-- docs/architecture/deterministic-content-id.md).
+--
+-- This migration remaps the *values* of content_id (and every column that
+-- references it) from per-server Sonyflake ids to provider-derived structured
+-- keys, and changes the storage collation of those columns to "C". The column
+-- *type* does not change (text -> text COLLATE "C"), so the soft-reference graph
+-- keeps working; only the values and collation change.
+--
+-- Mapping rules (kept in lockstep with internal/contentid; SchemeVersion = 1):
+--   movies   anchor precedence tmdb -> imdb -> tvdb  => movie:<provider>:<id>
+--   series   anchor precedence tvdb -> tmdb -> imdb  => series:<provider>:<id>
+--   seasons  compose from the series anchor          => season:<provider>:<sid>:<n>
+--   episodes compose from the series anchor          => episode:<provider>:<sid>:<s>:<e>
+-- Items with no usable provider anchor (and all item types other than
+-- movie/series, e.g. audiobook/ebook/podcast) keep their existing Sonyflake id:
+-- there is no stable cross-server anchor to derive from, so changing them gains
+-- nothing. New unmatched movies/series instead get a path-derived local: id at
+-- scan time (handled in Go, not here).
+--
+-- Safety: collisions (two ids deriving to the same key, or a key already taken
+-- by an un-mapped row) are detected and left on Sonyflake — the migration never
+-- merges or drops a row. The old->new map is retained in
+-- content_id_migration_map for audit and rollback.
+--
+-- OPERATIONAL NOTE: on a large production dataset (10-50M rows) the value
+-- UPDATEs and the COLLATE rewrite hold AccessExclusive locks for the duration.
+-- Run off-peak. For very large installs, replace the in-transaction UPDATE loop
+-- below with the batched/online procedure in the design doc (§7.2); the mapping
+-- and collision logic here are reusable as-is.
+
+-- +goose Up
+
+-- Step 1: persistent audit/rollback map.
+CREATE TABLE content_id_migration_map (
+    old_id text PRIMARY KEY,
+    new_id text NOT NULL,
+    entity text NOT NULL,                     -- media_item | season | episode
+    status text NOT NULL DEFAULT 'mapped'     -- mapped | collision
+);
+
+-- Step 2a: derive movie/series keys from the denormalized provider columns,
+-- applying the frozen precedence. Rows that already hold a non-Sonyflake key
+-- (new_id = old_id) or have no usable anchor are skipped.
+INSERT INTO content_id_migration_map (old_id, new_id, entity)
+SELECT old_id, new_id, 'media_item'
+FROM (
+    SELECT
+        mi.content_id AS old_id,
+        CASE
+            WHEN lower(mi.type) IN ('movie', 'movies') THEN
+                CASE
+                    WHEN nullif(btrim(mi.tmdb_id, E' \t\n\r\f'), '') ~ '^[0-9]+$'      THEN 'movie:tmdb:' || btrim(mi.tmdb_id, E' \t\n\r\f')
+                    WHEN lower(btrim(mi.imdb_id, E' \t\n\r\f')) ~ '^tt[0-9]+$'         THEN 'movie:imdb:' || lower(btrim(mi.imdb_id, E' \t\n\r\f'))
+                    WHEN nullif(btrim(mi.tvdb_id, E' \t\n\r\f'), '') ~ '^[0-9]+$'      THEN 'movie:tvdb:' || btrim(mi.tvdb_id, E' \t\n\r\f')
+                END
+            WHEN lower(mi.type) IN ('series', 'show', 'tv') THEN
+                CASE
+                    WHEN nullif(btrim(mi.tvdb_id, E' \t\n\r\f'), '') ~ '^[0-9]+$'      THEN 'series:tvdb:' || btrim(mi.tvdb_id, E' \t\n\r\f')
+                    WHEN nullif(btrim(mi.tmdb_id, E' \t\n\r\f'), '') ~ '^[0-9]+$'      THEN 'series:tmdb:' || btrim(mi.tmdb_id, E' \t\n\r\f')
+                    WHEN lower(btrim(mi.imdb_id, E' \t\n\r\f')) ~ '^tt[0-9]+$'         THEN 'series:imdb:' || lower(btrim(mi.imdb_id, E' \t\n\r\f'))
+                END
+        END AS new_id
+    FROM media_items mi
+) d
+WHERE d.new_id IS NOT NULL
+  AND d.new_id <> d.old_id;
+
+-- Step 2b: seasons compose from their series' new key. Joining on the map means
+-- only seasons of an already-mapped (legacy) series are remapped; seasons of a
+-- post-cutover series (series_id already structured) naturally fall out.
+INSERT INTO content_id_migration_map (old_id, new_id, entity)
+SELECT
+    s.content_id,
+    'season:' || split_part(m.new_id, ':', 2) || ':' || split_part(m.new_id, ':', 3)
+        || ':' || s.season_number,
+    'season'
+FROM seasons s
+JOIN content_id_migration_map m
+    ON m.old_id = s.series_id AND m.entity = 'media_item'
+WHERE m.new_id LIKE 'series:%';
+
+-- Step 2c: episodes compose from the series anchor + season/episode numbers.
+INSERT INTO content_id_migration_map (old_id, new_id, entity)
+SELECT
+    e.content_id,
+    'episode:' || split_part(m.new_id, ':', 2) || ':' || split_part(m.new_id, ':', 3)
+        || ':' || e.season_number || ':' || e.episode_number,
+    'episode'
+FROM episodes e
+JOIN content_id_migration_map m
+    ON m.old_id = e.series_id AND m.entity = 'media_item'
+WHERE m.new_id LIKE 'series:%';
+
+-- Step 3: collision detection. Never remap into a key that is claimed twice, or
+-- one already occupied by a row that is NOT being remapped (a pre-existing
+-- deterministic row). Such rows stay on Sonyflake; operators reconcile dupes
+-- separately. This guarantees the value remap can never violate a PK.
+CREATE INDEX content_id_migration_map_new_id_idx ON content_id_migration_map (new_id);
+
+UPDATE content_id_migration_map m
+SET status = 'collision'
+WHERE m.new_id IN (
+    SELECT new_id FROM content_id_migration_map GROUP BY new_id HAVING count(*) > 1
+);
+
+UPDATE content_id_migration_map m
+SET status = 'collision'
+WHERE m.status = 'mapped'
+  AND (
+        EXISTS (SELECT 1 FROM media_items x WHERE x.content_id = m.new_id)
+     OR EXISTS (SELECT 1 FROM seasons     x WHERE x.content_id = m.new_id)
+     OR EXISTS (SELECT 1 FROM episodes    x WHERE x.content_id = m.new_id)
+  );
+
+-- Cascade collisions from a series to its children. A season/episode key embeds
+-- the series anchor (season:<p>:<sid>:..., episode:<p>:<sid>:...), so if the
+-- series itself was left on Sonyflake (collision), remapping a child would point
+-- the embedded anchor at a series row that no longer exists under that key —
+-- orphaning the child and dropping its rows from the anchor-derived history
+-- query. Keep such children on Sonyflake too. (A collision on the season alone
+-- does not force the episode, whose anchor is the series, not the season.)
+UPDATE content_id_migration_map m
+SET status = 'collision'
+FROM seasons s
+JOIN content_id_migration_map ms ON ms.old_id = s.series_id AND ms.status = 'collision'
+WHERE m.entity = 'season' AND m.status = 'mapped' AND m.old_id = s.content_id;
+
+UPDATE content_id_migration_map m
+SET status = 'collision'
+FROM episodes e
+JOIN content_id_migration_map ms ON ms.old_id = e.series_id AND ms.status = 'collision'
+WHERE m.entity = 'episode' AND m.status = 'mapped' AND m.old_id = e.content_id;
+
+-- Step 4: enumerate every column in the content_id reference graph — the three
+-- PKs, every FK child column referencing them, and a name sweep for the
+-- unconstrained soft references — so the remap and collation change cover them
+-- all without trusting a hand-list (per the design doc).
+CREATE TEMP TABLE _cid_cols (table_name regclass, column_name name) ON COMMIT DROP;
+
+-- The three primary keys.
+INSERT INTO _cid_cols VALUES
+    ('media_items'::regclass, 'content_id'),
+    ('seasons'::regclass,     'content_id'),
+    ('episodes'::regclass,    'content_id');
+
+-- Every FK child column that references the family (reliable, from the catalog).
+INSERT INTO _cid_cols
+SELECT con.conrelid::regclass, att.attname
+FROM pg_constraint con
+JOIN unnest(con.conkey) WITH ORDINALITY AS k(attnum, ord) ON TRUE
+JOIN pg_attribute att ON att.attrelid = con.conrelid AND att.attnum = k.attnum
+WHERE con.contype = 'f'
+  AND con.confrelid IN ('media_items'::regclass, 'seasons'::regclass, 'episodes'::regclass);
+
+-- Soft references (no FK): text columns whose name is a known content-id holder
+-- in this schema. The value remap is self-protecting — only values that match a
+-- mapped Sonyflake id change — so an over-broad name match cannot corrupt
+-- unrelated data; it only needs the names to genuinely hold content ids.
+INSERT INTO _cid_cols
+SELECT c.oid::regclass, a.attname
+FROM pg_class c
+JOIN pg_namespace n ON n.oid = c.relnamespace
+JOIN pg_attribute a ON a.attrelid = c.oid AND a.attnum > 0 AND NOT a.attisdropped
+JOIN pg_type t ON t.oid = a.atttypid
+WHERE c.relkind IN ('r', 'p')
+  AND n.nspname = 'public'
+  AND t.typname IN ('text', 'varchar', 'bpchar')
+  AND a.attname IN (
+        'media_item_id', 'series_id', 'season_id', 'episode_id', 'content_id',
+        'season_content_id', 'episode_content_id', 'library_item_id', 'cover_item',
+        'item_id', 'similar_item_id', 'source_item_id'
+      )
+  AND c.relname NOT LIKE 'content_id_migration%'
+  AND NOT EXISTS (
+        SELECT 1 FROM _cid_cols ex WHERE ex.table_name = c.oid::regclass AND ex.column_name = a.attname
+      );
+
+-- Step 5: drop the family's FK constraints (so PK and child values can be
+-- remapped and recollated), saving their definitions to recreate afterward.
+CREATE TEMP TABLE content_id_migration_fk (conname name, rel regclass, condef text) ON COMMIT DROP;
+
+-- +goose StatementBegin
+DO $$
+DECLARE
+    r RECORD;
+BEGIN
+    FOR r IN
+        SELECT con.conname, con.conrelid::regclass AS rel, pg_get_constraintdef(con.oid) AS condef
+        FROM pg_constraint con
+        WHERE con.contype = 'f'
+          AND con.confrelid IN ('media_items'::regclass, 'seasons'::regclass, 'episodes'::regclass)
+    LOOP
+        INSERT INTO content_id_migration_fk (conname, rel, condef) VALUES (r.conname, r.rel, r.condef);
+        EXECUTE format('ALTER TABLE %s DROP CONSTRAINT %I', r.rel, r.conname);
+    END LOOP;
+END $$;
+-- +goose StatementEnd
+
+-- Step 5b: drop every user trigger on a swept table for the duration. Two
+-- reasons: (1) a trigger that names a family column in an UPDATE OF list or WHEN
+-- clause blocks ALTER COLUMN TYPE; (2) ANY row trigger on a swept table would
+-- fire per-row during the remap (e.g. the episode_catalog_entries
+-- denormalization triggers — including plain AFTER INSERT/UPDATE/DELETE ones a
+-- column-name match would miss), causing per-row plpgsql work and order-
+-- dependent corruption of the denormalized tables. Those tables are remapped
+-- directly by the column sweep, so dropping all of their triggers is both
+-- correct and faster. Recreated verbatim in Step 8.
+CREATE TEMP TABLE content_id_migration_trg (tgname name, rel regclass, def text) ON COMMIT DROP;
+
+-- +goose StatementBegin
+DO $$
+DECLARE
+    r RECORD;
+BEGIN
+    FOR r IN
+        SELECT t.tgname, t.tgrelid::regclass AS rel, pg_get_triggerdef(t.oid) AS def
+        FROM pg_trigger t
+        WHERE NOT t.tgisinternal
+          AND t.tgrelid IN (SELECT table_name FROM _cid_cols)
+    LOOP
+        INSERT INTO content_id_migration_trg (tgname, rel, def) VALUES (r.tgname, r.rel, r.def);
+        EXECUTE format('DROP TRIGGER %I ON %s', r.tgname, r.rel);
+    END LOOP;
+END $$;
+-- +goose StatementEnd
+
+-- Step 6: remap values across every family column. After a row's value becomes
+-- the (non-Sonyflake) new id it no longer matches any old_id, so a single pass
+-- per column suffices and is idempotent.
+-- +goose StatementBegin
+DO $$
+DECLARE
+    c RECORD;
+BEGIN
+    FOR c IN SELECT table_name, column_name FROM _cid_cols LOOP
+        EXECUTE format(
+            'UPDATE %s t SET %I = m.new_id FROM content_id_migration_map m '
+            || 'WHERE m.status = ''mapped'' AND m.old_id = t.%I',
+            c.table_name, c.column_name, c.column_name
+        );
+    END LOOP;
+END $$;
+-- +goose StatementEnd
+
+-- Step 7: change collation of every family column to "C". This rewrites the
+-- columns' indexes; structured keys share long prefixes, so "C" (memcmp) is
+-- load-bearing — without it ordered/probe paths regress below the Sonyflake
+-- status quo (design doc §5.2).
+-- +goose StatementBegin
+DO $$
+DECLARE
+    c RECORD;
+BEGIN
+    FOR c IN SELECT table_name, column_name FROM _cid_cols LOOP
+        EXECUTE format(
+            'ALTER TABLE %s ALTER COLUMN %I TYPE text COLLATE "C"',
+            c.table_name, c.column_name
+        );
+    END LOOP;
+END $$;
+-- +goose StatementEnd
+
+-- Step 8: recreate triggers, then the FK constraints (both sides now remapped
+-- and "C"-collated).
+-- +goose StatementBegin
+DO $$
+DECLARE
+    r RECORD;
+BEGIN
+    FOR r IN SELECT def FROM content_id_migration_trg LOOP
+        EXECUTE r.def;
+    END LOOP;
+    FOR r IN SELECT conname, rel, condef FROM content_id_migration_fk LOOP
+        EXECUTE format('ALTER TABLE %s ADD CONSTRAINT %I %s', r.rel, r.conname, r.condef);
+    END LOOP;
+END $$;
+-- +goose StatementEnd
+
+-- NOTE: the design doc (§9.2.2) also proposes an expression index on
+-- user_watch_history backing a "by show" display_id. It is intentionally NOT
+-- created here: the current hot query (full-history DISTINCT ON) cannot use it
+-- (its display_id references the joined episodes table and it lacks watched_at),
+-- and it would index the wrong value for legacy/local: episode rows (§9.2.5).
+-- It belongs with the O(page) summary-table work (§9.2.3) that actually reads
+-- it, using a resolved display_id that handles those rows correctly. Adding it
+-- now would be pure write-amplification on every watch event with no reader.
+
+-- +goose Down
+
+-- Rebuild the column set for the reverse remap and collation reset.
+CREATE TEMP TABLE _cid_cols (table_name regclass, column_name name) ON COMMIT DROP;
+INSERT INTO _cid_cols VALUES
+    ('media_items'::regclass, 'content_id'),
+    ('seasons'::regclass,     'content_id'),
+    ('episodes'::regclass,    'content_id');
+INSERT INTO _cid_cols
+SELECT con.conrelid::regclass, att.attname
+FROM pg_constraint con
+JOIN unnest(con.conkey) WITH ORDINALITY AS k(attnum, ord) ON TRUE
+JOIN pg_attribute att ON att.attrelid = con.conrelid AND att.attnum = k.attnum
+WHERE con.contype = 'f'
+  AND con.confrelid IN ('media_items'::regclass, 'seasons'::regclass, 'episodes'::regclass);
+INSERT INTO _cid_cols
+SELECT c.oid::regclass, a.attname
+FROM pg_class c
+JOIN pg_namespace n ON n.oid = c.relnamespace
+JOIN pg_attribute a ON a.attrelid = c.oid AND a.attnum > 0 AND NOT a.attisdropped
+JOIN pg_type t ON t.oid = a.atttypid
+WHERE c.relkind IN ('r', 'p')
+  AND n.nspname = 'public'
+  AND t.typname IN ('text', 'varchar', 'bpchar')
+  AND a.attname IN (
+        'media_item_id', 'series_id', 'season_id', 'episode_id', 'content_id',
+        'season_content_id', 'episode_content_id', 'library_item_id', 'cover_item',
+        'item_id', 'similar_item_id', 'source_item_id'
+      )
+  AND c.relname NOT LIKE 'content_id_migration%'
+  AND NOT EXISTS (
+        SELECT 1 FROM _cid_cols ex WHERE ex.table_name = c.oid::regclass AND ex.column_name = a.attname
+      );
+
+-- Drop FKs and family triggers, revert values via the map, reset collation to
+-- the database default, recreate triggers + FKs. NOTE: rollback is only
+-- consistent for rows minted before the generation cutover; rows created with
+-- structured ids after cutover have no map entry and remain structured
+-- (design doc §7.2).
+CREATE TEMP TABLE content_id_migration_fk (conname name, rel regclass, condef text) ON COMMIT DROP;
+CREATE TEMP TABLE content_id_migration_trg (tgname name, rel regclass, def text) ON COMMIT DROP;
+
+-- +goose StatementBegin
+DO $$
+DECLARE
+    r RECORD;
+BEGIN
+    FOR r IN
+        SELECT con.conname, con.conrelid::regclass AS rel, pg_get_constraintdef(con.oid) AS condef
+        FROM pg_constraint con
+        WHERE con.contype = 'f'
+          AND con.confrelid IN ('media_items'::regclass, 'seasons'::regclass, 'episodes'::regclass)
+    LOOP
+        INSERT INTO content_id_migration_fk (conname, rel, condef) VALUES (r.conname, r.rel, r.condef);
+        EXECUTE format('ALTER TABLE %s DROP CONSTRAINT %I', r.rel, r.conname);
+    END LOOP;
+    FOR r IN
+        SELECT t.tgname, t.tgrelid::regclass AS rel, pg_get_triggerdef(t.oid) AS def
+        FROM pg_trigger t
+        WHERE NOT t.tgisinternal
+          AND t.tgrelid IN (SELECT table_name FROM _cid_cols)
+    LOOP
+        INSERT INTO content_id_migration_trg (tgname, rel, def) VALUES (r.tgname, r.rel, r.def);
+        EXECUTE format('DROP TRIGGER %I ON %s', r.tgname, r.rel);
+    END LOOP;
+END $$;
+-- +goose StatementEnd
+
+-- +goose StatementBegin
+DO $$
+DECLARE
+    c RECORD;
+BEGIN
+    FOR c IN SELECT table_name, column_name FROM _cid_cols LOOP
+        EXECUTE format(
+            'UPDATE %s t SET %I = m.old_id FROM content_id_migration_map m '
+            || 'WHERE m.status = ''mapped'' AND m.new_id = t.%I',
+            c.table_name, c.column_name, c.column_name
+        );
+        EXECUTE format(
+            'ALTER TABLE %s ALTER COLUMN %I TYPE text COLLATE pg_catalog."default"',
+            c.table_name, c.column_name
+        );
+    END LOOP;
+END $$;
+-- +goose StatementEnd
+
+-- +goose StatementBegin
+DO $$
+DECLARE
+    r RECORD;
+BEGIN
+    FOR r IN SELECT def FROM content_id_migration_trg LOOP
+        EXECUTE r.def;
+    END LOOP;
+    FOR r IN SELECT conname, rel, condef FROM content_id_migration_fk LOOP
+        EXECUTE format('ALTER TABLE %s ADD CONSTRAINT %I %s', r.rel, r.conname, r.condef);
+    END LOOP;
+END $$;
+-- +goose StatementEnd
+
+DROP TABLE IF EXISTS content_id_migration_map;

--- a/migrations/sql/20260612130000_deterministic_content_id.sql
+++ b/migrations/sql/20260612130000_deterministic_content_id.sql
@@ -245,6 +245,36 @@ BEGIN
 END $$;
 -- +goose StatementEnd
 
+-- Step 6b: remap array-valued soft references. A text[] column that holds
+-- resolved content_ids is excluded from the scalar sweep above on BOTH axes —
+-- the type filter is scalar (text/varchar/bpchar) and the name list has
+-- 'content_id', not the plural 'content_ids' — and an array cannot carry an FK,
+-- so nothing else would touch it. Without this it keeps stale Sonyflake ids that
+-- resolve to nothing. trending_discover_snapshots.content_ids is the only such
+-- column in this schema; remap element-wise, preserving order, leaving unmapped
+-- elements (collisions / unmatched) untouched. The WHERE EXISTS guard skips
+-- empty and unaffected arrays so array_agg can never collapse the NOT NULL
+-- column to NULL.
+-- +goose StatementBegin
+DO $$
+BEGIN
+    IF to_regclass('public.trending_discover_snapshots') IS NOT NULL THEN
+        UPDATE trending_discover_snapshots t
+        SET content_ids = (
+            SELECT array_agg(COALESCE(m.new_id, u.elem) ORDER BY u.ord)
+            FROM unnest(t.content_ids) WITH ORDINALITY AS u(elem, ord)
+            LEFT JOIN content_id_migration_map m
+                ON m.status = 'mapped' AND m.old_id = u.elem
+        )
+        WHERE EXISTS (
+            SELECT 1
+            FROM unnest(t.content_ids) AS e(elem)
+            JOIN content_id_migration_map m ON m.status = 'mapped' AND m.old_id = e.elem
+        );
+    END IF;
+END $$;
+-- +goose StatementEnd
+
 -- Step 7: change collation of every family column to "C". This rewrites the
 -- columns' indexes; structured keys share long prefixes, so "C" (memcmp) is
 -- load-bearing — without it ordered/probe paths regress below the Sonyflake
@@ -386,6 +416,28 @@ BEGIN
     FOR r IN SELECT conname, rel, condef FROM content_id_migration_fk LOOP
         EXECUTE format('ALTER TABLE %s ADD CONSTRAINT %I %s', r.rel, r.conname, r.condef);
     END LOOP;
+END $$;
+-- +goose StatementEnd
+
+-- Reverse the array-valued soft-reference remap (mirror of Step 6b). Runs while
+-- content_id_migration_map still exists, i.e. before the DROP TABLE below.
+-- +goose StatementBegin
+DO $$
+BEGIN
+    IF to_regclass('public.trending_discover_snapshots') IS NOT NULL THEN
+        UPDATE trending_discover_snapshots t
+        SET content_ids = (
+            SELECT array_agg(COALESCE(m.old_id, u.elem) ORDER BY u.ord)
+            FROM unnest(t.content_ids) WITH ORDINALITY AS u(elem, ord)
+            LEFT JOIN content_id_migration_map m
+                ON m.status = 'mapped' AND m.new_id = u.elem
+        )
+        WHERE EXISTS (
+            SELECT 1
+            FROM unnest(t.content_ids) AS e(elem)
+            JOIN content_id_migration_map m ON m.status = 'mapped' AND m.new_id = e.elem
+        );
+    END IF;
 END $$;
 -- +goose StatementEnd
 

--- a/migrations/sql/20260614120000_content_id_online_reid.sql
+++ b/migrations/sql/20260614120000_content_id_online_reid.sql
@@ -1,0 +1,123 @@
+-- Online re-ID support for content_id (see
+-- docs/architecture/deterministic-content-id.md, "Re-ID on match").
+--
+-- The deterministic-content-id migration (20260612130000) does a one-shot,
+-- whole-table value remap under AccessExclusive locks. This migration instead
+-- makes a *single* content_id value cheap to move at runtime, so an untagged
+-- item that only learns its provider IDs at match time can be promoted from its
+-- local: placeholder to its deterministic id in place:
+--
+--   (a) add ON UPDATE CASCADE to every FK in the content_id family, so updating
+--       a parent PK (media_items / seasons / episodes) propagates to all FK
+--       children automatically (the existing ON DELETE behaviour is preserved);
+--       and
+--   (b) provide silo_rename_content_id(from, to), which moves the PK rows plus
+--       the unconstrained soft references (FK children follow via the cascade
+--       from (a)). The soft-reference name predicate mirrors 20260612130000 so
+--       the two stay in lockstep.
+--
+-- ON UPDATE CASCADE only fires when a content_id is updated (essentially never
+-- outside this promotion), so there is no steady-state cost. The caller
+-- (canonicalizeLocalContentID) guarantees the target id is free before calling
+-- the function; a lost race surfaces as a unique violation and is retried.
+
+-- +goose Up
+
+-- (a) Rebuild every content_id-family FK with ON UPDATE CASCADE. pg_get_constraintdef
+--     carries the existing ON DELETE clause through, so it is preserved.
+-- +goose StatementBegin
+DO $$
+DECLARE
+    r RECORD;
+BEGIN
+    FOR r IN
+        SELECT con.conname,
+               con.conrelid::regclass AS rel,
+               pg_get_constraintdef(con.oid) AS condef
+        FROM pg_constraint con
+        WHERE con.contype = 'f'
+          AND con.confrelid IN ('media_items'::regclass, 'seasons'::regclass, 'episodes'::regclass)
+          AND position('ON UPDATE' IN pg_get_constraintdef(con.oid)) = 0
+    LOOP
+        EXECUTE format('ALTER TABLE %s DROP CONSTRAINT %I', r.rel, r.conname);
+        EXECUTE format('ALTER TABLE %s ADD CONSTRAINT %I %s ON UPDATE CASCADE',
+                       r.rel, r.conname, r.condef);
+    END LOOP;
+END $$;
+-- +goose StatementEnd
+
+-- (b) Move one content_id value across the whole reference graph. FK children
+--     follow via the cascade above; this updates the three PK columns and the
+--     unconstrained soft references (same name predicate as 20260612130000).
+--     The whole body runs as one statement, so the move is atomic.
+-- +goose StatementBegin
+CREATE OR REPLACE FUNCTION silo_rename_content_id(p_from text, p_to text)
+RETURNS void
+LANGUAGE plpgsql
+AS $$
+DECLARE
+    c RECORD;
+BEGIN
+    IF p_from IS NULL OR p_to IS NULL OR p_from = p_to THEN
+        RETURN;
+    END IF;
+
+    FOR c IN
+        SELECT cl.oid::regclass AS rel, a.attname AS col
+        FROM pg_class cl
+        JOIN pg_namespace n ON n.oid = cl.relnamespace
+        JOIN pg_attribute a ON a.attrelid = cl.oid AND a.attnum > 0 AND NOT a.attisdropped
+        JOIN pg_type t ON t.oid = a.atttypid
+        WHERE cl.relkind IN ('r', 'p')
+          AND n.nspname = 'public'
+          AND t.typname IN ('text', 'varchar', 'bpchar')
+          AND a.attname IN (
+                'media_item_id', 'series_id', 'season_id', 'episode_id', 'content_id',
+                'season_content_id', 'episode_content_id', 'library_item_id', 'cover_item',
+                'item_id', 'similar_item_id', 'source_item_id'
+              )
+          AND cl.relname NOT LIKE 'content_id_migration%'
+          -- Skip real FK children of the family; ON UPDATE CASCADE moves those.
+          AND NOT EXISTS (
+                SELECT 1
+                FROM pg_constraint con
+                JOIN unnest(con.conkey) WITH ORDINALITY AS k(attnum, ord) ON TRUE
+                WHERE con.contype = 'f'
+                  AND con.conrelid = cl.oid
+                  AND con.confrelid IN ('media_items'::regclass, 'seasons'::regclass, 'episodes'::regclass)
+                  AND k.attnum = a.attnum
+              )
+    LOOP
+        EXECUTE format('UPDATE %s SET %I = $2 WHERE %I = $1', c.rel, c.col, c.col)
+            USING p_from, p_to;
+    END LOOP;
+END;
+$$;
+-- +goose StatementEnd
+
+-- +goose Down
+
+DROP FUNCTION IF EXISTS silo_rename_content_id(text, text);
+
+-- Revert the content_id-family FKs to their prior (no ON UPDATE) form.
+-- +goose StatementBegin
+DO $$
+DECLARE
+    r RECORD;
+BEGIN
+    FOR r IN
+        SELECT con.conname,
+               con.conrelid::regclass AS rel,
+               pg_get_constraintdef(con.oid) AS condef
+        FROM pg_constraint con
+        WHERE con.contype = 'f'
+          AND con.confrelid IN ('media_items'::regclass, 'seasons'::regclass, 'episodes'::regclass)
+          AND position('ON UPDATE CASCADE' IN pg_get_constraintdef(con.oid)) > 0
+    LOOP
+        EXECUTE format('ALTER TABLE %s DROP CONSTRAINT %I', r.rel, r.conname);
+        EXECUTE format('ALTER TABLE %s ADD CONSTRAINT %I %s',
+                       r.rel, r.conname,
+                       replace(r.condef, ' ON UPDATE CASCADE', ''));
+    END LOOP;
+END $$;
+-- +goose StatementEnd

--- a/migrations/sql/20260614120000_content_id_online_reid.sql
+++ b/migrations/sql/20260614120000_content_id_online_reid.sql
@@ -91,6 +91,17 @@ BEGIN
         EXECUTE format('UPDATE %s SET %I = $2 WHERE %I = $1', c.rel, c.col, c.col)
             USING p_from, p_to;
     END LOOP;
+
+    -- Array-valued soft references are not covered by the scalar loop above
+    -- (text[] is not in the type filter and cannot carry an FK), matching the
+    -- gap closed in 20260612130000 Step 6b. Negligible at runtime — a freshly
+    -- matched local item is essentially never already in a trending snapshot —
+    -- but kept in lockstep so a rename never leaves a stale array element.
+    IF to_regclass('public.trending_discover_snapshots') IS NOT NULL THEN
+        UPDATE trending_discover_snapshots
+        SET content_ids = array_replace(content_ids, p_from, p_to)
+        WHERE p_from = ANY(content_ids);
+    END IF;
 END;
 $$;
 -- +goose StatementEnd


### PR DESCRIPTION
<!--
PR DESCRIPTION for branch: feat/deterministic-content-id

To push and open the PR (origin route):
    git push -u origin feat/deterministic-content-id
    gh pr create --repo Silo-Server/silo-server --base main \
      --head feat/deterministic-content-id \
      --title "feat(catalog): deterministic cross-server content_id" \
      --body-file docs/architecture/deterministic-content-id-pr.md

(The body below is used verbatim by --body-file; this comment is hidden in
GitHub's rendered markdown.)
-->

Two feature commits: deterministic, cross-server `content_id` (a derivation core, generation wiring, a hot-query fast path, and a collision-safe value-remap migration), then an online re-ID that promotes untagged items to their deterministic id at first match.

Plus two follow-up commits from review: `fix(catalog): harden content_id parsing and merge per review` (the CodeRabbit findings — stricter anchored-id validation, frozen precedence, fail-closed canonicalize) and `refactor(contentid): URL-safe "-" separator in content_id` (see the separator note below).

**Scope:** id-system refactor (how `content_id` is minted/stored), not a new user-facing endpoint or feature — so it proceeds under the "bug fixes, refactors … proceed normally" carve-out of the v1 scope gate (`docs/architecture/v1-scope.md` is not yet locked). It lays groundwork for future cross-server share/sync, which will be filed as its own v1 capability proposal.

## Problem

**The same title on two servers was treated as two unrelated items.** Every logical movie, show, season, and episode was stamped with a per-server numeric id minted locally at scan time. Because that id is the anchor everything hangs off — artwork, metadata, watch history, progress, favorites, ratings, collections, credits — two servers holding the identical movie shared *none* of that state. Anyone operating more than one Silo, or trying to move/sync a profile's history between servers, saw the same film or show show up as a stranger on the other side: no resume point, no watched flags, no carried-over ratings.

**There was no stable identity to build cross-server features on.** Because the id was a time-ordered local counter, nothing about it could be reproduced on another machine, so any future "share/sync across servers" work had no ground truth to key on.

## Solution

The fix replaces the per-server counter with a structured natural key derived from the provider IDs already present in the library (`movie-tmdb-228064`, `series-tvdb-296762`, `episode-tvdb-296762-1-5`, `local-<hash>` fallback). Two servers that see the same tags mint the same id with no API call.

> **Separator note (post-review):** the component separator is `-`, not the `:` shown in earlier revisions. We switched it for readability/operability. `-` is an RFC 3986 *unreserved* character, so a `content_id` is URL-safe verbatim: it needs no percent-encoding and doubles as its own tidy path segment — `/item/series-tvdb-296762` — identical to the value stored in the database, instead of the `%3A`-escaped `/item/series%3Atvdb%3A296762` a colon produces. The stored value and the URL value are the same string, so there is no encode/decode boundary and an operator can grep an id straight out of a URL or log. Every component is `[a-z0-9]+` (or `tt`+digits), so `-` is an unambiguous delimiter. Structure and guarantees are unchanged.

### feat(catalog): deterministic cross-server content_id

#### Derivation core — `internal/contentid/contentid.go`

`ForMovie`/`ForSeries`/`ForSeason`/`ForEpisode`/`ForLocal`, the `SeriesIDFromContentID` string transform, and frozen provider precedence (movies `tmdb → imdb → tvdb`; series/season/episode `tvdb → tmdb → imdb`, matching where Radarr/Sonarr reliably tag). The load-bearing invariant: an episode/season id embeds its series anchor, so the show is a pure string transform of the episode id — no catalog lookup. `SchemeVersion = 1` freezes format + precedence as a code constant so the population is never mixed-version.

#### Generation wiring — `internal/metadata/service.go`

`deriveLogicalContentID`/`deriveSeasonContentID`/`deriveEpisodeContentID` replace `idgen.NextID()` at every mint site (skeleton creation, provider-match at `service.go:1499`, explicit + implicit seasons, episodes, scanner-fallback episodes). Tagged libraries get their deterministic id at scan time; untagged new items get a path-derived `local-` id. Convergence of same-title items on one server is preserved by the existing dedup (`findExistingByProviderIDs`) plus `UpsertTx`'s `ON CONFLICT (content_id) DO UPDATE` backstop.

#### Hot watch-history query — `internal/catalog/history_source.go`

`display_id` resolves an episode history row to its show via `seriesFromAnchoredEpisodeExpr` (pure `split_part` transform) for provider-anchored ids, probing only the `media_items` PK. Legacy/`local-` ids still fall through the `episodes` join, which is null-poisoned for anchored ids so the planner never descends `episodes_pkey` for them.

#### Migration (value remap) — `migrations/sql/20260612130000_deterministic_content_id.sql`

Collision-safe value remap (Sonyflake → structured key) across the dynamically-enumerated reference graph (65 columns) with `COLLATE "C"`, FK drop/recreate, trigger quarantine, a retained audit map, and a working `down`. Collisions and anchorless/non-movie-series items are detected and kept on Sonyflake — the migration never merges or drops a row. Approach chosen over a hand-listed column set so a missed soft-reference can't silently orphan rows; the value remap is self-protecting, so over-inclusion is safe.

### feat(catalog): re-ID untagged items to deterministic content_id at first match

Tagged libraries are born with the right id at scan time, but an *untagged* file gets a path-derived `local-` id and only learns its provider IDs later, when the match worker confirms a result. A single gate inside `mergeAndPersist` (`canonicalizeLocalContentID`) promotes that placeholder to its deterministic id at the moment of first confirmed match: if the deterministic id is free the row is renamed in place (the DB moves every child row via `ON UPDATE CASCADE`, so it is a handful of rows for a fresh skeleton, not the full-table remap the migration does); if a row already sits at that id the two are the same logical item and the existing merge path (`rebindItemToExistingItem`) folds them together. The guard is a single `IsLocal` prefix check, so tagged content and all refreshes pay nothing, and the promotion is self-healing — a partial run simply re-runs on the next match.

```
SCAN a new file                          ← unchanged, still no network call
      │
      ▼
createOrFindSkeleton ──► tag?  YES ► movie-tmdb-123   NO ► local-<hash>
      │
      ▼
(later) match worker → mergeAndPersist
      │
      ▼
┌─────────────────────────────────────────────────────────┐
│ canonicalizeLocalContentID                               │
│                                                          │
│  Is the id still local- AND do we now have provider IDs? │
│        │ no  → do nothing, carry on                      │
│        │ yes                                             │
│        ▼                                                 │
│  Does a row already sit at movie-tmdb-123 ?              │
│        ├─ yes → MERGE this row into it  (existing code)  │
│        └─ no  → RENAME local-<hash> → movie-tmdb-123     │
│                   │                                       │
│                   ▼                                       │
│           DB auto-moves all child rows (ON UPDATE CASCADE)│
└─────────────────────────────────────────────────────────┘
      │
      ▼
rest of mergeAndPersist runs with the corrected id
(title, artwork, cast, episodes — all written under movie-tmdb-123)
```

The rename primitive (`silo_rename_content_id`, in `internal/metadata/canonicalize.go`) reuses the migration's catalog-driven column enumeration so the two stay in lockstep, and is added alongside the `ON UPDATE CASCADE` clauses in `migrations/sql/20260614120000_content_id_online_reid.sql`. ON UPDATE CASCADE only fires when a `content_id` is updated (essentially never outside this promotion), so there is no steady-state read/write cost; the one-time cost is the FK drop/recreate during the migration.

## Performance — measured at production scale

Measured on an isolated, prod-tuned PostgreSQL 18 instance (`shared_buffers=4GB`) loaded with an **exact-cardinality copy of production** (`cprod-postgres`): 184k items, 1.93M episodes, 775k watch-history rows / 162 profiles. "Before" reproduces production today (Sonyflake numeric `content_id`, `en_US.utf8`); "after" applies this PR's structured-key remap + `COLLATE "C"`. The 100-client load test ran on the isolated instance, never against production. **Every metric improves — this is a speedup, not a downgrade.**

**1. `content_id` index-probe cost** — 300k forced point lookups over 1.9M keys (the operation the hot paths are built from):

The last three columns are the point: speed alone wasn't the goal, so the two *faster* schemes were rejected for giving up properties the feature exists for. ✓ = has the property, ✗ = lacks it.

| Key scheme | Index size | µs / probe | vs today | Cross-server deterministic | Zero-join show transform | Human-readable |
| ---------- | ---------- | ---------- | -------- | :------------------------: | :----------------------: | :------------: |
| Sonyflake text, `en_US.utf8` *(today)* | 74 MB | **5.05** | 1.00× | ✗ | ✗ | ✗ |
| 128-bit hash `bytea(16)` | 74 MB | 1.80 | 2.81× | ✓ | ✗ | ✗ |
| `bigint` surrogate (≈ old Sonyflake) | 41 MB | 1.23 | 4.11× | ✗ | ✗ | ✗ |
| **Structured `content_id` + `COLLATE "C"` (this PR)** | 84 MB | **1.86** | **2.71×** | ✓ | ✓ | ✓ |

The locale-aware `strcoll` on today's text column is the bottleneck; `COLLATE "C"` (byte-wise `memcmp`) removes it. The structured key lands within **3%** of a 128-bit hash and within **1.5×** of a raw `bigint`, and is the **only all-✓ row**:

- **128-bit hash `bytea(16)`** — cross-server deterministic (it hashes the same natural key), but an opaque digest can't be string-transformed, so episode→series needs a catalog join (no zero-join hot path), and it isn't legible in logs, URLs, or `psql`.
- **`bigint` surrogate** — fast only because it's 8 bytes; it's the status-quo serial: per-server (not reproducible elsewhere), no embedded anchor to transform, not meaningful to a human.

Index grows ~14% (84 vs 74 MB), immaterial.

**2. Real history-page query** — heaviest profile (25,384 rows), from `buildHistoryDisplayBaseQuery`, warmed median of 6:

| State | Latency | `episodes_pkey` probes | Speedup |
| ----- | ------- | ---------------------- | ------- |
| Before (Sonyflake + `en_US.utf8`) | 385 ms | 25,348 | 1.00× |
| **This PR (structured + `COLLATE "C"`)** | **150 ms** | **2,775** | **2.57×** |

`COLLATE "C"` removes the locale-aware comparison cost, and structured keys let anchored episode ids skip the `episodes_pkey` descent (25,348 → 2,775 probes, the M1 fix).

**3. Concurrency** — `pgbench`, workload randomized across 150 real profiles (≥200 history rows each), 20 s per level:

| Concurrency | Before (lat / tps) | This PR (lat / tps) | Throughput gain |
| ----------- | ------------------ | ------------------- | --------------- |
| 1   | 43.8 ms / 23  | 13.0 ms / 77  | 3.4× |
| 10  | 50.9 ms / 196 | 21.1 ms / 473 | 2.4× |
| 50  | 152 ms / 329  | 91 ms / 548   | 1.7× |
| **100** | **311 ms / 321** | **181 ms / 551** | **1.7×** |

Comparison cost is pure CPU, so it dominates under concurrency: the cheaper `COLLATE "C"` comparisons raise the throughput ceiling from ~321 to ~551 tps and cut tail latency at 100 concurrent users by 42%. *(Warmed — dataset fits in `shared_buffers`; isolated instance shares a host with production, so the before/after ratios are the robust result, not absolute tps.)*

## Risk / follow-ups

- Re-ID-on-match for untagged-then-matched items now runs inline at first confirmed match (see the Re-ID subsection above). The one remaining case is a series that accumulated season/episode rows *before* it matched: those children keep their Sonyflake ids until a follow-up `recomposeSeriesChildIDs` pass re-derives them. At first match the children usually do not exist yet, so this is rare; it is not yet wired. Promotion also changes a primary key, so an item's anchored id can vary during its first-match window (accepted — no alias/redirect table).
- Cross-provider reconciliation (a series tagged tmdb-only on one server, tvdb-only on another) is not yet handled — both paths derive from the denormalized provider columns; the proper fix consults `media_item_provider_ids`.
- The migration runs in one transaction holding `AccessExclusive` locks for the COLLATE rewrite and remap — run off-peak; very large installs (10–50M rows) should use the batched procedure noted in the migration header.
- `local-` ids hash the absolute path, so a same-server remount re-IDs local items (acceptable for the best-effort local namespace).
- **Client coordination.** `content_id` stays a `string` in every API response (no additive-only violation), but the value-remap migration changes the *values* clients use as their anchor. Any `silo-android` / `silo-apple` state keyed on the old Sonyflake ids (cached offline downloads, stored references) is stale after migration and needs a re-fetch/invalidation path — tracked as client follow-up, not in this PR.

## Verification

- Unit tests: `internal/contentid` (derivation, precedence, the composition↔transform round-trip invariant, edge cases) pass; `internal/catalog` and `internal/metadata` suites pass with updated history-query golden fragments.
- `go build ./internal/...`, `go vet`, `gofmt -l` all clean.
- Migration on real schema (PG18 + pgvector): full migration chain plus this one applies, reverts (`down`), and re-applies (`up`) cleanly — recollates 65 columns, drops/recreates 27 FKs and all `episode_catalog` triggers, retains only the audit map.
- Online re-ID migration (`20260614120000_content_id_online_reid`): applies on the real schema after the value-remap migration; every content_id-family FK gains `ON UPDATE CASCADE` while keeping its original `ON DELETE` action (e.g. `episodes_series_id_fkey` becomes `ON UPDATE CASCADE ON DELETE CASCADE`); `make migrate-validate` passes; full `up`/`down`/`up` cycle is clean (down drops `silo_rename_content_id` and strips only `ON UPDATE CASCADE`).
- Online re-ID functional test: `silo_rename_content_id` on a local series moves the `media_items` PK, cascades `seasons.series_id`/`episodes.series_id`, sweeps the provider-id soft references, and correctly leaves the children's own (Sonyflake) ids untouched (the deferred `recomposeSeriesChildIDs` case); a local movie rename moves the item and its provider ids; `ON DELETE CASCADE` still fires (delete leaves 0 orphans).
- Migration data-bearing test: correct precedence; soft-reference + FK-child remap; 0 FK orphans; collisions/unmatched correctly stay on Sonyflake; the collision cascade keeps a unique episode of a colliding series off an orphaned anchor; `down` reverts values and collation.
- Performance: benchmarked against an exact-cardinality copy of `cprod-postgres` (1.93M episodes, 775k history rows) — 2.57× faster history page, 1.7× throughput at 100 concurrent users, 2.7× cheaper per `content_id` probe (see Performance section).

## AI-use disclosure

Implemented with AI assistance (Claude). An independent adversarial review (Fable 5) was run against the spec's required properties; its critical/major findings were fixed and re-validated, with the larger items recorded as the follow-ups above. Performance benchmarking was AI-assisted against an isolated copy of production data.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added deterministic, provider-anchored identifiers for movies, series, seasons, and episodes to keep items consistent across server instances.
  * Canonicalizes local placeholder identifiers to deterministic provider identifiers during metadata ingestion.
  * Added reversible ID encoding support for compatibility item/season IDs.
* **Bug Fixes**
  * Improved watch/history resolution for provider-anchored episode content so related items link correctly.
* **Documentation**
  * Added a developer reference describing the deterministic identifier format and migration strategy.
* **Tests**
  * Expanded coverage for deterministic ID composition/parsing/packing, codec behavior, history query generation, and migration timeout handling.
* **Chores**
  * Added migrations to remap existing `content_id` values and enabled online re-ID with cascading updates; migration timeout is now configurable via an environment variable.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->



