### PR TITLE
fix(watchsync): respect MDBList rate limits and defer syncs on 429

### DIFF
--- a/internal/watchsync/lists.go
+++ b/internal/watchsync/lists.go
@@ -403,6 +403,11 @@ func (s *Service) exportList(ctx context.Context, conn Connection, cfg ServerCon
 			return result, fmt.Errorf("provider %q does not implement %s export", conn.Provider, b.kind)
 		}
 		if err != nil {
+			// Rate-limited items are not failures: leave them pending so the
+			// next run (after the deferral) retries without churning state.
+			if _, limited := AsRateLimited(err); limited {
+				return result, err
+			}
 			for _, item := range toSend {
 				_ = s.repo.MarkListItemError(ctx, conn.ID, b.kind, item.MediaItemID, err.Error())
 			}

--- a/internal/watchsync/providers/mdblist/provider.go
+++ b/internal/watchsync/providers/mdblist/provider.go
@@ -13,7 +13,10 @@ import (
 	"net/url"
 	"strconv"
 	"strings"
+	"sync"
 	"time"
+
+	"golang.org/x/time/rate"
 
 	"github.com/Silo-Server/silo-server/internal/historyimport"
 	"github.com/Silo-Server/silo-server/internal/userstore"
@@ -23,11 +26,31 @@ import (
 const (
 	defaultBaseURL = "https://api.mdblist.com"
 	syncPageLimit  = 1000
+
+	// MDBList enforces a daily request quota (1,000/day on the free tier) plus
+	// an undocumented short-window limit. Pacing to ~1 request/second keeps
+	// paginated fetches and chunked exports under the burst limit; the daily
+	// quota is handled by treating 429s as a signal to defer the whole sync.
+	requestInterval = time.Second
+	requestBurst    = 2
+
+	// A 429 with a short Retry-After is retried in place so pagination
+	// survives burst-limit blips; anything longer defers the sync run.
+	maxInPlaceRetryWait = 15 * time.Second
+	maxRetryAttempts    = 2
+
+	// Without a Retry-After header we cannot tell a burst limit from an
+	// exhausted daily quota, so default to backing off until the next
+	// scheduled sync (the scheduler runs hourly).
+	defaultRetryAfter = time.Hour
 )
 
 type Provider struct {
 	client  *http.Client
 	baseURL string
+	// limiters paces requests per API key: each key has its own MDBList
+	// quota, so one throttled account must not stall other users' syncs.
+	limiters sync.Map // apiKey string -> *rate.Limiter
 }
 
 func NewProvider(client *http.Client, baseURL string) *Provider {
@@ -428,6 +451,12 @@ func (p *Provider) fetchUser(ctx context.Context, apiKey string) (mdblistUser, e
 	return user, nil
 }
 
+func (p *Provider) limiter(apiKey string) *rate.Limiter {
+	actual, _ := p.limiters.LoadOrStore(apiKey, rate.NewLimiter(rate.Every(requestInterval), requestBurst))
+	limiter, _ := actual.(*rate.Limiter)
+	return limiter
+}
+
 func (p *Provider) do(ctx context.Context, method string, path string, apiKey string, body io.Reader, out any) error {
 	if strings.TrimSpace(apiKey) == "" {
 		return errors.New("mdblist api key is missing")
@@ -439,33 +468,104 @@ func (p *Provider) do(ctx context.Context, method string, path string, apiKey st
 	}
 	target += separator + "apikey=" + url.QueryEscape(apiKey)
 
+	// Buffer the body so rate-limited attempts can be replayed.
+	var payload []byte
+	if body != nil {
+		buffered, err := io.ReadAll(body)
+		if err != nil {
+			return fmt.Errorf("read mdblist request body: %w", err)
+		}
+		payload = buffered
+	}
+
+	limiter := p.limiter(apiKey)
+	for attempt := 0; ; attempt++ {
+		if err := limiter.Wait(ctx); err != nil {
+			return fmt.Errorf("wait for mdblist rate limiter: %w", err)
+		}
+		retryAfter, err := p.doOnce(ctx, method, path, target, payload, out)
+		if err == nil {
+			return nil
+		}
+		if retryAfter < 0 {
+			return err
+		}
+		// Rate limited. Retry in place for short waits; otherwise surface a
+		// typed error so the sync run defers instead of burning more quota.
+		if retryAfter == 0 {
+			retryAfter = defaultRetryAfter
+		}
+		if attempt >= maxRetryAttempts || retryAfter > maxInPlaceRetryWait {
+			return watchsync.RateLimitedError{Provider: p.Key(), RetryAfter: retryAfter}
+		}
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-time.After(retryAfter):
+		}
+	}
+}
+
+// doOnce performs a single HTTP attempt. On a 429 it returns the wait hinted
+// by Retry-After (0 when absent) alongside the error; every other failure
+// returns -1 to signal "not retryable".
+func (p *Provider) doOnce(ctx context.Context, method, path, target string, payload []byte, out any) (time.Duration, error) {
+	var body io.Reader
+	if payload != nil {
+		body = bytes.NewReader(payload)
+	}
 	req, err := http.NewRequestWithContext(ctx, method, target, body)
 	if err != nil {
-		return fmt.Errorf("create mdblist request: %w", err)
+		return -1, fmt.Errorf("create mdblist request: %w", err)
 	}
-	if body != nil {
+	if payload != nil {
 		req.Header.Set("Content-Type", "application/json")
 	}
 	req.Header.Set("Accept", "application/json")
 
 	resp, err := p.client.Do(req)
 	if err != nil {
-		return fmt.Errorf("send mdblist request: %w", err)
+		return -1, fmt.Errorf("send mdblist request: %w", err)
 	}
 	defer resp.Body.Close()
+	if resp.StatusCode == http.StatusTooManyRequests {
+		return parseRetryAfter(resp.Header.Get("Retry-After"), time.Now()),
+			fmt.Errorf("mdblist request %s %s rate limited: status 429", method, path)
+	}
 	if resp.StatusCode == http.StatusUnauthorized || resp.StatusCode == http.StatusForbidden {
-		return fmt.Errorf("mdblist request %s %s rejected: status %d (check api key)", method, path, resp.StatusCode)
+		return -1, fmt.Errorf("mdblist request %s %s rejected: status %d (check api key)", method, path, resp.StatusCode)
 	}
 	if resp.StatusCode < http.StatusOK || resp.StatusCode >= http.StatusMultipleChoices {
-		return fmt.Errorf("mdblist request %s %s failed: status %d", method, path, resp.StatusCode)
+		return -1, fmt.Errorf("mdblist request %s %s failed: status %d", method, path, resp.StatusCode)
 	}
 	if out == nil || resp.StatusCode == http.StatusNoContent {
-		return nil
+		return -1, nil
 	}
 	if err := json.NewDecoder(resp.Body).Decode(out); err != nil {
-		return fmt.Errorf("decode mdblist response: %w", err)
+		return -1, fmt.Errorf("decode mdblist response: %w", err)
 	}
-	return nil
+	return -1, nil
+}
+
+// parseRetryAfter reads an RFC 7231 Retry-After value (delay-seconds or
+// HTTP-date). It returns 0 when the header is absent or unparseable.
+func parseRetryAfter(value string, now time.Time) time.Duration {
+	value = strings.TrimSpace(value)
+	if value == "" {
+		return 0
+	}
+	if seconds, err := strconv.Atoi(value); err == nil {
+		if seconds < 0 {
+			return 0
+		}
+		return time.Duration(seconds) * time.Second
+	}
+	if at, err := http.ParseTime(value); err == nil {
+		if wait := at.Sub(now); wait > 0 {
+			return wait
+		}
+	}
+	return 0
 }
 
 // --- ID & payload helpers ---

--- a/internal/watchsync/providers/mdblist/provider.go
+++ b/internal/watchsync/providers/mdblist/provider.go
@@ -496,6 +496,12 @@ func (p *Provider) do(ctx context.Context, method string, path string, apiKey st
 			retryAfter = defaultRetryAfter
 		}
 		if attempt >= maxRetryAttempts || retryAfter > maxInPlaceRetryWait {
+			// Exhausted in-place retries mean the short Retry-After hints were
+			// not trustworthy; floor the deferral so the sync doesn't come
+			// straight back into the same limit.
+			if attempt >= maxRetryAttempts && retryAfter < defaultRetryAfter {
+				retryAfter = defaultRetryAfter
+			}
 			return watchsync.RateLimitedError{Provider: p.Key(), RetryAfter: retryAfter}
 		}
 		select {

--- a/internal/watchsync/providers/mdblist/provider_test.go
+++ b/internal/watchsync/providers/mdblist/provider_test.go
@@ -442,3 +442,28 @@ func TestLimiterIsPerAPIKey(t *testing.T) {
 		t.Fatal("distinct keys should not share a limiter")
 	}
 }
+
+func TestDoFloorsRetryAfterWhenRetriesExhausted(t *testing.T) {
+	attempts := 0
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		attempts++
+		w.Header().Set("Retry-After", "1")
+		w.WriteHeader(http.StatusTooManyRequests)
+	}))
+	defer server.Close()
+
+	p := NewProvider(server.Client(), server.URL)
+	_, err := p.fetchUser(context.Background(), "key")
+	rle, ok := watchsync.AsRateLimited(err)
+	if !ok {
+		t.Fatalf("expected RateLimitedError, got %v", err)
+	}
+	if attempts != maxRetryAttempts+1 {
+		t.Fatalf("got %d attempts, want %d", attempts, maxRetryAttempts+1)
+	}
+	// The short Retry-After hints proved untrustworthy, so the deferral must
+	// be floored rather than parroting the last 1s hint.
+	if rle.RetryAfter != defaultRetryAfter {
+		t.Fatalf("got retry-after %s, want floored %s", rle.RetryAfter, defaultRetryAfter)
+	}
+}

--- a/internal/watchsync/providers/mdblist/provider_test.go
+++ b/internal/watchsync/providers/mdblist/provider_test.go
@@ -314,3 +314,131 @@ func TestExportWatchlistSendsToWatchlistAdd(t *testing.T) {
 		t.Fatalf("expected shows array in body: %#v", gotBody)
 	}
 }
+
+func TestDoRetriesShortRateLimitInPlace(t *testing.T) {
+	attempts := 0
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		attempts++
+		if attempts == 1 {
+			w.Header().Set("Retry-After", "1")
+			w.WriteHeader(http.StatusTooManyRequests)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]any{"user_id": 7, "username": "retry"})
+	}))
+	defer server.Close()
+
+	p := NewProvider(server.Client(), server.URL)
+	user, err := p.fetchUser(context.Background(), "key")
+	if err != nil {
+		t.Fatalf("fetch user after retry: %v", err)
+	}
+	if attempts != 2 {
+		t.Fatalf("got %d attempts, want 2", attempts)
+	}
+	if user.UserID != 7 {
+		t.Fatalf("unexpected user %#v", user)
+	}
+}
+
+func TestDoReturnsRateLimitedErrorWithoutRetryAfter(t *testing.T) {
+	attempts := 0
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		attempts++
+		w.WriteHeader(http.StatusTooManyRequests)
+	}))
+	defer server.Close()
+
+	p := NewProvider(server.Client(), server.URL)
+	_, err := p.fetchUser(context.Background(), "key")
+	rle, ok := watchsync.AsRateLimited(err)
+	if !ok {
+		t.Fatalf("expected RateLimitedError, got %v", err)
+	}
+	if rle.Provider != "mdblist" {
+		t.Fatalf("got provider %q, want mdblist", rle.Provider)
+	}
+	// No Retry-After means burst limit and exhausted daily quota are
+	// indistinguishable, so the provider defers a full hour.
+	if rle.RetryAfter != defaultRetryAfter {
+		t.Fatalf("got retry-after %s, want %s", rle.RetryAfter, defaultRetryAfter)
+	}
+	if attempts != 1 {
+		t.Fatalf("got %d attempts, want 1 (no in-place retry for long waits)", attempts)
+	}
+}
+
+func TestDoReturnsRateLimitedErrorWithLongRetryAfter(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Retry-After", "3600")
+		w.WriteHeader(http.StatusTooManyRequests)
+	}))
+	defer server.Close()
+
+	p := NewProvider(server.Client(), server.URL)
+	_, err := p.fetchUser(context.Background(), "key")
+	rle, ok := watchsync.AsRateLimited(err)
+	if !ok {
+		t.Fatalf("expected RateLimitedError, got %v", err)
+	}
+	if rle.RetryAfter != time.Hour {
+		t.Fatalf("got retry-after %s, want 1h", rle.RetryAfter)
+	}
+}
+
+func TestDoReplaysBodyOnRateLimitRetry(t *testing.T) {
+	var bodies []string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		raw, _ := io.ReadAll(r.Body)
+		bodies = append(bodies, string(raw))
+		if len(bodies) == 1 {
+			w.Header().Set("Retry-After", "1")
+			w.WriteHeader(http.StatusTooManyRequests)
+			return
+		}
+		w.WriteHeader(http.StatusNoContent)
+	}))
+	defer server.Close()
+
+	p := NewProvider(server.Client(), server.URL)
+	err := p.do(context.Background(), http.MethodPost, "/watchlist/items/add", "key", strings.NewReader(`{"movies":[]}`), nil)
+	if err != nil {
+		t.Fatalf("do: %v", err)
+	}
+	if len(bodies) != 2 || bodies[0] != bodies[1] || bodies[0] != `{"movies":[]}` {
+		t.Fatalf("body not replayed identically: %#v", bodies)
+	}
+}
+
+func TestParseRetryAfter(t *testing.T) {
+	now := time.Date(2026, time.July, 5, 12, 0, 0, 0, time.UTC)
+	cases := []struct {
+		value string
+		want  time.Duration
+	}{
+		{"", 0},
+		{"garbage", 0},
+		{"-5", 0},
+		{"7", 7 * time.Second},
+		{now.Add(90 * time.Second).Format(http.TimeFormat), 90 * time.Second},
+		{now.Add(-time.Minute).Format(http.TimeFormat), 0},
+	}
+	for _, tc := range cases {
+		if got := parseRetryAfter(tc.value, now); got != tc.want {
+			t.Fatalf("parseRetryAfter(%q) = %s, want %s", tc.value, got, tc.want)
+		}
+	}
+}
+
+func TestLimiterIsPerAPIKey(t *testing.T) {
+	p := NewProvider(nil, "")
+	first := p.limiter("a")
+	second := p.limiter("a")
+	if first != second {
+		t.Fatal("same key should reuse one limiter")
+	}
+	if other := p.limiter("b"); other == first {
+		t.Fatal("distinct keys should not share a limiter")
+	}
+}

--- a/internal/watchsync/repository.go
+++ b/internal/watchsync/repository.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"strconv"
+	"strings"
 	"time"
 
 	"github.com/jackc/pgx/v5"
@@ -23,6 +24,7 @@ type Repository interface {
 	GetConnectionByID(ctx context.Context, id string) (Connection, bool, error)
 	DeleteConnection(ctx context.Context, provider string, userID int, profileID string) error
 	ListConnectionsDueForSync(ctx context.Context, now time.Time) ([]Connection, error)
+	DeferConnectionsForAccount(ctx context.Context, provider, providerAccountID string, until time.Time, lastError string) (int, error)
 	CreateSyncRun(ctx context.Context, run SyncRun) (SyncRun, error)
 	CompleteSyncRun(ctx context.Context, run SyncRun) (SyncRun, error)
 	GetLatestSyncRun(ctx context.Context, connectionID string) (SyncRun, bool, error)
@@ -369,6 +371,31 @@ func (r *PostgresRepository) ListConnectionsDueForSync(
 	return conns, nil
 }
 
+// DeferConnectionsForAccount stamps rate_limited_until on every connection
+// bound to the same provider account. Provider rate limits apply to the API
+// key/account, not the Silo profile, so all sibling connections must sit out
+// the same window.
+func (r *PostgresRepository) DeferConnectionsForAccount(
+	ctx context.Context,
+	provider string,
+	providerAccountID string,
+	until time.Time,
+	lastError string,
+) (int, error) {
+	if strings.TrimSpace(providerAccountID) == "" {
+		return 0, nil
+	}
+	tag, err := r.pool.Exec(ctx, `
+		UPDATE watch_provider_connections
+		SET rate_limited_until = $1, last_error = $2, updated_at = now()
+		WHERE provider = $3 AND provider_account_id = $4
+	`, until, lastError, provider, providerAccountID)
+	if err != nil {
+		return 0, fmt.Errorf("defer watch provider connections for account: %w", err)
+	}
+	return int(tag.RowsAffected()), nil
+}
+
 func (r *PostgresRepository) CreateSyncRun(ctx context.Context, run SyncRun) (SyncRun, error) {
 	if run.Status == "" {
 		run.Status = string(SyncRunStatusRunning)
@@ -534,6 +561,7 @@ func (r *PostgresRepository) ListLocalWatchEventConnections(
 		SELECT `+connectionColumns+`
 		FROM watch_provider_connections
 		WHERE user_id = $1 AND profile_id = $2 AND `+predicate+`
+			AND (rate_limited_until IS NULL OR rate_limited_until <= now())
 		ORDER BY provider
 	`, userID, profileID)
 	if err != nil {
@@ -571,6 +599,7 @@ func (r *PostgresRepository) ListListEventConnections(
 		SELECT `+connectionColumns+`
 		FROM watch_provider_connections
 		WHERE user_id = $1 AND profile_id = $2 AND `+column+` = true
+			AND (rate_limited_until IS NULL OR rate_limited_until <= now())
 		ORDER BY provider
 	`, userID, profileID)
 	if err != nil {
@@ -873,6 +902,7 @@ func (r *PostgresRepository) ListScrobbleConnections(ctx context.Context, userID
 		SELECT `+connectionColumns+`
 		FROM watch_provider_connections
 		WHERE user_id = $1 AND profile_id = $2 AND scrobble_enabled = true
+			AND (rate_limited_until IS NULL OR rate_limited_until <= now())
 		ORDER BY provider
 	`, userID, profileID)
 	if err != nil {

--- a/internal/watchsync/repository.go
+++ b/internal/watchsync/repository.go
@@ -59,7 +59,7 @@ const connectionColumns = `
 	sync_watchlist_order_enabled, scrobble_enabled, last_inbound_sync_at,
 	last_progress_sync_at, last_outbound_sync_at, last_favorites_sync_at,
 	last_watchlist_sync_at, last_scrobble_error_at, last_error,
-	sync_cursors, created_at, updated_at`
+	rate_limited_until, sync_cursors, created_at, updated_at`
 
 // syncRunColumns is the canonical select/returning column list for
 // watch_provider_sync_runs, in the exact order scanSyncRun reads.
@@ -198,12 +198,12 @@ func (r *PostgresRepository) UpsertConnection(ctx context.Context, conn Connecti
 			import_watchlist_enabled, export_watchlist_enabled, sync_watchlist_removals_enabled,
 			sync_watchlist_order_enabled, scrobble_enabled, last_inbound_sync_at, last_progress_sync_at,
 			last_outbound_sync_at, last_favorites_sync_at, last_watchlist_sync_at, last_scrobble_error_at,
-			last_error, sync_cursors
+			last_error, rate_limited_until, sync_cursors
 		)
 		VALUES (
 			COALESCE(NULLIF($1, '')::uuid, gen_random_uuid()),
 			$2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13,
-			$14, $15, $16, $17, $18, $19, $20, $21, $22, $23, $24, $25, $26, $27, $28, $29::jsonb
+			$14, $15, $16, $17, $18, $19, $20, $21, $22, $23, $24, $25, $26, $27, $28, $29, $30::jsonb
 		)
 		ON CONFLICT (provider, user_id, profile_id) DO UPDATE SET
 			provider_account_id = EXCLUDED.provider_account_id,
@@ -230,6 +230,7 @@ func (r *PostgresRepository) UpsertConnection(ctx context.Context, conn Connecti
 			last_watchlist_sync_at = EXCLUDED.last_watchlist_sync_at,
 			last_scrobble_error_at = EXCLUDED.last_scrobble_error_at,
 			last_error = EXCLUDED.last_error,
+			rate_limited_until = EXCLUDED.rate_limited_until,
 			sync_cursors = EXCLUDED.sync_cursors,
 			updated_at = now()
 		RETURNING `+connectionColumns+`
@@ -262,6 +263,7 @@ func (r *PostgresRepository) UpsertConnection(ctx context.Context, conn Connecti
 		conn.LastWatchlistSyncAt,
 		conn.LastScrobbleErrorAt,
 		conn.LastError,
+		conn.RateLimitedUntil,
 		encodeSyncCursors(conn.SyncCursors),
 	)
 	saved, err := r.scanConnection(row)
@@ -326,12 +328,13 @@ func (r *PostgresRepository) DeleteConnection(
 
 func (r *PostgresRepository) ListConnectionsDueForSync(
 	ctx context.Context,
-	_ time.Time,
+	now time.Time,
 ) ([]Connection, error) {
 	rows, err := r.pool.Query(ctx, `
 		SELECT `+connectionColumns+`
 		FROM watch_provider_connections
 		WHERE provider <> ''
+			AND (rate_limited_until IS NULL OR rate_limited_until <= $1)
 			AND (
 				import_watched_enabled
 				OR import_progress_enabled
@@ -346,7 +349,7 @@ func (r *PostgresRepository) ListConnectionsDueForSync(
 				OR scrobble_enabled
 			)
 		ORDER BY provider, user_id, profile_id
-	`)
+	`, now)
 	if err != nil {
 		return nil, fmt.Errorf("list due watch provider connections: %w", err)
 	}
@@ -1086,6 +1089,7 @@ func (r *PostgresRepository) scanConnection(row pgx.Row) (Connection, error) {
 		&conn.LastWatchlistSyncAt,
 		&conn.LastScrobbleErrorAt,
 		&conn.LastError,
+		&conn.RateLimitedUntil,
 		&rawSyncCursors,
 		&conn.CreatedAt,
 		&conn.UpdatedAt,

--- a/internal/watchsync/service.go
+++ b/internal/watchsync/service.go
@@ -232,6 +232,13 @@ func (s *Service) RequestManualSync(ctx context.Context, userID int, profileID s
 	if !ok {
 		return ManualSyncResult{}, fmt.Errorf("watch provider connection not found")
 	}
+	// A manual sync against a rate-limited provider would fail immediately
+	// while still spending the account's request quota, so honor the deferral.
+	if conn.RateLimitedUntil != nil {
+		if remaining := conn.RateLimitedUntil.Sub(s.now()); remaining > 0 {
+			return ManualSyncResult{}, SyncCooldownError{RetryAfterSeconds: ceilSeconds(remaining)}
+		}
+	}
 
 	for {
 		active, ok, err := s.repo.GetActiveSyncRun(ctx, conn.ID)
@@ -663,6 +670,11 @@ func (s *Service) executeSyncRun(ctx context.Context, conn Connection, run SyncR
 		}
 		return completed, err
 	}
+	// An expired deferral is cleared in memory here; the first successful
+	// flow persists the cleared value through its UpsertConnection call.
+	if conn.RateLimitedUntil != nil && !conn.RateLimitedUntil.After(s.now()) {
+		conn.RateLimitedUntil = nil
+	}
 	conn, err = s.refreshConnectionIfNeeded(ctx, provider, cfg, conn)
 	if err != nil {
 		run.Status = string(SyncRunStatusFailed)
@@ -674,7 +686,17 @@ func (s *Service) executeSyncRun(ctx context.Context, conn Connection, run SyncR
 		return completed, err
 	}
 
+	// The first RateLimitedError stops the remaining flows: the provider
+	// rejects everything until its quota window resets, so continuing would
+	// only burn more of the account's request budget.
 	var flowErrors []string
+	var rateLimited *RateLimitedError
+	recordFlowError := func(label string, err error) {
+		flowErrors = append(flowErrors, label+": "+err.Error())
+		if rle, ok := AsRateLimited(err); ok && rateLimited == nil {
+			rateLimited = &rle
+		}
+	}
 	if conn.ImportWatchedEnabled && provider.Capabilities().ImportWatched {
 		importer, ok := provider.(WatchedImporter)
 		if !ok {
@@ -685,7 +707,7 @@ func (s *Service) executeSyncRun(ctx context.Context, conn Connection, run SyncR
 			run.InboundWatchedImported = result.Imported
 			run.Warning = appendWarning(run.Warning, result.Warnings)
 			if err != nil {
-				flowErrors = append(flowErrors, "watched import: "+err.Error())
+				recordFlowError("watched import", err)
 			} else if refreshed, refreshErr := s.reloadConnection(ctx, conn); refreshErr != nil {
 				flowErrors = append(flowErrors, "watched import connection refresh: "+refreshErr.Error())
 			} else {
@@ -693,7 +715,7 @@ func (s *Service) executeSyncRun(ctx context.Context, conn Connection, run SyncR
 			}
 		}
 	}
-	if conn.ImportProgressEnabled && provider.Capabilities().ImportProgress {
+	if rateLimited == nil && conn.ImportProgressEnabled && provider.Capabilities().ImportProgress {
 		importer, ok := provider.(ProgressImporter)
 		if !ok {
 			flowErrors = append(flowErrors, fmt.Sprintf("provider %q does not implement progress import", conn.Provider))
@@ -703,7 +725,7 @@ func (s *Service) executeSyncRun(ctx context.Context, conn Connection, run SyncR
 			run.InboundProgressImported = result.Imported
 			run.Warning = appendWarning(run.Warning, result.Warnings)
 			if err != nil {
-				flowErrors = append(flowErrors, "progress import: "+err.Error())
+				recordFlowError("progress import", err)
 			} else if refreshed, refreshErr := s.reloadConnection(ctx, conn); refreshErr != nil {
 				flowErrors = append(flowErrors, "progress import connection refresh: "+refreshErr.Error())
 			} else {
@@ -711,7 +733,7 @@ func (s *Service) executeSyncRun(ctx context.Context, conn Connection, run SyncR
 			}
 		}
 	}
-	if conn.ExportWatchedEnabled && provider.Capabilities().ExportWatched {
+	if rateLimited == nil && conn.ExportWatchedEnabled && provider.Capabilities().ExportWatched {
 		exporter, ok := provider.(WatchedExporter)
 		if !ok {
 			flowErrors = append(flowErrors, fmt.Sprintf("provider %q does not implement watched export", conn.Provider))
@@ -720,7 +742,7 @@ func (s *Service) executeSyncRun(ctx context.Context, conn Connection, run SyncR
 			run.OutboundFound = result.LocalFound
 			run.OutboundSent = result.Sent
 			if err != nil {
-				flowErrors = append(flowErrors, "watched export: "+err.Error())
+				recordFlowError("watched export", err)
 			} else if refreshed, refreshErr := s.reloadConnection(ctx, conn); refreshErr != nil {
 				flowErrors = append(flowErrors, "watched export connection refresh: "+refreshErr.Error())
 			} else {
@@ -730,40 +752,48 @@ func (s *Service) executeSyncRun(ctx context.Context, conn Connection, run SyncR
 	}
 	// Favorites and watchlist share one pipeline, run per list kind.
 	for _, b := range s.listBindings() {
+		if rateLimited != nil {
+			break
+		}
 		caps := provider.Capabilities()
 		if b.importEnabled(conn) && b.capImport(caps) {
 			result, err := s.importList(ctx, conn, cfg, provider, b)
 			b.setImportCounts(&run, result.Found, result.Imported)
 			run.Warning = appendWarning(run.Warning, result.Warnings)
 			if err != nil {
-				flowErrors = append(flowErrors, string(b.kind)+" import: "+err.Error())
+				recordFlowError(string(b.kind)+" import", err)
 			} else if refreshed, refreshErr := s.reloadConnection(ctx, conn); refreshErr != nil {
 				flowErrors = append(flowErrors, string(b.kind)+" import connection refresh: "+refreshErr.Error())
 			} else {
 				conn = refreshed
 			}
 		}
-		if b.exportEnabled(conn) && b.capExport(caps) {
+		if rateLimited == nil && b.exportEnabled(conn) && b.capExport(caps) {
 			result, err := s.exportList(ctx, conn, cfg, provider, b)
 			b.setExportCounts(&run, result.LocalFound, result.Sent)
 			run.Warning = appendWarning(run.Warning, result.Warnings)
 			if err != nil {
-				flowErrors = append(flowErrors, string(b.kind)+" export: "+err.Error())
+				recordFlowError(string(b.kind)+" export", err)
 			} else if refreshed, refreshErr := s.reloadConnection(ctx, conn); refreshErr != nil {
 				flowErrors = append(flowErrors, string(b.kind)+" export connection refresh: "+refreshErr.Error())
 			} else {
 				conn = refreshed
 			}
 		}
-		if b.removalsEnabled(conn) && b.capRemove(caps) {
+		if rateLimited == nil && b.removalsEnabled(conn) && b.capRemove(caps) {
 			removed, err := s.removePendingListItems(ctx, conn, cfg, provider, b)
 			b.setRemovalCount(&run, removed)
 			if err != nil {
-				flowErrors = append(flowErrors, string(b.kind)+" removal: "+err.Error())
+				recordFlowError(string(b.kind)+" removal", err)
 			}
 		}
 	}
 
+	if rateLimited != nil {
+		if err := s.deferRateLimitedConnection(ctx, conn, *rateLimited); err != nil {
+			flowErrors = append(flowErrors, "record rate limit deferral: "+err.Error())
+		}
+	}
 	if len(flowErrors) > 0 {
 		run.Status = string(SyncRunStatusFailed)
 		run.Error = strings.Join(flowErrors, "; ")
@@ -775,6 +805,30 @@ func (s *Service) executeSyncRun(ctx context.Context, conn Connection, run SyncR
 	}
 	run.Status = string(SyncRunStatusSuccess)
 	return s.completeSyncRun(ctx, run)
+}
+
+// deferRateLimitedConnection records when the provider's rate limit is
+// expected to clear so scheduled syncs skip the connection until then. The
+// pending export/removal rows are left untouched and picked up by the first
+// run after the deferral expires.
+func (s *Service) deferRateLimitedConnection(ctx context.Context, conn Connection, rle RateLimitedError) error {
+	fresh, err := s.reloadConnection(ctx, conn)
+	if err != nil {
+		return err
+	}
+	retryAfter := rle.RetryAfter
+	if retryAfter <= 0 {
+		retryAfter = time.Hour
+	}
+	until := s.now().Add(retryAfter)
+	fresh.RateLimitedUntil = &until
+	fresh.LastError = fmt.Sprintf("%s; sync deferred until %s", rle.Error(), until.Format(time.RFC3339))
+	if _, err := s.repo.UpsertConnection(ctx, fresh); err != nil {
+		return err
+	}
+	slog.Info("watch provider sync deferred by rate limit",
+		"provider", conn.Provider, "user_id", conn.UserID, "profile_id", conn.ProfileID, "until", until)
+	return nil
 }
 
 func (s *Service) reloadConnection(ctx context.Context, conn Connection) (Connection, error) {
@@ -815,7 +869,10 @@ func retryAfterSeconds(now time.Time, reference time.Time, cooldown time.Duratio
 	if reference.IsZero() {
 		return 0
 	}
-	remaining := cooldown - now.Sub(reference)
+	return ceilSeconds(cooldown - now.Sub(reference))
+}
+
+func ceilSeconds(remaining time.Duration) int {
 	if remaining <= 0 {
 		return 0
 	}
@@ -1258,6 +1315,11 @@ func (s *Service) ExportWatched(
 		}
 		exportResult, err := exporter.ExportHistory(ctx, cfg, conn, pendingPlays)
 		if err != nil {
+			// Rate-limited plays are not failures: leave them pending so the
+			// next run (after the deferral) retries without churning state.
+			if _, limited := AsRateLimited(err); limited {
+				return result, err
+			}
 			for _, export := range pending {
 				_ = s.repo.MarkHistoryExportStatus(ctx, export.ID, "failed", err.Error())
 			}
@@ -1360,6 +1422,10 @@ func (s *Service) exportLocalPlays(
 	}
 	exportResult, err := exporter.ExportHistory(ctx, cfg, conn, pendingPlays)
 	if err != nil {
+		// Leave rate-limited plays pending; the next scheduled sync retries.
+		if _, limited := AsRateLimited(err); limited {
+			return err
+		}
 		for _, export := range exportByHistoryID {
 			_ = s.repo.MarkHistoryExportStatus(ctx, export.ID, "failed", err.Error())
 		}

--- a/internal/watchsync/service.go
+++ b/internal/watchsync/service.go
@@ -578,6 +578,15 @@ func (s *Service) SyncDueConnections(ctx context.Context) error {
 		return fmt.Errorf("list due watch provider connections: %w", err)
 	}
 	for _, conn := range conns {
+		// Re-read each connection before syncing: an earlier connection in
+		// this batch may have rate-limited the shared provider account and
+		// deferred its siblings after the snapshot was taken.
+		if current, ok, err := s.repo.GetConnectionByID(ctx, conn.ID); err == nil && ok {
+			conn = current
+		}
+		if conn.RateLimitedUntil != nil && conn.RateLimitedUntil.After(s.now()) {
+			continue
+		}
 		if err := s.SyncConnection(ctx, conn, "scheduled"); err != nil {
 			slog.Warn("watch provider connection sync failed", "provider", conn.Provider, "user_id", conn.UserID, "profile_id", conn.ProfileID, "error", err)
 		}
@@ -809,8 +818,10 @@ func (s *Service) executeSyncRun(ctx context.Context, conn Connection, run SyncR
 
 // deferRateLimitedConnection records when the provider's rate limit is
 // expected to clear so scheduled syncs skip the connection until then. The
-// pending export/removal rows are left untouched and picked up by the first
-// run after the deferral expires.
+// provider limit applies to the API key/account rather than the Silo profile,
+// so the deferral is stamped on every connection bound to the same provider
+// account. The pending export/removal rows are left untouched and picked up
+// by the first run after the deferral expires.
 func (s *Service) deferRateLimitedConnection(ctx context.Context, conn Connection, rle RateLimitedError) error {
 	fresh, err := s.reloadConnection(ctx, conn)
 	if err != nil {
@@ -821,13 +832,23 @@ func (s *Service) deferRateLimitedConnection(ctx context.Context, conn Connectio
 		retryAfter = time.Hour
 	}
 	until := s.now().Add(retryAfter)
-	fresh.RateLimitedUntil = &until
-	fresh.LastError = fmt.Sprintf("%s; sync deferred until %s", rle.Error(), until.Format(time.RFC3339))
-	if _, err := s.repo.UpsertConnection(ctx, fresh); err != nil {
-		return err
+	lastError := fmt.Sprintf("%s; sync deferred until %s", rle.Error(), until.Format(time.RFC3339))
+	deferred := 1
+	if strings.TrimSpace(fresh.ProviderAccountID) != "" {
+		deferred, err = s.repo.DeferConnectionsForAccount(ctx, fresh.Provider, fresh.ProviderAccountID, until, lastError)
+		if err != nil {
+			return err
+		}
+	} else {
+		fresh.RateLimitedUntil = &until
+		fresh.LastError = lastError
+		if _, err := s.repo.UpsertConnection(ctx, fresh); err != nil {
+			return err
+		}
 	}
 	slog.Info("watch provider sync deferred by rate limit",
-		"provider", conn.Provider, "user_id", conn.UserID, "profile_id", conn.ProfileID, "until", until)
+		"provider", conn.Provider, "user_id", conn.UserID, "profile_id", conn.ProfileID,
+		"until", until, "connections_deferred", deferred)
 	return nil
 }
 

--- a/internal/watchsync/service_test.go
+++ b/internal/watchsync/service_test.go
@@ -17,6 +17,7 @@ import (
 
 type serviceFakeRepo struct {
 	connections         map[string]Connection
+	dueConnections      []Connection
 	sessions            map[string]DeviceAuthSession
 	settings            map[string]string
 	syncRuns            []SyncRun
@@ -95,6 +96,30 @@ func (r *serviceFakeRepo) GetConnection(
 	return cloneConnectionForTest(conn), ok, nil
 }
 
+func (r *serviceFakeRepo) DeferConnectionsForAccount(
+	_ context.Context,
+	provider string,
+	providerAccountID string,
+	until time.Time,
+	lastError string,
+) (int, error) {
+	if providerAccountID == "" {
+		return 0, nil
+	}
+	deferred := 0
+	for key, conn := range r.connections {
+		if conn.Provider != provider || conn.ProviderAccountID != providerAccountID {
+			continue
+		}
+		untilCopy := until
+		conn.RateLimitedUntil = &untilCopy
+		conn.LastError = lastError
+		r.connections[key] = conn
+		deferred++
+	}
+	return deferred, nil
+}
+
 func (r *serviceFakeRepo) GetConnectionByID(_ context.Context, id string) (Connection, bool, error) {
 	for _, conn := range r.connections {
 		if conn.ID == id {
@@ -123,7 +148,11 @@ func (r *serviceFakeRepo) ListConnectionsDueForSync(
 	_ context.Context,
 	_ time.Time,
 ) ([]Connection, error) {
-	return nil, nil
+	out := make([]Connection, 0, len(r.dueConnections))
+	for _, conn := range r.dueConnections {
+		out = append(out, cloneConnectionForTest(conn))
+	}
+	return out, nil
 }
 
 func (r *serviceFakeRepo) CreateSyncRun(_ context.Context, run SyncRun) (SyncRun, error) {
@@ -2044,6 +2073,7 @@ func TestHistorySourceForProviderDefaultsAndUsesProviderSource(t *testing.T) {
 // progress flow was still attempted afterwards.
 type rateLimitedImporterStub struct {
 	progressCalled *bool
+	fetchCalls     *int
 }
 
 func (p rateLimitedImporterStub) Key() string         { return "trakt" }
@@ -2053,6 +2083,9 @@ func (p rateLimitedImporterStub) Capabilities() Capabilities {
 }
 
 func (p rateLimitedImporterStub) FetchWatched(context.Context, ServerConfig, Connection) ([]RemoteWatch, error) {
+	if p.fetchCalls != nil {
+		*p.fetchCalls++
+	}
 	return nil, RateLimitedError{Provider: "trakt", RetryAfter: 30 * time.Minute}
 }
 
@@ -2179,5 +2212,67 @@ func TestServiceSyncConnectionLeavesExportsPendingOnRateLimit(t *testing.T) {
 	updated := repo.connections[connectionKey("trakt", 7, "profile-1")]
 	if updated.RateLimitedUntil == nil {
 		t.Fatal("RateLimitedUntil not set after rate-limited export")
+	}
+}
+
+func TestSyncDueConnectionsSkipsSiblingsOfRateLimitedAccount(t *testing.T) {
+	db, err := sql.Open("sqlite3", ":memory:")
+	if err != nil {
+		t.Fatalf("open sqlite: %v", err)
+	}
+	defer db.Close()
+	if err := userdb.InitSchema(db); err != nil {
+		t.Fatalf("InitSchema: %v", err)
+	}
+
+	repo := newServiceFakeRepo()
+	fetchCalls := 0
+	progressCalled := false
+	provider := rateLimitedImporterStub{progressCalled: &progressCalled, fetchCalls: &fetchCalls}
+	reg := NewRegistry()
+	if err := reg.Register(provider); err != nil {
+		t.Fatalf("Register: %v", err)
+	}
+	now := time.Date(2026, 7, 5, 12, 0, 0, 0, time.UTC)
+	service := NewService(repo, reg).
+		WithMatcher(matchedMatcherStub{mediaItemID: "movie-1"}).
+		WithWatchState(noOpWatchState{}).
+		WithUserStoreProvider(staticStoreProvider{store: userdb.NewSQLiteUserStore(db)})
+	service.now = func() time.Time { return now }
+
+	// Two household profiles share one MDBList-style API key (same provider
+	// account); the second must not sync after the first exhausts the quota.
+	first := Connection{
+		ID:                   "conn-1",
+		Provider:             "trakt",
+		UserID:               7,
+		ProfileID:            "profile-1",
+		ProviderAccountID:    "acct-1",
+		AccessToken:          "access",
+		ImportWatchedEnabled: true,
+	}
+	second := Connection{
+		ID:                   "conn-2",
+		Provider:             "trakt",
+		UserID:               7,
+		ProfileID:            "profile-2",
+		ProviderAccountID:    "acct-1",
+		AccessToken:          "access",
+		ImportWatchedEnabled: true,
+	}
+	repo.connections[connectionKey("trakt", 7, "profile-1")] = first
+	repo.connections[connectionKey("trakt", 7, "profile-2")] = second
+	repo.dueConnections = []Connection{first, second}
+
+	if err := service.SyncDueConnections(context.Background()); err != nil {
+		t.Fatalf("SyncDueConnections: %v", err)
+	}
+	if fetchCalls != 1 {
+		t.Fatalf("fetch calls = %d, want 1 (sibling connection must be skipped)", fetchCalls)
+	}
+	sibling := repo.connections[connectionKey("trakt", 7, "profile-2")]
+	wantUntil := now.Add(30 * time.Minute)
+	if sibling.RateLimitedUntil == nil || !sibling.RateLimitedUntil.Equal(wantUntil) {
+		t.Fatalf("sibling RateLimitedUntil = %v, want %v", sibling.RateLimitedUntil, wantUntil)
 	}
 }

--- a/internal/watchsync/service_test.go
+++ b/internal/watchsync/service_test.go
@@ -5,6 +5,7 @@ import (
 	"database/sql"
 	"errors"
 	"strconv"
+	"strings"
 	"sync"
 	"testing"
 	"time"
@@ -2036,5 +2037,147 @@ func TestHistorySourceForProviderDefaultsAndUsesProviderSource(t *testing.T) {
 	}
 	if got := historySourceForProvider(struct{}{}); got != userstore.WatchHistorySourceImport {
 		t.Fatalf("historySourceForProvider(no source) = %q, want import", got)
+	}
+}
+
+// rateLimitedImporterStub rate-limits watched import and records whether the
+// progress flow was still attempted afterwards.
+type rateLimitedImporterStub struct {
+	progressCalled *bool
+}
+
+func (p rateLimitedImporterStub) Key() string         { return "trakt" }
+func (p rateLimitedImporterStub) DisplayName() string { return "Trakt" }
+func (p rateLimitedImporterStub) Capabilities() Capabilities {
+	return Capabilities{ImportWatched: true, ImportProgress: true}
+}
+
+func (p rateLimitedImporterStub) FetchWatched(context.Context, ServerConfig, Connection) ([]RemoteWatch, error) {
+	return nil, RateLimitedError{Provider: "trakt", RetryAfter: 30 * time.Minute}
+}
+
+func (p rateLimitedImporterStub) FetchProgress(context.Context, ServerConfig, Connection) ([]RemoteProgress, error) {
+	*p.progressCalled = true
+	return nil, nil
+}
+
+func (p rateLimitedImporterStub) HistorySource() userstore.WatchHistorySource {
+	return userstore.WatchHistorySourceTrakt
+}
+
+func TestServiceSyncConnectionDefersOnRateLimit(t *testing.T) {
+	db, err := sql.Open("sqlite3", ":memory:")
+	if err != nil {
+		t.Fatalf("open sqlite: %v", err)
+	}
+	defer db.Close()
+	if err := userdb.InitSchema(db); err != nil {
+		t.Fatalf("InitSchema: %v", err)
+	}
+
+	repo := newServiceFakeRepo()
+	progressCalled := false
+	provider := rateLimitedImporterStub{progressCalled: &progressCalled}
+	reg := NewRegistry()
+	if err := reg.Register(provider); err != nil {
+		t.Fatalf("Register: %v", err)
+	}
+	now := time.Date(2026, 7, 5, 12, 0, 0, 0, time.UTC)
+	service := NewService(repo, reg).
+		WithMatcher(matchedMatcherStub{mediaItemID: "movie-1"}).
+		WithWatchState(noOpWatchState{}).
+		WithUserStoreProvider(staticStoreProvider{store: userdb.NewSQLiteUserStore(db)})
+	service.now = func() time.Time { return now }
+	conn := Connection{
+		ID:                    "conn-1",
+		Provider:              "trakt",
+		UserID:                7,
+		ProfileID:             "profile-1",
+		AccessToken:           "access",
+		ImportWatchedEnabled:  true,
+		ImportProgressEnabled: true,
+	}
+	repo.connections[connectionKey("trakt", 7, "profile-1")] = conn
+
+	err = service.SyncConnection(context.Background(), conn, "scheduled")
+	if err == nil {
+		t.Fatal("SyncConnection error = nil, want rate limit failure")
+	}
+	if progressCalled {
+		t.Fatal("progress import ran after the watched import was rate limited")
+	}
+	updated := repo.connections[connectionKey("trakt", 7, "profile-1")]
+	wantUntil := now.Add(30 * time.Minute)
+	if updated.RateLimitedUntil == nil || !updated.RateLimitedUntil.Equal(wantUntil) {
+		t.Fatalf("RateLimitedUntil = %v, want %v", updated.RateLimitedUntil, wantUntil)
+	}
+	if !strings.Contains(updated.LastError, "rate limit") {
+		t.Fatalf("LastError = %q, want rate limit message", updated.LastError)
+	}
+
+	// A manual sync during the deferral must be refused with the remaining wait.
+	_, err = service.RequestManualSync(context.Background(), 7, "profile-1", "trakt")
+	var cooldown SyncCooldownError
+	if !errors.As(err, &cooldown) {
+		t.Fatalf("RequestManualSync error = %v, want SyncCooldownError", err)
+	}
+	if cooldown.RetryAfterSeconds != 30*60 {
+		t.Fatalf("RetryAfterSeconds = %d, want %d", cooldown.RetryAfterSeconds, 30*60)
+	}
+}
+
+func TestServiceSyncConnectionLeavesExportsPendingOnRateLimit(t *testing.T) {
+	db, err := sql.Open("sqlite3", ":memory:")
+	if err != nil {
+		t.Fatalf("open sqlite: %v", err)
+	}
+	defer db.Close()
+	if err := userdb.InitSchema(db); err != nil {
+		t.Fatalf("InitSchema: %v", err)
+	}
+	if err := userdb.AddHistory(db, userstore.WatchHistoryEntry{
+		ID:              "history-1",
+		ProfileID:       "profile-1",
+		MediaItemID:     "movie-1",
+		WatchedAt:       "2026-05-04T12:00:00Z",
+		DurationSeconds: 7200,
+		Completed:       true,
+		Source:          userstore.WatchHistorySourcePlayback,
+		Identity: userstore.WatchIdentity{
+			StableType:  "movie",
+			ProviderIDs: map[string]string{"tmdb": "603"},
+		},
+	}); err != nil {
+		t.Fatalf("AddHistory: %v", err)
+	}
+
+	repo := newServiceFakeRepo()
+	provider := watchedExporterStub{exportErr: RateLimitedError{Provider: "trakt", RetryAfter: time.Hour}}
+	reg := NewRegistry()
+	if err := reg.Register(provider); err != nil {
+		t.Fatalf("Register: %v", err)
+	}
+	service := NewService(repo, reg).WithUserStoreProvider(staticStoreProvider{
+		store: userdb.NewSQLiteUserStore(db),
+	})
+	conn := Connection{
+		ID:                   "conn-1",
+		Provider:             "trakt",
+		UserID:               7,
+		ProfileID:            "profile-1",
+		AccessToken:          "access",
+		ExportWatchedEnabled: true,
+	}
+	repo.connections[connectionKey("trakt", 7, "profile-1")] = conn
+
+	if err := service.SyncConnection(context.Background(), conn, "scheduled"); err == nil {
+		t.Fatal("SyncConnection error = nil, want rate limit failure")
+	}
+	if len(repo.historyExports) != 1 || repo.historyExports[0].Status != "pending" {
+		t.Fatalf("history exports = %+v, want one still-pending export", repo.historyExports)
+	}
+	updated := repo.connections[connectionKey("trakt", 7, "profile-1")]
+	if updated.RateLimitedUntil == nil {
+		t.Fatal("RateLimitedUntil not set after rate-limited export")
 	}
 }

--- a/internal/watchsync/types.go
+++ b/internal/watchsync/types.go
@@ -2,6 +2,8 @@ package watchsync
 
 import (
 	"context"
+	"errors"
+	"fmt"
 	"time"
 
 	"github.com/Silo-Server/silo-server/internal/historyimport"
@@ -192,9 +194,12 @@ type Connection struct {
 	LastWatchlistSyncAt          *time.Time
 	LastScrobbleErrorAt          *time.Time
 	LastError                    string
-	SyncCursors                  map[string]string `json:"-"`
-	CreatedAt                    time.Time
-	UpdatedAt                    time.Time
+	// RateLimitedUntil defers scheduled syncs after a provider 429 so retries
+	// don't burn more of the provider's request quota while still throttled.
+	RateLimitedUntil *time.Time
+	SyncCursors      map[string]string `json:"-"`
+	CreatedAt        time.Time
+	UpdatedAt        time.Time
 }
 
 type SyncRun struct {
@@ -247,6 +252,30 @@ type SyncCooldownError struct {
 
 func (e SyncCooldownError) Error() string {
 	return "watch provider sync is cooling down"
+}
+
+// RateLimitedError reports that a provider rejected a request with HTTP 429
+// (or an equivalent quota signal). RetryAfter carries the provider-supplied
+// Retry-After when available, otherwise a provider-chosen fallback; zero means
+// unknown. Callers should stop issuing requests to the provider and defer the
+// remaining work instead of treating affected items as failed.
+type RateLimitedError struct {
+	Provider   string
+	RetryAfter time.Duration
+}
+
+func (e RateLimitedError) Error() string {
+	if e.RetryAfter > 0 {
+		return fmt.Sprintf("%s rate limit reached; retry after %s", e.Provider, e.RetryAfter.Round(time.Second))
+	}
+	return fmt.Sprintf("%s rate limit reached", e.Provider)
+}
+
+// AsRateLimited unwraps err looking for a RateLimitedError.
+func AsRateLimited(err error) (RateLimitedError, bool) {
+	var rle RateLimitedError
+	ok := errors.As(err, &rle)
+	return rle, ok
 }
 
 type DeviceAuthSession struct {

--- a/migrations/sql/20260705181543_watch_provider_rate_limited_until.sql
+++ b/migrations/sql/20260705181543_watch_provider_rate_limited_until.sql
@@ -1,0 +1,7 @@
+-- +goose Up
+ALTER TABLE watch_provider_connections
+    ADD COLUMN rate_limited_until TIMESTAMPTZ;
+
+-- +goose Down
+ALTER TABLE watch_provider_connections
+    DROP COLUMN rate_limited_until;


### PR DESCRIPTION
## Problem

A user with a large watchlist hit a 429 from MDBList during watch-provider sync. MDBList caps API usage per day by supporter tier (**1,000 requests/day on the free tier**, per docs.mdblist.com), and Silo made no attempt to respect it:

- Paginated `/sync/watched` and `/watchlist/items` fetches and 100-item export POSTs fired back-to-back with no pacing.
- A 429 was a generic failure: every pending export chunk was marked `failed`, the run aborted, and the next scheduled run replayed the entire fetch+export sequence into the same limit — burning more quota while still throttled, potentially never completing a first sync.

## Approach

**MDBList provider** (`internal/watchsync/providers/mdblist`):
- Requests are paced at ~1/s (burst 2) **per API key** via `x/time/rate` — each key has its own quota, so one throttled account doesn't stall other users' syncs.
- `do()` now detects 429, parses `Retry-After` (delay-seconds or HTTP-date), and retries in place for short waits (≤15s, max 2 retries) so pagination survives burst blips. Longer or unhinted 429s return a typed `watchsync.RateLimitedError`; with no header the burst limit and an exhausted daily quota are indistinguishable, so it defers a full hour (the scheduler cadence). POST bodies are buffered so retried attempts replay identically. MDBList documents no 429 contract or rate headers (Cloudflare-fronted), hence honor-when-present.

**Sync orchestration** (`watchsync` service, provider-generic — Trakt/Simkl can adopt `RateLimitedError` later):
- The first rate-limited flow aborts the remaining flows in the run instead of letting each one slam into the same 429.
- New `rate_limited_until` column on `watch_provider_connections` (goose migration): the due-sync query skips deferred connections, manual sync returns a proper cooldown with remaining seconds, and `last_error` carries a readable "rate limit reached; sync deferred until …" message. Expired deferrals clear on the next run.
- Rate-limited exports leave items **pending** rather than marked failed, so the next run resumes exactly where it stopped.

## Testing

- New provider tests: in-place retry on short Retry-After, body replay on retried POSTs, `RateLimitedError` with/without Retry-After, `parseRetryAfter` table test, per-key limiter identity.
- New service tests: rate-limited flow aborts subsequent flows + persists deferral + blocks manual sync with correct cooldown; rate-limited watched export leaves the history export row pending.
- `go build ./...`, full `watchsync` test suite, `golangci-lint` (at pre-existing baseline), `make migrate-validate`, `make verify-local-paths` all pass.

## Risks / follow-ups

- The 1h default deferral is conservative when MDBList omits Retry-After on a mere burst 429; with 1 req/s pacing that case should be rare.
- Trakt/Simkl still treat 429 as a generic error; wiring them into the same typed-error path is a natural follow-up.
- Scope: bug fix from a user report (no linked capability epic).

## AI-use disclosure

Implemented by Claude Code (Claude Fable 5), reviewed by @Quick.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Sync connections now automatically pause when a provider signals rate limiting, with retries scheduled after the provider’s suggested cooldown.
  * Manual syncs respect the cooldown and report the remaining wait time.

* **Bug Fixes**
  * Rate-limited imports/exports no longer get marked failed; affected items remain pending for a later retry.
  * Due connection scheduling now skips rate-limited connections and defers sibling connections for the same provider account.
  * Retry-after parsing is more robust and cooldown timing is rounded consistently.

* **Tests**
  * Added coverage for rate-limit retry behavior, request replay, and cooldown/defer logic.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->