### PR TITLE
fix(metadata): limit episode refresh debt so the Refresh Metadata task can finish draining

### DIFF
--- a/internal/metadata/refresh_debt.go
+++ b/internal/metadata/refresh_debt.go
@@ -1,6 +1,7 @@
 package metadata
 
 import (
+	"log/slog"
 	"strings"
 	"time"
 
@@ -38,6 +39,48 @@ func hasRefreshDebtReason(mask, reason int64) bool {
 	return mask&reason != 0
 }
 
+const (
+	// refreshDebtEpisodeTerminalAttempts is the number of fruitless attempts after
+	// which episode-incomplete debt is treated as "the provider has no data" and given
+	// up on: demoted off the priority-300 band and re-checked only rarely. We give up
+	// fast — with the stepped backoff below (1d, 1d, 3d, ...) attempt 3 lands after
+	// ~5 days of trying. This is safe because operators can force an immediate re-check
+	// anytime via the library "refresh incomplete" / per-item refresh endpoints, and
+	// because media_items.episode_metadata_incomplete is left untouched so those paths
+	// still find the item.
+	refreshDebtEpisodeTerminalAttempts = 3
+	// refreshDebtTerminalPriority sorts terminal debt below the default band (100) so it
+	// never front-runs legitimately-due content.
+	refreshDebtTerminalPriority = 50
+	// refreshDebtTerminalDelay is the rare automatic safety re-check for terminal debt,
+	// so late-arriving provider data is eventually picked up without operator action.
+	refreshDebtTerminalDelay = 90 * 24 * time.Hour
+)
+
+// isTerminalEpisodeDebt reports that an episode-incomplete debt row has exhausted its
+// attempts and almost certainly cannot be improved by another provider fetch. The signal
+// is purely the persistent attempt_count on the row: resolved rows are deleted, so a row
+// that still exists with a high attempt count has been re-processed many times without
+// ever completing.
+func isTerminalEpisodeDebt(reasonMask int64, attemptCount int) bool {
+	return attemptCount >= refreshDebtEpisodeTerminalAttempts &&
+		hasRefreshDebtReason(reasonMask, RefreshDebtReasonEpisodeIncomplete)
+}
+
+// effectiveRefreshDebtPriority demotes terminal episode-incomplete debt off the priority-300
+// band. If the row also carries a still-fixable reason it falls to that reason's band (not
+// the floor), so a series with real core/provider-id debt keeps refreshing at the right
+// cadence; pure episode-incomplete debt falls to the terminal floor.
+func effectiveRefreshDebtPriority(reasonMask int64, attemptCount int) int {
+	if isTerminalEpisodeDebt(reasonMask, attemptCount) {
+		if demoted := reasonMask &^ RefreshDebtReasonEpisodeIncomplete; demoted != 0 {
+			return refreshDebtPriority(demoted)
+		}
+		return refreshDebtTerminalPriority
+	}
+	return refreshDebtPriority(reasonMask)
+}
+
 func refreshDebtPriority(reasonMask int64) int {
 	switch {
 	case hasRefreshDebtReason(reasonMask, RefreshDebtReasonEpisodeIncomplete):
@@ -56,6 +99,13 @@ func refreshDebtPriority(reasonMask int64) int {
 }
 
 func nextRefreshDelay(reasonMask int64, attemptCount int) time.Duration {
+	// Only pure episode-incomplete debt is parked on the rare terminal cadence. If the row
+	// also carries a still-fixable reason, that reason keeps driving the normal backoff (the
+	// priority demotion in effectiveRefreshDebtPriority handles the queue ordering).
+	if isTerminalEpisodeDebt(reasonMask, attemptCount) &&
+		reasonMask&^RefreshDebtReasonEpisodeIncomplete == 0 {
+		return refreshDebtTerminalDelay
+	}
 	if hasRefreshDebtReason(reasonMask, RefreshDebtReasonEpisodeIncomplete) {
 		switch {
 		case attemptCount <= 1:
@@ -87,6 +137,21 @@ func nextRefreshDelay(reasonMask int64, attemptCount int) time.Duration {
 
 func nextRefreshAtForDebt(reasonMask int64, attemptCount int, now time.Time) time.Time {
 	return now.Add(nextRefreshDelay(reasonMask, attemptCount))
+}
+
+// logRefreshDebtTerminal emits a one-time notice when an episode-incomplete debt row first
+// crosses into the terminal give-up state, so the demotion is observable in logs rather
+// than silent. Logging on the exact transition attempt keeps it to a single line per row.
+func logRefreshDebtTerminal(targetType, contentID string, reasonMask int64, attemptCount int) {
+	if attemptCount == refreshDebtEpisodeTerminalAttempts &&
+		isTerminalEpisodeDebt(reasonMask, attemptCount) {
+		slog.Warn("metadata: episode-incomplete refresh debt reached terminal attempts; demoting off top priority",
+			"target_type", NormalizeRefreshTargetType(targetType),
+			"content_id", contentID,
+			"attempt_count", attemptCount,
+			"reason_mask", reasonMask,
+		)
+	}
 }
 
 func refreshDebtReasonsForItem(item *models.MediaItem) int64 {

--- a/internal/metadata/refresh_debt_test.go
+++ b/internal/metadata/refresh_debt_test.go
@@ -105,17 +105,88 @@ func TestNextRefreshDelayEpisodeSchedule(t *testing.T) {
 		attempts int
 		want     time.Duration
 	}{
+		// Stepped backoff up to the terminal cap...
 		{attempts: 0, want: 24 * time.Hour},
 		{attempts: 1, want: 24 * time.Hour},
 		{attempts: 2, want: 3 * 24 * time.Hour},
-		{attempts: 3, want: 7 * 24 * time.Hour},
-		{attempts: 4, want: 14 * 24 * time.Hour},
-		{attempts: 5, want: 30 * 24 * time.Hour},
+		// ...then we give up: episode-incomplete debt goes terminal at attempt 3+.
+		{attempts: 3, want: refreshDebtTerminalDelay},
+		{attempts: 4, want: refreshDebtTerminalDelay},
+		{attempts: 5, want: refreshDebtTerminalDelay},
 	}
 
 	for _, tc := range cases {
 		if got := nextRefreshDelay(reasonMask, tc.attempts); got != tc.want {
 			t.Fatalf("attempts=%d delay=%s want %s", tc.attempts, got, tc.want)
 		}
+	}
+}
+
+func TestNextRefreshDelayNonEpisodeScheduleUnaffected(t *testing.T) {
+	// Non-episode reasons keep the full stepped backoff and never go terminal.
+	reasonMask := RefreshDebtReasonCoreMetadataIncomplete
+	cases := []struct {
+		attempts int
+		want     time.Duration
+	}{
+		{attempts: 2, want: 3 * 24 * time.Hour},
+		{attempts: 3, want: 7 * 24 * time.Hour},
+		{attempts: 4, want: 14 * 24 * time.Hour},
+		{attempts: 5, want: 30 * 24 * time.Hour},
+	}
+	for _, tc := range cases {
+		if got := nextRefreshDelay(reasonMask, tc.attempts); got != tc.want {
+			t.Fatalf("attempts=%d delay=%s want %s", tc.attempts, got, tc.want)
+		}
+	}
+}
+
+func TestNextRefreshDelayTerminalOnlyWhenPureEpisodeDebt(t *testing.T) {
+	// Pure episode-incomplete debt at/over the cap is parked on the rare terminal cadence.
+	if got := nextRefreshDelay(RefreshDebtReasonEpisodeIncomplete, refreshDebtEpisodeTerminalAttempts); got != refreshDebtTerminalDelay {
+		t.Fatalf("pure terminal delay = %s, want %s", got, refreshDebtTerminalDelay)
+	}
+	// Episode-incomplete + a still-fixable reason keeps the normal backoff, not 90d, so the
+	// fixable reason is not parked for a quarter of a year.
+	combined := RefreshDebtReasonEpisodeIncomplete | RefreshDebtReasonRefreshFailure
+	if got := nextRefreshDelay(combined, refreshDebtEpisodeTerminalAttempts); got == refreshDebtTerminalDelay {
+		t.Fatalf("mixed-reason delay must not use the terminal cadence, got %s", got)
+	}
+}
+
+func TestIsTerminalEpisodeDebt(t *testing.T) {
+	if isTerminalEpisodeDebt(RefreshDebtReasonEpisodeIncomplete, refreshDebtEpisodeTerminalAttempts-1) {
+		t.Fatalf("debt below the attempt cap must not be terminal")
+	}
+	if !isTerminalEpisodeDebt(RefreshDebtReasonEpisodeIncomplete, refreshDebtEpisodeTerminalAttempts) {
+		t.Fatalf("episode-incomplete debt at the attempt cap must be terminal")
+	}
+	if isTerminalEpisodeDebt(RefreshDebtReasonCoreMetadataIncomplete, refreshDebtEpisodeTerminalAttempts+5) {
+		t.Fatalf("non-episode debt must never be terminal regardless of attempts")
+	}
+}
+
+func TestEffectiveRefreshDebtPriorityDemotesTerminalEpisodeDebt(t *testing.T) {
+	threshold := refreshDebtEpisodeTerminalAttempts
+
+	// Below the cap: pure episode-incomplete debt keeps the top priority band.
+	if got := effectiveRefreshDebtPriority(RefreshDebtReasonEpisodeIncomplete, threshold-1); got != 300 {
+		t.Fatalf("pre-terminal episode priority = %d, want 300", got)
+	}
+
+	// At/over the cap: pure episode-incomplete debt falls to the terminal floor.
+	if got := effectiveRefreshDebtPriority(RefreshDebtReasonEpisodeIncomplete, threshold); got != refreshDebtTerminalPriority {
+		t.Fatalf("terminal episode priority = %d, want %d", got, refreshDebtTerminalPriority)
+	}
+
+	// At/over the cap with a still-fixable reason: falls to that reason's band, not the floor.
+	combined := RefreshDebtReasonEpisodeIncomplete | RefreshDebtReasonProviderIDIncomplete
+	if got := effectiveRefreshDebtPriority(combined, threshold); got != 240 {
+		t.Fatalf("terminal episode+provider priority = %d, want provider band 240", got)
+	}
+
+	// Non-episode debt is never demoted.
+	if got := effectiveRefreshDebtPriority(RefreshDebtReasonCoreMetadataIncomplete, threshold+5); got != 150 {
+		t.Fatalf("core metadata priority = %d, want 150", got)
 	}
 }

--- a/internal/metadata/service.go
+++ b/internal/metadata/service.go
@@ -2015,10 +2015,11 @@ func (s *MetadataService) syncRefreshDebtForItem(ctx context.Context, contentID 
 		return err
 	}
 	now := time.Now().UTC()
+	logRefreshDebtTerminal(RefreshTargetItem, contentID, reasonMask, attemptCount)
 	return s.refreshDebtRepo.MarkSuccess(
 		ctx,
 		contentID,
-		refreshDebtPriority(reasonMask),
+		effectiveRefreshDebtPriority(reasonMask, attemptCount),
 		reasonMask,
 		nextRefreshAtForDebt(reasonMask, attemptCount, now),
 	)
@@ -2066,11 +2067,12 @@ func (s *MetadataService) syncRefreshDebtForSeason(ctx context.Context, seasonID
 	if err != nil {
 		return err
 	}
+	logRefreshDebtTerminal(RefreshTargetSeason, seasonID, reasonMask, attemptCount)
 	return s.refreshDebtRepo.MarkTargetSuccess(
 		ctx,
 		RefreshTargetSeason,
 		seasonID,
-		refreshDebtPriority(reasonMask),
+		effectiveRefreshDebtPriority(reasonMask, attemptCount),
 		reasonMask,
 		nextRefreshAtForDebt(reasonMask, attemptCount, now),
 	)
@@ -2099,11 +2101,12 @@ func (s *MetadataService) syncRefreshDebtForEpisode(ctx context.Context, episode
 	if err != nil {
 		return err
 	}
+	logRefreshDebtTerminal(RefreshTargetEpisode, episodeID, reasonMask, attemptCount)
 	return s.refreshDebtRepo.MarkTargetSuccess(
 		ctx,
 		RefreshTargetEpisode,
 		episodeID,
-		refreshDebtPriority(reasonMask),
+		effectiveRefreshDebtPriority(reasonMask, attemptCount),
 		reasonMask,
 		nextRefreshAtForDebt(reasonMask, attemptCount, now),
 	)
@@ -2154,10 +2157,11 @@ func (s *MetadataService) syncRefreshDebtFailure(ctx context.Context, contentID 
 		attemptCount++
 	}
 	now := time.Now().UTC()
+	logRefreshDebtTerminal(RefreshTargetItem, contentID, reasonMask, attemptCount)
 	return s.refreshDebtRepo.MarkFailure(
 		ctx,
 		contentID,
-		refreshDebtPriority(reasonMask),
+		effectiveRefreshDebtPriority(reasonMask, attemptCount),
 		reasonMask,
 		nextRefreshAtForDebt(reasonMask, attemptCount, now),
 		attemptCount,
@@ -2183,11 +2187,12 @@ func (s *MetadataService) syncRefreshDebtTargetFailure(ctx context.Context, targ
 		attemptCount++
 	}
 	now := time.Now().UTC()
+	logRefreshDebtTerminal(targetType, contentID, reasonMask, attemptCount)
 	return s.refreshDebtRepo.MarkTargetFailure(
 		ctx,
 		targetType,
 		contentID,
-		refreshDebtPriority(reasonMask),
+		effectiveRefreshDebtPriority(reasonMask, attemptCount),
 		reasonMask,
 		nextRefreshAtForDebt(reasonMask, attemptCount, now),
 		attemptCount,
@@ -3632,11 +3637,12 @@ func (s *MetadataService) syncVisibleEpisodeRefreshDebt(ctx context.Context, epi
 	if err != nil {
 		return err
 	}
+	logRefreshDebtTerminal(RefreshTargetEpisode, episode.ContentID, reasonMask, attemptCount)
 	return s.refreshDebtRepo.MarkTargetSuccess(
 		ctx,
 		RefreshTargetEpisode,
 		episode.ContentID,
-		refreshDebtPriority(reasonMask),
+		effectiveRefreshDebtPriority(reasonMask, attemptCount),
 		reasonMask,
 		nextRefreshAtForDebt(reasonMask, attemptCount, now.UTC()),
 	)


### PR DESCRIPTION
## Problem

**The Refresh Metadata task never finishes draining, and a handful of "unfixable" shows keep jumping the line.** On the dev-silo stack the scheduled *Refresh Metadata* task crawled — the queue held a permanent floor of debt that never reached zero, no matter how long it ran.

The cause was a small set of TV episodes that the metadata provider simply has **no data for** — not just a missing translation, but no title at all. Silo correctly flags such an episode as "incomplete metadata," but there was no point at which it gave up: every cycle it re-checked the same episode, the provider returned nothing again, and the episode stayed flagged. Worse, a single one of these episodes marked its **entire series** as the highest-urgency item in the queue. So those few poisoned series permanently sat at the front of the line, re-running a full refresh ahead of fresh, legitimately-due content — forever, and without ever making progress, because the data they were waiting for does not exist.

The net effect an operator saw: the Refresh Metadata queue depth never settled to empty, and the same shows churned at the top of the work order indefinitely.

This pairs with the already-merged plugin change (`silo-plugin-tvdb` PR #2) that batched the per-episode translation requests; that fix removed the HTTP-volume/timeout problem, and this fix removes the remaining "queue never drains" problem.

## Solution

### fix(metadata): cap un-completable episode refresh debt as terminal

Refresh work is tracked in `metadata_refresh_debt`, one row per item/season/episode, each with a persistent `attempt_count`. A row that resolves is deleted, so a row that **still exists with a high attempt count** is, by definition, one that has been re-tried many times and never completed — that is the "the provider has no data" signal, and it needs no schema change.

New logic in `internal/metadata/refresh_debt.go`:

- `isTerminalEpisodeDebt(reasonMask, attemptCount)` — true once an episode-incomplete row reaches `refreshDebtEpisodeTerminalAttempts` (3, ~5 days under the existing stepped backoff). We give up fast deliberately.
- `effectiveRefreshDebtPriority` — demotes terminal episode-incomplete debt **off the priority-300 band**. If the row also carries a still-fixable reason (core metadata / provider-id), it falls to *that* reason's band so the item keeps refreshing normally; pure episode-incomplete debt falls to a terminal floor (`refreshDebtTerminalPriority = 50`).
- `nextRefreshDelay` — a *pure* terminal row re-checks rarely (`refreshDebtTerminalDelay = 90d`) as a cheap automatic safety net for late-arriving data. A row that also has a fixable reason keeps the normal backoff, so it is never parked for a quarter-year while a real reason waits.
- `logRefreshDebtTerminal` — one `slog.Warn` on the transition attempt, so the demotion is observable, not silent.

These are routed through every debt **success** and **failure** sync path that can carry episode-incomplete debt: `syncRefreshDebtForItem`, `syncRefreshDebtForSeason`, `syncRefreshDebtForEpisode`, `syncVisibleEpisodeRefreshDebt`, `syncRefreshDebtFailure`, `syncRefreshDebtTargetFailure` (all in `internal/metadata/service.go`). The viewer-triggered nudge `RequestStaleMetadataRefresh` (`service.go:1837`) is intentionally left at full priority — it is a one-shot, cooldown-gated, human-driven re-check.

**Why demote instead of delete:** deleting a terminal row does not make the problem go away — the next series pass calls `syncVisibleEpisodeRefreshDebt`, which recreates the row at `attempt_count = 0` and restarts the whole give-up cycle. Keeping the row preserves the attempt count across passes, so terminal stays terminal.

**Why giving up fast is safe:** the force-refresh path already exists and bypasses the backoff (it calls `MetadataService.Process` directly, not the debt claimer):
- Library "refresh incomplete" — `POST /api/v1/libraries/{id}/refresh-metadata` (quick mode), whose selector (`internal/adminjob/library_refresh.go`) explicitly includes `episode_metadata_incomplete = TRUE`.
- Per-item — `POST /api/v1/admin/items/{id}/refresh-metadata`.

This change leaves `media_items.episode_metadata_incomplete` untouched, so those operator paths still find terminal items on demand; new episode files re-seed naturally via the scanner's initial-match pass.

No schema change (`attempt_count` already exists). No `/api/v1` contract change.

## Risk / follow-ups

- **Recent-still false-positive (more likely with the fast cap).** `EpisodeHasActionableMetadataDebt` also fires for a recently-aired episode (<45d) missing its still image. With the cap at ~5 days, such an episode can go terminal before its still lands; it then waits for the 90-day safety re-check (or an operator force-refresh) rather than auto-filling inside the 45-day window. Judged acceptable given the explicit give-up-fast goal and the always-available force path. Tunable via the named constants.
- **Reversibility.** Demotion keeps the `reason_mask` bit + a 90-day auto re-check and leaves `episode_metadata_incomplete` set — no episode is permanently abandoned.
- **Threshold tuning.** `refreshDebtEpisodeTerminalAttempts` (3), `refreshDebtTerminalPriority` (50), and `refreshDebtTerminalDelay` (90d) are named constants; tune after dev-silo measurement.
- **Deferred (out of scope):** Step 1 from the architecture doc (incremental Phase 4b fetch — skip already-complete episodes) is now only a DB-write efficiency gain since the plugin captured the HTTP/timeout win; filed as a follow-up. The per-item timeout (Step 3) is left at 2 minutes (verification only).

## Verification

- `go test ./internal/metadata/` — pass. New/updated unit tests in `internal/metadata/refresh_debt_test.go`:
  - `TestNextRefreshDelayEpisodeSchedule` — pure episode-incomplete goes terminal (90d) at attempt 3+.
  - `TestNextRefreshDelayNonEpisodeScheduleUnaffected` — non-episode reasons keep the full stepped backoff.
  - `TestNextRefreshDelayTerminalOnlyWhenPureEpisodeDebt` — episode + fixable reason keeps normal backoff, not 90d.
  - `TestIsTerminalEpisodeDebt` / `TestEffectiveRefreshDebtPriorityDemotesTerminalEpisodeDebt` — cap boundary, floor demotion, fall-to-other-reason, non-episode never demoted.
- `go vet ./internal/metadata/` — clean. `gofmt -l internal/metadata/*.go` — no diffs.
- `make migrate-status` shows no new migration (confirms no schema change).
- Note: `golangci-lint` is not installed in this environment, so `make lint` could not be run locally; `go vet` and `gofmt` are clean.
- Suggested dev-silo re-measure (post-plugin + this change): completed entities per 10 min, that queue depth **drains** instead of holding a floor, and that the set of `attempt_count >= 3 AND reason_mask & 1 = 1` rows stabilizes.

## AI-use disclosure

Implemented with AI assistance (Claude Code): codebase exploration, design, implementation, and tests. Reviewed by the author.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Implemented terminal state handling for items that fail to complete after multiple attempts, with extended refresh delays and automatic deprioritization
  * Added logging visibility when items reach terminal give-up state

* **Tests**
  * Expanded test coverage for terminal delay scheduling, priority demotion, and edge case behaviors

<!-- end of auto-generated comment: release notes by coderabbit.ai -->