### PR TITLE
fix(metadata): publish artwork revisions atomically

### DIFF
--- a/cmd/silo/main.go
+++ b/cmd/silo/main.go
@@ -1255,6 +1255,7 @@ func main() {
 		// admin image applies can succeed even if automatic metadata caching is off.
 		if deps.S3Public != nil {
 			imageCacher := imagecache.New(deps.S3Public)
+			imageCacher.SetArtworkRevisionTracker(catalog.NewArtworkRevisionTracker(deps.DB))
 			metadataService.SetImageCacher(imageCacher)
 			imageCacheJobs := metadata.NewImageCacheJobRepository(deps.DB)
 			metadataService.SetImageCacheJobEnqueuer(imageCacheJobs)
@@ -1882,6 +1883,11 @@ func main() {
 			taskMgr.Register(tasks.NewScanLibrariesTask(deps.FolderRepo, deps.LibraryScanQueue, deps.EventBus))
 		}
 		taskMgr.Register(tasks.NewCleanupOrphanedMediaItemsTask(catalog.NewOrphanedProvisionalCleaner(deps.DB)))
+		if deps.S3Public != nil {
+			taskMgr.Register(tasks.NewCleanupArtworkRevisionsTask(
+				metadata.NewArtworkRevisionGarbageCollector(deps.DB, deps.S3Public),
+			))
+		}
 		catalogSearchIndexer := catalog.NewCatalogSearchIndexer(deps.DB, settingsRepo)
 		taskMgr.Register(tasks.NewSyncCatalogSearchIndexTask(catalogSearchIndexer))
 		taskMgr.Register(tasks.NewRebuildCatalogSearchIndexTask(catalogSearchIndexer))

--- a/internal/api/handlers/admin_images.go
+++ b/internal/api/handlers/admin_images.go
@@ -7,10 +7,12 @@ import (
 	"fmt"
 	"log/slog"
 	"net/http"
+	"time"
 
 	"github.com/go-chi/chi/v5"
 
 	"github.com/Silo-Server/silo-server/internal/catalog"
+	evt "github.com/Silo-Server/silo-server/internal/events"
 	"github.com/Silo-Server/silo-server/internal/metadata"
 	"github.com/Silo-Server/silo-server/internal/models"
 )
@@ -52,6 +54,7 @@ type AdminImageHandler struct {
 	imageSvc      ImageService
 	imageResolver ImageURLResolver
 	detailSvc     *catalog.DetailService
+	EventsHub     *evt.Hub
 }
 
 // NewAdminImageHandler creates a handler for admin image selection endpoints.
@@ -110,6 +113,8 @@ type applyItemImageResponse struct {
 	ContentID  string `json:"content_id"`
 	StoredPath string `json:"stored_path"`
 	Thumbhash  string `json:"thumbhash"`
+	ImageURL   string `json:"image_url,omitempty"`
+	Revision   string `json:"revision,omitempty"`
 }
 
 // resolvedItem holds the result of looking up a content ID across all three tables.
@@ -344,50 +349,45 @@ func (h *AdminImageHandler) HandleApplyItemImage(w http.ResponseWriter, r *http.
 		return
 	}
 
-	// Build the MetadataUpdate targeting only the relevant image field.
-	upd := buildImageUpdate(imageType, result.StoredPath, result.Thumbhash)
-
-	// Lock FieldImages on the parent media_items row to prevent
-	// automatic refreshes from overwriting the manual selection.
-	if resolved.contentType == "movie" || resolved.contentType == "series" {
-		locked := mergeLockedField(resolved.parentItem.LockedFields, int(metadata.FieldImages))
-		upd.LockedFields = &locked
-	}
-
-	// Persist to the correct table.
-	if err := h.persistImageUpdate(r.Context(), contentID, resolved, &upd); err != nil {
+	_, err = h.detailSvc.PublishArtworkSelection(r.Context(), catalog.ArtworkSelection{
+		TargetType:      resolved.contentType,
+		TargetContentID: contentID,
+		ParentContentID: resolved.parentItem.ContentID,
+		ImageType:       metadata.ImageTypeToString(imageType),
+		StoredPath:      result.StoredPath,
+		SourcePath:      req.OriginalURL,
+		Thumbhash:       result.Thumbhash,
+		LockField:       int(metadata.FieldImages),
+	})
+	if err != nil {
 		slog.ErrorContext(r.Context(), "admin images: persist failed", "component", "api", "content_id", contentID, "error", err)
+		if cleanupErr := h.detailSvc.QueueArtworkRevisionGC(
+			r.Context(), result.StoredPath, metadata.ImageTypeToString(imageType), time.Now().Add(time.Hour),
+		); cleanupErr != nil {
+			slog.ErrorContext(r.Context(), "admin images: failed to queue unpublished artwork cleanup", "component", "api",
+				"content_id", contentID, "stored_path", result.StoredPath, "error", cleanupErr)
+		}
 		writeError(w, http.StatusInternalServerError, "internal_error", "Image cached but failed to update item")
 		return
 	}
 
-	// Also lock FieldImages on the parent series for seasons/episodes.
-	if resolved.contentType == "season" || resolved.contentType == "episode" {
-		parentLocked := mergeLockedField(resolved.parentItem.LockedFields, int(metadata.FieldImages))
-		parentUpd := catalog.MetadataUpdate{LockedFields: &parentLocked}
-		if lockErr := h.detailSvc.UpdateMediaItemMetadata(r.Context(), resolved.parentItem.ContentID, &parentUpd); lockErr != nil {
-			slog.ErrorContext(r.Context(), "admin images: failed to lock FieldImages on parent series", "component", "api",
-				"content_id", contentID, "parent_id", resolved.parentItem.ContentID, "error", lockErr)
-		}
+	publishEventMetadataUpdate(r.Context(), h.EventsHub, 0, contentID)
+	if resolved.parentItem.ContentID != contentID {
+		publishEventMetadataUpdate(r.Context(), h.EventsHub, 0, resolved.parentItem.ContentID)
+	}
+
+	imageURL := ""
+	if h.imageResolver != nil {
+		imageURL = h.imageResolver.ResolveImageURL(r.Context(), result.StoredPath, "original")
 	}
 
 	writeJSON(w, http.StatusOK, applyItemImageResponse{
 		ContentID:  contentID,
 		StoredPath: result.StoredPath,
 		Thumbhash:  result.Thumbhash,
+		ImageURL:   imageURL,
+		Revision:   result.Revision,
 	})
-}
-
-// persistImageUpdate writes the image path update to the correct table.
-func (h *AdminImageHandler) persistImageUpdate(ctx context.Context, contentID string, resolved *resolvedItem, upd *catalog.MetadataUpdate) error {
-	switch resolved.contentType {
-	case "season":
-		return h.detailSvc.UpdateSeasonMetadata(ctx, contentID, upd)
-	case "episode":
-		return h.detailSvc.UpdateEpisodeMetadata(ctx, contentID, upd)
-	default:
-		return h.detailSvc.UpdateMediaItemMetadata(ctx, contentID, upd)
-	}
 }
 
 // resolveImageFolderID finds the primary library folder for a content ID.
@@ -415,38 +415,6 @@ func buildProviderIDs(item *models.MediaItem) map[string]string {
 		ids["imdb"] = item.ImdbID
 	}
 	return ids
-}
-
-// buildImageUpdate constructs a MetadataUpdate targeting a single image field.
-func buildImageUpdate(imageType metadata.ImageType, storedPath, thumbhash string) catalog.MetadataUpdate {
-	var upd catalog.MetadataUpdate
-	switch imageType {
-	case metadata.ImageBackdrop:
-		upd.BackdropPath = &storedPath
-		upd.BackdropThumbhash = &thumbhash
-	case metadata.ImageLogo:
-		upd.LogoPath = &storedPath
-	case metadata.ImageStill:
-		upd.StillPath = &storedPath
-		upd.StillThumbhash = &thumbhash
-	default: // poster
-		upd.PosterPath = &storedPath
-		upd.PosterThumbhash = &thumbhash
-	}
-	return upd
-}
-
-// mergeLockedField adds a field value to the locked fields slice if not already present.
-func mergeLockedField(existing []int, field int) []int {
-	for _, f := range existing {
-		if f == field {
-			return existing
-		}
-	}
-	result := make([]int, len(existing)+1)
-	copy(result, existing)
-	result[len(existing)] = field
-	return result
 }
 
 // primaryProvider returns the primary provider slug for a media item.

--- a/internal/api/handlers/admin_images.go
+++ b/internal/api/handlers/admin_images.go
@@ -309,6 +309,18 @@ func (h *AdminImageHandler) HandleApplyItemImage(w http.ResponseWriter, r *http.
 	}
 
 	imageType := metadata.ImageTypeFromString(req.Type)
+	// Episodes only have stills. Clients historically sent "poster" here (the
+	// old flow silently dropped it), so coerce rather than reject.
+	if resolved.contentType == "episode" {
+		imageType = metadata.ImageStill
+	}
+	// Reject unsupported target/image combinations before spending a download
+	// and an S3 upload on an image that can never be published.
+	if err := catalog.ValidateArtworkSelectionTarget(resolved.contentType, metadata.ImageTypeToString(imageType)); err != nil {
+		writeError(w, http.StatusBadRequest, "unsupported_image_type",
+			fmt.Sprintf("%s items do not accept %s images", resolved.contentType, metadata.ImageTypeToString(imageType)))
+		return
+	}
 	providerID := req.ProviderID
 	if providerID == "" {
 		providerID = primaryProvider(resolved.parentItem)
@@ -349,7 +361,7 @@ func (h *AdminImageHandler) HandleApplyItemImage(w http.ResponseWriter, r *http.
 		return
 	}
 
-	_, err = h.detailSvc.PublishArtworkSelection(r.Context(), catalog.ArtworkSelection{
+	err = h.detailSvc.PublishArtworkSelection(r.Context(), catalog.ArtworkSelection{
 		TargetType:      resolved.contentType,
 		TargetContentID: contentID,
 		ParentContentID: resolved.parentItem.ContentID,
@@ -367,7 +379,14 @@ func (h *AdminImageHandler) HandleApplyItemImage(w http.ResponseWriter, r *http.
 			slog.ErrorContext(r.Context(), "admin images: failed to queue unpublished artwork cleanup", "component", "api",
 				"content_id", contentID, "stored_path", result.StoredPath, "error", cleanupErr)
 		}
-		writeError(w, http.StatusInternalServerError, "internal_error", "Image cached but failed to update item")
+		switch {
+		case errors.Is(err, catalog.ErrItemNotFound),
+			errors.Is(err, catalog.ErrSeasonNotFound),
+			errors.Is(err, catalog.ErrEpisodeNotFound):
+			writeError(w, http.StatusNotFound, "not_found", "Item not found")
+		default:
+			writeError(w, http.StatusInternalServerError, "internal_error", "Image cached but failed to update item")
+		}
 		return
 	}
 

--- a/internal/api/router.go
+++ b/internal/api/router.go
@@ -1037,6 +1037,7 @@ func NewRouter(deps Dependencies) chi.Router {
 			deps.PluginImageResolver,
 			detailSvc,
 		)
+		adminImageHandler.EventsHub = deps.EventsHub
 	}
 
 	var adminIntroHandler *handlers.AdminIntroHandler

--- a/internal/artworkkey/artworkkey.go
+++ b/internal/artworkkey/artworkkey.go
@@ -1,0 +1,100 @@
+// Package artworkkey owns the object-key naming contract for cached artwork.
+// Legacy names such as original.webp and revisioned names such as
+// original.<revision>.webp are both supported.
+package artworkkey
+
+import (
+	"path"
+	"strings"
+)
+
+const OriginalVariant = "original"
+
+// Build returns an object key for a variant under basePath.
+func Build(basePath, variant, revision, ext string) string {
+	basePath = strings.TrimRight(strings.TrimSpace(basePath), "/")
+	variant = strings.TrimSpace(variant)
+	revision = strings.TrimSpace(revision)
+	if basePath == "" || variant == "" {
+		return ""
+	}
+	if ext == "" {
+		ext = ".webp"
+	} else if !strings.HasPrefix(ext, ".") {
+		ext = "." + ext
+	}
+	if revision == "" {
+		return basePath + "/" + variant + ext
+	}
+	return basePath + "/" + variant + "." + revision + ext
+}
+
+// Original returns the original-variant key under basePath.
+func Original(basePath, revision, ext string) string {
+	return Build(basePath, OriginalVariant, revision, ext)
+}
+
+// Variant rewrites an original key to another variant while retaining any
+// revision and extension. Unrecognized paths pass through unchanged.
+func Variant(originalPath, variant string) string {
+	if originalPath == "" || variant == "" || variant == OriginalVariant {
+		return originalPath
+	}
+	const marker = "/original."
+	if !strings.Contains(originalPath, marker) {
+		return originalPath
+	}
+	return strings.Replace(originalPath, marker, "/"+variant+".", 1)
+}
+
+// Directory returns the image-type prefix containing every revision and
+// variant for an artwork key, including a trailing slash.
+func Directory(objectPath string) string {
+	objectPath = strings.TrimSpace(objectPath)
+	if objectPath == "" || strings.Contains(objectPath, "://") {
+		return ""
+	}
+	dir := path.Dir(objectPath)
+	if dir == "." || dir == "/" {
+		return ""
+	}
+	return strings.TrimRight(dir, "/") + "/"
+}
+
+// Revision extracts the content revision from a revisioned key. Legacy keys
+// return an empty string.
+func Revision(objectPath string) string {
+	name := path.Base(strings.TrimSpace(objectPath))
+	ext := path.Ext(name)
+	stem := strings.TrimSuffix(name, ext)
+	firstDot := strings.IndexByte(stem, '.')
+	if firstDot < 0 || firstDot == len(stem)-1 {
+		return ""
+	}
+	return stem[firstDot+1:]
+}
+
+// VariantNames returns the cached variants generated for an artwork type.
+func VariantNames(imageType string) []string {
+	switch strings.ToLower(strings.TrimSpace(imageType)) {
+	case "backdrop":
+		return []string{OriginalVariant, "w1920", "w1280", "w300"}
+	case "logo":
+		return []string{OriginalVariant, "w500"}
+	default: // poster, still, profile
+		return []string{OriginalVariant, "w500", "w300"}
+	}
+}
+
+// ObjectKeys expands an original key to every expected key for its image type.
+func ObjectKeys(originalPath, imageType string) []string {
+	if originalPath == "" || strings.Contains(originalPath, "://") {
+		return nil
+	}
+	names := VariantNames(imageType)
+	keys := make([]string, 0, len(names))
+	for _, name := range names {
+		keys = append(keys, Variant(originalPath, name))
+	}
+	return keys
+}

--- a/internal/artworkkey/artworkkey.go
+++ b/internal/artworkkey/artworkkey.go
@@ -5,6 +5,7 @@ package artworkkey
 
 import (
 	"path"
+	"strconv"
 	"strings"
 )
 
@@ -75,16 +76,29 @@ func Revision(objectPath string) string {
 	return stem[firstDot+1:]
 }
 
-// VariantNames returns the cached variants generated for an artwork type.
-func VariantNames(imageType string) []string {
+// VariantWidths returns the resize widths generated for an artwork type. This
+// is the single source of truth for the variant ladder: image generation,
+// object-key expansion, and garbage collection all derive from it.
+func VariantWidths(imageType string) []int {
 	switch strings.ToLower(strings.TrimSpace(imageType)) {
 	case "backdrop":
-		return []string{OriginalVariant, "w1920", "w1280", "w300"}
+		return []int{1920, 1280, 300}
 	case "logo":
-		return []string{OriginalVariant, "w500"}
+		return []int{500}
 	default: // poster, still, profile
-		return []string{OriginalVariant, "w500", "w300"}
+		return []int{500, 300}
 	}
+}
+
+// VariantNames returns the cached variants generated for an artwork type.
+func VariantNames(imageType string) []string {
+	widths := VariantWidths(imageType)
+	names := make([]string, 0, len(widths)+1)
+	names = append(names, OriginalVariant)
+	for _, width := range widths {
+		names = append(names, "w"+strconv.Itoa(width))
+	}
+	return names
 }
 
 // ObjectKeys expands an original key to every expected key for its image type.

--- a/internal/artworkkey/artworkkey.go
+++ b/internal/artworkkey/artworkkey.go
@@ -40,11 +40,12 @@ func Variant(originalPath, variant string) string {
 	if originalPath == "" || variant == "" || variant == OriginalVariant {
 		return originalPath
 	}
-	const marker = "/original."
-	if !strings.Contains(originalPath, marker) {
+	dir := path.Dir(originalPath)
+	base := path.Base(originalPath)
+	if dir == "." || !strings.HasPrefix(base, OriginalVariant+".") {
 		return originalPath
 	}
-	return strings.Replace(originalPath, marker, "/"+variant+".", 1)
+	return strings.TrimRight(dir, "/") + "/" + variant + strings.TrimPrefix(base, OriginalVariant)
 }
 
 // Directory returns the image-type prefix containing every revision and

--- a/internal/artworkkey/artworkkey_test.go
+++ b/internal/artworkkey/artworkkey_test.go
@@ -1,0 +1,30 @@
+package artworkkey
+
+import "testing"
+
+func TestRevisionedArtworkKeys(t *testing.T) {
+	base := "tmdb/movies/550/poster"
+	original := Original(base, "abc123", ".webp")
+	if original != base+"/original.abc123.webp" {
+		t.Fatalf("Original() = %q", original)
+	}
+	if got := Variant(original, "w500"); got != base+"/w500.abc123.webp" {
+		t.Fatalf("Variant() = %q", got)
+	}
+	if got := Revision(original); got != "abc123" {
+		t.Fatalf("Revision() = %q", got)
+	}
+	if got := Directory(original); got != base+"/" {
+		t.Fatalf("Directory() = %q", got)
+	}
+}
+
+func TestLegacyArtworkKeysRemainSupported(t *testing.T) {
+	original := "tmdb/movies/550/poster/original.webp"
+	if got := Variant(original, "w300"); got != "tmdb/movies/550/poster/w300.webp" {
+		t.Fatalf("Variant() = %q", got)
+	}
+	if got := Revision(original); got != "" {
+		t.Fatalf("Revision() = %q, want empty", got)
+	}
+}

--- a/internal/artworkkey/artworkkey_test.go
+++ b/internal/artworkkey/artworkkey_test.go
@@ -28,3 +28,11 @@ func TestLegacyArtworkKeysRemainSupported(t *testing.T) {
 		t.Fatalf("Revision() = %q, want empty", got)
 	}
 }
+
+func TestVariantOnlyRewritesOriginalFilename(t *testing.T) {
+	original := "tmdb/movies/original.segment/550/poster/original.abc123.webp"
+	want := "tmdb/movies/original.segment/550/poster/w500.abc123.webp"
+	if got := Variant(original, "w500"); got != want {
+		t.Fatalf("Variant() = %q, want %q", got, want)
+	}
+}

--- a/internal/audiobooks/enrichment.go
+++ b/internal/audiobooks/enrichment.go
@@ -37,7 +37,7 @@ import (
 // method set by structural typing. Anything implementing CacheAudiobookCover can
 // be passed to scanner.ExtractAndUploadAudiobookCover via this interface.
 type audiobookCoverCacher interface {
-	CacheAudiobookCover(ctx context.Context, data []byte, contentID string) (basePath string, ext string, thumbhash string, err error)
+	CacheAudiobookCover(ctx context.Context, data []byte, contentID string) (storedPath string, thumbhash string, err error)
 }
 
 const (
@@ -570,25 +570,12 @@ func (e *Enricher) cacheRemotePoster(ctx context.Context, contentID string, resu
 		return
 	}
 
-	if storedPath := cachedOriginalImagePath(cached.BasePath, cached.Ext); storedPath != "" {
+	if storedPath := metadata.CachedImageOriginalPath(cached); storedPath != "" {
 		result.PosterPath = storedPath
 	}
 	if cached.Thumbhash != "" {
 		result.PosterThumbhash = cached.Thumbhash
 	}
-}
-
-func cachedOriginalImagePath(basePath, ext string) string {
-	if basePath == "" {
-		return ""
-	}
-	if strings.Contains(basePath, "/original.") {
-		return basePath
-	}
-	if ext == "" {
-		ext = ".jpg"
-	}
-	return strings.TrimRight(basePath, "/") + "/original" + ext
 }
 
 // persist writes the enriched metadata back to the database.

--- a/internal/audiobooks/enrichment_test.go
+++ b/internal/audiobooks/enrichment_test.go
@@ -125,7 +125,7 @@ func TestCacheRemotePosterCachesProviderURL(t *testing.T) {
 	if cacher.req.ContentType != "audiobooks" || cacher.req.ContentID != "content-1" {
 		t.Fatalf("cache target = %q/%q", cacher.req.ContentType, cacher.req.ContentID)
 	}
-	if result.PosterPath != "audiobook-metadata/audiobooks/content-1/poster/original.webp" {
+	if result.PosterPath != "audiobook-metadata/audiobooks/content-1/poster/original.test-revision.webp" {
 		t.Fatalf("PosterPath = %q", result.PosterPath)
 	}
 	if result.PosterThumbhash != "thumb" {
@@ -164,7 +164,7 @@ func (f *fakeAudiobookImageCacher) CacheImage(_ context.Context, req metadata.Ca
 	f.req = req
 	return &metadata.CacheImageResult{
 		BasePath:     req.ProviderID + "/" + req.ContentType + "/" + req.ContentID + "/poster",
-		OriginalPath: req.ProviderID + "/" + req.ContentType + "/" + req.ContentID + "/poster/original.webp",
+		OriginalPath: req.ProviderID + "/" + req.ContentType + "/" + req.ContentID + "/poster/original.test-revision.webp",
 		Thumbhash:    "thumb",
 		Ext:          ".webp",
 	}, nil

--- a/internal/audiobooks/enrichment_test.go
+++ b/internal/audiobooks/enrichment_test.go
@@ -155,16 +155,17 @@ type fakeAudiobookImageCacher struct {
 	req   metadata.CacheImageRequest
 }
 
-func (f *fakeAudiobookImageCacher) CacheAudiobookCover(context.Context, []byte, string) (string, string, string, error) {
-	return "", "", "", nil
+func (f *fakeAudiobookImageCacher) CacheAudiobookCover(context.Context, []byte, string) (string, string, error) {
+	return "", "", nil
 }
 
 func (f *fakeAudiobookImageCacher) CacheImage(_ context.Context, req metadata.CacheImageRequest) (*metadata.CacheImageResult, error) {
 	f.calls++
 	f.req = req
 	return &metadata.CacheImageResult{
-		BasePath:  req.ProviderID + "/" + req.ContentType + "/" + req.ContentID + "/poster",
-		Thumbhash: "thumb",
-		Ext:       ".webp",
+		BasePath:     req.ProviderID + "/" + req.ContentType + "/" + req.ContentID + "/poster",
+		OriginalPath: req.ProviderID + "/" + req.ContentType + "/" + req.ContentID + "/poster/original.webp",
+		Thumbhash:    "thumb",
+		Ext:          ".webp",
 	}, nil
 }

--- a/internal/catalog/artwork_selection.go
+++ b/internal/catalog/artwork_selection.go
@@ -66,6 +66,8 @@ func (t *ArtworkRevisionTracker) TrackArtworkRevision(ctx context.Context, origi
 		return nil
 	}
 	notBefore := time.Now().Add(t.gracePeriod)
+	// deleted_at is cleared because this upsert precedes a re-upload of the
+	// exact manifest: the objects exist again once the cacher finishes.
 	_, err := t.pool.Exec(ctx, `
 		INSERT INTO artwork_revision_gc_candidates (
 			original_path, image_type, object_keys, not_before, next_attempt_at
@@ -84,6 +86,7 @@ func (t *ArtworkRevisionTracker) TrackArtworkRevision(ctx context.Context, origi
 				WHEN artwork_revision_gc_candidates.next_attempt_at IS NULL THEN NULL
 				ELSE EXCLUDED.next_attempt_at
 			END,
+			deleted_at = NULL,
 			attempt_count = 0,
 			locked_at = NULL,
 			locked_by = '',

--- a/internal/catalog/artwork_selection.go
+++ b/internal/catalog/artwork_selection.go
@@ -10,14 +10,10 @@ import (
 	"github.com/jackc/pgx/v5"
 	"github.com/jackc/pgx/v5/pgconn"
 	"github.com/jackc/pgx/v5/pgxpool"
-
-	"github.com/Silo-Server/silo-server/internal/artworkkey"
 )
 
 const (
 	defaultArtworkGCGracePeriod = 24 * time.Hour
-	artworkTargetMovie          = "movie"
-	artworkTargetSeries         = "series"
 	artworkTargetSeason         = "season"
 	artworkTargetEpisode        = "episode"
 	artworkImagePoster          = "poster"
@@ -27,12 +23,21 @@ const (
 	artworkPosterPathColumn     = "poster_path"
 	artworkBackdropPathColumn   = "backdrop_path"
 	artworkLogoPathColumn       = "logo_path"
+	artworkPosterSourceColumn   = "poster_source_path"
+	artworkBackdropSourceColumn = "backdrop_source_path"
+	artworkLogoSourceColumn     = "logo_source_path"
+	artworkPosterThumbColumn    = "poster_thumbhash"
+	artworkBackdropThumbColumn  = "backdrop_thumbhash"
 )
+
+// ErrUnsupportedArtworkSelection reports a target/image-type combination that
+// has no artwork column. Handlers should reject these before caching anything.
+var ErrUnsupportedArtworkSelection = errors.New("catalog: unsupported artwork selection")
 
 // ArtworkRevisionTracker registers every immutable artwork upload before its
 // objects are written, allowing the collector to reclaim uploads that are
 // never published. Confirmed live revisions remain dormant in the registry so
-// database triggers can later reactivate their exact object manifests.
+// database triggers can later reactivate them.
 type ArtworkRevisionTracker struct {
 	pool        *pgxpool.Pool
 	gracePeriod time.Duration
@@ -45,14 +50,49 @@ func NewArtworkRevisionTracker(pool *pgxpool.Pool) *ArtworkRevisionTracker {
 	return &ArtworkRevisionTracker{pool: pool, gracePeriod: defaultArtworkGCGracePeriod}
 }
 
-// TrackArtworkRevision refreshes the publication grace period for a revision.
-// Image caching calls this before uploading, so it serializes with a collector
-// that may already be deleting an older, currently-unreferenced copy.
-func (t *ArtworkRevisionTracker) TrackArtworkRevision(ctx context.Context, originalPath string, objectKeys []string) error {
+// TrackArtworkRevision records the exact object manifest for a revision before
+// its upload starts. Image caching calls this before uploading, so it
+// serializes with a collector that may already be deleting an older,
+// currently-unreferenced copy. Revisions parked as referenced stay dormant: a
+// re-cache of live artwork is not garbage, and displacement triggers re-arm
+// the row if the reference later moves away.
+func (t *ArtworkRevisionTracker) TrackArtworkRevision(ctx context.Context, originalPath, imageType string, objectKeys []string) error {
 	if t == nil || t.pool == nil {
 		return fmt.Errorf("catalog: artwork revision tracking is not configured")
 	}
-	return trackArtworkRevision(ctx, t.pool, originalPath, objectKeys, time.Now().Add(t.gracePeriod), true)
+	originalPath = strings.TrimSpace(originalPath)
+	keys := compactArtworkObjectKeys(objectKeys)
+	if originalPath == "" || strings.Contains(originalPath, "://") || len(keys) == 0 {
+		return nil
+	}
+	notBefore := time.Now().Add(t.gracePeriod)
+	_, err := t.pool.Exec(ctx, `
+		INSERT INTO artwork_revision_gc_candidates (
+			original_path, image_type, object_keys, not_before, next_attempt_at
+		) VALUES ($1, $2, $3, $4, $4)
+		ON CONFLICT (original_path) DO UPDATE SET
+			object_keys = EXCLUDED.object_keys,
+			image_type = CASE
+				WHEN artwork_revision_gc_candidates.image_type = '' THEN EXCLUDED.image_type
+				ELSE artwork_revision_gc_candidates.image_type
+			END,
+			not_before = CASE
+				WHEN artwork_revision_gc_candidates.next_attempt_at IS NULL THEN artwork_revision_gc_candidates.not_before
+				ELSE EXCLUDED.not_before
+			END,
+			next_attempt_at = CASE
+				WHEN artwork_revision_gc_candidates.next_attempt_at IS NULL THEN NULL
+				ELSE EXCLUDED.next_attempt_at
+			END,
+			attempt_count = 0,
+			locked_at = NULL,
+			locked_by = '',
+			last_error = '',
+			updated_at = NOW()`, originalPath, strings.ToLower(strings.TrimSpace(imageType)), keys, notBefore)
+	if err != nil {
+		return fmt.Errorf("catalog: track artwork revision: %w", err)
+	}
+	return nil
 }
 
 // ArtworkSelection describes a manually selected, already-cached artwork
@@ -69,18 +109,23 @@ type ArtworkSelection struct {
 	LockField       int
 }
 
-// ArtworkSelectionResult reports the revision displaced by a successful
-// publication. PreviousPath is empty when the target had no prior artwork.
-type ArtworkSelectionResult struct {
-	PreviousPath string
+// ValidateArtworkSelectionTarget reports whether a target/image-type pair maps
+// to a real artwork column, so handlers can reject unsupported requests before
+// downloading or uploading anything.
+func ValidateArtworkSelectionTarget(targetType, imageType string) error {
+	_, _, _, _, _, err := artworkTargetColumns(
+		strings.ToLower(strings.TrimSpace(targetType)),
+		strings.ToLower(strings.TrimSpace(imageType)),
+	)
+	return err
 }
 
 // PublishArtworkSelection atomically changes the selected artwork, records its
 // source, locks automatic image refreshes, and queues the old immutable revision
 // for reference-aware garbage collection after a grace period.
-func (s *DetailService) PublishArtworkSelection(ctx context.Context, selection ArtworkSelection) (*ArtworkSelectionResult, error) {
+func (s *DetailService) PublishArtworkSelection(ctx context.Context, selection ArtworkSelection) error {
 	if s == nil || s.itemRepo == nil || s.itemRepo.pool == nil {
-		return nil, fmt.Errorf("catalog: artwork persistence is not configured")
+		return fmt.Errorf("catalog: artwork persistence is not configured")
 	}
 	selection.TargetType = strings.ToLower(strings.TrimSpace(selection.TargetType))
 	selection.ImageType = strings.ToLower(strings.TrimSpace(selection.ImageType))
@@ -88,17 +133,17 @@ func (s *DetailService) PublishArtworkSelection(ctx context.Context, selection A
 	selection.ParentContentID = strings.TrimSpace(selection.ParentContentID)
 	selection.StoredPath = strings.TrimSpace(selection.StoredPath)
 	if selection.TargetContentID == "" || selection.StoredPath == "" {
-		return nil, fmt.Errorf("catalog: artwork target and stored path are required")
+		return fmt.Errorf("catalog: artwork target and stored path are required")
 	}
 
 	table, pathColumn, sourceColumn, thumbhashColumn, notFound, err := artworkTargetColumns(selection.TargetType, selection.ImageType)
 	if err != nil {
-		return nil, err
+		return err
 	}
 
 	tx, err := s.itemRepo.pool.Begin(ctx)
 	if err != nil {
-		return nil, fmt.Errorf("catalog: begin artwork publication: %w", err)
+		return fmt.Errorf("catalog: begin artwork publication: %w", err)
 	}
 	defer func() { _ = tx.Rollback(ctx) }()
 
@@ -106,9 +151,9 @@ func (s *DetailService) PublishArtworkSelection(ctx context.Context, selection A
 	selectSQL := fmt.Sprintf("SELECT COALESCE(%s, '') FROM %s WHERE content_id = $1 FOR UPDATE", pathColumn, table)
 	if err := tx.QueryRow(ctx, selectSQL, selection.TargetContentID).Scan(&previousPath); err != nil {
 		if errors.Is(err, pgx.ErrNoRows) {
-			return nil, notFound
+			return notFound
 		}
-		return nil, fmt.Errorf("catalog: lock artwork target: %w", err)
+		return fmt.Errorf("catalog: lock artwork target: %w", err)
 	}
 
 	setThumbhash := ""
@@ -122,7 +167,7 @@ func (s *DetailService) PublishArtworkSelection(ctx context.Context, selection A
 		SET %s = $1, %s = $2%s, updated_at = NOW()
 		WHERE content_id = $3`, table, pathColumn, sourceColumn, setThumbhash)
 	if _, err := tx.Exec(ctx, updateSQL, args...); err != nil {
-		return nil, fmt.Errorf("catalog: publish artwork pointer: %w", err)
+		return fmt.Errorf("catalog: publish artwork pointer: %w", err)
 	}
 
 	lockContentID := selection.TargetContentID
@@ -130,7 +175,7 @@ func (s *DetailService) PublishArtworkSelection(ctx context.Context, selection A
 		lockContentID = selection.ParentContentID
 	}
 	if lockContentID == "" {
-		return nil, fmt.Errorf("catalog: parent content ID is required for %s artwork", selection.TargetType)
+		return fmt.Errorf("catalog: parent content ID is required for %s artwork", selection.TargetType)
 	}
 	tag, err := tx.Exec(ctx, `
 		UPDATE media_items
@@ -141,28 +186,28 @@ func (s *DetailService) PublishArtworkSelection(ctx context.Context, selection A
 			updated_at = NOW()
 		WHERE content_id = $1`, lockContentID, selection.LockField)
 	if err != nil {
-		return nil, fmt.Errorf("catalog: lock manual artwork: %w", err)
+		return fmt.Errorf("catalog: lock manual artwork: %w", err)
 	}
 	if tag.RowsAffected() == 0 {
-		return nil, ErrItemNotFound
+		return ErrItemNotFound
 	}
-	// Register the selected revision in the publication transaction. The first
-	// cleanup pass parks it while referenced; database triggers reactivate its
-	// exact manifest if any writer later displaces or deletes it.
-	if err := queueArtworkRevisionGC(ctx, tx, selection.StoredPath, selection.ImageType, time.Now().Add(defaultArtworkGCGracePeriod)); err != nil {
-		return nil, err
+	// The selected revision is referenced by construction once this transaction
+	// commits, so park it dormant immediately: no first-pass verification cycle
+	// is needed, and database triggers re-arm it if a later writer displaces it.
+	if err := parkArtworkRevision(ctx, tx, selection.StoredPath, selection.ImageType, time.Now().Add(defaultArtworkGCGracePeriod)); err != nil {
+		return err
 	}
 
 	if previousPath != "" && previousPath != selection.StoredPath {
 		if err := queueArtworkRevisionGC(ctx, tx, previousPath, selection.ImageType, time.Now().Add(defaultArtworkGCGracePeriod)); err != nil {
-			return nil, err
+			return err
 		}
 	}
 
 	if err := tx.Commit(ctx); err != nil {
-		return nil, fmt.Errorf("catalog: commit artwork publication: %w", err)
+		return fmt.Errorf("catalog: commit artwork publication: %w", err)
 	}
-	return &ArtworkSelectionResult{PreviousPath: previousPath}, nil
+	return nil
 }
 
 // QueueArtworkRevisionGC schedules an unreferenced cached revision for cleanup.
@@ -179,36 +224,48 @@ type artworkGCExecer interface {
 	Exec(ctx context.Context, sql string, arguments ...any) (pgconn.CommandTag, error)
 }
 
+// queueArtworkRevisionGC arms a revision for verification after notBefore. The
+// stored manifest (when one was tracked pre-upload) is kept; rows without one
+// carry the image type so the collector can expand the object keys itself.
 func queueArtworkRevisionGC(ctx context.Context, db artworkGCExecer, originalPath, imageType string, notBefore time.Time) error {
-	return trackArtworkRevision(ctx, db, originalPath, artworkkey.ObjectKeys(originalPath, imageType), notBefore, false)
+	return upsertArtworkRevision(ctx, db, originalPath, imageType, notBefore, false)
 }
 
-func trackArtworkRevision(
+// parkArtworkRevision registers a revision as referenced and dormant. Only a
+// displacement trigger or the collector's dormant sweep re-arms it.
+func parkArtworkRevision(ctx context.Context, db artworkGCExecer, originalPath, imageType string, notBefore time.Time) error {
+	return upsertArtworkRevision(ctx, db, originalPath, imageType, notBefore, true)
+}
+
+func upsertArtworkRevision(
 	ctx context.Context,
 	db artworkGCExecer,
 	originalPath string,
-	objectKeys []string,
+	imageType string,
 	notBefore time.Time,
-	replaceManifest bool,
+	dormant bool,
 ) error {
 	originalPath = strings.TrimSpace(originalPath)
-	keys := compactArtworkObjectKeys(objectKeys)
-	if originalPath == "" || strings.Contains(originalPath, "://") || len(keys) == 0 {
+	imageType = strings.ToLower(strings.TrimSpace(imageType))
+	if originalPath == "" || strings.Contains(originalPath, "://") || imageType == "" {
 		return nil
 	}
 	_, err := db.Exec(ctx, `
 		INSERT INTO artwork_revision_gc_candidates (
-			original_path, object_keys, not_before, next_attempt_at
-		) VALUES ($1, $2, $3, $3)
+			original_path, image_type, object_keys, not_before, next_attempt_at
+		) VALUES ($1, $2, '{}', $3, CASE WHEN $4 THEN NULL ELSE $3 END)
 		ON CONFLICT (original_path) DO UPDATE SET
-			object_keys = CASE WHEN $4 THEN EXCLUDED.object_keys ELSE artwork_revision_gc_candidates.object_keys END,
+			image_type = CASE
+				WHEN artwork_revision_gc_candidates.image_type = '' THEN EXCLUDED.image_type
+				ELSE artwork_revision_gc_candidates.image_type
+			END,
 			not_before = EXCLUDED.not_before,
 			next_attempt_at = EXCLUDED.next_attempt_at,
 			attempt_count = 0,
 			locked_at = NULL,
 			locked_by = '',
 			last_error = '',
-			updated_at = NOW()`, originalPath, keys, notBefore, replaceManifest)
+			updated_at = NOW()`, originalPath, imageType, notBefore, dormant)
 	if err != nil {
 		return fmt.Errorf("catalog: queue artwork revision cleanup: %w", err)
 	}
@@ -232,27 +289,31 @@ func compactArtworkObjectKeys(keys []string) []string {
 	return result
 }
 
+// artworkTargetColumns maps a selection target to its artwork columns. Season
+// and episode rows have dedicated tables; every other catalog item type
+// (movie, series, audiobook, ebook, manga, ...) stores artwork on its
+// media_items row.
 func artworkTargetColumns(targetType, imageType string) (table, pathColumn, sourceColumn, thumbhashColumn string, notFound error, err error) {
 	switch targetType {
-	case artworkTargetMovie, artworkTargetSeries:
-		table = "media_items"
-		notFound = ErrItemNotFound
-		switch imageType {
-		case artworkImagePoster:
-			return table, artworkPosterPathColumn, "poster_source_path", "poster_thumbhash", notFound, nil
-		case artworkImageBackdrop:
-			return table, artworkBackdropPathColumn, "backdrop_source_path", "backdrop_thumbhash", notFound, nil
-		case artworkImageLogo:
-			return table, artworkLogoPathColumn, "logo_source_path", "", notFound, nil
-		}
 	case artworkTargetSeason:
 		if imageType == artworkImagePoster {
-			return "seasons", artworkPosterPathColumn, "poster_source_path", "poster_thumbhash", ErrSeasonNotFound, nil
+			return "seasons", artworkPosterPathColumn, artworkPosterSourceColumn, artworkPosterThumbColumn, ErrSeasonNotFound, nil
 		}
 	case artworkTargetEpisode:
 		if imageType == artworkImageStill {
 			return "episodes", "still_path", "still_source_path", "still_thumbhash", ErrEpisodeNotFound, nil
 		}
+	default:
+		table = "media_items"
+		notFound = ErrItemNotFound
+		switch imageType {
+		case artworkImagePoster:
+			return table, artworkPosterPathColumn, artworkPosterSourceColumn, artworkPosterThumbColumn, notFound, nil
+		case artworkImageBackdrop:
+			return table, artworkBackdropPathColumn, artworkBackdropSourceColumn, artworkBackdropThumbColumn, notFound, nil
+		case artworkImageLogo:
+			return table, artworkLogoPathColumn, artworkLogoSourceColumn, "", notFound, nil
+		}
 	}
-	return "", "", "", "", nil, fmt.Errorf("catalog: unsupported %s artwork type %q", targetType, imageType)
+	return "", "", "", "", nil, fmt.Errorf("%w: %s does not accept %q images", ErrUnsupportedArtworkSelection, targetType, imageType)
 }

--- a/internal/catalog/artwork_selection.go
+++ b/internal/catalog/artwork_selection.go
@@ -253,7 +253,7 @@ func upsertArtworkRevision(
 	_, err := db.Exec(ctx, `
 		INSERT INTO artwork_revision_gc_candidates (
 			original_path, image_type, object_keys, not_before, next_attempt_at
-		) VALUES ($1, $2, '{}', $3, CASE WHEN $4 THEN NULL ELSE $3 END)
+		) VALUES ($1, $2, '{}', $3::timestamptz, CASE WHEN $4 THEN NULL ELSE $3::timestamptz END)
 		ON CONFLICT (original_path) DO UPDATE SET
 			image_type = CASE
 				WHEN artwork_revision_gc_candidates.image_type = '' THEN EXCLUDED.image_type

--- a/internal/catalog/artwork_selection.go
+++ b/internal/catalog/artwork_selection.go
@@ -1,0 +1,258 @@
+package catalog
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgconn"
+	"github.com/jackc/pgx/v5/pgxpool"
+
+	"github.com/Silo-Server/silo-server/internal/artworkkey"
+)
+
+const (
+	defaultArtworkGCGracePeriod = 24 * time.Hour
+	artworkTargetMovie          = "movie"
+	artworkTargetSeries         = "series"
+	artworkTargetSeason         = "season"
+	artworkTargetEpisode        = "episode"
+	artworkImagePoster          = "poster"
+	artworkImageBackdrop        = "backdrop"
+	artworkImageLogo            = "logo"
+	artworkImageStill           = "still"
+	artworkPosterPathColumn     = "poster_path"
+	artworkBackdropPathColumn   = "backdrop_path"
+	artworkLogoPathColumn       = "logo_path"
+)
+
+// ArtworkRevisionTracker registers every immutable artwork upload before its
+// objects are written, allowing the collector to reclaim uploads that are
+// never published. Confirmed live revisions remain dormant in the registry so
+// database triggers can later reactivate their exact object manifests.
+type ArtworkRevisionTracker struct {
+	pool        *pgxpool.Pool
+	gracePeriod time.Duration
+}
+
+func NewArtworkRevisionTracker(pool *pgxpool.Pool) *ArtworkRevisionTracker {
+	if pool == nil {
+		return nil
+	}
+	return &ArtworkRevisionTracker{pool: pool, gracePeriod: defaultArtworkGCGracePeriod}
+}
+
+// TrackArtworkRevision refreshes the publication grace period for a revision.
+// Image caching calls this before uploading, so it serializes with a collector
+// that may already be deleting an older, currently-unreferenced copy.
+func (t *ArtworkRevisionTracker) TrackArtworkRevision(ctx context.Context, originalPath string, objectKeys []string) error {
+	if t == nil || t.pool == nil {
+		return fmt.Errorf("catalog: artwork revision tracking is not configured")
+	}
+	return trackArtworkRevision(ctx, t.pool, originalPath, objectKeys, time.Now().Add(t.gracePeriod), true)
+}
+
+// ArtworkSelection describes a manually selected, already-cached artwork
+// revision. PublishArtworkSelection makes the database pointer and image lock
+// visible atomically, then schedules the displaced revision for delayed cleanup.
+type ArtworkSelection struct {
+	TargetType      string
+	TargetContentID string
+	ParentContentID string
+	ImageType       string
+	StoredPath      string
+	SourcePath      string
+	Thumbhash       string
+	LockField       int
+}
+
+// ArtworkSelectionResult reports the revision displaced by a successful
+// publication. PreviousPath is empty when the target had no prior artwork.
+type ArtworkSelectionResult struct {
+	PreviousPath string
+}
+
+// PublishArtworkSelection atomically changes the selected artwork, records its
+// source, locks automatic image refreshes, and queues the old immutable revision
+// for reference-aware garbage collection after a grace period.
+func (s *DetailService) PublishArtworkSelection(ctx context.Context, selection ArtworkSelection) (*ArtworkSelectionResult, error) {
+	if s == nil || s.itemRepo == nil || s.itemRepo.pool == nil {
+		return nil, fmt.Errorf("catalog: artwork persistence is not configured")
+	}
+	selection.TargetType = strings.ToLower(strings.TrimSpace(selection.TargetType))
+	selection.ImageType = strings.ToLower(strings.TrimSpace(selection.ImageType))
+	selection.TargetContentID = strings.TrimSpace(selection.TargetContentID)
+	selection.ParentContentID = strings.TrimSpace(selection.ParentContentID)
+	selection.StoredPath = strings.TrimSpace(selection.StoredPath)
+	if selection.TargetContentID == "" || selection.StoredPath == "" {
+		return nil, fmt.Errorf("catalog: artwork target and stored path are required")
+	}
+
+	table, pathColumn, sourceColumn, thumbhashColumn, notFound, err := artworkTargetColumns(selection.TargetType, selection.ImageType)
+	if err != nil {
+		return nil, err
+	}
+
+	tx, err := s.itemRepo.pool.Begin(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("catalog: begin artwork publication: %w", err)
+	}
+	defer func() { _ = tx.Rollback(ctx) }()
+
+	var previousPath string
+	selectSQL := fmt.Sprintf("SELECT COALESCE(%s, '') FROM %s WHERE content_id = $1 FOR UPDATE", pathColumn, table)
+	if err := tx.QueryRow(ctx, selectSQL, selection.TargetContentID).Scan(&previousPath); err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return nil, notFound
+		}
+		return nil, fmt.Errorf("catalog: lock artwork target: %w", err)
+	}
+
+	setThumbhash := ""
+	args := []any{selection.StoredPath, selection.SourcePath, selection.TargetContentID}
+	if thumbhashColumn != "" {
+		setThumbhash = fmt.Sprintf(", %s = $4", thumbhashColumn)
+		args = append(args, selection.Thumbhash)
+	}
+	updateSQL := fmt.Sprintf(`
+		UPDATE %s
+		SET %s = $1, %s = $2%s, updated_at = NOW()
+		WHERE content_id = $3`, table, pathColumn, sourceColumn, setThumbhash)
+	if _, err := tx.Exec(ctx, updateSQL, args...); err != nil {
+		return nil, fmt.Errorf("catalog: publish artwork pointer: %w", err)
+	}
+
+	lockContentID := selection.TargetContentID
+	if selection.TargetType == artworkTargetSeason || selection.TargetType == artworkTargetEpisode {
+		lockContentID = selection.ParentContentID
+	}
+	if lockContentID == "" {
+		return nil, fmt.Errorf("catalog: parent content ID is required for %s artwork", selection.TargetType)
+	}
+	tag, err := tx.Exec(ctx, `
+		UPDATE media_items
+		SET locked_fields = CASE
+				WHEN $2 = ANY(COALESCE(locked_fields, '{}'::integer[])) THEN COALESCE(locked_fields, '{}'::integer[])
+				ELSE array_append(COALESCE(locked_fields, '{}'::integer[]), $2)
+			END,
+			updated_at = NOW()
+		WHERE content_id = $1`, lockContentID, selection.LockField)
+	if err != nil {
+		return nil, fmt.Errorf("catalog: lock manual artwork: %w", err)
+	}
+	if tag.RowsAffected() == 0 {
+		return nil, ErrItemNotFound
+	}
+	// Register the selected revision in the publication transaction. The first
+	// cleanup pass parks it while referenced; database triggers reactivate its
+	// exact manifest if any writer later displaces or deletes it.
+	if err := queueArtworkRevisionGC(ctx, tx, selection.StoredPath, selection.ImageType, time.Now().Add(defaultArtworkGCGracePeriod)); err != nil {
+		return nil, err
+	}
+
+	if previousPath != "" && previousPath != selection.StoredPath {
+		if err := queueArtworkRevisionGC(ctx, tx, previousPath, selection.ImageType, time.Now().Add(defaultArtworkGCGracePeriod)); err != nil {
+			return nil, err
+		}
+	}
+
+	if err := tx.Commit(ctx); err != nil {
+		return nil, fmt.Errorf("catalog: commit artwork publication: %w", err)
+	}
+	return &ArtworkSelectionResult{PreviousPath: previousPath}, nil
+}
+
+// QueueArtworkRevisionGC schedules an unreferenced cached revision for cleanup.
+// It is used to reclaim an upload when publication fails after object storage
+// succeeded. Cleanup still verifies database references before deleting.
+func (s *DetailService) QueueArtworkRevisionGC(ctx context.Context, originalPath, imageType string, notBefore time.Time) error {
+	if s == nil || s.itemRepo == nil || s.itemRepo.pool == nil {
+		return fmt.Errorf("catalog: artwork persistence is not configured")
+	}
+	return queueArtworkRevisionGC(ctx, s.itemRepo.pool, originalPath, imageType, notBefore)
+}
+
+type artworkGCExecer interface {
+	Exec(ctx context.Context, sql string, arguments ...any) (pgconn.CommandTag, error)
+}
+
+func queueArtworkRevisionGC(ctx context.Context, db artworkGCExecer, originalPath, imageType string, notBefore time.Time) error {
+	return trackArtworkRevision(ctx, db, originalPath, artworkkey.ObjectKeys(originalPath, imageType), notBefore, false)
+}
+
+func trackArtworkRevision(
+	ctx context.Context,
+	db artworkGCExecer,
+	originalPath string,
+	objectKeys []string,
+	notBefore time.Time,
+	replaceManifest bool,
+) error {
+	originalPath = strings.TrimSpace(originalPath)
+	keys := compactArtworkObjectKeys(objectKeys)
+	if originalPath == "" || strings.Contains(originalPath, "://") || len(keys) == 0 {
+		return nil
+	}
+	_, err := db.Exec(ctx, `
+		INSERT INTO artwork_revision_gc_candidates (
+			original_path, object_keys, not_before, next_attempt_at
+		) VALUES ($1, $2, $3, $3)
+		ON CONFLICT (original_path) DO UPDATE SET
+			object_keys = CASE WHEN $4 THEN EXCLUDED.object_keys ELSE artwork_revision_gc_candidates.object_keys END,
+			not_before = EXCLUDED.not_before,
+			next_attempt_at = EXCLUDED.next_attempt_at,
+			attempt_count = 0,
+			locked_at = NULL,
+			locked_by = '',
+			last_error = '',
+			updated_at = NOW()`, originalPath, keys, notBefore, replaceManifest)
+	if err != nil {
+		return fmt.Errorf("catalog: queue artwork revision cleanup: %w", err)
+	}
+	return nil
+}
+
+func compactArtworkObjectKeys(keys []string) []string {
+	seen := make(map[string]struct{}, len(keys))
+	result := make([]string, 0, len(keys))
+	for _, key := range keys {
+		key = strings.TrimSpace(key)
+		if key == "" || strings.Contains(key, "://") {
+			continue
+		}
+		if _, ok := seen[key]; ok {
+			continue
+		}
+		seen[key] = struct{}{}
+		result = append(result, key)
+	}
+	return result
+}
+
+func artworkTargetColumns(targetType, imageType string) (table, pathColumn, sourceColumn, thumbhashColumn string, notFound error, err error) {
+	switch targetType {
+	case artworkTargetMovie, artworkTargetSeries:
+		table = "media_items"
+		notFound = ErrItemNotFound
+		switch imageType {
+		case artworkImagePoster:
+			return table, artworkPosterPathColumn, "poster_source_path", "poster_thumbhash", notFound, nil
+		case artworkImageBackdrop:
+			return table, artworkBackdropPathColumn, "backdrop_source_path", "backdrop_thumbhash", notFound, nil
+		case artworkImageLogo:
+			return table, artworkLogoPathColumn, "logo_source_path", "", notFound, nil
+		}
+	case artworkTargetSeason:
+		if imageType == artworkImagePoster {
+			return "seasons", artworkPosterPathColumn, "poster_source_path", "poster_thumbhash", ErrSeasonNotFound, nil
+		}
+	case artworkTargetEpisode:
+		if imageType == artworkImageStill {
+			return "episodes", "still_path", "still_source_path", "still_thumbhash", ErrEpisodeNotFound, nil
+		}
+	}
+	return "", "", "", "", nil, fmt.Errorf("catalog: unsupported %s artwork type %q", targetType, imageType)
+}

--- a/internal/catalog/artwork_selection_test.go
+++ b/internal/catalog/artwork_selection_test.go
@@ -1,0 +1,100 @@
+package catalog
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/jackc/pgx/v5/pgxpool"
+)
+
+func newArtworkSelectionTestPool(t *testing.T) *pgxpool.Pool {
+	t.Helper()
+	dsn := os.Getenv("SILO_TEST_DATABASE_URL")
+	if dsn == "" {
+		t.Skip("SILO_TEST_DATABASE_URL is not set")
+	}
+	pool, err := pgxpool.New(context.Background(), dsn)
+	if err != nil {
+		t.Fatalf("connect test database: %v", err)
+	}
+	t.Cleanup(pool.Close)
+	return pool
+}
+
+func TestQueueAndParkArtworkRevisionUpserts(t *testing.T) {
+	pool := newArtworkSelectionTestPool(t)
+	ctx := context.Background()
+	suffix := time.Now().UnixNano()
+	path := fmt.Sprintf("tmdb/movies/%d/poster/original.rev.webp", suffix)
+	t.Cleanup(func() {
+		_, _ = pool.Exec(ctx, `DELETE FROM artwork_revision_gc_candidates WHERE original_path = $1`, path)
+	})
+
+	// Arming registers the revision for verification after the grace period.
+	if err := queueArtworkRevisionGC(ctx, pool, path, "poster", time.Now().Add(time.Hour)); err != nil {
+		t.Fatalf("queueArtworkRevisionGC: %v", err)
+	}
+	var imageType string
+	var nextAttempt *time.Time
+	if err := pool.QueryRow(ctx, `
+		SELECT image_type, next_attempt_at FROM artwork_revision_gc_candidates
+		WHERE original_path = $1`, path).Scan(&imageType, &nextAttempt); err != nil {
+		t.Fatalf("load armed candidate: %v", err)
+	}
+	if imageType != "poster" {
+		t.Fatalf("image_type = %q, want poster", imageType)
+	}
+	if nextAttempt == nil {
+		t.Fatal("armed candidate has NULL next_attempt_at")
+	}
+
+	// Publication parks the selected revision: referenced by construction.
+	if err := parkArtworkRevision(ctx, pool, path, "poster", time.Now().Add(time.Hour)); err != nil {
+		t.Fatalf("parkArtworkRevision: %v", err)
+	}
+	if err := pool.QueryRow(ctx, `
+		SELECT next_attempt_at FROM artwork_revision_gc_candidates
+		WHERE original_path = $1`, path).Scan(&nextAttempt); err != nil {
+		t.Fatalf("load parked candidate: %v", err)
+	}
+	if nextAttempt != nil {
+		t.Fatalf("parked candidate next_attempt_at = %v, want NULL", *nextAttempt)
+	}
+}
+
+func TestTrackArtworkRevisionKeepsDormantRowsDormant(t *testing.T) {
+	pool := newArtworkSelectionTestPool(t)
+	ctx := context.Background()
+	suffix := time.Now().UnixNano()
+	path := fmt.Sprintf("tmdb/movies/%d/poster/original.live.webp", suffix)
+	keys := []string{path, fmt.Sprintf("tmdb/movies/%d/poster/w500.live.webp", suffix)}
+	t.Cleanup(func() {
+		_, _ = pool.Exec(ctx, `DELETE FROM artwork_revision_gc_candidates WHERE original_path = $1`, path)
+	})
+
+	if err := parkArtworkRevision(ctx, pool, path, "poster", time.Now().Add(time.Hour)); err != nil {
+		t.Fatalf("parkArtworkRevision: %v", err)
+	}
+	// A re-cache of live artwork must not re-arm the parked row.
+	tracker := NewArtworkRevisionTracker(pool)
+	if err := tracker.TrackArtworkRevision(ctx, path, "poster", keys); err != nil {
+		t.Fatalf("TrackArtworkRevision: %v", err)
+	}
+
+	var nextAttempt *time.Time
+	var storedKeys []string
+	if err := pool.QueryRow(ctx, `
+		SELECT next_attempt_at, object_keys FROM artwork_revision_gc_candidates
+		WHERE original_path = $1`, path).Scan(&nextAttempt, &storedKeys); err != nil {
+		t.Fatalf("load candidate: %v", err)
+	}
+	if nextAttempt != nil {
+		t.Fatalf("re-cache re-armed dormant row: next_attempt_at = %v", *nextAttempt)
+	}
+	if len(storedKeys) != len(keys) {
+		t.Fatalf("stored manifest = %v, want exact tracked manifest %v", storedKeys, keys)
+	}
+}

--- a/internal/catalog/artwork_selection_test.go
+++ b/internal/catalog/artwork_selection_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"os"
+	"slices"
 	"testing"
 	"time"
 
@@ -94,7 +95,7 @@ func TestTrackArtworkRevisionKeepsDormantRowsDormant(t *testing.T) {
 	if nextAttempt != nil {
 		t.Fatalf("re-cache re-armed dormant row: next_attempt_at = %v", *nextAttempt)
 	}
-	if len(storedKeys) != len(keys) {
+	if !slices.Equal(storedKeys, keys) {
 		t.Fatalf("stored manifest = %v, want exact tracked manifest %v", storedKeys, keys)
 	}
 }

--- a/internal/catalog/detail.go
+++ b/internal/catalog/detail.go
@@ -14,6 +14,7 @@ import (
 	"time"
 
 	"github.com/Silo-Server/silo-server/internal/access"
+	"github.com/Silo-Server/silo-server/internal/artworkkey"
 	"github.com/Silo-Server/silo-server/internal/models"
 	"github.com/Silo-Server/silo-server/internal/overlays"
 	"github.com/Silo-Server/silo-server/internal/playback"
@@ -3620,10 +3621,7 @@ func cachedImageVariantPath(path, imageType, size string) string {
 	if variant == "" {
 		return path
 	}
-	if strings.Contains(path, "/original.") {
-		return strings.Replace(path, "/original.", "/"+variant+".", 1)
-	}
-	return path
+	return artworkkey.Variant(path, variant)
 }
 
 // imageTypeFromCachedPath returns the image type segment ("poster", "backdrop",

--- a/internal/catalog/folder_repo.go
+++ b/internal/catalog/folder_repo.go
@@ -11,6 +11,7 @@ import (
 	"github.com/jackc/pgx/v5/pgconn"
 	"github.com/jackc/pgx/v5/pgxpool"
 
+	"github.com/Silo-Server/silo-server/internal/artworkkey"
 	"github.com/Silo-Server/silo-server/internal/models"
 )
 
@@ -897,11 +898,7 @@ func dirSetToSlice(set map[string]struct{}) []string {
 // pathDir extracts the directory portion of an S3 image path.
 // e.g. "tmdb/movies/550/poster/original.webp" → "tmdb/movies/550/poster/"
 func pathDir(path string) string {
-	idx := strings.LastIndex(path, "/")
-	if idx <= 0 {
-		return ""
-	}
-	return path[:idx+1]
+	return artworkkey.Directory(path)
 }
 
 // rowQuerier is satisfied by both *pgxpool.Pool and pgx.Tx, letting read

--- a/internal/ebooks/enrichment.go
+++ b/internal/ebooks/enrichment.go
@@ -527,7 +527,7 @@ func (e *Enricher) cacheRemotePoster(ctx context.Context, contentID string, resu
 		return
 	}
 
-	if storedPath := cachedOriginalImagePath(cached.BasePath, cached.Ext); storedPath != "" {
+	if storedPath := metadata.CachedImageOriginalPath(cached); storedPath != "" {
 		result.PosterPath = storedPath
 	}
 	if cached.Thumbhash != "" {
@@ -587,19 +587,6 @@ func isNilImageCacher(cacher metadata.ImageCacher) bool {
 	default:
 		return false
 	}
-}
-
-func cachedOriginalImagePath(basePath, ext string) string {
-	if basePath == "" {
-		return ""
-	}
-	if strings.Contains(basePath, "/original.") {
-		return basePath
-	}
-	if ext == "" {
-		ext = ".jpg"
-	}
-	return strings.TrimRight(basePath, "/") + "/original" + ext
 }
 
 func (e *Enricher) persist(ctx context.Context, contentID string, providerIDs map[string]string, result *metadata.MetadataResult) error {

--- a/internal/imagecache/imagecache.go
+++ b/internal/imagecache/imagecache.go
@@ -34,10 +34,6 @@ type ObjectPutter interface {
 	Bucket() string
 }
 
-type objectExister interface {
-	ObjectExists(ctx context.Context, bucket, key string) (bool, error)
-}
-
 type objectMatcher interface {
 	ObjectMatches(ctx context.Context, bucket, key string, data []byte) (bool, error)
 }
@@ -347,19 +343,15 @@ func (c *Cacher) trackRevision(ctx context.Context, imageType metadata.ImageType
 	return nil
 }
 
-func objectExists(ctx context.Context, putter ObjectPutter, bucket, key string) (bool, error) {
-	exister, ok := putter.(objectExister)
+// objectMatches reports whether the object at key already holds exactly data.
+// Backends that cannot verify content report false so the immutable object is
+// rewritten; bare existence must never be accepted as a content match.
+func objectMatches(ctx context.Context, putter ObjectPutter, bucket, key string, data []byte) (bool, error) {
+	matcher, ok := putter.(objectMatcher)
 	if !ok {
 		return false, nil
 	}
-	return exister.ObjectExists(ctx, bucket, key)
-}
-
-func objectMatches(ctx context.Context, putter ObjectPutter, bucket, key string, data []byte) (bool, error) {
-	if matcher, ok := putter.(objectMatcher); ok {
-		return matcher.ObjectMatches(ctx, bucket, key, data)
-	}
-	return objectExists(ctx, putter, bucket, key)
+	return matcher.ObjectMatches(ctx, bucket, key, data)
 }
 
 func putObjectWithRetry(ctx context.Context, putter ObjectPutter, bucket, key string, data []byte) error {

--- a/internal/imagecache/imagecache.go
+++ b/internal/imagecache/imagecache.go
@@ -45,7 +45,7 @@ type objectMatcher interface {
 // ArtworkRevisionTracker persists the exact object manifest for an immutable
 // revision before any object is uploaded.
 type ArtworkRevisionTracker interface {
-	TrackArtworkRevision(ctx context.Context, originalPath string, objectKeys []string) error
+	TrackArtworkRevision(ctx context.Context, originalPath, imageType string, objectKeys []string) error
 }
 
 // ImageURLResolver resolves plugin:// paths to HTTP URLs.
@@ -128,7 +128,6 @@ func (c *Cacher) CacheImage(ctx context.Context, req metadata.CacheImageRequest)
 		BasePath:         result.BasePath,
 		OriginalPath:     result.OriginalPath,
 		Revision:         result.Revision,
-		VariantPaths:     result.VariantPaths,
 		Thumbhash:        result.Thumbhash,
 		Ext:              result.Ext,
 		UploadedVariants: result.UploadedVariants,
@@ -200,7 +199,7 @@ func (c *Cacher) CacheBytes(ctx context.Context, data []byte, req CacheRequest) 
 	bucket := c.s3.Bucket()
 	revision := variantRevision(result)
 	variantPaths := buildVariantPaths(basePath, revision, result)
-	if err := c.trackRevision(ctx, variantPaths); err != nil {
+	if err := c.trackRevision(ctx, req.ImageType, variantPaths); err != nil {
 		return nil, err
 	}
 
@@ -220,8 +219,8 @@ func (c *Cacher) CacheBytes(ctx context.Context, data []byte, req CacheRequest) 
 	}, nil
 }
 
-// Cache downloads the image at req.SourceURL, generates variants, computes a
-// thumbhash, uploads all variants to S3, and returns the base path and thumbhash.
+// Cache downloads the image at req.SourceURL and stores it through the same
+// variant, revision-tracking, and upload pipeline as CacheBytes.
 func (c *Cacher) Cache(ctx context.Context, req CacheRequest) (*CacheResult, error) {
 	if strings.TrimSpace(req.ProviderID) == "" {
 		return nil, fmt.Errorf("imagecache: provider ID is required")
@@ -254,61 +253,14 @@ func (c *Cacher) Cache(ctx context.Context, req CacheRequest) (*CacheResult, err
 		return nil, fmt.Errorf("imagecache: download %s: %w", url, err)
 	}
 
-	// Compute thumbhash from the original downloaded data (JPEG/PNG) before
-	// converting to WebP, since Go's image.Decode doesn't support WebP.
-	thumbhash, err := imageutil.Thumbhash(data)
-	if err != nil {
-		return nil, fmt.Errorf("imagecache: thumbhash: %w", err)
-	}
-
-	widths := variantWidths(req.ImageType)
-
-	result, err := imageutil.GenerateVariants(data, widths)
-	if err != nil {
-		return nil, fmt.Errorf("imagecache: generate variants: %w", err)
-	}
-
-	basePath := buildBasePath(req.ProviderID, req.ContentType, req.ContentID, req.ImageType, req.Language, req.SeasonNumber, req.EpisodeNumber)
-	bucket := c.s3.Bucket()
-	revision := variantRevision(result)
-	variantPaths := buildVariantPaths(basePath, revision, result)
-	if err := c.trackRevision(ctx, variantPaths); err != nil {
-		return nil, err
-	}
-
-	uploadStats, err := c.uploadVariants(ctx, bucket, result, variantPaths)
-	if err != nil {
-		return nil, err
-	}
-
-	return &CacheResult{
-		BasePath:         basePath,
-		OriginalPath:     variantPaths[artworkkey.OriginalVariant],
-		Revision:         revision,
-		VariantPaths:     variantPaths,
-		Thumbhash:        thumbhash,
-		Ext:              result.Ext,
-		UploadedVariants: uploadStats.uploaded,
-		ExistingVariants: uploadStats.existing,
-	}, nil
+	return c.CacheBytes(ctx, data, req)
 }
 
-// variantWidths returns the resize widths for the given image type.
+// variantWidths returns the resize widths for the given image type. The
+// ladder itself is owned by artworkkey so key expansion and GC manifests can
+// never drift from what is generated here.
 func variantWidths(t metadata.ImageType) []int {
-	switch t {
-	case metadata.ImagePoster:
-		return []int{500, 300}
-	case metadata.ImageBackdrop:
-		return []int{1920, 1280, 300}
-	case metadata.ImageLogo:
-		return []int{500}
-	case metadata.ImageStill:
-		return []int{500, 300}
-	case metadata.ImageProfile:
-		return []int{500, 300}
-	default:
-		return []int{500, 300}
-	}
+	return artworkkey.VariantWidths(metadata.ImageTypeToString(t))
 }
 
 type uploadVariantStats struct {
@@ -379,7 +331,7 @@ func buildVariantPaths(basePath, revision string, result *imageutil.VariantResul
 	return paths
 }
 
-func (c *Cacher) trackRevision(ctx context.Context, variantPaths map[string]string) error {
+func (c *Cacher) trackRevision(ctx context.Context, imageType metadata.ImageType, variantPaths map[string]string) error {
 	if c == nil || c.revisionTracker == nil {
 		return nil
 	}
@@ -389,7 +341,7 @@ func (c *Cacher) trackRevision(ctx context.Context, variantPaths map[string]stri
 		keys = append(keys, key)
 	}
 	sort.Strings(keys)
-	if err := c.revisionTracker.TrackArtworkRevision(ctx, originalPath, keys); err != nil {
+	if err := c.revisionTracker.TrackArtworkRevision(ctx, originalPath, metadata.ImageTypeToString(imageType), keys); err != nil {
 		return fmt.Errorf("imagecache: track artwork revision: %w", err)
 	}
 	return nil

--- a/internal/imagecache/imagecache.go
+++ b/internal/imagecache/imagecache.go
@@ -4,16 +4,21 @@ package imagecache
 
 import (
 	"context"
+	"crypto/sha256"
+	"encoding/binary"
+	"encoding/hex"
 	"fmt"
 	"io"
 	"net"
 	"net/http"
 	"net/netip"
 	"net/url"
+	"sort"
 	"strings"
 	"sync"
 	"time"
 
+	"github.com/Silo-Server/silo-server/internal/artworkkey"
 	"github.com/Silo-Server/silo-server/internal/imageutil"
 	"github.com/Silo-Server/silo-server/internal/metadata"
 )
@@ -31,6 +36,16 @@ type ObjectPutter interface {
 
 type objectExister interface {
 	ObjectExists(ctx context.Context, bucket, key string) (bool, error)
+}
+
+type objectMatcher interface {
+	ObjectMatches(ctx context.Context, bucket, key string, data []byte) (bool, error)
+}
+
+// ArtworkRevisionTracker persists the exact object manifest for an immutable
+// revision before any object is uploaded.
+type ArtworkRevisionTracker interface {
+	TrackArtworkRevision(ctx context.Context, originalPath string, objectKeys []string) error
 }
 
 // ImageURLResolver resolves plugin:// paths to HTTP URLs.
@@ -57,6 +72,9 @@ type CacheRequest struct {
 // CacheResult is returned by Cache on success.
 type CacheResult struct {
 	BasePath         string // S3 key prefix, e.g. "tmdb/movies/550/poster"
+	OriginalPath     string // exact immutable original-variant object key
+	Revision         string // content revision shared by generated variants
+	VariantPaths     map[string]string
 	Thumbhash        string // base64-encoded
 	Ext              string // file extension including dot (e.g. ".jpg", ".png")
 	UploadedVariants int
@@ -66,6 +84,7 @@ type CacheResult struct {
 // Cacher downloads and stores image variants to S3.
 type Cacher struct {
 	s3                ObjectPutter
+	revisionTracker   ArtworkRevisionTracker
 	httpClient        *http.Client
 	enforcePublicURLs bool
 }
@@ -73,6 +92,14 @@ type Cacher struct {
 // New creates a new Cacher backed by the given ObjectPutter.
 func New(s3 ObjectPutter) *Cacher {
 	return &Cacher{s3: s3, httpClient: newSecureHTTPClient(), enforcePublicURLs: true}
+}
+
+// SetArtworkRevisionTracker wires durable revision lifecycle tracking. The
+// production server configures this whenever object storage is available.
+func (c *Cacher) SetArtworkRevisionTracker(tracker ArtworkRevisionTracker) {
+	if c != nil {
+		c.revisionTracker = tracker
+	}
 }
 
 func newWithHTTPClient(s3 ObjectPutter, client *http.Client) *Cacher {
@@ -99,6 +126,9 @@ func (c *Cacher) CacheImage(ctx context.Context, req metadata.CacheImageRequest)
 	}
 	return &metadata.CacheImageResult{
 		BasePath:         result.BasePath,
+		OriginalPath:     result.OriginalPath,
+		Revision:         result.Revision,
+		VariantPaths:     result.VariantPaths,
 		Thumbhash:        result.Thumbhash,
 		Ext:              result.Ext,
 		UploadedVariants: result.UploadedVariants,
@@ -111,7 +141,7 @@ func (c *Cacher) CacheImage(ctx context.Context, req metadata.CacheImageRequest)
 // struct to the scanner package (which would create an import cycle
 // scanner -> imagecache -> metadata -> scanner). Stores under
 // "local/audiobooks/{contentID}/poster/...".
-func (c *Cacher) CacheAudiobookCover(ctx context.Context, data []byte, contentID string) (basePath string, ext string, thumbhash string, err error) {
+func (c *Cacher) CacheAudiobookCover(ctx context.Context, data []byte, contentID string) (storedPath string, thumbhash string, err error) {
 	res, err := c.CacheBytes(ctx, data, CacheRequest{
 		ProviderID:  "local",
 		ContentType: "audiobooks",
@@ -119,15 +149,15 @@ func (c *Cacher) CacheAudiobookCover(ctx context.Context, data []byte, contentID
 		ImageType:   metadata.ImagePoster,
 	})
 	if err != nil {
-		return "", "", "", err
+		return "", "", err
 	}
-	return res.BasePath, res.Ext, res.Thumbhash, nil
+	return res.OriginalPath, res.Thumbhash, nil
 }
 
 // CacheEbookCover stores an embedded ebook cover under
 // "local/ebooks/{contentID}/poster/..." using the same poster variants as
 // provider-hosted book artwork.
-func (c *Cacher) CacheEbookCover(ctx context.Context, data []byte, contentID string) (basePath string, ext string, thumbhash string, err error) {
+func (c *Cacher) CacheEbookCover(ctx context.Context, data []byte, contentID string) (storedPath string, thumbhash string, err error) {
 	res, err := c.CacheBytes(ctx, data, CacheRequest{
 		ProviderID:  "local",
 		ContentType: "ebooks",
@@ -135,9 +165,9 @@ func (c *Cacher) CacheEbookCover(ctx context.Context, data []byte, contentID str
 		ImageType:   metadata.ImagePoster,
 	})
 	if err != nil {
-		return "", "", "", err
+		return "", "", err
 	}
-	return res.BasePath, res.Ext, res.Thumbhash, nil
+	return res.OriginalPath, res.Thumbhash, nil
 }
 
 // CacheBytes performs the same variant generation, thumbhash, and S3 upload as
@@ -168,13 +198,21 @@ func (c *Cacher) CacheBytes(ctx context.Context, data []byte, req CacheRequest) 
 	}
 	basePath := buildBasePath(req.ProviderID, req.ContentType, req.ContentID, req.ImageType, req.Language, req.SeasonNumber, req.EpisodeNumber)
 	bucket := c.s3.Bucket()
+	revision := variantRevision(result)
+	variantPaths := buildVariantPaths(basePath, revision, result)
+	if err := c.trackRevision(ctx, variantPaths); err != nil {
+		return nil, err
+	}
 
-	uploadStats, err := c.uploadVariants(ctx, bucket, basePath, result)
+	uploadStats, err := c.uploadVariants(ctx, bucket, result, variantPaths)
 	if err != nil {
 		return nil, err
 	}
 	return &CacheResult{
 		BasePath:         basePath,
+		OriginalPath:     variantPaths[artworkkey.OriginalVariant],
+		Revision:         revision,
+		VariantPaths:     variantPaths,
 		Thumbhash:        thumbhash,
 		Ext:              result.Ext,
 		UploadedVariants: uploadStats.uploaded,
@@ -232,14 +270,22 @@ func (c *Cacher) Cache(ctx context.Context, req CacheRequest) (*CacheResult, err
 
 	basePath := buildBasePath(req.ProviderID, req.ContentType, req.ContentID, req.ImageType, req.Language, req.SeasonNumber, req.EpisodeNumber)
 	bucket := c.s3.Bucket()
+	revision := variantRevision(result)
+	variantPaths := buildVariantPaths(basePath, revision, result)
+	if err := c.trackRevision(ctx, variantPaths); err != nil {
+		return nil, err
+	}
 
-	uploadStats, err := c.uploadVariants(ctx, bucket, basePath, result)
+	uploadStats, err := c.uploadVariants(ctx, bucket, result, variantPaths)
 	if err != nil {
 		return nil, err
 	}
 
 	return &CacheResult{
 		BasePath:         basePath,
+		OriginalPath:     variantPaths[artworkkey.OriginalVariant],
+		Revision:         revision,
+		VariantPaths:     variantPaths,
 		Thumbhash:        thumbhash,
 		Ext:              result.Ext,
 		UploadedVariants: uploadStats.uploaded,
@@ -270,7 +316,7 @@ type uploadVariantStats struct {
 	existing int
 }
 
-func (c *Cacher) uploadVariants(ctx context.Context, bucket, basePath string, result *imageutil.VariantResult) (uploadVariantStats, error) {
+func (c *Cacher) uploadVariants(ctx context.Context, bucket string, result *imageutil.VariantResult, variantPaths map[string]string) (uploadVariantStats, error) {
 	var wg sync.WaitGroup
 	uploadErrs := make([]error, len(result.Variants))
 	stats := make([]uploadVariantStats, len(result.Variants))
@@ -278,8 +324,8 @@ func (c *Cacher) uploadVariants(ctx context.Context, bucket, basePath string, re
 		wg.Add(1)
 		go func(idx int, variant imageutil.Variant) {
 			defer wg.Done()
-			key := basePath + "/" + variant.Key + result.Ext
-			if exists, err := objectExists(ctx, c.s3, bucket, key); err != nil {
+			key := variantPaths[variant.Key]
+			if exists, err := objectMatches(ctx, c.s3, bucket, key, variant.Data); err != nil {
 				uploadErrs[idx] = fmt.Errorf("imagecache: check existing %s: %w", key, err)
 				return
 			} else if exists {
@@ -307,12 +353,61 @@ func (c *Cacher) uploadVariants(ctx context.Context, bucket, basePath string, re
 	return total, nil
 }
 
+func variantRevision(result *imageutil.VariantResult) string {
+	h := sha256.New()
+	_, _ = io.WriteString(h, "silo-artwork-v1\x00")
+	_, _ = io.WriteString(h, result.Ext)
+	_, _ = h.Write([]byte{0})
+	variants := append([]imageutil.Variant(nil), result.Variants...)
+	sort.Slice(variants, func(i, j int) bool { return variants[i].Key < variants[j].Key })
+	var size [8]byte
+	for _, variant := range variants {
+		_, _ = io.WriteString(h, variant.Key)
+		_, _ = h.Write([]byte{0})
+		binary.BigEndian.PutUint64(size[:], uint64(len(variant.Data)))
+		_, _ = h.Write(size[:])
+		_, _ = h.Write(variant.Data)
+	}
+	return hex.EncodeToString(h.Sum(nil))
+}
+
+func buildVariantPaths(basePath, revision string, result *imageutil.VariantResult) map[string]string {
+	paths := make(map[string]string, len(result.Variants))
+	for _, variant := range result.Variants {
+		paths[variant.Key] = artworkkey.Build(basePath, variant.Key, revision, result.Ext)
+	}
+	return paths
+}
+
+func (c *Cacher) trackRevision(ctx context.Context, variantPaths map[string]string) error {
+	if c == nil || c.revisionTracker == nil {
+		return nil
+	}
+	originalPath := variantPaths[artworkkey.OriginalVariant]
+	keys := make([]string, 0, len(variantPaths))
+	for _, key := range variantPaths {
+		keys = append(keys, key)
+	}
+	sort.Strings(keys)
+	if err := c.revisionTracker.TrackArtworkRevision(ctx, originalPath, keys); err != nil {
+		return fmt.Errorf("imagecache: track artwork revision: %w", err)
+	}
+	return nil
+}
+
 func objectExists(ctx context.Context, putter ObjectPutter, bucket, key string) (bool, error) {
 	exister, ok := putter.(objectExister)
 	if !ok {
 		return false, nil
 	}
 	return exister.ObjectExists(ctx, bucket, key)
+}
+
+func objectMatches(ctx context.Context, putter ObjectPutter, bucket, key string, data []byte) (bool, error) {
+	if matcher, ok := putter.(objectMatcher); ok {
+		return matcher.ObjectMatches(ctx, bucket, key, data)
+	}
+	return objectExists(ctx, putter, bucket, key)
 }
 
 func putObjectWithRetry(ctx context.Context, putter ObjectPutter, bucket, key string, data []byte) error {

--- a/internal/imagecache/imagecache_test.go
+++ b/internal/imagecache/imagecache_test.go
@@ -4,19 +4,26 @@ import (
 	"bytes"
 	"context"
 	"errors"
-	"fmt"
 	"image"
 	"image/color"
 	"image/jpeg"
 	"image/png"
 	"net/http"
 	"net/http/httptest"
+	"slices"
+	"sort"
+	"strings"
 	"sync"
 	"testing"
 
 	"github.com/h2non/bimg"
 
 	"github.com/Silo-Server/silo-server/internal/metadata"
+)
+
+const (
+	testTMDBProviderID    = "tmdb"
+	testMoviesContentType = "movies"
 )
 
 // makeTestJPEG generates a minimal solid-color JPEG for use in tests.
@@ -67,6 +74,35 @@ type putCall struct {
 	key    string
 	size   int
 	data   []byte
+}
+
+type trackedRevision struct {
+	originalPath string
+	objectKeys   []string
+}
+
+type recordingRevisionTracker struct {
+	mu    sync.Mutex
+	calls []trackedRevision
+	err   error
+}
+
+func (t *recordingRevisionTracker) TrackArtworkRevision(_ context.Context, originalPath string, objectKeys []string) error {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	t.calls = append(t.calls, trackedRevision{
+		originalPath: originalPath,
+		objectKeys:   append([]string(nil), objectKeys...),
+	})
+	return t.err
+}
+
+func (t *recordingRevisionTracker) recorded() []trackedRevision {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	result := make([]trackedRevision, len(t.calls))
+	copy(result, t.calls)
+	return result
 }
 
 func (m *mockS3) PutObject(_ context.Context, bucket, key string, data []byte) error {
@@ -123,6 +159,77 @@ func (m *mockS3) checkedKeys() []string {
 	keys := make([]string, len(m.existsCalls))
 	copy(keys, m.existsCalls)
 	return keys
+}
+
+func (m *mockS3) resetCalls() {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.calls = nil
+	m.existsCalls = nil
+}
+
+func TestCacheBytesTracksExactRevisionBeforeUpload(t *testing.T) {
+	s3 := &mockS3{bucket: "artwork"}
+	tracker := &recordingRevisionTracker{}
+	cacher := newWithHTTPClient(s3, nil)
+	cacher.SetArtworkRevisionTracker(tracker)
+
+	result, err := cacher.CacheBytes(context.Background(), makeTestJPEG(t), CacheRequest{
+		ProviderID:  testTMDBProviderID,
+		ContentType: testMoviesContentType,
+		ContentID:   "335984",
+		ImageType:   metadata.ImagePoster,
+	})
+	if err != nil {
+		t.Fatalf("CacheBytes: %v", err)
+	}
+
+	calls := tracker.recorded()
+	if len(calls) != 1 {
+		t.Fatalf("tracker calls = %d, want 1", len(calls))
+	}
+	if calls[0].originalPath != result.OriginalPath {
+		t.Fatalf("tracked original = %q, want %q", calls[0].originalPath, result.OriginalPath)
+	}
+	wantKeys := make([]string, 0, len(result.VariantPaths))
+	for _, key := range result.VariantPaths {
+		wantKeys = append(wantKeys, key)
+	}
+	sort.Strings(wantKeys)
+	if !slices.Equal(calls[0].objectKeys, wantKeys) {
+		t.Fatalf("tracked keys = %v, want %v", calls[0].objectKeys, wantKeys)
+	}
+}
+
+func TestCacheBytesDoesNotUploadWhenRevisionTrackingFails(t *testing.T) {
+	s3 := &mockS3{bucket: "artwork"}
+	tracker := &recordingRevisionTracker{err: errors.New("registry unavailable")}
+	cacher := newWithHTTPClient(s3, nil)
+	cacher.SetArtworkRevisionTracker(tracker)
+
+	_, err := cacher.CacheBytes(context.Background(), makeTestJPEG(t), CacheRequest{
+		ProviderID:  testTMDBProviderID,
+		ContentType: testMoviesContentType,
+		ContentID:   "335984",
+		ImageType:   metadata.ImagePoster,
+	})
+	if err == nil || !strings.Contains(err.Error(), "track artwork revision") {
+		t.Fatalf("CacheBytes error = %v, want tracking failure", err)
+	}
+	if got := len(s3.keys()); got != 0 {
+		t.Fatalf("uploaded objects = %d, want 0", got)
+	}
+}
+
+func (m *mockS3) setExisting(keys ...string) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if m.existing == nil {
+		m.existing = make(map[string]bool)
+	}
+	for _, key := range keys {
+		m.existing[key] = true
+	}
 }
 
 func containsKey(keys []string, suffix string) bool {
@@ -195,7 +302,7 @@ func TestCache_Poster(t *testing.T) {
 		t.Errorf("expected 3 uploaded variants, got %d: %v", len(keys), keys)
 	}
 	for _, variant := range []string{"original", "w500", "w300"} {
-		want := wantBase + "/" + variant + ".webp"
+		want := result.VariantPaths[variant]
 		if !hasKey(keys, want) {
 			t.Errorf("missing S3 key %q in %v", want, keys)
 		}
@@ -207,23 +314,23 @@ func TestCacheSkipsUploadingVariantsThatAlreadyExist(t *testing.T) {
 	srv := startImageServer(t, jpeg, http.StatusOK)
 
 	wantBase := "tmdb/movies/550/poster"
-	s3 := &mockS3{
-		bucket: "media",
-		existing: map[string]bool{
-			wantBase + "/original.webp": true,
-			wantBase + "/w500.webp":     true,
-			wantBase + "/w300.webp":     true,
-		},
-	}
+	s3 := &mockS3{bucket: "media"}
 	c := newWithHTTPClient(s3, srv.Client())
 
-	result, err := c.Cache(context.Background(), CacheRequest{
+	req := CacheRequest{
 		SourceURL:   srv.URL + "/poster.jpg",
 		ProviderID:  "tmdb",
 		ContentType: "movies",
 		ContentID:   "550",
 		ImageType:   metadata.ImagePoster,
-	})
+	}
+	first, err := c.Cache(context.Background(), req)
+	if err != nil {
+		t.Fatalf("prime immutable variants: %v", err)
+	}
+	s3.setExisting(first.VariantPaths["original"], first.VariantPaths["w500"], first.VariantPaths["w300"])
+	s3.resetCalls()
+	result, err := c.Cache(context.Background(), req)
 	if err != nil {
 		t.Fatalf("Cache poster with existing variants: %v", err)
 	}
@@ -236,10 +343,32 @@ func TestCacheSkipsUploadingVariantsThatAlreadyExist(t *testing.T) {
 	if result.UploadedVariants != 0 || result.ExistingVariants != 3 {
 		t.Fatalf("upload stats = uploaded %d existing %d, want uploaded 0 existing 3", result.UploadedVariants, result.ExistingVariants)
 	}
-	for _, key := range []string{wantBase + "/original.webp", wantBase + "/w500.webp", wantBase + "/w300.webp"} {
+	for _, key := range []string{result.VariantPaths["original"], result.VariantPaths["w500"], result.VariantPaths["w300"]} {
 		if !hasKey(s3.checkedKeys(), key) {
 			t.Fatalf("ObjectExists was not checked for %q; checked %v", key, s3.checkedKeys())
 		}
+	}
+}
+
+func TestCacheDifferentContentCreatesDifferentImmutableRevision(t *testing.T) {
+	jpeg := makeTestJPEG(t)
+	png := makeTestPNG(t, 400, 600)
+	s3 := &mockS3{bucket: "media"}
+	c := newWithHTTPClient(s3, http.DefaultClient)
+	req := CacheRequest{ProviderID: testTMDBProviderID, ContentType: testMoviesContentType, ContentID: "550", ImageType: metadata.ImagePoster}
+	first, err := c.CacheBytes(context.Background(), jpeg, req)
+	if err != nil {
+		t.Fatalf("cache first poster: %v", err)
+	}
+	second, err := c.CacheBytes(context.Background(), png, req)
+	if err != nil {
+		t.Fatalf("cache replacement poster: %v", err)
+	}
+	if first.Revision == second.Revision || first.OriginalPath == second.OriginalPath {
+		t.Fatalf("different content reused revision: first=%q second=%q", first.OriginalPath, second.OriginalPath)
+	}
+	if got := s3.keys(); len(got) != 6 {
+		t.Fatalf("uploaded keys = %v, want both immutable three-variant revisions", got)
 	}
 }
 
@@ -247,27 +376,27 @@ func TestCacheUploadsOnlyMissingVariants(t *testing.T) {
 	jpeg := makeTestJPEG(t)
 	srv := startImageServer(t, jpeg, http.StatusOK)
 
-	wantBase := "tmdb/movies/550/poster"
-	s3 := &mockS3{
-		bucket: "media",
-		existing: map[string]bool{
-			wantBase + "/original.webp": true,
-			wantBase + "/w500.webp":     true,
-		},
-	}
+	s3 := &mockS3{bucket: "media"}
 	c := newWithHTTPClient(s3, srv.Client())
 
-	result, err := c.Cache(context.Background(), CacheRequest{
+	req := CacheRequest{
 		SourceURL:   srv.URL + "/poster.jpg",
 		ProviderID:  "tmdb",
 		ContentType: "movies",
 		ContentID:   "550",
 		ImageType:   metadata.ImagePoster,
-	})
+	}
+	first, err := c.Cache(context.Background(), req)
+	if err != nil {
+		t.Fatalf("prime immutable variants: %v", err)
+	}
+	s3.setExisting(first.VariantPaths["original"], first.VariantPaths["w500"])
+	s3.resetCalls()
+	result, err := c.Cache(context.Background(), req)
 	if err != nil {
 		t.Fatalf("Cache poster with partial existing variants: %v", err)
 	}
-	if got := s3.keys(); len(got) != 1 || got[0] != wantBase+"/w300.webp" {
+	if got := s3.keys(); len(got) != 1 || got[0] != result.VariantPaths["w300"] {
 		t.Fatalf("uploaded keys = %v, want only missing w300 variant", got)
 	}
 	if result.UploadedVariants != 1 || result.ExistingVariants != 2 {
@@ -304,13 +433,13 @@ func TestCache_Backdrop(t *testing.T) {
 		t.Errorf("expected 4 uploaded variants, got %d: %v", len(keys), keys)
 	}
 	for _, variant := range []string{"original", "w1920", "w1280", "w300"} {
-		want := wantBase + "/" + variant + ".webp"
+		want := result.VariantPaths[variant]
 		if !hasKey(keys, want) {
 			t.Errorf("missing S3 key %q in %v", want, keys)
 		}
 	}
 	// Must not have w500
-	if hasKey(keys, wantBase+"/w500.webp") {
+	if _, ok := result.VariantPaths["w500"]; ok {
 		t.Error("backdrop should not have w500 variant")
 	}
 }
@@ -344,13 +473,13 @@ func TestCache_Logo(t *testing.T) {
 		t.Errorf("expected 2 uploaded variants, got %d: %v", len(keys), keys)
 	}
 	for _, variant := range []string{"original", "w500"} {
-		want := wantBase + "/" + variant + ".webp"
+		want := result.VariantPaths[variant]
 		if !hasKey(keys, want) {
 			t.Errorf("missing S3 key %q in %v", want, keys)
 		}
 	}
 	for _, forbidden := range []string{"w300", "w1280"} {
-		if hasKey(keys, wantBase+"/"+forbidden+".webp") {
+		if _, ok := result.VariantPaths[forbidden]; ok {
 			t.Errorf("logo should not have %s variant", forbidden)
 		}
 	}
@@ -380,9 +509,8 @@ func TestCache_ConvertsSVGLogo(t *testing.T) {
 	if result.Thumbhash == "" {
 		t.Fatal("Thumbhash is empty")
 	}
-	wantBase := "tmdb/series/1396/logo"
 	for _, variant := range []string{"original", "w500"} {
-		want := wantBase + "/" + variant + ".webp"
+		want := result.VariantPaths[variant]
 		if !hasKey(s3.keys(), want) {
 			t.Errorf("missing S3 key %q in %v", want, s3.keys())
 		}
@@ -400,7 +528,7 @@ func TestCache_CapsLargeOriginalVariant(t *testing.T) {
 	s3 := &mockS3{bucket: "media"}
 	c := newWithHTTPClient(s3, srv.Client())
 
-	_, err := c.Cache(context.Background(), CacheRequest{
+	result, err := c.Cache(context.Background(), CacheRequest{
 		SourceURL:   srv.URL + "/logo.png",
 		ProviderID:  "tmdb",
 		ContentType: "series",
@@ -410,7 +538,7 @@ func TestCache_CapsLargeOriginalVariant(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Cache large logo: %v", err)
 	}
-	original := s3.objectData("tmdb/series/1396/logo/original.webp")
+	original := s3.objectData(result.OriginalPath)
 	if len(original) == 0 {
 		t.Fatal("missing original.webp upload")
 	}
@@ -449,7 +577,7 @@ func TestCache_LocalizedPosterUsesLanguageScopedPath(t *testing.T) {
 	if result.BasePath != wantBase {
 		t.Errorf("BasePath = %q, want %q", result.BasePath, wantBase)
 	}
-	if !hasKey(s3.keys(), wantBase+"/original.webp") {
+	if !hasKey(s3.keys(), result.OriginalPath) {
 		t.Errorf("missing localized original in %v", s3.keys())
 	}
 }
@@ -477,7 +605,7 @@ func TestCache_ProfileUsesProfileImagePath(t *testing.T) {
 		t.Errorf("BasePath = %q, want %q", result.BasePath, wantBase)
 	}
 	for _, variant := range []string{"original", "w500", "w300"} {
-		want := wantBase + "/" + variant + ".webp"
+		want := result.VariantPaths[variant]
 		if !hasKey(s3.keys(), want) {
 			t.Errorf("missing S3 key %q in %v", want, s3.keys())
 		}
@@ -571,7 +699,7 @@ func TestCache_SeasonPoster_NestsUnderSeries(t *testing.T) {
 		t.Errorf("BasePath = %q, want %q", result.BasePath, wantBase)
 	}
 	for _, variant := range []string{"original", "w500", "w300"} {
-		want := wantBase + "/" + variant + ".webp"
+		want := result.VariantPaths[variant]
 		if !hasKey(s3.keys(), want) {
 			t.Errorf("missing S3 key %q in %v", want, s3.keys())
 		}
@@ -604,7 +732,7 @@ func TestCache_EpisodeStill_NestsUnderSeasonAndEpisode(t *testing.T) {
 		t.Errorf("BasePath = %q, want %q", result.BasePath, wantBase)
 	}
 	for _, variant := range []string{"original", "w500", "w300"} {
-		want := wantBase + "/" + variant + ".webp"
+		want := result.VariantPaths[variant]
 		if !hasKey(s3.keys(), want) {
 			t.Errorf("missing S3 key %q in %v", want, s3.keys())
 		}
@@ -618,9 +746,10 @@ func TestCache_SeasonsDoNotCollide(t *testing.T) {
 	s3 := &mockS3{bucket: "media"}
 	c := newWithHTTPClient(s3, srv.Client())
 
+	originalPaths := make(map[int]string)
 	for _, season := range []int{1, 2, 3} {
 		s := season
-		_, err := c.Cache(context.Background(), CacheRequest{
+		result, err := c.Cache(context.Background(), CacheRequest{
 			SourceURL:    srv.URL + "/season.jpg",
 			ProviderID:   "tmdb",
 			ContentType:  "series",
@@ -631,11 +760,12 @@ func TestCache_SeasonsDoNotCollide(t *testing.T) {
 		if err != nil {
 			t.Fatalf("Cache season %d: %v", season, err)
 		}
+		originalPaths[season] = result.OriginalPath
 	}
 
 	keys := s3.keys()
 	for _, season := range []int{1, 2, 3} {
-		want := fmt.Sprintf("tmdb/series/1396/seasons/%d/poster/original.webp", season)
+		want := originalPaths[season]
 		if !hasKey(keys, want) {
 			t.Errorf("missing S3 key %q in %v", want, keys)
 		}

--- a/internal/imagecache/imagecache_test.go
+++ b/internal/imagecache/imagecache_test.go
@@ -124,7 +124,9 @@ func (m *mockS3) PutObject(_ context.Context, bucket, key string, data []byte) e
 
 func (m *mockS3) Bucket() string { return m.bucket }
 
-func (m *mockS3) ObjectExists(_ context.Context, _ string, key string) (bool, error) {
+// ObjectMatches treats keys registered via setExisting as content matches;
+// real content verification is exercised against the s3client implementation.
+func (m *mockS3) ObjectMatches(_ context.Context, _ string, key string, _ []byte) (bool, error) {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 	m.existsCalls = append(m.existsCalls, key)

--- a/internal/imagecache/imagecache_test.go
+++ b/internal/imagecache/imagecache_test.go
@@ -78,6 +78,7 @@ type putCall struct {
 
 type trackedRevision struct {
 	originalPath string
+	imageType    string
 	objectKeys   []string
 }
 
@@ -87,11 +88,12 @@ type recordingRevisionTracker struct {
 	err   error
 }
 
-func (t *recordingRevisionTracker) TrackArtworkRevision(_ context.Context, originalPath string, objectKeys []string) error {
+func (t *recordingRevisionTracker) TrackArtworkRevision(_ context.Context, originalPath, imageType string, objectKeys []string) error {
 	t.mu.Lock()
 	defer t.mu.Unlock()
 	t.calls = append(t.calls, trackedRevision{
 		originalPath: originalPath,
+		imageType:    imageType,
 		objectKeys:   append([]string(nil), objectKeys...),
 	})
 	return t.err
@@ -190,6 +192,9 @@ func TestCacheBytesTracksExactRevisionBeforeUpload(t *testing.T) {
 	}
 	if calls[0].originalPath != result.OriginalPath {
 		t.Fatalf("tracked original = %q, want %q", calls[0].originalPath, result.OriginalPath)
+	}
+	if calls[0].imageType != "poster" {
+		t.Fatalf("tracked image type = %q, want poster", calls[0].imageType)
 	}
 	wantKeys := make([]string, 0, len(result.VariantPaths))
 	for _, key := range result.VariantPaths {

--- a/internal/manga/enrichment.go
+++ b/internal/manga/enrichment.go
@@ -625,7 +625,7 @@ func (e *Enricher) cacheRemoteImage(ctx context.Context, contentID, url string, 
 		return url, ""
 	}
 
-	storedPath := cachedOriginalImagePath(cached.BasePath, cached.Ext)
+	storedPath := metadata.CachedImageOriginalPath(cached)
 	if storedPath == "" {
 		return url, ""
 	}
@@ -643,19 +643,6 @@ func isNilImageCacher(cacher metadata.ImageCacher) bool {
 	default:
 		return false
 	}
-}
-
-func cachedOriginalImagePath(basePath, ext string) string {
-	if basePath == "" {
-		return ""
-	}
-	if strings.Contains(basePath, "/original.") {
-		return basePath
-	}
-	if ext == "" {
-		ext = ".jpg"
-	}
-	return strings.TrimRight(basePath, "/") + "/original" + ext
 }
 
 func (e *Enricher) persist(ctx context.Context, contentID string, providerIDs map[string]string, result *metadata.MetadataResult) error {

--- a/internal/metadata/apply_item_image_test.go
+++ b/internal/metadata/apply_item_image_test.go
@@ -1,0 +1,49 @@
+package metadata
+
+import (
+	"context"
+	"testing"
+)
+
+const (
+	applyImageTestExt         = ".webp"
+	applyImageTestProviderID  = "tmdb"
+	applyImageTestContentType = "movie"
+)
+
+type recordingImageCacher struct {
+	request CacheImageRequest
+}
+
+func (c *recordingImageCacher) CacheImage(_ context.Context, req CacheImageRequest) (*CacheImageResult, error) {
+	c.request = req
+	return &CacheImageResult{
+		BasePath:     "tmdb/movies/335984/poster",
+		OriginalPath: "tmdb/movies/335984/poster/original.new-revision.webp",
+		Revision:     "new-revision",
+		Thumbhash:    "new-thumbhash",
+		Ext:          applyImageTestExt,
+	}, nil
+}
+
+func TestApplyItemImageReturnsExactImmutableRevision(t *testing.T) {
+	cacher := &recordingImageCacher{}
+	service := &MetadataService{imageCacher: cacher}
+
+	result, err := service.ApplyItemImage(context.Background(), ApplyItemImageRequest{
+		OriginalURL: "https://image.tmdb.org/t/p/original/new-poster.jpg",
+		ProviderID:  applyImageTestProviderID,
+		ContentType: applyImageTestContentType,
+		ContentID:   "335984",
+		ImageType:   ImagePoster,
+	})
+	if err != nil {
+		t.Fatalf("ApplyItemImage: %v", err)
+	}
+	if result.StoredPath != "tmdb/movies/335984/poster/original.new-revision.webp" {
+		t.Fatalf("StoredPath = %q, want exact immutable revision path", result.StoredPath)
+	}
+	if result.Revision != "new-revision" {
+		t.Fatalf("Revision = %q, want new-revision", result.Revision)
+	}
+}

--- a/internal/metadata/artwork_revision_gc.go
+++ b/internal/metadata/artwork_revision_gc.go
@@ -1,0 +1,240 @@
+package metadata
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgxpool"
+)
+
+const (
+	artworkRevisionGCBatchSize = 100
+	artworkRevisionGCLease     = 15 * time.Minute
+)
+
+// ArtworkRevisionDeleter is the object-storage surface used by revision GC.
+type ArtworkRevisionDeleter interface {
+	DeleteObjects(ctx context.Context, bucket string, keys []string) (int, error)
+	Bucket() string
+}
+
+// ArtworkRevisionGCStats summarizes one bounded cleanup pass.
+type ArtworkRevisionGCStats struct {
+	Claimed    int `json:"claimed"`
+	Deleted    int `json:"deleted"`
+	Referenced int `json:"referenced"`
+	Retried    int `json:"retried"`
+}
+
+// ArtworkRevisionGarbageCollector deletes unpublished or displaced immutable
+// revisions only after their grace period and while no catalog surface
+// references them. Work is leased with SKIP LOCKED so multiple workers are safe.
+type ArtworkRevisionGarbageCollector struct {
+	pool *pgxpool.Pool
+	s3   ArtworkRevisionDeleter
+}
+
+func NewArtworkRevisionGarbageCollector(pool *pgxpool.Pool, s3 ArtworkRevisionDeleter) *ArtworkRevisionGarbageCollector {
+	if pool == nil || s3 == nil {
+		return nil
+	}
+	return &ArtworkRevisionGarbageCollector{pool: pool, s3: s3}
+}
+
+// Run processes one bounded batch. Failed deletions are retried with
+// exponential backoff; an expired lease is recoverable by another worker.
+func (g *ArtworkRevisionGarbageCollector) Run(ctx context.Context) (ArtworkRevisionGCStats, error) {
+	stats := ArtworkRevisionGCStats{}
+	if g == nil || g.pool == nil || g.s3 == nil {
+		return stats, fmt.Errorf("artwork revision GC is not configured")
+	}
+
+	workerID := uuid.NewString()
+	candidates, err := g.claim(ctx, workerID, artworkRevisionGCBatchSize)
+	if err != nil {
+		return stats, err
+	}
+	stats.Claimed = len(candidates)
+
+	for _, candidate := range candidates {
+		outcome, err := g.processCandidate(ctx, candidate, workerID)
+		if err != nil {
+			stats.Retried++
+			if retryErr := g.retry(ctx, candidate, workerID, err); retryErr != nil {
+				return stats, retryErr
+			}
+			continue
+		}
+		switch outcome {
+		case artworkRevisionGCReferenced:
+			stats.Referenced++
+		case artworkRevisionGCDeleted:
+			stats.Deleted++
+		}
+	}
+	return stats, nil
+}
+
+type artworkRevisionGCOutcome int
+
+const (
+	artworkRevisionGCSuperseded artworkRevisionGCOutcome = iota
+	artworkRevisionGCReferenced
+	artworkRevisionGCDeleted
+)
+
+type artworkRevisionGCCandidate struct {
+	id           int64
+	originalPath string
+	objectKeys   []string
+	attemptCount int
+}
+
+func (g *ArtworkRevisionGarbageCollector) claim(ctx context.Context, workerID string, limit int) ([]artworkRevisionGCCandidate, error) {
+	rows, err := g.pool.Query(ctx, `
+		WITH due AS (
+			SELECT id
+			FROM artwork_revision_gc_candidates
+			WHERE not_before <= NOW()
+			  AND next_attempt_at <= NOW()
+			  AND (locked_at IS NULL OR locked_at < NOW() - ($3 * interval '1 second'))
+			ORDER BY next_attempt_at, id
+			FOR UPDATE SKIP LOCKED
+			LIMIT $1
+		)
+		UPDATE artwork_revision_gc_candidates AS candidate
+		SET locked_at = NOW(), locked_by = $2, updated_at = NOW()
+		FROM due
+		WHERE candidate.id = due.id
+		RETURNING candidate.id, candidate.original_path, candidate.object_keys, candidate.attempt_count`,
+		limit, workerID, int64(artworkRevisionGCLease/time.Second))
+	if err != nil {
+		return nil, fmt.Errorf("artwork revision GC: claim: %w", err)
+	}
+	defer rows.Close()
+
+	var candidates []artworkRevisionGCCandidate
+	for rows.Next() {
+		var candidate artworkRevisionGCCandidate
+		if err := rows.Scan(&candidate.id, &candidate.originalPath, &candidate.objectKeys, &candidate.attemptCount); err != nil {
+			return nil, fmt.Errorf("artwork revision GC: scan claim: %w", err)
+		}
+		candidates = append(candidates, candidate)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("artwork revision GC: claims: %w", err)
+	}
+	return candidates, nil
+}
+
+// processCandidate holds the registry row lock across the last reference check
+// and object deletion. A concurrent cache attempt registers the revision before
+// uploading and therefore waits here; once deletion commits, that attempt can
+// safely recreate the complete object set before publication.
+func (g *ArtworkRevisionGarbageCollector) processCandidate(
+	ctx context.Context,
+	candidate artworkRevisionGCCandidate,
+	workerID string,
+) (artworkRevisionGCOutcome, error) {
+	tx, err := g.pool.Begin(ctx)
+	if err != nil {
+		return artworkRevisionGCSuperseded, fmt.Errorf("artwork revision GC: begin deletion: %w", err)
+	}
+	defer func() { _ = tx.Rollback(ctx) }()
+
+	var originalPath string
+	var objectKeys []string
+	err = tx.QueryRow(ctx, `
+		SELECT original_path, object_keys
+		FROM artwork_revision_gc_candidates
+		WHERE id = $1 AND locked_by = $2
+		FOR UPDATE`, candidate.id, workerID).Scan(&originalPath, &objectKeys)
+	if errors.Is(err, pgx.ErrNoRows) {
+		return artworkRevisionGCSuperseded, nil
+	}
+	if err != nil {
+		return artworkRevisionGCSuperseded, fmt.Errorf("artwork revision GC: lock candidate: %w", err)
+	}
+
+	referenced, err := g.isReferenced(ctx, tx, originalPath)
+	if err != nil {
+		return artworkRevisionGCSuperseded, err
+	}
+	if referenced {
+		if _, err := tx.Exec(ctx, `
+			UPDATE artwork_revision_gc_candidates
+			SET next_attempt_at = NULL,
+				attempt_count = 0,
+				locked_at = NULL,
+				locked_by = '',
+				last_error = '',
+				updated_at = NOW()
+			WHERE id = $1 AND locked_by = $2`, candidate.id, workerID); err != nil {
+			return artworkRevisionGCSuperseded, fmt.Errorf("artwork revision GC: park referenced revision: %w", err)
+		}
+		if err := tx.Commit(ctx); err != nil {
+			return artworkRevisionGCSuperseded, fmt.Errorf("artwork revision GC: commit referenced revision: %w", err)
+		}
+		return artworkRevisionGCReferenced, nil
+	}
+
+	deleted, err := g.s3.DeleteObjects(ctx, g.s3.Bucket(), objectKeys)
+	if err == nil && deleted != len(objectKeys) {
+		err = fmt.Errorf("deleted %d of %d artwork objects", deleted, len(objectKeys))
+	}
+	if err != nil {
+		return artworkRevisionGCSuperseded, err
+	}
+	if _, err := tx.Exec(ctx, `DELETE FROM artwork_revision_gc_candidates WHERE id = $1 AND locked_by = $2`, candidate.id, workerID); err != nil {
+		return artworkRevisionGCSuperseded, fmt.Errorf("artwork revision GC: finish: %w", err)
+	}
+	if err := tx.Commit(ctx); err != nil {
+		return artworkRevisionGCSuperseded, fmt.Errorf("artwork revision GC: commit deletion: %w", err)
+	}
+	return artworkRevisionGCDeleted, nil
+}
+
+type artworkReferenceQuerier interface {
+	QueryRow(ctx context.Context, sql string, args ...any) pgx.Row
+}
+
+func (g *ArtworkRevisionGarbageCollector) isReferenced(ctx context.Context, q artworkReferenceQuerier, originalPath string) (bool, error) {
+	parts := make([]string, 0, len(artworkSweepSurfaces()))
+	for _, surface := range artworkSweepSurfaces() {
+		parts = append(parts, fmt.Sprintf("SELECT 1 FROM %s WHERE %s = $1", surface.table, surface.pathCol))
+	}
+	query := "SELECT EXISTS(" + strings.Join(parts, " UNION ALL ") + ")"
+	var referenced bool
+	if err := q.QueryRow(ctx, query, originalPath).Scan(&referenced); err != nil {
+		return false, fmt.Errorf("artwork revision GC: check references: %w", err)
+	}
+	return referenced, nil
+}
+
+func (g *ArtworkRevisionGarbageCollector) retry(ctx context.Context, candidate artworkRevisionGCCandidate, workerID string, cause error) error {
+	delay := time.Minute << min(candidate.attemptCount, 10)
+	_, err := g.pool.Exec(ctx, `
+		UPDATE artwork_revision_gc_candidates
+		SET attempt_count = attempt_count + 1,
+			next_attempt_at = NOW() + ($3 * interval '1 second'),
+			locked_at = NULL,
+			locked_by = '',
+			last_error = $4,
+			updated_at = NOW()
+		WHERE id = $1 AND locked_by = $2`, candidate.id, workerID, int64(delay/time.Second), cause.Error())
+	if err != nil {
+		return fmt.Errorf("artwork revision GC: schedule retry: %w", err)
+	}
+	return nil
+}
+
+func (s ArtworkRevisionGCStats) JSON() []byte {
+	data, _ := json.Marshal(s)
+	return data
+}

--- a/internal/metadata/artwork_revision_gc.go
+++ b/internal/metadata/artwork_revision_gc.go
@@ -5,17 +5,25 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"log/slog"
 	"strings"
 	"time"
 
 	"github.com/google/uuid"
 	"github.com/jackc/pgx/v5"
 	"github.com/jackc/pgx/v5/pgxpool"
+
+	"github.com/Silo-Server/silo-server/internal/artworkkey"
 )
 
 const (
 	artworkRevisionGCBatchSize = 100
 	artworkRevisionGCLease     = 15 * time.Minute
+	// artworkRevisionDormantRecheck bounds how stale a parked (referenced)
+	// revision may get before the sweep re-verifies it. Displacement triggers
+	// are the fast path; the sweep guarantees a reference that disappears
+	// through an untriggered surface still becomes collectible eventually.
+	artworkRevisionDormantRecheck = 24 * time.Hour
 )
 
 // ArtworkRevisionDeleter is the object-storage surface used by revision GC.
@@ -26,10 +34,13 @@ type ArtworkRevisionDeleter interface {
 
 // ArtworkRevisionGCStats summarizes one bounded cleanup pass.
 type ArtworkRevisionGCStats struct {
-	Claimed    int `json:"claimed"`
-	Deleted    int `json:"deleted"`
-	Referenced int `json:"referenced"`
-	Retried    int `json:"retried"`
+	Claimed         int `json:"claimed"`
+	Deleted         int `json:"deleted"`
+	Referenced      int `json:"referenced"`
+	Retried         int `json:"retried"`
+	DormantChecked  int `json:"dormant_checked"`
+	DormantRequeued int `json:"dormant_requeued"`
+	Healed          int `json:"healed"`
 }
 
 // ArtworkRevisionGarbageCollector deletes unpublished or displaced immutable
@@ -60,8 +71,38 @@ func (g *ArtworkRevisionGarbageCollector) Run(ctx context.Context) (ArtworkRevis
 	if err != nil {
 		return stats, err
 	}
-	return processArtworkRevisionGCBatch(
-		candidates,
+
+	// Park referenced candidates with one batched reference check instead of a
+	// per-candidate transaction; most publish/re-cache churn lands here. The
+	// per-candidate path below re-verifies under the row lock before deleting,
+	// so a stale answer from this pre-check can only cost extra work, never a
+	// wrong deletion.
+	due := candidates
+	if len(candidates) > 0 {
+		if referenced, refErr := g.referencedPaths(ctx, candidatePaths(candidates)); refErr == nil {
+			var parked []int64
+			due = due[:0]
+			for _, candidate := range candidates {
+				if _, ok := referenced[candidate.originalPath]; ok {
+					parked = append(parked, candidate.id)
+					continue
+				}
+				due = append(due, candidate)
+			}
+			if len(parked) > 0 {
+				if parkErr := g.parkClaimed(ctx, parked, workerID); parkErr != nil {
+					return stats, parkErr
+				}
+				stats.Referenced += len(parked)
+			}
+		} else {
+			slog.WarnContext(ctx, "artwork revision GC: batched reference pre-check failed; falling back to per-candidate checks",
+				"component", "metadata", "error", refErr)
+		}
+	}
+
+	batchStats, err := processArtworkRevisionGCBatch(
+		due,
 		func(candidate artworkRevisionGCCandidate) (artworkRevisionGCOutcome, error) {
 			return g.processCandidate(ctx, candidate, workerID)
 		},
@@ -69,6 +110,19 @@ func (g *ArtworkRevisionGarbageCollector) Run(ctx context.Context) (ArtworkRevis
 			return g.retry(ctx, candidate, workerID, cause)
 		},
 	)
+	stats.Claimed = len(candidates)
+	stats.Deleted = batchStats.Deleted
+	stats.Referenced += batchStats.Referenced
+	stats.Retried = batchStats.Retried
+	stats.Healed = batchStats.Healed
+
+	checked, requeued, sweepErr := g.sweepDormant(ctx, artworkRevisionGCBatchSize)
+	stats.DormantChecked = checked
+	stats.DormantRequeued = requeued
+	if err == nil {
+		err = sweepErr
+	}
+	return stats, err
 }
 
 func processArtworkRevisionGCBatch(
@@ -92,6 +146,9 @@ func processArtworkRevisionGCBatch(
 			stats.Referenced++
 		case artworkRevisionGCDeleted:
 			stats.Deleted++
+		case artworkRevisionGCDeletedAndHealed:
+			stats.Deleted++
+			stats.Healed++
 		}
 	}
 	return stats, firstErr
@@ -103,13 +160,23 @@ const (
 	artworkRevisionGCSuperseded artworkRevisionGCOutcome = iota
 	artworkRevisionGCReferenced
 	artworkRevisionGCDeleted
+	artworkRevisionGCDeletedAndHealed
 )
 
 type artworkRevisionGCCandidate struct {
 	id           int64
 	originalPath string
+	imageType    string
 	objectKeys   []string
 	attemptCount int
+}
+
+func candidatePaths(candidates []artworkRevisionGCCandidate) []string {
+	paths := make([]string, 0, len(candidates))
+	for _, candidate := range candidates {
+		paths = append(paths, candidate.originalPath)
+	}
+	return paths
 }
 
 func (g *ArtworkRevisionGarbageCollector) claim(ctx context.Context, workerID string, limit int) ([]artworkRevisionGCCandidate, error) {
@@ -128,7 +195,7 @@ func (g *ArtworkRevisionGarbageCollector) claim(ctx context.Context, workerID st
 		SET locked_at = NOW(), locked_by = $2, updated_at = NOW()
 		FROM due
 		WHERE candidate.id = due.id
-		RETURNING candidate.id, candidate.original_path, candidate.object_keys, candidate.attempt_count`,
+		RETURNING candidate.id, candidate.original_path, candidate.image_type, candidate.object_keys, candidate.attempt_count`,
 		limit, workerID, int64(artworkRevisionGCLease/time.Second))
 	if err != nil {
 		return nil, fmt.Errorf("artwork revision GC: claim: %w", err)
@@ -138,7 +205,7 @@ func (g *ArtworkRevisionGarbageCollector) claim(ctx context.Context, workerID st
 	var candidates []artworkRevisionGCCandidate
 	for rows.Next() {
 		var candidate artworkRevisionGCCandidate
-		if err := rows.Scan(&candidate.id, &candidate.originalPath, &candidate.objectKeys, &candidate.attemptCount); err != nil {
+		if err := rows.Scan(&candidate.id, &candidate.originalPath, &candidate.imageType, &candidate.objectKeys, &candidate.attemptCount); err != nil {
 			return nil, fmt.Errorf("artwork revision GC: scan claim: %w", err)
 		}
 		candidates = append(candidates, candidate)
@@ -147,6 +214,24 @@ func (g *ArtworkRevisionGarbageCollector) claim(ctx context.Context, workerID st
 		return nil, fmt.Errorf("artwork revision GC: claims: %w", err)
 	}
 	return candidates, nil
+}
+
+// parkClaimed releases claimed candidates back to the dormant state in one
+// statement. Used when the batched pre-check already proved them referenced.
+func (g *ArtworkRevisionGarbageCollector) parkClaimed(ctx context.Context, ids []int64, workerID string) error {
+	_, err := g.pool.Exec(ctx, `
+		UPDATE artwork_revision_gc_candidates
+		SET next_attempt_at = NULL,
+			attempt_count = 0,
+			locked_at = NULL,
+			locked_by = '',
+			last_error = '',
+			updated_at = NOW()
+		WHERE id = ANY($1) AND locked_by = $2`, ids, workerID)
+	if err != nil {
+		return fmt.Errorf("artwork revision GC: park referenced revisions: %w", err)
+	}
+	return nil
 }
 
 // processCandidate holds the registry row lock across the last reference check
@@ -164,13 +249,13 @@ func (g *ArtworkRevisionGarbageCollector) processCandidate(
 	}
 	defer func() { _ = tx.Rollback(ctx) }()
 
-	var originalPath string
+	var originalPath, imageType string
 	var objectKeys []string
 	err = tx.QueryRow(ctx, `
-		SELECT original_path, object_keys
+		SELECT original_path, image_type, object_keys
 		FROM artwork_revision_gc_candidates
 		WHERE id = $1 AND locked_by = $2
-		FOR UPDATE`, candidate.id, workerID).Scan(&originalPath, &objectKeys)
+		FOR UPDATE`, candidate.id, workerID).Scan(&originalPath, &imageType, &objectKeys)
 	if errors.Is(err, pgx.ErrNoRows) {
 		return artworkRevisionGCSuperseded, nil
 	}
@@ -200,18 +285,43 @@ func (g *ArtworkRevisionGarbageCollector) processCandidate(
 		return artworkRevisionGCReferenced, nil
 	}
 
-	deleted, err := g.s3.DeleteObjects(ctx, g.s3.Bucket(), objectKeys)
-	if err == nil && deleted != len(objectKeys) {
-		err = fmt.Errorf("deleted %d of %d artwork objects", deleted, len(objectKeys))
+	// Rows queued by the displacement triggers carry no manifest; expand the
+	// expected object set from the image type so the variant ladder stays
+	// defined once, in artworkkey.
+	if len(objectKeys) == 0 {
+		objectKeys = artworkkey.ObjectKeys(originalPath, imageType)
 	}
-	if err != nil {
-		return artworkRevisionGCSuperseded, err
+	if len(objectKeys) > 0 {
+		deleted, err := g.s3.DeleteObjects(ctx, g.s3.Bucket(), objectKeys)
+		if err == nil && deleted != len(objectKeys) {
+			err = fmt.Errorf("deleted %d of %d artwork objects", deleted, len(objectKeys))
+		}
+		if err != nil {
+			return artworkRevisionGCSuperseded, err
+		}
 	}
 	if _, err := tx.Exec(ctx, `DELETE FROM artwork_revision_gc_candidates WHERE id = $1 AND locked_by = $2`, candidate.id, workerID); err != nil {
 		return artworkRevisionGCSuperseded, fmt.Errorf("artwork revision GC: finish: %w", err)
 	}
 	if err := tx.Commit(ctx); err != nil {
 		return artworkRevisionGCSuperseded, fmt.Errorf("artwork revision GC: commit deletion: %w", err)
+	}
+
+	// Writers that assign an existing path without registering a revision
+	// (bulk upserts copying previously-read values) do not serialize with the
+	// row lock above. Detect that narrow race after the fact and reset the
+	// affected rows the same way the artwork reconciler handles missing
+	// objects, so pipelines re-cache instead of serving 404 artwork.
+	healed, healErr := g.healDeletedReferences(ctx, originalPath)
+	if healErr != nil {
+		slog.ErrorContext(ctx, "artwork revision GC: post-delete reference check failed",
+			"component", "metadata", "original_path", originalPath, "error", healErr)
+		return artworkRevisionGCDeleted, nil
+	}
+	if healed {
+		slog.WarnContext(ctx, "artwork revision GC: deleted revision was re-referenced concurrently; reset rows for re-cache",
+			"component", "metadata", "original_path", originalPath)
+		return artworkRevisionGCDeletedAndHealed, nil
 	}
 	return artworkRevisionGCDeleted, nil
 }
@@ -220,17 +330,144 @@ type artworkReferenceQuerier interface {
 	QueryRow(ctx context.Context, sql string, args ...any) pgx.Row
 }
 
-func (g *ArtworkRevisionGarbageCollector) isReferenced(ctx context.Context, q artworkReferenceQuerier, originalPath string) (bool, error) {
-	parts := make([]string, 0, len(artworkSweepSurfaces()))
-	for _, surface := range artworkSweepSurfaces() {
-		parts = append(parts, fmt.Sprintf("SELECT 1 FROM %s WHERE %s = $1", surface.table, surface.pathCol))
+func artworkReferenceUnionSQL() string {
+	surfaces := artworkSweepSurfaces()
+	parts := make([]string, 0, len(surfaces))
+	for _, surface := range surfaces {
+		parts = append(parts, fmt.Sprintf("SELECT %s AS path FROM %s WHERE %s = ANY($1)", surface.pathCol, surface.table, surface.pathCol))
 	}
-	query := "SELECT EXISTS(" + strings.Join(parts, " UNION ALL ") + ")"
+	return strings.Join(parts, " UNION ALL ")
+}
+
+func (g *ArtworkRevisionGarbageCollector) isReferenced(ctx context.Context, q artworkReferenceQuerier, originalPath string) (bool, error) {
 	var referenced bool
-	if err := q.QueryRow(ctx, query, originalPath).Scan(&referenced); err != nil {
+	query := "SELECT EXISTS(" + artworkReferenceUnionSQL() + ")"
+	if err := q.QueryRow(ctx, query, []string{originalPath}).Scan(&referenced); err != nil {
 		return false, fmt.Errorf("artwork revision GC: check references: %w", err)
 	}
 	return referenced, nil
+}
+
+// referencedPaths returns the subset of paths referenced by any catalog
+// surface, using one query per run instead of one per candidate.
+func (g *ArtworkRevisionGarbageCollector) referencedPaths(ctx context.Context, paths []string) (map[string]struct{}, error) {
+	referenced := make(map[string]struct{})
+	if len(paths) == 0 {
+		return referenced, nil
+	}
+	rows, err := g.pool.Query(ctx, "SELECT DISTINCT path FROM ("+artworkReferenceUnionSQL()+") refs", paths)
+	if err != nil {
+		return nil, fmt.Errorf("artwork revision GC: batch reference check: %w", err)
+	}
+	defer rows.Close()
+	for rows.Next() {
+		var path string
+		if err := rows.Scan(&path); err != nil {
+			return nil, fmt.Errorf("artwork revision GC: scan reference: %w", err)
+		}
+		referenced[path] = struct{}{}
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("artwork revision GC: references: %w", err)
+	}
+	return referenced, nil
+}
+
+// sweepDormant re-verifies a bounded batch of parked revisions whose last
+// check is older than the recheck interval, re-arming any that lost every
+// reference through a surface without a displacement trigger.
+func (g *ArtworkRevisionGarbageCollector) sweepDormant(ctx context.Context, limit int) (checked, requeued int, err error) {
+	rows, err := g.pool.Query(ctx, `
+		SELECT id, original_path
+		FROM artwork_revision_gc_candidates
+		WHERE next_attempt_at IS NULL
+		  AND updated_at < NOW() - ($2 * interval '1 second')
+		ORDER BY updated_at, id
+		LIMIT $1`, limit, int64(artworkRevisionDormantRecheck/time.Second))
+	if err != nil {
+		return 0, 0, fmt.Errorf("artwork revision GC: list dormant revisions: %w", err)
+	}
+	defer rows.Close()
+
+	ids := make(map[string][]int64)
+	var paths []string
+	for rows.Next() {
+		var id int64
+		var path string
+		if err := rows.Scan(&id, &path); err != nil {
+			return 0, 0, fmt.Errorf("artwork revision GC: scan dormant revision: %w", err)
+		}
+		if _, ok := ids[path]; !ok {
+			paths = append(paths, path)
+		}
+		ids[path] = append(ids[path], id)
+		checked++
+	}
+	if err := rows.Err(); err != nil {
+		return 0, 0, fmt.Errorf("artwork revision GC: dormant revisions: %w", err)
+	}
+	if checked == 0 {
+		return 0, 0, nil
+	}
+
+	referenced, err := g.referencedPaths(ctx, paths)
+	if err != nil {
+		return checked, 0, err
+	}
+	var touch, requeue []int64
+	for path, pathIDs := range ids {
+		if _, ok := referenced[path]; ok {
+			touch = append(touch, pathIDs...)
+			continue
+		}
+		requeue = append(requeue, pathIDs...)
+	}
+	if len(requeue) > 0 {
+		if _, err := g.pool.Exec(ctx, `
+			UPDATE artwork_revision_gc_candidates
+			SET next_attempt_at = GREATEST(not_before, NOW()),
+				updated_at = NOW()
+			WHERE id = ANY($1) AND next_attempt_at IS NULL`, requeue); err != nil {
+			return checked, 0, fmt.Errorf("artwork revision GC: requeue dormant revisions: %w", err)
+		}
+		requeued = len(requeue)
+	}
+	if len(touch) > 0 {
+		if _, err := g.pool.Exec(ctx, `
+			UPDATE artwork_revision_gc_candidates
+			SET updated_at = NOW()
+			WHERE id = ANY($1) AND next_attempt_at IS NULL`, touch); err != nil {
+			return checked, requeued, fmt.Errorf("artwork revision GC: touch dormant revisions: %w", err)
+		}
+	}
+	return checked, requeued, nil
+}
+
+// healDeletedReferences resets any row still pointing at a just-deleted
+// revision, mirroring the reconciler: rows with a re-downloadable source are
+// repointed at it (the image cache pipeline re-caches them); the rest are
+// cleared for their owning pipeline to refill.
+func (g *ArtworkRevisionGarbageCollector) healDeletedReferences(ctx context.Context, originalPath string) (bool, error) {
+	healed := false
+	for _, surface := range artworkSweepSurfaces() {
+		if surface.sourceCol != "" {
+			resetSQL := fmt.Sprintf(`UPDATE %s SET %s WHERE %s = $1 AND %s`,
+				surface.table, surface.resetSet(), surface.pathCol, surface.remoteSourcePredicate())
+			tag, err := g.pool.Exec(ctx, resetSQL, originalPath)
+			if err != nil {
+				return healed, fmt.Errorf("artwork revision GC: heal %s: %w", surface.name, err)
+			}
+			healed = healed || tag.RowsAffected() > 0
+		}
+		clearSQL := fmt.Sprintf(`UPDATE %s SET %s WHERE %s = $1 AND NOT (%s)`,
+			surface.table, surface.clearSet, surface.pathCol, surface.remoteSourcePredicate())
+		tag, err := g.pool.Exec(ctx, clearSQL, originalPath)
+		if err != nil {
+			return healed, fmt.Errorf("artwork revision GC: heal %s: %w", surface.name, err)
+		}
+		healed = healed || tag.RowsAffected() > 0
+	}
+	return healed, nil
 }
 
 func (g *ArtworkRevisionGarbageCollector) retry(ctx context.Context, candidate artworkRevisionGCCandidate, workerID string, cause error) error {

--- a/internal/metadata/artwork_revision_gc.go
+++ b/internal/metadata/artwork_revision_gc.go
@@ -83,7 +83,9 @@ func (g *ArtworkRevisionGarbageCollector) Run(ctx context.Context) (ArtworkRevis
 			var parked []int64
 			due = due[:0]
 			for _, candidate := range candidates {
-				if _, ok := referenced[candidate.originalPath]; ok {
+				// Rows whose objects were already deleted must finish their
+				// pending heal; a reference to them is broken, not live.
+				if _, ok := referenced[candidate.originalPath]; ok && candidate.deletedAt == nil {
 					parked = append(parked, candidate.id)
 					continue
 				}
@@ -169,6 +171,7 @@ type artworkRevisionGCCandidate struct {
 	imageType    string
 	objectKeys   []string
 	attemptCount int
+	deletedAt    *time.Time
 }
 
 func candidatePaths(candidates []artworkRevisionGCCandidate) []string {
@@ -195,7 +198,7 @@ func (g *ArtworkRevisionGarbageCollector) claim(ctx context.Context, workerID st
 		SET locked_at = NOW(), locked_by = $2, updated_at = NOW()
 		FROM due
 		WHERE candidate.id = due.id
-		RETURNING candidate.id, candidate.original_path, candidate.image_type, candidate.object_keys, candidate.attempt_count`,
+		RETURNING candidate.id, candidate.original_path, candidate.image_type, candidate.object_keys, candidate.attempt_count, candidate.deleted_at`,
 		limit, workerID, int64(artworkRevisionGCLease/time.Second))
 	if err != nil {
 		return nil, fmt.Errorf("artwork revision GC: claim: %w", err)
@@ -205,7 +208,7 @@ func (g *ArtworkRevisionGarbageCollector) claim(ctx context.Context, workerID st
 	var candidates []artworkRevisionGCCandidate
 	for rows.Next() {
 		var candidate artworkRevisionGCCandidate
-		if err := rows.Scan(&candidate.id, &candidate.originalPath, &candidate.imageType, &candidate.objectKeys, &candidate.attemptCount); err != nil {
+		if err := rows.Scan(&candidate.id, &candidate.originalPath, &candidate.imageType, &candidate.objectKeys, &candidate.attemptCount, &candidate.deletedAt); err != nil {
 			return nil, fmt.Errorf("artwork revision GC: scan claim: %w", err)
 		}
 		candidates = append(candidates, candidate)
@@ -251,11 +254,12 @@ func (g *ArtworkRevisionGarbageCollector) processCandidate(
 
 	var originalPath, imageType string
 	var objectKeys []string
+	var deletedAt *time.Time
 	err = tx.QueryRow(ctx, `
-		SELECT original_path, image_type, object_keys
+		SELECT original_path, image_type, object_keys, deleted_at
 		FROM artwork_revision_gc_candidates
 		WHERE id = $1 AND locked_by = $2
-		FOR UPDATE`, candidate.id, workerID).Scan(&originalPath, &imageType, &objectKeys)
+		FOR UPDATE`, candidate.id, workerID).Scan(&originalPath, &imageType, &objectKeys, &deletedAt)
 	if errors.Is(err, pgx.ErrNoRows) {
 		return artworkRevisionGCSuperseded, nil
 	}
@@ -263,26 +267,30 @@ func (g *ArtworkRevisionGarbageCollector) processCandidate(
 		return artworkRevisionGCSuperseded, fmt.Errorf("artwork revision GC: lock candidate: %w", err)
 	}
 
-	referenced, err := g.isReferenced(ctx, tx, originalPath)
-	if err != nil {
-		return artworkRevisionGCSuperseded, err
-	}
-	if referenced {
-		if _, err := tx.Exec(ctx, `
-			UPDATE artwork_revision_gc_candidates
-			SET next_attempt_at = NULL,
-				attempt_count = 0,
-				locked_at = NULL,
-				locked_by = '',
-				last_error = '',
-				updated_at = NOW()
-			WHERE id = $1 AND locked_by = $2`, candidate.id, workerID); err != nil {
-			return artworkRevisionGCSuperseded, fmt.Errorf("artwork revision GC: park referenced revision: %w", err)
+	// Once objects are deleted, a lingering reference is broken rather than
+	// live: skip parking and finish the pending heal instead.
+	if deletedAt == nil {
+		referenced, err := g.isReferenced(ctx, tx, originalPath)
+		if err != nil {
+			return artworkRevisionGCSuperseded, err
 		}
-		if err := tx.Commit(ctx); err != nil {
-			return artworkRevisionGCSuperseded, fmt.Errorf("artwork revision GC: commit referenced revision: %w", err)
+		if referenced {
+			if _, err := tx.Exec(ctx, `
+				UPDATE artwork_revision_gc_candidates
+				SET next_attempt_at = NULL,
+					attempt_count = 0,
+					locked_at = NULL,
+					locked_by = '',
+					last_error = '',
+					updated_at = NOW()
+				WHERE id = $1 AND locked_by = $2`, candidate.id, workerID); err != nil {
+				return artworkRevisionGCSuperseded, fmt.Errorf("artwork revision GC: park referenced revision: %w", err)
+			}
+			if err := tx.Commit(ctx); err != nil {
+				return artworkRevisionGCSuperseded, fmt.Errorf("artwork revision GC: commit referenced revision: %w", err)
+			}
+			return artworkRevisionGCReferenced, nil
 		}
-		return artworkRevisionGCReferenced, nil
 	}
 
 	// Rows queued by the displacement triggers carry no manifest; expand the
@@ -300,8 +308,14 @@ func (g *ArtworkRevisionGarbageCollector) processCandidate(
 			return artworkRevisionGCSuperseded, err
 		}
 	}
-	if _, err := tx.Exec(ctx, `DELETE FROM artwork_revision_gc_candidates WHERE id = $1 AND locked_by = $2`, candidate.id, workerID); err != nil {
-		return artworkRevisionGCSuperseded, fmt.Errorf("artwork revision GC: finish: %w", err)
+	// Keep the row until the post-delete heal succeeds: marking deleted_at
+	// (instead of deleting the row) preserves a durable retry if healing or
+	// the final row removal fails after the objects are already gone.
+	if _, err := tx.Exec(ctx, `
+		UPDATE artwork_revision_gc_candidates
+		SET deleted_at = COALESCE(deleted_at, NOW()), updated_at = NOW()
+		WHERE id = $1 AND locked_by = $2`, candidate.id, workerID); err != nil {
+		return artworkRevisionGCSuperseded, fmt.Errorf("artwork revision GC: mark deleted: %w", err)
 	}
 	if err := tx.Commit(ctx); err != nil {
 		return artworkRevisionGCSuperseded, fmt.Errorf("artwork revision GC: commit deletion: %w", err)
@@ -314,9 +328,17 @@ func (g *ArtworkRevisionGarbageCollector) processCandidate(
 	// objects, so pipelines re-cache instead of serving 404 artwork.
 	healed, healErr := g.healDeletedReferences(ctx, originalPath)
 	if healErr != nil {
-		slog.ErrorContext(ctx, "artwork revision GC: post-delete reference check failed",
-			"component", "metadata", "original_path", originalPath, "error", healErr)
-		return artworkRevisionGCDeleted, nil
+		return artworkRevisionGCSuperseded, fmt.Errorf("artwork revision GC: post-delete heal: %w", healErr)
+	}
+	// Healing can itself displace the path again (clearing a referencing row
+	// fires the trigger, which re-arms this row and drops our lease), so gate
+	// the removal on deleted_at instead of the lease: a concurrent tracker
+	// re-registration clears deleted_at and must survive; anything else with
+	// deleted_at set is a finished deletion.
+	if _, err := g.pool.Exec(ctx, `
+		DELETE FROM artwork_revision_gc_candidates
+		WHERE id = $1 AND deleted_at IS NOT NULL`, candidate.id); err != nil {
+		return artworkRevisionGCSuperseded, fmt.Errorf("artwork revision GC: finish: %w", err)
 	}
 	if healed {
 		slog.WarnContext(ctx, "artwork revision GC: deleted revision was re-referenced concurrently; reset rows for re-cache",

--- a/internal/metadata/artwork_revision_gc.go
+++ b/internal/metadata/artwork_revision_gc.go
@@ -60,14 +60,30 @@ func (g *ArtworkRevisionGarbageCollector) Run(ctx context.Context) (ArtworkRevis
 	if err != nil {
 		return stats, err
 	}
-	stats.Claimed = len(candidates)
+	return processArtworkRevisionGCBatch(
+		candidates,
+		func(candidate artworkRevisionGCCandidate) (artworkRevisionGCOutcome, error) {
+			return g.processCandidate(ctx, candidate, workerID)
+		},
+		func(candidate artworkRevisionGCCandidate, cause error) error {
+			return g.retry(ctx, candidate, workerID, cause)
+		},
+	)
+}
 
+func processArtworkRevisionGCBatch(
+	candidates []artworkRevisionGCCandidate,
+	process func(artworkRevisionGCCandidate) (artworkRevisionGCOutcome, error),
+	retry func(artworkRevisionGCCandidate, error) error,
+) (ArtworkRevisionGCStats, error) {
+	stats := ArtworkRevisionGCStats{Claimed: len(candidates)}
+	var firstErr error
 	for _, candidate := range candidates {
-		outcome, err := g.processCandidate(ctx, candidate, workerID)
+		outcome, err := process(candidate)
 		if err != nil {
 			stats.Retried++
-			if retryErr := g.retry(ctx, candidate, workerID, err); retryErr != nil {
-				return stats, retryErr
+			if retryErr := retry(candidate, err); retryErr != nil && firstErr == nil {
+				firstErr = retryErr
 			}
 			continue
 		}
@@ -78,7 +94,7 @@ func (g *ArtworkRevisionGarbageCollector) Run(ctx context.Context) (ArtworkRevis
 			stats.Deleted++
 		}
 	}
-	return stats, nil
+	return stats, firstErr
 }
 
 type artworkRevisionGCOutcome int

--- a/internal/metadata/artwork_revision_gc_test.go
+++ b/internal/metadata/artwork_revision_gc_test.go
@@ -2,6 +2,7 @@ package metadata
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"os"
 	"slices"
@@ -11,6 +12,7 @@ import (
 
 	"github.com/jackc/pgx/v5/pgxpool"
 
+	"github.com/Silo-Server/silo-server/internal/artworkkey"
 	"github.com/Silo-Server/silo-server/internal/catalog"
 )
 
@@ -48,6 +50,44 @@ func artworkRevisionGCTestPool(t *testing.T) *pgxpool.Pool {
 	}
 	t.Cleanup(pool.Close)
 	return pool
+}
+
+func TestProcessArtworkRevisionGCBatchContinuesAfterRetryFailure(t *testing.T) {
+	candidates := []artworkRevisionGCCandidate{{id: 1}, {id: 2}, {id: 3}}
+	processed := make([]int64, 0, len(candidates))
+	retryErr := errors.New("schedule retry")
+
+	stats, err := processArtworkRevisionGCBatch(
+		candidates,
+		func(candidate artworkRevisionGCCandidate) (artworkRevisionGCOutcome, error) {
+			processed = append(processed, candidate.id)
+			switch candidate.id {
+			case 1:
+				return artworkRevisionGCSuperseded, errors.New("delete object")
+			case 2:
+				return artworkRevisionGCReferenced, nil
+			default:
+				return artworkRevisionGCDeleted, nil
+			}
+		},
+		func(candidate artworkRevisionGCCandidate, _ error) error {
+			if candidate.id == 1 {
+				return retryErr
+			}
+			return nil
+		},
+	)
+
+	if !errors.Is(err, retryErr) {
+		t.Fatalf("process batch error = %v, want %v", err, retryErr)
+	}
+	if !slices.Equal(processed, []int64{1, 2, 3}) {
+		t.Fatalf("processed candidates = %v, want all candidates", processed)
+	}
+	want := ArtworkRevisionGCStats{Claimed: 3, Deleted: 1, Referenced: 1, Retried: 1}
+	if stats != want {
+		t.Fatalf("stats = %+v, want %+v", stats, want)
+	}
 }
 
 func TestArtworkRevisionGCSerializesDeletionWithRetracking(t *testing.T) {
@@ -238,5 +278,67 @@ func TestArtworkRevisionTriggerQueuesDisplacedRevision(t *testing.T) {
 	}
 	if !notBefore.After(time.Now().Add(23 * time.Hour)) {
 		t.Fatalf("not before = %v, want displacement grace period", notBefore)
+	}
+}
+
+func TestArtworkRevisionTriggerFallbackManifestMatchesArtworkKeyContract(t *testing.T) {
+	pool := artworkRevisionGCTestPool(t)
+	ctx := context.Background()
+	suffix := time.Now().UnixNano()
+	contentID := fmt.Sprintf("gc-trigger-manifest-%d", suffix)
+	imageTypes := []string{ImageCacheImagePoster, ImageCacheImageBackdrop, ImageCacheImageLogo}
+	oldPaths := make(map[string]string, len(imageTypes))
+	newPaths := make(map[string]string, len(imageTypes))
+	for _, imageType := range imageTypes {
+		oldPaths[imageType] = fmt.Sprintf(
+			"tmdb/movies/original.segment/%d/%s/original.old.webp", suffix, imageType,
+		)
+		newPaths[imageType] = fmt.Sprintf("tmdb/movies/%d/%s/original.new.webp", suffix, imageType)
+	}
+
+	if _, err := pool.Exec(ctx, `
+		INSERT INTO media_items (
+			content_id, type, title, status, genres, poster_path, backdrop_path, logo_path
+		) VALUES ($1, 'movie', 'GC Trigger Manifest', 'matched', '{}'::text[], $2, $3, $4)`,
+		contentID,
+		oldPaths[ImageCacheImagePoster],
+		oldPaths[ImageCacheImageBackdrop],
+		oldPaths[ImageCacheImageLogo],
+	); err != nil {
+		t.Fatalf("seed artwork: %v", err)
+	}
+	t.Cleanup(func() {
+		_, _ = pool.Exec(ctx, `DELETE FROM media_items WHERE content_id = $1`, contentID)
+		paths := []string{
+			oldPaths[ImageCacheImagePoster], oldPaths[ImageCacheImageBackdrop], oldPaths[ImageCacheImageLogo],
+			newPaths[ImageCacheImagePoster], newPaths[ImageCacheImageBackdrop], newPaths[ImageCacheImageLogo],
+		}
+		_, _ = pool.Exec(ctx, `DELETE FROM artwork_revision_gc_candidates WHERE original_path = ANY($1)`, paths)
+	})
+
+	if _, err := pool.Exec(ctx, `
+		UPDATE media_items
+		SET poster_path = $2, backdrop_path = $3, logo_path = $4
+		WHERE content_id = $1`,
+		contentID,
+		newPaths[ImageCacheImagePoster],
+		newPaths[ImageCacheImageBackdrop],
+		newPaths[ImageCacheImageLogo],
+	); err != nil {
+		t.Fatalf("replace artwork: %v", err)
+	}
+
+	for _, imageType := range imageTypes {
+		var objectKeys []string
+		if err := pool.QueryRow(ctx, `
+			SELECT object_keys
+			FROM artwork_revision_gc_candidates
+			WHERE original_path = $1`, oldPaths[imageType]).Scan(&objectKeys); err != nil {
+			t.Fatalf("load %s candidate: %v", imageType, err)
+		}
+		want := artworkkey.ObjectKeys(oldPaths[imageType], imageType)
+		if !slices.Equal(objectKeys, want) {
+			t.Fatalf("%s object manifest = %v, want %v", imageType, objectKeys, want)
+		}
 	}
 }

--- a/internal/metadata/artwork_revision_gc_test.go
+++ b/internal/metadata/artwork_revision_gc_test.go
@@ -1,0 +1,242 @@
+package metadata
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"slices"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/jackc/pgx/v5/pgxpool"
+
+	"github.com/Silo-Server/silo-server/internal/catalog"
+)
+
+type blockingArtworkRevisionDeleter struct {
+	started chan struct{}
+	release chan struct{}
+	once    sync.Once
+
+	mu      sync.Mutex
+	deleted [][]string
+}
+
+func (d *blockingArtworkRevisionDeleter) Bucket() string { return "artwork" }
+
+func (d *blockingArtworkRevisionDeleter) DeleteObjects(_ context.Context, _ string, keys []string) (int, error) {
+	d.once.Do(func() { close(d.started) })
+	if d.release != nil {
+		<-d.release
+	}
+	d.mu.Lock()
+	d.deleted = append(d.deleted, append([]string(nil), keys...))
+	d.mu.Unlock()
+	return len(keys), nil
+}
+
+func artworkRevisionGCTestPool(t *testing.T) *pgxpool.Pool {
+	t.Helper()
+	dsn := os.Getenv("SILO_TEST_DATABASE_URL")
+	if dsn == "" {
+		t.Skip("SILO_TEST_DATABASE_URL is not set")
+	}
+	pool, err := pgxpool.New(context.Background(), dsn)
+	if err != nil {
+		t.Fatalf("connect test database: %v", err)
+	}
+	t.Cleanup(pool.Close)
+	return pool
+}
+
+func TestArtworkRevisionGCSerializesDeletionWithRetracking(t *testing.T) {
+	pool := artworkRevisionGCTestPool(t)
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	suffix := time.Now().UnixNano()
+	originalPath := fmt.Sprintf("tmdb/movies/gc-%d/poster/original.old.webp", suffix)
+	oldKeys := []string{originalPath, fmt.Sprintf("tmdb/movies/gc-%d/poster/w500.old.webp", suffix)}
+	newKeys := []string{originalPath, fmt.Sprintf("tmdb/movies/gc-%d/poster/w500.old.webp", suffix), fmt.Sprintf("tmdb/movies/gc-%d/poster/w300.old.webp", suffix)}
+	workerID := fmt.Sprintf("gc-worker-%d", suffix)
+
+	var candidateID int64
+	if err := pool.QueryRow(ctx, `
+		INSERT INTO artwork_revision_gc_candidates (
+			original_path, object_keys, not_before, next_attempt_at, locked_at, locked_by
+		) VALUES ($1, $2, NOW() - interval '1 hour', NOW() - interval '1 hour', NOW(), $3)
+		RETURNING id`, originalPath, oldKeys, workerID).Scan(&candidateID); err != nil {
+		t.Fatalf("seed revision: %v", err)
+	}
+	t.Cleanup(func() {
+		_, _ = pool.Exec(context.Background(), `DELETE FROM artwork_revision_gc_candidates WHERE original_path = $1`, originalPath)
+	})
+
+	deleter := &blockingArtworkRevisionDeleter{started: make(chan struct{}), release: make(chan struct{})}
+	collector := NewArtworkRevisionGarbageCollector(pool, deleter)
+	processDone := make(chan struct {
+		outcome artworkRevisionGCOutcome
+		err     error
+	}, 1)
+	go func() {
+		outcome, err := collector.processCandidate(ctx, artworkRevisionGCCandidate{
+			id: candidateID, originalPath: originalPath, objectKeys: oldKeys,
+		}, workerID)
+		processDone <- struct {
+			outcome artworkRevisionGCOutcome
+			err     error
+		}{outcome: outcome, err: err}
+	}()
+
+	select {
+	case <-deleter.started:
+	case <-ctx.Done():
+		t.Fatalf("collector did not begin deletion: %v", ctx.Err())
+	}
+
+	tracker := catalog.NewArtworkRevisionTracker(pool)
+	trackDone := make(chan error, 1)
+	go func() { trackDone <- tracker.TrackArtworkRevision(ctx, originalPath, newKeys) }()
+
+	select {
+	case err := <-trackDone:
+		t.Fatalf("tracking completed while deletion row was locked: %v", err)
+	case <-time.After(100 * time.Millisecond):
+	}
+
+	close(deleter.release)
+	processed := <-processDone
+	if processed.err != nil {
+		t.Fatalf("processCandidate: %v", processed.err)
+	}
+	if processed.outcome != artworkRevisionGCDeleted {
+		t.Fatalf("outcome = %v, want deleted", processed.outcome)
+	}
+	if err := <-trackDone; err != nil {
+		t.Fatalf("retrack revision: %v", err)
+	}
+
+	var storedKeys []string
+	var nextAttempt time.Time
+	if err := pool.QueryRow(ctx, `
+		SELECT object_keys, next_attempt_at
+		FROM artwork_revision_gc_candidates
+		WHERE original_path = $1`, originalPath).Scan(&storedKeys, &nextAttempt); err != nil {
+		t.Fatalf("load retracked revision: %v", err)
+	}
+	if !slices.Equal(storedKeys, newKeys) {
+		t.Fatalf("stored manifest = %v, want %v", storedKeys, newKeys)
+	}
+	if !nextAttempt.After(time.Now().Add(23 * time.Hour)) {
+		t.Fatalf("next attempt = %v, want refreshed publication grace", nextAttempt)
+	}
+}
+
+func TestArtworkRevisionGCParksReferencedRevision(t *testing.T) {
+	pool := artworkRevisionGCTestPool(t)
+	ctx := context.Background()
+	suffix := time.Now().UnixNano()
+	contentID := fmt.Sprintf("gc-referenced-%d", suffix)
+	originalPath := fmt.Sprintf("tmdb/movies/%d/poster/original.live.webp", suffix)
+	keys := []string{originalPath}
+	workerID := fmt.Sprintf("gc-worker-%d", suffix)
+
+	if _, err := pool.Exec(ctx, `
+		INSERT INTO media_items (content_id, type, title, status, genres, poster_path)
+		VALUES ($1, 'movie', 'GC Referenced', 'matched', '{}'::text[], $2)`, contentID, originalPath); err != nil {
+		t.Fatalf("seed referenced item: %v", err)
+	}
+	var candidateID int64
+	if err := pool.QueryRow(ctx, `
+		INSERT INTO artwork_revision_gc_candidates (
+			original_path, object_keys, not_before, next_attempt_at, locked_at, locked_by
+		) VALUES ($1, $2, NOW() - interval '1 hour', NOW() - interval '1 hour', NOW(), $3)
+		RETURNING id`, originalPath, keys, workerID).Scan(&candidateID); err != nil {
+		t.Fatalf("seed revision: %v", err)
+	}
+	t.Cleanup(func() {
+		_, _ = pool.Exec(ctx, `DELETE FROM media_items WHERE content_id = $1`, contentID)
+		_, _ = pool.Exec(ctx, `DELETE FROM artwork_revision_gc_candidates WHERE original_path = $1`, originalPath)
+	})
+
+	deleter := &blockingArtworkRevisionDeleter{started: make(chan struct{})}
+	collector := NewArtworkRevisionGarbageCollector(pool, deleter)
+	outcome, err := collector.processCandidate(ctx, artworkRevisionGCCandidate{id: candidateID}, workerID)
+	if err != nil {
+		t.Fatalf("processCandidate: %v", err)
+	}
+	if outcome != artworkRevisionGCReferenced {
+		t.Fatalf("outcome = %v, want referenced", outcome)
+	}
+	select {
+	case <-deleter.started:
+		t.Fatal("referenced revision was sent to object deletion")
+	default:
+	}
+
+	var lockedBy string
+	var nextAttempt *time.Time
+	if err := pool.QueryRow(ctx, `
+		SELECT locked_by, next_attempt_at
+		FROM artwork_revision_gc_candidates
+		WHERE id = $1`, candidateID).Scan(&lockedBy, &nextAttempt); err != nil {
+		t.Fatalf("load parked revision: %v", err)
+	}
+	if lockedBy != "" {
+		t.Fatalf("locked_by = %q, want released", lockedBy)
+	}
+	if nextAttempt != nil {
+		t.Fatalf("next_attempt_at = %v, want dormant NULL", nextAttempt)
+	}
+}
+
+func TestArtworkRevisionTriggerQueuesDisplacedRevision(t *testing.T) {
+	pool := artworkRevisionGCTestPool(t)
+	ctx := context.Background()
+	suffix := time.Now().UnixNano()
+	contentID := fmt.Sprintf("gc-trigger-%d", suffix)
+	oldPath := fmt.Sprintf("tmdb/movies/%d/poster/original.old.webp", suffix)
+	newPath := fmt.Sprintf("tmdb/movies/%d/poster/original.new.webp", suffix)
+	wantKeys := []string{
+		oldPath,
+		fmt.Sprintf("tmdb/movies/%d/poster/w500.old.webp", suffix),
+		fmt.Sprintf("tmdb/movies/%d/poster/w300.old.webp", suffix),
+		fmt.Sprintf("tmdb/movies/%d/poster/future-variant.old.webp", suffix),
+	}
+
+	if _, err := pool.Exec(ctx, `
+		INSERT INTO media_items (content_id, type, title, status, genres, poster_path)
+		VALUES ($1, 'movie', 'GC Trigger', 'matched', '{}'::text[], $2)`, contentID, oldPath); err != nil {
+		t.Fatalf("seed artwork: %v", err)
+	}
+	if _, err := pool.Exec(ctx, `
+		INSERT INTO artwork_revision_gc_candidates (
+			original_path, object_keys, not_before, next_attempt_at
+		) VALUES ($1, $2, NOW(), NULL)`, oldPath, wantKeys); err != nil {
+		t.Fatalf("seed dormant manifest: %v", err)
+	}
+	t.Cleanup(func() {
+		_, _ = pool.Exec(ctx, `DELETE FROM media_items WHERE content_id = $1`, contentID)
+		_, _ = pool.Exec(ctx, `DELETE FROM artwork_revision_gc_candidates WHERE original_path IN ($1, $2)`, oldPath, newPath)
+	})
+
+	if _, err := pool.Exec(ctx, `UPDATE media_items SET poster_path = $2 WHERE content_id = $1`, contentID, newPath); err != nil {
+		t.Fatalf("replace artwork: %v", err)
+	}
+
+	var objectKeys []string
+	var notBefore time.Time
+	if err := pool.QueryRow(ctx, `
+		SELECT object_keys, not_before
+		FROM artwork_revision_gc_candidates
+		WHERE original_path = $1`, oldPath).Scan(&objectKeys, &notBefore); err != nil {
+		t.Fatalf("load displaced candidate: %v", err)
+	}
+	if !slices.Equal(objectKeys, wantKeys) {
+		t.Fatalf("object manifest = %v, want %v", objectKeys, wantKeys)
+	}
+	if !notBefore.After(time.Now().Add(23 * time.Hour)) {
+		t.Fatalf("not before = %v, want displacement grace period", notBefore)
+	}
+}

--- a/internal/metadata/artwork_revision_gc_test.go
+++ b/internal/metadata/artwork_revision_gc_test.go
@@ -27,10 +27,14 @@ type blockingArtworkRevisionDeleter struct {
 
 func (d *blockingArtworkRevisionDeleter) Bucket() string { return "artwork" }
 
-func (d *blockingArtworkRevisionDeleter) DeleteObjects(_ context.Context, _ string, keys []string) (int, error) {
+func (d *blockingArtworkRevisionDeleter) DeleteObjects(ctx context.Context, _ string, keys []string) (int, error) {
 	d.once.Do(func() { close(d.started) })
 	if d.release != nil {
-		<-d.release
+		select {
+		case <-d.release:
+		case <-ctx.Done():
+			return 0, ctx.Err()
+		}
 	}
 	d.mu.Lock()
 	d.deleted = append(d.deleted, append([]string(nil), keys...))
@@ -418,6 +422,62 @@ func TestArtworkRevisionGCExpandsTriggerManifestFromImageType(t *testing.T) {
 	want := artworkkey.ObjectKeys(originalPath, "backdrop")
 	if !slices.Equal(deleted[0], want) {
 		t.Fatalf("deleted keys = %v, want expanded manifest %v", deleted[0], want)
+	}
+}
+
+func TestArtworkRevisionGCHealsBrokenReferenceAfterObjectDeletion(t *testing.T) {
+	pool := artworkRevisionGCTestPool(t)
+	ctx := context.Background()
+	suffix := time.Now().UnixNano()
+	contentID := fmt.Sprintf("gc-heal-%d", suffix)
+	originalPath := fmt.Sprintf("tmdb/movies/%d/poster/original.gone.webp", suffix)
+	workerID := fmt.Sprintf("gc-worker-%d", suffix)
+
+	// A racing writer re-referenced the path after its objects were deleted:
+	// the candidate row survived with deleted_at set (heal previously failed).
+	if _, err := pool.Exec(ctx, `
+		INSERT INTO media_items (content_id, type, title, status, genres, poster_path)
+		VALUES ($1, 'movie', 'GC Heal', 'matched', '{}'::text[], $2)`, contentID, originalPath); err != nil {
+		t.Fatalf("seed re-referencing item: %v", err)
+	}
+	var candidateID int64
+	if err := pool.QueryRow(ctx, `
+		INSERT INTO artwork_revision_gc_candidates (
+			original_path, image_type, object_keys, not_before, next_attempt_at, deleted_at, locked_at, locked_by
+		) VALUES ($1, 'poster', '{}', NOW() - interval '1 hour', NOW() - interval '1 hour', NOW() - interval '1 hour', NOW(), $2)
+		RETURNING id`, originalPath, workerID).Scan(&candidateID); err != nil {
+		t.Fatalf("seed deleted candidate: %v", err)
+	}
+	t.Cleanup(func() {
+		_, _ = pool.Exec(ctx, `DELETE FROM media_items WHERE content_id = $1`, contentID)
+		_, _ = pool.Exec(ctx, `DELETE FROM artwork_revision_gc_candidates WHERE original_path = $1`, originalPath)
+	})
+
+	deleter := &blockingArtworkRevisionDeleter{started: make(chan struct{})}
+	collector := NewArtworkRevisionGarbageCollector(pool, deleter)
+	outcome, err := collector.processCandidate(ctx, artworkRevisionGCCandidate{id: candidateID}, workerID)
+	if err != nil {
+		t.Fatalf("processCandidate: %v", err)
+	}
+	if outcome != artworkRevisionGCDeletedAndHealed {
+		t.Fatalf("outcome = %v, want deleted-and-healed (broken reference must not park)", outcome)
+	}
+
+	var posterPath string
+	if err := pool.QueryRow(ctx, `
+		SELECT poster_path FROM media_items WHERE content_id = $1`, contentID).Scan(&posterPath); err != nil {
+		t.Fatalf("load healed item: %v", err)
+	}
+	if posterPath == originalPath {
+		t.Fatalf("poster_path still references deleted revision %q", posterPath)
+	}
+	var remaining int
+	if err := pool.QueryRow(ctx, `
+		SELECT COUNT(*) FROM artwork_revision_gc_candidates WHERE original_path = $1`, originalPath).Scan(&remaining); err != nil {
+		t.Fatalf("count candidates: %v", err)
+	}
+	if remaining != 0 {
+		t.Fatalf("candidate rows remaining = %d, want 0 after successful heal", remaining)
 	}
 }
 

--- a/internal/metadata/artwork_revision_gc_test.go
+++ b/internal/metadata/artwork_revision_gc_test.go
@@ -137,7 +137,7 @@ func TestArtworkRevisionGCSerializesDeletionWithRetracking(t *testing.T) {
 
 	tracker := catalog.NewArtworkRevisionTracker(pool)
 	trackDone := make(chan error, 1)
-	go func() { trackDone <- tracker.TrackArtworkRevision(ctx, originalPath, newKeys) }()
+	go func() { trackDone <- tracker.TrackArtworkRevision(ctx, originalPath, "poster", newKeys) }()
 
 	select {
 	case err := <-trackDone:
@@ -281,7 +281,7 @@ func TestArtworkRevisionTriggerQueuesDisplacedRevision(t *testing.T) {
 	}
 }
 
-func TestArtworkRevisionTriggerFallbackManifestMatchesArtworkKeyContract(t *testing.T) {
+func TestArtworkRevisionTriggerRecordsImageTypeForCollectorExpansion(t *testing.T) {
 	pool := artworkRevisionGCTestPool(t)
 	ctx := context.Background()
 	suffix := time.Now().UnixNano()
@@ -328,17 +328,159 @@ func TestArtworkRevisionTriggerFallbackManifestMatchesArtworkKeyContract(t *test
 		t.Fatalf("replace artwork: %v", err)
 	}
 
+	// The trigger stores only the displaced path and its image type; the
+	// collector expands the manifest via artworkkey at deletion time.
 	for _, imageType := range imageTypes {
 		var objectKeys []string
+		var storedType string
 		if err := pool.QueryRow(ctx, `
-			SELECT object_keys
+			SELECT object_keys, image_type
 			FROM artwork_revision_gc_candidates
-			WHERE original_path = $1`, oldPaths[imageType]).Scan(&objectKeys); err != nil {
+			WHERE original_path = $1`, oldPaths[imageType]).Scan(&objectKeys, &storedType); err != nil {
 			t.Fatalf("load %s candidate: %v", imageType, err)
 		}
-		want := artworkkey.ObjectKeys(oldPaths[imageType], imageType)
-		if !slices.Equal(objectKeys, want) {
-			t.Fatalf("%s object manifest = %v, want %v", imageType, objectKeys, want)
+		if len(objectKeys) != 0 {
+			t.Fatalf("%s object manifest = %v, want trigger to leave expansion to the collector", imageType, objectKeys)
 		}
+		if storedType != imageType {
+			t.Fatalf("stored image type = %q, want %q", storedType, imageType)
+		}
+	}
+}
+
+func TestArtworkRevisionTriggerIgnoresUnchangedAssignment(t *testing.T) {
+	pool := artworkRevisionGCTestPool(t)
+	ctx := context.Background()
+	suffix := time.Now().UnixNano()
+	contentID := fmt.Sprintf("gc-trigger-noop-%d", suffix)
+	path := fmt.Sprintf("tmdb/movies/%d/poster/original.same.webp", suffix)
+
+	if _, err := pool.Exec(ctx, `
+		INSERT INTO media_items (content_id, type, title, status, genres, poster_path)
+		VALUES ($1, 'movie', 'GC Trigger Noop', 'matched', '{}'::text[], $2)`, contentID, path); err != nil {
+		t.Fatalf("seed artwork: %v", err)
+	}
+	t.Cleanup(func() {
+		_, _ = pool.Exec(ctx, `DELETE FROM media_items WHERE content_id = $1`, contentID)
+		_, _ = pool.Exec(ctx, `DELETE FROM artwork_revision_gc_candidates WHERE original_path = $1`, path)
+	})
+
+	// Upsert-style write assigning the same value must not queue anything.
+	if _, err := pool.Exec(ctx, `UPDATE media_items SET poster_path = $2 WHERE content_id = $1`, contentID, path); err != nil {
+		t.Fatalf("no-op update: %v", err)
+	}
+
+	var count int
+	if err := pool.QueryRow(ctx, `
+		SELECT COUNT(*) FROM artwork_revision_gc_candidates WHERE original_path = $1`, path).Scan(&count); err != nil {
+		t.Fatalf("count candidates: %v", err)
+	}
+	if count != 0 {
+		t.Fatalf("unchanged assignment queued %d candidates, want 0", count)
+	}
+}
+
+func TestArtworkRevisionGCExpandsTriggerManifestFromImageType(t *testing.T) {
+	pool := artworkRevisionGCTestPool(t)
+	ctx := context.Background()
+	suffix := time.Now().UnixNano()
+	originalPath := fmt.Sprintf("tmdb/movies/gc-expand-%d/backdrop/original.old.webp", suffix)
+	workerID := fmt.Sprintf("gc-worker-%d", suffix)
+
+	var candidateID int64
+	if err := pool.QueryRow(ctx, `
+		INSERT INTO artwork_revision_gc_candidates (
+			original_path, image_type, object_keys, not_before, next_attempt_at, locked_at, locked_by
+		) VALUES ($1, 'backdrop', '{}', NOW() - interval '1 hour', NOW() - interval '1 hour', NOW(), $2)
+		RETURNING id`, originalPath, workerID).Scan(&candidateID); err != nil {
+		t.Fatalf("seed trigger-style candidate: %v", err)
+	}
+	t.Cleanup(func() {
+		_, _ = pool.Exec(ctx, `DELETE FROM artwork_revision_gc_candidates WHERE original_path = $1`, originalPath)
+	})
+
+	deleter := &blockingArtworkRevisionDeleter{started: make(chan struct{})}
+	collector := NewArtworkRevisionGarbageCollector(pool, deleter)
+	outcome, err := collector.processCandidate(ctx, artworkRevisionGCCandidate{id: candidateID}, workerID)
+	if err != nil {
+		t.Fatalf("processCandidate: %v", err)
+	}
+	if outcome != artworkRevisionGCDeleted {
+		t.Fatalf("outcome = %v, want deleted", outcome)
+	}
+
+	deleter.mu.Lock()
+	deleted := deleter.deleted
+	deleter.mu.Unlock()
+	if len(deleted) != 1 {
+		t.Fatalf("DeleteObjects calls = %d, want 1", len(deleted))
+	}
+	want := artworkkey.ObjectKeys(originalPath, "backdrop")
+	if !slices.Equal(deleted[0], want) {
+		t.Fatalf("deleted keys = %v, want expanded manifest %v", deleted[0], want)
+	}
+}
+
+func TestArtworkRevisionGCDormantSweep(t *testing.T) {
+	pool := artworkRevisionGCTestPool(t)
+	ctx := context.Background()
+	suffix := time.Now().UnixNano()
+	referencedContentID := fmt.Sprintf("gc-dormant-ref-%d", suffix)
+	referencedPath := fmt.Sprintf("tmdb/movies/%d/poster/original.ref.webp", suffix)
+	orphanPath := fmt.Sprintf("tmdb/movies/%d/poster/original.orphan.webp", suffix)
+
+	if _, err := pool.Exec(ctx, `
+		INSERT INTO media_items (content_id, type, title, status, genres, poster_path)
+		VALUES ($1, 'movie', 'GC Dormant Ref', 'matched', '{}'::text[], $2)`, referencedContentID, referencedPath); err != nil {
+		t.Fatalf("seed referenced item: %v", err)
+	}
+	for _, path := range []string{referencedPath, orphanPath} {
+		if _, err := pool.Exec(ctx, `
+			INSERT INTO artwork_revision_gc_candidates (
+				original_path, image_type, object_keys, not_before, next_attempt_at
+			) VALUES ($1, 'poster', '{}', NOW() - interval '2 days', NULL)`, path); err != nil {
+			t.Fatalf("seed dormant candidate: %v", err)
+		}
+	}
+	// Age both rows past the recheck interval; a reference that vanished
+	// through an untriggered surface looks exactly like the orphan row.
+	if _, err := pool.Exec(ctx, `
+		UPDATE artwork_revision_gc_candidates
+		SET updated_at = NOW() - interval '2 days'
+		WHERE original_path = ANY($1)`, []string{referencedPath, orphanPath}); err != nil {
+		t.Fatalf("age dormant candidates: %v", err)
+	}
+	t.Cleanup(func() {
+		_, _ = pool.Exec(ctx, `DELETE FROM media_items WHERE content_id = $1`, referencedContentID)
+		_, _ = pool.Exec(ctx, `DELETE FROM artwork_revision_gc_candidates WHERE original_path = ANY($1)`, []string{referencedPath, orphanPath})
+	})
+
+	deleter := &blockingArtworkRevisionDeleter{started: make(chan struct{})}
+	collector := NewArtworkRevisionGarbageCollector(pool, deleter)
+	checked, requeued, err := collector.sweepDormant(ctx, artworkRevisionGCBatchSize)
+	if err != nil {
+		t.Fatalf("sweepDormant: %v", err)
+	}
+	if checked < 2 {
+		t.Fatalf("checked = %d, want at least the two seeded rows", checked)
+	}
+	if requeued < 1 {
+		t.Fatalf("requeued = %d, want at least the orphan row", requeued)
+	}
+
+	var orphanNext, referencedNext *time.Time
+	if err := pool.QueryRow(ctx, `
+		SELECT next_attempt_at FROM artwork_revision_gc_candidates WHERE original_path = $1`, orphanPath).Scan(&orphanNext); err != nil {
+		t.Fatalf("load orphan candidate: %v", err)
+	}
+	if err := pool.QueryRow(ctx, `
+		SELECT next_attempt_at FROM artwork_revision_gc_candidates WHERE original_path = $1`, referencedPath).Scan(&referencedNext); err != nil {
+		t.Fatalf("load referenced candidate: %v", err)
+	}
+	if orphanNext == nil {
+		t.Fatal("orphan dormant row was not re-armed by the sweep")
+	}
+	if referencedNext != nil {
+		t.Fatalf("referenced dormant row was re-armed: %v", *referencedNext)
 	}
 }

--- a/internal/metadata/cache_result.go
+++ b/internal/metadata/cache_result.go
@@ -1,6 +1,10 @@
 package metadata
 
-import "strings"
+import (
+	"strings"
+
+	"github.com/Silo-Server/silo-server/internal/artworkkey"
+)
 
 // CachedImageOriginalPath returns the exact stored original key. The fallback
 // keeps older ImageCacher test doubles and implementations source compatible
@@ -20,7 +24,8 @@ func CachedImageOriginalPath(result *CacheImageResult) string {
 	}
 	ext := result.Ext
 	if ext == "" {
+		// Historical default for legacy cachers that predate WebP conversion.
 		ext = ".jpg"
 	}
-	return strings.TrimRight(result.BasePath, "/") + "/original" + ext
+	return artworkkey.Original(result.BasePath, "", ext)
 }

--- a/internal/metadata/cache_result.go
+++ b/internal/metadata/cache_result.go
@@ -1,0 +1,26 @@
+package metadata
+
+import "strings"
+
+// CachedImageOriginalPath returns the exact stored original key. The fallback
+// keeps older ImageCacher test doubles and implementations source compatible
+// while callers migrate away from reconstructing object keys themselves.
+func CachedImageOriginalPath(result *CacheImageResult) string {
+	if result == nil {
+		return ""
+	}
+	if result.OriginalPath != "" {
+		return result.OriginalPath
+	}
+	if result.BasePath == "" {
+		return ""
+	}
+	if strings.Contains(result.BasePath, "/original.") {
+		return result.BasePath
+	}
+	ext := result.Ext
+	if ext == "" {
+		ext = ".jpg"
+	}
+	return strings.TrimRight(result.BasePath, "/") + "/original" + ext
+}

--- a/internal/metadata/image_cache_processor.go
+++ b/internal/metadata/image_cache_processor.go
@@ -357,11 +357,9 @@ func (p *ImageCacheProcessor) processOne(ctx context.Context, job *models.Metada
 		return imageCacheProcessResult{outcome: "failed"}
 	}
 
-	// Confirm the target still references this job's source before uploading.
-	// CacheImage writes to a deterministic, source-independent storage key, so a
-	// stale job whose source an admin or newer refresh has already replaced would
-	// otherwise overwrite the live artwork object even though the conditional DB
-	// update later no-ops. Dropping the obsolete job here avoids that.
+	// Confirm the target still references this job's source before doing the
+	// download and immutable upload. The conditional update below remains the
+	// final concurrency guard; this early check avoids work for an obsolete job.
 	current, err := p.jobs.CurrentTargetSourcePath(ctx, job)
 	if err != nil {
 		p.markFailed(ctx, job, err.Error())
@@ -408,7 +406,7 @@ func (p *ImageCacheProcessor) processOne(ctx context.Context, job *models.Metada
 		uploadedVariants: result.UploadedVariants,
 		existingVariants: result.ExistingVariants,
 	}
-	cachedPath := cachedOriginalImagePath(result.BasePath, result.Ext)
+	cachedPath := CachedImageOriginalPath(result)
 	if cachedPath == "" {
 		p.markFailed(ctx, job, "image cache returned empty stored path")
 		processResult.outcome = "failed"

--- a/internal/metadata/person_refresh.go
+++ b/internal/metadata/person_refresh.go
@@ -262,7 +262,7 @@ func (s *PersonRefreshService) cachePersonPhoto(
 		return "", "", err
 	}
 
-	return cachedOriginalImagePath(result.BasePath, result.Ext), result.Thumbhash, nil
+	return CachedImageOriginalPath(result), result.Thumbhash, nil
 }
 
 func personProviderIDs(person models.Person) map[string]string {
@@ -369,17 +369,4 @@ func personCacheContentID(
 		}
 	}
 	return strconv.FormatInt(person.ID, 10)
-}
-
-func cachedOriginalImagePath(basePath, ext string) string {
-	if basePath == "" {
-		return ""
-	}
-	if strings.Contains(basePath, "/original.") {
-		return basePath
-	}
-	if ext == "" {
-		ext = ".jpg"
-	}
-	return strings.TrimRight(basePath, "/") + "/original" + ext
 }

--- a/internal/metadata/service.go
+++ b/internal/metadata/service.go
@@ -5956,10 +5956,9 @@ func (s *MetadataService) ApplyItemImage(ctx context.Context, req ApplyItemImage
 
 	storedPath := CachedImageOriginalPath(result)
 	return &ApplyItemImageResult{
-		StoredPath:   storedPath,
-		Revision:     result.Revision,
-		VariantPaths: result.VariantPaths,
-		Thumbhash:    result.Thumbhash,
+		StoredPath: storedPath,
+		Revision:   result.Revision,
+		Thumbhash:  result.Thumbhash,
 	}, nil
 }
 
@@ -5978,10 +5977,9 @@ type ApplyItemImageRequest struct {
 
 // ApplyItemImageResult contains the stored S3 path and thumbhash.
 type ApplyItemImageResult struct {
-	StoredPath   string
-	Revision     string
-	VariantPaths map[string]string
-	Thumbhash    string
+	StoredPath string
+	Revision   string
+	Thumbhash  string
 }
 
 // ImageTypeToString converts an ImageType to its string representation.

--- a/internal/metadata/service.go
+++ b/internal/metadata/service.go
@@ -5801,7 +5801,7 @@ func (s *MetadataService) cacheItemImages(ctx context.Context, item *models.Medi
 			// URLs from it (local storage URLs never leave the server).
 			item.PosterSourcePath = j.url
 		}
-		*j.field.path = cachedOriginalImagePath(cr.result.BasePath, cr.result.Ext)
+		*j.field.path = CachedImageOriginalPath(cr.result)
 		if j.field.thumbhash != nil && cr.result.Thumbhash != "" {
 			*j.field.thumbhash = cr.result.Thumbhash
 		}
@@ -5954,10 +5954,12 @@ func (s *MetadataService) ApplyItemImage(ctx context.Context, req ApplyItemImage
 		return nil, fmt.Errorf("caching image: %w", err)
 	}
 
-	storedPath := cachedOriginalImagePath(result.BasePath, result.Ext)
+	storedPath := CachedImageOriginalPath(result)
 	return &ApplyItemImageResult{
-		StoredPath: storedPath,
-		Thumbhash:  result.Thumbhash,
+		StoredPath:   storedPath,
+		Revision:     result.Revision,
+		VariantPaths: result.VariantPaths,
+		Thumbhash:    result.Thumbhash,
 	}, nil
 }
 
@@ -5976,8 +5978,10 @@ type ApplyItemImageRequest struct {
 
 // ApplyItemImageResult contains the stored S3 path and thumbhash.
 type ApplyItemImageResult struct {
-	StoredPath string
-	Thumbhash  string
+	StoredPath   string
+	Revision     string
+	VariantPaths map[string]string
+	Thumbhash    string
 }
 
 // ImageTypeToString converts an ImageType to its string representation.

--- a/internal/metadata/types.go
+++ b/internal/metadata/types.go
@@ -270,9 +270,12 @@ type CacheImageRequest struct {
 
 // CacheImageResult is returned by ImageCacher on success.
 type CacheImageResult struct {
-	BasePath  string // S3 key prefix
-	Thumbhash string // base64-encoded
-	Ext       string // file extension including dot (e.g. ".jpg", ".png")
+	BasePath     string // image-type prefix retained for legacy callers
+	OriginalPath string // exact immutable original-variant object key
+	Revision     string // content revision shared by all generated variants
+	VariantPaths map[string]string
+	Thumbhash    string // base64-encoded
+	Ext          string // encoded file extension including dot
 
 	UploadedVariants int
 	ExistingVariants int

--- a/internal/metadata/types.go
+++ b/internal/metadata/types.go
@@ -273,7 +273,6 @@ type CacheImageResult struct {
 	BasePath     string // image-type prefix retained for legacy callers
 	OriginalPath string // exact immutable original-variant object key
 	Revision     string // content revision shared by all generated variants
-	VariantPaths map[string]string
 	Thumbhash    string // base64-encoded
 	Ext          string // encoded file extension including dot
 

--- a/internal/s3client/client.go
+++ b/internal/s3client/client.go
@@ -9,6 +9,7 @@ import (
 	"crypto/hmac"
 	"crypto/sha256"
 	"encoding/base64"
+	"encoding/hex"
 	"errors"
 	"fmt"
 	"io"
@@ -160,6 +161,9 @@ func (c *Client) PutObject(ctx context.Context, bucket, key string, data []byte)
 		Bucket: aws.String(bucket),
 		Key:    aws.String(objectKey),
 		Body:   body,
+		Metadata: map[string]string{
+			"silo-sha256": objectSHA256(data),
+		},
 	}
 	if ct := contentTypeFromKey(key); ct != "" {
 		input.ContentType = aws.String(ct)
@@ -371,6 +375,32 @@ func (c *Client) ObjectExists(ctx context.Context, bucket, key string) (bool, er
 	}
 
 	return true, nil
+}
+
+// ObjectMatches checks that an immutable object exists with the expected
+// length and application-recorded SHA-256. Objects written before checksums
+// were recorded return false and are safely rewritten by the caller.
+func (c *Client) ObjectMatches(ctx context.Context, bucket, key string, data []byte) (bool, error) {
+	objectKey := c.prefixedKey(key)
+	out, err := c.s3Client.HeadObject(ctx, &s3.HeadObjectInput{
+		Bucket: aws.String(bucket),
+		Key:    aws.String(objectKey),
+	})
+	if err != nil {
+		if isNotFoundErr(err) {
+			return false, nil
+		}
+		return false, fmt.Errorf("s3 HeadObject %s/%s: %w", bucket, key, err)
+	}
+	if out.ContentLength == nil || *out.ContentLength != int64(len(data)) {
+		return false, nil
+	}
+	return strings.EqualFold(out.Metadata["silo-sha256"], objectSHA256(data)), nil
+}
+
+func objectSHA256(data []byte) string {
+	sum := sha256.Sum256(data)
+	return hex.EncodeToString(sum[:])
 }
 
 // DeleteObject deletes the object at the given key.

--- a/internal/scanner/audiobook_cover.go
+++ b/internal/scanner/audiobook_cover.go
@@ -21,11 +21,11 @@ const maxAudiobookSidecarCoverSize = 8 * 1024 * 1024
 // request struct) to avoid an import cycle: imagecache imports metadata
 // which imports scanner.
 type audiobookCoverCacher interface {
-	CacheAudiobookCover(ctx context.Context, data []byte, contentID string) (basePath string, ext string, thumbhash string, err error)
+	CacheAudiobookCover(ctx context.Context, data []byte, contentID string) (storedPath string, thumbhash string, err error)
 }
 
 type ebookCoverCacher interface {
-	CacheEbookCover(ctx context.Context, data []byte, contentID string) (basePath string, ext string, thumbhash string, err error)
+	CacheEbookCover(ctx context.Context, data []byte, contentID string) (storedPath string, thumbhash string, err error)
 }
 
 type audiobookCoverMetadataStore interface {
@@ -84,13 +84,13 @@ func ExtractAndUploadAudiobookCover(
 	if len(data) == 0 {
 		return "", ""
 	}
-	basePath, ext, thumbhash, err := cacher.CacheAudiobookCover(ctx, data, contentID)
+	storedPath, thumbhash, err := cacher.CacheAudiobookCover(ctx, data, contentID)
 	if err != nil {
 		slog.WarnContext(ctx, "audiobook cover: imagecache upload failed", "component", "scanner",
 			"path", audioFilePath, "error", err)
 		return "", ""
 	}
-	return fmt.Sprintf("%s/original%s", basePath, ext), thumbhash
+	return storedPath, thumbhash
 }
 
 func applyAudiobookSidecarCover(ctx context.Context, store audiobookCoverMetadataStore, cacher audiobookCoverCacher, contentID string, folderPath string) error {
@@ -108,11 +108,10 @@ func applyAudiobookSidecarCover(ctx context.Context, store audiobookCoverMetadat
 	if strings.TrimSpace(existingPosterPath) != "" {
 		return nil
 	}
-	basePath, ext, thumbhash, err := cacher.CacheAudiobookCover(ctx, cover, contentID)
+	posterPath, thumbhash, err := cacher.CacheAudiobookCover(ctx, cover, contentID)
 	if err != nil {
 		return err
 	}
-	posterPath := strings.TrimRight(basePath, "/") + "/original" + ext
 	update := &catalog.MetadataUpdate{PosterPath: &posterPath}
 	if thumbhash != "" {
 		update.PosterThumbhash = &thumbhash

--- a/internal/scanner/audiobook_cover_test.go
+++ b/internal/scanner/audiobook_cover_test.go
@@ -9,6 +9,8 @@ import (
 	"github.com/Silo-Server/silo-server/internal/catalog"
 )
 
+const audiobookCoverTestThumbhash = "thumb"
+
 type fakeAudiobookCoverCacher struct {
 	calls     int
 	data      []byte
@@ -16,14 +18,14 @@ type fakeAudiobookCoverCacher struct {
 	err       error
 }
 
-func (f *fakeAudiobookCoverCacher) CacheAudiobookCover(_ context.Context, data []byte, contentID string) (string, string, string, error) {
+func (f *fakeAudiobookCoverCacher) CacheAudiobookCover(_ context.Context, data []byte, contentID string) (string, string, error) {
 	f.calls++
 	f.data = append([]byte(nil), data...)
 	f.contentID = contentID
 	if f.err != nil {
-		return "", "", "", f.err
+		return "", "", f.err
 	}
-	return "local/audiobooks/" + contentID + "/poster", ".webp", "thumb", nil
+	return "local/audiobooks/" + contentID + "/poster/original.webp", audiobookCoverTestThumbhash, nil
 }
 
 type fakeAudiobookCoverStore struct {

--- a/internal/scanner/audiobook_cover_test.go
+++ b/internal/scanner/audiobook_cover_test.go
@@ -25,7 +25,7 @@ func (f *fakeAudiobookCoverCacher) CacheAudiobookCover(_ context.Context, data [
 	if f.err != nil {
 		return "", "", f.err
 	}
-	return "local/audiobooks/" + contentID + "/poster/original.webp", audiobookCoverTestThumbhash, nil
+	return "local/audiobooks/" + contentID + "/poster/original.test-revision.webp", audiobookCoverTestThumbhash, nil
 }
 
 type fakeAudiobookCoverStore struct {
@@ -62,7 +62,7 @@ func TestApplyAudiobookSidecarCoverCachesFolderCover(t *testing.T) {
 	if cacher.calls != 1 || string(cacher.data) != "audiobook-sidecar-cover" {
 		t.Fatalf("cache call = calls %d data %q", cacher.calls, string(cacher.data))
 	}
-	if store.update == nil || store.update.PosterPath == nil || *store.update.PosterPath != "local/audiobooks/content-1/poster/original.webp" {
+	if store.update == nil || store.update.PosterPath == nil || *store.update.PosterPath != "local/audiobooks/content-1/poster/original.test-revision.webp" {
 		t.Fatalf("poster update = %#v", store.update)
 	}
 	if store.update.PosterThumbhash == nil || *store.update.PosterThumbhash != "thumb" {

--- a/internal/scanner/audiobook_test.go
+++ b/internal/scanner/audiobook_test.go
@@ -71,7 +71,7 @@ func (f *fakeScannerCoverCacher) CacheAudiobookCover(_ context.Context, data []b
 	f.calls++
 	f.data = append([]byte(nil), data...)
 	f.contentID = contentID
-	return "local/audiobooks/" + contentID + "/poster/original.webp", "thumbhash", nil
+	return "local/audiobooks/" + contentID + "/poster/original.test-revision.webp", "thumbhash", nil
 }
 
 func TestApplyAudiobookEmbeddedCoverStoresPosterDuringScan(t *testing.T) {
@@ -108,7 +108,7 @@ func TestApplyAudiobookEmbeddedCoverStoresPosterDuringScan(t *testing.T) {
 	if len(exec.args) != 3 {
 		t.Fatalf("Exec args = %#v, want 3 args", exec.args)
 	}
-	if exec.args[0] != "local/audiobooks/content-1/poster/original.webp" {
+	if exec.args[0] != "local/audiobooks/content-1/poster/original.test-revision.webp" {
 		t.Fatalf("poster arg = %#v", exec.args[0])
 	}
 	if exec.args[1] != "thumbhash" || exec.args[2] != "content-1" {

--- a/internal/scanner/audiobook_test.go
+++ b/internal/scanner/audiobook_test.go
@@ -67,11 +67,11 @@ type fakeScannerCoverCacher struct {
 	contentID string
 }
 
-func (f *fakeScannerCoverCacher) CacheAudiobookCover(_ context.Context, data []byte, contentID string) (string, string, string, error) {
+func (f *fakeScannerCoverCacher) CacheAudiobookCover(_ context.Context, data []byte, contentID string) (string, string, error) {
 	f.calls++
 	f.data = append([]byte(nil), data...)
 	f.contentID = contentID
-	return "local/audiobooks/" + contentID + "/poster", ".webp", "thumbhash", nil
+	return "local/audiobooks/" + contentID + "/poster/original.webp", "thumbhash", nil
 }
 
 func TestApplyAudiobookEmbeddedCoverStoresPosterDuringScan(t *testing.T) {

--- a/internal/scanner/ebook_scan.go
+++ b/internal/scanner/ebook_scan.go
@@ -1119,11 +1119,10 @@ func cacheEbookCoverBytes(ctx context.Context, store ebookCoverMetadataStore, ca
 			return nil
 		}
 	}
-	basePath, ext, thumbhash, err := cacher.CacheEbookCover(ctx, data, contentID)
+	posterPath, thumbhash, err := cacher.CacheEbookCover(ctx, data, contentID)
 	if err != nil {
 		return err
 	}
-	posterPath := strings.TrimRight(basePath, "/") + "/original" + ext
 	if _, err := store.SetLocalPoster(ctx, contentID, posterPath, thumbhash, localEbookPosterPrefix); err != nil {
 		return fmt.Errorf("set ebook local poster: %w", err)
 	}

--- a/internal/scanner/ebook_test.go
+++ b/internal/scanner/ebook_test.go
@@ -52,7 +52,7 @@ func (f *fakeEbookCoverCacher) CacheEbookCover(_ context.Context, data []byte, c
 	if f.err != nil {
 		return "", "", f.err
 	}
-	return "local/ebooks/" + contentID + "/poster/original.webp", ebookCoverTestThumbhash, nil
+	return "local/ebooks/" + contentID + "/poster/original.test-revision.webp", ebookCoverTestThumbhash, nil
 }
 
 type fakeEbookMetadataUpdater struct {
@@ -1222,7 +1222,7 @@ func TestApplyEbookLocalCoverCachesEmbeddedAndSetsPoster(t *testing.T) {
 	if updater.setCalls != 1 || updater.contentID != "content-1" {
 		t.Fatalf("set call = calls %d content %q", updater.setCalls, updater.contentID)
 	}
-	if updater.setPosterPath != "local/ebooks/content-1/poster/original.webp" {
+	if updater.setPosterPath != "local/ebooks/content-1/poster/original.test-revision.webp" {
 		t.Fatalf("poster path = %q", updater.setPosterPath)
 	}
 	if updater.setThumbhash != "thumb" {
@@ -1295,7 +1295,7 @@ func TestApplyEbookLocalCoverPrefersSidecarOverEmbedded(t *testing.T) {
 	if cacher.calls != 1 || string(cacher.data) != "ebook-sidecar-cover" {
 		t.Fatalf("cache call = calls %d data %q, want sidecar bytes", cacher.calls, string(cacher.data))
 	}
-	if updater.setCalls != 1 || updater.setPosterPath != "local/ebooks/content-1/poster/original.webp" {
+	if updater.setCalls != 1 || updater.setPosterPath != "local/ebooks/content-1/poster/original.test-revision.webp" {
 		t.Fatalf("poster update = calls %d path %q", updater.setCalls, updater.setPosterPath)
 	}
 }

--- a/internal/scanner/ebook_test.go
+++ b/internal/scanner/ebook_test.go
@@ -16,6 +16,8 @@ import (
 	"github.com/jackc/pgx/v5/pgconn"
 )
 
+const ebookCoverTestThumbhash = "thumb"
+
 type recordingEbookExecutor struct {
 	queries []string
 	args    [][]any
@@ -43,14 +45,14 @@ type fakeEbookCoverCacher struct {
 	err       error
 }
 
-func (f *fakeEbookCoverCacher) CacheEbookCover(_ context.Context, data []byte, contentID string) (string, string, string, error) {
+func (f *fakeEbookCoverCacher) CacheEbookCover(_ context.Context, data []byte, contentID string) (string, string, error) {
 	f.calls++
 	f.data = append([]byte(nil), data...)
 	f.contentID = contentID
 	if f.err != nil {
-		return "", "", "", f.err
+		return "", "", f.err
 	}
-	return "local/ebooks/" + contentID + "/poster", ".webp", "thumb", nil
+	return "local/ebooks/" + contentID + "/poster/original.webp", ebookCoverTestThumbhash, nil
 }
 
 type fakeEbookMetadataUpdater struct {

--- a/internal/taskmanager/tasks/cleanup_artwork_revisions.go
+++ b/internal/taskmanager/tasks/cleanup_artwork_revisions.go
@@ -1,0 +1,56 @@
+package tasks
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/Silo-Server/silo-server/internal/metadata"
+	"github.com/Silo-Server/silo-server/internal/taskmanager"
+)
+
+type ArtworkRevisionGCRunner interface {
+	Run(ctx context.Context) (metadata.ArtworkRevisionGCStats, error)
+}
+
+type CleanupArtworkRevisionsTask struct {
+	runner ArtworkRevisionGCRunner
+}
+
+func NewCleanupArtworkRevisionsTask(runner ArtworkRevisionGCRunner) *CleanupArtworkRevisionsTask {
+	return &CleanupArtworkRevisionsTask{runner: runner}
+}
+
+func (t *CleanupArtworkRevisionsTask) Key() string  { return "cleanup_artwork_revisions" }
+func (t *CleanupArtworkRevisionsTask) Name() string { return "Clean Artwork Revisions" }
+func (t *CleanupArtworkRevisionsTask) Description() string {
+	return "Deletes unpublished or displaced immutable artwork revisions after a grace period when no catalog record references them."
+}
+func (t *CleanupArtworkRevisionsTask) Category() taskmanager.TaskCategory {
+	return taskmanager.TaskCategoryMetadata
+}
+func (t *CleanupArtworkRevisionsTask) IsHidden() bool { return false }
+func (t *CleanupArtworkRevisionsTask) DefaultTriggers() []taskmanager.TriggerConfig {
+	return []taskmanager.TriggerConfig{
+		{Type: taskmanager.TriggerTypeStartup},
+		{Type: taskmanager.TriggerTypeInterval, IntervalMs: int64(time.Hour / time.Millisecond)},
+	}
+}
+
+func (t *CleanupArtworkRevisionsTask) Execute(ctx context.Context, progress taskmanager.ProgressReporter) error {
+	if t == nil || t.runner == nil {
+		progress.Report(100, "Artwork revision cleanup is not configured")
+		return nil
+	}
+	progress.Report(0, "Checking displaced artwork revisions")
+	stats, err := t.runner.Run(ctx)
+	progress.SetResultData(stats.JSON())
+	if err != nil {
+		return fmt.Errorf("cleaning artwork revisions: %w", err)
+	}
+	progress.Report(100, fmt.Sprintf(
+		"Processed %d revisions: deleted %d, retained %d referenced, scheduled %d retries",
+		stats.Claimed, stats.Deleted, stats.Referenced, stats.Retried,
+	))
+	return nil
+}

--- a/migrations/sql/20260714120826_artwork_revision_gc.sql
+++ b/migrations/sql/20260714120826_artwork_revision_gc.sql
@@ -2,10 +2,14 @@
 CREATE TABLE public.artwork_revision_gc_candidates (
     id bigserial PRIMARY KEY,
     original_path text NOT NULL UNIQUE,
-    object_keys text[] NOT NULL,
+    -- Image type ("poster", "backdrop", ...) lets the collector expand the
+    -- expected object keys in Go (artworkkey.ObjectKeys) when no exact
+    -- manifest was tracked, so the variant ladder lives in one place.
+    image_type text NOT NULL DEFAULT '',
+    object_keys text[] NOT NULL DEFAULT '{}',
     not_before timestamptz NOT NULL,
     -- NULL means the revision is currently referenced and dormant. Artwork
-    -- displacement triggers reactivate it without losing the exact manifest.
+    -- displacement triggers or the collector's dormant sweep reactivate it.
     next_attempt_at timestamptz,
     attempt_count integer NOT NULL DEFAULT 0,
     locked_at timestamptz,
@@ -14,7 +18,7 @@ CREATE TABLE public.artwork_revision_gc_candidates (
     created_at timestamptz NOT NULL DEFAULT NOW(),
     updated_at timestamptz NOT NULL DEFAULT NOW(),
     CONSTRAINT artwork_revision_gc_original_path_check CHECK (BTRIM(original_path) <> ''),
-    CONSTRAINT artwork_revision_gc_object_keys_check CHECK (cardinality(object_keys) > 0),
+    CONSTRAINT artwork_revision_gc_manifest_check CHECK (cardinality(object_keys) > 0 OR BTRIM(image_type) <> ''),
     CONSTRAINT artwork_revision_gc_attempt_count_check CHECK (attempt_count >= 0)
 );
 
@@ -26,57 +30,55 @@ CREATE INDEX artwork_revision_gc_lease_idx
     ON public.artwork_revision_gc_candidates (locked_at, id)
     WHERE locked_at IS NOT NULL;
 
+-- The dormant sweep periodically re-verifies parked rows so a reference that
+-- disappears through a surface without a displacement trigger degrades to
+-- slower cleanup instead of a permanent leak.
+CREATE INDEX artwork_revision_gc_dormant_idx
+    ON public.artwork_revision_gc_candidates (updated_at, id)
+    WHERE next_attempt_at IS NULL;
+
 -- Queue displaced immutable artwork at the database boundary so every writer
 -- participates in the same lifecycle, including background refreshes, scanners,
 -- localizations, and future code paths that do not use the admin publication API.
+-- The trigger stores only the displaced path and its image type; the collector
+-- expands object keys in Go so the variant ladder has a single source of truth.
 -- +goose StatementBegin
 CREATE OR REPLACE FUNCTION public.queue_displaced_artwork_revision()
 RETURNS trigger
 LANGUAGE plpgsql
 AS $$
 DECLARE
-    arg_index integer;
+    old_row jsonb := to_jsonb(OLD);
+    new_row jsonb;
+    arg_index integer := 0;
     path_column text;
     image_type text;
     previous_path text;
     replacement_path text;
-    object_keys text[];
     cleanup_at timestamptz := NOW() + interval '24 hours';
 BEGIN
-    arg_index := 0;
+    IF TG_OP = 'UPDATE' THEN
+        new_row := to_jsonb(NEW);
+    END IF;
+
     WHILE arg_index < TG_NARGS LOOP
         path_column := TG_ARGV[arg_index];
         image_type := TG_ARGV[arg_index + 1];
-        previous_path := to_jsonb(OLD) ->> path_column;
-        replacement_path := CASE WHEN TG_OP = 'UPDATE' THEN to_jsonb(NEW) ->> path_column ELSE NULL END;
+        previous_path := old_row ->> path_column;
+        replacement_path := CASE WHEN new_row IS NULL THEN NULL ELSE new_row ->> path_column END;
 
         IF COALESCE(BTRIM(previous_path), '') <> ''
            AND previous_path NOT LIKE '%://%'
            AND previous_path ~ '/original\.[^/]+$'
            AND (TG_OP = 'DELETE' OR previous_path IS DISTINCT FROM replacement_path) THEN
-            object_keys := CASE image_type
-                WHEN 'backdrop' THEN ARRAY[
-                    previous_path,
-                    regexp_replace(previous_path, '/original(\.[^/]*)$', '/w1920\1'),
-                    regexp_replace(previous_path, '/original(\.[^/]*)$', '/w1280\1'),
-                    regexp_replace(previous_path, '/original(\.[^/]*)$', '/w300\1')
-                ]
-                WHEN 'logo' THEN ARRAY[
-                    previous_path,
-                    regexp_replace(previous_path, '/original(\.[^/]*)$', '/w500\1')
-                ]
-                ELSE ARRAY[
-                    previous_path,
-                    regexp_replace(previous_path, '/original(\.[^/]*)$', '/w500\1'),
-                    regexp_replace(previous_path, '/original(\.[^/]*)$', '/w300\1')
-                ]
-            END;
-
             INSERT INTO public.artwork_revision_gc_candidates (
-                original_path, object_keys, not_before, next_attempt_at
-            ) VALUES (previous_path, object_keys, cleanup_at, cleanup_at)
+                original_path, image_type, object_keys, not_before, next_attempt_at
+            ) VALUES (previous_path, image_type, '{}', cleanup_at, cleanup_at)
             ON CONFLICT (original_path) DO UPDATE SET
-                object_keys = artwork_revision_gc_candidates.object_keys,
+                image_type = CASE
+                    WHEN artwork_revision_gc_candidates.image_type = '' THEN EXCLUDED.image_type
+                    ELSE artwork_revision_gc_candidates.image_type
+                END,
                 not_before = EXCLUDED.not_before,
                 next_attempt_at = EXCLUDED.next_attempt_at,
                 attempt_count = 0,
@@ -97,40 +99,93 @@ END;
 $$;
 -- +goose StatementEnd
 
-CREATE TRIGGER media_items_artwork_revision_gc
-AFTER UPDATE OF poster_path, backdrop_path, logo_path OR DELETE ON public.media_items
+-- UPDATE triggers carry WHEN clauses so the function only runs when an artwork
+-- column actually changes; catalog upserts assign these columns on every row
+-- write. DELETE triggers cannot reference NEW and are declared separately.
+CREATE TRIGGER media_items_artwork_revision_gc_update
+AFTER UPDATE OF poster_path, backdrop_path, logo_path ON public.media_items
+FOR EACH ROW
+WHEN (OLD.poster_path IS DISTINCT FROM NEW.poster_path
+   OR OLD.backdrop_path IS DISTINCT FROM NEW.backdrop_path
+   OR OLD.logo_path IS DISTINCT FROM NEW.logo_path)
+EXECUTE FUNCTION public.queue_displaced_artwork_revision(
+    'poster_path', 'poster', 'backdrop_path', 'backdrop', 'logo_path', 'logo'
+);
+
+CREATE TRIGGER media_items_artwork_revision_gc_delete
+AFTER DELETE ON public.media_items
 FOR EACH ROW EXECUTE FUNCTION public.queue_displaced_artwork_revision(
     'poster_path', 'poster', 'backdrop_path', 'backdrop', 'logo_path', 'logo'
 );
 
-CREATE TRIGGER media_item_localizations_artwork_revision_gc
-AFTER UPDATE OF poster_path, backdrop_path, logo_path OR DELETE ON public.media_item_localizations
+CREATE TRIGGER media_item_localizations_artwork_revision_gc_update
+AFTER UPDATE OF poster_path, backdrop_path, logo_path ON public.media_item_localizations
+FOR EACH ROW
+WHEN (OLD.poster_path IS DISTINCT FROM NEW.poster_path
+   OR OLD.backdrop_path IS DISTINCT FROM NEW.backdrop_path
+   OR OLD.logo_path IS DISTINCT FROM NEW.logo_path)
+EXECUTE FUNCTION public.queue_displaced_artwork_revision(
+    'poster_path', 'poster', 'backdrop_path', 'backdrop', 'logo_path', 'logo'
+);
+
+CREATE TRIGGER media_item_localizations_artwork_revision_gc_delete
+AFTER DELETE ON public.media_item_localizations
 FOR EACH ROW EXECUTE FUNCTION public.queue_displaced_artwork_revision(
     'poster_path', 'poster', 'backdrop_path', 'backdrop', 'logo_path', 'logo'
 );
 
-CREATE TRIGGER seasons_artwork_revision_gc
-AFTER UPDATE OF poster_path OR DELETE ON public.seasons
+CREATE TRIGGER seasons_artwork_revision_gc_update
+AFTER UPDATE OF poster_path ON public.seasons
+FOR EACH ROW
+WHEN (OLD.poster_path IS DISTINCT FROM NEW.poster_path)
+EXECUTE FUNCTION public.queue_displaced_artwork_revision('poster_path', 'poster');
+
+CREATE TRIGGER seasons_artwork_revision_gc_delete
+AFTER DELETE ON public.seasons
 FOR EACH ROW EXECUTE FUNCTION public.queue_displaced_artwork_revision('poster_path', 'poster');
 
-CREATE TRIGGER season_localizations_artwork_revision_gc
-AFTER UPDATE OF poster_path OR DELETE ON public.season_localizations
+CREATE TRIGGER season_localizations_artwork_revision_gc_update
+AFTER UPDATE OF poster_path ON public.season_localizations
+FOR EACH ROW
+WHEN (OLD.poster_path IS DISTINCT FROM NEW.poster_path)
+EXECUTE FUNCTION public.queue_displaced_artwork_revision('poster_path', 'poster');
+
+CREATE TRIGGER season_localizations_artwork_revision_gc_delete
+AFTER DELETE ON public.season_localizations
 FOR EACH ROW EXECUTE FUNCTION public.queue_displaced_artwork_revision('poster_path', 'poster');
 
-CREATE TRIGGER episodes_artwork_revision_gc
-AFTER UPDATE OF still_path OR DELETE ON public.episodes
+CREATE TRIGGER episodes_artwork_revision_gc_update
+AFTER UPDATE OF still_path ON public.episodes
+FOR EACH ROW
+WHEN (OLD.still_path IS DISTINCT FROM NEW.still_path)
+EXECUTE FUNCTION public.queue_displaced_artwork_revision('still_path', 'still');
+
+CREATE TRIGGER episodes_artwork_revision_gc_delete
+AFTER DELETE ON public.episodes
 FOR EACH ROW EXECUTE FUNCTION public.queue_displaced_artwork_revision('still_path', 'still');
 
-CREATE TRIGGER people_artwork_revision_gc
-AFTER UPDATE OF photo_path OR DELETE ON public.people
+CREATE TRIGGER people_artwork_revision_gc_update
+AFTER UPDATE OF photo_path ON public.people
+FOR EACH ROW
+WHEN (OLD.photo_path IS DISTINCT FROM NEW.photo_path)
+EXECUTE FUNCTION public.queue_displaced_artwork_revision('photo_path', 'profile');
+
+CREATE TRIGGER people_artwork_revision_gc_delete
+AFTER DELETE ON public.people
 FOR EACH ROW EXECUTE FUNCTION public.queue_displaced_artwork_revision('photo_path', 'profile');
 
 -- +goose Down
-DROP TRIGGER IF EXISTS people_artwork_revision_gc ON public.people;
-DROP TRIGGER IF EXISTS episodes_artwork_revision_gc ON public.episodes;
-DROP TRIGGER IF EXISTS season_localizations_artwork_revision_gc ON public.season_localizations;
-DROP TRIGGER IF EXISTS seasons_artwork_revision_gc ON public.seasons;
-DROP TRIGGER IF EXISTS media_item_localizations_artwork_revision_gc ON public.media_item_localizations;
-DROP TRIGGER IF EXISTS media_items_artwork_revision_gc ON public.media_items;
+DROP TRIGGER IF EXISTS people_artwork_revision_gc_delete ON public.people;
+DROP TRIGGER IF EXISTS people_artwork_revision_gc_update ON public.people;
+DROP TRIGGER IF EXISTS episodes_artwork_revision_gc_delete ON public.episodes;
+DROP TRIGGER IF EXISTS episodes_artwork_revision_gc_update ON public.episodes;
+DROP TRIGGER IF EXISTS season_localizations_artwork_revision_gc_delete ON public.season_localizations;
+DROP TRIGGER IF EXISTS season_localizations_artwork_revision_gc_update ON public.season_localizations;
+DROP TRIGGER IF EXISTS seasons_artwork_revision_gc_delete ON public.seasons;
+DROP TRIGGER IF EXISTS seasons_artwork_revision_gc_update ON public.seasons;
+DROP TRIGGER IF EXISTS media_item_localizations_artwork_revision_gc_delete ON public.media_item_localizations;
+DROP TRIGGER IF EXISTS media_item_localizations_artwork_revision_gc_update ON public.media_item_localizations;
+DROP TRIGGER IF EXISTS media_items_artwork_revision_gc_delete ON public.media_items;
+DROP TRIGGER IF EXISTS media_items_artwork_revision_gc_update ON public.media_items;
 DROP FUNCTION IF EXISTS public.queue_displaced_artwork_revision();
 DROP TABLE IF EXISTS public.artwork_revision_gc_candidates;

--- a/migrations/sql/20260714120826_artwork_revision_gc.sql
+++ b/migrations/sql/20260714120826_artwork_revision_gc.sql
@@ -1,0 +1,136 @@
+-- +goose Up
+CREATE TABLE public.artwork_revision_gc_candidates (
+    id bigserial PRIMARY KEY,
+    original_path text NOT NULL UNIQUE,
+    object_keys text[] NOT NULL,
+    not_before timestamptz NOT NULL,
+    -- NULL means the revision is currently referenced and dormant. Artwork
+    -- displacement triggers reactivate it without losing the exact manifest.
+    next_attempt_at timestamptz,
+    attempt_count integer NOT NULL DEFAULT 0,
+    locked_at timestamptz,
+    locked_by text NOT NULL DEFAULT '',
+    last_error text NOT NULL DEFAULT '',
+    created_at timestamptz NOT NULL DEFAULT NOW(),
+    updated_at timestamptz NOT NULL DEFAULT NOW(),
+    CONSTRAINT artwork_revision_gc_original_path_check CHECK (BTRIM(original_path) <> ''),
+    CONSTRAINT artwork_revision_gc_object_keys_check CHECK (cardinality(object_keys) > 0),
+    CONSTRAINT artwork_revision_gc_attempt_count_check CHECK (attempt_count >= 0)
+);
+
+CREATE INDEX artwork_revision_gc_due_idx
+    ON public.artwork_revision_gc_candidates (next_attempt_at, id)
+    WHERE locked_at IS NULL AND next_attempt_at IS NOT NULL;
+
+CREATE INDEX artwork_revision_gc_lease_idx
+    ON public.artwork_revision_gc_candidates (locked_at, id)
+    WHERE locked_at IS NOT NULL;
+
+-- Queue displaced immutable artwork at the database boundary so every writer
+-- participates in the same lifecycle, including background refreshes, scanners,
+-- localizations, and future code paths that do not use the admin publication API.
+-- +goose StatementBegin
+CREATE OR REPLACE FUNCTION public.queue_displaced_artwork_revision()
+RETURNS trigger
+LANGUAGE plpgsql
+AS $$
+DECLARE
+    arg_index integer;
+    path_column text;
+    image_type text;
+    previous_path text;
+    replacement_path text;
+    object_keys text[];
+    cleanup_at timestamptz := NOW() + interval '24 hours';
+BEGIN
+    arg_index := 0;
+    WHILE arg_index < TG_NARGS LOOP
+        path_column := TG_ARGV[arg_index];
+        image_type := TG_ARGV[arg_index + 1];
+        previous_path := to_jsonb(OLD) ->> path_column;
+        replacement_path := CASE WHEN TG_OP = 'UPDATE' THEN to_jsonb(NEW) ->> path_column ELSE NULL END;
+
+        IF COALESCE(BTRIM(previous_path), '') <> ''
+           AND previous_path NOT LIKE '%://%'
+           AND previous_path LIKE '%/original.%'
+           AND (TG_OP = 'DELETE' OR previous_path IS DISTINCT FROM replacement_path) THEN
+            object_keys := CASE image_type
+                WHEN 'backdrop' THEN ARRAY[
+                    previous_path,
+                    replace(previous_path, '/original.', '/w1920.'),
+                    replace(previous_path, '/original.', '/w1280.'),
+                    replace(previous_path, '/original.', '/w300.')
+                ]
+                WHEN 'logo' THEN ARRAY[
+                    previous_path,
+                    replace(previous_path, '/original.', '/w500.')
+                ]
+                ELSE ARRAY[
+                    previous_path,
+                    replace(previous_path, '/original.', '/w500.'),
+                    replace(previous_path, '/original.', '/w300.')
+                ]
+            END;
+
+            INSERT INTO public.artwork_revision_gc_candidates (
+                original_path, object_keys, not_before, next_attempt_at
+            ) VALUES (previous_path, object_keys, cleanup_at, cleanup_at)
+            ON CONFLICT (original_path) DO UPDATE SET
+                object_keys = artwork_revision_gc_candidates.object_keys,
+                not_before = EXCLUDED.not_before,
+                next_attempt_at = EXCLUDED.next_attempt_at,
+                attempt_count = 0,
+                locked_at = NULL,
+                locked_by = '',
+                last_error = '',
+                updated_at = NOW();
+        END IF;
+
+        arg_index := arg_index + 2;
+    END LOOP;
+
+    IF TG_OP = 'DELETE' THEN
+        RETURN OLD;
+    END IF;
+    RETURN NEW;
+END;
+$$;
+-- +goose StatementEnd
+
+CREATE TRIGGER media_items_artwork_revision_gc
+AFTER UPDATE OF poster_path, backdrop_path, logo_path OR DELETE ON public.media_items
+FOR EACH ROW EXECUTE FUNCTION public.queue_displaced_artwork_revision(
+    'poster_path', 'poster', 'backdrop_path', 'backdrop', 'logo_path', 'logo'
+);
+
+CREATE TRIGGER media_item_localizations_artwork_revision_gc
+AFTER UPDATE OF poster_path, backdrop_path, logo_path OR DELETE ON public.media_item_localizations
+FOR EACH ROW EXECUTE FUNCTION public.queue_displaced_artwork_revision(
+    'poster_path', 'poster', 'backdrop_path', 'backdrop', 'logo_path', 'logo'
+);
+
+CREATE TRIGGER seasons_artwork_revision_gc
+AFTER UPDATE OF poster_path OR DELETE ON public.seasons
+FOR EACH ROW EXECUTE FUNCTION public.queue_displaced_artwork_revision('poster_path', 'poster');
+
+CREATE TRIGGER season_localizations_artwork_revision_gc
+AFTER UPDATE OF poster_path OR DELETE ON public.season_localizations
+FOR EACH ROW EXECUTE FUNCTION public.queue_displaced_artwork_revision('poster_path', 'poster');
+
+CREATE TRIGGER episodes_artwork_revision_gc
+AFTER UPDATE OF still_path OR DELETE ON public.episodes
+FOR EACH ROW EXECUTE FUNCTION public.queue_displaced_artwork_revision('still_path', 'still');
+
+CREATE TRIGGER people_artwork_revision_gc
+AFTER UPDATE OF photo_path OR DELETE ON public.people
+FOR EACH ROW EXECUTE FUNCTION public.queue_displaced_artwork_revision('photo_path', 'profile');
+
+-- +goose Down
+DROP TRIGGER IF EXISTS people_artwork_revision_gc ON public.people;
+DROP TRIGGER IF EXISTS episodes_artwork_revision_gc ON public.episodes;
+DROP TRIGGER IF EXISTS season_localizations_artwork_revision_gc ON public.season_localizations;
+DROP TRIGGER IF EXISTS seasons_artwork_revision_gc ON public.seasons;
+DROP TRIGGER IF EXISTS media_item_localizations_artwork_revision_gc ON public.media_item_localizations;
+DROP TRIGGER IF EXISTS media_items_artwork_revision_gc ON public.media_items;
+DROP FUNCTION IF EXISTS public.queue_displaced_artwork_revision();
+DROP TABLE IF EXISTS public.artwork_revision_gc_candidates;

--- a/migrations/sql/20260714120826_artwork_revision_gc.sql
+++ b/migrations/sql/20260714120826_artwork_revision_gc.sql
@@ -52,23 +52,23 @@ BEGIN
 
         IF COALESCE(BTRIM(previous_path), '') <> ''
            AND previous_path NOT LIKE '%://%'
-           AND previous_path LIKE '%/original.%'
+           AND previous_path ~ '/original\.[^/]+$'
            AND (TG_OP = 'DELETE' OR previous_path IS DISTINCT FROM replacement_path) THEN
             object_keys := CASE image_type
                 WHEN 'backdrop' THEN ARRAY[
                     previous_path,
-                    replace(previous_path, '/original.', '/w1920.'),
-                    replace(previous_path, '/original.', '/w1280.'),
-                    replace(previous_path, '/original.', '/w300.')
+                    regexp_replace(previous_path, '/original(\.[^/]*)$', '/w1920\1'),
+                    regexp_replace(previous_path, '/original(\.[^/]*)$', '/w1280\1'),
+                    regexp_replace(previous_path, '/original(\.[^/]*)$', '/w300\1')
                 ]
                 WHEN 'logo' THEN ARRAY[
                     previous_path,
-                    replace(previous_path, '/original.', '/w500.')
+                    regexp_replace(previous_path, '/original(\.[^/]*)$', '/w500\1')
                 ]
                 ELSE ARRAY[
                     previous_path,
-                    replace(previous_path, '/original.', '/w500.'),
-                    replace(previous_path, '/original.', '/w300.')
+                    regexp_replace(previous_path, '/original(\.[^/]*)$', '/w500\1'),
+                    regexp_replace(previous_path, '/original(\.[^/]*)$', '/w300\1')
                 ]
             END;
 

--- a/migrations/sql/20260714120826_artwork_revision_gc.sql
+++ b/migrations/sql/20260714120826_artwork_revision_gc.sql
@@ -11,6 +11,10 @@ CREATE TABLE public.artwork_revision_gc_candidates (
     -- NULL means the revision is currently referenced and dormant. Artwork
     -- displacement triggers or the collector's dormant sweep reactivate it.
     next_attempt_at timestamptz,
+    -- Set once the objects have been deleted from storage. The row then only
+    -- survives until the post-delete reference heal succeeds, so a transient
+    -- heal failure keeps a durable retry instead of orphaning broken pointers.
+    deleted_at timestamptz,
     attempt_count integer NOT NULL DEFAULT 0,
     locked_at timestamptz,
     locked_by text NOT NULL DEFAULT '',

--- a/web/src/api/types.ts
+++ b/web/src/api/types.ts
@@ -4338,6 +4338,8 @@ export interface ApplyItemImageResponse {
   content_id: string;
   stored_path: string;
   thumbhash: string;
+  image_url?: string;
+  revision?: string;
 }
 
 export interface UnmatchedLibraryItem {

--- a/web/src/components/EditMetadataDialog.tsx
+++ b/web/src/components/EditMetadataDialog.tsx
@@ -46,7 +46,10 @@ const SECTIONS: { key: Section; label: string; types: ItemDetail["type"][] }[] =
   { key: "dates", label: "Dates & Ratings", types: ["movie", "series", "season", "episode"] },
   { key: "tags", label: "Tags & Genres", types: ["movie", "series"] },
   { key: "ids", label: "External IDs", types: ["movie", "series", "season", "episode"] },
-  { key: "images", label: "Images", types: ["movie", "series", "season", "episode"] },
+  // Episodes are excluded: the image search endpoint only returns series-level
+  // posters/backdrops/logos, and episodes store stills — there is nothing an
+  // episode apply could legitimately show or persist from this dialog.
+  { key: "images", label: "Images", types: ["movie", "series", "season"] },
 ];
 
 // Maps form field names to their MetadataField lock value.

--- a/web/src/components/GlobalSearch.tsx
+++ b/web/src/components/GlobalSearch.tsx
@@ -1,4 +1,5 @@
 import { useMemo, useState, useEffect, useCallback } from "react";
+import { useImageLoaded } from "@/hooks/useImageLoaded";
 import { useQuery } from "@tanstack/react-query";
 import { Dialog, DialogContent, DialogTitle } from "@/components/ui/dialog";
 import { VisuallyHidden } from "radix-ui";
@@ -52,7 +53,7 @@ function GlobalSearchResultRow({
   isSelected: boolean;
   onPick: (contentId: string) => void;
 }) {
-  const [loaded, setLoaded] = useState(false);
+  const { loaded, onLoad } = useImageLoaded(item.poster_url);
   const thumbhashUrl = item.poster_thumbhash ? decodeThumbhash(item.poster_thumbhash) : "";
 
   return (
@@ -83,7 +84,7 @@ function GlobalSearchResultRow({
             alt=""
             className={`h-full w-full object-cover ${loaded ? "opacity-100" : "opacity-0"}`}
             loading="lazy"
-            onLoad={() => setLoaded(true)}
+            onLoad={onLoad}
           />
         ) : (
           <div className="text-muted-foreground flex h-full items-center justify-center px-1 text-center text-[10px] leading-tight">

--- a/web/src/components/ImageSelectorTab.tsx
+++ b/web/src/components/ImageSelectorTab.tsx
@@ -15,12 +15,16 @@ const IMAGE_TABS: { key: ImageTab; label: string; aspect: string }[] = [
   { key: "logo", label: "Logos", aspect: "aspect-video" },
 ];
 
+// Seasons only store a poster; the server rejects other image types for them.
+const SEASON_TABS = IMAGE_TABS.filter((tab) => tab.key === "poster");
+
 interface ImageSelectorTabProps {
   item: ItemDetail;
   enabled: boolean;
 }
 
 export default function ImageSelectorTab({ item, enabled }: ImageSelectorTabProps) {
+  const availableTabs = item.type === "season" ? SEASON_TABS : IMAGE_TABS;
   const [activeTab, setActiveTab] = useState<ImageTab>("poster");
   const [textlessOnly, setTextlessOnly] = useState(false);
   const [selectedImage, setSelectedImage] = useState<RemoteImage | null>(null);
@@ -92,7 +96,7 @@ export default function ImageSelectorTab({ item, enabled }: ImageSelectorTabProp
 
       {/* Image type tabs */}
       <div className="flex shrink-0 items-center gap-1">
-        {IMAGE_TABS.map((tab) => (
+        {availableTabs.map((tab) => (
           <button
             key={tab.key}
             type="button"

--- a/web/src/components/ItemCard.tsx
+++ b/web/src/components/ItemCard.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useImageLoaded } from "@/hooks/useImageLoaded";
 import { Check, Layers } from "lucide-react";
 import ViewTransitionLink from "@/components/ViewTransitionLink";
 import type { BrowseItem } from "@/api/types";
@@ -181,7 +181,7 @@ export default function ItemCard({
   selected?: boolean;
   onToggleSelect?: (item: BrowseItem) => void;
 }) {
-  const [loaded, setLoaded] = useState(false);
+  const { loaded, onLoad } = useImageLoaded(item.poster_url);
   const thumbhashUrl = item.poster_thumbhash ? decodeThumbhash(item.poster_thumbhash) : "";
   const itemHref = `/item/${encodeURIComponent(item.content_id)}${
     libraryId ? `?libraryId=${libraryId}` : ""
@@ -218,7 +218,7 @@ export default function ItemCard({
                 src={item.poster_url}
                 alt={displayTitle}
                 className={`h-full w-full object-cover transition-opacity duration-300 ${loaded ? "opacity-100" : "opacity-0"}`}
-                onLoad={() => setLoaded(true)}
+                onLoad={onLoad}
               />
             ) : (
               <div className="text-muted-foreground flex h-full w-full flex-col items-center justify-center gap-1 p-3 text-center text-sm">

--- a/web/src/components/SectionItemCard.tsx
+++ b/web/src/components/SectionItemCard.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useImageLoaded } from "@/hooks/useImageLoaded";
 import ViewTransitionLink from "@/components/ViewTransitionLink";
 import MediaItemMenu from "@/components/MediaItemMenu";
 import CardOverlays from "@/components/overlays/CardOverlays";
@@ -21,7 +21,7 @@ interface SectionItemCardProps {
 }
 
 export default function SectionItemCard({ item, libraryId }: SectionItemCardProps) {
-  const [loaded, setLoaded] = useState(false);
+  const { loaded, onLoad } = useImageLoaded(item.poster_url);
   const thumbhashUrl = item.poster_thumbhash ? decodeThumbhash(item.poster_thumbhash) : "";
   const itemHref = `/item/${encodeURIComponent(item.content_id)}${
     libraryId ? `?libraryId=${libraryId}` : ""
@@ -57,7 +57,7 @@ export default function SectionItemCard({ item, libraryId }: SectionItemCardProp
                 alt={item.title}
                 className={`h-full w-full object-cover transition-opacity duration-300 ${loaded ? "opacity-100" : "opacity-0"}`}
                 loading="lazy"
-                onLoad={() => setLoaded(true)}
+                onLoad={onLoad}
               />
             ) : (
               <div className="text-muted-foreground flex h-full w-full flex-col items-center justify-center gap-1 p-3 text-center text-sm">

--- a/web/src/components/collections/CollectionPosterCard.tsx
+++ b/web/src/components/collections/CollectionPosterCard.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useImageLoaded } from "@/hooks/useImageLoaded";
 import { Pin, PinOff, User } from "lucide-react";
 import type { LibraryTabCollection } from "@/api/types";
 import { useToggleSidebarPin } from "@/hooks/queries/sidebarPins";
@@ -23,7 +23,7 @@ export function CollectionPosterCard({
   kind: "regular" | "user_collections";
   libraryId: number;
 }) {
-  const [loaded, setLoaded] = useState(false);
+  const { loaded, onLoad } = useImageLoaded(collection.poster_url);
   const navigate = useViewTransitionNavigate();
   const { togglePin, isPinned } = useToggleSidebarPin();
   const pinned = isPinned(libraryId, "collection", collection.id);
@@ -45,7 +45,7 @@ export function CollectionPosterCard({
                 loaded ? "opacity-100" : "opacity-0"
               }`}
               loading="lazy"
-              onLoad={() => setLoaded(true)}
+              onLoad={onLoad}
             />
           ) : (
             <div className="text-muted-foreground flex h-full w-full flex-col items-center justify-center gap-1 p-3 text-center text-sm">

--- a/web/src/hooks/useImageLoaded.ts
+++ b/web/src/hooks/useImageLoaded.ts
@@ -1,0 +1,18 @@
+import { useCallback, useState } from "react";
+
+/**
+ * Tracks whether the image at `url` has finished loading, keyed by URL.
+ *
+ * Artwork URLs change in place when a new immutable revision is published; a
+ * plain boolean load flag would keep showing the previous revision's pixels at
+ * full opacity while the replacement is still fetching. Keying the loaded
+ * state by URL makes a changed `src` start hidden until its own load event.
+ */
+export function useImageLoaded(url: string | undefined | null): {
+  loaded: boolean;
+  onLoad: () => void;
+} {
+  const [loadedUrl, setLoadedUrl] = useState("");
+  const onLoad = useCallback(() => setLoadedUrl(url ?? ""), [url]);
+  return { loaded: !!url && loadedUrl === url, onLoad };
+}

--- a/web/src/pages/ItemDetail/DetailHero.test.tsx
+++ b/web/src/pages/ItemDetail/DetailHero.test.tsx
@@ -1,0 +1,23 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+
+import DetailHero from "./DetailHero";
+
+describe("DetailHero artwork revisions", () => {
+  it("treats a changed poster URL as unloaded until that revision finishes loading", () => {
+    const { rerender } = render(<DetailHero title="Blade Runner" posterUrl="/poster.rev-a.webp" />);
+
+    const first = screen.getByRole("img", { name: "Blade Runner" });
+    expect(first).toHaveClass("opacity-0");
+    fireEvent.load(first);
+    expect(first).toHaveClass("opacity-100");
+
+    rerender(<DetailHero title="Blade Runner" posterUrl="/poster.rev-b.webp" />);
+
+    const replacement = screen.getByRole("img", { name: "Blade Runner" });
+    expect(replacement).toHaveAttribute("src", "/poster.rev-b.webp");
+    expect(replacement).toHaveClass("opacity-0");
+    fireEvent.load(replacement);
+    expect(replacement).toHaveClass("opacity-100");
+  });
+});

--- a/web/src/pages/ItemDetail/DetailHero.tsx
+++ b/web/src/pages/ItemDetail/DetailHero.tsx
@@ -62,11 +62,13 @@ export default function DetailHero({
   variant = "full",
   topNav,
 }: DetailHeroProps) {
-  const [backdropLoaded, setBackdropLoaded] = useState(false);
-  const [posterLoaded, setPosterLoaded] = useState(false);
+  const [loadedBackdropUrl, setLoadedBackdropUrl] = useState("");
+  const [loadedPosterUrl, setLoadedPosterUrl] = useState("");
   const backdropPlaceholder = backdropThumbhash ? decodeThumbhash(backdropThumbhash) : "";
   const posterPlaceholder = posterThumbhash ? decodeThumbhash(posterThumbhash) : "";
   const isCompact = variant === "compact";
+  const backdropLoaded = !!backdropUrl && loadedBackdropUrl === backdropUrl;
+  const posterLoaded = !!posterUrl && loadedPosterUrl === posterUrl;
 
   const posterSizeClass = (() => {
     switch (posterOrientation) {
@@ -119,7 +121,7 @@ export default function DetailHero({
               alt=""
               className={`h-full w-full object-cover object-[center_20%] transition-opacity duration-300 will-change-transform ${backdropLoaded ? "opacity-100" : "opacity-0"}`}
               style={{ animation: "var(--animate-ken-burns-a)" }}
-              onLoad={() => setBackdropLoaded(true)}
+              onLoad={() => setLoadedBackdropUrl(backdropUrl)}
             />
           )}
         </div>
@@ -168,7 +170,7 @@ export default function DetailHero({
                     src={posterUrl}
                     alt={title}
                     className={`w-full object-cover ${posterAspect} transition-opacity duration-300 ${posterLoaded ? "opacity-100" : "opacity-0"}`}
-                    onLoad={() => setPosterLoaded(true)}
+                    onLoad={() => setLoadedPosterUrl(posterUrl)}
                   />
                 ) : (
                   <div

--- a/web/src/pages/ItemDetail/DetailHero.tsx
+++ b/web/src/pages/ItemDetail/DetailHero.tsx
@@ -1,6 +1,7 @@
-import { type ReactNode, useState } from "react";
+import { type ReactNode } from "react";
 import { Languages } from "lucide-react";
 import { decodeThumbhash } from "@/lib/thumbhash";
+import { useImageLoaded } from "@/hooks/useImageLoaded";
 
 interface DetailHeroProps {
   title: string;
@@ -62,13 +63,11 @@ export default function DetailHero({
   variant = "full",
   topNav,
 }: DetailHeroProps) {
-  const [loadedBackdropUrl, setLoadedBackdropUrl] = useState("");
-  const [loadedPosterUrl, setLoadedPosterUrl] = useState("");
+  const { loaded: backdropLoaded, onLoad: onBackdropLoad } = useImageLoaded(backdropUrl);
+  const { loaded: posterLoaded, onLoad: onPosterLoad } = useImageLoaded(posterUrl);
   const backdropPlaceholder = backdropThumbhash ? decodeThumbhash(backdropThumbhash) : "";
   const posterPlaceholder = posterThumbhash ? decodeThumbhash(posterThumbhash) : "";
   const isCompact = variant === "compact";
-  const backdropLoaded = !!backdropUrl && loadedBackdropUrl === backdropUrl;
-  const posterLoaded = !!posterUrl && loadedPosterUrl === posterUrl;
 
   const posterSizeClass = (() => {
     switch (posterOrientation) {
@@ -121,7 +120,7 @@ export default function DetailHero({
               alt=""
               className={`h-full w-full object-cover object-[center_20%] transition-opacity duration-300 will-change-transform ${backdropLoaded ? "opacity-100" : "opacity-0"}`}
               style={{ animation: "var(--animate-ken-burns-a)" }}
-              onLoad={() => setLoadedBackdropUrl(backdropUrl)}
+              onLoad={onBackdropLoad}
             />
           )}
         </div>
@@ -170,7 +169,7 @@ export default function DetailHero({
                     src={posterUrl}
                     alt={title}
                     className={`w-full object-cover ${posterAspect} transition-opacity duration-300 ${posterLoaded ? "opacity-100" : "opacity-0"}`}
-                    onLoad={() => setLoadedPosterUrl(posterUrl)}
+                    onLoad={onPosterLoad}
                   />
                 ) : (
                   <div


### PR DESCRIPTION
## Summary

- publish cached artwork under immutable content-revision keys
- update poster URLs immediately through the existing realtime metadata event flow
- atomically publish manual selections and preserve image locks
- track every immutable upload before S3 writes, including background cache jobs
- reclaim unpublished and displaced revisions with a delayed, reference-aware garbage collector

Related to #348. This addresses the separate artwork-overwrite path where a successful database update could continue resolving the previous mutable S3 object and cached URL.

## Root cause

Artwork variants previously reused deterministic object keys. Replacing a poster overwrote those keys while presigned URLs, browser caches, and resolver caches still identified the old resource. The API could therefore report success without clients observing a new resource identity.

The first immutable-key implementation also left two lifecycle gaps: background cache jobs could orphan uploaded revisions, and garbage collection could race a concurrent re-selection between its reference check and S3 deletion.

## Implementation

- derive one SHA-256 revision from the complete generated variant set and include it in every variant key
- verify existing immutable objects with stored SHA-256 metadata before skipping uploads
- register exact revision manifests before uploading; failed or skipped publications remain collectible
- use database triggers on every cached-artwork catalog surface to reactivate displaced manifests regardless of which writer performs the update
- park referenced manifests with no scheduled polling and reactivate them only when displaced
- hold the revision row lock across the collector's final reference check and S3 deletion, serializing deletion with concurrent retracking/re-upload
- publish realtime metadata events after the database transaction commits
- make `DetailHero` track load state per URL so a changed revision fades in only after the replacement has loaded

## Impact and risk

The migration adds an artwork revision registry, displacement triggers, and an hourly cleanup task. Deletion retains a 24-hour grace period and checks every catalog artwork surface before touching S3. Existing legacy keys remain readable; new writes use immutable revision keys.

## Validation

- `go test` for all changed backend packages
- PostgreSQL integration tests for delete/retrack serialization, referenced-revision parking, and trigger-driven displacement
- `golangci-lint run --new-from-rev=HEAD` (zero new findings)
- `make build`
- `make migrate-validate`
- `make verify-local-paths`
- `pnpm run lint` (zero errors; existing warnings remain)
- `pnpm run format:check`
- focused `DetailHero` Vitest

The repository-wide Go suite still has unrelated host-sensitive failures in existing Jellyfin process-lock and NVENC detection tests. The complete frontend Vitest run also has existing failures in compatibility-proxy/setup-wizard tests. None of those files are modified here.

## AI use disclosure

Implemented and reviewed with Codex assistance. The concurrency protocol, migration, and regression tests were exercised against the local PostgreSQL/S3 development environment before publication.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Artwork image updates now use immutable revisions for consistent replacements.
  * Admin image applications now return the applied image URL and revision details.
  * Added automatic cleanup for displaced, no-longer-used artwork revisions.
  * Season items now show poster-only image options in the image selector.

* **Bug Fixes**
  * Prevented stale poster/backdrop thumbnails by resetting image load state per URL.
  * Improved support for cached artwork variants across posters, backdrops, logos, covers, and stills.
  * Added safeguards to avoid incomplete uploads when revision tracking fails.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->