### PR TITLE
Fix episodes season index migration

### DIFF
--- a/migrations/episodes_season_id_index_test.go
+++ b/migrations/episodes_season_id_index_test.go
@@ -1,0 +1,24 @@
+package migrations
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestEpisodesSeasonIDIndexMigrationWrapsDollarQuotedBlock(t *testing.T) {
+	migrationBytes, err := FS.ReadFile("sql/20260618164519_add_episodes_season_id_index.sql")
+	if err != nil {
+		t.Fatalf("read migration: %v", err)
+	}
+
+	migration := string(migrationBytes)
+	for _, want := range []string{
+		"-- +goose StatementBegin\nDO $$",
+		"END;\n$$;\n-- +goose StatementEnd",
+		"CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_episodes_season_id_episode_number",
+	} {
+		if !strings.Contains(migration, want) {
+			t.Fatalf("migration missing %q", want)
+		}
+	}
+}

--- a/migrations/sql/20260618164519_add_episodes_season_id_index.sql
+++ b/migrations/sql/20260618164519_add_episodes_season_id_index.sql
@@ -5,6 +5,7 @@
 -- episodes.season_id, while the existing episode index is keyed by
 -- (series_id, season_number, episode_number). On large catalogs this forced a
 -- parallel scan of the full episodes table for each season page load.
+-- +goose StatementBegin
 DO $$
 BEGIN
     IF EXISTS (
@@ -18,10 +19,11 @@ BEGIN
     ) THEN
         DROP INDEX public.idx_episodes_season_id_episode_number;
     END IF;
-END
+END;
 $$;
+-- +goose StatementEnd
 
-CREATE INDEX CONCURRENTLY idx_episodes_season_id_episode_number
+CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_episodes_season_id_episode_number
 ON public.episodes USING btree (season_id, episode_number);
 
 -- +goose Down


### PR DESCRIPTION
## Summary
- wrap the dollar-quoted DO block in goose StatementBegin/StatementEnd so goose does not split the PL/pgSQL block
- add the missing END; terminator inside the DO block
- make the concurrent index creation idempotent for retry after a failed migration
- add a migration test covering the goose block structure

## Test
- GOCACHE=/Users/jimcole/projects/silo/silo-server/.cache/go-build go test ./migrations

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added verification tests for database migrations to ensure proper execution.

* **Chores**
  * Enhanced database migration robustness by improving SQL statement handling and making index creation idempotent.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->