### PR TITLE
fix(profiles): enforce per-account profile name uniqueness

### DIFF
--- a/internal/api/handlers/profiles.go
+++ b/internal/api/handlers/profiles.go
@@ -214,6 +214,13 @@ func writeProfileManagementPermissionError(w http.ResponseWriter, err error) {
 // member. Scoping is per account by construction: callers pass the profile
 // list of a single user's store, so another account's profiles can never
 // conflict.
+//
+// This is a check-then-write guard with no store-level uniqueness constraint
+// (the userstore's dual Postgres/SQLite backends carry no unique index on
+// name), so two concurrent requests can both pass and insert duplicates —
+// the same window the profile_limit_reached check accepts. Good enough for
+// interactive profile management; a functional unique index is the fix if
+// that ever stops being true.
 func profileNameConflicts(profiles []userstore.Profile, name, excludeID string) bool {
 	trimmed := strings.TrimSpace(name)
 	for _, p := range profiles {

--- a/internal/api/handlers/profiles.go
+++ b/internal/api/handlers/profiles.go
@@ -377,8 +377,10 @@ func (h *ProfileHandler) HandleCreateProfile(w http.ResponseWriter, r *http.Requ
 
 	profileID := uuid.New().String()
 	profile := userstore.Profile{
-		ID:                         profileID,
-		Name:                       req.Name,
+		ID: profileID,
+		// Store the trimmed form the conflict check compared, so " Laura "
+		// doesn't persist with stray whitespace.
+		Name:                       strings.TrimSpace(req.Name),
 		Avatar:                     avatarRef,
 		IsChild:                    req.IsChild,
 		MaxContentRating:           req.MaxContentRating,
@@ -527,10 +529,14 @@ func (h *ProfileHandler) HandleUpdateProfile(w http.ResponseWriter, r *http.Requ
 	}
 
 	if req.Name != nil {
-		if strings.TrimSpace(*req.Name) == "" {
+		// Normalize to the trimmed form up front: the conflict check compares
+		// it and the store persists it, so " Laura " never lands verbatim.
+		trimmedName := strings.TrimSpace(*req.Name)
+		if trimmedName == "" {
 			writeError(w, http.StatusBadRequest, "bad_request", "Profile name is required")
 			return
 		}
+		req.Name = &trimmedName
 		existingProfiles, err := store.ListProfiles(r.Context())
 		if err != nil {
 			writeError(w, http.StatusInternalServerError, "internal_error", "Failed to list profiles")

--- a/internal/api/handlers/profiles.go
+++ b/internal/api/handlers/profiles.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"log/slog"
 	"net/http"
+	"strings"
 	"time"
 
 	"github.com/go-chi/chi/v5"
@@ -207,6 +208,25 @@ func writeProfileManagementPermissionError(w http.ResponseWriter, err error) {
 	writeError(w, http.StatusInternalServerError, "internal_error", "Failed to check profile permissions")
 }
 
+// profileNameConflicts reports whether a profile other than excludeID already
+// uses name within this account's store, comparing the trimmed forms
+// case-insensitively so "Laura" and " laura " count as the same household
+// member. Scoping is per account by construction: callers pass the profile
+// list of a single user's store, so another account's profiles can never
+// conflict.
+func profileNameConflicts(profiles []userstore.Profile, name, excludeID string) bool {
+	trimmed := strings.TrimSpace(name)
+	for _, p := range profiles {
+		if p.ID == excludeID {
+			continue
+		}
+		if strings.EqualFold(strings.TrimSpace(p.Name), trimmed) {
+			return true
+		}
+	}
+	return false
+}
+
 // isAllowedSelfServiceProfileUpdate reports whether a non-admin update request
 // only touches fields the user is allowed to change on their own profiles.
 // Admin-only fields (access policy: library restrictions, content rating,
@@ -266,7 +286,7 @@ func (h *ProfileHandler) HandleCreateProfile(w http.ResponseWriter, r *http.Requ
 		return
 	}
 
-	if req.Name == "" {
+	if strings.TrimSpace(req.Name) == "" {
 		writeError(w, http.StatusBadRequest, "bad_request", "Profile name is required")
 		return
 	}
@@ -338,6 +358,16 @@ func (h *ProfileHandler) HandleCreateProfile(w http.ResponseWriter, r *http.Requ
 			)
 			return
 		}
+	}
+
+	if profileNameConflicts(existingProfiles, req.Name, "") {
+		writeError(
+			w,
+			http.StatusConflict,
+			"name_conflict",
+			"A profile with this name already exists",
+		)
+		return
 	}
 
 	showForcedSubtitles := true
@@ -491,6 +521,27 @@ func (h *ProfileHandler) HandleUpdateProfile(w http.ResponseWriter, r *http.Requ
 				http.StatusForbidden,
 				"forbidden",
 				"Profile access settings require the primary profile or admin access",
+			)
+			return
+		}
+	}
+
+	if req.Name != nil {
+		if strings.TrimSpace(*req.Name) == "" {
+			writeError(w, http.StatusBadRequest, "bad_request", "Profile name is required")
+			return
+		}
+		existingProfiles, err := store.ListProfiles(r.Context())
+		if err != nil {
+			writeError(w, http.StatusInternalServerError, "internal_error", "Failed to list profiles")
+			return
+		}
+		if profileNameConflicts(existingProfiles, *req.Name, profileID) {
+			writeError(
+				w,
+				http.StatusConflict,
+				"name_conflict",
+				"A profile with this name already exists",
 			)
 			return
 		}

--- a/internal/api/handlers/profiles_test.go
+++ b/internal/api/handlers/profiles_test.go
@@ -165,6 +165,44 @@ func TestHandleCreateProfile_AllowsNonAdminUpToCap(t *testing.T) {
 	}
 }
 
+func TestHandleCreateProfile_RejectsDuplicateName(t *testing.T) {
+	store := newProfileTestStore(t)
+	handler := NewProfileHandler(testUserStoreProvider{store: store})
+
+	// The seeded store already holds "Main"; a trimmed, case-insensitive
+	// match must be rejected within the same account.
+	req := newAuthorizedProfileRequestWithRole(
+		http.MethodPost,
+		"/profiles",
+		`{"name":" main "}`,
+		"user",
+		"profile-1",
+	)
+	rr := httptest.NewRecorder()
+
+	handler.HandleCreateProfile(rr, req)
+
+	if rr.Code != http.StatusConflict {
+		t.Fatalf("status = %d, body = %s", rr.Code, rr.Body.String())
+	}
+
+	var resp errorResponse
+	if err := json.NewDecoder(rr.Body).Decode(&resp); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if resp.Error != "name_conflict" {
+		t.Fatalf("error = %q, want %q", resp.Error, "name_conflict")
+	}
+
+	profiles, err := store.ListProfiles(context.Background())
+	if err != nil {
+		t.Fatalf("list profiles: %v", err)
+	}
+	if len(profiles) != 1 {
+		t.Fatalf("profile count = %d, want 1", len(profiles))
+	}
+}
+
 func TestHandleCreateProfile_BlocksNonPrimaryNonAdmin(t *testing.T) {
 	store := newProfileTestStore(t)
 	if err := store.CreateProfile(context.Background(), userstore.Profile{ID: "profile-2", Name: "Kids"}); err != nil {
@@ -431,6 +469,67 @@ func TestHandleUpdateProfile_AllowsNonAdminToUpdateAnyOwnedProfile(t *testing.T)
 	rr := httptest.NewRecorder()
 
 	handler.HandleUpdateProfile(rr, withProfileRouteParam(req, "id", "profile-2"))
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("status = %d, body = %s", rr.Code, rr.Body.String())
+	}
+}
+
+func TestHandleUpdateProfile_RejectsDuplicateNameOnRename(t *testing.T) {
+	store := newProfileTestStore(t)
+	if err := store.CreateProfile(context.Background(), userstore.Profile{ID: "profile-2", Name: "Kids"}); err != nil {
+		t.Fatalf("create profile: %v", err)
+	}
+	handler := NewProfileHandler(testUserStoreProvider{store: store})
+
+	req := newAuthorizedProfileRequestWithRole(
+		http.MethodPut,
+		"/profiles/profile-2",
+		`{"name":"MAIN"}`,
+		"user",
+		"profile-1",
+	)
+	rr := httptest.NewRecorder()
+
+	handler.HandleUpdateProfile(rr, withProfileRouteParam(req, "id", "profile-2"))
+
+	if rr.Code != http.StatusConflict {
+		t.Fatalf("status = %d, body = %s", rr.Code, rr.Body.String())
+	}
+
+	var resp errorResponse
+	if err := json.NewDecoder(rr.Body).Decode(&resp); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if resp.Error != "name_conflict" {
+		t.Fatalf("error = %q, want %q", resp.Error, "name_conflict")
+	}
+
+	profile, err := store.GetProfile(context.Background(), "profile-2")
+	if err != nil {
+		t.Fatalf("get profile: %v", err)
+	}
+	if profile == nil || profile.Name != "Kids" {
+		t.Fatalf("profile name changed despite conflict: %+v", profile)
+	}
+}
+
+func TestHandleUpdateProfile_AllowsKeepingOwnNameOnUpdate(t *testing.T) {
+	store := newProfileTestStore(t)
+	handler := NewProfileHandler(testUserStoreProvider{store: store})
+
+	// Saving a profile without renaming resubmits its own name; the
+	// conflict check must exclude the profile being updated.
+	req := newAuthorizedProfileRequestWithRole(
+		http.MethodPut,
+		"/profiles/profile-1",
+		`{"name":"Main","subtitle_mode":"always"}`,
+		"user",
+		"profile-1",
+	)
+	rr := httptest.NewRecorder()
+
+	handler.HandleUpdateProfile(rr, withProfileRouteParam(req, "id", "profile-1"))
 
 	if rr.Code != http.StatusOK {
 		t.Fatalf("status = %d, body = %s", rr.Code, rr.Body.String())

--- a/internal/api/handlers/profiles_test.go
+++ b/internal/api/handlers/profiles_test.go
@@ -203,6 +203,34 @@ func TestHandleCreateProfile_RejectsDuplicateName(t *testing.T) {
 	}
 }
 
+func TestHandleCreateProfile_RejectsWhitespaceOnlyName(t *testing.T) {
+	store := newProfileTestStore(t)
+	handler := NewProfileHandler(testUserStoreProvider{store: store})
+
+	req := newAuthorizedProfileRequestWithRole(
+		http.MethodPost,
+		"/profiles",
+		`{"name":"   "}`,
+		"user",
+		"profile-1",
+	)
+	rr := httptest.NewRecorder()
+
+	handler.HandleCreateProfile(rr, req)
+
+	if rr.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d, body = %s", rr.Code, rr.Body.String())
+	}
+
+	profiles, err := store.ListProfiles(context.Background())
+	if err != nil {
+		t.Fatalf("list profiles: %v", err)
+	}
+	if len(profiles) != 1 {
+		t.Fatalf("profile count = %d, want 1", len(profiles))
+	}
+}
+
 func TestHandleCreateProfile_TrimsStoredName(t *testing.T) {
 	store := newProfileTestStore(t)
 	handler := NewProfileHandler(testUserStoreProvider{store: store})
@@ -564,6 +592,62 @@ func TestHandleUpdateProfile_AllowsKeepingOwnNameOnUpdate(t *testing.T) {
 
 	if rr.Code != http.StatusOK {
 		t.Fatalf("status = %d, body = %s", rr.Code, rr.Body.String())
+	}
+}
+
+func TestHandleUpdateProfile_RejectsWhitespaceOnlyName(t *testing.T) {
+	store := newProfileTestStore(t)
+	handler := NewProfileHandler(testUserStoreProvider{store: store})
+
+	req := newAuthorizedProfileRequestWithRole(
+		http.MethodPut,
+		"/profiles/profile-1",
+		`{"name":"   "}`,
+		"user",
+		"profile-1",
+	)
+	rr := httptest.NewRecorder()
+
+	handler.HandleUpdateProfile(rr, withProfileRouteParam(req, "id", "profile-1"))
+
+	if rr.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d, body = %s", rr.Code, rr.Body.String())
+	}
+
+	profile, err := store.GetProfile(context.Background(), "profile-1")
+	if err != nil {
+		t.Fatalf("get profile: %v", err)
+	}
+	if profile == nil || profile.Name != "Main" {
+		t.Fatalf("profile name changed despite rejection: %+v", profile)
+	}
+}
+
+func TestHandleUpdateProfile_TrimsStoredNameOnRename(t *testing.T) {
+	store := newProfileTestStore(t)
+	handler := NewProfileHandler(testUserStoreProvider{store: store})
+
+	req := newAuthorizedProfileRequestWithRole(
+		http.MethodPut,
+		"/profiles/profile-1",
+		`{"name":" Laura "}`,
+		"user",
+		"profile-1",
+	)
+	rr := httptest.NewRecorder()
+
+	handler.HandleUpdateProfile(rr, withProfileRouteParam(req, "id", "profile-1"))
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("status = %d, body = %s", rr.Code, rr.Body.String())
+	}
+
+	profile, err := store.GetProfile(context.Background(), "profile-1")
+	if err != nil {
+		t.Fatalf("get profile: %v", err)
+	}
+	if profile == nil || profile.Name != "Laura" {
+		t.Fatalf("stored name not trimmed: %+v", profile)
 	}
 }
 

--- a/internal/api/handlers/profiles_test.go
+++ b/internal/api/handlers/profiles_test.go
@@ -203,6 +203,37 @@ func TestHandleCreateProfile_RejectsDuplicateName(t *testing.T) {
 	}
 }
 
+func TestHandleCreateProfile_TrimsStoredName(t *testing.T) {
+	store := newProfileTestStore(t)
+	handler := NewProfileHandler(testUserStoreProvider{store: store})
+
+	req := newAuthorizedProfileRequestWithRole(
+		http.MethodPost,
+		"/profiles",
+		`{"name":" Laura "}`,
+		"user",
+		"profile-1",
+	)
+	rr := httptest.NewRecorder()
+
+	handler.HandleCreateProfile(rr, req)
+
+	if rr.Code != http.StatusCreated {
+		t.Fatalf("status = %d, body = %s", rr.Code, rr.Body.String())
+	}
+
+	profiles, err := store.ListProfiles(context.Background())
+	if err != nil {
+		t.Fatalf("list profiles: %v", err)
+	}
+	for _, p := range profiles {
+		if p.Name == "Laura" {
+			return
+		}
+	}
+	t.Fatalf("no profile stored with trimmed name, profiles: %+v", profiles)
+}
+
 func TestHandleCreateProfile_BlocksNonPrimaryNonAdmin(t *testing.T) {
 	store := newProfileTestStore(t)
 	if err := store.CreateProfile(context.Background(), userstore.Profile{ID: "profile-2", Name: "Kids"}); err != nil {


### PR DESCRIPTION
## Problem

Profile create and rename accept any name, so a single account can hold unlimited identically-named profiles ("Laura", "laura", "Laura " — or five literal "Laura"s). Found during the 2026-07-08 Android profile QA pass. No client validates either, so every platform exposes the bug.

## Approach

Reject a create or rename whose trimmed, case-insensitive name matches another profile on the same account, with `409 name_conflict` ("A profile with this name already exists"), following the existing `profile_limit_reached` pattern.

- **Per-account scoping by construction**: the check compares against a single user's profile store (`storeProvider.ForUser`), so different accounts can still each have a "Laura". Cross-account names are never visible to it.
- **Renames exclude the profile being updated**, so re-saving a profile under its own name (avatar-only edits resubmit the name) still succeeds.
- Adjacent fix: whitespace-only names ("  ") previously passed the `name == ""` check on create, and renames had no blank check at all; both now reject with 400.

Additive-only per the v1 API rules: a new error condition on existing endpoints, no field or status-code changes to success paths.

## Tests

- `TestHandleCreateProfile_RejectsDuplicateName` — " main " vs seeded "Main" → 409, nothing created
- `TestHandleUpdateProfile_RejectsDuplicateNameOnRename` — rename "Kids" → "MAIN" → 409, name unchanged
- `TestHandleUpdateProfile_AllowsKeepingOwnNameOnUpdate` — self-name resave → 200

`go test ./internal/api/handlers/` passes; `go build ./...`, `go vet`, gofmt clean.

## Risks / follow-up

- Existing duplicate profiles are untouched; the rule applies to new creates/renames only. Editing one of two existing "Laura"s without renaming still saves (self-exclusion); renaming it *to* "Laura" again is rejected.
- Android surfaces the 409 message directly and pre-checks client-side (companion branch in silo-android); iOS/web inherit enforcement but may show their generic error text until they surface `message`.

No linked scope issue — small correctness fix out of device QA rather than a capability epic.

## AI-use disclosure

Implemented with Claude Code (Claude Fable 5); reviewed and test-verified locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Enforced profile-name uniqueness ignoring case and leading/trailing spaces.
  * Profile creation/renaming to a conflicting name now returns a conflict error (`409`, `name_conflict`).
  * Profile names that are empty after trimming whitespace are rejected (`400`).
  * When a name is provided, the stored value is the trimmed version.

* **Tests**
  * Added coverage for duplicate detection, whitespace trimming, and update scenarios (including keeping the same name on rename).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->