### PR TITLE
fix(playback): avoid unnecessary HDR video transcodes

### DIFF
--- a/internal/api/handlers/playback_v3.go
+++ b/internal/api/handlers/playback_v3.go
@@ -1214,7 +1214,7 @@ func (h *PlaybackHandler) executeReplanV3(r *http.Request, record *playback.Atte
 	}
 	result := playback.PlanPlaybackV3(playback.PlannerInputV3{Request: start, RequestedFile: plannerRequestedFile, EffectiveFile: effectiveFile, AudioTrackIndex: audioIndex, Settings: h.plannerSettingsV3(r.Context()), Registry: h.transformationRegistryV3(r.Context()), HLSRegistry: h.lazyHLSPlanningRegistryV3(r.Context()), Now: time.Now(), AttemptedKeys: attemptedKeys, AdditionalSubtitles: h.downloadedSubtitleInventoryV3(r.Context(), effectiveFile)})
 	if result.Terminal != nil &&
-		(result.Terminal.Reason == "no_alternate_version" || result.Terminal.Reason == "hdr_transcode_unsupported") &&
+		shouldTryAlternateAfterTerminalV3(result.Terminal.Reason, start.QualityPreference) &&
 		replanAllowsAlternateFileV3(operation, start.QualityPreference) {
 		if alternate, alternateErr := h.findAlternateFile(r.Context(), requestedFile); alternateErr == nil && alternate != nil {
 			alternate = h.ensurePlaybackProbe(r.Context(), alternate)

--- a/internal/api/handlers/playback_v3.go
+++ b/internal/api/handlers/playback_v3.go
@@ -428,7 +428,7 @@ func (h *PlaybackHandler) handleStartPlaybackV3(w http.ResponseWriter, r *http.R
 		Registry: h.transformationRegistryV3(r.Context()), HLSRegistry: h.lazyHLSPlanningRegistryV3(r.Context()), Now: time.Now(),
 		AdditionalSubtitles: h.downloadedSubtitleInventoryV3(r.Context(), effectiveFile),
 	})
-	if result.Terminal != nil && result.Terminal.Reason == "no_alternate_version" && shouldTryAlternateFileV3(req.QualityPreference) {
+	if result.Terminal != nil && shouldTryAlternateAfterTerminalV3(result.Terminal.Reason, req.QualityPreference) {
 		if alternate, alternateErr := h.findAlternateFile(r.Context(), requestedFile); alternateErr == nil && alternate != nil {
 			effectiveFile = h.ensurePlaybackProbe(r.Context(), alternate)
 			audioIndex = remapAudioIndexV3(requestedFile, effectiveFile, audioIndex)
@@ -1213,7 +1213,9 @@ func (h *PlaybackHandler) executeReplanV3(r *http.Request, record *playback.Atte
 		}
 	}
 	result := playback.PlanPlaybackV3(playback.PlannerInputV3{Request: start, RequestedFile: plannerRequestedFile, EffectiveFile: effectiveFile, AudioTrackIndex: audioIndex, Settings: h.plannerSettingsV3(r.Context()), Registry: h.transformationRegistryV3(r.Context()), HLSRegistry: h.lazyHLSPlanningRegistryV3(r.Context()), Now: time.Now(), AttemptedKeys: attemptedKeys, AdditionalSubtitles: h.downloadedSubtitleInventoryV3(r.Context(), effectiveFile)})
-	if result.Terminal != nil && result.Terminal.Reason == "no_alternate_version" && replanAllowsAlternateFileV3(operation, start.QualityPreference) {
+	if result.Terminal != nil &&
+		(result.Terminal.Reason == "no_alternate_version" || result.Terminal.Reason == "hdr_transcode_unsupported") &&
+		replanAllowsAlternateFileV3(operation, start.QualityPreference) {
 		if alternate, alternateErr := h.findAlternateFile(r.Context(), requestedFile); alternateErr == nil && alternate != nil {
 			alternate = h.ensurePlaybackProbe(r.Context(), alternate)
 			remappedAudio := remapAudioIndexV3(effectiveFile, alternate, audioIndex)
@@ -1488,6 +1490,17 @@ func copyOptionalIntV3(value *int) *int {
 
 func shouldTryAlternateFileV3(qualityPreference string) bool {
 	return !strings.EqualFold(strings.TrimSpace(qualityPreference), "original")
+}
+
+// shouldTryAlternateAfterTerminalV3 keeps HDR sources from entering an
+// unvalidated video transcode. When the requested HDR version needs video
+// adaptation but no safe HDR recipe is installed, try the same content's SDR
+// or lower-resolution version before returning the terminal response.
+func shouldTryAlternateAfterTerminalV3(reason, qualityPreference string) bool {
+	if !shouldTryAlternateFileV3(qualityPreference) {
+		return false
+	}
+	return reason == "no_alternate_version" || reason == "hdr_transcode_unsupported"
 }
 
 func replanAllowsAlternateFileV3(operation playback.ReplanOperationV3, qualityPreference string) bool {

--- a/internal/api/handlers/playback_v3_test.go
+++ b/internal/api/handlers/playback_v3_test.go
@@ -51,6 +51,26 @@ func TestShouldTryAlternateFileV3PinsOriginalQuality(t *testing.T) {
 	}
 }
 
+func TestShouldTryAlternateAfterTerminalV3AvoidsHDRTranscode(t *testing.T) {
+	tests := []struct {
+		reason  string
+		quality string
+		want    bool
+	}{
+		{reason: "hdr_transcode_unsupported", quality: "auto", want: true},
+		{reason: "no_alternate_version", quality: "1080p", want: true},
+		{reason: "hdr_transcode_unsupported", quality: "original", want: false},
+		{reason: "conversion_tool_unavailable", quality: "auto", want: false},
+	}
+	for _, test := range tests {
+		t.Run(test.reason+"/"+test.quality, func(t *testing.T) {
+			if got := shouldTryAlternateAfterTerminalV3(test.reason, test.quality); got != test.want {
+				t.Fatalf("shouldTryAlternateAfterTerminalV3(%q, %q) = %v, want %v", test.reason, test.quality, got, test.want)
+			}
+		})
+	}
+}
+
 func TestReplanAllowsAlternateFileV3PinsSeekOperations(t *testing.T) {
 	tests := []struct {
 		name      string

--- a/internal/playback/capabilities_v3.go
+++ b/internal/playback/capabilities_v3.go
@@ -93,9 +93,14 @@ func detailedVideoEligibleV3(source SourceDescriptorV3, request StartRequestV3) 
 		if len(capability.BitDepths) > 0 && !containsIntV3(capability.BitDepths, source.BitDepth) {
 			continue
 		}
-		if capability.MaxWidth > 0 && source.Width > capability.MaxWidth || capability.MaxHeight > 0 && source.Height > capability.MaxHeight || capability.MaxFrameRate > 0 && source.FrameRate > capability.MaxFrameRate || capability.MaxBitrateKbps > 0 && source.BitrateKbps > capability.MaxBitrateKbps {
+		if capability.MaxWidth > 0 && source.Width > capability.MaxWidth || capability.MaxHeight > 0 && source.Height > capability.MaxHeight || capability.MaxFrameRate > 0 && source.FrameRate > capability.MaxFrameRate {
 			continue
 		}
+		// MediaCodec's bitrateRange is not a reliable hard decode ceiling on
+		// Android TV. Vendors commonly report a conservative value even when
+		// the hardware decoder can accept higher-bitrate HEVC/HDR streams. A
+		// bitrate mismatch should affect buffering/quality policy, not turn a
+		// source-preserving route into a video transcode.
 		return true
 	}
 	return false

--- a/internal/playback/capabilities_v3_test.go
+++ b/internal/playback/capabilities_v3_test.go
@@ -1,0 +1,45 @@
+package playback
+
+import (
+	"testing"
+
+	"github.com/Silo-Server/silo-server/internal/models"
+)
+
+func TestDetailedVideoEligibilityDoesNotRejectHardwareForReportedBitrate(t *testing.T) {
+	file := &models.MediaFile{
+		ID:        42,
+		Container: "mkv",
+		VideoTracks: []models.VideoTrack{{
+			Codec:         "hevc",
+			Profile:       "Main 10",
+			Level:         153,
+			BitDepth:      10,
+			Width:         3840,
+			Height:        2160,
+			FrameRate:     "23.976",
+			Bitrate:       120_000_000,
+			VideoRange:    "HDR",
+			ColorTransfer: "smpte2084",
+		}},
+	}
+
+	request := validStartRequestV3()
+	request.ClientPlaybackContext.Features = append(request.ClientPlaybackContext.Features, FeatureDetailedDecodeV3)
+	request.Capabilities.VideoDecode = []VideoDecodeCapabilityV3{{
+		Codec:          "hevc",
+		Profiles:       []string{"main 10"},
+		Levels:         []int{153},
+		BitDepths:      []int{10},
+		MaxWidth:       3840,
+		MaxHeight:      2160,
+		MaxFrameRate:   60,
+		MaxBitrateKbps: 80_000,
+		Hardware:       true,
+	}}
+
+	source := SourceDescriptorFromFileV3(file, -1)
+	if !detailedVideoEligibleV3(source, request) {
+		t.Fatal("hardware HDR decode should not be rejected because of reported bitrate")
+	}
+}


### PR DESCRIPTION
## Summary

- Do not treat Android `MediaCodec`'s reported `bitrateRange` as a hard hardware decode ceiling.
- Keep source-preserving direct playback eligible when codec, profile, bit depth, resolution, and frame rate are supported.
- When an HDR route still cannot be validated, try an SDR or lower-resolution alternate for automatic quality instead of returning a blocked HDR transcode terminal.
- Preserve the explicit `original` preference and existing 4K-transcode policy.

## Why

Android TV devices such as NVIDIA Shield can direct-play HDR/HEVC files whose bitrate exceeds the conservative bitrate reported by `MediaCodec`. The old gate routed those files into video adaptation, where HDR encoding is intentionally unavailable, producing `hdr_transcode_unsupported` before the device ever received a media source.

Bitrate should influence buffering and quality selection, not declare a hardware decoder incapable of accepting a stream. Resolution, frame rate, codec, profile, and bit depth remain validated.

## Verification

- `go test ./internal/playback ./internal/api/handlers -run 'TestDetailedVideoEligibilityDoesNotRejectHardwareForReportedBitrate|TestShouldTryAlternateAfterTerminalV3AvoidsHDRTranscode|TestReplanAllowsAlternate'`
- `git diff --check`

The focused tests pass on current `upstream/main` (`95779c47`).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved playback fallback handling for HDR content when HDR transcoding is unavailable.
  * Preserved alternate-version selection where quality preferences allow it.
  * Improved hardware HDR playback eligibility by avoiding unnecessary rejection based on reported bitrate limits.

* **Tests**
  * Added coverage for HDR fallback decisions and hardware decoding eligibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->