### PR TITLE
fix(jellycompat): authenticate Android TV token-less direct play

### DIFF
--- a/internal/jellycompat/auth.go
+++ b/internal/jellycompat/auth.go
@@ -257,8 +257,10 @@ func PlaybackSessionAuth(sessions *SessionStore, playbackStore *PlaybackSessionS
 			// the PlaybackSession negotiated for this item: a successful PlaybackInfo
 			// already authenticated the user and registered a session holding the
 			// CompatToken. Scope this strictly to the direct-play video stream routes
-			// (NOT /Items/{id}/Download) via the chi route pattern, and prefer
-			// matching on mediaSourceId when present to narrow which item is served.
+			// (NOT /Items/{id}/Download) via the chi route pattern, prefer matching
+			// on mediaSourceId when present, and require the matched session's
+			// RouteItemID to equal the requested item so a source id can't
+			// authorize a stream for a different item.
 			if playbackStore != nil {
 				switch chi.RouteContext(r.Context()).RoutePattern() {
 				case "/Videos/{id}/stream", "/Videos/{id}/stream.{container}":
@@ -269,7 +271,7 @@ func PlaybackSessionAuth(sessions *SessionStore, playbackStore *PlaybackSessionS
 						if mediaSourceID != "" {
 							lookupID = mediaSourceID
 						}
-						if playSession, _, found := playbackStore.FindByRoute("", lookupID); found {
+						if playSession, _, found := playbackStore.FindByRoute("", lookupID); found && playSession.RouteItemID == routeItemID {
 							if session, ok := resolveCompatToken(r.Context(), sessions, keyAuth, playSession.CompatToken); ok {
 								serveWithSession(next, w, r, session)
 								return

--- a/internal/jellycompat/auth.go
+++ b/internal/jellycompat/auth.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/Silo-Server/silo-server/internal/auth"
 	"github.com/Silo-Server/silo-server/internal/playback"
+	"github.com/go-chi/chi/v5"
 )
 
 type sessionContextKey string
@@ -249,6 +250,35 @@ func PlaybackSessionAuth(sessions *SessionStore, playbackStore *PlaybackSessionS
 					return
 				}
 			}
+
+			// Stock Jellyfin Android TV ignores the api_key-bearing DirectStreamUrl
+			// we return from PlaybackInfo and builds its own direct-play URL with no
+			// auth header, no api_key/ApiKey, and no PlaySessionId. Anchor auth on
+			// the PlaybackSession negotiated for this item: a successful PlaybackInfo
+			// already authenticated the user and registered a session holding the
+			// CompatToken. Scope this strictly to the direct-play video stream routes
+			// (NOT /Items/{id}/Download) via the chi route pattern, and prefer
+			// matching on mediaSourceId when present to narrow which item is served.
+			if playbackStore != nil {
+				switch chi.RouteContext(r.Context()).RoutePattern() {
+				case "/Videos/{id}/stream", "/Videos/{id}/stream.{container}":
+					routeItemID := chi.URLParam(r, "id")
+					if routeItemID != "" {
+						mediaSourceID := newCaseInsensitiveQuery(r.URL.Query()).Get("mediaSourceId")
+						lookupID := routeItemID
+						if mediaSourceID != "" {
+							lookupID = mediaSourceID
+						}
+						if playSession, _, found := playbackStore.FindByRoute("", lookupID); found {
+							if session, ok := resolveCompatToken(r.Context(), sessions, keyAuth, playSession.CompatToken); ok {
+								serveWithSession(next, w, r, session)
+								return
+							}
+						}
+					}
+				}
+			}
+
 			writeError(w, http.StatusUnauthorized, "Unauthorized", "Missing authentication token")
 		})
 	}

--- a/internal/jellycompat/auth_directplay_test.go
+++ b/internal/jellycompat/auth_directplay_test.go
@@ -26,12 +26,10 @@ func directPlayRouter(t *testing.T, sessions *SessionStore, playback *PlaybackSe
 	return r
 }
 
-// TestPlaybackSessionAuth_DirectPlayNoToken: stock Jellyfin Android TV requests
-// /Videos/{id}/stream?static=true with no auth header, no api_key/ApiKey, and no
-// PlaySessionId. The negotiated PlaybackSession for the item authorizes it.
-func TestPlaybackSessionAuth_DirectPlayNoToken(t *testing.T) {
-	now := fixedNow()
-	clock := func() time.Time { return now }
+// seedDirectPlaySession registers a resolvable compat session plus the
+// PlaybackSession that PlaybackInfo would have negotiated for the item.
+func seedDirectPlaySession(t *testing.T, clock func() time.Time) (*SessionStore, *PlaybackSessionStore) {
+	t.Helper()
 	sessions := NewSessionStore(time.Hour, clock)
 	if err := sessions.Put(Session{Token: "compat-tok", StreamAppUserID: 7}); err != nil {
 		t.Fatalf("put session: %v", err)
@@ -43,28 +41,58 @@ func TestPlaybackSessionAuth_DirectPlayNoToken(t *testing.T) {
 		RouteItemID:  "item123",
 		MediaSources: []PlaybackMediaSource{{ID: "src9"}},
 	})
+	return sessions, playback
+}
 
-	var reached bool
-	router := directPlayRouter(t, sessions, playback, nil, &reached)
+// TestPlaybackSessionAuth_DirectPlayNoToken: stock Jellyfin Android TV requests
+// the stream with no auth header, no api_key/ApiKey, and no PlaySessionId. The
+// negotiated PlaybackSession for the item authorizes it — across both stream
+// route patterns and both lookup branches (by mediaSourceId, and by route item
+// id when mediaSourceId is absent).
+func TestPlaybackSessionAuth_DirectPlayNoToken(t *testing.T) {
+	now := fixedNow()
+	clock := func() time.Time { return now }
 
-	req := httptest.NewRequest(http.MethodGet, "/Videos/item123/stream?static=true&mediaSourceId=src9&container=mkv", nil)
-	rec := httptest.NewRecorder()
-	router.ServeHTTP(rec, req)
-
-	if rec.Code != http.StatusOK {
-		t.Fatalf("status = %d, want 200; body=%s", rec.Code, rec.Body.String())
+	cases := []struct {
+		name string
+		url  string
+	}{
+		{"stream + mediaSourceId", "/Videos/item123/stream?static=true&mediaSourceId=src9&container=mkv"},
+		{"stream.{container} + mediaSourceId", "/Videos/item123/stream.mkv?static=true&mediaSourceId=src9"},
+		{"stream, route-item lookup (no mediaSourceId)", "/Videos/item123/stream?static=true&container=mkv"},
+		{"stream.{container}, route-item lookup", "/Videos/item123/stream.mkv?static=true"},
 	}
-	if !reached {
-		t.Fatal("expected inner handler to be reached via PlaybackSession fallback")
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			sessions, playback := seedDirectPlaySession(t, clock)
+			var reached bool
+			router := directPlayRouter(t, sessions, playback, nil, &reached)
+
+			req := httptest.NewRequest(http.MethodGet, tc.url, nil)
+			rec := httptest.NewRecorder()
+			router.ServeHTTP(rec, req)
+
+			if rec.Code != http.StatusOK {
+				t.Fatalf("status = %d, want 200; body=%s", rec.Code, rec.Body.String())
+			}
+			if !reached {
+				t.Fatal("expected inner handler to be reached via PlaybackSession fallback")
+			}
+		})
 	}
 }
 
-// TestPlaybackSessionAuth_DirectPlayNoMatchingSession: without a negotiated
-// PlaybackSession for the item, the token-less request stays a 401.
+// TestPlaybackSessionAuth_DirectPlayNoMatchingSession: with a resolvable compat
+// session present but NO PlaybackSession negotiated for the requested item, the
+// token-less request stays a 401 (proves the playback-session match gates it,
+// not a missing compat session).
 func TestPlaybackSessionAuth_DirectPlayNoMatchingSession(t *testing.T) {
 	now := fixedNow()
 	clock := func() time.Time { return now }
 	sessions := NewSessionStore(time.Hour, clock)
+	if err := sessions.Put(Session{Token: "compat-tok", StreamAppUserID: 7}); err != nil {
+		t.Fatalf("put session: %v", err)
+	}
 	playback := NewPlaybackSessionStore(time.Hour, clock)
 	// Session exists, but for a different item id and source id.
 	playback.Put(PlaybackSession{ID: "ps1", CompatToken: "compat-tok", RouteItemID: "other"})
@@ -84,15 +112,48 @@ func TestPlaybackSessionAuth_DirectPlayNoMatchingSession(t *testing.T) {
 	}
 }
 
-// TestPlaybackSessionAuth_DownloadNotLoosened: the new direct-play fallback must
-// not apply to /Items/{id}/Download — a token-less download stays 401 even when a
-// PlaybackSession exists for the same item id.
-func TestPlaybackSessionAuth_DownloadNotLoosened(t *testing.T) {
+// TestPlaybackSessionAuth_DirectPlayCrossItemDenied: a mediaSourceId that resolves
+// to a session for a DIFFERENT route item must not authorize the request — the
+// session's RouteItemID must match the requested item.
+func TestPlaybackSessionAuth_DirectPlayCrossItemDenied(t *testing.T) {
 	now := fixedNow()
 	clock := func() time.Time { return now }
 	sessions := NewSessionStore(time.Hour, clock)
+	if err := sessions.Put(Session{Token: "compat-tok", StreamAppUserID: 7}); err != nil {
+		t.Fatalf("put session: %v", err)
+	}
 	playback := NewPlaybackSessionStore(time.Hour, clock)
-	playback.Put(PlaybackSession{ID: "ps1", CompatToken: "compat-tok", RouteItemID: "item123"})
+	// src9 belongs to itemB's session; the request targets itemA.
+	playback.Put(PlaybackSession{
+		ID:           "psB",
+		CompatToken:  "compat-tok",
+		RouteItemID:  "itemB",
+		MediaSources: []PlaybackMediaSource{{ID: "src9"}},
+	})
+
+	var reached bool
+	router := directPlayRouter(t, sessions, playback, nil, &reached)
+
+	req := httptest.NewRequest(http.MethodGet, "/Videos/itemA/stream?static=true&mediaSourceId=src9", nil)
+	rec := httptest.NewRecorder()
+	router.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusUnauthorized {
+		t.Fatalf("status = %d, want 401; body=%s", rec.Code, rec.Body.String())
+	}
+	if reached {
+		t.Fatal("inner handler must not run when the matched session belongs to another item")
+	}
+}
+
+// TestPlaybackSessionAuth_DownloadNotLoosened: the new direct-play fallback must
+// not apply to /Items/{id}/Download — a token-less download stays 401 even when a
+// resolvable compat session AND a PlaybackSession exist for the same item id, so
+// the 401 proves route scoping rather than a missing session.
+func TestPlaybackSessionAuth_DownloadNotLoosened(t *testing.T) {
+	now := fixedNow()
+	clock := func() time.Time { return now }
+	sessions, playback := seedDirectPlaySession(t, clock)
 
 	var reached bool
 	router := directPlayRouter(t, sessions, playback, nil, &reached)

--- a/internal/jellycompat/auth_directplay_test.go
+++ b/internal/jellycompat/auth_directplay_test.go
@@ -1,0 +1,110 @@
+package jellycompat
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/go-chi/chi/v5"
+)
+
+// directPlayRouter wraps the probe handler in PlaybackSessionAuth and mounts it
+// on a chi router so RoutePattern() and URLParam("id") are populated exactly as
+// they are in production. The same handler also fronts /Items/{id}/Download to
+// prove the new token-less fallback does NOT leak into that route.
+func directPlayRouter(t *testing.T, sessions *SessionStore, playback *PlaybackSessionStore, keyAuth *AdminAPIKeyAuthenticator, reached *bool) *chi.Mux {
+	t.Helper()
+	probe := PlaybackSessionAuth(sessions, playback, keyAuth)(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		*reached = true
+		w.WriteHeader(http.StatusOK)
+	}))
+	r := chi.NewRouter()
+	r.Handle("/Videos/{id}/stream", probe)
+	r.Handle("/Videos/{id}/stream.{container}", probe)
+	r.Handle("/Items/{id}/Download", probe)
+	return r
+}
+
+// TestPlaybackSessionAuth_DirectPlayNoToken: stock Jellyfin Android TV requests
+// /Videos/{id}/stream?static=true with no auth header, no api_key/ApiKey, and no
+// PlaySessionId. The negotiated PlaybackSession for the item authorizes it.
+func TestPlaybackSessionAuth_DirectPlayNoToken(t *testing.T) {
+	now := fixedNow()
+	clock := func() time.Time { return now }
+	sessions := NewSessionStore(time.Hour, clock)
+	if err := sessions.Put(Session{Token: "compat-tok", StreamAppUserID: 7}); err != nil {
+		t.Fatalf("put session: %v", err)
+	}
+	playback := NewPlaybackSessionStore(time.Hour, clock)
+	playback.Put(PlaybackSession{
+		ID:           "ps1",
+		CompatToken:  "compat-tok",
+		RouteItemID:  "item123",
+		MediaSources: []PlaybackMediaSource{{ID: "src9"}},
+	})
+
+	var reached bool
+	router := directPlayRouter(t, sessions, playback, nil, &reached)
+
+	req := httptest.NewRequest(http.MethodGet, "/Videos/item123/stream?static=true&mediaSourceId=src9&container=mkv", nil)
+	rec := httptest.NewRecorder()
+	router.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200; body=%s", rec.Code, rec.Body.String())
+	}
+	if !reached {
+		t.Fatal("expected inner handler to be reached via PlaybackSession fallback")
+	}
+}
+
+// TestPlaybackSessionAuth_DirectPlayNoMatchingSession: without a negotiated
+// PlaybackSession for the item, the token-less request stays a 401.
+func TestPlaybackSessionAuth_DirectPlayNoMatchingSession(t *testing.T) {
+	now := fixedNow()
+	clock := func() time.Time { return now }
+	sessions := NewSessionStore(time.Hour, clock)
+	playback := NewPlaybackSessionStore(time.Hour, clock)
+	// Session exists, but for a different item id and source id.
+	playback.Put(PlaybackSession{ID: "ps1", CompatToken: "compat-tok", RouteItemID: "other"})
+
+	var reached bool
+	router := directPlayRouter(t, sessions, playback, nil, &reached)
+
+	req := httptest.NewRequest(http.MethodGet, "/Videos/item123/stream?static=true&mediaSourceId=src9", nil)
+	rec := httptest.NewRecorder()
+	router.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusUnauthorized {
+		t.Fatalf("status = %d, want 401; body=%s", rec.Code, rec.Body.String())
+	}
+	if reached {
+		t.Fatal("inner handler must not run without a matching PlaybackSession")
+	}
+}
+
+// TestPlaybackSessionAuth_DownloadNotLoosened: the new direct-play fallback must
+// not apply to /Items/{id}/Download — a token-less download stays 401 even when a
+// PlaybackSession exists for the same item id.
+func TestPlaybackSessionAuth_DownloadNotLoosened(t *testing.T) {
+	now := fixedNow()
+	clock := func() time.Time { return now }
+	sessions := NewSessionStore(time.Hour, clock)
+	playback := NewPlaybackSessionStore(time.Hour, clock)
+	playback.Put(PlaybackSession{ID: "ps1", CompatToken: "compat-tok", RouteItemID: "item123"})
+
+	var reached bool
+	router := directPlayRouter(t, sessions, playback, nil, &reached)
+
+	req := httptest.NewRequest(http.MethodGet, "/Items/item123/Download", nil)
+	rec := httptest.NewRecorder()
+	router.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusUnauthorized {
+		t.Fatalf("status = %d, want 401; body=%s", rec.Code, rec.Body.String())
+	}
+	if reached {
+		t.Fatal("download route must not be served via the direct-play fallback")
+	}
+}


### PR DESCRIPTION
## Problem

Stock **Jellyfin Android TV** fails direct play against the jellycompat layer.

Observed sequence (from production logs, one episode, one TV):
1. `POST /Items/{id}/PlaybackInfo` → **200** (user authenticated; a `PlaybackSession` is registered holding the `CompatToken`, `RouteItemID`, and media sources).
2. The app then requests direct play: `GET /Videos/{id}/stream?static=true&container=mkv&tag=…&mediaSourceId=…` — but the request is made by the player's HTTP stack (`okhttp/4.12.0`) with **no auth header, no `api_key`/`ApiKey` query param, and no `PlaySessionId`** (`auth_kind=none`).
3. `PlaybackSessionAuth` has only two ways in — a token, or a `PlaySessionId` lookup — so it returns **401**. The client retries, falls back to a transcode that stalls after a couple of segments, and surfaces *"player error occurred, will try again"*.

The Jellyfin phone app works because it sends `X-Emby-Token`. We already return a `DirectStreamUrl` containing `api_key` from `PlaybackInfo`, but this client ignores it and builds its own token-less URL — slipping past even the existing lowercase-`playSessionId` accommodation (added for Wholphin).

## Fix

Add a third fallback in `PlaybackSessionAuth`, **scoped strictly to the direct-play video stream routes** (`/Videos/{id}/stream` and `/Videos/{id}/stream.{container}`) via the chi route pattern so `/Items/{id}/Download` stays protected. It anchors auth on the `PlaybackSession` negotiated during the preceding (already-authenticated) `PlaybackInfo`, looked up by `mediaSourceId` when present (else the route item id), and resolves its `CompatToken` exactly like the existing `PlaySessionId` branch.

## Security note

This serves a token-less direct-play stream when an unexpired `PlaybackSession` exists for the item. That mirrors the existing token-less HLS exposure (which is `PlaySessionId`-gated); item ids are more guessable, so the lookup prefers `mediaSourceId` to narrow it, and it is gated to the stream routes only. A natural follow-up is to restrict the fallback to sessions negotiated by Android TV (flag set from the `PlaybackInfo` User-Agent) — happy to add that if preferred.

## Tests

`internal/jellycompat/auth_directplay_test.go`:
- token-less direct play **with** a matching session → served (200)
- no matching session → 401
- `/Items/{id}/Download` token-less → still 401 (fallback does not apply)

Verified `go vet` + full `internal/jellycompat` test suite pass in a libvips-capable container; no regressions.

## AI-use disclosure

Investigated and authored with assistance from Claude Code (Claude Opus 4.8).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved playback authentication for direct-play streaming routes, allowing requests to continue when a matching playback session is already available.
  * Added a fallback path for stream URLs with or without a container suffix, reducing unauthorized failures for valid playback requests.
  * Kept download requests unchanged, so authentication requirements still apply where expected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->