### PR TITLE
feat(web): Media Info dialog + consolidated media-spec formatters

### DIFF
--- a/web/src/api/types.ts
+++ b/web/src/api/types.ts
@@ -955,6 +955,10 @@ export interface VersionVideoTrack {
   title?: string;
   codec?: string;
   dolby_vision?: string;
+  dv_profile?: number;
+  dv_bl_compat_id?: number;
+  dv_el_present?: boolean;
+  hdr10_plus?: boolean;
   profile?: string;
   level?: number;
   width?: number;
@@ -964,6 +968,7 @@ export interface VersionVideoTrack {
   frame_rate?: string;
   bitrate?: number;
   video_range?: string;
+  video_range_type?: string;
   color_primaries?: string;
   color_space?: string;
   color_transfer?: string;

--- a/web/src/components/DownloadVersionPicker.tsx
+++ b/web/src/components/DownloadVersionPicker.tsx
@@ -9,7 +9,7 @@ import {
   DialogHeader,
   DialogTitle,
 } from "@/components/ui/dialog";
-import { formatFileSize } from "@/pages/ItemDetail/components/versionFormatUtils";
+import { formatFileSize } from "@/lib/mediaFormat";
 import { buildDirectDownloadUrl } from "@/hooks/queries/downloads";
 import { buildQualitySummary, sortByResolution } from "@/pages/ItemDetail/components/VersionFlyout";
 

--- a/web/src/components/ItemCard.tsx
+++ b/web/src/components/ItemCard.tsx
@@ -9,6 +9,7 @@ import CardOverlays from "@/components/overlays/CardOverlays";
 import { overlayDataFromBrowseItem, type CardOverlayPrefs } from "@/lib/overlays";
 import { buildEpisodeCardLabels } from "@/lib/episodeCardLabels";
 import { formatDate as formatPreferredDate } from "@/lib/datetime";
+import { formatBitrate } from "@/lib/mediaFormat";
 
 const DATE_ONLY_PATTERN = /^\d{4}-\d{2}-\d{2}$/;
 
@@ -38,13 +39,6 @@ function formatRating(value?: number | null, max = 10) {
 
 function formatPercent(value?: number | null) {
   return value != null ? `${value}%` : null;
-}
-
-function formatBitrate(kbps?: number | null) {
-  if (!kbps || kbps <= 0) {
-    return null;
-  }
-  return `${kbps.toLocaleString()} kbps`;
 }
 
 function formatProgress(ratio?: number | null) {
@@ -149,7 +143,7 @@ function SortMeta({ item, sortField }: { item: BrowseItem; sortField?: string })
         <>{item.sort_metrics?.resolution || item.overlay_summary?.resolution || defaultLabel}</>
       );
     case "bitrate":
-      return <>{formatBitrate(item.sort_metrics?.bitrate_kbps) ?? defaultLabel}</>;
+      return <>{formatBitrate(item.sort_metrics?.bitrate_kbps ?? undefined) || defaultLabel}</>;
     case "progress":
       return <>{formatProgress(item.sort_metrics?.progress_ratio) ?? defaultLabel}</>;
     case "date_viewed":

--- a/web/src/components/MangaFilesDialog.tsx
+++ b/web/src/components/MangaFilesDialog.tsx
@@ -9,7 +9,7 @@ import {
 } from "@/components/ui/dialog";
 import { useMangaSeriesFiles } from "@/hooks/queries/catalogRead";
 import { prettifyVolumeLabel } from "@/lib/mangaChapters";
-import { formatFileSize } from "@/pages/ItemDetail/components/versionFormatUtils";
+import { formatFileSize } from "@/lib/mediaFormat";
 
 // fileRowLabel describes the chapter a file backs: its volume token when
 // present, otherwise a chapter form mirroring the series list labels.

--- a/web/src/components/MediaLocations.tsx
+++ b/web/src/components/MediaLocations.tsx
@@ -1,5 +1,5 @@
 import { useMemo } from "react";
-import { Copy } from "lucide-react";
+import { Copy, Info } from "lucide-react";
 import { toast } from "sonner";
 import type { FileVersion } from "@/api/types";
 import { Button } from "@/components/ui/button";
@@ -14,6 +14,7 @@ interface MediaLocationsProps {
   emptyMessage?: string;
   compact?: boolean;
   summaryBuilder?: (version: FileVersion) => string;
+  onShowMediaInfo?: (fileId: number) => void;
 }
 
 interface MediaLocationEntry {
@@ -95,6 +96,7 @@ export default function MediaLocations({
   emptyMessage,
   compact = false,
   summaryBuilder = buildQualitySummary,
+  onShowMediaInfo,
 }: MediaLocationsProps) {
   const locations = useMemo(
     () => deriveMediaLocationsWithSummary(versions, summaryBuilder),
@@ -144,19 +146,34 @@ export default function MediaLocations({
                 </div>
               </div>
 
-              {location.folderPath ? (
-                <Button
-                  type="button"
-                  variant="ghost"
-                  size="icon"
-                  className="text-muted-foreground hover:text-foreground h-7 w-7 shrink-0"
-                  onClick={() => copyText(location.folderPath, "Copied folder path")}
-                  title="Copy full folder path"
-                  aria-label={`Copy full folder path for ${location.fileName}`}
-                >
-                  <Copy className="h-3.5 w-3.5" />
-                </Button>
-              ) : null}
+              <div className="flex shrink-0 items-center gap-1">
+                {onShowMediaInfo ? (
+                  <Button
+                    type="button"
+                    variant="ghost"
+                    size="icon"
+                    className="text-muted-foreground hover:text-foreground h-7 w-7"
+                    onClick={() => onShowMediaInfo(location.fileId)}
+                    title="View media info"
+                    aria-label={`View media info for ${location.fileName}`}
+                  >
+                    <Info className="h-3.5 w-3.5" />
+                  </Button>
+                ) : null}
+                {location.folderPath ? (
+                  <Button
+                    type="button"
+                    variant="ghost"
+                    size="icon"
+                    className="text-muted-foreground hover:text-foreground h-7 w-7"
+                    onClick={() => copyText(location.folderPath, "Copied folder path")}
+                    title="Copy full folder path"
+                    aria-label={`Copy full folder path for ${location.fileName}`}
+                  >
+                    <Copy className="h-3.5 w-3.5" />
+                  </Button>
+                ) : null}
+              </div>
             </div>
           </div>
         ))}

--- a/web/src/lib/mediaFormat.test.ts
+++ b/web/src/lib/mediaFormat.test.ts
@@ -1,0 +1,174 @@
+import { describe, expect, it } from "vitest";
+import {
+  compactHdrSuffix,
+  dolbyVisionLabel,
+  formatBitrate,
+  formatChannels,
+  formatCodecLabel,
+  formatFileSize,
+  formatMbpsFromKbps,
+  formatSampleRate,
+  mapAudioLabel,
+  prettyResolution,
+} from "./mediaFormat";
+
+describe("formatCodecLabel", () => {
+  it("maps known codecs to display labels", () => {
+    expect(formatCodecLabel("h264")).toBe("H.264");
+    expect(formatCodecLabel("hevc")).toBe("HEVC");
+    expect(formatCodecLabel("truehd")).toBe("TrueHD");
+    expect(formatCodecLabel("opus")).toBe("Opus");
+  });
+
+  it("uppercases unknown codecs", () => {
+    expect(formatCodecLabel("vp9")).toBe("VP9");
+  });
+
+  it("returns the fallback for missing codecs", () => {
+    expect(formatCodecLabel(undefined)).toBe("—");
+    expect(formatCodecLabel("  ")).toBe("—");
+    expect(formatCodecLabel("", "")).toBe("");
+  });
+});
+
+describe("mapAudioLabel", () => {
+  it("prefers Atmos over other markers", () => {
+    expect(mapAudioLabel("TrueHD Atmos")).toBe("Atmos");
+    expect(mapAudioLabel("eac3 atmos")).toBe("Atmos");
+  });
+
+  it("maps codec families", () => {
+    expect(mapAudioLabel("truehd")).toBe("TrueHD");
+    expect(mapAudioLabel("dts-hd ma")).toBe("DTS-HD");
+    expect(mapAudioLabel("dts:x")).toBe("DTS-HD");
+    expect(mapAudioLabel("dts")).toBe("DTS");
+    expect(mapAudioLabel("eac3")).toBe("EAC3");
+    expect(mapAudioLabel("e-ac-3")).toBe("EAC3");
+    expect(mapAudioLabel("aac")).toBe("AAC");
+    expect(mapAudioLabel("flac")).toBe("FLAC");
+  });
+
+  it("uppercases unknown codecs, unlike formatCodecLabel's curated casing", () => {
+    expect(mapAudioLabel("pcm_s24le")).toBe("PCM_S24LE");
+    expect(mapAudioLabel("mp3")).toBe("MP3");
+    expect(mapAudioLabel("opus")).toBe("OPUS");
+  });
+});
+
+describe("formatFileSize", () => {
+  it("formats bytes in GB", () => {
+    expect(formatFileSize(2 * 1024 ** 3)).toBe("2.0 GB");
+    expect(formatFileSize(1.5 * 1024 ** 3)).toBe("1.5 GB");
+  });
+
+  it("formats bytes in MB and KB", () => {
+    expect(formatFileSize(512 * 1024 ** 2)).toBe("512.0 MB");
+    expect(formatFileSize(2 * 1024)).toBe("2.0 KB");
+    expect(formatFileSize(100)).toBe("100 B");
+  });
+
+  it("uses IEC unit labels when requested", () => {
+    expect(formatFileSize(2 * 1024 ** 3, { iecUnits: true })).toBe("2.0 GiB");
+    expect(formatFileSize(512 * 1024 ** 2, { iecUnits: true })).toBe("512.0 MiB");
+    expect(formatFileSize(2 * 1024, { iecUnits: true })).toBe("2.0 KiB");
+  });
+
+  it("returns the fallback for zero, negative, and missing values", () => {
+    expect(formatFileSize(0)).toBe("");
+    expect(formatFileSize(-100)).toBe("");
+    expect(formatFileSize(undefined)).toBe("");
+    expect(formatFileSize(0, { fallback: "—" })).toBe("—");
+  });
+});
+
+describe("formatBitrate", () => {
+  it("formats kbps with thousands separators", () => {
+    expect(formatBitrate(24_500)).toBe("24,500 kbps");
+    expect(formatBitrate(640)).toBe("640 kbps");
+  });
+
+  it("returns the fallback for missing values", () => {
+    expect(formatBitrate(0)).toBe("");
+    expect(formatBitrate(undefined)).toBe("");
+    expect(formatBitrate(undefined, "—")).toBe("—");
+  });
+});
+
+describe("formatMbpsFromKbps", () => {
+  it("converts kbps to Mbps with one decimal", () => {
+    expect(formatMbpsFromKbps(24_500)).toBe("24.5 Mbps");
+    expect(formatMbpsFromKbps(800)).toBe("0.8 Mbps");
+  });
+
+  it("returns the fallback for missing values", () => {
+    expect(formatMbpsFromKbps(0)).toBe("—");
+    expect(formatMbpsFromKbps(undefined, "")).toBe("");
+  });
+});
+
+describe("formatSampleRate", () => {
+  it("formats sample rates in Hz", () => {
+    expect(formatSampleRate(48_000)).toBe("48,000 Hz");
+  });
+
+  it("returns the fallback for missing values", () => {
+    expect(formatSampleRate(0)).toBe("");
+    expect(formatSampleRate(undefined, "—")).toBe("—");
+  });
+});
+
+describe("formatChannels", () => {
+  it("maps channel counts to layout labels", () => {
+    expect(formatChannels(8)).toBe("7.1");
+    expect(formatChannels(6)).toBe("5.1");
+    expect(formatChannels(2)).toBe("stereo");
+    expect(formatChannels(3)).toBe("3 ch");
+  });
+
+  it("returns empty string for missing values", () => {
+    expect(formatChannels(undefined)).toBe("");
+    expect(formatChannels(0)).toBe("");
+  });
+});
+
+describe("dolbyVisionLabel", () => {
+  it("prefixes raw profile strings", () => {
+    expect(dolbyVisionLabel("Profile 8.1")).toBe("Dolby Vision Profile 8.1");
+  });
+
+  it("keeps labels that already carry the prefix", () => {
+    expect(dolbyVisionLabel("Dolby Vision Profile 5")).toBe("Dolby Vision Profile 5");
+  });
+});
+
+describe("prettyResolution", () => {
+  it("maps 2160p variants to 4K and 4320p variants to 8K", () => {
+    expect(prettyResolution("2160p")).toBe("4K");
+    expect(prettyResolution("4k")).toBe("4K");
+    expect(prettyResolution("uhd")).toBe("4K");
+    expect(prettyResolution("4320p")).toBe("8K");
+  });
+
+  it("keeps lowercase-p resolutions and uppercases unknowns", () => {
+    expect(prettyResolution("1080p")).toBe("1080p");
+    expect(prettyResolution("720p")).toBe("720p");
+    expect(prettyResolution("sd")).toBe("SD");
+  });
+
+  it("returns null for missing values", () => {
+    expect(prettyResolution(undefined)).toBeNull();
+    expect(prettyResolution("  ")).toBeNull();
+  });
+});
+
+describe("compactHdrSuffix", () => {
+  it("collapses Dolby Vision variants to DV and others to HDR", () => {
+    expect(compactHdrSuffix("DV HDR10")).toBe("DV");
+    expect(compactHdrSuffix("HDR10")).toBe("HDR");
+    expect(compactHdrSuffix("HLG")).toBe("HDR");
+  });
+
+  it("returns null for missing values", () => {
+    expect(compactHdrSuffix(undefined)).toBeNull();
+  });
+});

--- a/web/src/lib/mediaFormat.ts
+++ b/web/src/lib/mediaFormat.ts
@@ -1,0 +1,110 @@
+// Canonical media-spec formatting helpers shared by item detail views, the
+// player stats overlay, poster overlays, and admin views. Display policy
+// differences between surfaces (empty-string vs "—" fallback, GB vs GiB
+// labels) are expressed via parameters here instead of per-surface copies.
+
+export const CODEC_LABELS: Record<string, string> = {
+  aac: "AAC",
+  ac3: "AC3",
+  av1: "AV1",
+  dts: "DTS",
+  dtshd: "DTS-HD",
+  eac3: "EAC3",
+  flac: "FLAC",
+  h264: "H.264",
+  hevc: "HEVC",
+  mp3: "MP3",
+  opus: "Opus",
+  truehd: "TrueHD",
+};
+
+/** Exact-match codec display label; unknown codecs are uppercased. */
+export function formatCodecLabel(codec?: string, fallback = "—"): string {
+  const normalized = codec?.trim();
+  if (!normalized) {
+    return fallback;
+  }
+  return CODEC_LABELS[normalized.toLowerCase()] ?? normalized.toUpperCase();
+}
+
+/** Fuzzy audio-family label for quality badges ("truehd atmos" → "Atmos"). */
+export function mapAudioLabel(codec: string): string {
+  const lower = codec.toLowerCase();
+  if (lower.includes("atmos")) return "Atmos";
+  if (lower.includes("truehd")) return "TrueHD";
+  if (lower.includes("dts-hd") || lower.includes("dts:x")) return "DTS-HD";
+  if (lower.includes("dts")) return "DTS";
+  if (lower.includes("eac3") || lower.includes("e-ac-3")) return "EAC3";
+  if (lower.includes("aac")) return "AAC";
+  if (lower.includes("flac")) return "FLAC";
+  return codec.toUpperCase();
+}
+
+interface FormatFileSizeOptions {
+  fallback?: string;
+  /** Use IEC unit labels (GiB/MiB/KiB) instead of GB/MB/KB. Math is 1024-based either way. */
+  iecUnits?: boolean;
+}
+
+export function formatFileSize(bytes?: number, options: FormatFileSizeOptions = {}): string {
+  const { fallback = "", iecUnits = false } = options;
+  if (!isPositive(bytes)) return fallback;
+  const [giga, mega, kilo] = iecUnits ? ["GiB", "MiB", "KiB"] : ["GB", "MB", "KB"];
+  if (bytes >= 1024 ** 3) return `${(bytes / 1024 ** 3).toFixed(1)} ${giga}`;
+  if (bytes >= 1024 ** 2) return `${(bytes / 1024 ** 2).toFixed(1)} ${mega}`;
+  if (bytes >= 1024) return `${(bytes / 1024).toFixed(1)} ${kilo}`;
+  return `${bytes} B`;
+}
+
+export function formatBitrate(kbps?: number, fallback = ""): string {
+  if (!isPositive(kbps)) return fallback;
+  return `${Math.round(kbps).toLocaleString()} kbps`;
+}
+
+export function formatMbpsFromKbps(kbps?: number, fallback = "—"): string {
+  if (!isPositive(kbps)) return fallback;
+  return `${(kbps / 1000).toFixed(1)} Mbps`;
+}
+
+export function formatSampleRate(sampleRate?: number, fallback = ""): string {
+  if (!isPositive(sampleRate)) return fallback;
+  return `${sampleRate.toLocaleString()} Hz`;
+}
+
+export function formatChannels(channels?: number): string {
+  if (!channels || channels <= 0) return "";
+  if (channels === 8) return "7.1";
+  if (channels === 6) return "5.1";
+  if (channels === 2) return "stereo";
+  return `${channels} ch`;
+}
+
+/** Ensures a raw Dolby Vision label ("Profile 8.1") carries the "Dolby Vision" prefix. */
+export function dolbyVisionLabel(raw: string): string {
+  return raw.toLowerCase().startsWith("dolby vision") ? raw : `Dolby Vision ${raw}`;
+}
+
+// Kometa-style pretty resolution label: "2160p" → "4K", others keep their
+// lowercase-p form ("1080p", "720p"). Unknown values are uppercased so they
+// at least look intentional.
+export function prettyResolution(value: string | undefined): string | null {
+  if (!value) return null;
+  const v = value.toLowerCase().trim();
+  if (v === "") return null;
+  if (v === "2160p" || v === "4k" || v === "uhd") return "4K";
+  if (v === "4320p" || v === "8k") return "8K";
+  if (/^\d+p$/.test(v)) return v;
+  return value.toUpperCase();
+}
+
+// Compact HDR suffix used for combined Resolution+HDR badges. Any Dolby
+// Vision variant collapses to "DV"; any other HDR variant to "HDR".
+export function compactHdrSuffix(value: string | undefined): string | null {
+  if (!value) return null;
+  if (value.includes("DV")) return "DV";
+  return "HDR";
+}
+
+function isPositive(value?: number): value is number {
+  return Number.isFinite(value) && value != null && value > 0;
+}

--- a/web/src/lib/overlays/registry/tech.ts
+++ b/web/src/lib/overlays/registry/tech.ts
@@ -1,3 +1,4 @@
+import { compactHdrSuffix, prettyResolution } from "@/lib/mediaFormat";
 import type { OverlayDef, OverlayIconId } from "../types";
 
 // Tech overlays — derived from the media file (codec, container, resolution,
@@ -8,27 +9,6 @@ function hdrIcon(value: string | undefined): OverlayIconId | null {
   if (value.includes("DV")) return "dolby-vision";
   if (value.includes("HDR10")) return "hdr10";
   return "hdr";
-}
-
-// Kometa-style pretty resolution label: "2160p" → "4K", others keep their
-// lowercase-p form ("1080p", "720p"). Unknown values are uppercased so they
-// at least look intentional.
-function prettyResolution(value: string | undefined): string | null {
-  if (!value) return null;
-  const v = value.toLowerCase().trim();
-  if (v === "") return null;
-  if (v === "2160p" || v === "4k" || v === "uhd") return "4K";
-  if (v === "4320p" || v === "8k") return "8K";
-  if (/^\d+p$/.test(v)) return v;
-  return value.toUpperCase();
-}
-
-// Compact HDR suffix used for the combined Resolution+HDR badge. Any
-// Dolby Vision variant collapses to "DV"; any other HDR variant to "HDR".
-function compactHdrSuffix(value: string | undefined): string | null {
-  if (!value) return null;
-  if (value.includes("DV")) return "DV";
-  return "HDR";
 }
 
 function audioIcon(value: string | undefined): OverlayIconId | null {

--- a/web/src/pages/ItemDetail/EbookContent.tsx
+++ b/web/src/pages/ItemDetail/EbookContent.tsx
@@ -20,7 +20,8 @@ import DetailHero from "./DetailHero";
 import MetadataBadges from "./components/MetadataBadges";
 import ScoreRow from "./components/ScoreRow";
 import { getWatchedActionLabel } from "./watchedState";
-import { formatFileSize, formatPageCount, metadataLine } from "./components/versionFormatUtils";
+import { formatFileSize } from "@/lib/mediaFormat";
+import { formatPageCount, metadataLine } from "./components/versionFormatUtils";
 
 function authorNames(item: ItemDetail): string[] {
   const extensionAuthors = (item.ebook?.authors ?? [])

--- a/web/src/pages/ItemDetail/EpisodeContent.tsx
+++ b/web/src/pages/ItemDetail/EpisodeContent.tsx
@@ -1,4 +1,4 @@
-import { useMemo, useState } from "react";
+import { useCallback, useMemo, useState } from "react";
 import { useLocation, useNavigate } from "react-router";
 import type { FileVersion, ItemDetail } from "@/api/types";
 import type { PlayerSubtitleTrackSignature, PrePlaySubtitleSelection } from "@/player/types";
@@ -27,6 +27,7 @@ import ScoreRow from "./components/ScoreRow";
 import HeroCrewLine from "./components/HeroCrewLine";
 import ActionBar from "./components/ActionBar";
 import DetailBreadcrumb from "./components/DetailBreadcrumb";
+import MediaInfoDialog from "./components/MediaInfoDialog";
 import SubtitleSearchDialog from "./components/SubtitleSearchDialog";
 import { sortByResolution } from "./components/VersionFlyout";
 import { selectDefaultPlaybackVariantVersion } from "./components/versionRankingUtils";
@@ -64,6 +65,8 @@ export default function EpisodeContent({ item }: { item: ItemDetail & { type: "e
   const [editOpen, setEditOpen] = useState(false);
   const [downloadOpen, setDownloadOpen] = useState(false);
   const [subtitleSearchOpen, setSubtitleSearchOpen] = useState(false);
+  const [mediaInfoOpen, setMediaInfoOpen] = useState(false);
+  const [mediaInfoFileId, setMediaInfoFileId] = useState<number | null>(null);
   const refreshMetadataMutation = useRefreshItemMetadata();
   const redetectIntroMutation = useRedetectEpisodeIntro();
 
@@ -95,6 +98,13 @@ export default function EpisodeContent({ item }: { item: ItemDetail & { type: "e
         ? (sortedVersions.find((version) => version.file_id === manualSelectedFileId) ?? null)
         : null) ?? defaultSelectedVersion,
     [defaultSelectedVersion, manualSelectedFileId, sortedVersions],
+  );
+  const openMediaInfo = useCallback(
+    (fileId?: number) => {
+      setMediaInfoFileId(fileId ?? selectedVersion?.file_id ?? null);
+      setMediaInfoOpen(true);
+    },
+    [selectedVersion?.file_id],
   );
   const [audioSelectionMode, setAudioSelectionMode] = useState<"auto" | "explicit">("auto");
   const [explicitAudioTrackIndex, setExplicitAudioTrackIndex] = useState<number | null>(null);
@@ -327,6 +337,11 @@ export default function EpisodeContent({ item }: { item: ItemDetail & { type: "e
             canCurateMetadata={canCurateMetadata}
             canEditMarkers={canEditMarkers}
             onEditMetadata={canCurateMetadata ? () => setEditOpen(true) : undefined}
+            onShowMediaInfo={
+              canCurateMetadata && (item.versions?.length ?? 0) > 0
+                ? () => openMediaInfo()
+                : undefined
+            }
             versions={item.versions ?? []}
             playbackVariants={item.playback_variants}
             selectedVersion={selectedVersion}
@@ -359,7 +374,13 @@ export default function EpisodeContent({ item }: { item: ItemDetail & { type: "e
       />
 
       <div className="page-shell space-y-12 py-10 sm:space-y-14">
-        {canCurateMetadata && <MediaLocations title="Media locations" versions={item.versions} />}
+        {canCurateMetadata && (
+          <MediaLocations
+            title="Media locations"
+            versions={item.versions}
+            onShowMediaInfo={openMediaInfo}
+          />
+        )}
 
         {/* More Episodes carousel — most useful, so show first */}
         {siblingsLoading ? (
@@ -401,6 +422,15 @@ export default function EpisodeContent({ item }: { item: ItemDetail & { type: "e
         version={selectedVersion}
         title={title}
       />
+      {canCurateMetadata && (
+        <MediaInfoDialog
+          open={mediaInfoOpen}
+          onOpenChange={setMediaInfoOpen}
+          versions={item.versions ?? []}
+          title={title}
+          initialFileId={mediaInfoFileId}
+        />
+      )}
     </div>
   );
 }

--- a/web/src/pages/ItemDetail/MangaContent.tsx
+++ b/web/src/pages/ItemDetail/MangaContent.tsx
@@ -42,7 +42,8 @@ import DetailHero from "./DetailHero";
 import HeroCrewLine from "./components/HeroCrewLine";
 import MetadataBadges from "./components/MetadataBadges";
 import ScoreRow from "./components/ScoreRow";
-import { formatFileSize, formatPageCount, metadataLine } from "./components/versionFormatUtils";
+import { formatFileSize } from "@/lib/mediaFormat";
+import { formatPageCount, metadataLine } from "./components/versionFormatUtils";
 
 function genreHref(genre: string, libraryId?: number): string {
   const params = new URLSearchParams();

--- a/web/src/pages/ItemDetail/MovieContent.tsx
+++ b/web/src/pages/ItemDetail/MovieContent.tsx
@@ -1,4 +1,4 @@
-import { useMemo, useState } from "react";
+import { useCallback, useMemo, useState } from "react";
 import { useNavigate } from "react-router";
 import type { FileVersion, ItemDetail } from "@/api/types";
 import type { PlayerSubtitleTrackSignature, PrePlaySubtitleSelection } from "@/player/types";
@@ -27,6 +27,7 @@ import QualityBadges from "./components/QualityBadges";
 import ScoreRow from "./components/ScoreRow";
 import HeroCrewLine from "./components/HeroCrewLine";
 import ActionBar from "./components/ActionBar";
+import MediaInfoDialog from "./components/MediaInfoDialog";
 import SubtitleSearchDialog from "./components/SubtitleSearchDialog";
 import { sortByResolution } from "./components/VersionFlyout";
 import { selectDefaultPlaybackVariantVersion } from "./components/versionRankingUtils";
@@ -69,6 +70,8 @@ export default function MovieContent({ item }: { item: ItemDetail & { type: "mov
   const [splitOpen, setSplitOpen] = useState(false);
   const [downloadOpen, setDownloadOpen] = useState(false);
   const [subtitleSearchOpen, setSubtitleSearchOpen] = useState(false);
+  const [mediaInfoOpen, setMediaInfoOpen] = useState(false);
+  const [mediaInfoFileId, setMediaInfoFileId] = useState<number | null>(null);
 
   // Version selection state — drives the Play button and inline stream popovers.
   const sortedVersions = useMemo(() => sortByResolution(item.versions), [item.versions]);
@@ -98,6 +101,13 @@ export default function MovieContent({ item }: { item: ItemDetail & { type: "mov
         ? (sortedVersions.find((version) => version.file_id === manualSelectedFileId) ?? null)
         : null) ?? defaultSelectedVersion,
     [defaultSelectedVersion, manualSelectedFileId, sortedVersions],
+  );
+  const openMediaInfo = useCallback(
+    (fileId?: number) => {
+      setMediaInfoFileId(fileId ?? selectedVersion?.file_id ?? null);
+      setMediaInfoOpen(true);
+    },
+    [selectedVersion?.file_id],
   );
   const [audioSelectionMode, setAudioSelectionMode] = useState<"auto" | "explicit">("auto");
   const [explicitAudioTrackIndex, setExplicitAudioTrackIndex] = useState<number | null>(null);
@@ -273,6 +283,9 @@ export default function MovieContent({ item }: { item: ItemDetail & { type: "mov
             onSplitItem={
               canCurateMetadata && item.versions.length > 1 ? () => setSplitOpen(true) : undefined
             }
+            onShowMediaInfo={
+              canCurateMetadata && item.versions.length > 0 ? () => openMediaInfo() : undefined
+            }
             versions={item.versions}
             playbackVariants={item.playback_variants}
             selectedVersion={selectedVersion}
@@ -307,7 +320,13 @@ export default function MovieContent({ item }: { item: ItemDetail & { type: "mov
       />
 
       <div className="page-shell space-y-12 py-10 sm:space-y-14">
-        {canCurateMetadata && <MediaLocations title="Media locations" versions={item.versions} />}
+        {canCurateMetadata && (
+          <MediaLocations
+            title="Media locations"
+            versions={item.versions}
+            onShowMediaInfo={openMediaInfo}
+          />
+        )}
 
         {item.cast && item.cast.length > 0 && (
           <div>
@@ -362,6 +381,15 @@ export default function MovieContent({ item }: { item: ItemDetail & { type: "mov
         version={selectedVersion}
         title={title}
       />
+      {canCurateMetadata && (
+        <MediaInfoDialog
+          open={mediaInfoOpen}
+          onOpenChange={setMediaInfoOpen}
+          versions={item.versions}
+          title={title}
+          initialFileId={mediaInfoFileId}
+        />
+      )}
     </div>
   );
 }

--- a/web/src/pages/ItemDetail/components/ActionBar.tsx
+++ b/web/src/pages/ItemDetail/components/ActionBar.tsx
@@ -7,6 +7,7 @@ import {
   Captions,
   Download,
   FolderPlus,
+  Info,
   Loader2,
   MoreVertical,
   Play,
@@ -76,6 +77,7 @@ interface ActionBarProps {
   onEditMetadata?: () => void;
   onMatchItem?: () => void;
   onSplitItem?: () => void;
+  onShowMediaInfo?: () => void;
   isAdmin?: boolean;
   canCurateMetadata?: boolean;
   /** Enables the "Edit Markers" action (playable items only: movies/episodes). */
@@ -128,6 +130,7 @@ export default function ActionBar({
   onEditMetadata,
   onMatchItem,
   onSplitItem,
+  onShowMediaInfo,
   isAdmin = false,
   canCurateMetadata = false,
   canEditMarkers = false,
@@ -240,7 +243,8 @@ export default function ActionBar({
   );
   const hasAdminActions = Boolean(isAdmin && (contentId || onRedetectIntro));
   const hasMetadataActions = Boolean(
-    (canCurateMetadata && (onRefresh || onEditMetadata || onMatchItem)) || showMarkerEditor,
+    (canCurateMetadata && (onRefresh || onEditMetadata || onMatchItem || onShowMediaInfo)) ||
+    showMarkerEditor,
   );
 
   const formattedResumeTime = formatPlaybackTime(resumePositionSeconds ?? 0);
@@ -398,6 +402,12 @@ export default function ActionBar({
             {(hasAdminActions || hasMetadataActions) && (
               <>
                 {hasOverflowActions && <DropdownMenuSeparator />}
+                {canCurateMetadata && onShowMediaInfo && (
+                  <DropdownMenuItem onSelect={onShowMediaInfo}>
+                    <Info className="size-4" />
+                    Media Info
+                  </DropdownMenuItem>
+                )}
                 {isAdmin && contentId && (
                   <DropdownMenuItem
                     onSelect={() =>

--- a/web/src/pages/ItemDetail/components/AudioTracksPopover.tsx
+++ b/web/src/pages/ItemDetail/components/AudioTracksPopover.tsx
@@ -6,9 +6,9 @@ import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover";
 import { getLanguageName } from "@/player/utils/languageNames";
-import { audioTitle, formatChannels, compactAudioMeta } from "./versionFormatUtils";
+import { formatChannels, mapAudioLabel } from "@/lib/mediaFormat";
+import { audioTitle, compactAudioMeta } from "./versionFormatUtils";
 import { formatAudioTrackSummary, resolveAudioTrackSelection } from "./prePlaySelection";
-import { mapAudioLabel } from "./versionRankingUtils";
 
 interface AudioTracksPopoverProps {
   version: FileVersion | null;

--- a/web/src/pages/ItemDetail/components/MediaInfoDialog.tsx
+++ b/web/src/pages/ItemDetail/components/MediaInfoDialog.tsx
@@ -1,0 +1,117 @@
+import { useMemo } from "react";
+import type { FileVersion } from "@/api/types";
+import {
+  Accordion,
+  AccordionContent,
+  AccordionItem,
+  AccordionTrigger,
+} from "@/components/ui/accordion";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { buildDetailLine, buildQualitySummary, sortByResolution } from "./VersionFlyout";
+import { buildMediaSpecSections, type MediaSpecSection } from "./mediaSpecSections";
+
+interface MediaInfoDialogProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  versions: FileVersion[];
+  title: string;
+  /** Version to expand initially; falls back to the highest-quality version. */
+  initialFileId?: number | null;
+}
+
+function VersionSpecSheet({ sections }: { sections: MediaSpecSection[] }) {
+  return (
+    <div className="space-y-4">
+      {sections.map((section) => (
+        <div key={section.title}>
+          <div className="text-muted-foreground/70 mb-1.5 text-[11px] font-semibold tracking-wide uppercase">
+            {section.title}
+          </div>
+          <div className="divide-border/40 bg-background/40 divide-y rounded-lg border">
+            {section.rows.map((row) => (
+              <div
+                key={row.label}
+                className="flex items-baseline justify-between gap-4 px-3 py-1.5 text-sm"
+              >
+                <span className="text-muted-foreground shrink-0">{row.label}</span>
+                <span className="text-foreground min-w-0 text-right break-all">{row.value}</span>
+              </div>
+            ))}
+          </div>
+        </div>
+      ))}
+    </div>
+  );
+}
+
+export default function MediaInfoDialog({
+  open,
+  onOpenChange,
+  versions,
+  title,
+  initialFileId,
+}: MediaInfoDialogProps) {
+  const sorted = useMemo(() => sortByResolution(versions), [versions]);
+  const initialValue = useMemo(() => {
+    const target = sorted.find((version) => version.file_id === initialFileId) ?? sorted[0];
+    return target ? String(target.file_id) : undefined;
+  }, [initialFileId, sorted]);
+  const onlyVersion = sorted.length === 1 ? sorted[0] : undefined;
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="max-w-2xl overflow-hidden sm:max-w-2xl">
+        <DialogHeader className="min-w-0">
+          <DialogTitle>Media Info</DialogTitle>
+          <DialogDescription className="truncate">{title}</DialogDescription>
+        </DialogHeader>
+
+        <div className="-mr-1 max-h-[65vh] min-w-0 overflow-x-hidden overflow-y-auto pr-1">
+          {onlyVersion ? (
+            <VersionSpecSheet sections={buildMediaSpecSections(onlyVersion)} />
+          ) : (
+            // DialogContent unmounts when closed, so defaultValue re-targets on each open.
+            <Accordion type="multiple" defaultValue={initialValue ? [initialValue] : []}>
+              {sorted.map((version, index) => {
+                const summary =
+                  buildQualitySummary(version) || version.file_name || `Version ${index + 1}`;
+                const detail = buildDetailLine(version);
+
+                return (
+                  <AccordionItem key={version.file_id} value={String(version.file_id)}>
+                    <AccordionTrigger className="py-3 hover:no-underline">
+                      <span className="min-w-0 flex-1">
+                        <span className="text-foreground block truncate text-sm font-medium">
+                          {summary}
+                        </span>
+                        {detail && (
+                          <span className="text-muted-foreground mt-0.5 block text-xs font-normal">
+                            {detail}
+                          </span>
+                        )}
+                      </span>
+                    </AccordionTrigger>
+                    <AccordionContent>
+                      <VersionSpecSheet sections={buildMediaSpecSections(version)} />
+                    </AccordionContent>
+                  </AccordionItem>
+                );
+              })}
+            </Accordion>
+          )}
+          {sorted.length === 0 && (
+            <div className="text-muted-foreground rounded-xl border border-dashed px-4 py-6 text-center text-sm">
+              No media files for this item.
+            </div>
+          )}
+        </div>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/web/src/pages/ItemDetail/components/VersionFlyout.tsx
+++ b/web/src/pages/ItemDetail/components/VersionFlyout.tsx
@@ -5,8 +5,9 @@ import {
   DropdownMenuLabel,
   DropdownMenuSeparator,
 } from "@/components/ui/dropdown-menu";
-import { formatFileSize, extractSourceHint } from "./versionFormatUtils";
-import { resolutionScore, mapAudioLabel } from "./versionRankingUtils";
+import { formatFileSize, mapAudioLabel } from "@/lib/mediaFormat";
+import { extractSourceHint } from "./versionFormatUtils";
+import { resolutionScore } from "./versionRankingUtils";
 
 // ---------------------------------------------------------------------------
 // Exported helper functions (also used by tests)

--- a/web/src/pages/ItemDetail/components/mediaSpecSections.test.ts
+++ b/web/src/pages/ItemDetail/components/mediaSpecSections.test.ts
@@ -1,0 +1,338 @@
+import { describe, expect, it } from "vitest";
+import type { FileVersion, VersionVideoTrack } from "@/api/types";
+import type { MediaSpecSection } from "./mediaSpecSections";
+import {
+  buildAudioSections,
+  buildGeneralSection,
+  buildMediaSpecSections,
+  buildSubtitleSections,
+  buildVideoSections,
+  formatChromaSubsampling,
+  formatDolbyVisionLabel,
+  formatDurationSeconds,
+  formatVideoLevel,
+  formatVideoRangeLabel,
+} from "./mediaSpecSections";
+
+function makeVersion(overrides: Partial<FileVersion> = {}): FileVersion {
+  return {
+    file_id: 1,
+    resolution: "2160p",
+    codec_video: "hevc",
+    codec_audio: "truehd",
+    hdr: true,
+    container: "mkv",
+    file_size: 0,
+    duration: 0,
+    bitrate: 0,
+    ...overrides,
+  };
+}
+
+function rowValue(rows: Array<{ label: string; value: string }>, label: string): string | null {
+  return rows.find((row) => row.label === label)?.value ?? null;
+}
+
+function sectionAt(sections: MediaSpecSection[], index: number): MediaSpecSection {
+  const section = sections[index];
+  if (!section) throw new Error(`expected a section at index ${index}`);
+  return section;
+}
+
+describe("formatChromaSubsampling", () => {
+  it("maps common yuv pixel formats", () => {
+    expect(formatChromaSubsampling("yuv420p")).toBe("4:2:0");
+    expect(formatChromaSubsampling("yuv420p10le")).toBe("4:2:0");
+    expect(formatChromaSubsampling("yuv422p")).toBe("4:2:2");
+    expect(formatChromaSubsampling("yuv444p10le")).toBe("4:4:4");
+    expect(formatChromaSubsampling("yuv411p")).toBe("4:1:1");
+  });
+
+  it("maps hardware-style formats to 4:2:0", () => {
+    expect(formatChromaSubsampling("nv12")).toBe("4:2:0");
+    expect(formatChromaSubsampling("p010le")).toBe("4:2:0");
+  });
+
+  it("returns empty string for unknown or missing formats", () => {
+    expect(formatChromaSubsampling("gray")).toBe("");
+    expect(formatChromaSubsampling("")).toBe("");
+    expect(formatChromaSubsampling(undefined)).toBe("");
+  });
+});
+
+describe("formatDolbyVisionLabel", () => {
+  it("returns empty string without any DV data", () => {
+    expect(formatDolbyVisionLabel({})).toBe("");
+  });
+
+  it("prefixes raw profile strings with Dolby Vision", () => {
+    expect(formatDolbyVisionLabel({ dolby_vision: "Profile 8.1" })).toBe(
+      "Dolby Vision Profile 8.1",
+    );
+  });
+
+  it("keeps labels that already start with Dolby Vision", () => {
+    expect(formatDolbyVisionLabel({ dolby_vision: "Dolby Vision Profile 5" })).toBe(
+      "Dolby Vision Profile 5",
+    );
+  });
+
+  it("falls back to the numeric profile", () => {
+    expect(formatDolbyVisionLabel({ dv_profile: 8 })).toBe("Dolby Vision Profile 8");
+  });
+
+  it("appends base-layer compatibility and enhancement layer details", () => {
+    expect(formatDolbyVisionLabel({ dolby_vision: "Profile 8.1", dv_bl_compat_id: 1 })).toBe(
+      "Dolby Vision Profile 8.1 (HDR10 compatible)",
+    );
+    expect(
+      formatDolbyVisionLabel({
+        dolby_vision: "Profile 7.6",
+        dv_bl_compat_id: 6,
+        dv_el_present: true,
+      }),
+    ).toBe("Dolby Vision Profile 7.6 (HDR10 compatible, EL)");
+    expect(formatDolbyVisionLabel({ dolby_vision: "Profile 8.2", dv_bl_compat_id: 2 })).toBe(
+      "Dolby Vision Profile 8.2 (SDR compatible)",
+    );
+  });
+});
+
+describe("formatVideoRangeLabel", () => {
+  it("combines Dolby Vision with HDR10+", () => {
+    const track: VersionVideoTrack = {
+      dolby_vision: "Profile 8.1",
+      dv_bl_compat_id: 1,
+      hdr10_plus: true,
+    };
+    expect(formatVideoRangeLabel(track)).toBe(
+      "Dolby Vision Profile 8.1 (HDR10 compatible) · HDR10+",
+    );
+  });
+
+  it("reports plain HDR10+ without Dolby Vision", () => {
+    expect(formatVideoRangeLabel({ hdr10_plus: true })).toBe("HDR10+");
+  });
+
+  it("maps video_range_type enum values to friendly labels", () => {
+    expect(formatVideoRangeLabel({ video_range_type: "HDR10" })).toBe("HDR10");
+    expect(formatVideoRangeLabel({ video_range_type: "DOVIWithHDR10" })).toBe(
+      "Dolby Vision (HDR10 compatible)",
+    );
+    expect(formatVideoRangeLabel({ video_range_type: "HLG" })).toBe("HLG");
+  });
+
+  it("passes through unknown range types and falls back to video_range", () => {
+    expect(formatVideoRangeLabel({ video_range_type: "FancyNewRange" })).toBe("FancyNewRange");
+    expect(formatVideoRangeLabel({ video_range: "SDR" })).toBe("SDR");
+    expect(formatVideoRangeLabel({})).toBe("");
+  });
+});
+
+describe("formatVideoLevel", () => {
+  it("scales H.264 levels by 10", () => {
+    expect(formatVideoLevel("h264", 41)).toBe("4.1");
+    expect(formatVideoLevel("avc", 40)).toBe("4");
+  });
+
+  it("scales HEVC levels by 30", () => {
+    expect(formatVideoLevel("hevc", 153)).toBe("5.1");
+    expect(formatVideoLevel("hevc", 120)).toBe("4");
+  });
+
+  it("decodes AV1 level indexes", () => {
+    expect(formatVideoLevel("av1", 13)).toBe("5.1");
+    expect(formatVideoLevel("av1", 8)).toBe("4.0");
+  });
+
+  it("returns raw values for unknown codecs and empty for missing levels", () => {
+    expect(formatVideoLevel("vp9", 31)).toBe("31");
+    expect(formatVideoLevel("hevc", 0)).toBe("");
+    expect(formatVideoLevel(undefined, undefined)).toBe("");
+  });
+});
+
+describe("formatDurationSeconds", () => {
+  it("formats hours, minutes, and seconds", () => {
+    expect(formatDurationSeconds(2 * 3600 + 14 * 60 + 32)).toBe("2h 14m 32s");
+    expect(formatDurationSeconds(14 * 60 + 32)).toBe("14m 32s");
+    expect(formatDurationSeconds(59)).toBe("59s");
+  });
+
+  it("returns empty string for missing durations", () => {
+    expect(formatDurationSeconds(0)).toBe("");
+    expect(formatDurationSeconds(undefined)).toBe("");
+  });
+});
+
+describe("buildGeneralSection", () => {
+  it("includes container, size, duration, bitrate, and path", () => {
+    const section = buildGeneralSection(
+      makeVersion({
+        container: "mkv",
+        file_size: 2 * 1024 ** 3,
+        duration: 3600,
+        bitrate: 24_500,
+        file_path: "/media/movies/Example (2024)/Example.mkv",
+      }),
+    );
+    expect(section.title).toBe("General");
+    expect(rowValue(section.rows, "Container")).toBe("MKV");
+    expect(rowValue(section.rows, "File Size")).toBe("2.0 GB");
+    expect(rowValue(section.rows, "Duration")).toBe("1h 0m 0s");
+    expect(rowValue(section.rows, "Overall Bitrate")).toBe("24,500 kbps");
+    expect(rowValue(section.rows, "File Path")).toBe("/media/movies/Example (2024)/Example.mkv");
+  });
+
+  it("omits the file path row when the server strips it", () => {
+    const section = buildGeneralSection(makeVersion({ container: "mkv" }));
+    expect(rowValue(section.rows, "File Path")).toBeNull();
+  });
+});
+
+describe("buildVideoSections", () => {
+  it("builds the full spec rows for a Dolby Vision HEVC track", () => {
+    const sections = buildVideoSections(
+      makeVersion({
+        video_tracks: [
+          {
+            codec: "hevc",
+            profile: "Main 10",
+            level: 153,
+            width: 3840,
+            height: 2160,
+            aspect_ratio: "16:9",
+            frame_rate: "23.976",
+            bitrate: 22_000,
+            bit_depth: 10,
+            pixel_format: "yuv420p10le",
+            dolby_vision: "Profile 8.1",
+            dv_bl_compat_id: 1,
+            hdr10_plus: false,
+            video_range: "HDR",
+            video_range_type: "DOVIWithHDR10",
+            color_primaries: "bt2020",
+            color_transfer: "smpte2084",
+            color_space: "bt2020nc",
+            reference_frames: 4,
+            interlaced: false,
+          },
+        ],
+      }),
+    );
+
+    const section = sectionAt(sections, 0);
+    expect(section.title).toBe("Video");
+    expect(rowValue(section.rows, "Codec")).toBe("HEVC");
+    expect(rowValue(section.rows, "Profile")).toBe("Main 10");
+    expect(rowValue(section.rows, "Level")).toBe("5.1");
+    expect(rowValue(section.rows, "Resolution")).toBe("3840x2160");
+    expect(rowValue(section.rows, "Frame Rate")).toBe("23.976 fps");
+    expect(rowValue(section.rows, "Bitrate")).toBe("22,000 kbps");
+    expect(rowValue(section.rows, "Bit Depth")).toBe("10-bit");
+    expect(rowValue(section.rows, "Chroma Subsampling")).toBe("4:2:0");
+    expect(rowValue(section.rows, "Dynamic Range")).toBe(
+      "Dolby Vision Profile 8.1 (HDR10 compatible)",
+    );
+    expect(rowValue(section.rows, "Color Primaries")).toBe("bt2020");
+    expect(rowValue(section.rows, "Reference Frames")).toBe("4");
+    expect(rowValue(section.rows, "Scan")).toBe("Progressive");
+  });
+
+  it("omits empty fields for sparse SDR tracks and numbers multiple tracks", () => {
+    const sections = buildVideoSections(
+      makeVersion({
+        video_tracks: [
+          { codec: "h264", width: 1920, height: 1080, interlaced: true },
+          { codec: "mjpeg" },
+        ],
+      }),
+    );
+    expect(sections).toHaveLength(2);
+    const first = sectionAt(sections, 0);
+    expect(first.title).toBe("Video 1");
+    expect(sectionAt(sections, 1).title).toBe("Video 2");
+    expect(rowValue(first.rows, "Scan")).toBe("Interlaced");
+    expect(rowValue(first.rows, "Dynamic Range")).toBeNull();
+    expect(rowValue(first.rows, "Chroma Subsampling")).toBeNull();
+    expect(rowValue(first.rows, "Bitrate")).toBeNull();
+  });
+});
+
+describe("buildAudioSections", () => {
+  it("builds labeled rows per audio track", () => {
+    const sections = buildAudioSections(
+      makeVersion({
+        audio_tracks: [
+          {
+            embedded_title: "TrueHD Atmos 7.1",
+            language: "eng",
+            codec: "truehd",
+            layout: "7.1",
+            channels: 8,
+            bitrate: 4_500,
+            sample_rate: 48_000,
+            bit_depth: 24,
+            default: true,
+          },
+          { language: "fra", codec: "aac", channels: 2, default: false },
+        ],
+      }),
+    );
+
+    expect(sections).toHaveLength(2);
+    const first = sectionAt(sections, 0);
+    expect(first.title).toBe("Audio 1");
+    expect(rowValue(first.rows, "Title")).toBe("TrueHD Atmos 7.1");
+    expect(rowValue(first.rows, "Language")).toBe("English");
+    expect(rowValue(first.rows, "Codec")).toBe("TrueHD");
+    expect(rowValue(first.rows, "Layout")).toBe("7.1");
+    expect(rowValue(first.rows, "Channels")).toBe("7.1");
+    expect(rowValue(first.rows, "Sample Rate")).toBe("48,000 Hz");
+    expect(rowValue(first.rows, "Bit Depth")).toBe("24-bit");
+    expect(rowValue(first.rows, "Default")).toBe("Yes");
+    expect(rowValue(sectionAt(sections, 1).rows, "Default")).toBeNull();
+  });
+});
+
+describe("buildSubtitleSections", () => {
+  it("distinguishes embedded and external tracks", () => {
+    const sections = buildSubtitleSections(
+      makeVersion({
+        subtitle_tracks: [
+          { language: "eng", codec: "subrip", forced: true, default: false },
+          {
+            language: "spa",
+            codec: "srt",
+            external: true,
+            file_name: "Example.spa.srt",
+            hearing_impaired: true,
+          },
+        ],
+      }),
+    );
+
+    const embedded = sectionAt(sections, 0);
+    const external = sectionAt(sections, 1);
+    expect(rowValue(embedded.rows, "Source")).toBe("Embedded");
+    expect(rowValue(embedded.rows, "Forced")).toBe("Yes");
+    expect(rowValue(embedded.rows, "File")).toBeNull();
+    expect(rowValue(external.rows, "Source")).toBe("External");
+    expect(rowValue(external.rows, "File")).toBe("Example.spa.srt");
+    expect(rowValue(external.rows, "Hearing Impaired")).toBe("Yes");
+  });
+});
+
+describe("buildMediaSpecSections", () => {
+  it("orders sections General, Video, Audio, Subtitle and drops empty groups", () => {
+    const sections = buildMediaSpecSections(
+      makeVersion({
+        container: "mkv",
+        file_size: 1024 ** 3,
+        video_tracks: [{ codec: "hevc" }],
+        audio_tracks: [{ codec: "aac", channels: 2 }],
+      }),
+    );
+    expect(sections.map((section) => section.title)).toEqual(["General", "Video", "Audio"]);
+  });
+});

--- a/web/src/pages/ItemDetail/components/mediaSpecSections.test.ts
+++ b/web/src/pages/ItemDetail/components/mediaSpecSections.test.ts
@@ -96,6 +96,28 @@ describe("formatDolbyVisionLabel", () => {
       "Dolby Vision Profile 8.2 (SDR compatible)",
     );
   });
+
+  it("falls back to video_range_type for compatibility when DV side-data fields are missing", () => {
+    expect(
+      formatDolbyVisionLabel({ dolby_vision: "Profile 8", video_range_type: "DOVIWithHDR10" }),
+    ).toBe("Dolby Vision Profile 8 (HDR10 compatible)");
+    expect(
+      formatDolbyVisionLabel({ dolby_vision: "Profile 8", video_range_type: "DOVIWithHLG" }),
+    ).toBe("Dolby Vision Profile 8 (HLG compatible)");
+    expect(formatDolbyVisionLabel({ dolby_vision: "Profile 5", video_range_type: "DOVI" })).toBe(
+      "Dolby Vision Profile 5",
+    );
+  });
+
+  it("prefers explicit DV side-data fields over the video_range_type fallback", () => {
+    expect(
+      formatDolbyVisionLabel({
+        dolby_vision: "Profile 8.2",
+        dv_bl_compat_id: 2,
+        video_range_type: "DOVIWithHDR10",
+      }),
+    ).toBe("Dolby Vision Profile 8.2 (SDR compatible)");
+  });
 });
 
 describe("formatVideoRangeLabel", () => {
@@ -112,6 +134,18 @@ describe("formatVideoRangeLabel", () => {
 
   it("reports plain HDR10+ without Dolby Vision", () => {
     expect(formatVideoRangeLabel({ hdr10_plus: true })).toBe("HDR10+");
+    expect(formatVideoRangeLabel({ hdr10_plus: true, video_range_type: "HDR10Plus" })).toBe(
+      "HDR10+",
+    );
+  });
+
+  it("keeps the DV hint from video_range_type when hdr10_plus is set without raw DV fields", () => {
+    expect(formatVideoRangeLabel({ hdr10_plus: true, video_range_type: "DOVIWithHDR10Plus" })).toBe(
+      "Dolby Vision · HDR10+",
+    );
+    expect(formatVideoRangeLabel({ hdr10_plus: true, video_range_type: "HDR10" })).toBe(
+      "HDR10 · HDR10+",
+    );
   });
 
   it("maps video_range_type enum values to friendly labels", () => {

--- a/web/src/pages/ItemDetail/components/mediaSpecSections.ts
+++ b/web/src/pages/ItemDetail/components/mediaSpecSections.ts
@@ -1,0 +1,217 @@
+import type { FileVersion, VersionVideoTrack } from "@/api/types";
+import {
+  dolbyVisionLabel,
+  formatBitrate,
+  formatChannels,
+  formatFileSize,
+  formatSampleRate,
+  mapAudioLabel,
+} from "@/lib/mediaFormat";
+import { formatAddedAt, formatLanguageName } from "./versionFormatUtils";
+
+export interface MediaSpecRow {
+  label: string;
+  value: string;
+}
+
+export interface MediaSpecSection {
+  title: string;
+  rows: MediaSpecRow[];
+}
+
+const CHROMA_SUBSAMPLING_PATTERNS: Array<{ pattern: RegExp; label: string }> = [
+  { pattern: /444/, label: "4:4:4" },
+  { pattern: /440/, label: "4:4:0" },
+  { pattern: /422/, label: "4:2:2" },
+  { pattern: /420|^nv12|^nv21|^p010|^p016/, label: "4:2:0" },
+  { pattern: /411/, label: "4:1:1" },
+  { pattern: /410/, label: "4:1:0" },
+];
+
+export function formatChromaSubsampling(pixelFormat?: string): string {
+  const normalized = pixelFormat?.trim().toLowerCase();
+  if (!normalized) return "";
+  for (const { pattern, label } of CHROMA_SUBSAMPLING_PATTERNS) {
+    if (pattern.test(normalized)) return label;
+  }
+  return "";
+}
+
+const DV_BL_COMPAT_LABELS: Record<number, string> = {
+  1: "HDR10",
+  2: "SDR",
+  4: "HLG",
+  6: "HDR10",
+};
+
+export function formatDolbyVisionLabel(track: VersionVideoTrack): string {
+  const raw = track.dolby_vision?.trim() ?? "";
+  if (!raw && !track.dv_profile) return "";
+
+  const base = raw ? dolbyVisionLabel(raw) : `Dolby Vision Profile ${track.dv_profile}`;
+
+  const compat = track.dv_bl_compat_id != null ? DV_BL_COMPAT_LABELS[track.dv_bl_compat_id] : "";
+  const details = [compat ? `${compat} compatible` : "", track.dv_el_present ? "EL" : ""].filter(
+    Boolean,
+  );
+
+  return details.length > 0 ? `${base} (${details.join(", ")})` : base;
+}
+
+// Friendly names for the Jellyfin-style video_range_type enum the scanner derives.
+const VIDEO_RANGE_TYPE_LABELS: Record<string, string> = {
+  SDR: "SDR",
+  HDR10: "HDR10",
+  HDR10Plus: "HDR10+",
+  HLG: "HLG",
+  DOVI: "Dolby Vision",
+  DOVIWithEL: "Dolby Vision (with EL)",
+  DOVIWithELHDR10Plus: "Dolby Vision (with EL) · HDR10+",
+  DOVIWithHDR10: "Dolby Vision (HDR10 compatible)",
+  DOVIWithHDR10Plus: "Dolby Vision · HDR10+",
+  DOVIWithHLG: "Dolby Vision (HLG compatible)",
+  DOVIWithSDR: "Dolby Vision (SDR compatible)",
+};
+
+export function formatVideoRangeLabel(track: VersionVideoTrack): string {
+  const dolbyVision = formatDolbyVisionLabel(track);
+  if (dolbyVision) {
+    return track.hdr10_plus ? `${dolbyVision} · HDR10+` : dolbyVision;
+  }
+  if (track.hdr10_plus) return "HDR10+";
+
+  const rangeType = track.video_range_type?.trim();
+  if (rangeType) return VIDEO_RANGE_TYPE_LABELS[rangeType] ?? rangeType;
+
+  return track.video_range?.trim() ?? "";
+}
+
+export function formatVideoLevel(codec?: string, level?: number): string {
+  if (!level || level <= 0) return "";
+  const normalized = codec?.toLowerCase() ?? "";
+  if (normalized.includes("hevc") || normalized.includes("h265") || normalized.includes("265")) {
+    return trimLevel(level / 30);
+  }
+  if (normalized.includes("avc") || normalized.includes("h264") || normalized.includes("264")) {
+    return trimLevel(level / 10);
+  }
+  if (normalized.includes("av1")) {
+    return `${2 + (level >> 2)}.${level & 3}`;
+  }
+  return String(level);
+}
+
+function trimLevel(value: number): string {
+  const rounded = Math.round(value * 10) / 10;
+  return Number.isInteger(rounded) ? String(rounded) : rounded.toFixed(1);
+}
+
+export function formatDurationSeconds(seconds?: number): string {
+  if (!seconds || seconds <= 0) return "";
+  const total = Math.floor(seconds);
+  const h = Math.floor(total / 3600);
+  const m = Math.floor((total % 3600) / 60);
+  const s = total % 60;
+  if (h > 0) return `${h}h ${m}m ${s}s`;
+  if (m > 0) return `${m}m ${s}s`;
+  return `${s}s`;
+}
+
+function pushRow(rows: MediaSpecRow[], label: string, value?: string | false) {
+  if (value) rows.push({ label, value });
+}
+
+function yesIf(flag?: boolean): string {
+  return flag ? "Yes" : "";
+}
+
+function sectionTitle(kind: string, index: number, total: number): string {
+  return total > 1 ? `${kind} ${index + 1}` : kind;
+}
+
+function trackTitle(track: { title?: string; embedded_title?: string }): string {
+  return track.title ?? track.embedded_title ?? "";
+}
+
+export function buildGeneralSection(version: FileVersion): MediaSpecSection {
+  const rows: MediaSpecRow[] = [];
+  pushRow(rows, "Container", version.container ? version.container.toUpperCase() : "");
+  pushRow(rows, "File Size", formatFileSize(version.file_size));
+  pushRow(rows, "Duration", formatDurationSeconds(version.duration));
+  pushRow(rows, "Overall Bitrate", formatBitrate(version.bitrate));
+  pushRow(rows, "Edition", version.edition_raw);
+  pushRow(rows, "Added", formatAddedAt(version.added_at));
+  pushRow(rows, "File Path", version.file_path?.trim());
+  return { title: "General", rows };
+}
+
+export function buildVideoSections(version: FileVersion): MediaSpecSection[] {
+  const tracks = version.video_tracks ?? [];
+  return tracks.map((track, index) => {
+    const rows: MediaSpecRow[] = [];
+    pushRow(rows, "Codec", track.codec ? track.codec.toUpperCase() : "");
+    pushRow(rows, "Profile", track.profile);
+    pushRow(rows, "Level", formatVideoLevel(track.codec, track.level));
+    pushRow(
+      rows,
+      "Resolution",
+      track.width && track.height ? `${track.width}x${track.height}` : "",
+    );
+    pushRow(rows, "Aspect Ratio", track.aspect_ratio);
+    pushRow(rows, "Frame Rate", track.frame_rate ? `${track.frame_rate} fps` : "");
+    pushRow(rows, "Bitrate", formatBitrate(track.bitrate));
+    pushRow(rows, "Bit Depth", track.bit_depth ? `${track.bit_depth}-bit` : "");
+    pushRow(rows, "Pixel Format", track.pixel_format);
+    pushRow(rows, "Chroma Subsampling", formatChromaSubsampling(track.pixel_format));
+    pushRow(rows, "Dynamic Range", formatVideoRangeLabel(track));
+    pushRow(rows, "Color Primaries", track.color_primaries);
+    pushRow(rows, "Color Transfer", track.color_transfer);
+    pushRow(rows, "Color Space", track.color_space);
+    pushRow(rows, "Reference Frames", track.reference_frames ? String(track.reference_frames) : "");
+    pushRow(rows, "Scan", track.interlaced ? "Interlaced" : "Progressive");
+    return { title: sectionTitle("Video", index, tracks.length), rows };
+  });
+}
+
+export function buildAudioSections(version: FileVersion): MediaSpecSection[] {
+  const tracks = version.audio_tracks ?? [];
+  return tracks.map((track, index) => {
+    const rows: MediaSpecRow[] = [];
+    pushRow(rows, "Title", trackTitle(track));
+    pushRow(rows, "Language", formatLanguageName(track.language));
+    pushRow(rows, "Codec", track.codec ? mapAudioLabel(track.codec) : "");
+    pushRow(rows, "Layout", track.layout);
+    pushRow(rows, "Channels", formatChannels(track.channels));
+    pushRow(rows, "Bitrate", formatBitrate(track.bitrate));
+    pushRow(rows, "Sample Rate", formatSampleRate(track.sample_rate));
+    pushRow(rows, "Bit Depth", track.bit_depth ? `${track.bit_depth}-bit` : "");
+    pushRow(rows, "Default", yesIf(track.default));
+    return { title: sectionTitle("Audio", index, tracks.length), rows };
+  });
+}
+
+export function buildSubtitleSections(version: FileVersion): MediaSpecSection[] {
+  const tracks = version.subtitle_tracks ?? [];
+  return tracks.map((track, index) => {
+    const rows: MediaSpecRow[] = [];
+    pushRow(rows, "Title", trackTitle(track));
+    pushRow(rows, "Language", formatLanguageName(track.language));
+    pushRow(rows, "Format", track.codec ? track.codec.toUpperCase() : "");
+    pushRow(rows, "Source", track.external ? "External" : "Embedded");
+    pushRow(rows, "File", track.external ? track.file_name : "");
+    pushRow(rows, "Resolution", track.resolution);
+    pushRow(rows, "Forced", yesIf(track.forced));
+    pushRow(rows, "Default", yesIf(track.default));
+    pushRow(rows, "Hearing Impaired", yesIf(track.hearing_impaired));
+    return { title: sectionTitle("Subtitle", index, tracks.length), rows };
+  });
+}
+
+export function buildMediaSpecSections(version: FileVersion): MediaSpecSection[] {
+  return [
+    buildGeneralSection(version),
+    ...buildVideoSections(version),
+    ...buildAudioSections(version),
+    ...buildSubtitleSections(version),
+  ].filter((section) => section.rows.length > 0);
+}

--- a/web/src/pages/ItemDetail/components/mediaSpecSections.ts
+++ b/web/src/pages/ItemDetail/components/mediaSpecSections.ts
@@ -44,6 +44,17 @@ const DV_BL_COMPAT_LABELS: Record<number, string> = {
   6: "HDR10",
 };
 
+// Compatibility details recoverable from the scanner-derived video_range_type
+// enum when ffprobe omitted the explicit DV side-data fields (probe.go still
+// classifies profile-8 files via color_transfer in that case).
+const DV_RANGE_TYPE_DETAILS: Record<string, string> = {
+  DOVIWithEL: "EL",
+  DOVIWithELHDR10Plus: "EL",
+  DOVIWithHDR10: "HDR10 compatible",
+  DOVIWithSDR: "SDR compatible",
+  DOVIWithHLG: "HLG compatible",
+};
+
 export function formatDolbyVisionLabel(track: VersionVideoTrack): string {
   const raw = track.dolby_vision?.trim() ?? "";
   if (!raw && !track.dv_profile) return "";
@@ -54,6 +65,10 @@ export function formatDolbyVisionLabel(track: VersionVideoTrack): string {
   const details = [compat ? `${compat} compatible` : "", track.dv_el_present ? "EL" : ""].filter(
     Boolean,
   );
+  if (details.length === 0) {
+    const rangeDetail = DV_RANGE_TYPE_DETAILS[track.video_range_type?.trim() ?? ""];
+    if (rangeDetail) details.push(rangeDetail);
+  }
 
   return details.length > 0 ? `${base} (${details.join(", ")})` : base;
 }
@@ -78,12 +93,14 @@ export function formatVideoRangeLabel(track: VersionVideoTrack): string {
   if (dolbyVision) {
     return track.hdr10_plus ? `${dolbyVision} · HDR10+` : dolbyVision;
   }
-  if (track.hdr10_plus) return "HDR10+";
 
   const rangeType = track.video_range_type?.trim();
-  if (rangeType) return VIDEO_RANGE_TYPE_LABELS[rangeType] ?? rangeType;
+  if (rangeType) {
+    const label = VIDEO_RANGE_TYPE_LABELS[rangeType] ?? rangeType;
+    return track.hdr10_plus && !label.includes("HDR10+") ? `${label} · HDR10+` : label;
+  }
 
-  return track.video_range?.trim() ?? "";
+  return track.hdr10_plus ? "HDR10+" : (track.video_range?.trim() ?? "");
 }
 
 export function formatVideoLevel(codec?: string, level?: number): string {

--- a/web/src/pages/ItemDetail/components/prePlaySelection.ts
+++ b/web/src/pages/ItemDetail/components/prePlaySelection.ts
@@ -14,12 +14,11 @@ import { resolveVersionAudioLanguage } from "@/player/utils/effectiveAudioLangua
 import { getLanguageName } from "@/player/utils/languageNames";
 import { normalizeSubtitleMode } from "@/player/utils/subtitleMode";
 import { resolveSubtitleAutoSelect } from "@/player/utils/subtitleSort";
-import { formatChannels } from "./versionFormatUtils";
+import { formatChannels, mapAudioLabel } from "@/lib/mediaFormat";
 import {
   buildVersionSubtitleInventory,
   type VersionSubtitleInventoryRow,
 } from "./versionSubtitleInventory";
-import { mapAudioLabel } from "./versionRankingUtils";
 
 export interface PrePlaySubtitleCandidate extends VersionSubtitleInventoryRow {
   selection: PrePlaySubtitleSelection;

--- a/web/src/pages/ItemDetail/components/versionFormatUtils.test.ts
+++ b/web/src/pages/ItemDetail/components/versionFormatUtils.test.ts
@@ -1,32 +1,5 @@
 import { describe, expect, it } from "vitest";
-import {
-  formatFileSize,
-  formatPageCount,
-  formatChannels,
-  formatBitrate,
-  formatLanguageName,
-  extractSourceHint,
-} from "./versionFormatUtils";
-
-describe("formatFileSize", () => {
-  it("formats bytes in GB", () => {
-    expect(formatFileSize(2 * 1024 ** 3)).toBe("2.0 GB");
-    expect(formatFileSize(1.5 * 1024 ** 3)).toBe("1.5 GB");
-  });
-
-  it("formats bytes in MB", () => {
-    expect(formatFileSize(512 * 1024 ** 2)).toBe("512.0 MB");
-    expect(formatFileSize(1.5 * 1024 ** 2)).toBe("1.5 MB");
-  });
-
-  it("returns empty string for zero", () => {
-    expect(formatFileSize(0)).toBe("");
-  });
-
-  it("returns empty string for negative values", () => {
-    expect(formatFileSize(-100)).toBe("");
-  });
-});
+import { formatPageCount, formatLanguageName, extractSourceHint } from "./versionFormatUtils";
 
 describe("formatPageCount", () => {
   it("formats singular and plural ebook page counts", () => {
@@ -37,47 +10,6 @@ describe("formatPageCount", () => {
   it("returns empty string for missing page counts", () => {
     expect(formatPageCount(0)).toBe("");
     expect(formatPageCount(undefined)).toBe("");
-  });
-});
-
-describe("formatChannels", () => {
-  it("maps 8 channels to 7.1", () => {
-    expect(formatChannels(8)).toBe("7.1");
-  });
-
-  it("maps 6 channels to 5.1", () => {
-    expect(formatChannels(6)).toBe("5.1");
-  });
-
-  it("maps 2 channels to stereo", () => {
-    expect(formatChannels(2)).toBe("stereo");
-  });
-
-  it("returns empty string for undefined", () => {
-    expect(formatChannels(undefined)).toBe("");
-  });
-
-  it("returns empty string for zero", () => {
-    expect(formatChannels(0)).toBe("");
-  });
-
-  it("formats other channel counts with ch suffix", () => {
-    expect(formatChannels(4)).toBe("4 ch");
-  });
-});
-
-describe("formatBitrate", () => {
-  it("formats bitrate with kbps suffix", () => {
-    expect(formatBitrate(1000)).toBe("1,000 kbps");
-    expect(formatBitrate(55000)).toBe("55,000 kbps");
-  });
-
-  it("returns empty string for zero", () => {
-    expect(formatBitrate(0)).toBe("");
-  });
-
-  it("returns empty string for undefined", () => {
-    expect(formatBitrate(undefined)).toBe("");
   });
 });
 

--- a/web/src/pages/ItemDetail/components/versionFormatUtils.ts
+++ b/web/src/pages/ItemDetail/components/versionFormatUtils.ts
@@ -1,5 +1,5 @@
-import { type ReactNode, useState } from "react";
 import type { VersionAudioTrack, VersionSubtitleTrack, VersionVideoTrack } from "@/api/types";
+import { formatBitrate, formatChannels, formatSampleRate } from "@/lib/mediaFormat";
 
 export const LANGUAGE_NAMES: Record<string, string> = {
   cze: "Czech",
@@ -14,14 +14,6 @@ export const LANGUAGE_NAMES: Record<string, string> = {
   spa: "Spanish",
 };
 
-export function formatFileSize(bytes: number): string {
-  if (!Number.isFinite(bytes) || bytes <= 0) return "";
-  if (bytes >= 1024 ** 3) return `${(bytes / 1024 ** 3).toFixed(1)} GB`;
-  if (bytes >= 1024 ** 2) return `${(bytes / 1024 ** 2).toFixed(1)} MB`;
-  if (bytes >= 1024) return `${(bytes / 1024).toFixed(1)} KB`;
-  return `${bytes} B`;
-}
-
 export function formatPageCount(pages?: number): string {
   if (!pages || pages <= 0) return "";
   return `${pages.toLocaleString()} ${pages === 1 ? "page" : "pages"}`;
@@ -35,24 +27,6 @@ export function formatAddedAt(value?: string): string {
     dateStyle: "medium",
     timeStyle: "short",
   }).format(date);
-}
-
-export function formatChannels(channels?: number): string {
-  if (!channels || channels <= 0) return "";
-  if (channels === 8) return "7.1";
-  if (channels === 6) return "5.1";
-  if (channels === 2) return "stereo";
-  return `${channels} ch`;
-}
-
-export function formatBitrate(bitrate?: number): string {
-  if (!bitrate || bitrate <= 0) return "";
-  return `${bitrate.toLocaleString()} kbps`;
-}
-
-export function formatSampleRate(sampleRate?: number): string {
-  if (!sampleRate || sampleRate <= 0) return "";
-  return `${sampleRate.toLocaleString()} Hz`;
 }
 
 export function formatLanguageName(language?: string): string {
@@ -169,46 +143,4 @@ export function compactSubtitleMeta(track: VersionSubtitleTrack): string {
     track.default ? "Default" : "",
     track.resolution,
   ]);
-}
-
-const TRACK_COLLAPSE_THRESHOLD = 3;
-
-export function TrackSection({
-  label,
-  count,
-  children,
-}: {
-  label: string;
-  count: number;
-  children: ReactNode[];
-}) {
-  const [expanded, setExpanded] = useState(false);
-  const collapsible = count > TRACK_COLLAPSE_THRESHOLD;
-  const visible = collapsible && !expanded ? children.slice(0, TRACK_COLLAPSE_THRESHOLD) : children;
-  const hiddenCount = count - TRACK_COLLAPSE_THRESHOLD;
-
-  return (
-    <div>
-      <div className="text-muted-foreground/60 mb-1 text-[11px] font-medium">{label}</div>
-      <div className="divide-border/10 divide-y">{visible}</div>
-      {collapsible && (
-        <button
-          type="button"
-          onClick={() => setExpanded((prev) => !prev)}
-          className="text-muted-foreground hover:text-foreground/70 mt-1 text-xs font-medium transition-colors"
-        >
-          {expanded ? "Show less" : `+${hiddenCount} more`}
-        </button>
-      )}
-    </div>
-  );
-}
-
-export function TrackRow({ title, meta }: { title: string; meta: string }) {
-  return (
-    <div className="py-1.5">
-      <div className="text-foreground/85 text-sm">{title}</div>
-      {meta && <div className="text-muted-foreground mt-0.5 text-xs">{meta}</div>}
-    </div>
-  );
 }

--- a/web/src/pages/ItemDetail/components/versionRankingUtils.test.ts
+++ b/web/src/pages/ItemDetail/components/versionRankingUtils.test.ts
@@ -3,7 +3,6 @@ import type { FileVersion } from "@/api/types";
 import {
   resolutionScore,
   audioScore,
-  mapAudioLabel,
   pickBestAttributes,
   RESOLUTION_RANK,
   AUDIO_RANK,
@@ -86,44 +85,6 @@ describe("audioScore", () => {
     expect(audioScore("mp3")).toBe(-1);
     expect(audioScore("")).toBe(-1);
     expect(audioScore("pcm")).toBe(-1);
-  });
-});
-
-describe("mapAudioLabel", () => {
-  it("maps atmos codec strings to Atmos", () => {
-    expect(mapAudioLabel("TrueHD Atmos")).toBe("Atmos");
-    expect(mapAudioLabel("eac3 atmos")).toBe("Atmos");
-  });
-
-  it("maps truehd to TrueHD", () => {
-    expect(mapAudioLabel("truehd")).toBe("TrueHD");
-  });
-
-  it("maps dts-hd and dts:x to DTS-HD", () => {
-    expect(mapAudioLabel("dts-hd")).toBe("DTS-HD");
-    expect(mapAudioLabel("dts:x")).toBe("DTS-HD");
-  });
-
-  it("maps dts to DTS", () => {
-    expect(mapAudioLabel("dts")).toBe("DTS");
-  });
-
-  it("maps eac3 and e-ac-3 to EAC3", () => {
-    expect(mapAudioLabel("eac3")).toBe("EAC3");
-    expect(mapAudioLabel("e-ac-3")).toBe("EAC3");
-  });
-
-  it("maps aac to AAC", () => {
-    expect(mapAudioLabel("aac")).toBe("AAC");
-  });
-
-  it("maps flac to FLAC", () => {
-    expect(mapAudioLabel("flac")).toBe("FLAC");
-  });
-
-  it("uppercases unknown codecs", () => {
-    expect(mapAudioLabel("mp3")).toBe("MP3");
-    expect(mapAudioLabel("opus")).toBe("OPUS");
   });
 });
 

--- a/web/src/pages/ItemDetail/components/versionRankingUtils.ts
+++ b/web/src/pages/ItemDetail/components/versionRankingUtils.ts
@@ -1,16 +1,5 @@
 import type { FileVersion, LeafItemUserData, PlaybackVariant } from "@/api/types";
-
-export function mapAudioLabel(codec: string): string {
-  const lower = codec.toLowerCase();
-  if (lower.includes("atmos")) return "Atmos";
-  if (lower.includes("truehd")) return "TrueHD";
-  if (lower.includes("dts-hd") || lower.includes("dts:x")) return "DTS-HD";
-  if (lower.includes("dts")) return "DTS";
-  if (lower.includes("eac3") || lower.includes("e-ac-3")) return "EAC3";
-  if (lower.includes("aac")) return "AAC";
-  if (lower.includes("flac")) return "FLAC";
-  return codec.toUpperCase();
-}
+import { mapAudioLabel } from "@/lib/mediaFormat";
 
 export const RESOLUTION_RANK: Record<string, number> = {
   "4k": 4,

--- a/web/src/pages/adminActivityPresentation.ts
+++ b/web/src/pages/adminActivityPresentation.ts
@@ -1,5 +1,5 @@
 import type { AdminSession } from "@/api/types";
-import { formatCodecLabel } from "@/player/playback-info";
+import { formatCodecLabel } from "@/lib/mediaFormat";
 
 export function formatDecisionLabel(decision?: string): string {
   switch (decision) {

--- a/web/src/player/components/AudioTrackMenu.tsx
+++ b/web/src/player/components/AudioTrackMenu.tsx
@@ -1,13 +1,12 @@
 import { useState, useCallback, useEffect, useRef } from "react";
 import { AudioLines } from "lucide-react";
 import type { PlayerAudioTrack } from "../types";
+import { formatChannels, mapAudioLabel } from "@/lib/mediaFormat";
 import {
   audioTitle,
   compactAudioMeta,
-  formatChannels,
   formatLanguageName,
 } from "@/pages/ItemDetail/components/versionFormatUtils";
-import { mapAudioLabel } from "@/pages/ItemDetail/components/versionRankingUtils";
 
 interface AudioTrackMenuProps {
   tracks: PlayerAudioTrack[];

--- a/web/src/player/hooks/useTranscodeQuality.ts
+++ b/web/src/player/hooks/useTranscodeQuality.ts
@@ -69,7 +69,10 @@ interface UseTranscodeQualityResult {
 
 export const COMPATIBILITY_QUALITY_ID = "compatibility";
 
-function formatBitrate(kbps: number): string {
+// Quality-menu bitrate label: Mbps with collapsed integers ("8 Mbps", not
+// "8.0 Mbps") — a deliberately different display policy than the canonical
+// formatBitrate/formatMbpsFromKbps in @/lib/mediaFormat.
+function formatQualityBitrate(kbps: number): string {
   if (kbps >= 1000) {
     const mbps = kbps / 1000;
     return mbps % 1 === 0 ? `${mbps} Mbps` : `${mbps.toFixed(1)} Mbps`;
@@ -111,7 +114,7 @@ function buildQualityOptions(
 
   // Original quality option.
   const methodLabel = playMethodLabel(playMethod);
-  const bitrateLabel = version.bitrate > 0 ? formatBitrate(version.bitrate) : "";
+  const bitrateLabel = version.bitrate > 0 ? formatQualityBitrate(version.bitrate) : "";
   const sublabelParts = [methodLabel, bitrateLabel].filter(Boolean);
 
   options.push({
@@ -145,7 +148,7 @@ function buildQualityOptions(
     options.push({
       id: tier.id,
       label: tier.label,
-      sublabel: `~${formatBitrate(tier.bitrate)}`,
+      sublabel: `~${formatQualityBitrate(tier.bitrate)}`,
       resolution: tier.resolution,
       bitrateKbps: tier.bitrate,
       isOriginal: false,

--- a/web/src/player/playback-info.ts
+++ b/web/src/player/playback-info.ts
@@ -1,3 +1,11 @@
+import {
+  dolbyVisionLabel,
+  formatBitrate,
+  formatCodecLabel,
+  formatFileSize,
+  formatMbpsFromKbps,
+  formatSampleRate,
+} from "@/lib/mediaFormat";
 import type {
   PlaybackSessionPlaybackInfo,
   PlayMethod,
@@ -41,21 +49,6 @@ interface BuildPlaybackInfoSectionsInput {
   requestedVersion?: PlayerFileVersion;
   runtimeStats: RuntimePlaybackStats;
 }
-
-const CODEC_LABELS: Record<string, string> = {
-  aac: "AAC",
-  ac3: "AC3",
-  av1: "AV1",
-  dts: "DTS",
-  dtshd: "DTS-HD",
-  eac3: "EAC3",
-  flac: "FLAC",
-  h264: "H.264",
-  hevc: "HEVC",
-  mp3: "MP3",
-  opus: "Opus",
-  truehd: "TrueHD",
-};
 
 export function buildPlaybackInfoSections({
   streamUrl,
@@ -132,7 +125,10 @@ export function buildPlaybackInfoSections({
         },
         {
           label: "Size",
-          value: formatFileSize(currentSourceVersion?.file_size),
+          value: formatFileSize(currentSourceVersion?.file_size, {
+            iecUnits: true,
+            fallback: "—",
+          }),
         },
         {
           label: "Bitrate",
@@ -156,7 +152,7 @@ export function buildPlaybackInfoSections({
         },
         {
           label: "Audio bitrate",
-          value: formatKbps(audioTrack?.bitrate),
+          value: formatBitrate(audioTrack?.bitrate, "—"),
         },
         {
           label: "Audio channels",
@@ -164,7 +160,7 @@ export function buildPlaybackInfoSections({
         },
         {
           label: "Audio sample rate",
-          value: formatSampleRate(audioTrack?.sample_rate),
+          value: formatSampleRate(audioTrack?.sample_rate, "—"),
         },
       ],
     },
@@ -331,9 +327,7 @@ export function formatVideoRangeType(
   track?: PlayerVideoTrack,
 ): string {
   if (track?.dolby_vision) {
-    const dolbyVision = track.dolby_vision.toLowerCase().startsWith("dolby vision")
-      ? track.dolby_vision
-      : `Dolby Vision ${track.dolby_vision}`;
+    const dolbyVision = dolbyVisionLabel(track.dolby_vision);
     return track.video_range ? `${dolbyVision} (${track.video_range})` : dolbyVision;
   }
   if (track?.video_range) {
@@ -362,45 +356,6 @@ export function formatOriginalAudioCodec(
 export function formatAudioChannels(version?: PlayerFileVersion, track?: PlayerAudioTrack): string {
   const channels = track?.channels ?? version?.audio_channels;
   return isPositive(channels) ? String(channels) : "—";
-}
-
-export function formatSampleRate(sampleRate?: number): string {
-  return isPositive(sampleRate) ? `${sampleRate.toLocaleString()} Hz` : "—";
-}
-
-export function formatKbps(kbps?: number): string {
-  return isPositive(kbps) ? `${Math.round(kbps).toLocaleString()} kbps` : "—";
-}
-
-export function formatMbpsFromKbps(kbps?: number): string {
-  return isPositive(kbps) ? `${(kbps / 1000).toFixed(1)} Mbps` : "—";
-}
-
-export function formatFileSize(bytes?: number): string {
-  if (!isPositive(bytes)) {
-    return "—";
-  }
-  if (bytes >= 1024 ** 3) {
-    return `${(bytes / 1024 ** 3).toFixed(1)} GiB`;
-  }
-  if (bytes >= 1024 ** 2) {
-    return `${(bytes / 1024 ** 2).toFixed(1)} MiB`;
-  }
-  if (bytes >= 1024) {
-    return `${(bytes / 1024).toFixed(1)} KiB`;
-  }
-  return `${bytes} B`;
-}
-
-export function formatCodecLabel(codec?: string): string {
-  if (!codec) {
-    return "—";
-  }
-  const normalized = codec.trim();
-  if (!normalized) {
-    return "—";
-  }
-  return CODEC_LABELS[normalized.toLowerCase()] ?? normalized.toUpperCase();
 }
 
 function pickVideoTrack(version: PlayerFileVersion): PlayerVideoTrack | undefined {


### PR DESCRIPTION
## Problem

There is no way to view a file's detailed technical specs (exact bitrate, Dolby Vision profile/tier, chroma subsampling, exact audio codecs) in the UI. The Media locations section shows paths and basic badges only. Separately, media-spec formatting logic had drifted into six divergent copies across the frontend (GB vs GiB labels, `""` vs `"—"` fallbacks, three codec-label mappers), including cross-boundary imports of player internals from pages.

## Approach

Two commits, refactor first so the feature builds on it:

1. **`refactor(web)`: consolidate media-spec formatters into `web/src/lib/mediaFormat.ts`.** One canonical implementation each for file size, bitrate, Mbps, sample rate, channels, codec labels (`formatCodecLabel` + fuzzy `mapAudioLabel`), Dolby Vision prefixing, and the overlay badge helpers (`prettyResolution`, `compactHdrSuffix`). Deliberate per-surface display differences are parameters (fallback text, GB vs GiB) instead of copies. All call sites migrated; dead `TrackSection`/`TrackRow` removed; `versionFormatUtils.tsx` → `.ts`. The quality-menu Mbps label stays local in `useTranscodeQuality` as a distinct display policy (renamed `formatQualityBitrate`).

2. **`feat(web)`: Media Info dialog** for movies/episodes (curator/admin-gated, like the Media locations section). Frontend-only — the item-detail response already carried full per-track data; `VersionVideoTrack` in `api/types.ts` was missing the `dv_profile`/`dv_bl_compat_id`/`dv_el_present`/`hdr10_plus`/`video_range_type` fields the backend already sends. Entry points: overflow-menu item (opens on the selected version) and a per-row info button in Media locations (opens on that file). All versions render as accordion sections, target expanded. Spec rows come from pure builders in `mediaSpecSections.ts` (chroma subsampling from pixel format, DV profile/BL-compat/EL composition, codec-aware H.264/HEVC/AV1 level decoding), fixture-tested across SDR/HDR10/DV7/DV8.1+HDR10+/multi-track/external-subtitle cases.

## Behavior preservation (refactor)

- `playback-info.test.ts` and `VersionFlyout.test.ts` are **unmodified and pass** — they assert the exact rendered strings of the player stats overlay ("7.1 GiB", "22.5 Mbps", "640 kbps", "48,000 Hz", "Dolby Vision Profile 8.1 (HDR10)", "H.264 (copy)").
- Poster-badge helpers moved verbatim and gained unit tests.
- Full web suite: 1196 passed; the only 4 failures (`CompatibilityProxiesSettings`, `ServerStorageStep`) fail identically on main (pre-existing jsdom environment issues).
- `tsc`, ESLint (0 errors), prettier, and `vite build` all pass; each commit builds and tests standalone.

## Screenshots

Not included: the modal and player overlay live behind authentication on the dev deployment and this branch was verified headlessly (unit tests pin the exact rendered strings). Happy to add screenshots from a signed-in session before merge if wanted.

## Risks / follow-ups

- Older probed files simply omit rows for fields that predate their scan (falsy fields are dropped, no blank placeholders).
- Not extracted: MaxCLL/MaxFALL mastering metadata (needs scanner-side side-data parsing + re-probe) — possible follow-up.
- `VersionVideoTrack` (api) vs `PlayerVideoTrack` (player) stay separate: `player/types.ts` is deliberately self-contained and the player doesn't consume the new DV fields; merging would couple the player to API types for no functional gain.

## Scope link

No linked issue — this started as a quality-of-life feature request (Plex-style "Media Info") plus the maintainability cleanup it surfaced, per the repo's duplicate-logic guideline. Additive UI only; no `/api/v1` surface changes.

## AI-use disclosure

Implemented by Claude Code (Claude Fable 5) under human direction; design decisions (data scope, gating, entry points, commit split) were human-approved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a “Media Info” dialog for item versions, with an improved spec sheet view and an empty-state when no media is available.
  * Added “View media info” actions to media locations and a “Media Info” option in the item action menu (when metadata curation is available).
* **Bug Fixes**
  * Improved consistency of displayed media details (size, bitrate, channels, resolution, and Dolby Vision/HDR10+ labeling).
  * Refined bitrate formatting in the transcode quality menu and improved handling of missing/empty metadata.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->