### PR TITLE
fix(jellycompat): stop play session ids leaking into the id codec map

### DIFF
--- a/internal/jellycompat/idcodec.go
+++ b/internal/jellycompat/idcodec.go
@@ -105,6 +105,15 @@ func (c *ResourceIDCodec) EncodeStringID(kind EncodedIDType, value string) strin
 	}
 	encoded := uuid.NewSHA1(namespace, []byte(value))
 
+	// Play-session ids are minted from a fresh random UUID on every
+	// PlaybackInfo/stream-open and are never decoded back: clients echo the
+	// encoded id and it is matched as an opaque string. Recording them would
+	// grow the reverse map by one permanent entry per playback for the life
+	// of the process.
+	if kind == EncodedIDPlaySession {
+		return encoded.String()
+	}
+
 	c.mu.Lock()
 	c.reverse[encoded.String()] = registeredID{kind: kind, value: value}
 	c.mu.Unlock()

--- a/internal/jellycompat/idcodec_test.go
+++ b/internal/jellycompat/idcodec_test.go
@@ -61,3 +61,23 @@ func TestGenreNameStillUsesReverseMap(t *testing.T) {
 		t.Fatalf("genre round trip = (%q, %v), want (%q, nil)", got, err, genre)
 	}
 }
+
+// TestPlaySessionIDsAreNotRetained guards the reverse map against unbounded
+// growth: play-session ids are minted from a fresh random UUID per playback
+// and never decoded back, so encoding them must not leave an entry behind.
+// Other hashed kinds (genres, studios) dedupe by value and plateau at catalog
+// size; a retained play-session entry would live until restart.
+func TestPlaySessionIDsAreNotRetained(t *testing.T) {
+	c := NewResourceIDCodec()
+	for i := 0; i < 3; i++ {
+		if u := c.EncodeStringID(EncodedIDPlaySession, uuidNewString()); u == "" {
+			t.Fatal("EncodeStringID returned empty play session id")
+		}
+	}
+	c.mu.RLock()
+	n := len(c.reverse)
+	c.mu.RUnlock()
+	if n != 0 {
+		t.Fatalf("reverse map retained %d play session entries, want 0", n)
+	}
+}


### PR DESCRIPTION
Every PlaybackInfo request and stream open mints a fresh random UUID for the play session and runs it through EncodeStringID, which recorded it in the codec's reverse map. Play session ids are never decoded back: clients echo the encoded id and it's matched as an opaque string against the playback session store, including across restarts via the durable store. So each playback left one permanent entry in a process-lifetime singleton, and since clients probe PlaybackInfo while browsing, the map grew faster than actual plays. The other hashed kinds in there (genres, studios) dedupe by value and plateau at catalog size, so in normal operation this was the only key space feeding the map without bound.

The fix skips the reverse map write for play session ids. The guard sits after the hashing, so the returned id is byte identical and encoding stays deterministic. Even the odd case of feeding a play session UUID to DecodeStringID with a different kind behaves the same: it failed the kind check before and returned unknown compat id, now it misses the map and returns the same error.

Tested with the package's idcodec tests plus a new regression test. The new test fails against the old code (reverse map retained 3 play session entries, want 0) and passes with the fix, and the existing restart-safety, legacy numeric and genre round-trip tests all still pass.

Built with AI assistance. I've read through the whole diff and tested it myself, and I'm happy to own it.
