### PR TITLE
feat(watchsync): sync watchlists with Trakt/Simkl/MDBList

### DIFF
--- a/cmd/silo/main.go
+++ b/cmd/silo/main.go
@@ -95,6 +95,7 @@ import (
 	"github.com/Silo-Server/silo-server/internal/userdb"
 	"github.com/Silo-Server/silo-server/internal/userstore"
 	"github.com/Silo-Server/silo-server/internal/userstore/pgstore"
+	"github.com/Silo-Server/silo-server/internal/watchlist"
 	"github.com/Silo-Server/silo-server/internal/watchstate"
 	"github.com/Silo-Server/silo-server/internal/watchsync"
 	watchmdblist "github.com/Silo-Server/silo-server/internal/watchsync/providers/mdblist"
@@ -1449,6 +1450,15 @@ func main() {
 			}
 		})
 	}
+	// Auto-remove fully-watched items from the watchlist (standalone behavior,
+	// default-on per profile), propagating removals to connected providers.
+	if itemRepo != nil && episodeRepo != nil && userStoreProvider != nil {
+		maintainer := watchlist.NewMaintainer(userStoreProvider, itemRepo, episodeRepo)
+		if watchProviderService != nil {
+			maintainer.WithListEventDispatcher(watchProviderService)
+		}
+		deps.WatchCompletionObserver = maintainer
+	}
 	deps.SessionMgr = sessionMgr
 	deps.PlaybackRealtimeHub = playback.NewRealtimeHub()
 	if chapterThumbService != nil && deps.S3Public != nil {
@@ -2172,6 +2182,7 @@ func main() {
 			compatDeps.FolderRepo = folderRepo
 			compatDeps.SessionMgr = sessionMgr
 			compatDeps.UserStoreProvider = userStoreProvider
+			compatDeps.WatchCompletionObserver = deps.WatchCompletionObserver
 			compatDeps.SettingsRepo = settingsRepo
 			compatDeps.PersonRepo = personRepo
 

--- a/internal/access/resolver_test.go
+++ b/internal/access/resolver_test.go
@@ -130,9 +130,18 @@ func (s stubStore) ListFavorites(context.Context, string, int, int) ([]userstore
 func (s stubStore) ListFavoritesByMediaItems(context.Context, string, []string) (map[string]bool, error) {
 	panic("unused")
 }
-func (s stubStore) IsFavorite(context.Context, string, string) (bool, error)  { panic("unused") }
-func (s stubStore) AddToWatchlist(context.Context, string, string) error      { panic("unused") }
+func (s stubStore) IsFavorite(context.Context, string, string) (bool, error) { panic("unused") }
+func (s stubStore) AddToWatchlist(context.Context, string, string) error     { panic("unused") }
+func (s stubStore) AddToWatchlistAt(context.Context, string, string, time.Time) error {
+	panic("unused")
+}
+func (s stubStore) RemoveWatchedFromWatchlist(context.Context, string) (bool, error) {
+	return true, nil
+}
 func (s stubStore) RemoveFromWatchlist(context.Context, string, string) error { panic("unused") }
+func (s stubStore) ReplaceWatchlistOrder(context.Context, string, []string) error {
+	panic("unused")
+}
 func (s stubStore) ListWatchlist(context.Context, string, int, int) ([]userstore.WatchlistEntry, error) {
 	panic("unused")
 }

--- a/internal/api/handlers/favorites.go
+++ b/internal/api/handlers/favorites.go
@@ -25,8 +25,8 @@ type personalDataItemRepository interface {
 	EnsureAccessible(ctx context.Context, contentID string, filter catalog.AccessFilter) error
 }
 
-type LocalFavoriteEventDispatcher interface {
-	HandleLocalFavoriteEvent(ctx context.Context, event watchsync.LocalFavoriteEvent) error
+type LocalListEventDispatcher interface {
+	HandleLocalListEvent(ctx context.Context, event watchsync.LocalListEvent) error
 }
 
 // PersonalDataHandler handles favorites, watchlist, and history endpoints.
@@ -37,7 +37,7 @@ type PersonalDataHandler struct {
 	seasonRepo              *catalog.SeasonRepository
 	detailSvc               *catalog.DetailService
 	EventsHub               *evt.Hub
-	localFavoriteDispatcher LocalFavoriteEventDispatcher
+	localListDispatcher     LocalListEventDispatcher
 	profileStaler           ProfileStaler
 	profileRefreshRequester ProfileRefreshRequester
 	ebookProgressStore      EbookReaderProgressLister
@@ -78,8 +78,8 @@ func (h *PersonalDataHandler) SetSeasonRepo(repo *catalog.SeasonRepository) {
 	h.seasonRepo = repo
 }
 
-func (h *PersonalDataHandler) SetLocalFavoriteEventDispatcher(dispatcher LocalFavoriteEventDispatcher) {
-	h.localFavoriteDispatcher = dispatcher
+func (h *PersonalDataHandler) SetLocalListEventDispatcher(dispatcher LocalListEventDispatcher) {
+	h.localListDispatcher = dispatcher
 }
 
 // --- Response types ---
@@ -219,7 +219,7 @@ func (h *PersonalDataHandler) HandleAddFavorite(w http.ResponseWriter, r *http.R
 		return
 	}
 
-	h.dispatchLocalFavoriteEvent(r.Context(), watchsync.LocalFavoriteEventAdded, userID, profileID, itemID)
+	h.dispatchLocalListEvent(r.Context(), watchsync.ListKindFavorites, watchsync.ListChangeAdded, userID, profileID, itemID)
 	triggerProfileRefresh(r.Context(), h.profileStaler, h.profileRefreshRequester, userID, profileID)
 	publishUserStateEvent(r.Context(), h.EventsHub, userID, profileID, itemID, "", "favorite", userStateEventState{
 		IsFavorite: boolPtr(true),
@@ -249,7 +249,7 @@ func (h *PersonalDataHandler) HandleRemoveFavorite(w http.ResponseWriter, r *htt
 		return
 	}
 
-	h.dispatchLocalFavoriteEvent(r.Context(), watchsync.LocalFavoriteEventRemoved, userID, profileID, itemID)
+	h.dispatchLocalListEvent(r.Context(), watchsync.ListKindFavorites, watchsync.ListChangeRemoved, userID, profileID, itemID)
 	triggerProfileRefresh(r.Context(), h.profileStaler, h.profileRefreshRequester, userID, profileID)
 	publishUserStateEvent(r.Context(), h.EventsHub, userID, profileID, itemID, "", "favorite", userStateEventState{
 		IsFavorite: boolPtr(false),
@@ -257,15 +257,15 @@ func (h *PersonalDataHandler) HandleRemoveFavorite(w http.ResponseWriter, r *htt
 	w.WriteHeader(http.StatusNoContent)
 }
 
-func (h *PersonalDataHandler) dispatchLocalFavoriteEvent(ctx context.Context, kind watchsync.LocalFavoriteEventKind, userID int, profileID string, itemID string) {
-	if h == nil || h.localFavoriteDispatcher == nil || h.itemRepo == nil {
+func (h *PersonalDataHandler) dispatchLocalListEvent(ctx context.Context, list watchsync.ListKind, change watchsync.ListChange, userID int, profileID string, itemID string) {
+	if h == nil || h.localListDispatcher == nil || h.itemRepo == nil {
 		return
 	}
 	item, err := h.itemRepo.GetByID(ctx, itemID)
 	if err != nil || item == nil {
 		return
 	}
-	favorite := watchsync.LocalFavorite{
+	listItem := watchsync.LocalFavorite{
 		MediaItemID: item.ContentID,
 		Kind:        item.Type,
 		Title:       item.Title,
@@ -275,11 +275,12 @@ func (h *PersonalDataHandler) dispatchLocalFavoriteEvent(ctx context.Context, ki
 		TVDBID:      item.TvdbID,
 		FavoritedAt: time.Now().UTC(),
 	}
-	_ = h.localFavoriteDispatcher.HandleLocalFavoriteEvent(ctx, watchsync.LocalFavoriteEvent{
-		Kind:      kind,
+	_ = h.localListDispatcher.HandleLocalListEvent(ctx, watchsync.LocalListEvent{
+		List:      list,
+		Change:    change,
 		UserID:    userID,
 		ProfileID: profileID,
-		Favorites: []watchsync.LocalFavorite{favorite},
+		Items:     []watchsync.LocalFavorite{listItem},
 	})
 }
 
@@ -374,6 +375,7 @@ func (h *PersonalDataHandler) HandleAddToWatchlist(w http.ResponseWriter, r *htt
 		return
 	}
 
+	h.dispatchLocalListEvent(r.Context(), watchsync.ListKindWatchlist, watchsync.ListChangeAdded, userID, profileID, itemID)
 	triggerProfileRefresh(r.Context(), h.profileStaler, h.profileRefreshRequester, userID, profileID)
 	publishUserStateEvent(r.Context(), h.EventsHub, userID, profileID, itemID, "", "watchlist", userStateEventState{
 		InWatchlist: boolPtr(true),
@@ -403,6 +405,7 @@ func (h *PersonalDataHandler) HandleRemoveFromWatchlist(w http.ResponseWriter, r
 		return
 	}
 
+	h.dispatchLocalListEvent(r.Context(), watchsync.ListKindWatchlist, watchsync.ListChangeRemoved, userID, profileID, itemID)
 	triggerProfileRefresh(r.Context(), h.profileStaler, h.profileRefreshRequester, userID, profileID)
 	publishUserStateEvent(r.Context(), h.EventsHub, userID, profileID, itemID, "", "watchlist", userStateEventState{
 		InWatchlist: boolPtr(false),

--- a/internal/api/handlers/items.go
+++ b/internal/api/handlers/items.go
@@ -107,6 +107,15 @@ func NewItemsHandler(
 	}
 }
 
+// SetCompletionObserver wires an optional observer notified when a watch
+// completes (used to auto-remove fully-watched items from the watchlist).
+func (h *ItemsHandler) SetCompletionObserver(obs watchstate.CompletionObserver) {
+	if h == nil || h.watchState == nil || obs == nil {
+		return
+	}
+	h.watchState.WithCompletionObserver(obs)
+}
+
 // SetProfileStaler configures an optional staleness trigger for taste profiles.
 func (h *ItemsHandler) SetProfileStaler(ps ProfileStaler) {
 	h.profileStaler = ps

--- a/internal/api/handlers/playback.go
+++ b/internal/api/handlers/playback.go
@@ -103,6 +103,7 @@ type PlaybackHandler struct {
 	StoreProvider           userstore.UserStoreProvider // optional; enables progress/history persistence
 	WatchScrobbler          PlaybackWatchScrobbler
 	StableIdentityResolver  *watchstate.StableIdentityResolver
+	CompletionObserver      watchstate.CompletionObserver // optional; auto-removes watched items from the watchlist
 	profileStaler           ProfileStaler
 	profileRefreshRequester ProfileRefreshRequester
 	AdminStore              PlaybackAdminStore    // optional; enables admin playback history/live session cleanup
@@ -826,7 +827,9 @@ func (h *PlaybackHandler) persistStopAndHistory(ctx context.Context, session *pl
 
 	duration := float64(file.Duration)
 	thresholds := h.playbackThresholds(ctx)
-	watchSvc := watchstate.NewService(h.StoreProvider).WithStableIdentityResolver(h.StableIdentityResolver)
+	watchSvc := watchstate.NewService(h.StoreProvider).
+		WithStableIdentityResolver(h.StableIdentityResolver).
+		WithCompletionObserver(h.CompletionObserver)
 	stoppedAt := time.Now().UTC()
 	result, err := watchSvc.RecordPlaybackStop(ctx, session.UserID, session.ProfileID, targetID, duration, session.Position, stoppedAt, userstore.VersionHints{
 		FileID:     file.ID,

--- a/internal/api/router.go
+++ b/internal/api/router.go
@@ -143,6 +143,7 @@ type Dependencies struct {
 	MarkerContributionStore      *markers.ContributionStore
 	MarkerContributionService    *markers.ContributionService
 	WatchProviderService         handlers.WatchProviderService
+	WatchCompletionObserver      watchstate.CompletionObserver
 	PluginService                *plugins.Service
 	PluginHTTPProxy              *plugins.HTTPProxy
 	PluginUserConfig             *plugins.UserConfigStore
@@ -523,6 +524,9 @@ func NewRouter(deps Dependencies) chi.Router {
 		if dispatcher, ok := deps.WatchProviderService.(handlers.LocalWatchEventDispatcher); ok {
 			itemsHandler.SetLocalWatchEventDispatcher(dispatcher)
 		}
+		if deps.WatchCompletionObserver != nil {
+			itemsHandler.SetCompletionObserver(deps.WatchCompletionObserver)
+		}
 		if ebookProgressStore != nil {
 			itemsHandler.SetEbookReaderProgressStore(ebookProgressStore)
 		}
@@ -638,8 +642,8 @@ func NewRouter(deps Dependencies) chi.Router {
 		personalDataHandler.SetEpisodeRepo(episodeRepo)
 		personalDataHandler.SetSeasonRepo(seasonRepo)
 		personalDataHandler.EventsHub = deps.EventsHub
-		if dispatcher, ok := deps.WatchProviderService.(handlers.LocalFavoriteEventDispatcher); ok {
-			personalDataHandler.SetLocalFavoriteEventDispatcher(dispatcher)
+		if dispatcher, ok := deps.WatchProviderService.(handlers.LocalListEventDispatcher); ok {
+			personalDataHandler.SetLocalListEventDispatcher(dispatcher)
 		}
 		progressHandler = handlers.NewProgressHandler(deps.UserStoreProvider)
 		progressHandler.EventsHub = deps.EventsHub
@@ -734,6 +738,7 @@ func NewRouter(deps Dependencies) chi.Router {
 			playbackHandler.StoreProvider = deps.UserStoreProvider
 		}
 		playbackHandler.StableIdentityResolver = watchstate.NewStableIdentityResolver(itemRepo, episodeRepo, providerIDRepo)
+		playbackHandler.CompletionObserver = deps.WatchCompletionObserver
 		if scrobbler, ok := deps.WatchProviderService.(handlers.PlaybackWatchScrobbler); ok {
 			playbackHandler.WatchScrobbler = scrobbler
 		}

--- a/internal/catalog/orphan_cleanup.go
+++ b/internal/catalog/orphan_cleanup.go
@@ -115,8 +115,8 @@ const orphanedMediaItemSafetyConditions = `NOT EXISTS (
 	WHERE uwl.media_item_id = mi.content_id
   )
   AND NOT EXISTS (
-	SELECT 1 FROM public.watch_provider_favorite_items wpfi
-	WHERE wpfi.media_item_id = mi.content_id
+	SELECT 1 FROM public.watch_provider_list_items wpli
+	WHERE wpli.media_item_id = mi.content_id
   )
   AND NOT EXISTS (
 	SELECT 1 FROM public.watch_provider_history_exports wphe

--- a/internal/catalog/orphan_cleanup_test.go
+++ b/internal/catalog/orphan_cleanup_test.go
@@ -24,6 +24,7 @@ func TestOrphanedProvisionalPredicatePreservesDurableMediaItemReferences(t *test
 		"public.user_personal_collection_items upci WHERE upci.media_item_id = mi.content_id",
 		"public.user_series_playback_preferences uspp WHERE uspp.series_id = mi.content_id",
 		"public.user_subtitle_preferences usp WHERE usp.series_id = mi.content_id",
+		"public.watch_provider_list_items wpli WHERE wpli.media_item_id = mi.content_id",
 	} {
 		if !strings.Contains(predicate, normalizePredicateSQL(want)) {
 			t.Fatalf("cleanup predicate missing durable reference guard %q", want)
@@ -33,6 +34,7 @@ func TestOrphanedProvisionalPredicatePreservesDurableMediaItemReferences(t *test
 		"abs_collection_items",
 		"abs_playlist_items",
 		"abs_playlists",
+		"watch_provider_favorite_items",
 	} {
 		if strings.Contains(predicate, droppedTable) {
 			t.Fatalf("cleanup predicate must not reference dropped legacy table %q", droppedTable)

--- a/internal/jellycompat/content_direct_test.go
+++ b/internal/jellycompat/content_direct_test.go
@@ -278,7 +278,16 @@ func (s *progressCountingStore) IsFavorite(context.Context, string, string) (boo
 func (s *progressCountingStore) AddToWatchlist(context.Context, string, string) error {
 	panic("unused")
 }
+func (s *progressCountingStore) AddToWatchlistAt(context.Context, string, string, time.Time) error {
+	panic("unused")
+}
+func (s *progressCountingStore) RemoveWatchedFromWatchlist(context.Context, string) (bool, error) {
+	return true, nil
+}
 func (s *progressCountingStore) RemoveFromWatchlist(context.Context, string, string) error {
+	panic("unused")
+}
+func (s *progressCountingStore) ReplaceWatchlistOrder(context.Context, string, []string) error {
 	panic("unused")
 }
 func (s *progressCountingStore) ListWatchlist(context.Context, string, int, int) ([]userstore.WatchlistEntry, error) {

--- a/internal/jellycompat/router.go
+++ b/internal/jellycompat/router.go
@@ -337,6 +337,7 @@ func withDefaults(deps Dependencies) Dependencies {
 			catalog.NewContinueWatchingProgressFilter(pool),
 			staler,
 			deps.RecWorker,
+			deps.WatchCompletionObserver,
 		)
 	}
 

--- a/internal/jellycompat/server.go
+++ b/internal/jellycompat/server.go
@@ -19,6 +19,7 @@ import (
 	"github.com/Silo-Server/silo-server/internal/secret"
 	"github.com/Silo-Server/silo-server/internal/subtitles"
 	"github.com/Silo-Server/silo-server/internal/userstore"
+	"github.com/Silo-Server/silo-server/internal/watchstate"
 )
 
 // Dependencies holds the pluggable pieces used by the compat server.
@@ -50,6 +51,10 @@ type Dependencies struct {
 	ContentService  ContentService
 	UserDataService UserDataService
 	AuthService     *auth.Service
+
+	// WatchCompletionObserver is notified when a Jellyfin-compat mark-played
+	// completes a watch, so fully-watched items leave the watchlist. Optional.
+	WatchCompletionObserver watchstate.CompletionObserver
 
 	// Autoscan / admin compatibility support.
 	APIKeyValidator  apiKeyValidator

--- a/internal/jellycompat/userdata_direct.go
+++ b/internal/jellycompat/userdata_direct.go
@@ -31,14 +31,15 @@ func newDirectUserDataService(
 	resumeFilter *catalog.ContinueWatchingProgressFilter,
 	staler profileStaler,
 	requester profileRefreshRequester,
+	completionObserver watchstate.CompletionObserver,
 ) *directUserDataService {
 	return &directUserDataService{
 		storeProvider: storeProvider,
 		itemRepo:      itemRepo,
 		detailSvc:     detailSvc,
-		watchState: watchstate.NewService(storeProvider).WithStableIdentityResolver(
-			watchstate.NewStableIdentityResolver(itemRepo, episodeRepo, providerIDRepo),
-		),
+		watchState: watchstate.NewService(storeProvider).
+			WithStableIdentityResolver(watchstate.NewStableIdentityResolver(itemRepo, episodeRepo, providerIDRepo)).
+			WithCompletionObserver(completionObserver),
 		resumeFilter:            resumeFilter,
 		profileStaler:           staler,
 		profileRefreshRequester: requester,

--- a/internal/metadata/provider_id_integrity.go
+++ b/internal/metadata/provider_id_integrity.go
@@ -876,8 +876,8 @@ var mediaItemMergeSteps = []mediaItemMergeStep{
 	{"delete source stale media ids", `DELETE FROM stale_media_ids WHERE content_id = $1`},
 	{"move watch provider history exports", `UPDATE watch_provider_history_exports SET media_item_id = $2, updated_at = NOW() WHERE media_item_id = $1`},
 	{"move watch provider scrobble sessions", `UPDATE watch_provider_scrobble_sessions SET media_item_id = $2, updated_at = NOW() WHERE media_item_id = $1`},
-	{"merge watch provider favorites by provider key", `
-			UPDATE watch_provider_favorite_items dest
+	{"merge watch provider list items by provider key", `
+			UPDATE watch_provider_list_items dest
 			SET remote_present = dest.remote_present OR src.remote_present,
 			    local_present = dest.local_present OR src.local_present,
 			    last_seen_remote_at = GREATEST(dest.last_seen_remote_at, src.last_seen_remote_at),
@@ -885,14 +885,15 @@ var mediaItemMergeSteps = []mediaItemMergeStep{
 			    last_exported_at = GREATEST(dest.last_exported_at, src.last_exported_at),
 			    last_error = COALESCE(NULLIF(dest.last_error, ''), src.last_error),
 			    updated_at = NOW()
-			FROM watch_provider_favorite_items src
+			FROM watch_provider_list_items src
 			WHERE src.media_item_id = $1
 			  AND dest.media_item_id = $2
 			  AND src.connection_id = dest.connection_id
+			  AND src.list_kind = dest.list_kind
 			  AND src.provider_item_key <> ''
 			  AND src.provider_item_key = dest.provider_item_key`},
-	{"merge watch provider favorites by connection", `
-			UPDATE watch_provider_favorite_items dest
+	{"merge watch provider list items by connection", `
+			UPDATE watch_provider_list_items dest
 			SET provider_item_key = CASE
 			        WHEN dest.provider_item_key = '' THEN src.provider_item_key
 			        ELSE dest.provider_item_key
@@ -907,18 +908,20 @@ var mediaItemMergeSteps = []mediaItemMergeStep{
 			    last_exported_at = GREATEST(dest.last_exported_at, src.last_exported_at),
 			    last_error = COALESCE(NULLIF(dest.last_error, ''), src.last_error),
 			    updated_at = NOW()
-			FROM watch_provider_favorite_items src
-			WHERE src.media_item_id = $1
-			  AND dest.media_item_id = $2
-			  AND src.connection_id = dest.connection_id`},
-	{"delete duplicate watch provider favorites", `
-			DELETE FROM watch_provider_favorite_items src
-			USING watch_provider_favorite_items dest
+			FROM watch_provider_list_items src
 			WHERE src.media_item_id = $1
 			  AND dest.media_item_id = $2
 			  AND src.connection_id = dest.connection_id
+			  AND src.list_kind = dest.list_kind`},
+	{"delete duplicate watch provider list items", `
+			DELETE FROM watch_provider_list_items src
+			USING watch_provider_list_items dest
+			WHERE src.media_item_id = $1
+			  AND dest.media_item_id = $2
+			  AND src.connection_id = dest.connection_id
+			  AND src.list_kind = dest.list_kind
 			  AND (src.provider_item_key = dest.provider_item_key OR dest.media_item_id = $2)`},
-	{"move remaining watch provider favorites", `UPDATE watch_provider_favorite_items SET media_item_id = $2, updated_at = NOW() WHERE media_item_id = $1`},
+	{"move remaining watch provider list items", `UPDATE watch_provider_list_items SET media_item_id = $2, updated_at = NOW() WHERE media_item_id = $1`},
 }
 
 func canonicalizeMediaItemReferencesTx(ctx context.Context, tx pgx.Tx, sourceID, canonicalID string) error {

--- a/internal/metadata/provider_id_integrity_test.go
+++ b/internal/metadata/provider_id_integrity_test.go
@@ -110,6 +110,37 @@ func TestMergeStepPlaceholdersAreBounded(t *testing.T) {
 	}
 }
 
+func TestMergeStepsUseCurrentWatchProviderListItemsTable(t *testing.T) {
+	for _, step := range mediaItemMergeSteps {
+		if strings.Contains(step.sql, "watch_provider_favorite_items") {
+			t.Fatalf("merge step %q still references renamed watch provider table", step.name)
+		}
+	}
+
+	for _, want := range []string{
+		"merge watch provider list items by provider key",
+		"merge watch provider list items by connection",
+		"delete duplicate watch provider list items",
+	} {
+		var stepSQL string
+		for _, step := range mediaItemMergeSteps {
+			if step.name == want {
+				stepSQL = normalizeMergeStepSQL(step.sql)
+				break
+			}
+		}
+		if stepSQL == "" {
+			t.Fatalf("missing merge step %q", want)
+		}
+		if !strings.Contains(stepSQL, "watch_provider_list_items") {
+			t.Fatalf("merge step %q does not reference watch_provider_list_items", want)
+		}
+		if !strings.Contains(stepSQL, "src.list_kind = dest.list_kind") {
+			t.Fatalf("merge step %q must preserve per-list shadow state", want)
+		}
+	}
+}
+
 func TestMergeStepsPreserveEbookReaderProgress(t *testing.T) {
 	var hasMerge bool
 	var hasDelete bool
@@ -127,6 +158,10 @@ func TestMergeStepsPreserveEbookReaderProgress(t *testing.T) {
 	if !hasDelete {
 		t.Fatal("media item merge steps should delete source ebook_reader_progress rows")
 	}
+}
+
+func normalizeMergeStepSQL(s string) string {
+	return strings.Join(strings.Fields(s), " ")
 }
 
 func TestBothCandidatesHaveContentDetectsRealUserData(t *testing.T) {

--- a/internal/userdb/favorites.go
+++ b/internal/userdb/favorites.go
@@ -2,6 +2,7 @@ package userdb
 
 import (
 	"database/sql"
+	"fmt"
 	"strings"
 	"time"
 
@@ -115,9 +116,15 @@ func ListFavoritesByMediaItems(db *sql.DB, profileID string, mediaItemIDs []stri
 // AddToWatchlist adds a media item to a profile's watchlist.
 // If the item is already on the watchlist, the operation is a no-op.
 func AddToWatchlist(db *sql.DB, profileID, mediaItemID string) error {
+	return AddToWatchlistAt(db, profileID, mediaItemID, time.Now().UTC())
+}
+
+// AddToWatchlistAt adds a media item to a profile's watchlist with an explicit
+// added-at timestamp (used when importing from an external provider).
+func AddToWatchlistAt(db *sql.DB, profileID, mediaItemID string, addedAt time.Time) error {
 	_, err := db.Exec(
 		`INSERT OR IGNORE INTO watchlist (profile_id, media_item_id, added_at) VALUES (?, ?, ?)`,
-		profileID, mediaItemID, nowUTC(),
+		profileID, mediaItemID, addedAt.UTC().Format(time.RFC3339),
 	)
 	return err
 }
@@ -131,12 +138,44 @@ func RemoveFromWatchlist(db *sql.DB, profileID, mediaItemID string) error {
 	return err
 }
 
-// ListWatchlist returns a paginated list of watchlist entries for a profile,
-// ordered by most-recently-added first.
+// ReplaceWatchlistOrder assigns sort_index 0..N-1 to the given ids in order and
+// clears sort_index on every other watchlist row for the profile. An empty
+// slice clears all synced ordering.
+func ReplaceWatchlistOrder(db *sql.DB, profileID string, orderedMediaItemIDs []string) error {
+	tx, err := db.Begin()
+	if err != nil {
+		return fmt.Errorf("begin watchlist order tx: %w", err)
+	}
+	defer func() { _ = tx.Rollback() }()
+
+	if _, err := tx.Exec(
+		`UPDATE watchlist SET sort_index = NULL WHERE profile_id = ? AND sort_index IS NOT NULL`,
+		profileID,
+	); err != nil {
+		return fmt.Errorf("clear watchlist order: %w", err)
+	}
+	for idx, mediaItemID := range orderedMediaItemIDs {
+		if _, err := tx.Exec(
+			`UPDATE watchlist SET sort_index = ? WHERE profile_id = ? AND media_item_id = ?`,
+			idx, profileID, mediaItemID,
+		); err != nil {
+			return fmt.Errorf("apply watchlist order: %w", err)
+		}
+	}
+	if err := tx.Commit(); err != nil {
+		return fmt.Errorf("commit watchlist order: %w", err)
+	}
+	return nil
+}
+
+// ListWatchlist returns a paginated list of watchlist entries for a profile.
+// Items with a synced sort_index (mirrored from a provider) come first in that
+// order; locally-added items (sort_index NULL) fall back to newest-first.
 func ListWatchlist(db *sql.DB, profileID string, limit, offset int) ([]WatchlistEntry, error) {
 	rows, err := db.Query(
 		`SELECT profile_id, media_item_id, added_at FROM watchlist
-		 WHERE profile_id = ? ORDER BY added_at DESC LIMIT ? OFFSET ?`,
+		 WHERE profile_id = ?
+		 ORDER BY sort_index IS NULL, sort_index ASC, added_at DESC LIMIT ? OFFSET ?`,
 		profileID, limit, offset,
 	)
 	if err != nil {

--- a/internal/userdb/migrate.go
+++ b/internal/userdb/migrate.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 )
 
-const schemaVersion = 11
+const schemaVersion = 12
 
 func runMigrations(db *sql.DB) error {
 	version, err := userVersion(db)
@@ -115,7 +115,28 @@ func runMigrations(db *sql.DB) error {
 		}
 	}
 
+	if version < 12 {
+		if err := migrateToV12(tx); err != nil {
+			return err
+		}
+		if _, err := tx.Exec("PRAGMA user_version = 12"); err != nil {
+			return fmt.Errorf("setting sqlite user_version 12: %w", err)
+		}
+	}
+
 	return tx.Commit()
+}
+
+// migrateToV12 adds the nullable watchlist.sort_index column used to mirror a
+// provider's watchlist order. NULL means "use added_at ordering".
+func migrateToV12(tx *sql.Tx) error {
+	if columnExists(tx, "watchlist", "sort_index") {
+		return nil
+	}
+	if _, err := tx.Exec("ALTER TABLE watchlist ADD COLUMN sort_index INTEGER"); err != nil {
+		return fmt.Errorf("adding watchlist.sort_index: %w", err)
+	}
+	return nil
 }
 
 // migrateToV11 resets legacy completed watch_progress rows to

--- a/internal/userdb/schema.go
+++ b/internal/userdb/schema.go
@@ -95,6 +95,7 @@ CREATE TABLE IF NOT EXISTS watchlist (
     profile_id TEXT NOT NULL,
     media_item_id TEXT NOT NULL,
     added_at TEXT NOT NULL,
+    sort_index INTEGER,
     PRIMARY KEY (profile_id, media_item_id)
 );
 

--- a/internal/userdb/sqlitestore.go
+++ b/internal/userdb/sqlitestore.go
@@ -177,8 +177,16 @@ func (s *SQLiteUserStore) AddToWatchlist(_ context.Context, profileID, mediaItem
 	return AddToWatchlist(s.db, profileID, mediaItemID)
 }
 
+func (s *SQLiteUserStore) AddToWatchlistAt(_ context.Context, profileID, mediaItemID string, addedAt time.Time) error {
+	return AddToWatchlistAt(s.db, profileID, mediaItemID, addedAt)
+}
+
 func (s *SQLiteUserStore) RemoveFromWatchlist(_ context.Context, profileID, mediaItemID string) error {
 	return RemoveFromWatchlist(s.db, profileID, mediaItemID)
+}
+
+func (s *SQLiteUserStore) ReplaceWatchlistOrder(_ context.Context, profileID string, orderedMediaItemIDs []string) error {
+	return ReplaceWatchlistOrder(s.db, profileID, orderedMediaItemIDs)
 }
 
 func (s *SQLiteUserStore) ListWatchlist(_ context.Context, profileID string, limit, offset int) ([]userstore.WatchlistEntry, error) {
@@ -191,6 +199,12 @@ func (s *SQLiteUserStore) ListWatchlistByMediaItems(_ context.Context, profileID
 
 func (s *SQLiteUserStore) InWatchlist(_ context.Context, profileID, mediaItemID string) (bool, error) {
 	return InWatchlist(s.db, profileID, mediaItemID)
+}
+
+// RemoveWatchedFromWatchlist defaults on for the embedded sqlite backend, which
+// does not persist the per-profile preference.
+func (s *SQLiteUserStore) RemoveWatchedFromWatchlist(_ context.Context, _ string) (bool, error) {
+	return true, nil
 }
 
 // --- Collections ---

--- a/internal/userdb/watchlist_order_test.go
+++ b/internal/userdb/watchlist_order_test.go
@@ -1,0 +1,91 @@
+package userdb
+
+import (
+	"database/sql"
+	"testing"
+	"time"
+)
+
+func watchlistIDs(t *testing.T, db *sql.DB, profileID string) []string {
+	t.Helper()
+	entries, err := ListWatchlist(db, profileID, 100, 0)
+	if err != nil {
+		t.Fatalf("ListWatchlist: %v", err)
+	}
+	ids := make([]string, 0, len(entries))
+	for _, e := range entries {
+		ids = append(ids, e.MediaItemID)
+	}
+	return ids
+}
+
+func TestWatchlistOrderMirrorsProviderSequence(t *testing.T) {
+	db, err := sql.Open("sqlite3", ":memory:")
+	if err != nil {
+		t.Fatalf("open sqlite: %v", err)
+	}
+	defer db.Close()
+	if err := InitSchema(db); err != nil {
+		t.Fatalf("InitSchema: %v", err)
+	}
+
+	const profile = "profile-1"
+	// Add in one order (added_at ascending a, b, c).
+	base := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+	for i, id := range []string{"a", "b", "c"} {
+		if err := AddToWatchlistAt(db, profile, id, base.Add(time.Duration(i)*time.Hour)); err != nil {
+			t.Fatalf("AddToWatchlistAt %s: %v", id, err)
+		}
+	}
+
+	// Without a synced order, newest-added comes first.
+	if got := watchlistIDs(t, db, profile); !equalStrings(got, []string{"c", "b", "a"}) {
+		t.Fatalf("default order = %v, want [c b a]", got)
+	}
+
+	// Mirror a provider order of c, a, b.
+	if err := ReplaceWatchlistOrder(db, profile, []string{"c", "a", "b"}); err != nil {
+		t.Fatalf("ReplaceWatchlistOrder: %v", err)
+	}
+	if got := watchlistIDs(t, db, profile); !equalStrings(got, []string{"c", "a", "b"}) {
+		t.Fatalf("synced order = %v, want [c a b]", got)
+	}
+
+	// A locally-added item (no synced index) sorts after the ordered ones.
+	if err := AddToWatchlistAt(db, profile, "d", base.Add(10*time.Hour)); err != nil {
+		t.Fatalf("AddToWatchlistAt d: %v", err)
+	}
+	if got := watchlistIDs(t, db, profile); !equalStrings(got, []string{"c", "a", "b", "d"}) {
+		t.Fatalf("order with local add = %v, want [c a b d]", got)
+	}
+
+	// Re-syncing a shorter provider list drops removed items' index and keeps
+	// the new order; items no longer present fall back to added_at.
+	if err := ReplaceWatchlistOrder(db, profile, []string{"b", "a"}); err != nil {
+		t.Fatalf("ReplaceWatchlistOrder re-sync: %v", err)
+	}
+	// b, a are positioned; c and d are unpositioned → after, newest-first (d then c).
+	if got := watchlistIDs(t, db, profile); !equalStrings(got, []string{"b", "a", "d", "c"}) {
+		t.Fatalf("re-synced order = %v, want [b a d c]", got)
+	}
+
+	// Clearing the order reverts everything to added_at DESC.
+	if err := ReplaceWatchlistOrder(db, profile, nil); err != nil {
+		t.Fatalf("ReplaceWatchlistOrder clear: %v", err)
+	}
+	if got := watchlistIDs(t, db, profile); !equalStrings(got, []string{"d", "c", "b", "a"}) {
+		t.Fatalf("cleared order = %v, want [d c b a]", got)
+	}
+}
+
+func equalStrings(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
+}

--- a/internal/userstore/pgstore/favorites.go
+++ b/internal/userstore/pgstore/favorites.go
@@ -2,9 +2,12 @@ package pgstore
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"strings"
 	"time"
+
+	"github.com/jackc/pgx/v5"
 
 	"github.com/Silo-Server/silo-server/internal/userstore"
 )
@@ -103,11 +106,15 @@ func (s *PostgresUserStore) ListFavoritesByMediaItems(ctx context.Context, profi
 // --- Watchlist ---
 
 func (s *PostgresUserStore) AddToWatchlist(ctx context.Context, profileID, mediaItemID string) error {
+	return s.AddToWatchlistAt(ctx, profileID, mediaItemID, time.Now().UTC())
+}
+
+func (s *PostgresUserStore) AddToWatchlistAt(ctx context.Context, profileID, mediaItemID string, addedAt time.Time) error {
 	_, err := s.pool.Exec(ctx,
 		`INSERT INTO user_watchlist (user_id, profile_id, media_item_id, added_at)
 		 VALUES ($1, $2, $3, $4)
 		 ON CONFLICT DO NOTHING`,
-		s.userID, profileID, mediaItemID, nowUTC(),
+		s.userID, profileID, mediaItemID, addedAt.UTC(),
 	)
 	return err
 }
@@ -121,9 +128,12 @@ func (s *PostgresUserStore) RemoveFromWatchlist(ctx context.Context, profileID, 
 }
 
 func (s *PostgresUserStore) ListWatchlist(ctx context.Context, profileID string, limit, offset int) ([]userstore.WatchlistEntry, error) {
+	// Items with a synced sort_index (mirrored from a provider) come first in
+	// that order; locally-added items (sort_index NULL) fall back to newest-first.
 	rows, err := s.pool.Query(ctx,
 		`SELECT profile_id, media_item_id, added_at FROM user_watchlist
-		 WHERE user_id = $1 AND profile_id = $2 ORDER BY added_at DESC LIMIT $3 OFFSET $4`,
+		 WHERE user_id = $1 AND profile_id = $2
+		 ORDER BY sort_index ASC NULLS LAST, added_at DESC LIMIT $3 OFFSET $4`,
 		s.userID, profileID, limit, offset,
 	)
 	if err != nil {
@@ -151,6 +161,73 @@ func (s *PostgresUserStore) InWatchlist(ctx context.Context, profileID, mediaIte
 		s.userID, profileID, mediaItemID,
 	).Scan(&count)
 	return count > 0, err
+}
+
+// ReplaceWatchlistOrder mirrors a provider's watchlist order: the given media
+// item ids get sort_index 0..N-1 in order, and every other watchlist row for
+// the profile is reset to NULL (falling back to added_at ordering). Pass an
+// empty slice to clear all synced ordering.
+func (s *PostgresUserStore) ReplaceWatchlistOrder(ctx context.Context, profileID string, orderedMediaItemIDs []string) error {
+	if len(orderedMediaItemIDs) == 0 {
+		// Clear all synced ordering — revert to added_at ordering.
+		if _, err := s.pool.Exec(ctx,
+			`UPDATE user_watchlist SET sort_index = NULL
+			 WHERE user_id = $1 AND profile_id = $2 AND sort_index IS NOT NULL`,
+			s.userID, profileID,
+		); err != nil {
+			return fmt.Errorf("clear watchlist order: %w", err)
+		}
+		return nil
+	}
+
+	tx, err := s.pool.Begin(ctx)
+	if err != nil {
+		return fmt.Errorf("begin watchlist order tx: %w", err)
+	}
+	defer tx.Rollback(ctx)
+
+	if _, err := tx.Exec(ctx,
+		`UPDATE user_watchlist SET sort_index = NULL
+		 WHERE user_id = $1 AND profile_id = $2 AND sort_index IS NOT NULL
+		   AND NOT (media_item_id = ANY($3))`,
+		s.userID, profileID, orderedMediaItemIDs,
+	); err != nil {
+		return fmt.Errorf("clear stale watchlist order: %w", err)
+	}
+
+	if _, err := tx.Exec(ctx,
+		`UPDATE user_watchlist w
+		 SET sort_index = v.idx
+		 FROM (
+		   SELECT unnest($3::text[]) AS media_item_id,
+		          generate_subscripts($3::text[], 1) - 1 AS idx
+		 ) v
+		 WHERE w.user_id = $1 AND w.profile_id = $2 AND w.media_item_id = v.media_item_id`,
+		s.userID, profileID, orderedMediaItemIDs,
+	); err != nil {
+		return fmt.Errorf("apply watchlist order: %w", err)
+	}
+
+	if err := tx.Commit(ctx); err != nil {
+		return fmt.Errorf("commit watchlist order: %w", err)
+	}
+	return nil
+}
+
+func (s *PostgresUserStore) RemoveWatchedFromWatchlist(ctx context.Context, profileID string) (bool, error) {
+	var enabled bool
+	err := s.pool.QueryRow(ctx,
+		`SELECT remove_watched_from_watchlist FROM user_profiles WHERE user_id = $1 AND id = $2`,
+		s.userID, profileID,
+	).Scan(&enabled)
+	if errors.Is(err, pgx.ErrNoRows) {
+		// Default-on when the profile row is unexpectedly absent.
+		return true, nil
+	}
+	if err != nil {
+		return true, fmt.Errorf("get remove_watched_from_watchlist: %w", err)
+	}
+	return enabled, nil
 }
 
 func (s *PostgresUserStore) ListWatchlistByMediaItems(ctx context.Context, profileID string, mediaItemIDs []string) (map[string]bool, error) {

--- a/internal/userstore/store.go
+++ b/internal/userstore/store.go
@@ -51,10 +51,17 @@ type UserStore interface {
 	ListFavoritesByMediaItems(ctx context.Context, profileID string, mediaItemIDs []string) (map[string]bool, error)
 	IsFavorite(ctx context.Context, profileID, mediaItemID string) (bool, error)
 	AddToWatchlist(ctx context.Context, profileID, mediaItemID string) error
+	AddToWatchlistAt(ctx context.Context, profileID, mediaItemID string, addedAt time.Time) error
 	RemoveFromWatchlist(ctx context.Context, profileID, mediaItemID string) error
+	// ReplaceWatchlistOrder mirrors a provider's watchlist order: the given ids
+	// get sort_index 0..N-1 in order; all other rows reset to added_at ordering.
+	ReplaceWatchlistOrder(ctx context.Context, profileID string, orderedMediaItemIDs []string) error
 	ListWatchlist(ctx context.Context, profileID string, limit, offset int) ([]WatchlistEntry, error)
 	ListWatchlistByMediaItems(ctx context.Context, profileID string, mediaItemIDs []string) (map[string]bool, error)
 	InWatchlist(ctx context.Context, profileID, mediaItemID string) (bool, error)
+	// RemoveWatchedFromWatchlist reports the profile's preference for auto-removing
+	// fully-watched items from the watchlist (defaults true).
+	RemoveWatchedFromWatchlist(ctx context.Context, profileID string) (bool, error)
 
 	// Collections
 	CreateCollection(ctx context.Context, input CreateCollectionInput) (*Collection, error)

--- a/internal/watchlist/maintainer.go
+++ b/internal/watchlist/maintainer.go
@@ -118,8 +118,16 @@ func (m *Maintainer) process(ctx context.Context, userID int, profileID string, 
 // resolveCandidate maps a completed media item id to the watchlist entry id to
 // clear, or ok=false when nothing should be removed.
 func (m *Maintainer) resolveCandidate(ctx context.Context, store maintainerStore, profileID, mediaItemID string) (string, bool, error) {
+	// A media-items miss is the normal path for episodes (they live in their own
+	// table), but a real repo error must not be silently swallowed — remember it
+	// and surface it if the episode path also can't resolve the id.
+	var itemLookupErr error
 	if m.items != nil {
-		if item, err := m.items.GetByID(ctx, mediaItemID); err == nil && item != nil {
+		item, err := m.items.GetByID(ctx, mediaItemID)
+		switch {
+		case err != nil:
+			itemLookupErr = err
+		case item != nil:
 			switch item.Type {
 			case "movie":
 				return item.ContentID, true, nil
@@ -136,11 +144,14 @@ func (m *Maintainer) resolveCandidate(ctx context.Context, store maintainerStore
 	// Not a catalog item — treat as an episode and clear the parent series once
 	// every episode has been watched.
 	if m.episodes == nil {
-		return "", false, nil
+		return "", false, itemLookupErr
 	}
 	episode, err := m.episodes.GetByID(ctx, mediaItemID)
-	if err != nil || episode == nil {
-		return "", false, nil
+	if err != nil {
+		return "", false, err
+	}
+	if episode == nil {
+		return "", false, itemLookupErr
 	}
 	return m.seriesCandidate(ctx, store, profileID, episode.SeriesID)
 }

--- a/internal/watchlist/maintainer.go
+++ b/internal/watchlist/maintainer.go
@@ -1,0 +1,229 @@
+// Package watchlist holds cross-cutting watchlist behavior that doesn't belong
+// to a single handler — currently the auto-removal of fully-watched items.
+package watchlist
+
+import (
+	"context"
+	"log/slog"
+	"time"
+
+	"github.com/Silo-Server/silo-server/internal/models"
+	"github.com/Silo-Server/silo-server/internal/userstore"
+	"github.com/Silo-Server/silo-server/internal/watchsync"
+)
+
+type itemLookup interface {
+	GetByID(ctx context.Context, contentID string) (*models.MediaItem, error)
+}
+
+type episodeLookup interface {
+	GetByID(ctx context.Context, contentID string) (*models.Episode, error)
+	ListBySeries(ctx context.Context, seriesID string) ([]*models.Episode, error)
+}
+
+type listEventDispatcher interface {
+	HandleLocalListEvent(ctx context.Context, event watchsync.LocalListEvent) error
+}
+
+// maintainerStore is the narrow slice of the user store the maintainer needs.
+type maintainerStore interface {
+	RemoveWatchedFromWatchlist(ctx context.Context, profileID string) (bool, error)
+	InWatchlist(ctx context.Context, profileID, mediaItemID string) (bool, error)
+	RemoveFromWatchlist(ctx context.Context, profileID, mediaItemID string) error
+	ListProgressByMediaItems(ctx context.Context, profileID string, mediaItemIDs []string) (map[string]userstore.WatchProgress, error)
+}
+
+// Maintainer removes fully-watched items from a profile's watchlist when a watch
+// completes: a movie when it is watched, a series once every episode is watched.
+// It implements watchstate.CompletionObserver. Removals route through the same
+// local-list-event path as a manual removal, so connected watchlist providers
+// mirror the change.
+type Maintainer struct {
+	storeFor   func(ctx context.Context, userID int) (maintainerStore, error)
+	items      itemLookup
+	episodes   episodeLookup
+	dispatcher listEventDispatcher
+}
+
+func NewMaintainer(stores userstore.UserStoreProvider, items itemLookup, episodes episodeLookup) *Maintainer {
+	return &Maintainer{
+		storeFor: func(ctx context.Context, userID int) (maintainerStore, error) {
+			return stores.ForUser(ctx, userID)
+		},
+		items:    items,
+		episodes: episodes,
+	}
+}
+
+func (m *Maintainer) WithListEventDispatcher(d listEventDispatcher) *Maintainer {
+	if m == nil {
+		return nil
+	}
+	m.dispatcher = d
+	return m
+}
+
+// HandleWatchedCompleted reacts to completed watches asynchronously so it never
+// blocks the caller's watch-recording path.
+func (m *Maintainer) HandleWatchedCompleted(_ context.Context, userID int, profileID string, mediaItemIDs []string) {
+	if m == nil || m.storeFor == nil || userID == 0 || profileID == "" || len(mediaItemIDs) == 0 {
+		return
+	}
+	ids := append([]string(nil), mediaItemIDs...)
+	go func() {
+		ctx, cancel := context.WithTimeout(context.Background(), 2*time.Minute)
+		defer cancel()
+		if err := m.process(ctx, userID, profileID, ids); err != nil {
+			slog.Warn("watchlist auto-remove failed", "user_id", userID, "profile_id", profileID, "error", err)
+		}
+	}()
+}
+
+func (m *Maintainer) process(ctx context.Context, userID int, profileID string, mediaItemIDs []string) error {
+	store, err := m.storeFor(ctx, userID)
+	if err != nil {
+		return err
+	}
+	enabled, err := store.RemoveWatchedFromWatchlist(ctx, profileID)
+	if err != nil {
+		return err
+	}
+	if !enabled {
+		return nil
+	}
+	// Resolve each completed item to the watchlist entry it clears (a movie
+	// clears itself; an episode clears its series only once the series is fully
+	// watched), deduping so a batch completing many episodes of one series
+	// checks that series once.
+	seen := make(map[string]struct{})
+	for _, id := range mediaItemIDs {
+		candidate, ok, err := m.resolveCandidate(ctx, store, profileID, id)
+		if err != nil {
+			return err
+		}
+		if !ok {
+			continue
+		}
+		if _, dup := seen[candidate]; dup {
+			continue
+		}
+		seen[candidate] = struct{}{}
+		if err := m.removeFromWatchlist(ctx, store, userID, profileID, candidate); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// resolveCandidate maps a completed media item id to the watchlist entry id to
+// clear, or ok=false when nothing should be removed.
+func (m *Maintainer) resolveCandidate(ctx context.Context, store maintainerStore, profileID, mediaItemID string) (string, bool, error) {
+	if m.items != nil {
+		if item, err := m.items.GetByID(ctx, mediaItemID); err == nil && item != nil {
+			switch item.Type {
+			case "movie":
+				return item.ContentID, true, nil
+			case "series":
+				// A series id can only reach here if the series itself was marked
+				// watched; still require every episode to be watched before
+				// clearing it, so a partially-watched series is never dropped.
+				return m.seriesCandidate(ctx, store, profileID, item.ContentID)
+			default:
+				return "", false, nil
+			}
+		}
+	}
+	// Not a catalog item — treat as an episode and clear the parent series once
+	// every episode has been watched.
+	if m.episodes == nil {
+		return "", false, nil
+	}
+	episode, err := m.episodes.GetByID(ctx, mediaItemID)
+	if err != nil || episode == nil {
+		return "", false, nil
+	}
+	return m.seriesCandidate(ctx, store, profileID, episode.SeriesID)
+}
+
+// seriesCandidate returns the series id as a removal candidate only if every
+// episode is watched.
+func (m *Maintainer) seriesCandidate(ctx context.Context, store maintainerStore, profileID, seriesID string) (string, bool, error) {
+	fully, err := m.seriesFullyWatched(ctx, store, profileID, seriesID)
+	if err != nil {
+		return "", false, err
+	}
+	if !fully {
+		return "", false, nil
+	}
+	return seriesID, true, nil
+}
+
+func (m *Maintainer) seriesFullyWatched(ctx context.Context, store maintainerStore, profileID, seriesID string) (bool, error) {
+	if seriesID == "" {
+		return false, nil
+	}
+	episodes, err := m.episodes.ListBySeries(ctx, seriesID)
+	if err != nil {
+		return false, err
+	}
+	ids := make([]string, 0, len(episodes))
+	for _, ep := range episodes {
+		if ep != nil && ep.ContentID != "" {
+			ids = append(ids, ep.ContentID)
+		}
+	}
+	if len(ids) == 0 {
+		return false, nil
+	}
+	progress, err := store.ListProgressByMediaItems(ctx, profileID, ids)
+	if err != nil {
+		return false, err
+	}
+	for _, id := range ids {
+		if p, ok := progress[id]; !ok || !p.Completed {
+			return false, nil
+		}
+	}
+	return true, nil
+}
+
+func (m *Maintainer) removeFromWatchlist(ctx context.Context, store maintainerStore, userID int, profileID, mediaItemID string) error {
+	in, err := store.InWatchlist(ctx, profileID, mediaItemID)
+	if err != nil {
+		return err
+	}
+	if !in {
+		return nil
+	}
+	if err := store.RemoveFromWatchlist(ctx, profileID, mediaItemID); err != nil {
+		return err
+	}
+	m.dispatchRemoval(ctx, userID, profileID, mediaItemID)
+	return nil
+}
+
+func (m *Maintainer) dispatchRemoval(ctx context.Context, userID int, profileID, mediaItemID string) {
+	if m.dispatcher == nil || m.items == nil {
+		return
+	}
+	item, err := m.items.GetByID(ctx, mediaItemID)
+	if err != nil || item == nil {
+		return
+	}
+	_ = m.dispatcher.HandleLocalListEvent(ctx, watchsync.LocalListEvent{
+		List:      watchsync.ListKindWatchlist,
+		Change:    watchsync.ListChangeRemoved,
+		UserID:    userID,
+		ProfileID: profileID,
+		Items: []watchsync.LocalFavorite{{
+			MediaItemID: item.ContentID,
+			Kind:        item.Type,
+			Title:       item.Title,
+			Year:        item.Year,
+			IMDbID:      item.ImdbID,
+			TMDBID:      item.TmdbID,
+			TVDBID:      item.TvdbID,
+			FavoritedAt: time.Now().UTC(),
+		}},
+	})
+}

--- a/internal/watchlist/maintainer_test.go
+++ b/internal/watchlist/maintainer_test.go
@@ -205,3 +205,29 @@ func TestMaintainerDedupesEpisodesOfSameSeries(t *testing.T) {
 		t.Fatalf("series should be removed exactly once, got %d removals (%v)", got, store.removed)
 	}
 }
+
+type erroringItems struct{ err error }
+
+func (e erroringItems) GetByID(context.Context, string) (*models.MediaItem, error) {
+	return nil, e.err
+}
+
+type emptyEpisodes struct{}
+
+func (emptyEpisodes) GetByID(context.Context, string) (*models.Episode, error) { return nil, nil }
+func (emptyEpisodes) ListBySeries(context.Context, string) ([]*models.Episode, error) {
+	return nil, nil
+}
+
+func TestMaintainerPropagatesItemLookupError(t *testing.T) {
+	boom := errors.New("db down")
+	store := &fakeStore{removeWatched: true, watchlist: map[string]bool{}}
+	m := &Maintainer{
+		storeFor: func(context.Context, int) (maintainerStore, error) { return store, nil },
+		items:    erroringItems{err: boom},
+		episodes: emptyEpisodes{},
+	}
+	if err := m.process(context.Background(), 7, "profile-1", []string{"x"}); err == nil {
+		t.Fatal("a transient catalog lookup error must propagate, not be swallowed")
+	}
+}

--- a/internal/watchlist/maintainer_test.go
+++ b/internal/watchlist/maintainer_test.go
@@ -1,0 +1,207 @@
+package watchlist
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/Silo-Server/silo-server/internal/models"
+	"github.com/Silo-Server/silo-server/internal/userstore"
+	"github.com/Silo-Server/silo-server/internal/watchsync"
+)
+
+var errNotFound = errors.New("not found")
+
+type fakeStore struct {
+	removeWatched bool
+	watchlist     map[string]bool
+	progress      map[string]userstore.WatchProgress
+	removed       []string
+}
+
+func (f *fakeStore) RemoveWatchedFromWatchlist(context.Context, string) (bool, error) {
+	return f.removeWatched, nil
+}
+
+func (f *fakeStore) InWatchlist(_ context.Context, _ string, mediaItemID string) (bool, error) {
+	return f.watchlist[mediaItemID], nil
+}
+
+func (f *fakeStore) RemoveFromWatchlist(_ context.Context, _ string, mediaItemID string) error {
+	delete(f.watchlist, mediaItemID)
+	f.removed = append(f.removed, mediaItemID)
+	return nil
+}
+
+func (f *fakeStore) ListProgressByMediaItems(_ context.Context, _ string, ids []string) (map[string]userstore.WatchProgress, error) {
+	out := make(map[string]userstore.WatchProgress, len(ids))
+	for _, id := range ids {
+		if p, ok := f.progress[id]; ok {
+			out[id] = p
+		}
+	}
+	return out, nil
+}
+
+type fakeItems map[string]*models.MediaItem
+
+func (f fakeItems) GetByID(_ context.Context, id string) (*models.MediaItem, error) {
+	if item, ok := f[id]; ok {
+		return item, nil
+	}
+	return nil, errNotFound
+}
+
+type fakeEpisodes struct {
+	byID     map[string]*models.Episode
+	bySeries map[string][]*models.Episode
+}
+
+func (f fakeEpisodes) GetByID(_ context.Context, id string) (*models.Episode, error) {
+	if ep, ok := f.byID[id]; ok {
+		return ep, nil
+	}
+	return nil, errNotFound
+}
+
+func (f fakeEpisodes) ListBySeries(_ context.Context, seriesID string) ([]*models.Episode, error) {
+	return f.bySeries[seriesID], nil
+}
+
+type fakeDispatcher struct {
+	events []watchsync.LocalListEvent
+}
+
+func (f *fakeDispatcher) HandleLocalListEvent(_ context.Context, event watchsync.LocalListEvent) error {
+	f.events = append(f.events, event)
+	return nil
+}
+
+func newMaintainer(store *fakeStore, items fakeItems, episodes fakeEpisodes, dispatcher *fakeDispatcher) *Maintainer {
+	return &Maintainer{
+		storeFor:   func(context.Context, int) (maintainerStore, error) { return store, nil },
+		items:      items,
+		episodes:   episodes,
+		dispatcher: dispatcher,
+	}
+}
+
+func completed() userstore.WatchProgress { return userstore.WatchProgress{Completed: true} }
+
+func TestMaintainerRemovesWatchedMovie(t *testing.T) {
+	store := &fakeStore{removeWatched: true, watchlist: map[string]bool{"movie-1": true}}
+	items := fakeItems{"movie-1": {ContentID: "movie-1", Type: "movie", Title: "M", ImdbID: "tt1"}}
+	dispatcher := &fakeDispatcher{}
+	m := newMaintainer(store, items, fakeEpisodes{}, dispatcher)
+
+	if err := m.process(context.Background(), 7, "profile-1", []string{"movie-1"}); err != nil {
+		t.Fatalf("process: %v", err)
+	}
+	if store.watchlist["movie-1"] {
+		t.Fatal("watched movie should be removed from the watchlist")
+	}
+	if len(dispatcher.events) != 1 || dispatcher.events[0].List != watchsync.ListKindWatchlist ||
+		dispatcher.events[0].Change != watchsync.ListChangeRemoved {
+		t.Fatalf("expected one watchlist-removed event, got %+v", dispatcher.events)
+	}
+}
+
+func TestMaintainerSkipsMovieNotOnWatchlist(t *testing.T) {
+	store := &fakeStore{removeWatched: true, watchlist: map[string]bool{}}
+	items := fakeItems{"movie-1": {ContentID: "movie-1", Type: "movie"}}
+	dispatcher := &fakeDispatcher{}
+	m := newMaintainer(store, items, fakeEpisodes{}, dispatcher)
+
+	if err := m.process(context.Background(), 7, "profile-1", []string{"movie-1"}); err != nil {
+		t.Fatalf("process: %v", err)
+	}
+	if len(store.removed) != 0 || len(dispatcher.events) != 0 {
+		t.Fatalf("nothing should happen for a movie not on the watchlist: removed=%v events=%v", store.removed, dispatcher.events)
+	}
+}
+
+func TestMaintainerRemovesSeriesOnlyWhenFullyWatched(t *testing.T) {
+	episodes := fakeEpisodes{
+		byID: map[string]*models.Episode{
+			"ep-1": {ContentID: "ep-1", SeriesID: "series-1"},
+			"ep-2": {ContentID: "ep-2", SeriesID: "series-1"},
+		},
+		bySeries: map[string][]*models.Episode{
+			"series-1": {{ContentID: "ep-1"}, {ContentID: "ep-2"}},
+		},
+	}
+	items := fakeItems{"series-1": {ContentID: "series-1", Type: "series", TvdbID: "99"}}
+
+	// Only ep-1 watched: series stays on the watchlist.
+	partial := &fakeStore{
+		removeWatched: true,
+		watchlist:     map[string]bool{"series-1": true},
+		progress:      map[string]userstore.WatchProgress{"ep-1": completed()},
+	}
+	m := newMaintainer(partial, items, episodes, &fakeDispatcher{})
+	if err := m.process(context.Background(), 7, "profile-1", []string{"ep-1"}); err != nil {
+		t.Fatalf("process: %v", err)
+	}
+	if !partial.watchlist["series-1"] {
+		t.Fatal("a partially-watched series must stay on the watchlist")
+	}
+
+	// Both episodes watched: series is removed.
+	full := &fakeStore{
+		removeWatched: true,
+		watchlist:     map[string]bool{"series-1": true},
+		progress:      map[string]userstore.WatchProgress{"ep-1": completed(), "ep-2": completed()},
+	}
+	dispatcher := &fakeDispatcher{}
+	m = newMaintainer(full, items, episodes, dispatcher)
+	if err := m.process(context.Background(), 7, "profile-1", []string{"ep-2"}); err != nil {
+		t.Fatalf("process: %v", err)
+	}
+	if full.watchlist["series-1"] {
+		t.Fatal("a fully-watched series must leave the watchlist")
+	}
+	if len(dispatcher.events) != 1 {
+		t.Fatalf("expected one removal event for the series, got %+v", dispatcher.events)
+	}
+}
+
+func TestMaintainerRespectsPreferenceOff(t *testing.T) {
+	store := &fakeStore{removeWatched: false, watchlist: map[string]bool{"movie-1": true}}
+	items := fakeItems{"movie-1": {ContentID: "movie-1", Type: "movie"}}
+	dispatcher := &fakeDispatcher{}
+	m := newMaintainer(store, items, fakeEpisodes{}, dispatcher)
+
+	if err := m.process(context.Background(), 7, "profile-1", []string{"movie-1"}); err != nil {
+		t.Fatalf("process: %v", err)
+	}
+	if !store.watchlist["movie-1"] || len(store.removed) != 0 {
+		t.Fatal("preference off must leave the watchlist untouched")
+	}
+}
+
+func TestMaintainerDedupesEpisodesOfSameSeries(t *testing.T) {
+	episodes := fakeEpisodes{
+		byID: map[string]*models.Episode{
+			"ep-1": {ContentID: "ep-1", SeriesID: "series-1"},
+			"ep-2": {ContentID: "ep-2", SeriesID: "series-1"},
+		},
+		bySeries: map[string][]*models.Episode{
+			"series-1": {{ContentID: "ep-1"}, {ContentID: "ep-2"}},
+		},
+	}
+	items := fakeItems{"series-1": {ContentID: "series-1", Type: "series"}}
+	store := &fakeStore{
+		removeWatched: true,
+		watchlist:     map[string]bool{"series-1": true},
+		progress:      map[string]userstore.WatchProgress{"ep-1": completed(), "ep-2": completed()},
+	}
+	m := newMaintainer(store, items, episodes, &fakeDispatcher{})
+
+	// Both episodes complete in one batch; the series should be removed once.
+	if err := m.process(context.Background(), 7, "profile-1", []string{"ep-1", "ep-2"}); err != nil {
+		t.Fatalf("process: %v", err)
+	}
+	if got := len(store.removed); got != 1 {
+		t.Fatalf("series should be removed exactly once, got %d removals (%v)", got, store.removed)
+	}
+}

--- a/internal/watchstate/service.go
+++ b/internal/watchstate/service.go
@@ -16,8 +16,18 @@ type LeafWatchTarget struct {
 }
 
 type Service struct {
-	storeProvider userstore.UserStoreProvider
-	identity      *StableIdentityResolver
+	storeProvider      userstore.UserStoreProvider
+	identity           *StableIdentityResolver
+	completionObserver CompletionObserver
+}
+
+// CompletionObserver is notified after a watch is recorded as completed via a
+// local action (manual mark-watched, playback completion, or a Jellyfin-compat
+// mark-played). It powers cross-cutting reactions such as removing watched
+// items from the watchlist. It is invoked best-effort and must not block the
+// recording path.
+type CompletionObserver interface {
+	HandleWatchedCompleted(ctx context.Context, userID int, profileID string, mediaItemIDs []string)
 }
 
 type PlaybackStopResult struct {
@@ -43,6 +53,21 @@ func (s *Service) WithStableIdentityResolver(identity *StableIdentityResolver) *
 	}
 	s.identity = identity
 	return s
+}
+
+func (s *Service) WithCompletionObserver(observer CompletionObserver) *Service {
+	if s == nil {
+		return nil
+	}
+	s.completionObserver = observer
+	return s
+}
+
+func (s *Service) notifyWatchedCompleted(ctx context.Context, userID int, profileID string, mediaItemIDs []string) {
+	if s == nil || s.completionObserver == nil || len(mediaItemIDs) == 0 {
+		return
+	}
+	s.completionObserver.HandleWatchedCompleted(ctx, userID, profileID, mediaItemIDs)
 }
 
 func (s *Service) RecordManualMarkWatched(ctx context.Context, userID int, profileID string, targets []LeafWatchTarget, watchedAt time.Time) error {
@@ -114,6 +139,9 @@ func (s *Service) RecordPlaybackStop(
 	}
 	result.Completed = entry.Completed
 	result.HistoryID = historyID
+	if entry.Completed {
+		s.notifyWatchedCompleted(ctx, userID, profileID, []string{targetID})
+	}
 	return result, nil
 }
 
@@ -318,6 +346,11 @@ func (s *Service) recordMarkWatched(
 		}
 		result.Entries = append(result.Entries, histEntry)
 	}
+	completedIDs := make([]string, 0, len(targets))
+	for _, target := range targets {
+		completedIDs = append(completedIDs, target.MediaItemID)
+	}
+	s.notifyWatchedCompleted(ctx, userID, profileID, completedIDs)
 	return result, nil
 }
 
@@ -431,6 +464,7 @@ func (s *Service) recordMarkWatchedBatch(
 			return err
 		}
 	}
+	s.notifyWatchedCompleted(ctx, userID, profileID, targetIDs)
 	return nil
 }
 

--- a/internal/watchsync/lists.go
+++ b/internal/watchsync/lists.go
@@ -1,0 +1,671 @@
+package watchsync
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"time"
+
+	"github.com/Silo-Server/silo-server/internal/historyimport"
+	"github.com/Silo-Server/silo-server/internal/userstore"
+)
+
+// This file generalizes the personal-list sync pipeline (import, export,
+// removal, and real-time local-change propagation) so it runs once for both the
+// favorites list and the watchlist. The only things that differ between the two
+// lists are the provider endpoints, the local store operations, the connection
+// toggles, and which counters/timestamps a run records — all captured by a
+// listBinding.
+
+// listRow is the kind-neutral shape of a local list membership row (a favorite
+// or a watchlist entry): just the media item id and its added-at timestamp.
+type listRow struct {
+	MediaItemID string
+	AddedAt     string
+}
+
+// listBinding captures everything that differs between the favorites and
+// watchlist pipelines so the shared machinery can operate on either list.
+type listBinding struct {
+	kind ListKind
+
+	importEnabled   func(Connection) bool
+	exportEnabled   func(Connection) bool
+	removalsEnabled func(Connection) bool
+
+	capImport func(Capabilities) bool
+	capExport func(Capabilities) bool
+	capRemove func(Capabilities) bool
+
+	// Provider interface resolution. ok=false means the provider does not
+	// implement the capability for this list kind.
+	fetchBatch  func(ctx context.Context, cfg ServerConfig, conn Connection, provider Provider) (batch FavoriteImportBatch, ok bool, err error)
+	exportItems func(ctx context.Context, cfg ServerConfig, conn Connection, provider Provider, items []LocalFavorite) (result ExportResult, ok bool, err error)
+	removeItems func(ctx context.Context, cfg ServerConfig, conn Connection, provider Provider, items []LocalFavorite) (result ExportResult, ok bool, err error)
+
+	// Local list operations against the per-user store.
+	localAdd    func(ctx context.Context, store userstore.UserStore, profileID, mediaItemID string, at time.Time) error
+	localRemove func(ctx context.Context, store userstore.UserStore, profileID, mediaItemID string) error
+	localList   func(ctx context.Context, store userstore.UserStore, profileID string, limit, offset int) ([]listRow, error)
+
+	setLastSync     func(conn *Connection, at time.Time)
+	setImportCounts func(run *SyncRun, found, imported int)
+	setExportCounts func(run *SyncRun, found, sent int)
+	setRemovalCount func(run *SyncRun, removed int)
+
+	// Optional order mirroring (watchlist only): when all three are set and
+	// gated true, importList mirrors the provider's returned item order locally.
+	orderEnabled func(Connection) bool
+	capOrder     func(Capabilities) bool
+	applyOrder   func(ctx context.Context, store userstore.UserStore, profileID string, orderedIDs []string) error
+}
+
+func (s *Service) favoritesBinding() listBinding {
+	return listBinding{
+		kind:            ListKindFavorites,
+		importEnabled:   func(c Connection) bool { return c.ImportFavoritesEnabled },
+		exportEnabled:   func(c Connection) bool { return c.ExportFavoritesEnabled },
+		removalsEnabled: func(c Connection) bool { return c.SyncFavoriteRemovalsEnabled },
+		capImport:       func(c Capabilities) bool { return c.ImportFavorites },
+		capExport:       func(c Capabilities) bool { return c.ExportFavorites },
+		capRemove:       func(c Capabilities) bool { return c.RemoveFavorites },
+		fetchBatch: func(ctx context.Context, cfg ServerConfig, conn Connection, provider Provider) (FavoriteImportBatch, bool, error) {
+			importer, ok := provider.(FavoriteImporter)
+			if !ok {
+				return FavoriteImportBatch{}, false, nil
+			}
+			if batchImporter, ok := provider.(FavoriteBatchImporter); ok {
+				batch, err := batchImporter.FetchFavoritesBatch(ctx, cfg, conn)
+				return batch, true, err
+			}
+			rows, err := importer.FetchFavorites(ctx, cfg, conn)
+			if err != nil {
+				return FavoriteImportBatch{}, true, err
+			}
+			return FavoriteImportBatch{Rows: rows}, true, nil
+		},
+		exportItems: func(ctx context.Context, cfg ServerConfig, conn Connection, provider Provider, items []LocalFavorite) (ExportResult, bool, error) {
+			exporter, ok := provider.(FavoriteExporter)
+			if !ok {
+				return ExportResult{}, false, nil
+			}
+			res, err := exporter.ExportFavorites(ctx, cfg, conn, items)
+			return res, true, err
+		},
+		removeItems: func(ctx context.Context, cfg ServerConfig, conn Connection, provider Provider, items []LocalFavorite) (ExportResult, bool, error) {
+			remover, ok := provider.(FavoriteRemover)
+			if !ok {
+				return ExportResult{}, false, nil
+			}
+			res, err := remover.RemoveFavorites(ctx, cfg, conn, items)
+			return res, true, err
+		},
+		localAdd: func(ctx context.Context, store userstore.UserStore, profileID, mediaItemID string, at time.Time) error {
+			return store.AddFavoriteAt(ctx, profileID, mediaItemID, at)
+		},
+		localRemove: func(ctx context.Context, store userstore.UserStore, profileID, mediaItemID string) error {
+			return store.RemoveFavorite(ctx, profileID, mediaItemID)
+		},
+		localList: func(ctx context.Context, store userstore.UserStore, profileID string, limit, offset int) ([]listRow, error) {
+			favorites, err := store.ListFavorites(ctx, profileID, limit, offset)
+			if err != nil {
+				return nil, err
+			}
+			rows := make([]listRow, 0, len(favorites))
+			for _, fav := range favorites {
+				rows = append(rows, listRow{MediaItemID: fav.MediaItemID, AddedAt: fav.AddedAt})
+			}
+			return rows, nil
+		},
+		setLastSync: func(conn *Connection, at time.Time) { conn.LastFavoritesSyncAt = &at },
+		setImportCounts: func(run *SyncRun, found, imported int) {
+			run.InboundFavoritesFound, run.InboundFavoritesImported = found, imported
+		},
+		setExportCounts: func(run *SyncRun, found, sent int) {
+			run.OutboundFavoritesFound, run.OutboundFavoritesSent = found, sent
+		},
+		setRemovalCount: func(run *SyncRun, removed int) { run.FavoriteRemovalsSent = removed },
+	}
+}
+
+func (s *Service) watchlistBinding() listBinding {
+	return listBinding{
+		kind:            ListKindWatchlist,
+		importEnabled:   func(c Connection) bool { return c.ImportWatchlistEnabled },
+		exportEnabled:   func(c Connection) bool { return c.ExportWatchlistEnabled },
+		removalsEnabled: func(c Connection) bool { return c.SyncWatchlistRemovalsEnabled },
+		capImport:       func(c Capabilities) bool { return c.ImportWatchlist },
+		capExport:       func(c Capabilities) bool { return c.ExportWatchlist },
+		capRemove:       func(c Capabilities) bool { return c.RemoveWatchlist },
+		fetchBatch: func(ctx context.Context, cfg ServerConfig, conn Connection, provider Provider) (FavoriteImportBatch, bool, error) {
+			importer, ok := provider.(WatchlistImporter)
+			if !ok {
+				return FavoriteImportBatch{}, false, nil
+			}
+			if batchImporter, ok := provider.(WatchlistBatchImporter); ok {
+				batch, err := batchImporter.FetchWatchlistBatch(ctx, cfg, conn)
+				return batch, true, err
+			}
+			rows, err := importer.FetchWatchlist(ctx, cfg, conn)
+			if err != nil {
+				return FavoriteImportBatch{}, true, err
+			}
+			return FavoriteImportBatch{Rows: rows}, true, nil
+		},
+		exportItems: func(ctx context.Context, cfg ServerConfig, conn Connection, provider Provider, items []LocalFavorite) (ExportResult, bool, error) {
+			exporter, ok := provider.(WatchlistExporter)
+			if !ok {
+				return ExportResult{}, false, nil
+			}
+			res, err := exporter.ExportWatchlist(ctx, cfg, conn, items)
+			return res, true, err
+		},
+		removeItems: func(ctx context.Context, cfg ServerConfig, conn Connection, provider Provider, items []LocalFavorite) (ExportResult, bool, error) {
+			remover, ok := provider.(WatchlistRemover)
+			if !ok {
+				return ExportResult{}, false, nil
+			}
+			res, err := remover.RemoveWatchlist(ctx, cfg, conn, items)
+			return res, true, err
+		},
+		localAdd: func(ctx context.Context, store userstore.UserStore, profileID, mediaItemID string, at time.Time) error {
+			return store.AddToWatchlistAt(ctx, profileID, mediaItemID, at)
+		},
+		localRemove: func(ctx context.Context, store userstore.UserStore, profileID, mediaItemID string) error {
+			return store.RemoveFromWatchlist(ctx, profileID, mediaItemID)
+		},
+		localList: func(ctx context.Context, store userstore.UserStore, profileID string, limit, offset int) ([]listRow, error) {
+			entries, err := store.ListWatchlist(ctx, profileID, limit, offset)
+			if err != nil {
+				return nil, err
+			}
+			rows := make([]listRow, 0, len(entries))
+			for _, entry := range entries {
+				rows = append(rows, listRow{MediaItemID: entry.MediaItemID, AddedAt: entry.AddedAt})
+			}
+			return rows, nil
+		},
+		setLastSync: func(conn *Connection, at time.Time) { conn.LastWatchlistSyncAt = &at },
+		setImportCounts: func(run *SyncRun, found, imported int) {
+			run.InboundWatchlistFound, run.InboundWatchlistImported = found, imported
+		},
+		setExportCounts: func(run *SyncRun, found, sent int) {
+			run.OutboundWatchlistFound, run.OutboundWatchlistSent = found, sent
+		},
+		setRemovalCount: func(run *SyncRun, removed int) { run.WatchlistRemovalsSent = removed },
+		orderEnabled:    func(c Connection) bool { return c.SyncWatchlistOrderEnabled },
+		capOrder:        func(c Capabilities) bool { return c.ProvidesWatchlistOrder },
+		applyOrder: func(ctx context.Context, store userstore.UserStore, profileID string, orderedIDs []string) error {
+			return store.ReplaceWatchlistOrder(ctx, profileID, orderedIDs)
+		},
+	}
+}
+
+func (s *Service) listBindings() []listBinding {
+	return []listBinding{s.favoritesBinding(), s.watchlistBinding()}
+}
+
+func (s *Service) bindingForKind(kind ListKind) (listBinding, bool) {
+	switch kind {
+	case ListKindFavorites:
+		return s.favoritesBinding(), true
+	case ListKindWatchlist:
+		return s.watchlistBinding(), true
+	default:
+		return listBinding{}, false
+	}
+}
+
+type ImportListResult struct {
+	Found     int
+	Imported  int
+	Unmatched int
+	Removed   int
+	Warnings  []string
+}
+
+// importList pulls the provider's list (favorites or watchlist) and mirrors it
+// into the local list, recording shadow state and reconciling remote removals.
+func (s *Service) importList(ctx context.Context, conn Connection, cfg ServerConfig, provider Provider, b listBinding) (ImportListResult, error) {
+	if s.matcher == nil {
+		return ImportListResult{}, fmt.Errorf("watch provider matcher is not configured")
+	}
+	if s.storeProvider == nil {
+		return ImportListResult{}, fmt.Errorf("user store provider is not configured")
+	}
+	store, err := s.storeProvider.ForUser(ctx, conn.UserID)
+	if err != nil {
+		return ImportListResult{}, fmt.Errorf("open user store: %w", err)
+	}
+	batch, ok, err := b.fetchBatch(ctx, cfg, conn, provider)
+	if err != nil {
+		return ImportListResult{}, err
+	}
+	if !ok {
+		return ImportListResult{}, fmt.Errorf("provider %q does not implement %s import", conn.Provider, b.kind)
+	}
+	rows := batch.Rows
+	result := ImportListResult{Found: len(rows), Warnings: append([]string{}, batch.Warnings...)}
+	seenRemoteKeys := make(map[string]bool, len(rows))
+	states := make([]ListItemState, 0, len(rows))
+	// orderedIDs records matched local ids in the order the provider returned
+	// them, so an order-providing list (e.g. MDBList watchlist) can mirror its
+	// sort locally.
+	orderedIDs := make([]string, 0, len(rows))
+	for _, row := range rows {
+		match, reason, err := s.matcher.Match(ctx, row.HistoryRecord())
+		if err != nil {
+			return result, err
+		}
+		if match == nil {
+			result.Unmatched++
+			if reason != "" {
+				result.Warnings = append(result.Warnings, reason)
+			}
+			continue
+		}
+		if err := b.localAdd(ctx, store, conn.ProfileID, match.MediaItemID, row.FavoritedAt); err != nil {
+			return result, err
+		}
+		orderedIDs = append(orderedIDs, match.MediaItemID)
+		result.Imported++
+		key := row.ProviderItemKey
+		if key == "" {
+			key = providerItemKeyForRemoteFavorite(row)
+		}
+		if key != "" {
+			seenRemoteKeys[key] = true
+		}
+		listedAt := row.FavoritedAt
+		states = append(states, ListItemState{
+			ConnectionID:     conn.ID,
+			ListKind:         b.kind,
+			MediaItemID:      match.MediaItemID,
+			ProviderItemKey:  key,
+			Kind:             row.Kind,
+			Title:            row.Title,
+			Year:             row.Year,
+			RemotePresent:    true,
+			LocalPresent:     true,
+			LastSeenRemoteAt: &listedAt,
+			LastSeenLocalAt:  &listedAt,
+		})
+	}
+	if err := s.repo.UpsertListItemStates(ctx, states); err != nil {
+		return result, err
+	}
+	if err := s.reconcileMissingRemoteListItems(ctx, conn, store, b, seenRemoteKeys, &result); err != nil {
+		return result, err
+	}
+	if b.applyOrder != nil && b.orderEnabled != nil && b.capOrder != nil &&
+		b.orderEnabled(conn) && b.capOrder(provider.Capabilities()) {
+		if err := b.applyOrder(ctx, store, conn.ProfileID, orderedIDs); err != nil {
+			return result, err
+		}
+	}
+	now := s.now()
+	b.setLastSync(&conn, now)
+	conn.LastError = ""
+	conn.SyncCursors = mergeSyncCursors(conn.SyncCursors, batch.UpdatedCursors)
+	if _, err := s.repo.UpsertConnection(ctx, conn); err != nil {
+		return result, err
+	}
+	return result, nil
+}
+
+func (s *Service) reconcileMissingRemoteListItems(ctx context.Context, conn Connection, store userstore.UserStore, b listBinding, seenRemoteKeys map[string]bool, result *ImportListResult) error {
+	states, err := s.repo.ListListItemStates(ctx, conn.ID, b.kind)
+	if err != nil {
+		return err
+	}
+	now := s.now()
+	for _, state := range states {
+		if !state.RemotePresent || state.ProviderItemKey == "" || seenRemoteKeys[state.ProviderItemKey] {
+			continue
+		}
+		if b.removalsEnabled(conn) && state.LocalPresent {
+			if err := b.localRemove(ctx, store, conn.ProfileID, state.MediaItemID); err != nil {
+				return err
+			}
+			if err := s.repo.MarkListItemLocalRemoved(ctx, conn.ID, b.kind, state.MediaItemID, now); err != nil {
+				return err
+			}
+			result.Removed++
+		}
+		if err := s.repo.MarkListItemRemoteRemoved(ctx, conn.ID, b.kind, state.MediaItemID, now); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+type ExportListResult struct {
+	LocalFound int
+	Queued     int
+	Sent       int
+	Failed     int
+	Warnings   []string
+}
+
+// exportList pushes the local list (favorites or watchlist) to the provider,
+// sending only items not yet known-present remotely.
+func (s *Service) exportList(ctx context.Context, conn Connection, cfg ServerConfig, provider Provider, b listBinding) (ExportListResult, error) {
+	if s.storeProvider == nil {
+		return ExportListResult{}, fmt.Errorf("user store provider is not configured")
+	}
+	store, err := s.storeProvider.ForUser(ctx, conn.UserID)
+	if err != nil {
+		return ExportListResult{}, fmt.Errorf("open user store: %w", err)
+	}
+	rows, err := b.localList(ctx, store, conn.ProfileID, 10000, 0)
+	if err != nil {
+		return ExportListResult{}, err
+	}
+	result := ExportListResult{LocalFound: len(rows)}
+	items, states, warnings, err := s.localItemsFromRows(ctx, conn, b, rows)
+	if err != nil {
+		return result, err
+	}
+	result.Warnings = append(result.Warnings, warnings...)
+	if err := s.repo.UpsertListItemStates(ctx, states); err != nil {
+		return result, err
+	}
+	for {
+		pending, err := s.repo.ListPendingListItemExports(ctx, conn.ID, b.kind, 100)
+		if err != nil {
+			return result, err
+		}
+		if len(pending) == 0 {
+			break
+		}
+		byMedia := make(map[string]LocalFavorite, len(items))
+		for _, item := range items {
+			byMedia[item.MediaItemID] = item
+		}
+		toSend := make([]LocalFavorite, 0, len(pending))
+		for _, state := range pending {
+			item, ok := byMedia[state.MediaItemID]
+			if !ok {
+				if err := s.repo.MarkListItemLocalRemoved(ctx, conn.ID, b.kind, state.MediaItemID, s.now()); err != nil {
+					return result, err
+				}
+				continue
+			}
+			toSend = append(toSend, item)
+		}
+		if len(toSend) == 0 {
+			continue
+		}
+		result.Queued += len(toSend)
+		exportResult, ok, err := b.exportItems(ctx, cfg, conn, provider, toSend)
+		if !ok {
+			return result, fmt.Errorf("provider %q does not implement %s export", conn.Provider, b.kind)
+		}
+		if err != nil {
+			for _, item := range toSend {
+				_ = s.repo.MarkListItemError(ctx, conn.ID, b.kind, item.MediaItemID, err.Error())
+			}
+			result.Failed += len(toSend)
+			return result, err
+		}
+		now := s.now()
+		sent := exportResultSentSet(exportResult)
+		for _, item := range toSend {
+			if sent[item.MediaItemID] || sent[item.ProviderItemKey] {
+				if err := s.repo.MarkListItemExported(ctx, conn.ID, b.kind, item.MediaItemID, now); err != nil {
+					return result, err
+				}
+				result.Sent++
+				continue
+			}
+			if containsString(exportResult.NotFound, item.MediaItemID) || containsString(exportResult.NotFound, item.ProviderItemKey) {
+				msg := string(b.kind) + " item not found by provider"
+				if err := s.repo.MarkListItemError(ctx, conn.ID, b.kind, item.MediaItemID, msg); err != nil {
+					return result, err
+				}
+				result.Warnings = append(result.Warnings, msg+": "+item.MediaItemID)
+			}
+		}
+	}
+	now := s.now()
+	b.setLastSync(&conn, now)
+	conn.LastError = ""
+	if _, err := s.repo.UpsertConnection(ctx, conn); err != nil {
+		return result, err
+	}
+	return result, nil
+}
+
+// removePendingListItems pushes pending local removals to the provider (items
+// dropped locally but still present remotely).
+func (s *Service) removePendingListItems(ctx context.Context, conn Connection, cfg ServerConfig, provider Provider, b listBinding) (int, error) {
+	removed := 0
+	for {
+		pending, err := s.repo.ListPendingListItemRemovals(ctx, conn.ID, b.kind, 100)
+		if err != nil {
+			return removed, err
+		}
+		if len(pending) == 0 {
+			return removed, nil
+		}
+		items := make([]LocalFavorite, 0, len(pending))
+		for _, state := range pending {
+			items = append(items, LocalFavorite{
+				MediaItemID:     state.MediaItemID,
+				ProviderItemKey: state.ProviderItemKey,
+				Kind:            state.Kind,
+				Title:           state.Title,
+				Year:            state.Year,
+			})
+		}
+		result, ok, err := b.removeItems(ctx, cfg, conn, provider, items)
+		if !ok {
+			return removed, fmt.Errorf("provider %q does not implement %s removal", conn.Provider, b.kind)
+		}
+		if err != nil {
+			for _, item := range items {
+				_ = s.repo.MarkListItemError(ctx, conn.ID, b.kind, item.MediaItemID, err.Error())
+			}
+			return removed, err
+		}
+		now := s.now()
+		sent := exportResultSentSet(result)
+		for _, item := range items {
+			if sent[item.MediaItemID] || sent[item.ProviderItemKey] {
+				if err := s.repo.MarkListItemRemoteRemoved(ctx, conn.ID, b.kind, item.MediaItemID, now); err != nil {
+					return removed, err
+				}
+				removed++
+			}
+		}
+	}
+}
+
+func (s *Service) localItemsFromRows(ctx context.Context, conn Connection, b listBinding, rows []listRow) ([]LocalFavorite, []ListItemState, []string, error) {
+	ids := make([]string, 0, len(rows))
+	addedAtByID := make(map[string]time.Time, len(rows))
+	for _, row := range rows {
+		ids = append(ids, row.MediaItemID)
+		if addedAt, err := time.Parse(time.RFC3339, row.AddedAt); err == nil {
+			addedAtByID[row.MediaItemID] = addedAt
+		}
+	}
+	type listMediaResolver interface {
+		GetListMediaItems(ctx context.Context, mediaItemIDs []string) (map[string]LocalFavorite, error)
+	}
+	resolver, ok := s.repo.(listMediaResolver)
+	if !ok {
+		return nil, nil, nil, fmt.Errorf("list media resolver is not configured")
+	}
+	resolved, err := resolver.GetListMediaItems(ctx, ids)
+	if err != nil {
+		return nil, nil, nil, err
+	}
+	items := make([]LocalFavorite, 0, len(rows))
+	states := make([]ListItemState, 0, len(rows))
+	var warnings []string
+	for _, row := range rows {
+		item, ok := resolved[row.MediaItemID]
+		if !ok {
+			warnings = append(warnings, string(b.kind)+" media item not found: "+row.MediaItemID)
+			continue
+		}
+		item.FavoritedAt = addedAtByID[row.MediaItemID]
+		if item.FavoritedAt.IsZero() {
+			item.FavoritedAt = s.now()
+		}
+		if item.Kind != historyimport.KindMovie && item.Kind != historyimport.KindSeries {
+			warnings = append(warnings, string(b.kind)+" kind is not supported by provider: "+row.MediaItemID)
+			continue
+		}
+		if item.ProviderItemKey == "" {
+			warnings = append(warnings, string(b.kind)+" item has no provider ids: "+row.MediaItemID)
+			continue
+		}
+		items = append(items, item)
+		listedAt := item.FavoritedAt
+		states = append(states, ListItemState{
+			ConnectionID:    conn.ID,
+			ListKind:        b.kind,
+			MediaItemID:     item.MediaItemID,
+			ProviderItemKey: item.ProviderItemKey,
+			Kind:            item.Kind,
+			Title:           item.Title,
+			Year:            item.Year,
+			RemotePresent:   false,
+			LocalPresent:    true,
+			LastSeenLocalAt: &listedAt,
+		})
+	}
+	return items, states, warnings, nil
+}
+
+// HandleLocalListEvent mirrors a real-time local list change (add/remove of a
+// favorite or watchlist item) to the providers bound to that list kind. It is
+// fire-and-forget so the originating API request is never blocked on provider
+// I/O.
+func (s *Service) HandleLocalListEvent(ctx context.Context, event LocalListEvent) error {
+	if event.UserID == 0 || event.ProfileID == "" || len(event.Items) == 0 {
+		return nil
+	}
+	if event.List == "" {
+		event.List = ListKindFavorites
+	}
+	go func() {
+		bg, cancel := context.WithTimeout(context.Background(), 2*time.Minute)
+		defer cancel()
+		if err := s.processLocalListEvent(bg, event); err != nil {
+			slog.Warn("failed to dispatch local list provider event", "list", event.List, "change", event.Change, "user_id", event.UserID, "profile_id", event.ProfileID, "error", err)
+		}
+	}()
+	return nil
+}
+
+func (s *Service) processLocalListEvent(ctx context.Context, event LocalListEvent) error {
+	b, ok := s.bindingForKind(event.List)
+	if !ok {
+		return fmt.Errorf("unknown list kind %q", event.List)
+	}
+	conns, err := s.repo.ListListEventConnections(ctx, event.UserID, event.ProfileID, event.List)
+	if err != nil {
+		return err
+	}
+	for _, conn := range conns {
+		provider, ok := s.registry.Get(conn.Provider)
+		if !ok {
+			continue
+		}
+		cfg, err := s.serverConfig(ctx, conn.Provider)
+		if err != nil {
+			s.recordLocalWatchEventError(ctx, conn, err)
+			continue
+		}
+		conn, err = s.refreshConnectionIfNeeded(ctx, provider, cfg, conn)
+		if err != nil {
+			s.recordLocalWatchEventError(ctx, conn, err)
+			continue
+		}
+		switch event.Change {
+		case ListChangeAdded:
+			if !b.capExport(provider.Capabilities()) {
+				continue
+			}
+			if err := s.exportLocalListItems(ctx, conn, cfg, provider, b, event.Items); err != nil {
+				s.recordLocalWatchEventError(ctx, conn, err)
+			}
+		case ListChangeRemoved:
+			now := s.now()
+			for _, item := range event.Items {
+				if err := s.repo.MarkListItemLocalRemoved(ctx, conn.ID, b.kind, item.MediaItemID, now); err != nil {
+					return err
+				}
+			}
+			if !b.removalsEnabled(conn) || !b.capRemove(provider.Capabilities()) {
+				continue
+			}
+			if _, ok, err := b.removeItems(ctx, cfg, conn, provider, event.Items); !ok {
+				continue
+			} else if err != nil {
+				s.recordLocalWatchEventError(ctx, conn, err)
+				continue
+			}
+			for _, item := range event.Items {
+				if err := s.repo.MarkListItemRemoteRemoved(ctx, conn.ID, b.kind, item.MediaItemID, now); err != nil {
+					return err
+				}
+			}
+		}
+	}
+	return nil
+}
+
+func (s *Service) exportLocalListItems(ctx context.Context, conn Connection, cfg ServerConfig, provider Provider, b listBinding, items []LocalFavorite) error {
+	states := make([]ListItemState, 0, len(items))
+	for _, item := range items {
+		if item.ProviderItemKey == "" {
+			item.ProviderItemKey = providerItemKeyForLocalFavorite(item)
+		}
+		if item.ProviderItemKey == "" {
+			continue
+		}
+		listedAt := item.FavoritedAt
+		if listedAt.IsZero() {
+			listedAt = s.now()
+		}
+		states = append(states, ListItemState{
+			ConnectionID:    conn.ID,
+			ListKind:        b.kind,
+			MediaItemID:     item.MediaItemID,
+			ProviderItemKey: item.ProviderItemKey,
+			Kind:            item.Kind,
+			Title:           item.Title,
+			Year:            item.Year,
+			RemotePresent:   false,
+			LocalPresent:    true,
+			LastSeenLocalAt: &listedAt,
+		})
+	}
+	if err := s.repo.UpsertListItemStates(ctx, states); err != nil {
+		return err
+	}
+	result, ok, err := b.exportItems(ctx, cfg, conn, provider, items)
+	if !ok {
+		return nil
+	}
+	if err != nil {
+		return err
+	}
+	now := s.now()
+	sent := exportResultSentSet(result)
+	for _, item := range items {
+		if sent[item.MediaItemID] || sent[item.ProviderItemKey] {
+			if err := s.repo.MarkListItemExported(ctx, conn.ID, b.kind, item.MediaItemID, now); err != nil {
+				return err
+			}
+		}
+	}
+	b.setLastSync(&conn, now)
+	conn.LastError = ""
+	_, err = s.repo.UpsertConnection(ctx, conn)
+	return err
+}

--- a/internal/watchsync/lists.go
+++ b/internal/watchsync/lists.go
@@ -418,13 +418,15 @@ func (s *Service) exportList(ctx context.Context, conn Connection, cfg ServerCon
 				result.Sent++
 				continue
 			}
-			if containsString(exportResult.NotFound, item.MediaItemID) || containsString(exportResult.NotFound, item.ProviderItemKey) {
-				msg := string(b.kind) + " item not found by provider"
-				if err := s.repo.MarkListItemError(ctx, conn.ID, b.kind, item.MediaItemID, msg); err != nil {
-					return result, err
-				}
-				result.Warnings = append(result.Warnings, msg+": "+item.MediaItemID)
+			// Anything not confirmed sent (not_found, failed, or omitted from the
+			// provider response) is marked with an error so it leaves the pending
+			// set this run; the next run's UpsertListItemStates clears the error
+			// and re-attempts, so transient failures still retry.
+			msg := exportFailureReason(exportResult, item, b.kind)
+			if err := s.repo.MarkListItemError(ctx, conn.ID, b.kind, item.MediaItemID, msg); err != nil {
+				return result, err
 			}
+			result.Warnings = append(result.Warnings, msg+": "+item.MediaItemID)
 		}
 	}
 	now := s.now()
@@ -440,16 +442,21 @@ func (s *Service) exportList(ctx context.Context, conn Connection, cfg ServerCon
 // dropped locally but still present remotely).
 func (s *Service) removePendingListItems(ctx context.Context, conn Connection, cfg ServerConfig, provider Provider, b listBinding) (int, error) {
 	removed := 0
+	// Removal failures intentionally do not set last_error (which would strand
+	// the row from ListPendingListItemRemovals, since there is no per-run upsert
+	// to clear it). Instead we track items attempted this run in memory so the
+	// loop terminates, and leave failed rows pending for the next scheduled run.
+	attempted := make(map[string]bool)
 	for {
 		pending, err := s.repo.ListPendingListItemRemovals(ctx, conn.ID, b.kind, 100)
 		if err != nil {
 			return removed, err
 		}
-		if len(pending) == 0 {
-			return removed, nil
-		}
 		items := make([]LocalFavorite, 0, len(pending))
 		for _, state := range pending {
+			if attempted[state.MediaItemID] {
+				continue
+			}
 			items = append(items, LocalFavorite{
 				MediaItemID:     state.MediaItemID,
 				ProviderItemKey: state.ProviderItemKey,
@@ -458,20 +465,25 @@ func (s *Service) removePendingListItems(ctx context.Context, conn Connection, c
 				Year:            state.Year,
 			})
 		}
+		if len(items) == 0 {
+			return removed, nil
+		}
 		result, ok, err := b.removeItems(ctx, cfg, conn, provider, items)
 		if !ok {
 			return removed, fmt.Errorf("provider %q does not implement %s removal", conn.Provider, b.kind)
 		}
 		if err != nil {
-			for _, item := range items {
-				_ = s.repo.MarkListItemError(ctx, conn.ID, b.kind, item.MediaItemID, err.Error())
-			}
+			// Leave the rows pending so the next scheduled run retries them.
 			return removed, err
 		}
 		now := s.now()
 		sent := exportResultSentSet(result)
 		for _, item := range items {
-			if sent[item.MediaItemID] || sent[item.ProviderItemKey] {
+			attempted[item.MediaItemID] = true
+			// Sent (removed) and NotFound (already absent remotely) both reconcile
+			// the row; true failures stay pending for the next run.
+			if sent[item.MediaItemID] || sent[item.ProviderItemKey] ||
+				containsString(result.NotFound, item.MediaItemID) || containsString(result.NotFound, item.ProviderItemKey) {
 				if err := s.repo.MarkListItemRemoteRemoved(ctx, conn.ID, b.kind, item.MediaItemID, now); err != nil {
 					return removed, err
 				}
@@ -603,15 +615,22 @@ func (s *Service) processLocalListEvent(ctx context.Context, event LocalListEven
 			if !b.removalsEnabled(conn) || !b.capRemove(provider.Capabilities()) {
 				continue
 			}
-			if _, ok, err := b.removeItems(ctx, cfg, conn, provider, event.Items); !ok {
+			result, ok, err := b.removeItems(ctx, cfg, conn, provider, event.Items)
+			if !ok {
 				continue
-			} else if err != nil {
+			}
+			if err != nil {
+				// Leave remote_present set so the scheduled reconcile retries.
 				s.recordLocalWatchEventError(ctx, conn, err)
 				continue
 			}
+			sent := exportResultSentSet(result)
 			for _, item := range event.Items {
-				if err := s.repo.MarkListItemRemoteRemoved(ctx, conn.ID, b.kind, item.MediaItemID, now); err != nil {
-					return err
+				if sent[item.MediaItemID] || sent[item.ProviderItemKey] ||
+					containsString(result.NotFound, item.MediaItemID) || containsString(result.NotFound, item.ProviderItemKey) {
+					if err := s.repo.MarkListItemRemoteRemoved(ctx, conn.ID, b.kind, item.MediaItemID, now); err != nil {
+						return err
+					}
 				}
 			}
 		}
@@ -621,6 +640,9 @@ func (s *Service) processLocalListEvent(ctx context.Context, event LocalListEven
 
 func (s *Service) exportLocalListItems(ctx context.Context, conn Connection, cfg ServerConfig, provider Provider, b listBinding, items []LocalFavorite) error {
 	states := make([]ListItemState, 0, len(items))
+	// toSend carries the normalized items (with a computed ProviderItemKey) so
+	// the provider receives the same keys we record in shadow state.
+	toSend := make([]LocalFavorite, 0, len(items))
 	for _, item := range items {
 		if item.ProviderItemKey == "" {
 			item.ProviderItemKey = providerItemKeyForLocalFavorite(item)
@@ -644,11 +666,12 @@ func (s *Service) exportLocalListItems(ctx context.Context, conn Connection, cfg
 			LocalPresent:    true,
 			LastSeenLocalAt: &listedAt,
 		})
+		toSend = append(toSend, item)
 	}
 	if err := s.repo.UpsertListItemStates(ctx, states); err != nil {
 		return err
 	}
-	result, ok, err := b.exportItems(ctx, cfg, conn, provider, items)
+	result, ok, err := b.exportItems(ctx, cfg, conn, provider, toSend)
 	if !ok {
 		return nil
 	}
@@ -657,7 +680,7 @@ func (s *Service) exportLocalListItems(ctx context.Context, conn Connection, cfg
 	}
 	now := s.now()
 	sent := exportResultSentSet(result)
-	for _, item := range items {
+	for _, item := range toSend {
 		if sent[item.MediaItemID] || sent[item.ProviderItemKey] {
 			if err := s.repo.MarkListItemExported(ctx, conn.ID, b.kind, item.MediaItemID, now); err != nil {
 				return err

--- a/internal/watchsync/providers/mdblist/provider.go
+++ b/internal/watchsync/providers/mdblist/provider.go
@@ -52,15 +52,18 @@ func (p *Provider) DisplayName() string {
 }
 
 func (p *Provider) Capabilities() watchsync.Capabilities {
+	// MDBList exposes a single list — its watchlist — so it binds to Silo's
+	// watchlist rather than favorites.
 	return watchsync.Capabilities{
-		ImportWatched:    true,
-		ImportProgress:   true,
-		ExportWatched:    true,
-		ExportUnwatched:  true,
-		ImportFavorites:  true,
-		ExportFavorites:  true,
-		RemoveFavorites:  true,
-		ScrobblePlayback: true,
+		ImportWatched:          true,
+		ImportProgress:         true,
+		ExportWatched:          true,
+		ExportUnwatched:        true,
+		ImportWatchlist:        true,
+		ExportWatchlist:        true,
+		RemoveWatchlist:        true,
+		ProvidesWatchlistOrder: true,
+		ScrobblePlayback:       true,
 	}
 }
 
@@ -305,7 +308,7 @@ func (p *Provider) sendWatched(ctx context.Context, conn watchsync.Connection, p
 	return result, nil
 }
 
-func (p *Provider) FetchFavorites(ctx context.Context, _ watchsync.ServerConfig, conn watchsync.Connection) ([]watchsync.RemoteFavorite, error) {
+func (p *Provider) FetchWatchlist(ctx context.Context, _ watchsync.ServerConfig, conn watchsync.Connection) ([]watchsync.RemoteFavorite, error) {
 	now := time.Now().UTC()
 	var rows []watchsync.RemoteFavorite
 	for offset := 0; ; {
@@ -365,12 +368,12 @@ func watchlistRowsFromPayload(providerKey string, payload mdblistWatchlistRespon
 	return rows
 }
 
-func (p *Provider) ExportFavorites(ctx context.Context, _ watchsync.ServerConfig, conn watchsync.Connection, favorites []watchsync.LocalFavorite) (watchsync.ExportResult, error) {
-	return p.sendWatchlist(ctx, conn, favorites, "/watchlist/items/add")
+func (p *Provider) ExportWatchlist(ctx context.Context, _ watchsync.ServerConfig, conn watchsync.Connection, items []watchsync.LocalFavorite) (watchsync.ExportResult, error) {
+	return p.sendWatchlist(ctx, conn, items, "/watchlist/items/add")
 }
 
-func (p *Provider) RemoveFavorites(ctx context.Context, _ watchsync.ServerConfig, conn watchsync.Connection, favorites []watchsync.LocalFavorite) (watchsync.ExportResult, error) {
-	return p.sendWatchlist(ctx, conn, favorites, "/watchlist/items/remove")
+func (p *Provider) RemoveWatchlist(ctx context.Context, _ watchsync.ServerConfig, conn watchsync.Connection, items []watchsync.LocalFavorite) (watchsync.ExportResult, error) {
+	return p.sendWatchlist(ctx, conn, items, "/watchlist/items/remove")
 }
 
 func (p *Provider) sendWatchlist(ctx context.Context, conn watchsync.Connection, favorites []watchsync.LocalFavorite, path string) (watchsync.ExportResult, error) {

--- a/internal/watchsync/providers/mdblist/provider_test.go
+++ b/internal/watchsync/providers/mdblist/provider_test.go
@@ -23,8 +23,14 @@ func TestProviderIdentityAndCapabilities(t *testing.T) {
 		t.Fatalf("got display name %q, want MDBList", p.DisplayName())
 	}
 	caps := p.Capabilities()
-	if !caps.ScrobblePlayback || !caps.ImportWatched || !caps.ExportFavorites {
+	if !caps.ScrobblePlayback || !caps.ImportWatched || !caps.ExportWatchlist {
 		t.Fatalf("unexpected capabilities: %#v", caps)
+	}
+	if caps.ImportFavorites || caps.ExportFavorites || caps.RemoveFavorites {
+		t.Fatalf("mdblist should bind to watchlist, not favorites: %#v", caps)
+	}
+	if !caps.ProvidesWatchlistOrder {
+		t.Fatalf("mdblist should provide watchlist order: %#v", caps)
 	}
 	var _ watchsync.APIKeyAuthProvider = p
 }
@@ -274,7 +280,7 @@ func TestScrobbleStartUsesEpisodeShape(t *testing.T) {
 	}
 }
 
-func TestExportFavoritesSendsToWatchlistAdd(t *testing.T) {
+func TestExportWatchlistSendsToWatchlistAdd(t *testing.T) {
 	var gotPath string
 	var gotBody map[string]any
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -291,9 +297,9 @@ func TestExportFavoritesSendsToWatchlistAdd(t *testing.T) {
 		{MediaItemID: "m1", Kind: historyimport.KindMovie, IMDbID: "tt0111161"},
 		{MediaItemID: "s1", Kind: historyimport.KindSeries, IMDbID: "tt0903747"},
 	}
-	result, err := p.ExportFavorites(context.Background(), watchsync.ServerConfig{}, watchsync.Connection{AccessToken: "k"}, favorites)
+	result, err := p.ExportWatchlist(context.Background(), watchsync.ServerConfig{}, watchsync.Connection{AccessToken: "k"}, favorites)
 	if err != nil {
-		t.Fatalf("export favorites: %v", err)
+		t.Fatalf("export watchlist: %v", err)
 	}
 	if !strings.HasPrefix(gotPath, "/watchlist/items/add") {
 		t.Fatalf("got path %q, want /watchlist/items/add", gotPath)

--- a/internal/watchsync/providers/simkl/provider.go
+++ b/internal/watchsync/providers/simkl/provider.go
@@ -65,6 +65,9 @@ func (p *Provider) Capabilities() watchsync.Capabilities {
 		ImportProgress:   true,
 		ExportWatched:    true,
 		ExportUnwatched:  true,
+		ImportWatchlist:  true,
+		ExportWatchlist:  true,
+		RemoveWatchlist:  true,
 		ScrobblePlayback: true,
 	}
 }
@@ -323,6 +326,91 @@ func (p *Provider) Stop(ctx context.Context, cfg watchsync.ServerConfig, conn wa
 		return nil
 	}
 	return err
+}
+
+// FetchWatchlist pulls Simkl's "plan to watch" list across movies, shows and
+// anime. Simkl has no separate favorites concept; plan-to-watch is its
+// watchlist.
+func (p *Provider) FetchWatchlist(ctx context.Context, cfg watchsync.ServerConfig, conn watchsync.Connection) ([]watchsync.RemoteFavorite, error) {
+	now := time.Now().UTC()
+	var rows []watchsync.RemoteFavorite
+
+	var movies simklAllItemsResponse
+	if err := p.do(ctx, http.MethodGet, "/sync/all-items/movies/plantowatch?extended=full", cfg, conn.AccessToken, nil, &movies); err != nil {
+		return nil, err
+	}
+	for _, movie := range movies.Movies {
+		key := movieKey(movie.Movie.IDs)
+		if key == "" {
+			continue
+		}
+		rows = append(rows, watchsync.RemoteFavorite{
+			Provider:        p.Key(),
+			ProviderItemKey: key,
+			Kind:            historyimport.KindMovie,
+			Title:           movie.Movie.Title,
+			Year:            movie.Movie.Year,
+			IMDbID:          movie.Movie.IDs.IMDb,
+			TMDBID:          intString(movie.Movie.IDs.TMDB),
+			TVDBID:          intString(movie.Movie.IDs.TVDB),
+			FavoritedAt:     now,
+		})
+	}
+
+	for _, path := range []string{
+		"/sync/all-items/shows/plantowatch?extended=full",
+		"/sync/all-items/anime/plantowatch?extended=full",
+	} {
+		var payload simklAllItemsResponse
+		if err := p.do(ctx, http.MethodGet, path, cfg, conn.AccessToken, nil, &payload); err != nil {
+			return nil, err
+		}
+		for _, show := range append(payload.Shows, payload.Anime...) {
+			key := showKey(show.Show.IDs)
+			if key == "" {
+				continue
+			}
+			rows = append(rows, watchsync.RemoteFavorite{
+				Provider:        p.Key(),
+				ProviderItemKey: key,
+				Kind:            historyimport.KindSeries,
+				Title:           show.Show.Title,
+				Year:            show.Show.Year,
+				IMDbID:          show.Show.IDs.IMDb,
+				TMDBID:          intString(show.Show.IDs.TMDB),
+				TVDBID:          intString(show.Show.IDs.TVDB),
+				FavoritedAt:     now,
+			})
+		}
+	}
+	return rows, nil
+}
+
+func (p *Provider) ExportWatchlist(ctx context.Context, cfg watchsync.ServerConfig, conn watchsync.Connection, items []watchsync.LocalFavorite) (watchsync.ExportResult, error) {
+	return p.sendListChange(ctx, "/sync/add-to-list", cfg, conn, items, "plantowatch")
+}
+
+func (p *Provider) RemoveWatchlist(ctx context.Context, cfg watchsync.ServerConfig, conn watchsync.Connection, items []watchsync.LocalFavorite) (watchsync.ExportResult, error) {
+	return p.sendListChange(ctx, "/sync/remove-from-list", cfg, conn, items, "")
+}
+
+func (p *Provider) sendListChange(ctx context.Context, path string, cfg watchsync.ServerConfig, conn watchsync.Connection, items []watchsync.LocalFavorite, to string) (watchsync.ExportResult, error) {
+	payload := buildSimklListPayload(items, to)
+	if len(payload.Movies) == 0 && len(payload.Shows) == 0 {
+		return watchsync.ExportResult{}, nil
+	}
+	var body bytes.Buffer
+	if err := json.NewEncoder(&body).Encode(payload); err != nil {
+		return watchsync.ExportResult{}, fmt.Errorf("encode simkl list payload: %w", err)
+	}
+	if err := p.do(ctx, http.MethodPost, path, cfg, conn.AccessToken, &body, nil); err != nil {
+		return watchsync.ExportResult{}, err
+	}
+	result := watchsync.ExportResult{Sent: make([]string, 0, len(items)*2)}
+	for _, item := range items {
+		result.Sent = append(result.Sent, item.MediaItemID, item.ProviderItemKey)
+	}
+	return result, nil
 }
 
 func (p *Provider) fetchActivities(ctx context.Context, cfg watchsync.ServerConfig, conn watchsync.Connection) (simklActivities, error) {
@@ -1045,6 +1133,71 @@ func movieKey(ids simklIDs) string {
 		return "simkl:" + strconv.Itoa(ids.Simkl)
 	default:
 		return ""
+	}
+}
+
+func showKey(ids simklIDs) string {
+	switch {
+	case ids.TVDB > 0:
+		return "tvdb:" + strconv.Itoa(ids.TVDB)
+	case ids.TMDB > 0:
+		return "tmdb:" + strconv.Itoa(ids.TMDB)
+	case ids.IMDb != "":
+		return "imdb:" + ids.IMDb
+	case ids.Simkl > 0:
+		return "simkl:" + strconv.Itoa(ids.Simkl)
+	default:
+		return ""
+	}
+}
+
+type simklListPayload struct {
+	Movies []simklListItem `json:"movies,omitempty"`
+	Shows  []simklListItem `json:"shows,omitempty"`
+}
+
+type simklListItem struct {
+	To  string   `json:"to,omitempty"`
+	IDs simklIDs `json:"ids"`
+}
+
+func buildSimklListPayload(items []watchsync.LocalFavorite, to string) simklListPayload {
+	var payload simklListPayload
+	for _, item := range items {
+		ids := idsFromLocal(item.IMDbID, item.TMDBID, item.TVDBID)
+		if ids == (simklIDs{}) {
+			ids = idsFromProviderItemKey(item.ProviderItemKey)
+		}
+		if ids == (simklIDs{}) {
+			continue
+		}
+		ref := simklListItem{To: to, IDs: ids}
+		switch item.Kind {
+		case historyimport.KindMovie:
+			payload.Movies = append(payload.Movies, ref)
+		case historyimport.KindSeries:
+			payload.Shows = append(payload.Shows, ref)
+		}
+	}
+	return payload
+}
+
+func idsFromProviderItemKey(key string) simklIDs {
+	prefix, value, ok := strings.Cut(key, ":")
+	if !ok || value == "" {
+		return simklIDs{}
+	}
+	switch prefix {
+	case "imdb":
+		return simklIDs{IMDb: value}
+	case "tmdb":
+		return simklIDs{TMDB: parseInt(value)}
+	case "tvdb":
+		return simklIDs{TVDB: parseInt(value)}
+	case "simkl":
+		return simklIDs{Simkl: parseInt(value)}
+	default:
+		return simklIDs{}
 	}
 }
 

--- a/internal/watchsync/providers/simkl/provider_test.go
+++ b/internal/watchsync/providers/simkl/provider_test.go
@@ -30,6 +30,9 @@ func TestProviderIdentityAndCapabilities(t *testing.T) {
 		ImportProgress:   true,
 		ExportWatched:    true,
 		ExportUnwatched:  true,
+		ImportWatchlist:  true,
+		ExportWatchlist:  true,
+		RemoveWatchlist:  true,
 		ScrobblePlayback: true,
 	}) {
 		t.Fatalf("capabilities = %#v", provider.Capabilities())

--- a/internal/watchsync/providers/trakt/provider.go
+++ b/internal/watchsync/providers/trakt/provider.go
@@ -55,6 +55,9 @@ func (p *Provider) Capabilities() watchsync.Capabilities {
 		ImportFavorites:  true,
 		ExportFavorites:  true,
 		RemoveFavorites:  true,
+		ImportWatchlist:  true,
+		ExportWatchlist:  true,
+		RemoveWatchlist:  true,
 		ScrobblePlayback: true,
 	}
 }
@@ -317,6 +320,30 @@ func (p *Provider) FetchFavorites(
 	if err := p.do(ctx, http.MethodGet, "/users/me/favorites/shows/added", cfg, conn.AccessToken, nil, &shows); err != nil {
 		return nil, err
 	}
+	return p.remoteListItems(movies, shows), nil
+}
+
+// FetchWatchlist pulls Trakt's watchlist — a distinct list from favorites. The
+// watchlist endpoints return the same item shape, so the mapping is shared.
+func (p *Provider) FetchWatchlist(
+	ctx context.Context,
+	cfg watchsync.ServerConfig,
+	conn watchsync.Connection,
+) ([]watchsync.RemoteFavorite, error) {
+	var movies []traktFavoriteMovie
+	if err := p.do(ctx, http.MethodGet, "/sync/watchlist/movies", cfg, conn.AccessToken, nil, &movies); err != nil {
+		return nil, err
+	}
+	var shows []traktFavoriteShow
+	if err := p.do(ctx, http.MethodGet, "/sync/watchlist/shows", cfg, conn.AccessToken, nil, &shows); err != nil {
+		return nil, err
+	}
+	return p.remoteListItems(movies, shows), nil
+}
+
+// remoteListItems maps Trakt movie/show list rows (favorites or watchlist) into
+// the kind-neutral RemoteFavorite carrier.
+func (p *Provider) remoteListItems(movies []traktFavoriteMovie, shows []traktFavoriteShow) []watchsync.RemoteFavorite {
 	rows := make([]watchsync.RemoteFavorite, 0, len(movies)+len(shows))
 	for _, item := range movies {
 		rows = append(rows, watchsync.RemoteFavorite{
@@ -344,7 +371,7 @@ func (p *Provider) FetchFavorites(
 			FavoritedAt:     item.ListedAt,
 		})
 	}
-	return rows, nil
+	return rows
 }
 
 func (p *Provider) FetchHistory(
@@ -453,6 +480,48 @@ func (p *Provider) RemoveFavorites(
 		return watchsync.ExportResult{}, err
 	}
 	return favoriteExportResult(favorites, response.NotFound), nil
+}
+
+// Trakt's watchlist accepts and returns the same {movies, shows} id payload as
+// favorites, so the payload builder and not-found parser are shared.
+func (p *Provider) ExportWatchlist(
+	ctx context.Context,
+	cfg watchsync.ServerConfig,
+	conn watchsync.Connection,
+	items []watchsync.LocalFavorite,
+) (watchsync.ExportResult, error) {
+	return p.sendWatchlist(ctx, "/sync/watchlist", cfg, conn, items)
+}
+
+func (p *Provider) RemoveWatchlist(
+	ctx context.Context,
+	cfg watchsync.ServerConfig,
+	conn watchsync.Connection,
+	items []watchsync.LocalFavorite,
+) (watchsync.ExportResult, error) {
+	return p.sendWatchlist(ctx, "/sync/watchlist/remove", cfg, conn, items)
+}
+
+func (p *Provider) sendWatchlist(
+	ctx context.Context,
+	path string,
+	cfg watchsync.ServerConfig,
+	conn watchsync.Connection,
+	items []watchsync.LocalFavorite,
+) (watchsync.ExportResult, error) {
+	payload := buildFavoritesPayload(items)
+	if len(payload.Movies) == 0 && len(payload.Shows) == 0 {
+		return watchsync.ExportResult{}, nil
+	}
+	var body bytes.Buffer
+	if err := json.NewEncoder(&body).Encode(payload); err != nil {
+		return watchsync.ExportResult{}, fmt.Errorf("encode trakt watchlist payload: %w", err)
+	}
+	var response traktFavoritesResponse
+	if err := p.do(ctx, http.MethodPost, path, cfg, conn.AccessToken, &body, &response); err != nil {
+		return watchsync.ExportResult{}, err
+	}
+	return favoriteExportResult(items, response.NotFound), nil
 }
 
 func (p *Provider) RemoveHistory(

--- a/internal/watchsync/providers/trakt/provider_test.go
+++ b/internal/watchsync/providers/trakt/provider_test.go
@@ -29,6 +29,9 @@ func TestProviderIdentityAndCapabilities(t *testing.T) {
 		ImportFavorites:  true,
 		ExportFavorites:  true,
 		RemoveFavorites:  true,
+		ImportWatchlist:  true,
+		ExportWatchlist:  true,
+		RemoveWatchlist:  true,
 		ScrobblePlayback: true,
 	}) {
 		t.Fatalf("unexpected capabilities: %#v", provider.Capabilities())

--- a/internal/watchsync/repository.go
+++ b/internal/watchsync/repository.go
@@ -29,23 +29,57 @@ type Repository interface {
 	GetActiveSyncRun(ctx context.Context, connectionID string) (SyncRun, bool, error)
 	ListSyncRuns(ctx context.Context, connectionID string, limit int) ([]SyncRun, error)
 	ListLocalWatchEventConnections(ctx context.Context, userID int, profileID string, kind LocalWatchEventKind) ([]Connection, error)
-	ListFavoriteEventConnections(ctx context.Context, userID int, profileID string, kind LocalFavoriteEventKind) ([]Connection, error)
+	ListListEventConnections(ctx context.Context, userID int, profileID string, list ListKind) ([]Connection, error)
 	UpsertHistoryExports(ctx context.Context, exports []HistoryExport) error
 	ListPendingHistoryExports(ctx context.Context, connectionID string, limit int) ([]HistoryExport, error)
 	MarkHistoryExportStatus(ctx context.Context, id string, status string, lastError string) error
-	UpsertFavoriteStates(ctx context.Context, states []FavoriteState) error
-	ListFavoriteStates(ctx context.Context, connectionID string) ([]FavoriteState, error)
-	ListPendingFavoriteExports(ctx context.Context, connectionID string, limit int) ([]FavoriteState, error)
-	ListPendingFavoriteRemovals(ctx context.Context, connectionID string, limit int) ([]FavoriteState, error)
-	MarkFavoriteExported(ctx context.Context, connectionID, mediaItemID string, exportedAt time.Time) error
-	MarkFavoriteRemoteRemoved(ctx context.Context, connectionID, mediaItemID string, removedAt time.Time) error
-	MarkFavoriteLocalRemoved(ctx context.Context, connectionID, mediaItemID string, removedAt time.Time) error
-	MarkFavoriteError(ctx context.Context, connectionID, mediaItemID, lastError string) error
+	UpsertListItemStates(ctx context.Context, states []ListItemState) error
+	ListListItemStates(ctx context.Context, connectionID string, kind ListKind) ([]ListItemState, error)
+	ListPendingListItemExports(ctx context.Context, connectionID string, kind ListKind, limit int) ([]ListItemState, error)
+	ListPendingListItemRemovals(ctx context.Context, connectionID string, kind ListKind, limit int) ([]ListItemState, error)
+	MarkListItemExported(ctx context.Context, connectionID string, kind ListKind, mediaItemID string, exportedAt time.Time) error
+	MarkListItemRemoteRemoved(ctx context.Context, connectionID string, kind ListKind, mediaItemID string, removedAt time.Time) error
+	MarkListItemLocalRemoved(ctx context.Context, connectionID string, kind ListKind, mediaItemID string, removedAt time.Time) error
+	MarkListItemError(ctx context.Context, connectionID string, kind ListKind, mediaItemID, lastError string) error
 	ListScrobbleConnections(ctx context.Context, userID int, profileID string) ([]Connection, error)
 	UpsertScrobbleSession(ctx context.Context, event ScrobbleEvent, connectionID string, action string) error
 	UpdateScrobbleSession(ctx context.Context, playbackSessionID string, connectionID string, action string, progress float64, historyID string, lastError string, stopSentAt *time.Time) error
 	ListOpenScrobbleSessions(ctx context.Context) ([]ScrobbleSession, error)
 }
+
+// connectionColumns is the canonical select/returning column list for
+// watch_provider_connections, in the exact order scanConnection reads. Sharing
+// it across every read query keeps the column set and scan order in lockstep.
+const connectionColumns = `
+	id::text, provider, user_id, profile_id, provider_account_id, provider_username,
+	access_token, refresh_token, token_expires_at, import_watched_enabled,
+	import_progress_enabled, export_watched_enabled, export_unwatched_enabled,
+	import_favorites_enabled, export_favorites_enabled, sync_favorite_removals_enabled,
+	import_watchlist_enabled, export_watchlist_enabled, sync_watchlist_removals_enabled,
+	sync_watchlist_order_enabled, scrobble_enabled, last_inbound_sync_at,
+	last_progress_sync_at, last_outbound_sync_at, last_favorites_sync_at,
+	last_watchlist_sync_at, last_scrobble_error_at, last_error,
+	sync_cursors, created_at, updated_at`
+
+// syncRunColumns is the canonical select/returning column list for
+// watch_provider_sync_runs, in the exact order scanSyncRun reads.
+const syncRunColumns = `
+	id::text, connection_id::text, trigger, status, provider,
+	inbound_watched_found, inbound_watched_imported,
+	inbound_progress_found, inbound_progress_imported,
+	outbound_found, outbound_sent, inbound_favorites_found,
+	inbound_favorites_imported, outbound_favorites_found,
+	outbound_favorites_sent, favorite_removals_sent,
+	inbound_watchlist_found, inbound_watchlist_imported,
+	outbound_watchlist_found, outbound_watchlist_sent, watchlist_removals_sent,
+	warning, error, started_at, completed_at, created_at`
+
+// listItemStateColumns is the canonical select column list for
+// watch_provider_list_items, in the exact order scanListItemStates reads.
+const listItemStateColumns = `
+	id::text, connection_id::text, list_kind, media_item_id, provider_item_key, kind, title, year,
+	remote_present, local_present, last_seen_remote_at, last_seen_local_at,
+	last_exported_at, last_removed_remote_at, last_removed_local_at, last_error, created_at, updated_at`
 
 type PostgresRepository struct {
 	pool   *pgxpool.Pool
@@ -161,13 +195,15 @@ func (r *PostgresRepository) UpsertConnection(ctx context.Context, conn Connecti
 			access_token, refresh_token, token_expires_at, import_watched_enabled,
 			import_progress_enabled, export_watched_enabled, export_unwatched_enabled,
 			import_favorites_enabled, export_favorites_enabled, sync_favorite_removals_enabled,
-			scrobble_enabled, last_inbound_sync_at, last_progress_sync_at, last_outbound_sync_at,
-			last_favorites_sync_at, last_scrobble_error_at, last_error, sync_cursors
+			import_watchlist_enabled, export_watchlist_enabled, sync_watchlist_removals_enabled,
+			sync_watchlist_order_enabled, scrobble_enabled, last_inbound_sync_at, last_progress_sync_at,
+			last_outbound_sync_at, last_favorites_sync_at, last_watchlist_sync_at, last_scrobble_error_at,
+			last_error, sync_cursors
 		)
 		VALUES (
 			COALESCE(NULLIF($1, '')::uuid, gen_random_uuid()),
 			$2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13,
-			$14, $15, $16, $17, $18, $19, $20, $21, $22, $23, $24::jsonb
+			$14, $15, $16, $17, $18, $19, $20, $21, $22, $23, $24, $25, $26, $27, $28, $29::jsonb
 		)
 		ON CONFLICT (provider, user_id, profile_id) DO UPDATE SET
 			provider_account_id = EXCLUDED.provider_account_id,
@@ -182,22 +218,21 @@ func (r *PostgresRepository) UpsertConnection(ctx context.Context, conn Connecti
 			import_favorites_enabled = EXCLUDED.import_favorites_enabled,
 			export_favorites_enabled = EXCLUDED.export_favorites_enabled,
 			sync_favorite_removals_enabled = EXCLUDED.sync_favorite_removals_enabled,
+			import_watchlist_enabled = EXCLUDED.import_watchlist_enabled,
+			export_watchlist_enabled = EXCLUDED.export_watchlist_enabled,
+			sync_watchlist_removals_enabled = EXCLUDED.sync_watchlist_removals_enabled,
+			sync_watchlist_order_enabled = EXCLUDED.sync_watchlist_order_enabled,
 			scrobble_enabled = EXCLUDED.scrobble_enabled,
 			last_inbound_sync_at = EXCLUDED.last_inbound_sync_at,
 			last_progress_sync_at = EXCLUDED.last_progress_sync_at,
 			last_outbound_sync_at = EXCLUDED.last_outbound_sync_at,
 			last_favorites_sync_at = EXCLUDED.last_favorites_sync_at,
+			last_watchlist_sync_at = EXCLUDED.last_watchlist_sync_at,
 			last_scrobble_error_at = EXCLUDED.last_scrobble_error_at,
 			last_error = EXCLUDED.last_error,
 			sync_cursors = EXCLUDED.sync_cursors,
 			updated_at = now()
-		RETURNING
-			id::text, provider, user_id, profile_id, provider_account_id, provider_username,
-			access_token, refresh_token, token_expires_at, import_watched_enabled,
-			import_progress_enabled, export_watched_enabled, export_unwatched_enabled,
-			import_favorites_enabled, export_favorites_enabled, sync_favorite_removals_enabled,
-			scrobble_enabled, last_inbound_sync_at, last_progress_sync_at, last_outbound_sync_at,
-			last_favorites_sync_at, last_scrobble_error_at, last_error, sync_cursors, created_at, updated_at
+		RETURNING `+connectionColumns+`
 	`,
 		conn.ID,
 		conn.Provider,
@@ -215,11 +250,16 @@ func (r *PostgresRepository) UpsertConnection(ctx context.Context, conn Connecti
 		conn.ImportFavoritesEnabled,
 		conn.ExportFavoritesEnabled,
 		conn.SyncFavoriteRemovalsEnabled,
+		conn.ImportWatchlistEnabled,
+		conn.ExportWatchlistEnabled,
+		conn.SyncWatchlistRemovalsEnabled,
+		conn.SyncWatchlistOrderEnabled,
 		conn.ScrobbleEnabled,
 		conn.LastInboundSyncAt,
 		conn.LastProgressSyncAt,
 		conn.LastOutboundSyncAt,
 		conn.LastFavoritesSyncAt,
+		conn.LastWatchlistSyncAt,
 		conn.LastScrobbleErrorAt,
 		conn.LastError,
 		encodeSyncCursors(conn.SyncCursors),
@@ -238,13 +278,7 @@ func (r *PostgresRepository) GetConnection(
 	profileID string,
 ) (Connection, bool, error) {
 	row := r.pool.QueryRow(ctx, `
-		SELECT
-			id::text, provider, user_id, profile_id, provider_account_id, provider_username,
-			access_token, refresh_token, token_expires_at, import_watched_enabled,
-			import_progress_enabled, export_watched_enabled, export_unwatched_enabled,
-			import_favorites_enabled, export_favorites_enabled, sync_favorite_removals_enabled,
-			scrobble_enabled, last_inbound_sync_at, last_progress_sync_at, last_outbound_sync_at,
-			last_favorites_sync_at, last_scrobble_error_at, last_error, sync_cursors, created_at, updated_at
+		SELECT `+connectionColumns+`
 		FROM watch_provider_connections
 		WHERE provider = $1 AND user_id = $2 AND profile_id = $3
 	`, provider, userID, profileID)
@@ -260,13 +294,7 @@ func (r *PostgresRepository) GetConnection(
 
 func (r *PostgresRepository) GetConnectionByID(ctx context.Context, id string) (Connection, bool, error) {
 	row := r.pool.QueryRow(ctx, `
-		SELECT
-			id::text, provider, user_id, profile_id, provider_account_id, provider_username,
-			access_token, refresh_token, token_expires_at, import_watched_enabled,
-			import_progress_enabled, export_watched_enabled, export_unwatched_enabled,
-			import_favorites_enabled, export_favorites_enabled, sync_favorite_removals_enabled,
-			scrobble_enabled, last_inbound_sync_at, last_progress_sync_at, last_outbound_sync_at,
-			last_favorites_sync_at, last_scrobble_error_at, last_error, sync_cursors, created_at, updated_at
+		SELECT `+connectionColumns+`
 		FROM watch_provider_connections
 		WHERE id = $1::uuid
 	`, id)
@@ -301,13 +329,7 @@ func (r *PostgresRepository) ListConnectionsDueForSync(
 	_ time.Time,
 ) ([]Connection, error) {
 	rows, err := r.pool.Query(ctx, `
-		SELECT
-			id::text, provider, user_id, profile_id, provider_account_id, provider_username,
-			access_token, refresh_token, token_expires_at, import_watched_enabled,
-			import_progress_enabled, export_watched_enabled, export_unwatched_enabled,
-			import_favorites_enabled, export_favorites_enabled, sync_favorite_removals_enabled,
-			scrobble_enabled, last_inbound_sync_at, last_progress_sync_at, last_outbound_sync_at,
-			last_favorites_sync_at, last_scrobble_error_at, last_error, sync_cursors, created_at, updated_at
+		SELECT `+connectionColumns+`
 		FROM watch_provider_connections
 		WHERE provider <> ''
 			AND (
@@ -318,6 +340,9 @@ func (r *PostgresRepository) ListConnectionsDueForSync(
 				OR import_favorites_enabled
 				OR export_favorites_enabled
 				OR sync_favorite_removals_enabled
+				OR import_watchlist_enabled
+				OR export_watchlist_enabled
+				OR sync_watchlist_removals_enabled
 				OR scrobble_enabled
 			)
 		ORDER BY provider, user_id, profile_id
@@ -356,26 +381,25 @@ func (r *PostgresRepository) CreateSyncRun(ctx context.Context, run SyncRun) (Sy
 			outbound_found, outbound_sent, inbound_favorites_found,
 			inbound_favorites_imported, outbound_favorites_found,
 			outbound_favorites_sent, favorite_removals_sent,
+			inbound_watchlist_found, inbound_watchlist_imported,
+			outbound_watchlist_found, outbound_watchlist_sent, watchlist_removals_sent,
 			warning, error, started_at, completed_at
 		)
 		VALUES (
 			$1::uuid, $2, $3, $4,
-			$5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17, $18, $19
+			$5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15,
+			$16, $17, $18, $19, $20, $21, $22, $23, $24
 		)
-		RETURNING id::text, connection_id::text, trigger, status, provider,
-			inbound_watched_found, inbound_watched_imported,
-			inbound_progress_found, inbound_progress_imported,
-			outbound_found, outbound_sent, inbound_favorites_found,
-			inbound_favorites_imported, outbound_favorites_found,
-			outbound_favorites_sent, favorite_removals_sent,
-			warning, error, started_at, completed_at, created_at
+		RETURNING `+syncRunColumns+`
 	`, run.ConnectionID, run.Trigger, run.Status, run.Provider,
 		run.InboundWatchedFound, run.InboundWatchedImported,
 		run.InboundProgressFound, run.InboundProgressImported,
 		run.OutboundFound, run.OutboundSent, run.InboundFavoritesFound,
 		run.InboundFavoritesImported, run.OutboundFavoritesFound,
-		run.OutboundFavoritesSent, run.FavoriteRemovalsSent, run.Warning, run.Error,
-		run.StartedAt, run.CompletedAt)
+		run.OutboundFavoritesSent, run.FavoriteRemovalsSent,
+		run.InboundWatchlistFound, run.InboundWatchlistImported,
+		run.OutboundWatchlistFound, run.OutboundWatchlistSent, run.WatchlistRemovalsSent,
+		run.Warning, run.Error, run.StartedAt, run.CompletedAt)
 	created, err := scanSyncRun(row)
 	if err != nil {
 		return SyncRun{}, fmt.Errorf("scan created watch provider sync run: %w", err)
@@ -398,21 +422,23 @@ func (r *PostgresRepository) CompleteSyncRun(ctx context.Context, run SyncRun) (
 			outbound_favorites_found = $11,
 			outbound_favorites_sent = $12,
 			favorite_removals_sent = $13,
-			warning = $14,
-			error = $15,
-			completed_at = $16
+			inbound_watchlist_found = $14,
+			inbound_watchlist_imported = $15,
+			outbound_watchlist_found = $16,
+			outbound_watchlist_sent = $17,
+			watchlist_removals_sent = $18,
+			warning = $19,
+			error = $20,
+			completed_at = $21
 		WHERE id = $1::uuid
-		RETURNING id::text, connection_id::text, trigger, status, provider,
-			inbound_watched_found, inbound_watched_imported,
-			inbound_progress_found, inbound_progress_imported,
-			outbound_found, outbound_sent, inbound_favorites_found,
-			inbound_favorites_imported, outbound_favorites_found,
-			outbound_favorites_sent, favorite_removals_sent,
-			warning, error, started_at, completed_at, created_at
+		RETURNING `+syncRunColumns+`
 	`, run.ID, run.Status, run.InboundWatchedFound, run.InboundWatchedImported,
 		run.InboundProgressFound, run.InboundProgressImported, run.OutboundFound, run.OutboundSent,
 		run.InboundFavoritesFound, run.InboundFavoritesImported, run.OutboundFavoritesFound,
-		run.OutboundFavoritesSent, run.FavoriteRemovalsSent, run.Warning, run.Error, run.CompletedAt)
+		run.OutboundFavoritesSent, run.FavoriteRemovalsSent,
+		run.InboundWatchlistFound, run.InboundWatchlistImported, run.OutboundWatchlistFound,
+		run.OutboundWatchlistSent, run.WatchlistRemovalsSent,
+		run.Warning, run.Error, run.CompletedAt)
 	completed, err := scanSyncRun(row)
 	if err != nil {
 		return SyncRun{}, fmt.Errorf("complete watch provider sync run: %w", err)
@@ -422,13 +448,7 @@ func (r *PostgresRepository) CompleteSyncRun(ctx context.Context, run SyncRun) (
 
 func (r *PostgresRepository) GetLatestSyncRun(ctx context.Context, connectionID string) (SyncRun, bool, error) {
 	row := r.pool.QueryRow(ctx, `
-		SELECT id::text, connection_id::text, trigger, status, provider,
-			inbound_watched_found, inbound_watched_imported,
-			inbound_progress_found, inbound_progress_imported,
-			outbound_found, outbound_sent, inbound_favorites_found,
-			inbound_favorites_imported, outbound_favorites_found,
-			outbound_favorites_sent, favorite_removals_sent,
-			warning, error, started_at, completed_at, created_at
+		SELECT `+syncRunColumns+`
 		FROM watch_provider_sync_runs
 		WHERE connection_id = $1::uuid
 		ORDER BY started_at DESC, created_at DESC
@@ -446,13 +466,7 @@ func (r *PostgresRepository) GetLatestSyncRun(ctx context.Context, connectionID 
 
 func (r *PostgresRepository) GetActiveSyncRun(ctx context.Context, connectionID string) (SyncRun, bool, error) {
 	row := r.pool.QueryRow(ctx, `
-		SELECT id::text, connection_id::text, trigger, status, provider,
-			inbound_watched_found, inbound_watched_imported,
-			inbound_progress_found, inbound_progress_imported,
-			outbound_found, outbound_sent, inbound_favorites_found,
-			inbound_favorites_imported, outbound_favorites_found,
-			outbound_favorites_sent, favorite_removals_sent,
-			warning, error, started_at, completed_at, created_at
+		SELECT `+syncRunColumns+`
 		FROM watch_provider_sync_runs
 		WHERE connection_id = $1::uuid
 		  AND status IN ('queued', 'running')
@@ -474,13 +488,7 @@ func (r *PostgresRepository) ListSyncRuns(ctx context.Context, connectionID stri
 		limit = 10
 	}
 	rows, err := r.pool.Query(ctx, `
-		SELECT id::text, connection_id::text, trigger, status, provider,
-			inbound_watched_found, inbound_watched_imported,
-			inbound_progress_found, inbound_progress_imported,
-			outbound_found, outbound_sent, inbound_favorites_found,
-			inbound_favorites_imported, outbound_favorites_found,
-			outbound_favorites_sent, favorite_removals_sent,
-			warning, error, started_at, completed_at, created_at
+		SELECT `+syncRunColumns+`
 		FROM watch_provider_sync_runs
 		WHERE connection_id = $1::uuid
 		ORDER BY started_at DESC, created_at DESC
@@ -520,13 +528,7 @@ func (r *PostgresRepository) ListLocalWatchEventConnections(
 		return nil, nil
 	}
 	rows, err := r.pool.Query(ctx, `
-		SELECT
-			id::text, provider, user_id, profile_id, provider_account_id, provider_username,
-			access_token, refresh_token, token_expires_at, import_watched_enabled,
-			import_progress_enabled, export_watched_enabled, export_unwatched_enabled,
-			import_favorites_enabled, export_favorites_enabled, sync_favorite_removals_enabled,
-			scrobble_enabled, last_inbound_sync_at, last_progress_sync_at, last_outbound_sync_at,
-			last_favorites_sync_at, last_scrobble_error_at, last_error, sync_cursors, created_at, updated_at
+		SELECT `+connectionColumns+`
 		FROM watch_provider_connections
 		WHERE user_id = $1 AND profile_id = $2 AND `+predicate+`
 		ORDER BY provider
@@ -550,35 +552,26 @@ func (r *PostgresRepository) ListLocalWatchEventConnections(
 	return conns, nil
 }
 
-func (r *PostgresRepository) ListFavoriteEventConnections(
+// ListListEventConnections returns connections that export the given list kind,
+// i.e. should mirror a local add/remove on that list to the provider.
+func (r *PostgresRepository) ListListEventConnections(
 	ctx context.Context,
 	userID int,
 	profileID string,
-	kind LocalFavoriteEventKind,
+	list ListKind,
 ) ([]Connection, error) {
-	var predicate string
-	switch kind {
-	case LocalFavoriteEventAdded:
-		predicate = "export_favorites_enabled = true"
-	case LocalFavoriteEventRemoved:
-		predicate = "export_favorites_enabled = true"
-	default:
-		return nil, nil
+	column := "export_favorites_enabled"
+	if list == ListKindWatchlist {
+		column = "export_watchlist_enabled"
 	}
 	rows, err := r.pool.Query(ctx, `
-		SELECT
-			id::text, provider, user_id, profile_id, provider_account_id, provider_username,
-			access_token, refresh_token, token_expires_at, import_watched_enabled,
-			import_progress_enabled, export_watched_enabled, export_unwatched_enabled,
-			import_favorites_enabled, export_favorites_enabled, sync_favorite_removals_enabled,
-			scrobble_enabled, last_inbound_sync_at, last_progress_sync_at, last_outbound_sync_at,
-			last_favorites_sync_at, last_scrobble_error_at, last_error, sync_cursors, created_at, updated_at
+		SELECT `+connectionColumns+`
 		FROM watch_provider_connections
-		WHERE user_id = $1 AND profile_id = $2 AND `+predicate+`
+		WHERE user_id = $1 AND profile_id = $2 AND `+column+` = true
 		ORDER BY provider
 	`, userID, profileID)
 	if err != nil {
-		return nil, fmt.Errorf("list favorite event connections: %w", err)
+		return nil, fmt.Errorf("list %s event connections: %w", list, err)
 	}
 	defer rows.Close()
 
@@ -586,12 +579,12 @@ func (r *PostgresRepository) ListFavoriteEventConnections(
 	for rows.Next() {
 		conn, scanErr := r.scanConnection(rows)
 		if scanErr != nil {
-			return nil, fmt.Errorf("scan favorite event connection: %w", scanErr)
+			return nil, fmt.Errorf("scan %s event connection: %w", list, scanErr)
 		}
 		conns = append(conns, conn)
 	}
 	if err := rows.Err(); err != nil {
-		return nil, fmt.Errorf("iterate favorite event connections: %w", err)
+		return nil, fmt.Errorf("iterate %s event connections: %w", list, err)
 	}
 	return conns, nil
 }
@@ -605,7 +598,7 @@ func (r *PostgresRepository) GetMediaDuration(ctx context.Context, mediaItemID s
 	return duration, nil
 }
 
-func (r *PostgresRepository) GetFavoriteMediaItems(ctx context.Context, mediaItemIDs []string) (map[string]LocalFavorite, error) {
+func (r *PostgresRepository) GetListMediaItems(ctx context.Context, mediaItemIDs []string) (map[string]LocalFavorite, error) {
 	result := make(map[string]LocalFavorite, len(mediaItemIDs))
 	if len(mediaItemIDs) == 0 {
 		return result, nil
@@ -616,19 +609,19 @@ func (r *PostgresRepository) GetFavoriteMediaItems(ctx context.Context, mediaIte
 		WHERE content_id = ANY($1)
 	`, mediaItemIDs)
 	if err != nil {
-		return nil, fmt.Errorf("get favorite media items: %w", err)
+		return nil, fmt.Errorf("get list media items: %w", err)
 	}
 	defer rows.Close()
 	for rows.Next() {
 		var fav LocalFavorite
 		if err := rows.Scan(&fav.MediaItemID, &fav.Kind, &fav.Title, &fav.Year, &fav.IMDbID, &fav.TMDBID, &fav.TVDBID); err != nil {
-			return nil, fmt.Errorf("scan favorite media item: %w", err)
+			return nil, fmt.Errorf("scan list media item: %w", err)
 		}
 		fav.ProviderItemKey = providerItemKeyForLocalFavorite(fav)
 		result[fav.MediaItemID] = fav
 	}
 	if err := rows.Err(); err != nil {
-		return nil, fmt.Errorf("iterate favorite media items: %w", err)
+		return nil, fmt.Errorf("iterate list media items: %w", err)
 	}
 	return result, nil
 }
@@ -724,163 +717,157 @@ func (r *PostgresRepository) MarkHistoryExportStatus(ctx context.Context, id str
 	return nil
 }
 
-func (r *PostgresRepository) UpsertFavoriteStates(ctx context.Context, states []FavoriteState) error {
+func (r *PostgresRepository) UpsertListItemStates(ctx context.Context, states []ListItemState) error {
 	for _, state := range states {
+		kind := state.ListKind
+		if kind == "" {
+			kind = ListKindFavorites
+		}
 		_, err := r.pool.Exec(ctx, `
-			INSERT INTO watch_provider_favorite_items (
-				connection_id, media_item_id, provider_item_key, kind, title, year,
+			INSERT INTO watch_provider_list_items (
+				connection_id, list_kind, media_item_id, provider_item_key, kind, title, year,
 				remote_present, local_present, last_seen_remote_at, last_seen_local_at,
 				last_exported_at, last_removed_remote_at, last_removed_local_at, last_error
 			)
-			VALUES ($1::uuid, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14)
-			ON CONFLICT (connection_id, media_item_id) DO UPDATE SET
+			VALUES ($1::uuid, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15)
+			ON CONFLICT (connection_id, list_kind, media_item_id) DO UPDATE SET
 				provider_item_key = CASE
 					WHEN EXCLUDED.provider_item_key <> '' THEN EXCLUDED.provider_item_key
-					ELSE watch_provider_favorite_items.provider_item_key
+					ELSE watch_provider_list_items.provider_item_key
 				END,
-				kind = CASE WHEN EXCLUDED.kind <> '' THEN EXCLUDED.kind ELSE watch_provider_favorite_items.kind END,
-				title = CASE WHEN EXCLUDED.title <> '' THEN EXCLUDED.title ELSE watch_provider_favorite_items.title END,
-				year = CASE WHEN EXCLUDED.year <> 0 THEN EXCLUDED.year ELSE watch_provider_favorite_items.year END,
-				remote_present = watch_provider_favorite_items.remote_present OR EXCLUDED.remote_present,
+				kind = CASE WHEN EXCLUDED.kind <> '' THEN EXCLUDED.kind ELSE watch_provider_list_items.kind END,
+				title = CASE WHEN EXCLUDED.title <> '' THEN EXCLUDED.title ELSE watch_provider_list_items.title END,
+				year = CASE WHEN EXCLUDED.year <> 0 THEN EXCLUDED.year ELSE watch_provider_list_items.year END,
+				remote_present = watch_provider_list_items.remote_present OR EXCLUDED.remote_present,
 				local_present = EXCLUDED.local_present,
-				last_seen_remote_at = COALESCE(EXCLUDED.last_seen_remote_at, watch_provider_favorite_items.last_seen_remote_at),
-				last_seen_local_at = COALESCE(EXCLUDED.last_seen_local_at, watch_provider_favorite_items.last_seen_local_at),
-				last_exported_at = COALESCE(EXCLUDED.last_exported_at, watch_provider_favorite_items.last_exported_at),
-				last_removed_remote_at = COALESCE(EXCLUDED.last_removed_remote_at, watch_provider_favorite_items.last_removed_remote_at),
-				last_removed_local_at = COALESCE(EXCLUDED.last_removed_local_at, watch_provider_favorite_items.last_removed_local_at),
+				last_seen_remote_at = COALESCE(EXCLUDED.last_seen_remote_at, watch_provider_list_items.last_seen_remote_at),
+				last_seen_local_at = COALESCE(EXCLUDED.last_seen_local_at, watch_provider_list_items.last_seen_local_at),
+				last_exported_at = COALESCE(EXCLUDED.last_exported_at, watch_provider_list_items.last_exported_at),
+				last_removed_remote_at = COALESCE(EXCLUDED.last_removed_remote_at, watch_provider_list_items.last_removed_remote_at),
+				last_removed_local_at = COALESCE(EXCLUDED.last_removed_local_at, watch_provider_list_items.last_removed_local_at),
 				last_error = EXCLUDED.last_error,
 				updated_at = now()
-		`, state.ConnectionID, state.MediaItemID, state.ProviderItemKey, state.Kind, state.Title, state.Year,
+		`, state.ConnectionID, string(kind), state.MediaItemID, state.ProviderItemKey, state.Kind, state.Title, state.Year,
 			state.RemotePresent, state.LocalPresent, state.LastSeenRemoteAt, state.LastSeenLocalAt,
 			state.LastExportedAt, state.LastRemovedRemoteAt, state.LastRemovedLocalAt, state.LastError)
 		if err != nil {
-			return fmt.Errorf("upsert favorite state: %w", err)
+			return fmt.Errorf("upsert list item state: %w", err)
 		}
 	}
 	return nil
 }
 
-func (r *PostgresRepository) ListFavoriteStates(ctx context.Context, connectionID string) ([]FavoriteState, error) {
+func (r *PostgresRepository) ListListItemStates(ctx context.Context, connectionID string, kind ListKind) ([]ListItemState, error) {
 	rows, err := r.pool.Query(ctx, `
-		SELECT id::text, connection_id::text, media_item_id, provider_item_key, kind, title, year,
-			remote_present, local_present, last_seen_remote_at, last_seen_local_at,
-			last_exported_at, last_removed_remote_at, last_removed_local_at, last_error, created_at, updated_at
-		FROM watch_provider_favorite_items
-		WHERE connection_id = $1::uuid
-	`, connectionID)
+		SELECT `+listItemStateColumns+`
+		FROM watch_provider_list_items
+		WHERE connection_id = $1::uuid AND list_kind = $2
+	`, connectionID, string(kind))
 	if err != nil {
-		return nil, fmt.Errorf("list favorite states: %w", err)
+		return nil, fmt.Errorf("list list item states: %w", err)
 	}
 	defer rows.Close()
-	return scanFavoriteStates(rows)
+	return scanListItemStates(rows)
 }
 
-func (r *PostgresRepository) ListPendingFavoriteExports(ctx context.Context, connectionID string, limit int) ([]FavoriteState, error) {
+func (r *PostgresRepository) ListPendingListItemExports(ctx context.Context, connectionID string, kind ListKind, limit int) ([]ListItemState, error) {
 	if limit <= 0 || limit > 100 {
 		limit = 100
 	}
 	rows, err := r.pool.Query(ctx, `
-		SELECT id::text, connection_id::text, media_item_id, provider_item_key, kind, title, year,
-			remote_present, local_present, last_seen_remote_at, last_seen_local_at,
-			last_exported_at, last_removed_remote_at, last_removed_local_at, last_error, created_at, updated_at
-		FROM watch_provider_favorite_items
+		SELECT `+listItemStateColumns+`
+		FROM watch_provider_list_items
 		WHERE connection_id = $1::uuid
+		  AND list_kind = $2
 		  AND local_present = true
 		  AND remote_present = false
 		  AND last_error = ''
 		ORDER BY last_seen_local_at ASC NULLS LAST, created_at ASC
-		LIMIT $2
-	`, connectionID, limit)
+		LIMIT $3
+	`, connectionID, string(kind), limit)
 	if err != nil {
-		return nil, fmt.Errorf("list pending favorite exports: %w", err)
+		return nil, fmt.Errorf("list pending list item exports: %w", err)
 	}
 	defer rows.Close()
-	return scanFavoriteStates(rows)
+	return scanListItemStates(rows)
 }
 
-func (r *PostgresRepository) ListPendingFavoriteRemovals(ctx context.Context, connectionID string, limit int) ([]FavoriteState, error) {
+func (r *PostgresRepository) ListPendingListItemRemovals(ctx context.Context, connectionID string, kind ListKind, limit int) ([]ListItemState, error) {
 	if limit <= 0 || limit > 100 {
 		limit = 100
 	}
 	rows, err := r.pool.Query(ctx, `
-		SELECT id::text, connection_id::text, media_item_id, provider_item_key, kind, title, year,
-			remote_present, local_present, last_seen_remote_at, last_seen_local_at,
-			last_exported_at, last_removed_remote_at, last_removed_local_at, last_error, created_at, updated_at
-		FROM watch_provider_favorite_items
+		SELECT `+listItemStateColumns+`
+		FROM watch_provider_list_items
 		WHERE connection_id = $1::uuid
+		  AND list_kind = $2
 		  AND local_present = false
 		  AND remote_present = true
 		  AND last_error = ''
 		ORDER BY last_removed_local_at ASC NULLS LAST, updated_at ASC
-		LIMIT $2
-	`, connectionID, limit)
+		LIMIT $3
+	`, connectionID, string(kind), limit)
 	if err != nil {
-		return nil, fmt.Errorf("list pending favorite removals: %w", err)
+		return nil, fmt.Errorf("list pending list item removals: %w", err)
 	}
 	defer rows.Close()
-	return scanFavoriteStates(rows)
+	return scanListItemStates(rows)
 }
 
-func (r *PostgresRepository) MarkFavoriteExported(ctx context.Context, connectionID, mediaItemID string, exportedAt time.Time) error {
-	return r.updateFavoriteState(ctx, connectionID, mediaItemID, `
+func (r *PostgresRepository) MarkListItemExported(ctx context.Context, connectionID string, kind ListKind, mediaItemID string, exportedAt time.Time) error {
+	return r.updateListItemState(ctx, connectionID, kind, mediaItemID, `
 		remote_present = true,
 		local_present = true,
-		last_exported_at = $3,
-		last_seen_remote_at = COALESCE(last_seen_remote_at, $3),
+		last_exported_at = $4,
+		last_seen_remote_at = COALESCE(last_seen_remote_at, $4),
 		last_error = ''
 	`, exportedAt)
 }
 
-func (r *PostgresRepository) MarkFavoriteRemoteRemoved(ctx context.Context, connectionID, mediaItemID string, removedAt time.Time) error {
-	return r.updateFavoriteState(ctx, connectionID, mediaItemID, `
+func (r *PostgresRepository) MarkListItemRemoteRemoved(ctx context.Context, connectionID string, kind ListKind, mediaItemID string, removedAt time.Time) error {
+	return r.updateListItemState(ctx, connectionID, kind, mediaItemID, `
 		remote_present = false,
-		last_removed_remote_at = $3,
+		last_removed_remote_at = $4,
 		last_error = ''
 	`, removedAt)
 }
 
-func (r *PostgresRepository) MarkFavoriteLocalRemoved(ctx context.Context, connectionID, mediaItemID string, removedAt time.Time) error {
-	return r.updateFavoriteState(ctx, connectionID, mediaItemID, `
+func (r *PostgresRepository) MarkListItemLocalRemoved(ctx context.Context, connectionID string, kind ListKind, mediaItemID string, removedAt time.Time) error {
+	return r.updateListItemState(ctx, connectionID, kind, mediaItemID, `
 		local_present = false,
-		last_removed_local_at = $3,
+		last_removed_local_at = $4,
 		last_error = ''
 	`, removedAt)
 }
 
-func (r *PostgresRepository) MarkFavoriteError(ctx context.Context, connectionID, mediaItemID, lastError string) error {
+func (r *PostgresRepository) MarkListItemError(ctx context.Context, connectionID string, kind ListKind, mediaItemID, lastError string) error {
 	_, err := r.pool.Exec(ctx, `
-		UPDATE watch_provider_favorite_items
-		SET last_error = $3, updated_at = now()
-		WHERE connection_id = $1::uuid AND media_item_id = $2
-	`, connectionID, mediaItemID, lastError)
+		UPDATE watch_provider_list_items
+		SET last_error = $4, updated_at = now()
+		WHERE connection_id = $1::uuid AND list_kind = $2 AND media_item_id = $3
+	`, connectionID, string(kind), mediaItemID, lastError)
 	if err != nil {
-		return fmt.Errorf("mark favorite error: %w", err)
+		return fmt.Errorf("mark list item error: %w", err)
 	}
 	return nil
 }
 
-func (r *PostgresRepository) updateFavoriteState(ctx context.Context, connectionID, mediaItemID, setClause string, at time.Time) error {
+func (r *PostgresRepository) updateListItemState(ctx context.Context, connectionID string, kind ListKind, mediaItemID, setClause string, at time.Time) error {
 	_, err := r.pool.Exec(ctx, `
-		UPDATE watch_provider_favorite_items
+		UPDATE watch_provider_list_items
 		SET `+setClause+`,
 			updated_at = now()
-		WHERE connection_id = $1::uuid AND media_item_id = $2
-	`, connectionID, mediaItemID, at)
+		WHERE connection_id = $1::uuid AND list_kind = $2 AND media_item_id = $3
+	`, connectionID, string(kind), mediaItemID, at)
 	if err != nil {
-		return fmt.Errorf("update favorite state: %w", err)
+		return fmt.Errorf("update list item state: %w", err)
 	}
 	return nil
 }
 
 func (r *PostgresRepository) ListScrobbleConnections(ctx context.Context, userID int, profileID string) ([]Connection, error) {
 	rows, err := r.pool.Query(ctx, `
-		SELECT
-			id::text, provider, user_id, profile_id, provider_account_id, provider_username,
-			access_token, refresh_token, token_expires_at, import_watched_enabled,
-			import_progress_enabled, export_watched_enabled, export_unwatched_enabled,
-			import_favorites_enabled, export_favorites_enabled, sync_favorite_removals_enabled,
-			scrobble_enabled, last_inbound_sync_at, last_progress_sync_at, last_outbound_sync_at,
-			last_favorites_sync_at, last_scrobble_error_at, last_error, sync_cursors, created_at, updated_at
+		SELECT `+connectionColumns+`
 		FROM watch_provider_connections
 		WHERE user_id = $1 AND profile_id = $2 AND scrobble_enabled = true
 		ORDER BY provider
@@ -1050,6 +1037,11 @@ func scanSyncRun(row pgx.Row) (SyncRun, error) {
 		&run.OutboundFavoritesFound,
 		&run.OutboundFavoritesSent,
 		&run.FavoriteRemovalsSent,
+		&run.InboundWatchlistFound,
+		&run.InboundWatchlistImported,
+		&run.OutboundWatchlistFound,
+		&run.OutboundWatchlistSent,
+		&run.WatchlistRemovalsSent,
 		&run.Warning,
 		&run.Error,
 		&run.StartedAt,
@@ -1082,11 +1074,16 @@ func (r *PostgresRepository) scanConnection(row pgx.Row) (Connection, error) {
 		&conn.ImportFavoritesEnabled,
 		&conn.ExportFavoritesEnabled,
 		&conn.SyncFavoriteRemovalsEnabled,
+		&conn.ImportWatchlistEnabled,
+		&conn.ExportWatchlistEnabled,
+		&conn.SyncWatchlistRemovalsEnabled,
+		&conn.SyncWatchlistOrderEnabled,
 		&conn.ScrobbleEnabled,
 		&conn.LastInboundSyncAt,
 		&conn.LastProgressSyncAt,
 		&conn.LastOutboundSyncAt,
 		&conn.LastFavoritesSyncAt,
+		&conn.LastWatchlistSyncAt,
 		&conn.LastScrobbleErrorAt,
 		&conn.LastError,
 		&rawSyncCursors,
@@ -1108,19 +1105,20 @@ func (r *PostgresRepository) scanConnection(row pgx.Row) (Connection, error) {
 	return conn, nil
 }
 
-type favoriteStateRows interface {
+type listItemStateRows interface {
 	Next() bool
 	Scan(dest ...any) error
 	Err() error
 }
 
-func scanFavoriteStates(rows favoriteStateRows) ([]FavoriteState, error) {
-	var states []FavoriteState
+func scanListItemStates(rows listItemStateRows) ([]ListItemState, error) {
+	var states []ListItemState
 	for rows.Next() {
-		var state FavoriteState
+		var state ListItemState
 		if err := rows.Scan(
 			&state.ID,
 			&state.ConnectionID,
+			&state.ListKind,
 			&state.MediaItemID,
 			&state.ProviderItemKey,
 			&state.Kind,
@@ -1137,12 +1135,12 @@ func scanFavoriteStates(rows favoriteStateRows) ([]FavoriteState, error) {
 			&state.CreatedAt,
 			&state.UpdatedAt,
 		); err != nil {
-			return nil, fmt.Errorf("scan favorite state: %w", err)
+			return nil, fmt.Errorf("scan list item state: %w", err)
 		}
 		states = append(states, state)
 	}
 	if err := rows.Err(); err != nil {
-		return nil, fmt.Errorf("iterate favorite states: %w", err)
+		return nil, fmt.Errorf("iterate list item states: %w", err)
 	}
 	return states, nil
 }

--- a/internal/watchsync/service.go
+++ b/internal/watchsync/service.go
@@ -98,20 +98,24 @@ func (s *Service) GetConnectionStatus(ctx context.Context, userID int, profileID
 	}
 	missingAccessToken := connected && strings.TrimSpace(conn.AccessToken) == ""
 	status := ConnectionStatus{
-		Provider:                    providerKey,
-		DisplayName:                 provider.DisplayName(),
-		Capabilities:                provider.Capabilities(),
-		AuthMethod:                  authMethod,
-		Connected:                   connected && !missingAccessToken,
-		CredentialsConfigured:       credentialsConfigured,
-		ImportWatchedEnabled:        true,
-		ImportProgressEnabled:       true,
-		ExportWatchedEnabled:        true,
-		ExportUnwatchedEnabled:      false,
-		ImportFavoritesEnabled:      true,
-		ExportFavoritesEnabled:      true,
-		SyncFavoriteRemovalsEnabled: false,
-		ScrobbleEnabled:             true,
+		Provider:                     providerKey,
+		DisplayName:                  provider.DisplayName(),
+		Capabilities:                 provider.Capabilities(),
+		AuthMethod:                   authMethod,
+		Connected:                    connected && !missingAccessToken,
+		CredentialsConfigured:        credentialsConfigured,
+		ImportWatchedEnabled:         true,
+		ImportProgressEnabled:        true,
+		ExportWatchedEnabled:         true,
+		ExportUnwatchedEnabled:       false,
+		ImportFavoritesEnabled:       true,
+		ExportFavoritesEnabled:       true,
+		SyncFavoriteRemovalsEnabled:  false,
+		ImportWatchlistEnabled:       true,
+		ExportWatchlistEnabled:       true,
+		SyncWatchlistRemovalsEnabled: false,
+		SyncWatchlistOrderEnabled:    false,
+		ScrobbleEnabled:              true,
 	}
 	if connected {
 		status.ProviderUsername = conn.ProviderUsername
@@ -122,11 +126,16 @@ func (s *Service) GetConnectionStatus(ctx context.Context, userID int, profileID
 		status.ImportFavoritesEnabled = conn.ImportFavoritesEnabled
 		status.ExportFavoritesEnabled = conn.ExportFavoritesEnabled
 		status.SyncFavoriteRemovalsEnabled = conn.SyncFavoriteRemovalsEnabled
+		status.ImportWatchlistEnabled = conn.ImportWatchlistEnabled
+		status.ExportWatchlistEnabled = conn.ExportWatchlistEnabled
+		status.SyncWatchlistRemovalsEnabled = conn.SyncWatchlistRemovalsEnabled
+		status.SyncWatchlistOrderEnabled = conn.SyncWatchlistOrderEnabled
 		status.ScrobbleEnabled = conn.ScrobbleEnabled
 		status.LastInboundSyncAt = conn.LastInboundSyncAt
 		status.LastProgressSyncAt = conn.LastProgressSyncAt
 		status.LastOutboundSyncAt = conn.LastOutboundSyncAt
 		status.LastFavoritesSyncAt = conn.LastFavoritesSyncAt
+		status.LastWatchlistSyncAt = conn.LastWatchlistSyncAt
 		status.LastScrobbleErrorAt = conn.LastScrobbleErrorAt
 		status.LastError = conn.LastError
 	}
@@ -165,13 +174,45 @@ func (s *Service) UpdateConnection(ctx context.Context, userID int, profileID st
 	if update.SyncFavoriteRemovalsEnabled != nil {
 		conn.SyncFavoriteRemovalsEnabled = *update.SyncFavoriteRemovalsEnabled
 	}
+	if update.ImportWatchlistEnabled != nil {
+		conn.ImportWatchlistEnabled = *update.ImportWatchlistEnabled
+	}
+	if update.ExportWatchlistEnabled != nil {
+		conn.ExportWatchlistEnabled = *update.ExportWatchlistEnabled
+	}
+	if update.SyncWatchlistRemovalsEnabled != nil {
+		conn.SyncWatchlistRemovalsEnabled = *update.SyncWatchlistRemovalsEnabled
+	}
+	watchlistOrderDisabled := false
+	if update.SyncWatchlistOrderEnabled != nil {
+		watchlistOrderDisabled = conn.SyncWatchlistOrderEnabled && !*update.SyncWatchlistOrderEnabled
+		conn.SyncWatchlistOrderEnabled = *update.SyncWatchlistOrderEnabled
+	}
 	if update.ScrobbleEnabled != nil {
 		conn.ScrobbleEnabled = *update.ScrobbleEnabled
 	}
 	if _, err := s.repo.UpsertConnection(ctx, conn); err != nil {
 		return ConnectionStatus{}, err
 	}
+	// Turning order mirroring off reverts the watchlist to added_at ordering.
+	if watchlistOrderDisabled {
+		s.clearWatchlistOrder(ctx, conn)
+	}
 	return s.GetConnectionStatus(ctx, userID, profileID, providerKey)
+}
+
+func (s *Service) clearWatchlistOrder(ctx context.Context, conn Connection) {
+	if s.storeProvider == nil {
+		return
+	}
+	store, err := s.storeProvider.ForUser(ctx, conn.UserID)
+	if err != nil {
+		slog.Warn("failed to open store to clear watchlist order", "provider", conn.Provider, "error", err)
+		return
+	}
+	if err := store.ReplaceWatchlistOrder(ctx, conn.ProfileID, nil); err != nil {
+		slog.Warn("failed to clear watchlist order", "provider", conn.Provider, "error", err)
+	}
 }
 
 func (s *Service) DeleteConnection(ctx context.Context, userID int, profileID string, providerKey string) error {
@@ -330,124 +371,6 @@ func (s *Service) processLocalWatchEvent(ctx context.Context, event LocalWatchEv
 		}
 	}
 	return nil
-}
-
-func (s *Service) HandleLocalFavoriteEvent(ctx context.Context, event LocalFavoriteEvent) error {
-	if event.UserID == 0 || event.ProfileID == "" || len(event.Favorites) == 0 {
-		return nil
-	}
-	go func() {
-		bg, cancel := context.WithTimeout(context.Background(), 2*time.Minute)
-		defer cancel()
-		if err := s.processLocalFavoriteEvent(bg, event); err != nil {
-			slog.Warn("failed to dispatch local favorite provider event", "kind", event.Kind, "user_id", event.UserID, "profile_id", event.ProfileID, "error", err)
-		}
-	}()
-	return nil
-}
-
-func (s *Service) processLocalFavoriteEvent(ctx context.Context, event LocalFavoriteEvent) error {
-	conns, err := s.repo.ListFavoriteEventConnections(ctx, event.UserID, event.ProfileID, event.Kind)
-	if err != nil {
-		return err
-	}
-	for _, conn := range conns {
-		provider, ok := s.registry.Get(conn.Provider)
-		if !ok {
-			continue
-		}
-		cfg, err := s.serverConfig(ctx, conn.Provider)
-		if err != nil {
-			s.recordLocalWatchEventError(ctx, conn, err)
-			continue
-		}
-		conn, err = s.refreshConnectionIfNeeded(ctx, provider, cfg, conn)
-		if err != nil {
-			s.recordLocalWatchEventError(ctx, conn, err)
-			continue
-		}
-		switch event.Kind {
-		case LocalFavoriteEventAdded:
-			exporter, ok := provider.(FavoriteExporter)
-			if !ok || !provider.Capabilities().ExportFavorites {
-				continue
-			}
-			if err := s.exportLocalFavorites(ctx, conn, cfg, exporter, event.Favorites); err != nil {
-				s.recordLocalWatchEventError(ctx, conn, err)
-			}
-		case LocalFavoriteEventRemoved:
-			now := s.now()
-			for _, favorite := range event.Favorites {
-				if err := s.repo.MarkFavoriteLocalRemoved(ctx, conn.ID, favorite.MediaItemID, now); err != nil {
-					return err
-				}
-			}
-			if !conn.SyncFavoriteRemovalsEnabled || !provider.Capabilities().RemoveFavorites {
-				continue
-			}
-			remover, ok := provider.(FavoriteRemover)
-			if !ok {
-				continue
-			}
-			if _, err := remover.RemoveFavorites(ctx, cfg, conn, event.Favorites); err != nil {
-				s.recordLocalWatchEventError(ctx, conn, err)
-				continue
-			}
-			for _, favorite := range event.Favorites {
-				if err := s.repo.MarkFavoriteRemoteRemoved(ctx, conn.ID, favorite.MediaItemID, now); err != nil {
-					return err
-				}
-			}
-		}
-	}
-	return nil
-}
-
-func (s *Service) exportLocalFavorites(ctx context.Context, conn Connection, cfg ServerConfig, exporter FavoriteExporter, favorites []LocalFavorite) error {
-	states := make([]FavoriteState, 0, len(favorites))
-	for _, favorite := range favorites {
-		if favorite.ProviderItemKey == "" {
-			favorite.ProviderItemKey = providerItemKeyForLocalFavorite(favorite)
-		}
-		if favorite.ProviderItemKey == "" {
-			continue
-		}
-		favoritedAt := favorite.FavoritedAt
-		if favoritedAt.IsZero() {
-			favoritedAt = s.now()
-		}
-		states = append(states, FavoriteState{
-			ConnectionID:    conn.ID,
-			MediaItemID:     favorite.MediaItemID,
-			ProviderItemKey: favorite.ProviderItemKey,
-			Kind:            favorite.Kind,
-			Title:           favorite.Title,
-			Year:            favorite.Year,
-			RemotePresent:   false,
-			LocalPresent:    true,
-			LastSeenLocalAt: &favoritedAt,
-		})
-	}
-	if err := s.repo.UpsertFavoriteStates(ctx, states); err != nil {
-		return err
-	}
-	result, err := exporter.ExportFavorites(ctx, cfg, conn, favorites)
-	if err != nil {
-		return err
-	}
-	now := s.now()
-	sent := exportResultSentSet(result)
-	for _, favorite := range favorites {
-		if sent[favorite.MediaItemID] || sent[favorite.ProviderItemKey] {
-			if err := s.repo.MarkFavoriteExported(ctx, conn.ID, favorite.MediaItemID, now); err != nil {
-				return err
-			}
-		}
-	}
-	conn.LastFavoritesSyncAt = &now
-	conn.LastError = ""
-	_, err = s.repo.UpsertConnection(ctx, conn)
-	return err
 }
 
 func (s *Service) recordLocalWatchEventError(ctx context.Context, conn Connection, err error) {
@@ -611,12 +534,17 @@ func (s *Service) persistConnection(
 		return Connection{}, err
 	}
 	if !ok {
+		// Enable every bidirectional sync by default; per-list removal stays
+		// opt-in. Toggles a provider can't serve are skipped at sync time via
+		// the capability check, so enabling them here is harmless.
 		conn = Connection{
 			ImportWatchedEnabled:   true,
 			ImportProgressEnabled:  true,
 			ExportWatchedEnabled:   true,
 			ImportFavoritesEnabled: true,
 			ExportFavoritesEnabled: true,
+			ImportWatchlistEnabled: true,
+			ExportWatchlistEnabled: true,
 			ScrobbleEnabled:        true,
 		}
 	}
@@ -778,24 +706,6 @@ func (s *Service) executeSyncRun(ctx context.Context, conn Connection, run SyncR
 			}
 		}
 	}
-	if conn.ImportFavoritesEnabled && provider.Capabilities().ImportFavorites {
-		importer, ok := provider.(FavoriteImporter)
-		if !ok {
-			flowErrors = append(flowErrors, fmt.Sprintf("provider %q does not implement favorites import", conn.Provider))
-		} else {
-			result, err := s.ImportFavorites(ctx, conn, cfg, importer)
-			run.InboundFavoritesFound = result.Found
-			run.InboundFavoritesImported = result.Imported
-			run.Warning = appendWarning(run.Warning, result.Warnings)
-			if err != nil {
-				flowErrors = append(flowErrors, "favorites import: "+err.Error())
-			} else if refreshed, refreshErr := s.reloadConnection(ctx, conn); refreshErr != nil {
-				flowErrors = append(flowErrors, "favorites import connection refresh: "+refreshErr.Error())
-			} else {
-				conn = refreshed
-			}
-		}
-	}
 	if conn.ExportWatchedEnabled && provider.Capabilities().ExportWatched {
 		exporter, ok := provider.(WatchedExporter)
 		if !ok {
@@ -813,33 +723,38 @@ func (s *Service) executeSyncRun(ctx context.Context, conn Connection, run SyncR
 			}
 		}
 	}
-	if conn.ExportFavoritesEnabled && provider.Capabilities().ExportFavorites {
-		exporter, ok := provider.(FavoriteExporter)
-		if !ok {
-			flowErrors = append(flowErrors, fmt.Sprintf("provider %q does not implement favorites export", conn.Provider))
-		} else {
-			result, err := s.ExportFavorites(ctx, conn, cfg, exporter)
-			run.OutboundFavoritesFound = result.LocalFound
-			run.OutboundFavoritesSent = result.Sent
+	// Favorites and watchlist share one pipeline, run per list kind.
+	for _, b := range s.listBindings() {
+		caps := provider.Capabilities()
+		if b.importEnabled(conn) && b.capImport(caps) {
+			result, err := s.importList(ctx, conn, cfg, provider, b)
+			b.setImportCounts(&run, result.Found, result.Imported)
 			run.Warning = appendWarning(run.Warning, result.Warnings)
 			if err != nil {
-				flowErrors = append(flowErrors, "favorites export: "+err.Error())
+				flowErrors = append(flowErrors, string(b.kind)+" import: "+err.Error())
 			} else if refreshed, refreshErr := s.reloadConnection(ctx, conn); refreshErr != nil {
-				flowErrors = append(flowErrors, "favorites export connection refresh: "+refreshErr.Error())
+				flowErrors = append(flowErrors, string(b.kind)+" import connection refresh: "+refreshErr.Error())
 			} else {
 				conn = refreshed
 			}
 		}
-	}
-	if conn.SyncFavoriteRemovalsEnabled && provider.Capabilities().RemoveFavorites {
-		remover, ok := provider.(FavoriteRemover)
-		if !ok {
-			flowErrors = append(flowErrors, fmt.Sprintf("provider %q does not implement favorites removal", conn.Provider))
-		} else {
-			removed, err := s.RemovePendingFavorites(ctx, conn, cfg, remover)
-			run.FavoriteRemovalsSent = removed
+		if b.exportEnabled(conn) && b.capExport(caps) {
+			result, err := s.exportList(ctx, conn, cfg, provider, b)
+			b.setExportCounts(&run, result.LocalFound, result.Sent)
+			run.Warning = appendWarning(run.Warning, result.Warnings)
 			if err != nil {
-				flowErrors = append(flowErrors, "favorites removal: "+err.Error())
+				flowErrors = append(flowErrors, string(b.kind)+" export: "+err.Error())
+			} else if refreshed, refreshErr := s.reloadConnection(ctx, conn); refreshErr != nil {
+				flowErrors = append(flowErrors, string(b.kind)+" export connection refresh: "+refreshErr.Error())
+			} else {
+				conn = refreshed
+			}
+		}
+		if b.removalsEnabled(conn) && b.capRemove(caps) {
+			removed, err := s.removePendingListItems(ctx, conn, cfg, provider, b)
+			b.setRemovalCount(&run, removed)
+			if err != nil {
+				flowErrors = append(flowErrors, string(b.kind)+" removal: "+err.Error())
 			}
 		}
 	}
@@ -879,6 +794,9 @@ func providerSyncNeedsAccessToken(caps Capabilities) bool {
 		caps.ImportFavorites ||
 		caps.ExportFavorites ||
 		caps.RemoveFavorites ||
+		caps.ImportWatchlist ||
+		caps.ExportWatchlist ||
+		caps.RemoveWatchlist ||
 		caps.ScrobblePlayback
 }
 
@@ -1154,133 +1072,6 @@ func fetchProgressImportBatch(
 	return ProgressImportBatch{Rows: rows}, nil
 }
 
-type ImportFavoritesResult struct {
-	Found     int
-	Imported  int
-	Unmatched int
-	Removed   int
-	Warnings  []string
-}
-
-func (s *Service) ImportFavorites(
-	ctx context.Context,
-	conn Connection,
-	cfg ServerConfig,
-	importer FavoriteImporter,
-) (ImportFavoritesResult, error) {
-	if s.matcher == nil {
-		return ImportFavoritesResult{}, fmt.Errorf("watch provider matcher is not configured")
-	}
-	if s.storeProvider == nil {
-		return ImportFavoritesResult{}, fmt.Errorf("user store provider is not configured")
-	}
-	store, err := s.storeProvider.ForUser(ctx, conn.UserID)
-	if err != nil {
-		return ImportFavoritesResult{}, fmt.Errorf("open user store: %w", err)
-	}
-	batch, err := fetchFavoriteImportBatch(ctx, cfg, conn, importer)
-	if err != nil {
-		return ImportFavoritesResult{}, err
-	}
-	rows := batch.Rows
-	result := ImportFavoritesResult{Found: len(rows), Warnings: append([]string{}, batch.Warnings...)}
-	seenRemoteKeys := make(map[string]bool, len(rows))
-	states := make([]FavoriteState, 0, len(rows))
-	for _, row := range rows {
-		match, reason, err := s.matcher.Match(ctx, row.HistoryRecord())
-		if err != nil {
-			return result, err
-		}
-		if match == nil {
-			result.Unmatched++
-			if reason != "" {
-				result.Warnings = append(result.Warnings, reason)
-			}
-			continue
-		}
-		if err := store.AddFavoriteAt(ctx, conn.ProfileID, match.MediaItemID, row.FavoritedAt); err != nil {
-			return result, err
-		}
-		result.Imported++
-		key := row.ProviderItemKey
-		if key == "" {
-			key = providerItemKeyForRemoteFavorite(row)
-		}
-		if key != "" {
-			seenRemoteKeys[key] = true
-		}
-		favoritedAt := row.FavoritedAt
-		states = append(states, FavoriteState{
-			ConnectionID:     conn.ID,
-			MediaItemID:      match.MediaItemID,
-			ProviderItemKey:  key,
-			Kind:             row.Kind,
-			Title:            row.Title,
-			Year:             row.Year,
-			RemotePresent:    true,
-			LocalPresent:     true,
-			LastSeenRemoteAt: &favoritedAt,
-			LastSeenLocalAt:  &favoritedAt,
-		})
-	}
-	if err := s.repo.UpsertFavoriteStates(ctx, states); err != nil {
-		return result, err
-	}
-	if err := s.reconcileMissingRemoteFavorites(ctx, conn, store, seenRemoteKeys, &result); err != nil {
-		return result, err
-	}
-	now := s.now()
-	conn.LastFavoritesSyncAt = &now
-	conn.LastError = ""
-	conn.SyncCursors = mergeSyncCursors(conn.SyncCursors, batch.UpdatedCursors)
-	if _, err := s.repo.UpsertConnection(ctx, conn); err != nil {
-		return result, err
-	}
-	return result, nil
-}
-
-func fetchFavoriteImportBatch(
-	ctx context.Context,
-	cfg ServerConfig,
-	conn Connection,
-	importer FavoriteImporter,
-) (FavoriteImportBatch, error) {
-	if batchImporter, ok := importer.(FavoriteBatchImporter); ok {
-		return batchImporter.FetchFavoritesBatch(ctx, cfg, conn)
-	}
-	rows, err := importer.FetchFavorites(ctx, cfg, conn)
-	if err != nil {
-		return FavoriteImportBatch{}, err
-	}
-	return FavoriteImportBatch{Rows: rows}, nil
-}
-
-func (s *Service) reconcileMissingRemoteFavorites(ctx context.Context, conn Connection, store userstore.UserStore, seenRemoteKeys map[string]bool, result *ImportFavoritesResult) error {
-	states, err := s.repo.ListFavoriteStates(ctx, conn.ID)
-	if err != nil {
-		return err
-	}
-	now := s.now()
-	for _, state := range states {
-		if !state.RemotePresent || state.ProviderItemKey == "" || seenRemoteKeys[state.ProviderItemKey] {
-			continue
-		}
-		if conn.SyncFavoriteRemovalsEnabled && state.LocalPresent {
-			if err := store.RemoveFavorite(ctx, conn.ProfileID, state.MediaItemID); err != nil {
-				return err
-			}
-			if err := s.repo.MarkFavoriteLocalRemoved(ctx, conn.ID, state.MediaItemID, now); err != nil {
-				return err
-			}
-			result.Removed++
-		}
-		if err := s.repo.MarkFavoriteRemoteRemoved(ctx, conn.ID, state.MediaItemID, now); err != nil {
-			return err
-		}
-	}
-	return nil
-}
-
 func mergeSyncCursors(existing map[string]string, updates map[string]string) map[string]string {
 	merged := make(map[string]string, len(existing)+len(updates))
 	for key, value := range existing {
@@ -1380,14 +1171,6 @@ type ExportWatchedResult struct {
 	RemotePresent int
 	Sent          int
 	Failed        int
-}
-
-type ExportFavoritesResult struct {
-	LocalFound int
-	Queued     int
-	Sent       int
-	Failed     int
-	Warnings   []string
 }
 
 func (s *Service) ExportWatched(
@@ -1520,193 +1303,6 @@ func (s *Service) ExportWatched(
 		return result, err
 	}
 	return result, nil
-}
-
-func (s *Service) ExportFavorites(
-	ctx context.Context,
-	conn Connection,
-	cfg ServerConfig,
-	exporter FavoriteExporter,
-) (ExportFavoritesResult, error) {
-	if s.storeProvider == nil {
-		return ExportFavoritesResult{}, fmt.Errorf("user store provider is not configured")
-	}
-	store, err := s.storeProvider.ForUser(ctx, conn.UserID)
-	if err != nil {
-		return ExportFavoritesResult{}, fmt.Errorf("open user store: %w", err)
-	}
-	rows, err := store.ListFavorites(ctx, conn.ProfileID, 10000, 0)
-	if err != nil {
-		return ExportFavoritesResult{}, err
-	}
-	result := ExportFavoritesResult{LocalFound: len(rows)}
-	favorites, states, warnings, err := s.localFavoritesFromRows(ctx, conn, rows)
-	if err != nil {
-		return result, err
-	}
-	result.Warnings = append(result.Warnings, warnings...)
-	if err := s.repo.UpsertFavoriteStates(ctx, states); err != nil {
-		return result, err
-	}
-	for {
-		pending, err := s.repo.ListPendingFavoriteExports(ctx, conn.ID, 100)
-		if err != nil {
-			return result, err
-		}
-		if len(pending) == 0 {
-			break
-		}
-		byMedia := make(map[string]LocalFavorite, len(favorites))
-		for _, favorite := range favorites {
-			byMedia[favorite.MediaItemID] = favorite
-		}
-		toSend := make([]LocalFavorite, 0, len(pending))
-		for _, state := range pending {
-			favorite, ok := byMedia[state.MediaItemID]
-			if !ok {
-				if err := s.repo.MarkFavoriteLocalRemoved(ctx, conn.ID, state.MediaItemID, s.now()); err != nil {
-					return result, err
-				}
-				continue
-			}
-			toSend = append(toSend, favorite)
-		}
-		if len(toSend) == 0 {
-			continue
-		}
-		result.Queued += len(toSend)
-		exportResult, err := exporter.ExportFavorites(ctx, cfg, conn, toSend)
-		if err != nil {
-			for _, favorite := range toSend {
-				_ = s.repo.MarkFavoriteError(ctx, conn.ID, favorite.MediaItemID, err.Error())
-			}
-			result.Failed += len(toSend)
-			return result, err
-		}
-		now := s.now()
-		sent := exportResultSentSet(exportResult)
-		for _, favorite := range toSend {
-			if sent[favorite.MediaItemID] || sent[favorite.ProviderItemKey] {
-				if err := s.repo.MarkFavoriteExported(ctx, conn.ID, favorite.MediaItemID, now); err != nil {
-					return result, err
-				}
-				result.Sent++
-				continue
-			}
-			if containsString(exportResult.NotFound, favorite.MediaItemID) || containsString(exportResult.NotFound, favorite.ProviderItemKey) {
-				msg := "favorite not found by provider"
-				if err := s.repo.MarkFavoriteError(ctx, conn.ID, favorite.MediaItemID, msg); err != nil {
-					return result, err
-				}
-				result.Warnings = append(result.Warnings, msg+": "+favorite.MediaItemID)
-			}
-		}
-	}
-	now := s.now()
-	conn.LastFavoritesSyncAt = &now
-	conn.LastError = ""
-	if _, err := s.repo.UpsertConnection(ctx, conn); err != nil {
-		return result, err
-	}
-	return result, nil
-}
-
-func (s *Service) RemovePendingFavorites(ctx context.Context, conn Connection, cfg ServerConfig, remover FavoriteRemover) (int, error) {
-	removed := 0
-	for {
-		pending, err := s.repo.ListPendingFavoriteRemovals(ctx, conn.ID, 100)
-		if err != nil {
-			return removed, err
-		}
-		if len(pending) == 0 {
-			return removed, nil
-		}
-		favorites := make([]LocalFavorite, 0, len(pending))
-		for _, state := range pending {
-			favorites = append(favorites, LocalFavorite{
-				MediaItemID:     state.MediaItemID,
-				ProviderItemKey: state.ProviderItemKey,
-				Kind:            state.Kind,
-				Title:           state.Title,
-				Year:            state.Year,
-			})
-		}
-		result, err := remover.RemoveFavorites(ctx, cfg, conn, favorites)
-		if err != nil {
-			for _, favorite := range favorites {
-				_ = s.repo.MarkFavoriteError(ctx, conn.ID, favorite.MediaItemID, err.Error())
-			}
-			return removed, err
-		}
-		now := s.now()
-		sent := exportResultSentSet(result)
-		for _, favorite := range favorites {
-			if sent[favorite.MediaItemID] || sent[favorite.ProviderItemKey] {
-				if err := s.repo.MarkFavoriteRemoteRemoved(ctx, conn.ID, favorite.MediaItemID, now); err != nil {
-					return removed, err
-				}
-				removed++
-			}
-		}
-	}
-}
-
-func (s *Service) localFavoritesFromRows(ctx context.Context, conn Connection, rows []userstore.Favorite) ([]LocalFavorite, []FavoriteState, []string, error) {
-	ids := make([]string, 0, len(rows))
-	addedAtByID := make(map[string]time.Time, len(rows))
-	for _, row := range rows {
-		ids = append(ids, row.MediaItemID)
-		if addedAt, err := time.Parse(time.RFC3339, row.AddedAt); err == nil {
-			addedAtByID[row.MediaItemID] = addedAt
-		}
-	}
-	type favoriteMediaResolver interface {
-		GetFavoriteMediaItems(ctx context.Context, mediaItemIDs []string) (map[string]LocalFavorite, error)
-	}
-	resolver, ok := s.repo.(favoriteMediaResolver)
-	if !ok {
-		return nil, nil, nil, fmt.Errorf("favorite media resolver is not configured")
-	}
-	items, err := resolver.GetFavoriteMediaItems(ctx, ids)
-	if err != nil {
-		return nil, nil, nil, err
-	}
-	favorites := make([]LocalFavorite, 0, len(rows))
-	states := make([]FavoriteState, 0, len(rows))
-	var warnings []string
-	for _, row := range rows {
-		favorite, ok := items[row.MediaItemID]
-		if !ok {
-			warnings = append(warnings, "favorite media item not found: "+row.MediaItemID)
-			continue
-		}
-		favorite.FavoritedAt = addedAtByID[row.MediaItemID]
-		if favorite.FavoritedAt.IsZero() {
-			favorite.FavoritedAt = s.now()
-		}
-		if favorite.Kind != historyimport.KindMovie && favorite.Kind != historyimport.KindSeries {
-			warnings = append(warnings, "favorite kind is not supported by provider: "+row.MediaItemID)
-			continue
-		}
-		if favorite.ProviderItemKey == "" {
-			warnings = append(warnings, "favorite has no provider ids: "+row.MediaItemID)
-			continue
-		}
-		favorites = append(favorites, favorite)
-		favoritedAt := favorite.FavoritedAt
-		states = append(states, FavoriteState{
-			ConnectionID:    conn.ID,
-			MediaItemID:     favorite.MediaItemID,
-			ProviderItemKey: favorite.ProviderItemKey,
-			Kind:            favorite.Kind,
-			Title:           favorite.Title,
-			Year:            favorite.Year,
-			RemotePresent:   false,
-			LocalPresent:    true,
-			LastSeenLocalAt: &favoritedAt,
-		})
-	}
-	return favorites, states, warnings, nil
 }
 
 func (s *Service) exportLocalPlays(

--- a/internal/watchsync/service.go
+++ b/internal/watchsync/service.go
@@ -191,28 +191,33 @@ func (s *Service) UpdateConnection(ctx context.Context, userID int, profileID st
 	if update.ScrobbleEnabled != nil {
 		conn.ScrobbleEnabled = *update.ScrobbleEnabled
 	}
+	// Turning order mirroring off reverts the watchlist to added_at ordering.
+	// Clear the stored order *before* persisting the disable so a failure leaves
+	// both the order and the toggle intact (retriable) rather than reporting
+	// "disabled" while sort_index ordering is still active.
+	if watchlistOrderDisabled {
+		if err := s.clearWatchlistOrder(ctx, conn); err != nil {
+			return ConnectionStatus{}, err
+		}
+	}
 	if _, err := s.repo.UpsertConnection(ctx, conn); err != nil {
 		return ConnectionStatus{}, err
-	}
-	// Turning order mirroring off reverts the watchlist to added_at ordering.
-	if watchlistOrderDisabled {
-		s.clearWatchlistOrder(ctx, conn)
 	}
 	return s.GetConnectionStatus(ctx, userID, profileID, providerKey)
 }
 
-func (s *Service) clearWatchlistOrder(ctx context.Context, conn Connection) {
+func (s *Service) clearWatchlistOrder(ctx context.Context, conn Connection) error {
 	if s.storeProvider == nil {
-		return
+		return nil
 	}
 	store, err := s.storeProvider.ForUser(ctx, conn.UserID)
 	if err != nil {
-		slog.Warn("failed to open store to clear watchlist order", "provider", conn.Provider, "error", err)
-		return
+		return fmt.Errorf("open user store to clear watchlist order: %w", err)
 	}
 	if err := store.ReplaceWatchlistOrder(ctx, conn.ProfileID, nil); err != nil {
-		slog.Warn("failed to clear watchlist order", "provider", conn.Provider, "error", err)
+		return fmt.Errorf("clear watchlist order: %w", err)
 	}
+	return nil
 }
 
 func (s *Service) DeleteConnection(ctx context.Context, userID int, profileID string, providerKey string) error {
@@ -1537,6 +1542,22 @@ func containsString(values []string, candidate string) bool {
 		}
 	}
 	return false
+}
+
+// exportFailureReason explains why an item was not confirmed sent, keyed by the
+// provider's failed/not-found result sets, so callers can record a per-item
+// error and let the pending queue advance.
+func exportFailureReason(result ExportResult, item LocalFavorite, kind ListKind) string {
+	if msg, ok := result.Failed[item.MediaItemID]; ok && msg != "" {
+		return msg
+	}
+	if msg, ok := result.Failed[item.ProviderItemKey]; ok && msg != "" {
+		return msg
+	}
+	if containsString(result.NotFound, item.MediaItemID) || containsString(result.NotFound, item.ProviderItemKey) {
+		return string(kind) + " item not found by provider"
+	}
+	return string(kind) + " item not confirmed by provider"
 }
 
 func historySourceForProvider(provider any) userstore.WatchHistorySource {

--- a/internal/watchsync/service_test.go
+++ b/internal/watchsync/service_test.go
@@ -20,7 +20,7 @@ type serviceFakeRepo struct {
 	settings            map[string]string
 	syncRuns            []SyncRun
 	historyExports      []HistoryExport
-	favoriteStates      []FavoriteState
+	listItemStates      []ListItemState
 	scrobbleConnections []Connection
 	scrobbleSessions    []ScrobbleSession
 	scrobbleUpdates     []scrobbleUpdate
@@ -211,21 +211,18 @@ func (r *serviceFakeRepo) ListLocalWatchEventConnections(_ context.Context, user
 	return conns, nil
 }
 
-func (r *serviceFakeRepo) ListFavoriteEventConnections(_ context.Context, userID int, profileID string, kind LocalFavoriteEventKind) ([]Connection, error) {
+func (r *serviceFakeRepo) ListListEventConnections(_ context.Context, userID int, profileID string, list ListKind) ([]Connection, error) {
 	var conns []Connection
 	for _, conn := range r.connections {
 		if conn.UserID != userID || conn.ProfileID != profileID {
 			continue
 		}
-		switch kind {
-		case LocalFavoriteEventAdded:
-			if conn.ExportFavoritesEnabled {
-				conns = append(conns, cloneConnectionForTest(conn))
-			}
-		case LocalFavoriteEventRemoved:
-			if conn.ExportFavoritesEnabled {
-				conns = append(conns, cloneConnectionForTest(conn))
-			}
+		enabled := conn.ExportFavoritesEnabled
+		if list == ListKindWatchlist {
+			enabled = conn.ExportWatchlistEnabled
+		}
+		if enabled {
+			conns = append(conns, cloneConnectionForTest(conn))
 		}
 	}
 	return conns, nil
@@ -276,56 +273,48 @@ func (r *serviceFakeRepo) MarkHistoryExportStatus(_ context.Context, id string, 
 	return nil
 }
 
-func (r *serviceFakeRepo) UpsertFavoriteStates(_ context.Context, states []FavoriteState) error {
+func (r *serviceFakeRepo) UpsertListItemStates(_ context.Context, states []ListItemState) error {
 	for _, state := range states {
+		if state.ListKind == "" {
+			state.ListKind = ListKindFavorites
+		}
 		replaced := false
-		for i := range r.favoriteStates {
-			if r.favoriteStates[i].ConnectionID == state.ConnectionID && r.favoriteStates[i].MediaItemID == state.MediaItemID {
+		for i := range r.listItemStates {
+			if r.listItemStates[i].ConnectionID == state.ConnectionID &&
+				r.listItemStates[i].ListKind == state.ListKind &&
+				r.listItemStates[i].MediaItemID == state.MediaItemID {
 				if state.ID == "" {
-					state.ID = r.favoriteStates[i].ID
+					state.ID = r.listItemStates[i].ID
 				}
-				r.favoriteStates[i] = state
+				r.listItemStates[i] = state
 				replaced = true
 				break
 			}
 		}
 		if !replaced {
 			if state.ID == "" {
-				state.ID = "favorite-" + strconv.Itoa(len(r.favoriteStates)+1)
+				state.ID = "list-item-" + strconv.Itoa(len(r.listItemStates)+1)
 			}
-			r.favoriteStates = append(r.favoriteStates, state)
+			r.listItemStates = append(r.listItemStates, state)
 		}
 	}
 	return nil
 }
 
-func (r *serviceFakeRepo) ListFavoriteStates(_ context.Context, connectionID string) ([]FavoriteState, error) {
-	var states []FavoriteState
-	for _, state := range r.favoriteStates {
-		if state.ConnectionID == connectionID {
+func (r *serviceFakeRepo) ListListItemStates(_ context.Context, connectionID string, kind ListKind) ([]ListItemState, error) {
+	var states []ListItemState
+	for _, state := range r.listItemStates {
+		if state.ConnectionID == connectionID && state.ListKind == kind {
 			states = append(states, state)
 		}
 	}
 	return states, nil
 }
 
-func (r *serviceFakeRepo) ListPendingFavoriteExports(_ context.Context, connectionID string, limit int) ([]FavoriteState, error) {
-	var states []FavoriteState
-	for _, state := range r.favoriteStates {
-		if state.ConnectionID == connectionID && state.LocalPresent && !state.RemotePresent && state.LastError == "" {
-			states = append(states, state)
-			if limit > 0 && len(states) >= limit {
-				break
-			}
-		}
-	}
-	return states, nil
-}
-
-func (r *serviceFakeRepo) ListPendingFavoriteRemovals(_ context.Context, connectionID string, limit int) ([]FavoriteState, error) {
-	var states []FavoriteState
-	for _, state := range r.favoriteStates {
-		if state.ConnectionID == connectionID && !state.LocalPresent && state.RemotePresent && state.LastError == "" {
+func (r *serviceFakeRepo) ListPendingListItemExports(_ context.Context, connectionID string, kind ListKind, limit int) ([]ListItemState, error) {
+	var states []ListItemState
+	for _, state := range r.listItemStates {
+		if state.ConnectionID == connectionID && state.ListKind == kind && state.LocalPresent && !state.RemotePresent && state.LastError == "" {
 			states = append(states, state)
 			if limit > 0 && len(states) >= limit {
 				break
@@ -335,43 +324,56 @@ func (r *serviceFakeRepo) ListPendingFavoriteRemovals(_ context.Context, connect
 	return states, nil
 }
 
-func (r *serviceFakeRepo) MarkFavoriteExported(_ context.Context, connectionID, mediaItemID string, exportedAt time.Time) error {
-	for i := range r.favoriteStates {
-		if r.favoriteStates[i].ConnectionID == connectionID && r.favoriteStates[i].MediaItemID == mediaItemID {
-			r.favoriteStates[i].RemotePresent = true
-			r.favoriteStates[i].LocalPresent = true
-			r.favoriteStates[i].LastExportedAt = &exportedAt
+func (r *serviceFakeRepo) ListPendingListItemRemovals(_ context.Context, connectionID string, kind ListKind, limit int) ([]ListItemState, error) {
+	var states []ListItemState
+	for _, state := range r.listItemStates {
+		if state.ConnectionID == connectionID && state.ListKind == kind && !state.LocalPresent && state.RemotePresent && state.LastError == "" {
+			states = append(states, state)
+			if limit > 0 && len(states) >= limit {
+				break
+			}
 		}
 	}
+	return states, nil
+}
+
+func (r *serviceFakeRepo) markListItem(connectionID string, kind ListKind, mediaItemID string, apply func(*ListItemState)) {
+	for i := range r.listItemStates {
+		if r.listItemStates[i].ConnectionID == connectionID && r.listItemStates[i].ListKind == kind && r.listItemStates[i].MediaItemID == mediaItemID {
+			apply(&r.listItemStates[i])
+		}
+	}
+}
+
+func (r *serviceFakeRepo) MarkListItemExported(_ context.Context, connectionID string, kind ListKind, mediaItemID string, exportedAt time.Time) error {
+	r.markListItem(connectionID, kind, mediaItemID, func(s *ListItemState) {
+		s.RemotePresent = true
+		s.LocalPresent = true
+		s.LastExportedAt = &exportedAt
+	})
 	return nil
 }
 
-func (r *serviceFakeRepo) MarkFavoriteRemoteRemoved(_ context.Context, connectionID, mediaItemID string, removedAt time.Time) error {
-	for i := range r.favoriteStates {
-		if r.favoriteStates[i].ConnectionID == connectionID && r.favoriteStates[i].MediaItemID == mediaItemID {
-			r.favoriteStates[i].RemotePresent = false
-			r.favoriteStates[i].LastRemovedRemoteAt = &removedAt
-		}
-	}
+func (r *serviceFakeRepo) MarkListItemRemoteRemoved(_ context.Context, connectionID string, kind ListKind, mediaItemID string, removedAt time.Time) error {
+	r.markListItem(connectionID, kind, mediaItemID, func(s *ListItemState) {
+		s.RemotePresent = false
+		s.LastRemovedRemoteAt = &removedAt
+	})
 	return nil
 }
 
-func (r *serviceFakeRepo) MarkFavoriteLocalRemoved(_ context.Context, connectionID, mediaItemID string, removedAt time.Time) error {
-	for i := range r.favoriteStates {
-		if r.favoriteStates[i].ConnectionID == connectionID && r.favoriteStates[i].MediaItemID == mediaItemID {
-			r.favoriteStates[i].LocalPresent = false
-			r.favoriteStates[i].LastRemovedLocalAt = &removedAt
-		}
-	}
+func (r *serviceFakeRepo) MarkListItemLocalRemoved(_ context.Context, connectionID string, kind ListKind, mediaItemID string, removedAt time.Time) error {
+	r.markListItem(connectionID, kind, mediaItemID, func(s *ListItemState) {
+		s.LocalPresent = false
+		s.LastRemovedLocalAt = &removedAt
+	})
 	return nil
 }
 
-func (r *serviceFakeRepo) MarkFavoriteError(_ context.Context, connectionID, mediaItemID, lastError string) error {
-	for i := range r.favoriteStates {
-		if r.favoriteStates[i].ConnectionID == connectionID && r.favoriteStates[i].MediaItemID == mediaItemID {
-			r.favoriteStates[i].LastError = lastError
-		}
-	}
+func (r *serviceFakeRepo) MarkListItemError(_ context.Context, connectionID string, kind ListKind, mediaItemID, lastError string) error {
+	r.markListItem(connectionID, kind, mediaItemID, func(s *ListItemState) {
+		s.LastError = lastError
+	})
 	return nil
 }
 

--- a/internal/watchsync/service_test.go
+++ b/internal/watchsync/service_test.go
@@ -346,10 +346,12 @@ func (r *serviceFakeRepo) markListItem(connectionID string, kind ListKind, media
 }
 
 func (r *serviceFakeRepo) MarkListItemExported(_ context.Context, connectionID string, kind ListKind, mediaItemID string, exportedAt time.Time) error {
+	// Mirror Postgres: successful transitions clear last_error.
 	r.markListItem(connectionID, kind, mediaItemID, func(s *ListItemState) {
 		s.RemotePresent = true
 		s.LocalPresent = true
 		s.LastExportedAt = &exportedAt
+		s.LastError = ""
 	})
 	return nil
 }
@@ -358,6 +360,7 @@ func (r *serviceFakeRepo) MarkListItemRemoteRemoved(_ context.Context, connectio
 	r.markListItem(connectionID, kind, mediaItemID, func(s *ListItemState) {
 		s.RemotePresent = false
 		s.LastRemovedRemoteAt = &removedAt
+		s.LastError = ""
 	})
 	return nil
 }
@@ -366,6 +369,7 @@ func (r *serviceFakeRepo) MarkListItemLocalRemoved(_ context.Context, connection
 	r.markListItem(connectionID, kind, mediaItemID, func(s *ListItemState) {
 		s.LocalPresent = false
 		s.LastRemovedLocalAt = &removedAt
+		s.LastError = ""
 	})
 	return nil
 }

--- a/internal/watchsync/types.go
+++ b/internal/watchsync/types.go
@@ -9,15 +9,30 @@ import (
 )
 
 type Capabilities struct {
-	ImportWatched    bool `json:"import_watched"`
-	ImportProgress   bool `json:"import_progress"`
-	ExportWatched    bool `json:"export_watched"`
-	ExportUnwatched  bool `json:"export_unwatched"`
-	ImportFavorites  bool `json:"import_favorites"`
-	ExportFavorites  bool `json:"export_favorites"`
-	RemoveFavorites  bool `json:"remove_favorites"`
-	ScrobblePlayback bool `json:"scrobble_playback"`
+	ImportWatched   bool `json:"import_watched"`
+	ImportProgress  bool `json:"import_progress"`
+	ExportWatched   bool `json:"export_watched"`
+	ExportUnwatched bool `json:"export_unwatched"`
+	ImportFavorites bool `json:"import_favorites"`
+	ExportFavorites bool `json:"export_favorites"`
+	RemoveFavorites bool `json:"remove_favorites"`
+	ImportWatchlist bool `json:"import_watchlist"`
+	ExportWatchlist bool `json:"export_watchlist"`
+	RemoveWatchlist bool `json:"remove_watchlist"`
+	// ProvidesWatchlistOrder is true when the provider returns its watchlist in a
+	// user-configurable order that Silo can mirror locally.
+	ProvidesWatchlistOrder bool `json:"provides_watchlist_order"`
+	ScrobblePlayback       bool `json:"scrobble_playback"`
 }
+
+// ListKind identifies which personal list a sync operates on. The favorites and
+// watchlist pipelines share the same machinery, parameterized by this kind.
+type ListKind string
+
+const (
+	ListKindFavorites ListKind = "favorites"
+	ListKindWatchlist ListKind = "watchlist"
+)
 
 const (
 	AuthMethodDeviceCode = "device_code"
@@ -109,6 +124,26 @@ type FavoriteRemover interface {
 	RemoveFavorites(ctx context.Context, cfg ServerConfig, conn Connection, favorites []LocalFavorite) (ExportResult, error)
 }
 
+// Watchlist provider interfaces mirror the favorite ones but target the
+// provider's watchlist ("want to watch") list rather than its favorites. They
+// reuse the RemoteFavorite/LocalFavorite/FavoriteImportBatch carriers, which
+// hold only generic item identity (external ids, title, year, kind).
+type WatchlistImporter interface {
+	FetchWatchlist(ctx context.Context, cfg ServerConfig, conn Connection) ([]RemoteFavorite, error)
+}
+
+type WatchlistBatchImporter interface {
+	FetchWatchlistBatch(ctx context.Context, cfg ServerConfig, conn Connection) (FavoriteImportBatch, error)
+}
+
+type WatchlistExporter interface {
+	ExportWatchlist(ctx context.Context, cfg ServerConfig, conn Connection, items []LocalFavorite) (ExportResult, error)
+}
+
+type WatchlistRemover interface {
+	RemoveWatchlist(ctx context.Context, cfg ServerConfig, conn Connection, items []LocalFavorite) (ExportResult, error)
+}
+
 type Scrobbler interface {
 	Start(ctx context.Context, cfg ServerConfig, conn Connection, event ScrobbleEvent) error
 	Pause(ctx context.Context, cfg ServerConfig, conn Connection, event ScrobbleEvent) error
@@ -129,32 +164,37 @@ func (c ServerConfig) Configured() bool {
 }
 
 type Connection struct {
-	ID                          string
-	Provider                    string
-	UserID                      int
-	ProfileID                   string
-	ProviderAccountID           string
-	ProviderUsername            string
-	AccessToken                 string
-	RefreshToken                string
-	TokenExpiresAt              *time.Time
-	ImportWatchedEnabled        bool
-	ImportProgressEnabled       bool
-	ExportWatchedEnabled        bool
-	ExportUnwatchedEnabled      bool
-	ImportFavoritesEnabled      bool
-	ExportFavoritesEnabled      bool
-	SyncFavoriteRemovalsEnabled bool
-	ScrobbleEnabled             bool
-	LastInboundSyncAt           *time.Time
-	LastProgressSyncAt          *time.Time
-	LastOutboundSyncAt          *time.Time
-	LastFavoritesSyncAt         *time.Time
-	LastScrobbleErrorAt         *time.Time
-	LastError                   string
-	SyncCursors                 map[string]string `json:"-"`
-	CreatedAt                   time.Time
-	UpdatedAt                   time.Time
+	ID                           string
+	Provider                     string
+	UserID                       int
+	ProfileID                    string
+	ProviderAccountID            string
+	ProviderUsername             string
+	AccessToken                  string
+	RefreshToken                 string
+	TokenExpiresAt               *time.Time
+	ImportWatchedEnabled         bool
+	ImportProgressEnabled        bool
+	ExportWatchedEnabled         bool
+	ExportUnwatchedEnabled       bool
+	ImportFavoritesEnabled       bool
+	ExportFavoritesEnabled       bool
+	SyncFavoriteRemovalsEnabled  bool
+	ImportWatchlistEnabled       bool
+	ExportWatchlistEnabled       bool
+	SyncWatchlistRemovalsEnabled bool
+	SyncWatchlistOrderEnabled    bool
+	ScrobbleEnabled              bool
+	LastInboundSyncAt            *time.Time
+	LastProgressSyncAt           *time.Time
+	LastOutboundSyncAt           *time.Time
+	LastFavoritesSyncAt          *time.Time
+	LastWatchlistSyncAt          *time.Time
+	LastScrobbleErrorAt          *time.Time
+	LastError                    string
+	SyncCursors                  map[string]string `json:"-"`
+	CreatedAt                    time.Time
+	UpdatedAt                    time.Time
 }
 
 type SyncRun struct {
@@ -174,6 +214,11 @@ type SyncRun struct {
 	OutboundFavoritesFound   int        `json:"outbound_favorites_found"`
 	OutboundFavoritesSent    int        `json:"outbound_favorites_sent"`
 	FavoriteRemovalsSent     int        `json:"favorite_removals_sent"`
+	InboundWatchlistFound    int        `json:"inbound_watchlist_found"`
+	InboundWatchlistImported int        `json:"inbound_watchlist_imported"`
+	OutboundWatchlistFound   int        `json:"outbound_watchlist_found"`
+	OutboundWatchlistSent    int        `json:"outbound_watchlist_sent"`
+	WatchlistRemovalsSent    int        `json:"watchlist_removals_sent"`
 	Warning                  string     `json:"warning,omitempty"`
 	Error                    string     `json:"error,omitempty"`
 	StartedAt                time.Time  `json:"started_at"`
@@ -357,18 +402,22 @@ type LocalWatchEvent struct {
 	Plays     []LocalPlay
 }
 
-type LocalFavoriteEventKind string
+type ListChange string
 
 const (
-	LocalFavoriteEventAdded   LocalFavoriteEventKind = "favorite_added"
-	LocalFavoriteEventRemoved LocalFavoriteEventKind = "favorite_removed"
+	ListChangeAdded   ListChange = "added"
+	ListChangeRemoved ListChange = "removed"
 )
 
-type LocalFavoriteEvent struct {
-	Kind      LocalFavoriteEventKind
+// LocalListEvent reports that a profile's local list membership changed (an item
+// added or removed), so the watch providers bound to that list kind can mirror
+// the change. It serves both the favorites and watchlist lists via List.
+type LocalListEvent struct {
+	List      ListKind
+	Change    ListChange
 	UserID    int
 	ProfileID string
-	Favorites []LocalFavorite
+	Items     []LocalFavorite
 }
 
 type HistoryExport struct {
@@ -386,9 +435,14 @@ type HistoryExport struct {
 	UpdatedAt       time.Time
 }
 
-type FavoriteState struct {
+// ListItemState is the per-connection, per-list shadow record tracking whether
+// an item is present locally and/or remotely, used to drive incremental
+// export/removal reconciliation. It serves both the favorites and watchlist
+// lists, discriminated by ListKind.
+type ListItemState struct {
 	ID                  string
 	ConnectionID        string
+	ListKind            ListKind
 	MediaItemID         string
 	ProviderItemKey     string
 	Kind                string
@@ -524,36 +578,45 @@ type ProviderSummary struct {
 }
 
 type ConnectionStatus struct {
-	Provider                    string       `json:"provider"`
-	DisplayName                 string       `json:"display_name"`
-	Capabilities                Capabilities `json:"capabilities"`
-	AuthMethod                  string       `json:"auth_method"`
-	Connected                   bool         `json:"connected"`
-	ProviderUsername            string       `json:"provider_username,omitempty"`
-	ImportWatchedEnabled        bool         `json:"import_watched_enabled"`
-	ImportProgressEnabled       bool         `json:"import_progress_enabled"`
-	ExportWatchedEnabled        bool         `json:"export_watched_enabled"`
-	ExportUnwatchedEnabled      bool         `json:"export_unwatched_enabled"`
-	ImportFavoritesEnabled      bool         `json:"import_favorites_enabled"`
-	ExportFavoritesEnabled      bool         `json:"export_favorites_enabled"`
-	SyncFavoriteRemovalsEnabled bool         `json:"sync_favorite_removals_enabled"`
-	ScrobbleEnabled             bool         `json:"scrobble_enabled"`
-	CredentialsConfigured       bool         `json:"credentials_configured"`
-	LastInboundSyncAt           *time.Time   `json:"last_inbound_sync_at,omitempty"`
-	LastProgressSyncAt          *time.Time   `json:"last_progress_sync_at,omitempty"`
-	LastOutboundSyncAt          *time.Time   `json:"last_outbound_sync_at,omitempty"`
-	LastFavoritesSyncAt         *time.Time   `json:"last_favorites_sync_at,omitempty"`
-	LastScrobbleErrorAt         *time.Time   `json:"last_scrobble_error_at,omitempty"`
-	LastError                   string       `json:"last_error,omitempty"`
+	Provider                     string       `json:"provider"`
+	DisplayName                  string       `json:"display_name"`
+	Capabilities                 Capabilities `json:"capabilities"`
+	AuthMethod                   string       `json:"auth_method"`
+	Connected                    bool         `json:"connected"`
+	ProviderUsername             string       `json:"provider_username,omitempty"`
+	ImportWatchedEnabled         bool         `json:"import_watched_enabled"`
+	ImportProgressEnabled        bool         `json:"import_progress_enabled"`
+	ExportWatchedEnabled         bool         `json:"export_watched_enabled"`
+	ExportUnwatchedEnabled       bool         `json:"export_unwatched_enabled"`
+	ImportFavoritesEnabled       bool         `json:"import_favorites_enabled"`
+	ExportFavoritesEnabled       bool         `json:"export_favorites_enabled"`
+	SyncFavoriteRemovalsEnabled  bool         `json:"sync_favorite_removals_enabled"`
+	ImportWatchlistEnabled       bool         `json:"import_watchlist_enabled"`
+	ExportWatchlistEnabled       bool         `json:"export_watchlist_enabled"`
+	SyncWatchlistRemovalsEnabled bool         `json:"sync_watchlist_removals_enabled"`
+	SyncWatchlistOrderEnabled    bool         `json:"sync_watchlist_order_enabled"`
+	ScrobbleEnabled              bool         `json:"scrobble_enabled"`
+	CredentialsConfigured        bool         `json:"credentials_configured"`
+	LastInboundSyncAt            *time.Time   `json:"last_inbound_sync_at,omitempty"`
+	LastProgressSyncAt           *time.Time   `json:"last_progress_sync_at,omitempty"`
+	LastOutboundSyncAt           *time.Time   `json:"last_outbound_sync_at,omitempty"`
+	LastFavoritesSyncAt          *time.Time   `json:"last_favorites_sync_at,omitempty"`
+	LastWatchlistSyncAt          *time.Time   `json:"last_watchlist_sync_at,omitempty"`
+	LastScrobbleErrorAt          *time.Time   `json:"last_scrobble_error_at,omitempty"`
+	LastError                    string       `json:"last_error,omitempty"`
 }
 
 type ConnectionUpdate struct {
-	ImportWatchedEnabled        *bool `json:"import_watched_enabled,omitempty"`
-	ImportProgressEnabled       *bool `json:"import_progress_enabled,omitempty"`
-	ExportWatchedEnabled        *bool `json:"export_watched_enabled,omitempty"`
-	ExportUnwatchedEnabled      *bool `json:"export_unwatched_enabled,omitempty"`
-	ImportFavoritesEnabled      *bool `json:"import_favorites_enabled,omitempty"`
-	ExportFavoritesEnabled      *bool `json:"export_favorites_enabled,omitempty"`
-	SyncFavoriteRemovalsEnabled *bool `json:"sync_favorite_removals_enabled,omitempty"`
-	ScrobbleEnabled             *bool `json:"scrobble_enabled,omitempty"`
+	ImportWatchedEnabled         *bool `json:"import_watched_enabled,omitempty"`
+	ImportProgressEnabled        *bool `json:"import_progress_enabled,omitempty"`
+	ExportWatchedEnabled         *bool `json:"export_watched_enabled,omitempty"`
+	ExportUnwatchedEnabled       *bool `json:"export_unwatched_enabled,omitempty"`
+	ImportFavoritesEnabled       *bool `json:"import_favorites_enabled,omitempty"`
+	ExportFavoritesEnabled       *bool `json:"export_favorites_enabled,omitempty"`
+	SyncFavoriteRemovalsEnabled  *bool `json:"sync_favorite_removals_enabled,omitempty"`
+	ImportWatchlistEnabled       *bool `json:"import_watchlist_enabled,omitempty"`
+	ExportWatchlistEnabled       *bool `json:"export_watchlist_enabled,omitempty"`
+	SyncWatchlistRemovalsEnabled *bool `json:"sync_watchlist_removals_enabled,omitempty"`
+	SyncWatchlistOrderEnabled    *bool `json:"sync_watchlist_order_enabled,omitempty"`
+	ScrobbleEnabled              *bool `json:"scrobble_enabled,omitempty"`
 }

--- a/migrations/sql/20260626174211_watch_provider_watchlist.sql
+++ b/migrations/sql/20260626174211_watch_provider_watchlist.sql
@@ -1,0 +1,127 @@
+-- +goose Up
+-- +goose StatementBegin
+
+-- Profile preference: remove an item from the watchlist once it is fully
+-- watched (a movie on completion, a series once every episode is watched).
+-- Defaults on; it is a standalone behavior that also propagates to connected
+-- watchlist providers.
+ALTER TABLE public.user_profiles
+    ADD COLUMN remove_watched_from_watchlist boolean NOT NULL DEFAULT true;
+
+-- Per-connection watchlist sync toggles, mirroring the favorites toggles.
+ALTER TABLE public.watch_provider_connections
+    ADD COLUMN import_watchlist_enabled boolean NOT NULL DEFAULT false,
+    ADD COLUMN export_watchlist_enabled boolean NOT NULL DEFAULT false,
+    ADD COLUMN sync_watchlist_removals_enabled boolean NOT NULL DEFAULT false,
+    ADD COLUMN last_watchlist_sync_at timestamptz;
+
+-- Per-run watchlist counters, mirroring the favorites counters.
+ALTER TABLE public.watch_provider_sync_runs
+    ADD COLUMN inbound_watchlist_found integer NOT NULL DEFAULT 0,
+    ADD COLUMN inbound_watchlist_imported integer NOT NULL DEFAULT 0,
+    ADD COLUMN outbound_watchlist_found integer NOT NULL DEFAULT 0,
+    ADD COLUMN outbound_watchlist_sent integer NOT NULL DEFAULT 0,
+    ADD COLUMN watchlist_removals_sent integer NOT NULL DEFAULT 0;
+
+-- The favorites shadow table generalizes into a list-item shadow table keyed by
+-- a list_kind discriminator ('favorites' | 'watchlist'). Existing rows are all
+-- favorites, so the new column defaults accordingly.
+ALTER TABLE public.watch_provider_favorite_items
+    RENAME TO watch_provider_list_items;
+
+ALTER TABLE public.watch_provider_list_items
+    ADD COLUMN list_kind text NOT NULL DEFAULT 'favorites';
+
+ALTER TABLE public.watch_provider_list_items
+    DROP CONSTRAINT watch_provider_favorite_items_connection_media_key;
+ALTER TABLE public.watch_provider_list_items
+    ADD CONSTRAINT watch_provider_list_items_connection_kind_media_key
+        UNIQUE (connection_id, list_kind, media_item_id);
+
+DROP INDEX IF EXISTS idx_watch_provider_favorite_items_provider_key;
+CREATE UNIQUE INDEX idx_watch_provider_list_items_provider_key
+    ON public.watch_provider_list_items (connection_id, list_kind, provider_item_key)
+    WHERE provider_item_key <> '';
+
+ALTER INDEX idx_watch_provider_favorite_items_connection_remote
+    RENAME TO idx_watch_provider_list_items_connection_remote;
+ALTER INDEX idx_watch_provider_favorite_items_connection_local
+    RENAME TO idx_watch_provider_list_items_connection_local;
+
+-- Re-map MDBList. MDBList exposes a single list — its watchlist — which Silo
+-- historically bound to the *favorites* abstraction. Re-bind those connections
+-- to the watchlist abstraction so MDBList's watchlist mirrors Silo's watchlist.
+-- The stale favorites shadow rows are dropped so the next sync rebuilds clean
+-- watchlist state (removals default off, so the first sync is a union, not a
+-- purge).
+UPDATE public.watch_provider_connections
+SET import_watchlist_enabled = import_favorites_enabled,
+    export_watchlist_enabled = export_favorites_enabled,
+    sync_watchlist_removals_enabled = sync_favorite_removals_enabled,
+    last_watchlist_sync_at = last_favorites_sync_at,
+    import_favorites_enabled = false,
+    export_favorites_enabled = false,
+    sync_favorite_removals_enabled = false
+WHERE provider = 'mdblist';
+
+DELETE FROM public.watch_provider_list_items
+WHERE list_kind = 'favorites'
+  AND connection_id IN (
+      SELECT id FROM public.watch_provider_connections WHERE provider = 'mdblist'
+  );
+-- +goose StatementEnd
+
+-- +goose Down
+-- +goose StatementBegin
+
+-- Re-bind MDBList connections back to the favorites abstraction.
+UPDATE public.watch_provider_connections
+SET import_favorites_enabled = import_watchlist_enabled,
+    export_favorites_enabled = export_watchlist_enabled,
+    sync_favorite_removals_enabled = sync_watchlist_removals_enabled,
+    last_favorites_sync_at = last_watchlist_sync_at
+WHERE provider = 'mdblist';
+
+-- Collapsing list_kind back into a single list requires dropping any
+-- watchlist-only rows to avoid violating the restored unique constraint.
+DELETE FROM public.watch_provider_list_items
+WHERE list_kind <> 'favorites';
+
+ALTER INDEX idx_watch_provider_list_items_connection_local
+    RENAME TO idx_watch_provider_favorite_items_connection_local;
+ALTER INDEX idx_watch_provider_list_items_connection_remote
+    RENAME TO idx_watch_provider_favorite_items_connection_remote;
+
+DROP INDEX IF EXISTS idx_watch_provider_list_items_provider_key;
+CREATE UNIQUE INDEX idx_watch_provider_favorite_items_provider_key
+    ON public.watch_provider_list_items (connection_id, provider_item_key)
+    WHERE provider_item_key <> '';
+
+ALTER TABLE public.watch_provider_list_items
+    DROP CONSTRAINT watch_provider_list_items_connection_kind_media_key;
+ALTER TABLE public.watch_provider_list_items
+    ADD CONSTRAINT watch_provider_favorite_items_connection_media_key
+        UNIQUE (connection_id, media_item_id);
+
+ALTER TABLE public.watch_provider_list_items
+    DROP COLUMN list_kind;
+
+ALTER TABLE public.watch_provider_list_items
+    RENAME TO watch_provider_favorite_items;
+
+ALTER TABLE public.watch_provider_sync_runs
+    DROP COLUMN IF EXISTS watchlist_removals_sent,
+    DROP COLUMN IF EXISTS outbound_watchlist_sent,
+    DROP COLUMN IF EXISTS outbound_watchlist_found,
+    DROP COLUMN IF EXISTS inbound_watchlist_imported,
+    DROP COLUMN IF EXISTS inbound_watchlist_found;
+
+ALTER TABLE public.watch_provider_connections
+    DROP COLUMN IF EXISTS last_watchlist_sync_at,
+    DROP COLUMN IF EXISTS sync_watchlist_removals_enabled,
+    DROP COLUMN IF EXISTS export_watchlist_enabled,
+    DROP COLUMN IF EXISTS import_watchlist_enabled;
+
+ALTER TABLE public.user_profiles
+    DROP COLUMN IF EXISTS remove_watched_from_watchlist;
+-- +goose StatementEnd

--- a/migrations/sql/20260626185649_watchlist_sort_order.sql
+++ b/migrations/sql/20260626185649_watchlist_sort_order.sql
@@ -1,0 +1,30 @@
+-- +goose Up
+-- +goose StatementBegin
+
+-- Optional mirroring of an external provider's watchlist sort order. sort_index
+-- is NULL for locally-added items (which fall back to added_at ordering) and
+-- 0..N-1 for items whose order is synced from a provider (currently MDBList).
+ALTER TABLE public.user_watchlist
+    ADD COLUMN sort_index integer;
+
+-- Supports "ORDER BY sort_index ASC NULLS LAST, added_at DESC".
+CREATE INDEX idx_user_watchlist_profile_sort
+    ON public.user_watchlist (user_id, profile_id, sort_index ASC NULLS LAST, added_at DESC);
+
+-- Per-connection toggle: mirror the provider's watchlist order into Silo's
+-- watchlist. Gated in the UI by the provider's provides_watchlist_order
+-- capability.
+ALTER TABLE public.watch_provider_connections
+    ADD COLUMN sync_watchlist_order_enabled boolean NOT NULL DEFAULT false;
+-- +goose StatementEnd
+
+-- +goose Down
+-- +goose StatementBegin
+ALTER TABLE public.watch_provider_connections
+    DROP COLUMN IF EXISTS sync_watchlist_order_enabled;
+
+DROP INDEX IF EXISTS idx_user_watchlist_profile_sort;
+
+ALTER TABLE public.user_watchlist
+    DROP COLUMN IF EXISTS sort_index;
+-- +goose StatementEnd

--- a/web/src/hooks/queries/watchProviders.ts
+++ b/web/src/hooks/queries/watchProviders.ts
@@ -1,6 +1,6 @@
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { api, ApiClientError } from "@/api/client";
-import { favoriteKeys, watchProviderKeys } from "./keys";
+import { favoriteKeys, watchlistKeys, watchProviderKeys } from "./keys";
 import { toast } from "sonner";
 import { storage } from "@/utils/storage";
 
@@ -25,6 +25,10 @@ export interface WatchProviderCapabilities {
   import_favorites: boolean;
   export_favorites: boolean;
   remove_favorites: boolean;
+  import_watchlist: boolean;
+  export_watchlist: boolean;
+  remove_watchlist: boolean;
+  provides_watchlist_order: boolean;
   scrobble_playback: boolean;
 }
 
@@ -42,12 +46,17 @@ export interface WatchProviderConnection {
   import_favorites_enabled: boolean;
   export_favorites_enabled: boolean;
   sync_favorite_removals_enabled: boolean;
+  import_watchlist_enabled: boolean;
+  export_watchlist_enabled: boolean;
+  sync_watchlist_removals_enabled: boolean;
+  sync_watchlist_order_enabled: boolean;
   scrobble_enabled: boolean;
   credentials_configured: boolean;
   last_inbound_sync_at?: string;
   last_progress_sync_at?: string;
   last_outbound_sync_at?: string;
   last_favorites_sync_at?: string;
+  last_watchlist_sync_at?: string;
   last_scrobble_error_at?: string;
   last_error?: string;
 }
@@ -78,6 +87,11 @@ export interface WatchProviderSyncRun {
   outbound_favorites_found: number;
   outbound_favorites_sent: number;
   favorite_removals_sent: number;
+  inbound_watchlist_found: number;
+  inbound_watchlist_imported: number;
+  outbound_watchlist_found: number;
+  outbound_watchlist_sent: number;
+  watchlist_removals_sent: number;
   warning?: string;
   error?: string;
   started_at: string;
@@ -109,6 +123,10 @@ export type UpdateWatchProviderConnection = Partial<
     | "import_favorites_enabled"
     | "export_favorites_enabled"
     | "sync_favorite_removals_enabled"
+    | "import_watchlist_enabled"
+    | "export_watchlist_enabled"
+    | "sync_watchlist_removals_enabled"
+    | "sync_watchlist_order_enabled"
     | "scrobble_enabled"
   >
 >;
@@ -284,6 +302,7 @@ export function useTriggerWatchProviderSync(provider: string) {
         queryKey: watchProviderKeys.connection(profileId, provider),
       });
       queryClient.invalidateQueries({ queryKey: favoriteKeys.list() });
+      queryClient.invalidateQueries({ queryKey: watchlistKeys.list() });
       toast.success("Watch provider sync started");
     },
     onError: (err) => {

--- a/web/src/pages/settings/WatchProvidersSettings.tsx
+++ b/web/src/pages/settings/WatchProvidersSettings.tsx
@@ -271,8 +271,8 @@ function APIKeyBlock({
 }
 
 interface ConnectedRunInfo {
-  imported: { watched: number; progress: number; favorites: number };
-  exported: { watched: number; favorites: number; favoriteRemovals: number };
+  imported: { watched: number; progress: number; favorites: number; watchlist: number };
+  exported: { watched: number; favorites: number; favoriteRemovals: number; watchlist: number };
   errorMessage?: string;
   errorHint?: string;
 }
@@ -285,11 +285,13 @@ function deriveRunInfo(
     watched: latestRun?.inbound_watched_imported ?? 0,
     progress: latestRun?.inbound_progress_imported ?? 0,
     favorites: latestRun?.inbound_favorites_imported ?? 0,
+    watchlist: latestRun?.inbound_watchlist_imported ?? 0,
   };
   const exported = {
     watched: latestRun?.outbound_sent ?? 0,
     favorites: latestRun?.outbound_favorites_sent ?? 0,
     favoriteRemovals: latestRun?.favorite_removals_sent ?? 0,
+    watchlist: latestRun?.outbound_watchlist_sent ?? 0,
   };
   let errorMessage: string | undefined;
   let errorHint: string | undefined;
@@ -312,6 +314,7 @@ function formatLastSync(connection: WatchProviderConnection, latestRun?: WatchPr
     connection.last_progress_sync_at,
     connection.last_outbound_sync_at,
     connection.last_favorites_sync_at,
+    connection.last_watchlist_sync_at,
   ].filter((value): value is string => Boolean(value));
   if (candidates.length === 0) return "Never synced";
   const newest = candidates
@@ -373,6 +376,8 @@ function WatchProviderCard({ providerKey }: { providerKey: string }) {
   const hasError = Boolean(runInfo?.errorMessage);
   const favoritesSyncEnabled =
     connection.import_favorites_enabled || connection.export_favorites_enabled;
+  const watchlistSyncEnabled =
+    connection.import_watchlist_enabled || connection.export_watchlist_enabled;
 
   let statusVariant: StatusVariant;
   let statusLabel: string;
@@ -554,14 +559,14 @@ function WatchProviderCard({ providerKey }: { providerKey: string }) {
             <div className="grid grid-cols-2 gap-3 sm:hidden">
               <StatCell
                 label="Last imported"
-                value={`${runInfo.imported.watched.toLocaleString()} watched · ${runInfo.imported.progress.toLocaleString()} progress · ${runInfo.imported.favorites.toLocaleString()} favorites`}
+                value={`${runInfo.imported.watched.toLocaleString()} watched · ${runInfo.imported.progress.toLocaleString()} progress · ${runInfo.imported.favorites.toLocaleString()} favorites · ${runInfo.imported.watchlist.toLocaleString()} watchlist`}
               />
               <StatCell
                 label="Last exported"
-                value={`${(runInfo.exported.watched + runInfo.exported.favorites).toLocaleString()} sent`}
+                value={`${(runInfo.exported.watched + runInfo.exported.favorites + runInfo.exported.watchlist).toLocaleString()} sent`}
               />
             </div>
-            <div className="hidden grid-cols-4 gap-3 sm:grid">
+            <div className="hidden grid-cols-5 gap-3 sm:grid">
               <StatCell
                 label="Watched"
                 value={`${runInfo.imported.watched.toLocaleString()} imported`}
@@ -575,8 +580,12 @@ function WatchProviderCard({ providerKey }: { providerKey: string }) {
                 value={`${runInfo.imported.favorites.toLocaleString()} imported`}
               />
               <StatCell
+                label="Watchlist"
+                value={`${runInfo.imported.watchlist.toLocaleString()} imported`}
+              />
+              <StatCell
                 label="Exported"
-                value={`${(runInfo.exported.watched + runInfo.exported.favorites).toLocaleString()} sent`}
+                value={`${(runInfo.exported.watched + runInfo.exported.favorites + runInfo.exported.watchlist).toLocaleString()} sent`}
               />
             </div>
           </div>
@@ -642,6 +651,49 @@ function WatchProviderCard({ providerKey }: { providerKey: string }) {
                 disabled={isBusy || !favoritesSyncEnabled}
                 onChange={(checked) =>
                   updateConnection.mutate({ sync_favorite_removals_enabled: checked })
+                }
+              />
+            ) : null}
+            {connection.capabilities.import_watchlist ||
+            connection.capabilities.export_watchlist ? (
+              <ToggleRow
+                id={`watch-provider-${providerKey}-watchlist`}
+                label="Sync watchlist"
+                description={`Import your ${displayName} watchlist, and send local watchlist adds.`}
+                checked={watchlistSyncEnabled}
+                disabled={isBusy}
+                onChange={(checked) =>
+                  updateConnection.mutate({
+                    import_watchlist_enabled: checked,
+                    export_watchlist_enabled: checked,
+                    sync_watchlist_removals_enabled: checked
+                      ? connection.sync_watchlist_removals_enabled
+                      : false,
+                  })
+                }
+              />
+            ) : null}
+            {connection.capabilities.remove_watchlist ? (
+              <ToggleRow
+                id={`watch-provider-${providerKey}-watchlist-removals`}
+                label="Sync watchlist removals"
+                description="Remove provider-synced watchlist items on the other side when they are removed locally."
+                checked={connection.sync_watchlist_removals_enabled}
+                disabled={isBusy || !watchlistSyncEnabled}
+                onChange={(checked) =>
+                  updateConnection.mutate({ sync_watchlist_removals_enabled: checked })
+                }
+              />
+            ) : null}
+            {connection.capabilities.provides_watchlist_order ? (
+              <ToggleRow
+                id={`watch-provider-${providerKey}-watchlist-order`}
+                label="Mirror watchlist order"
+                description={`Order your Silo watchlist to match its ${displayName} sort order. Items not on ${displayName} stay at the bottom.`}
+                checked={connection.sync_watchlist_order_enabled}
+                disabled={isBusy || !connection.import_watchlist_enabled}
+                onChange={(checked) =>
+                  updateConnection.mutate({ sync_watchlist_order_enabled: checked })
                 }
               />
             ) : null}

--- a/web/src/pages/settings/WatchProvidersSettings.tsx
+++ b/web/src/pages/settings/WatchProvidersSettings.tsx
@@ -272,7 +272,13 @@ function APIKeyBlock({
 
 interface ConnectedRunInfo {
   imported: { watched: number; progress: number; favorites: number; watchlist: number };
-  exported: { watched: number; favorites: number; favoriteRemovals: number; watchlist: number };
+  exported: {
+    watched: number;
+    favorites: number;
+    favoriteRemovals: number;
+    watchlist: number;
+    watchlistRemovals: number;
+  };
   errorMessage?: string;
   errorHint?: string;
 }
@@ -292,6 +298,7 @@ function deriveRunInfo(
     favorites: latestRun?.outbound_favorites_sent ?? 0,
     favoriteRemovals: latestRun?.favorite_removals_sent ?? 0,
     watchlist: latestRun?.outbound_watchlist_sent ?? 0,
+    watchlistRemovals: latestRun?.watchlist_removals_sent ?? 0,
   };
   let errorMessage: string | undefined;
   let errorHint: string | undefined;
@@ -563,7 +570,7 @@ function WatchProviderCard({ providerKey }: { providerKey: string }) {
               />
               <StatCell
                 label="Last exported"
-                value={`${(runInfo.exported.watched + runInfo.exported.favorites + runInfo.exported.watchlist).toLocaleString()} sent`}
+                value={`${(runInfo.exported.watched + runInfo.exported.favorites + runInfo.exported.favoriteRemovals + runInfo.exported.watchlist + runInfo.exported.watchlistRemovals).toLocaleString()} sent`}
               />
             </div>
             <div className="hidden grid-cols-5 gap-3 sm:grid">
@@ -585,7 +592,7 @@ function WatchProviderCard({ providerKey }: { providerKey: string }) {
               />
               <StatCell
                 label="Exported"
-                value={`${(runInfo.exported.watched + runInfo.exported.favorites + runInfo.exported.watchlist).toLocaleString()} sent`}
+                value={`${(runInfo.exported.watched + runInfo.exported.favorites + runInfo.exported.favoriteRemovals + runInfo.exported.watchlist + runInfo.exported.watchlistRemovals).toLocaleString()} sent`}
               />
             </div>
           </div>


### PR DESCRIPTION
## Problem
Watch-providers synced **favorites** but not a user's **watchlist**. This adds watchlist sync for Trakt, Simkl, and MDBList, plus auto-removal of watched items and optional MDBList sort-order mirroring.

## What changed
- **Generalized pipeline** — the favorites sync becomes one `ListKind`-parameterized pipeline (`internal/watchsync/lists.go`) that drives both favorites and watchlist; per-favorites service methods are replaced by kind-generic ones. The shadow table `watch_provider_favorite_items` → `watch_provider_list_items` with a `list_kind` discriminator.
- **Providers**
  - **Trakt**: adds watchlist sync via `/sync/watchlist*` (a list distinct from favorites).
  - **Simkl**: adds plan-to-watch sync (its watchlist) — Simkl gets list sync for the first time.
  - **MDBList**: re-mapped favorites → watchlist (its only list *is* a watchlist). Capabilities now report `import_favorites=false` / `import_watchlist=true`; the migration re-binds existing MDBList connections.
- **Auto-remove watched from watchlist** — standalone, default-on profile preference (`user_profiles.remove_watched_from_watchlist`): a movie leaves the watchlist when watched, a series only once every episode is watched. Implemented as `watchstate.CompletionObserver` (`internal/watchlist.Maintainer`), wired into the native mark-watched, playback-stop, and Jellyfin-compat mark-played paths. Imports do **not** trigger it.
- **Optional MDBList sort-order mirroring** — opt-in, capability-gated toggle mirrors MDBList's watchlist order into Silo via `user_watchlist.sort_index`; `ListWatchlist` orders by `sort_index` then `added_at`, so both `/api/v1/watchlist` and the catalog watchlist view inherit it. Disabling reverts to newest-first.
- **Timing** — local add/remove pushes to connected providers in real time (removals gated by the opt-in removals toggle); the hourly job handles inbound import + retry/reconcile.
- **Web** — watch-provider settings gain watchlist import/export/removals toggles, a "mirror watchlist order" toggle, and watchlist sync stats.

## Why this approach
The favorites and watchlist pipelines are ~90% identical. Generalizing into one kind-parameterized path follows CLAUDE.md's anti-duplication guidance instead of cloning the favorites machinery.

## API / compat
Additive-only per the Silo v1 rule: all new fields on `ConnectionStatus` / `Capabilities` / `ConnectionUpdate` / `SyncRun` and the web types are additions — no existing field renamed, removed, or retyped.

## Risks / follow-up
- **MDBList capability flip is intentional and client-visible** — `silo-android` / `silo-apple` may need to surface MDBList under the watchlist (not favorites) UI.
- **Existing MDBList users**: their MDBList list previously mirrored Silo *favorites* and now mirrors Silo *watchlist*; the first post-migration sync is a union (removals default off), so nothing is destructively purged.
- **Order mirroring** reflects the order MDBList returns from `/watchlist/items` (couldn't confirm against MDBList docs — Cloudflare-blocked). If it ever diverges from the configured UI sort, adding an explicit sort param is a small follow-up.

## Testing
- New unit tests: auto-remove maintainer (movie/series/partial/preference-off/dedupe) and watchlist sort-order (apply/re-sync/clear). Provider + service tests updated.
- `go build ./...`, `go test` (affected packages), `make migrate-validate`, `make verify-local-paths`, and web `prettier`/`eslint`/`tsc` all pass. (The only failing tests in the tree are pre-existing, environment-dependent PID-liveness tests in `jellycompat`, untouched here.)

> Note for reviewers: please link the watch-providers capability epic / scope item (`Part of #NNN`) — I didn't have the issue number.

## AI-use disclosure
Implemented with Claude Code (Claude Opus 4.8).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added watchlist synchronization for supported providers (import/export/removal), including optional mirroring of watchlist order.
  * Added automatic watchlist cleanup when items are marked fully watched, working consistently across playback and Jellyfin-compat “mark watched” flows.
  * Extended watch-provider settings and sync run stats with watchlist sync toggles, last-sync tracking, and additional watchlist counters.

* **Bug Fixes**
  * Improved deterministic watchlist ordering by prioritizing synced items’ stored sort order with a clear fallback for locally added items.
  * Ensured watched-item removal honors the user’s “remove watched from watchlist” preference.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->