### PR TITLE
fix(web): exit the reader through history so back doesn't re-open it

### DIFF
--- a/web/src/components/PageBack.tsx
+++ b/web/src/components/PageBack.tsx
@@ -1,6 +1,8 @@
 import { ChevronLeft } from "lucide-react";
 import { type To, useNavigate } from "react-router";
 
+import { hasRouterHistory } from "@/lib/backNavigation";
+
 interface PageBackProps {
   label?: string;
   to?: To;
@@ -25,9 +27,7 @@ export default function PageBack({
     : "absolute top-4 left-2 sm:top-6";
 
   function goBack() {
-    const historyIndex = window.history.state?.idx;
-
-    if (preferHistory && typeof historyIndex === "number" && historyIndex > 0) {
+    if (preferHistory && hasRouterHistory()) {
       navigate(-1);
       return;
     }

--- a/web/src/lib/backNavigation.ts
+++ b/web/src/lib/backNavigation.ts
@@ -1,0 +1,8 @@
+// hasRouterHistory reports whether the current entry has in-app router
+// history behind it, i.e. navigate(-1) stays inside the app. React Router
+// stamps its entry index on window.history.state.idx; the first in-app entry
+// has idx 0.
+export function hasRouterHistory(): boolean {
+  const historyIndex = (window.history.state as { idx?: unknown } | null)?.idx;
+  return typeof historyIndex === "number" && historyIndex > 0;
+}

--- a/web/src/pages/EbookReader.test.tsx
+++ b/web/src/pages/EbookReader.test.tsx
@@ -387,9 +387,7 @@ describe("EbookReader", () => {
     const backTo = encodeURIComponent("/item/manga-series-1?libraryId=7");
     await act(async () => {
       root.render(
-        <MemoryRouter
-          initialEntries={[`/reader/ebook/ebook-1?libraryId=7&backTo=${backTo}`]}
-        >
+        <MemoryRouter initialEntries={[`/reader/ebook/ebook-1?libraryId=7&backTo=${backTo}`]}>
           <Routes>
             <Route
               path="/item/:contentId"

--- a/web/src/pages/EbookReader.test.tsx
+++ b/web/src/pages/EbookReader.test.tsx
@@ -12,6 +12,7 @@ const mocks = vi.hoisted(() => ({
   useCatalogItemDetail: vi.fn(),
   readerPrev: vi.fn(),
   readerNext: vi.fn(),
+  readerProgress: 0.421,
   readerGoTo: vi.fn(),
   readerGoToFraction: vi.fn(),
   readerSearch: vi.fn(),
@@ -100,7 +101,7 @@ vi.mock("@/reader/FoliateBookReader", async () => {
       }));
       useEffect(() => {
         onFileLoaded?.({ objectUrl: "blob:ebook", filename: "Reader.epub" });
-        onProgressChange?.(0.421);
+        onProgressChange?.(mocks.readerProgress);
         onSelectionChange?.({
           cfi: "epubcfi(/6/4,/1:0,/1:12)",
           selectedText: "sample text",
@@ -234,6 +235,7 @@ describe("EbookReader", () => {
     mocks.useCatalogItemDetail.mockReset();
     mocks.readerPrev.mockReset();
     mocks.readerNext.mockReset();
+    mocks.readerProgress = 0.421;
     mocks.readerGoTo.mockReset();
     mocks.readerGoToFraction.mockReset();
     mocks.readerSearch.mockReset();
@@ -370,6 +372,82 @@ describe("EbookReader", () => {
     expect(container.querySelector('[data-testid="origin-page"]')).not.toBeNull();
     expect(container.querySelector('[data-testid="pushed-series-page"]')).toBeNull();
   });
+
+  it.each([
+    ["header", 0.421, 0, 1],
+    ["end-of-book", 1, 1, 2],
+  ] as const)(
+    "replaces reader history when advancing with the %s Next control",
+    async (_control, progress, linkIndex, expectedLinkCount) => {
+      mocks.readerProgress = progress;
+      mocks.useCatalogItemDetail.mockImplementation((requestedContentID?: string) => {
+        if (requestedContentID === "manga-series-1") {
+          return {
+            data: {
+              ...makeEbookItem(),
+              content_id: "manga-series-1",
+              type: "manga",
+              title: "Manga Series",
+              manga: {
+                chapters: [
+                  { content_id: "chapter-1", title: "Chapter 1", chapter_index: 1 },
+                  { content_id: "chapter-2", title: "Chapter 2", chapter_index: 2 },
+                ],
+              },
+            } as ItemDetail,
+            isLoading: false,
+            error: null,
+          };
+        }
+        return {
+          data: makeEbookItem({
+            content_id: requestedContentID ?? "chapter-1",
+            series_id: "manga-series-1",
+          }),
+          isLoading: false,
+          error: null,
+        };
+      });
+      window.history.replaceState({ idx: 1 }, "");
+      const backTo = encodeURIComponent("/item/manga-series-1?libraryId=7");
+
+      await act(async () => {
+        root.render(
+          <MemoryRouter
+            initialEntries={[
+              "/item/manga-series-1?libraryId=7",
+              `/reader/ebook/chapter-1?libraryId=7&backTo=${backTo}`,
+            ]}
+            initialIndex={1}
+          >
+            <Routes>
+              <Route path="/item/:contentId" element={<div data-testid="series-page" />} />
+              <Route path="/reader/ebook/:contentId" element={<EbookReader />} />
+            </Routes>
+          </MemoryRouter>,
+        );
+      });
+
+      const nextLinks = container.querySelectorAll<HTMLAnchorElement>(
+        'a[href^="/reader/ebook/chapter-2"]',
+      );
+      expect(nextLinks).toHaveLength(expectedLinkCount);
+      await act(async () => {
+        nextLinks[linkIndex]?.dispatchEvent(
+          new MouseEvent("click", { bubbles: true, cancelable: true }),
+        );
+      });
+
+      const back = container.querySelector<HTMLAnchorElement>('a[aria-label="Back"]');
+      expect(back).not.toBeNull();
+      await act(async () => {
+        back?.dispatchEvent(new MouseEvent("click", { bubbles: true, cancelable: true }));
+      });
+
+      expect(container.querySelector('[data-testid="series-page"]')).not.toBeNull();
+      expect(container.textContent).not.toContain("reader surface");
+    },
+  );
 
   it("switches between multiple ebook files from the reader header", async () => {
     mocks.useCatalogItemDetail.mockReturnValue({

--- a/web/src/pages/EbookReader.test.tsx
+++ b/web/src/pages/EbookReader.test.tsx
@@ -271,6 +271,7 @@ describe("EbookReader", () => {
 
   afterEach(async () => {
     vi.useRealTimers();
+    window.history.replaceState(null, "");
     await act(async () => {
       root.unmount();
     });
@@ -335,6 +336,39 @@ describe("EbookReader", () => {
     // backTo wins over the default chapter-detail target, breaking the loop.
     expect(container.innerHTML).toContain('href="/item/manga-series-1?libraryId=7"');
     expect(container.innerHTML).not.toContain('href="/item/ebook-1?libraryId=7"');
+  });
+
+  // Regression test for issue #189: exiting the reader must consume the
+  // reader's history entry (history back) rather than pushing the series page
+  // on top of it — otherwise pressing back on the series page re-opens the
+  // reader. With in-app history present, clicking Back returns to the entry
+  // the reader was opened from, not to a fresh push of the backTo target.
+  it("goes back through history on Back instead of pushing the backTo target", async () => {
+    window.history.replaceState({ idx: 1 }, "");
+    const backTo = encodeURIComponent("/item/manga-series-1?libraryId=7");
+    await act(async () => {
+      root.render(
+        <MemoryRouter
+          initialEntries={["/came-from-here", `/reader/ebook/ebook-1?libraryId=7&backTo=${backTo}`]}
+          initialIndex={1}
+        >
+          <Routes>
+            <Route path="/came-from-here" element={<div data-testid="origin-page" />} />
+            <Route path="/item/:contentId" element={<div data-testid="pushed-series-page" />} />
+            <Route path="/reader/ebook/:contentId" element={<EbookReader />} />
+          </Routes>
+        </MemoryRouter>,
+      );
+    });
+
+    const back = container.querySelector('a[aria-label="Back"], [aria-label="Back"]');
+    expect(back).not.toBeNull();
+    await act(async () => {
+      back!.dispatchEvent(new MouseEvent("click", { bubbles: true, cancelable: true }));
+    });
+
+    expect(container.querySelector('[data-testid="origin-page"]')).not.toBeNull();
+    expect(container.querySelector('[data-testid="pushed-series-page"]')).toBeNull();
   });
 
   it("switches between multiple ebook files from the reader header", async () => {

--- a/web/src/pages/EbookReader.test.tsx
+++ b/web/src/pages/EbookReader.test.tsx
@@ -2,7 +2,7 @@
 
 import { act, useEffect, useImperativeHandle, forwardRef } from "react";
 import { createRoot, type Root } from "react-dom/client";
-import { MemoryRouter, Route, Routes } from "react-router";
+import { MemoryRouter, Route, Routes, useNavigate } from "react-router";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import type { FileVersion, ItemDetail } from "@/api/types";
@@ -219,6 +219,15 @@ function setInputValue(input: HTMLInputElement, value: string) {
   input.dispatchEvent(new Event("input", { bubbles: true }));
 }
 
+function HistoryBackProbe() {
+  const navigate = useNavigate();
+  return (
+    <button type="button" aria-label="Browser back" onClick={() => navigate(-1)}>
+      Browser back
+    </button>
+  );
+}
+
 describe("EbookReader", () => {
   let container: HTMLDivElement;
   let root: Root;
@@ -371,6 +380,47 @@ describe("EbookReader", () => {
 
     expect(container.querySelector('[data-testid="origin-page"]')).not.toBeNull();
     expect(container.querySelector('[data-testid="pushed-series-page"]')).toBeNull();
+  });
+
+  it("replaces a direct reader entry when falling back to the backTo target", async () => {
+    window.history.replaceState({ idx: 0 }, "");
+    const backTo = encodeURIComponent("/item/manga-series-1?libraryId=7");
+    await act(async () => {
+      root.render(
+        <MemoryRouter
+          initialEntries={[`/reader/ebook/ebook-1?libraryId=7&backTo=${backTo}`]}
+        >
+          <Routes>
+            <Route
+              path="/item/:contentId"
+              element={
+                <div data-testid="series-page">
+                  <HistoryBackProbe />
+                </div>
+              }
+            />
+            <Route path="/reader/ebook/:contentId" element={<EbookReader />} />
+          </Routes>
+        </MemoryRouter>,
+      );
+    });
+
+    const back = container.querySelector<HTMLAnchorElement>('a[aria-label="Back"]');
+    expect(back).not.toBeNull();
+    await act(async () => {
+      back?.dispatchEvent(new MouseEvent("click", { bubbles: true, cancelable: true }));
+    });
+    expect(container.querySelector('[data-testid="series-page"]')).not.toBeNull();
+
+    const browserBack = container.querySelector<HTMLButtonElement>(
+      'button[aria-label="Browser back"]',
+    );
+    await act(async () => {
+      browserBack?.click();
+    });
+
+    expect(container.querySelector('[data-testid="series-page"]')).not.toBeNull();
+    expect(container.textContent).not.toContain("reader surface");
   });
 
   it.each([

--- a/web/src/pages/EbookReader.tsx
+++ b/web/src/pages/EbookReader.tsx
@@ -42,6 +42,7 @@ import { Button } from "@/components/ui/button";
 import { useScreenWakeLock } from "@/hooks/useScreenWakeLock";
 import { useTTS } from "@/hooks/useTTS";
 import { useCatalogItemDetail } from "@/hooks/queries/catalogRead";
+import { hasRouterHistory } from "@/lib/backNavigation";
 import { buildItemHref, buildMediaPlayHref } from "@/lib/mediaNavigation";
 import { buildMangaList, flattenMangaList } from "@/lib/mangaChapters";
 import { cn } from "@/lib/utils";
@@ -596,7 +597,29 @@ export default function EbookReader() {
       <header className="border-border/70 bg-background/95 sticky top-0 z-20 border-b backdrop-blur">
         <div className="flex h-14 items-center gap-3 px-4">
           <Button asChild variant="ghost" size="icon" aria-label="Back">
-            <Link to={backHref}>
+            <Link
+              to={backHref}
+              onClick={(event) => {
+                // Exiting the reader must consume the reader's history entry,
+                // not push the target on top of it — otherwise pressing back
+                // on the destination re-opens the reader (issue #189). The
+                // href stays for modified clicks (new tab) and as the
+                // fallback when the reader was opened directly.
+                if (
+                  event.defaultPrevented ||
+                  event.button !== 0 ||
+                  event.metaKey ||
+                  event.ctrlKey ||
+                  event.shiftKey ||
+                  event.altKey ||
+                  !hasRouterHistory()
+                ) {
+                  return;
+                }
+                event.preventDefault();
+                navigate(-1);
+              }}
+            >
               <ArrowLeft className="size-5" />
             </Link>
           </Button>

--- a/web/src/pages/EbookReader.tsx
+++ b/web/src/pages/EbookReader.tsx
@@ -603,21 +603,25 @@ export default function EbookReader() {
                 // Exiting the reader must consume the reader's history entry,
                 // not push the target on top of it — otherwise pressing back
                 // on the destination re-opens the reader (issue #189). The
-                // href stays for modified clicks (new tab) and as the
-                // fallback when the reader was opened directly.
+                // href stays for modified clicks (new tab). A directly opened
+                // reader replaces itself with that target so browser Back
+                // cannot reopen the reader.
                 if (
                   event.defaultPrevented ||
                   event.button !== 0 ||
                   event.metaKey ||
                   event.ctrlKey ||
                   event.shiftKey ||
-                  event.altKey ||
-                  !hasRouterHistory()
+                  event.altKey
                 ) {
                   return;
                 }
                 event.preventDefault();
-                navigate(-1);
+                if (hasRouterHistory()) {
+                  navigate(-1);
+                } else {
+                  navigate(backHref, { replace: true });
+                }
               }}
             >
               <ArrowLeft className="size-5" />

--- a/web/src/pages/EbookReader.tsx
+++ b/web/src/pages/EbookReader.tsx
@@ -635,7 +635,7 @@ export default function EbookReader() {
               className="hidden gap-1 sm:inline-flex"
               title={`Next: ${nextChapter.label}`}
             >
-              <Link to={nextChapterHref}>
+              <Link to={nextChapterHref} replace>
                 <span className="text-muted-foreground max-w-36 truncate text-xs">
                   {nextChapter.label}
                 </span>
@@ -1303,7 +1303,7 @@ export default function EbookReader() {
             size="lg"
             className="h-11 gap-2 rounded-full px-6 text-[15px] font-bold shadow-lg"
           >
-            <Link to={nextChapterHref}>
+            <Link to={nextChapterHref} replace>
               Next: {nextChapter.label}
               <ChevronRight className="size-[18px]" />
             </Link>


### PR DESCRIPTION
## Problem

Exiting the manga/ebook reader to the series page, then pressing back on the series page, re-opened the reader. The reader's header back control was a plain `<Link>` push: history became `[…, series, reader, series]`, so back landed on the reader again — an inescapable loop unless the user force-navigated elsewhere.

## Approach

Plain left-clicks on the reader's back control now consume the reader's history entry (`navigate(-1)`) when in-app history exists, so history returns to wherever the reader was opened from. The `href` is preserved for modified clicks (open in new tab) and remains the fallback when the reader was opened as a direct deep link (no in-app history).

The history-availability predicate is extracted to `lib/backNavigation.ts` and shared with `PageBack`, which already implemented the same pattern — one definition instead of two copies.

## Testing

New regression test: history seeded as `[origin, reader]` with `backTo` pointing at a third URL — clicking Back must land on the origin entry, not a fresh push of `backTo` (fails on the old push behavior). Existing backTo-sanitization tests still pass (the href is unchanged). Full EbookReader + PageBack suites green; `pnpm run lint` + `format:check` clean. (Two unrelated test files fail identically on clean origin/main — pre-existing upstream breakage, verified by stash comparison.)

Fixes #189

## AI-use disclosure

Implemented with Claude Code (test-first); human-reviewed before submission.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved back navigation in the ebook reader when browsing from existing history.
  * Readers without navigation history are now taken to the appropriate fallback page.
  * Next-chapter navigation now returns readers to the series page correctly when navigating back.
  * Preserved standard link behavior for modified clicks and direct navigation.
  * Added regression coverage for reader back navigation and chapter transitions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->