### PR TITLE
fix(jellycompat): resolve smart-collection BoxSet children at read time

### DIFF
--- a/internal/api/handlers/library_collections.go
+++ b/internal/api/handlers/library_collections.go
@@ -3131,12 +3131,12 @@ func (h *LibraryCollectionHandler) loadLiveCollectionItems(r *http.Request, coll
 
 	switch {
 	case len(collection.LibraryIDs) > 0:
-		def.LibraryIDs = intersectCollectionLibraryIDs(def.LibraryIDs, collection.LibraryIDs)
+		def.LibraryIDs = catalog.IntersectCollectionLibraryIDs(def.LibraryIDs, collection.LibraryIDs)
 		if len(def.LibraryIDs) == 0 {
 			return []itemListResponse{}, nil
 		}
 	case collection.LibraryID > 0:
-		def.LibraryIDs = intersectCollectionLibraryIDs(def.LibraryIDs, []int{collection.LibraryID})
+		def.LibraryIDs = catalog.IntersectCollectionLibraryIDs(def.LibraryIDs, []int{collection.LibraryID})
 		if len(def.LibraryIDs) == 0 {
 			return []itemListResponse{}, nil
 		}
@@ -3175,33 +3175,8 @@ func (e smartCollectionQueryError) Unwrap() error {
 	return e.err
 }
 
-func intersectCollectionLibraryIDs(existing, required []int) []int {
-	if len(required) == 0 {
-		return append([]int(nil), existing...)
-	}
-	if len(existing) == 0 {
-		return append([]int(nil), required...)
-	}
-
-	allowed := make(map[int]struct{}, len(required))
-	for _, id := range required {
-		allowed[id] = struct{}{}
-	}
-
-	result := make([]int, 0, len(existing))
-	seen := make(map[int]struct{}, len(existing))
-	for _, id := range existing {
-		if _, ok := allowed[id]; !ok {
-			continue
-		}
-		if _, ok := seen[id]; ok {
-			continue
-		}
-		seen[id] = struct{}{}
-		result = append(result, id)
-	}
-	return result
-}
+// intersectCollectionLibraryIDs moved to catalog.IntersectCollectionLibraryIDs
+// so the web API and the Jellyfin-compat resolver share one implementation.
 
 func (h *LibraryCollectionHandler) toItemListResponse(r *http.Request, item *models.MediaItem) itemListResponse {
 	resp := itemListResponse{

--- a/internal/catalog/collection_type.go
+++ b/internal/catalog/collection_type.go
@@ -17,3 +17,35 @@ func IsSyncableType(collectionType string) bool {
 		return false
 	}
 }
+
+// IntersectCollectionLibraryIDs narrows a smart collection's query library scope
+// (existing) to the libraries the collection is bound to (required), returning a
+// copy of the other set when one side is empty. Shared by the web API and the
+// Jellyfin-compat collection-item resolvers so their scoping stays identical.
+func IntersectCollectionLibraryIDs(existing, required []int) []int {
+	if len(required) == 0 {
+		return append([]int(nil), existing...)
+	}
+	if len(existing) == 0 {
+		return append([]int(nil), required...)
+	}
+
+	allowed := make(map[int]struct{}, len(required))
+	for _, id := range required {
+		allowed[id] = struct{}{}
+	}
+
+	result := make([]int, 0, len(existing))
+	seen := make(map[int]struct{}, len(existing))
+	for _, id := range existing {
+		if _, ok := allowed[id]; !ok {
+			continue
+		}
+		if _, ok := seen[id]; ok {
+			continue
+		}
+		seen[id] = struct{}{}
+		result = append(result, id)
+	}
+	return result
+}

--- a/internal/jellycompat/handlers_collections.go
+++ b/internal/jellycompat/handlers_collections.go
@@ -2,7 +2,9 @@ package jellycompat
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
+	"log/slog"
 	"net/http"
 	"sort"
 	"strings"
@@ -18,6 +20,13 @@ type collectionSource interface {
 	ListAll(ctx context.Context, libraryID *int, opts catalog.ListLibraryCollectionsOptions) ([]*models.LibraryCollection, error)
 	GetByID(ctx context.Context, id string) (*models.LibraryCollection, error)
 	ListItems(ctx context.Context, collectionID string) ([]*models.LibraryCollectionItem, error)
+}
+
+// smartCollectionQueryExecutor resolves a smart (live-query) collection's members
+// at read time. Backed by *catalog.QueryExecutor in production; an interface so
+// the BoxSet children path is unit-testable without a database.
+type smartCollectionQueryExecutor interface {
+	Preview(ctx context.Context, def catalog.QueryDefinition, access catalog.AccessFilter, limit int) ([]*models.MediaItem, int, error)
 }
 
 // visibleLibraryIDSet returns the set of library IDs the session may see on
@@ -290,14 +299,28 @@ func (h *ItemsHandler) handleBoxSetChildren(w http.ResponseWriter, r *http.Reque
 		return
 	}
 
-	members, err := h.collections.ListItems(r.Context(), collection.ID)
-	if err != nil {
-		writeCompatUpstreamError(w, err)
-		return
-	}
-	contentIDs := make([]string, 0, len(members))
-	for _, member := range members {
-		contentIDs = append(contentIDs, member.MediaItemID)
+	// Smart (live-query) collections derive membership from a query at read
+	// time and store no rows in library_collection_items, so ListItems returns
+	// nothing for them — that previously left smart-collection BoxSets showing a
+	// non-zero ChildCount but no browsable children. Resolve them via the query
+	// executor; stored collections keep the materialized ListItems path.
+	var contentIDs []string
+	if catalog.IsLiveQueryType(collection.CollectionType) {
+		contentIDs, err = h.smartCollectionContentIDs(r.Context(), session, collection)
+		if err != nil {
+			writeCompatUpstreamError(w, err)
+			return
+		}
+	} else {
+		members, listErr := h.collections.ListItems(r.Context(), collection.ID)
+		if listErr != nil {
+			writeCompatUpstreamError(w, listErr)
+			return
+		}
+		contentIDs = make([]string, 0, len(members))
+		for _, member := range members {
+			contentIDs = append(contentIDs, member.MediaItemID)
+		}
 	}
 	if len(contentIDs) == 0 {
 		writeJSON(w, http.StatusOK, emptyQueryResult(query.startIndex))
@@ -359,4 +382,66 @@ func (h *ItemsHandler) writeCollectionItemsPage(w http.ResponseWriter, r *http.R
 		TotalRecordCount: total,
 		StartIndex:       query.startIndex,
 	})
+}
+
+// smartCollectionContentIDs resolves a live-query (smart) collection's members
+// at read time, mirroring the web API's loadLiveCollectionItems. The returned
+// content IDs are in the smart query's own order and access-filtered for the
+// session; the caller reuses the same hydration path as stored collections. A
+// malformed or invalid query definition degrades to no children rather than an
+// error so a single bad collection never 500s a browse.
+func (h *ItemsHandler) smartCollectionContentIDs(ctx context.Context, session *Session, c *models.LibraryCollection) ([]string, error) {
+	if h.queryExecutor == nil {
+		return nil, nil
+	}
+
+	var def catalog.QueryDefinition
+	if len(c.QueryDefinition) > 0 {
+		if err := json.Unmarshal(c.QueryDefinition, &def); err != nil {
+			slog.DebugContext(ctx, "jellycompat smart collection query definition unmarshal failed",
+				"collection_id", c.ID, "error", err)
+			return nil, nil
+		}
+	}
+	def = def.Normalize()
+	if err := def.ValidateWithOptions(false, false); err != nil {
+		slog.DebugContext(ctx, "jellycompat smart collection query definition invalid",
+			"collection_id", c.ID, "error", err)
+		return nil, nil
+	}
+	def = catalog.ApplySmartCollectionItemLimit(def)
+
+	switch {
+	case len(c.LibraryIDs) > 0:
+		def.LibraryIDs = catalog.IntersectCollectionLibraryIDs(def.LibraryIDs, c.LibraryIDs)
+		if len(def.LibraryIDs) == 0 {
+			return nil, nil
+		}
+	case c.LibraryID > 0:
+		def.LibraryIDs = catalog.IntersectCollectionLibraryIDs(def.LibraryIDs, []int{c.LibraryID})
+		if len(def.LibraryIDs) == 0 {
+			return nil, nil
+		}
+	}
+
+	access := h.resolveAccessFilter(ctx, session)
+	items, total, err := h.queryExecutor.Preview(ctx, def, access, 1)
+	if err != nil {
+		return nil, err
+	}
+	if total == 0 {
+		return nil, nil
+	}
+	if total > len(items) {
+		items, _, err = h.queryExecutor.Preview(ctx, def, access, total)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	contentIDs := make([]string, 0, len(items))
+	for _, item := range items {
+		contentIDs = append(contentIDs, item.ContentID)
+	}
+	return contentIDs, nil
 }

--- a/internal/jellycompat/handlers_items.go
+++ b/internal/jellycompat/handlers_items.go
@@ -43,7 +43,10 @@ type ItemsHandler struct {
 	recommender  recommendations.Recommender
 	// collections is optional; when set, library collections are exposed as
 	// Jellyfin BoxSets. posterPresigner/presignTTL resolve their artwork keys.
-	collections     collectionSource
+	collections collectionSource
+	// queryExecutor is optional; when set, smart (live-query) collections
+	// resolve their BoxSet children at read time instead of from stored items.
+	queryExecutor   smartCollectionQueryExecutor
 	posterPresigner LibraryPosterPresigner
 	presignTTL      time.Duration
 	// FileResolver is optional; when set, /MediaSegments returns real intro/

--- a/internal/jellycompat/router.go
+++ b/internal/jellycompat/router.go
@@ -74,6 +74,9 @@ func NewRouter(deps Dependencies) chi.Router {
 	itemsHandler.recommender = deps.Recommender
 	if deps.DB != nil {
 		itemsHandler.collections = catalog.NewLibraryCollectionRepository(deps.DB)
+		// Smart (live-query) collections derive membership at read time, so the
+		// BoxSet children path needs a query executor to resolve them.
+		itemsHandler.queryExecutor = &catalog.QueryExecutor{Pool: deps.DB}
 	}
 	itemsHandler.posterPresigner = deps.PosterPresigner
 	itemsHandler.presignTTL = deps.PresignTTL

--- a/internal/jellycompat/smart_boxset_test.go
+++ b/internal/jellycompat/smart_boxset_test.go
@@ -1,0 +1,136 @@
+package jellycompat
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+
+	"github.com/Silo-Server/silo-server/internal/catalog"
+	"github.com/Silo-Server/silo-server/internal/models"
+)
+
+// fakeSmartExecutor is a smartCollectionQueryExecutor double returning a fixed
+// member list, mimicking catalog.QueryExecutor.Preview's two-call contract
+// (limit=1 probe, then limit=total).
+type fakeSmartExecutor struct {
+	items        []*models.MediaItem
+	previewCalls int
+	gotDef       catalog.QueryDefinition
+}
+
+func (f *fakeSmartExecutor) Preview(_ context.Context, def catalog.QueryDefinition, _ catalog.AccessFilter, limit int) ([]*models.MediaItem, int, error) {
+	f.previewCalls++
+	f.gotDef = def
+	total := len(f.items)
+	if limit < total {
+		return f.items[:limit], total, nil
+	}
+	return f.items, total, nil
+}
+
+// TestHandleItems_SmartBoxSetChildrenResolveViaQuery pins the Wholphin fix: a
+// smart (live-query) collection's BoxSet children resolve through the query
+// executor in the collection's own order, instead of returning empty because
+// nothing is materialized in library_collection_items.
+func TestHandleItems_SmartBoxSetChildrenResolveViaQuery(t *testing.T) {
+	collections := &fakeCollectionSource{
+		collections: []*models.LibraryCollection{
+			{ID: "201", LibraryID: 1, Title: "Directed by X", Visibility: "visible", CollectionType: "smart", ItemCount: 2, QueryDefinition: json.RawMessage(`{}`)},
+		},
+		// No materialized items: smart collections store none.
+	}
+	exec := &fakeSmartExecutor{items: []*models.MediaItem{
+		{ContentID: "m-1", Type: "movie", Title: "Kill Bill"},
+		{ContentID: "m-2", Type: "movie", Title: "Pulp Fiction"},
+	}}
+	itemRepo := &fakeBatchItemRepo{items: map[string]*models.MediaItem{
+		"m-1": {ContentID: "m-1", Type: "movie", Title: "Kill Bill"},
+		"m-2": {ContentID: "m-2", Type: "movie", Title: "Pulp Fiction"},
+	}}
+	h := newCollectionsTestHandler(collections, []upstreamUserLibrary{{ID: 1, Name: "Movies", Type: "movies"}}, itemRepo)
+	h.queryExecutor = exec
+
+	parentID := h.codec.EncodeStringID(EncodedIDCollection, "201")
+	result := performItemsRequest(t, h, "/Items?ParentId="+parentID)
+	if len(result.Items) != 2 {
+		t.Fatalf("expected 2 smart-collection children, got %d: %+v", len(result.Items), result.Items)
+	}
+	if result.Items[0].Name != "Kill Bill" || result.Items[1].Name != "Pulp Fiction" {
+		t.Fatalf("expected smart query order, got %q,%q", result.Items[0].Name, result.Items[1].Name)
+	}
+	if result.Items[0].ParentID != parentID {
+		t.Fatalf("expected ParentId %s, got %s", parentID, result.Items[0].ParentID)
+	}
+	if exec.previewCalls == 0 {
+		t.Fatal("expected the query executor to be consulted for a smart collection")
+	}
+}
+
+// TestHandleItems_SmartBoxSetChildrenWithoutExecutorEmpty ensures a smart
+// collection degrades to an empty page (never a 500) when no executor is wired.
+func TestHandleItems_SmartBoxSetChildrenWithoutExecutorEmpty(t *testing.T) {
+	collections := &fakeCollectionSource{
+		collections: []*models.LibraryCollection{
+			{ID: "201", LibraryID: 1, Title: "Directed by X", Visibility: "visible", CollectionType: "smart", ItemCount: 5, QueryDefinition: json.RawMessage(`{}`)},
+		},
+	}
+	h := newCollectionsTestHandler(collections, []upstreamUserLibrary{{ID: 1, Name: "Movies", Type: "movies"}}, nil)
+	// queryExecutor intentionally left nil.
+
+	parentID := h.codec.EncodeStringID(EncodedIDCollection, "201")
+	result := performItemsRequest(t, h, "/Items?ParentId="+parentID)
+	if result.TotalRecordCount != 0 || len(result.Items) != 0 {
+		t.Fatalf("expected graceful empty result without executor, got %+v", result.Items)
+	}
+}
+
+// TestHandleItems_SmartBoxSetChildrenIntersectLibraryScope asserts the query's
+// own library_ids are intersected with the collection's bound libraries before
+// the executor runs, so a restricted collection cannot widen its scope.
+func TestHandleItems_SmartBoxSetChildrenIntersectLibraryScope(t *testing.T) {
+	collections := &fakeCollectionSource{
+		collections: []*models.LibraryCollection{
+			{ID: "202", LibraryIDs: []int{1, 2}, Title: "Scoped", Visibility: "visible", CollectionType: "smart", ItemCount: 1, QueryDefinition: json.RawMessage(`{"library_ids":[2,3]}`)},
+		},
+	}
+	exec := &fakeSmartExecutor{items: []*models.MediaItem{{ContentID: "m-1", Type: "movie", Title: "Only Two"}}}
+	itemRepo := &fakeBatchItemRepo{items: map[string]*models.MediaItem{"m-1": {ContentID: "m-1", Type: "movie", Title: "Only Two"}}}
+	h := newCollectionsTestHandler(collections, []upstreamUserLibrary{
+		{ID: 1, Name: "Movies", Type: "movies"},
+		{ID: 2, Name: "Foreign", Type: "movies"},
+	}, itemRepo)
+	h.queryExecutor = exec
+
+	parentID := h.codec.EncodeStringID(EncodedIDCollection, "202")
+	result := performItemsRequest(t, h, "/Items?ParentId="+parentID)
+	if len(result.Items) != 1 || result.Items[0].Name != "Only Two" {
+		t.Fatalf("expected the single resolved child, got %+v", result.Items)
+	}
+	// query library_ids [2,3] ∩ collection [1,2] = [2].
+	if len(exec.gotDef.LibraryIDs) != 1 || exec.gotDef.LibraryIDs[0] != 2 {
+		t.Fatalf("expected executor to receive intersected library scope [2], got %v", exec.gotDef.LibraryIDs)
+	}
+}
+
+// TestHandleItems_SmartBoxSetMalformedQueryEmpty asserts a malformed query
+// definition degrades to an empty page and never consults the executor (so it
+// can never 500 a browse).
+func TestHandleItems_SmartBoxSetMalformedQueryEmpty(t *testing.T) {
+	collections := &fakeCollectionSource{
+		collections: []*models.LibraryCollection{
+			{ID: "203", LibraryID: 1, Title: "Broken", Visibility: "visible", CollectionType: "smart", ItemCount: 9, QueryDefinition: json.RawMessage(`{bad`)},
+		},
+	}
+	exec := &fakeSmartExecutor{items: []*models.MediaItem{{ContentID: "m-1", Type: "movie", Title: "Nope"}}}
+	h := newCollectionsTestHandler(collections, []upstreamUserLibrary{{ID: 1, Name: "Movies", Type: "movies"}}, nil)
+	h.queryExecutor = exec
+
+	parentID := h.codec.EncodeStringID(EncodedIDCollection, "203")
+	result := performItemsRequest(t, h, "/Items?ParentId="+parentID)
+	if result.TotalRecordCount != 0 || len(result.Items) != 0 {
+		t.Fatalf("expected empty result for malformed query definition, got %+v", result.Items)
+	}
+	if exec.previewCalls != 0 {
+		t.Fatalf("executor must not run for a malformed query definition; got %d calls", exec.previewCalls)
+	}
+}


### PR DESCRIPTION
## Problem
Browsing **into** a smart (live-query) collection via `/Items?ParentId={boxsetId}` returned **0 children** even though the BoxSet's `ChildCount` showed a non-zero count (e.g. a "Directed by Quentin Tarantino" collection reporting 14 items but listing none).

`handleBoxSetChildren` resolved members only from the materialized `library_collection_items` table (`ListItems`). Smart collections store **no** rows there — their membership is a query evaluated at read time — so `ListItems` returned empty while `ChildCount` (the stored item count) stayed non-zero.

Confirmed live against a production deployment: smart "Directed by …" collections returned `TotalRecordCount: 0` when browsed, while materialized collections (e.g. IMDb Top 250) returned their items correctly.

## Approach
- Branch `handleBoxSetChildren` on `catalog.IsLiveQueryType(collection.CollectionType)`:
  - **smart** → resolve members through the query executor in `smartCollectionContentIDs`, mirroring the web API's `loadLiveCollectionItems`: `Normalize` → `ValidateWithOptions(false,false)` → `ApplySmartCollectionItemLimit` → library-scope intersection → access-filtered `Preview` (limit=1 probe, then limit=total). The resolved content IDs feed the **same** hydration/paging path as stored collections, preserving the smart query's order.
  - **materialized** → unchanged `ListItems` path.
- A malformed or invalid query definition degrades to an empty page (debug-logged), never a 500 — appropriate for a browse surface.
- Access filtering uses the session-scoped filter, so library-restricted users only see members in libraries they can access.
- Hoist the duplicated `intersectCollectionLibraryIDs` helper into `catalog.IntersectCollectionLibraryIDs` so the web handler and the compat resolver share one implementation (the repo guidelines flag cross-file duplication).

## Testing
- New `smart_boxset_test.go`: smart children resolve in the query's order via an injected executor; the query's `library_ids` are intersected with the collection's bound libraries before the executor runs; malformed-query and no-executor cases degrade to an empty page without consulting/▶ crashing.
- `go test ./internal/jellycompat/... ./internal/catalog/...`, `go vet` (jellycompat + catalog + api/handlers), `go build ./...`, and `gofmt` are clean, run in a libvips-capable container.

## Compat
Additive. Materialized-collection browsing is unchanged; the web API's behavior is unchanged (same algorithm, now via the shared catalog helper).

## AI use
Implemented with AI assistance; the diff was reviewed in a separate pass and the tests were run in a Docker toolchain before submitting.