### PR TITLE
fix(playback): preserve remux copy on seek

### DIFF
--- a/internal/api/handlers/playback.go
+++ b/internal/api/handlers/playback.go
@@ -51,8 +51,10 @@ type SessionManagerInterface interface {
 	EndTransport(sessionID string) error
 	SetEffectiveMediaFileID(sessionID string, fileID int) error
 	SetTranscodeNodeURL(sessionID, url string) error
-	SetTranscodeRoute(sessionID, nodeURL, transportID string) error
-	SetTranscodeRouteIf(sessionID, expectedNodeURL, expectedTransportID, nodeURL, transportID string) (bool, error)
+	SetTranscodeRoute(sessionID string, route playback.TranscodeRoute) error
+	ApplyReplacement(sessionID string, replacement playback.SessionReplacement) (playback.SessionReplacementRollback, error)
+	ApplyReplacementIfRoute(sessionID string, expected playback.TranscodeRoute, replacement playback.SessionReplacement) (playback.SessionReplacementRollback, bool, error)
+	RollbackReplacement(sessionID string, rollback playback.SessionReplacementRollback) error
 	SetWebSocket(sessionID string, connected bool) error
 	SetRealtimeConnection(sessionID string, connected bool) error
 	SetProgressPersistenceDisabled(sessionID string, disabled bool) error
@@ -446,11 +448,24 @@ type changeAudioRequest struct {
 
 // changeAudioResponse represents the JSON response for PATCH /playback/{session_id}/audio.
 type changeAudioResponse struct {
-	AudioTrackIndex int                 `json:"audio_track_index"`
-	PlayMethod      string              `json:"play_method"`
-	StreamURL       string              `json:"stream_url"`
-	SwitchMode      string              `json:"switch_mode"`
-	PlaybackInfo    *playbackInfoResult `json:"playback_info,omitempty"`
+	AudioTrackIndex       int                 `json:"audio_track_index"`
+	PlayMethod            string              `json:"play_method"`
+	StreamURL             string              `json:"stream_url"`
+	SwitchMode            string              `json:"switch_mode"`
+	PlayerStartSeconds    *float64            `json:"player_start_seconds,omitempty"`
+	StreamOriginSeconds   *float64            `json:"stream_origin_seconds,omitempty"`
+	TimelineOffsetSeconds *float64            `json:"timeline_offset_seconds,omitempty"`
+	CanSeekAnywhere       *bool               `json:"can_seek_anywhere,omitempty"`
+	PlaybackInfo          *playbackInfoResult `json:"playback_info,omitempty"`
+}
+
+func (resp *changeAudioResponse) setCopyTimeline(position, origin float64) {
+	playerStart := max(0, position-origin)
+	canSeekAnywhere := false
+	resp.PlayerStartSeconds = &playerStart
+	resp.StreamOriginSeconds = &origin
+	resp.TimelineOffsetSeconds = &origin
+	resp.CanSeekAnywhere = &canSeekAnywhere
 }
 
 type transcodeStartRequest struct {
@@ -770,6 +785,16 @@ func remoteTransportID(session *playback.Session) string {
 	return session.ID
 }
 
+func sessionTranscodeRoute(session *playback.Session) playback.TranscodeRoute {
+	if session == nil {
+		return playback.TranscodeRoute{}
+	}
+	return playback.TranscodeRoute{
+		NodeURL:     session.TranscodeNodeURL,
+		TransportID: session.TranscodeTransportID,
+	}
+}
+
 const legacyTransportMarker = "-legacy-"
 
 func isLegacyTransportSession(session *playback.Session) bool {
@@ -789,8 +814,7 @@ func newLegacyTransportID(sessionID string) string {
 func (h *PlaybackHandler) transcodeRouteMatches(
 	sessionID string,
 	expectedLocal *playback.TranscodeSession,
-	nodeURL string,
-	transportID string,
+	route playback.TranscodeRoute,
 ) bool {
 	unlock := h.tm.LockSessionLifecycle(sessionID)
 	defer unlock()
@@ -799,18 +823,14 @@ func (h *PlaybackHandler) transcodeRouteMatches(
 		return false
 	}
 	return h.tm.GetTranscodeSession(sessionID) == expectedLocal &&
-		session.TranscodeNodeURL == nodeURL &&
-		session.TranscodeTransportID == transportID
+		sessionTranscodeRoute(session) == route
 }
 
 func (h *PlaybackHandler) commitLegacyRemoteReplacement(
 	sessionID string,
 	previousLocal *playback.TranscodeSession,
-	previousNodeURL string,
-	previousTransportID string,
-	nodeURL string,
-	transportID string,
-	publishState func() error,
+	previousRoute playback.TranscodeRoute,
+	replacement playback.SessionReplacement,
 ) error {
 	unlock := h.tm.LockSessionLifecycle(sessionID)
 	if h.tm.GetTranscodeSession(sessionID) != previousLocal {
@@ -818,13 +838,7 @@ func (h *PlaybackHandler) commitLegacyRemoteReplacement(
 		return playback.ErrSessionSuperseded
 	}
 
-	published, err := h.sessionMgr.SetTranscodeRouteIf(
-		sessionID,
-		previousNodeURL,
-		previousTransportID,
-		nodeURL,
-		transportID,
-	)
+	_, published, err := h.sessionMgr.ApplyReplacementIfRoute(sessionID, previousRoute, replacement)
 	if err != nil {
 		unlock()
 		return err
@@ -833,46 +847,122 @@ func (h *PlaybackHandler) commitLegacyRemoteReplacement(
 		unlock()
 		return playback.ErrSessionSuperseded
 	}
-	if publishState != nil {
-		if err := publishState(); err != nil {
-			_, rollbackErr := h.sessionMgr.SetTranscodeRouteIf(
-				sessionID,
-				nodeURL,
-				transportID,
-				previousNodeURL,
-				previousTransportID,
-			)
-			unlock()
-			return errors.Join(err, rollbackErr)
-		}
-	}
-	if previousLocal != nil && !h.tm.CloseTranscodeSessionIf(sessionID, previousLocal, "") {
-		// The lifecycle lock makes this defensive rollback unreachable for normal
-		// callers, but never leave a newly published remote route beside a local
-		// successor if a caller bypassed that lock contract.
-		_, rollbackErr := h.sessionMgr.SetTranscodeRouteIf(
-			sessionID,
-			nodeURL,
-			transportID,
-			previousNodeURL,
-			previousTransportID,
-		)
-		unlock()
-		if rollbackErr != nil {
-			return errors.Join(playback.ErrSessionSuperseded, rollbackErr)
-		}
-		return playback.ErrSessionSuperseded
+	if previousLocal != nil {
+		// A crash monitor can remove the predecessor while the remote successor is
+		// preparing. A false result is harmless: the new route is already complete,
+		// and CloseTranscodeSessionIf never touches a different local successor.
+		h.tm.CloseTranscodeSessionIf(sessionID, previousLocal, "")
 	}
 	unlock()
 
-	if previousNodeURL != "" {
-		previousProcessID := previousTransportID
+	if previousRoute.NodeURL != "" {
+		previousProcessID := previousRoute.TransportID
 		if previousProcessID == "" {
 			previousProcessID = sessionID
 		}
-		h.tm.StopRemoteTranscode(previousProcessID, previousNodeURL)
+		h.tm.StopRemoteTranscode(previousProcessID, previousRoute.NodeURL)
 	}
 	return nil
+}
+
+func (h *PlaybackHandler) commitLegacyRemoteLastWriter(
+	sessionID string,
+	successorRoute playback.TranscodeRoute,
+	replacement playback.SessionReplacement,
+) error {
+	unlock := h.tm.LockSessionLifecycle(sessionID)
+	current, err := h.sessionMgr.GetSession(sessionID)
+	if err != nil {
+		unlock()
+		return err
+	}
+	previousRoute := sessionTranscodeRoute(current)
+	previousLocal := h.tm.GetTranscodeSession(sessionID)
+	if _, err := h.sessionMgr.ApplyReplacement(sessionID, replacement); err != nil {
+		unlock()
+		return err
+	}
+	if previousLocal != nil {
+		h.tm.CloseTranscodeSessionIf(sessionID, previousLocal, "")
+	}
+	unlock()
+
+	if previousRoute.NodeURL != "" && previousRoute != successorRoute {
+		previousProcessID := previousRoute.TransportID
+		if previousProcessID == "" {
+			previousProcessID = sessionID
+		}
+		h.tm.StopRemoteTranscode(previousProcessID, previousRoute.NodeURL)
+	}
+	return nil
+}
+
+func (h *PlaybackHandler) commitLegacyLocalReplacement(
+	ctx context.Context,
+	sessionID string,
+	previousLocal *playback.TranscodeSession,
+	previousRoute playback.TranscodeRoute,
+	opts playback.TranscodeOpts,
+	replacement func(*playback.TranscodeSession) playback.SessionReplacement,
+) (*playback.TranscodeSession, error) {
+	if opts.OutputSubdir == "" {
+		return nil, errors.New("transactional local replacement requires a generation output directory")
+	}
+
+	unlock := h.tm.LockSessionLifecycle(sessionID)
+	if h.tm.GetTranscodeSession(sessionID) != previousLocal {
+		unlock()
+		return nil, playback.ErrSessionSuperseded
+	}
+	current, err := h.sessionMgr.GetSession(sessionID)
+	if err != nil {
+		unlock()
+		return nil, err
+	}
+	if sessionTranscodeRoute(current) != previousRoute {
+		unlock()
+		return nil, playback.ErrSessionSuperseded
+	}
+
+	successor, err := h.startLocalPlaybackTransport(ctx, opts)
+	if err != nil {
+		unlock()
+		return nil, err
+	}
+	if _, err := successor.WaitForManifest(8 * time.Second); err != nil {
+		_ = successor.Close()
+		unlock()
+		return nil, fmt.Errorf("local successor not ready: %w", err)
+	}
+
+	rollback, published, err := h.sessionMgr.ApplyReplacementIfRoute(sessionID, previousRoute, replacement(successor))
+	if err != nil || !published {
+		_ = successor.Close()
+		unlock()
+		if err != nil {
+			return nil, err
+		}
+		return nil, playback.ErrSessionSuperseded
+	}
+	if !h.tm.SwapTranscodeSessionIf(sessionID, previousLocal, successor) {
+		rollbackErr := h.sessionMgr.RollbackReplacement(sessionID, rollback)
+		_ = successor.Close()
+		unlock()
+		return nil, errors.Join(playback.ErrSessionSuperseded, rollbackErr)
+	}
+	unlock()
+
+	if previousLocal != nil {
+		_ = previousLocal.Close()
+	}
+	if previousRoute.NodeURL != "" {
+		previousProcessID := previousRoute.TransportID
+		if previousProcessID == "" {
+			previousProcessID = sessionID
+		}
+		h.tm.StopRemoteTranscode(previousProcessID, previousRoute.NodeURL)
+	}
+	return successor, nil
 }
 
 func (h *PlaybackHandler) closeTranscodeForSession(session *playback.Session) {
@@ -2166,6 +2256,7 @@ func (h *PlaybackHandler) HandleChangeAudioTrack(w http.ResponseWriter, r *http.
 		writeError(w, http.StatusForbidden, "forbidden", "Session belongs to another user")
 		return
 	}
+	previousRoute := sessionTranscodeRoute(session)
 
 	var req changeAudioRequest
 	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
@@ -2292,66 +2383,6 @@ func (h *PlaybackHandler) HandleChangeAudioTrack(w http.ResponseWriter, r *http.
 		"audio_codec", newTrack.Codec,
 		"transcode_audio", transcodeAudio,
 	)
-	persistAudioSwitchState := func() error {
-		if err := h.sessionMgr.UpdateAudioTrack(sessionID, req.AudioTrackIndex, newMethod); err != nil {
-			return err
-		}
-		return h.sessionMgr.UpdateStreamState(sessionID, playback.SessionStreamState{
-			PlayMethod:        session.PlayMethod,
-			BasePlayMethod:    newMethod,
-			AudioTrackIndex:   req.AudioTrackIndex,
-			TranscodeAudio:    transcodeAudio,
-			ClientIP:          session.ClientIP,
-			StreamBitrateKbps: streamBitrateKbps,
-			TargetResolution:  targetResolution,
-			TargetVideoCodec:  targetVideoCodec,
-			TargetAudioCodec:  targetAudioCodec,
-			TargetBitrateKbps: targetBitrateKbps,
-			// Carry the byte-affecting recipe forward: an audio switch changes only the
-			// audio selection, so subtitles and cadence must survive the state update
-			// (UpdateStreamState overwrites these fields unconditionally).
-			SubtitleTrackIndex: session.SubtitleTrackIndex,
-			SubtitleBurnIn:     session.SubtitleBurnIn,
-			SegmentDuration:    session.SegmentDuration,
-		})
-	}
-	if deferredRemoteCopyPlan == nil {
-		if err := persistAudioSwitchState(); err != nil {
-			writeError(w, http.StatusInternalServerError, "internal_error", "Failed to update audio track")
-			return
-		}
-	}
-
-	// Handle transcode restart.
-	if session.PlayMethod == playback.PlayTranscode && deferredRemoteCopyPlan == nil {
-		if ts := h.tm.GetTranscodeSession(sessionID); ts != nil {
-			ts.SetAudioTrackIndex(req.AudioTrackIndex)
-			// Throttler + exit monitor re-arm via the session's restart hook.
-			var restartErr error
-			if restartCopyAnchorResolved {
-				restartErr = h.tm.RestartSessionLockedWithCopySeekAnchor(
-					context.WithoutCancel(r.Context()),
-					sessionID,
-					ts,
-					restartSeekSeconds,
-					restartStartSegment,
-					restartStreamOriginSeconds,
-				)
-			} else {
-				restartErr = h.tm.RestartSessionLocked(
-					context.WithoutCancel(r.Context()),
-					sessionID,
-					ts,
-					restartSeekSeconds,
-					restartStartSegment,
-				)
-			}
-			if restartErr != nil {
-				slog.ErrorContext(r.Context(), "failed to restart transcode for audio switch", "component", "api", "session", sessionID, "error", restartErr)
-			}
-		}
-	}
-
 	updatedSession := *session
 	updatedSession.AudioTrackIndex = req.AudioTrackIndex
 	updatedSession.BasePlayMethod = newMethod
@@ -2363,13 +2394,108 @@ func (h *PlaybackHandler) HandleChangeAudioTrack(w http.ResponseWriter, r *http.
 	updatedSession.TargetVideoCodec = targetVideoCodec
 	updatedSession.TargetAudioCodec = targetAudioCodec
 	updatedSession.TargetBitrateKbps = targetBitrateKbps
+	updatedSession.SegmentDuration = restartSegmentDuration
+
+	audioSwitchReplacement := func(route playback.TranscodeRoute) playback.SessionReplacement {
+		return playback.SessionReplacement{
+			EffectiveMediaFileID: session.MediaFileID,
+			StreamState: playback.SessionStreamState{
+				PlayMethod:           updatedSession.PlayMethod,
+				BasePlayMethod:       newMethod,
+				AudioTrackIndex:      req.AudioTrackIndex,
+				TranscodeAudio:       transcodeAudio,
+				RemuxDVMode:          session.RemuxDVMode,
+				ClientIP:             session.ClientIP,
+				ClientName:           session.ClientName,
+				ClientVersion:        session.ClientVersion,
+				ClientUserAgent:      session.ClientUserAgent,
+				StreamBitrateKbps:    streamBitrateKbps,
+				TargetResolution:     targetResolution,
+				TargetVideoCodec:     targetVideoCodec,
+				TargetAudioCodec:     targetAudioCodec,
+				TargetBitrateKbps:    targetBitrateKbps,
+				TranscodeHWAccel:     updatedSession.TranscodeHWAccel,
+				TranscodeNodeURL:     route.NodeURL,
+				TranscodeTransportID: route.TransportID,
+				TranscodeRouteSet:    true,
+				SubtitleTrackIndex:   session.SubtitleTrackIndex,
+				SubtitleBurnIn:       session.SubtitleBurnIn,
+				SegmentDuration:      restartSegmentDuration,
+			},
+		}
+	}
+	audioStatePublished := false
+	publishAudioSwitch := func(route playback.TranscodeRoute) error {
+		if _, err := h.sessionMgr.ApplyReplacement(sessionID, audioSwitchReplacement(route)); err != nil {
+			return err
+		}
+		audioStatePublished = true
+		updatedSession.TranscodeNodeURL = route.NodeURL
+		updatedSession.TranscodeTransportID = route.TransportID
+		return nil
+	}
+
+	// Local audio switches stage a successor in a generation-scoped directory.
+	// The predecessor keeps serving until the successor has a manifest and the
+	// full session replacement has been published atomically.
+	if session.PlayMethod == playback.PlayTranscode && deferredRemoteCopyPlan == nil {
+		if previousLocal := h.tm.GetTranscodeSession(sessionID); previousLocal != nil {
+			opts := previousLocal.Opts()
+			outputSubdir := newLegacyTransportID(sessionID)
+			opts.OutputSubdir = outputSubdir
+			opts.OutputDir = filepath.Join(h.playbackConfig().TranscodeDir, outputSubdir)
+			opts.TranscodeTransportID = ""
+			opts.AudioTrackIndex = req.AudioTrackIndex
+			opts.SeekSeconds = restartSeekSeconds
+			opts.StartSegmentNumber = restartStartSegment
+			opts.StreamOriginSeconds = restartStreamOriginSeconds
+			opts.CopySeekAnchorResolved = restartCopyAnchorResolved
+			opts.FastStart = true
+			successor, restartErr := h.commitLegacyLocalReplacement(
+				context.WithoutCancel(r.Context()),
+				sessionID,
+				previousLocal,
+				previousRoute,
+				opts,
+				func(successor *playback.TranscodeSession) playback.SessionReplacement {
+					updatedSession.TranscodeHWAccel = successor.Opts().HWAccel
+					return audioSwitchReplacement(playback.TranscodeRoute{})
+				},
+			)
+			if restartErr != nil {
+				if errors.Is(restartErr, playback.ErrSessionSuperseded) {
+					writeError(w, http.StatusConflict, "transcode_replaced", "A newer playback transport replaced this request")
+					return
+				}
+				slog.ErrorContext(r.Context(), "failed to prepare transcode for audio switch", "component", "api", "session", sessionID, "error", restartErr)
+				writeError(w, http.StatusInternalServerError, "transcode_start_failed", "Failed to restart transcode session")
+				return
+			}
+			audioStatePublished = true
+			updatedSession.TranscodeNodeURL = ""
+			updatedSession.TranscodeTransportID = ""
+			successor.SetRestartHook(func(ctx context.Context) {
+				h.maybeStartThrottler(ctx, successor)
+				h.tm.MonitorLocalTranscodeExit(sessionID, successor)
+			})
+			h.maybeStartThrottler(r.Context(), successor)
+			h.tm.MonitorLocalTranscodeExit(sessionID, successor)
+		}
+	}
+
+	if session.PlayMethod != playback.PlayTranscode {
+		if err := publishAudioSwitch(playback.TranscodeRoute{}); err != nil {
+			writeError(w, http.StatusInternalServerError, "internal_error", "Failed to update audio track")
+			return
+		}
+	}
 
 	// The switched recipe travels in the freshly minted stream token on the new
 	// serve URL below, so a post-restart reconstruct resumes with the switched
 	// audio/method. For transcode the full-recipe manifest URL is rebuilt further
 	// down (proxy or local); for direct/remux the identity token on StreamURL
 	// carries the new audio selection.
-	if deferredRemoteCopyPlan == nil {
+	if audioStatePublished {
 		h.persistAudioPreference(r.Context(), userID, session.ProfileID, file, req.AudioTrackIndex)
 	}
 
@@ -2425,11 +2551,6 @@ func (h *PlaybackHandler) HandleChangeAudioTrack(w http.ResponseWriter, r *http.
 				nodeURL := plan.TranscodeNode.URL
 				atomicLegacyReplacement := legacyCopyRestart
 				previousLocalTranscode := h.tm.GetTranscodeSession(sessionID)
-				previousNodeURL := session.TranscodeNodeURL
-				previousTransportID := session.TranscodeTransportID
-				if !atomicLegacyReplacement {
-					_ = h.sessionMgr.SetTranscodeNodeURL(sessionID, nodeURL)
-				}
 
 				// Restart from the FULL live recipe, not a partial re-derivation.
 				// An audio switch alters only audio selection — subtitle burn-in and
@@ -2490,49 +2611,42 @@ func (h *PlaybackHandler) HandleChangeAudioTrack(w http.ResponseWriter, r *http.
 					nodeReq.VideoBitstreamFilter = playback.DV7ToHDR10BitstreamFilter
 				}
 
-				body, _ := json.Marshal(nodeReq)
-				ctx, cancel := context.WithTimeout(context.WithoutCancel(r.Context()), 10*time.Second)
-				defer cancel()
-				httpReq, reqErr := http.NewRequestWithContext(ctx, http.MethodPost, nodeURL+"/transcode/start", bytes.NewReader(body))
-				if reqErr != nil {
-					slog.ErrorContext(r.Context(), "failed to build remote transcode restart for audio switch", "component", "api", "session", sessionID, "node", nodeURL, "error", reqErr)
-					writeError(w, http.StatusInternalServerError, "internal_error", "Failed to build transcode request")
-					return
-				}
-				httpReq.Header.Set("Content-Type", "application/json")
-				httpReq.Header.Set("Authorization", "Bearer "+h.JWTSecret)
-
-				nodeResp, doErr := http.DefaultClient.Do(httpReq)
-				if doErr != nil {
+				startResp, status, startErr := h.startRemotePlaybackTransport(
+					context.WithoutCancel(r.Context()),
+					nodeURL,
+					nodeReq,
+				)
+				if startErr != nil {
 					if atomicLegacyReplacement {
 						h.tm.StopRemoteTranscode(restartTransportID, nodeURL)
 					}
-					slog.ErrorContext(r.Context(), "remote transcode restart for audio switch failed", "component", "api", "session", sessionID, "node", nodeURL, "error", doErr)
+					slog.ErrorContext(r.Context(), "remote transcode restart for audio switch failed", "component", "api", "session", sessionID, "node", nodeURL, "error", startErr)
 					writeError(w, http.StatusBadGateway, "transcode_node_unavailable", "Transcode node is unavailable")
 					return
 				}
-				defer nodeResp.Body.Close()
-				if nodeResp.StatusCode != http.StatusAccepted {
+				if status != http.StatusAccepted {
 					if atomicLegacyReplacement {
 						h.tm.StopRemoteTranscode(restartTransportID, nodeURL)
 					}
-					slog.ErrorContext(r.Context(), "remote transcode restart for audio switch rejected", "component", "api", "session", sessionID, "node", nodeURL, "status", nodeResp.StatusCode)
+					slog.ErrorContext(r.Context(), "remote transcode restart for audio switch rejected", "component", "api", "session", sessionID, "node", nodeURL, "status", status)
 					writeError(w, http.StatusBadGateway, "transcode_start_failed", "Transcode node rejected the request")
 					return
 				}
+				effectiveHWAccel := effectiveRemoteHWAccel(startResp, nodeReq)
+				updatedSession.TranscodeHWAccel = effectiveHWAccel
+				successorTransportID := restartTransportID
+				if !atomicLegacyReplacement {
+					// Empty is the durable legacy representation for a node process
+					// running under the public playback session ID.
+					successorTransportID = session.TranscodeTransportID
+				}
+				successorRoute := playback.TranscodeRoute{NodeURL: nodeURL, TransportID: successorTransportID}
 				if atomicLegacyReplacement {
-					var publishState func() error
-					if deferredRemoteCopyPlan != nil {
-						publishState = persistAudioSwitchState
-					}
 					if routeErr := h.commitLegacyRemoteReplacement(
 						sessionID,
 						previousLocalTranscode,
-						previousNodeURL,
-						previousTransportID,
-						nodeURL,
-						restartTransportID,
-						publishState,
+						previousRoute,
+						audioSwitchReplacement(successorRoute),
 					); routeErr != nil {
 						h.tm.StopRemoteTranscode(restartTransportID, nodeURL)
 						if errors.Is(routeErr, playback.ErrSessionSuperseded) {
@@ -2543,25 +2657,26 @@ func (h *PlaybackHandler) HandleChangeAudioTrack(w http.ResponseWriter, r *http.
 						writeError(w, http.StatusInternalServerError, "internal_error", "Failed to publish transcode session")
 						return
 					}
-					if !h.transcodeRouteMatches(sessionID, nil, nodeURL, restartTransportID) {
+					audioStatePublished = true
+					if !h.transcodeRouteMatches(sessionID, nil, successorRoute) {
 						writeError(w, http.StatusConflict, "transcode_replaced", "A newer playback transport replaced this request")
 						return
 					}
-					updatedSession.TranscodeNodeURL = nodeURL
-					updatedSession.TranscodeTransportID = restartTransportID
-					if deferredRemoteCopyPlan != nil {
-						h.persistAudioPreference(r.Context(), userID, session.ProfileID, file, req.AudioTrackIndex)
+				} else {
+					if routeErr := h.commitLegacyRemoteLastWriter(
+						sessionID,
+						successorRoute,
+						audioSwitchReplacement(successorRoute),
+					); routeErr != nil {
+						slog.ErrorContext(r.Context(), "publish remote audio-switch transcode route", "component", "api", "session", sessionID, "node", nodeURL, "error", routeErr)
+						writeError(w, http.StatusInternalServerError, "internal_error", "Failed to publish transcode session")
+						return
 					}
+					audioStatePublished = true
 				}
-
-				var startResp transcodenode.TranscodeStartResponse
-				if decErr := json.NewDecoder(nodeResp.Body).Decode(&startResp); decErr != nil {
-					slog.WarnContext(r.Context(), "remote transcode restart response decode failed", "component", "api", "session", sessionID, "node", nodeURL, "error", decErr)
-				}
-				effectiveHWAccel := strings.TrimSpace(startResp.HWAccel)
-				if effectiveHWAccel == "" {
-					effectiveHWAccel = strings.TrimSpace(nodeReq.HWAccel)
-				}
+				updatedSession.TranscodeNodeURL = successorRoute.NodeURL
+				updatedSession.TranscodeTransportID = successorRoute.TransportID
+				h.persistAudioPreference(r.Context(), userID, session.ProfileID, file, req.AudioTrackIndex)
 
 				card := playback.NewRecipeCard(updatedSession.UserID, updatedSession.ProfileID, updatedSession.MediaFileID, nodeURL, playback.TranscodeOpts{
 					InputPath:              nodeReq.InputPath,
@@ -2609,7 +2724,6 @@ func (h *PlaybackHandler) HandleChangeAudioTrack(w http.ResponseWriter, r *http.
 				}
 				if plan.TranscodeNode != nil {
 					tokenClaims.TranscodeNode = plan.TranscodeNode.URL
-					_ = h.sessionMgr.SetTranscodeNodeURL(sessionID, plan.TranscodeNode.URL)
 				}
 				if token, signErr := streamtoken.Sign(tokenClaims, h.JWTSecret, playback.MaxTokenTTL); signErr == nil {
 					switch updatedSession.PlayMethod {
@@ -2621,6 +2735,16 @@ func (h *PlaybackHandler) HandleChangeAudioTrack(w http.ResponseWriter, r *http.
 				}
 			}
 		}
+	}
+	if !audioStatePublished {
+		if err := publishAudioSwitch(previousRoute); err != nil {
+			writeError(w, http.StatusInternalServerError, "internal_error", "Failed to update audio track")
+			return
+		}
+		h.persistAudioPreference(r.Context(), userID, session.ProfileID, file, req.AudioTrackIndex)
+	}
+	if legacyCopyRestart {
+		resp.setCopyTimeline(req.Position, restartStreamOriginSeconds)
 	}
 
 	h.syncSessionsNow(r.Context(), "audio_change")
@@ -2784,35 +2908,13 @@ func effectiveRemoteHWAccel(
 	return hwAccel
 }
 
-// persistTranscodeStartState updates the durable playback recipe after a
-// transcode has started. Transactional replacement callers invoke it while
-// they still hold the per-session lifecycle lock.
-func (h *PlaybackHandler) persistTranscodeStartState(r *http.Request, st transcodeStartState) error {
-	if st.switchedFileID != nil {
-		if err := h.sessionMgr.SetEffectiveMediaFileID(st.req.SessionID, *st.switchedFileID); err != nil {
-			slog.ErrorContext(r.Context(), "failed to update effective media file", "component", "api", "session", st.req.SessionID, "error", err, "playback_session_id", st.req.SessionID)
-			return err
-		}
-	}
-
+func transcodeStartReplacement(st transcodeStartState, route playback.TranscodeRoute) playback.SessionReplacement {
 	streamBitrateKbps := st.req.TargetBitrateKbps
 	if streamBitrateKbps <= 0 {
 		streamBitrateKbps = st.file.Bitrate
 	}
 	transcodeAudio := st.req.TargetCodecAudio != "" && !strings.EqualFold(st.req.TargetCodecAudio, "copy")
 	baseMethod := semanticPlayMethod(st.session)
-
-	slog.InfoContext(r.Context(), "transcode start preserved base playback state", "component", "api",
-		"playback_session_id", st.req.SessionID,
-		"base_play_method", baseMethod,
-		"transport_play_method", playback.PlayTranscode,
-		"audio_track_index", st.session.AudioTrackIndex,
-		"target_codec_video", st.req.TargetCodecVideo,
-		"target_codec_audio", st.req.TargetCodecAudio,
-		"copy_video_original", strings.EqualFold(st.req.TargetCodecVideo, "copy"),
-		"transcode_audio", transcodeAudio,
-	)
-
 	// Persist the byte-affecting recipe (subtitles + segment cadence) so a later
 	// offloaded audio switch can rebuild the exact same stream. The session is the
 	// only recovery source for offloaded transcodes (no local ts.Opts()). Normalize
@@ -2822,33 +2924,49 @@ func (h *PlaybackHandler) persistTranscodeStartState(r *http.Request, st transco
 		segmentDuration = playback.DefaultSegmentDuration
 	}
 
-	if err := h.sessionMgr.UpdateStreamState(st.req.SessionID, playback.SessionStreamState{
-		PlayMethod:         playback.PlayTranscode,
-		BasePlayMethod:     baseMethod,
-		AudioTrackIndex:    st.session.AudioTrackIndex,
-		TranscodeAudio:     transcodeAudio,
-		ClientIP:           st.session.ClientIP,
-		StreamBitrateKbps:  streamBitrateKbps,
-		TargetResolution:   st.req.TargetResolution,
-		TargetVideoCodec:   st.req.TargetCodecVideo,
-		TargetAudioCodec:   st.req.TargetCodecAudio,
-		TargetBitrateKbps:  st.req.TargetBitrateKbps,
-		TranscodeHWAccel:   st.hwAccel,
-		SubtitleTrackIndex: st.req.SubtitleTrackIndex,
-		SubtitleBurnIn:     st.req.SubtitleBurnIn,
-		SegmentDuration:    segmentDuration,
-	}); err != nil {
-		slog.ErrorContext(r.Context(), "failed to update transcode stream state", "component", "api", "session", st.req.SessionID, "error", err, "playback_session_id", st.req.SessionID)
-		return err
+	effectiveFileID := st.file.ID
+	if st.switchedFileID != nil {
+		effectiveFileID = *st.switchedFileID
 	}
-	return nil
+	return playback.SessionReplacement{
+		EffectiveMediaFileID: effectiveFileID,
+		StreamState: playback.SessionStreamState{
+			PlayMethod:           playback.PlayTranscode,
+			BasePlayMethod:       baseMethod,
+			AudioTrackIndex:      st.session.AudioTrackIndex,
+			TranscodeAudio:       transcodeAudio,
+			RemuxDVMode:          st.session.RemuxDVMode,
+			ClientIP:             st.session.ClientIP,
+			ClientName:           st.session.ClientName,
+			ClientVersion:        st.session.ClientVersion,
+			ClientUserAgent:      st.session.ClientUserAgent,
+			StreamBitrateKbps:    streamBitrateKbps,
+			TargetResolution:     st.req.TargetResolution,
+			TargetVideoCodec:     st.req.TargetCodecVideo,
+			TargetAudioCodec:     st.req.TargetCodecAudio,
+			TargetBitrateKbps:    st.req.TargetBitrateKbps,
+			TranscodeHWAccel:     st.hwAccel,
+			TranscodeNodeURL:     route.NodeURL,
+			TranscodeTransportID: route.TransportID,
+			TranscodeRouteSet:    true,
+			SubtitleTrackIndex:   st.req.SubtitleTrackIndex,
+			SubtitleBurnIn:       st.req.SubtitleBurnIn,
+			SegmentDuration:      segmentDuration,
+		},
+	}
 }
 
-func (h *PlaybackHandler) finalizeTranscodeStart(r *http.Request, st transcodeStartState) {
-	if err := h.persistTranscodeStartState(r, st); err != nil {
-		return
-	}
-	h.syncSessionsNow(r.Context(), "transcode_start")
+func logTranscodeStartState(r *http.Request, st transcodeStartState) {
+	slog.InfoContext(r.Context(), "transcode start preserved base playback state", "component", "api",
+		"playback_session_id", st.req.SessionID,
+		"base_play_method", semanticPlayMethod(st.session),
+		"transport_play_method", playback.PlayTranscode,
+		"audio_track_index", st.session.AudioTrackIndex,
+		"target_codec_video", st.req.TargetCodecVideo,
+		"target_codec_audio", st.req.TargetCodecAudio,
+		"copy_video_original", strings.EqualFold(st.req.TargetCodecVideo, "copy"),
+		"transcode_audio", st.req.TargetCodecAudio != "" && !strings.EqualFold(st.req.TargetCodecAudio, "copy"),
+	)
 }
 
 // HandleStartTranscode handles POST /playback/transcode/start.
@@ -2892,9 +3010,7 @@ func (h *PlaybackHandler) HandleStartTranscode(w http.ResponseWriter, r *http.Re
 	// a legacy remote replacement is prepared under a distinct process identity
 	// and retired only after the node accepts and the session publishes its successor.
 	previousLocalTranscode := h.tm.GetTranscodeSession(req.SessionID)
-	previousTranscodeNodeURL := session.TranscodeNodeURL
-	previousTransportID := session.TranscodeTransportID
-	previousProcessID := remoteTransportID(session)
+	previousRoute := sessionTranscodeRoute(session)
 	abortCurrentSession := func(reason string, cause error) {
 		if abortErr := h.abortPlaybackSession(r.Context(), session); abortErr != nil && !errors.Is(abortErr, playback.ErrSessionNotFound) {
 			slog.ErrorContext(r.Context(), "failed to abort playback session", "component", "api",
@@ -3155,22 +3271,24 @@ func (h *PlaybackHandler) HandleStartTranscode(w http.ResponseWriter, r *http.Re
 			writeError(w, http.StatusBadGateway, "transcode_start_failed", "Transcode node rejected the request")
 			return
 		}
+		effectiveHWAccel := effectiveRemoteHWAccel(nodeResp, nodeReq)
+		startState := transcodeStartState{
+			req:            req,
+			file:           file,
+			session:        session,
+			switchedFileID: switchedFileID,
+			hwAccel:        effectiveHWAccel,
+		}
+		successorRoute := playback.TranscodeRoute{
+			NodeURL:     tcNode.URL,
+			TransportID: reconstructionTransportID,
+		}
 		if atomicLegacyReplacement {
-			startState := transcodeStartState{
-				req:            req,
-				file:           file,
-				session:        session,
-				switchedFileID: switchedFileID,
-				hwAccel:        effectiveRemoteHWAccel(nodeResp, nodeReq),
-			}
 			if err := h.commitLegacyRemoteReplacement(
 				req.SessionID,
 				previousLocalTranscode,
-				previousTranscodeNodeURL,
-				previousTransportID,
-				tcNode.URL,
-				replacementTransportID,
-				func() error { return h.persistTranscodeStartState(r, startState) },
+				previousRoute,
+				transcodeStartReplacement(startState, successorRoute),
 			); err != nil {
 				h.tm.StopRemoteTranscode(replacementTransportID, tcNode.URL)
 				if errors.Is(err, playback.ErrSessionSuperseded) {
@@ -3181,24 +3299,25 @@ func (h *PlaybackHandler) HandleStartTranscode(w http.ResponseWriter, r *http.Re
 				writeError(w, http.StatusInternalServerError, "internal_error", "Failed to publish transcode session")
 				return
 			}
-			if !h.transcodeRouteMatches(req.SessionID, nil, tcNode.URL, replacementTransportID) {
+			if !h.transcodeRouteMatches(req.SessionID, nil, successorRoute) {
 				writeError(w, http.StatusConflict, "transcode_replaced", "A newer playback transport replaced this request")
 				return
 			}
+			logTranscodeStartState(r, startState)
 			h.syncSessionsNow(r.Context(), "transcode_start")
 		} else {
-			if err := h.sessionMgr.SetTranscodeNodeURL(req.SessionID, tcNode.URL); err != nil {
-				slog.ErrorContext(r.Context(), "set transcode node URL", "component", "api", "error", err, "session", req.SessionID, "playback_session_id", req.SessionID)
+			if err := h.commitLegacyRemoteLastWriter(
+				req.SessionID,
+				successorRoute,
+				transcodeStartReplacement(startState, successorRoute),
+			); err != nil {
+				slog.ErrorContext(r.Context(), "publish remote transcode route", "component", "api", "error", err, "session", req.SessionID, "playback_session_id", req.SessionID)
+				writeError(w, http.StatusInternalServerError, "internal_error", "Failed to publish transcode session")
+				return
 			}
-			if previousLocalTranscode != nil {
-				h.tm.CloseTranscodeSessionIf(req.SessionID, previousLocalTranscode, "")
-			}
-			if previousTranscodeNodeURL != "" &&
-				(previousTranscodeNodeURL != tcNode.URL || previousProcessID != nodeReq.SessionID) {
-				h.tm.StopRemoteTranscode(previousProcessID, previousTranscodeNodeURL)
-			}
+			logTranscodeStartState(r, startState)
+			h.syncSessionsNow(r.Context(), "transcode_start")
 		}
-		effectiveHWAccel := effectiveRemoteHWAccel(nodeResp, nodeReq)
 
 		// The remote transcode's full recipe rides the proxy manifest token so the
 		// integrated server can re-bind and re-proxy the session after a restart
@@ -3227,15 +3346,6 @@ func (h *PlaybackHandler) HandleStartTranscode(w http.ResponseWriter, r *http.Re
 			TotalDuration:          nodeReq.TotalDuration,
 		})
 		manifestURL := h.buildProxyManifestURL(card, plan.ProxyNode)
-		if !atomicLegacyReplacement {
-			h.finalizeTranscodeStart(r, transcodeStartState{
-				req:            req,
-				file:           file,
-				session:        session,
-				switchedFileID: switchedFileID,
-				hwAccel:        effectiveHWAccel,
-			})
-		}
 		writeJSON(w, http.StatusAccepted, buildTranscodeStartResponse(req, file, switchedFileID, manifestURL, streamOriginSeconds))
 		return
 	}
@@ -3255,27 +3365,7 @@ func (h *PlaybackHandler) HandleStartTranscode(w http.ResponseWriter, r *http.Re
 		return
 	}
 
-	// Hold the per-session lifecycle lock across teardown → spawn → register so a
-	// concurrent reconstruct (or another fresh start) cannot run a second ffmpeg
-	// writer against this session's output directory. The in-lock close tears down
-	// any session a reconstruct rebuilt between the earlier close and here so the
-	// fresh ffmpeg is the sole writer.
-	unlock := h.tm.LockSessionLifecycle(req.SessionID)
-	currentSession, currentSessionErr := h.sessionMgr.GetSession(req.SessionID)
-	if currentSessionErr != nil {
-		unlock()
-		writeError(w, http.StatusInternalServerError, "internal_error", "Failed to verify playback transport")
-		return
-	}
-	if h.tm.GetTranscodeSession(req.SessionID) != previousLocalTranscode ||
-		currentSession.TranscodeNodeURL != previousTranscodeNodeURL ||
-		currentSession.TranscodeTransportID != previousTransportID {
-		unlock()
-		writeError(w, http.StatusConflict, "transcode_replaced", "A newer playback transport replaced this request")
-		return
-	}
-	h.tm.CloseTranscodeSession(req.SessionID, "")
-	transcodeSession, err := h.startLocalPlaybackTransport(r.Context(), playback.TranscodeOpts{
+	localOpts := playback.TranscodeOpts{
 		InputPath:              file.FilePath,
 		OutputDir:              filepath.Join(playbackCfg.TranscodeDir, req.SessionID),
 		SessionID:              req.SessionID,
@@ -3302,48 +3392,80 @@ func (h *PlaybackHandler) HandleStartTranscode(w http.ResponseWriter, r *http.Re
 		NodeType:               "integrated",
 		ExecutionMode:          "integrated",
 		FFmpegLogSink:          h.FFmpegLogSink,
-	})
-	if err != nil {
-		unlock()
-		writeError(w, http.StatusInternalServerError, "internal_error", "Failed to start transcode session")
-		return
 	}
-
-	h.tm.RegisterTranscodeSession(req.SessionID, transcodeSession)
-	if err := h.sessionMgr.SetTranscodeRoute(req.SessionID, "", ""); err != nil {
-		h.tm.CloseTranscodeSessionIf(req.SessionID, transcodeSession, "")
-		unlock()
-		slog.ErrorContext(r.Context(), "publish local transcode route", "component", "api", "error", err, "session", req.SessionID, "playback_session_id", req.SessionID)
-		writeError(w, http.StatusInternalServerError, "internal_error", "Failed to publish transcode session")
-		return
-	}
-	if err := h.persistTranscodeStartState(r, transcodeStartState{
+	startState := transcodeStartState{
 		req:            req,
 		file:           file,
 		session:        session,
 		switchedFileID: switchedFileID,
-		hwAccel:        transcodeSession.Opts().HWAccel,
-	}); err != nil {
-		h.tm.CloseTranscodeSessionIf(req.SessionID, transcodeSession, "")
-		_, _ = h.sessionMgr.SetTranscodeRouteIf(
+	}
+	localRoute := playback.TranscodeRoute{}
+	var transcodeSession *playback.TranscodeSession
+	if videoCopy {
+		// Copy-mode successors must coexist with the predecessor until readiness.
+		// A generation-scoped directory prevents two ffmpeg processes from writing
+		// the same manifest and segments during that overlap.
+		outputSubdir := newLegacyTransportID(req.SessionID)
+		localOpts.OutputSubdir = outputSubdir
+		localOpts.OutputDir = filepath.Join(playbackCfg.TranscodeDir, outputSubdir)
+		transcodeSession, err = h.commitLegacyLocalReplacement(
+			context.WithoutCancel(r.Context()),
 			req.SessionID,
-			"",
-			"",
-			previousTranscodeNodeURL,
-			previousTransportID,
+			previousLocalTranscode,
+			previousRoute,
+			localOpts,
+			func(successor *playback.TranscodeSession) playback.SessionReplacement {
+				startState.hwAccel = successor.Opts().HWAccel
+				return transcodeStartReplacement(startState, localRoute)
+			},
 		)
+		if err != nil {
+			if errors.Is(err, playback.ErrSessionSuperseded) {
+				writeError(w, http.StatusConflict, "transcode_replaced", "A newer playback transport replaced this request")
+				return
+			}
+			slog.ErrorContext(r.Context(), "prepare local copy transcode replacement", "component", "api", "error", err, "session", req.SessionID, "playback_session_id", req.SessionID)
+			writeError(w, http.StatusInternalServerError, "transcode_start_failed", "Failed to start transcode session")
+			return
+		}
+		if !h.transcodeRouteMatches(req.SessionID, transcodeSession, localRoute) {
+			writeError(w, http.StatusConflict, "transcode_replaced", "A newer playback transport replaced this request")
+			return
+		}
+	} else {
+		// Encoded legacy starts keep their historical serialized last-writer-wins
+		// behavior. Re-read the predecessor under the lifecycle lock instead of
+		// rejecting this request because another overlapping start finished first.
+		unlock := h.tm.LockSessionLifecycle(req.SessionID)
+		currentSession, currentErr := h.sessionMgr.GetSession(req.SessionID)
+		if currentErr != nil {
+			unlock()
+			writeError(w, http.StatusInternalServerError, "internal_error", "Failed to verify playback transport")
+			return
+		}
+		currentRoute := sessionTranscodeRoute(currentSession)
+		currentProcessID := remoteTransportID(currentSession)
+		h.tm.CloseTranscodeSession(req.SessionID, "")
+		transcodeSession, err = h.startLocalPlaybackTransport(r.Context(), localOpts)
+		if err != nil {
+			unlock()
+			writeError(w, http.StatusInternalServerError, "transcode_start_failed", "Failed to start transcode session")
+			return
+		}
+		h.tm.RegisterTranscodeSession(req.SessionID, transcodeSession)
+		startState.hwAccel = transcodeSession.Opts().HWAccel
+		if _, err := h.sessionMgr.ApplyReplacement(req.SessionID, transcodeStartReplacement(startState, localRoute)); err != nil {
+			h.tm.CloseTranscodeSessionIf(req.SessionID, transcodeSession, "")
+			unlock()
+			writeError(w, http.StatusInternalServerError, "internal_error", "Failed to publish transcode session")
+			return
+		}
 		unlock()
-		writeError(w, http.StatusInternalServerError, "internal_error", "Failed to publish transcode session")
-		return
+		if currentRoute.NodeURL != "" {
+			h.tm.StopRemoteTranscode(currentProcessID, currentRoute.NodeURL)
+		}
 	}
-	unlock()
-	if previousTranscodeNodeURL != "" {
-		h.tm.StopRemoteTranscode(previousProcessID, previousTranscodeNodeURL)
-	}
-	if !h.transcodeRouteMatches(req.SessionID, transcodeSession, "", "") {
-		writeError(w, http.StatusConflict, "transcode_replaced", "A newer playback transport replaced this request")
-		return
-	}
+	logTranscodeStartState(r, startState)
 
 	// Re-arm the throttler and exit monitor after every Restart of this
 	// handler-created session, regardless of which code path triggers it

--- a/internal/api/handlers/playback.go
+++ b/internal/api/handlers/playback.go
@@ -18,6 +18,7 @@ import (
 	"time"
 
 	"github.com/go-chi/chi/v5"
+	"github.com/google/uuid"
 
 	apimw "github.com/Silo-Server/silo-server/internal/api/middleware"
 	"github.com/Silo-Server/silo-server/internal/catalog"
@@ -50,6 +51,8 @@ type SessionManagerInterface interface {
 	EndTransport(sessionID string) error
 	SetEffectiveMediaFileID(sessionID string, fileID int) error
 	SetTranscodeNodeURL(sessionID, url string) error
+	SetTranscodeRoute(sessionID, nodeURL, transportID string) error
+	SetTranscodeRouteIf(sessionID, expectedNodeURL, expectedTransportID, nodeURL, transportID string) (bool, error)
 	SetWebSocket(sessionID string, connected bool) error
 	SetRealtimeConnection(sessionID string, connected bool) error
 	SetProgressPersistenceDisabled(sessionID string, disabled bool) error
@@ -128,6 +131,14 @@ type PlaybackOriginalLanguageLookup interface {
 	GetOriginalLanguage(ctx context.Context, contentID string) (string, error)
 }
 
+type copySeekAnchorResolver func(
+	ctx context.Context,
+	ffmpegPath string,
+	inputPath string,
+	requestedSeekSeconds float64,
+	segmentDuration int,
+) (float64, int, error)
+
 // PlaybackHandler handles playback session HTTP endpoints.
 type PlaybackHandler struct {
 	sessionMgr              SessionManagerInterface
@@ -170,6 +181,7 @@ type PlaybackHandler struct {
 	// playbackConfig(), which falls back to defaults when unset.
 	PlaybackConfig    func() config.PlaybackConfig
 	FFmpegLogSink     playback.FFmpegLogSink
+	copySeekAnchor    copySeekAnchorResolver
 	realtimeCommandMu sync.Mutex
 	realtimeCommands  map[string]playbackCommandRecord
 	// tm owns the transcode-session lifecycle (live map, recipe cards, and
@@ -514,6 +526,7 @@ func buildTranscodeStartResponse(
 	file *models.MediaFile,
 	switchedFileID *int,
 	manifestURL string,
+	streamOriginSeconds float64,
 ) transcodeStartResponse {
 	resp := transcodeStartResponse{
 		SessionID:       req.SessionID,
@@ -529,11 +542,27 @@ func buildTranscodeStartResponse(
 		resp.CanSeekAnywhere = true
 		return resp
 	}
-	resp.PlayerStartSeconds = 0
-	resp.StreamOriginSeconds = req.SeekSeconds
-	resp.TimelineOffsetSeconds = req.SeekSeconds
+	resp.PlayerStartSeconds = max(0, req.SeekSeconds-streamOriginSeconds)
+	resp.StreamOriginSeconds = streamOriginSeconds
+	resp.TimelineOffsetSeconds = streamOriginSeconds
 	resp.CanSeekAnywhere = false
 	return resp
+}
+
+func (h *PlaybackHandler) resolveLegacyCopySeekAnchor(
+	ctx context.Context,
+	ffmpegPath string,
+	inputPath string,
+	requestedSeekSeconds float64,
+	segmentDuration int,
+) (float64, int, error) {
+	resolver := h.copySeekAnchor
+	if resolver == nil {
+		resolver = playback.ResolveCopySeekAnchor
+	}
+	probeCtx, cancel := context.WithTimeout(ctx, 8*time.Second)
+	defer cancel()
+	return resolver(probeCtx, ffmpegPath, inputPath, requestedSeekSeconds, segmentDuration)
 }
 
 func (h *PlaybackHandler) ensurePlaybackProbe(ctx context.Context, file *models.MediaFile) *models.MediaFile {
@@ -739,6 +768,111 @@ func remoteTransportID(session *playback.Session) string {
 		return ""
 	}
 	return session.ID
+}
+
+const legacyTransportMarker = "-legacy-"
+
+func isLegacyTransportSession(session *playback.Session) bool {
+	if session == nil {
+		return false
+	}
+	if session.TranscodeTransportID == "" {
+		return true
+	}
+	return strings.HasPrefix(session.TranscodeTransportID, session.ID+legacyTransportMarker)
+}
+
+func newLegacyTransportID(sessionID string) string {
+	return sessionID + legacyTransportMarker + uuid.NewString()
+}
+
+func (h *PlaybackHandler) transcodeRouteMatches(
+	sessionID string,
+	expectedLocal *playback.TranscodeSession,
+	nodeURL string,
+	transportID string,
+) bool {
+	unlock := h.tm.LockSessionLifecycle(sessionID)
+	defer unlock()
+	session, err := h.sessionMgr.GetSession(sessionID)
+	if err != nil || session == nil {
+		return false
+	}
+	return h.tm.GetTranscodeSession(sessionID) == expectedLocal &&
+		session.TranscodeNodeURL == nodeURL &&
+		session.TranscodeTransportID == transportID
+}
+
+func (h *PlaybackHandler) commitLegacyRemoteReplacement(
+	sessionID string,
+	previousLocal *playback.TranscodeSession,
+	previousNodeURL string,
+	previousTransportID string,
+	nodeURL string,
+	transportID string,
+	publishState func() error,
+) error {
+	unlock := h.tm.LockSessionLifecycle(sessionID)
+	if h.tm.GetTranscodeSession(sessionID) != previousLocal {
+		unlock()
+		return playback.ErrSessionSuperseded
+	}
+
+	published, err := h.sessionMgr.SetTranscodeRouteIf(
+		sessionID,
+		previousNodeURL,
+		previousTransportID,
+		nodeURL,
+		transportID,
+	)
+	if err != nil {
+		unlock()
+		return err
+	}
+	if !published {
+		unlock()
+		return playback.ErrSessionSuperseded
+	}
+	if publishState != nil {
+		if err := publishState(); err != nil {
+			_, rollbackErr := h.sessionMgr.SetTranscodeRouteIf(
+				sessionID,
+				nodeURL,
+				transportID,
+				previousNodeURL,
+				previousTransportID,
+			)
+			unlock()
+			return errors.Join(err, rollbackErr)
+		}
+	}
+	if previousLocal != nil && !h.tm.CloseTranscodeSessionIf(sessionID, previousLocal, "") {
+		// The lifecycle lock makes this defensive rollback unreachable for normal
+		// callers, but never leave a newly published remote route beside a local
+		// successor if a caller bypassed that lock contract.
+		_, rollbackErr := h.sessionMgr.SetTranscodeRouteIf(
+			sessionID,
+			nodeURL,
+			transportID,
+			previousNodeURL,
+			previousTransportID,
+		)
+		unlock()
+		if rollbackErr != nil {
+			return errors.Join(playback.ErrSessionSuperseded, rollbackErr)
+		}
+		return playback.ErrSessionSuperseded
+	}
+	unlock()
+
+	if previousNodeURL != "" {
+		previousProcessID := previousTransportID
+		if previousProcessID == "" {
+			previousProcessID = sessionID
+		}
+		h.tm.StopRemoteTranscode(previousProcessID, previousNodeURL)
+	}
+	return nil
 }
 
 func (h *PlaybackHandler) closeTranscodeForSession(session *playback.Session) {
@@ -2095,6 +2229,60 @@ func (h *PlaybackHandler) HandleChangeAudioTrack(w http.ResponseWriter, r *http.
 	} else if transcodeAudio {
 		targetAudioCodec = "aac"
 	}
+
+	// A legacy copy-video restart needs a fresh keyframe origin for the new
+	// position. Resolve it before mutating the durable session or stopping the
+	// current transport so a probe failure leaves the active stream intact.
+	restartSegmentDuration := session.SegmentDuration
+	if restartSegmentDuration <= 0 {
+		restartSegmentDuration = playback.DefaultSegmentDuration
+	}
+	if ts := h.tm.GetTranscodeSession(sessionID); ts != nil {
+		if liveDuration := ts.Opts().SegmentDuration; liveDuration > 0 {
+			restartSegmentDuration = liveDuration
+		}
+	}
+	restartSeekSeconds := alignedSeekSeconds(req.Position, restartSegmentDuration, targetVideoCodec)
+	restartStartSegment := computeStartSegment(restartSeekSeconds, restartSegmentDuration)
+	restartStreamOriginSeconds := 0.0
+	restartCopyAnchorResolved := false
+	legacyCopyRestart := session.PlayMethod == playback.PlayTranscode &&
+		strings.EqualFold(targetVideoCodec, "copy") && isLegacyTransportSession(session)
+	if legacyCopyRestart {
+		restartCopyAnchorResolved = true
+		if req.Position > 0 {
+			anchor, anchorSegment, anchorErr := h.resolveLegacyCopySeekAnchor(
+				r.Context(),
+				h.playbackConfig().FFmpegPath,
+				file.FilePath,
+				req.Position,
+				restartSegmentDuration,
+			)
+			if anchorErr != nil {
+				slog.ErrorContext(r.Context(), "failed to resolve copy-video audio-switch seek anchor", "component", "api",
+					"playback_session_id", sessionID,
+					"requested_seek_seconds", req.Position,
+					"error", anchorErr,
+				)
+				writeError(w, http.StatusInternalServerError, "remux_seek_anchor_failed", "Failed to resolve remux seek position")
+				return
+			}
+			restartStreamOriginSeconds = anchor
+			restartStartSegment = anchorSegment
+		}
+	}
+	var deferredRemoteCopyPlan *nodepool.Plan
+	if legacyCopyRestart && strings.TrimSpace(session.TranscodeNodeURL) != "" &&
+		h.NodePlanner != nil && h.JWTSecret != "" {
+		estKbps := targetBitrateKbps
+		if estKbps <= 0 {
+			estKbps = fileBitrateKbps(file)
+		}
+		plan := h.NodePlanner.PlanSession(sessionID, session.TranscodeNodeURL, true, estKbps)
+		if plan.ProxyNode != nil && plan.TranscodeNode != nil {
+			deferredRemoteCopyPlan = &plan
+		}
+	}
 	slog.InfoContext(r.Context(), "audio switch computed playback state", "component", "api",
 		"playback_session_id", sessionID,
 		"previous_base_play_method", baseMethod,
@@ -2104,41 +2292,61 @@ func (h *PlaybackHandler) HandleChangeAudioTrack(w http.ResponseWriter, r *http.
 		"audio_codec", newTrack.Codec,
 		"transcode_audio", transcodeAudio,
 	)
-	if err := h.sessionMgr.UpdateAudioTrack(sessionID, req.AudioTrackIndex, newMethod); err != nil {
-		writeError(w, http.StatusInternalServerError, "internal_error", "Failed to update audio track")
-		return
+	persistAudioSwitchState := func() error {
+		if err := h.sessionMgr.UpdateAudioTrack(sessionID, req.AudioTrackIndex, newMethod); err != nil {
+			return err
+		}
+		return h.sessionMgr.UpdateStreamState(sessionID, playback.SessionStreamState{
+			PlayMethod:        session.PlayMethod,
+			BasePlayMethod:    newMethod,
+			AudioTrackIndex:   req.AudioTrackIndex,
+			TranscodeAudio:    transcodeAudio,
+			ClientIP:          session.ClientIP,
+			StreamBitrateKbps: streamBitrateKbps,
+			TargetResolution:  targetResolution,
+			TargetVideoCodec:  targetVideoCodec,
+			TargetAudioCodec:  targetAudioCodec,
+			TargetBitrateKbps: targetBitrateKbps,
+			// Carry the byte-affecting recipe forward: an audio switch changes only the
+			// audio selection, so subtitles and cadence must survive the state update
+			// (UpdateStreamState overwrites these fields unconditionally).
+			SubtitleTrackIndex: session.SubtitleTrackIndex,
+			SubtitleBurnIn:     session.SubtitleBurnIn,
+			SegmentDuration:    session.SegmentDuration,
+		})
 	}
-	if err := h.sessionMgr.UpdateStreamState(sessionID, playback.SessionStreamState{
-		PlayMethod:        session.PlayMethod,
-		BasePlayMethod:    newMethod,
-		AudioTrackIndex:   req.AudioTrackIndex,
-		TranscodeAudio:    transcodeAudio,
-		ClientIP:          session.ClientIP,
-		StreamBitrateKbps: streamBitrateKbps,
-		TargetResolution:  targetResolution,
-		TargetVideoCodec:  targetVideoCodec,
-		TargetAudioCodec:  targetAudioCodec,
-		TargetBitrateKbps: targetBitrateKbps,
-		// Carry the byte-affecting recipe forward: an audio switch changes only the
-		// audio selection, so subtitles and cadence must survive the state update
-		// (UpdateStreamState overwrites these fields unconditionally).
-		SubtitleTrackIndex: session.SubtitleTrackIndex,
-		SubtitleBurnIn:     session.SubtitleBurnIn,
-		SegmentDuration:    session.SegmentDuration,
-	}); err != nil {
-		writeError(w, http.StatusInternalServerError, "internal_error", "Failed to update stream state")
-		return
+	if deferredRemoteCopyPlan == nil {
+		if err := persistAudioSwitchState(); err != nil {
+			writeError(w, http.StatusInternalServerError, "internal_error", "Failed to update audio track")
+			return
+		}
 	}
 
 	// Handle transcode restart.
-	if session.PlayMethod == playback.PlayTranscode {
+	if session.PlayMethod == playback.PlayTranscode && deferredRemoteCopyPlan == nil {
 		if ts := h.tm.GetTranscodeSession(sessionID); ts != nil {
 			ts.SetAudioTrackIndex(req.AudioTrackIndex)
-			tsOpts := ts.Opts()
-			startSegment := computeStartSegment(req.Position, tsOpts.SegmentDuration)
-			seekSeconds := alignedSeekSeconds(req.Position, tsOpts.SegmentDuration, tsOpts.TargetCodecVideo)
 			// Throttler + exit monitor re-arm via the session's restart hook.
-			if restartErr := h.tm.RestartSessionLocked(context.WithoutCancel(r.Context()), sessionID, ts, seekSeconds, startSegment); restartErr != nil {
+			var restartErr error
+			if restartCopyAnchorResolved {
+				restartErr = h.tm.RestartSessionLockedWithCopySeekAnchor(
+					context.WithoutCancel(r.Context()),
+					sessionID,
+					ts,
+					restartSeekSeconds,
+					restartStartSegment,
+					restartStreamOriginSeconds,
+				)
+			} else {
+				restartErr = h.tm.RestartSessionLocked(
+					context.WithoutCancel(r.Context()),
+					sessionID,
+					ts,
+					restartSeekSeconds,
+					restartStartSegment,
+				)
+			}
+			if restartErr != nil {
 				slog.ErrorContext(r.Context(), "failed to restart transcode for audio switch", "component", "api", "session", sessionID, "error", restartErr)
 			}
 		}
@@ -2161,7 +2369,9 @@ func (h *PlaybackHandler) HandleChangeAudioTrack(w http.ResponseWriter, r *http.
 	// audio/method. For transcode the full-recipe manifest URL is rebuilt further
 	// down (proxy or local); for direct/remux the identity token on StreamURL
 	// carries the new audio selection.
-	h.persistAudioPreference(r.Context(), userID, session.ProfileID, file, req.AudioTrackIndex)
+	if deferredRemoteCopyPlan == nil {
+		h.persistAudioPreference(r.Context(), userID, session.ProfileID, file, req.AudioTrackIndex)
+	}
 
 	// For a local transcode, playbackStreamURL returns the bare manifest URL
 	// without the full-recipe ?st= token, so a post-restart reconstruct would
@@ -2193,22 +2403,33 @@ func (h *PlaybackHandler) HandleChangeAudioTrack(w http.ResponseWriter, r *http.
 		if estKbps <= 0 {
 			estKbps = fileBitrateKbps(file)
 		}
-		plan := h.NodePlanner.PlanSession(sessionID, session.TranscodeNodeURL, needsTranscode, estKbps)
+		var plan nodepool.Plan
+		if deferredRemoteCopyPlan != nil {
+			plan = *deferredRemoteCopyPlan
+		} else {
+			plan = h.NodePlanner.PlanSession(sessionID, session.TranscodeNodeURL, needsTranscode, estKbps)
+		}
 		if proxyNode := plan.ProxyNode; proxyNode != nil && (!needsTranscode || plan.TranscodeNode != nil) {
 			// Remote (offloaded) transcode: the API server owns no local
 			// TranscodeSession (the LOCAL restart block above was a no-op), so
 			// the node's ffmpeg is still serving the OLD audio track. POST a
-			// fresh /transcode/start with the new AudioTrackIndex — the node
-			// tears down the existing session for this ID and restarts ffmpeg
-			// (handleStart in internal/transcodenode/server.go), which IS the
-			// remote restart mechanism — then mint the replacement proxy URL
+			// fresh /transcode/start with the new AudioTrackIndex. Encoded legacy
+			// streams retain the node's same-ID replacement behavior; copy-video
+			// streams prepare a distinct successor and retire the predecessor only
+			// after readiness and route publication. Then mint the proxy URL
 			// from a FULL recipe card so a later node restart reconstructs with
 			// the switched audio (the lean identity-only claims used for remux
 			// below omit the byte-affecting encode fields and would 404).
 			isOffloaded := strings.TrimSpace(session.TranscodeNodeURL) != ""
 			if needsTranscode && plan.TranscodeNode != nil && isOffloaded {
 				nodeURL := plan.TranscodeNode.URL
-				_ = h.sessionMgr.SetTranscodeNodeURL(sessionID, nodeURL)
+				atomicLegacyReplacement := legacyCopyRestart
+				previousLocalTranscode := h.tm.GetTranscodeSession(sessionID)
+				previousNodeURL := session.TranscodeNodeURL
+				previousTransportID := session.TranscodeTransportID
+				if !atomicLegacyReplacement {
+					_ = h.sessionMgr.SetTranscodeNodeURL(sessionID, nodeURL)
+				}
 
 				// Restart from the FULL live recipe, not a partial re-derivation.
 				// An audio switch alters only audio selection — subtitle burn-in and
@@ -2219,19 +2440,13 @@ func (h *PlaybackHandler) HandleChangeAudioTrack(w http.ResponseWriter, r *http.
 				// post-restart reconstruct, so recover them here. Embed a concrete
 				// segment duration (not 0): the node's recipe token treats
 				// SegmentDuration<=0 as "incomplete" and would 404 on a node restart.
-				segmentDuration := session.SegmentDuration
-				if segmentDuration <= 0 {
-					segmentDuration = playback.DefaultSegmentDuration
-				}
-				seekSeconds := alignedSeekSeconds(req.Position, segmentDuration, updatedSession.TargetVideoCodec)
+				segmentDuration := restartSegmentDuration
 				subtitleTrackIndex := session.SubtitleTrackIndex
 				subtitleBurnIn := session.SubtitleBurnIn
 				subtitleCodec := ""
 				if subtitleBurnIn && subtitleTrackIndex >= 0 {
 					subtitleCodec = embeddedSubtitleCodec(file, subtitleTrackIndex)
 				}
-				startSegment := computeStartSegment(seekSeconds, segmentDuration)
-
 				// Derive the encode recipe the same way HandleStartTranscode
 				// does — from the durable session target fields plus the file —
 				// changing only the audio track. SourceVideoCodec/TotalDuration
@@ -2241,23 +2456,29 @@ func (h *PlaybackHandler) HandleChangeAudioTrack(w http.ResponseWriter, r *http.
 				// transport ID; restarting under the bare session ID would
 				// spawn a duplicate job beside it.
 				restartTransportID := remoteTransportID(&updatedSession)
+				if atomicLegacyReplacement {
+					restartTransportID = newLegacyTransportID(sessionID)
+				}
 				nodeReq := transcodenode.TranscodeStartRequest{
-					SessionID:          restartTransportID,
-					InputPath:          file.FilePath,
-					SourceVideoCodec:   file.CodecVideo,
-					SeekSeconds:        seekSeconds,
-					StartSegmentNumber: startSegment,
-					TargetResolution:   updatedSession.TargetResolution,
-					TargetCodecVideo:   updatedSession.TargetVideoCodec,
-					TargetCodecAudio:   updatedSession.TargetAudioCodec,
-					TargetBitrateKbps:  updatedSession.TargetBitrateKbps,
-					SegmentDuration:    segmentDuration,
-					HWAccel:            session.TranscodeHWAccel,
-					AudioTrackIndex:    req.AudioTrackIndex,
-					SubtitleTrackIndex: subtitleTrackIndex,
-					SubtitleBurnIn:     subtitleBurnIn,
-					SubtitleCodec:      subtitleCodec,
-					TotalDuration:      float64(file.Duration),
+					SessionID:              restartTransportID,
+					InputPath:              file.FilePath,
+					SourceVideoCodec:       file.CodecVideo,
+					SeekSeconds:            restartSeekSeconds,
+					StreamOriginSeconds:    restartStreamOriginSeconds,
+					CopySeekAnchorResolved: restartCopyAnchorResolved,
+					StartSegmentNumber:     restartStartSegment,
+					TargetResolution:       updatedSession.TargetResolution,
+					TargetCodecVideo:       updatedSession.TargetVideoCodec,
+					TargetCodecAudio:       updatedSession.TargetAudioCodec,
+					TargetBitrateKbps:      updatedSession.TargetBitrateKbps,
+					SegmentDuration:        segmentDuration,
+					HWAccel:                session.TranscodeHWAccel,
+					AudioTrackIndex:        req.AudioTrackIndex,
+					SubtitleTrackIndex:     subtitleTrackIndex,
+					SubtitleBurnIn:         subtitleBurnIn,
+					SubtitleCodec:          subtitleCodec,
+					TotalDuration:          float64(file.Duration),
+					RequireReady:           atomicLegacyReplacement,
 				}
 				if strings.TrimSpace(nodeReq.HWAccel) == "" {
 					nodeReq.HWAccel = h.playbackConfig().HWAccel
@@ -2283,15 +2504,54 @@ func (h *PlaybackHandler) HandleChangeAudioTrack(w http.ResponseWriter, r *http.
 
 				nodeResp, doErr := http.DefaultClient.Do(httpReq)
 				if doErr != nil {
+					if atomicLegacyReplacement {
+						h.tm.StopRemoteTranscode(restartTransportID, nodeURL)
+					}
 					slog.ErrorContext(r.Context(), "remote transcode restart for audio switch failed", "component", "api", "session", sessionID, "node", nodeURL, "error", doErr)
 					writeError(w, http.StatusBadGateway, "transcode_node_unavailable", "Transcode node is unavailable")
 					return
 				}
 				defer nodeResp.Body.Close()
 				if nodeResp.StatusCode != http.StatusAccepted {
+					if atomicLegacyReplacement {
+						h.tm.StopRemoteTranscode(restartTransportID, nodeURL)
+					}
 					slog.ErrorContext(r.Context(), "remote transcode restart for audio switch rejected", "component", "api", "session", sessionID, "node", nodeURL, "status", nodeResp.StatusCode)
 					writeError(w, http.StatusBadGateway, "transcode_start_failed", "Transcode node rejected the request")
 					return
+				}
+				if atomicLegacyReplacement {
+					var publishState func() error
+					if deferredRemoteCopyPlan != nil {
+						publishState = persistAudioSwitchState
+					}
+					if routeErr := h.commitLegacyRemoteReplacement(
+						sessionID,
+						previousLocalTranscode,
+						previousNodeURL,
+						previousTransportID,
+						nodeURL,
+						restartTransportID,
+						publishState,
+					); routeErr != nil {
+						h.tm.StopRemoteTranscode(restartTransportID, nodeURL)
+						if errors.Is(routeErr, playback.ErrSessionSuperseded) {
+							writeError(w, http.StatusConflict, "transcode_replaced", "A newer playback transport replaced this request")
+							return
+						}
+						slog.ErrorContext(r.Context(), "publish remote audio-switch transcode route", "component", "api", "session", sessionID, "node", nodeURL, "error", routeErr)
+						writeError(w, http.StatusInternalServerError, "internal_error", "Failed to publish transcode session")
+						return
+					}
+					if !h.transcodeRouteMatches(sessionID, nil, nodeURL, restartTransportID) {
+						writeError(w, http.StatusConflict, "transcode_replaced", "A newer playback transport replaced this request")
+						return
+					}
+					updatedSession.TranscodeNodeURL = nodeURL
+					updatedSession.TranscodeTransportID = restartTransportID
+					if deferredRemoteCopyPlan != nil {
+						h.persistAudioPreference(r.Context(), userID, session.ProfileID, file, req.AudioTrackIndex)
+					}
 				}
 
 				var startResp transcodenode.TranscodeStartResponse
@@ -2304,24 +2564,26 @@ func (h *PlaybackHandler) HandleChangeAudioTrack(w http.ResponseWriter, r *http.
 				}
 
 				card := playback.NewRecipeCard(updatedSession.UserID, updatedSession.ProfileID, updatedSession.MediaFileID, nodeURL, playback.TranscodeOpts{
-					InputPath:            nodeReq.InputPath,
-					SessionID:            sessionID,
-					TranscodeTransportID: restartTransportID,
-					VideoBitstreamFilter: nodeReq.VideoBitstreamFilter,
-					SourceVideoCodec:     nodeReq.SourceVideoCodec,
-					SeekSeconds:          nodeReq.SeekSeconds,
-					StartSegmentNumber:   nodeReq.StartSegmentNumber,
-					TargetResolution:     nodeReq.TargetResolution,
-					TargetCodecVideo:     nodeReq.TargetCodecVideo,
-					TargetCodecAudio:     nodeReq.TargetCodecAudio,
-					TargetBitrateKbps:    nodeReq.TargetBitrateKbps,
-					SegmentDuration:      nodeReq.SegmentDuration,
-					HWAccel:              effectiveHWAccel,
-					AudioTrackIndex:      nodeReq.AudioTrackIndex,
-					SubtitleTrackIndex:   nodeReq.SubtitleTrackIndex,
-					SubtitleBurnIn:       nodeReq.SubtitleBurnIn,
-					SubtitleCodec:        nodeReq.SubtitleCodec,
-					TotalDuration:        nodeReq.TotalDuration,
+					InputPath:              nodeReq.InputPath,
+					SessionID:              sessionID,
+					TranscodeTransportID:   restartTransportID,
+					VideoBitstreamFilter:   nodeReq.VideoBitstreamFilter,
+					SourceVideoCodec:       nodeReq.SourceVideoCodec,
+					SeekSeconds:            nodeReq.SeekSeconds,
+					StreamOriginSeconds:    nodeReq.StreamOriginSeconds,
+					CopySeekAnchorResolved: nodeReq.CopySeekAnchorResolved,
+					StartSegmentNumber:     nodeReq.StartSegmentNumber,
+					TargetResolution:       nodeReq.TargetResolution,
+					TargetCodecVideo:       nodeReq.TargetCodecVideo,
+					TargetCodecAudio:       nodeReq.TargetCodecAudio,
+					TargetBitrateKbps:      nodeReq.TargetBitrateKbps,
+					SegmentDuration:        nodeReq.SegmentDuration,
+					HWAccel:                effectiveHWAccel,
+					AudioTrackIndex:        nodeReq.AudioTrackIndex,
+					SubtitleTrackIndex:     nodeReq.SubtitleTrackIndex,
+					SubtitleBurnIn:         nodeReq.SubtitleBurnIn,
+					SubtitleCodec:          nodeReq.SubtitleCodec,
+					TotalDuration:          nodeReq.TotalDuration,
 				})
 				resp.StreamURL = h.buildProxyManifestURL(card, proxyNode)
 			} else {
@@ -2511,12 +2773,25 @@ type transcodeStartState struct {
 	hwAccel        string
 }
 
-// finalizeTranscodeStart updates the playback session state after a transcode
-// has been started (either locally or on a remote node).
-func (h *PlaybackHandler) finalizeTranscodeStart(r *http.Request, st transcodeStartState) {
+func effectiveRemoteHWAccel(
+	response transcodenode.TranscodeStartResponse,
+	request transcodenode.TranscodeStartRequest,
+) string {
+	hwAccel := strings.TrimSpace(response.HWAccel)
+	if hwAccel == "" {
+		hwAccel = strings.TrimSpace(request.HWAccel)
+	}
+	return hwAccel
+}
+
+// persistTranscodeStartState updates the durable playback recipe after a
+// transcode has started. Transactional replacement callers invoke it while
+// they still hold the per-session lifecycle lock.
+func (h *PlaybackHandler) persistTranscodeStartState(r *http.Request, st transcodeStartState) error {
 	if st.switchedFileID != nil {
 		if err := h.sessionMgr.SetEffectiveMediaFileID(st.req.SessionID, *st.switchedFileID); err != nil {
 			slog.ErrorContext(r.Context(), "failed to update effective media file", "component", "api", "session", st.req.SessionID, "error", err, "playback_session_id", st.req.SessionID)
+			return err
 		}
 	}
 
@@ -2564,8 +2839,15 @@ func (h *PlaybackHandler) finalizeTranscodeStart(r *http.Request, st transcodeSt
 		SegmentDuration:    segmentDuration,
 	}); err != nil {
 		slog.ErrorContext(r.Context(), "failed to update transcode stream state", "component", "api", "session", st.req.SessionID, "error", err, "playback_session_id", st.req.SessionID)
+		return err
 	}
+	return nil
+}
 
+func (h *PlaybackHandler) finalizeTranscodeStart(r *http.Request, st transcodeStartState) {
+	if err := h.persistTranscodeStartState(r, st); err != nil {
+		return
+	}
 	h.syncSessionsNow(r.Context(), "transcode_start")
 }
 
@@ -2605,15 +2887,14 @@ func (h *PlaybackHandler) HandleStartTranscode(w http.ResponseWriter, r *http.Re
 	if !h.ensureUserTranscodingAllowed(w, r, userID, requiresVideoTranscode) {
 		return
 	}
-	// Close any existing transcode so a new one can start at different quality.
-	// Check both local sessions AND remote node assignments — without the
-	// remote check, switching quality on a transcode node never sends DELETE,
-	// leaving the old ffmpeg running and its segments on disk.
-	if h.tm.GetTranscodeSession(req.SessionID) != nil || session.TranscodeNodeURL != "" {
-		// Restarting the transcode under the SAME session id (quality/seek
-		// change) — keep the card; it is re-saved with the new opts below.
-		h.closeTranscodeForSession(session)
-	}
+	// Keep the active transport alive through every fallible preflight. A local
+	// replacement is retired under the lifecycle lock immediately before spawn;
+	// a legacy remote replacement is prepared under a distinct process identity
+	// and retired only after the node accepts and the session publishes its successor.
+	previousLocalTranscode := h.tm.GetTranscodeSession(req.SessionID)
+	previousTranscodeNodeURL := session.TranscodeNodeURL
+	previousTransportID := session.TranscodeTransportID
+	previousProcessID := remoteTransportID(session)
 	abortCurrentSession := func(reason string, cause error) {
 		if abortErr := h.abortPlaybackSession(r.Context(), session); abortErr != nil && !errors.Is(abortErr, playback.ErrSessionNotFound) {
 			slog.ErrorContext(r.Context(), "failed to abort playback session", "component", "api",
@@ -2676,22 +2957,6 @@ func (h *PlaybackHandler) HandleStartTranscode(w http.ResponseWriter, r *http.Re
 		}
 	}
 
-	// Resume and seek-start requests generally cannot safely stream-copy video
-	// into HLS output. Arbitrary HEVC seek points often land on non-keyframes,
-	// which can leave Chromium stuck on a frozen frame while audio continues
-	// advancing. MPEG-2 compatibility HLS is allowed to keep copy-video so Apple
-	// devices can avoid a full video transcode for those files.
-	if req.SeekSeconds > 0 && strings.EqualFold(req.TargetCodecVideo, "copy") && !playback.IsMPEG2VideoCodec(file.CodecVideo) {
-		slog.InfoContext(r.Context(), "forcing video transcode for seeked copy request", "component", "api",
-			"playback_session_id", req.SessionID,
-			"seek_seconds", req.SeekSeconds,
-			"source_video_codec", file.CodecVideo,
-			"requested_target_codec_video", req.TargetCodecVideo,
-			"effective_target_codec_video", "h264",
-		)
-		req.TargetCodecVideo = "h264"
-	}
-
 	// Subtitle burn-in composites subtitles into the video frames, which is
 	// impossible with -c:v copy. If the requested recipe would stream-copy
 	// video (e.g. a remux "original" restart that adds burn-in), force an
@@ -2714,8 +2979,8 @@ func (h *PlaybackHandler) HandleStartTranscode(w http.ResponseWriter, r *http.Re
 	// audio-switch restart derives it from the durable session route, but this
 	// client-driven restart endpoint historically dropped it — the client asking
 	// for "copy" has no way to know the source needs the strip. Derived after
-	// the seek/burn-in guards above so a copy request they rewrite to h264
-	// never carries a copy-only bitstream filter.
+	// the burn-in guard above so a copy request it rewrites to h264 never carries
+	// a copy-only bitstream filter.
 	videoBitstreamFilter := ""
 	if strings.EqualFold(req.TargetCodecVideo, "copy") &&
 		(session.RemuxDVMode == playback.RemuxDVStripToHDR10V3 || file.PrimaryDVProfile() == 7) {
@@ -2723,8 +2988,8 @@ func (h *PlaybackHandler) HandleStartTranscode(w http.ResponseWriter, r *http.Re
 	}
 
 	// The request-level permission check above intentionally runs before the
-	// existing transcode is closed. Recheck when server-side normalization has
-	// upgraded an allowed copy-video request into actual video encoding.
+	// existing transcode is closed. Recheck when subtitle burn-in normalization
+	// has upgraded an allowed copy-video request into actual video encoding.
 	if !requiresVideoTranscode && !strings.EqualFold(req.TargetCodecVideo, "copy") &&
 		!h.ensureUserTranscodingAllowed(w, r, userID, true) {
 		return
@@ -2792,6 +3057,44 @@ func (h *PlaybackHandler) HandleStartTranscode(w http.ResponseWriter, r *http.Re
 		subtitleCodec = resolvedCodec
 	}
 
+	// A copy-video input seek starts at the demuxer's preceding keyframe. Keep
+	// the requested position as FFmpeg's -ss input, but resolve that keyframe
+	// before selecting local/offloaded transport so filenames, reconstruction,
+	// and the client timeline all describe the media that is actually emitted.
+	playbackCfg := h.playbackConfig()
+	transportSeekSeconds := alignedSeekSeconds(req.SeekSeconds, req.SegmentDuration, req.TargetCodecVideo)
+	startSegmentNumber := computeStartSegment(transportSeekSeconds, req.SegmentDuration)
+	streamOriginSeconds := 0.0
+	if videoCopy {
+		streamOriginSeconds = req.SeekSeconds
+		if req.SeekSeconds > 0 {
+			anchor, anchorSegment, anchorErr := h.resolveLegacyCopySeekAnchor(
+				r.Context(),
+				playbackCfg.FFmpegPath,
+				file.FilePath,
+				req.SeekSeconds,
+				req.SegmentDuration,
+			)
+			if anchorErr != nil {
+				slog.ErrorContext(r.Context(), "failed to resolve copy-video seek anchor", "component", "api",
+					"playback_session_id", req.SessionID,
+					"requested_seek_seconds", req.SeekSeconds,
+					"error", anchorErr,
+				)
+				writeError(w, http.StatusInternalServerError, "remux_seek_anchor_failed", "Failed to resolve remux seek position")
+				return
+			}
+			streamOriginSeconds = anchor
+			startSegmentNumber = anchorSegment
+			slog.DebugContext(r.Context(), "resolved copy-video seek anchor", "component", "api",
+				"playback_session_id", req.SessionID,
+				"requested_seek_seconds", req.SeekSeconds,
+				"stream_origin_seconds", streamOriginSeconds,
+				"start_segment_number", startSegmentNumber,
+			)
+		}
+	}
+
 	// Determine whether to run locally or forward to a remote transcode node.
 	var plan nodepool.Plan
 	if h.NodePlanner != nil {
@@ -2805,78 +3108,135 @@ func (h *PlaybackHandler) HandleStartTranscode(w http.ResponseWriter, r *http.Re
 
 	if tcNode != nil {
 		// Remote transcode: forward to the assigned node.
-		if err := h.sessionMgr.SetTranscodeNodeURL(req.SessionID, tcNode.URL); err != nil {
-			slog.ErrorContext(r.Context(), "set transcode node URL", "component", "api", "error", err, "session", req.SessionID, "playback_session_id", req.SessionID)
+		replacementTransportID := req.SessionID
+		reconstructionTransportID := ""
+		atomicLegacyReplacement := videoCopy && isLegacyTransportSession(session)
+		if atomicLegacyReplacement {
+			replacementTransportID = newLegacyTransportID(req.SessionID)
+			reconstructionTransportID = replacementTransportID
 		}
-
 		nodeReq := transcodenode.TranscodeStartRequest{
-			SessionID:            req.SessionID,
-			InputPath:            file.FilePath,
-			SourceVideoCodec:     file.CodecVideo,
-			VideoBitstreamFilter: videoBitstreamFilter,
-			SeekSeconds:          alignedSeekSeconds(req.SeekSeconds, req.SegmentDuration, req.TargetCodecVideo),
-			StartSegmentNumber:   computeStartSegment(req.SeekSeconds, req.SegmentDuration),
-			TargetResolution:     req.TargetResolution,
-			TargetCodecVideo:     req.TargetCodecVideo,
-			TargetCodecAudio:     req.TargetCodecAudio,
-			TargetBitrateKbps:    req.TargetBitrateKbps,
-			SegmentDuration:      req.SegmentDuration,
-			HWAccel:              h.playbackConfig().HWAccel,
-			AudioTrackIndex:      session.AudioTrackIndex,
-			SubtitleTrackIndex:   req.SubtitleTrackIndex,
-			SubtitleBurnIn:       req.SubtitleBurnIn,
-			SubtitleCodec:        subtitleCodec,
-			TotalDuration:        float64(file.Duration),
+			SessionID:              replacementTransportID,
+			InputPath:              file.FilePath,
+			SourceVideoCodec:       file.CodecVideo,
+			VideoBitstreamFilter:   videoBitstreamFilter,
+			SeekSeconds:            transportSeekSeconds,
+			StreamOriginSeconds:    streamOriginSeconds,
+			CopySeekAnchorResolved: videoCopy,
+			StartSegmentNumber:     startSegmentNumber,
+			TargetResolution:       req.TargetResolution,
+			TargetCodecVideo:       req.TargetCodecVideo,
+			TargetCodecAudio:       req.TargetCodecAudio,
+			TargetBitrateKbps:      req.TargetBitrateKbps,
+			SegmentDuration:        req.SegmentDuration,
+			HWAccel:                playbackCfg.HWAccel,
+			AudioTrackIndex:        session.AudioTrackIndex,
+			SubtitleTrackIndex:     req.SubtitleTrackIndex,
+			SubtitleBurnIn:         req.SubtitleBurnIn,
+			SubtitleCodec:          subtitleCodec,
+			TotalDuration:          float64(file.Duration),
+			RequireReady:           atomicLegacyReplacement,
 		}
 
 		nodeResp, status, err := h.startRemotePlaybackTransport(context.Background(), tcNode.URL, nodeReq)
 		if err != nil {
+			if atomicLegacyReplacement {
+				h.tm.StopRemoteTranscode(replacementTransportID, tcNode.URL)
+			}
 			slog.ErrorContext(r.Context(), "remote transcode start failed", "component", "api", "error", err, "node", tcNode.URL, "session", req.SessionID, "playback_session_id", req.SessionID)
 			writeError(w, http.StatusBadGateway, "transcode_node_unavailable", "Transcode node is unavailable")
 			return
 		}
 		if status != http.StatusAccepted {
+			if atomicLegacyReplacement {
+				h.tm.StopRemoteTranscode(replacementTransportID, tcNode.URL)
+			}
 			slog.ErrorContext(r.Context(), "remote transcode start rejected", "component", "api", "status", status, "node", tcNode.URL)
 			writeError(w, http.StatusBadGateway, "transcode_start_failed", "Transcode node rejected the request")
 			return
 		}
-		effectiveHWAccel := strings.TrimSpace(nodeResp.HWAccel)
-		if effectiveHWAccel == "" {
-			effectiveHWAccel = strings.TrimSpace(nodeReq.HWAccel)
+		if atomicLegacyReplacement {
+			startState := transcodeStartState{
+				req:            req,
+				file:           file,
+				session:        session,
+				switchedFileID: switchedFileID,
+				hwAccel:        effectiveRemoteHWAccel(nodeResp, nodeReq),
+			}
+			if err := h.commitLegacyRemoteReplacement(
+				req.SessionID,
+				previousLocalTranscode,
+				previousTranscodeNodeURL,
+				previousTransportID,
+				tcNode.URL,
+				replacementTransportID,
+				func() error { return h.persistTranscodeStartState(r, startState) },
+			); err != nil {
+				h.tm.StopRemoteTranscode(replacementTransportID, tcNode.URL)
+				if errors.Is(err, playback.ErrSessionSuperseded) {
+					writeError(w, http.StatusConflict, "transcode_replaced", "A newer playback transport replaced this request")
+					return
+				}
+				slog.ErrorContext(r.Context(), "publish legacy transcode route", "component", "api", "error", err, "session", req.SessionID, "playback_session_id", req.SessionID)
+				writeError(w, http.StatusInternalServerError, "internal_error", "Failed to publish transcode session")
+				return
+			}
+			if !h.transcodeRouteMatches(req.SessionID, nil, tcNode.URL, replacementTransportID) {
+				writeError(w, http.StatusConflict, "transcode_replaced", "A newer playback transport replaced this request")
+				return
+			}
+			h.syncSessionsNow(r.Context(), "transcode_start")
+		} else {
+			if err := h.sessionMgr.SetTranscodeNodeURL(req.SessionID, tcNode.URL); err != nil {
+				slog.ErrorContext(r.Context(), "set transcode node URL", "component", "api", "error", err, "session", req.SessionID, "playback_session_id", req.SessionID)
+			}
+			if previousLocalTranscode != nil {
+				h.tm.CloseTranscodeSessionIf(req.SessionID, previousLocalTranscode, "")
+			}
+			if previousTranscodeNodeURL != "" &&
+				(previousTranscodeNodeURL != tcNode.URL || previousProcessID != nodeReq.SessionID) {
+				h.tm.StopRemoteTranscode(previousProcessID, previousTranscodeNodeURL)
+			}
 		}
+		effectiveHWAccel := effectiveRemoteHWAccel(nodeResp, nodeReq)
 
 		// The remote transcode's full recipe rides the proxy manifest token so the
 		// integrated server can re-bind and re-proxy the session after a restart
 		// (and a node could someday self-reconstruct from it). Node-side segment
 		// reconstruction is a follow-up (see spec multi-node section).
 		card := playback.NewRecipeCard(session.UserID, session.ProfileID, session.MediaFileID, tcNode.URL, playback.TranscodeOpts{
-			InputPath:            nodeReq.InputPath,
-			SessionID:            nodeReq.SessionID,
-			SourceVideoCodec:     nodeReq.SourceVideoCodec,
-			VideoBitstreamFilter: nodeReq.VideoBitstreamFilter,
-			SeekSeconds:          nodeReq.SeekSeconds,
-			StartSegmentNumber:   nodeReq.StartSegmentNumber,
-			TargetResolution:     nodeReq.TargetResolution,
-			TargetCodecVideo:     nodeReq.TargetCodecVideo,
-			TargetCodecAudio:     nodeReq.TargetCodecAudio,
-			TargetBitrateKbps:    nodeReq.TargetBitrateKbps,
-			SegmentDuration:      nodeReq.SegmentDuration,
-			HWAccel:              effectiveHWAccel,
-			AudioTrackIndex:      nodeReq.AudioTrackIndex,
-			SubtitleTrackIndex:   nodeReq.SubtitleTrackIndex,
-			SubtitleBurnIn:       nodeReq.SubtitleBurnIn,
-			SubtitleCodec:        nodeReq.SubtitleCodec,
-			TotalDuration:        nodeReq.TotalDuration,
+			InputPath:              nodeReq.InputPath,
+			SessionID:              req.SessionID,
+			TranscodeTransportID:   reconstructionTransportID,
+			SourceVideoCodec:       nodeReq.SourceVideoCodec,
+			VideoBitstreamFilter:   nodeReq.VideoBitstreamFilter,
+			SeekSeconds:            nodeReq.SeekSeconds,
+			StreamOriginSeconds:    nodeReq.StreamOriginSeconds,
+			CopySeekAnchorResolved: nodeReq.CopySeekAnchorResolved,
+			StartSegmentNumber:     nodeReq.StartSegmentNumber,
+			TargetResolution:       nodeReq.TargetResolution,
+			TargetCodecVideo:       nodeReq.TargetCodecVideo,
+			TargetCodecAudio:       nodeReq.TargetCodecAudio,
+			TargetBitrateKbps:      nodeReq.TargetBitrateKbps,
+			SegmentDuration:        nodeReq.SegmentDuration,
+			HWAccel:                effectiveHWAccel,
+			AudioTrackIndex:        nodeReq.AudioTrackIndex,
+			SubtitleTrackIndex:     nodeReq.SubtitleTrackIndex,
+			SubtitleBurnIn:         nodeReq.SubtitleBurnIn,
+			SubtitleCodec:          nodeReq.SubtitleCodec,
+			TotalDuration:          nodeReq.TotalDuration,
 		})
 		manifestURL := h.buildProxyManifestURL(card, plan.ProxyNode)
-		h.finalizeTranscodeStart(r, transcodeStartState{
-			req:            req,
-			file:           file,
-			session:        session,
-			switchedFileID: switchedFileID,
-			hwAccel:        effectiveHWAccel,
-		})
-		writeJSON(w, http.StatusAccepted, buildTranscodeStartResponse(req, file, switchedFileID, manifestURL))
+		if !atomicLegacyReplacement {
+			h.finalizeTranscodeStart(r, transcodeStartState{
+				req:            req,
+				file:           file,
+				session:        session,
+				switchedFileID: switchedFileID,
+				hwAccel:        effectiveHWAccel,
+			})
+		}
+		writeJSON(w, http.StatusAccepted, buildTranscodeStartResponse(req, file, switchedFileID, manifestURL, streamOriginSeconds))
 		return
 	}
 
@@ -2890,7 +3250,6 @@ func (h *PlaybackHandler) HandleStartTranscode(w http.ResponseWriter, r *http.Re
 	}
 	// Snapshot once so the directory, ffmpeg path, and hwaccel of this
 	// session stay consistent even if the config reloads mid-start.
-	playbackCfg := h.playbackConfig()
 	if err := os.MkdirAll(playbackCfg.TranscodeDir, 0o755); err != nil {
 		writeError(w, http.StatusInternalServerError, "internal_error", "Failed to prepare transcode directory")
 		return
@@ -2902,32 +3261,47 @@ func (h *PlaybackHandler) HandleStartTranscode(w http.ResponseWriter, r *http.Re
 	// any session a reconstruct rebuilt between the earlier close and here so the
 	// fresh ffmpeg is the sole writer.
 	unlock := h.tm.LockSessionLifecycle(req.SessionID)
+	currentSession, currentSessionErr := h.sessionMgr.GetSession(req.SessionID)
+	if currentSessionErr != nil {
+		unlock()
+		writeError(w, http.StatusInternalServerError, "internal_error", "Failed to verify playback transport")
+		return
+	}
+	if h.tm.GetTranscodeSession(req.SessionID) != previousLocalTranscode ||
+		currentSession.TranscodeNodeURL != previousTranscodeNodeURL ||
+		currentSession.TranscodeTransportID != previousTransportID {
+		unlock()
+		writeError(w, http.StatusConflict, "transcode_replaced", "A newer playback transport replaced this request")
+		return
+	}
 	h.tm.CloseTranscodeSession(req.SessionID, "")
 	transcodeSession, err := h.startLocalPlaybackTransport(r.Context(), playback.TranscodeOpts{
-		InputPath:            file.FilePath,
-		OutputDir:            filepath.Join(playbackCfg.TranscodeDir, req.SessionID),
-		SessionID:            req.SessionID,
-		SourceVideoCodec:     file.CodecVideo,
-		VideoBitstreamFilter: videoBitstreamFilter,
-		SeekSeconds:          alignedSeekSeconds(req.SeekSeconds, req.SegmentDuration, req.TargetCodecVideo),
-		StartSegmentNumber:   computeStartSegment(req.SeekSeconds, req.SegmentDuration),
-		TargetResolution:     req.TargetResolution,
-		TargetCodecVideo:     req.TargetCodecVideo,
-		TargetCodecAudio:     req.TargetCodecAudio,
-		TargetBitrateKbps:    req.TargetBitrateKbps,
-		SegmentDuration:      req.SegmentDuration,
-		FFmpegPath:           playbackCfg.FFmpegPath,
-		HWAccel:              playbackCfg.HWAccel,
-		HWDevice:             playbackCfg.HWDevice,
-		AudioTrackIndex:      session.AudioTrackIndex,
-		SubtitleTrackIndex:   req.SubtitleTrackIndex,
-		SubtitleBurnIn:       req.SubtitleBurnIn,
-		SubtitleCodec:        subtitleCodec,
-		TotalDuration:        float64(file.Duration),
-		FastStart:            true,
-		NodeType:             "integrated",
-		ExecutionMode:        "integrated",
-		FFmpegLogSink:        h.FFmpegLogSink,
+		InputPath:              file.FilePath,
+		OutputDir:              filepath.Join(playbackCfg.TranscodeDir, req.SessionID),
+		SessionID:              req.SessionID,
+		SourceVideoCodec:       file.CodecVideo,
+		VideoBitstreamFilter:   videoBitstreamFilter,
+		SeekSeconds:            transportSeekSeconds,
+		StreamOriginSeconds:    streamOriginSeconds,
+		CopySeekAnchorResolved: videoCopy,
+		StartSegmentNumber:     startSegmentNumber,
+		TargetResolution:       req.TargetResolution,
+		TargetCodecVideo:       req.TargetCodecVideo,
+		TargetCodecAudio:       req.TargetCodecAudio,
+		TargetBitrateKbps:      req.TargetBitrateKbps,
+		SegmentDuration:        req.SegmentDuration,
+		FFmpegPath:             playbackCfg.FFmpegPath,
+		HWAccel:                playbackCfg.HWAccel,
+		HWDevice:               playbackCfg.HWDevice,
+		AudioTrackIndex:        session.AudioTrackIndex,
+		SubtitleTrackIndex:     req.SubtitleTrackIndex,
+		SubtitleBurnIn:         req.SubtitleBurnIn,
+		SubtitleCodec:          subtitleCodec,
+		TotalDuration:          float64(file.Duration),
+		FastStart:              true,
+		NodeType:               "integrated",
+		ExecutionMode:          "integrated",
+		FFmpegLogSink:          h.FFmpegLogSink,
 	})
 	if err != nil {
 		unlock()
@@ -2936,7 +3310,40 @@ func (h *PlaybackHandler) HandleStartTranscode(w http.ResponseWriter, r *http.Re
 	}
 
 	h.tm.RegisterTranscodeSession(req.SessionID, transcodeSession)
+	if err := h.sessionMgr.SetTranscodeRoute(req.SessionID, "", ""); err != nil {
+		h.tm.CloseTranscodeSessionIf(req.SessionID, transcodeSession, "")
+		unlock()
+		slog.ErrorContext(r.Context(), "publish local transcode route", "component", "api", "error", err, "session", req.SessionID, "playback_session_id", req.SessionID)
+		writeError(w, http.StatusInternalServerError, "internal_error", "Failed to publish transcode session")
+		return
+	}
+	if err := h.persistTranscodeStartState(r, transcodeStartState{
+		req:            req,
+		file:           file,
+		session:        session,
+		switchedFileID: switchedFileID,
+		hwAccel:        transcodeSession.Opts().HWAccel,
+	}); err != nil {
+		h.tm.CloseTranscodeSessionIf(req.SessionID, transcodeSession, "")
+		_, _ = h.sessionMgr.SetTranscodeRouteIf(
+			req.SessionID,
+			"",
+			"",
+			previousTranscodeNodeURL,
+			previousTransportID,
+		)
+		unlock()
+		writeError(w, http.StatusInternalServerError, "internal_error", "Failed to publish transcode session")
+		return
+	}
 	unlock()
+	if previousTranscodeNodeURL != "" {
+		h.tm.StopRemoteTranscode(previousProcessID, previousTranscodeNodeURL)
+	}
+	if !h.transcodeRouteMatches(req.SessionID, transcodeSession, "", "") {
+		writeError(w, http.StatusConflict, "transcode_replaced", "A newer playback transport replaced this request")
+		return
+	}
 
 	// Re-arm the throttler and exit monitor after every Restart of this
 	// handler-created session, regardless of which code path triggers it
@@ -2960,24 +3367,18 @@ func (h *PlaybackHandler) HandleStartTranscode(w http.ResponseWriter, r *http.Re
 		fmt.Sprintf("/playback/transcode/%s/master.m3u8", req.SessionID),
 		h.signSessionToken(card),
 	)
-	h.finalizeTranscodeStart(r, transcodeStartState{
-		req:            req,
-		file:           file,
-		session:        session,
-		switchedFileID: switchedFileID,
-		hwAccel:        transcodeSession.Opts().HWAccel,
-	})
-	writeJSON(w, http.StatusAccepted, buildTranscodeStartResponse(req, file, switchedFileID, manifestURL))
+	h.syncSessionsNow(r.Context(), "transcode_start")
+	writeJSON(w, http.StatusAccepted, buildTranscodeStartResponse(req, file, switchedFileID, manifestURL, streamOriginSeconds))
 }
 
 // HandleGetTranscodeManifest handles GET /playback/transcode/{session_id}/master.m3u8.
 // Auth is optional — the session UUID serves as an access token (same pattern
 // as /stream/{session_id}). When auth context is present, ownership is verified.
 //
-// Known-duration sessions expose a synthetic full VOD manifest so the player
-// can seek immediately. Copy-mode seeks that would start mid-GOP are forced to
-// encoded HLS earlier in HandleStartTranscode; otherwise BuildPlaybackManifest
-// still uses the same synthetic VOD path when the session duration is known.
+// Known-duration encoded sessions expose a synthetic full VOD manifest so the
+// player can seek immediately. Copy-video sessions expose FFmpeg's real
+// keyframe-aligned manifest and use the resolved stream origin returned by
+// HandleStartTranscode.
 func (h *PlaybackHandler) HandleGetTranscodeManifest(w http.ResponseWriter, r *http.Request) {
 	sessionID := chi.URLParam(r, "session_id")
 	session, status, card := h.loadTranscodeServeSession(r, sessionID)

--- a/internal/api/handlers/playback_test.go
+++ b/internal/api/handlers/playback_test.go
@@ -56,11 +56,30 @@ type firstBlockingSessionManager struct {
 }
 
 func (m *firstBlockingSessionManager) UpdateStreamState(sessionID string, state playback.SessionStreamState) error {
+	return m.SessionManager.UpdateStreamState(sessionID, state)
+}
+
+func (m *firstBlockingSessionManager) ApplyReplacementIfRoute(
+	sessionID string,
+	expected playback.TranscodeRoute,
+	replacement playback.SessionReplacement,
+) (playback.SessionReplacementRollback, bool, error) {
 	if m.blocked.CompareAndSwap(false, true) {
 		close(m.entered)
 		<-m.release
 	}
-	return m.SessionManager.UpdateStreamState(sessionID, state)
+	return m.SessionManager.ApplyReplacementIfRoute(sessionID, expected, replacement)
+}
+
+func (m *firstBlockingSessionManager) ApplyReplacement(
+	sessionID string,
+	replacement playback.SessionReplacement,
+) (playback.SessionReplacementRollback, error) {
+	if m.blocked.CompareAndSwap(false, true) {
+		close(m.entered)
+		<-m.release
+	}
+	return m.SessionManager.ApplyReplacement(sessionID, replacement)
 }
 
 func (r testPlaybackFileResolver) GetByID(context.Context, int) (*models.MediaFile, error) {
@@ -149,11 +168,17 @@ func (failingSessionManager) EndTransport(string) error { return nil }
 func (failingSessionManager) SetEffectiveMediaFileID(string, int) error { return nil }
 
 func (failingSessionManager) SetTranscodeNodeURL(string, string) error { return nil }
-func (failingSessionManager) SetTranscodeRoute(string, string, string) error {
+func (failingSessionManager) SetTranscodeRoute(string, playback.TranscodeRoute) error {
 	return nil
 }
-func (failingSessionManager) SetTranscodeRouteIf(string, string, string, string, string) (bool, error) {
-	return true, nil
+func (failingSessionManager) ApplyReplacement(string, playback.SessionReplacement) (playback.SessionReplacementRollback, error) {
+	return playback.SessionReplacementRollback{}, nil
+}
+func (failingSessionManager) ApplyReplacementIfRoute(string, playback.TranscodeRoute, playback.SessionReplacement) (playback.SessionReplacementRollback, bool, error) {
+	return playback.SessionReplacementRollback{}, true, nil
+}
+func (failingSessionManager) RollbackReplacement(string, playback.SessionReplacementRollback) error {
+	return nil
 }
 
 func (failingSessionManager) SetWebSocket(string, bool) error { return nil }
@@ -205,8 +230,46 @@ func writePlaybackTestFFmpeg(t *testing.T) string {
 	t.Helper()
 
 	path := filepath.Join(t.TempDir(), "fake-ffmpeg.sh")
-	if err := os.WriteFile(path, []byte("#!/bin/sh\nsleep 30\n"), 0o755); err != nil {
+	script := "#!/bin/sh\n" +
+		"last=\"\"\n" +
+		"for arg in \"$@\"; do last=\"$arg\"; done\n" +
+		"case \"$last\" in\n" +
+		"  *.m3u8) out=\"$(dirname \"$last\")\"; mkdir -p \"$out\"; " +
+		"printf x > \"$out/init.mp4\"; printf x > \"$out/seg_0.m4s\"; " +
+		"printf x > \"$out/seg_1.m4s\"; printf x > \"$out/seg_2.m4s\"; " +
+		"printf '#EXTM3U\\n#EXT-X-VERSION:7\\n#EXT-X-TARGETDURATION:2\\n" +
+		"#EXT-X-MEDIA-SEQUENCE:0\\n#EXT-X-MAP:URI=\"init.mp4\"\\n" +
+		"#EXTINF:2.0,\\nseg_0.m4s\\n#EXTINF:2.0,\\nseg_1.m4s\\n" +
+		"#EXTINF:2.0,\\nseg_2.m4s\\n' > \"$last\" ;;\n" +
+		"esac\n" +
+		"sleep 30\n"
+	if err := os.WriteFile(path, []byte(script), 0o755); err != nil {
 		t.Fatalf("write fake ffmpeg: %v", err)
+	}
+	return path
+}
+
+func writePlaybackTestFFmpegFailingAfterFirstStart(t *testing.T) string {
+	t.Helper()
+
+	dir := t.TempDir()
+	path := filepath.Join(dir, "fake-ffmpeg.sh")
+	countPath := filepath.Join(dir, "started")
+	script := "#!/bin/sh\n" +
+		"if [ -e \"" + countPath + "\" ]; then echo 'intentional successor failure' >&2; exit 1; fi\n" +
+		": > \"" + countPath + "\"\n" +
+		"last=\"\"\n" +
+		"for arg in \"$@\"; do last=\"$arg\"; done\n" +
+		"out=\"$(dirname \"$last\")\"; mkdir -p \"$out\"\n" +
+		"printf x > \"$out/init.mp4\"; printf x > \"$out/seg_0.m4s\"; " +
+		"printf x > \"$out/seg_1.m4s\"; printf x > \"$out/seg_2.m4s\"\n" +
+		"printf '#EXTM3U\\n#EXT-X-VERSION:7\\n#EXT-X-TARGETDURATION:2\\n" +
+		"#EXT-X-MEDIA-SEQUENCE:0\\n#EXT-X-MAP:URI=\"init.mp4\"\\n" +
+		"#EXTINF:2.0,\\nseg_0.m4s\\n#EXTINF:2.0,\\nseg_1.m4s\\n" +
+		"#EXTINF:2.0,\\nseg_2.m4s\\n' > \"$last\"\n" +
+		"sleep 30\n"
+	if err := os.WriteFile(path, []byte(script), 0o755); err != nil {
+		t.Fatalf("write fail-after-first fake ffmpeg: %v", err)
 	}
 	return path
 }
@@ -1897,11 +1960,11 @@ func TestHandleChangeAudioTrack_LocalCopyRestartUsesFreshSeekAnchor(t *testing.T
 		t.Fatalf("start status = %d, body = %s", startRR.Code, startRR.Body.String())
 	}
 
-	transcodeSession := handler.tm.GetTranscodeSession(session.ID)
-	if transcodeSession == nil {
+	predecessor := handler.tm.GetTranscodeSession(session.ID)
+	if predecessor == nil {
 		t.Fatal("expected local copy-video session")
 	}
-	t.Cleanup(func() { _ = transcodeSession.Close() })
+	t.Cleanup(func() { handler.tm.CloseTranscodeSession(session.ID, "") })
 
 	changeReq := httptest.NewRequest(
 		http.MethodPatch,
@@ -1915,7 +1978,14 @@ func TestHandleChangeAudioTrack_LocalCopyRestartUsesFreshSeekAnchor(t *testing.T
 		t.Fatalf("change status = %d, body = %s", changeRR.Code, changeRR.Body.String())
 	}
 
-	opts := transcodeSession.Opts()
+	successor := handler.tm.GetTranscodeSession(session.ID)
+	if successor == nil || successor == predecessor {
+		t.Fatal("audio switch did not publish a prepared successor")
+	}
+	if predecessor.IsRunning() {
+		t.Fatal("audio switch predecessor is still running after commit")
+	}
+	opts := successor.Opts()
 	if opts.TargetCodecVideo != "copy" || opts.SeekSeconds != 100 ||
 		opts.StreamOriginSeconds != 96 || !opts.CopySeekAnchorResolved ||
 		opts.StartSegmentNumber != 48 || opts.AudioTrackIndex != 1 {
@@ -1938,6 +2008,83 @@ func TestHandleChangeAudioTrack_LocalCopyRestartUsesFreshSeekAnchor(t *testing.T
 		claims.StreamOriginSeconds != 96 || !claims.CopySeekAnchorResolved ||
 		claims.StartSegmentNumber != 48 || claims.AudioTrackIndex != 1 {
 		t.Fatalf("local copy reconstruction claims = %+v", claims)
+	}
+	if resp.PlayerStartSeconds == nil || *resp.PlayerStartSeconds != 4 ||
+		resp.StreamOriginSeconds == nil || *resp.StreamOriginSeconds != 96 ||
+		resp.TimelineOffsetSeconds == nil || *resp.TimelineOffsetSeconds != 96 ||
+		resp.CanSeekAnywhere == nil || *resp.CanSeekAnywhere {
+		t.Fatalf("local copy response timeline = %+v", resp)
+	}
+}
+
+func TestHandleChangeAudioTrack_LocalCopyFailurePreservesPredecessor(t *testing.T) {
+	sessionMgr := playback.NewSessionManager(0, 0)
+	file := &models.MediaFile{
+		ID:          42,
+		ContentID:   "movie-1",
+		FilePath:    writePlaybackTestMediaFile(t, "movie-local-copy-failure.mkv"),
+		Resolution:  "1080p",
+		CodecVideo:  "hevc",
+		CodecAudio:  "ac3",
+		Container:   "mkv",
+		Bitrate:     8000,
+		Duration:    3600,
+		AudioTracks: []models.AudioTrack{{Codec: "ac3", Default: true}, {Codec: "dts"}},
+	}
+	session, err := sessionMgr.StartSession(1, "profile-1", file.ID, playback.PlayRemux, true)
+	if err != nil {
+		t.Fatalf("StartSession: %v", err)
+	}
+
+	handler := NewPlaybackHandler(sessionMgr, testPlaybackFileResolver{file: file})
+	handler.ItemAccess = allowAllPlaybackItemAccess{}
+	handler.PlaybackConfig = playbackTestConfig(
+		writePlaybackTestFFmpegFailingAfterFirstStart(t),
+		t.TempDir(),
+	)
+	handler.copySeekAnchor = func(_ context.Context, _, _ string, requested float64, _ int) (float64, int, error) {
+		return requested - 4, int((requested - 4) / 2), nil
+	}
+
+	startReq := httptest.NewRequest(
+		http.MethodPost,
+		"/api/v1/playback/transcode/start",
+		strings.NewReader(`{"session_id":"`+session.ID+`","seek_seconds":18,"target_codec_video":"copy","target_codec_audio":"aac","segment_duration":2,"subtitle_track_index":-1}`),
+	).WithContext(newAuthorizedPlaybackContext())
+	startRR := httptest.NewRecorder()
+	handler.HandleStartTranscode(startRR, startReq)
+	if startRR.Code != http.StatusAccepted {
+		t.Fatalf("start status = %d, body = %s", startRR.Code, startRR.Body.String())
+	}
+	predecessor := handler.tm.GetTranscodeSession(session.ID)
+	if predecessor == nil || !predecessor.IsRunning() {
+		t.Fatal("expected running predecessor")
+	}
+	t.Cleanup(func() { handler.tm.CloseTranscodeSession(session.ID, "") })
+
+	changeReq := httptest.NewRequest(
+		http.MethodPatch,
+		"/api/v1/playback/"+session.ID+"/audio",
+		strings.NewReader(`{"audio_track_index":1,"position":100}`),
+	).WithContext(newAuthorizedPlaybackContext())
+	changeReq = withPlaybackRouteParam(changeReq, "session_id", session.ID)
+	changeRR := httptest.NewRecorder()
+	handler.HandleChangeAudioTrack(changeRR, changeReq)
+	if changeRR.Code != http.StatusInternalServerError {
+		t.Fatalf("change status = %d, body = %s", changeRR.Code, changeRR.Body.String())
+	}
+	if current := handler.tm.GetTranscodeSession(session.ID); current != predecessor {
+		t.Fatal("failed successor replaced the predecessor")
+	}
+	if !predecessor.IsRunning() {
+		t.Fatal("failed successor stopped the predecessor")
+	}
+	persisted, err := sessionMgr.GetSession(session.ID)
+	if err != nil {
+		t.Fatalf("GetSession: %v", err)
+	}
+	if persisted.AudioTrackIndex != 0 {
+		t.Fatalf("persisted audio track = %d, want predecessor track 0", persisted.AudioTrackIndex)
 	}
 }
 
@@ -2415,8 +2562,6 @@ func TestHandleStartTranscode_RemoteSuccessorCannotBeOverwrittenByStaleFinalizat
 	var remoteMu sync.Mutex
 	preparedBitrates := make(map[string]int)
 	var deletedIDs []string
-	oldDeleteStarted := make(chan struct{})
-	releaseOldDelete := make(chan struct{})
 	remote := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		switch {
 		case r.Method == http.MethodPost && r.URL.Path == "/transcode/start":
@@ -2438,10 +2583,6 @@ func TestHandleStartTranscode_RemoteSuccessorCannotBeOverwrittenByStaleFinalizat
 			remoteMu.Lock()
 			deletedIDs = append(deletedIDs, deletedID)
 			remoteMu.Unlock()
-			if deletedID == session.ID {
-				close(oldDeleteStarted)
-				<-releaseOldDelete
-			}
 			w.WriteHeader(http.StatusNoContent)
 		default:
 			t.Errorf("unexpected remote request %s %s", r.Method, r.URL.Path)
@@ -2508,13 +2649,11 @@ func TestHandleStartTranscode_RemoteSuccessorCannotBeOverwrittenByStaleFinalizat
 	}
 	close(sessionMgr.release)
 
-	<-oldDeleteStarted
-	if status := <-secondResult; status != http.StatusAccepted {
-		t.Fatalf("second status = %d, want %d", status, http.StatusAccepted)
+	if status := <-firstResult; status != http.StatusAccepted {
+		t.Fatalf("first status = %d, want %d", status, http.StatusAccepted)
 	}
-	close(releaseOldDelete)
-	if status := <-firstResult; status != http.StatusConflict {
-		t.Fatalf("superseded first status = %d, want %d", status, http.StatusConflict)
+	if status := <-secondResult; status != http.StatusConflict {
+		t.Fatalf("superseded second status = %d, want %d", status, http.StatusConflict)
 	}
 	persisted, err := sessionMgr.GetSession(session.ID)
 	if err != nil {
@@ -2524,14 +2663,81 @@ func TestHandleStartTranscode_RemoteSuccessorCannotBeOverwrittenByStaleFinalizat
 	winnerBitrate := preparedBitrates[persisted.TranscodeTransportID]
 	deletedSnapshot := append([]string(nil), deletedIDs...)
 	remoteMu.Unlock()
-	if winnerBitrate != 2222 {
-		t.Fatalf("published transport bitrate = %d, want second successor bitrate 2222", winnerBitrate)
+	if winnerBitrate != 1111 {
+		t.Fatalf("published transport bitrate = %d, want committed successor bitrate 1111", winnerBitrate)
 	}
 	if persisted.TargetBitrateKbps != winnerBitrate {
 		t.Fatalf("persisted bitrate = %d, want route winner bitrate %d", persisted.TargetBitrateKbps, winnerBitrate)
 	}
 	if len(deletedSnapshot) != 2 {
 		t.Fatalf("deleted transports = %v, want predecessor and first successor", deletedSnapshot)
+	}
+}
+
+func TestHandleStartTranscode_ConcurrentLocalEncodedStartsRemainLastWriterWins(t *testing.T) {
+	baseSessionMgr := playback.NewSessionManager(0, 0)
+	sessionMgr := &firstBlockingSessionManager{
+		SessionManager: baseSessionMgr,
+		entered:        make(chan struct{}),
+		release:        make(chan struct{}),
+	}
+	file := &models.MediaFile{
+		ID:          42,
+		ContentID:   "movie-1",
+		FilePath:    writePlaybackTestMediaFile(t, "movie-local-encoded-overlap.mkv"),
+		Resolution:  "2160p",
+		CodecVideo:  "hevc",
+		CodecAudio:  "ac3",
+		Container:   "mkv",
+		Bitrate:     25000,
+		Duration:    3600,
+		AudioTracks: []models.AudioTrack{{Codec: "ac3", Default: true}},
+	}
+	session, err := sessionMgr.StartSession(1, "profile-1", file.ID, playback.PlayTranscode, true)
+	if err != nil {
+		t.Fatalf("StartSession: %v", err)
+	}
+
+	handler := NewPlaybackHandler(sessionMgr, testPlaybackFileResolver{file: file})
+	handler.ItemAccess = allowAllPlaybackItemAccess{}
+	handler.PlaybackConfig = playbackTestConfig(writePlaybackTestFFmpeg(t), t.TempDir())
+	t.Cleanup(func() { handler.tm.CloseTranscodeSession(session.ID, "") })
+
+	start := func(bitrate int) <-chan int {
+		result := make(chan int, 1)
+		go func() {
+			request := httptest.NewRequest(
+				http.MethodPost,
+				"/api/v1/playback/transcode/start",
+				strings.NewReader(fmt.Sprintf(
+					`{"session_id":%q,"target_resolution":"1080p","target_codec_video":"h264","target_codec_audio":"aac","target_bitrate_kbps":%d,"segment_duration":2,"subtitle_track_index":-1}`,
+					session.ID,
+					bitrate,
+				)),
+			).WithContext(newAuthorizedPlaybackContext())
+			response := httptest.NewRecorder()
+			handler.HandleStartTranscode(response, request)
+			result <- response.Code
+		}()
+		return result
+	}
+
+	firstResult := start(1111)
+	<-sessionMgr.entered
+	secondResult := start(2222)
+	close(sessionMgr.release)
+	if status := <-firstResult; status != http.StatusAccepted {
+		t.Fatalf("first status = %d, want %d", status, http.StatusAccepted)
+	}
+	if status := <-secondResult; status != http.StatusAccepted {
+		t.Fatalf("second status = %d, want %d", status, http.StatusAccepted)
+	}
+	persisted, err := sessionMgr.GetSession(session.ID)
+	if err != nil {
+		t.Fatalf("GetSession: %v", err)
+	}
+	if persisted.TargetBitrateKbps != 2222 {
+		t.Fatalf("persisted bitrate = %d, want last writer bitrate 2222", persisted.TargetBitrateKbps)
 	}
 }
 

--- a/internal/api/handlers/playback_test.go
+++ b/internal/api/handlers/playback_test.go
@@ -5,11 +5,17 @@ import (
 	"database/sql"
 	"encoding/json"
 	"errors"
+	"fmt"
+	"math"
 	"net/http"
 	"net/http/httptest"
+	"net/url"
 	"os"
 	"path/filepath"
+	"sort"
 	"strings"
+	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -40,6 +46,21 @@ func (p testUserStoreProvider) Close() error { return nil }
 
 type testPlaybackFileResolver struct {
 	file *models.MediaFile
+}
+
+type firstBlockingSessionManager struct {
+	*playback.SessionManager
+	blocked atomic.Bool
+	entered chan struct{}
+	release chan struct{}
+}
+
+func (m *firstBlockingSessionManager) UpdateStreamState(sessionID string, state playback.SessionStreamState) error {
+	if m.blocked.CompareAndSwap(false, true) {
+		close(m.entered)
+		<-m.release
+	}
+	return m.SessionManager.UpdateStreamState(sessionID, state)
 }
 
 func (r testPlaybackFileResolver) GetByID(context.Context, int) (*models.MediaFile, error) {
@@ -128,6 +149,12 @@ func (failingSessionManager) EndTransport(string) error { return nil }
 func (failingSessionManager) SetEffectiveMediaFileID(string, int) error { return nil }
 
 func (failingSessionManager) SetTranscodeNodeURL(string, string) error { return nil }
+func (failingSessionManager) SetTranscodeRoute(string, string, string) error {
+	return nil
+}
+func (failingSessionManager) SetTranscodeRouteIf(string, string, string, string, string) (bool, error) {
+	return true, nil
+}
 
 func (failingSessionManager) SetWebSocket(string, bool) error { return nil }
 
@@ -369,18 +396,19 @@ func TestBuildTranscodeStartResponse_UnifiedSeekAnywhere(t *testing.T) {
 		file,
 		nil,
 		"/playback/transcode/session-copy/master.m3u8",
+		16,
 	)
 	if copyResp.CanSeekAnywhere {
 		t.Fatal("copy-mode response should require explicit restart seeks")
 	}
-	if copyResp.PlayerStartSeconds != 0 {
-		t.Fatalf("copy-mode PlayerStartSeconds = %v, want 0", copyResp.PlayerStartSeconds)
+	if math.Abs(copyResp.PlayerStartSeconds-2.261) > 0.0001 {
+		t.Fatalf("copy-mode PlayerStartSeconds = %v, want 2.261", copyResp.PlayerStartSeconds)
 	}
-	if copyResp.StreamOriginSeconds != 18.261 {
-		t.Fatalf("copy-mode StreamOriginSeconds = %v, want 18.261", copyResp.StreamOriginSeconds)
+	if copyResp.StreamOriginSeconds != 16 {
+		t.Fatalf("copy-mode StreamOriginSeconds = %v, want 16", copyResp.StreamOriginSeconds)
 	}
-	if copyResp.TimelineOffsetSeconds != 18.261 {
-		t.Fatalf("copy-mode TimelineOffsetSeconds = %v, want 18.261", copyResp.TimelineOffsetSeconds)
+	if copyResp.TimelineOffsetSeconds != 16 {
+		t.Fatalf("copy-mode TimelineOffsetSeconds = %v, want 16", copyResp.TimelineOffsetSeconds)
 	}
 
 	encodedResp := buildTranscodeStartResponse(
@@ -392,6 +420,7 @@ func TestBuildTranscodeStartResponse_UnifiedSeekAnywhere(t *testing.T) {
 		file,
 		nil,
 		"/playback/transcode/session-encoded/master.m3u8",
+		0,
 	)
 	if !encodedResp.CanSeekAnywhere {
 		t.Fatal("encoded response should advertise seek-anywhere")
@@ -1320,22 +1349,27 @@ func TestHandleChangeAudioTrack_RemoteTranscodeRestartsNodeAndMintsFullRecipe(t 
 
 	var remoteStartRequests int
 	var remoteStartReq transcodenode.TranscodeStartRequest
+	var remoteDeletes []string
 	remote := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if r.Method != http.MethodPost || r.URL.Path != "/transcode/start" {
+		switch {
+		case r.Method == http.MethodPost && r.URL.Path == "/transcode/start":
+			remoteStartRequests++
+			if err := json.NewDecoder(r.Body).Decode(&remoteStartReq); err != nil {
+				t.Errorf("decode remote start request: %v", err)
+			}
+			w.WriteHeader(http.StatusAccepted)
+			_ = json.NewEncoder(w).Encode(transcodenode.TranscodeStartResponse{
+				SessionID: remoteStartReq.SessionID,
+				Status:    "accepted",
+				HWAccel:   "none",
+			})
+		case r.Method == http.MethodDelete && strings.HasPrefix(r.URL.Path, "/transcode/"):
+			remoteDeletes = append(remoteDeletes, r.URL.Path)
+			w.WriteHeader(http.StatusNoContent)
+		default:
 			t.Errorf("unexpected remote request %s %s", r.Method, r.URL.Path)
 			http.Error(w, "unexpected", http.StatusBadRequest)
-			return
 		}
-		remoteStartRequests++
-		if err := json.NewDecoder(r.Body).Decode(&remoteStartReq); err != nil {
-			t.Errorf("decode remote start request: %v", err)
-		}
-		w.WriteHeader(http.StatusAccepted)
-		_ = json.NewEncoder(w).Encode(transcodenode.TranscodeStartResponse{
-			SessionID: remoteStartReq.SessionID,
-			Status:    "accepted",
-			HWAccel:   "none",
-		})
 	}))
 	defer remote.Close()
 
@@ -1380,7 +1414,13 @@ func TestHandleChangeAudioTrack_RemoteTranscodeRestartsNodeAndMintsFullRecipe(t 
 		t.Fatalf("remote AudioTrackIndex = %d, want 1", remoteStartReq.AudioTrackIndex)
 	}
 	if remoteStartReq.SessionID != sessionID {
-		t.Fatalf("remote SessionID = %q, want %q", remoteStartReq.SessionID, sessionID)
+		t.Fatalf("remote SessionID = %q, want existing encoded transport %q", remoteStartReq.SessionID, sessionID)
+	}
+	if remoteStartReq.RequireReady {
+		t.Fatal("encoded audio switch unexpectedly changed to legacy copy replacement lifecycle")
+	}
+	if len(remoteDeletes) != 0 {
+		t.Fatalf("remote DELETEs = %v, want node-managed same-ID replacement", remoteDeletes)
 	}
 	// Seek 121.5s with the node-default 2s segments => align to 120s / segment 60.
 	if remoteStartReq.StartSegmentNumber != 60 {
@@ -1442,6 +1482,248 @@ func TestHandleChangeAudioTrack_RemoteTranscodeRestartsNodeAndMintsFullRecipe(t 
 	}
 	if claims.TranscodeNode != remote.URL {
 		t.Fatalf("token TranscodeNode = %q, want %q", claims.TranscodeNode, remote.URL)
+	}
+	if claims.TranscodeTransportID != remoteStartReq.SessionID {
+		t.Fatalf("token TranscodeTransportID = %q, want %q", claims.TranscodeTransportID, remoteStartReq.SessionID)
+	}
+	updated, err := sessionMgr.GetSession(sessionID)
+	if err != nil {
+		t.Fatalf("GetSession: %v", err)
+	}
+	if updated.TranscodeNodeURL != remote.URL || updated.TranscodeTransportID != "" {
+		t.Fatalf("published transcode route = %q/%q", updated.TranscodeNodeURL, updated.TranscodeTransportID)
+	}
+}
+
+func TestHandleChangeAudioTrack_RemoteCopyRestartUsesFreshSeekAnchor(t *testing.T) {
+	sessionMgr := playback.NewSessionManager(0, 0)
+	file := &models.MediaFile{
+		ID:         42,
+		ContentID:  "movie-1",
+		FilePath:   writePlaybackTestMediaFile(t, "movie-copy.mkv"),
+		Resolution: "1080p",
+		CodecVideo: "hevc",
+		CodecAudio: "ac3",
+		Container:  "mkv",
+		Bitrate:    8000,
+		Duration:   3600,
+		AudioTracks: []models.AudioTrack{
+			{Codec: "ac3", Default: true},
+			{Codec: "dts"},
+		},
+	}
+
+	var remoteStartReq transcodenode.TranscodeStartRequest
+	var remoteDeletes []string
+	remote := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == http.MethodPost && r.URL.Path == "/transcode/start":
+			if err := json.NewDecoder(r.Body).Decode(&remoteStartReq); err != nil {
+				t.Errorf("decode remote start request: %v", err)
+			}
+			w.WriteHeader(http.StatusAccepted)
+			_ = json.NewEncoder(w).Encode(transcodenode.TranscodeStartResponse{
+				SessionID: remoteStartReq.SessionID,
+				Status:    "accepted",
+				HWAccel:   "none",
+			})
+		case r.Method == http.MethodDelete && strings.HasPrefix(r.URL.Path, "/transcode/"):
+			remoteDeletes = append(remoteDeletes, r.URL.Path)
+			w.WriteHeader(http.StatusNoContent)
+		default:
+			t.Errorf("unexpected remote request %s %s", r.Method, r.URL.Path)
+			http.Error(w, "unexpected", http.StatusBadRequest)
+		}
+	}))
+	defer remote.Close()
+
+	handler := NewPlaybackHandler(sessionMgr, testPlaybackFileResolver{file: file})
+	handler.ItemAccess = allowAllPlaybackItemAccess{}
+	handler.JWTSecret = "test-secret"
+	handler.copySeekAnchor = func(context.Context, string, string, float64, int) (float64, int, error) {
+		return 96, 48, nil
+	}
+	group := "rack-a"
+	proxies := nodepool.NewProxyPool()
+	proxies.SetNodes([]*nodepool.Node{{
+		ID: 1, Name: "proxy-1", Type: nodepool.NodeTypeProxy, URL: "http://proxy-1",
+		Enabled: true, Healthy: true, Group: &group,
+	}})
+	transcodes := nodepool.NewTranscodePool()
+	transcodes.SetNodes([]*nodepool.Node{{
+		ID: 2, Name: "transcode-1", Type: nodepool.NodeTypeTranscode, URL: remote.URL,
+		Enabled: true, Healthy: true, Group: &group,
+	}})
+	handler.NodePlanner = nodepool.NewPlanner(proxies, transcodes)
+
+	session, err := sessionMgr.StartSession(1, "profile-1", file.ID, playback.PlayRemux, true)
+	if err != nil {
+		t.Fatalf("StartSession: %v", err)
+	}
+	if err := sessionMgr.UpdateStreamState(session.ID, playback.SessionStreamState{
+		PlayMethod:       playback.PlayTranscode,
+		BasePlayMethod:   playback.PlayRemux,
+		AudioTrackIndex:  0,
+		TranscodeAudio:   true,
+		TargetVideoCodec: "copy",
+		TargetAudioCodec: "aac",
+		TranscodeHWAccel: "none",
+		SegmentDuration:  2,
+	}); err != nil {
+		t.Fatalf("UpdateStreamState: %v", err)
+	}
+	if err := sessionMgr.SetTranscodeNodeURL(session.ID, remote.URL); err != nil {
+		t.Fatalf("SetTranscodeNodeURL: %v", err)
+	}
+
+	changeReq := httptest.NewRequest(
+		http.MethodPatch,
+		"/api/v1/playback/"+session.ID+"/audio",
+		strings.NewReader(`{"audio_track_index":1,"position":100}`),
+	).WithContext(newAuthorizedPlaybackContext())
+	changeReq = withPlaybackRouteParam(changeReq, "session_id", session.ID)
+
+	rr := httptest.NewRecorder()
+	handler.HandleChangeAudioTrack(rr, changeReq)
+	if rr.Code != http.StatusOK {
+		t.Fatalf("change status = %d, body = %s", rr.Code, rr.Body.String())
+	}
+	if remoteStartReq.TargetCodecVideo != "copy" || remoteStartReq.SeekSeconds != 100 ||
+		remoteStartReq.StreamOriginSeconds != 96 || !remoteStartReq.CopySeekAnchorResolved ||
+		remoteStartReq.StartSegmentNumber != 48 {
+		t.Fatalf("remote copy restart recipe = %+v", remoteStartReq)
+	}
+	if !strings.HasPrefix(remoteStartReq.SessionID, session.ID+legacyTransportMarker) {
+		t.Fatalf("remote SessionID = %q, want legacy replacement for %q", remoteStartReq.SessionID, session.ID)
+	}
+	if !remoteStartReq.RequireReady {
+		t.Fatal("remote copy replacement did not require readiness before predecessor retirement")
+	}
+	if len(remoteDeletes) != 1 || remoteDeletes[0] != "/transcode/"+session.ID {
+		t.Fatalf("remote DELETEs = %v, want predecessor %q", remoteDeletes, session.ID)
+	}
+
+	var resp changeAudioResponse
+	if err := json.NewDecoder(rr.Body).Decode(&resp); err != nil {
+		t.Fatalf("decode change response: %v", err)
+	}
+	token := strings.TrimSuffix(strings.TrimPrefix(resp.StreamURL, "http://proxy-1/stream/transcode/"), "/master.m3u8")
+	claims, err := streamtoken.Verify(token, handler.JWTSecret)
+	if err != nil {
+		t.Fatalf("verify stream token: %v", err)
+	}
+	if claims.TargetCodec != "copy" || claims.SeekSeconds != 100 ||
+		claims.StreamOriginSeconds != 96 || !claims.CopySeekAnchorResolved ||
+		claims.StartSegmentNumber != 48 {
+		t.Fatalf("remote copy reconstruction claims = %+v", claims)
+	}
+	if claims.TranscodeTransportID != remoteStartReq.SessionID {
+		t.Fatalf("token TranscodeTransportID = %q, want %q", claims.TranscodeTransportID, remoteStartReq.SessionID)
+	}
+}
+
+func TestHandleChangeAudioTrack_RemoteCopyRejectionPreservesPredecessorState(t *testing.T) {
+	sessionMgr := playback.NewSessionManager(0, 0)
+	file := &models.MediaFile{
+		ID:          42,
+		ContentID:   "movie-1",
+		FilePath:    writePlaybackTestMediaFile(t, "movie-copy-rejected.mkv"),
+		Resolution:  "1080p",
+		CodecVideo:  "hevc",
+		CodecAudio:  "ac3",
+		Container:   "mkv",
+		Bitrate:     8000,
+		Duration:    3600,
+		AudioTracks: []models.AudioTrack{{Codec: "ac3", Default: true}, {Codec: "dts"}},
+	}
+
+	var replacementID string
+	var deletedIDs []string
+	remote := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == http.MethodPost && r.URL.Path == "/transcode/start":
+			var startReq transcodenode.TranscodeStartRequest
+			if err := json.NewDecoder(r.Body).Decode(&startReq); err != nil {
+				t.Errorf("decode remote start request: %v", err)
+			}
+			replacementID = startReq.SessionID
+			http.Error(w, "rejected", http.StatusInternalServerError)
+		case r.Method == http.MethodDelete && strings.HasPrefix(r.URL.Path, "/transcode/"):
+			deletedIDs = append(deletedIDs, strings.TrimPrefix(r.URL.Path, "/transcode/"))
+			w.WriteHeader(http.StatusNoContent)
+		default:
+			t.Errorf("unexpected remote request %s %s", r.Method, r.URL.Path)
+			http.Error(w, "unexpected", http.StatusBadRequest)
+		}
+	}))
+	defer remote.Close()
+
+	session, err := sessionMgr.StartSession(1, "profile-1", file.ID, playback.PlayRemux, true)
+	if err != nil {
+		t.Fatalf("StartSession: %v", err)
+	}
+	if err := sessionMgr.UpdateStreamState(session.ID, playback.SessionStreamState{
+		PlayMethod:       playback.PlayTranscode,
+		BasePlayMethod:   playback.PlayRemux,
+		AudioTrackIndex:  0,
+		TranscodeAudio:   true,
+		TargetVideoCodec: "copy",
+		TargetAudioCodec: "aac",
+		TranscodeHWAccel: "none",
+		SegmentDuration:  2,
+	}); err != nil {
+		t.Fatalf("UpdateStreamState: %v", err)
+	}
+	if err := sessionMgr.SetTranscodeNodeURL(session.ID, remote.URL); err != nil {
+		t.Fatalf("SetTranscodeNodeURL: %v", err)
+	}
+
+	handler := NewPlaybackHandler(sessionMgr, testPlaybackFileResolver{file: file})
+	handler.ItemAccess = allowAllPlaybackItemAccess{}
+	handler.JWTSecret = "test-secret"
+	handler.copySeekAnchor = func(context.Context, string, string, float64, int) (float64, int, error) {
+		return 96, 48, nil
+	}
+	group := "rack-a"
+	proxies := nodepool.NewProxyPool()
+	proxies.SetNodes([]*nodepool.Node{{
+		ID: 1, Name: "proxy-1", Type: nodepool.NodeTypeProxy, URL: "http://proxy-1",
+		Enabled: true, Healthy: true, Group: &group,
+	}})
+	transcodes := nodepool.NewTranscodePool()
+	transcodes.SetNodes([]*nodepool.Node{{
+		ID: 2, Name: "transcode-1", Type: nodepool.NodeTypeTranscode, URL: remote.URL,
+		Enabled: true, Healthy: true, Group: &group,
+	}})
+	handler.NodePlanner = nodepool.NewPlanner(proxies, transcodes)
+
+	request := httptest.NewRequest(
+		http.MethodPatch,
+		"/api/v1/playback/"+session.ID+"/audio",
+		strings.NewReader(`{"audio_track_index":1,"position":100}`),
+	).WithContext(newAuthorizedPlaybackContext())
+	request = withPlaybackRouteParam(request, "session_id", session.ID)
+	response := httptest.NewRecorder()
+	handler.HandleChangeAudioTrack(response, request)
+	if response.Code != http.StatusBadGateway {
+		t.Fatalf("status = %d, want %d, body = %s", response.Code, http.StatusBadGateway, response.Body.String())
+	}
+	if !strings.HasPrefix(replacementID, session.ID+legacyTransportMarker) {
+		t.Fatalf("replacement ID = %q, want distinct legacy transport for %q", replacementID, session.ID)
+	}
+	if len(deletedIDs) != 1 || deletedIDs[0] != replacementID {
+		t.Fatalf("deleted transports = %v, want only rejected replacement %q", deletedIDs, replacementID)
+	}
+	persisted, err := sessionMgr.GetSession(session.ID)
+	if err != nil {
+		t.Fatalf("GetSession: %v", err)
+	}
+	if persisted.TranscodeNodeURL != remote.URL || persisted.TranscodeTransportID != "" {
+		t.Fatalf("predecessor route changed after rejection: %q/%q", persisted.TranscodeNodeURL, persisted.TranscodeTransportID)
+	}
+	if persisted.AudioTrackIndex != 0 || persisted.BasePlayMethod != playback.PlayRemux ||
+		persisted.TargetVideoCodec != "copy" || persisted.TargetAudioCodec != "aac" {
+		t.Fatalf("predecessor state changed after rejection: %+v", persisted)
 	}
 }
 
@@ -1570,22 +1852,705 @@ func TestHandleStartTranscode_LocalPathPropagatesSelectedAudioTrack(t *testing.T
 	}
 }
 
-func TestHandleStartTranscode_MPEG2SeekedCopyRemainsCopyVideo(t *testing.T) {
+func TestHandleChangeAudioTrack_LocalCopyRestartUsesFreshSeekAnchor(t *testing.T) {
 	sessionMgr := playback.NewSessionManager(0, 0)
-	filePath := writePlaybackTestMediaFile(t, "movie-mpeg2.mkv")
 	file := &models.MediaFile{
-		ID:         42,
-		ContentID:  "movie-1",
-		FilePath:   filePath,
-		Resolution: "1080p",
-		CodecVideo: "mpeg2video",
-		CodecAudio: "dts",
-		Container:  "mkv",
-		Bitrate:    25000,
-		Duration:   3600,
-		AudioTracks: []models.AudioTrack{
-			{Codec: "dts", Default: true},
-		},
+		ID:          42,
+		ContentID:   "movie-1",
+		FilePath:    writePlaybackTestMediaFile(t, "movie-local-copy.mkv"),
+		Resolution:  "1080p",
+		CodecVideo:  "hevc",
+		CodecAudio:  "ac3",
+		Container:   "mkv",
+		Bitrate:     8000,
+		Duration:    3600,
+		AudioTracks: []models.AudioTrack{{Codec: "ac3", Default: true}, {Codec: "dts"}},
+	}
+	session, err := sessionMgr.StartSession(1, "profile-1", file.ID, playback.PlayRemux, true)
+	if err != nil {
+		t.Fatalf("StartSession: %v", err)
+	}
+
+	handler := NewPlaybackHandler(sessionMgr, testPlaybackFileResolver{file: file})
+	handler.ItemAccess = allowAllPlaybackItemAccess{}
+	handler.JWTSecret = "test-secret"
+	handler.PlaybackConfig = playbackTestConfig(writePlaybackTestFFmpeg(t), t.TempDir())
+	handler.copySeekAnchor = func(_ context.Context, _, _ string, requested float64, _ int) (float64, int, error) {
+		switch requested {
+		case 18:
+			return 16, 8, nil
+		case 100:
+			return 96, 48, nil
+		default:
+			return 0, 0, fmt.Errorf("unexpected seek %v", requested)
+		}
+	}
+
+	startReq := httptest.NewRequest(
+		http.MethodPost,
+		"/api/v1/playback/transcode/start",
+		strings.NewReader(`{"session_id":"`+session.ID+`","seek_seconds":18,"target_codec_video":"copy","target_codec_audio":"aac","segment_duration":2,"subtitle_track_index":-1}`),
+	).WithContext(newAuthorizedPlaybackContext())
+	startRR := httptest.NewRecorder()
+	handler.HandleStartTranscode(startRR, startReq)
+	if startRR.Code != http.StatusAccepted {
+		t.Fatalf("start status = %d, body = %s", startRR.Code, startRR.Body.String())
+	}
+
+	transcodeSession := handler.tm.GetTranscodeSession(session.ID)
+	if transcodeSession == nil {
+		t.Fatal("expected local copy-video session")
+	}
+	t.Cleanup(func() { _ = transcodeSession.Close() })
+
+	changeReq := httptest.NewRequest(
+		http.MethodPatch,
+		"/api/v1/playback/"+session.ID+"/audio",
+		strings.NewReader(`{"audio_track_index":1,"position":100}`),
+	).WithContext(newAuthorizedPlaybackContext())
+	changeReq = withPlaybackRouteParam(changeReq, "session_id", session.ID)
+	changeRR := httptest.NewRecorder()
+	handler.HandleChangeAudioTrack(changeRR, changeReq)
+	if changeRR.Code != http.StatusOK {
+		t.Fatalf("change status = %d, body = %s", changeRR.Code, changeRR.Body.String())
+	}
+
+	opts := transcodeSession.Opts()
+	if opts.TargetCodecVideo != "copy" || opts.SeekSeconds != 100 ||
+		opts.StreamOriginSeconds != 96 || !opts.CopySeekAnchorResolved ||
+		opts.StartSegmentNumber != 48 || opts.AudioTrackIndex != 1 {
+		t.Fatalf("local copy restart opts = %+v", opts)
+	}
+
+	var resp changeAudioResponse
+	if err := json.NewDecoder(changeRR.Body).Decode(&resp); err != nil {
+		t.Fatalf("decode change response: %v", err)
+	}
+	manifestURL, err := url.Parse(resp.StreamURL)
+	if err != nil {
+		t.Fatalf("parse stream URL: %v", err)
+	}
+	claims, err := streamtoken.Verify(manifestURL.Query().Get(streamTokenParam), handler.JWTSecret)
+	if err != nil {
+		t.Fatalf("verify stream token: %v", err)
+	}
+	if claims.TargetCodec != "copy" || claims.SeekSeconds != 100 ||
+		claims.StreamOriginSeconds != 96 || !claims.CopySeekAnchorResolved ||
+		claims.StartSegmentNumber != 48 || claims.AudioTrackIndex != 1 {
+		t.Fatalf("local copy reconstruction claims = %+v", claims)
+	}
+}
+
+func TestHandleStartTranscode_SeekedCopyRemainsCopyVideo(t *testing.T) {
+	for _, tc := range []struct {
+		name       string
+		videoCodec string
+	}{
+		{name: "h264", videoCodec: "h264"},
+		{name: "hevc", videoCodec: "hevc"},
+		{name: "mpeg2", videoCodec: "mpeg2video"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			sessionMgr := playback.NewSessionManager(0, 0)
+			file := &models.MediaFile{
+				ID:          42,
+				ContentID:   "movie-1",
+				FilePath:    writePlaybackTestMediaFile(t, "movie-"+tc.name+".mkv"),
+				Resolution:  "1080p",
+				CodecVideo:  tc.videoCodec,
+				CodecAudio:  "dts",
+				Container:   "mkv",
+				Bitrate:     25000,
+				Duration:    3600,
+				AudioTracks: []models.AudioTrack{{Codec: "dts", Default: true}},
+			}
+			session, err := sessionMgr.StartSession(1, "profile-1", file.ID, playback.PlayRemux, true)
+			if err != nil {
+				t.Fatalf("StartSession: %v", err)
+			}
+
+			handler := NewPlaybackHandler(sessionMgr, testPlaybackFileResolver{file: file})
+			handler.ItemAccess = allowAllPlaybackItemAccess{}
+			handler.PlaybackConfig = playbackTestConfig(writePlaybackTestFFmpeg(t), t.TempDir())
+			handler.copySeekAnchor = func(context.Context, string, string, float64, int) (float64, int, error) {
+				return 16, 8, nil
+			}
+
+			transcodeReq := httptest.NewRequest(
+				http.MethodPost,
+				"/api/v1/playback/transcode/start",
+				strings.NewReader(`{"session_id":"`+session.ID+`","seek_seconds":18.261,"target_resolution":"","target_codec_video":"copy","target_codec_audio":"aac","target_bitrate_kbps":0,"segment_duration":2,"subtitle_track_index":-1,"subtitle_burn_in":false}`),
+			).WithContext(newAuthorizedPlaybackContext())
+
+			transcodeRR := httptest.NewRecorder()
+			handler.HandleStartTranscode(transcodeRR, transcodeReq)
+			if transcodeRR.Code != http.StatusAccepted {
+				t.Fatalf("transcode status = %d, body = %s", transcodeRR.Code, transcodeRR.Body.String())
+			}
+
+			var response transcodeStartResponse
+			if err := json.NewDecoder(transcodeRR.Body).Decode(&response); err != nil {
+				t.Fatalf("decode transcode response: %v", err)
+			}
+			if math.Abs(response.PlayerStartSeconds-2.261) > 0.0001 || response.StreamOriginSeconds != 16 ||
+				response.TimelineOffsetSeconds != 16 || response.CanSeekAnywhere {
+				t.Fatalf("copy response timeline = %+v", response)
+			}
+
+			transcodeSession := handler.tm.GetTranscodeSession(session.ID)
+			if transcodeSession == nil {
+				t.Fatal("expected local transcode session")
+			}
+			t.Cleanup(func() { _ = transcodeSession.Close() })
+			opts := transcodeSession.Opts()
+			if opts.TargetCodecVideo != "copy" || opts.SourceVideoCodec != tc.videoCodec || opts.TargetCodecAudio != "aac" {
+				t.Fatalf("copy recipe = video %q source %q audio %q", opts.TargetCodecVideo, opts.SourceVideoCodec, opts.TargetCodecAudio)
+			}
+			if opts.SeekSeconds != 18.261 || opts.StreamOriginSeconds != 16 || !opts.CopySeekAnchorResolved || opts.StartSegmentNumber != 8 || opts.TargetResolution != "" {
+				t.Fatalf("copy seek recipe = seek %v origin %v segment %d resolution %q", opts.SeekSeconds, opts.StreamOriginSeconds, opts.StartSegmentNumber, opts.TargetResolution)
+			}
+
+			persisted, err := sessionMgr.GetSession(session.ID)
+			if err != nil {
+				t.Fatalf("GetSession: %v", err)
+			}
+			if persisted.TargetVideoCodec != "copy" || semanticPlayMethod(persisted) != playback.PlayRemux {
+				t.Fatalf("persisted recipe = target %q semantic method %q", persisted.TargetVideoCodec, semanticPlayMethod(persisted))
+			}
+		})
+	}
+}
+
+func TestHandleStartTranscode_CopyAnchorFailureKeepsActiveTransport(t *testing.T) {
+	sessionMgr := playback.NewSessionManager(0, 0)
+	file := &models.MediaFile{
+		ID:          42,
+		ContentID:   "movie-1",
+		FilePath:    writePlaybackTestMediaFile(t, "movie-anchor-failure.mkv"),
+		Resolution:  "1080p",
+		CodecVideo:  "h264",
+		CodecAudio:  "aac",
+		Container:   "mkv",
+		Bitrate:     8000,
+		Duration:    3600,
+		AudioTracks: []models.AudioTrack{{Codec: "aac", Default: true}},
+	}
+	session, err := sessionMgr.StartSession(1, "profile-1", file.ID, playback.PlayTranscode, true)
+	if err != nil {
+		t.Fatalf("StartSession: %v", err)
+	}
+
+	handler := NewPlaybackHandler(sessionMgr, testPlaybackFileResolver{file: file})
+	handler.ItemAccess = allowAllPlaybackItemAccess{}
+	handler.PlaybackConfig = playbackTestConfig(writePlaybackTestFFmpeg(t), t.TempDir())
+
+	initialReq := httptest.NewRequest(
+		http.MethodPost,
+		"/api/v1/playback/transcode/start",
+		strings.NewReader(`{"session_id":"`+session.ID+`","seek_seconds":0,"target_resolution":"720p","target_codec_video":"h264","target_codec_audio":"aac","target_bitrate_kbps":2000,"segment_duration":2,"subtitle_track_index":-1}`),
+	).WithContext(newAuthorizedPlaybackContext())
+	initialRR := httptest.NewRecorder()
+	handler.HandleStartTranscode(initialRR, initialReq)
+	if initialRR.Code != http.StatusAccepted {
+		t.Fatalf("initial start status = %d, body = %s", initialRR.Code, initialRR.Body.String())
+	}
+	active := handler.tm.GetTranscodeSession(session.ID)
+	if active == nil || !active.IsRunning() {
+		t.Fatal("expected initial transcode to be running")
+	}
+	t.Cleanup(func() { _ = active.Close() })
+
+	handler.copySeekAnchor = func(context.Context, string, string, float64, int) (float64, int, error) {
+		return 0, 0, errors.New("probe failed")
+	}
+	replacementReq := httptest.NewRequest(
+		http.MethodPost,
+		"/api/v1/playback/transcode/start",
+		strings.NewReader(`{"session_id":"`+session.ID+`","seek_seconds":100,"target_codec_video":"copy","target_codec_audio":"aac","segment_duration":2,"subtitle_track_index":-1}`),
+	).WithContext(newAuthorizedPlaybackContext())
+	replacementRR := httptest.NewRecorder()
+	handler.HandleStartTranscode(replacementRR, replacementReq)
+	if replacementRR.Code != http.StatusInternalServerError {
+		t.Fatalf("replacement status = %d, body = %s", replacementRR.Code, replacementRR.Body.String())
+	}
+	if got := handler.tm.GetTranscodeSession(session.ID); got != active {
+		t.Fatalf("active transcode was replaced after failed preflight: got %p, want %p", got, active)
+	}
+	if !active.IsRunning() {
+		t.Fatal("active transcode was stopped before copy seek anchor preflight completed")
+	}
+}
+
+func TestHandleStartTranscode_SeekedCopyPreservedOnRemoteNode(t *testing.T) {
+	sessionMgr := playback.NewSessionManager(0, 0)
+	file := &models.MediaFile{
+		ID:          42,
+		ContentID:   "movie-1",
+		FilePath:    writePlaybackTestMediaFile(t, "movie-remote.mkv"),
+		Resolution:  "1080p",
+		CodecVideo:  "h264",
+		CodecAudio:  "ac3",
+		Container:   "mkv",
+		Bitrate:     8000,
+		Duration:    3600,
+		AudioTracks: []models.AudioTrack{{Codec: "ac3", Default: true}},
+	}
+	session, err := sessionMgr.StartSession(1, "profile-1", file.ID, playback.PlayRemux, true)
+	if err != nil {
+		t.Fatalf("StartSession: %v", err)
+	}
+
+	var remoteStartReq transcodenode.TranscodeStartRequest
+	remote := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost || r.URL.Path != "/transcode/start" {
+			t.Errorf("unexpected remote request %s %s", r.Method, r.URL.Path)
+			http.Error(w, "unexpected", http.StatusBadRequest)
+			return
+		}
+		if err := json.NewDecoder(r.Body).Decode(&remoteStartReq); err != nil {
+			t.Errorf("decode remote start request: %v", err)
+		}
+		w.WriteHeader(http.StatusAccepted)
+		_ = json.NewEncoder(w).Encode(transcodenode.TranscodeStartResponse{
+			SessionID: remoteStartReq.SessionID,
+			Status:    "accepted",
+			HWAccel:   "none",
+		})
+	}))
+	defer remote.Close()
+
+	handler := NewPlaybackHandler(sessionMgr, testPlaybackFileResolver{file: file})
+	handler.ItemAccess = allowAllPlaybackItemAccess{}
+	handler.JWTSecret = "test-secret"
+	handler.PlaybackConfig = playbackTestConfig(writePlaybackTestFFmpeg(t), t.TempDir())
+	handler.copySeekAnchor = func(context.Context, string, string, float64, int) (float64, int, error) {
+		return 16, 8, nil
+	}
+	pool := nodepool.NewTranscodePool()
+	pool.SetNodes([]*nodepool.Node{{
+		Name: "transcode-1", Type: nodepool.NodeTypeTranscode, URL: remote.URL,
+		Enabled: true, Healthy: true,
+	}})
+	handler.NodePlanner = nodepool.NewPlanner(nodepool.NewProxyPool(), pool)
+
+	transcodeReq := httptest.NewRequest(
+		http.MethodPost,
+		"/api/v1/playback/transcode/start",
+		strings.NewReader(`{"session_id":"`+session.ID+`","seek_seconds":18.261,"target_resolution":"","target_codec_video":"copy","target_codec_audio":"aac","target_bitrate_kbps":0,"segment_duration":2,"subtitle_track_index":-1,"subtitle_burn_in":false}`),
+	).WithContext(newAuthorizedPlaybackContext())
+	transcodeRR := httptest.NewRecorder()
+	handler.HandleStartTranscode(transcodeRR, transcodeReq)
+	if transcodeRR.Code != http.StatusAccepted {
+		t.Fatalf("transcode status = %d, body = %s", transcodeRR.Code, transcodeRR.Body.String())
+	}
+	if remoteStartReq.TargetCodecVideo != "copy" || remoteStartReq.SeekSeconds != 18.261 ||
+		remoteStartReq.StreamOriginSeconds != 16 || !remoteStartReq.CopySeekAnchorResolved || remoteStartReq.StartSegmentNumber != 8 {
+		t.Fatalf("remote copy recipe = codec %q seek %v origin %v segment %d", remoteStartReq.TargetCodecVideo, remoteStartReq.SeekSeconds, remoteStartReq.StreamOriginSeconds, remoteStartReq.StartSegmentNumber)
+	}
+	if !strings.HasPrefix(remoteStartReq.SessionID, session.ID+legacyTransportMarker) {
+		t.Fatalf("remote SessionID = %q, want legacy transport for %q", remoteStartReq.SessionID, session.ID)
+	}
+	if !remoteStartReq.RequireReady {
+		t.Fatal("remote copy start did not require readiness before route publication")
+	}
+
+	var response transcodeStartResponse
+	if err := json.NewDecoder(transcodeRR.Body).Decode(&response); err != nil {
+		t.Fatalf("decode transcode response: %v", err)
+	}
+	if math.Abs(response.PlayerStartSeconds-2.261) > 0.0001 || response.StreamOriginSeconds != 16 ||
+		response.TimelineOffsetSeconds != 16 || response.CanSeekAnywhere {
+		t.Fatalf("remote copy response timeline = %+v", response)
+	}
+	manifestURL, err := url.Parse(response.ManifestURL)
+	if err != nil {
+		t.Fatalf("parse manifest URL: %v", err)
+	}
+	claims, err := streamtoken.Verify(manifestURL.Query().Get(streamTokenParam), handler.JWTSecret)
+	if err != nil {
+		t.Fatalf("verify stream token: %v", err)
+	}
+	if claims.TargetCodec != "copy" || claims.SeekSeconds != 18.261 || claims.StreamOriginSeconds != 16 || !claims.CopySeekAnchorResolved ||
+		claims.StartSegmentNumber != 8 || claims.TranscodeNode != remote.URL {
+		t.Fatalf("remote reconstruction claims = codec %q seek %v origin %v segment %d node %q", claims.TargetCodec, claims.SeekSeconds, claims.StreamOriginSeconds, claims.StartSegmentNumber, claims.TranscodeNode)
+	}
+	if claims.TranscodeTransportID != remoteStartReq.SessionID {
+		t.Fatalf("remote reconstruction transport = %q, want %q", claims.TranscodeTransportID, remoteStartReq.SessionID)
+	}
+	persisted, err := sessionMgr.GetSession(session.ID)
+	if err != nil {
+		t.Fatalf("GetSession: %v", err)
+	}
+	if persisted.TranscodeNodeURL != remote.URL || persisted.TranscodeTransportID != remoteStartReq.SessionID {
+		t.Fatalf("published remote route = %q/%q", persisted.TranscodeNodeURL, persisted.TranscodeTransportID)
+	}
+}
+
+func TestHandleStartTranscode_RemoteRejectionPreservesLegacyPredecessor(t *testing.T) {
+	sessionMgr := playback.NewSessionManager(0, 0)
+	file := &models.MediaFile{
+		ID:          42,
+		ContentID:   "movie-1",
+		FilePath:    writePlaybackTestMediaFile(t, "movie-remote-reject.mkv"),
+		Resolution:  "1080p",
+		CodecVideo:  "h264",
+		CodecAudio:  "ac3",
+		Container:   "mkv",
+		Bitrate:     8000,
+		Duration:    3600,
+		AudioTracks: []models.AudioTrack{{Codec: "ac3", Default: true}},
+	}
+	session, err := sessionMgr.StartSession(1, "profile-1", file.ID, playback.PlayRemux, true)
+	if err != nil {
+		t.Fatalf("StartSession: %v", err)
+	}
+
+	var replacementID string
+	var deletedIDs []string
+	remote := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == http.MethodPost && r.URL.Path == "/transcode/start":
+			var startReq transcodenode.TranscodeStartRequest
+			if err := json.NewDecoder(r.Body).Decode(&startReq); err != nil {
+				t.Errorf("decode remote start request: %v", err)
+			}
+			replacementID = startReq.SessionID
+			http.Error(w, "rejected", http.StatusInternalServerError)
+		case r.Method == http.MethodDelete && strings.HasPrefix(r.URL.Path, "/transcode/"):
+			deletedIDs = append(deletedIDs, strings.TrimPrefix(r.URL.Path, "/transcode/"))
+			w.WriteHeader(http.StatusNoContent)
+		default:
+			t.Errorf("unexpected remote request %s %s", r.Method, r.URL.Path)
+			http.Error(w, "unexpected", http.StatusBadRequest)
+		}
+	}))
+	defer remote.Close()
+	if err := sessionMgr.SetTranscodeNodeURL(session.ID, remote.URL); err != nil {
+		t.Fatalf("SetTranscodeNodeURL: %v", err)
+	}
+
+	handler := NewPlaybackHandler(sessionMgr, testPlaybackFileResolver{file: file})
+	handler.ItemAccess = allowAllPlaybackItemAccess{}
+	handler.JWTSecret = "test-secret"
+	handler.PlaybackConfig = playbackTestConfig(writePlaybackTestFFmpeg(t), t.TempDir())
+	handler.copySeekAnchor = func(context.Context, string, string, float64, int) (float64, int, error) {
+		return 16, 8, nil
+	}
+	pool := nodepool.NewTranscodePool()
+	pool.SetNodes([]*nodepool.Node{{
+		Name: "transcode-1", Type: nodepool.NodeTypeTranscode, URL: remote.URL,
+		Enabled: true, Healthy: true,
+	}})
+	handler.NodePlanner = nodepool.NewPlanner(nodepool.NewProxyPool(), pool)
+
+	request := httptest.NewRequest(
+		http.MethodPost,
+		"/api/v1/playback/transcode/start",
+		strings.NewReader(`{"session_id":"`+session.ID+`","seek_seconds":18,"target_codec_video":"copy","target_codec_audio":"aac","segment_duration":2,"subtitle_track_index":-1}`),
+	).WithContext(newAuthorizedPlaybackContext())
+	response := httptest.NewRecorder()
+	handler.HandleStartTranscode(response, request)
+	if response.Code != http.StatusBadGateway {
+		t.Fatalf("status = %d, want %d, body = %s", response.Code, http.StatusBadGateway, response.Body.String())
+	}
+	if !strings.HasPrefix(replacementID, session.ID+legacyTransportMarker) {
+		t.Fatalf("replacement ID = %q, want distinct legacy transport for %q", replacementID, session.ID)
+	}
+	if len(deletedIDs) != 1 || deletedIDs[0] != replacementID {
+		t.Fatalf("deleted transports = %v, want only rejected replacement %q", deletedIDs, replacementID)
+	}
+	persisted, err := sessionMgr.GetSession(session.ID)
+	if err != nil {
+		t.Fatalf("GetSession: %v", err)
+	}
+	if persisted.TranscodeNodeURL != remote.URL || persisted.TranscodeTransportID != "" {
+		t.Fatalf("predecessor route changed after rejection: %q/%q", persisted.TranscodeNodeURL, persisted.TranscodeTransportID)
+	}
+}
+
+func TestHandleStartTranscode_ConcurrentRemoteReplacementsPublishOneWinner(t *testing.T) {
+	sessionMgr := playback.NewSessionManager(0, 0)
+	file := &models.MediaFile{
+		ID:          42,
+		ContentID:   "movie-1",
+		FilePath:    writePlaybackTestMediaFile(t, "movie-remote-concurrent.mkv"),
+		Resolution:  "1080p",
+		CodecVideo:  "h264",
+		CodecAudio:  "ac3",
+		Container:   "mkv",
+		Bitrate:     8000,
+		Duration:    3600,
+		AudioTracks: []models.AudioTrack{{Codec: "ac3", Default: true}},
+	}
+	session, err := sessionMgr.StartSession(1, "profile-1", file.ID, playback.PlayRemux, true)
+	if err != nil {
+		t.Fatalf("StartSession: %v", err)
+	}
+
+	var remoteMu sync.Mutex
+	var preparedIDs []string
+	var deletedIDs []string
+	prepared := make(chan struct{}, 2)
+	release := make(chan struct{})
+	remote := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == http.MethodPost && r.URL.Path == "/transcode/start":
+			var startReq transcodenode.TranscodeStartRequest
+			if err := json.NewDecoder(r.Body).Decode(&startReq); err != nil {
+				t.Errorf("decode remote start request: %v", err)
+			}
+			remoteMu.Lock()
+			preparedIDs = append(preparedIDs, startReq.SessionID)
+			remoteMu.Unlock()
+			prepared <- struct{}{}
+			<-release
+			w.WriteHeader(http.StatusAccepted)
+			_ = json.NewEncoder(w).Encode(transcodenode.TranscodeStartResponse{
+				SessionID: startReq.SessionID,
+				Status:    "accepted",
+				HWAccel:   "none",
+			})
+		case r.Method == http.MethodDelete && strings.HasPrefix(r.URL.Path, "/transcode/"):
+			remoteMu.Lock()
+			deletedIDs = append(deletedIDs, strings.TrimPrefix(r.URL.Path, "/transcode/"))
+			remoteMu.Unlock()
+			w.WriteHeader(http.StatusNoContent)
+		default:
+			t.Errorf("unexpected remote request %s %s", r.Method, r.URL.Path)
+			http.Error(w, "unexpected", http.StatusBadRequest)
+		}
+	}))
+	defer remote.Close()
+	if err := sessionMgr.SetTranscodeNodeURL(session.ID, remote.URL); err != nil {
+		t.Fatalf("SetTranscodeNodeURL: %v", err)
+	}
+
+	handler := NewPlaybackHandler(sessionMgr, testPlaybackFileResolver{file: file})
+	handler.ItemAccess = allowAllPlaybackItemAccess{}
+	handler.JWTSecret = "test-secret"
+	handler.PlaybackConfig = playbackTestConfig(writePlaybackTestFFmpeg(t), t.TempDir())
+	handler.copySeekAnchor = func(context.Context, string, string, float64, int) (float64, int, error) {
+		return 16, 8, nil
+	}
+	pool := nodepool.NewTranscodePool()
+	pool.SetNodes([]*nodepool.Node{{
+		Name: "transcode-1", Type: nodepool.NodeTypeTranscode, URL: remote.URL,
+		Enabled: true, Healthy: true,
+	}})
+	handler.NodePlanner = nodepool.NewPlanner(nodepool.NewProxyPool(), pool)
+
+	responses := make(chan int, 2)
+	start := func() {
+		request := httptest.NewRequest(
+			http.MethodPost,
+			"/api/v1/playback/transcode/start",
+			strings.NewReader(`{"session_id":"`+session.ID+`","seek_seconds":18,"target_codec_video":"copy","target_codec_audio":"aac","segment_duration":2,"subtitle_track_index":-1}`),
+		).WithContext(newAuthorizedPlaybackContext())
+		response := httptest.NewRecorder()
+		handler.HandleStartTranscode(response, request)
+		responses <- response.Code
+	}
+	go start()
+	go start()
+	<-prepared
+	<-prepared
+	close(release)
+
+	statuses := []int{<-responses, <-responses}
+	sort.Ints(statuses)
+	if statuses[0] != http.StatusAccepted || statuses[1] != http.StatusConflict {
+		t.Fatalf("replacement statuses = %v, want [%d %d]", statuses, http.StatusAccepted, http.StatusConflict)
+	}
+	persisted, err := sessionMgr.GetSession(session.ID)
+	if err != nil {
+		t.Fatalf("GetSession: %v", err)
+	}
+	remoteMu.Lock()
+	preparedSnapshot := append([]string(nil), preparedIDs...)
+	deletedSnapshot := append([]string(nil), deletedIDs...)
+	remoteMu.Unlock()
+	if len(preparedSnapshot) != 2 || preparedSnapshot[0] == preparedSnapshot[1] {
+		t.Fatalf("prepared transport IDs = %v, want two distinct successors", preparedSnapshot)
+	}
+	winner := persisted.TranscodeTransportID
+	if winner != preparedSnapshot[0] && winner != preparedSnapshot[1] {
+		t.Fatalf("published transport = %q, not one of %v", winner, preparedSnapshot)
+	}
+	loser := preparedSnapshot[0]
+	if loser == winner {
+		loser = preparedSnapshot[1]
+	}
+	sort.Strings(deletedSnapshot)
+	wantDeletes := []string{session.ID, loser}
+	sort.Strings(wantDeletes)
+	if len(deletedSnapshot) != 2 || deletedSnapshot[0] != wantDeletes[0] || deletedSnapshot[1] != wantDeletes[1] {
+		t.Fatalf("deleted transports = %v, want predecessor and loser %v", deletedSnapshot, wantDeletes)
+	}
+}
+
+func TestHandleStartTranscode_RemoteSuccessorCannotBeOverwrittenByStaleFinalization(t *testing.T) {
+	baseSessionMgr := playback.NewSessionManager(0, 0)
+	sessionMgr := &firstBlockingSessionManager{
+		SessionManager: baseSessionMgr,
+		entered:        make(chan struct{}),
+		release:        make(chan struct{}),
+	}
+	file := &models.MediaFile{
+		ID:          42,
+		ContentID:   "movie-1",
+		FilePath:    writePlaybackTestMediaFile(t, "movie-remote-state-order.mkv"),
+		Resolution:  "1080p",
+		CodecVideo:  "h264",
+		CodecAudio:  "ac3",
+		Container:   "mkv",
+		Bitrate:     8000,
+		Duration:    3600,
+		AudioTracks: []models.AudioTrack{{Codec: "ac3", Default: true}},
+	}
+	session, err := sessionMgr.StartSession(1, "profile-1", file.ID, playback.PlayRemux, true)
+	if err != nil {
+		t.Fatalf("StartSession: %v", err)
+	}
+
+	var remoteMu sync.Mutex
+	preparedBitrates := make(map[string]int)
+	var deletedIDs []string
+	oldDeleteStarted := make(chan struct{})
+	releaseOldDelete := make(chan struct{})
+	remote := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == http.MethodPost && r.URL.Path == "/transcode/start":
+			var startReq transcodenode.TranscodeStartRequest
+			if err := json.NewDecoder(r.Body).Decode(&startReq); err != nil {
+				t.Errorf("decode remote start request: %v", err)
+			}
+			remoteMu.Lock()
+			preparedBitrates[startReq.SessionID] = startReq.TargetBitrateKbps
+			remoteMu.Unlock()
+			w.WriteHeader(http.StatusAccepted)
+			_ = json.NewEncoder(w).Encode(transcodenode.TranscodeStartResponse{
+				SessionID: startReq.SessionID,
+				Status:    "accepted",
+				HWAccel:   "none",
+			})
+		case r.Method == http.MethodDelete && strings.HasPrefix(r.URL.Path, "/transcode/"):
+			deletedID := strings.TrimPrefix(r.URL.Path, "/transcode/")
+			remoteMu.Lock()
+			deletedIDs = append(deletedIDs, deletedID)
+			remoteMu.Unlock()
+			if deletedID == session.ID {
+				close(oldDeleteStarted)
+				<-releaseOldDelete
+			}
+			w.WriteHeader(http.StatusNoContent)
+		default:
+			t.Errorf("unexpected remote request %s %s", r.Method, r.URL.Path)
+			http.Error(w, "unexpected", http.StatusBadRequest)
+		}
+	}))
+	defer remote.Close()
+	if err := sessionMgr.SetTranscodeNodeURL(session.ID, remote.URL); err != nil {
+		t.Fatalf("SetTranscodeNodeURL: %v", err)
+	}
+
+	handler := NewPlaybackHandler(sessionMgr, testPlaybackFileResolver{file: file})
+	handler.ItemAccess = allowAllPlaybackItemAccess{}
+	handler.JWTSecret = "test-secret"
+	handler.PlaybackConfig = playbackTestConfig(writePlaybackTestFFmpeg(t), t.TempDir())
+	handler.copySeekAnchor = func(context.Context, string, string, float64, int) (float64, int, error) {
+		return 16, 8, nil
+	}
+	pool := nodepool.NewTranscodePool()
+	pool.SetNodes([]*nodepool.Node{{
+		Name: "transcode-1", Type: nodepool.NodeTypeTranscode, URL: remote.URL,
+		Enabled: true, Healthy: true,
+	}})
+	handler.NodePlanner = nodepool.NewPlanner(nodepool.NewProxyPool(), pool)
+
+	start := func(bitrate int) <-chan int {
+		result := make(chan int, 1)
+		go func() {
+			request := httptest.NewRequest(
+				http.MethodPost,
+				"/api/v1/playback/transcode/start",
+				strings.NewReader(fmt.Sprintf(
+					`{"session_id":%q,"seek_seconds":18,"target_codec_video":"copy","target_codec_audio":"aac","target_bitrate_kbps":%d,"segment_duration":2,"subtitle_track_index":-1}`,
+					session.ID,
+					bitrate,
+				)),
+			).WithContext(newAuthorizedPlaybackContext())
+			response := httptest.NewRecorder()
+			handler.HandleStartTranscode(response, request)
+			result <- response.Code
+		}()
+		return result
+	}
+
+	firstResult := start(1111)
+	<-sessionMgr.entered
+	secondResult := start(2222)
+
+	// Give the second request time to prepare its successor and contend on the
+	// lifecycle commit while the first request's durable state publication is
+	// deliberately paused.
+	deadline := time.Now().Add(2 * time.Second)
+	for {
+		remoteMu.Lock()
+		preparedCount := len(preparedBitrates)
+		remoteMu.Unlock()
+		if preparedCount == 2 {
+			break
+		}
+		if time.Now().After(deadline) {
+			t.Fatal("second replacement was not prepared")
+		}
+		time.Sleep(time.Millisecond)
+	}
+	close(sessionMgr.release)
+
+	<-oldDeleteStarted
+	if status := <-secondResult; status != http.StatusAccepted {
+		t.Fatalf("second status = %d, want %d", status, http.StatusAccepted)
+	}
+	close(releaseOldDelete)
+	if status := <-firstResult; status != http.StatusConflict {
+		t.Fatalf("superseded first status = %d, want %d", status, http.StatusConflict)
+	}
+	persisted, err := sessionMgr.GetSession(session.ID)
+	if err != nil {
+		t.Fatalf("GetSession: %v", err)
+	}
+	remoteMu.Lock()
+	winnerBitrate := preparedBitrates[persisted.TranscodeTransportID]
+	deletedSnapshot := append([]string(nil), deletedIDs...)
+	remoteMu.Unlock()
+	if winnerBitrate != 2222 {
+		t.Fatalf("published transport bitrate = %d, want second successor bitrate 2222", winnerBitrate)
+	}
+	if persisted.TargetBitrateKbps != winnerBitrate {
+		t.Fatalf("persisted bitrate = %d, want route winner bitrate %d", persisted.TargetBitrateKbps, winnerBitrate)
+	}
+	if len(deletedSnapshot) != 2 {
+		t.Fatalf("deleted transports = %v, want predecessor and first successor", deletedSnapshot)
+	}
+}
+
+func TestHandleStartTranscode_SeekedCopyAllowedWhenVideoTranscodingDisabled(t *testing.T) {
+	sessionMgr := playback.NewSessionManager(0, 0)
+	sessionMgr.SetLimitProvider(func(context.Context, int) (playback.SessionLimits, error) {
+		return playback.SessionLimits{TranscodingDisabled: true}, nil
+	})
+	file := &models.MediaFile{
+		ID:          42,
+		ContentID:   "movie-1",
+		FilePath:    writePlaybackTestMediaFile(t, "movie-copy-permission.mkv"),
+		Resolution:  "1080p",
+		CodecVideo:  "h264",
+		CodecAudio:  "ac3",
+		Container:   "mkv",
+		Bitrate:     8000,
+		Duration:    3600,
+		AudioTracks: []models.AudioTrack{{Codec: "ac3", Default: true}},
 	}
 	session, err := sessionMgr.StartSession(1, "profile-1", file.ID, playback.PlayRemux, true)
 	if err != nil {
@@ -1595,111 +2560,76 @@ func TestHandleStartTranscode_MPEG2SeekedCopyRemainsCopyVideo(t *testing.T) {
 	handler := NewPlaybackHandler(sessionMgr, testPlaybackFileResolver{file: file})
 	handler.ItemAccess = allowAllPlaybackItemAccess{}
 	handler.PlaybackConfig = playbackTestConfig(writePlaybackTestFFmpeg(t), t.TempDir())
-
+	handler.copySeekAnchor = func(context.Context, string, string, float64, int) (float64, int, error) {
+		return 16, 8, nil
+	}
 	transcodeReq := httptest.NewRequest(
-		"POST",
+		http.MethodPost,
 		"/api/v1/playback/transcode/start",
-		strings.NewReader(`{"session_id":"`+session.ID+`","seek_seconds":18.261,"target_resolution":"1080p","target_codec_video":"copy","target_codec_audio":"aac","target_bitrate_kbps":0,"segment_duration":2,"subtitle_track_index":-1,"subtitle_burn_in":false}`),
-	)
-	transcodeReq = transcodeReq.WithContext(newAuthorizedPlaybackContext())
-
+		strings.NewReader(`{"session_id":"`+session.ID+`","seek_seconds":18.261,"target_resolution":"","target_codec_video":"copy","target_codec_audio":"aac","target_bitrate_kbps":0,"segment_duration":2,"subtitle_track_index":-1,"subtitle_burn_in":false}`),
+	).WithContext(newAuthorizedPlaybackContext())
 	transcodeRR := httptest.NewRecorder()
 	handler.HandleStartTranscode(transcodeRR, transcodeReq)
-	if transcodeRR.Code != 202 {
+	if transcodeRR.Code != http.StatusAccepted {
 		t.Fatalf("transcode status = %d, body = %s", transcodeRR.Code, transcodeRR.Body.String())
 	}
-
 	transcodeSession := handler.tm.GetTranscodeSession(session.ID)
 	if transcodeSession == nil {
-		t.Fatal("expected local transcode session")
+		t.Fatal("expected local copy-video session")
 	}
-	t.Cleanup(func() {
-		_ = transcodeSession.Close()
-	})
-	opts := transcodeSession.Opts()
-	if got := opts.TargetCodecVideo; got != "copy" {
-		t.Fatalf("mpeg2 seeked copy target video codec = %q, want copy", got)
-	}
-	if got := opts.SourceVideoCodec; got != "mpeg2video" {
-		t.Fatalf("mpeg2 seeked copy source video codec = %q, want mpeg2video", got)
-	}
-	if got := opts.TargetCodecAudio; got != "aac" {
-		t.Fatalf("mpeg2 seeked copy target audio codec = %q, want aac", got)
+	t.Cleanup(func() { _ = transcodeSession.Close() })
+	if got := transcodeSession.Opts().TargetCodecVideo; got != "copy" {
+		t.Fatalf("target video codec = %q, want copy", got)
 	}
 }
 
-func TestHandleStartTranscode_ForcedVideoEncodingRechecksPermission(t *testing.T) {
-	for _, tc := range []struct {
-		name        string
-		requestBody func(sessionID string) string
-	}{
-		{
-			name: "seeked copy video",
-			requestBody: func(sessionID string) string {
-				return `{"session_id":"` + sessionID + `","seek_seconds":18.261,"target_resolution":"1080p","target_codec_video":"copy","target_codec_audio":"aac","target_bitrate_kbps":0,"segment_duration":2,"subtitle_track_index":-1,"subtitle_burn_in":false}`
-			},
+func TestHandleStartTranscode_SubtitleBurnInRechecksVideoTranscodePermission(t *testing.T) {
+	sessionMgr := playback.NewSessionManager(0, 0)
+	sessionMgr.SetLimitProvider(func(context.Context, int) (playback.SessionLimits, error) {
+		return playback.SessionLimits{TranscodingDisabled: true}, nil
+	})
+	file := &models.MediaFile{
+		ID:          42,
+		ContentID:   "movie-1",
+		FilePath:    writePlaybackTestMediaFile(t, "movie-burn-in.mkv"),
+		Resolution:  "1080p",
+		CodecVideo:  "h264",
+		CodecAudio:  "ac3",
+		Container:   "mkv",
+		Bitrate:     8000,
+		Duration:    3600,
+		AudioTracks: []models.AudioTrack{{Codec: "ac3", Default: true}},
+		SubtitleTracks: []models.SubtitleTrack{
+			{Index: 0, Language: "en", Codec: "subrip"},
 		},
-		{
-			name: "subtitle burn in",
-			requestBody: func(sessionID string) string {
-				return `{"session_id":"` + sessionID + `","seek_seconds":0,"target_resolution":"1080p","target_codec_video":"copy","target_codec_audio":"aac","target_bitrate_kbps":0,"segment_duration":2,"subtitle_track_index":0,"subtitle_burn_in":true}`
-			},
-		},
-	} {
-		t.Run(tc.name, func(t *testing.T) {
-			sessionMgr := playback.NewSessionManager(0, 0)
-			sessionMgr.SetLimitProvider(func(context.Context, int) (playback.SessionLimits, error) {
-				return playback.SessionLimits{TranscodingDisabled: true}, nil
-			})
-			file := &models.MediaFile{
-				ID:         42,
-				ContentID:  "movie-1",
-				FilePath:   writePlaybackTestMediaFile(t, "movie.mkv"),
-				Resolution: "1080p",
-				CodecVideo: "h264",
-				CodecAudio: "ac3",
-				Container:  "mkv",
-				Bitrate:    8000,
-				Duration:   3600,
-				AudioTracks: []models.AudioTrack{
-					{Codec: "ac3", Default: true},
-				},
-				SubtitleTracks: []models.SubtitleTrack{
-					{Index: 0, Language: "en", Codec: "subrip"},
-				},
-			}
-			session, err := sessionMgr.StartSession(1, "profile-1", file.ID, playback.PlayRemux, true)
-			if err != nil {
-				t.Fatalf("StartSession: %v", err)
-			}
+	}
+	session, err := sessionMgr.StartSession(1, "profile-1", file.ID, playback.PlayRemux, true)
+	if err != nil {
+		t.Fatalf("StartSession: %v", err)
+	}
 
-			handler := NewPlaybackHandler(sessionMgr, testPlaybackFileResolver{file: file})
-			handler.ItemAccess = allowAllPlaybackItemAccess{}
+	handler := NewPlaybackHandler(sessionMgr, testPlaybackFileResolver{file: file})
+	handler.ItemAccess = allowAllPlaybackItemAccess{}
+	transcodeReq := httptest.NewRequest(
+		http.MethodPost,
+		"/api/v1/playback/transcode/start",
+		strings.NewReader(`{"session_id":"`+session.ID+`","seek_seconds":0,"target_resolution":"1080p","target_codec_video":"copy","target_codec_audio":"aac","target_bitrate_kbps":0,"segment_duration":2,"subtitle_track_index":0,"subtitle_burn_in":true}`),
+	).WithContext(newAuthorizedPlaybackContext())
+	transcodeRR := httptest.NewRecorder()
+	handler.HandleStartTranscode(transcodeRR, transcodeReq)
 
-			transcodeReq := httptest.NewRequest(
-				http.MethodPost,
-				"/api/v1/playback/transcode/start",
-				strings.NewReader(tc.requestBody(session.ID)),
-			)
-			transcodeReq = transcodeReq.WithContext(newAuthorizedPlaybackContext())
-
-			transcodeRR := httptest.NewRecorder()
-			handler.HandleStartTranscode(transcodeRR, transcodeReq)
-
-			if transcodeRR.Code != http.StatusForbidden {
-				t.Fatalf("status = %d, want %d, body = %s", transcodeRR.Code, http.StatusForbidden, transcodeRR.Body.String())
-			}
-			var response errorResponse
-			if err := json.NewDecoder(transcodeRR.Body).Decode(&response); err != nil {
-				t.Fatalf("decode response: %v", err)
-			}
-			if response.Error != "transcoding_disabled" {
-				t.Fatalf("error = %q, want transcoding_disabled", response.Error)
-			}
-			if transcodeSession := handler.tm.GetTranscodeSession(session.ID); transcodeSession != nil {
-				t.Fatal("transcode session started despite disabled video transcoding")
-			}
-		})
+	if transcodeRR.Code != http.StatusForbidden {
+		t.Fatalf("status = %d, want %d, body = %s", transcodeRR.Code, http.StatusForbidden, transcodeRR.Body.String())
+	}
+	var response errorResponse
+	if err := json.NewDecoder(transcodeRR.Body).Decode(&response); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if response.Error != "transcoding_disabled" {
+		t.Fatalf("error = %q, want transcoding_disabled", response.Error)
+	}
+	if transcodeSession := handler.tm.GetTranscodeSession(session.ID); transcodeSession != nil {
+		t.Fatal("transcode session started despite disabled video transcoding")
 	}
 }
 

--- a/internal/playback/copy_seek_anchor.go
+++ b/internal/playback/copy_seek_anchor.go
@@ -1,0 +1,92 @@
+package playback
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"math"
+	"os/exec"
+	"strconv"
+	"strings"
+)
+
+type copySeekProbePacket struct {
+	PTSSeconds string `json:"pts_time"`
+	DTSSeconds string `json:"dts_time"`
+	Flags      string `json:"flags"`
+}
+
+type copySeekProbeOutput struct {
+	Packets []copySeekProbePacket `json:"packets"`
+}
+
+// ResolveCopySeekAnchor returns the keyframe timestamp FFmpeg's input seek will
+// actually use for a copy-video restart. FFmpeg cannot discard the pre-roll
+// between that keyframe and requestedSeekSeconds while preserving -c:v copy,
+// so callers need both timestamps: requestedSeekSeconds remains the -ss input,
+// while the returned anchor defines the stream's real timeline origin.
+//
+// The tiny read interval is intentional. ffprobe asks the demuxer to seek to
+// requestedSeekSeconds, which lands on the same preceding key packet FFmpeg
+// uses, then emits only the packets at that seek point instead of scanning the
+// media from the beginning.
+func ResolveCopySeekAnchor(
+	ctx context.Context,
+	ffmpegPath string,
+	inputPath string,
+	requestedSeekSeconds float64,
+	segmentDuration int,
+) (float64, int, error) {
+	if requestedSeekSeconds <= 0 {
+		return 0, 0, nil
+	}
+	if strings.TrimSpace(inputPath) == "" {
+		return 0, 0, fmt.Errorf("resolve copy seek anchor: empty input path")
+	}
+	if segmentDuration <= 0 {
+		segmentDuration = DefaultSegmentDuration
+	}
+
+	interval := strconv.FormatFloat(requestedSeekSeconds, 'f', 6, 64) + "%+0.001"
+	cmd := exec.CommandContext(ctx, ffprobePathFromFFmpeg(ffmpegPath),
+		"-v", "error",
+		"-select_streams", "v:0",
+		"-read_intervals", interval,
+		"-show_entries", "packet=pts_time,dts_time,flags",
+		"-of", "json",
+		inputPath,
+	)
+	var stdout bytes.Buffer
+	stderr := newBoundedTailBuffer(stderrTailMaxBytes)
+	cmd.Stdout = &stdout
+	cmd.Stderr = stderr
+	if err := cmd.Run(); err != nil {
+		if tail := truncateStderr(stderr.String()); tail != "" {
+			return 0, 0, fmt.Errorf("resolve copy seek anchor: ffprobe failed: %w (stderr: %s)", err, tail)
+		}
+		return 0, 0, fmt.Errorf("resolve copy seek anchor: ffprobe failed: %w", err)
+	}
+
+	var output copySeekProbeOutput
+	if err := json.Unmarshal(stdout.Bytes(), &output); err != nil {
+		return 0, 0, fmt.Errorf("resolve copy seek anchor: decode ffprobe output: %w", err)
+	}
+	for _, packet := range output.Packets {
+		if !strings.Contains(packet.Flags, "K") {
+			continue
+		}
+		timestamp := packet.PTSSeconds
+		if timestamp == "" || strings.EqualFold(timestamp, "N/A") {
+			timestamp = packet.DTSSeconds
+		}
+		anchor, err := strconv.ParseFloat(timestamp, 64)
+		if err != nil || math.IsNaN(anchor) || math.IsInf(anchor, 0) {
+			continue
+		}
+		anchor = math.Max(0, anchor)
+		return anchor, int(anchor / float64(segmentDuration)), nil
+	}
+
+	return 0, 0, fmt.Errorf("resolve copy seek anchor: ffprobe returned no key packet")
+}

--- a/internal/playback/copy_seek_anchor.go
+++ b/internal/playback/copy_seek_anchor.go
@@ -9,6 +9,19 @@ import (
 	"os/exec"
 	"strconv"
 	"strings"
+	"time"
+
+	"golang.org/x/sync/singleflight"
+)
+
+const (
+	maxConcurrentCopySeekProbes = 4
+	copySeekProbeTimeout        = 15 * time.Second
+)
+
+var (
+	copySeekProbeGroup singleflight.Group
+	copySeekProbeSlots = make(chan struct{}, maxConcurrentCopySeekProbes)
 )
 
 type copySeekProbePacket struct {
@@ -19,6 +32,11 @@ type copySeekProbePacket struct {
 
 type copySeekProbeOutput struct {
 	Packets []copySeekProbePacket `json:"packets"`
+}
+
+type copySeekAnchor struct {
+	seconds float64
+	segment int
 }
 
 // ResolveCopySeekAnchor returns the keyframe timestamp FFmpeg's input seek will
@@ -47,6 +65,45 @@ func ResolveCopySeekAnchor(
 	if segmentDuration <= 0 {
 		segmentDuration = DefaultSegmentDuration
 	}
+
+	key := strings.Join([]string{
+		ffprobePathFromFFmpeg(ffmpegPath),
+		inputPath,
+		strconv.FormatFloat(requestedSeekSeconds, 'f', 6, 64),
+		strconv.Itoa(segmentDuration),
+	}, "\x00")
+	resultCh := copySeekProbeGroup.DoChan(key, func() (any, error) {
+		probeCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), copySeekProbeTimeout)
+		defer cancel()
+		select {
+		case copySeekProbeSlots <- struct{}{}:
+			defer func() { <-copySeekProbeSlots }()
+		case <-probeCtx.Done():
+			return copySeekAnchor{}, probeCtx.Err()
+		}
+		seconds, segment, err := resolveCopySeekAnchor(probeCtx, ffmpegPath, inputPath, requestedSeekSeconds, segmentDuration)
+		return copySeekAnchor{seconds: seconds, segment: segment}, err
+	})
+
+	select {
+	case <-ctx.Done():
+		return 0, 0, ctx.Err()
+	case result := <-resultCh:
+		if result.Err != nil {
+			return 0, 0, result.Err
+		}
+		anchor := result.Val.(copySeekAnchor)
+		return anchor.seconds, anchor.segment, nil
+	}
+}
+
+func resolveCopySeekAnchor(
+	ctx context.Context,
+	ffmpegPath string,
+	inputPath string,
+	requestedSeekSeconds float64,
+	segmentDuration int,
+) (float64, int, error) {
 
 	interval := strconv.FormatFloat(requestedSeekSeconds, 'f', 6, 64) + "%+0.001"
 	cmd := exec.CommandContext(ctx, ffprobePathFromFFmpeg(ffmpegPath),

--- a/internal/playback/copy_seek_anchor_test.go
+++ b/internal/playback/copy_seek_anchor_test.go
@@ -1,0 +1,125 @@
+package playback
+
+import (
+	"context"
+	"math"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestResolveCopySeekAnchorUsesKeyPacketTimestamp(t *testing.T) {
+	dir := t.TempDir()
+	ffmpegPath := filepath.Join(dir, "ffmpeg")
+	ffprobePath := filepath.Join(dir, "ffprobe")
+	if err := os.WriteFile(ffmpegPath, []byte("#!/bin/sh\nexit 0\n"), 0o755); err != nil {
+		t.Fatalf("write fake ffmpeg: %v", err)
+	}
+	probe := `#!/bin/sh
+printf '%s' '{"packets":[{"pts_time":"N/A","dts_time":"14.500000","flags":"K__"}]}'
+`
+	if err := os.WriteFile(ffprobePath, []byte(probe), 0o755); err != nil {
+		t.Fatalf("write fake ffprobe: %v", err)
+	}
+
+	anchor, segment, err := ResolveCopySeekAnchor(context.Background(), ffmpegPath, "/media/movie.mkv", 18.261, 2)
+	if err != nil {
+		t.Fatalf("ResolveCopySeekAnchor: %v", err)
+	}
+	if anchor != 14.5 || segment != 7 {
+		t.Fatalf("resolved anchor = %v, segment = %d; want 14.5, 7", anchor, segment)
+	}
+}
+
+func TestResolveCopySeekAnchorMatchesRealLongGOPHEVC(t *testing.T) {
+	if testing.Short() {
+		t.Skip("real FFmpeg integration test")
+	}
+	ffmpegPath, err := exec.LookPath("ffmpeg")
+	if err != nil {
+		t.Skip("ffmpeg is not installed")
+	}
+	if _, err := exec.LookPath(ffprobePathFromFFmpeg(ffmpegPath)); err != nil {
+		t.Skip("ffprobe is not installed beside ffmpeg")
+	}
+	encoders, err := exec.Command(ffmpegPath, "-hide_banner", "-encoders").CombinedOutput()
+	if err != nil || !strings.Contains(string(encoders), "libx265") {
+		t.Skip("ffmpeg does not provide libx265")
+	}
+
+	sourcePath := filepath.Join(t.TempDir(), "long-gop-hevc.mkv")
+	encodeCtx, cancelEncode := context.WithTimeout(context.Background(), 20*time.Second)
+	defer cancelEncode()
+	encode := exec.CommandContext(encodeCtx, ffmpegPath,
+		"-hide_banner", "-loglevel", "error",
+		"-f", "lavfi", "-i", "testsrc2=size=320x180:rate=24",
+		"-t", "22",
+		"-c:v", "libx265", "-preset", "ultrafast",
+		"-x265-params", "keyint=240:min-keyint=240:scenecut=0:log-level=error:pools=1:frame-threads=1",
+		"-an", "-y", sourcePath,
+	)
+	if output, err := encode.CombinedOutput(); err != nil {
+		t.Fatalf("generate long-GOP HEVC fixture: %v\n%s", err, output)
+	}
+
+	probeCtx, cancelProbe := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancelProbe()
+	anchor, segment, err := ResolveCopySeekAnchor(probeCtx, ffmpegPath, sourcePath, 18.261, 2)
+	if err != nil {
+		t.Fatalf("ResolveCopySeekAnchor: %v", err)
+	}
+	if math.Abs(anchor-10) > 0.001 || segment != 5 {
+		t.Fatalf("resolved anchor = %v, segment = %d; want 10, 5", anchor, segment)
+	}
+
+	outputDir := filepath.Join(t.TempDir(), "hls")
+	if err := os.MkdirAll(outputDir, 0o755); err != nil {
+		t.Fatalf("create HLS output: %v", err)
+	}
+	opts := TranscodeOpts{
+		InputPath:              sourcePath,
+		OutputDir:              outputDir,
+		SessionID:              "copy-anchor-integration",
+		SourceVideoCodec:       "hevc",
+		SeekSeconds:            18.261,
+		StreamOriginSeconds:    anchor,
+		CopySeekAnchorResolved: true,
+		TargetCodecVideo:       "copy",
+		TargetCodecAudio:       "copy",
+		SegmentDuration:        2,
+		StartSegmentNumber:     segment,
+		FFmpegPath:             ffmpegPath,
+	}
+	packageCtx, cancelPackage := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancelPackage()
+	packageHLS := exec.CommandContext(packageCtx, ffmpegPath, buildFFmpegArgs(opts)...)
+	if output, err := packageHLS.CombinedOutput(); err != nil {
+		t.Fatalf("package copy HLS: %v\n%s", err, output)
+	}
+
+	manifestPath := filepath.Join(outputDir, "stream.m3u8")
+	manifest, err := os.ReadFile(manifestPath)
+	if err != nil {
+		t.Fatalf("read copy HLS manifest: %v", err)
+	}
+	if !strings.Contains(string(manifest), "#EXT-X-MEDIA-SEQUENCE:5") {
+		t.Fatalf("copy HLS media sequence does not use resolved anchor:\n%s", manifest)
+	}
+	firstFrame, err := exec.Command(ffprobePathFromFFmpeg(ffmpegPath),
+		"-v", "error",
+		"-select_streams", "v:0",
+		"-read_intervals", "%+0.1",
+		"-show_entries", "frame=best_effort_timestamp_time,key_frame",
+		"-of", "csv=p=0",
+		manifestPath,
+	).CombinedOutput()
+	if err != nil {
+		t.Fatalf("probe copy HLS first frame: %v\n%s", err, firstFrame)
+	}
+	if !strings.Contains(string(firstFrame), "10.000000") {
+		t.Fatalf("copy HLS first frame = %q, want resolved 10-second keyframe", firstFrame)
+	}
+}

--- a/internal/playback/copy_seek_anchor_test.go
+++ b/internal/playback/copy_seek_anchor_test.go
@@ -2,11 +2,13 @@ package playback
 
 import (
 	"context"
+	"fmt"
 	"math"
 	"os"
 	"os/exec"
 	"path/filepath"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 )
@@ -31,6 +33,53 @@ printf '%s' '{"packets":[{"pts_time":"N/A","dts_time":"14.500000","flags":"K__"}
 	}
 	if anchor != 14.5 || segment != 7 {
 		t.Fatalf("resolved anchor = %v, segment = %d; want 14.5, 7", anchor, segment)
+	}
+}
+
+func TestResolveCopySeekAnchorCoalescesMatchingConcurrentProbes(t *testing.T) {
+	dir := t.TempDir()
+	ffmpegPath := filepath.Join(dir, "ffmpeg")
+	ffprobePath := filepath.Join(dir, "ffprobe")
+	countPath := filepath.Join(dir, "probe-count")
+	if err := os.WriteFile(ffmpegPath, []byte("#!/bin/sh\nexit 0\n"), 0o755); err != nil {
+		t.Fatalf("write fake ffmpeg: %v", err)
+	}
+	probe := "#!/bin/sh\n" +
+		"printf x >> \"" + countPath + "\"\n" +
+		"sleep 0.1\n" +
+		"printf '%s' '{\"packets\":[{\"pts_time\":\"16.000000\",\"flags\":\"K__\"}]}'\n"
+	if err := os.WriteFile(ffprobePath, []byte(probe), 0o755); err != nil {
+		t.Fatalf("write fake ffprobe: %v", err)
+	}
+
+	start := make(chan struct{})
+	errs := make(chan error, 2)
+	var ready sync.WaitGroup
+	ready.Add(2)
+	for range 2 {
+		go func() {
+			ready.Done()
+			<-start
+			anchor, segment, err := ResolveCopySeekAnchor(context.Background(), ffmpegPath, "/media/movie.mkv", 18, 2)
+			if err == nil && (anchor != 16 || segment != 8) {
+				err = fmt.Errorf("resolved anchor = %v, segment = %d", anchor, segment)
+			}
+			errs <- err
+		}()
+	}
+	ready.Wait()
+	close(start)
+	for range 2 {
+		if err := <-errs; err != nil {
+			t.Fatal(err)
+		}
+	}
+	count, err := os.ReadFile(countPath)
+	if err != nil {
+		t.Fatalf("read probe count: %v", err)
+	}
+	if string(count) != "x" {
+		t.Fatalf("ffprobe executions = %d, want 1", len(count))
 	}
 }
 

--- a/internal/playback/recipecard.go
+++ b/internal/playback/recipecard.go
@@ -34,25 +34,27 @@ type RecipeCard struct {
 
 	// Encode parameters — mirror of the byte-affecting TranscodeOpts fields.
 	// Unused (zero) for direct/remux cards, which carry no segment-based encode.
-	InputPath            string  `json:"input_path"`
-	OutputSubdir         string  `json:"output_subdir,omitempty"`
-	SourceVideoCodec     string  `json:"source_video_codec,omitempty"`
-	VideoBitstreamFilter string  `json:"video_bitstream_filter,omitempty"`
-	SeekSeconds          float64 `json:"seek_seconds"`
-	TargetResolution     string  `json:"target_resolution,omitempty"`
-	TargetCodecVideo     string  `json:"target_codec_video,omitempty"`
-	TargetCodecAudio     string  `json:"target_codec_audio,omitempty"`
-	SegmentDuration      int     `json:"segment_duration"`
-	StartSegmentNumber   int     `json:"start_segment_number"`
-	HWAccel              string  `json:"hw_accel,omitempty"`
-	HWDevice             string  `json:"hw_device,omitempty"`
-	SubtitleTrackIndex   int     `json:"subtitle_track_index"`
-	SubtitleBurnIn       bool    `json:"subtitle_burn_in,omitempty"`
-	SubtitleCodec        string  `json:"subtitle_codec,omitempty"`
-	AudioTrackIndex      int     `json:"audio_track_index"`
-	TargetBitrateKbps    int     `json:"target_bitrate_kbps,omitempty"`
-	TotalDuration        float64 `json:"total_duration"`
-	FastStart            bool    `json:"fast_start,omitempty"`
+	InputPath              string  `json:"input_path"`
+	OutputSubdir           string  `json:"output_subdir,omitempty"`
+	SourceVideoCodec       string  `json:"source_video_codec,omitempty"`
+	VideoBitstreamFilter   string  `json:"video_bitstream_filter,omitempty"`
+	SeekSeconds            float64 `json:"seek_seconds"`
+	StreamOriginSeconds    float64 `json:"stream_origin_seconds,omitempty"`
+	CopySeekAnchorResolved bool    `json:"copy_seek_anchor_resolved,omitempty"`
+	TargetResolution       string  `json:"target_resolution,omitempty"`
+	TargetCodecVideo       string  `json:"target_codec_video,omitempty"`
+	TargetCodecAudio       string  `json:"target_codec_audio,omitempty"`
+	SegmentDuration        int     `json:"segment_duration"`
+	StartSegmentNumber     int     `json:"start_segment_number"`
+	HWAccel                string  `json:"hw_accel,omitempty"`
+	HWDevice               string  `json:"hw_device,omitempty"`
+	SubtitleTrackIndex     int     `json:"subtitle_track_index"`
+	SubtitleBurnIn         bool    `json:"subtitle_burn_in,omitempty"`
+	SubtitleCodec          string  `json:"subtitle_codec,omitempty"`
+	AudioTrackIndex        int     `json:"audio_track_index"`
+	TargetBitrateKbps      int     `json:"target_bitrate_kbps,omitempty"`
+	TotalDuration          float64 `json:"total_duration"`
+	FastStart              bool    `json:"fast_start,omitempty"`
 }
 
 // NewRecipeCard builds a RecipeCard from the durable identity fields plus the
@@ -62,32 +64,34 @@ type RecipeCard struct {
 // operator's config change applies to reconstructed sessions too.
 func NewRecipeCard(userID int, profileID string, mediaFileID int, transcodeNodeURL string, opts TranscodeOpts) RecipeCard {
 	return RecipeCard{
-		SessionID:            opts.SessionID,
-		UserID:               userID,
-		ProfileID:            profileID,
-		MediaFileID:          mediaFileID,
-		TranscodeNodeURL:     transcodeNodeURL,
-		TranscodeTransportID: opts.TranscodeTransportID,
-		PlayMethod:           PlayTranscode,
-		InputPath:            opts.InputPath,
-		OutputSubdir:         opts.OutputSubdir,
-		SourceVideoCodec:     opts.SourceVideoCodec,
-		VideoBitstreamFilter: opts.VideoBitstreamFilter,
-		SeekSeconds:          opts.SeekSeconds,
-		TargetResolution:     opts.TargetResolution,
-		TargetCodecVideo:     opts.TargetCodecVideo,
-		TargetCodecAudio:     opts.TargetCodecAudio,
-		SegmentDuration:      opts.SegmentDuration,
-		StartSegmentNumber:   opts.StartSegmentNumber,
-		HWAccel:              opts.HWAccel,
-		HWDevice:             opts.HWDevice,
-		SubtitleTrackIndex:   opts.SubtitleTrackIndex,
-		SubtitleBurnIn:       opts.SubtitleBurnIn,
-		SubtitleCodec:        opts.SubtitleCodec,
-		AudioTrackIndex:      opts.AudioTrackIndex,
-		TargetBitrateKbps:    opts.TargetBitrateKbps,
-		TotalDuration:        opts.TotalDuration,
-		FastStart:            opts.FastStart,
+		SessionID:              opts.SessionID,
+		UserID:                 userID,
+		ProfileID:              profileID,
+		MediaFileID:            mediaFileID,
+		TranscodeNodeURL:       transcodeNodeURL,
+		TranscodeTransportID:   opts.TranscodeTransportID,
+		PlayMethod:             PlayTranscode,
+		InputPath:              opts.InputPath,
+		OutputSubdir:           opts.OutputSubdir,
+		SourceVideoCodec:       opts.SourceVideoCodec,
+		VideoBitstreamFilter:   opts.VideoBitstreamFilter,
+		SeekSeconds:            opts.SeekSeconds,
+		StreamOriginSeconds:    opts.StreamOriginSeconds,
+		CopySeekAnchorResolved: opts.CopySeekAnchorResolved,
+		TargetResolution:       opts.TargetResolution,
+		TargetCodecVideo:       opts.TargetCodecVideo,
+		TargetCodecAudio:       opts.TargetCodecAudio,
+		SegmentDuration:        opts.SegmentDuration,
+		StartSegmentNumber:     opts.StartSegmentNumber,
+		HWAccel:                opts.HWAccel,
+		HWDevice:               opts.HWDevice,
+		SubtitleTrackIndex:     opts.SubtitleTrackIndex,
+		SubtitleBurnIn:         opts.SubtitleBurnIn,
+		SubtitleCodec:          opts.SubtitleCodec,
+		AudioTrackIndex:        opts.AudioTrackIndex,
+		TargetBitrateKbps:      opts.TargetBitrateKbps,
+		TotalDuration:          opts.TotalDuration,
+		FastStart:              opts.FastStart,
 	}
 }
 
@@ -130,32 +134,34 @@ func NewRemuxRecipeCard(sessionID string, userID int, profileID string, mediaFil
 // they are environment-specific and not pinned in the card.
 func (c RecipeCard) TranscodeOpts(outputDir, ffmpegPath string, logSink FFmpegLogSink) TranscodeOpts {
 	return TranscodeOpts{
-		InputPath:            c.InputPath,
-		OutputSubdir:         c.OutputSubdir,
-		OutputDir:            outputDir,
-		SessionID:            c.SessionID,
-		TranscodeTransportID: c.TranscodeTransportID,
-		SourceVideoCodec:     c.SourceVideoCodec,
-		VideoBitstreamFilter: c.VideoBitstreamFilter,
-		SeekSeconds:          c.SeekSeconds,
-		TargetResolution:     c.TargetResolution,
-		TargetCodecVideo:     c.TargetCodecVideo,
-		TargetCodecAudio:     c.TargetCodecAudio,
-		SegmentDuration:      c.SegmentDuration,
-		StartSegmentNumber:   c.StartSegmentNumber,
-		FFmpegPath:           ffmpegPath,
-		HWAccel:              c.HWAccel,
-		HWDevice:             c.HWDevice,
-		SubtitleTrackIndex:   c.SubtitleTrackIndex,
-		SubtitleBurnIn:       c.SubtitleBurnIn,
-		SubtitleCodec:        c.SubtitleCodec,
-		AudioTrackIndex:      c.AudioTrackIndex,
-		TargetBitrateKbps:    c.TargetBitrateKbps,
-		TotalDuration:        c.TotalDuration,
-		FastStart:            c.FastStart,
-		NodeType:             "integrated",
-		ExecutionMode:        "integrated",
-		FFmpegLogSink:        logSink,
+		InputPath:              c.InputPath,
+		OutputSubdir:           c.OutputSubdir,
+		OutputDir:              outputDir,
+		SessionID:              c.SessionID,
+		TranscodeTransportID:   c.TranscodeTransportID,
+		SourceVideoCodec:       c.SourceVideoCodec,
+		VideoBitstreamFilter:   c.VideoBitstreamFilter,
+		SeekSeconds:            c.SeekSeconds,
+		StreamOriginSeconds:    c.StreamOriginSeconds,
+		CopySeekAnchorResolved: c.CopySeekAnchorResolved,
+		TargetResolution:       c.TargetResolution,
+		TargetCodecVideo:       c.TargetCodecVideo,
+		TargetCodecAudio:       c.TargetCodecAudio,
+		SegmentDuration:        c.SegmentDuration,
+		StartSegmentNumber:     c.StartSegmentNumber,
+		FFmpegPath:             ffmpegPath,
+		HWAccel:                c.HWAccel,
+		HWDevice:               c.HWDevice,
+		SubtitleTrackIndex:     c.SubtitleTrackIndex,
+		SubtitleBurnIn:         c.SubtitleBurnIn,
+		SubtitleCodec:          c.SubtitleCodec,
+		AudioTrackIndex:        c.AudioTrackIndex,
+		TargetBitrateKbps:      c.TargetBitrateKbps,
+		TotalDuration:          c.TotalDuration,
+		FastStart:              c.FastStart,
+		NodeType:               "integrated",
+		ExecutionMode:          "integrated",
+		FFmpegLogSink:          logSink,
 	}
 }
 
@@ -174,32 +180,34 @@ const MaxTokenTTL = 24 * time.Hour
 // change applies to reconstructed sessions too.
 func (c RecipeCard) ToClaims() streamtoken.Claims {
 	return streamtoken.Claims{
-		SessionID:            c.SessionID,
-		MediaPath:            c.InputPath,
-		OutputSubdir:         c.OutputSubdir,
-		PlayMethod:           string(c.PlayMethod),
-		TranscodeAudio:       c.TranscodeAudio,
-		RemuxDVMode:          string(c.RemuxDVMode),
-		TranscodeNode:        c.TranscodeNodeURL,
-		TranscodeTransportID: c.TranscodeTransportID,
-		TargetCodec:          c.TargetCodecVideo,
-		TargetRes:            c.TargetResolution,
-		AudioTrackIndex:      c.AudioTrackIndex,
-		UserID:               c.UserID,
-		ProfileID:            c.ProfileID,
-		MediaFileID:          c.MediaFileID,
-		SourceVideoCodec:     c.SourceVideoCodec,
-		VideoBitstreamFilter: c.VideoBitstreamFilter,
-		SeekSeconds:          c.SeekSeconds,
-		SegmentDuration:      c.SegmentDuration,
-		StartSegmentNumber:   c.StartSegmentNumber,
-		SubtitleTrackIndex:   c.SubtitleTrackIndex,
-		SubtitleBurnIn:       c.SubtitleBurnIn,
-		SubtitleCodec:        c.SubtitleCodec,
-		TargetBitrateKbps:    c.TargetBitrateKbps,
-		TotalDuration:        c.TotalDuration,
-		FastStart:            c.FastStart,
-		TargetCodecAudio:     c.TargetCodecAudio,
+		SessionID:              c.SessionID,
+		MediaPath:              c.InputPath,
+		OutputSubdir:           c.OutputSubdir,
+		PlayMethod:             string(c.PlayMethod),
+		TranscodeAudio:         c.TranscodeAudio,
+		RemuxDVMode:            string(c.RemuxDVMode),
+		TranscodeNode:          c.TranscodeNodeURL,
+		TranscodeTransportID:   c.TranscodeTransportID,
+		TargetCodec:            c.TargetCodecVideo,
+		TargetRes:              c.TargetResolution,
+		AudioTrackIndex:        c.AudioTrackIndex,
+		UserID:                 c.UserID,
+		ProfileID:              c.ProfileID,
+		MediaFileID:            c.MediaFileID,
+		SourceVideoCodec:       c.SourceVideoCodec,
+		VideoBitstreamFilter:   c.VideoBitstreamFilter,
+		SeekSeconds:            c.SeekSeconds,
+		StreamOriginSeconds:    c.StreamOriginSeconds,
+		CopySeekAnchorResolved: c.CopySeekAnchorResolved,
+		SegmentDuration:        c.SegmentDuration,
+		StartSegmentNumber:     c.StartSegmentNumber,
+		SubtitleTrackIndex:     c.SubtitleTrackIndex,
+		SubtitleBurnIn:         c.SubtitleBurnIn,
+		SubtitleCodec:          c.SubtitleCodec,
+		TargetBitrateKbps:      c.TargetBitrateKbps,
+		TotalDuration:          c.TotalDuration,
+		FastStart:              c.FastStart,
+		TargetCodecAudio:       c.TargetCodecAudio,
 	}
 }
 
@@ -216,31 +224,33 @@ func RecipeCardFromClaims(c *streamtoken.Claims) RecipeCard {
 		method = PlayTranscode
 	}
 	return RecipeCard{
-		SessionID:            c.SessionID,
-		UserID:               c.UserID,
-		ProfileID:            c.ProfileID,
-		MediaFileID:          c.MediaFileID,
-		TranscodeNodeURL:     c.TranscodeNode,
-		TranscodeTransportID: c.TranscodeTransportID,
-		PlayMethod:           method,
-		TranscodeAudio:       c.TranscodeAudio,
-		RemuxDVMode:          RemuxDVMode(c.RemuxDVMode),
-		InputPath:            c.MediaPath,
-		OutputSubdir:         c.OutputSubdir,
-		SourceVideoCodec:     c.SourceVideoCodec,
-		VideoBitstreamFilter: c.VideoBitstreamFilter,
-		SeekSeconds:          c.SeekSeconds,
-		TargetResolution:     c.TargetRes,
-		TargetCodecVideo:     c.TargetCodec,
-		TargetCodecAudio:     c.TargetCodecAudio,
-		SegmentDuration:      c.SegmentDuration,
-		StartSegmentNumber:   c.StartSegmentNumber,
-		SubtitleTrackIndex:   c.SubtitleTrackIndex,
-		SubtitleBurnIn:       c.SubtitleBurnIn,
-		SubtitleCodec:        c.SubtitleCodec,
-		AudioTrackIndex:      c.AudioTrackIndex,
-		TargetBitrateKbps:    c.TargetBitrateKbps,
-		TotalDuration:        c.TotalDuration,
-		FastStart:            c.FastStart,
+		SessionID:              c.SessionID,
+		UserID:                 c.UserID,
+		ProfileID:              c.ProfileID,
+		MediaFileID:            c.MediaFileID,
+		TranscodeNodeURL:       c.TranscodeNode,
+		TranscodeTransportID:   c.TranscodeTransportID,
+		PlayMethod:             method,
+		TranscodeAudio:         c.TranscodeAudio,
+		RemuxDVMode:            RemuxDVMode(c.RemuxDVMode),
+		InputPath:              c.MediaPath,
+		OutputSubdir:           c.OutputSubdir,
+		SourceVideoCodec:       c.SourceVideoCodec,
+		VideoBitstreamFilter:   c.VideoBitstreamFilter,
+		SeekSeconds:            c.SeekSeconds,
+		StreamOriginSeconds:    c.StreamOriginSeconds,
+		CopySeekAnchorResolved: c.CopySeekAnchorResolved,
+		TargetResolution:       c.TargetRes,
+		TargetCodecVideo:       c.TargetCodec,
+		TargetCodecAudio:       c.TargetCodecAudio,
+		SegmentDuration:        c.SegmentDuration,
+		StartSegmentNumber:     c.StartSegmentNumber,
+		SubtitleTrackIndex:     c.SubtitleTrackIndex,
+		SubtitleBurnIn:         c.SubtitleBurnIn,
+		SubtitleCodec:          c.SubtitleCodec,
+		AudioTrackIndex:        c.AudioTrackIndex,
+		TargetBitrateKbps:      c.TargetBitrateKbps,
+		TotalDuration:          c.TotalDuration,
+		FastStart:              c.FastStart,
 	}
 }

--- a/internal/playback/recipecard_test.go
+++ b/internal/playback/recipecard_test.go
@@ -9,26 +9,28 @@ import (
 
 func TestRecipeCardRoundTripOpts(t *testing.T) {
 	opts := TranscodeOpts{
-		InputPath:            "/media/movie.mkv",
-		OutputDir:            "/tmp/silo-transcode/abc",
-		SessionID:            "abc",
-		SourceVideoCodec:     "hevc",
-		VideoBitstreamFilter: "dovi_rpu=strip=1",
-		SeekSeconds:          900,
-		TargetResolution:     "1080p",
-		TargetCodecVideo:     "h264",
-		TargetCodecAudio:     "aac",
-		SegmentDuration:      2,
-		StartSegmentNumber:   450,
-		HWAccel:              "qsv",
-		HWDevice:             "/dev/dri/renderD128",
-		SubtitleTrackIndex:   3,
-		SubtitleBurnIn:       true,
-		SubtitleCodec:        "hdmv_pgs_subtitle",
-		AudioTrackIndex:      1,
-		TargetBitrateKbps:    8000,
-		TotalDuration:        7200,
-		FastStart:            true,
+		InputPath:              "/media/movie.mkv",
+		OutputDir:              "/tmp/silo-transcode/abc",
+		SessionID:              "abc",
+		SourceVideoCodec:       "hevc",
+		VideoBitstreamFilter:   "dovi_rpu=strip=1",
+		SeekSeconds:            900,
+		StreamOriginSeconds:    896,
+		CopySeekAnchorResolved: true,
+		TargetResolution:       "1080p",
+		TargetCodecVideo:       "h264",
+		TargetCodecAudio:       "aac",
+		SegmentDuration:        2,
+		StartSegmentNumber:     450,
+		HWAccel:                "qsv",
+		HWDevice:               "/dev/dri/renderD128",
+		SubtitleTrackIndex:     3,
+		SubtitleBurnIn:         true,
+		SubtitleCodec:          "hdmv_pgs_subtitle",
+		AudioTrackIndex:        1,
+		TargetBitrateKbps:      8000,
+		TotalDuration:          7200,
+		FastStart:              true,
 	}
 
 	card := NewRecipeCard(42, "profile-1", 77, "", opts)
@@ -43,6 +45,9 @@ func TestRecipeCardRoundTripOpts(t *testing.T) {
 	}
 	if got.SeekSeconds != 900 {
 		t.Errorf("SeekSeconds = %v, want 900", got.SeekSeconds)
+	}
+	if got.StreamOriginSeconds != 896 || !got.CopySeekAnchorResolved {
+		t.Errorf("copy seek anchor lost: origin=%v resolved=%v", got.StreamOriginSeconds, got.CopySeekAnchorResolved)
 	}
 	if !got.SubtitleBurnIn {
 		t.Errorf("SubtitleBurnIn lost in round trip")
@@ -101,23 +106,25 @@ func TestRecipeCardLegacyDecodeHasEmptyPlayMethod(t *testing.T) {
 // not asserted here.
 func TestRecipeCardClaimsRoundTrip(t *testing.T) {
 	card := NewRecipeCard(42, "profile-1", 77, "http://node:9000", TranscodeOpts{
-		InputPath:            "/media/movie.mkv",
-		SessionID:            "abc",
-		SourceVideoCodec:     "hevc",
-		VideoBitstreamFilter: "dovi_rpu=strip=1",
-		SeekSeconds:          900,
-		TargetResolution:     "1080p",
-		TargetCodecVideo:     "h264",
-		TargetCodecAudio:     "aac",
-		SegmentDuration:      2,
-		StartSegmentNumber:   450,
-		SubtitleTrackIndex:   3,
-		SubtitleBurnIn:       true,
-		SubtitleCodec:        "hdmv_pgs_subtitle",
-		AudioTrackIndex:      1,
-		TargetBitrateKbps:    8000,
-		TotalDuration:        7200,
-		FastStart:            true,
+		InputPath:              "/media/movie.mkv",
+		SessionID:              "abc",
+		SourceVideoCodec:       "hevc",
+		VideoBitstreamFilter:   "dovi_rpu=strip=1",
+		SeekSeconds:            900,
+		StreamOriginSeconds:    896,
+		CopySeekAnchorResolved: true,
+		TargetResolution:       "1080p",
+		TargetCodecVideo:       "h264",
+		TargetCodecAudio:       "aac",
+		SegmentDuration:        2,
+		StartSegmentNumber:     450,
+		SubtitleTrackIndex:     3,
+		SubtitleBurnIn:         true,
+		SubtitleCodec:          "hdmv_pgs_subtitle",
+		AudioTrackIndex:        1,
+		TargetBitrateKbps:      8000,
+		TotalDuration:          7200,
+		FastStart:              true,
 	})
 
 	claims := card.ToClaims()
@@ -132,7 +139,8 @@ func TestRecipeCardClaimsRoundTrip(t *testing.T) {
 	// Byte-affecting encode parameters.
 	if got.InputPath != card.InputPath || got.SourceVideoCodec != card.SourceVideoCodec ||
 		got.VideoBitstreamFilter != card.VideoBitstreamFilter ||
-		got.SeekSeconds != card.SeekSeconds || got.TargetResolution != card.TargetResolution ||
+		got.SeekSeconds != card.SeekSeconds || got.StreamOriginSeconds != card.StreamOriginSeconds ||
+		got.CopySeekAnchorResolved != card.CopySeekAnchorResolved || got.TargetResolution != card.TargetResolution ||
 		got.TargetCodecVideo != card.TargetCodecVideo || got.TargetCodecAudio != card.TargetCodecAudio ||
 		got.SegmentDuration != card.SegmentDuration || got.StartSegmentNumber != card.StartSegmentNumber ||
 		got.SubtitleTrackIndex != card.SubtitleTrackIndex || got.SubtitleBurnIn != card.SubtitleBurnIn ||

--- a/internal/playback/session.go
+++ b/internal/playback/session.go
@@ -93,6 +93,14 @@ type SessionStreamState struct {
 	SegmentDuration    int
 }
 
+// TranscodeRoute identifies the process serving a playback session. An empty
+// NodeURL means the integrated server owns the process; an empty TransportID
+// means a remote process uses the public playback session ID.
+type TranscodeRoute struct {
+	NodeURL     string
+	TransportID string
+}
+
 // SessionReplacement is the complete mutable session state associated with a
 // protocol-v3 replacement plan. Position is optional because ordinary failure
 // recovery must preserve the player's latest progress while seek recovery
@@ -834,6 +842,36 @@ func (m *SessionManager) ApplyReplacement(sessionID string, replacement SessionR
 	if !ok {
 		return SessionReplacementRollback{}, ErrSessionNotFound
 	}
+	return m.applyReplacementLocked(s, sessionID, replacement)
+}
+
+// ApplyReplacementIfRoute applies a complete replacement only while the
+// session still routes to expected. It publishes route and stream state in one
+// critical section so callers never expose a successor with predecessor state.
+func (m *SessionManager) ApplyReplacementIfRoute(
+	sessionID string,
+	expected TranscodeRoute,
+	replacement SessionReplacement,
+) (SessionReplacementRollback, bool, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	s, ok := m.sessions[sessionID]
+	if !ok {
+		return SessionReplacementRollback{}, false, ErrSessionNotFound
+	}
+	if s.TranscodeNodeURL != expected.NodeURL || s.TranscodeTransportID != expected.TransportID {
+		return SessionReplacementRollback{}, false, nil
+	}
+	rollback, err := m.applyReplacementLocked(s, sessionID, replacement)
+	return rollback, err == nil, err
+}
+
+func (m *SessionManager) applyReplacementLocked(
+	s *Session,
+	sessionID string,
+	replacement SessionReplacement,
+) (SessionReplacementRollback, error) {
 	if replacement.EffectiveMediaFileID <= 0 {
 		return SessionReplacementRollback{}, errors.New("replacement effective media file id is invalid")
 	}
@@ -905,11 +943,9 @@ func (m *SessionManager) SetTranscodeNodeURL(sessionID, url string) error {
 	return nil
 }
 
-// SetTranscodeRoute atomically assigns the remote node and process identity
-// used to serve a transcode. Legacy remote replacements prepare a successor
-// under a distinct transport ID, then publish both values together only after
-// the node accepts it.
-func (m *SessionManager) SetTranscodeRoute(sessionID, nodeURL, transportID string) error {
+// SetTranscodeRoute atomically assigns the node and process identity used to
+// serve a transcode.
+func (m *SessionManager) SetTranscodeRoute(sessionID string, route TranscodeRoute) error {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 
@@ -918,39 +954,11 @@ func (m *SessionManager) SetTranscodeRoute(sessionID, nodeURL, transportID strin
 		return ErrSessionNotFound
 	}
 
-	s.TranscodeNodeURL = nodeURL
-	s.TranscodeTransportID = transportID
+	s.TranscodeNodeURL = route.NodeURL
+	s.TranscodeTransportID = route.TransportID
 	s.streamRevision++
 	m.touchSessionLocked(s)
 	return nil
-}
-
-// SetTranscodeRouteIf atomically publishes a route only while the session still
-// points at the predecessor the caller prepared against. A false result means
-// another replacement won and the caller must reap its uncommitted transport.
-func (m *SessionManager) SetTranscodeRouteIf(
-	sessionID string,
-	expectedNodeURL string,
-	expectedTransportID string,
-	nodeURL string,
-	transportID string,
-) (bool, error) {
-	m.mu.Lock()
-	defer m.mu.Unlock()
-
-	s, ok := m.sessions[sessionID]
-	if !ok {
-		return false, ErrSessionNotFound
-	}
-	if s.TranscodeNodeURL != expectedNodeURL || s.TranscodeTransportID != expectedTransportID {
-		return false, nil
-	}
-
-	s.TranscodeNodeURL = nodeURL
-	s.TranscodeTransportID = transportID
-	s.streamRevision++
-	m.touchSessionLocked(s)
-	return true, nil
 }
 
 // SetEffectiveMediaFileID updates the currently delivered source file while

--- a/internal/playback/session.go
+++ b/internal/playback/session.go
@@ -905,6 +905,54 @@ func (m *SessionManager) SetTranscodeNodeURL(sessionID, url string) error {
 	return nil
 }
 
+// SetTranscodeRoute atomically assigns the remote node and process identity
+// used to serve a transcode. Legacy remote replacements prepare a successor
+// under a distinct transport ID, then publish both values together only after
+// the node accepts it.
+func (m *SessionManager) SetTranscodeRoute(sessionID, nodeURL, transportID string) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	s, ok := m.sessions[sessionID]
+	if !ok {
+		return ErrSessionNotFound
+	}
+
+	s.TranscodeNodeURL = nodeURL
+	s.TranscodeTransportID = transportID
+	s.streamRevision++
+	m.touchSessionLocked(s)
+	return nil
+}
+
+// SetTranscodeRouteIf atomically publishes a route only while the session still
+// points at the predecessor the caller prepared against. A false result means
+// another replacement won and the caller must reap its uncommitted transport.
+func (m *SessionManager) SetTranscodeRouteIf(
+	sessionID string,
+	expectedNodeURL string,
+	expectedTransportID string,
+	nodeURL string,
+	transportID string,
+) (bool, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	s, ok := m.sessions[sessionID]
+	if !ok {
+		return false, ErrSessionNotFound
+	}
+	if s.TranscodeNodeURL != expectedNodeURL || s.TranscodeTransportID != expectedTransportID {
+		return false, nil
+	}
+
+	s.TranscodeNodeURL = nodeURL
+	s.TranscodeTransportID = transportID
+	s.streamRevision++
+	m.touchSessionLocked(s)
+	return true, nil
+}
+
 // SetEffectiveMediaFileID updates the currently delivered source file while
 // preserving the originally requested file selection.
 func (m *SessionManager) SetEffectiveMediaFileID(sessionID string, fileID int) error {

--- a/internal/playback/session_test.go
+++ b/internal/playback/session_test.go
@@ -668,7 +668,7 @@ func TestSetTranscodeRoutePublishesNodeAndTransportTogether(t *testing.T) {
 		t.Fatalf("StartSession: %v", err)
 	}
 
-	if err := mgr.SetTranscodeRoute(session.ID, "http://node:8070", session.ID+"-legacy-next"); err != nil {
+	if err := mgr.SetTranscodeRoute(session.ID, playback.TranscodeRoute{NodeURL: "http://node:8070", TransportID: session.ID + "-legacy-next"}); err != nil {
 		t.Fatalf("SetTranscodeRoute: %v", err)
 	}
 	got, err := mgr.GetSession(session.ID)
@@ -680,39 +680,47 @@ func TestSetTranscodeRoutePublishesNodeAndTransportTogether(t *testing.T) {
 	}
 }
 
-func TestSetTranscodeRouteIfRejectsStalePredecessor(t *testing.T) {
+func TestApplyReplacementIfRouteRejectsStalePredecessor(t *testing.T) {
 	mgr := playback.NewSessionManager(0, 0)
 	session, err := mgr.StartSession(1, "profile-1", 42, playback.PlayRemux, true)
 	if err != nil {
 		t.Fatalf("StartSession: %v", err)
 	}
-	if err := mgr.SetTranscodeRoute(session.ID, "http://old-node", "old-transport"); err != nil {
+	if err := mgr.SetTranscodeRoute(session.ID, playback.TranscodeRoute{NodeURL: "http://old-node", TransportID: "old-transport"}); err != nil {
 		t.Fatalf("SetTranscodeRoute: %v", err)
 	}
+	replacement := playback.SessionReplacement{
+		EffectiveMediaFileID: 42,
+		StreamState: playback.SessionStreamState{
+			PlayMethod:           playback.PlayTranscode,
+			BasePlayMethod:       playback.PlayRemux,
+			TranscodeAudio:       true,
+			TranscodeRouteSet:    true,
+			SubtitleTrackIndex:   -1,
+			TranscodeNodeURL:     "http://new-node",
+			TranscodeTransportID: "new-transport",
+		},
+	}
 
-	published, err := mgr.SetTranscodeRouteIf(
+	_, published, err := mgr.ApplyReplacementIfRoute(
 		session.ID,
-		"http://stale-node",
-		"stale-transport",
-		"http://new-node",
-		"new-transport",
+		playback.TranscodeRoute{NodeURL: "http://stale-node", TransportID: "stale-transport"},
+		replacement,
 	)
 	if err != nil {
-		t.Fatalf("SetTranscodeRouteIf stale: %v", err)
+		t.Fatalf("ApplyReplacementIfRoute stale: %v", err)
 	}
 	if published {
 		t.Fatal("stale predecessor unexpectedly published a replacement")
 	}
 
-	published, err = mgr.SetTranscodeRouteIf(
+	_, published, err = mgr.ApplyReplacementIfRoute(
 		session.ID,
-		"http://old-node",
-		"old-transport",
-		"http://new-node",
-		"new-transport",
+		playback.TranscodeRoute{NodeURL: "http://old-node", TransportID: "old-transport"},
+		replacement,
 	)
 	if err != nil {
-		t.Fatalf("SetTranscodeRouteIf current: %v", err)
+		t.Fatalf("ApplyReplacementIfRoute current: %v", err)
 	}
 	if !published {
 		t.Fatal("current predecessor did not publish its replacement")

--- a/internal/playback/session_test.go
+++ b/internal/playback/session_test.go
@@ -661,6 +661,71 @@ func TestSetTranscodeNodeURL_NotFound(t *testing.T) {
 	}
 }
 
+func TestSetTranscodeRoutePublishesNodeAndTransportTogether(t *testing.T) {
+	mgr := playback.NewSessionManager(0, 0)
+	session, err := mgr.StartSession(1, "profile-1", 42, playback.PlayRemux, true)
+	if err != nil {
+		t.Fatalf("StartSession: %v", err)
+	}
+
+	if err := mgr.SetTranscodeRoute(session.ID, "http://node:8070", session.ID+"-legacy-next"); err != nil {
+		t.Fatalf("SetTranscodeRoute: %v", err)
+	}
+	got, err := mgr.GetSession(session.ID)
+	if err != nil {
+		t.Fatalf("GetSession: %v", err)
+	}
+	if got.TranscodeNodeURL != "http://node:8070" || got.TranscodeTransportID != session.ID+"-legacy-next" {
+		t.Fatalf("transcode route = %q/%q", got.TranscodeNodeURL, got.TranscodeTransportID)
+	}
+}
+
+func TestSetTranscodeRouteIfRejectsStalePredecessor(t *testing.T) {
+	mgr := playback.NewSessionManager(0, 0)
+	session, err := mgr.StartSession(1, "profile-1", 42, playback.PlayRemux, true)
+	if err != nil {
+		t.Fatalf("StartSession: %v", err)
+	}
+	if err := mgr.SetTranscodeRoute(session.ID, "http://old-node", "old-transport"); err != nil {
+		t.Fatalf("SetTranscodeRoute: %v", err)
+	}
+
+	published, err := mgr.SetTranscodeRouteIf(
+		session.ID,
+		"http://stale-node",
+		"stale-transport",
+		"http://new-node",
+		"new-transport",
+	)
+	if err != nil {
+		t.Fatalf("SetTranscodeRouteIf stale: %v", err)
+	}
+	if published {
+		t.Fatal("stale predecessor unexpectedly published a replacement")
+	}
+
+	published, err = mgr.SetTranscodeRouteIf(
+		session.ID,
+		"http://old-node",
+		"old-transport",
+		"http://new-node",
+		"new-transport",
+	)
+	if err != nil {
+		t.Fatalf("SetTranscodeRouteIf current: %v", err)
+	}
+	if !published {
+		t.Fatal("current predecessor did not publish its replacement")
+	}
+	got, err := mgr.GetSession(session.ID)
+	if err != nil {
+		t.Fatalf("GetSession: %v", err)
+	}
+	if got.TranscodeNodeURL != "http://new-node" || got.TranscodeTransportID != "new-transport" {
+		t.Fatalf("transcode route = %q/%q", got.TranscodeNodeURL, got.TranscodeTransportID)
+	}
+}
+
 func TestSetEffectiveMediaFileID(t *testing.T) {
 	mgr := playback.NewSessionManager(0, 0)
 	session, err := mgr.StartSession(1, "profile-1", 100, playback.PlayDirect, false)

--- a/internal/playback/transcode.go
+++ b/internal/playback/transcode.go
@@ -38,16 +38,24 @@ type TranscodeOpts struct {
 	SourceVideoCodec     string
 	VideoBitstreamFilter string // validated copy-mode BSF, e.g. dovi_rpu=strip=1
 	SeekSeconds          float64
-	TargetResolution     string // e.g., 1080p, 720p
-	TargetCodecVideo     string // e.g., h264 (or hevc if allowed)
-	TargetCodecAudio     string // e.g., aac
-	SegmentDuration      int    // seconds, default 6
-	StartSegmentNumber   int    // -hls_segment_start_number, default 0
-	FFmpegPath           string // optional explicit ffmpeg binary path
-	HWAccel              string // auto, qsv, vaapi, nvenc, none
-	HWDevice             string // e.g., /dev/dri/renderD128 (default if empty)
-	SubtitleTrackIndex   int    // -1 = no subtitles
-	SubtitleBurnIn       bool
+	// StreamOriginSeconds is the keyframe timestamp at which a copy-video
+	// stream actually begins. SeekSeconds remains the client-requested -ss so
+	// FFmpeg performs exactly one demuxer seek; this origin keeps response and
+	// reconstruction timelines aligned with the resulting media pre-roll.
+	StreamOriginSeconds float64
+	// CopySeekAnchorResolved distinguishes a valid zero-second origin from
+	// older/shared recipes that never resolved a copy seek anchor.
+	CopySeekAnchorResolved bool
+	TargetResolution       string // e.g., 1080p, 720p
+	TargetCodecVideo       string // e.g., h264 (or hevc if allowed)
+	TargetCodecAudio       string // e.g., aac
+	SegmentDuration        int    // seconds, default 6
+	StartSegmentNumber     int    // -hls_segment_start_number, default 0
+	FFmpegPath             string // optional explicit ffmpeg binary path
+	HWAccel                string // auto, qsv, vaapi, nvenc, none
+	HWDevice               string // e.g., /dev/dri/renderD128 (default if empty)
+	SubtitleTrackIndex     int    // -1 = no subtitles
+	SubtitleBurnIn         bool
 	// SubtitleCodec is the probed codec of the burn-in track (e.g. "subrip",
 	// "hdmv_pgs_subtitle"). Bitmap codecs (PGS/DVD/DVB) select the overlay
 	// filter_complex pipeline; text codecs use the libass subtitles filter.
@@ -1521,6 +1529,28 @@ func (s *TranscodeSession) cleanStaleSegments(startSegment int) {
 // copy-mode sessions, stale segments at or after the restart point are
 // cleaned to prevent serving data from the wrong timeline position.
 func (s *TranscodeSession) Restart(ctx context.Context, seekSeconds float64, startSegment int) error {
+	return s.restart(ctx, seekSeconds, startSegment, 0, false)
+}
+
+// RestartWithCopySeekAnchor restarts a copy-video stream with the keyframe
+// origin resolved for this specific seek. Keeping this metadata explicit
+// prevents a prior seek's origin from being reused after an audio switch.
+func (s *TranscodeSession) RestartWithCopySeekAnchor(
+	ctx context.Context,
+	seekSeconds float64,
+	startSegment int,
+	streamOriginSeconds float64,
+) error {
+	return s.restart(ctx, seekSeconds, startSegment, streamOriginSeconds, true)
+}
+
+func (s *TranscodeSession) restart(
+	ctx context.Context,
+	seekSeconds float64,
+	startSegment int,
+	streamOriginSeconds float64,
+	copySeekAnchorResolved bool,
+) error {
 	s.mu.Lock()
 	// Single-flight: a second caller arriving while a restart is in
 	// progress must not kill the process the first restart just started.
@@ -1562,6 +1592,14 @@ func (s *TranscodeSession) Restart(ctx context.Context, seekSeconds float64, sta
 
 	opts.SeekSeconds = seekSeconds
 	opts.StartSegmentNumber = startSegment
+	if strings.EqualFold(opts.TargetCodecVideo, "copy") {
+		// A seek restart describes a new emitted timeline. Never retain the
+		// previous copy seek's keyframe origin when the caller has not resolved
+		// a replacement; falling back to SeekSeconds is conservative and matches
+		// the behavior of recipes created before copy anchors were introduced.
+		opts.StreamOriginSeconds = streamOriginSeconds
+		opts.CopySeekAnchorResolved = copySeekAnchorResolved
+	}
 	opts.FastStart = false // seek-restarts use veryfast for better quality
 
 	args := buildFFmpegArgs(opts)
@@ -1859,6 +1897,9 @@ func (s *TranscodeSession) SegmentStartTime(segNum int) (float64, bool, error) {
 	s.mu.Lock()
 	manifestPath := filepath.Join(s.outputDir, "stream.m3u8")
 	baseSeekSeconds := s.opts.SeekSeconds
+	if strings.EqualFold(s.opts.TargetCodecVideo, "copy") && s.opts.CopySeekAnchorResolved {
+		baseSeekSeconds = s.opts.StreamOriginSeconds
+	}
 	s.mu.Unlock()
 
 	manifest, err := os.ReadFile(manifestPath)

--- a/internal/playback/transcode_manager.go
+++ b/internal/playback/transcode_manager.go
@@ -198,6 +198,23 @@ func (m *TranscodeManager) SwapTranscodeSession(sessionID string, successor *Tra
 	return predecessor
 }
 
+// SwapTranscodeSessionIf publishes successor only while the live map still
+// contains expected. Callers use it after staging a process in a distinct
+// output directory so a stale replacement cannot overwrite a newer process.
+func (m *TranscodeManager) SwapTranscodeSessionIf(
+	sessionID string,
+	expected *TranscodeSession,
+	successor *TranscodeSession,
+) bool {
+	m.transcodeMu.Lock()
+	defer m.transcodeMu.Unlock()
+	if m.transcodes[sessionID] != expected {
+		return false
+	}
+	m.transcodes[sessionID] = successor
+	return true
+}
+
 // StopRemoteTranscode removes only the remote node process. It deliberately
 // leaves the local live-map entry untouched for an atomic remote-to-local v3
 // replacement.

--- a/internal/playback/transcode_manager.go
+++ b/internal/playback/transcode_manager.go
@@ -246,12 +246,33 @@ func (m *TranscodeManager) LockSessionLifecycle(sessionID string) func() {
 // replaced it, the stale handle is not re-spawned and ErrSessionSuperseded is
 // returned.
 func (m *TranscodeManager) RestartSessionLocked(ctx context.Context, sessionID string, ts *TranscodeSession, seekSeconds float64, startSegment int) error {
+	return m.restartSessionLocked(sessionID, ts, func() error {
+		return ts.Restart(ctx, seekSeconds, startSegment)
+	})
+}
+
+func (m *TranscodeManager) restartSessionLocked(sessionID string, ts *TranscodeSession, restart func() error) error {
 	unlock := m.LockSessionLifecycle(sessionID)
 	defer unlock()
 	if live := m.GetTranscodeSession(sessionID); live != ts {
 		return ErrSessionSuperseded
 	}
-	return ts.Restart(ctx, seekSeconds, startSegment)
+	return restart()
+}
+
+// RestartSessionLockedWithCopySeekAnchor is RestartSessionLocked with the
+// resolved keyframe origin for a legacy copy-video seek restart.
+func (m *TranscodeManager) RestartSessionLockedWithCopySeekAnchor(
+	ctx context.Context,
+	sessionID string,
+	ts *TranscodeSession,
+	seekSeconds float64,
+	startSegment int,
+	streamOriginSeconds float64,
+) error {
+	return m.restartSessionLocked(sessionID, ts, func() error {
+		return ts.RestartWithCopySeekAnchor(ctx, seekSeconds, startSegment, streamOriginSeconds)
+	})
 }
 
 // markReconstructing records that sessionID's ffmpeg is mid-reconstruct and

--- a/internal/playback/transcode_manifest_test.go
+++ b/internal/playback/transcode_manifest_test.go
@@ -300,9 +300,12 @@ func TestRestartSeekTarget_CopyModeUsesManifestTimelineWhenAvailable(t *testing.
 	session := &TranscodeSession{
 		outputDir: tempDir,
 		opts: TranscodeOpts{
-			SeekSeconds:      18.261,
-			TargetCodecVideo: "copy",
-			SegmentDuration:  2,
+			SeekSeconds:            18.261,
+			StreamOriginSeconds:    18,
+			CopySeekAnchorResolved: true,
+			TargetCodecVideo:       "copy",
+			SegmentDuration:        2,
+			StartSegmentNumber:     9,
 		},
 	}
 
@@ -313,8 +316,8 @@ func TestRestartSeekTarget_CopyModeUsesManifestTimelineWhenAvailable(t *testing.
 	if !ok {
 		t.Fatal("RestartSeekTarget returned ok=false")
 	}
-	if math.Abs(got-20.93) > 0.0001 {
-		t.Fatalf("RestartSeekTarget(10) = %.6f, want 20.93", got)
+	if math.Abs(got-20.669) > 0.0001 {
+		t.Fatalf("RestartSeekTarget(10) = %.6f, want 20.669", got)
 	}
 }
 

--- a/internal/playback/transcode_restart_guard_test.go
+++ b/internal/playback/transcode_restart_guard_test.go
@@ -74,6 +74,47 @@ func TestRestartInvokesRestartHook(t *testing.T) {
 	}
 }
 
+func TestRestartCopySeekOriginIsReplacedOrCleared(t *testing.T) {
+	truePath, err := exec.LookPath("true")
+	if err != nil {
+		t.Skipf("`true` not found in PATH: %v", err)
+	}
+
+	newSession := func() *TranscodeSession {
+		return &TranscodeSession{
+			outputDir: t.TempDir(),
+			opts: TranscodeOpts{
+				TargetCodecVideo:       "copy",
+				SegmentDuration:        2,
+				SeekSeconds:            18,
+				StreamOriginSeconds:    10,
+				CopySeekAnchorResolved: true,
+				StartSegmentNumber:     5,
+				FFmpegPath:             truePath,
+			},
+		}
+	}
+
+	resolved := newSession()
+	if err := resolved.RestartWithCopySeekAnchor(context.Background(), 100, 48, 96); err != nil {
+		t.Fatalf("RestartWithCopySeekAnchor: %v", err)
+	}
+	resolvedOpts := resolved.Opts()
+	if resolvedOpts.SeekSeconds != 100 || resolvedOpts.StreamOriginSeconds != 96 ||
+		!resolvedOpts.CopySeekAnchorResolved || resolvedOpts.StartSegmentNumber != 48 {
+		t.Fatalf("resolved restart opts = %+v", resolvedOpts)
+	}
+
+	unresolved := newSession()
+	if err := unresolved.Restart(context.Background(), 100, 50); err != nil {
+		t.Fatalf("Restart: %v", err)
+	}
+	unresolvedOpts := unresolved.Opts()
+	if unresolvedOpts.StreamOriginSeconds != 0 || unresolvedOpts.CopySeekAnchorResolved {
+		t.Fatalf("generic restart retained stale copy origin: %+v", unresolvedOpts)
+	}
+}
+
 // TestRestartIsSingleFlight covers the other half: Restart must be
 // single-flight per session. A second caller arriving while a restart is in
 // progress must return immediately without killing the process the first

--- a/internal/streamtoken/token.go
+++ b/internal/streamtoken/token.go
@@ -46,19 +46,21 @@ type Claims struct {
 	// Reconstruction recipe — the byte-affecting encode parameters, mirroring the
 	// former playback.RecipeCard. Zero for direct/remux tokens, which reconstruct
 	// from identity alone plus the client-supplied position.
-	SourceVideoCodec     string  `json:"svc,omitempty"`
-	VideoBitstreamFilter string  `json:"vbsf,omitempty"`
-	OutputSubdir         string  `json:"osd,omitempty"`
-	SeekSeconds          float64 `json:"seek,omitempty"`
-	SegmentDuration      int     `json:"segd,omitempty"`
-	StartSegmentNumber   int     `json:"ssn,omitempty"`
-	SubtitleTrackIndex   int     `json:"sti,omitempty"`
-	SubtitleBurnIn       bool    `json:"sbi,omitempty"`
-	SubtitleCodec        string  `json:"sbc,omitempty"`
-	TargetBitrateKbps    int     `json:"tbr,omitempty"`
-	TotalDuration        float64 `json:"dur,omitempty"`
-	FastStart            bool    `json:"fs,omitempty"`
-	TargetCodecAudio     string  `json:"tca,omitempty"`
+	SourceVideoCodec       string  `json:"svc,omitempty"`
+	VideoBitstreamFilter   string  `json:"vbsf,omitempty"`
+	OutputSubdir           string  `json:"osd,omitempty"`
+	SeekSeconds            float64 `json:"seek,omitempty"`
+	StreamOriginSeconds    float64 `json:"origin,omitempty"`
+	CopySeekAnchorResolved bool    `json:"origin_ok,omitempty"`
+	SegmentDuration        int     `json:"segd,omitempty"`
+	StartSegmentNumber     int     `json:"ssn,omitempty"`
+	SubtitleTrackIndex     int     `json:"sti,omitempty"`
+	SubtitleBurnIn         bool    `json:"sbi,omitempty"`
+	SubtitleCodec          string  `json:"sbc,omitempty"`
+	TargetBitrateKbps      int     `json:"tbr,omitempty"`
+	TotalDuration          float64 `json:"dur,omitempty"`
+	FastStart              bool    `json:"fs,omitempty"`
+	TargetCodecAudio       string  `json:"tca,omitempty"`
 
 	// Recipe staleness hint, bumped on each re-mint after a recipe mutation
 	// (audio/quality/seek switch). An optional client-side hint only.

--- a/internal/transcodenode/server.go
+++ b/internal/transcodenode/server.go
@@ -27,25 +27,27 @@ import (
 
 // TranscodeStartRequest is the JSON body for POST /transcode/start.
 type TranscodeStartRequest struct {
-	SessionID            string  `json:"session_id"`
-	InputPath            string  `json:"input_path"`
-	SourceVideoCodec     string  `json:"source_video_codec"`
-	VideoBitstreamFilter string  `json:"video_bitstream_filter,omitempty"`
-	SeekSeconds          float64 `json:"seek_seconds"`
-	StartSegmentNumber   int     `json:"start_segment_number"`
-	TargetResolution     string  `json:"target_resolution"`
-	TargetCodecVideo     string  `json:"target_codec_video"`
-	TargetCodecAudio     string  `json:"target_codec_audio"`
-	TargetAudioChannels  int     `json:"target_audio_channels,omitempty"`
-	TargetBitrateKbps    int     `json:"target_bitrate_kbps"`
-	SegmentDuration      int     `json:"segment_duration"`
-	HWAccel              string  `json:"hw_accel"`
-	AudioTrackIndex      int     `json:"audio_track_index"`
-	SubtitleTrackIndex   int     `json:"subtitle_track_index"`
-	SubtitleBurnIn       bool    `json:"subtitle_burn_in"`
-	SubtitleCodec        string  `json:"subtitle_codec,omitempty"`
-	TotalDuration        float64 `json:"total_duration"`
-	RequireReady         bool    `json:"require_ready,omitempty"`
+	SessionID              string  `json:"session_id"`
+	InputPath              string  `json:"input_path"`
+	SourceVideoCodec       string  `json:"source_video_codec"`
+	VideoBitstreamFilter   string  `json:"video_bitstream_filter,omitempty"`
+	SeekSeconds            float64 `json:"seek_seconds"`
+	StreamOriginSeconds    float64 `json:"stream_origin_seconds,omitempty"`
+	CopySeekAnchorResolved bool    `json:"copy_seek_anchor_resolved,omitempty"`
+	StartSegmentNumber     int     `json:"start_segment_number"`
+	TargetResolution       string  `json:"target_resolution"`
+	TargetCodecVideo       string  `json:"target_codec_video"`
+	TargetCodecAudio       string  `json:"target_codec_audio"`
+	TargetAudioChannels    int     `json:"target_audio_channels,omitempty"`
+	TargetBitrateKbps      int     `json:"target_bitrate_kbps"`
+	SegmentDuration        int     `json:"segment_duration"`
+	HWAccel                string  `json:"hw_accel"`
+	AudioTrackIndex        int     `json:"audio_track_index"`
+	SubtitleTrackIndex     int     `json:"subtitle_track_index"`
+	SubtitleBurnIn         bool    `json:"subtitle_burn_in"`
+	SubtitleCodec          string  `json:"subtitle_codec,omitempty"`
+	TotalDuration          float64 `json:"total_duration"`
+	RequireReady           bool    `json:"require_ready,omitempty"`
 }
 
 // TranscodeStartResponse is the JSON response for POST /transcode/start.
@@ -474,31 +476,33 @@ func (s *Server) handleStart(w http.ResponseWriter, r *http.Request) {
 	outputDir := filepath.Join(cfg.Playback.TranscodeDir, req.SessionID)
 
 	opts := playback.TranscodeOpts{
-		InputPath:            req.InputPath,
-		OutputDir:            outputDir,
-		SessionID:            req.SessionID,
-		SourceVideoCodec:     req.SourceVideoCodec,
-		VideoBitstreamFilter: req.VideoBitstreamFilter,
-		SeekSeconds:          req.SeekSeconds,
-		StartSegmentNumber:   req.StartSegmentNumber,
-		TargetResolution:     req.TargetResolution,
-		TargetCodecVideo:     req.TargetCodecVideo,
-		TargetCodecAudio:     req.TargetCodecAudio,
-		TargetAudioChannels:  req.TargetAudioChannels,
-		TargetBitrateKbps:    req.TargetBitrateKbps,
-		SegmentDuration:      req.SegmentDuration,
-		FFmpegPath:           cfg.Playback.FFmpegPath,
-		HWAccel:              req.HWAccel,
-		HWDevice:             "",
-		AudioTrackIndex:      req.AudioTrackIndex,
-		SubtitleTrackIndex:   req.SubtitleTrackIndex,
-		SubtitleBurnIn:       req.SubtitleBurnIn,
-		SubtitleCodec:        req.SubtitleCodec,
-		TotalDuration:        req.TotalDuration,
-		FastStart:            true,
-		NodeType:             "transcode",
-		ExecutionMode:        "transcode_node",
-		FFmpegLogSink:        s.ffmpegSink,
+		InputPath:              req.InputPath,
+		OutputDir:              outputDir,
+		SessionID:              req.SessionID,
+		SourceVideoCodec:       req.SourceVideoCodec,
+		VideoBitstreamFilter:   req.VideoBitstreamFilter,
+		SeekSeconds:            req.SeekSeconds,
+		StreamOriginSeconds:    req.StreamOriginSeconds,
+		CopySeekAnchorResolved: req.CopySeekAnchorResolved,
+		StartSegmentNumber:     req.StartSegmentNumber,
+		TargetResolution:       req.TargetResolution,
+		TargetCodecVideo:       req.TargetCodecVideo,
+		TargetCodecAudio:       req.TargetCodecAudio,
+		TargetAudioChannels:    req.TargetAudioChannels,
+		TargetBitrateKbps:      req.TargetBitrateKbps,
+		SegmentDuration:        req.SegmentDuration,
+		FFmpegPath:             cfg.Playback.FFmpegPath,
+		HWAccel:                req.HWAccel,
+		HWDevice:               "",
+		AudioTrackIndex:        req.AudioTrackIndex,
+		SubtitleTrackIndex:     req.SubtitleTrackIndex,
+		SubtitleBurnIn:         req.SubtitleBurnIn,
+		SubtitleCodec:          req.SubtitleCodec,
+		TotalDuration:          req.TotalDuration,
+		FastStart:              true,
+		NodeType:               "transcode",
+		ExecutionMode:          "transcode_node",
+		FFmpegLogSink:          s.ffmpegSink,
 	}
 
 	if opts.HWAccel == "" && cfg.Playback.HWAccel != "" {

--- a/internal/transcodenode/server_test.go
+++ b/internal/transcodenode/server_test.go
@@ -71,6 +71,49 @@ func TestHandleStartRequireReadyRejectsExitedFFmpeg(t *testing.T) {
 	}
 }
 
+func TestHandleStartDistinctReplacementFailurePreservesPredecessor(t *testing.T) {
+	server := newTestServer(t)
+	server.sessions["public-session"] = &playback.TranscodeSession{}
+	server.activeJobs.Store(1)
+
+	ffmpegPath := filepath.Join(t.TempDir(), "failing-ffmpeg.sh")
+	if err := os.WriteFile(ffmpegPath, []byte("#!/bin/sh\nexit 1\n"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	server.watcher.Config().Playback.FFmpegPath = ffmpegPath
+	requestBody, err := json.Marshal(TranscodeStartRequest{
+		SessionID:        "public-session-legacy-replacement",
+		InputPath:        "/media/movie.mkv",
+		TargetCodecVideo: "copy",
+		TargetCodecAudio: "aac",
+		SegmentDuration:  2,
+		RequireReady:     true,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	req := httptest.NewRequest(http.MethodPost, "/transcode/start", bytes.NewReader(requestBody))
+	rr := httptest.NewRecorder()
+	server.handleStart(rr, req)
+	if rr.Code != http.StatusInternalServerError {
+		t.Fatalf("status = %d, body = %s", rr.Code, rr.Body.String())
+	}
+	server.mu.RLock()
+	predecessor := server.sessions["public-session"]
+	_, replacementRegistered := server.sessions["public-session-legacy-replacement"]
+	server.mu.RUnlock()
+	if predecessor == nil {
+		t.Fatal("failed distinct replacement removed the active predecessor")
+	}
+	if replacementRegistered {
+		t.Fatal("failed distinct replacement was registered")
+	}
+	if got := server.activeJobs.Load(); got != 1 {
+		t.Fatalf("active jobs = %d, want predecessor only", got)
+	}
+}
+
 func signCard(t *testing.T, card playback.RecipeCard) string {
 	t.Helper()
 	tok, err := streamtoken.Sign(card.ToClaims(), testSecret, time.Hour)

--- a/web/src/player/components/VideoPlayer.tsx
+++ b/web/src/player/components/VideoPlayer.tsx
@@ -42,6 +42,7 @@ import type {
   PlayerPlaybackStateChange,
   PlayerPlaybackTransport,
   PlaybackSessionPlaybackInfo,
+  PlaybackTransportRestart,
   PlayerAudioTrack,
   PlayerChapter,
   PlayMethod,
@@ -83,6 +84,7 @@ interface VideoPlayerProps {
   onSwitchVersion?: (fileId: number, currentPosition: number) => void;
   subtitleUrls: PlayerSubtitleInfo[];
   initialPosition: number;
+  transportRestart?: PlaybackTransportRestart | null;
   preferredSubtitleLanguage?: string | null;
   preferredSubtitleTrackSignature?: PlayerSubtitleTrackSignature | null;
   subtitleMode?: SubtitleMode;
@@ -173,6 +175,7 @@ export function VideoPlayer({
   onSwitchVersion,
   subtitleUrls,
   initialPosition,
+  transportRestart,
   preferredSubtitleLanguage,
   preferredSubtitleTrackSignature,
   subtitleMode,
@@ -335,6 +338,7 @@ export function VideoPlayer({
     playMethod,
     initialPosition,
     qualityPreference,
+    transportRestart,
   });
 
   // Derive effective stream URL and play method.

--- a/web/src/player/components/WatchPage.tsx
+++ b/web/src/player/components/WatchPage.tsx
@@ -460,6 +460,7 @@ export function WatchPage({
       onSwitchVersion={handleSwitchVersion}
       subtitleUrls={playableSubtitles}
       initialPosition={session.initialPosition}
+      transportRestart={session.transportRestart}
       preferredSubtitleLanguage={preferredSubtitleLanguage}
       preferredSubtitleTrackSignature={preferredSubtitleTrackSignature}
       subtitleMode={subtitleMode}

--- a/web/src/player/hooks/usePlaybackSession.ts
+++ b/web/src/player/hooks/usePlaybackSession.ts
@@ -14,6 +14,7 @@ import type {
   ChangeAudioResponse,
   PlaybackSessionPlaybackInfo,
   PlaybackSessionResponse,
+  PlaybackTransportRestart,
   PlayMethod,
   PlayerFileVersion,
   PlayerPlaybackVariant,
@@ -31,6 +32,7 @@ interface PlaybackSessionState {
   durationSeconds: number | null;
   subtitleUrls: PlayerSubtitleInfo[];
   playbackInfo: PlaybackSessionPlaybackInfo | null;
+  transportRestart: PlaybackTransportRestart | null;
   loading: boolean;
   replacing: boolean;
   errorTitle: string | null;
@@ -215,6 +217,7 @@ export function usePlaybackSession(
     durationSeconds: null,
     subtitleUrls: [],
     playbackInfo: null,
+    transportRestart: null,
     loading: true,
     replacing: false,
     errorTitle: null,
@@ -222,6 +225,7 @@ export function usePlaybackSession(
   });
 
   const sessionIdRef = useRef<string | null>(null);
+  const audioSwitchRevisionRef = useRef(0);
   const stateRef = useRef(state);
   const activeRequestKeyRef = useRef<string | null>(null);
   const switchingRef = useRef(false);
@@ -304,6 +308,7 @@ export function usePlaybackSession(
             : undefined,
         })),
         playbackInfo: session.playback_info ?? null,
+        transportRestart: null,
         loading: false,
         replacing: false,
         errorTitle: null,
@@ -538,19 +543,28 @@ export function usePlaybackSession(
           });
 
           const token = config.getAccessToken();
+          const nextStreamUrl = buildPlayerStreamUrl(
+            config.apiBaseUrl,
+            resp.stream_url,
+            token,
+            resp.play_method,
+            currentPosition,
+          );
+          audioSwitchRevisionRef.current += 1;
           setState((prev) => ({
             ...prev,
-            streamUrl: buildPlayerStreamUrl(
-              config.apiBaseUrl,
-              resp.stream_url,
-              token,
-              resp.play_method,
-              currentPosition,
-            ),
+            streamUrl: nextStreamUrl,
             playMethod: resp.play_method,
             audioTrackIndex: resp.audio_track_index,
             playbackInfo: resp.playback_info ?? prev.playbackInfo,
             initialPosition: currentPosition,
+            transportRestart: {
+              revision: audioSwitchRevisionRef.current,
+              streamUrl: nextStreamUrl,
+              playerStartSeconds: resp.player_start_seconds ?? currentPosition,
+              streamOriginSeconds: resp.stream_origin_seconds ?? resp.timeline_offset_seconds ?? 0,
+              canSeekAnywhere: resp.can_seek_anywhere ?? true,
+            },
           }));
         } catch (err) {
           console.error("Failed to switch audio track:", err);

--- a/web/src/player/hooks/useTranscodeQuality.test.tsx
+++ b/web/src/player/hooks/useTranscodeQuality.test.tsx
@@ -76,6 +76,36 @@ function renderQuality() {
 }
 
 describe("useTranscodeQuality", () => {
+  it("adopts an audio-switch transport without starting another transcode", async () => {
+    const { result } = renderHook(
+      () =>
+        useTranscodeQuality({
+          sessionId: "sess-1",
+          selectedVersion: version,
+          versions: [version],
+          playMethod: "remux",
+          initialPosition: 100,
+          transportRestart: {
+            revision: 1,
+            streamUrl: "/api/v1/playback/transcode/sess-1/master.m3u8?st=token",
+            playerStartSeconds: 4,
+            streamOriginSeconds: 96,
+            canSeekAnywhere: false,
+          },
+        }),
+      { wrapper },
+    );
+
+    await waitFor(() =>
+      expect(result.current.transcodeStreamUrl).toContain("master.m3u8?st=token"),
+    );
+    expect(result.current.playerStartSeconds).toBe(4);
+    expect(result.current.streamOriginSeconds).toBe(96);
+    expect(result.current.canSeekAnywhere).toBe(false);
+    await new Promise((resolve) => setTimeout(resolve, 20));
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
   it("preserves video copy when auto-starting a resumed remux", async () => {
     fetchMock.mockImplementationOnce(() =>
       Promise.resolve(

--- a/web/src/player/hooks/useTranscodeQuality.test.tsx
+++ b/web/src/player/hooks/useTranscodeQuality.test.tsx
@@ -28,7 +28,7 @@ function wrapper({ children }: { children: ReactNode }) {
   return <PlayerConfigProvider config={config}>{children}</PlayerConfigProvider>;
 }
 
-function transcodeStartResponse() {
+function transcodeStartResponse(overrides: Record<string, unknown> = {}) {
   return {
     ok: true,
     status: 200,
@@ -40,6 +40,7 @@ function transcodeStartResponse() {
       player_start_seconds: 0,
       timeline_offset_seconds: 0,
       can_seek_anywhere: true,
+      ...overrides,
     }),
   };
 }
@@ -75,6 +76,40 @@ function renderQuality() {
 }
 
 describe("useTranscodeQuality", () => {
+  it("preserves video copy when auto-starting a resumed remux", async () => {
+    fetchMock.mockImplementationOnce(() =>
+      Promise.resolve(
+        transcodeStartResponse({
+          player_start_seconds: 2.261,
+          stream_origin_seconds: 16,
+          timeline_offset_seconds: 16,
+          can_seek_anywhere: false,
+        }),
+      ),
+    );
+    const { result } = renderHook(
+      () =>
+        useTranscodeQuality({
+          sessionId: "sess-1",
+          selectedVersion: version,
+          versions: [version],
+          playMethod: "remux",
+          initialPosition: 478.25,
+        }),
+      { wrapper },
+    );
+
+    await waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(1));
+    const body = sentBodies()[0]!;
+    expect(body.seek_seconds).toBe(478.25);
+    expect(body.target_codec_video).toBe("copy");
+    expect(body.target_resolution).toBe("");
+    expect(body.target_bitrate_kbps).toBe(0);
+    await waitFor(() => expect(result.current.streamOriginSeconds).toBe(16));
+    expect(result.current.playerStartSeconds).toBe(2.261);
+    expect(result.current.canSeekAnywhere).toBe(false);
+  });
+
   it("coalesces same-tick restarts into a single start with the final params", async () => {
     const { result } = renderQuality();
 

--- a/web/src/player/hooks/useTranscodeQuality.ts
+++ b/web/src/player/hooks/useTranscodeQuality.ts
@@ -2,7 +2,13 @@ import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { usePlayerConfig } from "../context/PlayerConfigContext";
 import { PlayerFetchError, playerFetch } from "../player-fetch";
 import { describeTranscodingPolicyError } from "../playback-errors";
-import type { PlayMethod, PlayerFileVersion, QualityOption, TranscodeStartRequest } from "../types";
+import type {
+  PlaybackTransportRestart,
+  PlayMethod,
+  PlayerFileVersion,
+  QualityOption,
+  TranscodeStartRequest,
+} from "../types";
 import { QUALITY_TO_RESOLUTION } from "./useCodecDetection";
 
 /** Quality tier definition. ID is frontend-only; backend receives resolution + bitrate separately. */
@@ -51,6 +57,7 @@ interface UseTranscodeQualityParams {
   playMethod: PlayMethod | null;
   initialPosition: number;
   qualityPreference?: string | null;
+  transportRestart?: PlaybackTransportRestart | null;
 }
 
 interface UseTranscodeQualityResult {
@@ -179,6 +186,7 @@ export function useTranscodeQuality({
   playMethod,
   initialPosition,
   qualityPreference,
+  transportRestart,
 }: UseTranscodeQualityParams): UseTranscodeQualityResult {
   const config = usePlayerConfig();
   const [activeQualityId, setActiveQualityId] = useState("original");
@@ -259,6 +267,23 @@ export function useTranscodeQuality({
     },
     [],
   );
+
+  useEffect(() => {
+    if (!sessionId || !transportRestart) return;
+
+    switchAbortRef.current?.abort();
+    switchAbortRef.current = null;
+    if (dispatchTimerRef.current != null) {
+      clearTimeout(dispatchTimerRef.current);
+      dispatchTimerRef.current = null;
+    }
+    setTranscodeStreamUrl(transportRestart.streamUrl);
+    setPlayerStartSeconds(transportRestart.playerStartSeconds);
+    setStreamOriginSeconds(transportRestart.streamOriginSeconds);
+    setCanSeekAnywhere(transportRestart.canSeekAnywhere);
+    setIsTranscoding(false);
+    setError(null);
+  }, [sessionId, transportRestart]);
 
   const startTranscode = useCallback(
     (qualityId: string, currentPosition: number, forceRestart = false) => {
@@ -520,7 +545,7 @@ export function useTranscodeQuality({
   );
 
   useEffect(() => {
-    if (!sessionId || (playMethod !== "transcode" && playMethod !== "remux")) {
+    if (!sessionId || transportRestart || (playMethod !== "transcode" && playMethod !== "remux")) {
       return;
     }
 
@@ -565,6 +590,7 @@ export function useTranscodeQuality({
     selectedVersion?.file_id,
     sessionId,
     startTranscode,
+    transportRestart,
   ]);
 
   return {

--- a/web/src/player/types.ts
+++ b/web/src/player/types.ts
@@ -210,7 +210,20 @@ export interface ChangeAudioResponse {
   play_method: PlayMethod;
   stream_url: string;
   switch_mode: "reload";
+  player_start_seconds?: number;
+  stream_origin_seconds?: number;
+  timeline_offset_seconds?: number;
+  can_seek_anywhere?: boolean;
   playback_info?: PlaybackSessionPlaybackInfo;
+}
+
+/** A server-prepared stream replacement that the player should adopt without restarting it. */
+export interface PlaybackTransportRestart {
+  revision: number;
+  streamUrl: string;
+  playerStartSeconds: number;
+  streamOriginSeconds: number;
+  canSeekAnywhere: boolean;
 }
 
 /** Client codec capabilities sent to the server. */


### PR DESCRIPTION
## Summary

- preserve `target_codec_video: "copy"` for legacy remux resume and seek requests across H.264, HEVC, and MPEG-2 sources
- resolve copy-stream keyframe anchors with bounded, coalesced ffprobe work before transport replacement
- publish the complete session recipe and typed transcode route atomically so stale transport IDs and mixed predecessor/successor state cannot leak
- stage local and offloaded copy-video successors until their manifests are ready, preserving the active predecessor on failure or stale commits
- retain serialized last-writer-wins behavior for overlapping encoded legacy starts
- return the rebased timeline from copy-mode audio switches and let the web player adopt that prepared transport without issuing a duplicate transcode start
- add handler, FFmpeg, manifest, reconstruction-token, transcode-node, concurrency, failure-preservation, and web-client regressions

Part of #197.

## Root cause

The legacy `/playback/transcode/start` handler promoted any positive seek using video copy to H.264, except for MPEG-2. That turned an original-quality remux into a full video transcode for the remainder of the stream.

Removing that promotion exposed several lifecycle details that also needed to be explicit: copy-video input seeks begin at the demuxer's preceding keyframe; same-ID replacement can destroy a predecessor before its successor is usable; route and stream state must become visible together; and audio-switch clients need the successor's rebased timeline instead of assuming the requested media position is the new player position.

The fix records the real keyframe origin, bounds and coalesces matching probes, prepares copy successors under distinct transport/output identities, and atomically publishes their full route and recipe only after readiness succeeds.

## Impact

Legacy clients can resume, seek, and switch audio on original-quality remuxes without unexpectedly selecting a video encoder or losing the active stream when a successor fails. Audio may still be converted to AAC, subtitle burn-in still requires H.264 encoding, and explicit quality reductions continue to transcode normally.

The audio-switch response gains additive optional timeline fields consumed by the bundled web player. There are no migrations, settings changes, or protocol-v3 handler/planner changes.

## Validation

- `GOWORK=off go test -timeout 180s ./internal/api/handlers ./internal/playback ./internal/transcodenode ./internal/proxy`
- `GOWORK=off go test -race -timeout 120s ./internal/api/handlers -run 'TestHandle(StartTranscode_(ConcurrentLocalEncodedStartsRemainLastWriterWins|ConcurrentRemoteReplacementsPublishOneWinner|RemoteSuccessorCannotBeOverwrittenByStaleFinalization)|ChangeAudioTrack_(LocalCopyFailurePreservesPredecessor|LocalCopyRestartUsesFreshSeekAnchor|RemoteCopyRestartUsesFreshSeekAnchor))$'`
- `GOWORK=off go vet ./internal/api/handlers ./internal/playback ./internal/transcodenode ./internal/proxy`
- `pnpm exec tsc -b --pretty false`
- `pnpm exec vitest run src/player/hooks/useTranscodeQuality.test.tsx`
- `pnpm run format:check`
- `pnpm run lint` (0 errors; 159 existing warnings)
- `make verify-local-paths`
- `git diff --check`

`golangci-lint` is not installed in this workspace; `go vet` and the affected frontend lint completed successfully.

## AI-use disclosure

Codex assisted with investigation, implementation, regression coverage, concurrency hardening, local code review, verification, and PR preparation. The final diff and behavior were reviewed, and the affected Go and web validation gates were rerun after the fixes.
