### PR TITLE
fix(catalogseed): cast v.id to bigint in bulkUpdatePeople

### DIFF
--- a/internal/catalogseed/service.go
+++ b/internal/catalogseed/service.go
@@ -1828,7 +1828,10 @@ func bulkUpdatePeople(ctx context.Context, tx pgx.Tx, people map[int64]*importPe
 		FROM (VALUES `,
 		rows,
 		7,
-		nil,
+		// A standalone VALUES clause has no target column to infer types
+		// from, so v.id must be cast explicitly or it defaults to text and
+		// the join predicate becomes bigint = text (SQLSTATE 42883).
+		map[int]string{0: "::bigint"},
 		`) AS v(id, tmdb_id, imdb_id, tvdb_id, plex_guid, photo_path, photo_thumbhash)
 		WHERE p.id = v.id`,
 		nil,

--- a/internal/catalogseed/service_db_test.go
+++ b/internal/catalogseed/service_db_test.go
@@ -1,0 +1,63 @@
+package catalogseed
+
+import (
+	"context"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/jackc/pgx/v5/pgxpool"
+)
+
+func newCatalogSeedTestPool(t *testing.T) *pgxpool.Pool {
+	t.Helper()
+	dsn := os.Getenv("SILO_TEST_DATABASE_URL")
+	if dsn == "" {
+		t.Skip("SILO_TEST_DATABASE_URL is not set")
+	}
+	pool, err := pgxpool.New(context.Background(), dsn)
+	if err != nil {
+		t.Fatalf("connect test database: %v", err)
+	}
+	t.Cleanup(pool.Close)
+	return pool
+}
+
+func TestBulkUpdatePeopleComparesIDsAsBigint(t *testing.T) {
+	ctx := context.Background()
+	pool := newCatalogSeedTestPool(t)
+
+	tx, err := pool.Begin(ctx)
+	if err != nil {
+		t.Fatalf("begin tx: %v", err)
+	}
+	defer func() { _ = tx.Rollback(ctx) }()
+
+	personID := time.Now().UnixNano()
+	if _, err := tx.Exec(ctx, `
+		INSERT INTO people (id, name, sort_name, tmdb_id)
+		VALUES ($1, 'Import Test Person', 'import test person', '111')
+	`, personID); err != nil {
+		t.Fatalf("seed person: %v", err)
+	}
+
+	people := map[int64]*importPersonState{
+		personID: {
+			ID:          personID,
+			Name:        "Import Test Person",
+			TmdbID:      "222",
+			NeedsUpdate: true,
+		},
+	}
+	if err := bulkUpdatePeople(ctx, tx, people); err != nil {
+		t.Fatalf("bulkUpdatePeople: %v", err)
+	}
+
+	var tmdbID string
+	if err := tx.QueryRow(ctx, `SELECT tmdb_id FROM people WHERE id = $1`, personID).Scan(&tmdbID); err != nil {
+		t.Fatalf("read back person: %v", err)
+	}
+	if tmdbID != "222" {
+		t.Fatalf("tmdb_id = %q, want %q", tmdbID, "222")
+	}
+}


### PR DESCRIPTION
## Problem

Importing catalogue seeds fails during the people-update phase with:

`Error: replacing people: updating imported people: ERROR: operator does not exist: bigint = text (SQLSTATE 42883)`

`bulkUpdatePeople` builds `UPDATE people AS p ... FROM (VALUES ...) AS v(id, ...) WHERE p.id = v.id` but passes `nil` for the casts argument. In a standalone `VALUES` clause Postgres has no target column to infer parameter types from, so `v.id` defaults to `text` while `people.id` is `bigint` — the join predicate becomes `bigint = text` and 42883s. The sibling `bulkInsertPeople` is unaffected because `INSERT ... VALUES` infers types from the target table.

## Approach

Pass `map[int]string{0: "::bigint"}` as the casts argument, mirroring the existing `::jsonb` cast pattern already used for `media_files` in the same file.

Added a DB-backed regression test (gated on `SILO_TEST_DATABASE_URL`, following the existing pattern in `internal/literaryworks`); it reproduced the exact 42883 before the fix and passes after.

## Risks / follow-ups

None expected — one-line SQL type-cast on a single bulk-update path; the test covers readback of the updated row.

Fixes #267

## AI-use disclosure

Implemented with Claude Code (test-first); human-reviewed before submission.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue that could prevent person metadata from updating correctly during catalog imports.
  * Improved database type handling so person IDs are compared consistently, reducing the chance of import failures or mismatched updates.

* **Tests**
  * Added database coverage to verify person metadata updates work as expected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->