### PR TITLE
fix(jellycompat): honor StartItemId episode queues

### DIFF
--- a/internal/jellycompat/handlers_items.go
+++ b/internal/jellycompat/handlers_items.go
@@ -1285,6 +1285,16 @@ func (h *ItemsHandler) writeSeriesEpisodesResponse(w http.ResponseWriter, r *htt
 		writeCompatUpstreamError(w, err)
 		return
 	}
+	sort.SliceStable(episodeModels, func(i, j int) bool {
+		if episodeModels[i] == nil || episodeModels[j] == nil {
+			return episodeModels[i] != nil
+		}
+		if episodeModels[i].SeasonNumber == episodeModels[j].SeasonNumber {
+			return episodeModels[i].EpisodeNumber < episodeModels[j].EpisodeNumber
+		}
+		return episodeModels[i].SeasonNumber < episodeModels[j].SeasonNumber
+	})
+	episodeModels = trimEpisodesFromStartItem(episodeModels, query.startItemID, h.codec)
 
 	contentIDs := contentIDsFromEpisodes(episodeModels)
 	favorites, progress, err := resolveUserStateForContentIDs(r.Context(), session, h.userData, contentIDs)
@@ -2383,6 +2393,26 @@ func (h *ItemsHandler) listSeriesEpisodes(ctx context.Context, session *Session,
 		}
 	}
 	return episodes, nil
+}
+
+func trimEpisodesFromStartItem(episodes []*models.Episode, rawStartItemID string, codec *ResourceIDCodec) []*models.Episode {
+	rawStartItemID = strings.TrimSpace(rawStartItemID)
+	if rawStartItemID == "" {
+		return episodes
+	}
+	if codec == nil {
+		return []*models.Episode{}
+	}
+	startContentID, err := decodeItemID(codec, rawStartItemID)
+	if err != nil || startContentID == "" {
+		return []*models.Episode{}
+	}
+	for i, episode := range episodes {
+		if episode != nil && episode.ContentID == startContentID {
+			return episodes[i:]
+		}
+	}
+	return []*models.Episode{}
 }
 
 func intPtr(value int) *int {

--- a/internal/jellycompat/handlers_items.go
+++ b/internal/jellycompat/handlers_items.go
@@ -1294,6 +1294,7 @@ func (h *ItemsHandler) writeSeriesEpisodesResponse(w http.ResponseWriter, r *htt
 		}
 		return episodeModels[i].SeasonNumber < episodeModels[j].SeasonNumber
 	})
+	episodeModels = compactEpisodeModels(episodeModels)
 	episodeModels = trimEpisodesFromStartItem(episodeModels, query.startItemID, h.codec)
 
 	contentIDs := contentIDsFromEpisodes(episodeModels)
@@ -2393,6 +2394,18 @@ func (h *ItemsHandler) listSeriesEpisodes(ctx context.Context, session *Session,
 		}
 	}
 	return episodes, nil
+}
+
+func compactEpisodeModels(episodes []*models.Episode) []*models.Episode {
+	write := 0
+	for _, episode := range episodes {
+		if episode == nil {
+			continue
+		}
+		episodes[write] = episode
+		write++
+	}
+	return episodes[:write]
 }
 
 func trimEpisodesFromStartItem(episodes []*models.Episode, rawStartItemID string, codec *ResourceIDCodec) []*models.Episode {

--- a/internal/jellycompat/handlers_items_test.go
+++ b/internal/jellycompat/handlers_items_test.go
@@ -140,6 +140,7 @@ func TestHandleEpisodes_StartItemIDTrimsPlayFromHereQueue(t *testing.T) {
 			{ContentID: "ep-1", SeriesID: seriesContentID, SeasonID: seasonContentID, SeasonNumber: 1, EpisodeNumber: 1, Title: "First"},
 			{ContentID: "ep-2", SeriesID: seriesContentID, SeasonID: seasonContentID, SeasonNumber: 1, EpisodeNumber: 2, Title: "Selected"},
 			{ContentID: "ep-3", SeriesID: seriesContentID, SeasonID: seasonContentID, SeasonNumber: 1, EpisodeNumber: 3, Title: "After"},
+			nil,
 		},
 	}}
 	h := &ItemsHandler{

--- a/internal/jellycompat/handlers_items_test.go
+++ b/internal/jellycompat/handlers_items_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/go-chi/chi/v5"
 
 	"github.com/Silo-Server/silo-server/internal/config"
+	"github.com/Silo-Server/silo-server/internal/models"
 )
 
 // countingContentService is a ContentService double that returns a fixed
@@ -93,6 +94,105 @@ func (s *recordingSearchContentService) SearchItems(_ context.Context, _ *Sessio
 		return s.result, nil
 	}
 	return &upstreamBrowseResponse{Items: []upstreamListItem{}}, nil
+}
+
+func performEpisodesRequest(t *testing.T, h *ItemsHandler, target, seriesID string) queryResultDTO {
+	t.Helper()
+	req := httptest.NewRequest("GET", target, nil)
+	routeCtx := chi.NewRouteContext()
+	routeCtx.URLParams.Add("id", seriesID)
+	ctx := context.WithValue(req.Context(), chi.RouteCtxKey, routeCtx)
+	ctx = context.WithValue(ctx, compatSessionKey, &Session{
+		StreamAppUserID: 1,
+		ProfileID:       "profile-1",
+	})
+	req = req.WithContext(ctx)
+
+	rec := httptest.NewRecorder()
+	h.HandleEpisodes(rec, req)
+	if rec.Code != 200 {
+		t.Fatalf("expected status 200; got %d, body=%s", rec.Code, rec.Body.String())
+	}
+	var result queryResultDTO
+	if err := json.NewDecoder(rec.Body).Decode(&result); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	return result
+}
+
+func TestHandleEpisodes_StartItemIDTrimsPlayFromHereQueue(t *testing.T) {
+	codec := NewResourceIDCodec()
+	seriesContentID := "series-1"
+	seasonContentID := "season-1"
+	encodedSeriesID := codec.EncodeStringID(EncodedIDItem, seriesContentID)
+	encodedStartItemID := codec.EncodeStringID(EncodedIDItem, "ep-2")
+	contentSvc := &countingContentService{
+		seasons: []upstreamSeason{
+			{ContentID: "season-0", SeasonNumber: 0, Title: "Specials", EpisodeCount: 1},
+			{ContentID: seasonContentID, SeasonNumber: 1, Title: "Season 1", EpisodeCount: 3},
+		},
+	}
+	episodeRepo := &fakeSeasonEpisodeRepo{bySeason: map[string][]*models.Episode{
+		episodeBySeasonKey(seriesContentID, 0): {
+			{ContentID: "special-1", SeriesID: seriesContentID, SeasonID: "season-0", SeasonNumber: 0, EpisodeNumber: 1, Title: "Special"},
+		},
+		episodeBySeasonKey(seriesContentID, 1): {
+			{ContentID: "ep-1", SeriesID: seriesContentID, SeasonID: seasonContentID, SeasonNumber: 1, EpisodeNumber: 1, Title: "First"},
+			{ContentID: "ep-2", SeriesID: seriesContentID, SeasonID: seasonContentID, SeasonNumber: 1, EpisodeNumber: 2, Title: "Selected"},
+			{ContentID: "ep-3", SeriesID: seriesContentID, SeasonID: seasonContentID, SeasonNumber: 1, EpisodeNumber: 3, Title: "After"},
+		},
+	}}
+	h := &ItemsHandler{
+		content:     contentSvc,
+		userData:    &mockUserDataService{},
+		codec:       codec,
+		mapper:      newMapper(codec, &config.Config{}),
+		images:      NewImageCache(time.Hour, time.Now),
+		episodeRepo: episodeRepo,
+	}
+
+	result := performEpisodesRequest(t, h, "/Shows/"+encodedSeriesID+"/Episodes?startItemId="+encodedStartItemID, encodedSeriesID)
+	if result.TotalRecordCount != 2 || result.StartIndex != 0 {
+		t.Fatalf("TotalRecordCount/StartIndex = %d/%d, want 2/0", result.TotalRecordCount, result.StartIndex)
+	}
+	if len(result.Items) != 2 {
+		t.Fatalf("len(Items) = %d, want 2: %+v", len(result.Items), result.Items)
+	}
+	if result.Items[0].Name != "Selected" || result.Items[1].Name != "After" {
+		t.Fatalf("unexpected queue order: %+v", result.Items)
+	}
+	if result.Items[0].ID != encodedStartItemID {
+		t.Fatalf("first item ID = %q, want %q", result.Items[0].ID, encodedStartItemID)
+	}
+}
+
+func TestHandleEpisodes_StartItemIDMissingReturnsEmptyQueue(t *testing.T) {
+	codec := NewResourceIDCodec()
+	seriesContentID := "series-1"
+	seasonContentID := "season-1"
+	encodedSeriesID := codec.EncodeStringID(EncodedIDItem, seriesContentID)
+	missingStartItemID := codec.EncodeStringID(EncodedIDItem, "missing-episode")
+	contentSvc := &countingContentService{
+		seasons: []upstreamSeason{{ContentID: seasonContentID, SeasonNumber: 1, Title: "Season 1", EpisodeCount: 1}},
+	}
+	episodeRepo := &fakeSeasonEpisodeRepo{bySeason: map[string][]*models.Episode{
+		episodeBySeasonKey(seriesContentID, 1): {
+			{ContentID: "ep-1", SeriesID: seriesContentID, SeasonID: seasonContentID, SeasonNumber: 1, EpisodeNumber: 1, Title: "First"},
+		},
+	}}
+	h := &ItemsHandler{
+		content:     contentSvc,
+		userData:    &mockUserDataService{},
+		codec:       codec,
+		mapper:      newMapper(codec, &config.Config{}),
+		images:      NewImageCache(time.Hour, time.Now),
+		episodeRepo: episodeRepo,
+	}
+
+	result := performEpisodesRequest(t, h, "/Shows/"+encodedSeriesID+"/Episodes?StartItemId="+missingStartItemID, encodedSeriesID)
+	if result.TotalRecordCount != 0 || len(result.Items) != 0 {
+		t.Fatalf("expected empty queue for missing StartItemId, got total=%d items=%+v", result.TotalRecordCount, result.Items)
+	}
 }
 
 func TestHandleItems_SeriesParentSeasonFilterReturnsPagedSeasons(t *testing.T) {

--- a/internal/jellycompat/query.go
+++ b/internal/jellycompat/query.go
@@ -45,6 +45,7 @@ type itemsQuery struct {
 	mediaTypesExplicit     bool
 	requestedFields        map[string]bool // parsed from Fields param
 	fieldsExplicit         bool            // true when Fields was in the request
+	startItemID            string          // raw encoded ID from StartItemId param
 }
 
 func parseItemsQuery(r *http.Request, codec *ResourceIDCodec) itemsQuery {
@@ -168,6 +169,8 @@ func parseItemsQuery(r *http.Request, codec *ResourceIDCodec) itemsQuery {
 	result.requestedFields = parseRequestedFields(fieldsRaw)
 	result.fieldsExplicit = strings.TrimSpace(fieldsRaw) != ""
 	result.needsDetailFields = requestedFieldsNeedDetail(result.requestedFields)
+
+	result.startItemID = strings.TrimSpace(q.Get("StartItemId"))
 
 	// Diagnostic: when the request stays on the list path, emit a Debug log
 	// listing any requested Fields that mapping.go's itemFromList does not

--- a/internal/jellycompat/query_repeated_fields_test.go
+++ b/internal/jellycompat/query_repeated_fields_test.go
@@ -33,6 +33,9 @@ func TestRepeatedFieldsParamTriggersDetail(t *testing.T) {
 	if !query.fieldsExplicit {
 		t.Error("fieldsExplicit must be true when repeated Fields params are present")
 	}
+	if query.startItemID != "x" {
+		t.Errorf("startItemID = %q, want x", query.startItemID)
+	}
 }
 
 // TestCommaSeparatedFieldsStillParsed guards the original single-param,


### PR DESCRIPTION
## Summary
- parse `StartItemId`/`startItemId` for Jellycompat item queries
- sort and trim episode models before user-state/detail hydration so `/Shows/{id}/Episodes?StartItemId=...` starts at the requested episode
- return an empty queue when the supplied start item cannot be decoded or is not present, instead of falling back to S0E1/Specials
- add focused regression coverage for Android TV play-from-here queue behavior

## Why
Android TV builds a play-from-here queue from `/Shows/{id}/Episodes?StartItemId=X` and trusts `Items[0]` to be the selected episode. The previous PR handled the happy path but still returned the full sorted episode list when `StartItemId` was stale, inaccessible, or mismatched, which could still play the wrong first episode.

## Validation
- `GOWORK=off go test ./internal/jellycompat -run 'TestHandleEpisodes_StartItemID|TestRepeatedFieldsParamTriggersDetail'`
- `GOWORK=off go test ./internal/jellycompat -run 'Test(HandleEpisodes_StartItemID|RepeatedFieldsParamTriggersDetail|HandleItems_SeasonParentEpisodesPaged|ParseItemsQuery_SeasonParentSetsParentSeasonID|HandleItems_SeasonParentReturnsEpisodes)$'`
- `git diff --check`
- `GOWORK=off go test ./internal/jellycompat/...` still fails on baseline `TestBeginWebOperationRecoversDeadProcessLock` and `TestBeginWebOperationRejectsLiveProcessLock`; reproduced the same failures on current `origin/main` (`a72094fe`).

## Related
Replaces #239.

## AI Use
Implemented with Codex. The code path, regression tests, and validation output were reviewed before publishing.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Episode queues now respect the selected starting episode, letting playback begin from the chosen item when available.
  * Episodes are consistently ordered by season and episode number before the queue is built.

* **Bug Fixes**
  * If the selected starting episode can’t be found, the episode queue now returns empty instead of showing the wrong items.
  * Repeated field requests now continue to parse the starting item correctly.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->