### PR TITLE
test(plugins): cover repository rename compatibility

### DIFF
--- a/internal/plugins/auto_update_replace_test.go
+++ b/internal/plugins/auto_update_replace_test.go
@@ -65,6 +65,59 @@ func TestAutoUpdateServiceCheckReplacesInstalledPluginsInPlace(t *testing.T) {
 	}
 }
 
+func TestAutoUpdateServiceCheckMatchesRenamedRepositoryByStablePluginIdentity(t *testing.T) {
+	installations := &fakeAutoUpdateInstallations{
+		list: []*Installation{
+			{ID: 41, RepositoryID: pluginRepositoryID(7), PluginID: "silo.tmdb", Version: "1.0.0", UpdatePolicy: "auto", Enabled: true},
+		},
+	}
+	installer := &fakeAutoUpdateInstaller{}
+	catalog := &fakeAutoUpdateCatalog{
+		entries: []CatalogEntry{
+			{
+				RepositoryID: 7,
+				RepoURL:      "https://github.com/Silo-Server/silo-plugins-metadata-tmdb",
+				Manifest: &pluginv1.PluginManifest{
+					PluginId: "silo.tmdb",
+					Version:  "1.1.0",
+				},
+			},
+		},
+		resolved: &ResolvedCatalogInstall{
+			RepositoryID: 7,
+			ArchiveURL:   "https://github.com/Silo-Server/silo-plugins-metadata-tmdb/releases/download/v1.1.0/plugin-linux-amd64",
+			Checksum:     "deadbeef",
+		},
+	}
+	service := NewAutoUpdateService(
+		&fakeAutoUpdateRepositories{list: []*Repository{{
+			ID:      7,
+			URL:     DefaultRepositoryURL,
+			Enabled: true,
+		}}},
+		installations,
+		catalog,
+		installer,
+		&fakeAutoUpdateHost{},
+		nil,
+		nil,
+	)
+
+	summary, err := service.Check(context.Background(), AutoUpdateOptions{})
+	if err != nil {
+		t.Fatalf("Check() returned error: %v", err)
+	}
+	if summary.UpdatesApplied != 1 {
+		t.Fatalf("UpdatesApplied = %d, want 1", summary.UpdatesApplied)
+	}
+	if len(installer.replaceBinary) != 1 || installer.replaceBinary[0].existingID != 41 {
+		t.Fatalf("replace binary calls = %#v, want one in-place replacement for installation 41", installer.replaceBinary)
+	}
+	if len(installations.deletedIDs) != 0 {
+		t.Fatalf("deleted installation IDs = %#v, want none", installations.deletedIDs)
+	}
+}
+
 func TestAutoUpdateServiceCheckFiresOnChangeAfterMutation(t *testing.T) {
 	newOnChangeService := func(installations *fakeAutoUpdateInstallations, opts AutoUpdateOptions, calls *int) (AutoUpdateSummary, error) {
 		catalog := &fakeAutoUpdateCatalog{


### PR DESCRIPTION
## Summary

Add a focused plugin auto-update regression test proving that a catalog package can move to a renamed GitHub repository while the stable `(repository_id, plugin_id)` identity still replaces the existing installation in place.

Part of #356.

## Validation

- `GOWORK=off go test ./internal/plugins`
- `git diff --check`

## Risk

Test-only change; no runtime behavior changes.

AI-assisted implementation: Codex prepared and validated this change.