### PR TITLE
fix(search): raise Meilisearch task-wait timeout from 5m to 2h

### DIFF
--- a/internal/catalog/search_meilisearch_client.go
+++ b/internal/catalog/search_meilisearch_client.go
@@ -126,7 +126,19 @@ type meilisearchEmbedderSettings struct {
 }
 
 const (
-	defaultMeilisearchTaskWaitTimeout = 5 * time.Minute
+	// defaultMeilisearchTaskWaitTimeout bounds how long WaitTask polls a
+	// single Meilisearch task when the caller supplies no deadline. Semantic
+	// (vector-embedded) batches can legitimately take many minutes on modest
+	// hardware — and Meilisearch auto-batches consecutive queued document
+	// tasks, so the oldest task's wall-clock completion covers the whole
+	// fused unit. Prod rebuilds died mid-batch with "context deadline
+	// exceeded" at the previous 5-minute value (2026-06-29 twice, 2026-07-08
+	// twice), leaving incremental sync gated on a stale schema version.
+	// Terminal task states (succeeded/failed/canceled) still end the wait
+	// immediately — this only caps waiting on a task that is genuinely still
+	// processing, where giving up guarantees rebuild failure and gains
+	// nothing.
+	defaultMeilisearchTaskWaitTimeout = 2 * time.Hour
 	meilisearchTaskPollInterval       = time.Second
 )
 


### PR DESCRIPTION
## Problem

`WaitTask`'s hard-coded 5-minute deadline killed **four** prod catalog rebuilds mid-batch ("context deadline exceeded"): twice on 2026-06-29 and twice on 2026-07-08 — the latter even after shrinking `rebuild_batch_size` to 1000 on an 8-core Meilisearch. Each death leaves incremental sync gated on a stale schema version while the event outbox grows unboundedly (1.6M+ rows on prod): search silently frozen.

Batch size can't fully mitigate because **Meilisearch auto-batches consecutive queued document tasks** — with `rebuild_task_queue_depth` tasks in flight, the oldest task only completes when the whole fused unit does, which exceeds 5 minutes in vector-heavy stretches of the catalog.

## Change

Raise `defaultMeilisearchTaskWaitTimeout` to 2 hours, with the incident history documented on the constant. Terminal task states (succeeded/failed/canceled) still end the wait immediately — the deadline only bounds a task genuinely still processing, where giving up guarantees rebuild failure and gains nothing.

## Validation

Running on prod (2026-07-08) via a hotfix image; the rebuild that failed four times is running with 2h headroom. `go build` / `go vet` / `go test ./internal/catalog/` pass. Rebased onto current main (the index-cleanup work this PR briefly carried was dropped as redundant with #291).

Companion PR from the same incident: #340 (smart collection cap removal).

## AI-use disclosure

Implemented with Claude Code (Claude Fable 5); prod-validated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Increased the maximum wait time for search indexing tasks, reducing the chance of timeouts when processing longer-running updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->