### PR TITLE
fix(web): preserve untouched metadata levels when toggling a provider

### DIFF
--- a/web/src/components/admin/libraries/useLibraryForm.ts
+++ b/web/src/components/admin/libraries/useLibraryForm.ts
@@ -257,12 +257,10 @@ export function useLibraryForm({
   }
 
   function toggleLevelProvider(level: string, index: number) {
-    setLevelChains((prev) => {
-      const source = prev[level] ?? activeLevelChains[level] ?? [];
-      const updated = [...source];
-      updated[index] = { ...updated[index]!, enabled: !updated[index]!.enabled };
-      return { ...prev, [level]: updated };
-    });
+    const source = activeLevelChains[level] ?? [];
+    const updated = [...source];
+    updated[index] = { ...updated[index]!, enabled: !updated[index]!.enabled };
+    setLevelChains({ ...activeLevelChains, [level]: updated });
     setChainDirty(true);
   }
 


### PR DESCRIPTION
## Problem

In the library create/edit dialog, disabling a metadata source on one TV level (e.g. unchecking a provider on the show level) blanks the provider lists on the *other* levels (season/episode). The dialog renders the untouched levels empty. Reordering a level first makes it "start to behave."

This was reported, imported to #213, and closed as fixed citing the dialog redesign (`b9a9613`). A user on a build that **already contains** that commit reported the same issue, so the fix was confirmed present-and-insufficient.

## Root cause

`toggleLevelProvider` merged the toggled level into the `levelChains` state object, which starts as `{}`:

```js
return { ...prev, [level]: updated };  // prev starts {} -> only the toggled level survives
```

After the first toggle, `levelChains` holds a single level. Once `chainDirty` flips true, `activeLevelChains = levelChains`, so every untouched level becomes `undefined` and renders as `[]`.

`b9a9613` only patched the *per-level* `source` fallback (`prev[level] ?? activeLevelChains[level]`), which preserved the toggled level's own items but never preserved the rest of the map. `reorderLevel` was already correct — it spreads the full `activeLevelChains` map — which is why reordering first masked the bug.

## Fix

Make `toggleLevelProvider` seed from the full resolved `activeLevelChains` map and write it back the same way `reorderLevel` does, so all untouched levels are preserved on the first toggle.

## Risk / scope

Frontend-only state change in `useLibraryForm.ts`, mirroring existing `reorderLevel` behavior. No API/contract impact. No new tests (small UI state change, consistent with repo norms). `prettier --check` and `eslint` pass.

Part of #213

## AI-use disclosure

Diagnosed and implemented with Claude Code (Opus 4.8).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved level provider toggling so changes are applied more reliably when editing library settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->