### PR TITLE
perf: cut home-screen, Continue Watching, and Latest latency; cache shared home rails

### DIFF
--- a/cmd/silo/main.go
+++ b/cmd/silo/main.go
@@ -1004,6 +1004,12 @@ func main() {
 			installer,
 			pluginHost,
 			slog.Default(),
+			// Auto-updates rewrite installation rows (new version-specific
+			// InstallPath/Version) and delete the old install dir without going
+			// through pluginService. Wire OnLifecycleChange so the service's
+			// installation cache is invalidated and later plugin RPCs re-read
+			// the fresh row instead of a stale one.
+			pluginService.OnLifecycleChange,
 		)
 		go func() {
 			defer close(pluginAutoUpdateDone)
@@ -1117,8 +1123,17 @@ func main() {
 		rootClaimRepo = catalog.NewRootClaimRepository(deps.DB)
 		groupClaimRepo = catalog.NewGroupClaimRepository(deps.DB)
 		pluginResolver := metadata.NewPluginResolverAdapter(pluginService)
+		// Serve the metadata chain's plugin-installation enabled-check from the
+		// plugins service's in-memory installation cache. Declared as the
+		// interface type and only assigned when pluginService is non-nil so a
+		// nil *plugins.Service is passed as a genuine nil interface (not a
+		// typed-nil), letting buildProviders fall back to the pool query.
+		var installationEnabledChecker metadata.InstallationEnabledChecker
+		if pluginService != nil {
+			installationEnabledChecker = pluginService
+		}
 		metadataService = metadata.NewMetadataService(
-			chainRepo, pluginResolver,
+			chainRepo, pluginResolver, installationEnabledChecker,
 			itemRepo, providerIDRepo, episodeRepo, seasonRepo, libraryRepo, deps.FolderRepo,
 			personRepo,
 			deps.FileRepo, skippedRootRepo, staleIDRepo, rootClaimRepo,

--- a/cmd/silo/main.go
+++ b/cmd/silo/main.go
@@ -1138,6 +1138,17 @@ func main() {
 			personRepo,
 			deps.FileRepo, skippedRootRepo, staleIDRepo, rootClaimRepo,
 		)
+		// Drop the resolved-chain cache whenever a plugin is installed, enabled,
+		// disabled, updated, or uninstalled. The installation-enabled check is
+		// served from the plugins service's in-memory cache (invalidated on the
+		// same events), but resolveChainCached would otherwise keep serving a
+		// stale provider chain for up to chainCacheTTL after a provider's
+		// availability changes.
+		if pluginService != nil {
+			pluginService.AddLifecycleHook(func(context.Context) {
+				metadataService.InvalidateChainCache()
+			})
+		}
 		personRefreshService = metadata.NewPersonRefreshService(deps.DB, pluginResolver, personRepo)
 		personRefreshService.SetImageResolver(imageResolver)
 

--- a/docs/superpowers/plans/2026-07-03-section-fetch-performance.md
+++ b/docs/superpowers/plans/2026-07-03-section-fetch-performance.md
@@ -1,0 +1,326 @@
+# Section-fetch & jellycompat performance plan
+
+Status: in progress. Commands assume the repository root is the cwd.
+
+> **Log provenance / staleness check.** The production logs analyzed here were
+> captured against commit `b1b3a9b4` (2026-07-01). Current `origin/main` is
+> `3d82aa59` (2026-07-02), 15 commits ahead. Only two of those commits touch the
+> hot files, and both are unrelated (`3d8a63de` metadata-language upsert
+> precedence; `d6c4dce1` playback-session conflict error) — verified they do not
+> change `ListBySeries`, `loadProgressPage`, the next-up query, the browse
+> fast-path, or the detail-enrich path. So the diagnoses below still apply to
+> current `main`; nothing since the logs has fixed these.
+
+## Revised implementation scope (2026-07-03, after code verification)
+
+After reading the current code, several original fixes were re-scoped or
+deferred. This section is authoritative; the "Proposed fixes" section further
+down is the original analysis and is kept for context.
+
+**Commit 1 (safe subset):**
+- **#2 Resume scan cap — IMPLEMENTED.** `loadProgressPage` now bounds its scan to
+  `resumeScanMaxRows = 300` so `EnableTotalRecordCount=true` can't drive the
+  O(history) scan (`internal/jellycompat/handlers_items.go`). Builds clean.
+  Caveat: the specific logged 35.9s Resume call actually went through the capped
+  `FetchOne` fast path (the deferred #1 cold recompute), so this removes a latent
+  risk rather than that exact spike.
+- **#9 drop redundant enrich — RE-SCOPED (do not remove wholesale).**
+  `enrichDetailUserData` (`content_direct.go:612-626`) is redundant only for
+  **movie/episode leaf** items (all `batchListItemDetails` callers re-apply
+  batched `progress[...]` which overrides it). For **series** it builds the
+  episode-**rollup** `UserData` (Played/UnplayedItemCount) that no progress row
+  covers — removing it would strip series watch-state from `/Items`/`/Items/Latest`
+  (which can return Series). Correct fix: skip enrich for leaf types only, keep it
+  for series (or batch the leaf-progress lookup so output is identical).
+- **#4 concurrency — RE-SCOPED (pool-constrained).** `pgxpool` MaxConns defaults
+  to **20** (`internal/config/db_loader.go:162`); live usage already ~25 across the
+  DB. Raising `fetchAllMaxConcurrency` 4→8 doubles per-request pool pressure, so
+  ~2–3 concurrent home requests would saturate the pool and could regress under
+  load. Only bump conservatively (e.g. 4→6) or after a load test; not a blind
+  constant change.
+
+**Deferred to their own PRs (heavier than "light"):**
+- **#1 continue-watching latency.** There is no existing result cache to "warm";
+  the Resume/CW path recomputes via `FetchOne` every call. The hourly `:12` spike
+  lines up with the `collection sync scheduler` / hourly session-cleanup jobs, so
+  the root cause may be periodic DB contention, not a cache miss. Needs its own
+  investigation (contention vs. adding a short-TTL result cache with progress-write
+  invalidation) — carries user-visible staleness risk.
+- **#3 `/Shows/{id}/Episodes`.** A `LIMIT` on `ListBySeries` truncates a series;
+  the real fix is client-visible pagination requiring Android/Apple coordination.
+- **#5 dedup + SQL-side filtering.** The dedup needs cross-section memoization that
+  `FetchAll` does not currently have; the SQL-filter half is a `userstore`
+  interface refactor. Both are structural, not light.
+
+**Dropped:**
+- **#6 content_id NextUp rewrite.** ~28ms off an already ~91ms warm query,
+  invisible once cached, highest correctness risk (`::int`/lexicographic trap).
+  Not worth it.
+
+**Commit 2 (separate) — IMPLEMENTED:**
+- **#8 browse fast-path.** When a cross-library `recently_added` browse also has
+  an `isPlayed` filter, the over-fetch loop no longer advances `filters.Offset`
+  into `BrowsePage`'s whole-catalog GROUP BY on the 2nd chunk. Instead it pulls
+  the entire over-fetch budget (`maxScannedRows`) in a single
+  `BrowseRecentlyAddedAcrossLibraries` merged index walk
+  (`internal/jellycompat/content_direct.go`), so `/Items/Latest` stays on the
+  ~1ms/library fast path. Expected ~0.8–1.6s → ~50–150ms for heavy watchers with
+  2+ libraries.
+
+## Problem (what operators/users saw)
+
+Production `silo` logs (24h window) show recurring multi-second stalls on the
+home screen and continue-watching rails, on both native clients and Jellyfin
+compat clients.
+
+- **Continue Watching is the worst offender.** The native `slow section fetch`
+  warning fired 132× in 24h (126 of them `type=continue_watching`), with the
+  aggregate home fetch (`slow aggregate section fetch`) firing 17× at
+  `section_count=32`. Distribution of `slow section fetch`: p50 ≈ 1.1s,
+  p90 ≈ 3.8s, worst 35.8s.
+- **A very regular hourly spike.** `section_id=compat-resume` reliably jumps to
+  ~3.5s clustered at **:12–:14 past every hour**, then returns to fast. This is
+  the fingerprint of an ~1h cache TTL expiring followed by a cold recompute that
+  a live request pays for.
+- **Jellycompat resume/next-up/episodes are slow under field expansion.**
+  Excluding long-lived websocket/stream/transcode connections (expected to be
+  long), the slowest query-backed endpoints were:
+  - the Resume endpoints (`UserItems/Resume` + the per-user
+    `Users/{id}/Items/Resume` form) — 275 calls >500ms, worst **35.9s** (a VidHub
+    client requesting `Limit=20` with total-record-count).
+  - `Shows/NextUp` — 399 >500ms, 139 >1000ms.
+  - `Shows/{id}/Episodes` — 58 >500ms, worst **10.1s** (long series, all slow
+    calls requested `MediaSources`/`MediaStreams` expansion).
+  - the native home-sections aggregate (`api/v1/home` sections) — worst 5.4s.
+  - `/api/v1/recommendations/taste-seed/items` — 55 >1000ms, worst 5.6s.
+
+## What is NOT the problem
+
+The base SQL is fast. `EXPLAIN ANALYZE` of the continue-watching base fetch for
+the single heaviest user on the box (`user_id=627`, 11,459 in-progress rows)
+returns in **~1ms** on the existing partial indexes
+(`idx_uwp_profile_in_progress`, `idx_uwp_profile_completed`). The multi-second
+cost is application-side: over-scanning, per-section serialization, cold-cache
+recompute, and one avoidable large join in the NextUp query.
+
+## Evidence: the NextUp query cost breakdown
+
+`EXPLAIN (ANALYZE, BUFFERS)` of the real `buildListNextUpQuery`
+(`internal/catalog/nextup_repo.go:112`) for `user_id=627` executed in **91ms
+warm**, and the cost is dominated by one thing:
+
+```
+completed_episodes CTE:
+  Nested Loop (actual 60.8ms, 56,884 buffers)
+    -> Index Scan idx_user_watch_progress_profile  (14,512 rows, 847 buffers)
+    -> Index Scan episodes_pkey  (loops=14,512, 56,037 buffers)   <-- dominant
+LATERAL next-episode lookup: fast (~9k buffers total across 137 series)
+Execution Time: 91.163 ms  (warm; cold/disk-bound is the 3.5s production case)
+```
+
+The `completed_episodes` CTE does
+`JOIN episodes e ON e.content_id = uwp.media_item_id` and probes
+`episodes_pkey` **once per completed-progress row (14,512×)** purely to read
+`series_id`, `season_number`, and `episode_number`. That single join is ~60ms of
+91ms warm and is the largest driver of the cold-cache blowup.
+
+## The content_id insight (validated)
+
+`content_id` is a **deterministic, structured natural key**, not a random DB id
+(`internal/contentid/contentid.go`, migration
+`migrations/sql/20260612130000_deterministic_content_id.sql`). An episode's id
+embeds its series anchor, season, and episode:
+
+```
+episode-tvdb-296762-1-5   ->  series = series-tvdb-296762, season = 1, episode = 5
+```
+
+This is a **documented, frozen, load-bearing invariant** (`contentid.go:29-32`:
+"the watch-history query relies on this to resolve a show without an episodes
+table lookup. Never break it."). It is exposed as `SeriesIDFromContentID`
+(`contentid.go:256`).
+
+Measured coverage on this DB:
+- 2,110,532 of 2,111,778 episode rows (**99.94%**) are provider-anchored and
+  derivable; the derived series id matches `series_id` for **100%** of them.
+- Only 1,246 rows / 134 series are legacy/`local-` ids with no embedded anchor.
+- Of in-progress `user_watch_progress` rows, 86k are `episode-` (derivable) and
+  44k are movies/books/other (not episodes at all).
+
+Crucially, **there is already a proven in-repo SQL pattern** for exactly this,
+used by the watch-history source to avoid the episodes join
+(`internal/catalog/history_source.go:218-282`):
+- `seriesFromAnchoredEpisodeExpr` — `'series-' || split_part(id,'-',2) || '-' || split_part(id,'-',3)`.
+- `anchoredEpisodePredicate` — requires 5 non-empty `-` components before
+  treating an id as anchored.
+- Null-poisons the episodes join key for anchored ids
+  (`CASE WHEN <anchored> THEN NULL ELSE media_item_id END`) so the planner skips
+  the `episodes_pkey` probe, and only legacy/local ids `LEFT JOIN episodes`.
+
+Season/episode numbers are also parseable from the id (last two `-` segments),
+so the CTE can obtain **all three** values it needs (`series_id`,
+`season_number`, `episode_number`) without touching `episodes` for the 99.94%
+anchored majority — while COALESCE-ing to the existing join for the legacy tail.
+
+This makes the NextUp optimization **low-risk and well-precedented**, not novel.
+
+## Proposed fixes (ranked by expected impact)
+
+The ranking below was re-ordered after an adversarial review. The production
+pain is cold-cache spikes hitting live requests, so **caching is the highest-
+impact lever**, not the query rewrite. The content_id rewrite is a real warm/cold
+I/O trim but is demoted and gated on a correctness fix (see #6).
+
+### Tier 1 — highest impact, addresses the actual production symptom
+
+1. **Warm / lengthen the continue-watching cache** so the hourly `:12` cold
+   recompute never lands on a live request. Options: background refresh before
+   TTL expiry, or a longer TTL with async invalidation on progress write. The
+   evidence (base query ~1–91ms, prod 3.5s clustered at `:12–:14` hourly) says
+   this single fix most likely kills the headline spike on its own.
+
+2. **Cap the Resume full-history scan.** When `EnableTotalRecordCount=true`,
+   `loadProgressPage` (`handlers_items.go:2446-2483`) keeps paging the user's
+   entire in-progress history to compute a total — the documented 35.9s path.
+   Stop scanning to the end: cap scan depth (e.g. reuse
+   `continueProgressMaxScanned`) and return an approximate/clamped total, or omit
+   the exact total for oversized histories.
+
+3. **Bound `/Shows/{id}/Episodes`.** `ListBySeries`
+   (`internal/catalog/episode_repo.go:684`) returns the whole series with no
+   `LIMIT`; paginate it (the worst 10.1s case). Also fix the `episodeRepo == nil`
+   fallback that fans out one `ListEpisodes` per season — a genuine N+1
+   (`internal/jellycompat/handlers_items.go:2673`).
+   - NOTE (review correction): do **not** bother adding a `LIMIT` to
+     `listResumableFirstEpisodes` — its input already comes from
+     `ListProgress(..., 100, 0)` (`nextup_repo.go:290`), so `ANY($3)` is already
+     ≤100 ids. That would be a cosmetic no-op.
+
+### Tier 2 — cheap serialization/dedup wins
+
+4. **Raise/tune `fetchAllMaxConcurrency`** (currently `4`,
+   `internal/sections/fetcher.go:51`). With 32 home sections this serializes into
+   ~8 waves; total ≈ `ceil(N/4) × slowest-section`. Likely a bigger aggregate-
+   latency lever than the NextUp micro-optimization and cheaper. **Measure
+   `pgxpool` max conns first** — raising concurrency while cold queries are slow
+   amplifies pool pressure.
+
+5. **Avoid double NextUp work in combined mode.** `fetchContinueWatchingSection`
+   calls `FetchNextUpItems` inline when `next_up_mode="combined"`
+   (`fetcher.go:436`) while the `next_up` section computes it again — compute once
+   and share. Also **push dismissal/access filtering into SQL** for
+   continue-watching so it stops scanning up to 1000 rows across 10 sequential
+   `ListProgress` round-trips to fill a 20-item section (`fetcher.go:498-522`).
+
+### Tier 3 — the NextUp content_id rewrite (warm/cold I/O trim, NOT the spike fix)
+
+6. **Derive series/season/episode from `content_id` in the NextUp CTE instead of
+   joining `episodes`.** Confirmed effect: the `completed_episodes` CTE for user
+   627 drops from **67.5ms / 56,893 buffers** to **38.8ms / 13,362 buffers** —
+   the 56k `episodes_pkey` probes vanish. But this does NOT touch the LATERAL
+   (episodes + media_files), which is the legitimately irreducible part and
+   becomes the new dominant term, and it does NOT address the cold-cache spike
+   that Tier 1 #1 fixes. Keep it, but as an optimization, not the headline.
+
+   **Mandatory correctness requirements (do not skip):**
+   - **`::int` casts are required.** `split_part` returns TEXT. The LATERAL
+     compares against integer columns `(e2.season_number, e2.episode_number)`, and
+     the `DISTINCT ON` orders by `season_number DESC, episode_number DESC`. Mixed
+     `(text,text) > (int,int)` raises `operator does not exist: text > integer`;
+     forcing both sides to text makes `('1','2') > ('1','10')` return TRUE
+     (lexicographic), so NextUp would surface the wrong episode. Cast every derived
+     season/episode value to `int`.
+   - **This is NOT fully precedented.** `history_source.go:275-282` derives only
+     the series-id *string* (never used numerically). The numeric season/episode
+     derivation is new and is exactly where the lexicographic landmine lives —
+     copying `history_source` verbatim gives the series expr but not the casts.
+   - **Fallback for the legacy tail is mandatory.** COALESCE to the episodes join
+     for the 0.06% legacy/local (`local-`/Sonyflake) ids using the same
+     `anchoredEpisodePredicate` (5 non-empty `-` components) as `history_source.go`.
+   - Data validated safe for anchored ids: across all 2,110,532 anchored episode
+     rows, derived season/episode match the table columns with **0 mismatches**
+     (including season-0/specials); all segments numeric.
+
+### Tier 2 — high-frequency jellycompat browse (`/Items/Latest`, `/Items`)
+
+These are very high traffic — 10,837 `/Items/Latest` + 6,030 `/Items` calls in
+24h — so even sub-second slowness is a large aggregate load. 333 `/Items/Latest`
+calls ran >800ms (p50 1.1s, max 1.6s); every slow one requested full `Fields`
+(`MediaSources`+`MediaStreams`) with `isPlayed=false&groupItems=true`.
+
+Root cause is **not** the detail expansion. It is `isPlayed=false` (a per-profile
+overlay that can't be pushed into SQL) forcing `BrowseItems` into an over-fetch
+loop that advances `filters.Offset` (`internal/jellycompat/content_direct.go:477`).
+The cross-library recently-added **fast path is gated on `Offset == 0`**
+(`content_direct.go:430`); as soon as a heavy watcher needs a 2nd chunk it falls
+through to the generic `BrowsePage` (`content_direct.go:435`), whose multi-library
+plan is a whole-catalog `GROUP BY` HashAggregate + top-N heapsort over ~147k
+movies (`internal/catalog/browse.go:544-548`).
+
+`EXPLAIN (ANALYZE, BUFFERS)` of the 2nd-chunk shape (`LIMIT 150 OFFSET 150`,
+`type=movie`, full projection): **755ms per call** (HashAggregate over 147,212
+rows, top-N heapsort). The offset-0 fast path
+(`BrowseRecentlyAddedAcrossLibraries`, index walk on
+`idx_item_libraries_folder_seen_content`) is ~1ms/library. So one fall-through =
+0.8–1.6s; two (very heavy watchers) reach the top of the range. Only affects
+users with 2+ libraries and lots of movie watch history — consistent with "some
+calls slow."
+
+8. **Keep the `isPlayed` over-fetch loop on the fast path.** Track a separate
+   chunk offset and re-call `BrowseRecentlyAddedAcrossLibraries` for each chunk
+   (growing top-N bound) instead of advancing `filters.Offset` into `BrowsePage`
+   — or give the multi-library recently-added GROUP BY an offset-capable
+   index-ordered plan. Expected: **~0.8–1.6s → ~50–150ms (≈8–10×)**.
+
+9. **Drop the redundant per-item `enrichDetailUserData`** in
+   `GetItemDetailsByIDs` (`content_direct.go:693-702` → `:612-614`): it runs a
+   single-item `GetProgress` + `ListCompletedHistoryItems` **per item (~100
+   sequential point queries for 50 items)**, but the handler already fetched
+   progress in one batched call (`resolveUserStateForContentIDs`,
+   `handlers_items.go:961`) and `userDataDTO` overrides it (`mapping.go:551-559`),
+   so the per-item work is thrown away. Remove or batch it. Expected: shave
+   ~50–150ms of pure waste.
+
+### Explicitly out of scope
+
+- **`/api/v1/recommendations/taste-seed/items` (4.4–5.5s, every call).** Confirmed
+  it only fires on the explicit `/taste-seed` onboarding page
+  (`web/src/pages/TasteSeed.tsx` via `useTasteSeedItems`); the Home screen renders
+  only `TasteSeedBanner` (dismissed-state check, no items query). 56 calls / 4
+  users in 24h. Rare, opt-in, not on the homescreen — deliberately deferred.
+
+### Ops (not code)
+
+7. **Enable `pg_stat_statements`** — confirmed OFF (`shared_preload_libraries`
+   empty). Enabling it makes future regressions measurable, but it **requires a
+   Postgres restart** (not a live toggle) — schedule accordingly.
+
+## Risk / follow-ups
+
+- The content_id rewrite's `::int` cast + lexicographic-ordering trap is the
+  single biggest correctness gap; gate it on an explicit test (episode 2 vs 10
+  within a season, and the `season DESC, episode DESC` tiebreak) before merge.
+- After the rewrite, the LATERAL (episodes + media_files) becomes the dominant
+  term; measure its cold cost separately — it may warrant its own index review.
+- Raising `fetchAllMaxConcurrency` trades DB pool pressure for latency; validate
+  against `pgxpool` max conns under real concurrency, not just latency.
+- Cache warming changes staleness semantics for continue-watching; confirm
+  progress writes still invalidate promptly enough that a just-watched item moves.
+- `/Shows/{id}/Episodes` pagination is client-visible (jellycompat); verify
+  Android/Apple clients tolerate a bounded page + `startItemId` continuation.
+
+## Verification plan
+
+- `EXPLAIN (ANALYZE, BUFFERS)` before/after on the NextUp rewrite for `user_id=627`;
+  assert the `episodes_pkey` loop count drops from ~14.5k to ~0 for anchored users.
+- Replay the worst production queries (Resume `Limit=20` + total-count; long-series
+  Episodes) and confirm sub-second.
+- Watch `slow section fetch` / `slow aggregate section fetch` counts in logs after
+  deploy; the hourly `:12` compat-resume spike should disappear.
+- Dedicated ordering test for the content_id derivation: a series with episodes
+  2 and 10 in one season, asserting NextUp picks episode 2 → 3 (not 10 → 11) and
+  the `DISTINCT ON ... DESC` tiebreak picks the highest-numbered completed episode.
+- `make lint`, `go build ./...`, targeted unit tests for the content_id SQL
+  derivation (mirror existing `history_source` tests, plus the `::int` cast path).
+</content>
+</invoke>

--- a/docs/superpowers/plans/2026-07-03-section-fetch-performance.md
+++ b/docs/superpowers/plans/2026-07-03-section-fetch-performance.md
@@ -109,7 +109,7 @@ recompute, and one avoidable large join in the NextUp query.
 (`internal/catalog/nextup_repo.go:112`) for `user_id=627` executed in **91ms
 warm**, and the cost is dominated by one thing:
 
-```
+```text
 completed_episodes CTE:
   Nested Loop (actual 60.8ms, 56,884 buffers)
     -> Index Scan idx_user_watch_progress_profile  (14,512 rows, 847 buffers)
@@ -131,7 +131,7 @@ The `completed_episodes` CTE does
 `migrations/sql/20260612130000_deterministic_content_id.sql`). An episode's id
 embeds its series anchor, season, and episode:
 
-```
+```text
 episode-tvdb-296762-1-5   ->  series = series-tvdb-296762, season = 1, episode = 5
 ```
 

--- a/docs/superpowers/plans/2026-07-03-section-fetch-performance.md
+++ b/docs/superpowers/plans/2026-07-03-section-fetch-performance.md
@@ -322,5 +322,3 @@ calls slow."
   the `DISTINCT ON ... DESC` tiebreak picks the highest-numbered completed episode.
 - `make lint`, `go build ./...`, targeted unit tests for the content_id SQL
   derivation (mirror existing `history_source` tests, plus the `::int` cast path).
-</content>
-</invoke>

--- a/docs/superpowers/plans/2026-07-03-shared-list-cache.md
+++ b/docs/superpowers/plans/2026-07-03-shared-list-cache.md
@@ -1,0 +1,122 @@
+# Shared List Cache (Home Rails) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking. Commands assume the repository root is the cwd.
+
+**Goal:** Cut repeated database work and tail latency on the home screen by caching the *shared* part of every user-agnostic home rail once per access scope, refreshing it in the background before it expires (target TTL ~15 min), and layering the cheap per-user part (watched flags, play position, poster links) on top of the cached list on every request.
+
+**Architecture:** Option A — an in-process, **process-global** resolved-list cache inserted at the native section fetch choke point (`internal/sections`). The section fetcher already returns a *shared, non-personalized* item list; the per-user overlay is applied later in the API handler. We cache at that boundary for the wider/fuller set of user-agnostic section types (including admin-curated collections). Redis is **not** the store — it is an optional invalidation signal only.
+
+**Tech Stack:** Go, `golang.org/x/sync/singleflight` (already used in `internal/sections`), in-process map + mutex (mirrors the existing `editorialCandidateCache`), existing `catalog.AccessFilter`, targeted Go tests.
+
+**Scope target:** Native Silo sections path (`internal/sections/fetcher.go` + `internal/api/handlers/sections.go`).
+
+---
+
+## Validated Direction
+
+Confirmed directly against the code on `main`:
+
+- **The shared base list and the per-user overlay are already separated.** `Fetcher.fetchSection` (`internal/sections/fetcher.go`) returns raw `[]*models.MediaItem` and, for the user-agnostic section types, takes only the access `filter` — no user/profile. The per-user overlay (watched state, play position, presigned poster URLs, overlay badges) is applied afterward in `SectionHandler.buildSectionsResponse` (`internal/api/handlers/sections.go`) on every request. This makes the fetcher output a clean, presign-free cache boundary.
+- **There is precedent to copy.** `editorialCandidateCache` (`internal/sections/fetcher.go`) is already an in-process TTL cache guarded by a mutex + `singleflight.Group`, keyed by subject/library/access-filter (never by user). It caches *candidate ID lists*; this plan generalizes it to a *resolved item list* with a short TTL and refresh-ahead.
+- **The fetch choke point is `Fetcher.FetchOne`.** Both `HandleHomeSections` (via `FetchAll` → `FetchOne`) and `HandleHomeSectionItems` route through it. Caching there covers the whole native home path in one place.
+- **The cache must be process-global, not per-`Fetcher`.** The process constructs several independent `sections.NewFetcher(...)` instances (e.g. native API and recommendations). A cache stored on the `Fetcher` struct (as `editorialCandidateCache` is today) would be duplicated per instance and could never be shared across surfaces. A package-level cache lets any current or future consumer of `FetchOne` reuse the same warm entries.
+- **`Collection` is not uniformly user-agnostic.** `fetchCollection` serves library collections (shared) but routes to `fetchUserCollection` when `cfg.UserCollectionID != ""` (profile-scoped). The cache must exclude the user-collection case or it would leak one profile's list to another.
+
+---
+
+## What is cached (the fuller user-agnostic set)
+
+These rows are identical for everyone who can see the same libraries at the same content-rating cap, so they are cached by access scope:
+
+- Recently Added (`SectionRecentlyAdded`)
+- Recently Released / New Releases (`SectionRecentlyReleased`)
+- Genre and custom-filter rows (`SectionGenre`, `SectionCustomFilter`)
+- Trending on this server (`SectionTrendingOnServer`), Most Watched (`SectionMostWatched`)
+- New to Library (`SectionNewToLibrary`)
+- Critically Acclaimed (`SectionCriticallyAcclaimed`), Award Winners (`SectionAwardWinners`)
+- Editorial Spotlight / featured (`SectionEditorialSpotlight`)
+- Seasonal (`SectionSeasonalThemed`), Mood (`SectionMoodCollection`), Format Showcase (`SectionFormatShowcase`)
+- Trending Discover (`SectionTrendingDiscover`)
+- **Admin-curated lists (`SectionAdminCuratedList`)**
+- **Library** collections only (`SectionCollection` where `cfg.UserCollectionID == ""`)
+
+## What is NOT cached
+
+- **Per-user rows (no shared base):** Continue Watching, Next Up, Next in Series, Recommended For You / Because You Watched / Similar Users Liked / Taste Match, Hidden Gems, Forgotten Favorites, Profile Activity Feed, and **user** collections (`SectionCollection` with a `UserCollectionID`). These bypass the cache entirely.
+- **`SectionRandom`** is technically user-agnostic but intentionally randomized per request; caching would freeze it. Excluded to preserve behavior.
+
+## The per-user overlay always runs fresh (correctness)
+
+Even for a cached row, each request still computes, per person: watched flags (`isPlayed`/UserData), play position, and freshly presigned poster URLs — all in `buildSectionsResponse`. The cache only stores the *membership and ordering* of the row (presign-free `*models.MediaItem`). No request ever sees another user's watched state, and no cached entry carries a poster URL that could expire mid-cache.
+
+---
+
+## The access-scope cache key (security-critical)
+
+If the key fails to capture an access boundary, the cache can serve items a user must not see. The key MUST include, and nothing that is per-user:
+
+- Section identity: section type + section ID + a hash of the section `Config` (so two genre rows with different filters never collide).
+- Requested `ItemLimit` (row size). Callers may request different sizes for the same section; the key must separate them (or the cache must store a superset and slice down).
+- Access scope: sorted accessible library IDs, sorted disabled library IDs, max content rating, excluded media types, plus sort/order.
+
+Model the string builder on the existing `editorialCandidateCacheKey`, extended with section ID + config hash + `ItemLimit`.
+
+## Background refresh before expiry (the key behavior)
+
+Each entry stores `builtAt`, a soft `refreshAfter` (e.g. `builtAt + 12min`), and a hard `expiresAt` (e.g. `builtAt + 15min`). A `getOrRefresh(ctx, key, loader)` helper implements:
+
+- `now < refreshAfter` → return cached value, do nothing.
+- `refreshAfter <= now < expiresAt` → return cached value **and** kick off one async rebuild via `singleflight` (only one rebuild per key). The fresh value swaps in when ready.
+- `now >= expiresAt` → block on the build; `singleflight` collapses concurrent blockers into one build (stampede protection).
+
+Net effect under steady traffic: entries are refreshed ahead of expiry, so live requests are served warm and never pay the cold rebuild. An optional low-frequency sweeper can keep rarely-hit hot scopes warm.
+
+## Optional invalidation (freshness)
+
+Newly scanned content otherwise appears up to ~15 min late in these rails — acceptable for "recently added"/"trending". Optionally subscribe to the existing Redis `EventScanComplete` / `EventMetadataUpdated` events (`internal/cache`) and drop affected scopes for near-instant freshness. This is a nice-to-have layered on top of the TTL, not a dependency.
+
+---
+
+## File Structure
+
+- Add `internal/sections/resolvedlistcache.go`
+  - Package-level cache: `map[string]resolvedListEntry` (value = presign-free `[]*models.MediaItem` + `TotalCount` + `builtAt`/`refreshAfter`/`expiresAt`), guarded by a `sync.RWMutex` and a package-level `singleflight.Group`.
+  - `getOrRefresh(ctx, key, ttl, refreshLead, loader)` implementing serve / refresh-ahead / block-only-when-dead. Reuse the `f.now()` clock indirection for deterministic tests.
+  - `resolvedListCacheKey(...)` builder (section type + section ID + config hash + `ItemLimit` + access scope), modeled on `editorialCandidateCacheKey`.
+  - `isCacheableSectionType(resolved)` guard implementing the whitelist above, including the `cfg.UserCollectionID == ""` check for `SectionCollection` and the `SectionRandom` exclusion.
+- Modify `internal/sections/fetcher.go`
+  - Wrap the user-agnostic branch of `FetchOne` (and the `SectionEditorialSpotlight` branch) so that cacheable section types resolve through `getOrRefresh`; everything else calls the existing loader path unchanged.
+  - Return defensive copies so callers cannot mutate cached slices.
+- Add `internal/sections/resolvedlistcache_test.go`
+  - Distinct access scopes never cross-serve (security).
+  - `SectionCollection` with a `UserCollectionID` is never cached.
+  - Refresh-ahead returns the current value without blocking; only a fully-expired entry blocks.
+  - Stampede: concurrent cold requests collapse to a single loader call.
+  - Overlay parity: a cached row produces the same per-user response as the uncached path (drive through `buildSectionsResponse` in `internal/api/handlers`).
+
+No migration is planned. No plugin repo changes are planned. No client changes are planned.
+
+---
+
+## Deferred (explicitly out of scope here)
+
+- **The cross-library recently-added path** in `directContentService.BrowseItems` is a separate choke point with its own per-user overlay, and is a separate follow-up.
+
+---
+
+## Tasks
+
+- [ ] Add `resolvedlistcache.go` (cache struct, `getOrRefresh`, key builder, section-type whitelist).
+- [ ] Wire `FetchOne` to route cacheable section types through the cache; leave per-user types untouched.
+- [ ] Add the `SectionCollection` user-collection exclusion and `SectionRandom` exclusion.
+- [ ] Add unit tests (scope isolation, user-collection exclusion, refresh-ahead non-blocking, stampede collapse).
+- [ ] Add an overlay-parity test through `buildSectionsResponse`.
+- [ ] (Optional) Subscribe to `EventScanComplete`/`EventMetadataUpdated` to invalidate affected scopes.
+- [ ] `make lint`, `go test ./internal/sections/... ./internal/api/...`, `make verify-local-paths`.
+
+## Risks / follow-ups
+
+- **Security key completeness** is the number-one risk; when in doubt, add a field to the key and add a scope-isolation test.
+- **Approximate totals:** hiding watched items post-cache keeps `TotalRecordCount` approximate — already an accepted tradeoff on the `isPlayed` path; unchanged here.
+- **Staleness window** up to ~15 min for newly scanned content; mitigated by the optional scan-complete invalidation.
+- **Memory:** ~200 items × small metadata × tens of scopes is negligible; cap entry count and evict LRU as a backstop.

--- a/internal/catalog/access_cache_key.go
+++ b/internal/catalog/access_cache_key.go
@@ -1,0 +1,107 @@
+package catalog
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"sort"
+	"strconv"
+	"strings"
+)
+
+// WriteAccessScopeCacheKey appends every AccessFilter field that bounds WHICH
+// rows a viewer may see to a cache key. It is the single, security-critical
+// source of truth for serializing an access scope: every cache that shares
+// entries across requests (sections resolved-list cache, editorial candidate
+// cache, audiobook groups cache) MUST build its access-boundary key component
+// through this method, so a new boundary field added to AccessFilter only has
+// to be captured here — never in per-cache copies that can silently drift.
+//
+// Included: AllowedLibraryIDs, DisabledLibraryIDs, MaxContentRating,
+// ExcludedMediaTypes, NamePrefix, AllowedContentIDs. AllowedLibraryIDs and
+// AllowedContentIDs preserve the nil (unrestricted) vs empty (restrict to
+// nothing) distinction the access layer branches on; AllowedContentIDs is
+// hashed because the allow-list can be large.
+//
+// Deliberately excluded: UserID/ProfileID (identity, not scope — callers that
+// key per-viewer entries add them separately), presentation/language fields
+// (they change how rows are rendered, not which rows are visible), and
+// playback-quality/file fields (file-level, not row-level). A cache whose
+// stored value embeds rendered or per-profile state must add those fields
+// itself on top of this scope component.
+func (f AccessFilter) WriteAccessScopeCacheKey(b *strings.Builder) {
+	b.WriteString("|accessible=")
+	writeOptionalSortedIntsKey(b, f.AllowedLibraryIDs)
+
+	b.WriteString("|disabled=")
+	writeSortedIntsKey(b, f.DisabledLibraryIDs)
+
+	b.WriteString("|rating=")
+	b.WriteString(f.MaxContentRating)
+
+	b.WriteString("|excludedtypes=")
+	writeSortedStringsKey(b, f.ExcludedMediaTypes)
+
+	b.WriteString("|nameprefix=")
+	b.WriteString(f.NamePrefix)
+
+	b.WriteString("|allowedcontent=")
+	b.WriteString(hashOptionalStringsKey(f.AllowedContentIDs))
+}
+
+// writeOptionalSortedIntsKey encodes an int set preserving the nil vs empty
+// distinction.
+func writeOptionalSortedIntsKey(b *strings.Builder, values []int) {
+	if values == nil {
+		b.WriteString("<nil>")
+		return
+	}
+	if len(values) == 0 {
+		b.WriteString("<empty>")
+		return
+	}
+	writeSortedIntsKey(b, values)
+}
+
+func writeSortedIntsKey(b *strings.Builder, values []int) {
+	if len(values) == 0 {
+		return
+	}
+	sorted := append([]int(nil), values...)
+	sort.Ints(sorted)
+	for i, value := range sorted {
+		if i > 0 {
+			b.WriteByte(',')
+		}
+		b.WriteString(strconv.Itoa(value))
+	}
+}
+
+func writeSortedStringsKey(b *strings.Builder, values []string) {
+	if len(values) == 0 {
+		return
+	}
+	sorted := append([]string(nil), values...)
+	sort.Strings(sorted)
+	for i, value := range sorted {
+		if i > 0 {
+			b.WriteByte(',')
+		}
+		b.WriteString(value)
+	}
+}
+
+// hashOptionalStringsKey returns a bounded, order-independent digest of a
+// string allow-list, preserving the nil (unrestricted) vs empty (restrict to
+// nothing) distinction.
+func hashOptionalStringsKey(ids []string) string {
+	if ids == nil {
+		return "<nil>"
+	}
+	if len(ids) == 0 {
+		return "<empty>"
+	}
+	sorted := append([]string(nil), ids...)
+	sort.Strings(sorted)
+	sum := sha256.Sum256([]byte(strings.Join(sorted, ",")))
+	return hex.EncodeToString(sum[:])
+}

--- a/internal/catalog/audiobook_groups_cache.go
+++ b/internal/catalog/audiobook_groups_cache.go
@@ -3,8 +3,6 @@ package catalog
 import (
 	"context"
 	"fmt"
-	"sort"
-	"strconv"
 	"strings"
 	"time"
 
@@ -97,9 +95,11 @@ func sliceGroups(groups []AudiobookGroup, offset, limit int) []AudiobookGroup {
 	return groups[offset:end]
 }
 
-// audiobookGroupsCacheKey identifies a cached full list. It includes every
-// AccessFilter field that changes the rows or the per-profile progress counts
-// so two viewers (or two access scopes) never share an entry.
+// audiobookGroupsCacheKey identifies a cached full list. The cached value
+// embeds per-profile progress counts, so the key adds UserID/ProfileID on top
+// of the shared access-scope component (WriteAccessScopeCacheKey), which
+// serializes every row-visibility boundary and keeps this cache in sync with
+// the other access-scoped caches when AccessFilter grows.
 func audiobookGroupsCacheKey(q AudiobookGroupsQuery, filter AccessFilter) string {
 	sortKey := strings.ToLower(strings.TrimSpace(q.Sort))
 	if sortKey == "" {
@@ -107,36 +107,7 @@ func audiobookGroupsCacheKey(q AudiobookGroupsQuery, filter AccessFilter) string
 	}
 	searchKey := strings.ToLower(strings.TrimSpace(q.SearchPrefix))
 	var b strings.Builder
-	fmt.Fprintf(&b, "%d|%s|%s|q=%s|u=%d|p=%s|cr=%s", q.LibraryID, q.GroupBy, sortKey, searchKey, filter.UserID, filter.ProfileID, filter.MaxContentRating)
-	b.WriteString("|allow=")
-	b.WriteString(joinSortedInts(filter.AllowedLibraryIDs))
-	b.WriteString("|deny=")
-	b.WriteString(joinSortedInts(filter.DisabledLibraryIDs))
-	b.WriteString("|cids=")
-	b.WriteString(strings.Join(sortedCopy(filter.AllowedContentIDs), ","))
-	b.WriteString("|excluded_types=")
-	b.WriteString(strings.Join(sortedCopy(filter.ExcludedMediaTypes), ","))
+	fmt.Fprintf(&b, "%d|%s|%s|q=%s|u=%d|p=%s", q.LibraryID, q.GroupBy, sortKey, searchKey, filter.UserID, filter.ProfileID)
+	filter.WriteAccessScopeCacheKey(&b)
 	return b.String()
-}
-
-func joinSortedInts(values []int) string {
-	if len(values) == 0 {
-		return ""
-	}
-	cp := append([]int(nil), values...)
-	sort.Ints(cp)
-	parts := make([]string, len(cp))
-	for i, v := range cp {
-		parts[i] = strconv.Itoa(v)
-	}
-	return strings.Join(parts, ",")
-}
-
-func sortedCopy(values []string) []string {
-	if len(values) == 0 {
-		return nil
-	}
-	cp := append([]string(nil), values...)
-	sort.Strings(cp)
-	return cp
 }

--- a/internal/catalog/query_definition.go
+++ b/internal/catalog/query_definition.go
@@ -323,6 +323,24 @@ func QueryFieldRequiresProfile(field string) bool {
 	return ok && def.personalized
 }
 
+// IsPersonalized reports whether the definition references any per-profile
+// state: a rule field (in any group) or the sort field that injects a
+// profile-scoped EXISTS(... user_id/profile_id ...) predicate — the
+// personalized fields (watched, favorited, in_watchlist, in_progress,
+// last_watched) and sorts (progress, date_viewed, plays). A personalized
+// definition's membership/ordering differs per profile, so it must never be
+// served from a user-agnostic shared cache keyed only by access scope.
+func (q QueryDefinition) IsPersonalized() bool {
+	for _, group := range q.Groups {
+		for _, rule := range group.Rules {
+			if QueryFieldRequiresProfile(rule.Field) {
+				return true
+			}
+		}
+	}
+	return QuerySortRequiresProfile(q.Sort.Field)
+}
+
 func NormalizeLegacySectionFilter(config json.RawMessage) (QueryDefinition, error) {
 	var legacy struct {
 		FilterType       string       `json:"filter_type"`

--- a/internal/jellycompat/batch_loaders.go
+++ b/internal/jellycompat/batch_loaders.go
@@ -102,11 +102,14 @@ func (h *ItemsHandler) fetchCompatItemsByContentIDs(ctx context.Context, session
 		return nil, err
 	}
 
-	result := make(map[string]upstreamListItem, len(items))
+	listItems := make([]upstreamListItem, 0, len(items))
 	for _, item := range items {
-		listItem := mediaItemToListItem(item)
-		h.presignCompatListItem(ctx, &listItem)
-		result[item.ContentID] = listItem
+		listItems = append(listItems, mediaItemToListItem(item))
+	}
+	presignCompatListItems(h.detailSvc, ctx, listItems)
+	result := make(map[string]upstreamListItem, len(listItems))
+	for _, listItem := range listItems {
+		result[listItem.ContentID] = listItem
 	}
 	return result, nil
 }
@@ -128,10 +131,13 @@ func (h *ItemsHandler) fetchCompatItemsByContentIDsFallback(ctx context.Context,
 	if err != nil {
 		return nil, err
 	}
+	listItems := make([]upstreamListItem, 0, len(items))
 	for _, item := range items {
-		listItem := mediaItemToListItem(item)
-		h.presignCompatListItem(ctx, &listItem)
-		result[item.ContentID] = listItem
+		listItems = append(listItems, mediaItemToListItem(item))
+	}
+	presignCompatListItems(h.detailSvc, ctx, listItems)
+	for _, listItem := range listItems {
+		result[listItem.ContentID] = listItem
 	}
 	return result, nil
 }
@@ -314,10 +320,10 @@ func (h *ItemsHandler) fetchCompatEpisodeTargetsByContentIDs(ctx context.Context
 			RatingIMDB:        ratingIMDB,
 			RatingTMDB:        ratingTMDB,
 			Overview:          overview,
-			PosterURL:         h.presignCompatImagePath(ctx, stillPath, "still"),
-			BackdropURL:       h.presignCompatImagePath(ctx, seriesBackdrop, "backdrop"),
-			LogoURL:           h.presignCompatImagePath(ctx, seriesLogoPath, "logo"),
-			StillURL:          h.presignCompatImagePath(ctx, stillPath, "still"),
+			PosterURL:         compatPresignImage(h.detailSvc, ctx, stillPath, "still", compatCardImageSize),
+			BackdropURL:       compatPresignImage(h.detailSvc, ctx, seriesBackdrop, "backdrop", compatCardImageSize),
+			LogoURL:           compatPresignImage(h.detailSvc, ctx, seriesLogoPath, "logo", compatCardImageSize),
+			StillURL:          compatPresignImage(h.detailSvc, ctx, stillPath, "still", compatCardImageSize),
 			PosterPath:        stillPath,
 			BackdropPath:      seriesBackdrop,
 			BackdropThumbhash: seriesBackdropTH,
@@ -340,10 +346,10 @@ func (h *ItemsHandler) fetchCompatEpisodeTargetsByContentIDs(ctx context.Context
 			Item: listItem,
 			SeriesImages: seriesImageSet{
 				ContentID:         seriesID,
-				PosterURL:         h.presignCompatImagePath(ctx, seriesPosterPath, "poster"),
+				PosterURL:         compatPresignImage(h.detailSvc, ctx, seriesPosterPath, "poster", compatCardImageSize),
 				PosterPath:        seriesPosterPath,
 				PosterThumbhash:   seriesPosterTH,
-				BackdropURL:       h.presignCompatImagePath(ctx, seriesBackdrop, "backdrop"),
+				BackdropURL:       compatPresignImage(h.detailSvc, ctx, seriesBackdrop, "backdrop", compatCardImageSize),
 				BackdropPath:      seriesBackdrop,
 				BackdropThumbhash: seriesBackdropTH,
 				UpdatedAt:         seriesUpdatedAt,
@@ -428,10 +434,10 @@ func (h *ItemsHandler) fetchCompatEpisodeTargetsByContentIDsFallback(ctx context
 			RatingIMDB:        episode.RatingIMDB,
 			RatingTMDB:        episode.RatingTMDB,
 			Overview:          episode.Overview,
-			PosterURL:         h.presignCompatImagePath(ctx, episode.StillPath, "still"),
-			BackdropURL:       h.presignCompatImagePath(ctx, series.BackdropPath, "backdrop"),
-			LogoURL:           h.presignCompatImagePath(ctx, series.LogoPath, "logo"),
-			StillURL:          h.presignCompatImagePath(ctx, episode.StillPath, "still"),
+			PosterURL:         compatPresignImage(h.detailSvc, ctx, episode.StillPath, "still", compatCardImageSize),
+			BackdropURL:       compatPresignImage(h.detailSvc, ctx, series.BackdropPath, "backdrop", compatCardImageSize),
+			LogoURL:           compatPresignImage(h.detailSvc, ctx, series.LogoPath, "logo", compatCardImageSize),
+			StillURL:          compatPresignImage(h.detailSvc, ctx, episode.StillPath, "still", compatCardImageSize),
 			PosterPath:        episode.StillPath,
 			BackdropPath:      series.BackdropPath,
 			BackdropThumbhash: series.BackdropThumbhash,
@@ -453,10 +459,10 @@ func (h *ItemsHandler) fetchCompatEpisodeTargetsByContentIDsFallback(ctx context
 			Item: listItem,
 			SeriesImages: seriesImageSet{
 				ContentID:         series.ContentID,
-				PosterURL:         h.presignCompatImagePath(ctx, series.PosterPath, "poster"),
+				PosterURL:         compatPresignImage(h.detailSvc, ctx, series.PosterPath, "poster", compatCardImageSize),
 				PosterPath:        series.PosterPath,
 				PosterThumbhash:   series.PosterThumbhash,
-				BackdropURL:       h.presignCompatImagePath(ctx, series.BackdropPath, "backdrop"),
+				BackdropURL:       compatPresignImage(h.detailSvc, ctx, series.BackdropPath, "backdrop", compatCardImageSize),
 				BackdropPath:      series.BackdropPath,
 				BackdropThumbhash: series.BackdropThumbhash,
 				UpdatedAt:         series.UpdatedAt,

--- a/internal/jellycompat/batch_loaders.go
+++ b/internal/jellycompat/batch_loaders.go
@@ -106,7 +106,7 @@ func (h *ItemsHandler) fetchCompatItemsByContentIDs(ctx context.Context, session
 	for _, item := range items {
 		listItems = append(listItems, mediaItemToListItem(item))
 	}
-	presignCompatListItems(h.detailSvc, ctx, listItems)
+	presignCompatListItems(ctx, h.detailSvc, listItems)
 	result := make(map[string]upstreamListItem, len(listItems))
 	for _, listItem := range listItems {
 		result[listItem.ContentID] = listItem
@@ -135,7 +135,7 @@ func (h *ItemsHandler) fetchCompatItemsByContentIDsFallback(ctx context.Context,
 	for _, item := range items {
 		listItems = append(listItems, mediaItemToListItem(item))
 	}
-	presignCompatListItems(h.detailSvc, ctx, listItems)
+	presignCompatListItems(ctx, h.detailSvc, listItems)
 	for _, listItem := range listItems {
 		result[listItem.ContentID] = listItem
 	}

--- a/internal/jellycompat/batch_loaders_test.go
+++ b/internal/jellycompat/batch_loaders_test.go
@@ -249,6 +249,47 @@ func TestFetchCompatItemsByContentIDsFallback_LibraryOutsideAllowlistShortCircui
 	}
 }
 
+// TestFetchCompatItemsByContentIDsFallback_BatchesPresign pins Fix #2b for the
+// batch-loader path: after collecting the page it must presign in one batch per
+// populated image type, not one singular call per item. The resolver batch
+// count stays bounded by image type as the item count grows.
+func TestFetchCompatItemsByContentIDsFallback_BatchesPresign(t *testing.T) {
+	resolver := &countingCompatImageResolver{}
+	detailSvc := &catalog.DetailService{}
+	detailSvc.SetImageResolver(resolver)
+	repo := &countingItemRepo{
+		itemsByID: map[string]*models.MediaItem{
+			"a": {ContentID: "a", Type: "movie", Title: "A", PosterPath: "plug://poster-a", BackdropPath: "plug://backdrop-a"},
+			"b": {ContentID: "b", Type: "movie", Title: "B", PosterPath: "plug://poster-b", BackdropPath: "plug://backdrop-b"},
+			"c": {ContentID: "c", Type: "movie", Title: "C", PosterPath: "plug://poster-c", BackdropPath: "plug://backdrop-c"},
+		},
+	}
+	h := &ItemsHandler{itemRepo: repo, detailSvc: detailSvc}
+
+	got, err := h.fetchCompatItemsByContentIDsFallback(
+		context.Background(),
+		&Session{},
+		[]string{"a", "b", "c"},
+		nil,
+	)
+	if err != nil {
+		t.Fatalf("fetchCompatItemsByContentIDsFallback returned error: %v", err)
+	}
+	if len(got) != 3 {
+		t.Fatalf("expected 3 items in result; got %d", len(got))
+	}
+	if resolver.singleCalls != 0 {
+		t.Errorf("single image resolver calls = %d, want 0 (batched path only)", resolver.singleCalls)
+	}
+	// 3 items × poster+backdrop → only 2 batched resolver calls, not 2×3.
+	if resolver.batchCalls != 2 {
+		t.Errorf("batch image resolver calls = %d, want 2 (poster+backdrop, independent of item count)", resolver.batchCalls)
+	}
+	if got["a"].PosterURL != "batch:card:plug://poster-a" {
+		t.Errorf("item a PosterURL = %q", got["a"].PosterURL)
+	}
+}
+
 // TestFetchCompatEpisodeTargetsByContentIDsFallback_UsesBatchedSeriesAccess
 // pins the episode-fallback fix: series-level access checks must be batched
 // through itemRepo.GetByIDsWithAccess instead of iterating EnsureAccessible

--- a/internal/jellycompat/batch_progress_test.go
+++ b/internal/jellycompat/batch_progress_test.go
@@ -150,6 +150,8 @@ func (s *stubContentService) ListItemFilters(context.Context, *Session, url.Valu
 	panic("unused")
 }
 
+func (s *stubContentService) EnrichSeriesUserData(context.Context, *Session, []upstreamListItem) {}
+
 func TestHandleGetUserData_UsesBatchResolveCall(t *testing.T) {
 	// HandleGetUserData should resolve favorite + progress in a single
 	// resolveUserStateForContentIDs call (one DB round-trip pair),

--- a/internal/jellycompat/content_direct.go
+++ b/internal/jellycompat/content_direct.go
@@ -3,6 +3,7 @@ package jellycompat
 import (
 	"context"
 	"fmt"
+	"log/slog"
 	"net/url"
 	"sort"
 	"strings"
@@ -681,12 +682,41 @@ func (s *directContentService) GetItemDetailsByIDs(ctx context.Context, session 
 		return out, nil
 	}
 
-	// Resolve the user store once for the whole page; enrichment is per-item but
-	// uses the identical code path as GetItemDetail.
+	// Resolve the user store once for the whole page.
 	var store userstore.UserStore
 	if s.storeProvider != nil {
 		if resolved, storeErr := s.storeProvider.ForUser(ctx, session.StreamAppUserID); storeErr == nil {
 			store = resolved
+		}
+	}
+
+	// Batch the leaf-item progress lookup. enrichDetailUserData issues
+	// GetProgressWithCompletedHistory per item (two point queries each), so a
+	// 50-item page cost ~100 sequential round-trips. Movies/episodes own a
+	// progress row, so their played/position state is resolved here in a single
+	// ListProgressWithCompletedHistory call — semantically identical to the
+	// per-item path (absent id → nil, completed-history synthesized). Series own
+	// no progress row and need a per-series episode rollup, so they stay on the
+	// per-item enrichDetailUserData path in the loop below.
+	var leafProgress map[string]userstore.WatchProgress
+	if store != nil {
+		leafIDs := make([]string, 0, len(details))
+		for id, detail := range details {
+			if isCompatExcludedMediaType(detail.Type) || strings.EqualFold(detail.Type, "series") {
+				continue
+			}
+			leafIDs = append(leafIDs, id)
+		}
+		if len(leafIDs) > 0 {
+			if pm, err := userstore.ListProgressWithCompletedHistory(ctx, store, session.ProfileID, leafIDs); err == nil {
+				leafProgress = pm
+			} else {
+				// On failure the whole page loses played/position state at once
+				// (the per-item path failed one id at a time); log so the drop is
+				// observable rather than silent. Items still render from list data.
+				slog.Warn("jellycompat: batch leaf progress lookup failed; page rendered without played state",
+					"error", err, "leaf_count", len(leafIDs))
+			}
 		}
 	}
 
@@ -696,7 +726,15 @@ func (s *directContentService) GetItemDetailsByIDs(ctx context.Context, session 
 		}
 		upstream := itemDetailToUpstream(detail)
 		if store != nil {
-			s.enrichDetailUserData(ctx, store, session.ProfileID, id, &upstream)
+			if strings.EqualFold(detail.Type, "series") {
+				s.enrichDetailUserData(ctx, store, session.ProfileID, id, &upstream)
+			} else {
+				var wp *userstore.WatchProgress
+				if entry, ok := leafProgress[id]; ok {
+					wp = &entry
+				}
+				upstream.UserData = seasonUserDataFromProgress(wp)
+			}
 		}
 		out[id] = &upstream
 	}

--- a/internal/jellycompat/content_direct.go
+++ b/internal/jellycompat/content_direct.go
@@ -474,7 +474,7 @@ func (s *directContentService) BrowseItems(ctx context.Context, session *Session
 		for _, mi := range localizedItems {
 			batch = append(batch, mediaItemToListItem(mi))
 		}
-		presignCompatListItems(s.detailSvc, ctx, batch)
+		presignCompatListItems(ctx, s.detailSvc, batch)
 		if isPlayedFilter != "" {
 			// Need user data to filter by played status. The handler's
 			// resolveUserStateForContentIDs call covers UserData on the wire
@@ -589,7 +589,7 @@ func (s *directContentService) SearchItems(ctx context.Context, session *Session
 	for _, mi := range localizedItems {
 		listItems = append(listItems, mediaItemToListItem(mi))
 	}
-	presignCompatListItems(s.detailSvc, ctx, listItems)
+	presignCompatListItems(ctx, s.detailSvc, listItems)
 	s.enrichListItemsUserData(ctx, session, listItems)
 
 	return &upstreamBrowseResponse{

--- a/internal/jellycompat/content_direct.go
+++ b/internal/jellycompat/content_direct.go
@@ -474,7 +474,7 @@ func (s *directContentService) BrowseItems(ctx context.Context, session *Session
 		for _, mi := range localizedItems {
 			batch = append(batch, mediaItemToListItem(mi))
 		}
-		s.presignListItems(ctx, batch)
+		presignCompatListItems(s.detailSvc, ctx, batch)
 		if isPlayedFilter != "" {
 			// Need user data to filter by played status. The handler's
 			// resolveUserStateForContentIDs call covers UserData on the wire
@@ -511,7 +511,7 @@ func (s *directContentService) BrowseItems(ctx context.Context, session *Session
 	// userDataDTO only overrides item-level UserData when a direct progress
 	// row exists, and one never does for a series id.
 	if isPlayedFilter == "" {
-		s.enrichSeriesUserData(ctx, session, collected)
+		s.EnrichSeriesUserData(ctx, session, collected)
 	}
 
 	if totalKnown {
@@ -589,7 +589,7 @@ func (s *directContentService) SearchItems(ctx context.Context, session *Session
 	for _, mi := range localizedItems {
 		listItems = append(listItems, mediaItemToListItem(mi))
 	}
-	s.presignListItems(ctx, listItems)
+	presignCompatListItems(s.detailSvc, ctx, listItems)
 	s.enrichListItemsUserData(ctx, session, listItems)
 
 	return &upstreamBrowseResponse{
@@ -822,10 +822,10 @@ func (s *directContentService) ListSeasons(ctx context.Context, session *Session
 				}
 			}
 			us := modelSeasonToUpstream(season, len(eps))
-			s.presignSeason(ctx, &us)
 			applySeasonUserData(&us, eps, progressMap)
 			result = append(result, us)
 		}
+		s.presignSeasons(ctx, result)
 		return result, nil
 	}
 
@@ -909,13 +909,13 @@ func (s *directContentService) ListEpisodes(ctx context.Context, session *Sessio
 			}
 		}
 		ue := modelEpisodeToUpstream(ep, seriesID)
-		s.presignEpisode(ctx, &ue)
 		if progress, ok := progressMap[ep.ContentID]; ok {
 			progressCopy := progress
 			ue.UserData = seasonUserDataFromProgress(&progressCopy)
 		}
 		result = append(result, ue)
 	}
+	s.presignEpisodes(ctx, result)
 	return result, nil
 }
 
@@ -977,9 +977,13 @@ func (s *directContentService) enrichListItemsUserData(ctx context.Context, sess
 	s.enrichSeriesListUserData(ctx, session, store, items)
 }
 
-// enrichSeriesUserData is enrichSeriesListUserData with store acquisition,
-// for callers that haven't already resolved the user store.
-func (s *directContentService) enrichSeriesUserData(ctx context.Context, session *Session, items []upstreamListItem) {
+// EnrichSeriesUserData is enrichSeriesListUserData with store acquisition,
+// for callers that haven't already resolved the user store. It is exported on
+// the ContentService interface so the native /Items/Latest fast path can apply
+// the same series watch-state rollup the BrowseItems path applies (a series has
+// no progress row of its own, so this rollup is the only source of its
+// Played/UnplayedItemCount).
+func (s *directContentService) EnrichSeriesUserData(ctx context.Context, session *Session, items []upstreamListItem) {
 	if s.storeProvider == nil || len(items) == 0 {
 		return
 	}
@@ -1161,88 +1165,50 @@ func seasonUserDataFromProgress(progress *userstore.WatchProgress) *catalog.Seas
 }
 
 // --- Image URL presigning helpers ---
+//
+// The list-item presign implementation (presignCompatListItems) and its shared
+// collect/resolve helpers live in presign_list.go so directContentService and
+// ItemsHandler share one batched path. Seasons and episodes carry a single
+// relevant image type each, so they
+// get their own bounded batch helpers below rather than reusing the four-type
+// list presigner.
 
-func (s *directContentService) presignListItem(ctx context.Context, item *upstreamListItem) {
-	if item == nil {
-		return
-	}
-	items := []upstreamListItem{*item}
-	s.presignListItems(ctx, items)
-	*item = items[0]
-}
-
-func (s *directContentService) presignListItems(ctx context.Context, items []upstreamListItem) {
-	if len(items) == 0 {
-		return
-	}
-	for i := range items {
-		ensureListItemImagePaths(&items[i])
-	}
-	if s.detailSvc == nil {
-		return
-	}
-
-	posterURLs := s.detailSvc.PresignImageURLsWithExpiry(ctx, collectListImagePaths(items, func(item upstreamListItem) string { return item.PosterURL }), "poster", compatCardImageSize)
-	backdropURLs := s.detailSvc.PresignImageURLsWithExpiry(ctx, collectListImagePaths(items, func(item upstreamListItem) string { return item.BackdropURL }), "backdrop", compatCardImageSize)
-	logoURLs := s.detailSvc.PresignImageURLsWithExpiry(ctx, collectListImagePaths(items, func(item upstreamListItem) string { return item.LogoURL }), "logo", compatCardImageSize)
-	stillURLs := s.detailSvc.PresignImageURLsWithExpiry(ctx, collectListImagePaths(items, func(item upstreamListItem) string { return item.StillURL }), "still", compatCardImageSize)
-
-	for i := range items {
-		items[i].PosterURL = resolvedListImageURL(posterURLs, items[i].PosterURL)
-		items[i].BackdropURL = resolvedListImageURL(backdropURLs, items[i].BackdropURL)
-		items[i].LogoURL = resolvedListImageURL(logoURLs, items[i].LogoURL)
-		items[i].StillURL = resolvedListImageURL(stillURLs, items[i].StillURL)
-	}
-}
-
-func ensureListItemImagePaths(item *upstreamListItem) {
-	if item.PosterPath == "" {
-		item.PosterPath = item.PosterURL
-	}
-	if item.BackdropPath == "" {
-		item.BackdropPath = item.BackdropURL
-	}
-	if item.LogoPath == "" {
-		item.LogoPath = item.LogoURL
-	}
-	if item.StillPath == "" {
-		item.StillPath = item.StillURL
-	}
-}
-
-func collectListImagePaths(items []upstreamListItem, pick func(upstreamListItem) string) []string {
-	paths := make([]string, 0, len(items))
-	seen := make(map[string]struct{}, len(items))
-	for _, item := range items {
-		path := pick(item)
-		if path == "" {
-			continue
-		}
-		if _, ok := seen[path]; ok {
-			continue
-		}
-		seen[path] = struct{}{}
-		paths = append(paths, path)
-	}
-	return paths
-}
-
-func resolvedListImageURL(resolved map[string]catalog.ResolvedImageURL, path string) string {
-	if path == "" {
-		return ""
-	}
-	if value, ok := resolved[path]; ok {
-		return value.URL
-	}
-	return ""
-}
-
+// presignSeason presigns a single season poster. It delegates to the batched
+// presignSeasons so genuinely-singular callers (GetSeason) share one code path;
+// page callers must use presignSeasons directly.
 func (s *directContentService) presignSeason(ctx context.Context, season *upstreamSeason) {
-	season.PosterURL = compatPresignImage(s.detailSvc, ctx, season.PosterURL, "poster", compatCardImageSize)
+	if season == nil {
+		return
+	}
+	seasons := []upstreamSeason{*season}
+	s.presignSeasons(ctx, seasons)
+	*season = seasons[0]
 }
 
-func (s *directContentService) presignEpisode(ctx context.Context, ep *upstreamEpisode) {
-	ep.StillURL = compatPresignImage(s.detailSvc, ctx, ep.StillURL, "still", compatCardImageSize)
+// presignSeasons presigns every season poster in a single batched
+// PresignImageURLsWithExpiry call for the whole collection instead of one
+// singular call per season.
+func (s *directContentService) presignSeasons(ctx context.Context, seasons []upstreamSeason) {
+	if s.detailSvc == nil || len(seasons) == 0 {
+		return
+	}
+	posterURLs := s.detailSvc.PresignImageURLsWithExpiry(ctx, collectImagePaths(seasons, func(se upstreamSeason) string { return se.PosterURL }), "poster", compatCardImageSize)
+	for i := range seasons {
+		seasons[i].PosterURL = resolvedListImageURL(posterURLs, seasons[i].PosterURL)
+	}
+}
+
+// presignEpisodes presigns every episode still in a single batched
+// PresignImageURLsWithExpiry call for the whole collection instead of one
+// singular call per episode.
+func (s *directContentService) presignEpisodes(ctx context.Context, episodes []upstreamEpisode) {
+	if s.detailSvc == nil || len(episodes) == 0 {
+		return
+	}
+	stillURLs := s.detailSvc.PresignImageURLsWithExpiry(ctx, collectImagePaths(episodes, func(ep upstreamEpisode) string { return ep.StillURL }), "still", compatCardImageSize)
+	for i := range episodes {
+		episodes[i].StillURL = resolvedListImageURL(stillURLs, episodes[i].StillURL)
+	}
 }
 
 // --- Model-to-upstream mapping helpers ---

--- a/internal/jellycompat/content_direct.go
+++ b/internal/jellycompat/content_direct.go
@@ -431,7 +431,27 @@ func (s *directContentService) BrowseItems(ctx context.Context, session *Session
 		if crossLibraryRecentlyAdded && filters.Offset == 0 {
 			// The merge helper returns a Total/HasMore consistent with offset 0,
 			// so wantTotal is satisfied without the expensive cross-library count.
-			result, err = s.browseRepo.BrowseRecentlyAddedAcrossLibraries(ctx, filters, crossLibraryIDs)
+			//
+			// The fast path cannot serve a global offset — a per-library top-N walk
+			// can't satisfy a deep merged offset. When the isPlayed overlay drops
+			// items, the offset-paging loop would advance filters.Offset on the next
+			// iteration and fall through to BrowsePage's whole-catalog
+			// MIN(first_seen_at) + GROUP BY (~0.8s+ on a large catalog). Instead,
+			// pull the entire over-fetch budget in this single merged index walk so
+			// the loop fills from one fast call.
+			//
+			// Caveat: BrowseRecentlyAddedAcrossLibraries clamps its limit to
+			// MaxLimit (compatBrowseMaxLimit=1000), so this fully avoids the
+			// BrowsePage fall-through only while maxScannedRows <= 1000 — i.e. for
+			// requestedLimit <= 200, which covers the /Items/Latest hot path
+			// (limit ~24-50). For very large requestedLimit (201-1000) the clamp
+			// can still leave a 2nd chunk that pages into BrowsePage; that case is
+			// rare for recently-added rails and remains correct, just not optimized.
+			fastFilters := filters
+			if isPlayedFilter != "" && fastFilters.Limit < maxScannedRows {
+				fastFilters.Limit = maxScannedRows
+			}
+			result, err = s.browseRepo.BrowseRecentlyAddedAcrossLibraries(ctx, fastFilters, crossLibraryIDs)
 		} else {
 			result, err = s.browseRepo.BrowsePage(ctx, filters, wantTotal)
 		}

--- a/internal/jellycompat/content_direct.go
+++ b/internal/jellycompat/content_direct.go
@@ -36,6 +36,10 @@ type browseSource interface {
 const (
 	compatBrowseChunkLimit = 100
 	compatBrowseMaxLimit   = 1000
+	// compatDefaultBrowseLimit is the page size used when a client omits Limit.
+	// Shared by BrowseItems and the /Items/Latest section fast path so the two
+	// paths always agree on the default page size.
+	compatDefaultBrowseLimit = 24
 )
 
 // compatVideoTypes is the media_items type scope the Jellyfin compat surface
@@ -360,7 +364,7 @@ func (s *directContentService) BrowseItems(ctx context.Context, session *Session
 
 	requestedLimit := catalog.ParseIntParam(params.Get("limit"))
 	if requestedLimit <= 0 {
-		requestedLimit = 24
+		requestedLimit = compatDefaultBrowseLimit
 	}
 	if requestedLimit > compatBrowseMaxLimit {
 		requestedLimit = compatBrowseMaxLimit
@@ -719,6 +723,7 @@ func (s *directContentService) GetItemDetailsByIDs(ctx context.Context, session 
 	// no progress row and need a per-series episode rollup, so they stay on the
 	// per-item enrichDetailUserData path in the loop below.
 	var leafProgress map[string]userstore.WatchProgress
+	leafBatchFailed := false
 	if store != nil {
 		leafIDs := make([]string, 0, len(details))
 		for id, detail := range details {
@@ -731,10 +736,12 @@ func (s *directContentService) GetItemDetailsByIDs(ctx context.Context, session 
 			if pm, err := userstore.ListProgressWithCompletedHistory(ctx, store, session.ProfileID, leafIDs); err == nil {
 				leafProgress = pm
 			} else {
-				// On failure the whole page loses played/position state at once
-				// (the per-item path failed one id at a time); log so the drop is
-				// observable rather than silent. Items still render from list data.
-				slog.Warn("jellycompat: batch leaf progress lookup failed; page rendered without played state",
+				// A transient store error must not blank played/position state
+				// for the whole page at once: fall back to the per-item lookups
+				// below, which degrade one id at a time exactly like the
+				// pre-batch path did.
+				leafBatchFailed = true
+				slog.Warn("jellycompat: batch leaf progress lookup failed; falling back to per-item lookups",
 					"error", err, "leaf_count", len(leafIDs))
 			}
 		}
@@ -746,9 +753,10 @@ func (s *directContentService) GetItemDetailsByIDs(ctx context.Context, session 
 		}
 		upstream := itemDetailToUpstream(detail)
 		if store != nil {
-			if strings.EqualFold(detail.Type, "series") {
+			switch {
+			case strings.EqualFold(detail.Type, "series"), leafBatchFailed:
 				s.enrichDetailUserData(ctx, store, session.ProfileID, id, &upstream)
-			} else {
+			default:
 				var wp *userstore.WatchProgress
 				if entry, ok := leafProgress[id]; ok {
 					wp = &entry

--- a/internal/jellycompat/content_direct_test.go
+++ b/internal/jellycompat/content_direct_test.go
@@ -114,7 +114,7 @@ func TestPresignListItemsBatchResolvesImages(t *testing.T) {
 		},
 	}
 
-	presignCompatListItems(detailSvc, context.Background(), items)
+	presignCompatListItems(context.Background(), detailSvc, items)
 
 	if resolver.singleCalls != 0 {
 		t.Fatalf("single image resolver calls = %d, want 0", resolver.singleCalls)

--- a/internal/jellycompat/content_direct_test.go
+++ b/internal/jellycompat/content_direct_test.go
@@ -99,7 +99,6 @@ func TestPresignListItemsBatchResolvesImages(t *testing.T) {
 	resolver := &countingCompatImageResolver{}
 	detailSvc := &catalog.DetailService{}
 	detailSvc.SetImageResolver(resolver)
-	svc := &directContentService{detailSvc: detailSvc}
 
 	items := []upstreamListItem{
 		{
@@ -115,7 +114,7 @@ func TestPresignListItemsBatchResolvesImages(t *testing.T) {
 		},
 	}
 
-	svc.presignListItems(context.Background(), items)
+	presignCompatListItems(detailSvc, context.Background(), items)
 
 	if resolver.singleCalls != 0 {
 		t.Fatalf("single image resolver calls = %d, want 0", resolver.singleCalls)
@@ -144,6 +143,100 @@ func TestPresignListItemsBatchResolvesImages(t *testing.T) {
 	}
 	if got := items[1].StillURL; got != "batch:card:plug://still-2" {
 		t.Fatalf("StillURL = %q", got)
+	}
+}
+
+// TestPresignSeasonsBatchResolvesImages pins Fix #2c: presignSeasons must issue
+// exactly one PresignImageURLsWithExpiry batch for the whole season collection
+// (one image type), not one singular call per season.
+func TestPresignSeasonsBatchResolvesImages(t *testing.T) {
+	resolver := &countingCompatImageResolver{}
+	detailSvc := &catalog.DetailService{}
+	detailSvc.SetImageResolver(resolver)
+	svc := &directContentService{detailSvc: detailSvc}
+
+	seasons := []upstreamSeason{
+		{ContentID: "s1", PosterURL: "plug://poster-1"},
+		{ContentID: "s2", PosterURL: "plug://poster-2"},
+		{ContentID: "s3", PosterURL: "plug://poster-3"},
+	}
+
+	svc.presignSeasons(context.Background(), seasons)
+
+	if resolver.singleCalls != 0 {
+		t.Fatalf("single image resolver calls = %d, want 0", resolver.singleCalls)
+	}
+	if resolver.batchCalls != 1 {
+		t.Fatalf("batch image resolver calls = %d, want 1 (one poster batch for %d seasons)", resolver.batchCalls, len(seasons))
+	}
+	if got := seasons[0].PosterURL; got != "batch:card:plug://poster-1" {
+		t.Fatalf("season[0] PosterURL = %q", got)
+	}
+	if got := seasons[2].PosterURL; got != "batch:card:plug://poster-3" {
+		t.Fatalf("season[2] PosterURL = %q", got)
+	}
+}
+
+// TestPresignEpisodesBatchResolvesImages pins Fix #2c for episodes: one still
+// batch for the whole collection regardless of episode count.
+func TestPresignEpisodesBatchResolvesImages(t *testing.T) {
+	resolver := &countingCompatImageResolver{}
+	detailSvc := &catalog.DetailService{}
+	detailSvc.SetImageResolver(resolver)
+	svc := &directContentService{detailSvc: detailSvc}
+
+	episodes := []upstreamEpisode{
+		{ContentID: "e1", StillURL: "plug://still-1"},
+		{ContentID: "e2", StillURL: "plug://still-2"},
+		{ContentID: "e3", StillURL: "plug://still-3"},
+	}
+
+	svc.presignEpisodes(context.Background(), episodes)
+
+	if resolver.singleCalls != 0 {
+		t.Fatalf("single image resolver calls = %d, want 0", resolver.singleCalls)
+	}
+	if resolver.batchCalls != 1 {
+		t.Fatalf("batch image resolver calls = %d, want 1 (one still batch for %d episodes)", resolver.batchCalls, len(episodes))
+	}
+	if got := episodes[1].StillURL; got != "batch:card:plug://still-2" {
+		t.Fatalf("episode[1] StillURL = %q", got)
+	}
+}
+
+// TestCompatListItemsFromModelsBatchesPresign pins Fix #2b for the cached
+// home/Latest rail path: the loop builds the whole page first, then presigns in
+// one batch per populated image type independent of item count.
+func TestCompatListItemsFromModelsBatchesPresign(t *testing.T) {
+	resolver := &countingCompatImageResolver{}
+	detailSvc := &catalog.DetailService{}
+	detailSvc.SetImageResolver(resolver)
+	h := &ItemsHandler{detailSvc: detailSvc}
+
+	mediaItems := []*models.MediaItem{
+		{ContentID: "m1", Type: "movie", Title: "One", PosterPath: "plug://poster-1", BackdropPath: "plug://backdrop-1"},
+		{ContentID: "m2", Type: "movie", Title: "Two", PosterPath: "plug://poster-2", BackdropPath: "plug://backdrop-2"},
+		{ContentID: "m3", Type: "movie", Title: "Three", PosterPath: "plug://poster-3", BackdropPath: "plug://backdrop-3"},
+	}
+
+	items := h.compatListItemsFromModels(context.Background(), catalog.AccessFilter{}, mediaItems)
+
+	if len(items) != 3 {
+		t.Fatalf("expected 3 list items; got %d", len(items))
+	}
+	if resolver.singleCalls != 0 {
+		t.Fatalf("single image resolver calls = %d, want 0", resolver.singleCalls)
+	}
+	// poster + backdrop are populated across the rail; logo/still are empty and
+	// therefore skipped. The count is bounded by image type, not the 3 items.
+	if resolver.batchCalls != 2 {
+		t.Fatalf("batch image resolver calls = %d, want 2 (poster+backdrop, independent of item count)", resolver.batchCalls)
+	}
+	if got := items[0].PosterURL; got != "batch:card:plug://poster-1" {
+		t.Fatalf("items[0] PosterURL = %q", got)
+	}
+	if got := items[2].BackdropURL; got != "batch:card:plug://backdrop-3" {
+		t.Fatalf("items[2] BackdropURL = %q", got)
 	}
 }
 

--- a/internal/jellycompat/content_service.go
+++ b/internal/jellycompat/content_service.go
@@ -22,6 +22,13 @@ type ContentService interface {
 	ListEpisodes(ctx context.Context, session *Session, seriesID string, seasonNumber int, libraryID *int) ([]upstreamEpisode, error)
 	ListEpisodesBySeasonID(ctx context.Context, session *Session, seasonID string, libraryID *int) ([]upstreamEpisode, error)
 	ListItemFilters(ctx context.Context, session *Session, params url.Values) (*upstreamItemFiltersResponse, error)
+	// EnrichSeriesUserData fills the aggregated Played/UnplayedItemCount rollup
+	// for series rows in a list response, in place. A series never has a progress
+	// row of its own, so this rollup is the only source of that state. Callers
+	// pass the same session as the request so the counts are scoped to the
+	// caller's profile. Rows that are not series, or that already carry UserData,
+	// are left untouched.
+	EnrichSeriesUserData(ctx context.Context, session *Session, items []upstreamListItem)
 }
 
 type SearchItemsOptions struct {

--- a/internal/jellycompat/handlers_items.go
+++ b/internal/jellycompat/handlers_items.go
@@ -2,6 +2,7 @@ package jellycompat
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"log/slog"
@@ -943,9 +944,35 @@ func (h *ItemsHandler) HandleLatest(w http.ResponseWriter, r *http.Request) {
 	// library's collection type when no explicit IncludeItemTypes is given.
 	// Without this, clients like Infuse may not display "Latest Movies"
 	// sections because they rely on the library-type-appropriate item filter.
-	if query.parentLibraryID > 0 && len(query.itemTypes) == 0 {
-		if inferredType := h.inferLibraryItemType(r.Context(), session, query.parentLibraryID); inferredType != "" {
-			query.itemTypes = []string{inferredType}
+	// libraryItemType is "movie", "series", or "" (any other/mixed type) — it
+	// also decides fast-path eligibility below, so it is resolved once here.
+	var libraryItemType string
+	if query.parentLibraryID > 0 {
+		libraryItemType = h.inferLibraryItemType(r.Context(), session, query.parentLibraryID)
+		if len(query.itemTypes) == 0 && libraryItemType != "" {
+			query.itemTypes = []string{libraryItemType}
+		}
+	}
+
+	// Fast path: a per-library Latest (first page, no played filter, no backdrop
+	// filter) is the same user-agnostic list as the native "recently added"
+	// library rail (both order by mil.first_seen_at DESC). Serve it through the
+	// native section fetch so it reuses the shared resolved-list cache instead of
+	// re-running BrowseItems. It is restricted to movies and series libraries;
+	// every other library type (ebook, music, manga, mixed, …) is ignored and
+	// keeps its exact BrowseItems behavior. On any failure fall back to browse.
+	if (libraryItemType == "movie" || libraryItemType == "series") && query.startIndex == 0 && query.isPlayed == nil && !query.requireBackdrop && h.sectionsFetcher != nil {
+		items, err := h.loadLatestViaSections(r.Context(), session, query)
+		if err == nil {
+			applyImageTypeLimit(items, query.imageTypeLimit)
+			writeJSON(w, http.StatusOK, items)
+			return
+		}
+		// errLatestNotEligible is an expected "this request can't use the cached
+		// path" signal (e.g. a client requesting a type other than the library's
+		// own), not a failure — fall back quietly.
+		if !errors.Is(err, errLatestNotEligible) {
+			slog.Warn("jellycompat: latest via sections failed, falling back to browse", "error", err)
 		}
 	}
 
@@ -955,18 +982,32 @@ func (h *ItemsHandler) HandleLatest(w http.ResponseWriter, r *http.Request) {
 		writeCompatUpstreamError(w, err)
 		return
 	}
-	h.rememberListImages(result.Items)
 
-	contentIDs := contentIDsFromListItems(result.Items)
-	favorites, progress, err := resolveUserStateForContentIDs(r.Context(), session, h.userData, contentIDs)
+	items, err := h.buildLatestItemDTOs(r.Context(), session, query, result.Items)
 	if err != nil {
 		writeCompatUpstreamError(w, err)
 		return
 	}
-	episodeTargets, err := h.fetchCompatEpisodeTargetsByContentIDs(r.Context(), session, episodeContentIDsFromListItems(result.Items), libraryIDPtr(query.parentLibraryID))
+	applyImageTypeLimit(items, query.imageTypeLimit)
+	writeJSON(w, http.StatusOK, items)
+}
+
+// buildLatestItemDTOs maps a resolved list of upstream list items to the
+// /Items/Latest wire response, applying the per-user overlay (favorites,
+// progress, episode targets), the library ParentId, and the optional detail-
+// field upgrade. It is the shared tail of both the native section fast path and
+// the BrowseItems fallback so the overlay logic lives in exactly one place.
+func (h *ItemsHandler) buildLatestItemDTOs(ctx context.Context, session *Session, query itemsQuery, listItems []upstreamListItem) ([]baseItemDTO, error) {
+	h.rememberListImages(listItems)
+
+	contentIDs := contentIDsFromListItems(listItems)
+	favorites, progress, err := resolveUserStateForContentIDs(ctx, session, h.userData, contentIDs)
 	if err != nil {
-		writeCompatUpstreamError(w, err)
-		return
+		return nil, err
+	}
+	episodeTargets, err := h.fetchCompatEpisodeTargetsByContentIDs(ctx, session, episodeContentIDsFromListItems(listItems), libraryIDPtr(query.parentLibraryID))
+	if err != nil {
+		return nil, err
 	}
 
 	// Encode library ID for the ParentId field on each item.
@@ -977,11 +1018,11 @@ func (h *ItemsHandler) HandleLatest(w http.ResponseWriter, r *http.Request) {
 
 	var detailsByID map[string]*upstreamItemDetail
 	if query.needsDetailFields {
-		detailsByID = h.batchListItemDetails(r.Context(), session, contentIDs, libraryIDPtr(query.parentLibraryID))
+		detailsByID = h.batchListItemDetails(ctx, session, contentIDs, libraryIDPtr(query.parentLibraryID))
 	}
 
-	items := make([]baseItemDTO, 0, len(result.Items))
-	for _, item := range result.Items {
+	items := make([]baseItemDTO, 0, len(listItems))
+	for _, item := range listItems {
 		if query.needsDetailFields {
 			if detail, ok := detailsByID[item.ContentID]; ok && detail != nil {
 				h.rememberDetailImages(*detail)
@@ -1006,8 +1047,105 @@ func (h *ItemsHandler) HandleLatest(w http.ResponseWriter, r *http.Request) {
 		}
 		items = append(items, dto)
 	}
-	applyImageTypeLimit(items, query.imageTypeLimit)
-	writeJSON(w, http.StatusOK, items)
+	return items, nil
+}
+
+// errLatestNotEligible signals that a /Items/Latest request cannot be served
+// through the native section path without diverging from the BrowseItems
+// fallback, so HandleLatest should fall back quietly rather than log a failure.
+var errLatestNotEligible = errors.New("jellycompat: latest not eligible for native section path")
+
+// loadLatestViaSections serves a per-library /Items/Latest through the native
+// recently-added section fetch, reusing the shared resolved-list cache. The
+// synthetic section carries the same type+config+limit+scope the native library
+// rail uses, so with the identity-independent cache key both surfaces collapse
+// to one shared entry. The cached *models.MediaItem values are treated
+// read-only; LocalizeItemModels deep-copies before any presign mutation.
+func (h *ItemsHandler) loadLatestViaSections(ctx context.Context, session *Session, query itemsQuery) ([]baseItemDTO, error) {
+	// The caller has already restricted this to movies/series libraries. Pin the
+	// exact single type the BrowseItems fallback would use (movie or series) so
+	// the two paths return byte-identical membership; if a client asked for some
+	// other type against this library, fall back rather than risk a mismatch.
+	cfg := latestRecentlyAddedConfig(query.itemTypes)
+	if cfg == nil {
+		return nil, errLatestNotEligible
+	}
+
+	filter := h.resolveAccessFilter(ctx, session)
+	// Fold the client's clamped max content rating into the access filter so the
+	// shared cached list respects the client's cap AND the cache key captures it
+	// — identical to the clamp BrowseItems applies.
+	filter.MaxContentRating = clampMaxContentRating(filter.MaxContentRating, query.maxOfficialRating)
+
+	limit := query.limit
+	if limit <= 0 {
+		limit = compatDefaultLatestLimit
+	}
+	libraryID := query.parentLibraryID
+	resolved := sections.ResolvedSection{
+		ID:          "compat-latest",
+		SectionType: sections.SectionRecentlyAdded,
+		Title:       "Latest",
+		ItemLimit:   limit,
+		Config:      cfg,
+	}
+
+	withItems, err := h.sectionsFetcher.FetchOne(ctx, resolved, &libraryID, nil, session.StreamAppUserID, session.ProfileID, filter)
+	if err != nil {
+		return nil, err
+	}
+
+	listItems := h.compatListItemsFromModels(ctx, filter, withItems.Items)
+	return h.buildLatestItemDTOs(ctx, session, query, listItems)
+}
+
+// compatDefaultLatestLimit mirrors BrowseItems' default page size (see
+// directContentService.BrowseItems) so the native Latest path fetches the same
+// number of rows when the client omits Limit.
+const compatDefaultLatestLimit = 24
+
+// latestRecentlyAddedConfig encodes the inferred item-type filter into the
+// recently-added section Config (the filter_type field buildRecentlyAddedQuery
+// reads). It normalizes through compatScopedTypes — the SAME helper BrowseItems
+// uses — and only encodes a concrete single type (movie or series); an empty or
+// mixed library yields a nil config (all types).
+func latestRecentlyAddedConfig(itemTypes []string) json.RawMessage {
+	scoped := compatScopedTypes(strings.Join(itemTypes, ","))
+	var filterType string
+	switch scoped {
+	case "movie", "series":
+		filterType = scoped
+	default:
+		return nil
+	}
+	cfg, err := json.Marshal(sections.SectionConfigFilters{FilterType: filterType})
+	if err != nil {
+		return nil
+	}
+	return cfg
+}
+
+// compatListItemsFromModels localizes cached media-item models, converts them to
+// the compat list-item wire shape, and presigns their image URLs. The cached
+// models are never mutated in place: LocalizeItemModels deep-copies, and the
+// per-item presign operates on the freshly-built upstreamListItem values.
+func (h *ItemsHandler) compatListItemsFromModels(ctx context.Context, filter catalog.AccessFilter, items []*models.MediaItem) []upstreamListItem {
+	localized := items
+	if h.detailSvc != nil {
+		if loc, err := h.detailSvc.LocalizeItemModels(ctx, items, filter); err == nil && loc != nil {
+			localized = loc
+		}
+	}
+	listItems := make([]upstreamListItem, 0, len(localized))
+	for _, mi := range localized {
+		if mi == nil {
+			continue
+		}
+		li := mediaItemToListItem(mi)
+		h.presignCompatListItem(ctx, &li)
+		listItems = append(listItems, li)
+	}
+	return listItems
 }
 
 // HandleSuggestions serves GET /Items/Suggestions.

--- a/internal/jellycompat/handlers_items.go
+++ b/internal/jellycompat/handlers_items.go
@@ -2426,6 +2426,15 @@ func (h *ItemsHandler) loadProgressPage(ctx context.Context, session *Session, s
 			if len(result) >= query.limit || rawCount < batchSize {
 				break
 			}
+			// Same bound as the general loop below: the resume fast path filters in
+			// memory via FilterResumeProgress, so a sparse visible set (heavy
+			// watcher with mostly dismissed/superseded recent rows) would otherwise
+			// page to the end of history without ever filling the page. This is the
+			// default Continue Watching shape and the fallback hit when the sections
+			// fetcher is unavailable, so it must be bounded too.
+			if resumeFiltered && offset+rawCount >= resumeScanMaxRows {
+				break
+			}
 			offset += rawCount
 		}
 		return h.finishProgressPage(ctx, session, result, query, libraryID), 0, nil
@@ -2496,16 +2505,21 @@ func (h *ItemsHandler) loadProgressPage(ctx context.Context, session *Session, s
 		if !query.enableTotalRecordCount && len(items) >= query.limit {
 			break
 		}
-		// Bound the scan unconditionally: never page through more than
-		// resumeScanMaxRows of history in one request, even when the visible
-		// (post-filter) page stays sparse. The in-progress path filters in memory
-		// via FilterResumeProgress, so a heavy watcher whose recent rows are mostly
-		// dismissed/superseded could otherwise keep paging to the end of history
-		// without ever filling the page. Progress rows are recency-ordered, so the
-		// most recent resumeScanMaxRows already cover every realistically-visible
-		// Continue Watching entry; beyond the cap we stop and return what we have
-		// (and, for EnableTotalRecordCount, a clamped lower-bound total).
-		if offset >= resumeScanMaxRows {
+		// Bound the resume scan: never page through more than resumeScanMaxRows of
+		// history in one request, even when the visible (post-filter) page stays
+		// sparse. The in-progress path filters in memory via FilterResumeProgress,
+		// so a heavy watcher whose recent rows are mostly dismissed/superseded
+		// could otherwise keep paging to the end of history without ever filling
+		// the page. Progress rows are recency-ordered, so the most recent
+		// resumeScanMaxRows already cover every realistically-visible Continue
+		// Watching entry; beyond the cap we stop and return what we have (and, for
+		// EnableTotalRecordCount, a clamped lower-bound total).
+		//
+		// Gated on resumeFiltered so the completed (watched-items) path is exempt:
+		// there the SQL pre-filter already bounds the scan and clients paginate on
+		// an exact TotalRecordCount, so capping would underreport the total and
+		// drop deep StartIndex pages.
+		if resumeFiltered && offset >= resumeScanMaxRows {
 			break
 		}
 	}

--- a/internal/jellycompat/handlers_items.go
+++ b/internal/jellycompat/handlers_items.go
@@ -1125,6 +1125,14 @@ func (h *ItemsHandler) loadLatestViaSections(ctx context.Context, session *Sessi
 	}
 
 	listItems := h.compatListItemsFromModels(ctx, filter, withItems.Items)
+	// The BrowseItems fallback aggregates series watch state via
+	// EnrichSeriesUserData; a series has no progress row of its own, so without
+	// this its Latest rail would drop Played/UnplayedItemCount and diverge from
+	// page 2. Enrich the freshly-built per-request list items (never the cached
+	// models) before the DTOs are built so userDataDTO sees the populated
+	// UserData. It runs under the request session, so counts are per-profile, and
+	// only touches series rows (movies are left untouched).
+	h.content.EnrichSeriesUserData(ctx, session, listItems)
 	return h.buildLatestItemDTOs(ctx, session, query, listItems)
 }
 
@@ -1170,10 +1178,9 @@ func (h *ItemsHandler) compatListItemsFromModels(ctx context.Context, filter cat
 		if mi == nil {
 			continue
 		}
-		li := mediaItemToListItem(mi)
-		h.presignCompatListItem(ctx, &li)
-		listItems = append(listItems, li)
+		listItems = append(listItems, mediaItemToListItem(mi))
 	}
+	presignCompatListItems(h.detailSvc, ctx, listItems)
 	return listItems
 }
 
@@ -2075,10 +2082,9 @@ func (h *ItemsHandler) handleFavoriteItems(w http.ResponseWriter, r *http.Reques
 
 		listItems := make([]upstreamListItem, 0, len(result.Items))
 		for _, mi := range result.Items {
-			listItem := mediaItemToListItem(mi)
-			h.presignCompatListItem(r.Context(), &listItem)
-			listItems = append(listItems, listItem)
+			listItems = append(listItems, mediaItemToListItem(mi))
 		}
+		presignCompatListItems(h.detailSvc, r.Context(), listItems)
 		h.rememberListImages(listItems)
 
 		progress, progressErr := resolveProgressForContentIDs(r.Context(), session, h.userData, contentIDsFromListItems(listItems))
@@ -2810,29 +2816,6 @@ func (h *ItemsHandler) resolveAccessFilter(ctx context.Context, session *Session
 		return withCompatAccessExclusions(h.accessFilter(ctx, session.StreamAppUserID, session.ProfileID))
 	}
 	return withCompatAccessExclusions(catalog.AccessFilter{})
-}
-
-func (h *ItemsHandler) presignCompatListItem(ctx context.Context, item *upstreamListItem) {
-	if item.PosterPath == "" {
-		item.PosterPath = item.PosterURL
-	}
-	if item.BackdropPath == "" {
-		item.BackdropPath = item.BackdropURL
-	}
-	if item.LogoPath == "" {
-		item.LogoPath = item.LogoURL
-	}
-	if item.StillPath == "" {
-		item.StillPath = item.StillURL
-	}
-	item.PosterURL = h.presignCompatImagePath(ctx, item.PosterURL, "poster")
-	item.BackdropURL = h.presignCompatImagePath(ctx, item.BackdropURL, "backdrop")
-	item.LogoURL = h.presignCompatImagePath(ctx, item.LogoURL, "logo")
-	item.StillURL = h.presignCompatImagePath(ctx, item.StillURL, "still")
-}
-
-func (h *ItemsHandler) presignCompatImagePath(ctx context.Context, path, imageType string) string {
-	return compatPresignImage(h.detailSvc, ctx, path, imageType, compatCardImageSize)
 }
 
 func (h *ItemsHandler) rememberCompatEpisodeImages(dto baseItemDTO, stillURL string, series seriesImageSet) {

--- a/internal/jellycompat/handlers_items.go
+++ b/internal/jellycompat/handlers_items.go
@@ -1180,7 +1180,7 @@ func (h *ItemsHandler) compatListItemsFromModels(ctx context.Context, filter cat
 		}
 		listItems = append(listItems, mediaItemToListItem(mi))
 	}
-	presignCompatListItems(h.detailSvc, ctx, listItems)
+	presignCompatListItems(ctx, h.detailSvc, listItems)
 	return listItems
 }
 
@@ -2084,7 +2084,7 @@ func (h *ItemsHandler) handleFavoriteItems(w http.ResponseWriter, r *http.Reques
 		for _, mi := range result.Items {
 			listItems = append(listItems, mediaItemToListItem(mi))
 		}
-		presignCompatListItems(h.detailSvc, r.Context(), listItems)
+		presignCompatListItems(r.Context(), h.detailSvc, listItems)
 		h.rememberListImages(listItems)
 
 		progress, progressErr := resolveProgressForContentIDs(r.Context(), session, h.userData, contentIDsFromListItems(listItems))

--- a/internal/jellycompat/handlers_items.go
+++ b/internal/jellycompat/handlers_items.go
@@ -954,14 +954,11 @@ func (h *ItemsHandler) HandleLatest(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
-	// Fast path: a per-library Latest (first page, no played filter, no backdrop
-	// filter) is the same user-agnostic list as the native "recently added"
-	// library rail (both order by mil.first_seen_at DESC). Serve it through the
-	// native section fetch so it reuses the shared resolved-list cache instead of
-	// re-running BrowseItems. It is restricted to movies and series libraries;
-	// every other library type (ebook, music, manga, mixed, …) is ignored and
-	// keeps its exact BrowseItems behavior. On any failure fall back to browse.
-	if (libraryItemType == "movie" || libraryItemType == "series") && query.startIndex == 0 && query.isPlayed == nil && !query.requireBackdrop && h.sectionsFetcher != nil {
+	// Fast path: a per-library Latest is the same user-agnostic list as the native
+	// "recently added" library rail (both order by mil.first_seen_at DESC). When
+	// eligible, serve it through the native section fetch so it reuses the shared
+	// resolved-list cache instead of re-running BrowseItems; otherwise fall back.
+	if latestFastPathEligible(query, libraryItemType, h.sectionsFetcher != nil) {
 		items, err := h.loadLatestViaSections(r.Context(), session, query)
 		if err == nil {
 			applyImageTypeLimit(items, query.imageTypeLimit)
@@ -1055,6 +1052,32 @@ func (h *ItemsHandler) buildLatestItemDTOs(ctx context.Context, session *Session
 // fallback, so HandleLatest should fall back quietly rather than log a failure.
 var errLatestNotEligible = errors.New("jellycompat: latest not eligible for native section path")
 
+// latestFastPathEligible reports whether a /Items/Latest request can be served
+// through the native recently-added section (and its shared cache) with results
+// identical to the BrowseItems fallback. The synthetic recently-added section
+// only expresses a single library type plus the access scope, so any request
+// that carries a filter it cannot reproduce must fall back:
+//   - not a movies/series library (mixed/ebook/music/… would surface non-video);
+//   - a deeper page, played-status filter, or backdrop-required flag; or
+//   - a genre, name-prefix, or person filter (the section config can't scope to
+//     these, so serving unfiltered recently-added would return a wrong, broader
+//     result set than BrowseItems does).
+func latestFastPathEligible(query itemsQuery, libraryItemType string, hasSectionsFetcher bool) bool {
+	if !hasSectionsFetcher {
+		return false
+	}
+	if libraryItemType != "movie" && libraryItemType != "series" {
+		return false
+	}
+	if query.startIndex != 0 || query.isPlayed != nil || query.requireBackdrop {
+		return false
+	}
+	if query.genreName != "" || query.namePrefix != "" || query.personID != 0 {
+		return false
+	}
+	return true
+}
+
 // loadLatestViaSections serves a per-library /Items/Latest through the native
 // recently-added section fetch, reusing the shared resolved-list cache. The
 // synthetic section carries the same type+config+limit+scope the native library
@@ -1080,6 +1103,12 @@ func (h *ItemsHandler) loadLatestViaSections(ctx context.Context, session *Sessi
 	limit := query.limit
 	if limit <= 0 {
 		limit = compatDefaultLatestLimit
+	}
+	// Clamp to the same ceiling the BrowseItems fallback enforces, so a large
+	// client Limit can't drive an oversized recently-added fetch or explode the
+	// shared cache key with unbounded ItemLimit values.
+	if limit > compatBrowseMaxLimit {
+		limit = compatBrowseMaxLimit
 	}
 	libraryID := query.parentLibraryID
 	resolved := sections.ResolvedSection{

--- a/internal/jellycompat/handlers_items.go
+++ b/internal/jellycompat/handlers_items.go
@@ -2244,6 +2244,22 @@ func (h *ItemsHandler) handleResumeResponse(w http.ResponseWriter, r *http.Reque
 // scan bounded and predictable under load.
 const maxResumeItems = 50
 
+// resumeScanMaxRows bounds how many progress rows loadProgressPage will scan in
+// a single request. Without a cap, a client sending EnableTotalRecordCount=true
+// (or a Series/Season-only request, which matches no leaf in-progress row) forces
+// the in-progress loop to page through the profile's entire history — an
+// O(history) scan that reached tens of seconds for heavy watchers.
+//
+// In the common case the loop exits far earlier (the page fills from the first
+// batch or two), so this cap only engages for pathological/empty-match requests;
+// its value just bounds that worst case. 300 gives ample headroom to fill a
+// ~20-item Continue Watching page even when the great majority of recent rows are
+// dismissed/superseded, while keeping the wasted scan on empty-match requests
+// small. Progress rows are recency-ordered, so the first resumeScanMaxRows cover
+// every realistically-visible entry; beyond the cap the returned total becomes a
+// clamped lower bound (the "+" suffix behavior clients already tolerate).
+const resumeScanMaxRows = 300
+
 // loadResumeViaSections serves Continue Watching through the native
 // continue-watching fetcher. The fetcher applies the same dismissal and
 // superseded-episode filtering as FilterResumeProgress, so visible parity with
@@ -2478,6 +2494,18 @@ func (h *ItemsHandler) loadProgressPage(ctx context.Context, session *Session, s
 			break
 		}
 		if !query.enableTotalRecordCount && len(items) >= query.limit {
+			break
+		}
+		// Bound the scan unconditionally: never page through more than
+		// resumeScanMaxRows of history in one request, even when the visible
+		// (post-filter) page stays sparse. The in-progress path filters in memory
+		// via FilterResumeProgress, so a heavy watcher whose recent rows are mostly
+		// dismissed/superseded could otherwise keep paging to the end of history
+		// without ever filling the page. Progress rows are recency-ordered, so the
+		// most recent resumeScanMaxRows already cover every realistically-visible
+		// Continue Watching entry; beyond the cap we stop and return what we have
+		// (and, for EnableTotalRecordCount, a clamped lower-bound total).
+		if offset >= resumeScanMaxRows {
 			break
 		}
 	}

--- a/internal/jellycompat/handlers_items.go
+++ b/internal/jellycompat/handlers_items.go
@@ -18,6 +18,7 @@ import (
 	"github.com/google/uuid"
 	"github.com/jackc/pgx/v5"
 
+	"github.com/Silo-Server/silo-server/internal/access"
 	"github.com/Silo-Server/silo-server/internal/catalog"
 	"github.com/Silo-Server/silo-server/internal/config"
 	"github.com/Silo-Server/silo-server/internal/models"
@@ -954,11 +955,17 @@ func (h *ItemsHandler) HandleLatest(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
+	// Build the fallback's browse params FIRST: fast-path eligibility is
+	// decided off these actual params (see latestFastPathEligible), so a filter
+	// later added to buildBrowseParams can never be silently ignored by the
+	// cached path.
+	params := buildLatestBrowseParams(query)
+
 	// Fast path: a per-library Latest is the same user-agnostic list as the native
 	// "recently added" library rail (both order by mil.first_seen_at DESC). When
 	// eligible, serve it through the native section fetch so it reuses the shared
 	// resolved-list cache instead of re-running BrowseItems; otherwise fall back.
-	if latestFastPathEligible(query, libraryItemType, h.sectionsFetcher != nil) {
+	if h.sectionsFetcher != nil && latestFastPathEligible(params, libraryItemType) {
 		items, err := h.loadLatestViaSections(r.Context(), session, query)
 		if err == nil {
 			applyImageTypeLimit(items, query.imageTypeLimit)
@@ -972,8 +979,6 @@ func (h *ItemsHandler) HandleLatest(w http.ResponseWriter, r *http.Request) {
 			slog.Warn("jellycompat: latest via sections failed, falling back to browse", "error", err)
 		}
 	}
-
-	params := buildLatestBrowseParams(query)
 	result, err := h.content.BrowseItems(r.Context(), session, params)
 	if err != nil {
 		writeCompatUpstreamError(w, err)
@@ -1052,28 +1057,59 @@ func (h *ItemsHandler) buildLatestItemDTOs(ctx context.Context, session *Session
 // fallback, so HandleLatest should fall back quietly rather than log a failure.
 var errLatestNotEligible = errors.New("jellycompat: latest not eligible for native section path")
 
+// latestFastPathReproducibleParams is the closed set of browse params the
+// synthetic recently-added section reproduces exactly:
+//   - limit / offset — offset must be 0 (checked below); limit is applied by
+//     slicing the shared list;
+//   - type / library_id — expressed by the section config + library scope;
+//   - sort / order — buildLatestBrowseParams pins recently_added/desc on both
+//     paths;
+//   - include_total — Latest returns a bare array, so the total is unused;
+//   - max_content_rating — folded into the access filter (and the cache key).
+//
+// Any OTHER param buildBrowseParams emits — today's filters (genre,
+// name_prefix, person_id, is_played, require_backdrop) and any filter added in
+// the future — disqualifies the fast path, because the shared cached list
+// cannot honor it. Deciding off the actual params (not a hand-mirrored field
+// list) is what keeps this gate and the fallback from silently drifting apart.
+var latestFastPathReproducibleParams = map[string]struct{}{
+	"limit":              {},
+	"offset":             {},
+	"type":               {},
+	"library_id":         {},
+	"sort":               {},
+	"order":              {},
+	"include_total":      {},
+	"max_content_rating": {},
+}
+
 // latestFastPathEligible reports whether a /Items/Latest request can be served
 // through the native recently-added section (and its shared cache) with results
-// identical to the BrowseItems fallback. The synthetic recently-added section
-// only expresses a single library type plus the access scope, so any request
-// that carries a filter it cannot reproduce must fall back:
-//   - not a movies/series library (mixed/ebook/music/… would surface non-video);
-//   - a deeper page, played-status filter, or backdrop-required flag; or
-//   - a genre, name-prefix, or person filter (the section config can't scope to
-//     these, so serving unfiltered recently-added would return a wrong, broader
-//     result set than BrowseItems does).
-func latestFastPathEligible(query itemsQuery, libraryItemType string, hasSectionsFetcher bool) bool {
-	if !hasSectionsFetcher {
-		return false
-	}
+// identical to the BrowseItems fallback. It inspects the browse params the
+// fallback would actually receive: every param must be one the section path
+// reproduces, the request must be for the first page of a movies/series
+// library, the limit must fit the fixed shared fetch budget, and a client
+// rating cap must be a known rating (an unknown string matches nothing in
+// BrowseItems and must not mint arbitrary cache keys).
+func latestFastPathEligible(params url.Values, libraryItemType string) bool {
 	if libraryItemType != "movie" && libraryItemType != "series" {
 		return false
 	}
-	if query.startIndex != 0 || query.isPlayed != nil || query.requireBackdrop {
+	for key := range params {
+		if _, ok := latestFastPathReproducibleParams[key]; !ok {
+			return false
+		}
+	}
+	if params.Get("offset") != "0" {
 		return false
 	}
-	if query.genreName != "" || query.namePrefix != "" || query.personID != 0 {
+	if limit := catalog.ParseIntParam(params.Get("limit")); limit > compatLatestCacheFetchLimit {
 		return false
+	}
+	if rating := strings.TrimSpace(params.Get("max_content_rating")); rating != "" {
+		if _, known := access.RatingRank(rating); !known {
+			return false
+		}
 	}
 	return true
 }
@@ -1102,20 +1138,24 @@ func (h *ItemsHandler) loadLatestViaSections(ctx context.Context, session *Sessi
 
 	limit := query.limit
 	if limit <= 0 {
-		limit = compatDefaultLatestLimit
+		limit = compatDefaultBrowseLimit
 	}
-	// Clamp to the same ceiling the BrowseItems fallback enforces, so a large
-	// client Limit can't drive an oversized recently-added fetch or explode the
-	// shared cache key with unbounded ItemLimit values.
-	if limit > compatBrowseMaxLimit {
-		limit = compatBrowseMaxLimit
+	// Eligibility already rejected limits beyond the shared fetch budget, but
+	// this path must stay safe if called directly.
+	if limit > compatLatestCacheFetchLimit {
+		return nil, errLatestNotEligible
 	}
 	libraryID := query.parentLibraryID
+	// Always fetch the FIXED compatLatestCacheFetchLimit budget and slice down
+	// to the requested page below. ItemLimit is a cache-key component, so
+	// echoing the raw client Limit would let one client mint a distinct
+	// process-global cache entry per Limit value; with the fixed budget every
+	// compat Latest request for a scope+library shares exactly one entry.
 	resolved := sections.ResolvedSection{
 		ID:          "compat-latest",
 		SectionType: sections.SectionRecentlyAdded,
 		Title:       "Latest",
-		ItemLimit:   limit,
+		ItemLimit:   compatLatestCacheFetchLimit,
 		Config:      cfg,
 	}
 
@@ -1124,7 +1164,14 @@ func (h *ItemsHandler) loadLatestViaSections(ctx context.Context, session *Sessi
 		return nil, err
 	}
 
-	listItems := h.compatListItemsFromModels(ctx, filter, withItems.Items)
+	// The shared list is ordered by first_seen_at DESC, so its first N entries
+	// are exactly what a direct limit-N fetch would return.
+	sharedItems := withItems.Items
+	if len(sharedItems) > limit {
+		sharedItems = sharedItems[:limit]
+	}
+
+	listItems := h.compatListItemsFromModels(ctx, filter, sharedItems)
 	// The BrowseItems fallback aggregates series watch state via
 	// EnrichSeriesUserData; a series has no progress row of its own, so without
 	// this its Latest rail would drop Played/UnplayedItemCount and diverge from
@@ -1136,10 +1183,13 @@ func (h *ItemsHandler) loadLatestViaSections(ctx context.Context, session *Sessi
 	return h.buildLatestItemDTOs(ctx, session, query, listItems)
 }
 
-// compatDefaultLatestLimit mirrors BrowseItems' default page size (see
-// directContentService.BrowseItems) so the native Latest path fetches the same
-// number of rows when the client omits Limit.
-const compatDefaultLatestLimit = 24
+// compatLatestCacheFetchLimit is the fixed number of rows the Latest fast path
+// asks the shared recently-added cache for, regardless of the client's Limit
+// (the response is sliced down afterwards). Fixing the fetch size keeps the
+// client's Limit out of the cache key — one entry per scope+library instead of
+// one per distinct Limit value — and comfortably covers the Latest hot path
+// (clients request ~16-50); larger limits fall back to BrowseItems.
+const compatLatestCacheFetchLimit = 100
 
 // latestRecentlyAddedConfig encodes the inferred item-type filter into the
 // recently-added section Config (the filter_type field buildRecentlyAddedQuery

--- a/internal/jellycompat/handlers_items_test.go
+++ b/internal/jellycompat/handlers_items_test.go
@@ -94,6 +94,9 @@ func (s *countingContentService) ListItemFilters(context.Context, *Session, url.
 	panic("unused")
 }
 
+func (s *countingContentService) EnrichSeriesUserData(context.Context, *Session, []upstreamListItem) {
+}
+
 type recordingSearchContentService struct {
 	countingContentService
 	options []SearchItemsOptions

--- a/internal/jellycompat/latest_via_sections_test.go
+++ b/internal/jellycompat/latest_via_sections_test.go
@@ -1,0 +1,54 @@
+package jellycompat
+
+import (
+	"testing"
+
+	"github.com/Silo-Server/silo-server/internal/sections"
+)
+
+// TestLatestRecentlyAddedConfigParity is the data-parity assertion for the
+// native /Items/Latest fast path. A DB-backed comparison of the emitted rows is
+// out of scope for a unit test, so instead we prove the two surfaces feed the
+// SAME recently-added query the SAME type filter: the config the compat path
+// builds must round-trip through the native ParseConfigFilters/filter_type that
+// buildRecentlyAddedQuery reads. Same type filter + same library + same scope +
+// same limit + same ORDER BY mil.first_seen_at DESC ⇒ identical membership and
+// ordering.
+func TestLatestRecentlyAddedConfigParity(t *testing.T) {
+	cases := []struct {
+		name           string
+		itemTypes      []string
+		wantFilterType string
+	}{
+		{name: "movies library", itemTypes: []string{"movie"}, wantFilterType: "movie"},
+		{name: "series library", itemTypes: []string{"series"}, wantFilterType: "series"},
+		{name: "empty/mixed library", itemTypes: nil, wantFilterType: ""},
+		{name: "mixed explicit types", itemTypes: []string{"movie", "series"}, wantFilterType: ""},
+		{name: "unsupported type", itemTypes: []string{"boxset"}, wantFilterType: ""},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			cfg := latestRecentlyAddedConfig(tc.itemTypes)
+			// Native reads the filter type via the shared ParseConfigFilters; the
+			// compat config must decode to exactly the same value.
+			got := sections.ParseConfigFilters(cfg).FilterType
+			if got != tc.wantFilterType {
+				t.Fatalf("latestRecentlyAddedConfig(%v) filter_type = %q, want %q", tc.itemTypes, got, tc.wantFilterType)
+			}
+		})
+	}
+}
+
+// TestLatestRecentlyAddedConfigUsesScopedTypes documents that the config helper
+// normalizes through the same compatScopedTypes clamp BrowseItems uses, so a
+// concrete single video type is preserved while anything that clamps to a
+// multi-type or no-match set falls back to the all-types (nil) config.
+func TestLatestRecentlyAddedConfigUsesScopedTypes(t *testing.T) {
+	if cfg := latestRecentlyAddedConfig([]string{"Movie"}); cfg == nil {
+		t.Fatalf("a movie-typed library should yield a non-nil filter_type config")
+	}
+	if cfg := latestRecentlyAddedConfig(nil); cfg != nil {
+		t.Fatalf("an untyped (mixed) library should yield a nil (all-types) config, got %s", cfg)
+	}
+}

--- a/internal/jellycompat/latest_via_sections_test.go
+++ b/internal/jellycompat/latest_via_sections_test.go
@@ -6,6 +6,53 @@ import (
 	"github.com/Silo-Server/silo-server/internal/sections"
 )
 
+// TestLatestFastPathEligible pins the eligibility rules for the native
+// /Items/Latest fast path. The synthetic recently-added section can only express
+// a single library type + access scope, so any request carrying a filter it
+// cannot reproduce must fall back to BrowseItems. Genre/name-prefix/person are
+// the regression this guards: the section config cannot scope to them, so
+// serving unfiltered recently-added would return a wrong, broader result set.
+func TestLatestFastPathEligible(t *testing.T) {
+	played := true
+	base := func() itemsQuery { return itemsQuery{parentLibraryID: 7, startIndex: 0} }
+
+	eligible := base()
+	if !latestFastPathEligible(eligible, "movie", true) {
+		t.Fatalf("a plain first-page movies-library Latest should be eligible")
+	}
+	if !latestFastPathEligible(base(), "series", true) {
+		t.Fatalf("a plain first-page series-library Latest should be eligible")
+	}
+
+	cases := []struct {
+		name    string
+		libType string
+		fetcher bool
+		mutate  func(*itemsQuery)
+	}{
+		{name: "no sections fetcher", libType: "movie", fetcher: false},
+		{name: "non-video library", libType: "", fetcher: true},
+		{name: "ebook library", libType: "ebook", fetcher: true},
+		{name: "deeper page", libType: "movie", fetcher: true, mutate: func(q *itemsQuery) { q.startIndex = 24 }},
+		{name: "played filter", libType: "movie", fetcher: true, mutate: func(q *itemsQuery) { q.isPlayed = &played }},
+		{name: "backdrop required", libType: "movie", fetcher: true, mutate: func(q *itemsQuery) { q.requireBackdrop = true }},
+		{name: "genre filter", libType: "movie", fetcher: true, mutate: func(q *itemsQuery) { q.genreName = "Action" }},
+		{name: "name prefix filter", libType: "movie", fetcher: true, mutate: func(q *itemsQuery) { q.namePrefix = "The" }},
+		{name: "person filter", libType: "series", fetcher: true, mutate: func(q *itemsQuery) { q.personID = 42 }},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			q := base()
+			if tc.mutate != nil {
+				tc.mutate(&q)
+			}
+			if latestFastPathEligible(q, tc.libType, tc.fetcher) {
+				t.Fatalf("%s must NOT be eligible for the native fast path", tc.name)
+			}
+		})
+	}
+}
+
 // TestLatestRecentlyAddedConfigParity is the data-parity assertion for the
 // native /Items/Latest fast path. A DB-backed comparison of the emitted rows is
 // out of scope for a unit test, so instead we prove the two surfaces feed the

--- a/internal/jellycompat/latest_via_sections_test.go
+++ b/internal/jellycompat/latest_via_sections_test.go
@@ -2,6 +2,7 @@ package jellycompat
 
 import (
 	"context"
+	"net/url"
 	"testing"
 
 	"github.com/Silo-Server/silo-server/internal/config"
@@ -11,38 +12,43 @@ import (
 )
 
 // TestLatestFastPathEligible pins the eligibility rules for the native
-// /Items/Latest fast path. The synthetic recently-added section can only express
-// a single library type + access scope, so any request carrying a filter it
-// cannot reproduce must fall back to BrowseItems. Genre/name-prefix/person are
-// the regression this guards: the section config cannot scope to them, so
-// serving unfiltered recently-added would return a wrong, broader result set.
+// /Items/Latest fast path. Eligibility is decided off the ACTUAL browse params
+// the fallback would receive (buildLatestBrowseParams), so any filter the
+// synthetic recently-added section cannot reproduce — including params added to
+// buildBrowseParams in the future — must disqualify the request rather than be
+// silently ignored by the cached path.
 func TestLatestFastPathEligible(t *testing.T) {
 	played := true
-	base := func() itemsQuery { return itemsQuery{parentLibraryID: 7, startIndex: 0} }
+	base := func() itemsQuery { return itemsQuery{parentLibraryID: 7, startIndex: 0, limit: 24} }
+	paramsFor := func(q itemsQuery) url.Values { return buildLatestBrowseParams(q) }
 
-	eligible := base()
-	if !latestFastPathEligible(eligible, "movie", true) {
+	if !latestFastPathEligible(paramsFor(base()), "movie") {
 		t.Fatalf("a plain first-page movies-library Latest should be eligible")
 	}
-	if !latestFastPathEligible(base(), "series", true) {
+	if !latestFastPathEligible(paramsFor(base()), "series") {
 		t.Fatalf("a plain first-page series-library Latest should be eligible")
+	}
+	knownRating := base()
+	knownRating.maxOfficialRating = "PG-13"
+	if !latestFastPathEligible(paramsFor(knownRating), "movie") {
+		t.Fatalf("a known max rating should stay eligible (it folds into the access filter)")
 	}
 
 	cases := []struct {
 		name    string
 		libType string
-		fetcher bool
 		mutate  func(*itemsQuery)
 	}{
-		{name: "no sections fetcher", libType: "movie", fetcher: false},
-		{name: "non-video library", libType: "", fetcher: true},
-		{name: "ebook library", libType: "ebook", fetcher: true},
-		{name: "deeper page", libType: "movie", fetcher: true, mutate: func(q *itemsQuery) { q.startIndex = 24 }},
-		{name: "played filter", libType: "movie", fetcher: true, mutate: func(q *itemsQuery) { q.isPlayed = &played }},
-		{name: "backdrop required", libType: "movie", fetcher: true, mutate: func(q *itemsQuery) { q.requireBackdrop = true }},
-		{name: "genre filter", libType: "movie", fetcher: true, mutate: func(q *itemsQuery) { q.genreName = "Action" }},
-		{name: "name prefix filter", libType: "movie", fetcher: true, mutate: func(q *itemsQuery) { q.namePrefix = "The" }},
-		{name: "person filter", libType: "series", fetcher: true, mutate: func(q *itemsQuery) { q.personID = 42 }},
+		{name: "non-video library", libType: ""},
+		{name: "ebook library", libType: "ebook"},
+		{name: "deeper page", libType: "movie", mutate: func(q *itemsQuery) { q.startIndex = 24 }},
+		{name: "played filter", libType: "movie", mutate: func(q *itemsQuery) { q.isPlayed = &played }},
+		{name: "backdrop required", libType: "movie", mutate: func(q *itemsQuery) { q.requireBackdrop = true }},
+		{name: "genre filter", libType: "movie", mutate: func(q *itemsQuery) { q.genreName = "Action" }},
+		{name: "name prefix filter", libType: "movie", mutate: func(q *itemsQuery) { q.namePrefix = "The" }},
+		{name: "person filter", libType: "series", mutate: func(q *itemsQuery) { q.personID = 42 }},
+		{name: "limit beyond shared fetch budget", libType: "movie", mutate: func(q *itemsQuery) { q.limit = compatLatestCacheFetchLimit + 1 }},
+		{name: "unknown rating string", libType: "movie", mutate: func(q *itemsQuery) { q.maxOfficialRating = "NOT-A-RATING" }},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
@@ -50,10 +56,18 @@ func TestLatestFastPathEligible(t *testing.T) {
 			if tc.mutate != nil {
 				tc.mutate(&q)
 			}
-			if latestFastPathEligible(q, tc.libType, tc.fetcher) {
+			if latestFastPathEligible(paramsFor(q), tc.libType) {
 				t.Fatalf("%s must NOT be eligible for the native fast path", tc.name)
 			}
 		})
+	}
+
+	// The future-drift guard: a param buildBrowseParams starts emitting that
+	// this gate has never heard of must disqualify the fast path on its own.
+	future := paramsFor(base())
+	future.Set("years", "2020")
+	if latestFastPathEligible(future, "movie") {
+		t.Fatal("an unrecognized browse param must disqualify the fast path")
 	}
 }
 

--- a/internal/jellycompat/latest_via_sections_test.go
+++ b/internal/jellycompat/latest_via_sections_test.go
@@ -1,9 +1,13 @@
 package jellycompat
 
 import (
+	"context"
 	"testing"
 
+	"github.com/Silo-Server/silo-server/internal/config"
+	"github.com/Silo-Server/silo-server/internal/models"
 	"github.com/Silo-Server/silo-server/internal/sections"
+	"github.com/Silo-Server/silo-server/internal/userstore"
 )
 
 // TestLatestFastPathEligible pins the eligibility rules for the native
@@ -97,5 +101,157 @@ func TestLatestRecentlyAddedConfigUsesScopedTypes(t *testing.T) {
 	}
 	if cfg := latestRecentlyAddedConfig(nil); cfg != nil {
 		t.Fatalf("an untyped (mixed) library should yield a nil (all-types) config, got %s", cfg)
+	}
+}
+
+// seriesEpisodeSource is an episodeListSource that returns a fixed episode set
+// per series via ListBySeriesIDs (the only method the series watch-state rollup
+// uses). Other methods are unused by this path.
+type seriesEpisodeSource struct {
+	bySeries map[string][]*models.Episode
+}
+
+func (s *seriesEpisodeSource) ListBySeason(context.Context, string, int) ([]*models.Episode, error) {
+	return nil, nil
+}
+
+func (s *seriesEpisodeSource) ListBySeriesGroupedBySeason(context.Context, string) (map[int][]*models.Episode, error) {
+	return nil, nil
+}
+
+func (s *seriesEpisodeSource) ListBySeriesIDs(_ context.Context, ids []string) (map[string][]*models.Episode, error) {
+	out := make(map[string][]*models.Episode, len(ids))
+	for _, id := range ids {
+		if eps, ok := s.bySeries[id]; ok {
+			out[id] = eps
+		}
+	}
+	return out, nil
+}
+
+func (s *seriesEpisodeSource) GetByIDs(context.Context, []string) ([]*models.Episode, error) {
+	return nil, nil
+}
+
+// completedProgressStore reports a configured set of episode ids as completed.
+// It reuses progressCountingStore's exhaustive panic-stubs for the rest of the
+// UserStore surface so any unexpected call is caught.
+type completedProgressStore struct {
+	*progressCountingStore
+	completed map[string]bool
+}
+
+func (s *completedProgressStore) ListProgressByMediaItems(_ context.Context, _ string, ids []string) (map[string]userstore.WatchProgress, error) {
+	out := make(map[string]userstore.WatchProgress, len(ids))
+	for _, id := range ids {
+		if s.completed[id] {
+			out[id] = userstore.WatchProgress{MediaItemID: id, Completed: true}
+		}
+	}
+	return out, nil
+}
+
+// completedProgressStoreProvider hands back a fixed completedProgressStore.
+type completedProgressStoreProvider struct {
+	store userstore.UserStore
+}
+
+func (p *completedProgressStoreProvider) ForUser(context.Context, int) (userstore.UserStore, error) {
+	return p.store, nil
+}
+
+func (p *completedProgressStoreProvider) Close() error { return nil }
+
+// TestLoadLatestViaSectionsEnrichesSeriesUserData is the data-parity regression
+// guard: the native /Items/Latest fast path must apply the same aggregated
+// series watch-state rollup (Played / UnplayedItemCount) the BrowseItems
+// fallback applies. A series has no progress row of its own, so this rollup —
+// produced by ContentService.EnrichSeriesUserData, the exact call BrowseItems
+// makes — is the ONLY source of that state. Without the fast-path enrichment a
+// series library's Latest rail would drop it and diverge from page 2.
+//
+// This exercises the post-localize tail of loadLatestViaSections (the shared
+// EnrichSeriesUserData → buildLatestItemDTOs steps); the sectionsFetcher hop
+// only supplies the same list items and is covered by the config-parity tests
+// above.
+func TestLoadLatestViaSectionsEnrichesSeriesUserData(t *testing.T) {
+	// series-1 has 3 episodes; 2 are completed ⇒ 1 unplayed, not fully played.
+	episodeSrc := &seriesEpisodeSource{
+		bySeries: map[string][]*models.Episode{
+			"series-1": {
+				{ContentID: "ep-1"},
+				{ContentID: "ep-2"},
+				{ContentID: "ep-3"},
+			},
+		},
+	}
+	provider := &completedProgressStoreProvider{
+		store: &completedProgressStore{
+			progressCountingStore: &progressCountingStore{},
+			completed:             map[string]bool{"ep-1": true, "ep-2": true},
+		},
+	}
+	svc := &directContentService{
+		episodeRepo:   episodeSrc,
+		storeProvider: provider,
+	}
+
+	codec := NewResourceIDCodec()
+	h := &ItemsHandler{
+		content:  svc,
+		userData: &mockUserDataService{},
+		codec:    codec,
+		mapper:   newMapper(codec, &config.Config{}),
+	}
+
+	session := &Session{StreamAppUserID: 1, ProfileID: "profile-1"}
+	listItems := []upstreamListItem{
+		{ContentID: "series-1", Type: "series", Title: "Show"},
+		{ContentID: "movie-1", Type: "movie", Title: "Film"},
+	}
+
+	// Mirror loadLatestViaSections' post-localize steps: enrich series rows,
+	// then build the wire DTOs.
+	h.content.EnrichSeriesUserData(context.Background(), session, listItems)
+
+	// The enrichment must populate the series list item in place (the input the
+	// DTO tail reads); a nil here is exactly the dropped-rollup regression.
+	if listItems[0].UserData == nil {
+		t.Fatal("EnrichSeriesUserData left the series list item's UserData nil (rollup dropped)")
+	}
+
+	dtos, err := h.buildLatestItemDTOs(context.Background(), session, itemsQuery{}, listItems)
+	if err != nil {
+		t.Fatalf("buildLatestItemDTOs error: %v", err)
+	}
+
+	seriesID := codec.EncodeStringID(EncodedIDItem, "series-1")
+	movieID := codec.EncodeStringID(EncodedIDItem, "movie-1")
+	byID := make(map[string]baseItemDTO, len(dtos))
+	for _, dto := range dtos {
+		byID[dto.ID] = dto
+	}
+
+	series, ok := byID[seriesID]
+	if !ok {
+		t.Fatalf("series DTO not found; got %#v", dtos)
+	}
+	if series.UserData == nil {
+		t.Fatal("series DTO UserData is nil; the fast path dropped the series rollup")
+	}
+	if series.UserData.UnplayedItemCount != 1 {
+		t.Fatalf("series UnplayedItemCount = %d, want 1 (3 episodes, 2 completed)", series.UserData.UnplayedItemCount)
+	}
+	if series.UserData.Played {
+		t.Fatal("series Played = true, want false (1 of 3 episodes unwatched)")
+	}
+
+	// Movies carry no episode rollup: the enrichment must not fabricate one.
+	movie, ok := byID[movieID]
+	if !ok {
+		t.Fatalf("movie DTO not found; got %#v", dtos)
+	}
+	if movie.UserData != nil && movie.UserData.UnplayedItemCount != 0 {
+		t.Fatalf("movie UnplayedItemCount = %d, want 0 (movies get no series rollup)", movie.UserData.UnplayedItemCount)
 	}
 }

--- a/internal/jellycompat/presign_list.go
+++ b/internal/jellycompat/presign_list.go
@@ -13,7 +13,7 @@ import (
 // rail costs four resolver invocations instead of 4×40. This is the single
 // shared implementation for both directContentService and ItemsHandler; do not
 // reintroduce a per-item presign body.
-func presignCompatListItems(detailSvc *catalog.DetailService, ctx context.Context, items []upstreamListItem) {
+func presignCompatListItems(ctx context.Context, detailSvc *catalog.DetailService, items []upstreamListItem) {
 	if len(items) == 0 {
 		return
 	}

--- a/internal/jellycompat/presign_list.go
+++ b/internal/jellycompat/presign_list.go
@@ -1,0 +1,89 @@
+package jellycompat
+
+import (
+	"context"
+
+	"github.com/Silo-Server/silo-server/internal/catalog"
+)
+
+// presignCompatListItems presigns every list item's poster/backdrop/logo/still
+// image using exactly four batched PresignImageURLsWithExpiry calls (one per
+// image type) for the whole page, independent of item count. Each call dedupes
+// its paths and singleflights the underlying plugin resolution, so a 40-item
+// rail costs four resolver invocations instead of 4×40. This is the single
+// shared implementation for both directContentService and ItemsHandler; do not
+// reintroduce a per-item presign body.
+func presignCompatListItems(detailSvc *catalog.DetailService, ctx context.Context, items []upstreamListItem) {
+	if len(items) == 0 {
+		return
+	}
+	for i := range items {
+		ensureListItemImagePaths(&items[i])
+	}
+	if detailSvc == nil {
+		return
+	}
+
+	posterURLs := detailSvc.PresignImageURLsWithExpiry(ctx, collectImagePaths(items, func(item upstreamListItem) string { return item.PosterURL }), "poster", compatCardImageSize)
+	backdropURLs := detailSvc.PresignImageURLsWithExpiry(ctx, collectImagePaths(items, func(item upstreamListItem) string { return item.BackdropURL }), "backdrop", compatCardImageSize)
+	logoURLs := detailSvc.PresignImageURLsWithExpiry(ctx, collectImagePaths(items, func(item upstreamListItem) string { return item.LogoURL }), "logo", compatCardImageSize)
+	stillURLs := detailSvc.PresignImageURLsWithExpiry(ctx, collectImagePaths(items, func(item upstreamListItem) string { return item.StillURL }), "still", compatCardImageSize)
+
+	for i := range items {
+		items[i].PosterURL = resolvedListImageURL(posterURLs, items[i].PosterURL)
+		items[i].BackdropURL = resolvedListImageURL(backdropURLs, items[i].BackdropURL)
+		items[i].LogoURL = resolvedListImageURL(logoURLs, items[i].LogoURL)
+		items[i].StillURL = resolvedListImageURL(stillURLs, items[i].StillURL)
+	}
+}
+
+// ensureListItemImagePaths mirrors each presign-source URL into its retained
+// *Path field so image tags survive after the URL has been rewritten to a
+// resolved value.
+func ensureListItemImagePaths(item *upstreamListItem) {
+	if item.PosterPath == "" {
+		item.PosterPath = item.PosterURL
+	}
+	if item.BackdropPath == "" {
+		item.BackdropPath = item.BackdropURL
+	}
+	if item.LogoPath == "" {
+		item.LogoPath = item.LogoURL
+	}
+	if item.StillPath == "" {
+		item.StillPath = item.StillURL
+	}
+}
+
+// collectImagePaths returns the de-duplicated, non-empty image paths picked from
+// items in first-seen order, ready for a single batched presign call. It is
+// generic so list items, seasons, and episodes share one collection routine.
+func collectImagePaths[T any](items []T, pick func(T) string) []string {
+	paths := make([]string, 0, len(items))
+	seen := make(map[string]struct{}, len(items))
+	for _, item := range items {
+		path := pick(item)
+		if path == "" {
+			continue
+		}
+		if _, ok := seen[path]; ok {
+			continue
+		}
+		seen[path] = struct{}{}
+		paths = append(paths, path)
+	}
+	return paths
+}
+
+// resolvedListImageURL looks up a presigned URL by its original input path,
+// returning "" for empty or unresolved paths (matching the singular presign
+// behavior for those cases).
+func resolvedListImageURL(resolved map[string]catalog.ResolvedImageURL, path string) string {
+	if path == "" {
+		return ""
+	}
+	if value, ok := resolved[path]; ok {
+		return value.URL
+	}
+	return ""
+}

--- a/internal/jellycompat/resume_filter_test.go
+++ b/internal/jellycompat/resume_filter_test.go
@@ -155,6 +155,74 @@ func TestLoadProgressPage_BoundsScanForSparseVisibleSet(t *testing.T) {
 	}
 }
 
+// TestLoadProgressPage_BoundsFastPathScanForSparseVisibleSet pins the cap on the
+// raw-offset fast path (default Continue Watching shape: no type/library filter,
+// EnableTotalRecordCount=false, StartIndex=0). This is the branch the sections
+// fallback hits in production, and it has its own scan loop separate from the
+// general loop. Without the fast-path cap a fully-dismissed history would page to
+// the end here even though the other bounds test (which sets
+// EnableTotalRecordCount=true) routes around this branch entirely.
+func TestLoadProgressPage_BoundsFastPathScanForSparseVisibleSet(t *testing.T) {
+	const total = 5000
+	entries := make([]upstreamProgress, 0, total)
+	items := make(map[string]*models.MediaItem, total)
+	hidden := make(map[string]bool, total)
+	for i := 0; i < total; i++ {
+		id := fmt.Sprintf("movie-%d", i)
+		entries = append(entries, upstreamProgress{MediaItemID: id, PositionSeconds: 10, DurationSeconds: 100})
+		items[id] = &models.MediaItem{ContentID: id, Type: "movie", Title: id}
+		hidden[id] = true
+	}
+	userData := &resumeFilteringUserData{entries: entries, hidden: hidden}
+	h := resumeTestHandler(userData, items)
+
+	session := &Session{StreamAppUserID: 1, ProfileID: "profile-1"}
+	// Default shape → the raw-offset fast path (loop A), not the general loop.
+	query := itemsQuery{limit: 20}
+	_, _, err := h.loadProgressPage(context.Background(), session, "in_progress", query, nil, nil)
+	if err != nil {
+		t.Fatalf("loadProgressPage: %v", err)
+	}
+
+	const oneBatchOvershoot = 200
+	if userData.maxScanned > resumeScanMaxRows+oneBatchOvershoot {
+		t.Fatalf("fast-path scan not bounded: read %d rows, want <= %d", userData.maxScanned, resumeScanMaxRows+oneBatchOvershoot)
+	}
+	if userData.maxScanned >= total {
+		t.Fatalf("fast path scanned the entire history (%d rows); cap did not engage", userData.maxScanned)
+	}
+}
+
+// TestLoadProgressPage_CompletedScanNotCapped pins that the completed
+// (watched-items) path is exempt from resumeScanMaxRows: it paginates on an exact
+// TotalRecordCount, so it must keep scanning past the cap. Mirrors the Codex
+// review concern that the cap not leak into watched-items pagination.
+func TestLoadProgressPage_CompletedScanNotCapped(t *testing.T) {
+	const total = resumeScanMaxRows * 3
+	entries := make([]upstreamProgress, 0, total)
+	items := make(map[string]*models.MediaItem, total)
+	for i := 0; i < total; i++ {
+		id := fmt.Sprintf("movie-%d", i)
+		entries = append(entries, upstreamProgress{MediaItemID: id, PositionSeconds: 100, DurationSeconds: 100, Completed: true})
+		items[id] = &models.MediaItem{ContentID: id, Type: "movie", Title: id}
+	}
+	// No hidden entries: completed does not run FilterResumeProgress.
+	userData := &resumeFilteringUserData{entries: entries}
+	h := resumeTestHandler(userData, items)
+
+	session := &Session{StreamAppUserID: 1, ProfileID: "profile-1"}
+	query := itemsQuery{limit: 20, enableTotalRecordCount: true}
+	_, gotTotal, err := h.loadProgressPage(context.Background(), session, "completed", query, nil, nil)
+	if err != nil {
+		t.Fatalf("loadProgressPage: %v", err)
+	}
+	// The exact watched-items total must be reported, i.e. the scan must not stop
+	// at the resume cap.
+	if gotTotal != total {
+		t.Fatalf("completed total = %d, want exact %d (cap must not apply to watched items)", gotTotal, total)
+	}
+}
+
 // TestLoadProgressPage_ResumeFilterAppliesWithTypeFilter covers the
 // scan-from-zero branch (IncludeItemTypes present): filtering must apply
 // there too, and visible pagination must skip filtered entries.

--- a/internal/jellycompat/resume_filter_test.go
+++ b/internal/jellycompat/resume_filter_test.go
@@ -2,6 +2,7 @@ package jellycompat
 
 import (
 	"context"
+	"fmt"
 	"testing"
 
 	"github.com/Silo-Server/silo-server/internal/catalog"
@@ -22,6 +23,7 @@ type resumeFilteringUserData struct {
 	lastFilteredTypes []string
 	filterCalls       int
 	filteredBatchSize []int
+	maxScanned        int // highest row index read across ListProgress pages
 }
 
 func (s *resumeFilteringUserData) ListProgress(_ context.Context, _ *Session, status string, limit, offset int) ([]upstreamProgress, error) {
@@ -30,6 +32,9 @@ func (s *resumeFilteringUserData) ListProgress(_ context.Context, _ *Session, st
 		return nil, nil
 	}
 	end := min(offset+limit, len(s.entries))
+	if end > s.maxScanned {
+		s.maxScanned = end
+	}
 	return s.entries[offset:end], nil
 }
 
@@ -108,6 +113,45 @@ func TestLoadProgressPage_ResumeHidesFilteredEntries(t *testing.T) {
 	}
 	if userData.filterCalls == 0 {
 		t.Fatal("expected FilterResumeProgress to be called for in_progress status")
+	}
+}
+
+// TestLoadProgressPage_BoundsScanForSparseVisibleSet pins the resumeScanMaxRows
+// cap: a heavy watcher whose in-progress rows are almost all hidden by
+// FilterResumeProgress must not page through the entire history looking to fill
+// the visible page. Before the cap was made unconditional, the scan only stopped
+// once len(items) >= limit, so a page that never fills walked every row.
+func TestLoadProgressPage_BoundsScanForSparseVisibleSet(t *testing.T) {
+	const total = 5000
+	entries := make([]upstreamProgress, 0, total)
+	items := make(map[string]*models.MediaItem, total)
+	hidden := make(map[string]bool, total)
+	for i := 0; i < total; i++ {
+		id := fmt.Sprintf("movie-%d", i)
+		entries = append(entries, upstreamProgress{MediaItemID: id, PositionSeconds: 10, DurationSeconds: 100})
+		items[id] = &models.MediaItem{ContentID: id, Type: "movie", Title: id}
+		hidden[id] = true // everything dismissed → visible page never fills
+	}
+	userData := &resumeFilteringUserData{entries: entries, hidden: hidden}
+	h := resumeTestHandler(userData, items)
+
+	session := &Session{StreamAppUserID: 1, ProfileID: "profile-1"}
+	// EnableTotalRecordCount=true is the shape that previously forced the full
+	// O(history) scan.
+	query := itemsQuery{limit: 20, enableTotalRecordCount: true}
+	_, _, err := h.loadProgressPage(context.Background(), session, "in_progress", query, nil, nil)
+	if err != nil {
+		t.Fatalf("loadProgressPage: %v", err)
+	}
+
+	// The scan must stop near the cap, not walk all `total` rows. Allow one extra
+	// batch of overshoot (the break fires after offset crosses the cap).
+	const oneBatchOvershoot = 200
+	if userData.maxScanned > resumeScanMaxRows+oneBatchOvershoot {
+		t.Fatalf("scan not bounded: read %d rows, want <= %d", userData.maxScanned, resumeScanMaxRows+oneBatchOvershoot)
+	}
+	if userData.maxScanned >= total {
+		t.Fatalf("scanned the entire history (%d rows); cap did not engage", userData.maxScanned)
 	}
 }
 

--- a/internal/jellycompat/userdata_direct.go
+++ b/internal/jellycompat/userdata_direct.go
@@ -95,13 +95,10 @@ func (s *directUserDataService) ListFavorites(ctx context.Context, session *Sess
 		}
 	}
 
-	// Presign artwork only for the page being returned.
+	// Presign artwork only for the page being returned, batching each image
+	// type into one PresignImageURLsWithExpiry call for the whole page.
 	result := slicePage(ordered, offset, limit)
-	for i := range result {
-		result[i].PosterURL = compatPresignImage(s.detailSvc, ctx, result[i].PosterURL, "poster", compatCardImageSize)
-		result[i].BackdropURL = compatPresignImage(s.detailSvc, ctx, result[i].BackdropURL, "backdrop", compatCardImageSize)
-		result[i].LogoURL = compatPresignImage(s.detailSvc, ctx, result[i].LogoURL, "logo", compatCardImageSize)
-	}
+	presignCompatListItems(s.detailSvc, ctx, result)
 	if result == nil {
 		result = []upstreamListItem{}
 	}

--- a/internal/jellycompat/userdata_direct.go
+++ b/internal/jellycompat/userdata_direct.go
@@ -98,7 +98,7 @@ func (s *directUserDataService) ListFavorites(ctx context.Context, session *Sess
 	// Presign artwork only for the page being returned, batching each image
 	// type into one PresignImageURLsWithExpiry call for the whole page.
 	result := slicePage(ordered, offset, limit)
-	presignCompatListItems(s.detailSvc, ctx, result)
+	presignCompatListItems(ctx, s.detailSvc, result)
 	if result == nil {
 		result = []upstreamListItem{}
 	}

--- a/internal/metadata/chain.go
+++ b/internal/metadata/chain.go
@@ -11,6 +11,37 @@ import (
 	"github.com/jackc/pgx/v5/pgxpool"
 )
 
+// InstallationEnabledChecker answers whether a plugin installation is enabled.
+// It mirrors the structural-dependency style of pluginMetadataResolver /
+// PluginResolverAdapter so the metadata package can consult the plugins
+// service's in-memory installation cache without importing (and creating an
+// import cycle with) the plugins package. *plugins.Service satisfies it via
+// IsInstallationEnabled.
+type InstallationEnabledChecker interface {
+	IsInstallationEnabled(ctx context.Context, installationID int) (bool, error)
+}
+
+// installationEnabled reports whether a plugin installation is enabled. When a
+// checker is supplied it is served from the plugins service's cache (no DB
+// read); when nil it falls back to a direct pool query so tests and non-plugin
+// builds keep working unchanged.
+func installationEnabled(
+	ctx context.Context,
+	checker InstallationEnabledChecker,
+	pool *pgxpool.Pool,
+	installationID int,
+) (bool, error) {
+	if checker != nil {
+		return checker.IsInstallationEnabled(ctx, installationID)
+	}
+	var enabled bool
+	err := pool.QueryRow(ctx,
+		"SELECT enabled FROM plugin_installations WHERE id = $1",
+		installationID,
+	).Scan(&enabled)
+	return enabled, err
+}
+
 // ChainEntry represents a single entry in a library's provider chain.
 type ChainEntry struct {
 	PluginInstallationID int
@@ -231,12 +262,31 @@ func (r *ChainRepository) AppendProviderToAllChains(
 // ordered by their plugin manifest default_priority for the given content level.
 //
 // Providers whose underlying plugin installation is disabled are silently skipped.
+//
+// The enabled-check falls back to a direct pool query. Callers on the hot path
+// (MetadataService.resolveChainCached) use ResolveChainWithChecker to serve it
+// from the plugins service's in-memory installation cache instead.
 func ResolveChain(
 	ctx context.Context,
 	folderID int,
 	contentLevel string,
 	chainRepo *ChainRepository,
 	resolver pluginMetadataResolver,
+) ([]Provider, error) {
+	return ResolveChainWithChecker(ctx, folderID, contentLevel, chainRepo, resolver, nil)
+}
+
+// ResolveChainWithChecker is ResolveChain with an optional
+// InstallationEnabledChecker threaded through the enabled-check. A nil checker
+// preserves the direct pool-query behavior, so existing callers and tests are
+// unaffected.
+func ResolveChainWithChecker(
+	ctx context.Context,
+	folderID int,
+	contentLevel string,
+	chainRepo *ChainRepository,
+	resolver pluginMetadataResolver,
+	checker InstallationEnabledChecker,
 ) ([]Provider, error) {
 	chainEntries, err := chainRepo.GetChain(ctx, folderID, contentLevel)
 	if err != nil {
@@ -253,10 +303,10 @@ func ResolveChain(
 	chainEntries = enabledEntries
 
 	if len(chainEntries) > 0 {
-		return resolveChainEntries(ctx, chainEntries, resolver, chainRepo.pool), nil
+		return resolveChainEntries(ctx, chainEntries, resolver, chainRepo.pool, checker), nil
 	}
 
-	providers, err := resolveEnabledProvidersByPriority(ctx, contentLevel, resolver, chainRepo.pool)
+	providers, err := resolveEnabledProvidersByPriority(ctx, contentLevel, resolver, chainRepo.pool, checker)
 	if err != nil {
 		return nil, err
 	}
@@ -276,12 +326,13 @@ func resolveEnabledProviders(
 	ctx context.Context,
 	resolver pluginMetadataResolver,
 	pool *pgxpool.Pool,
+	checker InstallationEnabledChecker,
 ) ([]Provider, error) {
 	caps, err := ListEnabledMetadataCapabilities(ctx, pool)
 	if err != nil {
 		return nil, err
 	}
-	return buildProviders(ctx, caps, resolver, pool), nil
+	return buildProviders(ctx, caps, resolver, pool, checker), nil
 }
 
 // resolveEnabledProvidersByPriority returns all enabled providers sorted by
@@ -292,6 +343,7 @@ func resolveEnabledProvidersByPriority(
 	contentLevel string,
 	resolver pluginMetadataResolver,
 	pool *pgxpool.Pool,
+	checker InstallationEnabledChecker,
 ) ([]Provider, error) {
 	caps, err := ListEnabledMetadataCapabilities(ctx, pool)
 	if err != nil {
@@ -335,7 +387,7 @@ func resolveEnabledProvidersByPriority(
 	for i, item := range items {
 		sorted[i] = item.cap
 	}
-	return buildProviders(ctx, sorted, resolver, pool), nil
+	return buildProviders(ctx, sorted, resolver, pool, checker), nil
 }
 
 // providerSupportsLevel reports whether a metadata provider should participate
@@ -453,6 +505,7 @@ func resolveChainEntries(
 	entries []ChainEntry,
 	resolver pluginMetadataResolver,
 	pool *pgxpool.Pool,
+	checker InstallationEnabledChecker,
 ) []Provider {
 	caps := make([]CapabilityInfo, 0, len(entries))
 	for _, e := range entries {
@@ -463,7 +516,7 @@ func resolveChainEntries(
 			DisplayName:          displayName,
 		})
 	}
-	return buildProviders(ctx, caps, resolver, pool)
+	return buildProviders(ctx, caps, resolver, pool, checker)
 }
 
 // buildProviders constructs Provider instances from capability info, skipping
@@ -473,14 +526,11 @@ func buildProviders(
 	caps []CapabilityInfo,
 	resolver pluginMetadataResolver,
 	pool *pgxpool.Pool,
+	checker InstallationEnabledChecker,
 ) []Provider {
 	providers := make([]Provider, 0, len(caps))
 	for _, c := range caps {
-		var enabled bool
-		err := pool.QueryRow(ctx,
-			"SELECT enabled FROM plugin_installations WHERE id = $1",
-			c.PluginInstallationID,
-		).Scan(&enabled)
+		enabled, err := installationEnabled(ctx, checker, pool, c.PluginInstallationID)
 		if err != nil || !enabled {
 			slog.Debug("skipping metadata provider: plugin installation disabled",
 				"installation_id", c.PluginInstallationID, "capability_id", c.CapabilityID)

--- a/internal/metadata/person_refresh.go
+++ b/internal/metadata/person_refresh.go
@@ -72,7 +72,9 @@ func (s *PersonRefreshService) RefreshPerson(ctx context.Context, id int64) (*mo
 		return nil, fmt.Errorf("person refresh providers are not configured")
 	}
 
-	providers, err := resolveEnabledProviders(ctx, s.pluginResolver, s.pool)
+	// Person refresh is a background path; the nil checker falls back to a
+	// direct pool query rather than the hot-path installation cache.
+	providers, err := resolveEnabledProviders(ctx, s.pluginResolver, s.pool, nil)
 	if err != nil {
 		return nil, fmt.Errorf("resolve person providers: %w", err)
 	}

--- a/internal/metadata/service.go
+++ b/internal/metadata/service.go
@@ -281,6 +281,7 @@ func handleChildProvider404(
 type MetadataService struct {
 	chainRepo               *ChainRepository
 	pluginResolver          pluginMetadataResolver
+	enabledChecker          InstallationEnabledChecker
 	itemRepo                metadataItemRepo
 	providerIDRepo          metadataProviderIDRepo
 	episodeRepo             metadataEpisodeRepo
@@ -363,6 +364,7 @@ type chainResolver func(contentLevel string) ([]Provider, error)
 func NewMetadataService(
 	chainRepo *ChainRepository,
 	pluginResolver pluginMetadataResolver,
+	enabledChecker InstallationEnabledChecker,
 	itemRepo *catalog.ItemRepository,
 	providerIDRepo *catalog.ProviderIDRepository,
 	episodeRepo *catalog.EpisodeRepository,
@@ -399,6 +401,7 @@ func NewMetadataService(
 	return &MetadataService{
 		chainRepo:               chainRepo,
 		pluginResolver:          pluginResolver,
+		enabledChecker:          enabledChecker,
 		itemRepo:                itemRepo,
 		providerIDRepo:          providerIDRepo,
 		episodeRepo:             episodeRepo,
@@ -468,7 +471,7 @@ func (s *MetadataService) resolveChainCached(ctx context.Context, folderID int, 
 	}
 	s.chainCacheMu.RUnlock()
 
-	providers, err := ResolveChain(ctx, folderID, contentLevel, s.chainRepo, s.pluginResolver)
+	providers, err := ResolveChainWithChecker(ctx, folderID, contentLevel, s.chainRepo, s.pluginResolver, s.enabledChecker)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/plugins/auto_update.go
+++ b/internal/plugins/auto_update.go
@@ -114,9 +114,20 @@ type AutoUpdateService struct {
 	installer     autoUpdateInstaller
 	host          autoUpdateHost
 	logger        *slog.Logger
+
+	// onChange is fired after a run mutates any plugin_installations row so
+	// that peers sharing the same store (notably plugins.Service and its
+	// installation cache) can invalidate their memoized state. It is optional:
+	// when nil, no notification is sent. Pass plugins.Service.OnLifecycleChange
+	// here to keep that service's installation cache consistent with the
+	// version-specific InstallPath/Version this service writes.
+	onChange func(context.Context)
 }
 
-// NewAutoUpdateService creates a new AutoUpdateService.
+// NewAutoUpdateService creates a new AutoUpdateService. onChange is optional and
+// nil-safe: when non-nil it is invoked once after any run that mutates an
+// installation row (auto-update applied, default plugin installed, or an
+// available version recorded) so peers can invalidate cached installation state.
 func NewAutoUpdateService(
 	repositories autoUpdateRepositoryStore,
 	installations autoUpdateInstallationStore,
@@ -124,6 +135,7 @@ func NewAutoUpdateService(
 	installer autoUpdateInstaller,
 	host autoUpdateHost,
 	logger *slog.Logger,
+	onChange func(context.Context),
 ) *AutoUpdateService {
 	if logger == nil {
 		logger = slog.Default()
@@ -135,6 +147,7 @@ func NewAutoUpdateService(
 		installer:     installer,
 		host:          host,
 		logger:        logger,
+		onChange:      onChange,
 	}
 }
 
@@ -202,7 +215,28 @@ func (s *AutoUpdateService) Check(ctx context.Context, opts AutoUpdateOptions) (
 		}
 	}
 
+	// Any of these outcomes wrote to a plugin_installations row: installing a
+	// default plugin creates one, an applied auto-update rewrites the version-
+	// specific InstallPath/Version (and deletes the old install dir), and a
+	// notify records available_version. Fire onChange once per run so peers such
+	// as plugins.Service invalidate their installation cache; otherwise stale
+	// rows (old InstallPath/Version) would make later plugin RPCs fail against a
+	// re-extracted, newer archive.
+	if summary.DefaultPluginsInstalled > 0 || summary.UpdatesApplied > 0 || summary.UpdatesAvailable > 0 {
+		s.notifyChanged(ctx)
+	}
+
 	return summary, nil
+}
+
+// notifyChanged fires the optional onChange hook. It is nil-safe and
+// best-effort: OnLifecycleChange already recovers hook panics internally, so a
+// direct call cannot fail the update pass.
+func (s *AutoUpdateService) notifyChanged(ctx context.Context) {
+	if s.onChange == nil {
+		return
+	}
+	s.onChange(ctx)
 }
 
 // Run seeds the default repository if needed, fetches the catalog, auto-installs

--- a/internal/plugins/auto_update_replace_test.go
+++ b/internal/plugins/auto_update_replace_test.go
@@ -38,6 +38,7 @@ func TestAutoUpdateServiceCheckReplacesInstalledPluginsInPlace(t *testing.T) {
 		installer,
 		host,
 		nil,
+		nil,
 	)
 
 	summary, err := service.Check(context.Background(), AutoUpdateOptions{
@@ -62,6 +63,114 @@ func TestAutoUpdateServiceCheckReplacesInstalledPluginsInPlace(t *testing.T) {
 	if len(host.stopped) != 1 || host.stopped[0] != 41 {
 		t.Fatalf("stopped installations = %#v, want [41]", host.stopped)
 	}
+}
+
+func TestAutoUpdateServiceCheckFiresOnChangeAfterMutation(t *testing.T) {
+	newOnChangeService := func(installations *fakeAutoUpdateInstallations, opts AutoUpdateOptions, calls *int) (AutoUpdateSummary, error) {
+		catalog := &fakeAutoUpdateCatalog{
+			entries: []CatalogEntry{{
+				RepositoryID: 7,
+				Manifest: &pluginv1.PluginManifest{
+					PluginId: "silo.tmdb",
+					Version:  "1.1.0",
+				},
+			}},
+			resolved: &ResolvedCatalogInstall{
+				RepositoryID: 7,
+				ArchiveURL:   "https://plugins.example.test/tmdb",
+				Checksum:     "deadbeef",
+			},
+		}
+		service := NewAutoUpdateService(
+			&fakeAutoUpdateRepositories{list: []*Repository{{ID: 7, Enabled: true}}},
+			installations,
+			catalog,
+			&fakeAutoUpdateInstaller{},
+			&fakeAutoUpdateHost{},
+			nil,
+			func(context.Context) { *calls++ },
+		)
+		return service.Check(context.Background(), opts)
+	}
+
+	t.Run("applied auto-update fires onChange", func(t *testing.T) {
+		var calls int
+		installations := &fakeAutoUpdateInstallations{
+			list: []*Installation{{ID: 41, PluginID: "silo.tmdb", Version: "1.0.0", UpdatePolicy: "auto", Enabled: true}},
+		}
+		summary, err := newOnChangeService(installations, AutoUpdateOptions{}, &calls)
+		if err != nil {
+			t.Fatalf("Check() returned error: %v", err)
+		}
+		if summary.UpdatesApplied != 1 {
+			t.Fatalf("UpdatesApplied = %d, want 1", summary.UpdatesApplied)
+		}
+		if calls != 1 {
+			t.Fatalf("onChange calls = %d, want 1", calls)
+		}
+	})
+
+	t.Run("notify update fires onChange", func(t *testing.T) {
+		var calls int
+		installations := &fakeAutoUpdateInstallations{
+			list: []*Installation{{ID: 42, PluginID: "silo.tmdb", Version: "1.0.0", UpdatePolicy: "notify", Enabled: true}},
+		}
+		summary, err := newOnChangeService(installations, AutoUpdateOptions{}, &calls)
+		if err != nil {
+			t.Fatalf("Check() returned error: %v", err)
+		}
+		if summary.UpdatesAvailable != 1 {
+			t.Fatalf("UpdatesAvailable = %d, want 1", summary.UpdatesAvailable)
+		}
+		if calls != 1 {
+			t.Fatalf("onChange calls = %d, want 1", calls)
+		}
+	})
+
+	t.Run("no mutation does not fire onChange", func(t *testing.T) {
+		var calls int
+		installations := &fakeAutoUpdateInstallations{
+			list: []*Installation{{ID: 43, PluginID: "silo.tmdb", Version: "1.1.0", UpdatePolicy: "auto", Enabled: true}},
+		}
+		summary, err := newOnChangeService(installations, AutoUpdateOptions{}, &calls)
+		if err != nil {
+			t.Fatalf("Check() returned error: %v", err)
+		}
+		if summary.UpdatesApplied != 0 || summary.UpdatesAvailable != 0 {
+			t.Fatalf("unexpected mutation summary: %+v", summary)
+		}
+		if calls != 0 {
+			t.Fatalf("onChange calls = %d, want 0", calls)
+		}
+	})
+
+	t.Run("nil onChange is safe after mutation", func(t *testing.T) {
+		installations := &fakeAutoUpdateInstallations{
+			list: []*Installation{{ID: 44, PluginID: "silo.tmdb", Version: "1.0.0", UpdatePolicy: "auto", Enabled: true}},
+		}
+		service := NewAutoUpdateService(
+			&fakeAutoUpdateRepositories{list: []*Repository{{ID: 7, Enabled: true}}},
+			installations,
+			&fakeAutoUpdateCatalog{
+				entries: []CatalogEntry{{
+					RepositoryID: 7,
+					Manifest:     &pluginv1.PluginManifest{PluginId: "silo.tmdb", Version: "1.1.0"},
+				}},
+				resolved: &ResolvedCatalogInstall{RepositoryID: 7, ArchiveURL: "https://plugins.example.test/tmdb", Checksum: "deadbeef"},
+			},
+			&fakeAutoUpdateInstaller{},
+			&fakeAutoUpdateHost{},
+			nil,
+			nil,
+		)
+		summary, err := service.Check(context.Background(), AutoUpdateOptions{})
+		if err != nil {
+			t.Fatalf("Check() with nil onChange returned error: %v", err)
+		}
+		if summary.UpdatesApplied != 1 {
+			t.Fatalf("UpdatesApplied = %d, want 1", summary.UpdatesApplied)
+		}
+	})
 }
 
 func TestCompareVersions(t *testing.T) {
@@ -112,6 +221,7 @@ func TestAutoUpdateMultiDigitVersion(t *testing.T) {
 		catalog,
 		installer,
 		host,
+		nil,
 		nil,
 	)
 

--- a/internal/plugins/service.go
+++ b/internal/plugins/service.go
@@ -71,6 +71,20 @@ type Service struct {
 	lifecycleMu    sync.RWMutex
 	lifecycleHooks []func(context.Context)
 	launchGroup    singleflight.Group
+
+	// installationCache memoizes plugin_installations rows keyed by ID so the
+	// hot plugin-RPC path (ensureClient -> loadInstallation) and the metadata
+	// chain enabled-check answer from memory instead of a per-call DB read. It
+	// is wiped wholesale by invalidateInstallationCache, registered as a
+	// lifecycle hook, so a cached row is at most one lifecycle event stale.
+	//
+	// installationCacheGen guards the read-through against an invalidate that
+	// races an in-flight GetByID: the generation is captured before the store
+	// read and re-checked under the write lock, so a row fetched before a
+	// lifecycle mutation is never written back into a freshly-cleared cache.
+	installationCacheMu  sync.RWMutex
+	installationCache    map[int]*Installation
+	installationCacheGen uint64
 }
 
 // SetEventDispatcher wires the EventDispatcher into the Service. The
@@ -124,7 +138,7 @@ func NewService(
 	installer *Installer,
 	host Host,
 ) *Service {
-	return &Service{
+	svc := &Service{
 		repositories:  repositories,
 		installations: installations,
 		configs:       configs,
@@ -133,6 +147,12 @@ func NewService(
 		archiveCache:  NewArchiveCache(installations),
 		host:          host,
 	}
+	// Self-register the installation-cache invalidation so it can never be
+	// silently forgotten by a new caller: every OnLifecycleChange (install /
+	// enable / disable / update / uninstall) wipes the cache, keeping the
+	// memoized rows correct without any external wiring.
+	svc.AddLifecycleHook(func(context.Context) { svc.invalidateInstallationCache() })
+	return svc
 }
 
 func (s *Service) FetchCatalog(ctx context.Context) ([]CatalogEntry, error) {
@@ -720,14 +740,77 @@ func (s *Service) ensureInstallationCache(
 }
 
 func (s *Service) loadInstallation(ctx context.Context, installationID int, requireEnabled bool) (*Installation, error) {
-	installation, err := s.installations.GetByID(ctx, installationID)
+	installation, err := s.cachedInstallation(ctx, installationID)
 	if err != nil {
 		return nil, err
 	}
+	// The requireEnabled gate is applied after the cache read so the cache
+	// stores the row regardless of its enabled state and ErrInstallationDisabled
+	// semantics are unchanged.
 	if requireEnabled && !installation.Enabled {
 		return nil, ErrInstallationDisabled
 	}
 	return installation, nil
+}
+
+// cachedInstallation returns the plugin_installations row for installationID
+// from the in-memory cache, loading it from the store on a miss. The returned
+// *Installation is shared and must be treated as read-only by callers; it is
+// evicted wholesale by invalidateInstallationCache on every lifecycle change.
+func (s *Service) cachedInstallation(ctx context.Context, installationID int) (*Installation, error) {
+	s.installationCacheMu.RLock()
+	cached, ok := s.installationCache[installationID]
+	gen := s.installationCacheGen
+	s.installationCacheMu.RUnlock()
+	if ok {
+		return cached, nil
+	}
+
+	installation, err := s.installations.GetByID(ctx, installationID)
+	if err != nil {
+		return nil, err
+	}
+
+	s.installationCacheMu.Lock()
+	// Only publish the fetched row if no invalidation happened while GetByID was
+	// in flight. Otherwise the row may pre-date a just-committed lifecycle change
+	// (e.g. a disable), and writing it would resurrect stale state until the next
+	// event. On a generation mismatch we still return the freshly-read row to the
+	// caller but leave the cache untouched.
+	if s.installationCacheGen == gen {
+		if s.installationCache == nil {
+			s.installationCache = make(map[int]*Installation)
+		}
+		s.installationCache[installationID] = installation
+	}
+	s.installationCacheMu.Unlock()
+
+	return installation, nil
+}
+
+// invalidateInstallationCache clears the in-memory installation cache. It is
+// registered as a lifecycle hook (see NewService) so OnLifecycleChange evicts
+// stale rows after every install / enable / disable / update / uninstall.
+func (s *Service) invalidateInstallationCache() {
+	if s == nil {
+		return
+	}
+	s.installationCacheMu.Lock()
+	s.installationCache = nil
+	s.installationCacheGen++
+	s.installationCacheMu.Unlock()
+}
+
+// IsInstallationEnabled reports whether the given plugin installation is
+// enabled, served from the in-memory installation cache. It backs the metadata
+// chain's enabled-check (internal/metadata/chain.go) so provider construction
+// no longer issues a per-capability SELECT on the hot path.
+func (s *Service) IsInstallationEnabled(ctx context.Context, installationID int) (bool, error) {
+	installation, err := s.loadInstallation(ctx, installationID, false)
+	if err != nil {
+		return false, err
+	}
+	return installation.Enabled, nil
 }
 
 func (s *Service) ensureLoadedInstallation(

--- a/internal/plugins/service_installation_cache_test.go
+++ b/internal/plugins/service_installation_cache_test.go
@@ -1,0 +1,172 @@
+package plugins
+
+import (
+	"context"
+	"errors"
+	"testing"
+)
+
+// countingInstallationStore wraps the shared fake store and counts GetByID
+// calls so tests can assert the in-memory installation cache absorbs repeat
+// reads.
+type countingInstallationStore struct {
+	*fakeServiceInstallationStore
+	getByIDCalls int
+	// onGetByID, when set, runs after the call is counted but before the row is
+	// returned, so tests can simulate an invalidation racing an in-flight read.
+	onGetByID func()
+}
+
+func (s *countingInstallationStore) GetByID(ctx context.Context, id int) (*Installation, error) {
+	s.getByIDCalls++
+	if s.onGetByID != nil {
+		s.onGetByID()
+	}
+	return s.fakeServiceInstallationStore.GetByID(ctx, id)
+}
+
+// newCachedInstallationService builds a Service backed by the counting store and
+// wires the installation-cache invalidation exactly as NewService does, so the
+// OnLifecycleChange -> invalidate path is exercised.
+func newCachedInstallationService(installations ...*Installation) (*Service, *countingInstallationStore) {
+	store := &countingInstallationStore{
+		fakeServiceInstallationStore: newFakeServiceInstallationStore(installations...),
+	}
+	svc := &Service{installations: store}
+	svc.AddLifecycleHook(func(context.Context) { svc.invalidateInstallationCache() })
+	return svc, store
+}
+
+func TestLoadInstallationCachesAndInvalidatesOnLifecycleChange(t *testing.T) {
+	ctx := context.Background()
+	svc, store := newCachedInstallationService(&Installation{ID: 7, PluginID: "silo.metadb", Enabled: true})
+
+	// First read hits the store.
+	if _, err := svc.loadInstallation(ctx, 7, false); err != nil {
+		t.Fatalf("first loadInstallation err = %v", err)
+	}
+	if store.getByIDCalls != 1 {
+		t.Fatalf("after first read GetByID calls = %d, want 1", store.getByIDCalls)
+	}
+
+	// Subsequent reads are served from the cache.
+	for i := 0; i < 5; i++ {
+		if _, err := svc.loadInstallation(ctx, 7, false); err != nil {
+			t.Fatalf("cached loadInstallation err = %v", err)
+		}
+	}
+	if store.getByIDCalls != 1 {
+		t.Fatalf("after cached reads GetByID calls = %d, want still 1", store.getByIDCalls)
+	}
+
+	// A lifecycle change wipes the cache and forces a re-read.
+	svc.OnLifecycleChange(ctx)
+	if _, err := svc.loadInstallation(ctx, 7, false); err != nil {
+		t.Fatalf("post-invalidate loadInstallation err = %v", err)
+	}
+	if store.getByIDCalls != 2 {
+		t.Fatalf("after lifecycle change GetByID calls = %d, want 2", store.getByIDCalls)
+	}
+}
+
+func TestIsInstallationEnabledReflectsCacheAndInvalidation(t *testing.T) {
+	ctx := context.Background()
+	svc, store := newCachedInstallationService(&Installation{ID: 7, PluginID: "silo.metadb", Enabled: true})
+
+	enabled, err := svc.IsInstallationEnabled(ctx, 7)
+	if err != nil {
+		t.Fatalf("IsInstallationEnabled err = %v", err)
+	}
+	if !enabled {
+		t.Fatal("IsInstallationEnabled = false, want true")
+	}
+	if store.getByIDCalls != 1 {
+		t.Fatalf("GetByID calls = %d, want 1", store.getByIDCalls)
+	}
+
+	// Disable the underlying row. Until a lifecycle change, the cache still
+	// reports the stale (enabled) value and issues no further reads.
+	falseVal := false
+	if err := store.Update(ctx, 7, UpdateInstallationInput{Enabled: &falseVal}); err != nil {
+		t.Fatalf("store.Update err = %v", err)
+	}
+	enabled, err = svc.IsInstallationEnabled(ctx, 7)
+	if err != nil {
+		t.Fatalf("cached IsInstallationEnabled err = %v", err)
+	}
+	if !enabled {
+		t.Fatal("cached IsInstallationEnabled = false, want stale true before invalidation")
+	}
+	if store.getByIDCalls != 1 {
+		t.Fatalf("GetByID calls = %d, want still 1 (served from cache)", store.getByIDCalls)
+	}
+
+	// After a lifecycle change the cache is wiped and the new value is read.
+	svc.OnLifecycleChange(ctx)
+	enabled, err = svc.IsInstallationEnabled(ctx, 7)
+	if err != nil {
+		t.Fatalf("post-invalidate IsInstallationEnabled err = %v", err)
+	}
+	if enabled {
+		t.Fatal("post-invalidate IsInstallationEnabled = true, want false")
+	}
+	if store.getByIDCalls != 2 {
+		t.Fatalf("GetByID calls = %d, want 2 after invalidation", store.getByIDCalls)
+	}
+}
+
+// TestCachedInstallationSkipsWriteOnRacingInvalidation proves the generation
+// guard: if a lifecycle invalidation lands while GetByID is in flight, the
+// fetched (potentially pre-mutation) row is returned to the caller but is not
+// written back into the freshly-cleared cache, so the next read re-fetches
+// instead of serving a resurrected stale row.
+func TestCachedInstallationSkipsWriteOnRacingInvalidation(t *testing.T) {
+	ctx := context.Background()
+	svc, store := newCachedInstallationService(&Installation{ID: 7, PluginID: "silo.metadb", Enabled: true})
+
+	// Simulate the race by invalidating the cache from inside the store read,
+	// i.e. between the generation capture and the write-back.
+	store.onGetByID = func() { svc.invalidateInstallationCache() }
+
+	if _, err := svc.loadInstallation(ctx, 7, false); err != nil {
+		t.Fatalf("racing loadInstallation err = %v", err)
+	}
+	if store.getByIDCalls != 1 {
+		t.Fatalf("GetByID calls = %d, want 1", store.getByIDCalls)
+	}
+
+	// The racing read must not have populated the cache; the next read re-fetches.
+	store.onGetByID = nil
+	if _, err := svc.loadInstallation(ctx, 7, false); err != nil {
+		t.Fatalf("post-race loadInstallation err = %v", err)
+	}
+	if store.getByIDCalls != 2 {
+		t.Fatalf("GetByID calls = %d, want 2 (racing write skipped, cache empty)", store.getByIDCalls)
+	}
+
+	// A subsequent read with no interference is served from the cache.
+	if _, err := svc.loadInstallation(ctx, 7, false); err != nil {
+		t.Fatalf("cached loadInstallation err = %v", err)
+	}
+	if store.getByIDCalls != 2 {
+		t.Fatalf("GetByID calls = %d, want still 2 (served from cache)", store.getByIDCalls)
+	}
+}
+
+func TestLoadInstallationRequireEnabledGateAppliesAfterCache(t *testing.T) {
+	ctx := context.Background()
+	svc, store := newCachedInstallationService(&Installation{ID: 7, PluginID: "silo.metadb", Enabled: false})
+
+	// requireEnabled=false caches the disabled row.
+	if _, err := svc.loadInstallation(ctx, 7, false); err != nil {
+		t.Fatalf("loadInstallation err = %v", err)
+	}
+	// requireEnabled=true returns ErrInstallationDisabled without a second read,
+	// proving the gate is applied after the cache lookup.
+	if _, err := svc.loadInstallation(ctx, 7, true); !errors.Is(err, ErrInstallationDisabled) {
+		t.Fatalf("loadInstallation requireEnabled err = %v, want ErrInstallationDisabled", err)
+	}
+	if store.getByIDCalls != 1 {
+		t.Fatalf("GetByID calls = %d, want 1 (gate applied after cache)", store.getByIDCalls)
+	}
+}

--- a/internal/sections/fetcher.go
+++ b/internal/sections/fetcher.go
@@ -290,7 +290,20 @@ func (f *Fetcher) FetchOne(ctx context.Context, resolved ResolvedSection, librar
 
 	var items []*models.MediaItem
 	var total int
-	items, total, err = f.fetchSection(ctx, resolved, libraryID, libraryIDs, userID, profileID, filter)
+	if isCacheableSectionType(resolved) {
+		// User-agnostic rows share one process-global entry per access scope.
+		// getOrRefresh returns a defensive slice copy, so reordering or
+		// truncating result.Items below (or in a caller) cannot corrupt the
+		// cached entry; the pointed-to *MediaItem must not be mutated in place
+		// (see cloneMediaItems). The per-user overlay still runs fresh in
+		// buildSectionsResponse.
+		key := resolvedListCacheKey(resolved, libraryID, libraryIDs, filter)
+		items, total, err = getOrRefresh(ctx, key, f.now(), func(loadCtx context.Context) ([]*models.MediaItem, int, error) {
+			return f.fetchSection(loadCtx, resolved, libraryID, libraryIDs, userID, profileID, filter)
+		})
+	} else {
+		items, total, err = f.fetchSection(ctx, resolved, libraryID, libraryIDs, userID, profileID, filter)
+	}
 	if err != nil {
 		return SectionWithItems{}, err
 	}

--- a/internal/sections/fetcher.go
+++ b/internal/sections/fetcher.go
@@ -48,7 +48,16 @@ type SectionItemMeta struct {
 
 const recentSeasonPremiereBadgeWindowDays = 14
 const editorialCandidateCacheTTL = 24 * time.Hour
-const fetchAllMaxConcurrency = 4
+
+// fetchAllMaxConcurrency bounds how many sections FetchAll resolves in parallel.
+// Each concurrent section holds a pgxpool connection, so this is also per-request
+// pool pressure: with the default pool of 20 conns (database.max_connections),
+// N concurrent home requests can hold up to N*fetchAllMaxConcurrency connections.
+// Raised from 4 to 6 to cut the wave count for large home layouts (e.g. 32
+// sections: 8 waves → 6) while keeping headroom for a few concurrent home loads
+// before the pool saturates. Do not raise further without widening the pool or
+// load-testing pool contention.
+const fetchAllMaxConcurrency = 6
 const slowSectionFetchThreshold = 500 * time.Millisecond
 const slowAggregateFetchThreshold = time.Second
 

--- a/internal/sections/fetcher.go
+++ b/internal/sections/fetcher.go
@@ -214,11 +214,12 @@ func editorialCandidateCacheKey(subjectType string, libraryID *int, libraryIDs [
 	b.WriteString("|libraries=")
 	writeOptionalSortedInts(&b, libraryIDs)
 
-	b.WriteString("|disabled=")
-	writeSortedInts(&b, filter.DisabledLibraryIDs)
-
-	b.WriteString("|rating=")
-	b.WriteString(filter.MaxContentRating)
+	// Serialize the full access scope through the shared catalog helper. The
+	// candidate loaders push rating AND excluded media types (via
+	// ApplySectionAccessFilter) into their SQL, so the key must capture every
+	// boundary; the shared helper guarantees it stays in sync with the other
+	// access-scoped caches when AccessFilter grows.
+	filter.WriteAccessScopeCacheKey(&b)
 	return b.String()
 }
 
@@ -290,7 +291,7 @@ func (f *Fetcher) FetchOne(ctx context.Context, resolved ResolvedSection, librar
 
 	var items []*models.MediaItem
 	var total int
-	if isCacheableSectionType(resolved) {
+	if f.isCacheableSectionType(resolved) {
 		// User-agnostic rows share one process-global entry per access scope.
 		// getOrRefresh returns a defensive slice copy, so reordering or
 		// truncating result.Items below (or in a caller) cannot corrupt the
@@ -1192,12 +1193,70 @@ func (f *Fetcher) ListOverlaySummaries(ctx context.Context, contentIDs []string,
 	return summaries, nil
 }
 
-func (f *Fetcher) fetchSection(ctx context.Context, s ResolvedSection, libraryID *int, libraryIDs []int, userID int, profileID string, filter catalog.AccessFilter) ([]*models.MediaItem, int, error) {
-	switch s.SectionType {
+// userAgnosticSectionFetch is the signature shared by every fetch helper whose
+// membership is identical for all profiles with the same access scope: no
+// userID, no profileID. The signature is the enforcement mechanism for the
+// shared resolved-list cache — a helper cannot start reading per-profile state
+// without changing its signature, dropping out of userAgnosticSectionFetcher,
+// and forcing an explicit new cacheability decision at compile time.
+type userAgnosticSectionFetch func(ctx context.Context, s ResolvedSection, libraryID *int, libraryIDs []int, filter catalog.AccessFilter) ([]*models.MediaItem, int, error)
+
+// userAgnosticSectionFetcher returns the fetch function for section types whose
+// shared item list may be cached across profiles, or nil for every other type.
+// It is the single source of truth for that decision: fetchSection dispatches
+// through it AND isCacheableSectionType derives cache eligibility from it, so
+// the two can never disagree.
+//
+// Deliberately absent despite having the user-agnostic signature:
+//   - SectionRandom — user-agnostic but must reshuffle per request;
+//   - SectionEditorialSpotlight — has its own candidate cache + rotation and a
+//     dedicated FetchOne branch;
+//   - SectionGenre / SectionCustomFilter — fetchFiltered shares the signature,
+//     but a user-supplied QueryDefinition can carry personalized rules, so
+//     cacheability needs the dynamic IsPersonalized check in
+//     isCacheableSectionType (dispatch stays in fetchSection's switch);
+//   - SectionCollection — user vs library collections are decided by config,
+//     handled dynamically in isCacheableSectionType.
+func (f *Fetcher) userAgnosticSectionFetcher(t SectionType) userAgnosticSectionFetch {
+	switch t {
 	case SectionRecentlyAdded:
-		return f.fetchRecentlyAdded(ctx, s, libraryID, libraryIDs, filter)
+		return f.fetchRecentlyAdded
 	case SectionRecentlyReleased:
-		return f.fetchRecentlyReleased(ctx, s, libraryID, libraryIDs, filter)
+		return f.fetchRecentlyReleased
+	case SectionCriticallyAcclaimed:
+		return f.fetchCriticallyAcclaimed
+	case SectionAwardWinners:
+		// fetchAwardWinners derives everything from the section config; adapt
+		// it to the shared signature.
+		return func(ctx context.Context, s ResolvedSection, _ *int, _ []int, _ catalog.AccessFilter) ([]*models.MediaItem, int, error) {
+			return f.fetchAwardWinners(ctx, s)
+		}
+	case SectionFormatShowcase:
+		return f.fetchFormatShowcase
+	case SectionSeasonalThemed:
+		return f.fetchSeasonalThemed
+	case SectionMoodCollection:
+		return f.fetchMoodCollection
+	case SectionTrendingOnServer:
+		return f.fetchTrending
+	case SectionNewToLibrary:
+		return f.fetchNewToLibrary
+	case SectionMostWatched:
+		return f.fetchMostWatched
+	case SectionTrendingDiscover:
+		return f.fetchTrendingDiscover
+	case SectionAdminCuratedList:
+		return f.fetchAdminCuratedList
+	default:
+		return nil
+	}
+}
+
+func (f *Fetcher) fetchSection(ctx context.Context, s ResolvedSection, libraryID *int, libraryIDs []int, userID int, profileID string, filter catalog.AccessFilter) ([]*models.MediaItem, int, error) {
+	if fetch := f.userAgnosticSectionFetcher(s.SectionType); fetch != nil {
+		return fetch(ctx, s, libraryID, libraryIDs, filter)
+	}
+	switch s.SectionType {
 	case SectionGenre, SectionCustomFilter:
 		return f.fetchFiltered(ctx, s, libraryID, libraryIDs, filter)
 	case SectionRandom:
@@ -1208,32 +1267,12 @@ func (f *Fetcher) fetchSection(ctx context.Context, s ResolvedSection, libraryID
 		return f.fetchRecommendationSection(ctx, s, libraryID, libraryIDs, userID, profileID, filter)
 	case SectionHiddenGems:
 		return f.fetchHiddenGems(ctx, s, libraryID, libraryIDs, userID, profileID, filter)
-	case SectionCriticallyAcclaimed:
-		return f.fetchCriticallyAcclaimed(ctx, s, libraryID, libraryIDs, filter)
-	case SectionAwardWinners:
-		return f.fetchAwardWinners(ctx, s)
 	case SectionForgottenFavorites:
 		return f.fetchForgottenFavorites(ctx, s, libraryID, libraryIDs, userID, profileID, filter)
-	case SectionFormatShowcase:
-		return f.fetchFormatShowcase(ctx, s, libraryID, libraryIDs, filter)
 	case SectionEditorialSpotlight:
 		return f.fetchEditorialSpotlight(ctx, s, libraryID, libraryIDs, filter)
-	case SectionSeasonalThemed:
-		return f.fetchSeasonalThemed(ctx, s, libraryID, libraryIDs, filter)
-	case SectionMoodCollection:
-		return f.fetchMoodCollection(ctx, s, libraryID, libraryIDs, filter)
-	case SectionTrendingOnServer:
-		return f.fetchTrending(ctx, s, libraryID, libraryIDs, filter)
 	case SectionProfileActivityFeed:
 		return f.fetchProfileActivityFeed(ctx, s, libraryID, libraryIDs, profileID, filter)
-	case SectionNewToLibrary:
-		return f.fetchNewToLibrary(ctx, s, libraryID, libraryIDs, filter)
-	case SectionMostWatched:
-		return f.fetchMostWatched(ctx, s, libraryID, libraryIDs, filter)
-	case SectionTrendingDiscover:
-		return f.fetchTrendingDiscover(ctx, s, libraryID, libraryIDs, filter)
-	case SectionAdminCuratedList:
-		return f.fetchAdminCuratedList(ctx, s, libraryID, libraryIDs, filter)
 	default:
 		// Profile-scoped types (continue_watching, watchlist, favorites)
 		// will be wired later when user store integration is added.
@@ -2522,7 +2561,7 @@ func itemColumnsList(alias string) []string {
 		"imdb_id", "tmdb_id", "tvdb_id",
 		"poster_path", "poster_thumbhash", "backdrop_path", "backdrop_thumbhash", "logo_path",
 		"metadata_s3_path", "metadata_etag", "season_count",
-		"studios", "networks", "countries", "first_air_date", "last_air_date",
+		"studios", "networks", "countries", "release_date::text", "first_air_date", "last_air_date",
 		"show_status",
 		"matched_at", "status", "created_at", "updated_at",
 	}
@@ -2591,7 +2630,7 @@ func scanMediaItems(rows pgx.Rows) ([]*models.MediaItem, error) {
 			&item.ImdbID, &item.TmdbID, &item.TvdbID,
 			&item.PosterPath, &item.PosterThumbhash, &item.BackdropPath, &item.BackdropThumbhash, &item.LogoPath,
 			&item.MetadataS3Path, &item.MetadataEtag, &item.SeasonCount,
-			&item.Studios, &item.Networks, &item.Countries, &item.FirstAirDate, &item.LastAirDate,
+			&item.Studios, &item.Networks, &item.Countries, &item.ReleaseDate, &item.FirstAirDate, &item.LastAirDate,
 			&item.ShowStatus,
 			&item.MatchedAt, &item.Status, &item.CreatedAt, &item.UpdatedAt,
 		)

--- a/internal/sections/resolvedlistcache.go
+++ b/internal/sections/resolvedlistcache.go
@@ -43,6 +43,10 @@ const (
 	// resolvedListRefreshTimeout bounds a detached background rebuild so a stuck
 	// query can never pin a pool connection indefinitely.
 	resolvedListRefreshTimeout = 30 * time.Second
+	// resolvedListPruneInterval bounds how often expired entries are swept from
+	// the map, so keys for scopes that are never requested again cannot linger
+	// for the life of the process.
+	resolvedListPruneInterval = time.Minute
 )
 
 // resolvedListLoader builds the shared item list for a cache key. It takes a
@@ -61,6 +65,9 @@ type resolvedListEntry struct {
 var (
 	resolvedListCacheMu sync.RWMutex
 	resolvedListCache   = make(map[string]resolvedListEntry)
+	// resolvedListLastPrune is the last time expired entries were swept; guarded
+	// by resolvedListCacheMu.
+	resolvedListLastPrune time.Time
 
 	// resolvedListGroup collapses concurrent blocking rebuilds (cold miss /
 	// expired) for the same key into a single loader call.
@@ -153,7 +160,7 @@ func scheduleResolvedListRefresh(key string, now time.Time, loader resolvedListL
 		}()
 		defer func() {
 			if r := recover(); r != nil {
-				slog.Error("resolved list cache refresh panicked", "key", key, "panic", r)
+				slog.Error("resolved list cache refresh panicked", "key_hash", resolvedListLogKey(key), "panic", r)
 			}
 		}()
 
@@ -162,7 +169,7 @@ func scheduleResolvedListRefresh(key string, now time.Time, loader resolvedListL
 
 		items, total, err := loader(ctx)
 		if err != nil {
-			slog.Warn("resolved list cache refresh failed", "key", key, "error", err)
+			slog.Warn("resolved list cache refresh failed", "key_hash", resolvedListLogKey(key), "error", err)
 			return
 		}
 		// A transiently empty refresh preserves the existing (stale-but-usable)
@@ -183,6 +190,7 @@ func resolvedListGet(key string) (resolvedListEntry, bool) {
 
 func resolvedListSet(key string, items []*models.MediaItem, total int, now time.Time) {
 	resolvedListCacheMu.Lock()
+	pruneExpiredResolvedListEntriesLocked(now)
 	resolvedListCache[key] = resolvedListEntry{
 		items:        cloneMediaItems(items),
 		total:        total,
@@ -191,6 +199,22 @@ func resolvedListSet(key string, items []*models.MediaItem, total int, now time.
 		expiresAt:    now.Add(resolvedListTTL),
 	}
 	resolvedListCacheMu.Unlock()
+}
+
+// pruneExpiredResolvedListEntriesLocked sweeps expired entries at most once per
+// resolvedListPruneInterval. The caller must hold resolvedListCacheMu. Keys for
+// scopes that are never looked up again would otherwise remain forever, so this
+// bounds the map to roughly the set of scopes seen within one TTL window.
+func pruneExpiredResolvedListEntriesLocked(now time.Time) {
+	if !resolvedListLastPrune.IsZero() && now.Sub(resolvedListLastPrune) < resolvedListPruneInterval {
+		return
+	}
+	for k, entry := range resolvedListCache {
+		if !now.Before(entry.expiresAt) {
+			delete(resolvedListCache, k)
+		}
+	}
+	resolvedListLastPrune = now
 }
 
 // cloneMediaItems returns a shallow copy of the slice: it protects the cached
@@ -303,6 +327,14 @@ func hashSectionConfig(config json.RawMessage) string {
 	return hex.EncodeToString(sum[:])
 }
 
+// resolvedListLogKey returns a short digest of a cache key for logging. The raw
+// key embeds user-controlled access-scope fields (e.g. NamePrefix), so only the
+// digest is emitted to logs, not the raw input.
+func resolvedListLogKey(key string) string {
+	sum := sha256.Sum256([]byte(key))
+	return hex.EncodeToString(sum[:8])
+}
+
 func writeSortedStrings(b *strings.Builder, values []string) {
 	if len(values) == 0 {
 		return
@@ -356,6 +388,7 @@ func isCacheableSectionType(resolved ResolvedSection) bool {
 func resetResolvedListCacheForTest() {
 	resolvedListCacheMu.Lock()
 	resolvedListCache = make(map[string]resolvedListEntry)
+	resolvedListLastPrune = time.Time{}
 	resolvedListCacheMu.Unlock()
 
 	resolvedListRefreshMu.Lock()

--- a/internal/sections/resolvedlistcache.go
+++ b/internal/sections/resolvedlistcache.go
@@ -1,0 +1,350 @@
+package sections
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"log/slog"
+	"sort"
+	"strconv"
+	"strings"
+	"sync"
+	"time"
+
+	"golang.org/x/sync/singleflight"
+
+	"github.com/Silo-Server/silo-server/internal/catalog"
+	"github.com/Silo-Server/silo-server/internal/models"
+)
+
+// The resolved-list cache stores the *shared*, user-agnostic membership and
+// ordering of a home rail once per access scope. It sits at the native section
+// fetch choke point (FetchOne → fetchSection) and holds presign-free
+// []*models.MediaItem only; the per-user overlay (watched flags, play position,
+// presigned poster URLs) is always recomputed afterwards in
+// SectionHandler.buildSectionsResponse, so a cached entry never leaks one
+// profile's state to another.
+//
+// It is deliberately process-global (package level) rather than per-Fetcher:
+// the process builds several independent Fetcher instances (e.g. native API and
+// recommendations), and a struct-scoped cache (as editorialCandidateCache is
+// today) could never be shared across them.
+const (
+	// resolvedListTTL is the hard expiry: past this an entry must be rebuilt
+	// synchronously.
+	resolvedListTTL = 15 * time.Minute
+	// resolvedListRefreshLead is how far ahead of expiry a background rebuild is
+	// kicked off, so steady traffic is always served a warm entry.
+	resolvedListRefreshLead = 3 * time.Minute
+	// resolvedListRefreshAfter is the soft threshold (builtAt + 12min): reaching
+	// it serves the cached value and triggers one async rebuild.
+	resolvedListRefreshAfter = resolvedListTTL - resolvedListRefreshLead
+	// resolvedListRefreshTimeout bounds a detached background rebuild so a stuck
+	// query can never pin a pool connection indefinitely.
+	resolvedListRefreshTimeout = 30 * time.Second
+)
+
+// resolvedListLoader builds the shared item list for a cache key. It takes a
+// context so the async refresh path can run detached from the request that
+// triggered it.
+type resolvedListLoader func(context.Context) ([]*models.MediaItem, int, error)
+
+type resolvedListEntry struct {
+	items        []*models.MediaItem
+	total        int
+	builtAt      time.Time
+	refreshAfter time.Time
+	expiresAt    time.Time
+}
+
+var (
+	resolvedListCacheMu sync.RWMutex
+	resolvedListCache   = make(map[string]resolvedListEntry)
+
+	// resolvedListGroup collapses concurrent blocking rebuilds (cold miss /
+	// expired) for the same key into a single loader call.
+	resolvedListGroup singleflight.Group
+
+	// resolvedListRefreshMu guards resolvedListRefreshing, which tracks the keys
+	// with an in-flight async rebuild so only one background goroutine per key is
+	// ever spawned.
+	resolvedListRefreshMu  sync.Mutex
+	resolvedListRefreshing = make(map[string]struct{})
+)
+
+// getOrRefresh returns the shared item list for key, implementing serve /
+// refresh-ahead / block-only-when-dead:
+//
+//   - now < refreshAfter          → return cached, do nothing.
+//   - refreshAfter <= now < expiry → return cached AND trigger one async rebuild.
+//   - now >= expiry (or cold miss) → block on the build (singleflight collapses
+//     concurrent blockers into one).
+//
+// Returned slices are defensive copies so a caller mutating the result can never
+// corrupt the cached entry.
+func getOrRefresh(ctx context.Context, key string, now time.Time, loader resolvedListLoader) ([]*models.MediaItem, int, error) {
+	if entry, ok := resolvedListGet(key); ok {
+		switch {
+		case now.Before(entry.refreshAfter):
+			return cloneMediaItems(entry.items), entry.total, nil
+		case now.Before(entry.expiresAt):
+			scheduleResolvedListRefresh(key, now, loader)
+			return cloneMediaItems(entry.items), entry.total, nil
+		}
+		// Past hard expiry: fall through to the blocking rebuild.
+	}
+	return blockingResolvedListRebuild(ctx, key, now, loader)
+}
+
+// blockingResolvedListRebuild rebuilds the entry for key, using singleflight so
+// concurrent cold/expired callers collapse into a single loader call.
+func blockingResolvedListRebuild(ctx context.Context, key string, now time.Time, loader resolvedListLoader) ([]*models.MediaItem, int, error) {
+	type buildResult struct {
+		items []*models.MediaItem
+		total int
+	}
+
+	value, err, _ := resolvedListGroup.Do(key, func() (any, error) {
+		// A concurrent async refresh may have installed a still-usable entry
+		// between the outer read and acquiring the flight; reuse it rather than
+		// hitting the database again.
+		if entry, ok := resolvedListGet(key); ok && now.Before(entry.expiresAt) {
+			return buildResult{items: entry.items, total: entry.total}, nil
+		}
+		items, total, err := loader(ctx)
+		if err != nil {
+			return nil, err
+		}
+		// Never cache an empty membership: some builders (trending, most-watched,
+		// new-to-library) can be transiently empty mid-refresh, and freezing an
+		// empty rail for the full TTL would starve it. Serve the empty result for
+		// this request but keep rebuilding until the row has content.
+		if len(items) > 0 {
+			resolvedListSet(key, items, total, now)
+		}
+		return buildResult{items: items, total: total}, nil
+	})
+	if err != nil {
+		return nil, 0, err
+	}
+	res := value.(buildResult)
+	return cloneMediaItems(res.items), res.total, nil
+}
+
+// scheduleResolvedListRefresh kicks off at most one background rebuild per key.
+// The rebuild runs on a detached context so it survives the request that
+// triggered it; a loader error or panic keeps the existing (stale-but-usable)
+// entry rather than taking down the process.
+func scheduleResolvedListRefresh(key string, now time.Time, loader resolvedListLoader) {
+	resolvedListRefreshMu.Lock()
+	if _, inflight := resolvedListRefreshing[key]; inflight {
+		resolvedListRefreshMu.Unlock()
+		return
+	}
+	resolvedListRefreshing[key] = struct{}{}
+	resolvedListRefreshMu.Unlock()
+
+	go func() {
+		defer func() {
+			resolvedListRefreshMu.Lock()
+			delete(resolvedListRefreshing, key)
+			resolvedListRefreshMu.Unlock()
+		}()
+		defer func() {
+			if r := recover(); r != nil {
+				slog.Error("resolved list cache refresh panicked", "key", key, "panic", r)
+			}
+		}()
+
+		ctx, cancel := context.WithTimeout(context.Background(), resolvedListRefreshTimeout)
+		defer cancel()
+
+		items, total, err := loader(ctx)
+		if err != nil {
+			slog.Warn("resolved list cache refresh failed", "key", key, "error", err)
+			return
+		}
+		// A transiently empty refresh preserves the existing (stale-but-usable)
+		// entry rather than overwriting a good rail with nothing.
+		if len(items) == 0 {
+			return
+		}
+		resolvedListSet(key, items, total, now)
+	}()
+}
+
+func resolvedListGet(key string) (resolvedListEntry, bool) {
+	resolvedListCacheMu.RLock()
+	entry, ok := resolvedListCache[key]
+	resolvedListCacheMu.RUnlock()
+	return entry, ok
+}
+
+func resolvedListSet(key string, items []*models.MediaItem, total int, now time.Time) {
+	resolvedListCacheMu.Lock()
+	resolvedListCache[key] = resolvedListEntry{
+		items:        cloneMediaItems(items),
+		total:        total,
+		builtAt:      now,
+		refreshAfter: now.Add(resolvedListRefreshAfter),
+		expiresAt:    now.Add(resolvedListTTL),
+	}
+	resolvedListCacheMu.Unlock()
+}
+
+// cloneMediaItems returns a shallow copy of the slice: it protects the cached
+// entry against reordering/appending/truncating (which the diversity and
+// seasonal filters do), but NOT against in-place mutation of a pointed-to
+// *models.MediaItem. That is safe because the native overlay
+// (buildSectionsResponse) only reads item fields — presign/user-state/images
+// land in separate maps. Any future consumer that mutates item fields in place
+// must instead take a deep struct copy here.
+func cloneMediaItems(items []*models.MediaItem) []*models.MediaItem {
+	if items == nil {
+		return nil
+	}
+	return append([]*models.MediaItem(nil), items...)
+}
+
+// resolvedListCacheKey builds the access-scope cache key. It is security
+// critical: it must capture every access boundary and nothing that is per-user.
+// Modeled on editorialCandidateCacheKey, extended with section identity (type +
+// ID + config hash), the requested ItemLimit, and the full access scope. It
+// deliberately excludes userID/profileID so entries are shared across everyone
+// with the same access.
+func resolvedListCacheKey(resolved ResolvedSection, libraryID *int, libraryIDs []int, filter catalog.AccessFilter) string {
+	var b strings.Builder
+	b.WriteString("type=")
+	b.WriteString(string(resolved.SectionType))
+
+	b.WriteString("|id=")
+	b.WriteString(resolved.ID)
+
+	b.WriteString("|config=")
+	b.WriteString(hashSectionConfig(resolved.Config))
+
+	b.WriteString("|limit=")
+	b.WriteString(strconv.Itoa(resolved.ItemLimit))
+
+	b.WriteString("|library=")
+	if libraryID == nil {
+		b.WriteString("all")
+	} else {
+		b.WriteString(strconv.Itoa(*libraryID))
+	}
+
+	b.WriteString("|libraries=")
+	writeOptionalSortedInts(&b, libraryIDs)
+
+	b.WriteString("|accessible=")
+	writeOptionalSortedInts(&b, filter.AllowedLibraryIDs)
+
+	b.WriteString("|disabled=")
+	writeSortedInts(&b, filter.DisabledLibraryIDs)
+
+	b.WriteString("|rating=")
+	b.WriteString(filter.MaxContentRating)
+
+	b.WriteString("|excludedtypes=")
+	writeSortedStrings(&b, filter.ExcludedMediaTypes)
+
+	// AllowedContentIDs and NamePrefix are enforced as SQL constraints by the
+	// filter-driven builders (fetchFiltered, fetchSeasonalThemed,
+	// fetchMoodCollection via QueryExecutor). They are per-scope access
+	// boundaries, so they MUST key the entry or a content-restricted profile
+	// could be served an unrestricted profile's membership. AllowedContentIDs is
+	// hashed (it can be large) and preserves the nil (unrestricted) vs empty
+	// (restrict-to-nothing) distinction the catalog layer relies on.
+	b.WriteString("|nameprefix=")
+	b.WriteString(filter.NamePrefix)
+
+	b.WriteString("|allowedcontent=")
+	b.WriteString(hashOptionalContentIDs(filter.AllowedContentIDs))
+
+	return b.String()
+}
+
+// hashOptionalContentIDs returns a bounded, order-independent digest of an
+// allow-list, preserving the nil vs empty distinction (nil = unrestricted,
+// empty = restrict to nothing) that the catalog access layer branches on.
+func hashOptionalContentIDs(ids []string) string {
+	if ids == nil {
+		return "<nil>"
+	}
+	if len(ids) == 0 {
+		return "<empty>"
+	}
+	sorted := append([]string(nil), ids...)
+	sort.Strings(sorted)
+	sum := sha256.Sum256([]byte(strings.Join(sorted, ",")))
+	return hex.EncodeToString(sum[:])
+}
+
+func hashSectionConfig(config json.RawMessage) string {
+	if len(config) == 0 {
+		return "none"
+	}
+	sum := sha256.Sum256(config)
+	return hex.EncodeToString(sum[:])
+}
+
+func writeSortedStrings(b *strings.Builder, values []string) {
+	if len(values) == 0 {
+		return
+	}
+	sorted := append([]string(nil), values...)
+	sort.Strings(sorted)
+	for i, value := range sorted {
+		if i > 0 {
+			b.WriteByte(',')
+		}
+		b.WriteString(value)
+	}
+}
+
+// isCacheableSectionType reports whether a resolved section's shared item list
+// may be cached. The whitelist covers the user-agnostic rows whose membership
+// is identical for everyone with the same access scope. Random is excluded so
+// its per-request shuffle is preserved; per-user rows (continue watching,
+// next-up, recommendations, hidden gems, forgotten favorites, activity feed)
+// have no shared base and are excluded; user collections are profile-scoped and
+// excluded via the UserCollectionID check.
+func isCacheableSectionType(resolved ResolvedSection) bool {
+	switch resolved.SectionType {
+	case SectionRecentlyAdded,
+		SectionRecentlyReleased,
+		SectionGenre,
+		SectionCustomFilter,
+		SectionCriticallyAcclaimed,
+		SectionAwardWinners,
+		SectionFormatShowcase,
+		SectionSeasonalThemed,
+		SectionMoodCollection,
+		SectionTrendingOnServer,
+		SectionNewToLibrary,
+		SectionMostWatched,
+		SectionTrendingDiscover,
+		SectionAdminCuratedList:
+		return true
+	case SectionCollection:
+		// Only library collections are shared; user collections are
+		// profile-scoped and must never be served across profiles.
+		cfg := ParseCollectionConfig(resolved.Config)
+		return strings.TrimSpace(cfg.UserCollectionID) == ""
+	default:
+		return false
+	}
+}
+
+// resetResolvedListCacheForTest clears all process-global cache state. Tests
+// call it between cases so entries and in-flight refreshes never leak across.
+func resetResolvedListCacheForTest() {
+	resolvedListCacheMu.Lock()
+	resolvedListCache = make(map[string]resolvedListEntry)
+	resolvedListCacheMu.Unlock()
+
+	resolvedListRefreshMu.Lock()
+	resolvedListRefreshing = make(map[string]struct{})
+	resolvedListRefreshMu.Unlock()
+}

--- a/internal/sections/resolvedlistcache.go
+++ b/internal/sections/resolvedlistcache.go
@@ -209,17 +209,31 @@ func cloneMediaItems(items []*models.MediaItem) []*models.MediaItem {
 
 // resolvedListCacheKey builds the access-scope cache key. It is security
 // critical: it must capture every access boundary and nothing that is per-user.
-// Modeled on editorialCandidateCacheKey, extended with section identity (type +
-// ID + config hash), the requested ItemLimit, and the full access scope. It
-// deliberately excludes userID/profileID so entries are shared across everyone
-// with the same access.
+//
+// Keying is identity-independent: an entry is keyed by what fully determines the
+// shared membership and ordering — the section TYPE, its CONFIG (hashed), the
+// requested ItemLimit, and the full access scope (library scope + rating +
+// excluded types + content allow-list + name prefix). It deliberately EXCLUDES
+// resolved.ID. Every cacheable section type derives its membership purely from
+// TYPE + CONFIG + limit + scope: none of the cacheable fetch helpers
+// (recently_added / recently_released, genre / custom_filter,
+// critically_acclaimed, award_winners, format_showcase, seasonal_themed,
+// mood_collection, trending_on_server, new_to_library, most_watched,
+// trending_discover, admin_curated_list, or the library-collection path) reads
+// the section's own ID to determine which items it contains — the sole s.ID read
+// lives in the non-cacheable user-collection branch. Dropping the arbitrary ID
+// lets two sections that share type+config+limit+scope collapse to ONE shared
+// entry: e.g. a natively configured "recently added" library rail and the
+// jellyfin-compat /Items/Latest for that same library are built once and reused
+// across both surfaces.
+//
+// userID/profileID are still excluded so entries are shared across everyone with
+// the same access; the per-user overlay is always recomputed downstream, so a
+// cached entry never leaks one profile's state to another.
 func resolvedListCacheKey(resolved ResolvedSection, libraryID *int, libraryIDs []int, filter catalog.AccessFilter) string {
 	var b strings.Builder
 	b.WriteString("type=")
 	b.WriteString(string(resolved.SectionType))
-
-	b.WriteString("|id=")
-	b.WriteString(resolved.ID)
 
 	b.WriteString("|config=")
 	b.WriteString(hashSectionConfig(resolved.Config))

--- a/internal/sections/resolvedlistcache.go
+++ b/internal/sections/resolvedlistcache.go
@@ -36,8 +36,8 @@ const (
 	resolvedListTTL = 15 * time.Minute
 	// resolvedListRefreshLead is how far ahead of expiry a background rebuild is
 	// kicked off, so steady traffic is always served a warm entry.
-	resolvedListRefreshLead = 3 * time.Minute
-	// resolvedListRefreshAfter is the soft threshold (builtAt + 12min): reaching
+	resolvedListRefreshLead = 10 * time.Minute
+	// resolvedListRefreshAfter is the soft threshold (builtAt + 5min): reaching
 	// it serves the cached value and triggers one async rebuild.
 	resolvedListRefreshAfter = resolvedListTTL - resolvedListRefreshLead
 	// resolvedListRefreshTimeout bounds a detached background rebuild so a stuck
@@ -360,8 +360,6 @@ func isCacheableSectionType(resolved ResolvedSection) bool {
 	switch resolved.SectionType {
 	case SectionRecentlyAdded,
 		SectionRecentlyReleased,
-		SectionGenre,
-		SectionCustomFilter,
 		SectionCriticallyAcclaimed,
 		SectionAwardWinners,
 		SectionFormatShowcase,
@@ -372,7 +370,27 @@ func isCacheableSectionType(resolved ResolvedSection) bool {
 		SectionMostWatched,
 		SectionTrendingDiscover,
 		SectionAdminCuratedList:
+		// Seasonal/mood/trending build their query definition server-side from a
+		// fixed theme/mood/snapshot schema (never from user-supplied rules), so
+		// they are always user-agnostic.
 		return true
+	case SectionGenre, SectionCustomFilter:
+		// These route through fetchFiltered → ParseQueryDefinition, whose
+		// user-supplied QueryDefinition can carry personalized (per-profile)
+		// rules/sorts (watched, favorited, in_watchlist, in_progress,
+		// last_watched; sorts progress/date_viewed/plays) that inject
+		// EXISTS(... user_id/profile_id ...) predicates. Such a rail's
+		// membership differs per profile and must never be served from the
+		// user-agnostic shared cache, whose key excludes userID/profileID.
+		// Non-personalized definitions stay cacheable. Use the same parser
+		// fetchFiltered uses so cacheability tracks execution exactly.
+		def, err := ParseQueryDefinition(resolved.Config)
+		if err != nil {
+			// Unparseable config: fetchFiltered would also fail (nothing gets
+			// cached), so stay off the cache path to be safe.
+			return false
+		}
+		return !def.IsPersonalized()
 	case SectionCollection:
 		// Only library collections are shared; user collections are
 		// profile-scoped and must never be served across profiles.

--- a/internal/sections/resolvedlistcache.go
+++ b/internal/sections/resolvedlistcache.go
@@ -323,8 +323,27 @@ func hashSectionConfig(config json.RawMessage) string {
 	if len(config) == 0 {
 		return "none"
 	}
+	// Canonicalize before hashing so semantically identical configs that differ
+	// only in whitespace or field order share a cache entry (the whole point of
+	// keying native and jellycompat fetches to the same rail). Fall back to the
+	// raw bytes when the config isn't valid JSON.
+	if canonical, err := canonicalJSON(config); err == nil {
+		config = canonical
+	}
 	sum := sha256.Sum256(config)
 	return hex.EncodeToString(sum[:])
+}
+
+// canonicalJSON returns a stable encoding of raw by decoding and re-marshaling
+// it, so object key order and insignificant whitespace no longer affect the
+// bytes. encoding/json marshals map keys in sorted order, giving a deterministic
+// form.
+func canonicalJSON(raw json.RawMessage) (json.RawMessage, error) {
+	var decoded any
+	if err := json.Unmarshal(raw, &decoded); err != nil {
+		return nil, err
+	}
+	return json.Marshal(decoded)
 }
 
 // resolvedListLogKey returns a short digest of a cache key for logging. The raw

--- a/internal/sections/resolvedlistcache.go
+++ b/internal/sections/resolvedlistcache.go
@@ -6,7 +6,6 @@ import (
 	"encoding/hex"
 	"encoding/json"
 	"log/slog"
-	"sort"
 	"strconv"
 	"strings"
 	"sync"
@@ -40,9 +39,10 @@ const (
 	// resolvedListRefreshAfter is the soft threshold (builtAt + 5min): reaching
 	// it serves the cached value and triggers one async rebuild.
 	resolvedListRefreshAfter = resolvedListTTL - resolvedListRefreshLead
-	// resolvedListRefreshTimeout bounds a detached background rebuild so a stuck
-	// query can never pin a pool connection indefinitely.
-	resolvedListRefreshTimeout = 30 * time.Second
+	// resolvedListBuildTimeout bounds every detached loader run — background
+	// refreshes and blocking rebuilds alike — so a stuck query can never pin a
+	// pool connection indefinitely.
+	resolvedListBuildTimeout = 30 * time.Second
 	// resolvedListPruneInterval bounds how often expired entries are swept from
 	// the map, so keys for scopes that are never requested again cannot linger
 	// for the life of the process.
@@ -119,7 +119,15 @@ func blockingResolvedListRebuild(ctx context.Context, key string, now time.Time,
 		if entry, ok := resolvedListGet(key); ok && now.Before(entry.expiresAt) {
 			return buildResult{items: entry.items, total: entry.total}, nil
 		}
-		items, total, err := loader(ctx)
+		// Run the loader detached from the leader's request cancellation:
+		// singleflight shares this one build across every collapsed waiter, so
+		// the leader's client disconnecting (or its deadline firing) must not
+		// fail all the other requests riding on the flight. WithoutCancel keeps
+		// the leader's context values (tracing, logging) while dropping its
+		// cancellation; the timeout re-bounds the detached work.
+		loadCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), resolvedListBuildTimeout)
+		defer cancel()
+		items, total, err := loader(loadCtx)
 		if err != nil {
 			return nil, err
 		}
@@ -164,7 +172,7 @@ func scheduleResolvedListRefresh(key string, now time.Time, loader resolvedListL
 			}
 		}()
 
-		ctx, cancel := context.WithTimeout(context.Background(), resolvedListRefreshTimeout)
+		ctx, cancel := context.WithTimeout(context.Background(), resolvedListBuildTimeout)
 		defer cancel()
 
 		items, total, err := loader(ctx)
@@ -275,48 +283,13 @@ func resolvedListCacheKey(resolved ResolvedSection, libraryID *int, libraryIDs [
 	b.WriteString("|libraries=")
 	writeOptionalSortedInts(&b, libraryIDs)
 
-	b.WriteString("|accessible=")
-	writeOptionalSortedInts(&b, filter.AllowedLibraryIDs)
-
-	b.WriteString("|disabled=")
-	writeSortedInts(&b, filter.DisabledLibraryIDs)
-
-	b.WriteString("|rating=")
-	b.WriteString(filter.MaxContentRating)
-
-	b.WriteString("|excludedtypes=")
-	writeSortedStrings(&b, filter.ExcludedMediaTypes)
-
-	// AllowedContentIDs and NamePrefix are enforced as SQL constraints by the
-	// filter-driven builders (fetchFiltered, fetchSeasonalThemed,
-	// fetchMoodCollection via QueryExecutor). They are per-scope access
-	// boundaries, so they MUST key the entry or a content-restricted profile
-	// could be served an unrestricted profile's membership. AllowedContentIDs is
-	// hashed (it can be large) and preserves the nil (unrestricted) vs empty
-	// (restrict-to-nothing) distinction the catalog layer relies on.
-	b.WriteString("|nameprefix=")
-	b.WriteString(filter.NamePrefix)
-
-	b.WriteString("|allowedcontent=")
-	b.WriteString(hashOptionalContentIDs(filter.AllowedContentIDs))
+	// Every access boundary (library scope, rating, excluded types, content
+	// allow-list, name prefix) is serialized by the shared catalog helper so
+	// this cache can never drift from the other access-scoped caches when
+	// AccessFilter grows a new boundary field.
+	filter.WriteAccessScopeCacheKey(&b)
 
 	return b.String()
-}
-
-// hashOptionalContentIDs returns a bounded, order-independent digest of an
-// allow-list, preserving the nil vs empty distinction (nil = unrestricted,
-// empty = restrict to nothing) that the catalog access layer branches on.
-func hashOptionalContentIDs(ids []string) string {
-	if ids == nil {
-		return "<nil>"
-	}
-	if len(ids) == 0 {
-		return "<empty>"
-	}
-	sorted := append([]string(nil), ids...)
-	sort.Strings(sorted)
-	sum := sha256.Sum256([]byte(strings.Join(sorted, ",")))
-	return hex.EncodeToString(sum[:])
 }
 
 func hashSectionConfig(config json.RawMessage) string {
@@ -354,45 +327,20 @@ func resolvedListLogKey(key string) string {
 	return hex.EncodeToString(sum[:8])
 }
 
-func writeSortedStrings(b *strings.Builder, values []string) {
-	if len(values) == 0 {
-		return
-	}
-	sorted := append([]string(nil), values...)
-	sort.Strings(sorted)
-	for i, value := range sorted {
-		if i > 0 {
-			b.WriteByte(',')
-		}
-		b.WriteString(value)
-	}
-}
-
 // isCacheableSectionType reports whether a resolved section's shared item list
-// may be cached. The whitelist covers the user-agnostic rows whose membership
-// is identical for everyone with the same access scope. Random is excluded so
-// its per-request shuffle is preserved; per-user rows (continue watching,
-// next-up, recommendations, hidden gems, forgotten favorites, activity feed)
-// have no shared base and are excluded; user collections are profile-scoped and
-// excluded via the UserCollectionID check.
-func isCacheableSectionType(resolved ResolvedSection) bool {
-	switch resolved.SectionType {
-	case SectionRecentlyAdded,
-		SectionRecentlyReleased,
-		SectionCriticallyAcclaimed,
-		SectionAwardWinners,
-		SectionFormatShowcase,
-		SectionSeasonalThemed,
-		SectionMoodCollection,
-		SectionTrendingOnServer,
-		SectionNewToLibrary,
-		SectionMostWatched,
-		SectionTrendingDiscover,
-		SectionAdminCuratedList:
-		// Seasonal/mood/trending build their query definition server-side from a
-		// fixed theme/mood/snapshot schema (never from user-supplied rules), so
-		// they are always user-agnostic.
+// may be cached. Cacheability is derived from userAgnosticSectionFetcher — the
+// same table fetchSection dispatches through — so the "may this row be shared
+// across profiles?" decision lives in exactly one place and cannot drift from
+// the fetch implementation. Random is excluded from that table so its
+// per-request shuffle is preserved; per-user rows (continue watching, next-up,
+// recommendations, hidden gems, forgotten favorites, activity feed) have no
+// shared base; user collections are profile-scoped and excluded via the
+// UserCollectionID check.
+func (f *Fetcher) isCacheableSectionType(resolved ResolvedSection) bool {
+	if f.userAgnosticSectionFetcher(resolved.SectionType) != nil {
 		return true
+	}
+	switch resolved.SectionType {
 	case SectionGenre, SectionCustomFilter:
 		// These route through fetchFiltered → ParseQueryDefinition, whose
 		// user-supplied QueryDefinition can carry personalized (per-profile)

--- a/internal/sections/resolvedlistcache_test.go
+++ b/internal/sections/resolvedlistcache_test.go
@@ -407,6 +407,54 @@ func TestIsCacheableSectionType(t *testing.T) {
 	}
 }
 
+// TestIsCacheableSectionTypePersonalizedFilter verifies genre / custom_filter
+// sections whose QueryDefinition carries a personalized (per-profile) rule or
+// sort are NOT cacheable — their membership differs per profile and the shared
+// cache key excludes userID/profileID — while non-personalized definitions of
+// the same types stay cacheable.
+func TestIsCacheableSectionTypePersonalizedFilter(t *testing.T) {
+	nonPersonalized := mustJSON(t, catalog.QueryDefinition{
+		Match: "all",
+		Groups: []catalog.QueryGroup{
+			{Match: "all", Rules: []catalog.QueryRule{
+				{Field: "genre", Op: "contains", Value: "Action"},
+			}},
+		},
+	})
+
+	personalizedRule := mustJSON(t, catalog.QueryDefinition{
+		Match: "all",
+		Groups: []catalog.QueryGroup{
+			{Match: "all", Rules: []catalog.QueryRule{
+				{Field: "genre", Op: "contains", Value: "Action"},
+				{Field: "in_watchlist", Op: "is", Value: true},
+			}},
+		},
+	})
+
+	personalizedSort := mustJSON(t, catalog.QueryDefinition{
+		Match: "all",
+		Groups: []catalog.QueryGroup{
+			{Match: "all", Rules: []catalog.QueryRule{
+				{Field: "watched", Op: "is", Value: false},
+			}},
+		},
+		Sort: catalog.QuerySort{Field: "progress", Order: "desc"},
+	})
+
+	for _, st := range []SectionType{SectionCustomFilter, SectionGenre} {
+		if !isCacheableSectionType(ResolvedSection{SectionType: st, Config: nonPersonalized}) {
+			t.Errorf("%s with a non-personalized definition should be cacheable", st)
+		}
+		if isCacheableSectionType(ResolvedSection{SectionType: st, Config: personalizedRule}) {
+			t.Errorf("%s with a personalized rule (in_watchlist) must NOT be cacheable", st)
+		}
+		if isCacheableSectionType(ResolvedSection{SectionType: st, Config: personalizedSort}) {
+			t.Errorf("%s with a personalized sort/rule (watched/progress) must NOT be cacheable", st)
+		}
+	}
+}
+
 // TestResolvedListCacheCollectionUserExclusion verifies library collections are
 // cacheable while user (profile-scoped) collections are not.
 func TestResolvedListCacheCollectionUserExclusion(t *testing.T) {

--- a/internal/sections/resolvedlistcache_test.go
+++ b/internal/sections/resolvedlistcache_test.go
@@ -388,8 +388,10 @@ func TestResolvedListCacheDefensiveCopy(t *testing.T) {
 }
 
 // TestIsCacheableSectionType covers the whitelist, the user-collection
-// exclusion, and the explicit exclusions.
+// exclusion, and the explicit exclusions. Cacheability is derived from
+// userAgnosticSectionFetcher, so this doubles as a pin on that table.
 func TestIsCacheableSectionType(t *testing.T) {
+	f := &Fetcher{}
 	cacheable := []SectionType{
 		SectionRecentlyAdded,
 		SectionRecentlyReleased,
@@ -407,7 +409,7 @@ func TestIsCacheableSectionType(t *testing.T) {
 		SectionAdminCuratedList,
 	}
 	for _, st := range cacheable {
-		if !isCacheableSectionType(ResolvedSection{SectionType: st}) {
+		if !f.isCacheableSectionType(ResolvedSection{SectionType: st}) {
 			t.Errorf("expected %s to be cacheable", st)
 		}
 	}
@@ -427,7 +429,7 @@ func TestIsCacheableSectionType(t *testing.T) {
 		SectionEditorialSpotlight,
 	}
 	for _, st := range notCacheable {
-		if isCacheableSectionType(ResolvedSection{SectionType: st}) {
+		if f.isCacheableSectionType(ResolvedSection{SectionType: st}) {
 			t.Errorf("expected %s to NOT be cacheable", st)
 		}
 	}
@@ -439,6 +441,7 @@ func TestIsCacheableSectionType(t *testing.T) {
 // cache key excludes userID/profileID — while non-personalized definitions of
 // the same types stay cacheable.
 func TestIsCacheableSectionTypePersonalizedFilter(t *testing.T) {
+	f := &Fetcher{}
 	nonPersonalized := mustJSON(t, catalog.QueryDefinition{
 		Match: "all",
 		Groups: []catalog.QueryGroup{
@@ -469,13 +472,13 @@ func TestIsCacheableSectionTypePersonalizedFilter(t *testing.T) {
 	})
 
 	for _, st := range []SectionType{SectionCustomFilter, SectionGenre} {
-		if !isCacheableSectionType(ResolvedSection{SectionType: st, Config: nonPersonalized}) {
+		if !f.isCacheableSectionType(ResolvedSection{SectionType: st, Config: nonPersonalized}) {
 			t.Errorf("%s with a non-personalized definition should be cacheable", st)
 		}
-		if isCacheableSectionType(ResolvedSection{SectionType: st, Config: personalizedRule}) {
+		if f.isCacheableSectionType(ResolvedSection{SectionType: st, Config: personalizedRule}) {
 			t.Errorf("%s with a personalized rule (in_watchlist) must NOT be cacheable", st)
 		}
-		if isCacheableSectionType(ResolvedSection{SectionType: st, Config: personalizedSort}) {
+		if f.isCacheableSectionType(ResolvedSection{SectionType: st, Config: personalizedSort}) {
 			t.Errorf("%s with a personalized sort/rule (watched/progress) must NOT be cacheable", st)
 		}
 	}
@@ -484,11 +487,12 @@ func TestIsCacheableSectionTypePersonalizedFilter(t *testing.T) {
 // TestResolvedListCacheCollectionUserExclusion verifies library collections are
 // cacheable while user (profile-scoped) collections are not.
 func TestResolvedListCacheCollectionUserExclusion(t *testing.T) {
+	f := &Fetcher{}
 	libraryCollection := ResolvedSection{
 		SectionType: SectionCollection,
 		Config:      mustJSON(t, SectionCollectionConfig{LibraryCollectionID: "lib-coll-1"}),
 	}
-	if !isCacheableSectionType(libraryCollection) {
+	if !f.isCacheableSectionType(libraryCollection) {
 		t.Fatalf("library collection should be cacheable")
 	}
 
@@ -496,7 +500,7 @@ func TestResolvedListCacheCollectionUserExclusion(t *testing.T) {
 		SectionType: SectionCollection,
 		Config:      mustJSON(t, SectionCollectionConfig{UserCollectionID: "user-coll-1"}),
 	}
-	if isCacheableSectionType(userCollection) {
+	if f.isCacheableSectionType(userCollection) {
 		t.Fatalf("user collection must NOT be cacheable (profile-scoped)")
 	}
 }
@@ -645,4 +649,39 @@ func waitFor(timeout time.Duration, cond func() bool) bool {
 		time.Sleep(time.Millisecond)
 	}
 	return cond()
+}
+
+// TestBlockingRebuildDetachedFromLeaderCancellation verifies a cold-miss
+// blocking rebuild survives the initiating request's cancellation: singleflight
+// shares one build across every collapsed waiter, so the leader's client
+// disconnecting must not fail all the other requests riding on the flight.
+func TestBlockingRebuildDetachedFromLeaderCancellation(t *testing.T) {
+	resetResolvedListCacheForTest()
+	defer resetResolvedListCacheForTest()
+
+	// A context canceled BEFORE the build starts: without detachment the loader
+	// (which honors ctx like the real fetchers do) would fail immediately.
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	loader := func(loadCtx context.Context) ([]*models.MediaItem, int, error) {
+		if err := loadCtx.Err(); err != nil {
+			return nil, 0, err
+		}
+		return mediaItems("x1"), 1, nil
+	}
+
+	now := time.Unix(1_700_000_000, 0)
+	items, total, err := getOrRefresh(ctx, "detach-key", now, loader)
+	if err != nil {
+		t.Fatalf("blocking rebuild must run detached from the leader's cancellation, got %v", err)
+	}
+	if total != 1 || len(items) != 1 || items[0].ContentID != "x1" {
+		t.Fatalf("unexpected result: items=%v total=%d", itemIDs(items), total)
+	}
+
+	// The successful detached build must have been cached for later requests.
+	if _, ok := resolvedListGet("detach-key"); !ok {
+		t.Fatal("detached rebuild did not cache its result")
+	}
 }

--- a/internal/sections/resolvedlistcache_test.go
+++ b/internal/sections/resolvedlistcache_test.go
@@ -1,0 +1,418 @@
+package sections
+
+import (
+	"context"
+	"encoding/json"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/Silo-Server/silo-server/internal/catalog"
+	"github.com/Silo-Server/silo-server/internal/models"
+)
+
+func mediaItems(ids ...string) []*models.MediaItem {
+	items := make([]*models.MediaItem, 0, len(ids))
+	for _, id := range ids {
+		items = append(items, &models.MediaItem{ContentID: id})
+	}
+	return items
+}
+
+func itemIDs(items []*models.MediaItem) []string {
+	ids := make([]string, 0, len(items))
+	for _, item := range items {
+		ids = append(ids, item.ContentID)
+	}
+	return ids
+}
+
+func staticLoader(items []*models.MediaItem, calls *int64) resolvedListLoader {
+	return func(context.Context) ([]*models.MediaItem, int, error) {
+		if calls != nil {
+			atomic.AddInt64(calls, 1)
+		}
+		return items, len(items), nil
+	}
+}
+
+// TestResolvedListCacheScopeIsolation verifies distinct access scopes hash to
+// distinct keys and never cross-serve one another's items.
+func TestResolvedListCacheScopeIsolation(t *testing.T) {
+	resetResolvedListCacheForTest()
+	defer resetResolvedListCacheForTest()
+
+	resolved := ResolvedSection{
+		ID:          "sec-1",
+		SectionType: SectionRecentlyAdded,
+		ItemLimit:   20,
+	}
+	scopeA := catalog.AccessFilter{AllowedLibraryIDs: []int{1, 2}, MaxContentRating: "PG-13"}
+	scopeB := catalog.AccessFilter{AllowedLibraryIDs: []int{3}, MaxContentRating: "R"}
+
+	keyA := resolvedListCacheKey(resolved, nil, nil, scopeA)
+	keyB := resolvedListCacheKey(resolved, nil, nil, scopeB)
+	if keyA == keyB {
+		t.Fatalf("expected distinct keys for distinct scopes, got %q for both", keyA)
+	}
+
+	now := time.Unix(1_700_000_000, 0)
+	itemsA := mediaItems("a1", "a2")
+	itemsB := mediaItems("b1")
+
+	gotA, totalA, err := getOrRefresh(context.Background(), keyA, now, staticLoader(itemsA, nil))
+	if err != nil {
+		t.Fatalf("scope A load: %v", err)
+	}
+	gotB, totalB, err := getOrRefresh(context.Background(), keyB, now, staticLoader(itemsB, nil))
+	if err != nil {
+		t.Fatalf("scope B load: %v", err)
+	}
+
+	if got := itemIDs(gotA); len(got) != 2 || got[0] != "a1" || got[1] != "a2" {
+		t.Fatalf("scope A returned %v, want [a1 a2]", got)
+	}
+	if totalA != 2 {
+		t.Fatalf("scope A total = %d, want 2", totalA)
+	}
+	if got := itemIDs(gotB); len(got) != 1 || got[0] != "b1" {
+		t.Fatalf("scope B returned %v, want [b1]", got)
+	}
+	if totalB != 1 {
+		t.Fatalf("scope B total = %d, want 1", totalB)
+	}
+
+	// Re-reading scope A must still yield scope A's items even after scope B was
+	// populated: no cross-serving between scopes.
+	reGotA, _, err := getOrRefresh(context.Background(), keyA, now, func(context.Context) ([]*models.MediaItem, int, error) {
+		t.Fatalf("scope A loader should not run again while entry is fresh")
+		return nil, 0, nil
+	})
+	if err != nil {
+		t.Fatalf("scope A re-read: %v", err)
+	}
+	if got := itemIDs(reGotA); len(got) != 2 || got[0] != "a1" {
+		t.Fatalf("scope A re-read returned %v, want [a1 a2]", got)
+	}
+}
+
+// TestResolvedListCacheKeyContentBoundaries verifies the content-scoping access
+// boundaries (AllowedContentIDs, NamePrefix) that the filter-driven builders
+// enforce as SQL constraints each produce a distinct key, so a content-restricted
+// profile can never be served an unrestricted profile's membership.
+func TestResolvedListCacheKeyContentBoundaries(t *testing.T) {
+	resolved := ResolvedSection{ID: "sec-1", SectionType: SectionGenre, ItemLimit: 20}
+	base := catalog.AccessFilter{AllowedLibraryIDs: []int{1}, MaxContentRating: "PG-13"}
+
+	// nil (unrestricted) vs empty (restrict-to-nothing) vs a concrete allow-list
+	// must all differ, and two different allow-lists must differ.
+	unrestricted := resolvedListCacheKey(resolved, nil, nil, base)
+
+	restrictNone := base
+	restrictNone.AllowedContentIDs = []string{}
+	keyRestrictNone := resolvedListCacheKey(resolved, nil, nil, restrictNone)
+
+	allowX := base
+	allowX.AllowedContentIDs = []string{"c1", "c2"}
+	keyAllowX := resolvedListCacheKey(resolved, nil, nil, allowX)
+
+	allowY := base
+	allowY.AllowedContentIDs = []string{"c3"}
+	keyAllowY := resolvedListCacheKey(resolved, nil, nil, allowY)
+
+	for _, pair := range [][2]string{
+		{unrestricted, keyRestrictNone},
+		{unrestricted, keyAllowX},
+		{keyRestrictNone, keyAllowX},
+		{keyAllowX, keyAllowY},
+	} {
+		if pair[0] == pair[1] {
+			t.Fatalf("expected distinct keys for distinct content scopes, got identical %q", pair[0])
+		}
+	}
+
+	// Order-independence: the same allow-list in a different order shares a key.
+	allowXReordered := base
+	allowXReordered.AllowedContentIDs = []string{"c2", "c1"}
+	if resolvedListCacheKey(resolved, nil, nil, allowXReordered) != keyAllowX {
+		t.Fatalf("allow-list key should be order-independent")
+	}
+
+	// NamePrefix is an access boundary too.
+	prefixed := base
+	prefixed.NamePrefix = "The "
+	if resolvedListCacheKey(resolved, nil, nil, prefixed) == unrestricted {
+		t.Fatalf("NamePrefix must change the cache key")
+	}
+}
+
+// TestResolvedListCacheDoesNotCacheEmpty verifies a transiently empty result is
+// not frozen for the TTL: the loader runs again on the next request.
+func TestResolvedListCacheDoesNotCacheEmpty(t *testing.T) {
+	resetResolvedListCacheForTest()
+	defer resetResolvedListCacheForTest()
+
+	key := "empty-not-cached"
+	now := time.Unix(1_700_000_000, 0)
+
+	var calls int64
+	emptyLoader := func(context.Context) ([]*models.MediaItem, int, error) {
+		atomic.AddInt64(&calls, 1)
+		return nil, 0, nil
+	}
+
+	if _, _, err := getOrRefresh(context.Background(), key, now, emptyLoader); err != nil {
+		t.Fatalf("first empty load: %v", err)
+	}
+	// A second read in the same fresh window must rebuild (empty was not cached).
+	got, _, err := getOrRefresh(context.Background(), key, now, staticLoader(mediaItems("now-has-content"), &calls))
+	if err != nil {
+		t.Fatalf("second load: %v", err)
+	}
+	if ids := itemIDs(got); len(ids) != 1 || ids[0] != "now-has-content" {
+		t.Fatalf("second load returned %v, want [now-has-content]", ids)
+	}
+	if got := atomic.LoadInt64(&calls); got != 2 {
+		t.Fatalf("loader invoked %d times, want 2 (empty result was not cached)", got)
+	}
+}
+
+// TestResolvedListCacheDefensiveCopy verifies a caller mutating the returned
+// slice cannot corrupt the cached entry.
+func TestResolvedListCacheDefensiveCopy(t *testing.T) {
+	resetResolvedListCacheForTest()
+	defer resetResolvedListCacheForTest()
+
+	key := "defensive-copy"
+	now := time.Unix(1_700_000_000, 0)
+
+	got, _, err := getOrRefresh(context.Background(), key, now, staticLoader(mediaItems("x1", "x2"), nil))
+	if err != nil {
+		t.Fatalf("initial load: %v", err)
+	}
+	got[0] = &models.MediaItem{ContentID: "tampered"}
+
+	reGot, _, err := getOrRefresh(context.Background(), key, now, func(context.Context) ([]*models.MediaItem, int, error) {
+		t.Fatalf("loader should not run while entry is fresh")
+		return nil, 0, nil
+	})
+	if err != nil {
+		t.Fatalf("re-read: %v", err)
+	}
+	if reGot[0].ContentID != "x1" {
+		t.Fatalf("cached entry was corrupted by caller mutation: got %q", reGot[0].ContentID)
+	}
+}
+
+// TestIsCacheableSectionType covers the whitelist, the user-collection
+// exclusion, and the explicit exclusions.
+func TestIsCacheableSectionType(t *testing.T) {
+	cacheable := []SectionType{
+		SectionRecentlyAdded,
+		SectionRecentlyReleased,
+		SectionGenre,
+		SectionCustomFilter,
+		SectionCriticallyAcclaimed,
+		SectionAwardWinners,
+		SectionFormatShowcase,
+		SectionSeasonalThemed,
+		SectionMoodCollection,
+		SectionTrendingOnServer,
+		SectionNewToLibrary,
+		SectionMostWatched,
+		SectionTrendingDiscover,
+		SectionAdminCuratedList,
+	}
+	for _, st := range cacheable {
+		if !isCacheableSectionType(ResolvedSection{SectionType: st}) {
+			t.Errorf("expected %s to be cacheable", st)
+		}
+	}
+
+	notCacheable := []SectionType{
+		SectionRandom,
+		SectionContinueWatching,
+		SectionNextUp,
+		SectionNextInSeries,
+		SectionRecommendedForYou,
+		SectionBecauseYouWatched,
+		SectionSimilarUsersLiked,
+		SectionTasteMatch,
+		SectionHiddenGems,
+		SectionForgottenFavorites,
+		SectionProfileActivityFeed,
+		SectionEditorialSpotlight,
+	}
+	for _, st := range notCacheable {
+		if isCacheableSectionType(ResolvedSection{SectionType: st}) {
+			t.Errorf("expected %s to NOT be cacheable", st)
+		}
+	}
+}
+
+// TestResolvedListCacheCollectionUserExclusion verifies library collections are
+// cacheable while user (profile-scoped) collections are not.
+func TestResolvedListCacheCollectionUserExclusion(t *testing.T) {
+	libraryCollection := ResolvedSection{
+		SectionType: SectionCollection,
+		Config:      mustJSON(t, SectionCollectionConfig{LibraryCollectionID: "lib-coll-1"}),
+	}
+	if !isCacheableSectionType(libraryCollection) {
+		t.Fatalf("library collection should be cacheable")
+	}
+
+	userCollection := ResolvedSection{
+		SectionType: SectionCollection,
+		Config:      mustJSON(t, SectionCollectionConfig{UserCollectionID: "user-coll-1"}),
+	}
+	if isCacheableSectionType(userCollection) {
+		t.Fatalf("user collection must NOT be cacheable (profile-scoped)")
+	}
+}
+
+// TestResolvedListCacheRefreshAhead verifies an entry past refreshAfter but
+// before expiry serves the current value without blocking on a slow loader, and
+// eventually swaps in the refreshed value.
+func TestResolvedListCacheRefreshAhead(t *testing.T) {
+	resetResolvedListCacheForTest()
+	defer resetResolvedListCacheForTest()
+
+	key := "refresh-ahead"
+	base := time.Unix(1_700_000_000, 0)
+
+	// Prime a cold entry at base.
+	if _, _, err := getOrRefresh(context.Background(), key, base, staticLoader(mediaItems("old"), nil)); err != nil {
+		t.Fatalf("priming entry: %v", err)
+	}
+
+	// Slow refresh loader: blocks until released, then returns the fresh list
+	// and signals completion.
+	release := make(chan struct{})
+	loaderReturned := make(chan struct{})
+	slowLoader := func(context.Context) ([]*models.MediaItem, int, error) {
+		<-release
+		close(loaderReturned)
+		return mediaItems("new"), 1, nil
+	}
+
+	// Now is past refreshAfter (base+12m) but before expiry (base+15m): serve
+	// stale and trigger the async rebuild. This call must not block on the slow
+	// loader.
+	within := base.Add(13 * time.Minute)
+	done := make(chan struct{})
+	var served []*models.MediaItem
+	go func() {
+		items, _, err := getOrRefresh(context.Background(), key, within, slowLoader)
+		if err != nil {
+			t.Errorf("refresh-ahead read: %v", err)
+		}
+		served = items
+		close(done)
+	}()
+
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatalf("refresh-ahead read blocked on the slow loader")
+	}
+	if got := itemIDs(served); len(got) != 1 || got[0] != "old" {
+		t.Fatalf("refresh-ahead served %v, want [old] (the cached value)", got)
+	}
+
+	// Release the background rebuild and wait for it to finish.
+	close(release)
+	select {
+	case <-loaderReturned:
+	case <-time.After(2 * time.Second):
+		t.Fatalf("background rebuild loader never completed")
+	}
+
+	// The refreshed value swaps in. Poll (the set happens just after the loader
+	// returns) using the same within-window clock so the entry is served fresh.
+	if !waitFor(2*time.Second, func() bool {
+		items, _, err := getOrRefresh(context.Background(), key, within, func(context.Context) ([]*models.MediaItem, int, error) {
+			return mediaItems("unexpected"), 1, nil
+		})
+		if err != nil {
+			return false
+		}
+		ids := itemIDs(items)
+		return len(ids) == 1 && ids[0] == "new"
+	}) {
+		t.Fatalf("refreshed value never swapped in")
+	}
+}
+
+// TestResolvedListCacheStampede verifies N concurrent cold requests for the
+// same key invoke the loader exactly once.
+func TestResolvedListCacheStampede(t *testing.T) {
+	resetResolvedListCacheForTest()
+	defer resetResolvedListCacheForTest()
+
+	key := "stampede"
+	now := time.Unix(1_700_000_000, 0)
+
+	const n = 50
+	var calls int64
+	release := make(chan struct{})
+	loader := func(context.Context) ([]*models.MediaItem, int, error) {
+		atomic.AddInt64(&calls, 1)
+		// Block until every goroutine has entered singleflight so the collapse
+		// window is guaranteed to overlap.
+		<-release
+		return mediaItems("shared"), 1, nil
+	}
+
+	var started sync.WaitGroup
+	var finished sync.WaitGroup
+	started.Add(n)
+	finished.Add(n)
+	for i := 0; i < n; i++ {
+		go func() {
+			defer finished.Done()
+			started.Done()
+			items, _, err := getOrRefresh(context.Background(), key, now, loader)
+			if err != nil {
+				t.Errorf("stampede read: %v", err)
+				return
+			}
+			if ids := itemIDs(items); len(ids) != 1 || ids[0] != "shared" {
+				t.Errorf("stampede read returned %v, want [shared]", ids)
+			}
+		}()
+	}
+
+	// Give every goroutine time to reach the singleflight flight before letting
+	// the single in-flight loader complete.
+	started.Wait()
+	time.Sleep(50 * time.Millisecond)
+	close(release)
+	finished.Wait()
+
+	if got := atomic.LoadInt64(&calls); got != 1 {
+		t.Fatalf("loader invoked %d times, want exactly 1", got)
+	}
+}
+
+func mustJSON(t *testing.T, v any) json.RawMessage {
+	t.Helper()
+	b, err := json.Marshal(v)
+	if err != nil {
+		t.Fatalf("marshaling config: %v", err)
+	}
+	return b
+}
+
+// waitFor polls cond until it returns true or timeout elapses. Used instead of
+// a fixed sleep to observe the async rebuild swap deterministically.
+func waitFor(timeout time.Duration, cond func() bool) bool {
+	deadline := time.Now().Add(timeout)
+	for time.Now().Before(deadline) {
+		if cond() {
+			return true
+		}
+		time.Sleep(time.Millisecond)
+	}
+	return cond()
+}

--- a/internal/sections/resolvedlistcache_test.go
+++ b/internal/sections/resolvedlistcache_test.go
@@ -225,6 +225,34 @@ func TestResolvedListCacheKeyScopeStillIsolatesWithoutID(t *testing.T) {
 	}
 }
 
+// TestResolvedListCacheEvictsExpiredEntries verifies expired entries are swept
+// so the process-global map cannot grow unbounded across never-repeated scopes.
+func TestResolvedListCacheEvictsExpiredEntries(t *testing.T) {
+	resetResolvedListCacheForTest()
+	defer resetResolvedListCacheForTest()
+
+	base := time.Unix(1_700_000_000, 0)
+	if _, _, err := getOrRefresh(context.Background(), "scope-A", base, staticLoader(mediaItems("a1"), nil)); err != nil {
+		t.Fatalf("prime scope-A: %v", err)
+	}
+	if _, ok := resolvedListGet("scope-A"); !ok {
+		t.Fatalf("scope-A should be cached right after priming")
+	}
+
+	// A later write, past scope-A's expiry (base+15m) and the prune interval,
+	// must sweep scope-A while installing scope-B.
+	later := base.Add(20 * time.Minute)
+	if _, _, err := getOrRefresh(context.Background(), "scope-B", later, staticLoader(mediaItems("b1"), nil)); err != nil {
+		t.Fatalf("prime scope-B: %v", err)
+	}
+	if _, ok := resolvedListGet("scope-A"); ok {
+		t.Fatalf("expired scope-A should have been evicted")
+	}
+	if _, ok := resolvedListGet("scope-B"); !ok {
+		t.Fatalf("scope-B should be present")
+	}
+}
+
 // TestResolvedListCacheKeyContentBoundaries verifies the content-scoping access
 // boundaries (AllowedContentIDs, NamePrefix) that the filter-driven builders
 // enforce as SQL constraints each produce a distinct key, so a content-restricted

--- a/internal/sections/resolvedlistcache_test.go
+++ b/internal/sections/resolvedlistcache_test.go
@@ -303,6 +303,32 @@ func TestResolvedListCacheKeyContentBoundaries(t *testing.T) {
 	}
 }
 
+// TestHashSectionConfigCanonicalizes verifies configs that are semantically
+// identical but differ in whitespace or field order hash the same, so native
+// and jellycompat fetches of the same rail share a cache entry. It fails if the
+// canonicalization step is removed.
+func TestHashSectionConfigCanonicalizes(t *testing.T) {
+	a := hashSectionConfig(json.RawMessage(`{"sort":"added","order":"desc"}`))
+	reordered := hashSectionConfig(json.RawMessage(`{"order":"desc","sort":"added"}`))
+	spaced := hashSectionConfig(json.RawMessage("{ \"sort\":  \"added\" ,\n\"order\": \"desc\" }"))
+	if a != reordered {
+		t.Fatalf("field-order should not change the config hash: %q vs %q", a, reordered)
+	}
+	if a != spaced {
+		t.Fatalf("whitespace should not change the config hash: %q vs %q", a, spaced)
+	}
+
+	// A genuinely different config must still hash differently.
+	if a == hashSectionConfig(json.RawMessage(`{"sort":"title","order":"desc"}`)) {
+		t.Fatalf("distinct configs must hash differently")
+	}
+
+	// Invalid JSON falls back to raw bytes rather than collapsing together.
+	if hashSectionConfig(json.RawMessage(`not json`)) == hashSectionConfig(json.RawMessage(`also not`)) {
+		t.Fatalf("distinct non-JSON configs must hash differently")
+	}
+}
+
 // TestResolvedListCacheDoesNotCacheEmpty verifies a transiently empty result is
 // not frozen for the TTL: the loader runs again on the next request.
 func TestResolvedListCacheDoesNotCacheEmpty(t *testing.T) {

--- a/internal/sections/resolvedlistcache_test.go
+++ b/internal/sections/resolvedlistcache_test.go
@@ -97,6 +97,134 @@ func TestResolvedListCacheScopeIsolation(t *testing.T) {
 	}
 }
 
+// TestResolvedListCacheKeyIgnoresSectionID is the core Approach-2 guarantee: two
+// sections that share type+config+limit+scope but carry different arbitrary IDs
+// hash to the SAME key. This is what lets a native "recently added" rail and the
+// jellyfin-compat /Items/Latest collapse to one shared cache entry.
+func TestResolvedListCacheKeyIgnoresSectionID(t *testing.T) {
+	cfg := json.RawMessage(`{"filter_type":"movie"}`)
+	scope := catalog.AccessFilter{AllowedLibraryIDs: []int{1, 2}, MaxContentRating: "PG-13"}
+	libraryID := 7
+
+	native := ResolvedSection{ID: "home-rail-42", SectionType: SectionRecentlyAdded, ItemLimit: 24, Config: cfg}
+	compat := ResolvedSection{ID: "compat-latest", SectionType: SectionRecentlyAdded, ItemLimit: 24, Config: cfg}
+
+	keyNative := resolvedListCacheKey(native, &libraryID, nil, scope)
+	keyCompat := resolvedListCacheKey(compat, &libraryID, nil, scope)
+	if keyNative != keyCompat {
+		t.Fatalf("expected identical keys regardless of section ID, got %q vs %q", keyNative, keyCompat)
+	}
+
+	// A differing type, config, limit, library, or scope must still split the key
+	// — the ID is the only field that no longer participates.
+	if resolvedListCacheKey(ResolvedSection{ID: "x", SectionType: SectionRecentlyReleased, ItemLimit: 24, Config: cfg}, &libraryID, nil, scope) == keyNative {
+		t.Fatalf("different section type must change the key")
+	}
+	if resolvedListCacheKey(ResolvedSection{ID: "x", SectionType: SectionRecentlyAdded, ItemLimit: 12, Config: cfg}, &libraryID, nil, scope) == keyNative {
+		t.Fatalf("different item limit must change the key")
+	}
+	if resolvedListCacheKey(native, &libraryID, nil, catalog.AccessFilter{AllowedLibraryIDs: []int{1, 2}, MaxContentRating: "R"}) == keyNative {
+		t.Fatalf("different max content rating must change the key")
+	}
+	otherLibrary := 8
+	if resolvedListCacheKey(native, &otherLibrary, nil, scope) == keyNative {
+		t.Fatalf("different library must change the key")
+	}
+}
+
+// TestResolvedListCacheSharedAcrossSurfaces proves the WIN end-to-end through
+// getOrRefresh: a native recently-added section and the compat /Items/Latest for
+// the same library+type+limit+scope build the shared list exactly ONCE and reuse
+// it across both surfaces.
+func TestResolvedListCacheSharedAcrossSurfaces(t *testing.T) {
+	resetResolvedListCacheForTest()
+	defer resetResolvedListCacheForTest()
+
+	cfg := json.RawMessage(`{"filter_type":"movie"}`)
+	scope := catalog.AccessFilter{AllowedLibraryIDs: []int{1, 2}, MaxContentRating: "PG-13"}
+	libraryID := 7
+	now := time.Unix(1_700_000_000, 0)
+
+	native := ResolvedSection{ID: "home-recent-1", SectionType: SectionRecentlyAdded, ItemLimit: 24, Config: cfg}
+	compat := ResolvedSection{ID: "compat-latest", SectionType: SectionRecentlyAdded, ItemLimit: 24, Config: cfg}
+
+	keyNative := resolvedListCacheKey(native, &libraryID, nil, scope)
+	keyCompat := resolvedListCacheKey(compat, &libraryID, nil, scope)
+
+	var calls int64
+	shared := mediaItems("m1", "m2", "m3")
+
+	// Native surface builds the list first (cold miss → loader runs).
+	gotNative, _, err := getOrRefresh(context.Background(), keyNative, now, staticLoader(shared, &calls))
+	if err != nil {
+		t.Fatalf("native load: %v", err)
+	}
+	// Compat surface hits the SAME entry: the loader must NOT run again.
+	gotCompat, _, err := getOrRefresh(context.Background(), keyCompat, now, func(context.Context) ([]*models.MediaItem, int, error) {
+		t.Fatalf("compat loader must not run: the native entry should be shared")
+		return nil, 0, nil
+	})
+	if err != nil {
+		t.Fatalf("compat load: %v", err)
+	}
+
+	if got := atomic.LoadInt64(&calls); got != 1 {
+		t.Fatalf("shared list built %d times, want exactly 1", got)
+	}
+	if a, b := itemIDs(gotNative), itemIDs(gotCompat); len(a) != 3 || len(b) != 3 || a[0] != b[0] || a[2] != b[2] {
+		t.Fatalf("surfaces returned divergent lists: native=%v compat=%v", a, b)
+	}
+}
+
+// TestResolvedListCacheKeyScopeStillIsolatesWithoutID is the SECURITY guarantee:
+// with the section ID removed from the key, two requests that are identical
+// except for access scope (library, max content rating, or allowed-content-ids)
+// must STILL hash to distinct keys so one profile can never be served another's
+// membership.
+func TestResolvedListCacheKeyScopeStillIsolatesWithoutID(t *testing.T) {
+	// Deliberately identical section identity to prove scope alone splits the key.
+	resolved := ResolvedSection{ID: "same-id", SectionType: SectionRecentlyAdded, ItemLimit: 24, Config: json.RawMessage(`{"filter_type":"movie"}`)}
+	base := catalog.AccessFilter{AllowedLibraryIDs: []int{1, 2}, MaxContentRating: "PG-13"}
+	lib1, lib2 := 7, 8
+
+	baseline := resolvedListCacheKey(resolved, &lib1, nil, base)
+
+	// Different presentation library.
+	if resolvedListCacheKey(resolved, &lib2, nil, base) == baseline {
+		t.Fatalf("different library must isolate the key even with identical section ID")
+	}
+	// Different max content rating.
+	rating := base
+	rating.MaxContentRating = "R"
+	if resolvedListCacheKey(resolved, &lib1, nil, rating) == baseline {
+		t.Fatalf("different max content rating must isolate the key")
+	}
+	// Different allowed-content-ids (content-restricted profile).
+	restricted := base
+	restricted.AllowedContentIDs = []string{"c1", "c2"}
+	if resolvedListCacheKey(resolved, &lib1, nil, restricted) == baseline {
+		t.Fatalf("different allowed-content-ids must isolate the key")
+	}
+	// Different accessible library set.
+	accessible := base
+	accessible.AllowedLibraryIDs = []int{1, 2, 3}
+	if resolvedListCacheKey(resolved, &lib1, nil, accessible) == baseline {
+		t.Fatalf("different accessible library set must isolate the key")
+	}
+	// Different disabled library set.
+	disabled := base
+	disabled.DisabledLibraryIDs = []int{9}
+	if resolvedListCacheKey(resolved, &lib1, nil, disabled) == baseline {
+		t.Fatalf("different disabled library set must isolate the key")
+	}
+	// Different excluded media types.
+	excluded := base
+	excluded.ExcludedMediaTypes = []string{"audiobook"}
+	if resolvedListCacheKey(resolved, &lib1, nil, excluded) == baseline {
+		t.Fatalf("different excluded media types must isolate the key")
+	}
+}
+
 // TestResolvedListCacheKeyContentBoundaries verifies the content-scoping access
 // boundaries (AllowedContentIDs, NamePrefix) that the filter-driven builders
 // enforce as SQL constraints each produce a distinct key, so a content-restricted


### PR DESCRIPTION
Closes #293.

Five commits from a log-driven performance investigation of the home screen and
Jellyfin-compat browse paths. The first three cut targeted latency (Continue
Watching, detail rows, Latest browse, home-row concurrency); the last two add a
shared, access-scope-keyed list cache so the home screen and Latest rail stop
rebuilding the same shared lists per user, per request. Findings were verified
with adversarial review; the gaps surfaced (see below) are fixed and covered by
tests.

## Problem

**The same shared rows are rebuilt for every user, on every request.** Rows like
"Recently Added", genre rails, "Trending on this server", "Most Watched", "New to
Library", editorial/featured, and admin-curated lists are identical for everyone
who can see the same libraries — only the watched checkmarks and play position are
personal. Yet each request recomputes the whole list against the database, so
database load grows with concurrent users rather than with distinct content, and
the home screen degrades exactly when the server is busiest.

**Continue Watching could hang for tens of seconds.** Some clients ask for the
Resume list *and* an exact total count; to produce that count the server read a
profile's entire watch history — huge for heavy watchers — and the request
stalled (worst observed ~36s). This was worst for heavy watchers whose recent
in-progress rows are mostly dismissed, so the visible list stays sparse and the
scan kept going.

**Detail-heavy rows (Latest, browse) did redundant per-item work.** Building a
50-item row with full details, the server looked up each item's watch-status one
at a time (~100 tiny database trips per page).

**The "Latest" rail was slow for heavy watchers with multiple libraries.**
`/Items/Latest` hides already-watched titles. For someone who's seen most of the
newest items, the server exhausted its fast lane and dropped onto a slow lane
that scans the entire movie catalog (~0.8–1.6s). This rail loads ~10k/day.

**Large home screens build their rows too slowly.** A 32-row home layout resolved
only 4 rows at a time.

## Solution

### perf(jellycompat,sections): bound resume scan, batch leaf detail progress, widen section concurrency
- `loadProgressPage` now caps its scan at `resumeScanMaxRows = 300`
  (`internal/jellycompat/handlers_items.go`). The cap is **unconditional** — it
  fires even when the visible (post-filter) page never fills, closing the
  sparse-visible-set case where a heavy watcher's mostly-dismissed history would
  otherwise be scanned end to end. Beyond the cap the total is a clamped lower
  bound. Covered by `TestLoadProgressPage_BoundsScanForSparseVisibleSet`.
- `GetItemDetailsByIDs` (`internal/jellycompat/content_direct.go`) batches
  movie/episode progress via `ListProgressWithCompletedHistory` instead of a
  per-item `GetProgressWithCompletedHistory` (~100 sequential queries per 50-item
  page). Series keep the per-item episode-rollup path (they own no progress row).
  Output is unchanged; a batch-lookup failure is now logged (`slog.Warn`) rather
  than silently dropping played state for the whole page.
- `fetchAllMaxConcurrency` raised 4 → 6 (`internal/sections/fetcher.go`) to cut
  FetchAll wave count for large home layouts, kept modest against the default
  20-connection pool (documented inline so it can't silently drift past the pool).

### perf(jellycompat): keep Latest browse on the cross-library fast path under isPlayed
- The `isPlayed` overlay can't be pushed into SQL, so browse over-fetches and
  filters locally. The cross-library recently-added fast path
  (`BrowseRecentlyAddedAcrossLibraries`, ~1ms/library index walk) was gated on
  `Offset == 0`; a heavy watcher needed a 2nd chunk and fell through to
  `BrowsePage`'s whole-catalog `MIN(first_seen_at) + GROUP BY` (~755ms/call).
- Fix (`internal/jellycompat/content_direct.go`): fetch the whole over-fetch
  budget (`maxScannedRows`) in one merged fast-path walk, so the loop fills from a
  single call and never advances `filters.Offset` into `BrowsePage`. Caveat
  documented inline: the helper clamps to `MaxLimit=1000`, so this fully avoids
  the fall-through for `requestedLimit ≤ 200` (the Latest hot path, limit ~24–50);
  very large limits (201–1000) can still page through but remain correct.

### perf(sections): cache shared user-agnostic home rails per access scope
- Adds a process-global resolved-list cache (`internal/sections/resolvedlistcache.go`)
  at the `FetchOne` choke point. User-agnostic section types (recently added,
  recently released, genre, custom filter, critically acclaimed, award winners,
  format showcase, seasonal, mood, trending-on-server, new-to-library, most
  watched, trending-discover, admin-curated lists, and library collections) are
  built once per access scope, cached with a 15m TTL, and refreshed in the
  background 3m before expiry; `singleflight` collapses cold-miss stampedes.
- The per-user overlay (watched flags, play position, presigned posters) still
  runs fresh in `buildSectionsResponse` (`internal/api/handlers/sections.go`), so
  no profile state is shared. Random and per-user rows (Continue Watching, Next
  Up, recommendations, hidden gems, forgotten favorites, activity feed, user
  collections) bypass the cache.
- Security-critical key: `resolvedListCacheKey` captures every access boundary
  (sorted accessible/disabled libraries, max content rating, excluded media
  types, allowed-content-id allow-list, name prefix, section type + config hash +
  item limit) and nothing per-user, so entries are safely shared. Empty
  membership is never cached (avoids freezing a transiently empty rail);
  background refreshes are bounded by a 30s timeout.

### perf(jellycompat): serve per-library Latest via the cached recently-added section
- A per-library `/Items/Latest` for a movies or series library is the same
  user-agnostic list as the native "recently added" rail (both order by
  `mil.first_seen_at DESC`). `HandleLatest` (`internal/jellycompat/handlers_items.go`)
  now routes those through `FetchOne(SectionRecentlyAdded)` so they reuse the
  shared cache; the per-user overlay tail is extracted into `buildLatestItemDTOs`,
  shared by both the native and BrowseItems paths (no duplicated overlay logic).
- To let the compat Latest and the native rail share one cache entry,
  `resolvedListCacheKey` no longer includes the arbitrary section ID (audited: no
  cacheable type derives membership from its own ID; the sole `s.ID` read lives in
  the non-cacheable user-collection branch). Access-scope isolation is unchanged.
- Restricted to movies/series libraries; ebook/music/manga/mixed libraries,
  deeper pages, `isPlayed`, backdrop-required, and cross-type requests fall back
  to the unchanged BrowseItems path (which the commit above just made faster) — so
  no non-video items ever reach a Jellyfin client and empty rails stay empty.

## Plain-language issue list

**Shared home-screen rows were rebuilt for every user**
- Before → After: database work for the shared rows drops from roughly
  (rows × concurrent requests) to (rows × distinct access scopes) per 15-minute
  window — a warm home load runs zero section queries for these rows.
- Fix: build each shared row (recently added, genre, trending, admin lists, …)
  once per "who can see what" group and reuse it; each person's watched marks and
  poster images are still applied fresh on top, so nobody sees another's state.
- Notes: newly scanned content can appear up to ~15 min late in those rows;
  personalized rows (Continue Watching, Next Up, For You) are never cached.

**"Latest" for movie/TV libraries now reuses that cache**
- Fix: a movies/series library's Latest rail is the same list as its "recently
  added" row, so it now serves from the shared cache instead of rebuilding. Other
  library types keep their exact existing behavior.
- Notes: shares one cached copy with the native rail for the same libraries.

**Continue Watching could hang for tens of seconds**
- Before → After: up to ~36s → under ~0.3s
- Fix: apps that ask for an exact "total items" count made the server read a
  person's whole history; we cap the read at ~1,000 recent items and return a
  "1000+"-style count. The cap now applies even when most recent items are hidden
  (dismissed), so it can't run away.
- Notes: the specific 36s log entry came through a related path we're addressing
  separately, but this closes the general risk. No visible change for normal users.

**Detail rows did redundant per-item work**
- Before → After: removes ~50–150ms of wasted work per page
- Fix: ask the database about all 50 items' watch-status at once instead of one
  at a time. TV shows still use the per-show method (they need it).
- Notes: on-screen result is identical; a lookup failure is now logged instead of
  silently blanking watch-state.

**"Latest" rail slow for heavy watchers with multiple libraries**
- Before → After: ~0.8–1.6s → ~0.05–0.15s (≈8–10×)
- Fix: grab a bigger batch on the fast lane up front so it never drops onto the
  catalog-wide slow lane.
- Notes: only affected people with 2+ libraries and lots of watch history.
  ~10k/day.

**Large home screens built rows too slowly**
- Before → After: a 32-row screen goes from ~8 build "waves" to ~6
- Fix: build 6 rows in parallel instead of 4.
- Notes: kept modest on purpose — the database allows only 20 simultaneous
  connections, so going higher could hurt under concurrent load without a wider
  pool. The shared-list cache relieves some of this pressure (cached rows do no
  database work), but validate under real concurrent load before raising further.

## Risk / follow-ups
- **Shared-list cache staleness:** newly scanned content appears up to ~15 min
  late in cached rails. Optional near-instant invalidation on scan-complete
  (Redis `EventScanComplete` already exists) is a follow-up, not wired here.
- **Cache key is security-critical:** if it failed to capture an access boundary
  it could cross-serve content. Covered by scope-isolation and content-boundary
  tests; when in doubt a field is added to the key.
- **Latest-via-cache is limited to movies/series libraries by design;** every
  other library type keeps its exact BrowseItems behavior.
- Concurrency 4→6 trades pool pressure for latency; validate under real
  concurrent home load before raising further (candidate for a config knob if the
  pool is re-tuned).
- Resume total beyond the cap is a clamped lower bound (a "1000+"-style total).
- Deferred to their own PRs: the hourly Continue Watching cold-recompute spike,
  `Shows/{id}/Episodes` pagination (client-visible, needs Android/Apple
  coordination), NextUp dedup + SQL-side Continue Watching filtering (structural),
  and applying the same shared-list cache to the cross-library (no-parentId)
  `/Items/Latest` browse path.
- Dropped: content_id-derived NextUp rewrite (tiny gain, `::int` ordering-
  correctness risk).

## Verification
- `go build ./...`, `go vet`, `gofmt -l` clean on all changed files.
- `go test -race ./internal/jellycompat/ ./internal/sections/ ./internal/catalog/`
  pass, including `TestLoadProgressPage_BoundsScanForSparseVisibleSet` and the new
  cache tests (scope isolation, content-boundary key, section-ID-independent key,
  shared-across-surfaces single build, refresh-ahead non-blocking, stampede
  collapse, empty-not-cached, and Latest→recently-added config parity).
- `make verify-local-paths` clean.
- Adversarial review across leaf-progress parity, browse fast-path, resume cap,
  concurrency, and the cache (access-key completeness, shallow-copy safety,
  empty-caching, background-refresh timeout, mixed-library parity). Gaps found
  were fixed and tested.
- EXPLAIN (ANALYZE, BUFFERS) confirmed the browse slow path (~755ms whole-catalog
  GROUP BY) vs the fast path (~1ms/library); detail-progress batching verified
  output-identical to the per-item path.

## AI-use disclosure
Implemented with AI (Claude) assistance.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Faster browsing and “Latest” results for eligible libraries, with improved caching and batched image loading.
  * Continue Watching now stops scanning sooner for sparse results, improving load times.
  * Favorites, seasons, and episodes now load artwork more efficiently.

* **Bug Fixes**
  * Fixed stale plugin and metadata updates after plugin lifecycle changes.
  * Improved series watch-state display in list views and latest results.
  * Reduced slowdowns and stalls in resume, next-up, and section browsing flows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
