### PR TITLE
Perf/recs hnsw custom plan refresh debounce

### DIFF
--- a/internal/recommendations/repo.go
+++ b/internal/recommendations/repo.go
@@ -116,8 +116,13 @@ func (r *Repo) withHNSWCandidateScan(ctx context.Context, candidateLimit int, fn
 	}
 	defer tx.Rollback(ctx)
 
+	// force_custom_plan keeps the planner replanning with the real bind
+	// parameters: the generic plan pgx's prepared statements otherwise flip to
+	// after five executions cannot cost the ORDER BY ... LIMIT against the HNSW
+	// index and falls back to brute-force scans of the whole embeddings table.
 	_, err = tx.Exec(ctx, `
-		SELECT set_config('hnsw.iterative_scan', 'relaxed_order', true),
+		SELECT set_config('plan_cache_mode', 'force_custom_plan', true),
+		       set_config('hnsw.iterative_scan', 'relaxed_order', true),
 		       set_config('hnsw.ef_search', $1, true)
 	`, fmt.Sprintf("%d", hnswEfSearch(candidateLimit)))
 	if err != nil {

--- a/internal/recommendations/worker.go
+++ b/internal/recommendations/worker.go
@@ -28,9 +28,19 @@ type Worker struct {
 	running               map[JobName]bool
 	profileRefreshCh      chan profileRefreshRequest
 	profileRefreshPending map[string]struct{}
+	profileRefreshDone    map[string]time.Time
 	cancelFunc            context.CancelFunc
 	embeddingsJobTimeout  time.Duration
 }
+
+// profileRefreshMinInterval is the per-profile cooldown between full
+// recommendation refreshes. Playback progress updates arrive every few seconds
+// during an active stream and each one requests a refresh; without a cooldown
+// the worker regenerates every For You row (several pgvector ANN queries) in a
+// continuous loop for the whole session. Debounced requests are not lost: the
+// profile stays marked stale and the 5-minute stalenessLoop sweep re-requests
+// it once the cooldown has passed.
+const profileRefreshMinInterval = 5 * time.Minute
 
 const tasteProfileRefreshSubjectsQuery = `
 	SELECT DISTINCT user_id, profile_id FROM user_ratings
@@ -56,6 +66,7 @@ func NewWorker(engine *Engine, embeddingsCron, tasteProfilesCron, cowatchCron, r
 		running:               make(map[JobName]bool),
 		profileRefreshCh:      make(chan profileRefreshRequest, 256),
 		profileRefreshPending: make(map[string]struct{}),
+		profileRefreshDone:    make(map[string]time.Time),
 		embeddingsJobTimeout:  embeddingsJobTimeout,
 	}
 
@@ -193,6 +204,10 @@ func (w *Worker) RequestProfileRefresh(ctx context.Context, userID int, profileI
 
 	w.mu.Lock()
 	if _, exists := w.profileRefreshPending[key]; exists {
+		w.mu.Unlock()
+		return
+	}
+	if done, ok := w.profileRefreshDone[key]; ok && time.Since(done) < profileRefreshMinInterval {
 		w.mu.Unlock()
 		return
 	}
@@ -524,10 +539,19 @@ func (w *Worker) profileRefreshLoop(ctx context.Context) {
 		case <-ctx.Done():
 			return
 		case req := <-w.profileRefreshCh:
-			if err := w.refreshProfile(ctx, req.userID, req.profileID); err != nil {
+			err := w.refreshProfile(ctx, req.userID, req.profileID)
+			if err != nil {
 				slog.ErrorContext(ctx, "profile recommendation refresh failed", "component", "recommendations", "user_id", req.userID, "profile_id", req.profileID, "error", err)
 			}
-			w.clearProfileRefreshPending(profileRefreshKey(req.userID, req.profileID))
+			key := profileRefreshKey(req.userID, req.profileID)
+			w.mu.Lock()
+			// Only a successful refresh starts the cooldown; a failed one may be
+			// retried immediately.
+			if err == nil {
+				w.profileRefreshDone[key] = time.Now()
+			}
+			delete(w.profileRefreshPending, key)
+			w.mu.Unlock()
 		}
 	}
 }

--- a/internal/recommendations/worker_test.go
+++ b/internal/recommendations/worker_test.go
@@ -1,0 +1,81 @@
+package recommendations
+
+import (
+	"context"
+	"testing"
+	"time"
+)
+
+func newDebounceTestWorker() *Worker {
+	return &Worker{
+		engine:                &Engine{},
+		profileRefreshCh:      make(chan profileRefreshRequest, 4),
+		profileRefreshPending: make(map[string]struct{}),
+		profileRefreshDone:    make(map[string]time.Time),
+	}
+}
+
+func TestRequestProfileRefreshDebouncesAfterSuccessfulRefresh(t *testing.T) {
+	ctx := context.Background()
+	w := newDebounceTestWorker()
+	key := profileRefreshKey(1, "profile-a")
+
+	w.RequestProfileRefresh(ctx, 1, "profile-a")
+	if got := len(w.profileRefreshCh); got != 1 {
+		t.Fatalf("queued requests = %d, want 1", got)
+	}
+
+	// While the request is pending, duplicates are dropped.
+	w.RequestProfileRefresh(ctx, 1, "profile-a")
+	if got := len(w.profileRefreshCh); got != 1 {
+		t.Fatalf("queued requests with pending entry = %d, want 1", got)
+	}
+
+	// Simulate the refresh loop completing the request successfully.
+	<-w.profileRefreshCh
+	w.mu.Lock()
+	w.profileRefreshDone[key] = time.Now()
+	delete(w.profileRefreshPending, key)
+	w.mu.Unlock()
+
+	// Within the cooldown the request is debounced.
+	w.RequestProfileRefresh(ctx, 1, "profile-a")
+	if got := len(w.profileRefreshCh); got != 0 {
+		t.Fatalf("queued requests within cooldown = %d, want 0", got)
+	}
+
+	// A different profile is not affected by the cooldown.
+	w.RequestProfileRefresh(ctx, 1, "profile-b")
+	if got := len(w.profileRefreshCh); got != 1 {
+		t.Fatalf("queued requests for other profile = %d, want 1", got)
+	}
+
+	// Once the cooldown has passed the profile can refresh again.
+	w.mu.Lock()
+	w.profileRefreshDone[key] = time.Now().Add(-profileRefreshMinInterval)
+	w.mu.Unlock()
+	w.RequestProfileRefresh(ctx, 1, "profile-a")
+	if got := len(w.profileRefreshCh); got != 2 {
+		t.Fatalf("queued requests after cooldown = %d, want 2", got)
+	}
+}
+
+func TestRequestProfileRefreshAllowsRetryAfterFailedRefresh(t *testing.T) {
+	ctx := context.Background()
+	w := newDebounceTestWorker()
+	key := profileRefreshKey(1, "profile-a")
+
+	w.RequestProfileRefresh(ctx, 1, "profile-a")
+	<-w.profileRefreshCh
+
+	// Simulate the refresh loop finishing with an error: pending is cleared but
+	// no completion time is recorded, so the next request is not debounced.
+	w.mu.Lock()
+	delete(w.profileRefreshPending, key)
+	w.mu.Unlock()
+
+	w.RequestProfileRefresh(ctx, 1, "profile-a")
+	if got := len(w.profileRefreshCh); got != 1 {
+		t.Fatalf("queued requests after failed refresh = %d, want 1", got)
+	}
+}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Recommendation refreshes are now limited to once every five minutes per profile after a successful refresh, reducing unnecessary repeated processing.
  * Refresh requests for different profiles continue to be handled independently.
  * Failed refreshes can be retried immediately.
  * Recommendation search performance and consistency have been improved through updated database scan settings.
* **Tests**
  * Added coverage for refresh deduplication, cooldown enforcement, and retry behavior after failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->