### PR TITLE
fix(api): surface ListDownloadedSubtitles errors instead of masking as 404

### DIFF
--- a/internal/api/handlers/stream.go
+++ b/internal/api/handlers/stream.go
@@ -240,37 +240,49 @@ func (h *StreamHandler) HandleSubtitle(w http.ResponseWriter, r *http.Request) {
 	// Check downloaded subtitles (from S3).
 	if h.SubtitleRepo != nil && h.S3Client != nil {
 		downloaded, err := h.SubtitleRepo.ListDownloadedSubtitles(r.Context(), file.ID)
-		if err == nil {
-			downloadedIndex := embeddedIndex - len(file.SubtitleTracks)
-			if downloadedIndex >= 0 && downloadedIndex < len(downloaded) {
-				dl := downloaded[downloadedIndex]
-				data, err := h.S3Client.GetObject(r.Context(), h.S3Bucket, dl.S3Key)
-				if err != nil {
-					writeError(w, http.StatusBadGateway, "s3_error", "Failed to load subtitle from storage")
-					return
-				}
+		if err != nil {
+			// A DB failure here must not masquerade as "track not found":
+			// surface it as an internal error (with a server-side signal)
+			// so the real failure is diagnosable instead of looking like an
+			// intermittent 404 to the client.
+			slog.ErrorContext(r.Context(), "list downloaded subtitles failed",
+				"file_id", file.ID,
+				"track", trackIndex,
+				"error", err,
+			)
+			writeError(w, http.StatusInternalServerError, "internal_error", "Failed to list downloaded subtitles")
+			return
+		}
 
-				// Serve ASS/SSA downloaded subtitles as raw data.
-				if playback.IsASS(string(dl.Format)) {
-					playback.ServeSubtitle(w, data, "ass")
-					return
-				}
-
-				// If the subtitle is already VTT, serve directly.
-				if dl.Format == subtitles.FormatVTT {
-					playback.ServeSubtitle(w, data, "vtt")
-					return
-				}
-
-				// Convert to VTT using the playback conversion pipeline.
-				vttData, err := playback.ConvertToVTT(data, string(dl.Format))
-				if err != nil {
-					writeError(w, http.StatusInternalServerError, "convert_error", "Failed to convert subtitle")
-					return
-				}
-				playback.ServeSubtitle(w, vttData, "vtt")
+		downloadedIndex := embeddedIndex - len(file.SubtitleTracks)
+		if downloadedIndex >= 0 && downloadedIndex < len(downloaded) {
+			dl := downloaded[downloadedIndex]
+			data, err := h.S3Client.GetObject(r.Context(), h.S3Bucket, dl.S3Key)
+			if err != nil {
+				writeError(w, http.StatusBadGateway, "s3_error", "Failed to load subtitle from storage")
 				return
 			}
+
+			// Serve ASS/SSA downloaded subtitles as raw data.
+			if playback.IsASS(string(dl.Format)) {
+				playback.ServeSubtitle(w, data, "ass")
+				return
+			}
+
+			// If the subtitle is already VTT, serve directly.
+			if dl.Format == subtitles.FormatVTT {
+				playback.ServeSubtitle(w, data, "vtt")
+				return
+			}
+
+			// Convert to VTT using the playback conversion pipeline.
+			vttData, err := playback.ConvertToVTT(data, string(dl.Format))
+			if err != nil {
+				writeError(w, http.StatusInternalServerError, "convert_error", "Failed to convert subtitle")
+				return
+			}
+			playback.ServeSubtitle(w, vttData, "vtt")
+			return
 		}
 	}
 

--- a/internal/api/handlers/stream_test.go
+++ b/internal/api/handlers/stream_test.go
@@ -2,11 +2,14 @@ package handlers
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"net/http"
 	"net/http/httptest"
 	"os"
 	"testing"
+
+	"github.com/go-chi/chi/v5"
 
 	"github.com/Silo-Server/silo-server/internal/models"
 	"github.com/Silo-Server/silo-server/internal/playback"
@@ -118,6 +121,55 @@ func TestHandleStream_KeepsSessionWhenLookupFailsForNonMissingReason(t *testing.
 	}
 	if syncer.calls != 0 {
 		t.Fatalf("sync calls = %d, want 0", syncer.calls)
+	}
+}
+
+// TestHandleSubtitle_ListDownloadedSubtitlesErrorReturns500 pins the fix for
+// issue #248: a failure listing downloaded subtitles must surface as a 500 with
+// an "internal_error" code, not be swallowed and reported to the client as a
+// generic "Subtitle track not found" 404 (which made a real backing-store
+// failure look like an intermittent client-side subtitle bug).
+func TestHandleSubtitle_ListDownloadedSubtitlesErrorReturns500(t *testing.T) {
+	// No external or embedded tracks, so track index 0 falls through to the
+	// downloaded-subtitle branch that queries the repository.
+	file := &models.MediaFile{
+		ID:        42,
+		ContentID: "movie-1",
+		FilePath:  "/tmp/movie.mkv",
+		Duration:  3600,
+	}
+	baseMgr := playback.NewSessionManager(0, 0)
+	session, err := baseMgr.StartSession(1, "profile-1", 42, playback.PlayDirect, false)
+	if err != nil {
+		t.Fatalf("StartSession: %v", err)
+	}
+
+	handler := NewStreamHandler(baseMgr, testPlaybackFileResolver{file: file})
+	handler.SubtitleRepo = &handlerMockSubtitleRepo{listErr: errors.New("db unavailable")}
+	handler.S3Client = newMockS3ClientForHandler()
+	handler.S3Bucket = "test-bucket"
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/stream/"+session.ID+"/subtitles/0.vtt", nil)
+	req = req.WithContext(newAuthorizedPlaybackContext())
+	routeCtx := chi.NewRouteContext()
+	routeCtx.URLParams.Add("session_id", session.ID)
+	routeCtx.URLParams.Add("track", "0.vtt")
+	req = req.WithContext(context.WithValue(req.Context(), chi.RouteCtxKey, routeCtx))
+
+	rr := httptest.NewRecorder()
+	handler.HandleSubtitle(rr, req)
+
+	if rr.Code != http.StatusInternalServerError {
+		t.Fatalf("status = %d, body = %s", rr.Code, rr.Body.String())
+	}
+	var body struct {
+		Error string `json:"error"`
+	}
+	if err := json.Unmarshal(rr.Body.Bytes(), &body); err != nil {
+		t.Fatalf("decode error body: %v (body = %s)", err, rr.Body.String())
+	}
+	if body.Error != "internal_error" {
+		t.Fatalf("error code = %q, want %q (body = %s)", body.Error, "internal_error", rr.Body.String())
 	}
 }
 

--- a/internal/api/handlers/subtitle_search_test.go
+++ b/internal/api/handlers/subtitle_search_test.go
@@ -239,6 +239,9 @@ type handlerMockSubtitleRepo struct {
 	subtitles map[int]*subtitles.DownloadedSubtitle
 	nextID    int
 	byKey     map[string]*subtitles.DownloadedSubtitle
+	// listErr, when set, is returned by ListDownloadedSubtitles to simulate a
+	// backing-store failure.
+	listErr error
 }
 
 func newMockSubtitleRepoForHandler() *handlerMockSubtitleRepo {
@@ -265,6 +268,9 @@ func (m *handlerMockSubtitleRepo) GetDownloadedSubtitle(_ context.Context, id in
 }
 
 func (m *handlerMockSubtitleRepo) ListDownloadedSubtitles(context.Context, int) ([]subtitles.DownloadedSubtitle, error) {
+	if m.listErr != nil {
+		return nil, m.listErr
+	}
 	return nil, nil
 }
 


### PR DESCRIPTION
## Problem

The web subtitle handler (`HandleSubtitle` in `internal/api/handlers/stream.go`) wrapped the downloaded-subtitle lookup in `if err == nil { ... }`. When `ListDownloadedSubtitles` failed (DB/backing-store error), the error was silently swallowed: control fell through to a generic `writeError(404, "Subtitle track not found")` with **no logging and no server-side signal**. A real internal failure was reported to the client as "subtitle not found", which is exactly why issue #248 looked like an intermittent, hard-to-diagnose client-side "subtitles won't render" bug.

Reproduced with a focused handler test: on the unpatched code, a repo returning an error yields `404 {"error":"not_found"}`; with the fix it yields `500 {"error":"internal_error"}` plus an `ERROR` log line (`list downloaded subtitles failed file_id=42 track=0 error="db unavailable"`).

## Approach

On `err != nil`, log at `ERROR` with `file_id`/`track`/`error` (matching the sibling font-extraction path in the same file) and return `500 internal_error` — mirroring the neighbouring error handling in the very same branch (`S3.GetObject` → 502, `ConvertToVTT` → 500). The successful-serve path and the *genuine* not-found fall-through (listing succeeds but the requested index is out of range) are left byte-for-byte unchanged; the large diff is just one level of de-indentation after replacing the `if err == nil` wrapper with an early return.

Scope is deliberately limited to error handling + logging, per the issue — this does not touch the downstream content/deployment-specific render behavior.

## Verification

All run inside the worktree with `GOWORK=off` and a stubbed `web/dist` per the repo's worktree conventions:

- `GOWORK=off go build ./internal/... ./cmd/...` → clean
- New regression test `TestHandleSubtitle_ListDownloadedSubtitlesErrorReturns500`: **red on origin/main** (asserts 404 masking), **green with the fix** (500 + `internal_error`)
- `GOWORK=off go test ./internal/api/handlers/` → `ok` (full package suite, no regressions)
- `golangci-lint` (v2): no new findings on the touched lines (the only findings referencing the touched file are pre-existing `stubEpisodeLookup` dead code already on `origin/main`)
- `make verify-local-paths` → exit 0

Test infra reuses the existing `handlerMockSubtitleRepo` / `handlerMockS3Client` (added a `listErr` hook) rather than duplicating a mock.

## Adversarial review

Codex adversarial review (`--base main`): **approve — no material findings**. It independently confirmed the failure path now logs + returns 500 while the success path and the nil-list/out-of-range 404 fall-through remain unchanged.

## Risks & follow-up

Low risk: additive, server-side observability only. The status code for a genuine internal failure changes from a (wrong) 404 to a (correct) 500 on the existing endpoint — clients already treat 5xx as a transient/server error, so no client contract field/type changes and no `silo-android` / `silo-apple` follow-up is required. No migration.

Closes #248

## AI-use disclosure
Implemented by Claude Code (issue-to-pr skill) with human oversight.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Subtitle requests now return a clear server error when subtitle listing fails, instead of appearing as if the track is missing.
  * Improved error logging for subtitle-loading issues to help distinguish backend failures from unavailable subtitles.
  * Added coverage to verify that subtitle listing failures return a 500 response with the expected error payload.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->