### PR TITLE
fix(plugins): restore image resolver startup build

### DIFF
--- a/cmd/silo/main.go
+++ b/cmd/silo/main.go
@@ -1074,9 +1074,9 @@ func main() {
 		<-pluginAutoUpdateDone
 
 		imageResolver := metadata.NewPluginImageResolver()
-		if pluginService != nil && installationStore != nil {
+		if pluginService != nil && pluginInstallationStore != nil {
 			reloadImageResolvers := func(ctx context.Context) {
-				if err := reloadPluginImageResolvers(ctx, installationStore, imageResolver, pluginService); err != nil {
+				if err := reloadPluginImageResolvers(ctx, pluginInstallationStore, imageResolver, pluginService); err != nil {
 					slog.Warn("failed to reload plugin image resolvers", "error", err)
 				}
 			}


### PR DESCRIPTION
Part of #135.

## Summary
- use the long-lived `pluginInstallationStore` when wiring plugin image resolver lifecycle reloads
- fixes `cmd/silo/main.go: undefined: installationStore` in production/Docker builds

## Verification
- `make frontend`
- `GOWORK=off go test ./cmd/silo`
- `GOWORK=off go build -o /tmp/silo-build-check ./cmd/silo/`
- Docker-shaped SDK replacement compile using temporary `-modfile` and `replace=github.com/Silo-Server/silo-plugin-sdk=/Volumes/NVMe/dev/github/SiloServer/silo-plugin-sdk`
- `GOWORK=off go test ./internal/metadata ./internal/pluginhost ./internal/plugins`
- `GOWORK=off go test ./internal/api/handlers -run 'Plugin|Install|Upload|Update|Delete|Capability|Image'`\n\n## AI use\nImplemented with Codex.