### PR TITLE
fix(web): detect HDR via video-dynamic-range media query for Firefox

### DIFF
--- a/web/src/player/hooks/useCodecDetection.test.ts
+++ b/web/src/player/hooks/useCodecDetection.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { detectMaxResolutionFromScreen } from "./useCodecDetection";
+import { detectHDRFromMatchMedia, detectMaxResolutionFromScreen } from "./useCodecDetection";
 
 describe("detectMaxResolutionFromScreen", () => {
   it("treats a 2560x1440 display as above the 720p bucket", () => {
@@ -8,5 +8,26 @@ describe("detectMaxResolutionFromScreen", () => {
 
   it("keeps a 1280x720 display in the 720p bucket", () => {
     expect(detectMaxResolutionFromScreen(1280, 720)).toBe("720p");
+  });
+});
+
+describe("detectHDRFromMatchMedia", () => {
+  const fakeMatchMedia = (matching: string[]) =>
+    ((query: string) => ({ matches: matching.includes(query) })) as unknown as typeof matchMedia;
+
+  it("returns false when matchMedia is unavailable", () => {
+    expect(detectHDRFromMatchMedia(undefined)).toBe(false);
+  });
+
+  it("returns true when dynamic-range reports high", () => {
+    expect(detectHDRFromMatchMedia(fakeMatchMedia(["(dynamic-range: high)"]))).toBe(true);
+  });
+
+  it("returns true when only video-dynamic-range reports high (Firefox)", () => {
+    expect(detectHDRFromMatchMedia(fakeMatchMedia(["(video-dynamic-range: high)"]))).toBe(true);
+  });
+
+  it("returns false when neither query matches", () => {
+    expect(detectHDRFromMatchMedia(fakeMatchMedia([]))).toBe(false);
   });
 });

--- a/web/src/player/hooks/useCodecDetection.ts
+++ b/web/src/player/hooks/useCodecDetection.ts
@@ -82,6 +82,21 @@ export function getPlaybackEnvironmentSnapshot(): PlaybackEnvironmentSnapshot | 
   };
 }
 
+/**
+ * Detects HDR display support (best effort). Firefox's `dynamic-range` query
+ * reflects the browser canvas and reports `standard` even on HDR displays;
+ * the video plane is exposed via `video-dynamic-range` (Firefox 116+), so
+ * accept either. Browsers treat unknown media features as non-matching, so
+ * querying both is safe everywhere.
+ */
+export function detectHDRFromMatchMedia(matchMediaFn: typeof matchMedia | undefined): boolean {
+  if (!matchMediaFn) return false;
+  return (
+    matchMediaFn("(dynamic-range: high)").matches ||
+    matchMediaFn("(video-dynamic-range: high)").matches
+  );
+}
+
 function testCodec(mimeWithCodec: string): boolean {
   if (typeof MediaSource === "undefined") return false;
   try {
@@ -171,7 +186,7 @@ export function useCodecDetection() {
     const max_resolution = detectMaxResolutionFromScreen(screen.width, screen.height);
 
     // HDR detection (best effort).
-    const hdr = typeof matchMedia !== "undefined" && matchMedia("(dynamic-range: high)").matches;
+    const hdr = detectHDRFromMatchMedia(typeof matchMedia !== "undefined" ? matchMedia : undefined);
 
     return { codecs_video, codecs_audio, containers, max_resolution, hdr };
   }, []);

--- a/web/src/player/hooks/useCodecDetection.ts
+++ b/web/src/player/hooks/useCodecDetection.ts
@@ -185,8 +185,11 @@ export function useCodecDetection() {
     // Detect max resolution via reported screen dimensions.
     const max_resolution = detectMaxResolutionFromScreen(screen.width, screen.height);
 
-    // HDR detection (best effort).
-    const hdr = detectHDRFromMatchMedia(typeof matchMedia !== "undefined" ? matchMedia : undefined);
+    // HDR detection (best effort). Wrap matchMedia so it keeps its Window
+    // receiver — invoking a detached reference throws in some browsers.
+    const hdr = detectHDRFromMatchMedia(
+      typeof matchMedia !== "undefined" ? (query) => matchMedia(query) : undefined,
+    );
 
     return { codecs_video, codecs_audio, containers, max_resolution, hdr };
   }, []);


### PR DESCRIPTION
## Problem
Firefox reports `matchMedia("(dynamic-range: high)").matches === false` even on HDR-enabled displays, because its `dynamic-range` media query reflects the browser canvas, not the video plane. The web player's capability detection (`web/src/player/hooks/useCodecDetection.ts`) only queried `dynamic-range`, so Firefox clients always advertised `hdr: false`. Confirmed on current `main`: that line was the sole HDR media-query site, matching the console evidence in the issue (`dynamic-range: high` → false, `video-dynamic-range: high` → true).

## Approach
Extract the check into an exported, testable `detectHDRFromMatchMedia()` helper (mirroring the existing `detectMaxResolutionFromScreen` pattern in the same file) that accepts either `(dynamic-range: high)` or `(video-dynamic-range: high)`. Firefox 116+ exposes the video plane via `video-dynamic-range`; browsers treat unknown media features as non-matching, so the extra query is a no-op on Chrome/Safari rather than a false-positive risk. Smallest change that fixes the reported capability; no API surface changes (the `hdr` field already exists on the capabilities payload).

## Verification
- `pnpm vitest run src/player/hooks/useCodecDetection.test.ts` — 6/6 pass, including a Firefox-simulation case where only `video-dynamic-range` matches.
- Full web suite: 1124 passed, 4 failed — the 4 failures (`CompatibilityProxiesSettings.test.tsx`, `ServerStorageStep.test.tsx`) reproduce identically on unmodified `origin/main` (verified via `git stash`), i.e. pre-existing and unrelated.
- `pnpm run lint` (0 errors; touched files individually clean), `pnpm run format:check` clean, `pnpm run build` succeeds, `make verify-local-paths` clean.

## Adversarial review
Codex review raised one medium finding: the `hdr` capability isn't used by `selectBestVersion` or the server's resolve path, so the fix "reports a better capability without changing file selection." Rebutted as out of scope: the issue's stated requirement is the capability check itself, and the value is consumed today — sent on playback start (`usePlaybackSession.ts`), stored on the session's `ClientCapabilities`, and checked in `internal/downloads/policy.go`. Making resolve/transcode HDR-aware is a separate feature. The reviewer's suggested Firefox-only-query test is included in this PR.

## Risks & follow-up
- Low risk: worst case matches current behavior (both queries false → `hdr: false`).
- Follow-up (separate scope): wire client HDR capability into version selection / tone-map decisions server-side.
- No `silo-android` / `silo-apple` impact — this is web-client detection only; the API payload shape is unchanged.

Closes #206

## AI-use disclosure
Implemented by Claude Code (issue-to-pr skill) with human oversight.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved HDR capability detection for video playback by checking both standard and browser-specific high dynamic range media queries.
  * Added safer, best-effort behavior in environments where media query APIs may be unavailable.

* **Tests**
  * Added unit tests covering HDR detection outcomes when media queries are missing, when standard HDR matches, and when only browser-specific HDR matches.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->