### PR TITLE
fix(overlays): show_status persistence + card overlay layout fixes

### DIFF
--- a/internal/metadata/service.go
+++ b/internal/metadata/service.go
@@ -5445,6 +5445,7 @@ func itemToMetadataResult(item *models.MediaItem) *MetadataResult {
 	if item.SeasonCount != nil {
 		result.SeasonCount = *item.SeasonCount
 	}
+	result.ShowStatus = item.ShowStatus
 
 	return result
 }
@@ -5514,6 +5515,16 @@ func metadataResultToItem(r *MetadataResult, contentType string) *models.MediaIt
 	}
 	if r.SeasonCount > 0 {
 		item.SeasonCount = &r.SeasonCount
+	}
+
+	// show_status is shared by two value domains: the series lifecycle
+	// (normalized here) and the manga publication domain (normalized by the
+	// manga enrichment pipeline). Pass non-series values through untouched so
+	// a round-trip through itemToMetadataResult can never mangle them.
+	if contentType == "series" {
+		item.ShowStatus = NormalizeShowStatus(r.ShowStatus)
+	} else {
+		item.ShowStatus = r.ShowStatus
 	}
 
 	return item

--- a/internal/metadata/show_status.go
+++ b/internal/metadata/show_status.go
@@ -1,0 +1,35 @@
+package metadata
+
+import "strings"
+
+// NormalizeShowStatus maps provider-reported series lifecycle statuses onto
+// the canonical domain persisted in media_items.show_status for series:
+// "returning", "ended", "cancelled", "in_production", "upcoming", or "".
+// Providers spell these differently (TMDB "Returning Series" / "Canceled",
+// TVDB "Continuing" / "Upcoming"), so persistence converges on one spelling
+// clients can rely on. Unrecognized values pass through trimmed and
+// lowercased rather than being dropped, so a new provider status still
+// reaches clients (which fall back to displaying the raw value).
+//
+// This is series-domain only. Manga statuses use a different value domain
+// ("Ongoing", "Completed", ...) normalized by the manga enrichment pipeline;
+// callers must not route manga values through this function.
+func NormalizeShowStatus(raw string) string {
+	cleaned := strings.ToLower(strings.TrimSpace(raw))
+	switch cleaned {
+	case "":
+		return ""
+	case "returning", "returning series", "continuing":
+		return "returning"
+	case "ended":
+		return "ended"
+	case "cancelled", "canceled":
+		return "cancelled"
+	case "in production", "in_production", "pilot":
+		return "in_production"
+	case "upcoming", "planned":
+		return "upcoming"
+	default:
+		return cleaned
+	}
+}

--- a/internal/metadata/show_status_test.go
+++ b/internal/metadata/show_status_test.go
@@ -1,0 +1,103 @@
+package metadata
+
+import (
+	"testing"
+
+	"github.com/Silo-Server/silo-server/internal/models"
+)
+
+func TestNormalizeShowStatus(t *testing.T) {
+	cases := []struct {
+		in   string
+		want string
+	}{
+		{"", ""},
+		{"  ", ""},
+		// TMDB spellings
+		{"Returning Series", "returning"},
+		{"Ended", "ended"},
+		{"Canceled", "cancelled"},
+		{"In Production", "in_production"},
+		{"Pilot", "in_production"},
+		{"Planned", "upcoming"},
+		// TVDB spellings
+		{"Continuing", "returning"},
+		{"Upcoming", "upcoming"},
+		// Already-canonical values are stable
+		{"returning", "returning"},
+		{"ended", "ended"},
+		{"cancelled", "cancelled"},
+		{"in_production", "in_production"},
+		{"upcoming", "upcoming"},
+		// Unknown values pass through lowercased instead of being dropped
+		{"On Hiatus", "on hiatus"},
+	}
+	for _, tc := range cases {
+		if got := NormalizeShowStatus(tc.in); got != tc.want {
+			t.Errorf("NormalizeShowStatus(%q) = %q, want %q", tc.in, got, tc.want)
+		}
+	}
+}
+
+func TestMetadataResultToItem_NormalizesSeriesShowStatus(t *testing.T) {
+	result := &MetadataResult{
+		HasMetadata: true,
+		Title:       "Series",
+		ShowStatus:  "Returning Series",
+	}
+
+	item := metadataResultToItem(result, "series")
+	if item.ShowStatus != "returning" {
+		t.Fatalf("expected item show_status %q, got %q", "returning", item.ShowStatus)
+	}
+}
+
+func TestMetadataResultToItem_PassesNonSeriesShowStatusVerbatim(t *testing.T) {
+	// Manga statuses use their own value domain ("Ongoing", "Completed", ...)
+	// normalized by the manga enrichment pipeline; the generic converter must
+	// not case-mangle them on a round-trip.
+	result := &MetadataResult{
+		HasMetadata: true,
+		Title:       "Manga",
+		ShowStatus:  "Ongoing",
+	}
+
+	item := metadataResultToItem(result, "manga")
+	if item.ShowStatus != "Ongoing" {
+		t.Fatalf("expected manga show_status to pass through verbatim, got %q", item.ShowStatus)
+	}
+}
+
+func TestItemToMetadataResult_CarriesShowStatus(t *testing.T) {
+	result := itemToMetadataResult(&models.MediaItem{
+		ContentID:  "series-1",
+		Type:       "series",
+		Title:      "Series",
+		ShowStatus: "returning",
+	})
+
+	if result.ShowStatus != "returning" {
+		t.Fatalf("expected metadata show_status %q, got %q", "returning", result.ShowStatus)
+	}
+}
+
+// A refresh cycle that fetches no status must not wipe a previously persisted
+// one: the existing item's status round-trips through itemToMetadataResult,
+// survives the merge (fresh empty values never overwrite), and lands back on
+// the item built for the upsert.
+func TestShowStatus_SurvivesRefreshWithoutProviderStatus(t *testing.T) {
+	existing := itemToMetadataResult(&models.MediaItem{
+		ContentID:  "series-1",
+		Type:       "series",
+		Title:      "Series",
+		ShowStatus: "ended",
+	})
+	fresh := &MetadataResult{HasMetadata: true, Title: "Series"}
+
+	MergeMetadata(fresh, existing, nil, MergeReplaceUnlocked)
+	item := metadataResultToItem(existing, "series")
+
+	if item.ShowStatus != "ended" {
+		t.Fatalf("expected persisted show_status to survive refresh, got %q", item.ShowStatus)
+	}
+}

--- a/internal/models/media.go
+++ b/internal/models/media.go
@@ -345,7 +345,7 @@ type MediaItem struct {
 	LastAirDate                  *string // ISO date (series only), nullable
 	AirTime                      *string // Series broadcast time (e.g. "20:00"), nullable
 	AirTimezone                  *string // Series broadcast timezone (IANA name, e.g. "America/New_York"), nullable
-	ShowStatus                   string  // Series lifecycle: "returning", "ended", "cancelled", "in_production", or "" if unknown (series only)
+	ShowStatus                   string  // Series lifecycle: "returning", "ended", "cancelled", "in_production", "upcoming", or "" if unknown (series; manga uses its own domain, e.g. "Ongoing")
 	People                       []ItemPerson
 	AudiobookSeries              []AudiobookSeriesMembership
 	MatchedAt                    *time.Time

--- a/web/src/components/ItemCard.tsx
+++ b/web/src/components/ItemCard.tsx
@@ -241,21 +241,31 @@ export default function ItemCard({
                 Ambiguous
               </span>
             )}
-            {item.status === "matched" && overlayPrefs && (
+            {/* Manga cards carry purpose-built status/count chips in both top
+                corners; generic overlays would render underneath them. */}
+            {item.status === "matched" && item.type !== "manga" && overlayPrefs && (
               <CardOverlays data={overlayDataFromBrowseItem(item)} prefs={overlayPrefs} />
             )}
-            {mangaStatus && (
-              <span
-                className={`glass-chip absolute top-2.5 left-2.5 rounded-full border px-2.5 py-1 text-[10px] font-semibold tracking-[0.14em] uppercase ${mangaStatus.tone}`}
-              >
-                {mangaStatus.label}
-              </span>
-            )}
-            {mangaCountLabel && (
-              <span className="glass-chip text-foreground absolute top-2.5 right-2.5 inline-flex items-center gap-1 rounded-full border border-white/15 px-2.5 py-1 text-[10px] font-semibold tracking-[0.14em] uppercase">
-                <Layers className="size-3" />
-                {mangaCountLabel}
-              </span>
+            {(mangaStatus || mangaCountLabel) && (
+              /* One shared row so the two chips split the card width and
+                 truncate instead of overlapping on narrow cards. */
+              <div className="pointer-events-none absolute inset-x-2.5 top-2.5 flex items-start justify-between gap-1.5">
+                {mangaStatus ? (
+                  <span
+                    className={`glass-chip min-w-0 truncate rounded-full border px-2.5 py-1 text-[10px] font-semibold tracking-[0.14em] uppercase ${mangaStatus.tone}`}
+                  >
+                    {mangaStatus.label}
+                  </span>
+                ) : (
+                  <span />
+                )}
+                {mangaCountLabel && (
+                  <span className="glass-chip text-foreground inline-flex min-w-0 items-center gap-1 rounded-full border border-white/15 px-2.5 py-1 text-[10px] font-semibold tracking-[0.14em] uppercase">
+                    <Layers className="size-3 shrink-0" />
+                    <span className="truncate">{mangaCountLabel}</span>
+                  </span>
+                )}
+              </div>
             )}
           </div>
         </ViewTransitionLink>

--- a/web/src/components/overlays/CardOverlays.test.tsx
+++ b/web/src/components/overlays/CardOverlays.test.tsx
@@ -1,0 +1,131 @@
+import { describe, expect, it } from "vitest";
+import { render } from "@testing-library/react";
+
+import CardOverlays from "./CardOverlays";
+import {
+  OVERLAY_REGISTRY,
+  SAMPLE_MOVIE_DATA,
+  SAMPLE_SHOW_DATA,
+  buildDefaultPrefs,
+  type CardOverlayPrefs,
+  type OverlayId,
+  type PresetId,
+} from "@/lib/overlays";
+
+function prefsWithOnly(id: OverlayId, preset: PresetId = "classic"): CardOverlayPrefs {
+  const prefs = buildDefaultPrefs();
+  prefs.preset = preset;
+  for (const key of Object.keys(prefs.items) as OverlayId[]) {
+    prefs.items[key] = { ...prefs.items[key], enabled: key === id };
+  }
+  return prefs;
+}
+
+function badgeTexts(container: HTMLElement): (string | null)[] {
+  return Array.from(container.querySelectorAll("span.inline-flex")).map((n) => n.textContent);
+}
+
+describe("CardOverlays", () => {
+  it("renders a badge for every registered overlay given sample data", () => {
+    for (const def of OVERLAY_REGISTRY) {
+      const data =
+        def.id === "network" || def.id === "show_status" ? SAMPLE_SHOW_DATA : SAMPLE_MOVIE_DATA;
+      const expected = def.getValue(data);
+      expect(expected, `sample data should exercise overlay ${def.id}`).toBeTruthy();
+      const { container, unmount } = render(
+        <CardOverlays data={data} prefs={prefsWithOnly(def.id)} />,
+      );
+      expect(badgeTexts(container), `overlay ${def.id}`).toEqual([expected]);
+      unmount();
+    }
+  });
+
+  it("shows 4K for a 2160p file on the standalone resolution badge", () => {
+    const { container } = render(
+      <CardOverlays data={SAMPLE_MOVIE_DATA} prefs={prefsWithOnly("resolution")} />,
+    );
+    expect(badgeTexts(container)).toEqual(["4K"]);
+  });
+
+  it("suppresses standalone resolution and hdr when the combined badge is enabled", () => {
+    const prefs = buildDefaultPrefs();
+    prefs.items.resolution_hdr = { ...prefs.items.resolution_hdr, enabled: true };
+    const texts = badgeTexts(
+      render(<CardOverlays data={SAMPLE_MOVIE_DATA} prefs={prefs} />).container,
+    );
+    expect(texts).toContain("4K DV");
+    expect(texts).not.toContain("4K");
+    expect(texts).not.toContain("DV HDR10");
+  });
+
+  it("honors prefs.order within a corner", () => {
+    const prefs = buildDefaultPrefs(); // resolution, hdr, audio all top-left
+    prefs.order = ["audio", "hdr", "resolution"];
+    const { container } = render(<CardOverlays data={SAMPLE_MOVIE_DATA} prefs={prefs} />);
+    const topLeftStack = container.querySelector("div.top-2 > div.items-start");
+    const texts = Array.from(topLeftStack?.querySelectorAll("span.inline-flex") ?? []).map(
+      (n) => n.textContent,
+    );
+    expect(texts).toEqual(["Atmos", "DV HDR10", "4K"]);
+  });
+
+  it("suppresses the text label when a wordmark icon already spells it", () => {
+    const data = { ...SAMPLE_MOVIE_DATA, hdr: "HDR10", audio: "Atmos", video_codec: "AV1" };
+    for (const id of ["hdr", "audio", "video_codec"] as OverlayId[]) {
+      const { container, unmount } = render(
+        // pill prefers icons, so wordmarks resolve
+        <CardOverlays data={data} prefs={prefsWithOnly(id, "pill")} />,
+      );
+      const badge = container.querySelector("span.inline-flex");
+      expect(badge?.querySelector("svg"), `${id} should render its wordmark`).toBeTruthy();
+      expect(badge?.querySelector("span.truncate"), `${id} label should be suppressed`).toBeNull();
+      unmount();
+    }
+  });
+
+  it("keeps the label when the icon does not spell it (DV HDR10)", () => {
+    const { container } = render(
+      <CardOverlays data={SAMPLE_MOVIE_DATA} prefs={prefsWithOnly("hdr", "pill")} />,
+    );
+    const badge = container.querySelector("span.inline-flex");
+    expect(badge?.textContent).toBe("DV HDR10");
+    expect(badge?.querySelector("svg")).toBeTruthy();
+  });
+
+  it("renders HLG as a plain text label without an HDR wordmark", () => {
+    const { container } = render(
+      <CardOverlays
+        data={{ ...SAMPLE_MOVIE_DATA, hdr: "HLG" }}
+        prefs={prefsWithOnly("hdr", "pill")}
+      />,
+    );
+    const badge = container.querySelector("span.inline-flex");
+    expect(badge?.textContent).toBe("HLG");
+    expect(badge?.querySelector("svg")).toBeNull();
+  });
+
+  it("caps each corner at three badges", () => {
+    const prefs = buildDefaultPrefs();
+    for (const key of Object.keys(prefs.items) as OverlayId[]) {
+      prefs.items[key] = { ...prefs.items[key], enabled: true, position: "top-left" };
+    }
+    const { container } = render(<CardOverlays data={SAMPLE_MOVIE_DATA} prefs={prefs} />);
+    expect(container.querySelectorAll("span.inline-flex").length).toBe(3);
+  });
+
+  it("lifts bottom-right badges above the card menu button", () => {
+    const prefs = prefsWithOnly("content_rating");
+    prefs.items.content_rating = { ...prefs.items.content_rating, position: "bottom-right" };
+    const poster = render(<CardOverlays data={SAMPLE_MOVIE_DATA} prefs={prefs} />).container;
+    expect(poster.querySelector("div.bottom-2 > div.items-end.mb-10")).toBeTruthy();
+    const wide = render(
+      <CardOverlays data={SAMPLE_MOVIE_DATA} prefs={prefs} variant="wide" />,
+    ).container;
+    expect(wide.querySelector("div.bottom-2 > div.items-end.mb-12")).toBeTruthy();
+  });
+
+  it("renders nothing when no enabled overlay has data", () => {
+    const { container } = render(<CardOverlays data={{}} prefs={buildDefaultPrefs()} />);
+    expect(container.querySelectorAll("span.inline-flex").length).toBe(0);
+  });
+});

--- a/web/src/components/overlays/CardOverlays.tsx
+++ b/web/src/components/overlays/CardOverlays.tsx
@@ -1,10 +1,4 @@
-import {
-  OVERLAY_POSITIONS,
-  OVERLAY_REGISTRY,
-  OverlayIcon,
-  getPreset,
-  isOverlaySuppressed,
-} from "@/lib/overlays";
+import { OverlayIcon, WORDMARK_TEXT, getPreset, orderedOverlaysForPosition } from "@/lib/overlays";
 import type {
   CardOverlayPrefs,
   OverlayData,
@@ -14,19 +8,9 @@ import type {
   OverlayPreset,
 } from "@/lib/overlays";
 
-function positionClasses(pos: OverlayPosition, variant: "poster" | "wide"): string {
-  const bottom = variant === "wide" ? "bottom-6" : "bottom-2";
-  switch (pos) {
-    case "top-left":
-      return "top-2 left-2 items-start";
-    case "top-right":
-      return "top-2 right-2 items-end";
-    case "bottom-left":
-      return `${bottom} left-2 items-start`;
-    case "bottom-right":
-      return `${bottom} right-2 items-end`;
-  }
-}
+// Corner stacks render at most this many badges; anything further down the
+// user's order is dropped rather than colliding with the opposite corner.
+const MAX_BADGES_PER_CORNER = 3;
 
 interface CardOverlaysProps {
   data: OverlayData;
@@ -61,47 +45,93 @@ function resolveBadge(
   };
 }
 
+// A wordmark icon (HDR10, ATMOS, ...) spells its text as the mark itself; when
+// the label says the same thing, showing both reads "HDR10 HDR10".
+function labelRedundantWithIcon(badge: ResolvedBadge): boolean {
+  if (!badge.iconId) return false;
+  const mark = WORDMARK_TEXT[badge.iconId];
+  return mark !== undefined && mark.toLowerCase() === badge.label.trim().toLowerCase();
+}
+
+function BadgeStack({
+  badges,
+  align,
+  preset,
+  extraClass = "",
+}: {
+  badges: ResolvedBadge[];
+  align: "start" | "end";
+  preset: OverlayPreset;
+  extraClass?: string;
+}) {
+  return (
+    <div
+      className={`flex min-w-0 flex-col ${align === "start" ? "items-start" : "items-end"} ${preset.gapClass} ${extraClass}`}
+    >
+      {badges.map((badge) => (
+        <span
+          key={badge.def.id}
+          className={`inline-flex max-w-full items-center gap-1 ${preset.badgeClass}`}
+          style={preset.badgeStyle(badge.accentColor)}
+        >
+          {badge.iconId && (
+            <OverlayIcon iconId={badge.iconId} size={preset.iconSize} className="shrink-0" />
+          )}
+          {!labelRedundantWithIcon(badge) && <span className="truncate">{badge.label}</span>}
+        </span>
+      ))}
+    </div>
+  );
+}
+
+// Each card edge renders as ONE flex row holding the left and right corner
+// stacks. Sharing a row lets flexbox divide the card width between opposing
+// corners (min-w-0 + truncate), so wide badges shrink instead of overlapping.
 export default function CardOverlays({ data, prefs, variant = "poster" }: CardOverlaysProps) {
   const preset = getPreset(prefs.preset);
-  const groups = new Map<OverlayPosition, ResolvedBadge[]>();
+  const resolve = (pos: OverlayPosition): ResolvedBadge[] =>
+    orderedOverlaysForPosition(prefs, pos)
+      .map((def) => {
+        const config = prefs.items[def.id];
+        return resolveBadge(def, data, preset, config?.accentColor, config?.showIcon);
+      })
+      .filter((badge): badge is ResolvedBadge => badge !== null)
+      .slice(0, MAX_BADGES_PER_CORNER);
 
-  for (const def of OVERLAY_REGISTRY) {
-    const config = prefs.items[def.id];
-    if (!config?.enabled) continue;
-    if (isOverlaySuppressed(def.id, prefs)) continue;
-    const badge = resolveBadge(def, data, preset, config.accentColor, config.showIcon);
-    if (!badge) continue;
-    const list = groups.get(config.position) ?? [];
-    list.push(badge);
-    groups.set(config.position, list);
-  }
-
-  if (groups.size === 0) return null;
+  const topLeft = resolve("top-left");
+  const topRight = resolve("top-right");
+  const bottomLeft = resolve("bottom-left");
+  const bottomRight = resolve("bottom-right");
+  const wide = variant === "wide";
 
   return (
     <>
-      {OVERLAY_POSITIONS.map((pos) => {
-        const badges = groups.get(pos);
-        if (!badges?.length) return null;
-
-        return (
-          <div
-            key={pos}
-            className={`pointer-events-none absolute z-10 flex flex-col ${preset.gapClass} ${positionClasses(pos, variant)}`}
-          >
-            {badges.map((badge) => (
-              <span
-                key={badge.def.id}
-                className={`inline-flex items-center gap-1 ${preset.badgeClass}`}
-                style={preset.badgeStyle(badge.accentColor)}
-              >
-                {badge.iconId && <OverlayIcon iconId={badge.iconId} size={preset.iconSize} />}
-                {!badge.def.iconOnly && badge.label}
-              </span>
-            ))}
-          </div>
-        );
-      })}
+      {(topLeft.length > 0 || topRight.length > 0) && (
+        <div className="pointer-events-none absolute inset-x-2 top-2 z-10 flex items-start justify-between gap-2">
+          <BadgeStack badges={topLeft} align="start" preset={preset} />
+          <BadgeStack badges={topRight} align="end" preset={preset} />
+        </div>
+      )}
+      {(bottomLeft.length > 0 || bottomRight.length > 0) && (
+        <div className="pointer-events-none absolute inset-x-2 bottom-2 z-10 flex items-end justify-between gap-2">
+          {/* Wide cards keep the bottom edge clear for the progress bar. */}
+          <BadgeStack
+            badges={bottomLeft}
+            align="start"
+            preset={preset}
+            extraClass={wide ? "mb-4" : ""}
+          />
+          {/* The card menu button (MediaItemMenu) owns the bottom-right
+              corner — always visible on touch devices — so this stack sits
+              above it. */}
+          <BadgeStack
+            badges={bottomRight}
+            align="end"
+            preset={preset}
+            extraClass={wide ? "mb-12" : "mb-10"}
+          />
+        </div>
+      )}
     </>
   );
 }

--- a/web/src/hooks/useOverlayPrefs.ts
+++ b/web/src/hooks/useOverlayPrefs.ts
@@ -45,10 +45,15 @@ export function useOverlayPrefs() {
     [raw, setSetting],
   );
 
+  // While either query is in flight, report null prefs instead of built-in
+  // defaults: rendering defaults first would flash badges that vanish (or
+  // change) the moment the user's own config or the admin kill switch loads.
+  const isLoading = userLoading || configLoading;
+
   return {
-    prefs: enabled ? prefs : null,
+    prefs: enabled && !isLoading ? prefs : null,
     setPrefs,
-    isLoading: userLoading || configLoading,
+    isLoading,
     enabled,
   };
 }

--- a/web/src/lib/overlays/icons.tsx
+++ b/web/src/lib/overlays/icons.tsx
@@ -47,9 +47,9 @@ const LUCIDE_ICONS: Partial<Record<OverlayIconId, LucideIcon>> = {
 
 function HDRMark(props: SVGProps<SVGSVGElement>) {
   return (
-    <svg viewBox="0 0 24 12" fill="currentColor" {...props}>
+    <svg viewBox="0 0 26 12" fill="currentColor" {...props}>
       <text
-        x="12"
+        x="13"
         y="9"
         fontSize="10"
         fontWeight="900"
@@ -64,9 +64,9 @@ function HDRMark(props: SVGProps<SVGSVGElement>) {
 
 function HDR10Mark(props: SVGProps<SVGSVGElement>) {
   return (
-    <svg viewBox="0 0 32 12" fill="currentColor" {...props}>
+    <svg viewBox="0 0 40 12" fill="currentColor" {...props}>
       <text
-        x="16"
+        x="20"
         y="9"
         fontSize="10"
         fontWeight="900"
@@ -89,9 +89,9 @@ function DolbyVisionMark(props: SVGProps<SVGSVGElement>) {
 
 function AtmosMark(props: SVGProps<SVGSVGElement>) {
   return (
-    <svg viewBox="0 0 28 12" fill="currentColor" {...props}>
+    <svg viewBox="0 0 40 12" fill="currentColor" {...props}>
       <text
-        x="14"
+        x="20"
         y="9"
         fontSize="9"
         fontWeight="900"
@@ -107,9 +107,9 @@ function AtmosMark(props: SVGProps<SVGSVGElement>) {
 
 function AV1Mark(props: SVGProps<SVGSVGElement>) {
   return (
-    <svg viewBox="0 0 20 12" fill="currentColor" {...props}>
+    <svg viewBox="0 0 24 12" fill="currentColor" {...props}>
       <text
-        x="10"
+        x="12"
         y="9"
         fontSize="10"
         fontWeight="900"

--- a/web/src/lib/overlays/index.ts
+++ b/web/src/lib/overlays/index.ts
@@ -17,7 +17,7 @@ export type {
 } from "./types";
 
 export { OVERLAY_REGISTRY, OVERLAY_MAP, getOverlayDef } from "./registry";
-export { OVERLAY_POSITIONS, OVERLAY_CATEGORIES } from "./types";
+export { OVERLAY_POSITIONS, OVERLAY_CATEGORIES, WORDMARK_TEXT } from "./types";
 export {
   buildDefaultPrefs,
   parseOverlayPrefs,

--- a/web/src/lib/overlays/registry/ribbons.ts
+++ b/web/src/lib/overlays/registry/ribbons.ts
@@ -12,6 +12,7 @@ function formatShowStatus(value: string | undefined): string | null {
   switch (value.toLowerCase()) {
     case "returning":
     case "returning series":
+    case "continuing":
     case "in_production":
     case "in production":
       return "Returning";
@@ -20,6 +21,9 @@ function formatShowStatus(value: string | undefined): string | null {
     case "cancelled":
     case "canceled":
       return "Cancelled";
+    case "upcoming":
+    case "planned":
+      return "Upcoming";
     default:
       return value;
   }

--- a/web/src/lib/overlays/registry/tech.ts
+++ b/web/src/lib/overlays/registry/tech.ts
@@ -4,11 +4,16 @@ import type { OverlayDef, OverlayIconId } from "../types";
 // Tech overlays — derived from the media file (codec, container, resolution,
 // audio properties). All data flows through OverlaySummary on the backend.
 
+// hdrIcon picks the badge icon for a dynamic-range value. Wordmark icons
+// (hdr10, hdr) replace the text label when they spell the same thing (see
+// WORDMARK_TEXT), so they are only returned for values they fully express;
+// HLG has no mark and renders as a plain text label.
 function hdrIcon(value: string | undefined): OverlayIconId | null {
   if (!value) return null;
   if (value.includes("DV")) return "dolby-vision";
-  if (value.includes("HDR10")) return "hdr10";
-  return "hdr";
+  if (value === "HDR10") return "hdr10";
+  if (value === "HDR") return "hdr";
+  return null;
 }
 
 function audioIcon(value: string | undefined): OverlayIconId | null {
@@ -33,7 +38,7 @@ export const TECH_OVERLAYS: readonly OverlayDef[] = [
     defaultEnabled: true,
     iconId: "monitor",
     iconCapable: true,
-    getValue: (d) => d.resolution?.toUpperCase() ?? null,
+    getValue: (d) => prettyResolution(d.resolution),
   },
   {
     id: "hdr",
@@ -60,7 +65,9 @@ export const TECH_OVERLAYS: readonly OverlayDef[] = [
       const hdr = compactHdrSuffix(d.hdr);
       return hdr ? `${res} ${hdr}` : res;
     },
-    getIcon: (d) => hdrIcon(d.hdr),
+    // Only the DV circle mark works next to a combined label; a wordmark
+    // (HDR10) would visually duplicate the label's HDR suffix.
+    getIcon: (d) => (d.hdr?.includes("DV") ? "dolby-vision" : null),
   },
   {
     id: "audio",

--- a/web/src/lib/overlays/types.ts
+++ b/web/src/lib/overlays/types.ts
@@ -117,7 +117,6 @@ export interface OverlayDef {
   iconId?: OverlayIconId; // static icon, when applicable
   defaultAccent?: string; // suggested accent color in palette pickers
   iconCapable: boolean; // whether the icon toggle should appear in settings
-  iconOnly?: boolean; // render icon only (no label) when icon is present
   availabilityNote?: string; // shown when data source isn't wired up yet
   getValue: (data: OverlayData) => string | null;
   getIcon?: (data: OverlayData) => OverlayIconId | null; // dynamic icon by data
@@ -150,3 +149,13 @@ export type OverlayIconId =
   | "atmos"
   | "av1"
   | "tomato";
+
+// Wordmark icons render their text as the mark itself (defined in icons.tsx).
+// When a badge's label says the same thing, the renderer suppresses the label
+// so the badge doesn't read "HDR10 HDR10".
+export const WORDMARK_TEXT: Partial<Record<OverlayIconId, string>> = {
+  hdr: "HDR",
+  hdr10: "HDR10",
+  atmos: "ATMOS",
+  av1: "AV1",
+};

--- a/web/src/pages/settings/CardOverlaySettings.tsx
+++ b/web/src/pages/settings/CardOverlaySettings.tsx
@@ -10,6 +10,7 @@ import {
   buildDefaultPrefs,
   CATEGORY_GROUPS,
   getOverlayDef,
+  isOverlaySuppressed,
   OVERLAY_REGISTRY,
   OVERLAY_PRESETS,
   POSITION_OPTIONS,
@@ -135,12 +136,17 @@ function OverlayToggle({ overlayId, prefs, onUpdate }: OverlayToggleProps) {
   const config = prefs.items[overlayId];
   const preset = getPreset(prefs.preset);
   const resolvedShowIcon = !!def.iconCapable && (config.showIcon ?? preset.preferIcon);
+  const suppressed = config.enabled && isOverlaySuppressed(overlayId, prefs);
 
   return (
     <SettingRow
       label={def.label}
       description={def.description}
-      hint={def.availabilityNote}
+      hint={
+        suppressed
+          ? "Hidden while the combined Resolution + HDR badge is enabled."
+          : def.availabilityNote
+      }
       control={({ id }) => (
         <div className="flex items-center gap-2">
           {def.iconCapable && (


### PR DESCRIPTION
## Problem

A full audit of the Card Overlay feature (every overlay validated through the real renderer, layout measured by DOM geometry at real card widths) found one data-pipeline bug and a cluster of layout/rendering bugs:

1. **Show Status never worked for series.** Plugin-reported status was mapped into `MetadataResult.ShowStatus` but dropped by both `metadataResultToItem` and `itemToMetadataResult`, so `media_items.show_status` stayed empty for every movie/series (verified on dev: all 36k series empty; only manga enrichment ever wrote it). The upsert's `show_status = EXCLUDED.show_status` also meant any future value would be wiped on the next refresh.
2. **Overlay layout/rendering defects** (all confirmed by measured badge-rectangle intersection): opposite-corner badges overlap on narrow cards; long labels (studio/edition) collide with the opposite corner; bottom-right badges sit underneath the card menu button (always visible on touch); pill/vibrant presets render duplicated wordmarks ("HDR10 HDR10", "ATMOS Atmos", "AV1 AV1") with clipped SVG marks; `prefs.order` was ignored by the renderer; standalone resolution showed "2160P" while the combined badge showed "4K"; matched manga cards rendered generic overlays underneath their status/count chips (which also overlapped each other); default badges flashed while user prefs loaded.

## Change

**`fix(metadata)` — persist series show_status (6deb1b9):**
- Both converters now carry `ShowStatus`; series values normalize via `NormalizeShowStatus` to a canonical domain (`returning`/`ended`/`cancelled`/`in_production`/`upcoming`) so TMDB "Returning Series"/"Canceled" and TVDB "Continuing"/"Upcoming" converge. Non-series values pass through verbatim so the manga domain can never be mangled by a generic refresh round-trip; the round-trip also stops refreshes from wiping a persisted value.
- Companion plugin changes already released: silo-plugin-tmdb v1.2.18 (#6) and silo-plugin-tvdb v1.2.22 (#5) now emit the proto `status` field.

**`fix(web)` — overlay layout/ordering/wordmarks (4cad6b3):**
- Each card edge renders as one flex row holding both corner stacks, so opposing badges share the width (`min-w-0` + truncate) instead of overlapping; corners cap at 3 badges; bottom-right stack sits above the menu button.
- `prefs.order` honored via `orderedOverlaysForPosition`; wordmark icons suppress a redundant label (and their viewBoxes no longer clip); standalone resolution uses `prettyResolution`; manga cards skip generic overlays and their chips share a truncating row; `useOverlayPrefs` returns null while loading; settings rows explain combined-badge suppression.

## Verification

- New unit suites: `internal/metadata/show_status_test.go` (normalization, converters, manga pass-through, refresh-wipe survival) and `web/.../CardOverlays.test.tsx` (all 25 overlays, ordering, suppression, wordmarks, corner cap, menu clearance).
- Go: `internal/metadata` + `internal/models` suites, `go build ./...`, golangci (no new findings). Web: vitest (only pre-existing Jellyfin setup-wizard failures remain, verified present without these changes), eslint at baseline, prettier + tsc clean.
- Layout re-verified in-browser on a stress page measuring badge-rectangle intersections: 0 overlaps across 15 scenarios (was 8 collision pairs), including 140px cards, all-overlays-enabled, long labels, menu button, and manga chips.

## Scope / risks

- No linked scope issue: this is bug-fix work from a requested audit of the shipped Card Overlay feature, not new v1 scope. API surface unchanged (additive only: `show_status` now actually populated).
- Existing series only pick up show_status on metadata refresh (backfill = refresh pass after deploy with the updated plugins).
- Behavior change: main's per-corner badge count caps at 3 and bottom-right badges sit above the menu button — both deliberate anti-crowding decisions.

## AI-use disclosure

Implemented with Claude Code (Claude Fable 5), reviewed by the maintainer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed show-status values so series metadata now round-trips correctly, while non-series items keep their own status values unchanged.
  * Improved card badges and manga chips so labels no longer overlap and display more consistently on narrow cards.
  * Prevented partially loaded overlay settings from showing incomplete badge preferences.
  * Refined overlay badge rendering for clearer resolution, HDR, and status display.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->