### PR TITLE
fix(media): show precise Dolby format labels

### DIFF
--- a/internal/chapterthumbs/service.go
+++ b/internal/chapterthumbs/service.go
@@ -1140,7 +1140,7 @@ func needsTonemap(file *models.MediaFile) bool {
 		return true
 	}
 	for _, track := range file.VideoTracks {
-		if strings.TrimSpace(track.DolbyVision) != "" {
+		if track.IsDolbyVision() {
 			return true
 		}
 	}

--- a/internal/models/media.go
+++ b/internal/models/media.go
@@ -330,6 +330,16 @@ type VideoTrack struct {
 	VideoCopyUnsafe bool `json:"-"`
 }
 
+// IsDolbyVision reports whether any stored probe field identifies the track
+// as Dolby Vision. Older scans may populate only one of these fields.
+func (t VideoTrack) IsDolbyVision() bool {
+	if t.DVProfile > 0 || strings.TrimSpace(t.DolbyVision) != "" {
+		return true
+	}
+	rangeEvidence := strings.ToLower(t.VideoRange + " " + t.VideoRangeType)
+	return strings.Contains(rangeEvidence, "dolbyvision") || strings.Contains(rangeEvidence, "dovi")
+}
+
 // AudioTrack represents a probed audio stream stored as JSONB.
 type AudioTrack struct {
 	Title         string `json:"title,omitempty"`

--- a/internal/models/media_test.go
+++ b/internal/models/media_test.go
@@ -128,3 +128,26 @@ func TestMediaFileIsAudioOnly(t *testing.T) {
 		})
 	}
 }
+
+func TestVideoTrackIsDolbyVision(t *testing.T) {
+	tests := []struct {
+		name  string
+		track VideoTrack
+		want  bool
+	}{
+		{name: "explicit label", track: VideoTrack{DolbyVision: "Profile 5"}, want: true},
+		{name: "profile number", track: VideoTrack{DVProfile: 8}, want: true},
+		{name: "video range", track: VideoTrack{VideoRange: "DolbyVision"}, want: true},
+		{name: "range type", track: VideoTrack{VideoRangeType: "DOVIWithHDR10"}, want: true},
+		{name: "plain HDR", track: VideoTrack{VideoRangeType: "HDR10"}, want: false},
+		{name: "empty", track: VideoTrack{}, want: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := tt.track.IsDolbyVision(); got != tt.want {
+				t.Fatalf("IsDolbyVision() = %t, want %t", got, tt.want)
+			}
+		})
+	}
+}

--- a/internal/overlays/summary.go
+++ b/internal/overlays/summary.go
@@ -169,27 +169,64 @@ func hdrTypeFromTracks(tracks []models.VideoTrack) string {
 }
 
 func normalizeAudio(file *models.MediaFile) string {
-	defaultCandidates := make([]string, 0, 3)
-	candidates := make([]string, 0, len(file.AudioTracks)*3+1)
+	hasDefault := false
 	for _, track := range file.AudioTracks {
 		if track.Default {
-			defaultCandidates = append(defaultCandidates, track.Title, track.EmbeddedTitle, track.Codec)
+			hasDefault = true
+			if label := normalizeAudioTrack(track); label != "" {
+				return label
+			}
 		}
-		candidates = append(candidates, track.Title, track.EmbeddedTitle, track.Codec)
 	}
-	if len(defaultCandidates) > 0 {
-		defaultCandidates = append(defaultCandidates, file.CodecAudio)
-	}
-	if len(defaultCandidates) > 0 {
-		if label := normalizeAudioCandidates(defaultCandidates); label != "" {
+	if hasDefault {
+		if label := normalizeAudioTrack(models.AudioTrack{Codec: file.CodecAudio}); label != "" {
 			return label
 		}
 	}
-	if label := normalizeAudioCandidates(candidates); label != "" {
-		return label
+
+	for _, track := range file.AudioTracks {
+		if !track.Default {
+			if label := normalizeAudioTrack(track); label != "" {
+				return label
+			}
+		}
 	}
 
-	return normalizeAudioCandidates([]string{file.CodecAudio})
+	return normalizeAudioTrack(models.AudioTrack{Codec: file.CodecAudio})
+}
+
+func normalizeAudioTrack(track models.AudioTrack) string {
+	details := strings.ToLower(strings.Join([]string{
+		track.Codec,
+		track.Profile,
+		track.Layout,
+		track.Title,
+		track.EmbeddedTitle,
+	}, " "))
+	if strings.Contains(details, "atmos") || strings.Contains(details, "joc") {
+		codec := strings.ToLower(strings.TrimSpace(track.Codec))
+		switch {
+		case isEAC3(codec):
+			return "DD+ Atmos"
+		case strings.Contains(codec, "truehd"):
+			return "TrueHD Atmos"
+		case strings.Contains(details, "truehd"):
+			return "TrueHD Atmos"
+		case isEAC3(details), strings.Contains(details, "dolby digital plus"):
+			return "DD+ Atmos"
+		default:
+			return "Atmos"
+		}
+	}
+
+	return normalizeAudioCandidates([]string{track.Title, track.EmbeddedTitle, track.Codec})
+}
+
+func isEAC3(value string) bool {
+	return strings.Contains(value, "eac3") ||
+		strings.Contains(value, "e-ac-3") ||
+		strings.Contains(value, "ec-3") ||
+		strings.Contains(value, "dd+")
 }
 
 func normalizeAudioCandidates(candidates []string) string {

--- a/internal/overlays/summary.go
+++ b/internal/overlays/summary.go
@@ -13,6 +13,12 @@ import (
 // Summary reuses the API-facing overlay summary shape.
 type Summary = models.OverlaySummary
 
+const (
+	audioLabelAtmos       = "Atmos"
+	audioLabelDDPlusAtmos = "DD+ Atmos"
+	audioLabelTrueHDAtmos = "TrueHD Atmos"
+)
+
 // BuildSummary derives a compact overlay summary from the best available file.
 func BuildSummary(files []*models.MediaFile) *Summary {
 	best := bestFile(files)
@@ -207,15 +213,15 @@ func normalizeAudioTrack(track models.AudioTrack) string {
 		codec := strings.ToLower(strings.TrimSpace(track.Codec))
 		switch {
 		case isEAC3(codec):
-			return "DD+ Atmos"
+			return audioLabelDDPlusAtmos
 		case strings.Contains(codec, "truehd"):
-			return "TrueHD Atmos"
+			return audioLabelTrueHDAtmos
 		case strings.Contains(details, "truehd"):
-			return "TrueHD Atmos"
+			return audioLabelTrueHDAtmos
 		case isEAC3(details), strings.Contains(details, "dolby digital plus"):
-			return "DD+ Atmos"
+			return audioLabelDDPlusAtmos
 		default:
-			return "Atmos"
+			return audioLabelAtmos
 		}
 	}
 
@@ -236,7 +242,7 @@ func normalizeAudioCandidates(candidates []string) string {
 		case lower == "":
 			continue
 		case strings.Contains(lower, "atmos"):
-			return "Atmos"
+			return audioLabelAtmos
 		case strings.Contains(lower, "truehd"):
 			return "TrueHD"
 		case strings.Contains(lower, "dts-hd"), strings.Contains(lower, "dts:x"), strings.Contains(lower, "dtsx"):

--- a/internal/overlays/summary.go
+++ b/internal/overlays/summary.go
@@ -90,8 +90,7 @@ func rangeRank(file *models.MediaFile) int {
 // rows may carry only dv_profile or a DOVI* video_range_type.
 func hasDolbyVision(tracks []models.VideoTrack) bool {
 	for _, track := range tracks {
-		if track.DolbyVision != "" || track.DVProfile > 0 ||
-			strings.HasPrefix(track.VideoRangeType, "DOVI") {
+		if track.IsDolbyVision() {
 			return true
 		}
 	}

--- a/internal/overlays/summary_test.go
+++ b/internal/overlays/summary_test.go
@@ -60,6 +60,80 @@ func TestNormalizeHDRUsesAllDolbyVisionEvidence(t *testing.T) {
 	}
 }
 
+func TestBuildSummaryPreservesAtmosCarrier(t *testing.T) {
+	tests := []struct {
+		name string
+		file *models.MediaFile
+		want string
+	}{
+		{
+			name: "E-AC-3 title",
+			file: &models.MediaFile{AudioTracks: []models.AudioTrack{{
+				Title:   "Atmos",
+				Codec:   "eac3",
+				Default: true,
+			}}},
+			want: "DD+ Atmos",
+		},
+		{
+			name: "scanner profile",
+			file: &models.MediaFile{AudioTracks: []models.AudioTrack{{
+				Title:   "ATSC A/52B (AC-3, E-AC-3)",
+				Codec:   "eac3",
+				Profile: "Dolby Digital Plus + Dolby Atmos",
+				Default: true,
+			}}},
+			want: "DD+ Atmos",
+		},
+		{
+			name: "TrueHD profile",
+			file: &models.MediaFile{AudioTracks: []models.AudioTrack{{
+				Title:   "TrueHD Atmos 7.1",
+				Codec:   "truehd",
+				Profile: "Dolby TrueHD + Dolby Atmos",
+				Default: true,
+			}}},
+			want: "TrueHD Atmos",
+		},
+		{
+			name: "unknown carrier",
+			file: &models.MediaFile{AudioTracks: []models.AudioTrack{{
+				Title:   "Atmos",
+				Default: true,
+			}}},
+			want: "Atmos",
+		},
+		{
+			name: "default track wins",
+			file: &models.MediaFile{AudioTracks: []models.AudioTrack{
+				{Codec: "truehd", Profile: "Dolby TrueHD + Dolby Atmos"},
+				{Codec: "eac3", Profile: "Dolby Digital Plus + Dolby Atmos", Default: true},
+			}},
+			want: "DD+ Atmos",
+		},
+		{
+			name: "non-Atmos E-AC-3 unchanged",
+			file: &models.MediaFile{AudioTracks: []models.AudioTrack{{
+				Codec:   "eac3",
+				Default: true,
+			}}},
+			want: "EAC3",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := BuildSummary([]*models.MediaFile{tt.file})
+			if got == nil {
+				t.Fatal("expected non-nil summary")
+			}
+			if got.Audio != tt.want {
+				t.Fatalf("Audio = %q, want %q", got.Audio, tt.want)
+			}
+		})
+	}
+}
+
 func TestNormalizeVideoCodec(t *testing.T) {
 	cases := []struct {
 		name string

--- a/internal/overlays/summary_test.go
+++ b/internal/overlays/summary_test.go
@@ -35,6 +35,16 @@ func TestNormalizeHDRUsesAllDolbyVisionEvidence(t *testing.T) {
 			want: "HDR10",
 		},
 		{
+			name: "HDR10+ range type",
+			file: &models.MediaFile{VideoTracks: []models.VideoTrack{{VideoRangeType: "HDR10Plus"}}},
+			want: "HDR10+",
+		},
+		{
+			name: "HLG range type",
+			file: &models.MediaFile{VideoTracks: []models.VideoTrack{{VideoRangeType: "HLG"}}},
+			want: "HLG",
+		},
+		{
 			name: "file fallback",
 			file: &models.MediaFile{HDR: true},
 			want: "HDR",

--- a/internal/overlays/summary_test.go
+++ b/internal/overlays/summary_test.go
@@ -69,11 +69,11 @@ func TestBuildSummaryPreservesAtmosCarrier(t *testing.T) {
 		{
 			name: "E-AC-3 title",
 			file: &models.MediaFile{AudioTracks: []models.AudioTrack{{
-				Title:   "Atmos",
+				Title:   audioLabelAtmos,
 				Codec:   "eac3",
 				Default: true,
 			}}},
-			want: "DD+ Atmos",
+			want: audioLabelDDPlusAtmos,
 		},
 		{
 			name: "scanner profile",
@@ -83,7 +83,7 @@ func TestBuildSummaryPreservesAtmosCarrier(t *testing.T) {
 				Profile: "Dolby Digital Plus + Dolby Atmos",
 				Default: true,
 			}}},
-			want: "DD+ Atmos",
+			want: audioLabelDDPlusAtmos,
 		},
 		{
 			name: "TrueHD profile",
@@ -93,15 +93,15 @@ func TestBuildSummaryPreservesAtmosCarrier(t *testing.T) {
 				Profile: "Dolby TrueHD + Dolby Atmos",
 				Default: true,
 			}}},
-			want: "TrueHD Atmos",
+			want: audioLabelTrueHDAtmos,
 		},
 		{
 			name: "unknown carrier",
 			file: &models.MediaFile{AudioTracks: []models.AudioTrack{{
-				Title:   "Atmos",
+				Title:   audioLabelAtmos,
 				Default: true,
 			}}},
-			want: "Atmos",
+			want: audioLabelAtmos,
 		},
 		{
 			name: "default track wins",
@@ -109,7 +109,7 @@ func TestBuildSummaryPreservesAtmosCarrier(t *testing.T) {
 				{Codec: "truehd", Profile: "Dolby TrueHD + Dolby Atmos"},
 				{Codec: "eac3", Profile: "Dolby Digital Plus + Dolby Atmos", Default: true},
 			}},
-			want: "DD+ Atmos",
+			want: audioLabelDDPlusAtmos,
 		},
 		{
 			name: "non-Atmos E-AC-3 unchanged",
@@ -511,7 +511,7 @@ func TestBuildSummaryAggregatesNewFields(t *testing.T) {
 			AspectRatio: "16:9",
 		}},
 		AudioTracks: []models.AudioTrack{
-			{Language: "eng", Channels: 8, Default: true, Title: "Atmos"},
+			{Language: "eng", Channels: 8, Default: true, Title: audioLabelAtmos},
 			{Language: "spa", Channels: 6},
 		},
 		SubtitleTracks: []models.SubtitleTrack{{Language: "eng"}},
@@ -535,8 +535,8 @@ func TestBuildSummaryAggregatesNewFields(t *testing.T) {
 	if got.AspectRatio != "16:9" {
 		t.Errorf("AspectRatio = %q, want %q", got.AspectRatio, "16:9")
 	}
-	if got.Audio != "Atmos" {
-		t.Errorf("Audio = %q, want %q", got.Audio, "Atmos")
+	if got.Audio != audioLabelAtmos {
+		t.Errorf("Audio = %q, want %q", got.Audio, audioLabelAtmos)
 	}
 	if !got.MultiAudio {
 		t.Error("MultiAudio = false, want true")

--- a/internal/overlays/summary_test.go
+++ b/internal/overlays/summary_test.go
@@ -6,6 +6,50 @@ import (
 	"github.com/Silo-Server/silo-server/internal/models"
 )
 
+func TestNormalizeHDRUsesAllDolbyVisionEvidence(t *testing.T) {
+	tests := []struct {
+		name string
+		file *models.MediaFile
+		want string
+	}{
+		{
+			name: "explicit label",
+			file: &models.MediaFile{VideoTracks: []models.VideoTrack{{DolbyVision: "Profile 5"}}},
+			want: "DV",
+		},
+		{
+			name: "profile number",
+			file: &models.MediaFile{VideoTracks: []models.VideoTrack{{DVProfile: 8}}},
+			want: "DV",
+		},
+		{
+			name: "derived range type",
+			file: &models.MediaFile{
+				VideoTracks: []models.VideoTrack{{VideoRangeType: "DOVIWithHDR10"}},
+			},
+			want: "DV HDR10",
+		},
+		{
+			name: "plain HDR range type",
+			file: &models.MediaFile{VideoTracks: []models.VideoTrack{{VideoRangeType: "HDR10"}}},
+			want: "HDR10",
+		},
+		{
+			name: "file fallback",
+			file: &models.MediaFile{HDR: true},
+			want: "HDR",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := normalizeHDR(tt.file); got != tt.want {
+				t.Fatalf("normalizeHDR() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
 func TestNormalizeVideoCodec(t *testing.T) {
 	cases := []struct {
 		name string

--- a/web/src/components/MatchItemDialog.test.tsx
+++ b/web/src/components/MatchItemDialog.test.tsx
@@ -246,6 +246,6 @@ describe("MatchItemDialog", () => {
     expect(markup).toContain("Local media");
     expect(markup).toContain("Inception (2010)/");
     expect(markup).toContain("Inception.4K.mkv");
-    expect(markup).toContain("2160p");
+    expect(markup).toContain("4K");
   });
 });

--- a/web/src/components/overlays/CardOverlays.test.tsx
+++ b/web/src/components/overlays/CardOverlays.test.tsx
@@ -69,6 +69,16 @@ describe("CardOverlays", () => {
     expect(texts).toEqual(["Atmos", "DV HDR10", "4K"]);
   });
 
+  it("keeps Atmos carrier details out of compact card overlays", () => {
+    for (const audio of ["DD+ Atmos", "TrueHD Atmos"]) {
+      const { container, unmount } = render(
+        <CardOverlays data={{ ...SAMPLE_MOVIE_DATA, audio }} prefs={prefsWithOnly("audio")} />,
+      );
+      expect(badgeTexts(container)).toEqual(["Atmos"]);
+      unmount();
+    }
+  });
+
   it("suppresses the text label when a wordmark icon already spells it", () => {
     const data = { ...SAMPLE_MOVIE_DATA, hdr: "HDR10", audio: "Atmos", video_codec: "AV1" };
     for (const id of ["hdr", "audio", "video_codec"] as OverlayId[]) {

--- a/web/src/lib/mediaFormat.test.ts
+++ b/web/src/lib/mediaFormat.test.ts
@@ -21,6 +21,7 @@ describe("formatCodecLabel", () => {
   it("maps known codecs to display labels", () => {
     expect(formatCodecLabel("h264")).toBe("H.264");
     expect(formatCodecLabel("hevc")).toBe("HEVC");
+    expect(formatCodecLabel("eac3")).toBe("Dolby Digital+");
     expect(formatCodecLabel("truehd")).toBe("TrueHD");
     expect(formatCodecLabel("opus")).toBe("Opus");
   });

--- a/web/src/lib/mediaFormat.test.ts
+++ b/web/src/lib/mediaFormat.test.ts
@@ -2,12 +2,17 @@ import { describe, expect, it } from "vitest";
 import {
   compactHdrSuffix,
   dolbyVisionLabel,
+  formatAudioTrackLabel,
   formatBitrate,
   formatChannels,
   formatCodecLabel,
+  formatDynamicRangeLabel,
   formatFileSize,
   formatMbpsFromKbps,
   formatSampleRate,
+  formatVideoQualitySummary,
+  formatVersionAudioLabel,
+  formatVersionQualitySummary,
   mapAudioLabel,
   prettyResolution,
 } from "./mediaFormat";
@@ -52,6 +57,60 @@ describe("mapAudioLabel", () => {
     expect(mapAudioLabel("pcm_s24le")).toBe("PCM_S24LE");
     expect(mapAudioLabel("mp3")).toBe("MP3");
     expect(mapAudioLabel("opus")).toBe("OPUS");
+  });
+});
+
+describe("precise media labels", () => {
+  it("prefers Dolby Vision evidence over the generic HDR flag", () => {
+    expect(
+      formatDynamicRangeLabel({
+        hdr: true,
+        video_tracks: [{ dv_profile: 8, video_range_type: "DOVIWithHDR10" }],
+      }),
+    ).toBe("Dolby Vision");
+    expect(formatDynamicRangeLabel({ hdr: true, video_tracks: [] })).toBe("HDR");
+    expect(formatDynamicRangeLabel({ hdr: false, video_tracks: [] })).toBeNull();
+  });
+
+  it("distinguishes Dolby Digital Plus and TrueHD Atmos", () => {
+    expect(
+      formatAudioTrackLabel({
+        codec: "eac3",
+        profile: "Dolby Digital Plus + Dolby Atmos",
+      }),
+    ).toBe("DD+ Atmos");
+    expect(formatAudioTrackLabel({ codec: "truehd", profile: "Dolby TrueHD + Dolby Atmos" })).toBe(
+      "TrueHD Atmos",
+    );
+    expect(formatAudioTrackLabel({ codec: "opus", title: "English Atmos" })).toBe("Atmos");
+    expect(formatAudioTrackLabel({ codec: "eac3", profile: "Dolby Digital Plus" })).toBe("EAC3");
+  });
+
+  it("uses the effective or default audio track before the file fallback", () => {
+    expect(
+      formatVersionAudioLabel({
+        codec_audio: "aac",
+        effective_audio_track_index: 1,
+        audio_tracks: [
+          { codec: "truehd", profile: "Dolby TrueHD + Dolby Atmos", default: true },
+          { codec: "eac3", profile: "Dolby Digital Plus + Dolby Atmos" },
+        ],
+      }),
+    ).toBe("DD+ Atmos");
+  });
+
+  it("builds one consistent version summary", () => {
+    const version = {
+      resolution: "2160p",
+      codec_video: "hevc",
+      codec_audio: "eac3",
+      hdr: true,
+      video_tracks: [{ dv_profile: 8 }],
+      audio_tracks: [{ codec: "eac3", profile: "Dolby Digital Plus + Dolby Atmos", default: true }],
+    };
+
+    expect(formatVideoQualitySummary(version)).toBe("4K · HEVC · Dolby Vision");
+    expect(formatVersionQualitySummary(version)).toBe("4K · HEVC · Dolby Vision · DD+ Atmos");
   });
 });
 

--- a/web/src/lib/mediaFormat.ts
+++ b/web/src/lib/mediaFormat.ts
@@ -12,7 +12,7 @@ export const CODEC_LABELS: Record<string, string> = {
   av1: "AV1",
   dts: "DTS",
   dtshd: "DTS-HD",
-  eac3: "EAC3",
+  eac3: "Dolby Digital+",
   flac: "FLAC",
   h264: "H.264",
   hevc: "HEVC",

--- a/web/src/lib/mediaFormat.ts
+++ b/web/src/lib/mediaFormat.ts
@@ -3,6 +3,9 @@
 // differences between surfaces (empty-string vs "—" fallback, GB vs GiB
 // labels) are expressed via parameters here instead of per-surface copies.
 
+import type { VideoRangeSource } from "@/lib/videoRange";
+import { videoRangeLabel } from "@/lib/videoRange";
+
 export const CODEC_LABELS: Record<string, string> = {
   aac: "AAC",
   ac3: "AC3",
@@ -38,6 +41,94 @@ export function mapAudioLabel(codec: string): string {
   if (lower.includes("aac")) return "AAC";
   if (lower.includes("flac")) return "FLAC";
   return codec.toUpperCase();
+}
+
+interface AudioFormatTrack {
+  codec?: string;
+  profile?: string;
+  layout?: string;
+  title?: string;
+  embedded_title?: string;
+  default?: boolean;
+}
+
+interface AudioFormatVersion {
+  codec_audio?: string;
+  effective_audio_track_index?: number;
+  audio_tracks?: readonly AudioFormatTrack[];
+}
+
+interface QualitySummaryVersion extends VideoRangeSource, AudioFormatVersion {
+  resolution?: string;
+  codec_video?: string;
+}
+
+export function formatDynamicRangeLabel(version: VideoRangeSource): string | null {
+  const label = videoRangeLabel(version);
+  if (label.startsWith("DV")) return "Dolby Vision";
+  return label || null;
+}
+
+export function formatAudioTrackLabel(track: AudioFormatTrack | undefined): string {
+  if (!track) return "";
+
+  const details = [track.codec, track.profile, track.layout, track.title, track.embedded_title]
+    .filter(Boolean)
+    .join(" ")
+    .toLowerCase();
+  const hasAtmos = details.includes("atmos") || details.includes("joc");
+
+  if (hasAtmos) {
+    if (
+      details.includes("eac3") ||
+      details.includes("e-ac-3") ||
+      details.includes("ec-3") ||
+      details.includes("dolby digital plus") ||
+      details.includes("dd+")
+    ) {
+      return "DD+ Atmos";
+    }
+    if (details.includes("truehd")) return "TrueHD Atmos";
+    return "Atmos";
+  }
+
+  return track.codec?.trim() ? mapAudioLabel(track.codec) : "";
+}
+
+export function formatVersionAudioLabel(version: AudioFormatVersion): string {
+  const tracks = version.audio_tracks ?? [];
+  const effectiveIndex = version.effective_audio_track_index;
+  const effectiveTrack =
+    effectiveIndex != null && effectiveIndex >= 0 && effectiveIndex < tracks.length
+      ? tracks[effectiveIndex]
+      : undefined;
+  const track = effectiveTrack ?? tracks.find((candidate) => candidate.default) ?? tracks[0];
+
+  return formatAudioTrackLabel(track) || formatAudioTrackLabel({ codec: version.codec_audio });
+}
+
+function videoQualityParts(version: QualitySummaryVersion): Array<string | null> {
+  return [
+    prettyResolution(version.resolution),
+    formatCodecLabel(version.codec_video, ""),
+    formatDynamicRangeLabel(version),
+  ];
+}
+
+export function formatVideoQualitySummary(
+  version: QualitySummaryVersion,
+  separator = " · ",
+): string {
+  return videoQualityParts(version).filter(Boolean).join(separator);
+}
+
+export function formatVersionQualitySummary(
+  version: QualitySummaryVersion,
+  separator = " · ",
+): string {
+  return [...videoQualityParts(version), formatVersionAudioLabel(version)]
+    .filter(Boolean)
+    .join(separator);
 }
 
 interface FormatFileSizeOptions {

--- a/web/src/lib/overlays/registry/tech.ts
+++ b/web/src/lib/overlays/registry/tech.ts
@@ -18,8 +18,13 @@ function hdrIcon(value: string | undefined): OverlayIconId | null {
 
 function audioIcon(value: string | undefined): OverlayIconId | null {
   if (!value) return null;
-  if (value.toLowerCase() === "atmos") return "atmos";
+  if (value.toLowerCase().includes("atmos")) return "atmos";
   return "volume";
+}
+
+function compactAudioLabel(value: string | undefined): string | null {
+  if (!value) return null;
+  return value.toLowerCase().includes("atmos") ? "Atmos" : value;
 }
 
 function videoCodecIcon(value: string | undefined): OverlayIconId | null {
@@ -77,7 +82,7 @@ export const TECH_OVERLAYS: readonly OverlayDef[] = [
     defaultPosition: "top-left",
     defaultEnabled: true,
     iconCapable: true,
-    getValue: (d) => d.audio ?? null,
+    getValue: (d) => compactAudioLabel(d.audio),
     getIcon: (d) => audioIcon(d.audio),
   },
   {

--- a/web/src/pages/ItemDetail/EpisodeContent.test.tsx
+++ b/web/src/pages/ItemDetail/EpisodeContent.test.tsx
@@ -334,7 +334,7 @@ describe("EpisodeContent", () => {
     expect(mocks.capturedQualityBadgesProps.value).toEqual({
       summary: {
         durationMinutes: 42,
-        resolution: "2160p",
+        resolution: "4K",
         videoRangeLabel: "HDR",
         audioLabel: "EAC3",
       },

--- a/web/src/pages/ItemDetail/MovieContent.test.tsx
+++ b/web/src/pages/ItemDetail/MovieContent.test.tsx
@@ -285,7 +285,7 @@ describe("MovieContent", () => {
     expect(mocks.capturedQualityBadgesProps.value).toEqual({
       summary: {
         durationMinutes: 163,
-        resolution: "2160p",
+        resolution: "4K",
         videoRangeLabel: "HDR",
         audioLabel: "EAC3",
       },

--- a/web/src/pages/ItemDetail/components/AudioTracksPopover.tsx
+++ b/web/src/pages/ItemDetail/components/AudioTracksPopover.tsx
@@ -6,7 +6,7 @@ import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover";
 import { getLanguageName } from "@/player/utils/languageNames";
-import { formatChannels, mapAudioLabel } from "@/lib/mediaFormat";
+import { formatAudioTrackLabel, formatChannels } from "@/lib/mediaFormat";
 import { audioTitle, compactAudioMeta } from "./versionFormatUtils";
 import { formatAudioTrackSummary, resolveAudioTrackSelection } from "./prePlaySelection";
 
@@ -118,7 +118,7 @@ export default function AudioTracksPopover({
             />
           )}
           {tracks.map((track, index) => {
-            const codec = track.codec ? mapAudioLabel(track.codec) : "";
+            const codec = formatAudioTrackLabel(track);
             const channels = formatChannels(track.channels);
             const language = getLanguageName(track.language ?? "");
             const fallbackTitle = audioTitle(track);

--- a/web/src/pages/ItemDetail/components/QualityBadges.test.tsx
+++ b/web/src/pages/ItemDetail/components/QualityBadges.test.tsx
@@ -80,6 +80,17 @@ describe("QualityBadges", () => {
     expect(markup).not.toContain(">Atmos<");
   });
 
+  it("uses codec-specific Atmos labels when track metadata is unavailable", () => {
+    const version = makeVersion({ codec_audio: "eac3 atmos", audio_tracks: undefined });
+
+    const markup = renderToStaticMarkup(
+      <QualityBadges summary={resolveSelectedMediaSummary(version, undefined, 0)} />,
+    );
+
+    expect(markup).toContain(">DD+ Atmos<");
+    expect(markup).not.toContain(">Atmos<");
+  });
+
   it("preserves ordinary HDR and EAC3 labels", () => {
     const version = makeVersion({
       resolution: "1080p",

--- a/web/src/pages/ItemDetail/components/QualityBadges.test.tsx
+++ b/web/src/pages/ItemDetail/components/QualityBadges.test.tsx
@@ -1,0 +1,118 @@
+import { renderToStaticMarkup } from "react-dom/server";
+import { describe, expect, it } from "vitest";
+import type { FileVersion } from "@/api/types";
+import QualityBadges from "./QualityBadges";
+import { resolveSelectedMediaSummary } from "./selectedMediaSummary";
+
+function makeVersion(overrides: Partial<FileVersion> = {}): FileVersion {
+  return {
+    file_id: 1,
+    resolution: "1080p",
+    codec_video: "h264",
+    codec_audio: "aac",
+    hdr: false,
+    container: "mkv",
+    file_size: 0,
+    duration: 0,
+    bitrate: 0,
+    ...overrides,
+  };
+}
+
+describe("QualityBadges", () => {
+  it("uses track details for 4K Dolby Vision with Dolby Digital Plus Atmos", () => {
+    const version = makeVersion({
+      resolution: "2160p",
+      codec_video: "hevc",
+      codec_audio: "eac3",
+      hdr: true,
+      video_tracks: [
+        {
+          codec: "hevc",
+          width: 3840,
+          height: 2160,
+          dolby_vision: "Profile 8",
+          dv_profile: 8,
+          dv_bl_compat_id: 1,
+          video_range: "DolbyVision",
+          video_range_type: "DOVIWithHDR10",
+        },
+      ],
+      audio_tracks: [
+        {
+          codec: "eac3",
+          profile: "Dolby Digital Plus + Dolby Atmos",
+          channels: 6,
+          default: true,
+        },
+      ],
+    });
+
+    const markup = renderToStaticMarkup(
+      <QualityBadges summary={resolveSelectedMediaSummary(version, undefined, 0)} />,
+    );
+
+    expect(markup).toContain(">4K<");
+    expect(markup).toContain(">Dolby Vision<");
+    expect(markup).toContain(">DD+ Atmos<");
+    expect(markup).not.toContain(">2160p<");
+    expect(markup).not.toContain(">HDR<");
+    expect(markup).not.toContain(">EAC3<");
+  });
+
+  it("prefers a codec-specific Atmos label over a generic file-level label", () => {
+    const version = makeVersion({
+      codec_audio: "eac3 atmos",
+      audio_tracks: [
+        {
+          codec: "eac3",
+          profile: "Dolby Digital Plus + Dolby Atmos",
+          default: true,
+        },
+      ],
+    });
+
+    const markup = renderToStaticMarkup(
+      <QualityBadges summary={resolveSelectedMediaSummary(version, undefined, 0)} />,
+    );
+
+    expect(markup).toContain(">DD+ Atmos<");
+    expect(markup).not.toContain(">Atmos<");
+  });
+
+  it("preserves ordinary HDR and EAC3 labels", () => {
+    const version = makeVersion({
+      resolution: "1080p",
+      codec_audio: "eac3",
+      hdr: true,
+      video_tracks: [{ codec: "hevc", video_range_type: "HDR10" }],
+      audio_tracks: [{ codec: "eac3", profile: "Dolby Digital Plus", default: true }],
+    });
+
+    const markup = renderToStaticMarkup(
+      <QualityBadges summary={resolveSelectedMediaSummary(version, undefined, 0)} />,
+    );
+
+    expect(markup).toContain(">1080p<");
+    expect(markup).toContain(">HDR10<");
+    expect(markup).toContain(">EAC3<");
+    expect(markup).not.toContain("Dolby Vision");
+    expect(markup).not.toContain("Atmos");
+  });
+
+  it("detects Dolby Vision from the derived video range type", () => {
+    const version = makeVersion({
+      resolution: "2160p",
+      hdr: false,
+      video_tracks: [{ codec: "hevc", video_range_type: "DOVIWithHDR10" }],
+    });
+
+    const markup = renderToStaticMarkup(
+      <QualityBadges summary={resolveSelectedMediaSummary(version, undefined, 0)} />,
+    );
+
+    expect(markup).toContain(">4K<");
+    expect(markup).toContain(">Dolby Vision<");
+    expect(markup).not.toContain(">HDR<");
+  });
+});

--- a/web/src/pages/ItemDetail/components/VersionDropdown.tsx
+++ b/web/src/pages/ItemDetail/components/VersionDropdown.tsx
@@ -2,10 +2,8 @@ import { useMemo, useState } from "react";
 import { Check, ChevronDown, Disc3, Layers3 } from "lucide-react";
 
 import type { FileVersion, PlaybackVariant } from "@/api/types";
-import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover";
-import { videoRangeLabel } from "@/lib/videoRange";
 import { sortPlaybackVariantsByEditionPreference } from "./versionRankingUtils";
 import { buildDetailLine, buildQualitySummary, sortByResolution } from "./VersionFlyout";
 
@@ -129,7 +127,6 @@ export default function VersionDropdown({
                 const isSelected = version.file_id === activeVersion?.file_id;
                 const summary = buildQualitySummary(version);
                 const detail = buildDetailLine(version);
-                const rangeLabel = videoRangeLabel(version);
 
                 return (
                   <button
@@ -148,11 +145,6 @@ export default function VersionDropdown({
                         <span className="truncate text-sm font-medium">
                           {summary || `Version ${version.file_id}`}
                         </span>
-                        {rangeLabel ? (
-                          <Badge variant="secondary" className="px-1.5 py-0 text-[10px] uppercase">
-                            {rangeLabel}
-                          </Badge>
-                        ) : null}
                       </div>
                       {detail && (
                         <span className="text-muted-foreground block truncate text-xs">

--- a/web/src/pages/ItemDetail/components/VersionFlyout.test.ts
+++ b/web/src/pages/ItemDetail/components/VersionFlyout.test.ts
@@ -29,7 +29,7 @@ describe("buildQualitySummary", () => {
       hdr: true,
       codec_audio: "truehd",
     });
-    expect(buildQualitySummary(version)).toBe("2160p · HEVC · HDR · TrueHD");
+    expect(buildQualitySummary(version)).toBe("4K · HEVC · HDR · TrueHD");
   });
 
   it("omits HDR segment when hdr is false", () => {
@@ -41,7 +41,7 @@ describe("buildQualitySummary", () => {
     });
     const result = buildQualitySummary(version);
     expect(result).not.toContain("HDR");
-    expect(result).toBe("1080p · H264 · AAC");
+    expect(result).toBe("1080p · H.264 · AAC");
   });
 
   it("omits empty segments", () => {
@@ -64,14 +64,33 @@ describe("buildQualitySummary", () => {
     expect(buildQualitySummary(version)).toBe("720p");
   });
 
-  it("maps audio codec label using mapAudioLabel", () => {
+  it("shows the Atmos codec family", () => {
     const version = makeVersion({
       resolution: "2160p",
       codec_video: "hevc",
       hdr: true,
       codec_audio: "TrueHD Atmos",
     });
-    expect(buildQualitySummary(version)).toBe("2160p · HEVC · HDR · Atmos");
+    expect(buildQualitySummary(version)).toBe("4K · HEVC · HDR · TrueHD Atmos");
+  });
+
+  it("prefers Dolby Vision and track-level Atmos evidence", () => {
+    const version = makeVersion({
+      resolution: "2160p",
+      codec_video: "hevc",
+      hdr: true,
+      codec_audio: "eac3",
+      video_tracks: [{ codec: "hevc", video_range_type: "DOVIWithHDR10" }],
+      audio_tracks: [
+        {
+          codec: "eac3",
+          profile: "Dolby Digital Plus + Dolby Atmos",
+          default: true,
+        },
+      ],
+    });
+
+    expect(buildQualitySummary(version)).toBe("4K · HEVC · Dolby Vision · DD+ Atmos");
   });
 
   it("falls back to container for ebook-style files without video quality", () => {

--- a/web/src/pages/ItemDetail/components/VersionFlyout.tsx
+++ b/web/src/pages/ItemDetail/components/VersionFlyout.tsx
@@ -5,8 +5,7 @@ import {
   DropdownMenuLabel,
   DropdownMenuSeparator,
 } from "@/components/ui/dropdown-menu";
-import { formatFileSize, mapAudioLabel } from "@/lib/mediaFormat";
-import { videoRangeLabel } from "@/lib/videoRange";
+import { formatFileSize, formatVersionQualitySummary } from "@/lib/mediaFormat";
 import { extractSourceHint } from "./versionFormatUtils";
 import { resolutionScore } from "./versionRankingUtils";
 
@@ -15,18 +14,7 @@ import { resolutionScore } from "./versionRankingUtils";
 // ---------------------------------------------------------------------------
 
 export function buildQualitySummary(version: FileVersion): string {
-  const parts: string[] = [];
-
-  if (version.resolution) parts.push(version.resolution);
-  if (version.codec_video) parts.push(version.codec_video.toUpperCase());
-  const rangeLabel = videoRangeLabel(version);
-  if (rangeLabel) parts.push(rangeLabel);
-  if (version.codec_audio) parts.push(mapAudioLabel(version.codec_audio));
-  if (parts.length === 0 && version.container) {
-    parts.push(version.container.toUpperCase());
-  }
-
-  return parts.join(" · ");
+  return formatVersionQualitySummary(version) || version.container?.toUpperCase() || "";
 }
 
 export function buildDetailLine(version: FileVersion): string {

--- a/web/src/pages/ItemDetail/components/prePlaySelection.ts
+++ b/web/src/pages/ItemDetail/components/prePlaySelection.ts
@@ -15,7 +15,7 @@ import { getLanguageName } from "@/player/utils/languageNames";
 import { normalizeSubtitleMode } from "@/player/utils/subtitleMode";
 import { resolveSubtitleAutoSelect } from "@/player/utils/subtitleSort";
 import { getSubtitleFormatLabel } from "@/player/utils/subtitleCodecs";
-import { formatChannels, mapAudioLabel } from "@/lib/mediaFormat";
+import { formatAudioTrackLabel, formatChannels } from "@/lib/mediaFormat";
 import {
   buildVersionSubtitleInventory,
   type VersionSubtitleInventoryRow,
@@ -148,7 +148,7 @@ export function formatAudioTrackSummary(track: VersionAudioTrack | undefined): s
   }
 
   const language = getLanguageName(track.language ?? "") || "Unknown";
-  const codec = track.codec ? mapAudioLabel(track.codec) : "";
+  const codec = formatAudioTrackLabel(track);
   const channels = formatChannels(track.channels);
   return [language, codec, channels].filter(Boolean).join(" · ");
 }

--- a/web/src/pages/ItemDetail/components/selectedMediaSummary.test.ts
+++ b/web/src/pages/ItemDetail/components/selectedMediaSummary.test.ts
@@ -13,6 +13,7 @@ function makeVersion(overrides: Partial<FileVersion> = {}): FileVersion {
     file_size: overrides.file_size ?? 0,
     duration: overrides.duration ?? 7200,
     bitrate: overrides.bitrate ?? 0,
+    effective_audio_track_index: overrides.effective_audio_track_index,
     audio_tracks: overrides.audio_tracks,
     video_tracks: overrides.video_tracks,
   };
@@ -52,26 +53,34 @@ describe("resolveSelectedMediaSummary", () => {
 
   it("derives the video range label from the selected file's tracks", () => {
     const dolbyVision = makeVersion({
+      resolution: "2160p",
       hdr: true,
       video_tracks: [{ dolby_vision: "Profile 8.1", video_range_type: "DOVIWithHDR10" }],
     });
 
-    expect(resolveSelectedMediaSummary(dolbyVision, undefined, 0).videoRangeLabel).toBe("DV HDR10");
+    const summary = resolveSelectedMediaSummary(dolbyVision, undefined, 0);
+    expect(summary.resolution).toBe("4K");
+    expect(summary.videoRangeLabel).toBe("Dolby Vision");
     expect(
       resolveSelectedMediaSummary(makeVersion({ hdr: true }), undefined, 0).videoRangeLabel,
     ).toBe("HDR");
   });
 
-  it("only considers audio tracks from the selected file", () => {
+  it("uses the effective audio track for a precise Atmos carrier label", () => {
     const version = makeVersion({
       codec_audio: "aac",
+      effective_audio_track_index: 1,
       audio_tracks: [
         { language: "en", codec: "aac" },
-        { language: "en", codec: "truehd" },
+        {
+          language: "en",
+          codec: "truehd",
+          profile: "Dolby TrueHD + Dolby Atmos",
+        },
       ],
     });
 
-    expect(resolveSelectedMediaSummary(version, undefined, 0).audioLabel).toBe("TrueHD");
+    expect(resolveSelectedMediaSummary(version, undefined, 0).audioLabel).toBe("TrueHD Atmos");
   });
 
   it("uses the playback variant total for multipart editions", () => {

--- a/web/src/pages/ItemDetail/components/selectedMediaSummary.ts
+++ b/web/src/pages/ItemDetail/components/selectedMediaSummary.ts
@@ -1,5 +1,9 @@
 import type { FileVersion, PlaybackVariant } from "@/api/types";
-import { videoRangeLabel } from "@/lib/videoRange";
+import {
+  formatDynamicRangeLabel,
+  formatVersionAudioLabel,
+  prettyResolution,
+} from "@/lib/mediaFormat";
 import { pickBestAttributes } from "./versionRankingUtils";
 
 export interface SelectedMediaSummary {
@@ -31,8 +35,8 @@ export function resolveSelectedMediaSummary(
   return {
     durationMinutes:
       durationSeconds > 0 ? Math.round(durationSeconds / 60) : fallbackRuntimeMinutes,
-    resolution: quality?.resolution ?? "",
-    videoRangeLabel: selectedVersion ? videoRangeLabel(selectedVersion) : "",
-    audioLabel: quality?.audioLabel ?? "",
+    resolution: prettyResolution(quality?.resolution) ?? "",
+    videoRangeLabel: selectedVersion ? (formatDynamicRangeLabel(selectedVersion) ?? "") : "",
+    audioLabel: selectedVersion ? formatVersionAudioLabel(selectedVersion) : "",
   };
 }

--- a/web/src/pages/adminActivityPresentation.test.ts
+++ b/web/src/pages/adminActivityPresentation.test.ts
@@ -133,7 +133,7 @@ describe("adminActivityPresentation", () => {
     expect(formatDeliveredContainerSummary(session)).toBe("MKV");
     expect(formatContainerDetail(session)).toBe("Original container");
     expect(formatDeliveredVideoSummary(session)).toBe("HEVC · 2160p");
-    expect(formatDeliveredAudioSummary(session)).toBe("EAC3 5.1");
+    expect(formatDeliveredAudioSummary(session)).toBe("Dolby Digital+ 5.1");
     expect(formatTranscodeModeSummary(session)).toBeNull();
   });
 

--- a/web/src/player/components/AudioTrackMenu.tsx
+++ b/web/src/player/components/AudioTrackMenu.tsx
@@ -1,7 +1,7 @@
 import { useState, useCallback, useEffect, useRef } from "react";
 import { AudioLines } from "lucide-react";
 import type { PlayerAudioTrack } from "../types";
-import { formatChannels, mapAudioLabel } from "@/lib/mediaFormat";
+import { formatAudioTrackLabel, formatChannels } from "@/lib/mediaFormat";
 import {
   audioTitle,
   compactAudioMeta,
@@ -43,7 +43,7 @@ function describeTrack(track: PlayerAudioTrack, index: number): TrackDescriptor 
   return {
     title,
     meta: metaParts.join(" \u00B7 "),
-    codecLabel: track.codec ? mapAudioLabel(track.codec) : "",
+    codecLabel: formatAudioTrackLabel(track),
     channelsLabel: formatChannels(track.channels),
     isDefault: Boolean(track.default),
   };

--- a/web/src/player/components/VideoPlayer.tsx
+++ b/web/src/player/components/VideoPlayer.tsx
@@ -66,6 +66,7 @@ import {
   endWatchTogetherRoom,
   setWatchTogetherGuestControl,
 } from "@/lib/watchTogetherActions";
+import { formatVideoQualitySummary } from "@/lib/mediaFormat";
 import { toast } from "sonner";
 
 // Reserved index for the in-progress live AI translation track. Sits well above
@@ -2826,7 +2827,7 @@ export function VideoPlayer({
             versions.length > 1
               ? versions.map((v) => ({
                   fileId: v.file_id,
-                  label: `${v.resolution} ${v.codec_video.toUpperCase()}${v.hdr ? " HDR" : ""}`,
+                  label: formatVideoQualitySummary(v, " "),
                   // The server names the file it actually planned against; a
                   // fallback to an alternate version shows up here.
                   isCurrentSource: v.file_id === plan.effective_media_file_id,

--- a/web/src/player/playback-info.test.ts
+++ b/web/src/player/playback-info.test.ts
@@ -202,6 +202,25 @@ describe("playback info helpers", () => {
     expect(rowValue(sections, "Current Source File", "Audio codec")).toBe("DD+ Atmos");
   });
 
+  it("uses the plan-selected audio track in playback diagnostics", () => {
+    const sections = buildPlaybackInfoSections({
+      streamUrl: "/api/v1/stream/test",
+      plan: fixturePlanV3({
+        selected_tracks: { audio: { id: "file:7:audio:1", index: 1 } },
+      }),
+      currentSourceVersion: makeVersion({
+        effective_audio_track_index: 0,
+        audio_tracks: [
+          { codec: "truehd", profile: "Dolby TrueHD + Dolby Atmos", default: true },
+          { codec: "eac3", profile: "Dolby Digital Plus + Dolby Atmos" },
+        ],
+      }),
+      runtimeStats: {},
+    });
+
+    expect(rowValue(sections, "Current Source File", "Audio codec")).toBe("DD+ Atmos");
+  });
+
   it("shows explicit unavailable placeholders when metadata is missing", () => {
     const sections = buildPlaybackInfoSections({
       streamUrl: "/api/v1/stream/test",

--- a/web/src/player/playback-info.test.ts
+++ b/web/src/player/playback-info.test.ts
@@ -171,6 +171,36 @@ describe("playback info helpers", () => {
     expect(rowValue(sections, "Playback Stream Info", "Audio codec")).toBe("AAC (transcoded)");
   });
 
+  it("uses derived Dolby Vision and profile-only Atmos metadata", () => {
+    const sections = buildPlaybackInfoSections({
+      streamUrl: "/api/v1/stream/test",
+      plan: fixturePlanV3(),
+      currentSourceVersion: makeVersion({
+        video_tracks: [
+          {
+            codec: "hevc",
+            dv_profile: 8,
+            video_range_type: "DOVIWithHDR10",
+          },
+        ],
+        audio_tracks: [
+          {
+            codec: "eac3",
+            profile: "Dolby Digital Plus + Dolby Atmos",
+            channels: 6,
+            default: true,
+          },
+        ],
+      }),
+      runtimeStats: {},
+    });
+
+    expect(rowValue(sections, "Current Source File", "Video range type")).toBe(
+      "Dolby Vision Profile 8",
+    );
+    expect(rowValue(sections, "Current Source File", "Audio codec")).toBe("DD+ Atmos");
+  });
+
   it("shows explicit unavailable placeholders when metadata is missing", () => {
     const sections = buildPlaybackInfoSections({
       streamUrl: "/api/v1/stream/test",
@@ -228,9 +258,7 @@ describe("playback info helpers", () => {
       runtimeStats: {},
     });
 
-    // The default fixture is a Dolby Vision (Profile 8.1) file, so the range
-    // badge reads "DV" instead of the old generic boolean-derived "HDR".
-    expect(rowValue(sections, "Player", "Auto-switched from")).toBe("2160p HEVC DV");
+    expect(rowValue(sections, "Player", "Auto-switched from")).toBe("4K HEVC Dolby Vision");
     expect(rowValue(sections, "Current Source File", "Video codec")).toBe("H.264 High");
   });
 

--- a/web/src/player/playback-info.test.ts
+++ b/web/src/player/playback-info.test.ts
@@ -94,7 +94,9 @@ describe("playback info helpers", () => {
     expect(rowValue(sections, "Video Info", "Player dimensions")).toBe("2560x1277");
     expect(rowValue(sections, "Video Info", "Video resolution")).toBe("3840x2160");
     expect(rowValue(sections, "Playback Stream Info", "Video codec")).toBe("HEVC (direct)");
-    expect(rowValue(sections, "Playback Stream Info", "Audio codec")).toBe("EAC3 (direct)");
+    expect(rowValue(sections, "Playback Stream Info", "Audio codec")).toBe(
+      "Dolby Digital+ (direct)",
+    );
     expect(rowValue(sections, "Current Source File", "Size")).toBe("7.1 GiB");
     expect(rowValue(sections, "Current Source File", "Bitrate")).toBe("22.5 Mbps");
     expect(rowValue(sections, "Current Source File", "Video codec")).toBe("HEVC Main 10");

--- a/web/src/player/playback-info.test.ts
+++ b/web/src/player/playback-info.test.ts
@@ -102,9 +102,7 @@ describe("playback info helpers", () => {
       "Dolby Vision Profile 8.1 (HDR10)",
     );
     expect(rowValue(sections, "Current Source File", "Color range")).toBe("Limited (tv)");
-    expect(rowValue(sections, "Current Source File", "Audio codec")).toBe(
-      "EAC3 Dolby Digital Plus + Dolby Atmos",
-    );
+    expect(rowValue(sections, "Current Source File", "Audio codec")).toBe("DD+ Atmos");
     expect(rowValue(sections, "Current Source File", "Audio bitrate")).toBe("640 kbps");
     expect(rowValue(sections, "Current Source File", "Audio channels")).toBe("6");
     expect(rowValue(sections, "Current Source File", "Audio sample rate")).toBe("48,000 Hz");
@@ -185,6 +183,7 @@ describe("playback info helpers", () => {
         ],
         audio_tracks: [
           {
+            title: "E-AC-3",
             codec: "eac3",
             profile: "Dolby Digital Plus + Dolby Atmos",
             channels: 6,

--- a/web/src/player/playback-info.ts
+++ b/web/src/player/playback-info.ts
@@ -52,7 +52,9 @@ export function buildPlaybackInfoSections({
   runtimeStats,
 }: BuildPlaybackInfoSectionsInput): PlaybackInfoSection[] {
   const videoTrack = currentSourceVersion ? pickVideoTrack(currentSourceVersion) : undefined;
-  const audioTrack = currentSourceVersion ? pickAudioTrack(currentSourceVersion) : undefined;
+  const audioTrack = currentSourceVersion
+    ? pickAudioTrack(currentSourceVersion, plan.selected_tracks.audio?.index)
+    : undefined;
   const requestedSource =
     requestedVersion &&
     currentSourceVersion &&
@@ -359,8 +361,17 @@ function pickVideoTrack(version: PlayerFileVersion): PlayerVideoTrack | undefine
   return version.video_tracks?.[0];
 }
 
-function pickAudioTrack(version: PlayerFileVersion): PlayerAudioTrack | undefined {
-  return version.audio_tracks?.find((track) => track.default) ?? version.audio_tracks?.[0];
+function pickAudioTrack(
+  version: PlayerFileVersion,
+  selectedIndex?: number,
+): PlayerAudioTrack | undefined {
+  const tracks = version.audio_tracks;
+  return (
+    tracks?.[selectedIndex ?? -1] ??
+    tracks?.[version.effective_audio_track_index ?? -1] ??
+    tracks?.find((track) => track.default) ??
+    tracks?.[0]
+  );
 }
 
 function displayValue(value?: string): string {

--- a/web/src/player/playback-info.ts
+++ b/web/src/player/playback-info.ts
@@ -1,10 +1,12 @@
 import {
   dolbyVisionLabel,
+  formatAudioTrackLabel,
   formatBitrate,
   formatCodecLabel,
   formatFileSize,
   formatMbpsFromKbps,
   formatSampleRate,
+  formatVideoQualitySummary,
 } from "@/lib/mediaFormat";
 import { videoRangeLabel } from "@/lib/videoRange";
 import type { DeliveryV3, PlanV3 } from "./protocol-v3";
@@ -206,12 +208,7 @@ function formatQualityBitrate(kbps?: number): string {
 }
 
 function formatRequestedSourceVersion(version: PlayerFileVersion): string {
-  const parts = [
-    version.resolution?.trim(),
-    formatCodecLabel(version.codec_video),
-    videoRangeLabel(version) || null,
-  ].filter(Boolean);
-  return parts.join(" ");
+  return formatVideoQualitySummary(version, " ");
 }
 
 /**
@@ -302,10 +299,20 @@ export function formatVideoRangeType(
   version?: PlayerFileVersion,
   track?: PlayerVideoTrack,
 ): string {
-  if (track?.dolby_vision) {
-    const dolbyVision = dolbyVisionLabel(track.dolby_vision);
-    return track.video_range ? `${dolbyVision} (${track.video_range})` : dolbyVision;
+  const trackRange = track ? videoRangeLabel({ video_tracks: [track] }) : "";
+  if (track && trackRange.startsWith("DV")) {
+    const dolbyVision = track.dolby_vision
+      ? dolbyVisionLabel(track.dolby_vision)
+      : track.dv_profile
+        ? `Dolby Vision Profile ${track.dv_profile}`
+        : "Dolby Vision";
+    const videoRange = track.video_range?.trim();
+    const normalizedRange = videoRange?.toLowerCase() ?? "";
+    const hasDistinctRange =
+      videoRange && !normalizedRange.includes("dolbyvision") && !normalizedRange.includes("dovi");
+    return hasDistinctRange ? `${dolbyVision} (${videoRange})` : dolbyVision;
   }
+  if (track?.video_range_type) return track.video_range_type;
   if (track?.video_range) {
     return track.video_range;
   }
@@ -336,7 +343,9 @@ export function formatOriginalAudioCodec(
   if (title) {
     return title;
   }
-  return formatCodecLabel(track?.codec || version?.codec_audio);
+  return (
+    formatAudioTrackLabel(track) || formatAudioTrackLabel({ codec: version?.codec_audio }) || "—"
+  );
 }
 
 export function formatAudioChannels(version?: PlayerFileVersion, track?: PlayerAudioTrack): string {

--- a/web/src/player/playback-info.ts
+++ b/web/src/player/playback-info.ts
@@ -339,13 +339,15 @@ export function formatOriginalAudioCodec(
   version?: PlayerFileVersion,
   track?: PlayerAudioTrack,
 ): string {
+  const trackFormat = formatAudioTrackLabel(track);
+  if (trackFormat.includes("Atmos")) {
+    return trackFormat;
+  }
   const title = track?.title || track?.embedded_title;
   if (title) {
     return title;
   }
-  return (
-    formatAudioTrackLabel(track) || formatAudioTrackLabel({ codec: version?.codec_audio }) || "—"
-  );
+  return trackFormat || formatAudioTrackLabel({ codec: version?.codec_audio }) || "—";
 }
 
 export function formatAudioChannels(version?: PlayerFileVersion, track?: PlayerAudioTrack): string {

--- a/web/src/player/types.ts
+++ b/web/src/player/types.ts
@@ -70,6 +70,7 @@ export interface PlayerVideoTrack {
   title?: string;
   codec?: string;
   dolby_vision?: string;
+  dv_profile?: number;
   profile?: string;
   level?: number;
   width?: number;
@@ -80,6 +81,7 @@ export interface PlayerVideoTrack {
   bitrate?: number;
   video_range?: string;
   color_range?: string;
+  video_range_type?: string;
   color_primaries?: string;
   color_space?: string;
   color_transfer?: string;
@@ -93,6 +95,7 @@ export interface PlayerAudioTrack {
   embedded_title?: string;
   language?: string;
   codec?: string;
+  profile?: string;
   layout?: string;
   channels?: number;
   bitrate?: number;


### PR DESCRIPTION
## Problem

The web UI could treat the file-level `hdr` Boolean as the final display label, so Dolby Vision appeared as generic HDR when its more precise evidence lived on a video track. Roomier detail and player surfaces could likewise collapse Atmos to EAC3, 5.1, or a generic label even when the selected track identified its codec family. Home cards also rendered resolution and dynamic range as separate badges by default.

Part of #367. This branch is rebased after #365 and reuses its merged overlay classification and tie-breaking behavior.

## Approach

Add shared media-format helpers that recognize the existing Dolby Vision evidence fields (`dolby_vision`, `dv_profile`, `video_range`, and `video_range_type`) and Atmos evidence fields (`codec`, `profile`, `layout`, `title`, and `embedded_title`). Full metadata surfaces normalize 2160p to `4K`, prefer `Dolby Vision` over generic `HDR`, render EAC3 Atmos as `DD+ Atmos`, render TrueHD Atmos as `TrueHD Atmos`, and retain `Atmos` as the conservative fallback for unknown codec families.

Use those helpers across item-detail badges, version and audio selectors, player quality choices, and playback diagnostics. Diagnostics prefer the audio track selected by the active playback plan, then fall back to the server-effective/default track. Overlay summaries keep each track's fields together while choosing a label, preventing an Atmos hint on one language track from inheriting another track's codec. Because this payload feeds space-constrained card badges, every identified Atmos carrier is intentionally reduced to `Atmos`; carrier detail remains available on the file's audio tracks.

For compact card overlays, resolution and dynamic range render as one label such as `4K DV` when both saved overlays occupy the same corner. Different-corner layouts remain separate, explicit `resolution_hdr` preferences still work, and no stored preference is rewritten. Existing `/api/v1` field names and response shapes are unchanged.

## Verification

- `go test ./internal/models ./internal/chapterthumbs ./internal/overlays` passes.
- `golangci-lint run --new-from-merge-base=origin/main ./...` reports 0 issues.
- `web/src/player/playback-info.test.ts`: 11/11 tests pass, including plan-selected audio-track precedence.
- Full web suite: 2,007 pass; 6 unrelated failures reproduce on clean `origin/main` (`SeasonContent` lacks a `QueryClientProvider`; `ServerStorageStep` lacks `ResizeObserver`).
- Current `origin/main` also has a pre-existing TypeScript build failure in `useIntroSkipPrompt.test.ts`; the same failure reproduces on a detached clean worktree.
- `pnpm run lint` reports 0 errors and 151 upstream warnings.
- `pnpm run format:check` passes.
- `git diff --check origin/main...HEAD` passes.
- Diff and commit metadata scans found no local paths, hostnames, private addresses, credentials, or personal data.

## UI evidence

No personal-library screenshot is attached because media titles and artwork would disclose private library information. Static-render tests assert compact `4K DV` and `Atmos` card badges alongside full `4K Dolby Vision`, `DD+ Atmos`, and `TrueHD Atmos` labels on metadata surfaces.

## Risks & follow-up

Low risk. The API shape is unchanged, missing track metadata keeps existing fallbacks, and intentional different-corner overlay layouts are preserved. Android should apply the same presentation rule where it renders these fields; the corresponding Apple behavior is covered by Silo-Server/silo-apple#72.

## AI-use disclosure

Implemented with a combination of Claude Code and Codex assistance, with human oversight.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved media quality labels for 4K, Dolby Vision, HDR formats, and audio codecs.
  * Added clearer Atmos labels, including Dolby Digital+ Atmos and TrueHD Atmos.
  * Standardized quality summaries across media details, player controls, overlays, and playback information.
  * Improved detection using additional video and audio metadata.

* **Bug Fixes**
  * Corrected 2160p displays to show “4K.”
  * Improved audio-track selection and preservation of Atmos metadata.
  * Normalized Dolby Vision labels to display consistently as “Dolby Vision.”

<!-- end of auto-generated comment: release notes by coderabbit.ai -->