### PR TITLE
feat(clientip): expose trusted proxy CIDRs in the Admin UI and via SILO_TRUSTED_PROXIES

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -63,6 +63,13 @@ POSTGRES_SHM_SIZE=8gb
 # Optional public URL for Silo. If not set, the server will use the IP address of the container.
 # SILO_PUBLIC_URL=https://silo.example.com
 
+# Optional trusted reverse-proxy CIDRs for client IP resolution. When set, this
+# overrides the "Trusted Proxies" admin setting on every startup (the value is
+# validated and written to server_settings, so the Admin UI shows it). Leave
+# unset to manage it from Admin > Settings > General instead. Defaults trust
+# RFC 1918 private ranges + loopback.
+# SILO_TRUSTED_PROXIES=10.0.0.0/8,172.16.0.0/12,192.168.0.0/16,127.0.0.0/8,::1/128,203.0.113.7/32
+
 # Run from source / advanced overrides
 # Only DATABASE_URL is required when running Silo outside the default docker compose stack.
 # DATABASE_URL=postgres://silo:password@localhost:5432/silo

--- a/cmd/silo/main.go
+++ b/cmd/silo/main.go
@@ -706,12 +706,14 @@ func main() {
 			restartReqCh <- struct{}{}
 			return nil
 		},
-		OnServerSettingUpdated: func(ctx context.Context, key, _ string) {
+		OnServerSettingUpdated: func(_ context.Context, key, _ string) {
 			// Key-scoped reload for the client-IP trust boundary: unlike the
 			// whole-config watcher reload below, this cannot be blocked by an
-			// unrelated malformed setting failing config.LoadFromDB.
+			// unrelated malformed setting failing config.LoadFromDB. Uses a
+			// fresh context — the setting is already persisted, so the reload
+			// must not be skipped because the admin request was canceled.
 			if key == clientip.SettingTrustedProxies && ipResolver != nil {
-				if cidrs, loadErr := clientip.LoadTrustedCIDRs(ctx, settingsRepo); loadErr != nil {
+				if cidrs, loadErr := clientip.LoadTrustedCIDRs(context.Background(), settingsRepo); loadErr != nil {
 					slog.Warn("clientip config reload failed", "error", loadErr)
 				} else {
 					ipResolver.UpdateTrustedCIDRs(cidrs)

--- a/cmd/silo/main.go
+++ b/cmd/silo/main.go
@@ -1583,6 +1583,24 @@ func main() {
 	}
 	ipResolver := clientip.NewResolver(trustedCIDRs)
 	deps.ClientIPResolver = ipResolver
+	// Hot-reload trusted proxies on settings changes. The config watcher
+	// covers both the Redis event path and the Redis-less poll/RequestReload
+	// path, so admin UI edits apply without a restart on any deployment.
+	configWatcher.OnChange(func(old, updated *config.Config) {
+		if old != nil && old.ClientIP.TrustedProxies == updated.ClientIP.TrustedProxies {
+			return
+		}
+		raw := updated.ClientIP.TrustedProxies
+		if raw == "" {
+			raw = clientip.DefaultTrustedProxies
+		}
+		cidrs, parseErr := clientip.ParseCIDRs(raw)
+		if parseErr != nil {
+			slog.Warn("clientip config reload failed", "error", parseErr)
+			return
+		}
+		ipResolver.UpdateTrustedCIDRs(cidrs)
+	})
 
 	// Step 6b: Create rate limiter.
 	if cfg.RateLimit.Enabled && deps.DB != nil {
@@ -1619,13 +1637,6 @@ func main() {
 			if event.Type == cache.EventSettingsChanged {
 				if reloadErr := rateLimitMW.Reload(context.Background()); reloadErr != nil {
 					slog.Warn("rate limit config reload from event failed", "error", reloadErr)
-				}
-				// Reload trusted proxies
-				cidrs, loadErr := clientip.LoadTrustedCIDRs(context.Background(), settingsRepo)
-				if loadErr != nil {
-					slog.Warn("clientip config reload failed", "error", loadErr)
-				} else {
-					ipResolver.UpdateTrustedCIDRs(cidrs)
 				}
 			}
 		})

--- a/cmd/silo/main.go
+++ b/cmd/silo/main.go
@@ -1583,9 +1583,23 @@ func main() {
 	}
 	ipResolver := clientip.NewResolver(trustedCIDRs)
 	deps.ClientIPResolver = ipResolver
-	// Hot-reload trusted proxies on settings changes. The config watcher
-	// covers both the Redis event path and the Redis-less poll/RequestReload
-	// path, so admin UI edits apply without a restart on any deployment.
+	// Hot-reload trusted proxies on settings changes via two complementary
+	// paths. The direct event-bus subscription re-reads only the clientip key,
+	// so a malformed unrelated setting (which fails the whole-config reload)
+	// cannot leave stale trust CIDRs on Redis-backed multi-instance deploys.
+	_ = eventBus.Subscribe(appCtx, cache.ChannelAdmin, func(event cache.Event) {
+		if event.Type != cache.EventSettingsChanged {
+			return
+		}
+		cidrs, loadErr := clientip.LoadTrustedCIDRs(context.Background(), settingsRepo)
+		if loadErr != nil {
+			slog.Warn("clientip config reload failed", "error", loadErr)
+			return
+		}
+		ipResolver.UpdateTrustedCIDRs(cidrs)
+	})
+	// The config watcher covers the Redis-less poll/RequestReload path, so
+	// admin UI edits apply without a restart on single-node deployments too.
 	configWatcher.OnChange(func(old, updated *config.Config) {
 		if old != nil && old.ClientIP.TrustedProxies == updated.ClientIP.TrustedProxies {
 			return

--- a/cmd/silo/main.go
+++ b/cmd/silo/main.go
@@ -676,6 +676,11 @@ func main() {
 		defer func() { _ = apiRedisClient.Close() }()
 	}
 
+	// Assigned below once the trusted-proxy config is seeded; captured by the
+	// OnServerSettingUpdated closure, which only runs on admin requests after
+	// startup completes.
+	var ipResolver *clientip.Resolver
+
 	deps := api.Dependencies{
 		Config:                       cfg,
 		LiveConfig:                   configWatcher.Config,
@@ -701,7 +706,17 @@ func main() {
 			restartReqCh <- struct{}{}
 			return nil
 		},
-		OnServerSettingUpdated: func(_ context.Context, _, _ string) {
+		OnServerSettingUpdated: func(ctx context.Context, key, _ string) {
+			// Key-scoped reload for the client-IP trust boundary: unlike the
+			// whole-config watcher reload below, this cannot be blocked by an
+			// unrelated malformed setting failing config.LoadFromDB.
+			if key == clientip.SettingTrustedProxies && ipResolver != nil {
+				if cidrs, loadErr := clientip.LoadTrustedCIDRs(ctx, settingsRepo); loadErr != nil {
+					slog.Warn("clientip config reload failed", "error", loadErr)
+				} else {
+					ipResolver.UpdateTrustedCIDRs(cidrs)
+				}
+			}
 			// Nudge the hot-reload watcher so same-process settings changes
 			// apply immediately even without Redis (the event bus is a no-op
 			// then, leaving only the 60s poll).
@@ -1581,7 +1596,7 @@ func main() {
 	if err != nil {
 		log.Fatalf("load trusted CIDRs: %v", err)
 	}
-	ipResolver := clientip.NewResolver(trustedCIDRs)
+	ipResolver = clientip.NewResolver(trustedCIDRs)
 	deps.ClientIPResolver = ipResolver
 	// Hot-reload trusted proxies on settings changes via two complementary
 	// paths. The direct event-bus subscription re-reads only the clientip key,

--- a/internal/api/handlers/admin.go
+++ b/internal/api/handlers/admin.go
@@ -2114,6 +2114,14 @@ func (h *AdminHandler) HandleUpdateSetting(w http.ResponseWriter, r *http.Reques
 		} else {
 			req.Value = normalized
 		}
+	case clientip.SettingTrustedProxies:
+		normalized, err := clientip.NormalizeCIDRList(req.Value)
+		if err != nil {
+			writeError(w, http.StatusBadRequest, "bad_request",
+				"clientip.trusted_proxies must be a comma-separated list of CIDRs: "+err.Error())
+			return
+		}
+		req.Value = normalized
 	case "ai.asr_base_url":
 		if llm.IsChatOnlyGateway(req.Value) {
 			writeError(w, http.StatusBadRequest, "bad_request",

--- a/internal/clientip/config.go
+++ b/internal/clientip/config.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"net"
+	"os"
 	"strings"
 )
 
@@ -15,33 +16,74 @@ type SettingsStore interface {
 }
 
 const (
-	keyTrustedProxies = "clientip.trusted_proxies"
-	// Default: RFC 1918 private ranges + loopback + link-local
-	defaultTrustedProxies = "10.0.0.0/8,172.16.0.0/12,192.168.0.0/16,127.0.0.0/8,::1/128"
+	// SettingTrustedProxies is the server_settings key holding the
+	// comma-separated CIDR list of trusted reverse proxies.
+	SettingTrustedProxies = "clientip.trusted_proxies"
+	// EnvTrustedProxies overrides SettingTrustedProxies at startup when set.
+	EnvTrustedProxies = "SILO_TRUSTED_PROXIES"
+	// DefaultTrustedProxies: RFC 1918 private ranges + loopback.
+	DefaultTrustedProxies = "10.0.0.0/8,172.16.0.0/12,192.168.0.0/16,127.0.0.0/8,::1/128"
 )
 
-// SeedDefaults writes the default trusted proxy config if not already set.
+// SeedDefaults ensures the trusted proxy setting exists. When the
+// SILO_TRUSTED_PROXIES environment variable is set it wins: the value is
+// validated and persisted so the admin UI shows the effective config (and is
+// re-applied on every startup while the variable remains set). Otherwise the
+// default list is written only if the setting is unset.
 func SeedDefaults(ctx context.Context, store SettingsStore) error {
-	existing, err := store.Get(ctx, keyTrustedProxies)
+	if env := strings.TrimSpace(os.Getenv(EnvTrustedProxies)); env != "" {
+		normalized, err := NormalizeCIDRList(env)
+		if err != nil {
+			return fmt.Errorf("invalid %s: %w", EnvTrustedProxies, err)
+		}
+		existing, err := store.Get(ctx, SettingTrustedProxies)
+		if err != nil {
+			return fmt.Errorf("seed clientip defaults: %w", err)
+		}
+		if existing == normalized {
+			return nil
+		}
+		return store.Set(ctx, SettingTrustedProxies, normalized)
+	}
+	existing, err := store.Get(ctx, SettingTrustedProxies)
 	if err != nil {
 		return fmt.Errorf("seed clientip defaults: %w", err)
 	}
 	if existing != "" {
 		return nil
 	}
-	return store.Set(ctx, keyTrustedProxies, defaultTrustedProxies)
+	return store.Set(ctx, SettingTrustedProxies, DefaultTrustedProxies)
 }
 
 // LoadTrustedCIDRs reads the trusted proxy CIDRs from settings.
 func LoadTrustedCIDRs(ctx context.Context, store SettingsStore) ([]*net.IPNet, error) {
-	raw, err := store.Get(ctx, keyTrustedProxies)
+	raw, err := store.Get(ctx, SettingTrustedProxies)
 	if err != nil {
 		return nil, fmt.Errorf("load trusted proxies: %w", err)
 	}
 	if raw == "" {
-		raw = defaultTrustedProxies
+		raw = DefaultTrustedProxies
 	}
 	return ParseCIDRs(raw)
+}
+
+// NormalizeCIDRList validates a comma-separated CIDR list and returns it in
+// canonical form (trimmed entries joined by ", "). An empty list is valid and
+// means "use the built-in defaults".
+func NormalizeCIDRList(raw string) (string, error) {
+	parts := strings.Split(raw, ",")
+	var out []string
+	for _, p := range parts {
+		p = strings.TrimSpace(p)
+		if p == "" {
+			continue
+		}
+		if _, _, err := net.ParseCIDR(p); err != nil {
+			return "", fmt.Errorf("invalid CIDR %q (expected e.g. 203.0.113.7/32)", p)
+		}
+		out = append(out, p)
+	}
+	return strings.Join(out, ", "), nil
 }
 
 // ParseCIDRs parses a comma-separated list of CIDR strings.

--- a/internal/clientip/config_test.go
+++ b/internal/clientip/config_test.go
@@ -1,0 +1,119 @@
+package clientip
+
+import (
+	"context"
+	"testing"
+)
+
+type fakeStore struct {
+	values map[string]string
+	sets   int
+}
+
+func newFakeStore() *fakeStore {
+	return &fakeStore{values: map[string]string{}}
+}
+
+func (s *fakeStore) Get(_ context.Context, key string) (string, error) {
+	return s.values[key], nil
+}
+
+func (s *fakeStore) Set(_ context.Context, key, value string) error {
+	s.values[key] = value
+	s.sets++
+	return nil
+}
+
+func (s *fakeStore) GetAll(_ context.Context) (map[string]string, error) {
+	return s.values, nil
+}
+
+func TestSeedDefaultsWritesDefaultsWhenUnset(t *testing.T) {
+	t.Setenv(EnvTrustedProxies, "")
+	store := newFakeStore()
+	if err := SeedDefaults(context.Background(), store); err != nil {
+		t.Fatal(err)
+	}
+	if got := store.values[SettingTrustedProxies]; got != DefaultTrustedProxies {
+		t.Fatalf("got %q, want defaults", got)
+	}
+}
+
+func TestSeedDefaultsKeepsExistingValue(t *testing.T) {
+	t.Setenv(EnvTrustedProxies, "")
+	store := newFakeStore()
+	store.values[SettingTrustedProxies] = "203.0.113.0/24"
+	if err := SeedDefaults(context.Background(), store); err != nil {
+		t.Fatal(err)
+	}
+	if store.sets != 0 {
+		t.Fatalf("expected no writes, got %d", store.sets)
+	}
+}
+
+func TestSeedDefaultsEnvOverridesExistingValue(t *testing.T) {
+	t.Setenv(EnvTrustedProxies, " 10.0.0.0/8 ,203.0.113.7/32 ")
+	store := newFakeStore()
+	store.values[SettingTrustedProxies] = "192.168.0.0/16"
+	if err := SeedDefaults(context.Background(), store); err != nil {
+		t.Fatal(err)
+	}
+	want := "10.0.0.0/8, 203.0.113.7/32"
+	if got := store.values[SettingTrustedProxies]; got != want {
+		t.Fatalf("got %q, want %q", got, want)
+	}
+}
+
+func TestSeedDefaultsEnvIdempotent(t *testing.T) {
+	t.Setenv(EnvTrustedProxies, "203.0.113.7/32")
+	store := newFakeStore()
+	store.values[SettingTrustedProxies] = "203.0.113.7/32"
+	if err := SeedDefaults(context.Background(), store); err != nil {
+		t.Fatal(err)
+	}
+	if store.sets != 0 {
+		t.Fatalf("expected no writes for unchanged env value, got %d", store.sets)
+	}
+}
+
+func TestSeedDefaultsEnvInvalid(t *testing.T) {
+	t.Setenv(EnvTrustedProxies, "not-a-cidr")
+	store := newFakeStore()
+	if err := SeedDefaults(context.Background(), store); err == nil {
+		t.Fatal("expected error for invalid env CIDR list")
+	}
+	if store.sets != 0 {
+		t.Fatalf("expected no writes on invalid env, got %d", store.sets)
+	}
+}
+
+func TestNormalizeCIDRList(t *testing.T) {
+	cases := []struct {
+		in      string
+		want    string
+		wantErr bool
+	}{
+		{"", "", false},
+		{" , ,", "", false},
+		{"10.0.0.0/8", "10.0.0.0/8", false},
+		{" 10.0.0.0/8, ::1/128 ", "10.0.0.0/8, ::1/128", false},
+		{"10.0.0.1", "", true},   // bare IP, no prefix
+		{"garbage/33", "", true}, // invalid prefix
+	}
+	for _, tc := range cases {
+		got, err := NormalizeCIDRList(tc.in)
+		if tc.wantErr {
+			if err == nil {
+				t.Errorf("NormalizeCIDRList(%q): expected error", tc.in)
+			}
+			continue
+		}
+		if err != nil {
+			t.Errorf("NormalizeCIDRList(%q): %v", tc.in, err)
+			continue
+		}
+		if got != tc.want {
+			t.Errorf("NormalizeCIDRList(%q) = %q, want %q", tc.in, got, tc.want)
+		}
+	}
+}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -321,6 +321,13 @@ type MetadataConfig struct {
 	CacheImages bool `yaml:"-"`
 }
 
+// ClientIPConfig holds client IP resolution settings.
+type ClientIPConfig struct {
+	// TrustedProxies is the comma-separated CIDR list of reverse proxies
+	// whose X-Forwarded-For headers are trusted ("" = built-in defaults).
+	TrustedProxies string `yaml:"-"`
+}
+
 // Config is the top-level configuration for Silo.
 type Config struct {
 	Server               ServerConfig               `yaml:"server"`
@@ -341,6 +348,7 @@ type Config struct {
 	SubtitleAI           SubtitleAIConfig           `yaml:"-"`
 	MetadataAI           MetadataAIConfig           `yaml:"-"`
 	Download             DownloadConfig             `yaml:"-"`
+	ClientIP             ClientIPConfig             `yaml:"-"`
 	TMDBAPIKey           string                     `yaml:"-"`
 	MDBListAPIKey        string                     `yaml:"-"`
 }

--- a/internal/config/db_loader.go
+++ b/internal/config/db_loader.go
@@ -218,6 +218,10 @@ func LoadFromDB(m map[string]string) (*Config, error) {
 	cfg.S3.UserDB.AccessKey = stringOr(m, "s3.user_db_access_key", "")
 	cfg.S3.UserDB.SecretKey = stringOr(m, "s3.user_db_secret_key", "")
 
+	// Client IP resolution ("" = clientip package defaults). Kept in the
+	// config snapshot so the nodeconfig watcher hot-reloads the resolver.
+	cfg.ClientIP.TrustedProxies = stringOr(m, "clientip.trusted_proxies", "")
+
 	// TMDB collection presets (independent of metadata providers)
 	cfg.TMDBAPIKey = stringOr(m, "tmdb.api_key", "")
 

--- a/web/src/pages/admin-settings/GeneralSettings.tsx
+++ b/web/src/pages/admin-settings/GeneralSettings.tsx
@@ -85,12 +85,32 @@ export default function GeneralSettings() {
             label="Trusted Proxies"
             hint={
               "Comma-separated CIDRs of reverse proxies whose X-Forwarded-For is trusted, " +
-              "e.g. 172.16.0.0/12, 203.0.113.7/32. Leave empty for the built-in " +
-              "private-network defaults. Applies without a restart."
+              "e.g. 172.16.0.0/12, 203.0.113.7/32. Applies without a restart."
             }
             value={form.getValue("clientip.trusted_proxies")}
             onChange={(v) => form.setValue("clientip.trusted_proxies", v)}
           />
+          <div className="border-border/60 bg-muted/30 my-3 rounded-lg border px-3 py-2">
+            <p className="text-sm font-medium">Choosing trusted proxy ranges</p>
+            <ul className="text-muted-foreground mt-1 list-disc space-y-1 pl-4 text-xs leading-relaxed">
+              <li>
+                Setting this replaces the defaults (private ranges 10.0.0.0/8, 172.16.0.0/12,
+                192.168.0.0/16 and loopback). Leave it empty to keep them.
+              </li>
+              <li>
+                Recommended: keep the defaults, and only add your proxy&apos;s public address as a
+                /32 (e.g. 203.0.113.7/32) if it reaches Silo from outside those ranges.
+              </li>
+              <li>
+                CDNs such as Cloudflare connect from many published IP ranges — you must list all
+                of their CIDRs and keep the list up to date as they change.
+              </li>
+              <li>
+                Avoid 0.0.0.0/0 (trust everything): any client could then spoof its IP with a
+                forged X-Forwarded-For header, affecting rate limits and audit logs.
+              </li>
+            </ul>
+          </div>
         </FieldGroup>
       </div>
 

--- a/web/src/pages/admin-settings/GeneralSettings.tsx
+++ b/web/src/pages/admin-settings/GeneralSettings.tsx
@@ -83,7 +83,11 @@ export default function GeneralSettings() {
         <FieldGroup label="Network">
           <SettingField
             label="Trusted Proxies"
-            hint="Comma-separated CIDRs of reverse proxies whose X-Forwarded-For is trusted, e.g. 172.16.0.0/12, 203.0.113.7/32. Leave empty for the built-in private-network defaults. Applies without a restart."
+            hint={
+              "Comma-separated CIDRs of reverse proxies whose X-Forwarded-For is trusted, " +
+              "e.g. 172.16.0.0/12, 203.0.113.7/32. Leave empty for the built-in " +
+              "private-network defaults. Applies without a restart."
+            }
             value={form.getValue("clientip.trusted_proxies")}
             onChange={(v) => form.setValue("clientip.trusted_proxies", v)}
           />

--- a/web/src/pages/admin-settings/GeneralSettings.tsx
+++ b/web/src/pages/admin-settings/GeneralSettings.tsx
@@ -10,6 +10,7 @@ const KEYS = [
   "auth.refresh_token_expiry",
   "server.log_level",
   "server.log_quiet",
+  "clientip.trusted_proxies",
 ];
 
 export default function GeneralSettings() {
@@ -36,7 +37,7 @@ export default function GeneralSettings() {
       <div className="mb-6 space-y-2">
         <h2 className="text-xl font-semibold tracking-tight">General</h2>
         <p className="text-muted-foreground text-sm leading-relaxed">
-          Authentication, token lifetimes, and server logging behavior.
+          Authentication, token lifetimes, networking, and server logging behavior.
         </p>
       </div>
 
@@ -76,6 +77,15 @@ export default function GeneralSettings() {
             hint="Comma-separated subsystem prefixes to silence"
             value={form.getValue("server.log_quiet")}
             onChange={(v) => form.setValue("server.log_quiet", v)}
+          />
+        </FieldGroup>
+
+        <FieldGroup label="Network">
+          <SettingField
+            label="Trusted Proxies"
+            hint="Comma-separated CIDRs of reverse proxies whose X-Forwarded-For is trusted, e.g. 172.16.0.0/12, 203.0.113.7/32. Leave empty for the built-in private-network defaults. Applies without a restart."
+            value={form.getValue("clientip.trusted_proxies")}
+            onChange={(v) => form.setValue("clientip.trusted_proxies", v)}
           />
         </FieldGroup>
       </div>


### PR DESCRIPTION
## Problem
Running Silo behind a reverse proxy on another host requires trusting that proxy's CIDR so `X-Forwarded-For` is honored — but `clientip.trusted_proxies` could only be set by hand-editing `server_settings` via SQL, followed by a restart (issue #300). Confirmed on main: no admin UI surface, no env var, and hot reload of the setting only ran on the Redis event bus, and only when rate limiting was enabled.

## Approach
- **Admin UI**: new *Network → Trusted Proxies* field on the General settings page (comma-separated CIDRs; empty = built-in RFC 1918 + loopback defaults). `PUT /admin/settings/clientip.trusted_proxies` now validates and normalizes the CIDR list server-side (additive; no API contract changes).
- **Env var**: `SILO_TRUSTED_PROXIES` is validated at startup and persisted into `server_settings` (re-applied on every boot while set), so Docker operators never touch the database and the UI always shows the effective value. Documented in `.env.example` (compose already forwards `.env` via `env_file`).
- **Hot reload**: the setting rides the nodeconfig watcher snapshot (`Config.ClientIP.TrustedProxies`), so admin edits apply without restart on Redis-less single nodes; a key-scoped reload also runs in `OnServerSettingUpdated` (same-process) and on the Redis event bus (multi-instance), so the trust boundary updates even if an unrelated malformed setting fails the whole-config reload. The old reload path buried inside the rate-limit block was removed.

## Verification
- `GOWORK=off go build ./internal/... ./cmd/...` — clean (worktree, stubbed web/dist).
- `GOWORK=off go test ./internal/clientip/... ./internal/config/... ./internal/api/handlers/` — all pass, including new tests for seed/env-override/normalization.
- golangci-lint (v2) on touched packages: no findings on changed lines (remaining output is the known pre-existing local baseline).
- `web`: `pnpm run lint` (0 errors), `pnpm run format:check`, `pnpm run build` — clean. The one failing vitest (`CompatibilityProxiesSettings.test.tsx`) also fails on clean `origin/main` (missing QueryClientProvider) — pre-existing, untouched by this PR.
- `make verify-local-paths` — clean.

## Adversarial review
Codex adversarial review, 3 iterations:
1. **Fixed** — trusted-proxy reload was coupled to whole-config parse success (an unrelated malformed setting could block it): restored a key-scoped Redis event-bus reload.
2. **Fixed** — same gap on the Redis-less path: added a key-scoped reload in `OnServerSettingUpdated`.
3. **Fixed** — that reload used the (already-canceled-able) admin request context: switched to a fresh context.

## Risks & follow-up
- Env-var semantics: while `SILO_TRUSTED_PROXIES` is set, it overwrites the stored setting on every startup (documented in `.env.example`); UI edits persist until the next restart. This was chosen so the UI always displays the effective value.
- Server-side change only; no `silo-android` / `silo-apple` follow-up needed.
- UI change is a single text field on the existing General settings page; screenshot not captured (worktree has no running backend) — flagging per repo guidelines.

Closes #300

## AI-use disclosure
Implemented by Claude Code (issue-to-pr skill) with human oversight.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an Admin UI “Network” section with a **Trusted Proxies** setting for client-IP CIDR ranges, including input normalization/validation, helpful guidance, and live updates (no restart).
  * Added optional `SILO_TRUSTED_PROXIES` support for preconfiguring trusted proxy CIDRs at startup; updated `.env.example`.
* **Bug Fixes**
  * Improved trusted-proxy hot-reloading reliability by ensuring updates propagate consistently across configuration changes.
  * Invalid trusted-proxy values now return a clear `400` error instead of accepting malformed inputs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->