### PR TITLE
feat(watchlist): honor provider list order by default

### DIFF
--- a/internal/catalog/catalog_parser.go
+++ b/internal/catalog/catalog_parser.go
@@ -83,7 +83,13 @@ func ParseCatalogRequest(values url.Values) (CatalogRequest, error) {
 		req.NamePrefix = overlay.namePrefix
 		req.SearchQuery = overlay.searchQuery
 		req.Query = overlay.query
-		req.UseSourceOrder = !overlay.hasExplicitSort
+		// On personal lists an explicit "added_at" sort means the date the item
+		// was added to the list, which loadPersonalSourceIDs applies on the
+		// source-order path; the query executor would sort by the library's
+		// created_at instead. History ID loading ignores the sort, so it stays
+		// on the executor path.
+		req.UseSourceOrder = !overlay.hasExplicitSort ||
+			(req.Source != CatalogSourceHistory && req.Query.Sort.Field == "added_at")
 	case CatalogSourcePerson:
 		req.PersonID = ParseInt64Param(values.Get("person_id"))
 		if req.PersonID <= 0 {

--- a/internal/catalog/catalog_parser_test.go
+++ b/internal/catalog/catalog_parser_test.go
@@ -17,6 +17,37 @@ func TestParseCatalogMediaScope_AllowsManga(t *testing.T) {
 	}
 }
 
+func TestParseCatalogRequest_PersonalSourceOrder(t *testing.T) {
+	cases := []struct {
+		name           string
+		values         url.Values
+		useSourceOrder bool
+	}{
+		{"watchlist default", url.Values{"source": {"watchlist"}}, true},
+		// added_at means "date added to the list" and is applied on the
+		// source-order path by loadPersonalSourceIDs.
+		{"watchlist explicit added_at", url.Values{"source": {"watchlist"}, "sort": {"added_at"}, "order": {"desc"}}, true},
+		{"favorites explicit added_at", url.Values{"source": {"favorites"}, "sort": {"added_at"}}, true},
+		{"watchlist metadata sort", url.Values{"source": {"watchlist"}, "sort": {"title"}}, false},
+		// History ID loading ignores the sort, so it keeps the executor path.
+		{"history explicit added_at", url.Values{"source": {"history"}, "sort": {"added_at"}}, false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			req, err := ParseCatalogRequest(tc.values)
+			if err != nil {
+				t.Fatalf("ParseCatalogRequest returned error: %v", err)
+			}
+			if req.UseSourceOrder != tc.useSourceOrder {
+				t.Fatalf("UseSourceOrder = %v, want %v", req.UseSourceOrder, tc.useSourceOrder)
+			}
+			if sort := tc.values.Get("sort"); sort != "" && req.Query.Sort.Field != sort {
+				t.Fatalf("sort field = %q, want %q", req.Query.Sort.Field, sort)
+			}
+		})
+	}
+}
+
 func TestParseCatalogRequest_AllowsCollectionOverlayParams(t *testing.T) {
 	values := url.Values{
 		"source":                     {"user_collection"},

--- a/internal/watchsync/service.go
+++ b/internal/watchsync/service.go
@@ -114,7 +114,7 @@ func (s *Service) GetConnectionStatus(ctx context.Context, userID int, profileID
 		ImportWatchlistEnabled:       true,
 		ExportWatchlistEnabled:       true,
 		SyncWatchlistRemovalsEnabled: false,
-		SyncWatchlistOrderEnabled:    false,
+		SyncWatchlistOrderEnabled:    true,
 		ScrobbleEnabled:              true,
 	}
 	if connected {
@@ -550,14 +550,15 @@ func (s *Service) persistConnection(
 		// opt-in. Toggles a provider can't serve are skipped at sync time via
 		// the capability check, so enabling them here is harmless.
 		conn = Connection{
-			ImportWatchedEnabled:   true,
-			ImportProgressEnabled:  true,
-			ExportWatchedEnabled:   true,
-			ImportFavoritesEnabled: true,
-			ExportFavoritesEnabled: true,
-			ImportWatchlistEnabled: true,
-			ExportWatchlistEnabled: true,
-			ScrobbleEnabled:        true,
+			ImportWatchedEnabled:      true,
+			ImportProgressEnabled:     true,
+			ExportWatchedEnabled:      true,
+			ImportFavoritesEnabled:    true,
+			ExportFavoritesEnabled:    true,
+			ImportWatchlistEnabled:    true,
+			ExportWatchlistEnabled:    true,
+			SyncWatchlistOrderEnabled: true,
+			ScrobbleEnabled:           true,
 		}
 	}
 	conn.Provider = providerKey

--- a/migrations/sql/20260709140902_enable_watchlist_order_mirroring.sql
+++ b/migrations/sql/20260709140902_enable_watchlist_order_mirroring.sql
@@ -1,0 +1,24 @@
+-- +goose Up
+-- +goose StatementBegin
+
+-- Watchlist order mirroring now defaults to enabled: new connections are
+-- created with sync_watchlist_order_enabled = true, so flip existing rows to
+-- match. The old default was false and the toggle shipped off, so a stored
+-- false almost always means "never touched" rather than an explicit opt-out.
+-- Providers without the provides_watchlist_order capability ignore the flag
+-- at sync time, so enabling it everywhere is harmless.
+UPDATE public.watch_provider_connections
+SET sync_watchlist_order_enabled = true;
+
+ALTER TABLE public.watch_provider_connections
+    ALTER COLUMN sync_watchlist_order_enabled SET DEFAULT true;
+-- +goose StatementEnd
+
+-- +goose Down
+-- +goose StatementBegin
+ALTER TABLE public.watch_provider_connections
+    ALTER COLUMN sync_watchlist_order_enabled SET DEFAULT false;
+
+-- Down intentionally leaves per-connection values untouched: there is no way
+-- to distinguish rows enabled by the Up from rows users enabled themselves.
+-- +goose StatementEnd

--- a/web/src/components/catalog/CatalogFiltersPanel.tsx
+++ b/web/src/components/catalog/CatalogFiltersPanel.tsx
@@ -8,7 +8,10 @@ import {
 } from "@/components/collections/CollectionGuidedRulesEditor";
 import { useCatalogFilters } from "@/hooks/queries/catalog";
 import type { QuerySortRelevanceScope } from "@/lib/querySortOptions";
-import type { CatalogSearchState } from "@/pages/catalogSearchParams";
+import {
+  catalogSourceSupportsSourceOrder,
+  type CatalogSearchState,
+} from "@/pages/catalogSearchParams";
 
 import ActiveFilterBadges from "./ActiveFilterBadges";
 import CatalogFilterBar, { CATALOG_SOURCE_ORDER_SORT_FIELD } from "./CatalogFilterBar";
@@ -48,7 +51,8 @@ export default function CatalogFiltersPanel({
   const isLocked = state.source === "section";
   const isCollectionSource =
     state.source === "library_collection" || state.source === "user_collection";
-  const usesSourceOrder = isCollectionSource && state.uses_source_order;
+  const supportsSourceOrder = catalogSourceSupportsSourceOrder(state.source);
+  const usesSourceOrder = supportsSourceOrder && state.uses_source_order;
 
   const qd = state.query_definition ?? createEmptyQueryDefinition();
   const guidedState = useMemo(() => queryDefinitionToGuidedState(qd), [qd]);
@@ -81,7 +85,7 @@ export default function CatalogFiltersPanel({
   function update(patch: Partial<GuidedFormState>) {
     const next = { ...toolbarGuidedState, ...patch };
     const nextUsesSourceOrder =
-      isCollectionSource && next.sortField === CATALOG_SOURCE_ORDER_SORT_FIELD;
+      supportsSourceOrder && next.sortField === CATALOG_SOURCE_ORDER_SORT_FIELD;
     const nextForQuery = nextUsesSourceOrder
       ? { ...next, sortField: guidedState.sortField, sortOrder: guidedState.sortOrder }
       : next;
@@ -105,7 +109,9 @@ export default function CatalogFiltersPanel({
         sortRelevanceScope={sortRelevanceScope}
         resultCountLabel={resultCountLabel}
         resultCountLoading={resultCountLoading}
-        sourceOrderLabel={isCollectionSource ? "Collection Order" : undefined}
+        sourceOrderLabel={
+          isCollectionSource ? "Collection Order" : supportsSourceOrder ? "List Order" : undefined
+        }
         allowEpisodeMediaScope={!isCollectionSource}
       />
 

--- a/web/src/pages/catalogSearchParams.test.ts
+++ b/web/src/pages/catalogSearchParams.test.ts
@@ -4,6 +4,7 @@ import {
   buildCatalogApiSearchParams,
   buildCatalogHref,
   buildPersonCatalogHref,
+  buildPersonalCatalogHref,
   catalogSourceAllowsOverlay,
   parseCatalogSearchParams,
 } from "./catalogSearchParams";
@@ -86,6 +87,20 @@ describe("parseCatalogSearchParams", () => {
     expect(state.query_definition.sort).toEqual({ field: "title", order: "asc" });
   });
 
+  it("defaults the watchlist to source order until a sort is chosen", () => {
+    expect(parseCatalogSearchParams(params("source=watchlist")).uses_source_order).toBe(true);
+    expect(parseCatalogSearchParams(params("source=watchlist&sort=title")).uses_source_order).toBe(
+      false,
+    );
+    expect(
+      parseCatalogSearchParams(params("source=watchlist&sort=added_at&order=desc"))
+        .uses_source_order,
+    ).toBe(false);
+    // Other personal sources keep their existing behavior.
+    expect(parseCatalogSearchParams(params("source=favorites")).uses_source_order).toBe(false);
+    expect(parseCatalogSearchParams(params("source=history")).uses_source_order).toBe(false);
+  });
+
   it("normalizes legacy sort aliases in catalog URLs", () => {
     expect(
       parseCatalogSearchParams(params("source=query&sort=sort_title")).query_definition.sort,
@@ -125,6 +140,37 @@ describe("buildCatalogHref", () => {
         },
       }).toString(),
     ).toBe("source=query&library_id=2&sort=added_at&order=desc");
+  });
+
+  it("omits the sort for watchlist source order but keeps an explicit Date Added", () => {
+    const sourceOrdered = buildCatalogApiSearchParams({
+      source: "watchlist",
+      uses_source_order: true,
+      query_definition: {
+        library_ids: [],
+        match: "all",
+        groups: [],
+        sort: { field: "added_at", order: "desc" },
+      },
+    });
+    expect(sourceOrdered.toString()).toBe("source=watchlist");
+
+    const explicitAddedAt = buildCatalogApiSearchParams({
+      source: "watchlist",
+      uses_source_order: false,
+      query_definition: {
+        library_ids: [],
+        match: "all",
+        groups: [],
+        sort: { field: "added_at", order: "desc" },
+      },
+    });
+    expect(explicitAddedAt.toString()).toBe("source=watchlist&sort=added_at&order=desc");
+  });
+
+  it("builds source-ordered personal catalog hrefs without a sort param", () => {
+    expect(buildPersonalCatalogHref("watchlist")).toBe("/catalog?source=watchlist");
+    expect(buildPersonalCatalogHref("favorites")).toBe("/catalog?source=favorites");
   });
 
   it("builds collection catalog URLs with overlay params", () => {

--- a/web/src/pages/catalogSearchParams.ts
+++ b/web/src/pages/catalogSearchParams.ts
@@ -67,6 +67,13 @@ function isCollectionSource(source: CatalogSource): boolean {
   return source === "library_collection" || source === "user_collection";
 }
 
+// Sources whose default ordering is the stored list order rather than a sort
+// field. The watchlist's stored order can mirror a watch provider's list
+// order (e.g. MDBList) via sort_index.
+export function catalogSourceSupportsSourceOrder(source: CatalogSource): boolean {
+  return isCollectionSource(source) || source === "watchlist";
+}
+
 export function catalogSourceAllowsOverlay(source: CatalogSource): boolean {
   return overlaySources.has(source);
 }
@@ -164,7 +171,7 @@ export function parseCatalogSearchParams(searchParams: URLSearchParams): Catalog
         : undefined,
     limit: queryLimit,
   });
-  baseState.uses_source_order = isCollectionSource(source) && !hasExplicitSort;
+  baseState.uses_source_order = catalogSourceSupportsSourceOrder(source) && !hasExplicitSort;
 
   return baseState;
 }
@@ -185,6 +192,7 @@ export function buildQueryCatalogHref(q?: string): string {
 export function buildPersonalCatalogHref(source: "favorites" | "watchlist" | "history"): string {
   return buildCatalogHref({
     source,
+    uses_source_order: catalogSourceSupportsSourceOrder(source),
     query_definition: createEmptyQueryDefinition(),
   });
 }
@@ -327,6 +335,9 @@ export function buildCatalogApiSearchParams(state: CatalogSearchState): URLSearc
     state.query_definition.sort.field &&
     (state.query_definition.sort.field !== "added_at" ||
       (state.source === "query" && effectiveLibraryID != null) ||
+      // Watchlist defaults to source order, so an explicit Date Added pick
+      // must be sent to distinguish it (the server maps it to list added-at).
+      state.source === "watchlist" ||
       state.source === "library_collection" ||
       state.source === "user_collection")
   ) {


### PR DESCRIPTION
## Problem

The watchlist catalog page (`/catalog?source=watchlist`) had two compounding confusions:

1. **The sort dropdown lied.** The default request sends no `sort` param, so the server returns the stored list order — but the UI displayed the default as "Date Added". Collections already solve this honestly with a "Collection Order" sentinel; the watchlist never got the same treatment. A side effect: explicitly picking "Date Added" was indistinguishable from the default (the param was stripped either way), so a true date-added sort was unreachable from the UI.
2. **Provider order mirroring was off by default.** MDBList declares `ProvidesWatchlistOrder` and the sync plumbing mirrors its order into `user_watchlist.sort_index`, but `sync_watchlist_order_enabled` shipped default-off — so synced watchlists appeared in first-sync-time order (every item from the initial sync shares one timestamp) unless the user found the toggle.

There was also a latent semantics bug: `source=watchlist&sort=added_at` went through the query executor, which maps `added_at` to the library's `created_at` — i.e. *date added to the library*, not *date added to the list* — inconsistent with the section path, which documents `added_at` on personal lists as list-added date.

## Changes

- **Web**: the watchlist source participates in the same `uses_source_order` mechanism as collections. The sort dropdown shows **"List Order"** as the active default, and an explicit "Date Added" pick now sends `sort=added_at`.
- **Server** (`catalog_parser.go`): on watchlist/favorites, an explicit `added_at` sort takes the source-order path where `OrderPersonalListIDs` applies the *list* added-at. History keeps the executor path since its ID loading ignores the sort.
- **watchsync**: new connections are created with `sync_watchlist_order_enabled = true`; a migration flips existing rows and the column default to match. Order application still requires the provider capability, so this is a no-op for Trakt/Simkl.

## Behavior notes / risks

- `GET /api/v1/catalog?source=watchlist&sort=added_at` changes meaning from library-added to list-added ordering. No fields or status codes change (additive-only rules respected); this is a semantics fix aligning with the section path. Clients that send this param (Android/Apple) should be checked — if they expose a watchlist "Date Added" sort they now get the more intuitive list-date ordering with no code change.
- The migration's Down restores the column default but intentionally leaves per-row values untouched: rows enabled by the Up are indistinguishable from user-enabled rows, and disabling a user-enabled row would wipe their mirrored `sort_index` on the next toggle-off.
- Mirrored order lands on the next watchlist sync after the migration runs.

## Verification

- New Go parser tests (`TestParseCatalogRequest_PersonalSourceOrder`) plus `internal/catalog` and `internal/watchsync/...` suites pass; `go build ./...` clean; no new golangci findings on changed lines.
- New vitest cases for parse/build round-trips; full web suite green except 4 pre-existing failures (Jellyfin proxy/setup-wizard, confirmed failing on a clean tree). ESLint/Prettier clean; `make verify-local-paths` passes.
- `goose validate` passes; migration column/table names cross-checked against `20260626185649_watchlist_sort_order.sql`. Not executed against a live DB (no local Docker).
- Verified live in the browser against the dev backend: default page requests `source=watchlist` with no sort and shows "List Order"; picking "Date Added" issues `sort=added_at&order=desc` and updates the URL; switching back strips it. No console errors.

Related: #214 (closed epic for external list-backed collections; no open scope issue covers this — it comes from a direct UX report that "Recently Added" on a synced MDBList watchlist was ambiguous and didn't honor MDBList's order).

## AI-use disclosure

Implemented with Claude Code (Claude Fable 5), human-directed and reviewed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Catalog filtering now better supports source-based ordering for personal lists like watchlists.
  * Watchlist links and search parameters now preserve the expected order behavior when navigating between views.

* **Bug Fixes**
  * Fixed sorting behavior for “Date Added” on personal lists so the displayed order matches user expectations.
  * Watchlist sync/order settings now default to enabled for new connections and existing connections were updated accordingly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->