### PR TITLE
fix(collections): correct multi-library sync — match all bound libraries and dedupe items

### DIFF
--- a/internal/api/handlers/library_collections.go
+++ b/internal/api/handlers/library_collections.go
@@ -1564,6 +1564,7 @@ func (h *LibraryCollectionHandler) HandleSyncAdminCollection(w http.ResponseWrit
 			writeError(w, http.StatusBadRequest, "bad_request", err.Error())
 			return
 		}
+		slog.Error("collection sync failed", "collection_id", collectionID, "error", err)
 		writeError(w, http.StatusInternalServerError, "internal_error", "Failed to sync collection")
 		return
 	}

--- a/internal/catalog/library_collection_repo.go
+++ b/internal/catalog/library_collection_repo.go
@@ -732,14 +732,29 @@ func (r *LibraryCollectionRepository) ReplaceItems(ctx context.Context, collecti
 		return fmt.Errorf("clearing collection items: %w", err)
 	}
 
+	// Dedupe by media_item_id before inserting. Different source entries can
+	// resolve to the same library item (e.g. an IMDb and a TMDB entry pointing
+	// at the same local content_id, or one item present in several of the
+	// collection's bound folders), and library_collection_items has a composite
+	// PK (collection_id, media_item_id). Inserting the same media_item_id twice
+	// would raise a duplicate-key violation that fails the whole sync. First
+	// occurrence wins, preserving rank order. Position is renumbered over the
+	// surviving rows so it stays dense.
+	seen := make(map[string]struct{}, len(items))
+	position := 0
 	for _, item := range items {
+		if _, dup := seen[item.MediaItemID]; dup {
+			continue
+		}
+		seen[item.MediaItemID] = struct{}{}
 		if _, err := tx.Exec(ctx, `
 			INSERT INTO library_collection_items (
 				collection_id, media_item_id, position, source_rank
 			) VALUES ($1, $2, $3, $4)
-		`, collectionID, item.MediaItemID, item.Position, item.SourceRank); err != nil {
+		`, collectionID, item.MediaItemID, position, item.SourceRank); err != nil {
 			return fmt.Errorf("inserting collection item %s: %w", item.MediaItemID, err)
 		}
+		position++
 	}
 
 	if _, err := tx.Exec(ctx, "UPDATE library_collections SET updated_at = NOW() WHERE id = $1", collectionID); err != nil {

--- a/internal/catalog/library_collection_service.go
+++ b/internal/catalog/library_collection_service.go
@@ -334,7 +334,7 @@ func (s *LibraryCollectionService) syncMDBListCollection(ctx context.Context, co
 	// Single batched library membership query covering EVERY candidate across
 	// all entries (preserves the libraryID filter from the legacy
 	// resolveMDBListEntry).
-	libraryMembers, err := s.libraryItems.GetItemsInFolder(ctx, candidateIDs, collection.LibraryID)
+	libraryMembers, err := s.libraryItems.GetItemsInFolders(ctx, candidateIDs, collection.LibraryIDs)
 	if err != nil {
 		return nil, err
 	}
@@ -350,7 +350,7 @@ func (s *LibraryCollectionService) syncMDBListCollection(ctx context.Context, co
 		scannedEntries = index + 1
 		r, ok := resolvedByIndex[index]
 		if !ok {
-			warnings = append(warnings, fmt.Sprintf("No match in library %d for %s", collection.LibraryID, entry.Title))
+			warnings = append(warnings, fmt.Sprintf("No match in libraries %v for %s", collection.LibraryIDs, entry.Title))
 			continue
 		}
 		var chosen string
@@ -361,7 +361,7 @@ func (s *LibraryCollectionService) syncMDBListCollection(ctx context.Context, co
 			}
 		}
 		if chosen == "" {
-			warnings = append(warnings, fmt.Sprintf("No match in library %d for %s", collection.LibraryID, entry.Title))
+			warnings = append(warnings, fmt.Sprintf("No match in libraries %v for %s", collection.LibraryIDs, entry.Title))
 			continue
 		}
 		matchedItems = append(matchedItems, LibraryCollectionItemInput{
@@ -469,7 +469,7 @@ func (s *LibraryCollectionService) syncTMDBPresetCollection(ctx context.Context,
 
 	for i, entry := range results {
 		scannedEntries = i + 1
-		item, err := s.resolveTMDBEntry(ctx, collection.LibraryID, entry)
+		item, err := s.resolveTMDBEntry(ctx, collection.LibraryIDs, entry)
 		if err != nil {
 			return nil, err
 		}
@@ -483,7 +483,7 @@ func (s *LibraryCollectionService) syncTMDBPresetCollection(ctx context.Context,
 				"tvdb_id", entry.TVDBID,
 			)
 			unmatchedCount++
-			warnings = append(warnings, fmt.Sprintf("No match in library %d for %s", collection.LibraryID, entry.Title))
+			warnings = append(warnings, fmt.Sprintf("No match in libraries %v for %s", collection.LibraryIDs, entry.Title))
 			continue
 		}
 		if firstRank, exists := seenContentIDs[item.ContentID]; exists {
@@ -633,7 +633,7 @@ func (s *LibraryCollectionService) syncTMDBFranchiseCollection(ctx context.Conte
 
 	for i, entry := range results {
 		scannedEntries = i + 1
-		item, err := s.resolveTMDBEntry(ctx, collection.LibraryID, entry)
+		item, err := s.resolveTMDBEntry(ctx, collection.LibraryIDs, entry)
 		if err != nil {
 			return nil, err
 		}
@@ -645,7 +645,7 @@ func (s *LibraryCollectionService) syncTMDBFranchiseCollection(ctx context.Conte
 				"imdb_id", entry.IMDbID,
 			)
 			unmatchedCount++
-			warnings = append(warnings, fmt.Sprintf("No match in library %d for %s", collection.LibraryID, entry.Title))
+			warnings = append(warnings, fmt.Sprintf("No match in libraries %v for %s", collection.LibraryIDs, entry.Title))
 			continue
 		}
 		if firstRank, exists := seenContentIDs[item.ContentID]; exists {
@@ -808,7 +808,7 @@ func (s *LibraryCollectionService) syncTMDBDiscoverCollection(ctx context.Contex
 
 	for i, entry := range results {
 		scannedEntries = i + 1
-		item, err := s.resolveTMDBEntry(ctx, collection.LibraryID, entry)
+		item, err := s.resolveTMDBEntry(ctx, collection.LibraryIDs, entry)
 		if err != nil {
 			return nil, err
 		}
@@ -822,7 +822,7 @@ func (s *LibraryCollectionService) syncTMDBDiscoverCollection(ctx context.Contex
 				"tvdb_id", entry.TVDBID,
 			)
 			unmatchedCount++
-			warnings = append(warnings, fmt.Sprintf("No match in library %d for %s", collection.LibraryID, entry.Title))
+			warnings = append(warnings, fmt.Sprintf("No match in libraries %v for %s", collection.LibraryIDs, entry.Title))
 			continue
 		}
 		if firstRank, exists := seenContentIDs[item.ContentID]; exists {
@@ -970,13 +970,13 @@ func (s *LibraryCollectionService) syncTraktPresetCollection(ctx context.Context
 
 	for i, entry := range results {
 		scannedEntries = i + 1
-		item, err := s.resolveTraktEntry(ctx, collection.LibraryID, entry)
+		item, err := s.resolveTraktEntry(ctx, collection.LibraryIDs, entry)
 		if err != nil {
 			return nil, err
 		}
 		if item == nil {
 			unmatchedCount++
-			warnings = append(warnings, fmt.Sprintf("No match in library %d for %s", collection.LibraryID, entry.Title))
+			warnings = append(warnings, fmt.Sprintf("No match in libraries %v for %s", collection.LibraryIDs, entry.Title))
 			continue
 		}
 		if firstRank, exists := seenContentIDs[item.ContentID]; exists {
@@ -1066,7 +1066,7 @@ func (s *LibraryCollectionService) recordFailedCollectionSync(ctx context.Contex
 
 // resolveTMDBEntry finds a media item in the library matching a TMDB preset entry.
 // It tries TMDB ID, IMDb ID, and TVDB ID (for TV shows) to maximize match rate.
-func (s *LibraryCollectionService) resolveTMDBEntry(ctx context.Context, libraryID int, entry TMDBCollectionEntry) (*models.MediaItem, error) {
+func (s *LibraryCollectionService) resolveTMDBEntry(ctx context.Context, libraryIDs []int, entry TMDBCollectionEntry) (*models.MediaItem, error) {
 	itemType := "movie"
 	if entry.MediaType == "tv" {
 		itemType = "series"
@@ -1089,7 +1089,7 @@ func (s *LibraryCollectionService) resolveTMDBEntry(ctx context.Context, library
 		return nil, nil
 	}
 
-	membership, err := s.libraryItems.GetItemsInFolder(ctx, []string{item.ContentID}, libraryID)
+	membership, err := s.libraryItems.GetItemsInFolders(ctx, []string{item.ContentID}, libraryIDs)
 	if err != nil {
 		return nil, err
 	}
@@ -1101,7 +1101,7 @@ func (s *LibraryCollectionService) resolveTMDBEntry(ctx context.Context, library
 }
 
 // resolveTraktEntry finds a local item matching a Trakt discovery entry.
-func (s *LibraryCollectionService) resolveTraktEntry(ctx context.Context, libraryID int, entry TraktCollectionEntry) (*models.MediaItem, error) {
+func (s *LibraryCollectionService) resolveTraktEntry(ctx context.Context, libraryIDs []int, entry TraktCollectionEntry) (*models.MediaItem, error) {
 	itemType := "movie"
 	if entry.MediaType == "tv" {
 		itemType = "series"
@@ -1125,7 +1125,7 @@ func (s *LibraryCollectionService) resolveTraktEntry(ctx context.Context, librar
 		return nil, nil
 	}
 
-	membership, err := s.libraryItems.GetItemsInFolder(ctx, candidates, libraryID)
+	membership, err := s.libraryItems.GetItemsInFolders(ctx, candidates, libraryIDs)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Two commits, both correcting collection sync: one fixes which libraries are matched, the second hardens the write path against a duplicate-key 500 that the first commit makes more likely.

## Problem

**1. Collection sync silently dropped items from all but one library.**
A collection can be bound to several libraries (for example a "Netflix Originals"
collection spanning both the movie and series libraries). On the admin/library
collections view, such a collection listed and opened correctly — but every time it
ran a scheduled or manual **sync**, its membership collapsed down to just one library's
matches. Operators saw collections that opened with ~161 items shrink to ~50 after a
sync, with the entire other class (e.g. all the series) disappearing. Worst hit were the
cross-class merged collections where the surviving "legacy" library was a single
movie-only or series-only folder, so a whole media class vanished.

**2. Some collections became permanently un-syncable, with no error in the logs.**
A single collection could start returning a generic failure on *every* sync — HTTP 500,
0 items, in ~250ms, with **no error or warning line on the server**. Through the CDN it
rendered as a misleading "524 - A Timeout Occurred" page, so it looked like a network
timeout rather than an application error. It was data-dependent, so it surfaced
unpredictably as catalogs grew (on dev, 1 of 50 collections hit it). The multi-library
union in the first fix widens the set of matched items, which makes this failure *more*
likely to appear.

## Solution

### fix(collections): sync matches across all bound libraries

Collections were historically 1:1 with a library via the legacy
`library_collections.library_id`. Migration 015 added the N:N membership table
`library_collection_libraries`; the **listing** and **catalog open** read paths were
already updated to use it, and `GetByID` already populates `collection.LibraryIDs` from
the N:N table (falling back to `[LibraryID]` when empty —
`internal/catalog/library_collection_repo.go:169`). Only the **sync** path was left
matching against the single legacy `collection.LibraryID`, so `ReplaceItems` (a full
overwrite) rebuilt membership from just one library.

The fix routes every sync matcher through the already-existing multi-folder helper
`LibraryItemRepository.GetItemsInFolders` (`internal/catalog/library_repo.go:164`,
`media_folder_id = ANY($1)`) and threads `collection.LibraryIDs` through the resolvers,
all in `internal/catalog/library_collection_service.go`:

- MDBList path: `syncMDBListCollection` membership query now uses
  `GetItemsInFolders(ctx, candidateIDs, collection.LibraryIDs)`
  (`library_collection_service.go:337`).
- `resolveTMDBEntry` (`:1069`) and `resolveTraktEntry` (`:1104`) take `libraryIDs []int`
  and call `GetItemsInFolders` internally (`:1092`, `:1128`).
- All four call sites (tmdb_preset `:472`, tmdb_franchise `:636`, tmdb_discover `:811`,
  trakt_preset `:973`) pass `collection.LibraryIDs`.
- "No match" warning strings updated to print the library set (`%v` over `LibraryIDs`).

Because `GetByID` guarantees `LibraryIDs` contains at least the legacy id, single-library
collections are byte-for-byte unaffected. No schema change.

This unblocks merging the duplicated per-library collections into single multi-library
collections.

### fix(collections): dedupe matched items by media_item_id before ReplaceItems

Each sync resolves source entries (external IDs) to library `content_id`s and appends one
`LibraryCollectionItemInput{MediaItemID: <content_id>}` per matched entry, **without
deduping by `MediaItemID`**. When two *different* source entries resolve to the *same*
library item — a remake/duplicate listing, one entry matched by IMDb and another by TMDB
pointing at the same local item, or (post-union) the same item present in more than one of
the collection's bound folders — the same `content_id` is appended twice.

`library_collection_items` has a composite primary key
`(collection_id, media_item_id)` (`migrations/sql/001_schema.sql:1302`).
`ReplaceItems` (`internal/catalog/library_collection_repo.go:724`) inserts each row
individually, so the second insert of a colliding `media_item_id` raises a duplicate-key
violation that fails the whole transaction. All five sync paths
(`syncMDBListCollection`, `syncTMDBPresetCollection`, `syncTMDBFranchiseCollection`,
`syncTMDBDiscoverCollection`, `syncTraktPresetCollection`) share the pattern.

The fix dedupes at the single choke point in `ReplaceItems`: a `seen` set skips repeated
`media_item_id`s (first occurrence wins, preserving rank order), and `position` is
renumbered over the surviving rows so it stays dense. This covers all five paths at once
and is why it lives in the repo rather than each matcher.

Separately, `HandleSyncAdminCollection`
(`internal/api/handlers/library_collections.go:1559`) mapped every non-sentinel sync
error to a generic 500 **and logged nothing**, which is why this was invisible on the
server. It now `slog.Error`s the underlying error with the collection id before returning
the 500.

**Why bundle the two fixes:** they touch the same five sync functions and the same
`ReplaceItems` write path, the branch is unmerged, and the first commit's multi-library
union directly increases the duplicate-collision rate the second commit defends against —
so shipping the union without the dedupe guard would ship a partial regression.

## Risk / follow-ups

- `HandleGetLibraryCollectionItems` (`internal/api/handlers/library_collections.go`) still
  gates on `collection.LibraryID != libraryID`. Only the pinned-collection carousel
  consumes it and it hides the rail silently on 404 — converting that to a membership
  check is a low-priority follow-up, out of scope here.
- Retiring the legacy `library_id` column's role entirely is a larger change, deferred.
- Deduping in `ReplaceItems` means `position` is renumbered over survivors; any caller
  relying on positions matching the pre-dedupe input slice would see denser values. No
  current caller does.
- The collection-maker cron currently retries syncs at a reduced limit on a 500 as a
  lossy workaround for the dedupe bug; that workaround should be removed now this is fixed.
- No new unit test was added for the union path: `items`/`libraryItems` are concrete
  DB-backed repositories (not interfaces), so a meaningful test requires a Postgres
  integration harness that does not yet exist in this package. Existing single-library
  tests cover the `LibraryIDs == [LibraryID]` path and stay green.

## Verification

- `go build ./internal/catalog/... ./internal/api/handlers/...`
- `go vet ./internal/catalog/...`
- `go test ./internal/catalog/...` (passes)
- Manual diff review against the change spec; confirmed no remaining
  `GetItemsInFolder`/`collection.LibraryID` references in the sync matchers, and that the
  dedupe path preserves rank order and dense positions.
- Original repro for the dedupe 500: an mdblist list whose 76–100 matched range contained
  a collider returned 500 at `limit=100` and 200 at `limit<=75`; with the fix it syncs to
  N-1 distinct items without error.

## AI-use disclosure

Implemented with AI assistance (Claude) from a human-authored handoff spec and bug report.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved library-collection syncing to match items across multiple library folders/IDs for external sources (TMDB, Trakt, MDB), ensuring “no match” and membership checks work with multi-library configurations.
* **Bug Fixes**
  * Improved collection item replacement by deduplicating duplicate entries by media item and restoring consistent sequential item ordering.
* **Observability**
  * Enhanced error logging during admin sync failures with collection context for easier troubleshooting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->