### PR TITLE
fix(recommendations): make embedding backfill job timeout configurable

### DIFF
--- a/cmd/silo/main.go
+++ b/cmd/silo/main.go
@@ -1521,6 +1521,7 @@ func main() {
 			cfg.Recommendations.TasteProfilesCron,
 			cfg.Recommendations.CowatchCron,
 			cfg.Recommendations.RecommendationsCron,
+			cfg.Recommendations.EmbeddingsJobTimeout,
 		)
 		if err != nil {
 			slog.Error("failed to create recommendation worker", "error", err)

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -246,6 +246,10 @@ type RecommendationsConfig struct {
 	TasteDecayHalfLifeDays float64 `yaml:"-"`
 	DiversityLambda        float64 `yaml:"-"`
 	CowatchCron            string  `yaml:"-"`
+	// EmbeddingsJobTimeout bounds a single embedding backfill run. A local
+	// CPU embedder over a large catalog needs hours, so this defaults to 24h
+	// (replacing a hardcoded 30m that truncated large first-run backfills).
+	EmbeddingsJobTimeout time.Duration `yaml:"-"`
 }
 
 // AIConfig holds the shared connection settings for Silo's AI features

--- a/internal/config/db_loader.go
+++ b/internal/config/db_loader.go
@@ -413,6 +413,10 @@ func LoadFromDB(m map[string]string) (*Config, error) {
 	}())
 	cfg.Recommendations.EmbeddingAuthToken = stringOr(m, "recommendations.embedding_auth_token", stringOr(m, "recommendations.openai_api_key", ""))
 	cfg.Recommendations.EmbeddingsCron = stringOr(m, "recommendations.embeddings_cron", "0 3 * * *")
+	cfg.Recommendations.EmbeddingsJobTimeout, err = durationOr(m, "recommendations.embeddings_job_timeout", 24*time.Hour)
+	if err != nil {
+		return nil, err
+	}
 	cfg.Recommendations.TasteProfilesCron = stringOr(m, "recommendations.taste_profiles_cron", "0 4 * * *")
 	cfg.Recommendations.RecommendationsCron = stringOr(m, "recommendations.recommendations_cron", "0 5 * * *")
 	tasteDecayHalfLife, err := floatOr(m, "recommendations.taste_decay_half_life_days", 180)

--- a/internal/recommendations/worker.go
+++ b/internal/recommendations/worker.go
@@ -29,6 +29,7 @@ type Worker struct {
 	profileRefreshCh      chan profileRefreshRequest
 	profileRefreshPending map[string]struct{}
 	cancelFunc            context.CancelFunc
+	embeddingsJobTimeout  time.Duration
 }
 
 const tasteProfileRefreshSubjectsQuery = `
@@ -45,13 +46,17 @@ const tasteProfileRefreshSubjectsQuery = `
 	SELECT DISTINCT user_id, profile_id FROM user_watchlist`
 
 // NewWorker creates a new recommendation Worker.
-func NewWorker(engine *Engine, embeddingsCron, tasteProfilesCron, cowatchCron, recommendationsCron string) (*Worker, error) {
+func NewWorker(engine *Engine, embeddingsCron, tasteProfilesCron, cowatchCron, recommendationsCron string, embeddingsJobTimeout time.Duration) (*Worker, error) {
+	if embeddingsJobTimeout <= 0 {
+		embeddingsJobTimeout = 24 * time.Hour
+	}
 	w := &Worker{
 		engine:                engine,
 		cron:                  cron.New(),
 		running:               make(map[JobName]bool),
 		profileRefreshCh:      make(chan profileRefreshRequest, 256),
 		profileRefreshPending: make(map[string]struct{}),
+		embeddingsJobTimeout:  embeddingsJobTimeout,
 	}
 
 	if _, err := w.cron.AddFunc(embeddingsCron, w.runEmbeddings); err != nil {
@@ -123,9 +128,9 @@ func (w *Worker) TriggerEmbeddings() error {
 	}
 	go func() {
 		defer w.setRunning(JobEmbeddings, false)
-		ctx, cancel := context.WithTimeout(context.Background(), 30*time.Minute)
+		ctx, cancel := context.WithTimeout(context.Background(), w.embeddingsJobTimeout)
 		defer cancel()
-		slog.Info("starting embedding job (manual trigger)")
+		slog.Info("starting embedding job (manual trigger)", "timeout", w.embeddingsJobTimeout)
 		count, err := w.engine.EmbedAll(ctx)
 		if err != nil {
 			slog.Error("embedding job failed", "error", err, "embedded", count)
@@ -236,9 +241,9 @@ func (w *Worker) runEmbeddings() {
 	}
 	defer w.setRunning(JobEmbeddings, false)
 
-	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Minute)
+	ctx, cancel := context.WithTimeout(context.Background(), w.embeddingsJobTimeout)
 	defer cancel()
-	slog.Info("starting embedding job")
+	slog.Info("starting embedding job", "timeout", w.embeddingsJobTimeout)
 	count, err := w.engine.EmbedAll(ctx)
 	if err != nil {
 		slog.Error("embedding job failed", "error", err, "embedded", count)


### PR DESCRIPTION
## Problem

The embedding backfill — both the manual `TriggerEmbeddings` and the cron-scheduled `runEmbeddings` — runs under a **hardcoded 30-minute context**:

```go
ctx, cancel := context.WithTimeout(context.Background(), 30*time.Minute)
count, err := w.engine.EmbedAll(ctx)
```

That budget is fine for a fast hosted embedding API, but it breaks **local / self-hosted embedders** (e.g. Ollama running on CPU), which are an order of magnitude slower. On a large catalog the run embeds only a few thousand items before the deadline fires and the job aborts with:

```
ERROR embedding job failed  error="context deadline exceeded"  embedded=5130
```

Concretely: a ~138k-item library against `qwen3-embedding:0.6b` on a CPU-only box embeds at ~3 items/sec, so a single run covers only ~3–4% before timing out. The job is idempotent and resumable (it skips already-embedded items via `ItemsNeedingEmbedding`), so no progress is lost — but it never completes without an operator re-triggering it ~28 times. `EmbedAll` is sequential, so raising the embedder's parallelism doesn't help; the wall-clock cap is the real limit.

## Change

Make the per-run timeout configurable via a new `recommendations.embeddings_job_timeout` setting (default **24h**), threaded `RecommendationsConfig` → `NewWorker` and applied to **both** the manual trigger and the scheduled run. A non-positive value falls back to 24h.

- `internal/config/config.go` — new `EmbeddingsJobTimeout time.Duration` field
- `internal/config/db_loader.go` — load `recommendations.embeddings_job_timeout` via the existing `durationOr` helper (default `24*time.Hour`)
- `internal/recommendations/worker.go` — new `Worker.embeddingsJobTimeout` field + `NewWorker` param; both `EmbedAll` sites use it; logs the effective timeout
- `cmd/silo/main.go` — pass the configured value through

## Why this approach

Minimal and additive. Default behavior is **unchanged for hosted users** — a full backfill comfortably fits in 24h — while local-LLM users can complete a one-shot backfill instead of stalling, and any operator can tune the budget without a code change. Reuses the existing `durationOr` settings helper and the established `recommendations.*` config-loading pattern.

## Risk / follow-up

- Low risk: pure timeout plumbing; no schema or API changes. The job remains guarded by `tryStart(JobEmbeddings)`, so a longer window simply means one in-flight run instead of many truncated ones.
- The new setting is read at startup like the rest of `recommendations.*` (restart to change).
- Not addressed here (possible follow-ups): batch-size tuning / concurrent embedding requests for throughput, and auto-re-triggering on partial completion.

## Testing

- Builds clean (`go build ./cmd/silo`).
- Verified on a live deployment: with the 24h default, a single triggered run logs `starting embedding job (manual trigger) timeout=24h0m0s` and proceeds past the previous 30-minute wall, where it previously aborted at ~3.6% coverage.

AI-use disclosure: implemented with assistance from Claude Code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Increased the default time allowed for large embeddings backfill jobs to help them complete more reliably.
  * Made the embeddings job timeout configurable, giving deployments more control over long-running runs.

* **Bug Fixes**
  * Embeddings jobs now use the configured timeout instead of a fixed shorter limit.
  * Job start logs now include the timeout value for easier monitoring.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->