### PR TITLE
fix(api): show symlinked directories in folder browser

### DIFF
--- a/internal/api/handlers/filesystem.go
+++ b/internal/api/handlers/filesystem.go
@@ -56,14 +56,27 @@ func (h *FilesystemHandler) HandleBrowse(w http.ResponseWriter, r *http.Request)
 
 	result := make([]filesystemBrowseEntry, 0, len(entries))
 	for _, entry := range entries {
+		name := entry.Name()
+		full := filepath.Join(cleaned, name)
+
+		// os.ReadDir reports lstat semantics, so a symlink to a directory has
+		// IsDir() == false. Follow symlink entries with os.Stat and keep them only
+		// when the target is a directory; skip links whose target cannot be stat'd
+		// (broken or looping). Non-symlink, non-directory entries (regular files)
+		// are skipped without the extra stat so large media folders stay fast.
 		if !entry.IsDir() {
-			continue
+			if entry.Type()&os.ModeSymlink == 0 {
+				continue
+			}
+			target, err := os.Stat(full)
+			if err != nil || !target.IsDir() {
+				continue
+			}
 		}
 
-		name := entry.Name()
 		result = append(result, filesystemBrowseEntry{
 			Name: name,
-			Path: filepath.Join(cleaned, name),
+			Path: full,
 		})
 	}
 

--- a/internal/api/handlers/filesystem_test.go
+++ b/internal/api/handlers/filesystem_test.go
@@ -1,0 +1,97 @@
+package handlers
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"runtime"
+	"testing"
+)
+
+// TestHandleBrowseFollowsDirectorySymlinks verifies that the folder browser
+// lists symlinks that resolve to directories (issue #208). os.ReadDir returns
+// lstat-based entries, so a directory symlink reports IsDir() == false and was
+// silently dropped; the handler must os.Stat each entry to follow the link.
+func TestHandleBrowseFollowsDirectorySymlinks(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("symlink creation is unreliable on Windows CI")
+	}
+	t.Parallel()
+
+	root := t.TempDir()
+
+	// A real directory that should always be listed.
+	realDir := filepath.Join(root, "real-dir")
+	if err := os.Mkdir(realDir, 0o755); err != nil {
+		t.Fatalf("mkdir real-dir: %v", err)
+	}
+
+	// The symlink-to-directory target lives outside root so the browser cannot
+	// reach it except by following the link — mirrors the reported setup where
+	// entries under a bind mount point into a separate FUSE mount.
+	linkTarget := filepath.Join(t.TempDir(), "link-target")
+	if err := os.Mkdir(linkTarget, 0o755); err != nil {
+		t.Fatalf("mkdir link-target: %v", err)
+	}
+	dirSymlink := filepath.Join(root, "symlinked-dir")
+	if err := os.Symlink(linkTarget, dirSymlink); err != nil {
+		t.Fatalf("symlink dir: %v", err)
+	}
+
+	// A regular file: must never be listed by the folder browser.
+	regularFile := filepath.Join(root, "note.txt")
+	if err := os.WriteFile(regularFile, []byte("x"), 0o644); err != nil {
+		t.Fatalf("write file: %v", err)
+	}
+
+	// A symlink to a file: resolves to a non-directory, must not be listed.
+	fileSymlink := filepath.Join(root, "note-link")
+	if err := os.Symlink(regularFile, fileSymlink); err != nil {
+		t.Fatalf("symlink file: %v", err)
+	}
+
+	// A broken symlink: os.Stat fails; it must be skipped, not error the request.
+	brokenSymlink := filepath.Join(root, "broken-link")
+	if err := os.Symlink(filepath.Join(root, "does-not-exist"), brokenSymlink); err != nil {
+		t.Fatalf("symlink broken: %v", err)
+	}
+
+	handler := NewFilesystemHandler()
+	req := httptest.NewRequest(http.MethodGet, "/filesystem/browse?path="+root, nil)
+	rec := httptest.NewRecorder()
+	handler.HandleBrowse(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, body = %s", rec.Code, rec.Body.String())
+	}
+
+	var resp filesystemBrowseResponse
+	if err := json.NewDecoder(rec.Body).Decode(&resp); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+
+	got := make(map[string]string, len(resp.Entries))
+	for _, e := range resp.Entries {
+		got[e.Name] = e.Path
+	}
+
+	if _, ok := got["real-dir"]; !ok {
+		t.Errorf("real-dir missing from entries: %+v", resp.Entries)
+	}
+	if path, ok := got["symlinked-dir"]; !ok {
+		t.Errorf("symlinked-dir (directory symlink) missing from entries: %+v", resp.Entries)
+	} else if want := filepath.Join(root, "symlinked-dir"); path != want {
+		t.Errorf("symlinked-dir path = %q, want %q", path, want)
+	}
+	if _, ok := got["note.txt"]; ok {
+		t.Errorf("regular file note.txt should not be listed: %+v", resp.Entries)
+	}
+	if _, ok := got["note-link"]; ok {
+		t.Errorf("file symlink note-link should not be listed: %+v", resp.Entries)
+	}
+	if _, ok := got["broken-link"]; ok {
+		t.Errorf("broken symlink broken-link should not be listed: %+v", resp.Entries)
+	}
+}


### PR DESCRIPTION
## Problem

The **Browse Library Folders** dialog silently omits directories reached through
symlinks (issue #208). Reported on a Docker setup where a bind mount contains
symlinks pointing into an rclone/FUSE mount: the symlinked show folders never
appear in the picker, even though they are valid and browsable inside the
container (and browsing works if the full symlink path is typed in manually).

**Root cause:** `HandleBrowse` in `internal/api/handlers/filesystem.go` filters
`os.ReadDir` entries with `entry.IsDir()`. `os.ReadDir` returns `lstat`-based
entries, so a symlink pointing at a directory reports `IsDir() == false` and was
dropped. (The browsed path itself already goes through `os.Stat`, which follows
the link — which is exactly why typing the full symlink path worked but browsing
into its parent did not.)

**Reproduced** with a failing unit test against `HandleBrowse` (tmpdir +
`os.Symlink`): on `main`, a directory symlink is absent from the response while a
real subdirectory is present.

## Approach

In the entry loop, when `entry.IsDir()` is false, follow only *symlink* entries
(`entry.Type()&os.ModeSymlink != 0`) with `os.Stat` and include them when the
resolved target is a directory. Links whose target cannot be stat'd (broken or
looping) are skipped rather than erroring the whole request.

Ordinary regular files stay on the original no-stat fast path — this deliberately
does **not** stat every entry. Statting every non-directory would add thousands of
synchronous, potentially slow/hanging filesystem calls per request on large
FUSE/NAS-backed media roots (an admin-triggerable latency risk), for no functional
benefit since the fix only needs to follow symlinks. Directory entries keep the
`lstat` fast path and take no extra syscall.

## Verification

Commands run in an isolated worktree (`GOWORK=off`, `web/dist` stubbed for the
embed directive):

- `GOWORK=off go build ./internal/... ./cmd/...` → OK
- New test red on `main` (directory symlink missing) → green after the fix:
  `GOWORK=off go test ./internal/api/handlers/ -run TestHandleBrowseFollowsDirectorySymlinks`
- Full package suite: `GOWORK=off go test ./internal/api/handlers/` → ok
- `golangci-lint` (v2) → no issues in `filesystem.go` / `filesystem_test.go`
- `make verify-local-paths` → clean

The test covers: real dir included, directory symlink included (with correct
path), and regular file / file symlink / broken symlink all excluded.

## Adversarial review

Codex adversarial review run against `main`.
- Iteration 1 (`needs-attention`, medium): the first cut statted *every*
  non-directory entry, adding an unbounded blocking stat pass over large media
  folders. **Fixed** by statting only symlink-typed entries so regular files skip
  the syscall.
- Iteration 2: **approve**, no material findings — confirmed regular files stay on
  the no-stat path, broken/looping links are skipped via `os.Stat` errors, and no
  new traversal boundary is introduced (the endpoint is already in the admin-only
  router group, where arbitrary absolute paths were already browsable).

## Risks & follow-up

Low risk; behavior for non-symlink entries is unchanged. Server-only fix for the
admin web folder picker (`FolderBrowser.tsx` → `GET /api/v1/.../filesystem/browse`).
The `silo-android` / `silo-apple` clients do not consume this admin
library-setup endpoint, so no client follow-up is required. No API contract change
(additive behavior on an existing endpoint), no migration.

Closes #208

## AI-use disclosure
Implemented by Claude Code (issue-to-pr skill) with human oversight.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Directory browsing now includes valid symlinks that point to directories.
  * Broken symlinks, file symlinks, and other non-directory entries are still excluded.
  * Listed items now show the correct path for directory symlinks.

* **Tests**
  * Added coverage for browsing real directories, directory symlinks, file symlinks, and broken symlinks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->