### PR TITLE
feat(notifications): Recently-Added notifications for audiobooks

### DIFF
--- a/internal/api/handlers/admin_server_channels.go
+++ b/internal/api/handlers/admin_server_channels.go
@@ -41,6 +41,7 @@ type serverChannelResponse struct {
 	Enabled                bool       `json:"enabled"`
 	NotifyNewMovies        bool       `json:"notify_new_movies"`
 	NotifyNewEpisodes      bool       `json:"notify_new_episodes"`
+	NotifyNewAudiobooks    bool       `json:"notify_new_audiobooks"`
 	NotifyRequestSubmitted bool       `json:"notify_request_submitted"`
 	NotifyRequestApproved  bool       `json:"notify_request_approved"`
 	NotifyRequestDeclined  bool       `json:"notify_request_declined"`
@@ -65,6 +66,7 @@ func serverChannelToResponse(ch notifications.ServerChannel) serverChannelRespon
 		Enabled:                ch.Enabled,
 		NotifyNewMovies:        ch.NotifyNewMovies,
 		NotifyNewEpisodes:      ch.NotifyNewEpisodes,
+		NotifyNewAudiobooks:    ch.NotifyNewAudiobooks,
 		NotifyRequestSubmitted: ch.NotifyRequestSubmitted,
 		NotifyRequestApproved:  ch.NotifyRequestApproved,
 		NotifyRequestDeclined:  ch.NotifyRequestDeclined,
@@ -86,6 +88,7 @@ type serverChannelRequest struct {
 	Enabled                *bool   `json:"enabled"`
 	NotifyNewMovies        *bool   `json:"notify_new_movies"`
 	NotifyNewEpisodes      *bool   `json:"notify_new_episodes"`
+	NotifyNewAudiobooks    *bool   `json:"notify_new_audiobooks"`
 	NotifyRequestSubmitted *bool   `json:"notify_request_submitted"`
 	NotifyRequestApproved  *bool   `json:"notify_request_approved"`
 	NotifyRequestDeclined  *bool   `json:"notify_request_declined"`
@@ -100,6 +103,7 @@ func (r serverChannelRequest) toInput() notifications.ServerChannelInput {
 		Enabled:                r.Enabled,
 		NotifyNewMovies:        r.NotifyNewMovies,
 		NotifyNewEpisodes:      r.NotifyNewEpisodes,
+		NotifyNewAudiobooks:    r.NotifyNewAudiobooks,
 		NotifyRequestSubmitted: r.NotifyRequestSubmitted,
 		NotifyRequestApproved:  r.NotifyRequestApproved,
 		NotifyRequestDeclined:  r.NotifyRequestDeclined,

--- a/internal/libraryingest/executor.go
+++ b/internal/libraryingest/executor.go
@@ -366,10 +366,11 @@ func (e *Executor) ingest(ctx context.Context, folder *models.MediaFolder, mode 
 	// serialized scan queue.
 	if e.availability != nil {
 		kinds := notifications.AvailabilityKinds{
-			Episodes: isTVLibraryType(folder.Type) || isMixedLibraryType(folder.Type),
-			Movies:   isMovieLibraryType(folder.Type) || isMixedLibraryType(folder.Type),
+			Episodes:   isTVLibraryType(folder.Type) || isMixedLibraryType(folder.Type),
+			Movies:     isMovieLibraryType(folder.Type) || isMixedLibraryType(folder.Type),
+			Audiobooks: isAudiobookLibraryType(folder.Type),
 		}
-		if kinds.Episodes || kinds.Movies {
+		if kinds.Episodes || kinds.Movies || kinds.Audiobooks {
 			go e.availability.HandleIngestCompleted(scanCtx, folder.ID, mode == scopeModeLibrary, matchScopes, kinds)
 		}
 	}
@@ -476,6 +477,17 @@ func isMixedLibraryType(libraryType string) bool {
 func isMovieLibraryType(libraryType string) bool {
 	switch strings.ToLower(strings.TrimSpace(libraryType)) {
 	case "movie", "movies":
+		return true
+	default:
+		return false
+	}
+}
+
+// isAudiobookLibraryType mirrors the scanner's audiobook library naming
+// (internal/scanner/scanner.go).
+func isAudiobookLibraryType(libraryType string) bool {
+	switch strings.ToLower(strings.TrimSpace(libraryType)) {
+	case "audiobook", "audiobooks":
 		return true
 	default:
 		return false

--- a/internal/notifications/audiobook_availability_test.go
+++ b/internal/notifications/audiobook_availability_test.go
@@ -1,0 +1,162 @@
+package notifications
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/jackc/pgx/v5/pgxpool"
+)
+
+func TestWantsContentKindAudiobook(t *testing.T) {
+	ch := ServerChannel{NotifyNewAudiobooks: true}
+	if !ch.WantsContentKind(EventKindAudiobook) {
+		t.Error("channel with NotifyNewAudiobooks must want audiobook events")
+	}
+	ch.NotifyNewAudiobooks = false
+	if ch.WantsContentKind(EventKindAudiobook) {
+		t.Error("channel without NotifyNewAudiobooks must not want audiobook events")
+	}
+}
+
+func TestGroupContentEventsGroupsAudiobooksIndividually(t *testing.T) {
+	events := []ReleaseEvent{
+		{Kind: EventKindAudiobook, LibraryID: 7, ItemID: "book-1"},
+		{Kind: EventKindAudiobook, LibraryID: 7, ItemID: "book-2"},
+		// The same audiobook in a second library announces once, like movies.
+		{Kind: EventKindAudiobook, LibraryID: 8, ItemID: "book-1"},
+	}
+	metas := map[string]ContentMeta{
+		"book-1": {Title: "Project Hail Mary", Year: 2021},
+	}
+
+	groups := GroupContentEvents(events, metas)
+	if len(groups) != 2 {
+		t.Fatalf("groups = %d, want 2 (audiobooks group individually, deduped across libraries)", len(groups))
+	}
+	if groups[0].Kind != EventKindAudiobook || groups[0].ItemID != "book-1" {
+		t.Fatalf("group[0] = %+v, want audiobook book-1", groups[0])
+	}
+	if groups[0].Meta.Title != "Project Hail Mary" {
+		t.Fatalf("group[0] title = %q, want metadata title", groups[0].Meta.Title)
+	}
+	if groups[1].ItemID != "book-2" || groups[1].Meta.Title != "New audiobook" {
+		t.Fatalf("group[1] = %+v, want book-2 with generic fallback title", groups[1])
+	}
+}
+
+func TestAudiobookDiscordContentRendering(t *testing.T) {
+	group := ContentGroup{
+		Kind:      EventKindAudiobook,
+		LibraryID: 7,
+		ItemID:    "book-1",
+		Meta:      ContentMeta{Title: "Project Hail Mary", Year: 2021},
+	}
+	if got := contentGroupTitle(group); got != "Project Hail Mary (2021)" {
+		t.Fatalf("contentGroupTitle = %q, want movie-style title-with-year", got)
+	}
+	body, err := BuildServerChannelDiscordContent([]ContentGroup{group}, false)
+	if err != nil {
+		t.Fatalf("BuildServerChannelDiscordContent: %v", err)
+	}
+	if !strings.Contains(string(body), "New audiobook available on Silo") {
+		t.Fatalf("discord body missing audiobook author line: %s", string(body))
+	}
+}
+
+// TestRecordAudiobookAvailability covers the repository half of issue #270:
+// a full-library pass inserts availability rows for audiobook items, emits
+// release events only when asked (seeded libraries), and re-runs are
+// idempotent.
+func TestRecordAudiobookAvailability(t *testing.T) {
+	dsn := os.Getenv("SILO_TEST_DATABASE_URL")
+	if dsn == "" {
+		t.Skip("SILO_TEST_DATABASE_URL is not set")
+	}
+	ctx := context.Background()
+	pool, err := pgxpool.New(ctx, dsn)
+	if err != nil {
+		t.Fatalf("connect test database: %v", err)
+	}
+	t.Cleanup(pool.Close)
+
+	suffix := time.Now().UnixNano()
+	bookID := fmt.Sprintf("ab-avail-%d", suffix)
+	var folderID int
+	if err := pool.QueryRow(ctx, `
+		INSERT INTO media_folders (type, name, enabled) VALUES ('audiobooks', 'AB Avail Test', true) RETURNING id
+	`).Scan(&folderID); err != nil {
+		t.Fatalf("seed folder: %v", err)
+	}
+	t.Cleanup(func() {
+		_, _ = pool.Exec(ctx, `DELETE FROM release_events WHERE library_id = $1`, folderID)
+		_, _ = pool.Exec(ctx, `DELETE FROM audiobook_availability WHERE library_id = $1`, folderID)
+		_, _ = pool.Exec(ctx, `DELETE FROM media_items WHERE content_id = $1`, bookID)
+		_, _ = pool.Exec(ctx, `DELETE FROM media_folders WHERE id = $1`, folderID)
+	})
+	if _, err := pool.Exec(ctx, `
+		INSERT INTO media_items (content_id, type, title, status, genres)
+		VALUES ($1, 'audiobook', 'AB Avail Book', 'matched', '{}'::text[])
+	`, bookID); err != nil {
+		t.Fatalf("seed audiobook: %v", err)
+	}
+	if _, err := pool.Exec(ctx, `
+		INSERT INTO media_item_libraries (content_id, media_folder_id) VALUES ($1, $2)
+	`, bookID, folderID); err != nil {
+		t.Fatalf("link audiobook: %v", err)
+	}
+
+	repo := NewReleaseRepository(pool)
+
+	// Unseeded pass: rows recorded silently.
+	inserted, events, err := repo.RecordAudiobookAvailabilityForLibrary(ctx, folderID, false)
+	if err != nil {
+		t.Fatalf("RecordAudiobookAvailabilityForLibrary(silent): %v", err)
+	}
+	if inserted != 1 || events != 0 {
+		t.Fatalf("silent pass = (%d inserted, %d events), want (1, 0)", inserted, events)
+	}
+
+	// Second item arrives after seeding: event emitted.
+	book2 := fmt.Sprintf("ab-avail2-%d", suffix)
+	t.Cleanup(func() { _, _ = pool.Exec(ctx, `DELETE FROM media_items WHERE content_id = $1`, book2) })
+	if _, err := pool.Exec(ctx, `
+		INSERT INTO media_items (content_id, type, title, status, genres)
+		VALUES ($1, 'audiobook', 'AB Avail Book 2', 'matched', '{}'::text[])
+	`, book2); err != nil {
+		t.Fatalf("seed audiobook 2: %v", err)
+	}
+	if _, err := pool.Exec(ctx, `
+		INSERT INTO media_item_libraries (content_id, media_folder_id) VALUES ($1, $2)
+	`, book2, folderID); err != nil {
+		t.Fatalf("link audiobook 2: %v", err)
+	}
+	inserted, events, err = repo.RecordAudiobookAvailabilityForLibrary(ctx, folderID, true)
+	if err != nil {
+		t.Fatalf("RecordAudiobookAvailabilityForLibrary(emit): %v", err)
+	}
+	if inserted != 1 || events != 1 {
+		t.Fatalf("emit pass = (%d inserted, %d events), want (1, 1)", inserted, events)
+	}
+	var kind string
+	if err := pool.QueryRow(ctx, `
+		SELECT kind FROM release_events WHERE library_id = $1 AND item_id = $2
+	`, folderID, book2).Scan(&kind); err != nil {
+		t.Fatalf("read release event: %v", err)
+	}
+	if kind != EventKindAudiobook {
+		t.Fatalf("release event kind = %q, want %q", kind, EventKindAudiobook)
+	}
+
+	// Idempotent re-run: nothing new.
+	inserted, events, err = repo.RecordAudiobookAvailabilityForLibrary(ctx, folderID, true)
+	if err != nil {
+		t.Fatalf("RecordAudiobookAvailabilityForLibrary(rerun): %v", err)
+	}
+	if inserted != 0 || events != 0 {
+		t.Fatalf("rerun = (%d inserted, %d events), want (0, 0)", inserted, events)
+	}
+}

--- a/internal/notifications/availability_detector.go
+++ b/internal/notifications/availability_detector.go
@@ -39,8 +39,9 @@ func (d *AvailabilityDetector) SetFanoutNudge(nudge func()) {
 // AvailabilityKinds selects which content kinds an ingest scope covers.
 // Each kind keeps its own seed marker and silent-seeding semantics.
 type AvailabilityKinds struct {
-	Episodes bool
-	Movies   bool
+	Episodes   bool
+	Movies     bool
+	Audiobooks bool
 }
 
 // availabilityKindOps abstracts the per-kind recording calls so episode and
@@ -82,6 +83,13 @@ func (d *AvailabilityDetector) HandleIngestCompleted(ctx context.Context, librar
 			kind:             EventKindMovie,
 			recordForLibrary: d.releases.RecordMovieAvailabilityForLibrary,
 			recordForPaths:   d.releases.RecordMovieAvailabilityForPaths,
+		})
+	}
+	if kinds.Audiobooks {
+		d.runKind(detectCtx, libraryID, fullLibrary, scopePaths, availabilityKindOps{
+			kind:             EventKindAudiobook,
+			recordForLibrary: d.releases.RecordAudiobookAvailabilityForLibrary,
+			recordForPaths:   d.releases.RecordAudiobookAvailabilityForPaths,
 		})
 	}
 }

--- a/internal/notifications/release_repo.go
+++ b/internal/notifications/release_repo.go
@@ -154,7 +154,51 @@ func (r *ReleaseRepository) RecordMovieAvailabilityForLibrary(ctx context.Contex
 		WHERE mil.media_folder_id = $1
 		ON CONFLICT (library_id, item_id) DO NOTHING
 		RETURNING item_id, available_at`
-	return r.recordMovieAvailability(ctx, libraryID, emitEvents, query, []any{libraryID})
+	return r.recordItemAvailability(ctx, libraryID, emitEvents, query, []any{libraryID}, EventKindMovie, MovieDedupeKey)
+}
+
+// RecordAudiobookAvailabilityForLibrary inserts availability rows for every
+// audiobook currently in the library (full-library pass) and optionally
+// creates release events for newly inserted rows (issue #270).
+func (r *ReleaseRepository) RecordAudiobookAvailabilityForLibrary(ctx context.Context, libraryID int, emitEvents bool) (int, int, error) {
+	query := `
+		INSERT INTO audiobook_availability (library_id, item_id)
+		SELECT mil.media_folder_id, mi.content_id
+		FROM media_item_libraries mil
+		JOIN media_items mi ON mi.content_id = mil.content_id AND mi.type = 'audiobook'
+		WHERE mil.media_folder_id = $1
+		ON CONFLICT (library_id, item_id) DO NOTHING
+		RETURNING item_id, available_at`
+	return r.recordItemAvailability(ctx, libraryID, emitEvents, query, []any{libraryID}, EventKindAudiobook, AudiobookDedupeKey)
+}
+
+// RecordAudiobookAvailabilityForPaths inserts availability rows for
+// audiobooks whose files live under the given scope paths (subtree ingest),
+// and optionally creates release events for newly inserted rows.
+func (r *ReleaseRepository) RecordAudiobookAvailabilityForPaths(ctx context.Context, libraryID int, scopePaths []string, emitEvents bool) (int, int, error) {
+	if len(scopePaths) == 0 {
+		return 0, 0, nil
+	}
+	args := []any{libraryID}
+	scopeConds := make([]string, 0, len(scopePaths))
+	for _, path := range scopePaths {
+		args = append(args, path)
+		idx := len(args)
+		scopeConds = append(scopeConds,
+			fmt.Sprintf("(mf.file_path = $%d OR starts_with(mf.file_path, $%d || '/'))", idx, idx))
+	}
+	query := `
+		INSERT INTO audiobook_availability (library_id, item_id)
+		SELECT DISTINCT mf.media_folder_id, mi.content_id
+		FROM media_files mf
+		JOIN media_items mi ON mi.content_id = mf.content_id AND mi.type = 'audiobook'
+		WHERE mf.media_folder_id = $1
+		  AND mf.missing_since IS NULL
+		  AND mf.content_id IS NOT NULL
+		  AND (` + strings.Join(scopeConds, " OR ") + `)
+		ON CONFLICT (library_id, item_id) DO NOTHING
+		RETURNING item_id, available_at`
+	return r.recordItemAvailability(ctx, libraryID, emitEvents, query, args, EventKindAudiobook, AudiobookDedupeKey)
 }
 
 // RecordMovieAvailabilityForPaths inserts availability rows for movies whose
@@ -184,38 +228,39 @@ func (r *ReleaseRepository) RecordMovieAvailabilityForPaths(ctx context.Context,
 		  AND (` + strings.Join(scopeConds, " OR ") + `)
 		ON CONFLICT (library_id, item_id) DO NOTHING
 		RETURNING item_id, available_at`
-	return r.recordMovieAvailability(ctx, libraryID, emitEvents, query, args)
+	return r.recordItemAvailability(ctx, libraryID, emitEvents, query, args, EventKindMovie, MovieDedupeKey)
 }
 
-// recordMovieAvailability is the movie counterpart of recordAvailability: insert
-// availability facts and the optional release events in one transaction.
-func (r *ReleaseRepository) recordMovieAvailability(ctx context.Context, libraryID int, emitEvents bool, query string, args []any) (int, int, error) {
+// recordItemAvailability is the item-level counterpart of recordAvailability
+// (movies, audiobooks): insert availability facts and the optional release
+// events of the given kind in one transaction.
+func (r *ReleaseRepository) recordItemAvailability(ctx context.Context, libraryID int, emitEvents bool, query string, args []any, kind string, dedupeKey func(int, string) string) (int, int, error) {
 	tx, err := r.pool.Begin(ctx)
 	if err != nil {
-		return 0, 0, fmt.Errorf("begin movie availability tx: %w", err)
+		return 0, 0, fmt.Errorf("begin %s availability tx: %w", kind, err)
 	}
 	defer func() { _ = tx.Rollback(ctx) }()
 
 	rows, err := tx.Query(ctx, query, args...)
 	if err != nil {
-		return 0, 0, fmt.Errorf("insert movie availability: %w", err)
+		return 0, 0, fmt.Errorf("insert %s availability: %w", kind, err)
 	}
-	type newMovie struct {
+	type newItem struct {
 		ItemID      string
 		AvailableAt time.Time
 	}
-	inserted := make([]newMovie, 0, 16)
+	inserted := make([]newItem, 0, 16)
 	for rows.Next() {
-		var row newMovie
+		var row newItem
 		if err := rows.Scan(&row.ItemID, &row.AvailableAt); err != nil {
 			rows.Close()
-			return 0, 0, fmt.Errorf("scan inserted movie availability: %w", err)
+			return 0, 0, fmt.Errorf("scan inserted %s availability: %w", kind, err)
 		}
 		inserted = append(inserted, row)
 	}
 	rows.Close()
 	if err := rows.Err(); err != nil {
-		return 0, 0, fmt.Errorf("read inserted movie availability: %w", err)
+		return 0, 0, fmt.Errorf("read inserted %s availability: %w", kind, err)
 	}
 
 	events := 0
@@ -241,23 +286,23 @@ func (r *ReleaseRepository) recordMovieAvailability(ctx context.Context, library
 				eventArgs = append(eventArgs,
 					ulid.Make().String(),
 					libraryID,
-					EventKindMovie,
+					kind,
 					row.ItemID,
 					row.AvailableAt,
-					MovieDedupeKey(libraryID, row.ItemID),
+					dedupeKey(libraryID, row.ItemID),
 				)
 			}
 			sb.WriteString(" ON CONFLICT (dedupe_key) DO NOTHING")
 			tag, err := tx.Exec(ctx, sb.String(), eventArgs...)
 			if err != nil {
-				return 0, 0, fmt.Errorf("insert movie release events: %w", err)
+				return 0, 0, fmt.Errorf("insert %s release events: %w", kind, err)
 			}
 			events += int(tag.RowsAffected())
 		}
 	}
 
 	if err := tx.Commit(ctx); err != nil {
-		return 0, 0, fmt.Errorf("commit movie availability tx: %w", err)
+		return 0, 0, fmt.Errorf("commit %s availability tx: %w", kind, err)
 	}
 	return len(inserted), events, nil
 }
@@ -274,6 +319,12 @@ func EpisodeDedupeKey(libraryID int, seriesID string, episodeKey int) string {
 // "movie:" prefix keeps the keyspace disjoint from episode keys.
 func MovieDedupeKey(libraryID int, itemID string) string {
 	return fmt.Sprintf("movie:%d:%s", libraryID, itemID)
+}
+
+// AudiobookDedupeKey composes the release_events dedupe key for an
+// audiobook, disjoint from movie and episode keyspaces.
+func AudiobookDedupeKey(libraryID int, itemID string) string {
+	return fmt.Sprintf("audiobook:%d:%s", libraryID, itemID)
 }
 
 type newAvailability struct {

--- a/internal/notifications/release_types.go
+++ b/internal/notifications/release_types.go
@@ -23,11 +23,13 @@ const SuppressedReasonSeriesBurst = "series_burst"
 const SuppressedReasonStale = "stale"
 
 // Release event kinds. Episode events carry the series/episode columns and
-// fan out to interested profiles; movie events carry ItemID only and exist
-// for the server-channel broadcast feed (no per-profile fanout in v1).
+// fan out to interested profiles; movie and audiobook events carry ItemID
+// only and exist for the server-channel broadcast feed (no per-profile
+// fanout in v1).
 const (
-	EventKindEpisode = "episode"
-	EventKindMovie   = "movie"
+	EventKindEpisode   = "episode"
+	EventKindMovie     = "movie"
+	EventKindAudiobook = "audiobook"
 )
 
 // normalizeEventKind treats an unset kind as episode — the single home of

--- a/internal/notifications/server_channel_payload.go
+++ b/internal/notifications/server_channel_payload.go
@@ -75,10 +75,27 @@ func GroupContentEvents(events []ReleaseEvent, metas map[string]ContentMeta) []C
 	}
 	index := make(map[groupKey]int)
 	seenMovies := make(map[string]struct{})
+	seenAudiobooks := make(map[string]struct{})
 	groups := make([]ContentGroup, 0, len(events))
 
 	for _, event := range events {
 		switch normalizeEventKind(event.Kind) {
+		case EventKindAudiobook:
+			// Like movies: one group per item, deduped across libraries.
+			if _, dup := seenAudiobooks[event.ItemID]; dup {
+				continue
+			}
+			seenAudiobooks[event.ItemID] = struct{}{}
+			meta := metas[event.ItemID]
+			if meta.Title == "" {
+				meta.Title = "New audiobook"
+			}
+			groups = append(groups, ContentGroup{
+				Kind:      EventKindAudiobook,
+				LibraryID: event.LibraryID,
+				ItemID:    event.ItemID,
+				Meta:      meta,
+			})
 		case EventKindMovie:
 			// The same movie landing in two libraries (e.g. "Movies" and
 			// "Movies 4K") announces once.
@@ -149,7 +166,7 @@ func episodeRangeLabel(episodes []ReleaseEvent) string {
 // contentGroupTitle renders a group's display line.
 func contentGroupTitle(group ContentGroup) string {
 	switch group.Kind {
-	case EventKindMovie:
+	case EventKindMovie, EventKindAudiobook:
 		return titleWithYear(group.Meta.Title, group.Meta.Year)
 	default:
 		if len(group.Episodes) == 1 {
@@ -179,6 +196,8 @@ func BuildServerChannelDiscordContent(groups []ContentGroup, test bool) ([]byte,
 		author := "New episodes available on Silo"
 		if group.Kind == EventKindMovie {
 			author = "New movie available on Silo"
+		} else if group.Kind == EventKindAudiobook {
+			author = "New audiobook available on Silo"
 		} else if len(group.Episodes) == 1 {
 			author = "New episode available on Silo"
 		}
@@ -260,7 +279,7 @@ func BuildServerChannelGenericContent(groups []ContentGroup, channelID string, t
 			LibraryID: group.LibraryID,
 		}
 		switch group.Kind {
-		case EventKindMovie:
+		case EventKindMovie, EventKindAudiobook:
 			row.ItemID = group.ItemID
 			row.Title = group.Meta.Title
 			row.Year = group.Meta.Year

--- a/internal/notifications/server_channel_repo.go
+++ b/internal/notifications/server_channel_repo.go
@@ -22,7 +22,7 @@ func NewServerChannelRepository(pool *pgxpool.Pool) *ServerChannelRepository {
 
 const serverChannelColumns = `
 	id, name, type, url_ciphertext, url_host, signing_secret_ciphertext, enabled,
-	notify_new_movies, notify_new_episodes,
+	notify_new_movies, notify_new_episodes, notify_new_audiobooks,
 	notify_request_submitted, notify_request_approved,
 	notify_request_declined, notify_request_fulfilled,
 	watermark_created_at, watermark_id,
@@ -35,7 +35,7 @@ func scanServerChannel(row pgx.Row) (*ServerChannel, error) {
 	err := row.Scan(
 		&ch.ID, &ch.Name, &ch.Type, &ch.URLCiphertext, &ch.URLHost,
 		&ch.SigningSecretCiphertext, &ch.Enabled,
-		&ch.NotifyNewMovies, &ch.NotifyNewEpisodes,
+		&ch.NotifyNewMovies, &ch.NotifyNewEpisodes, &ch.NotifyNewAudiobooks,
 		&ch.NotifyRequestSubmitted, &ch.NotifyRequestApproved,
 		&ch.NotifyRequestDeclined, &ch.NotifyRequestFulfilled,
 		&ch.WatermarkCreatedAt, &ch.WatermarkID,
@@ -122,13 +122,13 @@ func (r *ServerChannelRepository) InsertWithLimit(ctx context.Context, ch Server
 	if _, err := tx.Exec(ctx, `
 		INSERT INTO notification_server_channels
 			(id, name, type, url_ciphertext, url_host, signing_secret_ciphertext, enabled,
-			 notify_new_movies, notify_new_episodes,
+			 notify_new_movies, notify_new_episodes, notify_new_audiobooks,
 			 notify_request_submitted, notify_request_approved,
 			 notify_request_declined, notify_request_fulfilled,
 			 created_by_user_id)
-		VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12,$13,$14)`,
+		VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12,$13,$14,$15)`,
 		ch.ID, ch.Name, ch.Type, ch.URLCiphertext, ch.URLHost, ch.SigningSecretCiphertext, ch.Enabled,
-		ch.NotifyNewMovies, ch.NotifyNewEpisodes,
+		ch.NotifyNewMovies, ch.NotifyNewEpisodes, ch.NotifyNewAudiobooks,
 		ch.NotifyRequestSubmitted, ch.NotifyRequestApproved,
 		ch.NotifyRequestDeclined, ch.NotifyRequestFulfilled,
 		ch.CreatedByUserID); err != nil {
@@ -153,13 +153,14 @@ func (r *ServerChannelRepository) Update(ctx context.Context, ch ServerChannel) 
 			name = $2, url_ciphertext = $3, url_host = $4,
 			signing_secret_ciphertext = $5, enabled = $6,
 			notify_new_movies = $7, notify_new_episodes = $8,
-			notify_request_submitted = $9, notify_request_approved = $10,
-			notify_request_declined = $11, notify_request_fulfilled = $12,
+			notify_new_audiobooks = $9,
+			notify_request_submitted = $10, notify_request_approved = $11,
+			notify_request_declined = $12, notify_request_fulfilled = $13,
 			updated_at = now()
 		WHERE id = $1`,
 		ch.ID, ch.Name, ch.URLCiphertext, ch.URLHost,
 		ch.SigningSecretCiphertext, ch.Enabled,
-		ch.NotifyNewMovies, ch.NotifyNewEpisodes,
+		ch.NotifyNewMovies, ch.NotifyNewEpisodes, ch.NotifyNewAudiobooks,
 		ch.NotifyRequestSubmitted, ch.NotifyRequestApproved,
 		ch.NotifyRequestDeclined, ch.NotifyRequestFulfilled)
 	if err != nil {

--- a/internal/notifications/server_channel_service.go
+++ b/internal/notifications/server_channel_service.go
@@ -47,6 +47,7 @@ type ServerChannelInput struct {
 	Enabled                *bool
 	NotifyNewMovies        *bool
 	NotifyNewEpisodes      *bool
+	NotifyNewAudiobooks    *bool
 	NotifyRequestSubmitted *bool
 	NotifyRequestApproved  *bool
 	NotifyRequestDeclined  *bool
@@ -91,13 +92,17 @@ func (s *ServerChannelService) Create(ctx context.Context, createdByUserID int, 
 	}
 
 	ch := ServerChannel{
-		ID:                     ulid.Make().String(),
-		Name:                   name,
-		Type:                   channelType,
-		URLHost:                host,
-		Enabled:                boolOrDefault(input.Enabled, true),
-		NotifyNewMovies:        boolOrDefault(input.NotifyNewMovies, true),
-		NotifyNewEpisodes:      boolOrDefault(input.NotifyNewEpisodes, true),
+		ID:                ulid.Make().String(),
+		Name:              name,
+		Type:              channelType,
+		URLHost:           host,
+		Enabled:           boolOrDefault(input.Enabled, true),
+		NotifyNewMovies:   boolOrDefault(input.NotifyNewMovies, true),
+		NotifyNewEpisodes: boolOrDefault(input.NotifyNewEpisodes, true),
+		// Audiobook announcements are opt-in: most channels were configured
+		// before this kind existed, and video-only servers should not grow a
+		// new default-on toggle.
+		NotifyNewAudiobooks:    boolOrDefault(input.NotifyNewAudiobooks, false),
 		NotifyRequestSubmitted: boolOrDefault(input.NotifyRequestSubmitted, false),
 		NotifyRequestApproved:  boolOrDefault(input.NotifyRequestApproved, false),
 		NotifyRequestDeclined:  boolOrDefault(input.NotifyRequestDeclined, false),
@@ -177,6 +182,9 @@ func (s *ServerChannelService) Update(ctx context.Context, id string, input Serv
 	}
 	if input.NotifyNewEpisodes != nil {
 		ch.NotifyNewEpisodes = *input.NotifyNewEpisodes
+	}
+	if input.NotifyNewAudiobooks != nil {
+		ch.NotifyNewAudiobooks = *input.NotifyNewAudiobooks
 	}
 	if input.NotifyRequestSubmitted != nil {
 		ch.NotifyRequestSubmitted = *input.NotifyRequestSubmitted

--- a/internal/notifications/server_channel_types.go
+++ b/internal/notifications/server_channel_types.go
@@ -33,6 +33,7 @@ type ServerChannel struct {
 	Enabled                 bool
 	NotifyNewMovies         bool
 	NotifyNewEpisodes       bool
+	NotifyNewAudiobooks     bool
 	NotifyRequestSubmitted  bool
 	NotifyRequestApproved   bool
 	NotifyRequestDeclined   bool
@@ -66,6 +67,8 @@ func (c ServerChannel) WantsContentKind(kind string) bool {
 		return c.NotifyNewEpisodes
 	case EventKindMovie:
 		return c.NotifyNewMovies
+	case EventKindAudiobook:
+		return c.NotifyNewAudiobooks
 	default:
 		return false
 	}

--- a/internal/notifications/server_channel_worker.go
+++ b/internal/notifications/server_channel_worker.go
@@ -257,7 +257,7 @@ func loadContentMeta(ctx context.Context, tx pgx.Tx, events []ReleaseEvent) (map
 		}
 	}
 	for _, event := range events {
-		if event.Kind == EventKindMovie {
+		if event.Kind == EventKindMovie || event.Kind == EventKindAudiobook {
 			add(event.ItemID)
 		} else {
 			add(event.SeriesID)

--- a/internal/notifications/system.go
+++ b/internal/notifications/system.go
@@ -466,6 +466,9 @@ func (s *System) SeedAvailability(ctx context.Context, progress func(percent int
 		{EventKindMovie,
 			`SELECT 1 FROM notification_content_seed_state seed WHERE seed.library_id = mf.id AND seed.kind = 'movie'`,
 			s.Releases.RecordMovieAvailabilityForLibrary},
+		{EventKindAudiobook,
+			`SELECT 1 FROM notification_content_seed_state seed WHERE seed.library_id = mf.id AND seed.kind = 'audiobook'`,
+			s.Releases.RecordAudiobookAvailabilityForLibrary},
 	}
 	for passIdx, pass := range passes {
 		rows, err := s.pool.Query(ctx, `

--- a/migrations/sql/20260702191034_audiobook_availability_notifications.sql
+++ b/migrations/sql/20260702191034_audiobook_availability_notifications.sql
@@ -1,0 +1,46 @@
+-- +goose Up
+-- +goose StatementBegin
+-- Recently-Added notifications for audiobooks (issue #270): availability
+-- facts for audiobook items, mirroring movie_availability. Rows are written
+-- by the availability detector after audiobook library scans; release events
+-- are emitted only once the library's back catalog has been seeded (kind
+-- 'audiobook' in notification_content_seed_state).
+CREATE TABLE audiobook_availability (
+    library_id   integer NOT NULL,
+    item_id      text COLLATE "C" NOT NULL,
+    available_at timestamptz NOT NULL DEFAULT now(),
+    created_at   timestamptz NOT NULL DEFAULT now(),
+    PRIMARY KEY (library_id, item_id)
+);
+
+-- Per-channel opt-in toggle. Defaults false everywhere (existing and new
+-- channels): operators enable audiobook announcements explicitly, matching
+-- the conservative unknown-kind posture in WantsContentKind.
+ALTER TABLE notification_server_channels
+ADD COLUMN notify_new_audiobooks boolean NOT NULL DEFAULT false;
+
+-- Admit the new kind on release_events.
+ALTER TABLE release_events
+DROP CONSTRAINT IF EXISTS release_events_kind_check;
+ALTER TABLE release_events
+ADD CONSTRAINT release_events_kind_check
+CHECK (kind = ANY (ARRAY['episode'::text, 'movie'::text, 'audiobook'::text]));
+
+-- Audiobook events are item-shaped, like movies.
+ALTER TABLE release_events
+DROP CONSTRAINT IF EXISTS release_events_kind_shape_check;
+ALTER TABLE release_events
+ADD CONSTRAINT release_events_kind_shape_check
+CHECK (
+    (kind = 'episode' AND series_id IS NOT NULL AND episode_id IS NOT NULL
+        AND season_number IS NOT NULL AND episode_number IS NOT NULL AND episode_key IS NOT NULL)
+    OR (kind = 'movie' AND item_id IS NOT NULL)
+    OR (kind = 'audiobook' AND item_id IS NOT NULL)
+);
+-- +goose StatementEnd
+
+-- +goose Down
+-- +goose StatementBegin
+ALTER TABLE notification_server_channels DROP COLUMN IF EXISTS notify_new_audiobooks;
+DROP TABLE IF EXISTS audiobook_availability;
+-- +goose StatementEnd

--- a/web/src/api/types.ts
+++ b/web/src/api/types.ts
@@ -2521,6 +2521,7 @@ export interface ServerNotificationChannel {
   enabled: boolean;
   notify_new_movies: boolean;
   notify_new_episodes: boolean;
+  notify_new_audiobooks: boolean;
   notify_request_submitted: boolean;
   notify_request_approved: boolean;
   notify_request_declined: boolean;
@@ -2543,6 +2544,7 @@ export interface ServerNotificationChannelInput {
   enabled?: boolean;
   notify_new_movies?: boolean;
   notify_new_episodes?: boolean;
+  notify_new_audiobooks?: boolean;
   notify_request_submitted?: boolean;
   notify_request_approved?: boolean;
   notify_request_declined?: boolean;

--- a/web/src/pages/admin-settings/ServerNotificationChannels.tsx
+++ b/web/src/pages/admin-settings/ServerNotificationChannels.tsx
@@ -44,6 +44,7 @@ import { formatRelativeTime } from "@/lib/date";
 type ChannelNotifyKey =
   | "notify_new_movies"
   | "notify_new_episodes"
+  | "notify_new_audiobooks"
   | "notify_request_submitted"
   | "notify_request_approved"
   | "notify_request_declined"
@@ -61,6 +62,7 @@ const EVENT_SECTIONS: { label: string; fields: ChannelNotifyField[] }[] = [
     fields: [
       { key: "notify_new_movies", label: "New movies", defaultValue: true },
       { key: "notify_new_episodes", label: "New episodes", defaultValue: true },
+      { key: "notify_new_audiobooks", label: "New audiobooks", defaultValue: false },
     ],
   },
   {


### PR DESCRIPTION
## Problem

Availability detection only ran for TV/movie/mixed libraries: `AvailabilityKinds` had only Episodes and Movies, and server channels only exposed `notify_new_movies` / `notify_new_episodes`. Audiobook libraries never created release events, so Discord/webhook channels could not announce newly added audiobooks (#270).

## Approach

Audiobooks become a third availability kind, reusing the existing seeding semantics end to end:

- **New `audiobook_availability` table** mirroring `movie_availability`; the movie recorder is generalized into `recordItemAvailability` (kind + dedupe-key parameterized) rather than copy-pasted, and gains `RecordAudiobookAvailabilityForLibrary/ForPaths`. `release_events` admits the new kind — item-shaped like movies (both CHECK constraints extended).
- **Detector + ingest executor**: `AvailabilityKinds.Audiobooks` is set for audiobook libraries; the first full scan seeds silently, later scans announce — identical semantics to movies.
- **Channel toggle** `notify_new_audiobooks`, **opt-in (default false)** for both existing and new channels: most channels were configured before this kind existed, and video-only servers shouldn't grow a default-on toggle. Threaded through repo/service/REST/admin UI; `WantsContentKind` routes it (old nodes skip unknown kinds by design).
- **Digest rendering**: audiobooks group like movies — one group per item, deduped across libraries, title-with-year, a "New audiobook available on Silo" Discord author line; metadata comes from the existing `media_items` batch fetch.
- **Upgrade path**: the system backfill sweep gains an audiobook pass with its own seed marker, so existing audiobook libraries seed on upgrade without spamming their back catalog.

## Testing

- DB-backed test: silent unseeded pass, event emission with kind `audiobook` once seeded, idempotent re-run. (This test caught both `release_events` CHECK constraints — the kind allowlist and the kind-shape check — which the migration now extends.)
- Unit tests: `WantsContentKind`, audiobook grouping + cross-library dedupe + generic-title fallback, Discord rendering.
- **Live-validated**: on upgrade boot, the backfill pass seeded 44,557 audiobook availability rows silently across 6 libraries and wrote the seed markers — exactly the no-back-catalog-spam behavior intended.

Additive-only per v1 rules: new JSON fields, new event kind, no renames or repurposes.

Fixes #270

## AI-use disclosure

Implemented with Claude Code (test-first, live-validated); human-reviewed before submission.

🤖 Generated with [Claude Code](https://claude.com/claude-code)