### PR TITLE
fix(jellycompat): accept Jellyfin current ApiKey query param for stream auth

### DIFF
--- a/internal/jellycompat/auth.go
+++ b/internal/jellycompat/auth.go
@@ -62,9 +62,16 @@ func ExtractToken(r *http.Request) (string, bool) {
 	if token := strings.TrimSpace(r.Header.Get("X-Mediabrowser-Token")); token != "" {
 		return token, true
 	}
-	// Case-insensitive: Jellyfin clients vary the casing (api_key / Api_Key / API_KEY).
-	if token := strings.TrimSpace(newCaseInsensitiveQuery(r.URL.Query()).Get("api_key")); token != "" {
-		return token, true
+	// Query-param token. Jellyfin's current spelling is "ApiKey" (PascalCase,
+	// always enabled); "api_key" is the legacy spelling (gated behind
+	// EnableLegacyAuthorization on a real server). Clients vary the casing
+	// further (Api_Key / API_KEY), so match both keys case-insensitively.
+	// Ref: jellyfin Jellyfin.Server.Implementations/Security/AuthorizationContext.cs.
+	query := newCaseInsensitiveQuery(r.URL.Query())
+	for _, key := range []string{"ApiKey", "api_key"} {
+		if token := strings.TrimSpace(query.Get(key)); token != "" {
+			return token, true
+		}
 	}
 
 	return "", false

--- a/internal/jellycompat/auth_test.go
+++ b/internal/jellycompat/auth_test.go
@@ -165,7 +165,11 @@ func TestPlaybackSessionAuth_CaseInsensitivePlaySessionId(t *testing.T) {
 }
 
 func TestExtractToken_CaseInsensitiveAPIKey(t *testing.T) {
-	for _, key := range []string{"api_key", "Api_Key", "API_KEY"} {
+	// "ApiKey" is Jellyfin's current query spelling (PascalCase); "api_key" is
+	// the legacy spelling. Native clients (incl. Jellyfin Android TV) build
+	// direct-play /Videos/{id}/stream URLs with "ApiKey", so rejecting it 401s
+	// the stream. Match both, plus the casing variants clients send.
+	for _, key := range []string{"ApiKey", "apikey", "APIKEY", "api_key", "Api_Key", "API_KEY"} {
 		req := httptest.NewRequest("GET", "/Videos/itm/stream?"+key+"=tok123", nil)
 		if got, ok := ExtractToken(req); !ok || got != "tok123" {
 			t.Fatalf("%s: ExtractToken = (%q, %v), want (tok123, true)", key, got, ok)

--- a/internal/jellycompat/logging.go
+++ b/internal/jellycompat/logging.go
@@ -273,7 +273,9 @@ func authKind(r *http.Request) string {
 		return "x-emby-token"
 	case strings.TrimSpace(r.Header.Get("X-Mediabrowser-Token")) != "":
 		return "x-mediabrowser-token"
-	case strings.TrimSpace(r.URL.Query().Get("api_key")) != "":
+	case strings.TrimSpace(newCaseInsensitiveQuery(r.URL.Query()).Get("ApiKey")) != "":
+		return "api_key"
+	case strings.TrimSpace(newCaseInsensitiveQuery(r.URL.Query()).Get("api_key")) != "":
 		return "api_key"
 	default:
 		return "none"


### PR DESCRIPTION
## Problem
Native Jellyfin clients (confirmed with **Jellyfin Android TV 0.19.9**, jellyfin-sdk-kotlin) build their own direct-play `/Videos/{id}/stream?static=true` URLs and authenticate with the **`ApiKey`** query parameter. Silo's `ExtractToken` only honored the legacy `api_key` spelling (plus the auth headers), so these requests arrived with `auth_kind=none` and the stream route returned **401**, which clients surface as "playbackerror." Clients that send the token via header (e.g. the Jellyfin mobile app) were unaffected, which made it look device-specific.

## Why this approach
Real Jellyfin's `AuthorizationContext` checks **`ApiKey`** (PascalCase) as the current, always-enabled query token and treats `api_key` as legacy (gated behind `EnableLegacyAuthorization`). Silo had it backwards — accepting only the deprecated spelling. The fix matches both `ApiKey` and `api_key` case-insensitively in `ExtractToken`, and updates the `authKind` log classifier to agree. Strictly additive: existing header and `api_key` paths are unchanged, and unauthenticated requests are still rejected.

## Verification
- Unit: extended `TestExtractToken_CaseInsensitiveAPIKey` to cover `ApiKey` / `apikey` / `APIKEY`.
- Live, before -> after on `/Videos/{id}/stream`: `&ApiKey=<tok>` 401 -> **206**; `&api_key=<tok>` and the `X-Emby-Token` header remain 206; no-auth remains 401.

## Risk / follow-up
Low — additive auth source matching the documented Jellyfin contract. Does not by itself prove it resolves every Android TV "playbackerror" (that client's failing attempt did not always reach `/stream` in logs); a separate item may be needed to capture the client's raw request.

## AI-use disclosure
Diagnosis and patch developed with Claude Code (Opus 4.8).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Enhanced API key authentication to recognize parameters in multiple formats with case-insensitive matching, providing better compatibility with various client implementations and integration methods.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->