### PR TITLE
fix(streaming): stop killing healthy streams at the server WriteTimeout

### DIFF
--- a/docs/design/2026-07-09-streaming-write-deadline.md
+++ b/docs/design/2026-07-09-streaming-write-deadline.md
@@ -1,0 +1,179 @@
+# Streaming write-deadline fix: stop truncating streams at 120s without losing stalled-client protection
+
+**Status:** planned (2026-07-09)
+**Repos:** silo-server (primary), silo-apple (hardening follow-up)
+**Root-cause session:** live debugging on Apple TV, 2026-07-09 evening
+
+## Problem
+
+`cmd/silo/main.go:2373` sets `WriteTimeout: 120 * time.Second` on the main API
+`http.Server`. Go's `WriteTimeout` is an **absolute deadline from the start of each
+request**, not an idle timeout — so every response still being written at T+120s is
+killed mid-body with a clean connection close.
+
+Observed impact (2026-07-09, dev server, Apple TV loopback client):
+
+- Every direct-stream GET (`/api/v1/stream/{session_id}`) serving a 15.3 GB MKV was
+  cut at exactly 120s. Server log signature: `path=/api/v1/stream/` with
+  `duration_ms=120000` (three instances in a 3h window; more go unlogged when the
+  client disconnects first).
+- The Apple client's byte-cursor reconnect ladder silently absorbs most kills, so
+  playback "mostly works" — but when a kill lands during backpressure parking or a
+  demuxer resync, the client's 3-attempt `.prematureEOF` retry budget exhausts and it
+  performs a full teardown + new-session recovery (~5 s visible stop). Four such
+  failures in ~35 minutes of playback.
+- Confirmed by dual-path probe (long ranged GET consumed at playback rate): died at
+  ~123s direct to the origin and ~151s via the arkyncdn openresty edge (origin killed
+  the edge's upstream GET at 120s; the edge's buffer drained for the extra ~30s).
+  The CDN is exonerated — it only relayed the origin's truncation.
+
+Precedent inside the same file: the Jellyfin-compat listener (`main.go:2514`) and the
+Audiobookshelf-compat listener (`main.go:2535`) both already set `WriteTimeout: 0`
+because compat clients stream long responses. The main listener serves the exact same
+class of traffic for first-party clients and was never aligned.
+
+## Goals / non-goals
+
+Goals:
+
+1. Streaming/long responses are never killed while they are making progress.
+2. Genuinely stalled connections (client gone, TCP zombie, slow-loris) still get
+   reaped in bounded time — we do NOT simply set `WriteTimeout: 0` on the main
+   listener, because that removes mid-response stall protection entirely (a peer that
+   stops ACKing would block a handler goroutine + fd indefinitely).
+3. All non-streaming API routes keep today's 120s absolute protection unchanged.
+4. No client changes required for the fix to take effect (Android, web, Infuse/compat
+   benefit identically).
+
+Non-goals: CDN edge tuning; silo-server#333 control-plane restart work; the
+silo-apple `.prematureEOF` parking hardening (tracked as follow-up below, it is
+defense-in-depth once this lands).
+
+## Design: rolling per-write deadline for streaming handlers
+
+Semantics change for streaming responses only, from "must complete within 120s" to
+"must make progress at least every N seconds".
+
+### New helper (one small file, e.g. `internal/api/httpstream/rolling_deadline.go`)
+
+```go
+// RollingDeadlineWriter wraps a streaming http.ResponseWriter and pushes the
+// connection's write deadline forward on every successful write, so long
+// responses survive indefinitely while stalled ones die within `window`.
+type RollingDeadlineWriter struct {
+    w      http.ResponseWriter
+    rc     *http.ResponseController
+    window time.Duration // stall budget, e.g. 180s
+    step   time.Duration // min interval between deadline bumps, e.g. 15s
+    last   time.Time
+}
+
+func New(w http.ResponseWriter, window time.Duration) *RollingDeadlineWriter
+func (s *RollingDeadlineWriter) Write(p []byte) (int, error)  // bump-then-write
+func (s *RollingDeadlineWriter) ReadFrom(r io.Reader) (int64, error) // see below
+func (s *RollingDeadlineWriter) Header() http.Header
+func (s *RollingDeadlineWriter) WriteHeader(code int)
+func (s *RollingDeadlineWriter) Flush()
+func (s *RollingDeadlineWriter) Unwrap() http.ResponseWriter // ResponseController compat
+```
+
+Key points:
+
+- Uses `http.NewResponseController(w).SetWriteDeadline(time.Now().Add(window))` —
+  Go ≥ 1.20 (we are on 1.26.4). A per-request controller deadline **overrides** the
+  server-level `WriteTimeout` for that response, which is exactly the mechanism the
+  stdlib provides for this case.
+- Bumps are rate-limited (`step`, ~15s) so we do one `SetWriteDeadline` per ~15s of
+  wall time, not one per 32 KB chunk.
+- **`ReadFrom` must be implemented** and delegate to the underlying writer in bounded
+  slices (e.g. `io.CopyN(underlying, r, 64<<20)` per iteration, bumping the deadline
+  between iterations). Rationale: `http.ServeContent` → `io.Copy` uses the
+  `io.ReaderFrom` fast path on the response writer (sendfile for `*os.File`); a naive
+  wrapper without `ReadFrom` silently forfeits sendfile and burns CPU copying 15 GB
+  through userspace. Bounded-slice delegation keeps sendfile *and* the rolling
+  deadline.
+- First bump happens in `New` (covers the header write + first body bytes).
+- `window` default 180s, overridable via env `SILO_STREAM_WRITE_STALL_TIMEOUT`
+  (seconds). 180s > the Apple client's longest observed benign backpressure park
+  (~20s) and > outage-probe cadence with margin, while still reaping zombies in
+  minutes. Note: a paused client that stops reading its socket for >window will have
+  the connection reaped — that is fine and intended; the client's reconnect ladder
+  resumes at the byte cursor on unpause (this is today's behavior for ALL streams at
+  120s, so it is a strict improvement).
+
+### Application points (all on the main listener)
+
+| Path | File | Mechanism | Change |
+|---|---|---|---|
+| Direct play (the tonight failure) | `internal/playback/directplay.go:52` `ServeDirectPlay` | `http.ServeContent` of the full media file | wrap `w` before `ServeContent` |
+| Remux stream | `internal/playback/remux.go:226` `ServeRemux` (write loop `:255`) | manual chunked `Write`+`Flush` | wrap `w` (loop needs no change) |
+| Offline downloads | `internal/api/handlers/downloads.go:401` → `svc.ServeFile` | full media file download | wrap `w` at the handler before delegating |
+| Transcode-node proxy | `internal/api/handlers/playback.go:2998` `io.Copy(w, resp.Body)` | long-lived proxy of remote transcode output | wrap `w` |
+| Ebook/converted serving | `internal/api/handlers/ebook_convert_serve.go:159`, `ebook_reader.go:625` | `ServeContent`, files up to ~100s of MB; slow readers can exceed 120s | wrap `w` (cheap, same helper) |
+
+Explicitly **unchanged**:
+
+- Transcode HLS segments (`playback.go:2897 http.ServeFile`) — bounded few-second
+  files; 120s absolute is fine. (Harmless to wrap later if segment sizes grow.)
+- WebSockets (`/control/ws`) — hijacked connections manage their own deadlines;
+  tonight's WS survived 4+ minutes untouched, confirming no interaction.
+- Jellyfin/ABS compat listeners — separate `http.Server`s, already `WriteTimeout: 0`;
+  optionally migrate them to the rolling writer later so they regain stall
+  protection (follow-up, not required).
+- All JSON/image/API routes — keep the server-level 120s absolute deadline.
+
+`cmd/silo/main.go:2374` itself stays at `WriteTimeout: 120s`. That is the point: the
+global guard remains, streaming handlers opt out per-response with a better contract.
+
+## Server tests
+
+1. **Unit — rolling behavior:** wrapper on a fake ResponseController records deadline
+   bumps; assert bump on first write, rate-limited bumps thereafter, `ReadFrom`
+   chunking delegates and bumps per slice.
+2. **Integration — survives the server timeout:** `httptest.Server` with
+   `WriteTimeout: 1s`; handler streams 3s of throttled data through the wrapper
+   (window 2s). Assert full body received (fails without wrapper — this is the
+   regression test for tonight's bug).
+3. **Integration — stalled client still reaped:** wrapper with window 500ms writing
+   to a client that stops reading; assert handler write errors within ~window, not
+   never.
+4. **Regression:** non-streaming route on the same server still killed at
+   `WriteTimeout` (guard unchanged).
+
+## Validation on dev (after tonight's viewing)
+
+1. `make dev-deploy`.
+2. Re-run the range-GET probe (script preserved from tonight's session): sustained
+   open-ended GET at playback rate for ≥ 15 min on both direct and CDN paths; expect
+   zero early closes and no `duration_ms=120000` entries in the request log.
+3. Long ATV playback session (existing client build): expect zero
+   `prematureSourceEnd` teardowns over a full film.
+4. Spot-check normal API latency/behavior and one Jellyfin-compat client.
+
+## Follow-up workstream: silo-apple client hardening (separate branch)
+
+Defense-in-depth so any truncating origin/middlebox (not just our own bug) degrades
+to an invisible reconnect instead of a 5s rebuild:
+
+1. Park persistent mid-stream `.prematureEOF` into the existing outage ride-through
+   once the cursor-resume retries reproduce the same truncation offset
+   (`PlaybackOriginOutagePolicy.shouldPark`, `PlaybackSourceOriginStream.swift:159-173`;
+   writer then gets the 240s park allowance instead of the 10s deadline). Keep it
+   kill-switchable alongside `SILO_DISABLE_OUTAGE_RIDE_THROUGH`.
+2. Add `[CMP-ORIGIN]` logging: one line per origin connection end (cause, HTTP
+   status, cursor, bytes delivered, retry streak) — tonight the entire retry-and-give-up
+   sequence ran with zero log output.
+3. Verify reconnects use fresh connection state (AetherEngine builds a new URLSession
+   per reconnect to avoid poisoned keep-alive pools; our 3 rapid same-offset failures
+   while a fresh session succeeded seconds later is circumstantial evidence we reuse).
+4. Optional: raise `.prematureEOF` retry cap toward AE's progress-aware semantics.
+
+Android note: the server fix benefits Android identically with no client change;
+worth a later check of how its player handles a 120s kill today (it may have been
+absorbing them silently, or contributing to unexplained rebuffers).
+
+## Rollout
+
+Dev first (above), soak for a few days of normal viewing, then include in the next
+server release. The change is additive and per-handler; risk is localized to the
+wrapped streaming paths, and the global timeout still protects everything else.

--- a/internal/api/handlers/downloads.go
+++ b/internal/api/handlers/downloads.go
@@ -13,6 +13,7 @@ import (
 	apimw "github.com/Silo-Server/silo-server/internal/api/middleware"
 	"github.com/Silo-Server/silo-server/internal/catalog"
 	"github.com/Silo-Server/silo-server/internal/downloads"
+	"github.com/Silo-Server/silo-server/internal/httpstream"
 	"github.com/Silo-Server/silo-server/internal/playback"
 )
 
@@ -398,7 +399,10 @@ func (h *DownloadHandler) HandleDownloadFile(w http.ResponseWriter, r *http.Requ
 
 	profileID, deviceID, _, _ := managedIdentity(r)
 	filter := requestAccessFilter(r)
-	if err := h.svc.ServeFile(r.Context(), w, r, userID, profileID, deviceID, id, filter); err != nil {
+	// Full media downloads outlive the server's absolute WriteTimeout; roll
+	// the write deadline with progress instead.
+	sw := httpstream.NewRollingDeadlineWriter(w)
+	if err := h.svc.ServeFile(r.Context(), sw, r, userID, profileID, deviceID, id, filter); err != nil {
 		if errors.Is(err, downloads.ErrNotFound) || errors.Is(err, catalog.ErrItemNotFound) {
 			writeError(w, http.StatusNotFound, "not_found", "Download not found")
 			return

--- a/internal/api/handlers/ebook_convert_serve.go
+++ b/internal/api/handlers/ebook_convert_serve.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 
 	"github.com/Silo-Server/silo-server/internal/ebookconvert"
+	"github.com/Silo-Server/silo-server/internal/httpstream"
 	"github.com/Silo-Server/silo-server/internal/models"
 )
 
@@ -156,7 +157,7 @@ func serveConvertedEpub(w http.ResponseWriter, r *http.Request, file *models.Med
 
 	name := strings.TrimSuffix(filepath.Base(file.FilePath), filepath.Ext(file.FilePath)) + ".epub"
 	setConvertedEpubHeaders(w, file, key)
-	http.ServeContent(w, r, name, stat.ModTime(), f)
+	http.ServeContent(httpstream.NewRollingDeadlineWriter(w), r, name, stat.ModTime(), f)
 	return nil
 }
 

--- a/internal/api/handlers/ebook_reader.go
+++ b/internal/api/handlers/ebook_reader.go
@@ -20,6 +20,7 @@ import (
 
 	apimw "github.com/Silo-Server/silo-server/internal/api/middleware"
 	"github.com/Silo-Server/silo-server/internal/catalog"
+	"github.com/Silo-Server/silo-server/internal/httpstream"
 	"github.com/Silo-Server/silo-server/internal/models"
 )
 
@@ -622,7 +623,7 @@ func serveEbookInline(w http.ResponseWriter, r *http.Request, file *models.Media
 	// Ebook files are served inline on the API origin (and reachable via the
 	// ?token= query fallback), so browsers must never content-sniff them.
 	w.Header().Set("X-Content-Type-Options", "nosniff")
-	http.ServeContent(w, r, stat.Name(), stat.ModTime(), f)
+	http.ServeContent(httpstream.NewRollingDeadlineWriter(w), r, stat.Name(), stat.ModTime(), f)
 	return nil
 }
 

--- a/internal/api/handlers/playback.go
+++ b/internal/api/handlers/playback.go
@@ -24,6 +24,7 @@ import (
 	"github.com/Silo-Server/silo-server/internal/clientip"
 	"github.com/Silo-Server/silo-server/internal/config"
 	evt "github.com/Silo-Server/silo-server/internal/events"
+	"github.com/Silo-Server/silo-server/internal/httpstream"
 	"github.com/Silo-Server/silo-server/internal/markers"
 	"github.com/Silo-Server/silo-server/internal/models"
 	"github.com/Silo-Server/silo-server/internal/nodepool"
@@ -2183,7 +2184,8 @@ func (h *PlaybackHandler) HandleChangeAudioTrack(w http.ResponseWriter, r *http.
 						resp.StreamURL = proxyNode.URL + "/stream/remux/" + token
 					case playback.PlayTranscode:
 						resp.StreamURL = proxyNode.URL + "/stream/transcode/" + token + "/master.m3u8"
-					}				}
+					}
+				}
 			}
 		}
 	}
@@ -2994,8 +2996,11 @@ func (h *PlaybackHandler) proxyToTranscodeNode(w http.ResponseWriter, r *http.Re
 			w.Header().Add(k, v)
 		}
 	}
-	w.WriteHeader(resp.StatusCode)
-	io.Copy(w, resp.Body)
+	// Proxied transcode output can stream past the server's absolute
+	// WriteTimeout; roll the write deadline with progress instead.
+	sw := httpstream.NewRollingDeadlineWriter(w)
+	sw.WriteHeader(resp.StatusCode)
+	io.Copy(sw, resp.Body)
 }
 
 // maybeStartThrottler reads throttle settings and starts the throttler if enabled.

--- a/internal/api/middleware/metrics.go
+++ b/internal/api/middleware/metrics.go
@@ -72,6 +72,12 @@ func (w *statusWriter) Hijack() (net.Conn, *bufio.ReadWriter, error) {
 	return nil, nil, fmt.Errorf("underlying ResponseWriter does not implement http.Hijacker")
 }
 
+// Unwrap lets http.ResponseController reach the underlying connection (e.g.
+// for the per-response write deadlines used by streaming handlers).
+func (w *statusWriter) Unwrap() http.ResponseWriter {
+	return w.ResponseWriter
+}
+
 var (
 	uuidRegex    = regexp.MustCompile(`[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}`)
 	numericRegex = regexp.MustCompile(`/\d+(/|$)`)

--- a/internal/api/middleware/request_logger.go
+++ b/internal/api/middleware/request_logger.go
@@ -101,3 +101,9 @@ func (w *requestStatusWriter) Hijack() (net.Conn, *bufio.ReadWriter, error) {
 	}
 	return nil, nil, fmt.Errorf("underlying ResponseWriter does not implement http.Hijacker")
 }
+
+// Unwrap lets http.ResponseController reach the underlying connection (e.g.
+// for the per-response write deadlines used by streaming handlers).
+func (w *requestStatusWriter) Unwrap() http.ResponseWriter {
+	return w.ResponseWriter
+}

--- a/internal/api/middleware/stream_deadline_chain_test.go
+++ b/internal/api/middleware/stream_deadline_chain_test.go
@@ -1,0 +1,65 @@
+package middleware_test
+
+import (
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	chimw "github.com/go-chi/chi/v5/middleware"
+
+	apimw "github.com/Silo-Server/silo-server/internal/api/middleware"
+	"github.com/Silo-Server/silo-server/internal/httpstream"
+)
+
+// TestStreamingDeadlineSurvivesMiddlewareChain guards the Unwrap chain: the
+// streaming handlers' rolling write deadline only works if every
+// ResponseWriter wrapper between the server and the handler implements
+// Unwrap, so http.ResponseController can reach the connection. This assembles
+// the real wrapping middlewares from the main API chain (RequestLogger,
+// Metrics, Compress) around a streaming handler and proves a slow response
+// outlives the server's WriteTimeout. If a new middleware wraps the writer
+// without Unwrap, this fails with a truncated body.
+func TestStreamingDeadlineSurvivesMiddlewareChain(t *testing.T) {
+	const (
+		writeEvery = 50 * time.Millisecond
+		writes     = 60 // ~3s total, 3x the server WriteTimeout
+		chunk      = "0123456789abcdef"
+	)
+
+	var handler http.Handler = http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		sw := httpstream.NewRollingDeadlineWriter(w)
+		sw.WriteHeader(http.StatusOK)
+		for i := 0; i < writes; i++ {
+			if _, err := sw.Write([]byte(chunk)); err != nil {
+				return
+			}
+			sw.Flush()
+			time.Sleep(writeEvery)
+		}
+	})
+	// Same order as internal/api/router.go: RequestLogger, Metrics, Compress.
+	handler = chimw.Compress(5)(handler)
+	handler = apimw.Metrics(handler)
+	handler = apimw.RequestLogger("test-node")(handler)
+
+	srv := httptest.NewUnstartedServer(handler)
+	srv.Config.WriteTimeout = 1 * time.Second
+	srv.Start()
+	defer srv.Close()
+
+	resp, err := http.Get(srv.URL)
+	if err != nil {
+		t.Fatalf("GET: %v", err)
+	}
+	defer resp.Body.Close()
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		t.Fatalf("stream died through middleware chain at %d bytes: %v (a wrapper without Unwrap?)", len(body), err)
+	}
+	if want := writes * len(chunk); len(body) != want {
+		t.Fatalf("short body through middleware chain: got %d bytes, want %d", len(body), want)
+	}
+}

--- a/internal/httpstream/rolling_deadline.go
+++ b/internal/httpstream/rolling_deadline.go
@@ -1,0 +1,138 @@
+// Package httpstream provides helpers for HTTP handlers that stream large or
+// long-lived response bodies (direct play, remux, downloads).
+//
+// The main API server sets an absolute WriteTimeout, which kills any response
+// still being written when the deadline elapses — including perfectly healthy
+// multi-gigabyte media streams. RollingDeadlineWriter replaces that contract
+// for streaming responses only: the connection's write deadline is pushed
+// forward on every successful write, so a response that keeps making progress
+// lives indefinitely while a stalled one is still reaped within the window.
+package httpstream
+
+import (
+	"io"
+	"net/http"
+	"os"
+	"strconv"
+	"time"
+)
+
+const (
+	// DefaultStallWindow is how long a streaming response may go without
+	// forward progress before its connection is reaped.
+	DefaultStallWindow = 180 * time.Second
+
+	// stallWindowEnv overrides DefaultStallWindow (integer seconds).
+	stallWindowEnv = "SILO_STREAM_WRITE_STALL_TIMEOUT"
+
+	// bumpStep rate-limits deadline updates so a busy stream issues one
+	// SetWriteDeadline per step rather than one per 32 KB chunk.
+	bumpStep = 15 * time.Second
+
+	// readFromChunk bounds each ReadFrom slice so the deadline keeps rolling
+	// during zero-copy (sendfile) transfers of large files.
+	readFromChunk int64 = 64 << 20
+)
+
+// StallWindow returns the configured stall window for streaming responses.
+func StallWindow() time.Duration {
+	if v := os.Getenv(stallWindowEnv); v != "" {
+		if secs, err := strconv.Atoi(v); err == nil && secs > 0 {
+			return time.Duration(secs) * time.Second
+		}
+	}
+	return DefaultStallWindow
+}
+
+// RollingDeadlineWriter wraps a streaming response and rolls the connection's
+// write deadline forward as the body makes progress. Construct with
+// NewRollingDeadlineWriter and use in place of the original ResponseWriter.
+//
+// If the underlying transport does not support per-response write deadlines
+// (SetWriteDeadline errors), the wrapper degrades to a plain pass-through and
+// the server-level WriteTimeout, if any, stays in effect.
+type RollingDeadlineWriter struct {
+	w        http.ResponseWriter
+	rc       *http.ResponseController
+	window   time.Duration
+	step     time.Duration
+	lastBump time.Time
+	disabled bool
+}
+
+// NewRollingDeadlineWriter wraps w with the configured stall window.
+func NewRollingDeadlineWriter(w http.ResponseWriter) *RollingDeadlineWriter {
+	return newRollingDeadlineWriter(w, StallWindow(), bumpStep)
+}
+
+func newRollingDeadlineWriter(w http.ResponseWriter, window, step time.Duration) *RollingDeadlineWriter {
+	s := &RollingDeadlineWriter{
+		w:      w,
+		rc:     http.NewResponseController(w),
+		window: window,
+		step:   step,
+	}
+	s.bump()
+	return s
+}
+
+func (s *RollingDeadlineWriter) bump() {
+	if s.disabled {
+		return
+	}
+	now := time.Now()
+	if !s.lastBump.IsZero() && now.Sub(s.lastBump) < s.step {
+		return
+	}
+	if err := s.rc.SetWriteDeadline(now.Add(s.window)); err != nil {
+		s.disabled = true
+		return
+	}
+	s.lastBump = now
+}
+
+func (s *RollingDeadlineWriter) Header() http.Header { return s.w.Header() }
+
+func (s *RollingDeadlineWriter) WriteHeader(code int) {
+	s.bump()
+	s.w.WriteHeader(code)
+}
+
+func (s *RollingDeadlineWriter) Write(p []byte) (int, error) {
+	s.bump()
+	return s.w.Write(p)
+}
+
+// ReadFrom preserves the underlying ResponseWriter's io.ReaderFrom fast path
+// (sendfile for *os.File bodies, as used by http.ServeContent) while still
+// rolling the deadline between bounded slices.
+func (s *RollingDeadlineWriter) ReadFrom(r io.Reader) (int64, error) {
+	rf, ok := s.w.(io.ReaderFrom)
+	if !ok {
+		// writerOnly hides this method so io.Copy doesn't recurse into it.
+		s.bump()
+		return io.Copy(writerOnly{s}, r)
+	}
+	var total int64
+	for {
+		s.bump()
+		n, err := rf.ReadFrom(io.LimitReader(r, readFromChunk))
+		total += n
+		if err != nil {
+			return total, err
+		}
+		if n < readFromChunk {
+			return total, nil
+		}
+	}
+}
+
+func (s *RollingDeadlineWriter) Flush() {
+	s.bump()
+	_ = s.rc.Flush()
+}
+
+// Unwrap lets http.ResponseController traverse to the underlying writer.
+func (s *RollingDeadlineWriter) Unwrap() http.ResponseWriter { return s.w }
+
+type writerOnly struct{ io.Writer }

--- a/internal/httpstream/rolling_deadline_test.go
+++ b/internal/httpstream/rolling_deadline_test.go
@@ -1,0 +1,182 @@
+package httpstream
+
+import (
+	"bufio"
+	"fmt"
+	"io"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+)
+
+// TestStreamSurvivesServerWriteTimeout is the regression test for the 120s
+// stream-truncation bug: a response that keeps making progress must outlive
+// the server's absolute WriteTimeout when wrapped.
+func TestStreamSurvivesServerWriteTimeout(t *testing.T) {
+	const (
+		writeEvery = 50 * time.Millisecond
+		writes     = 60 // ~3s total, 3x the server WriteTimeout
+		chunk      = "0123456789abcdef"
+	)
+
+	srv := httptest.NewUnstartedServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		sw := newRollingDeadlineWriter(w, 2*time.Second, 0 /* bump every write */)
+		sw.WriteHeader(http.StatusOK)
+		for i := 0; i < writes; i++ {
+			if _, err := sw.Write([]byte(chunk)); err != nil {
+				return
+			}
+			sw.Flush()
+			time.Sleep(writeEvery)
+		}
+	}))
+	srv.Config.WriteTimeout = 1 * time.Second
+	srv.Start()
+	defer srv.Close()
+
+	resp, err := http.Get(srv.URL)
+	if err != nil {
+		t.Fatalf("GET: %v", err)
+	}
+	defer resp.Body.Close()
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		t.Fatalf("stream died before completion (got %d bytes): %v", len(body), err)
+	}
+	if want := writes * len(chunk); len(body) != want {
+		t.Fatalf("short body: got %d bytes, want %d", len(body), want)
+	}
+}
+
+// TestUnwrappedStreamStillKilledAtWriteTimeout proves the server-level guard
+// is unchanged for handlers that do not opt in.
+func TestUnwrappedStreamStillKilledAtWriteTimeout(t *testing.T) {
+	srv := httptest.NewUnstartedServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		f := w.(http.Flusher)
+		for i := 0; i < 60; i++ {
+			if _, err := w.Write([]byte("0123456789abcdef")); err != nil {
+				return
+			}
+			f.Flush()
+			time.Sleep(50 * time.Millisecond)
+		}
+	}))
+	srv.Config.WriteTimeout = 500 * time.Millisecond
+	srv.Start()
+	defer srv.Close()
+
+	resp, err := http.Get(srv.URL)
+	if err != nil {
+		return // connection died before headers: also a kill, test passes
+	}
+	defer resp.Body.Close()
+
+	body, err := io.ReadAll(resp.Body)
+	if err == nil && len(body) == 60*16 {
+		t.Fatal("unwrapped stream survived the server WriteTimeout; guard is gone")
+	}
+}
+
+// TestStalledClientReaped proves the wrapper still bounds a genuinely stalled
+// connection: a client that stops reading must cause a write error within
+// roughly the stall window, not never.
+func TestStalledClientReaped(t *testing.T) {
+	handlerDone := make(chan error, 1)
+	srv := httptest.NewUnstartedServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		sw := newRollingDeadlineWriter(w, 1*time.Second, 0)
+		sw.WriteHeader(http.StatusOK)
+		buf := make([]byte, 1<<20)
+		var err error
+		for i := 0; i < 256; i++ { // up to 256 MB >> any socket buffer
+			if _, err = sw.Write(buf); err != nil {
+				break
+			}
+			sw.Flush()
+		}
+		handlerDone <- err
+	}))
+	srv.Config.WriteTimeout = 0 // isolate: only the rolling deadline may reap
+	srv.Start()
+	defer srv.Close()
+
+	conn, err := net.Dial("tcp", strings.TrimPrefix(srv.URL, "http://"))
+	if err != nil {
+		t.Fatalf("dial: %v", err)
+	}
+	defer conn.Close()
+	fmt.Fprintf(conn, "GET / HTTP/1.1\r\nHost: x\r\n\r\n")
+	// Read just the status line, then stop reading entirely.
+	if _, err := bufio.NewReader(io.LimitReader(conn, 32)).ReadString('\n'); err != nil {
+		t.Fatalf("status line: %v", err)
+	}
+
+	select {
+	case err := <-handlerDone:
+		if err == nil {
+			t.Fatal("handler finished 256MB into a non-reading client without error")
+		}
+	case <-time.After(30 * time.Second):
+		t.Fatal("stalled client was never reaped by the rolling deadline")
+	}
+}
+
+// TestReadFromPreservesCompletion exercises the io.ReaderFrom path used by
+// http.ServeContent (sendfile) under a server WriteTimeout shorter than the
+// transfer, with a source large enough to require multiple bounded slices.
+func TestReadFromPreservesCompletion(t *testing.T) {
+	const totalSize = 8 << 20
+
+	srv := httptest.NewUnstartedServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		sw := newRollingDeadlineWriter(w, 2*time.Second, 0)
+		sw.WriteHeader(http.StatusOK)
+		src := &slowReader{r: io.LimitReader(neverEnding('x'), totalSize), delay: 200 * time.Microsecond}
+		// io.Copy must take sw's ReadFrom path, as http.ServeContent does.
+		if _, err := io.Copy(sw, src); err != nil {
+			return
+		}
+	}))
+	srv.Config.WriteTimeout = 1 * time.Second
+	srv.Start()
+	defer srv.Close()
+
+	resp, err := http.Get(srv.URL)
+	if err != nil {
+		t.Fatalf("GET: %v", err)
+	}
+	defer resp.Body.Close()
+	n, err := io.Copy(io.Discard, resp.Body)
+	if err != nil {
+		t.Fatalf("stream died at %d bytes: %v", n, err)
+	}
+	if n != totalSize {
+		t.Fatalf("short body: got %d, want %d", n, totalSize)
+	}
+}
+
+type neverEnding byte
+
+func (b neverEnding) Read(p []byte) (int, error) {
+	for i := range p {
+		p[i] = byte(b)
+	}
+	return len(p), nil
+}
+
+// slowReader throttles reads so the transfer outlives the server WriteTimeout.
+type slowReader struct {
+	r     io.Reader
+	delay time.Duration
+}
+
+func (s *slowReader) Read(p []byte) (int, error) {
+	time.Sleep(s.delay)
+	if len(p) > 32<<10 {
+		p = p[:32<<10]
+	}
+	return s.r.Read(p)
+}

--- a/internal/playback/directplay.go
+++ b/internal/playback/directplay.go
@@ -5,6 +5,8 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+
+	"github.com/Silo-Server/silo-server/internal/httpstream"
 )
 
 // MimeFromExtension returns a MIME type based on the file extension.
@@ -50,6 +52,9 @@ func MimeFromExtension(name string) string {
 // Range requests, conditional requests (If-Modified-Since, If-None-Match),
 // and Content-Type detection.
 func ServeDirectPlay(w http.ResponseWriter, r *http.Request, filePath string) error {
+	// Media bodies routinely take longer than the server's absolute
+	// WriteTimeout; roll the write deadline with progress instead.
+	w = httpstream.NewRollingDeadlineWriter(w)
 	f, err := os.Open(filePath)
 	if err != nil {
 		if os.IsNotExist(err) {

--- a/internal/playback/remux.go
+++ b/internal/playback/remux.go
@@ -11,6 +11,8 @@ import (
 	"os/exec"
 	"strconv"
 	"sync"
+
+	"github.com/Silo-Server/silo-server/internal/httpstream"
 )
 
 var (
@@ -224,6 +226,9 @@ func containerMIME(format string) string {
 // total size is not known in advance.
 // When transcodeAudio is true, audio is transcoded to AAC while video is copied.
 func ServeRemux(w http.ResponseWriter, r *http.Request, filePath, outputFormat string, seekSeconds float64, transcodeAudio bool, audioTrackIndex int, dvProfile int) error {
+	// Remux output streams for the length of the title; roll the write
+	// deadline with progress instead of the server's absolute WriteTimeout.
+	w = httpstream.NewRollingDeadlineWriter(w)
 	// Check file exists before starting ffmpeg to return a proper 404.
 	// Headers must be written before streaming begins, so we can't detect
 	// ffmpeg errors after WriteHeader(200) has been sent.


### PR DESCRIPTION
## Problem

`cmd/silo/main.go` sets `WriteTimeout: 120s` on the main API server. Go's `WriteTimeout` is an **absolute deadline from request start**, not an idle timeout — every streaming response still being written at T+120s is killed mid-body with a clean connection close. Server log signature: `path=/api/v1/stream/` entries with `duration_ms=120000`.

Live impact (root-caused on an Apple TV, 2026-07-09): every direct-stream of a 15.3 GB MKV died at exactly 120s. The client's byte-cursor reconnect absorbed most kills invisibly, but when one landed during backpressure parking or a demuxer resync, the client's retry budget exhausted and it did a full player teardown — a ~5s visible stop, roughly every 5–10 minutes, plus (on older client builds) audio desync seeded by the restart. Both compat listeners (`jellycompat`, ABS) already set `WriteTimeout: 0` for exactly this reason; the main listener serving first-party clients was never aligned.

## Fix

**Rolling per-write deadline instead of timeout removal** — new `internal/httpstream.RollingDeadlineWriter`:

- Pushes the connection's write deadline forward on progress via `http.ResponseController.SetWriteDeadline` (semantics: "must make progress every 180s" instead of "must finish in 120s"). Window overridable via `SILO_STREAM_WRITE_STALL_TIMEOUT`.
- Stalled/zombie connections are still reaped within the window — we deliberately do **not** set `WriteTimeout: 0`.
- `ReadFrom` delegates in bounded slices so `http.ServeContent` keeps its `sendfile` fast path for direct play.
- Deadline bumps rate-limited to one per 15s, not one per 32 KB chunk.

Wired into the five long-response paths on the main listener: direct play, remux, offline downloads, the transcode-node proxy, and ebook serving. The server-level 120s guard is unchanged for every other route.

**Middleware Unwrap fixes:** the metrics `statusWriter` and request-logger `requestStatusWriter` didn't implement `Unwrap`, so `http.ResponseController` couldn't traverse to the connection and the wrapper silently self-disabled (the first dev deploy proved this the hard way). Both now implement `Unwrap`, and a middleware-chain integration test (`stream_deadline_chain_test.go`) assembles the real chain (RequestLogger → Metrics → Compress) around a streaming handler with a 1s server WriteTimeout — it fails on truncation if a future wrapper breaks the chain again.

## Tests

- `internal/httpstream`: stream survives server WriteTimeout (regression test for the bug); unwrapped stream is still killed (guard intact); stalled client reaped within window; `ReadFrom` path completes past WriteTimeout.
- `internal/api/middleware`: chain-integration guard test.
- Full `./internal/playback` and `./internal/api/handlers` suites pass.

## Validation on dev

- Sustained range-GETs at playback rate: **200s / 512 MB direct** and **300s / 768 MB via CDN** with no early close (both previously died at ~120s).
- Zero `duration_ms=120000` stream entries since deploy.
- Design doc: `docs/design/2026-07-09-streaming-write-deadline.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Long-running media streams, downloads, remuxed playback, and ebook transfers can now continue beyond the server’s fixed write timeout while data is actively being delivered.
  * Stalled connections are still terminated after a bounded inactivity period.
  * Streaming behavior remains compatible with range requests and efficient file transfers.

* **Documentation**
  * Added design and rollout guidance for rolling streaming write deadlines.

* **Tests**
  * Added coverage for prolonged streaming, stalled clients, middleware compatibility, and file-transfer behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->