### PR TITLE
fix(catalog): make media_items scalar columns NOT NULL to stop NULL-scan crashes

### DIFF
--- a/internal/catalog/item_repo.go
+++ b/internal/catalog/item_repo.go
@@ -90,7 +90,7 @@ func (r *ItemRepository) SetLocalPoster(ctx context.Context, contentID, posterPa
 	tag, err := r.pool.Exec(ctx, `
 		UPDATE media_items
 		SET poster_path = $2,
-		    poster_thumbhash = NULLIF($3, ''),
+		    poster_thumbhash = $3,
 		    updated_at = NOW()
 		WHERE content_id = $1
 		  AND (poster_path IS NULL OR poster_path = '' OR poster_path LIKE $4 || '%')
@@ -1607,7 +1607,7 @@ func (r *ItemRepository) UpdateArtworkIfSourceMatches(ctx context.Context, conte
 			UPDATE media_items
 			SET poster_path = $3,
 				poster_source_path = $2,
-				poster_thumbhash = NULLIF($4, ''),
+				poster_thumbhash = $4,
 				updated_at = NOW()
 			WHERE content_id = $1
 			  AND poster_source_path = $2`
@@ -1617,7 +1617,7 @@ func (r *ItemRepository) UpdateArtworkIfSourceMatches(ctx context.Context, conte
 			UPDATE media_items
 			SET backdrop_path = $3,
 				backdrop_source_path = $2,
-				backdrop_thumbhash = NULLIF($4, ''),
+				backdrop_thumbhash = $4,
 				updated_at = NOW()
 			WHERE content_id = $1
 			  AND backdrop_source_path = $2`

--- a/migrations/sql/20260626190132_media_items_nonnull_scalar_columns.sql
+++ b/migrations/sql/20260626190132_media_items_nonnull_scalar_columns.sql
@@ -1,0 +1,89 @@
+-- +goose Up
+-- media_items has many columns that the Go model (models.MediaItem) declares as
+-- non-pointer string/int fields, yet migration 001 left them nullable. Every
+-- scanner — catalog item_repo, catalog browse, jellycompat, sections, and the
+-- catalog API handler — scans these straight into the non-pointer fields, so a
+-- NULL row panics with "cannot scan NULL into *string" (or *int). item_repo
+-- papers over a subset (poster/backdrop/logo/metadata paths) with COALESCE in
+-- its SELECT list, but the other four scanners read the same columns raw and
+-- crash; sort_title/original_title/etc. are not coalesced anywhere.
+--
+-- No writer stores a meaningful NULL: every insert/upsert passes the Go field
+-- ('' or 0 at worst), and all sort/filter SQL already collapses NULL and ''
+-- (COALESCE(NULLIF(BTRIM(sort_title), ''), title); "poster_path IS NULL OR
+-- poster_path = ''"; etc.). The only deliberate NULLs are poster_thumbhash /
+-- backdrop_thumbhash written via NULLIF($, '') in item_repo; those writers are
+-- updated in the same change to store '' directly. NULL rows otherwise arise
+-- only from raw SQL inserts and legacy data.
+--
+-- Enforce the invariant the code already assumes so the whole class of NULL-scan
+-- crash is fixed in one place rather than scattering COALESCE across every
+-- current and future scanner. This mirrors what later migrations already did for
+-- original_language, show_status, default_metadata_language, and the *_source_path
+-- columns (all NOT NULL DEFAULT '').
+
+-- Backfill existing NULLs to the type-appropriate empty value.
+UPDATE media_items SET
+    sort_title         = COALESCE(sort_title, ''),
+    original_title     = COALESCE(original_title, ''),
+    content_rating     = COALESCE(content_rating, ''),
+    overview           = COALESCE(overview, ''),
+    tagline            = COALESCE(tagline, ''),
+    imdb_id            = COALESCE(imdb_id, ''),
+    tmdb_id            = COALESCE(tmdb_id, ''),
+    tvdb_id            = COALESCE(tvdb_id, ''),
+    poster_path        = COALESCE(poster_path, ''),
+    poster_thumbhash   = COALESCE(poster_thumbhash, ''),
+    backdrop_path      = COALESCE(backdrop_path, ''),
+    backdrop_thumbhash = COALESCE(backdrop_thumbhash, ''),
+    logo_path          = COALESCE(logo_path, ''),
+    metadata_s3_path   = COALESCE(metadata_s3_path, ''),
+    metadata_etag      = COALESCE(metadata_etag, '')
+WHERE sort_title IS NULL OR original_title IS NULL OR content_rating IS NULL
+   OR overview IS NULL OR tagline IS NULL OR imdb_id IS NULL OR tmdb_id IS NULL
+   OR tvdb_id IS NULL OR poster_path IS NULL OR poster_thumbhash IS NULL
+   OR backdrop_path IS NULL OR backdrop_thumbhash IS NULL OR logo_path IS NULL
+   OR metadata_s3_path IS NULL OR metadata_etag IS NULL;
+
+UPDATE media_items SET year = 0 WHERE year IS NULL;
+UPDATE media_items SET runtime = 0 WHERE runtime IS NULL;
+
+-- Establish defaults and NOT NULL atomically (single ACCESS EXCLUSIVE lock).
+ALTER TABLE media_items
+    ALTER COLUMN sort_title         SET DEFAULT '', ALTER COLUMN sort_title         SET NOT NULL,
+    ALTER COLUMN original_title     SET DEFAULT '', ALTER COLUMN original_title     SET NOT NULL,
+    ALTER COLUMN content_rating     SET DEFAULT '', ALTER COLUMN content_rating     SET NOT NULL,
+    ALTER COLUMN overview           SET DEFAULT '', ALTER COLUMN overview           SET NOT NULL,
+    ALTER COLUMN tagline            SET DEFAULT '', ALTER COLUMN tagline            SET NOT NULL,
+    ALTER COLUMN imdb_id            SET DEFAULT '', ALTER COLUMN imdb_id            SET NOT NULL,
+    ALTER COLUMN tmdb_id            SET DEFAULT '', ALTER COLUMN tmdb_id            SET NOT NULL,
+    ALTER COLUMN tvdb_id            SET DEFAULT '', ALTER COLUMN tvdb_id            SET NOT NULL,
+    ALTER COLUMN poster_path        SET DEFAULT '', ALTER COLUMN poster_path        SET NOT NULL,
+    ALTER COLUMN poster_thumbhash   SET DEFAULT '', ALTER COLUMN poster_thumbhash   SET NOT NULL,
+    ALTER COLUMN backdrop_path      SET DEFAULT '', ALTER COLUMN backdrop_path      SET NOT NULL,
+    ALTER COLUMN backdrop_thumbhash SET DEFAULT '', ALTER COLUMN backdrop_thumbhash SET NOT NULL,
+    ALTER COLUMN logo_path          SET DEFAULT '', ALTER COLUMN logo_path          SET NOT NULL,
+    ALTER COLUMN metadata_s3_path   SET DEFAULT '', ALTER COLUMN metadata_s3_path   SET NOT NULL,
+    ALTER COLUMN metadata_etag      SET DEFAULT '', ALTER COLUMN metadata_etag      SET NOT NULL,
+    ALTER COLUMN year               SET DEFAULT 0,  ALTER COLUMN year               SET NOT NULL,
+    ALTER COLUMN runtime            SET DEFAULT 0,  ALTER COLUMN runtime            SET NOT NULL;
+
+-- +goose Down
+ALTER TABLE media_items
+    ALTER COLUMN sort_title         DROP NOT NULL, ALTER COLUMN sort_title         DROP DEFAULT,
+    ALTER COLUMN original_title     DROP NOT NULL, ALTER COLUMN original_title     DROP DEFAULT,
+    ALTER COLUMN content_rating     DROP NOT NULL, ALTER COLUMN content_rating     DROP DEFAULT,
+    ALTER COLUMN overview           DROP NOT NULL, ALTER COLUMN overview           DROP DEFAULT,
+    ALTER COLUMN tagline            DROP NOT NULL, ALTER COLUMN tagline            DROP DEFAULT,
+    ALTER COLUMN imdb_id            DROP NOT NULL, ALTER COLUMN imdb_id            DROP DEFAULT,
+    ALTER COLUMN tmdb_id            DROP NOT NULL, ALTER COLUMN tmdb_id            DROP DEFAULT,
+    ALTER COLUMN tvdb_id            DROP NOT NULL, ALTER COLUMN tvdb_id            DROP DEFAULT,
+    ALTER COLUMN poster_path        DROP NOT NULL, ALTER COLUMN poster_path        DROP DEFAULT,
+    ALTER COLUMN poster_thumbhash   DROP NOT NULL, ALTER COLUMN poster_thumbhash   DROP DEFAULT,
+    ALTER COLUMN backdrop_path      DROP NOT NULL, ALTER COLUMN backdrop_path      DROP DEFAULT,
+    ALTER COLUMN backdrop_thumbhash DROP NOT NULL, ALTER COLUMN backdrop_thumbhash DROP DEFAULT,
+    ALTER COLUMN logo_path          DROP NOT NULL, ALTER COLUMN logo_path          DROP DEFAULT,
+    ALTER COLUMN metadata_s3_path   DROP NOT NULL, ALTER COLUMN metadata_s3_path   DROP DEFAULT,
+    ALTER COLUMN metadata_etag      DROP NOT NULL, ALTER COLUMN metadata_etag      DROP DEFAULT,
+    ALTER COLUMN year               DROP NOT NULL, ALTER COLUMN year               DROP DEFAULT,
+    ALTER COLUMN runtime            DROP NOT NULL, ALTER COLUMN runtime            DROP DEFAULT;


### PR DESCRIPTION
## Problem

`media_items` has many columns the Go model (`models.MediaItem`) declares as **non-pointer** `string`/`int` fields, but migration 001 left them **nullable**. Five scanners across four packages read these straight into the non-pointer fields, so any NULL row panics with `cannot scan NULL into *string` (or `*int`):

- `internal/catalog/item_repo.go` (`scanItem`/`scanItems`/`scanItemsWithMangaCounts`)
- `internal/catalog/browse.go` (`scanBrowseItems`)
- `internal/jellycompat/batch_loaders.go` (`scanCompatMediaItems`)
- `internal/sections/fetcher.go`
- `internal/api/handlers/catalog.go`

`item_repo` papers over a *subset* (poster/backdrop/logo/metadata paths) with `COALESCE` in its SELECT, but the other four scanners read the same columns raw and crash; `sort_title`/`original_title`/etc. aren't coalesced anywhere. The thumbhash columns are the worst case: `SetLocalPoster`/`UpdateArtworkIfSourceMatches` *deliberately* wrote NULL via `NULLIF($,'')`, so browse/jellycompat could crash on real production rows, not just test data.

Reproduces today on `main`: `internal/catalog` `TestFilterCollectionItemsByDisplayQuery` fails with `cannot scan NULL into *string` because its seed inserts a minimal row (omitting the nullable columns).

## Why this approach

Make the **schema enforce the invariant the code already assumes**: every `media_items` column the Go model treats as non-nullable is `NOT NULL`. This fixes all five scanners (and any future one) in one place instead of scattering `COALESCE` across four packages — the "duplicate logic across multiple files" smell.

Safe because:
- **No writer stores a meaningful NULL** — every insert/upsert passes the Go field (`''`/`0` at worst). The only deliberate NULL writers were the two thumbhash `NULLIF` sites, updated here.
- **`''`/NULL are already treated identically** everywhere — all sort/filter SQL uses `COALESCE(NULLIF(BTRIM(sort_title), ''), title)`, and every `IS NULL` usage is `(x IS NULL OR x = '')` or guarded by `<> ''`. No `IS NULL` logic exists on `year`/`runtime`.
- Mirrors what later migrations **already did** for `original_language`, `show_status`, `default_metadata_language`, and the `*_source_path` columns (all `NOT NULL DEFAULT ''`).

## Changes

- **Migration** `20260626190132_media_items_nonnull_scalar_columns.sql`: backfill existing NULLs, then `NOT NULL DEFAULT ''` on 15 text columns (`sort_title`, `original_title`, `content_rating`, `overview`, `tagline`, `imdb_id`/`tmdb_id`/`tvdb_id`, `poster_path`, `poster_thumbhash`, `backdrop_path`, `backdrop_thumbhash`, `logo_path`, `metadata_s3_path`, `metadata_etag`) and `NOT NULL DEFAULT 0` on `year`/`runtime`. Single `ALTER TABLE` (one `ACCESS EXCLUSIVE` lock); reversible `Down`.
- **`internal/catalog/item_repo.go`**: `SetLocalPoster` and `UpdateArtworkIfSourceMatches` store `''` for empty thumbhashes (was `NULLIF($,'')`), matching the `upsert` path.

Genuinely-nullable pointer fields (ratings, dates, `season_count`, `air_*`) and `genres` (NULL arrays scan fine) are left untouched.

## Verification

Against a fresh, fully-migrated Postgres:
- `TestFilterCollectionItemsByDisplayQuery` passes; full `catalog` suite passes (DB-backed)
- `scanner` + `metadata` writer tests pass (cover the `NULLIF`→direct change); `sections` passes
- `go build ./...`, `gofmt`, `go vet` clean
- Down/Up rollback cycle clean both directions
- Minimal raw insert (the production NULL scenario) now yields `''`/`0` for every column

## Risks / follow-up

- Low risk; `SET NOT NULL` does a one-time validating scan (small on current data).
- Out of scope (harmless): the now-NOT-NULL path columns still sit in `nullableStringItemColumns`, so their SELECT `COALESCE` is now redundant — consistent with how `*_source_path` was already handled there.
- Not linked to a capability epic — standalone correctness/reliability fix. Please add a `Part of #NNN` if there's a relevant scope item.

## AI-use disclosure

Diagnosed, implemented, and verified with Claude Code (Claude Opus 4.8).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of artwork thumbnail data so empty values are stored consistently instead of being dropped.
  * Added a database update to normalize existing media item fields and enforce safer defaults for required values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->