### PR TITLE
fix(playback): open the listener before sweeping stale transcode dirs

### DIFF
--- a/cmd/silo/main.go
+++ b/cmd/silo/main.go
@@ -665,6 +665,9 @@ func main() {
 			// start, so this node can rebuild a Jellyfin transcode after its own
 			// restart (the node hop token is recipe-less). Shares the offload Redis.
 			srv.SetRecipeStore(noderecipe.NewStore(redisClient, 0))
+			// Reclaim orphaned transcode dirs at boot and hourly thereafter, bound
+			// to appCtx so it stops on shutdown.
+			srv.StartOrphanSweeper(appCtx)
 			handler = srv.Handler()
 		}
 
@@ -2359,6 +2362,7 @@ func main() {
 	if (mode == "integrated" || mode == "api") && cfg.JellyfinCompat.Enabled && cfg.JellyfinCompat.Listen != "" {
 		compatDeps := jellycompat.Dependencies{
 			Config:           cfg,
+			AppContext:       appCtx,
 			LiveConfig:       configWatcher.Config,
 			DB:               deps.DB,
 			SecretCipher:     dataCipher,

--- a/internal/api/router.go
+++ b/internal/api/router.go
@@ -857,7 +857,13 @@ func NewRouter(deps Dependencies) chi.Router {
 			playbackHandler.PlaybackConfig = func() config.PlaybackConfig {
 				return deps.CurrentConfig().Playback
 			}
-			playback.StartBackgroundOrphanCleanup("api", deps.Config.Playback.TranscodeDir, playbackHandler.CleanupOrphanedTranscodes)
+			// In integrated mode this and the jellycompat sweep both scan the same
+			// TranscodeDir but each snapshots only its own manager's live set, so a
+			// >24h idle dir owned by the other manager can be reaped. Bounded and
+			// safe: active dirs stay mtime-fresh (spared) and either side rebuilds
+			// from its token/recipe, so the worst case is a wasted rebuild. A shared
+			// active-set source across both managers would remove even that.
+			playback.StartPeriodicOrphanCleanup(deps.AppContext, "api", deps.Config.Playback.TranscodeDir, playbackHandler.CleanupOrphanedTranscodes, playback.OrphanCleanupInterval)
 		}
 		playbackHandler.ProbeEnsurer = deps.ProbeEnsurer
 		playbackHandler.ChapterThumbnailQueuer = deps.ChapterThumbnailQueuer

--- a/internal/api/router.go
+++ b/internal/api/router.go
@@ -857,11 +857,7 @@ func NewRouter(deps Dependencies) chi.Router {
 			playbackHandler.PlaybackConfig = func() config.PlaybackConfig {
 				return deps.CurrentConfig().Playback
 			}
-			if cleaned, err := playbackHandler.CleanupOrphanedTranscodes(); err != nil {
-				slog.Warn("playback transcode cleanup failed", "dir", deps.Config.Playback.TranscodeDir, "error", err)
-			} else if cleaned > 0 {
-				slog.Info("playback transcode cleanup removed orphaned dirs", "dir", deps.Config.Playback.TranscodeDir, "count", cleaned)
-			}
+			playback.StartBackgroundOrphanCleanup("api", deps.Config.Playback.TranscodeDir, playbackHandler.CleanupOrphanedTranscodes)
 		}
 		playbackHandler.ProbeEnsurer = deps.ProbeEnsurer
 		playbackHandler.ChapterThumbnailQueuer = deps.ChapterThumbnailQueuer

--- a/internal/jellycompat/router.go
+++ b/internal/jellycompat/router.go
@@ -111,7 +111,11 @@ func NewRouter(deps Dependencies) chi.Router {
 	// Compat transcode reconstruct is driven by the recipe carried in the durable
 	// compat playback store (jellycompat_playback_sessions); no separate native
 	// recipe table is needed.
-	playback.StartBackgroundOrphanCleanup("jellycompat", playbackHandler.TranscodeDir, playbackHandler.CleanupOrphanedTranscodes)
+	//
+	// This shares TranscodeDir with the native api sweep but snapshots only this
+	// manager's live set; see the api NewRouter call site for why cross-manager
+	// reaping of a >24h idle dir is bounded and safe.
+	playback.StartPeriodicOrphanCleanup(deps.AppContext, "jellycompat", playbackHandler.TranscodeDir, playbackHandler.CleanupOrphanedTranscodes, playback.OrphanCleanupInterval)
 	playbackHandler.profileRefreshRequester = deps.RecWorker
 	playbackHandler.SettingsRepo = deps.SettingsRepo
 	playbackHandler.RecipeNodeStore = deps.RecipeNodeStore

--- a/internal/jellycompat/router.go
+++ b/internal/jellycompat/router.go
@@ -111,11 +111,7 @@ func NewRouter(deps Dependencies) chi.Router {
 	// Compat transcode reconstruct is driven by the recipe carried in the durable
 	// compat playback store (jellycompat_playback_sessions); no separate native
 	// recipe table is needed.
-	if cleaned, err := playbackHandler.CleanupOrphanedTranscodes(); err != nil {
-		slog.Warn("jellycompat transcode cleanup failed", "dir", playbackHandler.TranscodeDir, "error", err)
-	} else if cleaned > 0 {
-		slog.Info("jellycompat transcode cleanup removed orphaned dirs", "dir", playbackHandler.TranscodeDir, "count", cleaned)
-	}
+	playback.StartBackgroundOrphanCleanup("jellycompat", playbackHandler.TranscodeDir, playbackHandler.CleanupOrphanedTranscodes)
 	playbackHandler.profileRefreshRequester = deps.RecWorker
 	playbackHandler.SettingsRepo = deps.SettingsRepo
 	playbackHandler.RecipeNodeStore = deps.RecipeNodeStore

--- a/internal/jellycompat/server.go
+++ b/internal/jellycompat/server.go
@@ -25,6 +25,10 @@ import (
 // Dependencies holds the pluggable pieces used by the compat server.
 type Dependencies struct {
 	Config *config.Config
+	// AppContext is the process lifecycle context. When set, it bounds the
+	// periodic orphan-transcode sweep so it stops on shutdown; nil (tests) makes
+	// the sweep a single boot-time run instead of a long-lived ticker.
+	AppContext context.Context
 	// LiveConfig returns the current hot-reloaded config. May be nil (tests,
 	// worker modes); read through CurrentConfig(), which falls back to Config.
 	LiveConfig       func() *config.Config

--- a/internal/playback/transcode_cleanup.go
+++ b/internal/playback/transcode_cleanup.go
@@ -2,11 +2,16 @@ package playback
 
 import (
 	"fmt"
+	"log/slog"
 	"os"
 	"path/filepath"
+	"runtime/debug"
 	"strings"
+	"sync"
 	"time"
 )
+
+var orphanCleanupMu sync.Mutex
 
 // CleanupOrphanedTranscodeDirs removes per-session transcode directories that
 // are not associated with any currently active session IDs.
@@ -20,6 +25,11 @@ import (
 // Pass 0 to disable age-sparing (e.g. a dedicated node's boot-time full wipe,
 // where node restart is an accepted session loss).
 func CleanupOrphanedTranscodeDirs(root string, activeSessionIDs map[string]struct{}, minAge time.Duration) (int, error) {
+	// Serialize concurrent orphan sweeps of the shared transcode root so two
+	// rare startup sweeps cannot race on os.RemoveAll; one global mutex is fine.
+	orphanCleanupMu.Lock()
+	defer orphanCleanupMu.Unlock()
+
 	if root == "" {
 		return 0, nil
 	}
@@ -63,6 +73,26 @@ func CleanupOrphanedTranscodeDirs(root string, activeSessionIDs map[string]struc
 	}
 
 	return removed, nil
+}
+
+// StartBackgroundOrphanCleanup runs an orphaned-transcode sweep in its own
+// goroutine so a slow network-filesystem delete never blocks server startup.
+// The sweep is already safe to run concurrently with request handling: it
+// spares live/in-flight sessions and any dir younger than MaxTokenTTL, and
+// CleanupOrphanedTranscodeDirs serializes concurrent sweeps of the same root.
+func StartBackgroundOrphanCleanup(component, dir string, cleanup func() (int, error)) {
+	go func() {
+		defer func() {
+			if r := recover(); r != nil {
+				slog.Error("transcode cleanup panicked", "component", component, "dir", dir, "panic", r, "stack", string(debug.Stack()))
+			}
+		}()
+		if cleaned, err := cleanup(); err != nil {
+			slog.Warn("transcode cleanup failed", "component", component, "dir", dir, "error", err)
+		} else if cleaned > 0 {
+			slog.Info("transcode cleanup removed orphaned dirs", "component", component, "dir", dir, "count", cleaned)
+		}
+	}()
 }
 
 func transcodeDirBelongsToActiveSession(name string, activeSessionIDs map[string]struct{}) bool {

--- a/internal/playback/transcode_cleanup.go
+++ b/internal/playback/transcode_cleanup.go
@@ -1,6 +1,7 @@
 package playback
 
 import (
+	"context"
 	"fmt"
 	"log/slog"
 	"os"
@@ -75,22 +76,60 @@ func CleanupOrphanedTranscodeDirs(root string, activeSessionIDs map[string]struc
 	return removed, nil
 }
 
-// StartBackgroundOrphanCleanup runs an orphaned-transcode sweep in its own
+// OrphanCleanupInterval is how often the periodic orphan sweep re-runs. A dir is
+// only reapable once it is older than MaxTokenTTL (24h), so sweeping much more
+// often than hourly buys nothing; hourly bounds how long an untracked orphan (a
+// dir whose owning session vanished without its RemoveAll succeeding) lingers on
+// a process that is never restarted, without adding meaningful load.
+const OrphanCleanupInterval = time.Hour
+
+// runOrphanCleanup executes one sweep, recovering from a panic (a background
+// goroutine's unrecovered panic would crash the process) and logging the result.
+func runOrphanCleanup(component, dir string, cleanup func() (int, error)) {
+	defer func() {
+		if r := recover(); r != nil {
+			slog.Error("transcode cleanup panicked", "component", component, "dir", dir, "panic", r, "stack", string(debug.Stack()))
+		}
+	}()
+	if cleaned, err := cleanup(); err != nil {
+		slog.Warn("transcode cleanup failed", "component", component, "dir", dir, "error", err)
+	} else if cleaned > 0 {
+		slog.Info("transcode cleanup removed orphaned dirs", "component", component, "dir", dir, "count", cleaned)
+	}
+}
+
+// StartBackgroundOrphanCleanup runs a single orphaned-transcode sweep in its own
 // goroutine so a slow network-filesystem delete never blocks server startup.
 // The sweep is already safe to run concurrently with request handling: it
 // spares live/in-flight sessions and any dir younger than MaxTokenTTL, and
 // CleanupOrphanedTranscodeDirs serializes concurrent sweeps of the same root.
 func StartBackgroundOrphanCleanup(component, dir string, cleanup func() (int, error)) {
+	go runOrphanCleanup(component, dir, cleanup)
+}
+
+// StartPeriodicOrphanCleanup runs an immediate background sweep and then repeats
+// it every interval until ctx is cancelled. The startup sweep only reclaims dirs
+// orphaned by an ungraceful prior shutdown; the periodic re-run additionally
+// bounds "untracked orphan" accumulation (a dir whose owning session was dropped
+// without its RemoveAll succeeding) on a process that stays up for weeks. When
+// ctx is nil or interval is non-positive it degrades to a single boot-time sweep
+// so no ticker goroutine outlives a caller with no lifecycle handle (e.g. tests).
+func StartPeriodicOrphanCleanup(ctx context.Context, component, dir string, cleanup func() (int, error), interval time.Duration) {
+	if ctx == nil || interval <= 0 {
+		StartBackgroundOrphanCleanup(component, dir, cleanup)
+		return
+	}
 	go func() {
-		defer func() {
-			if r := recover(); r != nil {
-				slog.Error("transcode cleanup panicked", "component", component, "dir", dir, "panic", r, "stack", string(debug.Stack()))
+		runOrphanCleanup(component, dir, cleanup)
+		ticker := time.NewTicker(interval)
+		defer ticker.Stop()
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			case <-ticker.C:
+				runOrphanCleanup(component, dir, cleanup)
 			}
-		}()
-		if cleaned, err := cleanup(); err != nil {
-			slog.Warn("transcode cleanup failed", "component", component, "dir", dir, "error", err)
-		} else if cleaned > 0 {
-			slog.Info("transcode cleanup removed orphaned dirs", "component", component, "dir", dir, "count", cleaned)
 		}
 	}()
 }

--- a/internal/transcodenode/server.go
+++ b/internal/transcodenode/server.go
@@ -176,11 +176,17 @@ func NewServer(watcher *nodeconfig.Watcher, tracker *nodesessions.Tracker) *Serv
 		lastAccess: make(map[string]time.Time),
 	}
 	if cfg := watcher.Config(); cfg != nil {
-		if cleaned, err := playback.CleanupOrphanedTranscodeDirs(cfg.Playback.TranscodeDir, nil, 0); err != nil {
-			slog.Warn("transcode node cleanup failed", "dir", cfg.Playback.TranscodeDir, "error", err)
-		} else if cleaned > 0 {
-			slog.Info("transcode node cleanup removed orphaned dirs", "dir", cfg.Playback.TranscodeDir, "count", cleaned)
-		}
+		// Sweep leftover transcode dirs in the background so a slow
+		// network-filesystem delete never blocks the node's listener from
+		// binding. Age-spare at MaxTokenTTL (was a full wipe): a dir younger
+		// than the max token lifetime may be reused by an imminent
+		// token-carried reconstruct writing into TranscodeDir/<sessionID>, so
+		// wiping it concurrently would race that ffmpeg. Dirs older than any
+		// surviving token are never reconstructable and are still reclaimed.
+		transcodeDir := cfg.Playback.TranscodeDir
+		playback.StartBackgroundOrphanCleanup("transcodenode", transcodeDir, func() (int, error) {
+			return playback.CleanupOrphanedTranscodeDirs(transcodeDir, nil, playback.MaxTokenTTL)
+		})
 	}
 	return s
 }

--- a/internal/transcodenode/server.go
+++ b/internal/transcodenode/server.go
@@ -175,20 +175,50 @@ func NewServer(watcher *nodeconfig.Watcher, tracker *nodesessions.Tracker) *Serv
 		sessions:   make(map[string]*playback.TranscodeSession),
 		lastAccess: make(map[string]time.Time),
 	}
-	if cfg := watcher.Config(); cfg != nil {
-		// Sweep leftover transcode dirs in the background so a slow
-		// network-filesystem delete never blocks the node's listener from
-		// binding. Age-spare at MaxTokenTTL (was a full wipe): a dir younger
-		// than the max token lifetime may be reused by an imminent
-		// token-carried reconstruct writing into TranscodeDir/<sessionID>, so
-		// wiping it concurrently would race that ffmpeg. Dirs older than any
-		// surviving token are never reconstructable and are still reclaimed.
-		transcodeDir := cfg.Playback.TranscodeDir
-		playback.StartBackgroundOrphanCleanup("transcodenode", transcodeDir, func() (int, error) {
-			return playback.CleanupOrphanedTranscodeDirs(transcodeDir, nil, playback.MaxTokenTTL)
-		})
-	}
 	return s
+}
+
+// StartOrphanSweeper runs the age-guarded orphan-transcode sweep immediately and
+// then hourly until ctx is cancelled. It never blocks (a slow network-filesystem
+// delete runs in its own goroutine), so it is safe to call before the node binds
+// its listener. This is the node's only filesystem-level reclaimer of dirs left
+// behind by a session that was dropped without its output dir being removed — the
+// idle reaper only deletes dirs it still tracks in s.sessions, so without this
+// periodic pass such orphans would linger until the next process restart. The
+// MaxTokenTTL age guard keeps a delete from racing a token-carried reconstruct
+// writing into TranscodeDir/<sessionID>: a dir younger than the max token
+// lifetime may still be reused, while older dirs are never reconstructable.
+func (s *Server) StartOrphanSweeper(ctx context.Context) {
+	dir := ""
+	if cfg := s.watcher.Config(); cfg != nil {
+		dir = cfg.Playback.TranscodeDir
+	}
+	playback.StartPeriodicOrphanCleanup(ctx, "transcodenode", dir, func() (int, error) {
+		// Re-read config each run so a hot-reloaded TranscodeDir is honored.
+		cfg := s.watcher.Config()
+		if cfg == nil {
+			return 0, nil
+		}
+		// Spare the live registered jobs by id, not by age alone: now that the
+		// sweep runs during live traffic, a long-lived session that re-serves
+		// already-written segments stops advancing its dir mtime, so the age
+		// guard could misclassify it as orphaned. The live set is authoritative
+		// (in-flight reconstructs are covered by their fresh writes + age guard).
+		return playback.CleanupOrphanedTranscodeDirs(cfg.Playback.TranscodeDir, s.activeSessionIDs(), playback.MaxTokenTTL)
+	}, playback.OrphanCleanupInterval)
+}
+
+// activeSessionIDs snapshots the ids of currently registered jobs so the orphan
+// sweep spares their output dirs regardless of directory mtime, mirroring the
+// central TranscodeManager's live-set snapshot.
+func (s *Server) activeSessionIDs() map[string]struct{} {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	active := make(map[string]struct{}, len(s.sessions))
+	for id := range s.sessions {
+		active[id] = struct{}{}
+	}
+	return active
 }
 
 func (s *Server) SetFFmpegLogSink(sink playback.FFmpegLogSink) {


### PR DESCRIPTION
Three commits: one fix for the reported startup stall, then two hardenings that follow from it.

Closes #412.

## Problem

**The server went dark for over a minute after every restart.** On the last deploy it took **more than 80 seconds** before the server would answer anyone at all. For that whole window it showed up as "unhealthy" in the health check, and nobody could connect — including the people whose playback had just been interrupted by the restart and were trying to reconnect. The resume-after-restart feature depends on those reconnects landing quickly, so this delay defeated exactly the thing it was meant to support.

The cause was ordering: before opening its doors, the server first walked through old leftover playback files on a slow shared network drive and deleted the ones no longer needed. On that restart there was a big pile (64 folders' worth), and clearing it took 80+ seconds — all of it spent before the server started listening. It was doing first-minute cleanup nobody was waiting on while the people who *did* need it were turned away.

**Two related gaps surfaced while fixing that.** The dedicated transcode nodes had the same "clean up before you open" ordering at their own startup. And separately, that leftover-file cleanup was the *only* filesystem-level backstop for a rare kind of stray folder — one whose owning session went away without its folder being deleted — yet it only ever ran at startup. On a machine left running for weeks without a restart, those strays had nothing to sweep them up.

## Solution

The cleanup itself is safe and unchanged in *what* it deletes — it only ever removes genuinely stale folders that no in-flight or still-resumable session could use. Every change here is about *when* it runs, never *what* it removes.

### fix(playback): run orphaned-transcode cleanup in the background at startup

`internal/api/router.go` and `internal/jellycompat/router.go` invoked `CleanupOrphanedTranscodes()` synchronously inside `NewRouter`, which runs in the main goroutine before `srv.ListenAndServe()` (`cmd/silo/main.go`). The 80s network-FS sweep therefore blocked the listener from binding.

New helper `playback.StartBackgroundOrphanCleanup` (`internal/playback/transcode_cleanup.go`) launches the sweep in a panic-recovered goroutine, so `NewRouter` returns immediately and the listener comes up right away. The delete logic is byte-for-byte the same — same active-session snapshot and `MaxTokenTTL` age-sparing, only later. Because the native and compat sweeps target the same `TranscodeDir`, a package-level `orphanCleanupMu` inside `CleanupOrphanedTranscodeDirs` serializes concurrent sweeps so they can't race on `os.RemoveAll`.

### fix(transcode): background the node boot-time transcode-dir sweep

The dedicated transcode node ran the same sweep synchronously in `NewServer` (`internal/transcodenode/server.go`) before `startStandaloneServer` bound its listener — the same startup stall, one hop out. Moved it to the shared background helper.

Backgrounding required an age guard here: the node sweep was previously a full wipe (`minAge=0`) that was only safe because it completed *before* any request could arrive. Run concurrently, a full wipe would race a token-carried reconstruct writing into `TranscodeDir/<sessionID>` and delete segments a fresh ffmpeg is producing. Passing `playback.MaxTokenTTL` spares any dir younger than the maximum token lifetime — exactly the ones a still-valid reconnect could reconstruct — while dirs older than any surviving token (never reconstructable) are still reclaimed.

### feat(playback): reclaim orphaned transcode dirs periodically, not just at boot

The sweep only ran at startup on both central and node, so it only ever reclaimed folders left by an ungraceful prior shutdown. During normal uptime the in-memory session reapers delete the folders of sessions they still track, but a folder whose owning session was dropped *without* its `RemoveAll` succeeding becomes an "untracked orphan" with no runtime GC — on a long-running box these slowly accumulate until the next restart.

New `playback.StartPeriodicOrphanCleanup(ctx, …)` runs an immediate background sweep and then re-runs hourly (`OrphanCleanupInterval`) until its lifecycle context is cancelled. Wired on all three surfaces: native API and Jellyfin-compat via `deps.AppContext`, and the transcode node via a new `Server.StartOrphanSweeper(appCtx)` (called from `cmd/silo/main.go`). When no context is supplied (tests) it degrades to a single boot-time sweep, so no ticker goroutine outlives its caller. Hourly is deliberate — a dir isn't reapable until it's older than 24h, so a tighter interval buys nothing.

Because the node sweep now runs during live traffic, it snapshots the live job set (`Server.activeSessionIDs`) and spares those dirs by id rather than by age alone: a long-lived session that only re-serves already-written segments stops advancing its directory mtime, which the age guard could otherwise misclassify as orphaned. This mirrors the central `TranscodeManager`'s existing live-set snapshot.

## Risk / follow-ups

- In integrated mode the native and compat sweeps share one `TranscodeDir` but each snapshots only its own manager's live set, so a >24h idle dir owned by the other manager can be reaped. Bounded and safe — active dirs stay mtime-fresh (spared) and either side rebuilds from its token/recipe, so the worst case is a wasted transcode rebuild. Documented at both call sites; a shared active-set source across the two managers would remove even that, and is left as a follow-up.
- The transcode node's `dir` log label is captured once, so after a `TranscodeDir` hot-reload the log line could show the old path while the sweep (which re-reads config) targets the new one. Cosmetic only.
- Fire-and-forget by design: a sweep interrupted at shutdown just leaves a partial delete for the next run to finish. Nothing waits on it, matching the prior behavior.

## Verification

- `go build ./...` — clean.
- `go vet ./internal/playback/ ./internal/transcodenode/ ./internal/jellycompat/ ./internal/api/` — clean.
- `go test -race ./internal/playback/ ./internal/transcodenode/` — pass.
- `gofmt -l` on all touched files — clean.
- Traced startup ordering by hand: `NewRouter`/`NewServer` now return before `ListenAndServe`/`startStandaloneServer`, so the listener binds without waiting on the sweep.
- Verified the age-guard invariant against the token model: token expiry is stamped at `MaxTokenTTL` (`recipecard.go`) and `streamtoken.Verify` rejects expired tokens, so a dir older than the cutoff has no valid reconstruct path.
- Confirmed no test sets `AppContext`, so the periodic ticker path is production-only and leaks no goroutines in tests.
- Two independent adversarial reviews (a second model on the plan and diff, plus a fresh high-effort pass over all three commits); the one real finding — the node sweep sparing live sessions by age alone — is fixed in the third commit.

## AI-use disclosure

Implemented with AI assistance (Claude Code). The plan and final reviews were done by Claude; the initial implementation of the first two commits was drafted by a second model (Codex gpt-5.6-sol) via a cross-model relay and then reviewed. All changes were verified with the build/vet/test steps above.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved cleanup of abandoned transcoding files and directories.
  - Cleanup now runs automatically at startup and periodically, reducing stale storage usage.
  - Concurrent cleanup operations are coordinated to prevent conflicts.
  - Active transcoding sessions are protected from accidental removal.
  - Cleanup processes stop cleanly when the application shuts down.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->