### PR TITLE
fix(autoscan): advance marker past paths outside any library folder

### DIFF
--- a/internal/autoscan/repository.go
+++ b/internal/autoscan/repository.go
@@ -458,7 +458,9 @@ func (r *Repository) DeleteSource(ctx context.Context, id string) error {
 }
 
 // AdvanceMarker stores the opaque next marker for a source, stamps last_run_at,
-// and clears any prior error. Called only after a successful enqueue.
+// and clears any prior error. Called once a poll window's work is consumed —
+// after a successful enqueue, or when the window's paths all resolved outside
+// Silo's libraries and were advanced past.
 func (r *Repository) AdvanceMarker(ctx context.Context, sourceID, marker string) error {
 	tag, err := r.pool.Exec(ctx, `
 		UPDATE autoscan_sources

--- a/internal/autoscan/service.go
+++ b/internal/autoscan/service.go
@@ -50,6 +50,10 @@ type resolveStats struct {
 	ChangesResolved int
 	TargetsClaimed  int
 	Suppressed      int
+	// TransientErrors counts resolve attempts that failed with an internal
+	// (non-RequestError) error — resolver/database faults that may clear on a
+	// later poll, as opposed to paths that are simply outside Silo's libraries.
+	TransientErrors int
 }
 
 // connectionResolver resolves a stored connection to concrete credentials.
@@ -122,12 +126,13 @@ func NewService(
 
 // PollOnce runs one autoscan cycle. Per-source failures are logged, recorded on
 // the source/event, and the loop continues; only settings/listing errors
-// propagate. The opaque next marker returned by the
-// provider is stored verbatim, but only when the cycle's work is genuinely
-// consumed: the provider returned no paths, or it returned paths and at least one
-// resolved+enqueued. When paths come back but NONE resolve to a library folder
-// (e.g. a freshly-enabled source with unconfigured rewrites) the marker is held
-// and an error recorded, so those imports aren't skipped forever.
+// propagate. The opaque next marker returned by the provider is stored
+// verbatim once the window's work is consumed — including windows whose paths
+// all resolve OUTSIDE Silo's libraries (routine for whole-volume filesystem
+// watchers; the event finishes as "unresolved" so it stays visible). The
+// marker is held only on genuine failures: provider errors, enqueue errors,
+// and windows where nothing resolved because resolve attempts failed
+// internally (possibly transient), so those imports are retried next poll.
 func (s *Service) PollOnce(ctx context.Context) error {
 	settings, err := s.store.GetSettings(ctx)
 	if err != nil {
@@ -239,17 +244,41 @@ func (s *Service) PollOnce(ctx context.Context) error {
 		//   - returned paths, resolved but all
 		//     suppressed (recently scanned /
 		//     debounced)                           → work is effectively done; advance.
-		//   - returned paths AND NOTHING resolved  → advance and warn. Filesystem
-		//     watchers (e.g. CephFS) observe the entire volume and will return paths
-		//     from folders that are not registered as Silo libraries. Stalling here
-		//     permanently blocks autoscan for every future poll. Log a warning so
-		//     the operator can investigate, but advance so the queue keeps moving.
+		//   - returned paths AND NOTHING resolved  → depends on WHY nothing
+		//     resolved:
+		//       * every path is outside Silo's libraries (RequestError) — a benign,
+		//         expected condition for whole-volume filesystem watchers (e.g.
+		//         CephFS), which observe folders that are not registered as Silo
+		//         libraries. Holding here would pin the marker and permanently
+		//         stall autoscan, so advance; finish the event as "unresolved" so
+		//         the condition stays visible in poll history.
+		//       * one or more resolve attempts failed INTERNALLY (resolver/database
+		//         fault) — possibly transient, so hold the marker and record the
+		//         error; a later poll re-reads the same window once the fault
+		//         clears. Advancing here would silently skip real imports.
 		// (Some-but-not-all resolving counts as resolved — the unresolved paths are
 		// legitimately outside Silo's libraries, so advancing is correct.)
 		//
 		// NOTE: len(targets)==0 alone is NOT misconfiguration — paths can resolve
-		// yet be fully suppressed. Gate the warning on resolvedAny, not targets.
+		// yet be fully suppressed. Gate on resolvedAny, not targets.
+		status := EventStatusSuccess
+		var statusMsg string
 		if len(changes) > 0 && !resolvedAny {
+			if stats.TransientErrors > 0 {
+				msg := fmt.Sprintf("returned %d path(s), none resolved and %d resolve attempt(s) failed internally — holding marker to retry", len(changes), stats.TransientErrors)
+				if rerr := s.store.RecordError(ctx, src.ID, msg); rerr != nil {
+					slog.WarnContext(ctx, "autoscan: record error failed", "source_id", src.ID, "err", rerr)
+				}
+				s.finishEvent(ctx, eventID, EventFinish{
+					Status:          EventStatusError,
+					ChangesReturned: len(changes),
+					ErrorMessage:    msg,
+					MarkerAfter:     marker,
+				})
+				continue // do NOT advance marker
+			}
+			status = EventStatusUnresolved
+			statusMsg = fmt.Sprintf("returned %d path(s) but none matched a Silo library folder — advanced past them", len(changes))
 			slog.WarnContext(ctx, "autoscan: returned paths matched no library folder — advancing marker",
 				"source_id", src.ID, "changes", len(changes))
 		}
@@ -269,13 +298,14 @@ func (s *Service) PollOnce(ctx context.Context) error {
 			continue
 		}
 		s.finishEvent(ctx, eventID, EventFinish{
-			Status:          EventStatusSuccess,
+			Status:          status,
 			ChangesReturned: len(changes),
 			ChangesResolved: stats.ChangesResolved,
 			TargetsClaimed:  stats.TargetsClaimed,
 			ScansCreated:    enqueue.Created,
 			ScansReused:     enqueue.Reused,
 			ScansSuppressed: stats.Suppressed,
+			ErrorMessage:    statusMsg,
 			MarkerAfter:     next,
 		})
 	}
@@ -375,7 +405,7 @@ func (s *Service) resolveAndClaim(ctx context.Context, changes []Change, ttl tim
 	for _, change := range changes {
 		switch change.Scope {
 		case ChangeScopeFile, ChangeScopeSubtree:
-			target, ok := s.resolveChange(ctx, change)
+			target, ok := s.resolveChange(ctx, change, &stats)
 			if !ok {
 				continue
 			}
@@ -405,6 +435,7 @@ func (s *Service) resolveAndClaim(ctx context.Context, changes []Change, ttl tim
 				// — an expected skip, not an error worth logging every cycle.
 				continue
 			}
+			stats.TransientErrors++
 			slog.WarnContext(ctx, "autoscan: resolve failed", "path", dir, "err", rerr)
 			continue
 		}
@@ -452,7 +483,7 @@ func isRequestError(err error) bool {
 	return errors.As(err, &reqErr)
 }
 
-func (s *Service) resolveChange(ctx context.Context, change Change) (*scantrigger.Target, bool) {
+func (s *Service) resolveChange(ctx context.Context, change Change, stats *resolveStats) (*scantrigger.Target, bool) {
 	if change.SourcePath == "" {
 		return nil, false
 	}
@@ -482,6 +513,7 @@ func (s *Service) resolveChange(ctx context.Context, change Change) (*scantrigge
 		if errors.As(err, &reqErr) {
 			return nil, false
 		}
+		stats.TransientErrors++
 		slog.WarnContext(ctx, "autoscan: resolve failed", "path", change.SourcePath, "scope", change.Scope, "err", err)
 		return nil, false
 	}

--- a/internal/autoscan/service.go
+++ b/internal/autoscan/service.go
@@ -239,28 +239,19 @@ func (s *Service) PollOnce(ctx context.Context) error {
 		//   - returned paths, resolved but all
 		//     suppressed (recently scanned /
 		//     debounced)                           → work is effectively done; advance.
-		//   - returned paths AND NOTHING resolved  → do NOT advance. This is the
-		//     freshly-enabled-source state (path_rewrites not configured yet); the
-		//     incoming paths don't map to any Silo library folder. Advancing here
-		//     would skip those imports forever. Surface why so the operator can fix
-		//     the rewrites, then a later poll re-reads the same window and resolves.
+		//   - returned paths AND NOTHING resolved  → advance and warn. Filesystem
+		//     watchers (e.g. CephFS) observe the entire volume and will return paths
+		//     from folders that are not registered as Silo libraries. Stalling here
+		//     permanently blocks autoscan for every future poll. Log a warning so
+		//     the operator can investigate, but advance so the queue keeps moving.
 		// (Some-but-not-all resolving counts as resolved — the unresolved paths are
 		// legitimately outside Silo's libraries, so advancing is correct.)
 		//
 		// NOTE: len(targets)==0 alone is NOT misconfiguration — paths can resolve
-		// yet be fully suppressed. Gate the error on resolvedAny, not targets.
+		// yet be fully suppressed. Gate the warning on resolvedAny, not targets.
 		if len(changes) > 0 && !resolvedAny {
-			msg := fmt.Sprintf("returned %d path(s) but none matched a Silo library folder — check this source's path rewrites", len(changes))
-			if rerr := s.store.RecordError(ctx, src.ID, msg); rerr != nil {
-				slog.WarnContext(ctx, "autoscan: record error failed", "source_id", src.ID, "err", rerr)
-			}
-			s.finishEvent(ctx, eventID, EventFinish{
-				Status:          EventStatusUnresolved,
-				ChangesReturned: len(changes),
-				ErrorMessage:    msg,
-				MarkerAfter:     marker,
-			})
-			continue // do NOT advance marker
+			slog.WarnContext(ctx, "autoscan: returned paths matched no library folder — advancing marker",
+				"source_id", src.ID, "changes", len(changes))
 		}
 		if aerr := s.store.AdvanceMarker(ctx, src.ID, next); aerr != nil {
 			slog.WarnContext(ctx, "autoscan: advance marker failed", "source_id", src.ID, "err", aerr)

--- a/internal/autoscan/service.go
+++ b/internal/autoscan/service.go
@@ -131,8 +131,8 @@ func NewService(
 // all resolve OUTSIDE Silo's libraries (routine for whole-volume filesystem
 // watchers; the event finishes as "unresolved" so it stays visible). The
 // marker is held only on genuine failures: provider errors, enqueue errors,
-// and windows where nothing resolved because resolve attempts failed
-// internally (possibly transient), so those imports are retried next poll.
+// and windows where any resolve attempt failed internally (possibly
+// transient), so the affected imports are retried next poll.
 func (s *Service) PollOnce(ctx context.Context) error {
 	settings, err := s.store.GetSettings(ctx)
 	if err != nil {
@@ -244,39 +244,45 @@ func (s *Service) PollOnce(ctx context.Context) error {
 		//   - returned paths, resolved but all
 		//     suppressed (recently scanned /
 		//     debounced)                           → work is effectively done; advance.
-		//   - returned paths AND NOTHING resolved  → depends on WHY nothing
-		//     resolved:
-		//       * every path is outside Silo's libraries (RequestError) — a benign,
-		//         expected condition for whole-volume filesystem watchers (e.g.
-		//         CephFS), which observe folders that are not registered as Silo
-		//         libraries. Holding here would pin the marker and permanently
-		//         stall autoscan, so advance; finish the event as "unresolved" so
-		//         the condition stays visible in poll history.
-		//       * one or more resolve attempts failed INTERNALLY (resolver/database
-		//         fault) — possibly transient, so hold the marker and record the
-		//         error; a later poll re-reads the same window once the fault
-		//         clears. Advancing here would silently skip real imports.
-		// (Some-but-not-all resolving counts as resolved — the unresolved paths are
-		// legitimately outside Silo's libraries, so advancing is correct.)
+		//   - ANY resolve attempt failed INTERNALLY (resolver/database fault —
+		//     possibly transient), whether or not other paths resolved → hold the
+		//     marker and record the error; a later poll re-reads the same window
+		//     once the fault clears. Advancing would silently skip the failed
+		//     paths. Targets that DID resolve were already enqueued above; the
+		//     re-read at worst re-scans them, which is safe.
+		//   - returned paths AND NOTHING resolved  → every path is outside Silo's
+		//     libraries (RequestError) — a benign, expected condition for
+		//     whole-volume filesystem watchers (e.g. CephFS), which observe
+		//     folders that are not registered as Silo libraries. Holding here
+		//     would pin the marker and permanently stall autoscan, so advance;
+		//     finish the event as "unresolved" so the condition stays visible in
+		//     poll history.
+		// (Some-but-not-all resolving still advances when the unresolved
+		// remainder is merely outside Silo's libraries.)
 		//
 		// NOTE: len(targets)==0 alone is NOT misconfiguration — paths can resolve
 		// yet be fully suppressed. Gate on resolvedAny, not targets.
+		if stats.TransientErrors > 0 {
+			msg := fmt.Sprintf("%d resolve attempt(s) failed internally (%d of %d path(s) resolved) — holding marker to retry", stats.TransientErrors, stats.ChangesResolved, len(changes))
+			if rerr := s.store.RecordError(ctx, src.ID, msg); rerr != nil {
+				slog.WarnContext(ctx, "autoscan: record error failed", "source_id", src.ID, "err", rerr)
+			}
+			s.finishEvent(ctx, eventID, EventFinish{
+				Status:          EventStatusError,
+				ChangesReturned: len(changes),
+				ChangesResolved: stats.ChangesResolved,
+				TargetsClaimed:  stats.TargetsClaimed,
+				ScansCreated:    enqueue.Created,
+				ScansReused:     enqueue.Reused,
+				ScansSuppressed: stats.Suppressed,
+				ErrorMessage:    msg,
+				MarkerAfter:     marker,
+			})
+			continue // do NOT advance marker
+		}
 		status := EventStatusSuccess
 		var statusMsg string
 		if len(changes) > 0 && !resolvedAny {
-			if stats.TransientErrors > 0 {
-				msg := fmt.Sprintf("returned %d path(s), none resolved and %d resolve attempt(s) failed internally — holding marker to retry", len(changes), stats.TransientErrors)
-				if rerr := s.store.RecordError(ctx, src.ID, msg); rerr != nil {
-					slog.WarnContext(ctx, "autoscan: record error failed", "source_id", src.ID, "err", rerr)
-				}
-				s.finishEvent(ctx, eventID, EventFinish{
-					Status:          EventStatusError,
-					ChangesReturned: len(changes),
-					ErrorMessage:    msg,
-					MarkerAfter:     marker,
-				})
-				continue // do NOT advance marker
-			}
 			status = EventStatusUnresolved
 			statusMsg = fmt.Sprintf("returned %d path(s) but none matched a Silo library folder — advanced past them", len(changes))
 			slog.WarnContext(ctx, "autoscan: returned paths matched no library folder — advancing marker",

--- a/internal/autoscan/service_test.go
+++ b/internal/autoscan/service_test.go
@@ -240,6 +240,24 @@ func (unresolvableResolver) ResolveVanishedPath(context.Context, string, string)
 	return nil, &scantrigger.RequestError{Status: 400, Code: "bad_request", Message: "outside media folders"}
 }
 
+// mixedTransientResolver resolves /mnt/media/ paths normally and fails every
+// other path with a plain (non-RequestError) internal error — the mixed
+// "some resolved, some failed transiently" poll window.
+type mixedTransientResolver struct{}
+
+func (mixedTransientResolver) Resolve(_ context.Context, req scantrigger.Request) (*scantrigger.Target, error) {
+	if strings.HasPrefix(req.Path, "/mnt/media/") {
+		return &scantrigger.Target{Folder: &models.MediaFolder{ID: 7}, Mode: scantrigger.ModeSubtree, Path: req.Path, Trigger: req.Trigger}, nil
+	}
+	return nil, errors.New("listing folders: connection timeout")
+}
+func (mixedTransientResolver) ResolveMissingSubtree(context.Context, string, string) (*scantrigger.Target, error) {
+	return nil, errors.New("listing folders: connection timeout")
+}
+func (mixedTransientResolver) ResolveVanishedPath(context.Context, string, string) (*scantrigger.Target, error) {
+	return nil, errors.New("listing folders: connection timeout")
+}
+
 // transientFailureResolver fails every resolve with a plain (non-RequestError)
 // error, simulating an internal fault such as a database timeout.
 type transientFailureResolver struct{}
@@ -816,6 +834,50 @@ func TestPollOnceHoldsMarkerOnTransientResolveFailure(t *testing.T) {
 		t.Fatalf("event status = %q, want %q", event.Status, EventStatusError)
 	}
 	if event.ChangesReturned != 2 || event.ChangesResolved != 0 {
+		t.Fatalf("event counts = %+v", event)
+	}
+}
+
+func TestPollOnceHoldsMarkerWhenSomeResolveAndOthersFailTransiently(t *testing.T) {
+	// One path resolves and enqueues, another fails with an internal
+	// (non-RequestError) resolver fault. The resolved target's scan must still
+	// be enqueued, but the marker must HOLD and an error be recorded so the
+	// failed path is retried next poll instead of being skipped.
+	store := &fakeStore{
+		settings: Settings{Enabled: true, DefaultPollIntervalSeconds: 600, DebounceSeconds: 60},
+		sources: []Source{{
+			ID: "s1", PluginID: "silo.autoscan.arr", CapabilityID: "arr", ConnectionID: strptr("c1"), Enabled: true,
+		}},
+	}
+	prov := &fakeProvider{paths: map[string][]string{
+		"arr": {
+			"/mnt/media/Show/S01/E01.mkv",
+			"/data/other/Movie/movie.mkv",
+		},
+	}, nextMarker: "m1"}
+	q := &recordingQueuer{}
+	svc := NewService(store, prov, passthroughConnRes{}, mixedTransientResolver{}, q, allowSuppressor{}, nil)
+	if err := svc.PollOnce(context.Background()); err != nil {
+		t.Fatalf("PollOnce: %v", err)
+	}
+	if len(q.enqueued) != 1 {
+		t.Fatalf("the resolved target should still enqueue, got %d", len(q.enqueued))
+	}
+	if got, ok := store.advanced["s1"]; ok {
+		t.Fatalf("marker must NOT advance when any resolve attempt failed transiently, advanced to %q", got)
+	}
+	msg, ok := store.recorded["s1"]
+	if !ok || !strings.Contains(msg, "failed internally") {
+		t.Fatalf("expected recorded transient-failure error, got %q ok=%v", msg, ok)
+	}
+	if len(store.events) != 1 {
+		t.Fatalf("expected one finished event, got %d", len(store.events))
+	}
+	event := store.events[0]
+	if event.Status != EventStatusError {
+		t.Fatalf("event status = %q, want %q", event.Status, EventStatusError)
+	}
+	if event.ChangesReturned != 2 || event.ChangesResolved != 1 {
 		t.Fatalf("event counts = %+v", event)
 	}
 }

--- a/internal/autoscan/service_test.go
+++ b/internal/autoscan/service_test.go
@@ -711,11 +711,10 @@ func TestPollOnceStoresOpaqueMarkerVerbatim(t *testing.T) {
 	}
 }
 
-func TestPollOnceHoldsMarkerWhenPathsReturnedButNoneResolve(t *testing.T) {
-	// A freshly-enabled source with no path_rewrites: the provider returns paths
-	// that don't map to any Silo library folder (the resolver RequestErrors on
-	// every path). The marker must NOT advance (so the imports aren't skipped
-	// forever) and an explaining error is recorded.
+func TestPollOnceAdvancesMarkerWhenPathsReturnedButNoneResolve(t *testing.T) {
+	// A filesystem watcher (e.g. CephFS) may return paths from folders that are
+	// not registered as Silo libraries. The marker must ADVANCE so autoscan does
+	// not stall permanently; no error is recorded, only a log warning.
 	store := &fakeStore{
 		settings: Settings{Enabled: true, DefaultPollIntervalSeconds: 600, DebounceSeconds: 60},
 		sources: []Source{{
@@ -738,28 +737,21 @@ func TestPollOnceHoldsMarkerWhenPathsReturnedButNoneResolve(t *testing.T) {
 	if len(q.enqueued) != 0 {
 		t.Fatalf("nothing should enqueue when no path resolves, got %d", len(q.enqueued))
 	}
-	if _, ok := store.advanced["s1"]; ok {
-		t.Fatalf("marker must NOT advance when paths returned but none resolved")
+	if got := store.advanced["s1"]; got != "m1" {
+		t.Fatalf("marker must advance when paths returned but none resolved, got %q", got)
 	}
-	msg, ok := store.recorded["s1"]
-	if !ok || msg == "" {
-		t.Fatalf("expected an explaining error recorded for s1, got %q ok=%v", msg, ok)
-	}
-	if want := "returned 2 path(s)"; !strings.Contains(msg, want) {
-		t.Fatalf("recorded error %q should mention %q", msg, want)
+	if msg, ok := store.recorded["s1"]; ok {
+		t.Fatalf("no error should be recorded when advancing past unresolvable paths, got %q", msg)
 	}
 	if len(store.events) != 1 {
 		t.Fatalf("expected one finished event, got %d", len(store.events))
 	}
 	event := store.events[0]
-	if event.Status != EventStatusUnresolved {
-		t.Fatalf("event status = %q, want %q", event.Status, EventStatusUnresolved)
+	if event.Status != EventStatusSuccess {
+		t.Fatalf("event status = %q, want %q", event.Status, EventStatusSuccess)
 	}
 	if event.ChangesReturned != 2 || event.ChangesResolved != 0 || event.TargetsClaimed != 0 {
 		t.Fatalf("event counts = %+v", event)
-	}
-	if !strings.Contains(event.ErrorMessage, "returned 2 path(s)") {
-		t.Fatalf("event error = %q", event.ErrorMessage)
 	}
 }
 

--- a/internal/autoscan/service_test.go
+++ b/internal/autoscan/service_test.go
@@ -240,6 +240,20 @@ func (unresolvableResolver) ResolveVanishedPath(context.Context, string, string)
 	return nil, &scantrigger.RequestError{Status: 400, Code: "bad_request", Message: "outside media folders"}
 }
 
+// transientFailureResolver fails every resolve with a plain (non-RequestError)
+// error, simulating an internal fault such as a database timeout.
+type transientFailureResolver struct{}
+
+func (transientFailureResolver) Resolve(context.Context, scantrigger.Request) (*scantrigger.Target, error) {
+	return nil, errors.New("listing folders: connection timeout")
+}
+func (transientFailureResolver) ResolveMissingSubtree(context.Context, string, string) (*scantrigger.Target, error) {
+	return nil, errors.New("listing folders: connection timeout")
+}
+func (transientFailureResolver) ResolveVanishedPath(context.Context, string, string) (*scantrigger.Target, error) {
+	return nil, errors.New("listing folders: connection timeout")
+}
+
 // denySuppressor resolves paths normally but denies every claim, simulating a
 // recently-scanned / debounced target (resolved but suppressed).
 type denySuppressor struct{}
@@ -714,7 +728,8 @@ func TestPollOnceStoresOpaqueMarkerVerbatim(t *testing.T) {
 func TestPollOnceAdvancesMarkerWhenPathsReturnedButNoneResolve(t *testing.T) {
 	// A filesystem watcher (e.g. CephFS) may return paths from folders that are
 	// not registered as Silo libraries. The marker must ADVANCE so autoscan does
-	// not stall permanently; no error is recorded, only a log warning.
+	// not stall permanently; no source error is recorded, but the event finishes
+	// as "unresolved" so the condition stays visible in poll history.
 	store := &fakeStore{
 		settings: Settings{Enabled: true, DefaultPollIntervalSeconds: 600, DebounceSeconds: 60},
 		sources: []Source{{
@@ -747,10 +762,60 @@ func TestPollOnceAdvancesMarkerWhenPathsReturnedButNoneResolve(t *testing.T) {
 		t.Fatalf("expected one finished event, got %d", len(store.events))
 	}
 	event := store.events[0]
-	if event.Status != EventStatusSuccess {
-		t.Fatalf("event status = %q, want %q", event.Status, EventStatusSuccess)
+	if event.Status != EventStatusUnresolved {
+		t.Fatalf("event status = %q, want %q", event.Status, EventStatusUnresolved)
 	}
 	if event.ChangesReturned != 2 || event.ChangesResolved != 0 || event.TargetsClaimed != 0 {
+		t.Fatalf("event counts = %+v", event)
+	}
+	if !strings.Contains(event.ErrorMessage, "none matched a Silo library folder") {
+		t.Fatalf("event message = %q", event.ErrorMessage)
+	}
+	if event.MarkerAfter != "m1" {
+		t.Fatalf("event marker after = %q, want %q", event.MarkerAfter, "m1")
+	}
+}
+
+func TestPollOnceHoldsMarkerOnTransientResolveFailure(t *testing.T) {
+	// Nothing resolved because the resolver failed INTERNALLY (e.g. a database
+	// fault), not because the paths are outside Silo's libraries. Advancing
+	// would silently skip real imports, so the marker must HOLD and an error be
+	// recorded; the window is retried once the fault clears.
+	store := &fakeStore{
+		settings: Settings{Enabled: true, DefaultPollIntervalSeconds: 600, DebounceSeconds: 60},
+		sources: []Source{{
+			ID: "s1", PluginID: "silo.autoscan.arr", CapabilityID: "arr", ConnectionID: strptr("c1"), Enabled: true,
+		}},
+	}
+	prov := &fakeProvider{paths: map[string][]string{
+		"arr": {
+			"/mnt/media/Show/S01/E01.mkv",
+			"/mnt/media/Show/S01/E02.mkv",
+		},
+	}, nextMarker: "m1"}
+	q := &recordingQueuer{}
+	svc := NewService(store, prov, passthroughConnRes{}, transientFailureResolver{}, q, allowSuppressor{}, nil)
+	if err := svc.PollOnce(context.Background()); err != nil {
+		t.Fatalf("PollOnce: %v", err)
+	}
+	if len(q.enqueued) != 0 {
+		t.Fatalf("nothing should enqueue when no path resolves, got %d", len(q.enqueued))
+	}
+	if got, ok := store.advanced["s1"]; ok {
+		t.Fatalf("marker must NOT advance on transient resolve failure, advanced to %q", got)
+	}
+	msg, ok := store.recorded["s1"]
+	if !ok || !strings.Contains(msg, "failed internally") {
+		t.Fatalf("expected recorded transient-failure error, got %q ok=%v", msg, ok)
+	}
+	if len(store.events) != 1 {
+		t.Fatalf("expected one finished event, got %d", len(store.events))
+	}
+	event := store.events[0]
+	if event.Status != EventStatusError {
+		t.Fatalf("event status = %q, want %q", event.Status, EventStatusError)
+	}
+	if event.ChangesReturned != 2 || event.ChangesResolved != 0 {
 		t.Fatalf("event counts = %+v", event)
 	}
 }


### PR DESCRIPTION
A filesystem-watcher scan source (e.g. the CephFS plugin) observes the entire volume, so it legitimately returns changes for paths that live in folders which are not registered as Silo libraries (unregistered decade buckets, 4k-dv, anime-dub, download/recycle dirs, etc.).

Previously, when a poll returned paths but none resolved to a library folder, PollOnce recorded an "unresolved" error and refused to advance the marker, on the assumption this only happens for a freshly-enabled source with unconfigured path rewrites. For a whole-volume watcher that assumption is wrong: a single change under an unregistered folder pins the journal marker in place, so every subsequent poll re-reads the same window and autoscan stalls permanently. Real imports pile up behind the stuck marker and are never scanned until the next full library scan.

Treat "paths returned but none resolved" as a benign, expected condition: log a warning (so an operator can still investigate a genuinely misconfigured source) and advance the marker so the queue keeps moving. Partial resolution was already handled correctly — the unresolved subset is simply outside Silo's libraries.

Observed in production: one file added under movies/4k-dv (not a library path) froze the CephFS source for ~18 days; ~42k journal changes had accumulated behind it. With this change the marker advances and the backlog drains on the next poll.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Refined autoscan polling marker behavior and event outcomes when provider-reported changes don’t match any library folder.
  * Autoscan now advances with an unresolved warning for non-library-related misses, while holding the marker and reporting an error when failures appear transient/internal, reducing unintended stalls and improving status accuracy.
* **Tests**
  * Expanded autoscan poll tests to cover marker-advance vs marker-hold for transient/internal resolution failures and updated existing expectations accordingly.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->