### PR TITLE
fix(scanner): never purge files under unreachable library roots

### DIFF
--- a/internal/api/handlers/libraries.go
+++ b/internal/api/handlers/libraries.go
@@ -251,6 +251,11 @@ type libraryMountCheckRootResponse struct {
 	Reachable    bool    `json:"reachable"`
 	ErrorCode    *string `json:"error_code"`
 	ErrorMessage *string `json:"error_message"`
+	// SuspectEmpty is set when the root is reachable but the library holds
+	// only missing-marked files under it — the signature of a lost mount
+	// exposing an empty mountpoint directory, which a reachability probe
+	// alone cannot detect. Additive field; absent/false for healthy roots.
+	SuspectEmpty bool `json:"suspect_empty"`
 }
 
 type libraryMountCheckResponse struct {
@@ -847,7 +852,7 @@ func (h *LibraryHandler) HandleCheckLibraryMount(w http.ResponseWriter, r *http.
 		return
 	}
 
-	resp := checkLibraryMount(folder)
+	resp := h.checkLibraryMount(r.Context(), folder)
 	if resp.Healthy && folder.ScanWarningCode != nil &&
 		(*folder.ScanWarningCode == "empty_root" || *folder.ScanWarningCode == "dead_root") {
 		if err := h.folderRepo.ClearScanWarning(r.Context(), folder.ID); err != nil {
@@ -1257,7 +1262,7 @@ func scanBoolMetric(result *libraryingest.Result, pick func(*scanner.ScanResult)
 	return pick(result.ScanResult)
 }
 
-func checkLibraryMount(folder *models.MediaFolder) libraryMountCheckResponse {
+func (h *LibraryHandler) checkLibraryMount(ctx context.Context, folder *models.MediaFolder) libraryMountCheckResponse {
 	resp := libraryMountCheckResponse{
 		Status:      "ok",
 		LibraryID:   folder.ID,
@@ -1274,8 +1279,9 @@ func checkLibraryMount(folder *models.MediaFolder) libraryMountCheckResponse {
 	}
 
 	unreachable := 0
+	emptyPaths := make([]string, 0, len(folder.Paths))
 	for _, path := range folder.Paths {
-		probe := rootcheck.Probe(path)
+		probe := rootcheck.ProbeWithTimeout(ctx, path, rootcheck.DefaultProbeTimeout)
 		root := libraryMountCheckRootResponse{
 			Path:      path,
 			Reachable: probe.Reachable,
@@ -1285,14 +1291,45 @@ func checkLibraryMount(folder *models.MediaFolder) libraryMountCheckResponse {
 			root.ErrorMessage = stringPtr(probe.ErrorMessage)
 			unreachable++
 			resp.Healthy = false
+		} else if probe.Empty {
+			emptyPaths = append(emptyPaths, path)
 		}
 		resp.Roots = append(resp.Roots, root)
 	}
 
-	switch unreachable {
-	case 0:
+	// A reachable but literally empty root can be a lost mount that left its
+	// bare mountpoint behind. Cross-check against the catalog: an empty root
+	// holding only missing-marked files is suspect, and reporting it healthy
+	// would both mislead the operator and wrongly clear the dead_root
+	// warning. Best-effort — probe results stand on a query error.
+	suspect := 0
+	if h.pool != nil && len(emptyPaths) > 0 {
+		suspectRoots, err := scanner.NewFileRepository(h.pool).ListRootsWithOnlyMissingFiles(ctx, folder.ID, emptyPaths)
+		if err != nil {
+			slog.WarnContext(ctx, "mount check: suspect-empty root query failed", "component", "api", "library_id", folder.ID, "error", err)
+		} else if len(suspectRoots) > 0 {
+			suspectSet := make(map[string]bool, len(suspectRoots))
+			for _, root := range suspectRoots {
+				suspectSet[root] = true
+			}
+			for i := range resp.Roots {
+				if resp.Roots[i].Reachable && suspectSet[resp.Roots[i].Path] {
+					resp.Roots[i].SuspectEmpty = true
+					suspect++
+					resp.Healthy = false
+				}
+			}
+		}
+	}
+
+	switch {
+	case unreachable == 0 && suspect == 0:
 		resp.Summary = "All configured roots are reachable"
-	case 1:
+	case unreachable == 0:
+		resp.Summary = fmt.Sprintf("%d of %d roots reachable but empty while the library still has cataloged files (lost mount?)", suspect, len(folder.Paths))
+	case suspect > 0:
+		resp.Summary = fmt.Sprintf("%d of %d roots unreachable; %d more reachable but empty while the library still has cataloged files", unreachable, len(folder.Paths), suspect)
+	case unreachable == 1:
 		resp.Summary = fmt.Sprintf("1 of %d roots unreachable", len(folder.Paths))
 	default:
 		resp.Summary = fmt.Sprintf("%d of %d roots unreachable", unreachable, len(folder.Paths))

--- a/internal/api/handlers/libraries.go
+++ b/internal/api/handlers/libraries.go
@@ -8,7 +8,6 @@ import (
 	"io"
 	"log/slog"
 	"net/http"
-	"os"
 	"path/filepath"
 	"slices"
 	"sort"
@@ -31,6 +30,7 @@ import (
 	"github.com/Silo-Server/silo-server/internal/metadata"
 	"github.com/Silo-Server/silo-server/internal/models"
 	"github.com/Silo-Server/silo-server/internal/plugins"
+	"github.com/Silo-Server/silo-server/internal/rootcheck"
 	"github.com/Silo-Server/silo-server/internal/scanner"
 	"github.com/Silo-Server/silo-server/internal/scantrigger"
 	"github.com/Silo-Server/silo-server/internal/sections"
@@ -848,7 +848,8 @@ func (h *LibraryHandler) HandleCheckLibraryMount(w http.ResponseWriter, r *http.
 	}
 
 	resp := checkLibraryMount(folder)
-	if resp.Healthy && folder.ScanWarningCode != nil && *folder.ScanWarningCode == "empty_root" {
+	if resp.Healthy && folder.ScanWarningCode != nil &&
+		(*folder.ScanWarningCode == "empty_root" || *folder.ScanWarningCode == "dead_root") {
 		if err := h.folderRepo.ClearScanWarning(r.Context(), folder.ID); err != nil {
 			if errors.Is(err, catalog.ErrFolderNotFound) {
 				writeError(w, http.StatusNotFound, "not_found", "Library not found")
@@ -1274,29 +1275,14 @@ func checkLibraryMount(folder *models.MediaFolder) libraryMountCheckResponse {
 
 	unreachable := 0
 	for _, path := range folder.Paths {
+		probe := rootcheck.Probe(path)
 		root := libraryMountCheckRootResponse{
 			Path:      path,
-			Reachable: true,
+			Reachable: probe.Reachable,
 		}
-
-		info, err := os.Stat(path)
-		if err != nil {
-			code, message := classifyMountCheckError(err, false)
-			root.Reachable = false
-			root.ErrorCode = stringPtr(code)
-			root.ErrorMessage = stringPtr(message)
-		} else if !info.IsDir() {
-			root.Reachable = false
-			root.ErrorCode = stringPtr("not_directory")
-			root.ErrorMessage = stringPtr("Path is not a directory")
-		} else if _, err := os.ReadDir(path); err != nil {
-			code, message := classifyMountCheckError(err, true)
-			root.Reachable = false
-			root.ErrorCode = stringPtr(code)
-			root.ErrorMessage = stringPtr(message)
-		}
-
-		if !root.Reachable {
+		if !probe.Reachable {
+			root.ErrorCode = stringPtr(probe.ErrorCode)
+			root.ErrorMessage = stringPtr(probe.ErrorMessage)
 			unreachable++
 			resp.Healthy = false
 		}
@@ -1313,19 +1299,6 @@ func checkLibraryMount(folder *models.MediaFolder) libraryMountCheckResponse {
 	}
 
 	return resp
-}
-
-func classifyMountCheckError(err error, isRead bool) (string, string) {
-	switch {
-	case errors.Is(err, os.ErrNotExist):
-		return "not_found", "Path does not exist"
-	case errors.Is(err, os.ErrPermission):
-		return "permission_denied", "Permission denied"
-	case isRead:
-		return "read_failed", "Failed to read directory"
-	default:
-		return "stat_failed", "Failed to stat path"
-	}
 }
 
 func stringPtr(v string) *string {

--- a/internal/api/handlers/libraries.go
+++ b/internal/api/handlers/libraries.go
@@ -1280,8 +1280,9 @@ func (h *LibraryHandler) checkLibraryMount(ctx context.Context, folder *models.M
 
 	unreachable := 0
 	emptyPaths := make([]string, 0, len(folder.Paths))
-	for _, path := range folder.Paths {
-		probe := rootcheck.ProbeWithTimeout(ctx, path, rootcheck.DefaultProbeTimeout)
+	probes := rootcheck.ProbeManyWithTimeout(ctx, folder.Paths, rootcheck.DefaultProbeTimeout)
+	for i, path := range folder.Paths {
+		probe := probes[i]
 		root := libraryMountCheckRootResponse{
 			Path:      path,
 			Reachable: probe.Reachable,

--- a/internal/catalog/library_repo.go
+++ b/internal/catalog/library_repo.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/Silo-Server/silo-server/internal/access"
 	"github.com/Silo-Server/silo-server/internal/models"
+	"github.com/Silo-Server/silo-server/internal/pathscope"
 )
 
 // LibraryItemRepository provides CRUD operations for the media_item_libraries
@@ -544,12 +545,8 @@ func (r *LibraryItemRepository) ReconcileFolderMembership(ctx context.Context, f
 // scanner's root matching, so a sibling root that merely shares a string
 // prefix (/mnt/movies2 vs /mnt/movies) is never protected by accident.
 func excludeOrphansUnderProtectedPrefixes(ctx context.Context, tx pgx.Tx, orphanIDs []string, folderID int, prefixes []string) ([]string, error) {
-	conds := make([]string, 0, len(prefixes))
-	args := []any{orphanIDs, folderID}
-	for _, prefix := range prefixes {
-		args = append(args, prefix, pathPrefixLike(prefix))
-		conds = append(conds, fmt.Sprintf("(mf.file_path = $%d OR mf.file_path LIKE $%d ESCAPE '\\')", len(args)-1, len(args)))
-	}
+	conds, condArgs := pathscope.CoverageClauses("mf.file_path", prefixes, 3)
+	args := append([]any{orphanIDs, folderID}, condArgs...)
 
 	rows, err := tx.Query(ctx, fmt.Sprintf(`
 		SELECT cid FROM unnest($1::text[]) AS cid

--- a/internal/catalog/library_repo.go
+++ b/internal/catalog/library_repo.go
@@ -421,7 +421,19 @@ func (r *LibraryItemRepository) Delete(ctx context.Context, contentID string, fo
 // longer has any non-missing files in the given folder. It also deletes orphaned
 // media items once they no longer belong to any library. Returns removed
 // membership count, deleted item count, orphaned S3 image dirs, and any error.
-func (r *LibraryItemRepository) ReconcileFolderMembership(ctx context.Context, folderID int) (int, int, []string, error) {
+//
+// protectedPathPrefixes lists library roots that are currently unreachable
+// (dead drive, lost mount). Membership removal proceeds regardless — browse
+// and home queries hide items via media_item_libraries, so removal is what
+// keeps a title with no playable files out of the catalog — but items whose
+// files in this folder sit under a protected prefix are exempt from the
+// orphan delete. Deleting them is not losslessly recoverable (user
+// collections cascade via library_collection_items, manual metadata edits and
+// cached artwork are lost), whereas a hidden membership-less item restores
+// automatically: when the root returns, the scanner clears missing_since on
+// its surviving media_files rows and syncPresentLibraryState re-inserts the
+// membership from those rows.
+func (r *LibraryItemRepository) ReconcileFolderMembership(ctx context.Context, folderID int, protectedPathPrefixes []string) (int, int, []string, error) {
 	tx, err := r.pool.Begin(ctx)
 	if err != nil {
 		return 0, 0, nil, fmt.Errorf("beginning membership reconciliation transaction: %w", err)
@@ -477,6 +489,15 @@ func (r *LibraryItemRepository) ReconcileFolderMembership(ctx context.Context, f
 			return 0, 0, nil, err
 		}
 
+		// Exempt orphans whose files sit under an unreachable root: the files
+		// still exist, the root is just offline. See the doc comment above.
+		if len(orphanIDs) > 0 && len(protectedPathPrefixes) > 0 {
+			orphanIDs, err = excludeOrphansUnderProtectedPrefixes(ctx, tx, orphanIDs, folderID, protectedPathPrefixes)
+			if err != nil {
+				return 0, 0, nil, err
+			}
+		}
+
 		// Collect image paths before deletion.
 		if len(orphanIDs) > 0 {
 			orphanedImageDirs, err = collectImageDirs(ctx, tx, orphanIDs)
@@ -515,4 +536,43 @@ func (r *LibraryItemRepository) ReconcileFolderMembership(ctx context.Context, f
 	}
 
 	return len(removedContentIDs), deletedItems, orphanedImageDirs, nil
+}
+
+// excludeOrphansUnderProtectedPrefixes returns the subset of orphanIDs that
+// have no media_files row in the folder at or under any protected prefix.
+// Matching uses the exact-path + escaped prefix-LIKE shape shared with the
+// scanner's root matching, so a sibling root that merely shares a string
+// prefix (/mnt/movies2 vs /mnt/movies) is never protected by accident.
+func excludeOrphansUnderProtectedPrefixes(ctx context.Context, tx pgx.Tx, orphanIDs []string, folderID int, prefixes []string) ([]string, error) {
+	conds := make([]string, 0, len(prefixes))
+	args := []any{orphanIDs, folderID}
+	for _, prefix := range prefixes {
+		args = append(args, prefix, pathPrefixLike(prefix))
+		conds = append(conds, fmt.Sprintf("(mf.file_path = $%d OR mf.file_path LIKE $%d ESCAPE '\\')", len(args)-1, len(args)))
+	}
+
+	rows, err := tx.Query(ctx, fmt.Sprintf(`
+		SELECT cid FROM unnest($1::text[]) AS cid
+		WHERE NOT EXISTS (
+			SELECT 1
+			FROM media_files mf
+			WHERE mf.media_folder_id = $2
+			  AND mf.content_id = cid
+			  AND (%s)
+		)
+	`, strings.Join(conds, " OR ")), args...)
+	if err != nil {
+		return nil, fmt.Errorf("filtering orphans under protected prefixes: %w", err)
+	}
+	defer rows.Close()
+
+	ids := make([]string, 0, len(orphanIDs))
+	for rows.Next() {
+		var id string
+		if err := rows.Scan(&id); err != nil {
+			return nil, fmt.Errorf("scanning unprotected orphan id: %w", err)
+		}
+		ids = append(ids, id)
+	}
+	return ids, rows.Err()
 }

--- a/internal/catalog/library_repo.go
+++ b/internal/catalog/library_repo.go
@@ -544,6 +544,16 @@ func (r *LibraryItemRepository) ReconcileFolderMembership(ctx context.Context, f
 // Matching uses the exact-path + escaped prefix-LIKE shape shared with the
 // scanner's root matching, so a sibling root that merely shares a string
 // prefix (/mnt/movies2 vs /mnt/movies) is never protected by accident.
+//
+// Known limitation: the check is scoped to the reconciled folder's own files
+// (mf.media_folder_id = folderID). An item shared across two libraries whose
+// only surviving files sit under ANOTHER folder's currently-unreachable root
+// is not exempted here — if its membership in this folder is genuinely
+// removed while the other folder's root is offline, the item is purged even
+// though its files under the dead root would have resurrected. Closing this
+// would require probing every enabled folder's roots (or persisting per-
+// folder unreachable state) on each reconcile; accepted for now given how
+// narrow the window is.
 func excludeOrphansUnderProtectedPrefixes(ctx context.Context, tx pgx.Tx, orphanIDs []string, folderID int, prefixes []string) ([]string, error) {
 	conds, condArgs := pathscope.CoverageClauses("mf.file_path", prefixes, 3)
 	args := append([]any{orphanIDs, folderID}, condArgs...)

--- a/internal/catalog/library_repo.go
+++ b/internal/catalog/library_repo.go
@@ -483,12 +483,20 @@ func (r *LibraryItemRepository) ReconcileFolderMembership(ctx context.Context, f
 
 	deletedItems := 0
 	var orphanedImageDirs []string
-	if len(removedContentIDs) > 0 {
-		// Find items that will become orphaned (no remaining library memberships).
-		orphanIDs, err := collectOrphanIDs(ctx, tx, removedContentIDs)
-		if err != nil {
-			return 0, 0, nil, err
-		}
+	// Find both newly orphaned items and items preserved by an earlier
+	// protected-root pass. The latter no longer have a membership to return from
+	// the DELETE above, but their surviving media_files row still ties them to
+	// this folder so they can be reconsidered after the root recovers.
+	orphanIDs, err := collectOrphanIDs(ctx, tx, removedContentIDs)
+	if err != nil {
+		return 0, 0, nil, err
+	}
+	previouslyProtected, err := collectFolderFileOrphanIDs(ctx, tx, folderID)
+	if err != nil {
+		return 0, 0, nil, err
+	}
+	orphanIDs = appendUniqueStrings(orphanIDs, previouslyProtected...)
+	if len(orphanIDs) > 0 {
 
 		// Exempt orphans whose files sit under an unreachable root: the files
 		// still exist, the root is just offline. See the doc comment above.
@@ -537,6 +545,43 @@ func (r *LibraryItemRepository) ReconcileFolderMembership(ctx context.Context, f
 	}
 
 	return len(removedContentIDs), deletedItems, orphanedImageDirs, nil
+}
+
+func collectFolderFileOrphanIDs(ctx context.Context, tx pgx.Tx, folderID int) ([]string, error) {
+	rows, err := tx.Query(ctx, `
+		SELECT DISTINCT mf.content_id
+		FROM media_files mf
+		WHERE mf.media_folder_id = $1
+		  AND mf.content_id IS NOT NULL
+		  AND mf.content_id <> ''
+		  AND NOT EXISTS (
+			SELECT 1 FROM media_item_libraries mil WHERE mil.content_id = mf.content_id
+		  )
+	`, folderID)
+	if err != nil {
+		return nil, fmt.Errorf("finding previously protected folder orphans: %w", err)
+	}
+	defer rows.Close()
+	ids, err := pgx.CollectRows(rows, pgx.RowTo[string])
+	if err != nil {
+		return nil, fmt.Errorf("collecting previously protected folder orphans: %w", err)
+	}
+	return ids, nil
+}
+
+func appendUniqueStrings(values []string, additions ...string) []string {
+	seen := make(map[string]struct{}, len(values)+len(additions))
+	for _, value := range values {
+		seen[value] = struct{}{}
+	}
+	for _, value := range additions {
+		if _, ok := seen[value]; ok {
+			continue
+		}
+		seen[value] = struct{}{}
+		values = append(values, value)
+	}
+	return values
 }
 
 // excludeOrphansUnderProtectedPrefixes returns the subset of orphanIDs that

--- a/internal/catalog/library_repo_dead_root_test.go
+++ b/internal/catalog/library_repo_dead_root_test.go
@@ -1,0 +1,115 @@
+package catalog
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/jackc/pgx/v5/pgxpool"
+)
+
+// TestReconcileFolderMembershipProtectsUnreachableRoots verifies the
+// dead-root exemption in the orphan purge: memberships are still removed for
+// content with no non-missing files (that is what hides the item from
+// browse/home, which gate on media_item_libraries), but the media_items row
+// of an item whose files sit under a protected (unreachable) root must
+// survive so user collections, metadata edits, and artwork are not destroyed
+// by a temporary outage. An orphan with no protected files is still purged.
+func TestReconcileFolderMembershipProtectsUnreachableRoots(t *testing.T) {
+	dsn := os.Getenv("SILO_TEST_DATABASE_URL")
+	if dsn == "" {
+		t.Skip("SILO_TEST_DATABASE_URL is not set")
+	}
+	ctx := context.Background()
+	pool, err := pgxpool.New(ctx, dsn)
+	if err != nil {
+		t.Fatalf("connect test database: %v", err)
+	}
+	t.Cleanup(pool.Close)
+
+	suffix := time.Now().UnixNano()
+	deadRoot := fmt.Sprintf("/drp-dead-%d", suffix)
+	goneItem := fmt.Sprintf("drp-gone-%d", suffix)
+	protectedItem := fmt.Sprintf("drp-protected-%d", suffix)
+
+	var folderID int
+	if err := pool.QueryRow(ctx,
+		`INSERT INTO media_folders (type, name, enabled) VALUES ('movies', 'DRP Test', true) RETURNING id`,
+	).Scan(&folderID); err != nil {
+		t.Fatalf("seed folder: %v", err)
+	}
+	t.Cleanup(func() {
+		_, _ = pool.Exec(ctx, `DELETE FROM media_files WHERE media_folder_id = $1`, folderID)
+		_, _ = pool.Exec(ctx, `DELETE FROM media_items WHERE content_id = ANY($1)`, []string{goneItem, protectedItem})
+		_, _ = pool.Exec(ctx, `DELETE FROM media_folders WHERE id = $1`, folderID)
+	})
+
+	for _, contentID := range []string{goneItem, protectedItem} {
+		if _, err := pool.Exec(ctx, `
+			INSERT INTO media_items (content_id, type, title, status, genres)
+			VALUES ($1, 'movie', 'DRP Item', 'matched', '{}'::text[])
+		`, contentID); err != nil {
+			t.Fatalf("seed item %s: %v", contentID, err)
+		}
+		if _, err := pool.Exec(ctx, `
+			INSERT INTO media_item_libraries (content_id, media_folder_id, first_seen_at)
+			VALUES ($1, $2, NOW())
+		`, contentID, folderID); err != nil {
+			t.Fatalf("seed membership %s: %v", contentID, err)
+		}
+	}
+	missingSince := time.Now().UTC().Add(-72 * time.Hour)
+	seedFile := func(contentID, path string) {
+		if _, err := pool.Exec(ctx, `
+			INSERT INTO media_files (content_id, media_folder_id, file_path, file_size, missing_since)
+			VALUES ($1, $2, $3, 1024, $4)
+		`, contentID, folderID, path, missingSince); err != nil {
+			t.Fatalf("seed file %s: %v", path, err)
+		}
+	}
+	// The protected item's only file lives under the unreachable root; the
+	// other item's file was under a root that is reachable (its absence is a
+	// genuine deletion).
+	seedFile(protectedItem, deadRoot+"/Alpha (2020)/Alpha (2020).mkv")
+	seedFile(goneItem, fmt.Sprintf("/drp-live-%d/Beta (2021)/Beta (2021).mkv", suffix))
+
+	repo := NewLibraryItemRepository(pool)
+	removed, deletedItems, _, err := repo.ReconcileFolderMembership(ctx, folderID, []string{deadRoot})
+	if err != nil {
+		t.Fatalf("ReconcileFolderMembership: %v", err)
+	}
+	if removed != 2 {
+		t.Fatalf("removed memberships = %d, want 2 (hiding still requires removal)", removed)
+	}
+	if deletedItems != 1 {
+		t.Fatalf("deleted items = %d, want 1 (only the unprotected orphan)", deletedItems)
+	}
+
+	var exists bool
+	if err := pool.QueryRow(ctx,
+		`SELECT EXISTS(SELECT 1 FROM media_items WHERE content_id = $1)`, protectedItem,
+	).Scan(&exists); err != nil {
+		t.Fatalf("check protected item: %v", err)
+	}
+	if !exists {
+		t.Fatal("protected item was purged despite its files sitting under an unreachable root")
+	}
+	if err := pool.QueryRow(ctx,
+		`SELECT EXISTS(SELECT 1 FROM media_items WHERE content_id = $1)`, goneItem,
+	).Scan(&exists); err != nil {
+		t.Fatalf("check gone item: %v", err)
+	}
+	if exists {
+		t.Fatal("unprotected orphan item survived; purge regressed")
+	}
+	if err := pool.QueryRow(ctx,
+		`SELECT EXISTS(SELECT 1 FROM media_item_libraries WHERE media_folder_id = $1)`, folderID,
+	).Scan(&exists); err != nil {
+		t.Fatalf("check memberships: %v", err)
+	}
+	if exists {
+		t.Fatal("memberships remain; items with only missing files must be hidden")
+	}
+}

--- a/internal/catalog/library_repo_dead_root_test.go
+++ b/internal/catalog/library_repo_dead_root_test.go
@@ -112,4 +112,22 @@ func TestReconcileFolderMembershipProtectsUnreachableRoots(t *testing.T) {
 	if exists {
 		t.Fatal("memberships remain; items with only missing files must be hidden")
 	}
+
+	// Once the root is reachable again, reconciliation must revisit the item
+	// even though its membership was removed during the protected pass.
+	removed, deletedItems, _, err = repo.ReconcileFolderMembership(ctx, folderID, nil)
+	if err != nil {
+		t.Fatalf("ReconcileFolderMembership after recovery: %v", err)
+	}
+	if removed != 0 || deletedItems != 1 {
+		t.Fatalf("recovery reconciliation removed/deleted = %d/%d, want 0/1", removed, deletedItems)
+	}
+	if err := pool.QueryRow(ctx,
+		`SELECT EXISTS(SELECT 1 FROM media_items WHERE content_id = $1)`, protectedItem,
+	).Scan(&exists); err != nil {
+		t.Fatalf("check recovered orphan: %v", err)
+	}
+	if exists {
+		t.Fatal("previously protected orphan survived after its root recovered")
+	}
 }

--- a/internal/pathscope/pathscope.go
+++ b/internal/pathscope/pathscope.go
@@ -1,6 +1,7 @@
 package pathscope
 
 import (
+	"fmt"
 	"path/filepath"
 	"strings"
 )
@@ -23,4 +24,22 @@ func PrefixLike(pathPrefix string) string {
 		return likeEscaper.Replace(clean) + "%"
 	}
 	return likeEscaper.Replace(clean) + string(filepath.Separator) + "%"
+}
+
+// CoverageClauses builds one SQL predicate per root matching rows whose
+// column value lies at or under that root, using the exact-match + escaped
+// prefix-LIKE shape (`column = $n OR column LIKE $n+1 ESCAPE '\'`). The
+// prefix pattern ends with a path separator, so a sibling root that merely
+// shares a string prefix (/mnt/movies2 vs /mnt/movies) never matches.
+// Placeholder numbering starts at firstArg; the returned args bind pairwise
+// (root, prefix pattern) in clause order.
+func CoverageClauses(column string, roots []string, firstArg int) ([]string, []any) {
+	clauses := make([]string, 0, len(roots))
+	args := make([]any, 0, len(roots)*2)
+	for i, root := range roots {
+		pathArg := firstArg + i*2
+		clauses = append(clauses, fmt.Sprintf(`(%s = $%d OR %s LIKE $%d ESCAPE '\')`, column, pathArg, column, pathArg+1))
+		args = append(args, root, PrefixLike(root))
+	}
+	return clauses, args
 }

--- a/internal/rootcheck/rootcheck.go
+++ b/internal/rootcheck/rootcheck.go
@@ -1,0 +1,61 @@
+// Package rootcheck probes library root paths for reachability: a root is
+// reachable when it exists, is a directory, and can be listed. It is shared
+// by the scanner's dead-root protection and the admin mount-check endpoint so
+// both agree on what "unreachable" means.
+package rootcheck
+
+import (
+	"errors"
+	"os"
+)
+
+// Error codes reported by Probe. They are part of the admin mount-check API
+// response contract.
+const (
+	ErrCodeNotFound         = "not_found"
+	ErrCodePermissionDenied = "permission_denied"
+	ErrCodeNotDirectory     = "not_directory"
+	ErrCodeReadFailed       = "read_failed"
+	ErrCodeStatFailed       = "stat_failed"
+)
+
+// Result describes the outcome of probing a single root path.
+type Result struct {
+	Path         string
+	Reachable    bool
+	ErrorCode    string // empty when Reachable
+	ErrorMessage string // empty when Reachable
+}
+
+// Probe checks that path exists, is a directory, and can be listed.
+func Probe(path string) Result {
+	res := Result{Path: path, Reachable: true}
+	info, err := os.Stat(path)
+	switch {
+	case err != nil:
+		res.Reachable = false
+		res.ErrorCode, res.ErrorMessage = classify(err, false)
+	case !info.IsDir():
+		res.Reachable = false
+		res.ErrorCode, res.ErrorMessage = ErrCodeNotDirectory, "Path is not a directory"
+	default:
+		if _, err := os.ReadDir(path); err != nil {
+			res.Reachable = false
+			res.ErrorCode, res.ErrorMessage = classify(err, true)
+		}
+	}
+	return res
+}
+
+func classify(err error, isRead bool) (string, string) {
+	switch {
+	case errors.Is(err, os.ErrNotExist):
+		return ErrCodeNotFound, "Path does not exist"
+	case errors.Is(err, os.ErrPermission):
+		return ErrCodePermissionDenied, "Permission denied"
+	case isRead:
+		return ErrCodeReadFailed, "Failed to read directory"
+	default:
+		return ErrCodeStatFailed, "Failed to stat path"
+	}
+}

--- a/internal/rootcheck/rootcheck.go
+++ b/internal/rootcheck/rootcheck.go
@@ -21,7 +21,6 @@ const (
 
 // Result describes the outcome of probing a single root path.
 type Result struct {
-	Path         string
 	Reachable    bool
 	ErrorCode    string // empty when Reachable
 	ErrorMessage string // empty when Reachable
@@ -29,7 +28,7 @@ type Result struct {
 
 // Probe checks that path exists, is a directory, and can be listed.
 func Probe(path string) Result {
-	res := Result{Path: path, Reachable: true}
+	res := Result{Reachable: true}
 	info, err := os.Stat(path)
 	switch {
 	case err != nil:

--- a/internal/rootcheck/rootcheck.go
+++ b/internal/rootcheck/rootcheck.go
@@ -7,7 +7,9 @@ package rootcheck
 import (
 	"context"
 	"errors"
+	"io"
 	"os"
+	"sync"
 	"time"
 )
 
@@ -28,6 +30,10 @@ const (
 // probes run on scan and request hot paths, so a hung mount must degrade
 // into "unreachable" rather than stall the caller.
 const DefaultProbeTimeout = 5 * time.Second
+
+// DefaultProbeConcurrency bounds the number of distinct roots started by one
+// batch. Repeated probes for the same path are also coalesced process-wide.
+const DefaultProbeConcurrency = 8
 
 // Result describes the outcome of probing a single root path.
 type Result struct {
@@ -53,23 +59,108 @@ func Probe(path string) Result {
 		res.Reachable = false
 		res.ErrorCode, res.ErrorMessage = ErrCodeNotDirectory, "Path is not a directory"
 	default:
-		entries, err := os.ReadDir(path)
-		if err != nil {
+		dir, err := os.Open(path)
+		if err == nil {
+			_, err = dir.Readdirnames(1)
+			_ = dir.Close()
+		}
+		if errors.Is(err, io.EOF) {
+			res.Empty = true
+		} else if err != nil {
 			res.Reachable = false
 			res.ErrorCode, res.ErrorMessage = classify(err, true)
-		} else {
-			res.Empty = len(entries) == 0
 		}
 	}
 	return res
 }
 
+type probeCall struct {
+	done   chan struct{}
+	result Result
+}
+
+type probeCoordinator struct {
+	mu       sync.Mutex
+	inFlight map[string]*probeCall
+}
+
+func newProbeCoordinator() *probeCoordinator {
+	return &probeCoordinator{inFlight: make(map[string]*probeCall)}
+}
+
+var sharedProbes = newProbeCoordinator()
+
 // ProbeWithTimeout runs Probe but gives up once timeout elapses or ctx is
-// done, reporting the root unreachable with ErrCodeTimeout. The probing
-// goroutine finishes in the background whenever the blocked syscall finally
-// returns; its result is discarded.
+// done, reporting the root unreachable with ErrCodeTimeout. Concurrent calls
+// for the same path share one underlying syscall so a wedged mount cannot
+// accumulate one blocked goroutine per scan or mount check.
 func ProbeWithTimeout(ctx context.Context, path string, timeout time.Duration) Result {
-	return probeBounded(ctx, timeout, func() Result { return Probe(path) })
+	return sharedProbes.probe(ctx, path, timeout, func(path string) Result { return Probe(path) })
+}
+
+func (c *probeCoordinator) probe(
+	ctx context.Context,
+	path string,
+	timeout time.Duration,
+	probe func(string) Result,
+) Result {
+	if timeout <= 0 {
+		timeout = DefaultProbeTimeout
+	}
+	c.mu.Lock()
+	call := c.inFlight[path]
+	if call == nil {
+		call = &probeCall{done: make(chan struct{})}
+		c.inFlight[path] = call
+		go func() {
+			call.result = probe(path)
+			close(call.done)
+			c.mu.Lock()
+			delete(c.inFlight, path)
+			c.mu.Unlock()
+		}()
+	}
+	c.mu.Unlock()
+
+	return awaitProbe(ctx, timeout, call.done, func() Result { return call.result })
+}
+
+// ProbeManyWithTimeout probes paths concurrently while preserving input order.
+func ProbeManyWithTimeout(ctx context.Context, paths []string, timeout time.Duration) []Result {
+	return probeMany(ctx, paths, timeout, DefaultProbeConcurrency, ProbeWithTimeout)
+}
+
+func probeMany(
+	ctx context.Context,
+	paths []string,
+	timeout time.Duration,
+	limit int,
+	probe func(context.Context, string, time.Duration) Result,
+) []Result {
+	results := make([]Result, len(paths))
+	if len(paths) == 0 {
+		return results
+	}
+	if limit <= 0 || limit > len(paths) {
+		limit = len(paths)
+	}
+	jobs := make(chan int)
+	var workers sync.WaitGroup
+	workers.Add(limit)
+	for range limit {
+		go func() {
+			defer workers.Done()
+			for i := range jobs {
+				results[i] = probe(ctx, paths[i], timeout)
+			}
+		}()
+	}
+	for i := range paths {
+		jobs <- i
+	}
+	close(jobs)
+	workers.Wait()
+	return results
 }
 
 func probeBounded(ctx context.Context, timeout time.Duration, probe func() Result) Result {
@@ -91,6 +182,26 @@ func probeBounded(ctx context.Context, timeout time.Duration, probe func() Resul
 	case <-ctxDone:
 	case <-timer.C:
 	}
+	return timeoutResult()
+}
+
+func awaitProbe(ctx context.Context, timeout time.Duration, done <-chan struct{}, result func() Result) Result {
+	var ctxDone <-chan struct{}
+	if ctx != nil {
+		ctxDone = ctx.Done()
+	}
+	timer := time.NewTimer(timeout)
+	defer timer.Stop()
+	select {
+	case <-done:
+		return result()
+	case <-ctxDone:
+	case <-timer.C:
+	}
+	return timeoutResult()
+}
+
+func timeoutResult() Result {
 	return Result{
 		Reachable:    false,
 		ErrorCode:    ErrCodeTimeout,

--- a/internal/rootcheck/rootcheck.go
+++ b/internal/rootcheck/rootcheck.go
@@ -5,8 +5,10 @@
 package rootcheck
 
 import (
+	"context"
 	"errors"
 	"os"
+	"time"
 )
 
 // Error codes reported by Probe. They are part of the admin mount-check API
@@ -17,11 +19,24 @@ const (
 	ErrCodeNotDirectory     = "not_directory"
 	ErrCodeReadFailed       = "read_failed"
 	ErrCodeStatFailed       = "stat_failed"
+	ErrCodeTimeout          = "probe_timeout"
 )
+
+// DefaultProbeTimeout bounds how long a single probe may block. A dead mount
+// usually errors within milliseconds, but a hung network filesystem
+// (hard-mounted NFS, wedged SMB/FUSE) blocks stat/readdir indefinitely —
+// probes run on scan and request hot paths, so a hung mount must degrade
+// into "unreachable" rather than stall the caller.
+const DefaultProbeTimeout = 5 * time.Second
 
 // Result describes the outcome of probing a single root path.
 type Result struct {
-	Reachable    bool
+	Reachable bool
+	// Empty is set for a reachable directory with zero entries. A completely
+	// empty root is the on-disk signature of a lost mount (the mountpoint
+	// directory remains, its contents vanished with the mount), which a
+	// reachability check alone cannot detect.
+	Empty        bool
 	ErrorCode    string // empty when Reachable
 	ErrorMessage string // empty when Reachable
 }
@@ -38,12 +53,49 @@ func Probe(path string) Result {
 		res.Reachable = false
 		res.ErrorCode, res.ErrorMessage = ErrCodeNotDirectory, "Path is not a directory"
 	default:
-		if _, err := os.ReadDir(path); err != nil {
+		entries, err := os.ReadDir(path)
+		if err != nil {
 			res.Reachable = false
 			res.ErrorCode, res.ErrorMessage = classify(err, true)
+		} else {
+			res.Empty = len(entries) == 0
 		}
 	}
 	return res
+}
+
+// ProbeWithTimeout runs Probe but gives up once timeout elapses or ctx is
+// done, reporting the root unreachable with ErrCodeTimeout. The probing
+// goroutine finishes in the background whenever the blocked syscall finally
+// returns; its result is discarded.
+func ProbeWithTimeout(ctx context.Context, path string, timeout time.Duration) Result {
+	return probeBounded(ctx, timeout, func() Result { return Probe(path) })
+}
+
+func probeBounded(ctx context.Context, timeout time.Duration, probe func() Result) Result {
+	if timeout <= 0 {
+		timeout = DefaultProbeTimeout
+	}
+	done := make(chan Result, 1)
+	go func() { done <- probe() }()
+
+	var ctxDone <-chan struct{}
+	if ctx != nil {
+		ctxDone = ctx.Done()
+	}
+	timer := time.NewTimer(timeout)
+	defer timer.Stop()
+	select {
+	case res := <-done:
+		return res
+	case <-ctxDone:
+	case <-timer.C:
+	}
+	return Result{
+		Reachable:    false,
+		ErrorCode:    ErrCodeTimeout,
+		ErrorMessage: "Probe timed out; filesystem is not responding",
+	}
 }
 
 func classify(err error, isRead bool) (string, string) {

--- a/internal/rootcheck/rootcheck_test.go
+++ b/internal/rootcheck/rootcheck_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"os"
 	"path/filepath"
+	"sync/atomic"
 	"testing"
 	"time"
 )
@@ -120,6 +121,65 @@ func TestProbeBoundedReturnsFastResult(t *testing.T) {
 	})
 	if res.Reachable || res.ErrorCode != ErrCodeNotFound {
 		t.Fatalf("probeBounded passthrough = %+v, want the probe's own result", res)
+	}
+}
+
+func TestProbeCoordinatorCoalescesBlockedPath(t *testing.T) {
+	t.Parallel()
+
+	var calls atomic.Int32
+	release := make(chan struct{})
+	t.Cleanup(func() { close(release) })
+	coordinator := newProbeCoordinator()
+	probe := func(string) Result {
+		calls.Add(1)
+		<-release
+		return Result{Reachable: true}
+	}
+
+	results := make(chan Result, 2)
+	for range 2 {
+		go func() {
+			results <- coordinator.probe(context.Background(), "/hung", 20*time.Millisecond, probe)
+		}()
+	}
+	for range 2 {
+		if result := <-results; result.Reachable || result.ErrorCode != ErrCodeTimeout {
+			t.Fatalf("coalesced blocked probe = %+v, want timeout", result)
+		}
+	}
+	if got := calls.Load(); got != 1 {
+		t.Fatalf("underlying probe calls = %d, want 1", got)
+	}
+}
+
+func TestProbeManyPreservesOrderAndBoundsConcurrency(t *testing.T) {
+	t.Parallel()
+
+	var active atomic.Int32
+	var peak atomic.Int32
+	probe := func(_ context.Context, path string, _ time.Duration) Result {
+		current := active.Add(1)
+		for {
+			observed := peak.Load()
+			if current <= observed || peak.CompareAndSwap(observed, current) {
+				break
+			}
+		}
+		time.Sleep(10 * time.Millisecond)
+		active.Add(-1)
+		return Result{Reachable: true, ErrorMessage: path}
+	}
+
+	paths := []string{"one", "two", "three", "four"}
+	results := probeMany(context.Background(), paths, time.Second, 2, probe)
+	if got := peak.Load(); got > 2 {
+		t.Fatalf("peak concurrent probes = %d, want at most 2", got)
+	}
+	for i, result := range results {
+		if result.ErrorMessage != paths[i] {
+			t.Fatalf("result[%d] = %q, want %q", i, result.ErrorMessage, paths[i])
+		}
 	}
 }
 

--- a/internal/rootcheck/rootcheck_test.go
+++ b/internal/rootcheck/rootcheck_test.go
@@ -1,9 +1,11 @@
 package rootcheck
 
 import (
+	"context"
 	"os"
 	"path/filepath"
 	"testing"
+	"time"
 )
 
 func TestProbeReachableDirectory(t *testing.T) {
@@ -65,5 +67,76 @@ func TestProbeUnreadableDirectory(t *testing.T) {
 	}
 	if res.ErrorCode != ErrCodePermissionDenied {
 		t.Fatalf("ErrorCode = %q, want %q", res.ErrorCode, ErrCodePermissionDenied)
+	}
+}
+
+func TestProbeWithTimeoutReachableDirectory(t *testing.T) {
+	t.Parallel()
+
+	res := ProbeWithTimeout(context.Background(), t.TempDir(), DefaultProbeTimeout)
+	if !res.Reachable {
+		t.Fatalf("ProbeWithTimeout(temp dir) = %+v, want reachable", res)
+	}
+}
+
+func TestProbeBoundedTimesOutOnHungProbe(t *testing.T) {
+	t.Parallel()
+
+	release := make(chan struct{})
+	t.Cleanup(func() { close(release) })
+	res := probeBounded(context.Background(), 10*time.Millisecond, func() Result {
+		<-release // simulate a stat/readdir blocked on a hung mount
+		return Result{Reachable: true}
+	})
+	if res.Reachable {
+		t.Fatal("hung probe reported reachable")
+	}
+	if res.ErrorCode != ErrCodeTimeout {
+		t.Fatalf("ErrorCode = %q, want %q", res.ErrorCode, ErrCodeTimeout)
+	}
+}
+
+func TestProbeBoundedHonorsContextCancellation(t *testing.T) {
+	t.Parallel()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	release := make(chan struct{})
+	t.Cleanup(func() { close(release) })
+	res := probeBounded(ctx, time.Minute, func() Result {
+		<-release
+		return Result{Reachable: true}
+	})
+	if res.Reachable || res.ErrorCode != ErrCodeTimeout {
+		t.Fatalf("canceled probe = %+v, want unreachable/%s", res, ErrCodeTimeout)
+	}
+}
+
+func TestProbeBoundedReturnsFastResult(t *testing.T) {
+	t.Parallel()
+
+	res := probeBounded(context.Background(), time.Minute, func() Result {
+		return Result{Reachable: false, ErrorCode: ErrCodeNotFound, ErrorMessage: "Path does not exist"}
+	})
+	if res.Reachable || res.ErrorCode != ErrCodeNotFound {
+		t.Fatalf("probeBounded passthrough = %+v, want the probe's own result", res)
+	}
+}
+
+func TestProbeReportsEmptyDirectory(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	res := Probe(dir)
+	if !res.Reachable || !res.Empty {
+		t.Fatalf("Probe(empty dir) = %+v, want reachable and empty", res)
+	}
+
+	if err := os.Mkdir(filepath.Join(dir, "sub"), 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	res = Probe(dir)
+	if !res.Reachable || res.Empty {
+		t.Fatalf("Probe(non-empty dir) = %+v, want reachable and not empty", res)
 	}
 }

--- a/internal/rootcheck/rootcheck_test.go
+++ b/internal/rootcheck/rootcheck_test.go
@@ -1,0 +1,69 @@
+package rootcheck
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestProbeReachableDirectory(t *testing.T) {
+	t.Parallel()
+
+	res := Probe(t.TempDir())
+	if !res.Reachable {
+		t.Fatalf("Probe(temp dir) = %+v, want reachable", res)
+	}
+	if res.ErrorCode != "" || res.ErrorMessage != "" {
+		t.Fatalf("Probe(temp dir) error fields = %q/%q, want empty", res.ErrorCode, res.ErrorMessage)
+	}
+}
+
+func TestProbeMissingPath(t *testing.T) {
+	t.Parallel()
+
+	res := Probe(filepath.Join(t.TempDir(), "does-not-exist"))
+	if res.Reachable {
+		t.Fatal("Probe(missing path) reported reachable")
+	}
+	if res.ErrorCode != ErrCodeNotFound {
+		t.Fatalf("ErrorCode = %q, want %q", res.ErrorCode, ErrCodeNotFound)
+	}
+}
+
+func TestProbeRegularFile(t *testing.T) {
+	t.Parallel()
+
+	path := filepath.Join(t.TempDir(), "file.txt")
+	if err := os.WriteFile(path, []byte("x"), 0o644); err != nil {
+		t.Fatalf("write file: %v", err)
+	}
+
+	res := Probe(path)
+	if res.Reachable {
+		t.Fatal("Probe(regular file) reported reachable")
+	}
+	if res.ErrorCode != ErrCodeNotDirectory {
+		t.Fatalf("ErrorCode = %q, want %q", res.ErrorCode, ErrCodeNotDirectory)
+	}
+}
+
+func TestProbeUnreadableDirectory(t *testing.T) {
+	t.Parallel()
+	if os.Getuid() == 0 {
+		t.Skip("running as root; permission bits are not enforced")
+	}
+
+	path := filepath.Join(t.TempDir(), "locked")
+	if err := os.Mkdir(path, 0o000); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	t.Cleanup(func() { _ = os.Chmod(path, 0o755) })
+
+	res := Probe(path)
+	if res.Reachable {
+		t.Fatal("Probe(unreadable dir) reported reachable")
+	}
+	if res.ErrorCode != ErrCodePermissionDenied {
+		t.Fatalf("ErrorCode = %q, want %q", res.ErrorCode, ErrCodePermissionDenied)
+	}
+}

--- a/internal/scanner/audiobook_scan.go
+++ b/internal/scanner/audiobook_scan.go
@@ -319,14 +319,14 @@ func (s *Scanner) ScanAudiobookFolder(ctx context.Context, folder *models.MediaF
 	for i := range scans {
 		candidates = append(candidates, scans[i].candidates...)
 	}
-	reconcileRoots, seenPaths, sawFiles := splitAudiobookReconcileRoots(scans)
+	reconcileRoots, seenPaths, _ := splitAudiobookReconcileRoots(scans)
 
 	if len(candidates) == 0 {
 		// No books on disk. Still reconcile (guarded) so a legitimately-emptied
 		// library converges — but only when a root was readable, and the
 		// empty-walk guard requires operator confirmation before deleting.
 		if len(reconcileRoots) > 0 {
-			if err := s.reconcileAudiobookMissingFiles(ctx, folder, reconcileRoots, seenPaths, sawFiles, fullScan); err != nil {
+			if err := s.reconcileAudiobookMissingFiles(ctx, folder, reconcileRoots, seenPaths, fullScan); err != nil {
 				slog.WarnContext(ctx, "audiobook scan: missing-file reconcile failed", "component", "scanner", "folder_id", folder.ID, "error", err)
 			}
 		} else if len(scans) > 0 {
@@ -431,7 +431,7 @@ func (s *Scanner) ScanAudiobookFolder(ctx context.Context, folder *models.MediaF
 
 	// Reconcile files that vanished from disk now that the full walk's
 	// seenPaths is known and the scan completed without cancellation.
-	if err := s.reconcileAudiobookMissingFiles(ctx, folder, reconcileRoots, seenPaths, sawFiles, fullScan); err != nil {
+	if err := s.reconcileAudiobookMissingFiles(ctx, folder, reconcileRoots, seenPaths, fullScan); err != nil {
 		slog.WarnContext(ctx, "audiobook scan: missing-file reconcile failed", "component", "scanner", "folder_id", folder.ID, "error", err)
 	}
 	return nil
@@ -444,40 +444,19 @@ func (s *Scanner) ScanAudiobookFolder(ctx context.Context, folder *models.MediaF
 // the newly indexed path instead of leaving a stale duplicate). A scan that saw
 // zero files while the DB still has rows only reconciles when the operator has
 // confirmed cleanup, so an unmounted source can't wipe the catalog.
-func (s *Scanner) reconcileAudiobookMissingFiles(ctx context.Context, folder *models.MediaFolder, roots []string, seenPaths map[string]bool, sawFiles, fullScan bool) error {
+func (s *Scanner) reconcileAudiobookMissingFiles(ctx context.Context, folder *models.MediaFolder, roots []string, seenPaths map[string]bool, fullScan bool) error {
 	if s.fileRepo == nil || s.libraryRepo == nil || len(roots) == 0 {
 		return nil
 	}
 
-	confirmedCleanup := false
-	if !sawFiles {
-		existingCount := 0
-		for _, root := range roots {
-			existing, err := s.fileRepo.GetByFolderAndPathPrefix(ctx, folder.ID, root)
-			if err != nil {
-				return fmt.Errorf("listing existing audiobook files for %q: %w", root, err)
-			}
-			existingCount += len(existing)
-		}
-		if existingCount > 0 {
-			var guard ebookCleanupGuardRepo
-			if s.folderRepo != nil {
-				guard = s.folderRepo
-			}
-			// Only a full scan may consume the operator's one-shot empty-cleanup
-			// allowance; an incremental/subtree scan that happens to see zero
-			// files must not (mirrors the ebook path).
-			allowed, err := ebookEmptyCleanupAllowed(ctx, guard, folder.ID, fullScan)
-			if err != nil {
-				return err
-			}
-			if !allowed {
-				slog.WarnContext(ctx, "audiobook scan: walk saw zero files but the database has files under the scanned roots; skipping reconciliation until cleanup is confirmed", "component", "scanner",
-					"folder_id", folder.ID, "existing_files", existingCount)
-				return nil
-			}
-			confirmedCleanup = true
-		}
+	confirmedCleanup, blockAll, err := s.emptyCleanupDecision(
+		ctx, folder, roots, seenPaths, fullScan, "audiobook",
+	)
+	if err != nil {
+		return err
+	}
+	if blockAll {
+		return nil
 	}
 
 	now := time.Now().UTC()

--- a/internal/scanner/audiobook_scan.go
+++ b/internal/scanner/audiobook_scan.go
@@ -500,8 +500,12 @@ func (s *Scanner) reconcileAudiobookMissingFiles(ctx context.Context, folder *mo
 		}
 	}
 
+	// The folder-wide sweep and orphan purge must not destroy rows/items whose
+	// files sit under a currently unreachable library root (see the video
+	// scanner's dead-root protection): unreachable is not removed.
+	unreachableRoots := probeUnreachableRoots(ctx, folder.ID, compactScanRoots(folder.Paths))
 	if s.emptyTrashAfterScan {
-		trashed, err := s.fileRepo.DeleteMissingByFolder(ctx, folder.ID, s.fileRemovalGrace)
+		trashed, err := s.fileRepo.DeleteMissingByFolder(ctx, folder.ID, s.fileRemovalGrace, unreachableRoots)
 		if err != nil {
 			return fmt.Errorf("emptying trash for folder %d: %w", folder.ID, err)
 		}
@@ -510,7 +514,7 @@ func (s *Scanner) reconcileAudiobookMissingFiles(ctx context.Context, folder *mo
 		}
 	}
 
-	removedMemberships, deletedItems, orphanedImageDirs, err := s.reconcileLibraryMemberships(ctx, folder.ID)
+	removedMemberships, deletedItems, orphanedImageDirs, err := s.reconcileLibraryMemberships(ctx, folder.ID, unreachableRoots)
 	if err != nil {
 		return fmt.Errorf("reconciling library membership for folder %d: %w", folder.ID, err)
 	}

--- a/internal/scanner/audiobook_scan.go
+++ b/internal/scanner/audiobook_scan.go
@@ -449,6 +449,7 @@ func (s *Scanner) reconcileAudiobookMissingFiles(ctx context.Context, folder *mo
 		return nil
 	}
 
+	confirmedCleanup := false
 	if !sawFiles {
 		existingCount := 0
 		for _, root := range roots {
@@ -475,6 +476,7 @@ func (s *Scanner) reconcileAudiobookMissingFiles(ctx context.Context, folder *mo
 					"folder_id", folder.ID, "existing_files", existingCount)
 				return nil
 			}
+			confirmedCleanup = true
 		}
 	}
 
@@ -500,7 +502,7 @@ func (s *Scanner) reconcileAudiobookMissingFiles(ctx context.Context, folder *mo
 		}
 	}
 
-	trashed, removedMemberships, deletedItems, err := s.sweepMissingAndReconcile(ctx, folder)
+	trashed, removedMemberships, deletedItems, err := s.sweepMissingAndReconcile(ctx, folder, confirmedCleanup)
 	if trashed > 0 {
 		slog.InfoContext(ctx, "audiobook scan: emptied trash", "component", "scanner", "folder_id", folder.ID, "deleted", trashed)
 	}

--- a/internal/scanner/audiobook_scan.go
+++ b/internal/scanner/audiobook_scan.go
@@ -500,29 +500,12 @@ func (s *Scanner) reconcileAudiobookMissingFiles(ctx context.Context, folder *mo
 		}
 	}
 
-	// The folder-wide sweep and orphan purge must not destroy rows/items whose
-	// files sit under a currently unreachable library root (see the video
-	// scanner's dead-root protection): unreachable is not removed.
-	unreachableRoots := probeUnreachableRoots(ctx, folder.ID, compactScanRoots(folder.Paths))
-	if s.emptyTrashAfterScan {
-		trashed, err := s.fileRepo.DeleteMissingByFolder(ctx, folder.ID, s.fileRemovalGrace, unreachableRoots)
-		if err != nil {
-			return fmt.Errorf("emptying trash for folder %d: %w", folder.ID, err)
-		}
-		if trashed > 0 {
-			slog.InfoContext(ctx, "audiobook scan: emptied trash", "component", "scanner", "folder_id", folder.ID, "deleted", trashed)
-		}
+	trashed, removedMemberships, deletedItems, err := s.sweepMissingAndReconcile(ctx, folder)
+	if trashed > 0 {
+		slog.InfoContext(ctx, "audiobook scan: emptied trash", "component", "scanner", "folder_id", folder.ID, "deleted", trashed)
 	}
-
-	removedMemberships, deletedItems, orphanedImageDirs, err := s.reconcileLibraryMemberships(ctx, folder.ID, unreachableRoots)
 	if err != nil {
-		return fmt.Errorf("reconciling library membership for folder %d: %w", folder.ID, err)
-	}
-	if s.s3Client != nil && len(orphanedImageDirs) > 0 {
-		bucket := s.s3Client.Bucket()
-		for _, dir := range orphanedImageDirs {
-			_, _ = s.s3Client.DeletePrefix(ctx, bucket, dir)
-		}
+		return err
 	}
 	if missing > 0 || removedMemberships > 0 || deletedItems > 0 {
 		slog.InfoContext(ctx, "audiobook scan: reconciled missing files", "component", "scanner",

--- a/internal/scanner/dead_root_test.go
+++ b/internal/scanner/dead_root_test.go
@@ -449,6 +449,68 @@ func TestScanFolderNestedDeadChildRootProtection(t *testing.T) {
 	}
 }
 
+func TestScanFolderNestedSuspectEmptyChildRootProtection(t *testing.T) {
+	pool := newDeadRootTestPool(t)
+	ctx := context.Background()
+	folderID := seedDeadRootTestFolder(t, pool, "movies", "Nested Suspect Root Scan Test")
+
+	base := t.TempDir()
+	parent := filepath.Join(base, "media")
+	child := filepath.Join(parent, "drive")
+	parentFile := filepath.Join(parent, "Alpha (2020)", "Alpha (2020).mkv")
+	childFile := filepath.Join(child, "Beta (2021)", "Beta (2021).mkv")
+	for _, path := range []string{parentFile, childFile} {
+		if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+			t.Fatalf("mkdir %s: %v", filepath.Dir(path), err)
+		}
+		if err := os.WriteFile(path, []byte("fake movie payload"), 0o644); err != nil {
+			t.Fatalf("write %s: %v", path, err)
+		}
+	}
+
+	folder := &models.MediaFolder{
+		ID: folderID, Paths: []string{parent, child}, Type: "movies",
+		Name: "Nested Suspect Root Scan Test", Enabled: true,
+	}
+	scanner := NewScanner(NewFileRepository(pool), "", nil, 2, true, 0)
+	if _, err := scanner.ScanFolder(ctx, folder); err != nil {
+		t.Fatalf("scan 1: %v", err)
+	}
+
+	var childID int
+	if err := pool.QueryRow(ctx,
+		`SELECT id FROM media_files WHERE media_folder_id = $1 AND file_path = $2`,
+		folderID, childFile,
+	).Scan(&childID); err != nil {
+		t.Fatalf("child row after scan 1: %v", err)
+	}
+	if err := os.RemoveAll(filepath.Dir(childFile)); err != nil {
+		t.Fatalf("empty child mountpoint: %v", err)
+	}
+	if err := os.MkdirAll(child, 0o755); err != nil {
+		t.Fatalf("restore empty child mountpoint: %v", err)
+	}
+
+	result, err := scanner.ScanFolder(ctx, folder)
+	if err != nil {
+		t.Fatalf("scan 2: %v", err)
+	}
+	if len(result.SuspectEmptyRoots) != 1 || result.SuspectEmptyRoots[0] != child {
+		t.Fatalf("SuspectEmptyRoots = %v, want [%s]", result.SuspectEmptyRoots, child)
+	}
+	var gotID int
+	var missing *time.Time
+	if err := pool.QueryRow(ctx,
+		`SELECT id, missing_since FROM media_files WHERE media_folder_id = $1 AND file_path = $2`,
+		folderID, childFile,
+	).Scan(&gotID, &missing); err != nil {
+		t.Fatalf("child row after scan 2 (was it deleted?): %v", err)
+	}
+	if gotID != childID || missing == nil {
+		t.Fatalf("child row id/missing = %d/%v, want %d/non-nil", gotID, missing, childID)
+	}
+}
+
 // TestScanFolderAllRootsDeadOutage covers the single-drive-library outage:
 // when EVERY configured root is unreachable, the scan must bypass the
 // empty-root confirm flow (without consuming the operator's one-time cleanup

--- a/internal/scanner/dead_root_test.go
+++ b/internal/scanner/dead_root_test.go
@@ -54,14 +54,26 @@ func TestRootCoverageClauses(t *testing.T) {
 func TestDeadRootWarningMessage(t *testing.T) {
 	t.Parallel()
 
-	got := deadRootWarningMessage(2, []string{"/mnt/movies"})
+	got := deadRootWarningMessage(2, []string{"/mnt/movies"}, nil)
 	want := "1 of 2 roots unreachable: /mnt/movies"
 	if got != want {
 		t.Fatalf("deadRootWarningMessage = %q, want %q", got, want)
 	}
 
-	got = deadRootWarningMessage(3, []string{"/a", "/b"})
+	got = deadRootWarningMessage(3, []string{"/a", "/b"}, nil)
 	want = "2 of 3 roots unreachable: /a, /b"
+	if got != want {
+		t.Fatalf("deadRootWarningMessage = %q, want %q", got, want)
+	}
+
+	got = deadRootWarningMessage(2, nil, []string{"/mnt/movies"})
+	want = "1 of 2 roots returned no files while the library still has cataloged files (lost mount?): /mnt/movies"
+	if got != want {
+		t.Fatalf("deadRootWarningMessage = %q, want %q", got, want)
+	}
+
+	got = deadRootWarningMessage(3, []string{"/a"}, []string{"/b"})
+	want = "1 of 3 roots unreachable: /a; 1 of 3 roots returned no files while the library still has cataloged files (lost mount?): /b"
 	if got != want {
 		t.Fatalf("deadRootWarningMessage = %q, want %q", got, want)
 	}
@@ -513,5 +525,379 @@ func TestScanFolderAllRootsDeadOutage(t *testing.T) {
 	}
 	if !allowance {
 		t.Fatal("outage scan consumed the empty-cleanup allowance; it must be preserved")
+	}
+}
+
+func TestListRootsWithOnlyMissingFiles(t *testing.T) {
+	pool := newDeadRootTestPool(t)
+	ctx := context.Background()
+	folderID := seedDeadRootTestFolder(t, pool, "movies", "Suspect Root Query Test")
+
+	base := fmt.Sprintf("/drp-suspect-%d", time.Now().UnixNano())
+	allMissing := base + "/gone"
+	mixed := base + "/mixed"
+	empty := base + "/empty"
+	stale := time.Now().UTC().Add(-48 * time.Hour)
+
+	seed := func(path string, missing *time.Time) {
+		t.Helper()
+		if _, err := pool.Exec(ctx, `
+			INSERT INTO media_files (media_folder_id, file_path, file_size, missing_since)
+			VALUES ($1, $2, 1024, $3)
+		`, folderID, path, missing); err != nil {
+			t.Fatalf("seed media file %s: %v", path, err)
+		}
+	}
+	seed(allMissing+"/Alpha (2020)/Alpha (2020).mkv", &stale)
+	seed(allMissing+"/Beta (2021)/Beta (2021).mkv", &stale)
+	seed(mixed+"/Gamma (2022)/Gamma (2022).mkv", &stale)
+	seed(mixed+"/Delta (2023)/Delta (2023).mkv", nil)
+
+	repo := NewFileRepository(pool)
+	got, err := repo.ListRootsWithOnlyMissingFiles(ctx, folderID, []string{allMissing, mixed, empty})
+	if err != nil {
+		t.Fatalf("ListRootsWithOnlyMissingFiles: %v", err)
+	}
+	if len(got) != 1 || got[0] != allMissing {
+		t.Fatalf("suspect roots = %v, want [%s]", got, allMissing)
+	}
+
+	if got, err := repo.ListRootsWithOnlyMissingFiles(ctx, folderID, nil); err != nil || len(got) != 0 {
+		t.Fatalf("ListRootsWithOnlyMissingFiles(nil) = %v, %v; want empty", got, err)
+	}
+}
+
+// TestScanFolderSuspectEmptyRootProtection covers the most common lost-mount
+// presentation: the mount drops out but leaves an empty, stat-able mountpoint
+// directory behind, so the reachability probe reports the root healthy. The
+// walk finds zero files while rows remain cataloged: those rows must only be
+// marked missing (surviving a zero-grace sweep), the folder must raise
+// dead_root, and a later scan with the operator's one-time cleanup allowance
+// armed must complete the deletion and clear the warning.
+func TestScanFolderSuspectEmptyRootProtection(t *testing.T) {
+	pool := newDeadRootTestPool(t)
+	ctx := context.Background()
+	folderID := seedDeadRootTestFolder(t, pool, "movies", "Suspect Empty Root Scan Test")
+
+	base := t.TempDir()
+	rootA := filepath.Join(base, "libraryA")
+	rootB := filepath.Join(base, "libraryB")
+	fileA := filepath.Join(rootA, "Alpha (2020)", "Alpha (2020).mkv")
+	fileB := filepath.Join(rootB, "Beta (2021)", "Beta (2021).mkv")
+	writeMovie := func(path string) {
+		t.Helper()
+		if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+			t.Fatalf("mkdir %s: %v", filepath.Dir(path), err)
+		}
+		if err := os.WriteFile(path, []byte("fake movie payload"), 0o644); err != nil {
+			t.Fatalf("write %s: %v", path, err)
+		}
+	}
+	writeMovie(fileA)
+	writeMovie(fileB)
+
+	folder := &models.MediaFolder{
+		ID:      folderID,
+		Paths:   []string{rootA, rootB},
+		Type:    "movies",
+		Name:    "Suspect Empty Root Scan Test",
+		Enabled: true,
+	}
+	scanner := NewScanner(NewFileRepository(pool), "", nil, 2, true, 0)
+
+	fileRow := func(path string) (id int, missingSince *time.Time, found bool) {
+		t.Helper()
+		err := pool.QueryRow(ctx,
+			`SELECT id, missing_since FROM media_files WHERE media_folder_id = $1 AND file_path = $2`,
+			folderID, path,
+		).Scan(&id, &missingSince)
+		if err != nil {
+			if strings.Contains(err.Error(), "no rows") {
+				return 0, nil, false
+			}
+			t.Fatalf("query file row %s: %v", path, err)
+		}
+		return id, missingSince, true
+	}
+	warning := func() (code, message *string) {
+		t.Helper()
+		if err := pool.QueryRow(ctx,
+			`SELECT scan_warning_code, scan_warning_message FROM media_folders WHERE id = $1`,
+			folderID,
+		).Scan(&code, &message); err != nil {
+			t.Fatalf("query scan warning: %v", err)
+		}
+		return code, message
+	}
+
+	if _, err := scanner.ScanFolder(ctx, folder); err != nil {
+		t.Fatalf("scan 1: %v", err)
+	}
+	idB, _, foundB := fileRow(fileB)
+	if !foundB {
+		t.Fatal("after scan 1: fileB row not found")
+	}
+
+	// Root B's mount drops out, leaving the empty mountpoint directory.
+	if err := os.RemoveAll(filepath.Join(rootB, "Beta (2021)")); err != nil {
+		t.Fatalf("empty rootB: %v", err)
+	}
+
+	result, err := scanner.ScanFolder(ctx, folder)
+	if err != nil {
+		t.Fatalf("scan 2: %v", err)
+	}
+	if len(result.UnreachableRoots) != 0 {
+		t.Fatalf("scan 2 UnreachableRoots = %v, want empty (root still probes reachable)", result.UnreachableRoots)
+	}
+	if len(result.SuspectEmptyRoots) != 1 || result.SuspectEmptyRoots[0] != rootB {
+		t.Fatalf("scan 2 SuspectEmptyRoots = %v, want [%s]", result.SuspectEmptyRoots, rootB)
+	}
+	gotIDB, missingB, foundB := fileRow(fileB)
+	if !foundB {
+		t.Fatal("after scan 2: fileB row was hard-deleted; suspect-empty protection failed")
+	}
+	if missingB == nil {
+		t.Fatal("after scan 2: fileB not marked missing; it should be hidden")
+	}
+	if gotIDB != idB {
+		t.Fatalf("after scan 2: fileB id changed %d -> %d", idB, gotIDB)
+	}
+	code, message := warning()
+	if code == nil || *code != "dead_root" {
+		t.Fatalf("after scan 2: scan_warning_code = %v, want dead_root", code)
+	}
+	if message == nil || !strings.Contains(*message, rootB) {
+		t.Fatalf("after scan 2: scan_warning_message = %v, want to contain %q", message, rootB)
+	}
+
+	// Rescan without confirmation: the rows keep surviving.
+	if _, err := scanner.ScanFolder(ctx, folder); err != nil {
+		t.Fatalf("scan 2b: %v", err)
+	}
+	if _, _, foundB = fileRow(fileB); !foundB {
+		t.Fatal("after scan 2b: fileB row was hard-deleted on rescan")
+	}
+
+	// The operator confirms the root really is meant to be empty.
+	if _, err := pool.Exec(ctx,
+		`UPDATE media_folders SET allow_empty_cleanup_once = true WHERE id = $1`, folderID,
+	); err != nil {
+		t.Fatalf("arm cleanup allowance: %v", err)
+	}
+	if _, err := scanner.ScanFolder(ctx, folder); err != nil {
+		t.Fatalf("scan 3: %v", err)
+	}
+	if _, _, foundB = fileRow(fileB); foundB {
+		t.Fatal("after scan 3: fileB row still present; confirmed cleanup did not complete")
+	}
+	if _, _, foundA := fileRow(fileA); !foundA {
+		t.Fatal("after scan 3: fileA row vanished unexpectedly")
+	}
+	if code, _ := warning(); code != nil {
+		t.Fatalf("after scan 3: scan_warning_code = %q, want cleared", *code)
+	}
+	var allowance bool
+	if err := pool.QueryRow(ctx,
+		`SELECT allow_empty_cleanup_once FROM media_folders WHERE id = $1`, folderID,
+	).Scan(&allowance); err != nil {
+		t.Fatalf("query allowance: %v", err)
+	}
+	if allowance {
+		t.Fatal("after scan 3: one-time cleanup allowance was not consumed")
+	}
+}
+
+// TestScanFolderConfirmedCleanupPreservesDeadRoot pins the confirmed
+// empty-cleanup path against dead roots: arming the one-time allowance to
+// clean a reachable, intentionally emptied root must not erase a probe-dead
+// sibling root's catalog — an outage is never a confirmation.
+func TestScanFolderConfirmedCleanupPreservesDeadRoot(t *testing.T) {
+	pool := newDeadRootTestPool(t)
+	ctx := context.Background()
+	folderID := seedDeadRootTestFolder(t, pool, "movies", "Confirmed Cleanup Dead Root Test")
+
+	base := t.TempDir()
+	rootA := filepath.Join(base, "libraryA")
+	rootB := filepath.Join(base, "libraryB")
+	fileA := filepath.Join(rootA, "Alpha (2020)", "Alpha (2020).mkv")
+	fileB := filepath.Join(rootB, "Beta (2021)", "Beta (2021).mkv")
+	writeMovie := func(path string) {
+		t.Helper()
+		if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+			t.Fatalf("mkdir %s: %v", filepath.Dir(path), err)
+		}
+		if err := os.WriteFile(path, []byte("fake movie payload"), 0o644); err != nil {
+			t.Fatalf("write %s: %v", path, err)
+		}
+	}
+	writeMovie(fileA)
+	writeMovie(fileB)
+
+	folder := &models.MediaFolder{
+		ID:      folderID,
+		Paths:   []string{rootA, rootB},
+		Type:    "movies",
+		Name:    "Confirmed Cleanup Dead Root Test",
+		Enabled: true,
+	}
+	scanner := NewScanner(NewFileRepository(pool), "", nil, 2, true, 0)
+
+	if _, err := scanner.ScanFolder(ctx, folder); err != nil {
+		t.Fatalf("scan 1: %v", err)
+	}
+
+	// Root A dies outright; root B is intentionally emptied (dir remains).
+	if err := os.RemoveAll(rootA); err != nil {
+		t.Fatalf("remove rootA: %v", err)
+	}
+	if err := os.RemoveAll(filepath.Join(rootB, "Beta (2021)")); err != nil {
+		t.Fatalf("empty rootB: %v", err)
+	}
+	if _, err := pool.Exec(ctx,
+		`UPDATE media_folders SET allow_empty_cleanup_once = true WHERE id = $1`, folderID,
+	); err != nil {
+		t.Fatalf("arm cleanup allowance: %v", err)
+	}
+
+	result, err := scanner.ScanFolder(ctx, folder)
+	if err != nil {
+		t.Fatalf("scan 2: %v", err)
+	}
+	if result.EmptyRootGuarded {
+		t.Fatal("scan 2 reported EmptyRootGuarded despite the armed allowance")
+	}
+	if len(result.UnreachableRoots) != 1 || result.UnreachableRoots[0] != rootA {
+		t.Fatalf("scan 2 UnreachableRoots = %v, want [%s]", result.UnreachableRoots, rootA)
+	}
+
+	var missingA *time.Time
+	if err := pool.QueryRow(ctx,
+		`SELECT missing_since FROM media_files WHERE media_folder_id = $1 AND file_path = $2`,
+		folderID, fileA,
+	).Scan(&missingA); err != nil {
+		t.Fatalf("fileA row after scan 2 (was the dead root's catalog erased?): %v", err)
+	}
+	if missingA == nil {
+		t.Fatal("fileA not marked missing during the outage")
+	}
+	var countB int
+	if err := pool.QueryRow(ctx,
+		`SELECT count(*) FROM media_files WHERE media_folder_id = $1 AND file_path = $2`,
+		folderID, fileB,
+	).Scan(&countB); err != nil {
+		t.Fatalf("count fileB rows: %v", err)
+	}
+	if countB != 0 {
+		t.Fatalf("fileB rows = %d, want 0 (confirmed cleanup of the reachable empty root)", countB)
+	}
+
+	var code *string
+	var allowance bool
+	if err := pool.QueryRow(ctx,
+		`SELECT scan_warning_code, allow_empty_cleanup_once FROM media_folders WHERE id = $1`,
+		folderID,
+	).Scan(&code, &allowance); err != nil {
+		t.Fatalf("query folder state: %v", err)
+	}
+	if code == nil || *code != "dead_root" {
+		t.Fatalf("scan_warning_code = %v, want dead_root", code)
+	}
+	if allowance {
+		t.Fatal("allowance was not consumed by the confirmed cleanup")
+	}
+}
+
+// TestSweepMissingAndReconcileProtectsDeadRootsFromScopedScans pins the
+// audiobook/ebook/podcast folder-wide sweep against two regressions at once:
+// a scoped scan clone (ScanSubtree/ScanFile) whose Paths holds only the
+// scanned subtree must still probe every CONFIGURED root (reloaded from the
+// DB), and the probe must use the uncompacted list so a nested child mount
+// inside a reachable parent is protected independently.
+func TestSweepMissingAndReconcileProtectsDeadRootsFromScopedScans(t *testing.T) {
+	pool := newDeadRootTestPool(t)
+	ctx := context.Background()
+	folderID := seedDeadRootTestFolder(t, pool, "audiobooks", "Scoped Sweep Dead Root Test")
+
+	base := t.TempDir()
+	parent := filepath.Join(base, "audio")
+	child := filepath.Join(parent, "drive")
+	if err := os.MkdirAll(child, 0o755); err != nil {
+		t.Fatalf("mkdir child: %v", err)
+	}
+	for _, p := range []string{parent, child} {
+		if _, err := pool.Exec(ctx,
+			`INSERT INTO media_folder_paths (media_folder_id, path) VALUES ($1, $2)`,
+			folderID, p,
+		); err != nil {
+			t.Fatalf("seed folder path %s: %v", p, err)
+		}
+	}
+	t.Cleanup(func() {
+		_, _ = pool.Exec(ctx, `DELETE FROM media_folder_paths WHERE media_folder_id = $1`, folderID)
+	})
+
+	stale := time.Now().UTC().Add(-48 * time.Hour)
+	seed := func(path string, missing *time.Time) int {
+		t.Helper()
+		var id int
+		if err := pool.QueryRow(ctx, `
+			INSERT INTO media_files (media_folder_id, file_path, file_size, missing_since)
+			VALUES ($1, $2, 1024, $3) RETURNING id
+		`, folderID, path, missing).Scan(&id); err != nil {
+			t.Fatalf("seed media file %s: %v", path, err)
+		}
+		return id
+	}
+	// A present book keeps the parent root non-suspect, a stale row under the
+	// parent is a genuine deletion the sweep must still purge, and a stale row
+	// under the (about to die) child mount must survive.
+	presentPath := filepath.Join(parent, "Book A", "a.m4b")
+	if err := os.MkdirAll(filepath.Dir(presentPath), 0o755); err != nil {
+		t.Fatalf("mkdir book: %v", err)
+	}
+	if err := os.WriteFile(presentPath, []byte("fake audio payload"), 0o644); err != nil {
+		t.Fatalf("write book: %v", err)
+	}
+	seed(presentPath, nil)
+	goneID := seed(filepath.Join(parent, "Book B", "b.m4b"), &stale)
+	childID := seed(filepath.Join(child, "Book C", "c.m4b"), &stale)
+
+	// The nested child mount dies while the parent stays reachable.
+	if err := os.RemoveAll(child); err != nil {
+		t.Fatalf("remove child mount: %v", err)
+	}
+
+	scanner := NewScanner(NewFileRepository(pool), "", nil, 2, true, 0)
+	// A scoped clone the way ScanSubtree/ScanFile build one: Paths is just the
+	// scanned subtree, not the configured roots.
+	scoped := scopedFolderPaths(&models.MediaFolder{
+		ID:      folderID,
+		Paths:   []string{parent, child},
+		Type:    "audiobooks",
+		Name:    "Scoped Sweep Dead Root Test",
+		Enabled: true,
+	}, []string{filepath.Join(parent, "Book A")})
+
+	if _, _, _, err := scanner.sweepMissingAndReconcile(ctx, scoped, false); err != nil {
+		t.Fatalf("sweepMissingAndReconcile: %v", err)
+	}
+
+	var exists bool
+	if err := pool.QueryRow(ctx,
+		`SELECT EXISTS(SELECT 1 FROM media_files WHERE id = $1)`, childID,
+	).Scan(&exists); err != nil {
+		t.Fatalf("check child row: %v", err)
+	}
+	if !exists {
+		t.Fatal("row under the dead nested child mount was hard-deleted by a scoped sweep")
+	}
+	if err := pool.QueryRow(ctx,
+		`SELECT EXISTS(SELECT 1 FROM media_files WHERE id = $1)`, goneID,
+	).Scan(&exists); err != nil {
+		t.Fatalf("check gone row: %v", err)
+	}
+	if exists {
+		t.Fatal("genuinely deleted row under the reachable parent survived the sweep")
 	}
 }

--- a/internal/scanner/dead_root_test.go
+++ b/internal/scanner/dead_root_test.go
@@ -345,3 +345,173 @@ func TestScanFolderDeadRootProtection(t *testing.T) {
 		t.Fatalf("after scan 4: scan_warning_code = %q, want none", *code)
 	}
 }
+
+// TestScanFolderNestedDeadChildRootProtection covers a child mount configured
+// INSIDE a reachable parent root (/parent plus /parent/child). Traversal
+// compaction drops the child, but it can die independently: its files must be
+// protected from the sweep and the folder must warn, even though the parent
+// scan is otherwise healthy.
+func TestScanFolderNestedDeadChildRootProtection(t *testing.T) {
+	pool := newDeadRootTestPool(t)
+	ctx := context.Background()
+	folderID := seedDeadRootTestFolder(t, pool, "movies", "Nested Dead Root Scan Test")
+
+	base := t.TempDir()
+	parent := filepath.Join(base, "media")
+	child := filepath.Join(parent, "drive")
+	fileParent := filepath.Join(parent, "Alpha (2020)", "Alpha (2020).mkv")
+	fileChild := filepath.Join(child, "Beta (2021)", "Beta (2021).mkv")
+	writeMovie := func(path string) {
+		t.Helper()
+		if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+			t.Fatalf("mkdir %s: %v", filepath.Dir(path), err)
+		}
+		if err := os.WriteFile(path, []byte("fake movie payload"), 0o644); err != nil {
+			t.Fatalf("write %s: %v", path, err)
+		}
+	}
+	writeMovie(fileParent)
+	writeMovie(fileChild)
+
+	folder := &models.MediaFolder{
+		ID:      folderID,
+		Paths:   []string{parent, child},
+		Type:    "movies",
+		Name:    "Nested Dead Root Scan Test",
+		Enabled: true,
+	}
+	scanner := NewScanner(NewFileRepository(pool), "", nil, 2, true, 0)
+
+	if _, err := scanner.ScanFolder(ctx, folder); err != nil {
+		t.Fatalf("scan 1: %v", err)
+	}
+	var childID int
+	var childMissing *time.Time
+	if err := pool.QueryRow(ctx,
+		`SELECT id, missing_since FROM media_files WHERE media_folder_id = $1 AND file_path = $2`,
+		folderID, fileChild,
+	).Scan(&childID, &childMissing); err != nil {
+		t.Fatalf("child row after scan 1: %v", err)
+	}
+	if childMissing != nil {
+		t.Fatalf("child missing after scan 1: %v, want nil", childMissing)
+	}
+
+	// The child mount dies while the parent stays reachable. Compaction hides
+	// the child from traversal, so only the uncompacted probe can protect it.
+	if err := os.RemoveAll(child); err != nil {
+		t.Fatalf("remove child root: %v", err)
+	}
+	result, err := scanner.ScanFolder(ctx, folder)
+	if err != nil {
+		t.Fatalf("scan 2: %v", err)
+	}
+	if len(result.UnreachableRoots) != 1 || result.UnreachableRoots[0] != child {
+		t.Fatalf("scan 2 UnreachableRoots = %v, want [%s]", result.UnreachableRoots, child)
+	}
+	var gotID int
+	if err := pool.QueryRow(ctx,
+		`SELECT id, missing_since FROM media_files WHERE media_folder_id = $1 AND file_path = $2`,
+		folderID, fileChild,
+	).Scan(&gotID, &childMissing); err != nil {
+		t.Fatalf("child row after scan 2 (was it hard-deleted?): %v", err)
+	}
+	if childMissing == nil {
+		t.Fatal("child file not marked missing after its root died")
+	}
+	if gotID != childID {
+		t.Fatalf("child row id changed %d -> %d", childID, gotID)
+	}
+	var code, message *string
+	if err := pool.QueryRow(ctx,
+		`SELECT scan_warning_code, scan_warning_message FROM media_folders WHERE id = $1`,
+		folderID,
+	).Scan(&code, &message); err != nil {
+		t.Fatalf("query warning: %v", err)
+	}
+	if code == nil || *code != "dead_root" {
+		t.Fatalf("scan_warning_code = %v, want dead_root", code)
+	}
+	if message == nil || !strings.Contains(*message, child) {
+		t.Fatalf("scan_warning_message = %v, want to contain %q", message, child)
+	}
+}
+
+// TestScanFolderAllRootsDeadOutage covers the single-drive-library outage:
+// when EVERY configured root is unreachable, the scan must bypass the
+// empty-root confirm flow (without consuming the operator's one-time cleanup
+// allowance), mark all files missing so they hide, keep every row, and raise
+// dead_root — not empty_root.
+func TestScanFolderAllRootsDeadOutage(t *testing.T) {
+	pool := newDeadRootTestPool(t)
+	ctx := context.Background()
+	folderID := seedDeadRootTestFolder(t, pool, "movies", "All Roots Dead Scan Test")
+
+	base := t.TempDir()
+	root := filepath.Join(base, "movies")
+	file := filepath.Join(root, "Alpha (2020)", "Alpha (2020).mkv")
+	if err := os.MkdirAll(filepath.Dir(file), 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	if err := os.WriteFile(file, []byte("fake movie payload"), 0o644); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+
+	folder := &models.MediaFolder{
+		ID:      folderID,
+		Paths:   []string{root},
+		Type:    "movies",
+		Name:    "All Roots Dead Scan Test",
+		Enabled: true,
+	}
+	scanner := NewScanner(NewFileRepository(pool), "", nil, 2, true, 0)
+
+	if _, err := scanner.ScanFolder(ctx, folder); err != nil {
+		t.Fatalf("scan 1: %v", err)
+	}
+
+	// Arm the one-time cleanup allowance so we can prove the outage path does
+	// NOT consume it (it must stay reserved for a deliberate empty-root scan).
+	if _, err := pool.Exec(ctx,
+		`UPDATE media_folders SET allow_empty_cleanup_once = true WHERE id = $1`, folderID,
+	); err != nil {
+		t.Fatalf("arm cleanup allowance: %v", err)
+	}
+
+	if err := os.RemoveAll(root); err != nil {
+		t.Fatalf("remove root: %v", err)
+	}
+	result, err := scanner.ScanFolder(ctx, folder)
+	if err != nil {
+		t.Fatalf("scan 2: %v", err)
+	}
+	if result.EmptyRootGuarded {
+		t.Fatal("scan 2 reported EmptyRootGuarded; all-dead outage should take the dead_root path")
+	}
+
+	var missing *time.Time
+	if err := pool.QueryRow(ctx,
+		`SELECT missing_since FROM media_files WHERE media_folder_id = $1 AND file_path = $2`,
+		folderID, file,
+	).Scan(&missing); err != nil {
+		t.Fatalf("file row after scan 2 (was it hard-deleted?): %v", err)
+	}
+	if missing == nil {
+		t.Fatal("file not marked missing during all-roots-dead outage")
+	}
+
+	var code *string
+	var allowance bool
+	if err := pool.QueryRow(ctx,
+		`SELECT scan_warning_code, allow_empty_cleanup_once FROM media_folders WHERE id = $1`,
+		folderID,
+	).Scan(&code, &allowance); err != nil {
+		t.Fatalf("query folder state: %v", err)
+	}
+	if code == nil || *code != "dead_root" {
+		t.Fatalf("scan_warning_code = %v, want dead_root (not empty_root)", code)
+	}
+	if !allowance {
+		t.Fatal("outage scan consumed the empty-cleanup allowance; it must be preserved")
+	}
+}

--- a/internal/scanner/dead_root_test.go
+++ b/internal/scanner/dead_root_test.go
@@ -1,0 +1,347 @@
+package scanner
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/jackc/pgx/v5/pgxpool"
+
+	"github.com/Silo-Server/silo-server/internal/models"
+)
+
+func TestRootCoverageClauses(t *testing.T) {
+	t.Parallel()
+
+	const moviesRoot = "/mnt/movies"
+	clauses, args := rootCoverageClauses([]string{moviesRoot, "/mnt/tv_shows"}, 3)
+	if len(clauses) != 2 {
+		t.Fatalf("clauses len = %d, want 2 (%v)", len(clauses), clauses)
+	}
+	if clauses[0] != `(file_path = $3 OR file_path LIKE $4 ESCAPE '\')` {
+		t.Fatalf("clauses[0] = %q", clauses[0])
+	}
+	if clauses[1] != `(file_path = $5 OR file_path LIKE $6 ESCAPE '\')` {
+		t.Fatalf("clauses[1] = %q", clauses[1])
+	}
+
+	want := []any{moviesRoot, moviesRoot + "/%", "/mnt/tv_shows", `/mnt/tv\_shows/%`}
+	if len(args) != len(want) {
+		t.Fatalf("args = %v, want %v", args, want)
+	}
+	for i := range want {
+		if args[i] != want[i] {
+			t.Fatalf("args[%d] = %v, want %v", i, args[i], want[i])
+		}
+	}
+
+	// The prefix pattern must end with a separator so a sibling root sharing a
+	// string prefix (/mnt/movies2) can never match /mnt/movies.
+	pattern, ok := args[1].(string)
+	if !ok || !strings.HasSuffix(pattern, string(filepath.Separator)+"%") {
+		t.Fatalf("prefix pattern %v does not enforce a path separator boundary", args[1])
+	}
+
+	if clauses, args := rootCoverageClauses(nil, 1); len(clauses) != 0 || len(args) != 0 {
+		t.Fatalf("rootCoverageClauses(nil) = %v, %v; want empty", clauses, args)
+	}
+}
+
+func TestDeadRootWarningMessage(t *testing.T) {
+	t.Parallel()
+
+	got := deadRootWarningMessage(2, []string{"/mnt/movies"})
+	want := "1 of 2 roots unreachable: /mnt/movies"
+	if got != want {
+		t.Fatalf("deadRootWarningMessage = %q, want %q", got, want)
+	}
+
+	got = deadRootWarningMessage(3, []string{"/a", "/b"})
+	want = "2 of 3 roots unreachable: /a, /b"
+	if got != want {
+		t.Fatalf("deadRootWarningMessage = %q, want %q", got, want)
+	}
+}
+
+func TestProbeUnreachableRoots(t *testing.T) {
+	t.Parallel()
+
+	alive := t.TempDir()
+	dead := filepath.Join(t.TempDir(), "gone")
+
+	got := probeUnreachableRoots(context.Background(), 1, []string{alive, dead})
+	if len(got) != 1 || got[0] != dead {
+		t.Fatalf("probeUnreachableRoots = %v, want [%s]", got, dead)
+	}
+	if got := probeUnreachableRoots(context.Background(), 1, []string{alive}); len(got) != 0 {
+		t.Fatalf("probeUnreachableRoots(all alive) = %v, want empty", got)
+	}
+}
+
+func newDeadRootTestPool(t *testing.T) *pgxpool.Pool {
+	t.Helper()
+	dsn := os.Getenv("SILO_TEST_DATABASE_URL")
+	if dsn == "" {
+		t.Skip("SILO_TEST_DATABASE_URL is not set")
+	}
+	pool, err := pgxpool.New(context.Background(), dsn)
+	if err != nil {
+		t.Fatalf("connect test database: %v", err)
+	}
+	t.Cleanup(pool.Close)
+	return pool
+}
+
+func seedDeadRootTestFolder(t *testing.T, pool *pgxpool.Pool, folderType, name string) int {
+	t.Helper()
+	ctx := context.Background()
+	var folderID int
+	if err := pool.QueryRow(ctx,
+		`INSERT INTO media_folders (type, name, enabled) VALUES ($1, $2, true) RETURNING id`,
+		folderType, name,
+	).Scan(&folderID); err != nil {
+		t.Fatalf("seed folder: %v", err)
+	}
+	t.Cleanup(func() {
+		_, _ = pool.Exec(ctx, `DELETE FROM media_files WHERE media_folder_id = $1`, folderID)
+		_, _ = pool.Exec(ctx, `DELETE FROM media_folders WHERE id = $1`, folderID)
+	})
+	return folderID
+}
+
+// TestDeleteMissingByFolderProtectedRoots covers the trash-sweep guard at the
+// repository level: rows under a protected (unreachable) root survive the
+// sweep no matter how stale their missing_since is, sibling roots that merely
+// share a string prefix are NOT protected, and an empty protected set
+// preserves the historical folder-wide sweep.
+func TestDeleteMissingByFolderProtectedRoots(t *testing.T) {
+	pool := newDeadRootTestPool(t)
+	ctx := context.Background()
+	folderID := seedDeadRootTestFolder(t, pool, "movies", "Dead Root Sweep Test")
+
+	base := fmt.Sprintf("/drp-sweep-%d", time.Now().UnixNano())
+	protectedRoot := base + "/movies"
+	staleSince := time.Now().UTC().Add(-48 * time.Hour)
+
+	seed := func(path string) int {
+		var id int
+		if err := pool.QueryRow(ctx, `
+			INSERT INTO media_files (media_folder_id, file_path, file_size, missing_since)
+			VALUES ($1, $2, 1024, $3) RETURNING id
+		`, folderID, path, staleSince).Scan(&id); err != nil {
+			t.Fatalf("seed media file %s: %v", path, err)
+		}
+		return id
+	}
+	protectedID := seed(protectedRoot + "/Alpha (2020)/Alpha (2020).mkv")
+	seed(base + "/movies2/Beta (2021)/Beta (2021).mkv") // sibling string prefix
+	seed(base + "/other/Gamma (2022)/Gamma (2022).mkv")
+
+	repo := NewFileRepository(pool)
+	deleted, err := repo.DeleteMissingByFolder(ctx, folderID, 24*time.Hour, []string{protectedRoot})
+	if err != nil {
+		t.Fatalf("DeleteMissingByFolder with protection: %v", err)
+	}
+	if deleted != 2 {
+		t.Fatalf("deleted = %d, want 2 (sibling-prefix and unrelated rows)", deleted)
+	}
+	var remaining int
+	if err := pool.QueryRow(ctx,
+		`SELECT count(*) FROM media_files WHERE media_folder_id = $1`, folderID,
+	).Scan(&remaining); err != nil {
+		t.Fatalf("count remaining: %v", err)
+	}
+	if remaining != 1 {
+		t.Fatalf("remaining rows = %d, want 1 (the protected row)", remaining)
+	}
+	var stillThere bool
+	if err := pool.QueryRow(ctx,
+		`SELECT EXISTS(SELECT 1 FROM media_files WHERE id = $1)`, protectedID,
+	).Scan(&stillThere); err != nil {
+		t.Fatalf("check protected row: %v", err)
+	}
+	if !stillThere {
+		t.Fatal("protected row was deleted")
+	}
+
+	// Without protection the sweep behaves exactly as before and removes it.
+	deleted, err = repo.DeleteMissingByFolder(ctx, folderID, 24*time.Hour, nil)
+	if err != nil {
+		t.Fatalf("DeleteMissingByFolder without protection: %v", err)
+	}
+	if deleted != 1 {
+		t.Fatalf("deleted = %d, want 1", deleted)
+	}
+}
+
+// TestScanFolderDeadRootProtection walks the real scan pipeline end to end
+// with two on-disk roots and verifies the full dead-root story:
+//
+//  1. a root that disappears has its files marked missing but never
+//     hard-deleted, even with trash emptying enabled and a zero grace
+//     (which would delete them in the very same scan without protection),
+//     and the folder surfaces a dead_root scan warning naming the root;
+//  2. when the root comes back the rows resurrect in place (same ids,
+//     missing_since cleared) and the warning clears;
+//  3. deleting a file under a reachable root still purges its row after the
+//     grace elapses (regression: the historical sweep is untouched).
+func TestScanFolderDeadRootProtection(t *testing.T) {
+	pool := newDeadRootTestPool(t)
+	ctx := context.Background()
+	folderID := seedDeadRootTestFolder(t, pool, "movies", "Dead Root Scan Test")
+
+	base := t.TempDir()
+	rootA := filepath.Join(base, "libraryA")
+	rootB := filepath.Join(base, "libraryB")
+	fileA := filepath.Join(rootA, "Alpha (2020)", "Alpha (2020).mkv")
+	fileB := filepath.Join(rootB, "Beta (2021)", "Beta (2021).mkv")
+	writeMovie := func(path string) {
+		t.Helper()
+		if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+			t.Fatalf("mkdir %s: %v", filepath.Dir(path), err)
+		}
+		if err := os.WriteFile(path, []byte("fake movie payload"), 0o644); err != nil {
+			t.Fatalf("write %s: %v", path, err)
+		}
+	}
+	writeMovie(fileA)
+	writeMovie(fileB)
+
+	folder := &models.MediaFolder{
+		ID:      folderID,
+		Paths:   []string{rootA, rootB},
+		Type:    "movies",
+		Name:    "Dead Root Scan Test",
+		Enabled: true,
+	}
+
+	// emptyTrashAfterScan=true with zero grace: a missing row is eligible for
+	// deletion in the very scan that marks it missing.
+	scanner := NewScanner(NewFileRepository(pool), "", nil, 2, true, 0)
+
+	fileRow := func(path string) (id int, missingSince *time.Time, found bool) {
+		t.Helper()
+		err := pool.QueryRow(ctx,
+			`SELECT id, missing_since FROM media_files WHERE media_folder_id = $1 AND file_path = $2`,
+			folderID, path,
+		).Scan(&id, &missingSince)
+		if err != nil {
+			if strings.Contains(err.Error(), "no rows") {
+				return 0, nil, false
+			}
+			t.Fatalf("query file row %s: %v", path, err)
+		}
+		return id, missingSince, true
+	}
+	warning := func() (code, message *string) {
+		t.Helper()
+		if err := pool.QueryRow(ctx,
+			`SELECT scan_warning_code, scan_warning_message FROM media_folders WHERE id = $1`,
+			folderID,
+		).Scan(&code, &message); err != nil {
+			t.Fatalf("query scan warning: %v", err)
+		}
+		return code, message
+	}
+
+	// Scan 1: both roots healthy.
+	if _, err := scanner.ScanFolder(ctx, folder); err != nil {
+		t.Fatalf("scan 1: %v", err)
+	}
+	idA, missingA, foundA := fileRow(fileA)
+	idB, missingB, foundB := fileRow(fileB)
+	if !foundA || !foundB {
+		t.Fatalf("after scan 1: foundA=%v foundB=%v, want both rows", foundA, foundB)
+	}
+	if missingA != nil || missingB != nil {
+		t.Fatalf("after scan 1: missingA=%v missingB=%v, want both nil", missingA, missingB)
+	}
+
+	// Root B dies (unmounted / dead drive).
+	if err := os.RemoveAll(rootB); err != nil {
+		t.Fatalf("remove rootB: %v", err)
+	}
+
+	// Scan 2: files under the dead root are marked missing (hidden) but the
+	// row must survive the sweep, and the folder must carry a dead_root
+	// warning naming the root.
+	result, err := scanner.ScanFolder(ctx, folder)
+	if err != nil {
+		t.Fatalf("scan 2: %v", err)
+	}
+	if len(result.UnreachableRoots) != 1 || result.UnreachableRoots[0] != rootB {
+		t.Fatalf("scan 2 UnreachableRoots = %v, want [%s]", result.UnreachableRoots, rootB)
+	}
+	if _, missingA, foundA = fileRow(fileA); !foundA || missingA != nil {
+		t.Fatalf("after scan 2: fileA found=%v missing=%v, want present and not missing", foundA, missingA)
+	}
+	gotIDB, missingB, foundB := fileRow(fileB)
+	if !foundB {
+		t.Fatal("after scan 2: fileB row was hard-deleted; dead-root protection failed")
+	}
+	if missingB == nil {
+		t.Fatal("after scan 2: fileB not marked missing; it should be hidden")
+	}
+	if gotIDB != idB {
+		t.Fatalf("after scan 2: fileB id changed %d -> %d", idB, gotIDB)
+	}
+	code, message := warning()
+	if code == nil || *code != "dead_root" {
+		t.Fatalf("after scan 2: scan_warning_code = %v, want dead_root", code)
+	}
+	if message == nil || !strings.Contains(*message, rootB) {
+		t.Fatalf("after scan 2: scan_warning_message = %v, want to contain %q", message, rootB)
+	}
+
+	// Rescan while still dead: row keeps surviving (grace long since elapsed).
+	if _, err := scanner.ScanFolder(ctx, folder); err != nil {
+		t.Fatalf("scan 2b: %v", err)
+	}
+	if _, _, foundB = fileRow(fileB); !foundB {
+		t.Fatal("after scan 2b: fileB row was hard-deleted on rescan")
+	}
+
+	// Root B returns: the same row resurrects (same id, missing cleared) and
+	// the warning clears.
+	writeMovie(fileB)
+	if _, err := scanner.ScanFolder(ctx, folder); err != nil {
+		t.Fatalf("scan 3: %v", err)
+	}
+	gotIDB, missingB, foundB = fileRow(fileB)
+	if !foundB || missingB != nil {
+		t.Fatalf("after scan 3: fileB found=%v missing=%v, want resurrected", foundB, missingB)
+	}
+	if gotIDB != idB {
+		t.Fatalf("after scan 3: fileB resurrected under a new id %d, want original %d", gotIDB, idB)
+	}
+	if code, _ := warning(); code != nil {
+		t.Fatalf("after scan 3: scan_warning_code = %q, want cleared", *code)
+	}
+	if _, missingA, _ = fileRow(fileA); missingA != nil {
+		t.Fatalf("after scan 3: fileA missing = %v, want nil", missingA)
+	}
+	_ = idA
+
+	// Regression: deleting one FILE under a reachable root still purges its
+	// row once the grace (zero here) elapses — reachable-root semantics are
+	// unchanged.
+	if err := os.Remove(fileB); err != nil {
+		t.Fatalf("remove fileB: %v", err)
+	}
+	if _, err := scanner.ScanFolder(ctx, folder); err != nil {
+		t.Fatalf("scan 4: %v", err)
+	}
+	if _, _, foundB = fileRow(fileB); foundB {
+		t.Fatal("after scan 4: fileB row still present; reachable-root purge regressed")
+	}
+	if _, _, foundA = fileRow(fileA); !foundA {
+		t.Fatal("after scan 4: fileA row vanished unexpectedly")
+	}
+	if code, _ := warning(); code != nil {
+		t.Fatalf("after scan 4: scan_warning_code = %q, want none", *code)
+	}
+}

--- a/internal/scanner/ebook_scan.go
+++ b/internal/scanner/ebook_scan.go
@@ -375,40 +375,17 @@ func (s *Scanner) reconcileMissingEbookFiles(ctx context.Context, folder *models
 		}
 	}
 
-	// The folder-wide sweep and orphan purge must not destroy rows/items whose
-	// files sit under a currently unreachable library root (see the video
-	// scanner's dead-root protection): unreachable is not removed.
-	unreachableRoots := probeUnreachableRoots(ctx, folder.ID, compactScanRoots(folder.Paths))
-	if s.emptyTrashAfterScan {
-		trashed, err := s.fileRepo.DeleteMissingByFolder(ctx, folder.ID, s.fileRemovalGrace, unreachableRoots)
-		if err != nil {
-			return fmt.Errorf("emptying trash for folder %d: %w", folder.ID, err)
-		}
-		if trashed > 0 {
-			slog.InfoContext(ctx, "ebook scan: emptied trash", "component", "scanner", "folder_id", folder.ID, "deleted", trashed)
-		}
+	trashed, removedMemberships, deletedItems, err := s.sweepMissingAndReconcile(ctx, folder)
+	if trashed > 0 {
+		slog.InfoContext(ctx, "ebook scan: emptied trash", "component", "scanner", "folder_id", folder.ID, "deleted", trashed)
 	}
-
-	removedMemberships, deletedItems, orphanedImageDirs, err := s.reconcileLibraryMemberships(ctx, folder.ID, unreachableRoots)
 	if err != nil {
-		return fmt.Errorf("reconciling library membership for folder %d: %w", folder.ID, err)
+		return err
 	}
-
-	// Best-effort S3 image cleanup for orphaned items.
-	if s.s3Client != nil && len(orphanedImageDirs) > 0 {
-		bucket := s.s3Client.Bucket()
-		for _, dir := range orphanedImageDirs {
-			_, _ = s.s3Client.DeletePrefix(ctx, bucket, dir)
-		}
-	}
-
 	if missing > 0 || removedMemberships > 0 || deletedItems > 0 {
 		slog.InfoContext(ctx, "ebook scan: reconciled missing files", "component", "scanner",
-			"folder_id", folder.ID,
-			"missing", missing,
-			"memberships_removed", removedMemberships,
-			"items_deleted", deletedItems,
-		)
+			"folder_id", folder.ID, "missing", missing,
+			"memberships_removed", removedMemberships, "items_deleted", deletedItems)
 	}
 	return nil
 }

--- a/internal/scanner/ebook_scan.go
+++ b/internal/scanner/ebook_scan.go
@@ -375,8 +375,12 @@ func (s *Scanner) reconcileMissingEbookFiles(ctx context.Context, folder *models
 		}
 	}
 
+	// The folder-wide sweep and orphan purge must not destroy rows/items whose
+	// files sit under a currently unreachable library root (see the video
+	// scanner's dead-root protection): unreachable is not removed.
+	unreachableRoots := probeUnreachableRoots(ctx, folder.ID, compactScanRoots(folder.Paths))
 	if s.emptyTrashAfterScan {
-		trashed, err := s.fileRepo.DeleteMissingByFolder(ctx, folder.ID, s.fileRemovalGrace)
+		trashed, err := s.fileRepo.DeleteMissingByFolder(ctx, folder.ID, s.fileRemovalGrace, unreachableRoots)
 		if err != nil {
 			return fmt.Errorf("emptying trash for folder %d: %w", folder.ID, err)
 		}
@@ -385,7 +389,7 @@ func (s *Scanner) reconcileMissingEbookFiles(ctx context.Context, folder *models
 		}
 	}
 
-	removedMemberships, deletedItems, orphanedImageDirs, err := s.reconcileLibraryMemberships(ctx, folder.ID)
+	removedMemberships, deletedItems, orphanedImageDirs, err := s.reconcileLibraryMemberships(ctx, folder.ID, unreachableRoots)
 	if err != nil {
 		return fmt.Errorf("reconciling library membership for folder %d: %w", folder.ID, err)
 	}

--- a/internal/scanner/ebook_scan.go
+++ b/internal/scanner/ebook_scan.go
@@ -19,6 +19,7 @@ import (
 	"github.com/Silo-Server/silo-server/internal/idgen"
 	"github.com/Silo-Server/silo-server/internal/imageutil"
 	"github.com/Silo-Server/silo-server/internal/models"
+	"github.com/Silo-Server/silo-server/internal/rootcheck"
 	"github.com/Silo-Server/silo-server/internal/titleutil"
 	"github.com/jackc/pgx/v5"
 	"github.com/jackc/pgx/v5/pgconn"
@@ -282,10 +283,89 @@ func ebookEmptyCleanupAllowed(ctx context.Context, repo ebookCleanupGuardRepo, f
 	return allowed, nil
 }
 
+// emptyCleanupDecision determines whether an audio/ebook scan may clean roots
+// that contain catalog rows but produced no files. A completely empty scan is
+// blocked until confirmation; in a mixed multi-root scan only literally empty
+// roots need confirmation, while healthy roots continue reconciling normally.
+func (s *Scanner) emptyCleanupDecision(
+	ctx context.Context,
+	folder *models.MediaFolder,
+	roots []string,
+	seenPaths map[string]bool,
+	fullScan bool,
+	mediaKind string,
+) (confirmed, blockAll bool, err error) {
+	if s.fileRepo == nil || len(roots) == 0 {
+		return false, false, nil
+	}
+	wholeScanEmpty := len(seenPaths) == 0
+	probes := rootcheck.ProbeManyWithTimeout(ctx, roots, rootcheck.DefaultProbeTimeout)
+	needsConfirmation := false
+	for i, root := range roots {
+		if !wholeScanEmpty {
+			seenUnderRoot := false
+			for path := range seenPaths {
+				if pathWithinAnyRoot(path, []string{root}) {
+					seenUnderRoot = true
+					break
+				}
+			}
+			if seenUnderRoot || !probes[i].Reachable || !probes[i].Empty {
+				continue
+			}
+		} else if !probes[i].Reachable {
+			continue
+		}
+		existing, listErr := s.fileRepo.GetByFolderAndPathPrefix(ctx, folder.ID, root)
+		if listErr != nil {
+			return false, false, fmt.Errorf("listing existing %s files for %q: %w", mediaKind, root, listErr)
+		}
+		if len(existing) > 0 {
+			needsConfirmation = true
+			break
+		}
+	}
+	if !needsConfirmation {
+		return false, false, nil
+	}
+	var guard ebookCleanupGuardRepo
+	if s.folderRepo != nil {
+		guard = s.folderRepo
+	}
+	allowed := false
+	if wholeScanEmpty {
+		var allowErr error
+		allowed, allowErr = ebookEmptyCleanupAllowed(ctx, guard, folder.ID, fullScan)
+		if allowErr != nil {
+			return false, false, allowErr
+		}
+	} else if fullScan && guard != nil {
+		var allowErr error
+		allowed, allowErr = guard.ConsumeEmptyCleanupAllowance(ctx, folder.ID)
+		if allowErr != nil {
+			return false, false, fmt.Errorf("checking partial-root cleanup confirmation for folder %d: %w", folder.ID, allowErr)
+		}
+		if !allowed {
+			if warnErr := guard.SetScanWarning(ctx, folder.ID,
+				"dead_root",
+				"One or more roots are reachable but empty while the library still has cataloged files; cleanup was skipped until deletion is confirmed.",
+				time.Now().UTC(),
+			); warnErr != nil {
+				return false, false, fmt.Errorf("recording partial-root warning for folder %d: %w", folder.ID, warnErr)
+			}
+		}
+	}
+	if !allowed {
+		slog.WarnContext(ctx, mediaKind+" scan: empty roots still have cataloged files; cleanup requires confirmation",
+			"component", "scanner", "folder_id", folder.ID, "full_scan", fullScan)
+	}
+	return allowed, wholeScanEmpty && !allowed, nil
+}
+
 // reconcileEbookScan applies the post-walk safety policy and then performs
 // missing-file reconciliation for the roots that walked cleanly.
 func (s *Scanner) reconcileEbookScan(ctx context.Context, folder *models.MediaFolder, scans []ebookRootScan, seenPaths map[string]bool, fullScan bool) error {
-	reconcileRoots, sawFiles := splitEbookReconcileRoots(scans)
+	reconcileRoots, _ := splitEbookReconcileRoots(scans)
 	if len(reconcileRoots) == 0 {
 		if len(scans) > 0 {
 			slog.WarnContext(ctx, "ebook scan: every root walk failed; skipping missing-file reconciliation", "component", "scanner",
@@ -298,35 +378,14 @@ func (s *Scanner) reconcileEbookScan(ctx context.Context, folder *models.MediaFo
 		return nil
 	}
 
-	confirmedCleanup := false
-	if !sawFiles {
-		existingCount := 0
-		for _, root := range reconcileRoots {
-			existing, err := s.fileRepo.GetByFolderAndPathPrefix(ctx, folder.ID, root)
-			if err != nil {
-				return fmt.Errorf("listing existing ebook files for %q: %w", root, err)
-			}
-			existingCount += len(existing)
-		}
-		if existingCount > 0 {
-			var guard ebookCleanupGuardRepo
-			if s.folderRepo != nil {
-				guard = s.folderRepo
-			}
-			allowed, err := ebookEmptyCleanupAllowed(ctx, guard, folder.ID, fullScan)
-			if err != nil {
-				return err
-			}
-			if !allowed {
-				slog.WarnContext(ctx, "ebook scan: walk saw zero ebooks but the database has files under the scanned roots; skipping reconciliation until cleanup is confirmed", "component", "scanner",
-					"folder_id", folder.ID,
-					"existing_files", existingCount,
-					"full_scan", fullScan,
-				)
-				return nil
-			}
-			confirmedCleanup = true
-		}
+	confirmedCleanup, blockAll, err := s.emptyCleanupDecision(
+		ctx, folder, reconcileRoots, seenPaths, fullScan, "ebook",
+	)
+	if err != nil {
+		return err
+	}
+	if blockAll {
+		return nil
 	}
 
 	if err := s.reconcileMissingEbookFiles(ctx, folder, reconcileRoots, seenPaths, confirmedCleanup); err != nil {

--- a/internal/scanner/ebook_scan.go
+++ b/internal/scanner/ebook_scan.go
@@ -298,6 +298,7 @@ func (s *Scanner) reconcileEbookScan(ctx context.Context, folder *models.MediaFo
 		return nil
 	}
 
+	confirmedCleanup := false
 	if !sawFiles {
 		existingCount := 0
 		for _, root := range reconcileRoots {
@@ -324,10 +325,11 @@ func (s *Scanner) reconcileEbookScan(ctx context.Context, folder *models.MediaFo
 				)
 				return nil
 			}
+			confirmedCleanup = true
 		}
 	}
 
-	if err := s.reconcileMissingEbookFiles(ctx, folder, reconcileRoots, seenPaths); err != nil {
+	if err := s.reconcileMissingEbookFiles(ctx, folder, reconcileRoots, seenPaths, confirmedCleanup); err != nil {
 		return err
 	}
 	if fullScan && s.folderRepo != nil {
@@ -345,7 +347,7 @@ func (s *Scanner) reconcileEbookScan(ctx context.Context, folder *models.MediaFo
 // folder trash is optionally emptied, and library memberships are reconciled
 // so items with no remaining files are removed (renames therefore converge on
 // the newly indexed path instead of leaving a stale duplicate item).
-func (s *Scanner) reconcileMissingEbookFiles(ctx context.Context, folder *models.MediaFolder, roots []string, seenPaths map[string]bool) error {
+func (s *Scanner) reconcileMissingEbookFiles(ctx context.Context, folder *models.MediaFolder, roots []string, seenPaths map[string]bool, confirmedCleanup bool) error {
 	if s.fileRepo == nil || s.libraryRepo == nil || len(roots) == 0 {
 		return nil
 	}
@@ -375,7 +377,7 @@ func (s *Scanner) reconcileMissingEbookFiles(ctx context.Context, folder *models
 		}
 	}
 
-	trashed, removedMemberships, deletedItems, err := s.sweepMissingAndReconcile(ctx, folder)
+	trashed, removedMemberships, deletedItems, err := s.sweepMissingAndReconcile(ctx, folder, confirmedCleanup)
 	if trashed > 0 {
 		slog.InfoContext(ctx, "ebook scan: emptied trash", "component", "scanner", "folder_id", folder.ID, "deleted", trashed)
 	}

--- a/internal/scanner/file_repo.go
+++ b/internal/scanner/file_repo.go
@@ -2638,6 +2638,55 @@ func (r *FileRepository) DeleteMissingByFolder(ctx context.Context, folderID int
 	return int(tag.RowsAffected()), nil
 }
 
+// ListRootsWithOnlyMissingFiles returns the subset of roots (in input order)
+// that still have media_files rows at or under them in the folder but none
+// that are present (missing_since IS NULL). A reachable root in this state is
+// "suspect empty": it is the on-disk signature of a mount that dropped out
+// while leaving an empty, stat-able mountpoint directory, which a
+// reachability probe cannot distinguish from an intentionally emptied root.
+func (r *FileRepository) ListRootsWithOnlyMissingFiles(ctx context.Context, folderID int, roots []string) ([]string, error) {
+	if len(roots) == 0 {
+		return nil, nil
+	}
+	patterns := make([]string, len(roots))
+	for i, root := range roots {
+		patterns[i] = pathscope.PrefixLike(root)
+	}
+	rows, err := r.pool.Query(ctx, `
+		SELECT r.root
+		FROM unnest($2::text[], $3::text[]) WITH ORDINALITY AS r(root, pattern, ord)
+		WHERE EXISTS (
+			SELECT 1 FROM media_files mf
+			WHERE mf.media_folder_id = $1
+			  AND (mf.file_path = r.root OR mf.file_path LIKE r.pattern ESCAPE '\')
+		)
+		AND NOT EXISTS (
+			SELECT 1 FROM media_files mf
+			WHERE mf.media_folder_id = $1
+			  AND (mf.file_path = r.root OR mf.file_path LIKE r.pattern ESCAPE '\')
+			  AND mf.missing_since IS NULL
+		)
+		ORDER BY r.ord
+	`, folderID, roots, patterns)
+	if err != nil {
+		return nil, fmt.Errorf("querying roots with only missing files: %w", err)
+	}
+	defer rows.Close()
+
+	suspect := make([]string, 0)
+	for rows.Next() {
+		var root string
+		if err := rows.Scan(&root); err != nil {
+			return nil, fmt.Errorf("scanning suspect-empty root: %w", err)
+		}
+		suspect = append(suspect, root)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("iterating suspect-empty roots: %w", err)
+	}
+	return suspect, nil
+}
+
 // DeleteByIDs removes specific media file rows by primary key.
 func (r *FileRepository) DeleteByIDs(ctx context.Context, ids []int) (int, error) {
 	if len(ids) == 0 {

--- a/internal/scanner/file_repo.go
+++ b/internal/scanner/file_repo.go
@@ -2616,13 +2616,22 @@ func (r *FileRepository) MarkMissing(ctx context.Context, id int, since time.Tim
 // hidden from clients; the grace only delays deleting the row so a file that
 // reappears within the window restores without re-probing or re-matching.
 // A zero grace deletes all missing-marked rows immediately.
+//
+// Rows whose file_path lies at or under one of protectedRoots are never
+// deleted, no matter how long they have been missing: an unreachable library
+// root (dead drive, lost mount) is temporarily offline, not removed, so its
+// catalog state must survive until the root is reachable again. Passing no
+// protected roots preserves the historical folder-wide sweep exactly.
 // Returns the number of rows deleted.
-func (r *FileRepository) DeleteMissingByFolder(ctx context.Context, folderID int, gracePeriod time.Duration) (int, error) {
+func (r *FileRepository) DeleteMissingByFolder(ctx context.Context, folderID int, gracePeriod time.Duration, protectedRoots []string) (int, error) {
 	cutoff := time.Now().UTC().Add(-gracePeriod)
-	tag, err := r.pool.Exec(ctx,
-		"DELETE FROM media_files WHERE media_folder_id = $1 AND missing_since IS NOT NULL AND missing_since < $2",
-		folderID, cutoff,
-	)
+	query := "DELETE FROM media_files WHERE media_folder_id = $1 AND missing_since IS NOT NULL AND missing_since < $2"
+	args := []any{folderID, cutoff}
+	if clauses, clauseArgs := rootCoverageClauses(protectedRoots, len(args)+1); len(clauses) > 0 {
+		query += " AND NOT (" + strings.Join(clauses, " OR ") + ")"
+		args = append(args, clauseArgs...)
+	}
+	tag, err := r.pool.Exec(ctx, query, args...)
 	if err != nil {
 		return 0, fmt.Errorf("deleting missing files for folder %d: %w", folderID, err)
 	}
@@ -2671,13 +2680,8 @@ func (r *FileRepository) ListIDsOutsideRoots(ctx context.Context, folderID int, 
 
 	args := make([]any, 0, 1+len(roots)*2)
 	args = append(args, folderID)
-	coveredClauses := make([]string, 0, len(roots))
-	for i, root := range roots {
-		pathArg := 2 + (i * 2)
-		likeArg := pathArg + 1
-		coveredClauses = append(coveredClauses, fmt.Sprintf("(file_path = $%d OR file_path LIKE $%d ESCAPE '\\')", pathArg, likeArg))
-		args = append(args, root, pathPrefixLike(root))
-	}
+	coveredClauses, coveredArgs := rootCoverageClauses(roots, 2)
+	args = append(args, coveredArgs...)
 
 	query := `SELECT id FROM media_files WHERE media_folder_id = $1 AND NOT (` + strings.Join(coveredClauses, " OR ") + `)`
 	rows, err := r.pool.Query(ctx, query, args...)
@@ -3448,4 +3452,21 @@ func nilIfZero(n int) *int {
 
 func pathPrefixLike(pathPrefix string) string {
 	return pathscope.PrefixLike(pathPrefix)
+}
+
+// rootCoverageClauses builds one SQL predicate per root matching file_path
+// rows that live at or under that root, using the exact-match + escaped
+// prefix-LIKE shape shared with ListIDsOutsideRoots (a root never matches a
+// sibling that merely shares a string prefix, e.g. /mnt/movies2 under
+// /mnt/movies). Placeholder numbering starts at firstArg; the returned args
+// bind pairwise (root, prefix pattern) in clause order.
+func rootCoverageClauses(roots []string, firstArg int) ([]string, []any) {
+	clauses := make([]string, 0, len(roots))
+	args := make([]any, 0, len(roots)*2)
+	for i, root := range roots {
+		pathArg := firstArg + i*2
+		clauses = append(clauses, fmt.Sprintf("(file_path = $%d OR file_path LIKE $%d ESCAPE '\\')", pathArg, pathArg+1))
+		args = append(args, root, pathPrefixLike(root))
+	}
+	return clauses, args
 }

--- a/internal/scanner/file_repo.go
+++ b/internal/scanner/file_repo.go
@@ -3455,18 +3455,7 @@ func pathPrefixLike(pathPrefix string) string {
 }
 
 // rootCoverageClauses builds one SQL predicate per root matching file_path
-// rows that live at or under that root, using the exact-match + escaped
-// prefix-LIKE shape shared with ListIDsOutsideRoots (a root never matches a
-// sibling that merely shares a string prefix, e.g. /mnt/movies2 under
-// /mnt/movies). Placeholder numbering starts at firstArg; the returned args
-// bind pairwise (root, prefix pattern) in clause order.
+// rows that live at or under that root; see pathscope.CoverageClauses.
 func rootCoverageClauses(roots []string, firstArg int) ([]string, []any) {
-	clauses := make([]string, 0, len(roots))
-	args := make([]any, 0, len(roots)*2)
-	for i, root := range roots {
-		pathArg := firstArg + i*2
-		clauses = append(clauses, fmt.Sprintf("(file_path = $%d OR file_path LIKE $%d ESCAPE '\\')", pathArg, pathArg+1))
-		args = append(args, root, pathPrefixLike(root))
-	}
-	return clauses, args
+	return pathscope.CoverageClauses("file_path", roots, firstArg)
 }

--- a/internal/scanner/podcast_scan.go
+++ b/internal/scanner/podcast_scan.go
@@ -84,7 +84,7 @@ func (s *Scanner) ScanPodcastFolder(ctx context.Context, folder *models.MediaFol
 	if attempted > 0 && succeeded == 0 && len(failures) > 0 {
 		return fmt.Errorf("podcast scan failed for every attempted folder_id=%d: %w", folder.ID, errors.Join(failures...))
 	}
-	if err := s.reconcilePodcastMissingFiles(ctx, folder, reconcileRoots, seenPaths, len(seenPaths) > 0); err != nil {
+	if err := s.reconcilePodcastMissingFiles(ctx, folder, reconcileRoots, seenPaths); err != nil {
 		slog.WarnContext(ctx, "podcast scan: missing-file reconcile failed", "component", "scanner", "folder_id", folder.ID, "error", err)
 	}
 	return nil
@@ -217,37 +217,19 @@ func applyPodcastShowMetadata(item *models.MediaItem, show *parsedPodcastShow) b
 	return changed
 }
 
-func (s *Scanner) reconcilePodcastMissingFiles(ctx context.Context, folder *models.MediaFolder, roots []string, seenPaths map[string]bool, sawFiles bool) error {
+func (s *Scanner) reconcilePodcastMissingFiles(ctx context.Context, folder *models.MediaFolder, roots []string, seenPaths map[string]bool) error {
 	if s.fileRepo == nil || s.libraryRepo == nil || len(roots) == 0 {
 		return nil
 	}
 
-	confirmedCleanup := false
-	if !sawFiles {
-		existingCount := 0
-		for _, root := range roots {
-			existing, err := s.fileRepo.GetByFolderAndPathPrefix(ctx, folder.ID, root)
-			if err != nil {
-				return fmt.Errorf("listing existing podcast files for %q: %w", root, err)
-			}
-			existingCount += len(existing)
-		}
-		if existingCount > 0 {
-			var guard ebookCleanupGuardRepo
-			if s.folderRepo != nil {
-				guard = s.folderRepo
-			}
-			allowed, err := ebookEmptyCleanupAllowed(ctx, guard, folder.ID, true)
-			if err != nil {
-				return err
-			}
-			if !allowed {
-				slog.WarnContext(ctx, "podcast scan: walk saw zero files but the database has files under the scanned roots; skipping reconciliation until cleanup is confirmed", "component", "scanner",
-					"folder_id", folder.ID, "existing_files", existingCount)
-				return nil
-			}
-			confirmedCleanup = true
-		}
+	confirmedCleanup, blockAll, err := s.emptyCleanupDecision(
+		ctx, folder, roots, seenPaths, true, "podcast",
+	)
+	if err != nil {
+		return err
+	}
+	if blockAll {
+		return nil
 	}
 
 	now := time.Now().UTC()

--- a/internal/scanner/podcast_scan.go
+++ b/internal/scanner/podcast_scan.go
@@ -270,29 +270,12 @@ func (s *Scanner) reconcilePodcastMissingFiles(ctx context.Context, folder *mode
 		}
 	}
 
-	// The folder-wide sweep and orphan purge must not destroy rows/items whose
-	// files sit under a currently unreachable library root (see the video
-	// scanner's dead-root protection): unreachable is not removed.
-	unreachableRoots := probeUnreachableRoots(ctx, folder.ID, compactScanRoots(folder.Paths))
-	if s.emptyTrashAfterScan {
-		trashed, err := s.fileRepo.DeleteMissingByFolder(ctx, folder.ID, s.fileRemovalGrace, unreachableRoots)
-		if err != nil {
-			return fmt.Errorf("emptying trash for folder %d: %w", folder.ID, err)
-		}
-		if trashed > 0 {
-			slog.InfoContext(ctx, "podcast scan: emptied trash", "component", "scanner", "folder_id", folder.ID, "deleted", trashed)
-		}
+	trashed, removedMemberships, deletedItems, err := s.sweepMissingAndReconcile(ctx, folder)
+	if trashed > 0 {
+		slog.InfoContext(ctx, "podcast scan: emptied trash", "component", "scanner", "folder_id", folder.ID, "deleted", trashed)
 	}
-
-	removedMemberships, deletedItems, orphanedImageDirs, err := s.reconcileLibraryMemberships(ctx, folder.ID, unreachableRoots)
 	if err != nil {
-		return fmt.Errorf("reconciling library membership for folder %d: %w", folder.ID, err)
-	}
-	if s.s3Client != nil && len(orphanedImageDirs) > 0 {
-		bucket := s.s3Client.Bucket()
-		for _, dir := range orphanedImageDirs {
-			_, _ = s.s3Client.DeletePrefix(ctx, bucket, dir)
-		}
+		return err
 	}
 	if missing > 0 || removedMemberships > 0 || deletedItems > 0 {
 		slog.InfoContext(ctx, "podcast scan: reconciled missing files", "component", "scanner",

--- a/internal/scanner/podcast_scan.go
+++ b/internal/scanner/podcast_scan.go
@@ -222,6 +222,7 @@ func (s *Scanner) reconcilePodcastMissingFiles(ctx context.Context, folder *mode
 		return nil
 	}
 
+	confirmedCleanup := false
 	if !sawFiles {
 		existingCount := 0
 		for _, root := range roots {
@@ -245,6 +246,7 @@ func (s *Scanner) reconcilePodcastMissingFiles(ctx context.Context, folder *mode
 					"folder_id", folder.ID, "existing_files", existingCount)
 				return nil
 			}
+			confirmedCleanup = true
 		}
 	}
 
@@ -270,7 +272,7 @@ func (s *Scanner) reconcilePodcastMissingFiles(ctx context.Context, folder *mode
 		}
 	}
 
-	trashed, removedMemberships, deletedItems, err := s.sweepMissingAndReconcile(ctx, folder)
+	trashed, removedMemberships, deletedItems, err := s.sweepMissingAndReconcile(ctx, folder, confirmedCleanup)
 	if trashed > 0 {
 		slog.InfoContext(ctx, "podcast scan: emptied trash", "component", "scanner", "folder_id", folder.ID, "deleted", trashed)
 	}

--- a/internal/scanner/podcast_scan.go
+++ b/internal/scanner/podcast_scan.go
@@ -270,8 +270,12 @@ func (s *Scanner) reconcilePodcastMissingFiles(ctx context.Context, folder *mode
 		}
 	}
 
+	// The folder-wide sweep and orphan purge must not destroy rows/items whose
+	// files sit under a currently unreachable library root (see the video
+	// scanner's dead-root protection): unreachable is not removed.
+	unreachableRoots := probeUnreachableRoots(ctx, folder.ID, compactScanRoots(folder.Paths))
 	if s.emptyTrashAfterScan {
-		trashed, err := s.fileRepo.DeleteMissingByFolder(ctx, folder.ID, s.fileRemovalGrace)
+		trashed, err := s.fileRepo.DeleteMissingByFolder(ctx, folder.ID, s.fileRemovalGrace, unreachableRoots)
 		if err != nil {
 			return fmt.Errorf("emptying trash for folder %d: %w", folder.ID, err)
 		}
@@ -280,7 +284,7 @@ func (s *Scanner) reconcilePodcastMissingFiles(ctx context.Context, folder *mode
 		}
 	}
 
-	removedMemberships, deletedItems, orphanedImageDirs, err := s.reconcileLibraryMemberships(ctx, folder.ID)
+	removedMemberships, deletedItems, orphanedImageDirs, err := s.reconcileLibraryMemberships(ctx, folder.ID, unreachableRoots)
 	if err != nil {
 		return fmt.Errorf("reconciling library membership for folder %d: %w", folder.ID, err)
 	}

--- a/internal/scanner/scanner.go
+++ b/internal/scanner/scanner.go
@@ -19,6 +19,7 @@ import (
 	"github.com/Silo-Server/silo-server/internal/librarykind"
 	"github.com/Silo-Server/silo-server/internal/models"
 	"github.com/Silo-Server/silo-server/internal/naming"
+	"github.com/Silo-Server/silo-server/internal/rootcheck"
 	"github.com/Silo-Server/silo-server/internal/s3client"
 )
 
@@ -889,9 +890,13 @@ func (s *Scanner) scanPaths(
 	// Empty trash: delete files marked as missing for longer than the removal
 	// grace for this folder. Safe because the empty-root guard (above) returns
 	// early when 0 files are found on disk, so we only reach here when the
-	// root is populated.
+	// root is populated. The sweep is folder-wide, so a scoped scan of a
+	// healthy subtree must not hard-delete rows an unreachable sibling root
+	// left marked missing: probe the configured library roots and exempt any
+	// that are currently unreachable.
+	unreachableRoots := probeUnreachableRoots(ctx, folder.ID, compactScanRoots(folder.Paths))
 	if s.emptyTrashAfterScan {
-		trashed, err := s.fileRepo.DeleteMissingByFolder(ctx, folder.ID, s.fileRemovalGrace)
+		trashed, err := s.fileRepo.DeleteMissingByFolder(ctx, folder.ID, s.fileRemovalGrace, unreachableRoots)
 		if err != nil {
 			return nil, fmt.Errorf("emptying trash for folder %d: %w", folder.ID, err)
 		}
@@ -914,7 +919,7 @@ func (s *Scanner) scanPaths(
 	}
 	result.FilesDeleted += deletedFiles
 
-	removedMemberships, deletedItems, orphanedImageDirs, err := s.reconcileLibraryMemberships(ctx, folder.ID)
+	removedMemberships, deletedItems, orphanedImageDirs, err := s.reconcileLibraryMemberships(ctx, folder.ID, unreachableRoots)
 	if err != nil {
 		return nil, fmt.Errorf("reconciling library membership for folder %d: %w", folder.ID, err)
 	}
@@ -1004,6 +1009,18 @@ func (s *Scanner) scanFolderByRoots(
 		roots = compactScanRoots(walkRoots)
 	}
 
+	// An unreachable root (dead drive, lost mount) is temporarily offline, not
+	// removed from the library: its files are still marked missing below so
+	// clients stop seeing them, but nothing under it may be hard-deleted while
+	// it stays unreachable — trash emptying and item purging are guarded
+	// against these roots further down.
+	unreachableRoots := probeUnreachableRoots(ctx, folder.ID, roots)
+	result.UnreachableRoots = unreachableRoots
+	unreachableSet := make(map[string]bool, len(unreachableRoots))
+	for _, root := range unreachableRoots {
+		unreachableSet[root] = true
+	}
+
 	pendingEmptyScopes := make([]*scopedScan, 0)
 	totalExisting := 0
 	seenAnyFiles := false
@@ -1015,7 +1032,13 @@ func (s *Scanner) scanFolderByRoots(
 			Message:      "Scanning library root",
 			CurrentScope: root,
 		})
-		scope, err := s.scanScope(ctx, folder, []string{root}, []string{root})
+		scopeWalkRoots := []string{root}
+		if unreachableSet[root] {
+			// Skip walking a dead root — it would yield nothing anyway. Its
+			// scope still reconciles below so existing rows are marked missing.
+			scopeWalkRoots = nil
+		}
+		scope, err := s.scanScope(ctx, folder, scopeWalkRoots, []string{root})
 		if err != nil {
 			return nil, err
 		}
@@ -1098,7 +1121,7 @@ func (s *Scanner) scanFolderByRoots(
 	}
 
 	if s.emptyTrashAfterScan {
-		trashed, err := s.fileRepo.DeleteMissingByFolder(ctx, folder.ID, s.fileRemovalGrace)
+		trashed, err := s.fileRepo.DeleteMissingByFolder(ctx, folder.ID, s.fileRemovalGrace, unreachableRoots)
 		if err != nil {
 			return nil, fmt.Errorf("emptying trash for folder %d: %w", folder.ID, err)
 		}
@@ -1118,7 +1141,7 @@ func (s *Scanner) scanFolderByRoots(
 	}
 	result.FilesDeleted += deletedOutsideRoots
 
-	removedMemberships, deletedItems, orphanedImageDirs, err := s.reconcileLibraryMemberships(ctx, folder.ID)
+	removedMemberships, deletedItems, orphanedImageDirs, err := s.reconcileLibraryMemberships(ctx, folder.ID, unreachableRoots)
 	if err != nil {
 		return nil, fmt.Errorf("reconciling library membership for folder %d: %w", folder.ID, err)
 	}
@@ -1161,13 +1184,48 @@ func (s *Scanner) scanFolderByRoots(
 		}
 	}
 
-	if seenAnyFiles || allowEmptyCleanup {
+	switch {
+	case len(unreachableRoots) > 0:
+		// Surface the outage so the admin UI explains why part of the library
+		// vanished; the mount-check endpoint or the next fully-healthy scan
+		// clears it (both clear "dead_root" the same way as "empty_root").
+		if err := s.folderRepo.SetScanWarning(ctx, folder.ID,
+			"dead_root",
+			deadRootWarningMessage(len(roots), unreachableRoots),
+			time.Now().UTC(),
+		); err != nil {
+			return nil, fmt.Errorf("recording dead-root warning for folder %d: %w", folder.ID, err)
+		}
+	case seenAnyFiles || allowEmptyCleanup:
 		if err := s.folderRepo.ClearScanWarning(ctx, folder.ID); err != nil {
 			return nil, fmt.Errorf("clearing scan warning for folder %d: %w", folder.ID, err)
 		}
 	}
 
 	return result, nil
+}
+
+// probeUnreachableRoots returns the subset of roots that are currently
+// unreachable (missing, not a directory, or unlistable), in input order.
+func probeUnreachableRoots(ctx context.Context, folderID int, roots []string) []string {
+	var unreachable []string
+	for _, root := range roots {
+		if probe := rootcheck.Probe(root); !probe.Reachable {
+			slog.WarnContext(ctx, "scanner: library root unreachable", "component", "scanner",
+				"folder_id", folderID,
+				"root", root,
+				"error_code", probe.ErrorCode,
+				"error", probe.ErrorMessage,
+			)
+			unreachable = append(unreachable, root)
+		}
+	}
+	return unreachable
+}
+
+func deadRootWarningMessage(totalRoots int, unreachableRoots []string) string {
+	return fmt.Sprintf("%d of %d roots unreachable: %s",
+		len(unreachableRoots), totalRoots, strings.Join(unreachableRoots, ", "))
 }
 
 func (s *Scanner) scanScope(
@@ -1569,13 +1627,18 @@ func (s *Scanner) syncFolderScopedAudioLibraryState(ctx context.Context, folderI
 	return nil
 }
 
-func (s *Scanner) reconcileLibraryMemberships(ctx context.Context, folderID int) (int, int, []string, error) {
+// reconcileLibraryMemberships removes memberships for content with no
+// remaining non-missing files in the folder and purges orphaned items.
+// unreachableRoots exempts items whose files sit under a currently
+// unreachable library root from the orphan purge (membership removal still
+// happens so the items stay hidden); pass nil when every root is reachable.
+func (s *Scanner) reconcileLibraryMemberships(ctx context.Context, folderID int, unreachableRoots []string) (int, int, []string, error) {
 	if s.episodeLibraryRepo != nil {
 		if _, err := s.episodeLibraryRepo.ReconcileFolderMembership(ctx, folderID); err != nil {
 			return 0, 0, nil, err
 		}
 	}
-	return s.libraryRepo.ReconcileFolderMembership(ctx, folderID)
+	return s.libraryRepo.ReconcileFolderMembership(ctx, folderID, unreachableRoots)
 }
 
 func collectStaleRemovedPathFileIDs(existingFiles []*scanStateFile, seenPaths map[string]bool, roots []string) []int {
@@ -1676,7 +1739,8 @@ func (s *Scanner) ScanFile(ctx context.Context, filePath string, folder *models.
 		if err := s.syncPresentLibraryState(ctx, folder.ID); err != nil {
 			return fmt.Errorf("syncing present library state for extra file: %w", err)
 		}
-		if _, _, _, err := s.reconcileLibraryMemberships(ctx, folder.ID); err != nil {
+		if _, _, _, err := s.reconcileLibraryMemberships(ctx, folder.ID,
+			probeUnreachableRoots(ctx, folder.ID, compactScanRoots(folder.Paths))); err != nil {
 			return fmt.Errorf("reconciling library membership after extra file scan: %w", err)
 		}
 		return nil
@@ -1692,7 +1756,8 @@ func (s *Scanner) ScanFile(ctx context.Context, filePath string, folder *models.
 			return clearErr
 		}
 		if cleared > 0 {
-			if _, _, _, reconcileErr := s.reconcileLibraryMemberships(ctx, folder.ID); reconcileErr != nil {
+			if _, _, _, reconcileErr := s.reconcileLibraryMemberships(ctx, folder.ID,
+				probeUnreachableRoots(ctx, folder.ID, compactScanRoots(folder.Paths))); reconcileErr != nil {
 				return fmt.Errorf("reconciling folder membership after clearing legacy links: %w", reconcileErr)
 			}
 		}

--- a/internal/scanner/scanner.go
+++ b/internal/scanner/scanner.go
@@ -898,6 +898,12 @@ func (s *Scanner) scanPaths(
 	if err != nil {
 		return nil, err
 	}
+	removedMemberships, deletedItems, orphanedImageDirs, err := s.reconcileLibraryMemberships(ctx, folder.ID, protectedRoots)
+	if err != nil {
+		return nil, fmt.Errorf("reconciling library membership for folder %d: %w", folder.ID, err)
+	}
+	result.MembershipsRemoved = removedMemberships
+	result.ItemsDeleted = deletedItems
 	if s.emptyTrashAfterScan {
 		trashed, err := s.fileRepo.DeleteMissingByFolder(ctx, folder.ID, s.fileRemovalGrace, protectedRoots)
 		if err != nil {
@@ -921,13 +927,6 @@ func (s *Scanner) scanPaths(
 		return nil, fmt.Errorf("deleting stale files for folder %d: %w", folder.ID, err)
 	}
 	result.FilesDeleted += deletedFiles
-
-	removedMemberships, deletedItems, orphanedImageDirs, err := s.reconcileLibraryMemberships(ctx, folder.ID, protectedRoots)
-	if err != nil {
-		return nil, fmt.Errorf("reconciling library membership for folder %d: %w", folder.ID, err)
-	}
-	result.MembershipsRemoved = removedMemberships
-	result.ItemsDeleted = deletedItems
 
 	if s.seriesQueueSyncer != nil {
 		if allowEmptyRootGuard {
@@ -1020,7 +1019,27 @@ func (s *Scanner) scanFolderByRoots(
 	// against these roots further down. Probe every CONFIGURED path, not the
 	// compacted traversal roots: a nested child mount is dropped by compaction
 	// but can die independently of its reachable parent.
-	unreachableRoots := probeUnreachableRoots(ctx, folder.ID, configuredRoots)
+	configuredProbes := rootcheck.ProbeManyWithTimeout(ctx, configuredRoots, rootcheck.DefaultProbeTimeout)
+	unreachableRoots := make([]string, 0)
+	suspectRoots := make([]string, 0)
+	for i, root := range configuredRoots {
+		probe := configuredProbes[i]
+		if !probe.Reachable {
+			logUnreachableRoot(ctx, folder.ID, root, probe)
+			unreachableRoots = append(unreachableRoots, root)
+			continue
+		}
+		if !probe.Empty {
+			continue
+		}
+		existing, err := s.fileRepo.GetByFolderAndPathPrefix(ctx, folder.ID, root)
+		if err != nil {
+			return nil, fmt.Errorf("listing files under empty root %q: %w", root, err)
+		}
+		if len(existing) > 0 {
+			suspectRoots = append(suspectRoots, root)
+		}
+	}
 	result.UnreachableRoots = unreachableRoots
 	unreachableSet := make(map[string]bool, len(unreachableRoots))
 	for _, root := range unreachableRoots {
@@ -1071,6 +1090,26 @@ func (s *Scanner) scanFolderByRoots(
 		pendingEmptyScopes = append(pendingEmptyScopes, scope)
 	}
 
+	// Re-probe empty scopes after walking. A root can disconnect after the
+	// initial check; promote that transition into the protected set before any
+	// empty-root guard or reconciliation decision is made.
+	for _, pending := range pendingEmptyScopes {
+		root := firstScope(pending.reconcileRoots)
+		if root == "" || unreachableSet[root] || len(pending.existingFiles) == 0 {
+			continue
+		}
+		probe := rootcheck.ProbeWithTimeout(ctx, root, rootcheck.DefaultProbeTimeout)
+		if !probe.Reachable {
+			logUnreachableRoot(ctx, folder.ID, root, probe)
+			unreachableSet[root] = true
+			unreachableRoots = appendUniquePath(unreachableRoots, root)
+			result.UnreachableRoots = unreachableRoots
+			suspectRoots = removePath(suspectRoots, root)
+		} else if probe.Empty {
+			suspectRoots = appendUniquePath(suspectRoots, root)
+		}
+	}
+
 	// When EVERY configured root is unreachable this is an outage, not an
 	// intentionally emptied library: skip the empty-root confirm flow (and do
 	// not consume the operator's one-time cleanup allowance), fall through so
@@ -1109,16 +1148,6 @@ func (s *Scanner) scanFolderByRoots(
 	// allowance was already consumed above; the mixed case (other roots
 	// healthy) consumes it here so a confirmed single-root cleanout still
 	// completes.
-	suspectRoots := make([]string, 0, len(pendingEmptyScopes))
-	for _, pending := range pendingEmptyScopes {
-		root := firstScope(pending.reconcileRoots)
-		if unreachableSet[root] || len(pending.existingFiles) == 0 {
-			continue
-		}
-		if probe := rootcheck.ProbeWithTimeout(ctx, root, rootcheck.DefaultProbeTimeout); probe.Reachable && probe.Empty {
-			suspectRoots = append(suspectRoots, root)
-		}
-	}
 	if seenAnyFiles && len(suspectRoots) > 0 {
 		var err error
 		allowEmptyCleanup, err = s.folderRepo.ConsumeEmptyCleanupAllowance(ctx, folder.ID)
@@ -1131,12 +1160,13 @@ func (s *Scanner) scanFolderByRoots(
 	}
 	result.SuspectEmptyRoots = suspectRoots
 
+	protectedScanRoots := append(append([]string(nil), unreachableRoots...), suspectRoots...)
 	for _, pending := range pendingEmptyScopes {
 		beforeErrors := pending.result.Errors
 		// forceDeleteAll only ever fires for confirmed cleanup, and even then
 		// rows under a probe-dead root must survive: an outage is not a
 		// confirmation to erase that root's catalog.
-		if err := s.applyScopedScan(ctx, folder, pending, allowEmptyCleanup, unreachableRoots); err != nil {
+		if err := s.applyScopedScan(ctx, folder, pending, allowEmptyCleanup, protectedScanRoots); err != nil {
 			return nil, err
 		}
 		mergeCleanupResult(result, pending.result, beforeErrors)
@@ -1160,6 +1190,12 @@ func (s *Scanner) scanFolderByRoots(
 		protectedRoots = make([]string, 0, len(unreachableRoots)+len(suspectRoots))
 		protectedRoots = append(append(protectedRoots, unreachableRoots...), suspectRoots...)
 	}
+	removedMemberships, deletedItems, orphanedImageDirs, err := s.reconcileLibraryMemberships(ctx, folder.ID, protectedRoots)
+	if err != nil {
+		return nil, fmt.Errorf("reconciling library membership for folder %d: %w", folder.ID, err)
+	}
+	result.MembershipsRemoved = removedMemberships
+	result.ItemsDeleted = deletedItems
 	if s.emptyTrashAfterScan {
 		trashed, err := s.fileRepo.DeleteMissingByFolder(ctx, folder.ID, s.fileRemovalGrace, protectedRoots)
 		if err != nil {
@@ -1180,13 +1216,6 @@ func (s *Scanner) scanFolderByRoots(
 		return nil, fmt.Errorf("deleting stale files outside configured roots for folder %d: %w", folder.ID, err)
 	}
 	result.FilesDeleted += deletedOutsideRoots
-
-	removedMemberships, deletedItems, orphanedImageDirs, err := s.reconcileLibraryMemberships(ctx, folder.ID, protectedRoots)
-	if err != nil {
-		return nil, fmt.Errorf("reconciling library membership for folder %d: %w", folder.ID, err)
-	}
-	result.MembershipsRemoved = removedMemberships
-	result.ItemsDeleted = deletedItems
 
 	if s.seriesQueueSyncer != nil {
 		reportProgress(ctx, ProgressUpdate{
@@ -1252,18 +1281,41 @@ func (s *Scanner) scanFolderByRoots(
 // into the protected "unreachable" path instead of stalling the scanner.
 func probeUnreachableRoots(ctx context.Context, folderID int, roots []string) []string {
 	var unreachable []string
-	for _, root := range roots {
-		if probe := rootcheck.ProbeWithTimeout(ctx, root, rootcheck.DefaultProbeTimeout); !probe.Reachable {
-			slog.WarnContext(ctx, "scanner: library root unreachable", "component", "scanner",
-				"folder_id", folderID,
-				"root", root,
-				"error_code", probe.ErrorCode,
-				"error", probe.ErrorMessage,
-			)
+	probes := rootcheck.ProbeManyWithTimeout(ctx, roots, rootcheck.DefaultProbeTimeout)
+	for i, root := range roots {
+		if probe := probes[i]; !probe.Reachable {
+			logUnreachableRoot(ctx, folderID, root, probe)
 			unreachable = append(unreachable, root)
 		}
 	}
 	return unreachable
+}
+
+func logUnreachableRoot(ctx context.Context, folderID int, root string, probe rootcheck.Result) {
+	slog.WarnContext(ctx, "scanner: library root unreachable", "component", "scanner",
+		"folder_id", folderID,
+		"root", root,
+		"error_code", probe.ErrorCode,
+		"error", probe.ErrorMessage,
+	)
+}
+
+func appendUniquePath(paths []string, path string) []string {
+	for _, existing := range paths {
+		if existing == path {
+			return paths
+		}
+	}
+	return append(paths, path)
+}
+
+func removePath(paths []string, path string) []string {
+	for i, existing := range paths {
+		if existing == path {
+			return append(paths[:i], paths[i+1:]...)
+		}
+	}
+	return paths
 }
 
 // suspectEmptyRoots returns configured roots that probe as reachable but
@@ -1280,11 +1332,12 @@ func (s *Scanner) suspectEmptyRoots(ctx context.Context, folderID int, configure
 		unreachableSet[root] = true
 	}
 	emptyRoots := make([]string, 0, len(configuredRoots))
-	for _, root := range configuredRoots {
+	probes := rootcheck.ProbeManyWithTimeout(ctx, configuredRoots, rootcheck.DefaultProbeTimeout)
+	for i, root := range configuredRoots {
 		if unreachableSet[root] {
 			continue
 		}
-		if probe := rootcheck.ProbeWithTimeout(ctx, root, rootcheck.DefaultProbeTimeout); probe.Reachable && probe.Empty {
+		if probe := probes[i]; probe.Reachable && probe.Empty {
 			emptyRoots = append(emptyRoots, root)
 		}
 	}
@@ -1798,7 +1851,7 @@ func (s *Scanner) reconcileLibraryMemberships(ctx context.Context, folderID int,
 }
 
 // sweepMissingAndReconcile finishes an audio/ebook/podcast missing-file pass:
-// it empties trash (when enabled), reconciles library memberships, and
+// it reconciles library memberships, empties trash (when enabled), and
 // best-effort deletes orphaned S3 image dirs. The folder-wide sweep and
 // orphan purge must not destroy rows/items whose files sit under a currently
 // unreachable or suspect-empty library root (see the video scanner's
@@ -1807,9 +1860,7 @@ func (s *Scanner) reconcileLibraryMemberships(ctx context.Context, folderID int,
 // reloaded and probed uncompacted — a nested child mount can die
 // independently of its reachable parent. confirmedCleanup skips the
 // suspect-empty exemption for a scan the operator explicitly confirmed.
-// Counts are returned for the caller's flavor-specific logging; trashed is
-// meaningful even when err is non-nil (the sweep may succeed before
-// reconciliation fails).
+// Counts are returned for the caller's flavor-specific logging.
 func (s *Scanner) sweepMissingAndReconcile(ctx context.Context, folder *models.MediaFolder, confirmedCleanup bool) (trashed, removedMemberships, deletedItems int, err error) {
 	configuredPaths, err := s.configuredFolderPaths(ctx, folder)
 	if err != nil {
@@ -1824,17 +1875,16 @@ func (s *Scanner) sweepMissingAndReconcile(ctx context.Context, folder *models.M
 		}
 		protectedRoots = append(protectedRoots, suspectRoots...)
 	}
+	var orphanedImageDirs []string
+	removedMemberships, deletedItems, orphanedImageDirs, err = s.reconcileLibraryMemberships(ctx, folder.ID, protectedRoots)
+	if err != nil {
+		return 0, 0, 0, fmt.Errorf("reconciling library membership for folder %d: %w", folder.ID, err)
+	}
 	if s.emptyTrashAfterScan {
 		trashed, err = s.fileRepo.DeleteMissingByFolder(ctx, folder.ID, s.fileRemovalGrace, protectedRoots)
 		if err != nil {
 			return 0, 0, 0, fmt.Errorf("emptying trash for folder %d: %w", folder.ID, err)
 		}
-	}
-
-	var orphanedImageDirs []string
-	removedMemberships, deletedItems, orphanedImageDirs, err = s.reconcileLibraryMemberships(ctx, folder.ID, protectedRoots)
-	if err != nil {
-		return trashed, 0, 0, fmt.Errorf("reconciling library membership for folder %d: %w", folder.ID, err)
 	}
 	if s.s3Client != nil && len(orphanedImageDirs) > 0 {
 		bucket := s.s3Client.Bucket()

--- a/internal/scanner/scanner.go
+++ b/internal/scanner/scanner.go
@@ -894,7 +894,7 @@ func (s *Scanner) scanPaths(
 	// healthy subtree must not hard-delete rows an unreachable sibling root
 	// left marked missing: probe the configured library roots and exempt any
 	// that are currently unreachable.
-	unreachableRoots := probeUnreachableRoots(ctx, folder.ID, compactScanRoots(folder.Paths))
+	unreachableRoots := probeUnreachableRoots(ctx, folder.ID, cleanScanRoots(folder.Paths))
 	if s.emptyTrashAfterScan {
 		trashed, err := s.fileRepo.DeleteMissingByFolder(ctx, folder.ID, s.fileRemovalGrace, unreachableRoots)
 		if err != nil {
@@ -1004,17 +1004,20 @@ func (s *Scanner) scanFolderByRoots(
 	reconcileRoots []string,
 ) (*ScanResult, error) {
 	result := &ScanResult{}
-	roots := compactScanRoots(reconcileRoots)
-	if len(roots) == 0 {
-		roots = compactScanRoots(walkRoots)
+	configuredRoots := cleanScanRoots(reconcileRoots)
+	if len(configuredRoots) == 0 {
+		configuredRoots = cleanScanRoots(walkRoots)
 	}
+	roots := compactScanRoots(configuredRoots)
 
 	// An unreachable root (dead drive, lost mount) is temporarily offline, not
 	// removed from the library: its files are still marked missing below so
 	// clients stop seeing them, but nothing under it may be hard-deleted while
 	// it stays unreachable — trash emptying and item purging are guarded
-	// against these roots further down.
-	unreachableRoots := probeUnreachableRoots(ctx, folder.ID, roots)
+	// against these roots further down. Probe every CONFIGURED path, not the
+	// compacted traversal roots: a nested child mount is dropped by compaction
+	// but can die independently of its reachable parent.
+	unreachableRoots := probeUnreachableRoots(ctx, folder.ID, configuredRoots)
 	result.UnreachableRoots = unreachableRoots
 	unreachableSet := make(map[string]bool, len(unreachableRoots))
 	for _, root := range unreachableRoots {
@@ -1080,7 +1083,14 @@ func (s *Scanner) scanFolderByRoots(
 		pendingEmptyScopes = append(pendingEmptyScopes, scope)
 	}
 
-	if !seenAnyFiles && totalExisting > 0 {
+	// When EVERY configured root is unreachable this is an outage, not an
+	// intentionally emptied library: skip the empty-root confirm flow (and do
+	// not consume the operator's one-time cleanup allowance), fall through so
+	// pending scopes mark files missing (hiding them), and let the dead_root
+	// warning below explain the state. All deletion paths are protected by
+	// the unreachable-roots exclusions, so nothing is purged.
+	allRootsUnreachable := len(unreachableRoots) > 0 && len(unreachableRoots) == len(configuredRoots)
+	if !seenAnyFiles && totalExisting > 0 && !allRootsUnreachable {
 		var err error
 		allowEmptyCleanup, err = s.folderRepo.ConsumeEmptyCleanupAllowance(ctx, folder.ID)
 		if err != nil {
@@ -1191,7 +1201,7 @@ func (s *Scanner) scanFolderByRoots(
 		// clears it (both clear "dead_root" the same way as "empty_root").
 		if err := s.folderRepo.SetScanWarning(ctx, folder.ID,
 			"dead_root",
-			deadRootWarningMessage(len(roots), unreachableRoots),
+			deadRootWarningMessage(len(configuredRoots), unreachableRoots),
 			time.Now().UTC(),
 		); err != nil {
 			return nil, fmt.Errorf("recording dead-root warning for folder %d: %w", folder.ID, err)
@@ -1498,6 +1508,28 @@ func mergeCleanupResult(dst *ScanResult, src *ScanResult, priorErrors int) {
 	}
 }
 
+// cleanScanRoots normalizes and dedupes configured root paths WITHOUT
+// removing nested roots. Reachability must be probed against every
+// configured path: a child mount (/media/drive under /media) is dropped by
+// compactScanRoots for traversal, but can die independently and its files
+// must still be protected from deletion.
+func cleanScanRoots(paths []string) []string {
+	out := make([]string, 0, len(paths))
+	seen := make(map[string]bool, len(paths))
+	for _, rawPath := range paths {
+		if strings.TrimSpace(rawPath) == "" {
+			continue
+		}
+		path := filepath.Clean(rawPath)
+		if path == "" || path == "." || seen[path] {
+			continue
+		}
+		seen[path] = true
+		out = append(out, path)
+	}
+	return out
+}
+
 func compactScanRoots(paths []string) []string {
 	out := make([]string, 0, len(paths))
 	for _, rawPath := range paths {
@@ -1740,7 +1772,7 @@ func (s *Scanner) ScanFile(ctx context.Context, filePath string, folder *models.
 			return fmt.Errorf("syncing present library state for extra file: %w", err)
 		}
 		if _, _, _, err := s.reconcileLibraryMemberships(ctx, folder.ID,
-			probeUnreachableRoots(ctx, folder.ID, compactScanRoots(folder.Paths))); err != nil {
+			probeUnreachableRoots(ctx, folder.ID, cleanScanRoots(folder.Paths))); err != nil {
 			return fmt.Errorf("reconciling library membership after extra file scan: %w", err)
 		}
 		return nil
@@ -1757,7 +1789,7 @@ func (s *Scanner) ScanFile(ctx context.Context, filePath string, folder *models.
 		}
 		if cleared > 0 {
 			if _, _, _, reconcileErr := s.reconcileLibraryMemberships(ctx, folder.ID,
-				probeUnreachableRoots(ctx, folder.ID, compactScanRoots(folder.Paths))); reconcileErr != nil {
+				probeUnreachableRoots(ctx, folder.ID, cleanScanRoots(folder.Paths))); reconcileErr != nil {
 				return fmt.Errorf("reconciling folder membership after clearing legacy links: %w", reconcileErr)
 			}
 		}

--- a/internal/scanner/scanner.go
+++ b/internal/scanner/scanner.go
@@ -891,12 +891,15 @@ func (s *Scanner) scanPaths(
 	// grace for this folder. Safe because the empty-root guard (above) returns
 	// early when 0 files are found on disk, so we only reach here when the
 	// root is populated. The sweep is folder-wide, so a scoped scan of a
-	// healthy subtree must not hard-delete rows an unreachable sibling root
-	// left marked missing: probe the configured library roots and exempt any
-	// that are currently unreachable.
-	unreachableRoots := unreachableConfiguredRoots(ctx, folder)
+	// healthy subtree must not hard-delete rows an unreachable or
+	// suspect-empty sibling root left marked missing: probe the configured
+	// library roots and exempt any that are currently protected.
+	protectedRoots, err := s.protectedConfiguredRoots(ctx, folder)
+	if err != nil {
+		return nil, err
+	}
 	if s.emptyTrashAfterScan {
-		trashed, err := s.fileRepo.DeleteMissingByFolder(ctx, folder.ID, s.fileRemovalGrace, unreachableRoots)
+		trashed, err := s.fileRepo.DeleteMissingByFolder(ctx, folder.ID, s.fileRemovalGrace, protectedRoots)
 		if err != nil {
 			return nil, fmt.Errorf("emptying trash for folder %d: %w", folder.ID, err)
 		}
@@ -919,7 +922,7 @@ func (s *Scanner) scanPaths(
 	}
 	result.FilesDeleted += deletedFiles
 
-	removedMemberships, deletedItems, orphanedImageDirs, err := s.reconcileLibraryMemberships(ctx, folder.ID, unreachableRoots)
+	removedMemberships, deletedItems, orphanedImageDirs, err := s.reconcileLibraryMemberships(ctx, folder.ID, protectedRoots)
 	if err != nil {
 		return nil, fmt.Errorf("reconciling library membership for folder %d: %w", folder.ID, err)
 	}
@@ -1054,32 +1057,17 @@ func (s *Scanner) scanFolderByRoots(
 
 		if len(scope.filePaths) > 0 {
 			seenAnyFiles = true
-			for _, pending := range pendingEmptyScopes {
-				beforeErrors := pending.result.Errors
-				if err := s.applyScopedScan(ctx, folder, pending, false); err != nil {
-					return nil, err
-				}
-				mergeCleanupResult(result, pending.result, beforeErrors)
-			}
-			pendingEmptyScopes = pendingEmptyScopes[:0]
-
 			beforeErrors := scope.result.Errors
-			if err := s.applyScopedScan(ctx, folder, scope, false); err != nil {
+			if err := s.applyScopedScan(ctx, folder, scope, false, nil); err != nil {
 				return nil, err
 			}
 			mergeCleanupResult(result, scope.result, beforeErrors)
 			continue
 		}
 
-		if seenAnyFiles {
-			beforeErrors := scope.result.Errors
-			if err := s.applyScopedScan(ctx, folder, scope, false); err != nil {
-				return nil, err
-			}
-			mergeCleanupResult(result, scope.result, beforeErrors)
-			continue
-		}
-
+		// Empty scopes stay pending until after the loop: whether they may
+		// force-delete (confirmed cleanup) and whether their roots must be
+		// treated as suspect depends on what the other roots produced.
 		pendingEmptyScopes = append(pendingEmptyScopes, scope)
 	}
 
@@ -1109,9 +1097,46 @@ func (s *Scanner) scanFolderByRoots(
 		}
 	}
 
+	// A reachable root that is a LITERALLY empty directory while rows remain
+	// cataloged under it carries the lost-mount signature: the mountpoint
+	// survived, its contents vanished with the mount (NFS/SMB drop, dead
+	// bind-mount source), and the reachability probe cannot tell it from an
+	// intentionally emptied root. Treat such roots as suspect: their rows are
+	// only marked missing, and the sweep/purge below exempts them until the
+	// operator confirms cleanup or the files return. A root that still has
+	// entries but no media files walked its files genuinely deleted and keeps
+	// the historical purge path. When the whole folder walked empty the
+	// allowance was already consumed above; the mixed case (other roots
+	// healthy) consumes it here so a confirmed single-root cleanout still
+	// completes.
+	suspectRoots := make([]string, 0, len(pendingEmptyScopes))
+	for _, pending := range pendingEmptyScopes {
+		root := firstScope(pending.reconcileRoots)
+		if unreachableSet[root] || len(pending.existingFiles) == 0 {
+			continue
+		}
+		if probe := rootcheck.ProbeWithTimeout(ctx, root, rootcheck.DefaultProbeTimeout); probe.Reachable && probe.Empty {
+			suspectRoots = append(suspectRoots, root)
+		}
+	}
+	if seenAnyFiles && len(suspectRoots) > 0 {
+		var err error
+		allowEmptyCleanup, err = s.folderRepo.ConsumeEmptyCleanupAllowance(ctx, folder.ID)
+		if err != nil {
+			return nil, fmt.Errorf("checking empty cleanup confirmation for folder %d: %w", folder.ID, err)
+		}
+	}
+	if allowEmptyCleanup {
+		suspectRoots = nil
+	}
+	result.SuspectEmptyRoots = suspectRoots
+
 	for _, pending := range pendingEmptyScopes {
 		beforeErrors := pending.result.Errors
-		if err := s.applyScopedScan(ctx, folder, pending, allowEmptyCleanup); err != nil {
+		// forceDeleteAll only ever fires for confirmed cleanup, and even then
+		// rows under a probe-dead root must survive: an outage is not a
+		// confirmation to erase that root's catalog.
+		if err := s.applyScopedScan(ctx, folder, pending, allowEmptyCleanup, unreachableRoots); err != nil {
 			return nil, err
 		}
 		mergeCleanupResult(result, pending.result, beforeErrors)
@@ -1130,8 +1155,13 @@ func (s *Scanner) scanFolderByRoots(
 		return nil, fmt.Errorf("syncing present library state for folder %d: %w", folder.ID, err)
 	}
 
+	protectedRoots := unreachableRoots
+	if len(suspectRoots) > 0 {
+		protectedRoots = make([]string, 0, len(unreachableRoots)+len(suspectRoots))
+		protectedRoots = append(append(protectedRoots, unreachableRoots...), suspectRoots...)
+	}
 	if s.emptyTrashAfterScan {
-		trashed, err := s.fileRepo.DeleteMissingByFolder(ctx, folder.ID, s.fileRemovalGrace, unreachableRoots)
+		trashed, err := s.fileRepo.DeleteMissingByFolder(ctx, folder.ID, s.fileRemovalGrace, protectedRoots)
 		if err != nil {
 			return nil, fmt.Errorf("emptying trash for folder %d: %w", folder.ID, err)
 		}
@@ -1151,7 +1181,7 @@ func (s *Scanner) scanFolderByRoots(
 	}
 	result.FilesDeleted += deletedOutsideRoots
 
-	removedMemberships, deletedItems, orphanedImageDirs, err := s.reconcileLibraryMemberships(ctx, folder.ID, unreachableRoots)
+	removedMemberships, deletedItems, orphanedImageDirs, err := s.reconcileLibraryMemberships(ctx, folder.ID, protectedRoots)
 	if err != nil {
 		return nil, fmt.Errorf("reconciling library membership for folder %d: %w", folder.ID, err)
 	}
@@ -1195,13 +1225,13 @@ func (s *Scanner) scanFolderByRoots(
 	}
 
 	switch {
-	case len(unreachableRoots) > 0:
+	case len(unreachableRoots) > 0 || len(suspectRoots) > 0:
 		// Surface the outage so the admin UI explains why part of the library
 		// vanished; the mount-check endpoint or the next fully-healthy scan
 		// clears it (both clear "dead_root" the same way as "empty_root").
 		if err := s.folderRepo.SetScanWarning(ctx, folder.ID,
 			"dead_root",
-			deadRootWarningMessage(len(configuredRoots), unreachableRoots),
+			deadRootWarningMessage(len(configuredRoots), unreachableRoots, suspectRoots),
 			time.Now().UTC(),
 		); err != nil {
 			return nil, fmt.Errorf("recording dead-root warning for folder %d: %w", folder.ID, err)
@@ -1216,11 +1246,14 @@ func (s *Scanner) scanFolderByRoots(
 }
 
 // probeUnreachableRoots returns the subset of roots that are currently
-// unreachable (missing, not a directory, or unlistable), in input order.
+// unreachable (missing, not a directory, unlistable, or hung past the probe
+// timeout), in input order. The timeout matters because probes run on scan
+// hot paths (including per-file autoscan events): a wedged mount must degrade
+// into the protected "unreachable" path instead of stalling the scanner.
 func probeUnreachableRoots(ctx context.Context, folderID int, roots []string) []string {
 	var unreachable []string
 	for _, root := range roots {
-		if probe := rootcheck.Probe(root); !probe.Reachable {
+		if probe := rootcheck.ProbeWithTimeout(ctx, root, rootcheck.DefaultProbeTimeout); !probe.Reachable {
 			slog.WarnContext(ctx, "scanner: library root unreachable", "component", "scanner",
 				"folder_id", folderID,
 				"root", root,
@@ -1233,16 +1266,91 @@ func probeUnreachableRoots(ctx context.Context, folderID int, roots []string) []
 	return unreachable
 }
 
-// unreachableConfiguredRoots probes the folder's configured root paths
-// (uncompacted, so a nested child mount is probed independently of its
-// reachable parent) and returns those currently unreachable.
-func unreachableConfiguredRoots(ctx context.Context, folder *models.MediaFolder) []string {
-	return probeUnreachableRoots(ctx, folder.ID, cleanScanRoots(folder.Paths))
+// suspectEmptyRoots returns configured roots that probe as reachable but
+// LITERALLY empty directories while the database still holds rows (all
+// missing-marked) under them. That is the signature of a mount that dropped
+// out leaving its bare mountpoint directory behind (NFS/SMB drop, dead
+// bind-mount source) — a reachability probe cannot tell it apart from an
+// intentionally emptied root, so destructive cleanup under these roots is
+// deferred until the operator confirms or the files return. A root that
+// still has directory entries keeps the historical purge path.
+func (s *Scanner) suspectEmptyRoots(ctx context.Context, folderID int, configuredRoots, unreachableRoots []string) ([]string, error) {
+	unreachableSet := make(map[string]bool, len(unreachableRoots))
+	for _, root := range unreachableRoots {
+		unreachableSet[root] = true
+	}
+	emptyRoots := make([]string, 0, len(configuredRoots))
+	for _, root := range configuredRoots {
+		if unreachableSet[root] {
+			continue
+		}
+		if probe := rootcheck.ProbeWithTimeout(ctx, root, rootcheck.DefaultProbeTimeout); probe.Reachable && probe.Empty {
+			emptyRoots = append(emptyRoots, root)
+		}
+	}
+	if len(emptyRoots) == 0 {
+		return nil, nil
+	}
+	suspect, err := s.fileRepo.ListRootsWithOnlyMissingFiles(ctx, folderID, emptyRoots)
+	if err != nil {
+		return nil, fmt.Errorf("listing suspect-empty roots for folder %d: %w", folderID, err)
+	}
+	if len(suspect) > 0 {
+		slog.WarnContext(ctx, "scanner: empty roots still hold cataloged files; protecting them from cleanup", "component", "scanner",
+			"folder_id", folderID,
+			"roots", suspect,
+		)
+	}
+	return suspect, nil
 }
 
-func deadRootWarningMessage(totalRoots int, unreachableRoots []string) string {
-	return fmt.Sprintf("%d of %d roots unreachable: %s",
-		len(unreachableRoots), totalRoots, strings.Join(unreachableRoots, ", "))
+// protectedConfiguredRoots probes the folder's configured root paths
+// (uncompacted, so a nested child mount is probed independently of its
+// reachable parent) and returns every root that must be exempted from
+// destructive cleanup right now: probe-unreachable roots plus suspect-empty
+// ones. Callers must pass a folder whose Paths is the full configured list.
+func (s *Scanner) protectedConfiguredRoots(ctx context.Context, folder *models.MediaFolder) ([]string, error) {
+	configuredRoots := cleanScanRoots(folder.Paths)
+	unreachableRoots := probeUnreachableRoots(ctx, folder.ID, configuredRoots)
+	suspectRoots, err := s.suspectEmptyRoots(ctx, folder.ID, configuredRoots, unreachableRoots)
+	if err != nil {
+		return nil, err
+	}
+	return append(unreachableRoots, suspectRoots...), nil
+}
+
+// configuredFolderPaths returns the folder's full configured root list for
+// dead-root protection. Scoped scans (ScanSubtree, ScanFile) pass a folder
+// clone whose Paths holds only the scanned subtree, but the cleanup they
+// trigger is folder-wide, so protection must consider every configured root:
+// reload them instead of trusting the possibly-scoped clone.
+func (s *Scanner) configuredFolderPaths(ctx context.Context, folder *models.MediaFolder) ([]string, error) {
+	if s.folderRepo == nil {
+		return folder.Paths, nil
+	}
+	full, err := s.folderRepo.GetByID(ctx, folder.ID)
+	if err != nil {
+		return nil, fmt.Errorf("loading configured paths for folder %d: %w", folder.ID, err)
+	}
+	if full == nil || len(full.Paths) == 0 {
+		// No persisted paths (fresh row, tests): the caller's view is all
+		// there is to probe.
+		return folder.Paths, nil
+	}
+	return full.Paths, nil
+}
+
+func deadRootWarningMessage(totalRoots int, unreachableRoots, suspectRoots []string) string {
+	parts := make([]string, 0, 2)
+	if len(unreachableRoots) > 0 {
+		parts = append(parts, fmt.Sprintf("%d of %d roots unreachable: %s",
+			len(unreachableRoots), totalRoots, strings.Join(unreachableRoots, ", ")))
+	}
+	if len(suspectRoots) > 0 {
+		parts = append(parts, fmt.Sprintf("%d of %d roots returned no files while the library still has cataloged files (lost mount?): %s",
+			len(suspectRoots), totalRoots, strings.Join(suspectRoots, ", ")))
+	}
+	return strings.Join(parts, "; ")
 }
 
 func (s *Scanner) scanScope(
@@ -1429,11 +1537,17 @@ func (s *Scanner) scanScope(
 	}, nil
 }
 
+// applyScopedScan reconciles one root's scope. forceDeleteAll (confirmed
+// empty cleanup) hard-deletes the scope's rows instead of marking them
+// missing — except rows under protectedRoots (probe-dead roots, including a
+// nested dead child inside this scope's root): an outage is never a
+// confirmation to erase that root's catalog.
 func (s *Scanner) applyScopedScan(
 	ctx context.Context,
 	folder *models.MediaFolder,
 	scope *scopedScan,
 	forceDeleteAll bool,
+	protectedRoots []string,
 ) error {
 	if scope == nil || scope.result == nil {
 		return nil
@@ -1473,6 +1587,9 @@ func (s *Scanner) applyScopedScan(
 	if forceDeleteAll && len(scope.filePaths) == 0 {
 		staleFileIDs = make([]int, 0, len(scope.existingFiles))
 		for _, existing := range scope.existingFiles {
+			if pathWithinAnyRoot(existing.FilePath, protectedRoots) {
+				continue
+			}
 			staleFileIDs = append(staleFileIDs, existing.ID)
 		}
 	}
@@ -1684,21 +1801,38 @@ func (s *Scanner) reconcileLibraryMemberships(ctx context.Context, folderID int,
 // it empties trash (when enabled), reconciles library memberships, and
 // best-effort deletes orphaned S3 image dirs. The folder-wide sweep and
 // orphan purge must not destroy rows/items whose files sit under a currently
-// unreachable library root (see the video scanner's dead-root protection):
-// unreachable is not removed. Counts are returned for the caller's
-// flavor-specific logging; trashed is meaningful even when err is non-nil
-// (the sweep may succeed before reconciliation fails).
-func (s *Scanner) sweepMissingAndReconcile(ctx context.Context, folder *models.MediaFolder) (trashed, removedMemberships, deletedItems int, err error) {
-	unreachableRoots := probeUnreachableRoots(ctx, folder.ID, compactScanRoots(folder.Paths))
+// unreachable or suspect-empty library root (see the video scanner's
+// dead-root protection): unreachable is not removed. The folder argument may
+// be a scoped clone (ScanSubtree/ScanFile), so the configured roots are
+// reloaded and probed uncompacted — a nested child mount can die
+// independently of its reachable parent. confirmedCleanup skips the
+// suspect-empty exemption for a scan the operator explicitly confirmed.
+// Counts are returned for the caller's flavor-specific logging; trashed is
+// meaningful even when err is non-nil (the sweep may succeed before
+// reconciliation fails).
+func (s *Scanner) sweepMissingAndReconcile(ctx context.Context, folder *models.MediaFolder, confirmedCleanup bool) (trashed, removedMemberships, deletedItems int, err error) {
+	configuredPaths, err := s.configuredFolderPaths(ctx, folder)
+	if err != nil {
+		return 0, 0, 0, err
+	}
+	configuredRoots := cleanScanRoots(configuredPaths)
+	protectedRoots := probeUnreachableRoots(ctx, folder.ID, configuredRoots)
+	if !confirmedCleanup {
+		suspectRoots, serr := s.suspectEmptyRoots(ctx, folder.ID, configuredRoots, protectedRoots)
+		if serr != nil {
+			return 0, 0, 0, serr
+		}
+		protectedRoots = append(protectedRoots, suspectRoots...)
+	}
 	if s.emptyTrashAfterScan {
-		trashed, err = s.fileRepo.DeleteMissingByFolder(ctx, folder.ID, s.fileRemovalGrace, unreachableRoots)
+		trashed, err = s.fileRepo.DeleteMissingByFolder(ctx, folder.ID, s.fileRemovalGrace, protectedRoots)
 		if err != nil {
 			return 0, 0, 0, fmt.Errorf("emptying trash for folder %d: %w", folder.ID, err)
 		}
 	}
 
 	var orphanedImageDirs []string
-	removedMemberships, deletedItems, orphanedImageDirs, err = s.reconcileLibraryMemberships(ctx, folder.ID, unreachableRoots)
+	removedMemberships, deletedItems, orphanedImageDirs, err = s.reconcileLibraryMemberships(ctx, folder.ID, protectedRoots)
 	if err != nil {
 		return trashed, 0, 0, fmt.Errorf("reconciling library membership for folder %d: %w", folder.ID, err)
 	}
@@ -1809,7 +1943,11 @@ func (s *Scanner) ScanFile(ctx context.Context, filePath string, folder *models.
 		if err := s.syncPresentLibraryState(ctx, folder.ID); err != nil {
 			return fmt.Errorf("syncing present library state for extra file: %w", err)
 		}
-		if _, _, _, err := s.reconcileLibraryMemberships(ctx, folder.ID, unreachableConfiguredRoots(ctx, folder)); err != nil {
+		protectedRoots, err := s.protectedConfiguredRoots(ctx, folder)
+		if err != nil {
+			return err
+		}
+		if _, _, _, err := s.reconcileLibraryMemberships(ctx, folder.ID, protectedRoots); err != nil {
 			return fmt.Errorf("reconciling library membership after extra file scan: %w", err)
 		}
 		return nil
@@ -1825,7 +1963,11 @@ func (s *Scanner) ScanFile(ctx context.Context, filePath string, folder *models.
 			return clearErr
 		}
 		if cleared > 0 {
-			if _, _, _, reconcileErr := s.reconcileLibraryMemberships(ctx, folder.ID, unreachableConfiguredRoots(ctx, folder)); reconcileErr != nil {
+			protectedRoots, protErr := s.protectedConfiguredRoots(ctx, folder)
+			if protErr != nil {
+				return protErr
+			}
+			if _, _, _, reconcileErr := s.reconcileLibraryMemberships(ctx, folder.ID, protectedRoots); reconcileErr != nil {
 				return fmt.Errorf("reconciling folder membership after clearing legacy links: %w", reconcileErr)
 			}
 		}

--- a/internal/scanner/scanner.go
+++ b/internal/scanner/scanner.go
@@ -894,7 +894,7 @@ func (s *Scanner) scanPaths(
 	// healthy subtree must not hard-delete rows an unreachable sibling root
 	// left marked missing: probe the configured library roots and exempt any
 	// that are currently unreachable.
-	unreachableRoots := probeUnreachableRoots(ctx, folder.ID, cleanScanRoots(folder.Paths))
+	unreachableRoots := unreachableConfiguredRoots(ctx, folder)
 	if s.emptyTrashAfterScan {
 		trashed, err := s.fileRepo.DeleteMissingByFolder(ctx, folder.ID, s.fileRemovalGrace, unreachableRoots)
 		if err != nil {
@@ -1231,6 +1231,13 @@ func probeUnreachableRoots(ctx context.Context, folderID int, roots []string) []
 		}
 	}
 	return unreachable
+}
+
+// unreachableConfiguredRoots probes the folder's configured root paths
+// (uncompacted, so a nested child mount is probed independently of its
+// reachable parent) and returns those currently unreachable.
+func unreachableConfiguredRoots(ctx context.Context, folder *models.MediaFolder) []string {
+	return probeUnreachableRoots(ctx, folder.ID, cleanScanRoots(folder.Paths))
 }
 
 func deadRootWarningMessage(totalRoots int, unreachableRoots []string) string {
@@ -1673,6 +1680,37 @@ func (s *Scanner) reconcileLibraryMemberships(ctx context.Context, folderID int,
 	return s.libraryRepo.ReconcileFolderMembership(ctx, folderID, unreachableRoots)
 }
 
+// sweepMissingAndReconcile finishes an audio/ebook/podcast missing-file pass:
+// it empties trash (when enabled), reconciles library memberships, and
+// best-effort deletes orphaned S3 image dirs. The folder-wide sweep and
+// orphan purge must not destroy rows/items whose files sit under a currently
+// unreachable library root (see the video scanner's dead-root protection):
+// unreachable is not removed. Counts are returned for the caller's
+// flavor-specific logging; trashed is meaningful even when err is non-nil
+// (the sweep may succeed before reconciliation fails).
+func (s *Scanner) sweepMissingAndReconcile(ctx context.Context, folder *models.MediaFolder) (trashed, removedMemberships, deletedItems int, err error) {
+	unreachableRoots := probeUnreachableRoots(ctx, folder.ID, compactScanRoots(folder.Paths))
+	if s.emptyTrashAfterScan {
+		trashed, err = s.fileRepo.DeleteMissingByFolder(ctx, folder.ID, s.fileRemovalGrace, unreachableRoots)
+		if err != nil {
+			return 0, 0, 0, fmt.Errorf("emptying trash for folder %d: %w", folder.ID, err)
+		}
+	}
+
+	var orphanedImageDirs []string
+	removedMemberships, deletedItems, orphanedImageDirs, err = s.reconcileLibraryMemberships(ctx, folder.ID, unreachableRoots)
+	if err != nil {
+		return trashed, 0, 0, fmt.Errorf("reconciling library membership for folder %d: %w", folder.ID, err)
+	}
+	if s.s3Client != nil && len(orphanedImageDirs) > 0 {
+		bucket := s.s3Client.Bucket()
+		for _, dir := range orphanedImageDirs {
+			_, _ = s.s3Client.DeletePrefix(ctx, bucket, dir)
+		}
+	}
+	return trashed, removedMemberships, deletedItems, nil
+}
+
 func collectStaleRemovedPathFileIDs(existingFiles []*scanStateFile, seenPaths map[string]bool, roots []string) []int {
 	ids := make([]int, 0)
 	for _, existing := range existingFiles {
@@ -1771,8 +1809,7 @@ func (s *Scanner) ScanFile(ctx context.Context, filePath string, folder *models.
 		if err := s.syncPresentLibraryState(ctx, folder.ID); err != nil {
 			return fmt.Errorf("syncing present library state for extra file: %w", err)
 		}
-		if _, _, _, err := s.reconcileLibraryMemberships(ctx, folder.ID,
-			probeUnreachableRoots(ctx, folder.ID, cleanScanRoots(folder.Paths))); err != nil {
+		if _, _, _, err := s.reconcileLibraryMemberships(ctx, folder.ID, unreachableConfiguredRoots(ctx, folder)); err != nil {
 			return fmt.Errorf("reconciling library membership after extra file scan: %w", err)
 		}
 		return nil
@@ -1788,8 +1825,7 @@ func (s *Scanner) ScanFile(ctx context.Context, filePath string, folder *models.
 			return clearErr
 		}
 		if cleared > 0 {
-			if _, _, _, reconcileErr := s.reconcileLibraryMemberships(ctx, folder.ID,
-				probeUnreachableRoots(ctx, folder.ID, cleanScanRoots(folder.Paths))); reconcileErr != nil {
+			if _, _, _, reconcileErr := s.reconcileLibraryMemberships(ctx, folder.ID, unreachableConfiguredRoots(ctx, folder)); reconcileErr != nil {
 				return fmt.Errorf("reconciling folder membership after clearing legacy links: %w", reconcileErr)
 			}
 		}

--- a/internal/scanner/types.go
+++ b/internal/scanner/types.go
@@ -11,7 +11,11 @@ type ScanResult struct {
 	ItemsDeleted       int
 	Errors             int
 	EmptyRootGuarded   bool
-	RootObservations   []RootObservation
+	// UnreachableRoots lists configured library roots that failed the
+	// reachability probe at scan start. Files under them were marked missing
+	// (hidden) but were exempted from trash emptying and item purging.
+	UnreachableRoots []string
+	RootObservations []RootObservation
 }
 
 // FileHints contains the OSHash gathered during scanning.

--- a/internal/scanner/types.go
+++ b/internal/scanner/types.go
@@ -15,7 +15,14 @@ type ScanResult struct {
 	// reachability probe at scan start. Files under them were marked missing
 	// (hidden) but were exempted from trash emptying and item purging.
 	UnreachableRoots []string
-	RootObservations []RootObservation
+	// SuspectEmptyRoots lists roots that probed reachable but were literally
+	// empty directories while the library still holds cataloged files under
+	// them — the signature of a lost mount exposing its bare mountpoint
+	// directory. They receive the same cleanup exemptions as
+	// UnreachableRoots until the operator confirms cleanup or the files
+	// return.
+	SuspectEmptyRoots []string
+	RootObservations  []RootObservation
 }
 
 // FileHints contains the OSHash gathered during scanning.

--- a/migrations/sql/20260716193000_media_files_folder_path_prefix_index.sql
+++ b/migrations/sql/20260716193000_media_files_folder_path_prefix_index.sql
@@ -1,0 +1,8 @@
+-- +goose NO TRANSACTION
+
+-- +goose Up
+CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_media_files_folder_file_path_pattern
+    ON media_files (media_folder_id, file_path text_pattern_ops);
+
+-- +goose Down
+DROP INDEX CONCURRENTLY IF EXISTS idx_media_files_folder_file_path_pattern;

--- a/web/src/api/types.ts
+++ b/web/src/api/types.ts
@@ -2882,8 +2882,10 @@ export interface LibraryMountCheckRoot {
     | "not_directory"
     | "stat_failed"
     | "read_failed"
+    | "probe_timeout"
     | null;
   error_message: string | null;
+  suspect_empty: boolean;
 }
 
 export interface LibraryMountCheckResponse {

--- a/web/src/pages/AdminLibraries.test.tsx
+++ b/web/src/pages/AdminLibraries.test.tsx
@@ -193,6 +193,29 @@ describe("AdminLibraries", () => {
     );
   });
 
+  it("offers confirmed cleanup for a suspect-empty dead-root warning", () => {
+    mocks.useAdminLibraries.mockReturnValue({
+      data: [
+        {
+          id: 2,
+          name: "Audiobooks",
+          paths: ["/media/audiobooks"],
+          type: "audiobooks",
+          enabled: true,
+          last_scanned_at: null,
+          scan_warning_code: "dead_root",
+          scan_warning_at: null,
+          scan_warning_message: "Root is reachable but empty",
+        },
+      ],
+      isLoading: false,
+    });
+
+    const markup = renderPage();
+
+    expect(markup).toContain('title="Confirm cleanup for missing or empty roots"');
+  });
+
   it("renders the collapsed Ambiguous Roots section with a populated count", () => {
     mocks.useLibraryRoots.mockReturnValue({
       data: [

--- a/web/src/pages/AdminLibraries.tsx
+++ b/web/src/pages/AdminLibraries.tsx
@@ -34,15 +34,6 @@ import {
 } from "@/hooks/queries/admin/libraries";
 import { useActiveScans } from "@/hooks/queries/admin/scans";
 import { buildLibraryReorderEntries } from "./adminLibraryOrder";
-
-const DEAD_ROOT_WARNING_TEXT =
-  "One or more library roots are unreachable. Their files are hidden, but nothing will be deleted until the root is back.";
-const DEAD_ROOT_WARNING_HINT =
-  "Run another scan after storage returns, or use Check Mount to verify connectivity.";
-const EMPTY_ROOT_WARNING_TEXT =
-  "Scan found 0 media files for this library. Cleanup was paused to avoid accidental deletion.";
-const EMPTY_ROOT_WARNING_HINT =
-  "Run another scan after storage returns, or confirm deletion before the next empty-root scan.";
 import MatchItemDialog from "@/components/MatchItemDialog";
 import { LibraryEditorDialog } from "@/components/admin/libraries/LibraryEditorDialog";
 import { Button } from "@/components/ui/button";
@@ -131,6 +122,15 @@ import { formatDateTime } from "@/lib/datetime";
 // Keep toast lifetime and delayed state cleanup coordinated so visible feedback
 // disappears before state is cleared.
 const MOUNT_CHECK_FEEDBACK_MS = 5_000;
+
+const DEAD_ROOT_WARNING_TEXT =
+  "One or more library roots are unreachable. Their files are hidden, but nothing will be deleted until the root is back.";
+const DEAD_ROOT_WARNING_HINT =
+  "Run another scan after storage returns, or use Check Mount to verify connectivity.";
+const EMPTY_ROOT_WARNING_TEXT =
+  "Scan found 0 media files for this library. Cleanup was paused to avoid accidental deletion.";
+const EMPTY_ROOT_WARNING_HINT =
+  "Run another scan after storage returns, or confirm deletion before the next empty-root scan.";
 
 export default function AdminLibraries() {
   useEventChannel("scans");

--- a/web/src/pages/AdminLibraries.tsx
+++ b/web/src/pages/AdminLibraries.tsx
@@ -314,7 +314,7 @@ export default function AdminLibraries() {
           if (!open) setConfirmEmptyRootLib(null);
         }}
         title="Confirm empty root cleanup"
-        description={`If the next scan still finds 0 media files for "${confirmEmptyRootLib?.name}", remove the library items?`}
+        description={`On the next scan of "${confirmEmptyRootLib?.name}", remove items from roots that are reachable but still empty? Unreachable roots remain protected.`}
         confirmLabel="Confirm"
         variant="destructive"
         onConfirm={() => {
@@ -580,12 +580,13 @@ export default function AdminLibraries() {
                             >
                               <Trash2 className="h-3 w-3" aria-hidden="true" />
                             </Button>
-                            {lib.scan_warning_code === "empty_root" ? (
+                            {lib.scan_warning_code === "empty_root" ||
+                            lib.scan_warning_code === "dead_root" ? (
                               <Button
                                 variant="ghost"
                                 size="icon"
                                 className="text-destructive h-7 w-7"
-                                title="Confirm deletion for the next empty-root scan"
+                                title="Confirm cleanup for missing or empty roots"
                                 disabled={
                                   confirmEmptyRootCleanupMutation.isPending &&
                                   confirmEmptyRootCleanupMutation.variables === lib.id
@@ -645,7 +646,7 @@ export default function AdminLibraries() {
                                   ? DEAD_ROOT_WARNING_HINT
                                   : EMPTY_ROOT_WARNING_HINT)}
                             </div>
-                            <div>
+                            <div className="flex gap-2">
                               <Button
                                 variant="outline"
                                 size="sm"
@@ -662,6 +663,21 @@ export default function AdminLibraries() {
                                 />
                                 Check Mount
                               </Button>
+                              {lib.scan_warning_code === "dead_root" ? (
+                                <Button
+                                  variant="outline"
+                                  size="sm"
+                                  title="Confirm cleanup for missing or empty roots"
+                                  disabled={
+                                    confirmEmptyRootCleanupMutation.isPending &&
+                                    confirmEmptyRootCleanupMutation.variables === lib.id
+                                  }
+                                  onClick={() => handleConfirmEmptyRootCleanup(lib)}
+                                >
+                                  <Trash2 className="mr-1 h-3.5 w-3.5" />
+                                  Confirm Cleanup
+                                </Button>
+                              ) : null}
                             </div>
                           </div>
                         </TableCell>

--- a/web/src/pages/AdminLibraries.tsx
+++ b/web/src/pages/AdminLibraries.tsx
@@ -453,6 +453,9 @@ export default function AdminLibraries() {
                             {lib.scan_warning_code === "empty_root" ? (
                               <Badge variant="destructive">Empty root guarded</Badge>
                             ) : null}
+                            {lib.scan_warning_code === "dead_root" ? (
+                              <Badge variant="destructive">Root unreachable</Badge>
+                            ) : null}
                           </div>
                         </TableCell>
                         <TableCell className="text-muted-foreground text-xs">
@@ -609,7 +612,11 @@ export default function AdminLibraries() {
                   );
                 })}
                 {orderedLibraries
-                  .filter((lib) => lib.scan_warning_code === "empty_root")
+                  .filter(
+                    (lib) =>
+                      lib.scan_warning_code === "empty_root" ||
+                      lib.scan_warning_code === "dead_root",
+                  )
                   .map((lib) => {
                     const mountCheck = lastMountCheckByLibraryId[lib.id];
                     const isCheckingMount =
@@ -619,8 +626,9 @@ export default function AdminLibraries() {
                         <TableCell colSpan={7} className="bg-destructive/5 text-sm">
                           <div className="flex flex-col gap-2 py-1">
                             <div className="text-destructive font-medium">
-                              Scan found 0 media files for this library. Cleanup was paused to avoid
-                              accidental deletion.
+                              {lib.scan_warning_code === "dead_root"
+                                ? "One or more library roots are unreachable. Their files are hidden, but nothing will be deleted until the root is back."
+                                : "Scan found 0 media files for this library. Cleanup was paused to avoid accidental deletion."}
                             </div>
                             <div className="text-muted-foreground">
                               {lib.scan_warning_message ??

--- a/web/src/pages/AdminLibraries.tsx
+++ b/web/src/pages/AdminLibraries.tsx
@@ -34,6 +34,15 @@ import {
 } from "@/hooks/queries/admin/libraries";
 import { useActiveScans } from "@/hooks/queries/admin/scans";
 import { buildLibraryReorderEntries } from "./adminLibraryOrder";
+
+const DEAD_ROOT_WARNING_TEXT =
+  "One or more library roots are unreachable. Their files are hidden, but nothing will be deleted until the root is back.";
+const DEAD_ROOT_WARNING_HINT =
+  "Run another scan after storage returns, or use Check Mount to verify connectivity.";
+const EMPTY_ROOT_WARNING_TEXT =
+  "Scan found 0 media files for this library. Cleanup was paused to avoid accidental deletion.";
+const EMPTY_ROOT_WARNING_HINT =
+  "Run another scan after storage returns, or confirm deletion before the next empty-root scan.";
 import MatchItemDialog from "@/components/MatchItemDialog";
 import { LibraryEditorDialog } from "@/components/admin/libraries/LibraryEditorDialog";
 import { Button } from "@/components/ui/button";
@@ -627,12 +636,14 @@ export default function AdminLibraries() {
                           <div className="flex flex-col gap-2 py-1">
                             <div className="text-destructive font-medium">
                               {lib.scan_warning_code === "dead_root"
-                                ? "One or more library roots are unreachable. Their files are hidden, but nothing will be deleted until the root is back."
-                                : "Scan found 0 media files for this library. Cleanup was paused to avoid accidental deletion."}
+                                ? DEAD_ROOT_WARNING_TEXT
+                                : EMPTY_ROOT_WARNING_TEXT}
                             </div>
                             <div className="text-muted-foreground">
                               {lib.scan_warning_message ??
-                                "Run another scan after storage returns, or confirm deletion before the next empty-root scan."}
+                                (lib.scan_warning_code === "dead_root"
+                                  ? DEAD_ROOT_WARNING_HINT
+                                  : EMPTY_ROOT_WARNING_HINT)}
                             </div>
                             <div>
                               <Button

--- a/web/src/pages/AdminLibraries.tsx
+++ b/web/src/pages/AdminLibraries.tsx
@@ -124,7 +124,7 @@ import { formatDateTime } from "@/lib/datetime";
 const MOUNT_CHECK_FEEDBACK_MS = 5_000;
 
 const DEAD_ROOT_WARNING_TEXT =
-  "One or more library roots are unreachable. Their files are hidden, but nothing will be deleted until the root is back.";
+  "One or more library roots are unreachable or mounted but returned no files. Their files are hidden, but nothing will be deleted until the root is back or cleanup is confirmed.";
 const DEAD_ROOT_WARNING_HINT =
   "Run another scan after storage returns, or use Check Mount to verify connectivity.";
 const EMPTY_ROOT_WARNING_TEXT =


### PR DESCRIPTION
## Problem

A library can have multiple roots. When one root is unreachable (dead drive, lost mount) while another still has files, the empty-root guard doesn't fire — the surviving root produced files — so everything under the dead root is marked missing (correct: it hides from browse/playback) and then, with the defaults `scanner.empty_trash_after_scan=true` + `file_removal_grace=24h`, the next scan after 24h **hard-deletes every row under the dead root**. A week-long drive outage silently destroys the root's catalog state (probe data, intro/credits markers, hashes) that would otherwise restore for free when the mount returns. Worse, membership reconciliation purges `media_items` whose only files lived on the dead root **immediately**, cascading user collections (`library_collection_items` is `ON DELETE CASCADE`) and deleting cached artwork.

## Approach

**Unreachable ≠ removed.** Each configured root is probed at scan start (new `internal/rootcheck`, shared with the admin mount-check endpoint). Unreachable roots are skipped by the walk but still reconciled (files marked missing); the trash sweep and the orphan item purge exclude anything under them (exact-path + escaped prefix-LIKE, same matching as `ListIDsOutsideRoots`, so `/mnt/movies2` is never protected by `/mnt/movies`). Membership removal still happens — browse/home hide items via `media_item_libraries`, and item recreation is *not* lossless (collection cascade) — so items stay hidden but their rows survive; when the root returns, upsert clears `missing_since` and `syncPresentLibraryState` re-inserts the membership. The folder surfaces `scan_warning_code='dead_root'` naming the roots; a healthy scan or mount check clears it. The audiobook/podcast/ebook scanners share the same sweep/purge and get the same guard.

| Scenario | Today | This PR |
|---|---|---|
| Root dies, other root alive | files hidden, **hard-deleted after 24h**; dead-root-only items **purged immediately** (collections cascade) | files hidden, rows survive indefinitely; items hidden but retained; `dead_root` warning |
| Root returns | full re-probe/re-match; metadata/collections lost | everything resurrects in place (same IDs), warning clears |
| File deleted under reachable root | purged after 24h grace | unchanged (byte-identical SQL with no dead roots) |
| Path removed from library config | rows deleted via `ListIDsOutsideRoots` | unchanged |
| All roots empty/dead | empty-root guard + confirm flow | unchanged |
| Autoscan on dead mount | guarded in scantrigger | unchanged |

## Risks / notes

- A retained membership-less item is invisible to all library-scoped views but could surface in unscoped search for library-unrestricted viewers until the root returns (previously it was deleted outright).
- Membership `first_seen_at` resets on restore, so restored titles may appear "recently added" after an outage.
- Probe cost is 2–3 syscalls per root per scan.
- When *all* roots are dead the existing empty-root guard fires first and keeps its `empty_root` confirm-flow semantics.

## Verification

`go build ./...`, `go vet`, gofmt/goimports clean; `go test ./internal/scanner/... ./internal/catalog/... ./internal/api/... ./internal/rootcheck/...` against a migrated Postgres — all pass, including new DB-backed end-to-end tests: dead root → rows survive a zero-grace sweep with `dead_root` warning; root restored → same-ID resurrection and warning cleared; reachable-root deletion still purges (regression); sibling-prefix protection; orphan-purge exemption. Web: lint/format clean, AdminLibraries vitest 9/9.

AI-use disclosure: implemented by Claude (Claude Code) under human direction and review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Detects unreachable and “suspect empty” library roots during scans, recording them as **dead_root** warnings in scan results and Admin Libraries.
  - Protects media and related records under these roots from hard-deletes/purging while they’re not reliably readable.
- **Bug Fixes**
  - Clears **dead_root** warnings after roots successfully recover, restoring normal media visibility.
  - Prevents cleanup from deleting content when roots temporarily fail or appear empty but still contain data.
- **Tests**
  - Adds integration and unit coverage for protected-root behavior and scan cleanup/reconciliation scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->