### PR TITLE
Fix semantic-disabled Meilisearch settings

### DIFF
--- a/internal/catalog/search_indexer.go
+++ b/internal/catalog/search_indexer.go
@@ -258,7 +258,7 @@ func (i *CatalogSearchIndexer) Rebuild(ctx context.Context, progress SearchIndex
 	if err := client.WaitTask(ctx, taskID); err != nil {
 		return stats, err
 	}
-	taskID, err = client.UpdateSettings(ctx, buildIndexUID, catalogSearchMeilisearchSettings(settings.Embedder))
+	taskID, err = client.UpdateSettings(ctx, buildIndexUID, catalogSearchMeilisearchSettings(settings.Embedder, settings.SemanticEnabled))
 	if err != nil {
 		return stats, err
 	}
@@ -438,12 +438,8 @@ func (i *CatalogSearchIndexer) CheckConnection(ctx context.Context, settings Cat
 	return client.Health(ctx)
 }
 
-func catalogSearchMeilisearchSettings(embedder string) map[string]any {
-	embedder, err := NormalizeCatalogSearchEmbedderName(embedder)
-	if err != nil {
-		embedder = DefaultMeilisearchEmbedder
-	}
-	return map[string]any{
+func catalogSearchMeilisearchSettings(embedder string, semanticEnabled bool) map[string]any {
+	settings := map[string]any{
 		"displayedAttributes":  []string{"content_id", "type"},
 		"filterableAttributes": []string{"type"},
 		"searchableAttributes": []string{
@@ -462,8 +458,15 @@ func catalogSearchMeilisearchSettings(embedder string) map[string]any {
 		"pagination": map[string]any{
 			"maxTotalHits": meilisearchDefaultCandidateScanCap,
 		},
-		"embedders": catalogSearchMeilisearchEmbedderSettings(embedder),
 	}
+	if semanticEnabled {
+		embedder, err := NormalizeCatalogSearchEmbedderName(embedder)
+		if err != nil {
+			embedder = DefaultMeilisearchEmbedder
+		}
+		settings["embedders"] = catalogSearchMeilisearchEmbedderSettings(embedder)
+	}
+	return settings
 }
 
 func coalesceSearchIndexEvents(events []SearchIndexEvent) (upsertIDs []string, deleteIDs []string) {

--- a/internal/catalog/search_provider_test.go
+++ b/internal/catalog/search_provider_test.go
@@ -127,6 +127,29 @@ func TestCatalogSearchDocumentVectorsUseEmbedderAndOptOutMissing(t *testing.T) {
 	}
 }
 
+func TestCatalogSearchMeilisearchSettingsOmitEmbeddersWhenSemanticDisabled(t *testing.T) {
+	settings := catalogSearchMeilisearchSettings("silo_recommendations", false)
+
+	if _, ok := settings["embedders"]; ok {
+		t.Fatalf("semantic-disabled settings should not include embedders: %#v", settings["embedders"])
+	}
+	if _, ok := settings["searchableAttributes"]; !ok {
+		t.Fatal("semantic-disabled settings should still configure keyword searchable attributes")
+	}
+}
+
+func TestCatalogSearchMeilisearchSettingsIncludeEmbeddersWhenSemanticEnabled(t *testing.T) {
+	settings := catalogSearchMeilisearchSettings("custom_embedder", true)
+
+	embedders, ok := settings["embedders"].(map[string]any)
+	if !ok {
+		t.Fatalf("embedders = %#v, want map[string]any", settings["embedders"])
+	}
+	if _, ok := embedders["custom_embedder"]; !ok {
+		t.Fatalf("embedders = %#v, want custom_embedder", embedders)
+	}
+}
+
 func TestCatalogSearchDocumentPayloadBatchesSplitVectorDocs(t *testing.T) {
 	vector := make([]float32, 128)
 	docs := []catalogSearchDocument{

--- a/migrations/sql/20260626160056_meilisearch_semantic_ratio_default_050.sql
+++ b/migrations/sql/20260626160056_meilisearch_semantic_ratio_default_050.sql
@@ -1,0 +1,15 @@
+-- +goose Up
+UPDATE server_settings
+SET value = '0.50'
+WHERE key = 'catalog.search.meilisearch.semantic_ratio'
+  AND value = '0.30';
+
+INSERT INTO server_settings (key, value)
+VALUES ('catalog.search.meilisearch.semantic_ratio', '0.50')
+ON CONFLICT (key) DO NOTHING;
+
+-- +goose Down
+UPDATE server_settings
+SET value = '0.30'
+WHERE key = 'catalog.search.meilisearch.semantic_ratio'
+  AND value = '0.50';


### PR DESCRIPTION
## Summary
- Omit Meilisearch `embedders` settings when semantic search is disabled so keyword-only indexes do not receive vector configuration.
- Preserve keyword search settings for semantic-disabled deployments.
- Add a Goose migration to default `catalog.search.meilisearch.semantic_ratio` to `0.50`.

## Testing
- Added tests covering Meilisearch settings with semantic search enabled and disabled.
- Not run: full test suite.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Search settings now respect whether semantic indexing is enabled, improving how catalog search is configured.
  * The default semantic search ratio has been updated to a higher value for new and existing setups.

* **Bug Fixes**
  * Prevented unnecessary semantic search configuration from being applied when semantic indexing is turned off.
  * Added coverage to ensure search settings behave correctly in both semantic-enabled and semantic-disabled cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->