### PR TITLE
feat(sections): allow row image style selection

### DIFF
--- a/internal/api/handlers/sections.go
+++ b/internal/api/handlers/sections.go
@@ -164,6 +164,9 @@ func validateSectionConfig(sectionType sections.SectionType, config json.RawMess
 	if _, err := sections.ParseContinueType(config); err != nil {
 		return err.Error(), false
 	}
+	if _, err := sections.ParseCardImageStyle(config); err != nil {
+		return err.Error(), false
+	}
 
 	var rawLibraryConfig struct {
 		FilterLibraryID  *int  `json:"filter_library_id"`
@@ -474,15 +477,16 @@ type sectionItemResponse struct {
 }
 
 type resolvedSectionResponse struct {
-	ID          string                `json:"id"`
-	SectionType string                `json:"section_type"`
-	Title       string                `json:"title"`
-	Featured    bool                  `json:"featured"`
-	ItemLimit   int                   `json:"item_limit"`
-	TotalCount  int                   `json:"total_count"`
-	IsCustom    bool                  `json:"is_custom"`
-	Customized  bool                  `json:"customized"`
-	Items       []sectionItemResponse `json:"items"`
+	ID             string                  `json:"id"`
+	SectionType    string                  `json:"section_type"`
+	Title          string                  `json:"title"`
+	Featured       bool                    `json:"featured"`
+	ItemLimit      int                     `json:"item_limit"`
+	CardImageStyle sections.CardImageStyle `json:"card_image_style,omitempty"`
+	TotalCount     int                     `json:"total_count"`
+	IsCustom       bool                    `json:"is_custom"`
+	Customized     bool                    `json:"customized"`
+	Items          []sectionItemResponse   `json:"items"`
 }
 
 type homeSectionsResponse struct {
@@ -490,13 +494,14 @@ type homeSectionsResponse struct {
 }
 
 type resolvedSectionLayoutResponse struct {
-	ID          string `json:"id"`
-	SectionType string `json:"section_type"`
-	Title       string `json:"title"`
-	Featured    bool   `json:"featured"`
-	ItemLimit   int    `json:"item_limit"`
-	IsCustom    bool   `json:"is_custom"`
-	Customized  bool   `json:"customized"`
+	ID             string                  `json:"id"`
+	SectionType    string                  `json:"section_type"`
+	Title          string                  `json:"title"`
+	Featured       bool                    `json:"featured"`
+	ItemLimit      int                     `json:"item_limit"`
+	CardImageStyle sections.CardImageStyle `json:"card_image_style,omitempty"`
+	IsCustom       bool                    `json:"is_custom"`
+	Customized     bool                    `json:"customized"`
 }
 
 type homeLayoutResponse struct {
@@ -523,13 +528,14 @@ func (h *SectionHandler) HandleHomeLayout(w http.ResponseWriter, r *http.Request
 	}
 	for _, s := range resolved {
 		resp.Sections = append(resp.Sections, resolvedSectionLayoutResponse{
-			ID:          s.ID,
-			SectionType: string(s.SectionType),
-			Title:       s.Title,
-			Featured:    s.Featured,
-			ItemLimit:   s.ItemLimit,
-			IsCustom:    s.IsCustom,
-			Customized:  s.Customized,
+			ID:             s.ID,
+			SectionType:    string(s.SectionType),
+			Title:          s.Title,
+			Featured:       s.Featured,
+			ItemLimit:      s.ItemLimit,
+			CardImageStyle: sections.CardImageStyleFromConfig(s.Config),
+			IsCustom:       s.IsCustom,
+			Customized:     s.Customized,
 		})
 	}
 
@@ -556,13 +562,14 @@ func (h *SectionHandler) HandleLibraryLayout(w http.ResponseWriter, r *http.Requ
 	}
 	for _, s := range resolved {
 		resp.Sections = append(resp.Sections, resolvedSectionLayoutResponse{
-			ID:          s.ID,
-			SectionType: string(s.SectionType),
-			Title:       s.Title,
-			Featured:    s.Featured,
-			ItemLimit:   s.ItemLimit,
-			IsCustom:    s.IsCustom,
-			Customized:  s.Customized,
+			ID:             s.ID,
+			SectionType:    string(s.SectionType),
+			Title:          s.Title,
+			Featured:       s.Featured,
+			ItemLimit:      s.ItemLimit,
+			CardImageStyle: sections.CardImageStyleFromConfig(s.Config),
+			IsCustom:       s.IsCustom,
+			Customized:     s.Customized,
 		})
 	}
 
@@ -1270,15 +1277,16 @@ func (h *SectionHandler) buildSectionsResponse(r *http.Request, withItems []sect
 			items = append(items, h.toSectionItemResponse(s.SectionType, item, meta, overlaySummaries[item.ContentID], userStates[item.ContentID], imageURLs[imageKey]))
 		}
 		resp.Sections = append(resp.Sections, resolvedSectionResponse{
-			ID:          s.ID,
-			SectionType: string(s.SectionType),
-			Title:       s.Title,
-			Featured:    s.Featured,
-			ItemLimit:   s.ItemLimit,
-			TotalCount:  s.TotalCount,
-			IsCustom:    s.IsCustom,
-			Customized:  s.Customized,
-			Items:       items,
+			ID:             s.ID,
+			SectionType:    string(s.SectionType),
+			Title:          s.Title,
+			Featured:       s.Featured,
+			ItemLimit:      s.ItemLimit,
+			CardImageStyle: sections.CardImageStyleFromConfig(s.Config),
+			TotalCount:     s.TotalCount,
+			IsCustom:       s.IsCustom,
+			Customized:     s.Customized,
+			Items:          items,
 		})
 	}
 	return resp

--- a/internal/api/handlers/sections_test.go
+++ b/internal/api/handlers/sections_test.go
@@ -3,6 +3,7 @@ package handlers
 import (
 	"bytes"
 	"context"
+	"encoding/json"
 	"fmt"
 	"net/http"
 	"net/http/httptest"
@@ -182,6 +183,28 @@ func TestBuildSectionsResponseKeepsExistingEpisodeMeta(t *testing.T) {
 	}
 }
 
+func TestBuildSectionsResponseIncludesCardImageStyle(t *testing.T) {
+	h := &SectionHandler{}
+	withItems := []sections.SectionWithItems{
+		{
+			ResolvedSection: sections.ResolvedSection{
+				ID:          "wide-recents",
+				SectionType: sections.SectionRecentlyAdded,
+				Title:       "Wide Recents",
+				ItemLimit:   20,
+				Config:      json.RawMessage(`{"card_image_style":"landscape"}`),
+			},
+		},
+	}
+
+	req := httptest.NewRequest(http.MethodGet, "/sections", nil)
+	resp := h.buildSectionsResponse(req, withItems)
+
+	if got := resp.Sections[0].CardImageStyle; got != sections.CardImageStyleLandscape {
+		t.Fatalf("card image style = %q, want %q", got, sections.CardImageStyleLandscape)
+	}
+}
+
 type countingSectionImageResolver struct {
 	batchCalls  int
 	singleCalls int
@@ -296,6 +319,25 @@ func TestValidateSectionConfigAcceptsContinueTypes(t *testing.T) {
 				t.Fatalf("validateSectionConfig(%s) rejected config: %s", config, msg)
 			}
 		})
+	}
+}
+
+func TestValidateSectionConfigAcceptsCardImageStyles(t *testing.T) {
+	for _, style := range []string{"portrait", "landscape"} {
+		config := []byte(fmt.Sprintf(`{"card_image_style":%q}`, style))
+		if msg, ok := validateSectionConfig(sections.SectionRecentlyAdded, config); !ok {
+			t.Fatalf("validateSectionConfig(%s) rejected config: %s", style, msg)
+		}
+	}
+}
+
+func TestValidateSectionConfigRejectsUnknownCardImageStyle(t *testing.T) {
+	msg, ok := validateSectionConfig(sections.SectionRecentlyAdded, []byte(`{"card_image_style":"square"}`))
+	if ok {
+		t.Fatal("validateSectionConfig accepted unknown card_image_style")
+	}
+	if msg != "card_image_style must be 'portrait' or 'landscape'" {
+		t.Fatalf("message = %q", msg)
 	}
 }
 

--- a/internal/sections/card_image_style.go
+++ b/internal/sections/card_image_style.go
@@ -1,0 +1,44 @@
+package sections
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+)
+
+type CardImageStyle string
+
+const (
+	CardImageStyleAuto      CardImageStyle = ""
+	CardImageStylePortrait  CardImageStyle = "portrait"
+	CardImageStyleLandscape CardImageStyle = "landscape"
+)
+
+type cardImageStyleConfig struct {
+	CardImageStyle string `json:"card_image_style"`
+}
+
+func CardImageStyleFromConfig(config json.RawMessage) CardImageStyle {
+	style, _ := ParseCardImageStyle(config)
+	return style
+}
+
+func ParseCardImageStyle(config json.RawMessage) (CardImageStyle, error) {
+	var raw cardImageStyleConfig
+	if len(config) > 0 {
+		if err := json.Unmarshal(config, &raw); err != nil {
+			return CardImageStyleAuto, err
+		}
+	}
+
+	switch strings.ToLower(strings.TrimSpace(raw.CardImageStyle)) {
+	case "", "auto":
+		return CardImageStyleAuto, nil
+	case string(CardImageStylePortrait):
+		return CardImageStylePortrait, nil
+	case string(CardImageStyleLandscape):
+		return CardImageStyleLandscape, nil
+	default:
+		return CardImageStyleAuto, fmt.Errorf("card_image_style must be 'portrait' or 'landscape'")
+	}
+}

--- a/internal/sections/card_image_style_test.go
+++ b/internal/sections/card_image_style_test.go
@@ -1,0 +1,42 @@
+package sections
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+func TestParseCardImageStyle(t *testing.T) {
+	tests := []struct {
+		name    string
+		config  json.RawMessage
+		want    CardImageStyle
+		wantErr bool
+	}{
+		{name: "missing defaults to auto", config: json.RawMessage(`{}`), want: CardImageStyleAuto},
+		{name: "empty defaults to auto", config: nil, want: CardImageStyleAuto},
+		{name: "auto is accepted", config: json.RawMessage(`{"card_image_style":"auto"}`), want: CardImageStyleAuto},
+		{name: "portrait", config: json.RawMessage(`{"card_image_style":"portrait"}`), want: CardImageStylePortrait},
+		{name: "landscape", config: json.RawMessage(`{"card_image_style":"landscape"}`), want: CardImageStyleLandscape},
+		{name: "trims and lowercases", config: json.RawMessage(`{"card_image_style":" Landscape "}`), want: CardImageStyleLandscape},
+		{name: "rejects unknown", config: json.RawMessage(`{"card_image_style":"square"}`), wantErr: true},
+		{name: "rejects invalid json", config: json.RawMessage(`{`), wantErr: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := ParseCardImageStyle(tt.config)
+			if tt.wantErr {
+				if err == nil {
+					t.Fatal("ParseCardImageStyle() error = nil, want error")
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("ParseCardImageStyle() error = %v", err)
+			}
+			if got != tt.want {
+				t.Fatalf("ParseCardImageStyle() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}

--- a/web/src/api/types.ts
+++ b/web/src/api/types.ts
@@ -3735,6 +3735,7 @@ export interface ResolvedSection {
   title: string;
   featured: boolean;
   item_limit: number;
+  card_image_style?: SectionCardImageStyle;
   total_count: number;
   is_custom: boolean;
   customized: boolean;
@@ -3773,9 +3774,12 @@ export interface ResolvedSectionLayout {
   title: string;
   featured: boolean;
   item_limit: number;
+  card_image_style?: SectionCardImageStyle;
   is_custom: boolean;
   customized: boolean;
 }
+
+export type SectionCardImageStyle = "portrait" | "landscape";
 
 export interface HomeLayoutResponse {
   sections: ResolvedSectionLayout[];

--- a/web/src/components/SectionItemCard.test.tsx
+++ b/web/src/components/SectionItemCard.test.tsx
@@ -161,6 +161,7 @@ describe("SectionItemCard", () => {
     );
 
     expect(markup).toContain('src="/movie-backdrop.jpg"');
+    expect(markup).toMatch(/<div[^>]*aria-hidden="true"[^>]*><span[^>]*>No Logo Title<\/span>/);
     expect(markup).toContain(">No Logo Title</span>");
   });
 });

--- a/web/src/components/SectionItemCard.test.tsx
+++ b/web/src/components/SectionItemCard.test.tsx
@@ -110,4 +110,57 @@ describe("SectionItemCard", () => {
     expect(markup).toContain("Wed, Apr 8");
     expect(markup).toContain("8:00 PM");
   });
+
+  it("renders title treatment over landscape artwork when a logo is available", () => {
+    const markup = renderToStaticMarkup(
+      <SectionItemCard
+        imageStyle="landscape"
+        item={{
+          content_id: "movie-1",
+          type: "movie",
+          title: "Movie One",
+          year: 2026,
+          genres: ["Drama"],
+          status: "matched",
+          rating_imdb: 7.4,
+          overview: "Overview",
+          poster_url: "/movie-poster.jpg",
+          poster_thumbhash: "",
+          backdrop_url: "/movie-backdrop.jpg",
+          backdrop_thumbhash: "",
+          logo_url: "/movie-logo.png",
+        }}
+      />,
+    );
+
+    expect(markup).toContain('src="/movie-backdrop.jpg"');
+    expect(markup).toContain('src="/movie-logo.png"');
+    expect(markup).toContain('aria-hidden="true"');
+  });
+
+  it("renders a readable title over landscape artwork when no logo is available", () => {
+    const markup = renderToStaticMarkup(
+      <SectionItemCard
+        imageStyle="landscape"
+        item={{
+          content_id: "movie-2",
+          type: "movie",
+          title: "No Logo Title",
+          year: 2026,
+          genres: ["Drama"],
+          status: "matched",
+          rating_imdb: 7.4,
+          overview: "Overview",
+          poster_url: "/movie-poster.jpg",
+          poster_thumbhash: "",
+          backdrop_url: "/movie-backdrop.jpg",
+          backdrop_thumbhash: "",
+          logo_url: "",
+        }}
+      />,
+    );
+
+    expect(markup).toContain('src="/movie-backdrop.jpg"');
+    expect(markup).toContain(">No Logo Title</span>");
+  });
 });

--- a/web/src/components/SectionItemCard.tsx
+++ b/web/src/components/SectionItemCard.tsx
@@ -81,7 +81,10 @@ export default function SectionItemCard({
             )}
             <div className="pointer-events-none absolute inset-x-0 bottom-0 h-24 bg-gradient-to-t from-black/55 to-transparent opacity-90" />
             {isLandscape && imageUrl && (
-              <div className="pointer-events-none absolute inset-x-8 bottom-3 z-[9] flex justify-center">
+              <div
+                className="pointer-events-none absolute inset-x-8 bottom-3 z-[9] flex justify-center"
+                aria-hidden="true"
+              >
                 {item.logo_url ? (
                   <img
                     src={item.logo_url}

--- a/web/src/components/SectionItemCard.tsx
+++ b/web/src/components/SectionItemCard.tsx
@@ -14,15 +14,32 @@ import {
   upcomingBadgeLabel,
 } from "@/lib/upcomingEventPresentation";
 import type { SectionItem } from "@/api/types";
+import type { SectionCardImageStyle } from "@/api/types";
 
 interface SectionItemCardProps {
   item: SectionItem;
   libraryId?: number;
+  imageStyle?: SectionCardImageStyle;
 }
 
-export default function SectionItemCard({ item, libraryId }: SectionItemCardProps) {
-  const { loaded, onLoad } = useImageLoaded(item.poster_url);
-  const thumbhashUrl = item.poster_thumbhash ? decodeThumbhash(item.poster_thumbhash) : "";
+export default function SectionItemCard({
+  item,
+  libraryId,
+  imageStyle = "portrait",
+}: SectionItemCardProps) {
+  const isLandscape = imageStyle === "landscape";
+  const thumbhash =
+    (isLandscape ? item.backdrop_thumbhash || item.poster_thumbhash : item.poster_thumbhash) || "";
+  const thumbhashUrl = thumbhash ? decodeThumbhash(thumbhash) : "";
+  const imageUrl = isLandscape
+    ? item.backdrop_url || item.poster_url
+    : item.poster_url || item.backdrop_url;
+  const { loaded, onLoad } = useImageLoaded(imageUrl);
+  const imageAspect = isLandscape
+    ? "aspect-video"
+    : item.type === "audiobook"
+      ? "aspect-square"
+      : "aspect-[2/3]";
   const itemHref = `/item/${encodeURIComponent(item.content_id)}${
     libraryId ? `?libraryId=${libraryId}` : ""
   }`;
@@ -38,9 +55,7 @@ export default function SectionItemCard({ item, libraryId }: SectionItemCardProp
       <div className="relative">
         <ViewTransitionLink to={itemHref} className="block overflow-hidden rounded-xl">
           <div
-            className={`media-card-image relative ${
-              item.type === "audiobook" ? "aspect-square" : "aspect-[2/3]"
-            }`}
+            className={`media-card-image relative ${imageAspect}`}
             style={
               thumbhashUrl
                 ? {
@@ -51,9 +66,9 @@ export default function SectionItemCard({ item, libraryId }: SectionItemCardProp
                 : undefined
             }
           >
-            {item.poster_url ? (
+            {imageUrl ? (
               <img
-                src={item.poster_url}
+                src={imageUrl}
                 alt={item.title}
                 className={`h-full w-full object-cover transition-opacity duration-300 ${loaded ? "opacity-100" : "opacity-0"}`}
                 loading="lazy"
@@ -71,7 +86,11 @@ export default function SectionItemCard({ item, libraryId }: SectionItemCardProp
               </span>
             )}
             {item.status === "matched" && overlayPrefs && (
-              <CardOverlays data={overlayDataFromSectionItem(item)} prefs={overlayPrefs} />
+              <CardOverlays
+                data={overlayDataFromSectionItem(item)}
+                prefs={overlayPrefs}
+                variant={isLandscape ? "wide" : "poster"}
+              />
             )}
             {upcomingEvent && upcomingEvent.badges.length > 0 && (
               <div className="absolute top-2.5 left-2.5 flex max-w-[calc(100%-2.5rem)] flex-wrap gap-1">
@@ -94,7 +113,7 @@ export default function SectionItemCard({ item, libraryId }: SectionItemCardProp
           mediaType={item.type}
           libraryId={libraryId}
           userState={item.user_state}
-          variant="poster"
+          variant={isLandscape ? "wide" : "poster"}
         />
       </div>
       <ViewTransitionLink to={itemHref} className="block px-1 pt-3">

--- a/web/src/components/SectionItemCard.tsx
+++ b/web/src/components/SectionItemCard.tsx
@@ -80,6 +80,23 @@ export default function SectionItemCard({
               </div>
             )}
             <div className="pointer-events-none absolute inset-x-0 bottom-0 h-24 bg-gradient-to-t from-black/55 to-transparent opacity-90" />
+            {isLandscape && imageUrl && (
+              <div className="pointer-events-none absolute inset-x-8 bottom-3 z-[9] flex justify-center">
+                {item.logo_url ? (
+                  <img
+                    src={item.logo_url}
+                    alt=""
+                    aria-hidden="true"
+                    className="max-h-12 max-w-full object-contain drop-shadow-[0_2px_8px_rgba(0,0,0,0.75)]"
+                    loading="lazy"
+                  />
+                ) : (
+                  <span className="max-w-full rounded-md bg-black/55 px-3 py-1.5 text-center text-sm leading-tight font-semibold text-white shadow-lg backdrop-blur-sm">
+                    {item.title}
+                  </span>
+                )}
+              </div>
+            )}
             {item.status === "ambiguous" && (
               <span className="absolute top-2.5 left-2.5 rounded-full border border-amber-500/25 bg-black/40 px-2 py-0.5 text-[10px] leading-none font-semibold tracking-wide text-amber-200 uppercase backdrop-blur-sm">
                 Ambiguous

--- a/web/src/components/SectionRow.test.tsx
+++ b/web/src/components/SectionRow.test.tsx
@@ -209,6 +209,94 @@ describe("SectionRow", () => {
     expect(markup).not.toContain("aspect-video");
   });
 
+  it("renders regular rows with landscape cards when configured", () => {
+    const queryClient = new QueryClient();
+    const section: ResolvedSection = {
+      id: "wide-recents",
+      section_type: "recently_added",
+      title: "Wide Recents",
+      featured: false,
+      item_limit: 10,
+      card_image_style: "landscape",
+      total_count: 1,
+      is_custom: false,
+      customized: false,
+      items: [
+        {
+          content_id: "movie-001",
+          type: "movie",
+          title: "Heat",
+          year: 1995,
+          genres: [],
+          status: "matched",
+          rating_imdb: null,
+          overview: "",
+          poster_url: "/movie-poster.jpg",
+          poster_thumbhash: "",
+          backdrop_url: "/movie-backdrop.jpg",
+          backdrop_thumbhash: "",
+          logo_url: "",
+        },
+      ],
+    };
+
+    const markup = renderToStaticMarkup(
+      <QueryClientProvider client={queryClient}>
+        <MemoryRouter>
+          <SectionRow section={section} />
+        </MemoryRouter>
+      </QueryClientProvider>,
+    );
+
+    expect(markup).toContain("aspect-video");
+    expect(markup).toContain('src="/movie-backdrop.jpg"');
+    expect(markup).toContain("w-[260px]");
+  });
+
+  it("lets layout card image style override cached section payload style", () => {
+    const queryClient = new QueryClient();
+    const section: ResolvedSection = {
+      id: "cached-recents",
+      section_type: "recently_added",
+      title: "Cached Recents",
+      featured: false,
+      item_limit: 10,
+      card_image_style: "landscape",
+      total_count: 1,
+      is_custom: false,
+      customized: false,
+      items: [
+        {
+          content_id: "movie-002",
+          type: "movie",
+          title: "Alien",
+          year: 1979,
+          genres: [],
+          status: "matched",
+          rating_imdb: null,
+          overview: "",
+          poster_url: "/alien-poster.jpg",
+          poster_thumbhash: "",
+          backdrop_url: "/alien-backdrop.jpg",
+          backdrop_thumbhash: "",
+          logo_url: "",
+        },
+      ],
+    };
+
+    const markup = renderToStaticMarkup(
+      <QueryClientProvider client={queryClient}>
+        <MemoryRouter>
+          <SectionRow section={section} cardImageStyle="portrait" />
+        </MemoryRouter>
+      </QueryClientProvider>,
+    );
+
+    expect(markup).toContain("aspect-[2/3]");
+    expect(markup).toContain('src="/alien-poster.jpg"');
+    expect(markup).not.toContain("aspect-video");
+  });
+
   it("routes supported section view-all actions to browse destinations", () => {
     const queryClient = new QueryClient();
     const section: ResolvedSection = {

--- a/web/src/components/SectionRow.tsx
+++ b/web/src/components/SectionRow.tsx
@@ -6,12 +6,14 @@ import { useToggleSidebarPin } from "@/hooks/queries/sidebarPins";
 import { useOverlayPrefs } from "@/hooks/useOverlayPrefs";
 import { buildSectionCatalogHref, isSectionBrowseSupported } from "@/pages/catalogSearchParams";
 import type { ResolvedSection } from "@/api/types";
+import type { SectionCardImageStyle } from "@/api/types";
 import { Pin, PinOff } from "lucide-react";
 
 interface SectionRowProps {
   section: ResolvedSection;
   /** Library ID this section belongs to (enables pin-to-sidebar) */
   libraryId?: number;
+  cardImageStyle?: SectionCardImageStyle;
 }
 
 function SectionPinButton({
@@ -41,10 +43,11 @@ function SectionPinButton({
   );
 }
 
-export default function SectionRow({ section, libraryId }: SectionRowProps) {
+export default function SectionRow({ section, libraryId, cardImageStyle }: SectionRowProps) {
   const navigate = useViewTransitionNavigate();
   const browseSupported = isSectionBrowseSupported(section.section_type);
   const { prefs: overlayPrefs } = useOverlayPrefs();
+  const configuredImageStyle = cardImageStyle ?? section.card_image_style;
 
   const handleViewAll = () => {
     if (!browseSupported) {
@@ -84,19 +87,26 @@ export default function SectionRow({ section, libraryId }: SectionRowProps) {
     >
       {section.section_type === "continue_watching" || section.section_type === "next_up"
         ? (() => {
+            const configuredVariant =
+              configuredImageStyle === "portrait"
+                ? "poster"
+                : configuredImageStyle === "landscape"
+                  ? "wide"
+                  : undefined;
             // Continue Watching with only movies, audiobooks, and/or ebooks
             // looks better as upright covers (audiobook covers render square
             // within the poster variant; ebook covers are naturally 2:3).
             // Episodes (incl. Next Up) keep the wide variant so stills are
             // shown with their natural 16:9 framing.
             const cardVariant: "wide" | "poster" =
-              section.section_type === "continue_watching" &&
+              configuredVariant ??
+              (section.section_type === "continue_watching" &&
               section.items.length > 0 &&
               section.items.every(
                 (it) => it.type === "movie" || it.type === "audiobook" || it.type === "ebook",
               )
                 ? "poster"
-                : "wide";
+                : "wide");
             return section.items.map((item) => (
               <ContinueWatchingCard
                 key={item.content_id}
@@ -107,15 +117,18 @@ export default function SectionRow({ section, libraryId }: SectionRowProps) {
               />
             ));
           })()
-        : section.items.map((item) => (
-            <div
-              key={item.content_id}
-              className="w-[140px] shrink-0 sm:w-[160px] lg:w-[185px]"
-              role="listitem"
-            >
-              <SectionItemCard item={item} libraryId={libraryId} />
-            </div>
-          ))}
+        : (() => {
+            const imageStyle = configuredImageStyle ?? "portrait";
+            const cardWidth =
+              imageStyle === "landscape"
+                ? "w-[260px] shrink-0 sm:w-[315px]"
+                : "w-[140px] shrink-0 sm:w-[160px] lg:w-[185px]";
+            return section.items.map((item) => (
+              <div key={item.content_id} className={cardWidth} role="listitem">
+                <SectionItemCard item={item} libraryId={libraryId} imageStyle={imageStyle} />
+              </div>
+            ));
+          })()}
     </MediaCarousel>
   );
 }

--- a/web/src/components/sections/EditableSectionRows.tsx
+++ b/web/src/components/sections/EditableSectionRows.tsx
@@ -2,6 +2,10 @@ import type { ReactNode } from "react";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { sectionTypeLabel } from "@/lib/sectionTypes";
+import {
+  getSectionCardImageStyleSetting,
+  sectionCardImageStyleLabel,
+} from "@/lib/sectionCardImageStyle";
 import { queryDefinitionFromSectionConfig } from "@/api/types";
 import type { Library } from "@/api/types";
 import type { RecipeCatalogResponse } from "@/lib/recipes";
@@ -68,11 +72,15 @@ export function SectionSummaryBadges({
   const collectionLabel = collectionId ? collectionLabels?.get(collectionId) : undefined;
   const resumeLabel =
     section.sectionType === "continue_watching" ? continueTypeLabel(section.config) : null;
+  const imageStyleLabel = sectionCardImageStyleLabel(
+    getSectionCardImageStyleSetting(section.config),
+  );
 
   return (
     <div className="flex flex-wrap gap-1">
       <Badge variant="secondary">{recipeLabel(catalog, section.sectionType)}</Badge>
       {resumeLabel ? <Badge variant="outline">{resumeLabel}</Badge> : null}
+      {imageStyleLabel ? <Badge variant="outline">{imageStyleLabel}</Badge> : null}
       {queryDefinition.media_scope === "movie" ? <Badge variant="outline">Movies</Badge> : null}
       {queryDefinition.media_scope === "series" ? <Badge variant="outline">Series</Badge> : null}
       {queryDefinition.media_scope === "episode" ? <Badge variant="outline">Episodes</Badge> : null}

--- a/web/src/components/sections/SectionEditorDrawer.test.ts
+++ b/web/src/components/sections/SectionEditorDrawer.test.ts
@@ -44,4 +44,50 @@ describe("SectionEditorDrawer payload builders", () => {
       config: { continue_type: "listening" },
     });
   });
+
+  it("adds row image style to admin section config", () => {
+    const payload = buildAdminSectionPayload({
+      section: null,
+      scope: "home",
+      currentLibraryId: null,
+      sectionType: "recently_added",
+      title: "Wide Recents",
+      itemLimit: 20,
+      featured: false,
+      cardImageStyle: "landscape",
+      enabled: true,
+      queryDefinition: queryDefinitionFromSectionConfig(),
+      selectedCollectionId: "",
+      recipeParams: {},
+    });
+
+    expect(payload.config).toMatchObject({ card_image_style: "landscape" });
+  });
+
+  it("omits automatic row image style from profile section config", () => {
+    const entry = buildProfileSectionSaveEntry({
+      section: {
+        id: "section-1",
+        section_type: "recently_added",
+        title: "Recently Added",
+        featured: false,
+        item_limit: 20,
+        hidden: false,
+        is_custom: true,
+        customized: true,
+        position: 0,
+        config: { card_image_style: "landscape", min_rating: 7 },
+      },
+      sectionType: "recently_added",
+      title: "Recently Added",
+      itemLimit: 20,
+      featured: false,
+      cardImageStyle: "auto",
+      queryDefinition: queryDefinitionFromSectionConfig(),
+      selectedCollectionId: "",
+      recipeParams: { min_rating: 7, card_image_style: "landscape" },
+    });
+
+    expect(entry.config).toEqual({ min_rating: 7 });
+  });
 });

--- a/web/src/components/sections/SectionEditorDrawer.tsx
+++ b/web/src/components/sections/SectionEditorDrawer.tsx
@@ -28,6 +28,11 @@ import RecipeParamFields from "@/components/RecipeGallery/RecipeParamFields";
 import { SECTION_TYPES, FILTER_SECTION_TYPES, sectionTypeLabel } from "@/lib/sectionTypes";
 import type { Category, RecipeCatalogResponse, RecipeDefinition } from "@/lib/recipes";
 import {
+  applySectionCardImageStyle,
+  getSectionCardImageStyleSetting,
+  type SectionCardImageStyleSetting,
+} from "@/lib/sectionCardImageStyle";
+import {
   queryDefinitionFromSectionConfig,
   queryDefinitionToSectionConfig,
   type PageSectionConfig,
@@ -109,6 +114,7 @@ interface BuildProfileSectionSaveEntryInput {
   title: string;
   itemLimit: number;
   featured: boolean;
+  cardImageStyle?: SectionCardImageStyleSetting;
   queryDefinition: QueryDefinition;
   selectedCollectionId: string;
   recipeParams?: Record<string, unknown>;
@@ -121,6 +127,7 @@ export function buildProfileSectionSaveEntry({
   title,
   itemLimit,
   featured,
+  cardImageStyle,
   queryDefinition,
   selectedCollectionId,
   recipeParams,
@@ -152,7 +159,7 @@ export function buildProfileSectionSaveEntry({
     is_custom: section?.is_custom ?? true,
     customized: section?.customized ?? false,
     position: section?.position ?? 0,
-    config,
+    config: applySectionCardImageStyle(config, cardImageStyle),
   };
 }
 
@@ -164,6 +171,7 @@ interface BuildAdminSectionPayloadInput {
   title: string;
   itemLimit: number;
   featured: boolean;
+  cardImageStyle?: SectionCardImageStyleSetting;
   enabled: boolean;
   queryDefinition: QueryDefinition;
   selectedCollectionId: string;
@@ -179,6 +187,7 @@ export function buildAdminSectionPayload({
   title,
   itemLimit,
   featured,
+  cardImageStyle,
   enabled,
   queryDefinition,
   selectedCollectionId,
@@ -209,7 +218,7 @@ export function buildAdminSectionPayload({
     item_limit: itemLimit,
     featured,
     enabled,
-    config,
+    config: applySectionCardImageStyle(config, cardImageStyle),
   };
 }
 
@@ -247,6 +256,7 @@ export default function SectionEditorDrawer(props: SectionEditorDrawerProps) {
   const [title, setTitle] = useState("");
   const [itemLimit, setItemLimit] = useState(20);
   const [featured, setFeatured] = useState(false);
+  const [cardImageStyle, setCardImageStyle] = useState<SectionCardImageStyleSetting>("auto");
   const [enabled, setEnabled] = useState(true);
   const [queryDefinition, setQueryDefinition] = useState<QueryDefinition>(
     queryDefinitionFromSectionConfig(),
@@ -280,6 +290,7 @@ export default function SectionEditorDrawer(props: SectionEditorDrawerProps) {
       setTitle(props.section.title);
       setItemLimit(props.section.item_limit);
       setFeatured(props.section.featured);
+      setCardImageStyle(getSectionCardImageStyleSetting(props.section.config));
       setEnabled("enabled" in props.section ? Boolean(props.section.enabled) : true);
       setQueryDefinition(queryDefinitionFromSectionConfig(props.section.config));
       setSelectedCollectionId(getCollectionId(props.section.config));
@@ -289,6 +300,7 @@ export default function SectionEditorDrawer(props: SectionEditorDrawerProps) {
       setTitle("");
       setItemLimit(20);
       setFeatured(false);
+      setCardImageStyle("auto");
       setEnabled(true);
       setQueryDefinition(queryDefinitionFromSectionConfig());
       setSelectedCollectionId("");
@@ -324,6 +336,7 @@ export default function SectionEditorDrawer(props: SectionEditorDrawerProps) {
           title,
           itemLimit,
           featured,
+          cardImageStyle,
           queryDefinition,
           selectedCollectionId,
           recipeParams,
@@ -341,6 +354,7 @@ export default function SectionEditorDrawer(props: SectionEditorDrawerProps) {
           title,
           itemLimit,
           featured,
+          cardImageStyle,
           enabled,
           queryDefinition,
           selectedCollectionId,
@@ -433,6 +447,23 @@ export default function SectionEditorDrawer(props: SectionEditorDrawerProps) {
               min={1}
               max={100}
             />
+          </div>
+
+          <div className="space-y-2">
+            <Label>Row Images</Label>
+            <Select
+              value={cardImageStyle}
+              onValueChange={(value) => setCardImageStyle(value as SectionCardImageStyleSetting)}
+            >
+              <SelectTrigger>
+                <SelectValue />
+              </SelectTrigger>
+              <SelectContent>
+                <SelectItem value="auto">Automatic</SelectItem>
+                <SelectItem value="portrait">Portrait</SelectItem>
+                <SelectItem value="landscape">Landscape</SelectItem>
+              </SelectContent>
+            </Select>
           </div>
 
           <div className="flex items-center justify-between gap-4 rounded-md border px-3 py-3">

--- a/web/src/lib/sectionCardImageStyle.ts
+++ b/web/src/lib/sectionCardImageStyle.ts
@@ -1,0 +1,39 @@
+import type { SectionCardImageStyle } from "@/api/types";
+
+export type SectionCardImageStyleSetting = SectionCardImageStyle | "auto";
+
+const CONFIG_KEY = "card_image_style";
+
+export function getSectionCardImageStyleSetting(
+  config?: Record<string, unknown>,
+): SectionCardImageStyleSetting {
+  const value = config?.[CONFIG_KEY];
+  if (value === "portrait" || value === "landscape") {
+    return value;
+  }
+  return "auto";
+}
+
+export function applySectionCardImageStyle(
+  config: Record<string, unknown> | undefined,
+  style: SectionCardImageStyleSetting | undefined,
+): Record<string, unknown> {
+  const next = { ...(config ?? {}) };
+  if (style === undefined) {
+    return next;
+  }
+
+  delete next[CONFIG_KEY];
+
+  if (style === "portrait" || style === "landscape") {
+    next[CONFIG_KEY] = style;
+  }
+
+  return next;
+}
+
+export function sectionCardImageStyleLabel(style: SectionCardImageStyleSetting): string | null {
+  if (style === "portrait") return "Portrait";
+  if (style === "landscape") return "Landscape";
+  return null;
+}

--- a/web/src/pages/Home.tsx
+++ b/web/src/pages/Home.tsx
@@ -46,7 +46,7 @@ export default function Home() {
   const layoutResetKey = layout
     .map(
       (section) =>
-        `${section.id}:${section.section_type}:${section.title}:${section.featured ? "featured" : "row"}:${section.item_limit}:${section.is_custom ? "custom" : "default"}:${section.customized ? "customized" : "clean"}`,
+        `${section.id}:${section.section_type}:${section.title}:${section.featured ? "featured" : "row"}:${section.item_limit}:${section.card_image_style ?? "auto"}:${section.is_custom ? "custom" : "default"}:${section.customized ? "customized" : "clean"}`,
     )
     .join("|");
 
@@ -202,7 +202,13 @@ export default function Home() {
             return null;
           }
           if (slot.state === "ready" && slot.section) {
-            return <SectionRow key={slot.layout.id} section={slot.section} />;
+            return (
+              <SectionRow
+                key={slot.layout.id}
+                section={slot.section}
+                cardImageStyle={slot.layout.card_image_style}
+              />
+            );
           }
           if (slot.state === "error") {
             return (

--- a/web/src/pages/LibraryRecommended.tsx
+++ b/web/src/pages/LibraryRecommended.tsx
@@ -50,7 +50,7 @@ export default function LibraryRecommended({
   const layoutResetKey = layout
     .map(
       (section) =>
-        `${section.id}:${section.section_type}:${section.title}:${section.featured ? "featured" : "row"}:${section.item_limit}:${section.is_custom ? "custom" : "default"}:${section.customized ? "customized" : "clean"}`,
+        `${section.id}:${section.section_type}:${section.title}:${section.featured ? "featured" : "row"}:${section.item_limit}:${section.card_image_style ?? "auto"}:${section.is_custom ? "custom" : "default"}:${section.customized ? "customized" : "clean"}`,
     )
     .join("|");
 
@@ -194,7 +194,14 @@ export default function LibraryRecommended({
           return null;
         }
         if (slot.state === "ready" && slot.section) {
-          return <SectionRow key={slot.layout.id} section={slot.section} libraryId={libraryId} />;
+          return (
+            <SectionRow
+              key={slot.layout.id}
+              section={slot.section}
+              libraryId={libraryId}
+              cardImageStyle={slot.layout.card_image_style}
+            />
+          );
         }
         if (slot.state === "error") {
           return (


### PR DESCRIPTION
# feat(sections): allow row image style selection

## Problem

Section rows on the web client have always rendered portrait posters. Some sources (network row, "Trending" row, editorially curated backdrops) look better as 16:9 landscape cards, but there was no way to choose per-row and no plumbing between the server section descriptor and the client card component.

## Approach

Introduce a small enum abstraction and thread it through the section pipeline without changing existing behavior:

- Add a `CardImageStyle` type (`Auto | Portrait | Landscape`) in the existing `internal/sections` package, with `Parse`/`String` helpers. `Auto` is the default and preserves current portrait rendering, so any section that omits the new field is unchanged.
- `SectionDescriptor` API responses gain an optional `card_image_style` field (`omitempty`) so old clients keep working.
- Web `SectionRow` picks the variant per row via a new `sectionCardImageStyle.ts` helper; `SectionItemCard` renders `aspect-video` when landscape is requested, otherwise the existing 2:3 poster path.
- Admin UI: the section editor drawer gains a "Card style" selector so the choice is persisted alongside the row definition.

## Verification

- `go test ./internal/sections/... ./internal/api/handlers/ -run 'CardImage|Section'` — passes.
- Manual: existing sections with no `card_image_style` continue to render as portrait posters; new rows configured `landscape` render 16:9 without card component regressions.

## Risks & follow-up

- Portrait behavior is preserved because the zero value maps to `Auto` and `Auto` falls through to the previous portrait path.
- No storage migration or backfill: the new field is API-only and derived per-request from the section definition.
- Follow-up (PR B) stores rendered landscape card artwork to avoid depending on unbranded backdrops at render time.

## AI-use disclosure

Implemented with a combination of Claude Code and Codex assistance, with human oversight.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added configurable section “Row Images” with Automatic, Portrait, and Landscape options.
  * Updated section layout responses to expose `card_image_style` and drive row/card rendering accordingly.
* **Bug Fixes**
  * Home and library layout refresh/reset now correctly react when `card_image_style` changes.
  * Row rendering respects `cardImageStyle` overrides (e.g., portrait vs landscape).
* **Tests**
  * Added unit/integration coverage for parsing, validation, response payloads, and landscape/portrait row rendering.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->