### PR TITLE
fix(player): contain the video element so ASS/PGS/VTT subtitles stop skewing

### DIFF
--- a/web/src/player/components/VideoPlayer.tsx
+++ b/web/src/player/components/VideoPlayer.tsx
@@ -54,6 +54,7 @@ import type {
   SubtitleMode,
 } from "../types";
 import { toMediaTime, toPlayerTime } from "../utils/mediaTimeline";
+import { videoElementClassName } from "../utils/videoElementClassName";
 import { buildWatchTogetherInviteUrl } from "@/lib/watchTogether";
 import { toast } from "sonner";
 
@@ -2279,7 +2280,7 @@ export function VideoPlayer({
           media timeline as restarted HLS playback. */}
       <video
         ref={videoRef}
-        className={isDetached ? "h-full w-full" : "absolute inset-0 h-full w-full"}
+        className={videoElementClassName(isDetached)}
         onClick={displayMode === "postroll" ? undefined : handlePlayPause}
         playsInline
         style={!isPlayerReady ? { visibility: "hidden" } : undefined}

--- a/web/src/player/utils/videoElementClassName.test.ts
+++ b/web/src/player/utils/videoElementClassName.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it } from "vitest";
+import { videoElementClassName } from "./videoElementClassName";
+
+describe("videoElementClassName", () => {
+  // object-contain is the fix for issue #209: without it the video defaults to
+  // object-fit: fill and stretches, skewing the video and its subtitle overlays
+  // (VTT/PGS/ASS all anchor to the contained video area) whenever the player box
+  // is not the video's aspect ratio.
+  it("applies object-contain in the inline/fullscreen layout", () => {
+    const cls = videoElementClassName(false);
+    expect(cls).toContain("object-contain");
+    expect(cls).toContain("absolute");
+    expect(cls).toContain("inset-0");
+    expect(cls).toContain("h-full");
+    expect(cls).toContain("w-full");
+  });
+
+  it("applies object-contain in the detached/floating layout", () => {
+    const cls = videoElementClassName(true);
+    expect(cls).toContain("object-contain");
+    expect(cls).toContain("h-full");
+    expect(cls).toContain("w-full");
+    // The detached player sizes itself inside an aspect-video container, so it
+    // must not pin to the fullscreen frame with absolute inset-0.
+    expect(cls).not.toContain("absolute");
+    expect(cls).not.toContain("inset-0");
+  });
+});

--- a/web/src/player/utils/videoElementClassName.ts
+++ b/web/src/player/utils/videoElementClassName.ts
@@ -1,0 +1,20 @@
+/**
+ * Computes the className for the player's `<video>` element.
+ *
+ * `object-contain` is load-bearing, not cosmetic: replaced elements default to
+ * `object-fit: fill`, which stretches the decoded frame to the element box and
+ * distorts the picture whenever the player box is not the video's aspect ratio.
+ * The subtitle systems all anchor to the *contained* video area —
+ * `useSubtitlePositionStyle` (VTT), libpgs (`aspectRatio: "contain"`), and
+ * JASSUB's contain-based canvas geometry — so a stretched video makes the video
+ * and its subtitles render skewed relative to each other (issue #209). Keeping
+ * the video on `object-fit: contain` matches that shared assumption.
+ *
+ * @param isDetached - true for the floating/mini player (no absolute fill), false
+ *   for the inline/fullscreen player that fills its positioned container.
+ */
+export function videoElementClassName(isDetached: boolean): string {
+  return isDetached
+    ? "h-full w-full object-contain"
+    : "absolute inset-0 h-full w-full object-contain";
+}


### PR DESCRIPTION
## Problem

ASS subtitles render skewed (horizontally stretched) at original resolution; lowering the playback resolution below original is the reported workaround (#209). The attached screenshots show the romaji + Japanese title rendered too wide and overflowing at 2560x1237, but correct at 1920x1080.

Root cause: the player `<video>` element (`web/src/player/components/VideoPlayer.tsx`) had **no `object-fit`**, so it used the replaced-element default `object-fit: fill`, which stretches the decoded frame to the element box whenever the box is not the video's aspect ratio. But every subtitle system in the player anchors to the *contained* (letterboxed) video area:

- VTT positioning — `useSubtitlePositionStyle` ("…centered on the actually-rendered video area (object-fit: contain)").
- PGS — `usePGSSubtitles` passes libpgs `aspectRatio: "contain"` ("Must match the video element's object-fit…").
- ASS — JASSUB's `_getVideoPosition`/canvas geometry computes a contain letterbox from the video's intrinsic aspect ratio.

So the video stretched while its subtitle overlays stayed contain-anchored, and the two rendered skewed relative to each other. When the player box happens to match the video aspect (e.g. a 16:9 window), `fill` and `contain` coincide and the skew disappears — which is why it was resolution/window-dependent and intermittent.

Reproduction: confirmed against current `origin/main` by reading the rendered DOM (video had no `object-fit`) and the three subtitle geometry paths, and by reproducing JASSUB's `_getVideoPosition` math for a 16:9 video in a non-16:9 element box (contain box 2199px wide vs a 2560px fill box → ~1.16x horizontal mismatch), matching the stretched text in the issue screenshots.

## Approach

Set `object-contain` on the `<video>` element so it letterboxes to its intrinsic aspect ratio instead of stretching. This makes the actual video rendering match the contain assumption the VTT, PGS, and ASS subtitle systems already depend on — fixing the skew for all three at once with a one-line behavioral change, rather than rewriting three subtitle geometry paths to chase `fill`. A video player should never distort the picture, so `contain` is also the correct framing on its own.

The className expression was extracted into a tiny pure helper (`web/src/player/utils/videoElementClassName.ts`) so the contain contract lives in one documented place and can be unit-tested without mounting the 2400-line `VideoPlayer`.

## Verification

Commands run in the worktree (frontend-only change; no Go touched):

- `pnpm exec vitest run` (player utils + ASS + PGS): **19 passed**, including the new `videoElementClassName.test.ts`.
- Full suite: **1117 passed**. The only failures (5, in `ServerStorageStep.test.tsx`) are pre-existing and unrelated — `ReferenceError: ResizeObserver is not defined` from a Radix UI dependency in the setup wizard; reproduced identically with this change stashed, and that test imports no player code.
- `pnpm run lint`: **0 errors** (changed files clean).
- `pnpm run format:check`: changed files clean (the lone `Profiles.tsx` warning has no diff vs `origin/main` — pre-existing drift).
- `pnpm run build`: succeeds (typecheck + bundle).
- `make verify-local-paths`: clean.

## Adversarial review

Codex adversarial review (`--base main`): **approve**, no material findings. It confirmed the change aligns the actual video rendering with the existing VTT/PGS/ASS contain-based subtitle geometry, and that the foreground, fullscreen, detached (`aspect-video` floating), and postroll container paths show no concrete regression from adding `object-contain`.

## Risks & follow-up

- Behavior change: non-16:9 content in a non-matching player box now letterboxes (contain) instead of stretching (fill). This is the correct, expected player behavior and matches what the subtitle systems already assumed.
- No API, schema, or backend changes. No `silo-android` / `silo-apple` follow-up — this is a web-client CSS fix; the native clients have their own video layout.
- **Before/after media:** the issue's own screenshots show the skewed (2560x1237) vs correct (1920x1080) cases. A fresh side-by-side capture from the running web player on a non-16:9 window with an ASS track is still recommended before merge — I could not stand up the full backend + sample clip in this environment to capture it.

Closes #209

## AI-use disclosure
Implemented by Claude Code (issue-to-pr skill) with human oversight.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved video player styling so video content now consistently uses the correct fit mode in both detached and inline playback.
  * Added coverage to verify the player’s layout classes behave correctly across playback modes.

* **Bug Fixes**
  * Prevented detached video playback from inheriting fullscreen-style positioning, helping avoid layout issues and keeping video/subtitles aligned consistently.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->