### PR TITLE
feat(plugins): group Apps sidebar by plugin manifest category

### DIFF
--- a/internal/api/handlers/plugins.go
+++ b/internal/api/handlers/plugins.go
@@ -321,7 +321,7 @@ type pluginUserSettingsSummary struct {
 	Routes           []pluginRouteJSON        `json:"routes"`
 	Assets           []pluginAssetJSON        `json:"assets"`
 	// Category is the manifest's optional slash-delimited grouping path
-	// (e.g. "Books/Audiobooks") used to group plugin entries in the
+	// (e.g. "Tools/Utilities") used to group plugin entries in the
 	// user-facing Apps navigation. Empty (omitted) when the manifest
 	// declares no category. Additive-only per v1 API rules.
 	Category string `json:"category,omitempty"`

--- a/internal/api/handlers/plugins.go
+++ b/internal/api/handlers/plugins.go
@@ -320,6 +320,11 @@ type pluginUserSettingsSummary struct {
 	UserConfigSchema []pluginConfigSchemaJSON `json:"user_config_schema"`
 	Routes           []pluginRouteJSON        `json:"routes"`
 	Assets           []pluginAssetJSON        `json:"assets"`
+	// Category is the manifest's optional slash-delimited grouping path
+	// (e.g. "Books/Audiobooks") used to group plugin entries in the
+	// user-facing Apps navigation. Empty (omitted) when the manifest
+	// declares no category. Additive-only per v1 API rules.
+	Category string `json:"category,omitempty"`
 }
 
 type pluginUserSettingsListResponse struct {
@@ -1465,6 +1470,7 @@ func toUserPluginSettingsSummary(
 		UserConfigSchema: configSchemasToJSON(manifest.GetUserConfigSchema()),
 		Routes:           routesToJSON(manifest.GetHttpRoutes()),
 		Assets:           assetsToJSON(manifest.GetAssets()),
+		Category:         manifest.GetCategory(),
 	}
 }
 

--- a/internal/api/handlers/plugins_user_settings_test.go
+++ b/internal/api/handlers/plugins_user_settings_test.go
@@ -1,0 +1,60 @@
+package handlers
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+
+	pluginv1 "github.com/Silo-Server/silo-plugin-sdk/pkg/pluginproto/silo/plugin/v1"
+
+	"github.com/Silo-Server/silo-server/internal/plugins"
+)
+
+func TestToUserPluginSettingsSummaryIncludesManifestCategory(t *testing.T) {
+	t.Parallel()
+
+	installation := &plugins.Installation{
+		ID:       42,
+		PluginID: "example-audiobooks",
+		Version:  "1.2.3",
+	}
+	manifest := &pluginv1.PluginManifest{
+		Category: "Books/Audiobooks",
+	}
+
+	got := toUserPluginSettingsSummary(installation, manifest)
+
+	if got.Category != "Books/Audiobooks" {
+		t.Fatalf("Category = %q, want %q", got.Category, "Books/Audiobooks")
+	}
+	if got.ID != 42 || got.PluginID != "example-audiobooks" || got.Version != "1.2.3" {
+		t.Fatalf("identity fields = %#v", got)
+	}
+}
+
+func TestToUserPluginSettingsSummaryOmitsEmptyCategory(t *testing.T) {
+	t.Parallel()
+
+	installation := &plugins.Installation{
+		ID:       7,
+		PluginID: "example-plain",
+		Version:  "0.1.0",
+	}
+
+	got := toUserPluginSettingsSummary(installation, &pluginv1.PluginManifest{})
+
+	if got.Category != "" {
+		t.Fatalf("Category = %q, want empty", got.Category)
+	}
+
+	// The field is additive-only; ensure it stays absent from the JSON
+	// payload for manifests without a category so existing clients see an
+	// unchanged response shape.
+	encoded, err := json.Marshal(got)
+	if err != nil {
+		t.Fatalf("marshaling summary: %v", err)
+	}
+	if strings.Contains(string(encoded), "\"category\"") {
+		t.Fatalf("JSON payload should omit empty category, got %s", encoded)
+	}
+}

--- a/internal/api/handlers/plugins_user_settings_test.go
+++ b/internal/api/handlers/plugins_user_settings_test.go
@@ -19,13 +19,13 @@ func TestToUserPluginSettingsSummaryIncludesManifestCategory(t *testing.T) {
 		Version:  "1.2.3",
 	}
 	manifest := &pluginv1.PluginManifest{
-		Category: "Books/Audiobooks",
+		Category: "Tools/Utilities",
 	}
 
 	got := toUserPluginSettingsSummary(installation, manifest)
 
-	if got.Category != "Books/Audiobooks" {
-		t.Fatalf("Category = %q, want %q", got.Category, "Books/Audiobooks")
+	if got.Category != "Tools/Utilities" {
+		t.Fatalf("Category = %q, want %q", got.Category, "Tools/Utilities")
 	}
 	if got.ID != 42 || got.PluginID != "example-audiobooks" || got.Version != "1.2.3" {
 		t.Fatalf("identity fields = %#v", got)

--- a/web/src/api/types.ts
+++ b/web/src/api/types.ts
@@ -3445,7 +3445,7 @@ export interface PluginSettingsSummary {
   assets: PluginAsset[];
   /**
    * Optional slash-delimited grouping path from the plugin manifest
-   * (e.g. "Books/Audiobooks") that groups the plugin's entries in the
+   * (e.g. "Tools/Utilities") that groups the plugin's entries in the
    * Apps sidebar section. Absent when the manifest declares no category.
    */
   category?: string;

--- a/web/src/api/types.ts
+++ b/web/src/api/types.ts
@@ -3443,6 +3443,12 @@ export interface PluginSettingsSummary {
   user_config_schema: PluginConfigSchema[];
   routes: PluginRoute[];
   assets: PluginAsset[];
+  /**
+   * Optional slash-delimited grouping path from the plugin manifest
+   * (e.g. "Books/Audiobooks") that groups the plugin's entries in the
+   * Apps sidebar section. Absent when the manifest declares no category.
+   */
+  category?: string;
 }
 
 export interface PluginSettingsListResponse {

--- a/web/src/components/AppSidebar.logic.ts
+++ b/web/src/components/AppSidebar.logic.ts
@@ -5,3 +5,64 @@ export function isSidebarExpanded(collapsed: boolean, hovered: boolean, profileM
 export function getProfileMenuSide(collapsed: boolean) {
   return collapsed ? "right" : "top";
 }
+
+export interface AppNavLink {
+  id: string;
+  basePath: string;
+  label: string;
+  pluginId: string;
+  /** Slash-delimited category path from the plugin manifest, if any. */
+  category?: string;
+}
+
+export interface AppNavGroup {
+  /** Display label for the group ("Other" for uncategorized plugins). */
+  category: string;
+  links: AppNavLink[];
+}
+
+/** Group label for plugins whose manifest declares no category. */
+export const UNCATEGORIZED_APP_GROUP = "Other";
+
+/**
+ * Groups Apps sidebar entries by the FIRST segment of the plugin manifest's
+ * slash-delimited `category` path.
+ *
+ * SDK contract (silo-plugin-sdk proto/silo/plugin/v1/common.proto,
+ * PluginManifest.category): a slash-delimited path that groups plugins in
+ * the user-facing Apps section — e.g. "Books/Audiobooks" lands in
+ * Apps → Books → Audiobooks. Plugins without a category render under
+ * "Other". The host does not validate the value; the sidebar tolerates
+ * unknown segments.
+ *
+ * We currently render only ONE level of grouping, so deeper segments
+ * ("Audiobooks" in the example above) are intentionally ignored for now.
+ *
+ * Returns null when fewer than 2 distinct categories exist among the
+ * links; the caller should then keep the flat list under the single
+ * "Apps" header instead of rendering per-category sub-headers.
+ *
+ * Group ordering: categories alphabetically (locale-aware), with "Other"
+ * always last. Link order within each group preserves the input order.
+ */
+export function groupAppNavLinks(links: AppNavLink[]): AppNavGroup[] | null {
+  const groups = new Map<string, AppNavLink[]>();
+  for (const link of links) {
+    const firstSegment = link.category?.split("/")[0]?.trim();
+    const category = firstSegment || UNCATEGORIZED_APP_GROUP;
+    const bucket = groups.get(category);
+    if (bucket) {
+      bucket.push(link);
+    } else {
+      groups.set(category, [link]);
+    }
+  }
+  if (groups.size < 2) return null;
+  return [...groups.entries()]
+    .sort(([a], [b]) => {
+      if (a === UNCATEGORIZED_APP_GROUP) return 1;
+      if (b === UNCATEGORIZED_APP_GROUP) return -1;
+      return a.localeCompare(b);
+    })
+    .map(([category, groupLinks]) => ({ category, links: groupLinks }));
+}

--- a/web/src/components/AppSidebar.logic.ts
+++ b/web/src/components/AppSidebar.logic.ts
@@ -30,13 +30,13 @@ export const UNCATEGORIZED_APP_GROUP = "Other";
  *
  * SDK contract (silo-plugin-sdk proto/silo/plugin/v1/common.proto,
  * PluginManifest.category): a slash-delimited path that groups plugins in
- * the user-facing Apps section — e.g. "Books/Audiobooks" lands in
- * Apps → Books → Audiobooks. Plugins without a category render under
+ * the user-facing Apps section — e.g. "Tools/Utilities" lands in
+ * Apps → Tools → Utilities. Plugins without a category render under
  * "Other". The host does not validate the value; the sidebar tolerates
  * unknown segments.
  *
  * We currently render only ONE level of grouping, so deeper segments
- * ("Audiobooks" in the example above) are intentionally ignored for now.
+ * ("Utilities" in the example above) are intentionally ignored for now.
  *
  * Returns null when fewer than 2 distinct categories exist among the
  * links; the caller should then keep the flat list under the single

--- a/web/src/components/AppSidebar.test.tsx
+++ b/web/src/components/AppSidebar.test.tsx
@@ -222,55 +222,55 @@ describe("AppSidebar", () => {
 
   it("keeps a flat Apps list when fewer than 2 distinct categories exist", () => {
     mockPluginInstallations = [
-      pluginInstallation(1, "audiobook-shelf", "Audiobooks", "Books/Audiobooks"),
-      pluginInstallation(2, "comic-reader", "Comics", "Books"),
+      pluginInstallation(1, "alpha-app", "Alpha", "Tools/Utilities"),
+      pluginInstallation(2, "beta-app", "Beta", "Tools"),
     ];
 
     const markup = renderSidebar("/");
 
     expect(markup).toContain(">Apps<");
-    expect(markup).toContain(">Audiobooks<");
-    expect(markup).toContain(">Comics<");
-    // Both plugins share the first category segment "Books", so no
+    expect(markup).toContain(">Alpha<");
+    expect(markup).toContain(">Beta<");
+    // Both plugins share the first category segment "Tools", so no
     // per-category sub-headers should render.
-    expect(markup).not.toContain(">Books<");
+    expect(markup).not.toContain(">Tools<");
     expect(markup).not.toContain(">Other<");
   });
 
   it("groups Apps entries by first category segment with Other last when 2+ categories exist", () => {
     mockPluginInstallations = [
-      pluginInstallation(1, "audiobook-shelf", "Audiobooks", "Books/Audiobooks"),
-      pluginInstallation(2, "arcade", "Arcade", "Games"),
-      pluginInstallation(3, "misc-tool", "Misc Tool"),
+      pluginInstallation(1, "alpha-app", "Alpha", "Tools/Utilities"),
+      pluginInstallation(2, "beta-app", "Beta", "Extras"),
+      pluginInstallation(3, "gamma-app", "Gamma"),
     ];
 
     const markup = renderSidebar("/");
 
     expect(markup).toContain(">Apps<");
-    expect(markup).toContain(">Books<");
-    expect(markup).toContain(">Games<");
+    expect(markup).toContain(">Extras<");
+    expect(markup).toContain(">Tools<");
     expect(markup).toContain(">Other<");
     // Alphabetical category order with the uncategorized bucket last.
-    const booksIndex = markup.indexOf(">Books<");
-    const gamesIndex = markup.indexOf(">Games<");
+    const extrasIndex = markup.indexOf(">Extras<");
+    const toolsIndex = markup.indexOf(">Tools<");
     const otherIndex = markup.indexOf(">Other<");
-    expect(booksIndex).toBeGreaterThan(-1);
-    expect(gamesIndex).toBeGreaterThan(booksIndex);
-    expect(otherIndex).toBeGreaterThan(gamesIndex);
+    expect(extrasIndex).toBeGreaterThan(-1);
+    expect(toolsIndex).toBeGreaterThan(extrasIndex);
+    expect(otherIndex).toBeGreaterThan(toolsIndex);
   });
 
   it("hides Apps group headers the same way as other section headers when collapsed", () => {
     mockPluginInstallations = [
-      pluginInstallation(1, "audiobook-shelf", "Audiobooks", "Books"),
-      pluginInstallation(2, "arcade", "Arcade", "Games"),
+      pluginInstallation(1, "alpha-app", "Alpha", "Tools"),
+      pluginInstallation(2, "beta-app", "Beta", "Extras"),
     ];
 
     const markup = renderSidebar("/", { collapsed: true });
 
     // Group headers reuse SidebarSectionHeader, so the label slot stays in
     // the layout (preventing shifts) but is visually hidden when collapsed.
-    expect(markup).toContain(">Books<");
-    expect(markup).toContain(">Games<");
+    expect(markup).toContain(">Tools<");
+    expect(markup).toContain(">Extras<");
     const hiddenHeaderCount = (markup.match(/aria-hidden="true" class="[^"]*opacity-0/g) ?? [])
       .length;
     expect(hiddenHeaderCount).toBeGreaterThan(0);
@@ -295,28 +295,28 @@ describe("groupAppNavLinks", () => {
   });
 
   it("returns null when all links share the same first category segment", () => {
-    expect(groupAppNavLinks([link("a", "Books/Audiobooks"), link("b", "Books/Comics")])).toBeNull();
+    expect(groupAppNavLinks([link("a", "Tools/Utilities"), link("b", "Tools/Extras")])).toBeNull();
   });
 
   it("groups by first segment, sorts alphabetically, and puts Other last", () => {
     const groups = groupAppNavLinks([
-      link("z", "Games"),
-      link("a", "Books/Audiobooks"),
+      link("z", "Extras"),
+      link("a", "Tools/Utilities"),
       link("m"),
-      link("b", "Books"),
+      link("b", "Tools"),
     ]);
 
     expect(groups).not.toBeNull();
-    expect(groups?.map((g) => g.category)).toEqual(["Books", "Games", "Other"]);
+    expect(groups?.map((g) => g.category)).toEqual(["Extras", "Tools", "Other"]);
     // Input order preserved within a group.
-    expect(groups?.[0]?.links.map((l) => l.id)).toEqual(["a", "b"]);
+    expect(groups?.[1]?.links.map((l) => l.id)).toEqual(["a", "b"]);
     expect(groups?.[2]?.links.map((l) => l.id)).toEqual(["m"]);
   });
 
   it("treats blank or slash-only categories as uncategorized", () => {
-    const groups = groupAppNavLinks([link("a", "  "), link("b", "/Books"), link("c", "Games")]);
+    const groups = groupAppNavLinks([link("a", "  "), link("b", "/Tools"), link("c", "Extras")]);
 
-    expect(groups?.map((g) => g.category)).toEqual(["Games", "Other"]);
+    expect(groups?.map((g) => g.category)).toEqual(["Extras", "Other"]);
     expect(groups?.[1]?.links.map((l) => l.id)).toEqual(["a", "b"]);
   });
 });

--- a/web/src/components/AppSidebar.test.tsx
+++ b/web/src/components/AppSidebar.test.tsx
@@ -5,8 +5,15 @@ import { renderToStaticMarkup } from "react-dom/server";
 import { MemoryRouter, Route, Routes } from "react-router";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
+import type { PluginSettingsSummary } from "@/api/types";
+
 import AppSidebar from "./AppSidebar";
-import { getProfileMenuSide, isSidebarExpanded } from "./AppSidebar.logic";
+import {
+  getProfileMenuSide,
+  groupAppNavLinks,
+  isSidebarExpanded,
+  type AppNavLink,
+} from "./AppSidebar.logic";
 
 const mockLogout = vi.fn();
 const mockClearProfile = vi.fn();
@@ -44,11 +51,41 @@ vi.mock("@/hooks/queries/sidebarPins", () => ({
   }),
 }));
 
+let mockPluginInstallations: PluginSettingsSummary[] = [];
+
 vi.mock("@/hooks/queries/pluginSettings", () => ({
   usePluginSettingsList: () => ({
-    data: { installations: [] },
+    data: { installations: mockPluginInstallations },
   }),
 }));
+
+function pluginInstallation(
+  id: number,
+  pluginId: string,
+  label: string,
+  category?: string,
+): PluginSettingsSummary {
+  return {
+    id,
+    plugin_id: pluginId,
+    version: "1.0.0",
+    user_config_schema: [],
+    routes: [
+      {
+        id: "home",
+        method: "GET",
+        path: "/",
+        access: "user",
+        navigable: true,
+        navigation_label: label,
+        navigation_kind: "user",
+        static_asset: false,
+      },
+    ],
+    assets: [],
+    category,
+  };
+}
 
 vi.mock("@/hooks/queries/useRequests", () => ({
   useRequestFeatureStatus: () => ({
@@ -116,6 +153,7 @@ describe("AppSidebar", () => {
     mockLogout.mockReset();
     mockClearProfile.mockReset();
     mockTogglePin.mockReset();
+    mockPluginInstallations = [];
   });
 
   it("uses the cinema highlight text color for active catalog source links", () => {
@@ -180,5 +218,105 @@ describe("AppSidebar", () => {
     const markup = renderSidebar("/item/42", { collapsed: true });
 
     expect(markup).toContain("mx-auto h-10 w-10 justify-center px-0");
+  });
+
+  it("keeps a flat Apps list when fewer than 2 distinct categories exist", () => {
+    mockPluginInstallations = [
+      pluginInstallation(1, "audiobook-shelf", "Audiobooks", "Books/Audiobooks"),
+      pluginInstallation(2, "comic-reader", "Comics", "Books"),
+    ];
+
+    const markup = renderSidebar("/");
+
+    expect(markup).toContain(">Apps<");
+    expect(markup).toContain(">Audiobooks<");
+    expect(markup).toContain(">Comics<");
+    // Both plugins share the first category segment "Books", so no
+    // per-category sub-headers should render.
+    expect(markup).not.toContain(">Books<");
+    expect(markup).not.toContain(">Other<");
+  });
+
+  it("groups Apps entries by first category segment with Other last when 2+ categories exist", () => {
+    mockPluginInstallations = [
+      pluginInstallation(1, "audiobook-shelf", "Audiobooks", "Books/Audiobooks"),
+      pluginInstallation(2, "arcade", "Arcade", "Games"),
+      pluginInstallation(3, "misc-tool", "Misc Tool"),
+    ];
+
+    const markup = renderSidebar("/");
+
+    expect(markup).toContain(">Apps<");
+    expect(markup).toContain(">Books<");
+    expect(markup).toContain(">Games<");
+    expect(markup).toContain(">Other<");
+    // Alphabetical category order with the uncategorized bucket last.
+    const booksIndex = markup.indexOf(">Books<");
+    const gamesIndex = markup.indexOf(">Games<");
+    const otherIndex = markup.indexOf(">Other<");
+    expect(booksIndex).toBeGreaterThan(-1);
+    expect(gamesIndex).toBeGreaterThan(booksIndex);
+    expect(otherIndex).toBeGreaterThan(gamesIndex);
+  });
+
+  it("hides Apps group headers the same way as other section headers when collapsed", () => {
+    mockPluginInstallations = [
+      pluginInstallation(1, "audiobook-shelf", "Audiobooks", "Books"),
+      pluginInstallation(2, "arcade", "Arcade", "Games"),
+    ];
+
+    const markup = renderSidebar("/", { collapsed: true });
+
+    // Group headers reuse SidebarSectionHeader, so the label slot stays in
+    // the layout (preventing shifts) but is visually hidden when collapsed.
+    expect(markup).toContain(">Books<");
+    expect(markup).toContain(">Games<");
+    const hiddenHeaderCount = (markup.match(/aria-hidden="true" class="[^"]*opacity-0/g) ?? [])
+      .length;
+    expect(hiddenHeaderCount).toBeGreaterThan(0);
+  });
+});
+
+describe("groupAppNavLinks", () => {
+  const link = (id: string, category?: string): AppNavLink => ({
+    id,
+    basePath: `/api/v1/plugins/${id}`,
+    label: id,
+    pluginId: id,
+    category,
+  });
+
+  it("returns null for an empty list", () => {
+    expect(groupAppNavLinks([])).toBeNull();
+  });
+
+  it("returns null when all links are uncategorized", () => {
+    expect(groupAppNavLinks([link("a"), link("b")])).toBeNull();
+  });
+
+  it("returns null when all links share the same first category segment", () => {
+    expect(groupAppNavLinks([link("a", "Books/Audiobooks"), link("b", "Books/Comics")])).toBeNull();
+  });
+
+  it("groups by first segment, sorts alphabetically, and puts Other last", () => {
+    const groups = groupAppNavLinks([
+      link("z", "Games"),
+      link("a", "Books/Audiobooks"),
+      link("m"),
+      link("b", "Books"),
+    ]);
+
+    expect(groups).not.toBeNull();
+    expect(groups?.map((g) => g.category)).toEqual(["Books", "Games", "Other"]);
+    // Input order preserved within a group.
+    expect(groups?.[0]?.links.map((l) => l.id)).toEqual(["a", "b"]);
+    expect(groups?.[2]?.links.map((l) => l.id)).toEqual(["m"]);
+  });
+
+  it("treats blank or slash-only categories as uncategorized", () => {
+    const groups = groupAppNavLinks([link("a", "  "), link("b", "/Books"), link("c", "Games")]);
+
+    expect(groups?.map((g) => g.category)).toEqual(["Games", "Other"]);
+    expect(groups?.[1]?.links.map((l) => l.id)).toEqual(["a", "b"]);
   });
 });

--- a/web/src/components/AppSidebar.tsx
+++ b/web/src/components/AppSidebar.tsx
@@ -313,22 +313,26 @@ export default function AppSidebar({ onNavigate, collapsed = false }: AppSidebar
         : "text-muted-foreground hover:text-sidebar-foreground hover:bg-sidebar-accent/70"
     }`;
 
-  const renderAppNavLink = (link: AppNavLink) => (
-    <li key={link.id}>
-      <a
-        href={link.basePath}
-        onClick={(e) => {
-          e.preventDefault();
-          void navigateToPluginRoute(link.basePath);
-          onNavigate?.();
-        }}
-        className={navLinkClassForState(false)}
-        title={link.pluginId}
-      >
-        <Puzzle className="h-[18px] w-[18px] shrink-0" />
-        <SidebarLabel show={showLabels}>{link.label}</SidebarLabel>
-      </a>
-    </li>
+  const renderAppNavList = (links: AppNavLink[]) => (
+    <ul className="list-none space-y-0.5">
+      {links.map((link) => (
+        <li key={link.id}>
+          <a
+            href={link.basePath}
+            onClick={(e) => {
+              e.preventDefault();
+              void navigateToPluginRoute(link.basePath);
+              onNavigate?.();
+            }}
+            className={navLinkClassForState(false)}
+            title={link.pluginId}
+          >
+            <Puzzle className="h-[18px] w-[18px] shrink-0" />
+            <SidebarLabel show={showLabels}>{link.label}</SidebarLabel>
+          </a>
+        </li>
+      ))}
+    </ul>
   );
 
   return (
@@ -733,16 +737,12 @@ export default function AppSidebar({ onNavigate, collapsed = false }: AppSidebar
                 {pluginNavGroups.map((group) => (
                   <div key={group.category} className="sidebar-apps-group">
                     <SidebarSectionHeader show={showLabels}>{group.category}</SidebarSectionHeader>
-                    <ul className="list-none space-y-0.5">
-                      {group.links.map((link) => renderAppNavLink(link))}
-                    </ul>
+                    {renderAppNavList(group.links)}
                   </div>
                 ))}
               </div>
             ) : (
-              <ul className="list-none space-y-0.5">
-                {pluginNavLinks.map((link) => renderAppNavLink(link))}
-              </ul>
+              renderAppNavList(pluginNavLinks)
             )}
           </div>
         )}

--- a/web/src/components/AppSidebar.tsx
+++ b/web/src/components/AppSidebar.tsx
@@ -2,7 +2,12 @@ import { useState, useCallback, useEffect, useMemo, useRef } from "react";
 import type { ReactNode } from "react";
 import { Link, useLocation, useParams } from "react-router";
 import ViewTransitionLink from "@/components/ViewTransitionLink";
-import { getProfileMenuSide, isSidebarExpanded } from "@/components/AppSidebar.logic";
+import {
+  getProfileMenuSide,
+  groupAppNavLinks,
+  isSidebarExpanded,
+  type AppNavLink,
+} from "@/components/AppSidebar.logic";
 import { SiloBrand } from "@/components/SiloBrand";
 import { useAuth } from "@/hooks/useAuth";
 import { useCurrentProfile } from "@/hooks/useCurrentProfile";
@@ -190,7 +195,7 @@ export default function AppSidebar({ onNavigate, collapsed = false }: AppSidebar
   );
   const pluginNavLinks = useMemo(() => {
     const installations = pluginSettings?.installations ?? [];
-    const links: { id: string; basePath: string; label: string; pluginId: string }[] = [];
+    const links: AppNavLink[] = [];
     for (const inst of installations) {
       for (const route of inst.routes) {
         if (!route.navigable || route.navigation_kind !== "user") continue;
@@ -199,11 +204,15 @@ export default function AppSidebar({ onNavigate, collapsed = false }: AppSidebar
           basePath: pluginRouteHref(inst.id, route.path),
           label: route.navigation_label || inst.plugin_id,
           pluginId: inst.plugin_id,
+          category: inst.category,
         });
       }
     }
     return links;
   }, [pluginSettings]);
+  // Grouped view of the Apps entries (null → keep the flat list under the
+  // single "Apps" header). See groupAppNavLinks for the SDK category contract.
+  const pluginNavGroups = useMemo(() => groupAppNavLinks(pluginNavLinks), [pluginNavLinks]);
 
   const catalogState = useMemo(
     () =>
@@ -303,6 +312,24 @@ export default function AppSidebar({ onNavigate, collapsed = false }: AppSidebar
         ? "text-sidebar-accent-foreground bg-sidebar-accent/90 shadow-[0_16px_30px_-24px_rgba(0,0,0,0.7)]"
         : "text-muted-foreground hover:text-sidebar-foreground hover:bg-sidebar-accent/70"
     }`;
+
+  const renderAppNavLink = (link: AppNavLink) => (
+    <li key={link.id}>
+      <a
+        href={link.basePath}
+        onClick={(e) => {
+          e.preventDefault();
+          void navigateToPluginRoute(link.basePath);
+          onNavigate?.();
+        }}
+        className={navLinkClassForState(false)}
+        title={link.pluginId}
+      >
+        <Puzzle className="h-[18px] w-[18px] shrink-0" />
+        <SidebarLabel show={showLabels}>{link.label}</SidebarLabel>
+      </a>
+    </li>
+  );
 
   return (
     <aside
@@ -695,29 +722,28 @@ export default function AppSidebar({ onNavigate, collapsed = false }: AppSidebar
           </ul>
         </div>
 
-        {/* Apps (plugin-supplied user navigation) */}
+        {/* Apps (plugin-supplied user navigation), grouped by the first
+            segment of the manifest's slash-delimited category when 2+
+            distinct categories exist; flat list otherwise. */}
         {pluginNavLinks.length > 0 && (
           <div className="sidebar-apps">
             <SidebarSectionHeader show={showLabels}>Apps</SidebarSectionHeader>
-            <ul className="list-none space-y-0.5">
-              {pluginNavLinks.map((link) => (
-                <li key={link.id}>
-                  <a
-                    href={link.basePath}
-                    onClick={(e) => {
-                      e.preventDefault();
-                      void navigateToPluginRoute(link.basePath);
-                      onNavigate?.();
-                    }}
-                    className={navLinkClassForState(false)}
-                    title={link.pluginId}
-                  >
-                    <Puzzle className="h-[18px] w-[18px] shrink-0" />
-                    <SidebarLabel show={showLabels}>{link.label}</SidebarLabel>
-                  </a>
-                </li>
-              ))}
-            </ul>
+            {pluginNavGroups ? (
+              <div className="space-y-3">
+                {pluginNavGroups.map((group) => (
+                  <div key={group.category} className="sidebar-apps-group">
+                    <SidebarSectionHeader show={showLabels}>{group.category}</SidebarSectionHeader>
+                    <ul className="list-none space-y-0.5">
+                      {group.links.map((link) => renderAppNavLink(link))}
+                    </ul>
+                  </div>
+                ))}
+              </div>
+            ) : (
+              <ul className="list-none space-y-0.5">
+                {pluginNavLinks.map((link) => renderAppNavLink(link))}
+              </ul>
+            )}
           </div>
         )}
       </nav>


### PR DESCRIPTION
## Problem

The plugin SDK documents `PluginManifest.category` (`proto/silo/plugin/v1/common.proto`) as a slash-delimited grouping path for the user-facing Apps section (e.g. `Tools/Utilities` lands in Apps → Tools → Utilities); plugins without a category render under "Other", and the host does not validate the value. silo-server never implemented it: the field wasn't surfaced in any API response and the Apps sidebar rendered a flat list.

## Approach

**Server:** the user plugin-settings responses gain `category` sourced from the already-loaded manifest (`GetCategory()`) — no new manifest parsing paths.

**Web:** `AppSidebar` groups Apps entries by the first segment of the category path via a pure, unit-tested `groupAppNavLinks` helper; sub-headers reuse `SidebarSectionHeader` so collapsed-sidebar behavior matches every other section. Deeper nesting (second+ segments) is intentionally deferred and documented in code against the SDK contract.

## API additivity

The new field is `category,omitempty` on the existing v1 responses — purely additive; clients that ignore it see an unchanged payload (covered by a test asserting the key is absent when empty).

## Flat-list behavior

When fewer than 2 distinct categories exist among visible app links (including the all-uncategorized case), the sidebar keeps today's flat list under the single "Apps" header; per-category sub-headers only appear at 2+ categories. Uncategorized plugins group under "Other", sorted last.

## Risks

Low — additive API field; the sidebar falls back to the exact previous rendering when grouping doesn't apply; case-sensitive segment matching means "tools" and "Tools" form separate groups (consistent with "host does not validate").

## Verification

`go build ./...`, `go test ./internal/api/... ./internal/plugins/...` pass (new category passthrough/omission tests); ESLint/Prettier/tsc clean; AppSidebar vitest suite 17/17 including grouped/flat/collapsed render tests.

AI-use disclosure: implemented by Claude (Claude Code) under human direction and review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
