### PR TITLE
fix(metadata): re-fetch titles/overviews when a library's metadata language changes

### DIFF
--- a/internal/adminjob/library_refresh.go
+++ b/internal/adminjob/library_refresh.go
@@ -89,6 +89,7 @@ func (l *PGLibraryRefreshItemLister) ListLibraryItems(ctx context.Context, libra
 	query := `
 		SELECT mi.content_id, COALESCE(mi.tmdb_id, ''), COALESCE(mi.tvdb_id, ''), COALESCE(mi.imdb_id, '')
 		FROM media_item_libraries mil
+		JOIN media_folders f ON f.id = mil.media_folder_id
 		JOIN media_items mi ON mi.content_id = mil.content_id
 		WHERE mil.media_folder_id = $1`
 	args := []any{libraryID}
@@ -122,6 +123,11 @@ func (l *PGLibraryRefreshItemLister) ListLibraryItems(ctx context.Context, libra
 				SELECT 1
 				FROM stale_media_ids smi
 				WHERE smi.content_id = mi.content_id
+			)
+			OR (
+				COALESCE(mi.default_metadata_language, '') <> ''
+				AND LOWER(TRIM(mi.default_metadata_language))
+					<> LOWER(TRIM(COALESCE(NULLIF(f.metadata_language, ''), 'en')))
 			)
 		  )`
 	}

--- a/internal/adminjob/library_refresh_language_test.go
+++ b/internal/adminjob/library_refresh_language_test.go
@@ -1,0 +1,93 @@
+package adminjob
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/jackc/pgx/v5/pgxpool"
+)
+
+// TestQuickRefreshListsLanguageMismatchedItems covers the listing half of
+// issue #211: quick-mode library refresh must include items whose stamped
+// default_metadata_language differs from the library's configured metadata
+// language, even when the item is otherwise complete (overview, poster,
+// backdrop all present) — otherwise a library language change never revisits
+// already-complete items.
+func TestQuickRefreshListsLanguageMismatchedItems(t *testing.T) {
+	dsn := os.Getenv("SILO_TEST_DATABASE_URL")
+	if dsn == "" {
+		t.Skip("SILO_TEST_DATABASE_URL is not set")
+	}
+	ctx := context.Background()
+	pool, err := pgxpool.New(ctx, dsn)
+	if err != nil {
+		t.Fatalf("connect test database: %v", err)
+	}
+	t.Cleanup(pool.Close)
+
+	suffix := time.Now().UnixNano()
+	mismatchID := fmt.Sprintf("lang-mismatch-%d", suffix)
+	matchedID := fmt.Sprintf("lang-matched-%d", suffix)
+
+	var folderID int
+	if err := pool.QueryRow(ctx, `
+		INSERT INTO media_folders (type, name, enabled, metadata_language)
+		VALUES ('movies', 'Lang Refresh Test', true, 'da')
+		RETURNING id
+	`).Scan(&folderID); err != nil {
+		t.Fatalf("seed folder: %v", err)
+	}
+	t.Cleanup(func() {
+		_, _ = pool.Exec(ctx, `DELETE FROM media_items WHERE content_id = ANY($1)`, []string{mismatchID, matchedID})
+		_, _ = pool.Exec(ctx, `DELETE FROM media_folders WHERE id = $1`, folderID)
+	})
+
+	for _, row := range []struct {
+		id, lang string
+	}{
+		{mismatchID, "zh"},
+		{matchedID, "da"},
+	} {
+		if _, err := pool.Exec(ctx, `
+			INSERT INTO media_items (
+				content_id, type, title, status, genres, tmdb_id,
+				default_metadata_language, overview, poster_path, backdrop_path,
+				last_refreshed, refresh_failures, episode_metadata_incomplete
+			) VALUES ($1, 'movie', 'Complete Item', 'matched', '{}'::text[], '42',
+				$2, 'An overview', '/p.jpg', '/b.jpg', NOW(), 0, FALSE)
+		`, row.id, row.lang); err != nil {
+			t.Fatalf("seed media item %s: %v", row.id, err)
+		}
+		if _, err := pool.Exec(ctx, `
+			INSERT INTO media_item_libraries (content_id, media_folder_id)
+			VALUES ($1, $2)
+		`, row.id, folderID); err != nil {
+			t.Fatalf("link media item %s: %v", row.id, err)
+		}
+	}
+
+	lister := NewPGLibraryRefreshItemLister(pool)
+	items, err := lister.ListLibraryItems(ctx, folderID, LibraryRefreshModeQuick)
+	if err != nil {
+		t.Fatalf("ListLibraryItems: %v", err)
+	}
+
+	var sawMismatch, sawMatched bool
+	for _, item := range items {
+		switch item.ContentID {
+		case mismatchID:
+			sawMismatch = true
+		case matchedID:
+			sawMatched = true
+		}
+	}
+	if !sawMismatch {
+		t.Errorf("quick refresh must include complete item with stamped language differing from the library language")
+	}
+	if sawMatched {
+		t.Errorf("quick refresh must not include complete item whose stamped language matches the library language")
+	}
+}

--- a/internal/api/handlers/libraries.go
+++ b/internal/api/handlers/libraries.go
@@ -687,6 +687,26 @@ func (h *LibraryHandler) HandleUpdateLibrary(w http.ResponseWriter, r *http.Requ
 		}
 	}
 
+	// Re-fetch metadata when the library's metadata language changed, so
+	// existing items adopt the new language instead of keeping the one
+	// stamped at first match. Quick mode suffices: the refresh item lister
+	// includes complete-but-language-mismatched items.
+	if h.JobRepo != nil && !strings.EqualFold(strings.TrimSpace(oldFolder.MetadataLanguage), strings.TrimSpace(folder.MetadataLanguage)) {
+		job, jobErr := h.JobRepo.CreateLibraryRefresh(r.Context(), currentAdminUserID(r), adminjob.LibraryRefreshRequest{
+			LibraryID:   folder.ID,
+			LibraryName: folder.Name,
+			Mode:        adminjob.LibraryRefreshModeQuick,
+		}, "Queued metadata refresh after library language change")
+		if jobErr != nil {
+			var conflict *adminjob.ActiveJobConflictError
+			if !errors.As(jobErr, &conflict) {
+				slog.Warn("queue language-change metadata refresh failed", "library_id", folder.ID, "error", jobErr)
+			}
+		} else {
+			publishEventJob(r.Context(), h.EventsHub, "job.created", job)
+		}
+	}
+
 	// Rescan when paths have changed (folders added or removed).
 	if req.Paths != nil && !slices.Equal(oldFolder.Paths, *req.Paths) {
 		if h.ScanQueue != nil {

--- a/internal/api/handlers/libraries_language_change_test.go
+++ b/internal/api/handlers/libraries_language_change_test.go
@@ -1,0 +1,112 @@
+package handlers
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"strconv"
+	"strings"
+	"sync"
+	"testing"
+
+	"github.com/go-chi/chi/v5"
+	"github.com/jackc/pgx/v5/pgxpool"
+
+	"github.com/Silo-Server/silo-server/internal/adminjob"
+	"github.com/Silo-Server/silo-server/internal/catalog"
+	"github.com/Silo-Server/silo-server/internal/models"
+)
+
+type fakeAdminJobCreator struct {
+	mu       sync.Mutex
+	refreshs []adminjob.LibraryRefreshRequest
+}
+
+func (f *fakeAdminJobCreator) Create(context.Context, adminjob.CreateJobInput) (*models.AdminJob, error) {
+	return &models.AdminJob{}, nil
+}
+
+func (f *fakeAdminJobCreator) CreateLibraryRefresh(_ context.Context, _ int, req adminjob.LibraryRefreshRequest, _ string) (*models.AdminJob, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.refreshs = append(f.refreshs, req)
+	return &models.AdminJob{}, nil
+}
+
+func (f *fakeAdminJobCreator) libraryRefreshes() []adminjob.LibraryRefreshRequest {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return append([]adminjob.LibraryRefreshRequest(nil), f.refreshs...)
+}
+
+// TestHandleUpdateLibraryLanguageChangeQueuesRefresh covers the trigger half
+// of issue #211: changing a library's metadata language must enqueue a
+// library metadata refresh so existing items re-fetch in the new language,
+// while an update that does not change the language must not enqueue one.
+func TestHandleUpdateLibraryLanguageChangeQueuesRefresh(t *testing.T) {
+	dsn := os.Getenv("SILO_TEST_DATABASE_URL")
+	if dsn == "" {
+		t.Skip("SILO_TEST_DATABASE_URL is not set")
+	}
+	ctx := context.Background()
+	pool, err := pgxpool.New(ctx, dsn)
+	if err != nil {
+		t.Fatalf("connect db: %v", err)
+	}
+	t.Cleanup(pool.Close)
+
+	var folderID int
+	if err := pool.QueryRow(ctx, `
+		INSERT INTO media_folders (type, name, enabled, metadata_language)
+		VALUES ('movies', 'Lang Change Test', true, 'zh')
+		RETURNING id
+	`).Scan(&folderID); err != nil {
+		t.Fatalf("seed folder: %v", err)
+	}
+	t.Cleanup(func() {
+		_, _ = pool.Exec(ctx, `DELETE FROM media_folders WHERE id = $1`, folderID)
+	})
+
+	jobs := &fakeAdminJobCreator{}
+	h := NewLibraryHandler(catalog.NewFolderRepository(pool), nil, nil, pool, nil)
+	h.JobRepo = jobs
+
+	doUpdate := func(body string) *httptest.ResponseRecorder {
+		req := httptest.NewRequest(http.MethodPut, "/libraries/"+strconv.Itoa(folderID), strings.NewReader(body))
+		chiCtx := chi.NewRouteContext()
+		chiCtx.URLParams.Add("id", strconv.Itoa(folderID))
+		req = req.WithContext(context.WithValue(req.Context(), chi.RouteCtxKey, chiCtx))
+		rec := httptest.NewRecorder()
+		h.HandleUpdateLibrary(rec, req)
+		return rec
+	}
+
+	// An update that does not touch the language must not enqueue a refresh.
+	if rec := doUpdate(`{"name":"Lang Change Test Renamed"}`); rec.Code != http.StatusOK {
+		t.Fatalf("rename update status = %d (body: %s)", rec.Code, rec.Body.String())
+	}
+	if got := jobs.libraryRefreshes(); len(got) != 0 {
+		t.Fatalf("refresh jobs after rename = %d, want 0", len(got))
+	}
+
+	// Changing the metadata language must enqueue a refresh for this library.
+	if rec := doUpdate(`{"metadata_language":"da"}`); rec.Code != http.StatusOK {
+		t.Fatalf("language update status = %d (body: %s)", rec.Code, rec.Body.String())
+	}
+	refreshes := jobs.libraryRefreshes()
+	if len(refreshes) != 1 {
+		t.Fatalf("refresh jobs after language change = %d, want 1", len(refreshes))
+	}
+	if refreshes[0].LibraryID != folderID {
+		t.Errorf("refresh library id = %d, want %d", refreshes[0].LibraryID, folderID)
+	}
+
+	// Re-submitting the same language is a no-op update and must not enqueue.
+	if rec := doUpdate(`{"metadata_language":"da"}`); rec.Code != http.StatusOK {
+		t.Fatalf("same-language update status = %d (body: %s)", rec.Code, rec.Body.String())
+	}
+	if got := jobs.libraryRefreshes(); len(got) != 1 {
+		t.Fatalf("refresh jobs after same-language update = %d, want still 1", len(got))
+	}
+}

--- a/internal/catalog/default_language_restamp_test.go
+++ b/internal/catalog/default_language_restamp_test.go
@@ -1,0 +1,166 @@
+package catalog
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/jackc/pgx/v5/pgxpool"
+
+	"github.com/Silo-Server/silo-server/internal/models"
+)
+
+func newRestampTestPool(t *testing.T) *pgxpool.Pool {
+	t.Helper()
+	dsn := os.Getenv("SILO_TEST_DATABASE_URL")
+	if dsn == "" {
+		t.Skip("SILO_TEST_DATABASE_URL is not set")
+	}
+	pool, err := pgxpool.New(context.Background(), dsn)
+	if err != nil {
+		t.Fatalf("connect test database: %v", err)
+	}
+	t.Cleanup(pool.Close)
+	return pool
+}
+
+// TestItemUpsertRestampsDefaultMetadataLanguage covers the persistence half of
+// issue #211: when a refresh adopts a new canonical language, the upsert must
+// accept the incoming non-empty default_metadata_language instead of pinning
+// to the stamp written at first match. An empty incoming value must still
+// keep the existing stamp (scanner skeleton writes send the zero value).
+func TestItemUpsertRestampsDefaultMetadataLanguage(t *testing.T) {
+	ctx := context.Background()
+	pool := newRestampTestPool(t)
+	repo := NewItemRepository(pool)
+
+	contentID := fmt.Sprintf("restamp-item-%d", time.Now().UnixNano())
+	t.Cleanup(func() {
+		_, _ = pool.Exec(ctx, `DELETE FROM media_items WHERE content_id = $1`, contentID)
+	})
+
+	base := &models.MediaItem{
+		ContentID:               contentID,
+		Type:                    "movie",
+		Title:                   "Gammel Titel",
+		Status:                  "matched",
+		DefaultMetadataLanguage: "zh",
+		Studios:                 []string{},
+		Networks:                []string{},
+		Countries:               []string{},
+		Genres:                  []string{},
+	}
+	if err := repo.Upsert(ctx, base); err != nil {
+		t.Fatalf("initial upsert: %v", err)
+	}
+
+	restamped := *base
+	restamped.Title = "Ny Titel"
+	restamped.DefaultMetadataLanguage = "da"
+	if err := repo.Upsert(ctx, &restamped); err != nil {
+		t.Fatalf("restamp upsert: %v", err)
+	}
+	got, err := repo.GetByID(ctx, contentID)
+	if err != nil {
+		t.Fatalf("get item: %v", err)
+	}
+	if got.DefaultMetadataLanguage != "da" {
+		t.Errorf("default_metadata_language = %q, want da (incoming non-empty stamp must win)", got.DefaultMetadataLanguage)
+	}
+
+	emptied := restamped
+	emptied.DefaultMetadataLanguage = ""
+	if err := repo.Upsert(ctx, &emptied); err != nil {
+		t.Fatalf("empty-language upsert: %v", err)
+	}
+	got, err = repo.GetByID(ctx, contentID)
+	if err != nil {
+		t.Fatalf("get item after empty upsert: %v", err)
+	}
+	if got.DefaultMetadataLanguage != "da" {
+		t.Errorf("default_metadata_language = %q, want da kept when incoming is empty", got.DefaultMetadataLanguage)
+	}
+}
+
+// TestSeasonAndEpisodeUpsertRestampDefaultMetadataLanguage verifies the same
+// restamp-on-upsert semantics for the season and episode tables, which carry
+// their own default_metadata_language pins.
+func TestSeasonAndEpisodeUpsertRestampDefaultMetadataLanguage(t *testing.T) {
+	ctx := context.Background()
+	pool := newRestampTestPool(t)
+
+	suffix := time.Now().UnixNano()
+	seriesID := fmt.Sprintf("restamp-series-%d", suffix)
+	seasonID := fmt.Sprintf("restamp-season-%d", suffix)
+	episodeID := fmt.Sprintf("restamp-episode-%d", suffix)
+	t.Cleanup(func() {
+		// Seasons and episodes cascade from the series row (FK ON DELETE
+		// CASCADE), so a single delete cleans up everything seeded here.
+		_, _ = pool.Exec(ctx, `DELETE FROM media_items WHERE content_id = $1`, seriesID)
+	})
+
+	itemRepo := NewItemRepository(pool)
+	if err := itemRepo.Upsert(ctx, &models.MediaItem{
+		ContentID:               seriesID,
+		Type:                    "series",
+		Title:                   "Restamp Series",
+		Status:                  "matched",
+		DefaultMetadataLanguage: "zh",
+		Studios:                 []string{},
+		Networks:                []string{},
+		Countries:               []string{},
+		Genres:                  []string{},
+	}); err != nil {
+		t.Fatalf("seed series: %v", err)
+	}
+
+	seasonRepo := NewSeasonRepository(pool)
+	season := &models.Season{
+		ContentID:               seasonID,
+		SeriesID:                seriesID,
+		SeasonNumber:            1,
+		Title:                   "Sæson 1",
+		DefaultMetadataLanguage: "zh",
+	}
+	if err := seasonRepo.Upsert(ctx, season); err != nil {
+		t.Fatalf("seed season: %v", err)
+	}
+	season.DefaultMetadataLanguage = "da"
+	if err := seasonRepo.Upsert(ctx, season); err != nil {
+		t.Fatalf("restamp season: %v", err)
+	}
+	var seasonLang string
+	if err := pool.QueryRow(ctx, `SELECT default_metadata_language FROM seasons WHERE content_id = $1`, seasonID).Scan(&seasonLang); err != nil {
+		t.Fatalf("read season language: %v", err)
+	}
+	if seasonLang != "da" {
+		t.Errorf("season default_metadata_language = %q, want da", seasonLang)
+	}
+
+	episodeRepo := NewEpisodeRepository(pool)
+	episode := &models.Episode{
+		ContentID:               episodeID,
+		SeriesID:                seriesID,
+		SeasonID:                seasonID,
+		SeasonNumber:            1,
+		EpisodeNumber:           1,
+		Title:                   "Afsnit 1",
+		DefaultMetadataLanguage: "zh",
+	}
+	if err := episodeRepo.Upsert(ctx, episode); err != nil {
+		t.Fatalf("seed episode: %v", err)
+	}
+	episode.DefaultMetadataLanguage = "da"
+	if err := episodeRepo.Upsert(ctx, episode); err != nil {
+		t.Fatalf("restamp episode: %v", err)
+	}
+	var episodeLang string
+	if err := pool.QueryRow(ctx, `SELECT default_metadata_language FROM episodes WHERE content_id = $1`, episodeID).Scan(&episodeLang); err != nil {
+		t.Fatalf("read episode language: %v", err)
+	}
+	if episodeLang != "da" {
+		t.Errorf("episode default_metadata_language = %q, want da", episodeLang)
+	}
+}

--- a/internal/catalog/episode_repo.go
+++ b/internal/catalog/episode_repo.go
@@ -320,7 +320,7 @@ func (r *EpisodeRepository) Upsert(ctx context.Context, ep *models.Episode) erro
 		ON CONFLICT (series_id, season_number, episode_number) DO UPDATE SET
 			season_id = COALESCE(EXCLUDED.season_id, episodes.season_id),
 			title = EXCLUDED.title,
-			default_metadata_language = COALESCE(NULLIF(episodes.default_metadata_language, ''), EXCLUDED.default_metadata_language),
+			default_metadata_language = COALESCE(NULLIF(EXCLUDED.default_metadata_language, ''), episodes.default_metadata_language),
 			overview = EXCLUDED.overview,
 			air_date = EXCLUDED.air_date,
 			runtime = EXCLUDED.runtime,
@@ -503,7 +503,7 @@ func (r *EpisodeRepository) BulkUpsert(ctx context.Context, seriesID string, epi
 		ON CONFLICT (series_id, season_number, episode_number) DO UPDATE SET
 			season_id = COALESCE(EXCLUDED.season_id, episodes.season_id),
 			title = EXCLUDED.title,
-			default_metadata_language = COALESCE(NULLIF(episodes.default_metadata_language, ''), EXCLUDED.default_metadata_language),
+			default_metadata_language = COALESCE(NULLIF(EXCLUDED.default_metadata_language, ''), episodes.default_metadata_language),
 			overview = EXCLUDED.overview,
 			air_date = EXCLUDED.air_date,
 			runtime = EXCLUDED.runtime,

--- a/internal/catalog/item_repo.go
+++ b/internal/catalog/item_repo.go
@@ -467,7 +467,7 @@ func (r *ItemRepository) upsert(ctx context.Context, execer itemExecer, item *mo
 			type = EXCLUDED.type,
 			title = EXCLUDED.title,
 			sort_title = EXCLUDED.sort_title,
-			default_metadata_language = COALESCE(NULLIF(media_items.default_metadata_language, ''), EXCLUDED.default_metadata_language),
+			default_metadata_language = COALESCE(NULLIF(EXCLUDED.default_metadata_language, ''), media_items.default_metadata_language),
 			original_title = EXCLUDED.original_title,
 			year = EXCLUDED.year,
 			genres = EXCLUDED.genres,

--- a/internal/catalog/season_repo.go
+++ b/internal/catalog/season_repo.go
@@ -112,7 +112,7 @@ func (r *SeasonRepository) Upsert(ctx context.Context, s *models.Season) error {
 		)
 		ON CONFLICT (series_id, season_number) DO UPDATE SET
 			title = EXCLUDED.title,
-			default_metadata_language = COALESCE(NULLIF(seasons.default_metadata_language, ''), EXCLUDED.default_metadata_language),
+			default_metadata_language = COALESCE(NULLIF(EXCLUDED.default_metadata_language, ''), seasons.default_metadata_language),
 			overview = EXCLUDED.overview,
 			air_date = EXCLUDED.air_date,
 			poster_path = EXCLUDED.poster_path,
@@ -198,7 +198,7 @@ func (r *SeasonRepository) BulkUpsert(ctx context.Context, seasons []*models.Sea
 		)
 		ON CONFLICT (series_id, season_number) DO UPDATE SET
 			title = EXCLUDED.title,
-			default_metadata_language = COALESCE(NULLIF(seasons.default_metadata_language, ''), EXCLUDED.default_metadata_language),
+			default_metadata_language = COALESCE(NULLIF(EXCLUDED.default_metadata_language, ''), seasons.default_metadata_language),
 			overview = EXCLUDED.overview,
 			air_date = EXCLUDED.air_date,
 			poster_path = EXCLUDED.poster_path,

--- a/internal/metadata/relanguage_test.go
+++ b/internal/metadata/relanguage_test.go
@@ -1,0 +1,146 @@
+package metadata
+
+import (
+	"context"
+	"testing"
+
+	"github.com/Silo-Server/silo-server/internal/models"
+)
+
+func seedRelanguageItem(t *testing.T, h *testHarness) {
+	t.Helper()
+	if err := h.itemRepo.Upsert(context.Background(), &models.MediaItem{
+		ContentID:               "existing-1",
+		Type:                    "movie",
+		Title:                   "Gammel Kinesisk Titel",
+		Overview:                "Old-language overview",
+		Year:                    2020,
+		Status:                  "matched",
+		DefaultMetadataLanguage: "zh",
+		Studios:                 []string{},
+		Networks:                []string{},
+		Countries:               []string{},
+		Genres:                  []string{},
+	}); err != nil {
+		t.Fatalf("upsert existing item: %v", err)
+	}
+}
+
+// TestProcess_AdoptLanguageRewritesBaseRowAndRestamps covers the core of
+// issue #211: a refresh carrying AdoptLanguage must treat req.Language as the
+// item's new canonical metadata language — replacing the base-row title and
+// overview and restamping default_metadata_language — instead of pinning to
+// the language stamped at first match.
+func TestProcess_AdoptLanguageRewritesBaseRowAndRestamps(t *testing.T) {
+	h := newTestHarness()
+	ctx := context.Background()
+	seedRelanguageItem(t, h)
+
+	provider := &capturingMetadataProvider{
+		response: &MetadataResult{
+			HasMetadata: true,
+			Title:       "Ny Dansk Titel",
+			Overview:    "Dansk oversigt",
+			ProviderIDs: map[string]string{"tmdb": "42"},
+		},
+	}
+
+	result, err := h.service.ProcessWithProviders(ctx, ProcessRequest{
+		ContentID:     "existing-1",
+		Language:      "da",
+		Mode:          ModeManualRefresh,
+		AdoptLanguage: true,
+	}, []Provider{provider})
+	if err != nil {
+		t.Fatalf("ProcessWithProviders: %v", err)
+	}
+	if result == nil || !result.Updated {
+		t.Fatalf("result = %#v, want Updated=true", result)
+	}
+
+	item, err := h.itemRepo.GetByID(ctx, "existing-1")
+	if err != nil {
+		t.Fatalf("get item: %v", err)
+	}
+	if item.Title != "Ny Dansk Titel" {
+		t.Errorf("title = %q, want base row rewritten to %q", item.Title, "Ny Dansk Titel")
+	}
+	if item.Overview != "Dansk oversigt" {
+		t.Errorf("overview = %q, want base row rewritten", item.Overview)
+	}
+	if item.DefaultMetadataLanguage != "da" {
+		t.Errorf("default_metadata_language = %q, want restamped to da", item.DefaultMetadataLanguage)
+	}
+}
+
+// TestProcess_WithoutAdoptLanguageKeepsCanonicalPin pins the pre-existing
+// behavior: a refresh in a non-canonical language without AdoptLanguage must
+// NOT rewrite the base row or restamp the item (the fetch routes to the
+// localization tables instead).
+func TestProcess_WithoutAdoptLanguageKeepsCanonicalPin(t *testing.T) {
+	h := newTestHarness()
+	ctx := context.Background()
+	seedRelanguageItem(t, h)
+
+	provider := &capturingMetadataProvider{
+		response: &MetadataResult{
+			HasMetadata: true,
+			Title:       "Ny Dansk Titel",
+			Overview:    "Dansk oversigt",
+			ProviderIDs: map[string]string{"tmdb": "42"},
+		},
+	}
+
+	result, err := h.service.ProcessWithProviders(ctx, ProcessRequest{
+		ContentID: "existing-1",
+		Language:  "da",
+		Mode:      ModeManualRefresh,
+	}, []Provider{provider})
+	if err != nil {
+		t.Fatalf("ProcessWithProviders: %v", err)
+	}
+	if result == nil || !result.Updated {
+		t.Fatalf("result = %#v, want Updated=true", result)
+	}
+
+	item, err := h.itemRepo.GetByID(ctx, "existing-1")
+	if err != nil {
+		t.Fatalf("get item: %v", err)
+	}
+	if item.Title != "Gammel Kinesisk Titel" {
+		t.Errorf("title = %q, want base row untouched", item.Title)
+	}
+	if item.DefaultMetadataLanguage != "zh" {
+		t.Errorf("default_metadata_language = %q, want zh (unchanged)", item.DefaultMetadataLanguage)
+	}
+}
+
+// TestAdoptableFolderLanguage covers the decision for when a folder-scoped
+// refresh should adopt the folder's language as the item's new canonical
+// language (issue #211). Only manual-refresh passes adopt: scheduled
+// refreshes merge fill-empty, which would restamp the language without
+// rewriting the text.
+func TestAdoptableFolderLanguage(t *testing.T) {
+	cases := []struct {
+		name     string
+		mode     RefreshMode
+		stamp    string
+		language string
+		want     bool
+	}{
+		{"manual refresh with mismatch adopts", ModeManualRefresh, "zh", "da", true},
+		{"manual refresh case-insensitive match does not adopt", ModeManualRefresh, "DA", "da", false},
+		{"scheduled refresh never adopts", ModeScheduledRefresh, "zh", "da", false},
+		{"identify never adopts", ModeIdentify, "zh", "da", false},
+		{"initial match never adopts", ModeInitialMatch, "zh", "da", false},
+		{"unstamped item does not adopt", ModeManualRefresh, "", "da", false},
+		{"empty target language does not adopt", ModeManualRefresh, "zh", "", false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := adoptableFolderLanguage(tc.mode, tc.stamp, tc.language); got != tc.want {
+				t.Fatalf("adoptableFolderLanguage(%v, %q, %q) = %v, want %v", tc.mode, tc.stamp, tc.language, got, tc.want)
+			}
+		})
+	}
+}

--- a/internal/metadata/relanguage_test.go
+++ b/internal/metadata/relanguage_test.go
@@ -2,13 +2,18 @@ package metadata
 
 import (
 	"context"
+	"fmt"
 	"testing"
 
 	"github.com/Silo-Server/silo-server/internal/models"
 )
 
-func seedRelanguageItem(t *testing.T, h *testHarness) {
+func seedRelanguageItem(t *testing.T, h *testHarness, lockedFields ...MetadataField) {
 	t.Helper()
+	locked := make([]int, 0, len(lockedFields))
+	for _, field := range lockedFields {
+		locked = append(locked, int(field))
+	}
 	if err := h.itemRepo.Upsert(context.Background(), &models.MediaItem{
 		ContentID:               "existing-1",
 		Type:                    "movie",
@@ -17,12 +22,24 @@ func seedRelanguageItem(t *testing.T, h *testHarness) {
 		Year:                    2020,
 		Status:                  "matched",
 		DefaultMetadataLanguage: "zh",
+		LockedFields:            locked,
 		Studios:                 []string{},
 		Networks:                []string{},
 		Countries:               []string{},
 		Genres:                  []string{},
 	}); err != nil {
 		t.Fatalf("upsert existing item: %v", err)
+	}
+}
+
+func newRelanguageProvider() *capturingMetadataProvider {
+	return &capturingMetadataProvider{
+		response: &MetadataResult{
+			HasMetadata: true,
+			Title:       "Ny Dansk Titel",
+			Overview:    "Dansk oversigt",
+			ProviderIDs: map[string]string{"tmdb": "42"},
+		},
 	}
 }
 
@@ -36,14 +53,7 @@ func TestProcess_AdoptLanguageRewritesBaseRowAndRestamps(t *testing.T) {
 	ctx := context.Background()
 	seedRelanguageItem(t, h)
 
-	provider := &capturingMetadataProvider{
-		response: &MetadataResult{
-			HasMetadata: true,
-			Title:       "Ny Dansk Titel",
-			Overview:    "Dansk oversigt",
-			ProviderIDs: map[string]string{"tmdb": "42"},
-		},
-	}
+	provider := newRelanguageProvider()
 
 	result, err := h.service.ProcessWithProviders(ctx, ProcessRequest{
 		ContentID:     "existing-1",
@@ -82,14 +92,7 @@ func TestProcess_WithoutAdoptLanguageKeepsCanonicalPin(t *testing.T) {
 	ctx := context.Background()
 	seedRelanguageItem(t, h)
 
-	provider := &capturingMetadataProvider{
-		response: &MetadataResult{
-			HasMetadata: true,
-			Title:       "Ny Dansk Titel",
-			Overview:    "Dansk oversigt",
-			ProviderIDs: map[string]string{"tmdb": "42"},
-		},
-	}
+	provider := newRelanguageProvider()
 
 	result, err := h.service.ProcessWithProviders(ctx, ProcessRequest{
 		ContentID: "existing-1",
@@ -140,6 +143,115 @@ func TestAdoptableFolderLanguage(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			if got := adoptableFolderLanguage(tc.mode, tc.stamp, tc.language); got != tc.want {
 				t.Fatalf("adoptableFolderLanguage(%v, %q, %q) = %v, want %v", tc.mode, tc.stamp, tc.language, got, tc.want)
+			}
+		})
+	}
+}
+
+// TestProcess_AdoptLanguageSkippedWhenBothLanguageFieldsLocked: when both
+// language-bearing fields (title, overview) are locked, adoption must not
+// restamp default_metadata_language — nothing would actually be rewritten,
+// so the restamp would permanently mislabel the old-language text and the
+// quick-refresh language-mismatch predicate would never flag the item again.
+// The refresh behaves like a non-adopting refresh in that language instead.
+func TestProcess_AdoptLanguageSkippedWhenBothLanguageFieldsLocked(t *testing.T) {
+	h := newTestHarness()
+	ctx := context.Background()
+	seedRelanguageItem(t, h, FieldName, FieldOverview)
+
+	result, err := h.service.ProcessWithProviders(ctx, ProcessRequest{
+		ContentID:     "existing-1",
+		Language:      "da",
+		Mode:          ModeManualRefresh,
+		AdoptLanguage: true,
+	}, []Provider{newRelanguageProvider()})
+	if err != nil {
+		t.Fatalf("ProcessWithProviders: %v", err)
+	}
+	if result == nil || !result.Updated {
+		t.Fatalf("result = %#v, want Updated=true", result)
+	}
+
+	item, err := h.itemRepo.GetByID(ctx, "existing-1")
+	if err != nil {
+		t.Fatalf("get item: %v", err)
+	}
+	if item.Title != "Gammel Kinesisk Titel" {
+		t.Errorf("title = %q, want locked title untouched", item.Title)
+	}
+	if item.Overview != "Old-language overview" {
+		t.Errorf("overview = %q, want locked overview untouched", item.Overview)
+	}
+	if item.DefaultMetadataLanguage != "zh" {
+		t.Errorf("default_metadata_language = %q, want zh (stamp kept when both language fields are locked)",
+			item.DefaultMetadataLanguage)
+	}
+}
+
+// TestProcess_AdoptLanguageWithOnlyTitleLocked: a single locked language
+// field does not block adoption — the unlocked field is rewritten in the new
+// language and the stamp is adopted, while the locked field keeps its text.
+func TestProcess_AdoptLanguageWithOnlyTitleLocked(t *testing.T) {
+	h := newTestHarness()
+	ctx := context.Background()
+	seedRelanguageItem(t, h, FieldName)
+
+	result, err := h.service.ProcessWithProviders(ctx, ProcessRequest{
+		ContentID:     "existing-1",
+		Language:      "da",
+		Mode:          ModeManualRefresh,
+		AdoptLanguage: true,
+	}, []Provider{newRelanguageProvider()})
+	if err != nil {
+		t.Fatalf("ProcessWithProviders: %v", err)
+	}
+	if result == nil || !result.Updated {
+		t.Fatalf("result = %#v, want Updated=true", result)
+	}
+
+	item, err := h.itemRepo.GetByID(ctx, "existing-1")
+	if err != nil {
+		t.Fatalf("get item: %v", err)
+	}
+	if item.Title != "Gammel Kinesisk Titel" {
+		t.Errorf("title = %q, want locked title untouched", item.Title)
+	}
+	if item.Overview != "Dansk oversigt" {
+		t.Errorf("overview = %q, want base row rewritten", item.Overview)
+	}
+	if item.DefaultMetadataLanguage != "da" {
+		t.Errorf("default_metadata_language = %q, want restamped to da (only one field locked)",
+			item.DefaultMetadataLanguage)
+	}
+}
+
+// TestItemLibrariesAgreeOnLanguage covers the multi-library adoption gate: an
+// item that lives in several libraries (media_item_libraries) must only adopt
+// a language every containing library agrees on — otherwise libraries with
+// different languages would rewrite the canonical base row back and forth on
+// every refresh.
+func TestItemLibrariesAgreeOnLanguage(t *testing.T) {
+	ctx := context.Background()
+	cases := []struct {
+		name      string
+		languages []string
+		lookupErr error
+		target    string
+		want      bool
+	}{
+		{"single library matching target agrees", []string{"da"}, nil, "da", true},
+		{"case-insensitive match agrees", []string{"DA"}, nil, "da", true},
+		{"disagreeing libraries block adoption", []string{"da", "en"}, nil, "da", false},
+		{"single library with other language blocks adoption", []string{"de"}, nil, "da", false},
+		{"no membership rows cannot disagree", nil, nil, "da", true},
+		{"lookup failure blocks adoption", nil, fmt.Errorf("boom"), "da", false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			h := newTestHarness()
+			h.libraryRepo.setMetadataLanguages("existing-1", tc.languages, tc.lookupErr)
+			if got := h.service.itemLibrariesAgreeOnLanguage(ctx, "existing-1", tc.target); got != tc.want {
+				t.Fatalf("itemLibrariesAgreeOnLanguage(%v, %q) = %v, want %v", tc.languages, tc.target, got, tc.want)
 			}
 		})
 	}

--- a/internal/metadata/service.go
+++ b/internal/metadata/service.go
@@ -523,11 +523,14 @@ func (s *MetadataService) Process(ctx context.Context, req ProcessRequest) (*Pro
 	// language instead of the fetch being shunted into localization tables
 	// forever (issue #211). Adoption is decided here (not in mergeAndPersist)
 	// so identify/initial-match and multi-language item-scoped refreshes are
-	// never affected.
+	// never affected. Adoption also requires every library containing the item
+	// to agree on the target language — otherwise two libraries with different
+	// languages would flip the canonical row back and forth on each refresh.
 	adoptTarget := ""
 	if folderID > 0 && req.ContentID != "" && len(languages) == 1 && s.itemRepo != nil {
 		if item, err := s.itemRepo.GetByID(ctx, req.ContentID); err == nil && item != nil {
-			if adoptableFolderLanguage(req.Mode, item.DefaultMetadataLanguage, languages[0]) {
+			if adoptableFolderLanguage(req.Mode, item.DefaultMetadataLanguage, languages[0]) &&
+				s.itemLibrariesAgreeOnLanguage(ctx, req.ContentID, languages[0]) {
 				adoptTarget = languages[0]
 			}
 		}
@@ -598,6 +601,33 @@ func adoptableFolderLanguage(mode RefreshMode, stampedLanguage, folderLanguage s
 	stamp := strings.TrimSpace(stampedLanguage)
 	target := strings.TrimSpace(folderLanguage)
 	return stamp != "" && target != "" && !strings.EqualFold(stamp, target)
+}
+
+// itemLibrariesAgreeOnLanguage reports whether every library containing the
+// item resolves to the same effective metadata language as target. An item can
+// live in several libraries (media_item_libraries); adopting the requesting
+// library's language while another library is configured differently would
+// rewrite the canonical base row to whichever library refreshed last, forever.
+// Disagreement (or a lookup failure) skips adoption — a stable stamp beats
+// flip-flopping. Unset library languages count as "en", the same default
+// resolveFolderLanguage applies, so both sides of the comparison use the same
+// effective-language rules.
+func (s *MetadataService) itemLibrariesAgreeOnLanguage(ctx context.Context, contentID, target string) bool {
+	if s.libraryRepo == nil {
+		return false
+	}
+	languages, err := s.libraryRepo.GetDistinctMetadataLanguagesForItem(ctx, contentID)
+	if err != nil {
+		slog.Warn("metadata: failed to look up library languages for adoption gate; keeping current stamp",
+			"content_id", contentID, "error", err)
+		return false
+	}
+	for _, language := range languages {
+		if !strings.EqualFold(strings.TrimSpace(language), strings.TrimSpace(target)) {
+			return false
+		}
+	}
+	return true
 }
 
 func parseProcessFolderID(raw string) int {
@@ -1483,8 +1513,21 @@ func (s *MetadataService) mergeAndPersist(
 		}
 	}
 
+	// Adoption restamps default_metadata_language to req.Language while the
+	// merge below rewrites the language-bearing text (title, overview). Field
+	// locks win over adoption: if BOTH are locked, nothing would actually be
+	// rewritten, and restamping would permanently mislabel the old-language
+	// text as the new language (the quick-refresh mismatch predicate would
+	// never flag the item again). Fall back to the non-adopting behavior in
+	// that case — keep the existing stamp and let the fetch route to the
+	// localization tables like any other non-canonical refresh.
+	adoptLanguage := req.AdoptLanguage
+	if adoptLanguage && isFieldLocked(locked, FieldName) && isFieldLocked(locked, FieldOverview) {
+		adoptLanguage = false
+	}
+
 	canonicalLanguage := strings.TrimSpace(req.Language)
-	if !req.AdoptLanguage && existingItem != nil && strings.TrimSpace(existingItem.DefaultMetadataLanguage) != "" {
+	if !adoptLanguage && existingItem != nil && strings.TrimSpace(existingItem.DefaultMetadataLanguage) != "" {
 		canonicalLanguage = strings.TrimSpace(existingItem.DefaultMetadataLanguage)
 	}
 	if canonicalLanguage == "" {

--- a/internal/metadata/service.go
+++ b/internal/metadata/service.go
@@ -517,10 +517,27 @@ func (s *MetadataService) Process(ctx context.Context, req ProcessRequest) (*Pro
 		return chain, nil
 	}
 
+	// A folder-scoped manual refresh resolves exactly one language — the
+	// library's setting. When that differs from the item's stamped canonical
+	// language, adopt it so the base row is re-fetched in the library's
+	// language instead of the fetch being shunted into localization tables
+	// forever (issue #211). Adoption is decided here (not in mergeAndPersist)
+	// so identify/initial-match and multi-language item-scoped refreshes are
+	// never affected.
+	adoptTarget := ""
+	if folderID > 0 && req.ContentID != "" && len(languages) == 1 && s.itemRepo != nil {
+		if item, err := s.itemRepo.GetByID(ctx, req.ContentID); err == nil && item != nil {
+			if adoptableFolderLanguage(req.Mode, item.DefaultMetadataLanguage, languages[0]) {
+				adoptTarget = languages[0]
+			}
+		}
+	}
+
 	var final ProcessResult
 	for _, language := range languages {
 		langReq := req
 		langReq.Language = language
+		langReq.AdoptLanguage = adoptTarget != "" && strings.EqualFold(language, adoptTarget)
 		result, err := s.processInternal(ctx, langReq, resolveChain)
 		if err != nil {
 			return nil, err
@@ -566,6 +583,21 @@ func (s *MetadataService) maybeAutoTranslate(ctx context.Context, folderID int, 
 		return
 	}
 	go s.autoTranslator.AutoEnqueue(context.WithoutCancel(ctx), contentID, library)
+}
+
+// adoptableFolderLanguage reports whether a folder-scoped refresh should
+// adopt the folder's language as the item's new canonical metadata language.
+// Only manual refreshes adopt: their MergeReplaceUnlocked policy actually
+// rewrites title/overview, whereas a scheduled refresh merges fill-empty and
+// would restamp the language without replacing the text — mislabeling the
+// base row.
+func adoptableFolderLanguage(mode RefreshMode, stampedLanguage, folderLanguage string) bool {
+	if mode != ModeManualRefresh {
+		return false
+	}
+	stamp := strings.TrimSpace(stampedLanguage)
+	target := strings.TrimSpace(folderLanguage)
+	return stamp != "" && target != "" && !strings.EqualFold(stamp, target)
 }
 
 func parseProcessFolderID(raw string) int {
@@ -1452,7 +1484,7 @@ func (s *MetadataService) mergeAndPersist(
 	}
 
 	canonicalLanguage := strings.TrimSpace(req.Language)
-	if existingItem != nil && strings.TrimSpace(existingItem.DefaultMetadataLanguage) != "" {
+	if !req.AdoptLanguage && existingItem != nil && strings.TrimSpace(existingItem.DefaultMetadataLanguage) != "" {
 		canonicalLanguage = strings.TrimSpace(existingItem.DefaultMetadataLanguage)
 	}
 	if canonicalLanguage == "" {

--- a/internal/metadata/service_test.go
+++ b/internal/metadata/service_test.go
@@ -626,12 +626,31 @@ func (r *fakeFileRepo) GetUnmatchedByFolderAndPathPrefix(_ context.Context, _ in
 
 // fakeLibraryRepo implements metadataLibraryRepo.
 type fakeLibraryRepo struct {
-	mu          sync.Mutex
-	memberships map[string]time.Time // "contentID:folderID" -> first_seen_at
+	mu           sync.Mutex
+	memberships  map[string]time.Time // "contentID:folderID" -> first_seen_at
+	languages    map[string][]string  // contentID -> distinct metadata languages override
+	languagesErr map[string]error     // contentID -> forced lookup error
 }
 
 func newFakeLibraryRepo() *fakeLibraryRepo {
-	return &fakeLibraryRepo{memberships: make(map[string]time.Time)}
+	return &fakeLibraryRepo{
+		memberships:  make(map[string]time.Time),
+		languages:    make(map[string][]string),
+		languagesErr: make(map[string]error),
+	}
+}
+
+// setMetadataLanguages overrides GetDistinctMetadataLanguagesForItem for one
+// item, optionally forcing a lookup error.
+func (r *fakeLibraryRepo) setMetadataLanguages(contentID string, languages []string, err error) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.languages[contentID] = languages
+	if err != nil {
+		r.languagesErr[contentID] = err
+	} else {
+		delete(r.languagesErr, contentID)
+	}
 }
 
 func (r *fakeLibraryRepo) Upsert(_ context.Context, contentID string, folderID int, firstSeenAt time.Time) error {
@@ -671,6 +690,16 @@ func (r *fakeLibraryRepo) GetFolderIDsForItem(_ context.Context, contentID strin
 }
 
 func (r *fakeLibraryRepo) GetDistinctMetadataLanguagesForItem(ctx context.Context, contentID string) ([]string, error) {
+	r.mu.Lock()
+	forcedErr := r.languagesErr[contentID]
+	override, hasOverride := r.languages[contentID]
+	r.mu.Unlock()
+	if forcedErr != nil {
+		return nil, forcedErr
+	}
+	if hasOverride {
+		return override, nil
+	}
 	folderIDs, err := r.GetFolderIDsForItem(ctx, contentID)
 	if err != nil {
 		return nil, err

--- a/internal/metadata/types.go
+++ b/internal/metadata/types.go
@@ -59,6 +59,14 @@ type ProcessRequest struct {
 	FolderID    string            // Which library folder
 	Language    string            // ISO 639-1 metadata language (resolved from folder)
 	Mode        RefreshMode
+	// AdoptLanguage makes Language the item's new canonical metadata
+	// language: the base row is rewritten in Language and
+	// default_metadata_language is restamped, instead of routing a
+	// non-canonical language to the localization tables. Set by
+	// folder-scoped manual refreshes when the library's configured
+	// language differs from the item's stamp, so changing a library's
+	// metadata language actually re-fetches titles/overviews.
+	AdoptLanguage bool
 }
 
 // ProcessResult is the output of MetadataService.Process().


### PR DESCRIPTION
## Problem

An item's `default_metadata_language` was stamped once at first match and never updated. Changing a library's metadata language did nothing for existing items: the canonical-language pin in `mergeAndPersist` routed any refresh in a different language into the localization side-tables, the upserts' `COALESCE` kept the old stamp forever, quick-mode library refresh skipped complete items entirely, and `HandleUpdateLibrary` triggered nothing on a language change. Items stayed in the old language no matter how often the admin refreshed or re-matched (#211).

## Approach — four coupled changes

1. **Trigger**: `HandleUpdateLibrary` enqueues a quick library metadata refresh when the metadata language changes (mirrors the existing paths-change rescan trigger; conflict with an already-queued refresh is tolerated).
2. **Lister**: quick-mode refresh includes complete items whose stamped language differs from the library's configured language — previously they were never revisited.
3. **Adoption**: a folder-scoped **manual** refresh whose resolved library language differs from the item's stamp sets `ProcessRequest.AdoptLanguage`; `mergeAndPersist` then treats the library language as the new canonical — base-row title/overview are rewritten and the item restamped — instead of shunting the fetch into localization tables. Gated to `ModeManualRefresh` only: scheduled refreshes merge fill-empty and would restamp the language without rewriting the text.
4. **SQL pins**: the five `COALESCE` clauses that made `default_metadata_language` write-once (media_items, seasons ×2, episodes ×2) now prefer the incoming non-empty value. Every existing caller sends the unchanged stamp or an empty string, so behavior is unchanged outside adoption — and the restamp is atomic with the successful canonical write (no mislabeled rows if a provider fetch fails mid-refresh).

Viewers preferring the old language still get localized text via the existing `LocalizeItemModel` overlay; the base row simply follows the library setting — which is what the setting claims to mean.

## Testing

- Unit tests on the canonical pin (adopt rewrites+restamps; without the flag the old pin behavior is preserved) and the adoption decision table.
- DB-backed tests (`SILO_TEST_DATABASE_URL`) proving the upsert restamp semantics on all three tables and the quick-lister language-mismatch predicate.
- Handler test proving the language-change trigger fires exactly once (and not on rename or same-language updates).
- **Live-validated** on a production deployment: one-movie test library flipped en→da→de→en — each flip auto-enqueued the refresh job and restamped the item (`default_metadata_language` followed each change; this exact flow was a no-op before the fix).

## Risks / notes

- An item shared by two libraries with different languages will follow whichever library was refreshed last (previously it was pinned to first-match language forever). Deemed acceptable: the localization overlay still serves per-viewer languages.
- `ProcessRequest` gains a field — additive, internal type.

Fixes #211

## AI-use disclosure

Implemented with Claude Code (test-first, live-validated); human-reviewed before submission.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Library updates can now trigger a quick metadata refresh when the library language changes.
  * Manual folder refreshes can now adopt the folder’s language as the item’s main language for cleaner updates.

* **Bug Fixes**
  * Quick refresh now includes items whose stored language differs from the folder language.
  * Language values are now preserved more consistently during item, season, and episode updates, avoiding unexpected resets.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->