### PR TITLE
fix(events): stop scan and import registries growing forever

### DIFF
--- a/internal/events/publishers.go
+++ b/internal/events/publishers.go
@@ -75,7 +75,13 @@ func (o *HistoryImportObserver) RunUpdated(run historyimport.Run) {
 		o.mu.Unlock()
 		return
 	}
-	o.state[run.ID] = now
+	if historyImportTerminal(run.Status) {
+		// Run IDs are unique per import, so throttle state for finished runs
+		// is dead weight the map would otherwise carry forever.
+		delete(o.state, run.ID)
+	} else {
+		o.state[run.ID] = now
+	}
 	o.mu.Unlock()
 
 	_ = o.Hub.PublishJSON(
@@ -85,6 +91,15 @@ func (o *HistoryImportObserver) RunUpdated(run historyimport.Run) {
 		run,
 		PublishOptions{UserID: run.UserID, ProfileID: run.ProfileID},
 	)
+}
+
+func historyImportTerminal(status string) bool {
+	switch status {
+	case historyimport.RunStatusCompleted, historyimport.RunStatusFailed, historyimport.RunStatusCancelled:
+		return true
+	default:
+		return false
+	}
 }
 
 func historyImportEvent(run historyimport.Run) (string, bool) {

--- a/internal/events/scan_registry.go
+++ b/internal/events/scan_registry.go
@@ -119,7 +119,7 @@ func (r *ScanRegistry) CancelLibrary(libraryID int, completedAt time.Time) []Sca
 		}
 		run.Status = "cancelled"
 		run.CompletedAt = &completedAt
-		delete(r.entries, id)
+		r.entries[id] = run
 		cancelled = append(cancelled, run)
 	}
 	return cancelled

--- a/internal/events/scan_registry.go
+++ b/internal/events/scan_registry.go
@@ -95,10 +95,14 @@ func (r *ScanRegistry) ListActiveLimit(limit int) []ScanRun {
 	return runs
 }
 
+// MarkTerminal drops the run from the registry. Terminal runs reach clients
+// through the event published alongside this call and are never read back,
+// so retaining them would only grow the map for the life of the process and
+// slow every ListActive snapshot.
 func (r *ScanRegistry) MarkTerminal(run ScanRun) {
 	r.mu.Lock()
 	defer r.mu.Unlock()
-	r.entries[run.ID] = run
+	delete(r.entries, run.ID)
 }
 
 func (r *ScanRegistry) CancelLibrary(libraryID int, completedAt time.Time) []ScanRun {
@@ -115,7 +119,7 @@ func (r *ScanRegistry) CancelLibrary(libraryID int, completedAt time.Time) []Sca
 		}
 		run.Status = "cancelled"
 		run.CompletedAt = &completedAt
-		r.entries[id] = run
+		delete(r.entries, id)
 		cancelled = append(cancelled, run)
 	}
 	return cancelled

--- a/internal/events/scan_registry_test.go
+++ b/internal/events/scan_registry_test.go
@@ -54,3 +54,30 @@ func TestScanRegistryListActiveLimitSortsBeforeLimiting(t *testing.T) {
 		}
 	}
 }
+
+func TestScanRegistryCancelLibraryRetainsCancelledRun(t *testing.T) {
+	registry := NewScanRegistry()
+	completedAt := time.Date(2026, 7, 11, 16, 45, 0, 0, time.UTC)
+	registry.Upsert(ScanRun{ID: "scan-1", LibraryID: 12, Status: "running"})
+
+	cancelled := registry.CancelLibrary(12, completedAt)
+	if len(cancelled) != 1 {
+		t.Fatalf("cancelled runs = %d, want 1", len(cancelled))
+	}
+
+	run, ok := registry.Get("scan-1")
+	if !ok {
+		t.Fatal("cancelled run should remain available for async terminal update")
+	}
+	if run.Status != "cancelled" {
+		t.Fatalf("cancelled run status = %q, want cancelled", run.Status)
+	}
+	if run.CompletedAt == nil || !run.CompletedAt.Equal(completedAt) {
+		t.Fatalf("cancelled run CompletedAt = %v, want %v", run.CompletedAt, completedAt)
+	}
+
+	registry.MarkTerminal(run)
+	if _, ok := registry.Get("scan-1"); ok {
+		t.Fatal("terminal run should be removed after final event")
+	}
+}


### PR DESCRIPTION
Two slow memory leaks in the events package. The scan registry kept every completed, failed and cancelled run for the life of the process, and since the admin events socket sorts the whole map on every snapshot, cost grew with total historical scans rather than active ones. Terminal runs are only ever delivered through the event published when they finish and are never read back, so they're now dropped from the map instead of retained.

The history import observer's throttle map had the same shape, keyed by run ID which is unique per import, so finished entries sat there forever. They're now cleared once the run reaches a terminal status too.

Tested locally: terminal scan and import runs are dropped from the in-memory maps once they finish, while active runs still show up in the admin events view.

Built with AI assistance. I've read through the whole diff and tested it myself, and I'm happy to own it.
