### PR TITLE
fix(api): show symlinked directories in the folder browser

### DIFF
--- a/internal/api/handlers/filesystem.go
+++ b/internal/api/handlers/filesystem.go
@@ -56,14 +56,29 @@ func (h *FilesystemHandler) HandleBrowse(w http.ResponseWriter, r *http.Request)
 
 	result := make([]filesystemBrowseEntry, 0, len(entries))
 	for _, entry := range entries {
+		name := entry.Name()
+		childPath := filepath.Join(cleaned, name)
+
+		// entry.IsDir() reports the lstat type, so a symlink that points at a
+		// directory is reported as a non-directory and would be skipped here.
+		// For symlinks, follow the link with os.Stat and include the entry only
+		// when its target resolves to a directory; this keeps symlinked library
+		// folders browsable (issue #208) while excluding symlinks to files and
+		// dangling symlinks (os.Stat fails). Non-symlink, non-directory entries
+		// take the fast path with no extra syscall.
 		if !entry.IsDir() {
-			continue
+			if entry.Type()&os.ModeSymlink == 0 {
+				continue
+			}
+			target, err := os.Stat(childPath)
+			if err != nil || !target.IsDir() {
+				continue
+			}
 		}
 
-		name := entry.Name()
 		result = append(result, filesystemBrowseEntry{
 			Name: name,
-			Path: filepath.Join(cleaned, name),
+			Path: childPath,
 		})
 	}
 

--- a/internal/api/handlers/filesystem_test.go
+++ b/internal/api/handlers/filesystem_test.go
@@ -1,0 +1,114 @@
+package handlers
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"runtime"
+	"testing"
+)
+
+// browseNames runs HandleBrowse against the given path and returns the names of
+// the entries reported in the response. It fails the test on any non-200 status.
+func browseNames(t *testing.T, path string) []string {
+	t.Helper()
+
+	h := NewFilesystemHandler()
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/filesystem/browse?path="+path, nil)
+	q := req.URL.Query()
+	q.Set("path", path)
+	req.URL.RawQuery = q.Encode()
+
+	rec := httptest.NewRecorder()
+	h.HandleBrowse(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("HandleBrowse(%q) status = %d, want 200; body=%s", path, rec.Code, rec.Body.String())
+	}
+
+	var resp filesystemBrowseResponse
+	if err := json.Unmarshal(rec.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("decode response: %v; body=%s", err, rec.Body.String())
+	}
+
+	names := make([]string, 0, len(resp.Entries))
+	for _, e := range resp.Entries {
+		names = append(names, e.Name)
+	}
+	return names
+}
+
+func contains(names []string, want string) bool {
+	for _, n := range names {
+		if n == want {
+			return true
+		}
+	}
+	return false
+}
+
+// TestHandleBrowseFollowsSymlinkedDirectories is the regression test for #208:
+// a folder whose children include a symlink pointing at a real directory must
+// list that symlink in the picker, while symlinks to files and dangling
+// symlinks must be excluded.
+func TestHandleBrowseFollowsSymlinkedDirectories(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("symlink semantics differ on windows")
+	}
+
+	root := t.TempDir()
+
+	// Real subdirectory (control — already worked).
+	if err := os.Mkdir(filepath.Join(root, "real-dir"), 0o755); err != nil {
+		t.Fatalf("mkdir real-dir: %v", err)
+	}
+
+	// A regular file (must be excluded).
+	if err := os.WriteFile(filepath.Join(root, "file.txt"), []byte("x"), 0o644); err != nil {
+		t.Fatalf("write file: %v", err)
+	}
+
+	// Target directory living outside the browsed root, then a symlink to it —
+	// this mirrors the issue's bind-mounted symlinks into a FUSE mount.
+	target := filepath.Join(t.TempDir(), "Africa (2013)")
+	if err := os.Mkdir(target, 0o755); err != nil {
+		t.Fatalf("mkdir target: %v", err)
+	}
+	if err := os.Symlink(target, filepath.Join(root, "symlink-dir")); err != nil {
+		t.Fatalf("symlink dir: %v", err)
+	}
+
+	// Symlink to a file (must be excluded — it is not a directory).
+	fileTarget := filepath.Join(t.TempDir(), "movie.mkv")
+	if err := os.WriteFile(fileTarget, []byte("x"), 0o644); err != nil {
+		t.Fatalf("write file target: %v", err)
+	}
+	if err := os.Symlink(fileTarget, filepath.Join(root, "symlink-file")); err != nil {
+		t.Fatalf("symlink file: %v", err)
+	}
+
+	// Dangling symlink (must be excluded — os.Stat fails).
+	if err := os.Symlink(filepath.Join(t.TempDir(), "missing"), filepath.Join(root, "dangling")); err != nil {
+		t.Fatalf("symlink dangling: %v", err)
+	}
+
+	names := browseNames(t, root)
+
+	if !contains(names, "real-dir") {
+		t.Errorf("real-dir missing from browse entries: %v", names)
+	}
+	if !contains(names, "symlink-dir") {
+		t.Errorf("symlink-dir (symlink to a directory) missing from browse entries: %v", names)
+	}
+	if contains(names, "file.txt") {
+		t.Errorf("file.txt should not appear in folder browse entries: %v", names)
+	}
+	if contains(names, "symlink-file") {
+		t.Errorf("symlink-file (symlink to a file) should not appear in folder browse entries: %v", names)
+	}
+	if contains(names, "dangling") {
+		t.Errorf("dangling symlink should not appear in folder browse entries: %v", names)
+	}
+}


### PR DESCRIPTION
## Problem

The library folder browser (`Browse Library Folders` dialog) does not show
symlinked directories. With Silo in Docker bind-mounting a folder of symlinks
into an rclone/FUSE mount, the symlinked subfolders never appear in the picker,
even though the targets are valid, readable directories (and manually typing the
full symlink path and pressing Browse works fine).

Root cause: `internal/api/handlers/filesystem.go` listed children with
`entry.IsDir()`. `os.ReadDir` returns `DirEntry`s whose `IsDir()` reflects the
**lstat** type, so a symlink that points at a directory is reported as a
non-directory and silently skipped. The top-level path already used `os.Stat`
(which follows symlinks) — that asymmetry is exactly why typing the symlink path
directly worked but browsing its parent did not.

Reproduced with a table-driven test that builds a temp dir containing a real
subdir, a regular file, a symlink-to-directory, a symlink-to-file, and a
dangling symlink, then calls `HandleBrowse`. On `main` the symlink-to-directory
is absent (red); with the fix it appears (green).

## Approach

For each child, keep the fast path for real directories. For symlink entries
(`entry.Type()&os.ModeSymlink != 0`), follow the link with `os.Stat` and include
the entry only when the target resolves to a directory.

This is the smallest correct change and stays performance-conscious: the extra
`os.Stat` syscall is incurred **only** for symlinks, not for every regular file.
It also naturally excludes the cases that should stay hidden — symlinks to files
(`IsDir()` false) and dangling symlinks (`os.Stat` errors). Listing remains one
level deep, so there is no symlink-loop/recursion concern. The `/api/v1` response
shape is unchanged (additive behavior only: previously-omitted valid entries now
appear).

## Verification

Commands run in the worktree (`GOWORK=off`, `web/dist` stubbed per repo worktree
quirks):

- `go test ./internal/api/handlers/ -run TestHandleBrowseFollowsSymlinkedDirectories` — **red on `main`** (`symlink-dir … missing`), **green after fix**.
- `go test ./internal/api/handlers/ -count=1` — full package suite **passes**.
- `go build ./internal/... ./cmd/...` — clean.
- `golangci-lint` (v2) on the package — **zero findings in `filesystem.go`** (only the pre-existing package baseline elsewhere).
- `gofmt`/`goimports` clean; `make verify-local-paths` clean.

## Adversarial review

Codex adversarial review (`--base main`): **approve, no material findings**. It
independently confirmed only symlink-to-directory targets are followed; symlink-
to-file, dangling, and ELOOP cases are excluded via `os.Stat` failure/non-dir
checks; the listing stays one level deep; and the endpoint remains behind the
existing acting-admin route. Its sole note was to run the Go test in a writable
environment, which was done above.

## Risks & follow-up

- Backend-only. No `web/` changes — the existing folder-browser UI renders
  whatever entries the API returns, so no before/after UI media applies.
- No API contract change (no field renamed/removed/retyped; no status-code
  change). No migration.
- No `silo-android` / `silo-apple` follow-up: the response schema is unchanged;
  clients simply receive the previously-missing valid directory entries.

Closes #208

## AI-use disclosure
Implemented by Claude Code (issue-to-pr skill) with human oversight.

🤖 Generated with [Claude Code](https://claude.com/claude-code)