### PR TITLE
fix(watchsync): correct Trakt TV episode sync payload

### DIFF
--- a/internal/watchstate/identity.go
+++ b/internal/watchstate/identity.go
@@ -56,6 +56,7 @@ func (r *StableIdentityResolver) ResolveHistoryIdentity(ctx context.Context, med
 			episodeNumber := episode.EpisodeNumber
 			return userstore.WatchIdentity{
 				StableType:        "episode",
+				ProviderIDs:       episodeProviderIDs(episode),
 				SeriesProviderIDs: seriesIDs,
 				Season:            &seasonNumber,
 				Episode:           &episodeNumber,
@@ -117,6 +118,24 @@ func (r *StableIdentityResolver) loadProviderIDs(ctx context.Context, contentID 
 	ids, err := r.providerIDs.GetByContentID(ctx, contentID)
 	if err != nil {
 		return nil
+	}
+	return ids
+}
+
+// episodeProviderIDs extracts the episode's own external IDs (populated by
+// metadata enrichment on the episodes table). When present, exports can address
+// the play by a real episode ID via the flat Trakt episodes[] form; when absent,
+// the caller still carries SeriesProviderIDs + season/episode for the nested form.
+func episodeProviderIDs(episode *models.Episode) map[string]string {
+	ids := map[string]string{}
+	if v := strings.TrimSpace(episode.ImdbID); v != "" {
+		ids["imdb"] = v
+	}
+	if v := strings.TrimSpace(episode.TmdbID); v != "" {
+		ids["tmdb"] = v
+	}
+	if v := strings.TrimSpace(episode.TvdbID); v != "" {
+		ids["tvdb"] = v
 	}
 	return ids
 }

--- a/internal/watchstate/identity.go
+++ b/internal/watchstate/identity.go
@@ -48,15 +48,19 @@ func (r *StableIdentityResolver) ResolveHistoryIdentity(ctx context.Context, med
 	if r.episodes != nil {
 		episode, err := r.episodes.GetByID(ctx, mediaItemID)
 		if err == nil && episode != nil {
+			episodeIDs := episodeProviderIDs(episode)
 			seriesIDs := providerIDMap(r.loadProviderIDs(ctx, episode.SeriesID))
-			if len(seriesIDs) == 0 {
+			// Only require series IDs when the episode has no IDs of its own:
+			// an episode with its own IMDb/TMDB/TVDB ID is addressable on the
+			// flat episodes[].ids path without needing the nested show fallback.
+			if len(episodeIDs) == 0 && len(seriesIDs) == 0 {
 				return userstore.WatchIdentity{}
 			}
 			seasonNumber := episode.SeasonNumber
 			episodeNumber := episode.EpisodeNumber
 			return userstore.WatchIdentity{
 				StableType:        "episode",
-				ProviderIDs:       episodeProviderIDs(episode),
+				ProviderIDs:       episodeIDs,
 				SeriesProviderIDs: seriesIDs,
 				Season:            &seasonNumber,
 				Episode:           &episodeNumber,

--- a/internal/watchsync/providers/trakt/provider.go
+++ b/internal/watchsync/providers/trakt/provider.go
@@ -424,7 +424,7 @@ func (p *Provider) ExportHistory(
 	plays []watchsync.LocalPlay,
 ) (watchsync.ExportResult, error) {
 	payload := buildHistoryPayload(plays)
-	if len(payload.Movies) == 0 && len(payload.Episodes) == 0 {
+	if len(payload.Movies) == 0 && len(payload.Episodes) == 0 && len(payload.Shows) == 0 {
 		return watchsync.ExportResult{}, nil
 	}
 	var body bytes.Buffer
@@ -532,7 +532,7 @@ func (p *Provider) RemoveHistory(
 	plays []watchsync.LocalPlay,
 ) (watchsync.ExportResult, error) {
 	payload := buildHistoryRemovePayload(plays)
-	if len(payload.Movies) == 0 && len(payload.Episodes) == 0 {
+	if len(payload.Movies) == 0 && len(payload.Episodes) == 0 && len(payload.Shows) == 0 {
 		return watchsync.ExportResult{}, nil
 	}
 	var body bytes.Buffer
@@ -750,11 +750,13 @@ func episodeKey(showIDs traktIDs, season, episode int, episodeIDs traktIDs) stri
 type traktHistoryPayload struct {
 	Movies   []traktHistoryMovie   `json:"movies,omitempty"`
 	Episodes []traktHistoryEpisode `json:"episodes,omitempty"`
+	Shows    []traktHistoryShow    `json:"shows,omitempty"`
 }
 
 type traktHistoryRemovePayload struct {
 	Movies   []traktHistoryRemoveMovie   `json:"movies,omitempty"`
 	Episodes []traktHistoryRemoveEpisode `json:"episodes,omitempty"`
+	Shows    []traktHistoryRemoveShow    `json:"shows,omitempty"`
 }
 
 type traktFavoritesPayload struct {
@@ -783,23 +785,79 @@ type traktHistoryRemoveMovie struct {
 	IDs traktIDs `json:"ids"`
 }
 
+// traktHistoryEpisode addresses an episode by its OWN episode-level id in the
+// flat episodes[] array. Episodes lacking their own id go through the nested
+// shows[] structure instead (see traktHistoryShow).
 type traktHistoryEpisode struct {
-	WatchedAt string    `json:"watched_at"`
-	IDs       *traktIDs `json:"ids,omitempty"`
-	Show      *struct {
-		IDs traktIDs `json:"ids"`
-	} `json:"show,omitempty"`
-	Season int `json:"season"`
-	Number int `json:"number"`
+	WatchedAt string   `json:"watched_at"`
+	IDs       traktIDs `json:"ids"`
 }
 
 type traktHistoryRemoveEpisode struct {
-	IDs  *traktIDs `json:"ids,omitempty"`
-	Show *struct {
-		IDs traktIDs `json:"ids"`
-	} `json:"show,omitempty"`
-	Season int `json:"season"`
+	IDs traktIDs `json:"ids"`
+}
+
+// traktHistoryShow is the nested add form: an episode is addressed by
+// show ids -> season number -> episode number, which is the only shape Trakt
+// accepts when the episode itself carries no external id.
+type traktHistoryShow struct {
+	IDs     traktIDs             `json:"ids"`
+	Seasons []traktHistorySeason `json:"seasons"`
+}
+
+type traktHistorySeason struct {
+	Number   int                       `json:"number"`
+	Episodes []traktHistoryShowEpisode `json:"episodes"`
+}
+
+type traktHistoryShowEpisode struct {
+	Number    int    `json:"number"`
+	WatchedAt string `json:"watched_at"`
+}
+
+// traktHistoryRemoveShow mirrors traktHistoryShow for /sync/history/remove,
+// where watched_at is not required.
+type traktHistoryRemoveShow struct {
+	IDs     traktIDs                   `json:"ids"`
+	Seasons []traktHistoryRemoveSeason `json:"seasons"`
+}
+
+type traktHistoryRemoveSeason struct {
+	Number   int                             `json:"number"`
+	Episodes []traktHistoryRemoveShowEpisode `json:"episodes"`
+}
+
+type traktHistoryRemoveShowEpisode struct {
 	Number int `json:"number"`
+}
+
+// playOwnIDs builds the item's OWN external ids (movie or episode level).
+func playOwnIDs(play watchsync.LocalPlay) traktIDs {
+	ids := traktIDs{IMDb: play.IMDbID}
+	if play.TVDBID != "" {
+		ids.TVDB, _ = strconv.Atoi(play.TVDBID)
+	}
+	if play.TMDBID != "" {
+		ids.TMDB, _ = strconv.Atoi(play.TMDBID)
+	}
+	return ids
+}
+
+// playSeriesIDs builds the parent show's external ids, used for the nested
+// shows[] fallback when an episode has no id of its own.
+func playSeriesIDs(play watchsync.LocalPlay) traktIDs {
+	ids := traktIDs{IMDb: play.SeriesIMDbID}
+	if play.SeriesTVDBID != "" {
+		ids.TVDB, _ = strconv.Atoi(play.SeriesTVDBID)
+	}
+	if play.SeriesTMDBID != "" {
+		ids.TMDB, _ = strconv.Atoi(play.SeriesTMDBID)
+	}
+	return ids
+}
+
+func hasAnyID(ids traktIDs) bool {
+	return ids.TVDB != 0 || ids.TMDB != 0 || ids.IMDb != ""
 }
 
 func buildHistoryPayload(plays []watchsync.LocalPlay) traktHistoryPayload {
@@ -808,41 +866,20 @@ func buildHistoryPayload(plays []watchsync.LocalPlay) traktHistoryPayload {
 		watchedAt := play.WatchedAt.UTC().Format(time.RFC3339)
 		switch play.Kind {
 		case historyimport.KindMovie:
-			ids := traktIDs{IMDb: play.IMDbID}
-			if play.TVDBID != "" {
-				ids.TVDB, _ = strconv.Atoi(play.TVDBID)
-			}
-			if play.TMDBID != "" {
-				ids.TMDB, _ = strconv.Atoi(play.TMDBID)
-			}
-			payload.Movies = append(payload.Movies, traktHistoryMovie{WatchedAt: watchedAt, IDs: ids})
+			payload.Movies = append(payload.Movies, traktHistoryMovie{WatchedAt: watchedAt, IDs: playOwnIDs(play)})
 		case historyimport.KindEpisode:
-			ids := traktIDs{IMDb: play.IMDbID}
-			if play.TVDBID != "" {
-				ids.TVDB, _ = strconv.Atoi(play.TVDBID)
+			if ids := playOwnIDs(play); hasAnyID(ids) {
+				payload.Episodes = append(payload.Episodes, traktHistoryEpisode{WatchedAt: watchedAt, IDs: ids})
+				continue
 			}
-			if play.TMDBID != "" {
-				ids.TMDB, _ = strconv.Atoi(play.TMDBID)
-			}
-			row := traktHistoryEpisode{WatchedAt: watchedAt, Season: play.SeasonNumber, Number: play.EpisodeNumber}
-			if ids.TVDB != 0 || ids.TMDB != 0 || ids.IMDb != "" {
-				row.IDs = &ids
-			} else {
-				showIDs := traktIDs{IMDb: play.SeriesIMDbID}
-				if play.SeriesTVDBID != "" {
-					showIDs.TVDB, _ = strconv.Atoi(play.SeriesTVDBID)
-				}
-				if play.SeriesTMDBID != "" {
-					showIDs.TMDB, _ = strconv.Atoi(play.SeriesTMDBID)
-				}
-				row.Show = &struct {
-					IDs traktIDs `json:"ids"`
-				}{IDs: showIDs}
-				slog.Debug("trakt history export: episode has no episode ids, falling back to show",
-					"show_tmdb", showIDs.TMDB, "show_tvdb", showIDs.TVDB, "show_imdb", showIDs.IMDb,
-					"season", play.SeasonNumber, "number", play.EpisodeNumber)
-			}
-			payload.Episodes = append(payload.Episodes, row)
+			showIDs := playSeriesIDs(play)
+			slog.Debug("trakt history export: episode has no episode ids, using nested show fallback",
+				"show_tmdb", showIDs.TMDB, "show_tvdb", showIDs.TVDB, "show_imdb", showIDs.IMDb,
+				"season", play.SeasonNumber, "number", play.EpisodeNumber)
+			payload.Shows = appendNestedEpisode(payload.Shows, showIDs, play.SeasonNumber, traktHistoryShowEpisode{
+				Number:    play.EpisodeNumber,
+				WatchedAt: watchedAt,
+			})
 		}
 	}
 	return payload
@@ -853,44 +890,79 @@ func buildHistoryRemovePayload(plays []watchsync.LocalPlay) traktHistoryRemovePa
 	for _, play := range plays {
 		switch play.Kind {
 		case historyimport.KindMovie:
-			ids := traktIDs{IMDb: play.IMDbID}
-			if play.TVDBID != "" {
-				ids.TVDB, _ = strconv.Atoi(play.TVDBID)
-			}
-			if play.TMDBID != "" {
-				ids.TMDB, _ = strconv.Atoi(play.TMDBID)
-			}
-			payload.Movies = append(payload.Movies, traktHistoryRemoveMovie{IDs: ids})
+			payload.Movies = append(payload.Movies, traktHistoryRemoveMovie{IDs: playOwnIDs(play)})
 		case historyimport.KindEpisode:
-			ids := traktIDs{IMDb: play.IMDbID}
-			if play.TVDBID != "" {
-				ids.TVDB, _ = strconv.Atoi(play.TVDBID)
+			if ids := playOwnIDs(play); hasAnyID(ids) {
+				payload.Episodes = append(payload.Episodes, traktHistoryRemoveEpisode{IDs: ids})
+				continue
 			}
-			if play.TMDBID != "" {
-				ids.TMDB, _ = strconv.Atoi(play.TMDBID)
-			}
-			row := traktHistoryRemoveEpisode{Season: play.SeasonNumber, Number: play.EpisodeNumber}
-			if ids.TVDB != 0 || ids.TMDB != 0 || ids.IMDb != "" {
-				row.IDs = &ids
-			} else {
-				showIDs := traktIDs{IMDb: play.SeriesIMDbID}
-				if play.SeriesTVDBID != "" {
-					showIDs.TVDB, _ = strconv.Atoi(play.SeriesTVDBID)
-				}
-				if play.SeriesTMDBID != "" {
-					showIDs.TMDB, _ = strconv.Atoi(play.SeriesTMDBID)
-				}
-				row.Show = &struct {
-					IDs traktIDs `json:"ids"`
-				}{IDs: showIDs}
-				slog.Debug("trakt history remove: episode has no episode ids, falling back to show",
-					"show_tmdb", showIDs.TMDB, "show_tvdb", showIDs.TVDB, "show_imdb", showIDs.IMDb,
-					"season", play.SeasonNumber, "number", play.EpisodeNumber)
-			}
-			payload.Episodes = append(payload.Episodes, row)
+			showIDs := playSeriesIDs(play)
+			slog.Debug("trakt history remove: episode has no episode ids, using nested show fallback",
+				"show_tmdb", showIDs.TMDB, "show_tvdb", showIDs.TVDB, "show_imdb", showIDs.IMDb,
+				"season", play.SeasonNumber, "number", play.EpisodeNumber)
+			payload.Shows = appendNestedRemoveEpisode(payload.Shows, showIDs, play.SeasonNumber, traktHistoryRemoveShowEpisode{
+				Number: play.EpisodeNumber,
+			})
 		}
 	}
 	return payload
+}
+
+// appendNestedEpisode inserts an episode under the nested shows[] structure,
+// merging by show ids then by season number so repeated episodes of the same
+// show/season collapse into a single show + season entry.
+func appendNestedEpisode(shows []traktHistoryShow, showIDs traktIDs, season int, episode traktHistoryShowEpisode) []traktHistoryShow {
+	idx := -1
+	for i := range shows {
+		if shows[i].IDs == showIDs {
+			idx = i
+			break
+		}
+	}
+	if idx == -1 {
+		shows = append(shows, traktHistoryShow{IDs: showIDs})
+		idx = len(shows) - 1
+	}
+	sIdx := -1
+	for i := range shows[idx].Seasons {
+		if shows[idx].Seasons[i].Number == season {
+			sIdx = i
+			break
+		}
+	}
+	if sIdx == -1 {
+		shows[idx].Seasons = append(shows[idx].Seasons, traktHistorySeason{Number: season})
+		sIdx = len(shows[idx].Seasons) - 1
+	}
+	shows[idx].Seasons[sIdx].Episodes = append(shows[idx].Seasons[sIdx].Episodes, episode)
+	return shows
+}
+
+func appendNestedRemoveEpisode(shows []traktHistoryRemoveShow, showIDs traktIDs, season int, episode traktHistoryRemoveShowEpisode) []traktHistoryRemoveShow {
+	idx := -1
+	for i := range shows {
+		if shows[i].IDs == showIDs {
+			idx = i
+			break
+		}
+	}
+	if idx == -1 {
+		shows = append(shows, traktHistoryRemoveShow{IDs: showIDs})
+		idx = len(shows) - 1
+	}
+	sIdx := -1
+	for i := range shows[idx].Seasons {
+		if shows[idx].Seasons[i].Number == season {
+			sIdx = i
+			break
+		}
+	}
+	if sIdx == -1 {
+		shows[idx].Seasons = append(shows[idx].Seasons, traktHistoryRemoveSeason{Number: season})
+		sIdx = len(shows[idx].Seasons) - 1
+	}
+	shows[idx].Seasons[sIdx].Episodes = append(shows[idx].Seasons[sIdx].Episodes, episode)
+	return shows
 }
 
 func buildFavoritesPayload(favorites []watchsync.LocalFavorite) traktFavoritesPayload {

--- a/internal/watchsync/providers/trakt/provider.go
+++ b/internal/watchsync/providers/trakt/provider.go
@@ -7,6 +7,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"log/slog"
 	"net/http"
 	"strconv"
 	"strings"
@@ -783,8 +784,8 @@ type traktHistoryRemoveMovie struct {
 }
 
 type traktHistoryEpisode struct {
-	WatchedAt string   `json:"watched_at"`
-	IDs       traktIDs `json:"ids,omitempty"`
+	WatchedAt string    `json:"watched_at"`
+	IDs       *traktIDs `json:"ids,omitempty"`
 	Show      *struct {
 		IDs traktIDs `json:"ids"`
 	} `json:"show,omitempty"`
@@ -793,7 +794,7 @@ type traktHistoryEpisode struct {
 }
 
 type traktHistoryRemoveEpisode struct {
-	IDs  traktIDs `json:"ids,omitempty"`
+	IDs  *traktIDs `json:"ids,omitempty"`
 	Show *struct {
 		IDs traktIDs `json:"ids"`
 	} `json:"show,omitempty"`
@@ -823,8 +824,10 @@ func buildHistoryPayload(plays []watchsync.LocalPlay) traktHistoryPayload {
 			if play.TMDBID != "" {
 				ids.TMDB, _ = strconv.Atoi(play.TMDBID)
 			}
-			row := traktHistoryEpisode{WatchedAt: watchedAt, IDs: ids, Season: play.SeasonNumber, Number: play.EpisodeNumber}
-			if ids.TVDB == 0 && ids.TMDB == 0 && ids.IMDb == "" {
+			row := traktHistoryEpisode{WatchedAt: watchedAt, Season: play.SeasonNumber, Number: play.EpisodeNumber}
+			if ids.TVDB != 0 || ids.TMDB != 0 || ids.IMDb != "" {
+				row.IDs = &ids
+			} else {
 				showIDs := traktIDs{IMDb: play.SeriesIMDbID}
 				if play.SeriesTVDBID != "" {
 					showIDs.TVDB, _ = strconv.Atoi(play.SeriesTVDBID)
@@ -835,6 +838,9 @@ func buildHistoryPayload(plays []watchsync.LocalPlay) traktHistoryPayload {
 				row.Show = &struct {
 					IDs traktIDs `json:"ids"`
 				}{IDs: showIDs}
+				slog.Debug("trakt history export: episode has no episode ids, falling back to show",
+					"show_tmdb", showIDs.TMDB, "show_tvdb", showIDs.TVDB, "show_imdb", showIDs.IMDb,
+					"season", play.SeasonNumber, "number", play.EpisodeNumber)
 			}
 			payload.Episodes = append(payload.Episodes, row)
 		}
@@ -863,8 +869,10 @@ func buildHistoryRemovePayload(plays []watchsync.LocalPlay) traktHistoryRemovePa
 			if play.TMDBID != "" {
 				ids.TMDB, _ = strconv.Atoi(play.TMDBID)
 			}
-			row := traktHistoryRemoveEpisode{IDs: ids, Season: play.SeasonNumber, Number: play.EpisodeNumber}
-			if ids.TVDB == 0 && ids.TMDB == 0 && ids.IMDb == "" {
+			row := traktHistoryRemoveEpisode{Season: play.SeasonNumber, Number: play.EpisodeNumber}
+			if ids.TVDB != 0 || ids.TMDB != 0 || ids.IMDb != "" {
+				row.IDs = &ids
+			} else {
 				showIDs := traktIDs{IMDb: play.SeriesIMDbID}
 				if play.SeriesTVDBID != "" {
 					showIDs.TVDB, _ = strconv.Atoi(play.SeriesTVDBID)
@@ -875,6 +883,9 @@ func buildHistoryRemovePayload(plays []watchsync.LocalPlay) traktHistoryRemovePa
 				row.Show = &struct {
 					IDs traktIDs `json:"ids"`
 				}{IDs: showIDs}
+				slog.Debug("trakt history remove: episode has no episode ids, falling back to show",
+					"show_tmdb", showIDs.TMDB, "show_tvdb", showIDs.TVDB, "show_imdb", showIDs.IMDb,
+					"season", play.SeasonNumber, "number", play.EpisodeNumber)
 			}
 			payload.Episodes = append(payload.Episodes, row)
 		}

--- a/internal/watchsync/providers/trakt/provider_test.go
+++ b/internal/watchsync/providers/trakt/provider_test.go
@@ -186,13 +186,38 @@ func TestRemoveHistorySendsTraktRemovePayload(t *testing.T) {
 	if len(movies) != 1 {
 		t.Fatalf("movies payload = %#v, want 1 movie", gotBody["movies"])
 	}
-	episodes, _ := gotBody["episodes"].([]any)
-	if len(episodes) != 1 {
-		t.Fatalf("episodes payload = %#v, want 1 episode", gotBody["episodes"])
+	// The episode carries only a series id + season/episode number, so it must
+	// land in the nested shows[] structure, not the flat episodes[] array.
+	if _, ok := gotBody["episodes"]; ok {
+		t.Fatalf("episodes payload unexpectedly present: %#v", gotBody["episodes"])
 	}
-	episode, _ := episodes[0].(map[string]any)
-	if episode["season"] != float64(0) || episode["number"] != float64(2) {
-		t.Fatalf("episode payload = %#v, want S00E02", episode)
+	shows, _ := gotBody["shows"].([]any)
+	if len(shows) != 1 {
+		t.Fatalf("shows payload = %#v, want 1 show", gotBody["shows"])
+	}
+	show, _ := shows[0].(map[string]any)
+	showIDs, _ := show["ids"].(map[string]any)
+	if showIDs["tvdb"] != float64(789) {
+		t.Fatalf("show ids = %#v, want tvdb 789", show["ids"])
+	}
+	seasons, _ := show["seasons"].([]any)
+	if len(seasons) != 1 {
+		t.Fatalf("seasons payload = %#v, want 1 season", show["seasons"])
+	}
+	season, _ := seasons[0].(map[string]any)
+	if season["number"] != float64(0) {
+		t.Fatalf("season payload = %#v, want season 0", season)
+	}
+	seasonEpisodes, _ := season["episodes"].([]any)
+	if len(seasonEpisodes) != 1 {
+		t.Fatalf("season episodes = %#v, want 1 episode", season["episodes"])
+	}
+	seasonEpisode, _ := seasonEpisodes[0].(map[string]any)
+	if seasonEpisode["number"] != float64(2) {
+		t.Fatalf("episode payload = %#v, want number 2", seasonEpisode)
+	}
+	if _, ok := seasonEpisode["watched_at"]; ok {
+		t.Fatalf("remove episode unexpectedly included watched_at: %#v", seasonEpisode)
 	}
 }
 
@@ -324,7 +349,7 @@ func TestHistoryPayloadsIncludeTVDBOnlyMovieIDs(t *testing.T) {
 	}
 }
 
-func TestHistoryEpisodeWithEmptyIDsOmitsEpisodeIDsAndUsesShowFallback(t *testing.T) {
+func TestHistoryEpisodeWithoutOwnIDsUsesNestedShowFallback(t *testing.T) {
 	play := watchsync.LocalPlay{
 		HistoryID:     "history-episode-no-ids",
 		Kind:          historyimport.KindEpisode,
@@ -335,40 +360,101 @@ func TestHistoryEpisodeWithEmptyIDsOmitsEpisodeIDsAndUsesShowFallback(t *testing
 	}
 
 	addPayload := buildHistoryPayload([]watchsync.LocalPlay{play})
-	if len(addPayload.Episodes) != 1 {
-		t.Fatalf("add payload episodes = %#v, want 1", addPayload.Episodes)
+	if len(addPayload.Episodes) != 0 {
+		t.Fatalf("add payload episodes = %#v, want 0 (episode has no own id)", addPayload.Episodes)
 	}
-	addEp := addPayload.Episodes[0]
-	if addEp.IDs != nil {
-		t.Fatalf("add payload episode IDs = %#v, want nil", addEp.IDs)
+	if len(addPayload.Shows) != 1 {
+		t.Fatalf("add payload shows = %#v, want 1", addPayload.Shows)
 	}
-	if addEp.Show == nil || addEp.Show.IDs.TMDB != 999 {
-		t.Fatalf("add payload episode show = %#v, want show TMDB 999", addEp.Show)
+	addShow := addPayload.Shows[0]
+	if addShow.IDs.TMDB != 999 {
+		t.Fatalf("add payload show IDs = %#v, want show TMDB 999", addShow.IDs)
+	}
+	if len(addShow.Seasons) != 1 || addShow.Seasons[0].Number != 2 {
+		t.Fatalf("add payload seasons = %#v, want 1 season numbered 2", addShow.Seasons)
+	}
+	if len(addShow.Seasons[0].Episodes) != 1 || addShow.Seasons[0].Episodes[0].Number != 5 {
+		t.Fatalf("add payload episodes = %#v, want 1 episode numbered 5", addShow.Seasons[0].Episodes)
+	}
+	if addShow.Seasons[0].Episodes[0].WatchedAt != "2026-05-04T12:00:00Z" {
+		t.Fatalf("add payload episode watched_at = %q", addShow.Seasons[0].Episodes[0].WatchedAt)
 	}
 
 	addJSON, err := json.Marshal(addPayload)
 	if err != nil {
 		t.Fatalf("marshal add payload: %v", err)
 	}
-	assertNoZeroEpisodeIDs(t, addJSON, "add")
+	if bytes.Contains(addJSON, []byte(`"episodes":[{"watched_at"`)) {
+		t.Fatalf("add payload JSON must not carry a flat episode with show sibling: %s", addJSON)
+	}
+	if !bytes.Contains(addJSON, []byte(`"shows":[{"ids":{"trakt":0,"slug":"","imdb":"","tmdb":999,"tvdb":0}`)) {
+		t.Fatalf("add payload JSON missing nested show: %s", addJSON)
+	}
 
 	removePayload := buildHistoryRemovePayload([]watchsync.LocalPlay{play})
-	if len(removePayload.Episodes) != 1 {
-		t.Fatalf("remove payload episodes = %#v, want 1", removePayload.Episodes)
+	if len(removePayload.Episodes) != 0 {
+		t.Fatalf("remove payload episodes = %#v, want 0", removePayload.Episodes)
 	}
-	removeEp := removePayload.Episodes[0]
-	if removeEp.IDs != nil {
-		t.Fatalf("remove payload episode IDs = %#v, want nil", removeEp.IDs)
+	if len(removePayload.Shows) != 1 {
+		t.Fatalf("remove payload shows = %#v, want 1", removePayload.Shows)
 	}
-	if removeEp.Show == nil || removeEp.Show.IDs.TMDB != 999 {
-		t.Fatalf("remove payload episode show = %#v, want show TMDB 999", removeEp.Show)
+	removeShow := removePayload.Shows[0]
+	if removeShow.IDs.TMDB != 999 {
+		t.Fatalf("remove payload show IDs = %#v, want show TMDB 999", removeShow.IDs)
+	}
+	if len(removeShow.Seasons) != 1 || removeShow.Seasons[0].Number != 2 {
+		t.Fatalf("remove payload seasons = %#v, want 1 season numbered 2", removeShow.Seasons)
+	}
+	if len(removeShow.Seasons[0].Episodes) != 1 || removeShow.Seasons[0].Episodes[0].Number != 5 {
+		t.Fatalf("remove payload episodes = %#v, want 1 episode numbered 5", removeShow.Seasons[0].Episodes)
 	}
 
 	removeJSON, err := json.Marshal(removePayload)
 	if err != nil {
 		t.Fatalf("marshal remove payload: %v", err)
 	}
-	assertNoZeroEpisodeIDs(t, removeJSON, "remove")
+	if bytes.Contains(removeJSON, []byte(`"watched_at"`)) {
+		t.Fatalf("remove payload JSON must not carry watched_at: %s", removeJSON)
+	}
+}
+
+func TestHistoryNestedFallbackMergesEpisodesBySeason(t *testing.T) {
+	plays := []watchsync.LocalPlay{
+		{
+			Kind:          historyimport.KindEpisode,
+			SeriesTMDBID:  "999",
+			SeasonNumber:  1,
+			EpisodeNumber: 3,
+			WatchedAt:     time.Date(2026, 5, 4, 12, 0, 0, 0, time.UTC),
+		},
+		{
+			Kind:          historyimport.KindEpisode,
+			SeriesTMDBID:  "999",
+			SeasonNumber:  1,
+			EpisodeNumber: 4,
+			WatchedAt:     time.Date(2026, 5, 5, 12, 0, 0, 0, time.UTC),
+		},
+	}
+
+	addPayload := buildHistoryPayload(plays)
+	if len(addPayload.Shows) != 1 {
+		t.Fatalf("shows = %#v, want 1 merged show", addPayload.Shows)
+	}
+	show := addPayload.Shows[0]
+	if len(show.Seasons) != 1 {
+		t.Fatalf("seasons = %#v, want 1 merged season", show.Seasons)
+	}
+	if len(show.Seasons[0].Episodes) != 2 {
+		t.Fatalf("episodes = %#v, want 2 episodes under one season", show.Seasons[0].Episodes)
+	}
+	if show.Seasons[0].Episodes[0].Number != 3 || show.Seasons[0].Episodes[1].Number != 4 {
+		t.Fatalf("episode numbers = %#v, want [3 4]", show.Seasons[0].Episodes)
+	}
+
+	removePayload := buildHistoryRemovePayload(plays)
+	if len(removePayload.Shows) != 1 || len(removePayload.Shows[0].Seasons) != 1 || len(removePayload.Shows[0].Seasons[0].Episodes) != 2 {
+		t.Fatalf("remove payload did not merge by show/season: %#v", removePayload.Shows)
+	}
 }
 
 func TestHistoryEpisodeWithRealIDsKeepsEpisodeIDs(t *testing.T) {
@@ -386,12 +472,11 @@ func TestHistoryEpisodeWithRealIDsKeepsEpisodeIDs(t *testing.T) {
 	if len(addPayload.Episodes) != 1 {
 		t.Fatalf("add payload episodes = %#v, want 1", addPayload.Episodes)
 	}
-	addEp := addPayload.Episodes[0]
-	if addEp.IDs == nil || addEp.IDs.TVDB != 54321 {
-		t.Fatalf("add payload episode IDs = %#v, want TVDB 54321", addEp.IDs)
+	if addPayload.Episodes[0].IDs.TVDB != 54321 {
+		t.Fatalf("add payload episode IDs = %#v, want TVDB 54321", addPayload.Episodes[0].IDs)
 	}
-	if addEp.Show != nil {
-		t.Fatalf("add payload episode show = %#v, want nil", addEp.Show)
+	if len(addPayload.Shows) != 0 {
+		t.Fatalf("add payload shows = %#v, want none", addPayload.Shows)
 	}
 
 	addJSON, err := json.Marshal(addPayload)
@@ -406,12 +491,11 @@ func TestHistoryEpisodeWithRealIDsKeepsEpisodeIDs(t *testing.T) {
 	if len(removePayload.Episodes) != 1 {
 		t.Fatalf("remove payload episodes = %#v, want 1", removePayload.Episodes)
 	}
-	removeEp := removePayload.Episodes[0]
-	if removeEp.IDs == nil || removeEp.IDs.TVDB != 54321 {
-		t.Fatalf("remove payload episode IDs = %#v, want TVDB 54321", removeEp.IDs)
+	if removePayload.Episodes[0].IDs.TVDB != 54321 {
+		t.Fatalf("remove payload episode IDs = %#v, want TVDB 54321", removePayload.Episodes[0].IDs)
 	}
-	if removeEp.Show != nil {
-		t.Fatalf("remove payload episode show = %#v, want nil", removeEp.Show)
+	if len(removePayload.Shows) != 0 {
+		t.Fatalf("remove payload shows = %#v, want none", removePayload.Shows)
 	}
 
 	removeJSON, err := json.Marshal(removePayload)
@@ -420,38 +504,5 @@ func TestHistoryEpisodeWithRealIDsKeepsEpisodeIDs(t *testing.T) {
 	}
 	if !bytes.Contains(removeJSON, []byte(`"tvdb":54321`)) {
 		t.Fatalf("remove payload JSON missing real episode id: %s", removeJSON)
-	}
-}
-
-// assertNoZeroEpisodeIDs verifies the marshaled history payload does not contain
-// a top-level episode "ids" object (which would carry zero values) and does carry
-// the show fallback id. The legitimate show.ids object may contain zero members
-// (e.g. tvdb:0 when only tmdb is known); we only guard against an episode-level
-// "ids" key, which is what previously matched Trakt to the wrong series.
-func assertNoZeroEpisodeIDs(t *testing.T, payload []byte, label string) {
-	t.Helper()
-	var parsed struct {
-		Episodes []struct {
-			IDs  json.RawMessage `json:"ids"`
-			Show struct {
-				IDs traktIDs `json:"ids"`
-			} `json:"show"`
-		} `json:"episodes"`
-	}
-	if err := json.Unmarshal(payload, &parsed); err != nil {
-		t.Fatalf("%s payload unmarshal: %v (%s)", label, err, payload)
-	}
-	if len(parsed.Episodes) != 1 {
-		t.Fatalf("%s payload episodes = %d, want 1: %s", label, len(parsed.Episodes), payload)
-	}
-	if parsed.Episodes[0].IDs != nil {
-		t.Fatalf("%s payload JSON has top-level episode ids: %s", label, payload)
-	}
-	if parsed.Episodes[0].Show.IDs.TMDB != 999 {
-		t.Fatalf("%s payload JSON missing show fallback id: %s", label, payload)
-	}
-	// Belt-and-suspenders: the raw JSON must not carry an episode-level zero tmdb/tvdb.
-	if bytes.Contains(payload, []byte(`"ids":{"trakt":0,"slug":"","imdb":"","tmdb":0,"tvdb":0}`)) {
-		t.Fatalf("%s payload JSON contains a fully-zero ids object: %s", label, payload)
 	}
 }

--- a/internal/watchsync/providers/trakt/provider_test.go
+++ b/internal/watchsync/providers/trakt/provider_test.go
@@ -1,6 +1,7 @@
 package trakt
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"net/http"
@@ -320,5 +321,137 @@ func TestHistoryPayloadsIncludeTVDBOnlyMovieIDs(t *testing.T) {
 	removePayload := buildHistoryRemovePayload([]watchsync.LocalPlay{play})
 	if len(removePayload.Movies) != 1 || removePayload.Movies[0].IDs.TVDB != 12345 {
 		t.Fatalf("remove payload movie IDs = %#v, want TVDB 12345", removePayload.Movies)
+	}
+}
+
+func TestHistoryEpisodeWithEmptyIDsOmitsEpisodeIDsAndUsesShowFallback(t *testing.T) {
+	play := watchsync.LocalPlay{
+		HistoryID:     "history-episode-no-ids",
+		Kind:          historyimport.KindEpisode,
+		SeriesTMDBID:  "999",
+		SeasonNumber:  2,
+		EpisodeNumber: 5,
+		WatchedAt:     time.Date(2026, 5, 4, 12, 0, 0, 0, time.UTC),
+	}
+
+	addPayload := buildHistoryPayload([]watchsync.LocalPlay{play})
+	if len(addPayload.Episodes) != 1 {
+		t.Fatalf("add payload episodes = %#v, want 1", addPayload.Episodes)
+	}
+	addEp := addPayload.Episodes[0]
+	if addEp.IDs != nil {
+		t.Fatalf("add payload episode IDs = %#v, want nil", addEp.IDs)
+	}
+	if addEp.Show == nil || addEp.Show.IDs.TMDB != 999 {
+		t.Fatalf("add payload episode show = %#v, want show TMDB 999", addEp.Show)
+	}
+
+	addJSON, err := json.Marshal(addPayload)
+	if err != nil {
+		t.Fatalf("marshal add payload: %v", err)
+	}
+	assertNoZeroEpisodeIDs(t, addJSON, "add")
+
+	removePayload := buildHistoryRemovePayload([]watchsync.LocalPlay{play})
+	if len(removePayload.Episodes) != 1 {
+		t.Fatalf("remove payload episodes = %#v, want 1", removePayload.Episodes)
+	}
+	removeEp := removePayload.Episodes[0]
+	if removeEp.IDs != nil {
+		t.Fatalf("remove payload episode IDs = %#v, want nil", removeEp.IDs)
+	}
+	if removeEp.Show == nil || removeEp.Show.IDs.TMDB != 999 {
+		t.Fatalf("remove payload episode show = %#v, want show TMDB 999", removeEp.Show)
+	}
+
+	removeJSON, err := json.Marshal(removePayload)
+	if err != nil {
+		t.Fatalf("marshal remove payload: %v", err)
+	}
+	assertNoZeroEpisodeIDs(t, removeJSON, "remove")
+}
+
+func TestHistoryEpisodeWithRealIDsKeepsEpisodeIDs(t *testing.T) {
+	play := watchsync.LocalPlay{
+		HistoryID:     "history-episode-with-ids",
+		Kind:          historyimport.KindEpisode,
+		TVDBID:        "54321",
+		SeriesTMDBID:  "999",
+		SeasonNumber:  2,
+		EpisodeNumber: 5,
+		WatchedAt:     time.Date(2026, 5, 4, 12, 0, 0, 0, time.UTC),
+	}
+
+	addPayload := buildHistoryPayload([]watchsync.LocalPlay{play})
+	if len(addPayload.Episodes) != 1 {
+		t.Fatalf("add payload episodes = %#v, want 1", addPayload.Episodes)
+	}
+	addEp := addPayload.Episodes[0]
+	if addEp.IDs == nil || addEp.IDs.TVDB != 54321 {
+		t.Fatalf("add payload episode IDs = %#v, want TVDB 54321", addEp.IDs)
+	}
+	if addEp.Show != nil {
+		t.Fatalf("add payload episode show = %#v, want nil", addEp.Show)
+	}
+
+	addJSON, err := json.Marshal(addPayload)
+	if err != nil {
+		t.Fatalf("marshal add payload: %v", err)
+	}
+	if !bytes.Contains(addJSON, []byte(`"tvdb":54321`)) {
+		t.Fatalf("add payload JSON missing real episode id: %s", addJSON)
+	}
+
+	removePayload := buildHistoryRemovePayload([]watchsync.LocalPlay{play})
+	if len(removePayload.Episodes) != 1 {
+		t.Fatalf("remove payload episodes = %#v, want 1", removePayload.Episodes)
+	}
+	removeEp := removePayload.Episodes[0]
+	if removeEp.IDs == nil || removeEp.IDs.TVDB != 54321 {
+		t.Fatalf("remove payload episode IDs = %#v, want TVDB 54321", removeEp.IDs)
+	}
+	if removeEp.Show != nil {
+		t.Fatalf("remove payload episode show = %#v, want nil", removeEp.Show)
+	}
+
+	removeJSON, err := json.Marshal(removePayload)
+	if err != nil {
+		t.Fatalf("marshal remove payload: %v", err)
+	}
+	if !bytes.Contains(removeJSON, []byte(`"tvdb":54321`)) {
+		t.Fatalf("remove payload JSON missing real episode id: %s", removeJSON)
+	}
+}
+
+// assertNoZeroEpisodeIDs verifies the marshaled history payload does not contain
+// a top-level episode "ids" object (which would carry zero values) and does carry
+// the show fallback id. The legitimate show.ids object may contain zero members
+// (e.g. tvdb:0 when only tmdb is known); we only guard against an episode-level
+// "ids" key, which is what previously matched Trakt to the wrong series.
+func assertNoZeroEpisodeIDs(t *testing.T, payload []byte, label string) {
+	t.Helper()
+	var parsed struct {
+		Episodes []struct {
+			IDs  json.RawMessage `json:"ids"`
+			Show struct {
+				IDs traktIDs `json:"ids"`
+			} `json:"show"`
+		} `json:"episodes"`
+	}
+	if err := json.Unmarshal(payload, &parsed); err != nil {
+		t.Fatalf("%s payload unmarshal: %v (%s)", label, err, payload)
+	}
+	if len(parsed.Episodes) != 1 {
+		t.Fatalf("%s payload episodes = %d, want 1: %s", label, len(parsed.Episodes), payload)
+	}
+	if parsed.Episodes[0].IDs != nil {
+		t.Fatalf("%s payload JSON has top-level episode ids: %s", label, payload)
+	}
+	if parsed.Episodes[0].Show.IDs.TMDB != 999 {
+		t.Fatalf("%s payload JSON missing show fallback id: %s", label, payload)
+	}
+	// Belt-and-suspenders: the raw JSON must not carry an episode-level zero tmdb/tvdb.
+	if bytes.Contains(payload, []byte(`"ids":{"trakt":0,"slug":"","imdb":"","tmdb":0,"tvdb":0}`)) {
+		t.Fatalf("%s payload JSON contains a fully-zero ids object: %s", label, payload)
 	}
 }


### PR DESCRIPTION
## Problem

Two related defects broke Trakt TV-episode watch sync:

1. **Wrong series targeted on series mark-watched.** Empty Trakt episode ids were being emitted, so a series-level mark-watched could target the wrong show.
2. **Episode history dropped by Trakt.** Episode history exports were emitted into the flat `episodes[]` array with a bogus sibling `show` object, which Trakt rejected — episodes never synced.

## Fix

- Omit empty Trakt episode ids so series mark-watched resolves to the correct show.
- Emit TV episodes via a valid nested `shows[].seasons[].episodes[]` payload instead of the flat array, matching Trakt's history contract.

## Notes

- Scope is limited to `internal/watchsync/providers/trakt/` plus a small `internal/watchstate/identity.go` helper.
- Unit tests added/updated in `provider_test.go`; `go test ./internal/watchsync/providers/trakt/` passes.

AI-use disclosure: authored with AI assistance.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Trakt history exports and removals now support nested show-based episode payloads when episode-specific IDs aren’t available.

* **Bug Fixes**
  * Episode watches now use more complete identity data, improving how history entries are matched and exported.
  * Multiple episodes from the same show and season are now grouped more consistently in history payloads.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->