### PR TITLE
fix(player): stop infinite HLS startup spinner

### DIFF
--- a/web/src/player/components/VideoPlayer.tsx
+++ b/web/src/player/components/VideoPlayer.tsx
@@ -219,6 +219,7 @@ export function VideoPlayer({
   const containerRef = useRef<HTMLDivElement>(null);
   const isMountedRef = useRef(true);
   const hlsRef = useRef<HlsType | null>(null);
+  const hlsStartupGuardRef = useRef<HlsStartupGuard | null>(null);
   const mediaRecoveryAttemptsRef = useRef(0);
   const lastRecoveryRef = useRef(0);
   const streamOriginRef = useRef(0);
@@ -337,6 +338,39 @@ export function VideoPlayer({
     initialPosition,
     qualityPreference,
   });
+  const { cancelPendingTranscodeStart, startupGeneration } = transcodeQuality;
+  const hlsStartupExpected =
+    transcodeQuality.isTranscoding || transcodeQuality.transcodeStreamUrl !== null;
+
+  const failHlsStartup = useCallback(() => {
+    console.error("[hls.js] Playback startup timed out or exhausted recovery attempts");
+    cancelPendingTranscodeStart();
+
+    const activeHls = hlsRef.current;
+    hlsRef.current = null;
+    activeHls?.destroy();
+
+    const video = videoRef.current;
+    if (video) {
+      video.removeAttribute("src");
+      video.load();
+    }
+    setError("Playback failed. The media could not be loaded.");
+  }, [cancelPendingTranscodeStart]);
+
+  useEffect(() => {
+    if (!hlsStartupExpected || startupGeneration === 0) return;
+
+    const guard = new HlsStartupGuard(failHlsStartup);
+    hlsStartupGuardRef.current = guard;
+
+    return () => {
+      guard.dispose();
+      if (hlsStartupGuardRef.current === guard) {
+        hlsStartupGuardRef.current = null;
+      }
+    };
+  }, [failHlsStartup, hlsStartupExpected, startupGeneration]);
 
   // Derive effective stream URL and play method.
   // Both transcode and remux go through HLS, so treat them as "transcode" for the player.
@@ -1239,10 +1273,9 @@ export function VideoPlayer({
   // -- hls.js lifecycle --
   useEffect(() => {
     const video = videoRef.current;
-    if (!video || !isPlayerReady) return;
+    if (!video || !isPlayerReady || hlsStartupGuardRef.current?.hasFailed()) return;
 
     let hls: HlsType | null = null;
-    let startupGuard: HlsStartupGuard | null = null;
     let destroyed = false;
     let autoplayStarted = false;
 
@@ -1253,15 +1286,15 @@ export function VideoPlayer({
     const cleanupStartupListeners = () => {
       video.removeEventListener("loadeddata", attemptAutoplayWhenReady);
       video.removeEventListener("canplay", attemptAutoplayWhenReady);
+      video.removeEventListener("loadedmetadata", attemptAutoplayWhenReady);
     };
 
     const attemptAutoplayWhenReady = () => {
-      if (destroyed || autoplayStarted) return;
+      if (destroyed || autoplayStarted || hlsStartupGuardRef.current?.hasFailed()) return;
       // HAVE_FUTURE_DATA means the browser has enough media to advance beyond
       // the current frame. Starting earlier can produce a visible first-frame
       // freeze where audio advances before video begins moving.
       if (video.readyState < HTMLMediaElement.HAVE_FUTURE_DATA) return;
-      startupGuard?.markPlayable();
       autoplayStarted = true;
       cleanupStartupListeners();
       video.play().catch(() => setPlaying(false));
@@ -1276,7 +1309,7 @@ export function VideoPlayer({
       if (effectivePlayMethod === "transcode") {
         try {
           const Hls = await hlsPromise;
-          if (destroyed) return;
+          if (destroyed || hlsStartupGuardRef.current?.hasFailed()) return;
 
           if (Hls.isSupported()) {
             const maxBufferLength = selectedVersionBitrate >= 25000 ? 60 : 120;
@@ -1304,15 +1337,6 @@ export function VideoPlayer({
               },
             });
 
-            startupGuard = new HlsStartupGuard(() => {
-              if (destroyed) return;
-
-              console.error("[hls.js] Playback startup timed out or exhausted recovery attempts");
-              setError("Playback failed. The media could not be loaded.");
-              hls?.destroy();
-              hlsRef.current = null;
-            });
-
             hls.on(Hls.Events.ERROR, (_event, data) => {
               if (!data.fatal || destroyed) return;
 
@@ -1329,7 +1353,7 @@ export function VideoPlayer({
               lastRecoveryRef.current = now;
 
               if (data.type === Hls.ErrorTypes.NETWORK_ERROR) {
-                if (startupGuard?.handleFatalNetworkError() ?? true) {
+                if (hlsStartupGuardRef.current?.handleFatalNetworkError() ?? true) {
                   console.warn("[hls.js] Fatal network error, attempting recovery...");
                   hls?.startLoad();
                 } else {
@@ -1392,7 +1416,6 @@ export function VideoPlayer({
 
     return () => {
       destroyed = true;
-      startupGuard?.dispose();
       cleanupStartupListeners();
       if (hls) {
         hls.destroy();
@@ -1428,6 +1451,10 @@ export function VideoPlayer({
       }
       setBuffering(false);
     };
+    const markPlaybackStarted = () => {
+      hlsStartupGuardRef.current?.markPlaybackStarted();
+      setAwaitingFirstFrame(false);
+    };
     const onTimeUpdate = () => {
       const nextTime = toMediaTime(video.currentTime, streamOriginRef.current);
       const resolved = resolvePendingSeekTime(nextTime, pendingSeekTime);
@@ -1438,13 +1465,13 @@ export function VideoPlayer({
       // timeupdate is the most reliable signal that frames are rendering.
       // Also clears any stale buffering state from HLS segment transitions
       // where `waiting` fired but `canplay`/`playing` never followed.
-      setAwaitingFirstFrame(false);
+      markPlaybackStarted();
       clearBuffering();
     };
     const onSeeked = () => {
       setPendingSeekTime(null);
       setCurrentTime(toMediaTime(video.currentTime, streamOriginRef.current));
-      setAwaitingFirstFrame(false);
+      markPlaybackStarted();
       clearBuffering();
       if (roomSyncWaiting && watchTogetherSync.attachedSessionId === sessionId) {
         watchTogetherSync.reportReady();
@@ -1486,7 +1513,7 @@ export function VideoPlayer({
     };
     const onPlaying = () => {
       clearBuffering();
-      setAwaitingFirstFrame(false);
+      markPlaybackStarted();
     };
     const onStalled = () => {
       if (watchTogetherRoomActive && watchTogetherSync.attachedSessionId === sessionId) {

--- a/web/src/player/components/VideoPlayer.tsx
+++ b/web/src/player/components/VideoPlayer.tsx
@@ -34,6 +34,7 @@ import type {
 } from "../realtime-protocol";
 import { resolvePendingSeekTime } from "../utils/pendingSeek";
 import { resolveVersionAudioLanguage } from "../utils/effectiveAudioLanguage";
+import { HlsStartupGuard } from "../utils/hlsStartupGuard";
 import { normalizeSubtitleMode } from "../utils/subtitleMode";
 import type {
   PlaybackExitState,
@@ -1241,6 +1242,7 @@ export function VideoPlayer({
     if (!video || !isPlayerReady) return;
 
     let hls: HlsType | null = null;
+    let startupGuard: HlsStartupGuard | null = null;
     let destroyed = false;
     let autoplayStarted = false;
 
@@ -1259,6 +1261,7 @@ export function VideoPlayer({
       // the current frame. Starting earlier can produce a visible first-frame
       // freeze where audio advances before video begins moving.
       if (video.readyState < HTMLMediaElement.HAVE_FUTURE_DATA) return;
+      startupGuard?.markPlayable();
       autoplayStarted = true;
       cleanupStartupListeners();
       video.play().catch(() => setPlaying(false));
@@ -1301,6 +1304,15 @@ export function VideoPlayer({
               },
             });
 
+            startupGuard = new HlsStartupGuard(() => {
+              if (destroyed) return;
+
+              console.error("[hls.js] Playback startup timed out or exhausted recovery attempts");
+              setError("Playback failed. The media could not be loaded.");
+              hls?.destroy();
+              hlsRef.current = null;
+            });
+
             hls.on(Hls.Events.ERROR, (_event, data) => {
               if (!data.fatal || destroyed) return;
 
@@ -1317,8 +1329,12 @@ export function VideoPlayer({
               lastRecoveryRef.current = now;
 
               if (data.type === Hls.ErrorTypes.NETWORK_ERROR) {
-                console.warn("[hls.js] Fatal network error, attempting recovery...");
-                hls?.startLoad();
+                if (startupGuard?.handleFatalNetworkError() ?? true) {
+                  console.warn("[hls.js] Fatal network error, attempting recovery...");
+                  hls?.startLoad();
+                } else {
+                  console.error("[hls.js] Fatal startup network error, giving up");
+                }
               } else if (data.type === Hls.ErrorTypes.MEDIA_ERROR) {
                 if (mediaRecoveryAttemptsRef.current === 0) {
                   console.warn("[hls.js] Fatal media error, attempting recovery...");
@@ -1376,6 +1392,7 @@ export function VideoPlayer({
 
     return () => {
       destroyed = true;
+      startupGuard?.dispose();
       cleanupStartupListeners();
       if (hls) {
         hls.destroy();

--- a/web/src/player/hooks/useTranscodeQuality.test.tsx
+++ b/web/src/player/hooks/useTranscodeQuality.test.tsx
@@ -150,6 +150,34 @@ describe("useTranscodeQuality", () => {
     expect(fetchMock).not.toHaveBeenCalled();
   });
 
+  it("cancels an in-flight startup before a manifest arrives", async () => {
+    let requestSignal: AbortSignal | undefined;
+    fetchMock.mockImplementationOnce((_, init: RequestInit) => {
+      requestSignal = init.signal as AbortSignal;
+      return new Promise((_, reject) => {
+        requestSignal?.addEventListener(
+          "abort",
+          () => reject(new DOMException("Aborted", "AbortError")),
+          { once: true },
+        );
+      });
+    });
+
+    const { result } = renderQuality();
+
+    await waitFor(() => expect(fetchMock).toHaveBeenCalledOnce());
+    expect(result.current.startupGeneration).toBe(1);
+    expect(result.current.isTranscoding).toBe(true);
+
+    act(() => {
+      result.current.cancelPendingTranscodeStart();
+    });
+
+    expect(requestSignal?.aborted).toBe(true);
+    await waitFor(() => expect(result.current.isTranscoding).toBe(false));
+    expect(result.current.error).toBeNull();
+  });
+
   it("rolls back a failed burn-in selection so the same track can be retried", async () => {
     const { result } = renderQuality();
 

--- a/web/src/player/hooks/useTranscodeQuality.ts
+++ b/web/src/player/hooks/useTranscodeQuality.ts
@@ -76,6 +76,10 @@ interface UseTranscodeQualityResult {
   canSeekAnywhere: boolean;
   durationSeconds: number | null;
   isTranscoding: boolean;
+  /** Increments when a user-visible HLS startup attempt begins. */
+  startupGeneration: number;
+  /** Cancels a transcode start that has not produced playable media yet. */
+  cancelPendingTranscodeStart: () => void;
   error: string | null;
   switchedFileId: number | null;
   effectiveVersion: PlayerFileVersion | undefined;
@@ -188,6 +192,7 @@ export function useTranscodeQuality({
   const [canSeekAnywhere, setCanSeekAnywhere] = useState(true);
   const [durationSeconds, setDurationSeconds] = useState<number | null>(null);
   const [isTranscoding, setIsTranscoding] = useState(false);
+  const [startupGeneration, setStartupGeneration] = useState(0);
   const [error, setError] = useState<string | null>(null);
   const [switchedFileId, setSwitchedFileId] = useState<number | null>(null);
   const switchAbortRef = useRef<AbortController | null>(null);
@@ -336,6 +341,7 @@ export function useTranscodeQuality({
       const abortController = new AbortController();
       switchAbortRef.current = abortController;
 
+      setStartupGeneration((generation) => generation + 1);
       setIsTranscoding(true);
       setActiveQualityId(qualityId);
       setError(null);
@@ -469,6 +475,16 @@ export function useTranscodeQuality({
     [sessionId, activeQualityId, qualityOptions, config, effectiveVersion, playMethod],
   );
 
+  const cancelPendingTranscodeStart = useCallback(() => {
+    if (dispatchTimerRef.current != null) {
+      clearTimeout(dispatchTimerRef.current);
+      dispatchTimerRef.current = null;
+    }
+    switchAbortRef.current?.abort();
+    switchAbortRef.current = null;
+    setIsTranscoding(false);
+  }, []);
+
   const switchQuality = useCallback(
     (qualityId: string, currentPosition: number, forceRestart?: boolean) => {
       requestedQualityIdRef.current = qualityId;
@@ -579,6 +595,8 @@ export function useTranscodeQuality({
     canSeekAnywhere,
     durationSeconds,
     isTranscoding,
+    startupGeneration,
+    cancelPendingTranscodeStart,
     error,
     switchedFileId,
     effectiveVersion,

--- a/web/src/player/utils/hlsStartupGuard.test.ts
+++ b/web/src/player/utils/hlsStartupGuard.test.ts
@@ -1,0 +1,58 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { HLS_STARTUP_TIMEOUT_MS, HlsStartupGuard } from "./hlsStartupGuard";
+
+describe("HlsStartupGuard", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("fails startup when no playable frame arrives before the deadline", () => {
+    const onFailure = vi.fn();
+    const guard = new HlsStartupGuard(onFailure);
+
+    vi.advanceTimersByTime(HLS_STARTUP_TIMEOUT_MS - 1);
+    expect(onFailure).not.toHaveBeenCalled();
+
+    vi.advanceTimersByTime(1);
+    expect(onFailure).toHaveBeenCalledOnce();
+    guard.dispose();
+  });
+
+  it("allows one fatal network recovery before failing startup", () => {
+    const onFailure = vi.fn();
+    const guard = new HlsStartupGuard(onFailure);
+
+    expect(guard.handleFatalNetworkError()).toBe(true);
+    expect(onFailure).not.toHaveBeenCalled();
+
+    expect(guard.handleFatalNetworkError()).toBe(false);
+    expect(onFailure).toHaveBeenCalledOnce();
+  });
+
+  it("disarms startup limits after playable media arrives", () => {
+    const onFailure = vi.fn();
+    const guard = new HlsStartupGuard(onFailure);
+
+    guard.markPlayable();
+    vi.advanceTimersByTime(HLS_STARTUP_TIMEOUT_MS);
+
+    expect(onFailure).not.toHaveBeenCalled();
+    expect(guard.handleFatalNetworkError()).toBe(true);
+    expect(guard.handleFatalNetworkError()).toBe(true);
+  });
+
+  it("does not fail after disposal", () => {
+    const onFailure = vi.fn();
+    const guard = new HlsStartupGuard(onFailure);
+
+    guard.dispose();
+    vi.advanceTimersByTime(HLS_STARTUP_TIMEOUT_MS);
+
+    expect(onFailure).not.toHaveBeenCalled();
+  });
+});

--- a/web/src/player/utils/hlsStartupGuard.test.ts
+++ b/web/src/player/utils/hlsStartupGuard.test.ts
@@ -17,9 +17,11 @@ describe("HlsStartupGuard", () => {
 
     vi.advanceTimersByTime(HLS_STARTUP_TIMEOUT_MS - 1);
     expect(onFailure).not.toHaveBeenCalled();
+    expect(guard.hasFailed()).toBe(false);
 
     vi.advanceTimersByTime(1);
     expect(onFailure).toHaveBeenCalledOnce();
+    expect(guard.hasFailed()).toBe(true);
     guard.dispose();
   });
 
@@ -32,16 +34,18 @@ describe("HlsStartupGuard", () => {
 
     expect(guard.handleFatalNetworkError()).toBe(false);
     expect(onFailure).toHaveBeenCalledOnce();
+    expect(guard.hasFailed()).toBe(true);
   });
 
   it("disarms startup limits after playable media arrives", () => {
     const onFailure = vi.fn();
     const guard = new HlsStartupGuard(onFailure);
 
-    guard.markPlayable();
+    guard.markPlaybackStarted();
     vi.advanceTimersByTime(HLS_STARTUP_TIMEOUT_MS);
 
     expect(onFailure).not.toHaveBeenCalled();
+    expect(guard.hasFailed()).toBe(false);
     expect(guard.handleFatalNetworkError()).toBe(true);
     expect(guard.handleFatalNetworkError()).toBe(true);
   });

--- a/web/src/player/utils/hlsStartupGuard.ts
+++ b/web/src/player/utils/hlsStartupGuard.ts
@@ -1,0 +1,58 @@
+export const HLS_STARTUP_TIMEOUT_MS = 60_000;
+
+const MAX_FATAL_NETWORK_RECOVERIES = 1;
+
+type StartupState = "starting" | "playable" | "failed" | "disposed";
+
+export class HlsStartupGuard {
+  private state: StartupState = "starting";
+  private fatalNetworkRecoveries = 0;
+  private timeoutId: ReturnType<typeof setTimeout> | null;
+
+  constructor(
+    private readonly onFailure: () => void,
+    timeoutMs = HLS_STARTUP_TIMEOUT_MS,
+  ) {
+    this.timeoutId = setTimeout(() => this.fail(), timeoutMs);
+  }
+
+  handleFatalNetworkError(): boolean {
+    if (this.state === "playable") return true;
+    if (this.state !== "starting") return false;
+
+    if (this.fatalNetworkRecoveries < MAX_FATAL_NETWORK_RECOVERIES) {
+      this.fatalNetworkRecoveries++;
+      return true;
+    }
+
+    this.fail();
+    return false;
+  }
+
+  markPlayable() {
+    if (this.state !== "starting") return;
+
+    this.state = "playable";
+    this.clearTimeout();
+  }
+
+  dispose() {
+    this.state = "disposed";
+    this.clearTimeout();
+  }
+
+  private fail() {
+    if (this.state !== "starting") return;
+
+    this.state = "failed";
+    this.clearTimeout();
+    this.onFailure();
+  }
+
+  private clearTimeout() {
+    if (this.timeoutId === null) return;
+
+    clearTimeout(this.timeoutId);
+    this.timeoutId = null;
+  }
+}

--- a/web/src/player/utils/hlsStartupGuard.ts
+++ b/web/src/player/utils/hlsStartupGuard.ts
@@ -9,11 +9,8 @@ export class HlsStartupGuard {
   private fatalNetworkRecoveries = 0;
   private timeoutId: ReturnType<typeof setTimeout> | null;
 
-  constructor(
-    private readonly onFailure: () => void,
-    timeoutMs = HLS_STARTUP_TIMEOUT_MS,
-  ) {
-    this.timeoutId = setTimeout(() => this.fail(), timeoutMs);
+  constructor(private readonly onFailure: () => void) {
+    this.timeoutId = setTimeout(() => this.fail(), HLS_STARTUP_TIMEOUT_MS);
   }
 
   handleFatalNetworkError(): boolean {
@@ -29,11 +26,15 @@ export class HlsStartupGuard {
     return false;
   }
 
-  markPlayable() {
+  markPlaybackStarted() {
     if (this.state !== "starting") return;
 
     this.state = "playable";
     this.clearTimeout();
+  }
+
+  hasFailed() {
+    return this.state === "failed";
   }
 
   dispose() {


### PR DESCRIPTION
## Summary
- begin one 60-second HLS startup deadline when the transcode request starts
- keep the deadline active through manifest acquisition, native or hls.js startup, and the first rendered frame
- abort pending transcode startup and stop media loading when the deadline or recovery limit is reached
- bound fatal network recovery during startup and replace the spinner with the playback error state

## Testing
- `pnpm exec vitest run src/player` — 24 files and 149 tests passed
- `pnpm exec eslint src/player/components/VideoPlayer.tsx src/player/hooks/useTranscodeQuality.ts src/player/hooks/useTranscodeQuality.test.tsx src/player/utils/hlsStartupGuard.ts src/player/utils/hlsStartupGuard.test.ts`
- `pnpm run lint` — 0 errors; 159 existing repository warnings
- `pnpm run format:check`
- `pnpm build`
- `make verify-local-paths`

## AI use
Codex assisted with review-driven implementation and validation. The resulting diff was manually inspected and exercised with the focused and full player test suites.