### PR TITLE
fix(web): show "Resume Reading" CTA for a part-read manga volume

### DIFF
--- a/web/src/lib/mangaChapters.test.ts
+++ b/web/src/lib/mangaChapters.test.ts
@@ -3,7 +3,7 @@
 import { describe, expect, it } from "vitest";
 
 import type { MangaChapter } from "@/api/types";
-import { buildMangaList, prettifyVolumeLabel } from "./mangaChapters";
+import { buildMangaList, prettifyVolumeLabel, resumeState } from "./mangaChapters";
 
 function chapter(partial: Partial<MangaChapter>): MangaChapter {
   return {
@@ -11,6 +11,8 @@ function chapter(partial: Partial<MangaChapter>): MangaChapter {
     title: partial.title ?? "Chapter",
     chapter_index: partial.chapter_index,
     volume: partial.volume,
+    read: partial.read,
+    progress: partial.progress,
   };
 }
 
@@ -153,5 +155,76 @@ describe("volume token normalization", () => {
       { content_id: "b", title: "v2", chapter_index: 2, volume: "v2" },
     ]);
     expect(entries).toHaveLength(2);
+  });
+});
+
+describe("resumeState", () => {
+  it("returns null for an empty list", () => {
+    expect(resumeState(buildMangaList([]))).toBeNull();
+  });
+
+  it("returns null once every chapter is read (caller restarts)", () => {
+    const entries = buildMangaList([
+      chapter({ content_id: "v01", chapter_index: 1, volume: "v01", read: true }),
+      chapter({ content_id: "v02", chapter_index: 2, volume: "v02", read: true }),
+    ]);
+    expect(resumeState(entries)).toBeNull();
+  });
+
+  it("targets the first volume with no earlier-read and no progress (Start Reading)", () => {
+    const entries = buildMangaList([
+      chapter({ content_id: "v01", chapter_index: 1, volume: "v01" }),
+      chapter({ content_id: "v02", chapter_index: 2, volume: "v02" }),
+    ]);
+    expect(resumeState(entries)).toEqual({
+      target: expect.objectContaining({ chapter: expect.objectContaining({ content_id: "v01" }) }),
+      hasEarlierRead: false,
+      targetInProgress: false,
+    });
+  });
+
+  it("flags the target in progress when it is part-read but unfinished (Resume Reading)", () => {
+    const entries = buildMangaList([
+      chapter({ content_id: "v01", chapter_index: 1, volume: "v01", progress: 0.18 }),
+      chapter({ content_id: "v02", chapter_index: 2, volume: "v02" }),
+    ]);
+    const state = resumeState(entries);
+    expect(state?.target.chapter.content_id).toBe("v01");
+    expect(state?.hasEarlierRead).toBe(false);
+    expect(state?.targetInProgress).toBe(true);
+  });
+
+  it("does not treat a fully read (progress 1, read true) earlier chapter as in-progress (Continue)", () => {
+    const entries = buildMangaList([
+      chapter({ content_id: "v01", chapter_index: 1, volume: "v01", read: true, progress: 1 }),
+      chapter({ content_id: "v02", chapter_index: 2, volume: "v02" }),
+    ]);
+    const state = resumeState(entries);
+    expect(state?.target.chapter.content_id).toBe("v02");
+    expect(state?.hasEarlierRead).toBe(true);
+    expect(state?.targetInProgress).toBe(false);
+  });
+
+  it("scopes hasEarlierRead to chapters before the target: a later read volume does not flip an in-progress target to Continue", () => {
+    const entries = buildMangaList([
+      chapter({ content_id: "v01", chapter_index: 1, volume: "v01", progress: 0.18 }),
+      chapter({ content_id: "v02", chapter_index: 2, volume: "v02", read: true }),
+    ]);
+    const state = resumeState(entries);
+    expect(state?.target.chapter.content_id).toBe("v01");
+    expect(state?.hasEarlierRead).toBe(false);
+    expect(state?.targetInProgress).toBe(true);
+  });
+
+  it("does not flag a full-progress (1.0) target with a stale/absent read flag as in-progress", () => {
+    // The server marks a chapter read past its finished threshold, so a target
+    // at full progress with read still unset is finished, not "Resume Reading".
+    const entries = buildMangaList([
+      chapter({ content_id: "v01", chapter_index: 1, volume: "v01", progress: 1 }),
+      chapter({ content_id: "v02", chapter_index: 2, volume: "v02" }),
+    ]);
+    const state = resumeState(entries);
+    expect(state?.target.chapter.content_id).toBe("v01");
+    expect(state?.targetInProgress).toBe(false);
   });
 });

--- a/web/src/lib/mangaChapters.ts
+++ b/web/src/lib/mangaChapters.ts
@@ -151,3 +151,38 @@ export function firstUnreadChapter(entries: MangaListEntry[]): FlatMangaChapter 
   }
   return null;
 }
+
+// A MangaResumeState describes where the viewer is in a series and how to label
+// the resume CTA. `target` is the first unfinished chapter (the resume point);
+// `hasEarlierRead` is true when any chapter *before* the target is finished
+// (the viewer is genuinely mid-series → "Continue"); `targetInProgress` is true
+// when the target itself is part-read but not finished (→ "Resume Reading").
+// Null means every chapter is read or the list is empty, so the caller offers a
+// restart.
+export interface MangaResumeState {
+  target: FlatMangaChapter;
+  hasEarlierRead: boolean;
+  targetInProgress: boolean;
+}
+
+// resumeState walks the flat reading order once to resolve the resume target and
+// classify it. `hasEarlierRead` is derived only from chapters before the target,
+// so a chapter read out of order *after* an unfinished one (skip-ahead or a
+// manual mark-read) does not mislabel an in-progress target as "Continue".
+//
+// `targetInProgress` requires a reading position strictly inside (0, 1): the
+// server marks a chapter read once progress crosses its finished threshold, so a
+// finished position (>= 1, or a stale/absent read flag at full progress) must
+// not be surfaced as "Resume Reading".
+export function resumeState(entries: MangaListEntry[]): MangaResumeState | null {
+  let hasEarlierRead = false;
+  for (const flat of flattenMangaList(entries)) {
+    if (flat.chapter.read !== true) {
+      const { progress } = flat.chapter;
+      const targetInProgress = typeof progress === "number" && progress > 0 && progress < 1;
+      return { target: flat, hasEarlierRead, targetInProgress };
+    }
+    hasEarlierRead = true;
+  }
+  return null;
+}

--- a/web/src/pages/ItemDetail/MangaContent.test.tsx
+++ b/web/src/pages/ItemDetail/MangaContent.test.tsx
@@ -139,6 +139,92 @@ describe("MangaContent", () => {
     expect(cta).toHaveAttribute("href", "/reader/ebook/v01?libraryId=7" + seriesBackTo);
   });
 
+  it("shows a Resume Reading hero CTA when the first volume is part-read but unfinished", () => {
+    render(
+      <MemoryRouter>
+        <MangaContent
+          item={mangaItem([
+            {
+              content_id: "v01",
+              title: "Railgun v01",
+              chapter_index: 1,
+              volume: "v01",
+              progress: 0.18,
+            },
+            { content_id: "v02", title: "Railgun v02", chapter_index: 2, volume: "v02" },
+          ])}
+          libraryId={7}
+        />
+      </MemoryRouter>,
+    );
+
+    // 18% into Volume 1 with read=false: the CTA must resume the in-progress
+    // volume rather than offer a fresh "Start Reading".
+    const cta = screen.getByRole("link", { name: /Resume Reading/i });
+    expect(cta).toHaveTextContent("Volume 1");
+    expect(cta).toHaveAttribute("href", "/reader/ebook/v01?libraryId=7" + seriesBackTo);
+    expect(screen.queryByRole("link", { name: /Start Reading/i })).not.toBeInTheDocument();
+  });
+
+  it("keeps Resume Reading on an in-progress volume even when a later volume was read out of order", () => {
+    render(
+      <MemoryRouter>
+        <MangaContent
+          item={mangaItem([
+            {
+              content_id: "v01",
+              title: "Railgun v01",
+              chapter_index: 1,
+              volume: "v01",
+              progress: 0.18,
+            },
+            {
+              content_id: "v02",
+              title: "Railgun v02",
+              chapter_index: 2,
+              volume: "v02",
+              read: true,
+            },
+          ])}
+          libraryId={7}
+        />
+      </MemoryRouter>,
+    );
+
+    // Volume 2 read out of order must not relabel the part-read Volume 1 as
+    // "Continue": the resume target (V1) is in progress, so it stays "Resume
+    // Reading" and still points at V1.
+    const cta = screen.getByRole("link", { name: /Resume Reading/i });
+    expect(cta).toHaveTextContent("Volume 1");
+    expect(cta).toHaveAttribute("href", "/reader/ebook/v01?libraryId=7" + seriesBackTo);
+    expect(screen.queryByRole("link", { name: /Continue/i })).not.toBeInTheDocument();
+  });
+
+  it("shows Start Reading (not Resume) for a full-progress target whose read flag is stale", () => {
+    render(
+      <MemoryRouter>
+        <MangaContent
+          item={mangaItem([
+            {
+              content_id: "v01",
+              title: "Railgun v01",
+              chapter_index: 1,
+              volume: "v01",
+              progress: 1,
+            },
+            { content_id: "v02", title: "Railgun v02", chapter_index: 2, volume: "v02" },
+          ])}
+          libraryId={7}
+        />
+      </MemoryRouter>,
+    );
+
+    // progress 1 means finished, not part-read: a stale/absent read flag must
+    // not surface "Resume Reading".
+    expect(screen.getByRole("link", { name: /Start Reading/i })).toBeInTheDocument();
+    expect(screen.queryByRole("link", { name: /Resume Reading/i })).not.toBeInTheDocument();
+  });
+
   it("shows a Continue hero CTA targeting the first unread chapter mid-series", () => {
     render(
       <MemoryRouter>

--- a/web/src/pages/ItemDetail/MangaContent.tsx
+++ b/web/src/pages/ItemDetail/MangaContent.tsx
@@ -33,8 +33,8 @@ import { buildItemHref, buildMediaPlayHref } from "@/lib/mediaNavigation";
 import {
   buildMangaList,
   chapterLabel,
-  firstUnreadChapter,
   flattenMangaList,
+  resumeState,
   type MangaListEntry,
 } from "@/lib/mangaChapters";
 import { cn } from "@/lib/utils";
@@ -252,7 +252,6 @@ export default function MangaContent({
   const entries = useMemo(() => buildMangaList(item.manga?.chapters ?? []), [item.manga?.chapters]);
   const year = item.year ? String(item.year) : "";
   const publisher = item.studios?.[0];
-  const chapterRows = item.manga?.chapters ?? [];
   // Derive the badge counts from the rendered list so they always match the
   // rows on screen: a volume/section entry is one volume (buildMangaList
   // already canonicalizes v01 ≡ 1), a loose chapter entry is one chapter.
@@ -265,14 +264,27 @@ export default function MangaContent({
     [entries],
   );
 
-  // The resume target is the first unfinished chapter in reading order. Any
-  // finished chapter before it means the viewer is mid-series ("Continue");
-  // a fully read series restarts from the beginning.
-  const anyRead = chapterRows.some((chapter) => chapter.read === true);
-  const resume = useMemo(() => firstUnreadChapter(entries), [entries]);
+  // The resume target is the first unfinished chapter in reading order. The CTA
+  // verb reflects how far along the viewer is:
+  //   - "Continue" when an earlier chapter is fully read (genuinely mid-series).
+  //   - "Resume Reading" when the resume target itself is part-read but not yet
+  //     finished (e.g. 18% into Volume 1) — its read flag is still false, so
+  //     this is detected from reading progress, not the read flag.
+  //   - "Start Reading" on a pristine series with no progress anywhere.
+  //   - "Read Again" from the start once every chapter is read.
+  // hasEarlierRead is scoped to chapters *before* the target, so a later volume
+  // read out of order doesn't relabel an in-progress earlier volume "Continue".
+  const resume = useMemo(() => resumeState(entries), [entries]);
   const fallbackStart = entries.length > 0 ? flattenFirst(entries) : null;
   const cta = resume
-    ? { ...resume, verb: anyRead ? "Continue" : "Start Reading" }
+    ? {
+        ...resume.target,
+        verb: resume.hasEarlierRead
+          ? "Continue"
+          : resume.targetInProgress
+            ? "Resume Reading"
+            : "Start Reading",
+      }
     : fallbackStart
       ? { ...fallbackStart, verb: "Read Again" }
       : null;
@@ -375,12 +387,12 @@ export default function MangaContent({
               className="text-muted-foreground gap-1.5"
               onClick={() => {
                 document
-                  .getElementById(`manga-chapter-${resume.chapter.content_id}`)
+                  .getElementById(`manga-chapter-${resume.target.chapter.content_id}`)
                   ?.scrollIntoView({ behavior: "smooth", block: "center" });
               }}
             >
               <CornerDownRight className="size-4" />
-              Jump to {resume.label}
+              Jump to {resume.target.label}
             </Button>
           </div>
         )}


### PR DESCRIPTION
## Problem
On a manga series detail page, the hero action button ignored active reading
progress. Per issue #188, a volume partially read (e.g. 18% into Volume 1)
showed **Start Reading Volume 1** instead of **Resume Reading Volume 1**.

Root cause (`web/src/pages/ItemDetail/MangaContent.tsx`): the CTA verb was chosen
from `anyRead = chapterRows.some(c => c.read === true)`, then
`anyRead ? "Continue" : "Start Reading"`. A part-read volume has `read === false`
(the server marks a chapter read only past its finished threshold), so `anyRead`
was false and the button fell through to "Start Reading" — even though the resume
target already carried a `progress` fraction. The per-row progress bar already
read that exact `chapter.progress` field; only the CTA verb ignored it.

Reproduced with a red unit test before fixing: a first volume with
`progress: 0.18` (and `read` unset) rendered no "Resume Reading" link on current
`main`.

## Approach
The verb decision is really a reading-state classification, so it moved into the
module that owns reading order, `web/src/lib/mangaChapters.ts`, as `resumeState()`.
A single pass over the flattened reading order returns:

- `target` — the first unfinished chapter (the resume point),
- `hasEarlierRead` — whether any chapter **before** the target is finished
  (genuinely mid-series → "Continue"), derived only from earlier chapters so a
  later volume read out of order can't relabel an in-progress earlier volume, and
- `targetInProgress` — whether the target itself is part-read, i.e. a reading
  position strictly inside `(0, 1)`.

The CTA verb becomes
`hasEarlierRead ? "Continue" : targetInProgress ? "Resume Reading" : "Start Reading"`,
with the existing "Read Again" fallback when every chapter is read. This keeps the
change additive to the verb set and leaves the "Continue" / "Start Reading" /
"Read Again" behaviors intact.

Why `targetInProgress` requires `progress < 1` and not a mirrored backend
threshold: the manga detail payload is produced by a single query
(`internal/catalog/detail.go`) where `read` is computed as
`progress >= EbookFinishedProgressThreshold` (0.9) in the same SQL row, so `read`
and `progress` can never disagree. The frontend deliberately does not duplicate
that server-side `0.9` constant (it is never exposed over the API and the
authoritative `read` flag already is); the `< 1` bound is a conservative guard so
a finished position can't be mislabeled "Resume Reading".

## Verification
Commands run from the worktree (`web/`), GOWORK not needed (frontend-only):

- `pnpm exec vitest run src/pages/ItemDetail/MangaContent.test.tsx src/lib/mangaChapters.test.ts`
  → **35 passed** (the new "Resume Reading" CTA test fails on `main`, passes here;
  added coverage for skip-ahead and full-progress edges, plus 6 `resumeState`
  unit tests).
- `pnpm run lint` → 0 errors (pre-existing warnings only; none in changed files).
- `pnpm exec prettier --check` on the four changed files → clean.
- `pnpm run build` (tsc + vite) → succeeds, no type errors.
- `pnpm exec vitest run` (full suite) → 1125 passed; the only 5 failures are
  pre-existing `ResizeObserver is not defined` cases in admin-settings/setup-wizard
  test files, confirmed identical on a pristine `main` checkout and unrelated to
  this change.
- `make verify-local-paths` → clean.

## Adversarial review
Codex `adversarial-review --base main`, three iterations:
1. Flagged that whole-list `anyRead` mislabeled an in-progress target as
   "Continue" when a later chapter was read out of order. **Fixed** by scoping
   `hasEarlierRead` to chapters before the target (the `resumeState` refactor) and
   adding a skip-ahead regression test.
2. Flagged that a full-progress target with a stale read flag could read as
   "Resume Reading". **Fixed** by gating `targetInProgress` to `progress < 1`,
   with unit + component tests for `progress: 1`.
3. Asked to additionally change target *selection* for full-progress
   stale-read chapters (→ "Read Again"/skip). **Rebutted (immaterial):** that
   input is structurally unreachable — `read` is derived from `progress >= 0.9`
   in the same SQL row (`internal/catalog/detail.go`, single producer), so a
   `progress >= 0.9` chapter always arrives with `read = true`. Restructuring
   target selection around an impossible state would be defensive code for a case
   that cannot happen. The two reachable findings were fixed and verified.

## Risks & follow-up
- Scope is the manga series detail CTA only; "Continue" / "Start Reading" /
  "Read Again" paths are unchanged and still covered by their existing tests.
- **UI media still needed:** this is a visual change (button label
  "Start Reading" → "Resume Reading" on a part-read volume) but I could not seed a
  part-read volume and run the full app in this environment. Before/after
  screenshots should be attached before merge.
- Client follow-up: the Android (`silo-android`) and Apple (`silo-apple`) manga/
  ebook detail screens render their own CTAs from the same `read`/`progress`
  fields. If they share this "Start Reading vs Resume" gap, a coordinated
  client-side fix may be warranted — no server contract changed (additive,
  frontend-only).

Closes #188

## AI-use disclosure
Implemented by Claude Code (issue-to-pr skill) with human oversight.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved manga reading progress handling, with smarter actions like **Start Reading**, **Resume Reading**, **Continue**, and **Read Again** based on your reading state.
  * Added a **Jump to** option that takes you directly to the recommended chapter and highlights the correct starting point.

* **Bug Fixes**
  * Fixed cases where partially read chapters or out-of-order read markers could show the wrong reading action.
  * Correctly handles fully read progress even when read status is outdated or missing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->