### PR TITLE
feat(notifications): harden push relay credentials

### DIFF
--- a/internal/api/handlers/admin.go
+++ b/internal/api/handlers/admin.go
@@ -2238,7 +2238,12 @@ func (h *AdminHandler) HandleUpdateSetting(w http.ResponseWriter, r *http.Reques
 			return
 		}
 		req.Value = strconv.FormatBool(enabled)
-	case notifications.SettingPushRelayURL, notifications.SettingPushRelayDeploymentID, notifications.SettingPushRelayAPIKey:
+	case notifications.SettingPushRelayURL,
+		notifications.SettingPushRelayDeploymentID,
+		notifications.SettingPushRelayAPIKey,
+		notifications.SettingPushRelayExpiresAt,
+		notifications.SettingPushRelayKeyPrefix,
+		notifications.SettingPushRelayReregister:
 		// The registration flow persists the relay URL, deployment id, and API
 		// key together; a direct write to any of them desyncs the stored URL
 		// from the credentials the relay minted for it (and feeds an arbitrary

--- a/internal/api/handlers/admin_apple_push.go
+++ b/internal/api/handlers/admin_apple_push.go
@@ -1,23 +1,20 @@
 package handlers
 
 import (
-	"bytes"
 	"encoding/json"
 	"errors"
-	"fmt"
-	"io"
 	"net/http"
-	"net/url"
-	"strings"
+	"os"
 	"time"
 
 	"github.com/Silo-Server/silo-server/internal/notifications"
 )
 
 type AdminApplePushHandler struct {
-	system   *notifications.System
-	settings ServerSettingsStore
-	client   httpDoer
+	system              *notifications.System
+	settings            ServerSettingsStore
+	client              httpDoer
+	developmentRelayURL string
 }
 
 type httpDoer interface {
@@ -26,9 +23,10 @@ type httpDoer interface {
 
 func NewAdminApplePushHandler(system *notifications.System, settings ServerSettingsStore) *AdminApplePushHandler {
 	return &AdminApplePushHandler{
-		system:   system,
-		settings: settings,
-		client:   &http.Client{Timeout: 10 * time.Second},
+		system:              system,
+		settings:            settings,
+		client:              &http.Client{Timeout: 10 * time.Second},
+		developmentRelayURL: os.Getenv("SILO_PUSH_RELAY_DEVELOPMENT_URL"),
 	}
 }
 
@@ -52,26 +50,6 @@ type adminPushRelayRegisterRequest struct {
 	RelayURL string `json:"relay_url"`
 }
 
-type pushRelayRegisterRequest struct {
-	DeploymentID string `json:"deployment_id,omitempty"`
-}
-
-type pushRelayRegisterResponse struct {
-	RequestID    string   `json:"request_id"`
-	DeploymentID string   `json:"deployment_id"`
-	APIKey       string   `json:"api_key"`
-	KeyPrefix    string   `json:"key_prefix"`
-	APNsTopics   []string `json:"apns_topics"`
-}
-
-type pushRelayNestedError struct {
-	Error struct {
-		Code      string `json:"code"`
-		Message   string `json:"message"`
-		RequestID string `json:"request_id"`
-	} `json:"error"`
-}
-
 type adminPushRelayRegisterResponse struct {
 	RelayURL         string   `json:"relay_url"`
 	DeploymentID     string   `json:"deployment_id"`
@@ -79,6 +57,7 @@ type adminPushRelayRegisterResponse struct {
 	APIKeyConfigured bool     `json:"api_key_configured"`
 	RelayRequestID   string   `json:"relay_request_id,omitempty"`
 	APNsTopics       []string `json:"apns_topics,omitempty"`
+	ExpiresAt        string   `json:"expires_at"`
 }
 
 // HandleTest handles POST /admin/notifications/push/apple/test.
@@ -131,149 +110,73 @@ func (h *AdminApplePushHandler) HandleRegisterRelay(w http.ResponseWriter, r *ht
 		writeError(w, http.StatusBadRequest, "bad_request", "Invalid request body")
 		return
 	}
-	relayURL, err := normalizePushRelayURL(req.RelayURL)
+	relayURL, err := notifications.NormalizePushRelayURL(req.RelayURL, h.developmentRelayURL)
 	if err != nil {
 		writeError(w, http.StatusBadRequest, "bad_request", err.Error())
 		return
 	}
 
-	existingDeploymentID, err := h.settings.Get(r.Context(), notifications.SettingPushRelayDeploymentID)
-	if err != nil {
-		writeError(w, http.StatusInternalServerError, "settings_error", "Failed to load relay deployment id")
-		return
+	settings := notifications.NewSettings(h.settings)
+	if h.system != nil && h.system.Settings != nil {
+		settings = h.system.Settings
 	}
-	relayResp, err := h.registerWithRelay(r, relayURL, strings.TrimSpace(existingDeploymentID))
+	current := notifications.LoadPushRelayCredential(r.Context(), settings)
+	var relayResp notifications.RelayCredentialResult
+	switch {
+	case current.APIKey == "", notifications.IsLegacyPushRelayKey(current.APIKey), current.ReregistrationRequired:
+		relayResp, err = notifications.RegisterRelayCredential(r.Context(), settings, h.client, relayURL)
+	default:
+		currentURL, urlErr := notifications.NormalizePushRelayURL(current.RelayURL, h.developmentRelayURL)
+		if urlErr != nil || currentURL != relayURL {
+			writeError(w, http.StatusConflict, "relay_origin_change_requires_reregistration", "Clear or re-register the relay credential before changing relay origins")
+			return
+		}
+		current.RelayURL = currentURL
+		relayResp, err = notifications.RotateRelayCredential(r.Context(), settings, h.client, current)
+	}
 	if err != nil {
+		var relayErr notifications.RelayCredentialError
+		if current.APIKey != "" && !notifications.IsLegacyPushRelayKey(current.APIKey) &&
+			errors.As(err, &relayErr) && relayErr.Status == http.StatusUnauthorized {
+			if markErr := notifications.MarkRelayReregistrationRequired(r.Context(), settings, current); markErr != nil {
+				writeError(w, http.StatusInternalServerError, "settings_error", "Failed to save push relay credential status")
+				return
+			}
+			writeError(w, http.StatusConflict, "relay_reregistration_required", "The current relay capability was rejected; explicit re-registration is required")
+			return
+		}
 		status, code, message := mapRelayRegistrationError(err)
 		writeError(w, status, code, message)
 		return
 	}
-	if strings.TrimSpace(relayResp.DeploymentID) == "" || strings.TrimSpace(relayResp.APIKey) == "" {
-		writeError(w, http.StatusBadGateway, "relay_bad_response", "Push relay returned an incomplete registration response")
-		return
-	}
-
-	if err := h.settings.Set(r.Context(), notifications.SettingPushRelayURL, relayURL); err != nil {
-		writeError(w, http.StatusInternalServerError, "settings_error", "Failed to save push relay URL")
-		return
-	}
-	if err := h.settings.Set(r.Context(), notifications.SettingPushRelayDeploymentID, relayResp.DeploymentID); err != nil {
-		writeError(w, http.StatusInternalServerError, "settings_error", "Failed to save push relay deployment id")
-		return
-	}
-	if err := h.settings.Set(r.Context(), notifications.SettingPushRelayAPIKey, relayResp.APIKey); err != nil {
-		writeError(w, http.StatusInternalServerError, "settings_error", "Failed to save push relay API key")
-		return
-	}
-	if h.system != nil && h.system.Settings != nil {
-		h.system.Settings.Invalidate(
-			notifications.SettingPushRelayURL,
-			notifications.SettingPushRelayDeploymentID,
-			notifications.SettingPushRelayAPIKey,
-		)
-	}
+	credential := relayResp.Credential
 	writeJSON(w, http.StatusOK, adminPushRelayRegisterResponse{
-		RelayURL:         relayURL,
-		DeploymentID:     relayResp.DeploymentID,
-		KeyPrefix:        relayResp.KeyPrefix,
+		RelayURL:         credential.RelayURL,
+		DeploymentID:     credential.DeploymentID,
+		KeyPrefix:        credential.KeyPrefix,
 		APIKeyConfigured: true,
 		RelayRequestID:   relayResp.RequestID,
 		APNsTopics:       relayResp.APNsTopics,
+		ExpiresAt:        credential.ExpiresAt.UTC().Format(time.RFC3339),
 	})
-}
-
-func (h *AdminApplePushHandler) registerWithRelay(r *http.Request, relayURL, deploymentID string) (*pushRelayRegisterResponse, error) {
-	body, err := json.Marshal(pushRelayRegisterRequest{
-		DeploymentID: deploymentID,
-	})
-	if err != nil {
-		return nil, err
-	}
-	httpReq, err := http.NewRequestWithContext(r.Context(), http.MethodPost, relayURL+"/v1/deployments/register", bytes.NewReader(body))
-	if err != nil {
-		return nil, err
-	}
-	httpReq.Header.Set("Content-Type", "application/json")
-	httpReq.Header.Set("User-Agent", "Silo-Server/PushRelayRegistration")
-
-	resp, err := h.client.Do(httpReq)
-	if err != nil {
-		return nil, relayRegistrationError{status: http.StatusBadGateway, code: "relay_unreachable", message: "Push relay could not be reached"}
-	}
-	defer func() { _ = resp.Body.Close() }()
-
-	data, _ := io.ReadAll(io.LimitReader(resp.Body, 16<<10))
-	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
-		var parsed pushRelayNestedError
-		_ = json.Unmarshal(data, &parsed)
-		code := parsed.Error.Code
-		if code == "" {
-			code = fmt.Sprintf("relay_http_%d", resp.StatusCode)
-		}
-		message := parsed.Error.Message
-		if message == "" {
-			message = http.StatusText(resp.StatusCode)
-		}
-		return nil, relayRegistrationError{status: resp.StatusCode, code: code, message: message}
-	}
-	var parsed pushRelayRegisterResponse
-	if err := json.Unmarshal(data, &parsed); err != nil {
-		return nil, relayRegistrationError{status: http.StatusBadGateway, code: "relay_bad_response", message: "Push relay returned invalid JSON"}
-	}
-	return &parsed, nil
-}
-
-type relayRegistrationError struct {
-	status  int
-	code    string
-	message string
-}
-
-func (e relayRegistrationError) Error() string {
-	return e.code
 }
 
 func mapRelayRegistrationError(err error) (int, string, string) {
-	var relayErr relayRegistrationError
+	var relayErr notifications.RelayCredentialError
 	if !errors.As(err, &relayErr) {
 		return http.StatusInternalServerError, "internal_error", "Failed to register push relay"
 	}
-	switch relayErr.status {
+	switch relayErr.Status {
 	case http.StatusForbidden:
 		return http.StatusUnprocessableEntity, "relay_deployment_rejected", "Push relay rejected this deployment"
 	case http.StatusTooManyRequests:
-		return http.StatusTooManyRequests, "relay_rate_limited", relayErr.message
+		return http.StatusTooManyRequests, "relay_rate_limited", relayErr.Message
 	case http.StatusServiceUnavailable:
-		return http.StatusServiceUnavailable, "relay_unavailable", relayErr.message
+		return http.StatusServiceUnavailable, "relay_unavailable", relayErr.Message
 	default:
-		if relayErr.status >= 500 {
-			return http.StatusBadGateway, "relay_error", relayErr.message
+		if relayErr.Status >= 500 {
+			return http.StatusBadGateway, "relay_error", relayErr.Message
 		}
-		return http.StatusBadGateway, relayErr.code, relayErr.message
+		return http.StatusBadGateway, relayErr.Code, relayErr.Message
 	}
-}
-
-// normalizePushRelayURLValue trims a relay URL and enforces https with a
-// host. Empty input stays empty so callers choose their own default.
-func normalizePushRelayURLValue(raw string) (string, error) {
-	value := strings.TrimRight(strings.TrimSpace(raw), "/")
-	if value == "" {
-		return "", nil
-	}
-	parsed, err := url.Parse(value)
-	if err != nil || parsed.Scheme != "https" || parsed.Host == "" {
-		return "", errors.New("relay_url must be an https URL")
-	}
-	return value, nil
-}
-
-func normalizePushRelayURL(raw string) (string, error) {
-	value, err := normalizePushRelayURLValue(raw)
-	if err != nil {
-		return "", err
-	}
-	if value == "" {
-		return notifications.DefaultPushRelayURL, nil
-	}
-	return value, nil
 }

--- a/internal/api/handlers/admin_apple_push_test.go
+++ b/internal/api/handlers/admin_apple_push_test.go
@@ -40,12 +40,13 @@ func TestAdminApplePushHandlerRegistersRelayAndStoresKey(t *testing.T) {
 		if err := json.NewDecoder(r.Body).Decode(&relayReq); err != nil {
 			t.Fatalf("decode relay request: %v", err)
 		}
-		writeJSON(w, http.StatusOK, pushRelayRegisterResponse{
-			RequestID:    "relay-request",
-			DeploymentID: "01RETURNED",
-			APIKey:       "rk_live_raw-key",
-			KeyPrefix:    "rk_live_raw",
-			APNsTopics:   []string{"org.siloserver.silo"},
+		writeJSON(w, http.StatusOK, map[string]any{
+			"request_id":    "relay-request",
+			"deployment_id": "01RETURNED",
+			"api_key":       "modern.capability.value",
+			"key_prefix":    "cap_v1_test",
+			"apns_topics":   []string{"org.siloserver.silo"},
+			"expires_at":    "2026-08-10T00:00:00Z",
 		})
 	}))
 	t.Cleanup(relay.Close)
@@ -65,6 +66,7 @@ func TestAdminApplePushHandlerRegistersRelayAndStoresKey(t *testing.T) {
 	httpsRelay := httptest.NewTLSServer(relay.Config.Handler)
 	t.Cleanup(httpsRelay.Close)
 	h.client = httpsRelay.Client()
+	h.developmentRelayURL = httpsRelay.URL
 	rec = httptest.NewRecorder()
 	h.HandleRegisterRelay(rec, httptest.NewRequest(http.MethodPost, "/admin/notifications/push/relay/register", strings.NewReader(`{
 		"relay_url":"`+httpsRelay.URL+`"
@@ -73,7 +75,7 @@ func TestAdminApplePushHandlerRegistersRelayAndStoresKey(t *testing.T) {
 	if rec.Code != http.StatusOK {
 		t.Fatalf("status = %d (%s), want 200", rec.Code, rec.Body.String())
 	}
-	if relayReq["deployment_id"] != "01EXISTING" || len(relayReq) != 1 {
+	if len(relayReq) != 0 {
 		t.Fatalf("relay request = %+v", relayReq)
 	}
 	if settings.values[notifications.SettingPushRelayURL] != httpsRelay.URL {
@@ -82,7 +84,7 @@ func TestAdminApplePushHandlerRegistersRelayAndStoresKey(t *testing.T) {
 	if settings.values[notifications.SettingPushRelayDeploymentID] != "01RETURNED" {
 		t.Fatalf("stored deployment id = %q", settings.values[notifications.SettingPushRelayDeploymentID])
 	}
-	if settings.values[notifications.SettingPushRelayAPIKey] != "rk_live_raw-key" {
+	if settings.values[notifications.SettingPushRelayAPIKey] != "modern.capability.value" {
 		t.Fatalf("stored api key = %q", settings.values[notifications.SettingPushRelayAPIKey])
 	}
 
@@ -109,6 +111,7 @@ func TestAdminApplePushHandlerMapsRelayRateLimit(t *testing.T) {
 
 	h := NewAdminApplePushHandler(&notifications.System{}, settings)
 	h.client = relay.Client()
+	h.developmentRelayURL = relay.URL
 	rec := httptest.NewRecorder()
 	h.HandleRegisterRelay(rec, httptest.NewRequest(http.MethodPost, "/admin/notifications/push/relay/register", strings.NewReader(`{
 		"relay_url":"`+relay.URL+`"
@@ -119,5 +122,48 @@ func TestAdminApplePushHandlerMapsRelayRateLimit(t *testing.T) {
 	}
 	if settings.values[notifications.SettingPushRelayAPIKey] != "" {
 		t.Fatal("api key was stored after relay rejected registration")
+	}
+}
+
+func TestAdminApplePushHandlerRotatesExistingCapability(t *testing.T) {
+	settings := &fakeServerSettingsStore{values: map[string]string{
+		notifications.SettingPushRelayDeploymentID: "deployment-existing",
+		notifications.SettingPushRelayAPIKey:       "existing.capability.value",
+		notifications.SettingPushRelayKeyPrefix:    "cap_v1_existing",
+		notifications.SettingPushRelayExpiresAt:    "2026-08-01T00:00:00Z",
+	}}
+	var idempotencyKey string
+	relay := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/v1/deployments/rotate" {
+			t.Fatalf("relay path = %q, want rotate", r.URL.Path)
+		}
+		if got := r.Header.Get("Authorization"); got != "Bearer existing.capability.value" {
+			t.Fatalf("Authorization = %q", got)
+		}
+		idempotencyKey = r.Header.Get("Idempotency-Key")
+		writeJSON(w, http.StatusOK, map[string]any{
+			"request_id":    "rotate-request",
+			"deployment_id": "deployment-existing",
+			"api_key":       "rotated.capability.value",
+			"key_prefix":    "cap_v1_rotated",
+			"expires_at":    "2026-09-01T00:00:00Z",
+		})
+	}))
+	t.Cleanup(relay.Close)
+	settings.values[notifications.SettingPushRelayURL] = relay.URL
+	h := NewAdminApplePushHandler(&notifications.System{Settings: notifications.NewSettings(settings)}, settings)
+	h.client = relay.Client()
+	h.developmentRelayURL = relay.URL
+
+	rec := httptest.NewRecorder()
+	h.HandleRegisterRelay(rec, httptest.NewRequest(http.MethodPost, "/admin/notifications/push/relay/register", strings.NewReader(`{"relay_url":"`+relay.URL+`"}`)))
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d (%s), want 200", rec.Code, rec.Body.String())
+	}
+	if idempotencyKey == "" {
+		t.Fatal("rotation omitted Idempotency-Key")
+	}
+	if got := settings.values[notifications.SettingPushRelayAPIKey]; got != "rotated.capability.value" {
+		t.Fatalf("stored capability = %q", got)
 	}
 }

--- a/internal/api/handlers/admin_settings_checks_test.go
+++ b/internal/api/handlers/admin_settings_checks_test.go
@@ -32,6 +32,16 @@ func (f *fakeServerSettingsStore) Set(_ context.Context, key, value string) erro
 	return nil
 }
 
+func (f *fakeServerSettingsStore) SetMany(_ context.Context, values map[string]string) error {
+	if f.values == nil {
+		f.values = map[string]string{}
+	}
+	for key, value := range values {
+		f.values[key] = value
+	}
+	return nil
+}
+
 func (f *fakeServerSettingsStore) GetAll(context.Context) (map[string]string, error) {
 	cloned := make(map[string]string, len(f.values))
 	for key, value := range f.values {

--- a/internal/catalog/encrypted_settings_repo.go
+++ b/internal/catalog/encrypted_settings_repo.go
@@ -153,6 +153,31 @@ type settingsConditionalWriter interface {
 	SetIfAbsent(ctx context.Context, key, value string) (bool, error)
 }
 
+type settingsBatchWriter interface {
+	SetMany(ctx context.Context, values map[string]string) error
+}
+
+// SetMany encrypts every sensitive member before delegating one atomic batch
+// to the raw settings repository.
+func (r *EncryptedSettingsRepo) SetMany(ctx context.Context, values map[string]string) error {
+	inner, ok := r.inner.(settingsBatchWriter)
+	if !ok {
+		return fmt.Errorf("settings store does not support atomic batch writes")
+	}
+	encrypted := make(map[string]string, len(values))
+	for key, value := range values {
+		if SensitiveSettingKeys[key] && value != "" {
+			ct, err := r.cipher.Encrypt(value, secret.SettingsAAD(key))
+			if err != nil {
+				return fmt.Errorf("encrypt setting %q: %w", key, err)
+			}
+			value = ct
+		}
+		encrypted[key] = value
+	}
+	return inner.SetMany(ctx, encrypted)
+}
+
 // SetIfAbsent applies Set's encryption contract to a conditional write: the
 // value lands only when the key currently has no value, so concurrent
 // provisioners of generated secrets cannot overwrite each other.

--- a/internal/catalog/server_settings_repo.go
+++ b/internal/catalog/server_settings_repo.go
@@ -45,6 +45,30 @@ func (r *ServerSettingsRepo) Set(ctx context.Context, key, value string) error {
 	return nil
 }
 
+// SetMany atomically upserts a related group of settings. Credential bundles
+// use this so readers can never observe a URL, identifier, or secret from
+// different relay generations after a partial write.
+func (r *ServerSettingsRepo) SetMany(ctx context.Context, values map[string]string) error {
+	tx, err := r.pool.Begin(ctx)
+	if err != nil {
+		return fmt.Errorf("server_settings begin batch: %w", err)
+	}
+	defer func() { _ = tx.Rollback(ctx) }()
+	for key, value := range values {
+		if _, err := tx.Exec(ctx,
+			`INSERT INTO server_settings (key, value) VALUES ($1, $2)
+			 ON CONFLICT (key) DO UPDATE SET value = EXCLUDED.value`,
+			key, value,
+		); err != nil {
+			return fmt.Errorf("server_settings batch set %q: %w", key, err)
+		}
+	}
+	if err := tx.Commit(ctx); err != nil {
+		return fmt.Errorf("server_settings commit batch: %w", err)
+	}
+	return nil
+}
+
 // SetIfAbsent inserts a setting only when the key has no value yet (absent or
 // empty), reporting whether this call won the write. Generated credentials
 // (e.g. the web push VAPID keypair) must be provisioned single-writer across

--- a/internal/notifications/push_sender.go
+++ b/internal/notifications/push_sender.go
@@ -8,7 +8,9 @@ import (
 	"io"
 	"log/slog"
 	"net/http"
+	"os"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/Silo-Server/silo-server/internal/secret"
@@ -71,22 +73,27 @@ type pushSendResult struct {
 }
 
 type pushSender struct {
-	devices    *PushDeviceRepository
-	deliveries *DeliveryRepository
-	cipher     *secret.Cipher
-	settings   *Settings
-	client     *http.Client
-	logger     *slog.Logger
+	devices             *PushDeviceRepository
+	deliveries          *DeliveryRepository
+	cipher              *secret.Cipher
+	settings            *Settings
+	client              *http.Client
+	logger              *slog.Logger
+	renewMu             sync.Mutex
+	developmentRelayURL string
+	now                 func() time.Time
 }
 
 func newPushSender(devices *PushDeviceRepository, deliveries *DeliveryRepository, cipher *secret.Cipher, settings *Settings) *pushSender {
 	return &pushSender{
-		devices:    devices,
-		deliveries: deliveries,
-		cipher:     cipher,
-		settings:   settings,
-		client:     newWebhookHTTPClient(nil),
-		logger:     slog.Default().With("component", "notifications.apple_push"),
+		devices:             devices,
+		deliveries:          deliveries,
+		cipher:              cipher,
+		settings:            settings,
+		client:              newWebhookHTTPClient(nil),
+		logger:              slog.Default().With("component", "notifications.apple_push"),
+		developmentRelayURL: os.Getenv("SILO_PUSH_RELAY_DEVELOPMENT_URL"),
+		now:                 time.Now,
 	}
 }
 
@@ -170,11 +177,62 @@ func (s *pushSender) finalize(ctx context.Context, attempt PushDeliveryAttempt, 
 }
 
 func (s *pushSender) send(ctx context.Context, attempt PushDeliveryAttempt, device *PushDevice, token string) pushSendResult {
-	apiKey := s.settings.PushRelayAPIKey(ctx)
-	if apiKey == "" {
-		return pushSendResult{Message: "push relay API key not configured", UpstreamReason: "relay_api_key_missing"}
+	credential, err := s.prepareRelayCredential(ctx)
+	if err != nil {
+		return pushSendResult{HTTPStatus: http.StatusServiceUnavailable, Message: err.Error(), UpstreamReason: "relay_credential_unavailable"}
 	}
-	relayURL := s.settings.PushRelayURL(ctx)
+	result := s.sendWithCapability(ctx, attempt, device, token, credential.RelayURL, credential.APIKey)
+	if result.HTTPStatus != http.StatusUnauthorized || result.UpstreamReason != "token_expired" {
+		if result.HTTPStatus == http.StatusUnauthorized {
+			_ = s.markReregistrationRequired(ctx, credential)
+		}
+		return result
+	}
+
+	renewed, err := s.renewRelayCapability(ctx, credential.APIKey)
+	if err != nil {
+		return pushSendResult{
+			HTTPStatus:     http.StatusServiceUnavailable,
+			UpstreamReason: "relay_renewal_failed",
+			Message:        "push relay capability renewal failed",
+		}
+	}
+	return s.sendWithCapability(ctx, attempt, device, token, renewed.RelayURL, renewed.APIKey)
+}
+
+func (s *pushSender) prepareRelayCredential(ctx context.Context) (PushRelayCredential, error) {
+	s.renewMu.Lock()
+	defer s.renewMu.Unlock()
+	current := LoadPushRelayCredential(ctx, s.settings)
+	relayURL, err := NormalizePushRelayURL(current.RelayURL, s.developmentRelayURL)
+	if err != nil {
+		return PushRelayCredential{}, err
+	}
+	current.RelayURL = relayURL
+	if current.APIKey == "" {
+		return PushRelayCredential{}, fmt.Errorf("push relay API key not configured")
+	}
+	if IsLegacyPushRelayKey(current.APIKey) {
+		result, err := RegisterRelayCredential(ctx, s.settings, s.client, relayURL)
+		return result.Credential, err
+	}
+	if current.ReregistrationRequired {
+		return PushRelayCredential{}, fmt.Errorf("push relay re-registration required")
+	}
+	if RelayCredentialNeedsRenewal(s.now(), current.ExpiresAt, current.DeploymentID) {
+		result, err := RenewRelayCredential(ctx, s.settings, s.client, current)
+		// A proactive refresh must not suppress delivery while the current
+		// capability is still valid. Reactive token_expired handling remains the
+		// final safety net once its actual expiry is reached.
+		if err != nil && s.now().Before(current.ExpiresAt) {
+			return current, nil
+		}
+		return result.Credential, err
+	}
+	return current, nil
+}
+
+func (s *pushSender) sendWithCapability(ctx context.Context, attempt PushDeliveryAttempt, device *PushDevice, token, relayURL, apiKey string) pushSendResult {
 	deliveryID := attempt.ID
 	if attempt.NotificationDeliveryID != nil {
 		deliveryID = *attempt.NotificationDeliveryID
@@ -202,7 +260,10 @@ func (s *pushSender) send(ctx context.Context, attempt PushDeliveryAttempt, devi
 	req.Header.Set("Authorization", "Bearer "+apiKey)
 	req.Header.Set("Content-Type", "application/json")
 	req.Header.Set("User-Agent", "Silo-Push/1.0")
-	req.Header.Set("Idempotency-Key", fmt.Sprintf("%s:%d", attempt.ID, attempt.AttemptNumber+1))
+	// One logical delivery attempt keeps the same key across every transport
+	// retry. The relay can then distinguish a safe retry from a new delivery and
+	// refuse to resend an ambiguous APNs outcome.
+	req.Header.Set("Idempotency-Key", attempt.ID)
 
 	resp, err := s.client.Do(req)
 	if err != nil {
@@ -245,6 +306,34 @@ func (s *pushSender) send(ctx context.Context, attempt PushDeliveryAttempt, devi
 		Message:        strings.TrimSpace(message),
 		TerminalDevice: resp.StatusCode == http.StatusUnprocessableEntity && code == "apns_rejected",
 	}
+}
+
+func (s *pushSender) renewRelayCapability(ctx context.Context, expiredKey string) (PushRelayCredential, error) {
+	s.renewMu.Lock()
+	defer s.renewMu.Unlock()
+
+	// Another sender may have renewed while this goroutine waited for the lock.
+	current := LoadPushRelayCredential(ctx, s.settings)
+	if current.APIKey != "" && current.APIKey != expiredKey {
+		return current, nil
+	}
+	relayURL, err := NormalizePushRelayURL(current.RelayURL, s.developmentRelayURL)
+	if err != nil {
+		return PushRelayCredential{}, err
+	}
+	current.RelayURL = relayURL
+	result, err := RenewRelayCredential(ctx, s.settings, s.client, current)
+	return result.Credential, err
+}
+
+func (s *pushSender) markReregistrationRequired(ctx context.Context, failed PushRelayCredential) error {
+	s.renewMu.Lock()
+	defer s.renewMu.Unlock()
+	current := LoadPushRelayCredential(ctx, s.settings)
+	if current.APIKey != failed.APIKey {
+		return nil
+	}
+	return MarkRelayReregistrationRequired(ctx, s.settings, current)
 }
 
 // PushDispatcher implements the channel Dispatcher interface for Apple push

--- a/internal/notifications/push_sender_test.go
+++ b/internal/notifications/push_sender_test.go
@@ -9,6 +9,24 @@ import (
 	"testing"
 )
 
+type mapSettingStore map[string]string
+
+func (m mapSettingStore) Get(_ context.Context, key string) (string, error) {
+	return m[key], nil
+}
+
+func (m mapSettingStore) Set(_ context.Context, key, value string) error {
+	m[key] = value
+	return nil
+}
+
+func (m mapSettingStore) SetMany(_ context.Context, values map[string]string) error {
+	for key, value := range values {
+		m[key] = value
+	}
+	return nil
+}
+
 func TestApplePushDeliverySettings(t *testing.T) {
 	ctx := context.Background()
 	settings := NewSettings(nil)
@@ -65,6 +83,7 @@ func TestPushSenderSendBuildsRelayRequest(t *testing.T) {
 	})
 	sender := newPushSender(nil, nil, nil, settings)
 	sender.client = server.Client()
+	sender.developmentRelayURL = server.URL
 
 	deliveryID := "delivery-1"
 	result := sender.send(context.Background(), PushDeliveryAttempt{
@@ -83,7 +102,7 @@ func TestPushSenderSendBuildsRelayRequest(t *testing.T) {
 	if got.auth != "Bearer relay-key" {
 		t.Fatalf("Authorization = %q", got.auth)
 	}
-	if got.idempotencyKey != "attempt-1:2" {
+	if got.idempotencyKey != "attempt-1" {
 		t.Fatalf("Idempotency-Key = %q", got.idempotencyKey)
 	}
 	if got.body.Token != token || got.body.Mode != "private_alert" || got.body.DeliveryID != deliveryID {
@@ -117,6 +136,7 @@ func TestPushSenderSendMapsRelayTerminalAPNsRejection(t *testing.T) {
 	})
 	sender := newPushSender(nil, nil, nil, settings)
 	sender.client = server.Client()
+	sender.developmentRelayURL = server.URL
 
 	result := sender.send(context.Background(), PushDeliveryAttempt{ID: "attempt-1"}, &PushDevice{
 		APNsEnvironment: APNsEnvironmentSandbox,
@@ -156,6 +176,7 @@ func TestPushSenderSendMapsRelayRetryAfter(t *testing.T) {
 	})
 	sender := newPushSender(nil, nil, nil, settings)
 	sender.client = server.Client()
+	sender.developmentRelayURL = server.URL
 
 	result := sender.send(context.Background(), PushDeliveryAttempt{ID: "attempt-1"}, &PushDevice{
 		APNsEnvironment: APNsEnvironmentSandbox,
@@ -165,5 +186,111 @@ func TestPushSenderSendMapsRelayRetryAfter(t *testing.T) {
 
 	if result.OK || result.TerminalDevice || result.RetryAfter == 0 {
 		t.Fatalf("retryable result = %+v", result)
+	}
+}
+
+func TestPushSenderRenewsExpiredCapabilityAndRetriesStableDelivery(t *testing.T) {
+	token := strings.Repeat("a", 64)
+	var sendKeys []string
+	var sendAuth []string
+	server := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case relayAppleSendPath:
+			sendKeys = append(sendKeys, r.Header.Get("Idempotency-Key"))
+			sendAuth = append(sendAuth, r.Header.Get("Authorization"))
+			if len(sendAuth) == 1 {
+				w.WriteHeader(http.StatusUnauthorized)
+				_ = json.NewEncoder(w).Encode(pushRelayErrorResponse{Error: struct {
+					Code      string `json:"code"`
+					Message   string `json:"message"`
+					RequestID string `json:"request_id"`
+				}{Code: "token_expired", Message: "relay capability has expired"}})
+				return
+			}
+			_ = json.NewEncoder(w).Encode(pushRelayAppleResponse{
+				RequestID: "relay-request-renewed",
+				APNsID:    "apns-renewed",
+				Status:    "accepted",
+			})
+		case relayRenewPath:
+			if got := r.Header.Get("Authorization"); got != "Bearer expired-capability" {
+				t.Fatalf("renew Authorization = %q", got)
+			}
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"request_id":    "renew-request",
+				"deployment_id": "deployment-renew",
+				"api_key":       "renewed-capability",
+				"key_prefix":    "cap_v1_renewed",
+				"expires_at":    "2026-08-10T00:00:00Z",
+			})
+		default:
+			t.Fatalf("unexpected relay path %q", r.URL.Path)
+		}
+	}))
+	defer server.Close()
+
+	store := mapSettingStore{
+		SettingPushRelayURL:          server.URL,
+		SettingPushRelayDeploymentID: "deployment-renew",
+		SettingPushRelayAPIKey:       "expired-capability",
+	}
+	sender := newPushSender(nil, nil, nil, NewSettings(store))
+	sender.client = server.Client()
+	sender.developmentRelayURL = server.URL
+	result := sender.send(context.Background(), PushDeliveryAttempt{ID: "attempt-renew"}, &PushDevice{
+		APNsEnvironment: APNsEnvironmentSandbox,
+		APNsTopic:       ApplePushTopicSilo,
+		ServerDeviceID:  "server-device-renew",
+	}, token)
+
+	if !result.OK || result.RelayRequestID != "relay-request-renewed" {
+		t.Fatalf("result = %+v", result)
+	}
+	if got := store[SettingPushRelayAPIKey]; got != "renewed-capability" {
+		t.Fatalf("stored renewed capability = %q", got)
+	}
+	if len(sendKeys) != 2 || sendKeys[0] != "attempt-renew" || sendKeys[1] != "attempt-renew" {
+		t.Fatalf("send Idempotency-Keys = %#v", sendKeys)
+	}
+	if len(sendAuth) != 2 || sendAuth[1] != "Bearer renewed-capability" {
+		t.Fatalf("send Authorization headers = %#v", sendAuth)
+	}
+}
+
+func TestPushSenderMapsRelayIdempotencyStatesWithStableKey(t *testing.T) {
+	for _, tc := range []struct {
+		name      string
+		status    int
+		code      string
+		retryable bool
+	}{
+		{name: "unknown", status: http.StatusConflict, code: "delivery_unknown", retryable: false},
+		{name: "in progress", status: http.StatusTooEarly, code: "idempotency_in_progress", retryable: true},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			var keys []string
+			sender := newPushSender(nil, nil, nil, NewSettings(mapSettingStore{}))
+			sender.client = &http.Client{Transport: relayRoundTripFunc(func(req *http.Request) (*http.Response, error) {
+				keys = append(keys, req.Header.Get("Idempotency-Key"))
+				return relayResponse(tc.status, `{"error":{"code":"`+tc.code+`","message":"relay state"}}`), nil
+			})}
+			attempt := PushDeliveryAttempt{ID: "attempt-stable"}
+			device := &PushDevice{
+				APNsEnvironment: APNsEnvironmentSandbox,
+				APNsTopic:       ApplePushTopicSilo,
+				ServerDeviceID:  "server-device-stable",
+			}
+			first := sender.sendWithCapability(context.Background(), attempt, device, strings.Repeat("a", 64), DefaultPushRelayURL, "capability")
+			second := sender.sendWithCapability(context.Background(), attempt, device, strings.Repeat("a", 64), DefaultPushRelayURL, "capability")
+			if first.HTTPStatus != tc.status || first.UpstreamReason != tc.code {
+				t.Fatalf("result = %+v", first)
+			}
+			if retryableHTTPStatus(first.HTTPStatus) != tc.retryable {
+				t.Fatalf("retryable = %v, want %v", retryableHTTPStatus(first.HTTPStatus), tc.retryable)
+			}
+			if second.UpstreamReason != tc.code || len(keys) != 2 || keys[0] != "attempt-stable" || keys[1] != keys[0] {
+				t.Fatalf("retry result = %+v, keys = %#v", second, keys)
+			}
+		})
 	}
 }

--- a/internal/notifications/relay_credentials.go
+++ b/internal/notifications/relay_credentials.go
@@ -1,0 +1,212 @@
+package notifications
+
+import (
+	"bytes"
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"strings"
+	"time"
+)
+
+const (
+	relayRegisterPath = "/v1/deployments/register"
+	relayRotatePath   = "/v1/deployments/rotate"
+	relayRenewPath    = "/v1/deployments/renew"
+	relayRenewBefore  = 7 * 24 * time.Hour
+	relayRenewJitter  = 24 * time.Hour
+)
+
+type RelayHTTPDoer interface {
+	Do(*http.Request) (*http.Response, error)
+}
+
+type RelayCredentialResult struct {
+	Credential PushRelayCredential
+	RequestID  string
+	APNsTopics []string
+}
+
+type relayCredentialResponse struct {
+	RequestID    string   `json:"request_id"`
+	DeploymentID string   `json:"deployment_id"`
+	APIKey       string   `json:"api_key"`
+	KeyPrefix    string   `json:"key_prefix"`
+	APNsTopics   []string `json:"apns_topics"`
+	ExpiresAt    string   `json:"expires_at"`
+}
+
+type relayNestedError struct {
+	Error struct {
+		Code      string `json:"code"`
+		Message   string `json:"message"`
+		RequestID string `json:"request_id"`
+	} `json:"error"`
+}
+
+type RelayCredentialError struct {
+	Status  int
+	Code    string
+	Message string
+}
+
+func (e RelayCredentialError) Error() string { return e.Code }
+
+// NormalizePushRelayURL accepts the official production origin or one exact
+// operator-configured development/staging origin. Capabilities and device
+// tokens must never be sent to an arbitrary URL supplied through the admin UI.
+func NormalizePushRelayURL(raw, developmentOrigin string) (string, error) {
+	value := strings.TrimRight(strings.TrimSpace(raw), "/")
+	if value == "" {
+		value = DefaultPushRelayURL
+	}
+	parsed, err := url.Parse(value)
+	if err != nil || parsed.Scheme != "https" || parsed.Host == "" || parsed.User != nil || parsed.RawQuery != "" || parsed.Fragment != "" || parsed.Path != "" {
+		return "", errors.New("relay_url must be an HTTPS origin")
+	}
+	allowed := map[string]bool{DefaultPushRelayURL: true}
+	if override := strings.TrimRight(strings.TrimSpace(developmentOrigin), "/"); override != "" {
+		allowed[override] = true
+	}
+	if !allowed[value] {
+		return "", errors.New("relay_url is not an allowed Silo relay origin")
+	}
+	return value, nil
+}
+
+func IsLegacyPushRelayKey(value string) bool {
+	return strings.HasPrefix(strings.TrimSpace(value), "rk_")
+}
+
+func LoadPushRelayCredential(ctx context.Context, settings *Settings) PushRelayCredential {
+	return PushRelayCredential{
+		RelayURL:               settings.PushRelayURL(ctx),
+		DeploymentID:           settings.PushRelayDeploymentID(ctx),
+		APIKey:                 settings.PushRelayAPIKey(ctx),
+		ExpiresAt:              settings.PushRelayExpiresAt(ctx),
+		KeyPrefix:              settings.PushRelayKeyPrefix(ctx),
+		ReregistrationRequired: settings.PushRelayReregistrationRequired(ctx),
+	}
+}
+
+func RelayCredentialNeedsRenewal(now, expiresAt time.Time, deploymentID string) bool {
+	if expiresAt.IsZero() {
+		return false
+	}
+	digest := sha256.Sum256([]byte(deploymentID))
+	jitterSeconds := int64(digest[0])<<8 | int64(digest[1])
+	jitter := time.Duration(jitterSeconds) * relayRenewJitter / 65535
+	return !now.Before(expiresAt.Add(-(relayRenewBefore + jitter)))
+}
+
+func RelayRotationIdempotencyKey(deploymentID, capability string) string {
+	digest := sha256.Sum256([]byte("silo-relay-rotation\x00" + deploymentID + "\x00" + capability))
+	return "silo-rotate-" + hex.EncodeToString(digest[:])
+}
+
+func RequestRelayCredential(ctx context.Context, client RelayHTTPDoer, relayURL, path, capability, idempotencyKey string) (RelayCredentialResult, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, relayURL+path, bytes.NewReader([]byte("{}")))
+	if err != nil {
+		return RelayCredentialResult{}, err
+	}
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("User-Agent", "Silo-Server/PushRelayCredential")
+	if capability != "" {
+		req.Header.Set("Authorization", "Bearer "+capability)
+	}
+	if idempotencyKey != "" {
+		req.Header.Set("Idempotency-Key", idempotencyKey)
+	}
+	resp, err := client.Do(req)
+	if err != nil {
+		return RelayCredentialResult{}, RelayCredentialError{Status: http.StatusBadGateway, Code: "relay_unreachable", Message: "Push relay could not be reached"}
+	}
+	defer func() { _ = resp.Body.Close() }()
+	data, readErr := io.ReadAll(io.LimitReader(resp.Body, 16<<10))
+	if readErr != nil {
+		return RelayCredentialResult{}, readErr
+	}
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		var parsed relayNestedError
+		_ = json.Unmarshal(data, &parsed)
+		code := strings.TrimSpace(parsed.Error.Code)
+		if code == "" {
+			code = fmt.Sprintf("relay_http_%d", resp.StatusCode)
+		}
+		message := strings.TrimSpace(parsed.Error.Message)
+		if message == "" {
+			message = http.StatusText(resp.StatusCode)
+		}
+		return RelayCredentialResult{}, RelayCredentialError{Status: resp.StatusCode, Code: code, Message: message}
+	}
+	var parsed relayCredentialResponse
+	if err := json.Unmarshal(data, &parsed); err != nil {
+		return RelayCredentialResult{}, RelayCredentialError{Status: http.StatusBadGateway, Code: "relay_bad_response", Message: "Push relay returned invalid JSON"}
+	}
+	expiresAt, err := time.Parse(time.RFC3339, strings.TrimSpace(parsed.ExpiresAt))
+	if err != nil || strings.TrimSpace(parsed.DeploymentID) == "" || strings.TrimSpace(parsed.APIKey) == "" || strings.TrimSpace(parsed.KeyPrefix) == "" {
+		return RelayCredentialResult{}, RelayCredentialError{Status: http.StatusBadGateway, Code: "relay_bad_response", Message: "Push relay returned an incomplete credential response"}
+	}
+	return RelayCredentialResult{
+		Credential: PushRelayCredential{
+			RelayURL:     relayURL,
+			DeploymentID: strings.TrimSpace(parsed.DeploymentID),
+			APIKey:       strings.TrimSpace(parsed.APIKey),
+			ExpiresAt:    expiresAt,
+			KeyPrefix:    strings.TrimSpace(parsed.KeyPrefix),
+		},
+		RequestID:  parsed.RequestID,
+		APNsTopics: parsed.APNsTopics,
+	}, nil
+}
+
+func RegisterRelayCredential(ctx context.Context, settings *Settings, client RelayHTTPDoer, relayURL string) (RelayCredentialResult, error) {
+	result, err := RequestRelayCredential(ctx, client, relayURL, relayRegisterPath, "", "")
+	if err != nil {
+		return RelayCredentialResult{}, err
+	}
+	if err := settings.UpdatePushRelayCredential(ctx, result.Credential); err != nil {
+		return RelayCredentialResult{}, err
+	}
+	return result, nil
+}
+
+func RotateRelayCredential(ctx context.Context, settings *Settings, client RelayHTTPDoer, current PushRelayCredential) (RelayCredentialResult, error) {
+	key := RelayRotationIdempotencyKey(current.DeploymentID, current.APIKey)
+	result, err := RequestRelayCredential(ctx, client, current.RelayURL, relayRotatePath, current.APIKey, key)
+	if err != nil {
+		return RelayCredentialResult{}, err
+	}
+	if result.Credential.DeploymentID != current.DeploymentID {
+		return RelayCredentialResult{}, RelayCredentialError{Status: http.StatusBadGateway, Code: "relay_bad_response", Message: "Push relay changed the deployment during rotation"}
+	}
+	if err := settings.UpdatePushRelayCredential(ctx, result.Credential); err != nil {
+		return RelayCredentialResult{}, err
+	}
+	return result, nil
+}
+
+func RenewRelayCredential(ctx context.Context, settings *Settings, client RelayHTTPDoer, current PushRelayCredential) (RelayCredentialResult, error) {
+	result, err := RequestRelayCredential(ctx, client, current.RelayURL, relayRenewPath, current.APIKey, "")
+	if err != nil {
+		return RelayCredentialResult{}, err
+	}
+	if result.Credential.DeploymentID != current.DeploymentID {
+		return RelayCredentialResult{}, RelayCredentialError{Status: http.StatusBadGateway, Code: "relay_bad_response", Message: "Push relay changed the deployment during renewal"}
+	}
+	if err := settings.UpdatePushRelayCredential(ctx, result.Credential); err != nil {
+		return RelayCredentialResult{}, err
+	}
+	return result, nil
+}
+
+func MarkRelayReregistrationRequired(ctx context.Context, settings *Settings, current PushRelayCredential) error {
+	current.ReregistrationRequired = true
+	return settings.UpdatePushRelayCredential(ctx, current)
+}

--- a/internal/notifications/relay_credentials_test.go
+++ b/internal/notifications/relay_credentials_test.go
@@ -1,0 +1,198 @@
+package notifications
+
+import (
+	"context"
+	"errors"
+	"io"
+	"net/http"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+)
+
+type relayDoerFunc func(*http.Request) (*http.Response, error)
+
+func (f relayDoerFunc) Do(req *http.Request) (*http.Response, error) { return f(req) }
+
+type relayRoundTripFunc func(*http.Request) (*http.Response, error)
+
+func (f relayRoundTripFunc) RoundTrip(req *http.Request) (*http.Response, error) { return f(req) }
+
+type lockedRelaySettings struct {
+	mu       sync.Mutex
+	values   map[string]string
+	batchErr error
+}
+
+func (s *lockedRelaySettings) Get(_ context.Context, key string) (string, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.values[key], nil
+}
+
+func (s *lockedRelaySettings) Set(_ context.Context, key, value string) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.values[key] = value
+	return nil
+}
+
+func (s *lockedRelaySettings) SetMany(_ context.Context, values map[string]string) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.batchErr != nil {
+		return s.batchErr
+	}
+	for key, value := range values {
+		s.values[key] = value
+	}
+	return nil
+}
+
+func credentialJSON(deploymentID, apiKey string, expiresAt time.Time) string {
+	return `{"request_id":"relay-request","deployment_id":"` + deploymentID +
+		`","api_key":"` + apiKey + `","key_prefix":"cap_v1_test","expires_at":"` +
+		expiresAt.UTC().Format(time.RFC3339) + `"}`
+}
+
+func relayResponse(status int, body string) *http.Response {
+	return &http.Response{
+		StatusCode: status,
+		Header:     make(http.Header),
+		Body:       io.NopCloser(strings.NewReader(body)),
+	}
+}
+
+func TestRotateRelayCredentialReplaysLostResponseWithStableIdempotency(t *testing.T) {
+	current := PushRelayCredential{
+		RelayURL:     DefaultPushRelayURL,
+		DeploymentID: "deployment-rotate",
+		APIKey:       "old.capability.value",
+		ExpiresAt:    time.Now().Add(30 * 24 * time.Hour),
+		KeyPrefix:    "cap_v1_old",
+	}
+	store := &lockedRelaySettings{values: map[string]string{}}
+	settings := NewSettings(store)
+	var keys []string
+	calls := 0
+	doer := relayDoerFunc(func(req *http.Request) (*http.Response, error) {
+		keys = append(keys, req.Header.Get("Idempotency-Key"))
+		calls++
+		if calls == 1 {
+			return nil, io.ErrUnexpectedEOF
+		}
+		return relayResponse(http.StatusOK, credentialJSON(current.DeploymentID, "new.capability.value", time.Now().Add(30*24*time.Hour))), nil
+	})
+
+	if _, err := RotateRelayCredential(context.Background(), settings, doer, current); err == nil {
+		t.Fatal("first rotation unexpectedly succeeded")
+	}
+	result, err := RotateRelayCredential(context.Background(), settings, doer, current)
+	if err != nil {
+		t.Fatalf("rotation replay: %v", err)
+	}
+	if len(keys) != 2 || keys[0] == "" || keys[0] != keys[1] {
+		t.Fatalf("rotation idempotency keys = %#v", keys)
+	}
+	if result.Credential.APIKey != "new.capability.value" {
+		t.Fatalf("rotated capability = %q", result.Credential.APIKey)
+	}
+}
+
+func TestRegisterRelayCredentialDoesNotPartiallyPersist(t *testing.T) {
+	store := &lockedRelaySettings{
+		values:   map[string]string{SettingPushRelayURL: "https://old.example"},
+		batchErr: errors.New("commit failed"),
+	}
+	settings := NewSettings(store)
+	doer := relayDoerFunc(func(*http.Request) (*http.Response, error) {
+		return relayResponse(http.StatusOK, credentialJSON("deployment-new", "new.capability", time.Now().Add(30*24*time.Hour))), nil
+	})
+	if _, err := RegisterRelayCredential(context.Background(), settings, doer, DefaultPushRelayURL); err == nil {
+		t.Fatal("registration unexpectedly persisted")
+	}
+	if got := store.values[SettingPushRelayURL]; got != "https://old.example" || len(store.values) != 1 {
+		t.Fatalf("partial credential state = %#v", store.values)
+	}
+}
+
+func TestPushSenderProactivelyRenewsOnceConcurrently(t *testing.T) {
+	now := time.Date(2026, 7, 10, 12, 0, 0, 0, time.UTC)
+	store := &lockedRelaySettings{values: map[string]string{
+		SettingPushRelayURL:          DefaultPushRelayURL,
+		SettingPushRelayDeploymentID: "deployment-renew",
+		SettingPushRelayAPIKey:       "old.capability",
+		SettingPushRelayExpiresAt:    now.Add(6 * 24 * time.Hour).Format(time.RFC3339),
+		SettingPushRelayKeyPrefix:    "cap_v1_old",
+	}}
+	renewals := 0
+	var mu sync.Mutex
+	sender := newPushSender(nil, nil, nil, NewSettings(store))
+	sender.now = func() time.Time { return now }
+	sender.client = &http.Client{Transport: relayRoundTripFunc(func(req *http.Request) (*http.Response, error) {
+		if req.URL.Path != relayRenewPath {
+			t.Fatalf("path = %q", req.URL.Path)
+		}
+		mu.Lock()
+		renewals++
+		mu.Unlock()
+		return relayResponse(http.StatusOK, credentialJSON("deployment-renew", "renewed.capability", now.Add(30*24*time.Hour))), nil
+	})}
+
+	var wg sync.WaitGroup
+	for range 8 {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			credential, err := sender.prepareRelayCredential(context.Background())
+			if err != nil || credential.APIKey != "renewed.capability" {
+				t.Errorf("credential = %+v, err = %v", credential, err)
+			}
+		}()
+	}
+	wg.Wait()
+	if renewals != 1 {
+		t.Fatalf("renewal requests = %d, want 1", renewals)
+	}
+}
+
+func TestPushSenderMigratesOnlyLegacyRelayKeys(t *testing.T) {
+	store := &lockedRelaySettings{values: map[string]string{
+		SettingPushRelayURL:    DefaultPushRelayURL,
+		SettingPushRelayAPIKey: "rk_legacy_database_key",
+	}}
+	registrations := 0
+	sender := newPushSender(nil, nil, nil, NewSettings(store))
+	sender.client = &http.Client{Transport: relayRoundTripFunc(func(req *http.Request) (*http.Response, error) {
+		if req.URL.Path != relayRegisterPath || req.Header.Get("Authorization") != "" {
+			t.Fatalf("legacy migration request = %s auth=%q", req.URL.Path, req.Header.Get("Authorization"))
+		}
+		registrations++
+		return relayResponse(http.StatusOK, credentialJSON("deployment-migrated", "modern.capability", time.Now().Add(30*24*time.Hour))), nil
+	})}
+	credential, err := sender.prepareRelayCredential(context.Background())
+	if err != nil || credential.APIKey != "modern.capability" || registrations != 1 {
+		t.Fatalf("credential = %+v, registrations = %d, err = %v", credential, registrations, err)
+	}
+
+	store.values[SettingPushRelayAPIKey] = "revoked.modern.capability"
+	store.values[SettingPushRelayReregister] = "true"
+	sender.settings.Invalidate(SettingPushRelayAPIKey, SettingPushRelayReregister)
+	if _, err := sender.prepareRelayCredential(context.Background()); err == nil {
+		t.Fatal("revoked modern capability silently re-registered")
+	}
+	if registrations != 1 {
+		t.Fatalf("registrations after modern revocation = %d", registrations)
+	}
+}
+
+func TestNormalizePushRelayURLRequiresAllowlistedOrigin(t *testing.T) {
+	staging := "https://silo-push-relay-staging.arkyn.workers.dev"
+	if got, err := NormalizePushRelayURL(staging, staging); err != nil || got != staging {
+		t.Fatalf("staging override = %q, %v", got, err)
+	}
+	if _, err := NormalizePushRelayURL("https://attacker.example", staging); err == nil {
+		t.Fatal("arbitrary relay origin accepted")
+	}
+}

--- a/internal/notifications/settings.go
+++ b/internal/notifications/settings.go
@@ -2,6 +2,7 @@ package notifications
 
 import (
 	"context"
+	"errors"
 	"strconv"
 	"strings"
 	"sync"
@@ -13,6 +14,10 @@ import (
 // locally to avoid a catalog dependency.
 type SettingReader interface {
 	Get(ctx context.Context, key string) (string, error)
+}
+
+type settingBatchWriter interface {
+	SetMany(ctx context.Context, values map[string]string) error
 }
 
 // Server-setting keys for the notification system. All keys are live (no
@@ -55,6 +60,9 @@ const (
 	SettingPushRelayURL             = "notifications.push_relay_url"
 	SettingPushRelayDeploymentID    = "notifications.push_relay_deployment_id"
 	SettingPushRelayAPIKey          = "notifications.push_relay_api_key"
+	SettingPushRelayExpiresAt       = "notifications.push_relay_expires_at"
+	SettingPushRelayKeyPrefix       = "notifications.push_relay_key_prefix"
+	SettingPushRelayReregister      = "notifications.push_relay_reregistration_required"
 
 	// Discord application credentials live under the discord.* namespace
 	// (admin-configured, alongside email.smtp_*). The secret and bot token
@@ -156,6 +164,51 @@ func (s *Settings) Invalidate(keys ...string) {
 		delete(s.cache, key)
 	}
 	s.mu.Unlock()
+}
+
+// PushRelayCredential is the complete persisted identity of one relay
+// capability generation. It must always be replaced as one atomic unit.
+type PushRelayCredential struct {
+	RelayURL               string
+	DeploymentID           string
+	APIKey                 string
+	ExpiresAt              time.Time
+	KeyPrefix              string
+	ReregistrationRequired bool
+}
+
+// UpdatePushRelayCredential atomically persists all fields that identify a
+// relay credential. Production requires a batch-capable settings repository;
+// refusing a sequential fallback is what preserves the invariant.
+func (s *Settings) UpdatePushRelayCredential(ctx context.Context, credential PushRelayCredential) error {
+	if s == nil || s.reader == nil {
+		return errors.New("push relay settings are unavailable")
+	}
+	writer, ok := s.reader.(settingBatchWriter)
+	if !ok {
+		return errors.New("push relay settings do not support atomic writes")
+	}
+	expiresAt := ""
+	if !credential.ExpiresAt.IsZero() {
+		expiresAt = credential.ExpiresAt.UTC().Format(time.RFC3339)
+	}
+	values := map[string]string{
+		SettingPushRelayURL:          strings.TrimRight(strings.TrimSpace(credential.RelayURL), "/"),
+		SettingPushRelayDeploymentID: strings.TrimSpace(credential.DeploymentID),
+		SettingPushRelayAPIKey:       strings.TrimSpace(credential.APIKey),
+		SettingPushRelayExpiresAt:    expiresAt,
+		SettingPushRelayKeyPrefix:    strings.TrimSpace(credential.KeyPrefix),
+		SettingPushRelayReregister:   strconv.FormatBool(credential.ReregistrationRequired),
+	}
+	if err := writer.SetMany(ctx, values); err != nil {
+		return err
+	}
+	keys := make([]string, 0, len(values))
+	for key := range values {
+		keys = append(keys, key)
+	}
+	s.Invalidate(keys...)
+	return nil
 }
 
 func (s *Settings) boolSetting(ctx context.Context, key string, fallback bool) bool {
@@ -382,6 +435,24 @@ func (s *Settings) PushRelayAPIKey(ctx context.Context) string {
 // subsequent key rotations.
 func (s *Settings) PushRelayDeploymentID(ctx context.Context) string {
 	return strings.TrimSpace(s.raw(ctx, SettingPushRelayDeploymentID))
+}
+
+func (s *Settings) PushRelayExpiresAt(ctx context.Context) time.Time {
+	value := strings.TrimSpace(s.raw(ctx, SettingPushRelayExpiresAt))
+	parsed, err := time.Parse(time.RFC3339, value)
+	if err != nil {
+		return time.Time{}
+	}
+	return parsed
+}
+
+func (s *Settings) PushRelayKeyPrefix(ctx context.Context) string {
+	return strings.TrimSpace(s.raw(ctx, SettingPushRelayKeyPrefix))
+}
+
+func (s *Settings) PushRelayReregistrationRequired(ctx context.Context) bool {
+	value, _ := strconv.ParseBool(strings.TrimSpace(s.raw(ctx, SettingPushRelayReregister)))
+	return value
 }
 
 // DiscordClientID is the Discord application's OAuth2 client ID.

--- a/web/src/pages/admin-settings/NotificationsAdminSettings.test.tsx
+++ b/web/src/pages/admin-settings/NotificationsAdminSettings.test.tsx
@@ -32,6 +32,10 @@ function makeForm() {
           return "https://push.siloserver.org";
         case "notifications.push_relay_deployment_id":
           return "01DEPLOYMENT";
+        case "notifications.push_relay_key_prefix":
+          return "cap_v1_test";
+        case "notifications.push_relay_expires_at":
+          return "2026-08-10T00:00:00Z";
         default:
           return "";
       }
@@ -76,6 +80,9 @@ describe("NotificationsAdminSettings", () => {
       keys: expect.arrayContaining([
         "notifications.apple_push_delivery_enabled",
         "notifications.push_relay_deployment_id",
+        "notifications.push_relay_expires_at",
+        "notifications.push_relay_key_prefix",
+        "notifications.push_relay_reregistration_required",
       ]),
     });
     const firstCall = useSettingsFormMock.mock.calls[0];
@@ -84,9 +91,7 @@ describe("NotificationsAdminSettings", () => {
     }
     const [options] = firstCall as [{ keys: string[] }];
     expect(options.keys).not.toContain("notifications.push_relay_api_key");
-    // The relay URL is persisted only via the registration endpoint, never
-    // through the settings form.
-    expect(options.keys).not.toContain("notifications.push_relay_url");
+    expect(options.keys).toContain("notifications.push_relay_url");
   });
 
   it("shows the Silo Push Relay channel status", async () => {
@@ -106,7 +111,9 @@ describe("NotificationsAdminSettings", () => {
     expect(screen.getByText(/does not receive notification titles/)).toBeInTheDocument();
     expect(screen.getByText(/fetches private content directly/)).toBeInTheDocument();
     expect(screen.getByText("Deployment ID")).toBeInTheDocument();
-    expect(screen.getByText("Rotate relay key")).toBeInTheDocument();
+    expect(screen.getByText("Rotate credential")).toBeInTheDocument();
+    expect(screen.getByText("Credential: cap_v1_test")).toBeInTheDocument();
+    expect(screen.getByText(/Silo renews automatically/)).toBeInTheDocument();
     expect(screen.queryByText("Relay API Key")).not.toBeInTheDocument();
     expect(screen.queryByText("Smoke Test Profile ID")).not.toBeInTheDocument();
     expect(screen.queryByText("Server Device ID")).not.toBeInTheDocument();

--- a/web/src/pages/admin-settings/NotificationsAdminSettings.tsx
+++ b/web/src/pages/admin-settings/NotificationsAdminSettings.tsx
@@ -45,10 +45,13 @@ const KEYS = [
   "notifications.webhooks_enabled",
   "notifications.web_push_enabled",
   "notifications.apple_push_delivery_enabled",
-  // notifications.push_relay_url is intentionally absent: the server rejects
-  // direct writes; the relay URL is persisted by the registration endpoint
-  // together with the deployment id and API key.
+  // Relay lifecycle fields are read for status but are never edited through
+  // the shared settings form; credential endpoints replace them atomically.
+  "notifications.push_relay_url",
   "notifications.push_relay_deployment_id",
+  "notifications.push_relay_expires_at",
+  "notifications.push_relay_key_prefix",
+  "notifications.push_relay_reregistration_required",
   "notifications.fanout.settle_seconds",
   "notifications.fanout.max_series_burst",
   "notifications.fanout.max_event_age_hours",
@@ -87,6 +90,7 @@ interface AppleRelayRegisterResult {
   api_key_configured: boolean;
   relay_request_id?: string;
   apns_topics?: string[];
+  expires_at: string;
 }
 
 const DEFAULT_PUSH_RELAY_URL = "https://push.siloserver.org";
@@ -430,11 +434,17 @@ function TestDiscordRow({ unsaved }: { unsaved: boolean }) {
 function RegisterRelayRow({
   relayURL,
   deploymentID,
+  keyPrefix,
+  expiresAt,
+  reregistrationRequired,
   urlEdited,
   onRegistered,
 }: {
   relayURL: string;
   deploymentID: string;
+  keyPrefix: string;
+  expiresAt: string;
+  reregistrationRequired: boolean;
   urlEdited: boolean;
   onRegistered: () => void;
 }) {
@@ -443,6 +453,20 @@ function RegisterRelayRow({
   const [result, setResult] = useState<AppleRelayRegisterResult | null>(null);
 
   const configured = deploymentID.trim() !== "";
+  const actionLabel = reregistrationRequired
+    ? "Re-register relay"
+    : configured
+      ? "Rotate credential"
+      : "Register relay";
+  const expiration = expiresAt ? new Date(expiresAt) : null;
+  const expirationValid = expiration != null && !Number.isNaN(expiration.getTime());
+  const renewalStatus = expirationValid
+    ? expiration.getTime() <= Date.now()
+      ? "Expired; Silo will renew before the next delivery when the relay grace period permits."
+      : `Expires ${expiration.toLocaleString()}; Silo renews automatically during the final week with per-server jitter.`
+    : configured
+      ? "Expiration is unknown; the credential will be refreshed on its next lifecycle operation."
+      : "No relay credential is registered.";
 
   const registerRelay = async () => {
     if (pending) return;
@@ -491,8 +515,18 @@ function RegisterRelayRow({
           ) : (
             <KeyRound className="mr-1.5 h-3.5 w-3.5" />
           )}
-          {configured ? "Rotate relay key" : "Register relay"}
+          {actionLabel}
         </Button>
+      </div>
+      {reregistrationRequired && (
+        <div className="text-xs text-amber-500">
+          The current capability was rejected or revoked. Automatic registration is disabled;
+          re-register explicitly to create a new relay deployment.
+        </div>
+      )}
+      <div className="text-muted-foreground space-y-1 text-xs">
+        {keyPrefix && <div>Credential: {keyPrefix}</div>}
+        <div>{renewalStatus}</div>
       </div>
       {urlEdited && (
         <div className="text-muted-foreground text-xs">
@@ -501,7 +535,7 @@ function RegisterRelayRow({
       )}
       {result && (
         <div className="text-xs text-emerald-500">
-          Registered {result.deployment_id}
+          Credential ready for {result.deployment_id}
           {result.key_prefix ? ` — key ${result.key_prefix}` : ""}
           {result.relay_request_id ? ` — relay ${result.relay_request_id}` : ""}
         </div>
@@ -586,6 +620,10 @@ export default function NotificationsAdminSettings() {
   const pushRelayURL = pushRelayURLDraft ?? savedPushRelayURL;
   const pushRelayURLEdited = pushRelayURL !== savedPushRelayURL;
   const pushRelayDeploymentID = form.getValue("notifications.push_relay_deployment_id");
+  const pushRelayKeyPrefix = form.getValue("notifications.push_relay_key_prefix");
+  const pushRelayExpiresAt = form.getValue("notifications.push_relay_expires_at");
+  const pushRelayReregistrationRequired =
+    form.getValue("notifications.push_relay_reregistration_required") === "true";
   const pushRelayAPIKeyReady = form.sensitiveConfigured.includes(
     "notifications.push_relay_api_key",
   );
@@ -721,7 +759,9 @@ export default function NotificationsAdminSettings() {
             enabled={applePushOn}
             onEnabledChange={setToggle("notifications.apple_push_delivery_enabled")}
             chips={
-              pushRelayAPIKeyReady ? (
+              pushRelayReregistrationRequired ? (
+                <Chip tone="warning">Re-registration required</Chip>
+              ) : pushRelayAPIKeyReady ? (
                 <Chip tone="positive">Relay configured</Chip>
               ) : (
                 <Chip tone={applePushOn ? "warning" : "neutral"}>Relay registration required</Chip>
@@ -740,6 +780,9 @@ export default function NotificationsAdminSettings() {
               <RegisterRelayRow
                 relayURL={pushRelayURL}
                 deploymentID={pushRelayDeploymentID}
+                keyPrefix={pushRelayKeyPrefix}
+                expiresAt={pushRelayExpiresAt}
+                reregistrationRequired={pushRelayReregistrationRequired}
                 urlEdited={pushRelayURLEdited}
                 onRegistered={() => setPushRelayURLDraft(null)}
               />


### PR DESCRIPTION
## Problem

Silo's Apple push relay integration could register capabilities, but credential rotation still created a new anonymous deployment, renewal was reactive-only, and sequential settings writes could leave mismatched credential state after partial failure. Legacy `rk_` credentials also need a safe migration path before the hosted relay moves to the Worker.

## Approach

- add a shared relay credential lifecycle for registration, authenticated rotation, renewal, and legacy migration
- rotate through `/v1/deployments/rotate` with a deterministic idempotency key so lost responses replay the same credential
- renew proactively during the final week with deterministic per-deployment jitter, while retaining reactive `token_expired` recovery
- persist relay URL, deployment ID, encrypted capability, expiration, key prefix, and re-registration status in one PostgreSQL transaction
- auto-register only legacy `rk_` credentials; rejected modern capabilities require explicit admin re-registration
- restrict relay destinations to `https://push.siloserver.org` plus an exact operator-configured `SILO_PUSH_RELAY_DEVELOPMENT_URL`
- update the admin UI to distinguish registration, rotation, and re-registration while showing safe expiration/renewal state
- keep one delivery-attempt idempotency key across transport, renewal, and outbox retries

## Verification

- `GOWORK=off go test -race ./internal/notifications ./internal/api/handlers ./internal/catalog`
- `cd web && pnpm exec vitest run src/pages/admin-settings/NotificationsAdminSettings.test.tsx`
- `cd web && pnpm run lint` (0 errors; existing repository warnings only)
- `cd web && pnpm run format:check`
- `make verify-local-paths`
- production frontend build completed during the dev image build

Live integration against the explicitly configured staging Worker origin:

- deployed the branch to the development Silo Server
- migrated the existing encrypted legacy relay credential through the admin registration endpoint
- verified all credential fields were persisted together and the capability remained encrypted
- sent an admin test notification to a real sandbox Apple device
- delivery completed on the first attempt with relay HTTP 200

## Risks and rollout

- `push.siloserver.org` and production DNS are unchanged; production must not move to the Worker until the compatibility window is ready
- staging/custom relay use requires the explicit development override; arbitrary HTTPS relay destinations are rejected
- no Apple-client API changes are required
- existing `/api/v1` behavior remains additive-only

Part of #135

## AI use disclosure

Implemented and verified with OpenAI Codex under human direction.
