### PR TITLE
fix(audiobooks): metadata search, fragmented content_id consolidation, ingest drainer skip

### DIFF
--- a/internal/audiobooks/enrichment.go
+++ b/internal/audiobooks/enrichment.go
@@ -15,6 +15,7 @@ package audiobooks
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"log/slog"
 	"os"
@@ -382,19 +383,18 @@ func (e *Enricher) enrichItem(ctx context.Context, item enrichmentItemRow) error
 	// Phase 1: Search — collect provider IDs.
 	searchQuery := metadata.SearchQuery{
 		Title:       item.Title,
+		Author:      item.Author,
 		Year:        item.Year,
 		ContentType: "audiobook",
 		ProviderIDs: accumulatedIDs,
 		Language:    item.Language,
 	}
-	// Include author in the search query title hint when present.
-	// The audnexus plugin uses title+author for ASIN lookup.
-	if item.Author != "" {
-		searchQuery.Title = item.Title
-		// Some plugins accept author via the generic extras pathway; others rely
-		// on the title field only. We pass it as a secondary field (no standard
-		// slot exists in SearchQuery yet).
-	}
+
+	// Track whether any provider errored during this item's enrichment. When
+	// nothing is accumulated AND at least one provider errored, we return an
+	// error WITHOUT stamping last_refreshed so the sweep retries the item later
+	// rather than burning it terminally on a transient provider failure.
+	var providerErrs []error
 
 	for _, p := range providers {
 		sp, ok := p.(metadata.SearchProvider)
@@ -408,6 +408,7 @@ func (e *Enricher) enrichItem(ctx context.Context, item enrichmentItemRow) error
 				"content_id", item.ContentID,
 				"error", searchErr,
 			)
+			providerErrs = append(providerErrs, fmt.Errorf("%s search: %w", p.Slug(), searchErr))
 			continue
 		}
 		if len(results) == 0 {
@@ -449,6 +450,7 @@ func (e *Enricher) enrichItem(ctx context.Context, item enrichmentItemRow) error
 				"content_id", item.ContentID,
 				"error", getErr,
 			)
+			providerErrs = append(providerErrs, fmt.Errorf("%s metadata: %w", p.Slug(), getErr))
 			continue
 		}
 		if result == nil || !result.HasMetadata {
@@ -467,8 +469,20 @@ func (e *Enricher) enrichItem(ctx context.Context, item enrichmentItemRow) error
 		)
 	}
 
-	// Nothing found — stamp last_refreshed so we skip on the next sweep.
+	// Nothing found.
 	if !accumulator.HasMetadata && accumulator.PosterPath == "" && accumulator.Overview == "" {
+		if err := ctx.Err(); err != nil {
+			// A cancelled sweep says nothing about the item or the providers.
+			return err
+		}
+		if len(providerErrs) > 0 {
+			// Transient provider trouble must not stamp the item terminally;
+			// surfacing an error lets the sweep retry it later instead.
+			return fmt.Errorf("no metadata obtained, %d provider error(s): %w",
+				len(providerErrs), errors.Join(providerErrs...))
+		}
+		// Providers ran cleanly but nothing matched — stamp last_refreshed so we
+		// skip on the next sweep.
 		slog.Info("audiobook enrichment: no metadata found",
 			"content_id", item.ContentID,
 			"title", item.Title,

--- a/internal/libraryingest/executor.go
+++ b/internal/libraryingest/executor.go
@@ -435,6 +435,15 @@ func scopeMatchPaths(folder *models.MediaFolder, mode scopeMode, scopePath strin
 	if folder == nil {
 		return nil
 	}
+	// Audiobook/podcast/ebook/manga libraries use scanner-driven grouping where
+	// the scanner assigns content_ids by folder root. Running the concurrent
+	// match drainer while the scan writes files causes per-file content_ids to
+	// be created for unlinked files. Skip concurrent matching; the post-scan
+	// drain handles these libraries correctly.
+	switch strings.ToLower(strings.TrimSpace(folder.Type)) {
+	case "audiobook", "audiobooks", "podcast", "podcasts", "ebook", "ebooks", "manga", "comics":
+		return nil
+	}
 	switch mode {
 	case scopeModeLibrary:
 		return cleanRoots(folder.Paths)

--- a/internal/scanner/audiobook_scan.go
+++ b/internal/scanner/audiobook_scan.go
@@ -153,6 +153,12 @@ func (s *Scanner) audiobookFolderShouldSkip(ctx context.Context, folder *models.
 	if contentID == "" {
 		return "", false, nil
 	}
+	// All files must share the same content_id; fragmented folders need reconcile.
+	for _, mf := range existing[1:] {
+		if mf.ContentID != contentID {
+			return "", false, nil
+		}
+	}
 	items, err := s.itemRepo.GetByIDs(ctx, []string{contentID})
 	if err != nil {
 		return "", false, fmt.Errorf("get item for skip check: %w", err)

--- a/internal/scanner/scanner.go
+++ b/internal/scanner/scanner.go
@@ -1507,7 +1507,8 @@ func (s *Scanner) syncFolderScopedAudioLibraryState(ctx context.Context, folderI
 
 	if _, err := s.fileRepo.Pool().Exec(ctx, `
 		INSERT INTO media_item_roots (media_folder_id, canonical_root_path, content_id)
-		SELECT DISTINCT mf.media_folder_id, mf.canonical_root_path, mf.content_id
+		SELECT DISTINCT ON (mf.media_folder_id, mf.canonical_root_path)
+			mf.media_folder_id, mf.canonical_root_path, mf.content_id
 		FROM media_files mf
 		JOIN media_items mi ON mi.content_id = mf.content_id
 		WHERE mf.media_folder_id = $1


### PR DESCRIPTION
## Summary
- Pass author in audiobook search query and retry on provider errors
- Consolidate fragmented multi-file audiobook content_ids on rescan
- Skip concurrent match drainer for audiobook/podcast/ebook/manga libraries

## Test plan
- [ ] Multi-file audiobook rescans without fragmented content_ids
- [ ] Audiobook metadata search returns author-scoped results
- [ ] Ingest drainer skipped for non-video library types

🤖 Generated with [Claude Code](https://claude.com/claude-code)