### PR TITLE
fix(jellycompat): serve item and user images anonymously to match Jellyfin

### DIFF
--- a/internal/jellycompat/handlers_images.go
+++ b/internal/jellycompat/handlers_images.go
@@ -3,7 +3,6 @@ package jellycompat
 import (
 	"context"
 	"errors"
-	"fmt"
 	"net/http"
 	"net/url"
 	"strings"
@@ -114,7 +113,10 @@ func (h *ImagesHandler) HandleItemImage(w http.ResponseWriter, r *http.Request) 
 		}
 	}
 	if session == nil {
-		writeError(w, http.StatusUnauthorized, "Unauthorized", "Missing authentication token")
+		// Jellyfin item/chapter image GETs are anonymous (200/404 only, never
+		// 401): media players can't attach auth headers to <img> requests, and
+		// absent or unsupported art (e.g. Chapter) must degrade to a clean 404.
+		writeError(w, http.StatusNotFound, "NotFound", "Image not found")
 		return
 	}
 
@@ -575,23 +577,17 @@ func parseRemoteImageURL(imageURL string) (*url.URL, error) {
 }
 
 // HandleUserImage returns a deterministic placeholder avatar.
+//
+// Jellyfin user-image GETs are anonymous (200/404 only): clients fetch avatars
+// via plain <img> tags that carry no auth. The response is selected from a
+// precomputed palette by hashing the path pseudo-user id, so it stays
+// deterministic per id without per-request PNG generation (which an anonymous
+// varying-{id} flood would otherwise turn into a CPU DoS amplifier).
 func (h *ImagesHandler) HandleUserImage(w http.ResponseWriter, r *http.Request) {
-	session := SessionFromContext(r.Context())
-	if session == nil {
-		writeError(w, http.StatusUnauthorized, "Unauthorized", "Missing authentication token")
-		return
-	}
-	if !validatePseudoUser(w, chiURLParam(r, "id"), session) {
-		return
-	}
+	id := chiURLParam(r, "id")
 
-	data, err := placeholderAvatarPNG(fmt.Sprintf("%s:%s", session.Username, session.ProfileID))
-	if err != nil {
-		writeError(w, http.StatusInternalServerError, "ServerError", "Failed to generate avatar")
-		return
-	}
 	w.Header().Set("Content-Type", "image/png")
 	w.Header().Set("Cache-Control", "public, max-age=3600")
 	w.WriteHeader(http.StatusOK)
-	_, _ = w.Write(data)
+	_, _ = w.Write(avatarPalette[avatarPaletteIndex(id)])
 }

--- a/internal/jellycompat/images.go
+++ b/internal/jellycompat/images.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"crypto/sha1"
 	"encoding/binary"
+	"fmt"
 	"image"
 	"image/color"
 	"image/png"
@@ -224,7 +225,40 @@ func setCompatImageRouteNoStore(header http.Header) {
 	header.Add("Vary", "User-Agent")
 }
 
-func placeholderAvatarPNG(seed string) ([]byte, error) {
+// avatarPaletteSize bounds the number of distinct placeholder avatars. The
+// route is anonymous, so per-request PNG generation would be a CPU DoS amplifier
+// (a varying {id} flood defeats Cache-Control). Instead we precompute a small
+// fixed palette once and select by hashing the id — zero per-request generation,
+// bounded memory, while retaining per-id color variety.
+const avatarPaletteSize = 16
+
+// avatarPalette holds the precomputed placeholder PNGs, one per slot. Building
+// it at package init means a panic here (image encode failure) is impossible to
+// miss and never reaches a request.
+var avatarPalette = buildAvatarPalette()
+
+func buildAvatarPalette() [avatarPaletteSize][]byte {
+	var palette [avatarPaletteSize][]byte
+	for i := range palette {
+		// Seed each slot with a distinct value so the colors are spread out;
+		// reuse the same sha1-fill drawing as the original per-id generator.
+		pngBytes, err := renderPlaceholderAvatarPNG(fmt.Sprintf("avatar-slot-%d", i))
+		if err != nil {
+			panic(fmt.Sprintf("jellycompat: build avatar palette slot %d: %v", i, err))
+		}
+		palette[i] = pngBytes
+	}
+	return palette
+}
+
+// avatarPaletteIndex maps an id to a stable palette slot via the first byte of
+// its sha1 digest, so a given id always resolves to the same avatar.
+func avatarPaletteIndex(id string) int {
+	sum := sha1.Sum([]byte(id))
+	return int(sum[0]) % avatarPaletteSize
+}
+
+func renderPlaceholderAvatarPNG(seed string) ([]byte, error) {
 	img := image.NewRGBA(image.Rect(0, 0, 128, 128))
 	sum := sha1.Sum([]byte(seed))
 	fill := color.RGBA{R: sum[0], G: sum[1], B: sum[2], A: 255}

--- a/internal/jellycompat/images_test.go
+++ b/internal/jellycompat/images_test.go
@@ -237,8 +237,11 @@ func TestHandleItemImageRejectsUnsignedTagWhenSecretBlank(t *testing.T) {
 
 	h.HandleItemImage(rec, req)
 
-	if rec.Code != http.StatusUnauthorized {
-		t.Fatalf("status = %d, body = %s; want 401", rec.Code, rec.Body.String())
+	// An unsigned/invalid tag must not serve the image. Per the Jellyfin
+	// contract (item-image GETs are anonymous, 200/404 only) the rejection
+	// surfaces as a 404, not a 401.
+	if rec.Code != http.StatusNotFound {
+		t.Fatalf("status = %d, body = %s; want 404", rec.Code, rec.Body.String())
 	}
 }
 
@@ -391,8 +394,10 @@ func TestHandleItemImageRevalidatesTagBeforeRouteCacheHit(t *testing.T) {
 
 	h.HandleItemImage(rec, req)
 
-	if rec.Code != http.StatusUnauthorized {
-		t.Fatalf("status = %d, body = %s; want 401", rec.Code, rec.Body.String())
+	// A stale tag (signed with the old secret) must not serve the cached image.
+	// Per the Jellyfin contract the rejection surfaces as a 404, not a 401.
+	if rec.Code != http.StatusNotFound {
+		t.Fatalf("status = %d, body = %s; want 404", rec.Code, rec.Body.String())
 	}
 	if called {
 		t.Fatal("served cached image before validating the signed tag")
@@ -411,6 +416,128 @@ func TestRedirectImageURLRejectsNonHTTPURL(t *testing.T) {
 	}
 	if got := rec.Header().Get("Location"); got != "" {
 		t.Fatalf("Location = %q, want empty", got)
+	}
+}
+
+// TestHandleItemImageChapterReturns404WithoutSession verifies an anonymous
+// chapter-image request (no auth, cold cache, no tag) degrades to a 404, not a
+// 401: Silo never stores "Chapter" route art, so the cache misses and the
+// session-fallback now returns NotFound per the Jellyfin contract.
+func TestHandleItemImageChapterReturns404WithoutSession(t *testing.T) {
+	codec := NewResourceIDCodec()
+	contentID := "movie-1"
+	routeID := codec.EncodeStringID(EncodedIDItem, contentID)
+	h := &ImagesHandler{
+		codec:     codec,
+		images:    NewImageCache(time.Hour, time.Now),
+		itemRepo:  fakeImageItemRepo{item: &models.MediaItem{ContentID: contentID}},
+		imageTags: newImageTagSigner("image-secret"),
+	}
+
+	req := httptest.NewRequest(http.MethodGet, "/Items/"+routeID+"/Images/Chapter/0", nil)
+	routeCtx := chi.NewRouteContext()
+	routeCtx.URLParams.Add("id", routeID)
+	routeCtx.URLParams.Add("imageType", "Chapter")
+	routeCtx.URLParams.Add("index", "0")
+	req = req.WithContext(context.WithValue(req.Context(), chi.RouteCtxKey, routeCtx))
+	rec := httptest.NewRecorder()
+
+	h.HandleItemImage(rec, req)
+
+	if rec.Code != http.StatusNotFound {
+		t.Fatalf("status = %d, body = %s; want 404", rec.Code, rec.Body.String())
+	}
+	if got := rec.Header().Get("Location"); got != "" {
+		t.Fatalf("Location = %q, want empty", got)
+	}
+}
+
+// TestHandleItemImagePrimaryCacheHitRedirectsWithoutSession verifies a warm
+// Primary cache entry serves an anonymous <img> request via redirect, never
+// consulting auth.
+func TestHandleItemImagePrimaryCacheHitRedirectsWithoutSession(t *testing.T) {
+	codec := NewResourceIDCodec()
+	contentID := "movie-1"
+	routeID := codec.EncodeStringID(EncodedIDItem, contentID)
+	upstreamURL := "https://cdn.example.test/poster.jpg"
+	h := &ImagesHandler{
+		codec:     codec,
+		images:    NewImageCache(time.Hour, time.Now),
+		itemRepo:  fakeImageItemRepo{item: &models.MediaItem{ContentID: contentID}},
+		imageTags: newImageTagSigner("image-secret"),
+	}
+	h.images.RememberSized(routeID, "Primary", upstreamURL, compatCardImageSize)
+
+	req := httptest.NewRequest(http.MethodGet, "/Items/"+routeID+"/Images/Primary", nil)
+	req = withImageRouteParams(req, routeID, "Primary")
+	rec := httptest.NewRecorder()
+
+	h.HandleItemImage(rec, req)
+
+	assertImageRedirect(t, rec, upstreamURL)
+}
+
+// serveUserImage issues an avatar request for pathID with the chi "id" route
+// param and no session in context.
+func serveUserImage(h *ImagesHandler, method, pathID string) *httptest.ResponseRecorder {
+	req := httptest.NewRequest(method, "/Users/"+pathID+"/Images/Primary", nil)
+	routeCtx := chi.NewRouteContext()
+	routeCtx.URLParams.Add("id", pathID)
+	req = req.WithContext(context.WithValue(req.Context(), chi.RouteCtxKey, routeCtx))
+	rec := httptest.NewRecorder()
+	h.HandleUserImage(rec, req)
+	return rec
+}
+
+// TestHandleUserImageServesPlaceholderWithoutSession verifies the user-avatar
+// route serves a placeholder PNG without a session: it is byte-stable per id and
+// the palette varies across ids (the avatar is now drawn from a bounded fixed
+// palette, so two distinct ids may collide — variety is asserted over a sample).
+func TestHandleUserImageServesPlaceholderWithoutSession(t *testing.T) {
+	h := &ImagesHandler{codec: NewResourceIDCodec()}
+	id := PseudoUserID(1, "profile-1").String()
+
+	rec := serveUserImage(h, http.MethodGet, id)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, body = %s; want 200", rec.Code, rec.Body.String())
+	}
+	if ct := rec.Header().Get("Content-Type"); ct != "image/png" {
+		t.Fatalf("Content-Type = %q, want image/png", ct)
+	}
+	body := rec.Body.Bytes()
+	if len(body) == 0 {
+		t.Fatal("expected a non-empty avatar body")
+	}
+
+	again := serveUserImage(h, http.MethodGet, id)
+	if got := again.Body.Bytes(); string(got) != string(body) {
+		t.Fatal("avatar bytes for the same path id must be stable across calls")
+	}
+
+	// The palette is bounded, so individual ids may collide; assert variety over
+	// a sample instead of strict per-id divergence.
+	distinct := map[string]struct{}{}
+	for i := 0; i < 12; i++ {
+		out := serveUserImage(h, http.MethodGet, PseudoUserID(i+10, "profile").String())
+		distinct[out.Body.String()] = struct{}{}
+	}
+	if len(distinct) < 2 {
+		t.Fatalf("expected the avatar palette to vary across ids; got %d distinct outputs", len(distinct))
+	}
+}
+
+// TestHandleUserImageHeadRequest verifies the HEAD variant of the anonymous
+// avatar route returns 200 + image/png (the body may be empty for HEAD).
+func TestHandleUserImageHeadRequest(t *testing.T) {
+	h := &ImagesHandler{codec: NewResourceIDCodec()}
+	id := PseudoUserID(1, "profile-1").String()
+
+	rec := serveUserImage(h, http.MethodHead, id)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, body = %s; want 200", rec.Code, rec.Body.String())
+	}
+	if ct := rec.Header().Get("Content-Type"); ct != "image/png" {
+		t.Fatalf("Content-Type = %q, want image/png", ct)
 	}
 }
 

--- a/internal/jellycompat/router.go
+++ b/internal/jellycompat/router.go
@@ -116,6 +116,11 @@ func NewRouter(deps Dependencies) chi.Router {
 	r.Post("/Users/AuthenticateByName", authHandler.HandleAuthenticateByName)
 	r.Get("/Items/{id}/Images/{imageType}", imagesHandler.HandleItemImage)
 	r.Get("/Items/{id}/Images/{imageType}/{index}", imagesHandler.HandleItemImage)
+	// Jellyfin user-avatar images are anonymous: clients fetch them via plain
+	// <img> tags that carry no auth, so the route is registered top-level rather
+	// than inside the session-auth group.
+	r.Get("/Users/{id}/Images/Primary", imagesHandler.HandleUserImage)
+	r.Method(http.MethodHead, "/Users/{id}/Images/Primary", http.HandlerFunc(imagesHandler.HandleUserImage))
 	webHandler := http.StripPrefix("/web", newDynamicCompatWebHandler(deps))
 	r.Get("/", func(w http.ResponseWriter, r *http.Request) {
 		http.Redirect(w, r, "/web/", http.StatusFound)
@@ -191,7 +196,6 @@ func NewRouter(deps Dependencies) chi.Router {
 			r.Get("/Studios", itemsHandler.HandleItemStub)
 			r.Get("/Artists", itemsHandler.HandleItemStub)
 			r.Get("/Movies/Recommendations", recsHandler.HandleRecommendations)
-			r.Get("/Users/{id}/Images/Primary", imagesHandler.HandleUserImage)
 			r.Post("/Sessions/Capabilities", playbackHandler.HandleCapabilitiesFull)
 			r.Post("/Sessions/Capabilities/Full", playbackHandler.HandleCapabilitiesFull)
 			r.Get("/Playback/BitrateTest", playbackHandler.HandleBitrateTest)


### PR DESCRIPTION
## Problem

Two image routes return `401` where genuine Jellyfin serves anonymously:

- `GET /Items/{id}/Images/{type}[/{index}]` returns `401` (not `404`) for absent/unsupported art when the request carries no session — e.g. chapter thumbnails (which Silo only ever serves as embedded `Chapters[].ImagePath`, never via this route) or any plain `<img>` request. Jellyfin's `ImageController.GetItemImage` / `GetItemImageByIndex` carry no `[Authorize]` and document `200`/`404` only.
- `GET /Users/{id}/Images/Primary` is registered inside the session-auth group, so an avatar `<img>` (which can't attach an auth header) `401`s. Jellyfin's `GetUserImage` / `GetUserImageLegacy` are anonymous as well.

Real clients (e.g. Fladder) hit both → missing chapter thumbnails and user avatars.

## Approach

- **Item images:** when there is no session after the existing token/tag fallbacks, return a clean `404 "Image not found"` instead of `401` — matching the contract and the handler's own default-case 404. The signed-tag rejection paths are untouched (a forged/stale tag still does not serve the image).
- **User avatar:** move `GET`/`HEAD /Users/{id}/Images/Primary` to a top-level anonymous route and seed the deterministic placeholder from the path pseudo-user id (no session needed). To keep the now-anonymous route from becoming a CPU amplifier, the placeholder is selected from a small precomputed palette by hashing the id, rather than generated per request.

## Testing

New tests: chapter image without session → `404` (not `401`); warm Primary cache redirects anonymously; user avatar serves a stable PNG without a session (byte-stable per id, varied across ids, plus a HEAD variant). Two existing tag-rejection tests updated `401`→`404` — the image is still never served, only the rejection status changed (now contract-correct). Green in a libvips container; tests mutation-verified.

## Notes / what to watch

- This changes a status code on existing compat routes (`401`→`404`). It is contract-correcting (Jellyfin documents `200`/`404`, never `401`, on these anonymous GETs); no client should depend on the `401`.
- Placeholder avatar bytes change for existing users (seed switched to the path id — cosmetic, no stored avatars exist) and there are now 16 color buckets rather than per-user-unique colors.
- These touch auth policy; happy to split further or gate behind discussion if maintainers prefer.

---
*AI-use disclosure: implemented and tested with AI assistance (Claude Code), including an adversarial security pass that caught and fixed a DoS-amplification risk on the now-anonymous avatar route. Diff and tests were human-reviewed and run in a libvips Docker container.*
