### PR TITLE
fix(userstore): batch allowed-library and profile lookups when listing

### DIFF
--- a/internal/userdb/collections.go
+++ b/internal/userdb/collections.go
@@ -3,7 +3,6 @@ package userdb
 import (
 	"database/sql"
 	"fmt"
-	"strings"
 
 	"github.com/Silo-Server/silo-server/internal/userstore"
 )
@@ -120,7 +119,7 @@ func ListCollections(db *sql.DB, profileID string) ([]Collection, error) {
 	if err := rows.Err(); err != nil {
 		return nil, err
 	}
-	if err := attachCollectionProfiles(db, collections); err != nil {
+	if err := attachCollectionProfiles(db, profileID, collections); err != nil {
 		return nil, err
 	}
 	return collections, nil
@@ -129,20 +128,18 @@ func ListCollections(db *sql.DB, profileID string) ([]Collection, error) {
 // attachCollectionProfiles fills AllowedProfileIDs for every collection with a
 // single batched query, avoiding the N+1 round trip a per-collection lookup
 // would create.
-func attachCollectionProfiles(db *sql.DB, collections []Collection) error {
+func attachCollectionProfiles(db *sql.DB, profileID string, collections []Collection) error {
 	if len(collections) == 0 {
 		return nil
 	}
-	placeholders := make([]string, len(collections))
-	args := make([]any, len(collections))
-	for i := range collections {
-		placeholders[i] = "?"
-		args[i] = collections[i].ID
-	}
 	rows, err := db.Query(
-		`SELECT collection_id, profile_id FROM personal_collection_profiles
-		 WHERE collection_id IN (`+strings.Join(placeholders, ",")+`) ORDER BY profile_id ASC`,
-		args...,
+		`SELECT allowed.collection_id, allowed.profile_id
+		 FROM personal_collection_profiles AS visible
+		 JOIN personal_collection_profiles AS allowed
+		   ON allowed.collection_id = visible.collection_id
+		 WHERE visible.profile_id = ?
+		 ORDER BY allowed.profile_id ASC`,
+		profileID,
 	)
 	if err != nil {
 		return err

--- a/internal/userdb/collections.go
+++ b/internal/userdb/collections.go
@@ -3,6 +3,7 @@ package userdb
 import (
 	"database/sql"
 	"fmt"
+	"strings"
 
 	"github.com/Silo-Server/silo-server/internal/userstore"
 )
@@ -114,13 +115,55 @@ func ListCollections(db *sql.DB, profileID string) ([]Collection, error) {
 		if err := rows.Scan(&c.ID, &c.ProfileID, &c.CreatorProfileID, &c.Name, &c.CollectionType, &c.IsShared, &c.QueryDefinition, &c.SortConfig, &c.CreatedAt, &c.UpdatedAt); err != nil {
 			return nil, err
 		}
-		c.AllowedProfileIDs, err = listCollectionProfiles(db, c.ID)
-		if err != nil {
-			return nil, err
-		}
 		collections = append(collections, c)
 	}
-	return collections, rows.Err()
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	if err := attachCollectionProfiles(db, collections); err != nil {
+		return nil, err
+	}
+	return collections, nil
+}
+
+// attachCollectionProfiles fills AllowedProfileIDs for every collection with a
+// single batched query, avoiding the N+1 round trip a per-collection lookup
+// would create.
+func attachCollectionProfiles(db *sql.DB, collections []Collection) error {
+	if len(collections) == 0 {
+		return nil
+	}
+	placeholders := make([]string, len(collections))
+	args := make([]any, len(collections))
+	for i := range collections {
+		placeholders[i] = "?"
+		args[i] = collections[i].ID
+	}
+	rows, err := db.Query(
+		`SELECT collection_id, profile_id FROM personal_collection_profiles
+		 WHERE collection_id IN (`+strings.Join(placeholders, ",")+`) ORDER BY profile_id ASC`,
+		args...,
+	)
+	if err != nil {
+		return err
+	}
+	defer rows.Close()
+
+	byCollection := make(map[string][]string, len(collections))
+	for rows.Next() {
+		var collectionID, profileID string
+		if err := rows.Scan(&collectionID, &profileID); err != nil {
+			return err
+		}
+		byCollection[collectionID] = append(byCollection[collectionID], profileID)
+	}
+	if err := rows.Err(); err != nil {
+		return err
+	}
+	for i := range collections {
+		collections[i].AllowedProfileIDs = byCollection[collections[i].ID]
+	}
+	return nil
 }
 
 // UpdateCollection renames a collection and updates its updated_at timestamp.

--- a/internal/userdb/listing_batch_test.go
+++ b/internal/userdb/listing_batch_test.go
@@ -1,0 +1,92 @@
+package userdb
+
+import (
+	"database/sql"
+	"reflect"
+	"testing"
+
+	"github.com/Silo-Server/silo-server/internal/userstore"
+)
+
+func newListingTestDB(t *testing.T) *sql.DB {
+	t.Helper()
+	db, err := sql.Open("sqlite3", ":memory:")
+	if err != nil {
+		t.Fatalf("open sqlite: %v", err)
+	}
+	db.SetMaxOpenConns(1)
+	t.Cleanup(func() { _ = db.Close() })
+	if err := InitSchema(db); err != nil {
+		t.Fatalf("InitSchema: %v", err)
+	}
+	return db
+}
+
+func TestListProfilesAttachesAllowedLibrariesInOrder(t *testing.T) {
+	db := newListingTestDB(t)
+	for _, profile := range []Profile{
+		{ID: "p1", Name: "One", AllowedLibraryIDs: []int{5, 2}, CreatedAt: "2026-01-01T00:00:00Z"},
+		{ID: "p2", Name: "Two", AllowedLibraryIDs: []int{3}, CreatedAt: "2026-01-02T00:00:00Z"},
+		{ID: "p3", Name: "Three", CreatedAt: "2026-01-03T00:00:00Z"},
+	} {
+		if err := CreateProfile(db, profile); err != nil {
+			t.Fatalf("CreateProfile(%s): %v", profile.ID, err)
+		}
+	}
+
+	profiles, err := ListProfiles(db)
+	if err != nil {
+		t.Fatalf("ListProfiles: %v", err)
+	}
+	if len(profiles) != 3 {
+		t.Fatalf("ListProfiles returned %d profiles, want 3", len(profiles))
+	}
+	if got, want := profiles[0].AllowedLibraryIDs, []int{2, 5}; !reflect.DeepEqual(got, want) {
+		t.Fatalf("p1 AllowedLibraryIDs = %v, want %v", got, want)
+	}
+	if got, want := profiles[1].AllowedLibraryIDs, []int{3}; !reflect.DeepEqual(got, want) {
+		t.Fatalf("p2 AllowedLibraryIDs = %v, want %v", got, want)
+	}
+	if profiles[2].AllowedLibraryIDs != nil {
+		t.Fatalf("p3 AllowedLibraryIDs = %v, want nil", profiles[2].AllowedLibraryIDs)
+	}
+}
+
+func TestListCollectionsAttachesAllowedProfilesInOrder(t *testing.T) {
+	db := newListingTestDB(t)
+	collection, err := CreateCollection(db, userstore.CreateCollectionInput{
+		CreatorProfileID:  "p1",
+		Name:              "Shared",
+		IsShared:          true,
+		AllowedProfileIDs: []string{"p3", "p2"},
+	})
+	if err != nil {
+		t.Fatalf("CreateCollection: %v", err)
+	}
+
+	collections, err := ListCollections(db, "p2")
+	if err != nil {
+		t.Fatalf("ListCollections: %v", err)
+	}
+	if len(collections) != 1 || collections[0].ID != collection.ID {
+		t.Fatalf("ListCollections = %+v, want collection %s", collections, collection.ID)
+	}
+	if got, want := collections[0].AllowedProfileIDs, []string{"p1", "p2", "p3"}; !reflect.DeepEqual(got, want) {
+		t.Fatalf("AllowedProfileIDs = %v, want %v", got, want)
+	}
+}
+
+func TestBatchAttachDoesNotScaleBindParametersWithRows(t *testing.T) {
+	db := newListingTestDB(t)
+	const aboveSQLiteVariableLimit = 32767
+
+	profiles := make([]Profile, aboveSQLiteVariableLimit)
+	if err := attachAllowedLibraries(db, profiles); err != nil {
+		t.Fatalf("attachAllowedLibraries: %v", err)
+	}
+
+	collections := make([]Collection, aboveSQLiteVariableLimit)
+	if err := attachCollectionProfiles(db, "viewer", collections); err != nil {
+		t.Fatalf("attachCollectionProfiles: %v", err)
+	}
+}

--- a/internal/userdb/profile_libraries.go
+++ b/internal/userdb/profile_libraries.go
@@ -3,7 +3,8 @@ package userdb
 import (
 	"database/sql"
 	"fmt"
-	"strings"
+
+	"github.com/Silo-Server/silo-server/internal/userstore"
 )
 
 func listProfileAllowedLibraries(db *sql.DB, profileID string) ([]int, error) {
@@ -37,37 +38,28 @@ func attachAllowedLibraries(db *sql.DB, profiles []Profile) error {
 	if len(profiles) == 0 {
 		return nil
 	}
-	placeholders := make([]string, len(profiles))
-	args := make([]any, len(profiles))
-	for i := range profiles {
-		placeholders[i] = "?"
-		args[i] = profiles[i].ID
-	}
 	rows, err := db.Query(
-		`SELECT profile_id, library_id FROM profile_allowed_libraries
-		 WHERE profile_id IN (`+strings.Join(placeholders, ",")+`) ORDER BY library_id ASC`,
-		args...,
+		`SELECT profile_id, library_id
+		 FROM profile_allowed_libraries
+		 ORDER BY library_id ASC`,
 	)
 	if err != nil {
 		return fmt.Errorf("listing allowed libraries: %w", err)
 	}
 	defer rows.Close()
 
-	byProfile := make(map[string][]int, len(profiles))
+	var allowedLibraries []userstore.ProfileAllowedLibrary
 	for rows.Next() {
-		var profileID string
-		var libraryID int
-		if err := rows.Scan(&profileID, &libraryID); err != nil {
+		var allowedLibrary userstore.ProfileAllowedLibrary
+		if err := rows.Scan(&allowedLibrary.ProfileID, &allowedLibrary.LibraryID); err != nil {
 			return fmt.Errorf("scanning allowed library: %w", err)
 		}
-		byProfile[profileID] = append(byProfile[profileID], libraryID)
+		allowedLibraries = append(allowedLibraries, allowedLibrary)
 	}
 	if err := rows.Err(); err != nil {
 		return fmt.Errorf("iterating allowed libraries: %w", err)
 	}
-	for i := range profiles {
-		profiles[i].AllowedLibraryIDs = byProfile[profiles[i].ID]
-	}
+	userstore.AttachAllowedLibraries(profiles, allowedLibraries)
 	return nil
 }
 

--- a/internal/userdb/profile_libraries.go
+++ b/internal/userdb/profile_libraries.go
@@ -3,6 +3,7 @@ package userdb
 import (
 	"database/sql"
 	"fmt"
+	"strings"
 )
 
 func listProfileAllowedLibraries(db *sql.DB, profileID string) ([]int, error) {
@@ -27,6 +28,47 @@ func listProfileAllowedLibraries(db *sql.DB, profileID string) ([]int, error) {
 		return nil, fmt.Errorf("iterating allowed libraries for profile %s: %w", profileID, err)
 	}
 	return libraryIDs, nil
+}
+
+// attachAllowedLibraries fills AllowedLibraryIDs for every profile with a
+// single batched query, avoiding the N+1 round trip a per-profile lookup
+// would create.
+func attachAllowedLibraries(db *sql.DB, profiles []Profile) error {
+	if len(profiles) == 0 {
+		return nil
+	}
+	placeholders := make([]string, len(profiles))
+	args := make([]any, len(profiles))
+	for i := range profiles {
+		placeholders[i] = "?"
+		args[i] = profiles[i].ID
+	}
+	rows, err := db.Query(
+		`SELECT profile_id, library_id FROM profile_allowed_libraries
+		 WHERE profile_id IN (`+strings.Join(placeholders, ",")+`) ORDER BY library_id ASC`,
+		args...,
+	)
+	if err != nil {
+		return fmt.Errorf("listing allowed libraries: %w", err)
+	}
+	defer rows.Close()
+
+	byProfile := make(map[string][]int, len(profiles))
+	for rows.Next() {
+		var profileID string
+		var libraryID int
+		if err := rows.Scan(&profileID, &libraryID); err != nil {
+			return fmt.Errorf("scanning allowed library: %w", err)
+		}
+		byProfile[profileID] = append(byProfile[profileID], libraryID)
+	}
+	if err := rows.Err(); err != nil {
+		return fmt.Errorf("iterating allowed libraries: %w", err)
+	}
+	for i := range profiles {
+		profiles[i].AllowedLibraryIDs = byProfile[profiles[i].ID]
+	}
+	return nil
 }
 
 func replaceProfileAllowedLibrariesTx(tx *sql.Tx, profileID string, libraryIDs []int) error {

--- a/internal/userdb/profiles.go
+++ b/internal/userdb/profiles.go
@@ -128,14 +128,13 @@ func ListProfiles(db *sql.DB) ([]Profile, error) {
 		); err != nil {
 			return nil, fmt.Errorf("scanning profile row: %w", err)
 		}
-		p.AllowedLibraryIDs, err = listProfileAllowedLibraries(db, p.ID)
-		if err != nil {
-			return nil, err
-		}
 		profiles = append(profiles, p)
 	}
 	if err := rows.Err(); err != nil {
 		return nil, fmt.Errorf("iterating profile rows: %w", err)
+	}
+	if err := attachAllowedLibraries(db, profiles); err != nil {
+		return nil, err
 	}
 	return profiles, nil
 }

--- a/internal/userstore/pgstore/profile_libraries.go
+++ b/internal/userstore/pgstore/profile_libraries.go
@@ -6,6 +6,8 @@ import (
 
 	"github.com/jackc/pgx/v5"
 	"github.com/jackc/pgx/v5/pgconn"
+
+	"github.com/Silo-Server/silo-server/internal/userstore"
 )
 
 type profileLibraryQuerier interface {
@@ -39,6 +41,48 @@ func listProfileAllowedLibraries(ctx context.Context, q profileLibraryQuerier, u
 		return nil, fmt.Errorf("iterating allowed libraries for profile %s: %w", profileID, err)
 	}
 	return libraryIDs, nil
+}
+
+// attachAllowedLibraries fills AllowedLibraryIDs for every profile with a
+// single batched query, avoiding the N+1 round trip a per-profile lookup
+// would create.
+func (s *PostgresUserStore) attachAllowedLibraries(ctx context.Context, profiles []userstore.Profile) error {
+	if len(profiles) == 0 {
+		return nil
+	}
+	ids := make([]string, len(profiles))
+	for i := range profiles {
+		ids[i] = profiles[i].ID
+	}
+	rows, err := s.pool.Query(ctx,
+		`SELECT profile_id, library_id
+		FROM user_profile_allowed_libraries
+		WHERE user_id = $1 AND profile_id = ANY($2)
+		ORDER BY library_id ASC`,
+		s.userID,
+		ids,
+	)
+	if err != nil {
+		return fmt.Errorf("listing allowed libraries for user %d: %w", s.userID, err)
+	}
+	defer rows.Close()
+
+	byProfile := make(map[string][]int, len(profiles))
+	for rows.Next() {
+		var profileID string
+		var libraryID int
+		if err := rows.Scan(&profileID, &libraryID); err != nil {
+			return fmt.Errorf("scanning allowed library for user %d: %w", s.userID, err)
+		}
+		byProfile[profileID] = append(byProfile[profileID], libraryID)
+	}
+	if err := rows.Err(); err != nil {
+		return fmt.Errorf("iterating allowed libraries for user %d: %w", s.userID, err)
+	}
+	for i := range profiles {
+		profiles[i].AllowedLibraryIDs = byProfile[profiles[i].ID]
+	}
+	return nil
 }
 
 func replaceProfileAllowedLibraries(ctx context.Context, q profileLibraryQuerier, userID int, profileID string, libraryIDs []int) error {

--- a/internal/userstore/pgstore/profile_libraries.go
+++ b/internal/userstore/pgstore/profile_libraries.go
@@ -67,21 +67,18 @@ func (s *PostgresUserStore) attachAllowedLibraries(ctx context.Context, profiles
 	}
 	defer rows.Close()
 
-	byProfile := make(map[string][]int, len(profiles))
+	var allowedLibraries []userstore.ProfileAllowedLibrary
 	for rows.Next() {
-		var profileID string
-		var libraryID int
-		if err := rows.Scan(&profileID, &libraryID); err != nil {
+		var allowedLibrary userstore.ProfileAllowedLibrary
+		if err := rows.Scan(&allowedLibrary.ProfileID, &allowedLibrary.LibraryID); err != nil {
 			return fmt.Errorf("scanning allowed library for user %d: %w", s.userID, err)
 		}
-		byProfile[profileID] = append(byProfile[profileID], libraryID)
+		allowedLibraries = append(allowedLibraries, allowedLibrary)
 	}
 	if err := rows.Err(); err != nil {
 		return fmt.Errorf("iterating allowed libraries for user %d: %w", s.userID, err)
 	}
-	for i := range profiles {
-		profiles[i].AllowedLibraryIDs = byProfile[profiles[i].ID]
-	}
+	userstore.AttachAllowedLibraries(profiles, allowedLibraries)
 	return nil
 }
 

--- a/internal/userstore/pgstore/profiles.go
+++ b/internal/userstore/pgstore/profiles.go
@@ -126,14 +126,13 @@ func (s *PostgresUserStore) ListProfiles(ctx context.Context) ([]userstore.Profi
 		if err != nil {
 			return nil, fmt.Errorf("scanning profile row: %w", err)
 		}
-		p.AllowedLibraryIDs, err = listProfileAllowedLibraries(ctx, s.pool, s.userID, p.ID)
-		if err != nil {
-			return nil, err
-		}
 		profiles = append(profiles, *p)
 	}
 	if err := rows.Err(); err != nil {
 		return nil, fmt.Errorf("iterating profile rows: %w", err)
+	}
+	if err := s.attachAllowedLibraries(ctx, profiles); err != nil {
+		return nil, err
 	}
 	return profiles, nil
 }

--- a/internal/userstore/profile_libraries.go
+++ b/internal/userstore/profile_libraries.go
@@ -1,0 +1,22 @@
+package userstore
+
+// ProfileAllowedLibrary associates one profile with one allowed library.
+type ProfileAllowedLibrary struct {
+	ProfileID string
+	LibraryID int
+}
+
+// AttachAllowedLibraries replaces each profile's AllowedLibraryIDs with the
+// matching associations, preserving their input order.
+func AttachAllowedLibraries(profiles []Profile, allowedLibraries []ProfileAllowedLibrary) {
+	byProfile := make(map[string][]int, len(profiles))
+	for _, allowedLibrary := range allowedLibraries {
+		byProfile[allowedLibrary.ProfileID] = append(
+			byProfile[allowedLibrary.ProfileID],
+			allowedLibrary.LibraryID,
+		)
+	}
+	for i := range profiles {
+		profiles[i].AllowedLibraryIDs = byProfile[profiles[i].ID]
+	}
+}

--- a/internal/userstore/profile_libraries_test.go
+++ b/internal/userstore/profile_libraries_test.go
@@ -1,0 +1,31 @@
+package userstore
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestAttachAllowedLibraries(t *testing.T) {
+	profiles := []Profile{
+		{ID: "p1", AllowedLibraryIDs: []int{99}},
+		{ID: "p2", AllowedLibraryIDs: []int{99}},
+		{ID: "p3", AllowedLibraryIDs: []int{99}},
+	}
+	allowedLibraries := []ProfileAllowedLibrary{
+		{ProfileID: "p2", LibraryID: 1},
+		{ProfileID: "p1", LibraryID: 2},
+		{ProfileID: "p1", LibraryID: 5},
+	}
+
+	AttachAllowedLibraries(profiles, allowedLibraries)
+
+	if got, want := profiles[0].AllowedLibraryIDs, []int{2, 5}; !reflect.DeepEqual(got, want) {
+		t.Fatalf("p1 AllowedLibraryIDs = %v, want %v", got, want)
+	}
+	if got, want := profiles[1].AllowedLibraryIDs, []int{1}; !reflect.DeepEqual(got, want) {
+		t.Fatalf("p2 AllowedLibraryIDs = %v, want %v", got, want)
+	}
+	if profiles[2].AllowedLibraryIDs != nil {
+		t.Fatalf("p3 AllowedLibraryIDs = %v, want nil", profiles[2].AllowedLibraryIDs)
+	}
+}


### PR DESCRIPTION
Listing profiles was costing 1 + P queries: one allowed-libraries lookup fired per profile row while the cursor was still open, which on Postgres also checks out a second pooled connection mid-scan. The admin sessions dashboard makes it worse by calling ListProfiles once per streaming user just to resolve names. The SQLite store had the same pattern for both profiles and collections, even though the Postgres collections path was already written with array_agg to avoid exactly this.

Now the rows are collected first and the child lists come back in one batched query. No behaviour change, just fewer round trips.

Tested locally: profile and collection listings return the same data in the same order as before, now with one batched child query instead of one per row.

Built with AI assistance. I've read through the whole diff and tested it myself, and I'm happy to own it.
