### PR TITLE
feat(web): show audio stream profile in Media Info

### DIFF
--- a/web/src/api/types.ts
+++ b/web/src/api/types.ts
@@ -982,6 +982,7 @@ export interface VersionAudioTrack {
   embedded_title?: string;
   language?: string;
   codec?: string;
+  profile?: string;
   layout?: string;
   channels?: number;
   bitrate?: number;

--- a/web/src/pages/ItemDetail/components/mediaSpecSections.test.ts
+++ b/web/src/pages/ItemDetail/components/mediaSpecSections.test.ts
@@ -302,6 +302,7 @@ describe("buildAudioSections", () => {
             embedded_title: "TrueHD Atmos 7.1",
             language: "eng",
             codec: "truehd",
+            profile: "Dolby TrueHD + Dolby Atmos",
             layout: "7.1",
             channels: 8,
             bitrate: 4_500,
@@ -320,12 +321,14 @@ describe("buildAudioSections", () => {
     expect(rowValue(first.rows, "Title")).toBe("TrueHD Atmos 7.1");
     expect(rowValue(first.rows, "Language")).toBe("English");
     expect(rowValue(first.rows, "Codec")).toBe("TrueHD");
+    expect(rowValue(first.rows, "Profile")).toBe("Dolby TrueHD + Dolby Atmos");
     expect(rowValue(first.rows, "Layout")).toBe("7.1");
     expect(rowValue(first.rows, "Channels")).toBe("7.1");
     expect(rowValue(first.rows, "Sample Rate")).toBe("48,000 Hz");
     expect(rowValue(first.rows, "Bit Depth")).toBe("24-bit");
     expect(rowValue(first.rows, "Default")).toBe("Yes");
     expect(rowValue(sectionAt(sections, 1).rows, "Default")).toBeNull();
+    expect(rowValue(sectionAt(sections, 1).rows, "Profile")).toBeNull();
   });
 });
 

--- a/web/src/pages/ItemDetail/components/mediaSpecSections.ts
+++ b/web/src/pages/ItemDetail/components/mediaSpecSections.ts
@@ -197,6 +197,7 @@ export function buildAudioSections(version: FileVersion): MediaSpecSection[] {
     pushRow(rows, "Title", trackTitle(track));
     pushRow(rows, "Language", formatLanguageName(track.language));
     pushRow(rows, "Codec", track.codec ? mapAudioLabel(track.codec) : "");
+    pushRow(rows, "Profile", track.profile);
     pushRow(rows, "Layout", track.layout);
     pushRow(rows, "Channels", formatChannels(track.channels));
     pushRow(rows, "Bitrate", formatBitrate(track.bitrate));


### PR DESCRIPTION
# feat(web): show audio stream profile in Media Info

## Problem

The Media Info dialog already surfaces video profile metadata, but it drops the equivalent audio stream profile even when the server provides one. That makes useful audio details, including Dolby Atmos-specific profile strings, invisible in the web UI.

## Approach

Add optional `profile` support to the web `VersionAudioTrack` type and render a `Profile` row in the Media Info dialog only when the value is present. Existing servers that do not send audio profiles keep the same output. Formatter test coverage was extended for the new optional row.

## Verification

```sh
pnpm exec vitest run src/pages/ItemDetail/components/mediaSpecSections.test.ts
pnpm exec eslint src/api/types.ts src/pages/ItemDetail/components/mediaSpecSections.ts src/pages/ItemDetail/components/mediaSpecSections.test.ts
pnpm exec prettier --check src/api/types.ts src/pages/ItemDetail/components/mediaSpecSections.ts src/pages/ItemDetail/components/mediaSpecSections.test.ts
git diff --check
```

## Risks & follow-up

Low risk. This is display-only and additive. No API contract is required from older servers because the field is optional.

## AI-use disclosure

Implemented with a combination of Claude Code and Codex assistance, with human oversight.
