### PR TITLE
feat(jellycompat): surface audio profile and spatial format on media streams

### DIFF
--- a/internal/catalogseed/service.go
+++ b/internal/catalogseed/service.go
@@ -2599,6 +2599,7 @@ func toAudioTrackRecords(tracks []models.AudioTrack) []AudioTrackRecord {
 			EmbeddedTitle: track.EmbeddedTitle,
 			Language:      track.Language,
 			Codec:         track.Codec,
+			Profile:       track.Profile,
 			Layout:        track.Layout,
 			Channels:      track.Channels,
 			Bitrate:       track.Bitrate,

--- a/internal/catalogseed/types.go
+++ b/internal/catalogseed/types.go
@@ -169,6 +169,7 @@ type AudioTrackRecord struct {
 	EmbeddedTitle string `json:"embedded_title,omitempty"`
 	Language      string `json:"language,omitempty"`
 	Codec         string `json:"codec,omitempty"`
+	Profile       string `json:"profile,omitempty"`
 	Layout        string `json:"layout,omitempty"`
 	Channels      int    `json:"channels,omitempty"`
 	Bitrate       int    `json:"bitrate,omitempty"`

--- a/internal/jellycompat/audio_profile_streams_test.go
+++ b/internal/jellycompat/audio_profile_streams_test.go
@@ -1,0 +1,101 @@
+package jellycompat
+
+import (
+	"testing"
+
+	"github.com/Silo-Server/silo-server/internal/catalog"
+	"github.com/Silo-Server/silo-server/internal/models"
+)
+
+func TestCompatAudioSpatialFormat(t *testing.T) {
+	cases := []struct {
+		profile string
+		want    string
+	}{
+		{"Dolby Digital Plus + Dolby Atmos", "DolbyAtmos"},
+		{"TrueHD + Dolby Atmos", "DolbyAtmos"},
+		{"dolby atmos", "DolbyAtmos"},
+		{"DTS-HD MA + DTS:X", "DTSX"},
+		{"dts:x", "DTSX"},
+		{"DTS-HD MA", "None"},
+		{"LC", "None"},
+		{"", "None"},
+	}
+	for _, tc := range cases {
+		if got := compatAudioSpatialFormat(tc.profile); got != tc.want {
+			t.Errorf("compatAudioSpatialFormat(%q) = %q, want %q", tc.profile, got, tc.want)
+		}
+	}
+}
+
+func TestBuildMediaStreamsCarriesAudioProfile(t *testing.T) {
+	version := catalog.FileVersion{
+		VideoTracks: []models.VideoTrack{{Codec: "hevc"}},
+		AudioTracks: []models.AudioTrack{
+			{
+				Codec:    "eac3",
+				Profile:  "Dolby Digital Plus + Dolby Atmos",
+				Language: "eng",
+				Channels: 6,
+				Default:  true,
+			},
+			{
+				Codec:    "dts",
+				Profile:  "DTS-HD MA + DTS:X",
+				Language: "eng",
+				Channels: 8,
+			},
+			{
+				Codec:    "aac",
+				Profile:  "LC",
+				Language: "eng",
+				Channels: 2,
+			},
+		},
+	}
+
+	streams := buildMediaStreams("item", "source", version)
+	if len(streams) != 4 {
+		t.Fatalf("streams length = %d, want 4", len(streams))
+	}
+
+	atmos := streams[1]
+	if atmos.Profile != "Dolby Digital Plus + Dolby Atmos" {
+		t.Fatalf("atmos Profile = %q", atmos.Profile)
+	}
+	if atmos.AudioSpatialFormat != "DolbyAtmos" {
+		t.Fatalf("atmos AudioSpatialFormat = %q, want DolbyAtmos", atmos.AudioSpatialFormat)
+	}
+	if atmos.DisplayTitle != "English - Dolby Digital Plus + Dolby Atmos 5.1" {
+		t.Fatalf("atmos DisplayTitle = %q", atmos.DisplayTitle)
+	}
+
+	dtsx := streams[2]
+	if dtsx.Profile != "DTS-HD MA + DTS:X" {
+		t.Fatalf("dtsx Profile = %q", dtsx.Profile)
+	}
+	if dtsx.AudioSpatialFormat != "DTSX" {
+		t.Fatalf("dtsx AudioSpatialFormat = %q, want DTSX", dtsx.AudioSpatialFormat)
+	}
+
+	// The AAC "LC" profile is uninformative: it is carried on the stream but
+	// must not replace the codec name in the display title, and it is not a
+	// spatial format.
+	aac := streams[3]
+	if aac.Profile != "LC" {
+		t.Fatalf("aac Profile = %q", aac.Profile)
+	}
+	if aac.AudioSpatialFormat != "None" {
+		t.Fatalf("aac AudioSpatialFormat = %q, want None", aac.AudioSpatialFormat)
+	}
+	if aac.DisplayTitle != "English - AAC Stereo" {
+		t.Fatalf("aac DisplayTitle = %q", aac.DisplayTitle)
+	}
+}
+
+func TestAudioTrackDisplayTitleWithoutProfileKeepsCodecName(t *testing.T) {
+	title := audioTrackDisplayTitle(models.AudioTrack{Codec: "eac3", Language: "eng", Channels: 6})
+	if title != "English - EAC3 5.1" {
+		t.Fatalf("DisplayTitle = %q", title)
+	}
+}

--- a/internal/jellycompat/handlers_playback.go
+++ b/internal/jellycompat/handlers_playback.go
@@ -882,7 +882,8 @@ func buildMediaStreamsWithSelection(routeItemID, mediaSourceID string, version c
 			IsHearingImpaired:      false,
 			IsTextSubtitleStream:   false,
 			SupportsExternalStream: false,
-			AudioSpatialFormat:     "None",
+			Profile:                track.Profile,
+			AudioSpatialFormat:     compatAudioSpatialFormat(track.Profile),
 			Channels:               track.Channels,
 			BitRate:                track.Bitrate,
 		})
@@ -1226,9 +1227,29 @@ func parseCompatFrameRate(raw string) float64 {
 	return 0
 }
 
+// compatAudioSpatialFormat mirrors Jellyfin's MediaStream.AudioSpatialFormat,
+// derived from the ffprobe profile string by case-insensitive substring match.
+func compatAudioSpatialFormat(profile string) string {
+	lower := strings.ToLower(profile)
+	switch {
+	case strings.Contains(lower, "dolby atmos"):
+		return "DolbyAtmos"
+	case strings.Contains(lower, "dts:x"):
+		return "DTSX"
+	default:
+		return "None"
+	}
+}
+
 func audioTrackDisplayTitle(track models.AudioTrack) string {
 	lang := compatLanguageName(track.Language)
+	// Jellyfin prefers the ffprobe profile over the codec name in audio display
+	// titles (e.g. "DTS-HD MA", "Dolby Digital Plus + Dolby Atmos"), except the
+	// uninformative AAC "LC" profile.
 	codec := audioCodecDisplayName(track.Codec)
+	if profile := strings.TrimSpace(track.Profile); profile != "" && !strings.EqualFold(profile, "lc") {
+		codec = profile
+	}
 	channels := audioChannelsDisplayName(track.Channels)
 	title := strings.TrimSpace(codec + " " + channels)
 	if lang != "" {

--- a/internal/models/media.go
+++ b/internal/models/media.go
@@ -186,6 +186,7 @@ type AudioTrack struct {
 	EmbeddedTitle string `json:"embedded_title,omitempty"`
 	Language      string `json:"language,omitempty"`
 	Codec         string `json:"codec,omitempty"`
+	Profile       string `json:"profile,omitempty"`
 	Layout        string `json:"layout,omitempty"`
 	Channels      int    `json:"channels,omitempty"`
 	Bitrate       int    `json:"bitrate,omitempty"`

--- a/internal/scanner/probe.go
+++ b/internal/scanner/probe.go
@@ -211,6 +211,7 @@ func convertProbeData(raw *ffprobeOutput) *ProbeData {
 				EmbeddedTitle: s.Tags["title"],
 				Language:      lang.Canonical(s.Tags["language"]),
 				Codec:         s.CodecName,
+				Profile:       s.Profile,
 				Layout:        s.ChannelLayout,
 				Channels:      s.Channels,
 				Bitrate:       parseNumeric(s.BitRate) / 1000,

--- a/internal/scanner/probe_audio_profile_test.go
+++ b/internal/scanner/probe_audio_profile_test.go
@@ -1,0 +1,37 @@
+package scanner
+
+import "testing"
+
+func TestConvertProbeDataCapturesAudioProfile(t *testing.T) {
+	probe := convertProbeData(&ffprobeOutput{
+		Streams: []ffprobeStream{
+			{
+				CodecType:        "audio",
+				CodecName:        "eac3",
+				CodecLongName:    "E-AC-3",
+				Profile:          "Dolby Digital Plus + Dolby Atmos",
+				ChannelLayout:    "5.1(side)",
+				Channels:         6,
+				BitRate:          "768000",
+				SampleRate:       "48000",
+				BitsPerRawSample: "24",
+				Disposition:      ffprobeDisp{Default: 1},
+				Tags:             map[string]string{"language": "eng", "title": "Main Audio"},
+			},
+		},
+	})
+
+	if len(probe.AudioTracks) != 1 {
+		t.Fatalf("audio tracks = %d, want 1", len(probe.AudioTracks))
+	}
+	track := probe.AudioTracks[0]
+	if track.Profile != "Dolby Digital Plus + Dolby Atmos" {
+		t.Fatalf("profile = %q, want Dolby Digital Plus + Dolby Atmos", track.Profile)
+	}
+	if track.Codec != "eac3" {
+		t.Fatalf("codec = %q, want eac3", track.Codec)
+	}
+	if !track.Default {
+		t.Fatal("expected default audio track")
+	}
+}

--- a/internal/scanner/scanner.go
+++ b/internal/scanner/scanner.go
@@ -2824,6 +2824,7 @@ func applyProbeData(mf *models.MediaFile, probe *ProbeData, probeSource string) 
 			EmbeddedTitle: at.EmbeddedTitle,
 			Language:      at.Language,
 			Codec:         at.Codec,
+			Profile:       at.Profile,
 			Layout:        at.Layout,
 			Channels:      at.Channels,
 			Bitrate:       at.Bitrate,

--- a/internal/scanner/types.go
+++ b/internal/scanner/types.go
@@ -69,6 +69,7 @@ type AudioTrackInfo struct {
 	EmbeddedTitle string
 	Language      string
 	Codec         string
+	Profile       string
 	Layout        string
 	Channels      int
 	Bitrate       int


### PR DESCRIPTION
# feat(jellycompat): surface audio profile and spatial format on media streams

## Problem

PR #337 captures the ffprobe audio stream `profile` (e.g. "Dolby Digital Plus + Dolby Atmos"), but jellycompat never exposed it: `buildMediaStreamsWithSelection` set `Profile` only on video streams and hardcoded `AudioSpatialFormat: "None"` for audio. Jellyfin clients such as Infuse rely on these fields to show Atmos / DTS:X badges.

## Approach

Match real Jellyfin's `MediaStream` semantics (verified against `MediaBrowser.Model/Entities/MediaStream.cs`):

- Set `Profile` on audio `mediaStreamDTO` entries from the captured track profile.
- Derive `AudioSpatialFormat` by case-insensitive substring match on the profile: "Dolby Atmos" → `DolbyAtmos`, "DTS:X" → `DTSX`, else `None`.
- Audio display titles now prefer the profile over the codec name (except the uninformative AAC "LC" profile), matching Jellyfin — a DTS-HD MA track previously displayed as plain "DTS".

Additive-only DTO changes (`omitempty` fields already existed on `mediaStreamDTO`).

## Stacked on #337

Part of the audio-profile work: #337 (scanner capture), #339 (web Media Info display). This branch is based on #337's head; the first two commits belong to that PR and this PR should be rebased/merged after it lands.

## Verification

```sh
go test ./internal/jellycompat -run 'TestCompatAudioSpatialFormat|TestBuildMediaStreamsCarriesAudioProfile|TestAudioTrackDisplayTitle'
gofmt -l internal/jellycompat
```

Full-package `go test ./internal/jellycompat` fails only on the pre-existing flaky `TestBeginWebOperationRejectsLiveProcessLock` (reproduces on a clean tree without this change).

## Risks & follow-up

Low risk. Display titles change for tracks that carry a profile (intentional, Jellyfin parity). Existing libraries only benefit once files are re-probed (see #337 limitations).

## AI-use disclosure

Implemented by Claude Code (Fable 5) with human oversight.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Audio tracks now include profile details throughout scanning and playback, improving audio format detection and display.
  * Spatial audio formats such as Dolby Atmos and DTS:X are now recognized more accurately.
  * Audio track titles now better reflect profile information when available.

* **Bug Fixes**
  * Improved handling of AAC LC so codec names remain correct in track titles.
  * Added coverage to verify audio profile data is captured and passed through consistently.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->