### PR TITLE
fix(jellycompat): trim episode list to StartItemId for play-from-here queue

### DIFF
--- a/internal/jellycompat/handlers_items.go
+++ b/internal/jellycompat/handlers_items.go
@@ -1378,6 +1378,21 @@ func (h *ItemsHandler) writeSeriesEpisodesResponse(w http.ResponseWriter, r *htt
 		return leftSeason < rightSeason
 	})
 
+	// StartItemId: trim the list so it begins at the requested item.
+	// Jellyfin Android TV uses this to build a "play from here" queue via
+	// /Shows/{id}/Episodes?startItemId=X — the client trusts that item[0]
+	// is the episode the user selected. Without this trim, an unscoped
+	// request returns all seasons sorted by season_number ASC, so item[0]
+	// is always S0E1 (Specials), causing the wrong episode to play.
+	if query.startItemID != "" {
+		for i, item := range items {
+			if item.ID == query.startItemID {
+				items = items[i:]
+				break
+			}
+		}
+	}
+
 	total := len(items)
 	startIndex := 0
 	if page {

--- a/internal/jellycompat/query.go
+++ b/internal/jellycompat/query.go
@@ -45,6 +45,7 @@ type itemsQuery struct {
 	mediaTypesExplicit     bool
 	requestedFields        map[string]bool // parsed from Fields param
 	fieldsExplicit         bool            // true when Fields was in the request
+	startItemID            string          // raw encoded ID from StartItemId param (Episodes trim-from)
 }
 
 func parseItemsQuery(r *http.Request, codec *ResourceIDCodec) itemsQuery {
@@ -167,6 +168,8 @@ func parseItemsQuery(r *http.Request, codec *ResourceIDCodec) itemsQuery {
 	result.requestedFields = parseRequestedFields(fieldsRaw)
 	result.fieldsExplicit = strings.TrimSpace(fieldsRaw) != ""
 	result.needsDetailFields = requestedFieldsNeedDetail(result.requestedFields)
+
+	result.startItemID = strings.TrimSpace(q.Get("StartItemId"))
 
 	// Diagnostic: when the request stays on the list path, emit a Debug log
 	// listing any requested Fields that mapping.go's itemFromList does not


### PR DESCRIPTION
## Summary
- Parse `StartItemId` query param in `itemsQuery`
- Trim the sorted episode list so it begins at the requested item
- Fixes Android TV "play from here" returning wrong episode (always S0E1/Specials)

## Test plan
- [ ] On Android TV, long-press mid-season episode → Play From Here → confirm correct episode plays
- [ ] Verify episode list without StartItemId is unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Episode playback requests now start from the requested episode when a start ID is provided, instead of always returning the full sorted list.
  * The app now correctly reads and applies the start-episode parameter from incoming requests, improving “resume from here” behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->