### PR TITLE
fix(web): start autoplay countdown when entering post-roll early

### DIFF
--- a/web/src/playback/WatchPlaybackChrome.tsx
+++ b/web/src/playback/WatchPlaybackChrome.tsx
@@ -775,6 +775,12 @@ export function WatchPlaybackHost() {
         snapshot.duration - snapshot.currentTime <= POST_ROLL_SECONDS_BEFORE_END
       ) {
         postRollEnteredRef.current = true;
+        // Entering post-roll early pauses the underlying video to stop HLS from
+        // buffering the tail segment (see VideoPlayer's post-roll pause effect).
+        // A paused video never fires `ended`, so we must arm the autoplay
+        // countdown here rather than waiting for an `ended` event that will
+        // never arrive — otherwise the overlay shows but the countdown stalls.
+        setPostRollVideoEnded(true);
         controller.enterPostRoll(requestKeyValue);
       }
     },


### PR DESCRIPTION
## Problem

On a series episode, the web player enters **post-roll** ~30s before the end and **pauses** the underlying video (intentional — `VideoPlayer`'s post-roll effect pauses to stop HLS buffering the tail segment). However, the auto-play countdown in `PlayingNextScreen` is gated on `postRollVideoEnded`, which is only set to `true` on the native `ended` event.

A paused video never fires `ended`, so:
- The "Up Next" overlay appears with the video paused.
- The countdown **never starts** and auto-play never fires.
- It only proceeds if the user manually resumes the video, letting it reach the end and emit `ended`.

Reported symptom (Silo Web, Win11/Firefox): *"Picture-in-picture video pauses on transition to auto-play screen. Countdown for auto-play never starts. Will start working if you manually resume the video."* — the player pauses exactly 30s before the end.

## Approach

Arm the countdown gate (`setPostRollVideoEnded(true)`) at the moment we enter post-roll early in `handlePlaybackStateChange`, rather than waiting for an `ended` event that an intentionally-paused video will never emit. Entering post-roll early is the point at which we've decided playback is effectively over, so that is the correct moment to start the countdown. The existing `ended`-driven and fallback paths are unchanged.

One-file change in `web/src/playback/WatchPlaybackChrome.tsx`.

## Testing

- `cd web && pnpm run lint` — 0 errors
- `cd web && pnpm run format:check` — clean
- `make verify-local-paths` — clean
- `tsc -b` — clean
- `pnpm test` — playback/WatchRoute suites pass (the 5 failing `ServerStorageStep` tests are a pre-existing `ResizeObserver is not defined` env issue, confirmed failing on clean `main`, unrelated to this change)

Note: verified statically and via the test suite; not yet exercised in a live browser session against a running deployment.

## Risk / scope

Bug fix, behavior-only, no API or schema changes. Auto-play for movies (no `series_id`) is unaffected — the early post-roll trigger only fires for series episodes.

Out of scope: a separate `404 GET /api/v1/catalog/items/{id}` symptom observed in the same report (next-item detail lookup) is not addressed here; this PR fixes the countdown stall only.

## AI-use disclosure

This change was implemented with AI assistance (Claude). The diff was reviewed and the reasoning/tradeoffs are as described above.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed post-roll overlay autoplay countdown that would stall when entering post-roll early (within 30 seconds of the end of a series episode). The countdown timer now displays and initiates properly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->