### PR TITLE
fix(scanner): recover malformed video durations

### DIFF
--- a/internal/scanner/probe.go
+++ b/internal/scanner/probe.go
@@ -1,9 +1,12 @@
 package scanner
 
 import (
+	"bufio"
 	"context"
 	"encoding/json"
 	"fmt"
+	"io"
+	"math"
 	"os/exec"
 	"slices"
 	"strconv"
@@ -50,6 +53,7 @@ type ffprobeFormat struct {
 	Filename       string            `json:"filename"`
 	FormatName     string            `json:"format_name"`
 	FormatLongName string            `json:"format_long_name"`
+	StartTime      string            `json:"start_time"`
 	Duration       string            `json:"duration"`
 	Size           string            `json:"size"`
 	BitRate        string            `json:"bit_rate"`
@@ -69,6 +73,8 @@ type ffprobeStream struct {
 	DisplayAspectRatio string              `json:"display_aspect_ratio"`
 	FieldOrder         string              `json:"field_order"`
 	AvgFrameRate       string              `json:"avg_frame_rate"`
+	StartTime          string              `json:"start_time"`
+	Duration           string              `json:"duration"`
 	BitRate            string              `json:"bit_rate"`
 	ColorTransfer      string              `json:"color_transfer"`
 	ColorPrimaries     string              `json:"color_primaries"`
@@ -131,7 +137,16 @@ func ProbeFile(ctx context.Context, ffprobePath string, filePath string) (*Probe
 		return nil, fmt.Errorf("ffprobe JSON parse failed for %s: %w", filePath, err)
 	}
 
-	return convertProbeData(&raw), nil
+	probe := convertProbeData(&raw)
+	if probe.Duration == 0 {
+		if frameRate, hasVideo := primaryVideoFrameRate(raw.Streams); hasVideo {
+			if duration, packetErr := probeVideoPacketDuration(ctx, ffprobePath, filePath, frameRate); packetErr == nil {
+				probe.Duration = duration
+			}
+		}
+	}
+
+	return probe, nil
 }
 
 // FFprobePathFromFFmpeg derives the sibling ffprobe binary path from a configured ffmpeg path.
@@ -151,17 +166,8 @@ func convertProbeData(raw *ffprobeOutput) *ProbeData {
 		Container: detectContainer(raw.Format.FormatName),
 	}
 
-	// Parse duration from format (ffprobe reports seconds).
-	// Some containers (notably MKV) may produce duration in microseconds;
-	// detect and normalise to seconds when the value is unreasonably large.
-	if raw.Format.Duration != "" {
-		if dur, err := strconv.ParseFloat(raw.Format.Duration, 64); err == nil {
-			const maxReasonableSec = 100_000 // ~27.8 hours
-			if dur > maxReasonableSec {
-				dur = dur / 1_000_000 // microseconds → seconds
-			}
-			pd.Duration = int(dur)
-		}
+	if duration, ok := durationFromProbeMetadata(raw); ok {
+		pd.Duration = duration
 	}
 
 	// Parse bitrate from format (bps to kbps).
@@ -246,6 +252,181 @@ func convertProbeData(raw *ffprobeOutput) *ProbeData {
 	pd.FormatTags = normalizeFormatTags(raw.Format.Tags)
 
 	return pd
+}
+
+const maxReasonableMediaDurationSeconds = 100_000
+
+func durationFromProbeMetadata(raw *ffprobeOutput) (int, bool) {
+	if raw == nil {
+		return 0, false
+	}
+
+	formatDuration := parseFloat(raw.Format.Duration)
+	if !hasVideoStream(raw.Streams) && durationIsPositiveFinite(formatDuration) {
+		return roundedDuration(formatDuration), true
+	}
+	if durationIsReasonable(formatDuration) && !durationLooksImplausiblyShort(raw, formatDuration) {
+		return roundedDuration(formatDuration), true
+	}
+
+	for _, stream := range raw.Streams {
+		if stream.CodecType != "video" {
+			continue
+		}
+		streamDuration := parseFloat(stream.Duration)
+		if durationIsReasonable(streamDuration) && !durationLooksImplausiblyShort(raw, streamDuration) {
+			return roundedDuration(streamDuration), true
+		}
+		if duration := durationAfterStart(streamDuration, parseFloat(stream.StartTime)); duration > 0 {
+			return roundedDuration(duration), true
+		}
+	}
+
+	if duration := durationAfterStart(formatDuration, parseFloat(raw.Format.StartTime)); duration > 0 {
+		return roundedDuration(duration), true
+	}
+	return 0, false
+}
+
+func durationLooksImplausiblyShort(raw *ffprobeOutput, duration float64) bool {
+	const (
+		maxShortDurationSeconds = 10
+		minLargeVideoBytes      = 100 * 1024 * 1024
+	)
+	if raw == nil || duration <= 0 || duration > maxShortDurationSeconds {
+		return false
+	}
+	size, err := strconv.ParseInt(raw.Format.Size, 10, 64)
+	if err != nil || size < minLargeVideoBytes {
+		return false
+	}
+	for _, stream := range raw.Streams {
+		if stream.CodecType == "video" {
+			return true
+		}
+	}
+	return false
+}
+
+func durationAfterStart(end, start float64) float64 {
+	if start <= 0 || end <= start {
+		return 0
+	}
+	duration := end - start
+	if !durationIsReasonable(duration) {
+		return 0
+	}
+	return duration
+}
+
+func durationIsReasonable(duration float64) bool {
+	return durationIsPositiveFinite(duration) && duration <= maxReasonableMediaDurationSeconds
+}
+
+func durationIsPositiveFinite(duration float64) bool {
+	return duration > 0 && !math.IsNaN(duration) && !math.IsInf(duration, 0)
+}
+
+func roundedDuration(duration float64) int {
+	return max(1, int(math.Round(duration)))
+}
+
+func hasVideoStream(streams []ffprobeStream) bool {
+	_, ok := primaryVideoFrameRate(streams)
+	return ok
+}
+
+func primaryVideoFrameRate(streams []ffprobeStream) (string, bool) {
+	for _, stream := range streams {
+		if stream.CodecType == "video" {
+			return stream.AvgFrameRate, true
+		}
+	}
+	return "", false
+}
+
+func probeVideoPacketDuration(
+	ctx context.Context,
+	ffprobePath string,
+	filePath string,
+	frameRate string,
+) (int, error) {
+	cmd := exec.CommandContext(ctx, ffprobePath,
+		"-v", "error",
+		"-select_streams", "v:0",
+		"-show_entries", "packet=pts_time",
+		"-of", "csv=p=0",
+		filePath,
+	)
+	stdout, err := cmd.StdoutPipe()
+	if err != nil {
+		return 0, fmt.Errorf("opening ffprobe packet output: %w", err)
+	}
+	if err := cmd.Start(); err != nil {
+		return 0, fmt.Errorf("starting ffprobe packet scan: %w", err)
+	}
+
+	duration := estimateVideoPacketDuration(stdout, frameRate)
+	if err := cmd.Wait(); err != nil {
+		return 0, fmt.Errorf("ffprobe packet scan failed for %s: %w", filePath, err)
+	}
+	return duration, nil
+}
+
+func estimateVideoPacketDuration(reader io.Reader, frameRate string) int {
+	scanner := bufio.NewScanner(reader)
+	packetCount := 0
+	minTimestamp := math.Inf(1)
+	maxTimestamp := math.Inf(-1)
+
+	for scanner.Scan() {
+		value := strings.TrimSpace(strings.SplitN(scanner.Text(), ",", 2)[0])
+		if value == "" {
+			continue
+		}
+		packetCount++
+		timestamp, err := strconv.ParseFloat(value, 64)
+		if err != nil {
+			continue
+		}
+		minTimestamp = min(minTimestamp, timestamp)
+		maxTimestamp = max(maxTimestamp, timestamp)
+	}
+
+	best := 0.0
+	if !math.IsInf(minTimestamp, 1) && !math.IsInf(maxTimestamp, -1) {
+		span := maxTimestamp - minTimestamp
+		if durationIsReasonable(span) {
+			best = span
+		}
+	}
+	if fps := parseFrameRate(frameRate); fps > 0 && packetCount > 0 {
+		frameDuration := float64(packetCount) / fps
+		if durationIsReasonable(frameDuration) && frameDuration > best {
+			best = frameDuration
+		}
+	}
+	if best <= 0 {
+		return 0
+	}
+	return roundedDuration(best)
+}
+
+func parseFrameRate(raw string) float64 {
+	parts := strings.SplitN(raw, "/", 2)
+	if len(parts) != 2 {
+		fps, _ := strconv.ParseFloat(raw, 64)
+		return fps
+	}
+	numerator, err := strconv.ParseFloat(parts[0], 64)
+	if err != nil {
+		return 0
+	}
+	denominator, err := strconv.ParseFloat(parts[1], 64)
+	if err != nil || denominator == 0 {
+		return 0
+	}
+	return numerator / denominator
 }
 
 func parseNumeric(raw string) int {

--- a/internal/scanner/probe.go
+++ b/internal/scanner/probe.go
@@ -111,8 +111,9 @@ type ffprobeSideData struct {
 
 // ffprobeDisp represents the disposition flags on a stream.
 type ffprobeDisp struct {
-	Default int `json:"default"`
-	Forced  int `json:"forced"`
+	Default     int `json:"default"`
+	Forced      int `json:"forced"`
+	AttachedPic int `json:"attached_pic"`
 }
 
 // ProbeFile runs ffprobe on the given file and returns parsed ProbeData.
@@ -140,14 +141,13 @@ func ProbeFile(ctx context.Context, ffprobePath string, filePath string) (*Probe
 	probe := convertProbeData(&raw)
 	if probe.Duration == 0 {
 		if frameRate, hasVideo := primaryVideoFrameRate(raw.Streams); hasVideo {
-			duration, packetErr := probeVideoPacketDuration(ctx, ffprobePath, filePath, frameRate)
-			if packetErr != nil {
-				return nil, packetErr
+			// A failed or empty packet scan must not discard the codec and
+			// track metadata that already parsed successfully: callers persist
+			// the partial probe, and the repair layer retries rows whose
+			// duration is still unknown.
+			if duration, packetErr := probeVideoPacketDuration(ctx, ffprobePath, filePath, frameRate); packetErr == nil && duration > 0 {
+				probe.Duration = duration
 			}
-			if duration <= 0 {
-				return nil, fmt.Errorf("ffprobe could not derive video duration for %s", filePath)
-			}
-			probe.Duration = duration
 		}
 	}
 
@@ -259,7 +259,29 @@ func convertProbeData(raw *ffprobeOutput) *ProbeData {
 	return pd
 }
 
-const maxReasonableMediaDurationSeconds = 100_000
+const (
+	maxReasonableMediaDurationSeconds = 100_000
+	// Audio-only files (audiobooks, podcasts) legitimately exceed the video
+	// ceiling, but still need a cap so malformed containers cannot persist
+	// multi-year durations.
+	maxReasonableAudioDurationSeconds = 1_000_000
+)
+
+// A large video file whose derived duration is only a few seconds is the
+// signature of malformed container timestamps (and of the legacy probe that
+// divided large durations by one million). The shape is shared with the
+// repair triggers in probe_repair.go and scanner.go so the probe parser and
+// the repair layers cannot drift apart.
+const (
+	implausiblyShortVideoMaxSeconds = 10
+	implausiblyShortVideoMinBytes   = 100 * 1024 * 1024
+)
+
+func videoDurationImplausiblyShort(durationSeconds float64, sizeBytes int64, hasVideo bool) bool {
+	return hasVideo &&
+		durationSeconds > 0 && durationSeconds <= implausiblyShortVideoMaxSeconds &&
+		sizeBytes >= implausiblyShortVideoMinBytes
+}
 
 func durationFromProbeMetadata(raw *ffprobeOutput) (int, bool) {
 	if raw == nil {
@@ -267,7 +289,8 @@ func durationFromProbeMetadata(raw *ffprobeOutput) (int, bool) {
 	}
 
 	formatDuration := parseFloat(raw.Format.Duration)
-	if !hasVideoStream(raw.Streams) && durationIsPositiveFinite(formatDuration) {
+	if !hasVideoStream(raw.Streams) &&
+		durationIsPositiveFinite(formatDuration) && formatDuration <= maxReasonableAudioDurationSeconds {
 		return truncatedDuration(formatDuration), true
 	}
 	if durationIsReasonable(formatDuration) && !durationLooksImplausiblyShort(raw, formatDuration) {
@@ -275,42 +298,32 @@ func durationFromProbeMetadata(raw *ffprobeOutput) (int, bool) {
 	}
 
 	for _, stream := range raw.Streams {
-		if stream.CodecType != "video" {
+		if !isMainVideoStream(stream) {
 			continue
 		}
 		streamDuration := parseFloat(stream.Duration)
 		if durationIsReasonable(streamDuration) && !durationLooksImplausiblyShort(raw, streamDuration) {
 			return truncatedDuration(streamDuration), true
 		}
-		if duration := durationAfterStart(streamDuration, parseFloat(stream.StartTime)); duration > 0 {
+		duration := durationAfterStart(streamDuration, parseFloat(stream.StartTime))
+		if duration > 0 && !durationLooksImplausiblyShort(raw, duration) {
 			return truncatedDuration(duration), true
 		}
 	}
 
-	if duration := durationAfterStart(formatDuration, parseFloat(raw.Format.StartTime)); duration > 0 {
+	duration := durationAfterStart(formatDuration, parseFloat(raw.Format.StartTime))
+	if duration > 0 && !durationLooksImplausiblyShort(raw, duration) {
 		return truncatedDuration(duration), true
 	}
 	return 0, false
 }
 
 func durationLooksImplausiblyShort(raw *ffprobeOutput, duration float64) bool {
-	const (
-		maxShortDurationSeconds = 10
-		minLargeVideoBytes      = 100 * 1024 * 1024
-	)
-	if raw == nil || duration <= 0 || duration > maxShortDurationSeconds {
+	if raw == nil {
 		return false
 	}
-	size, err := strconv.ParseInt(raw.Format.Size, 10, 64)
-	if err != nil || size < minLargeVideoBytes {
-		return false
-	}
-	for _, stream := range raw.Streams {
-		if stream.CodecType == "video" {
-			return true
-		}
-	}
-	return false
+	size := int64(parseFloat(raw.Format.Size))
+	return videoDurationImplausiblyShort(duration, size, hasVideoStream(raw.Streams))
 }
 
 func durationAfterStart(end, start float64) float64 {
@@ -340,20 +353,32 @@ func truncatedDuration(duration float64) int {
 	return max(1, int(duration))
 }
 
+// isMainVideoStream reports whether the stream is a real video stream.
+// Embedded cover art (attached_pic) is reported by ffprobe as a video stream
+// but must not drive duration decisions: it would route audiobooks and music
+// through the video duration gauntlet and packet-scan a single still image.
+func isMainVideoStream(stream ffprobeStream) bool {
+	return stream.CodecType == "video" && stream.Disposition.AttachedPic == 0
+}
+
 func hasVideoStream(streams []ffprobeStream) bool {
-	_, ok := primaryVideoFrameRate(streams)
-	return ok
+	return slices.ContainsFunc(streams, isMainVideoStream)
 }
 
 func primaryVideoFrameRate(streams []ffprobeStream) (string, bool) {
 	for _, stream := range streams {
-		if stream.CodecType == "video" {
+		if isMainVideoStream(stream) {
 			return stream.AvgFrameRate, true
 		}
 	}
 	return "", false
 }
 
+// probeVideoPacketDuration derives a duration for files whose duration
+// metadata is unusable by scanning video packet timestamps. It intentionally
+// demuxes the whole file: the timestamps being repaired are the same ones
+// ffprobe would need for reliable interval seeking, so sampling cannot be
+// trusted here. The repair layer keeps this one-shot per file.
 func probeVideoPacketDuration(
 	ctx context.Context,
 	ffprobePath string,
@@ -389,7 +414,7 @@ func estimateVideoPacketDuration(reader io.Reader, frameRate string) int {
 	maxTimestamp := math.Inf(-1)
 
 	for scanner.Scan() {
-		value := strings.TrimSpace(strings.SplitN(scanner.Text(), ",", 2)[0])
+		value := strings.TrimSpace(scanner.Text())
 		if value == "" {
 			continue
 		}
@@ -421,7 +446,11 @@ func estimateVideoPacketDuration(reader io.Reader, frameRate string) int {
 	return roundedDuration(best)
 }
 
+// parseFrameRate parses ffprobe's rational frame-rate shape ("30000/1001")
+// or a plain float, returning 0 when unparsable. normalizeFrameRate formats
+// the same parse for persistence; keep the parsing logic here only.
 func parseFrameRate(raw string) float64 {
+	raw = strings.TrimSpace(raw)
 	parts := strings.SplitN(raw, "/", 2)
 	if len(parts) != 2 {
 		fps, _ := strconv.ParseFloat(raw, 64)
@@ -561,16 +590,14 @@ func normalizeFrameRate(raw string) string {
 	if raw == "" || raw == "0/0" {
 		return ""
 	}
-	parts := strings.SplitN(raw, "/", 2)
-	if len(parts) != 2 {
+	if !strings.Contains(raw, "/") {
 		return raw
 	}
-	num, err1 := strconv.ParseFloat(parts[0], 64)
-	den, err2 := strconv.ParseFloat(parts[1], 64)
-	if err1 != nil || err2 != nil || den == 0 {
+	fps := parseFrameRate(raw)
+	if fps == 0 {
 		return raw
 	}
-	return strconv.FormatFloat(num/den, 'f', 3, 64)
+	return strconv.FormatFloat(fps, 'f', 3, 64)
 }
 
 func isInterlaced(fieldOrder string) bool {

--- a/internal/scanner/probe.go
+++ b/internal/scanner/probe.go
@@ -140,9 +140,14 @@ func ProbeFile(ctx context.Context, ffprobePath string, filePath string) (*Probe
 	probe := convertProbeData(&raw)
 	if probe.Duration == 0 {
 		if frameRate, hasVideo := primaryVideoFrameRate(raw.Streams); hasVideo {
-			if duration, packetErr := probeVideoPacketDuration(ctx, ffprobePath, filePath, frameRate); packetErr == nil {
-				probe.Duration = duration
+			duration, packetErr := probeVideoPacketDuration(ctx, ffprobePath, filePath, frameRate)
+			if packetErr != nil {
+				return nil, packetErr
 			}
+			if duration <= 0 {
+				return nil, fmt.Errorf("ffprobe could not derive video duration for %s", filePath)
+			}
+			probe.Duration = duration
 		}
 	}
 
@@ -263,10 +268,10 @@ func durationFromProbeMetadata(raw *ffprobeOutput) (int, bool) {
 
 	formatDuration := parseFloat(raw.Format.Duration)
 	if !hasVideoStream(raw.Streams) && durationIsPositiveFinite(formatDuration) {
-		return roundedDuration(formatDuration), true
+		return truncatedDuration(formatDuration), true
 	}
 	if durationIsReasonable(formatDuration) && !durationLooksImplausiblyShort(raw, formatDuration) {
-		return roundedDuration(formatDuration), true
+		return truncatedDuration(formatDuration), true
 	}
 
 	for _, stream := range raw.Streams {
@@ -275,15 +280,15 @@ func durationFromProbeMetadata(raw *ffprobeOutput) (int, bool) {
 		}
 		streamDuration := parseFloat(stream.Duration)
 		if durationIsReasonable(streamDuration) && !durationLooksImplausiblyShort(raw, streamDuration) {
-			return roundedDuration(streamDuration), true
+			return truncatedDuration(streamDuration), true
 		}
 		if duration := durationAfterStart(streamDuration, parseFloat(stream.StartTime)); duration > 0 {
-			return roundedDuration(duration), true
+			return truncatedDuration(duration), true
 		}
 	}
 
 	if duration := durationAfterStart(formatDuration, parseFloat(raw.Format.StartTime)); duration > 0 {
-		return roundedDuration(duration), true
+		return truncatedDuration(duration), true
 	}
 	return 0, false
 }
@@ -329,6 +334,10 @@ func durationIsPositiveFinite(duration float64) bool {
 
 func roundedDuration(duration float64) int {
 	return max(1, int(math.Round(duration)))
+}
+
+func truncatedDuration(duration float64) int {
+	return max(1, int(duration))
 }
 
 func hasVideoStream(streams []ffprobeStream) bool {

--- a/internal/scanner/probe_duration_test.go
+++ b/internal/scanner/probe_duration_test.go
@@ -151,14 +151,17 @@ esac
 	}
 }
 
-func TestProbeFileReturnsErrorWhenRequiredPacketFallbackFails(t *testing.T) {
+// A failed packet fallback must not discard the codec/track metadata that
+// already parsed successfully; the file imports with an unknown duration and
+// the repair layer retries later.
+func TestProbeFileKeepsMetadataWhenPacketFallbackFails(t *testing.T) {
 	t.Parallel()
 
 	ffprobePath := filepath.Join(t.TempDir(), "ffprobe")
 	script := `#!/bin/sh
 case " $* " in
   *" -show_format "*)
-    printf '%s\n' '{"format":{"duration":"4298357.248000","size":"1258000000"},"streams":[{"codec_type":"video","avg_frame_rate":"30/1"}]}'
+    printf '%s\n' '{"format":{"duration":"4298357.248000","size":"1258000000"},"streams":[{"codec_type":"video","codec_name":"h264","avg_frame_rate":"30/1"}]}'
     ;;
   *)
     exit 1
@@ -169,7 +172,68 @@ esac
 		t.Fatalf("writing fake ffprobe: %v", err)
 	}
 
-	if _, err := ProbeFile(context.Background(), ffprobePath, "broken.mkv"); err == nil {
-		t.Fatal("ProbeFile() error = nil, want packet fallback failure")
+	probe, err := ProbeFile(context.Background(), ffprobePath, "broken.mkv")
+	if err != nil {
+		t.Fatalf("ProbeFile() returned error: %v", err)
+	}
+	if probe.Duration != 0 {
+		t.Fatalf("ProbeFile() duration = %d, want 0 (unknown)", probe.Duration)
+	}
+	if probe.CodecVideo != "h264" {
+		t.Fatalf("ProbeFile() codec = %q, want parsed metadata to survive the failed fallback", probe.CodecVideo)
+	}
+}
+
+// Embedded cover art is reported by ffprobe as a video stream; it must not
+// route audiobooks and music through the video duration gauntlet.
+func TestDurationFromProbeMetadataIgnoresCoverArtVideoStream(t *testing.T) {
+	t.Parallel()
+
+	raw := &ffprobeOutput{
+		Format: ffprobeFormat{Duration: "108000.000000"},
+		Streams: []ffprobeStream{
+			{CodecType: "audio"},
+			{CodecType: "video", CodecName: "mjpeg", Disposition: ffprobeDisp{AttachedPic: 1}},
+		},
+	}
+
+	got, ok := durationFromProbeMetadata(raw)
+	if !ok || got != 108000 {
+		t.Fatalf("durationFromProbeMetadata() = %d, %v; want 108000, true", got, ok)
+	}
+}
+
+func TestDurationFromProbeMetadataRejectsAbsurdAudioDuration(t *testing.T) {
+	t.Parallel()
+
+	raw := &ffprobeOutput{
+		Format:  ffprobeFormat{Duration: "4298357.248000"},
+		Streams: []ffprobeStream{{CodecType: "audio"}},
+	}
+
+	got, ok := durationFromProbeMetadata(raw)
+	if ok || got != 0 {
+		t.Fatalf("durationFromProbeMetadata() = %d, %v; want 0, false", got, ok)
+	}
+}
+
+// The end-minus-start fallbacks must apply the same plausibility guard as the
+// direct duration paths: a multi-GB video whose absolute timestamps collapse
+// to a few seconds needs the packet fallback, not a persisted 3s duration.
+func TestDurationFromProbeMetadataRejectsCollapsedTimestampSpanForLargeVideo(t *testing.T) {
+	t.Parallel()
+
+	raw := &ffprobeOutput{
+		Format: ffprobeFormat{Size: "2022705152"},
+		Streams: []ffprobeStream{{
+			CodecType: "video",
+			StartTime: "1514891.405000",
+			Duration:  "1514894.405000",
+		}},
+	}
+
+	got, ok := durationFromProbeMetadata(raw)
+	if ok || got != 0 {
+		t.Fatalf("durationFromProbeMetadata() = %d, %v; want 0, false", got, ok)
 	}
 }

--- a/internal/scanner/probe_duration_test.go
+++ b/internal/scanner/probe_duration_test.go
@@ -1,0 +1,152 @@
+package scanner
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestDurationFromProbeMetadataUsesReasonableVideoDuration(t *testing.T) {
+	t.Parallel()
+
+	raw := &ffprobeOutput{
+		Format: ffprobeFormat{Duration: "1745764.949333"},
+		Streams: []ffprobeStream{
+			{CodecType: "video", Duration: "4077.708452"},
+			{CodecType: "audio", Duration: "1745764.949333"},
+		},
+	}
+
+	got, ok := durationFromProbeMetadata(raw)
+	if !ok || got != 4078 {
+		t.Fatalf("durationFromProbeMetadata() = %d, %v; want 4078, true", got, ok)
+	}
+}
+
+func TestDurationFromProbeMetadataRemovesAbsoluteTimestampOffset(t *testing.T) {
+	t.Parallel()
+
+	raw := &ffprobeOutput{
+		Format: ffprobeFormat{
+			StartTime: "1514891.405000",
+			Duration:  "1520667.605000",
+		},
+		Streams: []ffprobeStream{{
+			CodecType: "video",
+			StartTime: "1514891.405000",
+		}},
+	}
+
+	got, ok := durationFromProbeMetadata(raw)
+	if !ok || got != 5776 {
+		t.Fatalf("durationFromProbeMetadata() = %d, %v; want 5776, true", got, ok)
+	}
+}
+
+func TestDurationFromProbeMetadataRejectsAbsurdSubtitleTimeline(t *testing.T) {
+	t.Parallel()
+
+	raw := &ffprobeOutput{
+		Format: ffprobeFormat{Duration: "4298357.248000"},
+		Streams: []ffprobeStream{
+			{CodecType: "video", AvgFrameRate: "30000/1001"},
+			{CodecType: "subtitle", Duration: "4298357.248000"},
+		},
+	}
+
+	got, ok := durationFromProbeMetadata(raw)
+	if ok || got != 0 {
+		t.Fatalf("durationFromProbeMetadata() = %d, %v; want 0, false", got, ok)
+	}
+}
+
+func TestDurationFromProbeMetadataRejectsImplausiblyShortLargeVideo(t *testing.T) {
+	t.Parallel()
+
+	raw := &ffprobeOutput{
+		Format: ffprobeFormat{
+			Duration: "3.022000",
+			Size:     "2022705152",
+		},
+		Streams: []ffprobeStream{{
+			CodecType:    "video",
+			AvgFrameRate: "30/1",
+		}},
+	}
+
+	got, ok := durationFromProbeMetadata(raw)
+	if ok || got != 0 {
+		t.Fatalf("durationFromProbeMetadata() = %d, %v; want 0, false", got, ok)
+	}
+}
+
+func TestDurationFromProbeMetadataKeepsLongAudioDurationInSeconds(t *testing.T) {
+	t.Parallel()
+
+	raw := &ffprobeOutput{
+		Format:  ffprobeFormat{Duration: "108000.000000"},
+		Streams: []ffprobeStream{{CodecType: "audio"}},
+	}
+
+	got, ok := durationFromProbeMetadata(raw)
+	if !ok || got != 108000 {
+		t.Fatalf("durationFromProbeMetadata() = %d, %v; want 108000, true", got, ok)
+	}
+}
+
+func TestEstimateVideoPacketDurationUsesPacketSpan(t *testing.T) {
+	t.Parallel()
+
+	packets := strings.NewReader("1514891.405000\n1515000.000000\n1520667.605000\n")
+	got := estimateVideoPacketDuration(packets, "30000/1001")
+	if got != 5776 {
+		t.Fatalf("estimateVideoPacketDuration() = %d, want 5776", got)
+	}
+}
+
+func TestEstimateVideoPacketDurationUsesFrameCountForCollapsedTimestamps(t *testing.T) {
+	t.Parallel()
+
+	var packets strings.Builder
+	for i := 0; i < 300; i++ {
+		packets.WriteString("3.022000\n")
+	}
+
+	got := estimateVideoPacketDuration(strings.NewReader(packets.String()), "30/1")
+	if got != 10 {
+		t.Fatalf("estimateVideoPacketDuration() = %d, want 10", got)
+	}
+}
+
+func TestProbeFileFallsBackToVideoPacketsForInvalidMetadata(t *testing.T) {
+	t.Parallel()
+
+	ffprobePath := filepath.Join(t.TempDir(), "ffprobe")
+	script := `#!/bin/sh
+case " $* " in
+  *" -show_format "*)
+    printf '%s\n' '{"format":{"duration":"4298357.248000","size":"1258000000"},"streams":[{"codec_type":"video","avg_frame_rate":"30/1"},{"codec_type":"subtitle","duration":"4298357.248000"}]}'
+    ;;
+  *)
+    i=0
+    while [ "$i" -lt 300 ]; do
+      printf '%s\n' '3.022000'
+      i=$((i + 1))
+    done
+    ;;
+esac
+`
+	if err := os.WriteFile(ffprobePath, []byte(script), 0o755); err != nil {
+		t.Fatalf("writing fake ffprobe: %v", err)
+	}
+
+	probe, err := ProbeFile(context.Background(), ffprobePath, "broken.mkv")
+	if err != nil {
+		t.Fatalf("ProbeFile() returned error: %v", err)
+	}
+	if probe.Duration != 10 {
+		t.Fatalf("ProbeFile() duration = %d, want 10", probe.Duration)
+	}
+}

--- a/internal/scanner/probe_duration_test.go
+++ b/internal/scanner/probe_duration_test.go
@@ -20,8 +20,8 @@ func TestDurationFromProbeMetadataUsesReasonableVideoDuration(t *testing.T) {
 	}
 
 	got, ok := durationFromProbeMetadata(raw)
-	if !ok || got != 4078 {
-		t.Fatalf("durationFromProbeMetadata() = %d, %v; want 4078, true", got, ok)
+	if !ok || got != 4077 {
+		t.Fatalf("durationFromProbeMetadata() = %d, %v; want 4077, true", got, ok)
 	}
 }
 
@@ -148,5 +148,28 @@ esac
 	}
 	if probe.Duration != 10 {
 		t.Fatalf("ProbeFile() duration = %d, want 10", probe.Duration)
+	}
+}
+
+func TestProbeFileReturnsErrorWhenRequiredPacketFallbackFails(t *testing.T) {
+	t.Parallel()
+
+	ffprobePath := filepath.Join(t.TempDir(), "ffprobe")
+	script := `#!/bin/sh
+case " $* " in
+  *" -show_format "*)
+    printf '%s\n' '{"format":{"duration":"4298357.248000","size":"1258000000"},"streams":[{"codec_type":"video","avg_frame_rate":"30/1"}]}'
+    ;;
+  *)
+    exit 1
+    ;;
+esac
+`
+	if err := os.WriteFile(ffprobePath, []byte(script), 0o755); err != nil {
+		t.Fatalf("writing fake ffprobe: %v", err)
+	}
+
+	if _, err := ProbeFile(context.Background(), ffprobePath, "broken.mkv"); err == nil {
+		t.Fatal("ProbeFile() error = nil, want packet fallback failure")
 	}
 }

--- a/internal/scanner/probe_repair.go
+++ b/internal/scanner/probe_repair.go
@@ -89,7 +89,7 @@ func (e *PlaybackProbeEnsurer) Ensure(ctx context.Context, file *models.MediaFil
 	if timeout <= 0 {
 		timeout = 5 * time.Second
 	}
-	if needsLegacyDurationRepair(file) && timeout < time.Minute {
+	if reprobeMayScanPackets(file) && timeout < time.Minute {
 		timeout = time.Minute
 	}
 	probeCtx, cancel := context.WithTimeout(ctx, timeout)
@@ -105,9 +105,35 @@ func (e *PlaybackProbeEnsurer) Ensure(ctx context.Context, file *models.MediaFil
 	return e.fileRepo.Upsert(ctx, updated)
 }
 
+// reprobeMayScanPackets reports whether reprobing this file is likely to hit
+// ProbeFile's packet-scan fallback, which demuxes the entire file and cannot
+// finish inside the default metadata-probe timeout.
+func reprobeMayScanPackets(file *models.MediaFile) bool {
+	if file == nil || len(file.VideoTracks) == 0 {
+		return false
+	}
+	return file.Duration <= 0 ||
+		videoDurationImplausiblyShort(float64(file.Duration), file.FileSize, true)
+}
+
+// legacyProbeDurationFixTime is when the probe duration parser stopped
+// treating large ffprobe durations as microseconds. Rows probed before this
+// may carry the collapsed durations that conversion produced. Rows probed
+// after it are authoritative: a still-short duration was re-derived from
+// packet timestamps, and re-flagging it would reprobe genuinely short clips
+// on every playback decision forever. Adjust if this fix ships later.
+var legacyProbeDurationFixTime = time.Date(2026, time.July, 18, 0, 0, 0, 0, time.UTC)
+
 func needsLegacyDurationRepair(file *models.MediaFile) bool {
-	return file != nil &&
-		file.Duration > 0 && file.Duration <= 10 &&
-		file.FileSize >= 500*1024*1024 &&
-		len(file.VideoTracks) > 0
+	if file == nil {
+		return false
+	}
+	return legacyDurationRepairNeeded(file.Duration, file.FileSize, len(file.VideoTracks) > 0, file.ProbeUpdatedAt)
+}
+
+func legacyDurationRepairNeeded(duration int, sizeBytes int64, hasVideo bool, probeUpdatedAt *time.Time) bool {
+	if !videoDurationImplausiblyShort(float64(duration), sizeBytes, hasVideo) {
+		return false
+	}
+	return probeUpdatedAt == nil || probeUpdatedAt.Before(legacyProbeDurationFixTime)
 }

--- a/internal/scanner/probe_repair.go
+++ b/internal/scanner/probe_repair.go
@@ -28,6 +28,12 @@ func NeedsCriticalProbeRepair(file *models.MediaFile) bool {
 	if file.Duration <= 0 {
 		return true
 	}
+	// Legacy probes could turn malformed multi-day container timestamps into a
+	// few seconds by treating ffprobe's seconds as microseconds. Reprobe the
+	// narrow, physically implausible shape produced by that conversion.
+	if needsLegacyDurationRepair(file) {
+		return true
+	}
 	if strings.TrimSpace(file.Container) == "" {
 		return true
 	}
@@ -83,6 +89,9 @@ func (e *PlaybackProbeEnsurer) Ensure(ctx context.Context, file *models.MediaFil
 	if timeout <= 0 {
 		timeout = 5 * time.Second
 	}
+	if needsLegacyDurationRepair(file) && timeout < time.Minute {
+		timeout = time.Minute
+	}
 	probeCtx, cancel := context.WithTimeout(ctx, timeout)
 	defer cancel()
 
@@ -94,4 +103,11 @@ func (e *PlaybackProbeEnsurer) Ensure(ctx context.Context, file *models.MediaFil
 	updated := *file
 	applyProbeData(&updated, probe, "local")
 	return e.fileRepo.Upsert(ctx, updated)
+}
+
+func needsLegacyDurationRepair(file *models.MediaFile) bool {
+	return file != nil &&
+		file.Duration > 0 && file.Duration <= 10 &&
+		file.FileSize >= 500*1024*1024 &&
+		len(file.VideoTracks) > 0
 }

--- a/internal/scanner/probe_repair_audio_test.go
+++ b/internal/scanner/probe_repair_audio_test.go
@@ -53,11 +53,10 @@ func TestNeedsCriticalProbeRepair_UnprobedFileRepairs(t *testing.T) {
 	}
 }
 
-func TestNeedsCriticalProbeRepair_ImplausiblyShortLargeVideoRepairs(t *testing.T) {
-	now := time.Now()
-	f := &models.MediaFile{
+func implausiblyShortLargeVideoFile(probedAt time.Time) *models.MediaFile {
+	return &models.MediaFile{
 		ProbeSource:    "local",
-		ProbeUpdatedAt: &now,
+		ProbeUpdatedAt: &probedAt,
 		FileSize:       1_200_000_000,
 		Duration:       4,
 		Container:      "mkv",
@@ -68,8 +67,50 @@ func TestNeedsCriticalProbeRepair_ImplausiblyShortLargeVideoRepairs(t *testing.T
 		VideoTracks:    []models.VideoTrack{{Codec: "h264"}},
 		Chapters:       []models.MediaChapter{},
 	}
+}
+
+func TestNeedsCriticalProbeRepair_ImplausiblyShortLargeVideoRepairs(t *testing.T) {
+	f := implausiblyShortLargeVideoFile(legacyProbeDurationFixTime.Add(-time.Hour))
 
 	if !NeedsCriticalProbeRepair(f) {
 		t.Fatal("a large video claiming to be four seconds should need probe repair")
+	}
+}
+
+// A short duration re-derived by the fixed parser (packet scan) is
+// authoritative: re-flagging it would reprobe genuinely short clips on every
+// playback decision forever.
+func TestNeedsCriticalProbeRepair_ShortLargeVideoReprobedAfterFixConverges(t *testing.T) {
+	f := implausiblyShortLargeVideoFile(legacyProbeDurationFixTime.Add(time.Hour))
+
+	if NeedsCriticalProbeRepair(f) {
+		t.Fatal("a short large video already reprobed by the fixed parser must not repair again")
+	}
+}
+
+func TestNeedsCriticalProbeRepairScanState_LegacyShortDurationRepairs(t *testing.T) {
+	probedAt := legacyProbeDurationFixTime.Add(-time.Hour)
+	f := &scanStateFile{
+		ProbeSource:    "local",
+		ProbeUpdatedAt: &probedAt,
+		FileSize:       1_200_000_000,
+		Duration:       4,
+		Container:      "mkv",
+		CodecVideo:     "h264",
+		CodecAudio:     "aac",
+		Resolution:     "720p",
+		HasVideoTracks: true,
+		HasAudioTracks: true,
+		HasChapters:    true,
+	}
+
+	if !needsCriticalProbeRepairScanState(f) {
+		t.Fatal("library scans must flag legacy-collapsed durations for reprobe")
+	}
+
+	reprobedAt := legacyProbeDurationFixTime.Add(time.Hour)
+	f.ProbeUpdatedAt = &reprobedAt
+	if needsCriticalProbeRepairScanState(f) {
+		t.Fatal("a short large video already reprobed by the fixed parser must not repair again")
 	}
 }

--- a/internal/scanner/probe_repair_audio_test.go
+++ b/internal/scanner/probe_repair_audio_test.go
@@ -52,3 +52,24 @@ func TestNeedsCriticalProbeRepair_UnprobedFileRepairs(t *testing.T) {
 		t.Fatal("an unprobed file must need probe repair")
 	}
 }
+
+func TestNeedsCriticalProbeRepair_ImplausiblyShortLargeVideoRepairs(t *testing.T) {
+	now := time.Now()
+	f := &models.MediaFile{
+		ProbeSource:    "local",
+		ProbeUpdatedAt: &now,
+		FileSize:       1_200_000_000,
+		Duration:       4,
+		Container:      "mkv",
+		CodecAudio:     "aac",
+		AudioTracks:    []models.AudioTrack{{Language: "eng"}},
+		CodecVideo:     "h264",
+		Resolution:     "720p",
+		VideoTracks:    []models.VideoTrack{{Codec: "h264"}},
+		Chapters:       []models.MediaChapter{},
+	}
+
+	if !NeedsCriticalProbeRepair(f) {
+		t.Fatal("a large video claiming to be four seconds should need probe repair")
+	}
+}

--- a/internal/scanner/scanner.go
+++ b/internal/scanner/scanner.go
@@ -2402,6 +2402,9 @@ func needsCriticalProbeRepairScanState(file *scanStateFile) bool {
 	if file.Duration <= 0 {
 		return true
 	}
+	if legacyDurationRepairNeeded(file.Duration, file.FileSize, file.HasVideoTracks, file.ProbeUpdatedAt) {
+		return true
+	}
 	if strings.TrimSpace(file.Container) == "" {
 		return true
 	}


### PR DESCRIPTION
## Summary

- stop treating large ffprobe durations as microseconds; ffprobe reports these values in seconds
- recover malformed video durations from a sane video stream, an absolute timestamp offset, or a streaming packet timestamp/frame-count scan
- reprobe the narrow legacy signature of videos larger than 500 MiB that were stored as ten seconds or less
- preserve legitimate long-form audio durations, including audiobooks longer than 27.8 hours

## Root cause

Malformed container, audio, or subtitle timestamps can make ffprobe report a very large duration. The scanner divided every duration over 100,000 by 1,000,000, turning affected movies and episodes into 1-4 second database values. The player then correctly clamped seeking to that incorrect backend duration. Some malformed files instead report a directly collapsed duration; for those, packet count and frame rate provide the usable timeline.

## Validation

Production samples covered all fallback paths: a valid video stream duration, absolute end-minus-start timestamps, a malformed subtitle timeline, and collapsed packet timestamps.

- `go test -race ./internal/scanner`
- `go vet ./internal/scanner`
- `git diff --check`