### PR TITLE
fix(ebooks): improve metadata search query and MOBI/AZW author extraction

### DIFF
--- a/internal/ebooks/enrichment.go
+++ b/internal/ebooks/enrichment.go
@@ -827,9 +827,11 @@ var ebookYearOnlyRE = regexp.MustCompile(`^\s*(19|20)\d{2}\s*$`)
 func cleanEbookSearchTitle(title, author string) string {
 	title = strings.ReplaceAll(title, "_", " ")
 	if a := strings.TrimSpace(author); a != "" {
-		if idx := strings.LastIndex(strings.ToLower(title), " - "+strings.ToLower(a)); idx >= 0 {
-			title = title[:idx]
-		}
+		// Strip the author only when it is a true trailing suffix (optionally
+		// followed by a series/volume parenthetical). Anchoring to the end avoids
+		// truncating valid title text when " - <author>" appears mid-title.
+		authorSuffixRE := regexp.MustCompile(`(?i)\s-\s*` + regexp.QuoteMeta(a) + `(?:\s*[\(\[][^)\]]*[\)\]])*\s*$`)
+		title = authorSuffixRE.ReplaceAllString(title, "")
 	}
 	// Normalize trailing series/edition parentheticals. A bare year ("(2019)")
 	// is dropped because SearchQuery.Year already carries it. A series/volume

--- a/internal/ebooks/enrichment.go
+++ b/internal/ebooks/enrichment.go
@@ -11,6 +11,7 @@ import (
 	"log/slog"
 	"os"
 	"reflect"
+	"regexp"
 	"strconv"
 	"strings"
 	"sync"
@@ -776,12 +777,34 @@ func filterEbookPeople(people []models.ItemPerson) []models.ItemPerson {
 // path-fallback titles keep a trailing " - <Author>" segment. Both wreck a
 // title search, so collapse underscores to spaces and drop a trailing author
 // suffix (the author is searched as its own field).
+// ebookTrailingGroupRE matches a single trailing (...) or [...] group.
+var ebookTrailingGroupRE = regexp.MustCompile(`\s*[\(\[]([^\)\]]*)[\)\]]\s*$`)
+
+// ebookSeriesNoiseRE flags a parenthetical as series/edition noise rather than
+// part of the real title: a book/volume/part marker, a "#N", or a bare year.
+var ebookSeriesNoiseRE = regexp.MustCompile(`(?i)\b(book|bk|vol|volume|series|part|saga|edition|novella?)\b|#\s*\d|^\s*\d{1,4}\s*$|\b(19|20)\d{2}\b`)
+
 func cleanEbookSearchTitle(title, author string) string {
 	title = strings.ReplaceAll(title, "_", " ")
 	if a := strings.TrimSpace(author); a != "" {
 		if idx := strings.LastIndex(strings.ToLower(title), " - "+strings.ToLower(a)); idx >= 0 {
 			title = title[:idx]
 		}
+	}
+	// Strip trailing series/book-number parentheticals ("(The Raven Brothers
+	// Book 4)", "[#3]", "(2019)") that wreck provider title search. Only groups
+	// matching the noise pattern are removed, so meaningful parentheticals in a
+	// real title survive. Loop to peel stacked groups.
+	for {
+		m := ebookTrailingGroupRE.FindStringSubmatch(title)
+		if m == nil || !ebookSeriesNoiseRE.MatchString(m[1]) {
+			break
+		}
+		stripped := strings.TrimSpace(title[:len(title)-len(m[0])])
+		if stripped == "" {
+			break // never reduce the title to nothing
+		}
+		title = stripped
 	}
 	return strings.Join(strings.Fields(title), " ")
 }

--- a/internal/ebooks/enrichment.go
+++ b/internal/ebooks/enrichment.go
@@ -331,7 +331,11 @@ func (e *Enricher) enrichWithProviders(ctx context.Context, item enrichmentItemR
 		return fmt.Errorf("%w: no metadata providers configured for folder %d", errEnrichmentSkipped, item.FolderID)
 	}
 
-	accumulator, accumulatedIDs, providerErrs := collectEbookMetadata(ctx, item, providers)
+	var owner providerIDOwnerLookup
+	if e.providerIDs != nil {
+		owner = e.providerIDs
+	}
+	accumulator, accumulatedIDs, providerErrs := collectEbookMetadata(ctx, item, providers, owner)
 
 	if !accumulator.HasMetadata && accumulator.PosterPath == "" && accumulator.Overview == "" {
 		if err := ctx.Err(); err != nil {
@@ -368,11 +372,21 @@ func (e *Enricher) enrichWithProviders(ctx context.Context, item enrichmentItemR
 	return nil
 }
 
+// providerIDOwnerLookup reports the content item (if any) that already owns a
+// given set of durable provider IDs. *catalog.ProviderIDRepository satisfies it.
+type providerIDOwnerLookup interface {
+	FindContentIDByProviderIDs(ctx context.Context, providerIDs map[string]string, itemType, excludeContentID string) (string, error)
+}
+
 // collectEbookMetadata queries every provider in the chain and accumulates
 // IDs and metadata. Individual provider failures are collected (not fatal) so
 // the caller can distinguish "providers answered, no match" from "providers
-// were unreachable".
-func collectEbookMetadata(ctx context.Context, item enrichmentItemRow, providers []metadata.Provider) (*metadata.MetadataResult, map[string]string, []error) {
+// were unreachable". When owner is non-nil, a search-result provider ID already
+// claimed by a different content item is skipped: distinct books that resolve to
+// the same provider work (e.g. two series volumes searched as the bare series
+// name) must not steal each other's identity, which would mis-tag the loser and
+// violate the (provider, provider_id, item_type) uniqueness constraint on persist.
+func collectEbookMetadata(ctx context.Context, item enrichmentItemRow, providers []metadata.Provider, owner providerIDOwnerLookup) (*metadata.MetadataResult, map[string]string, []error) {
 	searchQuery, accumulatedIDs := buildEbookSearchQuery(item)
 	var providerErrs []error
 
@@ -395,11 +409,32 @@ func collectEbookMetadata(ctx context.Context, item enrichmentItemRow, providers
 			continue
 		}
 		for k, v := range results[0].ProviderIDs {
-			if v != "" {
-				if _, exists := accumulatedIDs[k]; !exists {
-					accumulatedIDs[k] = v
+			if v == "" {
+				continue
+			}
+			if _, exists := accumulatedIDs[k]; exists {
+				continue
+			}
+			if owner != nil {
+				ownerID, ownErr := owner.FindContentIDByProviderIDs(ctx, map[string]string{k: v}, ebookContentType(), item.ContentID)
+				if ownErr != nil {
+					// Don't claim an ID we couldn't verify is free, and surface
+					// the error so the item retries rather than terminally
+					// stamping as "no match".
+					providerErrs = append(providerErrs, fmt.Errorf("%s ownership check %s=%s: %w", p.Slug(), k, v, ownErr))
+					continue
+				}
+				if ownerID != "" {
+					slog.Info("ebook enrichment: provider id already owned by another item; skipping match",
+						"provider", k,
+						"provider_id", v,
+						"content_id", item.ContentID,
+						"owned_by", ownerID,
+					)
+					continue
 				}
 			}
+			accumulatedIDs[k] = v
 		}
 		slog.Debug("ebook enrichment: search result",
 			"provider", p.Slug(),
@@ -784,6 +819,11 @@ var ebookTrailingGroupRE = regexp.MustCompile(`\s*[\(\[]([^\)\]]*)[\)\]]\s*$`)
 // part of the real title: a book/volume/part marker, a "#N", or a bare year.
 var ebookSeriesNoiseRE = regexp.MustCompile(`(?i)\b(book|bk|vol|volume|series|part|saga|edition|novella?)\b|#\s*\d|^\s*\d{1,4}\s*$|\b(19|20)\d{2}\b`)
 
+// ebookYearOnlyRE matches a parenthetical that is nothing but a year. Years are
+// already carried by SearchQuery.Year, so they are dropped from the text rather
+// than folded back in.
+var ebookYearOnlyRE = regexp.MustCompile(`^\s*(19|20)\d{2}\s*$`)
+
 func cleanEbookSearchTitle(title, author string) string {
 	title = strings.ReplaceAll(title, "_", " ")
 	if a := strings.TrimSpace(author); a != "" {
@@ -791,20 +831,32 @@ func cleanEbookSearchTitle(title, author string) string {
 			title = title[:idx]
 		}
 	}
-	// Strip trailing series/book-number parentheticals ("(The Raven Brothers
-	// Book 4)", "[#3]", "(2019)") that wreck provider title search. Only groups
-	// matching the noise pattern are removed, so meaningful parentheticals in a
-	// real title survive. Loop to peel stacked groups.
+	// Normalize trailing series/edition parentheticals. A bare year ("(2019)")
+	// is dropped because SearchQuery.Year already carries it. A series/volume
+	// marker ("(The Raven Brothers Book 4)", "[#3]") is UNWRAPPED — its words
+	// are kept, only the brackets removed — because the volume number is the
+	// per-volume disambiguator: dropping it makes every entry in a series search
+	// as the bare series name and collapse onto a single provider work. Other
+	// parentheticals ("(Illustrated)") are meaningful title text and survive.
 	for {
 		m := ebookTrailingGroupRE.FindStringSubmatch(title)
-		if m == nil || !ebookSeriesNoiseRE.MatchString(m[1]) {
+		if m == nil {
 			break
 		}
-		stripped := strings.TrimSpace(title[:len(title)-len(m[0])])
-		if stripped == "" {
+		inner := strings.TrimSpace(m[1])
+		base := strings.TrimSpace(title[:len(title)-len(m[0])])
+		if base == "" {
 			break // never reduce the title to nothing
 		}
-		title = stripped
+		if ebookYearOnlyRE.MatchString(inner) {
+			title = base
+			continue // peel stacked groups (e.g. a year behind a series marker)
+		}
+		if ebookSeriesNoiseRE.MatchString(inner) {
+			title = base + " " + inner
+			break
+		}
+		break // meaningful parenthetical — leave intact
 	}
 	return strings.Join(strings.Fields(title), " ")
 }

--- a/internal/ebooks/enrichment.go
+++ b/internal/ebooks/enrichment.go
@@ -777,6 +777,7 @@ func buildEbookSearchQuery(item enrichmentItemRow) (metadata.SearchQuery, map[st
 	}
 	return metadata.SearchQuery{
 		Title:       item.Title,
+		Author:      item.Author,
 		Year:        item.Year,
 		ContentType: ebookContentType(),
 		ProviderIDs: accumulatedIDs,

--- a/internal/ebooks/enrichment.go
+++ b/internal/ebooks/enrichment.go
@@ -770,13 +770,29 @@ func filterEbookPeople(people []models.ItemPerson) []models.ItemPerson {
 	return authors
 }
 
+// cleanEbookSearchTitle normalizes a stored title for provider search. Scanner
+// titles are often filesystem-derived: underscores stand in for colons or
+// spaces ("Exit Strategy_ The Murderbot" / "LTB_067_Micky_Maus"), and
+// path-fallback titles keep a trailing " - <Author>" segment. Both wreck a
+// title search, so collapse underscores to spaces and drop a trailing author
+// suffix (the author is searched as its own field).
+func cleanEbookSearchTitle(title, author string) string {
+	title = strings.ReplaceAll(title, "_", " ")
+	if a := strings.TrimSpace(author); a != "" {
+		if idx := strings.LastIndex(strings.ToLower(title), " - "+strings.ToLower(a)); idx >= 0 {
+			title = title[:idx]
+		}
+	}
+	return strings.Join(strings.Fields(title), " ")
+}
+
 func buildEbookSearchQuery(item enrichmentItemRow) (metadata.SearchQuery, map[string]string) {
 	accumulatedIDs := filterEbookProviderIDs(item.ProviderIDs)
 	if accumulatedIDs == nil {
 		accumulatedIDs = map[string]string{}
 	}
 	return metadata.SearchQuery{
-		Title:       item.Title,
+		Title:       cleanEbookSearchTitle(item.Title, item.Author),
 		Author:      item.Author,
 		Year:        item.Year,
 		ContentType: ebookContentType(),

--- a/internal/ebooks/enrichment_test.go
+++ b/internal/ebooks/enrichment_test.go
@@ -571,3 +571,21 @@ func (f *fakeEbookImageCacher) CacheImage(_ context.Context, req metadata.CacheI
 		Ext:       ".webp",
 	}, nil
 }
+
+func TestCleanEbookSearchTitle(t *testing.T) {
+	cases := []struct {
+		title, author, want string
+	}{
+		{"Exit Strategy_ The Murderbot Di - Martha Wells", "Martha Wells", "Exit Strategy The Murderbot Di"},
+		{"LTB.067_-_Micky_Maus_Superstar", "", "LTB.067 - Micky Maus Superstar"},
+		{"Club Dark Lace_ Complete Dark Lace", "", "Club Dark Lace Complete Dark Lace"},
+		{"All of Us - A. F. Carter", "a. f. carter", "All of Us"},
+		{"Plain Title", "Some Author", "Plain Title"},
+		{"  spaced   out  ", "", "spaced out"},
+	}
+	for _, tc := range cases {
+		if got := cleanEbookSearchTitle(tc.title, tc.author); got != tc.want {
+			t.Errorf("cleanEbookSearchTitle(%q,%q)=%q want %q", tc.title, tc.author, got, tc.want)
+		}
+	}
+}

--- a/internal/ebooks/enrichment_test.go
+++ b/internal/ebooks/enrichment_test.go
@@ -582,6 +582,12 @@ func TestCleanEbookSearchTitle(t *testing.T) {
 		{"All of Us - A. F. Carter", "a. f. carter", "All of Us"},
 		{"Plain Title", "Some Author", "Plain Title"},
 		{"  spaced   out  ", "", "spaced out"},
+		{"Just One Night (The Raven Brothers Book 4)", "", "Just One Night"},
+		{"Mistborn (The Mistborn Saga #1)", "", "Mistborn"},
+		{"White Out [Badlands Thriller]", "", "White Out [Badlands Thriller]"},
+		{"Salem's Lot (2019)", "", "Salem's Lot"},
+		{"The Hobbit (Illustrated)", "", "The Hobbit (Illustrated)"},
+		{"Exit Strategy_ Murderbot Di - Martha Wells (Book 4)", "Martha Wells", "Exit Strategy Murderbot Di"},
 	}
 	for _, tc := range cases {
 		if got := cleanEbookSearchTitle(tc.title, tc.author); got != tc.want {

--- a/internal/ebooks/enrichment_test.go
+++ b/internal/ebooks/enrichment_test.go
@@ -267,7 +267,7 @@ func TestCollectEbookMetadataAccumulatesProviderErrors(t *testing.T) {
 		},
 	}
 
-	accumulator, ids, errs := collectEbookMetadata(context.Background(), enrichmentItemRow{ContentID: "c1", Title: "t"}, providers)
+	accumulator, ids, errs := collectEbookMetadata(context.Background(), enrichmentItemRow{ContentID: "c1", Title: "t"}, providers, nil)
 
 	if len(errs) != 2 || !errors.Is(errs[0], searchErr) || !errors.Is(errs[1], getErr) {
 		t.Fatalf("provider errors = %v, want both broken-provider errors", errs)
@@ -277,6 +277,63 @@ func TestCollectEbookMetadataAccumulatesProviderErrors(t *testing.T) {
 	}
 	if ids["openlibrary"] != "OL1M" {
 		t.Fatalf("accumulated IDs = %v, want search-result openlibrary ID", ids)
+	}
+}
+
+type fakeProviderIDOwner struct {
+	ownerByID map[string]string // provider_id -> owning content id
+	err       error
+}
+
+func (f *fakeProviderIDOwner) FindContentIDByProviderIDs(_ context.Context, ids map[string]string, _ string, exclude string) (string, error) {
+	if f.err != nil {
+		return "", f.err
+	}
+	for _, v := range ids {
+		if owner, ok := f.ownerByID[v]; ok && owner != exclude {
+			return owner, nil
+		}
+	}
+	return "", nil
+}
+
+func TestCollectEbookMetadataSkipsProviderIDOwnedByAnotherItem(t *testing.T) {
+	providers := []metadata.Provider{
+		&fakeEbookMetadataProvider{
+			slug:    "bookinfo",
+			results: []metadata.SearchResult{{ProviderIDs: map[string]string{"bookinfo": "40817436"}}},
+			result:  &metadata.MetadataResult{HasMetadata: true, Overview: "book one"},
+		},
+	}
+	owner := &fakeProviderIDOwner{ownerByID: map[string]string{"40817436": "other-book"}}
+
+	_, ids, errs := collectEbookMetadata(context.Background(), enrichmentItemRow{ContentID: "c2", Title: "t"}, providers, owner)
+
+	if len(errs) != 0 {
+		t.Fatalf("unexpected provider errors: %v", errs)
+	}
+	if _, ok := ids["bookinfo"]; ok {
+		t.Fatalf("provider id owned by another item was claimed: %v", ids)
+	}
+}
+
+func TestCollectEbookMetadataSurfacesOwnershipCheckError(t *testing.T) {
+	checkErr := errors.New("db down")
+	providers := []metadata.Provider{
+		&fakeEbookMetadataProvider{
+			slug:    "bookinfo",
+			results: []metadata.SearchResult{{ProviderIDs: map[string]string{"bookinfo": "40817436"}}},
+		},
+	}
+	owner := &fakeProviderIDOwner{err: checkErr}
+
+	_, ids, errs := collectEbookMetadata(context.Background(), enrichmentItemRow{ContentID: "c2", Title: "t"}, providers, owner)
+
+	if len(errs) != 1 || !errors.Is(errs[0], checkErr) {
+		t.Fatalf("provider errors = %v, want the ownership-check error", errs)
+	}
+	if _, ok := ids["bookinfo"]; ok {
+		t.Fatalf("provider id claimed despite failed ownership check: %v", ids)
 	}
 }
 
@@ -582,8 +639,12 @@ func TestCleanEbookSearchTitle(t *testing.T) {
 		{"All of Us - A. F. Carter", "a. f. carter", "All of Us"},
 		{"Plain Title", "Some Author", "Plain Title"},
 		{"  spaced   out  ", "", "spaced out"},
-		{"Just One Night (The Raven Brothers Book 4)", "", "Just One Night"},
-		{"Mistborn (The Mistborn Saga #1)", "", "Mistborn"},
+		// Series/volume markers are kept (unwrapped) so distinct volumes search
+		// distinctly instead of collapsing onto one provider work.
+		{"Just One Night (The Raven Brothers Book 4)", "", "Just One Night The Raven Brothers Book 4"},
+		{"Mistborn (The Mistborn Saga #1)", "", "Mistborn The Mistborn Saga #1"},
+		{"The Wheel of Time (Book 1)", "", "The Wheel of Time Book 1"},
+		{"The Wheel of Time (Book 2)", "", "The Wheel of Time Book 2"},
 		{"White Out [Badlands Thriller]", "", "White Out [Badlands Thriller]"},
 		{"Salem's Lot (2019)", "", "Salem's Lot"},
 		{"The Hobbit (Illustrated)", "", "The Hobbit (Illustrated)"},

--- a/internal/ebooks/enrichment_test.go
+++ b/internal/ebooks/enrichment_test.go
@@ -637,6 +637,8 @@ func TestCleanEbookSearchTitle(t *testing.T) {
 		{"LTB.067_-_Micky_Maus_Superstar", "", "LTB.067 - Micky Maus Superstar"},
 		{"Club Dark Lace_ Complete Dark Lace", "", "Club Dark Lace Complete Dark Lace"},
 		{"All of Us - A. F. Carter", "a. f. carter", "All of Us"},
+		// A " - <token>" that is not the trailing author must be preserved.
+		{"Alice - Bob and Carol", "Bob", "Alice - Bob and Carol"},
 		{"Plain Title", "Some Author", "Plain Title"},
 		{"  spaced   out  ", "", "spaced out"},
 		// Series/volume markers are kept (unwrapped) so distinct volumes search

--- a/internal/metadata/plugin_provider.go
+++ b/internal/metadata/plugin_provider.go
@@ -180,8 +180,16 @@ func (p *PluginProvider) Search(ctx context.Context, query SearchQuery) ([]Searc
 		return nil, fmt.Errorf("encode provider ids for plugin search: %w", err)
 	}
 
+	// The plugin search contract carries a single free-text Query. When the
+	// caller supplies an author hint (ebooks), fold it in so title-only matches
+	// that need disambiguation — or messy filename titles — can still resolve.
+	queryText := strings.TrimSpace(query.Title)
+	if author := strings.TrimSpace(query.Author); author != "" {
+		queryText = strings.TrimSpace(queryText + " " + author)
+	}
+
 	response, err := client.Search(ctx, &pluginv1.SearchMetadataRequest{
-		Query:       query.Title,
+		Query:       queryText,
 		ItemType:    query.ContentType,
 		Year:        int32(query.Year),
 		ProviderIds: providerIDs,

--- a/internal/metadata/types.go
+++ b/internal/metadata/types.go
@@ -92,6 +92,7 @@ type MatchHints struct {
 // SearchQuery is passed to SearchProvider.Search().
 type SearchQuery struct {
 	Title                     string
+	Author                    string // optional creator hint (e.g. ebook author) folded into the search query
 	Year                      int
 	ContentType               string            // media_items.type value
 	ProviderIDs               map[string]string // Accumulated IDs from prior providers

--- a/internal/scanner/ebook.go
+++ b/internal/scanner/ebook.go
@@ -531,6 +531,14 @@ func parseMOBIEXTH(data []byte, encoding uint32, book *parsedEbook) {
 	if len(data) < 12 || string(data[0:4]) != "EXTH" {
 		return
 	}
+	// data carries the rest of record 0, not just the EXTH block. Bound parsing
+	// to the declared EXTH length so a bad record count can't walk full-text
+	// bytes and assign junk metadata.
+	exthLen := int(binary.BigEndian.Uint32(data[4:8]))
+	if exthLen < 12 || exthLen > len(data) {
+		return
+	}
+	data = data[:exthLen]
 	count := int(binary.BigEndian.Uint32(data[8:12]))
 	pos := 12
 	var isbn string

--- a/internal/scanner/ebook.go
+++ b/internal/scanner/ebook.go
@@ -3,6 +3,7 @@ package scanner
 import (
 	"archive/zip"
 	"bytes"
+	"encoding/binary"
 	"encoding/hex"
 	"encoding/xml"
 	"fmt"
@@ -85,7 +86,9 @@ func parseEbookFile(path string) (book parsedEbook, err error) {
 		book, err = parseEbookCBZ(path)
 	case ".pdf":
 		book, err = parseEbookPDF(path)
-	case ".mobi", ".azw", ".azw3", ".cbr":
+	case ".mobi", ".azw", ".azw3":
+		book, err = parseEbookMOBI(path)
+	case ".cbr":
 		book = parsedEbook{Format: strings.TrimPrefix(format, ".")}
 	default:
 		err = fmt.Errorf("unsupported ebook format: %s", filepath.Ext(path))
@@ -440,6 +443,160 @@ func parseEbookCBZ(path string) (parsedEbook, error) {
 		}
 	}
 	return book, nil
+}
+
+// maxMOBIHeaderScanSize bounds how much of a MOBI/AZW file we read. All
+// metadata (PalmDOC header, MOBI header, EXTH records, full title) lives in
+// record 0 at the file start, so a fixed window covers it without streaming the
+// whole book.
+const maxMOBIHeaderScanSize = 256 * 1024
+
+// MOBI/AZW/AZW3 share the Palm Database (PDB) container: a PDB header, a record
+// offset list, then record 0 holding the PalmDOC header (16 bytes), the MOBI
+// header, and the optional EXTH metadata block. parseEbookMOBI extracts the
+// title, authors, and ISBN that Calibre and most tools write into EXTH, so these
+// formats no longer fall back to the filename with no author or identifier.
+func parseEbookMOBI(path string) (parsedEbook, error) {
+	book := parsedEbook{Format: strings.TrimPrefix(strings.ToLower(filepath.Ext(path)), ".")}
+	file, err := os.Open(path)
+	if err != nil {
+		return book, err
+	}
+	defer file.Close()
+
+	header := make([]byte, maxMOBIHeaderScanSize)
+	n, err := io.ReadFull(file, header)
+	if err != nil && err != io.ErrUnexpectedEOF && err != io.EOF {
+		return book, err
+	}
+	header = header[:n]
+	// PDB record count (uint16 BE @76) and first record-info entry (@78) give
+	// the offset of record 0, which holds the headers.
+	if len(header) < 78+8 {
+		return book, nil
+	}
+	if binary.BigEndian.Uint16(header[76:78]) < 1 {
+		return book, nil
+	}
+	rec0Off := int(binary.BigEndian.Uint32(header[78:82]))
+	if rec0Off <= 0 || rec0Off >= len(header) {
+		return book, nil
+	}
+
+	// PDB database name (bytes 0..31, NUL-padded) is the last-resort title.
+	pdbName := decodeMOBIString(trimTrailingNUL(header[0:32]), 65001)
+
+	rec0 := header[rec0Off:]
+	if len(rec0) < 16+8 || string(rec0[16:20]) != "MOBI" {
+		if pdbName != "" {
+			book.Title = pdbName
+		}
+		return book, nil
+	}
+	mobi := rec0[16:] // skip the 16-byte PalmDOC header
+
+	mobiHeaderLen := int(binary.BigEndian.Uint32(mobi[4:8]))
+	var encoding uint32
+	if len(mobi) >= 16 {
+		encoding = binary.BigEndian.Uint32(mobi[12:16]) // 65001=UTF-8, else CP1252
+	}
+
+	// Full title: offset (relative to rec0 start) and length at MOBI+0x44/0x48.
+	if len(mobi) >= 0x4C {
+		nameOff := int(binary.BigEndian.Uint32(mobi[0x44:0x48]))
+		nameLen := int(binary.BigEndian.Uint32(mobi[0x48:0x4C]))
+		if nameOff > 0 && nameLen > 0 && nameOff+nameLen <= len(rec0) {
+			book.Title = decodeMOBIString(rec0[nameOff:nameOff+nameLen], encoding)
+		}
+	}
+
+	// The EXTH metadata block, when present, immediately follows the MOBI header.
+	// Detect it by its "EXTH" magic rather than the header flag, whose offset
+	// varies across MOBI versions.
+	if mobiHeaderLen > 0 && mobiHeaderLen+4 <= len(mobi) &&
+		string(mobi[mobiHeaderLen:mobiHeaderLen+4]) == "EXTH" {
+		parseMOBIEXTH(mobi[mobiHeaderLen:], encoding, &book)
+	}
+
+	if book.Title == "" {
+		book.Title = pdbName
+	}
+	return book, nil
+}
+
+// parseMOBIEXTH walks the EXTH record list, pulling the metadata fields the
+// catalog/enricher uses. EXTH record types: 100 author, 101 publisher,
+// 103 description, 104 ISBN, 503 updated title, 524 language.
+func parseMOBIEXTH(data []byte, encoding uint32, book *parsedEbook) {
+	if len(data) < 12 || string(data[0:4]) != "EXTH" {
+		return
+	}
+	count := int(binary.BigEndian.Uint32(data[8:12]))
+	pos := 12
+	var isbn string
+	for i := 0; i < count; i++ {
+		if pos+8 > len(data) {
+			break
+		}
+		recType := binary.BigEndian.Uint32(data[pos : pos+4])
+		recLen := int(binary.BigEndian.Uint32(data[pos+4 : pos+8]))
+		if recLen < 8 || pos+recLen > len(data) {
+			break
+		}
+		payload := data[pos+8 : pos+recLen]
+		pos += recLen
+
+		switch recType {
+		case 100: // author
+			book.Authors = append(book.Authors, splitEbookAuthors(decodeMOBIString(payload, encoding))...)
+		case 101: // publisher
+			if book.Publisher == "" {
+				book.Publisher = decodeMOBIString(payload, encoding)
+			}
+		case 103: // description
+			if book.Description == "" {
+				book.Description = cleanEbookDescription(decodeMOBIString(payload, encoding))
+			}
+		case 104: // ISBN
+			if isbn == "" {
+				isbn = decodeMOBIString(payload, encoding)
+			}
+		case 503: // updated title (overrides the MOBI full-name title)
+			if t := decodeMOBIString(payload, encoding); t != "" {
+				book.Title = t
+			}
+		case 524: // language
+			if book.Language == "" {
+				book.Language = decodeMOBIString(payload, encoding)
+			}
+		}
+	}
+	if isbn != "" {
+		if normalized := normalizeEbookISBN(isbn); normalized != "" {
+			book.ISBN = normalized
+		}
+	}
+}
+
+// decodeMOBIString decodes EXTH/header bytes using the MOBI text-encoding code
+// (65001 = UTF-8, anything else defaults to CP1252, the MOBI default).
+func decodeMOBIString(data []byte, encoding uint32) string {
+	if len(data) == 0 {
+		return ""
+	}
+	if encoding != 65001 {
+		if decoded, err := charmap.Windows1252.NewDecoder().Bytes(data); err == nil {
+			return strings.TrimSpace(string(decoded))
+		}
+	}
+	return strings.TrimSpace(string(data))
+}
+
+func trimTrailingNUL(b []byte) []byte {
+	if i := bytes.IndexByte(b, 0); i >= 0 {
+		return b[:i]
+	}
+	return b
 }
 
 // naturalPathLess orders archive entry names case-insensitively with digit

--- a/internal/scanner/ebook_scan.go
+++ b/internal/scanner/ebook_scan.go
@@ -920,7 +920,53 @@ func ebookAuthorFromPath(filePath string) string {
 	if normalizeEbookIdentityPart(fromName) != normalizeEbookIdentityPart(grandparent) {
 		return ""
 	}
-	return fromName
+	// Position alone cannot tell author from title: some libraries shelve
+	// books as "<Title>/<Author>/<Author> - <Title>" (inverted) which also
+	// satisfies the grandparent==suffix check and would assign the title as
+	// the author. Require the candidate to look like a person name; series and
+	// title folders ("De legenden van de Alfen") fail this and are rejected.
+	if !looksLikePersonName(grandparent) {
+		return ""
+	}
+	// Return the directory form, which carries canonical casing ("A. F. Carter"
+	// rather than a lowercased filename suffix).
+	return grandparent
+}
+
+// looksLikePersonName reports whether value is shaped like an author name. A
+// "Last, First" comma form is accepted outright; otherwise every token must be
+// capitalized or a known name particle (van, de, von, ...). Title/series
+// strings contain lowercase content words and so are rejected.
+func looksLikePersonName(value string) bool {
+	value = strings.TrimSpace(value)
+	if value == "" {
+		return false
+	}
+	if strings.ContainsAny(value, "0123456789") {
+		return false
+	}
+	if strings.Contains(value, ",") {
+		return true
+	}
+	particles := map[string]struct{}{
+		"van": {}, "von": {}, "de": {}, "der": {}, "den": {}, "het": {}, "di": {},
+		"da": {}, "del": {}, "della": {}, "la": {}, "le": {}, "el": {}, "du": {},
+		"dos": {}, "das": {}, "bin": {}, "al": {}, "ter": {}, "te": {}, "ten": {},
+		"op": {}, "'t": {},
+	}
+	hasUpper := false
+	for _, token := range strings.Fields(value) {
+		r := []rune(token)[0]
+		if unicode.IsUpper(r) {
+			hasUpper = true
+			continue
+		}
+		if _, ok := particles[strings.ToLower(token)]; ok {
+			continue
+		}
+		return false
+	}
+	return hasUpper
 }
 
 func normalizeEbookIdentityPart(value string) string {

--- a/internal/scanner/ebook_scan.go
+++ b/internal/scanner/ebook_scan.go
@@ -457,9 +457,14 @@ func (s *Scanner) reconcileEbookFile(ctx context.Context, folder *models.MediaFo
 		if author := ebookAuthorFromPath(filePath); author != "" {
 			parsed.Authors = []string{author}
 			// A path-derived title carries the same " - Author" suffix; drop it
-			// so the title, group key, and enrichment query stay clean.
-			if suffix := " - " + author; strings.HasSuffix(parsed.Title, suffix) {
-				parsed.Title = strings.TrimSpace(strings.TrimSuffix(parsed.Title, suffix))
+			// so the title, group key, and enrichment query stay clean. Compare
+			// normalized so case/spacing variants (e.g. "a. f.  carter") match
+			// the recovered author and don't leave a duplicated suffix.
+			if idx := strings.LastIndex(parsed.Title, " - "); idx >= 0 {
+				suffixAuthor := strings.TrimSpace(parsed.Title[idx+len(" - "):])
+				if normalizeEbookIdentityPart(suffixAuthor) == normalizeEbookIdentityPart(author) {
+					parsed.Title = strings.TrimSpace(parsed.Title[:idx])
+				}
 			}
 		}
 	}

--- a/internal/scanner/ebook_scan.go
+++ b/internal/scanner/ebook_scan.go
@@ -453,6 +453,16 @@ func (s *Scanner) reconcileEbookFile(ctx context.Context, folder *models.MediaFo
 	if parsed.Title == "" {
 		parsed.Title = ebookTitleFromPath(filePath)
 	}
+	if len(parsed.Authors) == 0 {
+		if author := ebookAuthorFromPath(filePath); author != "" {
+			parsed.Authors = []string{author}
+			// A path-derived title carries the same " - Author" suffix; drop it
+			// so the title, group key, and enrichment query stay clean.
+			if suffix := " - " + author; strings.HasSuffix(parsed.Title, suffix) {
+				parsed.Title = strings.TrimSpace(strings.TrimSuffix(parsed.Title, suffix))
+			}
+		}
+	}
 
 	groupKey := ebookContentGroupKey(&parsed, filePath)
 	unlock := groupLocks.lock(groupKey)
@@ -883,6 +893,34 @@ func ebookTitleFromPath(filePath string) string {
 		return base[:len(base)-len(".fb2.zip")]
 	}
 	return strings.TrimSuffix(base, filepath.Ext(base))
+}
+
+// ebookAuthorFromPath recovers an author for libraries that shelve books as
+// ".../<Author>/<Title>/<Title> - <Author>.ext" but embed no author in the file
+// (common for PDF/MOBI/AZW3). It returns a value only when two independent path
+// signals agree: the grandparent directory name and the filename's trailing
+// " - X" segment. Authorless layouts — magazines, language courses, flat dumps —
+// satisfy neither or only one signal, so they never get a junk author that would
+// poison the enrichment search.
+func ebookAuthorFromPath(filePath string) string {
+	base := ebookTitleFromPath(filePath)
+	idx := strings.LastIndex(base, " - ")
+	if idx < 0 {
+		return ""
+	}
+	fromName := strings.TrimSpace(base[idx+len(" - "):])
+	if fromName == "" {
+		return ""
+	}
+	grandparent := strings.TrimSpace(filepath.Base(filepath.Dir(filepath.Dir(filePath))))
+	switch grandparent {
+	case "", ".", string(filepath.Separator):
+		return ""
+	}
+	if normalizeEbookIdentityPart(fromName) != normalizeEbookIdentityPart(grandparent) {
+		return ""
+	}
+	return fromName
 }
 
 func normalizeEbookIdentityPart(value string) string {

--- a/internal/scanner/ebook_test.go
+++ b/internal/scanner/ebook_test.go
@@ -3,6 +3,7 @@ package scanner
 import (
 	"archive/zip"
 	"context"
+	"encoding/binary"
 	"errors"
 	"os"
 	"path/filepath"
@@ -1892,5 +1893,79 @@ func TestParseEbookFB2RejectsOversizedFile(t *testing.T) {
 	_, err := parseEbookFile(path)
 	if err == nil || !strings.Contains(err.Error(), "too large") {
 		t.Fatalf("parseEbookFile error = %v, want size-cap rejection", err)
+	}
+}
+
+// buildTestMOBI assembles a minimal but valid MOBI/AZW container: a PDB header,
+// a single record-info entry pointing at record 0, and record 0 holding a
+// PalmDOC header, a MOBI header, an EXTH block, and the full-title string.
+func buildTestMOBI(t *testing.T) string {
+	t.Helper()
+
+	exthRec := func(typ uint32, val string) []byte {
+		b := make([]byte, 8+len(val))
+		binary.BigEndian.PutUint32(b[0:4], typ)
+		binary.BigEndian.PutUint32(b[4:8], uint32(8+len(val)))
+		copy(b[8:], val)
+		return b
+	}
+	var recs []byte
+	recs = append(recs, exthRec(100, "A H Lee")...)          // author
+	recs = append(recs, exthRec(503, "The Sea: A Novel")...) // updated title
+	recs = append(recs, exthRec(104, "9780306406157")...)    // ISBN
+	exth := make([]byte, 12)
+	copy(exth[0:4], "EXTH")
+	binary.BigEndian.PutUint32(exth[4:8], uint32(12+len(recs)))
+	binary.BigEndian.PutUint32(exth[8:12], 3)
+	exth = append(exth, recs...)
+
+	const mobiHeaderLen = 232
+	mobi := make([]byte, mobiHeaderLen)
+	copy(mobi[0:4], "MOBI")
+	binary.BigEndian.PutUint32(mobi[4:8], mobiHeaderLen)
+	binary.BigEndian.PutUint32(mobi[12:16], 65001) // text encoding: UTF-8
+
+	fullName := []byte("The Sea")
+	nameOff := 16 + mobiHeaderLen + len(exth) // relative to record 0 start
+	binary.BigEndian.PutUint32(mobi[0x44:0x48], uint32(nameOff))
+	binary.BigEndian.PutUint32(mobi[0x48:0x4C], uint32(len(fullName)))
+
+	var rec0 []byte
+	rec0 = append(rec0, make([]byte, 16)...) // PalmDOC header (zeroed)
+	rec0 = append(rec0, mobi...)
+	rec0 = append(rec0, exth...)
+	rec0 = append(rec0, fullName...)
+
+	const rec0Off = 86 // 78-byte PDB header + one 8-byte record-info entry
+	pdb := make([]byte, rec0Off)
+	copy(pdb[0:32], "The Sea") // PDB database name (last-resort title)
+	copy(pdb[60:64], "BOOK")
+	copy(pdb[64:68], "MOBI")
+	binary.BigEndian.PutUint16(pdb[76:78], 1)       // record count
+	binary.BigEndian.PutUint32(pdb[78:82], rec0Off) // record 0 offset
+
+	path := filepath.Join(t.TempDir(), "book.mobi")
+	if err := os.WriteFile(path, append(pdb, rec0...), 0o644); err != nil {
+		t.Fatalf("write test mobi: %v", err)
+	}
+	return path
+}
+
+func TestParseEbookMOBIEXTH(t *testing.T) {
+	got, err := parseEbookFile(buildTestMOBI(t))
+	if err != nil {
+		t.Fatalf("parseEbookFile error = %v", err)
+	}
+	if got.Format != "mobi" {
+		t.Fatalf("Format = %q, want mobi", got.Format)
+	}
+	if got.Title != "The Sea: A Novel" {
+		t.Fatalf("Title = %q, want EXTH updated title", got.Title)
+	}
+	if len(got.Authors) != 1 || got.Authors[0] != "A H Lee" {
+		t.Fatalf("Authors = %v, want [A H Lee]", got.Authors)
+	}
+	if got.ISBN != "9780306406157" {
+		t.Fatalf("ISBN = %q, want 9780306406157", got.ISBN)
 	}
 }

--- a/internal/scanner/ebook_test.go
+++ b/internal/scanner/ebook_test.go
@@ -1984,7 +1984,7 @@ func TestEbookAuthorFromPath(t *testing.T) {
 		{
 			name: "case and spacing differences still match",
 			path: "/books/Books_English/A. F. Carter/All of Us (57890)/All of Us - a. f.  carter.pdf",
-			want: "a. f.  carter",
+			want: "A. F. Carter",
 		},
 		{
 			name: "no dash in filename",
@@ -2000,6 +2000,21 @@ func TestEbookAuthorFromPath(t *testing.T) {
 			name: "empty suffix",
 			path: "/books/X/Author/Title/Title - .pdf",
 			want: "",
+		},
+		{
+			name: "inverted series folder rejected (grandparent is title)",
+			path: "/books/Books_Dutch/De legenden van de Alfen/Heinz, Markus (2118)/Heinz, Markus - De legenden van de Alfen.epub",
+			want: "",
+		},
+		{
+			name: "comma surname form accepted",
+			path: "/books/Books_Dutch/Mersbergen, Jan van/De laatste ontsnapping (8702)/De laatste ontsnapping - Mersbergen, Jan van.epub",
+			want: "Mersbergen, Jan van",
+		},
+		{
+			name: "particle in name accepted",
+			path: "/books/Books_English/Dean R. Koontz/Midnight (7408)/Midnight - Dean R. Koontz.epub",
+			want: "Dean R. Koontz",
 		},
 	}
 	for _, tc := range cases {

--- a/internal/scanner/ebook_test.go
+++ b/internal/scanner/ebook_test.go
@@ -1969,3 +1969,44 @@ func TestParseEbookMOBIEXTH(t *testing.T) {
 		t.Fatalf("ISBN = %q, want 9780306406157", got.ISBN)
 	}
 }
+
+func TestEbookAuthorFromPath(t *testing.T) {
+	cases := []struct {
+		name string
+		path string
+		want string
+	}{
+		{
+			name: "corroborated grandparent and filename suffix",
+			path: "/books/Books_English/Lisa Jewell/The House We Grew Up In (135563)/The House We Grew Up In - Lisa Jewell.azw3",
+			want: "Lisa Jewell",
+		},
+		{
+			name: "case and spacing differences still match",
+			path: "/books/Books_English/A. F. Carter/All of Us (57890)/All of Us - a. f.  carter.pdf",
+			want: "a. f.  carter",
+		},
+		{
+			name: "no dash in filename",
+			path: "/books/Books_German/Schweizer Familie 11.04.2019.pdf",
+			want: "",
+		},
+		{
+			name: "suffix does not match grandparent dir",
+			path: "/books/Books_English/Stephen King/Salem's Lot (8507)/Salem's Lot - Some Other Name.pdf",
+			want: "",
+		},
+		{
+			name: "empty suffix",
+			path: "/books/X/Author/Title/Title - .pdf",
+			want: "",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := ebookAuthorFromPath(tc.path); got != tc.want {
+				t.Fatalf("ebookAuthorFromPath(%q) = %q, want %q", tc.path, got, tc.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Problem

Ebook enrichment frequently searched metadata providers with a poor query (missing or
noisy author, series/book-number parentheticals in the title, dropped volume numbers),
producing wrong or empty matches. The scanner also lacked metadata for MOBI/AZW/AZW3 files
and could attach non-author path segments as the author.

## Changes

- `feat(scanner)`: extract MOBI/AZW/AZW3 metadata from EXTH headers.
- `fix(scanner)`: recover author from path, but gate path-author on a person-name shape so
  non-name path segments are not misused.
- `fix(ebooks)`: fold the author hint into the metadata search query; strip
  series/book-number parentheticals from the search title while keeping the volume number;
  dedup provider IDs.

## Why this approach

Cleans the query at the source (scanner + enrichment) rather than papering over bad matches
downstream, and keeps the author heuristic conservative to avoid false attributions.

## Risks / follow-up

Heuristics are name/title-shape based; unusual filenames may still mis-parse. Covered by new
unit tests in `enrichment_test.go` and `ebook_test.go`.

## AI-use disclosure

Implemented with assistance from Claude Code.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added support for MOBI, AZW, and AZW3 ebook file formats.
  * Enhanced automatic author metadata extraction from file paths and ebook file contents.
  * Improved metadata search queries to include author information for more accurate results.

* **Bug Fixes**
  * Fixed provider ID conflicts when multiple content items share the same identifier.

* **Tests**
  * Added test coverage for new MOBI format parsing and author extraction functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

---

Related to #153 (ebook items not picked up by metadata rescan) — this PR improves ebook author/metadata extraction at scan time.
