### PR TITLE
fix(api): throttle api_keys last_used_at writes in auth middleware

### DIFF
--- a/internal/api/middleware/auth.go
+++ b/internal/api/middleware/auth.go
@@ -7,6 +7,8 @@ import (
 	"encoding/json"
 	"net/http"
 	"strings"
+	"sync"
+	"time"
 
 	"github.com/Silo-Server/silo-server/internal/activitylog"
 	"github.com/Silo-Server/silo-server/internal/auth"
@@ -40,6 +42,11 @@ type APIKeyUserLoader interface {
 	GetByID(ctx context.Context, id int) (*models.User, error)
 }
 
+// apiKeyLastUsedInterval throttles api_keys.last_used_at writes so that
+// per-request validation on the hot path (e.g. HLS segments) does not issue
+// a DB write each time. Matches the jellycompat authenticator.
+const apiKeyLastUsedInterval = time.Minute
+
 // AuthMiddleware provides HTTP middleware for JWT-based authentication with
 // session validity caching.
 type AuthMiddleware struct {
@@ -47,6 +54,9 @@ type AuthMiddleware struct {
 	sessionValidator SessionValidator
 	apiKeyValidator  APIKeyValidator  // nil if API keys not configured
 	apiKeyUserLoader APIKeyUserLoader // nil if API keys not configured
+
+	lastUsedMu sync.Mutex
+	lastUsedAt map[int64]time.Time
 }
 
 // NewAuthMiddleware creates a new AuthMiddleware with the given token validator
@@ -57,7 +67,28 @@ func NewAuthMiddleware(tv TokenValidator, sv SessionValidator, akv APIKeyValidat
 		sessionValidator: sv,
 		apiKeyValidator:  akv,
 		apiKeyUserLoader: akul,
+		lastUsedAt:       make(map[int64]time.Time),
 	}
+}
+
+// touchLastUsed records key usage without blocking the request, throttled to
+// at most once per apiKeyLastUsedInterval per key. The map is bounded by the
+// number of API keys, so it never needs eviction.
+func (am *AuthMiddleware) touchLastUsed(id int64) {
+	now := time.Now()
+	am.lastUsedMu.Lock()
+	if last, ok := am.lastUsedAt[id]; ok && now.Sub(last) < apiKeyLastUsedInterval {
+		am.lastUsedMu.Unlock()
+		return
+	}
+	am.lastUsedAt[id] = now
+	am.lastUsedMu.Unlock()
+
+	go func(id int64) {
+		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+		_ = am.apiKeyValidator.UpdateLastUsed(ctx, id)
+	}(id)
 }
 
 // RequireAuth is an HTTP middleware that enforces JWT authentication.
@@ -98,10 +129,7 @@ func (am *AuthMiddleware) RequireAuth(next http.Handler) http.Handler {
 				return
 			}
 
-			// Update last_used_at asynchronously.
-			go func(id int64) {
-				_ = am.apiKeyValidator.UpdateLastUsed(context.Background(), id)
-			}(apiKey.ID)
+			am.touchLastUsed(apiKey.ID)
 
 			claims = &auth.Claims{
 				UserID:    user.ID,

--- a/internal/api/middleware/auth.go
+++ b/internal/api/middleware/auth.go
@@ -7,8 +7,6 @@ import (
 	"encoding/json"
 	"net/http"
 	"strings"
-	"sync"
-	"time"
 
 	"github.com/Silo-Server/silo-server/internal/activitylog"
 	"github.com/Silo-Server/silo-server/internal/auth"
@@ -42,11 +40,6 @@ type APIKeyUserLoader interface {
 	GetByID(ctx context.Context, id int) (*models.User, error)
 }
 
-// apiKeyLastUsedInterval throttles api_keys.last_used_at writes so that
-// per-request validation on the hot path (e.g. HLS segments) does not issue
-// a DB write each time. Matches the jellycompat authenticator.
-const apiKeyLastUsedInterval = time.Minute
-
 // AuthMiddleware provides HTTP middleware for JWT-based authentication with
 // session validity caching.
 type AuthMiddleware struct {
@@ -55,8 +48,7 @@ type AuthMiddleware struct {
 	apiKeyValidator  APIKeyValidator  // nil if API keys not configured
 	apiKeyUserLoader APIKeyUserLoader // nil if API keys not configured
 
-	lastUsedMu sync.Mutex
-	lastUsedAt map[int64]time.Time
+	apiKeyLastUsed *auth.APIKeyLastUsedTracker
 }
 
 // NewAuthMiddleware creates a new AuthMiddleware with the given token validator
@@ -67,28 +59,8 @@ func NewAuthMiddleware(tv TokenValidator, sv SessionValidator, akv APIKeyValidat
 		sessionValidator: sv,
 		apiKeyValidator:  akv,
 		apiKeyUserLoader: akul,
-		lastUsedAt:       make(map[int64]time.Time),
+		apiKeyLastUsed:   auth.NewAPIKeyLastUsedTracker(akv, nil),
 	}
-}
-
-// touchLastUsed records key usage without blocking the request, throttled to
-// at most once per apiKeyLastUsedInterval per key. The map is bounded by the
-// number of API keys, so it never needs eviction.
-func (am *AuthMiddleware) touchLastUsed(id int64) {
-	now := time.Now()
-	am.lastUsedMu.Lock()
-	if last, ok := am.lastUsedAt[id]; ok && now.Sub(last) < apiKeyLastUsedInterval {
-		am.lastUsedMu.Unlock()
-		return
-	}
-	am.lastUsedAt[id] = now
-	am.lastUsedMu.Unlock()
-
-	go func(id int64) {
-		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
-		defer cancel()
-		_ = am.apiKeyValidator.UpdateLastUsed(ctx, id)
-	}(id)
 }
 
 // RequireAuth is an HTTP middleware that enforces JWT authentication.
@@ -129,7 +101,7 @@ func (am *AuthMiddleware) RequireAuth(next http.Handler) http.Handler {
 				return
 			}
 
-			am.touchLastUsed(apiKey.ID)
+			am.apiKeyLastUsed.Touch(apiKey.ID)
 
 			claims = &auth.Claims{
 				UserID:    user.ID,

--- a/internal/auth/api_key_last_used.go
+++ b/internal/auth/api_key_last_used.go
@@ -1,0 +1,80 @@
+package auth
+
+import (
+	"context"
+	"log/slog"
+	"sync"
+	"time"
+)
+
+const (
+	apiKeyLastUsedInterval = time.Minute
+	apiKeyLastUsedTimeout  = 5 * time.Second
+)
+
+// APIKeyLastUsedUpdater persists an API key's last-used timestamp.
+type APIKeyLastUsedUpdater interface {
+	UpdateLastUsed(ctx context.Context, id int64) error
+}
+
+// APIKeyLastUsedTracker coalesces last-used writes per key without blocking
+// authentication requests. Stale entries are pruned inline once per interval,
+// avoiding both unbounded historical-key retention and another goroutine.
+type APIKeyLastUsedTracker struct {
+	updater APIKeyLastUsedUpdater
+	now     func() time.Time
+
+	mu         sync.Mutex
+	lastUsedAt map[int64]time.Time
+	nextPrune  time.Time
+}
+
+// NewAPIKeyLastUsedTracker creates a tracker. A nil clock uses time.Now.
+func NewAPIKeyLastUsedTracker(updater APIKeyLastUsedUpdater, now func() time.Time) *APIKeyLastUsedTracker {
+	if now == nil {
+		now = time.Now
+	}
+	return &APIKeyLastUsedTracker{
+		updater:    updater,
+		now:        now,
+		lastUsedAt: make(map[int64]time.Time),
+	}
+}
+
+// Touch records key usage asynchronously, at most once per interval per key.
+func (t *APIKeyLastUsedTracker) Touch(id int64) {
+	if t == nil || t.updater == nil || !t.shouldUpdate(id) {
+		return
+	}
+
+	go func() {
+		ctx, cancel := context.WithTimeout(context.Background(), apiKeyLastUsedTimeout)
+		defer cancel()
+		if err := t.updater.UpdateLastUsed(ctx, id); err != nil {
+			slog.DebugContext(ctx, "api key last-used update failed", "component", "auth", "id", id, "error", err)
+		}
+	}()
+}
+
+func (t *APIKeyLastUsedTracker) shouldUpdate(id int64) bool {
+	now := t.now()
+
+	t.mu.Lock()
+	defer t.mu.Unlock()
+
+	if t.nextPrune.IsZero() || !now.Before(t.nextPrune) {
+		cutoff := now.Add(-apiKeyLastUsedInterval)
+		for keyID, lastUsed := range t.lastUsedAt {
+			if !lastUsed.After(cutoff) {
+				delete(t.lastUsedAt, keyID)
+			}
+		}
+		t.nextPrune = now.Add(apiKeyLastUsedInterval)
+	}
+
+	if lastUsed, ok := t.lastUsedAt[id]; ok && now.Sub(lastUsed) < apiKeyLastUsedInterval {
+		return false
+	}
+	t.lastUsedAt[id] = now
+	return true
+}

--- a/internal/auth/api_key_last_used_test.go
+++ b/internal/auth/api_key_last_used_test.go
@@ -1,0 +1,82 @@
+package auth
+
+import (
+	"context"
+	"testing"
+	"time"
+)
+
+type recordingLastUsedUpdater struct {
+	calls chan lastUsedCall
+}
+
+type lastUsedCall struct {
+	id       int64
+	deadline time.Time
+}
+
+func (u *recordingLastUsedUpdater) UpdateLastUsed(ctx context.Context, id int64) error {
+	deadline, _ := ctx.Deadline()
+	u.calls <- lastUsedCall{id: id, deadline: deadline}
+	return nil
+}
+
+func TestAPIKeyLastUsedTrackerThrottlesPerKey(t *testing.T) {
+	now := time.Date(2026, time.July, 20, 12, 0, 0, 0, time.UTC)
+	tracker := NewAPIKeyLastUsedTracker(nil, func() time.Time { return now })
+
+	if !tracker.shouldUpdate(1) {
+		t.Fatal("first use should update")
+	}
+	if tracker.shouldUpdate(1) {
+		t.Fatal("repeat use inside the interval should be throttled")
+	}
+	if !tracker.shouldUpdate(2) {
+		t.Fatal("a different key should update independently")
+	}
+
+	now = now.Add(apiKeyLastUsedInterval)
+	if !tracker.shouldUpdate(1) {
+		t.Fatal("use at the next interval should update")
+	}
+}
+
+func TestAPIKeyLastUsedTrackerPrunesExpiredKeys(t *testing.T) {
+	now := time.Date(2026, time.July, 20, 12, 0, 0, 0, time.UTC)
+	tracker := NewAPIKeyLastUsedTracker(nil, func() time.Time { return now })
+
+	tracker.shouldUpdate(1)
+	tracker.shouldUpdate(2)
+
+	now = now.Add(apiKeyLastUsedInterval)
+	tracker.shouldUpdate(3)
+
+	if len(tracker.lastUsedAt) != 1 {
+		t.Fatalf("retained entries = %d, want 1", len(tracker.lastUsedAt))
+	}
+	if _, ok := tracker.lastUsedAt[3]; !ok {
+		t.Fatal("current key was not retained")
+	}
+}
+
+func TestAPIKeyLastUsedTrackerAddsWriteDeadline(t *testing.T) {
+	updater := &recordingLastUsedUpdater{calls: make(chan lastUsedCall, 1)}
+	tracker := NewAPIKeyLastUsedTracker(updater, nil)
+	tracker.Touch(42)
+
+	select {
+	case call := <-updater.calls:
+		if call.id != 42 {
+			t.Fatalf("key id = %d, want 42", call.id)
+		}
+		if call.deadline.IsZero() {
+			t.Fatal("last-used update context has no deadline")
+		}
+		remaining := time.Until(call.deadline)
+		if remaining <= 0 || remaining > apiKeyLastUsedTimeout {
+			t.Fatalf("deadline after %s, want within (0, %s]", remaining, apiKeyLastUsedTimeout)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for last-used update")
+	}
+}

--- a/internal/jellycompat/auth_api_key.go
+++ b/internal/jellycompat/auth_api_key.go
@@ -9,6 +9,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/Silo-Server/silo-server/internal/auth"
 	"github.com/Silo-Server/silo-server/internal/models"
 	"github.com/Silo-Server/silo-server/internal/userstore"
 )
@@ -36,8 +37,7 @@ type AdminAPIKeyAuthenticator struct {
 	// authorization decision, which is re-checked on every request.
 	profiles *apiKeyProfileCache
 
-	lastUsedMu sync.Mutex
-	lastUsedAt map[int64]time.Time
+	apiKeyLastUsed *auth.APIKeyLastUsedTracker
 }
 
 type adminAPIKeyAuthResult struct {
@@ -61,12 +61,12 @@ func NewAdminAPIKeyAuthenticator(keys apiKeyValidator, users apiKeyUserLoader, p
 		now = time.Now
 	}
 	return &AdminAPIKeyAuthenticator{
-		keys:       keys,
-		users:      users,
-		provider:   provider,
-		now:        now,
-		profiles:   newAPIKeyProfileCache(),
-		lastUsedAt: make(map[int64]time.Time),
+		keys:           keys,
+		users:          users,
+		provider:       provider,
+		now:            now,
+		profiles:       newAPIKeyProfileCache(),
+		apiKeyLastUsed: auth.NewAPIKeyLastUsedTracker(keys, now),
 	}
 }
 
@@ -138,7 +138,7 @@ func (a *AdminAPIKeyAuthenticator) authenticate(r *http.Request) adminAPIKeyAuth
 	if !res.ok {
 		return res
 	}
-	a.touchLastUsed(apiKey.ID)
+	a.apiKeyLastUsed.Touch(apiKey.ID)
 	return adminAPIKeyAuthResult{
 		ctx:    context.WithValue(r.Context(), adminAPIKeyKey, true),
 		status: http.StatusOK,
@@ -182,28 +182,6 @@ func (a *AdminAPIKeyAuthenticator) validate(ctx context.Context, token string) (
 	return apiKey, user, adminAPIKeyAuthResult{ok: true}
 }
 
-// touchLastUsed records key usage without blocking the request, throttled to at
-// most once per apiKeyLastUsedInterval per key so per-request validation on the
-// hot path (e.g. HLS segments) does not issue a DB write each time.
-func (a *AdminAPIKeyAuthenticator) touchLastUsed(id int64) {
-	now := a.now()
-	a.lastUsedMu.Lock()
-	if last, ok := a.lastUsedAt[id]; ok && now.Sub(last) < apiKeyLastUsedInterval {
-		a.lastUsedMu.Unlock()
-		return
-	}
-	a.lastUsedAt[id] = now
-	a.lastUsedMu.Unlock()
-
-	go func(id int64) {
-		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
-		defer cancel()
-		if err := a.keys.UpdateLastUsed(ctx, id); err != nil {
-			slog.Debug("jellycompat api key last-used update failed", "id", id, "error", err)
-		}
-	}(id)
-}
-
 // resolveSession authenticates an sa_ API key and returns a compat session
 // synthesized for the key user's primary profile, so ordinary browse/stream
 // handlers (which read SessionFromContext) work unchanged for an API key.
@@ -224,7 +202,7 @@ func (a *AdminAPIKeyAuthenticator) resolveSession(ctx context.Context, token str
 	if !res.ok {
 		return nil, res, true
 	}
-	a.touchLastUsed(apiKey.ID)
+	a.apiKeyLastUsed.Touch(apiKey.ID)
 
 	profile, err := a.primaryProfile(ctx, user.ID)
 	if err != nil {
@@ -298,9 +276,6 @@ const (
 	// reassigned/renamed primary profile is picked up, never authorization
 	// (the key and user are re-validated on every request).
 	apiKeyProfileCacheTTL = 5 * time.Minute
-	// apiKeyLastUsedInterval throttles api_keys.last_used_at writes so that
-	// per-request validation on the hot path does not write each time.
-	apiKeyLastUsedInterval = time.Minute
 )
 
 type apiKeyProfileCacheEntry struct {


### PR DESCRIPTION
Every API key request was spawning a goroutine that issued an UPDATE on api_keys, so a key driving HLS segments or a polling integration hammered the table with one write per request, and a stalled database could pile those goroutines up without bound. The main middleware was missing the once-per-minute throttle already used by the Jellycompat authenticator.

This moves the behavior into a shared auth-owned tracker used by both paths. It records usage at most once per minute per key, puts a five-second timeout on each background write, logs failures, and prunes expired throttle entries inline once per interval so deleted or rotated key IDs do not accumulate for the life of the process.

Validated locally:

- `GOWORK=off go test ./internal/auth ./internal/api/middleware`
- `GOWORK=off go test ./internal/jellycompat -run 'TestRequireAdminAPIKey|TestRequireSessionOrAPIKeySession|TestResolveSession'`
- `GOWORK=off go test -race ./internal/auth ./internal/api/middleware`

Built with AI assistance. The resulting diff was read, tested, and independently reviewed before merge.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * API key usage tracking is now more efficient by consolidating updates and limiting repeated writes.
  * Authentication flows continue recording when API keys were last used, including compatibility session flows.
  * Background updates now use timeouts to improve reliability and prevent unbounded tracking data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->