### PR TITLE
feat(collections): back collections with user-authored Trakt lists

### DIFF
--- a/internal/api/handlers/library_collections.go
+++ b/internal/api/handlers/library_collections.go
@@ -487,13 +487,16 @@ type importTMDBDiscoverSpecBody struct {
 }
 
 type importTraktRequest struct {
-	LibraryID         int    `json:"library_id"`
-	LibraryIDs        []int  `json:"library_ids"`
-	Title             string `json:"title"`
-	Description       string `json:"description"`
-	Preset            string `json:"preset"`
-	MediaType         string `json:"media_type"`
-	ProfileID         string `json:"profile_id,omitempty"`
+	LibraryID   int    `json:"library_id"`
+	LibraryIDs  []int  `json:"library_ids"`
+	Title       string `json:"title"`
+	Description string `json:"description"`
+	Preset      string `json:"preset"`
+	MediaType   string `json:"media_type"`
+	ProfileID   string `json:"profile_id,omitempty"`
+	// ListURL selects a user-authored Trakt list
+	// (https://trakt.tv/users/{user}/lists/{slug}) instead of a preset.
+	ListURL           string `json:"list_url,omitempty"`
 	Limit             *int   `json:"limit,omitempty"`
 	Featured          bool   `json:"featured"`
 	PosterURL         string `json:"poster_url"`
@@ -2996,10 +2999,20 @@ func (h *LibraryCollectionHandler) HandleImportTraktCollection(w http.ResponseWr
 		writeError(w, http.StatusBadRequest, "bad_request", "library_id/library_ids and title are required")
 		return
 	}
-	preset, mediaType, profileID, err := normalizeTraktPresetRequest(req.Preset, req.MediaType, req.ProfileID)
-	if err != nil {
-		writeError(w, http.StatusBadRequest, "bad_request", err.Error())
-		return
+	listURL := strings.TrimSpace(req.ListURL)
+	var preset, mediaType, profileID string
+	if listURL != "" {
+		if _, _, err := catalog.ParseTraktListURL(listURL); err != nil {
+			writeError(w, http.StatusBadRequest, "bad_request", err.Error())
+			return
+		}
+	} else {
+		var err error
+		preset, mediaType, profileID, err = normalizeTraktPresetRequest(req.Preset, req.MediaType, req.ProfileID)
+		if err != nil {
+			writeError(w, http.StatusBadRequest, "bad_request", err.Error())
+			return
+		}
 	}
 	if req.Limit != nil && *req.Limit <= 0 {
 		writeError(w, http.StatusBadRequest, "bad_request", "limit must be greater than 0")
@@ -3015,7 +3028,16 @@ func (h *LibraryCollectionHandler) HandleImportTraktCollection(w http.ResponseWr
 		syncSchedule = &s
 	}
 
-	sourceConfig, err := buildTraktSourceConfig(preset, mediaType, profileID, req.Limit)
+	var sourceConfig json.RawMessage
+	var sourceURL string
+	var err error
+	if listURL != "" {
+		sourceConfig, err = buildTraktListSourceConfig(listURL, req.Limit)
+		sourceURL = listURL
+	} else {
+		sourceConfig, err = buildTraktSourceConfig(preset, mediaType, profileID, req.Limit)
+		sourceURL = buildTraktSourceURL(preset, mediaType, profileID)
+	}
 	if err != nil {
 		writeError(w, http.StatusInternalServerError, "internal_error", "Failed to build source config")
 		return
@@ -3036,7 +3058,7 @@ func (h *LibraryCollectionHandler) HandleImportTraktCollection(w http.ResponseWr
 		Visibility:       "visible",
 		Featured:         req.Featured,
 		PosterURL:        req.PosterURL,
-		SourceURL:        buildTraktSourceURL(preset, mediaType, profileID),
+		SourceURL:        sourceURL,
 		SourceConfig:     sourceConfig,
 		ManagementMode:   managementMode,
 		ManagementSource: managementSource,
@@ -3493,6 +3515,23 @@ func buildTMDBDiscoverSourceConfig(mediaType string, spec importTMDBDiscoverSpec
 // source_config.
 func buildTMDBDiscoverSourceURL(mediaType, sortBy string) string {
 	return fmt.Sprintf("tmdb://discover/%s?sort_by=%s", mediaType, sortBy)
+}
+
+// buildTraktListSourceConfig builds the source config for a user-authored
+// Trakt list (mode trakt_list, issue #214).
+func buildTraktListSourceConfig(listURL string, limit *int) (json.RawMessage, error) {
+	payload := struct {
+		Mode     string `json:"mode"`
+		Provider string `json:"provider"`
+		URL      string `json:"url"`
+		Limit    *int   `json:"limit,omitempty"`
+	}{
+		Mode:     "trakt_list",
+		Provider: "trakt",
+		URL:      listURL,
+		Limit:    limit,
+	}
+	return json.Marshal(payload)
 }
 
 func buildTraktSourceConfig(preset, mediaType, profileID string, limit *int) (json.RawMessage, error) {

--- a/internal/api/handlers/library_collections.go
+++ b/internal/api/handlers/library_collections.go
@@ -3524,11 +3524,13 @@ func buildTraktListSourceConfig(listURL string, limit *int) (json.RawMessage, er
 		Mode     string `json:"mode"`
 		Provider string `json:"provider"`
 		URL      string `json:"url"`
+		ListURL  string `json:"list_url"`
 		Limit    *int   `json:"limit,omitempty"`
 	}{
 		Mode:     "trakt_list",
 		Provider: "trakt",
 		URL:      listURL,
+		ListURL:  listURL,
 		Limit:    limit,
 	}
 	return json.Marshal(payload)

--- a/internal/api/router.go
+++ b/internal/api/router.go
@@ -2962,6 +2962,27 @@ func (a *traktCollectionAdapter) GetCollectionPreset(ctx context.Context, preset
 	return entries, nil
 }
 
+func (a *traktCollectionAdapter) GetUserList(ctx context.Context, user, list string, limit int, accessToken string) ([]catalog.TraktCollectionEntry, error) {
+	results, err := a.client.GetUserList(ctx, user, list, limit, accessToken)
+	if err != nil {
+		return nil, err
+	}
+	entries := make([]catalog.TraktCollectionEntry, len(results))
+	for i, r := range results {
+		entries[i] = catalog.TraktCollectionEntry{
+			TraktID:   r.TraktID,
+			TMDBID:    r.TMDBID,
+			TVDBID:    r.TVDBID,
+			IMDbID:    r.IMDbID,
+			MediaType: r.MediaType,
+			Title:     r.Title,
+			Year:      r.Year,
+			Rank:      r.Rank,
+		}
+	}
+	return entries, nil
+}
+
 // llmConfigFromServer derives the shared AI client config from the server
 // config. Used at construction and again on every config reload.
 func llmConfigFromServer(cfg *config.Config) llm.Config {

--- a/internal/catalog/library_collection_service.go
+++ b/internal/catalog/library_collection_service.go
@@ -8,6 +8,7 @@ import (
 	"io"
 	"log/slog"
 	"net/http"
+	"net/url"
 	"strings"
 	"time"
 
@@ -82,6 +83,9 @@ type TMDBDiscoverFetcher interface {
 // TraktCollectionFetcher abstracts the Trakt discovery API.
 type TraktCollectionFetcher interface {
 	GetCollectionPreset(ctx context.Context, preset, mediaType string, limit int, accessToken string) ([]TraktCollectionEntry, error)
+	// GetUserList fetches a user-authored Trakt list in list order. Public
+	// lists need no access token.
+	GetUserList(ctx context.Context, user, list string, limit int, accessToken string) ([]TraktCollectionEntry, error)
 }
 
 // TraktAccessTokenResolver returns a profile-scoped Trakt access token for
@@ -234,6 +238,8 @@ func (s *LibraryCollectionService) SyncCollectionWithOptions(ctx context.Context
 		return s.syncTMDBDiscoverCollection(ctx, collection, source, opts)
 	case "trakt_preset":
 		return s.syncTraktPresetCollection(ctx, collection, source, opts)
+	case "trakt_list":
+		return s.syncTraktListCollection(ctx, collection, source, opts)
 	default:
 		return nil, fmt.Errorf("unsupported collection sync mode: %s", source.Mode)
 	}
@@ -965,6 +971,88 @@ func (s *LibraryCollectionService) syncTraktPresetCollection(ctx context.Context
 		"count", len(results),
 	)
 
+	return s.completeTraktEntrySync(ctx, collection, results, cfg.Limit, startedAt, opts)
+}
+
+// syncTraktListCollection populates a collection from a user-authored Trakt
+// list (issue #214). The list reference comes from cfg.URL, a trakt.tv list
+// URL like https://trakt.tv/users/{user}/lists/{slug}. Lists mix movies and
+// shows; matching and ordering reuse the preset pipeline.
+func (s *LibraryCollectionService) syncTraktListCollection(ctx context.Context, collection *models.LibraryCollection, cfg libraryCollectionSourceConfig, opts SyncCollectionOptions) (*models.LibraryCollectionSyncRun, error) {
+	startedAt := syncTimestamp()
+
+	if s.TraktCollections == nil {
+		return nil, fmt.Errorf("Trakt list sync requires configured Trakt access")
+	}
+	listURL := strings.TrimSpace(cfg.URL)
+	if listURL == "" {
+		listURL = strings.TrimSpace(collection.SourceURL)
+	}
+	user, list, err := ParseTraktListURL(listURL)
+	if err != nil {
+		return s.recordFailedCollectionSync(ctx, collection.ID, startedAt, err.Error())
+	}
+
+	fetchLimit := collectionutil.SourceFetchLimit(cfg.Limit)
+	results, err := s.TraktCollections.GetUserList(ctx, user, list, fetchLimit, "")
+	if err != nil {
+		return nil, fmt.Errorf("fetching Trakt list %s/%s: %w", user, list, err)
+	}
+
+	slog.Info("Trakt list sync: fetched results",
+		"collection_id", collection.ID,
+		"user", user,
+		"list", list,
+		"count", len(results),
+	)
+
+	return s.completeTraktEntrySync(ctx, collection, results, cfg.Limit, startedAt, opts)
+}
+
+// ParseTraktListURL extracts the user and list slug from a trakt.tv list URL
+// (https://trakt.tv/users/{user}/lists/{slug}[?...]) or a bare
+// "{user}/{slug}" shorthand.
+func ParseTraktListURL(raw string) (user, list string, err error) {
+	trimmed := strings.TrimSpace(raw)
+	if trimmed == "" {
+		return "", "", fmt.Errorf("Trakt list sync: url is required")
+	}
+	badFormat := func() (string, string, error) {
+		return "", "", fmt.Errorf("Trakt list sync: expected a URL like https://trakt.tv/users/{user}/lists/{list}, got %q", raw)
+	}
+	isURL := strings.Contains(trimmed, "://") || strings.Contains(strings.ToLower(trimmed), "trakt.tv")
+	if isURL {
+		normalized := trimmed
+		if !strings.Contains(normalized, "://") {
+			normalized = "https://" + normalized
+		}
+		parsed, parseErr := url.Parse(normalized)
+		if parseErr != nil {
+			return "", "", fmt.Errorf("Trakt list sync: invalid url %q", raw)
+		}
+		parts := strings.Split(strings.Trim(parsed.Path, "/"), "/")
+		if len(parts) != 4 || parts[0] != "users" || parts[2] != "lists" {
+			return badFormat()
+		}
+		user, list = parts[1], parts[3]
+	} else {
+		// Bare "{user}/{slug}" shorthand.
+		parts := strings.Split(strings.Trim(trimmed, "/"), "/")
+		if len(parts) != 2 {
+			return badFormat()
+		}
+		user, list = parts[0], parts[1]
+	}
+	if user == "" || list == "" {
+		return badFormat()
+	}
+	return user, list, nil
+}
+
+// completeTraktEntrySync matches fetched Trakt entries against the
+// collection's libraries and records the sync run. Shared by the preset and
+// user-list sources.
+func (s *LibraryCollectionService) completeTraktEntrySync(ctx context.Context, collection *models.LibraryCollection, results []TraktCollectionEntry, limit *int, startedAt time.Time, opts SyncCollectionOptions) (*models.LibraryCollectionSyncRun, error) {
 	matchedItems := make([]LibraryCollectionItemInput, 0, len(results))
 	seenContentIDs := make(map[string]int, len(results))
 	warnings := make([]string, 0)
@@ -1005,7 +1093,7 @@ func (s *LibraryCollectionService) syncTraktPresetCollection(ctx context.Context
 			Position:    len(matchedItems),
 			SourceRank:  sourceRank,
 		})
-		if collectionutil.ItemLimitReached(len(matchedItems), cfg.Limit) {
+		if collectionutil.ItemLimitReached(len(matchedItems), limit) {
 			limitReached = true
 			break
 		}

--- a/internal/catalog/library_collection_service.go
+++ b/internal/catalog/library_collection_service.go
@@ -162,6 +162,7 @@ type libraryCollectionSourceConfig struct {
 	Provider   string              `json:"provider,omitempty"`
 	Preset     string              `json:"preset,omitempty"`
 	URL        string              `json:"url,omitempty"`
+	ListURL    string              `json:"list_url,omitempty"`
 	MediaType  string              `json:"media_type,omitempty"`
 	TimeWindow string              `json:"time_window,omitempty"`
 	ProfileID  string              `json:"profile_id,omitempty"`
@@ -984,7 +985,10 @@ func (s *LibraryCollectionService) syncTraktListCollection(ctx context.Context, 
 	if s.TraktCollections == nil {
 		return nil, fmt.Errorf("Trakt list sync requires configured Trakt access")
 	}
-	listURL := strings.TrimSpace(cfg.URL)
+	listURL := strings.TrimSpace(cfg.ListURL)
+	if listURL == "" {
+		listURL = strings.TrimSpace(cfg.URL)
+	}
 	if listURL == "" {
 		listURL = strings.TrimSpace(collection.SourceURL)
 	}
@@ -1029,6 +1033,10 @@ func ParseTraktListURL(raw string) (user, list string, err error) {
 		parsed, parseErr := url.Parse(normalized)
 		if parseErr != nil {
 			return "", "", fmt.Errorf("Trakt list sync: invalid url %q", raw)
+		}
+		host := strings.ToLower(parsed.Hostname())
+		if host != "trakt.tv" && host != "www.trakt.tv" {
+			return badFormat()
 		}
 		parts := strings.Split(strings.Trim(parsed.Path, "/"), "/")
 		if len(parts) != 4 || parts[0] != "users" || parts[2] != "lists" {

--- a/internal/catalog/trakt_list_url_test.go
+++ b/internal/catalog/trakt_list_url_test.go
@@ -11,11 +11,14 @@ func TestParseTraktListURL(t *testing.T) {
 		wantErr bool
 	}{
 		{"full url", "https://trakt.tv/users/jjjonesjr33/lists/saw-cinematic-universe-in-timeline-order", "jjjonesjr33", "saw-cinematic-universe-in-timeline-order", false},
+		{"www url", "https://www.trakt.tv/users/someone/lists/best-of", "someone", "best-of", false},
+		{"mixed-case host", "https://Trakt.TV/users/someone/lists/best-of", "someone", "best-of", false},
 		{"url with query", "https://trakt.tv/users/someone/lists/best-of?sort=rank,asc", "someone", "best-of", false},
 		{"no scheme", "trakt.tv/users/someone/lists/best-of", "someone", "best-of", false},
 		{"shorthand", "someone/best-of", "someone", "best-of", false},
 		{"trailing slash", "https://trakt.tv/users/someone/lists/best-of/", "someone", "best-of", false},
 		{"empty", "", "", "", true},
+		{"wrong host", "https://example.com/users/someone/lists/best-of", "", "", true},
 		{"not a list url", "https://trakt.tv/movies/trending", "", "", true},
 		{"missing slug", "https://trakt.tv/users/someone/lists/", "", "", true},
 	}

--- a/internal/catalog/trakt_list_url_test.go
+++ b/internal/catalog/trakt_list_url_test.go
@@ -1,0 +1,39 @@
+package catalog
+
+import "testing"
+
+func TestParseTraktListURL(t *testing.T) {
+	cases := []struct {
+		name    string
+		in      string
+		user    string
+		list    string
+		wantErr bool
+	}{
+		{"full url", "https://trakt.tv/users/jjjonesjr33/lists/saw-cinematic-universe-in-timeline-order", "jjjonesjr33", "saw-cinematic-universe-in-timeline-order", false},
+		{"url with query", "https://trakt.tv/users/someone/lists/best-of?sort=rank,asc", "someone", "best-of", false},
+		{"no scheme", "trakt.tv/users/someone/lists/best-of", "someone", "best-of", false},
+		{"shorthand", "someone/best-of", "someone", "best-of", false},
+		{"trailing slash", "https://trakt.tv/users/someone/lists/best-of/", "someone", "best-of", false},
+		{"empty", "", "", "", true},
+		{"not a list url", "https://trakt.tv/movies/trending", "", "", true},
+		{"missing slug", "https://trakt.tv/users/someone/lists/", "", "", true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			user, list, err := ParseTraktListURL(tc.in)
+			if tc.wantErr {
+				if err == nil {
+					t.Fatalf("ParseTraktListURL(%q) = %q/%q, want error", tc.in, user, list)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("ParseTraktListURL(%q): %v", tc.in, err)
+			}
+			if user != tc.user || list != tc.list {
+				t.Fatalf("ParseTraktListURL(%q) = %q/%q, want %q/%q", tc.in, user, list, tc.user, tc.list)
+			}
+		})
+	}
+}

--- a/internal/metadata/trakt/client.go
+++ b/internal/metadata/trakt/client.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"net/url"
 	"strconv"
 	"strings"
 	"time"
@@ -118,6 +119,67 @@ func collectionPresetPath(preset, mediaType string) (string, error) {
 	default:
 		return "", fmt.Errorf("trakt: preset must be trending, popular, or recommended")
 	}
+}
+
+// GetUserList fetches the items of a user-authored Trakt list
+// (/users/{user}/lists/{list}/items), preserving list order. Lists mix
+// movies and shows; unknown item types (people, episodes, seasons) are
+// skipped. Public lists need only the app client id; accessToken is passed
+// through for the owner's private lists.
+func (c *Client) GetUserList(ctx context.Context, user, list string, limit int, accessToken string) ([]CollectionEntry, error) {
+	user = strings.TrimSpace(user)
+	list = strings.TrimSpace(list)
+	if user == "" || list == "" {
+		return nil, errors.New("trakt: user list requires user and list slug")
+	}
+	if limit <= 0 {
+		limit = defaultCollectionPageLimit
+	}
+	if limit > maxCollectionPresetResults {
+		limit = maxCollectionPresetResults
+	}
+
+	basePath := fmt.Sprintf("/users/%s/lists/%s/items", url.PathEscape(user), url.PathEscape(list))
+	results := make([]CollectionEntry, 0, limit)
+	for page := 1; len(results) < limit; page++ {
+		pageLimit := limit - len(results)
+		if pageLimit > defaultCollectionPageLimit {
+			pageLimit = defaultCollectionPageLimit
+		}
+		var resp []struct {
+			Rank  int         `json:"rank"`
+			Type  string      `json:"type"`
+			Movie *traktMedia `json:"movie"`
+			Show  *traktMedia `json:"show"`
+		}
+		reqPath := fmt.Sprintf("%s?page=%d&limit=%d", basePath, page, pageLimit)
+		if err := c.doGet(ctx, reqPath, accessToken, &resp); err != nil {
+			return nil, err
+		}
+		if len(resp) == 0 {
+			break
+		}
+		for _, row := range resp {
+			var entry CollectionEntry
+			switch {
+			case row.Type == "movie" && row.Movie != nil:
+				entry = row.Movie.entry("movie")
+			case row.Type == "show" && row.Show != nil:
+				entry = row.Show.entry("tv")
+			default:
+				continue
+			}
+			entry.Rank = row.Rank
+			results = append(results, entry)
+			if len(results) >= limit {
+				break
+			}
+		}
+		if len(resp) < pageLimit {
+			break
+		}
+	}
+	return results, nil
 }
 
 func (c *Client) getTrending(ctx context.Context, path, mediaType, accessToken string) ([]CollectionEntry, error) {

--- a/internal/metadata/trakt/user_list_test.go
+++ b/internal/metadata/trakt/user_list_test.go
@@ -1,0 +1,72 @@
+package trakt
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestGetUserListDecodesMixedTypesInListOrder(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/users/jjjonesjr33/lists/saw-timeline/items" {
+			t.Fatalf("path = %s, want /users/jjjonesjr33/lists/saw-timeline/items", r.URL.Path)
+		}
+		writeJSON(t, w, []map[string]any{
+			{
+				"rank": 1,
+				"type": "movie",
+				"movie": map[string]any{
+					"title": "Saw",
+					"year":  2004,
+					"ids":   map[string]any{"trakt": 10, "tmdb": 176, "imdb": "tt0387564"},
+				},
+			},
+			{
+				"rank": 2,
+				"type": "show",
+				"show": map[string]any{
+					"title": "Saw: The Series",
+					"year":  2024,
+					"ids":   map[string]any{"trakt": 11, "tvdb": 999001},
+				},
+			},
+			// Unknown types (person, episode, season) are skipped, not fatal.
+			{
+				"rank": 3,
+				"type": "person",
+			},
+		})
+	}))
+	defer server.Close()
+
+	client := NewClient("client-id", 1000)
+	client.SetBaseURL(server.URL)
+
+	results, err := client.GetUserList(context.Background(), "jjjonesjr33", "saw-timeline", 10, "")
+	if err != nil {
+		t.Fatalf("GetUserList: %v", err)
+	}
+	if len(results) != 2 {
+		t.Fatalf("results = %d, want 2 (unknown types skipped)", len(results))
+	}
+	if results[0].MediaType != "movie" || results[0].TMDBID != 176 || results[0].Title != "Saw" {
+		t.Fatalf("first entry = %+v, want the Saw movie", results[0])
+	}
+	if results[1].MediaType != "tv" || results[1].TVDBID != 999001 {
+		t.Fatalf("second entry = %+v, want the show mapped to media type tv", results[1])
+	}
+	if results[0].Rank != 1 || results[1].Rank != 2 {
+		t.Fatalf("ranks = %d,%d, want list order preserved", results[0].Rank, results[1].Rank)
+	}
+}
+
+func TestGetUserListRequiresUserAndSlug(t *testing.T) {
+	client := NewClient("client-id", 1000)
+	if _, err := client.GetUserList(context.Background(), "", "slug", 10, ""); err == nil {
+		t.Fatal("empty user must error")
+	}
+	if _, err := client.GetUserList(context.Background(), "user", "", 10, ""); err == nil {
+		t.Fatal("empty list slug must error")
+	}
+}

--- a/internal/sections/trending_refresher_test.go
+++ b/internal/sections/trending_refresher_test.go
@@ -64,6 +64,10 @@ type fakeTrakt struct {
 	errByType   map[string]error
 }
 
+func (f fakeTrakt) GetUserList(context.Context, string, string, int, string) ([]catalog.TraktCollectionEntry, error) {
+	return nil, nil
+}
+
 func (f fakeTrakt) GetCollectionPreset(_ context.Context, _, mediaType string, _ int, _ string) ([]catalog.TraktCollectionEntry, error) {
 	if err := f.errByType[mediaType]; err != nil {
 		return nil, err

--- a/web/src/api/types.ts
+++ b/web/src/api/types.ts
@@ -1630,9 +1630,12 @@ export interface ImportTraktCollectionRequest {
   library_ids?: number[];
   title: string;
   description?: string;
-  preset: "trending" | "popular" | "recommended";
-  media_type: "movie" | "tv";
+  // preset/media_type drive a discovery-feed collection; list_url drives a
+  // user-authored Trakt list. Exactly one path is used per request.
+  preset?: "trending" | "popular" | "recommended";
+  media_type?: "movie" | "tv";
   profile_id?: string;
+  list_url?: string;
   limit?: number;
   featured?: boolean;
   poster_url?: string;

--- a/web/src/pages/adminCollectionsShared.tsx
+++ b/web/src/pages/adminCollectionsShared.tsx
@@ -44,6 +44,7 @@ export type TMDBPreset =
   | "on_the_air";
 type TMDBMediaType = "movie" | "tv" | "all";
 type TMDBTimeWindow = "day" | "week";
+type TraktSourceKind = "preset" | "list";
 type TraktPreset = "trending" | "popular" | "recommended";
 type TraktMediaType = "movie" | "tv";
 
@@ -59,6 +60,11 @@ interface TraktPresetSourceConfig {
   mediaType: TraktMediaType;
   profileId: string;
   limit: string;
+}
+
+interface TraktSourceConfig extends TraktPresetSourceConfig {
+  sourceKind: TraktSourceKind;
+  listUrl: string;
 }
 
 export function buildAdminCollectionEditorPath(id: "new" | string, libraryId?: number | null) {
@@ -238,19 +244,27 @@ export function parseTMDBPresetSourceConfig(
 
 export function parseTraktPresetSourceConfig(
   collection: LibraryCollection | null,
-): TraktPresetSourceConfig {
+): TraktSourceConfig {
   const cfg = collection?.source_config;
+  const sourceKind: TraktSourceKind = cfg?.mode === "trakt_list" ? "list" : "preset";
   const preset: TraktPreset =
     cfg?.preset === "popular" || cfg?.preset === "recommended" || cfg?.preset === "trending"
       ? cfg.preset
       : "trending";
   const mediaType: TraktMediaType = cfg?.media_type === "tv" ? "tv" : "movie";
   const profileId = typeof cfg?.profile_id === "string" ? cfg.profile_id : "";
+  const configListUrl =
+    typeof cfg?.list_url === "string" && cfg.list_url.trim().length > 0
+      ? cfg.list_url
+      : typeof cfg?.url === "string" && cfg.url.trim().length > 0
+        ? cfg.url
+        : "";
+  const listUrl = configListUrl || collection?.source_url || "";
   const limit =
     typeof cfg?.limit === "number" && Number.isFinite(cfg.limit) && cfg.limit > 0
       ? String(cfg.limit)
       : "";
-  return { preset, mediaType, profileId, limit };
+  return { sourceKind, preset, mediaType, profileId, listUrl, limit };
 }
 
 export function buildTMDBPresetSourceInput({
@@ -280,6 +294,28 @@ export function buildTMDBPresetSourceInput({
     source_url: tmdbPresetNeedsTimeWindow(preset)
       ? `tmdb://${preset}/${normalizedMediaType}/${timeWindow}`
       : `tmdb://${preset}/${normalizedMediaType}`,
+    source_config,
+  };
+}
+
+function buildTraktListSourceInput({ listUrl, limit }: { listUrl: string; limit: string }): {
+  source_url: string;
+  source_config: Record<string, unknown>;
+} {
+  const trimmedListUrl = listUrl.trim();
+  const parsedLimit = parseOptionalPositiveInteger(limit);
+  const source_config: Record<string, unknown> = {
+    mode: "trakt_list",
+    provider: "trakt",
+    url: trimmedListUrl,
+    list_url: trimmedListUrl,
+  };
+  if (parsedLimit !== undefined) {
+    source_config.limit = parsedLimit;
+  }
+
+  return {
+    source_url: trimmedListUrl,
     source_config,
   };
 }
@@ -882,11 +918,10 @@ export function TraktPresetForm({
   );
   const [title, setTitle] = useState("");
   const [description, setDescription] = useState("");
-  const [sourceKind, setSourceKind] = useState<"preset" | "list">("preset");
+  const [sourceKind, setSourceKind] = useState<TraktSourceKind>("preset");
   const [listUrl, setListUrl] = useState("");
   const [preset, setPreset] = useState<TraktPreset>("trending");
   const [mediaType, setMediaType] = useState<TraktMediaType>("movie");
-  const eligibility = libraryEligibilityForMediaKind(mediaType);
   const [profileId, setProfileId] = useState("");
   const [limit, setLimit] = useState("");
   const [featured, setFeatured] = useState(true);
@@ -898,6 +933,7 @@ export function TraktPresetForm({
   const parsedLimit = parseOptionalPositiveInteger(limit);
   const hasInvalidLimit = limit.trim().length > 0 && parsedLimit === undefined;
   const isListMode = sourceKind === "list";
+  const eligibility = libraryEligibilityForMediaKind(isListMode ? "mixed" : mediaType);
   const requiresProfile = !isListMode && preset === "recommended";
   const missingProfile = requiresProfile && profileId.trim().length === 0;
   const missingListURL = isListMode && listUrl.trim().length === 0;
@@ -1001,7 +1037,7 @@ export function TraktPresetForm({
 
         <div className="space-y-2">
           <Label>Source</Label>
-          <Select value={sourceKind} onValueChange={(v) => setSourceKind(v as "preset" | "list")}>
+          <Select value={sourceKind} onValueChange={(v) => setSourceKind(v as TraktSourceKind)}>
             <SelectTrigger>
               <SelectValue />
             </SelectTrigger>
@@ -1347,6 +1383,8 @@ export function CollectionEditForm({
   const [tmdbMediaType, setTmdbMediaType] = useState<TMDBMediaType>(tmdbDefaults.mediaType);
   const [tmdbLimit, setTmdbLimit] = useState(tmdbDefaults.limit);
   const traktDefaults = parseTraktPresetSourceConfig(collection);
+  const [traktSourceKind, setTraktSourceKind] = useState<TraktSourceKind>(traktDefaults.sourceKind);
+  const [traktListUrl, setTraktListUrl] = useState(traktDefaults.listUrl);
   const [traktPreset, setTraktPreset] = useState<TraktPreset>(traktDefaults.preset);
   const [traktMediaType, setTraktMediaType] = useState<TraktMediaType>(traktDefaults.mediaType);
   const [traktProfileId, setTraktProfileId] = useState(traktDefaults.profileId);
@@ -1362,14 +1400,16 @@ export function CollectionEditForm({
   const hasInvalidTmdbLimit = tmdbLimit.trim().length > 0 && parsedTmdbLimit === undefined;
   const parsedTraktLimit = parseOptionalPositiveInteger(traktLimit);
   const hasInvalidTraktLimit = traktLimit.trim().length > 0 && parsedTraktLimit === undefined;
-  const traktNeedsProfile = traktPreset === "recommended";
+  const isTraktListMode = isTraktCollection && traktSourceKind === "list";
+  const traktNeedsProfile = !isTraktListMode && traktPreset === "recommended";
   const missingTraktProfile = isTraktCollection && traktNeedsProfile && traktProfileId === "";
+  const missingTraktListURL = isTraktListMode && traktListUrl.trim().length === 0;
   const allowedTMDBMediaTypes = getTMDBAllowedMediaTypes(tmdbPreset);
   const normalizedTMDBMediaType = normalizeTMDBPresetMediaType(tmdbPreset, tmdbMediaType);
   const editEligibility: LibraryEligibility | undefined = isTMDBCollection
     ? libraryEligibilityForMediaKind(normalizedTMDBMediaType)
     : isTraktCollection
-      ? libraryEligibilityForMediaKind(traktMediaType)
+      ? libraryEligibilityForMediaKind(isTraktListMode ? "mixed" : traktMediaType)
       : undefined;
 
   useEffect(() => {
@@ -1408,18 +1448,27 @@ export function CollectionEditForm({
       sourceUrlValue = tmdbSource.source_url;
       sourceConfig = tmdbSource.source_config;
     } else if (isTraktCollection) {
-      sourceUrlValue =
-        traktPreset === "recommended"
-          ? `trakt://${traktPreset}/${traktMediaType}/${traktProfileId}`
-          : `trakt://${traktPreset}/${traktMediaType}`;
-      sourceConfig = {
-        mode: "trakt_preset",
-        provider: "trakt",
-        preset: traktPreset,
-        media_type: traktMediaType,
-        ...(traktPreset === "recommended" ? { profile_id: traktProfileId } : {}),
-        ...(parsedTraktLimit ? { limit: parsedTraktLimit } : {}),
-      };
+      if (isTraktListMode) {
+        const traktListSource = buildTraktListSourceInput({
+          listUrl: traktListUrl,
+          limit: traktLimit,
+        });
+        sourceUrlValue = traktListSource.source_url;
+        sourceConfig = traktListSource.source_config;
+      } else {
+        sourceUrlValue =
+          traktPreset === "recommended"
+            ? `trakt://${traktPreset}/${traktMediaType}/${traktProfileId}`
+            : `trakt://${traktPreset}/${traktMediaType}`;
+        sourceConfig = {
+          mode: "trakt_preset",
+          provider: "trakt",
+          preset: traktPreset,
+          media_type: traktMediaType,
+          ...(traktPreset === "recommended" ? { profile_id: traktProfileId } : {}),
+          ...(parsedTraktLimit ? { limit: parsedTraktLimit } : {}),
+        };
+      }
     }
 
     const body: CreateLibraryCollectionRequest = {
@@ -1651,66 +1700,122 @@ export function CollectionEditForm({
         ) : null}
 
         {isTraktCollection ? (
-          <div className="grid gap-4 md:grid-cols-2">
+          <div className="space-y-4">
             <div className="space-y-2">
-              <Label>Preset</Label>
-              <Select value={traktPreset} onValueChange={(v) => setTraktPreset(v as TraktPreset)}>
-                <SelectTrigger>
-                  <SelectValue />
-                </SelectTrigger>
-                <SelectContent>
-                  <SelectItem value="trending">Trending</SelectItem>
-                  <SelectItem value="popular">Popular</SelectItem>
-                  <SelectItem value="recommended">Recommended</SelectItem>
-                </SelectContent>
-              </Select>
-            </div>
-            <div className="space-y-2">
-              <Label>Media Type</Label>
+              <Label>Source</Label>
               <Select
-                value={traktMediaType}
-                onValueChange={(v) => setTraktMediaType(v as TraktMediaType)}
+                value={traktSourceKind}
+                onValueChange={(v) => setTraktSourceKind(v as TraktSourceKind)}
               >
                 <SelectTrigger>
                   <SelectValue />
                 </SelectTrigger>
                 <SelectContent>
-                  <SelectItem value="movie">Movies</SelectItem>
-                  <SelectItem value="tv">TV Shows</SelectItem>
+                  <SelectItem value="preset">
+                    Discovery feed (Trending / Popular / Recommended)
+                  </SelectItem>
+                  <SelectItem value="list">User list (trakt.tv URL)</SelectItem>
                 </SelectContent>
               </Select>
             </div>
-            {traktNeedsProfile ? (
-              <div className="space-y-2">
-                <Label>Profile</Label>
-                <Select value={traktProfileId} onValueChange={setTraktProfileId}>
-                  <SelectTrigger>
-                    <SelectValue placeholder="Choose a profile" />
-                  </SelectTrigger>
-                  <SelectContent>
-                    {profiles.map((profile) => (
-                      <SelectItem key={profile.id} value={profile.id}>
-                        {profile.name}
-                      </SelectItem>
-                    ))}
-                  </SelectContent>
-                </Select>
+
+            {isTraktListMode ? (
+              <div className="grid gap-4 md:grid-cols-2">
+                <div className="space-y-2 md:col-span-2">
+                  <Label htmlFor="collection-trakt-list-url">Trakt list URL</Label>
+                  <Input
+                    id="collection-trakt-list-url"
+                    value={traktListUrl}
+                    onChange={(event) => setTraktListUrl(event.target.value)}
+                    placeholder="https://trakt.tv/users/jjjonesjr33/lists/saw-cinematic-universe-in-timeline-order"
+                    required
+                  />
+                  <p className="text-muted-foreground text-xs">
+                    Paste a public Trakt list URL. Movies and shows in the list are matched against
+                    the selected libraries in list order.
+                  </p>
+                </div>
+                <div className="space-y-2">
+                  <Label htmlFor="collection-trakt-limit">Max Items</Label>
+                  <Input
+                    id="collection-trakt-limit"
+                    type="number"
+                    min={1}
+                    max={200}
+                    step={1}
+                    inputMode="numeric"
+                    value={traktLimit}
+                    onChange={(event) => setTraktLimit(event.target.value)}
+                    placeholder="Defaults to 20"
+                  />
+                </div>
               </div>
-            ) : null}
-            <div className="space-y-2">
-              <Label htmlFor="collection-trakt-limit">Max Items</Label>
-              <Input
-                id="collection-trakt-limit"
-                type="number"
-                min={1}
-                max={200}
-                step={1}
-                inputMode="numeric"
-                value={traktLimit}
-                onChange={(event) => setTraktLimit(event.target.value)}
-                placeholder="Defaults to 20"
-              />
-            </div>
+            ) : (
+              <div className="grid gap-4 md:grid-cols-2">
+                <div className="space-y-2">
+                  <Label>Preset</Label>
+                  <Select
+                    value={traktPreset}
+                    onValueChange={(v) => setTraktPreset(v as TraktPreset)}
+                  >
+                    <SelectTrigger>
+                      <SelectValue />
+                    </SelectTrigger>
+                    <SelectContent>
+                      <SelectItem value="trending">Trending</SelectItem>
+                      <SelectItem value="popular">Popular</SelectItem>
+                      <SelectItem value="recommended">Recommended</SelectItem>
+                    </SelectContent>
+                  </Select>
+                </div>
+                <div className="space-y-2">
+                  <Label>Media Type</Label>
+                  <Select
+                    value={traktMediaType}
+                    onValueChange={(v) => setTraktMediaType(v as TraktMediaType)}
+                  >
+                    <SelectTrigger>
+                      <SelectValue />
+                    </SelectTrigger>
+                    <SelectContent>
+                      <SelectItem value="movie">Movies</SelectItem>
+                      <SelectItem value="tv">TV Shows</SelectItem>
+                    </SelectContent>
+                  </Select>
+                </div>
+                {traktNeedsProfile ? (
+                  <div className="space-y-2">
+                    <Label>Profile</Label>
+                    <Select value={traktProfileId} onValueChange={setTraktProfileId}>
+                      <SelectTrigger>
+                        <SelectValue placeholder="Choose a profile" />
+                      </SelectTrigger>
+                      <SelectContent>
+                        {profiles.map((profile) => (
+                          <SelectItem key={profile.id} value={profile.id}>
+                            {profile.name}
+                          </SelectItem>
+                        ))}
+                      </SelectContent>
+                    </Select>
+                  </div>
+                ) : null}
+                <div className="space-y-2">
+                  <Label htmlFor="collection-trakt-limit">Max Items</Label>
+                  <Input
+                    id="collection-trakt-limit"
+                    type="number"
+                    min={1}
+                    max={200}
+                    step={1}
+                    inputMode="numeric"
+                    value={traktLimit}
+                    onChange={(event) => setTraktLimit(event.target.value)}
+                    placeholder="Defaults to 20"
+                  />
+                </div>
+              </div>
+            )}
           </div>
         ) : null}
 
@@ -1751,6 +1856,7 @@ export function CollectionEditForm({
             missingSourceURL ||
             hasInvalidTmdbLimit ||
             hasInvalidTraktLimit ||
+            missingTraktListURL ||
             missingTraktProfile
           }
         >

--- a/web/src/pages/adminCollectionsShared.tsx
+++ b/web/src/pages/adminCollectionsShared.tsx
@@ -882,6 +882,8 @@ export function TraktPresetForm({
   );
   const [title, setTitle] = useState("");
   const [description, setDescription] = useState("");
+  const [sourceKind, setSourceKind] = useState<"preset" | "list">("preset");
+  const [listUrl, setListUrl] = useState("");
   const [preset, setPreset] = useState<TraktPreset>("trending");
   const [mediaType, setMediaType] = useState<TraktMediaType>("movie");
   const eligibility = libraryEligibilityForMediaKind(mediaType);
@@ -895,8 +897,10 @@ export function TraktPresetForm({
   const [syncSchedule, setSyncSchedule] = useState("");
   const parsedLimit = parseOptionalPositiveInteger(limit);
   const hasInvalidLimit = limit.trim().length > 0 && parsedLimit === undefined;
-  const requiresProfile = preset === "recommended";
+  const isListMode = sourceKind === "list";
+  const requiresProfile = !isListMode && preset === "recommended";
   const missingProfile = requiresProfile && profileId.trim().length === 0;
+  const missingListURL = isListMode && listUrl.trim().length === 0;
 
   useEffect(() => {
     const firstProfileID = profiles[0]?.id;
@@ -913,9 +917,13 @@ export function TraktPresetForm({
           library_ids: libraryIds,
           title,
           description,
-          preset,
-          media_type: mediaType,
-          profile_id: requiresProfile ? profileId : undefined,
+          ...(isListMode
+            ? { list_url: listUrl.trim() }
+            : {
+                preset,
+                media_type: mediaType,
+                profile_id: requiresProfile ? profileId : undefined,
+              }),
           limit: parsedLimit,
           featured,
           poster_source_url: posterSourceUrl.trim() || undefined,
@@ -939,8 +947,14 @@ export function TraktPresetForm({
             <CardTitle>Import Summary</CardTitle>
           </CardHeader>
           <CardContent className="space-y-4">
-            <SummaryRow label="Preset" value={getTraktPresetLabel(preset)} />
-            <SummaryRow label="Media" value={mediaType === "tv" ? "TV Shows" : "Movies"} />
+            {isListMode ? (
+              <SummaryRow label="Source" value="User list" />
+            ) : (
+              <>
+                <SummaryRow label="Preset" value={getTraktPresetLabel(preset)} />
+                <SummaryRow label="Media" value={mediaType === "tv" ? "TV Shows" : "Movies"} />
+              </>
+            )}
             {requiresProfile ? (
               <SummaryRow
                 label="Profile"
@@ -985,33 +999,65 @@ export function TraktPresetForm({
           />
         </div>
 
-        <div className="grid gap-4 md:grid-cols-2">
-          <div className="space-y-2">
-            <Label>Preset</Label>
-            <Select value={preset} onValueChange={(v) => setPreset(v as TraktPreset)}>
-              <SelectTrigger>
-                <SelectValue />
-              </SelectTrigger>
-              <SelectContent>
-                <SelectItem value="trending">Trending</SelectItem>
-                <SelectItem value="popular">Popular</SelectItem>
-                <SelectItem value="recommended">Recommended</SelectItem>
-              </SelectContent>
-            </Select>
-          </div>
-          <div className="space-y-2">
-            <Label>Media Type</Label>
-            <Select value={mediaType} onValueChange={(v) => setMediaType(v as TraktMediaType)}>
-              <SelectTrigger>
-                <SelectValue />
-              </SelectTrigger>
-              <SelectContent>
-                <SelectItem value="movie">Movies</SelectItem>
-                <SelectItem value="tv">TV Shows</SelectItem>
-              </SelectContent>
-            </Select>
-          </div>
+        <div className="space-y-2">
+          <Label>Source</Label>
+          <Select value={sourceKind} onValueChange={(v) => setSourceKind(v as "preset" | "list")}>
+            <SelectTrigger>
+              <SelectValue />
+            </SelectTrigger>
+            <SelectContent>
+              <SelectItem value="preset">
+                Discovery feed (Trending / Popular / Recommended)
+              </SelectItem>
+              <SelectItem value="list">User list (trakt.tv URL)</SelectItem>
+            </SelectContent>
+          </Select>
         </div>
+
+        {isListMode ? (
+          <div className="space-y-2">
+            <Label htmlFor="trakt-list-url">Trakt list URL</Label>
+            <Input
+              id="trakt-list-url"
+              value={listUrl}
+              onChange={(event) => setListUrl(event.target.value)}
+              placeholder="https://trakt.tv/users/jjjonesjr33/lists/saw-cinematic-universe-in-timeline-order"
+              required
+            />
+            <p className="text-muted-foreground text-xs">
+              Paste a public Trakt list URL. Movies and shows in the list are matched against the
+              selected libraries in list order.
+            </p>
+          </div>
+        ) : (
+          <div className="grid gap-4 md:grid-cols-2">
+            <div className="space-y-2">
+              <Label>Preset</Label>
+              <Select value={preset} onValueChange={(v) => setPreset(v as TraktPreset)}>
+                <SelectTrigger>
+                  <SelectValue />
+                </SelectTrigger>
+                <SelectContent>
+                  <SelectItem value="trending">Trending</SelectItem>
+                  <SelectItem value="popular">Popular</SelectItem>
+                  <SelectItem value="recommended">Recommended</SelectItem>
+                </SelectContent>
+              </Select>
+            </div>
+            <div className="space-y-2">
+              <Label>Media Type</Label>
+              <Select value={mediaType} onValueChange={(v) => setMediaType(v as TraktMediaType)}>
+                <SelectTrigger>
+                  <SelectValue />
+                </SelectTrigger>
+                <SelectContent>
+                  <SelectItem value="movie">Movies</SelectItem>
+                  <SelectItem value="tv">TV Shows</SelectItem>
+                </SelectContent>
+              </Select>
+            </div>
+          </div>
+        )}
 
         {requiresProfile ? (
           <div className="space-y-2">
@@ -1083,7 +1129,11 @@ export function TraktPresetForm({
           type="submit"
           className="w-full"
           disabled={
-            mutation.isPending || libraryIds.length === 0 || hasInvalidLimit || missingProfile
+            mutation.isPending ||
+            libraryIds.length === 0 ||
+            hasInvalidLimit ||
+            missingProfile ||
+            missingListURL
           }
         >
           {mutation.isPending ? "Importing..." : "Import Trakt Collection"}


### PR DESCRIPTION
## Problem

Collections could sync only Trakt's built-in trending/popular/recommended feeds. A server admin couldn't populate a collection from a specific user's Trakt list — e.g. a curated "Saw cinematic universe in timeline order" list pulled from a Kometa config (#214). The biggest community-signal item on the board (a 43-reply thread).

## Approach

- **`trakt.Client.GetUserList`** fetches `/users/{user}/lists/{slug}/items` in list order, mixing movies and shows and skipping non-title entries (people/episodes/seasons). Public lists need only the app client id; the access token is passed through for a private owner list.
- **New `trakt_list` collection source mode**: `catalog.ParseTraktListURL` accepts a `trakt.tv/users/{user}/lists/{slug}` URL (with or without scheme/query) or a bare `user/slug` shorthand; `syncTraktListCollection` fetches the list and reuses the preset pipeline's matching, dedupe, ranking, and sync-run recording via an extracted `completeTraktEntrySync` helper (no logic duplicated between preset and list paths).
- **Import handler** accepts `list_url` as an alternative to `preset`; the admin collection editor's Trakt form gains a **Source** toggle (discovery feed vs user list) with a list-URL input and summary row.

Reuses the whole existing collection machinery (auto-sync schedule, collage, library matching) that #227's provider work and the earlier preset modes already established — this is a new source, not a new subsystem.

## API contract

Additive-only: a new accepted `source_config.mode`, a new optional `list_url` request field; `preset`/`media_type` become optional but the preset path is unchanged. No renames or type changes.

## Testing

- `GetUserList`: httptest-backed mixed movie/show decoding in list order, unknown-type skipping, and required user/slug validation.
- `ParseTraktListURL`: full URL, query string, no-scheme, shorthand, trailing slash, and rejection of non-list URLs / missing slug (these caught two parser bugs during development — a non-list URL that resolved and a no-scheme URL that didn't).
- Trakt import handler + full catalog/sections/api suites green; `tsc` + prettier clean.
- Not live-validated: exercising the real Trakt API needs a configured Trakt client id; the sync path reuses the preset pipeline end to end.

Fixes #214

## AI-use disclosure

Implemented with Claude Code (test-first); human-reviewed before submission.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for importing Trakt collections from either a preset feed or a user list URL.
  * The import form now lets you choose the source type and enter a Trakt list link when needed.
  * List imports now preserve item order and show the chosen source in the summary.

* **Bug Fixes**
  * Improved validation for Trakt list inputs and required fields.
  * Kept item limits consistent across both import modes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->