### PR TITLE
feat(images): add larger TV image variants

### DIFF
--- a/internal/api/handlers/episode_image_variant_test.go
+++ b/internal/api/handlers/episode_image_variant_test.go
@@ -1,0 +1,33 @@
+package handlers
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/Silo-Server/silo-server/internal/models"
+)
+
+// The episode's own still generates w780/w500 variants, but the series-artwork
+// fallback (backdrop/poster) does not — applying w780 (or its w500 resolver
+// fallback) to a backdrop 404s. The card path must keep the fallback on w300.
+func TestEpisodeResponseShellImageVariant(t *testing.T) {
+	tests := []struct {
+		name       string
+		still      string
+		fallback   string
+		wantSuffix string
+	}{
+		{"own still uses w780", "tvdb/series/1/seasons/2/episodes/3/still/original.webp", "", "/still/w780.webp"},
+		{"backdrop fallback keeps w300", "", "tmdb/shows/1/backdrop/original.webp", "/backdrop/w300.webp"},
+		{"poster fallback keeps w300", "", "tmdb/shows/1/poster/original.webp", "/poster/w300.webp"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ep := &models.Episode{StillPath: tt.still}
+			_, path := episodeResponseShell(ep, episodeImageFallback{Path: tt.fallback})
+			if !strings.HasSuffix(path, tt.wantSuffix) {
+				t.Errorf("path = %q, want suffix %q", path, tt.wantSuffix)
+			}
+		})
+	}
+}

--- a/internal/api/handlers/items.go
+++ b/internal/api/handlers/items.go
@@ -1201,7 +1201,14 @@ func (h *ItemsHandler) toEpisodeResponseWithFallback(r *http.Request, ep *models
 func episodeResponseShell(ep *models.Episode, fallback episodeImageFallback) (episodeResponse, string) {
 	stillPath := ep.StillPath
 	stillThumbhash := ep.StillThumbhash
-	if strings.TrimSpace(stillPath) == "" && strings.TrimSpace(fallback.Path) != "" {
+	// Only the episode's own still is a "still" image type (which generates
+	// the w780/w500 variants). The fallback is the parent series' backdrop or
+	// poster, which generate different variants — applying the still's w780
+	// (and its w500 resolver fallback) to a backdrop 404s, since backdrops
+	// only have w1920/w1280/w300. Track which we're using so the card path
+	// keeps the fallback on an existing variant.
+	usingOwnStill := strings.TrimSpace(stillPath) != ""
+	if !usingOwnStill && strings.TrimSpace(fallback.Path) != "" {
 		stillPath = fallback.Path
 		stillThumbhash = fallback.Thumbhash
 	}
@@ -1222,6 +1229,11 @@ func episodeResponseShell(ep *models.Episode, fallback episodeImageFallback) (ep
 		resp.AirDate = ep.AirDate.Format("2006-01-02")
 	}
 
+	// w780 only for the episode's own still; the series-artwork fallback keeps
+	// the safe w300 card variant that backdrops and posters always generate.
+	if usingOwnStill {
+		return resp, episodeStillPath(stillPath)
+	}
 	return resp, cardThumbnailPath(stillPath)
 }
 
@@ -2020,32 +2032,36 @@ func (h *ItemsHandler) userStoreForRequest(r *http.Request) (userstore.UserStore
 	return store, profileID, true
 }
 
-// cardThumbnailPath converts an S3 image path from original to w300 for use in
-// browse/card views (posters, backdrops, and stills at card size).
-// Full URLs (TMDB/TVDB) and plugin-prefixed paths are returned as-is —
-// variant selection is handled at resolution time for plugin paths.
-func cardThumbnailPath(path string) string {
-	if strings.HasPrefix(path, "http://") || strings.HasPrefix(path, "https://") {
-		return path
-	}
-	// Plugin-prefixed paths pass through — variant handled at resolution time.
+// imageVariantPath rewrites a cached "/original." S3 image path to the given
+// variant. Full URLs (TMDB/TVDB) and plugin-prefixed paths are returned
+// as-is — their variant selection is handled at resolution time.
+func imageVariantPath(path, variant string) string {
 	if strings.Contains(path, "://") {
 		return path
 	}
-	return strings.Replace(path, "/original.", "/w300.", 1)
+	return strings.Replace(path, "/original.", "/"+variant+".", 1)
+}
+
+// cardThumbnailPath converts an S3 image path from original to w300 for use in
+// browse/card views (posters, backdrops, and stills at card size).
+func cardThumbnailPath(path string) string {
+	return imageVariantPath(path, "w300")
+}
+
+// episodeStillPath converts an S3 still path from original to w780 — the
+// largest variant the image cache generates for stills. Episode stills
+// render on large 16:9 cards (the tvOS season view draws them ~920px wide
+// on a 4K panel), where the w300 card thumbnail was a visible 3x upscale.
+// Libraries cached before w780 existed fall back to w500 at resolution
+// time (metadata.PluginImageResolver newVariantFallbacks).
+func episodeStillPath(path string) string {
+	return imageVariantPath(path, "w780")
 }
 
 // featuredPosterPath converts an S3 poster path from original to w500 for
 // featured/hero contexts (displayed at ~220px CSS / 440px retina).
-// Full URLs (TMDB/TVDB) and plugin-prefixed paths are returned as-is.
 func featuredPosterPath(path string) string {
-	if strings.HasPrefix(path, "http://") || strings.HasPrefix(path, "https://") {
-		return path
-	}
-	if strings.Contains(path, "://") {
-		return path
-	}
-	return strings.Replace(path, "/original.", "/w500.", 1)
+	return imageVariantPath(path, "w500")
 }
 
 // featuredBackdropPath converts an S3 backdrop path from original to w1920 for

--- a/internal/api/handlers/sections_test.go
+++ b/internal/api/handlers/sections_test.go
@@ -53,16 +53,16 @@ func TestSectionBackdropPathUsesExpectedVariants(t *testing.T) {
 			want:        "/tmdb/shows/1399/backdrop/w1920.jpg",
 		},
 		{
-			name:        "continue watching episode still clamps to w500",
+			name:        "continue watching episode still clamps to w780",
 			sectionType: sections.SectionContinueWatching,
 			path:        "tvdb/series/73141/seasons/22/episodes/9/still/original.webp",
-			want:        "tvdb/series/73141/seasons/22/episodes/9/still/w500.webp",
+			want:        "tvdb/series/73141/seasons/22/episodes/9/still/w780.webp",
 		},
 		{
-			name:        "featured section episode still clamps to w500",
+			name:        "featured section episode still clamps to w780",
 			sectionType: sections.SectionRecentlyAdded,
 			path:        "tvdb/series/73141/seasons/22/episodes/9/still/original.webp",
-			want:        "tvdb/series/73141/seasons/22/episodes/9/still/w500.webp",
+			want:        "tvdb/series/73141/seasons/22/episodes/9/still/w780.webp",
 		},
 		{
 			name:        "http paths pass through",

--- a/internal/artworkkey/artworkkey.go
+++ b/internal/artworkkey/artworkkey.go
@@ -84,8 +84,10 @@ func VariantWidths(imageType string) []int {
 	case "backdrop":
 		return []int{1920, 1280, 300}
 	case "logo":
-		return []int{500}
-	default: // poster, still, profile
+		return []int{1280, 500}
+	case "still":
+		return []int{780, 500, 300}
+	default: // poster, profile
 		return []int{500, 300}
 	}
 }

--- a/internal/artworkkey/artworkkey_test.go
+++ b/internal/artworkkey/artworkkey_test.go
@@ -1,6 +1,9 @@
 package artworkkey
 
-import "testing"
+import (
+	"reflect"
+	"testing"
+)
 
 func TestRevisionedArtworkKeys(t *testing.T) {
 	base := "tmdb/movies/550/poster"
@@ -34,5 +37,22 @@ func TestVariantOnlyRewritesOriginalFilename(t *testing.T) {
 	want := "tmdb/movies/original.segment/550/poster/w500.abc123.webp"
 	if got := Variant(original, "w500"); got != want {
 		t.Fatalf("Variant() = %q, want %q", got, want)
+	}
+}
+
+func TestTVArtworkVariantLadders(t *testing.T) {
+	tests := []struct {
+		imageType string
+		want      []int
+	}{
+		{imageType: "logo", want: []int{1280, 500}},
+		{imageType: "still", want: []int{780, 500, 300}},
+	}
+	for _, tt := range tests {
+		t.Run(tt.imageType, func(t *testing.T) {
+			if got := VariantWidths(tt.imageType); !reflect.DeepEqual(got, tt.want) {
+				t.Fatalf("VariantWidths(%q) = %v, want %v", tt.imageType, got, tt.want)
+			}
+		})
 	}
 }

--- a/internal/catalog/detail.go
+++ b/internal/catalog/detail.go
@@ -4036,10 +4036,11 @@ func imageTypeFromCachedPath(path string) string {
 
 // BackdropVariantPath rewrites a cached "/original." image path to the
 // requested backdrop variant (e.g. "w1280" or "w1920"). Episode "backdrops"
-// are frequently the episode still, which the cache only generates at
-// w500/w300 — so requesting a backdrop width 404s. For still/poster/logo
-// paths this clamps to that type's largest cached variant instead. Full URLs,
-// plugin-prefixed paths, and non-"/original." paths pass through unchanged.
+// are frequently the episode still, which the cache generates at smaller
+// widths than backdrops — so requesting a backdrop width 404s. For
+// still/poster/logo paths this clamps to that type's largest cached variant
+// instead. Full URLs, plugin-prefixed paths, and non-"/original." paths pass
+// through unchanged.
 func BackdropVariantPath(path, desiredVariant string) string {
 	if path == "" || strings.Contains(path, "://") || !strings.Contains(path, "/original.") {
 		return path
@@ -4067,8 +4068,19 @@ func cachedImageVariantKey(imageType, size string) string {
 		}
 		return "w1920"
 	case "logo":
-		return "w500"
-	case "poster", "still":
+		// Largest generated logo variant — 4K TV heroes render logos at
+		// ~1240 physical px. Libraries cached before the ladder grew fall
+		// back to w500 at resolution time (see newVariantFallbacks).
+		return "w1280"
+	case "still":
+		if size == "small" {
+			return "w300"
+		}
+		// Largest generated still variant — 4K TV season views render
+		// episode stills at ~920 physical px. Pre-ladder libraries fall
+		// back to w500 at resolution time (see newVariantFallbacks).
+		return "w780"
+	case "poster":
 		if size == "small" {
 			return "w300"
 		}

--- a/internal/catalog/image_variants_test.go
+++ b/internal/catalog/image_variants_test.go
@@ -45,16 +45,16 @@ func TestBackdropVariantPath(t *testing.T) {
 			want:    "/tmdb/shows/1399/backdrop/w1920.jpg",
 		},
 		{
-			name:    "episode still clamps to w500 (no large variant exists)",
+			name:    "episode still clamps to w780 (largest generated still variant)",
 			path:    "tvdb/series/73141/seasons/22/episodes/9/still/original.webp",
 			desired: "w1280",
-			want:    "tvdb/series/73141/seasons/22/episodes/9/still/w500.webp",
+			want:    "tvdb/series/73141/seasons/22/episodes/9/still/w780.webp",
 		},
 		{
-			name:    "episode still clamps w1920 to w500",
+			name:    "episode still clamps w1920 to w780",
 			path:    "tvdb/series/73141/seasons/22/episodes/9/still/original.webp",
 			desired: "w1920",
-			want:    "tvdb/series/73141/seasons/22/episodes/9/still/w500.webp",
+			want:    "tvdb/series/73141/seasons/22/episodes/9/still/w780.webp",
 		},
 		{
 			name:    "http url passes through",

--- a/internal/catalog/image_variants_test.go
+++ b/internal/catalog/image_variants_test.go
@@ -2,6 +2,8 @@ package catalog
 
 import "testing"
 
+const variantW1280 = "w1280"
+
 func TestImageTypeFromCachedPath(t *testing.T) {
 	tests := []struct {
 		name string
@@ -35,7 +37,7 @@ func TestBackdropVariantPath(t *testing.T) {
 		{
 			name:    "real backdrop keeps requested w1280",
 			path:    "tmdb/movies/550/backdrop/original.webp",
-			desired: "w1280",
+			desired: variantW1280,
 			want:    "tmdb/movies/550/backdrop/w1280.webp",
 		},
 		{
@@ -47,7 +49,7 @@ func TestBackdropVariantPath(t *testing.T) {
 		{
 			name:    "episode still clamps to w780 (largest generated still variant)",
 			path:    "tvdb/series/73141/seasons/22/episodes/9/still/original.webp",
-			desired: "w1280",
+			desired: variantW1280,
 			want:    "tvdb/series/73141/seasons/22/episodes/9/still/w780.webp",
 		},
 		{
@@ -59,19 +61,19 @@ func TestBackdropVariantPath(t *testing.T) {
 		{
 			name:    "http url passes through",
 			path:    "https://images.example.com/backdrop/original.jpg",
-			desired: "w1280",
+			desired: variantW1280,
 			want:    "https://images.example.com/backdrop/original.jpg",
 		},
 		{
 			name:    "plugin path passes through",
 			path:    "plugin://tmdb/backdrop/original.jpg",
-			desired: "w1280",
+			desired: variantW1280,
 			want:    "plugin://tmdb/backdrop/original.jpg",
 		},
 		{
 			name:    "path without original segment passes through",
 			path:    "tmdb/movies/550/backdrop/w300.webp",
-			desired: "w1280",
+			desired: variantW1280,
 			want:    "tmdb/movies/550/backdrop/w300.webp",
 		},
 	}

--- a/internal/imagecache/imagecache_test.go
+++ b/internal/imagecache/imagecache_test.go
@@ -475,17 +475,17 @@ func TestCache_Logo(t *testing.T) {
 	}
 
 	keys := s3.keys()
-	// Expect 2 variants: original, w500 — NO w300 or w1280
-	if len(keys) != 2 {
-		t.Errorf("expected 2 uploaded variants, got %d: %v", len(keys), keys)
+	// Expect 3 variants: original, w1280 (4K TV hero logos), w500 — NO w300
+	if len(keys) != 3 {
+		t.Errorf("expected 3 uploaded variants, got %d: %v", len(keys), keys)
 	}
-	for _, variant := range []string{"original", "w500"} {
+	for _, variant := range []string{"original", "w1280", "w500"} {
 		want := result.VariantPaths[variant]
 		if !hasKey(keys, want) {
 			t.Errorf("missing S3 key %q in %v", want, keys)
 		}
 	}
-	for _, forbidden := range []string{"w300", "w1280"} {
+	for _, forbidden := range []string{"w300"} {
 		if _, ok := result.VariantPaths[forbidden]; ok {
 			t.Errorf("logo should not have %s variant", forbidden)
 		}
@@ -516,7 +516,7 @@ func TestCache_ConvertsSVGLogo(t *testing.T) {
 	if result.Thumbhash == "" {
 		t.Fatal("Thumbhash is empty")
 	}
-	for _, variant := range []string{"original", "w500"} {
+	for _, variant := range []string{"original", "w1280", "w500"} {
 		want := result.VariantPaths[variant]
 		if !hasKey(s3.keys(), want) {
 			t.Errorf("missing S3 key %q in %v", want, s3.keys())

--- a/internal/metadata/image_resolver.go
+++ b/internal/metadata/image_resolver.go
@@ -156,6 +156,9 @@ func (r *PluginImageResolver) Close() {
 	if r.urlCache != nil {
 		r.urlCache.Close()
 	}
+	if r.variantExistsCache != nil {
+		r.variantExistsCache.Close()
+	}
 }
 
 // ResolveImageURL resolves a single plugin-prefixed image path.
@@ -395,7 +398,7 @@ func (r *PluginImageResolver) existingVariantKey(ctx context.Context, presigner 
 }
 
 // newVariantFallback extracts the variant filename from a cached image key
-// ("…/still/w780.webp" → "w780") and reports its fallback when the variant
+// ("…/still/w780.revision.webp" → "w780") and reports its fallback when the variant
 // is one of the newly-introduced rungs.
 func newVariantFallback(key string) (variant, fallback string, ok bool) {
 	lastSlash := strings.LastIndex(key, "/")

--- a/internal/metadata/image_resolver.go
+++ b/internal/metadata/image_resolver.go
@@ -22,6 +22,7 @@ import (
 const (
 	resolvedURLCacheSafetyMargin = 5 * time.Minute
 	maxResolvedURLCacheTTL       = 24 * time.Hour
+	missingVariantCacheTTL       = 15 * time.Minute
 )
 
 // PluginImageResolverSource provides image URL resolution for a single plugin.
@@ -68,15 +69,19 @@ type PluginImageResolver struct {
 	s3Presigner  s3ImagePresigner
 	s3PresignTTL time.Duration
 	urlCache     *cache.TTLCache[catalog.ResolvedImageURL]
-	group        singleflight.Group
+	// variantExistsCache memoizes S3 existence checks for newly-introduced
+	// image variants (see newVariantFallbacks).
+	variantExistsCache *cache.TTLCache[bool]
+	group              singleflight.Group
 }
 
 // NewPluginImageResolver creates a new resolver with no registered sources.
 func NewPluginImageResolver() *PluginImageResolver {
 	return &PluginImageResolver{
-		sources:      make(map[string][]pluginImageResolverSourceEntry),
-		s3PresignTTL: 15 * time.Minute,
-		urlCache:     cache.NewTTLCache[catalog.ResolvedImageURL](),
+		sources:            make(map[string][]pluginImageResolverSourceEntry),
+		s3PresignTTL:       15 * time.Minute,
+		urlCache:           cache.NewTTLCache[catalog.ResolvedImageURL](),
+		variantExistsCache: cache.NewTTLCache[bool](),
 	}
 }
 
@@ -318,15 +323,93 @@ func (r *PluginImageResolver) resolveS3Batch(
 	}
 	expiresAt := time.Now().Add(ttl)
 	for _, entry := range entries {
-		url, err := presigner.PresignGetURL(ctx, presigner.Bucket(), entry.originalPath, ttl)
+		key, usedFallback := r.existingVariantKey(ctx, presigner, entry.originalPath)
+		url, err := presigner.PresignGetURL(ctx, presigner.Bucket(), key, ttl)
 		if err != nil {
 			slog.ErrorContext(ctx, "s3 image resolution failed", "component", "metadata", "path", entry.originalPath, "error", err)
 			continue
 		}
 		expiry := expiresAt
+		if usedFallback {
+			fallbackExpiry := time.Now().Add(missingVariantCacheTTL + resolvedURLCacheSafetyMargin)
+			if fallbackExpiry.Before(expiry) {
+				expiry = fallbackExpiry
+			}
+		}
 		resolved[entry.originalPath] = catalog.ResolvedImageURL{URL: url, ExpiresAt: &expiry}
 	}
 	return resolved
+}
+
+// newVariantFallbacks maps variant filenames introduced after libraries were
+// first cached to the largest variant every earlier ladder generated. Images
+// cached before the ladder grew have no object at the new key; presigning it
+// blindly would serve a 404. Falling back keeps them rendering (slightly
+// softer) until a metadata refresh regenerates variants — uploadVariants
+// fills only the missing objects from the stored original, so the fallback
+// retires organically per image.
+var newVariantFallbacks = map[string]string{
+	"w780":  "w500", // stills: ladder grew for 4K TV episode cards
+	"w1280": "w500", // logos: ladder grew for 4K TV hero logos
+}
+
+type s3ObjectExister interface {
+	ObjectExists(ctx context.Context, bucket, key string) (bool, error)
+}
+
+// existingVariantKey returns the key to presign for a cached-image variant path
+// and whether that key is a pre-ladder fallback. Keys naming a
+// newly-introduced variant are existence-checked (with a TTL-cached result, so
+// steady-state serving adds no S3 round-trips) and swapped to the pre-ladder
+// fallback variant when the object is missing.
+func (r *PluginImageResolver) existingVariantKey(ctx context.Context, presigner s3ImagePresigner, key string) (string, bool) {
+	variant, fallback, ok := newVariantFallback(key)
+	if !ok {
+		return key, false
+	}
+	exister, ok := presigner.(s3ObjectExister)
+	if !ok {
+		return key, false
+	}
+	cacheKey := "s3-variant-exists|" + key
+	if exists, ok := r.variantExistsCache.Get(cacheKey); ok {
+		if exists {
+			return key, false
+		}
+		return strings.Replace(key, "/"+variant+".", "/"+fallback+".", 1), true
+	}
+	exists, err := exister.ObjectExists(ctx, presigner.Bucket(), key)
+	if err != nil {
+		// Optimistic on errors: presign the requested key rather than
+		// silently degrading every image during an S3 blip.
+		return key, false
+	}
+	if exists {
+		// Once generated, a variant object is immutable.
+		r.variantExistsCache.Set(cacheKey, true, 24*time.Hour)
+		return key, false
+	}
+	// Short TTL so a refresh-generated variant is picked up promptly.
+	r.variantExistsCache.Set(cacheKey, false, missingVariantCacheTTL)
+	return strings.Replace(key, "/"+variant+".", "/"+fallback+".", 1), true
+}
+
+// newVariantFallback extracts the variant filename from a cached image key
+// ("…/still/w780.webp" → "w780") and reports its fallback when the variant
+// is one of the newly-introduced rungs.
+func newVariantFallback(key string) (variant, fallback string, ok bool) {
+	lastSlash := strings.LastIndex(key, "/")
+	if lastSlash < 0 {
+		return "", "", false
+	}
+	name := key[lastSlash+1:]
+	dot := strings.IndexByte(name, '.')
+	if dot <= 0 {
+		return "", "", false
+	}
+	variant = name[:dot]
+	fallback, ok = newVariantFallbacks[variant]
+	return variant, fallback, ok
 }
 
 func (r *PluginImageResolver) resolvePluginBatch(

--- a/internal/metadata/image_resolver_test.go
+++ b/internal/metadata/image_resolver_test.go
@@ -2,6 +2,7 @@ package metadata
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"sync"
 	"sync/atomic"
@@ -331,6 +332,7 @@ type fakeS3ImagePresigner struct {
 	ttl         time.Duration
 	keys        []string
 	existing    map[string]bool
+	existsErr   error
 	existsCalls int
 }
 
@@ -347,6 +349,9 @@ func (p *fakeS3ImagePresigner) Bucket() string {
 
 func (p *fakeS3ImagePresigner) ObjectExists(_ context.Context, _ string, key string) (bool, error) {
 	p.existsCalls++
+	if p.existsErr != nil {
+		return false, p.existsErr
+	}
 	return p.existing[key], nil
 }
 
@@ -383,16 +388,76 @@ func TestPluginImageResolverS3FallsBackForMissingNewVariant(t *testing.T) {
 	defer resolver.Close()
 	resolver.SetS3Presigner(presigner, 10*time.Minute)
 
-	got := resolver.ResolveImageURL(context.Background(), "tvdb/series/1/seasons/1/episodes/1/still/w780.webp", "featured")
-	want := "s3:tvdb/series/1/seasons/1/episodes/1/still/w500.webp:1"
+	got := resolver.ResolveImageURL(context.Background(), "tvdb/series/1/seasons/1/episodes/1/still/w780.rev123.webp", "featured")
+	want := "s3:tvdb/series/1/seasons/1/episodes/1/still/w500.rev123.webp:1"
 	if got != want {
 		t.Fatalf("resolved URL = %q, want %q", got, want)
 	}
 	if presigner.existsCalls != 1 {
 		t.Fatalf("ObjectExists calls = %d, want 1", presigner.existsCalls)
 	}
-	if len(presigner.keys) != 1 || presigner.keys[0] != "tvdb/series/1/seasons/1/episodes/1/still/w500.webp" {
+	if len(presigner.keys) != 1 || presigner.keys[0] != "tvdb/series/1/seasons/1/episodes/1/still/w500.rev123.webp" {
 		t.Fatalf("presigned keys = %v, want w500 fallback", presigner.keys)
+	}
+}
+
+func TestPluginImageResolverS3PresignsExistingNewVariant(t *testing.T) {
+	const key = "tvdb/series/1/seasons/1/episodes/1/still/w780.webp"
+	presigner := &fakeS3ImagePresigner{existing: map[string]bool{key: true}}
+	resolver := NewPluginImageResolver()
+	defer resolver.Close()
+	resolver.SetS3Presigner(presigner, 10*time.Minute)
+
+	got := resolver.ResolveImageURL(context.Background(), key, "featured")
+	want := "s3:tvdb/series/1/seasons/1/episodes/1/still/w780.webp:1"
+	if got != want {
+		t.Fatalf("resolved URL = %q, want %q", got, want)
+	}
+	if presigner.existsCalls != 1 {
+		t.Fatalf("ObjectExists calls = %d, want 1", presigner.existsCalls)
+	}
+	if len(presigner.keys) != 1 || presigner.keys[0] != key {
+		t.Fatalf("presigned keys = %v, want direct w780 key", presigner.keys)
+	}
+
+	resolver.urlCache.InvalidatePrefix("")
+	got = resolver.ResolveImageURL(context.Background(), key, "featured")
+	want = "s3:tvdb/series/1/seasons/1/episodes/1/still/w780.webp:2"
+	if got != want {
+		t.Fatalf("resolved URL after URL cache clear = %q, want %q", got, want)
+	}
+	if presigner.existsCalls != 1 {
+		t.Fatalf("ObjectExists calls after cached existence = %d, want 1", presigner.existsCalls)
+	}
+}
+
+func TestPluginImageResolverS3PresignsRequestedVariantWhenExistsCheckErrors(t *testing.T) {
+	const key = "tvdb/series/1/seasons/1/episodes/1/still/w780.webp"
+	presigner := &fakeS3ImagePresigner{existsErr: errors.New("s3 unavailable")}
+	resolver := NewPluginImageResolver()
+	defer resolver.Close()
+	resolver.SetS3Presigner(presigner, 10*time.Minute)
+
+	got := resolver.ResolveImageURL(context.Background(), key, "featured")
+	want := "s3:tvdb/series/1/seasons/1/episodes/1/still/w780.webp:1"
+	if got != want {
+		t.Fatalf("resolved URL = %q, want %q", got, want)
+	}
+	if presigner.existsCalls != 1 {
+		t.Fatalf("ObjectExists calls = %d, want 1", presigner.existsCalls)
+	}
+	if len(presigner.keys) != 1 || presigner.keys[0] != key {
+		t.Fatalf("presigned keys = %v, want direct w780 key", presigner.keys)
+	}
+
+	resolver.urlCache.InvalidatePrefix("")
+	got = resolver.ResolveImageURL(context.Background(), key, "featured")
+	want = "s3:tvdb/series/1/seasons/1/episodes/1/still/w780.webp:2"
+	if got != want {
+		t.Fatalf("resolved URL after URL cache clear = %q, want %q", got, want)
+	}
+	if presigner.existsCalls != 2 {
+		t.Fatalf("ObjectExists calls after URL cache clear = %d, want 2 to prove error was not cached", presigner.existsCalls)
 	}
 }
 
@@ -402,8 +467,8 @@ func TestPluginImageResolverS3FallbackURLCacheUsesMissingVariantTTL(t *testing.T
 	defer resolver.Close()
 	resolver.SetS3Presigner(presigner, 4*time.Hour)
 
-	resolved := resolver.ResolveImageURLWithExpiry(context.Background(), "tvdb/series/1/seasons/1/episodes/1/still/w780.webp", "featured")
-	if resolved.URL != "s3:tvdb/series/1/seasons/1/episodes/1/still/w500.webp:1" {
+	resolved := resolver.ResolveImageURLWithExpiry(context.Background(), "tvdb/series/1/seasons/1/episodes/1/still/w780.rev123.webp", "featured")
+	if resolved.URL != "s3:tvdb/series/1/seasons/1/episodes/1/still/w500.rev123.webp:1" {
 		t.Fatalf("resolved URL = %q, want w500 fallback", resolved.URL)
 	}
 	if resolved.ExpiresAt == nil {
@@ -414,7 +479,7 @@ func TestPluginImageResolverS3FallbackURLCacheUsesMissingVariantTTL(t *testing.T
 		t.Fatalf("fallback URL cache TTL = %s, want about %s", cacheTTL, missingVariantCacheTTL)
 	}
 
-	cached := resolver.ResolveImageURLWithExpiry(context.Background(), "tvdb/series/1/seasons/1/episodes/1/still/w780.webp", "featured")
+	cached := resolver.ResolveImageURLWithExpiry(context.Background(), "tvdb/series/1/seasons/1/episodes/1/still/w780.rev123.webp", "featured")
 	if cached.URL != resolved.URL {
 		t.Fatalf("cached fallback URL = %q, want %q", cached.URL, resolved.URL)
 	}

--- a/internal/metadata/image_resolver_test.go
+++ b/internal/metadata/image_resolver_test.go
@@ -327,18 +327,27 @@ func TestPluginImageResolverCoalescesConcurrentBatchMisses(t *testing.T) {
 }
 
 type fakeS3ImagePresigner struct {
-	calls int
-	ttl   time.Duration
+	calls       int
+	ttl         time.Duration
+	keys        []string
+	existing    map[string]bool
+	existsCalls int
 }
 
 func (p *fakeS3ImagePresigner) PresignGetURL(_ context.Context, _ string, key string, expiry time.Duration) (string, error) {
 	p.calls++
 	p.ttl = expiry
+	p.keys = append(p.keys, key)
 	return fmt.Sprintf("s3:%s:%d", key, p.calls), nil
 }
 
 func (p *fakeS3ImagePresigner) Bucket() string {
 	return "metadata"
+}
+
+func (p *fakeS3ImagePresigner) ObjectExists(_ context.Context, _ string, key string) (bool, error) {
+	p.existsCalls++
+	return p.existing[key], nil
 }
 
 func TestPluginImageResolverS3URLsCarryConfiguredExpiry(t *testing.T) {
@@ -365,5 +374,51 @@ func TestPluginImageResolverS3URLsCarryConfiguredExpiry(t *testing.T) {
 	}
 	if first.ExpiresAt.Before(before.Add(9*time.Minute)) || first.ExpiresAt.After(before.Add(11*time.Minute)) {
 		t.Fatalf("S3 expiry = %s, want about 10m from now", first.ExpiresAt.Sub(before))
+	}
+}
+
+func TestPluginImageResolverS3FallsBackForMissingNewVariant(t *testing.T) {
+	presigner := &fakeS3ImagePresigner{}
+	resolver := NewPluginImageResolver()
+	defer resolver.Close()
+	resolver.SetS3Presigner(presigner, 10*time.Minute)
+
+	got := resolver.ResolveImageURL(context.Background(), "tvdb/series/1/seasons/1/episodes/1/still/w780.webp", "featured")
+	want := "s3:tvdb/series/1/seasons/1/episodes/1/still/w500.webp:1"
+	if got != want {
+		t.Fatalf("resolved URL = %q, want %q", got, want)
+	}
+	if presigner.existsCalls != 1 {
+		t.Fatalf("ObjectExists calls = %d, want 1", presigner.existsCalls)
+	}
+	if len(presigner.keys) != 1 || presigner.keys[0] != "tvdb/series/1/seasons/1/episodes/1/still/w500.webp" {
+		t.Fatalf("presigned keys = %v, want w500 fallback", presigner.keys)
+	}
+}
+
+func TestPluginImageResolverS3FallbackURLCacheUsesMissingVariantTTL(t *testing.T) {
+	presigner := &fakeS3ImagePresigner{}
+	resolver := NewPluginImageResolver()
+	defer resolver.Close()
+	resolver.SetS3Presigner(presigner, 4*time.Hour)
+
+	resolved := resolver.ResolveImageURLWithExpiry(context.Background(), "tvdb/series/1/seasons/1/episodes/1/still/w780.webp", "featured")
+	if resolved.URL != "s3:tvdb/series/1/seasons/1/episodes/1/still/w500.webp:1" {
+		t.Fatalf("resolved URL = %q, want w500 fallback", resolved.URL)
+	}
+	if resolved.ExpiresAt == nil {
+		t.Fatal("fallback resolved URL missing expiry")
+	}
+	cacheTTL := cacheTTLForResolvedURL(resolved, time.Now())
+	if cacheTTL < missingVariantCacheTTL-time.Second || cacheTTL > missingVariantCacheTTL+time.Second {
+		t.Fatalf("fallback URL cache TTL = %s, want about %s", cacheTTL, missingVariantCacheTTL)
+	}
+
+	cached := resolver.ResolveImageURLWithExpiry(context.Background(), "tvdb/series/1/seasons/1/episodes/1/still/w780.webp", "featured")
+	if cached.URL != resolved.URL {
+		t.Fatalf("cached fallback URL = %q, want %q", cached.URL, resolved.URL)
+	}
+	if presigner.calls != 1 {
+		t.Fatalf("s3 presign calls = %d, want cached fallback URL", presigner.calls)
 	}
 }


### PR DESCRIPTION
# feat(images): add larger TV image variants

## Problem

Large TV detail surfaces can upscale the existing small still/logo variants, which is especially noticeable on 4K displays. Episode stills also reuse a smaller card thumbnail path where a TV-sized still variant is more appropriate.

## Approach

Add larger generated variants for TV-sized still and logo surfaces, use a still-specific episode image variant where needed, and preserve fallback behavior for cached images whose larger variants have not been generated yet. Fallback presigned URLs are cached only for the short missing-variant window, so a refresh-generated larger object is picked up promptly. Focused tests cover variant selection, generated variant ladders, and S3 resolver fallback from new keys to older cached variants.

## Verification

```sh
go test ./internal/api/handlers ./internal/catalog ./internal/imagecache ./internal/metadata
git diff --check
```

## Risks & follow-up

Moderate risk. The change is additive and keeps existing small card surfaces on smaller variants, but operators should expect extra S3/storage and cache-warm bandwidth once images refresh: logos add `w1280` alongside existing logo variants, and stills add `w780` alongside existing still variants. Existing cached media can continue to fall back when larger variants are unavailable, and missing larger variants are filled only when refresh/upload runs.

## AI-use disclosure

Implemented with a combination of Claude Code and Codex assistance, with human oversight.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Episode still images now use larger, dedicated variants (including consistent w780 scaling), while backdrops follow safer cached limits.
  * Episode artwork fallback now selects the most appropriate card-sized variant (poster/backdrop/card-thumbnail behavior remains correct).
  * Image resizing has updated variant ladders for logo, still, poster, and profile for better consistency.
  * When an image variant isn’t available, the system automatically falls back to the nearest supported lower-size version and refreshes sooner for missing variants.
  * Logos can now be delivered in higher-resolution variants.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->