### PR TITLE
test(plugins): use canonical metadata repository name

### DIFF
--- a/internal/plugins/auto_update_replace_test.go
+++ b/internal/plugins/auto_update_replace_test.go
@@ -76,7 +76,7 @@ func TestAutoUpdateServiceCheckMatchesRenamedRepositoryByStablePluginIdentity(t 
 		entries: []CatalogEntry{
 			{
 				RepositoryID: 7,
-				RepoURL:      "https://github.com/Silo-Server/silo-plugins-metadata-tmdb",
+				RepoURL:      "https://github.com/Silo-Server/silo-plugin-metadata-tmdb",
 				Manifest: &pluginv1.PluginManifest{
 					PluginId: "silo.tmdb",
 					Version:  "1.1.0",
@@ -85,7 +85,7 @@ func TestAutoUpdateServiceCheckMatchesRenamedRepositoryByStablePluginIdentity(t 
 		},
 		resolved: &ResolvedCatalogInstall{
 			RepositoryID: 7,
-			ArchiveURL:   "https://github.com/Silo-Server/silo-plugins-metadata-tmdb/releases/download/v1.1.0/plugin-linux-amd64",
+			ArchiveURL:   "https://github.com/Silo-Server/silo-plugin-metadata-tmdb/releases/download/v1.1.0/plugin-linux-amd64",
 			Checksum:     "deadbeef",
 		},
 	}


### PR DESCRIPTION
## Summary

Correct the repository URL used by the plugin rename compatibility regression test to the final `silo-plugin-metadata-tmdb` name.

Part of #356.

## Validation

- `GOWORK=off go test ./internal/plugins`
- `git diff --check`

## Risk

Test-only change; no runtime behavior changes.

AI-assisted implementation: Codex prepared and validated this change.