### PR TITLE
fix(overlays): derive dynamic-range badges from Dolby Vision metadata

### DIFF
--- a/internal/overlays/summary.go
+++ b/internal/overlays/summary.go
@@ -73,10 +73,8 @@ func bestFile(files []*models.MediaFile) *models.MediaFile {
 // first-scanned file that only carries the bare HDR boolean (e.g. a stale
 // pre-DV probe row). Ties keep the earliest file in the slice.
 func rangeRank(file *models.MediaFile) int {
-	for _, track := range file.VideoTracks {
-		if track.DolbyVision != "" {
-			return 3
-		}
+	if hasDolbyVision(file.VideoTracks) {
+		return 3
 	}
 	if hdrTypeFromTracks(file.VideoTracks) != "" {
 		return 2
@@ -85,6 +83,19 @@ func rangeRank(file *models.MediaFile) int {
 		return 1
 	}
 	return 0
+}
+
+// hasDolbyVision reports whether any track carries Dolby Vision metadata.
+// Probed rows set DolbyVision and DVProfile together, but seeded/imported
+// rows may carry only dv_profile or a DOVI* video_range_type.
+func hasDolbyVision(tracks []models.VideoTrack) bool {
+	for _, track := range tracks {
+		if track.DolbyVision != "" || track.DVProfile > 0 ||
+			strings.HasPrefix(track.VideoRangeType, "DOVI") {
+			return true
+		}
+	}
+	return false
 }
 
 func normalizeResolution(value string) string {
@@ -114,13 +125,7 @@ func resolutionRank(value string) int {
 }
 
 func normalizeHDR(file *models.MediaFile) string {
-	hasDV := false
-	for _, track := range file.VideoTracks {
-		if track.DolbyVision != "" {
-			hasDV = true
-			break
-		}
-	}
+	hasDV := hasDolbyVision(file.VideoTracks)
 	hdrType := hdrTypeFromTracks(file.VideoTracks)
 
 	switch {

--- a/internal/overlays/summary.go
+++ b/internal/overlays/summary.go
@@ -51,18 +51,40 @@ func BuildSummary(files []*models.MediaFile) *Summary {
 
 func bestFile(files []*models.MediaFile) *models.MediaFile {
 	var best *models.MediaFile
-	bestRank := -1
+	bestRes := -1
+	bestRange := -1
 	for _, file := range files {
 		if file == nil {
 			continue
 		}
-		rank := resolutionRank(file.Resolution)
-		if best == nil || rank > bestRank {
+		res := resolutionRank(file.Resolution)
+		rng := rangeRank(file)
+		if best == nil || res > bestRes || (res == bestRes && rng > bestRange) {
 			best = file
-			bestRank = rank
+			bestRes = res
+			bestRange = rng
 		}
 	}
 	return best
+}
+
+// rangeRank orders files with equal resolution by the richness of their
+// dynamic-range metadata so a Dolby Vision version is not masked by a
+// first-scanned file that only carries the bare HDR boolean (e.g. a stale
+// pre-DV probe row). Ties keep the earliest file in the slice.
+func rangeRank(file *models.MediaFile) int {
+	for _, track := range file.VideoTracks {
+		if track.DolbyVision != "" {
+			return 3
+		}
+	}
+	if hdrTypeFromTracks(file.VideoTracks) != "" {
+		return 2
+	}
+	if file.HDR {
+		return 1
+	}
+	return 0
 }
 
 func normalizeResolution(value string) string {

--- a/internal/overlays/summary.go
+++ b/internal/overlays/summary.go
@@ -142,9 +142,22 @@ func normalizeHDR(file *models.MediaFile) string {
 	}
 }
 
-// hdrTypeFromTracks inspects video track color transfer to distinguish HDR variants.
+// hdrTypeFromTracks distinguishes HDR variants from the scanner-derived
+// video_range_type enum (HDR10, HDR10Plus, HLG, DOVIWith*) with color
+// transfer as a fallback, so rows without probed color metadata (e.g.
+// catalog-seeded imports) still resolve. Keep in sync with trackHdrType in
+// web/src/lib/videoRange.ts.
 func hdrTypeFromTracks(tracks []models.VideoTrack) string {
 	for _, track := range tracks {
+		rangeType := strings.TrimSpace(track.VideoRangeType)
+		switch {
+		case track.HDR10Plus || strings.Contains(rangeType, "HDR10Plus"):
+			return "HDR10+"
+		case rangeType == "HDR10" || strings.HasSuffix(rangeType, "WithHDR10"):
+			return "HDR10"
+		case rangeType == "HLG" || strings.HasSuffix(rangeType, "WithHLG"):
+			return "HLG"
+		}
 		ct := strings.ToLower(track.ColorTransfer)
 		switch {
 		case strings.Contains(ct, "smpte2084"):

--- a/internal/overlays/summary_test.go
+++ b/internal/overlays/summary_test.go
@@ -239,6 +239,17 @@ func TestNormalizeHDR(t *testing.T) {
 				ColorTransfer: "smpte2084",
 			}},
 		}, "DV HDR10"},
+		{"dv via profile number only", &models.MediaFile{
+			HDR:         true,
+			VideoTracks: []models.VideoTrack{{DVProfile: 5}},
+		}, "DV"},
+		{"dv via DOVI range type only", &models.MediaFile{
+			HDR: true,
+			VideoTracks: []models.VideoTrack{{
+				VideoRangeType: "DOVIWithHDR10",
+				ColorTransfer:  "smpte2084",
+			}},
+		}, "DV HDR10"},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
@@ -265,6 +276,11 @@ func TestBestFileRangeTieBreaking(t *testing.T) {
 		}},
 	}
 	sdr := &models.MediaFile{Resolution: "2160p"}
+	dvProfileOnly := &models.MediaFile{
+		Resolution:  "2160p",
+		HDR:         true,
+		VideoTracks: []models.VideoTrack{{DVProfile: 5}},
+	}
 	lowResDV := &models.MediaFile{
 		Resolution:  "1080p",
 		HDR:         true,
@@ -281,6 +297,8 @@ func TestBestFileRangeTieBreaking(t *testing.T) {
 			[]*models.MediaFile{genericHDR, dv}, dv},
 		{"dv beats explicit hdr10 at same resolution",
 			[]*models.MediaFile{explicitHDR10, dv}, dv},
+		{"dv via profile number only still outranks generic hdr",
+			[]*models.MediaFile{genericHDR, dvProfileOnly}, dvProfileOnly},
 		{"explicit hdr10 beats bare boolean at same resolution",
 			[]*models.MediaFile{genericHDR, explicitHDR10}, explicitHDR10},
 		{"bare boolean beats sdr at same resolution",

--- a/internal/overlays/summary_test.go
+++ b/internal/overlays/summary_test.go
@@ -250,6 +250,32 @@ func TestNormalizeHDR(t *testing.T) {
 				ColorTransfer:  "smpte2084",
 			}},
 		}, "DV HDR10"},
+		{"hdr10 via range type without color transfer", &models.MediaFile{
+			HDR:         true,
+			VideoTracks: []models.VideoTrack{{VideoRangeType: "HDR10"}},
+		}, "HDR10"},
+		{"hlg via range type without color transfer", &models.MediaFile{
+			HDR:         true,
+			VideoTracks: []models.VideoTrack{{VideoRangeType: "HLG"}},
+		}, "HLG"},
+		{"hdr10+ via flag", &models.MediaFile{
+			HDR: true,
+			VideoTracks: []models.VideoTrack{{
+				HDR10Plus:     true,
+				ColorTransfer: "smpte2084",
+			}},
+		}, "HDR10+"},
+		{"hdr10+ via range type", &models.MediaFile{
+			HDR:         true,
+			VideoTracks: []models.VideoTrack{{VideoRangeType: "HDR10Plus"}},
+		}, "HDR10+"},
+		{"dv with hdr10+ base layer", &models.MediaFile{
+			HDR:         true,
+			VideoTracks: []models.VideoTrack{{VideoRangeType: "DOVIWithELHDR10Plus"}},
+		}, "DV HDR10+"},
+		{"sdr range type stays sdr", &models.MediaFile{
+			VideoTracks: []models.VideoTrack{{VideoRangeType: "SDR"}},
+		}, ""},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
@@ -286,6 +312,11 @@ func TestBestFileRangeTieBreaking(t *testing.T) {
 		HDR:         true,
 		VideoTracks: []models.VideoTrack{{DolbyVision: "Profile 5"}},
 	}
+	rangeTypeHDR10 := &models.MediaFile{
+		Resolution:  "2160p",
+		HDR:         true,
+		VideoTracks: []models.VideoTrack{{VideoRangeType: "HDR10"}},
+	}
 
 	cases := []struct {
 		name  string
@@ -299,6 +330,8 @@ func TestBestFileRangeTieBreaking(t *testing.T) {
 			[]*models.MediaFile{explicitHDR10, dv}, dv},
 		{"dv via profile number only still outranks generic hdr",
 			[]*models.MediaFile{genericHDR, dvProfileOnly}, dvProfileOnly},
+		{"range-type-only hdr10 outranks bare boolean",
+			[]*models.MediaFile{genericHDR, rangeTypeHDR10}, rangeTypeHDR10},
 		{"explicit hdr10 beats bare boolean at same resolution",
 			[]*models.MediaFile{genericHDR, explicitHDR10}, explicitHDR10},
 		{"bare boolean beats sdr at same resolution",

--- a/internal/overlays/summary_test.go
+++ b/internal/overlays/summary_test.go
@@ -212,6 +212,114 @@ func TestNormalizeReleaseType(t *testing.T) {
 	}
 }
 
+func TestNormalizeHDR(t *testing.T) {
+	cases := []struct {
+		name string
+		file *models.MediaFile
+		want string
+	}{
+		{"sdr", &models.MediaFile{}, ""},
+		{"bare boolean", &models.MediaFile{HDR: true}, "HDR"},
+		{"hdr10 via color transfer", &models.MediaFile{
+			HDR:         true,
+			VideoTracks: []models.VideoTrack{{ColorTransfer: "smpte2084"}},
+		}, "HDR10"},
+		{"hlg via color transfer", &models.MediaFile{
+			HDR:         true,
+			VideoTracks: []models.VideoTrack{{ColorTransfer: "arib-std-b67"}},
+		}, "HLG"},
+		{"dv only", &models.MediaFile{
+			HDR:         true,
+			VideoTracks: []models.VideoTrack{{DolbyVision: "Profile 5"}},
+		}, "DV"},
+		{"dv with hdr10 base layer", &models.MediaFile{
+			HDR: true,
+			VideoTracks: []models.VideoTrack{{
+				DolbyVision:   "Profile 8",
+				ColorTransfer: "smpte2084",
+			}},
+		}, "DV HDR10"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := normalizeHDR(tc.file); got != tc.want {
+				t.Errorf("normalizeHDR = %q, want %q", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestBestFileRangeTieBreaking(t *testing.T) {
+	genericHDR := &models.MediaFile{Resolution: "2160p", HDR: true}
+	explicitHDR10 := &models.MediaFile{
+		Resolution:  "2160p",
+		HDR:         true,
+		VideoTracks: []models.VideoTrack{{ColorTransfer: "smpte2084"}},
+	}
+	dv := &models.MediaFile{
+		Resolution: "2160p",
+		HDR:        true,
+		VideoTracks: []models.VideoTrack{{
+			DolbyVision:   "Profile 8",
+			ColorTransfer: "smpte2084",
+		}},
+	}
+	sdr := &models.MediaFile{Resolution: "2160p"}
+	lowResDV := &models.MediaFile{
+		Resolution:  "1080p",
+		HDR:         true,
+		VideoTracks: []models.VideoTrack{{DolbyVision: "Profile 5"}},
+	}
+
+	cases := []struct {
+		name  string
+		files []*models.MediaFile
+		want  *models.MediaFile
+	}{
+		{"nil files ignored", []*models.MediaFile{nil, genericHDR}, genericHDR},
+		{"dv beats first-scanned generic hdr at same resolution",
+			[]*models.MediaFile{genericHDR, dv}, dv},
+		{"dv beats explicit hdr10 at same resolution",
+			[]*models.MediaFile{explicitHDR10, dv}, dv},
+		{"explicit hdr10 beats bare boolean at same resolution",
+			[]*models.MediaFile{genericHDR, explicitHDR10}, explicitHDR10},
+		{"bare boolean beats sdr at same resolution",
+			[]*models.MediaFile{sdr, genericHDR}, genericHDR},
+		{"higher resolution still wins over lower-res dv",
+			[]*models.MediaFile{lowResDV, genericHDR}, genericHDR},
+		{"full tie keeps earliest file",
+			[]*models.MediaFile{genericHDR, {Resolution: "2160p", HDR: true}}, genericHDR},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := bestFile(tc.files); got != tc.want {
+				t.Errorf("bestFile picked %+v, want %+v", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestBuildSummaryPrefersDolbyVisionSibling(t *testing.T) {
+	genericHDR := &models.MediaFile{Resolution: "2160p", HDR: true, CodecVideo: "hevc"}
+	dv := &models.MediaFile{
+		Resolution: "2160p",
+		HDR:        true,
+		CodecVideo: "hevc",
+		VideoTracks: []models.VideoTrack{{
+			Codec:         "hevc",
+			DolbyVision:   "Profile 8",
+			ColorTransfer: "smpte2084",
+		}},
+	}
+	got := BuildSummary([]*models.MediaFile{genericHDR, dv})
+	if got == nil {
+		t.Fatal("expected non-nil summary")
+	}
+	if got.HDR != "DV HDR10" {
+		t.Errorf("HDR = %q, want %q", got.HDR, "DV HDR10")
+	}
+}
+
 func TestBuildSummaryAggregatesNewFields(t *testing.T) {
 	file := &models.MediaFile{
 		Resolution: "1080p",

--- a/web/src/lib/videoRange.test.ts
+++ b/web/src/lib/videoRange.test.ts
@@ -1,0 +1,103 @@
+import { describe, expect, it } from "vitest";
+
+import { bestVideoRangeLabel, videoRangeLabel, type VideoRangeSource } from "./videoRange";
+
+describe("videoRangeLabel", () => {
+  it("returns empty for SDR / unprobed", () => {
+    expect(videoRangeLabel({ hdr: false })).toBe("");
+    expect(videoRangeLabel({ hdr: false, video_tracks: [{}] })).toBe("");
+  });
+
+  it("falls back to generic HDR from the bare boolean", () => {
+    expect(videoRangeLabel({ hdr: true })).toBe("HDR");
+    expect(videoRangeLabel({ hdr: true, video_tracks: [{}] })).toBe("HDR");
+  });
+
+  it("detects Dolby Vision from the dolby_vision string", () => {
+    expect(videoRangeLabel({ hdr: true, video_tracks: [{ dolby_vision: "Profile 5" }] })).toBe(
+      "DV",
+    );
+  });
+
+  it("detects Dolby Vision from dv_profile alone", () => {
+    expect(videoRangeLabel({ hdr: true, video_tracks: [{ dv_profile: 8 }] })).toBe("DV");
+  });
+
+  it("detects Dolby Vision from a DOVI video_range_type", () => {
+    expect(
+      videoRangeLabel({ hdr: true, video_tracks: [{ video_range_type: "DOVIWithSDR" }] }),
+    ).toBe("DV");
+  });
+
+  it("combines DV with HDR10 base-layer compatibility", () => {
+    expect(
+      videoRangeLabel({
+        hdr: true,
+        video_tracks: [{ dolby_vision: "Profile 8", video_range_type: "DOVIWithHDR10" }],
+      }),
+    ).toBe("DV HDR10");
+    expect(
+      videoRangeLabel({
+        hdr: true,
+        video_tracks: [{ dolby_vision: "Profile 7", color_transfer: "smpte2084" }],
+      }),
+    ).toBe("DV HDR10");
+  });
+
+  it("combines DV with HLG compatibility", () => {
+    expect(
+      videoRangeLabel({ hdr: true, video_tracks: [{ video_range_type: "DOVIWithHLG" }] }),
+    ).toBe("DV HLG");
+  });
+
+  it("labels HDR10+ from the flag or range type", () => {
+    expect(videoRangeLabel({ hdr: true, video_tracks: [{ hdr10_plus: true }] })).toBe("HDR10+");
+    expect(videoRangeLabel({ hdr: true, video_tracks: [{ video_range_type: "HDR10Plus" }] })).toBe(
+      "HDR10+",
+    );
+    expect(
+      videoRangeLabel({
+        hdr: true,
+        video_tracks: [{ video_range_type: "DOVIWithELHDR10Plus" }],
+      }),
+    ).toBe("DV HDR10+");
+  });
+
+  it("labels HDR10 and HLG from video_range_type or color_transfer", () => {
+    expect(videoRangeLabel({ hdr: true, video_tracks: [{ video_range_type: "HDR10" }] })).toBe(
+      "HDR10",
+    );
+    expect(videoRangeLabel({ hdr: true, video_tracks: [{ color_transfer: "smpte2084" }] })).toBe(
+      "HDR10",
+    );
+    expect(videoRangeLabel({ hdr: true, video_tracks: [{ video_range_type: "HLG" }] })).toBe("HLG");
+    expect(videoRangeLabel({ hdr: true, video_tracks: [{ color_transfer: "arib-std-b67" }] })).toBe(
+      "HLG",
+    );
+  });
+});
+
+describe("bestVideoRangeLabel", () => {
+  it("prefers DV over a generic-HDR sibling version", () => {
+    const versions: VideoRangeSource[] = [
+      { hdr: true },
+      {
+        hdr: true,
+        video_tracks: [{ dolby_vision: "Profile 8", video_range_type: "DOVIWithHDR10" }],
+      },
+    ];
+    expect(bestVideoRangeLabel(versions)).toBe("DV HDR10");
+  });
+
+  it("prefers explicit HDR10 over the bare boolean", () => {
+    const versions: VideoRangeSource[] = [
+      { hdr: true },
+      { hdr: true, video_tracks: [{ color_transfer: "smpte2084" }] },
+    ];
+    expect(bestVideoRangeLabel(versions)).toBe("HDR10");
+  });
+
+  it("returns empty when every version is SDR", () => {
+    expect(bestVideoRangeLabel([{ hdr: false }, { hdr: false }])).toBe("");
+  });
+});

--- a/web/src/lib/videoRange.ts
+++ b/web/src/lib/videoRange.ts
@@ -1,0 +1,90 @@
+// Derives a compact dynamic-range badge label ("DV", "DV HDR10", "HDR10+",
+// "HDR10", "HLG", "HDR") from a file version's probed video tracks. Mirrors
+// the server-side vocabulary in internal/overlays/summary.go (normalizeHDR)
+// so card overlays, detail badges, version pickers, and the player HUD all
+// agree. The bare `hdr` boolean is kept as the last-resort fallback for
+// files probed before Dolby Vision / video-range metadata existed.
+
+/** Minimal structural shape shared by VersionVideoTrack and PlayerVideoTrack. */
+export interface VideoRangeTrack {
+  dolby_vision?: string;
+  dv_profile?: number;
+  hdr10_plus?: boolean;
+  video_range?: string;
+  video_range_type?: string;
+  color_transfer?: string;
+}
+
+/** Minimal structural shape shared by FileVersion and PlayerFileVersion. */
+export interface VideoRangeSource {
+  hdr?: boolean;
+  video_tracks?: VideoRangeTrack[];
+}
+
+function trackHasDolbyVision(track: VideoRangeTrack): boolean {
+  if (track.dolby_vision?.trim()) return true;
+  if ((track.dv_profile ?? 0) > 0) return true;
+  return (track.video_range_type?.trim() ?? "").startsWith("DOVI");
+}
+
+// Distinguishes HDR variants from the scanner-derived video_range_type enum
+// (HDR10, HDR10Plus, HLG, DOVIWith*) with color_transfer as a fallback,
+// matching the server's hdrTypeFromTracks.
+function trackHdrType(track: VideoRangeTrack): string {
+  const rangeType = track.video_range_type?.trim() ?? "";
+  if (track.hdr10_plus || rangeType.includes("HDR10Plus")) return "HDR10+";
+  if (rangeType === "HDR10" || rangeType.endsWith("WithHDR10")) return "HDR10";
+  if (rangeType === "HLG" || rangeType.endsWith("WithHLG")) return "HLG";
+
+  const transfer = track.color_transfer?.toLowerCase() ?? "";
+  if (transfer.includes("smpte2084")) return "HDR10";
+  if (transfer.includes("arib-std-b67")) return "HLG";
+  return "";
+}
+
+/**
+ * Display label for a file version's dynamic range: "DV", "DV HDR10",
+ * "DV HDR10+", "DV HLG", "HDR10+", "HDR10", "HLG", "HDR" (boolean-only
+ * fallback), or "" for SDR/unknown.
+ */
+export function videoRangeLabel(source: VideoRangeSource): string {
+  let hasDV = false;
+  let hdrType = "";
+  for (const track of source.video_tracks ?? []) {
+    if (trackHasDolbyVision(track)) hasDV = true;
+    if (!hdrType) hdrType = trackHdrType(track);
+  }
+
+  if (hasDV) return hdrType ? `DV ${hdrType}` : "DV";
+  if (hdrType) return hdrType;
+  if (source.hdr) return "HDR";
+  return "";
+}
+
+// Rollup preference when a badge summarizes several versions: any DV variant
+// beats explicit HDR10+/HDR10/HLG, which beat the generic boolean "HDR".
+const LABEL_RANK: Record<string, number> = {
+  "DV HDR10+": 8,
+  "DV HDR10": 7,
+  "DV HLG": 6,
+  DV: 5,
+  "HDR10+": 4,
+  HDR10: 3,
+  HLG: 2,
+  HDR: 1,
+};
+
+/** Best (most specific) dynamic-range label across a set of versions. */
+export function bestVideoRangeLabel(sources: VideoRangeSource[]): string {
+  let best = "";
+  let bestRank = 0;
+  for (const source of sources) {
+    const label = videoRangeLabel(source);
+    const rank = LABEL_RANK[label] ?? 0;
+    if (rank > bestRank) {
+      best = label;
+      bestRank = rank;
+    }
+  }
+  return best;
+}

--- a/web/src/lib/videoRange.ts
+++ b/web/src/lib/videoRange.ts
@@ -10,7 +10,6 @@ export interface VideoRangeTrack {
   dolby_vision?: string;
   dv_profile?: number;
   hdr10_plus?: boolean;
-  video_range?: string;
   video_range_type?: string;
   color_transfer?: string;
 }

--- a/web/src/pages/ItemDetail/components/QualityBadges.tsx
+++ b/web/src/pages/ItemDetail/components/QualityBadges.tsx
@@ -1,4 +1,5 @@
 import type { FileVersion } from "@/api/types";
+import { bestVideoRangeLabel } from "@/lib/videoRange";
 import { pickBestAttributes } from "./versionRankingUtils";
 
 interface QualityBadgesProps {
@@ -11,7 +12,8 @@ export default function QualityBadges({ versions }: QualityBadgesProps) {
 
   const badges: string[] = [];
   if (best.resolution) badges.push(best.resolution);
-  if (best.hdr) badges.push("HDR");
+  const rangeLabel = bestVideoRangeLabel(versions);
+  if (rangeLabel) badges.push(rangeLabel);
   if (best.audioLabel) badges.push(best.audioLabel);
 
   if (badges.length === 0) return null;

--- a/web/src/pages/ItemDetail/components/VersionDropdown.tsx
+++ b/web/src/pages/ItemDetail/components/VersionDropdown.tsx
@@ -5,6 +5,7 @@ import type { FileVersion, PlaybackVariant } from "@/api/types";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover";
+import { videoRangeLabel } from "@/lib/videoRange";
 import { sortPlaybackVariantsByEditionPreference } from "./versionRankingUtils";
 import { buildDetailLine, buildQualitySummary, sortByResolution } from "./VersionFlyout";
 
@@ -128,6 +129,7 @@ export default function VersionDropdown({
                 const isSelected = version.file_id === activeVersion?.file_id;
                 const summary = buildQualitySummary(version);
                 const detail = buildDetailLine(version);
+                const rangeLabel = videoRangeLabel(version);
 
                 return (
                   <button
@@ -146,9 +148,9 @@ export default function VersionDropdown({
                         <span className="truncate text-sm font-medium">
                           {summary || `Version ${version.file_id}`}
                         </span>
-                        {version.hdr ? (
+                        {rangeLabel ? (
                           <Badge variant="secondary" className="px-1.5 py-0 text-[10px] uppercase">
-                            HDR
+                            {rangeLabel}
                           </Badge>
                         ) : null}
                       </div>

--- a/web/src/pages/ItemDetail/components/VersionFlyout.tsx
+++ b/web/src/pages/ItemDetail/components/VersionFlyout.tsx
@@ -6,6 +6,7 @@ import {
   DropdownMenuSeparator,
 } from "@/components/ui/dropdown-menu";
 import { formatFileSize, mapAudioLabel } from "@/lib/mediaFormat";
+import { videoRangeLabel } from "@/lib/videoRange";
 import { extractSourceHint } from "./versionFormatUtils";
 import { resolutionScore } from "./versionRankingUtils";
 
@@ -18,7 +19,8 @@ export function buildQualitySummary(version: FileVersion): string {
 
   if (version.resolution) parts.push(version.resolution);
   if (version.codec_video) parts.push(version.codec_video.toUpperCase());
-  if (version.hdr) parts.push("HDR");
+  const rangeLabel = videoRangeLabel(version);
+  if (rangeLabel) parts.push(rangeLabel);
   if (version.codec_audio) parts.push(mapAudioLabel(version.codec_audio));
   if (parts.length === 0 && version.container) {
     parts.push(version.container.toUpperCase());

--- a/web/src/player/playback-info.test.ts
+++ b/web/src/player/playback-info.test.ts
@@ -170,7 +170,9 @@ describe("playback info helpers", () => {
       runtimeStats: {},
     });
 
-    expect(rowValue(sections, "Player", "Auto-switched from")).toBe("2160p HEVC HDR");
+    // The default fixture is a Dolby Vision (Profile 8.1) file, so the range
+    // badge reads "DV" instead of the old generic boolean-derived "HDR".
+    expect(rowValue(sections, "Player", "Auto-switched from")).toBe("2160p HEVC DV");
     expect(rowValue(sections, "Current Source File", "Video codec")).toBe("H.264 High");
   });
 

--- a/web/src/player/playback-info.ts
+++ b/web/src/player/playback-info.ts
@@ -6,6 +6,7 @@ import {
   formatMbpsFromKbps,
   formatSampleRate,
 } from "@/lib/mediaFormat";
+import { videoRangeLabel } from "@/lib/videoRange";
 import type {
   PlaybackSessionPlaybackInfo,
   PlayMethod,
@@ -223,7 +224,7 @@ function formatRequestedSourceVersion(version: PlayerFileVersion): string {
   const parts = [
     version.resolution?.trim(),
     formatCodecLabel(version.codec_video),
-    version.hdr ? "HDR" : null,
+    videoRangeLabel(version) || null,
   ].filter(Boolean);
   return parts.join(" ");
 }
@@ -333,11 +334,8 @@ export function formatVideoRangeType(
   if (track?.video_range) {
     return track.video_range;
   }
-  if (version?.hdr) {
-    return "HDR";
-  }
   if (version) {
-    return "SDR";
+    return videoRangeLabel(version) || "SDR";
   }
   return "—";
 }


### PR DESCRIPTION
Part of #367.

## Problem

Files with Dolby Vision show a generic "HDR" badge on detail pages, version pickers, the player HUD, and card overlays. The web badge sites read only the `FileVersion.hdr` boolean and push a hardcoded `"HDR"` literal, even though the payload already carries `video_tracks[].dolby_vision` / `dv_profile` / `video_range_type` / `color_transfer` (the Media Info dialog renders these correctly). On the server, card-overlay rollup picks the best file by resolution with first-scanned tie-breaking, so one generic-HDR (or stale-probed) file at max resolution masks a DV sibling for a whole card/series.

## Approach

- New shared web helper `web/src/lib/videoRange.ts` derives a label ("DV", "DV HDR10", "DV HDR10+", "DV HLG", "HDR10+", "HDR10", "HLG") from probed track metadata; the `hdr` boolean remains the last-resort "HDR" fallback. Used in QualityBadges, VersionDropdown, VersionFlyout, and playback-info. Badge styling unchanged — text/logic only.
- `internal/overlays/summary.go`: `hdrTypeFromTracks` now reads `video_range_type` and `hdr10_plus` with color transfer as the fallback, sharing the web helper's exact detection order — server card overlays can now label HDR10+, and rows whose only signal is the range-type enum (e.g. catalog-seeded imports) no longer fall through to the bare-boolean tier.
- `internal/overlays/summary.go`: `bestFile` breaks same-resolution ties by range-metadata richness (DV > explicit HDR10+/HDR10/HLG > bare hdr boolean > SDR); full ties still keep the earliest file, so selection stays deterministic. Unit tests added for tie-breaking, `normalizeHDR`, and the DV-sibling rollup case.

## Risks / notes

- Files probed before DV/video-range fields existed have no track metadata, so they still show generic "HDR" until re-probed — expected, and the reason the boolean fallback stays. (Follow-up candidate: teach probe repair to re-probe rows missing range metadata.)
- `BuildSummary` derives every overlay field from the single best file, so the new tie-break can also change a card's audio/codec/aspect badges when it flips the winner (e.g. a DV file with AC3 now beats a generic-HDR sibling with Atmos). The previous winner among same-resolution files was arbitrary scan order, so this is a change between two arbitrary-but-deterministic choices, not a regression.
- The dynamic-range vocabulary now lives in two implementations (Go + TS), and silo-android / silo-apple have the same generic-HDR badge problem. Follow-up candidate: expose a server-computed `video_range_label` (additive) on version payloads and the overlay summary so all clients share one source of truth.
- One player HUD test expectation updated: the fixture is a DV Profile 8.1 file, so "Auto-switched from" now truthfully reads "… DV" instead of "… HDR".
- `selectDefaultVersion` matching still uses the boolean and is unaffected.
- Full web test suite has 4 failures in unrelated suites that also fail on pristine `upstream/main` (verified).

## Verification

`go build ./...`, `go test ./internal/overlays/...` pass; ESLint/Prettier/tsc clean; videoRange suite plus affected suites pass.

AI-use disclosure: implemented by Claude (Claude Code) under human direction and review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added clearer video range labels for Dolby Vision, HDR10+, HDR10, HLG, and HDR content.
  * Improved quality badges and version details to show the most accurate available range information.
  * Playback details now display consistent video range labels, including Dolby Vision.

* **Bug Fixes**
  * Improved media selection when multiple versions share the same resolution by prioritizing richer HDR metadata.
  * Added support for detecting HDR formats from additional video metadata sources.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->