### PR TITLE
fix(web): derive settings language options from canonical language list

### DIFF
--- a/web/src/lib/settingsManifest.ts
+++ b/web/src/lib/settingsManifest.ts
@@ -1,3 +1,5 @@
+import { LANGUAGES } from "@/player/utils/languageNames";
+
 export type SettingScope = "user" | "device";
 export type SettingControl = "switch" | "select" | "slider" | "json";
 
@@ -21,20 +23,13 @@ export interface SettingDefinition {
   summary?: (value: string | null | undefined) => string;
 }
 
+/**
+ * Language choices for settings dropdowns, derived from the canonical
+ * language list so every supported language stays selectable.
+ */
 export const LANGUAGE_OPTIONS: SettingOption[] = [
   { value: "", label: "No preference" },
-  { value: "en", label: "English" },
-  { value: "es", label: "Spanish" },
-  { value: "fr", label: "French" },
-  { value: "de", label: "German" },
-  { value: "it", label: "Italian" },
-  { value: "pt", label: "Portuguese" },
-  { value: "ja", label: "Japanese" },
-  { value: "ko", label: "Korean" },
-  { value: "zh", label: "Chinese" },
-  { value: "ru", label: "Russian" },
-  { value: "ar", label: "Arabic" },
-  { value: "hi", label: "Hindi" },
+  ...LANGUAGES.map(({ code, label }) => ({ value: code, label })),
 ];
 
 const definitions: SettingDefinition[] = [

--- a/web/src/pages/settings/libraryPlaybackPreferences.ts
+++ b/web/src/pages/settings/libraryPlaybackPreferences.ts
@@ -1,5 +1,6 @@
 import type { LibraryPlaybackPreference } from "@/api/types";
 import type { UpdateLibraryPlaybackPreferenceRequest } from "@/hooks/queries/libraryPlaybackPreferences";
+import { getLanguageName, LANGUAGES } from "@/player/utils/languageNames";
 
 export const INHERIT_VALUE = "inherit";
 export const NONE_VALUE = "none";
@@ -8,20 +9,11 @@ export const ORIGINAL_LANGUAGE_LABEL = "Original Language";
 export const DEFAULT_SUBTITLE_MODE = "auto";
 export const DEFAULT_SHOW_FORCED_SUBTITLES = true;
 
-export const LANGUAGE_OPTIONS = [
-  { code: "en", label: "English" },
-  { code: "es", label: "Spanish" },
-  { code: "fr", label: "French" },
-  { code: "de", label: "German" },
-  { code: "it", label: "Italian" },
-  { code: "pt", label: "Portuguese" },
-  { code: "ja", label: "Japanese" },
-  { code: "ko", label: "Korean" },
-  { code: "zh", label: "Chinese" },
-  { code: "ru", label: "Russian" },
-  { code: "ar", label: "Arabic" },
-  { code: "hi", label: "Hindi" },
-] as const;
+/**
+ * Language choices for per-library playback overrides, re-exported from the
+ * canonical language list so every supported language stays selectable.
+ */
+export const LANGUAGE_OPTIONS = LANGUAGES;
 
 export const SUBTITLE_MODE_OPTIONS = [
   { value: "auto", label: "Auto" },
@@ -40,8 +32,11 @@ export function getLanguageLabel(code: string) {
   if (code === ORIGINAL_LANGUAGE_VALUE) {
     return ORIGINAL_LANGUAGE_LABEL;
   }
+  if (!code) {
+    return code;
+  }
 
-  return LANGUAGE_OPTIONS.find((language) => language.code === code)?.label ?? code;
+  return getLanguageName(code);
 }
 
 export function getSubtitleModeLabel(mode: string) {


### PR DESCRIPTION
## Problem

Dutch (and 24 other languages) couldn't be selected in the settings language dropdowns — profile "Preferred subtitle language", spoken-language and metadata-language selects, the device "Preferred audio language" setting, and the per-library audio/subtitle overrides. Two separate hardcoded 12-language lists (`web/src/lib/settingsManifest.ts`, `web/src/pages/settings/libraryPlaybackPreferences.ts`) had drifted from the canonical 37-language list in `web/src/player/utils/languageNames.ts`, and stored codes outside the 12 (e.g. `nl`) rendered as raw codes in summaries.

## Approach

Deleted both hardcoded lists and derived them from the shared `LANGUAGES` array:

- `settingsManifest.LANGUAGE_OPTIONS` maps it to the `{value,label}` shape with the "No preference" entry pinned first.
- `libraryPlaybackPreferences.LANGUAGE_OPTIONS` re-exports `LANGUAGES` directly (same `{code,label}` shape, so `LibrarySettings.tsx` needed no change).
- `getLanguageLabel()` now delegates to `getLanguageName()`, so any stored code renders a proper display name everywhere.

No backend change needed — settings values are free-form ISO codes end to end and the backend already normalizes any valid tag.

## Risks

- Dropdowns are now alphabetized by label instead of the old ad-hoc English-first order — this matches the other language dropdowns that already use `LANGUAGES`, but is a visible ordering change.
- `getLanguageLabel` on an unknown code now returns a capitalized fallback instead of the raw code — cosmetic only.

## Verification

`pnpm run lint`, `pnpm run format:check`, `tsc -b` all clean; related vitest suites (`LibrarySettings.test.tsx`, `libraryPlaybackPreferences.test.ts`) 16/16 passing.

AI-use disclosure: authored by Claude (Claude Code) under human direction and review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved language preference consistency by using the canonical language list across settings.
  * Added support for displaying language labels reliably, including custom or empty language values.
  * Ensured the “No preference” option remains available in language settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->