### PR TITLE
fix(audiobooks): /api/authors/{id} 500 — select photo_path, not poster_path

### DIFF
--- a/internal/audiobooks/media_store.go
+++ b/internal/audiobooks/media_store.go
@@ -1001,19 +1001,15 @@ func (s *ABSMediaStore) GetAuthorByID(ctx context.Context, authorID string, acce
 	if err != nil {
 		return abs.Author{}, abs.ErrNotFound
 	}
-	var name string
-	var poster *string
-	row := s.Pool.QueryRow(ctx, `SELECT name, poster_path FROM people WHERE id = $1`, id)
-	if err := row.Scan(&name, &poster); err != nil {
+	var name, photo string
+	row := s.Pool.QueryRow(ctx, `SELECT name, photo_path FROM people WHERE id = $1`, id)
+	if err := row.Scan(&name, &photo); err != nil {
 		if errors.Is(err, pgx.ErrNoRows) {
 			return abs.Author{}, abs.ErrNotFound
 		}
 		return abs.Author{}, fmt.Errorf("abs_media_store: get author: %w", err)
 	}
-	author := abs.Author{ID: authorID, Name: name}
-	if poster != nil {
-		author.PosterPath = *poster
-	}
+	author := abs.Author{ID: authorID, Name: name, PosterPath: photo}
 	conditions := []string{`ip.person_id = $1`, `ip.kind = 7`, `mi.type = 'audiobook'`}
 	args := []any{id}
 	argIdx := 2


### PR DESCRIPTION
## Problem

Every `GET /api/authors/{id}` request on the Audiobookshelf-compat API returned a 500. `ABSMediaStore.GetAuthorByID` selected `poster_path` from the `people` table, but the person-image column is `photo_path`, so the query always failed with `SQLSTATE 42703 (column does not exist)`:

```
msg="abs author detail failed" err="abs_media_store: get author: ERROR: column \"poster_path\" does not exist (SQLSTATE 42703)"
```

Reported via an internal Discord thread by a user of a third-party ABS client; author detail pages failed to load.

## Fix

Select `photo_path` instead. Since the column is `NOT NULL DEFAULT ''`, the nullable `*string` scan is replaced with a plain `string` assigned directly to `Author.PosterPath` (empty stays empty, matching prior behavior).

Only the detail path was affected — author listing reads from the `abs_audiobook_author_counts` MV and does not touch this column.

## Verification

- `go build ./internal/audiobooks/` and `go vet ./internal/audiobooks/` pass.
- Column name verified against `migrations/sql/001_schema.sql` (`people.photo_path`).

## Disclosure

Implemented with Claude Code (AI-assisted); change reviewed against the schema.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Author details now load more reliably when viewed in the app.
  * Author images are now displayed consistently instead of being omitted when the stored image path is present.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->