### PR TITLE
fix(scanner): make the audiobook rescan skip path actually fire

### DIFF
--- a/internal/scanner/audiobook.go
+++ b/internal/scanner/audiobook.go
@@ -125,25 +125,25 @@ func parseAudiobookFolder(ctx context.Context, ffprobePath string, folderPath st
 	}
 
 	var audioFiles []string
-	fileStats := make(map[string]os.FileInfo)
 	for _, entry := range entries {
 		if entry.IsDir() {
 			continue
 		}
 		if SupportsAudioFile(entry.Name()) {
-			full := filepath.Join(folderPath, entry.Name())
-			audioFiles = append(audioFiles, full)
-			if info, err := entry.Info(); err == nil {
-				fileStats[full] = info
-			}
+			audioFiles = append(audioFiles, filepath.Join(folderPath, entry.Name()))
 		}
 	}
 	if len(audioFiles) == 0 {
 		return nil, fmt.Errorf("audiobook folder %s: %w", folderPath, os.ErrNotExist)
 	}
 	sort.Strings(audioFiles)
+	// os.Stat (not DirEntry.Info, which has lstat semantics) so symlinked
+	// audio files record the target's size/mtime — the same values
+	// audiobookFolderShouldSkip compares against on rescans. A zero value
+	// (stat failure) never matches, keeping the book on the full-reconcile
+	// path.
 	statOf := func(path string) (size int64, modTime time.Time) {
-		if info, ok := fileStats[path]; ok {
+		if info, err := os.Stat(path); err == nil {
 			return info.Size(), info.ModTime()
 		}
 		return 0, time.Time{}

--- a/internal/scanner/audiobook.go
+++ b/internal/scanner/audiobook.go
@@ -8,6 +8,7 @@ import (
 	"regexp"
 	"sort"
 	"strings"
+	"time"
 )
 
 // narratorSuffixRE matches a trailing "read by X" / "(Read by X)" /
@@ -100,6 +101,12 @@ type parsedAudiobookFile struct {
 	CodecAudio    string // aac, mp3, opus, flac
 	Container     string // m4b, mp3, mka, ...
 	AudioChannels int
+	// Size and ModTime feed media_files.file_size/file_modified_at, which
+	// audiobookFolderShouldSkip compares against the disk state on rescans.
+	// Zero values mean the stat failed; the row then never matches and the
+	// book keeps taking the full reconcile path (safe degradation).
+	Size    int64
+	ModTime time.Time
 }
 
 // parseAudiobookFolder reads a single audiobook folder and returns its
@@ -118,18 +125,29 @@ func parseAudiobookFolder(ctx context.Context, ffprobePath string, folderPath st
 	}
 
 	var audioFiles []string
+	fileStats := make(map[string]os.FileInfo)
 	for _, entry := range entries {
 		if entry.IsDir() {
 			continue
 		}
 		if SupportsAudioFile(entry.Name()) {
-			audioFiles = append(audioFiles, filepath.Join(folderPath, entry.Name()))
+			full := filepath.Join(folderPath, entry.Name())
+			audioFiles = append(audioFiles, full)
+			if info, err := entry.Info(); err == nil {
+				fileStats[full] = info
+			}
 		}
 	}
 	if len(audioFiles) == 0 {
 		return nil, fmt.Errorf("audiobook folder %s: %w", folderPath, os.ErrNotExist)
 	}
 	sort.Strings(audioFiles)
+	statOf := func(path string) (size int64, modTime time.Time) {
+		if info, ok := fileStats[path]; ok {
+			return info.Size(), info.ModTime()
+		}
+		return 0, time.Time{}
+	}
 
 	book := &parsedAudiobook{}
 
@@ -140,6 +158,7 @@ func parseAudiobookFolder(ctx context.Context, ffprobePath string, folderPath st
 		}
 		book.populateFromTags(probed.FormatTags)
 		book.applyFilesystemFallbacks(folderPath, audioFiles)
+		size, modTime := statOf(audioFiles[0])
 		book.Files = []parsedAudiobookFile{{
 			Path:          audioFiles[0],
 			Chapters:      probed.Chapters,
@@ -148,6 +167,8 @@ func parseAudiobookFolder(ctx context.Context, ffprobePath string, folderPath st
 			CodecAudio:    probed.CodecAudio,
 			Container:     probed.Container,
 			AudioChannels: probed.AudioChannels,
+			Size:          size,
+			ModTime:       modTime,
 		}}
 		return book, nil
 	}
@@ -169,6 +190,7 @@ func parseAudiobookFolder(ctx context.Context, ffprobePath string, folderPath st
 		if err != nil {
 			return nil, fmt.Errorf("probe audiobook file %s: %w", path, err)
 		}
+		size, modTime := statOf(path)
 		book.Files = append(book.Files, parsedAudiobookFile{
 			Path: path,
 			Chapters: []ChapterInfo{{
@@ -182,6 +204,8 @@ func parseAudiobookFolder(ctx context.Context, ffprobePath string, folderPath st
 			CodecAudio:    probed.CodecAudio,
 			Container:     probed.Container,
 			AudioChannels: probed.AudioChannels,
+			Size:          size,
+			ModTime:       modTime,
 		})
 	}
 	return book, nil

--- a/internal/scanner/audiobook_scan.go
+++ b/internal/scanner/audiobook_scan.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"io/fs"
 	"log/slog"
 	"os"
 	"path/filepath"
@@ -19,6 +18,7 @@ import (
 	"github.com/Silo-Server/silo-server/internal/titleutil"
 	"github.com/jackc/pgx/v5"
 	"github.com/jackc/pgx/v5/pgconn"
+	"golang.org/x/sync/errgroup"
 )
 
 type filesystemRootContentFinder interface {
@@ -222,42 +222,11 @@ func collectAudiobookRootScans(ctx context.Context, folderID int, roots []string
 			scan.rootErr = fmt.Errorf("root is not a directory after symlink resolution")
 		}
 		if statErr == nil && scan.rootErr == nil {
-			walkErr := filepath.WalkDir(cleanRoot, func(path string, d fs.DirEntry, walkErr error) error {
-				if err := ctx.Err(); err != nil {
-					return err
+			if err := walkAudiobookRoot(ctx, &scan, cleanRoot); err != nil {
+				if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
+					return nil, err
 				}
-				if walkErr != nil {
-					scan.walkFailures++
-					slog.WarnContext(ctx, "audiobook scan: walk error", "component", "scanner", "path", path, "error", walkErr)
-					return nil
-				}
-				if !d.IsDir() {
-					return nil
-				}
-				entries, err := os.ReadDir(path)
-				if err != nil {
-					scan.walkFailures++
-					slog.WarnContext(ctx, "audiobook scan: read dir failed", "component", "scanner", "path", path, "error", err)
-					return nil
-				}
-				hadAudio := false
-				for _, e := range entries {
-					if !e.IsDir() && SupportsAudioFile(e.Name()) {
-						scan.seenPaths[filepath.Join(path, e.Name())] = true
-						hadAudio = true
-					}
-				}
-				if hadAudio {
-					scan.candidates = append(scan.candidates, path)
-					return filepath.SkipDir
-				}
-				return nil
-			})
-			if walkErr != nil {
-				if errors.Is(walkErr, context.Canceled) || errors.Is(walkErr, context.DeadlineExceeded) {
-					return nil, walkErr
-				}
-				scan.rootErr = fmt.Errorf("walk root: %w", walkErr)
+				scan.rootErr = fmt.Errorf("walk root: %w", err)
 			}
 		}
 		if scan.failed() {
@@ -271,6 +240,69 @@ func collectAudiobookRootScans(ctx context.Context, folderID int, roots []string
 		scans = append(scans, scan)
 	}
 	return scans, nil
+}
+
+// walkAudiobookRoot discovers candidate book folders under root with a
+// level-parallel breadth-first traversal: every directory of the current
+// depth is listed concurrently (bounded workers), then the next depth is
+// processed. On a network filesystem the traversal is latency-bound, so this
+// beats a serial walk roughly by the worker factor. Each directory is listed
+// exactly once — a directory containing audio files becomes a candidate and
+// is not descended into, mirroring the previous filepath.SkipDir behavior
+// (which also listed every interior directory twice: once by the callback,
+// once by WalkDir to descend).
+func walkAudiobookRoot(ctx context.Context, scan *audiobookRootScan, root string) error {
+	workers := 4 * audiobookScanWorkers()
+	var mu sync.Mutex
+	level := []string{root}
+	for len(level) > 0 {
+		var next []string
+		g, gctx := errgroup.WithContext(ctx)
+		g.SetLimit(workers)
+		for _, dir := range level {
+			g.Go(func() error {
+				if err := gctx.Err(); err != nil {
+					return err
+				}
+				entries, err := os.ReadDir(dir)
+				if err != nil {
+					mu.Lock()
+					scan.walkFailures++
+					mu.Unlock()
+					slog.WarnContext(ctx, "audiobook scan: read dir failed", "component", "scanner", "path", dir, "error", err)
+					return nil
+				}
+				hadAudio := false
+				var subdirs []string
+				for _, e := range entries {
+					if e.IsDir() {
+						subdirs = append(subdirs, filepath.Join(dir, e.Name()))
+						continue
+					}
+					if SupportsAudioFile(e.Name()) {
+						mu.Lock()
+						scan.seenPaths[filepath.Join(dir, e.Name())] = true
+						mu.Unlock()
+						hadAudio = true
+					}
+				}
+				mu.Lock()
+				if hadAudio {
+					// One book = one folder: do not descend into candidates.
+					scan.candidates = append(scan.candidates, dir)
+				} else {
+					next = append(next, subdirs...)
+				}
+				mu.Unlock()
+				return nil
+			})
+		}
+		if err := g.Wait(); err != nil {
+			return err
+		}
+		level = next
+	}
+	return nil
 }
 
 func splitAudiobookReconcileRoots(scans []audiobookRootScan) (roots []string, seenPaths map[string]bool, sawFiles bool) {
@@ -1019,13 +1051,21 @@ func (s *Scanner) upsertAudiobookMediaFiles(
 			BaseType:           "audiobook",
 			IdentityConfidence: audiobookIdentityConfidence(book, af),
 			FilePath:           af.Path,
-			Chapters:           chapters,
-			ProbeSource:        "local",
-			Duration:           af.Duration,
-			Bitrate:            af.Bitrate,
-			CodecAudio:         af.CodecAudio,
-			Container:          af.Container,
-			AudioChannels:      af.AudioChannels,
+			// Size/mtime make audiobookFolderShouldSkip's unchanged check
+			// possible on the next scan; without them every rescan re-probes
+			// and re-upserts each book.
+			FileSize:      af.Size,
+			Chapters:      chapters,
+			ProbeSource:   "local",
+			Duration:      af.Duration,
+			Bitrate:       af.Bitrate,
+			CodecAudio:    af.CodecAudio,
+			Container:     af.Container,
+			AudioChannels: af.AudioChannels,
+		}
+		if !af.ModTime.IsZero() {
+			modifiedAt := normalizeFileModifiedAt(af.ModTime)
+			mf.FileModifiedAt = &modifiedAt
 		}
 		if partTotal > 1 {
 			mf.PresentationKind = "multipart"

--- a/internal/scanner/audiobook_skip_db_test.go
+++ b/internal/scanner/audiobook_skip_db_test.go
@@ -1,0 +1,117 @@
+package scanner
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/jackc/pgx/v5/pgxpool"
+
+	"github.com/Silo-Server/silo-server/internal/catalog"
+	"github.com/Silo-Server/silo-server/internal/models"
+)
+
+// TestAudiobookRescanSkipRoundTrip pins the rescan fast path end to end:
+// upserting a book's media_files with the parsed size/mtime must make
+// audiobookFolderShouldSkip report the folder as unchanged on the next scan,
+// and any size drift must force the full reconcile path again. Before the
+// size/mtime wiring existed, every stored row had file_size=0 /
+// file_modified_at=NULL, so the skip path could never fire and full-library
+// rescans re-probed all ~240k books every time.
+func TestAudiobookRescanSkipRoundTrip(t *testing.T) {
+	dsn := os.Getenv("SILO_TEST_DATABASE_URL")
+	if dsn == "" {
+		t.Skip("SILO_TEST_DATABASE_URL is not set")
+	}
+	ctx := context.Background()
+	pool, err := pgxpool.New(ctx, dsn)
+	if err != nil {
+		t.Fatalf("connect test database: %v", err)
+	}
+	t.Cleanup(pool.Close)
+
+	suffix := time.Now().UnixNano()
+	contentID := fmt.Sprintf("audiobook-skip-%d", suffix)
+
+	bookDir := filepath.Join(t.TempDir(), "Author", "Some Book (2020)")
+	if err := os.MkdirAll(bookDir, 0o755); err != nil {
+		t.Fatalf("mkdir book dir: %v", err)
+	}
+	audioPath := filepath.Join(bookDir, "Some Book.mp3")
+	if err := os.WriteFile(audioPath, []byte("not really audio"), 0o644); err != nil {
+		t.Fatalf("write audio file: %v", err)
+	}
+	info, err := os.Stat(audioPath)
+	if err != nil {
+		t.Fatalf("stat audio file: %v", err)
+	}
+
+	var folderID int
+	if err := pool.QueryRow(ctx, `
+		INSERT INTO media_folders (type, name, enabled) VALUES ('audiobooks', 'Skip Test', true) RETURNING id
+	`).Scan(&folderID); err != nil {
+		t.Fatalf("seed folder: %v", err)
+	}
+	t.Cleanup(func() {
+		_, _ = pool.Exec(ctx, `DELETE FROM media_items WHERE content_id = $1`, contentID)
+		_, _ = pool.Exec(ctx, `DELETE FROM media_folders WHERE id = $1`, folderID)
+	})
+	if _, err := pool.Exec(ctx, `
+		INSERT INTO media_items (content_id, type, title, status, genres)
+		VALUES ($1, 'audiobook', 'Some Book', 'matched', '{}'::text[])
+	`, contentID); err != nil {
+		t.Fatalf("seed item: %v", err)
+	}
+
+	s := &Scanner{
+		fileRepo: NewFileRepository(pool),
+		itemRepo: catalog.NewItemRepository(pool),
+	}
+	folder := &models.MediaFolder{ID: folderID, Type: "audiobooks"}
+
+	book := &parsedAudiobook{
+		Title: "Some Book",
+		Files: []parsedAudiobookFile{{
+			Path:      audioPath,
+			Container: "mp3",
+			Size:      info.Size(),
+			ModTime:   info.ModTime(),
+		}},
+	}
+	if err := s.upsertAudiobookMediaFiles(ctx, folder, contentID, bookDir, book); err != nil {
+		t.Fatalf("upsert audiobook files: %v", err)
+	}
+
+	// Stored size/mtime must round-trip so the disk comparison can match.
+	var storedSize int64
+	var storedMod *time.Time
+	if err := pool.QueryRow(ctx, `
+		SELECT file_size, file_modified_at FROM media_files WHERE file_path = $1
+	`, audioPath).Scan(&storedSize, &storedMod); err != nil {
+		t.Fatalf("read stored file row: %v", err)
+	}
+	if storedSize != info.Size() || storedMod == nil {
+		t.Fatalf("stored size/mtime = %d/%v, want %d/non-nil", storedSize, storedMod, info.Size())
+	}
+
+	gotContentID, unchanged, err := s.audiobookFolderShouldSkip(ctx, folder, bookDir)
+	if err != nil {
+		t.Fatalf("skip check: %v", err)
+	}
+	if !unchanged || gotContentID != contentID {
+		t.Fatalf("skip check = (%q, %v), want (%q, true)", gotContentID, unchanged, contentID)
+	}
+
+	// Any size drift must force the full reconcile path again.
+	if err := os.WriteFile(audioPath, []byte("not really audio, but longer"), 0o644); err != nil {
+		t.Fatalf("grow audio file: %v", err)
+	}
+	if _, unchanged, err := s.audiobookFolderShouldSkip(ctx, folder, bookDir); err != nil {
+		t.Fatalf("skip check after change: %v", err)
+	} else if unchanged {
+		t.Fatal("skip check reported unchanged after the file grew")
+	}
+}

--- a/internal/scanner/audiobook_skip_db_test.go
+++ b/internal/scanner/audiobook_skip_db_test.go
@@ -115,3 +115,96 @@ func TestAudiobookRescanSkipRoundTrip(t *testing.T) {
 		t.Fatal("skip check reported unchanged after the file grew")
 	}
 }
+
+// TestAudiobookRescanSkipSymlinkedFile pins follow-symlink semantics for the
+// stored size/mtime: for a symlinked audio file, the upsert must record the
+// TARGET's stats (os.Stat), because audiobookFolderShouldSkip also compares
+// with os.Stat. Recording the link's own lstat metadata would never match and
+// the book would re-probe on every rescan.
+func TestAudiobookRescanSkipSymlinkedFile(t *testing.T) {
+	dsn := os.Getenv("SILO_TEST_DATABASE_URL")
+	if dsn == "" {
+		t.Skip("SILO_TEST_DATABASE_URL is not set")
+	}
+	ctx := context.Background()
+	pool, err := pgxpool.New(ctx, dsn)
+	if err != nil {
+		t.Fatalf("connect test database: %v", err)
+	}
+	t.Cleanup(pool.Close)
+
+	suffix := time.Now().UnixNano()
+	contentID := fmt.Sprintf("audiobook-symlink-%d", suffix)
+
+	base := t.TempDir()
+	targetPath := filepath.Join(base, "storage", "real-audio.mp3")
+	if err := os.MkdirAll(filepath.Dir(targetPath), 0o755); err != nil {
+		t.Fatalf("mkdir storage: %v", err)
+	}
+	// Target content is much longer than any plausible symlink path so a
+	// link-length size could never coincidentally match the target size.
+	if err := os.WriteFile(targetPath, make([]byte, 4096), 0o644); err != nil {
+		t.Fatalf("write target file: %v", err)
+	}
+	bookDir := filepath.Join(base, "Author", "Linked Book (2021)")
+	if err := os.MkdirAll(bookDir, 0o755); err != nil {
+		t.Fatalf("mkdir book dir: %v", err)
+	}
+	linkPath := filepath.Join(bookDir, "Linked Book.mp3")
+	if err := os.Symlink(targetPath, linkPath); err != nil {
+		t.Skipf("symlinks unsupported here: %v", err)
+	}
+
+	var folderID int
+	if err := pool.QueryRow(ctx, `
+		INSERT INTO media_folders (type, name, enabled) VALUES ('audiobooks', 'Symlink Skip Test', true) RETURNING id
+	`).Scan(&folderID); err != nil {
+		t.Fatalf("seed folder: %v", err)
+	}
+	t.Cleanup(func() {
+		_, _ = pool.Exec(ctx, `DELETE FROM media_items WHERE content_id = $1`, contentID)
+		_, _ = pool.Exec(ctx, `DELETE FROM media_folders WHERE id = $1`, folderID)
+	})
+	if _, err := pool.Exec(ctx, `
+		INSERT INTO media_items (content_id, type, title, status, genres)
+		VALUES ($1, 'audiobook', 'Linked Book', 'matched', '{}'::text[])
+	`, contentID); err != nil {
+		t.Fatalf("seed item: %v", err)
+	}
+
+	s := &Scanner{
+		fileRepo: NewFileRepository(pool),
+		itemRepo: catalog.NewItemRepository(pool),
+	}
+	folder := &models.MediaFolder{ID: folderID, Type: "audiobooks"}
+
+	// Capture stats exactly as parseAudiobookFolder's statOf does: os.Stat on
+	// the (symlinked) path, following the link to the target.
+	info, err := os.Stat(linkPath)
+	if err != nil {
+		t.Fatalf("stat symlink: %v", err)
+	}
+	if info.Size() != 4096 {
+		t.Fatalf("os.Stat followed nothing: size = %d, want 4096 (target)", info.Size())
+	}
+	book := &parsedAudiobook{
+		Title: "Linked Book",
+		Files: []parsedAudiobookFile{{
+			Path:      linkPath,
+			Container: "mp3",
+			Size:      info.Size(),
+			ModTime:   info.ModTime(),
+		}},
+	}
+	if err := s.upsertAudiobookMediaFiles(ctx, folder, contentID, bookDir, book); err != nil {
+		t.Fatalf("upsert audiobook files: %v", err)
+	}
+
+	gotContentID, unchanged, err := s.audiobookFolderShouldSkip(ctx, folder, bookDir)
+	if err != nil {
+		t.Fatalf("skip check: %v", err)
+	}
+	if !unchanged || gotContentID != contentID {
+		t.Fatalf("skip check = (%q, %v), want (%q, true)", gotContentID, unchanged, contentID)
+	}
+}

--- a/internal/scanner/audiobook_walk_test.go
+++ b/internal/scanner/audiobook_walk_test.go
@@ -1,0 +1,110 @@
+package scanner
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"sort"
+	"testing"
+)
+
+// TestCollectAudiobookRootScansParallelWalk pins the traversal semantics of
+// the level-parallel walker against the previous serial WalkDir behavior:
+// a directory containing audio files is a candidate and is NOT descended
+// into; audio-free interior directories are traversed; non-audio files are
+// ignored; unreadable directories count as walk failures.
+func TestCollectAudiobookRootScansParallelWalk(t *testing.T) {
+	root := t.TempDir()
+	mk := func(parts ...string) string {
+		p := filepath.Join(append([]string{root}, parts...)...)
+		if err := os.MkdirAll(p, 0o755); err != nil {
+			t.Fatalf("mkdir %s: %v", p, err)
+		}
+		return p
+	}
+	touch := func(dir, name string) string {
+		p := filepath.Join(dir, name)
+		if err := os.WriteFile(p, []byte("x"), 0o644); err != nil {
+			t.Fatalf("write %s: %v", p, err)
+		}
+		return p
+	}
+
+	// Author A: two books, one with two audio files.
+	bookA1 := mk("Author A", "Book One (2001)")
+	a1f1 := touch(bookA1, "part1.mp3")
+	a1f2 := touch(bookA1, "part2.mp3")
+	touch(bookA1, "cover.jpg") // non-audio, ignored
+	bookA2 := mk("Author A", "Book Two (2002)")
+	a2f1 := touch(bookA2, "book.m4b")
+	// A book with a nested extras dir: candidate at the book level, no descent.
+	nested := mk("Author A", "Book Three (2003)", "extras")
+	touch(nested, "bonus.mp3") // must NOT be seen: parent is the candidate
+	bookA3 := filepath.Join(root, "Author A", "Book Three (2003)")
+	a3f1 := touch(bookA3, "main.mp3")
+	// Author B: deeper nesting before the book level.
+	bookB1 := mk("Author B", "Some Series", "Book Four (2004)")
+	b1f1 := touch(bookB1, "four.flac")
+	// Empty and audio-free directories: traversed, never candidates.
+	mk("Author C", "Empty Book")
+	pdfDir := mk("Author C", "PDF Only")
+	touch(pdfDir, "book.pdf")
+
+	scans, err := collectAudiobookRootScans(context.Background(), 1, []string{root})
+	if err != nil {
+		t.Fatalf("collectAudiobookRootScans: %v", err)
+	}
+	if len(scans) != 1 {
+		t.Fatalf("scans = %d, want 1", len(scans))
+	}
+	scan := scans[0]
+	if scan.failed() {
+		t.Fatalf("scan failed: rootErr=%v walkFailures=%d", scan.rootErr, scan.walkFailures)
+	}
+
+	gotCandidates := append([]string(nil), scan.candidates...)
+	sort.Strings(gotCandidates)
+	wantCandidates := []string{bookA1, bookA2, bookA3, bookB1}
+	sort.Strings(wantCandidates)
+	if len(gotCandidates) != len(wantCandidates) {
+		t.Fatalf("candidates = %v, want %v", gotCandidates, wantCandidates)
+	}
+	for i := range wantCandidates {
+		if gotCandidates[i] != wantCandidates[i] {
+			t.Fatalf("candidates = %v, want %v", gotCandidates, wantCandidates)
+		}
+	}
+
+	wantSeen := []string{a1f1, a1f2, a2f1, a3f1, b1f1}
+	if len(scan.seenPaths) != len(wantSeen) {
+		t.Fatalf("seenPaths = %v, want %v", scan.seenPaths, wantSeen)
+	}
+	for _, p := range wantSeen {
+		if !scan.seenPaths[p] {
+			t.Fatalf("seenPaths missing %s (have %v)", p, scan.seenPaths)
+		}
+	}
+}
+
+func TestCollectAudiobookRootScansCountsUnreadableDirs(t *testing.T) {
+	if os.Geteuid() == 0 {
+		t.Skip("permission-based unreadable-dir test is meaningless as root")
+	}
+	root := t.TempDir()
+	locked := filepath.Join(root, "Author", "Locked Book")
+	if err := os.MkdirAll(locked, 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	if err := os.Chmod(locked, 0o000); err != nil {
+		t.Fatalf("chmod: %v", err)
+	}
+	t.Cleanup(func() { _ = os.Chmod(locked, 0o755) })
+
+	scans, err := collectAudiobookRootScans(context.Background(), 1, []string{root})
+	if err != nil {
+		t.Fatalf("collectAudiobookRootScans: %v", err)
+	}
+	if len(scans) != 1 || scans[0].walkFailures == 0 {
+		t.Fatalf("walkFailures = %d, want > 0 for unreadable dir", scans[0].walkFailures)
+	}
+}


### PR DESCRIPTION
audiobookFolderShouldSkip compares each book's on-disk size/mtime against media_files to skip unchanged books on rescans - but upsertAudiobookMediaFiles never populated FileSize/FileModifiedAt, so every stored audiobook row had file_size=0 / file_modified_at=NULL and the comparison could never match. Verified live: a full rescan of a 240,979-book library ran with skipped=0, re-probing and re-upserting every unchanged book for ~2.5 hours.

Carry size/mtime from the directory listing through parseAudiobookFolder into the upsert. Existing rows self-heal: the first full scan after this change rewrites them with real values (the reconcile path upserts all columns), and every scan after that skips unchanged books. A DB test pins the round trip: upsert then skip-check reports unchanged, and size drift forces reconcile again.

Also replace the serial filepath.WalkDir discovery walk with a level-parallel traversal (bounded at 4x the scan workers) that lists each directory exactly once - the old walk listed every interior directory twice and was latency-bound on network filesystems.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Enhancements**
  - Improved audiobook library scanning with faster, more efficient discovery across nested folders.
  - Audiobook files now use size and modification date information to improve change detection.
  - Unchanged audiobook folders can be skipped during rescans, reducing unnecessary processing.
  - Modified audio files are detected automatically and trigger updated scanning.

- **Bug Fixes**
  - Improved handling and reporting of inaccessible audiobook directories during scans.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->