### PR TITLE
test(access): add ListProgressSince to stubStore so tests compile

### DIFF
--- a/internal/access/resolver_test.go
+++ b/internal/access/resolver_test.go
@@ -92,6 +92,9 @@ func (s stubStore) ListProgressFiltered(context.Context, string, string, []strin
 func (s stubStore) ListProgressByMediaItems(context.Context, string, []string) (map[string]userstore.WatchProgress, error) {
 	panic("unused")
 }
+func (s stubStore) ListProgressSince(context.Context, string, string) ([]userstore.WatchProgress, string, error) {
+	panic("unused")
+}
 func (s stubStore) AddHistory(context.Context, userstore.WatchHistoryEntry) error { panic("unused") }
 func (s stubStore) AddHistoryIfMissing(context.Context, userstore.WatchHistoryEntry) (bool, error) {
 	panic("unused")


### PR DESCRIPTION
## Problem

#258 (downloads v2 / offline sync) added `ListProgressSince` to the `userstore.UserStore` interface but didn't update the `stubStore` test double in `internal/access/resolver_test.go`, so `go test ./internal/access/` fails to build on main:

```
internal/access/resolver_test.go:275:28: cannot use stubStore{…} as userstore.UserStore value in struct literal: stubStore does not implement userstore.UserStore (missing method ListProgressSince)
```

## Approach

Add the missing method as a `panic("unused")` stub, consistent with the rest of `stubStore`. `go test ./internal/access/` compiles and passes again.

Part of the fallout from #258.

## AI-use disclosure

Implemented with Claude Code; human-reviewed before submission.

🤖 Generated with [Claude Code](https://claude.com/claude-code)