### PR TITLE
fix(web): show Resume Reading on the manga CTA when the target volume is in progress

### DIFF
--- a/web/src/pages/ItemDetail/MangaContent.test.tsx
+++ b/web/src/pages/ItemDetail/MangaContent.test.tsx
@@ -164,6 +164,32 @@ describe("MangaContent", () => {
     expect(cta).toHaveAttribute("href", "/reader/ebook/v02?libraryId=7" + seriesBackTo);
   });
 
+  // Regression test for issue #188: partial progress on the resume target
+  // must surface as "Resume Reading", not "Start Reading".
+  it("shows a Resume Reading hero CTA when the target volume is partially read", () => {
+    render(
+      <MemoryRouter>
+        <MangaContent
+          item={mangaItem([
+            {
+              content_id: "v01",
+              title: "Railgun v01",
+              chapter_index: 1,
+              volume: "v01",
+              progress: 0.18,
+            },
+            { content_id: "v02", title: "Railgun v02", chapter_index: 2, volume: "v02" },
+          ])}
+          libraryId={7}
+        />
+      </MemoryRouter>,
+    );
+
+    const cta = screen.getByRole("link", { name: /Resume Reading/i });
+    expect(cta).toHaveTextContent("Volume 1");
+    expect(cta).toHaveAttribute("href", "/reader/ebook/v01?libraryId=7" + seriesBackTo);
+  });
+
   it("offers a Read Again CTA from the start once every chapter is read", () => {
     render(
       <MemoryRouter>

--- a/web/src/pages/ItemDetail/MangaContent.tsx
+++ b/web/src/pages/ItemDetail/MangaContent.tsx
@@ -271,8 +271,12 @@ export default function MangaContent({
   const anyRead = chapterRows.some((chapter) => chapter.read === true);
   const resume = useMemo(() => firstUnreadChapter(entries), [entries]);
   const fallbackStart = entries.length > 0 ? flattenFirst(entries) : null;
+  const resumeInProgress = (resume?.chapter.progress ?? 0) > 0;
   const cta = resume
-    ? { ...resume, verb: anyRead ? "Continue" : "Start Reading" }
+    ? {
+        ...resume,
+        verb: resumeInProgress ? "Resume Reading" : anyRead ? "Continue" : "Start Reading",
+      }
     : fallbackStart
       ? { ...fallbackStart, verb: "Read Again" }
       : null;


### PR DESCRIPTION
## Problem

On a manga/ebook series detail page, the primary action button ignored saved reading progress: a volume at 18% still showed **Start Reading Volume 1**, contradicting the progress indicator rendered on the same page.

## Approach

The CTA verb only inspected `chapter.read` (finished chapters). The `MangaChapter.progress` fraction the API already returns now takes precedence: when the resume target has `progress > 0` the button reads **Resume Reading**; unread series keep **Start Reading**, mid-series targets keep **Continue**, fully-read series keep **Read Again**.

## Testing

New regression test (partial-progress volume → "Resume Reading Volume 1" with the same reader href); full MangaContent suite passes (13/13), `pnpm run lint` + `format:check` clean.

Fixes #188

## AI-use disclosure

Implemented with Claude Code (test-first); human-reviewed before submission.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the reading CTA on manga detail pages so it now shows the correct action for partially read volumes.
  * The CTA now links users back to the right ebook reader page, preserving the series context and return path.
  * Added coverage to prevent regressions in the reading resume flow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->