### PR TITLE
feat(notifications): add Android FCM push delivery via the relay

### DIFF
--- a/internal/api/handlers/admin.go
+++ b/internal/api/handlers/admin.go
@@ -2243,10 +2243,11 @@ func (h *AdminHandler) HandleUpdateSetting(w http.ResponseWriter, r *http.Reques
 				"subtitle_ai.transcribe_quota_period must be day, week, or month")
 			return
 		}
-	case notifications.SettingApplePushDeliveryEnabled:
+	case notifications.SettingApplePushDeliveryEnabled,
+		notifications.SettingAndroidPushDeliveryEnabled:
 		enabled, err := strconv.ParseBool(strings.TrimSpace(req.Value))
 		if err != nil {
-			writeError(w, http.StatusBadRequest, "bad_request", "notifications.apple_push_delivery_enabled must be true or false")
+			writeError(w, http.StatusBadRequest, "bad_request", key+" must be true or false")
 			return
 		}
 		req.Value = strconv.FormatBool(enabled)

--- a/internal/api/handlers/admin_apple_push.go
+++ b/internal/api/handlers/admin_apple_push.go
@@ -1,6 +1,7 @@
 package handlers
 
 import (
+	"context"
 	"encoding/json"
 	"errors"
 	"math"
@@ -64,8 +65,21 @@ type adminPushRelayRegisterResponse struct {
 
 // HandleTest handles POST /admin/notifications/push/apple/test.
 func (h *AdminApplePushHandler) HandleTest(w http.ResponseWriter, r *http.Request) {
+	h.handleTest(w, r, "Apple", func(ctx context.Context, profileID, serverDeviceID string) (*notifications.ApplePushTestResult, error) {
+		return h.system.SendApplePushTest(ctx, profileID, serverDeviceID)
+	})
+}
+
+// HandleTestAndroid handles POST /admin/notifications/push/fcm/test.
+func (h *AdminApplePushHandler) HandleTestAndroid(w http.ResponseWriter, r *http.Request) {
+	h.handleTest(w, r, "Android", func(ctx context.Context, profileID, serverDeviceID string) (*notifications.ApplePushTestResult, error) {
+		return h.system.SendAndroidPushTest(ctx, profileID, serverDeviceID)
+	})
+}
+
+func (h *AdminApplePushHandler) handleTest(w http.ResponseWriter, r *http.Request, platformLabel string, send func(context.Context, string, string) (*notifications.ApplePushTestResult, error)) {
 	if h == nil || h.system == nil {
-		writeError(w, http.StatusServiceUnavailable, "unavailable", "Apple push delivery is not available")
+		writeError(w, http.StatusServiceUnavailable, "unavailable", platformLabel+" push delivery is not available")
 		return
 	}
 	var req adminApplePushTestRequest
@@ -73,17 +87,17 @@ func (h *AdminApplePushHandler) HandleTest(w http.ResponseWriter, r *http.Reques
 		writeError(w, http.StatusBadRequest, "bad_request", "Invalid request body")
 		return
 	}
-	result, err := h.system.SendApplePushTest(r.Context(), req.ProfileID, req.ServerDeviceID)
+	result, err := send(r.Context(), req.ProfileID, req.ServerDeviceID)
 	if err != nil {
 		switch {
 		case errors.Is(err, notifications.ErrPushDeliveryInvalid):
 			writeError(w, http.StatusBadRequest, "bad_request", err.Error())
 		case errors.Is(err, notifications.ErrPushDeliveryNotFound):
-			writeError(w, http.StatusNotFound, "not_found", "Apple push device not found")
+			writeError(w, http.StatusNotFound, "not_found", platformLabel+" push device not found")
 		case errors.Is(err, notifications.ErrPushDeliveryUnavailable):
-			writeError(w, http.StatusServiceUnavailable, "unavailable", "Apple push delivery is not available")
+			writeError(w, http.StatusServiceUnavailable, "unavailable", platformLabel+" push delivery is not available")
 		default:
-			writeError(w, http.StatusInternalServerError, "internal_error", "Failed to send Apple push test")
+			writeError(w, http.StatusInternalServerError, "internal_error", "Failed to send "+platformLabel+" push test")
 		}
 		return
 	}

--- a/internal/api/handlers/notifications.go
+++ b/internal/api/handlers/notifications.go
@@ -388,21 +388,30 @@ func (h *NotificationsHandler) HandleCapability(w http.ResponseWriter, r *http.R
 		}
 	}
 	applePush := capabilityPush{Available: false, Provider: "off", SupportedModes: []string{"in_app_only"}}
+	androidPush := capabilityPush{Available: false, Provider: "off", SupportedModes: []string{"in_app_only"}}
 	// Like web push above, availability requires both the wiring (cipher/store)
 	// and the admin delivery toggle: Available must mean "setup will actually
 	// deliver", not "the server could store a token".
-	if h.system.PushDevices != nil && h.system.PushDevices.Available() &&
-		h.system.Settings.ApplePushDeliveryEnabled(r.Context()) {
-		applePush = capabilityPush{
-			Available:      true,
-			Provider:       notifications.PushProviderSiloRelay,
-			SupportedModes: []string{notifications.PushModePrivatePush, notifications.PushModeInAppOnly},
+	if h.system.PushDevices != nil && h.system.PushDevices.Available() {
+		if h.system.Settings.ApplePushDeliveryEnabled(r.Context()) {
+			applePush = capabilityPush{
+				Available:      true,
+				Provider:       notifications.PushProviderSiloRelay,
+				SupportedModes: []string{notifications.PushModePrivatePush, notifications.PushModeInAppOnly},
+			}
+		}
+		if h.system.Settings.AndroidPushDeliveryEnabled(r.Context()) {
+			androidPush = capabilityPush{
+				Available:      true,
+				Provider:       notifications.PushProviderSiloRelay,
+				SupportedModes: []string{notifications.PushModePrivatePush, notifications.PushModeInAppOnly},
+			}
 		}
 	}
 	writeJSON(w, http.StatusOK, capabilityResponse{
 		InApp:       capabilityInApp{Enabled: h.system.Settings.UIEnabled(r.Context())},
 		ApplePush:   applePush,
-		AndroidPush: capabilityPush{Available: false, Provider: "off", SupportedModes: []string{"in_app_only"}},
+		AndroidPush: androidPush,
 		WebPush:     webPush,
 		Webhooks:    webhooks,
 		Email:       email,

--- a/internal/api/handlers/notifications_push_devices.go
+++ b/internal/api/handlers/notifications_push_devices.go
@@ -7,6 +7,7 @@ import (
 
 	apimw "github.com/Silo-Server/silo-server/internal/api/middleware"
 	"github.com/Silo-Server/silo-server/internal/notifications"
+	"github.com/go-chi/chi/v5"
 )
 
 type applePushRegisterRequest struct {
@@ -72,4 +73,81 @@ func (h *NotificationsHandler) HandleRegisterApplePushDevice(w http.ResponseWrit
 		Enabled:        device.Enabled,
 		PushMode:       device.PushMode,
 	})
+}
+
+type pushDeviceRegisterRequest struct {
+	Platform string `json:"platform"`
+	Token    string `json:"token"`
+	DeviceID string `json:"device_id"`
+	PushMode string `json:"push_mode"`
+}
+
+// HandleRegisterPushDevice handles POST /notifications/push/devices, the
+// platform-generic registration used by the Android client. Apple installs
+// keep the dedicated /devices/push/apple route because their registration
+// carries APNs-specific fields (environment, topic).
+func (h *NotificationsHandler) HandleRegisterPushDevice(w http.ResponseWriter, r *http.Request) {
+	service := h.pushDevices()
+	if service == nil || !service.Available() {
+		writeError(w, http.StatusServiceUnavailable, "unavailable", "Push registration is not available")
+		return
+	}
+
+	var req pushDeviceRegisterRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		writeError(w, http.StatusBadRequest, "bad_request", "Invalid request body")
+		return
+	}
+	if req.Platform != notifications.PushPlatformAndroid {
+		writeError(w, http.StatusUnprocessableEntity, "unsupported_push_device", "platform is not supported on this endpoint")
+		return
+	}
+
+	device, err := service.RegisterFCM(r.Context(), apimw.GetUserID(r.Context()), apimw.GetProfileID(r.Context()), notifications.FCMPushRegistrationInput{
+		DeviceID: req.DeviceID,
+		FCMToken: req.Token,
+		PushMode: req.PushMode,
+	})
+	if err != nil {
+		switch {
+		case errors.Is(err, notifications.ErrPushDeviceInvalid):
+			writeError(w, http.StatusBadRequest, "bad_request", err.Error())
+		case errors.Is(err, notifications.ErrPushDeviceUnsupported):
+			writeError(w, http.StatusUnprocessableEntity, "unsupported_push_device", err.Error())
+		case errors.Is(err, notifications.ErrPushDeviceUnavailable):
+			writeError(w, http.StatusServiceUnavailable, "unavailable", "Push registration is not available")
+		default:
+			writeError(w, http.StatusInternalServerError, "internal_error", "Failed to register push device")
+		}
+		return
+	}
+
+	writeJSON(w, http.StatusOK, applePushRegisterResponse{
+		ID:             device.ID,
+		ServerDeviceID: device.ServerDeviceID,
+		Enabled:        device.Enabled,
+		PushMode:       device.PushMode,
+	})
+}
+
+// HandleUnregisterPushDevice handles DELETE /notifications/push/devices/{device_id}.
+func (h *NotificationsHandler) HandleUnregisterPushDevice(w http.ResponseWriter, r *http.Request) {
+	service := h.pushDevices()
+	if service == nil || !service.Available() {
+		writeError(w, http.StatusServiceUnavailable, "unavailable", "Push registration is not available")
+		return
+	}
+	err := service.Unregister(r.Context(), apimw.GetProfileID(r.Context()), chi.URLParam(r, "device_id"))
+	if err != nil {
+		switch {
+		case errors.Is(err, notifications.ErrPushDeviceInvalid):
+			writeError(w, http.StatusBadRequest, "bad_request", err.Error())
+		case errors.Is(err, notifications.ErrPushDeviceUnavailable):
+			writeError(w, http.StatusServiceUnavailable, "unavailable", "Push registration is not available")
+		default:
+			writeError(w, http.StatusInternalServerError, "internal_error", "Failed to unregister push device")
+		}
+		return
+	}
+	w.WriteHeader(http.StatusNoContent)
 }

--- a/internal/api/handlers/notifications_push_devices_test.go
+++ b/internal/api/handlers/notifications_push_devices_test.go
@@ -15,10 +15,12 @@ import (
 )
 
 type handlerPushStore struct {
-	got    notifications.ApplePushDeviceRegistration
-	calls  int
-	device *notifications.PushDevice
-	err    error
+	got     notifications.ApplePushDeviceRegistration
+	gotFCM  notifications.FCMPushDeviceRegistration
+	calls   int
+	device  *notifications.PushDevice
+	err     error
+	deleted []string
 }
 
 func (f *handlerPushStore) UpsertApple(ctx context.Context, registration notifications.ApplePushDeviceRegistration, cipher *secret.Cipher) (*notifications.PushDevice, error) {
@@ -36,6 +38,29 @@ func (f *handlerPushStore) UpsertApple(ctx context.Context, registration notific
 		Enabled:        true,
 		PushMode:       registration.PushMode,
 	}, nil
+}
+
+func (f *handlerPushStore) UpsertFCM(ctx context.Context, registration notifications.FCMPushDeviceRegistration, cipher *secret.Cipher) (*notifications.PushDevice, error) {
+	f.calls++
+	f.gotFCM = registration
+	if f.err != nil {
+		return nil, f.err
+	}
+	if f.device != nil {
+		return f.device, nil
+	}
+	return &notifications.PushDevice{
+		ID:             "push-row-android",
+		Platform:       notifications.PushPlatformAndroid,
+		ServerDeviceID: "server-device-android",
+		Enabled:        true,
+		PushMode:       registration.PushMode,
+	}, nil
+}
+
+func (f *handlerPushStore) DeleteByProfileDevice(ctx context.Context, profileID, deviceID string) error {
+	f.deleted = append(f.deleted, profileID+"/"+deviceID)
+	return f.err
 }
 
 func handlerPushCipher(t *testing.T) *secret.Cipher {
@@ -85,6 +110,68 @@ func TestHandleRegisterApplePushDevice(t *testing.T) {
 	}
 	if store.got.UserID != 42 || store.got.ProfileID != "profile-1" || store.got.DeviceID != "local-device" {
 		t.Fatalf("unexpected stored registration: %+v", store.got)
+	}
+}
+
+func newPushDevicesRequest(method, target, body string) *http.Request {
+	req := httptest.NewRequest(method, target, strings.NewReader(body))
+	ctx := apimw.SetClaims(req.Context(), &auth.Claims{UserID: 42, Role: "user", TokenType: auth.TokenTypeAccess})
+	ctx = apimw.SetProfileID(ctx, "profile-1")
+	return req.WithContext(ctx)
+}
+
+func TestHandleRegisterPushDeviceAndroid(t *testing.T) {
+	store := &handlerPushStore{}
+	handler := NewNotificationsHandler(&notifications.System{
+		PushDevices: notifications.NewPushDeviceService(store, handlerPushCipher(t)),
+	}, nil)
+
+	token := strings.Repeat("F", 140)
+	body := `{
+		"platform":"android",
+		"token":"` + token + `",
+		"device_id":"local-device",
+		"push_mode":"private_push"
+	}`
+	rr := httptest.NewRecorder()
+	handler.HandleRegisterPushDevice(rr, newPushDevicesRequest(http.MethodPost, "/api/v1/notifications/push/devices", body))
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("status = %d, body = %s", rr.Code, rr.Body.String())
+	}
+	var response applePushRegisterResponse
+	if err := json.NewDecoder(rr.Body).Decode(&response); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if response.ID != "push-row-android" || response.PushMode != notifications.PushModePrivatePush {
+		t.Fatalf("unexpected response: %+v", response)
+	}
+	if store.gotFCM.UserID != 42 || store.gotFCM.ProfileID != "profile-1" || store.gotFCM.FCMToken != token {
+		t.Fatalf("unexpected stored registration: %+v", store.gotFCM)
+	}
+}
+
+func TestHandleRegisterPushDeviceRejectsUnknownPlatformAndBadToken(t *testing.T) {
+	newHandler := func() *NotificationsHandler {
+		return NewNotificationsHandler(&notifications.System{
+			PushDevices: notifications.NewPushDeviceService(&handlerPushStore{}, handlerPushCipher(t)),
+		}, nil)
+	}
+
+	rr := httptest.NewRecorder()
+	newHandler().HandleRegisterPushDevice(rr, newPushDevicesRequest(http.MethodPost,
+		"/api/v1/notifications/push/devices",
+		`{"platform":"apple","token":"`+strings.Repeat("F", 140)+`","device_id":"local-device"}`))
+	if rr.Code != http.StatusUnprocessableEntity {
+		t.Fatalf("apple platform status = %d, want 422", rr.Code)
+	}
+
+	rr = httptest.NewRecorder()
+	newHandler().HandleRegisterPushDevice(rr, newPushDevicesRequest(http.MethodPost,
+		"/api/v1/notifications/push/devices",
+		`{"platform":"android","token":"short","device_id":"local-device"}`))
+	if rr.Code != http.StatusBadRequest {
+		t.Fatalf("bad token status = %d, want 400", rr.Code)
 	}
 }
 

--- a/internal/api/router.go
+++ b/internal/api/router.go
@@ -1824,6 +1824,10 @@ func NewRouter(deps Dependencies) chi.Router {
 						r.Get("/preferences", notificationsHandler.HandleGetPreferences)
 						r.Put("/preferences", notificationsHandler.HandleUpdatePreferences)
 						r.Get("/push/apple/display/{delivery_id}", notificationsHandler.HandleApplePushDisplay)
+						// Platform-generic registration used by the Android
+						// client; Apple keeps its dedicated route above.
+						r.Post("/push/devices", notificationsHandler.HandleRegisterPushDevice)
+						r.Delete("/push/devices/{device_id}", notificationsHandler.HandleUnregisterPushDevice)
 						r.Get("/email-preferences", notificationsHandler.HandleGetEmailPreferences)
 						r.Put("/email-preferences", notificationsHandler.HandleUpdateEmailPreferences)
 						r.Put("/email-preferences/address", notificationsHandler.HandleRequestEmailAddress)
@@ -2547,6 +2551,7 @@ func NewRouter(deps Dependencies) chi.Router {
 								applePushHandler := handlers.NewAdminApplePushHandler(deps.Notifications, settingsRepo)
 								if deps.Notifications != nil {
 									r.Post("/notifications/push/apple/test", applePushHandler.HandleTest)
+									r.Post("/notifications/push/fcm/test", applePushHandler.HandleTestAndroid)
 								}
 								if settingsRepo != nil {
 									r.Post("/notifications/push/relay/register", applePushHandler.HandleRegisterRelay)

--- a/internal/notifications/fanout_worker.go
+++ b/internal/notifications/fanout_worker.go
@@ -354,10 +354,15 @@ type pendingDelivery struct {
 	flags    ReasonFlags
 }
 
-// enqueuePushOutbox inserts pending Apple push attempt rows for each newly
-// inserted delivery and enabled private-push device.
+// enqueuePushOutbox inserts pending push attempt rows for each newly inserted
+// delivery and enabled private-push device on every admin-enabled platform
+// (Apple and Android).
 func (w *FanoutWorker) enqueuePushOutbox(ctx context.Context, tx pgx.Tx, inserted []InsertedDelivery) error {
-	if w.pushDevices == nil || len(inserted) == 0 || !w.settings.ApplePushDeliveryEnabled(ctx) {
+	if w.pushDevices == nil || len(inserted) == 0 {
+		return nil
+	}
+	platforms := w.settings.EnabledPushPlatforms(ctx)
+	if len(platforms) == 0 {
 		return nil
 	}
 	profileSet := make(map[string]struct{}, len(inserted))
@@ -368,7 +373,7 @@ func (w *FanoutWorker) enqueuePushOutbox(ctx context.Context, tx pgx.Tx, inserte
 			profileIDs = append(profileIDs, row.ProfileID)
 		}
 	}
-	devicesByProfile, err := w.pushDevices.ListEnabledAppleByProfiles(ctx, tx, profileIDs)
+	devicesByProfile, err := w.pushDevices.ListEnabledPushByProfiles(ctx, tx, profileIDs, platforms)
 	if err != nil {
 		return err
 	}

--- a/internal/notifications/operational_dispatch.go
+++ b/internal/notifications/operational_dispatch.go
@@ -79,14 +79,16 @@ func (s *System) DispatchOperational(ctx context.Context, delivery Delivery, opt
 			return nil, err
 		}
 	}
-	if s.pushDeviceRepo != nil && s.Settings.ApplePushDeliveryEnabled(ctx) {
-		devicesByProfile, err := s.pushDeviceRepo.ListEnabledAppleByProfiles(ctx, tx, []string{delivery.ProfileID})
-		if err != nil {
-			return nil, err
-		}
-		attempts := newPushDeliveryAttempts(row.ID, devicesByProfile[delivery.ProfileID])
-		if err := s.pushDeviceRepo.EnqueuePushAttempts(ctx, tx, attempts); err != nil {
-			return nil, err
+	if s.pushDeviceRepo != nil {
+		if platforms := s.Settings.EnabledPushPlatforms(ctx); len(platforms) > 0 {
+			devicesByProfile, err := s.pushDeviceRepo.ListEnabledPushByProfiles(ctx, tx, []string{delivery.ProfileID}, platforms)
+			if err != nil {
+				return nil, err
+			}
+			attempts := newPushDeliveryAttempts(row.ID, devicesByProfile[delivery.ProfileID])
+			if err := s.pushDeviceRepo.EnqueuePushAttempts(ctx, tx, attempts); err != nil {
+				return nil, err
+			}
 		}
 	}
 	if err := tx.Commit(ctx); err != nil {

--- a/internal/notifications/push_delivery.go
+++ b/internal/notifications/push_delivery.go
@@ -58,6 +58,8 @@ func newPushDeliveryAttempts(deliveryID string, devices []PushDevice) []PushDeli
 			NotificationDeliveryID: &deliveryID,
 			PushDeviceID:           device.ID,
 			TriggerType:            PushTriggerDelivery,
+			Provider:               device.Provider,
+			Platform:               device.Platform,
 		})
 	}
 	return attempts
@@ -98,20 +100,21 @@ func scanPushDeliveryAttempts(rows pgx.Rows) ([]PushDeliveryAttempt, error) {
 	return attempts, rows.Err()
 }
 
-// ListEnabledAppleByProfiles loads delivery-eligible APNs devices keyed by profile.
-func (r *PushDeviceRepository) ListEnabledAppleByProfiles(ctx context.Context, tx pgx.Tx, profileIDs []string) (map[string][]PushDevice, error) {
+// ListEnabledPushByProfiles loads delivery-eligible push devices for the
+// admin-enabled platforms, keyed by profile.
+func (r *PushDeviceRepository) ListEnabledPushByProfiles(ctx context.Context, tx pgx.Tx, profileIDs, platforms []string) (map[string][]PushDevice, error) {
 	out := make(map[string][]PushDevice, len(profileIDs))
-	if len(profileIDs) == 0 {
+	if len(profileIDs) == 0 || len(platforms) == 0 {
 		return out, nil
 	}
 	rows, err := tx.Query(ctx, `SELECT `+pushDeviceColumns+`
 		FROM push_devices
 		WHERE profile_id = ANY($1)
-		  AND platform = $2
+		  AND platform = ANY($2)
 		  AND provider = $3
 		  AND push_mode = $4
 		  AND enabled`,
-		profileIDs, PushPlatformApple, PushProviderSiloRelay, PushModePrivatePush)
+		profileIDs, platforms, PushProviderSiloRelay, PushModePrivatePush)
 	if err != nil {
 		return nil, fmt.Errorf("list enabled push devices: %w", err)
 	}
@@ -149,8 +152,8 @@ func (r *PushDeviceRepository) EnqueuePushAttempts(ctx context.Context, tx pgx.T
 			attempt.NotificationDeliveryID,
 			attempt.PushDeviceID,
 			defaultString(attempt.TriggerType, PushTriggerDelivery),
-			PushProviderSiloRelay,
-			PushPlatformApple,
+			defaultString(attempt.Provider, PushProviderSiloRelay),
+			defaultString(attempt.Platform, PushPlatformApple),
 			0,
 			PushOutcomePending,
 		)
@@ -162,8 +165,9 @@ func (r *PushDeviceRepository) EnqueuePushAttempts(ctx context.Context, tx pgx.T
 	return nil
 }
 
-// EnqueueAppleTestAttempt creates a pending diagnostic attempt for one enabled device.
-func (r *PushDeviceRepository) EnqueueAppleTestAttempt(ctx context.Context, profileID, serverDeviceID string) (*PushDeliveryAttempt, *PushDevice, error) {
+// EnqueueTestAttempt creates a pending diagnostic attempt for one enabled
+// device on the given platform.
+func (r *PushDeviceRepository) EnqueueTestAttempt(ctx context.Context, platform, profileID, serverDeviceID string) (*PushDeliveryAttempt, *PushDevice, error) {
 	if r == nil || r.pool == nil {
 		return nil, nil, ErrPushDeliveryUnavailable
 	}
@@ -185,7 +189,7 @@ func (r *PushDeviceRepository) EnqueueAppleTestAttempt(ctx context.Context, prof
 		  AND provider = $3
 		  AND push_mode = $4
 		  AND enabled`
-	args := []any{profileID, PushPlatformApple, PushProviderSiloRelay, PushModePrivatePush}
+	args := []any{profileID, platform, PushProviderSiloRelay, PushModePrivatePush}
 	if serverDeviceID != "" {
 		args = append(args, serverDeviceID)
 		query += fmt.Sprintf(" AND server_device_id = $%d", len(args))
@@ -205,7 +209,7 @@ func (r *PushDeviceRepository) EnqueueAppleTestAttempt(ctx context.Context, prof
 		INSERT INTO push_delivery_attempts
 			(id, notification_delivery_id, push_device_id, trigger_type, provider, platform, attempt_number, outcome)
 		VALUES ($1, NULL, $2, $3, $4, $5, 0, $6)`+pushAttemptReturning,
-		attemptID, device.ID, PushTriggerTest, PushProviderSiloRelay, PushPlatformApple, PushOutcomePending)
+		attemptID, device.ID, PushTriggerTest, PushProviderSiloRelay, platform, PushOutcomePending)
 	if err != nil {
 		return nil, nil, fmt.Errorf("insert push test attempt: %w", err)
 	}

--- a/internal/notifications/push_devices.go
+++ b/internal/notifications/push_devices.go
@@ -18,6 +18,7 @@ import (
 
 const (
 	PushPlatformApple      = "apple"
+	PushPlatformAndroid    = "android"
 	PushProviderSiloRelay  = "silo_relay"
 	PushModeOff            = "off"
 	PushModeInAppOnly      = "in_app_only"
@@ -33,6 +34,8 @@ var (
 	ErrPushDeviceUnsupported = errors.New("unsupported push device registration")
 
 	apnsTokenHexPattern = regexp.MustCompile(`^[0-9a-f]+$`)
+	// The relay validates FCM registration tokens against the same shape.
+	fcmTokenPattern = regexp.MustCompile(`^[A-Za-z0-9_:-]{64,512}$`)
 )
 
 // PushDevice represents one profile-scoped notification endpoint.
@@ -47,6 +50,8 @@ type PushDevice struct {
 	APNsTopic           string
 	APNsTokenCiphertext string
 	APNsTokenHash       string
+	FCMTokenCiphertext  string
+	FCMTokenHash        string
 	ServerDeviceID      string
 	PushMode            string
 	Enabled             bool
@@ -76,8 +81,24 @@ type ApplePushDeviceRegistration struct {
 	PushMode        string
 }
 
+type FCMPushRegistrationInput struct {
+	DeviceID string
+	FCMToken string
+	PushMode string
+}
+
+type FCMPushDeviceRegistration struct {
+	UserID    int
+	ProfileID string
+	DeviceID  string
+	FCMToken  string
+	PushMode  string
+}
+
 type PushDeviceStore interface {
 	UpsertApple(ctx context.Context, registration ApplePushDeviceRegistration, cipher *secret.Cipher) (*PushDevice, error)
+	UpsertFCM(ctx context.Context, registration FCMPushDeviceRegistration, cipher *secret.Cipher) (*PushDevice, error)
+	DeleteByProfileDevice(ctx context.Context, profileID, deviceID string) error
 }
 
 type PushDeviceRepository struct {
@@ -119,6 +140,40 @@ func (s *PushDeviceService) RegisterApple(ctx context.Context, userID int, profi
 	registration.UserID = userID
 	registration.ProfileID = profileID
 	return s.store.UpsertApple(ctx, registration, s.cipher)
+}
+
+func (s *PushDeviceService) RegisterFCM(ctx context.Context, userID int, profileID string, input FCMPushRegistrationInput) (*PushDevice, error) {
+	if !s.Available() {
+		return nil, ErrPushDeviceUnavailable
+	}
+	if userID <= 0 {
+		return nil, fmt.Errorf("%w: user_id is required", ErrPushDeviceInvalid)
+	}
+	profileID = strings.TrimSpace(profileID)
+	if profileID == "" {
+		return nil, fmt.Errorf("%w: profile_id is required", ErrPushDeviceInvalid)
+	}
+	registration, err := normalizeFCMPushRegistration(input)
+	if err != nil {
+		return nil, err
+	}
+	registration.UserID = userID
+	registration.ProfileID = profileID
+	return s.store.UpsertFCM(ctx, registration, s.cipher)
+}
+
+// Unregister removes every registration this device install holds for the
+// profile, regardless of platform.
+func (s *PushDeviceService) Unregister(ctx context.Context, profileID, deviceID string) error {
+	if !s.Available() {
+		return ErrPushDeviceUnavailable
+	}
+	profileID = strings.TrimSpace(profileID)
+	deviceID = strings.TrimSpace(deviceID)
+	if profileID == "" || deviceID == "" {
+		return fmt.Errorf("%w: profile_id and device_id are required", ErrPushDeviceInvalid)
+	}
+	return s.store.DeleteByProfileDevice(ctx, profileID, deviceID)
 }
 
 func normalizeApplePushRegistration(input ApplePushRegistrationInput) (ApplePushDeviceRegistration, error) {
@@ -170,8 +225,48 @@ func normalizeApplePushRegistration(input ApplePushRegistrationInput) (ApplePush
 	}, nil
 }
 
+func normalizeFCMPushRegistration(input FCMPushRegistrationInput) (FCMPushDeviceRegistration, error) {
+	deviceID := strings.TrimSpace(input.DeviceID)
+	if deviceID == "" {
+		return FCMPushDeviceRegistration{}, fmt.Errorf("%w: device_id is required", ErrPushDeviceInvalid)
+	}
+	if len(deviceID) > 128 {
+		return FCMPushDeviceRegistration{}, fmt.Errorf("%w: device_id is too long", ErrPushDeviceInvalid)
+	}
+
+	// FCM registration tokens are case-sensitive; only trim surrounding space.
+	token := strings.TrimSpace(input.FCMToken)
+	if token == "" {
+		return FCMPushDeviceRegistration{}, fmt.Errorf("%w: token is required", ErrPushDeviceInvalid)
+	}
+	if !fcmTokenPattern.MatchString(token) {
+		return FCMPushDeviceRegistration{}, fmt.Errorf("%w: token is not a plausible FCM registration token", ErrPushDeviceInvalid)
+	}
+
+	pushMode := strings.TrimSpace(input.PushMode)
+	if pushMode == "" {
+		pushMode = PushModePrivatePush
+	}
+	switch pushMode {
+	case PushModeOff, PushModeInAppOnly, PushModePrivatePush:
+	default:
+		return FCMPushDeviceRegistration{}, fmt.Errorf("%w: push_mode is not supported", ErrPushDeviceUnsupported)
+	}
+
+	return FCMPushDeviceRegistration{
+		DeviceID: deviceID,
+		FCMToken: token,
+		PushMode: pushMode,
+	}, nil
+}
+
 func apnsTokenHash(token string) string {
 	sum := sha256.Sum256([]byte(strings.ToLower(strings.TrimSpace(token))))
+	return hex.EncodeToString(sum[:])
+}
+
+func fcmTokenHash(token string) string {
+	sum := sha256.Sum256([]byte(strings.TrimSpace(token)))
 	return hex.EncodeToString(sum[:])
 }
 
@@ -179,6 +274,12 @@ func pushDeviceAPNsTokenAAD(id string) string {
 	return secret.RowAAD("push_devices", "apns_token", id)
 }
 
+func pushDeviceFCMTokenAAD(id string) string {
+	return secret.RowAAD("push_devices", "fcm_token", id)
+}
+
+// Platform-specific token columns are NULL for the other platform's rows;
+// COALESCE keeps the scan targets plain strings.
 const pushDeviceColumns = `
 	id,
 	user_id,
@@ -186,10 +287,12 @@ const pushDeviceColumns = `
 	device_id,
 	platform,
 	provider,
-	apns_environment,
-	apns_topic,
-	apns_token_ciphertext,
-	apns_token_hash,
+	COALESCE(apns_environment, ''),
+	COALESCE(apns_topic, ''),
+	COALESCE(apns_token_ciphertext, ''),
+	COALESCE(apns_token_hash, ''),
+	COALESCE(fcm_token_ciphertext, ''),
+	COALESCE(fcm_token_hash, ''),
 	server_device_id,
 	push_mode,
 	enabled,
@@ -221,7 +324,7 @@ func (r *PushDeviceRepository) UpsertApple(ctx context.Context, registration App
 		return nil, fmt.Errorf("purge reassigned push device: %w", err)
 	}
 
-	device, err := r.selectAppleForUpdate(ctx, tx, registration.ProfileID, registration.DeviceID)
+	device, err := r.selectForUpdate(ctx, tx, registration.ProfileID, registration.DeviceID, PushPlatformApple)
 	if err != nil {
 		return nil, err
 	}
@@ -238,7 +341,7 @@ func (r *PushDeviceRepository) UpsertApple(ctx context.Context, registration App
 			return device, nil
 		}
 
-		device, err = r.selectAppleForUpdate(ctx, tx, registration.ProfileID, registration.DeviceID)
+		device, err = r.selectForUpdate(ctx, tx, registration.ProfileID, registration.DeviceID, PushPlatformApple)
 		if err != nil {
 			return nil, err
 		}
@@ -257,6 +360,61 @@ func (r *PushDeviceRepository) UpsertApple(ctx context.Context, registration App
 	return device, nil
 }
 
+func (r *PushDeviceRepository) UpsertFCM(ctx context.Context, registration FCMPushDeviceRegistration, cipher *secret.Cipher) (*PushDevice, error) {
+	if r == nil || r.pool == nil || cipher == nil {
+		return nil, ErrPushDeviceUnavailable
+	}
+
+	tx, err := r.pool.Begin(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("begin push device upsert: %w", err)
+	}
+	defer func() { _ = tx.Rollback(ctx) }()
+
+	// Same profile-switch cleanup as UpsertApple: one install notifies one
+	// profile at a time.
+	if _, err := tx.Exec(ctx,
+		`DELETE FROM push_devices WHERE device_id = $1 AND platform = $2 AND profile_id <> $3`,
+		registration.DeviceID, PushPlatformAndroid, registration.ProfileID); err != nil {
+		return nil, fmt.Errorf("purge reassigned push device: %w", err)
+	}
+
+	device, err := r.selectForUpdate(ctx, tx, registration.ProfileID, registration.DeviceID, PushPlatformAndroid)
+	if err != nil {
+		return nil, err
+	}
+
+	if device == nil {
+		device, err = r.insertFCM(ctx, tx, registration, cipher)
+		if err != nil && !errors.Is(err, pgx.ErrNoRows) {
+			return nil, err
+		}
+		if device != nil {
+			if err := tx.Commit(ctx); err != nil {
+				return nil, fmt.Errorf("commit push device insert: %w", err)
+			}
+			return device, nil
+		}
+
+		device, err = r.selectForUpdate(ctx, tx, registration.ProfileID, registration.DeviceID, PushPlatformAndroid)
+		if err != nil {
+			return nil, err
+		}
+		if device == nil {
+			return nil, fmt.Errorf("push device upsert conflict row missing")
+		}
+	}
+
+	device, err = r.updateFCM(ctx, tx, registration, cipher, device)
+	if err != nil {
+		return nil, err
+	}
+	if err := tx.Commit(ctx); err != nil {
+		return nil, fmt.Errorf("commit push device update: %w", err)
+	}
+	return device, nil
+}
+
 // DeleteAllForProfile removes push registrations for a deleted profile.
 func (r *PushDeviceRepository) DeleteAllForProfile(ctx context.Context, profileID string) error {
 	if r == nil || r.pool == nil {
@@ -266,8 +424,19 @@ func (r *PushDeviceRepository) DeleteAllForProfile(ctx context.Context, profileI
 	return err
 }
 
-func (r *PushDeviceRepository) selectAppleForUpdate(ctx context.Context, tx pgx.Tx, profileID, deviceID string) (*PushDevice, error) {
-	row := tx.QueryRow(ctx, `SELECT `+pushDeviceColumns+` FROM push_devices WHERE profile_id = $1 AND device_id = $2 AND platform = $3 FOR UPDATE`, profileID, deviceID, PushPlatformApple)
+// DeleteByProfileDevice removes one install's registrations for a profile
+// across every platform (attempts cascade with the device rows).
+func (r *PushDeviceRepository) DeleteByProfileDevice(ctx context.Context, profileID, deviceID string) error {
+	if r == nil || r.pool == nil {
+		return ErrPushDeviceUnavailable
+	}
+	_, err := r.pool.Exec(ctx,
+		`DELETE FROM push_devices WHERE profile_id = $1 AND device_id = $2`, profileID, deviceID)
+	return err
+}
+
+func (r *PushDeviceRepository) selectForUpdate(ctx context.Context, tx pgx.Tx, profileID, deviceID, platform string) (*PushDevice, error) {
+	row := tx.QueryRow(ctx, `SELECT `+pushDeviceColumns+` FROM push_devices WHERE profile_id = $1 AND device_id = $2 AND platform = $3 FOR UPDATE`, profileID, deviceID, platform)
 	device, err := scanPushDevice(row)
 	if errors.Is(err, pgx.ErrNoRows) {
 		return nil, nil
@@ -364,6 +533,84 @@ func (r *PushDeviceRepository) updateApple(ctx context.Context, tx pgx.Tx, regis
 	return device, nil
 }
 
+func (r *PushDeviceRepository) insertFCM(ctx context.Context, tx pgx.Tx, registration FCMPushDeviceRegistration, cipher *secret.Cipher) (*PushDevice, error) {
+	id := ulid.Make().String()
+	serverDeviceID := ulid.Make().String()
+	ciphertext, err := cipher.Encrypt(registration.FCMToken, pushDeviceFCMTokenAAD(id))
+	if err != nil {
+		return nil, fmt.Errorf("encrypt fcm token: %w", err)
+	}
+
+	row := tx.QueryRow(ctx, `
+		INSERT INTO push_devices (
+			id,
+			user_id,
+			profile_id,
+			device_id,
+			platform,
+			provider,
+			fcm_token_ciphertext,
+			fcm_token_hash,
+			server_device_id,
+			push_mode,
+			enabled,
+			last_seen_at
+		)
+		VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, true, now())
+		ON CONFLICT (profile_id, device_id, platform) DO NOTHING
+		RETURNING `+pushDeviceColumns,
+		id,
+		registration.UserID,
+		registration.ProfileID,
+		registration.DeviceID,
+		PushPlatformAndroid,
+		PushProviderSiloRelay,
+		ciphertext,
+		fcmTokenHash(registration.FCMToken),
+		serverDeviceID,
+		registration.PushMode,
+	)
+	device, err := scanPushDevice(row)
+	if err != nil {
+		return nil, err
+	}
+	return device, nil
+}
+
+func (r *PushDeviceRepository) updateFCM(ctx context.Context, tx pgx.Tx, registration FCMPushDeviceRegistration, cipher *secret.Cipher, existing *PushDevice) (*PushDevice, error) {
+	ciphertext, err := cipher.Encrypt(registration.FCMToken, pushDeviceFCMTokenAAD(existing.ID))
+	if err != nil {
+		return nil, fmt.Errorf("encrypt fcm token: %w", err)
+	}
+
+	row := tx.QueryRow(ctx, `
+		UPDATE push_devices
+		SET user_id = $1,
+			provider = $2,
+			fcm_token_ciphertext = $3,
+			fcm_token_hash = $4,
+			push_mode = $5,
+			enabled = true,
+			last_seen_at = now(),
+			last_failure_at = NULL,
+			last_failure_code = NULL,
+			updated_at = now()
+		WHERE id = $6
+		RETURNING `+pushDeviceColumns,
+		registration.UserID,
+		PushProviderSiloRelay,
+		ciphertext,
+		fcmTokenHash(registration.FCMToken),
+		registration.PushMode,
+		existing.ID,
+	)
+	device, err := scanPushDevice(row)
+	if err != nil {
+		return nil, fmt.Errorf("update push device: %w", err)
+	}
+	return device, nil
+}
+
 func scanPushDevice(row pgx.Row) (*PushDevice, error) {
 	var device PushDevice
 	if err := row.Scan(
@@ -377,6 +624,8 @@ func scanPushDevice(row pgx.Row) (*PushDevice, error) {
 		&device.APNsTopic,
 		&device.APNsTokenCiphertext,
 		&device.APNsTokenHash,
+		&device.FCMTokenCiphertext,
+		&device.FCMTokenHash,
 		&device.ServerDeviceID,
 		&device.PushMode,
 		&device.Enabled,

--- a/internal/notifications/push_devices_test.go
+++ b/internal/notifications/push_devices_test.go
@@ -12,10 +12,12 @@ import (
 )
 
 type fakePushDeviceStore struct {
-	got    ApplePushDeviceRegistration
-	calls  int
-	device *PushDevice
-	err    error
+	got     ApplePushDeviceRegistration
+	gotFCM  FCMPushDeviceRegistration
+	calls   int
+	device  *PushDevice
+	err     error
+	deleted []string
 }
 
 func (f *fakePushDeviceStore) UpsertApple(ctx context.Context, registration ApplePushDeviceRegistration, cipher *secret.Cipher) (*PushDevice, error) {
@@ -33,6 +35,29 @@ func (f *fakePushDeviceStore) UpsertApple(ctx context.Context, registration Appl
 		Enabled:        true,
 		PushMode:       registration.PushMode,
 	}, nil
+}
+
+func (f *fakePushDeviceStore) UpsertFCM(ctx context.Context, registration FCMPushDeviceRegistration, cipher *secret.Cipher) (*PushDevice, error) {
+	f.calls++
+	f.gotFCM = registration
+	if f.err != nil {
+		return nil, f.err
+	}
+	if f.device != nil {
+		return f.device, nil
+	}
+	return &PushDevice{
+		ID:             "device-row",
+		Platform:       PushPlatformAndroid,
+		ServerDeviceID: "server-device",
+		Enabled:        true,
+		PushMode:       registration.PushMode,
+	}, nil
+}
+
+func (f *fakePushDeviceStore) DeleteByProfileDevice(ctx context.Context, profileID, deviceID string) error {
+	f.deleted = append(f.deleted, profileID+"/"+deviceID)
+	return f.err
 }
 
 func testPushCipher(t *testing.T) *secret.Cipher {
@@ -144,6 +169,87 @@ func TestPushDeviceServiceRegisterAppleRejectsInvalidOrUnsupported(t *testing.T)
 				t.Fatalf("store was called for rejected input")
 			}
 		})
+	}
+}
+
+func TestPushDeviceServiceRegisterFCMNormalizesAndStores(t *testing.T) {
+	store := &fakePushDeviceStore{}
+	service := NewPushDeviceService(store, testPushCipher(t))
+
+	token := strings.Repeat("F", 100) + ":APA91b-" + strings.Repeat("x", 40)
+	device, err := service.RegisterFCM(context.Background(), 42, " profile-1 ", FCMPushRegistrationInput{
+		DeviceID: " local-device ",
+		FCMToken: " " + token + " ",
+		PushMode: "",
+	})
+	if err != nil {
+		t.Fatalf("register fcm: %v", err)
+	}
+	if device.ServerDeviceID != "server-device" || !device.Enabled || device.PushMode != PushModePrivatePush {
+		t.Fatalf("unexpected device response: %+v", device)
+	}
+	if store.gotFCM.UserID != 42 || store.gotFCM.ProfileID != "profile-1" || store.gotFCM.DeviceID != "local-device" {
+		t.Fatalf("unexpected owner scope: %+v", store.gotFCM)
+	}
+	if store.gotFCM.FCMToken != token {
+		t.Fatalf("fcm token was not trimmed exactly: %q", store.gotFCM.FCMToken)
+	}
+	if store.gotFCM.PushMode != PushModePrivatePush {
+		t.Fatalf("push mode = %q", store.gotFCM.PushMode)
+	}
+}
+
+func TestPushDeviceServiceRegisterFCMRejectsInvalidOrUnsupported(t *testing.T) {
+	validToken := strings.Repeat("F", 140)
+	tests := []struct {
+		name    string
+		input   FCMPushRegistrationInput
+		wantErr error
+	}{
+		{
+			name:    "missing device id",
+			input:   FCMPushRegistrationInput{DeviceID: " ", FCMToken: validToken},
+			wantErr: ErrPushDeviceInvalid,
+		},
+		{
+			name:    "short token",
+			input:   FCMPushRegistrationInput{DeviceID: "local-device", FCMToken: "abc"},
+			wantErr: ErrPushDeviceInvalid,
+		},
+		{
+			name:    "token with invalid characters",
+			input:   FCMPushRegistrationInput{DeviceID: "local-device", FCMToken: strings.Repeat("!", 140)},
+			wantErr: ErrPushDeviceInvalid,
+		},
+		{
+			name:    "unsupported push mode",
+			input:   FCMPushRegistrationInput{DeviceID: "local-device", FCMToken: validToken, PushMode: "custom_fcm"},
+			wantErr: ErrPushDeviceUnsupported,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			store := &fakePushDeviceStore{}
+			service := NewPushDeviceService(store, testPushCipher(t))
+			_, err := service.RegisterFCM(context.Background(), 42, "profile-1", tt.input)
+			if !errors.Is(err, tt.wantErr) {
+				t.Fatalf("error = %v, want %v", err, tt.wantErr)
+			}
+			if store.calls != 0 {
+				t.Fatalf("store was called for rejected input")
+			}
+		})
+	}
+}
+
+func TestPushDeviceFCMTokenHashIsCaseSensitive(t *testing.T) {
+	token := strings.Repeat("f", 140)
+	if fcmTokenHash(token) == fcmTokenHash(strings.ToUpper(token)) {
+		t.Fatal("fcm token hash must be case-sensitive")
+	}
+	if fcmTokenHash(" "+token+" ") != fcmTokenHash(token) {
+		t.Fatal("fcm token hash must ignore surrounding whitespace")
 	}
 }
 

--- a/internal/notifications/push_sender.go
+++ b/internal/notifications/push_sender.go
@@ -31,6 +31,7 @@ const (
 	pushRelayRequestTimeout = 15 * time.Second
 	pushRelayMaxRetryAfter  = 23 * time.Hour
 	relayAppleSendPath      = "/v1/apple/send"
+	relayFcmSendPath        = "/v1/fcm/send"
 )
 
 func pushRetryDelay(completedAttempt int) (time.Duration, bool) {
@@ -64,6 +65,26 @@ func terminalAPNsDeviceRejection(status int, code, message string) bool {
 	}
 }
 
+// terminalFCMDeviceRejection recognizes the relay's fcm_rejected responses
+// whose FCM error code means the registration token is permanently gone.
+// Request-level rejections (e.g. INVALID_ARGUMENT payload complaints) keep the
+// device enabled, matching the conservative APNs list above.
+func terminalFCMDeviceRejection(status int, code, message string) bool {
+	if status != http.StatusUnprocessableEntity || code != "fcm_rejected" {
+		return false
+	}
+	const prefix = "FCM rejected the notification:"
+	reason := strings.TrimSpace(strings.TrimPrefix(message, prefix))
+	return reason == "UNREGISTERED"
+}
+
+func terminalDeviceRejection(platform string, status int, code, message string) bool {
+	if platform == PushPlatformAndroid {
+		return terminalFCMDeviceRejection(status, code, message)
+	}
+	return terminalAPNsDeviceRejection(status, code, message)
+}
+
 type pushRelayAppleRequest struct {
 	Token          string  `json:"token"`
 	Environment    string  `json:"environment"`
@@ -78,6 +99,16 @@ type pushRelayAppleResponse struct {
 	RequestID string `json:"request_id"`
 	APNsID    string `json:"apns_id"`
 	Status    string `json:"status"`
+}
+
+// pushRelayFcmRequest matches the relay's /v1/fcm/send contract: no
+// environment or topic — the relay's Firebase project is the boundary.
+type pushRelayFcmRequest struct {
+	Token          string  `json:"token"`
+	Mode           string  `json:"mode"`
+	ServerDeviceID string  `json:"server_device_id"`
+	DeliveryID     string  `json:"delivery_id"`
+	CollapseID     *string `json:"collapse_id,omitempty"`
 }
 
 type pushRelayErrorResponse struct {
@@ -138,8 +169,12 @@ func (s *pushSender) processAttempt(ctx context.Context, attempt PushDeliveryAtt
 		}
 		return nil
 	}
-	if !device.Enabled || device.PushMode != PushModePrivatePush || !s.settings.ApplePushDeliveryEnabled(ctx) {
-		return s.finalize(ctx, attempt, PushOutcomeFailed, "delivery_disabled", "apple push delivery disabled", nil, "", nil)
+	deliveryEnabled := s.settings.ApplePushDeliveryEnabled(ctx)
+	if device.Platform == PushPlatformAndroid {
+		deliveryEnabled = s.settings.AndroidPushDeliveryEnabled(ctx)
+	}
+	if !device.Enabled || device.PushMode != PushModePrivatePush || !deliveryEnabled {
+		return s.finalize(ctx, attempt, PushOutcomeFailed, "delivery_disabled", "push delivery disabled", nil, "", nil)
 	}
 	if attempt.NotificationDeliveryID != nil {
 		row, err := s.deliveries.GetRowByID(ctx, *attempt.NotificationDeliveryID)
@@ -160,9 +195,13 @@ func (s *pushSender) processAttempt(ctx context.Context, attempt PushDeliveryAtt
 		}
 	}
 
-	token, err := s.cipher.Decrypt(device.APNsTokenCiphertext, pushDeviceAPNsTokenAAD(device.ID))
+	ciphertext, aad := device.APNsTokenCiphertext, pushDeviceAPNsTokenAAD(device.ID)
+	if device.Platform == PushPlatformAndroid {
+		ciphertext, aad = device.FCMTokenCiphertext, pushDeviceFCMTokenAAD(device.ID)
+	}
+	token, err := s.cipher.Decrypt(ciphertext, aad)
 	if err != nil {
-		return s.finalize(ctx, attempt, PushOutcomeFailed, "decrypt_failed", "APNs token decrypt failed", nil, "", nil)
+		return s.finalize(ctx, attempt, PushOutcomeFailed, "decrypt_failed", "push token decrypt failed", nil, "", nil)
 	}
 	result := s.send(ctx, attempt, device, token)
 	attemptNumber := attempt.AttemptNumber + 1
@@ -265,7 +304,8 @@ func (s *pushSender) sendWithCapability(ctx context.Context, attempt PushDeliver
 		deliveryID = *attempt.NotificationDeliveryID
 	}
 	collapseID := deliveryID
-	body, err := json.Marshal(pushRelayAppleRequest{
+	sendPath := relayAppleSendPath
+	var payload any = pushRelayAppleRequest{
 		Token:          token,
 		Environment:    device.APNsEnvironment,
 		Topic:          device.APNsTopic,
@@ -273,11 +313,22 @@ func (s *pushSender) sendWithCapability(ctx context.Context, attempt PushDeliver
 		ServerDeviceID: device.ServerDeviceID,
 		DeliveryID:     deliveryID,
 		CollapseID:     &collapseID,
-	})
+	}
+	if device.Platform == PushPlatformAndroid {
+		sendPath = relayFcmSendPath
+		payload = pushRelayFcmRequest{
+			Token:          token,
+			Mode:           "private_alert",
+			ServerDeviceID: device.ServerDeviceID,
+			DeliveryID:     deliveryID,
+			CollapseID:     &collapseID,
+		}
+	}
+	body, err := json.Marshal(payload)
 	if err != nil {
 		return pushSendResult{Message: "relay payload build failed", UpstreamReason: "payload_build_failed"}
 	}
-	req, err := http.NewRequestWithContext(ctx, http.MethodPost, relayURL+relayAppleSendPath, bytes.NewReader(body))
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, relayURL+sendPath, bytes.NewReader(body))
 	if err != nil {
 		return pushSendResult{Message: "invalid push relay URL", UpstreamReason: "invalid_relay_url"}
 	}
@@ -331,7 +382,7 @@ func (s *pushSender) sendWithCapability(ctx context.Context, attempt PushDeliver
 		RelayRequestID: parsed.Error.RequestID,
 		UpstreamReason: code,
 		Message:        strings.TrimSpace(message),
-		TerminalDevice: terminalAPNsDeviceRejection(resp.StatusCode, code, message),
+		TerminalDevice: terminalDeviceRejection(device.Platform, resp.StatusCode, code, message),
 	}
 }
 
@@ -379,7 +430,9 @@ func newPushDispatcher(sender *pushSender) *PushDispatcher {
 		process: func(ctx context.Context, attempt PushDeliveryAttempt) {
 			sender.processAttempt(ctx, attempt)
 		},
-		enabled:    sender.settings.ApplePushDeliveryEnabled,
+		// The dispatcher claims attempts for every platform; processAttempt
+		// applies the per-platform delivery toggle to each device.
+		enabled:    sender.settings.PushDeliveryEnabled,
 		claimDue:   sender.devices.ClaimDuePushAttempts,
 		claimLimit: pushRetryClaimLimit,
 	}}
@@ -412,16 +465,28 @@ type ApplePushTestResult struct {
 }
 
 func (s *System) SendApplePushTest(ctx context.Context, profileID, serverDeviceID string) (*ApplePushTestResult, error) {
+	return s.sendPushTest(ctx, PushPlatformApple, profileID, serverDeviceID)
+}
+
+func (s *System) SendAndroidPushTest(ctx context.Context, profileID, serverDeviceID string) (*ApplePushTestResult, error) {
+	return s.sendPushTest(ctx, PushPlatformAndroid, profileID, serverDeviceID)
+}
+
+func (s *System) sendPushTest(ctx context.Context, platform, profileID, serverDeviceID string) (*ApplePushTestResult, error) {
 	if s == nil || s.pushDeviceRepo == nil || s.pushSender == nil {
 		return nil, ErrPushDeliveryUnavailable
 	}
-	if !s.Settings.ApplePushDeliveryEnabled(ctx) {
+	deliveryEnabled := s.Settings.ApplePushDeliveryEnabled(ctx)
+	if platform == PushPlatformAndroid {
+		deliveryEnabled = s.Settings.AndroidPushDeliveryEnabled(ctx)
+	}
+	if !deliveryEnabled {
 		return nil, ErrPushDeliveryUnavailable
 	}
 	if s.Settings.PushRelayAPIKey(ctx) == "" {
 		return nil, ErrPushDeliveryUnavailable
 	}
-	attempt, device, err := s.pushDeviceRepo.EnqueueAppleTestAttempt(ctx, profileID, serverDeviceID)
+	attempt, device, err := s.pushDeviceRepo.EnqueueTestAttempt(ctx, platform, profileID, serverDeviceID)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/notifications/push_sender_test.go
+++ b/internal/notifications/push_sender_test.go
@@ -153,6 +153,143 @@ func TestPushSenderSendMapsRelayTerminalAPNsRejection(t *testing.T) {
 	}
 }
 
+func TestPushSenderSendBuildsFcmRelayRequest(t *testing.T) {
+	token := strings.Repeat("F", 140)
+	var got struct {
+		auth           string
+		idempotencyKey string
+		body           pushRelayFcmRequest
+	}
+	server := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		got.auth = r.Header.Get("Authorization")
+		got.idempotencyKey = r.Header.Get("Idempotency-Key")
+		if r.URL.Path != relayFcmSendPath {
+			t.Fatalf("path = %q, want %q", r.URL.Path, relayFcmSendPath)
+		}
+		if err := json.NewDecoder(r.Body).Decode(&got.body); err != nil {
+			t.Fatalf("decode request body: %v", err)
+		}
+		_ = json.NewEncoder(w).Encode(map[string]string{
+			"request_id":     "relay-request-fcm-1",
+			"fcm_message_id": "fcm-1",
+			"status":         "accepted",
+		})
+	}))
+	defer server.Close()
+
+	settings := NewSettings(mapSettingReader{
+		SettingPushRelayURL:    server.URL,
+		SettingPushRelayAPIKey: "relay-key",
+	})
+	sender := newPushSender(nil, nil, nil, settings)
+	sender.client = server.Client()
+	sender.developmentRelayURL = server.URL
+
+	deliveryID := "delivery-fcm-1"
+	result := sender.send(context.Background(), PushDeliveryAttempt{
+		ID:                     "attempt-fcm-1",
+		NotificationDeliveryID: &deliveryID,
+	}, &PushDevice{
+		Platform:       PushPlatformAndroid,
+		ServerDeviceID: "server-device-fcm",
+	}, token)
+
+	if !result.OK || result.RelayRequestID != "relay-request-fcm-1" {
+		t.Fatalf("result = %+v", result)
+	}
+	if got.auth != "Bearer relay-key" || got.idempotencyKey != "attempt-fcm-1" {
+		t.Fatalf("headers = %+v", got)
+	}
+	if got.body.Token != token || got.body.Mode != "private_alert" || got.body.DeliveryID != deliveryID {
+		t.Fatalf("relay body = %+v", got.body)
+	}
+	if got.body.CollapseID == nil || *got.body.CollapseID != deliveryID {
+		t.Fatalf("collapse_id = %+v, want delivery id", got.body.CollapseID)
+	}
+}
+
+func TestPushSenderSendMapsRelayTerminalFCMRejection(t *testing.T) {
+	server := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusUnprocessableEntity)
+		_ = json.NewEncoder(w).Encode(pushRelayErrorResponse{
+			Error: struct {
+				Code      string `json:"code"`
+				Message   string `json:"message"`
+				RequestID string `json:"request_id"`
+			}{
+				Code:      "fcm_rejected",
+				Message:   "FCM rejected the notification: UNREGISTERED",
+				RequestID: "relay-request-fcm-2",
+			},
+		})
+	}))
+	defer server.Close()
+
+	sender := newPushSender(nil, nil, nil, NewSettings(mapSettingReader{
+		SettingPushRelayURL:    server.URL,
+		SettingPushRelayAPIKey: "relay-key",
+	}))
+	sender.client = server.Client()
+	sender.developmentRelayURL = server.URL
+
+	result := sender.send(context.Background(), PushDeliveryAttempt{ID: "attempt-fcm-2"}, &PushDevice{
+		Platform:       PushPlatformAndroid,
+		ServerDeviceID: "server-device-fcm",
+	}, strings.Repeat("F", 140))
+
+	if result.OK || !result.TerminalDevice || result.HTTPStatus != http.StatusUnprocessableEntity {
+		t.Fatalf("terminal result = %+v", result)
+	}
+	if result.UpstreamReason != "fcm_rejected" || result.RelayRequestID != "relay-request-fcm-2" {
+		t.Fatalf("terminal diagnostic = %+v", result)
+	}
+}
+
+func TestTerminalFCMDeviceRejectionReasons(t *testing.T) {
+	if !terminalFCMDeviceRejection(http.StatusUnprocessableEntity, "fcm_rejected",
+		"FCM rejected the notification: UNREGISTERED") {
+		t.Fatal("UNREGISTERED was not terminal for the device")
+	}
+	if terminalFCMDeviceRejection(http.StatusUnprocessableEntity, "fcm_rejected",
+		"FCM rejected the notification: INVALID_ARGUMENT") {
+		t.Fatal("request-level FCM rejection was terminal for the device")
+	}
+	if terminalFCMDeviceRejection(http.StatusUnprocessableEntity, "apns_rejected",
+		"APNs rejected the notification: Unregistered") {
+		t.Fatal("APNs rejection satisfied the FCM matcher")
+	}
+	if terminalDeviceRejection(PushPlatformAndroid, http.StatusUnprocessableEntity, "fcm_rejected",
+		"FCM rejected the notification: UNREGISTERED") !=
+		terminalFCMDeviceRejection(http.StatusUnprocessableEntity, "fcm_rejected",
+			"FCM rejected the notification: UNREGISTERED") {
+		t.Fatal("platform dispatch mismatch")
+	}
+}
+
+func TestAndroidPushDeliverySettings(t *testing.T) {
+	ctx := context.Background()
+	settings := NewSettings(nil)
+	if settings.AndroidPushDeliveryEnabled(ctx) {
+		t.Fatal("AndroidPushDeliveryEnabled must default to false")
+	}
+	if settings.PushDeliveryEnabled(ctx) {
+		t.Fatal("PushDeliveryEnabled must default to false")
+	}
+	if got := settings.EnabledPushPlatforms(ctx); len(got) != 0 {
+		t.Fatalf("EnabledPushPlatforms = %v, want empty", got)
+	}
+
+	settings = NewSettings(mapSettingReader{
+		SettingAndroidPushDeliveryEnabled: "true",
+	})
+	if !settings.AndroidPushDeliveryEnabled(ctx) || !settings.PushDeliveryEnabled(ctx) {
+		t.Fatal("android delivery setting did not enable push delivery")
+	}
+	if got := settings.EnabledPushPlatforms(ctx); len(got) != 1 || got[0] != PushPlatformAndroid {
+		t.Fatalf("EnabledPushPlatforms = %v, want [android]", got)
+	}
+}
+
 func TestTerminalAPNsDeviceRejectionReasons(t *testing.T) {
 	for _, reason := range []string{
 		"BadDeviceToken",

--- a/internal/notifications/settings.go
+++ b/internal/notifications/settings.go
@@ -56,13 +56,14 @@ const (
 	SettingServerChannelsBatchSeconds     = "notifications.server_channels.batch_seconds"
 	SettingServerChannelMentionRequesters = "notifications.server_channels.mention_requesters"
 
-	SettingApplePushDeliveryEnabled = "notifications.apple_push_delivery_enabled"
-	SettingPushRelayURL             = "notifications.push_relay_url"
-	SettingPushRelayDeploymentID    = "notifications.push_relay_deployment_id"
-	SettingPushRelayAPIKey          = "notifications.push_relay_api_key"
-	SettingPushRelayExpiresAt       = "notifications.push_relay_expires_at"
-	SettingPushRelayKeyPrefix       = "notifications.push_relay_key_prefix"
-	SettingPushRelayReregister      = "notifications.push_relay_reregistration_required"
+	SettingApplePushDeliveryEnabled   = "notifications.apple_push_delivery_enabled"
+	SettingAndroidPushDeliveryEnabled = "notifications.android_push_delivery_enabled"
+	SettingPushRelayURL               = "notifications.push_relay_url"
+	SettingPushRelayDeploymentID      = "notifications.push_relay_deployment_id"
+	SettingPushRelayAPIKey            = "notifications.push_relay_api_key"
+	SettingPushRelayExpiresAt         = "notifications.push_relay_expires_at"
+	SettingPushRelayKeyPrefix         = "notifications.push_relay_key_prefix"
+	SettingPushRelayReregister        = "notifications.push_relay_reregistration_required"
 
 	// Discord application credentials live under the discord.* namespace
 	// (admin-configured, alongside email.smtp_*). The secret and bot token
@@ -414,6 +415,32 @@ func (s *Settings) ServerChannelsBatchWindow(ctx context.Context) time.Duration 
 // already hold tokens keep them fresh across admin toggles.
 func (s *Settings) ApplePushDeliveryEnabled(ctx context.Context) bool {
 	return s.boolSetting(ctx, SettingApplePushDeliveryEnabled, false)
+}
+
+// AndroidPushDeliveryEnabled is the Android counterpart of
+// ApplePushDeliveryEnabled: it gates relay FCM sends and the capability
+// endpoint's android_push availability.
+func (s *Settings) AndroidPushDeliveryEnabled(ctx context.Context) bool {
+	return s.boolSetting(ctx, SettingAndroidPushDeliveryEnabled, false)
+}
+
+// PushDeliveryEnabled reports whether any push platform may deliver; the
+// shared dispatcher uses it as its wake-up gate.
+func (s *Settings) PushDeliveryEnabled(ctx context.Context) bool {
+	return s.ApplePushDeliveryEnabled(ctx) || s.AndroidPushDeliveryEnabled(ctx)
+}
+
+// EnabledPushPlatforms lists the platforms whose admin delivery toggle is on,
+// in the shape ListEnabledPushByProfiles expects.
+func (s *Settings) EnabledPushPlatforms(ctx context.Context) []string {
+	platforms := make([]string, 0, 2)
+	if s.ApplePushDeliveryEnabled(ctx) {
+		platforms = append(platforms, PushPlatformApple)
+	}
+	if s.AndroidPushDeliveryEnabled(ctx) {
+		platforms = append(platforms, PushPlatformAndroid)
+	}
+	return platforms
 }
 
 // PushRelayURL is the public Silo relay origin.

--- a/migrations/sql/20260714160000_push_devices_android.sql
+++ b/migrations/sql/20260714160000_push_devices_android.sql
@@ -1,0 +1,77 @@
+-- +goose Up
+-- +goose StatementBegin
+ALTER TABLE public.push_devices
+    ADD COLUMN fcm_token_ciphertext text,
+    ADD COLUMN fcm_token_hash text;
+
+ALTER TABLE public.push_devices
+    DROP CONSTRAINT push_devices_platform_check;
+ALTER TABLE public.push_devices
+    ADD CONSTRAINT push_devices_platform_check CHECK (platform IN ('apple', 'android'));
+
+ALTER TABLE public.push_devices
+    DROP CONSTRAINT push_devices_apple_fields_check;
+ALTER TABLE public.push_devices
+    ADD CONSTRAINT push_devices_platform_fields_check CHECK (
+        (
+            platform = 'apple'
+            AND apns_environment IS NOT NULL
+            AND apns_topic IS NOT NULL
+            AND apns_token_ciphertext IS NOT NULL
+            AND apns_token_hash IS NOT NULL
+            AND fcm_token_ciphertext IS NULL
+            AND fcm_token_hash IS NULL
+        )
+        OR (
+            platform = 'android'
+            AND fcm_token_ciphertext IS NOT NULL
+            AND fcm_token_hash IS NOT NULL
+            AND apns_environment IS NULL
+            AND apns_topic IS NULL
+            AND apns_token_ciphertext IS NULL
+            AND apns_token_hash IS NULL
+        )
+    );
+
+CREATE INDEX push_devices_fcm_token_hash_idx
+    ON public.push_devices (fcm_token_hash)
+    WHERE fcm_token_hash IS NOT NULL;
+
+ALTER TABLE public.push_delivery_attempts
+    DROP CONSTRAINT push_delivery_attempts_platform_check;
+ALTER TABLE public.push_delivery_attempts
+    ADD CONSTRAINT push_delivery_attempts_platform_check CHECK (platform IN ('apple', 'android'));
+-- +goose StatementEnd
+
+-- +goose Down
+-- +goose StatementBegin
+DELETE FROM public.push_delivery_attempts WHERE platform = 'android';
+DELETE FROM public.push_devices WHERE platform = 'android';
+
+ALTER TABLE public.push_delivery_attempts
+    DROP CONSTRAINT push_delivery_attempts_platform_check;
+ALTER TABLE public.push_delivery_attempts
+    ADD CONSTRAINT push_delivery_attempts_platform_check CHECK (platform IN ('apple'));
+
+DROP INDEX IF EXISTS push_devices_fcm_token_hash_idx;
+
+ALTER TABLE public.push_devices
+    DROP CONSTRAINT push_devices_platform_fields_check;
+ALTER TABLE public.push_devices
+    ADD CONSTRAINT push_devices_apple_fields_check CHECK (
+        platform = 'apple'
+        AND apns_environment IS NOT NULL
+        AND apns_topic IS NOT NULL
+        AND apns_token_ciphertext IS NOT NULL
+        AND apns_token_hash IS NOT NULL
+    );
+
+ALTER TABLE public.push_devices
+    DROP CONSTRAINT push_devices_platform_check;
+ALTER TABLE public.push_devices
+    ADD CONSTRAINT push_devices_platform_check CHECK (platform IN ('apple'));
+
+ALTER TABLE public.push_devices
+    DROP COLUMN fcm_token_ciphertext,
+    DROP COLUMN fcm_token_hash;
+-- +goose StatementEnd


### PR DESCRIPTION
## Summary

Adds Android push delivery through the Silo push relay's new `POST /v1/fcm/send` endpoint (deployed at `push.siloserver.org`), reusing the existing Apple pipeline end to end: same outbox, dispatcher, retry schedule, idempotency keys, credential renewal, and terminal-device pruning.

- **Schema** (`20260714160000_push_devices_android.sql`): `push_devices` gains nullable `fcm_token_ciphertext` / `fcm_token_hash`; the platform CHECKs on `push_devices` and `push_delivery_attempts` now allow `'android'`, and the old `apple_fields_check` becomes a platform-conditional exclusivity constraint.
- **Registration**: new profile-scoped `POST /notifications/push/devices` (the contract the Android client already ships with) plus `DELETE /notifications/push/devices/{device_id}`. FCM tokens are validated (`[A-Za-z0-9_:-]{64,512}`), encrypted at rest with per-row AAD, and hashed case-sensitively.
- **Delivery**: fanout and operational dispatch enqueue attempts for every admin-enabled platform; the sender picks `/v1/apple/send` or `/v1/fcm/send` per device. A relay `422 fcm_rejected` with reason `UNREGISTERED` disables the device (mirrors the conservative APNs list); `INVALID_ARGUMENT` stays request-level.
- **Config**: new `notifications.android_push_delivery_enabled` setting (default off, validated in admin settings), surfaced via the capability endpoint's `android_push` block, same relay credential as Apple.
- **Admin**: `POST /admin/notifications/push/fcm/test` mirrors the Apple test endpoint.

## Privacy / delivery risks

- The FCM payload is built by the relay and stays content-private (data-only, delivery ID + mode); this server still sends only the opaque IDs it already sent for Apple.
- FCM tokens follow the exact APNs token handling: encrypted at rest, hashed for lookups, never logged.
- Ambiguous relay outcomes remain delivery-unknown via the shared idempotency handling; nothing is resent on 409.

## Request/response examples

Register (Android client, profile-scoped):
```
POST /api/v1/notifications/push/devices
{"platform":"android","token":"<fcm-token>","device_id":"<install-id>","push_mode":"private_push"}
→ 200 {"id":"01J...","server_device_id":"01J...","enabled":true,"push_mode":"private_push"}
```

Relay send (server → relay):
```
POST /v1/fcm/send  (Idempotency-Key: <attempt-id>)
{"token":"<fcm-token>","mode":"private_alert","server_device_id":"01J...","delivery_id":"01J...","collapse_id":"01J..."}
→ 200 {"request_id":"...","fcm_message_id":"...","status":"accepted"}
```

## Commands run

- `GOWORK=off go build ./internal/... ./cmd/...`
- `GOWORK=off go vet ./internal/notifications/... ./internal/api/...`
- `GOWORK=off go test ./internal/...` (all pass; DB-backed tests skip without `SILO_TEST_DATABASE_URL`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Android push notification support using FCM, including device registration and removal.
  * Added Android push capability reporting and configurable delivery enablement.
  * Added admin tools for sending Android test notifications.
  * Enabled notification delivery across Apple and Android devices.
* **Bug Fixes**
  * Improved platform-specific validation and error messages for push settings and delivery failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->