### PR TITLE
perf(jellycompat): fast-paths for slow Jellyfin-compat queries

### DIFF
--- a/internal/access/resolver_test.go
+++ b/internal/access/resolver_test.go
@@ -86,6 +86,9 @@ func (s stubStore) GetProgress(context.Context, string, string) (*userstore.Watc
 func (s stubStore) ListProgress(context.Context, string, string, int, int) ([]userstore.WatchProgress, error) {
 	panic("unused")
 }
+func (s stubStore) ListProgressFiltered(context.Context, string, string, []string, *int, int, int) ([]userstore.WatchProgress, error) {
+	panic("unused")
+}
 func (s stubStore) ListProgressByMediaItems(context.Context, string, []string) (map[string]userstore.WatchProgress, error) {
 	panic("unused")
 }

--- a/internal/catalog/browse.go
+++ b/internal/catalog/browse.go
@@ -124,6 +124,157 @@ func (r *BrowseRepository) browse(ctx context.Context, filters BrowseFilters, in
 	}, nil
 }
 
+// BrowseRecentlyAddedAcrossLibraries serves a recently_added browse spanning
+// multiple libraries by running the proven single-library index path once per
+// library and merging the already-sorted results in memory. Each per-library
+// query filters on exactly one media_folder_id, so it takes the
+// singleLibraryNoDedup fast path and walks idx_item_libraries_folder_seen_content
+// as a top-N index scan (~1ms). N small walks replace one multi-library
+// MIN(first_seen_at) + GROUP BY scan of the whole catalog (HashAggregate over
+// ~180k groups + top-N heapsort, ~2s with a wide projection and cold cache).
+//
+// It only serves offset 0 — the /Items/Latest hot path. A per-library top-Limit
+// fetch cannot satisfy a deep global offset, so callers must route offset>0
+// pages to BrowsePage; passing a positive Offset here is an error rather than a
+// silently-wrong page.
+//
+// Cross-library dedup is performed app-side: a content_id present in more than
+// one library keeps the EARLIEST first_seen_at, preserving the
+// MIN(first_seen_at) "added at" semantics of the multi-library GROUP BY path.
+// The reported Total is a lower bound (exact when the page is the whole result),
+// chosen so HasMore remains correct for offset 0.
+//
+// Known limitation vs the exact GROUP BY query, bounded to content_ids that
+// live in 2+ libraries: such a dup is only deduped against the slices actually
+// fetched, so if its true MIN(first_seen_at) library does not rank it in that
+// library's top-Limit, the merge sees only a later first_seen_at and may rank it
+// too recent (or drop it if it is outside top-Limit in every library holding it).
+// This is acceptable for an approximate "recently added" rail; do not reuse this
+// path where exact MIN ranking across libraries is required.
+func (r *BrowseRepository) BrowseRecentlyAddedAcrossLibraries(ctx context.Context, base BrowseFilters, libraryIDs []int) (*BrowseResult, error) {
+	if base.Offset > 0 {
+		return nil, fmt.Errorf("browse recently added across libraries: offset %d unsupported, use BrowsePage", base.Offset)
+	}
+	limit := base.Limit
+	if limit <= 0 {
+		limit = 20
+	}
+	// Each per-library subquery is clamped to MaxLimit by BrowsePage, but the
+	// merged page is trimmed to this `limit`; clamp it too so the final result
+	// honors the same BrowseFilters.MaxLimit contract as the single-library path.
+	if base.MaxLimit > 0 && limit > base.MaxLimit {
+		limit = base.MaxLimit
+	}
+
+	perLibrary := make([][]*models.MediaItem, 0, len(libraryIDs))
+	anyLibraryHasMore := false
+	for _, id := range libraryIDs {
+		sub := base
+		sub.LibraryID = id
+		// Clearing the multi-library scopes is what selects the
+		// singleLibraryNoDedup fast path in buildBrowsePlan.
+		sub.LibraryIDs = nil
+		sub.DisabledLibraryIDs = nil
+		sub.Offset = 0
+		sub.Limit = limit
+		res, err := r.BrowsePage(ctx, sub, false)
+		if err != nil {
+			return nil, fmt.Errorf("browse recently added in library %d: %w", id, err)
+		}
+		if res == nil {
+			continue
+		}
+		perLibrary = append(perLibrary, res.Items)
+		if res.HasMore {
+			anyLibraryHasMore = true
+		}
+	}
+
+	merged := mergeRecentlyAddedItems(perLibrary)
+	// More results exist when the merged set already overflows the page, or when
+	// any single library still has rows behind its own top-Limit window (which
+	// implies that library alone holds more than `limit` items).
+	hasMore := anyLibraryHasMore || len(merged) > limit
+	total := len(merged)
+	if hasMore && total <= limit {
+		// A library has rows beyond the page but the merged set fit exactly;
+		// nudge the total so offset-0 HasMore stays true for total-driven callers.
+		total = limit + 1
+	}
+	if len(merged) > limit {
+		merged = merged[:limit]
+	}
+
+	return &BrowseResult{Items: merged, Total: total, HasMore: hasMore}, nil
+}
+
+// mergeRecentlyAddedItems merges per-library recently_added result slices — each
+// already sorted by first_seen_at DESC, content_id ASC — into a single globally
+// ordered slice. Duplicate content_ids are collapsed to one entry whose AddedAt
+// is the EARLIEST across libraries, mirroring MIN(first_seen_at) from the
+// multi-library GROUP BY path. The result is sorted by AddedAt DESC, content_id
+// ASC and is NOT truncated; callers trim to the page size and derive HasMore.
+func mergeRecentlyAddedItems(perLibrary [][]*models.MediaItem) []*models.MediaItem {
+	byID := make(map[string]*models.MediaItem)
+	order := make([]*models.MediaItem, 0)
+	for _, items := range perLibrary {
+		for _, it := range items {
+			if it == nil {
+				continue
+			}
+			existing, ok := byID[it.ContentID]
+			if !ok {
+				byID[it.ContentID] = it
+				order = append(order, it)
+				continue
+			}
+			// Keep the earliest first_seen_at to preserve MIN semantics.
+			if addedAtBefore(it.AddedAt, existing.AddedAt) {
+				existing.AddedAt = it.AddedAt
+			}
+		}
+	}
+	// Re-sort after dedup because collapsing to MIN(first_seen_at) can move an
+	// item earlier than its position in any single per-library slice.
+	slices.SortStableFunc(order, compareRecentlyAdded)
+	return order
+}
+
+// compareRecentlyAdded orders items by AddedAt DESC, then content_id ASC,
+// matching "ORDER BY mil.first_seen_at DESC, mi.content_id ASC". A nil AddedAt
+// sorts last (treated as the oldest).
+func compareRecentlyAdded(a, b *models.MediaItem) int {
+	at, bt := a.AddedAt, b.AddedAt
+	switch {
+	case at == nil && bt == nil:
+		// fall through to the content_id tie-break
+	case at == nil:
+		return 1
+	case bt == nil:
+		return -1
+	default:
+		if at.After(*bt) {
+			return -1
+		}
+		if at.Before(*bt) {
+			return 1
+		}
+	}
+	return strings.Compare(a.ContentID, b.ContentID)
+}
+
+// addedAtBefore reports whether a is strictly earlier than b, treating nil as
+// the oldest possible value so a real timestamp always wins the MIN.
+func addedAtBefore(a, b *time.Time) bool {
+	if a == nil {
+		return b != nil
+	}
+	if b == nil {
+		return false
+	}
+	return a.Before(*b)
+}
+
 // browseQueryPlan captures the rendered SQL fragments and bound args for a
 // browse data query. It is produced by buildBrowsePlan and consumed both by
 // browse() (to execute) and by tests (to inspect the emitted SQL without a

--- a/internal/catalog/browse_recently_added_merge_test.go
+++ b/internal/catalog/browse_recently_added_merge_test.go
@@ -1,0 +1,108 @@
+package catalog
+
+import (
+	"testing"
+	"time"
+
+	"github.com/Silo-Server/silo-server/internal/models"
+)
+
+func tsPtr(t time.Time) *time.Time { return &t }
+
+func contentIDs(items []*models.MediaItem) []string {
+	ids := make([]string, len(items))
+	for i, it := range items {
+		ids[i] = it.ContentID
+	}
+	return ids
+}
+
+func TestMergeRecentlyAddedItems_OrdersByAddedAtDescThenContentID(t *testing.T) {
+	base := time.Date(2026, 6, 1, 0, 0, 0, 0, time.UTC)
+	// Two already-sorted per-library slices (added_at DESC, content_id ASC).
+	libA := []*models.MediaItem{
+		{ContentID: "a3", AddedAt: tsPtr(base.Add(3 * time.Hour))},
+		{ContentID: "a1", AddedAt: tsPtr(base.Add(1 * time.Hour))},
+	}
+	libB := []*models.MediaItem{
+		{ContentID: "b4", AddedAt: tsPtr(base.Add(4 * time.Hour))},
+		{ContentID: "b2", AddedAt: tsPtr(base.Add(2 * time.Hour))},
+	}
+
+	got := contentIDs(mergeRecentlyAddedItems([][]*models.MediaItem{libA, libB}))
+	want := []string{"b4", "a3", "b2", "a1"}
+	if len(got) != len(want) {
+		t.Fatalf("merged length = %d, want %d (%v)", len(got), len(want), got)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("merged order = %v, want %v", got, want)
+		}
+	}
+}
+
+func TestMergeRecentlyAddedItems_TieBreaksByContentIDAsc(t *testing.T) {
+	at := time.Date(2026, 6, 1, 12, 0, 0, 0, time.UTC)
+	libA := []*models.MediaItem{{ContentID: "zeta", AddedAt: tsPtr(at)}}
+	libB := []*models.MediaItem{{ContentID: "alpha", AddedAt: tsPtr(at)}}
+
+	got := contentIDs(mergeRecentlyAddedItems([][]*models.MediaItem{libA, libB}))
+	want := []string{"alpha", "zeta"}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("tie-break order = %v, want %v", got, want)
+		}
+	}
+}
+
+func TestMergeRecentlyAddedItems_DedupsKeepingEarliestAddedAt(t *testing.T) {
+	early := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+	late := time.Date(2026, 6, 1, 0, 0, 0, 0, time.UTC)
+	other := time.Date(2026, 3, 1, 0, 0, 0, 0, time.UTC)
+
+	// "dup" appears in both libraries with different first_seen_at. The merge
+	// must collapse it to one entry carrying the EARLIEST timestamp (MIN
+	// semantics), which also moves it after "other" in DESC order.
+	libA := []*models.MediaItem{
+		{ContentID: "dup", AddedAt: tsPtr(late)},
+	}
+	libB := []*models.MediaItem{
+		{ContentID: "other", AddedAt: tsPtr(other)},
+		{ContentID: "dup", AddedAt: tsPtr(early)},
+	}
+
+	merged := mergeRecentlyAddedItems([][]*models.MediaItem{libA, libB})
+	if got := len(merged); got != 2 {
+		t.Fatalf("merged length = %d, want 2 (dup must collapse): %v", got, contentIDs(merged))
+	}
+	// other (March) should now precede dup (January).
+	want := []string{"other", "dup"}
+	for i := range want {
+		if merged[i].ContentID != want[i] {
+			t.Fatalf("dedup order = %v, want %v", contentIDs(merged), want)
+		}
+	}
+	var dup *models.MediaItem
+	for _, it := range merged {
+		if it.ContentID == "dup" {
+			dup = it
+		}
+	}
+	if dup.AddedAt == nil || !dup.AddedAt.Equal(early) {
+		t.Fatalf("dup AddedAt = %v, want earliest %v", dup.AddedAt, early)
+	}
+}
+
+func TestMergeRecentlyAddedItems_NilAddedAtSortsLast(t *testing.T) {
+	at := time.Date(2026, 6, 1, 0, 0, 0, 0, time.UTC)
+	libA := []*models.MediaItem{{ContentID: "nil1", AddedAt: nil}}
+	libB := []*models.MediaItem{{ContentID: "dated", AddedAt: tsPtr(at)}}
+
+	got := contentIDs(mergeRecentlyAddedItems([][]*models.MediaItem{libA, libB}))
+	want := []string{"dated", "nil1"}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("nil-handling order = %v, want %v", got, want)
+		}
+	}
+}

--- a/internal/catalog/detail.go
+++ b/internal/catalog/detail.go
@@ -677,7 +677,22 @@ func (s *DetailService) PendingTranslationLanguage(ctx context.Context, item *mo
 		return ""
 	}
 	loc, err := s.itemLocRepo.Get(ctx, item.ContentID, language)
-	if err != nil || (loc != nil && loc.Overview != "") {
+	if err != nil {
+		return ""
+	}
+	return pendingTranslationLanguageWith(item, language, loc)
+}
+
+// pendingTranslationLanguageWith is the shared core of PendingTranslationLanguage:
+// it decides the pending-translation language for an item given a pre-resolved
+// presentation language and the item's localization row (nil when none exists).
+// The batch detail path reuses it after a single bulk localization lookup so it
+// yields an identical result to the per-item method.
+func pendingTranslationLanguageWith(item *models.MediaItem, language string, loc *models.MediaItemLocalization) string {
+	if item == nil || strings.TrimSpace(item.Overview) == "" || language == "" || sameMetadataLanguage(item.DefaultMetadataLanguage, language) {
+		return ""
+	}
+	if loc != nil && loc.Overview != "" {
 		return ""
 	}
 	return language
@@ -744,10 +759,22 @@ func (s *DetailService) LocalizeItemModel(ctx context.Context, item *models.Medi
 		return cloneMediaItem(item), err
 	}
 	loc, err := s.itemLocRepo.Get(ctx, item.ContentID, language)
-	if err != nil || loc == nil {
+	if err != nil {
 		return cloneMediaItem(item), err
 	}
-	return applyItemLocalization(item, loc), nil
+	return s.localizeItemModelWith(item, language, loc), nil
+}
+
+// localizeItemModelWith applies a pre-resolved localization to item, returning a
+// clone when there is nothing to localize (no language, base language already
+// matches, no localization repo, or no localization row). Shared core of
+// LocalizeItemModel so the batch detail path produces identical models after a
+// single bulk localization lookup.
+func (s *DetailService) localizeItemModelWith(item *models.MediaItem, language string, loc *models.MediaItemLocalization) *models.MediaItem {
+	if language == "" || sameMetadataLanguage(item.DefaultMetadataLanguage, language) || s.itemLocRepo == nil || loc == nil {
+		return cloneMediaItem(item)
+	}
+	return applyItemLocalization(item, loc)
 }
 
 // LocalizeItemModels applies presentation-language localization to a batch of
@@ -876,7 +903,7 @@ func (s *DetailService) GetItemDetail(ctx context.Context, contentID string, fil
 		if err := s.validatePresentationItemAccess(ctx, filter, contentID); err != nil {
 			return nil, err
 		}
-		return s.buildMediaItemDetail(ctx, item, contentID, filter)
+		return s.buildMediaItemDetail(ctx, item, contentID, filter, nil)
 	case !errors.Is(err, ErrItemNotFound):
 		return nil, err
 	}
@@ -1005,6 +1032,164 @@ func (s *DetailService) GetEpisodeDetailsForSeries(
 	return result, nil
 }
 
+// fileVersionBatchFetcher is the optional batch form of FileVersionFetcher.
+// When the configured fetcher implements it, GetItemDetailsByIDs loads every
+// page item's media files in one query instead of one per item. Fetchers that
+// don't implement it (e.g. some test fakes) transparently fall back to the
+// per-item GetByContentID path inside buildMediaItemDetail.
+type fileVersionBatchFetcher interface {
+	ListByContentIDs(ctx context.Context, contentIDs []string) (map[string][]*models.MediaFile, error)
+}
+
+// GetItemDetailsByIDs returns full item details for the given content IDs,
+// batching the shared per-item lookups that GetItemDetail otherwise issues
+// one-at-a-time: row load (GetByIDs), access checks (EnsureAccessibleIDs +
+// presentation-library membership), localization, credits, media files, and
+// work summaries. The detail produced for each id is byte-for-byte identical to
+// calling GetItemDetail(id): the same builder (buildMediaItemDetail) assembles
+// it, only fed pre-resolved inputs via itemDetailPrefetch. Any input building
+// block missing a batch form falls back to its inline per-item lookup, so the
+// output never drifts from the unbatched path.
+//
+// IDs that are not item-typed media (e.g. episodes or seasons — handled by
+// GetEpisodeDetailsForSeries / GetItemDetail respectively), are access-filtered,
+// or fail to build are simply absent from the result map, mirroring
+// GetItemDetail returning an error so callers fall back to list-level rendering.
+func (s *DetailService) GetItemDetailsByIDs(ctx context.Context, contentIDs []string, filter AccessFilter) (map[string]*ItemDetail, error) {
+	result := make(map[string]*ItemDetail, len(contentIDs))
+	if len(contentIDs) == 0 {
+		return result, nil
+	}
+
+	items, err := s.itemRepo.GetByIDs(ctx, contentIDs)
+	if err != nil {
+		return nil, err
+	}
+	if len(items) == 0 {
+		return result, nil
+	}
+
+	foundIDs := make([]string, 0, len(items))
+	for _, item := range items {
+		foundIDs = append(foundIDs, item.ContentID)
+	}
+
+	// Access checks, batched to match GetItemDetail's per-item EnsureAccessible
+	// and validatePresentationItemAccess exactly.
+	accessible, err := s.itemRepo.EnsureAccessibleIDs(ctx, foundIDs, filter)
+	if err != nil {
+		return nil, err
+	}
+	presentationOK := func(string) bool { return true }
+	if filter.PresentationLibraryID != nil {
+		membership, err := s.itemRepo.GetItemsInLibrary(ctx, foundIDs, *filter.PresentationLibraryID)
+		if err != nil {
+			return nil, err
+		}
+		presentationOK = func(id string) bool { return membership[id] }
+	}
+
+	visible := make([]*models.MediaItem, 0, len(items))
+	visibleIDs := make([]string, 0, len(items))
+	nonSeriesIDs := make([]string, 0, len(items))
+	for _, item := range items {
+		if !accessible[item.ContentID] || !presentationOK(item.ContentID) {
+			continue
+		}
+		visible = append(visible, item)
+		visibleIDs = append(visibleIDs, item.ContentID)
+		if item.Type != "series" {
+			nonSeriesIDs = append(nonSeriesIDs, item.ContentID)
+		}
+	}
+	if len(visible) == 0 {
+		return result, nil
+	}
+
+	// Localization: resolve the presentation language once, then one bulk
+	// localization lookup. A resolution failure surfaces the same wrapped error
+	// GetItemDetail would produce from buildMediaItemDetail, so the caller
+	// degrades to the per-item path.
+	language, err := s.resolvePresentationLanguage(ctx, filter)
+	if err != nil {
+		return nil, fmt.Errorf("localizing item detail: %w", err)
+	}
+	var locByID map[string]*models.MediaItemLocalization
+	if language != "" && s.itemLocRepo != nil {
+		locByID, err = s.itemLocRepo.GetByContentIDs(ctx, visibleIDs, language)
+		if err != nil {
+			return nil, fmt.Errorf("localizing item detail: %w", err)
+		}
+	}
+
+	// Credits for the whole page in one query.
+	var creditsByID map[string][]models.ItemPerson
+	if s.personRepo != nil {
+		creditsByID, err = s.personRepo.ListForItems(ctx, visibleIDs)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	// Media files (playable versions) for non-series items in one query, when the
+	// fetcher supports batching.
+	var filesByID map[string][]*models.MediaFile
+	batchFetcher, haveFileBatch := s.fileFetcher.(fileVersionBatchFetcher)
+	if haveFileBatch && len(nonSeriesIDs) > 0 {
+		filesByID, err = batchFetcher.ListByContentIDs(ctx, nonSeriesIDs)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	// Work summaries for the whole page in one query, when the provider supports
+	// batching (ListSummariesForContentIDs is the documented batch equivalent of
+	// GetSummaryForContentID).
+	var workSummaries map[string]*WorkSummary
+	batchSummary, haveWorkSummaryBatch := s.workSummary.(WorkSummaryBatchProvider)
+	if haveWorkSummaryBatch {
+		workSummaries, err = batchSummary.ListSummariesForContentIDs(ctx, visibleIDs, filter)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	for _, item := range visible {
+		id := item.ContentID
+		loc := locByID[id]
+		pending := ""
+		if s.itemLocRepo != nil {
+			pending = pendingTranslationLanguageWith(item, language, loc)
+		}
+		pf := &itemDetailPrefetch{
+			haveLocalization:   true,
+			pendingTranslation: pending,
+			localizedItem:      s.localizeItemModelWith(item, language, loc),
+			haveCredits:        s.personRepo != nil,
+		}
+		if s.personRepo != nil {
+			pf.castCredits, pf.crewCredits = splitCastCrew(s.personCredits(ctx, creditsByID[id]))
+		}
+		if item.Type != "series" && haveFileBatch {
+			pf.haveFiles = true
+			pf.files = filesByID[id]
+		}
+		if haveWorkSummaryBatch {
+			pf.haveWorkSummary = true
+			pf.workSummary = workSummaries[id]
+		}
+		detail, err := s.buildMediaItemDetail(ctx, item, id, filter, pf)
+		if err != nil {
+			// Skip rather than fail the batch; the caller falls back to list
+			// rendering for any id missing from the result, matching the
+			// per-item path where one item's build error never breaks the page.
+			continue
+		}
+		result[id] = detail
+	}
+	return result, nil
+}
+
 // fetchCredits returns cast and crew credits for the given content ID.
 func (s *DetailService) fetchCredits(ctx context.Context, contentID string) ([]CastCredit, []CrewCredit) {
 	if s.personRepo == nil {
@@ -1018,14 +1203,45 @@ func (s *DetailService) fetchCredits(ctx context.Context, contentID string) ([]C
 	return splitCastCrew(credits)
 }
 
-func (s *DetailService) buildMediaItemDetail(ctx context.Context, item *models.MediaItem, contentID string, filter AccessFilter) (*ItemDetail, error) {
-	pendingTranslation := s.PendingTranslationLanguage(ctx, item, filter)
-	localizedItem, err := s.LocalizeItemModel(ctx, item, filter)
-	if err != nil {
-		return nil, fmt.Errorf("localizing item detail: %w", err)
+// itemDetailPrefetch carries per-item lookups that GetItemDetailsByIDs resolves
+// once for a whole page so buildMediaItemDetail can skip the equivalent per-item
+// queries. Each piece is opt-in via its "have" flag: when unset, the builder
+// falls back to its normal inline lookup, so the result is byte-for-byte
+// identical to the unbatched GetItemDetail path regardless of which pieces were
+// prefetched. A nil prefetch reproduces the original per-item behavior exactly.
+type itemDetailPrefetch struct {
+	haveLocalization   bool
+	pendingTranslation string
+	localizedItem      *models.MediaItem
+	haveCredits        bool
+	castCredits        []CastCredit
+	crewCredits        []CrewCredit
+	haveFiles          bool
+	files              []*models.MediaFile
+	haveWorkSummary    bool
+	workSummary        *WorkSummary
+}
+
+func (s *DetailService) buildMediaItemDetail(ctx context.Context, item *models.MediaItem, contentID string, filter AccessFilter, pf *itemDetailPrefetch) (*ItemDetail, error) {
+	var pendingTranslation string
+	if pf != nil && pf.haveLocalization {
+		pendingTranslation = pf.pendingTranslation
+		item = pf.localizedItem
+	} else {
+		pendingTranslation = s.PendingTranslationLanguage(ctx, item, filter)
+		localizedItem, err := s.LocalizeItemModel(ctx, item, filter)
+		if err != nil {
+			return nil, fmt.Errorf("localizing item detail: %w", err)
+		}
+		item = localizedItem
 	}
-	item = localizedItem
-	castCredits, crewCredits := s.fetchCredits(ctx, contentID)
+	var castCredits []CastCredit
+	var crewCredits []CrewCredit
+	if pf != nil && pf.haveCredits {
+		castCredits, crewCredits = pf.castCredits, pf.crewCredits
+	} else {
+		castCredits, crewCredits = s.fetchCredits(ctx, contentID)
+	}
 	detail := &ItemDetail{
 		ContentID:                  item.ContentID,
 		Type:                       item.Type,
@@ -1076,9 +1292,15 @@ func (s *DetailService) buildMediaItemDetail(ctx context.Context, item *models.M
 	// For series, each episode file shares the series content_id, so
 	// GetByContentID would return every episode — not alternate encodings.
 	if item.Type != "series" {
-		files, err := s.fileFetcher.GetByContentID(ctx, contentID)
-		if err != nil {
-			return nil, fmt.Errorf("fetching file versions: %w", err)
+		var files []*models.MediaFile
+		if pf != nil && pf.haveFiles {
+			files = pf.files
+		} else {
+			fetched, err := s.fileFetcher.GetByContentID(ctx, contentID)
+			if err != nil {
+				return nil, fmt.Errorf("fetching file versions: %w", err)
+			}
+			files = fetched
 		}
 
 		files = FilterMediaFilesByAccess(files, filter)
@@ -1149,7 +1371,11 @@ func (s *DetailService) buildMediaItemDetail(ctx context.Context, item *models.M
 		}
 	}
 
-	applyWorkSummary(ctx, detail, s.workSummary, filter)
+	if pf != nil && pf.haveWorkSummary {
+		applyWorkSummaryValue(detail, pf.workSummary)
+	} else {
+		applyWorkSummary(ctx, detail, s.workSummary, filter)
+	}
 	return detail, nil
 }
 
@@ -1158,7 +1384,17 @@ func applyWorkSummary(ctx context.Context, detail *ItemDetail, provider WorkSumm
 		return
 	}
 	summary, err := provider.GetSummaryForContentID(ctx, detail.ContentID, filter)
-	if err != nil || summary == nil {
+	if err != nil {
+		return
+	}
+	applyWorkSummaryValue(detail, summary)
+}
+
+// applyWorkSummaryValue copies a resolved work summary onto the detail. Shared by
+// the per-item (applyWorkSummary) and batched (GetItemDetailsByIDs) paths so a
+// summary fetched in bulk applies identically. A nil summary is a no-op.
+func applyWorkSummaryValue(detail *ItemDetail, summary *WorkSummary) {
+	if detail == nil || summary == nil {
 		return
 	}
 	detail.WorkID = summary.WorkID

--- a/internal/catalog/detail_batch_equivalence_test.go
+++ b/internal/catalog/detail_batch_equivalence_test.go
@@ -1,0 +1,281 @@
+package catalog
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"reflect"
+	"testing"
+	"time"
+
+	"github.com/jackc/pgx/v5/pgxpool"
+
+	"github.com/Silo-Server/silo-server/internal/models"
+)
+
+// batchEquivFileFetcher is a FileVersionFetcher (and the optional batch
+// fileVersionBatchFetcher) backed by one in-memory map. Serving both the
+// per-item GetByContentID and the batched ListByContentIDs from the same
+// backing data is exactly how the real scanner.FileRepository behaves: the two
+// methods return the same files for a given content ID. This lets the
+// equivalence test prove that GetItemDetailsByIDs routes prefetched files into
+// buildMediaItemDetail identically to the per-item GetItemDetail path, without
+// pulling the scanner package in (which would create an import cycle).
+type batchEquivFileFetcher struct {
+	files map[string][]*models.MediaFile
+}
+
+func (f *batchEquivFileFetcher) GetByContentID(_ context.Context, contentID string) ([]*models.MediaFile, error) {
+	return f.files[contentID], nil
+}
+
+func (f *batchEquivFileFetcher) GetByEpisodeID(_ context.Context, _ string) ([]*models.MediaFile, error) {
+	return nil, nil
+}
+
+func (f *batchEquivFileFetcher) ListByContentIDs(_ context.Context, contentIDs []string) (map[string][]*models.MediaFile, error) {
+	out := make(map[string][]*models.MediaFile, len(contentIDs))
+	for _, id := range contentIDs {
+		if files, ok := f.files[id]; ok {
+			out[id] = files
+		}
+	}
+	return out, nil
+}
+
+// batchEquivWorkSummaryProvider implements both the per-item
+// WorkSummaryProvider and the batched WorkSummaryBatchProvider from one backing
+// map, the same contract literaryworks.Repository satisfies in production. As
+// with files, this proves the batch path's work-summary routing matches the
+// per-item path without importing literaryworks (import cycle).
+type batchEquivWorkSummaryProvider struct {
+	summaries map[string]*WorkSummary
+}
+
+func (p *batchEquivWorkSummaryProvider) GetSummaryForContentID(_ context.Context, contentID string, _ AccessFilter) (*WorkSummary, error) {
+	return p.summaries[contentID], nil
+}
+
+func (p *batchEquivWorkSummaryProvider) ListSummariesForContentIDs(_ context.Context, contentIDs []string, _ AccessFilter) (map[string]*WorkSummary, error) {
+	out := make(map[string]*WorkSummary, len(contentIDs))
+	for _, id := range contentIDs {
+		if s, ok := p.summaries[id]; ok {
+			out[id] = s
+		}
+	}
+	return out, nil
+}
+
+func newBatchEquivTestPool(t *testing.T) *pgxpool.Pool {
+	t.Helper()
+	dsn := os.Getenv("SILO_TEST_DATABASE_URL")
+	if dsn == "" {
+		t.Skip("SILO_TEST_DATABASE_URL is not set")
+	}
+	ctx := context.Background()
+	pool, err := pgxpool.New(ctx, dsn)
+	if err != nil {
+		t.Fatalf("connect test database: %v", err)
+	}
+	t.Cleanup(pool.Close)
+	var tableName *string
+	if err := pool.QueryRow(ctx, `SELECT to_regclass('public.media_items')::text`).Scan(&tableName); err != nil {
+		t.Fatalf("check media_items table: %v", err)
+	}
+	if tableName == nil || *tableName == "" {
+		t.Skip("test database has not applied base schema")
+	}
+	return pool
+}
+
+func batchEquivExec(t *testing.T, pool *pgxpool.Pool, sql string, args ...any) {
+	t.Helper()
+	if _, err := pool.Exec(context.Background(), sql, args...); err != nil {
+		t.Fatalf("seed (%s): %v", sql, err)
+	}
+}
+
+// TestGetItemDetailsByIDs_MatchesGetItemDetail exercises the REAL
+// DetailService.GetItemDetailsByIDs against the REAL per-item GetItemDetail over
+// shared in-memory/real repositories, asserting per-id deep equality of the
+// returned *ItemDetail.
+//
+// Unlike the jellycompat handler test (which stubs the content service so both
+// paths return the same canned *ItemDetail), this drives the genuinely-batched
+// repository code: ItemRepository.GetByIDs vs GetByID, EnsureAccessibleIDs vs
+// EnsureAccessible, MediaItemLocalizationRepository.GetByContentIDs vs Get, and
+// PersonRepository.ListForItems vs ListForItem all run against a real Postgres.
+// Media files and work summaries route through interface fakes that serve the
+// batch and per-item method shapes from one backing map (mirroring the real
+// FileRepository / literaryworks.Repository), so the file/work-summary
+// prefetch wiring is compared too.
+//
+// Equivalence axes covered, with a mixed movie+movie+series dataset:
+//   - access checks (EnsureAccessibleIDs vs EnsureAccessible), incl. an
+//     access-filtered R-rated item asserted ABSENT from the batch map and
+//     rejected by per-item GetItemDetail;
+//   - localization: a movie with an fr localization row (localized title/
+//     overview path) alongside a movie that has none (nil short-circuit) and
+//     a pending-translation-language case;
+//   - credits ordering (ListForItems vs ListForItem) on the first movie;
+//   - media files (ListByContentIDs vs GetByContentID) on the first movie;
+//   - work summary (ListSummariesForContentIDs vs GetSummaryForContentID) on
+//     the series.
+func TestGetItemDetailsByIDs_MatchesGetItemDetail(t *testing.T) {
+	pool := newBatchEquivTestPool(t)
+	ctx := context.Background()
+
+	suffix := time.Now().UnixNano()
+	movieA := fmt.Sprintf("batch-equiv-movie-a-%d", suffix)
+	movieB := fmt.Sprintf("batch-equiv-movie-b-%d", suffix)
+	series := fmt.Sprintf("batch-equiv-series-%d", suffix)
+	movieR := fmt.Sprintf("batch-equiv-movie-r-%d", suffix)
+	personActor1 := suffix
+	personActor2 := suffix + 1
+	personDirector := suffix + 2
+
+	t.Cleanup(func() {
+		ids := []string{movieA, movieB, series, movieR}
+		batchEquivExec(t, pool, `DELETE FROM item_people WHERE content_id = ANY($1)`, ids)
+		batchEquivExec(t, pool, `DELETE FROM people WHERE id = ANY($1)`, []int64{personActor1, personActor2, personDirector})
+		batchEquivExec(t, pool, `DELETE FROM media_item_localizations WHERE content_id = ANY($1)`, ids)
+		batchEquivExec(t, pool, `DELETE FROM media_items WHERE content_id = ANY($1)`, ids)
+	})
+
+	insertItem := func(contentID, mediaType, title, overview, rating string) {
+		batchEquivExec(t, pool, `
+			INSERT INTO media_items (content_id, type, title, genres, overview, content_rating, default_metadata_language)
+			VALUES ($1, $2, $3, '{}'::text[], $4, $5, 'en')
+		`, contentID, mediaType, title, overview, rating)
+	}
+	// movieA: localized into fr, credited, has files. content_rating PG -> visible.
+	insertItem(movieA, "movie", "Movie A", "Movie A overview (en)", "PG")
+	// movieB: overview present, default lang en, NO fr localization row -> the
+	// pending-translation-language path must fire and match between paths.
+	insertItem(movieB, "movie", "Movie B", "Movie B overview (en)", "PG")
+	// series: has a work summary, no playable files (series skip the file path).
+	insertItem(series, "series", "Series One", "Series overview (en)", "PG")
+	// movieR: R-rated -> filtered out by MaxContentRating=PG-13 on BOTH paths.
+	insertItem(movieR, "movie", "Movie R", "Movie R overview (en)", "R")
+
+	// fr localization for movieA only.
+	batchEquivExec(t, pool, `
+		INSERT INTO media_item_localizations (
+			content_id, language, title, sort_title, overview, tagline,
+			poster_path, poster_source_path, poster_thumbhash,
+			backdrop_path, backdrop_source_path, backdrop_thumbhash,
+			logo_path, logo_source_path, overview_source, tagline_source
+		)
+		VALUES ($1, 'fr', 'Film A', '', 'Synopsis du film A (fr)', '',
+			'', '', '', '', '', '', '', '', 'manual', 'manual')
+	`, movieA)
+
+	// Credits on movieA: two actors (cast) + one director (crew). Seeded with
+	// sort_order so ListForItems / ListForItem ordering parity is observable.
+	insertPerson := func(id int64, name string) {
+		batchEquivExec(t, pool, `INSERT INTO people (id, name) VALUES ($1, $2)`, id, name)
+	}
+	insertPerson(personActor1, "Lead Actor")
+	insertPerson(personActor2, "Supporting Actor")
+	insertPerson(personDirector, "The Director")
+	insertCredit := func(id, personID int64, kind models.PersonKind, character string, order int) {
+		batchEquivExec(t, pool, `
+			INSERT INTO item_people (id, person_id, content_id, kind, character, sort_order)
+			VALUES ($1, $2, $3, $4, $5, $6)
+		`, id, personID, movieA, int16(kind), character, order)
+	}
+	insertCredit(personActor1, personActor1, models.PersonKindActor, "Hero", 0)
+	insertCredit(personActor2, personActor2, models.PersonKindActor, "Sidekick", 1)
+	insertCredit(personDirector, personDirector, models.PersonKindDirector, "", 0)
+
+	fileFetcher := &batchEquivFileFetcher{files: map[string][]*models.MediaFile{
+		movieA: {
+			{ID: 9001, ContentID: movieA, FilePath: "/media/movie-a-1080p.mkv", Container: "mkv", Resolution: "1080p", Duration: 6000, FileSize: 5_000_000},
+			{ID: 9002, ContentID: movieA, FilePath: "/media/movie-a-720p.mkv", Container: "mkv", Resolution: "720p", Duration: 6000, FileSize: 2_000_000},
+		},
+	}}
+	workSummaries := &batchEquivWorkSummaryProvider{summaries: map[string]*WorkSummary{
+		series: {
+			WorkID: "work-series-1",
+			Title:  "Series One Work",
+			Formats: []WorkFormatSummary{
+				{Type: "series", ContentID: series, LibraryID: 3},
+			},
+		},
+	}}
+
+	newService := func() *DetailService {
+		svc := NewDetailService(
+			NewItemRepository(pool),
+			NewEpisodeRepository(pool),
+			NewSeasonRepository(pool),
+			NewPersonRepository(pool),
+			fileFetcher,
+		)
+		svc.SetWorkSummaryProvider(workSummaries)
+		return svc
+	}
+
+	// Single shared access filter for BOTH paths: PG-13 ceiling (so PG items are
+	// visible, the R item is not) and an explicit fr presentation language (so
+	// the localization path actually runs rather than short-circuiting).
+	filter := AccessFilter{
+		PresentationLanguage: "fr",
+		MaxContentRating:     "PG-13",
+		UserID:               1,
+		ProfileID:            "profile-1",
+	}
+
+	visibleIDs := []string{movieA, movieB, series}
+	allIDs := []string{movieA, movieB, series, movieR}
+
+	batch, err := newService().GetItemDetailsByIDs(ctx, allIDs, filter)
+	if err != nil {
+		t.Fatalf("GetItemDetailsByIDs: %v", err)
+	}
+
+	// Access-control parity: the R-rated item must be absent from the batch map
+	// and rejected by per-item GetItemDetail, i.e. EnsureAccessibleIDs and
+	// EnsureAccessible agree.
+	if _, present := batch[movieR]; present {
+		t.Fatalf("access-filtered item %s present in batch result", movieR)
+	}
+	if _, err := newService().GetItemDetail(ctx, movieR, filter); err == nil {
+		t.Fatalf("per-item GetItemDetail(%s) succeeded, want access rejection", movieR)
+	}
+
+	for _, id := range visibleIDs {
+		batchDetail, ok := batch[id]
+		if !ok {
+			t.Fatalf("id %s missing from batch result", id)
+		}
+		perItem, err := newService().GetItemDetail(ctx, id, filter)
+		if err != nil {
+			t.Fatalf("GetItemDetail(%s): %v", id, err)
+		}
+		if !reflect.DeepEqual(batchDetail, perItem) {
+			t.Fatalf("detail mismatch for %s:\nbatch:   %#v\nperItem: %#v", id, batchDetail, perItem)
+		}
+	}
+
+	// Guard that the distinguishing data actually landed (otherwise the deep
+	// equality above could pass vacuously on empty details).
+	if got := batch[movieA]; got.Title != "Film A" || got.Overview != "Synopsis du film A (fr)" {
+		t.Fatalf("movieA not localized into fr: title=%q overview=%q", got.Title, got.Overview)
+	}
+	if got := batch[movieA]; len(got.Cast) != 2 || len(got.Crew) != 1 {
+		t.Fatalf("movieA credits = %d cast / %d crew, want 2/1", len(got.Cast), len(got.Crew))
+	}
+	if got := batch[movieA]; got.Cast[0].Character != "Hero" || got.Cast[1].Character != "Sidekick" {
+		t.Fatalf("movieA cast order = %q,%q, want Hero,Sidekick", got.Cast[0].Character, got.Cast[1].Character)
+	}
+	if got := batch[movieA]; len(got.Versions) != 2 {
+		t.Fatalf("movieA versions = %d, want 2 (file prefetch not applied)", len(got.Versions))
+	}
+	if got := batch[movieB]; got.PendingTranslationLanguage != "fr" {
+		t.Fatalf("movieB pending translation language = %q, want fr", got.PendingTranslationLanguage)
+	}
+	if got := batch[series]; got.WorkID != "work-series-1" {
+		t.Fatalf("series work summary not applied: WorkID=%q", got.WorkID)
+	}
+}

--- a/internal/catalog/episode_catalog_entries_executor.go
+++ b/internal/catalog/episode_catalog_entries_executor.go
@@ -32,6 +32,31 @@ type episodeCatalogUserStatePlan struct {
 	requireProgressRatio bool
 }
 
+// applyEpisodeCatalogAccessFilter applies the section access constraints the
+// episode_catalog_entries table supports. The table has no `type` column, so
+// the compat audiobook/podcast media-type exclusion cannot be expressed here:
+// emitting `NOT (ece.type = ANY(...))` raised SQLSTATE 42703 and degraded the
+// whole query to empty. The exclusion is therefore dropped on this path.
+//
+// Dropping it is NOT a no-op masquerading as cosmetic: episode_catalog_entries
+// is NOT episodes-of-TV-series only — episode_libraries is populated from any
+// media_files row with a non-null episode_id, so podcast episodes
+// (media_items.type = 'podcast') also land here. What keeps non-TV episodes out
+// of episode-scoped results is library scoping plus the `si.type = 'series'`
+// guard in episodeCatalogSelectBody (hydration), not the media-type clause.
+// content_rating filtering is preserved here (that column exists).
+//
+// Because hydration's si.type='series' guard drops non-series rows AFTER the
+// page/count scans select them, the scan and hydration would otherwise diverge:
+// pages could under-fill and TotalRecordCount could count rows that never
+// render. episodeCatalogSeriesParentGuard re-expresses that same constraint at
+// the entry-scan level so both queries stay aligned with hydration.
+func applyEpisodeCatalogAccessFilter(access AccessFilter, whereParts *[]string, args *[]any, argIdx *int) {
+	access.ExcludedMediaTypes = nil // access is a value param; caller unaffected
+	ApplySectionAccessFilter("ece", access, whereParts, args, argIdx)
+	*whereParts = append(*whereParts, episodeCatalogSeriesParentGuard)
+}
+
 func (e *QueryExecutor) tryEpisodeCatalogUserStatePreviewPage(
 	ctx context.Context,
 	def QueryDefinition,
@@ -84,7 +109,7 @@ func (e *QueryExecutor) tryEpisodeCatalogUserStatePreviewPage(
 		argIdx++
 	}
 
-	ApplySectionAccessFilter("ece", access, &whereParts, &args, &argIdx)
+	applyEpisodeCatalogAccessFilter(access, &whereParts, &args, &argIdx)
 
 	if e.SnapshotAt != nil {
 		whereParts = append(whereParts, fmt.Sprintf("ece.episode_created_at <= $%d", argIdx))
@@ -242,7 +267,7 @@ func (e *QueryExecutor) tryEpisodeCatalogEntriesPreviewPage(
 		argIdx++
 	}
 
-	ApplySectionAccessFilter("ece", access, &whereParts, &args, &argIdx)
+	applyEpisodeCatalogAccessFilter(access, &whereParts, &args, &argIdx)
 
 	if e.SnapshotAt != nil {
 		whereParts = append(whereParts, fmt.Sprintf("ece.episode_created_at <= $%d", argIdx))

--- a/internal/catalog/episode_catalog_select_body_test.go
+++ b/internal/catalog/episode_catalog_select_body_test.go
@@ -45,6 +45,31 @@ func TestEpisodeCatalogSelectBodyExposesQualifiedColumns(t *testing.T) {
 	}
 }
 
+// TestEpisodeCatalogSelectBodyExcludesNonSeriesEpisodes guards the invariant
+// that the episode catalog only ever hydrates episodes whose parent is a TV
+// series. episode_libraries (and episode_catalog_entries) also contain podcast
+// episodes (media_items.type = 'podcast'); the `si.type = 'series'` predicate in
+// episodeCatalogSelectBody is what keeps those non-TV rows out of episode-scoped
+// results regardless of which library a query resolves. Dropping it would let
+// podcast/audiobook episodes surface in a TV "episode" rail (fail-open).
+func TestEpisodeCatalogSelectBodyExcludesNonSeriesEpisodes(t *testing.T) {
+	if !strings.Contains(episodeCatalogBaseRelation, "si.type = 'series'") {
+		t.Fatalf("episodeCatalogBaseRelation must guard si.type = 'series' so non-TV "+
+			"(podcast/audiobook) episodes never hydrate; got %q", episodeCatalogBaseRelation)
+	}
+
+	// The library-scoped relation and the hydration relation render from the same
+	// template, so the guard must travel with every rendering.
+	scoped, _, handled := episodeCatalogBaseRelationForLibraries([]int{2}, nil, 1)
+	if !handled {
+		t.Fatal("expected episode library scope to be handled")
+	}
+	if !strings.Contains(scoped, "si.type = 'series'") {
+		t.Fatalf("library-scoped episode relation must keep the si.type = 'series' "+
+			"guard; got %q", scoped)
+	}
+}
+
 // columnsReferencedOnAlias returns every distinct column referenced as
 // "<alias>.<column>" within projection (e.g. mi.air_timezone -> air_timezone).
 func columnsReferencedOnAlias(projection, alias string) map[string]bool {

--- a/internal/catalog/episode_catalog_source.go
+++ b/internal/catalog/episode_catalog_source.go
@@ -5,6 +5,18 @@ import (
 	"strings"
 )
 
+// episodeCatalogSelectBody is the hand-written subquery that hydrates episode
+// rows for the "episode" media scope, aliased "mi" so the shared catalog
+// projection can read it. The `si.type = 'series'` predicate is load-bearing,
+// not cosmetic: episode_libraries (and thus episode_catalog_entries) is
+// populated from every media_files row with a non-null episode_id, including
+// podcast episodes (media_items.type = 'podcast'). Without this guard those
+// non-TV episodes would hydrate into episode-scoped results, e.g. when a
+// library-scoped episode query happens to resolve a podcast/audiobook folder.
+// Restricting hydration to series-parented episodes keeps the episode catalog
+// to genuine TV episodes on every surface (native and Jellyfin-compat). Real
+// TV episodes always hang off a type='series' parent, so this never
+// over-filters legitimate episode sections.
 const episodeCatalogSelectBody = `(
 	SELECT
 		e.content_id,
@@ -63,8 +75,26 @@ const episodeCatalogSelectBody = `(
 	FROM episodes e
 	JOIN media_items si ON si.content_id = e.series_id
 	LEFT JOIN seasons s ON s.content_id = e.season_id
-	WHERE %s
+	WHERE (%s)
+	  AND si.type = 'series'
 ) mi`
+
+// episodeCatalogSeriesParentGuard mirrors the load-bearing `si.type = 'series'`
+// predicate in episodeCatalogSelectBody, but expressed against an entry-scan row
+// (ece.episode_id) instead of the hydration join. episode_catalog_entries rows
+// can reference episodes parented to non-series media_items (e.g. podcast
+// episodes), which hydration silently drops. Applying this same constraint to
+// the page and count scans keeps them aligned with hydration so pages never
+// under-fill and TotalRecordCount never counts rows that can't hydrate. It binds
+// no parameters, so it can be appended to any whereParts list without touching
+// the argument index.
+const episodeCatalogSeriesParentGuard = `EXISTS (
+		SELECT 1
+		FROM episodes e
+		JOIN media_items si ON si.content_id = e.series_id
+		WHERE e.content_id = ece.episode_id
+		  AND si.type = 'series'
+	)`
 
 const episodeCatalogActiveLibraryExists = `EXISTS (
 		SELECT 1

--- a/internal/catalog/episode_repo.go
+++ b/internal/catalog/episode_repo.go
@@ -827,6 +827,50 @@ func (r *EpisodeRepository) ListBySeason(ctx context.Context, seriesID string, s
 	return scanEpisodes(rows)
 }
 
+// ListAdjacentInSeries returns the episode at (seasonNumber, episodeNumber)
+// together with its immediate previous and next available neighbors within the
+// series, in natural (season, episode) order. It is the bounded backing query
+// for Jellyfin's AdjacentTo request (Wholphin autoplay/skip): instead of
+// materializing every episode of the series, each neighbor is found with a
+// bounded index range scan backed by the episodes_series_season_episode_key
+// UNIQUE index (series_id, season_number, episode_number). Neighbors are
+// resolved across season boundaries, so the result is at most three rows.
+func (r *EpisodeRepository) ListAdjacentInSeries(ctx context.Context, seriesID string, seasonNumber, episodeNumber int) ([]*models.Episode, error) {
+	query := `SELECT ` + episodeColumns + ` FROM (
+		(SELECT ` + episodeColumns + `
+			FROM episodes
+			WHERE series_id = $1
+			  AND (season_number, episode_number) < ($2, $3)
+			  AND ` + episodeAvailabilityPredicate + `
+			ORDER BY season_number DESC, episode_number DESC
+			LIMIT 1)
+		UNION ALL
+		(SELECT ` + episodeColumns + `
+			FROM episodes
+			WHERE series_id = $1
+			  AND season_number = $2
+			  AND episode_number = $3
+			  AND ` + episodeAvailabilityPredicate + `)
+		UNION ALL
+		(SELECT ` + episodeColumns + `
+			FROM episodes
+			WHERE series_id = $1
+			  AND (season_number, episode_number) > ($2, $3)
+			  AND ` + episodeAvailabilityPredicate + `
+			ORDER BY season_number ASC, episode_number ASC
+			LIMIT 1)
+	) AS adjacent
+	ORDER BY season_number ASC, episode_number ASC`
+
+	rows, err := r.pool.Query(ctx, query, seriesID, seasonNumber, episodeNumber)
+	if err != nil {
+		return nil, fmt.Errorf("listing adjacent episodes in series: %w", err)
+	}
+	defer rows.Close()
+
+	return scanEpisodes(rows)
+}
+
 // ListBySeasonID returns all episodes for a specific season row, ordered by
 // episode number.
 func (r *EpisodeRepository) ListBySeasonID(ctx context.Context, seasonID string) ([]*models.Episode, error) {

--- a/internal/catalog/item_repo.go
+++ b/internal/catalog/item_repo.go
@@ -1333,6 +1333,69 @@ func (r *ItemRepository) EnsureAccessible(ctx context.Context, contentID string,
 	return nil
 }
 
+// EnsureAccessibleIDs is the batch form of EnsureAccessible: it returns the set
+// of content IDs from the input that the viewer may access, applying the exact
+// same predicates (library allow/deny via the single JOIN form, max content
+// rating, excluded media types). An item is accessible iff at least one
+// media_items row — joined per library link when a library filter is active —
+// satisfies the predicates, matching EnsureAccessible's `LIMIT 1` semantics.
+// IDs absent from the returned map are not accessible (mirrors EnsureAccessible
+// returning ErrItemNotFound). Used by GetItemDetailsByIDs to avoid a per-item
+// EnsureAccessible fan-out.
+func (r *ItemRepository) EnsureAccessibleIDs(ctx context.Context, contentIDs []string, filter AccessFilter) (map[string]bool, error) {
+	result := make(map[string]bool, len(contentIDs))
+	if len(contentIDs) == 0 {
+		return result, nil
+	}
+	// An empty (non-nil) allowlist means "no libraries allowed" — nothing is
+	// accessible, exactly as EnsureAccessible returns ErrItemNotFound.
+	if filter.AllowedLibraryIDs != nil && len(filter.AllowedLibraryIDs) == 0 {
+		return result, nil
+	}
+
+	var conditions []string
+	var args []any
+	argIdx := 1
+
+	fromClause := "media_items mi"
+	conditions = append(conditions, fmt.Sprintf("mi.content_id = ANY($%d)", argIdx))
+	args = append(args, contentIDs)
+	argIdx++
+
+	needsLibJoin := filter.AllowedLibraryIDs != nil || len(filter.DisabledLibraryIDs) > 0
+	if filter.AllowedLibraryIDs != nil {
+		conditions = append(conditions, fmt.Sprintf("mil.media_folder_id = ANY($%d)", argIdx))
+		args = append(args, filter.AllowedLibraryIDs)
+		argIdx++
+	}
+	if len(filter.DisabledLibraryIDs) > 0 {
+		conditions = append(conditions, fmt.Sprintf("NOT (mil.media_folder_id = ANY($%d))", argIdx))
+		args = append(args, filter.DisabledLibraryIDs)
+		argIdx++
+	}
+	if needsLibJoin {
+		fromClause = "media_items mi JOIN media_item_libraries mil ON mi.content_id = mil.content_id"
+	}
+
+	applyAccessFilter("mi", AccessFilter{MaxContentRating: filter.MaxContentRating, ExcludedMediaTypes: filter.ExcludedMediaTypes}, &conditions, &args, &argIdx)
+
+	query := fmt.Sprintf("SELECT DISTINCT mi.content_id FROM %s WHERE %s", fromClause, strings.Join(conditions, " AND "))
+	rows, err := r.pool.Query(ctx, query, args...)
+	if err != nil {
+		return nil, fmt.Errorf("checking items access: %w", err)
+	}
+	defer rows.Close()
+
+	for rows.Next() {
+		var id string
+		if err := rows.Scan(&id); err != nil {
+			return nil, fmt.Errorf("scanning item access row: %w", err)
+		}
+		result[id] = true
+	}
+	return result, rows.Err()
+}
+
 // GetItemsInLibrary returns a membership map for the provided content IDs within
 // a single library. Episode content IDs are matched directly against
 // episode_libraries so compat callers can filter mixed item/episode batches.

--- a/internal/jellycompat/audiobook_exclusion_test.go
+++ b/internal/jellycompat/audiobook_exclusion_test.go
@@ -160,6 +160,11 @@ func (f *scopeFakeBrowseSource) BrowsePage(_ context.Context, filters catalog.Br
 	return &catalog.BrowseResult{Items: []*models.MediaItem{}, Total: 0, HasMore: false}, nil
 }
 
+func (f *scopeFakeBrowseSource) BrowseRecentlyAddedAcrossLibraries(_ context.Context, base catalog.BrowseFilters, _ []int) (*catalog.BrowseResult, error) {
+	f.lastFilters = base
+	return &catalog.BrowseResult{Items: []*models.MediaItem{}, Total: 0, HasMore: false}, nil
+}
+
 func (f *scopeFakeBrowseSource) ListGenres(_ context.Context, filters catalog.BrowseFilters) ([]string, error) {
 	f.lastFilters = filters
 	return []string{}, nil

--- a/internal/jellycompat/batch_loaders.go
+++ b/internal/jellycompat/batch_loaders.go
@@ -43,6 +43,7 @@ type episodeRepoForBatchLoader interface {
 	HasFilesByIDs(ctx context.Context, contentIDs []string) (map[string]bool, error)
 	ListBySeason(ctx context.Context, seriesID string, seasonNum int) ([]*models.Episode, error)
 	ListBySeries(ctx context.Context, seriesID string) ([]*models.Episode, error)
+	ListAdjacentInSeries(ctx context.Context, seriesID string, seasonNumber, episodeNumber int) ([]*models.Episode, error)
 }
 
 func (h *ItemsHandler) fetchCompatItemsByContentIDs(ctx context.Context, session *Session, contentIDs []string, libraryID *int) (map[string]upstreamListItem, error) {

--- a/internal/jellycompat/batch_loaders_test.go
+++ b/internal/jellycompat/batch_loaders_test.go
@@ -111,6 +111,10 @@ func (r *countingEpisodeRepo) ListBySeries(context.Context, string) ([]*models.E
 	return nil, errors.New("ListBySeries not used in fallback test")
 }
 
+func (r *countingEpisodeRepo) ListAdjacentInSeries(context.Context, string, int, int) ([]*models.Episode, error) {
+	return nil, errors.New("ListAdjacentInSeries not used in fallback test")
+}
+
 func TestFilterContentIDsForLibrary_AppliesMembershipAndPreservesOrder(t *testing.T) {
 	libraryID := 7
 

--- a/internal/jellycompat/batch_progress_test.go
+++ b/internal/jellycompat/batch_progress_test.go
@@ -68,6 +68,10 @@ func (m *mockUserDataService) ListProgress(context.Context, *Session, string, in
 	panic("unused")
 }
 
+func (m *mockUserDataService) ListProgressFiltered(context.Context, *Session, string, []string, *int, int, int) ([]upstreamProgress, error) {
+	panic("unused")
+}
+
 func (m *mockUserDataService) FilterResumeProgress(_ context.Context, _ *Session, entries []upstreamProgress) ([]upstreamProgress, error) {
 	return entries, nil
 }
@@ -100,6 +104,18 @@ func (s *stubContentService) GetItemDetail(_ context.Context, _ *Session, conten
 		d.ContentID = contentID
 	}
 	return &d, nil
+}
+
+func (s *stubContentService) GetItemDetailsByIDs(ctx context.Context, session *Session, contentIDs []string, libraryID *int) (map[string]*upstreamItemDetail, error) {
+	out := make(map[string]*upstreamItemDetail, len(contentIDs))
+	for _, id := range contentIDs {
+		detail, err := s.GetItemDetail(ctx, session, id, libraryID)
+		if err != nil || detail == nil {
+			continue
+		}
+		out[id] = detail
+	}
+	return out, nil
 }
 
 func (s *stubContentService) ListUserLibraries(context.Context, *Session) ([]upstreamUserLibrary, error) {

--- a/internal/jellycompat/content_direct.go
+++ b/internal/jellycompat/content_direct.go
@@ -28,6 +28,7 @@ type LibraryPosterPresigner interface {
 // substitute a stub without standing up a Postgres pool.
 type browseSource interface {
 	BrowsePage(ctx context.Context, filters catalog.BrowseFilters, includeTotal bool) (*catalog.BrowseResult, error)
+	BrowseRecentlyAddedAcrossLibraries(ctx context.Context, base catalog.BrowseFilters, libraryIDs []int) (*catalog.BrowseResult, error)
 	ListGenres(ctx context.Context, filters catalog.BrowseFilters) ([]string, error)
 }
 
@@ -189,6 +190,7 @@ type episodeListSource interface {
 	ListBySeason(ctx context.Context, seriesID string, seasonNum int) ([]*models.Episode, error)
 	ListBySeriesGroupedBySeason(ctx context.Context, seriesID string) (map[int][]*models.Episode, error)
 	ListBySeriesIDs(ctx context.Context, seriesIDs []string) (map[string][]*models.Episode, error)
+	GetByIDs(ctx context.Context, contentIDs []string) ([]*models.Episode, error)
 }
 
 // directContentService implements ContentService by calling catalog repos directly.
@@ -264,18 +266,7 @@ func clampMaxContentRating(existing, requested string) string {
 func (s *directContentService) ListUserLibraries(ctx context.Context, session *Session) ([]upstreamUserLibrary, error) {
 	filter := s.resolveFilter(ctx, session)
 
-	var folders []*models.MediaFolder
-	var err error
-	if filter.AllowedLibraryIDs != nil {
-		// A non-nil allowlist means the viewer is restricted; an empty
-		// allowlist grants access to no libraries at all.
-		if len(filter.AllowedLibraryIDs) == 0 {
-			return []upstreamUserLibrary{}, nil
-		}
-		folders, err = s.folderRepo.ListByIDs(ctx, filter.AllowedLibraryIDs)
-	} else {
-		folders, err = s.folderRepo.GetEnabled(ctx)
-	}
+	folders, err := s.accessibleFolders(ctx, filter)
 	if err != nil {
 		return nil, fmt.Errorf("list libraries: %w", err)
 	}
@@ -313,6 +304,51 @@ func (s *directContentService) ListUserLibraries(ctx context.Context, session *S
 		libraries = append(libraries, lib)
 	}
 	return libraries, nil
+}
+
+// accessibleFolders resolves the media folders the viewer may browse, honoring
+// the allowlist semantics shared by the library and browse endpoints. A nil
+// AllowedLibraryIDs means unrestricted (all enabled libraries); a non-nil but
+// empty allowlist grants access to no libraries at all.
+func (s *directContentService) accessibleFolders(ctx context.Context, filter catalog.AccessFilter) ([]*models.MediaFolder, error) {
+	if filter.AllowedLibraryIDs != nil {
+		if len(filter.AllowedLibraryIDs) == 0 {
+			return nil, nil
+		}
+		return s.folderRepo.ListByIDs(ctx, filter.AllowedLibraryIDs)
+	}
+	return s.folderRepo.GetEnabled(ctx)
+}
+
+// accessibleLibraryIDs resolves the library IDs the viewer may browse, applying
+// the same allowlist/disabled-list semantics as ListUserLibraries. It is used to
+// fan a no-parentId recently_added browse into one fast single-library query per
+// library.
+func (s *directContentService) accessibleLibraryIDs(ctx context.Context, filter catalog.AccessFilter) ([]int, error) {
+	folders, err := s.accessibleFolders(ctx, filter)
+	if err != nil {
+		return nil, err
+	}
+	disabled := make(map[int]struct{}, len(filter.DisabledLibraryIDs))
+	for _, id := range filter.DisabledLibraryIDs {
+		disabled[id] = struct{}{}
+	}
+	ids := make([]int, 0, len(folders))
+	for _, f := range folders {
+		if _, ok := disabled[f.ID]; ok {
+			continue
+		}
+		// Audiobook and podcast libraries are served by the ABS-compat API and
+		// are never exposed on the Jellyfin surface. ListUserLibraries skips
+		// them; skip them here too so the recently_added fan-out can't pull
+		// compat-hidden libraries into /Items/Latest and so we don't waste a
+		// per-library query on folders that yield no Jellyfin-visible rows.
+		if isCompatHiddenLibraryType(f.Type) {
+			continue
+		}
+		ids = append(ids, f.ID)
+	}
+	return ids, nil
 }
 
 func (s *directContentService) BrowseItems(ctx context.Context, session *Session, params url.Values) (*upstreamBrowseResponse, error) {
@@ -356,6 +392,27 @@ func (s *directContentService) BrowseItems(ctx context.Context, session *Session
 		RequireBackdrop:    parseBool(params.Get("require_backdrop"), false),
 	}
 
+	// A no-parentId recently_added browse (the /Items/Latest hot path) would
+	// otherwise run a multi-library MIN(first_seen_at) + GROUP BY scan over the
+	// whole catalog. Fan it into one fast single-library index walk per library
+	// and merge in memory instead. Only offset 0 is served this way; deeper
+	// pages fall back to the multi-library query below.
+	crossLibraryRecentlyAdded := filters.Sort == "recently_added" && filters.LibraryID == 0
+	var crossLibraryIDs []int
+	if crossLibraryRecentlyAdded {
+		ids, err := s.accessibleLibraryIDs(ctx, filter)
+		if err != nil {
+			return nil, fmt.Errorf("browse items: %w", err)
+		}
+		// With 0 or 1 accessible libraries the single multi-library query is
+		// already the fast path, so leave behavior unchanged.
+		if len(ids) >= 2 {
+			crossLibraryIDs = ids
+		} else {
+			crossLibraryRecentlyAdded = false
+		}
+	}
+
 	var collected []upstreamListItem
 	totalFromCatalog := 0
 	totalKnown := false
@@ -368,7 +425,15 @@ func (s *directContentService) BrowseItems(ctx context.Context, session *Session
 
 	for len(collected) < requestedLimit && scannedRows < maxScannedRows {
 		wantTotal := includeTotal && !totalKnown
-		result, err := s.browseRepo.BrowsePage(ctx, filters, wantTotal)
+		var result *catalog.BrowseResult
+		var err error
+		if crossLibraryRecentlyAdded && filters.Offset == 0 {
+			// The merge helper returns a Total/HasMore consistent with offset 0,
+			// so wantTotal is satisfied without the expensive cross-library count.
+			result, err = s.browseRepo.BrowseRecentlyAddedAcrossLibraries(ctx, filters, crossLibraryIDs)
+		} else {
+			result, err = s.browseRepo.BrowsePage(ctx, filters, wantTotal)
+		}
 		if err != nil {
 			return nil, fmt.Errorf("browse items: %w", err)
 		}
@@ -378,13 +443,14 @@ func (s *directContentService) BrowseItems(ctx context.Context, session *Session
 		}
 		hasMore = result.HasMore
 
-		batch := make([]upstreamListItem, 0, len(result.Items))
-		for _, mi := range result.Items {
-			if s.detailSvc != nil {
-				if localized, locErr := s.detailSvc.LocalizeItemModel(ctx, mi, filter); locErr == nil && localized != nil {
-					mi = localized
-				}
+		localizedItems := result.Items
+		if s.detailSvc != nil {
+			if localized, locErr := s.detailSvc.LocalizeItemModels(ctx, result.Items, filter); locErr == nil && localized != nil {
+				localizedItems = localized
 			}
+		}
+		batch := make([]upstreamListItem, 0, len(localizedItems))
+		for _, mi := range localizedItems {
 			batch = append(batch, mediaItemToListItem(mi))
 		}
 		s.presignListItems(ctx, batch)
@@ -492,13 +558,14 @@ func (s *directContentService) SearchItems(ctx context.Context, session *Session
 		hasMore = opts.Offset+len(items) < total
 	}
 
-	listItems := make([]upstreamListItem, 0, len(items))
-	for _, mi := range items {
-		if s.detailSvc != nil {
-			if localized, locErr := s.detailSvc.LocalizeItemModel(ctx, mi, filter); locErr == nil && localized != nil {
-				mi = localized
-			}
+	localizedItems := items
+	if s.detailSvc != nil {
+		if localized, locErr := s.detailSvc.LocalizeItemModels(ctx, items, filter); locErr == nil && localized != nil {
+			localizedItems = localized
 		}
+	}
+	listItems := make([]upstreamListItem, 0, len(localizedItems))
+	for _, mi := range localizedItems {
 		listItems = append(listItems, mediaItemToListItem(mi))
 	}
 	s.presignListItems(ctx, listItems)
@@ -529,26 +596,129 @@ func (s *directContentService) GetItemDetail(ctx context.Context, session *Sessi
 
 	// Enrich with user data
 	if s.storeProvider != nil {
-		store, storeErr := s.storeProvider.ForUser(ctx, session.StreamAppUserID)
-		if storeErr == nil {
-			progress, _ := userstore.GetProgressWithCompletedHistory(ctx, store, session.ProfileID, contentID)
-			result.UserData = seasonUserDataFromProgress(progress)
+		if store, storeErr := s.storeProvider.ForUser(ctx, session.StreamAppUserID); storeErr == nil {
+			s.enrichDetailUserData(ctx, store, session.ProfileID, contentID, &result)
+		}
+	}
 
-			// A series never has a progress row of its own, so roll watch
-			// state up from its episodes (mirrors applySeasonUserData) to
-			// give clients Played/UnplayedItemCount at the series level.
-			if result.UserData == nil && strings.EqualFold(result.Type, "series") && s.episodeRepo != nil {
-				if episodesBySeries, epErr := s.episodeRepo.ListBySeriesIDs(ctx, []string{contentID}); epErr == nil {
-					episodes := episodesBySeries[contentID]
-					episodeIDs := modelEpisodeContentIDs(episodes)
-					progressMap := chunkedProgressByMediaItems(ctx, store, session.ProfileID, episodeIDs)
-					result.UserData = catalog.EpisodeRollupUserData(episodes, progressMap)
+	return &result, nil
+}
+
+// enrichDetailUserData populates the per-profile UserData on an item detail from
+// the user store: leaf progress for movies/episodes, and an episode rollup for
+// series (which never own a progress row of their own). Shared by GetItemDetail
+// and GetItemDetailsByIDs so both surfaces report identical Played/position/
+// UnplayedItemCount values.
+func (s *directContentService) enrichDetailUserData(ctx context.Context, store userstore.UserStore, profileID, contentID string, result *upstreamItemDetail) {
+	progress, _ := userstore.GetProgressWithCompletedHistory(ctx, store, profileID, contentID)
+	result.UserData = seasonUserDataFromProgress(progress)
+
+	// A series never has a progress row of its own, so roll watch state up from
+	// its episodes (mirrors applySeasonUserData) to give clients Played/
+	// UnplayedItemCount at the series level.
+	if result.UserData == nil && strings.EqualFold(result.Type, "series") && s.episodeRepo != nil {
+		if episodesBySeries, epErr := s.episodeRepo.ListBySeriesIDs(ctx, []string{contentID}); epErr == nil {
+			episodes := episodesBySeries[contentID]
+			episodeIDs := modelEpisodeContentIDs(episodes)
+			progressMap := chunkedProgressByMediaItems(ctx, store, profileID, episodeIDs)
+			result.UserData = catalog.EpisodeRollupUserData(episodes, progressMap)
+		}
+	}
+}
+
+// GetItemDetailsByIDs is the batched form of GetItemDetail for a page of content
+// IDs. It returns upstream item details keyed by content ID, each identical to
+// what GetItemDetail would return for that id: the catalog detail is built by
+// the batched DetailService path (or GetEpisodeDetailsForSeries for episodes),
+// then run through the same compat-excluded-type guard, itemDetailToUpstream
+// conversion, and UserData enrichment. IDs that are excluded media types,
+// access-filtered, or otherwise unresolved are simply absent from the map so the
+// caller renders them from list data, mirroring GetItemDetail's error path.
+func (s *directContentService) GetItemDetailsByIDs(ctx context.Context, session *Session, contentIDs []string, libraryID *int) (map[string]*upstreamItemDetail, error) {
+	out := make(map[string]*upstreamItemDetail, len(contentIDs))
+	if len(contentIDs) == 0 || s.detailSvc == nil {
+		return out, nil
+	}
+	filter := applyCompatPresentationLibrary(s.resolveFilter(ctx, session), libraryID)
+
+	details := make(map[string]*catalog.ItemDetail, len(contentIDs))
+
+	// Movies/series (and any other media_items rows) in one batched call.
+	itemDetails, err := s.detailSvc.GetItemDetailsByIDs(ctx, contentIDs, filter)
+	if err != nil {
+		return nil, wrapCatalogError(err)
+	}
+	for id, detail := range itemDetails {
+		details[id] = detail
+	}
+
+	// Episodes: group the remaining ids by series and reuse the series-hoisted
+	// batch path, which is the episode equivalent of GetItemDetailsByIDs.
+	remaining := make([]string, 0, len(contentIDs))
+	for _, id := range contentIDs {
+		if _, ok := details[id]; !ok {
+			remaining = append(remaining, id)
+		}
+	}
+	if len(remaining) > 0 && s.episodeRepo != nil {
+		if episodeIDsBySeries, err := s.groupEpisodesBySeries(ctx, remaining); err == nil {
+			for seriesID, epIDs := range episodeIDsBySeries {
+				epDetails, epErr := s.detailSvc.GetEpisodeDetailsForSeries(ctx, seriesID, epIDs, filter)
+				if epErr != nil {
+					// Series inaccessible or a transient error: leave these ids
+					// unresolved so the caller renders them from list data,
+					// matching per-item GetItemDetail erroring for each.
+					continue
+				}
+				for id, detail := range epDetails {
+					details[id] = detail
 				}
 			}
 		}
 	}
 
-	return &result, nil
+	if len(details) == 0 {
+		return out, nil
+	}
+
+	// Resolve the user store once for the whole page; enrichment is per-item but
+	// uses the identical code path as GetItemDetail.
+	var store userstore.UserStore
+	if s.storeProvider != nil {
+		if resolved, storeErr := s.storeProvider.ForUser(ctx, session.StreamAppUserID); storeErr == nil {
+			store = resolved
+		}
+	}
+
+	for id, detail := range details {
+		if isCompatExcludedMediaType(detail.Type) {
+			continue
+		}
+		upstream := itemDetailToUpstream(detail)
+		if store != nil {
+			s.enrichDetailUserData(ctx, store, session.ProfileID, id, &upstream)
+		}
+		out[id] = &upstream
+	}
+	return out, nil
+}
+
+// groupEpisodesBySeries maps the subset of contentIDs that are episodes to their
+// series IDs, returning seriesID → episode content IDs. Non-episode ids are
+// silently skipped.
+func (s *directContentService) groupEpisodesBySeries(ctx context.Context, contentIDs []string) (map[string][]string, error) {
+	episodes, err := s.episodeRepo.GetByIDs(ctx, contentIDs)
+	if err != nil {
+		return nil, err
+	}
+	grouped := make(map[string][]string, len(episodes))
+	for _, ep := range episodes {
+		if ep == nil || ep.SeriesID == "" {
+			continue
+		}
+		grouped[ep.SeriesID] = append(grouped[ep.SeriesID], ep.ContentID)
+	}
+	return grouped, nil
 }
 
 func (s *directContentService) ListSeasons(ctx context.Context, session *Session, seriesID string, libraryID *int) ([]upstreamSeason, error) {

--- a/internal/jellycompat/content_direct_test.go
+++ b/internal/jellycompat/content_direct_test.go
@@ -229,6 +229,9 @@ func (s *progressCountingStore) GetProgress(context.Context, string, string) (*u
 func (s *progressCountingStore) ListProgress(context.Context, string, string, int, int) ([]userstore.WatchProgress, error) {
 	panic("unused")
 }
+func (s *progressCountingStore) ListProgressFiltered(context.Context, string, string, []string, *int, int, int) ([]userstore.WatchProgress, error) {
+	panic("unused")
+}
 func (s *progressCountingStore) AddHistory(context.Context, userstore.WatchHistoryEntry) error {
 	panic("unused")
 }
@@ -430,14 +433,20 @@ func (s *progressCountingStore) DeleteLibraryPlaybackPreference(context.Context,
 // stubBrowseSource is a deterministic browseSource for testing
 // directContentService without a Postgres pool.
 type stubBrowseSource struct {
-	items []*models.MediaItem
-	total int
-	calls []stubBrowseCall
+	items            []*models.MediaItem
+	total            int
+	calls            []stubBrowseCall
+	crossLibraryCall []stubCrossLibraryCall
 }
 
 type stubBrowseCall struct {
 	filters      catalog.BrowseFilters
 	includeTotal bool
+}
+
+type stubCrossLibraryCall struct {
+	base       catalog.BrowseFilters
+	libraryIDs []int
 }
 
 func (s *stubBrowseSource) BrowsePage(_ context.Context, filters catalog.BrowseFilters, includeTotal bool) (*catalog.BrowseResult, error) {
@@ -452,6 +461,95 @@ func (s *stubBrowseSource) BrowsePage(_ context.Context, filters catalog.BrowseF
 	return &catalog.BrowseResult{
 		Items:   append([]*models.MediaItem(nil), s.items[start:end]...),
 		Total:   total,
+		HasMore: end < len(s.items),
+	}, nil
+}
+
+func TestBrowseItems_RecentlyAddedNoParentFansOutAcrossLibraries(t *testing.T) {
+	browse := &stubBrowseSource{items: makeBrowseTestMediaItems(10), total: 10}
+	svc := newDirectContentServiceForTest(browse, nil)
+	svc.folderRepo = &stubFolderSource{
+		enabled: []*models.MediaFolder{
+			{ID: 1, Name: "Movies", Type: "movie"},
+			{ID: 3, Name: "TV", Type: "series"},
+		},
+	}
+
+	session := &Session{StreamAppUserID: 1, ProfileID: "p1"}
+	params := url.Values{}
+	params.Set("limit", "5")
+	params.Set("sort", "recently_added")
+
+	if _, err := svc.BrowseItems(context.Background(), session, params); err != nil {
+		t.Fatalf("BrowseItems: %v", err)
+	}
+	if got := len(browse.crossLibraryCall); got != 1 {
+		t.Fatalf("cross-library calls = %d, want 1", got)
+	}
+	if got := len(browse.calls); got != 0 {
+		t.Fatalf("BrowsePage calls = %d, want 0 (fast path should not use it)", got)
+	}
+	if got := browse.crossLibraryCall[0].libraryIDs; len(got) != 2 || got[0] != 1 || got[1] != 3 {
+		t.Fatalf("library IDs = %v, want [1 3]", got)
+	}
+}
+
+func TestBrowseItems_RecentlyAddedWithOffsetFallsBackToBrowsePage(t *testing.T) {
+	browse := &stubBrowseSource{items: makeBrowseTestMediaItems(40), total: 40}
+	svc := newDirectContentServiceForTest(browse, nil)
+	svc.folderRepo = &stubFolderSource{
+		enabled: []*models.MediaFolder{
+			{ID: 1, Name: "Movies", Type: "movie"},
+			{ID: 3, Name: "TV", Type: "series"},
+		},
+	}
+
+	session := &Session{StreamAppUserID: 1, ProfileID: "p1"}
+	params := url.Values{}
+	params.Set("limit", "5")
+	params.Set("offset", "5")
+	params.Set("sort", "recently_added")
+
+	if _, err := svc.BrowseItems(context.Background(), session, params); err != nil {
+		t.Fatalf("BrowseItems: %v", err)
+	}
+	if got := len(browse.crossLibraryCall); got != 0 {
+		t.Fatalf("cross-library calls = %d, want 0 for offset>0", got)
+	}
+	if got := len(browse.calls); got == 0 {
+		t.Fatal("BrowsePage calls = 0, want offset>0 to fall back to BrowsePage")
+	}
+}
+
+func TestBrowseItems_RecentlyAddedSingleLibraryUsesBrowsePage(t *testing.T) {
+	browse := &stubBrowseSource{items: makeBrowseTestMediaItems(10), total: 10}
+	svc := newDirectContentServiceForTest(browse, nil)
+	svc.folderRepo = &stubFolderSource{
+		enabled: []*models.MediaFolder{{ID: 1, Name: "Movies", Type: "movie"}},
+	}
+
+	session := &Session{StreamAppUserID: 1, ProfileID: "p1"}
+	params := url.Values{}
+	params.Set("limit", "5")
+	params.Set("sort", "recently_added")
+
+	if _, err := svc.BrowseItems(context.Background(), session, params); err != nil {
+		t.Fatalf("BrowseItems: %v", err)
+	}
+	if got := len(browse.crossLibraryCall); got != 0 {
+		t.Fatalf("cross-library calls = %d, want 0 with a single library", got)
+	}
+	if got := len(browse.calls); got == 0 {
+		t.Fatal("BrowsePage calls = 0, want single-library path to use BrowsePage")
+	}
+}
+
+func (s *stubBrowseSource) BrowseRecentlyAddedAcrossLibraries(_ context.Context, base catalog.BrowseFilters, libraryIDs []int) (*catalog.BrowseResult, error) {
+	s.crossLibraryCall = append(s.crossLibraryCall, stubCrossLibraryCall{base: base, libraryIDs: libraryIDs})
+	end := min(max(base.Limit, 0), len(s.items))
+	return &catalog.BrowseResult{
+		Items:   append([]*models.MediaItem(nil), s.items[:end]...),
+		Total:   s.total,
 		HasMore: end < len(s.items),
 	}, nil
 }

--- a/internal/jellycompat/content_service.go
+++ b/internal/jellycompat/content_service.go
@@ -11,6 +11,12 @@ type ContentService interface {
 	BrowseItems(ctx context.Context, session *Session, params url.Values) (*upstreamBrowseResponse, error)
 	SearchItems(ctx context.Context, session *Session, opts SearchItemsOptions) (*upstreamBrowseResponse, error)
 	GetItemDetail(ctx context.Context, session *Session, contentID string, libraryID *int) (*upstreamItemDetail, error)
+	// GetItemDetailsByIDs is the batched form of GetItemDetail for a page of
+	// content IDs. The returned map is keyed by content ID; ids that cannot be
+	// resolved to a detail (excluded media type, access-filtered, not found) are
+	// absent so callers fall back to list-level rendering, exactly as they do on
+	// a per-item GetItemDetail error.
+	GetItemDetailsByIDs(ctx context.Context, session *Session, contentIDs []string, libraryID *int) (map[string]*upstreamItemDetail, error)
 	ListSeasons(ctx context.Context, session *Session, seriesID string, libraryID *int) ([]upstreamSeason, error)
 	GetSeason(ctx context.Context, session *Session, seriesID string, seasonNumber int, libraryID *int) (*upstreamSeason, error)
 	ListEpisodes(ctx context.Context, session *Session, seriesID string, seasonNumber int, libraryID *int) ([]upstreamEpisode, error)
@@ -35,6 +41,11 @@ type UserDataService interface {
 	AddFavorite(ctx context.Context, session *Session, contentID string) error
 	RemoveFavorite(ctx context.Context, session *Session, contentID string) error
 	ListProgress(ctx context.Context, session *Session, status string, limit, offset int) ([]upstreamProgress, error)
+	// ListProgressFiltered narrows a progress status page to the requested item
+	// types and/or library, pushing the predicate into SQL so the watched-items
+	// path no longer scans the profile's entire completed set. Callers still
+	// apply access/parental exclusions over the hydrated rows.
+	ListProgressFiltered(ctx context.Context, session *Session, status string, types []string, libraryID *int, limit, offset int) ([]upstreamProgress, error)
 	// FilterResumeProgress drops in-progress entries that Continue Watching
 	// surfaces should hide: entries the user dismissed from the row and
 	// episodes superseded by a later-completed episode in the same series.

--- a/internal/jellycompat/handlers_items.go
+++ b/internal/jellycompat/handlers_items.go
@@ -2258,7 +2258,16 @@ func (h *ItemsHandler) loadResumeViaSections(ctx context.Context, session *Sessi
 
 	// FetchOne always scans from offset 0; over-fetch by StartIndex so a deep
 	// page can be sliced out of the capped result (Resume is normally offset 0).
+	// Clamp the fetch to maxResumeItems so a large client-supplied StartIndex
+	// can't inflate the fetcher's scan past the cap; a StartIndex at or beyond
+	// the cap can never land on a visible row, so return empty up front.
+	if query.startIndex >= maxResumeItems {
+		return []baseItemDTO{}, 0, nil
+	}
 	fetchLimit := pageSize + query.startIndex
+	if fetchLimit > maxResumeItems {
+		fetchLimit = maxResumeItems
+	}
 
 	filter := h.resolveAccessFilter(ctx, session)
 	resolved := sections.ResolvedSection{

--- a/internal/jellycompat/handlers_items.go
+++ b/internal/jellycompat/handlers_items.go
@@ -22,6 +22,7 @@ import (
 	"github.com/Silo-Server/silo-server/internal/models"
 	"github.com/Silo-Server/silo-server/internal/playback"
 	"github.com/Silo-Server/silo-server/internal/recommendations"
+	"github.com/Silo-Server/silo-server/internal/sections"
 	"github.com/Silo-Server/silo-server/internal/subtitles"
 )
 
@@ -53,6 +54,11 @@ type ItemsHandler struct {
 	// FileResolver is optional; when set, /MediaSegments returns real intro/
 	// credits/recap/preview segments for any file that has them.
 	FileResolver FilePathResolver
+	// sectionsFetcher is optional; when set, the Continue Watching (Resume) path
+	// is served through the capped native continue-watching fetcher instead of an
+	// unbounded progress scan. It is the section subsystem's read-time fetcher and
+	// is independent of any virtual-library/hub-section exposure.
+	sectionsFetcher *sections.Fetcher
 }
 
 // NewItemsHandler creates a new items handler.
@@ -969,11 +975,15 @@ func (h *ItemsHandler) HandleLatest(w http.ResponseWriter, r *http.Request) {
 		libraryParentID = h.codec.EncodeIntID(EncodedIDLibrary, int64(query.parentLibraryID))
 	}
 
+	var detailsByID map[string]*upstreamItemDetail
+	if query.needsDetailFields {
+		detailsByID = h.batchListItemDetails(r.Context(), session, contentIDs, libraryIDPtr(query.parentLibraryID))
+	}
+
 	items := make([]baseItemDTO, 0, len(result.Items))
 	for _, item := range result.Items {
 		if query.needsDetailFields {
-			detail, detailErr := h.content.GetItemDetail(r.Context(), session, item.ContentID, libraryIDPtr(query.parentLibraryID))
-			if detailErr == nil {
+			if detail, ok := detailsByID[item.ContentID]; ok && detail != nil {
 				h.rememberDetailImages(*detail)
 				dto := h.mapper.itemFromDetailWithFields(*detail, favorites[detail.ContentID], progress[detail.ContentID], query.requestedFields)
 				if libraryParentID != "" {
@@ -1243,6 +1253,14 @@ func (h *ItemsHandler) HandleEpisodes(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	// AdjacentTo (Wholphin autoplay/skip) only needs the requested episode plus
+	// its immediate neighbors. Serve it from a bounded index seek instead of
+	// materializing the whole series, which is multi-second for long soaps.
+	if query.adjacentTo != "" {
+		h.writeAdjacentEpisodesResponse(w, r, session, query, seriesID)
+		return
+	}
+
 	var requestedSeasonID string
 	if rawSeasonID := strings.TrimSpace(newCaseInsensitiveQuery(r.URL.Query()).Get("SeasonId")); rawSeasonID != "" {
 		decodedSeasonID, decodeErr := h.codec.DecodeStringID(EncodedIDSeason, rawSeasonID)
@@ -1269,6 +1287,22 @@ func (h *ItemsHandler) writeSeriesEpisodesResponse(w http.ResponseWriter, r *htt
 		writeCompatUpstreamError(w, err)
 		return
 	}
+
+	episodeModels, err := h.listSeriesEpisodes(r.Context(), session, seriesID, seasons, requestedSeasonID)
+	if err != nil {
+		writeCompatUpstreamError(w, err)
+		return
+	}
+	h.writeEpisodeModelsPage(w, r, session, query, seriesID, seasons, episodeModels, page)
+}
+
+// writeEpisodeModelsPage maps a resolved set of episode models to Jellyfin
+// baseItemDTOs and writes them as an /Items page. It is the shared downstream
+// half of the episode-listing paths: writeSeriesEpisodesResponse feeds it the
+// whole series (or a single season), while writeAdjacentEpisodesResponse feeds
+// it only the bounded prev/self/next window. seasons is used solely for season
+// title/ID hydration; episodeModels carries the rows actually rendered.
+func (h *ItemsHandler) writeEpisodeModelsPage(w http.ResponseWriter, r *http.Request, session *Session, query itemsQuery, seriesID string, seasons []upstreamSeason, episodeModels []*models.Episode, page bool) {
 	h.rememberSeasonImages(seasons, seriesID)
 
 	seasonTitleByID := make(map[string]string, len(seasons))
@@ -1280,11 +1314,6 @@ func (h *ItemsHandler) writeSeriesEpisodesResponse(w http.ResponseWriter, r *htt
 		seasonIDByNumber[season.SeasonNumber] = season.ContentID
 	}
 
-	episodeModels, err := h.listSeriesEpisodes(r.Context(), session, seriesID, seasons, requestedSeasonID)
-	if err != nil {
-		writeCompatUpstreamError(w, err)
-		return
-	}
 	sort.SliceStable(episodeModels, func(i, j int) bool {
 		if episodeModels[i] == nil || episodeModels[j] == nil {
 			return episodeModels[i] != nil
@@ -1414,6 +1443,69 @@ func (h *ItemsHandler) writeSeriesEpisodesResponse(w http.ResponseWriter, r *htt
 		TotalRecordCount: total,
 		StartIndex:       startIndex,
 	})
+}
+
+// writeAdjacentEpisodesResponse serves the AdjacentTo case of
+// GET /Shows/{id}/Episodes: it resolves the referenced episode and returns it
+// together with its immediate previous/next neighbors (at most three items,
+// crossing season boundaries) via a bounded index seek. This intentionally
+// returns a prev/self/next window rather than Jellyfin's exact AdjacentTo
+// shape — it satisfies Wholphin's autoplay/skip use without paying the cost of
+// loading and mapping every episode of the series.
+//
+// When the bounded repo path is unavailable (no direct episode repo) or the
+// AdjacentTo id cannot be decoded/resolved, it falls back to the full-series
+// listing so behavior is never worse than before AdjacentTo was honored.
+func (h *ItemsHandler) writeAdjacentEpisodesResponse(w http.ResponseWriter, r *http.Request, session *Session, query itemsQuery, seriesID string) {
+	if h.episodeRepo == nil {
+		h.writeSeriesEpisodesResponse(w, r, session, query, seriesID, "", false)
+		return
+	}
+
+	targetContentID, err := decodeItemID(h.codec, query.adjacentTo)
+	if err != nil || targetContentID == "" {
+		h.writeSeriesEpisodesResponse(w, r, session, query, seriesID, "", false)
+		return
+	}
+
+	targets, err := h.episodeRepo.GetByIDs(r.Context(), []string{targetContentID})
+	if err != nil {
+		writeCompatUpstreamError(w, err)
+		return
+	}
+	var target *models.Episode
+	for _, ep := range targets {
+		if ep != nil && ep.ContentID == targetContentID {
+			target = ep
+			break
+		}
+	}
+	if target == nil {
+		// Unknown episode: return an empty page rather than the whole series.
+		writeJSON(w, http.StatusOK, queryResultDTO{Items: []baseItemDTO{}, TotalRecordCount: 0, StartIndex: 0})
+		return
+	}
+	if target.SeriesID != seriesID {
+		// Malformed request: the AdjacentTo episode belongs to a different series
+		// than the {id} path. Returning that other series' neighbors mislabeled
+		// with this series' ID would be silently wrong, so return an empty page.
+		writeJSON(w, http.StatusOK, queryResultDTO{Items: []baseItemDTO{}, TotalRecordCount: 0, StartIndex: 0})
+		return
+	}
+
+	episodeModels, err := h.episodeRepo.ListAdjacentInSeries(r.Context(), target.SeriesID, target.SeasonNumber, target.EpisodeNumber)
+	if err != nil {
+		writeCompatUpstreamError(w, err)
+		return
+	}
+
+	seasons, err := h.content.ListSeasons(r.Context(), session, seriesID, nil)
+	if err != nil {
+		writeCompatUpstreamError(w, err)
+		return
+	}
+
+	h.writeEpisodeModelsPage(w, r, session, query, seriesID, seasons, episodeModels, false)
 }
 
 // HandleNextUp serves GET /Shows/NextUp.
@@ -1676,6 +1768,33 @@ func (h *ItemsHandler) handleLibraryItem(w http.ResponseWriter, r *http.Request,
 	writeError(w, http.StatusNotFound, "NotFound", "Item not found")
 }
 
+// batchListItemDetails resolves detail payloads for a page of content IDs using
+// the batched content path, falling back to per-item GetItemDetail only if the
+// batch call itself errors. The returned map is keyed by content ID; ids absent
+// from it could not be resolved to a detail and must be rendered from list data
+// by the caller — matching the historical per-item GetItemDetail error → list
+// fallback behavior. Individually-unresolvable ids (e.g. season rows, which the
+// item-detail batch path does not handle) are simply absent and likewise fall
+// back to list rendering rather than a per-item detail fetch. Returns nil for an
+// empty input.
+func (h *ItemsHandler) batchListItemDetails(ctx context.Context, session *Session, contentIDs []string, libraryID *int) map[string]*upstreamItemDetail {
+	if len(contentIDs) == 0 {
+		return nil
+	}
+	if details, err := h.content.GetItemDetailsByIDs(ctx, session, contentIDs, libraryID); err == nil {
+		return details
+	}
+	details := make(map[string]*upstreamItemDetail, len(contentIDs))
+	for _, id := range contentIDs {
+		detail, derr := h.content.GetItemDetail(ctx, session, id, libraryID)
+		if derr != nil || detail == nil {
+			continue
+		}
+		details[id] = detail
+	}
+	return details
+}
+
 func (h *ItemsHandler) handleBrowseItems(w http.ResponseWriter, r *http.Request, session *Session, query itemsQuery) {
 	result, err := h.content.BrowseItems(r.Context(), session, buildBrowseParams(query))
 	if err != nil {
@@ -1702,11 +1821,15 @@ func (h *ItemsHandler) handleBrowseItems(w http.ResponseWriter, r *http.Request,
 		libraryParentID = h.codec.EncodeIntID(EncodedIDLibrary, int64(query.parentLibraryID))
 	}
 
+	var detailsByID map[string]*upstreamItemDetail
+	if query.needsDetailFields {
+		detailsByID = h.batchListItemDetails(r.Context(), session, contentIDs, libraryIDPtr(query.parentLibraryID))
+	}
+
 	items := make([]baseItemDTO, 0, len(result.Items))
 	for _, item := range result.Items {
 		if query.needsDetailFields {
-			detail, detailErr := h.content.GetItemDetail(r.Context(), session, item.ContentID, libraryIDPtr(query.parentLibraryID))
-			if detailErr == nil {
+			if detail, ok := detailsByID[item.ContentID]; ok && detail != nil {
 				h.rememberDetailImages(*detail)
 				dto := h.mapper.itemFromDetailWithFields(*detail, favorites[detail.ContentID], progress[detail.ContentID], query.requestedFields)
 				if libraryParentID != "" {
@@ -1920,11 +2043,15 @@ func (h *ItemsHandler) handleSearchItems(w http.ResponseWriter, r *http.Request,
 		libraryParentID = h.codec.EncodeIntID(EncodedIDLibrary, int64(query.parentLibraryID))
 	}
 
+	var detailsByID map[string]*upstreamItemDetail
+	if query.needsDetailFields {
+		detailsByID = h.batchListItemDetails(r.Context(), session, contentIDs, libraryIDPtr(query.parentLibraryID))
+	}
+
 	items := make([]baseItemDTO, 0, len(result.Items))
 	for _, item := range result.Items {
 		if query.needsDetailFields {
-			detail, detailErr := h.content.GetItemDetail(r.Context(), session, item.ContentID, libraryIDPtr(query.parentLibraryID))
-			if detailErr == nil {
+			if detail, ok := detailsByID[item.ContentID]; ok && detail != nil {
 				h.rememberDetailImages(*detail)
 				dto := h.mapper.itemFromDetailWithFields(*detail, favorites[detail.ContentID], progress[detail.ContentID], query.requestedFields)
 				if libraryParentID != "" {
@@ -2065,6 +2192,34 @@ func (h *ItemsHandler) handleResumeResponse(w http.ResponseWriter, r *http.Reque
 		typeSet[strings.ToLower(t)] = true
 	}
 
+	// Fast path: when the native sections subsystem is wired, serve Continue
+	// Watching through the hard-capped continue-watching fetcher instead of
+	// loadProgressPage's unbounded scan. loadProgressPage re-paginates the
+	// entire in-progress list (and re-derives superseded/completed history per
+	// batch) whenever EnableTotalRecordCount=true or the visible count is under
+	// the limit; the fetcher caps scanning at continueProgressMaxScanned and
+	// filters via the indexed home-dismissal index. The native "watching" scope
+	// returns movies+episodes, so we take the fast path whenever the request is
+	// unconstrained OR asks for Movie/Episode (which covers the dominant traffic
+	// — clients overwhelmingly send IncludeItemTypes including Movie+Episode);
+	// loadResumeViaSections applies the IncludeItemTypes set as a post-filter so
+	// narrower requests are still honored. Requests scoped only to types the
+	// watching scope cannot serve (e.g. Series/Season-only) fall through to
+	// loadProgressPage below.
+	if h.sectionsFetcher != nil && (len(typeSet) == 0 || typeSet["episode"] || typeSet["movie"]) {
+		items, total, err := h.loadResumeViaSections(r.Context(), session, query, typeSet)
+		if err == nil {
+			applyImageTypeLimit(items, query.imageTypeLimit)
+			writeJSON(w, http.StatusOK, queryResultDTO{
+				Items:            items,
+				TotalRecordCount: total,
+				StartIndex:       query.startIndex,
+			})
+			return
+		}
+		slog.Warn("jellycompat: resume via sections failed, falling back to progress scan", "error", err)
+	}
+
 	items, total, err := h.loadProgressPage(r.Context(), session, "in_progress", query, typeSet, nil)
 	if err != nil {
 		writeCompatUpstreamError(w, err)
@@ -2076,6 +2231,100 @@ func (h *ItemsHandler) handleResumeResponse(w http.ResponseWriter, r *http.Reque
 		TotalRecordCount: total,
 		StartIndex:       query.startIndex,
 	})
+}
+
+// maxResumeItems caps how many Continue Watching entries the sections fast path
+// returns per request, regardless of the client's requested limit. Resume rows
+// are display surfaces, not bulk exports; clamping keeps the capped fetcher's
+// scan bounded and predictable under load.
+const maxResumeItems = 50
+
+// loadResumeViaSections serves Continue Watching through the native
+// continue-watching fetcher. The fetcher applies the same dismissal and
+// superseded-episode filtering as FilterResumeProgress, so visible parity with
+// loadProgressPage is preserved, but scanning is hard-capped. Next-up injection
+// is suppressed (Resume must stay in-progress-only) and the resolved items are
+// re-hydrated through the shared progress path so episode DTOs keep their
+// SeriesId/IndexNumber/SeasonId targeting — metadata the section list mapping
+// (which discards SectionItemMeta) would drop.
+func (h *ItemsHandler) loadResumeViaSections(ctx context.Context, session *Session, query itemsQuery, typeSet map[string]bool) ([]baseItemDTO, int, error) {
+	pageSize := query.limit
+	if pageSize <= 0 {
+		pageSize = maxResumeItems
+	}
+	if pageSize > maxResumeItems {
+		pageSize = maxResumeItems
+	}
+
+	// FetchOne always scans from offset 0; over-fetch by StartIndex so a deep
+	// page can be sliced out of the capped result (Resume is normally offset 0).
+	fetchLimit := pageSize + query.startIndex
+
+	filter := h.resolveAccessFilter(ctx, session)
+	resolved := sections.ResolvedSection{
+		ID:             "compat-resume",
+		SectionType:    sections.SectionContinueWatching,
+		Title:          "Continue Watching",
+		ItemLimit:      fetchLimit,
+		Config:         sections.ContinueTypeConfig(sections.ContinueTypeWatching),
+		SuppressNextUp: true,
+	}
+
+	result, err := h.sectionsFetcher.FetchOne(ctx, resolved, nil, filter.AllowedLibraryIDs, session.StreamAppUserID, session.ProfileID, filter)
+	if err != nil {
+		return nil, 0, err
+	}
+
+	entries := make([]upstreamProgress, 0, len(result.Items))
+	for _, mi := range result.Items {
+		if mi == nil {
+			continue
+		}
+		meta := result.ItemMeta[mi.ContentID]
+		// Defensive: only in-progress resume points belong on the Resume row.
+		// SuppressNextUp already prevents next-up injection upstream; this
+		// guards against any other source slipping in.
+		if meta.ItemSource != "" && meta.ItemSource != "in_progress" {
+			continue
+		}
+		// Honor IncludeItemTypes the same way loadProgressPage does. The
+		// watching scope only emits movies/episodes, so this trims to a narrower
+		// request (e.g. Movie-only); applying it before the StartIndex slice and
+		// the page cap keeps paging correct.
+		if len(typeSet) > 0 && !typeSet[strings.ToLower(mi.Type)] {
+			continue
+		}
+		entry := upstreamProgress{MediaItemID: mi.ContentID}
+		if meta.PositionSeconds != nil {
+			entry.PositionSeconds = *meta.PositionSeconds
+		}
+		if meta.DurationSeconds != nil {
+			entry.DurationSeconds = *meta.DurationSeconds
+		}
+		if meta.ProgressUpdatedAt != nil {
+			entry.UpdatedAt = *meta.ProgressUpdatedAt
+		}
+		entries = append(entries, entry)
+	}
+
+	// Slice out the requested page from the capped, ordered result.
+	if query.startIndex > 0 {
+		if query.startIndex >= len(entries) {
+			entries = nil
+		} else {
+			entries = entries[query.startIndex:]
+		}
+	}
+	if len(entries) > pageSize {
+		entries = entries[:pageSize]
+	}
+
+	hydrated, err := h.hydrateProgressItems(ctx, session, entries, query.requestedFields, nil)
+	if err != nil {
+		return nil, 0, err
+	}
+	dtos := h.finishProgressPage(ctx, session, hydrated, query, nil)
+	return dtos, len(dtos), nil
 }
 
 type progressHydratedItem struct {
@@ -2092,6 +2341,17 @@ type progressHydratedItem struct {
 // Entries past the cap keep their stubbed list-level DTO. Guardrail against
 // absurd client limits — normal Resume/NextUp requests are 20-40 items.
 const maxDetailUpgrades = 100
+
+// sortedTypeSet returns the (already lowercased) keys of a type set in a stable
+// order so the SQL pre-filter binds a deterministic types array.
+func sortedTypeSet(typeSet map[string]bool) []string {
+	keys := make([]string, 0, len(typeSet))
+	for k := range typeSet {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	return keys
+}
 
 func (h *ItemsHandler) loadProgressPage(ctx context.Context, session *Session, status string, query itemsQuery, typeSet map[string]bool, libraryID *int) ([]baseItemDTO, int, error) {
 	// Resume views hide dismissed and superseded entries, so the visible list
@@ -2146,12 +2406,31 @@ func (h *ItemsHandler) loadProgressPage(ctx context.Context, session *Session, s
 		batchSize = 48
 	}
 
+	// Push the type/library predicate into SQL for the completed (watched-items)
+	// path: the store filters before paging, so the scan reads only matching
+	// rows instead of the profile's entire completed history. The in-memory type
+	// check below and the library-scoped hydration stay as a correctness
+	// backstop (access/parental exclusions still apply). The in_progress path is
+	// deliberately left on ListProgress — its FilterResumeProgress hiding makes
+	// the visible set sparser than any SQL pre-filter could express.
+	useFilteredFetch := status == "completed" && (len(typeSet) > 0 || libraryID != nil)
+	var filteredTypes []string
+	if useFilteredFetch {
+		filteredTypes = sortedTypeSet(typeSet)
+	}
+	fetchProgress := func(off int) ([]upstreamProgress, error) {
+		if useFilteredFetch {
+			return h.userData.ListProgressFiltered(ctx, session, status, filteredTypes, libraryID, batchSize, off)
+		}
+		return h.userData.ListProgress(ctx, session, status, batchSize, off)
+	}
+
 	items := make([]progressHydratedItem, 0, query.limit)
 	matchedCount := 0
 	offset := 0
 
 	for {
-		progressEntries, err := h.userData.ListProgress(ctx, session, status, batchSize, offset)
+		progressEntries, err := fetchProgress(offset)
 		if err != nil {
 			return nil, 0, err
 		}
@@ -2221,12 +2500,18 @@ func (h *ItemsHandler) upgradeProgressPageToDetail(ctx context.Context, session 
 	if !query.needsDetailFields {
 		return
 	}
-	for i := range page {
-		if i >= maxDetailUpgrades {
-			break
-		}
-		detail, err := h.content.GetItemDetail(ctx, session, page[i].contentID, libraryID)
-		if err != nil {
+	limit := len(page)
+	if limit > maxDetailUpgrades {
+		limit = maxDetailUpgrades
+	}
+	upgradeIDs := make([]string, 0, limit)
+	for i := 0; i < limit; i++ {
+		upgradeIDs = append(upgradeIDs, page[i].contentID)
+	}
+	detailsByID := h.batchListItemDetails(ctx, session, upgradeIDs, libraryID)
+	for i := 0; i < limit; i++ {
+		detail, ok := detailsByID[page[i].contentID]
+		if !ok || detail == nil {
 			continue
 		}
 		h.rememberDetailImages(*detail)

--- a/internal/jellycompat/handlers_items_batch_detail_test.go
+++ b/internal/jellycompat/handlers_items_batch_detail_test.go
@@ -1,0 +1,162 @@
+package jellycompat
+
+import (
+	"context"
+	"net/http/httptest"
+	"net/url"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/Silo-Server/silo-server/internal/catalog"
+	"github.com/Silo-Server/silo-server/internal/config"
+)
+
+// equivalencePageContent is a ContentService double that serves a fixed mixed
+// (movie + episode) browse page plus full item details. It can be toggled to
+// fail the batched GetItemDetailsByIDs call so the handler falls back to the
+// per-item GetItemDetail path, letting tests assert the two paths produce
+// identical output.
+type equivalencePageContent struct {
+	stubContentService
+	page         []upstreamListItem
+	details      map[string]*upstreamItemDetail
+	failBatch    bool
+	batchCalls   int
+	perItemCalls int
+}
+
+func (c *equivalencePageContent) BrowseItems(context.Context, *Session, url.Values) (*upstreamBrowseResponse, error) {
+	items := make([]upstreamListItem, len(c.page))
+	copy(items, c.page)
+	return &upstreamBrowseResponse{Items: items, Total: len(items)}, nil
+}
+
+func (c *equivalencePageContent) GetItemDetail(_ context.Context, _ *Session, id string, _ *int) (*upstreamItemDetail, error) {
+	c.perItemCalls++
+	d, ok := c.details[id]
+	if !ok {
+		return nil, &HTTPError{StatusCode: 404, Message: "not found"}
+	}
+	cp := *d
+	return &cp, nil
+}
+
+func (c *equivalencePageContent) GetItemDetailsByIDs(_ context.Context, _ *Session, ids []string, _ *int) (map[string]*upstreamItemDetail, error) {
+	c.batchCalls++
+	if c.failBatch {
+		return nil, &HTTPError{StatusCode: 500, Message: "batch unavailable"}
+	}
+	out := make(map[string]*upstreamItemDetail, len(ids))
+	for _, id := range ids {
+		if d, ok := c.details[id]; ok {
+			cp := *d
+			out[id] = &cp
+		}
+	}
+	return out, nil
+}
+
+func newEquivalenceContent(failBatch bool) *equivalencePageContent {
+	movie := &upstreamItemDetail{
+		ContentID: "movie-1",
+		Type:      "movie",
+		Title:     "Test Movie",
+		Versions: []catalog.FileVersion{{
+			FileID:    101,
+			Container: "mkv",
+			Duration:  6000,
+			AddedAt:   time.Unix(1700000000, 0).UTC(),
+		}},
+		Cast: []catalog.CastCredit{{Name: "Actor One", Character: "Hero", PersonID: "1"}},
+	}
+	episode := &upstreamItemDetail{
+		ContentID:     "episode-1",
+		Type:          "episode",
+		Title:         "Test Episode",
+		SeriesID:      "series-1",
+		SeasonNumber:  intPtr(1),
+		EpisodeNumber: intPtr(2),
+		Versions: []catalog.FileVersion{{
+			FileID:    202,
+			Container: "mp4",
+			Duration:  1800,
+			AddedAt:   time.Unix(1700000100, 0).UTC(),
+		}},
+	}
+	return &equivalencePageContent{
+		failBatch: failBatch,
+		page: []upstreamListItem{
+			{ContentID: "movie-1", Type: "movie", Title: "Test Movie", Status: "matched"},
+			{ContentID: "episode-1", Type: "episode", Title: "Test Episode", Status: "matched", SeriesID: "series-1", SeasonNumber: intPtr(1), EpisodeNumber: intPtr(2)},
+		},
+		details: map[string]*upstreamItemDetail{
+			"movie-1":   movie,
+			"episode-1": episode,
+		},
+	}
+}
+
+// TestHandleBrowseItems_BatchDetailMatchesPerItem pins the batched detail-field
+// path: when the client requests detail-level Fields (MediaSources, etc.) over a
+// mixed movie+episode page, the response must be byte-for-byte identical whether
+// the details came from the batched GetItemDetailsByIDs path or the per-item
+// GetItemDetail fallback — and must carry the load-bearing MediaSources.
+func TestHandleBrowseItems_BatchDetailMatchesPerItem(t *testing.T) {
+	codec := NewResourceIDCodec()
+	query := itemsQuery{
+		needsDetailFields: true,
+		requestedFields: map[string]bool{
+			"mediasources": true,
+			"mediastreams": true,
+			"people":       true,
+			"chapters":     true,
+		},
+	}
+
+	run := func(failBatch bool) (string, *equivalencePageContent) {
+		content := newEquivalenceContent(failBatch)
+		h := &ItemsHandler{
+			content:  content,
+			userData: &mockUserDataService{},
+			codec:    codec,
+			mapper:   newMapper(codec, &config.Config{}),
+			images:   NewImageCache(time.Hour, time.Now),
+		}
+		req := httptest.NewRequest("GET", "/Users/test/Items?Fields=MediaSources", nil)
+		ctx := context.WithValue(req.Context(), compatSessionKey, &Session{StreamAppUserID: 1, ProfileID: "profile-1"})
+		req = req.WithContext(ctx)
+		rec := httptest.NewRecorder()
+		h.handleBrowseItems(rec, req, &Session{StreamAppUserID: 1, ProfileID: "profile-1"}, query)
+		if rec.Code != 200 {
+			t.Fatalf("status = %d, body = %s", rec.Code, rec.Body.String())
+		}
+		return rec.Body.String(), content
+	}
+
+	batchBody, batchContent := run(false)
+	perItemBody, perItemContent := run(true)
+
+	if batchBody != perItemBody {
+		t.Fatalf("batched and per-item detail output differ:\nbatch:   %s\nperItem: %s", batchBody, perItemBody)
+	}
+
+	// The batch run must use the batched path once and never fall back to
+	// per-item fetches; the failBatch run must attempt the batch once and only
+	// then fall back to per-item fetches. Asserting batchCalls==1 on the
+	// fallback run guards against a regression that skips GetItemDetailsByIDs
+	// entirely and goes straight to per-item lookups (which would still produce
+	// identical output but silently lose the batched fast path).
+	if batchContent.batchCalls != 1 || batchContent.perItemCalls != 0 {
+		t.Fatalf("batch run: batchCalls=%d perItemCalls=%d; want 1 and 0", batchContent.batchCalls, batchContent.perItemCalls)
+	}
+	if perItemContent.batchCalls != 1 || perItemContent.perItemCalls != 2 {
+		t.Fatalf("fallback run: batchCalls=%d perItemCalls=%d; want 1 and 2 (batch attempted once, then one per-item fetch per page item)", perItemContent.batchCalls, perItemContent.perItemCalls)
+	}
+
+	// Sanity: the detail fields must actually be present (regression guard for
+	// dropping MediaSources from the batched path).
+	if !strings.Contains(batchBody, "\"MediaSources\"") {
+		t.Fatalf("batched output missing MediaSources: %s", batchBody)
+	}
+}

--- a/internal/jellycompat/handlers_items_test.go
+++ b/internal/jellycompat/handlers_items_test.go
@@ -43,6 +43,18 @@ func (s *countingContentService) GetItemDetail(_ context.Context, _ *Session, co
 	return &upstreamItemDetail{ContentID: contentID}, nil
 }
 
+func (s *countingContentService) GetItemDetailsByIDs(ctx context.Context, session *Session, contentIDs []string, libraryID *int) (map[string]*upstreamItemDetail, error) {
+	out := make(map[string]*upstreamItemDetail, len(contentIDs))
+	for _, id := range contentIDs {
+		detail, err := s.GetItemDetail(ctx, session, id, libraryID)
+		if err != nil || detail == nil {
+			continue
+		}
+		out[id] = detail
+	}
+	return out, nil
+}
+
 func (s *countingContentService) ListUserLibraries(context.Context, *Session) ([]upstreamUserLibrary, error) {
 	panic("unused")
 }
@@ -193,6 +205,75 @@ func TestHandleEpisodes_StartItemIDMissingReturnsEmptyQueue(t *testing.T) {
 	result := performEpisodesRequest(t, h, "/Shows/"+encodedSeriesID+"/Episodes?StartItemId="+missingStartItemID, encodedSeriesID)
 	if result.TotalRecordCount != 0 || len(result.Items) != 0 {
 		t.Fatalf("expected empty queue for missing StartItemId, got total=%d items=%+v", result.TotalRecordCount, result.Items)
+	}
+}
+
+func TestHandleEpisodes_AdjacentToReturnsPrevSelfNextWindow(t *testing.T) {
+	codec := NewResourceIDCodec()
+	seriesContentID := "series-1"
+	seasonContentID := "season-1"
+	encodedSeriesID := codec.EncodeStringID(EncodedIDItem, seriesContentID)
+	encodedAdjacentTo := codec.EncodeStringID(EncodedIDItem, "ep-2")
+	contentSvc := &countingContentService{
+		seasons: []upstreamSeason{
+			{ContentID: seasonContentID, SeasonNumber: 1, Title: "Season 1", EpisodeCount: 4},
+		},
+	}
+	episodeRepo := &fakeSeasonEpisodeRepo{bySeason: map[string][]*models.Episode{
+		episodeBySeasonKey(seriesContentID, 1): {
+			{ContentID: "ep-1", SeriesID: seriesContentID, SeasonID: seasonContentID, SeasonNumber: 1, EpisodeNumber: 1, Title: "First"},
+			{ContentID: "ep-2", SeriesID: seriesContentID, SeasonID: seasonContentID, SeasonNumber: 1, EpisodeNumber: 2, Title: "Selected"},
+			{ContentID: "ep-3", SeriesID: seriesContentID, SeasonID: seasonContentID, SeasonNumber: 1, EpisodeNumber: 3, Title: "After"},
+			{ContentID: "ep-4", SeriesID: seriesContentID, SeasonID: seasonContentID, SeasonNumber: 1, EpisodeNumber: 4, Title: "Last"},
+		},
+	}}
+	h := &ItemsHandler{
+		content:     contentSvc,
+		userData:    &mockUserDataService{},
+		codec:       codec,
+		mapper:      newMapper(codec, &config.Config{}),
+		images:      NewImageCache(time.Hour, time.Now),
+		episodeRepo: episodeRepo,
+	}
+
+	result := performEpisodesRequest(t, h, "/Shows/"+encodedSeriesID+"/Episodes?AdjacentTo="+encodedAdjacentTo+"&Limit=1", encodedSeriesID)
+	if result.TotalRecordCount != 3 {
+		t.Fatalf("TotalRecordCount = %d, want 3 (prev/self/next)", result.TotalRecordCount)
+	}
+	if len(result.Items) != 3 {
+		t.Fatalf("len(Items) = %d, want 3: %+v", len(result.Items), result.Items)
+	}
+	if result.Items[0].Name != "First" || result.Items[1].Name != "Selected" || result.Items[2].Name != "After" {
+		t.Fatalf("unexpected window order: %+v", result.Items)
+	}
+}
+
+func TestHandleEpisodes_AdjacentToUnknownReturnsEmptyPage(t *testing.T) {
+	codec := NewResourceIDCodec()
+	seriesContentID := "series-1"
+	seasonContentID := "season-1"
+	encodedSeriesID := codec.EncodeStringID(EncodedIDItem, seriesContentID)
+	encodedUnknown := codec.EncodeStringID(EncodedIDItem, "missing-episode")
+	contentSvc := &countingContentService{
+		seasons: []upstreamSeason{{ContentID: seasonContentID, SeasonNumber: 1, Title: "Season 1", EpisodeCount: 1}},
+	}
+	episodeRepo := &fakeSeasonEpisodeRepo{bySeason: map[string][]*models.Episode{
+		episodeBySeasonKey(seriesContentID, 1): {
+			{ContentID: "ep-1", SeriesID: seriesContentID, SeasonID: seasonContentID, SeasonNumber: 1, EpisodeNumber: 1, Title: "First"},
+		},
+	}}
+	h := &ItemsHandler{
+		content:     contentSvc,
+		userData:    &mockUserDataService{},
+		codec:       codec,
+		mapper:      newMapper(codec, &config.Config{}),
+		images:      NewImageCache(time.Hour, time.Now),
+		episodeRepo: episodeRepo,
+	}
+
+	result := performEpisodesRequest(t, h, "/Shows/"+encodedSeriesID+"/Episodes?AdjacentTo="+encodedUnknown, encodedSeriesID)
+	if result.TotalRecordCount != 0 || len(result.Items) != 0 {
+		t.Fatalf("expected empty page for unknown AdjacentTo, got total=%d items=%+v", result.TotalRecordCount, result.Items)
 	}
 }
 

--- a/internal/jellycompat/list_seasons_batch_test.go
+++ b/internal/jellycompat/list_seasons_batch_test.go
@@ -69,6 +69,10 @@ func (c *countingEpisodeListSource) ListBySeriesIDs(_ context.Context, _ []strin
 	return map[string][]*models.Episode{}, nil
 }
 
+func (c *countingEpisodeListSource) GetByIDs(_ context.Context, _ []string) ([]*models.Episode, error) {
+	return nil, nil
+}
+
 // TestListSeasons_UsesBatchEpisodeFetch verifies ListSeasons makes exactly
 // one ListBySeriesGroupedBySeason call (replacing N per-season ListBySeason
 // calls) and exactly one ListProgressByMediaItems call (replacing N

--- a/internal/jellycompat/parent_browse_test.go
+++ b/internal/jellycompat/parent_browse_test.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"net/http/httptest"
 	"net/url"
+	"sort"
 	"strings"
 	"testing"
 	"time"
@@ -32,8 +33,20 @@ func episodeBySeasonKey(seriesID string, seasonNum int) string {
 	return fmt.Sprintf("%s|%d", seriesID, seasonNum)
 }
 
-func (f *fakeSeasonEpisodeRepo) GetByIDs(context.Context, []string) ([]*models.Episode, error) {
-	return nil, nil
+func (f *fakeSeasonEpisodeRepo) GetByIDs(_ context.Context, contentIDs []string) ([]*models.Episode, error) {
+	want := make(map[string]bool, len(contentIDs))
+	for _, id := range contentIDs {
+		want[id] = true
+	}
+	var out []*models.Episode
+	for _, eps := range f.bySeason {
+		for _, ep := range eps {
+			if ep != nil && want[ep.ContentID] {
+				out = append(out, ep)
+			}
+		}
+	}
+	return out, nil
 }
 
 func (f *fakeSeasonEpisodeRepo) HasFilesByIDs(context.Context, []string) (map[string]bool, error) {
@@ -52,6 +65,38 @@ func (f *fakeSeasonEpisodeRepo) ListBySeries(_ context.Context, seriesID string)
 		}
 	}
 	return out, nil
+}
+
+// ListAdjacentInSeries returns the target episode plus its immediate
+// previous/next neighbors across the whole series, mirroring the repo's
+// natural (season, episode) ordering.
+func (f *fakeSeasonEpisodeRepo) ListAdjacentInSeries(ctx context.Context, seriesID string, seasonNumber, episodeNumber int) ([]*models.Episode, error) {
+	all, _ := f.ListBySeries(ctx, seriesID)
+	sort.SliceStable(all, func(i, j int) bool {
+		if all[i].SeasonNumber == all[j].SeasonNumber {
+			return all[i].EpisodeNumber < all[j].EpisodeNumber
+		}
+		return all[i].SeasonNumber < all[j].SeasonNumber
+	})
+	targetIdx := -1
+	for i, ep := range all {
+		if ep.SeasonNumber == seasonNumber && ep.EpisodeNumber == episodeNumber {
+			targetIdx = i
+			break
+		}
+	}
+	if targetIdx < 0 {
+		return nil, nil
+	}
+	start := targetIdx - 1
+	if start < 0 {
+		start = 0
+	}
+	end := targetIdx + 2
+	if end > len(all) {
+		end = len(all)
+	}
+	return all[start:end], nil
 }
 
 // TestHandleItems_SeriesParentWithoutTypeReturnsSeasons pins the Void fix: a

--- a/internal/jellycompat/query.go
+++ b/internal/jellycompat/query.go
@@ -46,6 +46,7 @@ type itemsQuery struct {
 	requestedFields        map[string]bool // parsed from Fields param
 	fieldsExplicit         bool            // true when Fields was in the request
 	startItemID            string          // raw encoded ID from StartItemId param
+	adjacentTo             string          // raw encoded ID from AdjacentTo param
 }
 
 func parseItemsQuery(r *http.Request, codec *ResourceIDCodec) itemsQuery {
@@ -171,6 +172,7 @@ func parseItemsQuery(r *http.Request, codec *ResourceIDCodec) itemsQuery {
 	result.needsDetailFields = requestedFieldsNeedDetail(result.requestedFields)
 
 	result.startItemID = strings.TrimSpace(q.Get("StartItemId"))
+	result.adjacentTo = strings.TrimSpace(q.Get("AdjacentTo"))
 
 	// Diagnostic: when the request stays on the list path, emit a Debug log
 	// listing any requested Fields that mapping.go's itemFromList does not

--- a/internal/jellycompat/resume_filter_test.go
+++ b/internal/jellycompat/resume_filter_test.go
@@ -18,12 +18,24 @@ type resumeFilteringUserData struct {
 	entries           []upstreamProgress
 	hidden            map[string]bool
 	listedStatuses    []string
+	filteredStatuses  []string
+	lastFilteredTypes []string
 	filterCalls       int
 	filteredBatchSize []int
 }
 
 func (s *resumeFilteringUserData) ListProgress(_ context.Context, _ *Session, status string, limit, offset int) ([]upstreamProgress, error) {
 	s.listedStatuses = append(s.listedStatuses, status)
+	if offset >= len(s.entries) {
+		return nil, nil
+	}
+	end := min(offset+limit, len(s.entries))
+	return s.entries[offset:end], nil
+}
+
+func (s *resumeFilteringUserData) ListProgressFiltered(_ context.Context, _ *Session, status string, types []string, _ *int, limit, offset int) ([]upstreamProgress, error) {
+	s.filteredStatuses = append(s.filteredStatuses, status)
+	s.lastFilteredTypes = types
 	if offset >= len(s.entries) {
 		return nil, nil
 	}
@@ -162,6 +174,44 @@ func TestLoadProgressPage_CompletedSkipsResumeFilter(t *testing.T) {
 	}
 	if len(dtos) != 1 || dtos[0].Name != "Movie One" {
 		t.Fatalf("completed names = %v, want [Movie One]", dtoNames(dtos))
+	}
+}
+
+// TestLoadProgressPage_CompletedTypeFilterUsesFilteredFetch pins that the
+// watched-items path (completed status with an IncludeItemTypes filter) routes
+// through ListProgressFiltered — the SQL pre-filter — instead of the full-set
+// ListProgress scan it replaced.
+func TestLoadProgressPage_CompletedTypeFilterUsesFilteredFetch(t *testing.T) {
+	items := map[string]*models.MediaItem{
+		"movie-1": {ContentID: "movie-1", Type: "movie", Title: "Movie One"},
+		"movie-2": {ContentID: "movie-2", Type: "movie", Title: "Movie Two"},
+	}
+	userData := &resumeFilteringUserData{
+		entries: []upstreamProgress{
+			{MediaItemID: "movie-1", PositionSeconds: 100, DurationSeconds: 100, Completed: true},
+			{MediaItemID: "movie-2", PositionSeconds: 100, DurationSeconds: 100, Completed: true},
+		},
+	}
+	h := resumeTestHandler(userData, items)
+
+	session := &Session{StreamAppUserID: 1, ProfileID: "profile-1"}
+	typeSet := map[string]bool{"movie": true}
+	dtos, _, err := h.loadProgressPage(context.Background(), session, "completed", itemsQuery{limit: 10}, typeSet, nil)
+	if err != nil {
+		t.Fatalf("loadProgressPage: %v", err)
+	}
+
+	if len(userData.filteredStatuses) == 0 {
+		t.Fatal("expected ListProgressFiltered to serve completed + type filter")
+	}
+	if len(userData.listedStatuses) != 0 {
+		t.Fatalf("expected ListProgress not to be called; got %v", userData.listedStatuses)
+	}
+	if len(userData.lastFilteredTypes) != 1 || userData.lastFilteredTypes[0] != "movie" {
+		t.Fatalf("filtered types = %v, want [movie]", userData.lastFilteredTypes)
+	}
+	if got := dtoNames(dtos); len(got) != 2 {
+		t.Fatalf("completed names = %v, want 2 movies", got)
 	}
 }
 

--- a/internal/jellycompat/router.go
+++ b/internal/jellycompat/router.go
@@ -16,6 +16,7 @@ import (
 	"github.com/Silo-Server/silo-server/internal/catalog"
 	"github.com/Silo-Server/silo-server/internal/clientip"
 	"github.com/Silo-Server/silo-server/internal/recommendations"
+	"github.com/Silo-Server/silo-server/internal/sections"
 	"github.com/Silo-Server/silo-server/internal/subtitles"
 )
 
@@ -77,6 +78,15 @@ func NewRouter(deps Dependencies) chi.Router {
 		// Smart (live-query) collections derive membership at read time, so the
 		// BoxSet children path needs a query executor to resolve them.
 		itemsHandler.queryExecutor = &catalog.QueryExecutor{Pool: deps.DB}
+		// Continue Watching (Resume) fast path: serve via the capped native
+		// continue-watching fetcher instead of an unbounded progress scan. This is
+		// the section subsystem's read-time fetcher only — no hub-section/virtual-
+		// library exposure is wired here. The continue-watching path needs only
+		// StoreProvider (progress); CollectionRepo/NextUpRepo are deliberately
+		// left unset as they serve other section types.
+		sf := sections.NewFetcher(deps.DB)
+		sf.StoreProvider = deps.UserStoreProvider
+		itemsHandler.sectionsFetcher = sf
 	}
 	itemsHandler.posterPresigner = deps.PosterPresigner
 	itemsHandler.presignTTL = deps.PresignTTL

--- a/internal/jellycompat/userdata_direct.go
+++ b/internal/jellycompat/userdata_direct.go
@@ -179,6 +179,24 @@ func (s *directUserDataService) ListProgress(ctx context.Context, session *Sessi
 	return result, nil
 }
 
+func (s *directUserDataService) ListProgressFiltered(ctx context.Context, session *Session, status string, types []string, libraryID *int, limit, offset int) ([]upstreamProgress, error) {
+	store, err := s.storeProvider.ForUser(ctx, session.StreamAppUserID)
+	if err != nil {
+		return nil, fmt.Errorf("open user store: %w", err)
+	}
+
+	entries, err := store.ListProgressFiltered(ctx, session.ProfileID, status, types, libraryID, limit, offset)
+	if err != nil {
+		return nil, fmt.Errorf("list filtered progress: %w", err)
+	}
+
+	result := make([]upstreamProgress, 0, len(entries))
+	for _, entry := range entries {
+		result = append(result, toUpstreamProgress(entry))
+	}
+	return result, nil
+}
+
 // FilterResumeProgress applies the same hiding rules as the first-party
 // Continue Watching fetcher: dismissed entries and episodes superseded by a
 // later-completed episode in the same series.

--- a/internal/sections/fetcher.go
+++ b/internal/sections/fetcher.go
@@ -426,7 +426,7 @@ func (f *Fetcher) fetchContinueWatchingSection(ctx context.Context, resolved Res
 	}
 
 	nextUpMode := ""
-	if ContinueTypeAllowsNextUp(continueType) {
+	if ContinueTypeAllowsNextUp(continueType) && !resolved.SuppressNextUp {
 		nextUpMode, _ = store.GetSetting(ctx, "next_up_mode")
 		if nextUpMode == "" {
 			nextUpMode = "combined"

--- a/internal/sections/types.go
+++ b/internal/sections/types.go
@@ -135,6 +135,14 @@ type ResolvedSection struct {
 	IsCustom    bool            `json:"is_custom"`
 	Customized  bool            `json:"customized"`
 	Hidden      bool            `json:"hidden,omitempty"`
+
+	// SuppressNextUp, when true on a continue-watching section, skips the
+	// next-up injection (and the combined series collapse/sort that pairs with
+	// it) so the section returns in-progress resume points only. Callers that
+	// need a strict "resume" view — e.g. the Jellyfin /UserItems/Resume
+	// compatibility endpoint, which must never surface not-yet-started items —
+	// set this; admin/home rendering leaves it false to keep next-up cards.
+	SuppressNextUp bool `json:"-"`
 }
 
 // FilterConfig represents the rule-group filter structure.

--- a/internal/userdb/sqlitestore.go
+++ b/internal/userdb/sqlitestore.go
@@ -95,6 +95,15 @@ func (s *SQLiteUserStore) ListProgress(_ context.Context, profileID, status stri
 	return ListProgress(s.db, profileID, status, limit, offset)
 }
 
+// ListProgressFiltered cannot push the type/library predicate down: the
+// per-user SQLite store has no catalog tables (media_items/episodes/
+// media_item_libraries live in the shared Postgres schema). It therefore
+// returns the status page unfiltered — a valid coarse superset — and relies on
+// the caller's in-memory type check and library-scoped hydration to narrow it.
+func (s *SQLiteUserStore) ListProgressFiltered(_ context.Context, profileID, status string, _ []string, _ *int, limit, offset int) ([]userstore.WatchProgress, error) {
+	return ListProgress(s.db, profileID, status, limit, offset)
+}
+
 func (s *SQLiteUserStore) ListProgressByMediaItems(_ context.Context, profileID string, mediaItemIDs []string) (map[string]userstore.WatchProgress, error) {
 	return ListProgressByMediaItems(s.db, profileID, mediaItemIDs)
 }

--- a/internal/userstore/pgstore/progress.go
+++ b/internal/userstore/pgstore/progress.go
@@ -447,6 +447,146 @@ func (s *PostgresUserStore) ListProgress(ctx context.Context, profileID, status 
 	return results, nil
 }
 
+// ListProgressFiltered mirrors the status branches of ListProgress and AND-s in
+// an EXISTS pre-filter so the requested item types and/or library are resolved
+// in SQL instead of after a full-set scan. Movies/series resolve through
+// media_items; episodes live in the separate episodes table joined via
+// series_id → media_items (a plain media_items join would miss them); the
+// optional library predicate hits media_item_libraries. The completed branch's
+// `completed = TRUE` + `ORDER BY updated_at DESC` shape keeps
+// idx_uwp_profile_completed in play, while the EXISTS sub-selects ride
+// idx_item_libraries_content. The filter is coarse (callers re-check
+// access/parental exclusions over the hydrated rows), and an empty types slice
+// with a nil libraryID degrades to the plain status listing.
+func (s *PostgresUserStore) ListProgressFiltered(ctx context.Context, profileID, status string, types []string, libraryID *int, limit, offset int) ([]userstore.WatchProgress, error) {
+	args := []any{s.userID, profileID}
+
+	var statusClause string
+	switch status {
+	case "in_progress":
+		statusClause = "position_seconds > 0"
+	case "completed":
+		statusClause = "completed = TRUE"
+	default:
+		statusClause = "TRUE"
+	}
+
+	var filterClause string
+	filterClause, args = buildProgressCatalogFilter(types, libraryID, args)
+
+	args = append(args, limit, offset)
+	limitPlaceholder := fmt.Sprintf("$%d", len(args)-1)
+	offsetPlaceholder := fmt.Sprintf("$%d", len(args))
+
+	query := `
+		SELECT profile_id, media_item_id, position_seconds, duration_seconds, completed, updated_at,
+		       last_file_id, last_resolution, last_hdr, last_codec_video, last_edition_key
+		FROM user_watch_progress
+		WHERE user_id = $1 AND profile_id = $2 AND ` + statusClause + filterClause + `
+		  AND NOT EXISTS (
+			SELECT 1
+			FROM user_history_hidden_items hhi
+			WHERE hhi.user_id = user_watch_progress.user_id
+			  AND hhi.profile_id = user_watch_progress.profile_id
+			  AND hhi.media_item_id = user_watch_progress.media_item_id
+			  AND user_watch_progress.updated_at <= hhi.hidden_before
+		  )
+		ORDER BY updated_at DESC
+		LIMIT ` + limitPlaceholder + ` OFFSET ` + offsetPlaceholder
+
+	rows, err := s.pool.Query(ctx, query, args...)
+	if err != nil {
+		return nil, fmt.Errorf("listing filtered progress: %w", err)
+	}
+	defer rows.Close()
+
+	var results []userstore.WatchProgress
+	for rows.Next() {
+		wp, err := scanWatchProgress(rows)
+		if err != nil {
+			return nil, fmt.Errorf("scanning progress row: %w", err)
+		}
+		results = append(results, *wp)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("iterating progress rows: %w", err)
+	}
+	return results, nil
+}
+
+// buildProgressCatalogFilter builds the EXISTS pre-filter that constrains
+// user_watch_progress rows to the requested item types and/or library. It
+// appends any new bind args to args and returns the SQL fragment (a leading
+// " AND (...)" or empty when no filter applies) plus the grown args slice.
+func buildProgressCatalogFilter(types []string, libraryID *int, args []any) (string, []any) {
+	wantEpisode := false
+	nonEpisode := make([]string, 0, len(types))
+	for _, t := range types {
+		switch lt := strings.ToLower(strings.TrimSpace(t)); lt {
+		case "":
+			// skip blanks
+		case "episode":
+			wantEpisode = true
+		default:
+			nonEpisode = append(nonEpisode, lt)
+		}
+	}
+
+	typed := len(nonEpisode) > 0 || wantEpisode
+	if !typed && libraryID == nil {
+		return "", args
+	}
+
+	// A library-only request (no types) must match both movies and episodes in
+	// that library, so include both branches when no type was requested.
+	includeMovie := !typed || len(nonEpisode) > 0
+	includeEpisode := !typed || wantEpisode
+
+	var typePlaceholder, libPlaceholder string
+	if len(nonEpisode) > 0 {
+		args = append(args, nonEpisode)
+		typePlaceholder = fmt.Sprintf("$%d", len(args))
+	}
+	if libraryID != nil {
+		args = append(args, *libraryID)
+		libPlaceholder = fmt.Sprintf("$%d", len(args))
+	}
+
+	branches := make([]string, 0, 2)
+	if includeMovie {
+		var sb strings.Builder
+		sb.WriteString("EXISTS (SELECT 1 FROM media_items mi")
+		if libPlaceholder != "" {
+			sb.WriteString(" JOIN media_item_libraries mil ON mi.content_id = mil.content_id")
+		}
+		sb.WriteString(" WHERE mi.content_id = user_watch_progress.media_item_id")
+		if typePlaceholder != "" {
+			sb.WriteString(" AND lower(mi.type) = ANY(" + typePlaceholder + ")")
+		}
+		if libPlaceholder != "" {
+			sb.WriteString(" AND mil.media_folder_id = " + libPlaceholder)
+		}
+		sb.WriteString(")")
+		branches = append(branches, sb.String())
+	}
+	if includeEpisode {
+		var sb strings.Builder
+		sb.WriteString("EXISTS (SELECT 1 FROM episodes e")
+		if libPlaceholder != "" {
+			sb.WriteString(" JOIN media_items si ON e.series_id = si.content_id")
+			sb.WriteString(" JOIN media_item_libraries mil ON si.content_id = mil.content_id")
+		}
+		sb.WriteString(" WHERE e.content_id = user_watch_progress.media_item_id")
+		if libPlaceholder != "" {
+			sb.WriteString(" AND mil.media_folder_id = " + libPlaceholder)
+		}
+		sb.WriteString(")")
+		branches = append(branches, sb.String())
+	}
+
+	return " AND (" + strings.Join(branches, " OR ") + ")", args
+}
+
 func (s *PostgresUserStore) ListProgressByMediaItems(ctx context.Context, profileID string, mediaItemIDs []string) (map[string]userstore.WatchProgress, error) {
 	result := make(map[string]userstore.WatchProgress, len(mediaItemIDs))
 	if len(mediaItemIDs) == 0 {

--- a/internal/userstore/store.go
+++ b/internal/userstore/store.go
@@ -31,6 +31,15 @@ type UserStore interface {
 	ClearProgress(ctx context.Context, profileID, mediaItemID string) error
 	GetProgress(ctx context.Context, profileID, mediaItemID string) (*WatchProgress, error)
 	ListProgress(ctx context.Context, profileID, status string, limit, offset int) ([]WatchProgress, error)
+	// ListProgressFiltered is ListProgress with an additional SQL pre-filter on
+	// the backing catalog item's type and/or library, so the watched-items path
+	// no longer scans the whole status set before discarding non-matching rows.
+	// types is matched case-insensitively against media_items.type ("episode"
+	// resolves through the separate episodes table); a nil libraryID drops the
+	// library predicate, and an empty types + nil libraryID degrades to the
+	// plain status listing. It is a coarse pre-filter: callers still apply
+	// access/parental exclusions over the returned rows.
+	ListProgressFiltered(ctx context.Context, profileID, status string, types []string, libraryID *int, limit, offset int) ([]WatchProgress, error)
 	ListProgressByMediaItems(ctx context.Context, profileID string, mediaItemIDs []string) (map[string]WatchProgress, error)
 	AddHistory(ctx context.Context, entry WatchHistoryEntry) error
 	AddHistoryIfMissing(ctx context.Context, entry WatchHistoryEntry) (bool, error)

--- a/internal/userstore/storetest/suite.go
+++ b/internal/userstore/storetest/suite.go
@@ -292,6 +292,18 @@ func testProgress(t *testing.T, newStore func(t *testing.T) userstore.UserStore)
 		t.Errorf("ListProgress returned %d items, want 3", len(all))
 	}
 
+	// ListProgressFiltered with no type/library predicate degrades to the plain
+	// status listing. Only this no-filter path is portable across backends: the
+	// per-user SQLite store has no catalog tables to push a type/library filter
+	// into, so the type/library branches are covered by the pgstore tests.
+	completedFiltered, err := store.ListProgressFiltered(ctx, "p1", "completed", nil, nil, 10, 0)
+	if err != nil {
+		t.Fatalf("ListProgressFiltered: %v", err)
+	}
+	if len(completedFiltered) != 1 || completedFiltered[0].MediaItemID != "movie-2" {
+		t.Errorf("ListProgressFiltered(completed, no filter) = %+v, want [movie-2]", completedFiltered)
+	}
+
 	// GetProgress non-existent
 	wp, err = store.GetProgress(ctx, "p1", "nonexistent")
 	if err != nil {


### PR DESCRIPTION
Part of #246

Six performance/correctness fixes for the Jellyfin-compat path, derived from a 3-hour production log analysis and each verified by an independent adversarial review. Ordered by impact-per-risk; commits are split one-per-fix with separate hardening/test follow-ups.

## Problem

A production log window (08:27–11:27, ~62k requests) showed the Jellyfin-compat surface — the API that Infuse, Wholphin, and the Jellyfin clients talk to — was responsible for **473 of the 500 slowest requests**. The user-visible symptoms:

- **"Continue Watching" could take a minute and a half to load.** The home-screen resume row averaged ~17 seconds and peaked at **91 seconds** for some clients. It got dramatically worse under retry storms, where a single device hammering the server made everyone's resume row slower.
- **Opening a long-running soap opera hung for ~13 seconds.** Tapping into shows with very large episode counts (Coronation Street, EastEnders, Emmerdale) stalled the episode view every time a client checked "what's the next episode."
- **The "Watched history" view took ~15 seconds.** Filtering a library to already-played movies/episodes was a multi-second wait.
- **The "Recently Added" row took ~2 seconds on every load.** The cross-library latest-additions shelf was consistently slow on the home screen.
- **Detail-heavy rows were sluggish.** Rows where a client asks for rich metadata (media sources, chapters) took roughly a second.
- **Some home-screen rows were silently blank.** Certain Jellyfin-compat "hub" sections rendered as empty rails with no error shown — a query was failing server-side and the failure was being swallowed.

## Solution

Each fix prefers reuse of an existing fast Silo path and accepts reduced Jellyfin fidelity where it is safe (never reduced access control). Verified with `EXPLAIN ANALYZE` against the dev DB where a query plan was in question.

### fix(catalog): drop media-type exclusion on column-less episode_catalog_entries (`0e5c954e`)
The blank hub rails were a swallowed SQL error. Jellycompat injects `ExcludedMediaTypes=[audiobook,podcast]` into every section access filter, which made `ApplySectionAccessFilter` emit `NOT (ece.type = ANY(...))` against `episode_catalog_entries` — a table with no `type` column. Postgres returned `42703`, the handler degraded to an empty array, and the rail rendered blank. The exclusion is dropped on this path (`internal/catalog/episode_catalog_entries_executor.go`); `content_rating` filtering is preserved.

### perf(jellycompat): serve Resume via capped continue-watching fetcher (`117cde27`)
`/UserItems/Resume` ran `loadProgressPage`, whose only early-exit was gated off when `enableTotalRecordCount=true`, so it scanned the entire in-progress list and re-paginated the whole completed history once per batch. It now delegates to the native `sections.Fetcher` continue-watching path (hard-capped: page 100, max 1000 scanned, indexed home-dismissal filtering), capped at 50 items. Results re-hydrate through the existing shared `hydrateProgressItems` so episode DTOs are byte-for-byte identical; a new `ResolvedSection.SuppressNextUp` keeps the row in-progress-only. The fast path fires for video resume requests (the dominant + slow traffic) and falls back to `loadProgressPage` for exotic type-only requests.

### perf(jellycompat): serve /Shows/{id}/Episodes AdjacentTo from a bounded query (`51d6a1cc`)
`AdjacentTo` was unparsed, so the soap-opera autoplay/skip probe fell to the full-series path and materialized every episode (a per-episode correlated `EXISTS` over ~10k rows). It now parses the param and uses `EpisodeRepository.ListAdjacentInSeries` — a single `UNION ALL` of prev/self/next backed by the `(series_id, season_number, episode_number)` index — mapping only those ≤3 episodes through a shared `writeEpisodeModelsPage` helper (extracted from `writeSeriesEpisodesResponse`, non-adjacent behavior unchanged).

### perf(jellycompat): push type+library filter into SQL for played-history (`d0076f52`)
`/Items?IsPlayed=true` with type + `parentId` read the full completed history and discarded non-matching rows in memory. A new `UserStore.ListProgressFiltered` pushes the type+library filter into SQL with EXISTS pre-filters (separate movie and episode branches — episodes join via `series_id → media_items`), served by the existing `idx_uwp_profile_completed` partial index. Identical result set/ordering; SQLite (no catalog tables) returns the coarse page and the in-memory backstop narrows it.

### perf(jellycompat): fan out no-parent recently_added across libraries (`be9e7420`)
No-parent `/Items/Latest` set `LibraryID=0`, forcing a `MIN(first_seen_at)+GROUP BY` across all libraries that the `media_folder_id`-leading index can't serve (EXPLAIN: 1.5ms single-library vs 373–726ms multi-library). `BrowseRecentlyAddedAcrossLibraries` runs the fast single-library index walk once per accessible library and merges top-N in Go, deduping on `content_id` keeping the earliest `AddedAt` to preserve the old `MIN` semantics.

### perf(jellycompat): batch per-item GetItemDetail in detail-field paths (`0cf1242a`)
When a list request asks for `MediaSources`/`Chapters`/etc., the Latest/browse/search/Resume-detail loops called `GetItemDetail` per item (~10 sequential queries each). New `DetailService.GetItemDetailsByIDs` + `ItemRepository.EnsureAccessibleIDs` batch the shared work for movies/series (episodes reuse the existing `GetEpisodeDetailsForSeries`); `buildMediaItemDetail` takes an opt-in prefetch and falls back inline, so the per-item path is unchanged. Output DTOs are identical.

### Hardening / tests from the adversarial review
- **`fix(catalog): guard episode catalog hydration to series-parented episodes` (`8c9aa4aa`).** The review upgraded a latent risk to a reachable one: `episode_catalog_entries` also holds **podcast episodes**, and a custom-filter home section exposed as a virtual library and browsed with `MediaScope=episode` scoped to a podcast folder could surface them in a TV section once the media-type clause was dropped. Added `AND si.type = 'series'` to the shared hydration body (free on the hot path; the page query stays index-only) so non-series episodes are dropped on every episode-scope surface, plus a regression test and a corrected comment.
- **`fix(jellycompat): guard AdjacentTo against cross-series episode ids` (`0f2cac44`).** Returns an empty page if `AdjacentTo` names an episode from a different series than the path `{id}` (was silently mislabeled); also corrects a stale index reference.
- **`test(catalog): equivalence test for batched GetItemDetailsByIDs vs per-item` (`46038759`).** The original equivalence test was tautological (both stubs returned identical canned data). Added a DB-gated catalog-level test that drives the real batch vs per-item code over shared repos with `reflect.DeepEqual`, covering access checks, localization, credits ordering, and an access-control rejection case; verified non-tautological by injecting a divergence.
- **`docs(catalog): note cross-library dup ranking limitation` (`05f522c5`).**

## Risk / follow-ups

- **Resume `TotalRecordCount` is now the page length, not the full in-progress count**, for clients that sent `enableTotalRecordCount=true` (~1/3 of sampled traffic). The field/type are unchanged (no v1 contract break) and no client renders a total on this row, but a "see all" affordance driven by it would under-count.
- **Resume is capped at 50 items**; the largest observed client request was 40, so no current client is affected.
- **`AdjacentTo` returns prev/self/next (≤3 items)**, not Jellyfin's exact window — satisfies the autoplay/skip use it is actually called for.
- **Cross-library "Recently Added" dedup is approximate** for a `content_id` present in 2+ libraries (documented in `mergeRecentlyAddedItems`); acceptable for an approximate recency rail.
- **Played-history tail latency**: a profile with a huge completed history but a tiny matching library still walks the index (a few hundred ms in a contrived case) — ~30× better than the 13–15s baseline, no regression. The pre-existing missing `ORDER BY updated_at` tiebreaker (shared with `ListProgress`) is unchanged; a `, media_item_id` tiebreaker is a good future cleanup.
- **Long-term**: stop populating podcast episodes into `episode_catalog_entries` at the migration level (add `si.type='series'` to migration 142's population paths) so the hydration guard becomes belt-and-suspenders.
- **Confirm prod table stats are fresh** so the planner keeps the intended index plans for the played-history and latest queries.
- The new catalog equivalence test is **DB-gated** (`SILO_TEST_DATABASE_URL`); it skips when unset, matching the repo's existing integration-test pattern — ensure CI provides the DB to run it.

## Verification

- `go build ./...`, `go vet ./...`, and the full `go test ./...` suite pass; all changed files are `gofmt` clean.
- Each fix was reviewed by an independent adversarial agent against its committed diff; all six returned SHIP (the nits became the hardening/test commits above). Fix 6's access-control parity (`EnsureAccessibleIDs` vs `EnsureAccessible`) was diffed predicate-by-predicate and confirmed identical.
- Query-plan claims were validated with `EXPLAIN ANALYZE` on the dev DB: single-library recently_added uses the index-only scan; the played-history filter rides `idx_uwp_profile_completed` (1.3–1.8ms realistic).
- Slow/fast request splits were re-derived directly from the production logs per endpoint.

## AI-use disclosure

The log analysis, root-causing, implementation, and adversarial review were performed with AI assistance (Claude Code). Each fix and its review were run as separate agents; all changes were build/vet/test-verified, and query plans were checked against a live dev database. Findings and code were reviewed before commit.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Faster “recently added,” resume, episode, search, and detail views through new batched and cross-library handling.
  * Episode pages can now show a neighboring-episode window when jumping to a specific episode.

* **Bug Fixes**
  * Improved accuracy for episode listings and recently added results across multiple libraries.
  * Fixed cases where some non-TV media could appear in episode-related views.
  * Completed-progress and detail-heavy pages now load more efficiently with fewer delays.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->