### PR TITLE
fix(player): detect Firefox HDR via video-dynamic-range media query

### DIFF
--- a/web/src/player/hooks/useCodecDetection.ts
+++ b/web/src/player/hooks/useCodecDetection.ts
@@ -170,8 +170,13 @@ export function useCodecDetection() {
     // Detect max resolution via reported screen dimensions.
     const max_resolution = detectMaxResolutionFromScreen(screen.width, screen.height);
 
-    // HDR detection (best effort).
-    const hdr = typeof matchMedia !== "undefined" && matchMedia("(dynamic-range: high)").matches;
+    // HDR detection (best effort). Firefox (116+) does not report HDR via the
+    // standard `(dynamic-range: high)` query but does via `(video-dynamic-range: high)`,
+    // so check both.
+    const hdr =
+      typeof matchMedia !== "undefined" &&
+      (matchMedia("(dynamic-range: high)").matches ||
+        matchMedia("(video-dynamic-range: high)").matches);
 
     return { codecs_video, codecs_audio, containers, max_resolution, hdr };
   }, []);


### PR DESCRIPTION
## Problem

The web client's codec-capability check reports `hdr: false` on HDR-capable
Firefox, so those clients are treated as SDR during playback negotiation.

Root cause: `web/src/player/hooks/useCodecDetection.ts` detected HDR using only
the standard `(dynamic-range: high)` media query. Firefox (116+) does **not**
report HDR through that query, but **does** through `(video-dynamic-range: high)`
(W3C Media Queries Level 5, video plane). The issue reporter verified in Firefox
that `matchMedia('(dynamic-range: high)').matches` is `false` while
`matchMedia('(video-dynamic-range: high)').matches` is `true` on the same HDR
display.

This `hdr` flag flows to the server's playback request via
`usePlaybackSession.ts` (`hdr: capabilities.hdr`), so the mis-detection affects
real negotiation, not just display.

## Approach

OR the `(video-dynamic-range: high)` query into the existing check, keeping the
single `typeof matchMedia !== "undefined"` guard in front of the whole
expression. Because `&&` short-circuits, the guard still protects *both*
`matchMedia(...)` calls, so non-browser/SSR contexts remain safe (the original
already relied on this for the first call).

Chosen over alternatives: replacing the standard query would regress Chromium,
which reports via `(dynamic-range: high)`; checking both is strictly additive —
`hdr` can only become `true` in more cases, never fewer, so no other browser
changes behavior. Confirmed via `grep` that this is the **only**
`dynamic-range` usage in the repo, so the fix is genuinely one place.

## Verification

Commands run from the worktree (frontend-only change):

- `pnpm run lint` → exit 0 (0 errors; 170 pre-existing warnings in untouched files; my file not flagged)
- `prettier --check src/player/hooks/useCodecDetection.ts` → "All matched files use Prettier code style!"
- `vitest run src/player/hooks/useCodecDetection.test.ts` → 2 passed
- `pnpm run build` → exit 0 (built successfully)
- `make verify-local-paths` → exit 0 (clean)

Note: repo-wide `pnpm run format:check` flags `src/pages/Profiles.tsx`, but that
file is byte-identical to `origin/main` (a pre-existing formatting issue,
unrelated to this PR and out of scope per one-concern-per-PR).

## Adversarial review

Codex adversarial review (`--base main`): **approve, no material findings**. It
independently confirmed (1) the added `matchMedia` call stays behind the
`typeof` short-circuit guard, (2) unknown media features resolve to non-matching
rather than throwing, (3) current playback/version selection does not gate HDR
direct-play on `capabilities.hdr`, so a `true` value carries no downstream
breakage risk, and (4) `video-dynamic-range` is a defensible query for a web
video player per the W3C spec.

## Risks & follow-up

- Low risk: additive boolean widening; no API/schema/backend change.
- **No silo-android / silo-apple follow-up needed** — those clients detect HDR
  via native platform display APIs, not web `matchMedia`, so this web-only query
  fix does not apply to them.
- UI media: none attached. This change has no rendered UI; the only observable
  effect is the `hdr` capability boolean (and resulting HDR-eligible playback)
  on Firefox with an HDR display, which cannot be captured as a static
  before/after screenshot.

Closes #206

## AI-use disclosure
Implemented by Claude Code (issue-to-pr skill) with human oversight.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved HDR detection so playback is more likely to work correctly in Firefox.
  * The app now checks multiple browser media queries and recognizes HDR support when either one is available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->