### PR TITLE
feat(sections): fix broken home section templates and add six new ones

### DIFF
--- a/internal/catalog/discovery_repo.go
+++ b/internal/catalog/discovery_repo.go
@@ -29,7 +29,11 @@ type RatingFilter struct {
 	// Limit caps the number of rows returned. Zero or negative means no limit.
 	Limit int
 	// LibraryID, when non-nil, restricts results to items in that library.
+	// Takes precedence over LibraryIDs.
 	LibraryID *int
+	// LibraryIDs, when non-empty, restricts results to items in any of these
+	// libraries (multi-library section scope).
+	LibraryIDs []int
 	// Filter carries viewer-level access constraints (content rating ceiling,
 	// allowed/disabled library sets).
 	Filter AccessFilter
@@ -48,7 +52,7 @@ func buildRatingThresholdQuery(f RatingFilter) (string, []any) {
 	args = append(args, f.Min)
 	argIdx++
 
-	if ok := appendDiscoveryLibraryScope(&conditions, &args, &argIdx, f.LibraryID, f.Filter); !ok {
+	if ok := appendDiscoveryLibraryScope(&conditions, &args, &argIdx, f.LibraryID, f.LibraryIDs, f.Filter); !ok {
 		return "", nil
 	}
 
@@ -96,12 +100,22 @@ func (r *DiscoveryRepository) ListByRatingThreshold(ctx context.Context, f Ratin
 type UnplayedFilter struct {
 	// MinRating is the minimum rating_imdb value (inclusive).
 	MinRating float64
+	// MaxPlays is the maximum number of watch-history events the viewer may
+	// have for an item before it stops counting as a hidden gem. Zero (the
+	// default) keeps the strict "never started" semantics.
+	MaxPlays int
 	// Limit caps the number of rows returned. Zero or negative means no limit.
 	Limit int
 	// UserID and ProfileID identify the viewer whose watch history is checked.
 	// Both are required; the function returns an error if either is absent.
 	UserID    int
 	ProfileID string
+	// LibraryID, when non-nil, restricts results to items in that library.
+	// Takes precedence over LibraryIDs.
+	LibraryID *int
+	// LibraryIDs, when non-empty, restricts results to items in any of these
+	// libraries (multi-library section scope).
+	LibraryIDs []int
 	// Filter carries viewer-level access constraints.
 	Filter AccessFilter
 }
@@ -119,18 +133,31 @@ func buildUnplayedHighRatedQuery(f UnplayedFilter) (string, []any) {
 	args = append(args, f.MinRating)
 	argIdx++
 
-	// Items the user has any watch history entry for are excluded.
-	conditions = append(conditions, fmt.Sprintf(`NOT EXISTS (
-		SELECT 1
-		FROM user_watch_history uwh
-		WHERE uwh.user_id = $%d
-		  AND uwh.profile_id = $%d
-		  AND uwh.media_item_id = mi.content_id
-	)`, argIdx, argIdx+1))
-	args = append(args, f.UserID, f.ProfileID)
-	argIdx += 2
+	// Items the viewer has watched more than MaxPlays times are excluded.
+	// MaxPlays 0 (the default) reduces to the strict "never started" check.
+	if f.MaxPlays > 0 {
+		conditions = append(conditions, fmt.Sprintf(`(
+			SELECT COUNT(*)
+			FROM user_watch_history uwh
+			WHERE uwh.user_id = $%d
+			  AND uwh.profile_id = $%d
+			  AND uwh.media_item_id = mi.content_id
+		) <= $%d`, argIdx, argIdx+1, argIdx+2))
+		args = append(args, f.UserID, f.ProfileID, f.MaxPlays)
+		argIdx += 3
+	} else {
+		conditions = append(conditions, fmt.Sprintf(`NOT EXISTS (
+			SELECT 1
+			FROM user_watch_history uwh
+			WHERE uwh.user_id = $%d
+			  AND uwh.profile_id = $%d
+			  AND uwh.media_item_id = mi.content_id
+		)`, argIdx, argIdx+1))
+		args = append(args, f.UserID, f.ProfileID)
+		argIdx += 2
+	}
 
-	if ok := appendDiscoveryLibraryScope(&conditions, &args, &argIdx, nil, f.Filter); !ok {
+	if ok := appendDiscoveryLibraryScope(&conditions, &args, &argIdx, f.LibraryID, f.LibraryIDs, f.Filter); !ok {
 		return "", nil
 	}
 
@@ -193,6 +220,12 @@ type ForgottenFavoritesFilter struct {
 	// Both are required; the function returns an error if either is absent.
 	UserID    int
 	ProfileID string
+	// LibraryID, when non-nil, restricts results to items in that library.
+	// Takes precedence over LibraryIDs.
+	LibraryID *int
+	// LibraryIDs, when non-empty, restricts results to items in any of these
+	// libraries (multi-library section scope).
+	LibraryIDs []int
 	// Filter carries viewer-level access constraints.
 	Filter AccessFilter
 }
@@ -224,7 +257,7 @@ func buildForgottenFavoritesQuery(f ForgottenFavoritesFilter) (string, []any) {
 	args = append(args, f.UserID, f.ProfileID, f.LookbackDays)
 	argIdx += 3
 
-	if ok := appendDiscoveryLibraryScope(&conditions, &args, &argIdx, nil, f.Filter); !ok {
+	if ok := appendDiscoveryLibraryScope(&conditions, &args, &argIdx, f.LibraryID, f.LibraryIDs, f.Filter); !ok {
 		return "", nil
 	}
 
@@ -276,25 +309,37 @@ func appendDiscoveryLibraryScope(
 	args *[]any,
 	argIdx *int,
 	libraryID *int,
+	libraryIDs []int,
 	filter AccessFilter,
 ) bool {
-	if libraryID != nil {
-		whereSQL, scopeArgs, ok := buildLibraryScopeJoin([]int{*libraryID}, nil, *argIdx, "", "mi.content_id")
-		if ok {
-			*conditions = append(*conditions, whereSQL)
-			*args = append(*args, scopeArgs...)
-			*argIdx += len(scopeArgs)
-		}
-		return true
+	// Section-level scope: a single pinned library wins over a multi-library set.
+	var scope []int
+	switch {
+	case libraryID != nil:
+		scope = []int{*libraryID}
+	case len(libraryIDs) > 0:
+		scope = libraryIDs
 	}
 
-	if filter.AllowedLibraryIDs != nil && len(filter.AllowedLibraryIDs) == 0 {
+	// Intersect the section scope with the viewer's allowed set so a scoped
+	// section can never widen access beyond what the viewer may see.
+	allowed := filter.AllowedLibraryIDs
+	if len(scope) > 0 {
+		if allowed != nil {
+			allowed = intersectInts(scope, allowed)
+			if len(allowed) == 0 {
+				return false
+			}
+		} else {
+			allowed = scope
+		}
+	} else if allowed != nil && len(allowed) == 0 {
 		return false
 	}
 
 	// buildLibraryScopeJoin uses semi-joins: disabled libraries are an item-level
 	// exclusion, matching the rest of catalog access filtering and avoiding row fanout.
-	if filter.AllowedLibraryIDs == nil && len(filter.DisabledLibraryIDs) > 0 {
+	if len(allowed) == 0 && len(filter.DisabledLibraryIDs) > 0 {
 		// In deny-only mode, require at least one library membership. Without this,
 		// stale or provisional media_items rows with no membership pass NOT EXISTS.
 		*conditions = append(*conditions,
@@ -303,7 +348,7 @@ func appendDiscoveryLibraryScope(
 	}
 
 	whereSQL, scopeArgs, ok := buildLibraryScopeJoin(
-		filter.AllowedLibraryIDs,
+		allowed,
 		filter.DisabledLibraryIDs,
 		*argIdx,
 		"",

--- a/internal/catalog/discovery_repo_test.go
+++ b/internal/catalog/discovery_repo_test.go
@@ -462,3 +462,98 @@ func assertIntSliceArg(t *testing.T, args []any, idx int, want []int) {
 }
 
 func mustQuery(query string, _ []any) string { return query }
+
+func TestUnplayedHighRated_LibraryScopeIntersectsViewerAccess(t *testing.T) {
+	lib := 5
+	query, args := buildUnplayedHighRatedQuery(UnplayedFilter{
+		MinRating: 7.5,
+		UserID:    1,
+		ProfileID: "p1",
+		LibraryID: &lib,
+		Filter:    AccessFilter{AllowedLibraryIDs: []int{7, 9}},
+	})
+	// Section scope {5} ∩ viewer-allowed {7,9} is empty: no query at all.
+	if query != "" {
+		t.Fatalf("expected empty query for disjoint scope, got %q", query)
+	}
+	_ = args
+}
+
+func TestUnplayedHighRated_MultiLibraryScope(t *testing.T) {
+	query, args := buildUnplayedHighRatedQuery(UnplayedFilter{
+		MinRating:  7.5,
+		UserID:     1,
+		ProfileID:  "p1",
+		LibraryIDs: []int{3, 4},
+	})
+	if !strings.Contains(query, "mil_scope_in.media_folder_id = ANY(") {
+		t.Errorf("expected library semi-join for multi-library scope, query: %s", query)
+	}
+	found := false
+	for _, arg := range args {
+		if ids, ok := arg.([]int); ok && len(ids) == 2 && ids[0] == 3 && ids[1] == 4 {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("expected [3 4] library ids in args, got %v", args)
+	}
+}
+
+func TestUnplayedHighRated_MaxPlaysUsesCountThreshold(t *testing.T) {
+	query, args := buildUnplayedHighRatedQuery(UnplayedFilter{
+		MinRating: 7.5,
+		MaxPlays:  2,
+		UserID:    1,
+		ProfileID: "p1",
+	})
+	if !strings.Contains(query, "SELECT COUNT(*)") {
+		t.Errorf("MaxPlays > 0 should use a COUNT threshold: %s", query)
+	}
+	// The strict never-started NOT EXISTS over watch history must be replaced
+	// by the COUNT form (the manga-exclusion NOT EXISTS is unrelated).
+	if strings.Contains(query, "NOT EXISTS (\n\t\t\tSELECT 1\n\t\t\tFROM user_watch_history") {
+		t.Errorf("MaxPlays > 0 should not use the never-started NOT EXISTS: %s", query)
+	}
+	found := false
+	for _, arg := range args {
+		if v, ok := arg.(int); ok && v == 2 {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("expected max plays 2 in args, got %v", args)
+	}
+}
+
+func TestForgottenFavorites_SingleLibraryScope(t *testing.T) {
+	lib := 3
+	query, _ := buildForgottenFavoritesQuery(ForgottenFavoritesFilter{
+		LookbackDays: 365,
+		UserID:       1,
+		ProfileID:    "p1",
+		LibraryID:    &lib,
+	})
+	if !strings.Contains(query, "mil_scope_in.media_folder_id = ANY(") {
+		t.Errorf("expected library semi-join for single-library scope, query: %s", query)
+	}
+}
+
+func TestRatingThreshold_MultiLibraryScope(t *testing.T) {
+	query, args := buildRatingThresholdQuery(RatingFilter{
+		Min:        8.0,
+		LibraryIDs: []int{2, 6},
+	})
+	if !strings.Contains(query, "mil_scope_in.media_folder_id = ANY(") {
+		t.Errorf("expected library semi-join for multi-library scope, query: %s", query)
+	}
+	found := false
+	for _, arg := range args {
+		if ids, ok := arg.([]int); ok && len(ids) == 2 && ids[0] == 2 && ids[1] == 6 {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("expected [2 6] library ids in args, got %v", args)
+	}
+}

--- a/internal/recommendations/reader.go
+++ b/internal/recommendations/reader.go
@@ -159,6 +159,8 @@ func (r *Reader) GetBecauseYouWatched(ctx context.Context, userID int, profileID
 
 // GetTasteMatchRow returns the strongest matching personalized cluster row for a genre,
 // falling back to the global genre sampler when no personalized cluster matches.
+// An empty genre auto-picks: every taste cluster qualifies (strongest first),
+// and the global fallback uses the server-wide top genre.
 func (r *Reader) GetTasteMatchRow(ctx context.Context, userID int, profileID, genre string, limit int, filter catalog.AccessFilter) (*ForYouRow, error) {
 	limit = normalizeRecommendationLimit(limit)
 
@@ -169,6 +171,10 @@ func (r *Reader) GetTasteMatchRow(ctx context.Context, userID int, profileID, ge
 
 	matching := make([]TasteCluster, 0, len(clusters))
 	for _, cluster := range clusters {
+		if genre == "" {
+			matching = append(matching, cluster)
+			continue
+		}
 		for _, dominantGenre := range cluster.DominantGenres {
 			if dominantGenre == genre {
 				matching = append(matching, cluster)
@@ -201,6 +207,14 @@ func (r *Reader) GetTasteMatchRow(ctx context.Context, userID int, profileID, ge
 			return nil, nil
 		}
 		return &rows[0], nil
+	}
+
+	if genre == "" {
+		topGenres, err := r.repo.GetTopGenres(ctx, 1)
+		if err != nil || len(topGenres) == 0 {
+			return nil, err
+		}
+		genre = topGenres[0]
 	}
 
 	items, err := r.repo.GetRecommendationCache(ctx, GlobalCacheUserID, GlobalCacheProfileID, RecTypeGenreSamplerPrefix+genre, "")

--- a/internal/recommendations/reader.go
+++ b/internal/recommendations/reader.go
@@ -204,7 +204,10 @@ func (r *Reader) GetTasteMatchRow(ctx context.Context, userID int, profileID, ge
 		}
 		rows = trimRows(rows, limit)
 		if len(rows) == 0 {
-			return nil, nil
+			// This cluster's cached items were entirely filtered out (e.g.
+			// access restrictions) — try the next-strongest cluster instead of
+			// giving up before the global fallback below.
+			continue
 		}
 		return &rows[0], nil
 	}

--- a/internal/sections/fetcher.go
+++ b/internal/sections/fetcher.go
@@ -3215,31 +3215,35 @@ func (f *Fetcher) fetchMostWatched(ctx context.Context, s ResolvedSection, libra
 	return items, len(items), nil
 }
 
+// buildLibraryScope returns the FROM clause and membership predicates that
+// constrain a section query to the requested library scope. Membership is
+// checked with EXISTS / NOT EXISTS semi-joins rather than a row join: an item
+// present in several in-scope libraries must produce exactly ONE result row
+// (rails without a GROUP BY would otherwise return duplicates that eat limit
+// slots), and the deny check must be item-level — with a row join, an item
+// linked to both an allowed and a disabled library passes via the allowed
+// membership row (see catalog audit 2026-05-01 §3 Pattern D, the same reason
+// catalog's buildLibraryScopeJoin uses semi-joins).
 func buildLibraryScope(libraryID *int, libraryIDs []int, configLibraryIDs []int, disabledLibraryIDs []int, argIdx int) (string, []string, []any, int) {
 	fromClause := "media_items mi"
 	var conditions []string
 	var args []any
 
-	needsJoin := libraryID != nil || libraryIDs != nil || len(configLibraryIDs) > 0 || len(disabledLibraryIDs) > 0
-
-	if needsJoin {
-		fromClause = "media_items mi JOIN media_item_libraries mil ON mi.content_id = mil.content_id"
-	}
-
-	if libraryID != nil {
-		conditions = append(conditions, fmt.Sprintf("mil.media_folder_id = $%d", argIdx))
-		args = append(args, *libraryID)
+	memberOfAny := func(ids []int) {
+		conditions = append(conditions, fmt.Sprintf(
+			"EXISTS (SELECT 1 FROM media_item_libraries mil_scope_in WHERE mil_scope_in.content_id = mi.content_id AND mil_scope_in.media_folder_id = ANY($%d))",
+			argIdx,
+		))
+		args = append(args, append([]int(nil), ids...))
 		argIdx++
 	}
 
+	if libraryID != nil {
+		memberOfAny([]int{*libraryID})
+	}
+
 	if len(configLibraryIDs) > 0 && libraryID == nil {
-		placeholders := make([]string, len(configLibraryIDs))
-		for i, id := range configLibraryIDs {
-			placeholders[i] = fmt.Sprintf("$%d", argIdx)
-			args = append(args, id)
-			argIdx++
-		}
-		conditions = append(conditions, fmt.Sprintf("mil.media_folder_id IN (%s)", strings.Join(placeholders, ", ")))
+		memberOfAny(configLibraryIDs)
 	}
 
 	if libraryIDs != nil {
@@ -3247,23 +3251,25 @@ func buildLibraryScope(libraryID *int, libraryIDs []int, configLibraryIDs []int,
 			conditions = append(conditions, "1 = 0")
 			return fromClause, conditions, args, argIdx
 		}
-		placeholders := make([]string, len(libraryIDs))
-		for i, id := range libraryIDs {
-			placeholders[i] = fmt.Sprintf("$%d", argIdx)
-			args = append(args, id)
-			argIdx++
-		}
-		conditions = append(conditions, fmt.Sprintf("mil.media_folder_id IN (%s)", strings.Join(placeholders, ", ")))
+		memberOfAny(libraryIDs)
 	}
 
 	if len(disabledLibraryIDs) > 0 {
-		placeholders := make([]string, len(disabledLibraryIDs))
-		for i, id := range disabledLibraryIDs {
-			placeholders[i] = fmt.Sprintf("$%d", argIdx)
-			args = append(args, id)
-			argIdx++
+		if libraryID == nil && libraryIDs == nil && len(configLibraryIDs) == 0 {
+			// Deny-only mode: still require at least one library membership so
+			// stale or provisional media_items rows with no membership don't
+			// become visible through a vacuous NOT EXISTS (mirrors
+			// appendDiscoveryLibraryScope in package catalog).
+			conditions = append(conditions,
+				"EXISTS (SELECT 1 FROM media_item_libraries mil_scope_any WHERE mil_scope_any.content_id = mi.content_id)",
+			)
 		}
-		conditions = append(conditions, fmt.Sprintf("mil.media_folder_id NOT IN (%s)", strings.Join(placeholders, ", ")))
+		conditions = append(conditions, fmt.Sprintf(
+			"NOT EXISTS (SELECT 1 FROM media_item_libraries mil_scope_out WHERE mil_scope_out.content_id = mi.content_id AND mil_scope_out.media_folder_id = ANY($%d))",
+			argIdx,
+		))
+		args = append(args, append([]int(nil), disabledLibraryIDs...))
+		argIdx++
 	}
 
 	return fromClause, conditions, args, argIdx
@@ -3733,12 +3739,46 @@ func (f *Fetcher) fetchReturningShows(ctx context.Context, s ResolvedSection, li
 		days = 30
 	}
 
+	// The new-season file check below must only count files in libraries the
+	// viewer can actually reach: section scope intersected with the viewer's
+	// allowed set, minus disabled libraries. Without this, a file that only
+	// exists in an out-of-scope folder would surface the series here.
+	scopeIDs := libraryIDs
+	if libraryID != nil {
+		scopeIDs = []int{*libraryID}
+	}
+	allowedFolders := filter.AllowedLibraryIDs
+	if len(scopeIDs) > 0 {
+		if allowedFolders != nil {
+			allowedFolders = intersectLibraryIDs(scopeIDs, allowedFolders)
+			if len(allowedFolders) == 0 {
+				return []*models.MediaItem{}, 0, nil
+			}
+		} else {
+			allowedFolders = scopeIDs
+		}
+	} else if allowedFolders != nil && len(allowedFolders) == 0 {
+		return []*models.MediaItem{}, 0, nil
+	}
+
 	var conditions []string
 	var args []any
 
 	// $1..$3 are shared by several subqueries below.
 	args = append(args, userID, profileID, days)
 	argIdx := 4
+
+	fileScopeCond := ""
+	if len(allowedFolders) > 0 {
+		fileScopeCond += fmt.Sprintf("\n\t\t\t\t  AND mf.media_folder_id = ANY($%d)", argIdx)
+		args = append(args, allowedFolders)
+		argIdx++
+	}
+	if len(filter.DisabledLibraryIDs) > 0 {
+		fileScopeCond += fmt.Sprintf("\n\t\t\t\t  AND NOT (mf.media_folder_id = ANY($%d))", argIdx)
+		args = append(args, filter.DisabledLibraryIDs)
+		argIdx++
+	}
 
 	conditions = append(conditions,
 		"mi.type = 'series'",
@@ -3752,8 +3792,8 @@ func (f *Fetcher) fetchReturningShows(ctx context.Context, s ResolvedSection, li
 			  AND uwh.profile_id = $2
 		)`,
 		// ...and a season newer than any they've watched arrived recently
-		// with at least one playable file.
-		`EXISTS (
+		// with at least one playable file in an in-scope library.
+		fmt.Sprintf(`EXISTS (
 			SELECT 1
 			FROM episodes ne
 			WHERE ne.series_id = mi.content_id
@@ -3770,9 +3810,9 @@ func (f *Fetcher) fetchReturningShows(ctx context.Context, s ResolvedSection, li
 			  AND EXISTS (
 				SELECT 1 FROM media_files mf
 				WHERE mf.episode_id = ne.content_id
-				  AND mf.missing_since IS NULL
+				  AND mf.missing_since IS NULL%s
 			  )
-		)`,
+		)`, fileScopeCond),
 	)
 
 	fromClause, libConditions, libArgs, newArgIdx := buildLibraryScope(libraryID, libraryIDs, nil, filter.DisabledLibraryIDs, argIdx)
@@ -3843,8 +3883,17 @@ func (f *Fetcher) fetchGenreRouletteWithTitle(ctx context.Context, s ResolvedSec
 
 	days := editorialCadenceDays(p.RotationCadence)
 	libKey := "all"
-	if libraryID != nil {
+	switch {
+	case libraryID != nil:
 		libKey = strconv.Itoa(*libraryID)
+	case len(libraryIDs) > 0:
+		// Multi-library scopes must not share one rotation bucket, or two
+		// differently-scoped roulette rows would always advance in lockstep.
+		parts := make([]string, len(libraryIDs))
+		for i, id := range libraryIDs {
+			parts[i] = strconv.Itoa(id)
+		}
+		libKey = strings.Join(parts, ",")
 	}
 	idx := recipes.RotationIndex(f.now(), "genre_roulette|"+libKey, len(cands), days)
 	genre := cands[idx]

--- a/internal/sections/fetcher.go
+++ b/internal/sections/fetcher.go
@@ -272,11 +272,15 @@ func (f *Fetcher) FetchOne(ctx context.Context, resolved ResolvedSection, librar
 		result, err = f.fetchNextInSeriesSection(ctx, resolved, libraryID, libraryIDs, userID, profileID, filter)
 		return result, err
 	}
-	if resolved.SectionType == SectionEditorialSpotlight {
+	if resolved.SectionType == SectionEditorialSpotlight || resolved.SectionType == SectionGenreRoulette {
 		var items []*models.MediaItem
 		var total int
 		var title string
-		items, total, title, err = f.fetchEditorialSpotlightWithTitle(ctx, resolved, libraryID, libraryIDs, filter)
+		if resolved.SectionType == SectionEditorialSpotlight {
+			items, total, title, err = f.fetchEditorialSpotlightWithTitle(ctx, resolved, libraryID, libraryIDs, filter)
+		} else {
+			items, total, title, err = f.fetchGenreRouletteWithTitle(ctx, resolved, libraryID, libraryIDs, filter)
+		}
 		if err != nil {
 			return SectionWithItems{}, err
 		}
@@ -370,7 +374,9 @@ func (f *Fetcher) seasonalTitleOverride(resolved ResolvedSection) string {
 	if f.Clock != nil {
 		now = f.Clock.Now()
 	}
-	return recipes.SeasonalTitleOverride(p, now)
+	// Same usable filter as fetchSeasonalThemed so the override tracks the
+	// theme that actually resolved.
+	return recipes.SeasonalTitleOverride(p, now, seasonalThemeHasQuery)
 }
 
 func (f *Fetcher) fetchContinueWatchingSection(ctx context.Context, resolved ResolvedSection, libraryID *int, libraryIDs []int, userID int, profileID string, filter catalog.AccessFilter) (SectionWithItems, error) {
@@ -1249,6 +1255,10 @@ func (f *Fetcher) userAgnosticSectionFetcher(t SectionType) userAgnosticSectionF
 		return f.fetchTrendingDiscover
 	case SectionAdminCuratedList:
 		return f.fetchAdminCuratedList
+	case SectionShortWatches:
+		return f.fetchShortWatches
+	case SectionAnniversaries:
+		return f.fetchAnniversaries
 	default:
 		return nil
 	}
@@ -1273,6 +1283,10 @@ func (f *Fetcher) fetchSection(ctx context.Context, s ResolvedSection, libraryID
 		return f.fetchForgottenFavorites(ctx, s, libraryID, libraryIDs, userID, profileID, filter)
 	case SectionEditorialSpotlight:
 		return f.fetchEditorialSpotlight(ctx, s, libraryID, libraryIDs, filter)
+	case SectionGenreRoulette:
+		return f.fetchGenreRoulette(ctx, s, libraryID, libraryIDs, filter)
+	case SectionReturningShows:
+		return f.fetchReturningShows(ctx, s, libraryID, libraryIDs, userID, profileID, filter)
 	case SectionProfileActivityFeed:
 		return f.fetchProfileActivityFeed(ctx, s, libraryID, libraryIDs, profileID, filter)
 	case SectionWatchlist, SectionFavorites:
@@ -1664,7 +1678,7 @@ func (f *Fetcher) fetchRecommendationSection(ctx context.Context, s ResolvedSect
 		}
 		scoredItems = row.Items
 	case SectionBecauseYouWatched:
-		items, err := f.RecommendationReader.GetBecauseYouWatched(ctx, userID, profileID, cfg.SourceItemID, s.ItemLimit, filter)
+		items, err := f.RecommendationReader.GetBecauseYouWatched(ctx, userID, profileID, cfg.anchor(), s.ItemLimit, filter)
 		if err != nil {
 			return []*models.MediaItem{}, 0, err
 		}
@@ -1676,10 +1690,9 @@ func (f *Fetcher) fetchRecommendationSection(ctx context.Context, s ResolvedSect
 		}
 		scoredItems = items
 	case SectionTasteMatch:
-		if strings.TrimSpace(cfg.Genre) == "" {
-			return []*models.MediaItem{}, 0, nil
-		}
-		row, err := f.RecommendationReader.GetTasteMatchRow(ctx, userID, profileID, cfg.Genre, s.ItemLimit, filter)
+		// An empty genre is valid: the reader auto-picks the profile's
+		// strongest taste cluster (falling back to the server top genre).
+		row, err := f.RecommendationReader.GetTasteMatchRow(ctx, userID, profileID, strings.TrimSpace(cfg.Genre), s.ItemLimit, filter)
 		if err != nil || row == nil {
 			return []*models.MediaItem{}, 0, err
 		}
@@ -1722,11 +1735,14 @@ func (f *Fetcher) fetchHiddenGems(ctx context.Context, s ResolvedSection, librar
 
 	repo := catalog.NewDiscoveryRepository(f.pool)
 	items, err := repo.ListUnplayedHighRated(ctx, catalog.UnplayedFilter{
-		MinRating: p.MinRating,
-		Limit:     s.ItemLimit,
-		UserID:    userID,
-		ProfileID: profileID,
-		Filter:    filter,
+		MinRating:  p.MinRating,
+		MaxPlays:   p.MaxPlayCount,
+		Limit:      s.ItemLimit,
+		UserID:     userID,
+		ProfileID:  profileID,
+		LibraryID:  libraryID,
+		LibraryIDs: libraryIDs,
+		Filter:     filter,
 	})
 	if err != nil {
 		return nil, 0, err
@@ -1745,10 +1761,11 @@ func (f *Fetcher) fetchCriticallyAcclaimed(ctx context.Context, s ResolvedSectio
 
 	repo := catalog.NewDiscoveryRepository(f.pool)
 	items, err := repo.ListByRatingThreshold(ctx, catalog.RatingFilter{
-		Min:       p.MinScore,
-		Limit:     s.ItemLimit,
-		LibraryID: libraryID,
-		Filter:    filter,
+		Min:        p.MinScore,
+		Limit:      s.ItemLimit,
+		LibraryID:  libraryID,
+		LibraryIDs: libraryIDs,
+		Filter:     filter,
 	})
 	if err != nil {
 		return nil, 0, err
@@ -1781,6 +1798,8 @@ func (f *Fetcher) fetchForgottenFavorites(ctx context.Context, s ResolvedSection
 		Limit:        s.ItemLimit,
 		UserID:       userID,
 		ProfileID:    profileID,
+		LibraryID:    libraryID,
+		LibraryIDs:   libraryIDs,
 		Filter:       filter,
 	})
 	if err != nil {
@@ -1867,9 +1886,14 @@ func (f *Fetcher) fetchFormatShowcase(ctx context.Context, s ResolvedSection, li
 		limit = 20
 	}
 
+	orderBy := "mi.rating_imdb DESC NULLS LAST, mi.content_id ASC"
+	if p.Sort == "recent" {
+		orderBy = "mi.created_at DESC, mi.content_id ASC"
+	}
+
 	query := fmt.Sprintf(
-		`SELECT %s FROM %s %s ORDER BY mi.rating_imdb DESC NULLS LAST, mi.content_id ASC LIMIT $%d`,
-		itemColumns("mi"), fromClause, whereClause, argIdx,
+		`SELECT %s FROM %s %s ORDER BY %s LIMIT $%d`,
+		itemColumns("mi"), fromClause, whereClause, orderBy, argIdx,
 	)
 	args = append(args, limit)
 
@@ -2100,9 +2124,6 @@ func (f *Fetcher) editorialCandidates(ctx context.Context, subjectType string, l
 		// Auto-rotate excludes the current decade — incomplete data + stylistic skew.
 		// "2020s" is still accepted as a manually-pinned subject via eraToYearRange.
 		return []string{"1970s", "1980s", "1990s", "2000s", "2010s"}, nil
-	case "franchise":
-		// TODO: franchise data not yet available; auto-rotate returns empty.
-		return nil, nil
 	default:
 		return nil, fmt.Errorf("editorial_spotlight: unsupported subject_type %q", subjectType)
 	}
@@ -2209,8 +2230,21 @@ func (f *Fetcher) topStudioCandidates(ctx context.Context, libraryID *int, libra
 }
 
 type recommendationSectionConfig struct {
+	// SourceItemID is the historical key for the because_you_watched anchor;
+	// AnchorItemID is the name the recipe params and web UI use. Both are
+	// honored so sections saved through either surface pin correctly.
 	SourceItemID string `json:"source_item_id"`
+	AnchorItemID string `json:"anchor_item_id"`
 	Genre        string `json:"genre"`
+}
+
+// anchor returns the pinned because_you_watched anchor item, preferring the
+// legacy key when both are present. Empty means auto-pick.
+func (c recommendationSectionConfig) anchor() string {
+	if strings.TrimSpace(c.SourceItemID) != "" {
+		return strings.TrimSpace(c.SourceItemID)
+	}
+	return strings.TrimSpace(c.AnchorItemID)
 }
 
 func parseRecommendationSectionConfig(config json.RawMessage) recommendationSectionConfig {
@@ -3319,10 +3353,13 @@ func (f *Fetcher) fetchSeasonalThemed(ctx context.Context, s ResolvedSection, li
 	}
 
 	// Resolve which theme to use. Multi-theme mode wins when populated.
+	// Selection skips themes without an executable query so a data-less theme
+	// never blacks out the section during its own window (see
+	// ActiveSeasonalThemeWhere).
 	var theme string
 	switch {
 	case len(p.EnabledThemes) > 0:
-		theme = recipes.ActiveSeasonalTheme(p.EnabledThemes, now)
+		theme = recipes.ActiveSeasonalThemeWhere(p.EnabledThemes, now, seasonalThemeHasQuery)
 		if theme == "" {
 			// No enabled theme is currently in season — hide the section.
 			return []*models.MediaItem{}, 0, nil
@@ -3347,9 +3384,11 @@ func (f *Fetcher) fetchSeasonalThemed(ctx context.Context, s ResolvedSection, li
 
 	def, hasQuery := seasonalQueryDef(theme)
 	if !hasQuery {
-		// Theme exists but has no executable genre query yet (christmas,
-		// st_patricks, thanksgiving need keyword/tag column support).
-		// Return empty until that data lands.
+		if keywords := seasonalKeywordTitles[theme]; len(keywords) > 0 {
+			return f.fetchSeasonalKeywordItems(ctx, keywords, s, libraryID, libraryIDs, filter)
+		}
+		// Legacy single-theme path can still pin a theme without an
+		// executable query. Return empty until that data lands.
 		return []*models.MediaItem{}, 0, nil
 	}
 
@@ -3380,8 +3419,10 @@ func (f *Fetcher) fetchSeasonalThemed(ctx context.Context, s ResolvedSection, li
 }
 
 // seasonalQueryDef returns a catalog.QueryDefinition for the given theme and
-// whether an executable query exists. Themes that require a keyword/tag column
-// (christmas, st_patricks, thanksgiving) return false until that data lands.
+// whether an executable query exists. Holiday themes without genre signal
+// (christmas, st_patricks, thanksgiving) use title-keyword matching as an
+// interim heuristic until a proper keyword/tag column lands — imperfect but
+// far better than the section going dark during the holiday itself.
 func seasonalQueryDef(theme string) (catalog.QueryDefinition, bool) {
 	newDef := func(rules ...catalog.QueryRule) catalog.QueryDefinition {
 		return catalog.QueryDefinition{
@@ -3415,12 +3456,85 @@ func seasonalQueryDef(theme string) (catalog.QueryDefinition, bool) {
 			rule("genre", "contains", "Animation"),
 			rule("genre", "contains", "Family"),
 		), true
-	case "christmas", "st_patricks", "thanksgiving":
-		// TODO: needs keyword/tag column to filter by theme-specific keywords.
-		return catalog.QueryDefinition{}, false
+	case "family_movie_night":
+		return newDef(
+			rule("genre", "contains", "Family"),
+			rule("genre", "contains", "Animation"),
+		), true
 	default:
 		return catalog.QueryDefinition{}, false
 	}
+}
+
+// seasonalKeywordTitles maps holiday themes without genre signal to title
+// keywords, matched case-insensitively as substrings. An interim heuristic
+// until a proper keyword/tag column lands — imperfect, but far better than
+// the section going dark during the holiday itself.
+var seasonalKeywordTitles = map[string][]string{
+	"christmas":    {"christmas", "santa", "xmas", "nutcracker", "scrooge", "grinch", "noel"},
+	"st_patricks":  {"st. patrick", "leprechaun", "shamrock"},
+	"thanksgiving": {"thanksgiving"},
+}
+
+// seasonalThemeHasQuery reports whether a theme can produce items (either a
+// genre query or a title-keyword fallback). Passed to
+// ActiveSeasonalThemeWhere so multi-theme selection never picks a theme that
+// would resolve to nothing.
+func seasonalThemeHasQuery(theme string) bool {
+	if _, ok := seasonalQueryDef(theme); ok {
+		return true
+	}
+	return len(seasonalKeywordTitles[theme]) > 0
+}
+
+// fetchSeasonalKeywordItems resolves a keyword-based seasonal theme with a
+// direct title ILIKE query (the QueryDefinition system has no title filter
+// field). Ordering favors well-rated titles.
+func (f *Fetcher) fetchSeasonalKeywordItems(ctx context.Context, keywords []string, s ResolvedSection, libraryID *int, libraryIDs []int, filter catalog.AccessFilter) ([]*models.MediaItem, int, error) {
+	var conditions []string
+	var args []any
+	argIdx := 1
+
+	patterns := make([]string, 0, len(keywords))
+	for _, kw := range keywords {
+		patterns = append(patterns, "%"+kw+"%")
+	}
+	conditions = append(conditions, fmt.Sprintf("mi.title ILIKE ANY($%d)", argIdx))
+	args = append(args, patterns)
+	argIdx++
+
+	conditions = append(conditions, "mi.type IN ('movie','series')")
+
+	fromClause, libConditions, libArgs, newArgIdx := buildLibraryScope(libraryID, libraryIDs, nil, filter.DisabledLibraryIDs, argIdx)
+	conditions = append(conditions, libConditions...)
+	args = append(args, libArgs...)
+	argIdx = newArgIdx
+	catalog.ApplySectionAccessFilter("mi", filter, &conditions, &args, &argIdx)
+
+	conditions = append(conditions, catalog.MangaChapterExclusionWhere("mi"))
+
+	limit := s.ItemLimit
+	if limit <= 0 {
+		limit = 20
+	}
+
+	query := fmt.Sprintf(
+		`SELECT %s FROM %s WHERE %s ORDER BY mi.rating_imdb DESC NULLS LAST, mi.content_id ASC LIMIT $%d`,
+		itemColumns("mi"), fromClause, strings.Join(conditions, " AND "), argIdx,
+	)
+	args = append(args, limit)
+
+	rows, err := f.pool.Query(ctx, query, args...)
+	if err != nil {
+		return nil, 0, fmt.Errorf("fetching seasonal keyword items: %w", err)
+	}
+	defer rows.Close()
+
+	items, err := scanMediaItems(rows)
+	if err != nil {
+		return nil, 0, err
+	}
+	return items, len(items), nil
 }
 
 // fetchMoodCollection returns items for a mood_collection section.
@@ -3474,6 +3588,346 @@ func (f *Fetcher) fetchMoodCollection(ctx context.Context, s ResolvedSection, li
 		return nil, 0, fmt.Errorf("mood_collection query: %w", err)
 	}
 	return items, len(items), nil
+}
+
+// fetchShortWatches returns well-rated movies whose runtime fits under the
+// configured cap — a "fits in a short evening" rail.
+func (f *Fetcher) fetchShortWatches(ctx context.Context, s ResolvedSection, libraryID *int, libraryIDs []int, filter catalog.AccessFilter) ([]*models.MediaItem, int, error) {
+	var p recipes.ShortWatchesParams
+	if len(s.Config) > 0 {
+		_ = json.Unmarshal(s.Config, &p)
+	}
+	if p.MaxMinutes <= 0 {
+		p.MaxMinutes = 95
+	}
+	minRating := p.MinRating
+	if minRating == 0 {
+		minRating = 6.0
+	}
+
+	var conditions []string
+	var args []any
+	argIdx := 1
+
+	conditions = append(conditions,
+		"mi.type = 'movie'",
+		fmt.Sprintf("mi.runtime > 0 AND mi.runtime <= $%d", argIdx),
+	)
+	args = append(args, p.MaxMinutes)
+	argIdx++
+
+	conditions = append(conditions, fmt.Sprintf("mi.rating_imdb >= $%d", argIdx))
+	args = append(args, minRating)
+	argIdx++
+
+	fromClause, libConditions, libArgs, newArgIdx := buildLibraryScope(libraryID, libraryIDs, nil, filter.DisabledLibraryIDs, argIdx)
+	conditions = append(conditions, libConditions...)
+	args = append(args, libArgs...)
+	argIdx = newArgIdx
+	catalog.ApplySectionAccessFilter("mi", filter, &conditions, &args, &argIdx)
+
+	limit := s.ItemLimit
+	if limit <= 0 {
+		limit = 20
+	}
+
+	query := fmt.Sprintf(
+		`SELECT %s FROM %s WHERE %s ORDER BY mi.rating_imdb DESC NULLS LAST, mi.content_id ASC LIMIT $%d`,
+		itemColumns("mi"), fromClause, strings.Join(conditions, " AND "), argIdx,
+	)
+	args = append(args, limit)
+
+	rows, err := f.pool.Query(ctx, query, args...)
+	if err != nil {
+		return nil, 0, fmt.Errorf("fetching short watches: %w", err)
+	}
+	defer rows.Close()
+
+	items, err := scanMediaItems(rows)
+	if err != nil {
+		return nil, 0, err
+	}
+	return items, len(items), nil
+}
+
+// fetchAnniversaries returns movies whose release month matches the current
+// month and whose age is a round milestone (default: multiples of 5 years).
+// Series are excluded: first_air_date is a free-text column, so anniversary
+// math on it would be unreliable.
+func (f *Fetcher) fetchAnniversaries(ctx context.Context, s ResolvedSection, libraryID *int, libraryIDs []int, filter catalog.AccessFilter) ([]*models.MediaItem, int, error) {
+	var p recipes.AnniversariesParams
+	if len(s.Config) > 0 {
+		_ = json.Unmarshal(s.Config, &p)
+	}
+	milestone := p.MilestoneYears
+	if milestone <= 0 {
+		milestone = 5
+	}
+
+	now := f.now()
+
+	var conditions []string
+	var args []any
+	argIdx := 1
+
+	conditions = append(conditions,
+		"mi.type = 'movie'",
+		"mi.release_date IS NOT NULL",
+		fmt.Sprintf("EXTRACT(MONTH FROM mi.release_date)::int = $%d", argIdx),
+		fmt.Sprintf("EXTRACT(YEAR FROM mi.release_date)::int < $%d", argIdx+1),
+	)
+	args = append(args, int(now.Month()), now.Year())
+	argIdx += 2
+
+	if milestone > 1 {
+		conditions = append(conditions, fmt.Sprintf("($%d - EXTRACT(YEAR FROM mi.release_date)::int) %% $%d = 0", argIdx, argIdx+1))
+		args = append(args, now.Year(), milestone)
+		argIdx += 2
+	}
+
+	fromClause, libConditions, libArgs, newArgIdx := buildLibraryScope(libraryID, libraryIDs, nil, filter.DisabledLibraryIDs, argIdx)
+	conditions = append(conditions, libConditions...)
+	args = append(args, libArgs...)
+	argIdx = newArgIdx
+	catalog.ApplySectionAccessFilter("mi", filter, &conditions, &args, &argIdx)
+
+	limit := s.ItemLimit
+	if limit <= 0 {
+		limit = 20
+	}
+
+	query := fmt.Sprintf(
+		`SELECT %s FROM %s WHERE %s ORDER BY mi.rating_imdb DESC NULLS LAST, mi.content_id ASC LIMIT $%d`,
+		itemColumns("mi"), fromClause, strings.Join(conditions, " AND "), argIdx,
+	)
+	args = append(args, limit)
+
+	rows, err := f.pool.Query(ctx, query, args...)
+	if err != nil {
+		return nil, 0, fmt.Errorf("fetching anniversaries: %w", err)
+	}
+	defer rows.Close()
+
+	items, err := scanMediaItems(rows)
+	if err != nil {
+		return nil, 0, err
+	}
+	return items, len(items), nil
+}
+
+// fetchReturningShows returns series the profile has watched that received a
+// brand-new season (episodes in a season newer than any the profile has
+// watched, with at least one present file) within the lookback window,
+// newest arrivals first.
+func (f *Fetcher) fetchReturningShows(ctx context.Context, s ResolvedSection, libraryID *int, libraryIDs []int, userID int, profileID string, filter catalog.AccessFilter) ([]*models.MediaItem, int, error) {
+	if userID <= 0 || profileID == "" {
+		return []*models.MediaItem{}, 0, nil
+	}
+
+	var p recipes.ReturningShowsParams
+	if len(s.Config) > 0 {
+		_ = json.Unmarshal(s.Config, &p)
+	}
+	days := p.LookbackDays
+	if days <= 0 {
+		days = 30
+	}
+
+	var conditions []string
+	var args []any
+
+	// $1..$3 are shared by several subqueries below.
+	args = append(args, userID, profileID, days)
+	argIdx := 4
+
+	conditions = append(conditions,
+		"mi.type = 'series'",
+		// The profile has watched at least one episode of this series...
+		`EXISTS (
+			SELECT 1
+			FROM episodes we
+			JOIN user_watch_history uwh ON uwh.media_item_id = we.content_id
+			WHERE we.series_id = mi.content_id
+			  AND uwh.user_id = $1
+			  AND uwh.profile_id = $2
+		)`,
+		// ...and a season newer than any they've watched arrived recently
+		// with at least one playable file.
+		`EXISTS (
+			SELECT 1
+			FROM episodes ne
+			WHERE ne.series_id = mi.content_id
+			  AND ne.season_number > 0
+			  AND ne.created_at > NOW() - ($3 || ' days')::interval
+			  AND ne.season_number > COALESCE((
+				SELECT MAX(we2.season_number)
+				FROM episodes we2
+				JOIN user_watch_history uwh2 ON uwh2.media_item_id = we2.content_id
+				WHERE we2.series_id = mi.content_id
+				  AND uwh2.user_id = $1
+				  AND uwh2.profile_id = $2
+			  ), 0)
+			  AND EXISTS (
+				SELECT 1 FROM media_files mf
+				WHERE mf.episode_id = ne.content_id
+				  AND mf.missing_since IS NULL
+			  )
+		)`,
+	)
+
+	fromClause, libConditions, libArgs, newArgIdx := buildLibraryScope(libraryID, libraryIDs, nil, filter.DisabledLibraryIDs, argIdx)
+	conditions = append(conditions, libConditions...)
+	args = append(args, libArgs...)
+	argIdx = newArgIdx
+	catalog.ApplySectionAccessFilter("mi", filter, &conditions, &args, &argIdx)
+
+	limit := s.ItemLimit
+	if limit <= 0 {
+		limit = 20
+	}
+
+	query := fmt.Sprintf(
+		`SELECT %s FROM %s WHERE %s
+		ORDER BY (
+			SELECT MAX(ord.created_at)
+			FROM episodes ord
+			WHERE ord.series_id = mi.content_id
+			  AND ord.created_at > NOW() - ($3 || ' days')::interval
+		) DESC NULLS LAST, mi.content_id ASC
+		LIMIT $%d`,
+		itemColumns("mi"), fromClause, strings.Join(conditions, " AND "), argIdx,
+	)
+	args = append(args, limit)
+
+	rows, err := f.pool.Query(ctx, query, args...)
+	if err != nil {
+		return nil, 0, fmt.Errorf("fetching returning shows: %w", err)
+	}
+	defer rows.Close()
+
+	items, err := scanMediaItems(rows)
+	if err != nil {
+		return nil, 0, err
+	}
+	return items, len(items), nil
+}
+
+// fetchGenreRoulette is the title-less fallback used by fetchSection; FetchOne
+// intercepts genre_roulette to surface the rotating genre in the row title,
+// mirroring the editorial_spotlight flow.
+func (f *Fetcher) fetchGenreRoulette(ctx context.Context, s ResolvedSection, libraryID *int, libraryIDs []int, filter catalog.AccessFilter) ([]*models.MediaItem, int, error) {
+	items, total, _, err := f.fetchGenreRouletteWithTitle(ctx, s, libraryID, libraryIDs, filter)
+	return items, total, err
+}
+
+// fetchGenreRouletteWithTitle picks one of the library's top genres with the
+// same deterministic bucket hashing as editorial_spotlight and returns its
+// best-rated titles plus a display title carrying the active genre.
+func (f *Fetcher) fetchGenreRouletteWithTitle(ctx context.Context, s ResolvedSection, libraryID *int, libraryIDs []int, filter catalog.AccessFilter) ([]*models.MediaItem, int, string, error) {
+	var p recipes.GenreRouletteParams
+	if len(s.Config) > 0 {
+		_ = json.Unmarshal(s.Config, &p)
+	}
+	minRating := p.MinRating
+	if minRating == 0 {
+		minRating = 6.0
+	}
+
+	cands, err := f.cachedEditorialCandidates(ctx, "genre_roulette", libraryID, libraryIDs, filter, editorialCandidateCacheTTL, f.genreRouletteCandidates)
+	if err != nil {
+		return nil, 0, "", fmt.Errorf("genre_roulette candidates: %w", err)
+	}
+	if len(cands) == 0 {
+		return []*models.MediaItem{}, 0, "", nil
+	}
+
+	days := editorialCadenceDays(p.RotationCadence)
+	libKey := "all"
+	if libraryID != nil {
+		libKey = strconv.Itoa(*libraryID)
+	}
+	idx := recipes.RotationIndex(f.now(), "genre_roulette|"+libKey, len(cands), days)
+	genre := cands[idx]
+
+	def := catalog.QueryDefinition{
+		Match: "all",
+		Groups: []catalog.QueryGroup{
+			{Match: "all", Rules: []catalog.QueryRule{
+				{Field: "genre", Op: "contains", Value: genre},
+				{Field: "rating_imdb", Op: "gte", Value: minRating},
+			}},
+		},
+	}
+
+	switch {
+	case libraryID != nil:
+		def.LibraryIDs = []int{*libraryID}
+	case libraryIDs != nil:
+		def.LibraryIDs = append([]int(nil), libraryIDs...)
+	}
+
+	limit := s.ItemLimit
+	if limit <= 0 {
+		limit = 20
+	}
+	def.Limit = &limit
+
+	executor := &catalog.QueryExecutor{Pool: f.pool}
+	items, _, _, err := executor.PreviewPage(ctx, def.Normalize(), filter, limit, 0, false)
+	if err != nil {
+		return nil, 0, "", fmt.Errorf("genre_roulette query: %w", err)
+	}
+	return items, len(items), editorialSpotlightDisplayTitle(s.Title, genre), nil
+}
+
+// genreRouletteCandidates returns the most common genres in scope, mirroring
+// topStudioCandidates. The subjectType parameter is fixed ("genre_roulette")
+// and only exists to satisfy the shared candidate-loader signature.
+func (f *Fetcher) genreRouletteCandidates(ctx context.Context, _ string, libraryID *int, libraryIDs []int, filter catalog.AccessFilter) ([]string, error) {
+	var conditions []string
+	var args []any
+	argIdx := 1
+
+	fromClause, libConditions, libArgs, newArgIdx := buildLibraryScope(libraryID, libraryIDs, nil, filter.DisabledLibraryIDs, argIdx)
+	conditions = append(conditions, libConditions...)
+	args = append(args, libArgs...)
+	argIdx = newArgIdx
+	catalog.ApplySectionAccessFilter("mi", filter, &conditions, &args, &argIdx)
+
+	whereClause := ""
+	if len(conditions) > 0 {
+		whereClause = "AND " + strings.Join(conditions, " AND ")
+	}
+
+	args = append(args, editorialCandidateLimit)
+	query := fmt.Sprintf(`
+		SELECT genre
+		FROM (
+			SELECT unnest(mi.genres) AS genre
+			FROM %s
+			WHERE mi.genres IS NOT NULL
+			%s
+		) sub
+		GROUP BY genre
+		ORDER BY COUNT(*) DESC
+		LIMIT $%d
+	`, fromClause, whereClause, argIdx)
+
+	rows, err := f.pool.Query(ctx, query, args...)
+	if err != nil {
+		return nil, fmt.Errorf("querying top genres: %w", err)
+	}
+	defer rows.Close()
+
+	var genres []string
+	for rows.Next() {
+		var genre string
+		if err := rows.Scan(&genre); err != nil {
+			return nil, fmt.Errorf("scanning genre name: %w", err)
+		}
+		genres = append(genres, genre)
+	}
+	return genres, rows.Err()
 }
 
 // mangaChapterSeriesMetaQuery resolves the owning manga series for chapter

--- a/internal/sections/recently_added_query_test.go
+++ b/internal/sections/recently_added_query_test.go
@@ -44,8 +44,10 @@ func TestBuildRecentlyAddedQueryKeepsGenericPathForMultiLibraryConfig(t *testing
 	}, nil, nil, catalog.AccessFilter{})
 
 	for _, want := range []string{
-		"FROM media_items mi JOIN media_item_libraries mil ON mi.content_id = mil.content_id",
-		"mil.media_folder_id IN ($2, $3)",
+		"FROM media_items mi",
+		// Library scope is a semi-join so an item in several selected
+		// libraries yields one row (see buildLibraryScope).
+		"EXISTS (SELECT 1 FROM media_item_libraries mil_scope_in WHERE mil_scope_in.content_id = mi.content_id AND mil_scope_in.media_folder_id = ANY($2))",
 		"ORDER BY mi.created_at DESC, mi.content_id ASC",
 	} {
 		if !strings.Contains(query, want) {

--- a/internal/sections/recipes/discovery.go
+++ b/internal/sections/recipes/discovery.go
@@ -108,6 +108,10 @@ func (awardWinnersRecipe) Definition() RecipeDefinition {
 		Type:            "award_winners",
 		Category:        CategoryDiscovery,
 		AvoidDuplicates: true,
+		// The resolver is a stub until award metadata exists (see
+		// fetchAwardWinners). Hidden keeps existing saved sections resolvable
+		// (they render empty) without advertising presets that can't work.
+		Hidden: true,
 		Presets: []GalleryPreset{
 			{
 				Key:              "aw_oscar",
@@ -173,7 +177,8 @@ func (forgottenFavoritesRecipe) Definition() RecipeDefinition {
 
 // FormatShowcaseParams configures the format_showcase resolver.
 type FormatShowcaseParams struct {
-	Format string `json:"format"` // 4k | dolby_vision | hdr
+	Format string `json:"format"`         // 4k | dolby_vision | hdr
+	Sort   string `json:"sort,omitempty"` // rating (default) | recent
 }
 
 type formatShowcaseRecipe struct{}
@@ -194,9 +199,14 @@ func (formatShowcaseRecipe) Validate(raw json.RawMessage) error {
 	}
 	switch p.Format {
 	case "", "4k", "dolby_vision", "hdr":
-		return nil
 	default:
 		return errors.New("format_showcase: unknown format")
+	}
+	switch p.Sort {
+	case "", "rating", "recent":
+		return nil
+	default:
+		return errors.New("format_showcase: sort must be rating or recent")
 	}
 }
 func (formatShowcaseRecipe) Definition() RecipeDefinition {
@@ -206,6 +216,7 @@ func (formatShowcaseRecipe) Definition() RecipeDefinition {
 		AvoidDuplicates: false,
 		Presets: []GalleryPreset{
 			{Key: "fs_4k", DisplayName: "4K Showcase", Icon: "🎥", DescriptionShort: "Titles available in 4K UHD.", DefaultParams: json.RawMessage(`{"format":"4k"}`)},
+			{Key: "fs_4k_recent", DisplayName: "New in 4K", Icon: "🎥", DescriptionShort: "Recently added 4K UHD titles.", DefaultParams: json.RawMessage(`{"format":"4k","sort":"recent"}`)},
 			{Key: "fs_dv", DisplayName: "Dolby Vision Picks", Icon: "🌈", DescriptionShort: "Dolby Vision titles.", DefaultParams: json.RawMessage(`{"format":"dolby_vision"}`)},
 			{Key: "fs_hdr", DisplayName: "HDR Highlights", Icon: "✨", DescriptionShort: "HDR-mastered titles.", DefaultParams: json.RawMessage(`{"format":"hdr"}`)},
 		},

--- a/internal/sections/recipes/discovery.go
+++ b/internal/sections/recipes/discovery.go
@@ -2,7 +2,6 @@ package recipes
 
 import (
 	"encoding/json"
-	"errors"
 	"time"
 )
 
@@ -197,17 +196,10 @@ func (formatShowcaseRecipe) Validate(raw json.RawMessage) error {
 	if err := json.Unmarshal(raw, &p); err != nil {
 		return err
 	}
-	switch p.Format {
-	case "", "4k", "dolby_vision", "hdr":
-	default:
-		return errors.New("format_showcase: unknown format")
+	if err := oneOf("format_showcase: format", p.Format, "", "4k", "dolby_vision", "hdr"); err != nil {
+		return err
 	}
-	switch p.Sort {
-	case "", "rating", "recent":
-		return nil
-	default:
-		return errors.New("format_showcase: sort must be rating or recent")
-	}
+	return oneOf("format_showcase: sort", p.Sort, "", "rating", "recent")
 }
 func (formatShowcaseRecipe) Definition() RecipeDefinition {
 	return RecipeDefinition{

--- a/internal/sections/recipes/discovery_test.go
+++ b/internal/sections/recipes/discovery_test.go
@@ -126,10 +126,10 @@ func TestFormatShowcaseRecipeDefinition(t *testing.T) {
 	if def.AvoidDuplicates {
 		t.Errorf("format_showcase should not set AvoidDuplicates")
 	}
-	if len(def.Presets) != 3 {
-		t.Fatalf("expected 3 presets, got %d", len(def.Presets))
+	if len(def.Presets) != 4 {
+		t.Fatalf("expected 4 presets, got %d", len(def.Presets))
 	}
-	keys := map[string]bool{"fs_4k": false, "fs_dv": false, "fs_hdr": false}
+	keys := map[string]bool{"fs_4k": false, "fs_4k_recent": false, "fs_dv": false, "fs_hdr": false}
 	for _, p := range def.Presets {
 		keys[p.Key] = true
 	}

--- a/internal/sections/recipes/editorial.go
+++ b/internal/sections/recipes/editorial.go
@@ -94,16 +94,9 @@ func (editorialSpotlightRecipe) Validate(raw json.RawMessage) error {
 		return fmt.Errorf("editorial_spotlight: unknown subject_type %q", p.SubjectType)
 	}
 
-	// Default empty cadence to weekly before validating.
-	if p.RotationCadence == "" {
-		p.RotationCadence = CadenceWeekly
-	}
-
-	switch p.RotationCadence {
-	case CadenceDaily, CadenceWeekly, CadenceMonthly:
-		// valid
-	default:
-		return fmt.Errorf("editorial_spotlight: invalid rotation_cadence %q (want daily|weekly|monthly)", p.RotationCadence)
+	if err := oneOf("editorial_spotlight: rotation_cadence", string(p.RotationCadence),
+		"", string(CadenceDaily), string(CadenceWeekly), string(CadenceMonthly)); err != nil {
+		return err
 	}
 
 	if !p.AutoRotate && p.Subject == "" {
@@ -171,12 +164,8 @@ func (genreRouletteRecipe) Validate(raw json.RawMessage) error {
 	if err := json.Unmarshal(raw, &p); err != nil {
 		return err
 	}
-	switch p.RotationCadence {
-	case "", CadenceDaily, CadenceWeekly, CadenceMonthly:
-		return nil
-	default:
-		return fmt.Errorf("genre_roulette: invalid rotation_cadence %q (want daily|weekly|monthly)", p.RotationCadence)
-	}
+	return oneOf("genre_roulette: rotation_cadence", string(p.RotationCadence),
+		"", string(CadenceDaily), string(CadenceWeekly), string(CadenceMonthly))
 }
 func (genreRouletteRecipe) Definition() RecipeDefinition {
 	return RecipeDefinition{

--- a/internal/sections/recipes/editorial.go
+++ b/internal/sections/recipes/editorial.go
@@ -59,12 +59,14 @@ type EditorialSpotlightParams struct {
 	LibraryID       *int            `json:"library_id,omitempty"`
 }
 
+// Note: "franchise" is intentionally absent — the fetcher has no franchise
+// data source yet, so accepting it would validate configs that can never
+// resolve. Re-add once franchise/collection grouping data lands.
 var validSubjectTypes = map[string]bool{
-	"director":  true,
-	"studio":    true,
-	"actor":     true,
-	"era":       true,
-	"franchise": true,
+	"director": true,
+	"studio":   true,
+	"actor":    true,
+	"era":      true,
 }
 
 type editorialSpotlightRecipe struct{}
@@ -144,6 +146,103 @@ func (editorialSpotlightRecipe) Definition() RecipeDefinition {
 	}
 }
 
+// GenreRouletteParams configures genre_roulette: a deterministic rotating
+// spotlight on one of the library's top genres, using the same bucket hashing
+// as editorial_spotlight so every client sees the same genre for the whole
+// rotation window.
+type GenreRouletteParams struct {
+	RotationCadence RotationCadence `json:"rotation_cadence,omitempty"` // daily | weekly (default) | monthly
+	MinRating       float64         `json:"min_rating,omitempty"`       // default 6.0
+}
+
+type genreRouletteRecipe struct{}
+
+func (genreRouletteRecipe) Type() string                   { return "genre_roulette" }
+func (genreRouletteRecipe) NewParams() any                 { return &GenreRouletteParams{} }
+func (genreRouletteRecipe) DefaultCacheTTL() time.Duration { return 6 * time.Hour }
+func (genreRouletteRecipe) Resolve(rc ResolverContext) (ResolvedItems, error) {
+	return delegateResolve("genre_roulette", rc)
+}
+func (genreRouletteRecipe) Validate(raw json.RawMessage) error {
+	if len(raw) == 0 {
+		return nil
+	}
+	var p GenreRouletteParams
+	if err := json.Unmarshal(raw, &p); err != nil {
+		return err
+	}
+	switch p.RotationCadence {
+	case "", CadenceDaily, CadenceWeekly, CadenceMonthly:
+		return nil
+	default:
+		return fmt.Errorf("genre_roulette: invalid rotation_cadence %q (want daily|weekly|monthly)", p.RotationCadence)
+	}
+}
+func (genreRouletteRecipe) Definition() RecipeDefinition {
+	return RecipeDefinition{
+		Type:             "genre_roulette",
+		Category:         CategoryEditorial,
+		SupportsRotation: true,
+		Presets: []GalleryPreset{
+			{
+				Key:              "genre_roulette_weekly",
+				DisplayName:      "Genre Roulette",
+				Icon:             "🎰",
+				DescriptionShort: "A different genre from your library every week.",
+				DefaultParams:    json.RawMessage(`{"rotation_cadence":"weekly"}`),
+			},
+		},
+	}
+}
+
+// AnniversariesParams configures anniversaries: titles celebrating a round
+// release anniversary this month (e.g. released exactly 10/20/25 years ago).
+type AnniversariesParams struct {
+	// MilestoneYears keeps only anniversaries that are a multiple of this many
+	// years (default 5, so 5th/10th/15th/... anniversaries qualify). Set to 1
+	// to include every anniversary.
+	MilestoneYears int `json:"milestone_years,omitempty"`
+}
+
+type anniversariesRecipe struct{}
+
+func (anniversariesRecipe) Type() string                   { return "anniversaries" }
+func (anniversariesRecipe) NewParams() any                 { return &AnniversariesParams{} }
+func (anniversariesRecipe) DefaultCacheTTL() time.Duration { return 24 * time.Hour }
+func (anniversariesRecipe) Resolve(rc ResolverContext) (ResolvedItems, error) {
+	return delegateResolve("anniversaries", rc)
+}
+func (anniversariesRecipe) Validate(raw json.RawMessage) error {
+	if len(raw) == 0 {
+		return nil
+	}
+	var p AnniversariesParams
+	if err := json.Unmarshal(raw, &p); err != nil {
+		return err
+	}
+	if p.MilestoneYears < 0 {
+		return errors.New("anniversaries: milestone_years must be >= 0")
+	}
+	return nil
+}
+func (anniversariesRecipe) Definition() RecipeDefinition {
+	return RecipeDefinition{
+		Type:     "anniversaries",
+		Category: CategoryEditorial,
+		Presets: []GalleryPreset{
+			{
+				Key:              "anniversaries_default",
+				DisplayName:      "Anniversaries",
+				Icon:             "🎂",
+				DescriptionShort: "Titles celebrating a milestone release anniversary this month.",
+				DefaultParams:    json.RawMessage(`{"milestone_years":5}`),
+			},
+		},
+	}
+}
+
 func init() {
 	Register(editorialSpotlightRecipe{})
+	Register(genreRouletteRecipe{})
+	Register(anniversariesRecipe{})
 }

--- a/internal/sections/recipes/editorial_test.go
+++ b/internal/sections/recipes/editorial_test.go
@@ -103,13 +103,14 @@ func TestEditorialSpotlightAcceptsEraWithSubject(t *testing.T) {
 	}
 }
 
-func TestEditorialSpotlightAcceptsFranchiseWithSubject(t *testing.T) {
+func TestEditorialSpotlightRejectsFranchise(t *testing.T) {
 	rec, _ := Get("editorial_spotlight")
-	// Franchise data isn't wired up yet, but the validator must accept it
-	// so persisted configs round-trip cleanly.
+	// No franchise data source exists, so the fetcher can never resolve a
+	// franchise subject — accepting it here would let admins save a section
+	// that errors at fetch time. Reject until the data lands.
 	raw := json.RawMessage(`{"subject_type":"franchise","subject":"Marvel"}`)
-	if err := rec.Validate(raw); err != nil {
-		t.Errorf("valid franchise params rejected: %v", err)
+	if err := rec.Validate(raw); err == nil {
+		t.Error("franchise subject_type should be rejected until franchise data exists")
 	}
 }
 

--- a/internal/sections/recipes/mood.go
+++ b/internal/sections/recipes/mood.go
@@ -96,6 +96,52 @@ func (moodRecipe) Definition() RecipeDefinition {
 	}
 }
 
+// ShortWatchesParams configures short_watches: movies that fit in a short
+// evening slot, capped by runtime.
+type ShortWatchesParams struct {
+	MaxMinutes int     `json:"max_minutes,omitempty"` // default 95
+	MinRating  float64 `json:"min_rating,omitempty"`  // default 6.0
+}
+
+type shortWatchesRecipe struct{}
+
+func (shortWatchesRecipe) Type() string                   { return "short_watches" }
+func (shortWatchesRecipe) NewParams() any                 { return &ShortWatchesParams{} }
+func (shortWatchesRecipe) DefaultCacheTTL() time.Duration { return 6 * time.Hour }
+func (shortWatchesRecipe) Resolve(rc ResolverContext) (ResolvedItems, error) {
+	return delegateResolve("short_watches", rc)
+}
+func (shortWatchesRecipe) Validate(raw json.RawMessage) error {
+	if len(raw) == 0 {
+		return nil
+	}
+	var p ShortWatchesParams
+	if err := json.Unmarshal(raw, &p); err != nil {
+		return err
+	}
+	if p.MaxMinutes < 0 {
+		return errors.New("short_watches: max_minutes must be >= 0")
+	}
+	return nil
+}
+func (shortWatchesRecipe) Definition() RecipeDefinition {
+	return RecipeDefinition{
+		Type:            "short_watches",
+		Category:        CategoryMood,
+		AvoidDuplicates: true,
+		Presets: []GalleryPreset{
+			{
+				Key:              "short_watches_default",
+				DisplayName:      "Short & Sweet",
+				Icon:             "⏱️",
+				DescriptionShort: "Well-rated movies under 95 minutes.",
+				DefaultParams:    json.RawMessage(`{"max_minutes":95}`),
+			},
+		},
+	}
+}
+
 func init() {
 	Register(moodRecipe{})
+	Register(shortWatchesRecipe{})
 }

--- a/internal/sections/recipes/personalized.go
+++ b/internal/sections/recipes/personalized.go
@@ -78,7 +78,9 @@ func (similarUsersRecipe) Definition() RecipeDefinition {
 	}
 }
 
-// TasteMatchParams optionally narrows by genre.
+// TasteMatchParams optionally narrows by genre. When Genre is empty the
+// recommendation reader auto-picks the profile's strongest taste cluster
+// (falling back to the server-wide top genre).
 type TasteMatchParams struct {
 	Genre string `json:"genre"`
 }
@@ -104,7 +106,45 @@ func (tasteMatchRecipe) Definition() RecipeDefinition {
 		Category:        CategoryPersonalized,
 		AvoidDuplicates: true,
 		Presets: []GalleryPreset{
-			{Key: "taste_top", DisplayName: "Top Picks Today", Icon: "🎯", DescriptionShort: "Today's best matches for your taste.", DefaultParams: json.RawMessage(`{}`)},
+			{Key: "taste_top", DisplayName: "Top Picks Today", Icon: "🎯", DescriptionShort: "Best matches for your strongest taste — set a genre to narrow it.", DefaultParams: json.RawMessage(`{}`)},
+		},
+	}
+}
+
+// ReturningShowsParams configures returning_shows: series the profile has
+// watched that received a brand-new season within the lookback window.
+type ReturningShowsParams struct {
+	LookbackDays int `json:"lookback_days,omitempty"` // default 30
+}
+
+type returningShowsRecipe struct{}
+
+func (returningShowsRecipe) Type() string                   { return "returning_shows" }
+func (returningShowsRecipe) NewParams() any                 { return &ReturningShowsParams{} }
+func (returningShowsRecipe) DefaultCacheTTL() time.Duration { return time.Hour }
+func (returningShowsRecipe) Resolve(rc ResolverContext) (ResolvedItems, error) {
+	return delegateResolve("returning_shows", rc)
+}
+func (returningShowsRecipe) Validate(raw json.RawMessage) error {
+	if len(raw) == 0 {
+		return nil
+	}
+	var p ReturningShowsParams
+	return json.Unmarshal(raw, &p)
+}
+func (returningShowsRecipe) Definition() RecipeDefinition {
+	return RecipeDefinition{
+		Type:            "returning_shows",
+		Category:        CategoryPersonalized,
+		AvoidDuplicates: true,
+		Presets: []GalleryPreset{
+			{
+				Key:              "returning_shows_default",
+				DisplayName:      "Returning Shows",
+				Icon:             "🔁",
+				DescriptionShort: "Shows you've watched with a brand-new season in your library.",
+				DefaultParams:    json.RawMessage(`{"lookback_days":30}`),
+			},
 		},
 	}
 }
@@ -114,4 +154,5 @@ func init() {
 	Register(becauseRecipe{})
 	Register(similarUsersRecipe{})
 	Register(tasteMatchRecipe{})
+	Register(returningShowsRecipe{})
 }

--- a/internal/sections/recipes/personalized.go
+++ b/internal/sections/recipes/personalized.go
@@ -2,6 +2,7 @@ package recipes
 
 import (
 	"encoding/json"
+	"errors"
 	"time"
 )
 
@@ -130,7 +131,13 @@ func (returningShowsRecipe) Validate(raw json.RawMessage) error {
 		return nil
 	}
 	var p ReturningShowsParams
-	return json.Unmarshal(raw, &p)
+	if err := json.Unmarshal(raw, &p); err != nil {
+		return err
+	}
+	if p.LookbackDays < 0 {
+		return errors.New("returning_shows: lookback_days must be >= 0")
+	}
+	return nil
 }
 func (returningShowsRecipe) Definition() RecipeDefinition {
 	return RecipeDefinition{

--- a/internal/sections/recipes/presets_test.go
+++ b/internal/sections/recipes/presets_test.go
@@ -1,0 +1,52 @@
+package recipes
+
+import "testing"
+
+// presetsRequiringInput lists preset keys whose DefaultParams are intentionally
+// incomplete: the add-section drawer blocks saving until the admin supplies
+// the missing value (a collection id, curated item list, ...). Every other
+// preset must ship defaults that pass its own recipe's Validate — a preset
+// that fails validation out of the box is un-addable from the gallery.
+var presetsRequiringInput = map[string]bool{
+	"collection_pick":          true, // collection: requires picking a collection
+	"trakt_trending_movies":    true, // collection: Trakt sync target chosen/created at add time
+	"trakt_trending_shows":     true,
+	"trakt_popular_movies":     true,
+	"trakt_popular_shows":      true,
+	"trakt_recommended_movies": true,
+	"trakt_recommended_shows":  true,
+	"acl_blank":                true, // admin_curated_list: drawer requires at least one item
+}
+
+func TestAllGalleryPresetDefaultsValidate(t *testing.T) {
+	for _, rec := range List() {
+		def := rec.Definition()
+		if def.Hidden {
+			continue
+		}
+		for _, preset := range def.Presets {
+			if presetsRequiringInput[preset.Key] {
+				continue
+			}
+			if err := rec.Validate(preset.DefaultParams); err != nil {
+				t.Errorf("recipe %s preset %s: default params fail validation: %v", def.Type, preset.Key, err)
+			}
+		}
+	}
+}
+
+// TestHiddenRecipesStayResolvable pins the contract that Hidden recipes remain
+// registered (existing saved sections keep resolving) while the gallery omits
+// them.
+func TestHiddenRecipesStayResolvable(t *testing.T) {
+	for _, typ := range []string{"award_winners", "genre"} {
+		rec, ok := Get(typ)
+		if !ok {
+			t.Errorf("hidden recipe %s must stay registered", typ)
+			continue
+		}
+		if !rec.Definition().Hidden {
+			t.Errorf("recipe %s expected Hidden", typ)
+		}
+	}
+}

--- a/internal/sections/recipes/seasonal.go
+++ b/internal/sections/recipes/seasonal.go
@@ -49,6 +49,18 @@ func weekdayBeforeHour(weekday time.Weekday, hour int) DatePredicate {
 	}
 }
 
+// weekdaysFromHour returns a predicate that matches times on any of the given
+// weekdays at or after the given hour (24-hour, e.g. 17 for 5pm).
+func weekdaysFromHour(hour int, weekdays ...time.Weekday) DatePredicate {
+	set := make(map[time.Weekday]bool, len(weekdays))
+	for _, d := range weekdays {
+		set[d] = true
+	}
+	return func(t time.Time) bool {
+		return set[t.Weekday()] && t.Hour() >= hour
+	}
+}
+
 // SeasonalPredicates maps theme names to their date predicates.
 // Themes without a predicate here are not supported.
 var SeasonalPredicates = map[string]DatePredicate{
@@ -60,6 +72,7 @@ var SeasonalPredicates = map[string]DatePredicate{
 	"summer":             inMonths(time.June, time.July, time.August),
 	"summer_blockbuster": inMonths(time.June, time.July, time.August),
 	"saturday_morning":   weekdayBeforeHour(time.Saturday, 13),
+	"family_movie_night": weekdaysFromHour(17, time.Friday, time.Saturday),
 }
 
 // SeasonalThemeOrder lists themes from most-specific to most-general. When
@@ -73,6 +86,7 @@ var SeasonalThemeOrder = []string{
 	"christmas",
 	"halloween",
 	"saturday_morning",
+	"family_movie_night",
 	"summer_blockbuster",
 	"summer",
 }
@@ -174,6 +188,13 @@ func (seasonalRecipe) Definition() RecipeDefinition {
 					`{"enabled_themes":["halloween","christmas","valentines","st_patricks","thanksgiving","summer_blockbuster","saturday_morning"]}`,
 				),
 			},
+			{
+				Key:              "se_family_movie_night",
+				DisplayName:      "Family Movie Night",
+				Icon:             "🍿",
+				DescriptionShort: "Family picks on Friday and Saturday evenings.",
+				DefaultParams:    json.RawMessage(`{"enabled_themes":["family_movie_night"]}`),
+			},
 		},
 	}
 }
@@ -181,12 +202,14 @@ func (seasonalRecipe) Definition() RecipeDefinition {
 // SeasonalTitleOverride returns the per-theme display name for the active
 // theme, or "" when no override is configured (or no theme is active). The
 // fetcher applies the override only when non-empty, so callers can fall back
-// to the section's saved Title.
-func SeasonalTitleOverride(p SeasonalThemedParams, now time.Time) string {
+// to the section's saved Title. The usable filter must match the one passed
+// to ActiveSeasonalThemeWhere so the override tracks the theme that actually
+// resolved; pass nil to consider every theme usable.
+func SeasonalTitleOverride(p SeasonalThemedParams, now time.Time, usable func(theme string) bool) string {
 	var theme string
 	switch {
 	case len(p.EnabledThemes) > 0:
-		theme = ActiveSeasonalTheme(p.EnabledThemes, now)
+		theme = ActiveSeasonalThemeWhere(p.EnabledThemes, now, usable)
 	case p.Theme != "":
 		// Legacy mode — only honour an override if the predicate currently fires.
 		pred, ok := SeasonalPredicates[p.Theme]
@@ -204,6 +227,16 @@ func SeasonalTitleOverride(p SeasonalThemedParams, now time.Time) string {
 // predicate matches `now`. Returns "" when no enabled theme is in season.
 // Themes not in SeasonalThemeOrder are skipped silently.
 func ActiveSeasonalTheme(enabled []string, now time.Time) string {
+	return ActiveSeasonalThemeWhere(enabled, now, nil)
+}
+
+// ActiveSeasonalThemeWhere is ActiveSeasonalTheme with an extra usable filter:
+// an in-season theme that fails the filter is skipped so a lower-priority
+// in-season theme can win instead. The fetcher passes "has an executable
+// query" here so a theme without backing data never blacks out the section
+// during its own window (e.g. an enabled theme whose query support hasn't
+// landed yet outranking one that works). A nil filter accepts every theme.
+func ActiveSeasonalThemeWhere(enabled []string, now time.Time, usable func(theme string) bool) string {
 	if len(enabled) == 0 {
 		return ""
 	}
@@ -213,6 +246,9 @@ func ActiveSeasonalTheme(enabled []string, now time.Time) string {
 	}
 	for _, t := range SeasonalThemeOrder {
 		if !enabledSet[t] {
+			continue
+		}
+		if usable != nil && !usable(t) {
 			continue
 		}
 		pred, ok := SeasonalPredicates[t]

--- a/internal/sections/recipes/seasonal_test.go
+++ b/internal/sections/recipes/seasonal_test.go
@@ -276,19 +276,19 @@ func TestSeasonalTitleOverridePicksActiveThemeTitle(t *testing.T) {
 	}
 
 	// October — halloween fires.
-	got := SeasonalTitleOverride(p, time.Date(2026, 10, 14, 12, 0, 0, 0, time.UTC))
+	got := SeasonalTitleOverride(p, time.Date(2026, 10, 14, 12, 0, 0, 0, time.UTC), nil)
 	if got != "Spooky Picks" {
 		t.Errorf("Oct 14 → %q, want Spooky Picks", got)
 	}
 
 	// December — christmas fires.
-	got = SeasonalTitleOverride(p, time.Date(2026, 12, 20, 12, 0, 0, 0, time.UTC))
+	got = SeasonalTitleOverride(p, time.Date(2026, 12, 20, 12, 0, 0, 0, time.UTC), nil)
 	if got != "Festive Films" {
 		t.Errorf("Dec 20 → %q, want Festive Films", got)
 	}
 
 	// April — nothing fires, no override.
-	got = SeasonalTitleOverride(p, time.Date(2026, 4, 15, 12, 0, 0, 0, time.UTC))
+	got = SeasonalTitleOverride(p, time.Date(2026, 4, 15, 12, 0, 0, 0, time.UTC), nil)
 	if got != "" {
 		t.Errorf("Apr 15 → %q, want empty", got)
 	}
@@ -301,7 +301,7 @@ func TestSeasonalTitleOverrideHandlesMissingEntry(t *testing.T) {
 		EnabledThemes: []string{"halloween", "christmas"},
 		ThemeTitles:   map[string]string{"christmas": "Festive Films"},
 	}
-	got := SeasonalTitleOverride(p, time.Date(2026, 10, 14, 12, 0, 0, 0, time.UTC))
+	got := SeasonalTitleOverride(p, time.Date(2026, 10, 14, 12, 0, 0, 0, time.UTC), nil)
 	if got != "" {
 		t.Errorf("halloween active but no entry → %q, want empty (caller falls back to section Title)", got)
 	}
@@ -315,11 +315,11 @@ func TestSeasonalTitleOverrideLegacyMode(t *testing.T) {
 		Mode:        "auto",
 		ThemeTitles: map[string]string{"halloween": "Spooky"},
 	}
-	got := SeasonalTitleOverride(p, time.Date(2026, 10, 14, 12, 0, 0, 0, time.UTC))
+	got := SeasonalTitleOverride(p, time.Date(2026, 10, 14, 12, 0, 0, 0, time.UTC), nil)
 	if got != "Spooky" {
 		t.Errorf("legacy in-season → %q, want Spooky", got)
 	}
-	got = SeasonalTitleOverride(p, time.Date(2026, 4, 15, 12, 0, 0, 0, time.UTC))
+	got = SeasonalTitleOverride(p, time.Date(2026, 4, 15, 12, 0, 0, 0, time.UTC), nil)
 	if got != "" {
 		t.Errorf("legacy off-season → %q, want empty", got)
 	}
@@ -338,5 +338,58 @@ func TestSeasonalValidatesEnabledThemes(t *testing.T) {
 	bad := json.RawMessage(`{"enabled_themes":["halloween","made_up"]}`)
 	if err := rec.Validate(bad); err == nil {
 		t.Error("expected error for unknown theme in enabled_themes")
+	}
+}
+
+// TestFamilyMovieNightPredicate pins the window: Friday and Saturday from 5pm,
+// rejecting earlier hours and other weekdays.
+func TestFamilyMovieNightPredicate(t *testing.T) {
+	pred, ok := SeasonalPredicates["family_movie_night"]
+	if !ok {
+		t.Fatal("family_movie_night predicate not found")
+	}
+
+	// 2026-04-10 is a Friday, 2026-04-11 a Saturday, 2026-04-12 a Sunday.
+	friEvening := time.Date(2026, time.April, 10, 19, 0, 0, 0, time.UTC)
+	if !pred(friEvening) {
+		t.Error("should match Friday 7pm")
+	}
+	satFivePM := time.Date(2026, time.April, 11, 17, 0, 0, 0, time.UTC)
+	if !pred(satFivePM) {
+		t.Error("should match Saturday 5pm (inclusive)")
+	}
+	friAfternoon := time.Date(2026, time.April, 10, 16, 59, 0, 0, time.UTC)
+	if pred(friAfternoon) {
+		t.Error("should reject Friday 4:59pm")
+	}
+	sunEvening := time.Date(2026, time.April, 12, 19, 0, 0, 0, time.UTC)
+	if pred(sunEvening) {
+		t.Error("should reject Sunday evening")
+	}
+}
+
+// TestActiveSeasonalThemeWhereSkipsUnusable verifies that an in-season theme
+// failing the usable filter yields to a lower-priority in-season theme instead
+// of blacking out the section — the December regression where an enabled
+// christmas theme without query support suppressed halloween/saturday rails.
+func TestActiveSeasonalThemeWhereSkipsUnusable(t *testing.T) {
+	enabled := []string{"christmas", "saturday_morning"}
+	// A Saturday morning in December: christmas outranks saturday_morning.
+	saturdayInDecember := time.Date(2026, time.December, 12, 9, 0, 0, 0, time.UTC)
+
+	got := ActiveSeasonalThemeWhere(enabled, saturdayInDecember, nil)
+	if got != "christmas" {
+		t.Fatalf("nil filter should pick christmas, got %q", got)
+	}
+
+	noChristmas := func(theme string) bool { return theme != "christmas" }
+	got = ActiveSeasonalThemeWhere(enabled, saturdayInDecember, noChristmas)
+	if got != "saturday_morning" {
+		t.Errorf("filtered selection should fall through to saturday_morning, got %q", got)
+	}
+
+	nothingUsable := func(string) bool { return false }
+	if got := ActiveSeasonalThemeWhere(enabled, saturdayInDecember, nothingUsable); got != "" {
+		t.Errorf("expected no theme when nothing is usable, got %q", got)
 	}
 }

--- a/internal/sections/recipes/seasonal_test.go
+++ b/internal/sections/recipes/seasonal_test.go
@@ -393,3 +393,26 @@ func TestActiveSeasonalThemeWhereSkipsUnusable(t *testing.T) {
 		t.Errorf("expected no theme when nothing is usable, got %q", got)
 	}
 }
+
+// TestSeasonalTitleOverrideHonorsUsableFilter verifies the title override
+// follows the same filtered selection as the fetcher: when the top-priority
+// in-season theme is unusable, the override comes from the theme that
+// actually resolves.
+func TestSeasonalTitleOverrideHonorsUsableFilter(t *testing.T) {
+	p := SeasonalThemedParams{
+		EnabledThemes: []string{"christmas", "saturday_morning"},
+		ThemeTitles: map[string]string{
+			"christmas":        "Christmas Movies",
+			"saturday_morning": "Saturday Cartoons",
+		},
+	}
+	saturdayInDecember := time.Date(2026, time.December, 12, 9, 0, 0, 0, time.UTC)
+
+	if got := SeasonalTitleOverride(p, saturdayInDecember, nil); got != "Christmas Movies" {
+		t.Errorf("nil filter: got %q, want Christmas Movies", got)
+	}
+	noChristmas := func(theme string) bool { return theme != "christmas" }
+	if got := SeasonalTitleOverride(p, saturdayInDecember, noChristmas); got != "Saturday Cartoons" {
+		t.Errorf("filtered: got %q, want Saturday Cartoons", got)
+	}
+}

--- a/internal/sections/recipes/types.go
+++ b/internal/sections/recipes/types.go
@@ -3,6 +3,8 @@ package recipes
 import (
 	"context"
 	"encoding/json"
+	"fmt"
+	"strings"
 	"time"
 
 	"github.com/Silo-Server/silo-server/internal/catalog"
@@ -112,6 +114,17 @@ type ResolvedItems struct {
 	Suppressed    bool          // when true, dispatcher omits the section
 	LayoutHint    string        // poster | landscape | hero | square
 	CacheTTL      time.Duration // 0 = use DefaultCacheTTL
+}
+
+// oneOf validates an enum-style string param against its allowed values.
+// Shared by recipe validators so allowed-value checks read identically.
+func oneOf(field, value string, allowed ...string) error {
+	for _, a := range allowed {
+		if value == a {
+			return nil
+		}
+	}
+	return fmt.Errorf("%s: invalid value %q (want one of %s)", field, value, strings.Join(allowed, "|"))
 }
 
 // Recipe is the contract every section type implements.

--- a/internal/sections/seasonal_query_test.go
+++ b/internal/sections/seasonal_query_test.go
@@ -1,0 +1,59 @@
+package sections
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/Silo-Server/silo-server/internal/sections/recipes"
+)
+
+// TestSeasonalThemeHasQueryCoversAllOrderedThemes ensures every theme that can
+// win multi-theme selection resolves to either a genre query or a keyword
+// fallback. A theme in SeasonalThemeOrder without either would black out the
+// section during its own window.
+func TestSeasonalThemeHasQueryCoversAllOrderedThemes(t *testing.T) {
+	for _, theme := range recipes.SeasonalThemeOrder {
+		if !seasonalThemeHasQuery(theme) {
+			t.Errorf("theme %q is selectable (SeasonalThemeOrder) but has no query or keyword fallback", theme)
+		}
+	}
+}
+
+// TestSeasonalKeywordThemesHaveNoGenreQuery pins the routing: keyword themes
+// must not also have a genre QueryDefinition, otherwise the keyword fallback
+// is dead code.
+func TestSeasonalKeywordThemesHaveNoGenreQuery(t *testing.T) {
+	for theme := range seasonalKeywordTitles {
+		if _, ok := seasonalQueryDef(theme); ok {
+			t.Errorf("theme %q has both a genre query and keyword fallback; keyword path unreachable", theme)
+		}
+		if _, ok := recipes.SeasonalPredicates[theme]; !ok {
+			t.Errorf("keyword theme %q has no seasonal predicate", theme)
+		}
+	}
+}
+
+// TestRecommendationConfigAnchorPrecedence verifies because_you_watched honors
+// both the legacy source_item_id key and the recipe's anchor_item_id key,
+// preferring the legacy key when both are set.
+func TestRecommendationConfigAnchorPrecedence(t *testing.T) {
+	cases := []struct {
+		name   string
+		config string
+		want   string
+	}{
+		{"anchor only", `{"anchor_item_id":"abc"}`, "abc"},
+		{"source only", `{"source_item_id":"def"}`, "def"},
+		{"both set prefers legacy", `{"source_item_id":"def","anchor_item_id":"abc"}`, "def"},
+		{"blank strings auto-pick", `{"source_item_id":"","anchor_item_id":"  "}`, ""},
+		{"empty config auto-picks", `{}`, ""},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			cfg := parseRecommendationSectionConfig(json.RawMessage(tc.config))
+			if got := cfg.anchor(); got != tc.want {
+				t.Errorf("anchor() = %q, want %q", got, tc.want)
+			}
+		})
+	}
+}

--- a/internal/sections/types.go
+++ b/internal/sections/types.go
@@ -44,6 +44,11 @@ const (
 	SectionTrendingDiscover SectionType = "trending_discover"
 
 	SectionAdminCuratedList SectionType = "admin_curated_list"
+
+	SectionReturningShows SectionType = "returning_shows"
+	SectionGenreRoulette  SectionType = "genre_roulette"
+	SectionAnniversaries  SectionType = "anniversaries"
+	SectionShortWatches   SectionType = "short_watches"
 )
 
 // ValidSectionTypes is the set of all valid section type values.
@@ -77,6 +82,10 @@ var ValidSectionTypes = map[SectionType]bool{
 	SectionMostWatched:         true,
 	SectionTrendingDiscover:    true,
 	SectionAdminCuratedList:    true,
+	SectionReturningShows:      true,
+	SectionGenreRoulette:       true,
+	SectionAnniversaries:       true,
+	SectionShortWatches:        true,
 }
 
 // PageSection is an admin-defined section stored in PostgreSQL.

--- a/web/src/components/RecipeGallery/RecipeConfigDrawer.tsx
+++ b/web/src/components/RecipeGallery/RecipeConfigDrawer.tsx
@@ -56,9 +56,12 @@ export default function RecipeConfigDrawer({
     (params.source_preset === "trending" || params.source_preset === "popular");
   const collectionMissing =
     def.type === "collection" && collectionID.trim() === "" && !isAutoBackedTraktPreset;
+  const curatedListEmpty =
+    def.type === "admin_curated_list" &&
+    (!Array.isArray(params.item_ids) || params.item_ids.length === 0);
 
   const handleAdd = () => {
-    if (collectionMissing) {
+    if (collectionMissing || curatedListEmpty) {
       return;
     }
     const payload = {
@@ -120,6 +123,10 @@ export default function RecipeConfigDrawer({
         </p>
       ) : null}
 
+      {curatedListEmpty ? (
+        <p className="mt-2 text-xs text-amber-300">Add at least one title to the curated list.</p>
+      ) : null}
+
       <div className="mt-4">
         <label className="mb-1 block text-xs text-white/70">Item limit</label>
         <input
@@ -166,7 +173,7 @@ export default function RecipeConfigDrawer({
         <button
           type="button"
           onClick={handleAdd}
-          disabled={collectionMissing}
+          disabled={collectionMissing || curatedListEmpty}
           className="rounded bg-indigo-600 px-3 py-1 text-sm text-white disabled:cursor-not-allowed disabled:opacity-50"
         >
           Add section

--- a/web/src/components/RecipeGallery/RecipeGalleryModal.tsx
+++ b/web/src/components/RecipeGallery/RecipeGalleryModal.tsx
@@ -34,9 +34,15 @@ interface Props {
   open: boolean;
   onClose: () => void;
   onPick: (def: RecipeDefinition, preset: GalleryPreset) => void;
+  /**
+   * Hide recipes flagged admin_only by the backend. Set on profile-facing
+   * surfaces (customize home, home settings); the admin sections page shows
+   * everything.
+   */
+  hideAdminOnly?: boolean;
 }
 
-export default function RecipeGalleryModal({ open, onClose, onPick }: Props) {
+export default function RecipeGalleryModal({ open, onClose, onPick, hideAdminOnly }: Props) {
   const [catalog, setCatalog] = useState<Partial<Record<Category, RecipeDefinition[]>>>({});
   const [search, setSearch] = useState("");
   const [activeCategory, setActiveCategory] = useState<Category | "all">("all");
@@ -54,6 +60,7 @@ export default function RecipeGalleryModal({ open, onClose, onPick }: Props) {
     for (const cat of Object.keys(catalog) as Category[]) {
       if (activeCategory !== "all" && activeCategory !== cat) continue;
       for (const def of catalog[cat] ?? []) {
+        if (hideAdminOnly && def.admin_only) continue;
         for (const preset of def.presets ?? []) {
           const s = search.trim() ? score(search.trim(), preset) : 1;
           if (s === 0) continue;
@@ -65,7 +72,7 @@ export default function RecipeGalleryModal({ open, onClose, onPick }: Props) {
       rows.sort((a, b) => b.score - a.score);
     }
     return rows;
-  }, [catalog, search, activeCategory]);
+  }, [catalog, search, activeCategory, hideAdminOnly]);
 
   if (!open) return null;
 

--- a/web/src/components/RecipeGallery/RecipeParamFields.tsx
+++ b/web/src/components/RecipeGallery/RecipeParamFields.tsx
@@ -1,11 +1,12 @@
 import { useMemo, useState } from "react";
-import { useQuery } from "@tanstack/react-query";
+import { useQueries, useQuery } from "@tanstack/react-query";
 import { CollectionSearchableSelect } from "@/components/CollectionSearchableSelect";
 import LibraryMultiSelect from "@/components/LibraryMultiSelect";
 import { useAllUserCollections } from "@/hooks/queries/useAllUserCollections";
 import { useAvailableUserLibraries } from "@/hooks/queries/libraries";
 import { createCatalogSearchState, fetchCatalogPage } from "@/hooks/queries/catalog";
-import { catalogKeys } from "@/hooks/queries/keys";
+import { fetchWatchDetail } from "@/hooks/queries/items";
+import { catalogKeys, itemKeys } from "@/hooks/queries/keys";
 import { useDebounce } from "@/hooks/useDebounce";
 import type { BrowseItem } from "@/api/types";
 import type { RecipeDefinition } from "@/lib/recipes";
@@ -413,15 +414,18 @@ function NumberParamField({
       <input
         type="number"
         min={1}
+        step={1}
         className="w-full rounded border border-white/15 bg-white/5 px-3 py-2 text-sm"
         placeholder={placeholder}
         value={value}
         onChange={(e) => {
           const parsed = Number(e.target.value);
+          // All numeric recipe params are Go ints server-side; storing a
+          // fractional value would fail JSON unmarshalling at save time.
           onChange({
             ...params,
             [paramKey]:
-              e.target.value && Number.isFinite(parsed) && parsed > 0 ? parsed : undefined,
+              e.target.value && Number.isInteger(parsed) && parsed > 0 ? parsed : undefined,
           });
         }}
       />
@@ -433,10 +437,15 @@ function NumberParamField({
 const CURATED_SEARCH_LIMIT = 10;
 const CURATED_SEARCH_DEBOUNCE_MS = 250;
 
+function curatedItemLabel(title: string, year?: number): string {
+  return year ? `${title} (${year})` : title;
+}
+
 // CuratedItemsParamField builds the ordered item_ids list for
 // admin_curated_list sections: catalog search on top, the picked (ordered)
-// list below. Titles for picked items are remembered locally from search
-// results; items persisted before this drawer opened fall back to their id.
+// list below. Titles for freshly added items come from the search result;
+// items persisted before this drawer opened are hydrated from the item
+// detail endpoint, falling back to the raw id while loading.
 function CuratedItemsParamField({ params, onChange }: ParamFieldProps) {
   const [query, setQuery] = useState("");
   const [labels, setLabels] = useState<Record<string, string>>({});
@@ -446,6 +455,24 @@ function CuratedItemsParamField({ params, onChange }: ParamFieldProps) {
     ? params.item_ids.filter((id): id is string => typeof id === "string")
     : [];
   const picked = new Set(itemIDs);
+
+  // Hydrate display titles for ids we have no label for (pre-existing config
+  // being edited). Cached under the same key as the watch-detail hook.
+  const unlabeled = itemIDs.filter((id) => !(id in labels));
+  const detailQueries = useQueries({
+    queries: unlabeled.map((id) => ({
+      queryKey: itemKeys.watchDetail(id),
+      queryFn: ({ signal }: { signal?: AbortSignal }) =>
+        fetchWatchDetail(id, undefined, undefined, { signal }),
+      staleTime: 5 * 60 * 1000,
+      retry: false,
+    })),
+  });
+  const hydratedLabels: Record<string, string> = {};
+  unlabeled.forEach((id, i) => {
+    const detail = detailQueries[i]?.data;
+    if (detail) hydratedLabels[id] = curatedItemLabel(detail.title, detail.year);
+  });
 
   const searchState = useMemo(
     () => createCatalogSearchState("query", { q: debounced || undefined }),
@@ -471,7 +498,7 @@ function CuratedItemsParamField({ params, onChange }: ParamFieldProps) {
     if (picked.has(item.content_id)) return;
     setLabels((prev) => ({
       ...prev,
-      [item.content_id]: item.year ? `${item.title} (${item.year})` : item.title,
+      [item.content_id]: curatedItemLabel(item.title, item.year),
     }));
     onChange({ ...params, item_ids: [...itemIDs, item.content_id] });
   }
@@ -503,6 +530,8 @@ function CuratedItemsParamField({ params, onChange }: ParamFieldProps) {
         />
         {debounced.length === 0 ? null : results.isLoading ? (
           <div className="mt-2 text-xs text-white/50">Searching…</div>
+        ) : results.isError ? (
+          <div className="mt-2 text-xs text-amber-300">Search failed — try again.</div>
         ) : found.length === 0 ? (
           <div className="mt-2 text-xs text-white/50">No matches.</div>
         ) : (
@@ -546,7 +575,9 @@ function CuratedItemsParamField({ params, onChange }: ParamFieldProps) {
           <ul className="divide-y divide-white/10 rounded border border-white/10">
             {itemIDs.map((id, idx) => (
               <li key={id} className="flex items-center gap-2 px-3 py-2 text-sm">
-                <span className="min-w-0 flex-1 truncate">{labels[id] ?? id}</span>
+                <span className="min-w-0 flex-1 truncate">
+                  {labels[id] ?? hydratedLabels[id] ?? id}
+                </span>
                 <button
                   type="button"
                   onClick={() => move(id, -1)}

--- a/web/src/components/RecipeGallery/RecipeParamFields.tsx
+++ b/web/src/components/RecipeGallery/RecipeParamFields.tsx
@@ -1,7 +1,13 @@
+import { useMemo, useState } from "react";
+import { useQuery } from "@tanstack/react-query";
 import { CollectionSearchableSelect } from "@/components/CollectionSearchableSelect";
 import LibraryMultiSelect from "@/components/LibraryMultiSelect";
 import { useAllUserCollections } from "@/hooks/queries/useAllUserCollections";
 import { useAvailableUserLibraries } from "@/hooks/queries/libraries";
+import { createCatalogSearchState, fetchCatalogPage } from "@/hooks/queries/catalog";
+import { catalogKeys } from "@/hooks/queries/keys";
+import { useDebounce } from "@/hooks/useDebounce";
+import type { BrowseItem } from "@/api/types";
 import type { RecipeDefinition } from "@/lib/recipes";
 
 export interface RecipeParamFieldsProps {
@@ -23,9 +29,52 @@ export default function RecipeParamFields({ def, params, onChange }: RecipeParam
   if (def.type === "seasonal_themed") {
     return <SeasonalParamField params={params} onChange={onChange} />;
   }
+  if (def.type === "admin_curated_list") {
+    return <CuratedItemsParamField params={params} onChange={onChange} />;
+  }
+  if (def.type === "returning_shows") {
+    return (
+      <NumberParamField
+        params={params}
+        onChange={onChange}
+        paramKey="lookback_days"
+        label="Lookback window (days)"
+        placeholder="30"
+        hint="How far back a new season counts as “just arrived”."
+      />
+    );
+  }
+  if (def.type === "short_watches") {
+    return (
+      <NumberParamField
+        params={params}
+        onChange={onChange}
+        paramKey="max_minutes"
+        label="Maximum runtime (minutes)"
+        placeholder="95"
+        hint="Movies at or under this runtime qualify."
+      />
+    );
+  }
+  if (def.type === "anniversaries") {
+    return (
+      <NumberParamField
+        params={params}
+        onChange={onChange}
+        paramKey="milestone_years"
+        label="Milestone (years)"
+        placeholder="5"
+        hint="Only anniversaries that are a multiple of this many years. Set 1 for every anniversary."
+      />
+    );
+  }
   if (def.type === "editorial_spotlight") {
     const subjectType = (params.subject_type as string) ?? "director";
-    const autoRotate = (params.auto_rotate as boolean) ?? true;
+    // A preset that ships a pinned subject (e.g. "The 80s") without an
+    // explicit auto_rotate is a pinned config — mirroring the backend's Go
+    // zero-value. Defaulting the toggle to ON here would hide the subject
+    // field and misrepresent what gets saved.
+    const autoRotate = (params.auto_rotate as boolean) ?? !params.subject;
     const cadence = (params.rotation_cadence as string) ?? "weekly";
     const subject = (params.subject as string) ?? "";
     return (
@@ -102,10 +151,13 @@ export default function RecipeParamFields({ def, params, onChange }: RecipeParam
         <label className="mb-1 block text-xs text-white/70">Genre (optional)</label>
         <input
           className="w-full rounded border border-white/15 bg-white/5 px-3 py-2 text-sm"
-          placeholder="e.g. Sci-Fi"
+          placeholder="Auto-pick your strongest genre (leave blank)"
           value={genre}
           onChange={(e) => onChange({ ...params, genre: e.target.value })}
         />
+        <div className="mt-1 text-[11px] text-white/50">
+          Leave blank to follow the profile&apos;s strongest taste automatically.
+        </div>
       </div>
     );
   }
@@ -232,6 +284,12 @@ const SEASONAL_THEMES: Array<{ key: string; label: string; window: string; icon:
     icon: "📺",
   },
   {
+    key: "family_movie_night",
+    label: "Family Movie Night",
+    window: "Fri & Sat from 5pm",
+    icon: "🍿",
+  },
+  {
     key: "summer_blockbuster",
     label: "Summer Blockbusters",
     window: "June – August",
@@ -328,6 +386,198 @@ function SeasonalParamField({ params, onChange }: ParamFieldProps) {
         hides itself when none match. Per-holiday titles override the section name only while that
         holiday is active.
       </p>
+    </div>
+  );
+}
+
+// NumberParamField edits a single optional integer param (e.g. lookback_days).
+// Clearing the input removes the key so the backend default applies.
+function NumberParamField({
+  params,
+  onChange,
+  paramKey,
+  label,
+  placeholder,
+  hint,
+}: ParamFieldProps & {
+  paramKey: string;
+  label: string;
+  placeholder: string;
+  hint?: string;
+}) {
+  const raw = params[paramKey];
+  const value = typeof raw === "number" && Number.isFinite(raw) ? String(raw) : "";
+  return (
+    <div>
+      <label className="mb-1 block text-xs text-white/70">{label}</label>
+      <input
+        type="number"
+        min={1}
+        className="w-full rounded border border-white/15 bg-white/5 px-3 py-2 text-sm"
+        placeholder={placeholder}
+        value={value}
+        onChange={(e) => {
+          const parsed = Number(e.target.value);
+          onChange({
+            ...params,
+            [paramKey]:
+              e.target.value && Number.isFinite(parsed) && parsed > 0 ? parsed : undefined,
+          });
+        }}
+      />
+      {hint ? <div className="mt-1 text-[11px] text-white/50">{hint}</div> : null}
+    </div>
+  );
+}
+
+const CURATED_SEARCH_LIMIT = 10;
+const CURATED_SEARCH_DEBOUNCE_MS = 250;
+
+// CuratedItemsParamField builds the ordered item_ids list for
+// admin_curated_list sections: catalog search on top, the picked (ordered)
+// list below. Titles for picked items are remembered locally from search
+// results; items persisted before this drawer opened fall back to their id.
+function CuratedItemsParamField({ params, onChange }: ParamFieldProps) {
+  const [query, setQuery] = useState("");
+  const [labels, setLabels] = useState<Record<string, string>>({});
+  const debounced = useDebounce(query.trim(), CURATED_SEARCH_DEBOUNCE_MS);
+
+  const itemIDs = Array.isArray(params.item_ids)
+    ? params.item_ids.filter((id): id is string => typeof id === "string")
+    : [];
+  const picked = new Set(itemIDs);
+
+  const searchState = useMemo(
+    () => createCatalogSearchState("query", { q: debounced || undefined }),
+    [debounced],
+  );
+  const results = useQuery({
+    queryKey: [
+      "curatedListPicker",
+      catalogKeys.list({
+        source: searchState.source,
+        q: searchState.q,
+        limit: CURATED_SEARCH_LIMIT,
+        offset: 0,
+      }),
+    ],
+    queryFn: ({ signal }) => fetchCatalogPage(searchState, CURATED_SEARCH_LIMIT, 0, { signal }),
+    enabled: debounced.length > 0,
+    staleTime: 30 * 1000,
+  });
+  const found: BrowseItem[] = results.data?.items ?? [];
+
+  function add(item: BrowseItem) {
+    if (picked.has(item.content_id)) return;
+    setLabels((prev) => ({
+      ...prev,
+      [item.content_id]: item.year ? `${item.title} (${item.year})` : item.title,
+    }));
+    onChange({ ...params, item_ids: [...itemIDs, item.content_id] });
+  }
+
+  function remove(id: string) {
+    onChange({ ...params, item_ids: itemIDs.filter((existing) => existing !== id) });
+  }
+
+  function move(id: string, delta: number) {
+    const idx = itemIDs.indexOf(id);
+    const target = idx + delta;
+    if (idx < 0 || target < 0 || target >= itemIDs.length) return;
+    const next = [...itemIDs];
+    next.splice(idx, 1);
+    next.splice(target, 0, id);
+    onChange({ ...params, item_ids: next });
+  }
+
+  return (
+    <div className="space-y-3">
+      <div>
+        <label className="mb-1 block text-xs text-white/70">Add titles</label>
+        <input
+          className="w-full rounded border border-white/15 bg-white/5 px-3 py-2 text-sm"
+          placeholder="🔍 Search your catalog…"
+          value={query}
+          onChange={(e) => setQuery(e.target.value)}
+          autoComplete="off"
+        />
+        {debounced.length === 0 ? null : results.isLoading ? (
+          <div className="mt-2 text-xs text-white/50">Searching…</div>
+        ) : found.length === 0 ? (
+          <div className="mt-2 text-xs text-white/50">No matches.</div>
+        ) : (
+          <ul className="mt-2 max-h-52 divide-y divide-white/10 overflow-y-auto rounded border border-white/10">
+            {found.map((item) => {
+              const already = picked.has(item.content_id);
+              return (
+                <li key={item.content_id} className="flex items-center gap-2 px-3 py-2 text-sm">
+                  <span className="min-w-0 flex-1 truncate">
+                    {item.title}
+                    <span className="ml-1 text-xs text-white/40">
+                      {item.year ? `${item.year} · ` : ""}
+                      {item.type}
+                    </span>
+                  </span>
+                  <button
+                    type="button"
+                    disabled={already}
+                    onClick={() => add(item)}
+                    className="rounded border border-white/15 px-2 py-0.5 text-xs disabled:opacity-40"
+                  >
+                    {already ? "Added" : "Add"}
+                  </button>
+                </li>
+              );
+            })}
+          </ul>
+        )}
+      </div>
+
+      <div>
+        <span className="mb-1 block text-xs text-white/70">
+          Curated list ({itemIDs.length} {itemIDs.length === 1 ? "title" : "titles"}, shown in this
+          order)
+        </span>
+        {itemIDs.length === 0 ? (
+          <div className="rounded border border-dashed border-white/15 px-3 py-3 text-xs text-white/50">
+            Search above and add at least one title.
+          </div>
+        ) : (
+          <ul className="divide-y divide-white/10 rounded border border-white/10">
+            {itemIDs.map((id, idx) => (
+              <li key={id} className="flex items-center gap-2 px-3 py-2 text-sm">
+                <span className="min-w-0 flex-1 truncate">{labels[id] ?? id}</span>
+                <button
+                  type="button"
+                  onClick={() => move(id, -1)}
+                  disabled={idx === 0}
+                  aria-label="Move up"
+                  className="rounded border border-white/15 px-2 py-0.5 text-xs disabled:opacity-40"
+                >
+                  ↑
+                </button>
+                <button
+                  type="button"
+                  onClick={() => move(id, 1)}
+                  disabled={idx === itemIDs.length - 1}
+                  aria-label="Move down"
+                  className="rounded border border-white/15 px-2 py-0.5 text-xs disabled:opacity-40"
+                >
+                  ↓
+                </button>
+                <button
+                  type="button"
+                  onClick={() => remove(id)}
+                  aria-label="Remove"
+                  className="rounded border border-white/15 px-2 py-0.5 text-xs text-red-300"
+                >
+                  ✕
+                </button>
+              </li>
+            ))}
+          </ul>
+        )}
+      </div>
     </div>
   );
 }

--- a/web/src/pages/ProfileCustomizeHome.tsx
+++ b/web/src/pages/ProfileCustomizeHome.tsx
@@ -255,6 +255,7 @@ export default function ProfileCustomizeHome() {
       <RecipeGalleryModal
         open={galleryOpen}
         onClose={() => setGalleryOpen(false)}
+        hideAdminOnly
         onPick={(def, preset) => {
           setGalleryOpen(false);
           setPicked({ def, preset });

--- a/web/src/pages/settings/HomeScreenSettings.tsx
+++ b/web/src/pages/settings/HomeScreenSettings.tsx
@@ -577,6 +577,7 @@ export default function HomeScreenSettings() {
       <RecipeGalleryModal
         open={galleryOpen}
         onClose={() => setGalleryOpen(false)}
+        hideAdminOnly
         onPick={(def, preset) => {
           setGalleryOpen(false);
           setPickedRecipe({ def, preset });


### PR DESCRIPTION
## Problem

A review of the home page section templates (recipes) found several that are advertised in the gallery but silently produce nothing — the home page hides empty sections, so they just never appear:

- **Award Winners** (all 3 presets): `fetchAwardWinners` is a stub that always returns empty.
- **Seasonal Picks** went dark during the biggest holidays: christmas/st_patricks/thanksgiving have date predicates but no query, and theme selection picked them by priority anyway — an enabled christmas theme suppressed the whole section for all of December.
- **Taste Match** default preset: the fetcher required a genre but the preset ships `{}`, so it never rendered.
- **Because You Watched**: the recipe/UI write `anchor_item_id` but the fetcher only read `source_item_id` — pinning an anchor did nothing.
- **Editor's Picks** (admin_curated_list): no item picker existed, and the preset's empty `item_ids` always failed validation → add always 400s. It also leaked into non-admin galleries because `admin_only` was never enforced client-side.
- **Editorial franchise** subject validated but can never resolve (no data source).
- **Library scoping**: hidden_gems/forgotten_favorites ignored library scope entirely and critically_acclaimed dropped multi-library scope, leaking items across libraries on scoped pages; hidden_gems' advertised `max_play_count` param was dead.

## What changed

**Fixes**
- `award_winners` marked `Hidden` (stays resolvable for saved sections).
- Seasonal: interim title-keyword resolver for christmas/st_patricks/thanksgiving (until a proper keyword/tag column lands), and `ActiveSeasonalThemeWhere` skips themes that can't produce items so a data-less theme never blacks out the section in its own window. Title overrides track the same selection.
- Taste match: empty genre auto-picks the profile's strongest taste cluster, falling back to the server-wide top genre.
- Because You Watched: fetcher honors both `anchor_item_id` and legacy `source_item_id` (legacy wins when both set).
- Editorial: `franchise` removed from valid subject types; drawer no longer misrepresents pinned presets (e.g. "The 80s") as auto-rotate.
- Editor's Picks: new catalog-search item picker (ordered, reorderable) in the recipe drawer (reused by the admin edit drawer); Add is blocked until the list is non-empty; `admin_only` recipes hidden from profile-facing galleries.
- Discovery repo filters take single/multi library scope, **intersected with viewer access** so a scoped section can never widen access; `max_play_count` implemented as a watch-count threshold.

**New templates**
- `returning_shows` — shows you've watched with a brand-new season (newer than any you've seen, with playable files) in the lookback window.
- `genre_roulette` — deterministic rotating top-genre spotlight (reuses editorial rotation hashing + candidate cache), row title carries the active genre.
- `anniversaries` — movies with a milestone release anniversary this month (5-year multiples by default).
- `short_watches` — well-rated movies under a runtime cap ("Short & Sweet").
- `family_movie_night` — new seasonal theme for Friday/Saturday evenings, with preset and holiday-picker entry.
- `format_showcase` gains `sort: recent` + a "New in 4K" preset.

## Review notes

- New user-agnostic fetchers (`short_watches`, `anniversaries`) join the shared resolved-list cache via `userAgnosticSectionFetcher`, so cacheability tracks dispatch as before; `genre_roulette` mirrors the `editorial_spotlight` title-override interception in `FetchOne`; `returning_shows` is per-user.
- A new blanket test asserts every visible gallery preset's default params pass that recipe's own validation (with an explicit allowlist for presets whose drawer requires input) — this is the test that would have caught taste_match and Editor's Picks.
- All four new SQL shapes were validated with `EXPLAIN` against the dev database; plans use existing indexes.
- Seasonal keyword matching is an explicit interim heuristic; it should be replaced when keyword/tag metadata lands.
- Pre-existing failures not touched: jellycompat `TestBeginWebOperation*` (flaky), setup-wizard/compat-proxy vitest files (fail on HEAD).
- Scope: ad-hoc fix from a section-template review in this session — no linked epic; happy to file/link an issue if wanted.

## Verification

- `go build ./...`, `go test ./internal/... ./cmd/...` (only the documented pre-existing failures), `gofmt`, `make verify-local-paths`.
- Web: `tsc -b`, `pnpm run lint` (0 errors), `pnpm run format:check`, vitest (RecipeGallery suites pass; full-suite failures are pre-existing).

## AI-use disclosure

Implemented by Claude (Fable 5) via Claude Code under human direction, including the review that found the defects; verified with the test runs and dev-DB EXPLAIN checks above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added new home screen and discovery options, including returning shows, genre roulette, anniversaries, short watches, and a family movie night seasonal theme.
  * Added more flexible recipe settings, including recent sorting, max plays, and multi-library selection.
  * Improved the recipe gallery with curated list editing and support for more parameter types.

* **Bug Fixes**
  * Refined matching and seasonal selection behavior so empty inputs and unavailable themes fall back more reliably.
  * Tightened access checks so scoped sections won’t expand beyond permitted libraries.

* **UI Improvements**
  * Hidden admin-only items from the public recipe gallery view.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->