### PR TITLE
fix(history-import): import Emby favorites

### DIFF
--- a/internal/access/resolver_test.go
+++ b/internal/access/resolver_test.go
@@ -124,7 +124,7 @@ func (s stubStore) DeleteHomeDismissal(context.Context, string, string, string) 
 	panic("unused")
 }
 func (s stubStore) AddFavorite(context.Context, string, string) error { panic("unused") }
-func (s stubStore) AddFavoriteAt(context.Context, string, string, time.Time) error {
+func (s stubStore) AddFavoriteAt(context.Context, string, string, time.Time) (bool, error) {
 	panic("unused")
 }
 func (s stubStore) RemoveFavorite(context.Context, string, string) error {

--- a/internal/historyimport/emby_client.go
+++ b/internal/historyimport/emby_client.go
@@ -200,11 +200,19 @@ func (c *EmbyClient) AuthenticateServerUser(ctx context.Context, baseURL, userna
 }
 
 func (c *EmbyClient) FetchItems(ctx context.Context, auth embyLocalAuth, filter string) ([]embyItem, error) {
+	return c.fetchItems(ctx, auth, filter, "Movie,Episode")
+}
+
+func (c *EmbyClient) FetchFavoriteItems(ctx context.Context, auth embyLocalAuth) ([]embyItem, error) {
+	return c.fetchItems(ctx, auth, "IsFavorite", "Movie,Series")
+}
+
+func (c *EmbyClient) fetchItems(ctx context.Context, auth embyLocalAuth, filter, includeItemTypes string) ([]embyItem, error) {
 	query := url.Values{}
 	query.Set("Recursive", "true")
 	query.Set("EnableUserData", "true")
 	query.Set("Fields", "ProviderIds")
-	query.Set("IncludeItemTypes", "Movie,Episode")
+	query.Set("IncludeItemTypes", includeItemTypes)
 	query.Set("Filters", filter)
 	path := fmt.Sprintf("%s/Users/%s/Items?%s", auth.BaseURL, url.PathEscape(auth.UserID), query.Encode())
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, path, nil)

--- a/internal/historyimport/emby_favorites_test.go
+++ b/internal/historyimport/emby_favorites_test.go
@@ -1,0 +1,77 @@
+package historyimport
+
+import (
+	"context"
+	"testing"
+
+	"github.com/Silo-Server/silo-server/internal/userstore/pgstore"
+)
+
+func TestEmbyFavoriteOnlyRecordAddsFavoriteWithoutProgress(t *testing.T) {
+	ctx := context.Background()
+	pool := newPlexWatchlistImportTestPool(t)
+	repo := NewRepository(pool, nil)
+	service := &Service{
+		repo:         repo,
+		matcher:      NewMatcher(repo),
+		stores:       pgstore.NewPostgresProvider(pool),
+		bgContext:    ctx,
+		runSemaphore: make(chan struct{}, maxConcurrentRuns),
+		runCancels:   make(map[string]context.CancelFunc),
+	}
+
+	if _, err := pool.Exec(ctx, `
+		INSERT INTO media_items (content_id, type, title, year, tvdb_id, status)
+		VALUES ($1, $2, $3, $4, $5, $6)`,
+		"series-371980", KindSeries, "Severance", 2022, "371980", "matched",
+	); err != nil {
+		t.Fatalf("seed media item: %v", err)
+	}
+	run, err := repo.CreateRun(ctx, Run{
+		ID:               "emby-favorites-run",
+		UserID:           42,
+		ProfileID:        "profile-1",
+		SourceType:       SourceTypeEmby,
+		ConnectionMode:   ConnectionModeCustom,
+		Status:           RunStatusQueued,
+		Warnings:         []string{},
+		UnmatchedSamples: []UnmatchedSample{},
+	})
+	if err != nil {
+		t.Fatalf("CreateRun: %v", err)
+	}
+
+	record := Record{
+		ExternalID:   "emby-series-1",
+		Kind:         KindSeries,
+		Title:        "Severance",
+		Year:         2022,
+		TVDBID:       "371980",
+		Favorite:     true,
+		FavoriteOnly: true,
+	}
+	service.executeRun(run, staticWatchlistProvider{records: []Record{record, record}})
+
+	completed, err := repo.GetRunForUser(ctx, 42, run.ID)
+	if err != nil {
+		t.Fatalf("GetRunForUser: %v", err)
+	}
+	if completed.Status != RunStatusCompleted {
+		t.Fatalf("run status = %q, want %q; warnings=%v", completed.Status, RunStatusCompleted, completed.Warnings)
+	}
+	if completed.FavoritesImported != 1 || completed.ProgressUpdated != 0 || completed.HistoryCreated != 0 {
+		t.Fatalf("run counters = favorites:%d progress:%d history:%d, want 1/0/0",
+			completed.FavoritesImported, completed.ProgressUpdated, completed.HistoryCreated)
+	}
+	var rows int
+	if err := pool.QueryRow(ctx, `
+		SELECT COUNT(*) FROM user_favorites
+		WHERE user_id = $1 AND profile_id = $2 AND media_item_id = $3`,
+		42, "profile-1", "series-371980",
+	).Scan(&rows); err != nil {
+		t.Fatalf("count favorite rows: %v", err)
+	}
+	if rows != 1 {
+		t.Fatalf("favorite rows = %d, want 1", rows)
+	}
+}

--- a/internal/historyimport/emby_favorites_test.go
+++ b/internal/historyimport/emby_favorites_test.go
@@ -3,9 +3,30 @@ package historyimport
 import (
 	"context"
 	"testing"
+	"time"
 
+	"github.com/Silo-Server/silo-server/internal/userstore"
 	"github.com/Silo-Server/silo-server/internal/userstore/pgstore"
 )
+
+func TestAddFavoriteUsesAtomicInsertResult(t *testing.T) {
+	store := &favoriteInsertTestStore{}
+	service := &Service{stores: favoriteInsertTestProvider{store: store}}
+
+	inserted, err := service.addFavorite(context.Background(), 42, "profile-1", "movie-1")
+	if err != nil {
+		t.Fatalf("addFavorite: %v", err)
+	}
+	if inserted {
+		t.Fatal("addFavorite reported an existing favorite as newly inserted")
+	}
+	if store.addCalls != 1 {
+		t.Fatalf("AddFavoriteAt calls = %d, want 1", store.addCalls)
+	}
+	if store.isFavoriteCalls != 0 {
+		t.Fatalf("IsFavorite calls = %d, want 0", store.isFavoriteCalls)
+	}
+}
 
 func TestEmbyFavoriteOnlyRecordAddsFavoriteWithoutProgress(t *testing.T) {
 	ctx := context.Background()
@@ -74,4 +95,30 @@ func TestEmbyFavoriteOnlyRecordAddsFavoriteWithoutProgress(t *testing.T) {
 	if rows != 1 {
 		t.Fatalf("favorite rows = %d, want 1", rows)
 	}
+}
+
+type favoriteInsertTestProvider struct {
+	store userstore.UserStore
+}
+
+func (p favoriteInsertTestProvider) ForUser(context.Context, int) (userstore.UserStore, error) {
+	return p.store, nil
+}
+
+func (favoriteInsertTestProvider) Close() error { return nil }
+
+type favoriteInsertTestStore struct {
+	userstore.UserStore
+	addCalls        int
+	isFavoriteCalls int
+}
+
+func (s *favoriteInsertTestStore) AddFavoriteAt(context.Context, string, string, time.Time) (bool, error) {
+	s.addCalls++
+	return false, nil
+}
+
+func (s *favoriteInsertTestStore) IsFavorite(context.Context, string, string) (bool, error) {
+	s.isFavoriteCalls++
+	return false, nil
 }

--- a/internal/historyimport/emby_provider.go
+++ b/internal/historyimport/emby_provider.go
@@ -28,8 +28,10 @@ func (p *EmbyProvider) Fetch(ctx context.Context) ([]Record, []string, error) {
 		return nil, nil, err
 	}
 	favoriteItems, err := p.client.FetchFavoriteItems(ctx, p.auth)
+	var warnings []string
 	if err != nil {
-		return nil, nil, err
+		warnings = append(warnings, "fetching Emby favorites: "+err.Error())
+		favoriteItems = nil
 	}
 
 	seriesMeta, err := p.fetchSeriesMetadata(ctx, append(playedItems, resumableItems...))
@@ -67,7 +69,7 @@ func (p *EmbyProvider) Fetch(ctx context.Context) ([]Record, []string, error) {
 	for _, record := range merged {
 		records = append(records, record)
 	}
-	return records, nil, nil
+	return records, warnings, nil
 }
 
 func (p *EmbyProvider) fetchSeriesMetadata(ctx context.Context, items []embyItem) (map[string]embyItem, error) {

--- a/internal/historyimport/emby_provider.go
+++ b/internal/historyimport/emby_provider.go
@@ -27,18 +27,34 @@ func (p *EmbyProvider) Fetch(ctx context.Context) ([]Record, []string, error) {
 	if err != nil {
 		return nil, nil, err
 	}
+	favoriteItems, err := p.client.FetchFavoriteItems(ctx, p.auth)
+	if err != nil {
+		return nil, nil, err
+	}
 
 	seriesMeta, err := p.fetchSeriesMetadata(ctx, append(playedItems, resumableItems...))
 	if err != nil {
 		return nil, nil, err
 	}
 
-	merged := make(map[string]Record, len(playedItems)+len(resumableItems))
+	merged := make(map[string]Record, len(playedItems)+len(resumableItems)+len(favoriteItems))
 	for _, item := range append(playedItems, resumableItems...) {
 		record := normalizeEmbyItem(item, seriesMeta[item.SeriesID])
 		if record.ExternalID == "" {
 			record.ExternalID = item.ID
 		}
+		existing, ok := merged[record.ExternalID]
+		if !ok {
+			merged[record.ExternalID] = record
+			continue
+		}
+		merged[record.ExternalID] = mergeRecords(existing, record)
+	}
+	for _, item := range favoriteItems {
+		record := normalizeEmbyItem(item, embyItem{})
+		record.Favorite = true
+		record.FavoriteOnly = true
+		record.PreferTMDB = true
 		existing, ok := merged[record.ExternalID]
 		if !ok {
 			merged[record.ExternalID] = record
@@ -126,6 +142,13 @@ func mergeRecords(a, b Record) Record {
 	if b.Played {
 		result.Played = true
 	}
+	if b.Favorite {
+		result.Favorite = true
+	}
+	if b.PreferTMDB {
+		result.PreferTMDB = true
+	}
+	result.FavoriteOnly = result.FavoriteOnly && b.FavoriteOnly
 	if b.PlayCount > result.PlayCount {
 		result.PlayCount = b.PlayCount
 	}

--- a/internal/historyimport/emby_provider_test.go
+++ b/internal/historyimport/emby_provider_test.go
@@ -67,9 +67,56 @@ func TestEmbyProviderFetchIncludesMovieAndSeriesFavorites(t *testing.T) {
 	if !movie.Favorite || movie.FavoriteOnly {
 		t.Fatalf("merged movie flags = favorite:%v favoriteOnly:%v, want true/false", movie.Favorite, movie.FavoriteOnly)
 	}
+	if !movie.PreferTMDB {
+		t.Fatalf("movie PreferTMDB = %v, want true", movie.PreferTMDB)
+	}
 	series := byID["series-1"]
 	if series.Kind != KindSeries || !series.Favorite || !series.FavoriteOnly {
 		t.Fatalf("series record = %+v, want favorite-only series", series)
+	}
+	if !series.PreferTMDB {
+		t.Fatalf("series PreferTMDB = %v, want true", series.PreferTMDB)
+	}
+}
+
+func TestEmbyProviderFetchContinuesWhenFavoritesFail(t *testing.T) {
+	t.Parallel()
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Query().Get("Filters") {
+		case "IsPlayed":
+			w.Header().Set("Content-Type", "application/json")
+			if err := json.NewEncoder(w).Encode(embyItemsResponse{Items: []embyItem{{
+				ID: "movie-1", Name: "Arrival", Type: "Movie", ProductionYear: 2016,
+				ProviderIDs: map[string]string{"Tmdb": "329865"},
+			}}}); err != nil {
+				t.Errorf("encode response: %v", err)
+			}
+		case "IsResumable":
+			w.Header().Set("Content-Type", "application/json")
+			if err := json.NewEncoder(w).Encode(embyItemsResponse{}); err != nil {
+				t.Errorf("encode response: %v", err)
+			}
+		case "IsFavorite":
+			http.Error(w, "favorites unavailable", http.StatusInternalServerError)
+		default:
+			w.WriteHeader(http.StatusBadRequest)
+		}
+	}))
+	defer server.Close()
+
+	provider := NewEmbyProvider(NewEmbyClient(), embyLocalAuth{
+		BaseURL: server.URL, UserID: "emby-user", AccessToken: "token",
+	})
+	records, warnings, err := provider.Fetch(context.Background())
+	if err != nil {
+		t.Fatalf("Fetch: %v", err)
+	}
+	if len(records) != 1 || records[0].ExternalID != "movie-1" {
+		t.Fatalf("records = %+v, want played movie preserved", records)
+	}
+	if len(warnings) != 1 {
+		t.Fatalf("warnings = %v, want one favorites warning", warnings)
 	}
 }
 

--- a/internal/historyimport/emby_provider_test.go
+++ b/internal/historyimport/emby_provider_test.go
@@ -1,9 +1,77 @@
 package historyimport
 
 import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
 	"testing"
 	"time"
 )
+
+func TestEmbyProviderFetchIncludesMovieAndSeriesFavorites(t *testing.T) {
+	t.Parallel()
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if got := r.URL.Query().Get("EnableUserData"); got != "true" {
+			t.Errorf("EnableUserData = %q, want true", got)
+		}
+		var items []embyItem
+		switch filter := r.URL.Query().Get("Filters"); filter {
+		case "IsPlayed":
+			items = []embyItem{{
+				ID: "movie-1", Name: "Arrival", Type: "Movie", ProductionYear: 2016,
+				ProviderIDs: map[string]string{"Tmdb": "329865"},
+			}}
+		case "IsResumable":
+			items = []embyItem{}
+		case "IsFavorite":
+			if got := r.URL.Query().Get("IncludeItemTypes"); got != "Movie,Series" {
+				t.Errorf("favorite IncludeItemTypes = %q, want Movie,Series", got)
+			}
+			items = []embyItem{
+				{ID: "movie-1", Name: "Arrival", Type: "Movie", ProductionYear: 2016, ProviderIDs: map[string]string{"Tmdb": "329865"}},
+				{ID: "series-1", Name: "Severance", Type: "Series", ProductionYear: 2022, ProviderIDs: map[string]string{"Tvdb": "371980"}},
+			}
+		default:
+			t.Errorf("unexpected filter %q", filter)
+			w.WriteHeader(http.StatusBadRequest)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		if err := json.NewEncoder(w).Encode(embyItemsResponse{Items: items}); err != nil {
+			t.Errorf("encode response: %v", err)
+		}
+	}))
+	defer server.Close()
+
+	provider := NewEmbyProvider(NewEmbyClient(), embyLocalAuth{
+		BaseURL: server.URL, UserID: "emby-user", AccessToken: "token",
+	})
+	records, warnings, err := provider.Fetch(context.Background())
+	if err != nil {
+		t.Fatalf("Fetch: %v", err)
+	}
+	if len(warnings) != 0 {
+		t.Fatalf("warnings = %v, want none", warnings)
+	}
+	if len(records) != 2 {
+		t.Fatalf("records = %d, want 2", len(records))
+	}
+
+	byID := make(map[string]Record, len(records))
+	for _, record := range records {
+		byID[record.ExternalID] = record
+	}
+	movie := byID["movie-1"]
+	if !movie.Favorite || movie.FavoriteOnly {
+		t.Fatalf("merged movie flags = favorite:%v favoriteOnly:%v, want true/false", movie.Favorite, movie.FavoriteOnly)
+	}
+	series := byID["series-1"]
+	if series.Kind != KindSeries || !series.Favorite || !series.FavoriteOnly {
+		t.Fatalf("series record = %+v, want favorite-only series", series)
+	}
+}
 
 func TestNormalizeEmbyItemWithoutLastPlayedDateHasNoFreshnessTimestamp(t *testing.T) {
 	t.Parallel()

--- a/internal/historyimport/matcher.go
+++ b/internal/historyimport/matcher.go
@@ -35,7 +35,7 @@ func (m *Matcher) Match(ctx context.Context, record Record) (*Match, string, err
 }
 
 func (m *Matcher) matchMovie(ctx context.Context, record Record) (*Match, string, error) {
-	match, reason, err := m.matchMedia(ctx, KindMovie, record.TMDBID, record.IMDbID, "", record.Title, record.Year)
+	match, reason, err := m.matchMedia(ctx, KindMovie, record.TMDBID, record.IMDbID, "", record.Title, record.Year, false)
 	if err != nil {
 		return nil, "", err
 	}
@@ -43,7 +43,7 @@ func (m *Matcher) matchMovie(ctx context.Context, record Record) (*Match, string
 }
 
 func (m *Matcher) matchSeries(ctx context.Context, record Record) (*Match, string, error) {
-	match, reason, err := m.matchMedia(ctx, KindSeries, record.TMDBID, record.IMDbID, record.TVDBID, record.Title, record.Year)
+	match, reason, err := m.matchMedia(ctx, KindSeries, record.TMDBID, record.IMDbID, record.TVDBID, record.Title, record.Year, record.PreferTMDB)
 	if err != nil {
 		return nil, "", err
 	}
@@ -115,7 +115,7 @@ func (m *Matcher) matchEpisode(ctx context.Context, record Record) (*Match, stri
 	return match, "", nil
 }
 
-func (m *Matcher) matchMedia(ctx context.Context, kind, tmdbID, imdbID, tvdbID, title string, year int) (*Match, string, error) {
+func (m *Matcher) matchMedia(ctx context.Context, kind, tmdbID, imdbID, tvdbID, title string, year int, preferTMDB bool) (*Match, string, error) {
 	attempts := make([]string, 0, 4)
 	candidates := []struct {
 		column string
@@ -134,6 +134,9 @@ func (m *Matcher) matchMedia(ctx context.Context, kind, tmdbID, imdbID, tvdbID, 
 			{column: "tvdb_id", value: tvdbID, label: "tvdb_id"},
 			{column: "tmdb_id", value: tmdbID, label: "tmdb_id"},
 			{column: "imdb_id", value: imdbID, label: "imdb_id"},
+		}
+		if preferTMDB {
+			candidates[0], candidates[1] = candidates[1], candidates[0]
 		}
 	}
 

--- a/internal/historyimport/matcher_test.go
+++ b/internal/historyimport/matcher_test.go
@@ -120,3 +120,33 @@ func TestMatcherMatchEpisode_AllowsSeasonZeroSpecials(t *testing.T) {
 			repo.episodeBySeriesID, repo.episodeBySeriesSeason, repo.episodeBySeriesEpisode)
 	}
 }
+
+func TestMatcherMatchSeries_PrefersTMDBForEmbyFavorite(t *testing.T) {
+	t.Parallel()
+
+	repo := &matcherRepoStub{
+		mediaByExternal: map[string][]mediaLookupRow{
+			"series:tmdb_id:94997":  {{ContentID: "house-of-the-dragon", Title: "House of the Dragon", Year: 2022}},
+			"series:tvdb_id:425793": {{ContentID: "making-of", Title: "The House That Dragons Built", Year: 2022}},
+		},
+	}
+	matcher := NewMatcher(repo)
+
+	match, reason, err := matcher.Match(context.Background(), Record{
+		Kind:       KindSeries,
+		Title:      "House of the Dragon",
+		Year:       2022,
+		TMDBID:     "94997",
+		TVDBID:     "425793",
+		PreferTMDB: true,
+	})
+	if err != nil {
+		t.Fatalf("Match returned error: %v", err)
+	}
+	if reason != "" {
+		t.Fatalf("reason = %q, want empty string", reason)
+	}
+	if match == nil || match.MediaItemID != "house-of-the-dragon" {
+		t.Fatalf("match = %+v, want TMDB-backed House of the Dragon", match)
+	}
+}

--- a/internal/historyimport/plex_watchlist_test.go
+++ b/internal/historyimport/plex_watchlist_test.go
@@ -344,6 +344,7 @@ func newPlexWatchlistImportTestPool(t *testing.T) *pgxpool.Pool {
 			progress_updated integer NOT NULL DEFAULT 0,
 			history_created integer NOT NULL DEFAULT 0,
 			watchlist_added integer NOT NULL DEFAULT 0,
+			favorites_imported integer NOT NULL DEFAULT 0,
 			skipped integer NOT NULL DEFAULT 0,
 			warnings jsonb NOT NULL DEFAULT '[]'::jsonb,
 			unmatched_samples jsonb NOT NULL DEFAULT '[]'::jsonb,
@@ -352,6 +353,13 @@ func newPlexWatchlistImportTestPool(t *testing.T) *pgxpool.Pool {
 			started_at timestamptz,
 			completed_at timestamptz,
 			last_heartbeat_at timestamptz
+		) ON COMMIT PRESERVE ROWS`,
+		`CREATE TEMP TABLE user_favorites (
+			user_id integer NOT NULL,
+			profile_id text NOT NULL,
+			media_item_id text NOT NULL,
+			added_at timestamptz NOT NULL DEFAULT now(),
+			PRIMARY KEY (user_id, profile_id, media_item_id)
 		) ON COMMIT PRESERVE ROWS`,
 	} {
 		if _, err := pool.Exec(ctx, stmt); err != nil {

--- a/internal/historyimport/repo.go
+++ b/internal/historyimport/repo.go
@@ -597,21 +597,21 @@ func (r *Repository) CreateRun(ctx context.Context, run Run) (*Run, error) {
 		INSERT INTO history_import_runs (
 			id, user_id, profile_id, source_type, connection_mode, status,
 			mapping_id,
-			fetched, matched, unmatched, progress_updated, history_created, watchlist_added, skipped,
+			fetched, matched, unmatched, progress_updated, history_created, watchlist_added, favorites_imported, skipped,
 			warnings, unmatched_samples, error_message
 		) VALUES (
 			$1, $2, $3, $4, $5, $6,
 			$7,
-			$8, $9, $10, $11, $12, $13, $14,
-			$15, $16, NULLIF($17, '')
+			$8, $9, $10, $11, $12, $13, $14, $15,
+			$16, $17, NULLIF($18, '')
 		)
 		RETURNING id, user_id, profile_id, source_type, connection_mode, status,
 			mapping_id,
-			fetched, matched, unmatched, progress_updated, history_created, watchlist_added, skipped,
+			fetched, matched, unmatched, progress_updated, history_created, watchlist_added, favorites_imported, skipped,
 			warnings, unmatched_samples, COALESCE(error_message, ''), created_at, started_at, completed_at`,
 		run.ID, run.UserID, run.ProfileID, run.SourceType, run.ConnectionMode, run.Status,
 		run.MappingID,
-		run.Fetched, run.Matched, run.Unmatched, run.ProgressUpdated, run.HistoryCreated, run.WatchlistAdded, run.Skipped,
+		run.Fetched, run.Matched, run.Unmatched, run.ProgressUpdated, run.HistoryCreated, run.WatchlistAdded, run.FavoritesImported, run.Skipped,
 		warningsJSON, unmatchedJSON, run.ErrorMessage,
 	)
 	created, err := scanRunWithMappingID(row)
@@ -668,15 +668,16 @@ func (r *Repository) CompleteRun(ctx context.Context, runID string, summary Exec
 			progress_updated = $6,
 			history_created = $7,
 			watchlist_added = $8,
-			skipped = $9,
-			warnings = $10,
-			unmatched_samples = $11,
+			favorites_imported = $9,
+			skipped = $10,
+			warnings = $11,
+			unmatched_samples = $12,
 			error_message = NULL,
 			completed_at = NOW(),
 			last_heartbeat_at = NOW()
 		WHERE id = $1`,
 		runID, RunStatusCompleted, summary.Fetched, summary.Matched, summary.Unmatched,
-		summary.ProgressUpdated, summary.HistoryCreated, summary.WatchlistAdded, summary.Skipped, warningsJSON, unmatchedJSON,
+		summary.ProgressUpdated, summary.HistoryCreated, summary.WatchlistAdded, summary.FavoritesImported, summary.Skipped, warningsJSON, unmatchedJSON,
 	)
 	if err != nil {
 		return fmt.Errorf("completing run %s: %w", runID, err)
@@ -705,11 +706,12 @@ func (r *Repository) UpdateRunProgress(ctx context.Context, runID string, summar
 			progress_updated = $5,
 			history_created = $6,
 			watchlist_added = $7,
-			skipped = $8,
-			warnings = $9,
-			unmatched_samples = $10,
+			favorites_imported = $8,
+			skipped = $9,
+			warnings = $10,
+			unmatched_samples = $11,
 			last_heartbeat_at = NOW()
-		WHERE id = $1 AND status = $11`,
+		WHERE id = $1 AND status = $12`,
 		runID,
 		summary.Fetched,
 		summary.Matched,
@@ -717,6 +719,7 @@ func (r *Repository) UpdateRunProgress(ctx context.Context, runID string, summar
 		summary.ProgressUpdated,
 		summary.HistoryCreated,
 		summary.WatchlistAdded,
+		summary.FavoritesImported,
 		summary.Skipped,
 		warningsJSON,
 		unmatchedJSON,
@@ -771,15 +774,16 @@ func (r *Repository) FailRun(ctx context.Context, runID string, summary Executio
 			progress_updated = $6,
 			history_created = $7,
 			watchlist_added = $8,
-			skipped = $9,
-			warnings = $10,
-			unmatched_samples = $11,
-			error_message = NULLIF($12, ''),
+			favorites_imported = $9,
+			skipped = $10,
+			warnings = $11,
+			unmatched_samples = $12,
+			error_message = NULLIF($13, ''),
 			completed_at = NOW(),
 			last_heartbeat_at = NOW()
 		WHERE id = $1`,
 		runID, RunStatusFailed, summary.Fetched, summary.Matched, summary.Unmatched,
-		summary.ProgressUpdated, summary.HistoryCreated, summary.WatchlistAdded, summary.Skipped, warningsJSON, unmatchedJSON, errorMessage,
+		summary.ProgressUpdated, summary.HistoryCreated, summary.WatchlistAdded, summary.FavoritesImported, summary.Skipped, warningsJSON, unmatchedJSON, errorMessage,
 	)
 	if err != nil {
 		return fmt.Errorf("failing run %s: %w", runID, err)
@@ -794,7 +798,7 @@ func (r *Repository) ListRunsForUser(ctx context.Context, userID, limit int) ([]
 	rows, err := r.pool.Query(ctx, `
 		SELECT id, user_id, profile_id, source_type, connection_mode, status,
 			mapping_id,
-			fetched, matched, unmatched, progress_updated, history_created, watchlist_added, skipped,
+			fetched, matched, unmatched, progress_updated, history_created, watchlist_added, favorites_imported, skipped,
 			warnings, unmatched_samples, COALESCE(error_message, ''), created_at, started_at, completed_at
 		FROM history_import_runs
 		WHERE user_id = $1
@@ -811,7 +815,7 @@ func (r *Repository) GetRunForUser(ctx context.Context, userID int, runID string
 	row := r.pool.QueryRow(ctx, `
 		SELECT id, user_id, profile_id, source_type, connection_mode, status,
 			mapping_id,
-			fetched, matched, unmatched, progress_updated, history_created, watchlist_added, skipped,
+			fetched, matched, unmatched, progress_updated, history_created, watchlist_added, favorites_imported, skipped,
 			warnings, unmatched_samples, COALESCE(error_message, ''), created_at, started_at, completed_at
 		FROM history_import_runs
 		WHERE id = $1 AND user_id = $2`, runID, userID)
@@ -829,7 +833,7 @@ func (r *Repository) ListActiveRunsForUser(ctx context.Context, userID int) ([]R
 	rows, err := r.pool.Query(ctx, `
 		SELECT id, user_id, profile_id, source_type, connection_mode, status,
 			mapping_id,
-			fetched, matched, unmatched, progress_updated, history_created, watchlist_added, skipped,
+			fetched, matched, unmatched, progress_updated, history_created, watchlist_added, favorites_imported, skipped,
 			warnings, unmatched_samples, COALESCE(error_message, ''), created_at, started_at, completed_at
 		FROM history_import_runs
 		WHERE user_id = $1
@@ -1105,7 +1109,7 @@ func scanRun(scanner interface{ Scan(dest ...any) error }) (*Run, error) {
 	var unmatchedJSON []byte
 	if err := scanner.Scan(
 		&run.ID, &run.UserID, &run.ProfileID, &run.SourceType, &run.ConnectionMode, &run.Status,
-		&run.Fetched, &run.Matched, &run.Unmatched, &run.ProgressUpdated, &run.HistoryCreated, &run.WatchlistAdded, &run.Skipped,
+		&run.Fetched, &run.Matched, &run.Unmatched, &run.ProgressUpdated, &run.HistoryCreated, &run.WatchlistAdded, &run.FavoritesImported, &run.Skipped,
 		&warningsJSON, &unmatchedJSON, &run.ErrorMessage, &run.CreatedAt, &run.StartedAt, &run.CompletedAt,
 	); err != nil {
 		return nil, err
@@ -1121,7 +1125,7 @@ func scanRunWithMappingID(scanner interface{ Scan(dest ...any) error }) (*Run, e
 	if err := scanner.Scan(
 		&run.ID, &run.UserID, &run.ProfileID, &run.SourceType, &run.ConnectionMode, &run.Status,
 		&run.MappingID,
-		&run.Fetched, &run.Matched, &run.Unmatched, &run.ProgressUpdated, &run.HistoryCreated, &run.WatchlistAdded, &run.Skipped,
+		&run.Fetched, &run.Matched, &run.Unmatched, &run.ProgressUpdated, &run.HistoryCreated, &run.WatchlistAdded, &run.FavoritesImported, &run.Skipped,
 		&warningsJSON, &unmatchedJSON, &run.ErrorMessage, &run.CreatedAt, &run.StartedAt, &run.CompletedAt,
 	); err != nil {
 		return nil, err

--- a/internal/historyimport/repo_admin.go
+++ b/internal/historyimport/repo_admin.go
@@ -271,7 +271,7 @@ func (r *Repository) ListAllRuns(ctx context.Context, sourceID *int, limit int) 
 		rows, err = r.pool.Query(ctx, `
 			SELECT r.id, r.user_id, r.profile_id, r.source_type, r.connection_mode, r.status,
 			       r.mapping_id,
-			       r.fetched, r.matched, r.unmatched, r.progress_updated, r.history_created, r.watchlist_added, r.skipped,
+			       r.fetched, r.matched, r.unmatched, r.progress_updated, r.history_created, r.watchlist_added, r.favorites_imported, r.skipped,
 			       r.warnings, r.unmatched_samples, COALESCE(r.error_message, ''),
 			       r.created_at, r.started_at, r.completed_at
 			FROM history_import_runs r
@@ -283,7 +283,7 @@ func (r *Repository) ListAllRuns(ctx context.Context, sourceID *int, limit int) 
 		rows, err = r.pool.Query(ctx, `
 			SELECT id, user_id, profile_id, source_type, connection_mode, status,
 			       mapping_id,
-			       fetched, matched, unmatched, progress_updated, history_created, watchlist_added, skipped,
+			       fetched, matched, unmatched, progress_updated, history_created, watchlist_added, favorites_imported, skipped,
 			       warnings, unmatched_samples, COALESCE(error_message, ''),
 			       created_at, started_at, completed_at
 			FROM history_import_runs
@@ -302,7 +302,7 @@ func (r *Repository) GetRunByID(ctx context.Context, runID string) (*Run, error)
 	row := r.pool.QueryRow(ctx, `
 		SELECT id, user_id, profile_id, source_type, connection_mode, status,
 		       mapping_id,
-		       fetched, matched, unmatched, progress_updated, history_created, watchlist_added, skipped,
+		       fetched, matched, unmatched, progress_updated, history_created, watchlist_added, favorites_imported, skipped,
 		       warnings, unmatched_samples, COALESCE(error_message, ''),
 		       created_at, started_at, completed_at
 		FROM history_import_runs
@@ -330,7 +330,7 @@ func (r *Repository) ListActiveRuns(ctx context.Context, sourceID *int) ([]Run, 
 		rows, err = r.pool.Query(ctx, `
 			SELECT r.id, r.user_id, r.profile_id, r.source_type, r.connection_mode, r.status,
 			       r.mapping_id,
-			       r.fetched, r.matched, r.unmatched, r.progress_updated, r.history_created, r.watchlist_added, r.skipped,
+			       r.fetched, r.matched, r.unmatched, r.progress_updated, r.history_created, r.watchlist_added, r.favorites_imported, r.skipped,
 			       r.warnings, r.unmatched_samples, COALESCE(r.error_message, ''),
 			       r.created_at, r.started_at, r.completed_at
 			FROM history_import_runs r
@@ -342,7 +342,7 @@ func (r *Repository) ListActiveRuns(ctx context.Context, sourceID *int) ([]Run, 
 		rows, err = r.pool.Query(ctx, `
 			SELECT id, user_id, profile_id, source_type, connection_mode, status,
 			       mapping_id,
-			       fetched, matched, unmatched, progress_updated, history_created, watchlist_added, skipped,
+			       fetched, matched, unmatched, progress_updated, history_created, watchlist_added, favorites_imported, skipped,
 			       warnings, unmatched_samples, COALESCE(error_message, ''),
 			       created_at, started_at, completed_at
 			FROM history_import_runs

--- a/internal/historyimport/service.go
+++ b/internal/historyimport/service.go
@@ -422,6 +422,27 @@ func (s *Service) addToWatchlist(ctx context.Context, userID int, profileID, med
 	return inserted, nil
 }
 
+func (s *Service) addFavorite(ctx context.Context, userID int, profileID, mediaItemID string) (bool, error) {
+	if s.stores == nil {
+		return false, fmt.Errorf("favorites import: user store provider not configured")
+	}
+	store, err := s.stores.ForUser(ctx, userID)
+	if err != nil {
+		return false, fmt.Errorf("favorites import: open user store: %w", err)
+	}
+	exists, err := store.IsFavorite(ctx, profileID, mediaItemID)
+	if err != nil {
+		return false, fmt.Errorf("favorites import: check %s: %w", mediaItemID, err)
+	}
+	if exists {
+		return false, nil
+	}
+	if err := store.AddFavorite(ctx, profileID, mediaItemID); err != nil {
+		return false, fmt.Errorf("favorites import: add %s: %w", mediaItemID, err)
+	}
+	return true, nil
+}
+
 func (s *Service) executeRun(run *Run, provider Provider) {
 	ctx, cancel := newRunContext(s.bgContext)
 	s.registerRunCancel(run.ID, cancel)
@@ -505,6 +526,14 @@ func (s *Service) executeRun(run *Run, provider Provider) {
 		}
 		summary.Matched++
 
+		if record.Favorite {
+			inserted, err := s.addFavorite(ctx, run.UserID, run.ProfileID, match.MediaItemID)
+			if err != nil {
+				summary.Warnings = append(summary.Warnings, err.Error())
+			} else if inserted {
+				summary.FavoritesImported++
+			}
+		}
 		// Watchlist entries carry no watch state: the matched item joins the
 		// importing profile's watchlist and the progress pipeline is skipped.
 		if record.Watchlisted {
@@ -514,6 +543,10 @@ func (s *Service) executeRun(run *Run, provider Provider) {
 			} else if inserted {
 				summary.WatchlistAdded++
 			}
+			s.persistProgressMaybe(ctx, run.ID, summary, i+1, len(records))
+			continue
+		}
+		if record.FavoriteOnly {
 			s.persistProgressMaybe(ctx, run.ID, summary, i+1, len(records))
 			continue
 		}
@@ -585,6 +618,7 @@ func (s *Service) executeRun(run *Run, provider Provider) {
 		"unmatched", summary.Unmatched,
 		"progress_updated", summary.ProgressUpdated,
 		"history_created", summary.HistoryCreated,
+		"favorites_imported", summary.FavoritesImported,
 		"skipped", summary.Skipped,
 		"warnings", len(summary.Warnings),
 	)
@@ -622,7 +656,7 @@ func userFacingRunError(summary ExecutionSummary, err error) string {
 	if UpstreamHTTPStatus(err) == http.StatusUnauthorized {
 		return "Couldn't connect to that server. Check the URL, username, and password and try again."
 	}
-	if summary.Fetched > 0 || summary.Matched > 0 || summary.ProgressUpdated > 0 || summary.HistoryCreated > 0 {
+	if summary.Fetched > 0 || summary.Matched > 0 || summary.ProgressUpdated > 0 || summary.HistoryCreated > 0 || summary.FavoritesImported > 0 {
 		return "Import stopped early. Some history may already be imported."
 	}
 	return "Import couldn't be completed. Please try again."

--- a/internal/historyimport/service.go
+++ b/internal/historyimport/service.go
@@ -430,17 +430,11 @@ func (s *Service) addFavorite(ctx context.Context, userID int, profileID, mediaI
 	if err != nil {
 		return false, fmt.Errorf("favorites import: open user store: %w", err)
 	}
-	exists, err := store.IsFavorite(ctx, profileID, mediaItemID)
+	inserted, err := store.AddFavoriteAt(ctx, profileID, mediaItemID, time.Now().UTC())
 	if err != nil {
-		return false, fmt.Errorf("favorites import: check %s: %w", mediaItemID, err)
-	}
-	if exists {
-		return false, nil
-	}
-	if err := store.AddFavorite(ctx, profileID, mediaItemID); err != nil {
 		return false, fmt.Errorf("favorites import: add %s: %w", mediaItemID, err)
 	}
-	return true, nil
+	return inserted, nil
 }
 
 func (s *Service) executeRun(run *Run, provider Provider) {

--- a/internal/historyimport/types.go
+++ b/internal/historyimport/types.go
@@ -133,26 +133,27 @@ type PlexServerPublic struct {
 
 // Run represents one history import execution.
 type Run struct {
-	ID               string            `json:"id"`
-	UserID           int               `json:"user_id"`
-	ProfileID        string            `json:"profile_id"`
-	SourceType       string            `json:"source_type"`
-	ConnectionMode   string            `json:"connection_mode"`
-	Status           string            `json:"status"`
-	MappingID        *int              `json:"mapping_id,omitempty"`
-	Fetched          int               `json:"fetched"`
-	Matched          int               `json:"matched"`
-	Unmatched        int               `json:"unmatched"`
-	ProgressUpdated  int               `json:"progress_updated"`
-	HistoryCreated   int               `json:"history_created"`
-	WatchlistAdded   int               `json:"watchlist_added"`
-	Skipped          int               `json:"skipped"`
-	Warnings         []string          `json:"warnings"`
-	UnmatchedSamples []UnmatchedSample `json:"unmatched_samples"`
-	ErrorMessage     string            `json:"error_message,omitempty"`
-	CreatedAt        time.Time         `json:"created_at"`
-	StartedAt        *time.Time        `json:"started_at,omitempty"`
-	CompletedAt      *time.Time        `json:"completed_at,omitempty"`
+	ID                string            `json:"id"`
+	UserID            int               `json:"user_id"`
+	ProfileID         string            `json:"profile_id"`
+	SourceType        string            `json:"source_type"`
+	ConnectionMode    string            `json:"connection_mode"`
+	Status            string            `json:"status"`
+	MappingID         *int              `json:"mapping_id,omitempty"`
+	Fetched           int               `json:"fetched"`
+	Matched           int               `json:"matched"`
+	Unmatched         int               `json:"unmatched"`
+	ProgressUpdated   int               `json:"progress_updated"`
+	HistoryCreated    int               `json:"history_created"`
+	WatchlistAdded    int               `json:"watchlist_added"`
+	FavoritesImported int               `json:"favorites_imported"`
+	Skipped           int               `json:"skipped"`
+	Warnings          []string          `json:"warnings"`
+	UnmatchedSamples  []UnmatchedSample `json:"unmatched_samples"`
+	ErrorMessage      string            `json:"error_message,omitempty"`
+	CreatedAt         time.Time         `json:"created_at"`
+	StartedAt         *time.Time        `json:"started_at,omitempty"`
+	CompletedAt       *time.Time        `json:"completed_at,omitempty"`
 }
 
 type UnmatchedSample struct {
@@ -186,7 +187,13 @@ type Record struct {
 	// matched item is added to the importing profile's watchlist instead of
 	// receiving watch state.
 	Watchlisted bool
-	UpdatedAt   time.Time
+	// FavoriteOnly prevents a favorite with no played/resumable counterpart
+	// from creating an empty progress row. PreferTMDB avoids stale secondary
+	// TVDB IDs winning over Emby's primary TMDB identity for favorite series.
+	Favorite     bool
+	FavoriteOnly bool
+	PreferTMDB   bool
+	UpdatedAt    time.Time
 }
 
 type Match struct {
@@ -250,6 +257,7 @@ type ExecutionSummary struct {
 	ProgressUpdated       int
 	HistoryCreated        int
 	WatchlistAdded        int
+	FavoritesImported     int
 	Skipped               int
 	Warnings              []string
 	UnmatchedSamples      []UnmatchedSample

--- a/internal/jellycompat/content_direct_test.go
+++ b/internal/jellycompat/content_direct_test.go
@@ -359,7 +359,7 @@ func (s *progressCountingStore) DeleteHomeDismissal(context.Context, string, str
 	panic("unused")
 }
 func (s *progressCountingStore) AddFavorite(context.Context, string, string) error { panic("unused") }
-func (s *progressCountingStore) AddFavoriteAt(context.Context, string, string, time.Time) error {
+func (s *progressCountingStore) AddFavoriteAt(context.Context, string, string, time.Time) (bool, error) {
 	panic("unused")
 }
 func (s *progressCountingStore) RemoveFavorite(context.Context, string, string) error {

--- a/internal/notifications/interest_hooks.go
+++ b/internal/notifications/interest_hooks.go
@@ -107,12 +107,12 @@ func (s *interestTrackingStore) AddFavorite(ctx context.Context, profileID, medi
 	return err
 }
 
-func (s *interestTrackingStore) AddFavoriteAt(ctx context.Context, profileID, mediaItemID string, addedAt time.Time) error {
-	err := s.UserStore.AddFavoriteAt(ctx, profileID, mediaItemID, addedAt)
-	if err == nil {
+func (s *interestTrackingStore) AddFavoriteAt(ctx context.Context, profileID, mediaItemID string, addedAt time.Time) (bool, error) {
+	inserted, err := s.UserStore.AddFavoriteAt(ctx, profileID, mediaItemID, addedAt)
+	if err == nil && inserted {
 		s.updater.QueueItemMutation(s.userID, profileID, mediaItemID)
 	}
-	return err
+	return inserted, err
 }
 
 func (s *interestTrackingStore) RemoveFavorite(ctx context.Context, profileID, mediaItemID string) error {

--- a/internal/userdb/conformance_test.go
+++ b/internal/userdb/conformance_test.go
@@ -1,8 +1,10 @@
 package userdb
 
 import (
+	"context"
 	"database/sql"
 	"testing"
+	"time"
 
 	"github.com/Silo-Server/silo-server/internal/userstore"
 	"github.com/Silo-Server/silo-server/internal/userstore/storetest"
@@ -26,4 +28,28 @@ func newConformanceStore(t *testing.T) userstore.UserStore {
 // synced_seq stamping triggers and event_at LWW comparison.
 func TestSQLiteProgressSince(t *testing.T) {
 	storetest.RunProgressSince(t, newConformanceStore)
+}
+
+func TestSQLiteAddFavoriteAtReportsInsertion(t *testing.T) {
+	ctx := context.Background()
+	store := newConformanceStore(t)
+	if err := store.CreateProfile(ctx, userstore.Profile{ID: "p1", Name: "Test"}); err != nil {
+		t.Fatalf("CreateProfile: %v", err)
+	}
+
+	addedAt := time.Date(2026, time.July, 16, 12, 0, 0, 0, time.UTC)
+	inserted, err := store.AddFavoriteAt(ctx, "p1", "movie-1", addedAt)
+	if err != nil {
+		t.Fatalf("first AddFavoriteAt: %v", err)
+	}
+	if !inserted {
+		t.Fatal("first AddFavoriteAt reported no insertion")
+	}
+	inserted, err = store.AddFavoriteAt(ctx, "p1", "movie-1", addedAt)
+	if err != nil {
+		t.Fatalf("duplicate AddFavoriteAt: %v", err)
+	}
+	if inserted {
+		t.Fatal("duplicate AddFavoriteAt reported an insertion")
+	}
 }

--- a/internal/userdb/favorites.go
+++ b/internal/userdb/favorites.go
@@ -20,19 +20,23 @@ type WatchlistEntry = userstore.WatchlistEntry
 // AddFavorite adds a media item to a profile's favorites.
 // If the item is already a favorite, the operation is a no-op.
 func AddFavorite(db *sql.DB, profileID, mediaItemID string) error {
-	_, err := db.Exec(
-		`INSERT OR IGNORE INTO favorites (profile_id, media_item_id, added_at) VALUES (?, ?, ?)`,
-		profileID, mediaItemID, nowUTC(),
-	)
+	_, err := AddFavoriteAt(db, profileID, mediaItemID, time.Now().UTC())
 	return err
 }
 
-func AddFavoriteAt(db *sql.DB, profileID, mediaItemID string, addedAt time.Time) error {
-	_, err := db.Exec(
+func AddFavoriteAt(db *sql.DB, profileID, mediaItemID string, addedAt time.Time) (bool, error) {
+	result, err := db.Exec(
 		`INSERT OR IGNORE INTO favorites (profile_id, media_item_id, added_at) VALUES (?, ?, ?)`,
 		profileID, mediaItemID, addedAt.UTC().Format(time.RFC3339),
 	)
-	return err
+	if err != nil {
+		return false, err
+	}
+	rows, err := result.RowsAffected()
+	if err != nil {
+		return false, err
+	}
+	return rows > 0, nil
 }
 
 // RemoveFavorite removes a media item from a profile's favorites.

--- a/internal/userdb/sqlitestore.go
+++ b/internal/userdb/sqlitestore.go
@@ -172,7 +172,7 @@ func (s *SQLiteUserStore) AddFavorite(_ context.Context, profileID, mediaItemID 
 	return AddFavorite(s.db, profileID, mediaItemID)
 }
 
-func (s *SQLiteUserStore) AddFavoriteAt(_ context.Context, profileID, mediaItemID string, addedAt time.Time) error {
+func (s *SQLiteUserStore) AddFavoriteAt(_ context.Context, profileID, mediaItemID string, addedAt time.Time) (bool, error) {
 	return AddFavoriteAt(s.db, profileID, mediaItemID, addedAt)
 }
 

--- a/internal/userstore/pgstore/favorites.go
+++ b/internal/userstore/pgstore/favorites.go
@@ -15,17 +15,21 @@ import (
 // --- Favorites ---
 
 func (s *PostgresUserStore) AddFavorite(ctx context.Context, profileID, mediaItemID string) error {
-	return s.AddFavoriteAt(ctx, profileID, mediaItemID, time.Now().UTC())
+	_, err := s.AddFavoriteAt(ctx, profileID, mediaItemID, time.Now().UTC())
+	return err
 }
 
-func (s *PostgresUserStore) AddFavoriteAt(ctx context.Context, profileID, mediaItemID string, addedAt time.Time) error {
-	_, err := s.pool.Exec(ctx,
+func (s *PostgresUserStore) AddFavoriteAt(ctx context.Context, profileID, mediaItemID string, addedAt time.Time) (bool, error) {
+	tag, err := s.pool.Exec(ctx,
 		`INSERT INTO user_favorites (user_id, profile_id, media_item_id, added_at)
 		 VALUES ($1, $2, $3, $4)
 		 ON CONFLICT DO NOTHING`,
 		s.userID, profileID, mediaItemID, addedAt.UTC(),
 	)
-	return err
+	if err != nil {
+		return false, err
+	}
+	return tag.RowsAffected() > 0, nil
 }
 
 func (s *PostgresUserStore) RemoveFavorite(ctx context.Context, profileID, mediaItemID string) error {

--- a/internal/userstore/store.go
+++ b/internal/userstore/store.go
@@ -58,7 +58,7 @@ type UserStore interface {
 
 	// Favorites & Watchlist
 	AddFavorite(ctx context.Context, profileID, mediaItemID string) error
-	AddFavoriteAt(ctx context.Context, profileID, mediaItemID string, addedAt time.Time) error
+	AddFavoriteAt(ctx context.Context, profileID, mediaItemID string, addedAt time.Time) (bool, error)
 	RemoveFavorite(ctx context.Context, profileID, mediaItemID string) error
 	ListFavorites(ctx context.Context, profileID string, limit, offset int) ([]Favorite, error)
 	ListFavoritesByMediaItems(ctx context.Context, profileID string, mediaItemIDs []string) (map[string]bool, error)

--- a/internal/watchsync/lists.go
+++ b/internal/watchsync/lists.go
@@ -101,7 +101,8 @@ func (s *Service) favoritesBinding() listBinding {
 			return res, true, err
 		},
 		localAdd: func(ctx context.Context, store userstore.UserStore, profileID, mediaItemID string, at time.Time) error {
-			return store.AddFavoriteAt(ctx, profileID, mediaItemID, at)
+			_, err := store.AddFavoriteAt(ctx, profileID, mediaItemID, at)
+			return err
 		},
 		localRemove: func(ctx context.Context, store userstore.UserStore, profileID, mediaItemID string) error {
 			return store.RemoveFavorite(ctx, profileID, mediaItemID)

--- a/migrations/sql/20260711114310_history_import_favorites_imported.sql
+++ b/migrations/sql/20260711114310_history_import_favorites_imported.sql
@@ -1,0 +1,11 @@
+-- +goose Up
+-- +goose StatementBegin
+-- Count successfully applied Emby favorites during history import runs.
+ALTER TABLE history_import_runs
+ADD COLUMN favorites_imported integer NOT NULL DEFAULT 0;
+-- +goose StatementEnd
+
+-- +goose Down
+-- +goose StatementBegin
+ALTER TABLE history_import_runs DROP COLUMN IF EXISTS favorites_imported;
+-- +goose StatementEnd

--- a/web/src/api/types.ts
+++ b/web/src/api/types.ts
@@ -422,6 +422,7 @@ export interface HistoryImportRun {
   progress_updated: number;
   history_created: number;
   watchlist_added: number;
+  favorites_imported: number;
   skipped: number;
   warnings: string[];
   unmatched_samples: HistoryImportUnmatchedSample[];

--- a/web/src/pages/AdminHistoryImport.tsx
+++ b/web/src/pages/AdminHistoryImport.tsx
@@ -1240,6 +1240,10 @@ function RunsSection({ sourceId }: { sourceId: number }) {
                           <p>{run.history_created}</p>
                         </div>
                         <div>
+                          <p className="font-medium">Favorites</p>
+                          <p>{run.favorites_imported}</p>
+                        </div>
+                        <div>
                           <p className="font-medium">Watchlist</p>
                           <p>{run.watchlist_added}</p>
                         </div>

--- a/web/src/pages/settings/HistoryImportSettings.tsx
+++ b/web/src/pages/settings/HistoryImportSettings.tsx
@@ -842,13 +842,14 @@ function RunSummary({ run }: { run: HistoryImportRun | null }) {
       )}
 
       {/* Metrics */}
-      <div className="grid grid-cols-3 gap-2 sm:grid-cols-6">
+      <div className="grid grid-cols-3 gap-2 sm:grid-cols-7">
         <MetricCard label="Fetched" value={run.fetched} />
         <MetricCard label="Matched" value={run.matched} accent="positive" />
         <MetricCard label="Unmatched" value={run.unmatched} accent="warning" />
         <MetricCard label="Progress" value={run.progress_updated} accent="positive" />
         <MetricCard label="History" value={run.history_created} accent="positive" />
         <MetricCard label="Watchlist" value={run.watchlist_added} accent="positive" />
+        <MetricCard label="Favorites" value={run.favorites_imported} accent="positive" />
         <MetricCard label="Skipped" value={run.skipped} />
       </div>
 


### PR DESCRIPTION
## Summary
- fetch historical Emby movie and series favorites during history imports
- add favorites without creating empty watch-progress rows
- prefer Emby TMDB identity for favorite series while retaining TVDB/IMDb fallback
- expose the number of newly imported favorites in user and admin run summaries

## Why
Emby history import previously fetched only played and resumable items, so existing favorites were silently omitted.

## Testing
- go test ./...
- database-backed history-import tests against temporary PostgreSQL tables
- golangci-lint run
- pnpm run lint
- pnpm run format:check
- pnpm test --run
- pnpm run build
- Goose migration validation
- make verify-local-paths

## Migration
Adds the additive, non-null history_import_runs.favorites_imported counter with a default of zero.

## AI use
Codex assisted with implementation, test design, and review. Every changed line was reviewed and the full verification suite above was run.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * History imports now include Emby movie and series favorites.
  * Import summaries now report how many favorites were imported.
  * Series matching can prioritize TMDb identifiers when appropriate (improves favorite matching accuracy).
* **UI**
  * Added Favorites metrics to recent import details and history import run summaries.
* **Bug Fixes**
  * Favorite-only items no longer create progress or watch-history entries.
  * Favorite fetching failures no longer stop the import; the import continues and reports a warning.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->