### PR TITLE
fix(catalog): exclude manga chapters from admin Unmatched queue (#204)

### DIFF
--- a/internal/api/handlers/libraries.go
+++ b/internal/api/handlers/libraries.go
@@ -2495,10 +2495,17 @@ func (h *LibraryHandler) HandleListUnmatchedItems(w http.ResponseWriter, r *http
 		)`
 	}
 
+	// Manga chapters are type='ebook' rows linked into a manga series via
+	// manga_chapters. They are internal sub-units that keep a non-matched status,
+	// so without this guard they leak into the admin Unmatched queue (issue #204).
+	// Applied to both the count and the list query so the total stays consistent.
+	statusWhere := `WHERE mi.status IN ('unmatched', 'pending', 'ambiguous')
+			AND ` + catalog.MangaChapterExclusionWhere("mi")
+
 	countSQL := `
 		SELECT COUNT(*)
 		FROM media_items mi
-		WHERE mi.status IN ('unmatched', 'pending', 'ambiguous')`
+		` + statusWhere
 	countSQL += filter
 
 	var total int
@@ -2521,10 +2528,10 @@ func (h *LibraryHandler) HandleListUnmatchedItems(w http.ResponseWriter, r *http
 			WHERE mil.content_id = mi.content_id
 			LIMIT 1
 		) lib ON true
-		WHERE mi.status IN ('unmatched', 'pending', 'ambiguous')%s
+		%s%s
 		ORDER BY mi.title ASC, mi.content_id ASC
 		LIMIT $%d OFFSET $%d
-	`, filter, len(filterArgs)+1, len(filterArgs)+2)
+	`, statusWhere, filter, len(filterArgs)+1, len(filterArgs)+2)
 
 	rows, err := h.pool.Query(r.Context(), listSQL, listArgs...)
 	if err != nil {

--- a/internal/api/handlers/libraries_unmatched_manga_test.go
+++ b/internal/api/handlers/libraries_unmatched_manga_test.go
@@ -1,0 +1,130 @@
+package handlers
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/go-chi/chi/v5"
+	"github.com/jackc/pgx/v5/pgxpool"
+)
+
+// newUnmatchedTestPool connects to the test database used for DB-backed handler
+// tests. It skips when SILO_TEST_DATABASE_URL is unset or the manga_chapters
+// migration has not been applied, mirroring the literaryworks repository tests.
+func newUnmatchedTestPool(t *testing.T) *pgxpool.Pool {
+	t.Helper()
+	dsn := os.Getenv("SILO_TEST_DATABASE_URL")
+	if dsn == "" {
+		t.Skip("SILO_TEST_DATABASE_URL is not set")
+	}
+	ctx := context.Background()
+	pool, err := pgxpool.New(ctx, dsn)
+	if err != nil {
+		t.Fatalf("connect test database: %v", err)
+	}
+	t.Cleanup(pool.Close)
+	var tableName *string
+	if err := pool.QueryRow(ctx, `SELECT to_regclass('public.manga_chapters')::text`).Scan(&tableName); err != nil {
+		t.Fatalf("check manga_chapters table: %v", err)
+	}
+	if tableName == nil || *tableName == "" {
+		t.Skip("test database has not applied manga_chapters migration")
+	}
+	return pool
+}
+
+// TestHandleListUnmatchedItems_ExcludesMangaChapters verifies that manga chapter
+// rows (type='ebook' linked into a manga series via manga_chapters) are hidden
+// from the admin Unmatched queue, while genuinely unmatched standalone items are
+// still returned. This is the regression guard for issue #204: matched manga
+// items were leaking into the queue because the chapter rows kept a non-matched
+// status and the queries lacked the MangaChapterExclusionWhere guard.
+func TestHandleListUnmatchedItems_ExcludesMangaChapters(t *testing.T) {
+	ctx := context.Background()
+	pool := newUnmatchedTestPool(t)
+
+	suffix := time.Now().UnixNano()
+	seriesID := fmt.Sprintf("manga-series-%d", suffix)
+	chapterID := fmt.Sprintf("manga-chapter-%d", suffix)
+	ebookID := fmt.Sprintf("standalone-ebook-%d", suffix)
+
+	t.Cleanup(func() {
+		_, _ = pool.Exec(ctx, `DELETE FROM manga_chapters WHERE chapter_content_id = $1`, chapterID)
+		_, _ = pool.Exec(ctx, `DELETE FROM media_items WHERE content_id = ANY($1)`, []string{seriesID, chapterID, ebookID})
+	})
+
+	seed := func(contentID, mediaType, title, status string) {
+		t.Helper()
+		if _, err := pool.Exec(ctx, `
+			INSERT INTO media_items (content_id, type, title, status, genres)
+			VALUES ($1, $2, $3, $4, '{}'::text[])
+		`, contentID, mediaType, title, status); err != nil {
+			t.Fatalf("seed media item %s: %v", contentID, err)
+		}
+	}
+
+	// Titles embed the unique suffix so the search filter below scopes the
+	// query to exactly these seeded rows in the shared test database.
+	tag := fmt.Sprintf("issue204-%d", suffix)
+	// The matched manga series is correctly out of the queue already.
+	seed(seriesID, "manga", "Attack on Titan "+tag, "matched")
+	// The chapter row is a type='ebook' sub-unit that stays in a non-matched
+	// status; before the fix it leaked into the queue.
+	seed(chapterID, "ebook", "Attack on Titan Ch. 1 "+tag, "pending")
+	// A genuinely unmatched standalone ebook must still appear in the queue.
+	seed(ebookID, "ebook", "Some Loose Ebook "+tag, "unmatched")
+
+	if _, err := pool.Exec(ctx, `
+		INSERT INTO manga_chapters (chapter_content_id, series_content_id, chapter_index)
+		VALUES ($1, $2, 1)
+	`, chapterID, seriesID); err != nil {
+		t.Fatalf("link manga chapter: %v", err)
+	}
+
+	h := &LibraryHandler{pool: pool}
+	r := chi.NewRouter()
+	r.Get("/libraries/unmatched-items", h.HandleListUnmatchedItems)
+
+	// Scope the query to our seeded rows via the search filter so the assertion
+	// is robust against other data in the shared test database.
+	req := httptest.NewRequest(http.MethodGet, "/libraries/unmatched-items?q="+tag, nil)
+	rec := httptest.NewRecorder()
+	r.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", rec.Code, rec.Body.String())
+	}
+
+	var resp unmatchedItemsListResponse
+	if err := json.NewDecoder(rec.Body).Decode(&resp); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+
+	for _, item := range resp.Items {
+		if item.ContentID == chapterID {
+			t.Errorf("manga chapter %s leaked into the Unmatched queue", chapterID)
+		}
+	}
+
+	foundStandalone := false
+	for _, item := range resp.Items {
+		if item.ContentID == ebookID {
+			foundStandalone = true
+		}
+	}
+	if !foundStandalone {
+		t.Errorf("standalone unmatched ebook %s missing from the queue", ebookID)
+	}
+
+	// Total must also exclude the chapter: only the standalone ebook matches the
+	// scoped search, so the count is exactly 1.
+	if resp.Total != 1 {
+		t.Errorf("Total = %d, want 1 (chapter must be excluded from the count too)", resp.Total)
+	}
+}


### PR DESCRIPTION
## Problem
With the Manga plugin enabled, successfully matched manga items stayed stuck in the admin **Unmatched Items** queue and were displayed with Type `ebook` instead of `manga` (#204).

Root cause: manga *chapters* are stored as `type='ebook'` rows linked into a `type='manga'` series via the `manga_chapters` table. These chapter rows keep a non-matched status (`pending`/`unmatched`/`ambiguous`). `HandleListUnmatchedItems` in `internal/api/handlers/libraries.go` built its count and list queries (alias `mi`) filtering only on status, *without* the manga-chapter exclusion guard that every other catalog listing surface already applies. So the chapter sub-units leaked into the admin queue and surfaced as generic ebooks.

Reproduced with a DB-backed handler test: a seeded manga series + a `pending` chapter linked via `manga_chapters` + a genuinely unmatched standalone ebook. Before the fix the chapter leaks in (`Total = 2`); after the fix only the standalone ebook is returned (`Total = 1`).

## Approach
Apply the existing, well-documented `catalog.MangaChapterExclusionWhere("mi")` predicate — the same index-backed anti-join used across browse, sections, discovery, favorites, and search — to a single shared `WHERE` clause consumed by **both** the count and the list query. Sharing one clause (rather than duplicating the predicate in two string literals) keeps the count and the page consistent and avoids the drift that caused this bug class. The predicate takes no SQL parameters, so the existing `$1` (search) / limit / offset placeholder ordering is unchanged. Smallest correct change; no API/contract change, no migration.

## Verification
Commands run from the worktree (`GOWORK=off`, stubbed `web/dist`, DB-backed via `SILO_TEST_DATABASE_URL`):
- `go build ./internal/... ./cmd/...` → clean.
- New regression test `TestHandleListUnmatchedItems_ExcludesMangaChapters`: **fails on main** (chapter leaks, `Total=2`) → **passes after the fix** (`Total=1`).
- `go test ./internal/api/handlers/...` → `ok` (full package, no regressions).
- `golangci-lint v2 run ./internal/api/handlers/...` → identical 123 pre-existing issues on branch and base `main`; **zero new** issues, none in the changed lines or the new test file.
- `make verify-local-paths` → clean.

## Adversarial review
Codex adversarial review (`--base main`) verdict: **approve — no material findings**. It independently confirmed SQL parameter ordering is preserved ($1 search, then limit/offset), that the count and list now share the same status-plus-manga-exclusion predicate, that linked manga chapters are excluded, and that standalone ebooks without a `manga_chapters` row still pass.

## Risks & follow-up
- Low risk: read-only query change scoped to one admin endpoint; the predicate is harmless for every non-chapter row (regular ebooks have no `manga_chapters` link; non-ebook types never match).
- No `/api/v1` contract change (response shape unchanged), no DB migration.
- The issue also mentioned chapters appearing with Type `ebook`: that is inherent to how chapter rows are stored; excluding them from the queue is the correct fix, since chapters should never surface as standalone items. The matched *series* already shows as `manga`.
- No `silo-android` / `silo-apple` follow-up: this is an admin-web-only maintenance surface; client-facing catalog listings already applied this guard. No UI screenshots attached — the change is a backend query filter with no visual component beyond fewer rows in the existing admin list.
- Related: this is the canonical fix for near-duplicate #187; the scan-time retry half of the original report was previously fixed by #142.

Closes #204

## AI-use disclosure
Implemented by Claude Code (issue-to-pr skill) with human oversight.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * The “Unmatched” library list now excludes manga chapter entries from both the results and the total count.
  * This keeps pending/unmatched items focused on truly unlinked content.
  
* **Tests**
  * Added regression coverage to verify excluded manga chapter items do not appear in the list while other unmatched items still do.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->