### PR TITLE
Add ACL access management

### DIFF
--- a/.superpowers/sdd/task-5-report.md
+++ b/.superpowers/sdd/task-5-report.md
@@ -48,3 +48,57 @@
 
 ## Any issues or concerns
 - None. The implementation is small and matches the task brief closely.
+
+---
+
+# Task 5 Review Fix Follow-Up
+
+## What I fixed
+- Short-circuited `ACLAuthorizer` for nil or disabled users immediately after `GetByID`, so repository rule loading is skipped and disabled users deny cleanly without depending on ACL storage.
+- Expanded the facade test coverage to prove repository rules are included, not just legacy compatibility rules.
+- Added an `Explain` test that verifies allowed decisions and returned evaluated rules.
+
+## What I tested and test results
+- Focused ACL authorizer test set:
+  - Command: `GOWORK=off GOCACHE=/private/tmp/silo-go-build GOMODCACHE=/private/tmp/silo-go-mod go test ./internal/auth -run 'TestACLAuthorizer'`
+  - Result: PASS
+- Full auth package:
+  - Command: `GOWORK=off GOCACHE=/private/tmp/silo-go-build GOMODCACHE=/private/tmp/silo-go-mod go test ./internal/auth`
+  - Result: PASS
+
+## TDD Evidence
+### RED
+- Command: `GOWORK=off GOCACHE=/private/tmp/silo-go-build GOMODCACHE=/private/tmp/silo-go-mod go test ./internal/auth -run 'TestACLAuthorizer'`
+- Output:
+  ```text
+  --- FAIL: TestACLAuthorizerDisabledUserShortCircuitsBeforeRuleLoad (0.00s)
+      acl_authorizer_test.go:81: authorize error: context canceled
+  FAIL
+  FAIL	github.com/Silo-Server/silo-server/internal/auth	0.418s
+  FAIL
+  ```
+- Why expected: the disabled-user test intentionally made the rule loader error if it was called, proving the current implementation still loaded rules for disabled users.
+
+### GREEN
+- Command: `GOWORK=off GOCACHE=/private/tmp/silo-go-build GOMODCACHE=/private/tmp/silo-go-mod go test ./internal/auth -run 'TestACLAuthorizer'`
+- Output:
+  ```text
+  ok  	github.com/Silo-Server/silo-server/internal/auth	0.300s
+  ```
+- Full-package confirmation:
+  ```text
+  ok  	github.com/Silo-Server/silo-server/internal/auth	0.299s
+  ```
+
+## Files changed
+- `/Users/jimcole/projects/personal/silo/core/silo-server/internal/auth/acl_authorizer.go`
+- `/Users/jimcole/projects/personal/silo/core/silo-server/internal/auth/acl_authorizer_test.go`
+- `/Users/jimcole/projects/personal/silo/core/silo-server/.superpowers/sdd/task-5-report.md`
+
+## Self-review findings
+- The disabled-user path now exits before any ACL repository call, which removes the coupling the reviewer flagged.
+- `Explain` uses the same loaded inputs as `Authorize`, so the rule set and effective policy stay consistent between both entry points.
+- The tests now cover the repository rule path, the disabled-user short circuit, and the explain surface.
+
+## Any issues or concerns
+- None.

--- a/.superpowers/sdd/task-5-report.md
+++ b/.superpowers/sdd/task-5-report.md
@@ -1,0 +1,50 @@
+# Task 5 Report: Authorizer Facade for Future Middleware
+
+## What I implemented
+- Added `internal/auth/acl_authorizer.go` with the new `Authorizer` interface, `UserLoaderForACL`, `ACLRuleLoader`, and `ACLAuthorizer`.
+- Wired `NewACLAuthorizer` to load the user, repository rules, compatibility rules, and compatibility effective policy, then delegate authorization and explanation to `ACLEvaluator`.
+- Added `internal/auth/acl_authorizer_test.go` with a focused facade test proving repository rules and legacy compatibility data are combined correctly.
+
+## What I tested and test results
+- Focused facade test:
+  - Command: `GOWORK=off GOCACHE=/private/tmp/silo-go-build GOMODCACHE=/private/tmp/silo-go-mod go test ./internal/auth -run 'TestACLAuthorizer'`
+  - Result: PASS
+- Full auth package:
+  - Command: `GOWORK=off GOCACHE=/private/tmp/silo-go-build GOMODCACHE=/private/tmp/silo-go-mod go test ./internal/auth`
+  - Result: PASS
+
+## TDD Evidence
+### RED
+- Command: `GOWORK=off GOCACHE=/private/tmp/silo-go-build GOMODCACHE=/private/tmp/silo-go-mod go test ./internal/auth -run 'TestACLAuthorizer'`
+- Output:
+  ```text
+  # github.com/Silo-Server/silo-server/internal/auth [github.com/Silo-Server/silo-server/internal/auth.test]
+  internal/auth/acl_authorizer_test.go:34:16: undefined: NewACLAuthorizer
+  FAIL	github.com/Silo-Server/silo-server/internal/auth [build failed]
+  FAIL
+  ```
+- Why expected: the test referenced the new facade before it existed, so the package should fail to compile.
+
+### GREEN
+- Command: `GOWORK=off GOCACHE=/private/tmp/silo-go-build GOMODCACHE=/private/tmp/silo-go-mod go test ./internal/auth -run 'TestACLAuthorizer'`
+- Output:
+  ```text
+  ok  	github.com/Silo-Server/silo-server/internal/auth	0.520s
+  ```
+- Follow-up full-package check:
+  ```text
+  ok  	github.com/Silo-Server/silo-server/internal/auth	0.408s
+  ```
+
+## Files changed
+- `/Users/jimcole/projects/personal/silo/core/silo-server/internal/auth/acl_authorizer.go`
+- `/Users/jimcole/projects/personal/silo/core/silo-server/internal/auth/acl_authorizer_test.go`
+- `/Users/jimcole/projects/personal/silo/core/silo-server/.superpowers/sdd/task-5-report.md`
+
+## Self-review findings
+- The facade matches the brief’s interfaces and delegates all policy evaluation to the existing `ACLEvaluator`.
+- Compatibility rules and compatibility effective policy are loaded from the user record exactly once per request.
+- The focused test covers the intended combined behavior; the broader auth package test confirms no regression in neighboring auth code.
+
+## Any issues or concerns
+- None. The implementation is small and matches the task brief closely.

--- a/docs/superpowers/plans/2026-06-29-security-acl-foundation.md
+++ b/docs/superpowers/plans/2026-06-29-security-acl-foundation.md
@@ -99,7 +99,7 @@ func TestBuiltInGroupSlugsAreStable(t *testing.T) {
 Run:
 
 ```bash
-GOWORK=off GOCACHE=/private/tmp/silo-go-build GOMODCACHE=/private/tmp/silo-go-mod go test ./internal/auth -run 'TestACLActionConstantsCoverLegacyPermissions|TestBuiltInGroupSlugsAreStable'
+GOWORK=off GOCACHE=${SILO_GO_BUILD_CACHE:-.cache/go-build} GOMODCACHE=${SILO_GO_MOD_CACHE:-.cache/go-mod} go test ./internal/auth -run 'TestACLActionConstantsCoverLegacyPermissions|TestBuiltInGroupSlugsAreStable'
 ```
 
 Expected: FAIL with undefined identifiers such as `LegacyPermissionAction`, `ActionMarkersEdit`, and `GroupOwner`.
@@ -272,7 +272,7 @@ type EffectivePolicy struct {
 Run:
 
 ```bash
-GOWORK=off GOCACHE=/private/tmp/silo-go-build GOMODCACHE=/private/tmp/silo-go-mod go test ./internal/auth -run 'TestACLActionConstantsCoverLegacyPermissions|TestBuiltInGroupSlugsAreStable'
+GOWORK=off GOCACHE=${SILO_GO_BUILD_CACHE:-.cache/go-build} GOMODCACHE=${SILO_GO_MOD_CACHE:-.cache/go-mod} go test ./internal/auth -run 'TestACLActionConstantsCoverLegacyPermissions|TestBuiltInGroupSlugsAreStable'
 ```
 
 Expected: PASS.
@@ -387,7 +387,7 @@ func TestCompatibilityEffectivePolicyPreservesUserLimits(t *testing.T) {
 Run:
 
 ```bash
-GOWORK=off GOCACHE=/private/tmp/silo-go-build GOMODCACHE=/private/tmp/silo-go-mod go test ./internal/auth -run 'TestCompatibility'
+GOWORK=off GOCACHE=${SILO_GO_BUILD_CACHE:-.cache/go-build} GOMODCACHE=${SILO_GO_MOD_CACHE:-.cache/go-mod} go test ./internal/auth -run 'TestCompatibility'
 ```
 
 Expected: FAIL with undefined compatibility functions.
@@ -503,7 +503,7 @@ func CompatibilityEffectivePolicyForUser(user *models.User) EffectivePolicy {
 Run:
 
 ```bash
-GOWORK=off GOCACHE=/private/tmp/silo-go-build GOMODCACHE=/private/tmp/silo-go-mod go test ./internal/auth -run 'TestCompatibility'
+GOWORK=off GOCACHE=${SILO_GO_BUILD_CACHE:-.cache/go-build} GOMODCACHE=${SILO_GO_MOD_CACHE:-.cache/go-mod} go test ./internal/auth -run 'TestCompatibility'
 ```
 
 Expected: PASS.
@@ -609,7 +609,7 @@ func TestACLEvaluatorExplainIncludesMatchedRules(t *testing.T) {
 Run:
 
 ```bash
-GOWORK=off GOCACHE=/private/tmp/silo-go-build GOMODCACHE=/private/tmp/silo-go-mod go test ./internal/auth -run 'TestACLEvaluator'
+GOWORK=off GOCACHE=${SILO_GO_BUILD_CACHE:-.cache/go-build} GOMODCACHE=${SILO_GO_MOD_CACHE:-.cache/go-mod} go test ./internal/auth -run 'TestACLEvaluator'
 ```
 
 Expected: FAIL with undefined `NewACLEvaluator`.
@@ -777,7 +777,7 @@ func ruleRank(rule ACLRule) int {
 Run:
 
 ```bash
-GOWORK=off GOCACHE=/private/tmp/silo-go-build GOMODCACHE=/private/tmp/silo-go-mod go test ./internal/auth -run 'TestACLEvaluator'
+GOWORK=off GOCACHE=${SILO_GO_BUILD_CACHE:-.cache/go-build} GOMODCACHE=${SILO_GO_MOD_CACHE:-.cache/go-mod} go test ./internal/auth -run 'TestACLEvaluator'
 ```
 
 Expected: PASS.
@@ -852,7 +852,7 @@ func TestScanACLRuleFields(t *testing.T) {
 Run:
 
 ```bash
-GOWORK=off GOCACHE=/private/tmp/silo-go-build GOMODCACHE=/private/tmp/silo-go-mod go test ./internal/auth -run 'TestScanACLRuleFields'
+GOWORK=off GOCACHE=${SILO_GO_BUILD_CACHE:-.cache/go-build} GOMODCACHE=${SILO_GO_MOD_CACHE:-.cache/go-mod} go test ./internal/auth -run 'TestScanACLRuleFields'
 ```
 
 Expected: FAIL with undefined `aclRuleRow`.
@@ -1087,7 +1087,7 @@ func (r *ACLRepository) CurrentPolicyRevision(ctx context.Context) (int64, error
 Run:
 
 ```bash
-GOWORK=off GOCACHE=/private/tmp/silo-go-build GOMODCACHE=/private/tmp/silo-go-mod go test ./internal/auth -run 'TestScanACLRuleFields'
+GOWORK=off GOCACHE=${SILO_GO_BUILD_CACHE:-.cache/go-build} GOMODCACHE=${SILO_GO_MOD_CACHE:-.cache/go-mod} go test ./internal/auth -run 'TestScanACLRuleFields'
 ```
 
 Expected: PASS.
@@ -1097,7 +1097,7 @@ Expected: PASS.
 Run:
 
 ```bash
-GOWORK=off GOCACHE=/private/tmp/silo-go-build GOMODCACHE=/private/tmp/silo-go-mod go test ./internal/auth
+GOWORK=off GOCACHE=${SILO_GO_BUILD_CACHE:-.cache/go-build} GOMODCACHE=${SILO_GO_MOD_CACHE:-.cache/go-mod} go test ./internal/auth
 ```
 
 Expected: PASS.
@@ -1184,7 +1184,7 @@ func TestACLAuthorizerCombinesRepositoryAndCompatibilityRules(t *testing.T) {
 Run:
 
 ```bash
-GOWORK=off GOCACHE=/private/tmp/silo-go-build GOMODCACHE=/private/tmp/silo-go-mod go test ./internal/auth -run 'TestACLAuthorizer'
+GOWORK=off GOCACHE=${SILO_GO_BUILD_CACHE:-.cache/go-build} GOMODCACHE=${SILO_GO_MOD_CACHE:-.cache/go-mod} go test ./internal/auth -run 'TestACLAuthorizer'
 ```
 
 Expected: FAIL with undefined `NewACLAuthorizer`.
@@ -1270,7 +1270,7 @@ func (a *ACLAuthorizer) loadInputs(ctx context.Context, userID int) (*models.Use
 Run:
 
 ```bash
-GOWORK=off GOCACHE=/private/tmp/silo-go-build GOMODCACHE=/private/tmp/silo-go-mod go test ./internal/auth -run 'TestACLAuthorizer'
+GOWORK=off GOCACHE=${SILO_GO_BUILD_CACHE:-.cache/go-build} GOMODCACHE=${SILO_GO_MOD_CACHE:-.cache/go-mod} go test ./internal/auth -run 'TestACLAuthorizer'
 ```
 
 Expected: PASS.
@@ -1280,7 +1280,7 @@ Expected: PASS.
 Run:
 
 ```bash
-GOWORK=off GOCACHE=/private/tmp/silo-go-build GOMODCACHE=/private/tmp/silo-go-mod go test ./internal/auth
+GOWORK=off GOCACHE=${SILO_GO_BUILD_CACHE:-.cache/go-build} GOMODCACHE=${SILO_GO_MOD_CACHE:-.cache/go-mod} go test ./internal/auth
 ```
 
 Expected: PASS.
@@ -1320,7 +1320,7 @@ The first implementation pass adds the ACL data model, constants, evaluator, com
 Run:
 
 ```bash
-GOWORK=off GOCACHE=/private/tmp/silo-go-build GOMODCACHE=/private/tmp/silo-go-mod go test ./internal/auth
+GOWORK=off GOCACHE=${SILO_GO_BUILD_CACHE:-.cache/go-build} GOMODCACHE=${SILO_GO_MOD_CACHE:-.cache/go-mod} go test ./internal/auth
 ```
 
 Expected: PASS.
@@ -1330,7 +1330,7 @@ Expected: PASS.
 Run:
 
 ```bash
-GOWORK=off GOCACHE=/private/tmp/silo-go-build GOMODCACHE=/private/tmp/silo-go-mod go test ./internal/api/middleware
+GOWORK=off GOCACHE=${SILO_GO_BUILD_CACHE:-.cache/go-build} GOMODCACHE=${SILO_GO_MOD_CACHE:-.cache/go-mod} go test ./internal/api/middleware
 ```
 
 Expected: PASS.
@@ -1340,7 +1340,7 @@ Expected: PASS.
 Run:
 
 ```bash
-GOWORK=off GOCACHE=/private/tmp/silo-go-build GOMODCACHE=/private/tmp/silo-go-mod go test ./internal/auth ./internal/api/middleware ./internal/api/handlers
+GOWORK=off GOCACHE=${SILO_GO_BUILD_CACHE:-.cache/go-build} GOMODCACHE=${SILO_GO_MOD_CACHE:-.cache/go-mod} go test ./internal/auth ./internal/api/middleware ./internal/api/handlers
 ```
 
 Expected: PASS.

--- a/docs/superpowers/plans/2026-06-29-security-acl-foundation.md
+++ b/docs/superpowers/plans/2026-06-29-security-acl-foundation.md
@@ -1123,7 +1123,7 @@ git commit -m "Add ACL persistence foundation"
 - Consumes: `CompatibilityRulesForUser`
 - Consumes: `CompatibilityEffectivePolicyForUser`
 - Produces: `type Authorizer interface`
-- Produces: `func NewACLAuthorizer(repository *ACLRepository, users UserLoaderForACL) *ACLAuthorizer`
+- Produces: `func NewACLAuthorizer(rules ACLRuleLoader, users UserLoaderForACL) *ACLAuthorizer`
 - Produces: `func (a *ACLAuthorizer) Authorize(ctx context.Context, request AccessRequest) (AccessDecision, error)`
 - Produces: `func (a *ACLAuthorizer) Explain(ctx context.Context, request AccessRequest) (AccessExplanation, error)`
 

--- a/docs/superpowers/plans/2026-06-29-security-acl-foundation.md
+++ b/docs/superpowers/plans/2026-06-29-security-acl-foundation.md
@@ -1,0 +1,1376 @@
+# Security ACL Foundation Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add the behavior-preserving ACL foundation for Silo's future tiered/customizable security model.
+
+**Architecture:** Introduce a central ACL model and evaluator in `internal/auth` without changing existing API route behavior. Seed durable ACL tables and compatibility mappings so current `admin`, `user`, `marker_edit`, `metadata_curation`, library, playback, and download policy inputs can be resolved through the new engine.
+
+**Tech Stack:** Go, PostgreSQL, goose SQL migrations, pgx, existing Silo auth/user models, `go test`.
+
+## Global Constraints
+
+- Preserve current behavior in the first rollout.
+- Existing admins remain admins.
+- Existing users keep their library restrictions, playback limits, download settings, and current feature permissions.
+- Built-in roles are seeded as default groups, not special cases spread across the codebase.
+- API code should move toward action/resource authorization instead of role-string checks.
+- Access decisions must be explainable.
+- Conditions must be structured data, not free-form expressions.
+- Disabled users are always denied.
+- Existing `marker_edit` maps to `markers.edit`.
+- Existing `metadata_curation` maps to `metadata.curate`.
+- The first migration promotes the oldest enabled admin account to Owner and every other enabled admin to Admin.
+- Do not remove or repurpose legacy `users.role`, `users.permissions`, `users.library_ids`, playback/download/profile limit columns, or `users.access_policy_revision` in this phase.
+
+---
+
+## File Structure
+
+- Create `internal/auth/acl_actions.go`: action constants, resource constants, effect constants, and built-in group slugs.
+- Create `internal/auth/acl_types.go`: request, rule, condition, decision, explanation, and effective policy structs.
+- Create `internal/auth/acl_evaluator.go`: pure in-memory evaluator for deny/allow precedence, condition matching, and explanation output.
+- Create `internal/auth/acl_compat.go`: compatibility adapter from existing `models.User` fields and legacy permissions into seeded group/rule inputs.
+- Create `internal/auth/acl_repository.go`: repository methods for reading groups, memberships, rules, and policy revision.
+- Create `internal/auth/acl_*_test.go`: unit tests for constants, compatibility mapping, evaluator precedence, limits, and explanations.
+- Add migration `migrations/sql/20260629193000_acl_foundation.sql`: ACL groups, memberships, rules, policy revision table, and safe seed data.
+- No frontend files in this foundation plan.
+- No route middleware conversion in this foundation plan.
+
+---
+
+### Task 1: Action, Resource, and Type Definitions
+
+**Files:**
+- Create: `internal/auth/acl_actions.go`
+- Create: `internal/auth/acl_types.go`
+- Test: `internal/auth/acl_actions_test.go`
+
+**Interfaces:**
+- Produces: `type ACLAction string`
+- Produces: `type ACLResourceType string`
+- Produces: `type ACLEffect string`
+- Produces: `type ACLSubjectType string`
+- Produces: constants such as `ActionUsersManage`, `ActionPlaybackPlay`, `ResourceLibrary`, `EffectAllow`, `SubjectGroup`
+- Produces: `type AccessRequest struct`
+- Produces: `type ACLRule struct`
+- Produces: `type ACLCondition struct`
+- Produces: `type AccessDecision struct`
+- Produces: `type AccessExplanation struct`
+- Produces: `type EffectivePolicy struct`
+
+- [ ] **Step 1: Write failing constant coverage tests**
+
+Create `internal/auth/acl_actions_test.go`:
+
+```go
+package auth
+
+import "testing"
+
+func TestACLActionConstantsCoverLegacyPermissions(t *testing.T) {
+	if LegacyPermissionAction(PermissionMarkerEdit) != ActionMarkersEdit {
+		t.Fatalf("marker_edit maps to %q, want %q", LegacyPermissionAction(PermissionMarkerEdit), ActionMarkersEdit)
+	}
+	if LegacyPermissionAction(PermissionMetadataCuration) != ActionMetadataCurate {
+		t.Fatalf("metadata_curation maps to %q, want %q", LegacyPermissionAction(PermissionMetadataCuration), ActionMetadataCurate)
+	}
+}
+
+func TestBuiltInGroupSlugsAreStable(t *testing.T) {
+	tests := map[string]BuiltInGroupSlug{
+		"owner":            GroupOwner,
+		"admin":            GroupAdmin,
+		"library_manager":  GroupLibraryManager,
+		"metadata_curator": GroupMetadataCurator,
+		"viewer":           GroupViewer,
+		"restricted_viewer": GroupRestrictedViewer,
+	}
+	for want, got := range tests {
+		if string(got) != want {
+			t.Fatalf("group slug = %q, want %q", got, want)
+		}
+	}
+}
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run:
+
+```bash
+GOWORK=off GOCACHE=/private/tmp/silo-go-build GOMODCACHE=/private/tmp/silo-go-mod go test ./internal/auth -run 'TestACLActionConstantsCoverLegacyPermissions|TestBuiltInGroupSlugsAreStable'
+```
+
+Expected: FAIL with undefined identifiers such as `LegacyPermissionAction`, `ActionMarkersEdit`, and `GroupOwner`.
+
+- [ ] **Step 3: Add action/resource constants**
+
+Create `internal/auth/acl_actions.go`:
+
+```go
+package auth
+
+type ACLAction string
+type ACLResourceType string
+type ACLEffect string
+type ACLSubjectType string
+type BuiltInGroupSlug string
+
+const (
+	EffectAllow ACLEffect = "allow"
+	EffectDeny  ACLEffect = "deny"
+)
+
+const (
+	SubjectUser        ACLSubjectType = "user"
+	SubjectGroup       ACLSubjectType = "group"
+	SubjectBuiltInRole ACLSubjectType = "builtin_role"
+	SubjectEveryone    ACLSubjectType = "everyone"
+)
+
+const (
+	GroupOwner            BuiltInGroupSlug = "owner"
+	GroupAdmin            BuiltInGroupSlug = "admin"
+	GroupLibraryManager   BuiltInGroupSlug = "library_manager"
+	GroupMetadataCurator  BuiltInGroupSlug = "metadata_curator"
+	GroupViewer           BuiltInGroupSlug = "viewer"
+	GroupRestrictedViewer BuiltInGroupSlug = "restricted_viewer"
+)
+
+const (
+	ActionServerView         ACLAction = "server.view"
+	ActionServerConfigure    ACLAction = "server.configure"
+	ActionSecurityManage     ACLAction = "security.manage"
+	ActionUsersView          ACLAction = "users.view"
+	ActionUsersManage        ACLAction = "users.manage"
+	ActionUsersImpersonate   ACLAction = "users.impersonate"
+	ActionLibrariesView      ACLAction = "libraries.view"
+	ActionLibrariesManage    ACLAction = "libraries.manage"
+	ActionTasksView          ACLAction = "tasks.view"
+	ActionTasksRun           ACLAction = "tasks.run"
+	ActionLogsView           ACLAction = "logs.view"
+	ActionPluginsView        ACLAction = "plugins.view"
+	ActionPluginsManage      ACLAction = "plugins.manage"
+	ActionNodesView          ACLAction = "nodes.view"
+	ActionNodesManage        ACLAction = "nodes.manage"
+	ActionMetadataCurate     ACLAction = "metadata.curate"
+	ActionMarkersEdit        ACLAction = "markers.edit"
+	ActionPlaybackPlay       ACLAction = "playback.play"
+	ActionPlaybackTranscode  ACLAction = "playback.transcode"
+	ActionDownloadsDirect    ACLAction = "downloads.direct"
+	ActionDownloadsTranscode ACLAction = "downloads.transcode"
+	ActionProfilesManage     ACLAction = "profiles.manage"
+	ActionRequestsCreate     ACLAction = "requests.create"
+	ActionRequestsApprove    ACLAction = "requests.approve"
+)
+
+const (
+	ResourceServer           ACLResourceType = "server"
+	ResourceSecuritySettings ACLResourceType = "security_settings"
+	ResourceUser             ACLResourceType = "user"
+	ResourceGroup            ACLResourceType = "group"
+	ResourceLibrary          ACLResourceType = "library"
+	ResourceMediaItem        ACLResourceType = "media_item"
+	ResourceMediaType        ACLResourceType = "media_type"
+	ResourceTask             ACLResourceType = "task"
+	ResourceLog              ACLResourceType = "log"
+	ResourcePlugin           ACLResourceType = "plugin"
+	ResourceRemoteNode       ACLResourceType = "remote_node"
+	ResourceProfile          ACLResourceType = "profile"
+	ResourceRequest          ACLResourceType = "request"
+)
+
+func LegacyPermissionAction(permission Permission) ACLAction {
+	switch permission {
+	case PermissionMarkerEdit:
+		return ActionMarkersEdit
+	case PermissionMetadataCuration:
+		return ActionMetadataCurate
+	default:
+		return ""
+	}
+}
+```
+
+- [ ] **Step 4: Add ACL request/decision types**
+
+Create `internal/auth/acl_types.go`:
+
+```go
+package auth
+
+import "time"
+
+type AccessRequest struct {
+	UserID       int
+	Action       ACLAction
+	ResourceType ACLResourceType
+	ResourceID   string
+	LibraryIDs   []int
+	MediaType    string
+	ProfileID    string
+	PrimaryProfile bool
+}
+
+type ACLRule struct {
+	ID          int64
+	SubjectType ACLSubjectType
+	SubjectID   string
+	Action      ACLAction
+	ResourceType ACLResourceType
+	ResourceID   string
+	Effect      ACLEffect
+	Conditions  ACLCondition
+	Priority    int
+	Name        string
+	Description string
+	CreatedAt   time.Time
+	UpdatedAt   time.Time
+}
+
+type ACLCondition struct {
+	LibraryIDs                 []int
+	MediaTypes                 []string
+	PrimaryProfileRequired     *bool
+	MaxPlaybackQuality         string
+	MaxStreams                 *int
+	MaxTranscodes              *int
+	DirectDownloadsAllowed     *bool
+	TranscodedDownloadsAllowed *bool
+	MaxContentRating           string
+}
+
+type AccessDecision struct {
+	Allowed         bool
+	ReasonCode      string
+	WinningRule     *ACLRule
+	MatchedRules    []ACLRule
+	EffectivePolicy EffectivePolicy
+}
+
+type AccessExplanation struct {
+	Request      AccessRequest
+	Decision     AccessDecision
+	EvaluatedRules []ACLRule
+}
+
+type EffectivePolicy struct {
+	LibraryIDs                 []int
+	MediaTypes                 []string
+	MaxPlaybackQuality         string
+	MaxStreams                 int
+	MaxTranscodes              int
+	DirectDownloadsAllowed     bool
+	TranscodedDownloadsAllowed bool
+	MaxContentRating           string
+}
+```
+
+- [ ] **Step 5: Run tests to verify they pass**
+
+Run:
+
+```bash
+GOWORK=off GOCACHE=/private/tmp/silo-go-build GOMODCACHE=/private/tmp/silo-go-mod go test ./internal/auth -run 'TestACLActionConstantsCoverLegacyPermissions|TestBuiltInGroupSlugsAreStable'
+```
+
+Expected: PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add internal/auth/acl_actions.go internal/auth/acl_types.go internal/auth/acl_actions_test.go
+git commit -m "Add ACL action and resource types"
+```
+
+---
+
+### Task 2: Behavior-Preserving Compatibility Mapping
+
+**Files:**
+- Create: `internal/auth/acl_compat.go`
+- Test: `internal/auth/acl_compat_test.go`
+
+**Interfaces:**
+- Consumes: `models.User`
+- Consumes: action/group constants from Task 1
+- Produces: `func CompatibilityGroupsForUser(user *models.User) []BuiltInGroupSlug`
+- Produces: `func CompatibilityRulesForUser(user *models.User) []ACLRule`
+- Produces: `func CompatibilityEffectivePolicyForUser(user *models.User) EffectivePolicy`
+
+- [ ] **Step 1: Write failing compatibility tests**
+
+Create `internal/auth/acl_compat_test.go`:
+
+```go
+package auth
+
+import (
+	"testing"
+
+	"github.com/Silo-Server/silo-server/internal/models"
+)
+
+func TestCompatibilityGroupsForAdminAndUser(t *testing.T) {
+	adminGroups := CompatibilityGroupsForUser(&models.User{ID: 1, Role: "admin", Enabled: true})
+	if len(adminGroups) != 1 || adminGroups[0] != GroupAdmin {
+		t.Fatalf("admin groups = %#v, want [%q]", adminGroups, GroupAdmin)
+	}
+
+	userGroups := CompatibilityGroupsForUser(&models.User{ID: 2, Role: "user", Enabled: true})
+	if len(userGroups) != 1 || userGroups[0] != GroupViewer {
+		t.Fatalf("user groups = %#v, want [%q]", userGroups, GroupViewer)
+	}
+}
+
+func TestCompatibilityRulesForLegacyPermissions(t *testing.T) {
+	user := &models.User{
+		ID:          7,
+		Role:        "user",
+		Enabled:     true,
+		Permissions: []string{"marker_edit", "metadata_curation"},
+	}
+
+	rules := CompatibilityRulesForUser(user)
+	actions := map[ACLAction]bool{}
+	for _, rule := range rules {
+		if rule.Effect == EffectAllow {
+			actions[rule.Action] = true
+		}
+	}
+
+	if !actions[ActionMarkersEdit] {
+		t.Fatalf("expected marker_edit compatibility rule, got %#v", rules)
+	}
+	if !actions[ActionMetadataCurate] {
+		t.Fatalf("expected metadata_curation compatibility rule, got %#v", rules)
+	}
+}
+
+func TestCompatibilityEffectivePolicyPreservesUserLimits(t *testing.T) {
+	user := &models.User{
+		ID:                       7,
+		Enabled:                  true,
+		LibraryIDs:               []int{10, 20},
+		MaxPlaybackQuality:       "1080p",
+		MaxStreams:               3,
+		MaxTranscodes:            1,
+		DownloadAllowed:          true,
+		DownloadTranscodeAllowed: false,
+	}
+
+	policy := CompatibilityEffectivePolicyForUser(user)
+	if len(policy.LibraryIDs) != 2 || policy.LibraryIDs[0] != 10 || policy.LibraryIDs[1] != 20 {
+		t.Fatalf("library ids = %#v, want [10 20]", policy.LibraryIDs)
+	}
+	if policy.MaxPlaybackQuality != "1080p" {
+		t.Fatalf("max quality = %q, want 1080p", policy.MaxPlaybackQuality)
+	}
+	if policy.MaxStreams != 3 {
+		t.Fatalf("max streams = %d, want 3", policy.MaxStreams)
+	}
+	if policy.MaxTranscodes != 1 {
+		t.Fatalf("max transcodes = %d, want 1", policy.MaxTranscodes)
+	}
+	if !policy.DirectDownloadsAllowed {
+		t.Fatalf("direct downloads should be allowed")
+	}
+	if policy.TranscodedDownloadsAllowed {
+		t.Fatalf("transcoded downloads should not be allowed")
+	}
+}
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run:
+
+```bash
+GOWORK=off GOCACHE=/private/tmp/silo-go-build GOMODCACHE=/private/tmp/silo-go-mod go test ./internal/auth -run 'TestCompatibility'
+```
+
+Expected: FAIL with undefined compatibility functions.
+
+- [ ] **Step 3: Implement compatibility mapping**
+
+Create `internal/auth/acl_compat.go`:
+
+```go
+package auth
+
+import (
+	"fmt"
+
+	"github.com/Silo-Server/silo-server/internal/models"
+)
+
+func CompatibilityGroupsForUser(user *models.User) []BuiltInGroupSlug {
+	if user == nil || !user.Enabled {
+		return []BuiltInGroupSlug{}
+	}
+	if user.Role == "admin" {
+		return []BuiltInGroupSlug{GroupAdmin}
+	}
+	return []BuiltInGroupSlug{GroupViewer}
+}
+
+func CompatibilityRulesForUser(user *models.User) []ACLRule {
+	if user == nil || !user.Enabled {
+		return []ACLRule{}
+	}
+
+	rules := make([]ACLRule, 0, len(user.Permissions)+4)
+	subjectID := fmt.Sprintf("%d", user.ID)
+
+	for _, permission := range user.Permissions {
+		action := LegacyPermissionAction(Permission(permission))
+		if action == "" {
+			continue
+		}
+		rules = append(rules, ACLRule{
+			SubjectType:  SubjectUser,
+			SubjectID:    subjectID,
+			Action:       action,
+			ResourceType: ResourceServer,
+			ResourceID:   "*",
+			Effect:       EffectAllow,
+			Priority:     1000,
+			Name:         "legacy permission " + permission,
+		})
+	}
+
+	if user.Role == "admin" {
+		for _, action := range []ACLAction{
+			ActionServerView,
+			ActionServerConfigure,
+			ActionSecurityManage,
+			ActionUsersView,
+			ActionUsersManage,
+			ActionUsersImpersonate,
+			ActionLibrariesView,
+			ActionLibrariesManage,
+			ActionTasksView,
+			ActionTasksRun,
+			ActionLogsView,
+			ActionPluginsView,
+			ActionPluginsManage,
+			ActionNodesView,
+			ActionNodesManage,
+			ActionMetadataCurate,
+			ActionMarkersEdit,
+			ActionPlaybackPlay,
+			ActionPlaybackTranscode,
+			ActionDownloadsDirect,
+			ActionDownloadsTranscode,
+			ActionProfilesManage,
+			ActionRequestsCreate,
+			ActionRequestsApprove,
+		} {
+			rules = append(rules, ACLRule{
+				SubjectType:  SubjectBuiltInRole,
+				SubjectID:    string(GroupAdmin),
+				Action:       action,
+				ResourceType: ResourceServer,
+				ResourceID:   "*",
+				Effect:       EffectAllow,
+				Priority:     100,
+				Name:         "legacy admin grant",
+			})
+		}
+	}
+
+	return rules
+}
+
+func CompatibilityEffectivePolicyForUser(user *models.User) EffectivePolicy {
+	if user == nil || !user.Enabled {
+		return EffectivePolicy{}
+	}
+	return EffectivePolicy{
+		LibraryIDs:                 append([]int(nil), user.LibraryIDs...),
+		MaxPlaybackQuality:         user.MaxPlaybackQuality,
+		MaxStreams:                 user.MaxStreams,
+		MaxTranscodes:              user.MaxTranscodes,
+		DirectDownloadsAllowed:     user.DownloadAllowed,
+		TranscodedDownloadsAllowed: user.DownloadTranscodeAllowed,
+	}
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run:
+
+```bash
+GOWORK=off GOCACHE=/private/tmp/silo-go-build GOMODCACHE=/private/tmp/silo-go-mod go test ./internal/auth -run 'TestCompatibility'
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add internal/auth/acl_compat.go internal/auth/acl_compat_test.go
+git commit -m "Map legacy users into ACL compatibility policy"
+```
+
+---
+
+### Task 3: ACL Evaluator and Explain Decisions
+
+**Files:**
+- Create: `internal/auth/acl_evaluator.go`
+- Test: `internal/auth/acl_evaluator_test.go`
+
+**Interfaces:**
+- Consumes: `AccessRequest`, `ACLRule`, `EffectivePolicy`
+- Produces: `type ACLEvaluator struct{}`
+- Produces: `func NewACLEvaluator() *ACLEvaluator`
+- Produces: `func (e *ACLEvaluator) Authorize(request AccessRequest, rules []ACLRule, basePolicy EffectivePolicy, userEnabled bool) AccessDecision`
+- Produces: `func (e *ACLEvaluator) Explain(request AccessRequest, rules []ACLRule, basePolicy EffectivePolicy, userEnabled bool) AccessExplanation`
+
+- [ ] **Step 1: Write failing evaluator tests**
+
+Create `internal/auth/acl_evaluator_test.go`:
+
+```go
+package auth
+
+import "testing"
+
+func TestACLEvaluatorDisabledUserDenied(t *testing.T) {
+	evaluator := NewACLEvaluator()
+	decision := evaluator.Authorize(AccessRequest{Action: ActionPlaybackPlay, ResourceType: ResourceLibrary, ResourceID: "1"}, nil, EffectivePolicy{}, false)
+	if decision.Allowed {
+		t.Fatalf("disabled user should be denied")
+	}
+	if decision.ReasonCode != "user_disabled" {
+		t.Fatalf("reason = %q, want user_disabled", decision.ReasonCode)
+	}
+}
+
+func TestACLEvaluatorUserDenyBeatsUserAllow(t *testing.T) {
+	evaluator := NewACLEvaluator()
+	request := AccessRequest{UserID: 7, Action: ActionDownloadsDirect, ResourceType: ResourceLibrary, ResourceID: "10"}
+	rules := []ACLRule{
+		{ID: 1, SubjectType: SubjectUser, SubjectID: "7", Action: ActionDownloadsDirect, ResourceType: ResourceLibrary, ResourceID: "10", Effect: EffectAllow, Priority: 10, Name: "allow direct downloads"},
+		{ID: 2, SubjectType: SubjectUser, SubjectID: "7", Action: ActionDownloadsDirect, ResourceType: ResourceLibrary, ResourceID: "10", Effect: EffectDeny, Priority: 10, Name: "deny direct downloads"},
+	}
+
+	decision := evaluator.Authorize(request, rules, EffectivePolicy{}, true)
+	if decision.Allowed {
+		t.Fatalf("user deny should win over user allow")
+	}
+	if decision.WinningRule == nil || decision.WinningRule.ID != 2 {
+		t.Fatalf("winning rule = %#v, want rule 2", decision.WinningRule)
+	}
+}
+
+func TestACLEvaluatorUserAllowBeatsGroupDeny(t *testing.T) {
+	evaluator := NewACLEvaluator()
+	request := AccessRequest{UserID: 7, Action: ActionMetadataCurate, ResourceType: ResourceLibrary, ResourceID: "10"}
+	rules := []ACLRule{
+		{ID: 1, SubjectType: SubjectGroup, SubjectID: "curators", Action: ActionMetadataCurate, ResourceType: ResourceLibrary, ResourceID: "10", Effect: EffectDeny, Priority: 10, Name: "group deny"},
+		{ID: 2, SubjectType: SubjectUser, SubjectID: "7", Action: ActionMetadataCurate, ResourceType: ResourceLibrary, ResourceID: "10", Effect: EffectAllow, Priority: 10, Name: "user override"},
+	}
+
+	decision := evaluator.Authorize(request, rules, EffectivePolicy{}, true)
+	if !decision.Allowed {
+		t.Fatalf("user allow should beat group deny: %#v", decision)
+	}
+	if decision.WinningRule == nil || decision.WinningRule.ID != 2 {
+		t.Fatalf("winning rule = %#v, want rule 2", decision.WinningRule)
+	}
+}
+
+func TestACLEvaluatorExplainIncludesMatchedRules(t *testing.T) {
+	evaluator := NewACLEvaluator()
+	request := AccessRequest{UserID: 7, Action: ActionPlaybackPlay, ResourceType: ResourceLibrary, ResourceID: "10"}
+	rules := []ACLRule{
+		{ID: 1, SubjectType: SubjectGroup, SubjectID: "viewer", Action: ActionPlaybackPlay, ResourceType: ResourceLibrary, ResourceID: "10", Effect: EffectAllow, Priority: 10, Name: "viewer playback"},
+	}
+
+	explanation := evaluator.Explain(request, rules, EffectivePolicy{MaxStreams: 2}, true)
+	if !explanation.Decision.Allowed {
+		t.Fatalf("expected allowed decision: %#v", explanation.Decision)
+	}
+	if len(explanation.Decision.MatchedRules) != 1 {
+		t.Fatalf("matched rules = %#v, want one rule", explanation.Decision.MatchedRules)
+	}
+	if explanation.Decision.EffectivePolicy.MaxStreams != 2 {
+		t.Fatalf("effective max streams = %d, want 2", explanation.Decision.EffectivePolicy.MaxStreams)
+	}
+}
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run:
+
+```bash
+GOWORK=off GOCACHE=/private/tmp/silo-go-build GOMODCACHE=/private/tmp/silo-go-mod go test ./internal/auth -run 'TestACLEvaluator'
+```
+
+Expected: FAIL with undefined `NewACLEvaluator`.
+
+- [ ] **Step 3: Implement evaluator**
+
+Create `internal/auth/acl_evaluator.go`:
+
+```go
+package auth
+
+import (
+	"fmt"
+	"sort"
+)
+
+type ACLEvaluator struct{}
+
+func NewACLEvaluator() *ACLEvaluator {
+	return &ACLEvaluator{}
+}
+
+func (e *ACLEvaluator) Authorize(request AccessRequest, rules []ACLRule, basePolicy EffectivePolicy, userEnabled bool) AccessDecision {
+	if !userEnabled {
+		return AccessDecision{Allowed: false, ReasonCode: "user_disabled", EffectivePolicy: basePolicy}
+	}
+
+	matched := matchingRules(request, rules)
+	sortMatchedRules(matched)
+	if len(matched) == 0 {
+		return AccessDecision{Allowed: false, ReasonCode: "default_deny", MatchedRules: matched, EffectivePolicy: basePolicy}
+	}
+
+	winning := matched[0]
+	allowed := winning.Effect == EffectAllow
+	reason := "rule_allow"
+	if !allowed {
+		reason = "rule_deny"
+	}
+	return AccessDecision{
+		Allowed:         allowed,
+		ReasonCode:      reason,
+		WinningRule:     &winning,
+		MatchedRules:    matched,
+		EffectivePolicy: basePolicy,
+	}
+}
+
+func (e *ACLEvaluator) Explain(request AccessRequest, rules []ACLRule, basePolicy EffectivePolicy, userEnabled bool) AccessExplanation {
+	decision := e.Authorize(request, rules, basePolicy, userEnabled)
+	return AccessExplanation{
+		Request:        request,
+		Decision:       decision,
+		EvaluatedRules: append([]ACLRule(nil), rules...),
+	}
+}
+
+func matchingRules(request AccessRequest, rules []ACLRule) []ACLRule {
+	out := make([]ACLRule, 0, len(rules))
+	for _, rule := range rules {
+		if rule.Action != request.Action {
+			continue
+		}
+		if !resourceMatches(request, rule) {
+			continue
+		}
+		if !conditionsMatch(request, rule.Conditions) {
+			continue
+		}
+		out = append(out, rule)
+	}
+	return out
+}
+
+func resourceMatches(request AccessRequest, rule ACLRule) bool {
+	if rule.ResourceType != request.ResourceType && rule.ResourceType != ResourceServer {
+		return false
+	}
+	if rule.ResourceID == "" || rule.ResourceID == "*" {
+		return true
+	}
+	if request.ResourceID == "" {
+		return false
+	}
+	return rule.ResourceID == request.ResourceID
+}
+
+func conditionsMatch(request AccessRequest, conditions ACLCondition) bool {
+	if len(conditions.LibraryIDs) > 0 {
+		ok := false
+		for _, allowed := range conditions.LibraryIDs {
+			for _, requested := range request.LibraryIDs {
+				if allowed == requested {
+					ok = true
+					break
+				}
+			}
+			if ok {
+				break
+			}
+		}
+		if !ok {
+			return false
+		}
+	}
+
+	if len(conditions.MediaTypes) > 0 {
+		ok := false
+		for _, mediaType := range conditions.MediaTypes {
+			if mediaType == request.MediaType {
+				ok = true
+				break
+			}
+		}
+		if !ok {
+			return false
+		}
+	}
+
+	if conditions.PrimaryProfileRequired != nil && *conditions.PrimaryProfileRequired != request.PrimaryProfile {
+		return false
+	}
+
+	return true
+}
+
+func sortMatchedRules(rules []ACLRule) {
+	sort.SliceStable(rules, func(i, j int) bool {
+		left := ruleRank(rules[i])
+		right := ruleRank(rules[j])
+		if left != right {
+			return left < right
+		}
+		if rules[i].Priority != rules[j].Priority {
+			return rules[i].Priority > rules[j].Priority
+		}
+		return rules[i].ID < rules[j].ID
+	})
+}
+
+func ruleRank(rule ACLRule) int {
+	switch {
+	case rule.SubjectType == SubjectBuiltInRole && rule.SubjectID == string(GroupOwner) && rule.Effect == EffectAllow:
+		return 0
+	case rule.SubjectType == SubjectUser && rule.Effect == EffectDeny:
+		return 1
+	case rule.SubjectType == SubjectUser && rule.Effect == EffectAllow:
+		return 2
+	case rule.SubjectType == SubjectGroup && rule.Effect == EffectDeny:
+		return 3
+	case rule.SubjectType == SubjectGroup && rule.Effect == EffectAllow:
+		return 4
+	case rule.Effect == EffectDeny:
+		return 5
+	case rule.Effect == EffectAllow:
+		return 6
+	default:
+		panic(fmt.Sprintf("unknown ACL effect %q", rule.Effect))
+	}
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run:
+
+```bash
+GOWORK=off GOCACHE=/private/tmp/silo-go-build GOMODCACHE=/private/tmp/silo-go-mod go test ./internal/auth -run 'TestACLEvaluator'
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add internal/auth/acl_evaluator.go internal/auth/acl_evaluator_test.go
+git commit -m "Add ACL evaluator"
+```
+
+---
+
+### Task 4: ACL Database Foundation
+
+**Files:**
+- Create: `migrations/sql/20260629193000_acl_foundation.sql`
+- Create: `internal/auth/acl_repository.go`
+- Test: `internal/auth/acl_repository_test.go`
+
+**Interfaces:**
+- Consumes: `ACLRule`, constants from Task 1
+- Produces: `type ACLRepository struct`
+- Produces: `func NewACLRepository(db *pgxpool.Pool) *ACLRepository`
+- Produces: `func (r *ACLRepository) ListRulesForUser(ctx context.Context, userID int) ([]ACLRule, error)`
+- Produces: `func (r *ACLRepository) CurrentPolicyRevision(ctx context.Context) (int64, error)`
+
+- [ ] **Step 1: Add repository unit test for SQL row scanning**
+
+Create `internal/auth/acl_repository_test.go`:
+
+```go
+package auth
+
+import "testing"
+
+func TestScanACLRuleFields(t *testing.T) {
+	row := aclRuleRow{
+		ID:           42,
+		SubjectType:  "group",
+		SubjectID:    "viewer",
+		Action:       "playback.play",
+		ResourceType: "library",
+		ResourceID:   "10",
+		Effect:       "allow",
+		Priority:     5,
+		Name:         "viewer playback",
+		Description:  "allows library playback",
+	}
+
+	rule := row.toRule()
+	if rule.ID != 42 {
+		t.Fatalf("id = %d, want 42", rule.ID)
+	}
+	if rule.SubjectType != SubjectGroup {
+		t.Fatalf("subject type = %q, want %q", rule.SubjectType, SubjectGroup)
+	}
+	if rule.Action != ActionPlaybackPlay {
+		t.Fatalf("action = %q, want %q", rule.Action, ActionPlaybackPlay)
+	}
+	if rule.ResourceType != ResourceLibrary {
+		t.Fatalf("resource type = %q, want %q", rule.ResourceType, ResourceLibrary)
+	}
+	if rule.Effect != EffectAllow {
+		t.Fatalf("effect = %q, want %q", rule.Effect, EffectAllow)
+	}
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run:
+
+```bash
+GOWORK=off GOCACHE=/private/tmp/silo-go-build GOMODCACHE=/private/tmp/silo-go-mod go test ./internal/auth -run 'TestScanACLRuleFields'
+```
+
+Expected: FAIL with undefined `aclRuleRow`.
+
+- [ ] **Step 3: Add ACL migration**
+
+Create `migrations/sql/20260629193000_acl_foundation.sql`:
+
+```sql
+-- +goose Up
+-- +goose StatementBegin
+CREATE TABLE IF NOT EXISTS public.acl_groups (
+    id bigserial PRIMARY KEY,
+    slug text NOT NULL UNIQUE,
+    name text NOT NULL,
+    description text NOT NULL DEFAULT '',
+    built_in boolean NOT NULL DEFAULT false,
+    protected boolean NOT NULL DEFAULT false,
+    created_at timestamptz NOT NULL DEFAULT now(),
+    updated_at timestamptz NOT NULL DEFAULT now()
+);
+
+CREATE TABLE IF NOT EXISTS public.acl_group_members (
+    group_id bigint NOT NULL REFERENCES public.acl_groups(id) ON DELETE CASCADE,
+    user_id integer NOT NULL REFERENCES public.users(id) ON DELETE CASCADE,
+    created_at timestamptz NOT NULL DEFAULT now(),
+    PRIMARY KEY (group_id, user_id)
+);
+
+CREATE TABLE IF NOT EXISTS public.acl_rules (
+    id bigserial PRIMARY KEY,
+    subject_type text NOT NULL,
+    subject_id text NOT NULL,
+    action text NOT NULL,
+    resource_type text NOT NULL,
+    resource_id text NOT NULL DEFAULT '*',
+    effect text NOT NULL,
+    conditions jsonb NOT NULL DEFAULT '{}'::jsonb,
+    priority integer NOT NULL DEFAULT 0,
+    name text NOT NULL DEFAULT '',
+    description text NOT NULL DEFAULT '',
+    created_at timestamptz NOT NULL DEFAULT now(),
+    updated_at timestamptz NOT NULL DEFAULT now(),
+    CONSTRAINT acl_rules_effect_check CHECK (effect IN ('allow', 'deny')),
+    CONSTRAINT acl_rules_subject_type_check CHECK (subject_type IN ('user', 'group', 'builtin_role', 'everyone'))
+);
+
+CREATE INDEX IF NOT EXISTS acl_group_members_user_idx ON public.acl_group_members(user_id);
+CREATE INDEX IF NOT EXISTS acl_rules_subject_idx ON public.acl_rules(subject_type, subject_id);
+CREATE INDEX IF NOT EXISTS acl_rules_action_resource_idx ON public.acl_rules(action, resource_type, resource_id);
+
+CREATE TABLE IF NOT EXISTS public.acl_policy_revisions (
+    id boolean PRIMARY KEY DEFAULT true,
+    revision bigint NOT NULL DEFAULT 1,
+    updated_at timestamptz NOT NULL DEFAULT now(),
+    CONSTRAINT acl_policy_revisions_singleton CHECK (id)
+);
+
+INSERT INTO public.acl_policy_revisions (id, revision)
+VALUES (true, 1)
+ON CONFLICT (id) DO NOTHING;
+
+INSERT INTO public.acl_groups (slug, name, description, built_in, protected)
+VALUES
+    ('owner', 'Owner', 'Full server ownership and security control.', true, true),
+    ('admin', 'Admin', 'Broad operational administration.', true, true),
+    ('library_manager', 'Library Manager', 'Library and scan management.', true, false),
+    ('metadata_curator', 'Metadata Curator', 'Metadata, poster, marker, and provider curation.', true, false),
+    ('viewer', 'Viewer', 'Normal media playback access.', true, false),
+    ('restricted_viewer', 'Restricted Viewer', 'Playback access with tighter limits.', true, false)
+ON CONFLICT (slug) DO UPDATE
+SET name = EXCLUDED.name,
+    description = EXCLUDED.description,
+    built_in = EXCLUDED.built_in,
+    protected = EXCLUDED.protected,
+    updated_at = now();
+
+WITH oldest_admin AS (
+    SELECT id
+    FROM public.users
+    WHERE enabled = true AND role = 'admin'
+    ORDER BY created_at ASC, id ASC
+    LIMIT 1
+),
+owner_group AS (
+    SELECT id FROM public.acl_groups WHERE slug = 'owner'
+),
+admin_group AS (
+    SELECT id FROM public.acl_groups WHERE slug = 'admin'
+),
+viewer_group AS (
+    SELECT id FROM public.acl_groups WHERE slug = 'viewer'
+)
+INSERT INTO public.acl_group_members (group_id, user_id)
+SELECT owner_group.id, oldest_admin.id
+FROM owner_group, oldest_admin
+ON CONFLICT DO NOTHING;
+
+WITH oldest_admin AS (
+    SELECT id
+    FROM public.users
+    WHERE enabled = true AND role = 'admin'
+    ORDER BY created_at ASC, id ASC
+    LIMIT 1
+),
+admin_group AS (
+    SELECT id FROM public.acl_groups WHERE slug = 'admin'
+)
+INSERT INTO public.acl_group_members (group_id, user_id)
+SELECT admin_group.id, users.id
+FROM public.users, admin_group
+WHERE users.enabled = true
+  AND users.role = 'admin'
+  AND users.id NOT IN (SELECT id FROM oldest_admin)
+ON CONFLICT DO NOTHING;
+
+WITH viewer_group AS (
+    SELECT id FROM public.acl_groups WHERE slug = 'viewer'
+)
+INSERT INTO public.acl_group_members (group_id, user_id)
+SELECT viewer_group.id, users.id
+FROM public.users, viewer_group
+WHERE users.enabled = true
+  AND COALESCE(users.role, 'user') <> 'admin'
+ON CONFLICT DO NOTHING;
+-- +goose StatementEnd
+
+-- +goose Down
+-- +goose StatementBegin
+DROP TABLE IF EXISTS public.acl_policy_revisions;
+DROP TABLE IF EXISTS public.acl_rules;
+DROP TABLE IF EXISTS public.acl_group_members;
+DROP TABLE IF EXISTS public.acl_groups;
+-- +goose StatementEnd
+```
+
+- [ ] **Step 4: Add repository scanner and methods**
+
+Create `internal/auth/acl_repository.go`:
+
+```go
+package auth
+
+import (
+	"context"
+	"encoding/json"
+
+	"github.com/jackc/pgx/v5/pgxpool"
+)
+
+type ACLRepository struct {
+	db *pgxpool.Pool
+}
+
+func NewACLRepository(db *pgxpool.Pool) *ACLRepository {
+	return &ACLRepository{db: db}
+}
+
+type aclRuleRow struct {
+	ID           int64
+	SubjectType  string
+	SubjectID    string
+	Action       string
+	ResourceType string
+	ResourceID   string
+	Effect       string
+	Conditions   []byte
+	Priority     int
+	Name         string
+	Description  string
+}
+
+func (row aclRuleRow) toRule() ACLRule {
+	var conditions ACLCondition
+	if len(row.Conditions) > 0 {
+		_ = json.Unmarshal(row.Conditions, &conditions)
+	}
+	return ACLRule{
+		ID:           row.ID,
+		SubjectType:  ACLSubjectType(row.SubjectType),
+		SubjectID:    row.SubjectID,
+		Action:       ACLAction(row.Action),
+		ResourceType: ACLResourceType(row.ResourceType),
+		ResourceID:   row.ResourceID,
+		Effect:       ACLEffect(row.Effect),
+		Conditions:   conditions,
+		Priority:     row.Priority,
+		Name:         row.Name,
+		Description:  row.Description,
+	}
+}
+
+func (r *ACLRepository) ListRulesForUser(ctx context.Context, userID int) ([]ACLRule, error) {
+	rows, err := r.db.Query(ctx, `
+		SELECT id, subject_type, subject_id, action, resource_type, resource_id, effect, conditions, priority, name, description
+		FROM public.acl_rules
+		WHERE (subject_type = 'user' AND subject_id = $1::text)
+		   OR (subject_type = 'group' AND subject_id IN (
+		       SELECT g.slug
+		       FROM public.acl_groups g
+		       JOIN public.acl_group_members gm ON gm.group_id = g.id
+		       WHERE gm.user_id = $2
+		   ))
+		   OR subject_type = 'everyone'
+		ORDER BY priority DESC, id ASC
+	`, userID, userID)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	rules := []ACLRule{}
+	for rows.Next() {
+		var row aclRuleRow
+		if err := rows.Scan(&row.ID, &row.SubjectType, &row.SubjectID, &row.Action, &row.ResourceType, &row.ResourceID, &row.Effect, &row.Conditions, &row.Priority, &row.Name, &row.Description); err != nil {
+			return nil, err
+		}
+		rules = append(rules, row.toRule())
+	}
+	return rules, rows.Err()
+}
+
+func (r *ACLRepository) CurrentPolicyRevision(ctx context.Context) (int64, error) {
+	var revision int64
+	err := r.db.QueryRow(ctx, `SELECT revision FROM public.acl_policy_revisions WHERE id = true`).Scan(&revision)
+	return revision, err
+}
+```
+
+- [ ] **Step 5: Run repository tests**
+
+Run:
+
+```bash
+GOWORK=off GOCACHE=/private/tmp/silo-go-build GOMODCACHE=/private/tmp/silo-go-mod go test ./internal/auth -run 'TestScanACLRuleFields'
+```
+
+Expected: PASS.
+
+- [ ] **Step 6: Run full auth tests**
+
+Run:
+
+```bash
+GOWORK=off GOCACHE=/private/tmp/silo-go-build GOMODCACHE=/private/tmp/silo-go-mod go test ./internal/auth
+```
+
+Expected: PASS.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add migrations/sql/20260629193000_acl_foundation.sql internal/auth/acl_repository.go internal/auth/acl_repository_test.go
+git commit -m "Add ACL persistence foundation"
+```
+
+---
+
+### Task 5: Authorizer Facade for Future Middleware
+
+**Files:**
+- Create: `internal/auth/acl_authorizer.go`
+- Test: `internal/auth/acl_authorizer_test.go`
+
+**Interfaces:**
+- Consumes: `ACLRepository`
+- Consumes: `ACLEvaluator`
+- Consumes: `CompatibilityRulesForUser`
+- Consumes: `CompatibilityEffectivePolicyForUser`
+- Produces: `type Authorizer interface`
+- Produces: `func NewACLAuthorizer(repository *ACLRepository, users UserLoaderForACL) *ACLAuthorizer`
+- Produces: `func (a *ACLAuthorizer) Authorize(ctx context.Context, request AccessRequest) (AccessDecision, error)`
+- Produces: `func (a *ACLAuthorizer) Explain(ctx context.Context, request AccessRequest) (AccessExplanation, error)`
+
+- [ ] **Step 1: Write failing facade test with fakes**
+
+Create `internal/auth/acl_authorizer_test.go`:
+
+```go
+package auth
+
+import (
+	"context"
+	"testing"
+
+	"github.com/Silo-Server/silo-server/internal/models"
+)
+
+type fakeACLUserLoader struct {
+	user *models.User
+}
+
+func (f fakeACLUserLoader) GetByID(ctx context.Context, id int) (*models.User, error) {
+	return f.user, nil
+}
+
+type fakeACLRuleLoader struct {
+	rules []ACLRule
+}
+
+func (f fakeACLRuleLoader) ListRulesForUser(ctx context.Context, userID int) ([]ACLRule, error) {
+	return f.rules, nil
+}
+
+func TestACLAuthorizerCombinesRepositoryAndCompatibilityRules(t *testing.T) {
+	user := &models.User{ID: 7, Role: "user", Enabled: true, Permissions: []string{"marker_edit"}, MaxStreams: 2}
+	ruleLoader := fakeACLRuleLoader{
+		rules: []ACLRule{
+			{ID: 99, SubjectType: SubjectGroup, SubjectID: "viewer", Action: ActionPlaybackPlay, ResourceType: ResourceLibrary, ResourceID: "10", Effect: EffectAllow, Priority: 1, Name: "viewer playback"},
+		},
+	}
+
+	authorizer := NewACLAuthorizer(ruleLoader, fakeACLUserLoader{user: user})
+	decision, err := authorizer.Authorize(context.Background(), AccessRequest{UserID: 7, Action: ActionMarkersEdit, ResourceType: ResourceServer, ResourceID: "*"})
+	if err != nil {
+		t.Fatalf("authorize error: %v", err)
+	}
+	if !decision.Allowed {
+		t.Fatalf("legacy marker_edit should allow markers.edit: %#v", decision)
+	}
+	if decision.EffectivePolicy.MaxStreams != 2 {
+		t.Fatalf("effective max streams = %d, want 2", decision.EffectivePolicy.MaxStreams)
+	}
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run:
+
+```bash
+GOWORK=off GOCACHE=/private/tmp/silo-go-build GOMODCACHE=/private/tmp/silo-go-mod go test ./internal/auth -run 'TestACLAuthorizer'
+```
+
+Expected: FAIL with undefined `NewACLAuthorizer`.
+
+- [ ] **Step 3: Implement authorizer facade**
+
+Create `internal/auth/acl_authorizer.go`:
+
+```go
+package auth
+
+import (
+	"context"
+
+	"github.com/Silo-Server/silo-server/internal/models"
+)
+
+type Authorizer interface {
+	Authorize(ctx context.Context, request AccessRequest) (AccessDecision, error)
+	Explain(ctx context.Context, request AccessRequest) (AccessExplanation, error)
+}
+
+type UserLoaderForACL interface {
+	GetByID(ctx context.Context, id int) (*models.User, error)
+}
+
+type ACLRuleLoader interface {
+	ListRulesForUser(ctx context.Context, userID int) ([]ACLRule, error)
+}
+
+type ACLAuthorizer struct {
+	rules     ACLRuleLoader
+	users     UserLoaderForACL
+	evaluator *ACLEvaluator
+}
+
+func NewACLAuthorizer(rules ACLRuleLoader, users UserLoaderForACL) *ACLAuthorizer {
+	return &ACLAuthorizer{
+		rules:     rules,
+		users:     users,
+		evaluator: NewACLEvaluator(),
+	}
+}
+
+func (a *ACLAuthorizer) Authorize(ctx context.Context, request AccessRequest) (AccessDecision, error) {
+	user, rules, policy, err := a.loadInputs(ctx, request.UserID)
+	if err != nil {
+		return AccessDecision{}, err
+	}
+	return a.evaluator.Authorize(request, rules, policy, user != nil && user.Enabled), nil
+}
+
+func (a *ACLAuthorizer) Explain(ctx context.Context, request AccessRequest) (AccessExplanation, error) {
+	user, rules, policy, err := a.loadInputs(ctx, request.UserID)
+	if err != nil {
+		return AccessExplanation{}, err
+	}
+	return a.evaluator.Explain(request, rules, policy, user != nil && user.Enabled), nil
+}
+
+func (a *ACLAuthorizer) loadInputs(ctx context.Context, userID int) (*models.User, []ACLRule, EffectivePolicy, error) {
+	user, err := a.users.GetByID(ctx, userID)
+	if err != nil {
+		return nil, nil, EffectivePolicy{}, err
+	}
+
+	rules := []ACLRule{}
+	if a.rules != nil {
+		repositoryRules, err := a.rules.ListRulesForUser(ctx, userID)
+		if err != nil {
+			return nil, nil, EffectivePolicy{}, err
+		}
+		rules = append(rules, repositoryRules...)
+	}
+	rules = append(rules, CompatibilityRulesForUser(user)...)
+
+	return user, rules, CompatibilityEffectivePolicyForUser(user), nil
+}
+```
+
+- [ ] **Step 4: Run facade tests**
+
+Run:
+
+```bash
+GOWORK=off GOCACHE=/private/tmp/silo-go-build GOMODCACHE=/private/tmp/silo-go-mod go test ./internal/auth -run 'TestACLAuthorizer'
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Run full auth tests**
+
+Run:
+
+```bash
+GOWORK=off GOCACHE=/private/tmp/silo-go-build GOMODCACHE=/private/tmp/silo-go-mod go test ./internal/auth
+```
+
+Expected: PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add internal/auth/acl_authorizer.go internal/auth/acl_authorizer_test.go
+git commit -m "Add ACL authorizer facade"
+```
+
+---
+
+### Task 6: Foundation Verification and Documentation Update
+
+**Files:**
+- Modify: `docs/superpowers/specs/2026-06-29-security-acl-design.md`
+- Test: full auth and middleware package tests
+
+**Interfaces:**
+- Consumes: all previous tasks
+- Produces: verified foundation branch ready for route-conversion planning
+
+- [ ] **Step 1: Add implementation note to spec**
+
+Append this section to `docs/superpowers/specs/2026-06-29-security-acl-design.md`:
+
+```markdown
+
+## Foundation Implementation Notes
+
+The first implementation pass adds the ACL data model, constants, evaluator, compatibility mapping, repository, and authorizer facade without converting existing route middleware. Current behavior remains controlled by the legacy role and permission paths until route-specific ACL checks are introduced in later PRs.
+```
+
+- [ ] **Step 2: Run auth package tests**
+
+Run:
+
+```bash
+GOWORK=off GOCACHE=/private/tmp/silo-go-build GOMODCACHE=/private/tmp/silo-go-mod go test ./internal/auth
+```
+
+Expected: PASS.
+
+- [ ] **Step 3: Run middleware package tests**
+
+Run:
+
+```bash
+GOWORK=off GOCACHE=/private/tmp/silo-go-build GOMODCACHE=/private/tmp/silo-go-mod go test ./internal/api/middleware
+```
+
+Expected: PASS.
+
+- [ ] **Step 4: Run migration-aware package compile check**
+
+Run:
+
+```bash
+GOWORK=off GOCACHE=/private/tmp/silo-go-build GOMODCACHE=/private/tmp/silo-go-mod go test ./internal/auth ./internal/api/middleware ./internal/api/handlers
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit verification note**
+
+```bash
+git add docs/superpowers/specs/2026-06-29-security-acl-design.md
+git commit -m "Document ACL foundation rollout boundary"
+```
+
+---
+
+## Self-Review
+
+Spec coverage:
+
+- Full ACL internally: covered by Tasks 1, 3, 4, and 5.
+- Group-oriented compatibility: covered by Tasks 2 and 4.
+- Behavior-preserving rollout: covered by Tasks 2, 5, and 6.
+- Explain access: covered by Task 3 and Task 5.
+- Data model: covered by Task 4.
+- Session/cache invalidation table foundation: covered by Task 4 through `acl_policy_revisions`.
+- UI: intentionally deferred because the foundation plan has no route behavior or frontend behavior changes.
+- Route conversion: intentionally deferred to the next implementation plan after this foundation is merged.
+
+Completion scan:
+
+- The plan gives exact file paths, test names, commands, expected outputs, and code for each implementation step.
+
+Type consistency:
+
+- `ACLAction`, `ACLResourceType`, `ACLEffect`, `ACLSubjectType`, `BuiltInGroupSlug`, `AccessRequest`, `ACLRule`, `ACLCondition`, `AccessDecision`, `AccessExplanation`, and `EffectivePolicy` are introduced in Task 1 and reused consistently by Tasks 2 through 6.

--- a/docs/superpowers/specs/2026-06-29-security-acl-design.md
+++ b/docs/superpowers/specs/2026-06-29-security-acl-design.md
@@ -1,0 +1,318 @@
+# Security ACL Design
+
+Date: 2026-06-29
+
+## Goal
+
+Replace Silo's current binary `user` / `admin` authorization model with a full access-control-list policy engine that can support tiered security, customizable groups, media access rules, playback restrictions, and explainable access decisions.
+
+The first implementation must preserve current behavior while introducing the engine and migration path. Later phases can expose richer group and rule management in the admin UI.
+
+## Current State
+
+Silo currently stores a `role` string and a `permissions` string array on each user. Most privileged routes check whether the authenticated claim role equals `admin`. A small feature-permission layer exists for `marker_edit` and `metadata_curation`; admins implicitly receive those permissions, while normal users need them assigned.
+
+The user model already includes several policy-oriented fields:
+
+- assigned library IDs
+- maximum playback quality
+- access policy revision
+- maximum streams
+- maximum transcodes
+- maximum profiles
+- direct download permission
+- assigned permissions
+
+Those fields should be treated as existing policy inputs during migration rather than discarded.
+
+## Design Principles
+
+The backend policy engine should be more flexible than the initial UI. The UI should begin with understandable presets and group editors, while the engine stores and evaluates ACL rules.
+
+Authorization must become action-based rather than role-string-based. API code should ask whether an actor can perform a specific action against a specific resource, not whether the actor is an admin.
+
+Access decisions must be explainable. Admins need to know which rule allowed or denied a request, especially once users can belong to multiple groups.
+
+The first production rollout must be behavior-preserving. Existing admins remain admins. Existing users keep their library restrictions, playback limits, download settings, and current feature permissions.
+
+## Core Model
+
+An actor is a user, plus the groups they belong to, plus any direct user-level overrides.
+
+A policy rule has:
+
+- subject: user, group, built-in role, or everyone
+- action: what is being attempted
+- resource: what the action targets
+- effect: allow or deny
+- conditions: optional constraints that refine when the rule applies
+- priority: deterministic ordering when multiple rules match at the same specificity
+- metadata: name, description, created_by, updated_at, and audit fields
+
+Groups are named collections of ACL rules. Built-in roles are seeded as default groups, not special cases spread across the codebase.
+
+## Built-In Groups
+
+Initial seeded groups should include:
+
+- Owner: full control over server, security, users, settings, libraries, tasks, plugins, media access, playback, downloads, and diagnostics.
+- Admin: broad operational control, but owner-only actions remain reserved for the owner group.
+- Library Manager: manage libraries, scans, media organization, and library-scoped tasks.
+- Metadata Curator: edit metadata, posters, markers, and provider matches for allowed libraries.
+- Viewer: play allowed media under normal playback policy.
+- Restricted Viewer: play allowed media with tighter default playback and download limits.
+
+These groups are seed data. Admins can later create custom groups and can eventually edit most seeded group memberships, while owner-only safety rules remain protected.
+
+## Actions
+
+The initial action set should cover existing behavior and obvious near-term needs:
+
+- `server.view`
+- `server.configure`
+- `security.manage`
+- `users.view`
+- `users.manage`
+- `users.impersonate`
+- `libraries.view`
+- `libraries.manage`
+- `tasks.view`
+- `tasks.run`
+- `logs.view`
+- `plugins.view`
+- `plugins.manage`
+- `nodes.view`
+- `nodes.manage`
+- `metadata.curate`
+- `markers.edit`
+- `playback.play`
+- `playback.transcode`
+- `downloads.direct`
+- `downloads.transcode`
+- `profiles.manage`
+- `requests.create`
+- `requests.approve`
+
+Existing `marker_edit` maps to `markers.edit`. Existing `metadata_curation` maps to `metadata.curate`.
+
+## Resources
+
+The first resource model should include:
+
+- server
+- security settings
+- users
+- groups
+- libraries
+- media item
+- media type: movie, series, episode, audiobook, ebook, music
+- tasks
+- logs
+- plugins
+- remote nodes
+- profiles
+- requests
+
+Resource matching should support hierarchy. For example, a rule on a library applies to items in that library. A rule on `media_type:movie` applies to movie items across allowed libraries unless narrowed by another resource scope.
+
+## Conditions
+
+Conditions should be represented as structured JSON with typed evaluation helpers, not as free-form expressions. The initial condition set should support:
+
+- allowed library IDs
+- media types
+- profile context, including primary profile behavior
+- maximum playback quality
+- maximum concurrent streams
+- maximum concurrent transcodes
+- direct downloads allowed
+- transcoded downloads allowed
+- content rating limits
+
+Advanced conditions such as network location, time windows, device class, or remote access can be added later without changing the core rule model.
+
+## Precedence
+
+Policy evaluation must be deterministic and documented:
+
+1. Disabled users are denied.
+2. Owner allow rules bypass ordinary denies for operational actions, except audit logging still occurs.
+3. Direct user deny rules win over direct user allow rules.
+4. Direct user allow rules win over group deny rules.
+5. Group deny rules win over group allow rules.
+6. Group allow rules grant access.
+7. Legacy default allow applies only to existing normal playback paths during migration.
+8. Everything else is denied by default.
+
+This gives direct user overrides clear meaning while keeping group denies useful.
+
+## Restrictions and Limits
+
+ACL rules answer whether an action is allowed. Playback and account limits also need an effective policy result.
+
+Effective restrictions should merge as follows:
+
+- library access: union of allowed libraries
+- allowed media types: union
+- allowed capabilities: resolved by ACL action evaluation
+- maximum quality: highest allowed quality across matching allow rules, unless a direct user deny or condition excludes the request
+- maximum streams: highest matching limit
+- maximum transcodes: highest matching limit
+- downloads: allowed only when the relevant download action is allowed
+- rating limits: most restrictive matching limit unless a more specific direct user allow grants an exception
+
+The evaluator should return both the boolean decision and the effective limits used for playback/download decisions.
+
+## Explain Access
+
+The policy package should expose an explain mode that returns:
+
+- final decision: allow or deny
+- requested actor, action, and resource
+- matched rules in evaluation order
+- winning rule
+- effective limits used
+- reason code
+
+The admin UI should eventually expose this as an "Explain access" tool on user, group, library, and item screens.
+
+## Data Model
+
+Initial tables:
+
+- `acl_groups`: custom and seeded groups
+- `acl_group_members`: user-to-group memberships
+- `acl_rules`: allow/deny rules for users, groups, built-in roles, or everyone
+- `acl_policy_revisions`: global policy revision tracking for cache/session invalidation
+- `acl_rule_audit`: optional append-only rule mutation log if the existing activity log is not enough
+
+Existing user columns should remain during the migration:
+
+- `role`
+- `permissions`
+- `library_ids`
+- playback/download/profile limit columns
+- `access_policy_revision`
+
+The resolver should initially read both the new ACL tables and legacy fields. Once every caller uses the policy service, legacy fields can be converted to seeded rules or compatibility projections.
+
+## API Shape
+
+Backend code should move toward a central authorization service:
+
+```go
+type Authorizer interface {
+    Authorize(ctx context.Context, request AccessRequest) (AccessDecision, error)
+    Explain(ctx context.Context, request AccessRequest) (AccessExplanation, error)
+    EffectivePolicy(ctx context.Context, userID int, scope PolicyScope) (EffectivePolicy, error)
+}
+```
+
+Middleware should use action-specific gates:
+
+```go
+RequireAction("users.manage")
+RequireActionForItem("metadata.curate")
+RequireActionForLibrary("libraries.manage")
+```
+
+The existing `RequireAdmin` middleware should remain temporarily as a compatibility wrapper around owner/admin-equivalent ACL actions, then be retired route by route.
+
+## Session and Cache Invalidation
+
+JWTs currently carry role information. ACL decisions should not permanently trust stale role or permission claims.
+
+The policy system should use the existing access policy revision concept. When group membership, direct user overrides, or security-sensitive rules change, affected sessions should be invalidated or forced to refresh. Short-lived per-request or short-TTL policy caches are acceptable if keyed by user ID and policy revision.
+
+## UI Direction
+
+The first UI should avoid a raw rule-builder as the default experience.
+
+Initial admin screens should expose:
+
+- users and assigned groups
+- built-in groups
+- custom groups
+- group capabilities
+- library/media scopes
+- playback and download limits
+- direct user overrides
+- explain access
+
+An advanced ACL editor can come later once the safe group-based workflow is proven.
+
+## Migration Plan
+
+Phase 1: Foundation with no behavior change.
+
+- Add action/resource constants.
+- Add policy engine interfaces and tests.
+- Seed ACL groups and compatibility rules.
+- Keep existing `role` and `permissions` behavior intact.
+
+Phase 2: Route conversion.
+
+- Convert admin-only middleware and handlers to action-specific checks.
+- Keep `RequireAdmin` as a wrapper for unconverted routes.
+- Add coverage for representative admin, media, marker, metadata, download, and playback paths.
+
+Phase 3: Media and playback policy.
+
+- Route library access, playback, transcoding, and download decisions through the policy service.
+- Preserve current user limits during migration.
+- Add explain output for denied playback/download decisions.
+
+Phase 4: Group UI.
+
+- Add admin UI for group assignment and group-scoped capabilities.
+- Add direct user overrides.
+- Add explain access UI.
+
+Phase 5: Advanced ACL.
+
+- Add advanced rule editing.
+- Add richer conditions only after the core model is stable.
+- Consider migration away from legacy role/permission columns once compatibility is no longer needed.
+
+## Testing Strategy
+
+Unit tests should cover:
+
+- allow/deny precedence
+- group membership merging
+- direct user overrides
+- owner/admin compatibility
+- legacy `marker_edit` and `metadata_curation` mapping
+- library-scoped access
+- playback/download limit merging
+- disabled user denial
+- explain output stability
+
+Integration tests should cover:
+
+- admin route authorization
+- metadata curation by library-scoped curator
+- marker editing by assigned user
+- playback allowed/denied by library and media type
+- direct download allowed/denied
+- policy revision invalidation after group changes
+
+Frontend tests should cover:
+
+- user/group form state
+- capability toggles
+- direct overrides
+- explain access display
+- preservation of existing admin/user behavior
+
+## Rollout Safety
+
+The ACL engine must be introduced behind compatibility behavior first. A deployment should not suddenly lock out admins or change media access.
+
+At least one owner-capable account must exist after migration. The first migration should promote the oldest enabled admin account to Owner and assign every other enabled admin to Admin. If no admin exists, the existing first-user/bootstrap behavior must still create an owner-capable account.
+
+Every denied privileged request should return a stable error code and be logged with enough context to diagnose the decision through explain access.
+
+## Open Decisions
+
+The initial design chooses full ACL internally, group-oriented UI externally, and incremental migration. The advanced rule-editor UI can be finalized during implementation planning because it does not change the core model.

--- a/docs/superpowers/specs/2026-06-29-security-acl-design.md
+++ b/docs/superpowers/specs/2026-06-29-security-acl-design.md
@@ -316,3 +316,7 @@ Every denied privileged request should return a stable error code and be logged 
 ## Open Decisions
 
 The initial design chooses full ACL internally, group-oriented UI externally, and incremental migration. The advanced rule-editor UI can be finalized during implementation planning because it does not change the core model.
+
+## Foundation Implementation Notes
+
+The first implementation pass adds the ACL data model, constants, evaluator, compatibility mapping, repository, and authorizer facade without converting existing route middleware. Current behavior remains controlled by the legacy role and permission paths until route-specific ACL checks are introduced in later PRs.

--- a/internal/api/handlers/acl_authorization.go
+++ b/internal/api/handlers/acl_authorization.go
@@ -1,0 +1,24 @@
+package handlers
+
+import (
+	"context"
+	"errors"
+
+	"github.com/Silo-Server/silo-server/internal/auth"
+)
+
+var errACLActionDenied = errors.New("acl action denied")
+
+func authorizeACLAction(ctx context.Context, authorizer auth.Authorizer, request auth.AccessRequest) error {
+	if authorizer == nil {
+		return nil
+	}
+	decision, err := authorizer.Authorize(ctx, request)
+	if err != nil {
+		return err
+	}
+	if !decision.Allowed {
+		return errACLActionDenied
+	}
+	return nil
+}

--- a/internal/api/handlers/admin.go
+++ b/internal/api/handlers/admin.go
@@ -52,6 +52,19 @@ type UserRepository interface {
 	GetByID(ctx context.Context, id int) (*models.User, error)
 }
 
+type ACLGroupRepository interface {
+	ListGroups(ctx context.Context) ([]auth.ACLGroup, error)
+	GetGroup(ctx context.Context, slug string) (auth.ACLGroup, []auth.ACLRule, error)
+	CreateGroup(ctx context.Context, input auth.CreateACLGroupInput) (auth.ACLGroup, error)
+	UpdateGroup(ctx context.Context, slug string, input auth.UpdateACLGroupInput) (auth.ACLGroup, error)
+	DeleteGroup(ctx context.Context, slug string) error
+	ListGroupsByUserIDs(ctx context.Context, userIDs []int) (map[int][]auth.ACLGroup, error)
+	ListGroupMemberCounts(ctx context.Context) (map[string]int, error)
+	ListGroupMembers(ctx context.Context, slug string) ([]auth.ACLGroupMember, error)
+	ReplaceUserGroups(ctx context.Context, userID int, groupSlugs []string) error
+	ReplaceGroupRules(ctx context.Context, slug string, rules []auth.ACLRuleInput) ([]auth.ACLRule, error)
+}
+
 // ServerSettingsStore provides access to server-wide admin settings.
 type ServerSettingsStore interface {
 	Get(ctx context.Context, key string) (string, error)
@@ -95,6 +108,9 @@ type AdminHandler struct {
 	JobRepo                      AdminJobCreator
 	ItemRefreshResolver          ItemRefreshScopeResolver
 	ImpersonationService         ImpersonationService
+	AccessGroups                 ACLGroupRepository
+	AdminAuthorizer              auth.Authorizer
+	PrimaryProfileChecker        apimw.PrimaryProfileChecker
 	RealtimeHub                  *notifications.Hub
 	BootstrapSensitiveConfigured map[string]bool
 	BootstrapSensitiveValues     map[string]string
@@ -137,6 +153,7 @@ type createUserRequest struct {
 	MaxProfiles              *int                   `json:"max_profiles,omitempty"`
 	DownloadAllowed          *bool                  `json:"download_allowed,omitempty"`
 	DownloadTranscodeAllowed *bool                  `json:"download_transcode_allowed,omitempty"`
+	AccessGroupSlugs         createStringSliceField `json:"access_group_slugs"`
 }
 
 type createStringSliceField struct {
@@ -212,26 +229,127 @@ type updateUserRequest struct {
 	MaxProfiles              *int                   `json:"max_profiles,omitempty"`
 	DownloadAllowed          *bool                  `json:"download_allowed,omitempty"`
 	DownloadTranscodeAllowed *bool                  `json:"download_transcode_allowed,omitempty"`
+	AccessGroupSlugs         updateStringSliceField `json:"access_group_slugs,omitempty"`
 }
 
 // adminUserResponse represents a user in admin JSON responses.
 type adminUserResponse struct {
-	ID                       int        `json:"id"`
-	Username                 string     `json:"username"`
-	Email                    string     `json:"email"`
-	Role                     string     `json:"role"`
-	Permissions              []string   `json:"permissions"`
-	Enabled                  bool       `json:"enabled"`
-	LibraryIDs               []int      `json:"library_ids"`
-	MaxPlaybackQuality       string     `json:"max_playback_quality"`
-	MaxStreams               int        `json:"max_streams"`
-	MaxTranscodes            int        `json:"max_transcodes"`
-	MaxProfiles              int        `json:"max_profiles"`
-	DownloadAllowed          bool       `json:"download_allowed"`
-	DownloadTranscodeAllowed bool       `json:"download_transcode_allowed"`
-	CreatedAt                time.Time  `json:"created_at"`
-	UpdatedAt                time.Time  `json:"updated_at"`
-	LastActiveAt             *time.Time `json:"last_active_at,omitempty"`
+	ID                       int                     `json:"id"`
+	Username                 string                  `json:"username"`
+	Email                    string                  `json:"email"`
+	Role                     string                  `json:"role"`
+	Permissions              []string                `json:"permissions"`
+	Enabled                  bool                    `json:"enabled"`
+	LibraryIDs               []int                   `json:"library_ids"`
+	MaxPlaybackQuality       string                  `json:"max_playback_quality"`
+	MaxStreams               int                     `json:"max_streams"`
+	MaxTranscodes            int                     `json:"max_transcodes"`
+	MaxProfiles              int                     `json:"max_profiles"`
+	DownloadAllowed          bool                    `json:"download_allowed"`
+	DownloadTranscodeAllowed bool                    `json:"download_transcode_allowed"`
+	CreatedAt                time.Time               `json:"created_at"`
+	UpdatedAt                time.Time               `json:"updated_at"`
+	LastActiveAt             *time.Time              `json:"last_active_at,omitempty"`
+	AccessGroups             []adminACLGroupResponse `json:"access_groups"`
+}
+
+type adminACLGroupResponse struct {
+	ID          int64          `json:"id"`
+	Slug        string         `json:"slug"`
+	Name        string         `json:"name"`
+	Description string         `json:"description"`
+	Policy      auth.ACLPolicy `json:"policy"`
+	BuiltIn     bool           `json:"built_in"`
+	Protected   bool           `json:"protected"`
+	MemberCount int            `json:"member_count"`
+}
+
+type adminACLGroupDetailResponse struct {
+	ID          int64                         `json:"id"`
+	Slug        string                        `json:"slug"`
+	Name        string                        `json:"name"`
+	Description string                        `json:"description"`
+	Policy      auth.ACLPolicy                `json:"policy"`
+	BuiltIn     bool                          `json:"built_in"`
+	Protected   bool                          `json:"protected"`
+	MemberCount int                           `json:"member_count"`
+	Members     []adminACLGroupMemberResponse `json:"members"`
+	Rules       []adminACLRuleResponse        `json:"rules"`
+}
+
+type adminACLGroupMemberResponse struct {
+	UserID   int    `json:"user_id"`
+	Username string `json:"username"`
+	Email    string `json:"email"`
+	Role     string `json:"role"`
+	Enabled  bool   `json:"enabled"`
+}
+
+type adminACLRuleResponse struct {
+	ID           int64                `json:"id"`
+	Action       auth.ACLAction       `json:"action"`
+	ResourceType auth.ACLResourceType `json:"resource_type"`
+	ResourceID   string               `json:"resource_id"`
+	Effect       auth.ACLEffect       `json:"effect"`
+	Conditions   auth.ACLCondition    `json:"conditions"`
+	Priority     int                  `json:"priority"`
+	Name         string               `json:"name"`
+	Description  string               `json:"description"`
+}
+
+type adminUserAccessExplanationResponse struct {
+	User            adminUserResponse                   `json:"user"`
+	Groups          []adminACLGroupResponse             `json:"groups"`
+	EffectivePolicy adminEffectivePolicyResponse        `json:"effective_policy"`
+	Actions         []adminACLActionExplanationResponse `json:"actions"`
+}
+
+type adminEffectivePolicyResponse struct {
+	LibraryIDs                 []int    `json:"library_ids,omitempty"`
+	MediaTypes                 []string `json:"media_types,omitempty"`
+	MaxPlaybackQuality         string   `json:"max_playback_quality,omitempty"`
+	MaxStreams                 int      `json:"max_streams"`
+	MaxTranscodes              int      `json:"max_transcodes"`
+	MaxProfiles                int      `json:"max_profiles"`
+	DirectDownloadsAllowed     bool     `json:"direct_downloads_allowed"`
+	TranscodedDownloadsAllowed bool     `json:"transcoded_downloads_allowed"`
+	MaxContentRating           string   `json:"max_content_rating,omitempty"`
+}
+
+type adminACLActionExplanationResponse struct {
+	Action         auth.ACLAction                    `json:"action"`
+	ResourceType   auth.ACLResourceType              `json:"resource_type"`
+	Allowed        bool                              `json:"allowed"`
+	ReasonCode     string                            `json:"reason_code"`
+	Source         adminACLExplanationSourceResponse `json:"source"`
+	WinningRule    *adminACLRuleResponse             `json:"winning_rule,omitempty"`
+	MatchedRules   []adminACLRuleResponse            `json:"matched_rules"`
+	EvaluatedRules []adminACLRuleResponse            `json:"evaluated_rules"`
+}
+
+type adminACLExplanationSourceResponse struct {
+	Type string `json:"type"`
+	ID   string `json:"id,omitempty"`
+	Name string `json:"name,omitempty"`
+}
+
+type adminAccessGroupWriteRequest struct {
+	Slug        string                `json:"slug,omitempty"`
+	Name        string                `json:"name"`
+	Description string                `json:"description"`
+	Policy      auth.ACLPolicy        `json:"policy"`
+	Rules       []adminACLRuleRequest `json:"rules"`
+}
+
+type adminACLRuleRequest struct {
+	Action       auth.ACLAction       `json:"action"`
+	ResourceType auth.ACLResourceType `json:"resource_type"`
+	ResourceID   string               `json:"resource_id"`
+	Effect       auth.ACLEffect       `json:"effect"`
+	Conditions   auth.ACLCondition    `json:"conditions"`
+	Priority     int                  `json:"priority"`
+	Name         string               `json:"name"`
+	Description  string               `json:"description"`
 }
 
 type adminPlaybackHistoryRow struct {
@@ -295,7 +413,123 @@ func toAdminUserResponse(u *models.User) adminUserResponse {
 		DownloadTranscodeAllowed: u.DownloadTranscodeAllowed,
 		CreatedAt:                u.CreatedAt,
 		UpdatedAt:                u.UpdatedAt,
+		AccessGroups:             []adminACLGroupResponse{},
 	}
+}
+
+func toAdminACLGroupResponse(group auth.ACLGroup) adminACLGroupResponse {
+	return adminACLGroupResponse{
+		ID:          group.ID,
+		Slug:        group.Slug,
+		Name:        group.Name,
+		Description: group.Description,
+		Policy:      group.Policy,
+		BuiltIn:     group.BuiltIn,
+		Protected:   group.Protected,
+	}
+}
+
+func applyACLGroupMemberCounts(resp []adminACLGroupResponse, counts map[string]int) {
+	if len(counts) == 0 {
+		return
+	}
+	for i := range resp {
+		resp[i].MemberCount = counts[resp[i].Slug]
+	}
+}
+
+func toAdminACLGroupResponses(groups []auth.ACLGroup) []adminACLGroupResponse {
+	out := make([]adminACLGroupResponse, 0, len(groups))
+	for _, group := range groups {
+		out = append(out, toAdminACLGroupResponse(group))
+	}
+	return out
+}
+
+func toAdminACLGroupDetailResponse(group auth.ACLGroup, rules []auth.ACLRule, members []auth.ACLGroupMember) adminACLGroupDetailResponse {
+	return adminACLGroupDetailResponse{
+		ID:          group.ID,
+		Slug:        group.Slug,
+		Name:        group.Name,
+		Description: group.Description,
+		Policy:      group.Policy,
+		BuiltIn:     group.BuiltIn,
+		Protected:   group.Protected,
+		MemberCount: len(members),
+		Members:     toAdminACLGroupMemberResponses(members),
+		Rules:       toAdminACLRuleResponses(rules),
+	}
+}
+
+func toAdminACLGroupMemberResponses(members []auth.ACLGroupMember) []adminACLGroupMemberResponse {
+	out := make([]adminACLGroupMemberResponse, 0, len(members))
+	for _, member := range members {
+		out = append(out, adminACLGroupMemberResponse{
+			UserID:   member.UserID,
+			Username: member.Username,
+			Email:    member.Email,
+			Role:     member.Role,
+			Enabled:  member.Enabled,
+		})
+	}
+	return out
+}
+
+func toAdminACLRuleResponse(rule auth.ACLRule) adminACLRuleResponse {
+	return adminACLRuleResponse{
+		ID:           rule.ID,
+		Action:       rule.Action,
+		ResourceType: rule.ResourceType,
+		ResourceID:   rule.ResourceID,
+		Effect:       rule.Effect,
+		Conditions:   rule.Conditions,
+		Priority:     rule.Priority,
+		Name:         rule.Name,
+		Description:  rule.Description,
+	}
+}
+
+func toAdminACLRuleResponses(rules []auth.ACLRule) []adminACLRuleResponse {
+	out := make([]adminACLRuleResponse, 0, len(rules))
+	for _, rule := range rules {
+		out = append(out, toAdminACLRuleResponse(rule))
+	}
+	return out
+}
+
+func toAdminEffectivePolicyResponse(policy auth.EffectivePolicy) adminEffectivePolicyResponse {
+	return adminEffectivePolicyResponse{
+		LibraryIDs:                 append([]int(nil), policy.LibraryIDs...),
+		MediaTypes:                 append([]string(nil), policy.MediaTypes...),
+		MaxPlaybackQuality:         policy.MaxPlaybackQuality,
+		MaxStreams:                 policy.MaxStreams,
+		MaxTranscodes:              policy.MaxTranscodes,
+		MaxProfiles:                policy.MaxProfiles,
+		DirectDownloadsAllowed:     policy.DirectDownloadsAllowed,
+		TranscodedDownloadsAllowed: policy.TranscodedDownloadsAllowed,
+		MaxContentRating:           policy.MaxContentRating,
+	}
+}
+
+func (req adminACLRuleRequest) toInput() auth.ACLRuleInput {
+	return auth.ACLRuleInput{
+		Action:       req.Action,
+		ResourceType: req.ResourceType,
+		ResourceID:   req.ResourceID,
+		Effect:       req.Effect,
+		Conditions:   req.Conditions,
+		Priority:     req.Priority,
+		Name:         req.Name,
+		Description:  req.Description,
+	}
+}
+
+func adminACLRuleInputs(rules []adminACLRuleRequest) ([]auth.ACLRuleInput, error) {
+	inputs := make([]auth.ACLRuleInput, 0, len(rules))
+	for _, rule := range rules {
+		inputs = append(inputs, rule.toInput())
+	}
+	return auth.NormalizeACLRuleInputs(inputs)
 }
 
 func (h *AdminHandler) loadUserLastActiveAt(ctx context.Context, userIDs []int) (map[int]time.Time, error) {
@@ -338,6 +572,164 @@ func applyLastActiveAt(resp *adminUserResponse, lastActive map[int]time.Time) {
 	}
 }
 
+func applyAccessGroups(resp *adminUserResponse, groups map[int][]auth.ACLGroup) {
+	if resp == nil {
+		return
+	}
+	resp.AccessGroups = toAdminACLGroupResponses(groups[resp.ID])
+}
+
+func (h *AdminHandler) loadUserAccessGroups(ctx context.Context, userIDs []int) (map[int][]auth.ACLGroup, error) {
+	if h == nil || h.AccessGroups == nil || len(userIDs) == 0 {
+		return map[int][]auth.ACLGroup{}, nil
+	}
+	return h.AccessGroups.ListGroupsByUserIDs(ctx, userIDs)
+}
+
+func (h *AdminHandler) validateAccessGroupSlugs(ctx context.Context, slugs []string) error {
+	if h == nil || h.AccessGroups == nil {
+		return nil
+	}
+	normalized, err := auth.NormalizeACLGroupSlugs(slugs)
+	if err != nil {
+		return err
+	}
+	groups, err := h.AccessGroups.ListGroups(ctx)
+	if err != nil {
+		return err
+	}
+	known := make(map[string]struct{}, len(groups))
+	for _, group := range groups {
+		known[group.Slug] = struct{}{}
+	}
+	for _, slug := range normalized {
+		if _, ok := known[slug]; !ok {
+			return auth.ErrUnknownACLGroup
+		}
+	}
+	return nil
+}
+
+func (h *AdminHandler) adminCapabilityAllowed(r *http.Request, action auth.ACLAction) (bool, error) {
+	claims := apimw.GetClaims(r.Context())
+	if claims == nil {
+		return false, nil
+	}
+
+	primaryProfile := claims.Role == "admin"
+	if h.PrimaryProfileChecker != nil {
+		profileID := apimw.GetProfileID(r.Context())
+		if profileID == "" {
+			profileID = r.Header.Get("X-Profile-Id")
+		}
+		if profileID != "" {
+			isPrimary, found, err := h.PrimaryProfileChecker(r.Context(), claims.UserID, profileID)
+			if err != nil {
+				return false, err
+			}
+			primaryProfile = found && isPrimary
+		}
+	}
+
+	if h.AdminAuthorizer == nil {
+		return claims.Role == "admin" && primaryProfile, nil
+	}
+
+	decision, err := h.AdminAuthorizer.Authorize(r.Context(), auth.AccessRequest{
+		UserID:         claims.UserID,
+		Action:         action,
+		ResourceType:   auth.ResourceServer,
+		ResourceID:     "*",
+		PrimaryProfile: primaryProfile,
+	})
+	if err != nil {
+		return false, err
+	}
+	return decision.Allowed, nil
+}
+
+func (h *AdminHandler) requireSecurityManage(w http.ResponseWriter, r *http.Request, message string) bool {
+	allowed, err := h.adminCapabilityAllowed(r, auth.ActionSecurityManage)
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, "internal_error", "Failed to verify security management permission")
+		return false
+	}
+	if !allowed {
+		writeError(w, http.StatusForbidden, "forbidden", message)
+		return false
+	}
+	return true
+}
+
+func (h *AdminHandler) requireSecurityManageForAccessGroups(w http.ResponseWriter, r *http.Request) bool {
+	return h.requireSecurityManage(w, r, "Security management permission is required to change access groups")
+}
+
+func (h *AdminHandler) requireSecurityManageForAdminRole(w http.ResponseWriter, r *http.Request) bool {
+	return h.requireSecurityManage(w, r, "Security management permission is required to manage admin users")
+}
+
+func (h *AdminHandler) requireSecurityManageForUserAccessPolicy(w http.ResponseWriter, r *http.Request) bool {
+	return h.requireSecurityManage(w, r, "Security management permission is required to change user access policy")
+}
+
+func isLegacyAdminRole(role string) bool {
+	return strings.EqualFold(strings.TrimSpace(role), "admin")
+}
+
+func createUserAccessPolicySet(req createUserRequest) bool {
+	return req.Permissions.Set ||
+		req.AccessGroupSlugs.Set ||
+		len(req.LibraryIDs) > 0 ||
+		strings.TrimSpace(req.MaxPlaybackQuality) != "" ||
+		req.MaxStreams != nil ||
+		req.MaxTranscodes != nil ||
+		req.MaxProfiles != nil ||
+		req.DownloadAllowed != nil ||
+		req.DownloadTranscodeAllowed != nil
+}
+
+func updateUserAccessPolicySet(req updateUserRequest) bool {
+	return req.Permissions.Set ||
+		req.AccessGroupSlugs.Set ||
+		req.LibraryIDs.Set ||
+		req.MaxPlaybackQuality != nil ||
+		req.MaxStreams != nil ||
+		req.MaxTranscodes != nil ||
+		req.MaxProfiles != nil ||
+		req.DownloadAllowed != nil ||
+		req.DownloadTranscodeAllowed != nil
+}
+
+func writeAccessGroupError(w http.ResponseWriter, err error) bool {
+	if err == nil {
+		return false
+	}
+	if errors.Is(err, auth.ErrUnknownACLGroup) {
+		writeError(w, http.StatusBadRequest, "bad_request", "Unknown access group")
+		return true
+	}
+	if errors.Is(err, auth.ErrACLGroupExists) {
+		writeError(w, http.StatusConflict, "conflict", "Access group already exists")
+		return true
+	}
+	if errors.Is(err, auth.ErrProtectedACLGroup) {
+		writeError(w, http.StatusForbidden, "forbidden", "Built-in access groups cannot be changed")
+		return true
+	}
+	if errors.Is(err, auth.ErrNotFound) {
+		writeError(w, http.StatusNotFound, "not_found", "Access group not found")
+		return true
+	}
+	if strings.Contains(err.Error(), "ACL group name is required") ||
+		strings.Contains(err.Error(), "invalid ACL") {
+		writeError(w, http.StatusBadRequest, "bad_request", err.Error())
+		return true
+	}
+	writeError(w, http.StatusInternalServerError, "internal_error", "Access group operation failed")
+	return true
+}
+
 // --- Handler methods ---
 
 // HandleListUsers handles GET /admin/users.
@@ -358,8 +750,13 @@ func (h *AdminHandler) HandleListUsers(w http.ResponseWriter, r *http.Request) {
 	if err != nil {
 		slog.Warn("failed to load admin user last activity", "error", err)
 	}
+	accessGroups, err := h.loadUserAccessGroups(r.Context(), userIDs)
+	if err != nil {
+		slog.Warn("failed to load admin user access groups", "error", err)
+	}
 	for i := range resp {
 		applyLastActiveAt(&resp[i], lastActive)
+		applyAccessGroups(&resp[i], accessGroups)
 	}
 
 	writeJSON(w, http.StatusOK, resp)
@@ -386,8 +783,283 @@ func (h *AdminHandler) HandleGetUser(w http.ResponseWriter, r *http.Request) {
 		slog.Warn("failed to load admin user last activity", "user_id", user.ID, "error", err)
 	}
 	applyLastActiveAt(&resp, lastActive)
+	accessGroups, err := h.loadUserAccessGroups(r.Context(), []int{user.ID})
+	if err != nil {
+		slog.Warn("failed to load admin user access groups", "user_id", user.ID, "error", err)
+	}
+	applyAccessGroups(&resp, accessGroups)
 
 	writeJSON(w, http.StatusOK, resp)
+}
+
+// HandleListAccessGroups handles GET /admin/access-groups.
+func (h *AdminHandler) HandleListAccessGroups(w http.ResponseWriter, r *http.Request) {
+	if h.AccessGroups == nil {
+		writeJSON(w, http.StatusOK, []adminACLGroupResponse{})
+		return
+	}
+	groups, err := h.AccessGroups.ListGroups(r.Context())
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, "internal_error", "Failed to list access groups")
+		return
+	}
+	counts, err := h.AccessGroups.ListGroupMemberCounts(r.Context())
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, "internal_error", "Failed to list access group members")
+		return
+	}
+	resp := toAdminACLGroupResponses(groups)
+	applyACLGroupMemberCounts(resp, counts)
+	writeJSON(w, http.StatusOK, resp)
+}
+
+// HandleGetAccessGroup handles GET /admin/access-groups/{slug}.
+func (h *AdminHandler) HandleGetAccessGroup(w http.ResponseWriter, r *http.Request) {
+	if h.AccessGroups == nil {
+		writeError(w, http.StatusInternalServerError, "internal_error", "Access groups are unavailable")
+		return
+	}
+	group, rules, err := h.AccessGroups.GetGroup(r.Context(), chi.URLParam(r, "slug"))
+	if writeAccessGroupError(w, err) {
+		return
+	}
+	members, err := h.AccessGroups.ListGroupMembers(r.Context(), group.Slug)
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, "internal_error", "Failed to list access group members")
+		return
+	}
+	writeJSON(w, http.StatusOK, toAdminACLGroupDetailResponse(group, rules, members))
+}
+
+// HandleCreateAccessGroup handles POST /admin/access-groups.
+func (h *AdminHandler) HandleCreateAccessGroup(w http.ResponseWriter, r *http.Request) {
+	if h.AccessGroups == nil {
+		writeError(w, http.StatusInternalServerError, "internal_error", "Access groups are unavailable")
+		return
+	}
+	var req adminAccessGroupWriteRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		writeError(w, http.StatusBadRequest, "bad_request", "Invalid request body")
+		return
+	}
+	rules, err := adminACLRuleInputs(req.Rules)
+	if writeAccessGroupError(w, err) {
+		return
+	}
+
+	group, err := h.AccessGroups.CreateGroup(r.Context(), auth.CreateACLGroupInput{
+		Slug:        req.Slug,
+		Name:        req.Name,
+		Description: req.Description,
+		Policy:      req.Policy,
+	})
+	if writeAccessGroupError(w, err) {
+		return
+	}
+
+	appliedRules := []auth.ACLRule{}
+	if len(rules) > 0 {
+		appliedRules, err = h.AccessGroups.ReplaceGroupRules(r.Context(), group.Slug, rules)
+		if writeAccessGroupError(w, err) {
+			return
+		}
+	}
+	writeJSON(w, http.StatusCreated, toAdminACLGroupDetailResponse(group, appliedRules, nil))
+}
+
+// HandleUpdateAccessGroup handles PUT /admin/access-groups/{slug}.
+func (h *AdminHandler) HandleUpdateAccessGroup(w http.ResponseWriter, r *http.Request) {
+	if h.AccessGroups == nil {
+		writeError(w, http.StatusInternalServerError, "internal_error", "Access groups are unavailable")
+		return
+	}
+	var req adminAccessGroupWriteRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		writeError(w, http.StatusBadRequest, "bad_request", "Invalid request body")
+		return
+	}
+	rules, err := adminACLRuleInputs(req.Rules)
+	if writeAccessGroupError(w, err) {
+		return
+	}
+
+	slug := chi.URLParam(r, "slug")
+	group, err := h.AccessGroups.UpdateGroup(r.Context(), slug, auth.UpdateACLGroupInput{
+		Name:        req.Name,
+		Description: req.Description,
+		Policy:      req.Policy,
+	})
+	if writeAccessGroupError(w, err) {
+		return
+	}
+	appliedRules, err := h.AccessGroups.ReplaceGroupRules(r.Context(), group.Slug, rules)
+	if writeAccessGroupError(w, err) {
+		return
+	}
+	writeJSON(w, http.StatusOK, toAdminACLGroupDetailResponse(group, appliedRules, nil))
+}
+
+// HandleDeleteAccessGroup handles DELETE /admin/access-groups/{slug}.
+func (h *AdminHandler) HandleDeleteAccessGroup(w http.ResponseWriter, r *http.Request) {
+	if h.AccessGroups == nil {
+		writeError(w, http.StatusInternalServerError, "internal_error", "Access groups are unavailable")
+		return
+	}
+	if err := h.AccessGroups.DeleteGroup(r.Context(), chi.URLParam(r, "slug")); writeAccessGroupError(w, err) {
+		return
+	}
+	w.WriteHeader(http.StatusNoContent)
+}
+
+func (h *AdminHandler) HandleGetUserAccessExplanation(w http.ResponseWriter, r *http.Request) {
+	idStr := chi.URLParam(r, "id")
+	id, err := strconv.Atoi(idStr)
+	if err != nil {
+		writeError(w, http.StatusBadRequest, "bad_request", "Invalid user ID")
+		return
+	}
+	user, err := h.userRepo.GetByID(r.Context(), id)
+	if err != nil {
+		if auth.IsNotFound(err) {
+			writeError(w, http.StatusNotFound, "not_found", "User not found")
+			return
+		}
+		writeError(w, http.StatusInternalServerError, "internal_error", "Failed to fetch user")
+		return
+	}
+
+	authorizer := h.AdminAuthorizer
+	if authorizer == nil {
+		authorizer = auth.NewACLAuthorizer(nil, h.userRepo)
+	}
+
+	userResp := toAdminUserResponse(user)
+	groupMap := map[string]auth.ACLGroup{}
+	if h.AccessGroups != nil {
+		groupsByUser, err := h.loadUserAccessGroups(r.Context(), []int{user.ID})
+		if err != nil {
+			writeError(w, http.StatusInternalServerError, "internal_error", "Failed to load user access groups")
+			return
+		}
+		applyAccessGroups(&userResp, groupsByUser)
+		for _, group := range groupsByUser[user.ID] {
+			groupMap[group.Slug] = group
+		}
+	}
+
+	actions := make([]adminACLActionExplanationResponse, 0, len(auth.ExplainableCapabilityActions()))
+	var effectivePolicy adminEffectivePolicyResponse
+	policySet := false
+	for _, action := range auth.ExplainableCapabilityActions() {
+		resourceType := adminACLResourceTypeForAction(action)
+		explanation, err := authorizer.Explain(r.Context(), auth.AccessRequest{
+			UserID:         user.ID,
+			Action:         action,
+			ResourceType:   resourceType,
+			ResourceID:     "*",
+			PrimaryProfile: true,
+		})
+		if err != nil {
+			writeError(w, http.StatusInternalServerError, "internal_error", "Failed to explain user access")
+			return
+		}
+		if !policySet {
+			effectivePolicy = toAdminEffectivePolicyResponse(explanation.Decision.EffectivePolicy)
+			policySet = true
+		}
+		actions = append(actions, adminACLActionExplanationResponse{
+			Action:         action,
+			ResourceType:   resourceType,
+			Allowed:        explanation.Decision.Allowed,
+			ReasonCode:     explanation.Decision.ReasonCode,
+			Source:         adminACLExplanationSource(explanation.Decision, groupMap),
+			WinningRule:    adminACLWinningRuleResponse(explanation.Decision.WinningRule),
+			MatchedRules:   toAdminACLRuleResponses(explanation.Decision.MatchedRules),
+			EvaluatedRules: toAdminACLRuleResponses(explanation.EvaluatedRules),
+		})
+	}
+
+	writeJSON(w, http.StatusOK, adminUserAccessExplanationResponse{
+		User:            userResp,
+		Groups:          userResp.AccessGroups,
+		EffectivePolicy: effectivePolicy,
+		Actions:         actions,
+	})
+}
+
+func adminACLWinningRuleResponse(rule *auth.ACLRule) *adminACLRuleResponse {
+	if rule == nil {
+		return nil
+	}
+	resp := toAdminACLRuleResponse(*rule)
+	return &resp
+}
+
+func adminACLExplanationSource(decision auth.AccessDecision, groups map[string]auth.ACLGroup) adminACLExplanationSourceResponse {
+	if decision.WinningRule == nil {
+		if decision.ReasonCode == "user_disabled" {
+			return adminACLExplanationSourceResponse{Type: "user", Name: "Disabled user"}
+		}
+		return adminACLExplanationSourceResponse{Type: "default", Name: "Default deny"}
+	}
+	rule := decision.WinningRule
+	switch rule.SubjectType {
+	case auth.SubjectUser:
+		sourceType := "user"
+		if strings.HasPrefix(rule.Name, "legacy permission ") {
+			sourceType = "legacy_permission"
+		}
+		return adminACLExplanationSourceResponse{Type: sourceType, ID: rule.SubjectID, Name: rule.Name}
+	case auth.SubjectGroup:
+		name := rule.SubjectID
+		if group, ok := groups[rule.SubjectID]; ok {
+			name = group.Name
+		}
+		return adminACLExplanationSourceResponse{Type: "group", ID: rule.SubjectID, Name: name}
+	case auth.SubjectBuiltInRole:
+		name := rule.SubjectID
+		if group, ok := groups[rule.SubjectID]; ok {
+			name = group.Name
+		}
+		return adminACLExplanationSourceResponse{Type: "builtin_role", ID: rule.SubjectID, Name: name}
+	case auth.SubjectEveryone:
+		return adminACLExplanationSourceResponse{Type: "everyone", Name: "Everyone"}
+	default:
+		return adminACLExplanationSourceResponse{Type: string(rule.SubjectType), ID: rule.SubjectID, Name: rule.Name}
+	}
+}
+
+func adminACLResourceTypeForAction(action auth.ACLAction) auth.ACLResourceType {
+	switch action {
+	case auth.ActionPlaybackPlay,
+		auth.ActionPlaybackTranscode,
+		auth.ActionDownloadsDirect,
+		auth.ActionDownloadsTranscode,
+		auth.ActionPersonalListsManage,
+		auth.ActionMetadataCurate,
+		auth.ActionMarkersEdit:
+		return auth.ResourceMediaItem
+	case auth.ActionRequestsCreate, auth.ActionRequestsApprove:
+		return auth.ResourceRequest
+	case auth.ActionUsersView, auth.ActionUsersManage, auth.ActionUsersImpersonate:
+		return auth.ResourceUser
+	case auth.ActionLibrariesView, auth.ActionLibrariesManage:
+		return auth.ResourceLibrary
+	case auth.ActionTasksView, auth.ActionTasksRun:
+		return auth.ResourceTask
+	case auth.ActionLogsView:
+		return auth.ResourceLog
+	case auth.ActionPluginsView, auth.ActionPluginsManage:
+		return auth.ResourcePlugin
+	case auth.ActionNodesView, auth.ActionNodesManage:
+		return auth.ResourceRemoteNode
+	case auth.ActionProfilesManage:
+		return auth.ResourceProfile
+	case auth.ActionSecurityManage:
+		return auth.ResourceSecuritySettings
+	default:
+		return auth.ResourceServer
+	}
 }
 
 // HandleCreateUser handles POST /admin/users.
@@ -405,6 +1077,30 @@ func (h *AdminHandler) HandleCreateUser(w http.ResponseWriter, r *http.Request) 
 		writeError(w, http.StatusBadRequest, "bad_request", "Username, email, password, and role are required")
 		return
 	}
+	if isLegacyAdminRole(req.Role) {
+		if !h.requireSecurityManageForAdminRole(w, r) {
+			return
+		}
+	}
+	if createUserAccessPolicySet(req) {
+		if !h.requireSecurityManageForUserAccessPolicy(w, r) {
+			return
+		}
+	}
+
+	accessGroupSlugs := auth.DefaultACLGroupSlugsForRole(req.Role)
+	if req.AccessGroupSlugs.Set {
+		accessGroupSlugs = req.AccessGroupSlugs.Value
+	}
+	normalizedAccessGroupSlugs, err := auth.NormalizeACLGroupSlugs(accessGroupSlugs)
+	if err != nil {
+		writeAccessGroupError(w, err)
+		return
+	}
+	if err := h.validateAccessGroupSlugs(r.Context(), normalizedAccessGroupSlugs); err != nil {
+		writeAccessGroupError(w, err)
+		return
+	}
 
 	maxPlaybackQuality, ok := access.ParsePlaybackQualityPreset(req.MaxPlaybackQuality)
 	if !ok {
@@ -419,7 +1115,7 @@ func (h *AdminHandler) HandleCreateUser(w http.ResponseWriter, r *http.Request) 
 	if req.Permissions.Set {
 		permissions = req.Permissions.Value
 	}
-	permissions, err := auth.NormalizePermissions(permissions)
+	permissions, err = auth.NormalizePermissions(permissions)
 	if err != nil {
 		writeError(w, http.StatusBadRequest, "bad_request", err.Error())
 		return
@@ -449,9 +1145,21 @@ func (h *AdminHandler) HandleCreateUser(w http.ResponseWriter, r *http.Request) 
 		writeError(w, http.StatusInternalServerError, "internal_error", "Failed to create user")
 		return
 	}
+	if h.AccessGroups != nil {
+		if err := h.AccessGroups.ReplaceUserGroups(r.Context(), user.ID, normalizedAccessGroupSlugs); err != nil {
+			writeError(w, http.StatusInternalServerError, "internal_error", "Failed to assign access groups")
+			return
+		}
+	}
 	h.invalidateStats(r.Context(), cache.ChannelAdmin, cache.EventAdminStatsInvalidated, strconv.Itoa(user.ID))
 
-	writeJSON(w, http.StatusCreated, toAdminUserResponse(user))
+	resp := toAdminUserResponse(user)
+	accessGroups, err := h.loadUserAccessGroups(r.Context(), []int{user.ID})
+	if err != nil {
+		slog.Warn("failed to load created user access groups", "user_id", user.ID, "error", err)
+	}
+	applyAccessGroups(&resp, accessGroups)
+	writeJSON(w, http.StatusCreated, resp)
 }
 
 // HandleUpdateUser handles PUT /admin/users/{id}.
@@ -508,17 +1216,38 @@ func (h *AdminHandler) HandleUpdateUser(w http.ResponseWriter, r *http.Request) 
 		DownloadTranscodeAllowed: req.DownloadTranscodeAllowed,
 	}
 
-	var currentUser *models.User
-	if updateMayRequireSessionRevocation(updateInput) {
-		currentUser, err = h.userRepo.GetByID(r.Context(), id)
-		if err != nil {
-			if auth.IsNotFound(err) {
-				writeError(w, http.StatusNotFound, "not_found", "User not found")
-				return
-			}
-			writeError(w, http.StatusInternalServerError, "internal_error", "Failed to fetch user")
+	currentUser, err := h.userRepo.GetByID(r.Context(), id)
+	if err != nil {
+		if auth.IsNotFound(err) {
+			writeError(w, http.StatusNotFound, "not_found", "User not found")
 			return
 		}
+		writeError(w, http.StatusInternalServerError, "internal_error", "Failed to fetch user")
+		return
+	}
+	if isLegacyAdminRole(currentUser.Role) || (req.Role != nil && isLegacyAdminRole(*req.Role)) {
+		if !h.requireSecurityManageForAdminRole(w, r) {
+			return
+		}
+	}
+	if updateUserAccessPolicySet(req) {
+		if !h.requireSecurityManageForUserAccessPolicy(w, r) {
+			return
+		}
+	}
+
+	var normalizedAccessGroupSlugs []string
+	if req.AccessGroupSlugs.Set {
+		normalized, err := auth.NormalizeACLGroupSlugs(req.AccessGroupSlugs.Value)
+		if err != nil {
+			writeAccessGroupError(w, err)
+			return
+		}
+		if err := h.validateAccessGroupSlugs(r.Context(), normalized); err != nil {
+			writeAccessGroupError(w, err)
+			return
+		}
+		normalizedAccessGroupSlugs = normalized
 	}
 
 	err = h.userRepo.Update(r.Context(), id, updateInput)
@@ -530,7 +1259,21 @@ func (h *AdminHandler) HandleUpdateUser(w http.ResponseWriter, r *http.Request) 
 		writeError(w, http.StatusInternalServerError, "internal_error", "Failed to update user")
 		return
 	}
-	if updateRequiresSessionRevocation(currentUser, updateInput) {
+	if req.AccessGroupSlugs.Set && h.AccessGroups != nil {
+		if err := h.AccessGroups.ReplaceUserGroups(r.Context(), id, normalizedAccessGroupSlugs); err != nil {
+			if errors.Is(err, auth.ErrNotFound) {
+				writeError(w, http.StatusNotFound, "not_found", "User not found")
+				return
+			}
+			if errors.Is(err, auth.ErrUnknownACLGroup) {
+				writeError(w, http.StatusBadRequest, "bad_request", "Unknown access group")
+				return
+			}
+			writeError(w, http.StatusInternalServerError, "internal_error", "Failed to update access groups")
+			return
+		}
+	}
+	if updateRequiresSessionRevocation(currentUser, updateInput) || req.AccessGroupSlugs.Set {
 		if err := h.revokeUserSessions(r.Context(), id); err != nil {
 			writeError(w, http.StatusInternalServerError, "internal_error", "Failed to revoke updated user sessions")
 			return
@@ -543,7 +1286,13 @@ func (h *AdminHandler) HandleUpdateUser(w http.ResponseWriter, r *http.Request) 
 		return
 	}
 
-	writeJSON(w, http.StatusOK, toAdminUserResponse(user))
+	resp := toAdminUserResponse(user)
+	accessGroups, err := h.loadUserAccessGroups(r.Context(), []int{user.ID})
+	if err != nil {
+		slog.Warn("failed to load updated user access groups", "user_id", user.ID, "error", err)
+	}
+	applyAccessGroups(&resp, accessGroups)
+	writeJSON(w, http.StatusOK, resp)
 }
 
 // HandleDeleteUser handles DELETE /admin/users/{id}.
@@ -553,6 +1302,21 @@ func (h *AdminHandler) HandleDeleteUser(w http.ResponseWriter, r *http.Request) 
 	if err != nil {
 		writeError(w, http.StatusBadRequest, "bad_request", "Invalid user ID")
 		return
+	}
+
+	user, err := h.userRepo.GetByID(r.Context(), id)
+	if err != nil {
+		if auth.IsNotFound(err) {
+			writeError(w, http.StatusNotFound, "not_found", "User not found")
+			return
+		}
+		writeError(w, http.StatusInternalServerError, "internal_error", "Failed to fetch user")
+		return
+	}
+	if isLegacyAdminRole(user.Role) {
+		if !h.requireSecurityManageForAdminRole(w, r) {
+			return
+		}
 	}
 
 	err = h.userRepo.Delete(r.Context(), id)

--- a/internal/api/handlers/admin_access_explain_test.go
+++ b/internal/api/handlers/admin_access_explain_test.go
@@ -1,0 +1,153 @@
+package handlers
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/go-chi/chi/v5"
+
+	"github.com/Silo-Server/silo-server/internal/auth"
+	"github.com/Silo-Server/silo-server/internal/models"
+)
+
+type fakeAdminAccessExplainAuthorizer struct {
+	explanations  map[auth.ACLAction]auth.AccessExplanation
+	defaultPolicy auth.EffectivePolicy
+	requests      []auth.AccessRequest
+}
+
+func (f *fakeAdminAccessExplainAuthorizer) Authorize(_ context.Context, request auth.AccessRequest) (auth.AccessDecision, error) {
+	explanation, ok := f.explanations[request.Action]
+	if !ok {
+		return auth.AccessDecision{
+			Allowed:         false,
+			ReasonCode:      "default_deny",
+			EffectivePolicy: f.defaultPolicy,
+		}, nil
+	}
+	return explanation.Decision, nil
+}
+
+func (f *fakeAdminAccessExplainAuthorizer) Explain(_ context.Context, request auth.AccessRequest) (auth.AccessExplanation, error) {
+	f.requests = append(f.requests, request)
+	explanation, ok := f.explanations[request.Action]
+	if !ok {
+		return auth.AccessExplanation{
+			Request: request,
+			Decision: auth.AccessDecision{
+				Allowed:         false,
+				ReasonCode:      "default_deny",
+				EffectivePolicy: f.defaultPolicy,
+			},
+		}, nil
+	}
+	explanation.Request = request
+	return explanation, nil
+}
+
+func TestHandleGetUserAccessExplanationShowsCascadeSources(t *testing.T) {
+	winningRule := auth.ACLRule{
+		ID:           7,
+		SubjectType:  auth.SubjectGroup,
+		SubjectID:    "standard_user",
+		Action:       auth.ActionPlaybackPlay,
+		ResourceType: auth.ResourceMediaItem,
+		ResourceID:   "*",
+		Effect:       auth.EffectAllow,
+		Priority:     10,
+		Name:         "User playback",
+	}
+	authorizer := &fakeAdminAccessExplainAuthorizer{
+		explanations: map[auth.ACLAction]auth.AccessExplanation{
+			auth.ActionPlaybackPlay: {
+				Decision: auth.AccessDecision{
+					Allowed:      true,
+					ReasonCode:   "rule_allow",
+					WinningRule:  &winningRule,
+					MatchedRules: []auth.ACLRule{winningRule},
+					EffectivePolicy: auth.EffectivePolicy{
+						MaxStreams:                 4,
+						MaxTranscodes:              2,
+						MaxProfiles:                5,
+						DirectDownloadsAllowed:     true,
+						TranscodedDownloadsAllowed: false,
+					},
+				},
+				EvaluatedRules: []auth.ACLRule{winningRule},
+			},
+		},
+		defaultPolicy: auth.EffectivePolicy{
+			MaxStreams:                 4,
+			MaxTranscodes:              2,
+			MaxProfiles:                5,
+			DirectDownloadsAllowed:     true,
+			TranscodedDownloadsAllowed: false,
+		},
+	}
+	repo := newFakeAdminACLRepository()
+	repo.groups["standard_user"] = auth.ACLGroup{ID: 5, Slug: "standard_user", Name: "User", BuiltIn: true}
+	repo.userGroups[7] = []auth.ACLGroup{repo.groups["standard_user"]}
+	h := &AdminHandler{
+		userRepo: &fakeAdminUpdateUserRepo{
+			user: &models.User{ID: 7, Username: "tom", Email: "tom@example.com", Role: "user", Enabled: true},
+		},
+		AccessGroups:    repo,
+		AdminAuthorizer: authorizer,
+	}
+	req := httptest.NewRequest(http.MethodGet, "/admin/users/7/access-explain", nil)
+	routeCtx := chi.NewRouteContext()
+	routeCtx.URLParams.Add("id", "7")
+	req = req.WithContext(context.WithValue(req.Context(), chi.RouteCtxKey, routeCtx))
+	rec := httptest.NewRecorder()
+
+	h.HandleGetUserAccessExplanation(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, body = %s", rec.Code, rec.Body.String())
+	}
+	var resp adminUserAccessExplanationResponse
+	if err := json.NewDecoder(rec.Body).Decode(&resp); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if resp.User.Username != "tom" {
+		t.Fatalf("user = %#v, want tom", resp.User)
+	}
+	if resp.EffectivePolicy.MaxStreams != 4 {
+		t.Fatalf("max streams = %d, want 4", resp.EffectivePolicy.MaxStreams)
+	}
+	playback := findAdminAccessExplanation(resp.Actions, auth.ActionPlaybackPlay)
+	if playback == nil {
+		t.Fatalf("missing playback.play explanation in %#v", resp.Actions)
+	}
+	if !playback.Allowed || playback.ReasonCode != "rule_allow" {
+		t.Fatalf("playback explanation = %#v, want allowed rule_allow", playback)
+	}
+	if playback.Source.Type != "group" || playback.Source.ID != "standard_user" || playback.Source.Name != "User" {
+		t.Fatalf("playback source = %#v, want standard_user group", playback.Source)
+	}
+	if playback.WinningRule == nil || playback.WinningRule.Name != "User playback" {
+		t.Fatalf("winning rule = %#v, want User playback", playback.WinningRule)
+	}
+	security := findAdminAccessExplanation(resp.Actions, auth.ActionSecurityManage)
+	if security == nil {
+		t.Fatalf("missing security.manage explanation")
+	}
+	if security.Allowed || security.Source.Type != "default" || security.ReasonCode != "default_deny" {
+		t.Fatalf("security explanation = %#v, want default deny", security)
+	}
+	if len(authorizer.requests) == 0 || authorizer.requests[0].ResourceType != auth.ResourceServer {
+		t.Fatalf("first request = %#v, want server resource", authorizer.requests)
+	}
+}
+
+func findAdminAccessExplanation(rows []adminACLActionExplanationResponse, action auth.ACLAction) *adminACLActionExplanationResponse {
+	for i := range rows {
+		if rows[i].Action == action {
+			return &rows[i]
+		}
+	}
+	return nil
+}

--- a/internal/api/handlers/admin_access_groups_test.go
+++ b/internal/api/handlers/admin_access_groups_test.go
@@ -1,0 +1,335 @@
+package handlers
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"reflect"
+	"testing"
+
+	"github.com/go-chi/chi/v5"
+
+	"github.com/Silo-Server/silo-server/internal/auth"
+)
+
+type fakeAdminACLRepository struct {
+	groups     map[string]auth.ACLGroup
+	rules      map[string][]auth.ACLRule
+	members    map[string][]auth.ACLGroupMember
+	counts     map[string]int
+	userGroups map[int][]auth.ACLGroup
+
+	createInput       auth.CreateACLGroupInput
+	updateSlug        string
+	updateInput       auth.UpdateACLGroupInput
+	deleteSlug        string
+	replaceRulesSlug  string
+	replaceRulesInput []auth.ACLRuleInput
+	err               error
+}
+
+func newFakeAdminACLRepository() *fakeAdminACLRepository {
+	return &fakeAdminACLRepository{
+		groups:     map[string]auth.ACLGroup{},
+		rules:      map[string][]auth.ACLRule{},
+		members:    map[string][]auth.ACLGroupMember{},
+		counts:     map[string]int{},
+		userGroups: map[int][]auth.ACLGroup{},
+	}
+}
+
+func (f *fakeAdminACLRepository) ListGroups(context.Context) ([]auth.ACLGroup, error) {
+	if f.err != nil {
+		return nil, f.err
+	}
+	out := make([]auth.ACLGroup, 0, len(f.groups))
+	for _, group := range f.groups {
+		out = append(out, group)
+	}
+	return out, nil
+}
+
+func (f *fakeAdminACLRepository) ListGroupsByUserIDs(_ context.Context, userIDs []int) (map[int][]auth.ACLGroup, error) {
+	out := map[int][]auth.ACLGroup{}
+	for _, userID := range userIDs {
+		out[userID] = append([]auth.ACLGroup(nil), f.userGroups[userID]...)
+	}
+	return out, nil
+}
+
+func (f *fakeAdminACLRepository) ListGroupMemberCounts(context.Context) (map[string]int, error) {
+	return f.counts, nil
+}
+
+func (f *fakeAdminACLRepository) ListGroupMembers(_ context.Context, slug string) ([]auth.ACLGroupMember, error) {
+	return append([]auth.ACLGroupMember(nil), f.members[slug]...), nil
+}
+
+func (f *fakeAdminACLRepository) ReplaceUserGroups(context.Context, int, []string) error {
+	return nil
+}
+
+func (f *fakeAdminACLRepository) GetGroup(ctx context.Context, slug string) (auth.ACLGroup, []auth.ACLRule, error) {
+	if f.err != nil {
+		return auth.ACLGroup{}, nil, f.err
+	}
+	group, ok := f.groups[slug]
+	if !ok {
+		return auth.ACLGroup{}, nil, auth.ErrNotFound
+	}
+	return group, f.rules[slug], nil
+}
+
+func (f *fakeAdminACLRepository) CreateGroup(ctx context.Context, input auth.CreateACLGroupInput) (auth.ACLGroup, error) {
+	if f.err != nil {
+		return auth.ACLGroup{}, f.err
+	}
+	f.createInput = input
+	group := auth.ACLGroup{ID: 42, Slug: input.Slug, Name: input.Name, Description: input.Description, Policy: input.Policy}
+	f.groups[group.Slug] = group
+	return group, nil
+}
+
+func (f *fakeAdminACLRepository) UpdateGroup(ctx context.Context, slug string, input auth.UpdateACLGroupInput) (auth.ACLGroup, error) {
+	if f.err != nil {
+		return auth.ACLGroup{}, f.err
+	}
+	f.updateSlug = slug
+	f.updateInput = input
+	group, ok := f.groups[slug]
+	if !ok {
+		return auth.ACLGroup{}, auth.ErrNotFound
+	}
+	if group.Protected || group.BuiltIn {
+		return auth.ACLGroup{}, auth.ErrProtectedACLGroup
+	}
+	group.Name = input.Name
+	group.Description = input.Description
+	group.Policy = input.Policy
+	f.groups[slug] = group
+	return group, nil
+}
+
+func (f *fakeAdminACLRepository) DeleteGroup(ctx context.Context, slug string) error {
+	if f.err != nil {
+		return f.err
+	}
+	f.deleteSlug = slug
+	group, ok := f.groups[slug]
+	if !ok {
+		return auth.ErrNotFound
+	}
+	if group.Protected || group.BuiltIn {
+		return auth.ErrProtectedACLGroup
+	}
+	delete(f.groups, slug)
+	delete(f.rules, slug)
+	return nil
+}
+
+func (f *fakeAdminACLRepository) ReplaceGroupRules(ctx context.Context, slug string, rules []auth.ACLRuleInput) ([]auth.ACLRule, error) {
+	if f.err != nil {
+		return nil, f.err
+	}
+	f.replaceRulesSlug = slug
+	f.replaceRulesInput = append([]auth.ACLRuleInput(nil), rules...)
+	out := make([]auth.ACLRule, 0, len(rules))
+	for i, rule := range rules {
+		out = append(out, auth.ACLRule{
+			ID:           int64(i + 1),
+			SubjectType:  auth.SubjectGroup,
+			SubjectID:    slug,
+			Action:       rule.Action,
+			ResourceType: rule.ResourceType,
+			ResourceID:   rule.ResourceID,
+			Effect:       rule.Effect,
+			Conditions:   rule.Conditions,
+			Priority:     rule.Priority,
+			Name:         rule.Name,
+			Description:  rule.Description,
+		})
+	}
+	f.rules[slug] = out
+	return out, nil
+}
+
+func accessGroupRequest(t *testing.T, method, path, slug, body string) (*httptest.ResponseRecorder, *http.Request) {
+	t.Helper()
+	req := httptest.NewRequest(method, path, bytes.NewBufferString(body))
+	req.Header.Set("Content-Type", "application/json")
+	if slug != "" {
+		routeCtx := chi.NewRouteContext()
+		routeCtx.URLParams.Add("slug", slug)
+		req = req.WithContext(context.WithValue(req.Context(), chi.RouteCtxKey, routeCtx))
+	}
+	return httptest.NewRecorder(), req
+}
+
+func TestHandleGetAccessGroupIncludesMembers(t *testing.T) {
+	repo := newFakeAdminACLRepository()
+	repo.groups["standard_user"] = auth.ACLGroup{
+		ID:          5,
+		Slug:        "standard_user",
+		Name:        "User",
+		Description: "Normal media access.",
+		BuiltIn:     true,
+	}
+	repo.rules["standard_user"] = []auth.ACLRule{
+		{ID: 1, SubjectType: auth.SubjectGroup, SubjectID: "standard_user", Action: auth.ActionPlaybackPlay, ResourceType: auth.ResourceMediaItem, ResourceID: "*", Effect: auth.EffectAllow, Name: "User playback"},
+	}
+	repo.members["standard_user"] = []auth.ACLGroupMember{
+		{UserID: 7, Username: "tom", Email: "tom@example.com", Role: "user", Enabled: true},
+		{UserID: 8, Username: "martha", Email: "martha@example.com", Role: "user", Enabled: false},
+	}
+	h := &AdminHandler{AccessGroups: repo}
+	rec, req := accessGroupRequest(t, http.MethodGet, "/admin/access-groups/standard_user", "standard_user", "")
+
+	h.HandleGetAccessGroup(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, body = %s", rec.Code, rec.Body.String())
+	}
+	var resp adminACLGroupDetailResponse
+	if err := json.NewDecoder(rec.Body).Decode(&resp); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if resp.Slug != "standard_user" {
+		t.Fatalf("slug = %q, want standard_user", resp.Slug)
+	}
+	if len(resp.Members) != 2 {
+		t.Fatalf("members = %#v, want two", resp.Members)
+	}
+	if resp.Members[0].Username != "tom" || !resp.Members[0].Enabled {
+		t.Fatalf("first member = %#v, want enabled tom", resp.Members[0])
+	}
+	if resp.Members[1].Username != "martha" || resp.Members[1].Enabled {
+		t.Fatalf("second member = %#v, want disabled martha", resp.Members[1])
+	}
+}
+
+func TestHandleCreateAccessGroupCreatesCustomGroupWithRules(t *testing.T) {
+	repo := newFakeAdminACLRepository()
+	h := &AdminHandler{AccessGroups: repo}
+	rec, req := accessGroupRequest(t, http.MethodPost, "/admin/access-groups", "", `{
+		"slug": "curators",
+		"name": "Curators",
+		"description": "Can curate metadata in selected libraries.",
+		"policy": {"max_profiles": 4, "max_streams": 5},
+		"rules": [
+			{
+				"action": "metadata.curate",
+				"resource_type": "media_item",
+				"resource_id": "*",
+				"effect": "allow",
+				"conditions": {"library_ids": [1, 2]},
+				"priority": 25,
+				"name": "Curate selected libraries"
+			}
+		]
+	}`)
+
+	h.HandleCreateAccessGroup(rec, req)
+
+	if rec.Code != http.StatusCreated {
+		t.Fatalf("status = %d, body = %s", rec.Code, rec.Body.String())
+	}
+	if repo.createInput.Slug != "curators" || repo.createInput.Name != "Curators" {
+		t.Fatalf("create input = %#v", repo.createInput)
+	}
+	if repo.createInput.Policy.MaxProfiles == nil || *repo.createInput.Policy.MaxProfiles != 4 {
+		t.Fatalf("create policy max profiles = %#v, want 4", repo.createInput.Policy.MaxProfiles)
+	}
+	if repo.createInput.Policy.MaxStreams == nil || *repo.createInput.Policy.MaxStreams != 5 {
+		t.Fatalf("create policy max streams = %#v, want 5", repo.createInput.Policy.MaxStreams)
+	}
+	if repo.replaceRulesSlug != "curators" || len(repo.replaceRulesInput) != 1 {
+		t.Fatalf("replace rules slug/input = %q %#v", repo.replaceRulesSlug, repo.replaceRulesInput)
+	}
+	gotRule := repo.replaceRulesInput[0]
+	if gotRule.Action != auth.ActionMetadataCurate || gotRule.ResourceType != auth.ResourceMediaItem {
+		t.Fatalf("rule = %#v", gotRule)
+	}
+	if !reflect.DeepEqual(gotRule.Conditions.LibraryIDs, []int{1, 2}) {
+		t.Fatalf("library ids = %#v, want [1 2]", gotRule.Conditions.LibraryIDs)
+	}
+
+	var resp adminACLGroupDetailResponse
+	if err := json.NewDecoder(rec.Body).Decode(&resp); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if resp.Slug != "curators" || len(resp.Rules) != 1 {
+		t.Fatalf("response = %#v", resp)
+	}
+}
+
+func TestHandleUpdateAccessGroupRejectsBuiltInGroup(t *testing.T) {
+	repo := newFakeAdminACLRepository()
+	repo.groups["admin"] = auth.ACLGroup{ID: 1, Slug: "admin", Name: "Admin", BuiltIn: true, Protected: true}
+	h := &AdminHandler{AccessGroups: repo}
+	rec, req := accessGroupRequest(t, http.MethodPut, "/admin/access-groups/admin", "admin", `{
+		"name": "Changed",
+		"description": "",
+		"rules": []
+	}`)
+
+	h.HandleUpdateAccessGroup(rec, req)
+
+	if rec.Code != http.StatusForbidden {
+		t.Fatalf("status = %d, body = %s", rec.Code, rec.Body.String())
+	}
+}
+
+func TestHandleDeleteAccessGroupDeletesCustomGroup(t *testing.T) {
+	repo := newFakeAdminACLRepository()
+	repo.groups["curators"] = auth.ACLGroup{ID: 42, Slug: "curators", Name: "Curators"}
+	h := &AdminHandler{AccessGroups: repo}
+	rec, req := accessGroupRequest(t, http.MethodDelete, "/admin/access-groups/curators", "curators", "")
+
+	h.HandleDeleteAccessGroup(rec, req)
+
+	if rec.Code != http.StatusNoContent {
+		t.Fatalf("status = %d, body = %s", rec.Code, rec.Body.String())
+	}
+	if repo.deleteSlug != "curators" {
+		t.Fatalf("delete slug = %q, want curators", repo.deleteSlug)
+	}
+}
+
+func TestHandleCreateAccessGroupMapsDuplicateGroupToConflict(t *testing.T) {
+	repo := newFakeAdminACLRepository()
+	repo.err = auth.ErrACLGroupExists
+	h := &AdminHandler{AccessGroups: repo}
+	rec, req := accessGroupRequest(t, http.MethodPost, "/admin/access-groups", "", `{
+		"slug": "curators",
+		"name": "Curators",
+		"rules": []
+	}`)
+
+	h.HandleCreateAccessGroup(rec, req)
+
+	if rec.Code != http.StatusConflict {
+		t.Fatalf("status = %d, body = %s", rec.Code, rec.Body.String())
+	}
+}
+
+func TestHandleCreateAccessGroupRejectsInvalidRule(t *testing.T) {
+	repo := newFakeAdminACLRepository()
+	h := &AdminHandler{AccessGroups: repo}
+	rec, req := accessGroupRequest(t, http.MethodPost, "/admin/access-groups", "", `{
+		"slug": "curators",
+		"name": "Curators",
+		"rules": [{"action": "server.destroy", "resource_type": "server", "effect": "allow"}]
+	}`)
+
+	h.HandleCreateAccessGroup(rec, req)
+
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d, body = %s", rec.Code, rec.Body.String())
+	}
+	if !errors.Is(repo.err, nil) {
+		t.Fatalf("repo should not be called with invalid rule")
+	}
+}

--- a/internal/api/handlers/admin_test.go
+++ b/internal/api/handlers/admin_test.go
@@ -1,8 +1,16 @@
 package handlers
 
 import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"strings"
 	"testing"
 
+	"github.com/go-chi/chi/v5"
+
+	apimw "github.com/Silo-Server/silo-server/internal/api/middleware"
+	"github.com/Silo-Server/silo-server/internal/auth"
 	"github.com/Silo-Server/silo-server/internal/models"
 )
 
@@ -129,4 +137,310 @@ func TestUpdateRequiresSessionRevocation(t *testing.T) {
 			t.Fatalf("updateRequiresSessionRevocation() = %v, want false", got)
 		}
 	})
+}
+
+type fakeAdminUpdateUserRepo struct {
+	createCalled bool
+	updateCalled bool
+	deleteCalled bool
+	user         *models.User
+}
+
+func (f *fakeAdminUpdateUserRepo) List(context.Context) ([]*models.User, error) {
+	return nil, nil
+}
+
+func (f *fakeAdminUpdateUserRepo) Create(_ context.Context, input models.CreateUserInput) (*models.User, error) {
+	f.createCalled = true
+	return &models.User{ID: 99, Username: input.Username, Email: input.Email, Role: input.Role, Enabled: true}, nil
+}
+
+func (f *fakeAdminUpdateUserRepo) Update(context.Context, int, models.UpdateUserInput) error {
+	f.updateCalled = true
+	return nil
+}
+
+func (f *fakeAdminUpdateUserRepo) Delete(context.Context, int) error {
+	f.deleteCalled = true
+	return nil
+}
+
+func (f *fakeAdminUpdateUserRepo) GetByID(context.Context, int) (*models.User, error) {
+	if f.user != nil {
+		return f.user, nil
+	}
+	return &models.User{ID: 7, Username: "tom", Role: "user", Enabled: true}, nil
+}
+
+type fakeHandlerAdminAuthorizer struct {
+	decision auth.AccessDecision
+	request  auth.AccessRequest
+	called   bool
+}
+
+func (f *fakeHandlerAdminAuthorizer) Authorize(_ context.Context, request auth.AccessRequest) (auth.AccessDecision, error) {
+	f.called = true
+	f.request = request
+	return f.decision, nil
+}
+
+func (f *fakeHandlerAdminAuthorizer) Explain(_ context.Context, request auth.AccessRequest) (auth.AccessExplanation, error) {
+	decision, err := f.Authorize(context.Background(), request)
+	return auth.AccessExplanation{Request: request, Decision: decision}, err
+}
+
+func TestHandleUpdateUserRejectsAccessGroupChangesWithoutSecurityManage(t *testing.T) {
+	userRepo := &fakeAdminUpdateUserRepo{}
+	authorizer := &fakeHandlerAdminAuthorizer{
+		decision: auth.AccessDecision{Allowed: false, ReasonCode: "default_deny"},
+	}
+	handler := &AdminHandler{
+		userRepo:        userRepo,
+		AdminAuthorizer: authorizer,
+	}
+
+	req := httptest.NewRequest(http.MethodPut, "/admin/users/7", strings.NewReader(`{
+		"username": "tom",
+		"access_group_slugs": ["admin"]
+	}`))
+	routeCtx := chi.NewRouteContext()
+	routeCtx.URLParams.Add("id", "7")
+	ctx := context.WithValue(req.Context(), chi.RouteCtxKey, routeCtx)
+	ctx = apimw.SetClaims(ctx, &auth.Claims{UserID: 42, Role: "user", TokenType: auth.TokenTypeAccess})
+	req = req.WithContext(ctx)
+
+	rec := httptest.NewRecorder()
+	handler.HandleUpdateUser(rec, req)
+
+	if rec.Code != http.StatusForbidden {
+		t.Fatalf("status = %d, body = %s", rec.Code, rec.Body.String())
+	}
+	if userRepo.updateCalled {
+		t.Fatalf("user repo update was called")
+	}
+	if !authorizer.called {
+		t.Fatalf("admin authorizer was not called")
+	}
+	if authorizer.request.Action != auth.ActionSecurityManage {
+		t.Fatalf("authorizer action = %q, want %q", authorizer.request.Action, auth.ActionSecurityManage)
+	}
+}
+
+func TestHandleCreateUserRejectsAdminRoleWithoutSecurityManage(t *testing.T) {
+	userRepo := &fakeAdminUpdateUserRepo{}
+	authorizer := &fakeHandlerAdminAuthorizer{
+		decision: auth.AccessDecision{Allowed: false, ReasonCode: "default_deny"},
+	}
+	handler := &AdminHandler{
+		userRepo:        userRepo,
+		AdminAuthorizer: authorizer,
+	}
+
+	req := httptest.NewRequest(http.MethodPost, "/admin/users", strings.NewReader(`{
+		"username": "martha",
+		"email": "martha@example.test",
+		"password": "secret-password",
+		"role": "admin"
+	}`))
+	ctx := apimw.SetClaims(req.Context(), &auth.Claims{UserID: 42, Role: "user", TokenType: auth.TokenTypeAccess})
+	req = req.WithContext(ctx)
+
+	rec := httptest.NewRecorder()
+	handler.HandleCreateUser(rec, req)
+
+	if rec.Code != http.StatusForbidden {
+		t.Fatalf("status = %d, body = %s", rec.Code, rec.Body.String())
+	}
+	if userRepo.createCalled {
+		t.Fatalf("user repo create was called")
+	}
+	if !authorizer.called {
+		t.Fatalf("admin authorizer was not called")
+	}
+	if authorizer.request.Action != auth.ActionSecurityManage {
+		t.Fatalf("authorizer action = %q, want %q", authorizer.request.Action, auth.ActionSecurityManage)
+	}
+}
+
+func TestHandleCreateUserRejectsAccessPolicyWithoutSecurityManage(t *testing.T) {
+	userRepo := &fakeAdminUpdateUserRepo{}
+	authorizer := &fakeHandlerAdminAuthorizer{
+		decision: auth.AccessDecision{Allowed: false, ReasonCode: "default_deny"},
+	}
+	handler := &AdminHandler{
+		userRepo:        userRepo,
+		AdminAuthorizer: authorizer,
+	}
+
+	req := httptest.NewRequest(http.MethodPost, "/admin/users", strings.NewReader(`{
+		"username": "tom",
+		"email": "tom@example.test",
+		"password": "secret-password",
+		"role": "user",
+		"max_streams": 10
+	}`))
+	ctx := apimw.SetClaims(req.Context(), &auth.Claims{UserID: 42, Role: "user", TokenType: auth.TokenTypeAccess})
+	req = req.WithContext(ctx)
+
+	rec := httptest.NewRecorder()
+	handler.HandleCreateUser(rec, req)
+
+	if rec.Code != http.StatusForbidden {
+		t.Fatalf("status = %d, body = %s", rec.Code, rec.Body.String())
+	}
+	if userRepo.createCalled {
+		t.Fatalf("user repo create was called")
+	}
+	if !authorizer.called {
+		t.Fatalf("admin authorizer was not called")
+	}
+	if authorizer.request.Action != auth.ActionSecurityManage {
+		t.Fatalf("authorizer action = %q, want %q", authorizer.request.Action, auth.ActionSecurityManage)
+	}
+}
+
+func TestHandleUpdateUserRejectsAdminPromotionWithoutSecurityManage(t *testing.T) {
+	userRepo := &fakeAdminUpdateUserRepo{}
+	authorizer := &fakeHandlerAdminAuthorizer{
+		decision: auth.AccessDecision{Allowed: false, ReasonCode: "default_deny"},
+	}
+	handler := &AdminHandler{
+		userRepo:        userRepo,
+		AdminAuthorizer: authorizer,
+	}
+
+	req := httptest.NewRequest(http.MethodPut, "/admin/users/7", strings.NewReader(`{
+		"role": "admin"
+	}`))
+	routeCtx := chi.NewRouteContext()
+	routeCtx.URLParams.Add("id", "7")
+	ctx := context.WithValue(req.Context(), chi.RouteCtxKey, routeCtx)
+	ctx = apimw.SetClaims(ctx, &auth.Claims{UserID: 42, Role: "user", TokenType: auth.TokenTypeAccess})
+	req = req.WithContext(ctx)
+
+	rec := httptest.NewRecorder()
+	handler.HandleUpdateUser(rec, req)
+
+	if rec.Code != http.StatusForbidden {
+		t.Fatalf("status = %d, body = %s", rec.Code, rec.Body.String())
+	}
+	if userRepo.updateCalled {
+		t.Fatalf("user repo update was called")
+	}
+	if !authorizer.called {
+		t.Fatalf("admin authorizer was not called")
+	}
+	if authorizer.request.Action != auth.ActionSecurityManage {
+		t.Fatalf("authorizer action = %q, want %q", authorizer.request.Action, auth.ActionSecurityManage)
+	}
+}
+
+func TestHandleUpdateUserRejectsAccessPolicyWithoutSecurityManage(t *testing.T) {
+	userRepo := &fakeAdminUpdateUserRepo{}
+	authorizer := &fakeHandlerAdminAuthorizer{
+		decision: auth.AccessDecision{Allowed: false, ReasonCode: "default_deny"},
+	}
+	handler := &AdminHandler{
+		userRepo:        userRepo,
+		AdminAuthorizer: authorizer,
+	}
+
+	req := httptest.NewRequest(http.MethodPut, "/admin/users/7", strings.NewReader(`{
+		"permissions": ["metadata_curation"]
+	}`))
+	routeCtx := chi.NewRouteContext()
+	routeCtx.URLParams.Add("id", "7")
+	ctx := context.WithValue(req.Context(), chi.RouteCtxKey, routeCtx)
+	ctx = apimw.SetClaims(ctx, &auth.Claims{UserID: 42, Role: "user", TokenType: auth.TokenTypeAccess})
+	req = req.WithContext(ctx)
+
+	rec := httptest.NewRecorder()
+	handler.HandleUpdateUser(rec, req)
+
+	if rec.Code != http.StatusForbidden {
+		t.Fatalf("status = %d, body = %s", rec.Code, rec.Body.String())
+	}
+	if userRepo.updateCalled {
+		t.Fatalf("user repo update was called")
+	}
+	if !authorizer.called {
+		t.Fatalf("admin authorizer was not called")
+	}
+	if authorizer.request.Action != auth.ActionSecurityManage {
+		t.Fatalf("authorizer action = %q, want %q", authorizer.request.Action, auth.ActionSecurityManage)
+	}
+}
+
+func TestHandleUpdateUserRejectsAdminAccountChangesWithoutSecurityManage(t *testing.T) {
+	userRepo := &fakeAdminUpdateUserRepo{
+		user: &models.User{ID: 7, Username: "martha", Role: "admin", Enabled: true},
+	}
+	authorizer := &fakeHandlerAdminAuthorizer{
+		decision: auth.AccessDecision{Allowed: false, ReasonCode: "default_deny"},
+	}
+	handler := &AdminHandler{
+		userRepo:        userRepo,
+		AdminAuthorizer: authorizer,
+	}
+
+	req := httptest.NewRequest(http.MethodPut, "/admin/users/7", strings.NewReader(`{
+		"username": "martha-renamed"
+	}`))
+	routeCtx := chi.NewRouteContext()
+	routeCtx.URLParams.Add("id", "7")
+	ctx := context.WithValue(req.Context(), chi.RouteCtxKey, routeCtx)
+	ctx = apimw.SetClaims(ctx, &auth.Claims{UserID: 42, Role: "user", TokenType: auth.TokenTypeAccess})
+	req = req.WithContext(ctx)
+
+	rec := httptest.NewRecorder()
+	handler.HandleUpdateUser(rec, req)
+
+	if rec.Code != http.StatusForbidden {
+		t.Fatalf("status = %d, body = %s", rec.Code, rec.Body.String())
+	}
+	if userRepo.updateCalled {
+		t.Fatalf("user repo update was called")
+	}
+	if !authorizer.called {
+		t.Fatalf("admin authorizer was not called")
+	}
+	if authorizer.request.Action != auth.ActionSecurityManage {
+		t.Fatalf("authorizer action = %q, want %q", authorizer.request.Action, auth.ActionSecurityManage)
+	}
+}
+
+func TestHandleDeleteUserRejectsAdminAccountWithoutSecurityManage(t *testing.T) {
+	userRepo := &fakeAdminUpdateUserRepo{
+		user: &models.User{ID: 7, Username: "martha", Role: "admin", Enabled: true},
+	}
+	authorizer := &fakeHandlerAdminAuthorizer{
+		decision: auth.AccessDecision{Allowed: false, ReasonCode: "default_deny"},
+	}
+	handler := &AdminHandler{
+		userRepo:        userRepo,
+		AdminAuthorizer: authorizer,
+	}
+
+	req := httptest.NewRequest(http.MethodDelete, "/admin/users/7", nil)
+	routeCtx := chi.NewRouteContext()
+	routeCtx.URLParams.Add("id", "7")
+	ctx := context.WithValue(req.Context(), chi.RouteCtxKey, routeCtx)
+	ctx = apimw.SetClaims(ctx, &auth.Claims{UserID: 42, Role: "user", TokenType: auth.TokenTypeAccess})
+	req = req.WithContext(ctx)
+
+	rec := httptest.NewRecorder()
+	handler.HandleDeleteUser(rec, req)
+
+	if rec.Code != http.StatusForbidden {
+		t.Fatalf("status = %d, body = %s", rec.Code, rec.Body.String())
+	}
+	if userRepo.deleteCalled {
+		t.Fatalf("user repo delete was called")
+	}
+	if !authorizer.called {
+		t.Fatalf("admin authorizer was not called")
+	}
+	if authorizer.request.Action != auth.ActionSecurityManage {
+		t.Fatalf("authorizer action = %q, want %q", authorizer.request.Action, auth.ActionSecurityManage)
+	}
 }

--- a/internal/api/handlers/auth.go
+++ b/internal/api/handlers/auth.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/go-chi/chi/v5"
 
+	apimw "github.com/Silo-Server/silo-server/internal/api/middleware"
 	"github.com/Silo-Server/silo-server/internal/auth"
 	"github.com/Silo-Server/silo-server/internal/clientip"
 	"github.com/Silo-Server/silo-server/internal/models"
@@ -17,10 +18,12 @@ import (
 
 // AuthHandler handles authentication-related HTTP endpoints.
 type AuthHandler struct {
-	service              *auth.Service
-	jwt                  *auth.JWTService
-	device               *auth.DeviceLoginService
-	oauthRoutesAvailable bool
+	service               *auth.Service
+	jwt                   *auth.JWTService
+	device                *auth.DeviceLoginService
+	AdminAuthorizer       auth.Authorizer
+	PrimaryProfileChecker apimw.PrimaryProfileChecker
+	oauthRoutesAvailable  bool
 }
 
 // NewAuthHandler creates a new AuthHandler backed by the given auth, JWT,
@@ -147,6 +150,10 @@ type authProviderResponse struct {
 	Default        bool   `json:"default"`
 	IconURL        string `json:"icon_url,omitempty"`
 	InstallationID int    `json:"installation_id,omitempty"`
+}
+
+type adminCapabilitiesResponse struct {
+	Actions []string `json:"actions"`
 }
 
 // --- Handler methods ---
@@ -383,6 +390,114 @@ func (h *AuthHandler) HandleMe(w http.ResponseWriter, r *http.Request) {
 	}
 
 	writeJSON(w, http.StatusOK, buildUserResponse(user, claims.ImpersonatorUserID, impersonator))
+}
+
+func (h *AuthHandler) HandleAdminCapabilities(w http.ResponseWriter, r *http.Request) {
+	claims := apimw.GetClaims(r.Context())
+	if claims == nil {
+		var err error
+		claims, err = h.extractClaims(r)
+		if err != nil {
+			writeError(w, http.StatusUnauthorized, "unauthorized", "Invalid or missing authentication token")
+			return
+		}
+	}
+
+	primaryProfile := claims.Role == "admin"
+	if h.PrimaryProfileChecker != nil {
+		profileID := apimw.GetProfileID(r.Context())
+		if profileID == "" {
+			profileID = r.Header.Get("X-Profile-Id")
+		}
+		if profileID != "" {
+			isPrimary, found, err := h.PrimaryProfileChecker(r.Context(), claims.UserID, profileID)
+			if err != nil {
+				writeError(w, http.StatusInternalServerError, "internal_error", "Failed to load admin capabilities")
+				return
+			}
+			primaryProfile = found && isPrimary
+		}
+	}
+
+	actions := make([]string, 0)
+	for _, action := range auth.AdminCapabilityActions() {
+		if h.AdminAuthorizer == nil {
+			if claims.Role == "admin" && primaryProfile {
+				actions = append(actions, string(action))
+			}
+			continue
+		}
+
+		decision, err := h.AdminAuthorizer.Authorize(r.Context(), auth.AccessRequest{
+			UserID:         claims.UserID,
+			Action:         action,
+			ResourceType:   auth.ResourceServer,
+			ResourceID:     "*",
+			PrimaryProfile: primaryProfile,
+		})
+		if err != nil {
+			writeError(w, http.StatusInternalServerError, "internal_error", "Failed to load admin capabilities")
+			return
+		}
+		if decision.Allowed {
+			actions = append(actions, string(action))
+		}
+	}
+
+	writeJSON(w, http.StatusOK, adminCapabilitiesResponse{Actions: actions})
+}
+
+func (h *AuthHandler) HandleCapabilities(w http.ResponseWriter, r *http.Request) {
+	claims := apimw.GetClaims(r.Context())
+	if claims == nil {
+		var err error
+		claims, err = h.extractClaims(r)
+		if err != nil {
+			writeError(w, http.StatusUnauthorized, "unauthorized", "Invalid or missing authentication token")
+			return
+		}
+	}
+
+	profileID := apimw.GetProfileID(r.Context())
+	if profileID == "" {
+		profileID = r.Header.Get("X-Profile-Id")
+	}
+
+	actions := make([]string, 0)
+	for _, action := range auth.UserFacingCapabilityActions() {
+		if h.AdminAuthorizer == nil {
+			actions = append(actions, string(action))
+			continue
+		}
+
+		decision, err := h.AdminAuthorizer.Authorize(r.Context(), auth.AccessRequest{
+			UserID:       claims.UserID,
+			ProfileID:    profileID,
+			Action:       action,
+			ResourceType: userFacingCapabilityResourceType(action),
+			ResourceID:   "*",
+		})
+		if err != nil {
+			writeError(w, http.StatusInternalServerError, "internal_error", "Failed to load capabilities")
+			return
+		}
+		if decision.Allowed {
+			actions = append(actions, string(action))
+		}
+	}
+
+	writeJSON(w, http.StatusOK, adminCapabilitiesResponse{Actions: actions})
+}
+
+func userFacingCapabilityResourceType(action auth.ACLAction) auth.ACLResourceType {
+	switch action {
+	case auth.ActionProfilesManage:
+		return auth.ResourceProfile
+	case auth.ActionRequestsCreate:
+		return auth.ResourceRequest
+	default:
+		return auth.ResourceMediaItem
+	}
 }
 
 // HandleListSessions handles GET /auth/sessions. Requires authentication.

--- a/internal/api/handlers/auth_capabilities_test.go
+++ b/internal/api/handlers/auth_capabilities_test.go
@@ -1,0 +1,156 @@
+package handlers
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	apimw "github.com/Silo-Server/silo-server/internal/api/middleware"
+	"github.com/Silo-Server/silo-server/internal/auth"
+)
+
+type fakeAuthCapabilitiesAuthorizer struct {
+	allowed        map[auth.ACLAction]bool
+	requirePrimary bool
+	requests       *[]auth.AccessRequest
+}
+
+func (f fakeAuthCapabilitiesAuthorizer) Authorize(_ context.Context, request auth.AccessRequest) (auth.AccessDecision, error) {
+	if f.requests != nil {
+		*f.requests = append(*f.requests, request)
+	}
+	if f.requirePrimary && !request.PrimaryProfile {
+		return auth.AccessDecision{Allowed: false}, nil
+	}
+	return auth.AccessDecision{Allowed: f.allowed[request.Action]}, nil
+}
+
+func (f fakeAuthCapabilitiesAuthorizer) Explain(_ context.Context, request auth.AccessRequest) (auth.AccessExplanation, error) {
+	decision, err := f.Authorize(context.Background(), request)
+	return auth.AccessExplanation{Request: request, Decision: decision}, err
+}
+
+func TestHandleAdminCapabilitiesListsExplicitDelegatedGrants(t *testing.T) {
+	handler := &AuthHandler{
+		AdminAuthorizer: fakeAuthCapabilitiesAuthorizer{
+			allowed: map[auth.ACLAction]bool{
+				auth.ActionUsersManage:     true,
+				auth.ActionRequestsApprove: true,
+			},
+		},
+	}
+	req := httptest.NewRequest(http.MethodGet, "/auth/admin-capabilities", nil)
+	req = req.WithContext(apimw.SetClaims(req.Context(), &auth.Claims{
+		UserID:    42,
+		Role:      "user",
+		TokenType: auth.TokenTypeAccess,
+	}))
+	rec := httptest.NewRecorder()
+
+	handler.HandleAdminCapabilities(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, body = %s", rec.Code, rec.Body.String())
+	}
+	var resp adminCapabilitiesResponse
+	if err := json.NewDecoder(rec.Body).Decode(&resp); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	want := []string{"users.manage", "requests.approve"}
+	if len(resp.Actions) != len(want) {
+		t.Fatalf("actions = %#v, want %#v", resp.Actions, want)
+	}
+	for i := range want {
+		if resp.Actions[i] != want[i] {
+			t.Fatalf("actions = %#v, want %#v", resp.Actions, want)
+		}
+	}
+}
+
+func TestHandleAdminCapabilitiesHonorsPrimaryProfileForLegacyAdmin(t *testing.T) {
+	handler := &AuthHandler{
+		AdminAuthorizer: fakeAuthCapabilitiesAuthorizer{
+			allowed: map[auth.ACLAction]bool{
+				auth.ActionUsersManage: true,
+			},
+			requirePrimary: true,
+		},
+		PrimaryProfileChecker: func(context.Context, int, string) (bool, bool, error) {
+			return false, true, nil
+		},
+	}
+	req := httptest.NewRequest(http.MethodGet, "/auth/admin-capabilities", nil)
+	req.Header.Set("X-Profile-Id", "non-primary-profile")
+	req = req.WithContext(apimw.SetClaims(req.Context(), &auth.Claims{
+		UserID:    42,
+		Role:      "admin",
+		TokenType: auth.TokenTypeAccess,
+	}))
+	rec := httptest.NewRecorder()
+
+	handler.HandleAdminCapabilities(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, body = %s", rec.Code, rec.Body.String())
+	}
+	var resp adminCapabilitiesResponse
+	if err := json.NewDecoder(rec.Body).Decode(&resp); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if len(resp.Actions) != 0 {
+		t.Fatalf("actions = %#v, want empty", resp.Actions)
+	}
+}
+
+func TestHandleCapabilitiesListsUserFacingGrantsForActiveProfile(t *testing.T) {
+	var requests []auth.AccessRequest
+	handler := &AuthHandler{
+		AdminAuthorizer: fakeAuthCapabilitiesAuthorizer{
+			allowed: map[auth.ACLAction]bool{
+				auth.ActionPlaybackPlay:        true,
+				auth.ActionPersonalListsManage: true,
+				auth.ActionRequestsCreate:      true,
+			},
+			requests: &requests,
+		},
+	}
+	req := httptest.NewRequest(http.MethodGet, "/auth/capabilities", nil)
+	req = req.WithContext(apimw.SetProfileID(apimw.SetClaims(req.Context(), &auth.Claims{
+		UserID:    42,
+		Role:      "user",
+		TokenType: auth.TokenTypeAccess,
+	}), "profile-1"))
+	rec := httptest.NewRecorder()
+
+	handler.HandleCapabilities(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, body = %s", rec.Code, rec.Body.String())
+	}
+	var resp adminCapabilitiesResponse
+	if err := json.NewDecoder(rec.Body).Decode(&resp); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	want := []string{"playback.play", "personal_lists.manage", "requests.create"}
+	if len(resp.Actions) != len(want) {
+		t.Fatalf("actions = %#v, want %#v", resp.Actions, want)
+	}
+	for i := range want {
+		if resp.Actions[i] != want[i] {
+			t.Fatalf("actions = %#v, want %#v", resp.Actions, want)
+		}
+	}
+	if len(requests) != len(auth.UserFacingCapabilityActions()) {
+		t.Fatalf("authorizer calls = %d, want %d", len(requests), len(auth.UserFacingCapabilityActions()))
+	}
+	for _, request := range requests {
+		if request.ProfileID != "profile-1" {
+			t.Fatalf("ProfileID = %q, want profile-1", request.ProfileID)
+		}
+		if request.ResourceID != "*" {
+			t.Fatalf("ResourceID = %q, want *", request.ResourceID)
+		}
+	}
+}

--- a/internal/api/handlers/ebook_reader.go
+++ b/internal/api/handlers/ebook_reader.go
@@ -595,6 +595,8 @@ func mergeEbookReaderAnnotationPatch(
 
 func (h *EbookReaderHandler) writeReadError(w http.ResponseWriter, err error) {
 	switch {
+	case errors.Is(err, errMediaConsumptionForbidden):
+		writeError(w, http.StatusForbidden, "forbidden", "Ebook reading is not allowed")
 	case errors.Is(err, catalog.ErrItemNotFound), errors.Is(err, catalog.ErrEpisodeNotFound):
 		writeError(w, http.StatusNotFound, "not_found", "Ebook file not found")
 	default:

--- a/internal/api/handlers/ebook_reader_test.go
+++ b/internal/api/handlers/ebook_reader_test.go
@@ -202,6 +202,48 @@ func TestEbookReaderServesEbookInlineWithRangeSupport(t *testing.T) {
 	}
 }
 
+func TestEbookReaderRejectsReadWithoutPlaybackPlayGrant(t *testing.T) {
+	authorizer := &fakeMediaConsumptionAuthorizer{
+		decision: auth.AccessDecision{Allowed: false, ReasonCode: "default_deny"},
+	}
+	handler := NewEbookReaderHandler(&MediaFileAuthorizer{
+		FileResolver: stubMediaFileResolver{
+			file: &models.MediaFile{
+				ID:            42,
+				ContentID:     "ebook-1",
+				MediaFolderID: 10,
+				FilePath:      writePlaybackTestMediaFile(t, "book.epub"),
+				Container:     "epub",
+				BaseType:      "ebook",
+			},
+		},
+		ItemAccess:            stubItemAccessChecker{},
+		ConsumptionAuthorizer: authorizer,
+	})
+
+	req := newEbookReaderAuthRequest(http.MethodGet, "/ebooks/ebook-1/files/42/read")
+	req = withEbookReaderRouteParams(req, "ebook-1", "42")
+	rr := httptest.NewRecorder()
+
+	handler.HandleReadFile(rr, req)
+
+	if rr.Code != http.StatusForbidden {
+		t.Fatalf("status = %d, body = %s", rr.Code, rr.Body.String())
+	}
+	if !authorizer.called {
+		t.Fatalf("ebook read ACL authorizer was not called")
+	}
+	if authorizer.request.Action != auth.ActionPlaybackPlay {
+		t.Fatalf("action = %q, want %q", authorizer.request.Action, auth.ActionPlaybackPlay)
+	}
+	if authorizer.request.ResourceType != auth.ResourceMediaItem || authorizer.request.ResourceID != "ebook-1" {
+		t.Fatalf("resource = %s/%q, want media_item/ebook-1", authorizer.request.ResourceType, authorizer.request.ResourceID)
+	}
+	if authorizer.request.MediaType != "ebook" {
+		t.Fatalf("media type = %q, want ebook", authorizer.request.MediaType)
+	}
+}
+
 func TestEbookReaderServesContainerMimeForMismatchedExtension(t *testing.T) {
 	filePath := writePlaybackTestMediaFile(t, "book.txt")
 	if err := os.WriteFile(filePath, []byte("<html>not really</html>"), 0o644); err != nil {

--- a/internal/api/handlers/favorites.go
+++ b/internal/api/handlers/favorites.go
@@ -12,6 +12,7 @@ import (
 	"github.com/go-chi/chi/v5"
 
 	apimw "github.com/Silo-Server/silo-server/internal/api/middleware"
+	"github.com/Silo-Server/silo-server/internal/auth"
 	"github.com/Silo-Server/silo-server/internal/catalog"
 	evt "github.com/Silo-Server/silo-server/internal/events"
 	"github.com/Silo-Server/silo-server/internal/models"
@@ -37,6 +38,7 @@ type PersonalDataHandler struct {
 	seasonRepo              *catalog.SeasonRepository
 	detailSvc               *catalog.DetailService
 	EventsHub               *evt.Hub
+	Authorizer              auth.Authorizer
 	localListDispatcher     LocalListEventDispatcher
 	profileStaler           ProfileStaler
 	profileRefreshRequester ProfileRefreshRequester
@@ -203,6 +205,9 @@ func (h *PersonalDataHandler) HandleAddFavorite(w http.ResponseWriter, r *http.R
 		writeError(w, http.StatusBadRequest, "bad_request", "Item ID is required")
 		return
 	}
+	if !h.authorizePersonalListMutation(w, r, itemID) {
+		return
+	}
 
 	store, err := h.storeProvider.ForUser(r.Context(), userID)
 	if err != nil {
@@ -235,6 +240,9 @@ func (h *PersonalDataHandler) HandleRemoveFavorite(w http.ResponseWriter, r *htt
 
 	if itemID == "" {
 		writeError(w, http.StatusBadRequest, "bad_request", "Item ID is required")
+		return
+	}
+	if !h.authorizePersonalListMutation(w, r, itemID) {
 		return
 	}
 
@@ -359,6 +367,9 @@ func (h *PersonalDataHandler) HandleAddToWatchlist(w http.ResponseWriter, r *htt
 		writeError(w, http.StatusBadRequest, "bad_request", "Item ID is required")
 		return
 	}
+	if !h.authorizePersonalListMutation(w, r, itemID) {
+		return
+	}
 
 	store, err := h.storeProvider.ForUser(r.Context(), userID)
 	if err != nil {
@@ -393,6 +404,9 @@ func (h *PersonalDataHandler) HandleRemoveFromWatchlist(w http.ResponseWriter, r
 		writeError(w, http.StatusBadRequest, "bad_request", "Item ID is required")
 		return
 	}
+	if !h.authorizePersonalListMutation(w, r, itemID) {
+		return
+	}
 
 	store, err := h.storeProvider.ForUser(r.Context(), userID)
 	if err != nil {
@@ -411,6 +425,25 @@ func (h *PersonalDataHandler) HandleRemoveFromWatchlist(w http.ResponseWriter, r
 		InWatchlist: boolPtr(false),
 	})
 	w.WriteHeader(http.StatusNoContent)
+}
+
+func (h *PersonalDataHandler) authorizePersonalListMutation(w http.ResponseWriter, r *http.Request, itemID string) bool {
+	err := authorizeACLAction(r.Context(), h.Authorizer, auth.AccessRequest{
+		UserID:       apimw.GetUserID(r.Context()),
+		ProfileID:    apimw.GetProfileID(r.Context()),
+		Action:       auth.ActionPersonalListsManage,
+		ResourceType: auth.ResourceMediaItem,
+		ResourceID:   itemID,
+	})
+	if err == nil {
+		return true
+	}
+	if errors.Is(err, errACLActionDenied) {
+		writeError(w, http.StatusForbidden, "forbidden", "Personal list changes are not allowed")
+		return false
+	}
+	writeError(w, http.StatusInternalServerError, "internal_error", "Failed to authorize personal list change")
+	return false
 }
 
 // --- History ---

--- a/internal/api/handlers/favorites_acl_test.go
+++ b/internal/api/handlers/favorites_acl_test.go
@@ -1,0 +1,141 @@
+package handlers
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/Silo-Server/silo-server/internal/auth"
+	"github.com/Silo-Server/silo-server/internal/models"
+)
+
+func TestHandleAddFavoriteRejectsWithoutPersonalListGrant(t *testing.T) {
+	store := newProfileTestStore(t)
+	authorizer := &fakeMediaConsumptionAuthorizer{
+		decision: auth.AccessDecision{Allowed: false, ReasonCode: "default_deny"},
+	}
+	handler := NewPersonalDataHandler(testUserStoreProvider{store: store}, &fakeHistoryItemRepo{
+		items: map[string]*models.MediaItem{
+			"movie-1": {ContentID: "movie-1", Type: "movie", Title: "Movie"},
+		},
+	})
+	handler.Authorizer = authorizer
+
+	req := newAuthorizedProfileRequestWithRole(http.MethodPut, "/favorites/movie-1", "", "user", "profile-1")
+	req = withProfileRouteParam(req, "item_id", "movie-1")
+	rr := httptest.NewRecorder()
+
+	handler.HandleAddFavorite(rr, req)
+
+	if rr.Code != http.StatusForbidden {
+		t.Fatalf("status = %d, body = %s", rr.Code, rr.Body.String())
+	}
+	if !authorizer.called {
+		t.Fatalf("personal list ACL authorizer was not called")
+	}
+	if authorizer.request.Action != auth.ActionPersonalListsManage {
+		t.Fatalf("action = %q, want %q", authorizer.request.Action, auth.ActionPersonalListsManage)
+	}
+	ok, err := store.IsFavorite(context.Background(), "profile-1", "movie-1")
+	if err != nil {
+		t.Fatalf("IsFavorite: %v", err)
+	}
+	if ok {
+		t.Fatalf("favorite was written despite missing grant")
+	}
+}
+
+func TestHandleAddToWatchlistRejectsWithoutPersonalListGrant(t *testing.T) {
+	store := newProfileTestStore(t)
+	authorizer := &fakeMediaConsumptionAuthorizer{
+		decision: auth.AccessDecision{Allowed: false, ReasonCode: "default_deny"},
+	}
+	handler := NewPersonalDataHandler(testUserStoreProvider{store: store}, &fakeHistoryItemRepo{
+		items: map[string]*models.MediaItem{
+			"movie-1": {ContentID: "movie-1", Type: "movie", Title: "Movie"},
+		},
+	})
+	handler.Authorizer = authorizer
+
+	req := newAuthorizedProfileRequestWithRole(http.MethodPut, "/watchlist/movie-1", "", "user", "profile-1")
+	req = withProfileRouteParam(req, "item_id", "movie-1")
+	rr := httptest.NewRecorder()
+
+	handler.HandleAddToWatchlist(rr, req)
+
+	if rr.Code != http.StatusForbidden {
+		t.Fatalf("status = %d, body = %s", rr.Code, rr.Body.String())
+	}
+	if !authorizer.called {
+		t.Fatalf("personal list ACL authorizer was not called")
+	}
+	if authorizer.request.Action != auth.ActionPersonalListsManage {
+		t.Fatalf("action = %q, want %q", authorizer.request.Action, auth.ActionPersonalListsManage)
+	}
+	ok, err := store.InWatchlist(context.Background(), "profile-1", "movie-1")
+	if err != nil {
+		t.Fatalf("InWatchlist: %v", err)
+	}
+	if ok {
+		t.Fatalf("watchlist entry was written despite missing grant")
+	}
+}
+
+func TestHandleRemoveFavoriteRejectsWithoutPersonalListGrant(t *testing.T) {
+	store := newProfileTestStore(t)
+	if err := store.AddFavorite(context.Background(), "profile-1", "movie-1"); err != nil {
+		t.Fatalf("AddFavorite: %v", err)
+	}
+	authorizer := &fakeMediaConsumptionAuthorizer{
+		decision: auth.AccessDecision{Allowed: false, ReasonCode: "default_deny"},
+	}
+	handler := NewPersonalDataHandler(testUserStoreProvider{store: store}, &fakeHistoryItemRepo{})
+	handler.Authorizer = authorizer
+
+	req := newAuthorizedProfileRequestWithRole(http.MethodDelete, "/favorites/movie-1", "", "user", "profile-1")
+	req = withProfileRouteParam(req, "item_id", "movie-1")
+	rr := httptest.NewRecorder()
+
+	handler.HandleRemoveFavorite(rr, req)
+
+	if rr.Code != http.StatusForbidden {
+		t.Fatalf("status = %d, body = %s", rr.Code, rr.Body.String())
+	}
+	ok, err := store.IsFavorite(context.Background(), "profile-1", "movie-1")
+	if err != nil {
+		t.Fatalf("IsFavorite: %v", err)
+	}
+	if !ok {
+		t.Fatalf("favorite was removed despite missing grant")
+	}
+}
+
+func TestHandleRemoveFromWatchlistRejectsWithoutPersonalListGrant(t *testing.T) {
+	store := newProfileTestStore(t)
+	if err := store.AddToWatchlist(context.Background(), "profile-1", "movie-1"); err != nil {
+		t.Fatalf("AddToWatchlist: %v", err)
+	}
+	authorizer := &fakeMediaConsumptionAuthorizer{
+		decision: auth.AccessDecision{Allowed: false, ReasonCode: "default_deny"},
+	}
+	handler := NewPersonalDataHandler(testUserStoreProvider{store: store}, &fakeHistoryItemRepo{})
+	handler.Authorizer = authorizer
+
+	req := newAuthorizedProfileRequestWithRole(http.MethodDelete, "/watchlist/movie-1", "", "user", "profile-1")
+	req = withProfileRouteParam(req, "item_id", "movie-1")
+	rr := httptest.NewRecorder()
+
+	handler.HandleRemoveFromWatchlist(rr, req)
+
+	if rr.Code != http.StatusForbidden {
+		t.Fatalf("status = %d, body = %s", rr.Code, rr.Body.String())
+	}
+	ok, err := store.InWatchlist(context.Background(), "profile-1", "movie-1")
+	if err != nil {
+		t.Fatalf("InWatchlist: %v", err)
+	}
+	if !ok {
+		t.Fatalf("watchlist entry was removed despite missing grant")
+	}
+}

--- a/internal/api/handlers/media_file_auth.go
+++ b/internal/api/handlers/media_file_auth.go
@@ -1,9 +1,11 @@
 package handlers
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"net/http"
+	"strings"
 
 	apimw "github.com/Silo-Server/silo-server/internal/api/middleware"
 	"github.com/Silo-Server/silo-server/internal/auth"
@@ -17,7 +19,12 @@ type MediaFileAuthorizer struct {
 	FileResolver          FilePathResolver
 	ItemAccess            PlaybackItemAccessChecker
 	EpisodeLookup         PlaybackEpisodeLookup
+	ItemLookup            MediaItemLookup
 	ConsumptionAuthorizer auth.Authorizer
+}
+
+type MediaItemLookup interface {
+	GetByID(ctx context.Context, contentID string) (*models.MediaItem, error)
 }
 
 // Authorize returns the media file when the caller may access it, or catalog.ErrItemNotFound.
@@ -63,7 +70,11 @@ func (a *MediaFileAuthorizer) Authorize(r *http.Request, fileID int) (*models.Me
 	if !catalog.FileAllowedByAccess(file, filter) {
 		return nil, catalog.ErrItemNotFound
 	}
-	if err := authorizeMediaConsumption(r, a.ConsumptionAuthorizer, file, resourceID); err != nil {
+	contentRating, err := lookupMediaContentRating(r.Context(), a.ItemLookup, resourceID)
+	if err != nil {
+		return nil, err
+	}
+	if err := authorizeMediaPlaybackAction(r, a.ConsumptionAuthorizer, file, resourceID, auth.ActionPlaybackPlay, "", contentRating); err != nil {
 		return nil, err
 	}
 
@@ -73,6 +84,18 @@ func (a *MediaFileAuthorizer) Authorize(r *http.Request, fileID int) (*models.Me
 var errMediaConsumptionForbidden = errors.New("media consumption forbidden")
 
 func authorizeMediaConsumption(r *http.Request, authorizer auth.Authorizer, file *models.MediaFile, resourceID string) error {
+	return authorizeMediaPlaybackAction(r, authorizer, file, resourceID, auth.ActionPlaybackPlay, "", "")
+}
+
+func authorizeMediaPlaybackAction(
+	r *http.Request,
+	authorizer auth.Authorizer,
+	file *models.MediaFile,
+	resourceID string,
+	action auth.ACLAction,
+	playbackQuality string,
+	contentRating string,
+) error {
 	if authorizer == nil {
 		return nil
 	}
@@ -87,18 +110,44 @@ func authorizeMediaConsumption(r *http.Request, authorizer auth.Authorizer, file
 		libraryIDs = []int{file.MediaFolderID}
 	}
 	err := authorizeACLAction(r.Context(), authorizer, auth.AccessRequest{
-		UserID:       apimw.GetUserID(r.Context()),
-		ProfileID:    apimw.GetProfileID(r.Context()),
-		Action:       auth.ActionPlaybackPlay,
-		ResourceType: auth.ResourceMediaItem,
-		ResourceID:   resourceID,
-		LibraryIDs:   libraryIDs,
-		MediaType:    file.BaseType,
+		UserID:          apimw.GetUserID(r.Context()),
+		ProfileID:       apimw.GetProfileID(r.Context()),
+		Action:          action,
+		ResourceType:    auth.ResourceMediaItem,
+		ResourceID:      resourceID,
+		LibraryIDs:      libraryIDs,
+		MediaType:       file.BaseType,
+		PlaybackQuality: mediaPlaybackQuality(file, playbackQuality),
+		ContentRating:   strings.TrimSpace(contentRating),
 	})
 	if errors.Is(err, errACLActionDenied) {
 		return errMediaConsumptionForbidden
 	}
 	return err
+}
+
+func mediaPlaybackQuality(file *models.MediaFile, requestedQuality string) string {
+	if quality := strings.TrimSpace(requestedQuality); quality != "" {
+		return quality
+	}
+	if file == nil {
+		return ""
+	}
+	return strings.TrimSpace(file.Resolution)
+}
+
+func lookupMediaContentRating(ctx context.Context, lookup MediaItemLookup, resourceID string) (string, error) {
+	if lookup == nil || strings.TrimSpace(resourceID) == "" {
+		return "", nil
+	}
+	item, err := lookup.GetByID(ctx, resourceID)
+	if err != nil {
+		return "", err
+	}
+	if item == nil {
+		return "", nil
+	}
+	return strings.TrimSpace(item.ContentRating), nil
 }
 
 func mapMediaFileLookupError(err error) error {

--- a/internal/api/handlers/media_file_auth.go
+++ b/internal/api/handlers/media_file_auth.go
@@ -5,6 +5,8 @@ import (
 	"fmt"
 	"net/http"
 
+	apimw "github.com/Silo-Server/silo-server/internal/api/middleware"
+	"github.com/Silo-Server/silo-server/internal/auth"
 	"github.com/Silo-Server/silo-server/internal/catalog"
 	"github.com/Silo-Server/silo-server/internal/models"
 	"github.com/Silo-Server/silo-server/internal/scanner"
@@ -12,9 +14,10 @@ import (
 
 // MediaFileAuthorizer validates that the authenticated user can access a media file.
 type MediaFileAuthorizer struct {
-	FileResolver  FilePathResolver
-	ItemAccess    PlaybackItemAccessChecker
-	EpisodeLookup PlaybackEpisodeLookup
+	FileResolver          FilePathResolver
+	ItemAccess            PlaybackItemAccessChecker
+	EpisodeLookup         PlaybackEpisodeLookup
+	ConsumptionAuthorizer auth.Authorizer
 }
 
 // Authorize returns the media file when the caller may access it, or catalog.ErrItemNotFound.
@@ -32,6 +35,7 @@ func (a *MediaFileAuthorizer) Authorize(r *http.Request, fileID int) (*models.Me
 	}
 
 	filter := requestAccessFilter(r)
+	resourceID := file.ContentID
 	switch {
 	case file.EpisodeID != "":
 		if a.EpisodeLookup == nil {
@@ -44,6 +48,7 @@ func (a *MediaFileAuthorizer) Authorize(r *http.Request, fileID int) (*models.Me
 		if episode == nil {
 			return nil, catalog.ErrEpisodeNotFound
 		}
+		resourceID = episode.SeriesID
 		if err := a.ItemAccess.EnsureAccessible(r.Context(), episode.SeriesID, filter); err != nil {
 			return nil, err
 		}
@@ -58,8 +63,42 @@ func (a *MediaFileAuthorizer) Authorize(r *http.Request, fileID int) (*models.Me
 	if !catalog.FileAllowedByAccess(file, filter) {
 		return nil, catalog.ErrItemNotFound
 	}
+	if err := authorizeMediaConsumption(r, a.ConsumptionAuthorizer, file, resourceID); err != nil {
+		return nil, err
+	}
 
 	return file, nil
+}
+
+var errMediaConsumptionForbidden = errors.New("media consumption forbidden")
+
+func authorizeMediaConsumption(r *http.Request, authorizer auth.Authorizer, file *models.MediaFile, resourceID string) error {
+	if authorizer == nil {
+		return nil
+	}
+	if file == nil {
+		return catalog.ErrItemNotFound
+	}
+	if resourceID == "" {
+		return catalog.ErrItemNotFound
+	}
+	libraryIDs := []int(nil)
+	if file.MediaFolderID > 0 {
+		libraryIDs = []int{file.MediaFolderID}
+	}
+	err := authorizeACLAction(r.Context(), authorizer, auth.AccessRequest{
+		UserID:       apimw.GetUserID(r.Context()),
+		ProfileID:    apimw.GetProfileID(r.Context()),
+		Action:       auth.ActionPlaybackPlay,
+		ResourceType: auth.ResourceMediaItem,
+		ResourceID:   resourceID,
+		LibraryIDs:   libraryIDs,
+		MediaType:    file.BaseType,
+	})
+	if errors.Is(err, errACLActionDenied) {
+		return errMediaConsumptionForbidden
+	}
+	return err
 }
 
 func mapMediaFileLookupError(err error) error {

--- a/internal/api/handlers/media_file_auth_test.go
+++ b/internal/api/handlers/media_file_auth_test.go
@@ -1,6 +1,7 @@
 package handlers
 
 import (
+	"context"
 	"errors"
 	"net/http"
 	"net/http/httptest"
@@ -13,6 +14,24 @@ import (
 	"github.com/Silo-Server/silo-server/internal/scanner"
 	"github.com/Silo-Server/silo-server/internal/subtitles"
 )
+
+type fakeMediaConsumptionAuthorizer struct {
+	decision auth.AccessDecision
+	request  auth.AccessRequest
+	err      error
+	called   bool
+}
+
+func (f *fakeMediaConsumptionAuthorizer) Authorize(_ context.Context, request auth.AccessRequest) (auth.AccessDecision, error) {
+	f.called = true
+	f.request = request
+	return f.decision, f.err
+}
+
+func (f *fakeMediaConsumptionAuthorizer) Explain(_ context.Context, request auth.AccessRequest) (auth.AccessExplanation, error) {
+	decision, err := f.Authorize(context.Background(), request)
+	return auth.AccessExplanation{Request: request, Decision: decision}, err
+}
 
 func TestMediaFileAuthorizerMapsMissingFileToNotFound(t *testing.T) {
 	authorizer := &MediaFileAuthorizer{

--- a/internal/api/handlers/media_file_auth_test.go
+++ b/internal/api/handlers/media_file_auth_test.go
@@ -16,21 +16,38 @@ import (
 )
 
 type fakeMediaConsumptionAuthorizer struct {
-	decision auth.AccessDecision
-	request  auth.AccessRequest
-	err      error
-	called   bool
+	decision  auth.AccessDecision
+	decisions map[auth.ACLAction]auth.AccessDecision
+	request   auth.AccessRequest
+	requests  []auth.AccessRequest
+	err       error
+	called    bool
 }
 
 func (f *fakeMediaConsumptionAuthorizer) Authorize(_ context.Context, request auth.AccessRequest) (auth.AccessDecision, error) {
 	f.called = true
 	f.request = request
+	f.requests = append(f.requests, request)
+	if f.decisions != nil {
+		if decision, ok := f.decisions[request.Action]; ok {
+			return decision, f.err
+		}
+	}
 	return f.decision, f.err
 }
 
 func (f *fakeMediaConsumptionAuthorizer) Explain(_ context.Context, request auth.AccessRequest) (auth.AccessExplanation, error) {
 	decision, err := f.Authorize(context.Background(), request)
 	return auth.AccessExplanation{Request: request, Decision: decision}, err
+}
+
+type stubMediaItemLookup struct {
+	item *models.MediaItem
+	err  error
+}
+
+func (s stubMediaItemLookup) GetByID(context.Context, string) (*models.MediaItem, error) {
+	return s.item, s.err
 }
 
 func TestMediaFileAuthorizerMapsMissingFileToNotFound(t *testing.T) {
@@ -108,6 +125,45 @@ func TestMediaFileAuthorizerAllowsAccessibleFile(t *testing.T) {
 	}
 	if file == nil || file.ID != 42 {
 		t.Fatalf("file = %#v, want id 42", file)
+	}
+}
+
+func TestMediaFileAuthorizerPopulatesPlaybackACLFacts(t *testing.T) {
+	consumptionAuthorizer := &fakeMediaConsumptionAuthorizer{
+		decision: auth.AccessDecision{Allowed: true},
+	}
+	authorizer := &MediaFileAuthorizer{
+		FileResolver: stubMediaFileResolver{
+			file: &models.MediaFile{
+				ID:            42,
+				ContentID:     "movie-1",
+				MediaFolderID: 10,
+				BaseType:      "movie",
+				Resolution:    "2160p",
+			},
+		},
+		ItemAccess:            stubItemAccessChecker{},
+		ItemLookup:            stubMediaItemLookup{item: &models.MediaItem{ContentID: "movie-1", ContentRating: "TV-MA"}},
+		ConsumptionAuthorizer: consumptionAuthorizer,
+	}
+
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	req = req.WithContext(apimw.SetClaims(req.Context(), &auth.Claims{
+		UserID:    1,
+		TokenType: auth.TokenTypeAccess,
+	}))
+
+	if _, err := authorizer.Authorize(req, 42); err != nil {
+		t.Fatalf("Authorize() error = %v", err)
+	}
+	if !consumptionAuthorizer.called {
+		t.Fatal("playback ACL authorizer was not called")
+	}
+	if consumptionAuthorizer.request.PlaybackQuality != "2160p" {
+		t.Fatalf("playback quality = %q, want 2160p", consumptionAuthorizer.request.PlaybackQuality)
+	}
+	if consumptionAuthorizer.request.ContentRating != "TV-MA" {
+		t.Fatalf("content rating = %q, want TV-MA", consumptionAuthorizer.request.ContentRating)
 	}
 }
 

--- a/internal/api/handlers/playback.go
+++ b/internal/api/handlers/playback.go
@@ -20,6 +20,7 @@ import (
 	"github.com/go-chi/chi/v5"
 
 	apimw "github.com/Silo-Server/silo-server/internal/api/middleware"
+	"github.com/Silo-Server/silo-server/internal/auth"
 	"github.com/Silo-Server/silo-server/internal/catalog"
 	"github.com/Silo-Server/silo-server/internal/clientip"
 	"github.com/Silo-Server/silo-server/internal/config"
@@ -113,7 +114,8 @@ type PlaybackHandler struct {
 	NodePlanner             nodepool.SessionPlanner   // optional; enables proxy/transcode node selection
 	JWTSecret               string                    // needed for signing stream tokens
 	ItemAccess              PlaybackItemAccessChecker // optional; enables file authorization checks
-	EpisodeLookup           PlaybackEpisodeLookup     // optional; resolves episode files to their series
+	AccessAuthorizer        auth.Authorizer
+	EpisodeLookup           PlaybackEpisodeLookup // optional; resolves episode files to their series
 	OriginalLangLookup      PlaybackOriginalLanguageLookup
 	SettingsRepo            PlaybackSettingsReader     // optional; reads server settings (e.g., allow_4k_transcode)
 	FileVersionFetcher      PlaybackFileVersionFetcher // optional; queries sibling file versions for 4K guard
@@ -1156,6 +1158,8 @@ func (h *PlaybackHandler) HandleStartPlayback(w http.ResponseWriter, r *http.Req
 	file, err := h.loadAuthorizedFile(r, req.FileID)
 	if err != nil {
 		switch {
+		case errors.Is(err, errMediaConsumptionForbidden):
+			writeError(w, http.StatusForbidden, "forbidden", "Playback is not allowed")
 		case errors.Is(err, catalog.ErrItemNotFound), errors.Is(err, catalog.ErrEpisodeNotFound):
 			writeError(w, http.StatusNotFound, "not_found", "Media file not found")
 		default:
@@ -1854,6 +1858,7 @@ func (h *PlaybackHandler) loadAuthorizedFile(r *http.Request, fileID int) (*mode
 	}
 
 	filter := requestAccessFilter(r)
+	resourceID := file.ContentID
 	switch {
 	case file.EpisodeID != "":
 		if h.EpisodeLookup == nil {
@@ -1866,6 +1871,7 @@ func (h *PlaybackHandler) loadAuthorizedFile(r *http.Request, fileID int) (*mode
 		if episode == nil {
 			return nil, catalog.ErrEpisodeNotFound
 		}
+		resourceID = episode.SeriesID
 		if err := h.ItemAccess.EnsureAccessible(r.Context(), episode.SeriesID, filter); err != nil {
 			return nil, err
 		}
@@ -1879,6 +1885,9 @@ func (h *PlaybackHandler) loadAuthorizedFile(r *http.Request, fileID int) (*mode
 
 	if !catalog.FileAllowedByAccess(file, filter) {
 		return nil, catalog.ErrItemNotFound
+	}
+	if err := authorizeMediaConsumption(r, h.AccessAuthorizer, file, resourceID); err != nil {
+		return nil, err
 	}
 
 	return file, nil

--- a/internal/api/handlers/playback.go
+++ b/internal/api/handlers/playback.go
@@ -116,6 +116,7 @@ type PlaybackHandler struct {
 	ItemAccess              PlaybackItemAccessChecker // optional; enables file authorization checks
 	AccessAuthorizer        auth.Authorizer
 	EpisodeLookup           PlaybackEpisodeLookup // optional; resolves episode files to their series
+	ItemLookup              MediaItemLookup
 	OriginalLangLookup      PlaybackOriginalLanguageLookup
 	SettingsRepo            PlaybackSettingsReader     // optional; reads server settings (e.g., allow_4k_transcode)
 	FileVersionFetcher      PlaybackFileVersionFetcher // optional; queries sibling file versions for 4K guard
@@ -1886,11 +1887,59 @@ func (h *PlaybackHandler) loadAuthorizedFile(r *http.Request, fileID int) (*mode
 	if !catalog.FileAllowedByAccess(file, filter) {
 		return nil, catalog.ErrItemNotFound
 	}
-	if err := authorizeMediaConsumption(r, h.AccessAuthorizer, file, resourceID); err != nil {
+	contentRating, err := lookupMediaContentRating(r.Context(), h.ItemLookup, resourceID)
+	if err != nil {
+		return nil, err
+	}
+	if err := authorizeMediaPlaybackAction(r, h.AccessAuthorizer, file, resourceID, auth.ActionPlaybackPlay, "", contentRating); err != nil {
 		return nil, err
 	}
 
 	return file, nil
+}
+
+func (h *PlaybackHandler) playbackResourceID(ctx context.Context, file *models.MediaFile) (string, error) {
+	if file == nil {
+		return "", catalog.ErrItemNotFound
+	}
+	switch {
+	case file.EpisodeID != "":
+		if h.EpisodeLookup == nil {
+			return "", fmt.Errorf("episode lookup not configured")
+		}
+		episode, err := h.EpisodeLookup.GetByID(ctx, file.EpisodeID)
+		if err != nil {
+			return "", err
+		}
+		if episode == nil {
+			return "", catalog.ErrEpisodeNotFound
+		}
+		return episode.SeriesID, nil
+	case file.ContentID != "":
+		return file.ContentID, nil
+	default:
+		return "", catalog.ErrItemNotFound
+	}
+}
+
+func (h *PlaybackHandler) authorizeTranscodeStart(r *http.Request, file *models.MediaFile, targetResolution string) error {
+	resourceID, err := h.playbackResourceID(r.Context(), file)
+	if err != nil {
+		return err
+	}
+	contentRating, err := lookupMediaContentRating(r.Context(), h.ItemLookup, resourceID)
+	if err != nil {
+		return err
+	}
+	return authorizeMediaPlaybackAction(
+		r,
+		h.AccessAuthorizer,
+		file,
+		resourceID,
+		auth.ActionPlaybackTranscode,
+		targetResolution,
+		contentRating,
+	)
 }
 
 // computeStartSegment returns the HLS segment number corresponding to a seek
@@ -1995,13 +2044,6 @@ func (h *PlaybackHandler) HandleStartTranscode(w http.ResponseWriter, r *http.Re
 		writeError(w, http.StatusForbidden, "forbidden", "Session belongs to another user")
 		return
 	}
-	// Close any existing transcode so a new one can start at different quality.
-	// Check both local sessions AND remote node assignments — without the
-	// remote check, switching quality on a transcode node never sends DELETE,
-	// leaving the old ffmpeg running and its segments on disk.
-	if h.getTranscodeSession(req.SessionID) != nil || session.TranscodeNodeURL != "" {
-		h.closeTranscodeSession(req.SessionID, session.TranscodeNodeURL)
-	}
 	abortCurrentSession := func(reason string, cause error) {
 		if abortErr := h.abortPlaybackSession(r.Context(), session); abortErr != nil && !errors.Is(abortErr, playback.ErrSessionNotFound) {
 			slog.Error("failed to abort playback session",
@@ -2077,12 +2119,30 @@ func (h *PlaybackHandler) HandleStartTranscode(w http.ResponseWriter, r *http.Re
 			)
 		}
 	}
+	if err := h.authorizeTranscodeStart(r, file, req.TargetResolution); err != nil {
+		switch {
+		case errors.Is(err, errMediaConsumptionForbidden):
+			writeError(w, http.StatusForbidden, "forbidden", "Transcoding is not allowed")
+		case errors.Is(err, catalog.ErrItemNotFound), errors.Is(err, catalog.ErrEpisodeNotFound):
+			writeError(w, http.StatusNotFound, "not_found", "Media file not found")
+		default:
+			writeError(w, http.StatusInternalServerError, "internal_error", "Failed to authorize transcode")
+		}
+		return
+	}
 	if err := preflightPlaybackFile(r.Context(), file, h.MissingMarker, h.EventsHub); err != nil {
 		if isPlaybackFileMissing(err) {
 			abortCurrentSession("preflight_file", err)
 		}
 		writePlaybackFilePreflightError(w, err)
 		return
+	}
+	// Close any existing transcode so a new one can start at different quality.
+	// Check both local sessions AND remote node assignments — without the
+	// remote check, switching quality on a transcode node never sends DELETE,
+	// leaving the old ffmpeg running and its segments on disk.
+	if h.getTranscodeSession(req.SessionID) != nil || session.TranscodeNodeURL != "" {
+		h.closeTranscodeSession(req.SessionID, session.TranscodeNodeURL)
 	}
 
 	// Determine whether to run locally or forward to a remote transcode node.

--- a/internal/api/handlers/playback_test.go
+++ b/internal/api/handlers/playback_test.go
@@ -298,6 +298,49 @@ func TestHandleStartPlayback_UsesExplicitZeroStartPositionInsteadOfStoredResume(
 	}
 }
 
+func TestHandleStartPlayback_RejectsWithoutPlaybackPlayGrant(t *testing.T) {
+	file := &models.MediaFile{
+		ID:            42,
+		ContentID:     "movie-1",
+		MediaFolderID: 10,
+		BaseType:      "movie",
+		FilePath:      writePlaybackTestMediaFile(t, "movie.mp4"),
+		Container:     "mp4",
+		Duration:      120,
+	}
+	authorizer := &fakeMediaConsumptionAuthorizer{
+		decision: auth.AccessDecision{Allowed: false, ReasonCode: "default_deny"},
+	}
+	handler := NewPlaybackHandler(playback.NewSessionManager(0, 0), testPlaybackFileResolver{file: file})
+	handler.ItemAccess = allowAllPlaybackItemAccess{}
+	handler.AccessAuthorizer = authorizer
+
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/playback/start", strings.NewReader(`{"file_id":42,"profile_id":"profile-1","play_method":"direct"}`))
+	req = req.WithContext(newAuthorizedPlaybackContext())
+	rr := httptest.NewRecorder()
+
+	handler.HandleStartPlayback(rr, req)
+
+	if rr.Code != http.StatusForbidden {
+		t.Fatalf("status = %d, body = %s", rr.Code, rr.Body.String())
+	}
+	if !authorizer.called {
+		t.Fatalf("playback ACL authorizer was not called")
+	}
+	if authorizer.request.Action != auth.ActionPlaybackPlay {
+		t.Fatalf("action = %q, want %q", authorizer.request.Action, auth.ActionPlaybackPlay)
+	}
+	if authorizer.request.ResourceType != auth.ResourceMediaItem || authorizer.request.ResourceID != "movie-1" {
+		t.Fatalf("resource = %s/%q, want media_item/movie-1", authorizer.request.ResourceType, authorizer.request.ResourceID)
+	}
+	if len(authorizer.request.LibraryIDs) != 1 || authorizer.request.LibraryIDs[0] != 10 {
+		t.Fatalf("library ids = %#v, want [10]", authorizer.request.LibraryIDs)
+	}
+	if authorizer.request.MediaType != "movie" {
+		t.Fatalf("media type = %q, want movie", authorizer.request.MediaType)
+	}
+}
+
 func TestPlaybackSessionProgressPersistenceCanBeDisabled(t *testing.T) {
 	store := newPlaybackTestStore(t)
 	if err := store.SetProgress(context.Background(), "profile-1", "book-1", 500, 1200, userstore.ProgressThresholds{}); err != nil {

--- a/internal/api/handlers/playback_test.go
+++ b/internal/api/handlers/playback_test.go
@@ -306,6 +306,7 @@ func TestHandleStartPlayback_RejectsWithoutPlaybackPlayGrant(t *testing.T) {
 		BaseType:      "movie",
 		FilePath:      writePlaybackTestMediaFile(t, "movie.mp4"),
 		Container:     "mp4",
+		Resolution:    "2160p",
 		Duration:      120,
 	}
 	authorizer := &fakeMediaConsumptionAuthorizer{
@@ -313,6 +314,7 @@ func TestHandleStartPlayback_RejectsWithoutPlaybackPlayGrant(t *testing.T) {
 	}
 	handler := NewPlaybackHandler(playback.NewSessionManager(0, 0), testPlaybackFileResolver{file: file})
 	handler.ItemAccess = allowAllPlaybackItemAccess{}
+	handler.ItemLookup = stubMediaItemLookup{item: &models.MediaItem{ContentID: "movie-1", ContentRating: "TV-MA"}}
 	handler.AccessAuthorizer = authorizer
 
 	req := httptest.NewRequest(http.MethodPost, "/api/v1/playback/start", strings.NewReader(`{"file_id":42,"profile_id":"profile-1","play_method":"direct"}`))
@@ -338,6 +340,78 @@ func TestHandleStartPlayback_RejectsWithoutPlaybackPlayGrant(t *testing.T) {
 	}
 	if authorizer.request.MediaType != "movie" {
 		t.Fatalf("media type = %q, want movie", authorizer.request.MediaType)
+	}
+	if authorizer.request.PlaybackQuality != "2160p" {
+		t.Fatalf("playback quality = %q, want 2160p", authorizer.request.PlaybackQuality)
+	}
+	if authorizer.request.ContentRating != "TV-MA" {
+		t.Fatalf("content rating = %q, want TV-MA", authorizer.request.ContentRating)
+	}
+}
+
+func TestHandleStartTranscode_RejectsWithoutPlaybackTranscodeGrant(t *testing.T) {
+	file := &models.MediaFile{
+		ID:            42,
+		ContentID:     "movie-1",
+		MediaFolderID: 10,
+		BaseType:      "movie",
+		FilePath:      writePlaybackTestMediaFile(t, "movie.mp4"),
+		Container:     "mp4",
+		Resolution:    "1080p",
+		Duration:      120,
+		CodecVideo:    "h264",
+		CodecAudio:    "aac",
+	}
+	authorizer := &fakeMediaConsumptionAuthorizer{
+		decision: auth.AccessDecision{Allowed: true},
+		decisions: map[auth.ACLAction]auth.AccessDecision{
+			auth.ActionPlaybackTranscode: {Allowed: false, ReasonCode: "default_deny"},
+		},
+	}
+	sessionMgr := playback.NewSessionManager(0, 0)
+	handler := NewPlaybackHandler(sessionMgr, testPlaybackFileResolver{file: file})
+	handler.ItemAccess = allowAllPlaybackItemAccess{}
+	handler.ItemLookup = stubMediaItemLookup{item: &models.MediaItem{ContentID: "movie-1", ContentRating: "PG-13"}}
+	handler.AccessAuthorizer = authorizer
+	handler.PlaybackConfig = playbackTestConfig("", t.TempDir())
+
+	startReq := httptest.NewRequest(http.MethodPost, "/api/v1/playback/start", strings.NewReader(`{"file_id":42,"profile_id":"profile-1","play_method":"direct"}`))
+	startReq = startReq.WithContext(newAuthorizedPlaybackContext())
+	startRR := httptest.NewRecorder()
+	handler.HandleStartPlayback(startRR, startReq)
+	if startRR.Code != http.StatusCreated {
+		t.Fatalf("start playback status = %d, body = %s", startRR.Code, startRR.Body.String())
+	}
+	var startResp playbackSessionResponse
+	if err := json.Unmarshal(startRR.Body.Bytes(), &startResp); err != nil {
+		t.Fatalf("decode start response: %v", err)
+	}
+
+	transcodeReq := httptest.NewRequest(http.MethodPost, "/api/v1/playback/transcode/start", strings.NewReader(`{"session_id":"`+startResp.SessionID+`","target_resolution":"720p","target_codec_video":"h264","target_codec_audio":"aac"}`))
+	transcodeReq = transcodeReq.WithContext(newAuthorizedPlaybackContext())
+	transcodeRR := httptest.NewRecorder()
+	handler.HandleStartTranscode(transcodeRR, transcodeReq)
+
+	if transcodeRR.Code != http.StatusForbidden {
+		t.Fatalf("transcode status = %d, body = %s", transcodeRR.Code, transcodeRR.Body.String())
+	}
+	foundTranscodeCheck := false
+	for _, request := range authorizer.requests {
+		if request.Action == auth.ActionPlaybackTranscode {
+			foundTranscodeCheck = true
+			if request.ResourceType != auth.ResourceMediaItem || request.ResourceID != "movie-1" {
+				t.Fatalf("transcode resource = %s/%q, want media_item/movie-1", request.ResourceType, request.ResourceID)
+			}
+			if request.PlaybackQuality != "720p" {
+				t.Fatalf("transcode playback quality = %q, want 720p", request.PlaybackQuality)
+			}
+			if request.ContentRating != "PG-13" {
+				t.Fatalf("transcode content rating = %q, want PG-13", request.ContentRating)
+			}
+		}
+	}
+	if !foundTranscodeCheck {
+		t.Fatal("transcode ACL authorizer was not called")
 	}
 }
 

--- a/internal/api/handlers/profiles.go
+++ b/internal/api/handlers/profiles.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/Silo-Server/silo-server/internal/access"
 	apimw "github.com/Silo-Server/silo-server/internal/api/middleware"
+	"github.com/Silo-Server/silo-server/internal/auth"
 	"github.com/Silo-Server/silo-server/internal/models"
 	"github.com/Silo-Server/silo-server/internal/userstore"
 )
@@ -25,9 +26,10 @@ type ProfileHandler struct {
 	UserRepo       interface {
 		GetByID(ctx context.Context, id int) (*models.User, error)
 	}
-	ProfileTokens *access.ProfileTokenService
-	AvatarStore   profileAvatarStore
-	AvatarTTL     time.Duration
+	ProfileTokens    *access.ProfileTokenService
+	AvatarStore      profileAvatarStore
+	AvatarTTL        time.Duration
+	AccessAuthorizer auth.Authorizer
 }
 
 // NewProfileHandler creates a new ProfileHandler.
@@ -329,12 +331,13 @@ func (h *ProfileHandler) HandleCreateProfile(w http.ResponseWriter, r *http.Requ
 			writeError(w, http.StatusInternalServerError, "internal_error", "Failed to load user")
 			return
 		}
-		if user != nil && user.MaxProfiles >= 1 && len(existingProfiles) >= user.MaxProfiles {
+		maxProfiles := h.effectiveMaxProfiles(r.Context(), user)
+		if maxProfiles >= 1 && len(existingProfiles) >= maxProfiles {
 			writeError(
 				w,
 				http.StatusConflict,
 				"profile_limit_reached",
-				fmt.Sprintf("This account has reached its profile limit (%d)", user.MaxProfiles),
+				fmt.Sprintf("This account has reached its profile limit (%d)", maxProfiles),
 			)
 			return
 		}
@@ -412,6 +415,29 @@ func (h *ProfileHandler) HandleCreateProfile(w http.ResponseWriter, r *http.Requ
 	}
 
 	writeJSON(w, http.StatusCreated, h.toProfileResponse(r.Context(), created))
+}
+
+func (h *ProfileHandler) effectiveMaxProfiles(ctx context.Context, user *models.User) int {
+	if user == nil {
+		return 0
+	}
+	maxProfiles := user.MaxProfiles
+	if h.AccessAuthorizer == nil {
+		return maxProfiles
+	}
+	decision, err := h.AccessAuthorizer.Authorize(ctx, auth.AccessRequest{
+		UserID:       user.ID,
+		Action:       auth.ActionProfilesManage,
+		ResourceType: auth.ResourceProfile,
+		ResourceID:   "*",
+	})
+	if err != nil {
+		return maxProfiles
+	}
+	if decision.EffectivePolicy.MaxProfiles > 0 {
+		return decision.EffectivePolicy.MaxProfiles
+	}
+	return maxProfiles
 }
 
 // HandleUpdateProfile handles PUT /profiles/{id}.

--- a/internal/api/handlers/profiles_test.go
+++ b/internal/api/handlers/profiles_test.go
@@ -134,6 +134,40 @@ func TestHandleCreateProfile_EnforcesUserProfileLimit(t *testing.T) {
 	}
 }
 
+func TestHandleCreateProfile_EnforcesACLProfileLimit(t *testing.T) {
+	store := newProfileTestStore(t)
+	handler := NewProfileHandler(testUserStoreProvider{store: store})
+	handler.UserRepo = testProfileUserRepo{
+		user: &models.User{ID: 1, MaxProfiles: 5},
+	}
+	handler.AccessAuthorizer = &fakeHandlerAdminAuthorizer{
+		decision: auth.AccessDecision{
+			Allowed: true,
+			EffectivePolicy: auth.EffectivePolicy{
+				MaxProfiles: 1,
+			},
+		},
+	}
+
+	req := newAuthorizedProfileRequestWithRole(
+		http.MethodPost,
+		"/profiles",
+		`{"name":"Kids","max_playback_quality":"1080p"}`,
+		"admin",
+		"",
+	)
+	rr := httptest.NewRecorder()
+
+	handler.HandleCreateProfile(rr, req)
+
+	if rr.Code != http.StatusConflict {
+		t.Fatalf("status = %d, body = %s", rr.Code, rr.Body.String())
+	}
+	if !strings.Contains(rr.Body.String(), "profile limit (1)") {
+		t.Fatalf("body = %s", rr.Body.String())
+	}
+}
+
 func TestHandleCreateProfile_AllowsNonAdminUpToCap(t *testing.T) {
 	store := newProfileTestStore(t)
 	handler := NewProfileHandler(testUserStoreProvider{store: store})

--- a/internal/api/handlers/recommendations.go
+++ b/internal/api/handlers/recommendations.go
@@ -12,6 +12,7 @@ import (
 	"github.com/go-chi/chi/v5"
 
 	apimw "github.com/Silo-Server/silo-server/internal/api/middleware"
+	"github.com/Silo-Server/silo-server/internal/auth"
 	"github.com/Silo-Server/silo-server/internal/catalog"
 	"github.com/Silo-Server/silo-server/internal/models"
 	"github.com/Silo-Server/silo-server/internal/recommendations"
@@ -48,6 +49,7 @@ type RecommendationsHandler struct {
 	EpisodeRepo         *catalog.EpisodeRepository
 	WatchTonightFetcher watchTonightSectionFetcher
 	CastFetcher         cardsCastFetcher
+	Authorizer          auth.Authorizer
 	EbookProgress       EbookReaderProgressLister
 	// RecWorker enqueues asynchronous taste-profile refreshes after writes
 	// (taste seeding). Optional — when nil, refresh is simply skipped.

--- a/internal/api/handlers/requests.go
+++ b/internal/api/handlers/requests.go
@@ -13,6 +13,7 @@ import (
 	"github.com/go-chi/chi/v5"
 
 	apimw "github.com/Silo-Server/silo-server/internal/api/middleware"
+	"github.com/Silo-Server/silo-server/internal/auth"
 	mediarequests "github.com/Silo-Server/silo-server/internal/requests"
 )
 
@@ -49,7 +50,8 @@ type RequestService interface {
 }
 
 type RequestsHandler struct {
-	service RequestService
+	service    RequestService
+	Authorizer auth.Authorizer
 }
 
 func NewRequestsHandler(service RequestService) *RequestsHandler {
@@ -238,6 +240,9 @@ func (h *RequestsHandler) HandleCreate(w http.ResponseWriter, r *http.Request) {
 	if !ok {
 		return
 	}
+	if !h.authorizeRequestCreate(w, r, viewer) {
+		return
+	}
 	var input mediarequests.CreateRequestInput
 	if err := json.NewDecoder(r.Body).Decode(&input); err != nil {
 		writeError(w, http.StatusBadRequest, "bad_request", "Invalid request body")
@@ -249,6 +254,25 @@ func (h *RequestsHandler) HandleCreate(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	writeJSON(w, http.StatusCreated, req)
+}
+
+func (h *RequestsHandler) authorizeRequestCreate(w http.ResponseWriter, r *http.Request, viewer mediarequests.Viewer) bool {
+	err := authorizeACLAction(r.Context(), h.Authorizer, auth.AccessRequest{
+		UserID:       viewer.UserID,
+		ProfileID:    viewer.ProfileID,
+		Action:       auth.ActionRequestsCreate,
+		ResourceType: auth.ResourceRequest,
+		ResourceID:   "*",
+	})
+	if err == nil {
+		return true
+	}
+	if errors.Is(err, errACLActionDenied) {
+		writeError(w, http.StatusForbidden, "forbidden", "Media requests are not allowed")
+		return false
+	}
+	writeError(w, http.StatusInternalServerError, "internal_error", "Failed to authorize media request")
+	return false
 }
 
 func (h *RequestsHandler) HandleListMine(w http.ResponseWriter, r *http.Request) {

--- a/internal/api/handlers/requests_test.go
+++ b/internal/api/handlers/requests_test.go
@@ -20,6 +20,7 @@ type fakeRequestService struct {
 	listNetworksFn func() ([]mediarequests.DiscoverBrandCard, error)
 	listGenresFn   func() ([]mediarequests.DiscoverBrandCard, error)
 	browseFn       func(kind, slug string, mediaType mediarequests.MediaType, sort string, page int) (*mediarequests.DiscoverBrowseResponse, error)
+	createCalled   bool
 }
 
 func (f *fakeRequestService) ListStudios(context.Context, mediarequests.Viewer) ([]mediarequests.DiscoverBrandCard, error) {
@@ -72,6 +73,7 @@ func (f *fakeRequestService) GetDetail(context.Context, mediarequests.Viewer, me
 }
 
 func (f *fakeRequestService) CreateRequest(context.Context, mediarequests.Viewer, mediarequests.CreateRequestInput) (*mediarequests.Request, error) {
+	f.createCalled = true
 	return nil, nil
 }
 
@@ -245,5 +247,35 @@ func TestHandleBrowseGenreRequiresMediaType(t *testing.T) {
 
 	if rec.Code != http.StatusBadRequest {
 		t.Fatalf("status = %d, want 400; body=%s", rec.Code, rec.Body.String())
+	}
+}
+
+func TestHandleCreateRejectsWithoutRequestCreateGrant(t *testing.T) {
+	svc := &fakeRequestService{}
+	authorizer := &fakeMediaConsumptionAuthorizer{
+		decision: auth.AccessDecision{Allowed: false, ReasonCode: "default_deny"},
+	}
+	h := NewRequestsHandler(svc)
+	h.Authorizer = authorizer
+
+	req := authedRequest("POST", "/api/v1/requests")
+	req.Body = http.NoBody
+	req = httptest.NewRequest(http.MethodPost, "/api/v1/requests", strings.NewReader(`{"media_type":"movie","tmdb_id":123}`)).
+		WithContext(req.Context())
+	rec := httptest.NewRecorder()
+
+	h.HandleCreate(rec, req)
+
+	if rec.Code != http.StatusForbidden {
+		t.Fatalf("status = %d, want 403; body=%s", rec.Code, rec.Body.String())
+	}
+	if !authorizer.called {
+		t.Fatalf("request ACL authorizer was not called")
+	}
+	if authorizer.request.Action != auth.ActionRequestsCreate {
+		t.Fatalf("action = %q, want %q", authorizer.request.Action, auth.ActionRequestsCreate)
+	}
+	if svc.createCalled {
+		t.Fatalf("CreateRequest was called despite missing grant")
 	}
 }

--- a/internal/api/handlers/taste_seed.go
+++ b/internal/api/handlers/taste_seed.go
@@ -3,11 +3,13 @@ package handlers
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"log/slog"
 	"net/http"
 	"strconv"
 
 	apimw "github.com/Silo-Server/silo-server/internal/api/middleware"
+	"github.com/Silo-Server/silo-server/internal/auth"
 	"github.com/Silo-Server/silo-server/internal/models"
 )
 
@@ -134,6 +136,10 @@ func (h *RecommendationsHandler) HandleTasteSeed(w http.ResponseWriter, r *http.
 	userID := apimw.GetUserID(r.Context())
 	profileID := apimw.GetProfileID(r.Context())
 
+	if !h.authorizeTasteSeed(w, r, userID, profileID) {
+		return
+	}
+
 	store, err := h.storeProvider.ForUser(r.Context(), userID)
 	if err != nil || store == nil {
 		slog.Error("TasteSeed: failed to load user store", "user_id", userID, "error", err)
@@ -167,6 +173,25 @@ func (h *RecommendationsHandler) HandleTasteSeed(w http.ResponseWriter, r *http.
 	}
 
 	writeJSON(w, http.StatusOK, tasteSeedSubmitResponse{Added: added})
+}
+
+func (h *RecommendationsHandler) authorizeTasteSeed(w http.ResponseWriter, r *http.Request, userID int, profileID string) bool {
+	err := authorizeACLAction(r.Context(), h.Authorizer, auth.AccessRequest{
+		UserID:       userID,
+		ProfileID:    profileID,
+		Action:       auth.ActionPersonalListsManage,
+		ResourceType: auth.ResourceMediaItem,
+		ResourceID:   "*",
+	})
+	if err == nil {
+		return true
+	}
+	if errors.Is(err, errACLActionDenied) {
+		writeError(w, http.StatusForbidden, "forbidden", "Personal list changes are not allowed")
+		return false
+	}
+	writeError(w, http.StatusInternalServerError, "internal_error", "Failed to authorize personal list change")
+	return false
 }
 
 // resolveTasteSeedUserStates returns the per-item user state map (favorite,

--- a/internal/api/handlers/taste_seed_acl_test.go
+++ b/internal/api/handlers/taste_seed_acl_test.go
@@ -1,0 +1,47 @@
+package handlers
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/Silo-Server/silo-server/internal/auth"
+)
+
+func TestHandleTasteSeedRejectsWithoutPersonalListGrant(t *testing.T) {
+	store := newProfileTestStore(t)
+	authorizer := &fakeMediaConsumptionAuthorizer{
+		decision: auth.AccessDecision{Allowed: false, ReasonCode: "default_deny"},
+	}
+	handler := NewRecommendationsHandler(nil, nil, testUserStoreProvider{store: store}, nil, nil, false)
+	handler.Authorizer = authorizer
+
+	req := newAuthorizedProfileRequestWithRole(
+		http.MethodPost,
+		"/recommendations/taste-seed",
+		`{"item_ids":["movie-1"]}`,
+		"user",
+		"profile-1",
+	)
+	rr := httptest.NewRecorder()
+
+	handler.HandleTasteSeed(rr, req)
+
+	if rr.Code != http.StatusForbidden {
+		t.Fatalf("status = %d, body = %s", rr.Code, rr.Body.String())
+	}
+	if !authorizer.called {
+		t.Fatalf("personal list ACL authorizer was not called")
+	}
+	if authorizer.request.Action != auth.ActionPersonalListsManage {
+		t.Fatalf("action = %q, want %q", authorizer.request.Action, auth.ActionPersonalListsManage)
+	}
+	ok, err := store.IsFavorite(context.Background(), "profile-1", "movie-1")
+	if err != nil {
+		t.Fatalf("IsFavorite: %v", err)
+	}
+	if ok {
+		t.Fatalf("favorite was written despite missing grant")
+	}
+}

--- a/internal/api/middleware/admin_capabilities.go
+++ b/internal/api/middleware/admin_capabilities.go
@@ -1,0 +1,80 @@
+package middleware
+
+import (
+	"net/http"
+
+	"github.com/Silo-Server/silo-server/internal/auth"
+)
+
+// RequireAdminCapability permits a request when the caller is either a normal
+// acting admin or has an explicit ACL grant for the requested admin action.
+func RequireAdminCapability(authorizer auth.Authorizer, action auth.ACLAction, checkPrimary PrimaryProfileChecker) func(http.Handler) http.Handler {
+	return func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			claims := GetClaims(r.Context())
+			if claims == nil {
+				writeUnauthorized(w, "Authentication required")
+				return
+			}
+
+			actingAdmin := false
+			primaryProfile := false
+			if claims.Role == "admin" {
+				allowed, err := actingAdminAllowed(r, claims.UserID, checkPrimary)
+				if err != nil {
+					writeInternalError(w, "Failed to verify active profile")
+					return
+				}
+				if allowed {
+					next.ServeHTTP(w, r)
+					return
+				}
+				actingAdmin = allowed
+			}
+
+			if checkPrimary == nil {
+				primaryProfile = claims.Role == "admin"
+			} else if profileID := declaredProfileID(r); profileID != "" {
+				isPrimary, found, err := checkPrimary(r.Context(), claims.UserID, profileID)
+				if err != nil {
+					writeInternalError(w, "Failed to verify active profile")
+					return
+				}
+				primaryProfile = found && isPrimary
+			} else if claims.Role == "admin" {
+				primaryProfile = true
+			}
+
+			if authorizer == nil {
+				if claims.Role == "admin" && !actingAdmin {
+					writeForbidden(w, "Admin access requires the account's primary profile")
+					return
+				}
+				writeForbidden(w, "Admin capability required")
+				return
+			}
+
+			decision, err := authorizer.Authorize(r.Context(), auth.AccessRequest{
+				UserID:         claims.UserID,
+				Action:         action,
+				ResourceType:   auth.ResourceServer,
+				ResourceID:     "*",
+				PrimaryProfile: primaryProfile,
+			})
+			if err != nil {
+				writeInternalError(w, "Failed to verify admin capability")
+				return
+			}
+			if !decision.Allowed {
+				if claims.Role == "admin" {
+					writeForbidden(w, "Admin access requires the account's primary profile or an explicit access grant")
+					return
+				}
+				writeForbidden(w, "Admin capability required")
+				return
+			}
+
+			next.ServeHTTP(w, r)
+		})
+	}
+}

--- a/internal/api/middleware/admin_capabilities_test.go
+++ b/internal/api/middleware/admin_capabilities_test.go
@@ -1,0 +1,117 @@
+package middleware
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/Silo-Server/silo-server/internal/auth"
+)
+
+type fakeAdminACLAuthorizer struct {
+	decision auth.AccessDecision
+	request  auth.AccessRequest
+	err      error
+	called   bool
+}
+
+func (f *fakeAdminACLAuthorizer) Authorize(_ context.Context, request auth.AccessRequest) (auth.AccessDecision, error) {
+	f.called = true
+	f.request = request
+	return f.decision, f.err
+}
+
+func (f *fakeAdminACLAuthorizer) Explain(_ context.Context, request auth.AccessRequest) (auth.AccessExplanation, error) {
+	decision, err := f.Authorize(context.Background(), request)
+	return auth.AccessExplanation{Request: request, Decision: decision}, err
+}
+
+func runAdminCapabilityMiddleware(role string, action auth.ACLAction, authorizer auth.Authorizer, check PrimaryProfileChecker, profileID string) (int, *fakeAdminACLAuthorizer) {
+	req := httptest.NewRequest(http.MethodGet, "/admin/users", nil)
+	if profileID != "" {
+		req.Header.Set("X-Profile-Id", profileID)
+	}
+	req = req.WithContext(SetClaims(req.Context(), &auth.Claims{UserID: 42, Role: role, TokenType: auth.TokenTypeAccess}))
+
+	next := RequireAdminCapability(authorizer, action, check)(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusNoContent)
+	}))
+
+	rec := httptest.NewRecorder()
+	next.ServeHTTP(rec, req)
+	fake, _ := authorizer.(*fakeAdminACLAuthorizer)
+	return rec.Code, fake
+}
+
+func TestRequireAdminCapability_AllowsDelegatedUserWithACLGrant(t *testing.T) {
+	acl := &fakeAdminACLAuthorizer{decision: auth.AccessDecision{Allowed: true, ReasonCode: "rule_allow"}}
+	code, fake := runAdminCapabilityMiddleware("user", auth.ActionUsersManage, acl, nil, "")
+
+	if code != http.StatusNoContent {
+		t.Fatalf("status = %d, want %d", code, http.StatusNoContent)
+	}
+	if fake == nil || !fake.called {
+		t.Fatalf("ACL authorizer was not called")
+	}
+	if fake.request.UserID != 42 || fake.request.Action != auth.ActionUsersManage || fake.request.ResourceType != auth.ResourceServer || fake.request.ResourceID != "*" {
+		t.Fatalf("ACL request = %#v", fake.request)
+	}
+}
+
+func TestRequireAdminCapability_RejectsDelegatedUserWithoutACLGrant(t *testing.T) {
+	acl := &fakeAdminACLAuthorizer{decision: auth.AccessDecision{Allowed: false, ReasonCode: "default_deny"}}
+	code, _ := runAdminCapabilityMiddleware("user", auth.ActionUsersManage, acl, nil, "")
+
+	if code != http.StatusForbidden {
+		t.Fatalf("status = %d, want %d", code, http.StatusForbidden)
+	}
+}
+
+func TestRequireAdminCapability_AllowsPrimaryAdminWithoutACLAuthorizer(t *testing.T) {
+	code, _ := runAdminCapabilityMiddleware("admin", auth.ActionUsersManage, nil, primaryChecker(true, true, nil), "primary")
+
+	if code != http.StatusNoContent {
+		t.Fatalf("status = %d, want %d", code, http.StatusNoContent)
+	}
+}
+
+func TestRequireAdminCapability_AdminOnNonPrimaryProfileNeedsACLGrant(t *testing.T) {
+	acl := &fakeAdminACLAuthorizer{decision: auth.AccessDecision{Allowed: false, ReasonCode: "default_deny"}}
+	code, fake := runAdminCapabilityMiddleware("admin", auth.ActionUsersManage, acl, primaryChecker(false, true, nil), "kid")
+
+	if code != http.StatusForbidden {
+		t.Fatalf("status = %d, want %d", code, http.StatusForbidden)
+	}
+	if fake == nil || !fake.called {
+		t.Fatalf("ACL authorizer was not called")
+	}
+	if fake.request.PrimaryProfile {
+		t.Fatalf("primary profile flag = true, want false")
+	}
+}
+
+func TestRequireAdminCapability_AllowsAdminOnNonPrimaryProfileWithExplicitACLGrant(t *testing.T) {
+	acl := &fakeAdminACLAuthorizer{decision: auth.AccessDecision{Allowed: true, ReasonCode: "rule_allow"}}
+	code, fake := runAdminCapabilityMiddleware("admin", auth.ActionUsersManage, acl, primaryChecker(false, true, nil), "kid")
+
+	if code != http.StatusNoContent {
+		t.Fatalf("status = %d, want %d", code, http.StatusNoContent)
+	}
+	if fake == nil || !fake.called {
+		t.Fatalf("ACL authorizer was not called")
+	}
+	if fake.request.PrimaryProfile {
+		t.Fatalf("primary profile flag = true, want false")
+	}
+}
+
+func TestRequireAdminCapability_AuthorizerErrorReturnsInternalError(t *testing.T) {
+	acl := &fakeAdminACLAuthorizer{err: errors.New("database offline")}
+	code, _ := runAdminCapabilityMiddleware("user", auth.ActionUsersManage, acl, nil, "")
+
+	if code != http.StatusInternalServerError {
+		t.Fatalf("status = %d, want %d", code, http.StatusInternalServerError)
+	}
+}

--- a/internal/api/middleware/permissions.go
+++ b/internal/api/middleware/permissions.go
@@ -25,6 +25,7 @@ type PermissionMiddleware struct {
 	users        PermissionUserLoader
 	libraries    MetadataTargetLibraryResolver
 	checkPrimary PrimaryProfileChecker // nil disables the acting-admin profile policy
+	Authorizer   auth.Authorizer
 }
 
 func NewPermissionMiddleware(
@@ -48,22 +49,24 @@ func (m *PermissionMiddleware) RequireMetadataCurationForItem(next http.Handler)
 			writeUnauthorized(w, "Authentication required")
 			return
 		}
+		actingAdmin := false
 		if claims.Role == "admin" {
 			var checkPrimary PrimaryProfileChecker
 			if m != nil {
 				checkPrimary = m.checkPrimary
 			}
-			actingAdmin, err := actingAdminAllowed(r, claims.UserID, checkPrimary)
+			allowed, err := actingAdminAllowed(r, claims.UserID, checkPrimary)
 			if err != nil {
 				writePermissionError(w, http.StatusInternalServerError, "internal_error", "Failed to verify active profile")
 				return
 			}
+			actingAdmin = allowed
 			if actingAdmin {
 				next.ServeHTTP(w, r)
 				return
 			}
 		}
-		if m == nil || m.users == nil || m.libraries == nil {
+		if m == nil || m.libraries == nil {
 			writeForbidden(w, "Metadata curation permission required")
 			return
 		}
@@ -71,6 +74,40 @@ func (m *PermissionMiddleware) RequireMetadataCurationForItem(next http.Handler)
 		contentID := chi.URLParam(r, "id")
 		if contentID == "" {
 			writePermissionError(w, http.StatusBadRequest, "bad_request", "Item ID is required")
+			return
+		}
+
+		targetLibraries, err := m.libraries.ResolveMetadataTargetLibraryIDs(r.Context(), contentID)
+		if err != nil {
+			writePermissionError(w, http.StatusInternalServerError, "internal_error", "Failed to resolve item libraries")
+			return
+		}
+		if len(targetLibraries) == 0 {
+			writePermissionError(w, http.StatusNotFound, "not_found", "Item not found")
+			return
+		}
+		if m.Authorizer != nil {
+			decision, err := m.Authorizer.Authorize(r.Context(), auth.AccessRequest{
+				UserID:         claims.UserID,
+				Action:         auth.ActionMetadataCurate,
+				ResourceType:   auth.ResourceMediaItem,
+				ResourceID:     contentID,
+				LibraryIDs:     targetLibraries,
+				PrimaryProfile: actingAdmin,
+			})
+			if err != nil {
+				writePermissionError(w, http.StatusInternalServerError, "internal_error", "Failed to authorize metadata curation")
+				return
+			}
+			if !decision.Allowed {
+				writeForbidden(w, "Metadata curation permission required")
+				return
+			}
+			next.ServeHTTP(w, r)
+			return
+		}
+		if m.users == nil {
+			writeForbidden(w, "Metadata curation permission required")
 			return
 		}
 
@@ -88,16 +125,6 @@ func (m *PermissionMiddleware) RequireMetadataCurationForItem(next http.Handler)
 		}
 		if !hasPermission {
 			writeForbidden(w, "Metadata curation permission required")
-			return
-		}
-
-		targetLibraries, err := m.libraries.ResolveMetadataTargetLibraryIDs(r.Context(), contentID)
-		if err != nil {
-			writePermissionError(w, http.StatusInternalServerError, "internal_error", "Failed to resolve item libraries")
-			return
-		}
-		if len(targetLibraries) == 0 {
-			writePermissionError(w, http.StatusNotFound, "not_found", "Item not found")
 			return
 		}
 		if !metadataTargetWithinUserLibraries(user.LibraryIDs, targetLibraries) {

--- a/internal/api/middleware/permissions_test.go
+++ b/internal/api/middleware/permissions_test.go
@@ -30,6 +30,24 @@ func (f fakeTargetLibraryResolver) ResolveMetadataTargetLibraryIDs(context.Conte
 	return f.ids, f.err
 }
 
+type fakePermissionACLAuthorizer struct {
+	decision auth.AccessDecision
+	request  auth.AccessRequest
+	err      error
+	called   bool
+}
+
+func (f *fakePermissionACLAuthorizer) Authorize(_ context.Context, request auth.AccessRequest) (auth.AccessDecision, error) {
+	f.called = true
+	f.request = request
+	return f.decision, f.err
+}
+
+func (f *fakePermissionACLAuthorizer) Explain(_ context.Context, request auth.AccessRequest) (auth.AccessExplanation, error) {
+	decision, err := f.Authorize(context.Background(), request)
+	return auth.AccessExplanation{Request: request, Decision: decision}, err
+}
+
 func requestWithItemID(role string) *http.Request {
 	req := httptest.NewRequest(http.MethodPost, "/admin/items/item-1/refresh-metadata", nil)
 	ctx := SetClaims(req.Context(), &auth.Claims{UserID: 7, Role: role, TokenType: auth.TokenTypeAccess})
@@ -143,5 +161,91 @@ func TestRequireMetadataCurationForItem_NotFoundWhenTargetHasNoLibraries(t *test
 	code := runMetadataCurationMiddleware(user, nil, "user")
 	if code != http.StatusNotFound {
 		t.Fatalf("status = %d, want %d", code, http.StatusNotFound)
+	}
+}
+
+func TestRequireMetadataCurationForItem_AllowsCustomACLGrant(t *testing.T) {
+	user := &models.User{ID: 7, Role: "user", Enabled: true, LibraryIDs: []int{1}, Permissions: nil}
+	acl := &fakePermissionACLAuthorizer{
+		decision: auth.AccessDecision{Allowed: true, ReasonCode: "rule_allow"},
+	}
+	mw := NewPermissionMiddleware(
+		fakePermissionUserLoader{user: user},
+		fakeTargetLibraryResolver{ids: []int{1, 2}},
+		nil,
+	)
+	mw.Authorizer = acl
+	next := mw.RequireMetadataCurationForItem(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusNoContent)
+	}))
+
+	rec := httptest.NewRecorder()
+	next.ServeHTTP(rec, requestWithItemID("user"))
+
+	if rec.Code != http.StatusNoContent {
+		t.Fatalf("status = %d, want %d", rec.Code, http.StatusNoContent)
+	}
+	if !acl.called {
+		t.Fatalf("ACL authorizer was not called")
+	}
+	if acl.request.Action != auth.ActionMetadataCurate || acl.request.ResourceType != auth.ResourceMediaItem || acl.request.ResourceID != "item-1" {
+		t.Fatalf("ACL request = %#v", acl.request)
+	}
+	if len(acl.request.LibraryIDs) != 2 || acl.request.LibraryIDs[0] != 1 || acl.request.LibraryIDs[1] != 2 {
+		t.Fatalf("ACL library ids = %#v, want [1 2]", acl.request.LibraryIDs)
+	}
+}
+
+func TestRequireMetadataCurationForItem_RejectsCustomACLDeny(t *testing.T) {
+	user := &models.User{ID: 7, Role: "user", Enabled: true, LibraryIDs: nil, Permissions: nil}
+	acl := &fakePermissionACLAuthorizer{
+		decision: auth.AccessDecision{Allowed: false, ReasonCode: "rule_deny"},
+	}
+	mw := NewPermissionMiddleware(
+		fakePermissionUserLoader{user: user},
+		fakeTargetLibraryResolver{ids: []int{1}},
+		nil,
+	)
+	mw.Authorizer = acl
+	next := mw.RequireMetadataCurationForItem(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusNoContent)
+	}))
+
+	rec := httptest.NewRecorder()
+	next.ServeHTTP(rec, requestWithItemID("user"))
+
+	if rec.Code != http.StatusForbidden {
+		t.Fatalf("status = %d, want %d", rec.Code, http.StatusForbidden)
+	}
+}
+
+func TestRequireMetadataCurationForItem_AdminNonPrimaryRequiresACLGrant(t *testing.T) {
+	admin := &models.User{ID: 7, Role: "admin", Enabled: true, LibraryIDs: nil, Permissions: nil}
+	acl := &fakePermissionACLAuthorizer{
+		decision: auth.AccessDecision{Allowed: false, ReasonCode: "default_deny"},
+	}
+	mw := NewPermissionMiddleware(
+		fakePermissionUserLoader{user: admin},
+		fakeTargetLibraryResolver{ids: []int{1}},
+		primaryChecker(false, true, nil),
+	)
+	mw.Authorizer = acl
+	next := mw.RequireMetadataCurationForItem(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusNoContent)
+	}))
+	req := requestWithItemID("admin")
+	req.Header.Set("X-Profile-Id", "prof-2")
+
+	rec := httptest.NewRecorder()
+	next.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusForbidden {
+		t.Fatalf("status = %d, want %d", rec.Code, http.StatusForbidden)
+	}
+	if !acl.called {
+		t.Fatalf("ACL authorizer was not called")
+	}
+	if acl.request.PrimaryProfile {
+		t.Fatalf("primary profile flag = true, want false")
 	}
 }

--- a/internal/api/router.go
+++ b/internal/api/router.go
@@ -535,6 +535,7 @@ func NewRouter(deps Dependencies) chi.Router {
 				FileResolver:          deps.FileRepo,
 				ItemAccess:            itemRepo,
 				EpisodeLookup:         episodeRepo,
+				ItemLookup:            itemRepo,
 				ConsumptionAuthorizer: adminAuthorizer,
 			})
 			if ebookProgressStore != nil {
@@ -973,6 +974,7 @@ func NewRouter(deps Dependencies) chi.Router {
 				FileResolver:  deps.FileRepo,
 				ItemAccess:    itemRepo,
 				EpisodeLookup: episodeRepo,
+				ItemLookup:    itemRepo,
 			}
 		}
 	}
@@ -2078,6 +2080,7 @@ func NewRouter(deps Dependencies) chi.Router {
 							FileResolver:  deps.FileRepo,
 							ItemAccess:    itemRepo,
 							EpisodeLookup: episodeRepo,
+							ItemLookup:    itemRepo,
 						}
 						subtitleSearchHandler.FileAuthorizer = fileAuthorizer
 						if subtitleAIHandler != nil {
@@ -2112,6 +2115,7 @@ func NewRouter(deps Dependencies) chi.Router {
 					playbackHandler.ItemAccess = itemRepo
 					playbackHandler.AccessAuthorizer = adminAuthorizer
 					playbackHandler.EpisodeLookup = episodeRepo
+					playbackHandler.ItemLookup = itemRepo
 					playbackHandler.OriginalLangLookup = itemRepo
 					playbackHandler.FFmpegLogSink = deps.FFmpegLogSink
 

--- a/internal/api/router.go
+++ b/internal/api/router.go
@@ -46,6 +46,7 @@ import (
 	"github.com/Silo-Server/silo-server/internal/metadata/tmdb"
 	metatrakt "github.com/Silo-Server/silo-server/internal/metadata/trakt"
 	metadatatranslation "github.com/Silo-Server/silo-server/internal/metadata/translation"
+	"github.com/Silo-Server/silo-server/internal/models"
 	"github.com/Silo-Server/silo-server/internal/nodepool"
 	"github.com/Silo-Server/silo-server/internal/notifications"
 	"github.com/Silo-Server/silo-server/internal/opslog"
@@ -270,7 +271,11 @@ func NewRouter(deps Dependencies) chi.Router {
 
 	// Admin authorization for routes: admin role, exercised through the
 	// account's primary household profile (see apimw.RequireActingAdmin).
+	var adminAuthorizer auth.Authorizer
 	requireActingAdmin := apimw.RequireActingAdmin(checkPrimaryProfile)
+	requireAdminCapability := func(action auth.ACLAction) func(http.Handler) http.Handler {
+		return apimw.RequireAdminCapability(adminAuthorizer, action, checkPrimaryProfile)
+	}
 
 	// Health handler advertises the server's identity so multi-server
 	// clients can display a friendly name. Falls back to empty strings
@@ -299,6 +304,7 @@ func NewRouter(deps Dependencies) chi.Router {
 	var authMiddleware *apimw.AuthMiddleware
 	var viewerAccessMiddleware *apimw.ViewerAccessMiddleware
 	var permissionMiddleware *apimw.PermissionMiddleware
+	var aclRepo *auth.ACLRepository
 	var viewerResolver *access.Resolver
 	var profileTokenService *access.ProfileTokenService
 	var jwtService *auth.JWTService
@@ -335,6 +341,7 @@ func NewRouter(deps Dependencies) chi.Router {
 		}
 		deviceLoginService = auth.NewDeviceLoginService(deps.DB, userRepo, jwtService, sessionRepo)
 		authHandler = handlers.NewAuthHandler(authService, jwtService, deviceLoginService)
+		authHandler.PrimaryProfileChecker = checkPrimaryProfile
 		authMiddleware = apimw.NewAuthMiddleware(jwtService, sessionRepo, apiKeyRepo, userRepo)
 		profileTokenService = access.NewProfileTokenService(deps.Config.Auth.JWTSecret, 0)
 		if deps.UserStoreProvider != nil {
@@ -342,23 +349,20 @@ func NewRouter(deps Dependencies) chi.Router {
 			viewerAccessMiddleware = apimw.NewViewerAccessMiddleware(viewerResolver)
 		}
 		if deps.DB != nil {
+			aclRepo = auth.NewACLRepository(deps.DB)
+			adminAuthorizer = auth.NewACLAuthorizer(aclRepo, userRepo)
+			authHandler.AdminAuthorizer = adminAuthorizer
 			permissionMiddleware = apimw.NewPermissionMiddleware(
 				userRepo,
 				apimw.NewPGMetadataTargetLibraryResolver(deps.DB),
 				checkPrimaryProfile,
 			)
+			permissionMiddleware.Authorizer = adminAuthorizer
 		}
 	}
 	if deps.SessionMgr != nil && userRepo != nil {
 		deps.SessionMgr.SetLimitProvider(func(ctx context.Context, userID int) (playback.SessionLimits, error) {
-			user, err := userRepo.GetByID(ctx, userID)
-			if err != nil {
-				return playback.SessionLimits{}, err
-			}
-			return playback.SessionLimits{
-				MaxStreams:    user.MaxStreams,
-				MaxTranscodes: user.MaxTranscodes,
-			}, nil
+			return resolvePlaybackSessionLimits(ctx, userRepo, adminAuthorizer, userID)
 		})
 	}
 
@@ -528,9 +532,10 @@ func NewRouter(deps Dependencies) chi.Router {
 		}
 		if deps.FileRepo != nil {
 			ebookReaderHandler = handlers.NewEbookReaderHandler(&handlers.MediaFileAuthorizer{
-				FileResolver:  deps.FileRepo,
-				ItemAccess:    itemRepo,
-				EpisodeLookup: episodeRepo,
+				FileResolver:          deps.FileRepo,
+				ItemAccess:            itemRepo,
+				EpisodeLookup:         episodeRepo,
+				ConsumptionAuthorizer: adminAuthorizer,
 			})
 			if ebookProgressStore != nil {
 				ebookReaderHandler.ProgressStore = ebookProgressStore
@@ -578,6 +583,7 @@ func NewRouter(deps Dependencies) chi.Router {
 			requestSvc.SetLifecycleNotifier(lifecycle)
 		}
 		requestHandler = handlers.NewRequestsHandler(requestSvc)
+		requestHandler.Authorizer = adminAuthorizer
 
 		autoscanRepo := autoscan.NewRepository(deps.DB, deps.SecretCipher)
 		if deps.FolderRepo != nil && deps.LibraryScanQueue != nil && deps.PluginService != nil {
@@ -628,7 +634,9 @@ func NewRouter(deps Dependencies) chi.Router {
 		profileHandler.ProfileTokens = profileTokenService
 		profileHandler.AvatarStore = deps.S3Private
 		profileHandler.SessionsReader = playbackSessionsLoader
+		profileHandler.AccessAuthorizer = adminAuthorizer
 		personalDataHandler = handlers.NewPersonalDataHandler(deps.UserStoreProvider, itemRepo)
+		personalDataHandler.Authorizer = adminAuthorizer
 		if detailSvc != nil {
 			personalDataHandler.SetDetailService(detailSvc)
 		}
@@ -854,6 +862,11 @@ func NewRouter(deps Dependencies) chi.Router {
 		adminHandler.EventBus = deps.EventBus
 		adminHandler.EventsHub = deps.EventsHub
 		adminHandler.ImpersonationService = authService
+		adminHandler.AdminAuthorizer = adminAuthorizer
+		adminHandler.PrimaryProfileChecker = checkPrimaryProfile
+		if aclRepo != nil {
+			adminHandler.AccessGroups = aclRepo
+		}
 		adminHandler.StatsSource = deps.AdminStatsProvider
 		adminHandler.RealtimeHub = deps.RealtimeHub
 		adminHandler.BootstrapSensitiveConfigured = deps.BootstrapSensitiveConfigured
@@ -1322,6 +1335,7 @@ func NewRouter(deps Dependencies) chi.Router {
 			recsReader = recommendations.NewReader(recsRepo, ratingsRepo, deps.RecWorker, deps.UserStoreProvider)
 		}
 		recsHandler = handlers.NewRecommendationsHandler(deps.Recommender, recsReader, deps.UserStoreProvider, ratingsRepo, recsRepo, deps.Recommender != nil)
+		recsHandler.Authorizer = adminAuthorizer
 		if deps.DB != nil {
 			recsFetcher := sections.NewFetcher(deps.DB)
 			recsFetcher.StoreProvider = deps.UserStoreProvider
@@ -1538,6 +1552,8 @@ func NewRouter(deps Dependencies) chi.Router {
 						r.Post("/logout", authHandler.HandleLogout)
 						r.Post("/impersonation/end", authHandler.HandleEndImpersonation)
 						r.Get("/me", authHandler.HandleMe)
+						r.Get("/capabilities", authHandler.HandleCapabilities)
+						r.Get("/admin-capabilities", authHandler.HandleAdminCapabilities)
 						r.Get("/sessions", authHandler.HandleListSessions)
 						r.Delete("/sessions/{id}", authHandler.HandleDeleteSession)
 						r.Post("/device/approve", authHandler.HandleDeviceApprove)
@@ -1686,7 +1702,7 @@ func NewRouter(deps Dependencies) chi.Router {
 				// Library management routes (admin-only).
 				if libraryHandler != nil {
 					r.Group(func(r chi.Router) {
-						r.Use(requireActingAdmin)
+						r.Use(requireAdminCapability(auth.ActionLibrariesManage))
 
 						r.Route("/libraries", func(r chi.Router) {
 							r.Get("/", libraryHandler.HandleListLibraries)
@@ -2094,6 +2110,7 @@ func NewRouter(deps Dependencies) chi.Router {
 				// Playback routes.
 				if playbackHandler != nil {
 					playbackHandler.ItemAccess = itemRepo
+					playbackHandler.AccessAuthorizer = adminAuthorizer
 					playbackHandler.EpisodeLookup = episodeRepo
 					playbackHandler.OriginalLangLookup = itemRepo
 					playbackHandler.FFmpegLogSink = deps.FFmpegLogSink
@@ -2240,27 +2257,75 @@ func NewRouter(deps Dependencies) chi.Router {
 						}
 
 						r.Group(func(r chi.Router) {
-							r.Use(requireActingAdmin)
+							r.Use(requireAdminCapability(auth.ActionSecurityManage))
+							r.Get("/access-groups", adminHandler.HandleListAccessGroups)
+							r.Post("/access-groups", adminHandler.HandleCreateAccessGroup)
+							r.Get("/access-groups/{slug}", adminHandler.HandleGetAccessGroup)
+							r.Put("/access-groups/{slug}", adminHandler.HandleUpdateAccessGroup)
+							r.Delete("/access-groups/{slug}", adminHandler.HandleDeleteAccessGroup)
+						})
 
+						r.Group(func(r chi.Router) {
+							r.Use(requireAdminCapability(auth.ActionUsersView))
 							r.Get("/users", adminHandler.HandleListUsers)
-							r.Post("/users", adminHandler.HandleCreateUser)
 							r.Get("/users/{id}", adminHandler.HandleGetUser)
-							r.Put("/users/{id}", adminHandler.HandleUpdateUser)
-							r.Delete("/users/{id}", adminHandler.HandleDeleteUser)
-							r.Post("/users/{id}/impersonate", adminHandler.HandleImpersonateUser)
+							r.Get("/users/{id}/access-explain", adminHandler.HandleGetUserAccessExplanation)
 							r.Get("/users/{id}/profiles", adminHandler.HandleListUserProfiles)
 							r.Get("/users/{id}/settings", adminHandler.HandleListUserSettings)
 							r.Get("/users/{id}/settings/{key}", adminHandler.HandleGetUserSetting)
-							r.Put("/users/{id}/settings/{key}", adminHandler.HandleUpdateUserSetting)
-							r.Delete("/users/{id}/settings/{key}", adminHandler.HandleDeleteUserSetting)
 							r.Get("/users/{id}/device-settings", adminHandler.HandleListUserDeviceSettings)
 							r.Get("/users/{id}/device-settings/{key}", adminHandler.HandleListUserDeviceSettingsByKey)
+							r.Get("/devices", adminHandler.HandleListDevices)
+							r.Get("/devices/{user_id}/{device_id}", adminHandler.HandleGetDevice)
+							if deps.ActivityLogRepo != nil {
+								adminIPHandler := handlers.NewAdminIPHandler(deps.ActivityLogRepo)
+								r.Get("/users/{id}/ips", adminIPHandler.HandleGetUserIPs)
+								r.Get("/ips", adminIPHandler.HandleGetIPUsers)
+							}
+						})
+
+						r.Group(func(r chi.Router) {
+							r.Use(requireAdminCapability(auth.ActionUsersManage))
+							r.Post("/users", adminHandler.HandleCreateUser)
+							r.Put("/users/{id}", adminHandler.HandleUpdateUser)
+							r.Delete("/users/{id}", adminHandler.HandleDeleteUser)
+							r.Put("/users/{id}/settings/{key}", adminHandler.HandleUpdateUserSetting)
+							r.Delete("/users/{id}/settings/{key}", adminHandler.HandleDeleteUserSetting)
 							r.Put("/users/{id}/profiles/{profile_id}/device-settings/{key}/{device_id}", adminHandler.HandleUpdateUserDeviceSetting)
 							r.Delete("/users/{id}/device-settings/{key}", adminHandler.HandleDeleteUserDeviceSettingsByKey)
 							r.Delete("/users/{id}/profiles/{profile_id}/device-settings/{key}/{device_id}", adminHandler.HandleDeleteUserDeviceSetting)
 							r.Delete("/users/{id}/profiles/{profile_id}/devices/{device_id}/settings", adminHandler.HandleDeleteAllUserDeviceSettings)
-							r.Get("/devices", adminHandler.HandleListDevices)
-							r.Get("/devices/{user_id}/{device_id}", adminHandler.HandleGetDevice)
+						})
+						r.With(requireAdminCapability(auth.ActionUsersImpersonate)).Post("/users/{id}/impersonate", adminHandler.HandleImpersonateUser)
+
+						if requestHandler != nil {
+							r.Group(func(r chi.Router) {
+								r.Use(requireAdminCapability(auth.ActionRequestsApprove))
+								r.Get("/requests", requestHandler.HandleAdminList)
+								r.Post("/requests/{id}/approve", requestHandler.HandleApprove)
+								r.Post("/requests/{id}/decline", requestHandler.HandleDecline)
+								r.Post("/requests/{id}/cancel", requestHandler.HandleCancel)
+								r.Post("/requests/{id}/retry", requestHandler.HandleRetry)
+							})
+							r.Group(func(r chi.Router) {
+								r.Use(requireAdminCapability(auth.ActionServerConfigure))
+								r.Get("/request-settings", requestHandler.HandleGetSettings)
+								r.Put("/request-settings", requestHandler.HandleUpdateSettings)
+								r.Get("/request-integrations", requestHandler.HandleListIntegrations)
+								r.Post("/request-integrations", requestHandler.HandleCreateIntegration)
+								r.Put("/request-integrations/{id}", requestHandler.HandleUpdateIntegration)
+								r.Delete("/request-integrations/{id}", requestHandler.HandleDeleteIntegration)
+								r.Post("/request-integrations/{id}/options", requestHandler.HandleLoadIntegrationOptions)
+							})
+							r.Group(func(r chi.Router) {
+								r.Use(requireAdminCapability(auth.ActionUsersManage))
+								r.Get("/request-users/{user_id}/limit", requestHandler.HandleGetUserLimit)
+								r.Put("/request-users/{user_id}/limit", requestHandler.HandleUpdateUserLimit)
+							})
+						}
+
+						r.Group(func(r chi.Router) {
+							r.Use(requireActingAdmin)
 
 							r.Get("/sessions", adminHandler.HandleListSessions)
 							r.Get("/playback-history", adminHandler.HandleListPlaybackHistory)
@@ -2572,23 +2637,6 @@ func NewRouter(deps Dependencies) chi.Router {
 								r.Put("/api-keys/{id}/tier", apiKeyHandler.HandleAdminUpdateTier)
 							}
 
-							if requestHandler != nil {
-								r.Get("/requests", requestHandler.HandleAdminList)
-								r.Post("/requests/{id}/approve", requestHandler.HandleApprove)
-								r.Post("/requests/{id}/decline", requestHandler.HandleDecline)
-								r.Post("/requests/{id}/cancel", requestHandler.HandleCancel)
-								r.Post("/requests/{id}/retry", requestHandler.HandleRetry)
-								r.Get("/request-settings", requestHandler.HandleGetSettings)
-								r.Put("/request-settings", requestHandler.HandleUpdateSettings)
-								r.Get("/request-users/{user_id}/limit", requestHandler.HandleGetUserLimit)
-								r.Put("/request-users/{user_id}/limit", requestHandler.HandleUpdateUserLimit)
-								r.Get("/request-integrations", requestHandler.HandleListIntegrations)
-								r.Post("/request-integrations", requestHandler.HandleCreateIntegration)
-								r.Put("/request-integrations/{id}", requestHandler.HandleUpdateIntegration)
-								r.Delete("/request-integrations/{id}", requestHandler.HandleDeleteIntegration)
-								r.Post("/request-integrations/{id}/options", requestHandler.HandleLoadIntegrationOptions)
-							}
-
 							if autoscanHandler != nil {
 								r.Get("/autoscan/settings", autoscanHandler.HandleGetSettings)
 								r.Put("/autoscan/settings", autoscanHandler.HandleUpdateSettings)
@@ -2609,11 +2657,6 @@ func NewRouter(deps Dependencies) chi.Router {
 								r.Get("/autoscan/status", autoscanHandler.HandleStatus)
 							}
 
-							if deps.ActivityLogRepo != nil {
-								adminIPHandler := handlers.NewAdminIPHandler(deps.ActivityLogRepo)
-								r.Get("/users/{id}/ips", adminIPHandler.HandleGetUserIPs)
-								r.Get("/ips", adminIPHandler.HandleGetIPUsers)
-							}
 							if deps.OpsLogRepo != nil && deps.ActivityLogRepo != nil {
 								adminLogsHandler := handlers.NewAdminLogsHandler(deps.OpsLogRepo, deps.ActivityLogRepo, deps.LogStreamHub)
 								r.Get("/logs/app", adminLogsHandler.HandleListOperationalLogs)
@@ -2655,6 +2698,44 @@ func NewRouter(deps Dependencies) chi.Router {
 // pgSubtitleMediaResolver implements handlers.SubtitleMediaResolver using a direct PG query.
 type pgSubtitleMediaResolver struct {
 	pool *pgxpool.Pool
+}
+
+type playbackLimitUserLoader interface {
+	GetByID(ctx context.Context, id int) (*models.User, error)
+}
+
+func resolvePlaybackSessionLimits(
+	ctx context.Context,
+	users playbackLimitUserLoader,
+	authorizer auth.Authorizer,
+	userID int,
+) (playback.SessionLimits, error) {
+	if authorizer != nil {
+		decision, err := authorizer.Authorize(ctx, auth.AccessRequest{
+			UserID:       userID,
+			Action:       auth.ActionPlaybackPlay,
+			ResourceType: auth.ResourceServer,
+			ResourceID:   "*",
+		})
+		if err != nil {
+			return playback.SessionLimits{}, err
+		}
+		if decision.EffectivePolicy.MaxStreams > 0 || decision.EffectivePolicy.MaxTranscodes > 0 {
+			return playback.SessionLimits{
+				MaxStreams:    decision.EffectivePolicy.MaxStreams,
+				MaxTranscodes: decision.EffectivePolicy.MaxTranscodes,
+			}, nil
+		}
+	}
+
+	user, err := users.GetByID(ctx, userID)
+	if err != nil {
+		return playback.SessionLimits{}, err
+	}
+	return playback.SessionLimits{
+		MaxStreams:    user.MaxStreams,
+		MaxTranscodes: user.MaxTranscodes,
+	}, nil
 }
 
 func (r *pgSubtitleMediaResolver) GetMediaFileWithMetadata(ctx context.Context, fileID int) (*handlers.MediaFileMetadata, error) {

--- a/internal/api/router_session_limits_test.go
+++ b/internal/api/router_session_limits_test.go
@@ -1,0 +1,60 @@
+package api
+
+import (
+	"context"
+	"testing"
+
+	"github.com/Silo-Server/silo-server/internal/auth"
+	"github.com/Silo-Server/silo-server/internal/models"
+)
+
+type fakeSessionLimitUserRepo struct {
+	user *models.User
+}
+
+func (f fakeSessionLimitUserRepo) GetByID(context.Context, int) (*models.User, error) {
+	return f.user, nil
+}
+
+type fakeSessionLimitAuthorizer struct {
+	decision auth.AccessDecision
+	request  auth.AccessRequest
+}
+
+func (f *fakeSessionLimitAuthorizer) Authorize(_ context.Context, request auth.AccessRequest) (auth.AccessDecision, error) {
+	f.request = request
+	return f.decision, nil
+}
+
+func (f *fakeSessionLimitAuthorizer) Explain(_ context.Context, request auth.AccessRequest) (auth.AccessExplanation, error) {
+	decision, err := f.Authorize(context.Background(), request)
+	return auth.AccessExplanation{Request: request, Decision: decision}, err
+}
+
+func TestResolvePlaybackSessionLimitsUsesEffectiveACLPolicy(t *testing.T) {
+	authorizer := &fakeSessionLimitAuthorizer{
+		decision: auth.AccessDecision{
+			Allowed: true,
+			EffectivePolicy: auth.EffectivePolicy{
+				MaxStreams:    5,
+				MaxTranscodes: 1,
+			},
+		},
+	}
+
+	limits, err := resolvePlaybackSessionLimits(
+		context.Background(),
+		fakeSessionLimitUserRepo{user: &models.User{ID: 7, MaxStreams: 6, MaxTranscodes: 2}},
+		authorizer,
+		7,
+	)
+	if err != nil {
+		t.Fatalf("resolvePlaybackSessionLimits() error = %v", err)
+	}
+	if limits.MaxStreams != 5 || limits.MaxTranscodes != 1 {
+		t.Fatalf("limits = %#v, want max streams 5 and transcodes 1", limits)
+	}
+	if authorizer.request.Action != auth.ActionPlaybackPlay {
+		t.Fatalf("authorizer action = %q, want %q", authorizer.request.Action, auth.ActionPlaybackPlay)
+	}
+}

--- a/internal/auth/account_provisioner.go
+++ b/internal/auth/account_provisioner.go
@@ -14,6 +14,10 @@ type AccountUserRepository interface {
 	Delete(ctx context.Context, id int) error
 }
 
+type AccountACLGroupAssigner interface {
+	ReplaceUserGroups(ctx context.Context, userID int, groupSlugs []string) error
+}
+
 type DefaultProfileOptions struct {
 	Enabled bool
 	Name    string
@@ -48,6 +52,17 @@ func (p *AccountProvisioner) CreateAccount(
 		return nil, err
 	}
 
+	if err := p.assignDefaultACLGroups(ctx, user, input.User.Role); err != nil {
+		if deleteErr := p.users.Delete(ctx, user.ID); deleteErr != nil {
+			return nil, fmt.Errorf(
+				"assign default ACL groups: %w (cleanup user: %v)",
+				err,
+				deleteErr,
+			)
+		}
+		return nil, fmt.Errorf("assign default ACL groups: %w", err)
+	}
+
 	if !input.DefaultProfile.Enabled {
 		return user, nil
 	}
@@ -64,6 +79,19 @@ func (p *AccountProvisioner) CreateAccount(
 	}
 
 	return user, nil
+}
+
+func (p *AccountProvisioner) assignDefaultACLGroups(ctx context.Context, user *models.User, inputRole string) error {
+	assigner, ok := p.users.(AccountACLGroupAssigner)
+	if !ok || user == nil {
+		return nil
+	}
+
+	role := strings.TrimSpace(user.Role)
+	if role == "" {
+		role = inputRole
+	}
+	return assigner.ReplaceUserGroups(ctx, user.ID, DefaultACLGroupSlugsForRole(role))
 }
 
 func (p *AccountProvisioner) createDefaultProfile(

--- a/internal/auth/account_provisioner_test.go
+++ b/internal/auth/account_provisioner_test.go
@@ -10,8 +10,9 @@ import (
 )
 
 type stubAccountUsers struct {
-	createFn func(context.Context, models.CreateUserInput) (*models.User, error)
-	deleteFn func(context.Context, int) error
+	createFn        func(context.Context, models.CreateUserInput) (*models.User, error)
+	deleteFn        func(context.Context, int) error
+	replaceGroupsFn func(context.Context, int, []string) error
 }
 
 func (s stubAccountUsers) Create(ctx context.Context, input models.CreateUserInput) (*models.User, error) {
@@ -23,6 +24,13 @@ func (s stubAccountUsers) Delete(ctx context.Context, id int) error {
 		return nil
 	}
 	return s.deleteFn(ctx, id)
+}
+
+func (s stubAccountUsers) ReplaceUserGroups(ctx context.Context, id int, groupSlugs []string) error {
+	if s.replaceGroupsFn == nil {
+		return nil
+	}
+	return s.replaceGroupsFn(ctx, id, groupSlugs)
 }
 
 type stubStoreProvider struct {
@@ -106,6 +114,66 @@ func TestAccountProvisionerCreateAccount_CreatesDefaultProfile(t *testing.T) {
 	}
 	if !createdProfile.ShowForcedSubtitles {
 		t.Fatal("created profile should enable forced subtitles by default")
+	}
+}
+
+func TestAccountProvisionerCreateAccount_AssignsDefaultACLGroup(t *testing.T) {
+	var assignedUserID int
+	var assignedGroups []string
+	provisioner := NewAccountProvisioner(
+		stubAccountUsers{
+			createFn: func(context.Context, models.CreateUserInput) (*models.User, error) {
+				return &models.User{ID: 7, Username: "alex", Role: "user"}, nil
+			},
+			replaceGroupsFn: func(_ context.Context, userID int, groupSlugs []string) error {
+				assignedUserID = userID
+				assignedGroups = append([]string(nil), groupSlugs...)
+				return nil
+			},
+		},
+		nil,
+	)
+
+	_, err := provisioner.CreateAccount(context.Background(), CreateAccountInput{
+		User: models.CreateUserInput{Username: "alex", Role: "user"},
+	})
+	if err != nil {
+		t.Fatalf("CreateAccount returned error: %v", err)
+	}
+	if assignedUserID != 7 {
+		t.Fatalf("assigned user id = %d, want 7", assignedUserID)
+	}
+	if len(assignedGroups) != 1 || assignedGroups[0] != string(GroupStandardUser) {
+		t.Fatalf("assigned groups = %#v, want [standard_user]", assignedGroups)
+	}
+}
+
+func TestAccountProvisionerCreateAccount_DeletesUserWhenDefaultACLGroupAssignmentFails(t *testing.T) {
+	var deletedUserID int
+	provisioner := NewAccountProvisioner(
+		stubAccountUsers{
+			createFn: func(context.Context, models.CreateUserInput) (*models.User, error) {
+				return &models.User{ID: 9, Username: "alex", Role: "user"}, nil
+			},
+			replaceGroupsFn: func(context.Context, int, []string) error {
+				return errors.New("groups unavailable")
+			},
+			deleteFn: func(_ context.Context, id int) error {
+				deletedUserID = id
+				return nil
+			},
+		},
+		nil,
+	)
+
+	_, err := provisioner.CreateAccount(context.Background(), CreateAccountInput{
+		User: models.CreateUserInput{Username: "alex", Role: "user"},
+	})
+	if err == nil {
+		t.Fatal("CreateAccount returned nil error, want failure")
+	}
+	if deletedUserID != 9 {
+		t.Fatalf("deletedUserID = %d, want 9", deletedUserID)
 	}
 }
 

--- a/internal/auth/acl_actions.go
+++ b/internal/auth/acl_actions.go
@@ -1,0 +1,82 @@
+package auth
+
+type ACLAction string
+type ACLResourceType string
+type ACLEffect string
+type ACLSubjectType string
+type BuiltInGroupSlug string
+
+const (
+	EffectAllow ACLEffect = "allow"
+	EffectDeny  ACLEffect = "deny"
+)
+
+const (
+	SubjectUser        ACLSubjectType = "user"
+	SubjectGroup       ACLSubjectType = "group"
+	SubjectBuiltInRole ACLSubjectType = "builtin_role"
+	SubjectEveryone    ACLSubjectType = "everyone"
+)
+
+const (
+	GroupOwner            BuiltInGroupSlug = "owner"
+	GroupAdmin            BuiltInGroupSlug = "admin"
+	GroupLibraryManager   BuiltInGroupSlug = "library_manager"
+	GroupMetadataCurator  BuiltInGroupSlug = "metadata_curator"
+	GroupViewer           BuiltInGroupSlug = "viewer"
+	GroupRestrictedViewer BuiltInGroupSlug = "restricted_viewer"
+)
+
+const (
+	ActionServerView         ACLAction = "server.view"
+	ActionServerConfigure    ACLAction = "server.configure"
+	ActionSecurityManage     ACLAction = "security.manage"
+	ActionUsersView          ACLAction = "users.view"
+	ActionUsersManage        ACLAction = "users.manage"
+	ActionUsersImpersonate   ACLAction = "users.impersonate"
+	ActionLibrariesView      ACLAction = "libraries.view"
+	ActionLibrariesManage    ACLAction = "libraries.manage"
+	ActionTasksView          ACLAction = "tasks.view"
+	ActionTasksRun           ACLAction = "tasks.run"
+	ActionLogsView           ACLAction = "logs.view"
+	ActionPluginsView        ACLAction = "plugins.view"
+	ActionPluginsManage      ACLAction = "plugins.manage"
+	ActionNodesView          ACLAction = "nodes.view"
+	ActionNodesManage        ACLAction = "nodes.manage"
+	ActionMetadataCurate     ACLAction = "metadata.curate"
+	ActionMarkersEdit        ACLAction = "markers.edit"
+	ActionPlaybackPlay       ACLAction = "playback.play"
+	ActionPlaybackTranscode  ACLAction = "playback.transcode"
+	ActionDownloadsDirect    ACLAction = "downloads.direct"
+	ActionDownloadsTranscode ACLAction = "downloads.transcode"
+	ActionProfilesManage     ACLAction = "profiles.manage"
+	ActionRequestsCreate     ACLAction = "requests.create"
+	ActionRequestsApprove    ACLAction = "requests.approve"
+)
+
+const (
+	ResourceServer           ACLResourceType = "server"
+	ResourceSecuritySettings ACLResourceType = "security_settings"
+	ResourceUser             ACLResourceType = "user"
+	ResourceGroup            ACLResourceType = "group"
+	ResourceLibrary          ACLResourceType = "library"
+	ResourceMediaItem        ACLResourceType = "media_item"
+	ResourceMediaType        ACLResourceType = "media_type"
+	ResourceTask             ACLResourceType = "task"
+	ResourceLog              ACLResourceType = "log"
+	ResourcePlugin           ACLResourceType = "plugin"
+	ResourceRemoteNode       ACLResourceType = "remote_node"
+	ResourceProfile          ACLResourceType = "profile"
+	ResourceRequest          ACLResourceType = "request"
+)
+
+func LegacyPermissionAction(permission Permission) ACLAction {
+	switch permission {
+	case PermissionMarkerEdit:
+		return ActionMarkersEdit
+	case PermissionMetadataCuration:
+		return ActionMetadataCurate
+	default:
+		return ""
+	}
+}

--- a/internal/auth/acl_actions.go
+++ b/internal/auth/acl_actions.go
@@ -1,5 +1,10 @@
 package auth
 
+import (
+	"fmt"
+	"strings"
+)
+
 type ACLAction string
 type ACLResourceType string
 type ACLEffect string
@@ -19,39 +24,42 @@ const (
 )
 
 const (
-	GroupOwner            BuiltInGroupSlug = "owner"
-	GroupAdmin            BuiltInGroupSlug = "admin"
-	GroupLibraryManager   BuiltInGroupSlug = "library_manager"
-	GroupMetadataCurator  BuiltInGroupSlug = "metadata_curator"
-	GroupViewer           BuiltInGroupSlug = "viewer"
-	GroupRestrictedViewer BuiltInGroupSlug = "restricted_viewer"
+	GroupOwner           BuiltInGroupSlug = "owner"
+	GroupAdmin           BuiltInGroupSlug = "admin"
+	GroupLibraryManager  BuiltInGroupSlug = "library_manager"
+	GroupMetadataCurator BuiltInGroupSlug = "metadata_curator"
+	GroupStandardUser    BuiltInGroupSlug = "standard_user"
+	GroupRestrictedUser  BuiltInGroupSlug = "restricted_user"
 )
 
 const (
-	ActionServerView         ACLAction = "server.view"
-	ActionServerConfigure    ACLAction = "server.configure"
-	ActionSecurityManage     ACLAction = "security.manage"
-	ActionUsersView          ACLAction = "users.view"
-	ActionUsersManage        ACLAction = "users.manage"
-	ActionUsersImpersonate   ACLAction = "users.impersonate"
-	ActionLibrariesView      ACLAction = "libraries.view"
-	ActionLibrariesManage    ACLAction = "libraries.manage"
-	ActionTasksView          ACLAction = "tasks.view"
-	ActionTasksRun           ACLAction = "tasks.run"
-	ActionLogsView           ACLAction = "logs.view"
-	ActionPluginsView        ACLAction = "plugins.view"
-	ActionPluginsManage      ACLAction = "plugins.manage"
-	ActionNodesView          ACLAction = "nodes.view"
-	ActionNodesManage        ACLAction = "nodes.manage"
-	ActionMetadataCurate     ACLAction = "metadata.curate"
-	ActionMarkersEdit        ACLAction = "markers.edit"
-	ActionPlaybackPlay       ACLAction = "playback.play"
-	ActionPlaybackTranscode  ACLAction = "playback.transcode"
-	ActionDownloadsDirect    ACLAction = "downloads.direct"
-	ActionDownloadsTranscode ACLAction = "downloads.transcode"
-	ActionProfilesManage     ACLAction = "profiles.manage"
-	ActionRequestsCreate     ACLAction = "requests.create"
-	ActionRequestsApprove    ACLAction = "requests.approve"
+	ActionServerView            ACLAction = "server.view"
+	ActionServerConfigure       ACLAction = "server.configure"
+	ActionSecurityManage        ACLAction = "security.manage"
+	ActionUsersView             ACLAction = "users.view"
+	ActionUsersManage           ACLAction = "users.manage"
+	ActionUsersImpersonate      ACLAction = "users.impersonate"
+	ActionLibrariesView         ACLAction = "libraries.view"
+	ActionLibrariesManage       ACLAction = "libraries.manage"
+	ActionTasksView             ACLAction = "tasks.view"
+	ActionTasksRun              ACLAction = "tasks.run"
+	ActionLogsView              ACLAction = "logs.view"
+	ActionPluginsView           ACLAction = "plugins.view"
+	ActionPluginsManage         ACLAction = "plugins.manage"
+	ActionNodesView             ACLAction = "nodes.view"
+	ActionNodesManage           ACLAction = "nodes.manage"
+	ActionRecommendationsView   ACLAction = "recommendations.view"
+	ActionRecommendationsManage ACLAction = "recommendations.manage"
+	ActionMetadataCurate        ACLAction = "metadata.curate"
+	ActionMarkersEdit           ACLAction = "markers.edit"
+	ActionPlaybackPlay          ACLAction = "playback.play"
+	ActionPlaybackTranscode     ACLAction = "playback.transcode"
+	ActionDownloadsDirect       ACLAction = "downloads.direct"
+	ActionDownloadsTranscode    ACLAction = "downloads.transcode"
+	ActionProfilesManage        ACLAction = "profiles.manage"
+	ActionPersonalListsManage   ACLAction = "personal_lists.manage"
+	ActionRequestsCreate        ACLAction = "requests.create"
+	ActionRequestsApprove       ACLAction = "requests.approve"
 )
 
 const (
@@ -78,5 +86,304 @@ func LegacyPermissionAction(permission Permission) ACLAction {
 		return ActionMetadataCurate
 	default:
 		return ""
+	}
+}
+
+func DefaultACLGroupSlugsForRole(role string) []string {
+	if strings.TrimSpace(strings.ToLower(role)) == "admin" {
+		return []string{string(GroupAdmin)}
+	}
+	return []string{string(GroupStandardUser)}
+}
+
+func NormalizeACLGroupSlug(raw string) (string, error) {
+	slug := strings.TrimSpace(strings.ToLower(raw))
+	if !validACLGroupSlug(slug) {
+		return "", fmt.Errorf("invalid ACL group slug %q", raw)
+	}
+	return slug, nil
+}
+
+func NormalizeACLGroupSlugs(slugs []string) ([]string, error) {
+	out := make([]string, 0, len(slugs))
+	seen := map[string]struct{}{}
+	for _, raw := range slugs {
+		slug := strings.TrimSpace(strings.ToLower(raw))
+		if slug == "" {
+			continue
+		}
+		if !validACLGroupSlug(slug) {
+			return nil, fmt.Errorf("invalid ACL group slug %q", slug)
+		}
+		if _, ok := seen[slug]; ok {
+			continue
+		}
+		seen[slug] = struct{}{}
+		out = append(out, slug)
+	}
+	return out, nil
+}
+
+func validACLGroupSlug(slug string) bool {
+	for i, r := range slug {
+		switch {
+		case r >= 'a' && r <= 'z':
+		case r >= '0' && r <= '9' && i > 0:
+		case (r == '_' || r == '-') && i > 0:
+		default:
+			return false
+		}
+	}
+	return slug != ""
+}
+
+func NormalizeACLRuleInput(input ACLRuleInput) (ACLRuleInput, error) {
+	out := input
+	out.Action = ACLAction(strings.TrimSpace(strings.ToLower(string(input.Action))))
+	out.ResourceType = ACLResourceType(strings.TrimSpace(strings.ToLower(string(input.ResourceType))))
+	out.ResourceID = strings.TrimSpace(input.ResourceID)
+	out.Effect = ACLEffect(strings.TrimSpace(strings.ToLower(string(input.Effect))))
+	out.Name = strings.TrimSpace(input.Name)
+	out.Description = strings.TrimSpace(input.Description)
+	out.Conditions = normalizeACLCondition(input.Conditions)
+
+	if !ValidACLAction(out.Action) {
+		return ACLRuleInput{}, fmt.Errorf("invalid ACL action %q", input.Action)
+	}
+	if !ValidACLResourceType(out.ResourceType) {
+		return ACLRuleInput{}, fmt.Errorf("invalid ACL resource type %q", input.ResourceType)
+	}
+	if out.ResourceID == "" {
+		out.ResourceID = "*"
+	}
+	if out.Effect == "" {
+		out.Effect = EffectAllow
+	}
+	if out.Effect != EffectAllow && out.Effect != EffectDeny {
+		return ACLRuleInput{}, fmt.Errorf("invalid ACL effect %q", input.Effect)
+	}
+	if out.Conditions.MaxPlaybackQuality != "" {
+		if _, ok := playbackQualityRank(out.Conditions.MaxPlaybackQuality); !ok {
+			return ACLRuleInput{}, fmt.Errorf("invalid ACL max playback quality %q", out.Conditions.MaxPlaybackQuality)
+		}
+	}
+	if out.Conditions.MaxContentRating != "" {
+		if _, ok := contentRatingRank(out.Conditions.MaxContentRating); !ok {
+			return ACLRuleInput{}, fmt.Errorf("invalid ACL max content rating %q", out.Conditions.MaxContentRating)
+		}
+	}
+	if out.Conditions.MaxStreams != nil && *out.Conditions.MaxStreams < 0 {
+		return ACLRuleInput{}, fmt.Errorf("invalid ACL max streams %d", *out.Conditions.MaxStreams)
+	}
+	if out.Conditions.MaxTranscodes != nil && *out.Conditions.MaxTranscodes < 0 {
+		return ACLRuleInput{}, fmt.Errorf("invalid ACL max transcodes %d", *out.Conditions.MaxTranscodes)
+	}
+	return out, nil
+}
+
+func NormalizeACLRuleInputs(inputs []ACLRuleInput) ([]ACLRuleInput, error) {
+	out := make([]ACLRuleInput, 0, len(inputs))
+	for _, input := range inputs {
+		normalized, err := NormalizeACLRuleInput(input)
+		if err != nil {
+			return nil, err
+		}
+		out = append(out, normalized)
+	}
+	return out, nil
+}
+
+func NormalizeACLPolicy(input ACLPolicy) (ACLPolicy, error) {
+	out := input
+	if out.LibraryIDs != nil {
+		libraryIDs := make([]int, 0, len(out.LibraryIDs))
+		seen := map[int]struct{}{}
+		for _, id := range out.LibraryIDs {
+			if _, ok := seen[id]; ok {
+				continue
+			}
+			seen[id] = struct{}{}
+			libraryIDs = append(libraryIDs, id)
+		}
+		out.LibraryIDs = libraryIDs
+	}
+	if out.MediaTypes != nil {
+		mediaTypes := make([]string, 0, len(out.MediaTypes))
+		seen := map[string]struct{}{}
+		for _, raw := range out.MediaTypes {
+			mediaType := strings.TrimSpace(strings.ToLower(raw))
+			if mediaType == "" {
+				continue
+			}
+			if _, ok := seen[mediaType]; ok {
+				continue
+			}
+			seen[mediaType] = struct{}{}
+			mediaTypes = append(mediaTypes, mediaType)
+		}
+		out.MediaTypes = mediaTypes
+	}
+	out.MaxPlaybackQuality = strings.ToUpper(strings.TrimSpace(out.MaxPlaybackQuality))
+	if out.MaxPlaybackQuality != "" {
+		if _, ok := playbackQualityRank(out.MaxPlaybackQuality); !ok {
+			return ACLPolicy{}, fmt.Errorf("invalid ACL max playback quality %q", out.MaxPlaybackQuality)
+		}
+	}
+	if out.MaxStreams != nil && *out.MaxStreams < 0 {
+		return ACLPolicy{}, fmt.Errorf("invalid ACL max streams %d", *out.MaxStreams)
+	}
+	if out.MaxTranscodes != nil && *out.MaxTranscodes < 0 {
+		return ACLPolicy{}, fmt.Errorf("invalid ACL max transcodes %d", *out.MaxTranscodes)
+	}
+	if out.MaxProfiles != nil && *out.MaxProfiles < 1 {
+		return ACLPolicy{}, fmt.Errorf("invalid ACL max profiles %d", *out.MaxProfiles)
+	}
+	return out, nil
+}
+
+func ValidACLAction(action ACLAction) bool {
+	_, ok := validACLActions[action]
+	return ok
+}
+
+func ValidACLResourceType(resourceType ACLResourceType) bool {
+	_, ok := validACLResourceTypes[resourceType]
+	return ok
+}
+
+func normalizeACLCondition(condition ACLCondition) ACLCondition {
+	out := condition
+	if out.MediaTypes != nil {
+		mediaTypes := make([]string, 0, len(out.MediaTypes))
+		seen := map[string]struct{}{}
+		for _, raw := range out.MediaTypes {
+			mediaType := strings.TrimSpace(strings.ToLower(raw))
+			if mediaType == "" {
+				continue
+			}
+			if _, ok := seen[mediaType]; ok {
+				continue
+			}
+			seen[mediaType] = struct{}{}
+			mediaTypes = append(mediaTypes, mediaType)
+		}
+		out.MediaTypes = mediaTypes
+	}
+	out.MaxPlaybackQuality = strings.ToUpper(strings.TrimSpace(out.MaxPlaybackQuality))
+	out.MaxContentRating = strings.ToUpper(strings.TrimSpace(out.MaxContentRating))
+	return out
+}
+
+var validACLActions = map[ACLAction]struct{}{
+	ActionServerView:            {},
+	ActionServerConfigure:       {},
+	ActionSecurityManage:        {},
+	ActionUsersView:             {},
+	ActionUsersManage:           {},
+	ActionUsersImpersonate:      {},
+	ActionLibrariesView:         {},
+	ActionLibrariesManage:       {},
+	ActionTasksView:             {},
+	ActionTasksRun:              {},
+	ActionLogsView:              {},
+	ActionPluginsView:           {},
+	ActionPluginsManage:         {},
+	ActionNodesView:             {},
+	ActionNodesManage:           {},
+	ActionRecommendationsView:   {},
+	ActionRecommendationsManage: {},
+	ActionMetadataCurate:        {},
+	ActionMarkersEdit:           {},
+	ActionPlaybackPlay:          {},
+	ActionPlaybackTranscode:     {},
+	ActionDownloadsDirect:       {},
+	ActionDownloadsTranscode:    {},
+	ActionProfilesManage:        {},
+	ActionPersonalListsManage:   {},
+	ActionRequestsCreate:        {},
+	ActionRequestsApprove:       {},
+}
+
+var validACLResourceTypes = map[ACLResourceType]struct{}{
+	ResourceServer:           {},
+	ResourceSecuritySettings: {},
+	ResourceUser:             {},
+	ResourceGroup:            {},
+	ResourceLibrary:          {},
+	ResourceMediaItem:        {},
+	ResourceMediaType:        {},
+	ResourceTask:             {},
+	ResourceLog:              {},
+	ResourcePlugin:           {},
+	ResourceRemoteNode:       {},
+	ResourceProfile:          {},
+	ResourceRequest:          {},
+}
+
+func AdminCapabilityActions() []ACLAction {
+	return []ACLAction{
+		ActionServerView,
+		ActionServerConfigure,
+		ActionSecurityManage,
+		ActionUsersView,
+		ActionUsersManage,
+		ActionUsersImpersonate,
+		ActionLibrariesView,
+		ActionLibrariesManage,
+		ActionTasksView,
+		ActionTasksRun,
+		ActionLogsView,
+		ActionPluginsView,
+		ActionPluginsManage,
+		ActionNodesView,
+		ActionNodesManage,
+		ActionRecommendationsView,
+		ActionRecommendationsManage,
+		ActionProfilesManage,
+		ActionRequestsApprove,
+	}
+}
+
+func ExplainableCapabilityActions() []ACLAction {
+	return []ACLAction{
+		ActionServerView,
+		ActionServerConfigure,
+		ActionSecurityManage,
+		ActionLogsView,
+		ActionUsersView,
+		ActionUsersManage,
+		ActionUsersImpersonate,
+		ActionProfilesManage,
+		ActionPersonalListsManage,
+		ActionRequestsCreate,
+		ActionRequestsApprove,
+		ActionLibrariesView,
+		ActionLibrariesManage,
+		ActionMetadataCurate,
+		ActionMarkersEdit,
+		ActionRecommendationsView,
+		ActionRecommendationsManage,
+		ActionTasksView,
+		ActionTasksRun,
+		ActionPluginsView,
+		ActionPluginsManage,
+		ActionNodesView,
+		ActionNodesManage,
+		ActionPlaybackPlay,
+		ActionPlaybackTranscode,
+		ActionDownloadsDirect,
+		ActionDownloadsTranscode,
+	}
+}
+
+func UserFacingCapabilityActions() []ACLAction {
+	return []ACLAction{
+		ActionPlaybackPlay,
+		ActionPlaybackTranscode,
+		ActionDownloadsDirect,
+		ActionDownloadsTranscode,
+		ActionProfilesManage,
+		ActionPersonalListsManage,
+		ActionRequestsCreate,
 	}
 }

--- a/internal/auth/acl_actions_test.go
+++ b/internal/auth/acl_actions_test.go
@@ -1,0 +1,28 @@
+package auth
+
+import "testing"
+
+func TestACLActionConstantsCoverLegacyPermissions(t *testing.T) {
+	if LegacyPermissionAction(PermissionMarkerEdit) != ActionMarkersEdit {
+		t.Fatalf("marker_edit maps to %q, want %q", LegacyPermissionAction(PermissionMarkerEdit), ActionMarkersEdit)
+	}
+	if LegacyPermissionAction(PermissionMetadataCuration) != ActionMetadataCurate {
+		t.Fatalf("metadata_curation maps to %q, want %q", LegacyPermissionAction(PermissionMetadataCuration), ActionMetadataCurate)
+	}
+}
+
+func TestBuiltInGroupSlugsAreStable(t *testing.T) {
+	tests := map[string]BuiltInGroupSlug{
+		"owner":             GroupOwner,
+		"admin":             GroupAdmin,
+		"library_manager":   GroupLibraryManager,
+		"metadata_curator":  GroupMetadataCurator,
+		"viewer":            GroupViewer,
+		"restricted_viewer": GroupRestrictedViewer,
+	}
+	for want, got := range tests {
+		if string(got) != want {
+			t.Fatalf("group slug = %q, want %q", got, want)
+		}
+	}
+}

--- a/internal/auth/acl_actions_test.go
+++ b/internal/auth/acl_actions_test.go
@@ -11,18 +11,102 @@ func TestACLActionConstantsCoverLegacyPermissions(t *testing.T) {
 	}
 }
 
+func TestACLActionConstantsIncludeAdminRecommendationActions(t *testing.T) {
+	for _, action := range []ACLAction{
+		ActionRecommendationsView,
+		ActionRecommendationsManage,
+	} {
+		if !ValidACLAction(action) {
+			t.Fatalf("ValidACLAction(%q) = false, want true", action)
+		}
+	}
+}
+
+func TestACLActionConstantsIncludePersonalListMutationAction(t *testing.T) {
+	if !ValidACLAction(ActionPersonalListsManage) {
+		t.Fatalf("ValidACLAction(%q) = false, want true", ActionPersonalListsManage)
+	}
+}
+
+func TestUserFacingCapabilityActionsAreStable(t *testing.T) {
+	got := UserFacingCapabilityActions()
+	want := []ACLAction{
+		ActionPlaybackPlay,
+		ActionPlaybackTranscode,
+		ActionDownloadsDirect,
+		ActionDownloadsTranscode,
+		ActionProfilesManage,
+		ActionPersonalListsManage,
+		ActionRequestsCreate,
+	}
+	if len(got) != len(want) {
+		t.Fatalf("actions = %#v, want %#v", got, want)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("actions = %#v, want %#v", got, want)
+		}
+	}
+}
+
 func TestBuiltInGroupSlugsAreStable(t *testing.T) {
 	tests := map[string]BuiltInGroupSlug{
-		"owner":             GroupOwner,
-		"admin":             GroupAdmin,
-		"library_manager":   GroupLibraryManager,
-		"metadata_curator":  GroupMetadataCurator,
-		"viewer":            GroupViewer,
-		"restricted_viewer": GroupRestrictedViewer,
+		"owner":            GroupOwner,
+		"admin":            GroupAdmin,
+		"library_manager":  GroupLibraryManager,
+		"metadata_curator": GroupMetadataCurator,
+		"standard_user":    GroupStandardUser,
+		"restricted_user":  GroupRestrictedUser,
 	}
 	for want, got := range tests {
 		if string(got) != want {
 			t.Fatalf("group slug = %q, want %q", got, want)
 		}
+	}
+}
+
+func TestDefaultACLGroupSlugsForRole(t *testing.T) {
+	tests := map[string][]string{
+		"admin": {string(GroupAdmin)},
+		"user":  {string(GroupStandardUser)},
+		"":      {string(GroupStandardUser)},
+	}
+	for role, want := range tests {
+		got := DefaultACLGroupSlugsForRole(role)
+		if len(got) != len(want) {
+			t.Fatalf("role %q default groups = %#v, want %#v", role, got, want)
+		}
+		for i := range want {
+			if got[i] != want[i] {
+				t.Fatalf("role %q default groups = %#v, want %#v", role, got, want)
+			}
+		}
+	}
+}
+
+func TestNormalizeACLGroupSlugs(t *testing.T) {
+	got, err := NormalizeACLGroupSlugs([]string{
+		" standard_user ",
+		"metadata_curator",
+		"standard_user",
+		"",
+	})
+	if err != nil {
+		t.Fatalf("NormalizeACLGroupSlugs() error = %v", err)
+	}
+	want := []string{"standard_user", "metadata_curator"}
+	if len(got) != len(want) {
+		t.Fatalf("normalized groups = %#v, want %#v", got, want)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("normalized groups = %#v, want %#v", got, want)
+		}
+	}
+}
+
+func TestNormalizeACLGroupSlugsRejectsInvalidSlug(t *testing.T) {
+	if _, err := NormalizeACLGroupSlugs([]string{"standard user"}); err == nil {
+		t.Fatalf("NormalizeACLGroupSlugs() error = nil, want invalid slug error")
 	}
 }

--- a/internal/auth/acl_authorizer.go
+++ b/internal/auth/acl_authorizer.go
@@ -19,6 +19,10 @@ type ACLRuleLoader interface {
 	ListRulesForUser(ctx context.Context, userID int) ([]ACLRule, error)
 }
 
+type ACLPolicyLoader interface {
+	ListPoliciesForUser(ctx context.Context, userID int) ([]ACLPolicy, error)
+}
+
 type ACLAuthorizer struct {
 	rules     ACLRuleLoader
 	users     UserLoaderForACL
@@ -67,6 +71,14 @@ func (a *ACLAuthorizer) loadInputs(ctx context.Context, userID int) (*models.Use
 		rules = append(rules, repositoryRules...)
 	}
 	rules = append(rules, CompatibilityRulesForUser(user)...)
+	policy := CompatibilityEffectivePolicyForUser(user)
+	if loader, ok := a.rules.(ACLPolicyLoader); ok {
+		policies, err := loader.ListPoliciesForUser(ctx, userID)
+		if err != nil {
+			return nil, nil, EffectivePolicy{}, err
+		}
+		policy = MergeACLPolicies(policy, policies)
+	}
 
-	return user, rules, CompatibilityEffectivePolicyForUser(user), nil
+	return user, rules, policy, nil
 }

--- a/internal/auth/acl_authorizer.go
+++ b/internal/auth/acl_authorizer.go
@@ -1,0 +1,69 @@
+package auth
+
+import (
+	"context"
+
+	"github.com/Silo-Server/silo-server/internal/models"
+)
+
+type Authorizer interface {
+	Authorize(ctx context.Context, request AccessRequest) (AccessDecision, error)
+	Explain(ctx context.Context, request AccessRequest) (AccessExplanation, error)
+}
+
+type UserLoaderForACL interface {
+	GetByID(ctx context.Context, id int) (*models.User, error)
+}
+
+type ACLRuleLoader interface {
+	ListRulesForUser(ctx context.Context, userID int) ([]ACLRule, error)
+}
+
+type ACLAuthorizer struct {
+	rules     ACLRuleLoader
+	users     UserLoaderForACL
+	evaluator *ACLEvaluator
+}
+
+func NewACLAuthorizer(rules ACLRuleLoader, users UserLoaderForACL) *ACLAuthorizer {
+	return &ACLAuthorizer{
+		rules:     rules,
+		users:     users,
+		evaluator: NewACLEvaluator(),
+	}
+}
+
+func (a *ACLAuthorizer) Authorize(ctx context.Context, request AccessRequest) (AccessDecision, error) {
+	user, rules, policy, err := a.loadInputs(ctx, request.UserID)
+	if err != nil {
+		return AccessDecision{}, err
+	}
+	return a.evaluator.Authorize(request, rules, policy, user != nil && user.Enabled), nil
+}
+
+func (a *ACLAuthorizer) Explain(ctx context.Context, request AccessRequest) (AccessExplanation, error) {
+	user, rules, policy, err := a.loadInputs(ctx, request.UserID)
+	if err != nil {
+		return AccessExplanation{}, err
+	}
+	return a.evaluator.Explain(request, rules, policy, user != nil && user.Enabled), nil
+}
+
+func (a *ACLAuthorizer) loadInputs(ctx context.Context, userID int) (*models.User, []ACLRule, EffectivePolicy, error) {
+	user, err := a.users.GetByID(ctx, userID)
+	if err != nil {
+		return nil, nil, EffectivePolicy{}, err
+	}
+
+	rules := []ACLRule{}
+	if a.rules != nil {
+		repositoryRules, err := a.rules.ListRulesForUser(ctx, userID)
+		if err != nil {
+			return nil, nil, EffectivePolicy{}, err
+		}
+		rules = append(rules, repositoryRules...)
+	}
+	rules = append(rules, CompatibilityRulesForUser(user)...)
+
+	return user, rules, CompatibilityEffectivePolicyForUser(user), nil
+}

--- a/internal/auth/acl_authorizer.go
+++ b/internal/auth/acl_authorizer.go
@@ -54,6 +54,9 @@ func (a *ACLAuthorizer) loadInputs(ctx context.Context, userID int) (*models.Use
 	if err != nil {
 		return nil, nil, EffectivePolicy{}, err
 	}
+	if user == nil || !user.Enabled {
+		return user, nil, EffectivePolicy{}, nil
+	}
 
 	rules := []ACLRule{}
 	if a.rules != nil {

--- a/internal/auth/acl_authorizer_test.go
+++ b/internal/auth/acl_authorizer_test.go
@@ -23,11 +23,26 @@ func (f fakeACLRuleLoader) ListRulesForUser(ctx context.Context, userID int) ([]
 	return f.rules, nil
 }
 
+type trackingACLRuleLoader struct {
+	calls int
+	err   error
+	rules []ACLRule
+}
+
+func (f *trackingACLRuleLoader) ListRulesForUser(ctx context.Context, userID int) ([]ACLRule, error) {
+	f.calls++
+	if f.err != nil {
+		return nil, f.err
+	}
+	return f.rules, nil
+}
+
 func TestACLAuthorizerCombinesRepositoryAndCompatibilityRules(t *testing.T) {
 	user := &models.User{ID: 7, Role: "user", Enabled: true, Permissions: []string{"marker_edit"}, MaxStreams: 2}
 	ruleLoader := fakeACLRuleLoader{
 		rules: []ACLRule{
 			{ID: 99, SubjectType: SubjectGroup, SubjectID: "viewer", Action: ActionPlaybackPlay, ResourceType: ResourceLibrary, ResourceID: "10", Effect: EffectAllow, Priority: 1, Name: "viewer playback"},
+			{ID: 100, SubjectType: SubjectUser, SubjectID: "7", Action: ActionMarkersEdit, ResourceType: ResourceServer, ResourceID: "*", Effect: EffectAllow, Priority: 2, Name: "repository marker edit"},
 		},
 	}
 
@@ -41,5 +56,61 @@ func TestACLAuthorizerCombinesRepositoryAndCompatibilityRules(t *testing.T) {
 	}
 	if decision.EffectivePolicy.MaxStreams != 2 {
 		t.Fatalf("effective max streams = %d, want 2", decision.EffectivePolicy.MaxStreams)
+	}
+	if len(decision.MatchedRules) != 2 {
+		t.Fatalf("matched rules = %#v, want repository and compatibility rules", decision.MatchedRules)
+	}
+	foundRepositoryRule := false
+	for _, rule := range decision.MatchedRules {
+		if rule.ID == 100 {
+			foundRepositoryRule = true
+		}
+	}
+	if !foundRepositoryRule {
+		t.Fatalf("matched rules = %#v, want repository rule 100 to be included", decision.MatchedRules)
+	}
+}
+
+func TestACLAuthorizerDisabledUserShortCircuitsBeforeRuleLoad(t *testing.T) {
+	user := &models.User{ID: 7, Role: "user", Enabled: false}
+	ruleLoader := &trackingACLRuleLoader{err: context.Canceled}
+
+	authorizer := NewACLAuthorizer(ruleLoader, fakeACLUserLoader{user: user})
+	decision, err := authorizer.Authorize(context.Background(), AccessRequest{UserID: 7, Action: ActionMarkersEdit, ResourceType: ResourceServer, ResourceID: "*"})
+	if err != nil {
+		t.Fatalf("authorize error: %v", err)
+	}
+	if decision.Allowed {
+		t.Fatalf("disabled user should be denied: %#v", decision)
+	}
+	if decision.ReasonCode != "user_disabled" {
+		t.Fatalf("reason = %q, want user_disabled", decision.ReasonCode)
+	}
+	if ruleLoader.calls != 0 {
+		t.Fatalf("rule loader calls = %d, want 0", ruleLoader.calls)
+	}
+}
+
+func TestACLAuthorizerExplainIncludesEvaluatedRules(t *testing.T) {
+	user := &models.User{ID: 7, Role: "user", Enabled: true}
+	ruleLoader := fakeACLRuleLoader{
+		rules: []ACLRule{
+			{ID: 77, SubjectType: SubjectUser, SubjectID: "7", Action: ActionPlaybackPlay, ResourceType: ResourceServer, ResourceID: "*", Effect: EffectAllow, Priority: 5, Name: "repository playback"},
+		},
+	}
+
+	authorizer := NewACLAuthorizer(ruleLoader, fakeACLUserLoader{user: user})
+	explanation, err := authorizer.Explain(context.Background(), AccessRequest{UserID: 7, Action: ActionPlaybackPlay, ResourceType: ResourceServer, ResourceID: "*"})
+	if err != nil {
+		t.Fatalf("explain error: %v", err)
+	}
+	if !explanation.Decision.Allowed {
+		t.Fatalf("expected allowed explanation: %#v", explanation.Decision)
+	}
+	if len(explanation.EvaluatedRules) != 1 {
+		t.Fatalf("evaluated rules = %#v, want one repository rule", explanation.EvaluatedRules)
+	}
+	if explanation.EvaluatedRules[0].ID != 77 {
+		t.Fatalf("evaluated rule id = %d, want 77", explanation.EvaluatedRules[0].ID)
 	}
 }

--- a/internal/auth/acl_authorizer_test.go
+++ b/internal/auth/acl_authorizer_test.go
@@ -156,6 +156,23 @@ func TestACLAuthorizerLegacyMetadataCurationRespectsLibraryScope(t *testing.T) {
 	if deniedDecision.ReasonCode != "default_deny" {
 		t.Fatalf("reason code = %q, want default_deny", deniedDecision.ReasonCode)
 	}
+
+	partialOverlapDecision, err := authorizer.Authorize(context.Background(), AccessRequest{
+		UserID:       7,
+		Action:       ActionMetadataCurate,
+		ResourceType: ResourceMediaItem,
+		ResourceID:   "item-1",
+		LibraryIDs:   []int{10, 20},
+	})
+	if err != nil {
+		t.Fatalf("authorize partial-overlap request error: %v", err)
+	}
+	if partialOverlapDecision.Allowed {
+		t.Fatalf("expected partially out-of-scope multi-library request to be denied: %#v", partialOverlapDecision)
+	}
+	if partialOverlapDecision.ReasonCode != "default_deny" {
+		t.Fatalf("partial-overlap reason code = %q, want default_deny", partialOverlapDecision.ReasonCode)
+	}
 }
 
 func TestACLAuthorizerLegacyMetadataCurationDeniedWhenLibraryScopeEmpty(t *testing.T) {

--- a/internal/auth/acl_authorizer_test.go
+++ b/internal/auth/acl_authorizer_test.go
@@ -1,0 +1,45 @@
+package auth
+
+import (
+	"context"
+	"testing"
+
+	"github.com/Silo-Server/silo-server/internal/models"
+)
+
+type fakeACLUserLoader struct {
+	user *models.User
+}
+
+func (f fakeACLUserLoader) GetByID(ctx context.Context, id int) (*models.User, error) {
+	return f.user, nil
+}
+
+type fakeACLRuleLoader struct {
+	rules []ACLRule
+}
+
+func (f fakeACLRuleLoader) ListRulesForUser(ctx context.Context, userID int) ([]ACLRule, error) {
+	return f.rules, nil
+}
+
+func TestACLAuthorizerCombinesRepositoryAndCompatibilityRules(t *testing.T) {
+	user := &models.User{ID: 7, Role: "user", Enabled: true, Permissions: []string{"marker_edit"}, MaxStreams: 2}
+	ruleLoader := fakeACLRuleLoader{
+		rules: []ACLRule{
+			{ID: 99, SubjectType: SubjectGroup, SubjectID: "viewer", Action: ActionPlaybackPlay, ResourceType: ResourceLibrary, ResourceID: "10", Effect: EffectAllow, Priority: 1, Name: "viewer playback"},
+		},
+	}
+
+	authorizer := NewACLAuthorizer(ruleLoader, fakeACLUserLoader{user: user})
+	decision, err := authorizer.Authorize(context.Background(), AccessRequest{UserID: 7, Action: ActionMarkersEdit, ResourceType: ResourceServer, ResourceID: "*"})
+	if err != nil {
+		t.Fatalf("authorize error: %v", err)
+	}
+	if !decision.Allowed {
+		t.Fatalf("legacy marker_edit should allow markers.edit: %#v", decision)
+	}
+	if decision.EffectivePolicy.MaxStreams != 2 {
+		t.Fatalf("effective max streams = %d, want 2", decision.EffectivePolicy.MaxStreams)
+	}
+}

--- a/internal/auth/acl_authorizer_test.go
+++ b/internal/auth/acl_authorizer_test.go
@@ -23,6 +23,19 @@ func (f fakeACLRuleLoader) ListRulesForUser(ctx context.Context, userID int) ([]
 	return f.rules, nil
 }
 
+type fakeACLPolicyRuleLoader struct {
+	rules    []ACLRule
+	policies []ACLPolicy
+}
+
+func (f fakeACLPolicyRuleLoader) ListRulesForUser(ctx context.Context, userID int) ([]ACLRule, error) {
+	return f.rules, nil
+}
+
+func (f fakeACLPolicyRuleLoader) ListPoliciesForUser(ctx context.Context, userID int) ([]ACLPolicy, error) {
+	return f.policies, nil
+}
+
 type trackingACLRuleLoader struct {
 	calls int
 	err   error
@@ -41,7 +54,7 @@ func TestACLAuthorizerCombinesRepositoryAndCompatibilityRules(t *testing.T) {
 	user := &models.User{ID: 7, Role: "user", Enabled: true, Permissions: []string{"marker_edit"}, MaxStreams: 2}
 	ruleLoader := fakeACLRuleLoader{
 		rules: []ACLRule{
-			{ID: 99, SubjectType: SubjectGroup, SubjectID: "viewer", Action: ActionPlaybackPlay, ResourceType: ResourceLibrary, ResourceID: "10", Effect: EffectAllow, Priority: 1, Name: "viewer playback"},
+			{ID: 99, SubjectType: SubjectGroup, SubjectID: string(GroupStandardUser), Action: ActionPlaybackPlay, ResourceType: ResourceLibrary, ResourceID: "10", Effect: EffectAllow, Priority: 1, Name: "user playback"},
 			{ID: 100, SubjectType: SubjectUser, SubjectID: "7", Action: ActionMarkersEdit, ResourceType: ResourceServer, ResourceID: "*", Effect: EffectAllow, Priority: 2, Name: "repository marker edit"},
 		},
 	}
@@ -68,6 +81,56 @@ func TestACLAuthorizerCombinesRepositoryAndCompatibilityRules(t *testing.T) {
 	}
 	if !foundRepositoryRule {
 		t.Fatalf("matched rules = %#v, want repository rule 100 to be included", decision.MatchedRules)
+	}
+}
+
+func TestACLAuthorizerCascadesGroupPolicyByMostPermissiveValue(t *testing.T) {
+	maxProfiles := 4
+	fourStreams := 4
+	fiveStreams := 5
+	oneTranscode := 1
+	user := &models.User{
+		ID:                       7,
+		Role:                     "user",
+		Enabled:                  true,
+		MaxPlaybackQuality:       "1080p",
+		MaxStreams:               6,
+		MaxTranscodes:            2,
+		MaxProfiles:              5,
+		DownloadAllowed:          false,
+		DownloadTranscodeAllowed: false,
+	}
+	ruleLoader := fakeACLPolicyRuleLoader{
+		rules: []ACLRule{
+			{ID: 1, SubjectType: SubjectGroup, SubjectID: string(GroupStandardUser), Action: ActionServerView, ResourceType: ResourceServer, ResourceID: "*", Effect: EffectAllow},
+		},
+		policies: []ACLPolicy{
+			{MaxProfiles: &maxProfiles},
+			{MaxStreams: &fourStreams},
+			{MaxStreams: &fiveStreams, MaxTranscodes: &oneTranscode},
+		},
+	}
+
+	authorizer := NewACLAuthorizer(ruleLoader, fakeACLUserLoader{user: user})
+	decision, err := authorizer.Authorize(context.Background(), AccessRequest{UserID: 7, Action: ActionServerView, ResourceType: ResourceServer, ResourceID: "*"})
+	if err != nil {
+		t.Fatalf("authorize error: %v", err)
+	}
+
+	if !decision.Allowed {
+		t.Fatalf("server.view should be allowed: %#v", decision)
+	}
+	if decision.EffectivePolicy.MaxProfiles != 4 {
+		t.Fatalf("max profiles = %d, want 4", decision.EffectivePolicy.MaxProfiles)
+	}
+	if decision.EffectivePolicy.MaxStreams != 5 {
+		t.Fatalf("max streams = %d, want 5", decision.EffectivePolicy.MaxStreams)
+	}
+	if decision.EffectivePolicy.MaxTranscodes != 1 {
+		t.Fatalf("max transcodes = %d, want 1", decision.EffectivePolicy.MaxTranscodes)
+	}
+	if decision.EffectivePolicy.MaxPlaybackQuality != "1080p" {
+		t.Fatalf("max quality = %q, want legacy fallback 1080p", decision.EffectivePolicy.MaxPlaybackQuality)
 	}
 }
 

--- a/internal/auth/acl_authorizer_test.go
+++ b/internal/auth/acl_authorizer_test.go
@@ -114,3 +114,74 @@ func TestACLAuthorizerExplainIncludesEvaluatedRules(t *testing.T) {
 		t.Fatalf("evaluated rule id = %d, want 77", explanation.EvaluatedRules[0].ID)
 	}
 }
+
+func TestACLAuthorizerLegacyMetadataCurationRespectsLibraryScope(t *testing.T) {
+	user := &models.User{
+		ID:          7,
+		Role:        "user",
+		Enabled:     true,
+		Permissions: []string{"metadata_curation"},
+		LibraryIDs:  []int{10},
+	}
+
+	authorizer := NewACLAuthorizer(fakeACLRuleLoader{}, fakeACLUserLoader{user: user})
+
+	allowedDecision, err := authorizer.Authorize(context.Background(), AccessRequest{
+		UserID:       7,
+		Action:       ActionMetadataCurate,
+		ResourceType: ResourceLibrary,
+		ResourceID:   "10",
+		LibraryIDs:   []int{10},
+	})
+	if err != nil {
+		t.Fatalf("authorize allowed request error: %v", err)
+	}
+	if !allowedDecision.Allowed {
+		t.Fatalf("expected in-scope library request to be allowed: %#v", allowedDecision)
+	}
+
+	deniedDecision, err := authorizer.Authorize(context.Background(), AccessRequest{
+		UserID:       7,
+		Action:       ActionMetadataCurate,
+		ResourceType: ResourceLibrary,
+		ResourceID:   "20",
+		LibraryIDs:   []int{20},
+	})
+	if err != nil {
+		t.Fatalf("authorize denied request error: %v", err)
+	}
+	if deniedDecision.Allowed {
+		t.Fatalf("expected out-of-scope library request to be denied: %#v", deniedDecision)
+	}
+	if deniedDecision.ReasonCode != "default_deny" {
+		t.Fatalf("reason code = %q, want default_deny", deniedDecision.ReasonCode)
+	}
+}
+
+func TestACLAuthorizerLegacyMetadataCurationDeniedWhenLibraryScopeEmpty(t *testing.T) {
+	user := &models.User{
+		ID:          7,
+		Role:        "user",
+		Enabled:     true,
+		Permissions: []string{"metadata_curation"},
+		LibraryIDs:  []int{},
+	}
+
+	authorizer := NewACLAuthorizer(fakeACLRuleLoader{}, fakeACLUserLoader{user: user})
+	decision, err := authorizer.Authorize(context.Background(), AccessRequest{
+		UserID:       7,
+		Action:       ActionMetadataCurate,
+		ResourceType: ResourceLibrary,
+		ResourceID:   "10",
+		LibraryIDs:   []int{10},
+	})
+	if err != nil {
+		t.Fatalf("authorize error: %v", err)
+	}
+	if decision.Allowed {
+		t.Fatalf("expected empty library scope to deny library request: %#v", decision)
+	}
+	if decision.ReasonCode != "default_deny" {
+		t.Fatalf("reason code = %q, want default_deny", decision.ReasonCode)
+	}
+}

--- a/internal/auth/acl_compat.go
+++ b/internal/auth/acl_compat.go
@@ -36,6 +36,7 @@ func CompatibilityRulesForUser(user *models.User) []ACLRule {
 			ResourceType: ResourceServer,
 			ResourceID:   "*",
 			Effect:       EffectAllow,
+			Conditions:   legacyPermissionConditions(user, action),
 			Priority:     1000,
 			Name:         "legacy permission " + permission,
 		})
@@ -93,9 +94,20 @@ func CompatibilityEffectivePolicyForUser(user *models.User) EffectivePolicy {
 		MaxPlaybackQuality:         user.MaxPlaybackQuality,
 		MaxStreams:                 user.MaxStreams,
 		MaxTranscodes:              user.MaxTranscodes,
+		MaxProfiles:                user.MaxProfiles,
 		DirectDownloadsAllowed:     user.DownloadAllowed,
 		TranscodedDownloadsAllowed: user.DownloadTranscodeAllowed,
 	}
+}
+
+func legacyPermissionConditions(user *models.User, action ACLAction) ACLCondition {
+	switch action {
+	case ActionMarkersEdit, ActionMetadataCurate:
+		if user.LibraryIDs != nil {
+			return ACLCondition{LibraryIDs: cloneOptionalInts(user.LibraryIDs)}
+		}
+	}
+	return ACLCondition{}
 }
 
 func cloneOptionalInts(values []int) []int {

--- a/internal/auth/acl_compat.go
+++ b/internal/auth/acl_compat.go
@@ -1,0 +1,99 @@
+package auth
+
+import (
+	"fmt"
+
+	"github.com/Silo-Server/silo-server/internal/models"
+)
+
+func CompatibilityGroupsForUser(user *models.User) []BuiltInGroupSlug {
+	if user == nil || !user.Enabled {
+		return []BuiltInGroupSlug{}
+	}
+	if user.Role == "admin" {
+		return []BuiltInGroupSlug{GroupAdmin}
+	}
+	return []BuiltInGroupSlug{GroupViewer}
+}
+
+func CompatibilityRulesForUser(user *models.User) []ACLRule {
+	if user == nil || !user.Enabled {
+		return []ACLRule{}
+	}
+
+	rules := make([]ACLRule, 0, len(user.Permissions)+4)
+	subjectID := fmt.Sprintf("%d", user.ID)
+
+	for _, permission := range user.Permissions {
+		action := LegacyPermissionAction(Permission(permission))
+		if action == "" {
+			continue
+		}
+		rules = append(rules, ACLRule{
+			SubjectType:  SubjectUser,
+			SubjectID:    subjectID,
+			Action:       action,
+			ResourceType: ResourceServer,
+			ResourceID:   "*",
+			Effect:       EffectAllow,
+			Priority:     1000,
+			Name:         "legacy permission " + permission,
+		})
+	}
+
+	if user.Role == "admin" {
+		for _, action := range []ACLAction{
+			ActionServerView,
+			ActionServerConfigure,
+			ActionSecurityManage,
+			ActionUsersView,
+			ActionUsersManage,
+			ActionUsersImpersonate,
+			ActionLibrariesView,
+			ActionLibrariesManage,
+			ActionTasksView,
+			ActionTasksRun,
+			ActionLogsView,
+			ActionPluginsView,
+			ActionPluginsManage,
+			ActionNodesView,
+			ActionNodesManage,
+			ActionMetadataCurate,
+			ActionMarkersEdit,
+			ActionPlaybackPlay,
+			ActionPlaybackTranscode,
+			ActionDownloadsDirect,
+			ActionDownloadsTranscode,
+			ActionProfilesManage,
+			ActionRequestsCreate,
+			ActionRequestsApprove,
+		} {
+			rules = append(rules, ACLRule{
+				SubjectType:  SubjectBuiltInRole,
+				SubjectID:    string(GroupAdmin),
+				Action:       action,
+				ResourceType: ResourceServer,
+				ResourceID:   "*",
+				Effect:       EffectAllow,
+				Priority:     100,
+				Name:         "legacy admin grant",
+			})
+		}
+	}
+
+	return rules
+}
+
+func CompatibilityEffectivePolicyForUser(user *models.User) EffectivePolicy {
+	if user == nil || !user.Enabled {
+		return EffectivePolicy{}
+	}
+	return EffectivePolicy{
+		LibraryIDs:                 append([]int(nil), user.LibraryIDs...),
+		MaxPlaybackQuality:         user.MaxPlaybackQuality,
+		MaxStreams:                 user.MaxStreams,
+		MaxTranscodes:              user.MaxTranscodes,
+		DirectDownloadsAllowed:     user.DownloadAllowed,
+		TranscodedDownloadsAllowed: user.DownloadTranscodeAllowed,
+	}
+}

--- a/internal/auth/acl_compat.go
+++ b/internal/auth/acl_compat.go
@@ -89,11 +89,20 @@ func CompatibilityEffectivePolicyForUser(user *models.User) EffectivePolicy {
 		return EffectivePolicy{}
 	}
 	return EffectivePolicy{
-		LibraryIDs:                 append([]int(nil), user.LibraryIDs...),
+		LibraryIDs:                 cloneOptionalInts(user.LibraryIDs),
 		MaxPlaybackQuality:         user.MaxPlaybackQuality,
 		MaxStreams:                 user.MaxStreams,
 		MaxTranscodes:              user.MaxTranscodes,
 		DirectDownloadsAllowed:     user.DownloadAllowed,
 		TranscodedDownloadsAllowed: user.DownloadTranscodeAllowed,
 	}
+}
+
+func cloneOptionalInts(values []int) []int {
+	if values == nil {
+		return nil
+	}
+	out := make([]int, len(values))
+	copy(out, values)
+	return out
 }

--- a/internal/auth/acl_compat.go
+++ b/internal/auth/acl_compat.go
@@ -13,7 +13,7 @@ func CompatibilityGroupsForUser(user *models.User) []BuiltInGroupSlug {
 	if user.Role == "admin" {
 		return []BuiltInGroupSlug{GroupAdmin}
 	}
-	return []BuiltInGroupSlug{GroupViewer}
+	return []BuiltInGroupSlug{GroupStandardUser}
 }
 
 func CompatibilityRulesForUser(user *models.User) []ACLRule {
@@ -43,6 +43,7 @@ func CompatibilityRulesForUser(user *models.User) []ACLRule {
 	}
 
 	if user.Role == "admin" {
+		primaryProfileRequired := true
 		for _, action := range []ACLAction{
 			ActionServerView,
 			ActionServerConfigure,
@@ -59,6 +60,8 @@ func CompatibilityRulesForUser(user *models.User) []ACLRule {
 			ActionPluginsManage,
 			ActionNodesView,
 			ActionNodesManage,
+			ActionRecommendationsView,
+			ActionRecommendationsManage,
 			ActionMetadataCurate,
 			ActionMarkersEdit,
 			ActionPlaybackPlay,
@@ -76,6 +79,7 @@ func CompatibilityRulesForUser(user *models.User) []ACLRule {
 				ResourceType: ResourceServer,
 				ResourceID:   "*",
 				Effect:       EffectAllow,
+				Conditions:   ACLCondition{PrimaryProfileRequired: &primaryProfileRequired},
 				Priority:     100,
 				Name:         "legacy admin grant",
 			})

--- a/internal/auth/acl_compat_test.go
+++ b/internal/auth/acl_compat_test.go
@@ -50,6 +50,7 @@ func TestCompatibilityEffectivePolicyPreservesUserLimits(t *testing.T) {
 		MaxPlaybackQuality:       "1080p",
 		MaxStreams:               3,
 		MaxTranscodes:            1,
+		MaxProfiles:              4,
 		DownloadAllowed:          true,
 		DownloadTranscodeAllowed: false,
 	}
@@ -66,6 +67,9 @@ func TestCompatibilityEffectivePolicyPreservesUserLimits(t *testing.T) {
 	}
 	if policy.MaxTranscodes != 1 {
 		t.Fatalf("max transcodes = %d, want 1", policy.MaxTranscodes)
+	}
+	if policy.MaxProfiles != 4 {
+		t.Fatalf("max profiles = %d, want 4", policy.MaxProfiles)
 	}
 	if !policy.DirectDownloadsAllowed {
 		t.Fatalf("direct downloads should be allowed")

--- a/internal/auth/acl_compat_test.go
+++ b/internal/auth/acl_compat_test.go
@@ -1,0 +1,76 @@
+package auth
+
+import (
+	"testing"
+
+	"github.com/Silo-Server/silo-server/internal/models"
+)
+
+func TestCompatibilityGroupsForAdminAndUser(t *testing.T) {
+	adminGroups := CompatibilityGroupsForUser(&models.User{ID: 1, Role: "admin", Enabled: true})
+	if len(adminGroups) != 1 || adminGroups[0] != GroupAdmin {
+		t.Fatalf("admin groups = %#v, want [%q]", adminGroups, GroupAdmin)
+	}
+
+	userGroups := CompatibilityGroupsForUser(&models.User{ID: 2, Role: "user", Enabled: true})
+	if len(userGroups) != 1 || userGroups[0] != GroupViewer {
+		t.Fatalf("user groups = %#v, want [%q]", userGroups, GroupViewer)
+	}
+}
+
+func TestCompatibilityRulesForLegacyPermissions(t *testing.T) {
+	user := &models.User{
+		ID:          7,
+		Role:        "user",
+		Enabled:     true,
+		Permissions: []string{"marker_edit", "metadata_curation"},
+	}
+
+	rules := CompatibilityRulesForUser(user)
+	actions := map[ACLAction]bool{}
+	for _, rule := range rules {
+		if rule.Effect == EffectAllow {
+			actions[rule.Action] = true
+		}
+	}
+
+	if !actions[ActionMarkersEdit] {
+		t.Fatalf("expected marker_edit compatibility rule, got %#v", rules)
+	}
+	if !actions[ActionMetadataCurate] {
+		t.Fatalf("expected metadata_curation compatibility rule, got %#v", rules)
+	}
+}
+
+func TestCompatibilityEffectivePolicyPreservesUserLimits(t *testing.T) {
+	user := &models.User{
+		ID:                       7,
+		Enabled:                  true,
+		LibraryIDs:               []int{10, 20},
+		MaxPlaybackQuality:       "1080p",
+		MaxStreams:               3,
+		MaxTranscodes:            1,
+		DownloadAllowed:          true,
+		DownloadTranscodeAllowed: false,
+	}
+
+	policy := CompatibilityEffectivePolicyForUser(user)
+	if len(policy.LibraryIDs) != 2 || policy.LibraryIDs[0] != 10 || policy.LibraryIDs[1] != 20 {
+		t.Fatalf("library ids = %#v, want [10 20]", policy.LibraryIDs)
+	}
+	if policy.MaxPlaybackQuality != "1080p" {
+		t.Fatalf("max quality = %q, want 1080p", policy.MaxPlaybackQuality)
+	}
+	if policy.MaxStreams != 3 {
+		t.Fatalf("max streams = %d, want 3", policy.MaxStreams)
+	}
+	if policy.MaxTranscodes != 1 {
+		t.Fatalf("max transcodes = %d, want 1", policy.MaxTranscodes)
+	}
+	if !policy.DirectDownloadsAllowed {
+		t.Fatalf("direct downloads should be allowed")
+	}
+	if policy.TranscodedDownloadsAllowed {
+		t.Fatalf("transcoded downloads should not be allowed")
+	}
+}

--- a/internal/auth/acl_compat_test.go
+++ b/internal/auth/acl_compat_test.go
@@ -13,8 +13,8 @@ func TestCompatibilityGroupsForAdminAndUser(t *testing.T) {
 	}
 
 	userGroups := CompatibilityGroupsForUser(&models.User{ID: 2, Role: "user", Enabled: true})
-	if len(userGroups) != 1 || userGroups[0] != GroupViewer {
-		t.Fatalf("user groups = %#v, want [%q]", userGroups, GroupViewer)
+	if len(userGroups) != 1 || userGroups[0] != GroupStandardUser {
+		t.Fatalf("user groups = %#v, want [%q]", userGroups, GroupStandardUser)
 	}
 }
 

--- a/internal/auth/acl_compat_test.go
+++ b/internal/auth/acl_compat_test.go
@@ -74,3 +74,27 @@ func TestCompatibilityEffectivePolicyPreservesUserLimits(t *testing.T) {
 		t.Fatalf("transcoded downloads should not be allowed")
 	}
 }
+
+func TestCompatibilityEffectivePolicyPreservesLibraryIDNilness(t *testing.T) {
+	unrestrictedUser := &models.User{
+		ID:      8,
+		Enabled: true,
+	}
+	unrestrictedPolicy := CompatibilityEffectivePolicyForUser(unrestrictedUser)
+	if unrestrictedPolicy.LibraryIDs != nil {
+		t.Fatalf("unrestricted library ids = %#v, want nil", unrestrictedPolicy.LibraryIDs)
+	}
+
+	restrictedUser := &models.User{
+		ID:         9,
+		Enabled:    true,
+		LibraryIDs: []int{},
+	}
+	restrictedPolicy := CompatibilityEffectivePolicyForUser(restrictedUser)
+	if restrictedPolicy.LibraryIDs == nil {
+		t.Fatalf("restricted library ids is nil, want empty non-nil slice")
+	}
+	if len(restrictedPolicy.LibraryIDs) != 0 {
+		t.Fatalf("restricted library ids len = %d, want 0", len(restrictedPolicy.LibraryIDs))
+	}
+}

--- a/internal/auth/acl_evaluator.go
+++ b/internal/auth/acl_evaluator.go
@@ -14,13 +14,13 @@ func NewACLEvaluator() *ACLEvaluator {
 
 func (e *ACLEvaluator) Authorize(request AccessRequest, rules []ACLRule, basePolicy EffectivePolicy, userEnabled bool) AccessDecision {
 	if !userEnabled {
-		return AccessDecision{Allowed: false, ReasonCode: "user_disabled", EffectivePolicy: basePolicy}
+		return AccessDecision{Allowed: false, ReasonCode: "user_disabled", EffectivePolicy: cloneEffectivePolicy(basePolicy)}
 	}
 
 	matched := matchingRules(request, rules)
 	sortMatchedRules(matched)
 	if len(matched) == 0 {
-		return AccessDecision{Allowed: false, ReasonCode: "default_deny", MatchedRules: matched, EffectivePolicy: basePolicy}
+		return AccessDecision{Allowed: false, ReasonCode: "default_deny", MatchedRules: matched, EffectivePolicy: cloneEffectivePolicy(basePolicy)}
 	}
 
 	winning := matched[0]
@@ -35,14 +35,14 @@ func (e *ACLEvaluator) Authorize(request AccessRequest, rules []ACLRule, basePol
 		ReasonCode:      reason,
 		WinningRule:     &winning,
 		MatchedRules:    matched,
-		EffectivePolicy: basePolicy,
+		EffectivePolicy: cloneEffectivePolicy(basePolicy),
 	}
 }
 
 func (e *ACLEvaluator) Explain(request AccessRequest, rules []ACLRule, basePolicy EffectivePolicy, userEnabled bool) AccessExplanation {
 	decision := e.Authorize(request, rules, basePolicy, userEnabled)
 	return AccessExplanation{
-		Request:        request,
+		Request:        cloneAccessRequest(request),
 		Decision:       decision,
 		EvaluatedRules: cloneACLRules(rules),
 	}
@@ -266,6 +266,25 @@ func cloneACLCondition(condition ACLCondition) ACLCondition {
 	}
 	if condition.MediaTypes != nil {
 		cloned.MediaTypes = append([]string(nil), condition.MediaTypes...)
+	}
+	return cloned
+}
+
+func cloneAccessRequest(request AccessRequest) AccessRequest {
+	cloned := request
+	if request.LibraryIDs != nil {
+		cloned.LibraryIDs = append([]int(nil), request.LibraryIDs...)
+	}
+	return cloned
+}
+
+func cloneEffectivePolicy(policy EffectivePolicy) EffectivePolicy {
+	cloned := policy
+	if policy.LibraryIDs != nil {
+		cloned.LibraryIDs = append([]int(nil), policy.LibraryIDs...)
+	}
+	if policy.MediaTypes != nil {
+		cloned.MediaTypes = append([]string(nil), policy.MediaTypes...)
 	}
 	return cloned
 }

--- a/internal/auth/acl_evaluator.go
+++ b/internal/auth/acl_evaluator.go
@@ -83,20 +83,17 @@ func conditionsMatch(request AccessRequest, conditions ACLCondition) bool {
 		if len(conditions.LibraryIDs) == 0 {
 			return false
 		}
-		ok := false
-		for _, allowed := range conditions.LibraryIDs {
-			for _, requested := range request.LibraryIDs {
-				if allowed == requested {
-					ok = true
-					break
-				}
-			}
-			if ok {
-				break
-			}
-		}
-		if !ok {
+		if len(request.LibraryIDs) == 0 {
 			return false
+		}
+		allowedSet := make(map[int]struct{}, len(conditions.LibraryIDs))
+		for _, allowed := range conditions.LibraryIDs {
+			allowedSet[allowed] = struct{}{}
+		}
+		for _, requested := range request.LibraryIDs {
+			if _, ok := allowedSet[requested]; !ok {
+				return false
+			}
 		}
 	}
 

--- a/internal/auth/acl_evaluator.go
+++ b/internal/auth/acl_evaluator.go
@@ -79,7 +79,10 @@ func resourceMatches(request AccessRequest, rule ACLRule) bool {
 }
 
 func conditionsMatch(request AccessRequest, conditions ACLCondition) bool {
-	if len(conditions.LibraryIDs) > 0 {
+	if conditions.LibraryIDs != nil && requestNeedsLibraryScope(request) {
+		if len(conditions.LibraryIDs) == 0 {
+			return false
+		}
 		ok := false
 		for _, allowed := range conditions.LibraryIDs {
 			for _, requested := range request.LibraryIDs {
@@ -151,6 +154,19 @@ func conditionsMatch(request AccessRequest, conditions ACLCondition) bool {
 	}
 
 	return true
+}
+
+func requestNeedsLibraryScope(request AccessRequest) bool {
+	if len(request.LibraryIDs) > 0 {
+		return true
+	}
+
+	switch request.ResourceType {
+	case ResourceLibrary, ResourceMediaItem:
+		return true
+	default:
+		return false
+	}
 }
 
 func sortMatchedRules(rules []ACLRule) {
@@ -266,6 +282,26 @@ func cloneACLCondition(condition ACLCondition) ACLCondition {
 	}
 	if condition.MediaTypes != nil {
 		cloned.MediaTypes = append([]string(nil), condition.MediaTypes...)
+	}
+	if condition.PrimaryProfileRequired != nil {
+		value := *condition.PrimaryProfileRequired
+		cloned.PrimaryProfileRequired = &value
+	}
+	if condition.MaxStreams != nil {
+		value := *condition.MaxStreams
+		cloned.MaxStreams = &value
+	}
+	if condition.MaxTranscodes != nil {
+		value := *condition.MaxTranscodes
+		cloned.MaxTranscodes = &value
+	}
+	if condition.DirectDownloadsAllowed != nil {
+		value := *condition.DirectDownloadsAllowed
+		cloned.DirectDownloadsAllowed = &value
+	}
+	if condition.TranscodedDownloadsAllowed != nil {
+		value := *condition.TranscodedDownloadsAllowed
+		cloned.TranscodedDownloadsAllowed = &value
 	}
 	return cloned
 }

--- a/internal/auth/acl_evaluator.go
+++ b/internal/auth/acl_evaluator.go
@@ -1,0 +1,152 @@
+package auth
+
+import (
+	"fmt"
+	"sort"
+)
+
+type ACLEvaluator struct{}
+
+func NewACLEvaluator() *ACLEvaluator {
+	return &ACLEvaluator{}
+}
+
+func (e *ACLEvaluator) Authorize(request AccessRequest, rules []ACLRule, basePolicy EffectivePolicy, userEnabled bool) AccessDecision {
+	if !userEnabled {
+		return AccessDecision{Allowed: false, ReasonCode: "user_disabled", EffectivePolicy: basePolicy}
+	}
+
+	matched := matchingRules(request, rules)
+	sortMatchedRules(matched)
+	if len(matched) == 0 {
+		return AccessDecision{Allowed: false, ReasonCode: "default_deny", MatchedRules: matched, EffectivePolicy: basePolicy}
+	}
+
+	winning := matched[0]
+	allowed := winning.Effect == EffectAllow
+	reason := "rule_allow"
+	if !allowed {
+		reason = "rule_deny"
+	}
+
+	return AccessDecision{
+		Allowed:         allowed,
+		ReasonCode:      reason,
+		WinningRule:     &winning,
+		MatchedRules:    matched,
+		EffectivePolicy: basePolicy,
+	}
+}
+
+func (e *ACLEvaluator) Explain(request AccessRequest, rules []ACLRule, basePolicy EffectivePolicy, userEnabled bool) AccessExplanation {
+	decision := e.Authorize(request, rules, basePolicy, userEnabled)
+	return AccessExplanation{
+		Request:        request,
+		Decision:       decision,
+		EvaluatedRules: append([]ACLRule(nil), rules...),
+	}
+}
+
+func matchingRules(request AccessRequest, rules []ACLRule) []ACLRule {
+	out := make([]ACLRule, 0, len(rules))
+	for _, rule := range rules {
+		if rule.Action != request.Action {
+			continue
+		}
+		if !resourceMatches(request, rule) {
+			continue
+		}
+		if !conditionsMatch(request, rule.Conditions) {
+			continue
+		}
+		out = append(out, rule)
+	}
+	return out
+}
+
+func resourceMatches(request AccessRequest, rule ACLRule) bool {
+	if rule.ResourceType != request.ResourceType && rule.ResourceType != ResourceServer {
+		return false
+	}
+	if rule.ResourceID == "" || rule.ResourceID == "*" {
+		return true
+	}
+	if request.ResourceID == "" {
+		return false
+	}
+	return rule.ResourceID == request.ResourceID
+}
+
+func conditionsMatch(request AccessRequest, conditions ACLCondition) bool {
+	if len(conditions.LibraryIDs) > 0 {
+		ok := false
+		for _, allowed := range conditions.LibraryIDs {
+			for _, requested := range request.LibraryIDs {
+				if allowed == requested {
+					ok = true
+					break
+				}
+			}
+			if ok {
+				break
+			}
+		}
+		if !ok {
+			return false
+		}
+	}
+
+	if len(conditions.MediaTypes) > 0 {
+		ok := false
+		for _, mediaType := range conditions.MediaTypes {
+			if mediaType == request.MediaType {
+				ok = true
+				break
+			}
+		}
+		if !ok {
+			return false
+		}
+	}
+
+	if conditions.PrimaryProfileRequired != nil && *conditions.PrimaryProfileRequired != request.PrimaryProfile {
+		return false
+	}
+
+	return true
+}
+
+func sortMatchedRules(rules []ACLRule) {
+	sort.SliceStable(rules, func(i, j int) bool {
+		left := ruleRank(rules[i])
+		right := ruleRank(rules[j])
+		if left != right {
+			return left < right
+		}
+		if rules[i].Priority != rules[j].Priority {
+			return rules[i].Priority > rules[j].Priority
+		}
+		return rules[i].ID < rules[j].ID
+	})
+}
+
+func ruleRank(rule ACLRule) int {
+	switch {
+	case rule.SubjectType == SubjectBuiltInRole && rule.SubjectID == string(GroupOwner) && rule.Effect == EffectAllow:
+		return 0
+	case rule.SubjectType == SubjectUser && rule.Effect == EffectDeny:
+		return 1
+	case rule.SubjectType == SubjectUser && rule.Effect == EffectAllow:
+		return 2
+	case rule.SubjectType == SubjectGroup && rule.Effect == EffectDeny:
+		return 3
+	case rule.SubjectType == SubjectGroup && rule.Effect == EffectAllow:
+		return 4
+	case rule.Effect == EffectDeny:
+		return 5
+	case rule.Effect == EffectAllow:
+		return 6
+	default:
+		panic(fmt.Sprintf("unknown ACL effect %q", rule.Effect))
+	}
+}

--- a/internal/auth/acl_evaluator.go
+++ b/internal/auth/acl_evaluator.go
@@ -3,6 +3,7 @@ package auth
 import (
 	"fmt"
 	"sort"
+	"strings"
 )
 
 type ACLEvaluator struct{}
@@ -43,7 +44,7 @@ func (e *ACLEvaluator) Explain(request AccessRequest, rules []ACLRule, basePolic
 	return AccessExplanation{
 		Request:        request,
 		Decision:       decision,
-		EvaluatedRules: append([]ACLRule(nil), rules...),
+		EvaluatedRules: cloneACLRules(rules),
 	}
 }
 
@@ -59,7 +60,7 @@ func matchingRules(request AccessRequest, rules []ACLRule) []ACLRule {
 		if !conditionsMatch(request, rule.Conditions) {
 			continue
 		}
-		out = append(out, rule)
+		out = append(out, cloneACLRule(rule))
 	}
 	return out
 }
@@ -113,6 +114,42 @@ func conditionsMatch(request AccessRequest, conditions ACLCondition) bool {
 		return false
 	}
 
+	if conditions.MaxPlaybackQuality != "" {
+		if request.PlaybackQuality == "" {
+			// Caller has not supplied this fact yet.
+		} else if !playbackQualityAllowed(request.PlaybackQuality, conditions.MaxPlaybackQuality) {
+			return false
+		}
+	}
+
+	if conditions.MaxStreams != nil {
+		if request.CurrentStreams != 0 && request.CurrentStreams > *conditions.MaxStreams {
+			return false
+		}
+	}
+
+	if conditions.MaxTranscodes != nil {
+		if request.CurrentTranscodes != 0 && request.CurrentTranscodes > *conditions.MaxTranscodes {
+			return false
+		}
+	}
+
+	if conditions.DirectDownloadsAllowed != nil && !*conditions.DirectDownloadsAllowed && request.DirectDownloadRequested {
+		return false
+	}
+
+	if conditions.TranscodedDownloadsAllowed != nil && !*conditions.TranscodedDownloadsAllowed && request.TranscodedDownloadRequested {
+		return false
+	}
+
+	if conditions.MaxContentRating != "" {
+		if request.ContentRating == "" {
+			// Caller has not supplied this fact yet.
+		} else if !contentRatingAllowed(request.ContentRating, conditions.MaxContentRating) {
+			return false
+		}
+	}
+
 	return true
 }
 
@@ -149,4 +186,86 @@ func ruleRank(rule ACLRule) int {
 	default:
 		panic(fmt.Sprintf("unknown ACL effect %q", rule.Effect))
 	}
+}
+
+var playbackQualityRanks = map[string]int{
+	"480P":  1,
+	"720P":  2,
+	"1080P": 3,
+	"2160P": 4,
+	"4320P": 5,
+}
+
+var contentRatingRanks = map[string]int{
+	"G":     1,
+	"TV-G":  1,
+	"PG":    2,
+	"TV-PG": 2,
+	"PG-13": 3,
+	"TV-14": 3,
+	"R":     4,
+	"TV-MA": 4,
+	"NC-17": 5,
+}
+
+func playbackQualityAllowed(requested, max string) bool {
+	requestRank, ok := playbackQualityRank(requested)
+	if !ok {
+		return false
+	}
+	maxRank, ok := playbackQualityRank(max)
+	if !ok {
+		return false
+	}
+	return requestRank <= maxRank
+}
+
+func contentRatingAllowed(requested, max string) bool {
+	requestRank, ok := contentRatingRank(requested)
+	if !ok {
+		return false
+	}
+	maxRank, ok := contentRatingRank(max)
+	if !ok {
+		return false
+	}
+	return requestRank <= maxRank
+}
+
+func playbackQualityRank(value string) (int, bool) {
+	rank, ok := playbackQualityRanks[strings.ToUpper(strings.TrimSpace(value))]
+	return rank, ok
+}
+
+func contentRatingRank(value string) (int, bool) {
+	rank, ok := contentRatingRanks[strings.ToUpper(strings.TrimSpace(value))]
+	return rank, ok
+}
+
+func cloneACLRules(rules []ACLRule) []ACLRule {
+	if rules == nil {
+		return nil
+	}
+	out := make([]ACLRule, len(rules))
+	for i, rule := range rules {
+		out[i] = cloneACLRule(rule)
+	}
+	return out
+}
+
+func cloneACLRule(rule ACLRule) ACLRule {
+	cloned := rule
+	cloned.Conditions = cloneACLCondition(rule.Conditions)
+	return cloned
+}
+
+func cloneACLCondition(condition ACLCondition) ACLCondition {
+	cloned := condition
+	if condition.LibraryIDs != nil {
+		cloned.LibraryIDs = append([]int(nil), condition.LibraryIDs...)
+	}
+	if condition.MediaTypes != nil {
+		cloned.MediaTypes = append([]string(nil), condition.MediaTypes...)
+	}
+	return cloned
 }

--- a/internal/auth/acl_evaluator_test.go
+++ b/internal/auth/acl_evaluator_test.go
@@ -304,3 +304,90 @@ func TestACLEvaluatorExplainSnapshotsRequestAndPolicySlices(t *testing.T) {
 		t.Fatalf("effective policy media types = %#v, want [movie]", explanation.Decision.EffectivePolicy.MediaTypes)
 	}
 }
+
+func TestACLEvaluatorExplainDeepCopiesPointerConditions(t *testing.T) {
+	evaluator := NewACLEvaluator()
+
+	primaryProfileRequired := true
+	maxStreams := 2
+	maxTranscodes := 1
+	directDownloadsAllowed := true
+	transcodedDownloadsAllowed := false
+
+	rules := []ACLRule{
+		{
+			ID:           31,
+			SubjectType:  SubjectUser,
+			SubjectID:    "7",
+			Action:       ActionPlaybackPlay,
+			ResourceType: ResourceLibrary,
+			ResourceID:   "10",
+			Effect:       EffectAllow,
+			Priority:     10,
+			Conditions: ACLCondition{
+				PrimaryProfileRequired:     &primaryProfileRequired,
+				MaxStreams:                 &maxStreams,
+				MaxTranscodes:              &maxTranscodes,
+				DirectDownloadsAllowed:     &directDownloadsAllowed,
+				TranscodedDownloadsAllowed: &transcodedDownloadsAllowed,
+			},
+		},
+	}
+
+	explanation := evaluator.Explain(
+		AccessRequest{
+			UserID:         7,
+			Action:         ActionPlaybackPlay,
+			ResourceType:   ResourceLibrary,
+			ResourceID:     "10",
+			LibraryIDs:     []int{10},
+			PrimaryProfile: true,
+		},
+		rules,
+		EffectivePolicy{},
+		true,
+	)
+
+	primaryProfileRequired = false
+	maxStreams = 9
+	maxTranscodes = 8
+	directDownloadsAllowed = false
+	transcodedDownloadsAllowed = true
+
+	evaluated := explanation.EvaluatedRules[0].Conditions
+	if evaluated.PrimaryProfileRequired == nil || !*evaluated.PrimaryProfileRequired {
+		t.Fatalf("evaluated primary profile required = %#v, want true", evaluated.PrimaryProfileRequired)
+	}
+	if evaluated.MaxStreams == nil || *evaluated.MaxStreams != 2 {
+		t.Fatalf("evaluated max streams = %#v, want 2", evaluated.MaxStreams)
+	}
+	if evaluated.MaxTranscodes == nil || *evaluated.MaxTranscodes != 1 {
+		t.Fatalf("evaluated max transcodes = %#v, want 1", evaluated.MaxTranscodes)
+	}
+	if evaluated.DirectDownloadsAllowed == nil || !*evaluated.DirectDownloadsAllowed {
+		t.Fatalf("evaluated direct downloads allowed = %#v, want true", evaluated.DirectDownloadsAllowed)
+	}
+	if evaluated.TranscodedDownloadsAllowed == nil || *evaluated.TranscodedDownloadsAllowed {
+		t.Fatalf("evaluated transcoded downloads allowed = %#v, want false", evaluated.TranscodedDownloadsAllowed)
+	}
+
+	matched := explanation.Decision.MatchedRules[0].Conditions
+	if matched.PrimaryProfileRequired == nil || !*matched.PrimaryProfileRequired {
+		t.Fatalf("matched primary profile required = %#v, want true", matched.PrimaryProfileRequired)
+	}
+	if matched.MaxStreams == nil || *matched.MaxStreams != 2 {
+		t.Fatalf("matched max streams = %#v, want 2", matched.MaxStreams)
+	}
+	if explanation.Decision.WinningRule == nil {
+		t.Fatalf("winning rule = nil, want rule snapshot")
+	}
+	if explanation.Decision.WinningRule.Conditions.MaxTranscodes == nil || *explanation.Decision.WinningRule.Conditions.MaxTranscodes != 1 {
+		t.Fatalf("winning rule max transcodes = %#v, want 1", explanation.Decision.WinningRule.Conditions.MaxTranscodes)
+	}
+	if explanation.Decision.WinningRule.Conditions.DirectDownloadsAllowed == nil || !*explanation.Decision.WinningRule.Conditions.DirectDownloadsAllowed {
+		t.Fatalf("winning rule direct downloads allowed = %#v, want true", explanation.Decision.WinningRule.Conditions.DirectDownloadsAllowed)
+	}
+	if explanation.Decision.WinningRule.Conditions.TranscodedDownloadsAllowed == nil || *explanation.Decision.WinningRule.Conditions.TranscodedDownloadsAllowed {
+		t.Fatalf("winning rule transcoded downloads allowed = %#v, want false", explanation.Decision.WinningRule.Conditions.TranscodedDownloadsAllowed)
+	}
+}

--- a/internal/auth/acl_evaluator_test.go
+++ b/internal/auth/acl_evaluator_test.go
@@ -1,0 +1,67 @@
+package auth
+
+import "testing"
+
+func TestACLEvaluatorDisabledUserDenied(t *testing.T) {
+	evaluator := NewACLEvaluator()
+	decision := evaluator.Authorize(AccessRequest{Action: ActionPlaybackPlay, ResourceType: ResourceLibrary, ResourceID: "1"}, nil, EffectivePolicy{}, false)
+	if decision.Allowed {
+		t.Fatalf("disabled user should be denied")
+	}
+	if decision.ReasonCode != "user_disabled" {
+		t.Fatalf("reason = %q, want user_disabled", decision.ReasonCode)
+	}
+}
+
+func TestACLEvaluatorUserDenyBeatsUserAllow(t *testing.T) {
+	evaluator := NewACLEvaluator()
+	request := AccessRequest{UserID: 7, Action: ActionDownloadsDirect, ResourceType: ResourceLibrary, ResourceID: "10"}
+	rules := []ACLRule{
+		{ID: 1, SubjectType: SubjectUser, SubjectID: "7", Action: ActionDownloadsDirect, ResourceType: ResourceLibrary, ResourceID: "10", Effect: EffectAllow, Priority: 10, Name: "allow direct downloads"},
+		{ID: 2, SubjectType: SubjectUser, SubjectID: "7", Action: ActionDownloadsDirect, ResourceType: ResourceLibrary, ResourceID: "10", Effect: EffectDeny, Priority: 10, Name: "deny direct downloads"},
+	}
+
+	decision := evaluator.Authorize(request, rules, EffectivePolicy{}, true)
+	if decision.Allowed {
+		t.Fatalf("user deny should win over user allow")
+	}
+	if decision.WinningRule == nil || decision.WinningRule.ID != 2 {
+		t.Fatalf("winning rule = %#v, want rule 2", decision.WinningRule)
+	}
+}
+
+func TestACLEvaluatorUserAllowBeatsGroupDeny(t *testing.T) {
+	evaluator := NewACLEvaluator()
+	request := AccessRequest{UserID: 7, Action: ActionMetadataCurate, ResourceType: ResourceLibrary, ResourceID: "10"}
+	rules := []ACLRule{
+		{ID: 1, SubjectType: SubjectGroup, SubjectID: "curators", Action: ActionMetadataCurate, ResourceType: ResourceLibrary, ResourceID: "10", Effect: EffectDeny, Priority: 10, Name: "group deny"},
+		{ID: 2, SubjectType: SubjectUser, SubjectID: "7", Action: ActionMetadataCurate, ResourceType: ResourceLibrary, ResourceID: "10", Effect: EffectAllow, Priority: 10, Name: "user override"},
+	}
+
+	decision := evaluator.Authorize(request, rules, EffectivePolicy{}, true)
+	if !decision.Allowed {
+		t.Fatalf("user allow should beat group deny: %#v", decision)
+	}
+	if decision.WinningRule == nil || decision.WinningRule.ID != 2 {
+		t.Fatalf("winning rule = %#v, want rule 2", decision.WinningRule)
+	}
+}
+
+func TestACLEvaluatorExplainIncludesMatchedRules(t *testing.T) {
+	evaluator := NewACLEvaluator()
+	request := AccessRequest{UserID: 7, Action: ActionPlaybackPlay, ResourceType: ResourceLibrary, ResourceID: "10"}
+	rules := []ACLRule{
+		{ID: 1, SubjectType: SubjectGroup, SubjectID: "viewer", Action: ActionPlaybackPlay, ResourceType: ResourceLibrary, ResourceID: "10", Effect: EffectAllow, Priority: 10, Name: "viewer playback"},
+	}
+
+	explanation := evaluator.Explain(request, rules, EffectivePolicy{MaxStreams: 2}, true)
+	if !explanation.Decision.Allowed {
+		t.Fatalf("expected allowed decision: %#v", explanation.Decision)
+	}
+	if len(explanation.Decision.MatchedRules) != 1 {
+		t.Fatalf("matched rules = %#v, want one rule", explanation.Decision.MatchedRules)
+	}
+	if explanation.Decision.EffectivePolicy.MaxStreams != 2 {
+		t.Fatalf("effective max streams = %d, want 2", explanation.Decision.EffectivePolicy.MaxStreams)
+	}
+}

--- a/internal/auth/acl_evaluator_test.go
+++ b/internal/auth/acl_evaluator_test.go
@@ -65,3 +65,195 @@ func TestACLEvaluatorExplainIncludesMatchedRules(t *testing.T) {
 		t.Fatalf("effective max streams = %d, want 2", explanation.Decision.EffectivePolicy.MaxStreams)
 	}
 }
+
+func TestACLEvaluatorConditionFactsBlockUnmetConstraints(t *testing.T) {
+	evaluator := NewACLEvaluator()
+
+	maxStreams := 2
+	maxTranscodes := 1
+	allowDirectDownloads := false
+	allowTranscodedDownloads := false
+
+	tests := []struct {
+		name    string
+		request AccessRequest
+		rule    ACLRule
+	}{
+		{
+			name: "playback quality ceiling",
+			request: AccessRequest{
+				Action:          ActionPlaybackPlay,
+				ResourceType:    ResourceLibrary,
+				ResourceID:      "10",
+				PlaybackQuality: "2160p",
+			},
+			rule: ACLRule{
+				ID:           10,
+				SubjectType:  SubjectGroup,
+				SubjectID:    "viewer",
+				Action:       ActionPlaybackPlay,
+				ResourceType: ResourceLibrary,
+				ResourceID:   "10",
+				Effect:       EffectAllow,
+				Priority:     10,
+				Conditions:   ACLCondition{MaxPlaybackQuality: "1080p"},
+			},
+		},
+		{
+			name: "stream ceiling",
+			request: AccessRequest{
+				Action:         ActionPlaybackPlay,
+				ResourceType:   ResourceLibrary,
+				ResourceID:     "10",
+				CurrentStreams: 3,
+			},
+			rule: ACLRule{
+				ID:           11,
+				SubjectType:  SubjectGroup,
+				SubjectID:    "viewer",
+				Action:       ActionPlaybackPlay,
+				ResourceType: ResourceLibrary,
+				ResourceID:   "10",
+				Effect:       EffectAllow,
+				Priority:     10,
+				Conditions:   ACLCondition{MaxStreams: &maxStreams},
+			},
+		},
+		{
+			name: "transcode ceiling",
+			request: AccessRequest{
+				Action:            ActionPlaybackTranscode,
+				ResourceType:      ResourceLibrary,
+				ResourceID:        "10",
+				CurrentTranscodes: 2,
+			},
+			rule: ACLRule{
+				ID:           12,
+				SubjectType:  SubjectGroup,
+				SubjectID:    "viewer",
+				Action:       ActionPlaybackTranscode,
+				ResourceType: ResourceLibrary,
+				ResourceID:   "10",
+				Effect:       EffectAllow,
+				Priority:     10,
+				Conditions:   ACLCondition{MaxTranscodes: &maxTranscodes},
+			},
+		},
+		{
+			name: "direct download flag",
+			request: AccessRequest{
+				Action:                  ActionDownloadsDirect,
+				ResourceType:            ResourceLibrary,
+				ResourceID:              "10",
+				DirectDownloadRequested: true,
+			},
+			rule: ACLRule{
+				ID:           13,
+				SubjectType:  SubjectGroup,
+				SubjectID:    "viewer",
+				Action:       ActionDownloadsDirect,
+				ResourceType: ResourceLibrary,
+				ResourceID:   "10",
+				Effect:       EffectAllow,
+				Priority:     10,
+				Conditions:   ACLCondition{DirectDownloadsAllowed: &allowDirectDownloads},
+			},
+		},
+		{
+			name: "transcoded download flag",
+			request: AccessRequest{
+				Action:                      ActionDownloadsTranscode,
+				ResourceType:                ResourceLibrary,
+				ResourceID:                  "10",
+				TranscodedDownloadRequested: true,
+			},
+			rule: ACLRule{
+				ID:           14,
+				SubjectType:  SubjectGroup,
+				SubjectID:    "viewer",
+				Action:       ActionDownloadsTranscode,
+				ResourceType: ResourceLibrary,
+				ResourceID:   "10",
+				Effect:       EffectAllow,
+				Priority:     10,
+				Conditions:   ACLCondition{TranscodedDownloadsAllowed: &allowTranscodedDownloads},
+			},
+		},
+		{
+			name: "content rating ceiling",
+			request: AccessRequest{
+				Action:        ActionPlaybackPlay,
+				ResourceType:  ResourceLibrary,
+				ResourceID:    "10",
+				ContentRating: "TV-MA",
+			},
+			rule: ACLRule{
+				ID:           15,
+				SubjectType:  SubjectGroup,
+				SubjectID:    "viewer",
+				Action:       ActionPlaybackPlay,
+				ResourceType: ResourceLibrary,
+				ResourceID:   "10",
+				Effect:       EffectAllow,
+				Priority:     10,
+				Conditions:   ACLCondition{MaxContentRating: "PG-13"},
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			decision := evaluator.Authorize(tc.request, []ACLRule{tc.rule}, EffectivePolicy{}, true)
+			if decision.Allowed {
+				t.Fatalf("expected rule to be blocked: %#v", decision)
+			}
+			if decision.ReasonCode != "default_deny" {
+				t.Fatalf("reason code = %q, want default_deny", decision.ReasonCode)
+			}
+			if len(decision.MatchedRules) != 0 {
+				t.Fatalf("matched rules = %#v, want none", decision.MatchedRules)
+			}
+		})
+	}
+}
+
+func TestACLEvaluatorConditionFactsIgnoreMissingRequestValues(t *testing.T) {
+	evaluator := NewACLEvaluator()
+	maxStreams := 2
+	maxTranscodes := 1
+	allowDirectDownloads := true
+	allowTranscodedDownloads := true
+
+	decision := evaluator.Authorize(
+		AccessRequest{Action: ActionPlaybackPlay, ResourceType: ResourceLibrary, ResourceID: "10"},
+		[]ACLRule{
+			{
+				ID:           20,
+				SubjectType:  SubjectGroup,
+				SubjectID:    "viewer",
+				Action:       ActionPlaybackPlay,
+				ResourceType: ResourceLibrary,
+				ResourceID:   "10",
+				Effect:       EffectAllow,
+				Priority:     10,
+				Conditions: ACLCondition{
+					MaxPlaybackQuality:         "1080p",
+					MaxStreams:                 &maxStreams,
+					MaxTranscodes:              &maxTranscodes,
+					DirectDownloadsAllowed:     &allowDirectDownloads,
+					TranscodedDownloadsAllowed: &allowTranscodedDownloads,
+					MaxContentRating:           "PG-13",
+				},
+			},
+		},
+		EffectivePolicy{},
+		true,
+	)
+
+	if !decision.Allowed {
+		t.Fatalf("missing request facts should not block matching rule: %#v", decision)
+	}
+	if decision.ReasonCode != "rule_allow" {
+		t.Fatalf("reason code = %q, want rule_allow", decision.ReasonCode)
+	}
+}

--- a/internal/auth/acl_evaluator_test.go
+++ b/internal/auth/acl_evaluator_test.go
@@ -51,7 +51,7 @@ func TestACLEvaluatorExplainIncludesMatchedRules(t *testing.T) {
 	evaluator := NewACLEvaluator()
 	request := AccessRequest{UserID: 7, Action: ActionPlaybackPlay, ResourceType: ResourceLibrary, ResourceID: "10"}
 	rules := []ACLRule{
-		{ID: 1, SubjectType: SubjectGroup, SubjectID: "viewer", Action: ActionPlaybackPlay, ResourceType: ResourceLibrary, ResourceID: "10", Effect: EffectAllow, Priority: 10, Name: "viewer playback"},
+		{ID: 1, SubjectType: SubjectGroup, SubjectID: string(GroupStandardUser), Action: ActionPlaybackPlay, ResourceType: ResourceLibrary, ResourceID: "10", Effect: EffectAllow, Priority: 10, Name: "user playback"},
 	}
 
 	explanation := evaluator.Explain(request, rules, EffectivePolicy{MaxStreams: 2}, true)
@@ -90,7 +90,7 @@ func TestACLEvaluatorConditionFactsBlockUnmetConstraints(t *testing.T) {
 			rule: ACLRule{
 				ID:           10,
 				SubjectType:  SubjectGroup,
-				SubjectID:    "viewer",
+				SubjectID:    string(GroupStandardUser),
 				Action:       ActionPlaybackPlay,
 				ResourceType: ResourceLibrary,
 				ResourceID:   "10",
@@ -110,7 +110,7 @@ func TestACLEvaluatorConditionFactsBlockUnmetConstraints(t *testing.T) {
 			rule: ACLRule{
 				ID:           11,
 				SubjectType:  SubjectGroup,
-				SubjectID:    "viewer",
+				SubjectID:    string(GroupStandardUser),
 				Action:       ActionPlaybackPlay,
 				ResourceType: ResourceLibrary,
 				ResourceID:   "10",
@@ -130,7 +130,7 @@ func TestACLEvaluatorConditionFactsBlockUnmetConstraints(t *testing.T) {
 			rule: ACLRule{
 				ID:           12,
 				SubjectType:  SubjectGroup,
-				SubjectID:    "viewer",
+				SubjectID:    string(GroupStandardUser),
 				Action:       ActionPlaybackTranscode,
 				ResourceType: ResourceLibrary,
 				ResourceID:   "10",
@@ -150,7 +150,7 @@ func TestACLEvaluatorConditionFactsBlockUnmetConstraints(t *testing.T) {
 			rule: ACLRule{
 				ID:           13,
 				SubjectType:  SubjectGroup,
-				SubjectID:    "viewer",
+				SubjectID:    string(GroupStandardUser),
 				Action:       ActionDownloadsDirect,
 				ResourceType: ResourceLibrary,
 				ResourceID:   "10",
@@ -170,7 +170,7 @@ func TestACLEvaluatorConditionFactsBlockUnmetConstraints(t *testing.T) {
 			rule: ACLRule{
 				ID:           14,
 				SubjectType:  SubjectGroup,
-				SubjectID:    "viewer",
+				SubjectID:    string(GroupStandardUser),
 				Action:       ActionDownloadsTranscode,
 				ResourceType: ResourceLibrary,
 				ResourceID:   "10",
@@ -190,7 +190,7 @@ func TestACLEvaluatorConditionFactsBlockUnmetConstraints(t *testing.T) {
 			rule: ACLRule{
 				ID:           15,
 				SubjectType:  SubjectGroup,
-				SubjectID:    "viewer",
+				SubjectID:    string(GroupStandardUser),
 				Action:       ActionPlaybackPlay,
 				ResourceType: ResourceLibrary,
 				ResourceID:   "10",
@@ -230,7 +230,7 @@ func TestACLEvaluatorConditionFactsIgnoreMissingRequestValues(t *testing.T) {
 			{
 				ID:           20,
 				SubjectType:  SubjectGroup,
-				SubjectID:    "viewer",
+				SubjectID:    string(GroupStandardUser),
 				Action:       ActionPlaybackPlay,
 				ResourceType: ResourceLibrary,
 				ResourceID:   "10",
@@ -278,7 +278,7 @@ func TestACLEvaluatorExplainSnapshotsRequestAndPolicySlices(t *testing.T) {
 			{
 				ID:           30,
 				SubjectType:  SubjectGroup,
-				SubjectID:    "viewer",
+				SubjectID:    string(GroupStandardUser),
 				Action:       ActionPlaybackPlay,
 				ResourceType: ResourceLibrary,
 				ResourceID:   "10",

--- a/internal/auth/acl_evaluator_test.go
+++ b/internal/auth/acl_evaluator_test.go
@@ -257,3 +257,50 @@ func TestACLEvaluatorConditionFactsIgnoreMissingRequestValues(t *testing.T) {
 		t.Fatalf("reason code = %q, want rule_allow", decision.ReasonCode)
 	}
 }
+
+func TestACLEvaluatorExplainSnapshotsRequestAndPolicySlices(t *testing.T) {
+	evaluator := NewACLEvaluator()
+
+	request := AccessRequest{
+		Action:       ActionPlaybackPlay,
+		ResourceType: ResourceLibrary,
+		ResourceID:   "10",
+		LibraryIDs:   []int{10},
+	}
+	basePolicy := EffectivePolicy{
+		LibraryIDs: []int{10},
+		MediaTypes: []string{"movie"},
+	}
+
+	explanation := evaluator.Explain(
+		request,
+		[]ACLRule{
+			{
+				ID:           30,
+				SubjectType:  SubjectGroup,
+				SubjectID:    "viewer",
+				Action:       ActionPlaybackPlay,
+				ResourceType: ResourceLibrary,
+				ResourceID:   "10",
+				Effect:       EffectAllow,
+				Priority:     10,
+			},
+		},
+		basePolicy,
+		true,
+	)
+
+	request.LibraryIDs[0] = 99
+	basePolicy.LibraryIDs[0] = 99
+	basePolicy.MediaTypes[0] = "series"
+
+	if len(explanation.Request.LibraryIDs) != 1 || explanation.Request.LibraryIDs[0] != 10 {
+		t.Fatalf("request library ids = %#v, want [10]", explanation.Request.LibraryIDs)
+	}
+	if len(explanation.Decision.EffectivePolicy.LibraryIDs) != 1 || explanation.Decision.EffectivePolicy.LibraryIDs[0] != 10 {
+		t.Fatalf("effective policy library ids = %#v, want [10]", explanation.Decision.EffectivePolicy.LibraryIDs)
+	}
+	if len(explanation.Decision.EffectivePolicy.MediaTypes) != 1 || explanation.Decision.EffectivePolicy.MediaTypes[0] != "movie" {
+		t.Fatalf("effective policy media types = %#v, want [movie]", explanation.Decision.EffectivePolicy.MediaTypes)
+	}
+}

--- a/internal/auth/acl_policy.go
+++ b/internal/auth/acl_policy.go
@@ -1,0 +1,125 @@
+package auth
+
+import "sort"
+
+func MergeACLPolicies(base EffectivePolicy, policies []ACLPolicy) EffectivePolicy {
+	out := cloneEffectivePolicy(base)
+
+	var (
+		librarySet          map[int]struct{}
+		mediaTypeSet        map[string]struct{}
+		hasLibraryIDs       bool
+		hasMediaTypes       bool
+		hasMaxQuality       bool
+		hasMaxStreams       bool
+		hasMaxTranscodes    bool
+		hasMaxProfiles      bool
+		hasDirectDownloads  bool
+		hasTransDownloads   bool
+		maxPlaybackQuality  string
+		maxStreams          int
+		maxTranscodes       int
+		maxProfiles         int
+		directDownloads     bool
+		transcodedDownloads bool
+	)
+
+	for _, policy := range policies {
+		if policy.LibraryIDs != nil {
+			hasLibraryIDs = true
+			if librarySet == nil {
+				librarySet = map[int]struct{}{}
+			}
+			for _, id := range policy.LibraryIDs {
+				librarySet[id] = struct{}{}
+			}
+		}
+		if policy.MediaTypes != nil {
+			hasMediaTypes = true
+			if mediaTypeSet == nil {
+				mediaTypeSet = map[string]struct{}{}
+			}
+			for _, mediaType := range policy.MediaTypes {
+				mediaTypeSet[mediaType] = struct{}{}
+			}
+		}
+		if policy.MaxPlaybackQuality != "" {
+			if !hasMaxQuality || playbackQualityMorePermissive(policy.MaxPlaybackQuality, maxPlaybackQuality) {
+				maxPlaybackQuality = policy.MaxPlaybackQuality
+			}
+			hasMaxQuality = true
+		}
+		if policy.MaxStreams != nil {
+			if !hasMaxStreams || *policy.MaxStreams > maxStreams {
+				maxStreams = *policy.MaxStreams
+			}
+			hasMaxStreams = true
+		}
+		if policy.MaxTranscodes != nil {
+			if !hasMaxTranscodes || *policy.MaxTranscodes > maxTranscodes {
+				maxTranscodes = *policy.MaxTranscodes
+			}
+			hasMaxTranscodes = true
+		}
+		if policy.MaxProfiles != nil {
+			if !hasMaxProfiles || *policy.MaxProfiles > maxProfiles {
+				maxProfiles = *policy.MaxProfiles
+			}
+			hasMaxProfiles = true
+		}
+		if policy.DirectDownloadsAllowed != nil {
+			directDownloads = directDownloads || *policy.DirectDownloadsAllowed
+			hasDirectDownloads = true
+		}
+		if policy.TranscodedDownloadsAllowed != nil {
+			transcodedDownloads = transcodedDownloads || *policy.TranscodedDownloadsAllowed
+			hasTransDownloads = true
+		}
+	}
+
+	if hasLibraryIDs {
+		out.LibraryIDs = make([]int, 0, len(librarySet))
+		for id := range librarySet {
+			out.LibraryIDs = append(out.LibraryIDs, id)
+		}
+		sort.Ints(out.LibraryIDs)
+	}
+	if hasMediaTypes {
+		out.MediaTypes = make([]string, 0, len(mediaTypeSet))
+		for mediaType := range mediaTypeSet {
+			out.MediaTypes = append(out.MediaTypes, mediaType)
+		}
+		sort.Strings(out.MediaTypes)
+	}
+	if hasMaxQuality {
+		out.MaxPlaybackQuality = maxPlaybackQuality
+	}
+	if hasMaxStreams {
+		out.MaxStreams = maxStreams
+	}
+	if hasMaxTranscodes {
+		out.MaxTranscodes = maxTranscodes
+	}
+	if hasMaxProfiles {
+		out.MaxProfiles = maxProfiles
+	}
+	if hasDirectDownloads {
+		out.DirectDownloadsAllowed = directDownloads
+	}
+	if hasTransDownloads {
+		out.TranscodedDownloadsAllowed = transcodedDownloads
+	}
+	return out
+}
+
+func playbackQualityMorePermissive(left, right string) bool {
+	leftRank, leftOK := playbackQualityRank(left)
+	rightRank, rightOK := playbackQualityRank(right)
+	if !leftOK {
+		return false
+	}
+	if !rightOK {
+		return true
+	}
+	return leftRank > rightRank
+}

--- a/internal/auth/acl_repository.go
+++ b/internal/auth/acl_repository.go
@@ -4,15 +4,23 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
+	"strings"
 
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgconn"
 	"github.com/jackc/pgx/v5/pgxpool"
 )
 
 type ACLRepository struct {
 	db *pgxpool.Pool
 }
+
+var ErrUnknownACLGroup = errors.New("unknown ACL group")
+var ErrACLGroupExists = errors.New("acl group exists")
+var ErrProtectedACLGroup = errors.New("protected acl group")
 
 func NewACLRepository(db *pgxpool.Pool) *ACLRepository {
 	return &ACLRepository{db: db}
@@ -73,6 +81,31 @@ func decodeACLConditions(raw []byte) (ACLCondition, error) {
 	return conditions, nil
 }
 
+func decodeACLPolicy(raw []byte) (ACLPolicy, error) {
+	trimmed := bytes.TrimSpace(raw)
+	if len(trimmed) == 0 {
+		return ACLPolicy{}, nil
+	}
+	if trimmed[0] != '{' {
+		return ACLPolicy{}, fmt.Errorf("decoding acl policy: expected object JSON, got %s", string(trimmed))
+	}
+
+	var policy ACLPolicy
+	decoder := json.NewDecoder(bytes.NewReader(trimmed))
+	decoder.DisallowUnknownFields()
+	if err := decoder.Decode(&policy); err != nil {
+		return ACLPolicy{}, fmt.Errorf("decoding acl policy: %w", err)
+	}
+	if err := decoder.Decode(&struct{}{}); err != io.EOF {
+		return ACLPolicy{}, fmt.Errorf("decoding acl policy: unexpected trailing JSON")
+	}
+	normalized, err := NormalizeACLPolicy(policy)
+	if err != nil {
+		return ACLPolicy{}, err
+	}
+	return normalized, nil
+}
+
 const aclRulesForUserQuery = `
 		SELECT r.id, r.subject_type, r.subject_id, r.action, r.resource_type, r.resource_id, r.effect, r.conditions, r.priority, r.name, r.description
 		FROM public.acl_rules r
@@ -93,6 +126,14 @@ const aclRulesForUserQuery = `
 		   ))
 		   OR r.subject_type = 'everyone'
 		ORDER BY r.priority DESC, r.id ASC
+`
+
+const aclPoliciesForUserQuery = `
+		SELECT g.policy
+		FROM public.acl_groups g
+		JOIN public.acl_group_members gm ON gm.group_id = g.id
+		WHERE gm.user_id = $1
+		ORDER BY g.id ASC
 `
 
 func (r *ACLRepository) ListRulesForUser(ctx context.Context, userID int) ([]ACLRule, error) {
@@ -117,8 +158,537 @@ func (r *ACLRepository) ListRulesForUser(ctx context.Context, userID int) ([]ACL
 	return rules, rows.Err()
 }
 
+func (r *ACLRepository) ListPoliciesForUser(ctx context.Context, userID int) ([]ACLPolicy, error) {
+	rows, err := r.db.Query(ctx, aclPoliciesForUserQuery, userID)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	policies := []ACLPolicy{}
+	for rows.Next() {
+		var raw []byte
+		if err := rows.Scan(&raw); err != nil {
+			return nil, err
+		}
+		policy, err := decodeACLPolicy(raw)
+		if err != nil {
+			return nil, err
+		}
+		policies = append(policies, policy)
+	}
+	return policies, rows.Err()
+}
+
 func (r *ACLRepository) CurrentPolicyRevision(ctx context.Context) (int64, error) {
 	var revision int64
 	err := r.db.QueryRow(ctx, `SELECT revision FROM public.acl_policy_revisions WHERE id = true`).Scan(&revision)
 	return revision, err
+}
+
+func (r *ACLRepository) ListGroups(ctx context.Context) ([]ACLGroup, error) {
+	rows, err := r.db.Query(ctx, `
+		SELECT id, slug, name, description, policy, built_in, protected, created_at, updated_at
+		FROM public.acl_groups
+		ORDER BY id ASC`)
+	if err != nil {
+		return nil, fmt.Errorf("listing ACL groups: %w", err)
+	}
+	defer rows.Close()
+
+	groups := []ACLGroup{}
+	for rows.Next() {
+		var group ACLGroup
+		var rawPolicy []byte
+		if err := rows.Scan(&group.ID, &group.Slug, &group.Name, &group.Description, &rawPolicy, &group.BuiltIn, &group.Protected, &group.CreatedAt, &group.UpdatedAt); err != nil {
+			return nil, fmt.Errorf("scanning ACL group: %w", err)
+		}
+		policy, err := decodeACLPolicy(rawPolicy)
+		if err != nil {
+			return nil, err
+		}
+		group.Policy = policy
+		groups = append(groups, group)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("iterating ACL groups: %w", err)
+	}
+	return groups, nil
+}
+
+func (r *ACLRepository) GetGroup(ctx context.Context, slug string) (ACLGroup, []ACLRule, error) {
+	normalizedSlug, err := NormalizeACLGroupSlug(slug)
+	if err != nil {
+		return ACLGroup{}, nil, err
+	}
+
+	var group ACLGroup
+	var rawPolicy []byte
+	err = r.db.QueryRow(ctx, `
+		SELECT id, slug, name, description, policy, built_in, protected, created_at, updated_at
+		FROM public.acl_groups
+		WHERE slug = $1`, normalizedSlug).
+		Scan(&group.ID, &group.Slug, &group.Name, &group.Description, &rawPolicy, &group.BuiltIn, &group.Protected, &group.CreatedAt, &group.UpdatedAt)
+	if err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return ACLGroup{}, nil, ErrNotFound
+		}
+		return ACLGroup{}, nil, fmt.Errorf("loading ACL group: %w", err)
+	}
+	policy, err := decodeACLPolicy(rawPolicy)
+	if err != nil {
+		return ACLGroup{}, nil, err
+	}
+	group.Policy = policy
+
+	rules, err := r.listRulesForGroup(ctx, group.Slug)
+	if err != nil {
+		return ACLGroup{}, nil, err
+	}
+	return group, rules, nil
+}
+
+func (r *ACLRepository) CreateGroup(ctx context.Context, input CreateACLGroupInput) (ACLGroup, error) {
+	slug, err := NormalizeACLGroupSlug(input.Slug)
+	if err != nil {
+		return ACLGroup{}, err
+	}
+	name := strings.TrimSpace(input.Name)
+	if name == "" {
+		return ACLGroup{}, fmt.Errorf("ACL group name is required")
+	}
+	description := strings.TrimSpace(input.Description)
+	policy, err := NormalizeACLPolicy(input.Policy)
+	if err != nil {
+		return ACLGroup{}, err
+	}
+	policyJSON, err := json.Marshal(policy)
+	if err != nil {
+		return ACLGroup{}, fmt.Errorf("encoding ACL group policy: %w", err)
+	}
+
+	var group ACLGroup
+	var rawPolicy []byte
+	err = r.db.QueryRow(ctx, `
+		INSERT INTO public.acl_groups (slug, name, description, policy, built_in, protected)
+		VALUES ($1, $2, $3, $4, false, false)
+		RETURNING id, slug, name, description, policy, built_in, protected, created_at, updated_at`,
+		slug, name, description, policyJSON).
+		Scan(&group.ID, &group.Slug, &group.Name, &group.Description, &rawPolicy, &group.BuiltIn, &group.Protected, &group.CreatedAt, &group.UpdatedAt)
+	if err != nil {
+		if isUniqueViolation(err) {
+			return ACLGroup{}, ErrACLGroupExists
+		}
+		return ACLGroup{}, fmt.Errorf("creating ACL group: %w", err)
+	}
+	group.Policy = policy
+	if err := r.bumpPolicyRevision(ctx); err != nil {
+		return ACLGroup{}, err
+	}
+	return group, nil
+}
+
+func (r *ACLRepository) UpdateGroup(ctx context.Context, slug string, input UpdateACLGroupInput) (ACLGroup, error) {
+	normalizedSlug, err := NormalizeACLGroupSlug(slug)
+	if err != nil {
+		return ACLGroup{}, err
+	}
+	name := strings.TrimSpace(input.Name)
+	if name == "" {
+		return ACLGroup{}, fmt.Errorf("ACL group name is required")
+	}
+	description := strings.TrimSpace(input.Description)
+	policy, err := NormalizeACLPolicy(input.Policy)
+	if err != nil {
+		return ACLGroup{}, err
+	}
+	policyJSON, err := json.Marshal(policy)
+	if err != nil {
+		return ACLGroup{}, fmt.Errorf("encoding ACL group policy: %w", err)
+	}
+
+	tx, err := r.db.BeginTx(ctx, pgx.TxOptions{})
+	if err != nil {
+		return ACLGroup{}, fmt.Errorf("beginning ACL group update: %w", err)
+	}
+	defer tx.Rollback(ctx)
+
+	group, err := loadACLGroupForUpdate(ctx, tx, normalizedSlug)
+	if err != nil {
+		return ACLGroup{}, err
+	}
+	if group.Protected {
+		return ACLGroup{}, ErrProtectedACLGroup
+	}
+
+	var rawPolicy []byte
+	err = tx.QueryRow(ctx, `
+		UPDATE public.acl_groups
+		SET name = $2,
+		    description = $3,
+		    policy = $4,
+		    updated_at = now()
+		WHERE slug = $1
+		RETURNING id, slug, name, description, policy, built_in, protected, created_at, updated_at`,
+		normalizedSlug, name, description, policyJSON).
+		Scan(&group.ID, &group.Slug, &group.Name, &group.Description, &rawPolicy, &group.BuiltIn, &group.Protected, &group.CreatedAt, &group.UpdatedAt)
+	if err != nil {
+		return ACLGroup{}, fmt.Errorf("updating ACL group: %w", err)
+	}
+	group.Policy = policy
+	if err := bumpPolicyRevisionTx(ctx, tx); err != nil {
+		return ACLGroup{}, err
+	}
+	if err := tx.Commit(ctx); err != nil {
+		return ACLGroup{}, fmt.Errorf("committing ACL group update: %w", err)
+	}
+	return group, nil
+}
+
+func (r *ACLRepository) DeleteGroup(ctx context.Context, slug string) error {
+	normalizedSlug, err := NormalizeACLGroupSlug(slug)
+	if err != nil {
+		return err
+	}
+
+	tx, err := r.db.BeginTx(ctx, pgx.TxOptions{})
+	if err != nil {
+		return fmt.Errorf("beginning ACL group delete: %w", err)
+	}
+	defer tx.Rollback(ctx)
+
+	group, err := loadACLGroupForUpdate(ctx, tx, normalizedSlug)
+	if err != nil {
+		return err
+	}
+	if group.BuiltIn || group.Protected {
+		return ErrProtectedACLGroup
+	}
+	if _, err := tx.Exec(ctx, `
+		DELETE FROM public.acl_rules
+		WHERE subject_type = 'group' AND subject_id = $1`, normalizedSlug); err != nil {
+		return fmt.Errorf("deleting ACL group rules: %w", err)
+	}
+	if _, err := tx.Exec(ctx, `DELETE FROM public.acl_groups WHERE slug = $1`, normalizedSlug); err != nil {
+		return fmt.Errorf("deleting ACL group: %w", err)
+	}
+	if err := bumpPolicyRevisionTx(ctx, tx); err != nil {
+		return err
+	}
+	if err := tx.Commit(ctx); err != nil {
+		return fmt.Errorf("committing ACL group delete: %w", err)
+	}
+	return nil
+}
+
+func (r *ACLRepository) ListGroupsByUserIDs(ctx context.Context, userIDs []int) (map[int][]ACLGroup, error) {
+	out := make(map[int][]ACLGroup, len(userIDs))
+	if len(userIDs) == 0 {
+		return out, nil
+	}
+
+	rows, err := r.db.Query(ctx, `
+		SELECT gm.user_id, g.id, g.slug, g.name, g.description, g.policy, g.built_in, g.protected, g.created_at, g.updated_at
+		FROM public.acl_group_members gm
+		JOIN public.acl_groups g ON g.id = gm.group_id
+		WHERE gm.user_id = ANY($1::int[])
+		ORDER BY gm.user_id ASC, g.id ASC`, userIDs)
+	if err != nil {
+		return nil, fmt.Errorf("listing ACL groups by user: %w", err)
+	}
+	defer rows.Close()
+
+	for rows.Next() {
+		var userID int
+		var group ACLGroup
+		var rawPolicy []byte
+		if err := rows.Scan(&userID, &group.ID, &group.Slug, &group.Name, &group.Description, &rawPolicy, &group.BuiltIn, &group.Protected, &group.CreatedAt, &group.UpdatedAt); err != nil {
+			return nil, fmt.Errorf("scanning ACL group membership: %w", err)
+		}
+		policy, err := decodeACLPolicy(rawPolicy)
+		if err != nil {
+			return nil, err
+		}
+		group.Policy = policy
+		out[userID] = append(out[userID], group)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("iterating ACL group memberships: %w", err)
+	}
+	return out, nil
+}
+
+func (r *ACLRepository) ListGroupMemberCounts(ctx context.Context) (map[string]int, error) {
+	rows, err := r.db.Query(ctx, `
+		SELECT g.slug, count(gm.user_id)::int
+		FROM public.acl_groups g
+		LEFT JOIN public.acl_group_members gm ON gm.group_id = g.id
+		GROUP BY g.slug`)
+	if err != nil {
+		return nil, fmt.Errorf("listing ACL group member counts: %w", err)
+	}
+	defer rows.Close()
+
+	out := map[string]int{}
+	for rows.Next() {
+		var slug string
+		var count int
+		if err := rows.Scan(&slug, &count); err != nil {
+			return nil, fmt.Errorf("scanning ACL group member count: %w", err)
+		}
+		out[slug] = count
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("iterating ACL group member counts: %w", err)
+	}
+	return out, nil
+}
+
+func (r *ACLRepository) ListGroupMembers(ctx context.Context, slug string) ([]ACLGroupMember, error) {
+	normalizedSlug, err := NormalizeACLGroupSlug(slug)
+	if err != nil {
+		return nil, err
+	}
+	rows, err := r.db.Query(ctx, `
+		SELECT u.id, u.username, u.email, u.role, u.enabled
+		FROM public.acl_group_members gm
+		JOIN public.acl_groups g ON g.id = gm.group_id
+		JOIN public.users u ON u.id = gm.user_id
+		WHERE g.slug = $1
+		ORDER BY lower(u.username) ASC, u.id ASC`, normalizedSlug)
+	if err != nil {
+		return nil, fmt.Errorf("listing ACL group members: %w", err)
+	}
+	defer rows.Close()
+
+	members := []ACLGroupMember{}
+	for rows.Next() {
+		var member ACLGroupMember
+		if err := rows.Scan(&member.UserID, &member.Username, &member.Email, &member.Role, &member.Enabled); err != nil {
+			return nil, fmt.Errorf("scanning ACL group member: %w", err)
+		}
+		members = append(members, member)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("iterating ACL group members: %w", err)
+	}
+	return members, nil
+}
+
+func (r *ACLRepository) ReplaceUserGroups(ctx context.Context, userID int, groupSlugs []string) error {
+	normalized, err := NormalizeACLGroupSlugs(groupSlugs)
+	if err != nil {
+		return err
+	}
+
+	tx, err := r.db.BeginTx(ctx, pgx.TxOptions{})
+	if err != nil {
+		return fmt.Errorf("beginning ACL group update: %w", err)
+	}
+	defer tx.Rollback(ctx)
+
+	var exists bool
+	if err := tx.QueryRow(ctx, `SELECT EXISTS(SELECT 1 FROM public.users WHERE id = $1)`, userID).Scan(&exists); err != nil {
+		return fmt.Errorf("checking user for ACL group update: %w", err)
+	}
+	if !exists {
+		return ErrNotFound
+	}
+
+	groupIDs := make([]int64, 0, len(normalized))
+	if len(normalized) > 0 {
+		rows, err := tx.Query(ctx, `
+			SELECT id, slug
+			FROM public.acl_groups
+			WHERE slug = ANY($1::text[])
+			ORDER BY id ASC`, normalized)
+		if err != nil {
+			return fmt.Errorf("loading ACL groups: %w", err)
+		}
+		found := map[string]struct{}{}
+		for rows.Next() {
+			var id int64
+			var slug string
+			if err := rows.Scan(&id, &slug); err != nil {
+				rows.Close()
+				return fmt.Errorf("scanning ACL group id: %w", err)
+			}
+			groupIDs = append(groupIDs, id)
+			found[slug] = struct{}{}
+		}
+		if err := rows.Err(); err != nil {
+			rows.Close()
+			return fmt.Errorf("iterating ACL group ids: %w", err)
+		}
+		rows.Close()
+		if len(found) != len(normalized) {
+			return ErrUnknownACLGroup
+		}
+	}
+
+	if _, err := tx.Exec(ctx, `DELETE FROM public.acl_group_members WHERE user_id = $1`, userID); err != nil {
+		return fmt.Errorf("clearing ACL group memberships: %w", err)
+	}
+	for _, groupID := range groupIDs {
+		if _, err := tx.Exec(ctx, `
+			INSERT INTO public.acl_group_members (group_id, user_id)
+			VALUES ($1, $2)
+			ON CONFLICT DO NOTHING`, groupID, userID); err != nil {
+			return fmt.Errorf("inserting ACL group membership: %w", err)
+		}
+	}
+	if _, err := tx.Exec(ctx, `
+		UPDATE public.users
+		SET access_policy_revision = access_policy_revision + 1,
+		    updated_at = now()
+		WHERE id = $1`, userID); err != nil {
+		return fmt.Errorf("bumping user ACL revision: %w", err)
+	}
+	if err := bumpPolicyRevisionTx(ctx, tx); err != nil {
+		return err
+	}
+
+	if err := tx.Commit(ctx); err != nil {
+		return fmt.Errorf("committing ACL group update: %w", err)
+	}
+	return nil
+}
+
+func (r *ACLRepository) ReplaceGroupRules(ctx context.Context, slug string, inputs []ACLRuleInput) ([]ACLRule, error) {
+	normalizedSlug, err := NormalizeACLGroupSlug(slug)
+	if err != nil {
+		return nil, err
+	}
+	normalizedInputs, err := NormalizeACLRuleInputs(inputs)
+	if err != nil {
+		return nil, err
+	}
+
+	tx, err := r.db.BeginTx(ctx, pgx.TxOptions{})
+	if err != nil {
+		return nil, fmt.Errorf("beginning ACL rule update: %w", err)
+	}
+	defer tx.Rollback(ctx)
+
+	group, err := loadACLGroupForUpdate(ctx, tx, normalizedSlug)
+	if err != nil {
+		return nil, err
+	}
+	if group.Protected {
+		return nil, ErrProtectedACLGroup
+	}
+
+	if _, err := tx.Exec(ctx, `
+		DELETE FROM public.acl_rules
+		WHERE subject_type = 'group' AND subject_id = $1`, normalizedSlug); err != nil {
+		return nil, fmt.Errorf("clearing ACL group rules: %w", err)
+	}
+	for _, rule := range normalizedInputs {
+		conditions, err := json.Marshal(rule.Conditions)
+		if err != nil {
+			return nil, fmt.Errorf("encoding ACL rule conditions: %w", err)
+		}
+		if _, err := tx.Exec(ctx, `
+			INSERT INTO public.acl_rules
+				(subject_type, subject_id, action, resource_type, resource_id, effect, conditions, priority, name, description)
+			VALUES
+				('group', $1, $2, $3, $4, $5, $6, $7, $8, $9)`,
+			normalizedSlug, rule.Action, rule.ResourceType, rule.ResourceID, rule.Effect, conditions, rule.Priority, rule.Name, rule.Description); err != nil {
+			return nil, fmt.Errorf("inserting ACL group rule: %w", err)
+		}
+	}
+	if err := bumpPolicyRevisionTx(ctx, tx); err != nil {
+		return nil, err
+	}
+	if err := tx.Commit(ctx); err != nil {
+		return nil, fmt.Errorf("committing ACL rule update: %w", err)
+	}
+	return r.listRulesForGroup(ctx, normalizedSlug)
+}
+
+func (r *ACLRepository) listRulesForGroup(ctx context.Context, slug string) ([]ACLRule, error) {
+	rows, err := r.db.Query(ctx, `
+		SELECT id, subject_type, subject_id, action, resource_type, resource_id, effect, conditions, priority, name, description
+		FROM public.acl_rules
+		WHERE subject_type = 'group' AND subject_id = $1
+		ORDER BY priority DESC, id ASC`, slug)
+	if err != nil {
+		return nil, fmt.Errorf("listing ACL group rules: %w", err)
+	}
+	defer rows.Close()
+
+	rules := []ACLRule{}
+	for rows.Next() {
+		var row aclRuleRow
+		if err := rows.Scan(&row.ID, &row.SubjectType, &row.SubjectID, &row.Action, &row.ResourceType, &row.ResourceID, &row.Effect, &row.Conditions, &row.Priority, &row.Name, &row.Description); err != nil {
+			return nil, fmt.Errorf("scanning ACL group rule: %w", err)
+		}
+		rule, err := row.toRule()
+		if err != nil {
+			return nil, err
+		}
+		rules = append(rules, rule)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("iterating ACL group rules: %w", err)
+	}
+	return rules, nil
+}
+
+type aclTx interface {
+	QueryRow(ctx context.Context, sql string, args ...any) pgx.Row
+	Exec(ctx context.Context, sql string, args ...any) (pgconn.CommandTag, error)
+}
+
+func loadACLGroupForUpdate(ctx context.Context, tx aclTx, slug string) (ACLGroup, error) {
+	var group ACLGroup
+	var rawPolicy []byte
+	err := tx.QueryRow(ctx, `
+		SELECT id, slug, name, description, policy, built_in, protected, created_at, updated_at
+		FROM public.acl_groups
+		WHERE slug = $1
+		FOR UPDATE`, slug).
+		Scan(&group.ID, &group.Slug, &group.Name, &group.Description, &rawPolicy, &group.BuiltIn, &group.Protected, &group.CreatedAt, &group.UpdatedAt)
+	if err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return ACLGroup{}, ErrNotFound
+		}
+		return ACLGroup{}, fmt.Errorf("loading ACL group: %w", err)
+	}
+	policy, err := decodeACLPolicy(rawPolicy)
+	if err != nil {
+		return ACLGroup{}, err
+	}
+	group.Policy = policy
+	return group, nil
+}
+
+func (r *ACLRepository) bumpPolicyRevision(ctx context.Context) error {
+	_, err := r.db.Exec(ctx, `
+		INSERT INTO public.acl_policy_revisions (id, revision, updated_at)
+		VALUES (true, 1, now())
+		ON CONFLICT (id) DO UPDATE
+		SET revision = public.acl_policy_revisions.revision + 1,
+		    updated_at = now()`)
+	if err != nil {
+		return fmt.Errorf("bumping ACL policy revision: %w", err)
+	}
+	return nil
+}
+
+func bumpPolicyRevisionTx(ctx context.Context, tx aclTx) error {
+	if _, err := tx.Exec(ctx, `
+		INSERT INTO public.acl_policy_revisions (id, revision, updated_at)
+		VALUES (true, 1, now())
+		ON CONFLICT (id) DO UPDATE
+		SET revision = public.acl_policy_revisions.revision + 1,
+		    updated_at = now()`); err != nil {
+		return fmt.Errorf("bumping ACL policy revision: %w", err)
+	}
+	return nil
+}
+
+func isUniqueViolation(err error) bool {
+	var pgErr *pgconn.PgError
+	return errors.As(err, &pgErr) && pgErr.Code == "23505"
 }

--- a/internal/auth/acl_repository.go
+++ b/internal/auth/acl_repository.go
@@ -67,8 +67,7 @@ func decodeACLConditions(raw []byte) (ACLCondition, error) {
 	return conditions, nil
 }
 
-func (r *ACLRepository) ListRulesForUser(ctx context.Context, userID int) ([]ACLRule, error) {
-	rows, err := r.db.Query(ctx, `
+const aclRulesForUserQuery = `
 		SELECT r.id, r.subject_type, r.subject_id, r.action, r.resource_type, r.resource_id, r.effect, r.conditions, r.priority, r.name, r.description
 		FROM public.acl_rules r
 		JOIN public.users u ON u.id = $1
@@ -79,10 +78,19 @@ func (r *ACLRepository) ListRulesForUser(ctx context.Context, userID int) ([]ACL
 		       JOIN public.acl_group_members gm ON gm.group_id = g.id
 		       WHERE gm.user_id = u.id
 		   ))
-		   OR (r.subject_type = 'builtin_role' AND r.subject_id = u.role)
+		   OR (r.subject_type = 'builtin_role' AND r.subject_id IN (
+		       SELECT g.slug
+		       FROM public.acl_groups g
+		       JOIN public.acl_group_members gm ON gm.group_id = g.id
+		       WHERE gm.user_id = u.id
+		         AND g.built_in = true
+		   ))
 		   OR r.subject_type = 'everyone'
 		ORDER BY r.priority DESC, r.id ASC
-	`, userID)
+`
+
+func (r *ACLRepository) ListRulesForUser(ctx context.Context, userID int) ([]ACLRule, error) {
+	rows, err := r.db.Query(ctx, aclRulesForUserQuery, userID)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/auth/acl_repository.go
+++ b/internal/auth/acl_repository.go
@@ -1,8 +1,10 @@
 package auth
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
+	"fmt"
 
 	"github.com/jackc/pgx/v5/pgxpool"
 )
@@ -29,10 +31,10 @@ type aclRuleRow struct {
 	Description  string
 }
 
-func (row aclRuleRow) toRule() ACLRule {
-	var conditions ACLCondition
-	if len(row.Conditions) > 0 {
-		_ = json.Unmarshal(row.Conditions, &conditions)
+func (row aclRuleRow) toRule() (ACLRule, error) {
+	conditions, err := decodeACLConditions(row.Conditions)
+	if err != nil {
+		return ACLRule{}, err
 	}
 	return ACLRule{
 		ID:           row.ID,
@@ -46,23 +48,41 @@ func (row aclRuleRow) toRule() ACLRule {
 		Priority:     row.Priority,
 		Name:         row.Name,
 		Description:  row.Description,
+	}, nil
+}
+
+func decodeACLConditions(raw []byte) (ACLCondition, error) {
+	trimmed := bytes.TrimSpace(raw)
+	if len(trimmed) == 0 {
+		return ACLCondition{}, nil
 	}
+	if trimmed[0] != '{' {
+		return ACLCondition{}, fmt.Errorf("decoding acl conditions: expected object JSON, got %s", string(trimmed))
+	}
+
+	var conditions ACLCondition
+	if err := json.Unmarshal(trimmed, &conditions); err != nil {
+		return ACLCondition{}, fmt.Errorf("decoding acl conditions: %w", err)
+	}
+	return conditions, nil
 }
 
 func (r *ACLRepository) ListRulesForUser(ctx context.Context, userID int) ([]ACLRule, error) {
 	rows, err := r.db.Query(ctx, `
-		SELECT id, subject_type, subject_id, action, resource_type, resource_id, effect, conditions, priority, name, description
-		FROM public.acl_rules
-		WHERE (subject_type = 'user' AND subject_id = $1::text)
-		   OR (subject_type = 'group' AND subject_id IN (
+		SELECT r.id, r.subject_type, r.subject_id, r.action, r.resource_type, r.resource_id, r.effect, r.conditions, r.priority, r.name, r.description
+		FROM public.acl_rules r
+		JOIN public.users u ON u.id = $1
+		WHERE (r.subject_type = 'user' AND r.subject_id = u.id::text)
+		   OR (r.subject_type = 'group' AND r.subject_id IN (
 		       SELECT g.slug
 		       FROM public.acl_groups g
 		       JOIN public.acl_group_members gm ON gm.group_id = g.id
-		       WHERE gm.user_id = $2
+		       WHERE gm.user_id = u.id
 		   ))
-		   OR subject_type = 'everyone'
-		ORDER BY priority DESC, id ASC
-	`, userID, userID)
+		   OR (r.subject_type = 'builtin_role' AND r.subject_id = u.role)
+		   OR r.subject_type = 'everyone'
+		ORDER BY r.priority DESC, r.id ASC
+	`, userID)
 	if err != nil {
 		return nil, err
 	}
@@ -74,7 +94,11 @@ func (r *ACLRepository) ListRulesForUser(ctx context.Context, userID int) ([]ACL
 		if err := rows.Scan(&row.ID, &row.SubjectType, &row.SubjectID, &row.Action, &row.ResourceType, &row.ResourceID, &row.Effect, &row.Conditions, &row.Priority, &row.Name, &row.Description); err != nil {
 			return nil, err
 		}
-		rules = append(rules, row.toRule())
+		rule, err := row.toRule()
+		if err != nil {
+			return nil, err
+		}
+		rules = append(rules, rule)
 	}
 	return rules, rows.Err()
 }

--- a/internal/auth/acl_repository.go
+++ b/internal/auth/acl_repository.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"io"
 
 	"github.com/jackc/pgx/v5/pgxpool"
 )
@@ -61,8 +62,13 @@ func decodeACLConditions(raw []byte) (ACLCondition, error) {
 	}
 
 	var conditions ACLCondition
-	if err := json.Unmarshal(trimmed, &conditions); err != nil {
+	decoder := json.NewDecoder(bytes.NewReader(trimmed))
+	decoder.DisallowUnknownFields()
+	if err := decoder.Decode(&conditions); err != nil {
 		return ACLCondition{}, fmt.Errorf("decoding acl conditions: %w", err)
+	}
+	if err := decoder.Decode(&struct{}{}); err != io.EOF {
+		return ACLCondition{}, fmt.Errorf("decoding acl conditions: unexpected trailing JSON")
 	}
 	return conditions, nil
 }

--- a/internal/auth/acl_repository.go
+++ b/internal/auth/acl_repository.go
@@ -1,0 +1,86 @@
+package auth
+
+import (
+	"context"
+	"encoding/json"
+
+	"github.com/jackc/pgx/v5/pgxpool"
+)
+
+type ACLRepository struct {
+	db *pgxpool.Pool
+}
+
+func NewACLRepository(db *pgxpool.Pool) *ACLRepository {
+	return &ACLRepository{db: db}
+}
+
+type aclRuleRow struct {
+	ID           int64
+	SubjectType  string
+	SubjectID    string
+	Action       string
+	ResourceType string
+	ResourceID   string
+	Effect       string
+	Conditions   []byte
+	Priority     int
+	Name         string
+	Description  string
+}
+
+func (row aclRuleRow) toRule() ACLRule {
+	var conditions ACLCondition
+	if len(row.Conditions) > 0 {
+		_ = json.Unmarshal(row.Conditions, &conditions)
+	}
+	return ACLRule{
+		ID:           row.ID,
+		SubjectType:  ACLSubjectType(row.SubjectType),
+		SubjectID:    row.SubjectID,
+		Action:       ACLAction(row.Action),
+		ResourceType: ACLResourceType(row.ResourceType),
+		ResourceID:   row.ResourceID,
+		Effect:       ACLEffect(row.Effect),
+		Conditions:   conditions,
+		Priority:     row.Priority,
+		Name:         row.Name,
+		Description:  row.Description,
+	}
+}
+
+func (r *ACLRepository) ListRulesForUser(ctx context.Context, userID int) ([]ACLRule, error) {
+	rows, err := r.db.Query(ctx, `
+		SELECT id, subject_type, subject_id, action, resource_type, resource_id, effect, conditions, priority, name, description
+		FROM public.acl_rules
+		WHERE (subject_type = 'user' AND subject_id = $1::text)
+		   OR (subject_type = 'group' AND subject_id IN (
+		       SELECT g.slug
+		       FROM public.acl_groups g
+		       JOIN public.acl_group_members gm ON gm.group_id = g.id
+		       WHERE gm.user_id = $2
+		   ))
+		   OR subject_type = 'everyone'
+		ORDER BY priority DESC, id ASC
+	`, userID, userID)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	rules := []ACLRule{}
+	for rows.Next() {
+		var row aclRuleRow
+		if err := rows.Scan(&row.ID, &row.SubjectType, &row.SubjectID, &row.Action, &row.ResourceType, &row.ResourceID, &row.Effect, &row.Conditions, &row.Priority, &row.Name, &row.Description); err != nil {
+			return nil, err
+		}
+		rules = append(rules, row.toRule())
+	}
+	return rules, rows.Err()
+}
+
+func (r *ACLRepository) CurrentPolicyRevision(ctx context.Context) (int64, error) {
+	var revision int64
+	err := r.db.QueryRow(ctx, `SELECT revision FROM public.acl_policy_revisions WHERE id = true`).Scan(&revision)
+	return revision, err
+}

--- a/internal/auth/acl_repository_test.go
+++ b/internal/auth/acl_repository_test.go
@@ -42,7 +42,17 @@ func TestScanACLRuleFields(t *testing.T) {
 
 func TestACLRuleConditionsDecodeObject(t *testing.T) {
 	row := aclRuleRow{
-		Conditions: []byte(`{"LibraryIDs":[10],"MediaTypes":["movie"]}`),
+		Conditions: []byte(`{
+			"library_ids":[10],
+			"media_types":["movie"],
+			"primary_profile_required":true,
+			"max_playback_quality":"1080p",
+			"max_streams":2,
+			"max_transcodes":1,
+			"direct_downloads_allowed":true,
+			"transcoded_downloads_allowed":false,
+			"max_content_rating":"PG-13"
+		}`),
 	}
 
 	rule, err := row.toRule()
@@ -55,6 +65,27 @@ func TestACLRuleConditionsDecodeObject(t *testing.T) {
 	if len(rule.Conditions.MediaTypes) != 1 || rule.Conditions.MediaTypes[0] != "movie" {
 		t.Fatalf("media types = %#v, want [movie]", rule.Conditions.MediaTypes)
 	}
+	if rule.Conditions.PrimaryProfileRequired == nil || !*rule.Conditions.PrimaryProfileRequired {
+		t.Fatalf("primary profile required = %#v, want true", rule.Conditions.PrimaryProfileRequired)
+	}
+	if rule.Conditions.MaxPlaybackQuality != "1080p" {
+		t.Fatalf("max playback quality = %q, want 1080p", rule.Conditions.MaxPlaybackQuality)
+	}
+	if rule.Conditions.MaxStreams == nil || *rule.Conditions.MaxStreams != 2 {
+		t.Fatalf("max streams = %#v, want 2", rule.Conditions.MaxStreams)
+	}
+	if rule.Conditions.MaxTranscodes == nil || *rule.Conditions.MaxTranscodes != 1 {
+		t.Fatalf("max transcodes = %#v, want 1", rule.Conditions.MaxTranscodes)
+	}
+	if rule.Conditions.DirectDownloadsAllowed == nil || !*rule.Conditions.DirectDownloadsAllowed {
+		t.Fatalf("direct downloads allowed = %#v, want true", rule.Conditions.DirectDownloadsAllowed)
+	}
+	if rule.Conditions.TranscodedDownloadsAllowed == nil || *rule.Conditions.TranscodedDownloadsAllowed {
+		t.Fatalf("transcoded downloads allowed = %#v, want false", rule.Conditions.TranscodedDownloadsAllowed)
+	}
+	if rule.Conditions.MaxContentRating != "PG-13" {
+		t.Fatalf("max content rating = %q, want PG-13", rule.Conditions.MaxContentRating)
+	}
 }
 
 func TestACLRuleConditionsRejectNonObject(t *testing.T) {
@@ -62,6 +93,16 @@ func TestACLRuleConditionsRejectNonObject(t *testing.T) {
 
 	if _, err := row.toRule(); err == nil {
 		t.Fatalf("toRule() error = nil, want non-object conditions to fail")
+	}
+}
+
+func TestACLRuleConditionsRejectUnknownKeys(t *testing.T) {
+	row := aclRuleRow{
+		Conditions: []byte(`{"library_ids":[10],"library_ids_typo":[20]}`),
+	}
+
+	if _, err := row.toRule(); err == nil {
+		t.Fatalf("toRule() error = nil, want unknown condition keys to fail")
 	}
 }
 

--- a/internal/auth/acl_repository_test.go
+++ b/internal/auth/acl_repository_test.go
@@ -1,0 +1,35 @@
+package auth
+
+import "testing"
+
+func TestScanACLRuleFields(t *testing.T) {
+	row := aclRuleRow{
+		ID:           42,
+		SubjectType:  "group",
+		SubjectID:    "viewer",
+		Action:       "playback.play",
+		ResourceType: "library",
+		ResourceID:   "10",
+		Effect:       "allow",
+		Priority:     5,
+		Name:         "viewer playback",
+		Description:  "allows library playback",
+	}
+
+	rule := row.toRule()
+	if rule.ID != 42 {
+		t.Fatalf("id = %d, want 42", rule.ID)
+	}
+	if rule.SubjectType != SubjectGroup {
+		t.Fatalf("subject type = %q, want %q", rule.SubjectType, SubjectGroup)
+	}
+	if rule.Action != ActionPlaybackPlay {
+		t.Fatalf("action = %q, want %q", rule.Action, ActionPlaybackPlay)
+	}
+	if rule.ResourceType != ResourceLibrary {
+		t.Fatalf("resource type = %q, want %q", rule.ResourceType, ResourceLibrary)
+	}
+	if rule.Effect != EffectAllow {
+		t.Fatalf("effect = %q, want %q", rule.Effect, EffectAllow)
+	}
+}

--- a/internal/auth/acl_repository_test.go
+++ b/internal/auth/acl_repository_test.go
@@ -16,7 +16,10 @@ func TestScanACLRuleFields(t *testing.T) {
 		Description:  "allows library playback",
 	}
 
-	rule := row.toRule()
+	rule, err := row.toRule()
+	if err != nil {
+		t.Fatalf("toRule() error = %v", err)
+	}
 	if rule.ID != 42 {
 		t.Fatalf("id = %d, want 42", rule.ID)
 	}
@@ -31,5 +34,48 @@ func TestScanACLRuleFields(t *testing.T) {
 	}
 	if rule.Effect != EffectAllow {
 		t.Fatalf("effect = %q, want %q", rule.Effect, EffectAllow)
+	}
+}
+
+func TestACLRuleConditionsDecodeObject(t *testing.T) {
+	row := aclRuleRow{
+		Conditions: []byte(`{"LibraryIDs":[10],"MediaTypes":["movie"]}`),
+	}
+
+	rule, err := row.toRule()
+	if err != nil {
+		t.Fatalf("toRule() error = %v", err)
+	}
+	if len(rule.Conditions.LibraryIDs) != 1 || rule.Conditions.LibraryIDs[0] != 10 {
+		t.Fatalf("library ids = %#v, want [10]", rule.Conditions.LibraryIDs)
+	}
+	if len(rule.Conditions.MediaTypes) != 1 || rule.Conditions.MediaTypes[0] != "movie" {
+		t.Fatalf("media types = %#v, want [movie]", rule.Conditions.MediaTypes)
+	}
+}
+
+func TestACLRuleConditionsRejectNonObject(t *testing.T) {
+	row := aclRuleRow{Conditions: []byte(`[]`)}
+
+	if _, err := row.toRule(); err == nil {
+		t.Fatalf("toRule() error = nil, want non-object conditions to fail")
+	}
+}
+
+func TestACLRuleBuiltInRoleMapping(t *testing.T) {
+	row := aclRuleRow{
+		SubjectType: "builtin_role",
+		SubjectID:   string(GroupAdmin),
+	}
+
+	rule, err := row.toRule()
+	if err != nil {
+		t.Fatalf("toRule() error = %v", err)
+	}
+	if rule.SubjectType != SubjectBuiltInRole {
+		t.Fatalf("subject type = %q, want %q", rule.SubjectType, SubjectBuiltInRole)
+	}
+	if rule.SubjectID != string(GroupAdmin) {
+		t.Fatalf("subject id = %q, want %q", rule.SubjectID, GroupAdmin)
 	}
 }

--- a/internal/auth/acl_repository_test.go
+++ b/internal/auth/acl_repository_test.go
@@ -1,6 +1,9 @@
 package auth
 
-import "testing"
+import (
+	"strings"
+	"testing"
+)
 
 func TestScanACLRuleFields(t *testing.T) {
 	row := aclRuleRow{
@@ -77,5 +80,17 @@ func TestACLRuleBuiltInRoleMapping(t *testing.T) {
 	}
 	if rule.SubjectID != string(GroupAdmin) {
 		t.Fatalf("subject id = %q, want %q", rule.SubjectID, GroupAdmin)
+	}
+}
+
+func TestACLRepositoryListRulesForUserQueryUsesBuiltInMemberships(t *testing.T) {
+	if !strings.Contains(aclRulesForUserQuery, "subject_type = 'builtin_role'") {
+		t.Fatalf("query missing builtin role filter: %s", aclRulesForUserQuery)
+	}
+	if !strings.Contains(aclRulesForUserQuery, "g.built_in = true") {
+		t.Fatalf("query missing built-in group guard: %s", aclRulesForUserQuery)
+	}
+	if strings.Contains(aclRulesForUserQuery, "users.role") {
+		t.Fatalf("query still depends on users.role: %s", aclRulesForUserQuery)
 	}
 }

--- a/internal/auth/acl_repository_test.go
+++ b/internal/auth/acl_repository_test.go
@@ -9,13 +9,13 @@ func TestScanACLRuleFields(t *testing.T) {
 	row := aclRuleRow{
 		ID:           42,
 		SubjectType:  "group",
-		SubjectID:    "viewer",
+		SubjectID:    string(GroupStandardUser),
 		Action:       "playback.play",
 		ResourceType: "library",
 		ResourceID:   "10",
 		Effect:       "allow",
 		Priority:     5,
-		Name:         "viewer playback",
+		Name:         "user playback",
 		Description:  "allows library playback",
 	}
 
@@ -103,6 +103,34 @@ func TestACLRuleConditionsRejectUnknownKeys(t *testing.T) {
 
 	if _, err := row.toRule(); err == nil {
 		t.Fatalf("toRule() error = nil, want unknown condition keys to fail")
+	}
+}
+
+func TestACLPolicyDecodeObject(t *testing.T) {
+	policy, err := decodeACLPolicy([]byte(`{
+		"library_ids":[10],
+		"media_types":["movie"],
+		"max_playback_quality":"1080p",
+		"max_streams":5,
+		"max_transcodes":2,
+		"max_profiles":4,
+		"direct_downloads_allowed":true,
+		"transcoded_downloads_allowed":false
+	}`))
+	if err != nil {
+		t.Fatalf("decodeACLPolicy() error = %v", err)
+	}
+	if len(policy.LibraryIDs) != 1 || policy.LibraryIDs[0] != 10 {
+		t.Fatalf("library ids = %#v, want [10]", policy.LibraryIDs)
+	}
+	if policy.MaxProfiles == nil || *policy.MaxProfiles != 4 {
+		t.Fatalf("max profiles = %#v, want 4", policy.MaxProfiles)
+	}
+	if policy.MaxStreams == nil || *policy.MaxStreams != 5 {
+		t.Fatalf("max streams = %#v, want 5", policy.MaxStreams)
+	}
+	if policy.TranscodedDownloadsAllowed == nil || *policy.TranscodedDownloadsAllowed {
+		t.Fatalf("transcoded downloads allowed = %#v, want false", policy.TranscodedDownloadsAllowed)
 	}
 }
 

--- a/internal/auth/acl_types.go
+++ b/internal/auth/acl_types.go
@@ -35,6 +35,61 @@ type ACLRule struct {
 	UpdatedAt    time.Time
 }
 
+type CreateACLGroupInput struct {
+	Slug        string
+	Name        string
+	Description string
+	Policy      ACLPolicy
+}
+
+type UpdateACLGroupInput struct {
+	Name        string
+	Description string
+	Policy      ACLPolicy
+}
+
+type ACLRuleInput struct {
+	Action       ACLAction
+	ResourceType ACLResourceType
+	ResourceID   string
+	Effect       ACLEffect
+	Conditions   ACLCondition
+	Priority     int
+	Name         string
+	Description  string
+}
+
+type ACLGroup struct {
+	ID          int64
+	Slug        string
+	Name        string
+	Description string
+	Policy      ACLPolicy
+	BuiltIn     bool
+	Protected   bool
+	CreatedAt   time.Time
+	UpdatedAt   time.Time
+}
+
+type ACLGroupMember struct {
+	UserID   int
+	Username string
+	Email    string
+	Role     string
+	Enabled  bool
+}
+
+type ACLPolicy struct {
+	LibraryIDs                 []int    `json:"library_ids,omitempty"`
+	MediaTypes                 []string `json:"media_types,omitempty"`
+	MaxPlaybackQuality         string   `json:"max_playback_quality,omitempty"`
+	MaxStreams                 *int     `json:"max_streams,omitempty"`
+	MaxTranscodes              *int     `json:"max_transcodes,omitempty"`
+	MaxProfiles                *int     `json:"max_profiles,omitempty"`
+	DirectDownloadsAllowed     *bool    `json:"direct_downloads_allowed,omitempty"`
+	TranscodedDownloadsAllowed *bool    `json:"transcoded_downloads_allowed,omitempty"`
+}
+
 type ACLCondition struct {
 	LibraryIDs                 []int    `json:"library_ids"`
 	MediaTypes                 []string `json:"media_types"`

--- a/internal/auth/acl_types.go
+++ b/internal/auth/acl_types.go
@@ -36,15 +36,15 @@ type ACLRule struct {
 }
 
 type ACLCondition struct {
-	LibraryIDs                 []int
-	MediaTypes                 []string
-	PrimaryProfileRequired     *bool
-	MaxPlaybackQuality         string
-	MaxStreams                 *int
-	MaxTranscodes              *int
-	DirectDownloadsAllowed     *bool
-	TranscodedDownloadsAllowed *bool
-	MaxContentRating           string
+	LibraryIDs                 []int    `json:"library_ids"`
+	MediaTypes                 []string `json:"media_types"`
+	PrimaryProfileRequired     *bool    `json:"primary_profile_required"`
+	MaxPlaybackQuality         string   `json:"max_playback_quality"`
+	MaxStreams                 *int     `json:"max_streams"`
+	MaxTranscodes              *int     `json:"max_transcodes"`
+	DirectDownloadsAllowed     *bool    `json:"direct_downloads_allowed"`
+	TranscodedDownloadsAllowed *bool    `json:"transcoded_downloads_allowed"`
+	MaxContentRating           string   `json:"max_content_rating"`
 }
 
 type AccessDecision struct {
@@ -67,6 +67,7 @@ type EffectivePolicy struct {
 	MaxPlaybackQuality         string
 	MaxStreams                 int
 	MaxTranscodes              int
+	MaxProfiles                int
 	DirectDownloadsAllowed     bool
 	TranscodedDownloadsAllowed bool
 	MaxContentRating           string

--- a/internal/auth/acl_types.go
+++ b/internal/auth/acl_types.go
@@ -1,0 +1,67 @@
+package auth
+
+import "time"
+
+type AccessRequest struct {
+	UserID         int
+	Action         ACLAction
+	ResourceType   ACLResourceType
+	ResourceID     string
+	LibraryIDs     []int
+	MediaType      string
+	ProfileID      string
+	PrimaryProfile bool
+}
+
+type ACLRule struct {
+	ID           int64
+	SubjectType  ACLSubjectType
+	SubjectID    string
+	Action       ACLAction
+	ResourceType ACLResourceType
+	ResourceID   string
+	Effect       ACLEffect
+	Conditions   ACLCondition
+	Priority     int
+	Name         string
+	Description  string
+	CreatedAt    time.Time
+	UpdatedAt    time.Time
+}
+
+type ACLCondition struct {
+	LibraryIDs                 []int
+	MediaTypes                 []string
+	PrimaryProfileRequired     *bool
+	MaxPlaybackQuality         string
+	MaxStreams                 *int
+	MaxTranscodes              *int
+	DirectDownloadsAllowed     *bool
+	TranscodedDownloadsAllowed *bool
+	MaxContentRating           string
+}
+
+type AccessDecision struct {
+	Allowed         bool
+	ReasonCode      string
+	WinningRule     *ACLRule
+	MatchedRules    []ACLRule
+	EffectivePolicy EffectivePolicy
+}
+
+type AccessExplanation struct {
+	Request        AccessRequest
+	Decision       AccessDecision
+	EvaluatedRules []ACLRule
+}
+
+type EffectivePolicy struct {
+	LibraryIDs                 []int
+	MediaTypes                 []string
+	MaxPlaybackQuality         string
+	MaxStreams                 int
+	MaxTranscodes              int
+	DirectDownloadsAllowed     bool
+	TranscodedDownloadsAllowed bool
+	MaxContentRating           string
+}

--- a/internal/auth/acl_types.go
+++ b/internal/auth/acl_types.go
@@ -3,14 +3,20 @@ package auth
 import "time"
 
 type AccessRequest struct {
-	UserID         int
-	Action         ACLAction
-	ResourceType   ACLResourceType
-	ResourceID     string
-	LibraryIDs     []int
-	MediaType      string
-	ProfileID      string
-	PrimaryProfile bool
+	UserID                      int
+	Action                      ACLAction
+	ResourceType                ACLResourceType
+	ResourceID                  string
+	LibraryIDs                  []int
+	MediaType                   string
+	ProfileID                   string
+	PrimaryProfile              bool
+	PlaybackQuality             string
+	CurrentStreams              int
+	CurrentTranscodes           int
+	ContentRating               string
+	DirectDownloadRequested     bool
+	TranscodedDownloadRequested bool
 }
 
 type ACLRule struct {

--- a/internal/auth/jwt_test.go
+++ b/internal/auth/jwt_test.go
@@ -181,8 +181,18 @@ func TestJWT_TamperedToken(t *testing.T) {
 		t.Fatalf("GenerateAccessToken() error: %v", err)
 	}
 
-	// Tamper with the token by modifying the last character of the signature.
-	tampered := token[:len(token)-1] + "X"
+	// Tamper with the token by modifying the first character of the payload.
+	// Avoid changing trailing base64url bits, which may decode to the same bytes.
+	parts := strings.Split(token, ".")
+	if len(parts) != 3 {
+		t.Fatalf("expected 3 JWT parts, got %d", len(parts))
+	}
+	replacement := "A"
+	if strings.HasPrefix(parts[1], replacement) {
+		replacement = "B"
+	}
+	parts[1] = replacement + parts[1][1:]
+	tampered := strings.Join(parts, ".")
 
 	_, err = svc.ValidateToken(tampered)
 	if err == nil {

--- a/internal/auth/permissions.go
+++ b/internal/auth/permissions.go
@@ -61,7 +61,7 @@ func NormalizePermissions(values []string) ([]string, error) {
 }
 
 func DefaultUserPermissions() []string {
-	return []string{string(PermissionMarkerEdit)}
+	return []string{}
 }
 
 func HasAssignedPermission(user *models.User, permission Permission) bool {

--- a/internal/auth/permissions_test.go
+++ b/internal/auth/permissions_test.go
@@ -50,9 +50,9 @@ func TestHasEffectivePermission_UserRequiresAssignedPermission(t *testing.T) {
 	}
 }
 
-func TestDefaultUserPermissionsIncludesMarkerEditOnly(t *testing.T) {
+func TestDefaultUserPermissionsGrantNoSpecialAccess(t *testing.T) {
 	got := DefaultUserPermissions()
-	want := []string{"marker_edit"}
+	want := []string{}
 	if !reflect.DeepEqual(got, want) {
 		t.Fatalf("default permissions = %#v, want %#v", got, want)
 	}

--- a/internal/auth/repository.go
+++ b/internal/auth/repository.go
@@ -47,6 +47,13 @@ func NewUserRepository(pool *pgxpool.Pool) *UserRepository {
 	return &UserRepository{pool: pool}
 }
 
+func (r *UserRepository) ReplaceUserGroups(ctx context.Context, userID int, groupSlugs []string) error {
+	if r == nil || r.pool == nil {
+		return fmt.Errorf("user repository is not configured")
+	}
+	return NewACLRepository(r.pool).ReplaceUserGroups(ctx, userID, groupSlugs)
+}
+
 // allColumns is the list of columns returned by all SELECT queries.
 // Kept in one place so scanUser stays in sync.
 const allColumns = `id, email, username, password_hash, local_password_login_enabled, role, permissions, enabled,

--- a/internal/jellycompat/web_component.go
+++ b/internal/jellycompat/web_component.go
@@ -1053,10 +1053,10 @@ func isRecoverableWebOperation(op *WebComponentOperationStatus) bool {
 			return op.Process != token
 		}
 	}
-	if webOperationLockAge(op) >= webOperationStaleAge {
-		return true
+	if processIsRunning(op.PID) {
+		return false
 	}
-	return !processIsRunning(op.PID)
+	return true
 }
 
 func webOperationLockAge(op *WebComponentOperationStatus) time.Duration {
@@ -1114,19 +1114,22 @@ func processToken(pid int) string {
 		return ""
 	}
 	data, err := os.ReadFile(filepath.Join("/proc", strconv.Itoa(pid), "stat"))
+	if err == nil {
+		stat := string(data)
+		commEnd := strings.LastIndex(stat, ") ")
+		if commEnd != -1 && commEnd+2 < len(stat) {
+			fields := strings.Fields(stat[commEnd+2:])
+			if len(fields) >= 20 {
+				return fields[19]
+			}
+		}
+	}
+
+	output, err := exec.Command("ps", "-o", "lstart=", "-p", strconv.Itoa(pid)).Output()
 	if err != nil {
 		return ""
 	}
-	stat := string(data)
-	commEnd := strings.LastIndex(stat, ") ")
-	if commEnd == -1 || commEnd+2 >= len(stat) {
-		return ""
-	}
-	fields := strings.Fields(stat[commEnd+2:])
-	if len(fields) < 20 {
-		return ""
-	}
-	return fields[19]
+	return strings.Join(strings.Fields(string(output)), " ")
 }
 
 func finishWebOperation(root, id string, err error) *WebComponentOperationStatus {

--- a/internal/playback/gpudetect_test.go
+++ b/internal/playback/gpudetect_test.go
@@ -223,7 +223,7 @@ func setupHWAccelTest(t *testing.T) *hwAccelTestEnv {
 	defaultNVIDIADeviceGlob = filepath.Join(env.devDir, "nvidia[0-9]*")
 	sysClassDRMDir = env.sysDir
 	currentGOOS = "linux"
-	nvencProbeCommandTimeout = 200 * time.Millisecond
+	nvencProbeCommandTimeout = 3 * time.Second
 
 	if err := os.MkdirAll(env.driDir, 0o755); err != nil {
 		t.Fatalf("create test dri dir: %v", err)

--- a/internal/server/frontend.go
+++ b/internal/server/frontend.go
@@ -106,6 +106,7 @@ func FrontendHandler() http.Handler {
 		if Branding != nil {
 			indexBytes = branding.RenderIndexHTML(indexBytes, Branding.Load(r.Context()))
 		}
+		w.Header().Set("Cache-Control", "no-cache")
 		w.Header().Set("Content-Type", "text/html; charset=utf-8")
 		w.Header().Set("Content-Security-Policy", frontendContentSecurityPolicy)
 		w.WriteHeader(http.StatusOK)

--- a/internal/server/frontend_test.go
+++ b/internal/server/frontend_test.go
@@ -31,6 +31,9 @@ func TestFrontendHandlerSetsSecurityHeadersOnSPAHTML(t *testing.T) {
 			if got := rr.Header().Get("Content-Type"); got != "text/html; charset=utf-8" {
 				t.Fatalf("content-type = %q", got)
 			}
+			if got := rr.Header().Get("Cache-Control"); got != "no-cache" {
+				t.Fatalf("cache-control = %q", got)
+			}
 			csp := rr.Header().Get("Content-Security-Policy")
 			if csp != frontendContentSecurityPolicy {
 				t.Fatalf("csp = %q", csp)

--- a/migrations/acl_foundation_test.go
+++ b/migrations/acl_foundation_test.go
@@ -93,13 +93,23 @@ func TestACLFoundationSeedsDefaultUserFacingGrants(t *testing.T) {
 		"('standard_user', 'personal_lists.manage', 'media_item', 'User personal lists')",
 		"('standard_user', 'requests.create', 'request', 'User request creation')",
 		"('restricted_user', 'playback.play', 'media_item', 'Restricted user playback')",
-		"grant_subjects(subject_type) AS",
-		"('group'),",
-		"existing.subject_type = grant_subjects.subject_type",
+		"'group',",
+		"existing.subject_type = 'group'",
 	}
 	for _, snippet := range requiredSnippets {
 		if !strings.Contains(migration, snippet) {
 			t.Fatalf("ACL foundation migration missing default grant snippet:\n%s", snippet)
+		}
+	}
+
+	forbiddenSnippets := []string{
+		"grant_subjects(subject_type) AS",
+		"('builtin_role')",
+		"existing.subject_type = grant_subjects.subject_type",
+	}
+	for _, snippet := range forbiddenSnippets {
+		if strings.Contains(migration, snippet) {
+			t.Fatalf("ACL foundation migration still seeds hidden default grant snippet:\n%s", snippet)
 		}
 	}
 }
@@ -118,14 +128,25 @@ func TestACLRepairMigrationBackfillsMutableGroupSchema(t *testing.T) {
 		"ADD CONSTRAINT acl_groups_policy_object_check CHECK (jsonb_typeof(policy) = 'object')",
 		"('standard_user', 'User', 'Normal media access.', '{}'::jsonb, true, false)",
 		"('restricted_user', 'Restricted User', 'Media access with tighter limits.', '{}'::jsonb, true, false)",
-		"grant_subjects(subject_type) AS",
-		"('group'),",
-		"('builtin_role')",
-		"existing.subject_type = grant_subjects.subject_type",
+		"DELETE FROM public.acl_rules",
+		"subject_type = 'builtin_role'",
+		"'group',",
+		"existing.subject_type = 'group'",
 	}
 	for _, snippet := range requiredSnippets {
 		if !strings.Contains(migration, snippet) {
 			t.Fatalf("ACL repair migration missing schema/default snippet:\n%s", snippet)
+		}
+	}
+
+	forbiddenSnippets := []string{
+		"grant_subjects(subject_type) AS",
+		"('builtin_role')",
+		"existing.subject_type = grant_subjects.subject_type",
+	}
+	for _, snippet := range forbiddenSnippets {
+		if strings.Contains(migration, snippet) {
+			t.Fatalf("ACL repair migration still seeds hidden default grant snippet:\n%s", snippet)
 		}
 	}
 }

--- a/migrations/acl_foundation_test.go
+++ b/migrations/acl_foundation_test.go
@@ -1,0 +1,131 @@
+package migrations
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestACLFoundationResetsHistoricalMarkerEditDefault(t *testing.T) {
+	migrationBytes, err := FS.ReadFile("sql/20260629193000_acl_foundation.sql")
+	if err != nil {
+		t.Fatalf("read ACL foundation migration: %v", err)
+	}
+	migration := string(migrationBytes)
+
+	requiredSnippets := []string{
+		"ALTER TABLE public.users\n    ALTER COLUMN permissions SET DEFAULT '{}'::text[];",
+		"UPDATE public.users\nSET permissions = array_remove(permissions, 'marker_edit'),\n    access_policy_revision = access_policy_revision + 1,\n    updated_at = now()\nWHERE COALESCE(role, 'user') <> 'admin'\n  AND 'marker_edit' = ANY (permissions);",
+	}
+	for _, snippet := range requiredSnippets {
+		if !strings.Contains(migration, snippet) {
+			t.Fatalf("ACL foundation migration missing marker_edit cleanup snippet:\n%s", snippet)
+		}
+	}
+
+	cleanupIdx := strings.Index(migration, "UPDATE public.users\nSET permissions = array_remove(permissions, 'marker_edit')")
+	userBackfillIdx := strings.Index(migration, "WITH standard_user_group AS")
+	if cleanupIdx < 0 || userBackfillIdx < 0 {
+		t.Fatalf("failed to locate cleanup/user backfill blocks")
+	}
+	if cleanupIdx > userBackfillIdx {
+		t.Fatalf("marker_edit cleanup must run before user ACL backfill")
+	}
+}
+
+func TestACLFoundationSeedsUserGroupsWithClearLabels(t *testing.T) {
+	migrationBytes, err := FS.ReadFile("sql/20260629193000_acl_foundation.sql")
+	if err != nil {
+		t.Fatalf("read ACL foundation migration: %v", err)
+	}
+	migration := string(migrationBytes)
+
+	requiredSnippets := []string{
+		"('standard_user', 'User', 'Normal media access.', true, false)",
+		"('restricted_user', 'Restricted User', 'Media access with tighter limits.', true, false)",
+		"SELECT id FROM public.acl_groups WHERE slug = 'standard_user'",
+	}
+	for _, snippet := range requiredSnippets {
+		if !strings.Contains(migration, snippet) {
+			t.Fatalf("ACL foundation migration missing user group naming snippet:\n%s", snippet)
+		}
+	}
+
+	forbiddenSnippets := []string{
+		"('viewer', 'Viewer'",
+		"('restricted_viewer', 'Restricted Viewer'",
+		"WHERE slug = 'viewer'",
+	}
+	for _, snippet := range forbiddenSnippets {
+		if strings.Contains(migration, snippet) {
+			t.Fatalf("ACL foundation migration still contains old viewer naming snippet:\n%s", snippet)
+		}
+	}
+}
+
+func TestACLFoundationAddsGroupPolicyObject(t *testing.T) {
+	migrationBytes, err := FS.ReadFile("sql/20260629193000_acl_foundation.sql")
+	if err != nil {
+		t.Fatalf("read ACL foundation migration: %v", err)
+	}
+	migration := string(migrationBytes)
+
+	requiredSnippets := []string{
+		"policy jsonb NOT NULL DEFAULT '{}'::jsonb",
+		"CONSTRAINT acl_groups_policy_object_check CHECK (jsonb_typeof(policy) = 'object')",
+	}
+	for _, snippet := range requiredSnippets {
+		if !strings.Contains(migration, snippet) {
+			t.Fatalf("ACL foundation migration missing group policy snippet:\n%s", snippet)
+		}
+	}
+}
+
+func TestACLFoundationSeedsDefaultUserFacingGrants(t *testing.T) {
+	migrationBytes, err := FS.ReadFile("sql/20260629193000_acl_foundation.sql")
+	if err != nil {
+		t.Fatalf("read ACL foundation migration: %v", err)
+	}
+	migration := string(migrationBytes)
+
+	requiredSnippets := []string{
+		"WITH built_in_user_grants(subject_id, action, resource_type, name) AS",
+		"('standard_user', 'playback.play', 'media_item', 'User playback')",
+		"('standard_user', 'personal_lists.manage', 'media_item', 'User personal lists')",
+		"('standard_user', 'requests.create', 'request', 'User request creation')",
+		"('restricted_user', 'playback.play', 'media_item', 'Restricted user playback')",
+		"grant_subjects(subject_type) AS",
+		"('group'),",
+		"existing.subject_type = grant_subjects.subject_type",
+	}
+	for _, snippet := range requiredSnippets {
+		if !strings.Contains(migration, snippet) {
+			t.Fatalf("ACL foundation migration missing default grant snippet:\n%s", snippet)
+		}
+	}
+}
+
+func TestACLRepairMigrationBackfillsMutableGroupSchema(t *testing.T) {
+	migrationBytes, err := FS.ReadFile("sql/20260630124500_repair_acl_builtin_defaults.sql")
+	if err != nil {
+		t.Fatalf("read ACL repair migration: %v", err)
+	}
+	migration := string(migrationBytes)
+
+	requiredSnippets := []string{
+		"ALTER TABLE public.acl_groups\n    ADD COLUMN IF NOT EXISTS policy jsonb;",
+		"ALTER TABLE public.acl_groups\n    ALTER COLUMN policy SET DEFAULT '{}'::jsonb;",
+		"ALTER TABLE public.acl_groups\n    ALTER COLUMN policy SET NOT NULL;",
+		"ADD CONSTRAINT acl_groups_policy_object_check CHECK (jsonb_typeof(policy) = 'object')",
+		"('standard_user', 'User', 'Normal media access.', '{}'::jsonb, true, false)",
+		"('restricted_user', 'Restricted User', 'Media access with tighter limits.', '{}'::jsonb, true, false)",
+		"grant_subjects(subject_type) AS",
+		"('group'),",
+		"('builtin_role')",
+		"existing.subject_type = grant_subjects.subject_type",
+	}
+	for _, snippet := range requiredSnippets {
+		if !strings.Contains(migration, snippet) {
+			t.Fatalf("ACL repair migration missing schema/default snippet:\n%s", snippet)
+		}
+	}
+}

--- a/migrations/sql/20260629193000_acl_foundation.sql
+++ b/migrations/sql/20260629193000_acl_foundation.sql
@@ -33,7 +33,8 @@ CREATE TABLE IF NOT EXISTS public.acl_rules (
     created_at timestamptz NOT NULL DEFAULT now(),
     updated_at timestamptz NOT NULL DEFAULT now(),
     CONSTRAINT acl_rules_effect_check CHECK (effect IN ('allow', 'deny')),
-    CONSTRAINT acl_rules_subject_type_check CHECK (subject_type IN ('user', 'group', 'builtin_role', 'everyone'))
+    CONSTRAINT acl_rules_subject_type_check CHECK (subject_type IN ('user', 'group', 'builtin_role', 'everyone')),
+    CONSTRAINT acl_rules_conditions_object_check CHECK (jsonb_typeof(conditions) = 'object')
 );
 
 CREATE INDEX IF NOT EXISTS acl_group_members_user_idx ON public.acl_group_members(user_id);

--- a/migrations/sql/20260629193000_acl_foundation.sql
+++ b/migrations/sql/20260629193000_acl_foundation.sql
@@ -5,10 +5,12 @@ CREATE TABLE IF NOT EXISTS public.acl_groups (
     slug text NOT NULL UNIQUE,
     name text NOT NULL,
     description text NOT NULL DEFAULT '',
+    policy jsonb NOT NULL DEFAULT '{}'::jsonb,
     built_in boolean NOT NULL DEFAULT false,
     protected boolean NOT NULL DEFAULT false,
     created_at timestamptz NOT NULL DEFAULT now(),
-    updated_at timestamptz NOT NULL DEFAULT now()
+    updated_at timestamptz NOT NULL DEFAULT now(),
+    CONSTRAINT acl_groups_policy_object_check CHECK (jsonb_typeof(policy) = 'object')
 );
 
 CREATE TABLE IF NOT EXISTS public.acl_group_members (
@@ -52,20 +54,83 @@ INSERT INTO public.acl_policy_revisions (id, revision)
 VALUES (true, 1)
 ON CONFLICT (id) DO NOTHING;
 
+ALTER TABLE public.users
+    ALTER COLUMN permissions SET DEFAULT '{}'::text[];
+
+UPDATE public.users
+SET permissions = array_remove(permissions, 'marker_edit'),
+    access_policy_revision = access_policy_revision + 1,
+    updated_at = now()
+WHERE COALESCE(role, 'user') <> 'admin'
+  AND 'marker_edit' = ANY (permissions);
+
 INSERT INTO public.acl_groups (slug, name, description, built_in, protected)
 VALUES
     ('owner', 'Owner', 'Full server ownership and security control.', true, true),
     ('admin', 'Admin', 'Broad operational administration.', true, true),
     ('library_manager', 'Library Manager', 'Library and scan management.', true, false),
     ('metadata_curator', 'Metadata Curator', 'Metadata, poster, marker, and provider curation.', true, false),
-    ('viewer', 'Viewer', 'Normal media playback access.', true, false),
-    ('restricted_viewer', 'Restricted Viewer', 'Playback access with tighter limits.', true, false)
+    ('standard_user', 'User', 'Normal media access.', true, false),
+    ('restricted_user', 'Restricted User', 'Media access with tighter limits.', true, false)
 ON CONFLICT (slug) DO UPDATE
 SET name = EXCLUDED.name,
     description = EXCLUDED.description,
     built_in = EXCLUDED.built_in,
     protected = EXCLUDED.protected,
     updated_at = now();
+
+WITH built_in_user_grants(subject_id, action, resource_type, name) AS (
+    VALUES
+        ('owner', 'playback.play', 'media_item', 'Owner playback'),
+        ('owner', 'playback.transcode', 'media_item', 'Owner transcoding'),
+        ('owner', 'profiles.manage', 'profile', 'Owner profile management'),
+        ('owner', 'personal_lists.manage', 'media_item', 'Owner personal lists'),
+        ('owner', 'requests.create', 'request', 'Owner request creation'),
+        ('admin', 'playback.play', 'media_item', 'Admin playback'),
+        ('admin', 'playback.transcode', 'media_item', 'Admin transcoding'),
+        ('admin', 'profiles.manage', 'profile', 'Admin profile management'),
+        ('admin', 'personal_lists.manage', 'media_item', 'Admin personal lists'),
+        ('admin', 'requests.create', 'request', 'Admin request creation'),
+        ('standard_user', 'playback.play', 'media_item', 'User playback'),
+        ('standard_user', 'playback.transcode', 'media_item', 'User transcoding'),
+        ('standard_user', 'profiles.manage', 'profile', 'User profile management'),
+        ('standard_user', 'personal_lists.manage', 'media_item', 'User personal lists'),
+        ('standard_user', 'requests.create', 'request', 'User request creation'),
+        ('restricted_user', 'playback.play', 'media_item', 'Restricted user playback'),
+        ('restricted_user', 'playback.transcode', 'media_item', 'Restricted user transcoding'),
+        ('restricted_user', 'profiles.manage', 'profile', 'Restricted user profile management'),
+        ('restricted_user', 'personal_lists.manage', 'media_item', 'Restricted user personal lists'),
+        ('restricted_user', 'requests.create', 'request', 'Restricted user request creation')
+),
+grant_subjects(subject_type) AS (
+    VALUES
+        ('group'),
+        ('builtin_role')
+)
+INSERT INTO public.acl_rules (
+    subject_type, subject_id, action, resource_type, resource_id, effect, conditions, priority, name
+)
+SELECT
+    grant_subjects.subject_type,
+    grant_row.subject_id,
+    grant_row.action,
+    grant_row.resource_type,
+    '*',
+    'allow',
+    '{}'::jsonb,
+    10,
+    grant_row.name
+FROM built_in_user_grants AS grant_row
+CROSS JOIN grant_subjects
+WHERE NOT EXISTS (
+    SELECT 1
+    FROM public.acl_rules existing
+    WHERE existing.subject_type = grant_subjects.subject_type
+      AND existing.subject_id = grant_row.subject_id
+      AND existing.action = grant_row.action
+      AND existing.resource_type = grant_row.resource_type
+      AND existing.resource_id = '*'
+);
 
 WITH oldest_admin AS (
     SELECT id
@@ -100,12 +165,12 @@ WHERE users.enabled = true
   AND users.id NOT IN (SELECT id FROM oldest_admin)
 ON CONFLICT DO NOTHING;
 
-WITH viewer_group AS (
-    SELECT id FROM public.acl_groups WHERE slug = 'viewer'
+WITH standard_user_group AS (
+    SELECT id FROM public.acl_groups WHERE slug = 'standard_user'
 )
 INSERT INTO public.acl_group_members (group_id, user_id)
-SELECT viewer_group.id, users.id
-FROM public.users, viewer_group
+SELECT standard_user_group.id, users.id
+FROM public.users, standard_user_group
 WHERE users.enabled = true
   AND COALESCE(users.role, 'user') <> 'admin'
 ON CONFLICT DO NOTHING;

--- a/migrations/sql/20260629193000_acl_foundation.sql
+++ b/migrations/sql/20260629193000_acl_foundation.sql
@@ -101,17 +101,12 @@ WITH built_in_user_grants(subject_id, action, resource_type, name) AS (
         ('restricted_user', 'profiles.manage', 'profile', 'Restricted user profile management'),
         ('restricted_user', 'personal_lists.manage', 'media_item', 'Restricted user personal lists'),
         ('restricted_user', 'requests.create', 'request', 'Restricted user request creation')
-),
-grant_subjects(subject_type) AS (
-    VALUES
-        ('group'),
-        ('builtin_role')
 )
 INSERT INTO public.acl_rules (
     subject_type, subject_id, action, resource_type, resource_id, effect, conditions, priority, name
 )
 SELECT
-    grant_subjects.subject_type,
+    'group',
     grant_row.subject_id,
     grant_row.action,
     grant_row.resource_type,
@@ -121,11 +116,10 @@ SELECT
     10,
     grant_row.name
 FROM built_in_user_grants AS grant_row
-CROSS JOIN grant_subjects
 WHERE NOT EXISTS (
     SELECT 1
     FROM public.acl_rules existing
-    WHERE existing.subject_type = grant_subjects.subject_type
+    WHERE existing.subject_type = 'group'
       AND existing.subject_id = grant_row.subject_id
       AND existing.action = grant_row.action
       AND existing.resource_type = grant_row.resource_type

--- a/migrations/sql/20260629193000_acl_foundation.sql
+++ b/migrations/sql/20260629193000_acl_foundation.sql
@@ -1,0 +1,119 @@
+-- +goose Up
+-- +goose StatementBegin
+CREATE TABLE IF NOT EXISTS public.acl_groups (
+    id bigserial PRIMARY KEY,
+    slug text NOT NULL UNIQUE,
+    name text NOT NULL,
+    description text NOT NULL DEFAULT '',
+    built_in boolean NOT NULL DEFAULT false,
+    protected boolean NOT NULL DEFAULT false,
+    created_at timestamptz NOT NULL DEFAULT now(),
+    updated_at timestamptz NOT NULL DEFAULT now()
+);
+
+CREATE TABLE IF NOT EXISTS public.acl_group_members (
+    group_id bigint NOT NULL REFERENCES public.acl_groups(id) ON DELETE CASCADE,
+    user_id integer NOT NULL REFERENCES public.users(id) ON DELETE CASCADE,
+    created_at timestamptz NOT NULL DEFAULT now(),
+    PRIMARY KEY (group_id, user_id)
+);
+
+CREATE TABLE IF NOT EXISTS public.acl_rules (
+    id bigserial PRIMARY KEY,
+    subject_type text NOT NULL,
+    subject_id text NOT NULL,
+    action text NOT NULL,
+    resource_type text NOT NULL,
+    resource_id text NOT NULL DEFAULT '*',
+    effect text NOT NULL,
+    conditions jsonb NOT NULL DEFAULT '{}'::jsonb,
+    priority integer NOT NULL DEFAULT 0,
+    name text NOT NULL DEFAULT '',
+    description text NOT NULL DEFAULT '',
+    created_at timestamptz NOT NULL DEFAULT now(),
+    updated_at timestamptz NOT NULL DEFAULT now(),
+    CONSTRAINT acl_rules_effect_check CHECK (effect IN ('allow', 'deny')),
+    CONSTRAINT acl_rules_subject_type_check CHECK (subject_type IN ('user', 'group', 'builtin_role', 'everyone'))
+);
+
+CREATE INDEX IF NOT EXISTS acl_group_members_user_idx ON public.acl_group_members(user_id);
+CREATE INDEX IF NOT EXISTS acl_rules_subject_idx ON public.acl_rules(subject_type, subject_id);
+CREATE INDEX IF NOT EXISTS acl_rules_action_resource_idx ON public.acl_rules(action, resource_type, resource_id);
+
+CREATE TABLE IF NOT EXISTS public.acl_policy_revisions (
+    id boolean PRIMARY KEY DEFAULT true,
+    revision bigint NOT NULL DEFAULT 1,
+    updated_at timestamptz NOT NULL DEFAULT now(),
+    CONSTRAINT acl_policy_revisions_singleton CHECK (id)
+);
+
+INSERT INTO public.acl_policy_revisions (id, revision)
+VALUES (true, 1)
+ON CONFLICT (id) DO NOTHING;
+
+INSERT INTO public.acl_groups (slug, name, description, built_in, protected)
+VALUES
+    ('owner', 'Owner', 'Full server ownership and security control.', true, true),
+    ('admin', 'Admin', 'Broad operational administration.', true, true),
+    ('library_manager', 'Library Manager', 'Library and scan management.', true, false),
+    ('metadata_curator', 'Metadata Curator', 'Metadata, poster, marker, and provider curation.', true, false),
+    ('viewer', 'Viewer', 'Normal media playback access.', true, false),
+    ('restricted_viewer', 'Restricted Viewer', 'Playback access with tighter limits.', true, false)
+ON CONFLICT (slug) DO UPDATE
+SET name = EXCLUDED.name,
+    description = EXCLUDED.description,
+    built_in = EXCLUDED.built_in,
+    protected = EXCLUDED.protected,
+    updated_at = now();
+
+WITH oldest_admin AS (
+    SELECT id
+    FROM public.users
+    WHERE enabled = true AND role = 'admin'
+    ORDER BY created_at ASC, id ASC
+    LIMIT 1
+),
+owner_group AS (
+    SELECT id FROM public.acl_groups WHERE slug = 'owner'
+)
+INSERT INTO public.acl_group_members (group_id, user_id)
+SELECT owner_group.id, oldest_admin.id
+FROM owner_group, oldest_admin
+ON CONFLICT DO NOTHING;
+
+WITH oldest_admin AS (
+    SELECT id
+    FROM public.users
+    WHERE enabled = true AND role = 'admin'
+    ORDER BY created_at ASC, id ASC
+    LIMIT 1
+),
+admin_group AS (
+    SELECT id FROM public.acl_groups WHERE slug = 'admin'
+)
+INSERT INTO public.acl_group_members (group_id, user_id)
+SELECT admin_group.id, users.id
+FROM public.users, admin_group
+WHERE users.enabled = true
+  AND users.role = 'admin'
+  AND users.id NOT IN (SELECT id FROM oldest_admin)
+ON CONFLICT DO NOTHING;
+
+WITH viewer_group AS (
+    SELECT id FROM public.acl_groups WHERE slug = 'viewer'
+)
+INSERT INTO public.acl_group_members (group_id, user_id)
+SELECT viewer_group.id, users.id
+FROM public.users, viewer_group
+WHERE users.enabled = true
+  AND COALESCE(users.role, 'user') <> 'admin'
+ON CONFLICT DO NOTHING;
+-- +goose StatementEnd
+
+-- +goose Down
+-- +goose StatementBegin
+DROP TABLE IF EXISTS public.acl_policy_revisions;
+DROP TABLE IF EXISTS public.acl_rules;
+DROP TABLE IF EXISTS public.acl_group_members;
+DROP TABLE IF EXISTS public.acl_groups;
+-- +goose StatementEnd

--- a/migrations/sql/20260630124500_repair_acl_builtin_defaults.sql
+++ b/migrations/sql/20260630124500_repair_acl_builtin_defaults.sql
@@ -74,16 +74,21 @@ WITH built_in_user_grants(subject_id, action, resource_type, name) AS (
         ('restricted_user', 'personal_lists.manage', 'media_item', 'Restricted user personal lists'),
         ('restricted_user', 'requests.create', 'request', 'Restricted user request creation')
 ),
-grant_subjects(subject_type) AS (
-    VALUES
-        ('group'),
-        ('builtin_role')
+deleted_hidden_default_grants AS (
+    DELETE FROM public.acl_rules AS hidden
+    USING built_in_user_grants AS grant_row
+    WHERE hidden.subject_type = 'builtin_role'
+      AND hidden.subject_id = grant_row.subject_id
+      AND hidden.action = grant_row.action
+      AND hidden.resource_type = grant_row.resource_type
+      AND hidden.resource_id = '*'
+    RETURNING hidden.id
 )
 INSERT INTO public.acl_rules (
     subject_type, subject_id, action, resource_type, resource_id, effect, conditions, priority, name
 )
 SELECT
-    grant_subjects.subject_type,
+    'group',
     grant_row.subject_id,
     grant_row.action,
     grant_row.resource_type,
@@ -93,11 +98,10 @@ SELECT
     10,
     grant_row.name
 FROM built_in_user_grants AS grant_row
-CROSS JOIN grant_subjects
 WHERE NOT EXISTS (
     SELECT 1
     FROM public.acl_rules existing
-    WHERE existing.subject_type = grant_subjects.subject_type
+    WHERE existing.subject_type = 'group'
       AND existing.subject_id = grant_row.subject_id
       AND existing.action = grant_row.action
       AND existing.resource_type = grant_row.resource_type

--- a/migrations/sql/20260630124500_repair_acl_builtin_defaults.sql
+++ b/migrations/sql/20260630124500_repair_acl_builtin_defaults.sql
@@ -1,0 +1,161 @@
+-- +goose Up
+-- +goose StatementBegin
+ALTER TABLE public.acl_groups
+    ADD COLUMN IF NOT EXISTS policy jsonb;
+
+UPDATE public.acl_groups
+SET policy = '{}'::jsonb,
+    updated_at = now()
+WHERE policy IS NULL
+   OR jsonb_typeof(policy) <> 'object';
+
+ALTER TABLE public.acl_groups
+    ALTER COLUMN policy SET DEFAULT '{}'::jsonb;
+
+ALTER TABLE public.acl_groups
+    ALTER COLUMN policy SET NOT NULL;
+
+DO $$
+BEGIN
+    IF NOT EXISTS (
+        SELECT 1
+        FROM pg_constraint
+        WHERE conrelid = 'public.acl_groups'::regclass
+          AND conname = 'acl_groups_policy_object_check'
+    ) THEN
+        ALTER TABLE public.acl_groups
+            ADD CONSTRAINT acl_groups_policy_object_check CHECK (jsonb_typeof(policy) = 'object');
+    END IF;
+END $$;
+
+INSERT INTO public.acl_policy_revisions (id, revision)
+VALUES (true, 1)
+ON CONFLICT (id) DO NOTHING;
+
+INSERT INTO public.acl_groups (slug, name, description, policy, built_in, protected)
+VALUES
+    ('owner', 'Owner', 'Full server ownership and security control.', '{}'::jsonb, true, true),
+    ('admin', 'Admin', 'Broad operational administration.', '{}'::jsonb, true, true),
+    ('library_manager', 'Library Manager', 'Library and scan management.', '{}'::jsonb, true, false),
+    ('metadata_curator', 'Metadata Curator', 'Metadata, poster, marker, and provider curation.', '{}'::jsonb, true, false),
+    ('standard_user', 'User', 'Normal media access.', '{}'::jsonb, true, false),
+    ('restricted_user', 'Restricted User', 'Media access with tighter limits.', '{}'::jsonb, true, false)
+ON CONFLICT (slug) DO UPDATE
+SET name = EXCLUDED.name,
+    description = EXCLUDED.description,
+    policy = CASE
+        WHEN jsonb_typeof(public.acl_groups.policy) = 'object' THEN public.acl_groups.policy
+        ELSE '{}'::jsonb
+    END,
+    built_in = EXCLUDED.built_in,
+    protected = EXCLUDED.protected,
+    updated_at = now();
+
+WITH built_in_user_grants(subject_id, action, resource_type, name) AS (
+    VALUES
+        ('owner', 'playback.play', 'media_item', 'Owner playback'),
+        ('owner', 'playback.transcode', 'media_item', 'Owner transcoding'),
+        ('owner', 'profiles.manage', 'profile', 'Owner profile management'),
+        ('owner', 'personal_lists.manage', 'media_item', 'Owner personal lists'),
+        ('owner', 'requests.create', 'request', 'Owner request creation'),
+        ('admin', 'playback.play', 'media_item', 'Admin playback'),
+        ('admin', 'playback.transcode', 'media_item', 'Admin transcoding'),
+        ('admin', 'profiles.manage', 'profile', 'Admin profile management'),
+        ('admin', 'personal_lists.manage', 'media_item', 'Admin personal lists'),
+        ('admin', 'requests.create', 'request', 'Admin request creation'),
+        ('standard_user', 'playback.play', 'media_item', 'User playback'),
+        ('standard_user', 'playback.transcode', 'media_item', 'User transcoding'),
+        ('standard_user', 'profiles.manage', 'profile', 'User profile management'),
+        ('standard_user', 'personal_lists.manage', 'media_item', 'User personal lists'),
+        ('standard_user', 'requests.create', 'request', 'User request creation'),
+        ('restricted_user', 'playback.play', 'media_item', 'Restricted user playback'),
+        ('restricted_user', 'playback.transcode', 'media_item', 'Restricted user transcoding'),
+        ('restricted_user', 'profiles.manage', 'profile', 'Restricted user profile management'),
+        ('restricted_user', 'personal_lists.manage', 'media_item', 'Restricted user personal lists'),
+        ('restricted_user', 'requests.create', 'request', 'Restricted user request creation')
+),
+grant_subjects(subject_type) AS (
+    VALUES
+        ('group'),
+        ('builtin_role')
+)
+INSERT INTO public.acl_rules (
+    subject_type, subject_id, action, resource_type, resource_id, effect, conditions, priority, name
+)
+SELECT
+    grant_subjects.subject_type,
+    grant_row.subject_id,
+    grant_row.action,
+    grant_row.resource_type,
+    '*',
+    'allow',
+    '{}'::jsonb,
+    10,
+    grant_row.name
+FROM built_in_user_grants AS grant_row
+CROSS JOIN grant_subjects
+WHERE NOT EXISTS (
+    SELECT 1
+    FROM public.acl_rules existing
+    WHERE existing.subject_type = grant_subjects.subject_type
+      AND existing.subject_id = grant_row.subject_id
+      AND existing.action = grant_row.action
+      AND existing.resource_type = grant_row.resource_type
+      AND existing.resource_id = '*'
+);
+
+WITH oldest_admin AS (
+    SELECT id
+    FROM public.users
+    WHERE enabled = true AND role = 'admin'
+    ORDER BY created_at ASC, id ASC
+    LIMIT 1
+),
+owner_group AS (
+    SELECT id FROM public.acl_groups WHERE slug = 'owner'
+)
+INSERT INTO public.acl_group_members (group_id, user_id)
+SELECT owner_group.id, oldest_admin.id
+FROM owner_group, oldest_admin
+ON CONFLICT DO NOTHING;
+
+WITH oldest_admin AS (
+    SELECT id
+    FROM public.users
+    WHERE enabled = true AND role = 'admin'
+    ORDER BY created_at ASC, id ASC
+    LIMIT 1
+),
+admin_group AS (
+    SELECT id FROM public.acl_groups WHERE slug = 'admin'
+)
+INSERT INTO public.acl_group_members (group_id, user_id)
+SELECT admin_group.id, users.id
+FROM public.users, admin_group
+WHERE users.role = 'admin'
+  AND NOT EXISTS (
+      SELECT 1
+      FROM oldest_admin
+      WHERE oldest_admin.id = users.id
+  )
+ON CONFLICT DO NOTHING;
+
+WITH standard_user_group AS (
+    SELECT id FROM public.acl_groups WHERE slug = 'standard_user'
+)
+INSERT INTO public.acl_group_members (group_id, user_id)
+SELECT standard_user_group.id, users.id
+FROM public.users, standard_user_group
+WHERE COALESCE(users.role, 'user') <> 'admin'
+ON CONFLICT DO NOTHING;
+
+UPDATE public.acl_policy_revisions
+SET revision = revision + 1,
+    updated_at = now()
+WHERE id = true;
+-- +goose StatementEnd
+
+-- +goose Down
+-- +goose StatementBegin
+SELECT 1;
+-- +goose StatementEnd

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -14,6 +14,8 @@ import { queryClient } from "@/lib/query-client";
 import { AuthProvider, useAuth } from "@/hooks/useAuth";
 import { useCurrentProfile } from "@/hooks/useCurrentProfile";
 import { useIsActingAdmin } from "@/hooks/useIsActingAdmin";
+import { useAdminAccess } from "@/hooks/useAdminCapabilities";
+import { USER_CAPABILITY_ACTIONS, useUserCapabilityAccess } from "@/hooks/useUserCapabilities";
 import { ThemeProvider } from "@/hooks/useTheme";
 import { CustomThemeProvider } from "@/contexts/CustomThemeProvider";
 import { BrandingProvider } from "@/contexts/BrandingProvider";
@@ -46,6 +48,7 @@ import RequestDetail from "@/pages/RequestDetail";
 import AdminDashboard from "@/pages/AdminDashboard";
 import AdminActivity from "@/pages/AdminActivity";
 import AdminLogs from "@/pages/AdminLogs";
+import AdminAccessGroups from "@/pages/AdminAccessGroups";
 import AdminUsers from "@/pages/AdminUsers";
 import AdminRequests from "@/pages/AdminRequests";
 import AdminAutoscan from "@/pages/AdminAutoscan";
@@ -107,6 +110,7 @@ import {
   buildUserCollectionCatalogHref,
 } from "@/pages/catalogSearchParams";
 import { buildLegacyWebhookSyncRedirectTarget } from "@/lib/webhookSync";
+import { ADMIN_ROUTE_ACTIONS, firstAllowedAdminPath } from "@/lib/adminCapabilities";
 import { toast } from "sonner";
 
 /** Scrolls to top on pathname change (custom replacement for ScrollRestoration which requires data router). */
@@ -177,8 +181,38 @@ function RequireProfile({ children }: { children: ReactNode }) {
 }
 
 function RequireAdmin({ children }: { children: ReactNode }) {
-  const actingAdmin = useIsActingAdmin();
-  if (!actingAdmin) return <Navigate to="/" replace />;
+  const adminAccess = useAdminAccess();
+  if (adminAccess.isLoading) {
+    return (
+      <div className="p-8" role="status" aria-live="polite">
+        <span className="sr-only">Loading admin access</span>
+        Loading...
+      </div>
+    );
+  }
+  if (!adminAccess.canAccessAdmin) return <Navigate to="/" replace />;
+  return <>{children}</>;
+}
+
+function RequireAdminAction({
+  actions,
+  children,
+}: {
+  actions: readonly string[];
+  children: ReactNode;
+}) {
+  const adminAccess = useAdminAccess();
+  if (adminAccess.isLoading) {
+    return (
+      <div className="p-8" role="status" aria-live="polite">
+        <span className="sr-only">Loading admin access</span>
+        Loading...
+      </div>
+    );
+  }
+  if (!adminAccess.can(actions)) {
+    return <Navigate to={firstAllowedAdminPath(adminAccess.actionSet)} replace />;
+  }
   return <>{children}</>;
 }
 
@@ -214,8 +248,11 @@ function RequireRequestsEnabled({ children }: { children: ReactNode }) {
  */
 function TasteSeedGate({ children }: { children: ReactNode }) {
   const { profile } = useAuth();
+  const userCapabilities = useUserCapabilityAccess();
+  const canManagePersonalLists = userCapabilities.can(USER_CAPABILITY_ACTIONS.personalListsManage);
   const { data: favorites, isPending, isError } = useFavorites();
 
+  if (userCapabilities.isLoading || !canManagePersonalLists) return <>{children}</>;
   if (isPending || isError || !profile) return <>{children}</>;
 
   const hasFavorites = (favorites?.length ?? 0) > 0;
@@ -250,6 +287,7 @@ function QueryCacheManager() {
       qc.removeQueries({ queryKey: ["calendar"] });
       qc.removeQueries({ queryKey: ["requests"] });
       qc.removeQueries({ queryKey: ["notifications"] });
+      qc.removeQueries({ queryKey: ["auth"] });
       // Recommendation rows include per-profile user_state (is_favorite, etc.);
       // the taste-seed picker depends on this for pre-selection.
       qc.removeQueries({ queryKey: ["recommendations"] });
@@ -384,32 +422,222 @@ function AppRoutes() {
                     </RequireAdmin>
                   }
                 >
-                  <Route index element={<AdminDashboard />} />
-                  <Route path="activity" element={<AdminActivity />} />
-                  <Route path="logs" element={<AdminLogs />} />
-                  <Route path="libraries" element={<AdminLibraries />} />
-                  <Route path="maintenance" element={<AdminMaintenance />} />
-                  <Route path="collections" element={<AdminCollections />} />
-                  <Route path="collections/new" element={<AdminCollectionEditor />} />
-                  <Route path="collections/:id/edit" element={<AdminCollectionEditor />} />
-                  <Route path="requests" element={<AdminRequests />} />
-                  <Route path="autoscan" element={<AdminAutoscan />} />
-                  <Route path="history" element={<AdminPlaybackHistory />} />
-                  <Route path="marker-history" element={<AdminMarkerHistory />} />
-                  <Route path="history-import" element={<AdminHistoryImport />} />
-                  <Route path="users" element={<AdminUsers />} />
-                  <Route path="users/:id" element={<AdminUserDetail />} />
-                  <Route path="devices" element={<AdminDevices />} />
-                  <Route path="devices/:userId/:deviceId" element={<AdminDevices />} />
-                  <Route path="nodes" element={<AdminNodes />} />
-                  <Route path="sections" element={<AdminSections />} />
-                  <Route path="plugins" element={<AdminPlugins />} />
-                  <Route path="settings" element={<AdminSettingsLayout />} />
-                  <Route path="recommendations" element={<AdminRecommendations />} />
-                  <Route path="api-keys" element={<AdminApiKeys />} />
-                  <Route path="subtitles" element={<AdminSubtitles />} />
-                  <Route path="tasks" element={<AdminTasks />} />
-                  <Route path="tasks/:key" element={<AdminTaskDetail />} />
+                  <Route
+                    index
+                    element={
+                      <RequireAdminAction actions={ADMIN_ROUTE_ACTIONS.dashboard}>
+                        <AdminDashboard />
+                      </RequireAdminAction>
+                    }
+                  />
+                  <Route
+                    path="activity"
+                    element={
+                      <RequireAdminAction actions={ADMIN_ROUTE_ACTIONS.activity}>
+                        <AdminActivity />
+                      </RequireAdminAction>
+                    }
+                  />
+                  <Route
+                    path="logs"
+                    element={
+                      <RequireAdminAction actions={ADMIN_ROUTE_ACTIONS.logs}>
+                        <AdminLogs />
+                      </RequireAdminAction>
+                    }
+                  />
+                  <Route
+                    path="libraries"
+                    element={
+                      <RequireAdminAction actions={ADMIN_ROUTE_ACTIONS.libraries}>
+                        <AdminLibraries />
+                      </RequireAdminAction>
+                    }
+                  />
+                  <Route
+                    path="maintenance"
+                    element={
+                      <RequireAdminAction actions={ADMIN_ROUTE_ACTIONS.maintenance}>
+                        <AdminMaintenance />
+                      </RequireAdminAction>
+                    }
+                  />
+                  <Route
+                    path="collections"
+                    element={
+                      <RequireAdminAction actions={ADMIN_ROUTE_ACTIONS.collections}>
+                        <AdminCollections />
+                      </RequireAdminAction>
+                    }
+                  />
+                  <Route
+                    path="collections/new"
+                    element={
+                      <RequireAdminAction actions={ADMIN_ROUTE_ACTIONS.collections}>
+                        <AdminCollectionEditor />
+                      </RequireAdminAction>
+                    }
+                  />
+                  <Route
+                    path="collections/:id/edit"
+                    element={
+                      <RequireAdminAction actions={ADMIN_ROUTE_ACTIONS.collections}>
+                        <AdminCollectionEditor />
+                      </RequireAdminAction>
+                    }
+                  />
+                  <Route
+                    path="requests"
+                    element={
+                      <RequireAdminAction actions={ADMIN_ROUTE_ACTIONS.requests}>
+                        <AdminRequests />
+                      </RequireAdminAction>
+                    }
+                  />
+                  <Route
+                    path="autoscan"
+                    element={
+                      <RequireAdminAction actions={ADMIN_ROUTE_ACTIONS.autoscan}>
+                        <AdminAutoscan />
+                      </RequireAdminAction>
+                    }
+                  />
+                  <Route
+                    path="history"
+                    element={
+                      <RequireAdminAction actions={ADMIN_ROUTE_ACTIONS.history}>
+                        <AdminPlaybackHistory />
+                      </RequireAdminAction>
+                    }
+                  />
+                  <Route
+                    path="marker-history"
+                    element={
+                      <RequireAdminAction actions={ADMIN_ROUTE_ACTIONS.markerHistory}>
+                        <AdminMarkerHistory />
+                      </RequireAdminAction>
+                    }
+                  />
+                  <Route
+                    path="history-import"
+                    element={
+                      <RequireAdminAction actions={ADMIN_ROUTE_ACTIONS.historyImport}>
+                        <AdminHistoryImport />
+                      </RequireAdminAction>
+                    }
+                  />
+                  <Route
+                    path="access-groups"
+                    element={
+                      <RequireAdminAction actions={ADMIN_ROUTE_ACTIONS.accessGroups}>
+                        <AdminAccessGroups />
+                      </RequireAdminAction>
+                    }
+                  />
+                  <Route
+                    path="users"
+                    element={
+                      <RequireAdminAction actions={ADMIN_ROUTE_ACTIONS.users}>
+                        <AdminUsers />
+                      </RequireAdminAction>
+                    }
+                  />
+                  <Route
+                    path="users/:id"
+                    element={
+                      <RequireAdminAction actions={ADMIN_ROUTE_ACTIONS.users}>
+                        <AdminUserDetail />
+                      </RequireAdminAction>
+                    }
+                  />
+                  <Route
+                    path="devices"
+                    element={
+                      <RequireAdminAction actions={ADMIN_ROUTE_ACTIONS.devices}>
+                        <AdminDevices />
+                      </RequireAdminAction>
+                    }
+                  />
+                  <Route
+                    path="devices/:userId/:deviceId"
+                    element={
+                      <RequireAdminAction actions={ADMIN_ROUTE_ACTIONS.devices}>
+                        <AdminDevices />
+                      </RequireAdminAction>
+                    }
+                  />
+                  <Route
+                    path="nodes"
+                    element={
+                      <RequireAdminAction actions={ADMIN_ROUTE_ACTIONS.nodes}>
+                        <AdminNodes />
+                      </RequireAdminAction>
+                    }
+                  />
+                  <Route
+                    path="sections"
+                    element={
+                      <RequireAdminAction actions={ADMIN_ROUTE_ACTIONS.sections}>
+                        <AdminSections />
+                      </RequireAdminAction>
+                    }
+                  />
+                  <Route
+                    path="plugins"
+                    element={
+                      <RequireAdminAction actions={ADMIN_ROUTE_ACTIONS.plugins}>
+                        <AdminPlugins />
+                      </RequireAdminAction>
+                    }
+                  />
+                  <Route
+                    path="settings"
+                    element={
+                      <RequireAdminAction actions={ADMIN_ROUTE_ACTIONS.settings}>
+                        <AdminSettingsLayout />
+                      </RequireAdminAction>
+                    }
+                  />
+                  <Route
+                    path="recommendations"
+                    element={
+                      <RequireAdminAction actions={ADMIN_ROUTE_ACTIONS.recommendations}>
+                        <AdminRecommendations />
+                      </RequireAdminAction>
+                    }
+                  />
+                  <Route
+                    path="api-keys"
+                    element={
+                      <RequireAdminAction actions={ADMIN_ROUTE_ACTIONS.apiKeys}>
+                        <AdminApiKeys />
+                      </RequireAdminAction>
+                    }
+                  />
+                  <Route
+                    path="subtitles"
+                    element={
+                      <RequireAdminAction actions={ADMIN_ROUTE_ACTIONS.subtitles}>
+                        <AdminSubtitles />
+                      </RequireAdminAction>
+                    }
+                  />
+                  <Route
+                    path="tasks"
+                    element={
+                      <RequireAdminAction actions={ADMIN_ROUTE_ACTIONS.tasks}>
+                        <AdminTasks />
+                      </RequireAdminAction>
+                    }
+                  />
+                  <Route
+                    path="tasks/:key"
+                    element={
+                      <RequireAdminAction actions={ADMIN_ROUTE_ACTIONS.tasks}>
+                        <AdminTaskDetail />
+                      </RequireAdminAction>
+                    }
+                  />
                   <Route path="stats" element={<Navigate to="/admin" replace />} />
                   <Route path="*" element={<Navigate to="/admin" replace />} />
                 </Route>

--- a/web/src/api/types.ts
+++ b/web/src/api/types.ts
@@ -103,6 +103,14 @@ export interface User {
   impersonation?: ImpersonationInfo | null;
 }
 
+export interface AdminCapabilities {
+  actions: string[];
+}
+
+export interface UserCapabilities {
+  actions: string[];
+}
+
 export interface AuthSession {
   id: string;
   device_name: string;
@@ -2201,6 +2209,7 @@ export interface AdminUser {
   email: string;
   role: string;
   permissions: string[];
+  access_groups: AdminAccessGroup[];
   enabled: boolean;
   library_ids: number[] | null;
   max_playback_quality: string;
@@ -2214,12 +2223,127 @@ export interface AdminUser {
   last_active_at?: string;
 }
 
+export interface AdminAccessGroup {
+  id: number;
+  slug: string;
+  name: string;
+  description: string;
+  policy: AdminACLPolicy;
+  built_in: boolean;
+  protected: boolean;
+  member_count: number;
+}
+
+export interface AdminAccessGroupMember {
+  user_id: number;
+  username: string;
+  email: string;
+  role: string;
+  enabled: boolean;
+}
+
+export interface AdminACLPolicy {
+  library_ids?: number[];
+  media_types?: string[];
+  max_playback_quality?: string;
+  max_streams?: number;
+  max_transcodes?: number;
+  max_profiles?: number;
+  direct_downloads_allowed?: boolean;
+  transcoded_downloads_allowed?: boolean;
+}
+
+export interface AdminACLCondition {
+  library_ids?: number[];
+  media_types?: string[];
+  primary_profile_required?: boolean;
+  max_playback_quality?: string;
+  max_streams?: number;
+  max_transcodes?: number;
+  direct_downloads_allowed?: boolean;
+  transcoded_downloads_allowed?: boolean;
+  max_content_rating?: string;
+}
+
+export interface AdminACLRule {
+  id: number;
+  action: string;
+  resource_type: string;
+  resource_id: string;
+  effect: "allow" | "deny";
+  conditions: AdminACLCondition;
+  priority: number;
+  name: string;
+  description: string;
+}
+
+export interface AdminACLRuleWriteRequest {
+  action: string;
+  resource_type: string;
+  resource_id: string;
+  effect: "allow" | "deny";
+  conditions: AdminACLCondition;
+  priority: number;
+  name: string;
+  description: string;
+}
+
+export interface AdminAccessGroupDetail extends AdminAccessGroup {
+  members: AdminAccessGroupMember[];
+  rules: AdminACLRule[];
+}
+
+export interface AdminEffectivePolicy {
+  library_ids?: number[];
+  media_types?: string[];
+  max_playback_quality?: string;
+  max_streams: number;
+  max_transcodes: number;
+  max_profiles: number;
+  direct_downloads_allowed: boolean;
+  transcoded_downloads_allowed: boolean;
+  max_content_rating?: string;
+}
+
+export interface AdminACLExplanationSource {
+  type: string;
+  id?: string;
+  name?: string;
+}
+
+export interface AdminACLActionExplanation {
+  action: string;
+  resource_type: string;
+  allowed: boolean;
+  reason_code: string;
+  source: AdminACLExplanationSource;
+  winning_rule?: AdminACLRule;
+  matched_rules: AdminACLRule[];
+  evaluated_rules: AdminACLRule[];
+}
+
+export interface AdminUserAccessExplanation {
+  user: AdminUser;
+  groups: AdminAccessGroup[];
+  effective_policy: AdminEffectivePolicy;
+  actions: AdminACLActionExplanation[];
+}
+
+export interface AdminAccessGroupWriteRequest {
+  slug?: string;
+  name: string;
+  description?: string;
+  policy?: AdminACLPolicy;
+  rules: AdminACLRuleWriteRequest[];
+}
+
 export interface CreateUserRequest {
   username: string;
   email: string;
   password: string;
   role: string;
   permissions?: string[];
+  access_group_slugs?: string[];
   create_default_profile?: boolean;
   default_profile_name?: string;
   library_ids?: number[] | null;
@@ -2237,6 +2361,7 @@ export interface UpdateUserRequest {
   password?: string;
   role?: string;
   permissions?: string[];
+  access_group_slugs?: string[];
   enabled?: boolean;
   library_ids?: number[] | null;
   max_playback_quality?: string;

--- a/web/src/components/AdminSidebar.test.tsx
+++ b/web/src/components/AdminSidebar.test.tsx
@@ -45,6 +45,16 @@ vi.mock("@/hooks/queries/admin/plugins", () => ({
   useAdminPluginInstallations: () => mockUseAdminPluginInstallations(),
 }));
 
+vi.mock("@/hooks/useAdminCapabilities", () => ({
+  useAdminAccess: () => ({
+    actingAdmin: true,
+    actionSet: new Set<string>(),
+    can: () => true,
+    canAccessAdmin: true,
+    isLoading: false,
+  }),
+}));
+
 function renderSidebar() {
   return renderToStaticMarkup(
     <MemoryRouter initialEntries={["/admin"]}>

--- a/web/src/components/AdminSidebar.tsx
+++ b/web/src/components/AdminSidebar.tsx
@@ -13,6 +13,8 @@ import { navigateToPluginRoute } from "@/lib/buildPluginHref";
 import { useAdminPluginInstallations } from "@/hooks/queries/admin/plugins";
 import { useAdminSessions } from "@/hooks/queries/admin/stats";
 import { useBuildInfo } from "@/hooks/queries/admin/system";
+import { useAdminAccess } from "@/hooks/useAdminCapabilities";
+import { filterAdminNavSections } from "@/lib/adminCapabilities";
 
 interface SidebarItem extends AdminNavItem {
   badge?: ReactNode;
@@ -27,15 +29,18 @@ interface AdminSidebarProps {
   onNavigate?: () => void;
 }
 
-function useSessionCount() {
-  const { data: sessions = [] } = useAdminSessions();
+function useSessionCount(enabled: boolean) {
+  const { data: sessions = [] } = useAdminSessions(enabled);
   return sessions.length;
 }
 
 export default function AdminSidebar({ onNavigate }: AdminSidebarProps) {
   const location = useLocation();
-  const sessionCount = useSessionCount();
-  const buildInfo = useBuildInfo();
+  const adminAccess = useAdminAccess();
+  const canViewServer = adminAccess.can("server.view");
+  const canViewPlugins = adminAccess.can(["plugins.view", "plugins.manage"]);
+  const sessionCount = useSessionCount(canViewServer);
+  const buildInfo = useBuildInfo(canViewServer);
   // Falls back to "dev build" when the binary carries no VCS/ldflags revision
   // (e.g. `go run` or an image built without BUILD_REVISION) rather than a stark
   // "unavailable".
@@ -50,7 +55,11 @@ export default function AdminSidebar({ onNavigate }: AdminSidebarProps) {
 
   const activityBadge =
     sessionCount > 0 ? <span className="live-badge">{sessionCount} live</span> : undefined;
-  const sections: SidebarSection[] = ADMIN_NAV_SECTIONS.map((section) => ({
+  const sections: SidebarSection[] = filterAdminNavSections(
+    ADMIN_NAV_SECTIONS,
+    adminAccess.actionSet,
+    adminAccess.actingAdmin,
+  ).map((section) => ({
     ...section,
     items: section.items.map((item) =>
       item.href === "/admin/activity" ? { ...item, badge: activityBadge } : item,
@@ -62,7 +71,7 @@ export default function AdminSidebar({ onNavigate }: AdminSidebarProps) {
   // navigable route, which excludes admin-only plugins like arrproxy and
   // arrouter. The admin sidebar needs the full installation list to render
   // its "Plugin Apps" group.
-  const { data: adminInstallations } = useAdminPluginInstallations();
+  const { data: adminInstallations } = useAdminPluginInstallations(canViewPlugins);
   const adminPluginItems = buildAdminPluginNavItems(adminInstallations);
   if (adminPluginItems.length > 0) {
     sections.push({ label: "Plugin Apps", items: adminPluginItems });

--- a/web/src/components/AppSidebar.test.tsx
+++ b/web/src/components/AppSidebar.test.tsx
@@ -27,6 +27,12 @@ vi.mock("@/hooks/useCurrentProfile", () => ({
   }),
 }));
 
+vi.mock("@/hooks/useAdminCapabilities", () => ({
+  useAdminAccess: () => ({
+    canAccessAdmin: true,
+  }),
+}));
+
 vi.mock("@/hooks/queries/libraries", () => ({
   useUserLibraries: () => ({
     data: [{ id: 7, name: "Movies", type: "movies" }],

--- a/web/src/components/AppSidebar.tsx
+++ b/web/src/components/AppSidebar.tsx
@@ -6,7 +6,7 @@ import { getProfileMenuSide, isSidebarExpanded } from "@/components/AppSidebar.l
 import { SiloBrand } from "@/components/SiloBrand";
 import { useAuth } from "@/hooks/useAuth";
 import { useCurrentProfile } from "@/hooks/useCurrentProfile";
-import { useIsActingAdmin } from "@/hooks/useIsActingAdmin";
+import { useAdminAccess } from "@/hooks/useAdminCapabilities";
 import { navigateToPluginRoute } from "@/lib/buildPluginHref";
 import { useUserLibraries } from "@/hooks/queries/libraries";
 import { useUnreadNotificationCount } from "@/hooks/queries/notifications";
@@ -171,7 +171,7 @@ export default function AppSidebar({ onNavigate, collapsed = false }: AppSidebar
   const { user, logout, clearProfile } = useAuth();
   const { profile } = useCurrentProfile();
   const { theme, setTheme, previewTheme, resetPreviewTheme } = useTheme();
-  const showAdminNav = useIsActingAdmin();
+  const showAdminNav = useAdminAccess().canAccessAdmin;
   const { data: libraries } = useUserLibraries();
   const { pins } = useSidebarPins();
   const { togglePin } = useToggleSidebarPin();

--- a/web/src/components/ContinueWatchingCard.tsx
+++ b/web/src/components/ContinueWatchingCard.tsx
@@ -9,6 +9,7 @@ import CardOverlays from "@/components/overlays/CardOverlays";
 import { overlayDataFromSectionItem, type CardOverlayPrefs } from "@/lib/overlays";
 import { formatListeningTimeLeft } from "@/lib/audiobooks/duration";
 import { upcomingBadgeClass, upcomingBadgeLabel } from "@/lib/upcomingEventPresentation";
+import { USER_CAPABILITY_ACTIONS, useUserCapabilityAccess } from "@/hooks/useUserCapabilities";
 import { useWatchPlaybackController } from "@/playback/watchPlaybackContext";
 import { parseWatchHref } from "@/pages/watchRouteHelpers";
 import { buildItemHref, buildMediaPlayHref, isVideoWatchHref } from "@/lib/mediaNavigation";
@@ -33,6 +34,8 @@ type ContinueWatchingCardProps = (
 export default function ContinueWatchingCard(props: ContinueWatchingCardProps) {
   const location = useLocation();
   const playbackController = useWatchPlaybackController();
+  const userCapabilities = useUserCapabilityAccess();
+  const canPlayback = userCapabilities.can(USER_CAPABILITY_ACTIONS.playbackPlay);
   const card =
     "sectionItem" in props && props.sectionItem
       ? {
@@ -123,6 +126,7 @@ export default function ContinueWatchingCard(props: ContinueWatchingCardProps) {
   // Detail-page link target for the card's image and meta lines: manga
   // chapters head to the series page like the heading does.
   const detailHref = isMangaChapter ? headingHref : card.itemHref;
+  const progressHref = canPlayback && isMangaChapter ? card.watchHref : card.itemHref;
   const episodeLabel = hasEpisodeMeta
     ? `Season ${card.seasonNumber} Episode ${card.episodeNumber}`
     : null;
@@ -151,6 +155,7 @@ export default function ContinueWatchingCard(props: ContinueWatchingCardProps) {
   const handleWatchClick = useCallback(
     (event: React.MouseEvent<HTMLAnchorElement>) => {
       if (
+        !canPlayback ||
         event.defaultPrevented ||
         event.button !== 0 ||
         event.metaKey ||
@@ -179,7 +184,7 @@ export default function ContinueWatchingCard(props: ContinueWatchingCardProps) {
         returnHref: `${location.pathname}${location.search}`,
       });
     },
-    [card.watchHref, location.pathname, location.search, playbackController],
+    [canPlayback, card.watchHref, location.pathname, location.search, playbackController],
   );
 
   const variant = props.variant ?? "wide";
@@ -259,18 +264,20 @@ export default function ContinueWatchingCard(props: ContinueWatchingCardProps) {
             )}
           </div>
         </ViewTransitionLink>
-        <ViewTransitionLink
-          to={card.watchHref}
-          onClick={handleWatchClick}
-          aria-label={`${card.type === "ebook" ? "Read" : "Play"} ${heading}`}
-          className="bg-primary text-primary-foreground absolute top-1/2 left-1/2 flex h-11 w-11 -translate-x-1/2 -translate-y-1/2 items-center justify-center rounded-full opacity-100 shadow-lg transition-all duration-200 hover:scale-110 hover:shadow-xl hover:brightness-110 active:scale-95 pointer-fine:pointer-events-none pointer-fine:opacity-0 pointer-fine:group-hover/media:pointer-events-auto pointer-fine:group-hover/media:opacity-100 pointer-fine:focus-visible:pointer-events-auto pointer-fine:focus-visible:opacity-100"
-        >
-          {card.type === "ebook" ? (
-            <BookOpen className="h-5 w-5" />
-          ) : (
-            <Play className="ml-0.5 h-5 w-5" fill="currentColor" />
-          )}
-        </ViewTransitionLink>
+        {canPlayback && (
+          <ViewTransitionLink
+            to={card.watchHref}
+            onClick={handleWatchClick}
+            aria-label={`${card.type === "ebook" ? "Read" : "Play"} ${heading}`}
+            className="bg-primary text-primary-foreground absolute top-1/2 left-1/2 flex h-11 w-11 -translate-x-1/2 -translate-y-1/2 items-center justify-center rounded-full opacity-100 shadow-lg transition-all duration-200 hover:scale-110 hover:shadow-xl hover:brightness-110 active:scale-95 pointer-fine:pointer-events-none pointer-fine:opacity-0 pointer-fine:group-hover/media:pointer-events-auto pointer-fine:group-hover/media:opacity-100 pointer-fine:focus-visible:pointer-events-auto pointer-fine:focus-visible:opacity-100"
+          >
+            {card.type === "ebook" ? (
+              <BookOpen className="h-5 w-5" />
+            ) : (
+              <Play className="ml-0.5 h-5 w-5" fill="currentColor" />
+            )}
+          </ViewTransitionLink>
+        )}
         <MediaItemMenu
           contentId={
             "sectionItem" in props && props.sectionItem
@@ -300,7 +307,7 @@ export default function ContinueWatchingCard(props: ContinueWatchingCardProps) {
         </ViewTransitionLink>
         {episodeMeta && (
           <ViewTransitionLink
-            to={isMangaChapter ? card.watchHref : card.itemHref}
+            to={progressHref}
             className="text-muted-foreground block truncate text-xs hover:underline"
           >
             {episodeMeta}
@@ -322,7 +329,7 @@ export default function ContinueWatchingCard(props: ContinueWatchingCardProps) {
             <div className="text-muted-foreground text-xs">{timeLeftLabel}</div>
           ) : (
             <ViewTransitionLink
-              to={isMangaChapter ? card.watchHref : card.itemHref}
+              to={progressHref}
               className="text-muted-foreground block w-fit text-xs hover:underline"
             >
               {timeLeftLabel}

--- a/web/src/components/HeroBanner.test.tsx
+++ b/web/src/components/HeroBanner.test.tsx
@@ -26,6 +26,16 @@ vi.mock("@/pages/audiobooks/player/audiobookPlaybackContext", () => ({
   useAudiobookPlaybackController: () => playbackMocks.controller,
 }));
 
+vi.mock("@/hooks/useUserCapabilities", () => ({
+  USER_CAPABILITY_ACTIONS: {
+    playbackPlay: "playback.play",
+  },
+  useUserCapabilityAccess: () => ({
+    can: () => true,
+    isLoading: false,
+  }),
+}));
+
 function audiobookSlide() {
   return {
     content_id: "book-1",

--- a/web/src/components/HeroBanner.tsx
+++ b/web/src/components/HeroBanner.tsx
@@ -4,6 +4,7 @@ import { Info, ChevronLeft, ChevronRight, Play, Pause, BookOpen } from "lucide-r
 import { decodeThumbhash } from "@/lib/thumbhash";
 import { HERO_BANNER_SIZE } from "@/lib/design-system";
 import { useAmbientColor } from "@/hooks/useAmbientColor";
+import { USER_CAPABILITY_ACTIONS, useUserCapabilityAccess } from "@/hooks/useUserCapabilities";
 import { cn } from "@/lib/utils";
 import type { SectionItem } from "@/api/types";
 import { buildItemHref, buildMediaPlayHref } from "@/lib/mediaNavigation";
@@ -81,6 +82,8 @@ export default function HeroBanner({
   const [loaded, setLoaded] = useState<Record<number, boolean>>({});
   const [paused, setPaused] = useState(false);
   const audiobookPlayback = useAudiobookPlaybackController();
+  const userCapabilities = useUserCapabilityAccess();
+  const canPlayback = userCapabilities.can(USER_CAPABILITY_ACTIONS.playbackPlay);
   // Bumped whenever auto-advance restarts a fresh 8s cycle — after the slide
   // changes, or after the user unpauses. Used as part of the progress-rail key
   // so the CSS animation restarts in lockstep with the setInterval timer
@@ -151,6 +154,10 @@ export default function HeroBanner({
   });
 
   const handlePlayClick = (event: MouseEvent<HTMLAnchorElement>) => {
+    if (!canPlayback) {
+      event.preventDefault();
+      return;
+    }
     if (activeAudiobookPlaying == null) {
       return;
     }
@@ -250,20 +257,22 @@ export default function HeroBanner({
               </p>
             )}
             <div className="flex flex-wrap items-center gap-3">
-              <Link
-                to={playHref}
-                onClick={handlePlayClick}
-                className="pill pill-primary transition-colors duration-[--duration-fast]"
-              >
-                {current.type === "ebook" ? (
-                  <BookOpen className="h-4 w-4" />
-                ) : activeAudiobookPlaying ? (
-                  <Pause className="h-4 w-4 fill-current" />
-                ) : (
-                  <Play className="h-4 w-4 fill-current" />
-                )}
-                {playLabel}
-              </Link>
+              {canPlayback && (
+                <Link
+                  to={playHref}
+                  onClick={handlePlayClick}
+                  className="pill pill-primary transition-colors duration-[--duration-fast]"
+                >
+                  {current.type === "ebook" ? (
+                    <BookOpen className="h-4 w-4" />
+                  ) : activeAudiobookPlaying ? (
+                    <Pause className="h-4 w-4 fill-current" />
+                  ) : (
+                    <Play className="h-4 w-4 fill-current" />
+                  )}
+                  {playLabel}
+                </Link>
+              )}
               <Link
                 to={buildItemHref({ contentId: current.content_id, libraryId })}
                 className="pill pill-glass transition-colors duration-[--duration-fast]"

--- a/web/src/components/LibraryAccessSelector.tsx
+++ b/web/src/components/LibraryAccessSelector.tsx
@@ -1,3 +1,4 @@
+import type { ReactNode } from "react";
 import type { Library } from "@/api/types";
 import { Badge } from "@/components/ui/badge";
 import { Label } from "@/components/ui/label";
@@ -7,6 +8,7 @@ interface LibraryAccessSelectorProps {
   libraries: Library[];
   value: number[] | null;
   onChange: (value: number[] | null) => void;
+  labelAccessory?: ReactNode;
 }
 
 function sortByLibraryOrder(libraries: Library[], ids: number[]) {
@@ -14,7 +16,12 @@ function sortByLibraryOrder(libraries: Library[], ids: number[]) {
   return libraries.filter((library) => selected.has(library.id)).map((library) => library.id);
 }
 
-export function LibraryAccessSelector({ libraries, value, onChange }: LibraryAccessSelectorProps) {
+export function LibraryAccessSelector({
+  libraries,
+  value,
+  onChange,
+  labelAccessory,
+}: LibraryAccessSelectorProps) {
   const allLibraries = value === null;
 
   function handleAllLibrariesChange(checked: boolean) {
@@ -32,7 +39,10 @@ export function LibraryAccessSelector({ libraries, value, onChange }: LibraryAcc
   return (
     <div className="space-y-2">
       <div className="flex items-center justify-between">
-        <Label>Library Access</Label>
+        <div className="flex items-center gap-1.5">
+          <Label>Library Access</Label>
+          {labelAccessory}
+        </div>
         <div className="flex items-center gap-2">
           <span className="text-muted-foreground text-xs">All libraries</span>
           <Switch checked={allLibraries} onCheckedChange={handleAllLibrariesChange} />

--- a/web/src/components/MediaItemMenu.test.tsx
+++ b/web/src/components/MediaItemMenu.test.tsx
@@ -142,6 +142,40 @@ describe("buildMediaItemMenuModel", () => {
     ).toBe(true);
   });
 
+  it("omits play from beginning when playback is not allowed", () => {
+    const model = buildMediaItemMenuModel({
+      mediaType: "episode",
+      hasPartialProgress: true,
+      userState: {
+        played: false,
+        is_favorite: false,
+        in_watchlist: false,
+      },
+      isAdmin: false,
+      canPlayback: false,
+    });
+
+    expect(
+      model.some((item) => item.kind === "action" && item.label === "Play from Beginning"),
+    ).toBe(false);
+  });
+
+  it("omits favorites and watchlist when personal list management is not allowed", () => {
+    const model = buildMediaItemMenuModel({
+      mediaType: "movie",
+      userState: {
+        played: false,
+        is_favorite: false,
+        in_watchlist: false,
+      },
+      isAdmin: false,
+      canManagePersonalLists: false,
+    });
+    const labels = model.filter((item) => item.kind === "action").map((item) => item.label);
+
+    expect(labels).toEqual(["Mark Watched"]);
+  });
+
   it("uses listening labels for audiobook state actions", () => {
     const model = buildMediaItemMenuModel({
       mediaType: "audiobook",

--- a/web/src/components/MediaItemMenu.tsx
+++ b/web/src/components/MediaItemMenu.tsx
@@ -8,6 +8,7 @@ import { useRefreshItemMetadata, useWatchedStateMutation } from "@/hooks/queries
 import { type DismissHomeItemVariables, useDismissHomeItem } from "@/hooks/queries/homeDismissals";
 import { useToggleFavorite } from "@/hooks/queries/favorites";
 import { useToggleWatchlist } from "@/hooks/queries/watchlist";
+import { USER_CAPABILITY_ACTIONS, useUserCapabilityAccess } from "@/hooks/useUserCapabilities";
 import { getWatchedActionLabel } from "@/pages/ItemDetail/watchedState";
 import MangaFilesDialog from "@/components/MangaFilesDialog";
 import RefreshMetadataDialog from "@/components/RefreshMetadataDialog";
@@ -45,6 +46,8 @@ interface BuildMediaItemMenuModelOptions {
   userState?: MediaItemUserState;
   hasPartialProgress?: boolean;
   isAdmin: boolean;
+  canPlayback?: boolean;
+  canManagePersonalLists?: boolean;
   showCollectionActions?: boolean;
   dismissLabel?: string;
 }
@@ -66,6 +69,8 @@ export function buildMediaItemMenuModel({
   userState,
   hasPartialProgress = false,
   isAdmin,
+  canPlayback = true,
+  canManagePersonalLists = true,
   showCollectionActions = true,
   dismissLabel,
 }: BuildMediaItemMenuModelOptions): MediaItemMenuEntry[] {
@@ -73,7 +78,7 @@ export function buildMediaItemMenuModel({
   const isAudiobook = mediaType === "audiobook";
   const isLeaf = mediaType === "movie" || mediaType === "episode" || isAudiobook;
 
-  if (isLeaf && (hasPartialProgress || userState?.played === true)) {
+  if (canPlayback && isLeaf && (hasPartialProgress || userState?.played === true)) {
     entries.push({
       kind: "action",
       key: "playFromBeginning",
@@ -90,7 +95,7 @@ export function buildMediaItemMenuModel({
   }
 
   if (userState) {
-    if (showCollectionActions) {
+    if (showCollectionActions && canManagePersonalLists) {
       entries.push(
         {
           kind: "action",
@@ -162,6 +167,9 @@ export default function MediaItemMenu({
   const location = useLocation();
   const playbackController = useWatchPlaybackController();
   const isAdmin = useIsActingAdmin();
+  const userCapabilities = useUserCapabilityAccess();
+  const canPlayback = userCapabilities.can(USER_CAPABILITY_ACTIONS.playbackPlay);
+  const canManagePersonalLists = userCapabilities.can(USER_CAPABILITY_ACTIONS.personalListsManage);
   const [currentUserState, setCurrentUserState] = useState(userState);
   const [refreshDialogOpen, setRefreshDialogOpen] = useState(false);
   const [filesDialogOpen, setFilesDialogOpen] = useState(false);
@@ -199,6 +207,8 @@ export default function MediaItemMenu({
     userState: currentUserState,
     hasPartialProgress,
     isAdmin,
+    canPlayback,
+    canManagePersonalLists,
     showCollectionActions,
     dismissLabel,
   });
@@ -219,6 +229,7 @@ export default function MediaItemMenu({
   async function handleAction(actionKey: Extract<MediaItemMenuEntry, { kind: "action" }>["key"]) {
     switch (actionKey) {
       case "playFromBeginning": {
+        if (!canPlayback) return;
         if (mediaType === "audiobook") {
           navigate(buildMediaPlayHref({ contentId, type: mediaType, libraryId, restart: true }));
           return;
@@ -238,13 +249,13 @@ export default function MediaItemMenu({
         return;
       }
       case "toggleFavorite": {
-        if (!currentUserState) return;
+        if (!currentUserState || !canManagePersonalLists) return;
         await favoriteMutation.mutateAsync(currentUserState.is_favorite);
         setCurrentUserState((prev) => (prev ? { ...prev, is_favorite: !prev.is_favorite } : prev));
         return;
       }
       case "toggleWatchlist": {
-        if (!currentUserState) return;
+        if (!currentUserState || !canManagePersonalLists) return;
         await watchlistMutation.mutateAsync(currentUserState.in_watchlist);
         setCurrentUserState((prev) =>
           prev ? { ...prev, in_watchlist: !prev.in_watchlist } : prev,

--- a/web/src/components/TasteSeedBanner.tsx
+++ b/web/src/components/TasteSeedBanner.tsx
@@ -4,6 +4,7 @@ import { Sparkles, X } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { useAuth } from "@/hooks/useAuth";
 import { useFavorites } from "@/hooks/queries/favorites";
+import { USER_CAPABILITY_ACTIONS, useUserCapabilityAccess } from "@/hooks/useUserCapabilities";
 import {
   isTasteSeedBannerDismissed,
   isTasteSeedDismissed,
@@ -25,9 +26,12 @@ import {
  */
 export default function TasteSeedBanner() {
   const { profile } = useAuth();
+  const userCapabilities = useUserCapabilityAccess();
+  const canManagePersonalLists = userCapabilities.can(USER_CAPABILITY_ACTIONS.personalListsManage);
   const { data: favorites, isPending } = useFavorites();
   const [hidden, setHidden] = useState(false);
 
+  if (userCapabilities.isLoading || !canManagePersonalLists) return null;
   if (!profile || isPending) return null;
   if ((favorites?.length ?? 0) > 0) return null;
   if (!isTasteSeedDismissed(profile.id)) return null;

--- a/web/src/components/WatchTonightCard.test.tsx
+++ b/web/src/components/WatchTonightCard.test.tsx
@@ -8,6 +8,16 @@ vi.mock("@/playback/watchPlaybackContext", () => ({
   useWatchPlaybackController: () => ({ startPlayback: vi.fn() }),
 }));
 
+vi.mock("@/hooks/useUserCapabilities", () => ({
+  USER_CAPABILITY_ACTIONS: {
+    playbackPlay: "playback.play",
+  },
+  useUserCapabilityAccess: () => ({
+    can: () => true,
+    isLoading: false,
+  }),
+}));
+
 describe("WatchTonightCard", () => {
   it("links ebook cards to the reader and shows percent read", () => {
     const markup = renderToStaticMarkup(

--- a/web/src/components/WatchTonightCard.tsx
+++ b/web/src/components/WatchTonightCard.tsx
@@ -4,6 +4,7 @@ import { useLocation } from "react-router";
 import type { WatchTonightItem } from "@/hooks/queries/recommendations";
 import ViewTransitionLink from "@/components/ViewTransitionLink";
 import { Badge } from "@/components/ui/badge";
+import { USER_CAPABILITY_ACTIONS, useUserCapabilityAccess } from "@/hooks/useUserCapabilities";
 import { useWatchPlaybackController } from "@/playback/watchPlaybackContext";
 import { parseWatchHref } from "@/pages/watchRouteHelpers";
 import { buildItemHref, buildMediaPlayHref, isVideoWatchHref } from "@/lib/mediaNavigation";
@@ -22,9 +23,12 @@ interface WatchTonightCardProps {
 export default function WatchTonightCard({ item, onPlay }: WatchTonightCardProps) {
   const location = useLocation();
   const playbackController = useWatchPlaybackController();
+  const userCapabilities = useUserCapabilityAccess();
+  const canPlayback = userCapabilities.can(USER_CAPABILITY_ACTIONS.playbackPlay);
 
   const watchHref = buildMediaPlayHref({ contentId: item.content_id, type: item.type });
   const itemHref = buildItemHref({ contentId: item.content_id });
+  const thumbnailHref = canPlayback ? watchHref : itemHref;
   const source = item.watch_tonight_source ?? "";
   const isInProgress = source === "continue_watching";
   const isNextUp = source === "next_up";
@@ -51,6 +55,7 @@ export default function WatchTonightCard({ item, onPlay }: WatchTonightCardProps
   const handlePlayClick = useCallback(
     (event: React.MouseEvent<HTMLAnchorElement>) => {
       if (
+        !canPlayback ||
         event.defaultPrevented ||
         event.button !== 0 ||
         event.metaKey ||
@@ -78,7 +83,7 @@ export default function WatchTonightCard({ item, onPlay }: WatchTonightCardProps
         returnHref: `${location.pathname}${location.search}`,
       });
     },
-    [watchHref, location.pathname, location.search, playbackController, onPlay],
+    [canPlayback, watchHref, location.pathname, location.search, playbackController, onPlay],
   );
 
   const badgeLabel = sourceLabels[source];
@@ -87,9 +92,9 @@ export default function WatchTonightCard({ item, onPlay }: WatchTonightCardProps
     <div className="group/card flex gap-5 rounded-xl p-3 transition-colors hover:bg-white/5">
       {/* Thumbnail */}
       <ViewTransitionLink
-        to={watchHref}
+        to={thumbnailHref}
         onClick={handlePlayClick}
-        aria-label={`${playVerb} ${heading}`}
+        aria-label={canPlayback ? `${playVerb} ${heading}` : `Open ${heading}`}
         className="group/play relative w-44 shrink-0"
       >
         <div className="relative aspect-video overflow-hidden rounded-lg">
@@ -114,15 +119,17 @@ export default function WatchTonightCard({ item, onPlay }: WatchTonightCardProps
           )}
 
           {/* Play overlay */}
-          <div className="absolute inset-0 flex items-center justify-center bg-black/0 transition-colors group-hover/card:bg-black/30 group-focus-visible/play:bg-black/30">
-            <div className="bg-primary text-primary-foreground flex h-10 w-10 items-center justify-center rounded-full opacity-0 shadow-lg transition-opacity group-hover/card:opacity-100 group-focus-visible/play:opacity-100">
-              {item.type === "ebook" ? (
-                <BookOpen className="h-4 w-4" />
-              ) : (
-                <Play className="ml-0.5 h-4 w-4" fill="currentColor" />
-              )}
+          {canPlayback && (
+            <div className="absolute inset-0 flex items-center justify-center bg-black/0 transition-colors group-hover/card:bg-black/30 group-focus-visible/play:bg-black/30">
+              <div className="bg-primary text-primary-foreground flex h-10 w-10 items-center justify-center rounded-full opacity-0 shadow-lg transition-opacity group-hover/card:opacity-100 group-focus-visible/play:opacity-100">
+                {item.type === "ebook" ? (
+                  <BookOpen className="h-4 w-4" />
+                ) : (
+                  <Play className="ml-0.5 h-4 w-4" fill="currentColor" />
+                )}
+              </div>
             </div>
-          </div>
+          )}
 
           {/* Progress bar */}
           {isInProgress && progressPercent > 0 && (

--- a/web/src/components/watchtonight/CardStack.tsx
+++ b/web/src/components/watchtonight/CardStack.tsx
@@ -3,6 +3,7 @@ import { AnimatePresence, motion } from "framer-motion";
 import { useLocation, useNavigate } from "react-router";
 import { RefreshCw, Tv } from "lucide-react";
 import type { SwipeCard as SwipeCardType } from "@/hooks/queries/recommendations";
+import { USER_CAPABILITY_ACTIONS, useUserCapabilityAccess } from "@/hooks/useUserCapabilities";
 import { useWatchPlaybackController } from "@/playback/watchPlaybackContext";
 import { Skeleton } from "@/components/ui/skeleton";
 import SwipeCard, { CardActions } from "./SwipeCard";
@@ -47,6 +48,8 @@ export default function CardStack({
   const location = useLocation();
   const navigate = useNavigate();
   const playbackController = useWatchPlaybackController();
+  const userCapabilities = useUserCapabilityAccess();
+  const canPlayback = userCapabilities.can(USER_CAPABILITY_ACTIONS.playbackPlay);
 
   const visibleCards = cards.slice(topIndex, topIndex + 3);
   const isDone = visibleCards.length === 0 && !hasMore && !isFetching;
@@ -68,6 +71,7 @@ export default function CardStack({
   }, []);
 
   const handlePlay = useCallback(() => {
+    if (!canPlayback) return;
     const card = cards[topIndex];
     if (!card) return;
     onClose();
@@ -80,7 +84,16 @@ export default function CardStack({
       contentId: card.content_id,
       returnHref: `${location.pathname}${location.search}`,
     });
-  }, [cards, topIndex, onClose, playbackController, location.pathname, location.search, navigate]);
+  }, [
+    canPlayback,
+    cards,
+    topIndex,
+    onClose,
+    playbackController,
+    location.pathname,
+    location.search,
+    navigate,
+  ]);
 
   // Keyboard navigation.
   useEffect(() => {
@@ -89,14 +102,14 @@ export default function CardStack({
       if (e.key === "ArrowLeft") {
         e.preventDefault();
         advance();
-      } else if (e.key === "ArrowRight") {
+      } else if (canPlayback && e.key === "ArrowRight") {
         e.preventDefault();
         handlePlay();
       }
     }
     window.addEventListener("keydown", handleKeyDown);
     return () => window.removeEventListener("keydown", handleKeyDown);
-  }, [visibleCards.length, advance, handlePlay]);
+  }, [visibleCards.length, canPlayback, advance, handlePlay]);
 
   // Loading initial cards.
   if (cards.length === 0 && isFetching) {
@@ -169,7 +182,12 @@ export default function CardStack({
                 }}
                 transition={stackTransition}
               >
-                <SwipeCard card={card} isTop={isTop} onAccept={handlePlay} onReject={advance} />
+                <SwipeCard
+                  card={card}
+                  isTop={isTop}
+                  onAccept={canPlayback ? handlePlay : advance}
+                  onReject={advance}
+                />
               </motion.div>
             );
           })}
@@ -183,6 +201,7 @@ export default function CardStack({
           onAccept={handlePlay}
           onPlay={handlePlay}
           playLabel={visibleCards[0]?.type === "audiobook" ? "Listen now" : "Play now"}
+          canPlay={canPlayback}
         />
       )}
 

--- a/web/src/components/watchtonight/SwipeCard.tsx
+++ b/web/src/components/watchtonight/SwipeCard.tsx
@@ -309,6 +309,7 @@ interface CardActionsProps {
   onAccept: () => void;
   onPlay: () => void;
   playLabel?: string;
+  canPlay?: boolean;
   disabled?: boolean;
 }
 
@@ -317,6 +318,7 @@ export function CardActions({
   onAccept,
   onPlay,
   playLabel = "Play now",
+  canPlay = true,
   disabled,
 }: CardActionsProps) {
   return (
@@ -335,34 +337,38 @@ export function CardActions({
       >
         <X className="h-6 w-6" />
       </button>
-      <button
-        type="button"
-        data-action
-        onClick={onPlay}
-        disabled={disabled}
-        className={cn(
-          "flex h-16 w-16 items-center justify-center rounded-full border-2 transition-colors",
-          "border-primary/40 text-primary hover:border-primary hover:bg-primary/10",
-          "disabled:pointer-events-none disabled:opacity-40",
-        )}
-        aria-label={playLabel}
-      >
-        <Play className="ml-0.5 h-7 w-7" fill="currentColor" />
-      </button>
-      <button
-        type="button"
-        data-action
-        onClick={onAccept}
-        disabled={disabled}
-        className={cn(
-          "flex h-14 w-14 items-center justify-center rounded-full border-2 transition-colors",
-          "border-green-500/40 text-green-400 hover:border-green-500 hover:bg-green-500/10 hover:text-green-500",
-          "disabled:pointer-events-none disabled:opacity-40",
-        )}
-        aria-label="Like"
-      >
-        <Check className="h-6 w-6" />
-      </button>
+      {canPlay && (
+        <>
+          <button
+            type="button"
+            data-action
+            onClick={onPlay}
+            disabled={disabled}
+            className={cn(
+              "flex h-16 w-16 items-center justify-center rounded-full border-2 transition-colors",
+              "border-primary/40 text-primary hover:border-primary hover:bg-primary/10",
+              "disabled:pointer-events-none disabled:opacity-40",
+            )}
+            aria-label={playLabel}
+          >
+            <Play className="ml-0.5 h-7 w-7" fill="currentColor" />
+          </button>
+          <button
+            type="button"
+            data-action
+            onClick={onAccept}
+            disabled={disabled}
+            className={cn(
+              "flex h-14 w-14 items-center justify-center rounded-full border-2 transition-colors",
+              "border-green-500/40 text-green-400 hover:border-green-500 hover:bg-green-500/10 hover:text-green-500",
+              "disabled:pointer-events-none disabled:opacity-40",
+            )}
+            aria-label="Like"
+          >
+            <Check className="h-6 w-6" />
+          </button>
+        </>
+      )}
     </div>
   );
 }

--- a/web/src/hooks/queries/admin/libraries.ts
+++ b/web/src/hooks/queries/admin/libraries.ts
@@ -185,10 +185,11 @@ async function publishCatalogExportJob(id: string): Promise<AdminJob> {
   return (await res.json()) as AdminJob;
 }
 
-export function useAdminLibraries() {
+export function useAdminLibraries(enabled = true) {
   return useQuery({
     queryKey: adminKeys.libraries(),
     queryFn: () => api<Library[]>("/libraries").then((d) => d ?? []),
+    enabled,
     staleTime: ADMIN_STALE_TIME,
   });
 }

--- a/web/src/hooks/queries/admin/plugins.ts
+++ b/web/src/hooks/queries/admin/plugins.ts
@@ -36,12 +36,13 @@ function invalidatePluginQueries(queryClient: ReturnType<typeof useQueryClient>)
 // useAdminPluginInstallations is a slim hook for callers (e.g. AdminSidebar)
 // that only need the installations list. Shares its cache key with
 // useAdminPlugins() so triggering a refetch in either keeps both in sync.
-export function useAdminPluginInstallations() {
+export function useAdminPluginInstallations(enabled = true) {
   return useQuery({
     queryKey: adminKeys.pluginInstallations(),
     queryFn: () =>
       api<PluginInstallation[]>("/admin/plugins/installations").then((data) => data ?? []),
     staleTime: ADMIN_STALE_TIME,
+    enabled,
   });
 }
 

--- a/web/src/hooks/queries/admin/settings.ts
+++ b/web/src/hooks/queries/admin/settings.ts
@@ -72,10 +72,11 @@ export interface CatalogSearchStatus {
   }>;
 }
 
-export function useAdminServerSettings() {
+export function useAdminServerSettings(enabled = true) {
   return useQuery({
     queryKey: adminKeys.serverSettings(),
     queryFn: () => api<ServerSettings>("/admin/settings").then((d) => d ?? {}),
+    enabled,
     staleTime: 30_000,
   });
 }

--- a/web/src/hooks/queries/admin/stats.ts
+++ b/web/src/hooks/queries/admin/stats.ts
@@ -17,10 +17,11 @@ export function useAdminStats() {
   });
 }
 
-export function useAdminSessions() {
+export function useAdminSessions(enabled = true) {
   return useQuery({
     queryKey: adminKeys.sessions(),
     queryFn: () => api<AdminSession[]>("/admin/sessions").then((d) => d ?? []),
     staleTime: ADMIN_STALE_TIME,
+    enabled,
   });
 }

--- a/web/src/hooks/queries/admin/system.ts
+++ b/web/src/hooks/queries/admin/system.ts
@@ -18,12 +18,13 @@ export interface HWAccelInfo {
   node_url?: string;
 }
 
-export function useBuildInfo() {
+export function useBuildInfo(enabled = true) {
   return useQuery({
     queryKey: adminKeys.buildInfo(),
     queryFn: () => api<BuildInfo>("/admin/system/build"),
     staleTime: Number.POSITIVE_INFINITY,
     retry: false,
+    enabled,
   });
 }
 

--- a/web/src/hooks/queries/admin/users.ts
+++ b/web/src/hooks/queries/admin/users.ts
@@ -1,6 +1,10 @@
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { api } from "@/api/client";
 import type {
+  AdminAccessGroup,
+  AdminAccessGroupDetail,
+  AdminAccessGroupWriteRequest,
+  AdminUserAccessExplanation,
   AdminDeviceDetail,
   AdminDeviceSummary,
   AdminSettingEntry,
@@ -54,6 +58,92 @@ export function useAdminUsers() {
   });
 }
 
+export function useAdminAccessGroups(enabled = true) {
+  return useQuery({
+    queryKey: adminKeys.accessGroups(),
+    queryFn: () => api<AdminAccessGroup[]>("/admin/access-groups").then((d) => d ?? []),
+    enabled,
+    staleTime: ADMIN_STALE_TIME,
+  });
+}
+
+export function useAdminAccessGroup(slug: string | null, enabled = true) {
+  return useQuery({
+    queryKey: adminKeys.accessGroup(slug ?? ""),
+    queryFn: () => api<AdminAccessGroupDetail>(`/admin/access-groups/${slug}`),
+    enabled: enabled && Boolean(slug),
+    staleTime: ADMIN_STALE_TIME,
+  });
+}
+
+export function useAdminUserAccessExplanation(userId: number | null, enabled = true) {
+  return useQuery({
+    queryKey: adminKeys.userAccessExplanation(userId ?? 0),
+    queryFn: () => api<AdminUserAccessExplanation>(`/admin/users/${userId}/access-explain`),
+    enabled: enabled && userId != null,
+    staleTime: ADMIN_STALE_TIME,
+  });
+}
+
+export function useCreateAdminAccessGroup() {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: (body: AdminAccessGroupWriteRequest) =>
+      api<AdminAccessGroupDetail>("/admin/access-groups", {
+        method: "POST",
+        body: JSON.stringify(body),
+      }),
+    onSuccess: (group) => {
+      toast.success("Access group created");
+      queryClient.invalidateQueries({ queryKey: adminKeys.accessGroups() });
+      if (group?.slug)
+        queryClient.invalidateQueries({ queryKey: adminKeys.accessGroup(group.slug) });
+    },
+    onError: (err) => {
+      toast.error(err instanceof Error ? err.message : "Failed to save access group");
+    },
+  });
+}
+
+export function useUpdateAdminAccessGroup() {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: ({ slug, body }: { slug: string; body: AdminAccessGroupWriteRequest }) =>
+      api<AdminAccessGroupDetail>(`/admin/access-groups/${slug}`, {
+        method: "PUT",
+        body: JSON.stringify(body),
+      }),
+    onSuccess: (group, variables) => {
+      toast.success("Access group updated");
+      queryClient.invalidateQueries({ queryKey: adminKeys.accessGroups() });
+      queryClient.invalidateQueries({ queryKey: adminKeys.accessGroup(variables.slug) });
+      if (group?.slug && group.slug !== variables.slug) {
+        queryClient.invalidateQueries({ queryKey: adminKeys.accessGroup(group.slug) });
+      }
+      queryClient.invalidateQueries({ queryKey: adminKeys.users() });
+    },
+    onError: (err) => {
+      toast.error(err instanceof Error ? err.message : "Failed to save access group");
+    },
+  });
+}
+
+export function useDeleteAdminAccessGroup() {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: (slug: string) => api(`/admin/access-groups/${slug}`, { method: "DELETE" }),
+    onSuccess: (_data, slug) => {
+      toast.success("Access group deleted");
+      queryClient.invalidateQueries({ queryKey: adminKeys.accessGroups() });
+      queryClient.invalidateQueries({ queryKey: adminKeys.accessGroup(slug) });
+      queryClient.invalidateQueries({ queryKey: adminKeys.users() });
+    },
+    onError: (err) => {
+      toast.error(err instanceof Error ? err.message : "Failed to delete access group");
+    },
+  });
+}
+
 export function useAdminUser(id: number) {
   return useQuery({
     queryKey: adminKeys.userDetail(id),
@@ -73,6 +163,7 @@ export function useCreateUser() {
     onSuccess: () => {
       toast.success("User created");
       queryClient.invalidateQueries({ queryKey: adminKeys.users() });
+      queryClient.invalidateQueries({ queryKey: adminKeys.accessGroups() });
     },
     onError: (err) => {
       toast.error(err instanceof Error ? err.message : "Failed to save");
@@ -93,6 +184,7 @@ export function useUpdateUser() {
       queryClient.invalidateQueries({ queryKey: adminKeys.users() });
       queryClient.invalidateQueries({ queryKey: adminKeys.userDetail(variables.id) });
       queryClient.invalidateQueries({ queryKey: adminKeys.userProfiles(variables.id) });
+      queryClient.invalidateQueries({ queryKey: adminKeys.accessGroups() });
     },
     onError: (err) => {
       toast.error(err instanceof Error ? err.message : "Failed to save");

--- a/web/src/hooks/queries/keys.ts
+++ b/web/src/hooks/queries/keys.ts
@@ -109,6 +109,11 @@ export const historyKeys = {
   list: () => ["history", "list"] as const,
 };
 
+export const authKeys = {
+  all: ["auth"] as const,
+  capabilities: () => ["auth", "capabilities"] as const,
+};
+
 export const collectionKeys = {
   all: ["collections"] as const,
   list: () => ["collections", "list"] as const,
@@ -329,9 +334,13 @@ export const themeKeys = {
 };
 
 export const adminKeys = {
+  capabilities: () => ["admin", "capabilities"] as const,
   users: () => ["admin", "users"] as const,
+  accessGroups: () => ["admin", "accessGroups"] as const,
+  accessGroup: (slug: string) => ["admin", "accessGroups", slug] as const,
   serverNotificationChannels: () => ["admin", "notifications", "serverChannels"] as const,
   userDetail: (userId: number) => ["admin", "users", userId] as const,
+  userAccessExplanation: (userId: number) => ["admin", "users", userId, "accessExplanation"] as const,
   userProfiles: (userId?: number) => ["admin", "users", userId, "profiles"] as const,
   userSettings: (userId: number) => ["admin", "users", userId, "settings"] as const,
   userSetting: (userId: number, key: string) =>

--- a/web/src/hooks/useAdminCapabilities.ts
+++ b/web/src/hooks/useAdminCapabilities.ts
@@ -1,0 +1,42 @@
+import { useMemo } from "react";
+import { useQuery } from "@tanstack/react-query";
+
+import { api } from "@/api/client";
+import type { AdminCapabilities } from "@/api/types";
+import { useOptionalAuth } from "@/hooks/useAuth";
+import { useIsActingAdmin } from "@/hooks/useIsActingAdmin";
+import { adminKeys } from "@/hooks/queries/keys";
+
+const ADMIN_CAPABILITIES_STALE_TIME = 30_000;
+
+export function useAdminCapabilities() {
+  const user = useOptionalAuth()?.user;
+  return useQuery({
+    queryKey: adminKeys.capabilities(),
+    queryFn: () => api<AdminCapabilities>("/auth/admin-capabilities"),
+    enabled: Boolean(user),
+    staleTime: ADMIN_CAPABILITIES_STALE_TIME,
+  });
+}
+
+export function useAdminAccess() {
+  const actingAdmin = useIsActingAdmin();
+  const capabilities = useAdminCapabilities();
+  const actionSet = useMemo(
+    () => new Set(capabilities.data?.actions ?? []),
+    [capabilities.data?.actions],
+  );
+
+  return {
+    actingAdmin,
+    actions: capabilities.data?.actions ?? [],
+    actionSet,
+    isLoading: !actingAdmin && capabilities.isLoading,
+    canAccessAdmin: actingAdmin || actionSet.size > 0,
+    can: (action: string | readonly string[]) => {
+      if (actingAdmin) return true;
+      const actions = Array.isArray(action) ? action : [action];
+      return actions.some((value) => actionSet.has(value));
+    },
+  };
+}

--- a/web/src/hooks/useCanRequest.test.tsx
+++ b/web/src/hooks/useCanRequest.test.tsx
@@ -1,4 +1,4 @@
-import { describe, expect, it, vi } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 import { renderToStaticMarkup } from "react-dom/server";
 import type { ReactNode } from "react";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
@@ -6,6 +6,7 @@ import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 const mocks = vi.hoisted(() => ({
   useRequestFeatureStatus: vi.fn(),
   useCurrentProfile: vi.fn(),
+  useUserCapabilityAccess: vi.fn(),
 }));
 
 vi.mock("@/hooks/queries/useRequests", () => ({
@@ -14,6 +15,13 @@ vi.mock("@/hooks/queries/useRequests", () => ({
 
 vi.mock("@/hooks/useCurrentProfile", () => ({
   useCurrentProfile: () => mocks.useCurrentProfile(),
+}));
+
+vi.mock("@/hooks/useUserCapabilities", () => ({
+  USER_CAPABILITY_ACTIONS: {
+    requestsCreate: "requests.create",
+  },
+  useUserCapabilityAccess: () => mocks.useUserCapabilityAccess(),
 }));
 
 import { useCanRequest } from "./useCanRequest";
@@ -30,6 +38,13 @@ function render(child: ReactNode) {
 }
 
 describe("useCanRequest", () => {
+  beforeEach(() => {
+    mocks.useUserCapabilityAccess.mockReturnValue({
+      can: (action: string) => action === "requests.create",
+      isLoading: false,
+    });
+  });
+
   it("returns discoveryEnabled=false when requests_enabled is false", () => {
     mocks.useRequestFeatureStatus.mockReturnValue({
       data: { requests_enabled: false },
@@ -96,6 +111,33 @@ describe("useCanRequest", () => {
       discoveryEnabled: true,
       isResolving: false,
       submitDisabledReason: null,
+    });
+  });
+
+  it("returns discoveryEnabled=false when the profile cannot create requests", () => {
+    mocks.useRequestFeatureStatus.mockReturnValue({
+      data: { requests_enabled: true },
+      isLoading: false,
+    });
+    mocks.useCurrentProfile.mockReturnValue({ profile: { id: "p1" } });
+    mocks.useUserCapabilityAccess.mockReturnValue({
+      can: () => false,
+      isLoading: false,
+    });
+
+    let captured: ReturnType<typeof useCanRequest> | null = null;
+    render(
+      <CaptureHook
+        onResult={(r) => {
+          captured = r;
+        }}
+      />,
+    );
+
+    expect(captured).toEqual({
+      discoveryEnabled: false,
+      isResolving: false,
+      submitDisabledReason: "Media requests are not allowed",
     });
   });
 

--- a/web/src/hooks/useCanRequest.ts
+++ b/web/src/hooks/useCanRequest.ts
@@ -1,5 +1,6 @@
 import { useRequestFeatureStatus } from "@/hooks/queries/useRequests";
 import { useCurrentProfile } from "@/hooks/useCurrentProfile";
+import { USER_CAPABILITY_ACTIONS, useUserCapabilityAccess } from "@/hooks/useUserCapabilities";
 
 export interface CanRequestState {
   discoveryEnabled: boolean;
@@ -15,12 +16,15 @@ export interface CanRequestState {
 export function useCanRequest(): CanRequestState {
   const status = useRequestFeatureStatus();
   const { profile } = useCurrentProfile();
-  const discoveryEnabled = Boolean(status.data?.requests_enabled) && Boolean(profile?.id);
-  const isResolving = status.isLoading;
+  const capabilities = useUserCapabilityAccess();
+  const canCreateRequests = capabilities.can(USER_CAPABILITY_ACTIONS.requestsCreate);
+  const discoveryEnabled =
+    Boolean(status.data?.requests_enabled) && Boolean(profile?.id) && canCreateRequests;
+  const isResolving = status.isLoading || capabilities.isLoading;
 
   return {
     discoveryEnabled,
     isResolving,
-    submitDisabledReason: null,
+    submitDisabledReason: canCreateRequests ? null : "Media requests are not allowed",
   };
 }

--- a/web/src/hooks/useUserCapabilities.ts
+++ b/web/src/hooks/useUserCapabilities.ts
@@ -1,0 +1,48 @@
+import { useMemo } from "react";
+import { useQuery } from "@tanstack/react-query";
+
+import { api } from "@/api/client";
+import type { UserCapabilities } from "@/api/types";
+import { authKeys } from "@/hooks/queries/keys";
+import { useOptionalAuth } from "@/hooks/useAuth";
+
+const USER_CAPABILITIES_STALE_TIME = 30_000;
+
+export const USER_CAPABILITY_ACTIONS = {
+  playbackPlay: "playback.play",
+  playbackTranscode: "playback.transcode",
+  downloadsDirect: "downloads.direct",
+  downloadsTranscode: "downloads.transcode",
+  profilesManage: "profiles.manage",
+  personalListsManage: "personal_lists.manage",
+  requestsCreate: "requests.create",
+} as const;
+
+export function useUserCapabilities() {
+  const user = useOptionalAuth()?.user;
+  return useQuery({
+    queryKey: authKeys.capabilities(),
+    queryFn: () => api<UserCapabilities>("/auth/capabilities"),
+    enabled: Boolean(user),
+    staleTime: USER_CAPABILITIES_STALE_TIME,
+  });
+}
+
+export function useUserCapabilityAccess() {
+  const user = useOptionalAuth()?.user;
+  const capabilities = useUserCapabilities();
+  const actions = capabilities.data?.actions ?? [];
+  const actionSet = useMemo(() => new Set(actions), [actions]);
+
+  return {
+    actions: user ? actions : Object.values(USER_CAPABILITY_ACTIONS),
+    actionSet,
+    isLoading: Boolean(user) && capabilities.isLoading,
+    can: (action: string | readonly string[]) => {
+      if (!user) return true;
+      if (!capabilities.data && capabilities.isLoading) return false;
+      const requestedActions = Array.isArray(action) ? action : [action];
+      return requestedActions.some((value) => actionSet.has(value));
+    },
+  };
+}

--- a/web/src/lib/adminCapabilities.ts
+++ b/web/src/lib/adminCapabilities.ts
@@ -1,0 +1,94 @@
+import type { AdminNavGroup, AdminNavItem } from "@/lib/adminNavigation";
+
+export const ADMIN_ROUTE_ACTIONS = {
+  dashboard: ["server.view"],
+  activity: ["server.view"],
+  logs: ["logs.view"],
+  libraries: ["libraries.manage"],
+  maintenance: ["server.configure"],
+  collections: ["libraries.manage"],
+  sections: ["libraries.manage"],
+  requests: ["requests.approve"],
+  autoscan: ["libraries.manage"],
+  history: ["server.view"],
+  markerHistory: ["metadata.curate", "markers.edit"],
+  historyImport: ["server.configure"],
+  accessGroups: ["security.manage"],
+  users: ["users.view"],
+  devices: ["users.view"],
+  nodes: ["nodes.view", "nodes.manage"],
+  plugins: ["plugins.view", "plugins.manage"],
+  settings: ["server.configure"],
+  recommendations: ["recommendations.view", "recommendations.manage"],
+  apiKeys: ["server.configure"],
+  subtitles: ["server.configure"],
+  tasks: ["tasks.view", "tasks.run"],
+} as const satisfies Record<string, readonly string[]>;
+
+export function hasAnyAdminAction(
+  actionSet: ReadonlySet<string>,
+  actions: readonly string[] | undefined,
+) {
+  if (!actions || actions.length === 0) return true;
+  return actions.some((action) => actionSet.has(action));
+}
+
+export function filterAdminNavSections(
+  sections: readonly AdminNavGroup[],
+  actionSet: ReadonlySet<string>,
+  showAll: boolean,
+): AdminNavGroup[] {
+  if (showAll) {
+    return sections.map((section) => ({ ...section, items: [...section.items] }));
+  }
+
+  return sections
+    .map((section) => ({
+      ...section,
+      items: section.items.filter((item) => canUseAdminNavItem(item, actionSet)),
+    }))
+    .filter((section) => section.items.length > 0);
+}
+
+export function canUseAdminNavItem(item: AdminNavItem, actionSet: ReadonlySet<string>) {
+  return hasAnyAdminAction(actionSet, actionsForAdminHref(item.href));
+}
+
+export function firstAllowedAdminPath(actionSet: ReadonlySet<string>) {
+  const ordered: Array<{ href: string; actions: readonly string[] }> = [
+    { href: "/admin", actions: ADMIN_ROUTE_ACTIONS.dashboard },
+    { href: "/admin/users", actions: ADMIN_ROUTE_ACTIONS.users },
+    { href: "/admin/requests", actions: ADMIN_ROUTE_ACTIONS.requests },
+    { href: "/admin/logs", actions: ADMIN_ROUTE_ACTIONS.logs },
+    { href: "/admin/tasks", actions: ADMIN_ROUTE_ACTIONS.tasks },
+    { href: "/admin/access-groups", actions: ADMIN_ROUTE_ACTIONS.accessGroups },
+    { href: "/admin/settings", actions: ADMIN_ROUTE_ACTIONS.settings },
+  ];
+  return ordered.find((item) => hasAnyAdminAction(actionSet, item.actions))?.href ?? "/";
+}
+
+function actionsForAdminHref(href: string) {
+  if (href === "/admin") return ADMIN_ROUTE_ACTIONS.dashboard;
+  if (href.startsWith("/admin/activity")) return ADMIN_ROUTE_ACTIONS.activity;
+  if (href.startsWith("/admin/logs")) return ADMIN_ROUTE_ACTIONS.logs;
+  if (href.startsWith("/admin/libraries")) return ADMIN_ROUTE_ACTIONS.libraries;
+  if (href.startsWith("/admin/maintenance")) return ADMIN_ROUTE_ACTIONS.maintenance;
+  if (href.startsWith("/admin/collections")) return ADMIN_ROUTE_ACTIONS.collections;
+  if (href.startsWith("/admin/sections")) return ADMIN_ROUTE_ACTIONS.sections;
+  if (href.startsWith("/admin/requests")) return ADMIN_ROUTE_ACTIONS.requests;
+  if (href.startsWith("/admin/autoscan")) return ADMIN_ROUTE_ACTIONS.autoscan;
+  if (href.startsWith("/admin/history-import")) return ADMIN_ROUTE_ACTIONS.historyImport;
+  if (href.startsWith("/admin/history")) return ADMIN_ROUTE_ACTIONS.history;
+  if (href.startsWith("/admin/marker-history")) return ADMIN_ROUTE_ACTIONS.markerHistory;
+  if (href.startsWith("/admin/access-groups")) return ADMIN_ROUTE_ACTIONS.accessGroups;
+  if (href.startsWith("/admin/users")) return ADMIN_ROUTE_ACTIONS.users;
+  if (href.startsWith("/admin/devices")) return ADMIN_ROUTE_ACTIONS.devices;
+  if (href.startsWith("/admin/nodes")) return ADMIN_ROUTE_ACTIONS.nodes;
+  if (href.startsWith("/admin/plugins")) return ADMIN_ROUTE_ACTIONS.plugins;
+  if (href.startsWith("/admin/settings")) return ADMIN_ROUTE_ACTIONS.settings;
+  if (href.startsWith("/admin/recommendations")) return ADMIN_ROUTE_ACTIONS.recommendations;
+  if (href.startsWith("/admin/api-keys")) return ADMIN_ROUTE_ACTIONS.apiKeys;
+  if (href.startsWith("/admin/subtitles")) return ADMIN_ROUTE_ACTIONS.subtitles;
+  if (href.startsWith("/admin/tasks")) return ADMIN_ROUTE_ACTIONS.tasks;
+  return undefined;
+}

--- a/web/src/lib/adminNavigation.ts
+++ b/web/src/lib/adminNavigation.ts
@@ -17,6 +17,7 @@ import {
   ScrollText,
   Send,
   Server,
+  ShieldCheck,
   SkipForward,
   SlidersHorizontal,
   Users,
@@ -149,6 +150,13 @@ export const ADMIN_NAV_SECTIONS: AdminNavGroup[] = [
         keywords: ["accounts", "profiles", "roles", "permissions"],
         icon: Users,
         href: "/admin/users",
+      },
+      {
+        label: "Access Groups",
+        description: "Built-in and custom authorization groups.",
+        keywords: ["acl", "groups", "roles", "permissions", "access"],
+        icon: ShieldCheck,
+        href: "/admin/access-groups",
       },
       {
         label: "Devices",

--- a/web/src/pages/AdminAccessGroups.test.tsx
+++ b/web/src/pages/AdminAccessGroups.test.tsx
@@ -1,0 +1,51 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { renderToStaticMarkup } from "react-dom/server";
+import { describe, expect, it, vi } from "vitest";
+import type { AdminAccessGroup } from "@/api/types";
+import AdminAccessGroups from "./AdminAccessGroups";
+
+const groups: AdminAccessGroup[] = [
+  {
+    id: 1,
+    slug: "standard_user",
+    name: "User",
+    description: "Default user access",
+    policy: {},
+    built_in: true,
+    protected: true,
+    member_count: 3,
+  },
+];
+
+vi.mock("@/hooks/queries/admin/users", () => ({
+  useAdminAccessGroups: () => ({ data: groups, isLoading: false }),
+  useAdminAccessGroup: () => ({ data: undefined, isLoading: false }),
+  useCreateAdminAccessGroup: () => ({ isPending: false, mutate: vi.fn() }),
+  useUpdateAdminAccessGroup: () => ({ isPending: false, mutate: vi.fn() }),
+  useDeleteAdminAccessGroup: () => ({ isPending: false, mutate: vi.fn() }),
+}));
+
+vi.mock("@/hooks/queries/admin/libraries", () => ({
+  useAdminLibraries: () => ({ data: [] }),
+}));
+
+describe("AdminAccessGroups", () => {
+  it("renders clickable group rows with member counts", () => {
+    const markup = renderToStaticMarkup(<AdminAccessGroups />);
+
+    expect(markup).toContain(">Members<");
+    expect(markup).toContain(">3<");
+    expect(markup).toContain('aria-label="View User access group"');
+  });
+
+  it("renders helper controls for presets, actions, and policy limits", async () => {
+    render(<AdminAccessGroups />);
+
+    await userEvent.click(screen.getByRole("button", { name: "Add Group" }));
+
+    expect(screen.getByLabelText(/^Junior Admin preset help:/)).toBeInTheDocument();
+    expect(screen.getByLabelText(/^Server View help:/)).toBeInTheDocument();
+    expect(screen.getByLabelText(/^Max Streams help:/)).toBeInTheDocument();
+  });
+});

--- a/web/src/pages/AdminAccessGroups.tsx
+++ b/web/src/pages/AdminAccessGroups.tsx
@@ -1,0 +1,786 @@
+import { useEffect, useId, useState } from "react";
+import type { FormEvent } from "react";
+import type {
+  AdminACLCondition,
+  AdminACLPolicy,
+  AdminAccessGroup,
+  AdminAccessGroupDetail,
+  AdminAccessGroupWriteRequest,
+} from "@/api/types";
+import {
+  useAdminAccessGroup,
+  useAdminAccessGroups,
+  useCreateAdminAccessGroup,
+  useDeleteAdminAccessGroup,
+  useUpdateAdminAccessGroup,
+} from "@/hooks/queries/admin/users";
+import { useAdminLibraries } from "@/hooks/queries/admin/libraries";
+import { LibraryAccessSelector } from "@/components/LibraryAccessSelector";
+import { ConfirmDialog } from "@/components/ConfirmDialog";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogTrigger,
+} from "@/components/ui/dialog";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import { Skeleton } from "@/components/ui/skeleton";
+import { Switch } from "@/components/ui/switch";
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table";
+import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@/components/ui/tooltip";
+import { Info, Pencil, Plus, Shield, Trash2 } from "lucide-react";
+import {
+  ACCESS_GROUP_ACTION_CATEGORIES,
+  ACCESS_GROUP_ACTIONS,
+  ACCESS_GROUP_PRESETS,
+  accessGroupActionLabel,
+  accessGroupSlugFromName,
+  buildAccessGroupRuleDrafts,
+  type AccessGroupAction,
+} from "./adminAccessGroupsModel";
+
+const MEDIA_TYPE_OPTIONS = [
+  {
+    value: "movie",
+    label: "Movies",
+    description: "Applies this group only to movie library items.",
+  },
+  {
+    value: "series",
+    label: "Series",
+    description: "Applies this group only to series and episode library items.",
+  },
+  {
+    value: "audiobook",
+    label: "Audiobooks",
+    description: "Applies this group only to audiobook library items.",
+  },
+  {
+    value: "ebook",
+    label: "Ebooks",
+    description: "Applies this group only to ebook library items.",
+  },
+] as const;
+
+const PLAYBACK_QUALITY_OPTIONS = ["480P", "720P", "1080P", "2160P", "4320P"] as const;
+
+const LIBRARY_ACCESS_HELP =
+  "Limits the group to selected libraries. All libraries means this group can apply everywhere.";
+const MEDIA_TYPES_HELP =
+  "Limits matching rules to selected media types. Leave all off to apply the rules to every media type.";
+const POLICY_LIMIT_HELP =
+  "Limits from multiple groups cascade; the most permissive explicit value wins.";
+const MAX_QUALITY_HELP =
+  "Caps the highest playback quality this group can receive. Any leaves quality unrestricted.";
+const MAX_STREAMS_HELP =
+  "Maximum simultaneous playback sessions allowed by this group. Zero or blank means no explicit group limit.";
+const MAX_TRANSCODES_HELP =
+  "Maximum simultaneous transcode sessions allowed by this group. Zero or blank means no explicit group limit.";
+const MAX_PROFILES_HELP =
+  "Maximum profiles allowed on a user account through this group. Blank inherits the normal default.";
+
+const supportedActions = new Set<string>(ACCESS_GROUP_ACTIONS.map((item) => item.action));
+
+export default function AdminAccessGroups() {
+  const { data: groups = [], isLoading } = useAdminAccessGroups();
+  const [dialogOpen, setDialogOpen] = useState(false);
+  const [editingGroup, setEditingGroup] = useState<AdminAccessGroup | null>(null);
+  const [viewingGroup, setViewingGroup] = useState<AdminAccessGroup | null>(null);
+  const [deleteGroup, setDeleteGroup] = useState<AdminAccessGroup | null>(null);
+  const deleteMutation = useDeleteAdminAccessGroup();
+
+  if (isLoading) {
+    return (
+      <div className="space-y-3">
+        <Skeleton className="h-10 w-full rounded-lg" />
+        {Array.from({ length: 5 }).map((_, i) => (
+          <Skeleton key={i} className="h-12 w-full rounded-lg" />
+        ))}
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-6">
+      <ConfirmDialog
+        open={deleteGroup !== null}
+        onOpenChange={(open) => {
+          if (!open) setDeleteGroup(null);
+        }}
+        title="Delete access group"
+        description={`Delete access group "${deleteGroup?.name}"? This action cannot be undone.`}
+        confirmLabel="Delete"
+        variant="destructive"
+        onConfirm={() => {
+          if (deleteGroup) deleteMutation.mutate(deleteGroup.slug);
+          setDeleteGroup(null);
+        }}
+      />
+      <Dialog
+        open={viewingGroup !== null}
+        onOpenChange={(open) => {
+          if (!open) setViewingGroup(null);
+        }}
+      >
+        <DialogContent className="sm:max-w-4xl">
+          <DialogHeader>
+            <DialogTitle>{viewingGroup?.name ?? "Access Group"}</DialogTitle>
+          </DialogHeader>
+          {viewingGroup && <AccessGroupDetailPanel group={viewingGroup} />}
+        </DialogContent>
+      </Dialog>
+
+      <div className="page-header">
+        <div className="space-y-3">
+          <h1 className="page-title text-[clamp(2rem,4vw,3rem)]">Access Groups</h1>
+          <p className="page-subtitle text-sm sm:text-base">
+            Manage built-in and custom authorization groups.
+          </p>
+        </div>
+        <Dialog
+          open={dialogOpen}
+          onOpenChange={(open) => {
+            setDialogOpen(open);
+            if (!open) setEditingGroup(null);
+          }}
+        >
+          <DialogTrigger asChild>
+            <Button
+              size="sm"
+              onClick={() => {
+                setEditingGroup(null);
+              }}
+            >
+              <Plus className="mr-1 h-4 w-4" /> Add Group
+            </Button>
+          </DialogTrigger>
+          <DialogContent className="sm:max-w-3xl">
+            <DialogHeader>
+              <DialogTitle>
+                {editingGroup ? "Edit Access Group" : "Create Access Group"}
+              </DialogTitle>
+            </DialogHeader>
+            <AccessGroupForm
+              key={editingGroup?.slug ?? "new"}
+              group={editingGroup}
+              onClose={() => {
+                setDialogOpen(false);
+                setEditingGroup(null);
+              }}
+            />
+          </DialogContent>
+        </Dialog>
+      </div>
+
+      <div className="surface-panel overflow-x-auto rounded-2xl border-0">
+        <Table>
+          <TableHeader>
+            <TableRow>
+              <TableHead>Name</TableHead>
+              <TableHead>Slug</TableHead>
+              <TableHead>Type</TableHead>
+              <TableHead>Members</TableHead>
+              <TableHead>Description</TableHead>
+              <TableHead className="w-24">Actions</TableHead>
+            </TableRow>
+          </TableHeader>
+          <TableBody>
+            {groups.length === 0 && (
+              <TableRow>
+                <TableCell colSpan={6} className="text-muted-foreground text-center">
+                  No access groups found.
+                </TableCell>
+              </TableRow>
+            )}
+            {groups.map((group) => (
+              <TableRow key={group.slug}>
+                <TableCell className="font-medium">
+                  <div className="flex items-center gap-2">
+                    {group.protected && <Shield className="text-muted-foreground h-4 w-4" />}
+                    <button
+                      type="button"
+                      className="hover:text-primary text-left hover:underline"
+                      aria-label={`View ${group.name} access group`}
+                      onClick={() => setViewingGroup(group)}
+                    >
+                      {group.name}
+                    </button>
+                  </div>
+                </TableCell>
+                <TableCell>
+                  <code className="bg-muted rounded px-1.5 py-0.5 font-mono text-xs">
+                    {group.slug}
+                  </code>
+                </TableCell>
+                <TableCell>
+                  <Badge variant={group.built_in ? "default" : "secondary"}>
+                    {group.built_in ? "Built-in" : "Custom"}
+                  </Badge>
+                </TableCell>
+                <TableCell>{group.member_count}</TableCell>
+                <TableCell className="text-muted-foreground max-w-md text-sm">
+                  {group.description}
+                </TableCell>
+                <TableCell>
+                  <div className="flex items-center gap-1">
+                    <Button
+                      variant="ghost"
+                      size="icon"
+                      className="h-7 w-7"
+                      aria-label={`Edit access group ${group.name}`}
+                      disabled={group.protected}
+                      onClick={() => {
+                        setEditingGroup(group);
+                        setDialogOpen(true);
+                      }}
+                    >
+                      <Pencil className="h-3.5 w-3.5" aria-hidden="true" />
+                    </Button>
+                    <Button
+                      variant="ghost"
+                      size="icon"
+                      className="h-7 w-7"
+                      aria-label={`Delete access group ${group.name}`}
+                      disabled={group.built_in || group.protected}
+                      onClick={() => setDeleteGroup(group)}
+                    >
+                      <Trash2 className="h-3.5 w-3.5" aria-hidden="true" />
+                    </Button>
+                  </div>
+                </TableCell>
+              </TableRow>
+            ))}
+          </TableBody>
+        </Table>
+      </div>
+    </div>
+  );
+}
+
+function AccessGroupDetailPanel({ group }: { group: AdminAccessGroup }) {
+  const { data: detail, isLoading } = useAdminAccessGroup(group.slug);
+
+  if (isLoading || !detail) {
+    return (
+      <div className="space-y-4">
+        <Skeleton className="h-20 w-full rounded-md" />
+        <Skeleton className="h-32 w-full rounded-md" />
+        <Skeleton className="h-32 w-full rounded-md" />
+      </div>
+    );
+  }
+
+  return (
+    <div className="max-h-[72vh] space-y-5 overflow-y-auto pr-1">
+      <div className="grid gap-3 sm:grid-cols-3">
+        <div className="border-border rounded-md border px-3 py-2">
+          <div className="text-muted-foreground text-xs font-medium uppercase">Slug</div>
+          <code className="mt-1 block font-mono text-sm">{detail.slug}</code>
+        </div>
+        <div className="border-border rounded-md border px-3 py-2">
+          <div className="text-muted-foreground text-xs font-medium uppercase">Type</div>
+          <div className="mt-1">
+            <Badge variant={detail.built_in ? "default" : "secondary"}>
+              {detail.built_in ? "Built-in" : "Custom"}
+            </Badge>
+          </div>
+        </div>
+        <div className="border-border rounded-md border px-3 py-2">
+          <div className="text-muted-foreground text-xs font-medium uppercase">Members</div>
+          <div className="mt-1 text-sm font-medium">{detail.member_count}</div>
+        </div>
+      </div>
+
+      {detail.description && <p className="text-muted-foreground text-sm">{detail.description}</p>}
+
+      <section className="space-y-2">
+        <h3 className="text-sm font-semibold">Members</h3>
+        <div className="border-border overflow-hidden rounded-md border">
+          <Table>
+            <TableHeader>
+              <TableRow>
+                <TableHead>Username</TableHead>
+                <TableHead>Email</TableHead>
+                <TableHead>Role</TableHead>
+                <TableHead>Status</TableHead>
+              </TableRow>
+            </TableHeader>
+            <TableBody>
+              {detail.members.length === 0 ? (
+                <TableRow>
+                  <TableCell colSpan={4} className="text-muted-foreground text-center">
+                    No members in this group.
+                  </TableCell>
+                </TableRow>
+              ) : (
+                detail.members.map((member) => (
+                  <TableRow key={member.user_id}>
+                    <TableCell className="font-medium">{member.username}</TableCell>
+                    <TableCell>{member.email}</TableCell>
+                    <TableCell>
+                      <Badge variant={member.role === "admin" ? "default" : "secondary"}>
+                        {member.role}
+                      </Badge>
+                    </TableCell>
+                    <TableCell>
+                      <Badge variant={member.enabled ? "outline" : "destructive"}>
+                        {member.enabled ? "Active" : "Disabled"}
+                      </Badge>
+                    </TableCell>
+                  </TableRow>
+                ))
+              )}
+            </TableBody>
+          </Table>
+        </div>
+      </section>
+
+      <section className="space-y-2">
+        <h3 className="text-sm font-semibold">Rules</h3>
+        <div className="border-border overflow-hidden rounded-md border">
+          <Table>
+            <TableHeader>
+              <TableRow>
+                <TableHead>Action</TableHead>
+                <TableHead>Effect</TableHead>
+                <TableHead>Resource</TableHead>
+                <TableHead>Priority</TableHead>
+              </TableRow>
+            </TableHeader>
+            <TableBody>
+              {detail.rules.length === 0 ? (
+                <TableRow>
+                  <TableCell colSpan={4} className="text-muted-foreground text-center">
+                    No rules defined.
+                  </TableCell>
+                </TableRow>
+              ) : (
+                detail.rules.map((rule) => (
+                  <TableRow key={rule.id}>
+                    <TableCell>
+                      <div className="font-medium">{accessGroupActionLabel(rule.action)}</div>
+                      <div className="text-muted-foreground font-mono text-xs">{rule.action}</div>
+                    </TableCell>
+                    <TableCell>
+                      <Badge variant={rule.effect === "allow" ? "outline" : "destructive"}>
+                        {rule.effect}
+                      </Badge>
+                    </TableCell>
+                    <TableCell className="font-mono text-xs">
+                      {rule.resource_type}:{rule.resource_id}
+                    </TableCell>
+                    <TableCell>{rule.priority}</TableCell>
+                  </TableRow>
+                ))
+              )}
+            </TableBody>
+          </Table>
+        </div>
+      </section>
+    </div>
+  );
+}
+
+function AccessGroupForm({
+  group,
+  onClose,
+}: {
+  group: AdminAccessGroup | null;
+  onClose: () => void;
+}) {
+  const { data: detail, isLoading } = useAdminAccessGroup(group?.slug ?? null);
+  const { data: libraries = [] } = useAdminLibraries();
+  const createMutation = useCreateAdminAccessGroup();
+  const updateMutation = useUpdateAdminAccessGroup();
+  const [name, setName] = useState(group?.name ?? "");
+  const [slug, setSlug] = useState(group?.slug ?? "");
+  const [slugTouched, setSlugTouched] = useState(Boolean(group));
+  const [description, setDescription] = useState(group?.description ?? "");
+  const [selectedActions, setSelectedActions] = useState<AccessGroupAction[]>([]);
+  const [libraryIDs, setLibraryIDs] = useState<number[] | null>(null);
+  const [mediaTypes, setMediaTypes] = useState<string[]>([]);
+  const [maxPlaybackQuality, setMaxPlaybackQuality] = useState("");
+  const [maxStreams, setMaxStreams] = useState("");
+  const [maxTranscodes, setMaxTranscodes] = useState("");
+  const [maxProfiles, setMaxProfiles] = useState("");
+  const nameId = useId();
+  const slugId = useId();
+  const descriptionId = useId();
+  const maxPlaybackQualityId = useId();
+  const maxStreamsId = useId();
+  const maxTranscodesId = useId();
+  const maxProfilesId = useId();
+  const isPending = createMutation.isPending || updateMutation.isPending;
+
+  useEffect(() => {
+    if (!detail) return;
+    setName(detail.name);
+    setSlug(detail.slug);
+    setDescription(detail.description);
+    const actions = detail.rules
+      .map((rule) => rule.action)
+      .filter((action): action is AccessGroupAction => supportedActions.has(action));
+    setSelectedActions(actions);
+    const conditions = firstRuleConditions(detail);
+    setLibraryIDs(conditions.library_ids ?? null);
+    setMediaTypes(conditions.media_types ?? []);
+    const policy = detail.policy ?? {};
+    setMaxPlaybackQuality(policy.max_playback_quality ?? "");
+    setMaxStreams(policy.max_streams != null ? String(policy.max_streams) : "");
+    setMaxTranscodes(policy.max_transcodes != null ? String(policy.max_transcodes) : "");
+    setMaxProfiles(policy.max_profiles != null ? String(policy.max_profiles) : "");
+  }, [detail]);
+
+  function handleNameChange(value: string) {
+    setName(value);
+    if (!group && !slugTouched) {
+      setSlug(accessGroupSlugFromName(value));
+    }
+  }
+
+  function toggleAction(action: AccessGroupAction, checked: boolean) {
+    setSelectedActions((current) => {
+      if (checked) {
+        return current.includes(action) ? current : [...current, action];
+      }
+      return current.filter((value) => value !== action);
+    });
+  }
+
+  function applyPreset(actions: readonly AccessGroupAction[]) {
+    setSelectedActions(actions.filter((action) => supportedActions.has(action)));
+  }
+
+  function toggleMediaType(mediaType: string, checked: boolean) {
+    setMediaTypes((current) => {
+      if (checked) {
+        return current.includes(mediaType) ? current : [...current, mediaType];
+      }
+      return current.filter((value) => value !== mediaType);
+    });
+  }
+
+  function buildConditions(): AdminACLCondition {
+    const conditions: AdminACLCondition = {};
+    if (libraryIDs !== null) conditions.library_ids = libraryIDs;
+    if (mediaTypes.length > 0) conditions.media_types = mediaTypes;
+    return conditions;
+  }
+
+  function buildPolicy(): AdminACLPolicy {
+    const policy: AdminACLPolicy = {};
+    if (maxPlaybackQuality) policy.max_playback_quality = maxPlaybackQuality;
+    if (maxStreams.trim() !== "") policy.max_streams = Number(maxStreams);
+    if (maxTranscodes.trim() !== "") policy.max_transcodes = Number(maxTranscodes);
+    if (maxProfiles.trim() !== "") policy.max_profiles = Number(maxProfiles);
+    return policy;
+  }
+
+  function handleSubmit(event: FormEvent) {
+    event.preventDefault();
+    const body: AdminAccessGroupWriteRequest = {
+      slug,
+      name,
+      description,
+      policy: buildPolicy(),
+      rules: buildAccessGroupRuleDrafts(selectedActions, buildConditions()),
+    };
+    if (group) {
+      updateMutation.mutate({ slug: group.slug, body }, { onSuccess: onClose });
+    } else {
+      createMutation.mutate(body, { onSuccess: onClose });
+    }
+  }
+
+  if (group && isLoading) {
+    return (
+      <div className="space-y-3">
+        <Skeleton className="h-9 w-full rounded-md" />
+        <Skeleton className="h-36 w-full rounded-md" />
+      </div>
+    );
+  }
+
+  return (
+    <TooltipProvider delayDuration={150}>
+      <form onSubmit={handleSubmit} className="flex max-h-[74vh] flex-col">
+        <div className="min-h-0 flex-1 space-y-5 overflow-y-auto pr-1">
+          <div className="grid gap-3 sm:grid-cols-2">
+            <div className="space-y-2">
+              <Label htmlFor={nameId}>Name</Label>
+              <Input
+                id={nameId}
+                value={name}
+                onChange={(event) => handleNameChange(event.target.value)}
+                required
+              />
+            </div>
+            <div className="space-y-2">
+              <Label htmlFor={slugId}>Slug</Label>
+              <Input
+                id={slugId}
+                value={slug}
+                onChange={(event) => {
+                  setSlugTouched(true);
+                  setSlug(accessGroupSlugFromName(event.target.value));
+                }}
+                disabled={Boolean(group)}
+                required
+              />
+            </div>
+          </div>
+          <div className="space-y-2">
+            <Label htmlFor={descriptionId}>Description</Label>
+            <Input
+              id={descriptionId}
+              value={description}
+              onChange={(event) => setDescription(event.target.value)}
+            />
+          </div>
+
+          <div className="border-border rounded-md border px-3 py-3">
+            <div className="flex flex-wrap items-center justify-between gap-2">
+              <LabelWithHelp
+                label="Actions"
+                description="Choose the capabilities this group grants. Library and media filters below narrow where matching rules apply."
+              />
+              <div className="flex flex-wrap gap-2">
+                {ACCESS_GROUP_PRESETS.map((preset) => (
+                  <div key={preset.id} className="flex items-center gap-1">
+                    <Tooltip>
+                      <TooltipTrigger asChild>
+                        <Button
+                          type="button"
+                          variant="outline"
+                          size="sm"
+                          className="h-8"
+                          title={preset.description}
+                          onClick={() => applyPreset(preset.actions)}
+                        >
+                          {preset.label}
+                        </Button>
+                      </TooltipTrigger>
+                      <TooltipContent side="top">{preset.description}</TooltipContent>
+                    </Tooltip>
+                    <HelpTooltip
+                      label={`${preset.label} preset`}
+                      description={preset.description}
+                    />
+                  </div>
+                ))}
+              </div>
+            </div>
+            <div className="mt-3 space-y-4">
+              {ACCESS_GROUP_ACTION_CATEGORIES.map((category) => {
+                const actions = ACCESS_GROUP_ACTIONS.filter(
+                  (item) => item.category === category.id,
+                );
+                if (actions.length === 0) return null;
+                return (
+                  <div key={category.id} className="space-y-2">
+                    <CategoryLabel label={category.label} description={category.description} />
+                    <div className="grid gap-2 sm:grid-cols-2">
+                      {actions.map((item) => (
+                        <div
+                          key={item.action}
+                          className="border-border flex min-h-11 items-center justify-between rounded-md border px-3 py-2"
+                        >
+                          <div className="flex min-w-0 items-center gap-1.5">
+                            <Label htmlFor={`acl-action-${item.action}`}>{item.label}</Label>
+                            <HelpTooltip label={item.label} description={item.description} />
+                          </div>
+                          <Switch
+                            id={`acl-action-${item.action}`}
+                            checked={selectedActions.includes(item.action)}
+                            onCheckedChange={(checked) => toggleAction(item.action, checked)}
+                          />
+                        </div>
+                      ))}
+                    </div>
+                  </div>
+                );
+              })}
+            </div>
+          </div>
+
+          <LibraryAccessSelector
+            libraries={libraries}
+            value={libraryIDs}
+            onChange={setLibraryIDs}
+            labelAccessory={
+              <HelpTooltip label="Library Access" description={LIBRARY_ACCESS_HELP} />
+            }
+          />
+
+          <div className="border-border rounded-md border px-3 py-3">
+            <LabelWithHelp label="Media Types" description={MEDIA_TYPES_HELP} />
+            <div className="mt-3 grid gap-2 sm:grid-cols-2">
+              {MEDIA_TYPE_OPTIONS.map((item) => (
+                <div
+                  key={item.value}
+                  className="border-border flex min-h-11 items-center justify-between rounded-md border px-3 py-2"
+                >
+                  <div className="flex min-w-0 items-center gap-1.5">
+                    <Label htmlFor={`acl-media-${item.value}`}>{item.label}</Label>
+                    <HelpTooltip label={item.label} description={item.description} />
+                  </div>
+                  <Switch
+                    id={`acl-media-${item.value}`}
+                    checked={mediaTypes.includes(item.value)}
+                    onCheckedChange={(checked) => toggleMediaType(item.value, checked)}
+                  />
+                </div>
+              ))}
+            </div>
+          </div>
+
+          <div className="border-border rounded-md border px-3 py-3">
+            <LabelWithHelp label="Policy Limits" description={POLICY_LIMIT_HELP} />
+            <div className="mt-3 grid gap-3 sm:grid-cols-4">
+              <div className="space-y-2">
+                <LabelWithHelp
+                  label="Max Quality"
+                  description={MAX_QUALITY_HELP}
+                  htmlFor={maxPlaybackQualityId}
+                />
+                <Select
+                  value={maxPlaybackQuality || "none"}
+                  onValueChange={(value) => setMaxPlaybackQuality(value === "none" ? "" : value)}
+                >
+                  <SelectTrigger id={maxPlaybackQualityId}>
+                    <SelectValue />
+                  </SelectTrigger>
+                  <SelectContent>
+                    <SelectItem value="none">Any</SelectItem>
+                    {PLAYBACK_QUALITY_OPTIONS.map((quality) => (
+                      <SelectItem key={quality} value={quality}>
+                        {quality}
+                      </SelectItem>
+                    ))}
+                  </SelectContent>
+                </Select>
+              </div>
+              <div className="space-y-2">
+                <LabelWithHelp
+                  label="Max Streams"
+                  description={MAX_STREAMS_HELP}
+                  htmlFor={maxStreamsId}
+                />
+                <Input
+                  id={maxStreamsId}
+                  type="number"
+                  min={0}
+                  value={maxStreams}
+                  onChange={(event) => setMaxStreams(event.target.value)}
+                />
+              </div>
+              <div className="space-y-2">
+                <LabelWithHelp
+                  label="Max Transcodes"
+                  description={MAX_TRANSCODES_HELP}
+                  htmlFor={maxTranscodesId}
+                />
+                <Input
+                  id={maxTranscodesId}
+                  type="number"
+                  min={0}
+                  value={maxTranscodes}
+                  onChange={(event) => setMaxTranscodes(event.target.value)}
+                />
+              </div>
+              <div className="space-y-2">
+                <LabelWithHelp
+                  label="Max Profiles"
+                  description={MAX_PROFILES_HELP}
+                  htmlFor={maxProfilesId}
+                />
+                <Input
+                  id={maxProfilesId}
+                  type="number"
+                  min={1}
+                  value={maxProfiles}
+                  onChange={(event) => setMaxProfiles(event.target.value)}
+                />
+              </div>
+            </div>
+          </div>
+        </div>
+
+        <div className="border-border mt-5 flex justify-end gap-2 border-t pt-4">
+          <Button type="button" variant="outline" onClick={onClose}>
+            Cancel
+          </Button>
+          <Button type="submit" disabled={isPending}>
+            {group ? "Save Group" : "Create Group"}
+          </Button>
+        </div>
+      </form>
+    </TooltipProvider>
+  );
+}
+
+function LabelWithHelp({
+  label,
+  description,
+  htmlFor,
+}: {
+  label: string;
+  description: string;
+  htmlFor?: string;
+}) {
+  return (
+    <div className="flex items-center gap-1.5">
+      <Label htmlFor={htmlFor}>{label}</Label>
+      <HelpTooltip label={label} description={description} />
+    </div>
+  );
+}
+
+function CategoryLabel({ label, description }: { label: string; description: string }) {
+  return (
+    <div className="text-muted-foreground flex items-center gap-1.5 text-xs font-medium uppercase">
+      <span>{label}</span>
+      <HelpTooltip label={label} description={description} />
+    </div>
+  );
+}
+
+function HelpTooltip({ label, description }: { label: string; description: string }) {
+  return (
+    <Tooltip>
+      <TooltipTrigger asChild>
+        <button
+          type="button"
+          className="text-muted-foreground hover:text-foreground focus-visible:ring-ring/50 inline-flex h-5 w-5 shrink-0 items-center justify-center rounded-full transition-colors focus-visible:ring-[3px] focus-visible:outline-none"
+          aria-label={`${label} help: ${description}`}
+          title={description}
+        >
+          <Info className="h-3.5 w-3.5" aria-hidden="true" />
+        </button>
+      </TooltipTrigger>
+      <TooltipContent side="top">{description}</TooltipContent>
+    </Tooltip>
+  );
+}
+
+function firstRuleConditions(detail: AdminAccessGroupDetail): AdminACLCondition {
+  return detail.rules[0]?.conditions ?? {};
+}

--- a/web/src/pages/AdminUserDetail.tsx
+++ b/web/src/pages/AdminUserDetail.tsx
@@ -72,6 +72,7 @@ import {
   hasAssignedPermission,
   setAssignedPermission,
 } from "@/lib/permissions";
+import { useAdminAccess } from "@/hooks/useAdminCapabilities";
 import { RegistrySettingControl } from "@/components/settings/RegistrySettingControl";
 import { formatSettingValue, getSettingDefinition } from "@/lib/settingsManifest";
 import {
@@ -92,6 +93,7 @@ export default function AdminUserDetail() {
   const navigate = useNavigate();
   const { beginImpersonation } = useAuth();
   const { data: user, isLoading, error } = useAdminUser(userId);
+  const adminAccess = useAdminAccess();
   const [editOpen, setEditOpen] = useState(false);
   const [confirmDeleteOpen, setConfirmDeleteOpen] = useState(false);
   const [confirmImpersonateOpen, setConfirmImpersonateOpen] = useState(false);
@@ -102,7 +104,11 @@ export default function AdminUserDetail() {
   if (error || !user)
     return <div className="page-shell text-destructive py-8">User not found.</div>;
 
-  const impersonationDisabled = user.role === "admin" || !user.enabled;
+  const canManageUsers = adminAccess.can("users.manage");
+  const canManageUserAccessPolicy = adminAccess.can("security.manage");
+  const canEditUser = canManageUsers && (user.role !== "admin" || canManageUserAccessPolicy);
+  const impersonationDisabled =
+    !adminAccess.can("users.impersonate") || user.role === "admin" || !user.enabled;
 
   function handleDelete() {
     setConfirmDeleteOpen(true);
@@ -148,7 +154,12 @@ export default function AdminUserDetail() {
           </Button>
           <Dialog open={editOpen} onOpenChange={setEditOpen}>
             <DialogTrigger asChild>
-              <Button variant="outline" size="sm" className="flex-1 sm:flex-none">
+              <Button
+                variant="outline"
+                size="sm"
+                className="flex-1 sm:flex-none"
+                disabled={!canEditUser}
+              >
                 <Pencil className="mr-1 h-3.5 w-3.5" /> Edit
               </Button>
             </DialogTrigger>
@@ -164,7 +175,7 @@ export default function AdminUserDetail() {
             size="sm"
             className="flex-1 sm:flex-none"
             onClick={handleDelete}
-            disabled={deleteMutation.isPending}
+            disabled={!canEditUser || deleteMutation.isPending}
           >
             Delete
           </Button>
@@ -503,6 +514,7 @@ function IPHistoryTab({ userId }: { userId: number }) {
 }
 
 function UserSettingsTab({ userId }: { userId: number }) {
+  const canManageUsers = useAdminAccess().can("users.manage");
   const { data: settings = [], isLoading } = useAdminUserSettings(userId);
   const updateSetting = useUpdateAdminUserSetting();
   const deleteSetting = useDeleteAdminUserSetting();
@@ -540,7 +552,7 @@ function UserSettingsTab({ userId }: { userId: number }) {
             <RegistrySettingControl
               definition={definition}
               value={entry.value}
-              disabled={updateSetting.isPending || deleteSetting.isPending}
+              disabled={!canManageUsers || updateSetting.isPending || deleteSetting.isPending}
               onChange={(value) =>
                 updateSetting.mutate({
                   userId,
@@ -553,7 +565,7 @@ function UserSettingsTab({ userId }: { userId: number }) {
             <Input
               key={`${entry.key}:${entry.value}`}
               defaultValue={entry.value}
-              disabled={updateSetting.isPending || deleteSetting.isPending}
+              disabled={!canManageUsers || updateSetting.isPending || deleteSetting.isPending}
               className="w-full min-w-[180px] sm:w-[220px]"
               onBlur={(event) => {
                 if (event.currentTarget.value === entry.value) return;
@@ -570,7 +582,7 @@ function UserSettingsTab({ userId }: { userId: number }) {
             size="sm"
             className="h-7 rounded-full px-2 text-xs"
             onClick={() => deleteSetting.mutate({ userId, key: entry.key })}
-            disabled={updateSetting.isPending || deleteSetting.isPending}
+            disabled={!canManageUsers || updateSetting.isPending || deleteSetting.isPending}
           >
             <RotateCcw className="mr-1 h-3 w-3" />
             Reset
@@ -609,6 +621,7 @@ function UserSettingsTab({ userId }: { userId: number }) {
 }
 
 function DeviceOverridesTab({ userId }: { userId: number }) {
+  const canManageUsers = useAdminAccess().can("users.manage");
   const { data: settings = [], isLoading } = useAdminUserDeviceSettings(userId);
   const updateSetting = useUpdateAdminUserDeviceSetting();
   const deleteSetting = useDeleteAdminUserDeviceSetting();
@@ -739,6 +752,7 @@ function DeviceOverridesTab({ userId }: { userId: number }) {
               </Button>
               <Button
                 size="sm"
+                disabled={!canManageUsers || updateSetting.isPending}
                 onClick={() => {
                   if (!jsonEditor) return;
                   updateSetting.mutate(
@@ -865,24 +879,26 @@ function DeviceOverridesTab({ userId }: { userId: number }) {
                     }),
                   )}
                   onResetProfile={(profileId, profileName) =>
-                    setDeviceToReset({ deviceId, profileId, profileName })
+                    canManageUsers && setDeviceToReset({ deviceId, profileId, profileName })
                   }
                   onEditJson={(setting) => {
+                    if (!canManageUsers) return;
                     setJsonEditor(setting);
                     setJsonValue(setting.value);
                   }}
-                  onResetSetting={(setting) => setSettingToReset(setting)}
-                  onChangeSetting={(setting, value) =>
+                  onResetSetting={(setting) => canManageUsers && setSettingToReset(setting)}
+                  onChangeSetting={(setting, value) => {
+                    if (!canManageUsers) return;
                     updateSetting.mutate({
                       userId,
                       profileId: setting.profile_id,
                       deviceId: setting.device_id,
                       key: setting.key,
                       value,
-                    })
-                  }
-                  updatePending={updateSetting.isPending}
-                  resetPending={deleteDevice.isPending}
+                    });
+                  }}
+                  updatePending={!canManageUsers || updateSetting.isPending}
+                  resetPending={!canManageUsers || deleteDevice.isPending}
                 />
               </section>
             );
@@ -894,7 +910,9 @@ function DeviceOverridesTab({ userId }: { userId: number }) {
 }
 
 function EditUserForm({ user, onClose }: { user: AdminUser; onClose: () => void }) {
-  const { data: libraries = [] } = useAdminLibraries();
+  const adminAccess = useAdminAccess();
+  const canManageUserAccessPolicy = adminAccess.can("security.manage");
+  const { data: libraries = [] } = useAdminLibraries(canManageUserAccessPolicy);
   const [username, setUsername] = useState(user.username);
   const [email, setEmail] = useState(user.email);
   const [password, setPassword] = useState("");
@@ -922,16 +940,18 @@ function EditUserForm({ user, onClose }: { user: AdminUser; onClose: () => void 
       username,
       email,
       role,
-      permissions,
       enabled,
-      library_ids: libraryIDs,
-      max_streams: maxStreams,
-      max_transcodes: maxTranscodes,
-      max_profiles: maxProfiles,
-      max_playback_quality: playbackQualityValueFromPreset(maxPlaybackQualityPreset),
-      download_allowed: downloadAllowed,
-      download_transcode_allowed: downloadTranscodeAllowed,
     };
+    if (canManageUserAccessPolicy) {
+      body.permissions = permissions;
+      body.library_ids = libraryIDs;
+      body.max_streams = maxStreams;
+      body.max_transcodes = maxTranscodes;
+      body.max_profiles = maxProfiles;
+      body.max_playback_quality = playbackQualityValueFromPreset(maxPlaybackQualityPreset);
+      body.download_allowed = downloadAllowed;
+      body.download_transcode_allowed = downloadTranscodeAllowed;
+    }
     if (password) body.password = password;
     updateMutation.mutate({ id: user.id, body }, { onSuccess: onClose });
   }
@@ -943,12 +963,16 @@ function EditUserForm({ user, onClose }: { user: AdminUser; onClose: () => void 
           <TabsTrigger value="account" className="flex-none px-1">
             Account
           </TabsTrigger>
-          <TabsTrigger value="access" className="flex-none px-1">
-            Access
-          </TabsTrigger>
-          <TabsTrigger value="limits" className="flex-none px-1">
-            Limits
-          </TabsTrigger>
+          {canManageUserAccessPolicy && (
+            <TabsTrigger value="access" className="flex-none px-1">
+              Access
+            </TabsTrigger>
+          )}
+          {canManageUserAccessPolicy && (
+            <TabsTrigger value="limits" className="flex-none px-1">
+              Limits
+            </TabsTrigger>
+          )}
         </TabsList>
 
         <div className="min-h-0 flex-1 overflow-y-auto pr-1">
@@ -983,7 +1007,11 @@ function EditUserForm({ user, onClose }: { user: AdminUser; onClose: () => void 
                   </SelectTrigger>
                   <SelectContent>
                     <SelectItem value="user">User</SelectItem>
-                    <SelectItem value="admin">Admin</SelectItem>
+                    {(canManageUserAccessPolicy || role === "admin") && (
+                      <SelectItem value="admin" disabled={!canManageUserAccessPolicy}>
+                        Admin
+                      </SelectItem>
+                    )}
                   </SelectContent>
                 </Select>
               </div>
@@ -1002,121 +1030,125 @@ function EditUserForm({ user, onClose }: { user: AdminUser; onClose: () => void 
             </div>
           </TabsContent>
 
-          <TabsContent value="access" className="mt-0 space-y-4">
-            <LibraryAccessSelector
-              libraries={libraries}
-              value={libraryIDs}
-              onChange={setLibraryIDs}
-            />
-            <div className="border-border flex items-center justify-between rounded-md border px-3 py-2">
-              <div>
-                <Label htmlFor={markerEditId}>Marker Editing</Label>
-                <p className="text-muted-foreground text-xs">
-                  Edit intro, recap, credits, and preview markers within assigned libraries.
-                </p>
-              </div>
-              <Switch
-                id={markerEditId}
-                checked={hasAssignedPermission(permissions, PERMISSION_MARKER_EDIT)}
-                onCheckedChange={(checked) =>
-                  setPermissions((current) =>
-                    setAssignedPermission(current, PERMISSION_MARKER_EDIT, checked),
-                  )
-                }
+          {canManageUserAccessPolicy && (
+            <TabsContent value="access" className="mt-0 space-y-4">
+              <LibraryAccessSelector
+                libraries={libraries}
+                value={libraryIDs}
+                onChange={setLibraryIDs}
               />
-            </div>
-            <div className="border-border flex items-center justify-between rounded-md border px-3 py-2">
-              <div>
-                <Label htmlFor={metadataCurationId}>Metadata Curation</Label>
-                <p className="text-muted-foreground text-xs">
-                  Edit, refresh, and rematch metadata within assigned libraries.
-                </p>
-              </div>
-              <Switch
-                id={metadataCurationId}
-                checked={hasAssignedPermission(permissions, PERMISSION_METADATA_CURATION)}
-                onCheckedChange={(checked) =>
-                  setPermissions((current) =>
-                    setAssignedPermission(current, PERMISSION_METADATA_CURATION, checked),
-                  )
-                }
-              />
-            </div>
-            <div className="grid gap-2 sm:grid-cols-2">
               <div className="border-border flex items-center justify-between rounded-md border px-3 py-2">
-                <Label>Downloads Allowed</Label>
-                <Switch checked={downloadAllowed} onCheckedChange={setDownloadAllowed} />
-              </div>
-              <div className="border-border flex items-center justify-between rounded-md border px-3 py-2">
-                <Label>Download Transcode Allowed</Label>
+                <div>
+                  <Label htmlFor={markerEditId}>Marker Editing</Label>
+                  <p className="text-muted-foreground text-xs">
+                    Edit intro, recap, credits, and preview markers within assigned libraries.
+                  </p>
+                </div>
                 <Switch
-                  checked={downloadTranscodeAllowed}
-                  onCheckedChange={setDownloadTranscodeAllowed}
+                  id={markerEditId}
+                  checked={hasAssignedPermission(permissions, PERMISSION_MARKER_EDIT)}
+                  onCheckedChange={(checked) =>
+                    setPermissions((current) =>
+                      setAssignedPermission(current, PERMISSION_MARKER_EDIT, checked),
+                    )
+                  }
                 />
               </div>
-            </div>
-          </TabsContent>
+              <div className="border-border flex items-center justify-between rounded-md border px-3 py-2">
+                <div>
+                  <Label htmlFor={metadataCurationId}>Metadata Curation</Label>
+                  <p className="text-muted-foreground text-xs">
+                    Edit, refresh, and rematch metadata within assigned libraries.
+                  </p>
+                </div>
+                <Switch
+                  id={metadataCurationId}
+                  checked={hasAssignedPermission(permissions, PERMISSION_METADATA_CURATION)}
+                  onCheckedChange={(checked) =>
+                    setPermissions((current) =>
+                      setAssignedPermission(current, PERMISSION_METADATA_CURATION, checked),
+                    )
+                  }
+                />
+              </div>
+              <div className="grid gap-2 sm:grid-cols-2">
+                <div className="border-border flex items-center justify-between rounded-md border px-3 py-2">
+                  <Label>Downloads Allowed</Label>
+                  <Switch checked={downloadAllowed} onCheckedChange={setDownloadAllowed} />
+                </div>
+                <div className="border-border flex items-center justify-between rounded-md border px-3 py-2">
+                  <Label>Download Transcode Allowed</Label>
+                  <Switch
+                    checked={downloadTranscodeAllowed}
+                    onCheckedChange={setDownloadTranscodeAllowed}
+                  />
+                </div>
+              </div>
+            </TabsContent>
+          )}
 
-          <TabsContent value="limits" className="mt-0 space-y-4">
-            <div className="grid gap-3 sm:grid-cols-2">
-              <div className="space-y-1">
-                <Label>Max Streams</Label>
-                <Input
-                  type="number"
-                  min={0}
-                  value={maxStreams}
-                  onChange={(e) => setMaxStreams(Number(e.target.value))}
-                />
-                <p className="text-muted-foreground text-xs">0 = unlimited</p>
+          {canManageUserAccessPolicy && (
+            <TabsContent value="limits" className="mt-0 space-y-4">
+              <div className="grid gap-3 sm:grid-cols-2">
+                <div className="space-y-1">
+                  <Label>Max Streams</Label>
+                  <Input
+                    type="number"
+                    min={0}
+                    value={maxStreams}
+                    onChange={(e) => setMaxStreams(Number(e.target.value))}
+                  />
+                  <p className="text-muted-foreground text-xs">0 = unlimited</p>
+                </div>
+                <div className="space-y-1">
+                  <Label>Max Transcodes</Label>
+                  <Input
+                    type="number"
+                    min={0}
+                    value={maxTranscodes}
+                    onChange={(e) => setMaxTranscodes(Number(e.target.value))}
+                  />
+                  <p className="text-muted-foreground text-xs">0 = unlimited</p>
+                </div>
+                <div className="space-y-1">
+                  <Label>Max Profiles</Label>
+                  <Input
+                    type="number"
+                    min={1}
+                    value={maxProfiles}
+                    onChange={(e) => setMaxProfiles(Number(e.target.value))}
+                  />
+                </div>
+                <div className="space-y-1 sm:col-span-2">
+                  <Label>Max Playback Quality</Label>
+                  <Select
+                    value={maxPlaybackQualityPreset}
+                    onValueChange={(value) =>
+                      setMaxPlaybackQualityPreset(value as PlaybackQualityPreset)
+                    }
+                  >
+                    <SelectTrigger>
+                      <SelectValue />
+                    </SelectTrigger>
+                    <SelectContent>
+                      {PLAYBACK_QUALITY_OPTIONS.map((option) => (
+                        <SelectItem key={option.value} value={option.value}>
+                          {option.label}
+                        </SelectItem>
+                      ))}
+                    </SelectContent>
+                  </Select>
+                  <p className="text-muted-foreground text-xs">
+                    {
+                      PLAYBACK_QUALITY_OPTIONS.find(
+                        (option) => option.value === maxPlaybackQualityPreset,
+                      )?.description
+                    }
+                  </p>
+                </div>
               </div>
-              <div className="space-y-1">
-                <Label>Max Transcodes</Label>
-                <Input
-                  type="number"
-                  min={0}
-                  value={maxTranscodes}
-                  onChange={(e) => setMaxTranscodes(Number(e.target.value))}
-                />
-                <p className="text-muted-foreground text-xs">0 = unlimited</p>
-              </div>
-              <div className="space-y-1">
-                <Label>Max Profiles</Label>
-                <Input
-                  type="number"
-                  min={1}
-                  value={maxProfiles}
-                  onChange={(e) => setMaxProfiles(Number(e.target.value))}
-                />
-              </div>
-              <div className="space-y-1 sm:col-span-2">
-                <Label>Max Playback Quality</Label>
-                <Select
-                  value={maxPlaybackQualityPreset}
-                  onValueChange={(value) =>
-                    setMaxPlaybackQualityPreset(value as PlaybackQualityPreset)
-                  }
-                >
-                  <SelectTrigger>
-                    <SelectValue />
-                  </SelectTrigger>
-                  <SelectContent>
-                    {PLAYBACK_QUALITY_OPTIONS.map((option) => (
-                      <SelectItem key={option.value} value={option.value}>
-                        {option.label}
-                      </SelectItem>
-                    ))}
-                  </SelectContent>
-                </Select>
-                <p className="text-muted-foreground text-xs">
-                  {
-                    PLAYBACK_QUALITY_OPTIONS.find(
-                      (option) => option.value === maxPlaybackQualityPreset,
-                    )?.description
-                  }
-                </p>
-              </div>
-            </div>
-          </TabsContent>
+            </TabsContent>
+          )}
         </div>
       </Tabs>
 

--- a/web/src/pages/AdminUsers.test.tsx
+++ b/web/src/pages/AdminUsers.test.tsx
@@ -1,0 +1,81 @@
+import { renderToStaticMarkup } from "react-dom/server";
+import { MemoryRouter } from "react-router";
+import { describe, expect, it, vi } from "vitest";
+import type { AdminUser } from "@/api/types";
+import AdminUsers from "./AdminUsers";
+
+const users: AdminUser[] = [
+  {
+    id: 2,
+    username: "tom",
+    email: "tom@example.com",
+    role: "user",
+    permissions: [],
+    access_groups: [
+      {
+        id: 1,
+        slug: "standard_user",
+        name: "User",
+        description: "Default user access",
+        policy: {},
+        built_in: true,
+        protected: true,
+        member_count: 1,
+      },
+    ],
+    enabled: true,
+    library_ids: null,
+    max_playback_quality: "",
+    max_streams: 4,
+    max_transcodes: 1,
+    max_profiles: 5,
+    download_allowed: true,
+    download_transcode_allowed: false,
+    created_at: "2026-06-30T12:00:00Z",
+    updated_at: "2026-06-30T12:00:00Z",
+  },
+];
+
+vi.mock("@/hooks/queries/admin/users", () => ({
+  useAdminUsers: () => ({ data: users, isLoading: false }),
+  useAdminAccessGroups: () => ({ data: [], isLoading: false }),
+  useAdminUserAccessExplanation: () => ({ data: undefined, isLoading: false }),
+  useCreateUser: () => ({ isPending: false, mutate: vi.fn() }),
+  useUpdateUser: () => ({ isPending: false, mutate: vi.fn() }),
+  useDeleteUser: () => ({ isPending: false, mutate: vi.fn() }),
+}));
+
+vi.mock("@/hooks/useAdminCapabilities", () => ({
+  useAdminAccess: () => ({
+    actingAdmin: true,
+    actionSet: new Set<string>(),
+    can: () => true,
+    canAccessAdmin: true,
+    isLoading: false,
+  }),
+}));
+
+vi.mock("@/hooks/queries/admin/libraries", () => ({
+  useAdminLibraries: () => ({ data: [] }),
+}));
+
+vi.mock("@/hooks/queries/admin/settings", () => ({
+  useAdminServerSettings: () => ({ data: {} }),
+  useUpdateServerSetting: () => ({ isPending: false, mutate: vi.fn() }),
+}));
+
+vi.mock("./admin-settings/InviteCodesTab", () => ({
+  default: () => null,
+}));
+
+describe("AdminUsers", () => {
+  it("renders an access explanation action for each user", () => {
+    const markup = renderToStaticMarkup(
+      <MemoryRouter>
+        <AdminUsers />
+      </MemoryRouter>,
+    );
+
+    expect(markup).toContain('aria-label="View tom access explanation"');
+  });
+});

--- a/web/src/pages/AdminUsers.tsx
+++ b/web/src/pages/AdminUsers.tsx
@@ -1,13 +1,21 @@
 import { useState, useId, useMemo } from "react";
 import type { FormEvent, ReactNode } from "react";
 import { Link } from "react-router";
-import type { AdminUser, CreateUserRequest, UpdateUserRequest } from "@/api/types";
+import type {
+  AdminACLActionExplanation,
+  AdminUser,
+  CreateUserRequest,
+  UpdateUserRequest,
+} from "@/api/types";
 import {
+  useAdminAccessGroups,
+  useAdminUserAccessExplanation,
   useAdminUsers,
   useCreateUser,
   useUpdateUser,
   useDeleteUser,
 } from "@/hooks/queries/admin/users";
+import { useAdminAccess } from "@/hooks/useAdminCapabilities";
 import { useAdminLibraries } from "@/hooks/queries/admin/libraries";
 import { useAdminServerSettings, useUpdateServerSetting } from "@/hooks/queries/admin/settings";
 import { LibraryAccessSelector } from "@/components/LibraryAccessSelector";
@@ -43,6 +51,7 @@ import {
   ChevronDown,
   ChevronUp,
   History,
+  KeyRound,
   Plus,
   Pencil,
   Trash2,
@@ -65,6 +74,16 @@ import {
   hasAssignedPermission,
   setAssignedPermission,
 } from "@/lib/permissions";
+import {
+  ACCESS_GROUP_ACTION_CATEGORIES,
+  ACCESS_GROUP_ACTIONS,
+  accessGroupActionLabel,
+} from "./adminAccessGroupsModel";
+import {
+  accessExplanationReasonLabel,
+  accessExplanationSourceLabel,
+  policyLimitRows,
+} from "./adminAccessExplainModel";
 
 const PAGE_SIZE_OPTIONS = ["25", "50", "100"] as const;
 type UserSortField = "username" | "email" | "role" | "enabled" | "created_at" | "last_active_at";
@@ -72,8 +91,12 @@ type SortDirection = "asc" | "desc";
 
 export default function AdminUsers() {
   const { data: users = [], isLoading } = useAdminUsers();
+  const adminAccess = useAdminAccess();
+  const canManageUsers = adminAccess.can("users.manage");
+  const canManageUserAccessPolicy = adminAccess.can("security.manage");
   const [dialogOpen, setDialogOpen] = useState(false);
   const [editingUser, setEditingUser] = useState<AdminUser | null>(null);
+  const [accessUser, setAccessUser] = useState<AdminUser | null>(null);
   const [defaultsOpen, setDefaultsOpen] = useState(false);
   const [confirmDeleteUser, setConfirmDeleteUser] = useState<AdminUser | null>(null);
   const deleteMutation = useDeleteUser();
@@ -139,6 +162,21 @@ export default function AdminUsers() {
           setConfirmDeleteUser(null);
         }}
       />
+      <Dialog
+        open={accessUser !== null}
+        onOpenChange={(open) => {
+          if (!open) setAccessUser(null);
+        }}
+      >
+        <DialogContent className="sm:max-w-5xl">
+          <DialogHeader>
+            <DialogTitle>
+              {accessUser ? `${accessUser.username} Access` : "User Access"}
+            </DialogTitle>
+          </DialogHeader>
+          {accessUser && <UserAccessExplanationPanel user={accessUser} />}
+        </DialogContent>
+      </Dialog>
       <div className="page-header">
         <div className="space-y-3">
           <h1 className="page-title text-[clamp(2rem,4vw,3rem)]">Users</h1>
@@ -147,44 +185,48 @@ export default function AdminUsers() {
           </p>
         </div>
         <div className="flex gap-2">
-          <Dialog open={defaultsOpen} onOpenChange={setDefaultsOpen}>
-            <DialogTrigger asChild>
-              <Button variant="outline" size="sm">
-                <Settings2 className="mr-1 h-4 w-4" /> User Defaults
-              </Button>
-            </DialogTrigger>
-            <DialogContent>
-              <DialogHeader>
-                <DialogTitle>Default New User Settings</DialogTitle>
-              </DialogHeader>
-              <UserDefaultsForm onClose={() => setDefaultsOpen(false)} />
-            </DialogContent>
-          </Dialog>
-          <Dialog
-            open={dialogOpen}
-            onOpenChange={(open) => {
-              setDialogOpen(open);
-              if (!open) setEditingUser(null);
-            }}
-          >
-            <DialogTrigger asChild>
-              <Button size="sm">
-                <Plus className="mr-1 h-4 w-4" /> Add User
-              </Button>
-            </DialogTrigger>
-            <DialogContent className="sm:max-w-2xl">
-              <DialogHeader>
-                <DialogTitle>{editingUser ? "Edit User" : "Create User"}</DialogTitle>
-              </DialogHeader>
-              <UserForm
-                user={editingUser}
-                onClose={() => {
-                  setDialogOpen(false);
-                  setEditingUser(null);
-                }}
-              />
-            </DialogContent>
-          </Dialog>
+          {adminAccess.actingAdmin && (
+            <Dialog open={defaultsOpen} onOpenChange={setDefaultsOpen}>
+              <DialogTrigger asChild>
+                <Button variant="outline" size="sm">
+                  <Settings2 className="mr-1 h-4 w-4" /> User Defaults
+                </Button>
+              </DialogTrigger>
+              <DialogContent>
+                <DialogHeader>
+                  <DialogTitle>Default New User Settings</DialogTitle>
+                </DialogHeader>
+                <UserDefaultsForm onClose={() => setDefaultsOpen(false)} />
+              </DialogContent>
+            </Dialog>
+          )}
+          {canManageUsers && (
+            <Dialog
+              open={dialogOpen}
+              onOpenChange={(open) => {
+                setDialogOpen(open);
+                if (!open) setEditingUser(null);
+              }}
+            >
+              <DialogTrigger asChild>
+                <Button size="sm">
+                  <Plus className="mr-1 h-4 w-4" /> Add User
+                </Button>
+              </DialogTrigger>
+              <DialogContent className="sm:max-w-2xl">
+                <DialogHeader>
+                  <DialogTitle>{editingUser ? "Edit User" : "Create User"}</DialogTitle>
+                </DialogHeader>
+                <UserForm
+                  user={editingUser}
+                  onClose={() => {
+                    setDialogOpen(false);
+                    setEditingUser(null);
+                  }}
+                />
+              </DialogContent>
+            </Dialog>
+          )}
         </div>
       </div>
 
@@ -247,6 +289,7 @@ export default function AdminUsers() {
                   >
                     Role
                   </SortableUserHead>
+                  <TableHead>Access</TableHead>
                   <SortableUserHead
                     field="enabled"
                     activeField={sortField}
@@ -287,6 +330,9 @@ export default function AdminUsers() {
                       <Badge variant={u.role === "admin" ? "default" : "secondary"}>{u.role}</Badge>
                     </TableCell>
                     <TableCell>
+                      <AccessGroupBadges user={u} />
+                    </TableCell>
+                    <TableCell>
                       <Badge variant={u.enabled ? "outline" : "destructive"}>
                         {u.enabled ? "Active" : "Disabled"}
                       </Badge>
@@ -311,7 +357,19 @@ export default function AdminUsers() {
                           variant="ghost"
                           size="icon"
                           className="h-7 w-7"
+                          aria-label={`View ${u.username} access explanation`}
+                          onClick={() => setAccessUser(u)}
+                        >
+                          <KeyRound className="h-3 w-3" aria-hidden="true" />
+                        </Button>
+                        <Button
+                          variant="ghost"
+                          size="icon"
+                          className="h-7 w-7"
                           aria-label={`Edit ${u.username}`}
+                          disabled={
+                            !canManageUsers || (u.role === "admin" && !canManageUserAccessPolicy)
+                          }
                           onClick={() => {
                             setEditingUser(u);
                             setDialogOpen(true);
@@ -324,6 +382,9 @@ export default function AdminUsers() {
                           size="icon"
                           className="h-7 w-7"
                           aria-label={`Delete ${u.username}`}
+                          disabled={
+                            !canManageUsers || (u.role === "admin" && !canManageUserAccessPolicy)
+                          }
                           onClick={() => handleDelete(u)}
                         >
                           <Trash2 className="h-3 w-3" aria-hidden="true" />
@@ -522,16 +583,196 @@ function formatRelativeTime(value?: string | null, fallback = "-") {
   return fallback;
 }
 
+function defaultAccessGroupSlugsForRole(role: string) {
+  return role === "admin" ? ["admin"] : ["standard_user"];
+}
+
+function defaultAccessGroupSlugForRole(role: string) {
+  return defaultAccessGroupSlugsForRole(role)[0] ?? "standard_user";
+}
+
+function accessGroupLabel(slug: string) {
+  switch (slug) {
+    case "owner":
+      return "Owner";
+    case "admin":
+      return "Admin";
+    case "library_manager":
+      return "Library Manager";
+    case "metadata_curator":
+      return "Metadata Curator";
+    case "standard_user":
+      return "User";
+    case "restricted_user":
+      return "Restricted User";
+    default:
+      return slug;
+  }
+}
+
+function AccessGroupBadges({ user }: { user: AdminUser }) {
+  const groups = user.access_groups ?? [];
+  if (groups.length === 0) {
+    return (
+      <Badge variant="secondary">
+        {accessGroupLabel(defaultAccessGroupSlugForRole(user.role))}
+      </Badge>
+    );
+  }
+  return (
+    <div className="flex max-w-64 flex-wrap gap-1">
+      {groups.map((group) => (
+        <Badge key={group.slug} variant={group.protected ? "default" : "secondary"}>
+          {group.name}
+        </Badge>
+      ))}
+    </div>
+  );
+}
+
+function UserAccessExplanationPanel({ user }: { user: AdminUser }) {
+  const { data, isLoading } = useAdminUserAccessExplanation(user.id);
+
+  if (isLoading || !data) {
+    return (
+      <div className="space-y-4">
+        <Skeleton className="h-20 w-full rounded-md" />
+        <Skeleton className="h-28 w-full rounded-md" />
+        <Skeleton className="h-48 w-full rounded-md" />
+      </div>
+    );
+  }
+
+  const actionsByName = new Map(data.actions.map((action) => [action.action, action]));
+  const catalogActionNames = new Set<string>(ACCESS_GROUP_ACTIONS.map((item) => item.action));
+  const uncategorizedActions = data.actions.filter(
+    (action) => !catalogActionNames.has(action.action),
+  );
+
+  return (
+    <div className="max-h-[72vh] space-y-5 overflow-y-auto pr-1">
+      <div className="grid gap-3 sm:grid-cols-2">
+        <section className="border-border rounded-md border px-3 py-3">
+          <h3 className="text-sm font-semibold">Groups</h3>
+          <div className="mt-3 flex flex-wrap gap-2">
+            {data.groups.length === 0 ? (
+              <Badge variant="secondary">
+                {accessGroupLabel(defaultAccessGroupSlugForRole(data.user.role))}
+              </Badge>
+            ) : (
+              data.groups.map((group) => (
+                <Badge key={group.slug} variant={group.protected ? "default" : "secondary"}>
+                  {group.name}
+                </Badge>
+              ))
+            )}
+          </div>
+        </section>
+        <section className="border-border rounded-md border px-3 py-3">
+          <h3 className="text-sm font-semibold">Effective Limits</h3>
+          <dl className="mt-3 grid gap-2 sm:grid-cols-2">
+            {policyLimitRows(data.effective_policy).map(([label, value]) => (
+              <div key={label} className="min-w-0">
+                <dt className="text-muted-foreground text-xs">{label}</dt>
+                <dd className="truncate text-sm font-medium" title={value}>
+                  {value}
+                </dd>
+              </div>
+            ))}
+          </dl>
+        </section>
+      </div>
+
+      <section className="space-y-4">
+        {ACCESS_GROUP_ACTION_CATEGORIES.map((category) => {
+          const rows = ACCESS_GROUP_ACTIONS.filter((item) => item.category === category.id)
+            .map((item) => actionsByName.get(item.action))
+            .filter((action): action is AdminACLActionExplanation => Boolean(action));
+          if (rows.length === 0) return null;
+          return (
+            <div key={category.id} className="space-y-2">
+              <h3 className="text-sm font-semibold">{category.label}</h3>
+              <AccessExplanationTable rows={rows} />
+            </div>
+          );
+        })}
+        {uncategorizedActions.length > 0 && (
+          <div className="space-y-2">
+            <h3 className="text-sm font-semibold">Other</h3>
+            <AccessExplanationTable rows={uncategorizedActions} />
+          </div>
+        )}
+      </section>
+    </div>
+  );
+}
+
+function AccessExplanationTable({ rows }: { rows: AdminACLActionExplanation[] }) {
+  return (
+    <div className="border-border overflow-hidden rounded-md border">
+      <Table>
+        <TableHeader>
+          <TableRow>
+            <TableHead>Action</TableHead>
+            <TableHead>Decision</TableHead>
+            <TableHead>Source</TableHead>
+            <TableHead>Reason</TableHead>
+            <TableHead>Rule</TableHead>
+          </TableRow>
+        </TableHeader>
+        <TableBody>
+          {rows.map((row) => (
+            <TableRow key={`${row.resource_type}:${row.action}`}>
+              <TableCell>
+                <div className="font-medium">{accessGroupActionLabel(row.action)}</div>
+                <div className="text-muted-foreground font-mono text-xs">{row.action}</div>
+              </TableCell>
+              <TableCell>
+                <Badge variant={row.allowed ? "outline" : "destructive"}>
+                  {row.allowed ? "Allowed" : "Denied"}
+                </Badge>
+              </TableCell>
+              <TableCell>{accessExplanationSourceLabel(row.source)}</TableCell>
+              <TableCell>{accessExplanationReasonLabel(row)}</TableCell>
+              <TableCell className="max-w-56">
+                {row.winning_rule ? (
+                  <div
+                    className="truncate"
+                    title={row.winning_rule.name || row.winning_rule.action}
+                  >
+                    {row.winning_rule.name || row.winning_rule.action}
+                  </div>
+                ) : (
+                  <span className="text-muted-foreground">-</span>
+                )}
+                {row.matched_rules.length > 1 && (
+                  <div className="text-muted-foreground text-xs">
+                    {row.matched_rules.length} matching rules
+                  </div>
+                )}
+              </TableCell>
+            </TableRow>
+          ))}
+        </TableBody>
+      </Table>
+    </div>
+  );
+}
+
 function UserForm({ user, onClose }: { user: AdminUser | null; onClose: () => void }) {
-  const { data: settings } = useAdminServerSettings();
-  const { data: libraries = [] } = useAdminLibraries();
+  const adminAccess = useAdminAccess();
+  const canManageUserAccessPolicy = adminAccess.can("security.manage");
+  const { data: settings } = useAdminServerSettings(canManageUserAccessPolicy);
+  const { data: libraries = [] } = useAdminLibraries(canManageUserAccessPolicy);
+  const { data: accessGroups = [] } = useAdminAccessGroups(canManageUserAccessPolicy);
   const [username, setUsername] = useState(user?.username ?? "");
   const [email, setEmail] = useState(user?.email ?? "");
   const [password, setPassword] = useState("");
   const [role, setRole] = useState(user?.role ?? "user");
   const [enabled, setEnabled] = useState(user?.enabled ?? true);
-  const [permissions, setPermissions] = useState<string[]>(
-    user?.permissions ?? [PERMISSION_MARKER_EDIT],
+  const [permissions, setPermissions] = useState<string[]>(user?.permissions ?? []);
+  const [accessGroupSlugs, setAccessGroupSlugs] = useState<string[]>(
+    user?.access_groups?.map((group) => group.slug) ?? defaultAccessGroupSlugsForRole("user"),
   );
   const [libraryIDs, setLibraryIDs] = useState<number[] | null>(user?.library_ids ?? null);
   const [maxStreams, setMaxStreams] = useState<number>(
@@ -560,6 +801,7 @@ function UserForm({ user, onClose }: { user: AdminUser | null; onClose: () => vo
   const passwordId = useId();
   const roleId = useId();
   const enabledId = useId();
+  const accessGroupsId = useId();
   const markerEditId = useId();
   const metadataCurationId = useId();
   const downloadAllowedId = useId();
@@ -572,23 +814,37 @@ function UserForm({ user, onClose }: { user: AdminUser | null; onClose: () => vo
   const updateMutation = useUpdateUser();
   const isPending = createMutation.isPending || updateMutation.isPending;
 
+  function toggleAccessGroup(slug: string, checked: boolean) {
+    setAccessGroupSlugs((current) => {
+      if (checked) {
+        return current.includes(slug) ? current : [...current, slug];
+      }
+      return current.filter((value) => value !== slug);
+    });
+  }
+
   function handleSubmit(e: FormEvent) {
     e.preventDefault();
+    const selectedAccessGroups =
+      accessGroupSlugs.length > 0 ? accessGroupSlugs : defaultAccessGroupSlugsForRole(role);
     if (user) {
       const body: UpdateUserRequest = {
         username,
         email,
         role,
-        permissions,
         enabled,
-        library_ids: libraryIDs,
-        max_streams: maxStreams,
-        max_transcodes: maxTranscodes,
-        max_profiles: maxProfiles,
-        max_playback_quality: playbackQualityValueFromPreset(maxPlaybackQualityPreset),
-        download_allowed: downloadAllowed,
-        download_transcode_allowed: downloadTranscodeAllowed,
       };
+      if (canManageUserAccessPolicy) {
+        body.permissions = permissions;
+        body.access_group_slugs = selectedAccessGroups;
+        body.library_ids = libraryIDs;
+        body.max_streams = maxStreams;
+        body.max_transcodes = maxTranscodes;
+        body.max_profiles = maxProfiles;
+        body.max_playback_quality = playbackQualityValueFromPreset(maxPlaybackQualityPreset);
+        body.download_allowed = downloadAllowed;
+        body.download_transcode_allowed = downloadTranscodeAllowed;
+      }
       if (password) body.password = password;
       updateMutation.mutate({ id: user.id, body }, { onSuccess: onClose });
     } else {
@@ -597,16 +853,20 @@ function UserForm({ user, onClose }: { user: AdminUser | null; onClose: () => vo
         email,
         password,
         role,
-        permissions,
         create_default_profile: true,
-        max_streams: maxStreams,
-        max_transcodes: maxTranscodes,
-        max_profiles: maxProfiles,
-        max_playback_quality: playbackQualityValueFromPreset(maxPlaybackQualityPreset) || undefined,
-        download_allowed: downloadAllowed,
-        download_transcode_allowed: downloadTranscodeAllowed,
       };
-      if (libraryIDs !== null) body.library_ids = libraryIDs;
+      if (canManageUserAccessPolicy) {
+        body.permissions = permissions;
+        body.access_group_slugs = selectedAccessGroups;
+        body.max_streams = maxStreams;
+        body.max_transcodes = maxTranscodes;
+        body.max_profiles = maxProfiles;
+        body.max_playback_quality =
+          playbackQualityValueFromPreset(maxPlaybackQualityPreset) || undefined;
+        body.download_allowed = downloadAllowed;
+        body.download_transcode_allowed = downloadTranscodeAllowed;
+        if (libraryIDs !== null) body.library_ids = libraryIDs;
+      }
       createMutation.mutate(body, { onSuccess: onClose });
     }
   }
@@ -618,12 +878,16 @@ function UserForm({ user, onClose }: { user: AdminUser | null; onClose: () => vo
           <TabsTrigger value="account" className="flex-none px-1">
             Account
           </TabsTrigger>
-          <TabsTrigger value="access" className="flex-none px-1">
-            Access
-          </TabsTrigger>
-          <TabsTrigger value="limits" className="flex-none px-1">
-            Limits
-          </TabsTrigger>
+          {canManageUserAccessPolicy && (
+            <TabsTrigger value="access" className="flex-none px-1">
+              Access
+            </TabsTrigger>
+          )}
+          {canManageUserAccessPolicy && (
+            <TabsTrigger value="limits" className="flex-none px-1">
+              Limits
+            </TabsTrigger>
+          )}
         </TabsList>
 
         <div className="min-h-0 flex-1 overflow-y-auto pr-1">
@@ -668,7 +932,11 @@ function UserForm({ user, onClose }: { user: AdminUser | null; onClose: () => vo
                   </SelectTrigger>
                   <SelectContent>
                     <SelectItem value="user">User</SelectItem>
-                    <SelectItem value="admin">Admin</SelectItem>
+                    {(canManageUserAccessPolicy || role === "admin") && (
+                      <SelectItem value="admin" disabled={!canManageUserAccessPolicy}>
+                        Admin
+                      </SelectItem>
+                    )}
                   </SelectContent>
                 </Select>
               </div>
@@ -691,129 +959,166 @@ function UserForm({ user, onClose }: { user: AdminUser | null; onClose: () => vo
             )}
           </TabsContent>
 
-          <TabsContent value="access" className="mt-0 space-y-4">
-            <LibraryAccessSelector
-              libraries={libraries}
-              value={libraryIDs}
-              onChange={setLibraryIDs}
-            />
-            <div className="border-border flex items-center justify-between rounded-md border px-3 py-2">
-              <div>
-                <Label htmlFor={markerEditId}>Marker Editing</Label>
-                <p className="text-muted-foreground text-xs">
-                  Edit intro, recap, credits, and preview markers within assigned libraries.
-                </p>
+          {canManageUserAccessPolicy && (
+            <TabsContent value="access" className="mt-0 space-y-4">
+              <div className="border-border rounded-md border px-3 py-3" id={accessGroupsId}>
+                <div className="mb-3 flex items-center justify-between">
+                  <Label>Access groups</Label>
+                  {accessGroupSlugs.length === 0 && (
+                    <Badge variant="secondary">
+                      {accessGroupLabel(defaultAccessGroupSlugForRole(role))}
+                    </Badge>
+                  )}
+                </div>
+                <div className="grid gap-2 sm:grid-cols-2">
+                  {accessGroups.map((group) => (
+                    <div
+                      key={group.slug}
+                      className="border-border flex min-h-12 items-center justify-between rounded-md border px-3 py-2"
+                    >
+                      <div className="min-w-0">
+                        <Label
+                          className="block truncate"
+                          htmlFor={`${accessGroupsId}-${group.slug}`}
+                        >
+                          {group.name}
+                        </Label>
+                        <div className="text-muted-foreground truncate text-xs">{group.slug}</div>
+                      </div>
+                      <Switch
+                        id={`${accessGroupsId}-${group.slug}`}
+                        checked={accessGroupSlugs.includes(group.slug)}
+                        onCheckedChange={(checked) => toggleAccessGroup(group.slug, checked)}
+                      />
+                    </div>
+                  ))}
+                </div>
               </div>
-              <Switch
-                id={markerEditId}
-                checked={hasAssignedPermission(permissions, PERMISSION_MARKER_EDIT)}
-                onCheckedChange={(checked) =>
-                  setPermissions((current) =>
-                    setAssignedPermission(current, PERMISSION_MARKER_EDIT, checked),
-                  )
-                }
+              <LibraryAccessSelector
+                libraries={libraries}
+                value={libraryIDs}
+                onChange={setLibraryIDs}
               />
-            </div>
-            <div className="border-border flex items-center justify-between rounded-md border px-3 py-2">
-              <div>
-                <Label htmlFor={metadataCurationId}>Metadata Curation</Label>
-                <p className="text-muted-foreground text-xs">
-                  Edit, refresh, and rematch metadata within assigned libraries.
-                </p>
-              </div>
-              <Switch
-                id={metadataCurationId}
-                checked={hasAssignedPermission(permissions, PERMISSION_METADATA_CURATION)}
-                onCheckedChange={(checked) =>
-                  setPermissions((current) =>
-                    setAssignedPermission(current, PERMISSION_METADATA_CURATION, checked),
-                  )
-                }
-              />
-            </div>
-            <div className="grid gap-2 sm:grid-cols-2">
               <div className="border-border flex items-center justify-between rounded-md border px-3 py-2">
-                <Label htmlFor={downloadAllowedId}>Downloads Allowed</Label>
+                <div>
+                  <Label htmlFor={markerEditId}>Marker Editing</Label>
+                  <p className="text-muted-foreground text-xs">
+                    Edit intro, recap, credits, and preview markers within assigned libraries.
+                  </p>
+                </div>
                 <Switch
-                  id={downloadAllowedId}
-                  checked={downloadAllowed}
-                  onCheckedChange={setDownloadAllowed}
+                  id={markerEditId}
+                  checked={hasAssignedPermission(permissions, PERMISSION_MARKER_EDIT)}
+                  onCheckedChange={(checked) =>
+                    setPermissions((current) =>
+                      setAssignedPermission(current, PERMISSION_MARKER_EDIT, checked),
+                    )
+                  }
                 />
               </div>
               <div className="border-border flex items-center justify-between rounded-md border px-3 py-2">
-                <Label htmlFor={downloadTranscodeAllowedId}>Download Transcode Allowed</Label>
+                <div>
+                  <Label htmlFor={metadataCurationId}>Metadata Curation</Label>
+                  <p className="text-muted-foreground text-xs">
+                    Edit, refresh, and rematch metadata within assigned libraries.
+                  </p>
+                </div>
                 <Switch
-                  id={downloadTranscodeAllowedId}
-                  checked={downloadTranscodeAllowed}
-                  onCheckedChange={setDownloadTranscodeAllowed}
+                  id={metadataCurationId}
+                  checked={hasAssignedPermission(permissions, PERMISSION_METADATA_CURATION)}
+                  onCheckedChange={(checked) =>
+                    setPermissions((current) =>
+                      setAssignedPermission(current, PERMISSION_METADATA_CURATION, checked),
+                    )
+                  }
                 />
               </div>
-            </div>
-          </TabsContent>
+              <div className="grid gap-2 sm:grid-cols-2">
+                <div className="border-border flex items-center justify-between rounded-md border px-3 py-2">
+                  <Label htmlFor={downloadAllowedId}>Downloads Allowed</Label>
+                  <Switch
+                    id={downloadAllowedId}
+                    checked={downloadAllowed}
+                    onCheckedChange={setDownloadAllowed}
+                  />
+                </div>
+                <div className="border-border flex items-center justify-between rounded-md border px-3 py-2">
+                  <Label htmlFor={downloadTranscodeAllowedId}>Download Transcode Allowed</Label>
+                  <Switch
+                    id={downloadTranscodeAllowedId}
+                    checked={downloadTranscodeAllowed}
+                    onCheckedChange={setDownloadTranscodeAllowed}
+                  />
+                </div>
+              </div>
+            </TabsContent>
+          )}
 
-          <TabsContent value="limits" className="mt-0 space-y-4">
-            <div className="grid gap-3 sm:grid-cols-2">
-              <div className="space-y-1">
-                <Label htmlFor={maxStreamsId}>Max Streams</Label>
-                <Input
-                  id={maxStreamsId}
-                  type="number"
-                  min={0}
-                  value={maxStreams}
-                  onChange={(e) => setMaxStreams(Number(e.target.value))}
-                />
-                <p className="text-muted-foreground text-xs">0 = unlimited</p>
+          {canManageUserAccessPolicy && (
+            <TabsContent value="limits" className="mt-0 space-y-4">
+              <div className="grid gap-3 sm:grid-cols-2">
+                <div className="space-y-1">
+                  <Label htmlFor={maxStreamsId}>Max Streams</Label>
+                  <Input
+                    id={maxStreamsId}
+                    type="number"
+                    min={0}
+                    value={maxStreams}
+                    onChange={(e) => setMaxStreams(Number(e.target.value))}
+                  />
+                  <p className="text-muted-foreground text-xs">0 = unlimited</p>
+                </div>
+                <div className="space-y-1">
+                  <Label htmlFor={maxTranscodesId}>Max Transcodes</Label>
+                  <Input
+                    id={maxTranscodesId}
+                    type="number"
+                    min={0}
+                    value={maxTranscodes}
+                    onChange={(e) => setMaxTranscodes(Number(e.target.value))}
+                  />
+                  <p className="text-muted-foreground text-xs">0 = unlimited</p>
+                </div>
+                <div className="space-y-1">
+                  <Label htmlFor={maxProfilesId}>Max Profiles</Label>
+                  <Input
+                    id={maxProfilesId}
+                    type="number"
+                    min={1}
+                    value={maxProfiles}
+                    onChange={(e) => setMaxProfiles(Number(e.target.value))}
+                  />
+                </div>
+                <div className="space-y-1 sm:col-span-2">
+                  <Label htmlFor={maxPlaybackQualityId}>Max Playback Quality</Label>
+                  <Select
+                    value={maxPlaybackQualityPreset}
+                    onValueChange={(value) =>
+                      setMaxPlaybackQualityPreset(value as PlaybackQualityPreset)
+                    }
+                  >
+                    <SelectTrigger id={maxPlaybackQualityId}>
+                      <SelectValue />
+                    </SelectTrigger>
+                    <SelectContent>
+                      {PLAYBACK_QUALITY_OPTIONS.map((option) => (
+                        <SelectItem key={option.value} value={option.value}>
+                          {option.label}
+                        </SelectItem>
+                      ))}
+                    </SelectContent>
+                  </Select>
+                  <p className="text-muted-foreground text-xs">
+                    {
+                      PLAYBACK_QUALITY_OPTIONS.find(
+                        (option) => option.value === maxPlaybackQualityPreset,
+                      )?.description
+                    }
+                  </p>
+                </div>
               </div>
-              <div className="space-y-1">
-                <Label htmlFor={maxTranscodesId}>Max Transcodes</Label>
-                <Input
-                  id={maxTranscodesId}
-                  type="number"
-                  min={0}
-                  value={maxTranscodes}
-                  onChange={(e) => setMaxTranscodes(Number(e.target.value))}
-                />
-                <p className="text-muted-foreground text-xs">0 = unlimited</p>
-              </div>
-              <div className="space-y-1">
-                <Label htmlFor={maxProfilesId}>Max Profiles</Label>
-                <Input
-                  id={maxProfilesId}
-                  type="number"
-                  min={1}
-                  value={maxProfiles}
-                  onChange={(e) => setMaxProfiles(Number(e.target.value))}
-                />
-              </div>
-              <div className="space-y-1 sm:col-span-2">
-                <Label htmlFor={maxPlaybackQualityId}>Max Playback Quality</Label>
-                <Select
-                  value={maxPlaybackQualityPreset}
-                  onValueChange={(value) =>
-                    setMaxPlaybackQualityPreset(value as PlaybackQualityPreset)
-                  }
-                >
-                  <SelectTrigger id={maxPlaybackQualityId}>
-                    <SelectValue />
-                  </SelectTrigger>
-                  <SelectContent>
-                    {PLAYBACK_QUALITY_OPTIONS.map((option) => (
-                      <SelectItem key={option.value} value={option.value}>
-                        {option.label}
-                      </SelectItem>
-                    ))}
-                  </SelectContent>
-                </Select>
-                <p className="text-muted-foreground text-xs">
-                  {
-                    PLAYBACK_QUALITY_OPTIONS.find(
-                      (option) => option.value === maxPlaybackQualityPreset,
-                    )?.description
-                  }
-                </p>
-              </div>
-            </div>
-          </TabsContent>
+            </TabsContent>
+          )}
         </div>
       </Tabs>
 

--- a/web/src/pages/ItemDetail/AudiobookContent.test.tsx
+++ b/web/src/pages/ItemDetail/AudiobookContent.test.tsx
@@ -28,6 +28,17 @@ vi.mock("@/pages/audiobooks/player/audiobookPlaybackContext", () => ({
   useAudiobookPlaybackController: () => mocks.controller,
 }));
 
+vi.mock("@/hooks/useUserCapabilities", () => ({
+  USER_CAPABILITY_ACTIONS: {
+    playbackPlay: "playback.play",
+    personalListsManage: "personal_lists.manage",
+  },
+  useUserCapabilityAccess: () => ({
+    can: () => true,
+    isLoading: false,
+  }),
+}));
+
 vi.mock("@/components/AddToCollectionDialog", () => ({
   default: () => null,
 }));

--- a/web/src/pages/ItemDetail/AudiobookContent.tsx
+++ b/web/src/pages/ItemDetail/AudiobookContent.tsx
@@ -17,6 +17,7 @@ import { audiobookFilesFromVersions } from "@/lib/audiobooks/files";
 import { useAudiobookPlaybackController } from "@/pages/audiobooks/player/audiobookPlaybackContext";
 import { coldResumePosition } from "@/pages/audiobooks/player/smartRewind";
 import { getAudiobookSmartRewind } from "@/pages/audiobooks/player/useAudiobookPrefs";
+import { USER_CAPABILITY_ACTIONS, useUserCapabilityAccess } from "@/hooks/useUserCapabilities";
 
 function formatSeconds(totalSeconds: number): string {
   if (!Number.isFinite(totalSeconds) || totalSeconds < 0) return "";
@@ -75,6 +76,9 @@ export default function AudiobookContent({
   const handledPlayParamRef = useRef(false);
   const [addToCollectionOpen, setAddToCollectionOpen] = useState(false);
   const audiobookPlayback = useAudiobookPlaybackController();
+  const userCapabilities = useUserCapabilityAccess();
+  const canPlayback = userCapabilities.can(USER_CAPABILITY_ACTIONS.playbackPlay);
+  const canManagePersonalLists = userCapabilities.can(USER_CAPABILITY_ACTIONS.personalListsManage);
 
   const files = useMemo<AudiobookFile[]>(
     () => audiobookFilesFromVersions(item.versions),
@@ -105,6 +109,7 @@ export default function AudiobookContent({
 
   const openPlayer = useCallback(
     (atSeconds: number) => {
+      if (!canPlayback) return;
       audiobookPlayback?.startPlayback({
         contentId: item.content_id,
         title: item.title,
@@ -115,10 +120,20 @@ export default function AudiobookContent({
         initialPositionSeconds: atSeconds,
       });
     },
-    [audiobookPlayback, author, files, item.content_id, item.poster_url, item.title, narrator],
+    [
+      audiobookPlayback,
+      author,
+      canPlayback,
+      files,
+      item.content_id,
+      item.poster_url,
+      item.title,
+      narrator,
+    ],
   );
 
   function handlePlayResume() {
+    if (!canPlayback) return;
     if (activePlayback) {
       audiobookPlayback?.toggleActivePlayback();
       return;
@@ -141,7 +156,12 @@ export default function AudiobookContent({
   }
 
   useEffect(() => {
-    if (handledPlayParamRef.current || searchParams.get("play") !== "1" || files.length === 0) {
+    if (
+      !canPlayback ||
+      handledPlayParamRef.current ||
+      searchParams.get("play") !== "1" ||
+      files.length === 0
+    ) {
       return;
     }
     handledPlayParamRef.current = true;
@@ -152,7 +172,7 @@ export default function AudiobookContent({
           ? coldResumePosition(resumeSeconds, getAudiobookSmartRewind())
           : 0,
     );
-  }, [files.length, hasProgress, openPlayer, resumeSeconds, searchParams]);
+  }, [canPlayback, files.length, hasProgress, openPlayer, resumeSeconds, searchParams]);
 
   return (
     <div>
@@ -206,9 +226,9 @@ export default function AudiobookContent({
         genres={item.genres}
         genreHref={(genre) => genreHref(genre, libraryId)}
         actions={
-          files.length > 0 && (
+          (files.length > 0 || canManagePersonalLists) && (
             <div className="flex max-w-md flex-col gap-3">
-              {hasProgress && durationTotal > 0 && (
+              {canPlayback && hasProgress && durationTotal > 0 && (
                 <div>
                   <div className="bg-muted h-1.5 w-full overflow-hidden rounded-full">
                     <div
@@ -223,25 +243,29 @@ export default function AudiobookContent({
                 </div>
               )}
               <div className="flex flex-wrap items-center gap-3">
-                <Button onClick={handlePlayResume} size="lg" className="gap-2">
-                  {activePlayback?.playing ? (
-                    <Pause className="h-4 w-4 fill-current" />
-                  ) : (
-                    <Play className="h-4 w-4 fill-current" />
-                  )}
-                  {primaryPlaybackLabel()}
-                </Button>
-                <Button
-                  variant="outline"
-                  size="lg"
-                  onClick={() => setAddToCollectionOpen(true)}
-                  className="gap-2"
-                  title="Add to a manual collection"
-                >
-                  <FolderPlus className="h-4 w-4" />
-                  Add to Collection
-                </Button>
-                {hasProgress && (
+                {canPlayback && files.length > 0 && (
+                  <Button onClick={handlePlayResume} size="lg" className="gap-2">
+                    {activePlayback?.playing ? (
+                      <Pause className="h-4 w-4 fill-current" />
+                    ) : (
+                      <Play className="h-4 w-4 fill-current" />
+                    )}
+                    {primaryPlaybackLabel()}
+                  </Button>
+                )}
+                {canManagePersonalLists && (
+                  <Button
+                    variant="outline"
+                    size="lg"
+                    onClick={() => setAddToCollectionOpen(true)}
+                    className="gap-2"
+                    title="Add to a manual collection"
+                  >
+                    <FolderPlus className="h-4 w-4" />
+                    Add to Collection
+                  </Button>
+                )}
+                {canPlayback && hasProgress && (
                   <Button variant="outline" size="lg" onClick={() => openPlayer(0)}>
                     Listen from Start
                   </Button>
@@ -298,11 +322,13 @@ export default function AudiobookContent({
           />
         )}
 
-        <ChaptersSection
-          files={files}
-          currentPositionSeconds={currentPlayerSeconds ?? (resumeSeconds || null)}
-          onSelect={(seconds) => openPlayer(seconds)}
-        />
+        {canPlayback && (
+          <ChaptersSection
+            files={files}
+            currentPositionSeconds={currentPlayerSeconds ?? (resumeSeconds || null)}
+            onSelect={(seconds) => openPlayer(seconds)}
+          />
+        )}
       </div>
     </div>
   );

--- a/web/src/pages/ItemDetail/EbookContent.test.tsx
+++ b/web/src/pages/ItemDetail/EbookContent.test.tsx
@@ -15,6 +15,18 @@ vi.mock("@/hooks/useAuth", () => ({
   useAuth: mocks.useAuth,
 }));
 
+vi.mock("@/hooks/useUserCapabilities", () => ({
+  USER_CAPABILITY_ACTIONS: {
+    playbackPlay: "playback.play",
+    downloadsDirect: "downloads.direct",
+    downloadsTranscode: "downloads.transcode",
+  },
+  useUserCapabilityAccess: () => ({
+    can: () => true,
+    isLoading: false,
+  }),
+}));
+
 vi.mock("@/hooks/queries/items", () => ({
   useWatchedStateMutation: mocks.useWatchedStateMutation,
 }));

--- a/web/src/pages/ItemDetail/EbookContent.tsx
+++ b/web/src/pages/ItemDetail/EbookContent.tsx
@@ -10,6 +10,7 @@ import { useAuth } from "@/hooks/useAuth";
 import { useAmbientColor } from "@/hooks/useAmbientColor";
 import { useEbookReaderProgress } from "@/hooks/queries/ebookReaderProgress";
 import { useWatchedStateMutation } from "@/hooks/queries/items";
+import { USER_CAPABILITY_ACTIONS, useUserCapabilityAccess } from "@/hooks/useUserCapabilities";
 import { RelatedRail } from "@/pages/audiobooks/components/RelatedRail";
 import {
   formatReaderProgress,
@@ -80,6 +81,12 @@ export default function EbookContent({
 }) {
   useAmbientColor(item.poster_thumbhash);
   const { user } = useAuth();
+  const userCapabilities = useUserCapabilityAccess();
+  const canPlayback = userCapabilities.can(USER_CAPABILITY_ACTIONS.playbackPlay);
+  const canUseDownloads = userCapabilities.can([
+    USER_CAPABILITY_ACTIONS.downloadsDirect,
+    USER_CAPABILITY_ACTIONS.downloadsTranscode,
+  ]);
   const { data: readerProgress } = useEbookReaderProgress(item.content_id);
   const watchedMutation = useWatchedStateMutation(item);
   const isRead = item.user_data?.played === true;
@@ -92,8 +99,10 @@ export default function EbookContent({
   const readVersion =
     (hasSavedProgress ? progressReadVersion(item.versions, readerProgress?.file_id) : undefined) ??
     preferredReadVersion(item.versions);
-  const canRead = Boolean(readVersion);
-  const canDownload = Boolean(user?.download_allowed && item.versions.length > 0);
+  const canRead = canPlayback && Boolean(readVersion);
+  const canDownload = Boolean(
+    canUseDownloads && user?.download_allowed && item.versions.length > 0,
+  );
   const readerParams = new URLSearchParams();
   if (readVersion) {
     readerParams.set("file_id", String(readVersion.file_id));

--- a/web/src/pages/ItemDetail/components/ActionBar.tsx
+++ b/web/src/pages/ItemDetail/components/ActionBar.tsx
@@ -42,6 +42,7 @@ import type {
 import RefreshMetadataDialog from "@/components/RefreshMetadataDialog";
 import { MarkerEditor } from "@/components/markers/MarkerEditor";
 import StarRating from "@/components/StarRating";
+import { USER_CAPABILITY_ACTIONS, useUserCapabilityAccess } from "@/hooks/useUserCapabilities";
 import { useWatchPlaybackController } from "@/playback/watchPlaybackContext";
 import { parseWatchHref } from "@/pages/watchRouteHelpers";
 import VersionDropdown from "./VersionDropdown";
@@ -154,6 +155,13 @@ export default function ActionBar({
   const navigate = useNavigate();
   const location = useLocation();
   const playbackController = useWatchPlaybackController();
+  const userCapabilities = useUserCapabilityAccess();
+  const canPlayback = userCapabilities.can(USER_CAPABILITY_ACTIONS.playbackPlay);
+  const canManagePersonalLists = userCapabilities.can(USER_CAPABILITY_ACTIONS.personalListsManage);
+  const canDownload = userCapabilities.can([
+    USER_CAPABILITY_ACTIONS.downloadsDirect,
+    USER_CAPABILITY_ACTIONS.downloadsTranscode,
+  ]);
   const [playChoiceOpen, setPlayChoiceOpen] = useState(false);
   const [refreshDialogOpen, setRefreshDialogOpen] = useState(false);
   const [addToCollectionOpen, setAddToCollectionOpen] = useState(false);
@@ -161,7 +169,7 @@ export default function ActionBar({
   const showMarkerEditor = canEditMarkers && !!contentId;
   const hasMultipleVersions = (playbackVariants?.length ?? 0) > 1 || (versions?.length ?? 0) > 1;
   const showPlayChoiceDialog =
-    !hasMultipleVersions && playLabel === "Resume" && !!playHref && !!restartHref;
+    canPlayback && !hasMultipleVersions && playLabel === "Resume" && !!playHref && !!restartHref;
   const displayedPlayLabel = showPlayChoiceDialog ? "Play" : playLabel;
 
   const progressOverlay =
@@ -200,6 +208,7 @@ export default function ActionBar({
   );
   const startPlaybackFromHref = useCallback(
     (href: string, restartOverride?: boolean) => {
+      if (!canPlayback) return;
       const parsed = parseWatchHref(href);
       if (!parsed) {
         navigate(href);
@@ -216,7 +225,14 @@ export default function ActionBar({
         }),
       );
     },
-    [buildPrePlayStartInput, currentHref, navigate, playbackController, selectedVersion?.file_id],
+    [
+      buildPrePlayStartInput,
+      canPlayback,
+      currentHref,
+      navigate,
+      playbackController,
+      selectedVersion?.file_id,
+    ],
   );
   const handleResumePlayback = () => {
     if (!playHref) return;
@@ -232,8 +248,13 @@ export default function ActionBar({
     setRefreshDialogOpen(false);
     onRefresh?.(mode);
   };
+  const hasCollectionAction = Boolean(contentId && canManagePersonalLists);
   const hasOverflowActions = Boolean(
-    restartHref || onToggleWatchlist || onDownload || onSearchSubtitles,
+    (canPlayback && restartHref) ||
+    (canManagePersonalLists && onToggleWatchlist) ||
+    (canDownload && onDownload) ||
+    onSearchSubtitles ||
+    hasCollectionAction,
   );
   const hasAdminActions = Boolean(isAdmin && (contentId || onRedetectIntro));
   const hasMetadataActions = Boolean(
@@ -254,7 +275,7 @@ export default function ActionBar({
   // When a version is explicitly selected (multi-version), play it directly.
   const handleSelectedVersionPlay = useCallback(
     (restart: boolean) => {
-      if (!selectedVersion || !contentId) return;
+      if (!canPlayback || !selectedVersion || !contentId) return;
       playbackController.startPlayback(
         buildPrePlayStartInput({
           contentId,
@@ -264,10 +285,18 @@ export default function ActionBar({
         }),
       );
     },
-    [buildPrePlayStartInput, contentId, currentHref, playbackController, selectedVersion],
+    [
+      buildPrePlayStartInput,
+      canPlayback,
+      contentId,
+      currentHref,
+      playbackController,
+      selectedVersion,
+    ],
   );
 
   const hasStreamControls =
+    canPlayback &&
     selectedVersion &&
     ((versions && hasMultipleVersions) || (selectedVersion.audio_tracks?.length ?? 0) > 0 || true); // subs popover always shows when version is selected
 
@@ -276,48 +305,50 @@ export default function ActionBar({
       {/* ── Primary actions ──────────────────────────────────── */}
       <div className="flex flex-wrap items-center gap-3">
         {/* ── Play button ────────────────────────────────────── */}
-        {playHref ? (
-          showPlayChoiceDialog ? (
-            <Button
-              onClick={openPlayChoiceDialog}
-              className="relative h-11 gap-2.5 overflow-hidden rounded-full px-8 text-[15px] font-bold tracking-wide shadow-md"
-            >
-              <Play className="size-[18px] fill-current" />
-              {displayedPlayLabel}
-              {progressOverlay}
-            </Button>
-          ) : selectedVersion ? (
-            <Button
-              onClick={() => handleSelectedVersionPlay(false)}
-              className="relative h-11 gap-2.5 overflow-hidden rounded-full px-8 text-[15px] font-bold tracking-wide shadow-md"
-            >
-              <Play className="size-[18px] fill-current" />
-              {displayedPlayLabel}
-              {progressOverlay}
-            </Button>
+        {canPlayback ? (
+          playHref ? (
+            showPlayChoiceDialog ? (
+              <Button
+                onClick={openPlayChoiceDialog}
+                className="relative h-11 gap-2.5 overflow-hidden rounded-full px-8 text-[15px] font-bold tracking-wide shadow-md"
+              >
+                <Play className="size-[18px] fill-current" />
+                {displayedPlayLabel}
+                {progressOverlay}
+              </Button>
+            ) : selectedVersion ? (
+              <Button
+                onClick={() => handleSelectedVersionPlay(false)}
+                className="relative h-11 gap-2.5 overflow-hidden rounded-full px-8 text-[15px] font-bold tracking-wide shadow-md"
+              >
+                <Play className="size-[18px] fill-current" />
+                {displayedPlayLabel}
+                {progressOverlay}
+              </Button>
+            ) : (
+              <Button
+                onClick={() => startPlaybackFromHref(playHref)}
+                className="relative h-11 gap-2.5 overflow-hidden rounded-full px-8 text-[15px] font-bold tracking-wide shadow-md"
+              >
+                <Play className="size-[18px] fill-current" />
+                {displayedPlayLabel}
+                {progressOverlay}
+              </Button>
+            )
           ) : (
             <Button
-              onClick={() => startPlaybackFromHref(playHref)}
-              className="relative h-11 gap-2.5 overflow-hidden rounded-full px-8 text-[15px] font-bold tracking-wide shadow-md"
+              disabled
+              className="h-11 gap-2.5 rounded-full px-8 text-[15px] font-bold tracking-wide"
             >
-              <Play className="size-[18px] fill-current" />
-              {displayedPlayLabel}
-              {progressOverlay}
+              {playLoading ? (
+                <Loader2 className="size-[18px] animate-spin" />
+              ) : (
+                <Play className="size-[18px] fill-current" />
+              )}
+              {playLabel}
             </Button>
           )
-        ) : (
-          <Button
-            disabled
-            className="h-11 gap-2.5 rounded-full px-8 text-[15px] font-bold tracking-wide"
-          >
-            {playLoading ? (
-              <Loader2 className="size-[18px] animate-spin" />
-            ) : (
-              <Play className="size-[18px] fill-current" />
-            )}
-            {playLabel}
-          </Button>
-        )}
+        ) : null}
 
         {/* ── Watched toggle ─────────────────────────────────── */}
         {watchedLabel && onToggleWatched && (
@@ -333,7 +364,7 @@ export default function ActionBar({
         )}
 
         {/* ── Icon action buttons ────────────────────────────── */}
-        {onToggleFavorite && (
+        {canManagePersonalLists && onToggleFavorite && (
           <Button
             variant="glass"
             size="icon-lg"
@@ -351,98 +382,100 @@ export default function ActionBar({
           <StarRating value={rating ?? null} onChange={onRatingChange} size={18} />
         )}
 
-        <DropdownMenu modal={false}>
-          <DropdownMenuTrigger asChild>
-            <Button variant="glass" size="icon-lg" title="More" className="size-11 rounded-full">
-              <MoreVertical className="size-[18px]" />
-            </Button>
-          </DropdownMenuTrigger>
-          <DropdownMenuContent align="end" className="w-56">
-            {restartHref && (
-              <DropdownMenuItem
-                onSelect={() => {
-                  handleRestartPlayback();
-                }}
-              >
-                <RotateCcw className="size-4" />
-                Play from Beginning
-              </DropdownMenuItem>
-            )}
-            {onToggleWatchlist && (
-              <DropdownMenuItem onSelect={onToggleWatchlist}>
-                {inWatchlist ? <Check className="size-4" /> : <Plus className="size-4" />}
-                {inWatchlist ? "Remove from Watchlist" : "Add to Watchlist"}
-              </DropdownMenuItem>
-            )}
-            {contentId && (
-              <DropdownMenuItem onSelect={() => setAddToCollectionOpen(true)}>
-                <FolderPlus className="size-4" />
-                Add to Collection
-              </DropdownMenuItem>
-            )}
-            {onDownload && (
-              <DropdownMenuItem onSelect={onDownload}>
-                <Download className="size-4" />
-                Download
-              </DropdownMenuItem>
-            )}
-            {onSearchSubtitles && (
-              <DropdownMenuItem onSelect={onSearchSubtitles}>
-                <Captions className="size-4" />
-                Search Subtitles
-              </DropdownMenuItem>
-            )}
-            {(hasAdminActions || hasMetadataActions) && (
-              <>
-                {hasOverflowActions && <DropdownMenuSeparator />}
-                {isAdmin && contentId && (
-                  <DropdownMenuItem
-                    onSelect={() =>
-                      navigate(`/admin/history?media_item_id=${encodeURIComponent(contentId)}`)
-                    }
-                  >
-                    View Play History
-                  </DropdownMenuItem>
-                )}
-                {canCurateMetadata && onRefresh && (
-                  <DropdownMenuItem
-                    disabled={isRefreshing}
-                    onSelect={() => {
-                      setRefreshDialogOpen(true);
-                    }}
-                  >
-                    {isRefreshing && <RefreshCw className="size-4 animate-spin" />}
-                    Refresh Metadata
-                  </DropdownMenuItem>
-                )}
-                {isAdmin && onRedetectIntro && (
-                  <DropdownMenuItem disabled={isRedetectingIntro} onSelect={onRedetectIntro}>
-                    <RefreshCw className={`size-4 ${isRedetectingIntro ? "animate-spin" : ""}`} />
-                    Re-detect Intro Markers
-                  </DropdownMenuItem>
-                )}
-                {canCurateMetadata && onEditMetadata && (
-                  <DropdownMenuItem onSelect={onEditMetadata}>
-                    <Pencil className="size-4" />
-                    Edit Metadata
-                  </DropdownMenuItem>
-                )}
-                {showMarkerEditor && (
-                  <DropdownMenuItem onSelect={() => setMarkerEditorOpen(true)}>
-                    <Tags className="size-4" />
-                    Edit Markers
-                  </DropdownMenuItem>
-                )}
-                {canCurateMetadata && onMatchItem && (
-                  <DropdownMenuItem onSelect={onMatchItem}>
-                    <Search className="size-4" />
-                    Match Item
-                  </DropdownMenuItem>
-                )}
-              </>
-            )}
-          </DropdownMenuContent>
-        </DropdownMenu>
+        {(hasOverflowActions || hasAdminActions || hasMetadataActions) && (
+          <DropdownMenu modal={false}>
+            <DropdownMenuTrigger asChild>
+              <Button variant="glass" size="icon-lg" title="More" className="size-11 rounded-full">
+                <MoreVertical className="size-[18px]" />
+              </Button>
+            </DropdownMenuTrigger>
+            <DropdownMenuContent align="end" className="w-56">
+              {canPlayback && restartHref && (
+                <DropdownMenuItem
+                  onSelect={() => {
+                    handleRestartPlayback();
+                  }}
+                >
+                  <RotateCcw className="size-4" />
+                  Play from Beginning
+                </DropdownMenuItem>
+              )}
+              {canManagePersonalLists && onToggleWatchlist && (
+                <DropdownMenuItem onSelect={onToggleWatchlist}>
+                  {inWatchlist ? <Check className="size-4" /> : <Plus className="size-4" />}
+                  {inWatchlist ? "Remove from Watchlist" : "Add to Watchlist"}
+                </DropdownMenuItem>
+              )}
+              {hasCollectionAction && (
+                <DropdownMenuItem onSelect={() => setAddToCollectionOpen(true)}>
+                  <FolderPlus className="size-4" />
+                  Add to Collection
+                </DropdownMenuItem>
+              )}
+              {canDownload && onDownload && (
+                <DropdownMenuItem onSelect={onDownload}>
+                  <Download className="size-4" />
+                  Download
+                </DropdownMenuItem>
+              )}
+              {onSearchSubtitles && (
+                <DropdownMenuItem onSelect={onSearchSubtitles}>
+                  <Captions className="size-4" />
+                  Search Subtitles
+                </DropdownMenuItem>
+              )}
+              {(hasAdminActions || hasMetadataActions) && (
+                <>
+                  {hasOverflowActions && <DropdownMenuSeparator />}
+                  {isAdmin && contentId && (
+                    <DropdownMenuItem
+                      onSelect={() =>
+                        navigate(`/admin/history?media_item_id=${encodeURIComponent(contentId)}`)
+                      }
+                    >
+                      View Play History
+                    </DropdownMenuItem>
+                  )}
+                  {canCurateMetadata && onRefresh && (
+                    <DropdownMenuItem
+                      disabled={isRefreshing}
+                      onSelect={() => {
+                        setRefreshDialogOpen(true);
+                      }}
+                    >
+                      {isRefreshing && <RefreshCw className="size-4 animate-spin" />}
+                      Refresh Metadata
+                    </DropdownMenuItem>
+                  )}
+                  {isAdmin && onRedetectIntro && (
+                    <DropdownMenuItem disabled={isRedetectingIntro} onSelect={onRedetectIntro}>
+                      <RefreshCw className={`size-4 ${isRedetectingIntro ? "animate-spin" : ""}`} />
+                      Re-detect Intro Markers
+                    </DropdownMenuItem>
+                  )}
+                  {canCurateMetadata && onEditMetadata && (
+                    <DropdownMenuItem onSelect={onEditMetadata}>
+                      <Pencil className="size-4" />
+                      Edit Metadata
+                    </DropdownMenuItem>
+                  )}
+                  {showMarkerEditor && (
+                    <DropdownMenuItem onSelect={() => setMarkerEditorOpen(true)}>
+                      <Tags className="size-4" />
+                      Edit Markers
+                    </DropdownMenuItem>
+                  )}
+                  {canCurateMetadata && onMatchItem && (
+                    <DropdownMenuItem onSelect={onMatchItem}>
+                      <Search className="size-4" />
+                      Match Item
+                    </DropdownMenuItem>
+                  )}
+                </>
+              )}
+            </DropdownMenuContent>
+          </DropdownMenu>
+        )}
         {showPlayChoiceDialog && (
           <Dialog open={playChoiceOpen} onOpenChange={setPlayChoiceOpen}>
             <DialogContent className="max-w-xs gap-3 p-5">

--- a/web/src/pages/RequestBrowse.tsx
+++ b/web/src/pages/RequestBrowse.tsx
@@ -13,6 +13,7 @@ import { Skeleton } from "@/components/ui/skeleton";
 import { Tabs, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { useDocumentTitle } from "@/hooks/useDocumentTitle";
 import { useCreateMediaRequest, useRequestBrowse } from "@/hooks/queries/useRequests";
+import { useCanRequest } from "@/hooks/useCanRequest";
 import { requestInputFromMediaResult } from "@/lib/mediaRequests";
 import type {
   DiscoverBrowseKind,
@@ -46,6 +47,7 @@ export default function RequestBrowse({ kind }: RequestBrowseProps) {
 
   const browse = useRequestBrowse({ kind, slug, mediaType, sort, page });
   const createRequest = useCreateMediaRequest();
+  const canRequest = useCanRequest();
   const pendingRequestKey = createRequest.variables
     ? mediaRequestKey(createRequest.variables.media_type, createRequest.variables.tmdb_id)
     : undefined;
@@ -75,6 +77,7 @@ export default function RequestBrowse({ kind }: RequestBrowseProps) {
   }
 
   function submitRequest(item: RequestMediaResult) {
+    if (!canRequest.discoveryEnabled) return;
     createRequest.mutate(requestInputFromMediaResult(item));
   }
 
@@ -153,7 +156,7 @@ export default function RequestBrowse({ kind }: RequestBrowseProps) {
                 key={`${item.media_type}-${item.tmdb_id}`}
                 variant="discover"
                 item={item}
-                onRequest={() => submitRequest(item)}
+                onRequest={canRequest.discoveryEnabled ? () => submitRequest(item) : undefined}
                 isSubmitting={
                   createRequest.isPending &&
                   pendingRequestKey === mediaRequestKey(item.media_type, item.tmdb_id)

--- a/web/src/pages/RequestDetail.tsx
+++ b/web/src/pages/RequestDetail.tsx
@@ -14,6 +14,7 @@ import type {
   RequestMediaResult,
 } from "@/api/types";
 import { useCreateMediaRequest, useRequestMediaDetail } from "@/hooks/queries/useRequests";
+import { useCanRequest } from "@/hooks/useCanRequest";
 import { useDocumentTitle } from "@/hooks/useDocumentTitle";
 import { cn } from "@/lib/utils";
 import {
@@ -30,6 +31,7 @@ export default function RequestDetail() {
 
   const detail = useRequestMediaDetail(mediaType, tmdbID);
   const createRequest = useCreateMediaRequest();
+  const canRequest = useCanRequest();
 
   useDocumentTitle(detail.data?.title ?? "Request");
 
@@ -76,7 +78,11 @@ export default function RequestDetail() {
             isSubmitting={
               createRequest.isPending && createRequest.variables?.tmdb_id === item.tmdb_id
             }
-            onRequest={() => createRequest.mutate(requestInputFromMediaResult(item))}
+            onRequest={
+              canRequest.discoveryEnabled
+                ? () => createRequest.mutate(requestInputFromMediaResult(item))
+                : undefined
+            }
           />
         }
       />
@@ -96,7 +102,11 @@ export default function RequestDetail() {
             recommendations={item.recommendations}
             pendingTMDBID={createRequest.variables?.tmdb_id}
             isSubmitting={createRequest.isPending}
-            onRequest={(rec) => createRequest.mutate(requestInputFromMediaResult(rec))}
+            onRequest={
+              canRequest.discoveryEnabled
+                ? (rec) => createRequest.mutate(requestInputFromMediaResult(rec))
+                : undefined
+            }
           />
         )}
       </div>
@@ -198,7 +208,7 @@ function RequestActions({
 }: {
   item: RequestMediaDetail;
   isSubmitting: boolean;
-  onRequest: () => void;
+  onRequest?: () => void;
 }) {
   const requestable = item.request.requestable;
   const statusLabel = item.request.status ? formatRequestStatus(item.request.status) : null;
@@ -209,23 +219,25 @@ function RequestActions({
   return (
     <div className="flex flex-wrap items-center gap-2">
       {requestable ? (
-        <Button
-          onClick={onRequest}
-          disabled={isSubmitting}
-          className="h-11 rounded-full px-6 text-sm font-semibold"
-        >
-          {isSubmitting ? (
-            <>
-              <Loader2 className="h-4 w-4 animate-spin" />
-              Submitting
-            </>
-          ) : (
-            <>
-              <Plus className="h-4 w-4 stroke-[2.5]" />
-              Request {item.media_type === "series" ? "series" : "movie"}
-            </>
-          )}
-        </Button>
+        onRequest ? (
+          <Button
+            onClick={onRequest}
+            disabled={isSubmitting}
+            className="h-11 rounded-full px-6 text-sm font-semibold"
+          >
+            {isSubmitting ? (
+              <>
+                <Loader2 className="h-4 w-4 animate-spin" />
+                Submitting
+              </>
+            ) : (
+              <>
+                <Plus className="h-4 w-4 stroke-[2.5]" />
+                Request {item.media_type === "series" ? "series" : "movie"}
+              </>
+            )}
+          </Button>
+        ) : null
       ) : availableInLibrary ? (
         <>
           <StatusBlock
@@ -335,7 +347,7 @@ function RecommendationsRow({
   recommendations: RequestMediaResult[];
   pendingTMDBID?: number;
   isSubmitting: boolean;
-  onRequest: (item: RequestMediaResult) => void;
+  onRequest?: (item: RequestMediaResult) => void;
 }) {
   return (
     <MediaCarousel title="More Like This">
@@ -345,7 +357,7 @@ function RecommendationsRow({
           variant="discover"
           item={item}
           isSubmitting={isSubmitting && pendingTMDBID === item.tmdb_id}
-          onRequest={() => onRequest(item)}
+          onRequest={onRequest ? () => onRequest(item) : undefined}
         />
       ))}
     </MediaCarousel>

--- a/web/src/pages/Requests.tsx
+++ b/web/src/pages/Requests.tsx
@@ -33,6 +33,7 @@ import {
   useRequestDiscovery,
   useRequestSearch,
 } from "@/hooks/queries/useRequests";
+import { useCanRequest } from "@/hooks/useCanRequest";
 import { useDocumentTitle } from "@/hooks/useDocumentTitle";
 import { cn } from "@/lib/utils";
 import { formatRequestStatus, requestInputFromMediaResult } from "@/lib/mediaRequests";
@@ -140,6 +141,7 @@ export default function Requests() {
   const search = useRequestSearch(mediaType, searchQuery, searchPage);
   const mine = useMyMediaRequests({ limit: 100 });
   const createRequest = useCreateMediaRequest();
+  const canRequest = useCanRequest();
   const pendingRequestKey = createRequest.variables
     ? mediaRequestKey(createRequest.variables.media_type, createRequest.variables.tmdb_id)
     : undefined;
@@ -232,6 +234,7 @@ export default function Requests() {
   }
 
   function submitRequest(item: RequestMediaResult) {
+    if (!canRequest.discoveryEnabled) return;
     createRequest.mutate(requestInputFromMediaResult(item));
   }
 
@@ -286,7 +289,7 @@ export default function Requests() {
               results={search.data?.results ?? []}
               pendingRequestKey={pendingRequestKey}
               isSubmitting={createRequest.isPending}
-              onRequest={submitRequest}
+              onRequest={canRequest.discoveryEnabled ? submitRequest : undefined}
             />
           ) : discovery.isLoading ? (
             <DiscoveryCarouselSkeleton />
@@ -303,7 +306,7 @@ export default function Requests() {
                   section={section}
                   pendingRequestKey={pendingRequestKey}
                   isSubmitting={createRequest.isPending}
-                  onRequest={submitRequest}
+                  onRequest={canRequest.discoveryEnabled ? submitRequest : undefined}
                 />
               ))}
               <BrandCarousel
@@ -535,7 +538,7 @@ function DiscoverySectionRow({
   section: RequestDiscoverySection;
   pendingRequestKey?: string;
   isSubmitting: boolean;
-  onRequest: (item: RequestMediaResult) => void;
+  onRequest?: (item: RequestMediaResult) => void;
 }) {
   const eyebrow = sectionEyebrow(section.key);
   return (
@@ -554,7 +557,7 @@ function DiscoverySectionRow({
             isSubmitting={
               isSubmitting && pendingRequestKey === mediaRequestKey(item.media_type, item.tmdb_id)
             }
-            onRequest={() => onRequest(item)}
+            onRequest={onRequest ? () => onRequest(item) : undefined}
           />
         ))}
       </MediaCarousel>
@@ -605,7 +608,7 @@ function SearchResultsView({
   results: RequestMediaResult[];
   pendingRequestKey?: string;
   isSubmitting: boolean;
-  onRequest: (item: RequestMediaResult) => void;
+  onRequest?: (item: RequestMediaResult) => void;
 }) {
   const typeLabel =
     mediaType === "series" ? "series" : mediaType === "movie" ? "movies" : "movies and series";
@@ -684,7 +687,7 @@ function SearchResultsView({
                   isSubmitting &&
                   pendingRequestKey === mediaRequestKey(item.media_type, item.tmdb_id)
                 }
-                onRequest={() => onRequest(item)}
+                onRequest={onRequest ? () => onRequest(item) : undefined}
                 fluid
               />
             ))}

--- a/web/src/pages/TasteSeed.tsx
+++ b/web/src/pages/TasteSeed.tsx
@@ -5,6 +5,7 @@ import { toast } from "sonner";
 import { Button } from "@/components/ui/button";
 import { useAuth } from "@/hooks/useAuth";
 import { useDocumentTitle } from "@/hooks/useDocumentTitle";
+import { USER_CAPABILITY_ACTIONS, useUserCapabilityAccess } from "@/hooks/useUserCapabilities";
 import { decodeThumbhash } from "@/lib/thumbhash";
 import type { SectionItem } from "@/api/types";
 import { useTasteSeedItems, useSubmitTasteSeed } from "@/hooks/queries/tasteSeed";
@@ -16,6 +17,8 @@ export default function TasteSeed() {
   const navigate = useNavigate();
   const [searchParams] = useSearchParams();
   const { profile } = useAuth();
+  const userCapabilities = useUserCapabilityAccess();
+  const canManagePersonalLists = userCapabilities.can(USER_CAPABILITY_ACTIONS.personalListsManage);
   useDocumentTitle("Pick what you love");
 
   const isReturning = searchParams.get("from") === "settings";
@@ -26,8 +29,16 @@ export default function TasteSeed() {
   const [userToggles, setUserToggles] = useState<Map<string, boolean>>(new Map());
 
   const { data, fetchNextPage, hasNextPage, isFetching, isFetchingNextPage, isPending } =
-    useTasteSeedItems(true);
+    useTasteSeedItems(canManagePersonalLists);
   const submit = useSubmitTasteSeed();
+
+  useEffect(() => {
+    if (userCapabilities.isLoading || canManagePersonalLists) return;
+    if (profile) {
+      setTasteSeedDismissed(profile.id);
+    }
+    navigate(isReturning ? "/settings/playback" : "/", { replace: true });
+  }, [canManagePersonalLists, isReturning, navigate, profile, userCapabilities.isLoading]);
 
   // Flatten paginated pages into a single item list.
   const items = useMemo(() => data?.pages.flatMap((p) => p.items) ?? [], [data]);
@@ -86,6 +97,7 @@ export default function TasteSeed() {
   }, [navigate, profile, isReturning]);
 
   const handleSubmit = useCallback(async () => {
+    if (!canManagePersonalLists) return;
     if (selected.size < MIN_PICKS) {
       toast.error(`Pick at least ${MIN_PICKS} to continue`);
       return;
@@ -121,9 +133,9 @@ export default function TasteSeed() {
     } catch (err) {
       toast.error(err instanceof Error ? err.message : "Failed to save your picks");
     }
-  }, [selected, items, submit, navigate, profile, isReturning]);
+  }, [canManagePersonalLists, selected, items, submit, navigate, profile, isReturning]);
 
-  const submitDisabled = selected.size < MIN_PICKS || submit.isPending;
+  const submitDisabled = !canManagePersonalLists || selected.size < MIN_PICKS || submit.isPending;
 
   return (
     <div className="min-h-[100dvh]">

--- a/web/src/pages/admin-settings/AdminSettingsLayout.test.tsx
+++ b/web/src/pages/admin-settings/AdminSettingsLayout.test.tsx
@@ -12,6 +12,17 @@ vi.mock("@/hooks/useSettingsForm", () => ({
   useSettingsForm: () => ({ isLoading: true }),
 }));
 
+vi.mock("@/hooks/queries/admin/settings", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@/hooks/queries/admin/settings")>();
+  return {
+    ...actual,
+    useJellyfinCompatStatus: () => ({ data: null, isLoading: false }),
+    useInstallJellyfinCompatWeb: () => ({ isPending: false, mutate: vi.fn() }),
+    useRemoveJellyfinCompatWeb: () => ({ isPending: false, mutate: vi.fn() }),
+    useUpdateJellyfinCompatSettings: () => ({ isPending: false, mutate: vi.fn() }),
+  };
+});
+
 function renderLayout(search = "") {
   return renderToStaticMarkup(
     <MemoryRouter initialEntries={[`/admin/settings${search}`]}>

--- a/web/src/pages/admin-settings/CompatibilityProxiesSettings.test.tsx
+++ b/web/src/pages/admin-settings/CompatibilityProxiesSettings.test.tsx
@@ -4,13 +4,50 @@ import { describe, expect, it, vi } from "vitest";
 import CompatibilityProxiesSettings from "./CompatibilityProxiesSettings";
 
 const useSettingsFormMock = vi.fn();
+const useJellyfinCompatStatusMock = vi.fn();
+const useInstallJellyfinCompatWebMock = vi.fn();
+const useRemoveJellyfinCompatWebMock = vi.fn();
+const useUpdateJellyfinCompatSettingsMock = vi.fn();
 
 vi.mock("@/hooks/useSettingsForm", () => ({
   useSettingsForm: (...args: unknown[]) => useSettingsFormMock(...args),
 }));
 
+vi.mock("@/hooks/queries/admin/settings", () => ({
+  useJellyfinCompatStatus: (...args: unknown[]) => useJellyfinCompatStatusMock(...args),
+  useInstallJellyfinCompatWeb: (...args: unknown[]) => useInstallJellyfinCompatWebMock(...args),
+  useRemoveJellyfinCompatWeb: (...args: unknown[]) => useRemoveJellyfinCompatWebMock(...args),
+  useUpdateJellyfinCompatSettings: (...args: unknown[]) =>
+    useUpdateJellyfinCompatSettingsMock(...args),
+}));
+
 describe("CompatibilityProxiesSettings", () => {
   it("shows Jellyfin and Audiobookshelf proxy settings", () => {
+    useJellyfinCompatStatusMock.mockReturnValue({
+      data: {
+        enabled: true,
+        api_state: "enabled",
+        listen: "",
+        public_url: "",
+        emulated_server_version: "10.10.7",
+        server_name: "Silo",
+        web_enabled: false,
+        web_state: "missing",
+        pinned_version: "",
+        source_url: "",
+        install_root: "",
+        install_path: "",
+        license_present: false,
+        provenance_present: false,
+        installer_ready: true,
+        prerequisites: [],
+        restart_required: false,
+      },
+      isLoading: false,
+    });
+    useInstallJellyfinCompatWebMock.mockReturnValue({ isPending: false, mutate: vi.fn() });
+    useRemoveJellyfinCompatWebMock.mockReturnValue({ isPending: false, mutate: vi.fn() });
+    useUpdateJellyfinCompatSettingsMock.mockReturnValue({ isPending: false, mutate: vi.fn() });
     useSettingsFormMock.mockReturnValue({
       isLoading: false,
       getValue: (key: string) => {
@@ -20,6 +57,7 @@ describe("CompatibilityProxiesSettings", () => {
       },
       setValue: vi.fn(),
       dirtyCount: 0,
+      dirtyKeys: [],
       save: vi.fn(),
       discard: vi.fn(),
       isSaving: false,

--- a/web/src/pages/adminAccessExplainModel.test.ts
+++ b/web/src/pages/adminAccessExplainModel.test.ts
@@ -1,0 +1,65 @@
+import { describe, expect, it } from "vitest";
+import {
+  accessExplanationReasonLabel,
+  accessExplanationSourceLabel,
+  formatPolicyValue,
+  policyLimitRows,
+} from "./adminAccessExplainModel";
+
+describe("admin access explanation model", () => {
+  it("labels cascade sources for admins", () => {
+    expect(accessExplanationSourceLabel({ type: "group", id: "standard_user", name: "User" })).toBe(
+      "Group: User",
+    );
+    expect(accessExplanationSourceLabel({ type: "builtin_role", id: "admin", name: "Admin" })).toBe(
+      "Built-in role: Admin",
+    );
+    expect(accessExplanationSourceLabel({ type: "default", name: "Default deny" })).toBe(
+      "Default deny",
+    );
+  });
+
+  it("labels access decision reasons", () => {
+    expect(
+      accessExplanationReasonLabel({
+        action: "playback.play",
+        resource_type: "media_item",
+        allowed: true,
+        reason_code: "rule_allow",
+        source: { type: "group", name: "User" },
+        matched_rules: [],
+        evaluated_rules: [],
+      }),
+    ).toBe("Allowed by rule");
+    expect(
+      accessExplanationReasonLabel({
+        action: "security.manage",
+        resource_type: "security_settings",
+        allowed: false,
+        reason_code: "default_deny",
+        source: { type: "default" },
+        matched_rules: [],
+        evaluated_rules: [],
+      }),
+    ).toBe("No matching allow");
+  });
+
+  it("formats effective policy rows", () => {
+    expect(formatPolicyValue(["movie", "ebook"])).toBe("movie, ebook");
+    expect(formatPolicyValue([])).toBe("All");
+    expect(formatPolicyValue(true)).toBe("Allowed");
+    expect(formatPolicyValue("")).toBe("Inherited");
+
+    const rows = policyLimitRows({
+      max_streams: 4,
+      max_transcodes: 2,
+      max_profiles: 5,
+      direct_downloads_allowed: true,
+      transcoded_downloads_allowed: false,
+    });
+
+    expect(rows).toContainEqual(["Max Streams", "4"]);
+    expect(rows).toContainEqual(["Direct Downloads", "Allowed"]);
+    expect(rows).toContainEqual(["Transcoded Downloads", "Not allowed"]);
+  });
+});

--- a/web/src/pages/adminAccessExplainModel.ts
+++ b/web/src/pages/adminAccessExplainModel.ts
@@ -1,0 +1,65 @@
+import type {
+  AdminACLActionExplanation,
+  AdminACLExplanationSource,
+  AdminEffectivePolicy,
+} from "@/api/types";
+
+export function accessExplanationSourceLabel(source: AdminACLExplanationSource) {
+  switch (source.type) {
+    case "group":
+      return source.name ? `Group: ${source.name}` : "Group";
+    case "builtin_role":
+      return source.name ? `Built-in role: ${source.name}` : "Built-in role";
+    case "legacy_permission":
+      return source.name || "Legacy permission";
+    case "user":
+      return source.name || "Direct user grant";
+    case "everyone":
+      return "Everyone";
+    case "default":
+      return "Default deny";
+    default:
+      return source.name || source.id || source.type;
+  }
+}
+
+export function accessExplanationReasonLabel(row: AdminACLActionExplanation) {
+  switch (row.reason_code) {
+    case "rule_allow":
+      return "Allowed by rule";
+    case "rule_deny":
+      return "Denied by rule";
+    case "default_deny":
+      return "No matching allow";
+    case "user_disabled":
+      return "User disabled";
+    default:
+      return row.reason_code;
+  }
+}
+
+export function formatPolicyValue(value: unknown) {
+  if (Array.isArray(value)) {
+    return value.length > 0 ? value.join(", ") : "All";
+  }
+  if (typeof value === "boolean") {
+    return value ? "Allowed" : "Not allowed";
+  }
+  if (value === "" || value == null) {
+    return "Inherited";
+  }
+  return String(value);
+}
+
+export function policyLimitRows(policy: AdminEffectivePolicy) {
+  return [
+    ["Libraries", formatPolicyValue(policy.library_ids)],
+    ["Media Types", formatPolicyValue(policy.media_types)],
+    ["Max Quality", formatPolicyValue(policy.max_playback_quality)],
+    ["Max Streams", formatPolicyValue(policy.max_streams)],
+    ["Max Transcodes", formatPolicyValue(policy.max_transcodes)],
+    ["Max Profiles", formatPolicyValue(policy.max_profiles)],
+    ["Direct Downloads", formatPolicyValue(policy.direct_downloads_allowed)],
+    ["Transcoded Downloads", formatPolicyValue(policy.transcoded_downloads_allowed)],
+  ] as const;
+}

--- a/web/src/pages/adminAccessGroupsModel.test.ts
+++ b/web/src/pages/adminAccessGroupsModel.test.ts
@@ -1,0 +1,72 @@
+import { describe, expect, it } from "vitest";
+import {
+  ACCESS_GROUP_ACTION_CATEGORIES,
+  ACCESS_GROUP_ACTIONS,
+  ACCESS_GROUP_PRESETS,
+  accessGroupSlugFromName,
+  buildAccessGroupRuleDrafts,
+  ruleResourceTypeForAction,
+} from "./adminAccessGroupsModel";
+
+describe("admin access groups model", () => {
+  it("generates stable slugs from names", () => {
+    expect(accessGroupSlugFromName("Movie Curators!")).toBe("movie_curators");
+    expect(accessGroupSlugFromName("  4K Streaming  ")).toBe("group_4k_streaming");
+  });
+
+  it("maps media actions to media item rules", () => {
+    expect(ruleResourceTypeForAction("metadata.curate")).toBe("media_item");
+    expect(ruleResourceTypeForAction("markers.edit")).toBe("media_item");
+    expect(ruleResourceTypeForAction("playback.play")).toBe("media_item");
+    expect(ruleResourceTypeForAction("personal_lists.manage")).toBe("media_item");
+  });
+
+  it("builds allow rules with shared conditions", () => {
+    const rules = buildAccessGroupRuleDrafts(["metadata.curate", "downloads.direct"], {
+      library_ids: [1, 2],
+      media_types: ["movie"],
+    });
+
+    expect(rules).toEqual([
+      {
+        action: "metadata.curate",
+        resource_type: "media_item",
+        resource_id: "*",
+        effect: "allow",
+        priority: 50,
+        name: "Metadata Curation",
+        description: "",
+        conditions: { library_ids: [1, 2], media_types: ["movie"] },
+      },
+      {
+        action: "downloads.direct",
+        resource_type: "media_item",
+        resource_id: "*",
+        effect: "allow",
+        priority: 50,
+        name: "Direct Downloads",
+        description: "",
+        conditions: { library_ids: [1, 2], media_types: ["movie"] },
+      },
+    ]);
+  });
+
+  it("defines helper descriptions for every access group option", () => {
+    for (const category of ACCESS_GROUP_ACTION_CATEGORIES) {
+      expect(category.description.trim().length, category.label).toBeGreaterThan(24);
+    }
+    for (const action of ACCESS_GROUP_ACTIONS) {
+      expect(action.description.trim().length, action.action).toBeGreaterThan(24);
+    }
+    for (const preset of ACCESS_GROUP_PRESETS) {
+      expect(preset.description.trim().length, preset.id).toBeGreaterThan(24);
+    }
+
+    expect(ACCESS_GROUP_ACTIONS.find((item) => item.action === "playback.play")?.description).toBe(
+      "Allows reading ebooks, listening to audiobooks, and playing video.",
+    );
+    expect(
+      ACCESS_GROUP_ACTIONS.find((item) => item.action === "security.manage")?.description,
+    ).toBe("Allows changing access groups, permissions, and security-sensitive settings.");
+  });
+});

--- a/web/src/pages/adminAccessGroupsModel.ts
+++ b/web/src/pages/adminAccessGroupsModel.ts
@@ -1,0 +1,304 @@
+import type { AdminACLCondition, AdminACLRuleWriteRequest } from "@/api/types";
+
+export const ACCESS_GROUP_ACTION_CATEGORIES = [
+  {
+    id: "administration",
+    label: "Administration",
+    description: "Server-wide administration tools, security controls, logs, and settings.",
+  },
+  {
+    id: "users",
+    label: "Users",
+    description: "People, profiles, requests, and user-owned lists.",
+  },
+  {
+    id: "content",
+    label: "Content",
+    description: "Libraries, metadata, markers, and recommendation management.",
+  },
+  {
+    id: "automation",
+    label: "Automation",
+    description: "Background tasks, plugins, and remote node administration.",
+  },
+  {
+    id: "playback",
+    label: "Playback",
+    description: "Reading, listening, streaming, transcoding, and downloads.",
+  },
+] as const;
+
+type AccessGroupActionCategory = (typeof ACCESS_GROUP_ACTION_CATEGORIES)[number]["id"];
+
+export const ACCESS_GROUP_ACTIONS = [
+  {
+    action: "server.view",
+    label: "Server View",
+    category: "administration",
+    description: "Allows access to admin overview pages and server status screens.",
+  },
+  {
+    action: "server.configure",
+    label: "Server Configuration",
+    category: "administration",
+    description: "Allows changing server settings that affect global behavior.",
+  },
+  {
+    action: "security.manage",
+    label: "Security Management",
+    category: "administration",
+    description: "Allows changing access groups, permissions, and security-sensitive settings.",
+  },
+  {
+    action: "logs.view",
+    label: "View Logs",
+    category: "administration",
+    description: "Allows viewing operational logs and diagnostic history.",
+  },
+  {
+    action: "users.view",
+    label: "View Users",
+    category: "users",
+    description: "Allows viewing user accounts, profiles, devices, and access details.",
+  },
+  {
+    action: "users.manage",
+    label: "Manage Users",
+    category: "users",
+    description: "Allows creating, editing, disabling, and deleting user accounts.",
+  },
+  {
+    action: "users.impersonate",
+    label: "Impersonate Users",
+    category: "users",
+    description: "Allows starting an admin impersonation session for another user.",
+  },
+  {
+    action: "profiles.manage",
+    label: "Manage Profiles",
+    category: "users",
+    description: "Allows creating, editing, and deleting profiles on user accounts.",
+  },
+  {
+    action: "personal_lists.manage",
+    label: "Manage Personal Lists",
+    category: "users",
+    description: "Allows changing favorites, watchlists, and other personal lists.",
+  },
+  {
+    action: "requests.create",
+    label: "Create Requests",
+    category: "users",
+    description: "Allows submitting requests for new media or content changes.",
+  },
+  {
+    action: "requests.approve",
+    label: "Approve Requests",
+    category: "users",
+    description: "Allows approving, declining, retrying, and managing user requests.",
+  },
+  {
+    action: "libraries.view",
+    label: "View Libraries",
+    category: "content",
+    description: "Allows viewing configured libraries, sections, and library details.",
+  },
+  {
+    action: "libraries.manage",
+    label: "Manage Libraries",
+    category: "content",
+    description: "Allows creating, editing, scanning, and deleting libraries.",
+  },
+  {
+    action: "metadata.curate",
+    label: "Metadata Curation",
+    category: "content",
+    description: "Allows editing metadata, matching items, and refreshing metadata.",
+  },
+  {
+    action: "markers.edit",
+    label: "Marker Editing",
+    category: "content",
+    description: "Allows editing intro, credits, and other playback markers.",
+  },
+  {
+    action: "recommendations.view",
+    label: "View Recommendations",
+    category: "content",
+    description: "Allows viewing recommendation configuration and status.",
+  },
+  {
+    action: "recommendations.manage",
+    label: "Manage Recommendations",
+    category: "content",
+    description: "Allows changing recommendation settings, rebuilds, and curation inputs.",
+  },
+  {
+    action: "tasks.view",
+    label: "View Tasks",
+    category: "automation",
+    description: "Allows viewing scheduled tasks, histories, and run status.",
+  },
+  {
+    action: "tasks.run",
+    label: "Run Tasks",
+    category: "automation",
+    description: "Allows manually starting maintenance, scan, and rebuild tasks.",
+  },
+  {
+    action: "plugins.view",
+    label: "View Plugins",
+    category: "automation",
+    description: "Allows viewing installed plugins, plugin status, and plugin configuration.",
+  },
+  {
+    action: "plugins.manage",
+    label: "Manage Plugins",
+    category: "automation",
+    description: "Allows installing, updating, configuring, and removing plugins.",
+  },
+  {
+    action: "nodes.view",
+    label: "View Nodes",
+    category: "automation",
+    description: "Allows viewing remote transcode nodes and node health.",
+  },
+  {
+    action: "nodes.manage",
+    label: "Manage Nodes",
+    category: "automation",
+    description: "Allows adding, editing, removing, and testing remote nodes.",
+  },
+  {
+    action: "playback.play",
+    label: "Read / Listen / Play",
+    category: "playback",
+    description: "Allows reading ebooks, listening to audiobooks, and playing video.",
+  },
+  {
+    action: "playback.transcode",
+    label: "Transcoding",
+    category: "playback",
+    description: "Allows playback that requires server-side transcoding.",
+  },
+  {
+    action: "downloads.direct",
+    label: "Direct Downloads",
+    category: "playback",
+    description: "Allows downloading original files without conversion.",
+  },
+  {
+    action: "downloads.transcode",
+    label: "Transcoded Downloads",
+    category: "playback",
+    description: "Allows creating converted downloads for compatibility or smaller files.",
+  },
+] as const satisfies readonly {
+  action: string;
+  label: string;
+  category: AccessGroupActionCategory;
+  description: string;
+}[];
+
+export type AccessGroupAction = (typeof ACCESS_GROUP_ACTIONS)[number]["action"];
+
+export const ACCESS_GROUP_PRESETS = [
+  {
+    id: "junior_admin",
+    label: "Junior Admin",
+    description: "Can view the server, manage users, and handle requests without library control.",
+    actions: ["server.view", "users.view", "users.manage", "requests.approve"],
+  },
+  {
+    id: "request_manager",
+    label: "Request Manager",
+    description: "Can create and approve requests without broader admin access.",
+    actions: ["requests.create", "requests.approve"],
+  },
+  {
+    id: "library_steward",
+    label: "Library Steward",
+    description: "Can manage libraries and curate metadata without managing users or security.",
+    actions: ["server.view", "libraries.manage", "metadata.curate", "markers.edit", "tasks.view"],
+  },
+] as const satisfies readonly {
+  id: string;
+  label: string;
+  description: string;
+  actions: readonly AccessGroupAction[];
+}[];
+
+const MEDIA_ACTIONS = new Set<AccessGroupAction>([
+  "playback.play",
+  "playback.transcode",
+  "downloads.direct",
+  "downloads.transcode",
+  "personal_lists.manage",
+  "metadata.curate",
+  "markers.edit",
+]);
+
+const GROUP_ACTIONS = new Set<AccessGroupAction>(["requests.create", "requests.approve"]);
+
+const USER_ACTIONS = new Set<AccessGroupAction>([
+  "users.view",
+  "users.manage",
+  "users.impersonate",
+]);
+
+const LIBRARY_ACTIONS = new Set<AccessGroupAction>(["libraries.view", "libraries.manage"]);
+
+const TASK_ACTIONS = new Set<AccessGroupAction>(["tasks.view", "tasks.run"]);
+
+const PLUGIN_ACTIONS = new Set<AccessGroupAction>(["plugins.view", "plugins.manage"]);
+
+const NODE_ACTIONS = new Set<AccessGroupAction>(["nodes.view", "nodes.manage"]);
+
+export function accessGroupSlugFromName(name: string): string {
+  const slug = name
+    .trim()
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "_")
+    .replace(/^_+|_+$/g, "")
+    .replace(/_{2,}/g, "_");
+  if (!slug) return "";
+  return /^[a-z]/.test(slug) ? slug : `group_${slug}`;
+}
+
+export function ruleResourceTypeForAction(action: AccessGroupAction): string {
+  if (MEDIA_ACTIONS.has(action)) return "media_item";
+  if (GROUP_ACTIONS.has(action)) return "request";
+  if (USER_ACTIONS.has(action)) return "user";
+  if (LIBRARY_ACTIONS.has(action)) return "library";
+  if (TASK_ACTIONS.has(action)) return "task";
+  if (action === "logs.view") return "log";
+  if (PLUGIN_ACTIONS.has(action)) return "plugin";
+  if (NODE_ACTIONS.has(action)) return "remote_node";
+  if (action === "profiles.manage") return "profile";
+  if (action === "security.manage") return "security_settings";
+  return "server";
+}
+
+export function buildAccessGroupRuleDrafts(
+  actions: readonly AccessGroupAction[],
+  conditions: AdminACLCondition,
+): AdminACLRuleWriteRequest[] {
+  return actions.map((action) => ({
+    action,
+    resource_type: ruleResourceTypeForAction(action),
+    resource_id: "*",
+    effect: "allow",
+    priority: 50,
+    name: accessGroupActionLabel(action),
+    description: "",
+    conditions: { ...conditions },
+  }));
+}
+
+export function accessGroupActionLabel(action: string): string {
+  return ACCESS_GROUP_ACTIONS.find((item) => item.action === action)?.label ?? action;
+}
+
+export function accessGroupActionDescription(action: string): string {
+  return ACCESS_GROUP_ACTIONS.find((item) => item.action === action)?.description ?? "";
+}

--- a/web/src/test-setup.ts
+++ b/web/src/test-setup.ts
@@ -1,1 +1,15 @@
 import "@testing-library/jest-dom";
+
+class MockResizeObserver {
+  observe() {}
+  unobserve() {}
+  disconnect() {}
+}
+
+if (!globalThis.ResizeObserver) {
+  Object.defineProperty(globalThis, "ResizeObserver", {
+    configurable: true,
+    writable: true,
+    value: MockResizeObserver,
+  });
+}


### PR DESCRIPTION
## Summary
- add ACL-backed admin/user capability checks and compatibility policy helpers
- add access group management UI, user access explanations, and helper tooltips
- apply capability checks across admin navigation, user actions, playback/download/request surfaces, and relevant tests

## Verification
- `GOWORK=off go test ./migrations ./internal/auth ./internal/api/handlers ./internal/api/middleware -count=1`
- `pnpm --dir web test`
- `pnpm --dir web build`
- deployed and smoke-tested on CT 120 with `silo-dev-silo-1` healthy on `silo-server:security-acl-dev`