### PR TITLE
feat(images): sharp episode stills and logos on 4K TV clients

### DIFF
--- a/internal/api/handlers/episode_image_variant_test.go
+++ b/internal/api/handlers/episode_image_variant_test.go
@@ -1,0 +1,33 @@
+package handlers
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/Silo-Server/silo-server/internal/models"
+)
+
+// The episode's own still generates w780/w500 variants, but the series-artwork
+// fallback (backdrop/poster) does not — applying w780 (or its w500 resolver
+// fallback) to a backdrop 404s. The card path must keep the fallback on w300.
+func TestEpisodeResponseShellImageVariant(t *testing.T) {
+	tests := []struct {
+		name       string
+		still      string
+		fallback   string
+		wantSuffix string
+	}{
+		{"own still uses w780", "tvdb/series/1/seasons/2/episodes/3/still/original.webp", "", "/still/w780.webp"},
+		{"backdrop fallback keeps w300", "", "tmdb/shows/1/backdrop/original.webp", "/backdrop/w300.webp"},
+		{"poster fallback keeps w300", "", "tmdb/shows/1/poster/original.webp", "/poster/w300.webp"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ep := &models.Episode{StillPath: tt.still}
+			_, path := episodeResponseShell(ep, episodeImageFallback{Path: tt.fallback})
+			if !strings.HasSuffix(path, tt.wantSuffix) {
+				t.Errorf("path = %q, want suffix %q", path, tt.wantSuffix)
+			}
+		})
+	}
+}

--- a/internal/api/handlers/items.go
+++ b/internal/api/handlers/items.go
@@ -915,7 +915,7 @@ func episodeResponseShell(ep *models.Episode, fallback episodeImageFallback) (ep
 		resp.AirDate = ep.AirDate.Format("2006-01-02")
 	}
 
-	return resp, cardThumbnailPath(stillPath)
+	return resp, episodeStillPath(stillPath)
 }
 
 // buildEpisodeResponses converts episodes to API responses using batched
@@ -1700,32 +1700,34 @@ func (h *ItemsHandler) userStoreForRequest(r *http.Request) (userstore.UserStore
 	return store, profileID, true
 }
 
-// cardThumbnailPath converts an S3 image path from original to w300 for use in
-// browse/card views (posters, backdrops, and stills at card size).
-// Full URLs (TMDB/TVDB) and plugin-prefixed paths are returned as-is —
-// variant selection is handled at resolution time for plugin paths.
-func cardThumbnailPath(path string) string {
-	if strings.HasPrefix(path, "http://") || strings.HasPrefix(path, "https://") {
-		return path
-	}
-	// Plugin-prefixed paths pass through — variant handled at resolution time.
+// imageVariantPath rewrites a cached "/original." S3 image path to the given
+// variant. Full URLs (TMDB/TVDB) and plugin-prefixed paths are returned
+// as-is — their variant selection is handled at resolution time.
+func imageVariantPath(path, variant string) string {
 	if strings.Contains(path, "://") {
 		return path
 	}
-	return strings.Replace(path, "/original.", "/w300.", 1)
+	return strings.Replace(path, "/original.", "/"+variant+".", 1)
+}
+
+// cardThumbnailPath converts an S3 image path from original to w300 for use in
+// browse/card views (posters, backdrops, and stills at card size).
+func cardThumbnailPath(path string) string {
+	return imageVariantPath(path, "w300")
+}
+
+// episodeStillPath converts an S3 still path from original to w500 — the
+// largest variant the image cache generates for stills. Episode stills
+// render on large 16:9 cards (the tvOS season view draws them ~920px wide
+// on a 4K panel), where the w300 card thumbnail is a visible 3x upscale.
+func episodeStillPath(path string) string {
+	return imageVariantPath(path, "w500")
 }
 
 // featuredPosterPath converts an S3 poster path from original to w500 for
 // featured/hero contexts (displayed at ~220px CSS / 440px retina).
-// Full URLs (TMDB/TVDB) and plugin-prefixed paths are returned as-is.
 func featuredPosterPath(path string) string {
-	if strings.HasPrefix(path, "http://") || strings.HasPrefix(path, "https://") {
-		return path
-	}
-	if strings.Contains(path, "://") {
-		return path
-	}
-	return strings.Replace(path, "/original.", "/w500.", 1)
+	return imageVariantPath(path, "w500")
 }
 
 // featuredBackdropPath converts an S3 backdrop path from original to w1920 for

--- a/internal/api/handlers/items.go
+++ b/internal/api/handlers/items.go
@@ -894,7 +894,14 @@ func (h *ItemsHandler) toEpisodeResponseWithFallback(r *http.Request, ep *models
 func episodeResponseShell(ep *models.Episode, fallback episodeImageFallback) (episodeResponse, string) {
 	stillPath := ep.StillPath
 	stillThumbhash := ep.StillThumbhash
-	if strings.TrimSpace(stillPath) == "" && strings.TrimSpace(fallback.Path) != "" {
+	// Only the episode's own still is a "still" image type (which generates
+	// the w780/w500 variants). The fallback is the parent series' backdrop or
+	// poster, which generate different variants — applying the still's w780
+	// (and its w500 resolver fallback) to a backdrop 404s, since backdrops
+	// only have w1920/w1280/w300. Track which we're using so the card path
+	// keeps the fallback on an existing variant.
+	usingOwnStill := strings.TrimSpace(stillPath) != ""
+	if !usingOwnStill && strings.TrimSpace(fallback.Path) != "" {
 		stillPath = fallback.Path
 		stillThumbhash = fallback.Thumbhash
 	}
@@ -915,7 +922,12 @@ func episodeResponseShell(ep *models.Episode, fallback episodeImageFallback) (ep
 		resp.AirDate = ep.AirDate.Format("2006-01-02")
 	}
 
-	return resp, episodeStillPath(stillPath)
+	// w780 only for the episode's own still; the series-artwork fallback keeps
+	// the safe w300 card variant that backdrops and posters always generate.
+	if usingOwnStill {
+		return resp, episodeStillPath(stillPath)
+	}
+	return resp, cardThumbnailPath(stillPath)
 }
 
 // buildEpisodeResponses converts episodes to API responses using batched
@@ -1716,12 +1728,14 @@ func cardThumbnailPath(path string) string {
 	return imageVariantPath(path, "w300")
 }
 
-// episodeStillPath converts an S3 still path from original to w500 — the
+// episodeStillPath converts an S3 still path from original to w780 — the
 // largest variant the image cache generates for stills. Episode stills
 // render on large 16:9 cards (the tvOS season view draws them ~920px wide
-// on a 4K panel), where the w300 card thumbnail is a visible 3x upscale.
+// on a 4K panel), where the w300 card thumbnail was a visible 3x upscale.
+// Libraries cached before w780 existed fall back to w500 at resolution
+// time (metadata.PluginImageResolver newVariantFallbacks).
 func episodeStillPath(path string) string {
-	return imageVariantPath(path, "w500")
+	return imageVariantPath(path, "w780")
 }
 
 // featuredPosterPath converts an S3 poster path from original to w500 for

--- a/internal/api/handlers/sections_test.go
+++ b/internal/api/handlers/sections_test.go
@@ -53,16 +53,16 @@ func TestSectionBackdropPathUsesExpectedVariants(t *testing.T) {
 			want:        "/tmdb/shows/1399/backdrop/w1920.jpg",
 		},
 		{
-			name:        "continue watching episode still clamps to w500",
+			name:        "continue watching episode still clamps to w780",
 			sectionType: sections.SectionContinueWatching,
 			path:        "tvdb/series/73141/seasons/22/episodes/9/still/original.webp",
-			want:        "tvdb/series/73141/seasons/22/episodes/9/still/w500.webp",
+			want:        "tvdb/series/73141/seasons/22/episodes/9/still/w780.webp",
 		},
 		{
-			name:        "featured section episode still clamps to w500",
+			name:        "featured section episode still clamps to w780",
 			sectionType: sections.SectionRecentlyAdded,
 			path:        "tvdb/series/73141/seasons/22/episodes/9/still/original.webp",
-			want:        "tvdb/series/73141/seasons/22/episodes/9/still/w500.webp",
+			want:        "tvdb/series/73141/seasons/22/episodes/9/still/w780.webp",
 		},
 		{
 			name:        "http paths pass through",

--- a/internal/catalog/detail.go
+++ b/internal/catalog/detail.go
@@ -3355,10 +3355,11 @@ func imageTypeFromCachedPath(path string) string {
 
 // BackdropVariantPath rewrites a cached "/original." image path to the
 // requested backdrop variant (e.g. "w1280" or "w1920"). Episode "backdrops"
-// are frequently the episode still, which the cache only generates at
-// w500/w300 — so requesting a backdrop width 404s. For still/poster/logo
-// paths this clamps to that type's largest cached variant instead. Full URLs,
-// plugin-prefixed paths, and non-"/original." paths pass through unchanged.
+// are frequently the episode still, which the cache generates at smaller
+// widths than backdrops — so requesting a backdrop width 404s. For
+// still/poster/logo paths this clamps to that type's largest cached variant
+// instead. Full URLs, plugin-prefixed paths, and non-"/original." paths pass
+// through unchanged.
 func BackdropVariantPath(path, desiredVariant string) string {
 	if path == "" || strings.Contains(path, "://") || !strings.Contains(path, "/original.") {
 		return path
@@ -3386,8 +3387,19 @@ func cachedImageVariantKey(imageType, size string) string {
 		}
 		return "w1920"
 	case "logo":
-		return "w500"
-	case "poster", "still":
+		// Largest generated logo variant — 4K TV heroes render logos at
+		// ~1240 physical px. Libraries cached before the ladder grew fall
+		// back to w500 at resolution time (see newVariantFallbacks).
+		return "w1280"
+	case "still":
+		if size == "small" {
+			return "w300"
+		}
+		// Largest generated still variant — 4K TV season views render
+		// episode stills at ~920 physical px. Pre-ladder libraries fall
+		// back to w500 at resolution time (see newVariantFallbacks).
+		return "w780"
+	case "poster":
 		if size == "small" {
 			return "w300"
 		}

--- a/internal/catalog/image_variants_test.go
+++ b/internal/catalog/image_variants_test.go
@@ -45,16 +45,16 @@ func TestBackdropVariantPath(t *testing.T) {
 			want:    "/tmdb/shows/1399/backdrop/w1920.jpg",
 		},
 		{
-			name:    "episode still clamps to w500 (no large variant exists)",
+			name:    "episode still clamps to w780 (largest generated still variant)",
 			path:    "tvdb/series/73141/seasons/22/episodes/9/still/original.webp",
 			desired: "w1280",
-			want:    "tvdb/series/73141/seasons/22/episodes/9/still/w500.webp",
+			want:    "tvdb/series/73141/seasons/22/episodes/9/still/w780.webp",
 		},
 		{
-			name:    "episode still clamps w1920 to w500",
+			name:    "episode still clamps w1920 to w780",
 			path:    "tvdb/series/73141/seasons/22/episodes/9/still/original.webp",
 			desired: "w1920",
-			want:    "tvdb/series/73141/seasons/22/episodes/9/still/w500.webp",
+			want:    "tvdb/series/73141/seasons/22/episodes/9/still/w780.webp",
 		},
 		{
 			name:    "http url passes through",

--- a/internal/imagecache/imagecache.go
+++ b/internal/imagecache/imagecache.go
@@ -255,9 +255,14 @@ func variantWidths(t metadata.ImageType) []int {
 	case metadata.ImageBackdrop:
 		return []int{1920, 1280, 300}
 	case metadata.ImageLogo:
-		return []int{500}
+		// w1280: hero logos render up to ~1240 physical px on 4K TV
+		// clients (620 pt at the tvOS 2x composite scale); w500 was a
+		// visible 2.5x upscale on crisp-edged title art.
+		return []int{1280, 500}
 	case metadata.ImageStill:
-		return []int{500, 300}
+		// w780: episode stills render ~920 physical px on 4K TV season
+		// views; w500 leaves a 1.8x upscale, w780 is visually native.
+		return []int{780, 500, 300}
 	case metadata.ImageProfile:
 		return []int{500, 300}
 	default:

--- a/internal/imagecache/imagecache_test.go
+++ b/internal/imagecache/imagecache_test.go
@@ -339,17 +339,17 @@ func TestCache_Logo(t *testing.T) {
 	}
 
 	keys := s3.keys()
-	// Expect 2 variants: original, w500 — NO w300 or w1280
-	if len(keys) != 2 {
-		t.Errorf("expected 2 uploaded variants, got %d: %v", len(keys), keys)
+	// Expect 3 variants: original, w1280 (4K TV hero logos), w500 — NO w300
+	if len(keys) != 3 {
+		t.Errorf("expected 3 uploaded variants, got %d: %v", len(keys), keys)
 	}
-	for _, variant := range []string{"original", "w500"} {
+	for _, variant := range []string{"original", "w1280", "w500"} {
 		want := wantBase + "/" + variant + ".webp"
 		if !hasKey(keys, want) {
 			t.Errorf("missing S3 key %q in %v", want, keys)
 		}
 	}
-	for _, forbidden := range []string{"w300", "w1280"} {
+	for _, forbidden := range []string{"w300"} {
 		if hasKey(keys, wantBase+"/"+forbidden+".webp") {
 			t.Errorf("logo should not have %s variant", forbidden)
 		}

--- a/internal/metadata/image_resolver.go
+++ b/internal/metadata/image_resolver.go
@@ -68,15 +68,19 @@ type PluginImageResolver struct {
 	s3Presigner  s3ImagePresigner
 	s3PresignTTL time.Duration
 	urlCache     *cache.TTLCache[catalog.ResolvedImageURL]
-	group        singleflight.Group
+	// variantExistsCache memoizes S3 existence checks for newly-introduced
+	// image variants (see newVariantFallbacks).
+	variantExistsCache *cache.TTLCache[bool]
+	group              singleflight.Group
 }
 
 // NewPluginImageResolver creates a new resolver with no registered sources.
 func NewPluginImageResolver() *PluginImageResolver {
 	return &PluginImageResolver{
-		sources:      make(map[string][]pluginImageResolverSourceEntry),
-		s3PresignTTL: 15 * time.Minute,
-		urlCache:     cache.NewTTLCache[catalog.ResolvedImageURL](),
+		sources:            make(map[string][]pluginImageResolverSourceEntry),
+		s3PresignTTL:       15 * time.Minute,
+		urlCache:           cache.NewTTLCache[catalog.ResolvedImageURL](),
+		variantExistsCache: cache.NewTTLCache[bool](),
 	}
 }
 
@@ -318,15 +322,86 @@ func (r *PluginImageResolver) resolveS3Batch(
 	}
 	expiresAt := time.Now().Add(ttl)
 	for _, entry := range entries {
-		url, err := presigner.PresignGetURL(ctx, presigner.Bucket(), entry.originalPath, ttl)
+		key := r.existingVariantKey(ctx, presigner, entry.originalPath)
+		url, err := presigner.PresignGetURL(ctx, presigner.Bucket(), key, ttl)
 		if err != nil {
-			slog.Error("s3 image resolution failed", "path", entry.originalPath, "error", err)
+			slog.Error("s3 image resolution failed", "path", key, "error", err)
 			continue
 		}
 		expiry := expiresAt
 		resolved[entry.originalPath] = catalog.ResolvedImageURL{URL: url, ExpiresAt: &expiry}
 	}
 	return resolved
+}
+
+// newVariantFallbacks maps variant filenames introduced after libraries were
+// first cached to the largest variant every earlier ladder generated. Images
+// cached before the ladder grew have no object at the new key; presigning it
+// blindly would serve a 404. Falling back keeps them rendering (slightly
+// softer) until a metadata refresh regenerates variants — uploadVariants
+// fills only the missing objects from the stored original, so the fallback
+// retires organically per image.
+var newVariantFallbacks = map[string]string{
+	"w780":  "w500", // stills: ladder grew for 4K TV episode cards
+	"w1280": "w500", // logos: ladder grew for 4K TV hero logos
+}
+
+type s3ObjectExister interface {
+	ObjectExists(ctx context.Context, bucket, key string) (bool, error)
+}
+
+// existingVariantKey returns the key to presign for a cached-image variant
+// path. Keys naming a newly-introduced variant are existence-checked (with a
+// TTL-cached result, so steady-state serving adds no S3 round-trips) and
+// swapped to the pre-ladder fallback variant when the object is missing.
+func (r *PluginImageResolver) existingVariantKey(ctx context.Context, presigner s3ImagePresigner, key string) string {
+	variant, fallback, ok := newVariantFallback(key)
+	if !ok {
+		return key
+	}
+	exister, ok := presigner.(s3ObjectExister)
+	if !ok {
+		return key
+	}
+	cacheKey := "s3-variant-exists|" + key
+	if exists, ok := r.variantExistsCache.Get(cacheKey); ok {
+		if exists {
+			return key
+		}
+		return strings.Replace(key, "/"+variant+".", "/"+fallback+".", 1)
+	}
+	exists, err := exister.ObjectExists(ctx, presigner.Bucket(), key)
+	if err != nil {
+		// Optimistic on errors: presign the requested key rather than
+		// silently degrading every image during an S3 blip.
+		return key
+	}
+	if exists {
+		// Once generated, a variant object is immutable.
+		r.variantExistsCache.Set(cacheKey, true, 24*time.Hour)
+		return key
+	}
+	// Short TTL so a refresh-generated variant is picked up promptly.
+	r.variantExistsCache.Set(cacheKey, false, 15*time.Minute)
+	return strings.Replace(key, "/"+variant+".", "/"+fallback+".", 1)
+}
+
+// newVariantFallback extracts the variant filename from a cached image key
+// ("…/still/w780.webp" → "w780") and reports its fallback when the variant
+// is one of the newly-introduced rungs.
+func newVariantFallback(key string) (variant, fallback string, ok bool) {
+	lastSlash := strings.LastIndex(key, "/")
+	if lastSlash < 0 {
+		return "", "", false
+	}
+	name := key[lastSlash+1:]
+	dot := strings.IndexByte(name, '.')
+	if dot <= 0 {
+		return "", "", false
+	}
+	variant = name[:dot]
+	fallback, ok = newVariantFallbacks[variant]
+	return variant, fallback, ok
 }
 
 func (r *PluginImageResolver) resolvePluginBatch(


### PR DESCRIPTION
## Problem
4K TV clients composite their UI at 3840×2160, but episode stills were served at the `w300` card variant even though `w500` was already cached — a visible 3× upscale on the ~920px season-view cards. Hero logos and 4K-TV rendering were similarly under-served.

Part of the 4K-image sharpness work (client-side counterpart: decode at native panel density + label fixes, in silo-apple).

## Change
1. **Serve episode stills at the largest still variant** via a dedicated `episodeStillPath` (was `cardThumbnailPath`/w300). The three original→variant path helpers shared identical passthrough guards; extracted `imageVariantPath` so card/featured/still are one-liners over one implementation.
2. **Grow the variant ladder for 4K TV**: stills `{500,300}` → `{780,500,300}`; logos `{500}` → `{1280,500}`.
3. **Safe rollout for pre-ladder libraries**: the S3 resolution path existence-checks a newly-introduced variant key (TTL-cached — 24h for immutable hits, 15m for misses) and falls back to the pre-ladder variant when the object isn't there yet. `uploadVariants` already fills only missing objects from the stored original, so each image upgrades organically on its next metadata refresh and the fallback retires itself. **No 404s and no forced re-download on deploy.**

## Verification
`go build ./...` clean; `go test` green in `catalog`, `metadata`, `imagecache`, `api/handlers` (updated variant-key + section-backdrop + logo-cache expectations). Bucket check on a real library: every episode has `w500` (immediate w300→w500 win), `original` present everywhere (w780 regenerates on refresh). Deployed and confirmed on a production server + Apple TV 4K.

_Authored with Claude Code._
