### PR TITLE
feat(scanner): capture audio stream profile metadata

### DIFF
--- a/internal/catalogseed/service.go
+++ b/internal/catalogseed/service.go
@@ -2599,6 +2599,7 @@ func toAudioTrackRecords(tracks []models.AudioTrack) []AudioTrackRecord {
 			EmbeddedTitle: track.EmbeddedTitle,
 			Language:      track.Language,
 			Codec:         track.Codec,
+			Profile:       track.Profile,
 			Layout:        track.Layout,
 			Channels:      track.Channels,
 			Bitrate:       track.Bitrate,

--- a/internal/catalogseed/types.go
+++ b/internal/catalogseed/types.go
@@ -169,6 +169,7 @@ type AudioTrackRecord struct {
 	EmbeddedTitle string `json:"embedded_title,omitempty"`
 	Language      string `json:"language,omitempty"`
 	Codec         string `json:"codec,omitempty"`
+	Profile       string `json:"profile,omitempty"`
 	Layout        string `json:"layout,omitempty"`
 	Channels      int    `json:"channels,omitempty"`
 	Bitrate       int    `json:"bitrate,omitempty"`

--- a/internal/models/media.go
+++ b/internal/models/media.go
@@ -186,6 +186,7 @@ type AudioTrack struct {
 	EmbeddedTitle string `json:"embedded_title,omitempty"`
 	Language      string `json:"language,omitempty"`
 	Codec         string `json:"codec,omitempty"`
+	Profile       string `json:"profile,omitempty"`
 	Layout        string `json:"layout,omitempty"`
 	Channels      int    `json:"channels,omitempty"`
 	Bitrate       int    `json:"bitrate,omitempty"`

--- a/internal/scanner/probe.go
+++ b/internal/scanner/probe.go
@@ -211,6 +211,7 @@ func convertProbeData(raw *ffprobeOutput) *ProbeData {
 				EmbeddedTitle: s.Tags["title"],
 				Language:      lang.Canonical(s.Tags["language"]),
 				Codec:         s.CodecName,
+				Profile:       s.Profile,
 				Layout:        s.ChannelLayout,
 				Channels:      s.Channels,
 				Bitrate:       parseNumeric(s.BitRate) / 1000,

--- a/internal/scanner/probe_audio_profile_test.go
+++ b/internal/scanner/probe_audio_profile_test.go
@@ -1,0 +1,37 @@
+package scanner
+
+import "testing"
+
+func TestConvertProbeDataCapturesAudioProfile(t *testing.T) {
+	probe := convertProbeData(&ffprobeOutput{
+		Streams: []ffprobeStream{
+			{
+				CodecType:        "audio",
+				CodecName:        "eac3",
+				CodecLongName:    "E-AC-3",
+				Profile:          "Dolby Digital Plus + Dolby Atmos",
+				ChannelLayout:    "5.1(side)",
+				Channels:         6,
+				BitRate:          "768000",
+				SampleRate:       "48000",
+				BitsPerRawSample: "24",
+				Disposition:      ffprobeDisp{Default: 1},
+				Tags:             map[string]string{"language": "eng", "title": "Main Audio"},
+			},
+		},
+	})
+
+	if len(probe.AudioTracks) != 1 {
+		t.Fatalf("audio tracks = %d, want 1", len(probe.AudioTracks))
+	}
+	track := probe.AudioTracks[0]
+	if track.Profile != "Dolby Digital Plus + Dolby Atmos" {
+		t.Fatalf("profile = %q, want Dolby Digital Plus + Dolby Atmos", track.Profile)
+	}
+	if track.Codec != "eac3" {
+		t.Fatalf("codec = %q, want eac3", track.Codec)
+	}
+	if !track.Default {
+		t.Fatal("expected default audio track")
+	}
+}

--- a/internal/scanner/scanner.go
+++ b/internal/scanner/scanner.go
@@ -2824,6 +2824,7 @@ func applyProbeData(mf *models.MediaFile, probe *ProbeData, probeSource string) 
 			EmbeddedTitle: at.EmbeddedTitle,
 			Language:      at.Language,
 			Codec:         at.Codec,
+			Profile:       at.Profile,
 			Layout:        at.Layout,
 			Channels:      at.Channels,
 			Bitrate:       at.Bitrate,

--- a/internal/scanner/types.go
+++ b/internal/scanner/types.go
@@ -69,6 +69,7 @@ type AudioTrackInfo struct {
 	EmbeddedTitle string
 	Language      string
 	Codec         string
+	Profile       string
 	Layout        string
 	Channels      int
 	Bitrate       int


### PR DESCRIPTION
# feat(scanner): capture audio stream profile metadata

## Problem

The scanner preserves video track profile metadata but discards ffprobe's audio stream `profile`. Downstream surfaces therefore cannot display or reason about audio profile details such as Dolby Digital Plus + Dolby Atmos when ffprobe exposes them.

## Approach

Carry the ffprobe audio stream `profile` through scanner probe data and store it in the existing audio track JSON metadata. This is an additive JSON field, with a focused scanner test that verifies profile capture.

## Verification

```sh
go test ./internal/scanner
git diff --check
```

## Risks & follow-up

Low risk. Existing fields and scanner decisions are unchanged. Consumers that do not know about `profile` can ignore it.

## AI-use disclosure

Implemented with a combination of Claude Code and Codex assistance, with human oversight.


## Linked scope

Companion web PR that displays the captured field in Media Info: #339.

## Review follow-ups applied

- `catalogseed.AudioTrackRecord` now mirrors the audio `profile` field (parity with `VideoTrackRecord.Profile`), so seed exports do not drop it.

## Known limitations

- Existing libraries only gain `profile` once files are re-probed (new/changed files, probe repair, or a metadata refresh); there is no automatic backfill.
- jellycompat does not yet expose the audio profile on `MediaStream.Profile` / `AudioSpatialFormat`; tracked as a follow-up.
