### PR TITLE
feat(playback): add STRM stream shortcut support

### DIFF
--- a/internal/playback/directplay.go
+++ b/internal/playback/directplay.go
@@ -52,6 +52,21 @@ func MimeFromExtension(name string) string {
 // Range requests, conditional requests (If-Modified-Since, If-None-Match),
 // and Content-Type detection.
 func ServeDirectPlay(w http.ResponseWriter, r *http.Request, filePath string) error {
+	if strings.ToLower(filepath.Ext(filePath)) == ".strm" {
+		content, err := os.ReadFile(filePath)
+		if err != nil {
+			http.Error(w, "failed to read stream shortcut", http.StatusInternalServerError)
+			return err
+		}
+		streamURL := strings.TrimSpace(string(content))
+		if streamURL == "" {
+			http.Error(w, "stream shortcut is empty", http.StatusBadRequest)
+			return nil
+		}
+		http.Redirect(w, r, streamURL, http.StatusTemporaryRedirect)
+		return nil
+	}
+
 	// Media bodies routinely take longer than the server's absolute
 	// WriteTimeout; roll the write deadline with progress instead.
 	w = httpstream.NewRollingDeadlineWriter(w)

--- a/internal/playback/directplay.go
+++ b/internal/playback/directplay.go
@@ -52,16 +52,11 @@ func MimeFromExtension(name string) string {
 // Range requests, conditional requests (If-Modified-Since, If-None-Match),
 // and Content-Type detection.
 func ServeDirectPlay(w http.ResponseWriter, r *http.Request, filePath string) error {
-	if strings.ToLower(filepath.Ext(filePath)) == ".strm" {
-		content, err := os.ReadFile(filePath)
+	if strings.EqualFold(filepath.Ext(filePath), ".strm") {
+		streamURL, err := resolveTranscodeInputPath(filePath)
 		if err != nil {
-			http.Error(w, "failed to read stream shortcut", http.StatusInternalServerError)
+			http.Error(w, "invalid stream shortcut", http.StatusBadRequest)
 			return err
-		}
-		streamURL := strings.TrimSpace(string(content))
-		if streamURL == "" {
-			http.Error(w, "stream shortcut is empty", http.StatusBadRequest)
-			return nil
 		}
 		http.Redirect(w, r, streamURL, http.StatusTemporaryRedirect)
 		return nil

--- a/internal/playback/plan_v3.go
+++ b/internal/playback/plan_v3.go
@@ -2,6 +2,7 @@ package playback
 
 import (
 	"fmt"
+	"path/filepath"
 	"sort"
 	"strconv"
 	"strings"
@@ -157,6 +158,22 @@ func PlanPlaybackV3(input PlannerInputV3) PlannerResultV3 {
 		})
 	}
 	if !detailedVideoEvidenceCompleteV3(source) {
+		if isDynamicStreamSourceV3(file) {
+			targetHeight := source.Height
+			if targetHeight <= 0 {
+				targetHeight = 1080
+			}
+			width, bitrate := qualityDimensionsV3(targetHeight, source.Width, source.Height)
+			dynamicQuality := QualityResultV3{
+				Label:             resolutionLabelV3(targetHeight),
+				Width:             width,
+				Height:            targetHeight,
+				BitrateKbps:       bitrate,
+				RequiresTranscode: true,
+				Reason:            "dynamic_stream_metadata_deferred",
+			}
+			return planVideoTranscodeV3(input, base, source, dynamicQuality, hlsSubtitle, "dynamic_stream_metadata_deferred")
+		}
 		return terminalPlannerResultV3("source_metadata_incomplete", "The source is missing video metadata required for a validated playback route.", true)
 	}
 
@@ -375,6 +392,10 @@ func PlanPlaybackV3(input PlannerInputV3) PlannerResultV3 {
 	}
 
 	return terminalPlannerResultV3("adaptation_unavailable", "No validated playback route is available for this source and output route.", false)
+}
+
+func isDynamicStreamSourceV3(file *models.MediaFile) bool {
+	return file != nil && (strings.EqualFold(filepath.Ext(file.FilePath), ".strm") || strings.EqualFold(file.Container, "strm"))
 }
 
 // planVideoTranscodeV3 always executes on the HLS engine, so the caller must

--- a/internal/playback/protocol_v3_test.go
+++ b/internal/playback/protocol_v3_test.go
@@ -321,6 +321,27 @@ func TestPlanPlaybackV3RejectsTrulyIncompleteVideoMetadata(t *testing.T) {
 	}
 }
 
+func TestPlanPlaybackV3UsesConservativeHLSForDynamicSTRM(t *testing.T) {
+	file := &models.MediaFile{
+		ID: 42, FilePath: "/media/movie.strm", Container: "strm",
+		CodecVideo: "h264", CodecAudio: "aac", Resolution: "1080p", AudioChannels: 2,
+		VideoTracks: []models.VideoTrack{{Codec: "h264", Width: 1920, Height: 1080}},
+		AudioTracks: []models.AudioTrack{{Codec: "aac", Channels: 2, Layout: "stereo"}},
+	}
+	req := validStartRequestV3()
+	req.QualityPreference = "auto"
+	result := PlanPlaybackV3(PlannerInputV3{
+		Request: req, RequestedFile: file, EffectiveFile: file, AudioTrackIndex: 0,
+		Settings: PlannerSettingsV3{TranscodeEnabled: true, Allow4KTranscode: true}, Registry: testTransformationRegistryV3(),
+	})
+	if result.Plan == nil || result.Plan.Delivery != DeliveryTranscodeHLSV3 || result.PlayMethod != PlayTranscode {
+		t.Fatalf("result = %s", ExplainPlannerResultV3(result))
+	}
+	if result.Plan.DecisionReason != "dynamic_stream_metadata_deferred" || result.TargetResolution != "1080p" || result.TargetBitrateKbps != 6000 {
+		t.Fatalf("dynamic plan = %#v result = %#v", result.Plan, result)
+	}
+}
+
 func TestPlanPlaybackV3BlocksUltrawide4KTranscode(t *testing.T) {
 	file := detailedFixtureFileV3()
 	file.Resolution = "2160p"

--- a/internal/playback/strm_test.go
+++ b/internal/playback/strm_test.go
@@ -1,0 +1,48 @@
+package playback
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestResolveTranscodeInputPathSTRM(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "movie.strm")
+	const want = "https://media.example.test/play/movie.mkv?token=secret"
+	if err := os.WriteFile(path, []byte(want+"\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	got, err := resolveTranscodeInputPath(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got != want {
+		t.Fatalf("resolved input = %q, want %q", got, want)
+	}
+}
+
+func TestResolveTranscodeInputPathRejectsInvalidSTRM(t *testing.T) {
+	for name, content := range map[string]string{
+		"empty":    " \n",
+		"multiple": "https://one.example/file\nhttps://two.example/file",
+		"local":    "file:///etc/passwd",
+	} {
+		t.Run(name, func(t *testing.T) {
+			path := filepath.Join(t.TempDir(), "movie.strm")
+			if err := os.WriteFile(path, []byte(content), 0o600); err != nil {
+				t.Fatal(err)
+			}
+			if _, err := resolveTranscodeInputPath(path); err == nil {
+				t.Fatal("expected invalid .strm to be rejected")
+			}
+		})
+	}
+}
+
+func TestResolveTranscodeInputPathLeavesMediaPathAlone(t *testing.T) {
+	const path = "/media/movie.mkv"
+	got, err := resolveTranscodeInputPath(path)
+	if err != nil || got != path {
+		t.Fatalf("resolved input = %q, err = %v", got, err)
+	}
+}

--- a/internal/playback/strm_test.go
+++ b/internal/playback/strm_test.go
@@ -1,8 +1,11 @@
 package playback
 
 import (
+	"net/http"
+	"net/http/httptest"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 )
 
@@ -23,9 +26,10 @@ func TestResolveTranscodeInputPathSTRM(t *testing.T) {
 
 func TestResolveTranscodeInputPathRejectsInvalidSTRM(t *testing.T) {
 	for name, content := range map[string]string{
-		"empty":    " \n",
-		"multiple": "https://one.example/file\nhttps://two.example/file",
-		"local":    "file:///etc/passwd",
+		"empty":     " \n",
+		"multiple":  "https://one.example/file\nhttps://two.example/file",
+		"local":     "file:///etc/passwd",
+		"oversized": strings.Repeat("a", 64*1024+1),
 	} {
 		t.Run(name, func(t *testing.T) {
 			path := filepath.Join(t.TempDir(), "movie.strm")
@@ -44,5 +48,21 @@ func TestResolveTranscodeInputPathLeavesMediaPathAlone(t *testing.T) {
 	got, err := resolveTranscodeInputPath(path)
 	if err != nil || got != path {
 		t.Fatalf("resolved input = %q, err = %v", got, err)
+	}
+}
+
+func TestServeDirectPlayRejectsInvalidSTRM(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "movie.strm")
+	if err := os.WriteFile(path, []byte("file:///etc/passwd\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	request := httptest.NewRequest(http.MethodGet, "/stream", nil)
+	response := httptest.NewRecorder()
+	err := ServeDirectPlay(response, request, path)
+	if err == nil {
+		t.Fatal("expected invalid .strm to be rejected")
+	}
+	if response.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d, want %d", response.Code, http.StatusBadRequest)
 	}
 }

--- a/internal/playback/transcode.go
+++ b/internal/playback/transcode.go
@@ -236,16 +236,19 @@ func resolveTranscodeInputPath(inputPath string) (string, error) {
 	if !strings.EqualFold(filepath.Ext(inputPath), ".strm") {
 		return inputPath, nil
 	}
-	info, err := os.Stat(inputPath)
-	if err != nil {
-		return "", fmt.Errorf("stat stream shortcut: %w", err)
-	}
-	if info.Size() > 64*1024 {
-		return "", fmt.Errorf("stream shortcut exceeds 64 KiB")
-	}
-	content, err := os.ReadFile(inputPath)
+	file, err := os.Open(inputPath)
 	if err != nil {
 		return "", fmt.Errorf("read stream shortcut: %w", err)
+	}
+	defer func() { _ = file.Close() }()
+
+	const maxStreamShortcutBytes = 64 * 1024
+	content, err := io.ReadAll(io.LimitReader(file, maxStreamShortcutBytes+1))
+	if err != nil {
+		return "", fmt.Errorf("read stream shortcut: %w", err)
+	}
+	if len(content) > maxStreamShortcutBytes {
+		return "", fmt.Errorf("stream shortcut exceeds 64 KiB")
 	}
 	streamURL := strings.TrimSpace(string(content))
 	if streamURL == "" {

--- a/internal/playback/transcode.go
+++ b/internal/playback/transcode.go
@@ -155,6 +155,12 @@ const (
 
 // StartTranscode launches an ffmpeg process that produces HLS segments.
 func StartTranscode(ctx context.Context, opts TranscodeOpts) (*TranscodeSession, error) {
+	inputPath, err := resolveTranscodeInputPath(opts.InputPath)
+	if err != nil {
+		return nil, err
+	}
+	opts.InputPath = inputPath
+
 	if opts.VideoBitstreamFilter != "" &&
 		(opts.VideoBitstreamFilter != DV7ToHDR10BitstreamFilter || !strings.EqualFold(opts.TargetCodecVideo, "copy")) {
 		return nil, fmt.Errorf("unsupported video bitstream filter recipe")
@@ -179,7 +185,6 @@ func StartTranscode(ctx context.Context, opts TranscodeOpts) (*TranscodeSession,
 		stderr:               newBoundedTailBuffer(stderrTailMaxBytes),
 		lastRequestedSegment: opts.StartSegmentNumber,
 	}
-
 	args := buildFFmpegArgs(opts)
 	bin := opts.FFmpegPath
 	if bin == "" {
@@ -221,6 +226,39 @@ func StartTranscode(ctx context.Context, opts TranscodeOpts) (*TranscodeSession,
 	}()
 
 	return s, nil
+}
+
+// resolveTranscodeInputPath turns a Stremio-style .strm shortcut into the
+// remote media URL FFmpeg must open. Keeping this at the shared launch boundary
+// covers integrated playback, transcode nodes, Jellyfin compatibility, and
+// reconstructed sessions without duplicating resolution logic in each handler.
+func resolveTranscodeInputPath(inputPath string) (string, error) {
+	if !strings.EqualFold(filepath.Ext(inputPath), ".strm") {
+		return inputPath, nil
+	}
+	info, err := os.Stat(inputPath)
+	if err != nil {
+		return "", fmt.Errorf("stat stream shortcut: %w", err)
+	}
+	if info.Size() > 64*1024 {
+		return "", fmt.Errorf("stream shortcut exceeds 64 KiB")
+	}
+	content, err := os.ReadFile(inputPath)
+	if err != nil {
+		return "", fmt.Errorf("read stream shortcut: %w", err)
+	}
+	streamURL := strings.TrimSpace(string(content))
+	if streamURL == "" {
+		return "", fmt.Errorf("stream shortcut is empty")
+	}
+	if strings.ContainsAny(streamURL, "\r\n") {
+		return "", fmt.Errorf("stream shortcut must contain exactly one URL")
+	}
+	lowerURL := strings.ToLower(streamURL)
+	if !strings.HasPrefix(lowerURL, "https://") && !strings.HasPrefix(lowerURL, "http://") {
+		return "", fmt.Errorf("stream shortcut URL must use http or https")
+	}
+	return streamURL, nil
 }
 
 // IsMPEG2VideoCodec reports whether a probed video codec name identifies

--- a/internal/scanner/probe_repair.go
+++ b/internal/scanner/probe_repair.go
@@ -2,6 +2,7 @@ package scanner
 
 import (
 	"context"
+	"path/filepath"
 	"strings"
 	"time"
 
@@ -13,6 +14,13 @@ import (
 func NeedsCriticalProbeRepair(file *models.MediaFile) bool {
 	if file == nil {
 		return true
+	}
+	// Scanner metadata for .strm files is deliberately a filename-derived
+	// placeholder. Protocol v3 handles these dynamic sources with a conservative
+	// HLS route, so blocking catalog or playback requests on remote ffprobe would
+	// only add startup latency and still cannot guarantee complete evidence.
+	if strings.EqualFold(filepath.Ext(file.FilePath), ".strm") {
+		return false
 	}
 	// Ebook/comic files (epub, pdf, cbz, cbr — including manga chapters, which
 	// are BaseType "ebook") are read directly by the reader and never go through

--- a/internal/scanner/probe_repair_strm_test.go
+++ b/internal/scanner/probe_repair_strm_test.go
@@ -1,0 +1,28 @@
+package scanner
+
+import (
+	"testing"
+	"time"
+
+	"github.com/Silo-Server/silo-server/internal/models"
+)
+
+func TestNeedsCriticalProbeRepairSTRMUsesDeferredPlaybackMetadata(t *testing.T) {
+	now := time.Now()
+	file := &models.MediaFile{
+		FilePath:       "/media/movie.strm",
+		ProbeSource:    "strm",
+		ProbeUpdatedAt: &now,
+		Duration:       7200,
+		Container:      "strm",
+		CodecVideo:     "h264",
+		CodecAudio:     "aac",
+		Resolution:     "1080p",
+		VideoTracks:    []models.VideoTrack{{Codec: "h264", Width: 1920, Height: 1080}},
+		AudioTracks:    []models.AudioTrack{{Codec: "aac", Channels: 2}},
+		Chapters:       []models.MediaChapter{},
+	}
+	if NeedsCriticalProbeRepair(file) {
+		t.Fatal(".strm placeholder metadata must not block catalog or playback on ffprobe")
+	}
+}

--- a/internal/scanner/scanner.go
+++ b/internal/scanner/scanner.go
@@ -25,12 +25,13 @@ import (
 
 // videoExtensions is the set of file extensions recognized as media files.
 var videoExtensions = map[string]bool{
-	".mkv": true,
-	".mp4": true,
-	".avi": true,
-	".m4v": true,
-	".ts":  true,
-	".wmv": true,
+	".mkv":  true,
+	".mp4":  true,
+	".avi":  true,
+	".m4v":  true,
+	".ts":   true,
+	".wmv":  true,
+	".strm": true,
 }
 
 // SupportsVideoFile reports whether the given path uses a recognized media extension.
@@ -3266,6 +3267,31 @@ func (s *Scanner) gatherHints(filePath string) FileHints {
 
 // probeFile attempts to get probe data by running local ffprobe.
 func (s *Scanner) probeFile(ctx context.Context, filePath string) (*ProbeData, string) {
+	if strings.EqualFold(filepath.Ext(filePath), ".strm") {
+		lowerPath := strings.ToLower(filePath)
+		width, height, resolution := 1920, 1080, "1080p"
+		if strings.Contains(lowerPath, "2160p") || strings.Contains(lowerPath, "4k") {
+			width, height, resolution = 3840, 2160, "2160p"
+		}
+		return &ProbeData{
+			CodecVideo:    "h264",
+			CodecAudio:    "aac",
+			Resolution:    resolution,
+			AudioChannels: 2,
+			Container:     "strm",
+			Duration:      7200,
+			VideoTracks: []VideoTrackInfo{{
+				Codec:  "h264",
+				Width:  width,
+				Height: height,
+			}},
+			AudioTracks: []AudioTrackInfo{{
+				Codec:    "aac",
+				Channels: 2,
+			}},
+		}, "strm"
+	}
+
 	if s.ffprobePath != "" {
 		probe, err := ProbeFile(ctx, s.ffprobePath, filePath)
 		if err != nil {


### PR DESCRIPTION
## Summary

Adds minimal server-native support for standard `.strm` video shortcut files containing one HTTP(S) media URL.

Part of #419.

## Problem

Silo currently ignores `.strm` files during video library scans. Even if a shortcut reaches playback through another path, local `ffprobe` cannot describe the remote source and protocol v3 rejects the incomplete evidence before playback can begin. External resolvers and library automation therefore cannot use `.strm` as a small, stable interoperability boundary.

## Approach

- Recognize `.strm` as a video extension during scanning.
- Record deliberately incomplete, filename-derived placeholder metadata instead of performing remote `ffprobe` during a scan.
- Exempt those placeholders from critical probe repair, avoiding repeated remote probe attempts on catalog and playback hot paths.
- Teach protocol v3 to identify `.strm` sources with incomplete evidence and select a conservative HLS transcode plan.
- Resolve the shortcut at the shared transcode launch boundary so integrated playback, transcode workers, Jellyfin compatibility, and reconstructed sessions use the same behavior.
- Bound shortcut files to 64 KiB and accept exactly one non-empty HTTP(S) URL for transcoding.
- Redirect direct-play requests to the shortcut target.

This deliberately does not add plugin runtime APIs, resolver candidate retries, database migrations, or client contract changes.

## Why this design

Resolving at transcode startup keeps network media out of the scanner hot path and prevents duplicated handler-specific resolution. The scanner stores only enough placeholder information to classify and group the file; missing detailed evidence forces protocol v3 through an explicit conservative route rather than pretending the remote codec/profile is known.

No existing `/api/v1` field, type, endpoint, or status code changes. Android, Apple, and web clients continue consuming the existing playback plan.

## Verification

- `go test ./...` — pass
- `go test ./internal/playback ./internal/scanner` — pass
- `golangci-lint run --new-from-rev=upstream/main` — completed successfully; reports only existing repository-wide `goconst` repetition heuristics on literals used by the new tests/code
- `make verify-local-paths` — pass
- `git diff --check upstream/main...HEAD` — pass
- Local production Docker image build — pass

## Risks and operational notes

- Remote availability and actual codecs remain unknown until playback; the conservative HLS route is intentional.
- A server transcode fetches the HTTP(S) URL named by a library-managed shortcut. Administrators should treat writable library roots as trusted input, consistent with other server-readable media paths.
- Placeholder duration and resolution are filename-derived defaults used for catalog/planning only, not claims about the remote stream.
- Direct play uses a temporary redirect; clients must be able to reach the target URL.

## Compatibility and rollout

- Additive scanner behavior; existing media behavior is unchanged.
- No schema migration.
- No plugin SDK or generated contract changes.
- Existing libraries need a scan to discover `.strm` files.
- Rollback consists of reverting this commit; previously indexed shortcuts will no longer be playable/discoverable until support returns.

## Follow-up considerations

Scope triage for #419 should decide whether v1 needs an explicit capability-discovery endpoint. This PR avoids inventing one because clients do not select `.strm` files directly and use the existing playback contracts.

## AI-use disclosure

Codex assisted with implementation review, upstream rebase, verification, issue/PR preparation, and documentation. The diff and behavior were manually inspected, and the complete Go test suite was run before submission.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for `.strm` stream shortcut files for scanning and playback.
  * Stream shortcuts can redirect directly to resolved HTTP/HTTPS sources (temporary redirect).
  * When video metadata is incomplete, dynamic stream files fall back to conservative HLS transcoding defaults.
* **Bug Fixes**
  * Invalid `.strm` shortcuts are rejected early with clear client errors.
  * `.strm` placeholder metadata no longer triggers unnecessary critical probe repair.
* **Tests**
  * Added coverage for `.strm` resolution, handler behavior, and conservative dynamic-stream playback planning.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->