### PR TITLE
fix(jellycompat): reuse the play session for Static direct play instead of leaking one per request

### DIFF
--- a/internal/jellycompat/audio_selection_test.go
+++ b/internal/jellycompat/audio_selection_test.go
@@ -22,6 +22,7 @@ type testCompatSessionManager struct {
 	audioTrackCalls []compatAudioTrackCall
 	progressCalls   int
 	stopCalls       []string
+	startCalls      int
 }
 
 type compatAudioTrackCall struct {
@@ -31,6 +32,7 @@ type compatAudioTrackCall struct {
 }
 
 func (m *testCompatSessionManager) StartSession(userID int, profileID string, fileID int, method playback.PlayMethod, transcodeAudio bool) (*playback.Session, error) {
+	m.startCalls++
 	session := &playback.Session{
 		ID:             "upstream-started",
 		UserID:         userID,

--- a/internal/jellycompat/playback_static_directplay_test.go
+++ b/internal/jellycompat/playback_static_directplay_test.go
@@ -121,6 +121,33 @@ func TestHandleVideoStream_NoStaticNoSessionReturns404(t *testing.T) {
 	}
 }
 
+// TestHandleVideoStream_StaticDirectPlayReusesSessionAcrossRequests proves the
+// ghost-session fix: a Static=true direct play repeats the client's own
+// (server-unknown) PlaySessionId on every range request. These must reuse one
+// upstream session via route lookup instead of minting a fresh, separately
+// stream-capped session per request — the leak that piled up orphaned sessions
+// and tripped the per-user stream limit (429). StartSession must run exactly
+// once across the repeated requests.
+func TestHandleVideoStream_StaticDirectPlayReusesSessionAcrossRequests(t *testing.T) {
+	handler, encodedID, body := newStaticDirectPlayHandler(t)
+	mgr := handler.sessionMgr.(*testCompatSessionManager)
+
+	const clientPlaySessionID = "client-generated-psid"
+	for i := 0; i < 3; i++ {
+		rec := serveStaticStream(handler, encodedID, "Static=true&PlaySessionId="+clientPlaySessionID)
+		if rec.Code != 200 {
+			t.Fatalf("request %d: expected 200; got %d, body=%s", i, rec.Code, rec.Body.String())
+		}
+		if got := rec.Body.String(); got != body {
+			t.Fatalf("request %d: expected file content %q; got %q", i, body, got)
+		}
+	}
+
+	if mgr.startCalls != 1 {
+		t.Fatalf("StartSession ran %d times across 3 Static requests with the same PlaySessionId; want 1 (sessions must be reused, not leaked)", mgr.startCalls)
+	}
+}
+
 // serveStaticStream issues a GET /Videos/{id}/stream with the given raw query
 // (no leading "?"), the chi "id" route param, and a compat session in context.
 func serveStaticStream(handler *PlaybackHandler, encodedID, rawQuery string) *httptest.ResponseRecorder {

--- a/internal/jellycompat/streams.go
+++ b/internal/jellycompat/streams.go
@@ -1177,15 +1177,21 @@ func (h *PlaybackHandler) createStaticPlaySession(ctx context.Context, session *
 
 func (h *PlaybackHandler) resolvePlaybackRoute(r *http.Request, compatSession *Session, routeID, mediaSourceID string) (*PlaybackSession, *PlaybackMediaSource, error) {
 	if playSessionID := newCaseInsensitiveQuery(r.URL.Query()).Get("PlaySessionId"); playSessionID != "" {
-		playSession, ok := h.playbackStore.Get(playSessionID)
-		if !ok || playSession.CompatToken != compatSession.Token {
-			return nil, nil, ErrSessionNotFound
+		if playSession, ok := h.playbackStore.Get(playSessionID); ok && playSession.CompatToken == compatSession.Token {
+			if mediaSourceID != "" {
+				source := findMediaSource(playSession, mediaSourceID)
+				return playSession, source, nil
+			}
+			return playSession, firstMediaSource(playSession), nil
 		}
-		if mediaSourceID != "" {
-			source := findMediaSource(playSession, mediaSourceID)
-			return playSession, source, nil
-		}
-		return playSession, firstMediaSource(playSession), nil
+		// The PlaySessionId is unknown to us (the client never called PlaybackInfo,
+		// so it is the client's own id) or belongs to another caller. Fall through
+		// to route-based reuse below instead of erroring: a Static=true direct play
+		// repeats this same client id on every range request, and minting a fresh,
+		// separately stream-capped upstream session each time piles up orphaned
+		// sessions that trip the per-user stream limit (429). Route reuse keeps one
+		// session per direct play. (Reuse stays scoped to this caller's CompatToken
+		// via FindByRoute, so a guessed/foreign id cannot bind another user's session.)
 	}
 
 	playSession, source, ok := h.playbackStore.FindByRoute(compatSession.Token, routeID)


### PR DESCRIPTION
## Problem

Clients that direct-play via `GET /Videos/{id}/stream?…&Static=true` never call
`PlaybackInfo`, so they send their own client-generated `PlaySessionId` and repeat
it on every byte-range request. `resolvePlaybackRoute` looked that id up, missed
(the server never minted it), returned `ErrSessionNotFound`, and `HandleVideoStream`
fell to `createStaticPlaySession` → a **new upstream session for every request**.

Each new session counts toward the per-user `max_streams` cap and only ages out
after the 45s activity grace, so a single direct play's range requests pile up
orphaned sessions and quickly trip the cap → `429 TooManyStreams`, locking the
user out of their own playback. (Confirmed in real traffic: one playback's
`PlaySessionId` repeated 160+ times, each request minting a fresh session.)

## Approach

When the provided `PlaySessionId` is unknown (or owned by another caller), fall
through to the existing CompatToken-scoped `FindByRoute` reuse instead of
erroring, so all of a direct play's requests share one session. Reuse stays scoped
to the caller's own token, so a guessed/foreign id cannot bind another user's
session.

## Scope / what this does and doesn't do

- Fixes the **per-request leak** (N sessions per direct play → 1).
- Does **not** change the cap itself: 6+ *genuinely distinct* titles played within
  the 45s grace still legitimately hit `max_streams` (real concurrency, not a
  leak; `activeCountLocked` has no per-item dedup).
- The fall-through applies to any `/Videos/{id}/stream` (and the subtitle path)
  with an unknown `PlaySessionId`, not strictly `Static=true`. This is safe: the
  play method is recomputed per-request from the resolved source's
  direct-play/stream flags, `ensureUpstreamPlayback` restarts the upstream session
  on a method mismatch, and reuse is CompatToken-scoped. Transcode/HLS manifest +
  segment handlers resolve sessions via `playbackStore.Get` directly and are
  unaffected.

## Testing

- New `TestHandleVideoStream_StaticDirectPlayReusesSessionAcrossRequests` asserts
  `StartSession` runs exactly once across 3 repeated Static requests carrying the
  same client `PlaySessionId`. Mutation-verified (revert → 3 calls → RED).
- Existing Static-serve and no-Static-404 tests still pass.
- `gofmt`/`go vet` clean; full `internal/jellycompat` suite green in the
  libvips-capable container.

---
*AI-assisted: root-caused from production jellycompat request captures and reviewed
across regression / security / effectiveness passes; every line reviewed, and the
tests run and mutation-verified, by me.*
