### PR TITLE
feat(catalog): remove smart collection item limit cap

### DIFF
--- a/internal/catalog/query_definition.go
+++ b/internal/catalog/query_definition.go
@@ -157,18 +157,21 @@ func MediaScopeMatchesItemType(scope, itemType string) bool {
 	return false
 }
 
-const (
-	DefaultSmartCollectionItemLimit = 100
-	MaxSmartCollectionItemLimit     = 500
-)
+// DefaultSmartCollectionItemLimit applies when a smart collection sets no
+// explicit limit. Smart collections are deliberately uncapped: an unset
+// limit resolves the full result set. The large sentinel keeps the int
+// plumbing (SQL LIMIT) intact everywhere a concrete value is required.
+const DefaultSmartCollectionItemLimit = 10_000_000
 
+// ApplySmartCollectionItemLimit fills in the default item limit when a smart
+// collection's query definition does not set one. An explicit positive limit
+// is honored as-is: membership size is an admin decision, and every read path
+// that serves collection items either paginates in SQL or scales with the
+// actual collection size rather than this value.
 func ApplySmartCollectionItemLimit(def QueryDefinition) QueryDefinition {
 	limit := DefaultSmartCollectionItemLimit
 	if def.Limit != nil && *def.Limit > 0 {
 		limit = *def.Limit
-	}
-	if limit > MaxSmartCollectionItemLimit {
-		limit = MaxSmartCollectionItemLimit
 	}
 	def.Limit = &limit
 	return def

--- a/internal/jellycompat/handlers_collections.go
+++ b/internal/jellycompat/handlers_collections.go
@@ -119,6 +119,7 @@ func (h *ItemsHandler) collectionsViewVisible(ctx context.Context, libraries []u
 // the BoxSet children path is unit-testable without a database.
 type smartCollectionQueryExecutor interface {
 	Preview(ctx context.Context, def catalog.QueryDefinition, access catalog.AccessFilter, limit int) ([]*models.MediaItem, int, error)
+	PreviewPage(ctx context.Context, def catalog.QueryDefinition, access catalog.AccessFilter, limit, offset int, includeTotal bool) ([]*models.MediaItem, int, bool, error)
 }
 
 // visibleLibraryIDSet returns the set of library IDs the session may see on
@@ -416,6 +417,49 @@ func (h *ItemsHandler) handleBoxSetChildren(w http.ResponseWriter, r *http.Reque
 		return
 	}
 
+	// Smart (live-query) collections have no curated position order — their
+	// members come straight from the query's own ordering, and their membership
+	// is deliberately uncapped (an admin decision). Without an explicit client
+	// sort we page that query directly in SQL rather than resolving the entire
+	// membership and slicing one page locally, so per-request work stays
+	// proportional to the page size instead of the collection size. The
+	// explicit-sort case falls through to the browse allowlist path below, which
+	// re-sorts the whole membership.
+	if catalog.IsLiveQueryType(collection.CollectionType) && !query.sortExplicit {
+		routeID := h.codec.EncodeStringID(EncodedIDCollection, collection.ID)
+		pageIDs, total, ok, pageErr := h.smartCollectionContentIDPage(
+			r.Context(), session, collection, query.startIndex, query.limit)
+		if pageErr != nil {
+			writeCompatUpstreamError(w, pageErr)
+			return
+		}
+		if !ok {
+			writeJSON(w, http.StatusOK, emptyQueryResult(query.startIndex))
+			return
+		}
+		if len(pageIDs) == 0 {
+			// Empty membership, or a page past the end: preserve the real total
+			// so clients that paged beyond the last item still see the size.
+			result := emptyQueryResult(query.startIndex)
+			result.TotalRecordCount = total
+			writeJSON(w, http.StatusOK, result)
+			return
+		}
+		itemsByID, fetchErr := h.fetchCompatItemsByContentIDs(r.Context(), session, pageIDs, nil)
+		if fetchErr != nil {
+			writeCompatUpstreamError(w, fetchErr)
+			return
+		}
+		ordered := make([]upstreamListItem, 0, len(pageIDs))
+		for _, contentID := range pageIDs {
+			if item, itemOK := itemsByID[contentID]; itemOK {
+				ordered = append(ordered, item)
+			}
+		}
+		h.writeCollectionItemsPage(w, r, session, query, routeID, ordered, total)
+		return
+	}
+
 	// Smart (live-query) collections derive membership from a query at read
 	// time and store no rows in library_collection_items, so ListItems returns
 	// nothing for them — that previously left smart-collection BoxSets showing a
@@ -501,15 +545,16 @@ func (h *ItemsHandler) writeCollectionItemsPage(w http.ResponseWriter, r *http.R
 	})
 }
 
-// smartCollectionContentIDs resolves a live-query (smart) collection's members
-// at read time, mirroring the web API's loadLiveCollectionItems. The returned
-// content IDs are in the smart query's own order and access-filtered for the
-// session; the caller reuses the same hydration path as stored collections. A
-// malformed or invalid query definition degrades to no children rather than an
-// error so a single bad collection never 500s a browse.
-func (h *ItemsHandler) smartCollectionContentIDs(ctx context.Context, session *Session, c *models.LibraryCollection) ([]string, error) {
+// prepareSmartCollectionQuery resolves a smart (live-query) collection's stored
+// query definition into an executable form: normalized, validated, item-limited,
+// and intersected with the collection's own bound library scope, plus the
+// session access filter. ok is false when the collection has no executable
+// query — no executor wired, a malformed or invalid definition, or an empty
+// library intersection — so callers degrade to no children rather than error
+// and a single bad collection never 500s a browse.
+func (h *ItemsHandler) prepareSmartCollectionQuery(ctx context.Context, session *Session, c *models.LibraryCollection) (catalog.QueryDefinition, catalog.AccessFilter, bool) {
 	if h.queryExecutor == nil {
-		return nil, nil
+		return catalog.QueryDefinition{}, catalog.AccessFilter{}, false
 	}
 
 	var def catalog.QueryDefinition
@@ -517,14 +562,14 @@ func (h *ItemsHandler) smartCollectionContentIDs(ctx context.Context, session *S
 		if err := json.Unmarshal(c.QueryDefinition, &def); err != nil {
 			slog.DebugContext(ctx, "jellycompat smart collection query definition unmarshal failed",
 				"collection_id", c.ID, "error", err)
-			return nil, nil
+			return catalog.QueryDefinition{}, catalog.AccessFilter{}, false
 		}
 	}
 	def = def.Normalize()
 	if err := def.ValidateWithOptions(false, false); err != nil {
 		slog.DebugContext(ctx, "jellycompat smart collection query definition invalid",
 			"collection_id", c.ID, "error", err)
-		return nil, nil
+		return catalog.QueryDefinition{}, catalog.AccessFilter{}, false
 	}
 	def = catalog.ApplySmartCollectionItemLimit(def)
 
@@ -532,16 +577,54 @@ func (h *ItemsHandler) smartCollectionContentIDs(ctx context.Context, session *S
 	case len(c.LibraryIDs) > 0:
 		def.LibraryIDs = catalog.IntersectCollectionLibraryIDs(def.LibraryIDs, c.LibraryIDs)
 		if len(def.LibraryIDs) == 0 {
-			return nil, nil
+			return catalog.QueryDefinition{}, catalog.AccessFilter{}, false
 		}
 	case c.LibraryID > 0:
 		def.LibraryIDs = catalog.IntersectCollectionLibraryIDs(def.LibraryIDs, []int{c.LibraryID})
 		if len(def.LibraryIDs) == 0 {
-			return nil, nil
+			return catalog.QueryDefinition{}, catalog.AccessFilter{}, false
 		}
 	}
 
-	access := h.resolveAccessFilter(ctx, session)
+	return def, h.resolveAccessFilter(ctx, session), true
+}
+
+// smartCollectionContentIDPage resolves a single page of a smart collection's
+// member content IDs directly in SQL (OFFSET/LIMIT over the query's own order),
+// plus the total membership count. This bounds per-request work to one page
+// regardless of collection size — the membership is uncapped, so materializing
+// every member to serve one browse page would scale memory and latency with the
+// collection. ok is false when the collection has no executable query.
+func (h *ItemsHandler) smartCollectionContentIDPage(ctx context.Context, session *Session, c *models.LibraryCollection, offset, limit int) (contentIDs []string, total int, ok bool, err error) {
+	def, access, prepared := h.prepareSmartCollectionQuery(ctx, session, c)
+	if !prepared {
+		return nil, 0, false, nil
+	}
+
+	items, total, _, err := h.queryExecutor.PreviewPage(ctx, def, access, limit, offset, true)
+	if err != nil {
+		return nil, 0, false, err
+	}
+
+	contentIDs = make([]string, 0, len(items))
+	for _, item := range items {
+		contentIDs = append(contentIDs, item.ContentID)
+	}
+	return contentIDs, total, true, nil
+}
+
+// smartCollectionContentIDs resolves a live-query (smart) collection's full
+// member set at read time, mirroring the web API's loadLiveCollectionItems. The
+// returned content IDs are in the smart query's own order and access-filtered
+// for the session. Used by the explicit-sort browse path, which re-sorts and
+// paginates the membership as an allowlist; the default (no explicit sort) path
+// uses smartCollectionContentIDPage to page directly in SQL.
+func (h *ItemsHandler) smartCollectionContentIDs(ctx context.Context, session *Session, c *models.LibraryCollection) ([]string, error) {
+	def, access, ok := h.prepareSmartCollectionQuery(ctx, session, c)
+	if !ok {
+		return nil, nil
+	}
+
 	items, total, err := h.queryExecutor.Preview(ctx, def, access, 1)
 	if err != nil {
 		return nil, err

--- a/internal/jellycompat/smart_boxset_test.go
+++ b/internal/jellycompat/smart_boxset_test.go
@@ -10,12 +10,16 @@ import (
 )
 
 // fakeSmartExecutor is a smartCollectionQueryExecutor double returning a fixed
-// member list, mimicking catalog.QueryExecutor.Preview's two-call contract
-// (limit=1 probe, then limit=total).
+// member list. Preview mimics catalog.QueryExecutor.Preview's two-call contract
+// (limit=1 probe, then limit=total) for the explicit-sort allowlist path;
+// PreviewPage mimics OFFSET/LIMIT SQL paging for the default browse path.
 type fakeSmartExecutor struct {
-	items        []*models.MediaItem
-	previewCalls int
-	gotDef       catalog.QueryDefinition
+	items            []*models.MediaItem
+	previewCalls     int
+	previewPageCalls int
+	gotPageOffset    int
+	gotPageLimit     int
+	gotDef           catalog.QueryDefinition
 }
 
 func (f *fakeSmartExecutor) Preview(_ context.Context, def catalog.QueryDefinition, _ catalog.AccessFilter, limit int) ([]*models.MediaItem, int, error) {
@@ -26,6 +30,22 @@ func (f *fakeSmartExecutor) Preview(_ context.Context, def catalog.QueryDefiniti
 		return f.items[:limit], total, nil
 	}
 	return f.items, total, nil
+}
+
+func (f *fakeSmartExecutor) PreviewPage(_ context.Context, def catalog.QueryDefinition, _ catalog.AccessFilter, limit, offset int, _ bool) ([]*models.MediaItem, int, bool, error) {
+	f.previewPageCalls++
+	f.gotDef = def
+	f.gotPageOffset = offset
+	f.gotPageLimit = limit
+	total := len(f.items)
+	if offset >= total {
+		return nil, total, true, nil
+	}
+	end := offset + limit
+	if end > total {
+		end = total
+	}
+	return f.items[offset:end], total, true, nil
 }
 
 // TestHandleItems_SmartBoxSetChildrenResolveViaQuery pins the Wholphin fix: a
@@ -61,8 +81,8 @@ func TestHandleItems_SmartBoxSetChildrenResolveViaQuery(t *testing.T) {
 	if result.Items[0].ParentID != parentID {
 		t.Fatalf("expected ParentId %s, got %s", parentID, result.Items[0].ParentID)
 	}
-	if exec.previewCalls == 0 {
-		t.Fatal("expected the query executor to be consulted for a smart collection")
+	if exec.previewPageCalls == 0 {
+		t.Fatal("expected the query executor to be paged for a smart collection")
 	}
 }
 
@@ -130,7 +150,58 @@ func TestHandleItems_SmartBoxSetMalformedQueryEmpty(t *testing.T) {
 	if result.TotalRecordCount != 0 || len(result.Items) != 0 {
 		t.Fatalf("expected empty result for malformed query definition, got %+v", result.Items)
 	}
+	if exec.previewCalls != 0 || exec.previewPageCalls != 0 {
+		t.Fatalf("executor must not run for a malformed query definition; got %d Preview + %d PreviewPage calls",
+			exec.previewCalls, exec.previewPageCalls)
+	}
+}
+
+// TestHandleItems_SmartBoxSetChildrenPageInSQL asserts the default (no explicit
+// sort) browse path pages a smart collection directly in SQL — passing the
+// request's StartIndex/Limit through to the executor as OFFSET/LIMIT and
+// reporting the full membership as TotalRecordCount — instead of materializing
+// the entire (uncapped) membership and slicing one page locally.
+func TestHandleItems_SmartBoxSetChildrenPageInSQL(t *testing.T) {
+	collections := &fakeCollectionSource{
+		collections: []*models.LibraryCollection{
+			{ID: "210", LibraryID: 1, Title: "Big Smart", Visibility: "visible", CollectionType: "smart", ItemCount: 5, QueryDefinition: json.RawMessage(`{}`)},
+		},
+	}
+	members := []*models.MediaItem{
+		{ContentID: "m-1", Type: "movie", Title: "One"},
+		{ContentID: "m-2", Type: "movie", Title: "Two"},
+		{ContentID: "m-3", Type: "movie", Title: "Three"},
+		{ContentID: "m-4", Type: "movie", Title: "Four"},
+		{ContentID: "m-5", Type: "movie", Title: "Five"},
+	}
+	exec := &fakeSmartExecutor{items: members}
+	itemRepo := &fakeBatchItemRepo{items: map[string]*models.MediaItem{
+		"m-3": {ContentID: "m-3", Type: "movie", Title: "Three"},
+		"m-4": {ContentID: "m-4", Type: "movie", Title: "Four"},
+	}}
+	h := newCollectionsTestHandler(collections, []upstreamUserLibrary{{ID: 1, Name: "Movies", Type: "movies"}}, itemRepo)
+	h.queryExecutor = exec
+
+	parentID := h.codec.EncodeStringID(EncodedIDCollection, "210")
+	result := performItemsRequest(t, h, "/Items?ParentId="+parentID+"&StartIndex=2&Limit=2")
+
+	if exec.previewPageCalls != 1 {
+		t.Fatalf("expected exactly one paged executor call, got %d", exec.previewPageCalls)
+	}
 	if exec.previewCalls != 0 {
-		t.Fatalf("executor must not run for a malformed query definition; got %d calls", exec.previewCalls)
+		t.Fatalf("default browse must not use the full-membership Preview path; got %d calls", exec.previewCalls)
+	}
+	if exec.gotPageOffset != 2 || exec.gotPageLimit != 2 {
+		t.Fatalf("expected the request paging to reach the executor as offset=2 limit=2, got offset=%d limit=%d",
+			exec.gotPageOffset, exec.gotPageLimit)
+	}
+	if result.TotalRecordCount != 5 {
+		t.Fatalf("expected TotalRecordCount to reflect full membership (5), got %d", result.TotalRecordCount)
+	}
+	if len(result.Items) != 2 || result.Items[0].Name != "Three" || result.Items[1].Name != "Four" {
+		t.Fatalf("expected page [Three, Four], got %+v", result.Items)
+	}
+	if result.StartIndex != 2 {
+		t.Fatalf("expected StartIndex 2, got %d", result.StartIndex)
 	}
 }


### PR DESCRIPTION
## Motivation

`MaxSmartCollectionItemLimit` silently clamps every smart collection's query definition to 500 items (`ApplySmartCollectionItemLimit`), and an **unset** limit defaults to 100. On servers with large libraries this truncates collections with no indication to the admin — a per-language smart collection (`original_language is fr`) on our server has **10,625 real matches**, so it showed under 1% of them, cut off mid-alphabet.

## Change

Remove the cap entirely, and make an unset limit resolve the **full result set** (the default becomes a large sentinel so every consumer's int plumbing / SQL LIMIT keeps working). An explicit positive `limit` in the query definition is still honored as-is: membership size is an admin decision, and every read path that serves collection items either paginates in SQL or scales with the actual collection size rather than this value.

## Validation

Running on prod (2026-07-08) via a hotfix image with all 50 language collections unstamped — they resolve their full membership. `go build` / `go vet` / `go test ./internal/catalog/` pass. Rebased onto current main.

Companion PR from the same incident: #347 (Meilisearch task-wait timeout).

## AI-use disclosure

Updated with Claude Code (Claude Fable 5); prod-validated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)