### PR TITLE
feat(observability): persistent per-subsystem file logging via SILO_LOG_FILE

### DIFF
--- a/cmd/silo/logsink_env_test.go
+++ b/cmd/silo/logsink_env_test.go
@@ -1,0 +1,85 @@
+package main
+
+import (
+	"log/slog"
+	"testing"
+)
+
+func TestEnvIsTrue(t *testing.T) {
+	cases := map[string]bool{
+		"1": true, "true": true, "TRUE": true, "yes": true, "  yes  ": true,
+		"": false, "0": false, "false": false, "no": false, "off": false,
+	}
+	for in, want := range cases {
+		t.Run(in, func(t *testing.T) {
+			t.Setenv("SILO_TEST_BOOL", in)
+			if got := envIsTrue("SILO_TEST_BOOL"); got != want {
+				t.Errorf("envIsTrue(%q) = %v, want %v", in, got, want)
+			}
+		})
+	}
+}
+
+func TestLogSinkOptionsFromEnvDefaults(t *testing.T) {
+	// With nothing set, file logging is off and rotation matches DefaultRotation.
+	for _, k := range []string{"SILO_LOG_FILE", "SILO_LOG_SPLIT", "SILO_LOG_MAX_SIZE_MB", "SILO_LOG_MAX_BACKUPS", "SILO_LOG_MAX_AGE_DAYS", "SILO_LOG_COMPRESS"} {
+		t.Setenv(k, "")
+	}
+	opts := logSinkOptionsFromEnv("text", slog.LevelInfo)
+	if opts.File != "" {
+		t.Errorf("File = %q, want empty when SILO_LOG_FILE unset", opts.File)
+	}
+	if opts.Split {
+		t.Error("Split = true, want false when unset")
+	}
+	if opts.Rotation.MaxSizeMB != 50 || opts.Rotation.MaxBackups != 100 || opts.Rotation.MaxAgeDays != 30 || !opts.Rotation.Compress {
+		t.Errorf("default rotation = %+v, want {50 100 30 true}", opts.Rotation)
+	}
+}
+
+func TestLogSinkOptionsFromEnvOverrides(t *testing.T) {
+	t.Setenv("SILO_LOG_FILE", "/var/log/silo/silo.log")
+	t.Setenv("SILO_LOG_SPLIT", "1")
+	t.Setenv("SILO_LOG_MAX_SIZE_MB", "10")
+	// Explicit 0 must be preserved (lumberjack: keep-all / never-expire), not
+	// coalesced back to the defaults.
+	t.Setenv("SILO_LOG_MAX_BACKUPS", "0")
+	t.Setenv("SILO_LOG_MAX_AGE_DAYS", "0")
+	t.Setenv("SILO_LOG_COMPRESS", "false")
+
+	opts := logSinkOptionsFromEnv("json", slog.LevelDebug)
+	if opts.File != "/var/log/silo/silo.log" {
+		t.Errorf("File = %q", opts.File)
+	}
+	if !opts.Split {
+		t.Error("Split = false, want true for SILO_LOG_SPLIT=1")
+	}
+	if opts.Rotation.MaxSizeMB != 10 {
+		t.Errorf("MaxSizeMB = %d, want 10", opts.Rotation.MaxSizeMB)
+	}
+	if opts.Rotation.MaxBackups != 0 {
+		t.Errorf("MaxBackups = %d, want 0 (explicit keep-all)", opts.Rotation.MaxBackups)
+	}
+	if opts.Rotation.MaxAgeDays != 0 {
+		t.Errorf("MaxAgeDays = %d, want 0 (explicit never-expire)", opts.Rotation.MaxAgeDays)
+	}
+	if opts.Rotation.Compress {
+		t.Error("Compress = true, want false for SILO_LOG_COMPRESS=false")
+	}
+	if opts.Format != "json" {
+		t.Errorf("Format = %q, want json", opts.Format)
+	}
+}
+
+func TestLogSinkOptionsIgnoresInvalidNumbers(t *testing.T) {
+	t.Setenv("SILO_LOG_FILE", "/tmp/x.log")
+	t.Setenv("SILO_LOG_MAX_SIZE_MB", "not-a-number")
+	t.Setenv("SILO_LOG_MAX_BACKUPS", "-5") // negative rejected (>=0 guard)
+	opts := logSinkOptionsFromEnv("text", slog.LevelInfo)
+	if opts.Rotation.MaxSizeMB != 50 {
+		t.Errorf("MaxSizeMB = %d, want default 50 on invalid input", opts.Rotation.MaxSizeMB)
+	}
+	if opts.Rotation.MaxBackups != 100 {
+		t.Errorf("MaxBackups = %d, want default 100 on negative input", opts.Rotation.MaxBackups)
+	}
+}

--- a/cmd/silo/main.go
+++ b/cmd/silo/main.go
@@ -60,6 +60,7 @@ import (
 	"github.com/Silo-Server/silo-server/internal/libraryingest"
 	"github.com/Silo-Server/silo-server/internal/literaryworks"
 	"github.com/Silo-Server/silo-server/internal/logfilter"
+	"github.com/Silo-Server/silo-server/internal/logsink"
 	"github.com/Silo-Server/silo-server/internal/logstream"
 	"github.com/Silo-Server/silo-server/internal/mail"
 	"github.com/Silo-Server/silo-server/internal/manga"
@@ -128,12 +129,68 @@ func resolvePluginCacheDir() string {
 	return filepath.Join(os.TempDir(), "silo-plugins")
 }
 
-func buildBaseHandler(format string, level slog.Leveler) slog.Handler {
-	opts := &slog.HandlerOptions{Level: level}
-	if strings.EqualFold(format, "json") {
-		return slog.NewJSONHandler(os.Stderr, opts)
+// buildBaseHandler constructs the process-wide base slog handler. It always
+// writes to stderr (the historical behaviour). When SILO_LOG_FILE is set it
+// additionally persists logs to rotating files via logsink, optionally split
+// per subsystem (SILO_LOG_SPLIT). The returned closer flushes/closes any file
+// writers and must be deferred by the caller.
+func buildBaseHandler(format string, level slog.Leveler) (slog.Handler, io.Closer) {
+	handler, closer, err := logsink.New(logSinkOptionsFromEnv(format, level))
+	if err != nil {
+		// Never let a logging-config problem take down the server: fall back to
+		// stderr-only and surface the failure through the standard logger.
+		log.Printf("file logging disabled: %v", err)
+		opts := &slog.HandlerOptions{Level: level}
+		if strings.EqualFold(format, "json") {
+			return slog.NewJSONHandler(os.Stderr, opts), noopLogCloser{}
+		}
+		return slog.NewTextHandler(os.Stderr, opts), noopLogCloser{}
 	}
-	return slog.NewTextHandler(os.Stderr, opts)
+	return handler, closer
+}
+
+type noopLogCloser struct{}
+
+func (noopLogCloser) Close() error { return nil }
+
+// logSinkOptionsFromEnv reads the file-logging knobs from the environment.
+// File logging is operational infrastructure that must be configurable before
+// (and independently of) the DB-backed settings, so it is env-driven like
+// SILO_NODE_NAME / SILO_PLUGIN_CACHE_DIR rather than a hot-reloadable setting.
+//
+//	SILO_LOG_FILE            combined log file path; empty disables file logging
+//	SILO_LOG_SPLIT           "1"/"true" to also write per-category files
+//	SILO_LOG_MAX_SIZE_MB     rotation size before rollover (default 50)
+//	SILO_LOG_MAX_BACKUPS     rotated files to retain (default 100)
+//	SILO_LOG_MAX_AGE_DAYS    max age of rotated files in days (default 30)
+//	SILO_LOG_COMPRESS        "0"/"false" to disable gzip of rotated files
+func logSinkOptionsFromEnv(format string, level slog.Leveler) logsink.Options {
+	rot := logsink.DefaultRotation
+	if v, err := strconv.Atoi(strings.TrimSpace(os.Getenv("SILO_LOG_MAX_SIZE_MB"))); err == nil && v > 0 {
+		rot.MaxSizeMB = v
+	}
+	if v, err := strconv.Atoi(strings.TrimSpace(os.Getenv("SILO_LOG_MAX_BACKUPS"))); err == nil && v >= 0 {
+		rot.MaxBackups = v
+	}
+	if v, err := strconv.Atoi(strings.TrimSpace(os.Getenv("SILO_LOG_MAX_AGE_DAYS"))); err == nil && v >= 0 {
+		rot.MaxAgeDays = v
+	}
+	if v := strings.TrimSpace(os.Getenv("SILO_LOG_COMPRESS")); v != "" {
+		rot.Compress = !(v == "0" || strings.EqualFold(v, "false"))
+	}
+	return logsink.Options{
+		Stderr:   os.Stderr,
+		Format:   format,
+		Level:    level,
+		File:     strings.TrimSpace(os.Getenv("SILO_LOG_FILE")),
+		Split:    envIsTrue("SILO_LOG_SPLIT"),
+		Rotation: rot,
+	}
+}
+
+func envIsTrue(key string) bool {
+	v := strings.TrimSpace(os.Getenv(key))
+	return v == "1" || strings.EqualFold(v, "true") || strings.EqualFold(v, "yes")
 }
 
 func parseLogLevel(level string) slog.Level {
@@ -539,7 +596,12 @@ func main() {
 	// the config watcher in integrated mode.
 	logLevelVar := new(slog.LevelVar)
 	logLevelVar.Set(parseLogLevel(cfg.Server.LogLevel))
-	baseHandler := buildBaseHandler(cfg.Server.LogFormat, logLevelVar)
+	baseHandler, logCloser := buildBaseHandler(cfg.Server.LogFormat, logLevelVar)
+	defer func() {
+		if err := logCloser.Close(); err != nil {
+			log.Printf("close log files: %v", err)
+		}
+	}()
 	quietFilter := logfilter.New(baseHandler, cfg.Server.LogQuiet)
 	slog.SetDefault(slog.New(quietFilter))
 

--- a/internal/logsink/logsink.go
+++ b/internal/logsink/logsink.go
@@ -1,0 +1,413 @@
+// Package logsink provides a routing slog.Handler that persists logs to
+// rotating files in addition to the console (stderr).
+//
+// Silo's application logging otherwise only ever reaches os.Stderr, so under
+// Docker the sole record of a run lives in the daemon's json-file log, which
+// is discarded when the container is recreated. logsink lets an operator opt
+// into durable, self-rotating log files via SILO_LOG_FILE without touching the
+// container entrypoint.
+//
+// Records are classified into a coarse Category using the same "component"
+// signal opslog persists to the database (an explicit "component" attribute, or
+// the "subsystem:" message prefix via opslog.InferComponent). When split output
+// is enabled every record is written to the combined file AND to a per-category
+// file (e.g. silo-jellycompat.log, silo-playback.log), so an operator chasing a
+// transcode or Jellyfin-compat issue can tail one focused file instead of
+// grepping the firehose.
+//
+// The Router is installed as the process's base handler, beneath the log_quiet
+// filter (see cmd/silo/main.go). Consequently server.log_quiet suppresses
+// records from the files exactly as it does from the console: quieting a noisy
+// subsystem also empties its per-category file. This keeps file output an exact
+// mirror of the console stream; operators who need a quieted subsystem captured
+// durably should narrow log_quiet rather than rely on the split file.
+package logsink
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"log/slog"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/Silo-Server/silo-server/internal/opslog"
+	"gopkg.in/natefinch/lumberjack.v2"
+)
+
+// Category is a coarse routing bucket for a log record. The set is intentionally
+// small and stable: per-category files are only created for these buckets, so
+// an unbounded component space (e.g. "notifications.webhooks.retry") can never
+// spawn unbounded files. Anything unmapped falls back to CategoryApp, which has
+// no dedicated file and lands only in the combined log + stderr.
+type Category string
+
+const (
+	CategoryApp           Category = "app"
+	CategoryJellycompat   Category = "jellycompat"
+	CategoryPlayback      Category = "playback"
+	CategoryAPI           Category = "api"
+	CategoryScanner       Category = "scanner"
+	CategoryMetadata      Category = "metadata"
+	CategoryNotifications Category = "notifications"
+)
+
+// splitCategories are the categories that get their own file when Split is on.
+// CategoryApp is deliberately excluded: it is the default bucket and would just
+// duplicate the combined log.
+var splitCategories = []Category{
+	CategoryJellycompat,
+	CategoryPlayback,
+	CategoryAPI,
+	CategoryScanner,
+	CategoryMetadata,
+	CategoryNotifications,
+}
+
+// componentPrefixCategory maps the leading dotted/underscored segment of a
+// component name to a Category. Matching is longest-prefix-wins on "."-segments
+// so "notifications.webhooks.retry" resolves via "notifications". Values come
+// from two sources that already exist in the codebase: explicit
+// slog.With("component", …) attributes and opslog.InferComponent's "subsystem:"
+// message prefixes (see the log_quiet convention in internal/logfilter).
+var componentPrefixCategory = map[string]Category{
+	"jellycompat":   CategoryJellycompat,
+	"ffmpeg":        CategoryPlayback,
+	"play":          CategoryPlayback,
+	"playback":      CategoryPlayback,
+	"transcode":     CategoryPlayback,
+	"api":           CategoryAPI,
+	"admin":         CategoryAPI,
+	"requests":      CategoryAPI,
+	"webhook_sync":  CategoryAPI,
+	"scanner":       CategoryScanner,
+	"scan":          CategoryScanner,
+	"autoscan":      CategoryScanner,
+	"metadata":      CategoryMetadata,
+	"collage":       CategoryMetadata,
+	"people":        CategoryMetadata,
+	"catalog":       CategoryMetadata,
+	"library":       CategoryMetadata,
+	"notifications": CategoryNotifications,
+}
+
+// CategoryForComponent maps a component name to its routing Category. It walks
+// the "."-separated prefixes from longest to shortest so the most specific
+// registered mapping wins, then falls back to CategoryApp.
+func CategoryForComponent(component string) Category {
+	component = strings.TrimSpace(strings.ToLower(component))
+	if component == "" {
+		return CategoryApp
+	}
+	if cat, ok := lookupCategory(component); ok {
+		return cat
+	}
+	// opslog.InferComponent yields the whole message prefix before ':', which is
+	// frequently a multi-word "subsystem detail" string (e.g. "jellycompat
+	// autoscan", "person refresh"). Fall back to the leading whitespace token so
+	// those still route to their subsystem file instead of the catch-all app log.
+	if first := strings.Fields(component)[0]; first != component {
+		if cat, ok := lookupCategory(first); ok {
+			return cat
+		}
+	}
+	return CategoryApp
+}
+
+// lookupCategory walks the "."-separated prefixes of component from longest to
+// shortest and returns the first registered Category, so the most specific
+// mapping wins (e.g. "notifications.webhooks" resolves via "notifications").
+func lookupCategory(component string) (Category, bool) {
+	segments := strings.Split(component, ".")
+	for i := len(segments); i > 0; i-- {
+		key := strings.Join(segments[:i], ".")
+		if cat, ok := componentPrefixCategory[key]; ok {
+			return cat, true
+		}
+	}
+	return "", false
+}
+
+// Rotation controls lumberjack file rotation. A zero MaxSizeMB falls back to
+// DefaultRotation.MaxSizeMB in New; MaxBackups and MaxAgeDays are passed through
+// verbatim, so an explicit 0 keeps its lumberjack meaning (retain all backups /
+// never expire by age). Callers that want defaults should start from
+// DefaultRotation rather than the zero value.
+type Rotation struct {
+	MaxSizeMB  int
+	MaxBackups int
+	MaxAgeDays int
+	Compress   bool
+}
+
+// DefaultRotation mirrors the settings already used by the Jellyfin-compat
+// debug logger (internal/jellycompat/router.go) for consistency.
+var DefaultRotation = Rotation{
+	MaxSizeMB:  50,
+	MaxBackups: 100,
+	MaxAgeDays: 30,
+	Compress:   true,
+}
+
+// Options configures New.
+type Options struct {
+	// Stderr is the console sink. It always receives every record and must be
+	// non-nil; file sinks are layered on top of it.
+	Stderr io.Writer
+	// Format is "json" or "text"; it applies to both the console and files.
+	Format string
+	// Level gates every sink.
+	Level slog.Leveler
+	// File is the combined log file path. When empty, New returns a plain
+	// console-only handler and a no-op closer — behaviour identical to today.
+	File string
+	// Split, when true, additionally writes a per-category file alongside the
+	// combined file (silo-<category>.log in the combined file's directory).
+	Split bool
+	// Rotation tunes file rotation; zero fields fall back to DefaultRotation.
+	Rotation Rotation
+}
+
+// New builds the base slog.Handler for the process. When opts.File is empty it
+// returns a console-only handler (matching the pre-file-logging behaviour). The
+// returned closer flushes and closes any file writers; callers should defer it.
+func New(opts Options) (slog.Handler, io.Closer, error) {
+	console := newFormatHandler(opts.Format, opts.Stderr, opts.Level)
+	if strings.TrimSpace(opts.File) == "" {
+		return console, noopCloser{}, nil
+	}
+
+	rot := opts.Rotation
+	// Only MaxSizeMB is coalesced: a zero size is never meaningful. MaxBackups
+	// and MaxAgeDays are passed through verbatim so an explicit 0 keeps its
+	// lumberjack meaning (retain all backups / never expire by age); the env
+	// layer already starts from DefaultRotation, so "unset" arrives here as the
+	// defaults rather than as zero.
+	if rot.MaxSizeMB == 0 {
+		rot.MaxSizeMB = DefaultRotation.MaxSizeMB
+	}
+
+	// Collect every target path up front so we can fail fast (and let the caller
+	// fall back to stderr-only) if the log directory is unwritable. lumberjack
+	// otherwise opens files lazily on first write, which would surface a bad
+	// path only at runtime, where slog discards Handle errors.
+	paths := []string{opts.File}
+	if opts.Split {
+		dir := filepath.Dir(opts.File)
+		stem := stem(opts.File)
+		ext := filepath.Ext(opts.File)
+		if ext == "" {
+			ext = ".log"
+		}
+		for _, cat := range splitCategories {
+			paths = append(paths, filepath.Join(dir, stem+"-"+string(cat)+ext))
+		}
+	}
+	for _, p := range paths {
+		if err := ensureWritable(p); err != nil {
+			return nil, noopCloser{}, err
+		}
+	}
+
+	var closers []io.Closer
+	newFile := func(path string, only Category) dest {
+		lj := &lumberjack.Logger{
+			Filename:   path,
+			MaxSize:    rot.MaxSizeMB,
+			MaxBackups: rot.MaxBackups,
+			MaxAge:     rot.MaxAgeDays,
+			Compress:   rot.Compress,
+		}
+		closers = append(closers, lj)
+		return dest{h: newFormatHandler(opts.Format, lj, opts.Level), only: only}
+	}
+
+	// The console is the only destination whose write error may propagate (see
+	// Router.Handle); the combined file and split files are best-effort.
+	dests := []dest{
+		{h: console, console: true},
+		newFile(opts.File, ""),
+	}
+	if opts.Split {
+		for i, cat := range splitCategories {
+			dests = append(dests, newFile(paths[i+1], cat))
+		}
+	}
+
+	return &Router{dests: dests}, multiCloser(closers), nil
+}
+
+// ensureWritable makes the parent directory and confirms the log file can be
+// opened for appending, so a misconfigured SILO_LOG_FILE fails at startup
+// instead of silently no-opping at runtime.
+func ensureWritable(path string) error {
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		return fmt.Errorf("create log directory for %s: %w", path, err)
+	}
+	f, err := os.OpenFile(path, os.O_CREATE|os.O_APPEND|os.O_WRONLY, 0o644)
+	if err != nil {
+		return fmt.Errorf("open log file %s: %w", path, err)
+	}
+	return f.Close()
+}
+
+// dest is one output destination. only == "" accepts every record; otherwise it
+// accepts only records classified into that Category. console marks the single
+// stderr destination whose write error may propagate out of Router.Handle.
+type dest struct {
+	h       slog.Handler
+	only    Category
+	console bool
+}
+
+// Router fans each record out to the console, the combined file, and (when
+// split output is enabled) the file for the record's Category.
+//
+// Component classification mirrors opslog: an explicit top-level "component"
+// attribute wins, otherwise the message prefix via opslog.InferComponent. Only
+// top-level attributes count — a "component" nested inside a WithGroup is
+// namespaced ("group.component") and intentionally ignored, matching how opslog
+// keys its column.
+type Router struct {
+	dests []dest
+	// staticComponent is the component carried by With("component", …) applied
+	// to this handler, resolved only while at the top level (no active group).
+	staticComponent string
+	inGroup         bool
+}
+
+func (r *Router) Enabled(ctx context.Context, level slog.Level) bool {
+	for i := range r.dests {
+		if r.dests[i].h.Enabled(ctx, level) {
+			return true
+		}
+	}
+	return false
+}
+
+func (r *Router) Handle(ctx context.Context, rec slog.Record) error {
+	cat := r.classify(rec)
+	var consoleErr error
+	for i := range r.dests {
+		d := r.dests[i]
+		if d.only != "" && d.only != cat {
+			continue
+		}
+		if !d.h.Enabled(ctx, rec.Level) {
+			continue
+		}
+		err := d.h.Handle(ctx, rec)
+		// File destinations are best-effort. Their write errors (ENOSPC,
+		// read-only mount, rotation failure) must NOT propagate: this handler is
+		// wrapped by opslog.Handler, which skips its DB/admin-stream capture
+		// whenever its inner handler returns an error. Only the console error may
+		// bubble up, so a file problem can never disable the other log paths —
+		// preserving the pre-file-logging contract that logging never fails.
+		if d.console && err != nil {
+			consoleErr = err
+		}
+	}
+	return consoleErr
+}
+
+func (r *Router) classify(rec slog.Record) Category {
+	component := r.staticComponent
+	// A top-level inline "component" attribute overrides one set via
+	// With("component", …), matching opslog.Handler's last-write-wins precedence
+	// so file and DB classification agree. Attributes inside a group are
+	// namespaced ("group.component") and intentionally ignored, as opslog does.
+	if !r.inGroup {
+		rec.Attrs(func(a slog.Attr) bool {
+			if a.Key == "component" {
+				if s := a.Value.Resolve().String(); s != "" {
+					component = s
+					return false
+				}
+			}
+			return true
+		})
+	}
+	if component == "" {
+		component = opslog.InferComponent(rec.Message)
+	}
+	return CategoryForComponent(component)
+}
+
+func (r *Router) WithAttrs(attrs []slog.Attr) slog.Handler {
+	next := &Router{
+		dests:           make([]dest, len(r.dests)),
+		staticComponent: r.staticComponent,
+		inGroup:         r.inGroup,
+	}
+	for i := range r.dests {
+		next.dests[i] = dest{h: r.dests[i].h.WithAttrs(attrs), only: r.dests[i].only, console: r.dests[i].console}
+	}
+	// A top-level component attribute pins the category for every subsequent
+	// record from this logger; inside a group it would be namespaced, so skip.
+	if !r.inGroup {
+		for _, a := range attrs {
+			if a.Key == "component" {
+				if s := a.Value.Resolve().String(); s != "" {
+					next.staticComponent = s
+				}
+			}
+		}
+	}
+	return next
+}
+
+func (r *Router) WithGroup(name string) slog.Handler {
+	if name == "" {
+		return r
+	}
+	next := &Router{
+		dests:           make([]dest, len(r.dests)),
+		staticComponent: r.staticComponent,
+		inGroup:         true,
+	}
+	for i := range r.dests {
+		next.dests[i] = dest{h: r.dests[i].h.WithGroup(name), only: r.dests[i].only, console: r.dests[i].console}
+	}
+	return next
+}
+
+func newFormatHandler(format string, w io.Writer, level slog.Leveler) slog.Handler {
+	opts := &slog.HandlerOptions{Level: level}
+	if strings.EqualFold(format, "json") {
+		return slog.NewJSONHandler(w, opts)
+	}
+	return slog.NewTextHandler(w, opts)
+}
+
+// stem returns the filename of path without its directory or final extension:
+// "/var/log/silo/silo.log" -> "silo".
+func stem(path string) string {
+	base := filepath.Base(path)
+	if ext := filepath.Ext(base); ext != "" {
+		base = strings.TrimSuffix(base, ext)
+	}
+	if base == "" {
+		return "silo"
+	}
+	return base
+}
+
+type noopCloser struct{}
+
+func (noopCloser) Close() error { return nil }
+
+type multiCloser []io.Closer
+
+func (m multiCloser) Close() error {
+	var firstErr error
+	for _, c := range m {
+		if c == nil {
+			continue
+		}
+		if err := c.Close(); err != nil && firstErr == nil {
+			firstErr = err
+		}
+	}
+	return firstErr
+}

--- a/internal/logsink/logsink_test.go
+++ b/internal/logsink/logsink_test.go
@@ -1,0 +1,252 @@
+package logsink
+
+import (
+	"bytes"
+	"errors"
+	"io"
+	"log/slog"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestCategoryForComponent(t *testing.T) {
+	cases := map[string]Category{
+		"jellycompat":                  CategoryJellycompat,
+		"ffmpeg":                       CategoryPlayback,
+		"api":                          CategoryAPI,
+		"admin":                        CategoryAPI,
+		"scanner":                      CategoryScanner,
+		"scan":                         CategoryScanner,
+		"metadata":                     CategoryMetadata,
+		"notifications":                CategoryNotifications,
+		"notifications.webhooks.retry": CategoryNotifications, // longest-prefix fallback
+		"NotIfIcAtIoNs":                CategoryNotifications, // case-insensitive
+		"jellycompat autoscan":         CategoryJellycompat,   // multi-word: leading token wins
+		"":                             CategoryApp,
+		"something-unmapped":           CategoryApp,
+		"unmapped detail here":         CategoryApp, // leading token also unmapped
+	}
+	for component, want := range cases {
+		if got := CategoryForComponent(component); got != want {
+			t.Errorf("CategoryForComponent(%q) = %q, want %q", component, got, want)
+		}
+	}
+}
+
+// TestRouterFileRouting is the "do logs actually land where I think" check: it
+// drives real records through the handler and asserts the on-disk files.
+func TestRouterFileRouting(t *testing.T) {
+	dir := t.TempDir()
+	combined := filepath.Join(dir, "silo.log")
+
+	var console bytes.Buffer
+	h, closer, err := New(Options{
+		Stderr: &console,
+		Format: "text",
+		Level:  slog.LevelInfo,
+		File:   combined,
+		Split:  true,
+	})
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	logger := slog.New(h)
+
+	// Static component attribute via With(...).
+	logger.With("component", "jellycompat").Info("compat request served")
+	// Message-prefix inference ("scanner:" -> scanner category).
+	logger.Info("scanner: indexed library")
+	// Static component mapping to playback.
+	logger.With("component", "ffmpeg").Warn("transcode stalled")
+	// Inline component attr on the log call itself (distinct code path from
+	// With): must route to its category file.
+	logger.Info("cache warmed", "component", "metadata")
+	// Multi-word message prefix: InferComponent yields "jellycompat autoscan";
+	// the leading-token fallback must still route it to jellycompat.
+	logger.Info("jellycompat autoscan: listing libraries")
+	// Inline component overrides a static one (mirrors opslog last-write-wins):
+	// routes to scanner, not api.
+	logger.With("component", "api").Info("done", "component", "scanner")
+	// Unmapped -> app: combined + console only, no dedicated file.
+	logger.Info("just some app noise")
+	// Component nested in a group must NOT route (namespaced key) -> app.
+	logger.WithGroup("grp").With("component", "jellycompat").Info("grouped noise")
+
+	if err := closer.Close(); err != nil {
+		t.Fatalf("close: %v", err)
+	}
+
+	read := func(name string) string {
+		b, err := os.ReadFile(filepath.Join(dir, name))
+		if err != nil {
+			return "" // missing file reads as empty; assertions below handle it
+		}
+		return string(b)
+	}
+
+	combinedContent := read("silo.log")
+	for _, msg := range []string{
+		"compat request served", "scanner: indexed library", "transcode stalled",
+		"cache warmed", "jellycompat autoscan: listing libraries", "done",
+		"just some app noise", "grouped noise",
+	} {
+		if !contains(combinedContent, msg) {
+			t.Errorf("combined log missing %q\n---\n%s", msg, combinedContent)
+		}
+	}
+
+	// Console mirrors the combined stream.
+	if !contains(console.String(), "compat request served") || !contains(console.String(), "just some app noise") {
+		t.Errorf("console missing expected records:\n%s", console.String())
+	}
+
+	jelly := read("silo-jellycompat.log")
+	if !contains(jelly, "compat request served") {
+		t.Errorf("jellycompat file missing static-component record:\n%s", jelly)
+	}
+	if !contains(jelly, "jellycompat autoscan: listing libraries") {
+		t.Errorf("jellycompat file missing multi-word-prefix record:\n%s", jelly)
+	}
+	if contains(jelly, "scanner: indexed library") || contains(jelly, "grouped noise") {
+		t.Errorf("jellycompat file captured foreign records:\n%s", jelly)
+	}
+
+	scan := read("silo-scanner.log")
+	if !contains(scan, "scanner: indexed library") {
+		t.Errorf("scanner file missing prefix-inferred record:\n%s", scan)
+	}
+	// Inline component "scanner" overrode the static "api".
+	if !contains(scan, "done") {
+		t.Errorf("scanner file missing inline-overrides-static record:\n%s", scan)
+	}
+	if api := read("silo-api.log"); contains(api, "done") {
+		t.Errorf("api file wrongly captured a record whose inline component was scanner:\n%s", api)
+	}
+
+	if play := read("silo-playback.log"); !contains(play, "transcode stalled") {
+		t.Errorf("playback file missing its record:\n%s", play)
+	}
+	// Inline component attr on the log call routed to the metadata file.
+	if meta := read("silo-metadata.log"); !contains(meta, "cache warmed") {
+		t.Errorf("metadata file missing inline-component record:\n%s", meta)
+	}
+
+	// "app" is the default bucket and must never spawn a dedicated file.
+	if _, err := os.Stat(filepath.Join(dir, "silo-app.log")); !os.IsNotExist(err) {
+		t.Errorf("unexpected silo-app.log created (err=%v)", err)
+	}
+	// Grouped component=jellycompat must have fallen through to app (combined
+	// only), never the jellycompat file (already checked above).
+}
+
+func TestNewNoFileIsConsoleOnly(t *testing.T) {
+	dir := t.TempDir()
+	var console bytes.Buffer
+	h, closer, err := New(Options{Stderr: &console, Format: "text", Level: slog.LevelInfo})
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	defer closer.Close()
+
+	slog.New(h).Info("hello")
+	if !contains(console.String(), "hello") {
+		t.Fatalf("console missing record: %q", console.String())
+	}
+	entries, _ := os.ReadDir(dir)
+	if len(entries) != 0 {
+		t.Fatalf("expected no files created, got %d", len(entries))
+	}
+}
+
+// TestRotation drives lumberjack past its size threshold and asserts a rotated
+// backup is produced (rotation was previously untested).
+func TestRotation(t *testing.T) {
+	dir := t.TempDir()
+	combined := filepath.Join(dir, "silo.log")
+	h, closer, err := New(Options{
+		Stderr:   &bytes.Buffer{},
+		Format:   "text",
+		Level:    slog.LevelInfo,
+		File:     combined,
+		Rotation: Rotation{MaxSizeMB: 1, Compress: false}, // 1 MB, no async gzip to avoid races
+	})
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	logger := slog.New(h)
+
+	// Two ~600 KB records: the second exceeds the 1 MB cap and forces a rollover.
+	big := strings.Repeat("x", 600*1024)
+	logger.Info(big)
+	logger.Info(big)
+	if err := closer.Close(); err != nil {
+		t.Fatalf("close: %v", err)
+	}
+
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		t.Fatalf("readdir: %v", err)
+	}
+	var logs int
+	for _, e := range entries {
+		if strings.HasPrefix(e.Name(), "silo") && strings.HasSuffix(e.Name(), ".log") {
+			logs++
+		}
+	}
+	if logs < 2 {
+		t.Fatalf("expected at least 2 log files after rotation (current + rotated), got %d: %v", logs, entries)
+	}
+}
+
+// TestNewUnwritablePathErrors ensures a bad SILO_LOG_FILE surfaces as an error
+// from New (so buildBaseHandler's stderr fallback engages) rather than silently
+// no-opping at first write.
+func TestNewUnwritablePathErrors(t *testing.T) {
+	dir := t.TempDir()
+	// Make a regular file, then try to nest a log path beneath it: MkdirAll must
+	// fail because a path component is a file, not a directory.
+	blocker := filepath.Join(dir, "not-a-dir")
+	if err := os.WriteFile(blocker, []byte("x"), 0o644); err != nil {
+		t.Fatalf("setup: %v", err)
+	}
+	_, _, err := New(Options{
+		Stderr: &bytes.Buffer{},
+		Format: "text",
+		Level:  slog.LevelInfo,
+		File:   filepath.Join(blocker, "sub", "silo.log"),
+	})
+	if err == nil {
+		t.Fatal("expected New to return an error for an unwritable log path, got nil")
+	}
+}
+
+func TestMultiCloserPropagatesFirstErrorAndClosesAll(t *testing.T) {
+	sentinel := errors.New("boom")
+	var closed []string
+	stub := func(name string, err error) io.Closer {
+		return closerFunc(func() error { closed = append(closed, name); return err })
+	}
+	mc := multiCloser{
+		stub("a", nil),
+		stub("b", sentinel),
+		nil, // nil entries must be skipped, not panic
+		stub("c", errors.New("second")),
+	}
+	if err := mc.Close(); !errors.Is(err, sentinel) {
+		t.Fatalf("Close returned %v, want first error %v", err, sentinel)
+	}
+	// Every non-nil closer must still have run despite the earlier failure.
+	if len(closed) != 3 || closed[0] != "a" || closed[1] != "b" || closed[2] != "c" {
+		t.Fatalf("expected all closers invoked in order, got %v", closed)
+	}
+}
+
+type closerFunc func() error
+
+func (f closerFunc) Close() error { return f() }
+
+func contains(haystack, needle string) bool {
+	return bytes.Contains([]byte(haystack), []byte(needle))
+}

--- a/internal/opslog/handler.go
+++ b/internal/opslog/handler.go
@@ -50,7 +50,7 @@ func (h *Handler) Handle(ctx context.Context, r slog.Record) error {
 
 	component, _ := attrs["component"].(string)
 	if component == "" {
-		component = inferComponent(r.Message)
+		component = InferComponent(r.Message)
 	}
 	requestID, _ := attrs["request_id"].(string)
 	sessionID, _ := attrs["session_id"].(string)
@@ -163,7 +163,12 @@ func attrValue(v slog.Value) any {
 	}
 }
 
-func inferComponent(message string) string {
+// InferComponent derives a component name from a log message when no explicit
+// "component" attribute is present. It uses the text before the first ":" —
+// the same "subsystem:" prefix convention that logfilter's quiet list keys on
+// (e.g. "metadata: ...", "scanner: ..."). Shared with the file-routing log sink
+// so DB-persisted and file-persisted logs classify records identically.
+func InferComponent(message string) string {
 	if prefix, _, ok := strings.Cut(message, ":"); ok {
 		prefix = strings.TrimSpace(prefix)
 		if prefix != "" {


### PR DESCRIPTION
Part of #265.

Adds opt-in durable file logging so a server's logs survive container recreation, with optional per-subsystem split files.

## Problem

**Logs vanish when the container is recreated.** Silo only ever wrote its logs to stderr. Under Docker that means the only record of a run lives in the daemon's `json-file` log, which is deleted every time the container is recreated (a redeploy, an image bump, a `docker compose up` after an edit). An operator investigating something that happened "before the last restart" has nothing to look at — the history is gone. There is also no way, short of hand-editing the container entrypoint, to keep logs on a mounted volume.

**No way to isolate one subsystem's logs.** When chasing a specific problem — a Jellyfin-compat client misbehaving, a transcode failing, a scan stalling — an operator has to grep the entire firehose. There is no focused, per-area log to tail.

## Solution

A new opt-in file sink, gated entirely on the `SILO_LOG_FILE` environment variable (empty = today's stderr-only behaviour, unchanged). File logging is operational infrastructure, so it is env-driven and configured before the DB-backed settings, matching the existing `SILO_NODE_NAME` / `SILO_PLUGIN_CACHE_DIR` pattern.

### feat(observability): persistent per-subsystem file logging via SILO_LOG_FILE

- **New `internal/logsink` package (`logsink.go`).** `logsink.Router` is an `slog.Handler` installed as the process base handler. It fans each record to stderr + a combined rotating file, and — with `SILO_LOG_SPLIT` — to a per-subsystem file (`silo-jellycompat.log`, `silo-playback.log`, `silo-api.log`, `silo-scanner.log`, `silo-metadata.log`, `silo-notifications.log`). Rotation uses `lumberjack` (already a dependency, same settings as the jellycompat debug logger). Records are classified by the same `component` signal `opslog` persists — an explicit `component` attr, else the `subsystem:` message prefix — reusing `opslog.InferComponent` (exported in `internal/opslog/handler.go`) so file and DB classification stay in lock-step.
- **Wiring (`cmd/silo/main.go:131`, `buildBaseHandler`).** Delegates to `logsink.New`, reads the `SILO_LOG_*` env knobs (`logSinkOptionsFromEnv`), and returns a closer deferred in `run()`. Chain is unchanged otherwise: `opslog.Handler → logfilter(quiet) → logsink.Router → {stderr, files}`.
- **Reliability: file writes are best-effort (`logsink.go`, `Router.Handle`).** Only the console destination's error may propagate. A file write failure (ENOSPC, read-only mount, rotation error) is swallowed. This matters because the wrapping `opslog.Handler` skips its DB/admin-stream capture whenever its inner handler returns an error — so without this, a full log volume would silently disable the *database* operational-log path too. The console's effectively-never-fails contract is preserved, so logging can't wedge the server.
- **Reliability: bad paths fail fast (`logsink.go`, `ensureWritable`).** `lumberjack` opens files lazily on first write, so a bad `SILO_LOG_FILE` would otherwise surface only at runtime (where slog discards `Handle` errors). `New` now `MkdirAll`s and probe-opens every target path up front and returns an error, so `buildBaseHandler`'s stderr fallback actually engages and logs the reason.
- **Config fidelity.** Explicit `SILO_LOG_MAX_BACKUPS=0` / `SILO_LOG_MAX_AGE_DAYS=0` are passed through verbatim (lumberjack's "keep all" / "never expire") rather than coalesced back to defaults. Multi-word inferred prefixes (`jellycompat autoscan:`) route via their leading token so they still land in the subsystem file. Inline `component` attrs override a static `With("component", …)`, matching `opslog`'s last-write-wins precedence.

This change went through a 7-angle adversarial review; the items above (best-effort file writes, eager path validation, config fidelity, routing fixes) are the confirmed findings from that pass, folded into the initial commit.

## Risk / follow-ups

- **`log_quiet` also suppresses file records.** The router sits below the quiet filter, so quieting a noisy subsystem also empties its split file. This keeps files an exact mirror of the console stream (documented in the package doc). If durable-capture-despite-quiet is wanted, the file sinks would need to tee in before the filter — deferred pending a product call.
- **Per-subsystem routing is best-effort, not exhaustive.** Subsystems that neither set a `component` attr nor use a `subsystem:` message prefix fall to the combined log only. Tagging more subsystem roots explicitly is a follow-up.
- **File records are not redacted.** Like stderr today (no regression), file output is raw; `opslog`'s DB redaction does not apply to console/file sinks. Worth a separate hardening pass if secrets-in-logs is a concern.
- **Runtime wiring not included.** The deployment `docker-compose.yml` still needs `SILO_LOG_FILE`/`SILO_LOG_SPLIT` set and the old tee/FIFO entrypoint removed; intentionally left out of this code-only PR.

## Verification

- `go build ./...` — clean.
- `go vet ./internal/logsink/ ./cmd/silo/ ./internal/opslog/` — clean.
- `gofmt -l` on all touched files — no output.
- `go test ./internal/logsink/ -race` — 6 tests pass (routing to correct files incl. inline-attr and multi-word paths, inline-overrides-static, rotation produces a backup, unwritable path returns an error, closer error propagation, console-only when no file set).
- `go test ./cmd/silo/` — env-parsing tests pass (`envIsTrue`, defaults, overrides incl. explicit-0 retention, invalid-number fallback).

## AI-use disclosure

Implemented with AI assistance (Claude Code): drafting, the multi-agent adversarial review, the resulting fixes, and this description. All changes were reviewed by the author.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added optional file-based logging with automatic rotation and per-area log splitting.
  * Logging now falls back to console output if file logging can’t be initialized, so the app still starts.
  * Added broader log category detection for more consistent routing.
* **Bug Fixes**
  * Improved handling of environment settings, including default values, zero values, and invalid numeric inputs.
  * Added safeguards for log cleanup so log files are properly closed and flushed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->