### PR TITLE
perf(literaryworks): rewrite match-candidate OR into indexable UNION …

### DIFF
--- a/internal/literaryworks/match_candidates_test.go
+++ b/internal/literaryworks/match_candidates_test.go
@@ -1,0 +1,148 @@
+package literaryworks
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+)
+
+// TestListMatchCandidatesBranches covers the UNION-branch candidate query:
+// title, provider-id, and series matches must each surface candidates through
+// their own indexable branch, ignored decisions must exclude, and same-format
+// items must never match.
+func TestListMatchCandidatesBranches(t *testing.T) {
+	ctx := context.Background()
+	pool := newLiteraryWorksTestPool(t)
+	repo := NewRepository(pool)
+	suffix := time.Now().UnixNano()
+	folderID := seedLiteraryFolder(t, pool)
+
+	id := func(kind string) string { return fmt.Sprintf("%s-test-%d", kind, suffix) }
+	sourceID := id("audio-src")
+	titleMatchID := id("ebook-title")
+	seriesMatchID := id("ebook-series")
+	providerMatchID := id("ebook-provider")
+	ignoredID := id("ebook-ignored")
+	sameFormatID := id("audio-same")
+	unrelatedID := id("ebook-unrelated")
+
+	allIDs := []string{sourceID, titleMatchID, seriesMatchID, providerMatchID, ignoredID, sameFormatID, unrelatedID}
+	t.Cleanup(func() {
+		_, _ = pool.Exec(ctx, `DELETE FROM literary_work_match_decisions WHERE source_content_id = ANY($1) OR target_content_id = ANY($1)`, allIDs)
+		_, _ = pool.Exec(ctx, `DELETE FROM media_items WHERE content_id = ANY($1)`, allIDs)
+		_, _ = pool.Exec(ctx, `DELETE FROM media_folders WHERE id = $1`, folderID)
+	})
+
+	title := fmt.Sprintf("The Left Hand of Testing %d", suffix)
+	seedLiteraryMediaItem(t, pool, sourceID, FormatAudiobook, title, folderID)
+	seedLiteraryMediaItem(t, pool, titleMatchID, FormatEbook, title, folderID)
+	seedLiteraryMediaItem(t, pool, seriesMatchID, FormatEbook, "Different Series Title", folderID)
+	seedLiteraryMediaItem(t, pool, providerMatchID, FormatEbook, "Different Provider Title", folderID)
+	seedLiteraryMediaItem(t, pool, ignoredID, FormatEbook, title, folderID)
+	seedLiteraryMediaItem(t, pool, sameFormatID, FormatAudiobook, title, folderID)
+	seedLiteraryMediaItem(t, pool, unrelatedID, FormatEbook, "Completely Unrelated", folderID)
+
+	seriesName := fmt.Sprintf("Testing Cycle %d", suffix)
+	if _, err := pool.Exec(ctx, `
+		INSERT INTO ebook_series (content_id, series_name, series_index)
+		VALUES ($1, $2, 2)
+	`, seriesMatchID, seriesName); err != nil {
+		t.Fatalf("seed ebook series: %v", err)
+	}
+	providerID := fmt.Sprintf("gr-%d", suffix)
+	if _, err := pool.Exec(ctx, `
+		INSERT INTO media_item_provider_ids (content_id, provider, provider_id, item_type)
+		VALUES ($1, 'goodreads', $2, 'ebook')
+	`, providerMatchID, providerID); err != nil {
+		t.Fatalf("seed provider id: %v", err)
+	}
+	if _, err := pool.Exec(ctx, `
+		INSERT INTO literary_work_match_decisions (source_content_id, target_content_id, decision)
+		VALUES ($1, $2, 'ignored')
+	`, ignoredID, sourceID); err != nil {
+		t.Fatalf("seed ignored decision: %v", err)
+	}
+
+	seriesIndex := 2.0
+	source := MatchItem{
+		ContentID:   sourceID,
+		Type:        FormatAudiobook,
+		Title:       title,
+		SeriesName:  seriesName,
+		SeriesIndex: &seriesIndex,
+		ExternalIDs: map[string]string{"goodreads": providerID},
+	}
+
+	candidates, err := repo.ListMatchCandidates(ctx, source, 50)
+	if err != nil {
+		t.Fatalf("ListMatchCandidates: %v", err)
+	}
+	got := make(map[string]bool, len(candidates))
+	for _, c := range candidates {
+		got[c.ContentID] = true
+	}
+
+	for _, want := range []struct {
+		id     string
+		branch string
+	}{
+		{titleMatchID, "title"},
+		{seriesMatchID, "series"},
+		{providerMatchID, "provider"},
+	} {
+		if !got[want.id] {
+			t.Errorf("%s branch: candidate %s missing from %v", want.branch, want.id, candidates)
+		}
+	}
+	for _, exclude := range []struct {
+		id     string
+		reason string
+	}{
+		{ignoredID, "ignored decision"},
+		{sameFormatID, "same format as source"},
+		{sourceID, "source itself"},
+		{unrelatedID, "no matching predicate"},
+	} {
+		if got[exclude.id] {
+			t.Errorf("%s must be excluded (%s)", exclude.id, exclude.reason)
+		}
+	}
+}
+
+// TestListMatchCandidatesNoPredicatesFallsBack preserves the pre-UNION
+// behavior: a source without title/provider/series still lists every
+// opposite-format item as a candidate.
+func TestListMatchCandidatesNoPredicatesFallsBack(t *testing.T) {
+	ctx := context.Background()
+	pool := newLiteraryWorksTestPool(t)
+	repo := NewRepository(pool)
+	suffix := time.Now().UnixNano()
+	folderID := seedLiteraryFolder(t, pool)
+
+	sourceID := fmt.Sprintf("audio-nofilter-%d", suffix)
+	ebookID := fmt.Sprintf("ebook-nofilter-%d", suffix)
+	t.Cleanup(func() {
+		_, _ = pool.Exec(ctx, `DELETE FROM media_items WHERE content_id = ANY($1)`, []string{sourceID, ebookID})
+		_, _ = pool.Exec(ctx, `DELETE FROM media_folders WHERE id = $1`, folderID)
+	})
+	seedLiteraryMediaItem(t, pool, sourceID, FormatAudiobook, "Untitled Source", folderID)
+	seedLiteraryMediaItem(t, pool, ebookID, FormatEbook, "Some Ebook", folderID)
+
+	ids, err := repo.listMatchCandidateIDs(ctx, MatchItem{ContentID: sourceID, Type: FormatAudiobook}, 1000000)
+	if err != nil {
+		t.Fatalf("listMatchCandidateIDs: %v", err)
+	}
+	found := false
+	for _, id := range ids {
+		if id == ebookID {
+			found = true
+		}
+		if id == sourceID {
+			t.Fatal("source itself must not be a candidate")
+		}
+	}
+	if !found {
+		t.Fatalf("fallback branch: %s missing from %d candidates", ebookID, len(ids))
+	}
+}

--- a/internal/literaryworks/repository.go
+++ b/internal/literaryworks/repository.go
@@ -194,6 +194,12 @@ func (r *Repository) ListMatchCandidates(ctx context.Context, source MatchItem, 
 // on media_item_provider_ids, series on the format-specific series table) instead
 // of filtering on lateral aggregate output. The opposite format is fixed by the
 // source type, so the series lookup targets a single concrete table.
+//
+// The title/provider/series predicates are combined as a UNION of independently
+// indexable branches rather than one OR: mixing a column predicate with EXISTS
+// subqueries in an OR forces the planner to walk every ebook/audiobook row and
+// apply the OR as a filter (~250k rows per call on a large library), while each
+// UNION branch resolves through its own index in a handful of buffer hits.
 func (r *Repository) listMatchCandidateIDs(ctx context.Context, source MatchItem, limit int) ([]string, error) {
 	if r == nil || r.pool == nil {
 		return nil, fmt.Errorf("literary works repository requires a database pool")
@@ -204,51 +210,67 @@ func (r *Repository) listMatchCandidateIDs(ctx context.Context, source MatchItem
 		seriesTable = "audiobook_series"
 	}
 	args := []any{source.ContentID, source.Type}
-	matchFilters := make([]string, 0, 3)
+	branches := make([]string, 0, 3)
 	if strings.TrimSpace(source.Title) != "" {
 		args = append(args, source.Title)
-		matchFilters = append(matchFilters, fmt.Sprintf("LOWER(mi.title) = LOWER($%d)", len(args)))
+		branches = append(branches, fmt.Sprintf(`
+			SELECT mi.content_id, mi.title
+			FROM media_items mi
+			WHERE mi.type IN ('ebook', 'audiobook')
+			  AND mi.type <> $2
+			  AND LOWER(mi.title) = LOWER($%d)`, len(args)))
 	}
 	for provider, providerID := range source.ExternalIDs {
 		if provider == "" || provider == "asin" || providerID == "" {
 			continue
 		}
 		args = append(args, provider, providerID)
-		matchFilters = append(matchFilters, fmt.Sprintf(
-			"EXISTS (SELECT 1 FROM media_item_provider_ids mip WHERE mip.content_id = mi.content_id AND mip.provider = $%d AND mip.provider_id = $%d)",
-			len(args)-1,
-			len(args),
-		))
+		branches = append(branches, fmt.Sprintf(`
+			SELECT mi.content_id, mi.title
+			FROM media_item_provider_ids mip
+			JOIN media_items mi ON mi.content_id = mip.content_id
+			WHERE mip.provider = $%d
+			  AND mip.provider_id = $%d
+			  AND mi.type IN ('ebook', 'audiobook')
+			  AND mi.type <> $2`, len(args)-1, len(args)))
 	}
 	if strings.TrimSpace(source.SeriesName) != "" && source.SeriesIndex != nil {
 		args = append(args, source.SeriesName, *source.SeriesIndex)
-		matchFilters = append(matchFilters, fmt.Sprintf(
-			"EXISTS (SELECT 1 FROM %s bs WHERE bs.content_id = mi.content_id AND LOWER(bs.series_name) = LOWER($%d) AND bs.series_index = $%d)",
-			seriesTable,
-			len(args)-1,
-			len(args),
-		))
+		branches = append(branches, fmt.Sprintf(`
+			SELECT mi.content_id, mi.title
+			FROM %s bs
+			JOIN media_items mi ON mi.content_id = bs.content_id
+			WHERE LOWER(bs.series_name) = LOWER($%d)
+			  AND bs.series_index = $%d
+			  AND mi.type IN ('ebook', 'audiobook')
+			  AND mi.type <> $2`, seriesTable, len(args)-1, len(args)))
 	}
-	matchWhere := ""
-	if len(matchFilters) > 0 {
-		matchWhere = " AND (" + strings.Join(matchFilters, " OR ") + ")"
+	// Without any match predicate every opposite-format item is a candidate;
+	// keep that as the (rare) fallback branch so behavior is unchanged.
+	if len(branches) == 0 {
+		branches = append(branches, `
+			SELECT mi.content_id, mi.title
+			FROM media_items mi
+			WHERE mi.type IN ('ebook', 'audiobook')
+			  AND mi.type <> $2`)
 	}
 	args = append(args, limit)
 	rows, err := r.pool.Query(ctx, `
-		SELECT mi.content_id
-		FROM media_items mi
-		WHERE mi.content_id <> $1
-		  AND mi.type IN ('ebook', 'audiobook')
-		  AND mi.type <> $2
+		WITH candidates AS (`+strings.Join(branches, `
+			UNION`)+`
+		)
+		SELECT c.content_id
+		FROM candidates c
+		WHERE c.content_id <> $1
 		  AND NOT EXISTS (
 			SELECT 1 FROM literary_work_match_decisions d
 			WHERE d.decision = 'ignored'
 			  AND (
-				(d.source_content_id = $1 AND d.target_content_id = mi.content_id)
-				OR (d.source_content_id = mi.content_id AND d.target_content_id = $1)
+				(d.source_content_id = $1 AND d.target_content_id = c.content_id)
+				OR (d.source_content_id = c.content_id AND d.target_content_id = $1)
 			  )
-		  )`+matchWhere+`
-		ORDER BY mi.title ASC, mi.content_id ASC
+		  )
+		ORDER BY c.title ASC, c.content_id ASC
 		LIMIT $`+fmt.Sprint(len(args))+`
 	`, args...)
 	if err != nil {


### PR DESCRIPTION
…branches

listMatchCandidateIDs combined its title, provider-id, and series predicates in one OR. Mixing a column predicate with EXISTS subqueries in an OR defeats index selection, so the planner walked every ebook/audiobook row (~250k on a large library) and applied the OR as a filter: ~220ms and ~209k buffer hits per call, measured live. The audiobook scanner calls this once per unlinked book via AutoLinkContent, turning a full library scan into ~15 core-hours of Postgres time.

Rewriting the OR as a UNION of independently indexable branches (title via idx_media_items_books_title_lower, provider ids via their unique index, series via the *_series_name_lower indexes) resolves the same candidates in ~0.07ms and 9 buffer hits. A source with no predicates keeps the old all-opposite-format fallback. Result set, ordering, ignored-decision exclusion, and LIMIT semantics are unchanged, covered by new DB-backed tests.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved matching candidate selection for literary works using title, series, and provider information.
  * Preserved exclusions for ignored matches, same-format items, source items, and unrelated content.
  * Added fallback matching to include opposite-format items when no matching details are available.
  * Maintained candidate ordering and result limits for consistent results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->