### PR TITLE
Reduce metadata image cache R2 churn

### DIFF
--- a/internal/imagecache/imagecache.go
+++ b/internal/imagecache/imagecache.go
@@ -19,7 +19,7 @@ import (
 )
 
 const (
-	maxDownloadBytes = 10 * 1024 * 1024 // 10 MB
+	maxDownloadBytes = 25 * 1024 * 1024 // allow oversized provider originals; cached variants are dimension-capped
 	downloadTimeout  = 30 * time.Second
 )
 
@@ -27,6 +27,10 @@ const (
 type ObjectPutter interface {
 	PutObject(ctx context.Context, bucket, key string, data []byte) error
 	Bucket() string
+}
+
+type objectExister interface {
+	ObjectExists(ctx context.Context, bucket, key string) (bool, error)
 }
 
 // ImageURLResolver resolves plugin:// paths to HTTP URLs.
@@ -52,9 +56,11 @@ type CacheRequest struct {
 
 // CacheResult is returned by Cache on success.
 type CacheResult struct {
-	BasePath  string // S3 key prefix, e.g. "tmdb/movies/550/poster"
-	Thumbhash string // base64-encoded
-	Ext       string // file extension including dot (e.g. ".jpg", ".png")
+	BasePath         string // S3 key prefix, e.g. "tmdb/movies/550/poster"
+	Thumbhash        string // base64-encoded
+	Ext              string // file extension including dot (e.g. ".jpg", ".png")
+	UploadedVariants int
+	ExistingVariants int
 }
 
 // Cacher downloads and stores image variants to S3.
@@ -92,9 +98,11 @@ func (c *Cacher) CacheImage(ctx context.Context, req metadata.CacheImageRequest)
 		return nil, err
 	}
 	return &metadata.CacheImageResult{
-		BasePath:  result.BasePath,
-		Thumbhash: result.Thumbhash,
-		Ext:       result.Ext,
+		BasePath:         result.BasePath,
+		Thumbhash:        result.Thumbhash,
+		Ext:              result.Ext,
+		UploadedVariants: result.UploadedVariants,
+		ExistingVariants: result.ExistingVariants,
 	}, nil
 }
 
@@ -160,25 +168,18 @@ func (c *Cacher) CacheBytes(ctx context.Context, data []byte, req CacheRequest) 
 	}
 	basePath := buildBasePath(req.ProviderID, req.ContentType, req.ContentID, req.ImageType, req.Language, req.SeasonNumber, req.EpisodeNumber)
 	bucket := c.s3.Bucket()
-	var wg sync.WaitGroup
-	uploadErrs := make([]error, len(result.Variants))
-	for i, v := range result.Variants {
-		wg.Add(1)
-		go func(idx int, variant imageutil.Variant) {
-			defer wg.Done()
-			key := basePath + "/" + variant.Key + result.Ext
-			if err := putObjectWithRetry(ctx, c.s3, bucket, key, variant.Data); err != nil {
-				uploadErrs[idx] = fmt.Errorf("imagecache: upload %s: %w", key, err)
-			}
-		}(i, v)
+
+	uploadStats, err := c.uploadVariants(ctx, bucket, basePath, result)
+	if err != nil {
+		return nil, err
 	}
-	wg.Wait()
-	for _, err := range uploadErrs {
-		if err != nil {
-			return nil, err
-		}
-	}
-	return &CacheResult{BasePath: basePath, Thumbhash: thumbhash, Ext: result.Ext}, nil
+	return &CacheResult{
+		BasePath:         basePath,
+		Thumbhash:        thumbhash,
+		Ext:              result.Ext,
+		UploadedVariants: uploadStats.uploaded,
+		ExistingVariants: uploadStats.existing,
+	}, nil
 }
 
 // Cache downloads the image at req.SourceURL, generates variants, computes a
@@ -232,31 +233,17 @@ func (c *Cacher) Cache(ctx context.Context, req CacheRequest) (*CacheResult, err
 	basePath := buildBasePath(req.ProviderID, req.ContentType, req.ContentID, req.ImageType, req.Language, req.SeasonNumber, req.EpisodeNumber)
 	bucket := c.s3.Bucket()
 
-	// Upload all variants concurrently.
-	var wg sync.WaitGroup
-	uploadErrs := make([]error, len(result.Variants))
-	for i, v := range result.Variants {
-		wg.Add(1)
-		go func(idx int, variant imageutil.Variant) {
-			defer wg.Done()
-			key := basePath + "/" + variant.Key + result.Ext
-			if err := putObjectWithRetry(ctx, c.s3, bucket, key, variant.Data); err != nil {
-				uploadErrs[idx] = fmt.Errorf("imagecache: upload %s: %w", key, err)
-			}
-		}(i, v)
-	}
-	wg.Wait()
-
-	for _, err := range uploadErrs {
-		if err != nil {
-			return nil, err
-		}
+	uploadStats, err := c.uploadVariants(ctx, bucket, basePath, result)
+	if err != nil {
+		return nil, err
 	}
 
 	return &CacheResult{
-		BasePath:  basePath,
-		Thumbhash: thumbhash,
-		Ext:       result.Ext,
+		BasePath:         basePath,
+		Thumbhash:        thumbhash,
+		Ext:              result.Ext,
+		UploadedVariants: uploadStats.uploaded,
+		ExistingVariants: uploadStats.existing,
 	}, nil
 }
 
@@ -276,6 +263,56 @@ func variantWidths(t metadata.ImageType) []int {
 	default:
 		return []int{500, 300}
 	}
+}
+
+type uploadVariantStats struct {
+	uploaded int
+	existing int
+}
+
+func (c *Cacher) uploadVariants(ctx context.Context, bucket, basePath string, result *imageutil.VariantResult) (uploadVariantStats, error) {
+	var wg sync.WaitGroup
+	uploadErrs := make([]error, len(result.Variants))
+	stats := make([]uploadVariantStats, len(result.Variants))
+	for i, v := range result.Variants {
+		wg.Add(1)
+		go func(idx int, variant imageutil.Variant) {
+			defer wg.Done()
+			key := basePath + "/" + variant.Key + result.Ext
+			if exists, err := objectExists(ctx, c.s3, bucket, key); err != nil {
+				uploadErrs[idx] = fmt.Errorf("imagecache: check existing %s: %w", key, err)
+				return
+			} else if exists {
+				stats[idx].existing = 1
+				return
+			}
+			if err := putObjectWithRetry(ctx, c.s3, bucket, key, variant.Data); err != nil {
+				uploadErrs[idx] = fmt.Errorf("imagecache: upload %s: %w", key, err)
+				return
+			}
+			stats[idx].uploaded = 1
+		}(i, v)
+	}
+	wg.Wait()
+	var total uploadVariantStats
+	for _, err := range uploadErrs {
+		if err != nil {
+			return total, err
+		}
+	}
+	for _, s := range stats {
+		total.uploaded += s.uploaded
+		total.existing += s.existing
+	}
+	return total, nil
+}
+
+func objectExists(ctx context.Context, putter ObjectPutter, bucket, key string) (bool, error) {
+	exister, ok := putter.(objectExister)
+	if !ok {
+		return false, nil
+	}
+	return exister.ObjectExists(ctx, bucket, key)
 }
 
 func putObjectWithRetry(ctx context.Context, putter ObjectPutter, bucket, key string, data []byte) error {

--- a/internal/imagecache/imagecache_test.go
+++ b/internal/imagecache/imagecache_test.go
@@ -8,10 +8,13 @@ import (
 	"image"
 	"image/color"
 	"image/jpeg"
+	"image/png"
 	"net/http"
 	"net/http/httptest"
 	"sync"
 	"testing"
+
+	"github.com/h2non/bimg"
 
 	"github.com/Silo-Server/silo-server/internal/metadata"
 )
@@ -32,6 +35,21 @@ func makeTestJPEG(t *testing.T) []byte {
 	return buf.Bytes()
 }
 
+func makeTestPNG(t *testing.T, width, height int) []byte {
+	t.Helper()
+	img := image.NewRGBA(image.Rect(0, 0, width, height))
+	for y := range height {
+		for x := range width {
+			img.SetRGBA(x, y, color.RGBA{R: uint8(x % 255), G: uint8(y % 255), B: 180, A: 255})
+		}
+	}
+	var buf bytes.Buffer
+	if err := png.Encode(&buf, img); err != nil {
+		t.Fatalf("makeTestPNG: encode: %v", err)
+	}
+	return buf.Bytes()
+}
+
 // mockS3 records all PutObject calls for test assertions.
 type mockS3 struct {
 	mu                    sync.Mutex
@@ -39,12 +57,16 @@ type mockS3 struct {
 	bucket                string
 	putErr                error // if non-nil, returned for every PutObject call
 	failuresBeforeSuccess int
+	existing              map[string]bool
+	existsErr             error
+	existsCalls           []string
 }
 
 type putCall struct {
 	bucket string
 	key    string
 	size   int
+	data   []byte
 }
 
 func (m *mockS3) PutObject(_ context.Context, bucket, key string, data []byte) error {
@@ -57,11 +79,22 @@ func (m *mockS3) PutObject(_ context.Context, bucket, key string, data []byte) e
 	if m.putErr != nil {
 		return m.putErr
 	}
-	m.calls = append(m.calls, putCall{bucket: bucket, key: key, size: len(data)})
+	copied := append([]byte(nil), data...)
+	m.calls = append(m.calls, putCall{bucket: bucket, key: key, size: len(data), data: copied})
 	return nil
 }
 
 func (m *mockS3) Bucket() string { return m.bucket }
+
+func (m *mockS3) ObjectExists(_ context.Context, _ string, key string) (bool, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.existsCalls = append(m.existsCalls, key)
+	if m.existsErr != nil {
+		return false, m.existsErr
+	}
+	return m.existing[key], nil
+}
 
 func (m *mockS3) keys() []string {
 	m.mu.Lock()
@@ -70,6 +103,25 @@ func (m *mockS3) keys() []string {
 	for i, c := range m.calls {
 		keys[i] = c.key
 	}
+	return keys
+}
+
+func (m *mockS3) objectData(key string) []byte {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	for _, c := range m.calls {
+		if c.key == key {
+			return c.data
+		}
+	}
+	return nil
+}
+
+func (m *mockS3) checkedKeys() []string {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	keys := make([]string, len(m.existsCalls))
+	copy(keys, m.existsCalls)
 	return keys
 }
 
@@ -147,6 +199,79 @@ func TestCache_Poster(t *testing.T) {
 		if !hasKey(keys, want) {
 			t.Errorf("missing S3 key %q in %v", want, keys)
 		}
+	}
+}
+
+func TestCacheSkipsUploadingVariantsThatAlreadyExist(t *testing.T) {
+	jpeg := makeTestJPEG(t)
+	srv := startImageServer(t, jpeg, http.StatusOK)
+
+	wantBase := "tmdb/movies/550/poster"
+	s3 := &mockS3{
+		bucket: "media",
+		existing: map[string]bool{
+			wantBase + "/original.webp": true,
+			wantBase + "/w500.webp":     true,
+			wantBase + "/w300.webp":     true,
+		},
+	}
+	c := newWithHTTPClient(s3, srv.Client())
+
+	result, err := c.Cache(context.Background(), CacheRequest{
+		SourceURL:   srv.URL + "/poster.jpg",
+		ProviderID:  "tmdb",
+		ContentType: "movies",
+		ContentID:   "550",
+		ImageType:   metadata.ImagePoster,
+	})
+	if err != nil {
+		t.Fatalf("Cache poster with existing variants: %v", err)
+	}
+	if result.BasePath != wantBase {
+		t.Fatalf("BasePath = %q, want %q", result.BasePath, wantBase)
+	}
+	if got := s3.keys(); len(got) != 0 {
+		t.Fatalf("uploaded keys = %v, want none when variants already exist", got)
+	}
+	if result.UploadedVariants != 0 || result.ExistingVariants != 3 {
+		t.Fatalf("upload stats = uploaded %d existing %d, want uploaded 0 existing 3", result.UploadedVariants, result.ExistingVariants)
+	}
+	for _, key := range []string{wantBase + "/original.webp", wantBase + "/w500.webp", wantBase + "/w300.webp"} {
+		if !hasKey(s3.checkedKeys(), key) {
+			t.Fatalf("ObjectExists was not checked for %q; checked %v", key, s3.checkedKeys())
+		}
+	}
+}
+
+func TestCacheUploadsOnlyMissingVariants(t *testing.T) {
+	jpeg := makeTestJPEG(t)
+	srv := startImageServer(t, jpeg, http.StatusOK)
+
+	wantBase := "tmdb/movies/550/poster"
+	s3 := &mockS3{
+		bucket: "media",
+		existing: map[string]bool{
+			wantBase + "/original.webp": true,
+			wantBase + "/w500.webp":     true,
+		},
+	}
+	c := newWithHTTPClient(s3, srv.Client())
+
+	result, err := c.Cache(context.Background(), CacheRequest{
+		SourceURL:   srv.URL + "/poster.jpg",
+		ProviderID:  "tmdb",
+		ContentType: "movies",
+		ContentID:   "550",
+		ImageType:   metadata.ImagePoster,
+	})
+	if err != nil {
+		t.Fatalf("Cache poster with partial existing variants: %v", err)
+	}
+	if got := s3.keys(); len(got) != 1 || got[0] != wantBase+"/w300.webp" {
+		t.Fatalf("uploaded keys = %v, want only missing w300 variant", got)
+	}
+	if result.UploadedVariants != 1 || result.ExistingVariants != 2 {
+		t.Fatalf("upload stats = uploaded %d existing %d, want uploaded 1 existing 2", result.UploadedVariants, result.ExistingVariants)
 	}
 }
 
@@ -228,6 +353,76 @@ func TestCache_Logo(t *testing.T) {
 		if hasKey(keys, wantBase+"/"+forbidden+".webp") {
 			t.Errorf("logo should not have %s variant", forbidden)
 		}
+	}
+}
+
+func TestCache_ConvertsSVGLogo(t *testing.T) {
+	svg := []byte(`<svg xmlns="http://www.w3.org/2000/svg" width="1200" height="400" viewBox="0 0 1200 400"><rect width="1200" height="400" fill="#111"/><text x="80" y="255" fill="#fff" font-family="Arial" font-size="180">SILO</text></svg>`)
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "image/svg+xml")
+		_, _ = w.Write(svg)
+	}))
+	t.Cleanup(srv.Close)
+
+	s3 := &mockS3{bucket: "media"}
+	c := newWithHTTPClient(s3, srv.Client())
+
+	result, err := c.Cache(context.Background(), CacheRequest{
+		SourceURL:   srv.URL + "/logo.svg",
+		ProviderID:  "tmdb",
+		ContentType: "series",
+		ContentID:   "1396",
+		ImageType:   metadata.ImageLogo,
+	})
+	if err != nil {
+		t.Fatalf("Cache SVG logo: %v", err)
+	}
+	if result.Thumbhash == "" {
+		t.Fatal("Thumbhash is empty")
+	}
+	wantBase := "tmdb/series/1396/logo"
+	for _, variant := range []string{"original", "w500"} {
+		want := wantBase + "/" + variant + ".webp"
+		if !hasKey(s3.keys(), want) {
+			t.Errorf("missing S3 key %q in %v", want, s3.keys())
+		}
+	}
+}
+
+func TestCache_CapsLargeOriginalVariant(t *testing.T) {
+	pngData := makeTestPNG(t, 2600, 900)
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "image/png")
+		_, _ = w.Write(pngData)
+	}))
+	t.Cleanup(srv.Close)
+
+	s3 := &mockS3{bucket: "media"}
+	c := newWithHTTPClient(s3, srv.Client())
+
+	_, err := c.Cache(context.Background(), CacheRequest{
+		SourceURL:   srv.URL + "/logo.png",
+		ProviderID:  "tmdb",
+		ContentType: "series",
+		ContentID:   "1396",
+		ImageType:   metadata.ImageLogo,
+	})
+	if err != nil {
+		t.Fatalf("Cache large logo: %v", err)
+	}
+	original := s3.objectData("tmdb/series/1396/logo/original.webp")
+	if len(original) == 0 {
+		t.Fatal("missing original.webp upload")
+	}
+	size, err := bimg.NewImage(original).Size()
+	if err != nil {
+		t.Fatalf("reading original.webp size: %v", err)
+	}
+	if size.Width > 1920 {
+		t.Fatalf("original.webp width = %d, want <= 1920", size.Width)
+	}
+	if len(original) >= 10*1024*1024 {
+		t.Fatalf("original.webp size = %d bytes, want < 10 MiB", len(original))
 	}
 }
 

--- a/internal/imageutil/imageutil.go
+++ b/internal/imageutil/imageutil.go
@@ -16,7 +16,11 @@ import (
 	"go.n16f.net/thumbhash"
 )
 
-const webpQuality = 90
+const (
+	webpQuality                = 90
+	maxCachedOriginalDimension = 1920
+	thumbhashSourceDimension   = 100
+)
 
 // Variant holds a named image variant (e.g. "original", "w500").
 type Variant struct {
@@ -39,18 +43,22 @@ func GenerateVariants(data []byte, widths []int) (*VariantResult, error) {
 	img := bimg.NewImage(data)
 
 	// Validate input by reading size.
-	if _, err := img.Size(); err != nil {
+	size, err := img.Size()
+	if err != nil {
 		return nil, fmt.Errorf("imageutil: invalid image: %w", err)
 	}
 
 	variants := make([]Variant, 0, len(widths)+1)
 
-	// Original — re-encode as WebP, strip metadata, no resize.
-	original, err := bimg.NewImage(data).Process(bimg.Options{
+	// Original — re-encode as WebP, strip metadata, and cap very large provider
+	// artwork so cached originals do not preserve oversized source dimensions.
+	originalOptions := bimg.Options{
 		Type:          bimg.WEBP,
 		Quality:       webpQuality,
 		StripMetadata: true,
-	})
+	}
+	fitWithin(&originalOptions, size, maxCachedOriginalDimension)
+	original, err := bimg.NewImage(data).Process(originalOptions)
 	if err != nil {
 		return nil, fmt.Errorf("imageutil: encode original: %w", err)
 	}
@@ -148,12 +156,51 @@ func GenerateSquareVariants(data []byte, sizes []int) (*VariantResult, error) {
 func Thumbhash(data []byte) (string, error) {
 	img, _, err := image.Decode(bytes.NewReader(data))
 	if err != nil {
-		return "", fmt.Errorf("imageutil: decode for thumbhash: %w", err)
+		normalized, normalizeErr := normalizeThumbhashSource(data)
+		if normalizeErr != nil {
+			return "", fmt.Errorf("imageutil: decode for thumbhash: %w", err)
+		}
+		img, _, err = image.Decode(bytes.NewReader(normalized))
+		if err != nil {
+			return "", fmt.Errorf("imageutil: decode normalized thumbhash source: %w", err)
+		}
 	}
 
 	scaled := scaleImage(img, 100)
 	hashBytes := thumbhash.EncodeImage(scaled)
 	return base64.StdEncoding.EncodeToString(hashBytes), nil
+}
+
+func normalizeThumbhashSource(data []byte) ([]byte, error) {
+	img := bimg.NewImage(data)
+	size, err := img.Size()
+	if err != nil {
+		return nil, fmt.Errorf("imageutil: invalid image: %w", err)
+	}
+	opts := bimg.Options{
+		Type:          bimg.PNG,
+		StripMetadata: true,
+	}
+	fitWithin(&opts, size, thumbhashSourceDimension)
+	out, err := img.Process(opts)
+	if err != nil {
+		return nil, fmt.Errorf("imageutil: normalize thumbhash source: %w", err)
+	}
+	return out, nil
+}
+
+func fitWithin(opts *bimg.Options, size bimg.ImageSize, maxDim int) {
+	if opts == nil || maxDim <= 0 {
+		return
+	}
+	if size.Width <= maxDim && size.Height <= maxDim {
+		return
+	}
+	if size.Width >= size.Height {
+		opts.Width = maxDim
+		return
+	}
+	opts.Height = maxDim
 }
 
 // scaleImage scales src so its longest dimension does not exceed maxDim,

--- a/internal/metadata/image_cache_job_repo.go
+++ b/internal/metadata/image_cache_job_repo.go
@@ -35,6 +35,7 @@ const (
 	imageCacheLeaseDuration    = 15 * time.Minute
 	imageCacheMaxAttempts      = 8
 	imageCacheFailedRetryAfter = 6 * time.Hour
+	imageCacheDeferredRetry    = 7 * 24 * time.Hour
 )
 
 type EnqueueImageCacheJobInput struct {
@@ -70,12 +71,30 @@ func imageCacheRetryDelay(attempt int) time.Duration {
 	return delay
 }
 
+func imageCacheFailureRetryDelay(attempt int, errText string) time.Duration {
+	if isStableProviderImageFailure(errText) {
+		return imageCacheDeferredRetry
+	}
+	return imageCacheRetryDelay(attempt)
+}
+
+func isStableProviderImageFailure(errText string) bool {
+	return strings.Contains(errText, "unexpected status 403") ||
+		strings.Contains(errText, "unexpected status 404") ||
+		strings.Contains(errText, "unexpected status 410") ||
+		strings.Contains(errText, "unexpected status 418")
+}
+
 func (r *ImageCacheJobRepository) Enqueue(ctx context.Context, in EnqueueImageCacheJobInput) error {
 	_, err := r.EnqueueBatch(ctx, []EnqueueImageCacheJobInput{in})
 	return err
 }
 
 func (r *ImageCacheJobRepository) EnqueueBatch(ctx context.Context, inputs []EnqueueImageCacheJobInput) (int, error) {
+	return r.enqueueBatch(ctx, inputs, false)
+}
+
+func (r *ImageCacheJobRepository) enqueueBatch(ctx context.Context, inputs []EnqueueImageCacheJobInput, requeueSucceeded bool) (int, error) {
 	if r == nil || r.pool == nil {
 		return 0, nil
 	}
@@ -97,7 +116,7 @@ func (r *ImageCacheJobRepository) EnqueueBatch(ctx context.Context, inputs []Enq
 		if end > len(valid) {
 			end = len(valid)
 		}
-		affected, err := r.enqueueBatchChunk(ctx, valid[start:end])
+		affected, err := r.enqueueBatchChunk(ctx, valid[start:end], requeueSucceeded)
 		if err != nil {
 			return total, err
 		}
@@ -124,7 +143,7 @@ func normalizeImageCacheJobInput(in EnqueueImageCacheJobInput) (EnqueueImageCach
 	return in, true
 }
 
-func (r *ImageCacheJobRepository) enqueueBatchChunk(ctx context.Context, inputs []EnqueueImageCacheJobInput) (int, error) {
+func (r *ImageCacheJobRepository) enqueueBatchChunk(ctx context.Context, inputs []EnqueueImageCacheJobInput, requeueSucceeded bool) (int, error) {
 	var sql strings.Builder
 	args := make([]any, 0, len(inputs)*11+1)
 	sql.WriteString(`
@@ -151,6 +170,8 @@ func (r *ImageCacheJobRepository) enqueueBatchChunk(ctx context.Context, inputs 
 	}
 	retryArg := len(args) + 1
 	args = append(args, intervalLiteral(imageCacheFailedRetryAfter))
+	requeueSucceededArg := len(args) + 1
+	args = append(args, requeueSucceeded)
 	fmt.Fprintf(&sql, `
 	ON CONFLICT (target_type, target_content_id, image_type, target_language) DO UPDATE SET
 		series_id = EXCLUDED.series_id,
@@ -166,6 +187,9 @@ func (r *ImageCacheJobRepository) enqueueBatchChunk(ctx context.Context, inputs 
 				WHEN metadata_image_cache_jobs.status = 'failed'
 					AND metadata_image_cache_jobs.updated_at < NOW() - $%d::interval
 					THEN 'queued'
+				WHEN $%d::boolean
+					AND metadata_image_cache_jobs.status = 'succeeded'
+					THEN 'queued'
 				WHEN metadata_image_cache_jobs.status = 'succeeded'
 					THEN 'succeeded'
 				ELSE metadata_image_cache_jobs.status
@@ -176,6 +200,9 @@ func (r *ImageCacheJobRepository) enqueueBatchChunk(ctx context.Context, inputs 
 				WHEN metadata_image_cache_jobs.status = 'failed'
 					AND metadata_image_cache_jobs.updated_at < NOW() - $%d::interval
 					THEN 0
+				WHEN $%d::boolean
+					AND metadata_image_cache_jobs.status = 'succeeded'
+					THEN 0
 				ELSE metadata_image_cache_jobs.attempt_count
 			END,
 			next_attempt_at = CASE
@@ -183,6 +210,9 @@ func (r *ImageCacheJobRepository) enqueueBatchChunk(ctx context.Context, inputs 
 					THEN NOW()
 				WHEN metadata_image_cache_jobs.status = 'failed'
 					AND metadata_image_cache_jobs.updated_at < NOW() - $%d::interval
+					THEN NOW()
+				WHEN $%d::boolean
+					AND metadata_image_cache_jobs.status = 'succeeded'
 					THEN NOW()
 				ELSE metadata_image_cache_jobs.next_attempt_at
 			END,
@@ -192,6 +222,9 @@ func (r *ImageCacheJobRepository) enqueueBatchChunk(ctx context.Context, inputs 
 				WHEN metadata_image_cache_jobs.status = 'failed'
 					AND metadata_image_cache_jobs.updated_at < NOW() - $%d::interval
 					THEN NULL
+				WHEN $%d::boolean
+					AND metadata_image_cache_jobs.status = 'succeeded'
+					THEN NULL
 				ELSE metadata_image_cache_jobs.locked_at
 			END,
 			locked_by = CASE
@@ -199,6 +232,9 @@ func (r *ImageCacheJobRepository) enqueueBatchChunk(ctx context.Context, inputs 
 					THEN ''
 				WHEN metadata_image_cache_jobs.status = 'failed'
 					AND metadata_image_cache_jobs.updated_at < NOW() - $%d::interval
+					THEN ''
+				WHEN $%d::boolean
+					AND metadata_image_cache_jobs.status = 'succeeded'
 					THEN ''
 				ELSE metadata_image_cache_jobs.locked_by
 			END,
@@ -208,6 +244,9 @@ func (r *ImageCacheJobRepository) enqueueBatchChunk(ctx context.Context, inputs 
 				WHEN metadata_image_cache_jobs.status = 'failed'
 					AND metadata_image_cache_jobs.updated_at < NOW() - $%d::interval
 					THEN ''
+				WHEN $%d::boolean
+					AND metadata_image_cache_jobs.status = 'succeeded'
+					THEN ''
 				ELSE metadata_image_cache_jobs.last_error
 			END,
 			completed_at = CASE
@@ -215,6 +254,9 @@ func (r *ImageCacheJobRepository) enqueueBatchChunk(ctx context.Context, inputs 
 					THEN NULL
 				WHEN metadata_image_cache_jobs.status = 'failed'
 					AND metadata_image_cache_jobs.updated_at < NOW() - $%d::interval
+					THEN NULL
+				WHEN $%d::boolean
+					AND metadata_image_cache_jobs.status = 'succeeded'
 					THEN NULL
 				ELSE metadata_image_cache_jobs.completed_at
 			END,
@@ -224,8 +266,19 @@ func (r *ImageCacheJobRepository) enqueueBatchChunk(ctx context.Context, inputs 
 		   OR (
 			   metadata_image_cache_jobs.status = 'failed'
 			   AND metadata_image_cache_jobs.updated_at < NOW() - $%d::interval
+		   )
+		   OR (
+			   $%d::boolean
+			   AND metadata_image_cache_jobs.status = 'succeeded'
 		   )`,
-		retryArg, retryArg, retryArg, retryArg, retryArg, retryArg, retryArg, retryArg)
+		retryArg, requeueSucceededArg,
+		retryArg, requeueSucceededArg,
+		retryArg, requeueSucceededArg,
+		retryArg, requeueSucceededArg,
+		retryArg, requeueSucceededArg,
+		retryArg, requeueSucceededArg,
+		retryArg, requeueSucceededArg,
+		retryArg, requeueSucceededArg)
 
 	tag, err := r.pool.Exec(ctx, sql.String(), args...)
 	if err != nil {
@@ -350,7 +403,7 @@ func (r *ImageCacheJobRepository) MarkFailed(ctx context.Context, id int64, atte
 	if nextAttempt >= imageCacheMaxAttempts {
 		status = ImageCacheStatusFailed
 	}
-	delay := imageCacheRetryDelay(nextAttempt)
+	delay := imageCacheFailureRetryDelay(nextAttempt, errText)
 
 	_, err := r.pool.Exec(ctx, `
 		UPDATE metadata_image_cache_jobs
@@ -695,6 +748,7 @@ func (r *ImageCacheJobRepository) EnqueueExistingProviderArtwork(ctx context.Con
 			 AND j.target_language = ac.target_language
 			WHERE j.id IS NULL
 			   OR j.source_path IS DISTINCT FROM ac.source_path
+			   OR j.status = 'succeeded'
 			   OR (
 				   j.status = 'failed'
 				   AND j.updated_at < NOW() - $2::interval
@@ -743,7 +797,7 @@ func (r *ImageCacheJobRepository) EnqueueExistingProviderArtwork(ctx context.Con
 	if err := rows.Err(); err != nil {
 		return 0, fmt.Errorf("iterating existing provider artwork: %w", err)
 	}
-	return r.EnqueueBatch(ctx, inputs)
+	return r.enqueueBatch(ctx, inputs, true)
 }
 
 func imageCacheProviderIDFromSource(sourcePath, fallback string) string {

--- a/internal/metadata/image_cache_job_repo.go
+++ b/internal/metadata/image_cache_job_repo.go
@@ -32,10 +32,9 @@ const (
 	ImageCacheStatusSucceeded = "succeeded"
 	ImageCacheStatusFailed    = "failed"
 
-	imageCacheLeaseDuration    = 15 * time.Minute
-	imageCacheMaxAttempts      = 8
-	imageCacheFailedRetryAfter = 6 * time.Hour
-	imageCacheDeferredRetry    = 7 * 24 * time.Hour
+	imageCacheLeaseDuration = 15 * time.Minute
+	imageCacheMaxAttempts   = 8
+	imageCacheDeferredRetry = 7 * 24 * time.Hour
 )
 
 type EnqueueImageCacheJobInput struct {
@@ -168,8 +167,6 @@ func (r *ImageCacheJobRepository) enqueueBatchChunk(ctx context.Context, inputs 
 			in.SeasonNumber, in.EpisodeNumber,
 		)
 	}
-	retryArg := len(args) + 1
-	args = append(args, intervalLiteral(imageCacheFailedRetryAfter))
 	requeueSucceededArg := len(args) + 1
 	args = append(args, requeueSucceeded)
 	fmt.Fprintf(&sql, `
@@ -185,7 +182,7 @@ func (r *ImageCacheJobRepository) enqueueBatchChunk(ctx context.Context, inputs 
 				WHEN metadata_image_cache_jobs.source_path IS DISTINCT FROM EXCLUDED.source_path
 					THEN 'queued'
 				WHEN metadata_image_cache_jobs.status = 'failed'
-					AND metadata_image_cache_jobs.updated_at < NOW() - $%d::interval
+					AND metadata_image_cache_jobs.next_attempt_at <= NOW()
 					THEN 'queued'
 				WHEN $%d::boolean
 					AND metadata_image_cache_jobs.status = 'succeeded'
@@ -198,7 +195,7 @@ func (r *ImageCacheJobRepository) enqueueBatchChunk(ctx context.Context, inputs 
 				WHEN metadata_image_cache_jobs.source_path IS DISTINCT FROM EXCLUDED.source_path
 					THEN 0
 				WHEN metadata_image_cache_jobs.status = 'failed'
-					AND metadata_image_cache_jobs.updated_at < NOW() - $%d::interval
+					AND metadata_image_cache_jobs.next_attempt_at <= NOW()
 					THEN 0
 				WHEN $%d::boolean
 					AND metadata_image_cache_jobs.status = 'succeeded'
@@ -209,7 +206,7 @@ func (r *ImageCacheJobRepository) enqueueBatchChunk(ctx context.Context, inputs 
 				WHEN metadata_image_cache_jobs.source_path IS DISTINCT FROM EXCLUDED.source_path
 					THEN NOW()
 				WHEN metadata_image_cache_jobs.status = 'failed'
-					AND metadata_image_cache_jobs.updated_at < NOW() - $%d::interval
+					AND metadata_image_cache_jobs.next_attempt_at <= NOW()
 					THEN NOW()
 				WHEN $%d::boolean
 					AND metadata_image_cache_jobs.status = 'succeeded'
@@ -220,7 +217,7 @@ func (r *ImageCacheJobRepository) enqueueBatchChunk(ctx context.Context, inputs 
 				WHEN metadata_image_cache_jobs.source_path IS DISTINCT FROM EXCLUDED.source_path
 					THEN NULL
 				WHEN metadata_image_cache_jobs.status = 'failed'
-					AND metadata_image_cache_jobs.updated_at < NOW() - $%d::interval
+					AND metadata_image_cache_jobs.next_attempt_at <= NOW()
 					THEN NULL
 				WHEN $%d::boolean
 					AND metadata_image_cache_jobs.status = 'succeeded'
@@ -231,7 +228,7 @@ func (r *ImageCacheJobRepository) enqueueBatchChunk(ctx context.Context, inputs 
 				WHEN metadata_image_cache_jobs.source_path IS DISTINCT FROM EXCLUDED.source_path
 					THEN ''
 				WHEN metadata_image_cache_jobs.status = 'failed'
-					AND metadata_image_cache_jobs.updated_at < NOW() - $%d::interval
+					AND metadata_image_cache_jobs.next_attempt_at <= NOW()
 					THEN ''
 				WHEN $%d::boolean
 					AND metadata_image_cache_jobs.status = 'succeeded'
@@ -242,7 +239,7 @@ func (r *ImageCacheJobRepository) enqueueBatchChunk(ctx context.Context, inputs 
 				WHEN metadata_image_cache_jobs.source_path IS DISTINCT FROM EXCLUDED.source_path
 					THEN ''
 				WHEN metadata_image_cache_jobs.status = 'failed'
-					AND metadata_image_cache_jobs.updated_at < NOW() - $%d::interval
+					AND metadata_image_cache_jobs.next_attempt_at <= NOW()
 					THEN ''
 				WHEN $%d::boolean
 					AND metadata_image_cache_jobs.status = 'succeeded'
@@ -253,7 +250,7 @@ func (r *ImageCacheJobRepository) enqueueBatchChunk(ctx context.Context, inputs 
 				WHEN metadata_image_cache_jobs.source_path IS DISTINCT FROM EXCLUDED.source_path
 					THEN NULL
 				WHEN metadata_image_cache_jobs.status = 'failed'
-					AND metadata_image_cache_jobs.updated_at < NOW() - $%d::interval
+					AND metadata_image_cache_jobs.next_attempt_at <= NOW()
 					THEN NULL
 				WHEN $%d::boolean
 					AND metadata_image_cache_jobs.status = 'succeeded'
@@ -265,20 +262,20 @@ func (r *ImageCacheJobRepository) enqueueBatchChunk(ctx context.Context, inputs 
 		   OR metadata_image_cache_jobs.status IN ('queued', 'running')
 		   OR (
 			   metadata_image_cache_jobs.status = 'failed'
-			   AND metadata_image_cache_jobs.updated_at < NOW() - $%d::interval
+			   AND metadata_image_cache_jobs.next_attempt_at <= NOW()
 		   )
 		   OR (
 			   $%d::boolean
 			   AND metadata_image_cache_jobs.status = 'succeeded'
 		   )`,
-		retryArg, requeueSucceededArg,
-		retryArg, requeueSucceededArg,
-		retryArg, requeueSucceededArg,
-		retryArg, requeueSucceededArg,
-		retryArg, requeueSucceededArg,
-		retryArg, requeueSucceededArg,
-		retryArg, requeueSucceededArg,
-		retryArg, requeueSucceededArg)
+		requeueSucceededArg,
+		requeueSucceededArg,
+		requeueSucceededArg,
+		requeueSucceededArg,
+		requeueSucceededArg,
+		requeueSucceededArg,
+		requeueSucceededArg,
+		requeueSucceededArg)
 
 	tag, err := r.pool.Exec(ctx, sql.String(), args...)
 	if err != nil {
@@ -751,7 +748,7 @@ func (r *ImageCacheJobRepository) EnqueueExistingProviderArtwork(ctx context.Con
 			   OR j.status = 'succeeded'
 			   OR (
 				   j.status = 'failed'
-				   AND j.updated_at < NOW() - $2::interval
+				   AND j.next_attempt_at <= NOW()
 			   )
 			ORDER BY ac.target_type, ac.target_content_id, ac.target_language, ac.image_type
 			LIMIT $1
@@ -762,7 +759,7 @@ func (r *ImageCacheJobRepository) EnqueueExistingProviderArtwork(ctx context.Con
 		       COALESCE(tvdb_id, '') AS tvdb_id,
 		       COALESCE(imdb_id, '') AS imdb_id
 		FROM candidates
-	`, limit, intervalLiteral(imageCacheFailedRetryAfter))
+	`, limit)
 	if err != nil {
 		return 0, fmt.Errorf("enqueueing existing provider artwork: %w", err)
 	}

--- a/internal/metadata/image_cache_job_repo_test.go
+++ b/internal/metadata/image_cache_job_repo_test.go
@@ -16,6 +16,23 @@ func TestImageCacheRetryDelayCaps(t *testing.T) {
 	}
 }
 
+func TestImageCacheFailureRetryDelayDefersStableProviderFailures(t *testing.T) {
+	tests := []string{
+		"imagecache: download https://example.invalid/missing.jpg: unexpected status 403",
+		"imagecache: download https://example.invalid/missing.jpg: unexpected status 404",
+		"imagecache: download https://example.invalid/missing.jpg: unexpected status 410",
+		"imagecache: download https://example.invalid/missing.jpg: unexpected status 418",
+	}
+	for _, errText := range tests {
+		if got := imageCacheFailureRetryDelay(1, errText); got != 7*24*time.Hour {
+			t.Fatalf("imageCacheFailureRetryDelay(%q) = %s, want 7d", errText, got)
+		}
+	}
+	if got := imageCacheFailureRetryDelay(1, "temporary network error"); got != time.Minute {
+		t.Fatalf("transient failure delay = %s, want 1m", got)
+	}
+}
+
 func TestNormalizeImageCacheJobInputSkipsNonProviderArtwork(t *testing.T) {
 	for _, sourcePath := range []string{
 		"",

--- a/internal/metadata/image_cache_job_repo_test.go
+++ b/internal/metadata/image_cache_job_repo_test.go
@@ -33,6 +33,25 @@ func TestImageCacheFailureRetryDelayDefersStableProviderFailures(t *testing.T) {
 	}
 }
 
+func TestImageCacheJobRediscoveryUsesNextAttemptAt(t *testing.T) {
+	body, err := os.ReadFile("image_cache_job_repo.go")
+	if err != nil {
+		t.Fatalf("read image_cache_job_repo.go: %v", err)
+	}
+	sql := string(body)
+	if strings.Contains(sql, "metadata_image_cache_jobs.updated_at < NOW()") || strings.Contains(sql, "j.updated_at < NOW()") {
+		t.Fatal("failed image cache job rediscovery must use next_attempt_at, not updated_at age")
+	}
+	for _, want := range []string{
+		"metadata_image_cache_jobs.next_attempt_at <= NOW()",
+		"j.next_attempt_at <= NOW()",
+	} {
+		if !strings.Contains(sql, want) {
+			t.Fatalf("image cache job rediscovery missing %q", want)
+		}
+	}
+}
+
 func TestNormalizeImageCacheJobInputSkipsNonProviderArtwork(t *testing.T) {
 	for _, sourcePath := range []string{
 		"",

--- a/internal/metadata/image_cache_processor.go
+++ b/internal/metadata/image_cache_processor.go
@@ -130,6 +130,8 @@ type ImageCacheRunStats struct {
 	Failed           int
 	Skipped          int
 	DeletedSucceeded int
+	UploadedVariants int
+	ExistingVariants int
 	RuntimeLimited   bool
 }
 
@@ -140,6 +142,8 @@ func (s *ImageCacheRunStats) add(other ImageCacheRunStats) {
 	s.Failed += other.Failed
 	s.Skipped += other.Skipped
 	s.DeletedSucceeded += other.DeletedSucceeded
+	s.UploadedVariants += other.UploadedVariants
+	s.ExistingVariants += other.ExistingVariants
 }
 
 // RunOnce claims and processes one batch of already-queued jobs. It does not
@@ -189,9 +193,9 @@ loop:
 		go func(job *models.MetadataImageCacheJob) {
 			defer wg.Done()
 			defer func() { <-sem }()
-			outcome := p.processOne(ctx, job)
+			result := p.processOne(ctx, job)
 			mu.Lock()
-			switch outcome {
+			switch result.outcome {
 			case "succeeded":
 				stats.Succeeded++
 			case "skipped":
@@ -199,6 +203,8 @@ loop:
 			default:
 				stats.Failed++
 			}
+			stats.UploadedVariants += result.uploadedVariants
+			stats.ExistingVariants += result.existingVariants
 			mu.Unlock()
 		}(job)
 	}
@@ -335,14 +341,20 @@ func (p *ImageCacheProcessor) markSucceeded(parent context.Context, job *models.
 	}
 }
 
-func (p *ImageCacheProcessor) processOne(ctx context.Context, job *models.MetadataImageCacheJob) string {
+type imageCacheProcessResult struct {
+	outcome          string
+	uploadedVariants int
+	existingVariants int
+}
+
+func (p *ImageCacheProcessor) processOne(ctx context.Context, job *models.MetadataImageCacheJob) imageCacheProcessResult {
 	if job == nil {
-		return "skipped"
+		return imageCacheProcessResult{outcome: "skipped"}
 	}
 	imageType, err := imageCacheJobImageType(job.ImageType)
 	if err != nil {
 		p.markFailed(ctx, job, err.Error())
-		return "failed"
+		return imageCacheProcessResult{outcome: "failed"}
 	}
 
 	// Confirm the target still references this job's source before uploading.
@@ -353,23 +365,23 @@ func (p *ImageCacheProcessor) processOne(ctx context.Context, job *models.Metada
 	current, err := p.jobs.CurrentTargetSourcePath(ctx, job)
 	if err != nil {
 		p.markFailed(ctx, job, err.Error())
-		return "failed"
+		return imageCacheProcessResult{outcome: "failed"}
 	}
 	if current != job.SourcePath {
 		p.markSucceeded(ctx, job)
-		return "skipped"
+		return imageCacheProcessResult{outcome: "skipped"}
 	}
 
 	downloadURL := job.SourcePath
 	if isProviderImagePath(downloadURL) {
 		if p.resolver == nil {
 			p.markFailed(ctx, job, "missing image resolver")
-			return "failed"
+			return imageCacheProcessResult{outcome: "failed"}
 		}
 		downloadURL = p.resolver.ResolveImageURL(ctx, job.SourcePath, "original")
 		if downloadURL == "" {
 			p.markFailed(ctx, job, "image resolver returned empty URL")
-			return "failed"
+			return imageCacheProcessResult{outcome: "failed"}
 		}
 	}
 
@@ -385,54 +397,65 @@ func (p *ImageCacheProcessor) processOne(ctx context.Context, job *models.Metada
 	})
 	if err != nil {
 		p.markFailed(ctx, job, err.Error())
-		return "failed"
+		return imageCacheProcessResult{outcome: "failed"}
 	}
 
 	if result == nil {
 		p.markFailed(ctx, job, "image cache returned no result")
-		return "failed"
+		return imageCacheProcessResult{outcome: "failed"}
+	}
+	processResult := imageCacheProcessResult{
+		uploadedVariants: result.UploadedVariants,
+		existingVariants: result.ExistingVariants,
 	}
 	cachedPath := cachedOriginalImagePath(result.BasePath, result.Ext)
 	if cachedPath == "" {
 		p.markFailed(ctx, job, "image cache returned empty stored path")
-		return "failed"
+		processResult.outcome = "failed"
+		return processResult
 	}
 	var updated bool
 	switch job.TargetType {
 	case ImageCacheTargetItem:
 		if p.targets.Items == nil {
 			p.markFailed(ctx, job, "missing item updater")
-			return "failed"
+			processResult.outcome = "failed"
+			return processResult
 		}
 		updated, err = p.targets.Items.UpdateArtworkIfSourceMatches(ctx, job.TargetContentID, job.ImageType, job.SourcePath, cachedPath, result.Thumbhash)
 	case ImageCacheTargetItemLocalization:
 		if p.targets.ItemLocalizations == nil {
 			p.markFailed(ctx, job, "missing item localization updater")
-			return "failed"
+			processResult.outcome = "failed"
+			return processResult
 		}
 		updated, err = p.targets.ItemLocalizations.UpdateArtworkIfSourceMatches(ctx, job.TargetContentID, job.TargetLanguage, job.ImageType, job.SourcePath, cachedPath, result.Thumbhash)
 	case ImageCacheTargetSeason:
 		if p.targets.Seasons == nil {
 			p.markFailed(ctx, job, "missing season updater")
-			return "failed"
+			processResult.outcome = "failed"
+			return processResult
 		}
 		updated, err = p.targets.Seasons.UpdateArtworkIfSourceMatches(ctx, job.TargetContentID, job.SourcePath, cachedPath, result.Thumbhash)
 	case ImageCacheTargetSeasonLocalization:
 		if p.targets.SeasonLocalizations == nil {
 			p.markFailed(ctx, job, "missing season localization updater")
-			return "failed"
+			processResult.outcome = "failed"
+			return processResult
 		}
 		updated, err = p.targets.SeasonLocalizations.UpdateArtworkIfSourceMatches(ctx, job.TargetContentID, job.TargetLanguage, job.SourcePath, cachedPath, result.Thumbhash)
 	case ImageCacheTargetEpisode:
 		if p.targets.Episodes == nil {
 			p.markFailed(ctx, job, "missing episode updater")
-			return "failed"
+			processResult.outcome = "failed"
+			return processResult
 		}
 		updated, err = p.targets.Episodes.UpdateStillIfSourceMatches(ctx, job.TargetContentID, job.SourcePath, cachedPath, result.Thumbhash)
 	case ImageCacheTargetPerson:
 		if p.targets.People == nil {
 			p.markFailed(ctx, job, "missing person updater")
-			return "failed"
+			processResult.outcome = "failed"
+			return processResult
 		}
 		personID, parseErr := strconv.ParseInt(job.TargetContentID, 10, 64)
 		if parseErr != nil {
@@ -445,14 +468,17 @@ func (p *ImageCacheProcessor) processOne(ctx context.Context, job *models.Metada
 	}
 	if err != nil {
 		p.markFailed(ctx, job, err.Error())
-		return "failed"
+		processResult.outcome = "failed"
+		return processResult
 	}
 	if !updated {
 		p.markSucceeded(ctx, job)
-		return "skipped"
+		processResult.outcome = "skipped"
+		return processResult
 	}
 	p.markSucceeded(ctx, job)
-	return "succeeded"
+	processResult.outcome = "succeeded"
+	return processResult
 }
 
 func imageCacheJobImageType(value string) (ImageType, error) {

--- a/internal/metadata/types.go
+++ b/internal/metadata/types.go
@@ -243,6 +243,9 @@ type CacheImageResult struct {
 	BasePath  string // S3 key prefix
 	Thumbhash string // base64-encoded
 	Ext       string // file extension including dot (e.g. ".jpg", ".png")
+
+	UploadedVariants int
+	ExistingVariants int
 }
 
 // ImageCacher caches a remote image to object storage.

--- a/internal/taskmanager/tasks/cache_metadata_images.go
+++ b/internal/taskmanager/tasks/cache_metadata_images.go
@@ -60,13 +60,15 @@ func (t *CacheMetadataImagesTask) Execute(ctx context.Context, progress taskmana
 		return fmt.Errorf("caching metadata images: %w", err)
 	}
 	message := fmt.Sprintf(
-		"Batches %d, enqueued %d existing, claimed %d, cached %d, failed %d, skipped %d, deleted %d old successes",
+		"Batches %d, enqueued %d existing, claimed %d, cached %d, failed %d, skipped %d, uploaded %d variants, found %d existing variants, deleted %d old successes",
 		stats.Batches,
 		stats.EnqueuedExisting,
 		stats.Claimed,
 		stats.Succeeded,
 		stats.Failed,
 		stats.Skipped,
+		stats.UploadedVariants,
+		stats.ExistingVariants,
 		stats.DeletedSucceeded,
 	)
 	if stats.RuntimeLimited {

--- a/internal/taskmanager/tasks/cache_metadata_images_test.go
+++ b/internal/taskmanager/tasks/cache_metadata_images_test.go
@@ -56,6 +56,8 @@ func TestCacheMetadataImagesTaskReportsStats(t *testing.T) {
 			Claimed:          4,
 			Succeeded:        3,
 			Failed:           1,
+			UploadedVariants: 7,
+			ExistingVariants: 2,
 		},
 	}
 	task := NewCacheMetadataImagesTask(runner)
@@ -72,7 +74,7 @@ func TestCacheMetadataImagesTaskReportsStats(t *testing.T) {
 	if runner.maxRuntime != 10*time.Minute {
 		t.Fatalf("maxRuntime = %s, want 10m", runner.maxRuntime)
 	}
-	if progress.message != "Batches 3, enqueued 5 existing, claimed 4, cached 3, failed 1, skipped 0, deleted 0 old successes" {
+	if progress.message != "Batches 3, enqueued 5 existing, claimed 4, cached 3, failed 1, skipped 0, uploaded 7 variants, found 2 existing variants, deleted 0 old successes" {
 		t.Fatalf("progress message = %q", progress.message)
 	}
 }


### PR DESCRIPTION
## Summary
- skip uploading metadata image variants that already exist in object storage and report uploaded/existing counts
- normalize provider artwork through libvips so SVG logos and unusual JPEGs can cache successfully
- allow larger provider originals to download while capping cached original.webp dimensions below oversized source dimensions
- requeue stale succeeded cache jobs during discovery when live artwork still points at provider URLs
- defer stable provider failures (403/404/410/418) for a 7-day retry cooldown instead of hot-looping

## Verification
- GOWORK=off GOCACHE=/private/tmp/silo-go-build GOMODCACHE=/private/tmp/silo-go-mod go test ./internal/imagecache ./internal/imageutil ./internal/metadata ./internal/taskmanager/tasks

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Image caching now reports how many variants were uploaded versus already present.
  * Progress updates include the new variant counts during metadata image caching.

* **Bug Fixes**
  * Improved handling for larger images and SVGs during caching.
  * Cached preview hashes are now generated more consistently across image types.
  * Failed image-cache jobs are retried more intelligently, with longer delays for stable provider errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->