### PR TITLE
Reinforce the first-profile empty state layout

### DIFF
--- a/web/src/pages/Profiles.tsx
+++ b/web/src/pages/Profiles.tsx
@@ -81,21 +81,25 @@ export default function Profiles() {
   if (profiles.length === 0) {
     return (
       <div className="auth-shell flex-col gap-6">
-        <div className="w-full max-w-md space-y-3 text-center">
-          <h1 className="page-title text-[clamp(2.1rem,6vw,4rem)]">Create your first profile</h1>
-          <p className="text-muted-foreground text-sm">
-            You need a profile before you can enter the app.
-          </p>
+        <div className="relative z-10 flex flex-col items-center gap-6">
+          <div className="w-full max-w-md space-y-3 text-center">
+            <h1 className="page-title text-[clamp(2.1rem,6vw,4rem)]">
+              Create your first profile
+            </h1>
+            <p className="text-muted-foreground text-sm">
+              You need a profile before you can enter the app.
+            </p>
+          </div>
+
+          <Button onClick={() => setEditorOpen(true)}>
+            <Plus className="h-4 w-4" />
+            Create profile
+          </Button>
+
+          <Button variant="outline" size="sm" onClick={logout}>
+            Sign out
+          </Button>
         </div>
-
-        <Button onClick={() => setEditorOpen(true)}>
-          <Plus className="h-4 w-4" />
-          Create profile
-        </Button>
-
-        <Button variant="outline" size="sm" onClick={logout}>
-          Sign out
-        </Button>
 
         <ProfileEditorDialog
           open={editorOpen}


### PR DESCRIPTION
## Summary
- Wrap the empty-state content in a positioned container so it sits cleanly within the auth shell
- Keep the create-profile and sign-out actions grouped with the headline and supporting copy

## Testing
- Not run (not requested)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Improved the visual layout of the empty profiles view by enhancing centering and spacing of the profile creation prompt and associated action buttons through DOM structure adjustments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->