### PR TITLE
fix(scanner): repair invalid CTE that made UpdateEpisodeLink fail on every call

### DIFF
--- a/internal/scanner/file_repo.go
+++ b/internal/scanner/file_repo.go
@@ -2949,6 +2949,10 @@ func (r *FileRepository) UpdateEpisodeLink(ctx context.Context, fileID int, epis
 		return fmt.Errorf("loading existing episode link: %w", err)
 	}
 
+	// The INSERT is the top-level statement: a data-modifying CTE can only be
+	// referenced by later query parts if it has a RETURNING clause, so a
+	// trailing "SELECT COUNT(*) FROM inserted" is invalid PostgreSQL and made
+	// this statement error on every call.
 	if _, err := tx.Exec(ctx, `
 		WITH updated AS (
 			UPDATE media_files
@@ -2958,16 +2962,13 @@ func (r *FileRepository) UpdateEpisodeLink(ctx context.Context, fileID int, epis
 				updated_at = NOW()
 			WHERE id = $4
 			RETURNING episode_id, media_folder_id, created_at, missing_since
-		),
-		inserted AS (
-			INSERT INTO episode_libraries (episode_id, media_folder_id, first_seen_at)
-			SELECT episode_id, media_folder_id, created_at
-			FROM updated
-			WHERE episode_id IS NOT NULL
-			  AND missing_since IS NULL
-			ON CONFLICT (episode_id, media_folder_id) DO NOTHING
 		)
-		SELECT COUNT(*) FROM inserted
+		INSERT INTO episode_libraries (episode_id, media_folder_id, first_seen_at)
+		SELECT episode_id, media_folder_id, created_at
+		FROM updated
+		WHERE episode_id IS NOT NULL
+		  AND missing_since IS NULL
+		ON CONFLICT (episode_id, media_folder_id) DO NOTHING
 	`, episodeID, seasonNum, episodeNum, fileID); err != nil {
 		return fmt.Errorf("updating episode link: %w", err)
 	}


### PR DESCRIPTION
Fixes #320.

## Problem

`UpdateEpisodeLink` ends its update+insert statement with `SELECT COUNT(*) FROM inserted`, but the `inserted` CTE has no `RETURNING` clause. PostgreSQL rejects referencing a data-modifying CTE without `RETURNING` (SQLSTATE 0A000), so **every call has failed at runtime since #283**. The sole caller (`internal/metadata/service.go` episode file linking) logs a warning and continues, so the metadata-side single-file relink silently did nothing: `media_files.episode_id` stayed stale, `episode_libraries` rows were never inserted, and `latest_episode_added_at` never bumped through this path. `BulkLinkEpisodesBySeries` uses the correct CTE pattern (its `inserted` CTE has `RETURNING`), which masked the breakage.

## Fix

Make the `INSERT … ON CONFLICT DO NOTHING` the top-level statement of the `WITH`; the trailing count was unused. One statement, identical semantics, now valid SQL.

## Verification

Against a migrated PostgreSQL scratch database: `TestEpisodeLinkMaintainsLatestEpisodeAdded` (the existing skip-gated DB test at `episode_added_denorm_test.go`) fails on main with the exact production error and passes with this change — verified in both directions. `go build ./...`, the scanner unit suite, and `golangci-lint --new-from-rev=origin/main` are clean. No CI runs DB-backed Go tests, which is why this survived since #283; worth considering a self-hosted DB test job as follow-up.

Found while running the database suites for #319.

## AI-use disclosure

Diagnosed and fixed with Claude Code (Claude Fable 5); human-directed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue that could cause episode link updates to fail due to an invalid database query.
  * Improved reliability when saving library links so updates complete successfully without triggering errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->