### PR TITLE
fix(playback): stop orphan cleanup deleting the subtitle cache

### DIFF
--- a/internal/playback/transcode_cleanup.go
+++ b/internal/playback/transcode_cleanup.go
@@ -42,6 +42,11 @@ func CleanupOrphanedTranscodeDirs(root string, activeSessionIDs map[string]struc
 			continue
 		}
 
+		// The subtitle cache is not session state; it manages its own eviction.
+		if entry.Name() == subtitleCacheDirName {
+			continue
+		}
+
 		dir := filepath.Join(root, entry.Name())
 		if minAge > 0 {
 			info, statErr := entry.Info()


### PR DESCRIPTION
Was reading through the transcode cleanup path and noticed the orphaned session sweep treats every subdirectory of the transcode dir as a dead session. The subtitle cache lives in there too, and cache hits only bump the entry file mtimes, never the directory's, so an active cache that hasn't seen a new extraction in 24 hours looks stale and gets wiped in one go. The next PGS subtitle selection then has to re-run a full ffmpeg demux, which is exactly the cost the cache is there to avoid. On the dedicated node the boot wipe deletes it unconditionally.

The fix is one line: skip the cache directory in the sweep. It validates entries on lookup and handles its own LRU eviction, so leaving it alone is safe.

Tested locally: an actively used subtitle cache now survives the cleanup sweep, while genuinely orphaned session directories still get removed.

Built with AI assistance. I've read through the whole diff and tested it myself, and I'm happy to own it.
