### PR TITLE
fix(jellycompat): return seasons/episodes when browsing a series via /Items?ParentId=

### DIFF
--- a/internal/jellycompat/handlers_items.go
+++ b/internal/jellycompat/handlers_items.go
@@ -222,6 +222,13 @@ func (h *ItemsHandler) handleItemParentChildren(w http.ResponseWriter, r *http.R
 // episodes of that season. The season is resolved to its owning series so the
 // shared episode-listing path (also used by /Shows/{id}/Episodes) can be reused.
 func (h *ItemsHandler) handleSeasonEpisodeChildren(w http.ResponseWriter, r *http.Request, session *Session, query itemsQuery) {
+	// A season's only children are its episodes; a type filter that excludes
+	// Episode (e.g. IncludeItemTypes=Movie) yields nothing, mirroring the
+	// series-parent path's handling of unsatisfiable type filters.
+	if query.hasItemTypeFilter && !itemTypesContain(query.itemTypes, "episode") {
+		writeJSON(w, http.StatusOK, emptyQueryResult(query.startIndex))
+		return
+	}
 	if h.seasonRepo == nil {
 		writeJSON(w, http.StatusOK, emptyQueryResult(query.startIndex))
 		return

--- a/internal/jellycompat/handlers_items.go
+++ b/internal/jellycompat/handlers_items.go
@@ -38,6 +38,7 @@ type ItemsHandler struct {
 	detailSvc    *catalog.DetailService
 	itemRepo     itemRepoForBatchLoader
 	episodeRepo  episodeRepoForBatchLoader
+	seasonRepo   imageSeasonRepository
 	accessFilter AccessFilterResolver
 	subtitleRepo subtitles.Repository
 	recommender  recommendations.Recommender
@@ -52,8 +53,8 @@ type ItemsHandler struct {
 }
 
 // NewItemsHandler creates a new items handler.
-func NewItemsHandler(content ContentService, userData UserDataService, codec *ResourceIDCodec, cfg *config.Config, images *ImageCache, nextUpRepo *catalog.NextUpRepository, browseRepo *catalog.BrowseRepository, personRepo *catalog.PersonRepository, detailSvc *catalog.DetailService, itemRepo *catalog.ItemRepository, episodeRepo *catalog.EpisodeRepository, accessFilter AccessFilterResolver, subtitleRepo subtitles.Repository) *ItemsHandler {
-	return &ItemsHandler{
+func NewItemsHandler(content ContentService, userData UserDataService, codec *ResourceIDCodec, cfg *config.Config, images *ImageCache, nextUpRepo *catalog.NextUpRepository, browseRepo *catalog.BrowseRepository, personRepo *catalog.PersonRepository, detailSvc *catalog.DetailService, itemRepo *catalog.ItemRepository, episodeRepo *catalog.EpisodeRepository, seasonRepo *catalog.SeasonRepository, accessFilter AccessFilterResolver, subtitleRepo subtitles.Repository) *ItemsHandler {
+	h := &ItemsHandler{
 		content:      content,
 		userData:     userData,
 		codec:        codec,
@@ -68,6 +69,13 @@ func NewItemsHandler(content ContentService, userData UserDataService, codec *Re
 		accessFilter: accessFilter,
 		subtitleRepo: subtitleRepo,
 	}
+	// Assign through the typed pointer only when present so the interface field
+	// stays a true nil (a typed nil would defeat the nil check in
+	// handleSeasonEpisodeChildren and panic on GetByID).
+	if seasonRepo != nil {
+		h.seasonRepo = seasonRepo
+	}
+	return h
 }
 
 // HandleViews serves GET /Users/{userId}/Views.
@@ -162,8 +170,18 @@ func (h *ItemsHandler) HandleItems(w http.ResponseWriter, r *http.Request) {
 		h.handleSearchItems(w, r, session, query)
 	case query.isFavorite:
 		h.handleFavoriteItems(w, r, session, query)
-	case isSeasonChildItemsQuery(query):
-		h.handleSeasonChildItems(w, r, session, query)
+	case query.parentSeasonID != "":
+		// ParentId is a season: list that season's episodes. Clients that browse
+		// a show through generic /Items?ParentId= (e.g. Void's getEpisodes) send
+		// no IncludeItemTypes, so this must not depend on a type filter.
+		h.handleSeasonEpisodeChildren(w, r, session, query)
+	case query.parentItemID != "":
+		// ParentId is a series (or movie): list the series' seasons, or its
+		// episodes when IncludeItemTypes=Episode is requested. Without this, a
+		// series ParentId fell through to the library-views fallback below, so
+		// clients browsing a show via /Items?ParentId= (e.g. Void's getSeasons)
+		// saw the top-level libraries rendered as season tabs.
+		h.handleItemParentChildren(w, r, session, query)
 	case query.parentLibraryID == 0 && len(query.itemTypes) == 0:
 		// No ParentId and no type filter: return top-level library views.
 		// Jellyfin clients (e.g. Findroid "My Media") call GET /Items?userId=...
@@ -183,12 +201,43 @@ func emptyQueryResult(startIndex int) queryResultDTO {
 	}
 }
 
-func isSeasonChildItemsQuery(query itemsQuery) bool {
-	if query.parentItemID == "" {
-		return false
+// handleItemParentChildren serves GET /Items?ParentId={seriesId}. A series parent
+// lists the series' seasons by default (and for an explicit IncludeItemTypes=Season);
+// IncludeItemTypes=Episode lists every episode of the series instead. A type filter
+// a series parent cannot satisfy (e.g. Movie) returns an empty page rather than a
+// wrong-typed seasons listing. Movie/other item parents have no seasons, so the
+// default path's ListSeasons yields an empty set and writes an empty page.
+func (h *ItemsHandler) handleItemParentChildren(w http.ResponseWriter, r *http.Request, session *Session, query itemsQuery) {
+	switch {
+	case itemTypesContain(query.itemTypes, "episode"):
+		h.writeSeriesEpisodesResponse(w, r, session, query, query.parentItemID, "", true)
+	case !query.hasItemTypeFilter || itemTypesContain(query.itemTypes, "season"):
+		h.handleSeasonChildItems(w, r, session, query)
+	default:
+		writeJSON(w, http.StatusOK, emptyQueryResult(query.startIndex))
 	}
-	for _, itemType := range query.itemTypes {
-		if itemType == "season" {
+}
+
+// handleSeasonEpisodeChildren serves GET /Items?ParentId={seasonId} by listing the
+// episodes of that season. The season is resolved to its owning series so the
+// shared episode-listing path (also used by /Shows/{id}/Episodes) can be reused.
+func (h *ItemsHandler) handleSeasonEpisodeChildren(w http.ResponseWriter, r *http.Request, session *Session, query itemsQuery) {
+	if h.seasonRepo == nil {
+		writeJSON(w, http.StatusOK, emptyQueryResult(query.startIndex))
+		return
+	}
+	season, err := h.seasonRepo.GetByID(r.Context(), query.parentSeasonID)
+	if err != nil || season == nil {
+		writeJSON(w, http.StatusOK, emptyQueryResult(query.startIndex))
+		return
+	}
+	h.writeSeriesEpisodesResponse(w, r, session, query, season.SeriesID, query.parentSeasonID, true)
+}
+
+// itemTypesContain reports whether the mapped IncludeItemTypes contain target.
+func itemTypesContain(itemTypes []string, target string) bool {
+	for _, itemType := range itemTypes {
+		if itemType == target {
 			return true
 		}
 	}
@@ -1117,17 +1166,8 @@ func (h *ItemsHandler) HandleEpisodes(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	seasons, err := h.content.ListSeasons(r.Context(), session, seriesID, nil)
-	if err != nil {
-		writeCompatUpstreamError(w, err)
-		return
-	}
-	h.rememberSeasonImages(seasons, seriesID)
-
-	qp := newCaseInsensitiveQuery(r.URL.Query())
-
 	var requestedSeasonID string
-	if rawSeasonID := strings.TrimSpace(qp.Get("SeasonId")); rawSeasonID != "" {
+	if rawSeasonID := strings.TrimSpace(newCaseInsensitiveQuery(r.URL.Query()).Get("SeasonId")); rawSeasonID != "" {
 		decodedSeasonID, decodeErr := h.codec.DecodeStringID(EncodedIDSeason, rawSeasonID)
 		if decodeErr != nil {
 			writeError(w, http.StatusNotFound, "NotFound", "Season not found")
@@ -1135,6 +1175,24 @@ func (h *ItemsHandler) HandleEpisodes(w http.ResponseWriter, r *http.Request) {
 		}
 		requestedSeasonID = decodedSeasonID
 	}
+
+	h.writeSeriesEpisodesResponse(w, r, session, query, seriesID, requestedSeasonID, false)
+}
+
+// writeSeriesEpisodesResponse lists a series' episodes (optionally scoped to a
+// single season via requestedSeasonID) and writes them as a Jellyfin /Items page.
+// It is the shared core of GET /Shows/{id}/Episodes and the generic
+// /Items?ParentId= series/season browse paths. page applies StartIndex/Limit to
+// the result: the generic /Items browse paths page (matching the /Items contract
+// and the sibling seasons listing); /Shows/{id}/Episodes passes false to keep its
+// long-standing whole-season response.
+func (h *ItemsHandler) writeSeriesEpisodesResponse(w http.ResponseWriter, r *http.Request, session *Session, query itemsQuery, seriesID, requestedSeasonID string, page bool) {
+	seasons, err := h.content.ListSeasons(r.Context(), session, seriesID, nil)
+	if err != nil {
+		writeCompatUpstreamError(w, err)
+		return
+	}
+	h.rememberSeasonImages(seasons, seriesID)
 
 	seasonTitleByID := make(map[string]string, len(seasons))
 	seasonTitleByNumber := make(map[int]string, len(seasons))
@@ -1254,10 +1312,19 @@ func (h *ItemsHandler) HandleEpisodes(w http.ResponseWriter, r *http.Request) {
 		return leftSeason < rightSeason
 	})
 
+	total := len(items)
+	startIndex := 0
+	if page {
+		startIndex = query.startIndex
+		items = slicePage(items, query.startIndex, query.limit)
+		if items == nil {
+			items = []baseItemDTO{}
+		}
+	}
 	writeJSON(w, http.StatusOK, queryResultDTO{
 		Items:            items,
-		TotalRecordCount: len(items),
-		StartIndex:       0,
+		TotalRecordCount: total,
+		StartIndex:       startIndex,
 	})
 }
 

--- a/internal/jellycompat/parent_browse_test.go
+++ b/internal/jellycompat/parent_browse_test.go
@@ -1,0 +1,245 @@
+package jellycompat
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net/http/httptest"
+	"net/url"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/Silo-Server/silo-server/internal/config"
+	"github.com/Silo-Server/silo-server/internal/models"
+)
+
+// fakeSeasonByIDRepo implements imageSeasonRepository for the season-parent path.
+type fakeSeasonByIDRepo struct{ seasons map[string]*models.Season }
+
+func (f *fakeSeasonByIDRepo) GetByID(_ context.Context, id string) (*models.Season, error) {
+	if s, ok := f.seasons[id]; ok {
+		return s, nil
+	}
+	return nil, errors.New("season not found")
+}
+
+// fakeSeasonEpisodeRepo implements episodeRepoForBatchLoader, serving episodes by
+// (seriesID, seasonNumber) for the season-parent episode listing.
+type fakeSeasonEpisodeRepo struct{ bySeason map[string][]*models.Episode }
+
+func episodeBySeasonKey(seriesID string, seasonNum int) string {
+	return fmt.Sprintf("%s|%d", seriesID, seasonNum)
+}
+
+func (f *fakeSeasonEpisodeRepo) GetByIDs(context.Context, []string) ([]*models.Episode, error) {
+	return nil, nil
+}
+
+func (f *fakeSeasonEpisodeRepo) HasFilesByIDs(context.Context, []string) (map[string]bool, error) {
+	return map[string]bool{}, nil
+}
+
+func (f *fakeSeasonEpisodeRepo) ListBySeason(_ context.Context, seriesID string, seasonNum int) ([]*models.Episode, error) {
+	return f.bySeason[episodeBySeasonKey(seriesID, seasonNum)], nil
+}
+
+func (f *fakeSeasonEpisodeRepo) ListBySeries(_ context.Context, seriesID string) ([]*models.Episode, error) {
+	var out []*models.Episode
+	for key, eps := range f.bySeason {
+		if strings.HasPrefix(key, seriesID+"|") {
+			out = append(out, eps...)
+		}
+	}
+	return out, nil
+}
+
+// TestHandleItems_SeriesParentWithoutTypeReturnsSeasons pins the Void fix: a
+// series ParentId with no IncludeItemTypes must list the series' seasons, not
+// fall through to the top-level library views. countingContentService panics in
+// ListUserLibraries, so a regression that routes to handleViewsResponse would
+// panic this test rather than silently pass.
+func TestHandleItems_SeriesParentWithoutTypeReturnsSeasons(t *testing.T) {
+	codec := NewResourceIDCodec()
+	seriesContentID := "series-1"
+	encodedSeriesID := codec.EncodeStringID(EncodedIDItem, seriesContentID)
+	contentSvc := &countingContentService{
+		seasons: []upstreamSeason{
+			{ContentID: "season-1", SeasonNumber: 1, Title: "Season 1", EpisodeCount: 10},
+			{ContentID: "season-2", SeasonNumber: 2, Title: "Season 2", EpisodeCount: 8},
+		},
+	}
+	h := &ItemsHandler{
+		content:  contentSvc,
+		userData: &mockUserDataService{},
+		codec:    codec,
+		mapper:   newMapper(codec, &config.Config{}),
+		images:   NewImageCache(time.Hour, time.Now),
+	}
+
+	result := performItemsRequest(t, h, "/Users/test/Items?ParentId="+encodedSeriesID)
+	if result.TotalRecordCount != 2 || len(result.Items) != 2 {
+		t.Fatalf("expected 2 seasons, got %+v", result.Items)
+	}
+	for _, item := range result.Items {
+		if item.Type != "Season" {
+			t.Fatalf("expected Season items (not library views), got %q", item.Type)
+		}
+	}
+	if contentSvc.listSeasonsSeries != seriesContentID {
+		t.Fatalf("ListSeasons series = %q, want %q", contentSvc.listSeasonsSeries, seriesContentID)
+	}
+}
+
+// TestHandleItems_SeriesParentNonEpisodeTypeIsEmpty pins that a type filter a
+// series parent cannot satisfy (e.g. Movie) returns an empty page rather than a
+// wrong-typed seasons listing, and does not even hit ListSeasons.
+func TestHandleItems_SeriesParentNonEpisodeTypeIsEmpty(t *testing.T) {
+	codec := NewResourceIDCodec()
+	encodedSeriesID := codec.EncodeStringID(EncodedIDItem, "series-1")
+	contentSvc := &countingContentService{
+		seasons: []upstreamSeason{{ContentID: "season-1", SeasonNumber: 1, Title: "Season 1", EpisodeCount: 10}},
+	}
+	h := &ItemsHandler{
+		content:  contentSvc,
+		userData: &mockUserDataService{},
+		codec:    codec,
+		mapper:   newMapper(codec, &config.Config{}),
+		images:   NewImageCache(time.Hour, time.Now),
+	}
+
+	result := performItemsRequest(t, h, "/Users/test/Items?ParentId="+encodedSeriesID+"&IncludeItemTypes=Movie")
+	if result.TotalRecordCount != 0 || len(result.Items) != 0 {
+		t.Fatalf("expected empty result for Movie type under a series parent, got %+v", result.Items)
+	}
+	if contentSvc.listSeasonsCalls != 0 {
+		t.Fatalf("ListSeasons must not be called for an unsatisfiable type filter; got %d", contentSvc.listSeasonsCalls)
+	}
+}
+
+// TestHandleItems_SeasonParentReturnsEpisodes pins the second half of the Void
+// fix: a season ParentId (no IncludeItemTypes) must list that season's episodes.
+func TestHandleItems_SeasonParentReturnsEpisodes(t *testing.T) {
+	codec := NewResourceIDCodec()
+	seriesContentID := "series-1"
+	seasonContentID := "season-1"
+	encodedSeasonID := codec.EncodeStringID(EncodedIDSeason, seasonContentID)
+
+	contentSvc := &countingContentService{
+		seasons: []upstreamSeason{
+			{ContentID: seasonContentID, SeasonNumber: 1, Title: "Season 1", EpisodeCount: 2},
+		},
+	}
+	episodeRepo := &fakeSeasonEpisodeRepo{bySeason: map[string][]*models.Episode{
+		episodeBySeasonKey(seriesContentID, 1): {
+			{ContentID: "ep-1", SeriesID: seriesContentID, SeasonID: seasonContentID, SeasonNumber: 1, EpisodeNumber: 1, Title: "Pilot"},
+			{ContentID: "ep-2", SeriesID: seriesContentID, SeasonID: seasonContentID, SeasonNumber: 1, EpisodeNumber: 2, Title: "Second"},
+		},
+	}}
+	h := &ItemsHandler{
+		content:     contentSvc,
+		userData:    &mockUserDataService{},
+		codec:       codec,
+		mapper:      newMapper(codec, &config.Config{}),
+		images:      NewImageCache(time.Hour, time.Now),
+		episodeRepo: episodeRepo,
+		seasonRepo: &fakeSeasonByIDRepo{seasons: map[string]*models.Season{
+			seasonContentID: {ContentID: seasonContentID, SeriesID: seriesContentID, SeasonNumber: 1},
+		}},
+	}
+
+	result := performItemsRequest(t, h, "/Users/test/Items?ParentId="+encodedSeasonID)
+	if len(result.Items) != 2 {
+		t.Fatalf("expected 2 episodes, got %+v", result.Items)
+	}
+	for _, item := range result.Items {
+		if item.Type != "Episode" {
+			t.Fatalf("expected Episode items (not library views), got %q", item.Type)
+		}
+	}
+	if result.Items[0].Name != "Pilot" || result.Items[1].Name != "Second" {
+		t.Fatalf("unexpected episode order/names: %+v", result.Items)
+	}
+}
+
+// TestHandleItems_SeasonParentWithoutRepoIsEmptyNotViews ensures the season-parent
+// path degrades to an empty page (never the library views) when no season repo is
+// wired. countingContentService panics in ListUserLibraries to catch a views
+// fall-through regression.
+func TestHandleItems_SeasonParentWithoutRepoIsEmptyNotViews(t *testing.T) {
+	codec := NewResourceIDCodec()
+	encodedSeasonID := codec.EncodeStringID(EncodedIDSeason, "season-1")
+	h := &ItemsHandler{
+		content:  &countingContentService{},
+		userData: &mockUserDataService{},
+		codec:    codec,
+		mapper:   newMapper(codec, &config.Config{}),
+		images:   NewImageCache(time.Hour, time.Now),
+	}
+
+	result := performItemsRequest(t, h, "/Users/test/Items?ParentId="+encodedSeasonID)
+	if result.TotalRecordCount != 0 || len(result.Items) != 0 {
+		t.Fatalf("expected empty result without season repo, got %+v", result.Items)
+	}
+}
+
+// TestHandleItems_SeasonParentEpisodesPaged pins that the generic season-parent
+// browse path honors StartIndex/Limit (unlike /Shows/{id}/Episodes, which stays
+// whole-season) and reports the full count.
+func TestHandleItems_SeasonParentEpisodesPaged(t *testing.T) {
+	codec := NewResourceIDCodec()
+	seriesContentID := "series-1"
+	seasonContentID := "season-1"
+	encodedSeasonID := codec.EncodeStringID(EncodedIDSeason, seasonContentID)
+	contentSvc := &countingContentService{
+		seasons: []upstreamSeason{{ContentID: seasonContentID, SeasonNumber: 1, Title: "Season 1", EpisodeCount: 3}},
+	}
+	episodeRepo := &fakeSeasonEpisodeRepo{bySeason: map[string][]*models.Episode{
+		episodeBySeasonKey(seriesContentID, 1): {
+			{ContentID: "ep-1", SeriesID: seriesContentID, SeasonID: seasonContentID, SeasonNumber: 1, EpisodeNumber: 1, Title: "E1"},
+			{ContentID: "ep-2", SeriesID: seriesContentID, SeasonID: seasonContentID, SeasonNumber: 1, EpisodeNumber: 2, Title: "E2"},
+			{ContentID: "ep-3", SeriesID: seriesContentID, SeasonID: seasonContentID, SeasonNumber: 1, EpisodeNumber: 3, Title: "E3"},
+		},
+	}}
+	h := &ItemsHandler{
+		content:     contentSvc,
+		userData:    &mockUserDataService{},
+		codec:       codec,
+		mapper:      newMapper(codec, &config.Config{}),
+		images:      NewImageCache(time.Hour, time.Now),
+		episodeRepo: episodeRepo,
+		seasonRepo: &fakeSeasonByIDRepo{seasons: map[string]*models.Season{
+			seasonContentID: {ContentID: seasonContentID, SeriesID: seriesContentID, SeasonNumber: 1},
+		}},
+	}
+
+	result := performItemsRequest(t, h, "/Users/test/Items?ParentId="+encodedSeasonID+"&StartIndex=1&Limit=1")
+	if result.TotalRecordCount != 3 || result.StartIndex != 1 {
+		t.Fatalf("expected total 3 / startIndex 1, got %d / %d", result.TotalRecordCount, result.StartIndex)
+	}
+	if len(result.Items) != 1 || result.Items[0].Name != "E2" {
+		t.Fatalf("expected page [E2], got %+v", result.Items)
+	}
+}
+
+// TestParseItemsQuery_SeasonParentSetsParentSeasonID asserts the parser routes a
+// season ParentId to parentSeasonID while a series (item) ParentId stays in
+// parentItemID — the distinction the new routing relies on.
+func TestParseItemsQuery_SeasonParentSetsParentSeasonID(t *testing.T) {
+	codec := NewResourceIDCodec()
+
+	seasonID := codec.EncodeStringID(EncodedIDSeason, "season-9")
+	q := parseItemsQuery(httptest.NewRequest("GET", "/Items?ParentId="+url.QueryEscape(seasonID), nil), codec)
+	if q.parentSeasonID != "season-9" {
+		t.Fatalf("expected parentSeasonID season-9, got %q", q.parentSeasonID)
+	}
+	if q.parentItemID != "" {
+		t.Fatalf("expected parentItemID empty for a season parent, got %q", q.parentItemID)
+	}
+
+	seriesID := codec.EncodeStringID(EncodedIDItem, "series-9")
+	q = parseItemsQuery(httptest.NewRequest("GET", "/Items?ParentId="+url.QueryEscape(seriesID), nil), codec)
+	if q.parentItemID != "series-9" || q.parentSeasonID != "" {
+		t.Fatalf("expected parentItemID series-9 only, got item=%q season=%q", q.parentItemID, q.parentSeasonID)
+	}
+}

--- a/internal/jellycompat/parent_browse_test.go
+++ b/internal/jellycompat/parent_browse_test.go
@@ -162,6 +162,43 @@ func TestHandleItems_SeasonParentReturnsEpisodes(t *testing.T) {
 	}
 }
 
+// TestHandleItems_SeasonParentNonEpisodeTypeIsEmpty pins that a season ParentId
+// with a type filter that excludes Episode (e.g. Movie) returns an empty page and
+// short-circuits before listing episodes, even though episodes exist.
+func TestHandleItems_SeasonParentNonEpisodeTypeIsEmpty(t *testing.T) {
+	codec := NewResourceIDCodec()
+	seriesContentID := "series-1"
+	seasonContentID := "season-1"
+	encodedSeasonID := codec.EncodeStringID(EncodedIDSeason, seasonContentID)
+	contentSvc := &countingContentService{
+		seasons: []upstreamSeason{{ContentID: seasonContentID, SeasonNumber: 1, Title: "Season 1", EpisodeCount: 1}},
+	}
+	episodeRepo := &fakeSeasonEpisodeRepo{bySeason: map[string][]*models.Episode{
+		episodeBySeasonKey(seriesContentID, 1): {
+			{ContentID: "ep-1", SeriesID: seriesContentID, SeasonID: seasonContentID, SeasonNumber: 1, EpisodeNumber: 1, Title: "E1"},
+		},
+	}}
+	h := &ItemsHandler{
+		content:     contentSvc,
+		userData:    &mockUserDataService{},
+		codec:       codec,
+		mapper:      newMapper(codec, &config.Config{}),
+		images:      NewImageCache(time.Hour, time.Now),
+		episodeRepo: episodeRepo,
+		seasonRepo: &fakeSeasonByIDRepo{seasons: map[string]*models.Season{
+			seasonContentID: {ContentID: seasonContentID, SeriesID: seriesContentID, SeasonNumber: 1},
+		}},
+	}
+
+	result := performItemsRequest(t, h, "/Users/test/Items?ParentId="+encodedSeasonID+"&IncludeItemTypes=Movie")
+	if result.TotalRecordCount != 0 || len(result.Items) != 0 {
+		t.Fatalf("expected empty for Movie type under a season parent, got %+v", result.Items)
+	}
+	if contentSvc.listSeasonsCalls != 0 {
+		t.Fatalf("type guard should short-circuit before episode listing; ListSeasons called %d times", contentSvc.listSeasonsCalls)
+	}
+}
+
 // TestHandleItems_SeasonParentWithoutRepoIsEmptyNotViews ensures the season-parent
 // path degrades to an empty page (never the library views) when no season repo is
 // wired. countingContentService panics in ListUserLibraries to catch a views

--- a/internal/jellycompat/query.go
+++ b/internal/jellycompat/query.go
@@ -20,6 +20,7 @@ type itemsQuery struct {
 	maxOfficialRating      string
 	parentLibraryID        int
 	parentItemID           string
+	parentSeasonID         string
 	parentCollectionID     string
 	specificIDs            []string
 	specificCollectionIDs  []string
@@ -64,6 +65,11 @@ func parseItemsQuery(r *http.Request, codec *ResourceIDCodec) itemsQuery {
 			result.parentLibraryID = int(libraryID)
 		} else if collectionID, collErr := codec.DecodeStringID(EncodedIDCollection, parentID); collErr == nil && collectionID != "" {
 			result.parentCollectionID = collectionID
+		} else if seasonID, seasonErr := codec.DecodeStringID(EncodedIDSeason, parentID); seasonErr == nil && seasonID != "" {
+			// A season ParentId means "list this season's episodes". The codec's
+			// kind tagging already keeps Season and Item IDs distinct; decoding
+			// Season first is defensive in case that separation ever changes.
+			result.parentSeasonID = seasonID
 		} else if contentID, itemErr := decodeItemID(codec, parentID); itemErr == nil && contentID != "" {
 			result.parentItemID = contentID
 		}

--- a/internal/jellycompat/router.go
+++ b/internal/jellycompat/router.go
@@ -70,7 +70,7 @@ func NewRouter(deps Dependencies) chi.Router {
 	} else if deps.DB != nil {
 		subtitleRepo = subtitles.NewPgRepository(deps.DB, deps.SecretCipher)
 	}
-	itemsHandler := NewItemsHandler(deps.ContentService, deps.UserDataService, deps.IDCodec, deps.Config, deps.ImageCache, nextUpRepo, deps.BrowseRepo, deps.PersonRepo, deps.DetailSvc, deps.ItemRepo, deps.EpisodeRepo, deps.AccessFilterFn, subtitleRepo)
+	itemsHandler := NewItemsHandler(deps.ContentService, deps.UserDataService, deps.IDCodec, deps.Config, deps.ImageCache, nextUpRepo, deps.BrowseRepo, deps.PersonRepo, deps.DetailSvc, deps.ItemRepo, deps.EpisodeRepo, deps.SeasonRepo, deps.AccessFilterFn, subtitleRepo)
 	itemsHandler.recommender = deps.Recommender
 	if deps.DB != nil {
 		itemsHandler.collections = catalog.NewLibraryCollectionRepository(deps.DB)


### PR DESCRIPTION
## Problem
Clients that browse a show through the generic `/Items?ParentId=` endpoint **without** `IncludeItemTypes` — e.g. the VoidTV Android-TV client's `getSeasons(seriesId)`/`getEpisodes(seasonId)`, which send `ParentId`+`SortBy=SortName` and no type filter — received the **top-level library views** (CollectionFolders) instead of the series' seasons / the season's episodes.

`HandleItems` only honored an item/season `ParentId` when `IncludeItemTypes=Season` was also present; otherwise `parentItemID` was dropped and the request fell through to the library-views fallback (or a global type browse). On a real Jellyfin server `/Items?ParentId={series}` returns seasons and `/Items?ParentId={season}` returns episodes.

Confirmed live against a production deployment: `/Items?ParentId={series}` and `{season}` both returned the library CollectionFolders, while the dedicated `/Shows/{id}/Seasons|Episodes` routes worked — which is why clients using those dedicated routes were unaffected and only `/Items?ParentId=` browsers (VoidTV) broke.

## Approach
- Decode a season `ParentId` into a dedicated `parentSeasonID` (the codec already kind-tags item vs season ids; decoding season first keeps them distinct).
- Route item/season parents in `HandleItems`:
  - season `ParentId` → that season's episodes
  - series `ParentId` → the series' seasons (default, and explicit `IncludeItemTypes=Season`), or the series' episodes for `IncludeItemTypes=Episode`; a type filter a series can't satisfy (e.g. `Movie`) returns an empty page rather than a wrong-typed listing.
- Extract `writeSeriesEpisodesResponse` as the shared core of `/Shows/{id}/Episodes` and the new browse paths (avoids duplicated logic). The generic `/Items` browse paths honor `StartIndex`/`Limit` (matching the `/Items` contract and the sibling seasons listing); `/Shows/{id}/Episodes` keeps its existing whole-season response.

## Testing
- New `parent_browse_test.go`: series→seasons, season→episodes, unsatisfiable-type-filter→empty, season-parent paging, season-parent-without-repo→empty-not-views, and the parser's season/item `ParentId` distinction. The series/season tests use a content double that panics in `ListUserLibraries`, so a views-fallthrough regression fails the test rather than silently passing.
- `go test ./internal/jellycompat/...`, `go vet`, and `gofmt` are clean, run in a libvips-capable container (the package needs libvips to build).

## Compat
Additive: `/Shows/{id}/Seasons|Episodes` behavior is unchanged; movie/episode `ParentId`s degrade to an empty page (never a 500).

## AI use
Implemented with AI assistance; the diff was reviewed in a separate pass and the tests were run in a Docker toolchain before submitting.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for browsing episodes within seasons
  * Enhanced series navigation to display seasons by default, with option to view episodes directly
  * Improved pagination support for episode listings with accurate record counts and page navigation

<!-- end of auto-generated comment: release notes by coderabbit.ai -->