### PR TITLE
feat(historyimport): import the Plex account watchlist alongside watch history

### DIFF
--- a/internal/access/resolver_test.go
+++ b/internal/access/resolver_test.go
@@ -135,7 +135,7 @@ func (s stubStore) ListFavoritesByMediaItems(context.Context, string, []string) 
 }
 func (s stubStore) IsFavorite(context.Context, string, string) (bool, error) { panic("unused") }
 func (s stubStore) AddToWatchlist(context.Context, string, string) error     { panic("unused") }
-func (s stubStore) AddToWatchlistAt(context.Context, string, string, time.Time) error {
+func (s stubStore) AddToWatchlistAt(context.Context, string, string, time.Time) (bool, error) {
 	panic("unused")
 }
 func (s stubStore) RemoveWatchedFromWatchlist(context.Context, string) (bool, error) {

--- a/internal/historyimport/plex_client.go
+++ b/internal/historyimport/plex_client.go
@@ -17,12 +17,17 @@ const (
 	plexProduct          = "Silo"
 	plexVersion          = "1.0.0"
 	plexTVBaseURL        = "https://plex.tv"
-	plexPageSize         = 500
+	// plexDiscoverBaseURL hosts account-level metadata (the user's
+	// watchlist), which lives on plex.tv infrastructure rather than the PMS.
+	plexDiscoverBaseURL = "https://discover.provider.plex.tv"
+	plexPageSize        = 500
 )
 
 type PlexClient struct {
 	httpClient *http.Client
 	limiter    *upstreamRateLimiter
+	// discoverBaseURL is overridable for tests; empty means the real host.
+	discoverBaseURL string
 }
 
 type PlexAccount struct {
@@ -249,6 +254,41 @@ func (c *PlexClient) fetchSectionItems(ctx context.Context, baseURL, token, sect
 		var container plexMediaContainer
 		if err := c.doJSON(req, &container); err != nil {
 			return nil, fmt.Errorf("fetching Plex section items (section %s, type %d, offset %d): %w", sectionKey, mediaType, offset, err)
+		}
+		allItems = append(allItems, container.MediaContainer.Metadata...)
+		offset += len(container.MediaContainer.Metadata)
+		if offset >= container.MediaContainer.TotalSize || len(container.MediaContainer.Metadata) == 0 {
+			break
+		}
+	}
+	return allItems, nil
+}
+
+// FetchWatchlist pages through the user's account-level watchlist on the
+// Plex discover API. It authenticates with the plex.tv ACCOUNT token (from
+// the PIN/OAuth session), not a server access token: the watchlist belongs
+// to the account, not to any PMS.
+func (c *PlexClient) FetchWatchlist(ctx context.Context, accountToken string) ([]PlexItem, error) {
+	base := c.discoverBaseURL
+	if base == "" {
+		base = plexDiscoverBaseURL
+	}
+	var allItems []PlexItem
+	offset := 0
+	for {
+		query := url.Values{}
+		query.Set("includeGuids", "1")
+		query.Set("X-Plex-Container-Start", strconv.Itoa(offset))
+		query.Set("X-Plex-Container-Size", strconv.Itoa(plexPageSize))
+		reqURL := fmt.Sprintf("%s/library/sections/watchlist/all?%s", base, query.Encode())
+		req, err := http.NewRequestWithContext(ctx, http.MethodGet, reqURL, nil)
+		if err != nil {
+			return nil, err
+		}
+		c.setPlexHeaders(req, accountToken)
+		var container plexMediaContainer
+		if err := c.doJSON(req, &container); err != nil {
+			return nil, fmt.Errorf("fetching Plex watchlist (offset %d): %w", offset, err)
 		}
 		allItems = append(allItems, container.MediaContainer.Metadata...)
 		offset += len(container.MediaContainer.Metadata)

--- a/internal/historyimport/plex_normalize.go
+++ b/internal/historyimport/plex_normalize.go
@@ -47,6 +47,29 @@ func NormalizePlexItem(item PlexItem, series *PlexItem) Record {
 	return record
 }
 
+// NormalizePlexWatchlistItem maps an account-watchlist entry to an import
+// record: movie or series identity only, flagged Watchlisted, and carrying
+// no watch state (a watchlist entry says "want to watch", not "watched").
+func NormalizePlexWatchlistItem(item PlexItem) Record {
+	record := Record{
+		ExternalID:  item.RatingKey,
+		Title:       item.Title,
+		Year:        item.Year,
+		Watchlisted: true,
+		UpdatedAt:   time.Now().UTC(),
+	}
+	ParsePlexGuids(item.Guid, &record.IMDbID, &record.TMDBID, &record.TVDBID)
+	switch item.Type {
+	case "movie":
+		record.Kind = KindMovie
+	case "show":
+		record.Kind = KindSeries
+	default:
+		record.Kind = item.Type
+	}
+	return record
+}
+
 func NormalizePlexHistoryItem(item PlexHistoryItem, series *PlexItem) Record {
 	record := Record{
 		ExternalID:      item.RatingKey,

--- a/internal/historyimport/plex_provider.go
+++ b/internal/historyimport/plex_provider.go
@@ -7,13 +7,21 @@ import (
 )
 
 type PlexServerProvider struct {
-	client  *PlexClient
-	baseURL string
-	token   string
+	client       *PlexClient
+	baseURL      string
+	token        string
+	accountToken string
 }
 
 func NewPlexServerProvider(client *PlexClient, baseURL, token string) *PlexServerProvider {
 	return &PlexServerProvider{client: client, baseURL: baseURL, token: token}
+}
+
+// WithAccountToken enables account-level fetches (the watchlist). Empty
+// disables them: server-token-only imports still work, minus the watchlist.
+func (p *PlexServerProvider) WithAccountToken(token string) *PlexServerProvider {
+	p.accountToken = token
+	return p
 }
 
 func (p *PlexServerProvider) Fetch(ctx context.Context) ([]Record, []string, error) {
@@ -68,6 +76,20 @@ func (p *PlexServerProvider) Fetch(ctx context.Context) ([]Record, []string, err
 	for _, record := range merged {
 		records = append(records, record)
 	}
+	// The account watchlist rides along with the history import. Best
+	// effort: a watchlist fetch failure downgrades to a warning so the
+	// watch-history import still completes (issue #245).
+	if p.accountToken != "" {
+		items, err := p.client.FetchWatchlist(ctx, p.accountToken)
+		if err != nil {
+			warnings = append(warnings, fmt.Sprintf("watchlist fetch failed: %v", err))
+		} else {
+			for _, item := range items {
+				records = append(records, NormalizePlexWatchlistItem(item))
+			}
+		}
+	}
+
 	return records, warnings, nil
 }
 

--- a/internal/historyimport/plex_watchlist_test.go
+++ b/internal/historyimport/plex_watchlist_test.go
@@ -1,0 +1,119 @@
+package historyimport
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestNormalizePlexWatchlistItem(t *testing.T) {
+	movie := PlexItem{
+		RatingKey: "wl-1",
+		Type:      "movie",
+		Title:     "Dune: Part Two",
+		Year:      2024,
+		Guid:      PlexGuids{{ID: "imdb://tt15239678"}, {ID: "tmdb://693134"}},
+	}
+	record := NormalizePlexWatchlistItem(movie)
+	if record.Kind != KindMovie {
+		t.Fatalf("movie kind = %q, want %q", record.Kind, KindMovie)
+	}
+	if !record.Watchlisted {
+		t.Fatal("watchlist record must be flagged Watchlisted")
+	}
+	if record.Played || record.PlayCount != 0 || record.LastPlayedAt != nil {
+		t.Fatalf("watchlist record must carry no watch state: %+v", record)
+	}
+	if record.IMDbID != "tt15239678" || record.TMDBID != "693134" {
+		t.Fatalf("ids = imdb %q tmdb %q, want parsed from guids", record.IMDbID, record.TMDBID)
+	}
+
+	show := PlexItem{
+		RatingKey: "wl-2",
+		Type:      "show",
+		Title:     "Severance",
+		Year:      2022,
+		Guid:      PlexGuids{{ID: "tvdb://371980"}},
+	}
+	record = NormalizePlexWatchlistItem(show)
+	if record.Kind != KindSeries {
+		t.Fatalf("show kind = %q, want %q (Plex watchlist uses 'show')", record.Kind, KindSeries)
+	}
+	if record.TVDBID != "371980" {
+		t.Fatalf("tvdb id = %q, want parsed", record.TVDBID)
+	}
+}
+
+func TestFetchWatchlistPaginatesDiscoverAPI(t *testing.T) {
+	var gotToken string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/library/sections/watchlist/all" {
+			t.Errorf("path = %q, want /library/sections/watchlist/all", r.URL.Path)
+		}
+		gotToken = r.Header.Get("X-Plex-Token")
+		start := r.URL.Query().Get("X-Plex-Container-Start")
+		page := map[string]any{}
+		if start == "0" {
+			page = map[string]any{"MediaContainer": map[string]any{
+				"totalSize": 2,
+				"Metadata": []map[string]any{{
+					"ratingKey": "wl-1", "type": "movie", "title": "Dune: Part Two", "year": 2024,
+					"Guid": []map[string]string{{"id": "tmdb://693134"}},
+				}},
+			}}
+		} else {
+			page = map[string]any{"MediaContainer": map[string]any{
+				"totalSize": 2,
+				"Metadata": []map[string]any{{
+					"ratingKey": "wl-2", "type": "show", "title": "Severance", "year": 2022,
+					"Guid": []map[string]string{{"id": "tvdb://371980"}},
+				}},
+			}}
+		}
+		w.Header().Set("Content-Type", "application/json")
+		if err := json.NewEncoder(w).Encode(page); err != nil {
+			t.Errorf("encode page: %v", err)
+		}
+	}))
+	defer server.Close()
+
+	client := NewPlexClient()
+	client.discoverBaseURL = server.URL
+	items, err := client.FetchWatchlist(context.Background(), "account-token-1")
+	if err != nil {
+		t.Fatalf("FetchWatchlist: %v", err)
+	}
+	if gotToken != "account-token-1" {
+		t.Fatalf("token header = %q, want account token", gotToken)
+	}
+	if len(items) != 2 {
+		t.Fatalf("items = %d, want 2 (paginated)", len(items))
+	}
+	if items[0].RatingKey != "wl-1" || items[1].RatingKey != "wl-2" {
+		t.Fatalf("unexpected items: %+v", items)
+	}
+}
+
+// Guard against page-size regressions: a server reporting a huge total but
+// returning empty pages must not loop forever.
+func TestFetchWatchlistStopsOnEmptyPage(t *testing.T) {
+	calls := 0
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		calls++
+		fmt.Fprint(w, `{"MediaContainer":{"totalSize":999,"Metadata":[]}}`)
+	}))
+	defer server.Close()
+
+	client := NewPlexClient()
+	client.discoverBaseURL = server.URL
+	items, err := client.FetchWatchlist(context.Background(), "tok")
+	if err != nil {
+		t.Fatalf("FetchWatchlist: %v", err)
+	}
+	if len(items) != 0 || calls != 1 {
+		t.Fatalf("items=%d calls=%d, want 0 items after a single call", len(items), calls)
+	}
+}

--- a/internal/historyimport/plex_watchlist_test.go
+++ b/internal/historyimport/plex_watchlist_test.go
@@ -6,7 +6,13 @@ import (
 	"fmt"
 	"net/http"
 	"net/http/httptest"
+	"os"
 	"testing"
+	"time"
+
+	"github.com/jackc/pgx/v5/pgxpool"
+
+	"github.com/Silo-Server/silo-server/internal/userstore/pgstore"
 )
 
 func TestNormalizePlexWatchlistItem(t *testing.T) {
@@ -116,4 +122,149 @@ func TestFetchWatchlistStopsOnEmptyPage(t *testing.T) {
 	if len(items) != 0 || calls != 1 {
 		t.Fatalf("items=%d calls=%d, want 0 items after a single call", len(items), calls)
 	}
+}
+
+func TestPlexWatchlistImportCountsOnlyInsertedRows(t *testing.T) {
+	ctx := context.Background()
+	pool := newPlexWatchlistImportTestPool(t)
+	repo := NewRepository(pool, nil)
+	service := &Service{
+		repo:         repo,
+		matcher:      NewMatcher(repo),
+		stores:       pgstore.NewPostgresProvider(pool),
+		bgContext:    ctx,
+		runSemaphore: make(chan struct{}, maxConcurrentRuns),
+		runCancels:   make(map[string]context.CancelFunc),
+	}
+
+	if _, err := pool.Exec(ctx, `
+		INSERT INTO media_items (content_id, type, title, year, tmdb_id, status)
+		VALUES ($1, $2, $3, $4, $5, $6)`,
+		"movie-693134", KindMovie, "Dune: Part Two", 2024, "693134", "matched",
+	); err != nil {
+		t.Fatalf("seed media item: %v", err)
+	}
+	run, err := repo.CreateRun(ctx, Run{
+		ID:               "plex-watchlist-duplicate-run",
+		UserID:           42,
+		ProfileID:        "profile-1",
+		SourceType:       SourceTypePlex,
+		ConnectionMode:   ConnectionModePlexOAuth,
+		Status:           RunStatusQueued,
+		Warnings:         []string{},
+		UnmatchedSamples: []UnmatchedSample{},
+	})
+	if err != nil {
+		t.Fatalf("CreateRun: %v", err)
+	}
+
+	updatedAt := time.Date(2026, time.July, 2, 12, 0, 0, 0, time.UTC)
+	record := Record{
+		Kind:        KindMovie,
+		Title:       "Dune: Part Two",
+		Year:        2024,
+		TMDBID:      "693134",
+		Watchlisted: true,
+		UpdatedAt:   updatedAt,
+	}
+	service.executeRun(run, staticWatchlistProvider{records: []Record{record, record}})
+
+	completed, err := repo.GetRunForUser(ctx, 42, run.ID)
+	if err != nil {
+		t.Fatalf("GetRunForUser: %v", err)
+	}
+	if completed.Status != RunStatusCompleted {
+		t.Fatalf("run status = %q, want %q; warnings=%v", completed.Status, RunStatusCompleted, completed.Warnings)
+	}
+	if completed.WatchlistAdded != 1 {
+		t.Fatalf("WatchlistAdded = %d, want 1", completed.WatchlistAdded)
+	}
+	var rows int
+	if err := pool.QueryRow(ctx, `
+		SELECT COUNT(*)
+		FROM user_watchlist
+		WHERE user_id = $1 AND profile_id = $2 AND media_item_id = $3`,
+		42, "profile-1", "movie-693134",
+	).Scan(&rows); err != nil {
+		t.Fatalf("count watchlist rows: %v", err)
+	}
+	if rows != 1 {
+		t.Fatalf("watchlist rows = %d, want 1", rows)
+	}
+}
+
+type staticWatchlistProvider struct {
+	records []Record
+}
+
+func (p staticWatchlistProvider) Fetch(context.Context) ([]Record, []string, error) {
+	return p.records, nil, nil
+}
+
+func newPlexWatchlistImportTestPool(t *testing.T) *pgxpool.Pool {
+	t.Helper()
+	dsn := os.Getenv("SILO_TEST_DATABASE_URL")
+	if dsn == "" {
+		t.Skip("SILO_TEST_DATABASE_URL is not set")
+	}
+	ctx := context.Background()
+	config, err := pgxpool.ParseConfig(dsn)
+	if err != nil {
+		t.Fatalf("parse db config: %v", err)
+	}
+	config.MaxConns = 1
+	pool, err := pgxpool.NewWithConfig(ctx, config)
+	if err != nil {
+		t.Fatalf("connect test database: %v", err)
+	}
+	t.Cleanup(pool.Close)
+
+	for _, stmt := range []string{
+		`CREATE TEMP TABLE media_items (
+			content_id text PRIMARY KEY,
+			type text NOT NULL,
+			title text NOT NULL,
+			year integer,
+			imdb_id text,
+			tmdb_id text,
+			tvdb_id text,
+			status text NOT NULL DEFAULT 'matched'
+		) ON COMMIT PRESERVE ROWS`,
+		`CREATE TEMP TABLE user_watchlist (
+			user_id integer NOT NULL,
+			profile_id text NOT NULL,
+			media_item_id text NOT NULL,
+			added_at timestamptz NOT NULL DEFAULT now(),
+			sort_index integer,
+			PRIMARY KEY (user_id, profile_id, media_item_id)
+		) ON COMMIT PRESERVE ROWS`,
+		`CREATE TEMP TABLE history_import_runs (
+			id text PRIMARY KEY,
+			user_id integer NOT NULL,
+			profile_id text NOT NULL,
+			source_type text NOT NULL,
+			connection_mode text NOT NULL,
+			status text NOT NULL,
+			mapping_id integer,
+			fetched integer NOT NULL DEFAULT 0,
+			matched integer NOT NULL DEFAULT 0,
+			unmatched integer NOT NULL DEFAULT 0,
+			progress_updated integer NOT NULL DEFAULT 0,
+			history_created integer NOT NULL DEFAULT 0,
+			watchlist_added integer NOT NULL DEFAULT 0,
+			skipped integer NOT NULL DEFAULT 0,
+			warnings jsonb NOT NULL DEFAULT '[]'::jsonb,
+			unmatched_samples jsonb NOT NULL DEFAULT '[]'::jsonb,
+			error_message text,
+			created_at timestamptz NOT NULL DEFAULT now(),
+			started_at timestamptz,
+			completed_at timestamptz,
+			last_heartbeat_at timestamptz
+		) ON COMMIT PRESERVE ROWS`,
+	} {
+		if _, err := pool.Exec(ctx, stmt); err != nil {
+			t.Fatalf("create temp test table: %v", err)
+		}
+	}
+	return pool
 }

--- a/internal/historyimport/repo.go
+++ b/internal/historyimport/repo.go
@@ -597,21 +597,21 @@ func (r *Repository) CreateRun(ctx context.Context, run Run) (*Run, error) {
 		INSERT INTO history_import_runs (
 			id, user_id, profile_id, source_type, connection_mode, status,
 			mapping_id,
-			fetched, matched, unmatched, progress_updated, history_created, skipped,
+			fetched, matched, unmatched, progress_updated, history_created, watchlist_added, skipped,
 			warnings, unmatched_samples, error_message
 		) VALUES (
 			$1, $2, $3, $4, $5, $6,
 			$7,
-			$8, $9, $10, $11, $12, $13,
-			$14, $15, NULLIF($16, '')
+			$8, $9, $10, $11, $12, $13, $14,
+			$15, $16, NULLIF($17, '')
 		)
 		RETURNING id, user_id, profile_id, source_type, connection_mode, status,
 			mapping_id,
-			fetched, matched, unmatched, progress_updated, history_created, skipped,
+			fetched, matched, unmatched, progress_updated, history_created, watchlist_added, skipped,
 			warnings, unmatched_samples, COALESCE(error_message, ''), created_at, started_at, completed_at`,
 		run.ID, run.UserID, run.ProfileID, run.SourceType, run.ConnectionMode, run.Status,
 		run.MappingID,
-		run.Fetched, run.Matched, run.Unmatched, run.ProgressUpdated, run.HistoryCreated, run.Skipped,
+		run.Fetched, run.Matched, run.Unmatched, run.ProgressUpdated, run.HistoryCreated, run.WatchlistAdded, run.Skipped,
 		warningsJSON, unmatchedJSON, run.ErrorMessage,
 	)
 	created, err := scanRunWithMappingID(row)
@@ -667,15 +667,16 @@ func (r *Repository) CompleteRun(ctx context.Context, runID string, summary Exec
 			unmatched = $5,
 			progress_updated = $6,
 			history_created = $7,
-			skipped = $8,
-			warnings = $9,
-			unmatched_samples = $10,
+			watchlist_added = $8,
+			skipped = $9,
+			warnings = $10,
+			unmatched_samples = $11,
 			error_message = NULL,
 			completed_at = NOW(),
 			last_heartbeat_at = NOW()
 		WHERE id = $1`,
 		runID, RunStatusCompleted, summary.Fetched, summary.Matched, summary.Unmatched,
-		summary.ProgressUpdated, summary.HistoryCreated, summary.Skipped, warningsJSON, unmatchedJSON,
+		summary.ProgressUpdated, summary.HistoryCreated, summary.WatchlistAdded, summary.Skipped, warningsJSON, unmatchedJSON,
 	)
 	if err != nil {
 		return fmt.Errorf("completing run %s: %w", runID, err)
@@ -703,17 +704,19 @@ func (r *Repository) UpdateRunProgress(ctx context.Context, runID string, summar
 			unmatched = $4,
 			progress_updated = $5,
 			history_created = $6,
-			skipped = $7,
-			warnings = $8,
-			unmatched_samples = $9,
+			watchlist_added = $7,
+			skipped = $8,
+			warnings = $9,
+			unmatched_samples = $10,
 			last_heartbeat_at = NOW()
-		WHERE id = $1 AND status = $10`,
+		WHERE id = $1 AND status = $11`,
 		runID,
 		summary.Fetched,
 		summary.Matched,
 		summary.Unmatched,
 		summary.ProgressUpdated,
 		summary.HistoryCreated,
+		summary.WatchlistAdded,
 		summary.Skipped,
 		warningsJSON,
 		unmatchedJSON,
@@ -767,15 +770,16 @@ func (r *Repository) FailRun(ctx context.Context, runID string, summary Executio
 			unmatched = $5,
 			progress_updated = $6,
 			history_created = $7,
-			skipped = $8,
-			warnings = $9,
-			unmatched_samples = $10,
-			error_message = NULLIF($11, ''),
+			watchlist_added = $8,
+			skipped = $9,
+			warnings = $10,
+			unmatched_samples = $11,
+			error_message = NULLIF($12, ''),
 			completed_at = NOW(),
 			last_heartbeat_at = NOW()
 		WHERE id = $1`,
 		runID, RunStatusFailed, summary.Fetched, summary.Matched, summary.Unmatched,
-		summary.ProgressUpdated, summary.HistoryCreated, summary.Skipped, warningsJSON, unmatchedJSON, errorMessage,
+		summary.ProgressUpdated, summary.HistoryCreated, summary.WatchlistAdded, summary.Skipped, warningsJSON, unmatchedJSON, errorMessage,
 	)
 	if err != nil {
 		return fmt.Errorf("failing run %s: %w", runID, err)
@@ -790,7 +794,7 @@ func (r *Repository) ListRunsForUser(ctx context.Context, userID, limit int) ([]
 	rows, err := r.pool.Query(ctx, `
 		SELECT id, user_id, profile_id, source_type, connection_mode, status,
 			mapping_id,
-			fetched, matched, unmatched, progress_updated, history_created, skipped,
+			fetched, matched, unmatched, progress_updated, history_created, watchlist_added, skipped,
 			warnings, unmatched_samples, COALESCE(error_message, ''), created_at, started_at, completed_at
 		FROM history_import_runs
 		WHERE user_id = $1
@@ -807,7 +811,7 @@ func (r *Repository) GetRunForUser(ctx context.Context, userID int, runID string
 	row := r.pool.QueryRow(ctx, `
 		SELECT id, user_id, profile_id, source_type, connection_mode, status,
 			mapping_id,
-			fetched, matched, unmatched, progress_updated, history_created, skipped,
+			fetched, matched, unmatched, progress_updated, history_created, watchlist_added, skipped,
 			warnings, unmatched_samples, COALESCE(error_message, ''), created_at, started_at, completed_at
 		FROM history_import_runs
 		WHERE id = $1 AND user_id = $2`, runID, userID)
@@ -825,7 +829,7 @@ func (r *Repository) ListActiveRunsForUser(ctx context.Context, userID int) ([]R
 	rows, err := r.pool.Query(ctx, `
 		SELECT id, user_id, profile_id, source_type, connection_mode, status,
 			mapping_id,
-			fetched, matched, unmatched, progress_updated, history_created, skipped,
+			fetched, matched, unmatched, progress_updated, history_created, watchlist_added, skipped,
 			warnings, unmatched_samples, COALESCE(error_message, ''), created_at, started_at, completed_at
 		FROM history_import_runs
 		WHERE user_id = $1
@@ -1101,7 +1105,7 @@ func scanRun(scanner interface{ Scan(dest ...any) error }) (*Run, error) {
 	var unmatchedJSON []byte
 	if err := scanner.Scan(
 		&run.ID, &run.UserID, &run.ProfileID, &run.SourceType, &run.ConnectionMode, &run.Status,
-		&run.Fetched, &run.Matched, &run.Unmatched, &run.ProgressUpdated, &run.HistoryCreated, &run.Skipped,
+		&run.Fetched, &run.Matched, &run.Unmatched, &run.ProgressUpdated, &run.HistoryCreated, &run.WatchlistAdded, &run.Skipped,
 		&warningsJSON, &unmatchedJSON, &run.ErrorMessage, &run.CreatedAt, &run.StartedAt, &run.CompletedAt,
 	); err != nil {
 		return nil, err
@@ -1117,7 +1121,7 @@ func scanRunWithMappingID(scanner interface{ Scan(dest ...any) error }) (*Run, e
 	if err := scanner.Scan(
 		&run.ID, &run.UserID, &run.ProfileID, &run.SourceType, &run.ConnectionMode, &run.Status,
 		&run.MappingID,
-		&run.Fetched, &run.Matched, &run.Unmatched, &run.ProgressUpdated, &run.HistoryCreated, &run.Skipped,
+		&run.Fetched, &run.Matched, &run.Unmatched, &run.ProgressUpdated, &run.HistoryCreated, &run.WatchlistAdded, &run.Skipped,
 		&warningsJSON, &unmatchedJSON, &run.ErrorMessage, &run.CreatedAt, &run.StartedAt, &run.CompletedAt,
 	); err != nil {
 		return nil, err

--- a/internal/historyimport/repo_admin.go
+++ b/internal/historyimport/repo_admin.go
@@ -271,7 +271,7 @@ func (r *Repository) ListAllRuns(ctx context.Context, sourceID *int, limit int) 
 		rows, err = r.pool.Query(ctx, `
 			SELECT r.id, r.user_id, r.profile_id, r.source_type, r.connection_mode, r.status,
 			       r.mapping_id,
-			       r.fetched, r.matched, r.unmatched, r.progress_updated, r.history_created, r.skipped,
+			       r.fetched, r.matched, r.unmatched, r.progress_updated, r.history_created, r.watchlist_added, r.skipped,
 			       r.warnings, r.unmatched_samples, COALESCE(r.error_message, ''),
 			       r.created_at, r.started_at, r.completed_at
 			FROM history_import_runs r
@@ -283,7 +283,7 @@ func (r *Repository) ListAllRuns(ctx context.Context, sourceID *int, limit int) 
 		rows, err = r.pool.Query(ctx, `
 			SELECT id, user_id, profile_id, source_type, connection_mode, status,
 			       mapping_id,
-			       fetched, matched, unmatched, progress_updated, history_created, skipped,
+			       fetched, matched, unmatched, progress_updated, history_created, watchlist_added, skipped,
 			       warnings, unmatched_samples, COALESCE(error_message, ''),
 			       created_at, started_at, completed_at
 			FROM history_import_runs
@@ -302,7 +302,7 @@ func (r *Repository) GetRunByID(ctx context.Context, runID string) (*Run, error)
 	row := r.pool.QueryRow(ctx, `
 		SELECT id, user_id, profile_id, source_type, connection_mode, status,
 		       mapping_id,
-		       fetched, matched, unmatched, progress_updated, history_created, skipped,
+		       fetched, matched, unmatched, progress_updated, history_created, watchlist_added, skipped,
 		       warnings, unmatched_samples, COALESCE(error_message, ''),
 		       created_at, started_at, completed_at
 		FROM history_import_runs
@@ -330,7 +330,7 @@ func (r *Repository) ListActiveRuns(ctx context.Context, sourceID *int) ([]Run, 
 		rows, err = r.pool.Query(ctx, `
 			SELECT r.id, r.user_id, r.profile_id, r.source_type, r.connection_mode, r.status,
 			       r.mapping_id,
-			       r.fetched, r.matched, r.unmatched, r.progress_updated, r.history_created, r.skipped,
+			       r.fetched, r.matched, r.unmatched, r.progress_updated, r.history_created, r.watchlist_added, r.skipped,
 			       r.warnings, r.unmatched_samples, COALESCE(r.error_message, ''),
 			       r.created_at, r.started_at, r.completed_at
 			FROM history_import_runs r
@@ -342,7 +342,7 @@ func (r *Repository) ListActiveRuns(ctx context.Context, sourceID *int) ([]Run, 
 		rows, err = r.pool.Query(ctx, `
 			SELECT id, user_id, profile_id, source_type, connection_mode, status,
 			       mapping_id,
-			       fetched, matched, unmatched, progress_updated, history_created, skipped,
+			       fetched, matched, unmatched, progress_updated, history_created, watchlist_added, skipped,
 			       warnings, unmatched_samples, COALESCE(error_message, ''),
 			       created_at, started_at, completed_at
 			FROM history_import_runs

--- a/internal/historyimport/service.go
+++ b/internal/historyimport/service.go
@@ -403,18 +403,19 @@ func (s *Service) resolvePlexAuth(ctx context.Context, userID int, input CreateR
 // addToWatchlist puts a matched watchlist import onto the importing
 // profile's watchlist (idempotent: the store insert is ON CONFLICT DO
 // NOTHING, so re-imports do not duplicate or reorder entries).
-func (s *Service) addToWatchlist(ctx context.Context, userID int, profileID, mediaItemID string, addedAt time.Time) error {
+func (s *Service) addToWatchlist(ctx context.Context, userID int, profileID, mediaItemID string, addedAt time.Time) (bool, error) {
 	if s.stores == nil {
-		return fmt.Errorf("watchlist import: user store provider not configured")
+		return false, fmt.Errorf("watchlist import: user store provider not configured")
 	}
 	store, err := s.stores.ForUser(ctx, userID)
 	if err != nil {
-		return fmt.Errorf("watchlist import: open user store: %w", err)
+		return false, fmt.Errorf("watchlist import: open user store: %w", err)
 	}
-	if err := store.AddToWatchlistAt(ctx, profileID, mediaItemID, addedAt); err != nil {
-		return fmt.Errorf("watchlist import: add %s: %w", mediaItemID, err)
+	inserted, err := store.AddToWatchlistAt(ctx, profileID, mediaItemID, addedAt)
+	if err != nil {
+		return false, fmt.Errorf("watchlist import: add %s: %w", mediaItemID, err)
 	}
-	return nil
+	return inserted, nil
 }
 
 func (s *Service) executeRun(run *Run, provider Provider) {
@@ -503,9 +504,10 @@ func (s *Service) executeRun(run *Run, provider Provider) {
 		// Watchlist entries carry no watch state: the matched item joins the
 		// importing profile's watchlist and the progress pipeline is skipped.
 		if record.Watchlisted {
-			if err := s.addToWatchlist(ctx, run.UserID, run.ProfileID, match.MediaItemID, record.UpdatedAt); err != nil {
+			inserted, err := s.addToWatchlist(ctx, run.UserID, run.ProfileID, match.MediaItemID, record.UpdatedAt)
+			if err != nil {
 				summary.Warnings = append(summary.Warnings, err.Error())
-			} else {
+			} else if inserted {
 				summary.WatchlistAdded++
 			}
 			s.persistProgressMaybe(ctx, run.ID, summary, i+1, len(records))

--- a/internal/historyimport/service.go
+++ b/internal/historyimport/service.go
@@ -29,6 +29,7 @@ type Service struct {
 	jellyfin   *JellyfinClient
 	plex       *PlexClient
 	watchState *watchstate.Service
+	stores     userstore.UserStoreProvider
 	bgContext  context.Context
 
 	// runSemaphore limits concurrent run goroutines to maxConcurrentRuns.
@@ -51,6 +52,7 @@ func NewService(bgContext context.Context, repo *Repository, storeProvider users
 		jellyfin:     NewJellyfinClient(),
 		plex:         NewPlexClient(),
 		watchState:   watchstate.NewService(storeProvider),
+		stores:       storeProvider,
 		bgContext:    bgContext,
 		runSemaphore: make(chan struct{}, maxConcurrentRuns),
 		runCancels:   make(map[string]context.CancelFunc),
@@ -252,7 +254,7 @@ func (s *Service) CreateRun(ctx context.Context, userID int, input CreateRunInpu
 		}
 		sourceType = SourceTypePlex
 		connectionMode = mode
-		provider = NewPlexServerProvider(s.plex, auth.BaseURL, auth.Token)
+		provider = NewPlexServerProvider(s.plex, auth.BaseURL, auth.Token).WithAccountToken(auth.AccountToken)
 
 	default:
 		return nil, fmt.Errorf("unsupported source type")
@@ -365,14 +367,14 @@ func (s *Service) resolvePlexAuth(ctx context.Context, userID int, input CreateR
 		if err := s.repo.ConsumePlexSession(ctx, session.ID); err != nil {
 			return nil, "", err
 		}
-		return &plexAuth{BaseURL: baseURL, Token: server.AccessToken}, ConnectionModePlexOAuth, nil
+		return &plexAuth{BaseURL: baseURL, Token: server.AccessToken, AccountToken: session.AuthToken}, ConnectionModePlexOAuth, nil
 	}
 
 	if input.PlexBaseURL != "" {
 		if input.PlexToken == "" {
 			return nil, "", fmt.Errorf("plex_token is required for browser Plex imports")
 		}
-		return &plexAuth{BaseURL: input.PlexBaseURL, Token: input.PlexToken}, ConnectionModePlexOAuth, nil
+		return &plexAuth{BaseURL: input.PlexBaseURL, Token: input.PlexToken, AccountToken: input.PlexToken}, ConnectionModePlexOAuth, nil
 	}
 	if input.PlexToken != "" {
 		return nil, "", fmt.Errorf("plex_base_url is required for browser Plex imports")
@@ -392,10 +394,27 @@ func (s *Service) resolvePlexAuth(ctx context.Context, userID int, input CreateR
 		if input.PlexToken == "" {
 			return nil, "", fmt.Errorf("plex_token is required for predefined Plex sources")
 		}
-		return &plexAuth{BaseURL: source.BaseURL, Token: input.PlexToken}, ConnectionModePredefined, nil
+		return &plexAuth{BaseURL: source.BaseURL, Token: input.PlexToken, AccountToken: input.PlexToken}, ConnectionModePredefined, nil
 	}
 
 	return nil, "", fmt.Errorf("plex_session_id, plex_base_url, or source_id is required for Plex imports")
+}
+
+// addToWatchlist puts a matched watchlist import onto the importing
+// profile's watchlist (idempotent: the store insert is ON CONFLICT DO
+// NOTHING, so re-imports do not duplicate or reorder entries).
+func (s *Service) addToWatchlist(ctx context.Context, userID int, profileID, mediaItemID string, addedAt time.Time) error {
+	if s.stores == nil {
+		return fmt.Errorf("watchlist import: user store provider not configured")
+	}
+	store, err := s.stores.ForUser(ctx, userID)
+	if err != nil {
+		return fmt.Errorf("watchlist import: open user store: %w", err)
+	}
+	if err := store.AddToWatchlistAt(ctx, profileID, mediaItemID, addedAt); err != nil {
+		return fmt.Errorf("watchlist import: add %s: %w", mediaItemID, err)
+	}
+	return nil
 }
 
 func (s *Service) executeRun(run *Run, provider Provider) {
@@ -480,6 +499,18 @@ func (s *Service) executeRun(run *Run, provider Provider) {
 			continue
 		}
 		summary.Matched++
+
+		// Watchlist entries carry no watch state: the matched item joins the
+		// importing profile's watchlist and the progress pipeline is skipped.
+		if record.Watchlisted {
+			if err := s.addToWatchlist(ctx, run.UserID, run.ProfileID, match.MediaItemID, record.UpdatedAt); err != nil {
+				summary.Warnings = append(summary.Warnings, err.Error())
+			} else {
+				summary.WatchlistAdded++
+			}
+			s.persistProgressMaybe(ctx, run.ID, summary, i+1, len(records))
+			continue
+		}
 
 		shouldWriteProgress := true
 		localProgress, err := s.repo.GetProgress(ctx, run.UserID, run.ProfileID, match.MediaItemID)

--- a/internal/historyimport/types.go
+++ b/internal/historyimport/types.go
@@ -145,6 +145,7 @@ type Run struct {
 	Unmatched        int               `json:"unmatched"`
 	ProgressUpdated  int               `json:"progress_updated"`
 	HistoryCreated   int               `json:"history_created"`
+	WatchlistAdded   int               `json:"watchlist_added"`
 	Skipped          int               `json:"skipped"`
 	Warnings         []string          `json:"warnings"`
 	UnmatchedSamples []UnmatchedSample `json:"unmatched_samples"`
@@ -181,7 +182,11 @@ type Record struct {
 	LastPlayedAt    *time.Time
 	PositionSeconds float64
 	DurationSeconds float64
-	UpdatedAt       time.Time
+	// Watchlisted marks an entry from the source account's watchlist: the
+	// matched item is added to the importing profile's watchlist instead of
+	// receiving watch state.
+	Watchlisted bool
+	UpdatedAt   time.Time
 }
 
 type Match struct {
@@ -239,6 +244,7 @@ type ExecutionSummary struct {
 	Unmatched             int
 	ProgressUpdated       int
 	HistoryCreated        int
+	WatchlistAdded        int
 	Skipped               int
 	Warnings              []string
 	UnmatchedSamples      []UnmatchedSample
@@ -252,6 +258,10 @@ type localProgressRow struct {
 type plexAuth struct {
 	BaseURL string
 	Token   string
+	// AccountToken is the plex.tv account token (PIN/OAuth session token or
+	// the user-supplied token), used for account-level fetches such as the
+	// watchlist. May equal Token for manual-token imports.
+	AccountToken string
 }
 
 // --- Admin types ---

--- a/internal/jellycompat/content_direct_test.go
+++ b/internal/jellycompat/content_direct_test.go
@@ -284,7 +284,7 @@ func (s *progressCountingStore) IsFavorite(context.Context, string, string) (boo
 func (s *progressCountingStore) AddToWatchlist(context.Context, string, string) error {
 	panic("unused")
 }
-func (s *progressCountingStore) AddToWatchlistAt(context.Context, string, string, time.Time) error {
+func (s *progressCountingStore) AddToWatchlistAt(context.Context, string, string, time.Time) (bool, error) {
 	panic("unused")
 }
 func (s *progressCountingStore) RemoveWatchedFromWatchlist(context.Context, string) (bool, error) {

--- a/internal/userdb/favorites.go
+++ b/internal/userdb/favorites.go
@@ -116,17 +116,25 @@ func ListFavoritesByMediaItems(db *sql.DB, profileID string, mediaItemIDs []stri
 // AddToWatchlist adds a media item to a profile's watchlist.
 // If the item is already on the watchlist, the operation is a no-op.
 func AddToWatchlist(db *sql.DB, profileID, mediaItemID string) error {
-	return AddToWatchlistAt(db, profileID, mediaItemID, time.Now().UTC())
+	_, err := AddToWatchlistAt(db, profileID, mediaItemID, time.Now().UTC())
+	return err
 }
 
 // AddToWatchlistAt adds a media item to a profile's watchlist with an explicit
 // added-at timestamp (used when importing from an external provider).
-func AddToWatchlistAt(db *sql.DB, profileID, mediaItemID string, addedAt time.Time) error {
-	_, err := db.Exec(
+func AddToWatchlistAt(db *sql.DB, profileID, mediaItemID string, addedAt time.Time) (bool, error) {
+	result, err := db.Exec(
 		`INSERT OR IGNORE INTO watchlist (profile_id, media_item_id, added_at) VALUES (?, ?, ?)`,
 		profileID, mediaItemID, addedAt.UTC().Format(time.RFC3339),
 	)
-	return err
+	if err != nil {
+		return false, err
+	}
+	rows, err := result.RowsAffected()
+	if err != nil {
+		return false, err
+	}
+	return rows > 0, nil
 }
 
 // RemoveFromWatchlist removes a media item from a profile's watchlist.

--- a/internal/userdb/sqlitestore.go
+++ b/internal/userdb/sqlitestore.go
@@ -196,7 +196,7 @@ func (s *SQLiteUserStore) AddToWatchlist(_ context.Context, profileID, mediaItem
 	return AddToWatchlist(s.db, profileID, mediaItemID)
 }
 
-func (s *SQLiteUserStore) AddToWatchlistAt(_ context.Context, profileID, mediaItemID string, addedAt time.Time) error {
+func (s *SQLiteUserStore) AddToWatchlistAt(_ context.Context, profileID, mediaItemID string, addedAt time.Time) (bool, error) {
 	return AddToWatchlistAt(s.db, profileID, mediaItemID, addedAt)
 }
 

--- a/internal/userdb/watchlist_order_test.go
+++ b/internal/userdb/watchlist_order_test.go
@@ -33,7 +33,7 @@ func TestWatchlistOrderMirrorsProviderSequence(t *testing.T) {
 	// Add in one order (added_at ascending a, b, c).
 	base := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
 	for i, id := range []string{"a", "b", "c"} {
-		if err := AddToWatchlistAt(db, profile, id, base.Add(time.Duration(i)*time.Hour)); err != nil {
+		if _, err := AddToWatchlistAt(db, profile, id, base.Add(time.Duration(i)*time.Hour)); err != nil {
 			t.Fatalf("AddToWatchlistAt %s: %v", id, err)
 		}
 	}
@@ -52,7 +52,7 @@ func TestWatchlistOrderMirrorsProviderSequence(t *testing.T) {
 	}
 
 	// A locally-added item (no synced index) sorts after the ordered ones.
-	if err := AddToWatchlistAt(db, profile, "d", base.Add(10*time.Hour)); err != nil {
+	if _, err := AddToWatchlistAt(db, profile, "d", base.Add(10*time.Hour)); err != nil {
 		t.Fatalf("AddToWatchlistAt d: %v", err)
 	}
 	if got := watchlistIDs(t, db, profile); !equalStrings(got, []string{"c", "a", "b", "d"}) {

--- a/internal/userstore/pgstore/favorites.go
+++ b/internal/userstore/pgstore/favorites.go
@@ -106,17 +106,21 @@ func (s *PostgresUserStore) ListFavoritesByMediaItems(ctx context.Context, profi
 // --- Watchlist ---
 
 func (s *PostgresUserStore) AddToWatchlist(ctx context.Context, profileID, mediaItemID string) error {
-	return s.AddToWatchlistAt(ctx, profileID, mediaItemID, time.Now().UTC())
+	_, err := s.AddToWatchlistAt(ctx, profileID, mediaItemID, time.Now().UTC())
+	return err
 }
 
-func (s *PostgresUserStore) AddToWatchlistAt(ctx context.Context, profileID, mediaItemID string, addedAt time.Time) error {
-	_, err := s.pool.Exec(ctx,
+func (s *PostgresUserStore) AddToWatchlistAt(ctx context.Context, profileID, mediaItemID string, addedAt time.Time) (bool, error) {
+	tag, err := s.pool.Exec(ctx,
 		`INSERT INTO user_watchlist (user_id, profile_id, media_item_id, added_at)
 		 VALUES ($1, $2, $3, $4)
 		 ON CONFLICT DO NOTHING`,
 		s.userID, profileID, mediaItemID, addedAt.UTC(),
 	)
-	return err
+	if err != nil {
+		return false, err
+	}
+	return tag.RowsAffected() > 0, nil
 }
 
 func (s *PostgresUserStore) RemoveFromWatchlist(ctx context.Context, profileID, mediaItemID string) error {

--- a/internal/userstore/store.go
+++ b/internal/userstore/store.go
@@ -64,7 +64,7 @@ type UserStore interface {
 	ListFavoritesByMediaItems(ctx context.Context, profileID string, mediaItemIDs []string) (map[string]bool, error)
 	IsFavorite(ctx context.Context, profileID, mediaItemID string) (bool, error)
 	AddToWatchlist(ctx context.Context, profileID, mediaItemID string) error
-	AddToWatchlistAt(ctx context.Context, profileID, mediaItemID string, addedAt time.Time) error
+	AddToWatchlistAt(ctx context.Context, profileID, mediaItemID string, addedAt time.Time) (bool, error)
 	RemoveFromWatchlist(ctx context.Context, profileID, mediaItemID string) error
 	// ReplaceWatchlistOrder mirrors a provider's watchlist order: the given ids
 	// get sort_index 0..N-1 in order; all other rows reset to added_at ordering.

--- a/internal/watchsync/lists.go
+++ b/internal/watchsync/lists.go
@@ -169,7 +169,8 @@ func (s *Service) watchlistBinding() listBinding {
 			return res, true, err
 		},
 		localAdd: func(ctx context.Context, store userstore.UserStore, profileID, mediaItemID string, at time.Time) error {
-			return store.AddToWatchlistAt(ctx, profileID, mediaItemID, at)
+			_, err := store.AddToWatchlistAt(ctx, profileID, mediaItemID, at)
+			return err
 		},
 		localRemove: func(ctx context.Context, store userstore.UserStore, profileID, mediaItemID string) error {
 			return store.RemoveFromWatchlist(ctx, profileID, mediaItemID)

--- a/migrations/sql/20260702193158_history_import_watchlist_added.sql
+++ b/migrations/sql/20260702193158_history_import_watchlist_added.sql
@@ -1,0 +1,12 @@
+-- +goose Up
+-- +goose StatementBegin
+-- Plex watchlist import (issue #245): count of watchlist entries added to
+-- the importing profile during a history import run.
+ALTER TABLE history_import_runs
+ADD COLUMN watchlist_added integer NOT NULL DEFAULT 0;
+-- +goose StatementEnd
+
+-- +goose Down
+-- +goose StatementBegin
+ALTER TABLE history_import_runs DROP COLUMN IF EXISTS watchlist_added;
+-- +goose StatementEnd

--- a/web/src/api/types.ts
+++ b/web/src/api/types.ts
@@ -421,6 +421,7 @@ export interface HistoryImportRun {
   unmatched: number;
   progress_updated: number;
   history_created: number;
+  watchlist_added: number;
   skipped: number;
   warnings: string[];
   unmatched_samples: HistoryImportUnmatchedSample[];

--- a/web/src/pages/AdminHistoryImport.tsx
+++ b/web/src/pages/AdminHistoryImport.tsx
@@ -1236,6 +1236,10 @@ function RunsSection({ sourceId }: { sourceId: number }) {
                           <p>{run.history_created}</p>
                         </div>
                         <div>
+                          <p className="font-medium">Watchlist</p>
+                          <p>{run.watchlist_added}</p>
+                        </div>
+                        <div>
                           <p className="font-medium">Skipped</p>
                           <p>{run.skipped}</p>
                         </div>

--- a/web/src/pages/settings/HistoryImportSettings.tsx
+++ b/web/src/pages/settings/HistoryImportSettings.tsx
@@ -840,6 +840,7 @@ function RunSummary({ run }: { run: HistoryImportRun | null }) {
         <MetricCard label="Unmatched" value={run.unmatched} accent="warning" />
         <MetricCard label="Progress" value={run.progress_updated} accent="positive" />
         <MetricCard label="History" value={run.history_created} accent="positive" />
+        <MetricCard label="Watchlist" value={run.watchlist_added} accent="positive" />
         <MetricCard label="Skipped" value={run.skipped} />
       </div>
 


### PR DESCRIPTION
## Problem

The Plex import migrated only watch history — the user's saved Plex watchlist was left behind and had to be rebuilt manually (#245).

## Approach

- **`PlexClient.FetchWatchlist`** pages the account-level watchlist on the Plex discover API (`discover.provider.plex.tv`). Watchlists belong to the plex.tv **account**, not a PMS, so it authenticates with the account token: the PIN/OAuth session token, now threaded through `plexAuth.AccountToken` (manual-token imports pass the user-supplied token, which doubles as the account token).
- Watchlist entries become import `Record`s flagged `Watchlisted` — identity only (`movie`/`show` → movie/series kinds, guids parsed into imdb/tmdb/tvdb ids), no watch state. They ride the **existing matcher** (series matching already existed), and matched entries land on the importing profile's watchlist via the idempotent `AddToWatchlistAt` (`ON CONFLICT DO NOTHING`) — re-imports never duplicate or reorder.
- A watchlist fetch failure downgrades to a run **warning**, so the history import still completes (the watchlist is a bonus, not a gate).
- Run summaries gain a `watchlist_added` counter: new column + repo plumbing + a metric card in both the client settings page and the admin import view.

Distinct from #227 (continuous Trakt/Simkl/MDBList sync) — this is the one-time Plex migration path.

## Testing

- httptest-backed `FetchWatchlist` tests: pagination, account-token header, and a runaway-pagination guard (huge totalSize + empty pages must not loop).
- Normalizer tests: movie/show kind mapping, guid parsing, watchlisted flag, no-watch-state invariant.
- Full historyimport suite green; `tsc` clean.
- Not live-validated: exercising the real discover API requires a Plex account login (PIN flow); the run path reuses the existing import pipeline end to end.

Fixes #245

## AI-use disclosure

Implemented with Claude Code (test-first); human-reviewed before submission.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * History imports can now add watched items directly to your watchlist.
  * Plex imports now include watchlist items in addition to watch history.
  * Admin and settings views now show a watchlist-added count for each import run.

* **Bug Fixes**
  * Import runs now track watchlist additions more accurately.
  * Watchlist imports are handled safely so a failed watchlist fetch won’t stop the rest of the import.

* **Tests**
  * Added coverage for Plex watchlist import behavior and run counting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->