### PR TITLE
fix(jellycompat): tolerate item-id mediaSourceId on direct-play streams

### DIFF
--- a/internal/jellycompat/playback_static_directplay_test.go
+++ b/internal/jellycompat/playback_static_directplay_test.go
@@ -148,6 +148,80 @@ func TestHandleVideoStream_StaticBypassesNegotiatedCapabilityRejection(t *testin
 	}
 }
 
+// TestHandleVideoStream_KnownPlaySessionItemIDMediaSourceServesFile covers a
+// client that calls PlaybackInfo, reuses the server-minted PlaySessionId on the
+// stream request, but sends the *item id* as mediaSourceId (Jellyfin's
+// MediaSource.Id == Item.Id convention) instead of the server's fileID-based
+// source id. The PlaySessionId lookup hits, but the item id matches no stored
+// source, so findMediaSource returns nil. That branch must fall back to the
+// session's primary source — as FindByRoute and createStaticPlaySession already
+// do — rather than returning a nil source and 400ing "Media source is required".
+func TestHandleVideoStream_KnownPlaySessionItemIDMediaSourceServesFile(t *testing.T) {
+	handler, encodedID, body := newStaticDirectPlayHandler(t)
+	sourceID := NewResourceIDCodec().EncodeIntID(EncodedIDMediaSource, 42)
+	handler.playbackStore.Put(PlaybackSession{
+		ID:          "server-psid",
+		CompatToken: "token-1",
+		ItemID:      "movie-1",
+		RouteItemID: encodedID,
+		UserID:      "user-1",
+		MediaSources: []PlaybackMediaSource{{
+			ID:                 sourceID,
+			FileID:             42,
+			Version:            catalog.FileVersion{FileID: 42, Container: "mkv", Duration: 3600},
+			SupportsDirectPlay: true,
+		}},
+	})
+
+	// mediaSourceId is the route item id (encodedID), which is NOT the stored
+	// source id (a distinct EncodedIDMediaSource UUID). Lowercase playSessionId
+	// mirrors the real client call shape.
+	rawQuery := "static=true&playSessionId=server-psid&mediaSourceId=" + url.QueryEscape(encodedID)
+	rec := serveStaticStream(handler, encodedID, rawQuery)
+
+	if rec.Code != 200 {
+		t.Fatalf("expected status 200; got %d, body=%s", rec.Code, rec.Body.String())
+	}
+	if got := rec.Body.String(); got != body {
+		t.Errorf("expected file content %q; got %q", body, got)
+	}
+}
+
+// TestHandleVideoStream_KnownPlaySessionUnknownMediaSourceRejected guards the
+// scope of the item-id fallback: a named mediaSourceId under a known
+// PlaySessionId that matches neither a stored source nor the route item id
+// (a stale/foreign id, or a wrong version on a multi-version item) must stay
+// rejected with 400 rather than silently serving the primary source. Only the
+// item-id convention (routeID) falls back; everything else is an error, matching
+// Jellyfin's StreamingHelpers.
+func TestHandleVideoStream_KnownPlaySessionUnknownMediaSourceRejected(t *testing.T) {
+	handler, encodedID, _ := newStaticDirectPlayHandler(t)
+	sourceID := NewResourceIDCodec().EncodeIntID(EncodedIDMediaSource, 42)
+	handler.playbackStore.Put(PlaybackSession{
+		ID:          "server-psid",
+		CompatToken: "token-1",
+		ItemID:      "movie-1",
+		RouteItemID: encodedID,
+		UserID:      "user-1",
+		MediaSources: []PlaybackMediaSource{{
+			ID:                 sourceID,
+			FileID:             42,
+			Version:            catalog.FileVersion{FileID: 42, Container: "mkv", Duration: 3600},
+			SupportsDirectPlay: true,
+		}},
+	})
+
+	// A media source id that is neither the stored source (fileID 42) nor the
+	// route item id -- e.g. a stale/foreign or wrong-version id.
+	otherSourceID := NewResourceIDCodec().EncodeIntID(EncodedIDMediaSource, 999)
+	rawQuery := "static=true&playSessionId=server-psid&mediaSourceId=" + url.QueryEscape(otherSourceID)
+	rec := serveStaticStream(handler, encodedID, rawQuery)
+
+	if rec.Code != 400 {
+		t.Fatalf("expected status 400 for an unknown mediaSourceId; got %d, body=%s", rec.Code, rec.Body.String())
+	}
+}
+
 // TestHandleVideoStream_NoStaticNoSessionReturns404 proves the static fallback
 // does not fire unconditionally: with no Static param and an empty playback
 // store, resolvePlaybackRoute correctly 404s.

--- a/internal/jellycompat/streams.go
+++ b/internal/jellycompat/streams.go
@@ -1460,11 +1460,20 @@ func (h *PlaybackHandler) resolvePlaybackRoute(r *http.Request, compatSession *S
 	clientPlaySessionID := newCaseInsensitiveQuery(r.URL.Query()).Get("PlaySessionId")
 	if clientPlaySessionID != "" {
 		if playSession, ok := h.playbackStore.Get(clientPlaySessionID); ok && playSession.CompatToken == compatSession.Token {
-			if mediaSourceID != "" {
-				source := findMediaSource(playSession, mediaSourceID)
-				return playSession, source, nil
+			// Fall back to the primary source only for the Jellyfin
+			// MediaSource.Id == Item.Id convention: a client that reused the
+			// server's PlaySessionId may send the item id (== routeID) as
+			// mediaSourceId, which never matches Silo's fileID-based source ids.
+			// Any other unmatched id (stale/foreign, or a wrong multi-version
+			// id) keeps source nil so HandleVideoStream rejects it rather than
+			// silently serving the wrong file. Mirrors Jellyfin's
+			// StreamingHelpers, which defaults to the primary source only for an
+			// empty or item-id mediaSourceId.
+			source := findMediaSource(playSession, mediaSourceID)
+			if source == nil && (mediaSourceID == "" || mediaSourceIDsEqual(mediaSourceID, routeID)) {
+				source = firstMediaSource(playSession)
 			}
-			return playSession, firstMediaSource(playSession), nil
+			return playSession, source, nil
 		}
 		// The PlaySessionId is unknown to us (the client never called PlaybackInfo,
 		// so it is the client's own id) or belongs to another caller. Fall through


### PR DESCRIPTION
## Problem

Native clients that direct-play via `/Videos/{id}/stream?static=true` fail with `400 "Media source is required"` and can't play back at all (even content the device supports natively) when they:

1. call `PlaybackInfo` and reuse the server-returned `PlaySessionId` on the stream request, and
2. send the **item id** as `mediaSourceId` (per the Jellyfin `MediaSource.Id == Item.Id` convention) rather than Silo's fileID-based media-source id.

Negotiation succeeds (`PlaybackInfo` returns 200, direct play), but the follow-up stream request 400s, so playback never starts.

## Root cause

`resolvePlaybackRoute` has three resolution paths. `FindByRoute` and `createStaticPlaySession` both fall back to `firstMediaSource` when a named `mediaSourceId` matches no stored source. The **`PlaySessionId`-hit** path does not; it returns `findMediaSource`'s nil result directly:

```go
if mediaSourceID != "" {
    source := findMediaSource(playSession, mediaSourceID)
    return playSession, source, nil   // nil when the id doesn't match
}
```

Silo assigns each media source a fileID-based id (`EncodeIntID(EncodedIDMediaSource, fileID)`), intentionally distinct from the item id so `/Items/{id}/Download` and detail/image routes can decode the file statelessly and multi-version files stay distinguishable. So a client sending the item id as `mediaSourceId` never matches, `findMediaSource` returns nil, and because resolution returns a nil *error*, `HandleVideoStream`'s `Static` fallback (`createStaticPlaySession`) never fires either. The result is a hard 400 on every direct-play request.

This slips past the #165 safety net, which only covers clients whose `PlaySessionId` is server-*unknown* (client-generated, so it falls through to `FindByRoute`). A client that calls `PlaybackInfo` and reuses the server's `PlaySessionId` lands in the strict branch instead.

## Fix

Give the `PlaySessionId`-hit branch a primary-source fallback **scoped to the convention it needs to satisfy**: fall back to the session's primary source only when `mediaSourceId` is empty or equals the route item id. This mirrors upstream Jellyfin's `StreamingHelpers`, which defaults to `mediaSources[0]` only for an empty or item-id `mediaSourceId` and leaves any other unmatched id unresolved.

The behavior delta is exactly one case: a known `PlaySessionId` plus an **item-id** `mediaSourceId` now serves the primary source instead of 400ing. Exact source-id matches and the empty-`mediaSourceId` case are unchanged. Any other unmatched id (a stale/foreign id, or a wrong version on a multi-version item) still returns 400, so it can't silently stream the wrong file. The media-source id scheme is left as-is.

## Test

Adds two tests:
- `TestHandleVideoStream_KnownPlaySessionItemIDMediaSourceServesFile` — known `PlaySessionId` + item-id `mediaSourceId`: 400 before, serves the file (200) after.
- `TestHandleVideoStream_KnownPlaySessionUnknownMediaSourceRejected` — known `PlaySessionId` + a non-item, non-matching id: still 400 (guards the fallback scope).

The full `internal/jellycompat` suite passes.
