### PR TITLE
feat(ebooks): decouple metadata enrichment from scans via a durable queue

### DIFF
--- a/cmd/silo/main.go
+++ b/cmd/silo/main.go
@@ -2095,6 +2095,7 @@ func main() {
 		}
 		if ebookEnricher != nil {
 			taskMgr.Register(tasks.NewSyncEbookMetadataTask(ebookEnricher))
+			taskMgr.Register(tasks.NewBackfillEbookMetadataTask(ebookEnricher))
 		}
 		if mangaEnricher != nil {
 			taskMgr.Register(tasks.NewSyncMangaMetadataTask(mangaEnricher))

--- a/cmd/silo/main.go
+++ b/cmd/silo/main.go
@@ -910,6 +910,7 @@ func main() {
 			s.SetWorkers(updated.Scanner.Workers)
 		})
 		s.SetLiteraryWorkLinker(literaryWorkService)
+		s.SetEbookEnrichmentQueue(ebooks.NewEnrichmentQueue(deps.DB))
 		deps.Scanner = s
 		deps.ProbeEnsurer = scanner.NewPlaybackProbeEnsurer(fileRepo, ffprobePath, 10*time.Second)
 		slog.Info("scanner initialized")

--- a/docs/superpowers/plans/2026-07-19-ebook-enrichment-architecture.md
+++ b/docs/superpowers/plans/2026-07-19-ebook-enrichment-architecture.md
@@ -1,0 +1,345 @@
+# Ebook Enrichment Architecture Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make ebook discovery fast and deterministic while metadata enrichment runs independently as a durable, bounded, observable workflow that can improve records over time.
+
+**Architecture:** The scanner remains responsible for filesystem reconciliation, embedded metadata, local artwork, format grouping, and identity hints such as ISBN. It never performs broad remote enrichment. A database-backed ebook enrichment state machine claims work with leases, applies outcome-specific retry or refresh horizons, and is drained by the existing task manager. The ebook metadata plugin uses ISBN-first source tiers, ranked matches, and per-source health cooldowns instead of fanning every title query out to every configured source.
+
+**Tech Stack:** Go, PostgreSQL/goose, pgx, Silo task manager, Silo plugin gRPC API
+
+## Global Constraints
+
+- Ebook scans must not wait for remote metadata providers.
+- Existing embedded ebook metadata and local artwork remain higher priority than remote metadata.
+- Ebooks use ISBN identifiers; audiobook-only identifiers and narrator fields must not be introduced.
+- Enrichment must survive process restarts and must not let concurrent workers claim the same item.
+- Provider outages, rate limits, and deterministic client errors must not block scans or create tight retry loops.
+- Previously enriched records must become eligible for controlled refresh so corrected metadata can be adopted later.
+- Changes must be based on `Silo-Server/silo-server` upstream `main` and must not modify unrelated local branches.
+
+---
+
+### Task 1: Decouple Ebook Scans From Remote Retry
+
+**Files:**
+- Modify: `internal/libraryingest/executor.go`
+- Modify: `internal/libraryingest/executor_test.go`
+
+**Interfaces:**
+- Consumes: `librarykind.Of(folder.Type)` and the existing matcher interface.
+- Produces: `usesDedicatedEnrichment(folderType string) bool`, used to skip synchronous unmatched-item retry for ebooks while preserving existing video behavior.
+
+- [x] **Step 1: Write the failing executor test**
+
+Add a matcher that records retry calls and a table test which ingests an ebook folder and a movie folder. Assert that `RetryUnmatchedItemsByFolderAndPathPrefix` is not called for `ebooks`, but remains called for `movies`.
+
+- [x] **Step 2: Run the focused test and verify red**
+
+Run: `go test ./internal/libraryingest -run TestIngestFolderSkipsSynchronousRetryForDedicatedEnrichment -count=1`
+
+Expected: FAIL because ebook ingestion still calls the synchronous retry method.
+
+- [x] **Step 3: Implement the dedicated-enrichment gate**
+
+Add:
+
+```go
+func usesDedicatedEnrichment(folderType string) bool {
+	return librarykind.Of(folderType).Ebook
+}
+```
+
+In the scoped matching loop, retain `ProcessAllByFolderAndPathPrefix` and variant finalization, but call `RetryUnmatchedItemsByFolderAndPathPrefix` only when `usesDedicatedEnrichment(folder.Type)` is false.
+
+- [x] **Step 4: Verify the focused and package tests**
+
+Run: `go test ./internal/libraryingest -count=1`
+
+Expected: PASS.
+
+- [x] **Step 5: Commit**
+
+```bash
+git add internal/libraryingest/executor.go internal/libraryingest/executor_test.go
+git commit -m "fix(ebooks): decouple enrichment from library scans"
+```
+
+### Task 2: Replace Failure Counting With a Durable Enrichment State Machine
+
+**Files:**
+- Create: `migrations/sql/20260719090000_ebook_enrichment_jobs.sql`
+- Create: `internal/ebooks/enrichment_queue.go`
+- Create: `internal/ebooks/enrichment_queue_test.go`
+- Modify: `internal/ebooks/enrichment.go`
+- Modify: `internal/ebooks/enrichment_test.go`
+
+**Interfaces:**
+- Produces: `EnrichmentQueue.Enqueue(ctx, contentID, priority)`, `ClaimBatch(ctx, limit, leaseDuration)`, `Complete(ctx, contentID, outcome, refreshAfter)`, and `Fail(ctx, contentID, errorClass, message, retryAfter)`.
+- Consumes: `enrichmentItemRow` and the existing `Enricher.enrichItem` persistence path.
+
+- [x] **Step 1: Write failing queue query and transition tests**
+
+Test that claims use `FOR UPDATE SKIP LOCKED`, set `lease_until`, and only select `pending` jobs whose `next_attempt_at` is due or whose lease expired. Test outcome policies:
+
+```go
+success -> next_attempt_at = now + 90 days
+no_match -> next_attempt_at = now + 30 days
+transient failure -> exponential backoff capped at 24 hours
+rate_limited -> provider retry horizon, capped at 24 hours
+permanent failure -> next_attempt_at = now + 30 days
+```
+
+- [x] **Step 2: Run queue tests and verify red**
+
+Run: `go test ./internal/ebooks -run 'TestEnrichmentQueue|TestEnrichmentRetryPolicy' -count=1`
+
+Expected: FAIL because the queue and retry policy do not exist.
+
+- [x] **Step 3: Add the migration**
+
+Extend `ebook_enrichment_state` with:
+
+```sql
+status text NOT NULL DEFAULT 'pending',
+priority integer NOT NULL DEFAULT 0,
+attempts integer NOT NULL DEFAULT 0,
+next_attempt_at timestamptz NOT NULL DEFAULT now(),
+lease_until timestamptz,
+last_attempt_at timestamptz,
+completed_at timestamptz,
+outcome text,
+last_error_class text,
+last_error text
+```
+
+Add a partial claim index on `(priority DESC, next_attempt_at, updated_at)` for rows whose status is `pending` or `running`.
+
+- [x] **Step 4: Implement atomic queue claims and transitions**
+
+Use one transaction and a CTE:
+
+```sql
+WITH candidates AS (
+    SELECT content_id
+    FROM ebook_enrichment_state
+    WHERE next_attempt_at <= now()
+      AND (status = 'pending' OR (status = 'running' AND lease_until < now()))
+    ORDER BY priority DESC, next_attempt_at, updated_at
+    FOR UPDATE SKIP LOCKED
+    LIMIT $1
+)
+UPDATE ebook_enrichment_state state
+SET status = 'running',
+    lease_until = now() + $2::interval,
+    last_attempt_at = now(),
+    attempts = attempts + 1,
+    updated_at = now()
+FROM candidates
+WHERE state.content_id = candidates.content_id
+RETURNING state.content_id;
+```
+
+Keep state rows after success so refresh eligibility and prior outcomes are durable.
+
+- [x] **Step 5: Route `Enricher.Run` through the queue**
+
+Materialize missing candidates into `ebook_enrichment_state` with `INSERT ... SELECT ... ON CONFLICT DO NOTHING`, claim a bounded batch, load the existing item fields, and transition each claim to success, no-match, skipped, or failure. Context cancellation must release the lease without incrementing item failure state.
+
+- [x] **Step 6: Verify ebook package tests**
+
+Run: `go test ./internal/ebooks -count=1`
+
+Expected: PASS.
+
+- [x] **Step 7: Commit**
+
+```bash
+git add migrations/sql/20260719090000_ebook_enrichment_jobs.sql internal/ebooks/enrichment_queue.go internal/ebooks/enrichment_queue_test.go internal/ebooks/enrichment.go internal/ebooks/enrichment_test.go
+git commit -m "feat(ebooks): add durable metadata enrichment queue"
+```
+
+### Task 3: Drain Bounded Work Continuously And Report Honest Progress
+
+**Files:**
+- Modify: `internal/taskmanager/tasks/sync_ebook_metadata.go`
+- Modify: `internal/taskmanager/tasks/sync_ebook_metadata_test.go`
+- Modify: `internal/ebooks/enrichment.go`
+- Modify: `cmd/silo/main.go`
+
+**Interfaces:**
+- Produces: `EnrichmentRunResult{Claimed, Enriched, NoMatch, Failed, Deferred, Remaining int}`, an incremental task, and a separate manual legacy-backfill task.
+- Consumes: the durable queue from Task 2.
+
+- [x] **Step 1: Write failing task tests**
+
+Test that the scheduled task drains only priority-zero-or-higher work until the queue is empty or a four-minute execution budget expires. Add a separate `backfill_ebook_metadata` task with no default triggers which may claim the priority `-100` legacy backlog. Assert progress messages include claimed, enriched, failed, and remaining counts, and cancellation stops between batches.
+
+- [x] **Step 2: Run focused task tests and verify red**
+
+Run: `go test ./internal/taskmanager/tasks -run TestSyncEbookMetadata -count=1`
+
+Expected: FAIL because the task runs one opaque batch and only returns `items_enriched`.
+
+- [x] **Step 3: Add structured enrichment results**
+
+Change `Enricher.Run` to return:
+
+```go
+type EnrichmentRunResult struct {
+	Claimed   int `json:"claimed"`
+	Enriched  int `json:"enriched"`
+	NoMatch   int `json:"no_match"`
+	Failed    int `json:"failed"`
+	Deferred  int `json:"deferred"`
+	Remaining int `json:"remaining"`
+}
+```
+
+- [x] **Step 4: Implement time-budgeted draining**
+
+Loop over bounded queue claims while work remains and the execution deadline has not elapsed. The scheduled task must never claim legacy-backfill rows; only the manually triggered backfill task may include them. Report progress after every batch; never estimate 100 percent until no immediately eligible work remains.
+
+- [x] **Step 5: Verify task and ebook tests**
+
+Run: `go test ./internal/taskmanager/tasks ./internal/ebooks -count=1`
+
+Expected: PASS.
+
+- [x] **Step 6: Commit**
+
+```bash
+git add internal/taskmanager/tasks/sync_ebook_metadata.go internal/taskmanager/tasks/sync_ebook_metadata_test.go internal/ebooks/enrichment.go
+git commit -m "feat(ebooks): drain enrichment backlog with progress"
+```
+
+### Task 4: Rebuild Ebook Provider Strategy In The Metadata Plugin
+
+**Files (plugin repository `silo-plugin-ebook-metadata`):**
+- Create: `provider/health.go`
+- Create: `provider/health_test.go`
+- Create: `provider/ranking.go`
+- Create: `provider/ranking_test.go`
+- Modify: `provider/provider.go`
+- Modify: `provider/provider_test.go`
+- Modify: `README.md`
+
+**Interfaces:**
+- Produces: source tiers `identifier`, `catalog`, and `extended`; `SourceHealth.Allow`, `RecordSuccess`, and `RecordFailure`; deterministic `RankMatches`.
+- Consumes: existing `Source.Search`, `Source.Fetch`, normalized ISBN helpers, and plugin settings.
+
+- [x] **Step 1: Write failing source-tier tests**
+
+Assert default operation enables reliable catalog sources only, exact ISBN fetches use identifier-capable sources in order, and title/author searches do not invoke optional scraper sources unless explicitly enabled.
+
+- [x] **Step 2: Write failing health-policy tests**
+
+Assert HTTP 403/405 disables a source for one hour, HTTP 429 honors `Retry-After`, timeouts use exponential cooldown, and one healthy response closes the circuit.
+
+- [x] **Step 3: Write failing ranking tests**
+
+Rank exact normalized ISBN first, then normalized title plus author, then title plus year/language. Reject low-confidence title-only collisions and deduplicate matches by normalized ISBN or source/provider ID.
+
+- [x] **Step 4: Implement tiered querying**
+
+For an ISBN query, fetch identifier sources sequentially and stop after a complete high-confidence match. For title/author queries, query the reliable catalog tier with bounded concurrency, rank all results, and query the extended tier only when enabled and the catalog tier produced no acceptable match.
+
+- [x] **Step 5: Implement per-source health cooldowns**
+
+Wrap every source call with health admission and outcome recording. A source in cooldown is skipped without returning a provider-wide error; healthy sources continue serving the request.
+
+- [x] **Step 6: Update plugin documentation**
+
+Document default sources, optional extended sources, API-key sources, match ranking, cooldown behavior, and the `enabled_sources` override.
+
+- [x] **Step 7: Verify plugin tests**
+
+Run: `go test ./... -count=1`
+
+Expected: PASS.
+
+- [x] **Step 8: Commit**
+
+```bash
+git add provider/health.go provider/health_test.go provider/ranking.go provider/ranking_test.go provider/provider.go provider/provider_test.go README.md
+git commit -m "feat: add tiered resilient ebook metadata sources"
+```
+
+### Task 5: Add Backfill Safety Controls
+
+**Files:**
+- Modify: `internal/taskmanager/tasks/sync_ebook_metadata.go`
+- Modify: `internal/taskmanager/tasks/sync_ebook_metadata_test.go`
+
+**Interfaces:**
+- Consumes: the manual legacy task from Task 3.
+- Produces: a claim cap, inter-batch pacing, and a no-progress circuit breaker.
+
+- [ ] **Step 1: Preserve typed source deferrals**
+
+Count `ResourceExhausted` provider results as deferred work with the provider's
+retry delay, not as generic failures.
+
+- [ ] **Step 2: Stop stalled drains**
+
+Stop cleanly after one full batch with no terminal outcome. A plugin packaging
+error, source outage, or rate-limit saturation must never walk the backlog.
+
+- [ ] **Step 3: Add canary controls**
+
+Support a maximum number of claims per manual run and an inter-batch delay.
+The first production trial uses 20 claims, one worker, and a one-second delay.
+
+- [ ] **Step 4: Verify safety behavior**
+
+Test all-failed, all-deferred, mixed-progress, claim-cap, pacing, cancellation,
+and honest result reporting.
+
+### Task 6: End-To-End Verification And Operational Rollout
+
+**Files:**
+- Modify: `docs/superpowers/plans/2026-07-19-ebook-enrichment-architecture.md`
+
+**Interfaces:**
+- Consumes: Tasks 1-4.
+- Produces: verified deployment and backfill procedure.
+
+- [ ] **Step 1: Run server verification**
+
+Run: `go test ./internal/libraryingest ./internal/ebooks ./internal/taskmanager/tasks ./internal/scanner -count=1`
+
+Expected: PASS.
+
+- [ ] **Step 2: Run race-sensitive server verification**
+
+Run: `go test -race ./internal/ebooks ./internal/taskmanager/tasks -count=1`
+
+Expected: PASS.
+
+- [ ] **Step 3: Run plugin verification**
+
+Run from the plugin worktree: `go test -race ./... -count=1`
+
+Expected: PASS.
+
+- [ ] **Step 4: Package and preflight**
+
+Build the plugin binary and installed manifest together. Verify their checksums,
+versions, and runtime manifests match before replacing a running installation.
+
+- [ ] **Step 5: Deploy a bounded production canary**
+
+Deploy without overwriting compose or `.env`. Use 20 maximum claims, one worker,
+and a one-second inter-batch delay. Do not enable an automatic legacy trigger.
+
+- [ ] **Step 6: Apply acceptance gates**
+
+Promote only when runtime-manifest errors are zero, no full batch fails or
+defers, at least 80 percent of claimed rows reach success or no-match, database
+claims remain below one second, and Silo stays healthy without scan regressions.
+
+- [ ] **Step 7: Expand in measured stages**
+
+Increase the claim cap only after recording throughput, provider error rate,
+queue depth, database load, and projected completion time. Stop automatically
+when a stage misses an acceptance gate.

--- a/docs/superpowers/specs/2026-07-20-ebook-backfill-automation-design.md
+++ b/docs/superpowers/specs/2026-07-20-ebook-backfill-automation-design.md
@@ -1,0 +1,81 @@
+# Ebook Backfill Automation + Rate-Limit Cooldown Floor
+
+Date: 2026-07-20
+Status: approved
+
+## Problem
+
+The legacy ebook enrichment lane (priority -100, ~65k items on the first
+production install) only drains when an operator manually runs the
+`backfill_ebook_metadata` task. Worse, the first production canary run showed
+that rate-limited items become claimable again almost immediately: the
+ebook-metadata plugin attaches a `RetryInfo` of about one second to its
+`ResourceExhausted` errors — request-pacing advice for its internal token
+bucket — and `enrichmentRetryDelay` adopts that hint verbatim as the queue
+re-eligibility horizon. Successive runs therefore re-claim and re-defer the
+same saturated tail instead of letting the provider's quota recover.
+
+Evidence (production, 2026-07-20): 100 claimed, 30 enriched, 1 no-match,
+69 deferred with `last_error_class = 'rate_limited'` and
+`next_attempt_at ≈ last_attempt_at + 1s`.
+
+## Design
+
+Two independent pieces that compose into self-pacing automation.
+
+### 1. Rate-limit cooldown floor
+
+`internal/ebooks/enrichment_queue.go`, `enrichmentRetryDelay`:
+
+- Rate-limited branch: resolve the candidate delay as today (provider
+  `retryAfter` if positive, else the transient backoff for the attempt
+  count), then clamp it to no less than the cooldown floor, and cap at
+  `maxEnrichmentRetry` (24h) as today.
+- Floor default: **15 minutes**.
+- Env override: `SILO_EBOOK_RATE_LIMIT_COOLDOWN` (Go duration string,
+  e.g. `30m`). Invalid or non-positive values fall back to the default,
+  matching the tolerant parsing style of the other `SILO_EBOOK_*` knobs.
+- Provider hints longer than the floor are honored unchanged (up to the
+  24h cap). Only pacing-grade short hints are raised.
+- Transient and permanent classes are unchanged.
+
+### 2. Default interval trigger for the backfill task
+
+`internal/taskmanager/tasks/sync_ebook_metadata.go`:
+
+- `BackfillEbookMetadataTask` gains a default trigger:
+  `TriggerConfig{Type: TriggerTypeInterval, IntervalMs: 15 * 60 * 1000}`.
+- The task manager applies defaults whenever no triggers are persisted for
+  the task key (`internal/taskmanager/manager.go`), and this task has never
+  persisted any, so existing installs pick the trigger up on upgrade with no
+  migration or manual step.
+- Operators can retune or disable the trigger through the existing admin
+  task-triggers UI/API; the manual run endpoint keeps working.
+- The canary claim cap (`SILO_EBOOK_BACKFILL_MAX_CLAIMS`) and batch delay
+  (`SILO_EBOOK_BACKFILL_BATCH_DELAY`) keep their semantics; unset means
+  uncapped runs bounded by the 4-minute execution budget.
+
+### Emergent behavior
+
+Each 15-minute run claims what is ready under the execution budget and the
+claim cap. Rate-limited items sleep at least the floor, so the next run meets
+a fresh ready-set instead of the same saturated tail. A fully saturated batch
+trips the existing zero-progress circuit breaker and ends the run early. An
+empty ready-set makes the run exit in milliseconds. The backlog drains at
+whatever pace the provider allows, unattended.
+
+## Testing
+
+- `enrichmentRetryDelay`: short hint raised to the floor; hint above the
+  floor honored; no hint yields at least the floor; 24h cap still applies.
+- Cooldown env parsing: valid duration honored, invalid/non-positive falls
+  back to the default.
+- `BackfillEbookMetadataTask.DefaultTriggers()` returns the 15-minute
+  interval trigger; the sync task's triggers are unchanged.
+
+## Out of scope
+
+- Plugin-side changes to what `RetryInfo` the ebook-metadata plugin sends
+  (its 1s hint remains correct for in-process pacing).
+- Any change to the scheduled priority-0 sync task.
+- Migrations and API surface: none needed.

--- a/internal/ebooks/enrichment.go
+++ b/internal/ebooks/enrichment.go
@@ -31,8 +31,9 @@ import (
 const (
 	ebookMetadataImageProviderID = "ebook-metadata"
 
-	defaultEnrichBatchSize = 50
+	defaultEnrichBatchSize = 5000
 	defaultEnrichWorkers   = 4
+	maxEnrichWorkers       = 5000
 
 	defaultEnrichmentItemTimeout = 2 * time.Minute
 )
@@ -69,8 +70,8 @@ func ebookEnrichWorkers() int {
 			n = parsed
 		}
 	}
-	if n > defaultEnrichBatchSize {
-		n = defaultEnrichBatchSize
+	if n > maxEnrichWorkers {
+		n = maxEnrichWorkers
 	}
 	return n
 }

--- a/internal/ebooks/enrichment.go
+++ b/internal/ebooks/enrichment.go
@@ -383,7 +383,11 @@ func (e *Enricher) runQueueBatch(
 					}
 					recordTransitionError(item.ContentID, transitionErr)
 					if transitionErr == nil {
-						atomic.AddInt64(&failed, 1)
+						if errorClass == EnrichmentErrorRateLimited {
+							atomic.AddInt64(&deferred, 1)
+						} else {
+							atomic.AddInt64(&failed, 1)
+						}
 					}
 					continue
 				}

--- a/internal/ebooks/enrichment.go
+++ b/internal/ebooks/enrichment.go
@@ -119,6 +119,17 @@ type EnrichmentRunResult struct {
 	HasMore   bool `json:"-"`
 }
 
+type ebookProviderIDRepository interface {
+	GetByContentIDs(ctx context.Context, contentIDs []string) (map[string][]*models.MediaItemProviderID, error)
+	ReplaceByContentID(ctx context.Context, contentID string, providerIDs map[string]string) error
+	FindContentIDByProviderIDs(
+		ctx context.Context,
+		providerIDs map[string]string,
+		itemType string,
+		excludeContentID string,
+	) (string, error)
+}
+
 // Enricher drives the ebook metadata enrichment sweep.
 type Enricher struct {
 	pool           *pgxpool.Pool
@@ -126,7 +137,7 @@ type Enricher struct {
 	resolver       *metadata.PluginResolverAdapter
 	itemRepo       *catalog.ItemRepository
 	personRepo     *catalog.PersonRepository
-	providerIDs    *catalog.ProviderIDRepository
+	providerIDs    ebookProviderIDRepository
 	imageCacher    metadata.ImageCacher
 	imageCacheJobs metadata.ImageCacheJobEnqueuer
 	workLinker     literaryWorkLinker
@@ -151,13 +162,17 @@ func NewEnricher(
 	personRepo *catalog.PersonRepository,
 	providerIDs *catalog.ProviderIDRepository,
 ) *Enricher {
+	var providerIDStore ebookProviderIDRepository
+	if providerIDs != nil {
+		providerIDStore = providerIDs
+	}
 	return &Enricher{
 		pool:        pool,
 		chainRepo:   chainRepo,
 		resolver:    resolver,
 		itemRepo:    itemRepo,
 		personRepo:  personRepo,
-		providerIDs: providerIDs,
+		providerIDs: providerIDStore,
 		batchSize:   defaultEnrichBatchSize,
 		workers:     ebookEnrichWorkers(),
 		queue:       NewEnrichmentQueue(pool),
@@ -649,16 +664,36 @@ func (e *Enricher) loadClaimedItems(ctx context.Context, jobs []EnrichmentJob) (
 		return nil, fmt.Errorf("iterating ebook enrichment rows: %w", err)
 	}
 
-	if e.providerIDs != nil {
-		for i := range items {
-			pids, err := e.providerIDs.GetByContentID(ctx, items[i].ContentID)
-			if err == nil {
-				items[i].ProviderIDs = providerIDMapFromRows(pids)
-			}
-		}
+	if err := e.loadProviderIDs(ctx, contentIDs, items); err != nil {
+		return nil, err
 	}
 
 	return items, nil
+}
+
+func (e *Enricher) loadProviderIDs(
+	ctx context.Context,
+	contentIDs []string,
+	items []enrichmentItemRow,
+) error {
+	if e == nil || e.providerIDs == nil || len(contentIDs) == 0 {
+		return nil
+	}
+	rowsByContentID, err := e.providerIDs.GetByContentIDs(ctx, contentIDs)
+	if err != nil {
+		return fmt.Errorf("loading ebook provider IDs: %w", err)
+	}
+	for i := range items {
+		items[i].ProviderIDs = providerIDMapFromRows(rowsByContentID[items[i].ContentID])
+		_, hasISBN := items[i].ProviderIDs["isbn"]
+		slog.DebugContext(ctx, "ebook enrichment: loaded provider identifiers",
+			"component", "ebooks",
+			"content_id", items[i].ContentID,
+			"identifier_count", len(items[i].ProviderIDs),
+			"has_isbn", hasISBN,
+		)
+	}
+	return nil
 }
 
 func (e *Enricher) enrichItem(ctx context.Context, item enrichmentItemRow) error {
@@ -951,6 +986,7 @@ func collectEbookMetadata(ctx context.Context, item enrichmentItemRow, providers
 		if result == nil || !result.HasMetadata {
 			continue
 		}
+		accumulator.HasMetadata = true
 		mergeEnrichmentProviderIDs(accumulator, result)
 		metadata.MergeMetadata(result, accumulator, nil, metadata.MergeFillEmpty)
 

--- a/internal/ebooks/enrichment.go
+++ b/internal/ebooks/enrichment.go
@@ -116,6 +116,7 @@ type EnrichmentRunResult struct {
 	NoMatch   int  `json:"no_match"`
 	Failed    int  `json:"failed"`
 	Deferred  int  `json:"deferred"`
+	Discarded int  `json:"discarded"`
 	Remaining int  `json:"remaining"`
 	HasMore   bool `json:"-"`
 }
@@ -282,6 +283,7 @@ func (e *Enricher) RunLimited(ctx context.Context, scope EnrichmentScope, maxCla
 		"no_match", result.NoMatch,
 		"failed", result.Failed,
 		"deferred", result.Deferred,
+		"discarded", result.Discarded,
 		"has_more", result.HasMore,
 	)
 	return result, runErr
@@ -325,7 +327,7 @@ func (e *Enricher) runQueueBatch(
 			if err := e.discardJob(queue, job); err != nil && !errors.Is(err, ErrEnrichmentLeaseLost) {
 				transitionErrs = append(transitionErrs, fmt.Errorf("%s: %w", job.ContentID, err))
 			} else if err == nil {
-				result.Deferred++
+				result.Discarded++
 			}
 		}
 	}
@@ -403,10 +405,6 @@ func (e *Enricher) runQueueBatch(
 					if transitionErr == nil {
 						atomic.AddInt64(&failed, 1)
 					}
-					continue
-				}
-				if errors.Is(enrichErr, context.Canceled) {
-					recordTransitionError(item.ContentID, e.releaseJob(queue, job))
 					continue
 				}
 				if enrichErr != nil {

--- a/internal/ebooks/enrichment.go
+++ b/internal/ebooks/enrichment.go
@@ -33,6 +33,8 @@ const (
 
 	defaultEnrichBatchSize = 50
 	defaultEnrichWorkers   = 4
+
+	defaultEnrichmentItemTimeout = 2 * time.Minute
 )
 
 // errEnrichmentSkipped preserves the direct helper contract for an item that
@@ -58,33 +60,35 @@ func ebookEnrichWorkers() int {
 }
 
 type enrichmentItemRow struct {
-	ContentID   string
-	Title       string
-	Year        int
-	FolderID    int
-	Language    string
-	Author      string
-	ProviderIDs map[string]string
-	Status      string
-	Overview    string
-	ReleaseDate string
-	Genres      []string
-	Studios     []string
-	PosterPath  string
+	ContentID       string
+	Title           string
+	Year            int
+	FolderID        int
+	Language        string
+	Author          string
+	ProviderIDs     map[string]string
+	Status          string
+	Overview        string
+	Tagline         string
+	ContentRating   string
+	Runtime         int
+	ReleaseDate     string
+	Genres          []string
+	Studios         []string
+	PosterPath      string
+	BackdropPath    string
+	LogoPath        string
+	LockedFields    []int
+	ProtectedFields []string
 }
 
 type enrichmentQueue interface {
 	MaterializeCandidates(ctx context.Context) error
 	ClaimBatch(ctx context.Context, limit int, leaseDuration time.Duration) ([]EnrichmentJob, error)
-	Complete(ctx context.Context, contentID string, outcome EnrichmentOutcome, refreshAfter time.Duration) error
-	Fail(ctx context.Context, contentID string, errorClass EnrichmentErrorClass, message string, retryAfter time.Duration) error
-	Release(ctx context.Context, contentID string) error
-}
-
-type claimAwareEnrichmentQueue interface {
-	CompleteClaim(ctx context.Context, job EnrichmentJob, outcome EnrichmentOutcome, refreshAfter time.Duration) error
-	FailClaim(ctx context.Context, job EnrichmentJob, errorClass EnrichmentErrorClass, message string, retryAfter time.Duration) error
-	ReleaseClaim(ctx context.Context, job EnrichmentJob) error
+	Complete(ctx context.Context, job EnrichmentJob, outcome EnrichmentOutcome, refreshAfter time.Duration) error
+	Fail(ctx context.Context, job EnrichmentJob, errorClass EnrichmentErrorClass, message string, retryAfter time.Duration) error
+	Release(ctx context.Context, job EnrichmentJob) error
+	Discard(ctx context.Context, job EnrichmentJob) error
 }
 
 // Enricher drives the ebook metadata enrichment sweep.
@@ -100,6 +104,7 @@ type Enricher struct {
 	workLinker     literaryWorkLinker
 	batchSize      int
 	workers        int
+	itemTimeout    time.Duration
 	queue          enrichmentQueue
 
 	loadClaimedItemsFn  func(context.Context, []EnrichmentJob) ([]enrichmentItemRow, error)
@@ -214,13 +219,16 @@ func (e *Enricher) runQueueBatch(
 	for _, job := range jobs {
 		claimedJobs[job.ContentID] = job
 	}
+	var transitionErrs []error
 	loaded := make(map[string]struct{}, len(items))
 	for i := range items {
 		loaded[items[i].ContentID] = struct{}{}
 	}
 	for _, job := range jobs {
 		if _, ok := loaded[job.ContentID]; !ok {
-			_ = e.releaseJob(queue, job)
+			if err := e.discardJob(queue, job); err != nil && !errors.Is(err, ErrEnrichmentLeaseLost) {
+				transitionErrs = append(transitionErrs, fmt.Errorf("%s: %w", job.ContentID, err))
+			}
 		}
 	}
 
@@ -232,15 +240,18 @@ func (e *Enricher) runQueueBatch(
 		workers = len(items)
 	}
 	if workers == 0 {
-		return 0, nil
+		return 0, errors.Join(transitionErrs...)
+	}
+	itemTimeout := e.itemTimeout
+	if itemTimeout <= 0 || itemTimeout >= defaultEnrichmentLease {
+		itemTimeout = defaultEnrichmentItemTimeout
 	}
 
 	ch := make(chan enrichmentItemRow, workers)
 	var (
-		wg             sync.WaitGroup
-		enriched       int64
-		transitionMu   sync.Mutex
-		transitionErrs []error
+		wg           sync.WaitGroup
+		enriched     int64
+		transitionMu sync.Mutex
 	)
 	recordTransitionError := func(contentID string, err error) {
 		if err == nil || errors.Is(err, ErrEnrichmentLeaseLost) {
@@ -262,8 +273,12 @@ func (e *Enricher) runQueueBatch(
 					continue
 				}
 
-				outcome, enrichErr := enrichFn(ctx, item)
-				if ctx.Err() != nil || errors.Is(enrichErr, context.Canceled) || errors.Is(enrichErr, context.DeadlineExceeded) {
+				itemCtx, cancelItem := context.WithTimeout(ctx, itemTimeout)
+				outcome, enrichErr := enrichFn(itemCtx, item)
+				itemCtxErr := itemCtx.Err()
+				cancelItem()
+				if ctx.Err() != nil || itemCtxErr != nil ||
+					errors.Is(enrichErr, context.Canceled) || errors.Is(enrichErr, context.DeadlineExceeded) {
 					recordTransitionError(item.ContentID, e.releaseJob(queue, job))
 					continue
 				}
@@ -330,10 +345,7 @@ func (e *Enricher) completeJob(
 	job EnrichmentJob,
 	outcome EnrichmentOutcome,
 ) error {
-	if claimQueue, ok := queue.(claimAwareEnrichmentQueue); ok {
-		return claimQueue.CompleteClaim(ctx, job, outcome, enrichmentRefreshHorizon(outcome))
-	}
-	return queue.Complete(ctx, job.ContentID, outcome, enrichmentRefreshHorizon(outcome))
+	return queue.Complete(ctx, job, outcome, enrichmentRefreshHorizon(outcome))
 }
 
 func (e *Enricher) failJob(
@@ -344,19 +356,19 @@ func (e *Enricher) failJob(
 	message string,
 	retryAfter time.Duration,
 ) error {
-	if claimQueue, ok := queue.(claimAwareEnrichmentQueue); ok {
-		return claimQueue.FailClaim(ctx, job, errorClass, message, retryAfter)
-	}
-	return queue.Fail(ctx, job.ContentID, errorClass, message, retryAfter)
+	return queue.Fail(ctx, job, errorClass, message, retryAfter)
 }
 
 func (e *Enricher) releaseJob(queue enrichmentQueue, job EnrichmentJob) error {
 	releaseCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
-	if claimQueue, ok := queue.(claimAwareEnrichmentQueue); ok {
-		return claimQueue.ReleaseClaim(releaseCtx, job)
-	}
-	return queue.Release(releaseCtx, job.ContentID)
+	return queue.Release(releaseCtx, job)
+}
+
+func (e *Enricher) discardJob(queue enrichmentQueue, job EnrichmentJob) error {
+	discardCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	return queue.Discard(discardCtx, job)
 }
 
 func (e *Enricher) runBatch(
@@ -441,10 +453,16 @@ var loadEnrichmentItemsQuery = `
 		) AS author,
 		COALESCE(mi.status, ''),
 		COALESCE(mi.overview, ''),
-		COALESCE(mi.release_date, ''),
+		COALESCE(mi.tagline, ''),
+		COALESCE(mi.content_rating, ''),
+		COALESCE(mi.runtime, 0),
+		COALESCE(mi.release_date::text, ''),
 		COALESCE(mi.genres, '{}'),
 		COALESCE(mi.studios, '{}'),
-		COALESCE(mi.poster_path, '')
+		COALESCE(mi.poster_path, ''),
+		COALESCE(mi.backdrop_path, ''),
+		COALESCE(mi.logo_path, ''),
+		COALESCE(mi.locked_fields, '{}'::integer[])
 	FROM unnest($1::text[]) WITH ORDINALITY AS claimed(content_id, position)
 	JOIN media_items mi ON mi.content_id = claimed.content_id
 	LEFT JOIN LATERAL (
@@ -462,8 +480,10 @@ var loadEnrichmentItemsQuery = `
 
 func (e *Enricher) loadClaimedItems(ctx context.Context, jobs []EnrichmentJob) ([]enrichmentItemRow, error) {
 	contentIDs := make([]string, 0, len(jobs))
+	claimedJobs := make(map[string]EnrichmentJob, len(jobs))
 	for _, job := range jobs {
 		contentIDs = append(contentIDs, job.ContentID)
+		claimedJobs[job.ContentID] = job
 	}
 	rows, err := e.pool.Query(ctx, loadEnrichmentItemsQuery, contentIDs)
 	if err != nil {
@@ -483,13 +503,20 @@ func (e *Enricher) loadClaimedItems(ctx context.Context, jobs []EnrichmentJob) (
 			&item.Author,
 			&item.Status,
 			&item.Overview,
+			&item.Tagline,
+			&item.ContentRating,
+			&item.Runtime,
 			&item.ReleaseDate,
 			&item.Genres,
 			&item.Studios,
 			&item.PosterPath,
+			&item.BackdropPath,
+			&item.LogoPath,
+			&item.LockedFields,
 		); err != nil {
 			return nil, fmt.Errorf("scanning ebook enrichment row: %w", err)
 		}
+		item.ProtectedFields = append([]string(nil), claimedJobs[item.ContentID].ProtectedFields...)
 		items = append(items, item)
 	}
 	if err := rows.Err(); err != nil {
@@ -604,35 +631,75 @@ func preserveEbookLocalMetadata(item enrichmentItemRow, result *metadata.Metadat
 	if result == nil {
 		return
 	}
-	if item.PosterPath != "" && !ebookPosterOwnedByRemoteProvider(item.PosterPath) {
+	protected := make(map[string]struct{}, len(item.ProtectedFields))
+	for _, field := range item.ProtectedFields {
+		protected[strings.ToLower(strings.TrimSpace(field))] = struct{}{}
+	}
+	isProtected := func(field string) bool {
+		_, ok := protected[field]
+		return ok
+	}
+	isLocked := func(field metadata.MetadataField) bool {
+		for _, locked := range item.LockedFields {
+			if locked == int(field) {
+				return true
+			}
+		}
+		return false
+	}
+
+	if isProtected("title") || isLocked(metadata.FieldName) {
+		result.Title = ""
+		result.OriginalTitle = ""
+		result.SortTitle = ""
+	}
+	if isProtected("year") || isLocked(metadata.FieldReleaseDates) {
+		result.Year = 0
+	}
+	if isProtected("overview") || isLocked(metadata.FieldOverview) {
+		result.Overview = ""
+	}
+	if isProtected("tagline") {
+		result.Tagline = ""
+	}
+	if isProtected("content_rating") || isLocked(metadata.FieldContentRating) {
+		result.ContentRating = ""
+	}
+	if isProtected("runtime") || isLocked(metadata.FieldRuntime) {
+		result.Runtime = 0
+	}
+	if isProtected("release_date") || isLocked(metadata.FieldReleaseDates) {
+		result.ReleaseDate = ""
+	}
+	if isProtected("genres") || isLocked(metadata.FieldGenres) {
+		result.Genres = nil
+	}
+	if isProtected("studios") || isLocked(metadata.FieldStudios) {
+		result.Studios = nil
+	}
+	if isProtected("authors") || isLocked(metadata.FieldCrew) || isLocked(metadata.FieldCast) {
+		result.People = nil
+	}
+
+	imagesLocked := isLocked(metadata.FieldImages)
+	if imagesLocked || isProtected("poster_path") ||
+		(item.PosterPath != "" && !ebookArtworkOwnedByRemoteProvider(item.PosterPath)) {
 		result.PosterPath = ""
 		result.PosterThumbhash = ""
 	}
-	if !strings.EqualFold(strings.TrimSpace(item.Status), "pending") {
-		return
+	if imagesLocked || isProtected("backdrop_path") ||
+		(item.BackdropPath != "" && !ebookArtworkOwnedByRemoteProvider(item.BackdropPath)) {
+		result.BackdropPath = ""
+		result.BackdropThumbhash = ""
 	}
-	if item.Year > 0 {
-		result.Year = 0
-	}
-	if item.Overview != "" {
-		result.Overview = ""
-	}
-	if item.ReleaseDate != "" {
-		result.ReleaseDate = ""
-	}
-	if len(item.Genres) > 0 {
-		result.Genres = nil
-	}
-	if len(item.Studios) > 0 {
-		result.Studios = nil
-	}
-	if item.Author != "" {
-		result.People = nil
+	if imagesLocked || isProtected("logo_path") ||
+		(item.LogoPath != "" && !ebookArtworkOwnedByRemoteProvider(item.LogoPath)) {
+		result.LogoPath = ""
 	}
 }
 
-func ebookPosterOwnedByRemoteProvider(path string) bool {
-	path = strings.TrimSpace(path)
+func ebookArtworkOwnedByRemoteProvider(path string) bool {
+	path = strings.ToLower(strings.TrimSpace(path))
 	return isRemoteHTTPImage(path) || strings.HasPrefix(path, ebookMetadataImageProviderID+"/ebooks/")
 }
 

--- a/internal/ebooks/enrichment.go
+++ b/internal/ebooks/enrichment.go
@@ -101,6 +101,7 @@ type enrichmentItemRow struct {
 type enrichmentQueue interface {
 	ClaimBatch(ctx context.Context, scope EnrichmentScope, limit int, leaseDuration time.Duration) ([]EnrichmentJob, error)
 	ReadyCount(ctx context.Context, scope EnrichmentScope) (int, error)
+	HasReady(ctx context.Context, scope EnrichmentScope) (bool, error)
 	CheckClaim(ctx context.Context, job EnrichmentJob) error
 	Complete(ctx context.Context, job EnrichmentJob, outcome EnrichmentOutcome, refreshAfter time.Duration) error
 	Fail(ctx context.Context, job EnrichmentJob, errorClass EnrichmentErrorClass, message string, retryAfter time.Duration) error
@@ -109,12 +110,13 @@ type enrichmentQueue interface {
 }
 
 type EnrichmentRunResult struct {
-	Claimed   int `json:"claimed"`
-	Enriched  int `json:"enriched"`
-	NoMatch   int `json:"no_match"`
-	Failed    int `json:"failed"`
-	Deferred  int `json:"deferred"`
-	Remaining int `json:"remaining"`
+	Claimed   int  `json:"claimed"`
+	Enriched  int  `json:"enriched"`
+	NoMatch   int  `json:"no_match"`
+	Failed    int  `json:"failed"`
+	Deferred  int  `json:"deferred"`
+	Remaining int  `json:"remaining"`
+	HasMore   bool `json:"-"`
 }
 
 // Enricher drives the ebook metadata enrichment sweep.
@@ -184,6 +186,27 @@ func (e *Enricher) SetLiteraryWorkLinker(linker literaryWorkLinker) {
 }
 
 func (e *Enricher) Run(ctx context.Context, scope EnrichmentScope) (EnrichmentRunResult, error) {
+	return e.RunLimited(ctx, scope, 0)
+}
+
+func (e *Enricher) ReadyCount(ctx context.Context, scope EnrichmentScope) (int, error) {
+	if e == nil {
+		return 0, nil
+	}
+	if err := scope.validate(); err != nil {
+		return 0, err
+	}
+	queue := e.queue
+	if queue == nil && e.pool != nil {
+		queue = NewEnrichmentQueue(e.pool)
+	}
+	if queue == nil {
+		return 0, nil
+	}
+	return queue.ReadyCount(ctx, scope)
+}
+
+func (e *Enricher) RunLimited(ctx context.Context, scope EnrichmentScope, maxClaims int) (EnrichmentRunResult, error) {
 	if e == nil {
 		return EnrichmentRunResult{}, nil
 	}
@@ -198,16 +221,16 @@ func (e *Enricher) Run(ctx context.Context, scope EnrichmentScope) (EnrichmentRu
 	if queue == nil || (e.chainRepo == nil && e.enrichClaimedItemFn == nil) {
 		return EnrichmentRunResult{}, nil
 	}
-	jobs, err := queue.ClaimBatch(ctx, scope, e.claimLimit(), defaultEnrichmentLease)
+	jobs, err := queue.ClaimBatch(ctx, scope, e.claimLimit(maxClaims), defaultEnrichmentLease)
 	if err != nil {
 		return EnrichmentRunResult{}, fmt.Errorf("ebook enrichment: claim batch: %w", err)
 	}
 	if len(jobs) == 0 {
-		remaining, countErr := queue.ReadyCount(ctx, scope)
-		if countErr != nil {
-			return EnrichmentRunResult{}, fmt.Errorf("ebook enrichment: count remaining: %w", countErr)
+		hasMore, readyErr := queue.HasReady(ctx, scope)
+		if readyErr != nil {
+			return EnrichmentRunResult{}, fmt.Errorf("ebook enrichment: check remaining: %w", readyErr)
 		}
-		return EnrichmentRunResult{Remaining: remaining}, nil
+		return EnrichmentRunResult{HasMore: hasMore}, nil
 	}
 
 	loadItems := e.loadClaimedItems
@@ -231,10 +254,10 @@ func (e *Enricher) Run(ctx context.Context, scope EnrichmentScope) (EnrichmentRu
 		enrichItem = e.enrichClaimedItemFn
 	}
 	result, runErr := e.runQueueBatch(ctx, queue, jobs, items, enrichItem)
-	remaining, countErr := queue.ReadyCount(ctx, scope)
-	result.Remaining = remaining
-	if countErr != nil {
-		runErr = errors.Join(runErr, fmt.Errorf("ebook enrichment: count remaining: %w", countErr))
+	hasMore, readyErr := queue.HasReady(ctx, scope)
+	result.HasMore = hasMore
+	if readyErr != nil {
+		runErr = errors.Join(runErr, fmt.Errorf("ebook enrichment: check remaining: %w", readyErr))
 	}
 
 	slog.InfoContext(ctx, "ebook enrichment: sweep complete", "component", "ebooks",
@@ -243,12 +266,12 @@ func (e *Enricher) Run(ctx context.Context, scope EnrichmentScope) (EnrichmentRu
 		"no_match", result.NoMatch,
 		"failed", result.Failed,
 		"deferred", result.Deferred,
-		"remaining", result.Remaining,
+		"has_more", result.HasMore,
 	)
 	return result, runErr
 }
 
-func (e *Enricher) claimLimit() int {
+func (e *Enricher) claimLimit(maxClaims int) int {
 	batchSize := e.batchSize
 	if batchSize <= 0 {
 		batchSize = defaultEnrichBatchSize
@@ -257,7 +280,11 @@ func (e *Enricher) claimLimit() int {
 	if workers <= 0 {
 		workers = 1
 	}
-	return min(batchSize, workers)
+	limit := min(batchSize, workers)
+	if maxClaims > 0 {
+		limit = min(limit, maxClaims)
+	}
+	return limit
 }
 
 func (e *Enricher) runQueueBatch(

--- a/internal/ebooks/enrichment.go
+++ b/internal/ebooks/enrichment.go
@@ -19,6 +19,9 @@ import (
 	"time"
 
 	"github.com/jackc/pgx/v5/pgxpool"
+	"google.golang.org/genproto/googleapis/rpc/errdetails"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 
 	"github.com/Silo-Server/silo-server/internal/catalog"
 	"github.com/Silo-Server/silo-server/internal/metadata"
@@ -30,19 +33,11 @@ const (
 
 	defaultEnrichBatchSize = 50
 	defaultEnrichWorkers   = 4
-
-	// enrichFailureCap is the ebook_enrichment_state.failures count at which
-	// an ebook stops being claimed for enrichment. Combined with the
-	// failure-count-first claim ordering this prevents a head-of-line block
-	// of permanently failing items from starving newer items and hammering
-	// providers.
-	enrichFailureCap = 5
 )
 
-// errEnrichmentSkipped marks an item that could not be attempted at all (no
-// library folder linked yet, no providers configured). Skipped items are
-// neither stamped as refreshed nor counted against the failure cap, so they
-// are retried on every sweep until the missing prerequisite appears.
+// errEnrichmentSkipped preserves the direct helper contract for an item that
+// cannot be attempted. Queue-backed runs record a short skipped horizon instead
+// of counting the missing prerequisite as a provider failure.
 var errEnrichmentSkipped = errors.New("ebook enrichment skipped")
 
 func ebookContentType() string {
@@ -70,6 +65,26 @@ type enrichmentItemRow struct {
 	Language    string
 	Author      string
 	ProviderIDs map[string]string
+	Status      string
+	Overview    string
+	ReleaseDate string
+	Genres      []string
+	Studios     []string
+	PosterPath  string
+}
+
+type enrichmentQueue interface {
+	MaterializeCandidates(ctx context.Context) error
+	ClaimBatch(ctx context.Context, limit int, leaseDuration time.Duration) ([]EnrichmentJob, error)
+	Complete(ctx context.Context, contentID string, outcome EnrichmentOutcome, refreshAfter time.Duration) error
+	Fail(ctx context.Context, contentID string, errorClass EnrichmentErrorClass, message string, retryAfter time.Duration) error
+	Release(ctx context.Context, contentID string) error
+}
+
+type claimAwareEnrichmentQueue interface {
+	CompleteClaim(ctx context.Context, job EnrichmentJob, outcome EnrichmentOutcome, refreshAfter time.Duration) error
+	FailClaim(ctx context.Context, job EnrichmentJob, errorClass EnrichmentErrorClass, message string, retryAfter time.Duration) error
+	ReleaseClaim(ctx context.Context, job EnrichmentJob) error
 }
 
 // Enricher drives the ebook metadata enrichment sweep.
@@ -85,6 +100,10 @@ type Enricher struct {
 	workLinker     literaryWorkLinker
 	batchSize      int
 	workers        int
+	queue          enrichmentQueue
+
+	loadClaimedItemsFn  func(context.Context, []EnrichmentJob) ([]enrichmentItemRow, error)
+	enrichClaimedItemFn func(context.Context, enrichmentItemRow) (EnrichmentOutcome, error)
 }
 
 type literaryWorkLinker interface {
@@ -108,6 +127,7 @@ func NewEnricher(
 		providerIDs: providerIDs,
 		batchSize:   defaultEnrichBatchSize,
 		workers:     ebookEnrichWorkers(),
+		queue:       NewEnrichmentQueue(pool),
 	}
 }
 
@@ -133,16 +153,36 @@ func (e *Enricher) SetLiteraryWorkLinker(linker literaryWorkLinker) {
 }
 
 func (e *Enricher) Run(ctx context.Context) (int, error) {
-	if e == nil || e.pool == nil || e.chainRepo == nil {
+	if e == nil {
 		return 0, nil
 	}
 
-	items, err := e.claimBatch(ctx)
+	queue := e.queue
+	if queue == nil && e.pool != nil {
+		queue = NewEnrichmentQueue(e.pool)
+	}
+	if queue == nil || (e.chainRepo == nil && e.enrichClaimedItemFn == nil) {
+		return 0, nil
+	}
+	if err := queue.MaterializeCandidates(ctx); err != nil {
+		return 0, fmt.Errorf("ebook enrichment: materialize candidates: %w", err)
+	}
+	jobs, err := queue.ClaimBatch(ctx, e.batchSize, defaultEnrichmentLease)
 	if err != nil {
 		return 0, fmt.Errorf("ebook enrichment: claim batch: %w", err)
 	}
-	if len(items) == 0 {
+	if len(jobs) == 0 {
 		return 0, nil
+	}
+
+	loadItems := e.loadClaimedItems
+	if e.loadClaimedItemsFn != nil {
+		loadItems = e.loadClaimedItemsFn
+	}
+	items, err := loadItems(ctx, jobs)
+	if err != nil {
+		e.releaseJobs(queue, jobs)
+		return 0, fmt.Errorf("ebook enrichment: load claimed items: %w", err)
 	}
 
 	slog.InfoContext(ctx, "ebook enrichment: sweep started", "component", "ebooks",
@@ -150,13 +190,173 @@ func (e *Enricher) Run(ctx context.Context) (int, error) {
 		"workers", e.workers,
 	)
 
-	enriched := e.runBatch(ctx, items, e.enrichItem, e.recordEnrichFailure)
+	enrichItem := e.enrichClaimedItem
+	if e.enrichClaimedItemFn != nil {
+		enrichItem = e.enrichClaimedItemFn
+	}
+	enriched, runErr := e.runQueueBatch(ctx, queue, jobs, items, enrichItem)
 
 	slog.InfoContext(ctx, "ebook enrichment: sweep complete", "component", "ebooks",
 		"attempted", len(items),
 		"enriched", enriched,
 	)
-	return enriched, nil
+	return enriched, runErr
+}
+
+func (e *Enricher) runQueueBatch(
+	ctx context.Context,
+	queue enrichmentQueue,
+	jobs []EnrichmentJob,
+	items []enrichmentItemRow,
+	enrichFn func(context.Context, enrichmentItemRow) (EnrichmentOutcome, error),
+) (int, error) {
+	claimedJobs := make(map[string]EnrichmentJob, len(jobs))
+	for _, job := range jobs {
+		claimedJobs[job.ContentID] = job
+	}
+	loaded := make(map[string]struct{}, len(items))
+	for i := range items {
+		loaded[items[i].ContentID] = struct{}{}
+	}
+	for _, job := range jobs {
+		if _, ok := loaded[job.ContentID]; !ok {
+			_ = e.releaseJob(queue, job)
+		}
+	}
+
+	workers := e.workers
+	if workers <= 0 {
+		workers = 1
+	}
+	if workers > len(items) {
+		workers = len(items)
+	}
+	if workers == 0 {
+		return 0, nil
+	}
+
+	ch := make(chan enrichmentItemRow, workers)
+	var (
+		wg             sync.WaitGroup
+		enriched       int64
+		transitionMu   sync.Mutex
+		transitionErrs []error
+	)
+	recordTransitionError := func(contentID string, err error) {
+		if err == nil || errors.Is(err, ErrEnrichmentLeaseLost) {
+			return
+		}
+		transitionMu.Lock()
+		defer transitionMu.Unlock()
+		transitionErrs = append(transitionErrs, fmt.Errorf("%s: %w", contentID, err))
+	}
+
+	for i := 0; i < workers; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for item := range ch {
+				job := claimedJobs[item.ContentID]
+				if ctx.Err() != nil {
+					recordTransitionError(item.ContentID, e.releaseJob(queue, job))
+					continue
+				}
+
+				outcome, enrichErr := enrichFn(ctx, item)
+				if ctx.Err() != nil || errors.Is(enrichErr, context.Canceled) || errors.Is(enrichErr, context.DeadlineExceeded) {
+					recordTransitionError(item.ContentID, e.releaseJob(queue, job))
+					continue
+				}
+				if enrichErr != nil {
+					errorClass, retryAfter := classifyEnrichmentError(enrichErr)
+					transitionErr := e.failJob(
+						queue,
+						ctx,
+						job,
+						errorClass,
+						enrichErr.Error(),
+						retryAfter,
+					)
+					if transitionErr != nil && (ctx.Err() != nil ||
+						errors.Is(transitionErr, context.Canceled) ||
+						errors.Is(transitionErr, context.DeadlineExceeded)) {
+						recordTransitionError(item.ContentID, e.releaseJob(queue, job))
+					}
+					recordTransitionError(item.ContentID, transitionErr)
+					continue
+				}
+				transitionErr := e.completeJob(queue, ctx, job, outcome)
+				if transitionErr != nil && (ctx.Err() != nil ||
+					errors.Is(transitionErr, context.Canceled) ||
+					errors.Is(transitionErr, context.DeadlineExceeded)) {
+					recordTransitionError(item.ContentID, e.releaseJob(queue, job))
+				}
+				if transitionErr != nil {
+					recordTransitionError(item.ContentID, transitionErr)
+					continue
+				}
+				if outcome == EnrichmentOutcomeSuccess {
+					atomic.AddInt64(&enriched, 1)
+				}
+			}
+		}()
+	}
+	for _, item := range items {
+		ch <- item
+	}
+	close(ch)
+	wg.Wait()
+
+	if ctx.Err() != nil {
+		transitionErrs = append([]error{ctx.Err()}, transitionErrs...)
+	}
+	return int(enriched), errors.Join(transitionErrs...)
+}
+
+func (e *Enricher) releaseJobs(queue enrichmentQueue, jobs []EnrichmentJob) {
+	for _, job := range jobs {
+		if err := e.releaseJob(queue, job); err != nil && !errors.Is(err, ErrEnrichmentLeaseLost) {
+			slog.Warn("ebook enrichment: failed to release lease", "component", "ebooks",
+				"content_id", job.ContentID,
+				"error", err,
+			)
+		}
+	}
+}
+
+func (e *Enricher) completeJob(
+	queue enrichmentQueue,
+	ctx context.Context,
+	job EnrichmentJob,
+	outcome EnrichmentOutcome,
+) error {
+	if claimQueue, ok := queue.(claimAwareEnrichmentQueue); ok {
+		return claimQueue.CompleteClaim(ctx, job, outcome, enrichmentRefreshHorizon(outcome))
+	}
+	return queue.Complete(ctx, job.ContentID, outcome, enrichmentRefreshHorizon(outcome))
+}
+
+func (e *Enricher) failJob(
+	queue enrichmentQueue,
+	ctx context.Context,
+	job EnrichmentJob,
+	errorClass EnrichmentErrorClass,
+	message string,
+	retryAfter time.Duration,
+) error {
+	if claimQueue, ok := queue.(claimAwareEnrichmentQueue); ok {
+		return claimQueue.FailClaim(ctx, job, errorClass, message, retryAfter)
+	}
+	return queue.Fail(ctx, job.ContentID, errorClass, message, retryAfter)
+}
+
+func (e *Enricher) releaseJob(queue enrichmentQueue, job EnrichmentJob) error {
+	releaseCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	if claimQueue, ok := queue.(claimAwareEnrichmentQueue); ok {
+		return claimQueue.ReleaseClaim(releaseCtx, job)
+	}
+	return queue.Release(releaseCtx, job.ContentID)
 }
 
 func (e *Enricher) runBatch(
@@ -222,15 +422,12 @@ func (e *Enricher) runBatch(
 	return int(enriched)
 }
 
-// claimBatchQuery selects unenriched ebooks. Items with fewer prior failures
-// are claimed first and items at/above enrichFailureCap are skipped entirely,
-// so a block of permanently failing items cannot occupy every sweep.
-var claimBatchQuery = `
+var loadEnrichmentItemsQuery = `
 	SELECT
 		mi.content_id,
 		mi.title,
-		mi.year,
-		COALESCE(mil.media_folder_id, 0) AS folder_id,
+		COALESCE(mi.year, 0),
+		COALESCE(membership.media_folder_id, 0) AS folder_id,
 		COALESCE(mf.metadata_language, 'en') AS language,
 		COALESCE(
 			(SELECT p.name
@@ -241,33 +438,40 @@ var claimBatchQuery = `
 			 ORDER BY ip.sort_order, ip.id
 			 LIMIT 1),
 			''
-		) AS author
-	FROM media_items mi
-	LEFT JOIN media_item_libraries mil ON mil.content_id = mi.content_id
-	LEFT JOIN media_folders mf ON mf.id = mil.media_folder_id
-	LEFT JOIN ebook_enrichment_state ees ON ees.content_id = mi.content_id
+		) AS author,
+		COALESCE(mi.status, ''),
+		COALESCE(mi.overview, ''),
+		COALESCE(mi.release_date, ''),
+		COALESCE(mi.genres, '{}'),
+		COALESCE(mi.studios, '{}'),
+		COALESCE(mi.poster_path, '')
+	FROM unnest($1::text[]) WITH ORDINALITY AS claimed(content_id, position)
+	JOIN media_items mi ON mi.content_id = claimed.content_id
+	LEFT JOIN LATERAL (
+		SELECT mil.media_folder_id
+		FROM media_item_libraries mil
+		WHERE mil.content_id = mi.content_id
+		ORDER BY mil.first_seen_at, mil.media_folder_id
+		LIMIT 1
+	) membership ON true
+	LEFT JOIN media_folders mf ON mf.id = membership.media_folder_id
 	WHERE mi.type = 'ebook'
-	  -- Manga chapters are type='ebook' but are parts of a series, not
-	  -- standalone books. They are enriched via their type='manga' series (a
-	  -- separate path), never individually against book sources — excluding
-	  -- them here stops a pointless search storm over Gutenberg/Anna's/etc.
 	  AND ` + catalog.MangaChapterExclusionWhere("mi") + `
-	  AND (mi.poster_path IS NULL OR mi.poster_path = '')
-	  AND mi.last_refreshed IS NULL
-	  AND COALESCE(ees.failures, 0) < $2
-	ORDER BY COALESCE(ees.failures, 0) ASC, mi.created_at ASC
-	LIMIT $1
+	ORDER BY claimed.position
 `
 
-func (e *Enricher) claimBatch(ctx context.Context) ([]enrichmentItemRow, error) {
-	rows, err := e.pool.Query(ctx, claimBatchQuery, e.batchSize, enrichFailureCap)
+func (e *Enricher) loadClaimedItems(ctx context.Context, jobs []EnrichmentJob) ([]enrichmentItemRow, error) {
+	contentIDs := make([]string, 0, len(jobs))
+	for _, job := range jobs {
+		contentIDs = append(contentIDs, job.ContentID)
+	}
+	rows, err := e.pool.Query(ctx, loadEnrichmentItemsQuery, contentIDs)
 	if err != nil {
-		return nil, fmt.Errorf("querying unenriched ebooks: %w", err)
+		return nil, fmt.Errorf("querying claimed ebooks: %w", err)
 	}
 	defer rows.Close()
 
 	var items []enrichmentItemRow
-	seen := make(map[string]struct{})
 	for rows.Next() {
 		var item enrichmentItemRow
 		if err := rows.Scan(
@@ -277,13 +481,15 @@ func (e *Enricher) claimBatch(ctx context.Context) ([]enrichmentItemRow, error) 
 			&item.FolderID,
 			&item.Language,
 			&item.Author,
+			&item.Status,
+			&item.Overview,
+			&item.ReleaseDate,
+			&item.Genres,
+			&item.Studios,
+			&item.PosterPath,
 		); err != nil {
 			return nil, fmt.Errorf("scanning ebook enrichment row: %w", err)
 		}
-		if _, dup := seen[item.ContentID]; dup {
-			continue
-		}
-		seen[item.ContentID] = struct{}{}
 		items = append(items, item)
 	}
 	if err := rows.Err(); err != nil {
@@ -303,19 +509,27 @@ func (e *Enricher) claimBatch(ctx context.Context) ([]enrichmentItemRow, error) 
 }
 
 func (e *Enricher) enrichItem(ctx context.Context, item enrichmentItemRow) error {
+	outcome, err := e.enrichClaimedItem(ctx, item)
+	if err == nil && outcome == EnrichmentOutcomeSkipped {
+		return fmt.Errorf("%w: item %s is not ready", errEnrichmentSkipped, item.ContentID)
+	}
+	return err
+}
+
+func (e *Enricher) enrichClaimedItem(ctx context.Context, item enrichmentItemRow) (EnrichmentOutcome, error) {
 	if item.FolderID == 0 {
 		// The scanner inserts the library membership after the item upsert, so
 		// a freshly indexed ebook can be claimed inside that window. Skip it:
 		// stamping here would terminally mark the item refreshed before any
 		// provider ever saw it.
-		return fmt.Errorf("%w: item %s has no library folder yet", errEnrichmentSkipped, item.ContentID)
+		return EnrichmentOutcomeSkipped, nil
 	}
 
 	providers, err := metadata.ResolveChain(ctx, item.FolderID, ebookContentType(), e.chainRepo, e.resolver)
 	if err != nil {
-		return fmt.Errorf("resolving ebook chain for folder %d: %w", item.FolderID, err)
+		return "", fmt.Errorf("resolving ebook chain for folder %d: %w", item.FolderID, err)
 	}
-	return e.enrichWithProviders(ctx, item, providers)
+	return e.enrichWithProvidersOutcome(ctx, item, providers)
 }
 
 // enrichWithProviders runs the provider chain for one claimed item. Outcomes:
@@ -323,12 +537,24 @@ func (e *Enricher) enrichItem(ctx context.Context, item enrichmentItemRow) error
 //   - providers answered but nothing matched: stamp last_refreshed so the
 //     item is not re-claimed every sweep (nil error);
 //   - one or more providers errored and no metadata was obtained: return an
-//     error so the failure cap/backoff engages, without stamping;
+//     error so durable queue backoff engages, without stamping;
 //   - no providers configured: skip (no stamp, no failure) so the item is
 //     retried once a chain exists.
 func (e *Enricher) enrichWithProviders(ctx context.Context, item enrichmentItemRow, providers []metadata.Provider) error {
-	if len(providers) == 0 {
+	outcome, err := e.enrichWithProvidersOutcome(ctx, item, providers)
+	if err == nil && outcome == EnrichmentOutcomeSkipped {
 		return fmt.Errorf("%w: no metadata providers configured for folder %d", errEnrichmentSkipped, item.FolderID)
+	}
+	return err
+}
+
+func (e *Enricher) enrichWithProvidersOutcome(
+	ctx context.Context,
+	item enrichmentItemRow,
+	providers []metadata.Provider,
+) (EnrichmentOutcome, error) {
+	if len(providers) == 0 {
+		return EnrichmentOutcomeSkipped, nil
 	}
 
 	var owner providerIDOwnerLookup
@@ -340,23 +566,25 @@ func (e *Enricher) enrichWithProviders(ctx context.Context, item enrichmentItemR
 	if !accumulator.HasMetadata && accumulator.PosterPath == "" && accumulator.Overview == "" {
 		if err := ctx.Err(); err != nil {
 			// A cancelled sweep says nothing about the item or the providers.
-			return err
+			return "", err
 		}
 		if len(providerErrs) > 0 {
-			// Transient provider trouble must not stamp the item terminally;
-			// surfacing an error engages the failure cap and backoff instead.
-			return fmt.Errorf("no metadata obtained, %d provider error(s): %w",
+			return "", fmt.Errorf("no metadata obtained, %d provider error(s): %w",
 				len(providerErrs), errors.Join(providerErrs...))
 		}
 		slog.InfoContext(ctx, "ebook enrichment: no metadata found", "component", "ebooks",
 			"content_id", item.ContentID,
 			"title", item.Title,
 		)
-		return e.stampLastRefreshed(ctx, item.ContentID)
+		if err := e.stampLastRefreshed(ctx, item.ContentID); err != nil {
+			return "", err
+		}
+		return EnrichmentOutcomeNoMatch, nil
 	}
 
+	preserveEbookLocalMetadata(item, accumulator)
 	if err := e.persist(ctx, item.ContentID, accumulatedIDs, accumulator); err != nil {
-		return fmt.Errorf("persisting enrichment for %s: %w", item.ContentID, err)
+		return "", fmt.Errorf("persisting enrichment for %s: %w", item.ContentID, err)
 	}
 	e.enqueueRemoteArtwork(ctx, item.ContentID, accumulator)
 	e.autoLinkLiteraryWork(ctx, item.ContentID)
@@ -369,7 +597,69 @@ func (e *Enricher) enrichWithProviders(ctx context.Context, item enrichmentItemR
 		"people", len(filterEbookPeople(accumulator.People)),
 	)
 
-	return nil
+	return EnrichmentOutcomeSuccess, nil
+}
+
+func preserveEbookLocalMetadata(item enrichmentItemRow, result *metadata.MetadataResult) {
+	if result == nil {
+		return
+	}
+	if item.PosterPath != "" && !ebookPosterOwnedByRemoteProvider(item.PosterPath) {
+		result.PosterPath = ""
+		result.PosterThumbhash = ""
+	}
+	if !strings.EqualFold(strings.TrimSpace(item.Status), "pending") {
+		return
+	}
+	if item.Year > 0 {
+		result.Year = 0
+	}
+	if item.Overview != "" {
+		result.Overview = ""
+	}
+	if item.ReleaseDate != "" {
+		result.ReleaseDate = ""
+	}
+	if len(item.Genres) > 0 {
+		result.Genres = nil
+	}
+	if len(item.Studios) > 0 {
+		result.Studios = nil
+	}
+	if item.Author != "" {
+		result.People = nil
+	}
+}
+
+func ebookPosterOwnedByRemoteProvider(path string) bool {
+	path = strings.TrimSpace(path)
+	return isRemoteHTTPImage(path) || strings.HasPrefix(path, ebookMetadataImageProviderID+"/ebooks/")
+}
+
+func classifyEnrichmentError(err error) (EnrichmentErrorClass, time.Duration) {
+	grpcStatus, ok := status.FromError(err)
+	if !ok {
+		return EnrichmentErrorTransient, 0
+	}
+
+	switch grpcStatus.Code() {
+	case codes.ResourceExhausted:
+		for _, detail := range grpcStatus.Details() {
+			if retry, ok := detail.(*errdetails.RetryInfo); ok && retry.GetRetryDelay() != nil {
+				return EnrichmentErrorRateLimited, retry.GetRetryDelay().AsDuration()
+			}
+		}
+		return EnrichmentErrorRateLimited, 0
+	case codes.InvalidArgument,
+		codes.NotFound,
+		codes.PermissionDenied,
+		codes.Unauthenticated,
+		codes.FailedPrecondition,
+		codes.Unimplemented:
+		return EnrichmentErrorPermanent, 0
+	default:
+		return EnrichmentErrorTransient, 0
+	}
 }
 
 // providerIDOwnerLookup reports the content item (if any) that already owns a
@@ -685,44 +975,14 @@ func (e *Enricher) stampLastRefreshed(ctx context.Context, contentID string) err
 		return nil
 	}
 	now := time.Now().UTC()
-	if _, err := e.pool.Exec(ctx, `
+	_, err := e.pool.Exec(ctx, `
 		UPDATE media_items
 		SET last_refreshed = $1,
 		    matched_at = COALESCE(matched_at, $1),
 		    status = CASE WHEN status = 'pending' THEN 'matched' ELSE status END
 		WHERE content_id = $2
-	`, now, contentID); err != nil {
-		return err
-	}
-	// Success clears the enrichment failure backlog. media_items.refresh_failures
-	// is intentionally left alone: it belongs to the metadata refresh-debt system.
-	_, err := e.pool.Exec(ctx, `
-		DELETE FROM ebook_enrichment_state WHERE content_id = $1
-	`, contentID)
+	`, now, contentID)
 	return err
-}
-
-// recordEnrichFailure increments the item's ebook_enrichment_state failure
-// counter so claimBatch deprioritizes it on the next sweep and stops claiming
-// it at enrichFailureCap. The state is dedicated to ebook enrichment;
-// media_items.refresh_failures is owned by the metadata refresh-debt system
-// and is never touched here.
-func (e *Enricher) recordEnrichFailure(ctx context.Context, item enrichmentItemRow) {
-	if e == nil || e.pool == nil {
-		return
-	}
-	if _, err := e.pool.Exec(ctx, `
-		INSERT INTO ebook_enrichment_state (content_id, failures, updated_at)
-		VALUES ($1, 1, NOW())
-		ON CONFLICT (content_id) DO UPDATE SET
-			failures   = ebook_enrichment_state.failures + 1,
-			updated_at = NOW()
-	`, item.ContentID); err != nil {
-		slog.WarnContext(ctx, "ebook enrichment: failed to record enrichment failure", "component", "ebooks",
-			"content_id", item.ContentID,
-			"error", err,
-		)
-	}
 }
 
 func (e *Enricher) persistPeople(ctx context.Context, contentID string, people []models.ItemPerson) error {

--- a/internal/ebooks/enrichment.go
+++ b/internal/ebooks/enrichment.go
@@ -713,12 +713,45 @@ func (e *Enricher) enrichClaimedItem(ctx context.Context, item enrichmentItemRow
 		// provider ever saw it.
 		return EnrichmentOutcomeSkipped, nil
 	}
+	if ebookHasCompleteLocalMetadata(item) {
+		slog.DebugContext(ctx, "ebook enrichment: local metadata is complete",
+			"component", "ebooks",
+			"content_id", item.ContentID,
+		)
+		return EnrichmentOutcomeSuccess, nil
+	}
+	slog.DebugContext(ctx, "ebook enrichment: remote metadata required",
+		"component", "ebooks",
+		"content_id", item.ContentID,
+		"missing_fields", ebookMissingMetadataFields(item),
+	)
 
 	providers, err := metadata.ResolveChain(ctx, item.FolderID, ebookContentType(), e.chainRepo, e.resolver)
 	if err != nil {
 		return "", fmt.Errorf("resolving ebook chain for folder %d: %w", item.FolderID, err)
 	}
 	return e.enrichWithProvidersOutcome(ctx, item, providers)
+}
+
+func ebookHasCompleteLocalMetadata(item enrichmentItemRow) bool {
+	return len(ebookMissingMetadataFields(item)) == 0
+}
+
+func ebookMissingMetadataFields(item enrichmentItemRow) []string {
+	missing := make([]string, 0, 4)
+	if strings.TrimSpace(item.Title) == "" {
+		missing = append(missing, "title")
+	}
+	if strings.TrimSpace(item.Author) == "" {
+		missing = append(missing, "author")
+	}
+	if strings.TrimSpace(item.Overview) == "" {
+		missing = append(missing, "description")
+	}
+	if strings.TrimSpace(item.PosterPath) == "" {
+		missing = append(missing, "cover")
+	}
+	return missing
 }
 
 // enrichWithProviders runs the provider chain for one claimed item. Outcomes:

--- a/internal/ebooks/enrichment.go
+++ b/internal/ebooks/enrichment.go
@@ -42,6 +42,22 @@ const (
 // of counting the missing prerequisite as a provider failure.
 var errEnrichmentSkipped = errors.New("ebook enrichment skipped")
 
+type enrichmentClaimCheck func(context.Context) error
+
+type enrichmentClaimCheckContextKey struct{}
+
+func withEnrichmentClaimCheck(ctx context.Context, check enrichmentClaimCheck) context.Context {
+	return context.WithValue(ctx, enrichmentClaimCheckContextKey{}, check)
+}
+
+func requireEnrichmentClaim(ctx context.Context) error {
+	check, _ := ctx.Value(enrichmentClaimCheckContextKey{}).(enrichmentClaimCheck)
+	if check == nil {
+		return nil
+	}
+	return check(ctx)
+}
+
 func ebookContentType() string {
 	return "ebook"
 }
@@ -83,8 +99,8 @@ type enrichmentItemRow struct {
 }
 
 type enrichmentQueue interface {
-	MaterializeCandidates(ctx context.Context) error
 	ClaimBatch(ctx context.Context, limit int, leaseDuration time.Duration) ([]EnrichmentJob, error)
+	CheckClaim(ctx context.Context, job EnrichmentJob) error
 	Complete(ctx context.Context, job EnrichmentJob, outcome EnrichmentOutcome, refreshAfter time.Duration) error
 	Fail(ctx context.Context, job EnrichmentJob, errorClass EnrichmentErrorClass, message string, retryAfter time.Duration) error
 	Release(ctx context.Context, job EnrichmentJob) error
@@ -169,10 +185,7 @@ func (e *Enricher) Run(ctx context.Context) (int, error) {
 	if queue == nil || (e.chainRepo == nil && e.enrichClaimedItemFn == nil) {
 		return 0, nil
 	}
-	if err := queue.MaterializeCandidates(ctx); err != nil {
-		return 0, fmt.Errorf("ebook enrichment: materialize candidates: %w", err)
-	}
-	jobs, err := queue.ClaimBatch(ctx, e.batchSize, defaultEnrichmentLease)
+	jobs, err := queue.ClaimBatch(ctx, e.claimLimit(), defaultEnrichmentLease)
 	if err != nil {
 		return 0, fmt.Errorf("ebook enrichment: claim batch: %w", err)
 	}
@@ -206,6 +219,18 @@ func (e *Enricher) Run(ctx context.Context) (int, error) {
 		"enriched", enriched,
 	)
 	return enriched, runErr
+}
+
+func (e *Enricher) claimLimit() int {
+	batchSize := e.batchSize
+	if batchSize <= 0 {
+		batchSize = defaultEnrichBatchSize
+	}
+	workers := e.workers
+	if workers <= 0 {
+		workers = 1
+	}
+	return min(batchSize, workers)
 }
 
 func (e *Enricher) runQueueBatch(
@@ -274,11 +299,34 @@ func (e *Enricher) runQueueBatch(
 				}
 
 				itemCtx, cancelItem := context.WithTimeout(ctx, itemTimeout)
+				itemCtx = withEnrichmentClaimCheck(itemCtx, func(checkCtx context.Context) error {
+					return queue.CheckClaim(checkCtx, job)
+				})
 				outcome, enrichErr := enrichFn(itemCtx, item)
 				itemCtxErr := itemCtx.Err()
 				cancelItem()
-				if ctx.Err() != nil || itemCtxErr != nil ||
-					errors.Is(enrichErr, context.Canceled) || errors.Is(enrichErr, context.DeadlineExceeded) {
+				if ctx.Err() != nil {
+					recordTransitionError(item.ContentID, e.releaseJob(queue, job))
+					continue
+				}
+				if errors.Is(itemCtxErr, context.DeadlineExceeded) ||
+					errors.Is(enrichErr, context.DeadlineExceeded) {
+					timeoutErr := itemCtxErr
+					if timeoutErr == nil {
+						timeoutErr = enrichErr
+					}
+					transitionErr := e.failJob(
+						queue,
+						ctx,
+						job,
+						EnrichmentErrorTransient,
+						fmt.Sprintf("ebook enrichment item timeout: %v", timeoutErr),
+						0,
+					)
+					recordTransitionError(item.ContentID, transitionErr)
+					continue
+				}
+				if errors.Is(enrichErr, context.Canceled) {
 					recordTransitionError(item.ContentID, e.releaseJob(queue, job))
 					continue
 				}
@@ -603,6 +651,9 @@ func (e *Enricher) enrichWithProvidersOutcome(
 			"content_id", item.ContentID,
 			"title", item.Title,
 		)
+		if err := requireEnrichmentClaim(ctx); err != nil {
+			return "", err
+		}
 		if err := e.stampLastRefreshed(ctx, item.ContentID); err != nil {
 			return "", err
 		}
@@ -947,6 +998,9 @@ func isNilImageCacher(cacher metadata.ImageCacher) bool {
 }
 
 func (e *Enricher) persist(ctx context.Context, contentID string, providerIDs map[string]string, result *metadata.MetadataResult) error {
+	if err := requireEnrichmentClaim(ctx); err != nil {
+		return err
+	}
 	upd := &catalog.MetadataUpdate{}
 
 	if result.PosterPath != "" {

--- a/internal/ebooks/enrichment.go
+++ b/internal/ebooks/enrichment.go
@@ -99,12 +99,22 @@ type enrichmentItemRow struct {
 }
 
 type enrichmentQueue interface {
-	ClaimBatch(ctx context.Context, limit int, leaseDuration time.Duration) ([]EnrichmentJob, error)
+	ClaimBatch(ctx context.Context, scope EnrichmentScope, limit int, leaseDuration time.Duration) ([]EnrichmentJob, error)
+	ReadyCount(ctx context.Context, scope EnrichmentScope) (int, error)
 	CheckClaim(ctx context.Context, job EnrichmentJob) error
 	Complete(ctx context.Context, job EnrichmentJob, outcome EnrichmentOutcome, refreshAfter time.Duration) error
 	Fail(ctx context.Context, job EnrichmentJob, errorClass EnrichmentErrorClass, message string, retryAfter time.Duration) error
 	Release(ctx context.Context, job EnrichmentJob) error
 	Discard(ctx context.Context, job EnrichmentJob) error
+}
+
+type EnrichmentRunResult struct {
+	Claimed   int `json:"claimed"`
+	Enriched  int `json:"enriched"`
+	NoMatch   int `json:"no_match"`
+	Failed    int `json:"failed"`
+	Deferred  int `json:"deferred"`
+	Remaining int `json:"remaining"`
 }
 
 // Enricher drives the ebook metadata enrichment sweep.
@@ -173,9 +183,12 @@ func (e *Enricher) SetLiteraryWorkLinker(linker literaryWorkLinker) {
 	e.workLinker = linker
 }
 
-func (e *Enricher) Run(ctx context.Context) (int, error) {
+func (e *Enricher) Run(ctx context.Context, scope EnrichmentScope) (EnrichmentRunResult, error) {
 	if e == nil {
-		return 0, nil
+		return EnrichmentRunResult{}, nil
+	}
+	if err := scope.validate(); err != nil {
+		return EnrichmentRunResult{}, err
 	}
 
 	queue := e.queue
@@ -183,14 +196,18 @@ func (e *Enricher) Run(ctx context.Context) (int, error) {
 		queue = NewEnrichmentQueue(e.pool)
 	}
 	if queue == nil || (e.chainRepo == nil && e.enrichClaimedItemFn == nil) {
-		return 0, nil
+		return EnrichmentRunResult{}, nil
 	}
-	jobs, err := queue.ClaimBatch(ctx, e.claimLimit(), defaultEnrichmentLease)
+	jobs, err := queue.ClaimBatch(ctx, scope, e.claimLimit(), defaultEnrichmentLease)
 	if err != nil {
-		return 0, fmt.Errorf("ebook enrichment: claim batch: %w", err)
+		return EnrichmentRunResult{}, fmt.Errorf("ebook enrichment: claim batch: %w", err)
 	}
 	if len(jobs) == 0 {
-		return 0, nil
+		remaining, countErr := queue.ReadyCount(ctx, scope)
+		if countErr != nil {
+			return EnrichmentRunResult{}, fmt.Errorf("ebook enrichment: count remaining: %w", countErr)
+		}
+		return EnrichmentRunResult{Remaining: remaining}, nil
 	}
 
 	loadItems := e.loadClaimedItems
@@ -200,7 +217,8 @@ func (e *Enricher) Run(ctx context.Context) (int, error) {
 	items, err := loadItems(ctx, jobs)
 	if err != nil {
 		e.releaseJobs(queue, jobs)
-		return 0, fmt.Errorf("ebook enrichment: load claimed items: %w", err)
+		return EnrichmentRunResult{Claimed: len(jobs), Deferred: len(jobs)},
+			fmt.Errorf("ebook enrichment: load claimed items: %w", err)
 	}
 
 	slog.InfoContext(ctx, "ebook enrichment: sweep started", "component", "ebooks",
@@ -212,13 +230,22 @@ func (e *Enricher) Run(ctx context.Context) (int, error) {
 	if e.enrichClaimedItemFn != nil {
 		enrichItem = e.enrichClaimedItemFn
 	}
-	enriched, runErr := e.runQueueBatch(ctx, queue, jobs, items, enrichItem)
+	result, runErr := e.runQueueBatch(ctx, queue, jobs, items, enrichItem)
+	remaining, countErr := queue.ReadyCount(ctx, scope)
+	result.Remaining = remaining
+	if countErr != nil {
+		runErr = errors.Join(runErr, fmt.Errorf("ebook enrichment: count remaining: %w", countErr))
+	}
 
 	slog.InfoContext(ctx, "ebook enrichment: sweep complete", "component", "ebooks",
 		"attempted", len(items),
-		"enriched", enriched,
+		"enriched", result.Enriched,
+		"no_match", result.NoMatch,
+		"failed", result.Failed,
+		"deferred", result.Deferred,
+		"remaining", result.Remaining,
 	)
-	return enriched, runErr
+	return result, runErr
 }
 
 func (e *Enricher) claimLimit() int {
@@ -239,7 +266,8 @@ func (e *Enricher) runQueueBatch(
 	jobs []EnrichmentJob,
 	items []enrichmentItemRow,
 	enrichFn func(context.Context, enrichmentItemRow) (EnrichmentOutcome, error),
-) (int, error) {
+) (EnrichmentRunResult, error) {
+	result := EnrichmentRunResult{Claimed: len(jobs)}
 	claimedJobs := make(map[string]EnrichmentJob, len(jobs))
 	for _, job := range jobs {
 		claimedJobs[job.ContentID] = job
@@ -253,6 +281,8 @@ func (e *Enricher) runQueueBatch(
 		if _, ok := loaded[job.ContentID]; !ok {
 			if err := e.discardJob(queue, job); err != nil && !errors.Is(err, ErrEnrichmentLeaseLost) {
 				transitionErrs = append(transitionErrs, fmt.Errorf("%s: %w", job.ContentID, err))
+			} else if err == nil {
+				result.Deferred++
 			}
 		}
 	}
@@ -265,7 +295,7 @@ func (e *Enricher) runQueueBatch(
 		workers = len(items)
 	}
 	if workers == 0 {
-		return 0, errors.Join(transitionErrs...)
+		return result, errors.Join(transitionErrs...)
 	}
 	itemTimeout := e.itemTimeout
 	if itemTimeout <= 0 || itemTimeout >= defaultEnrichmentLease {
@@ -276,6 +306,9 @@ func (e *Enricher) runQueueBatch(
 	var (
 		wg           sync.WaitGroup
 		enriched     int64
+		noMatch      int64
+		failed       int64
+		deferred     int64
 		transitionMu sync.Mutex
 	)
 	recordTransitionError := func(contentID string, err error) {
@@ -324,6 +357,9 @@ func (e *Enricher) runQueueBatch(
 						0,
 					)
 					recordTransitionError(item.ContentID, transitionErr)
+					if transitionErr == nil {
+						atomic.AddInt64(&failed, 1)
+					}
 					continue
 				}
 				if errors.Is(enrichErr, context.Canceled) {
@@ -346,6 +382,9 @@ func (e *Enricher) runQueueBatch(
 						recordTransitionError(item.ContentID, e.releaseJob(queue, job))
 					}
 					recordTransitionError(item.ContentID, transitionErr)
+					if transitionErr == nil {
+						atomic.AddInt64(&failed, 1)
+					}
 					continue
 				}
 				transitionErr := e.completeJob(queue, ctx, job, outcome)
@@ -360,6 +399,10 @@ func (e *Enricher) runQueueBatch(
 				}
 				if outcome == EnrichmentOutcomeSuccess {
 					atomic.AddInt64(&enriched, 1)
+				} else if outcome == EnrichmentOutcomeNoMatch {
+					atomic.AddInt64(&noMatch, 1)
+				} else {
+					atomic.AddInt64(&deferred, 1)
 				}
 			}
 		}()
@@ -373,7 +416,11 @@ func (e *Enricher) runQueueBatch(
 	if ctx.Err() != nil {
 		transitionErrs = append([]error{ctx.Err()}, transitionErrs...)
 	}
-	return int(enriched), errors.Join(transitionErrs...)
+	result.Enriched += int(enriched)
+	result.NoMatch += int(noMatch)
+	result.Failed += int(failed)
+	result.Deferred += int(deferred)
+	return result, errors.Join(transitionErrs...)
 }
 
 func (e *Enricher) releaseJobs(queue enrichmentQueue, jobs []EnrichmentJob) {

--- a/internal/ebooks/enrichment_queue.go
+++ b/internal/ebooks/enrichment_queue.go
@@ -157,24 +157,24 @@ func (q *EnrichmentQueue) Enqueue(ctx context.Context, contentID string, priorit
 
 // Each indexed window is fixed-size; only their deduplicated union pays for
 // aging/ranking, while the oldest-due window guarantees eventual promotion.
-var claimEnrichmentJobsQuery = `
+const claimEnrichmentJobsQueryTemplate = `
 	WITH high_priority_candidates AS MATERIALIZED (
 		SELECT content_id, priority, next_attempt_at, updated_at
 		FROM ebook_enrichment_state
 		WHERE next_attempt_at <= now()
 		  AND (status = 'pending' OR (status = 'running' AND lease_until < now()))
-		  AND (priority < 0) = ($3 = 'legacy')
+		  AND {{lane_predicate}}
 		ORDER BY priority DESC, next_attempt_at, updated_at
-		LIMIT $4
+		LIMIT $3
 	),
 	oldest_due_candidates AS MATERIALIZED (
 		SELECT content_id, priority, next_attempt_at, updated_at
 		FROM ebook_enrichment_state
 		WHERE next_attempt_at <= now()
 		  AND (status = 'pending' OR (status = 'running' AND lease_until < now()))
-		  AND (priority < 0) = ($3 = 'legacy')
+		  AND {{lane_predicate}}
 		ORDER BY next_attempt_at, updated_at, priority DESC
-		LIMIT $4
+		LIMIT $3
 	),
 	candidate_pool AS MATERIALIZED (
 		SELECT * FROM high_priority_candidates
@@ -196,7 +196,7 @@ var claimEnrichmentJobsQuery = `
 		JOIN ebook_enrichment_state state ON state.content_id = ranked.content_id
 		WHERE state.next_attempt_at <= now()
 		  AND (state.status = 'pending' OR (state.status = 'running' AND state.lease_until < now()))
-		  AND (state.priority < 0) = ($3 = 'legacy')
+		  AND {{state_lane_predicate}}
 		ORDER BY
 			ranked.effective_priority DESC,
 			ranked.priority DESC,
@@ -217,6 +217,23 @@ var claimEnrichmentJobsQuery = `
 	RETURNING state.content_id, state.claim_token, state.attempts, state.last_attempt_at, state.protected_fields
 `
 
+var (
+	claimIncrementalEnrichmentJobsQuery = buildClaimEnrichmentJobsQuery("priority >= 0", "state.priority >= 0")
+	claimLegacyEnrichmentJobsQuery      = buildClaimEnrichmentJobsQuery("priority < 0", "state.priority < 0")
+)
+
+func buildClaimEnrichmentJobsQuery(lanePredicate, stateLanePredicate string) string {
+	query := strings.ReplaceAll(claimEnrichmentJobsQueryTemplate, "{{lane_predicate}}", lanePredicate)
+	return strings.ReplaceAll(query, "{{state_lane_predicate}}", stateLanePredicate)
+}
+
+func claimEnrichmentJobsQueryForScope(scope EnrichmentScope) string {
+	if scope == EnrichmentScopeLegacy {
+		return claimLegacyEnrichmentJobsQuery
+	}
+	return claimIncrementalEnrichmentJobsQuery
+}
+
 func (q *EnrichmentQueue) ClaimBatch(
 	ctx context.Context,
 	scope EnrichmentScope,
@@ -236,12 +253,12 @@ func (q *EnrichmentQueue) ClaimBatch(
 		leaseDuration = defaultEnrichmentLease
 	}
 
+	query := claimEnrichmentJobsQueryForScope(scope)
 	rows, err := q.pool.Query(
 		ctx,
-		claimEnrichmentJobsQuery,
+		query,
 		limit,
 		postgresInterval(leaseDuration),
-		string(scope),
 		claimCandidateWindow,
 	)
 	if err != nil {
@@ -263,13 +280,33 @@ func (q *EnrichmentQueue) ClaimBatch(
 	return jobs, nil
 }
 
-var countReadyEnrichmentJobsQuery = `
+const countReadyEnrichmentJobsQueryTemplate = `
 	SELECT COUNT(*)
 	FROM ebook_enrichment_state
 	WHERE next_attempt_at <= now()
 	  AND (status = 'pending' OR (status = 'running' AND lease_until < now()))
-	  AND (priority < 0) = ($1 = 'legacy')
+	  AND {{lane_predicate}}
 `
+
+var (
+	countReadyIncrementalEnrichmentJobsQuery = strings.ReplaceAll(
+		countReadyEnrichmentJobsQueryTemplate,
+		"{{lane_predicate}}",
+		"priority >= 0",
+	)
+	countReadyLegacyEnrichmentJobsQuery = strings.ReplaceAll(
+		countReadyEnrichmentJobsQueryTemplate,
+		"{{lane_predicate}}",
+		"priority < 0",
+	)
+)
+
+func countReadyEnrichmentJobsQueryForScope(scope EnrichmentScope) string {
+	if scope == EnrichmentScopeLegacy {
+		return countReadyLegacyEnrichmentJobsQuery
+	}
+	return countReadyIncrementalEnrichmentJobsQuery
+}
 
 func (q *EnrichmentQueue) ReadyCount(ctx context.Context, scope EnrichmentScope) (int, error) {
 	if q == nil || q.pool == nil {
@@ -279,7 +316,7 @@ func (q *EnrichmentQueue) ReadyCount(ctx context.Context, scope EnrichmentScope)
 		return 0, err
 	}
 	var count int
-	if err := q.pool.QueryRow(ctx, countReadyEnrichmentJobsQuery, string(scope)).Scan(&count); err != nil {
+	if err := q.pool.QueryRow(ctx, countReadyEnrichmentJobsQueryForScope(scope)).Scan(&count); err != nil {
 		return 0, err
 	}
 	return count, nil

--- a/internal/ebooks/enrichment_queue.go
+++ b/internal/ebooks/enrichment_queue.go
@@ -170,6 +170,37 @@ const lockEnrichmentReconcileCursorQuery = `
 	FOR UPDATE
 `
 
+var reconcileRecentMissingEnrichmentJobsQuery = `
+	WITH recent_memberships AS MATERIALIZED (
+		SELECT membership.content_id
+		FROM media_item_libraries membership
+		WHERE membership.media_folder_id = $1
+		ORDER BY membership.first_seen_at DESC, membership.content_id DESC
+		LIMIT $3
+	),
+	candidates AS MATERIALIZED (
+		SELECT candidate.content_id, ` + ebookProtectedFieldsSQL + ` AS protected_fields
+		FROM recent_memberships candidate
+		JOIN media_items mi ON mi.content_id = candidate.content_id
+		LEFT JOIN ebook_enrichment_state state ON state.content_id = candidate.content_id
+		WHERE mi.type = 'ebook'
+		  AND ` + catalog.MangaChapterExclusionWhere("mi") + `
+		  AND state.content_id IS NULL
+	),
+	inserted AS (
+		INSERT INTO ebook_enrichment_state (
+			content_id, status, priority, next_attempt_at, protected_fields, updated_at
+		)
+		SELECT candidates.content_id, 'pending', $2, now(), candidates.protected_fields, now()
+		FROM candidates
+		ON CONFLICT (content_id) DO NOTHING
+		RETURNING content_id
+	)
+	SELECT
+		(SELECT COUNT(*)::integer FROM inserted) AS reconciled,
+		(SELECT COUNT(*)::integer FROM recent_memberships) AS inspected
+`
+
 var reconcileMissingEnrichmentJobsQuery = `
 	WITH membership_candidates AS MATERIALIZED (
 		SELECT membership.content_id, membership.first_seen_at
@@ -272,6 +303,17 @@ func (q *EnrichmentQueue) ReconcileMissing(
 		return 0, 0, false, err
 	}
 
+	var recentReconciled, recentInspected int
+	if err = tx.QueryRow(
+		ctx,
+		reconcileRecentMissingEnrichmentJobsQuery,
+		folderID,
+		priority,
+		limit,
+	).Scan(&recentReconciled, &recentInspected); err != nil {
+		return 0, 0, false, err
+	}
+
 	var lastFirstSeenAt *time.Time
 	var lastContentID *string
 	err = tx.QueryRow(
@@ -303,6 +345,8 @@ func (q *EnrichmentQueue) ReconcileMissing(
 	if err = tx.Commit(ctx); err != nil {
 		return 0, 0, false, err
 	}
+	reconciled += recentReconciled
+	inspected += recentInspected
 	return reconciled, inspected, wrapped, nil
 }
 

--- a/internal/ebooks/enrichment_queue.go
+++ b/internal/ebooks/enrichment_queue.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"os"
 	"strings"
 	"time"
 
@@ -13,12 +14,23 @@ import (
 )
 
 const (
-	defaultEnrichmentLease = 10 * time.Minute
-	maxEnrichmentRetry     = 24 * time.Hour
-	transientRetryBase     = 5 * time.Minute
-	skippedRetryHorizon    = 15 * time.Minute
-	claimCandidateWindow   = maxEnrichWorkers
+	defaultEnrichmentLease   = 10 * time.Minute
+	maxEnrichmentRetry       = 24 * time.Hour
+	transientRetryBase       = 5 * time.Minute
+	skippedRetryHorizon      = 15 * time.Minute
+	claimCandidateWindow     = maxEnrichWorkers
+	defaultRateLimitCooldown = 15 * time.Minute
+	rateLimitCooldownEnv     = "SILO_EBOOK_RATE_LIMIT_COOLDOWN"
 )
+
+func rateLimitCooldownFloor() time.Duration {
+	if v := os.Getenv(rateLimitCooldownEnv); v != "" {
+		if parsed, err := time.ParseDuration(v); err == nil && parsed > 0 {
+			return parsed
+		}
+	}
+	return defaultRateLimitCooldown
+}
 
 type EnrichmentOutcome string
 
@@ -787,6 +799,10 @@ func enrichmentRetryDelay(errorClass EnrichmentErrorClass, attempts int, retryAf
 		if retryAfter <= 0 {
 			retryAfter = transientRetryDelay(attempts)
 		}
+		// A provider's short RetryInfo is request-pacing advice for its own
+		// token bucket, not a queue horizon; requeueing that fast re-claims
+		// the same saturated tail every run.
+		retryAfter = max(retryAfter, rateLimitCooldownFloor())
 		return min(retryAfter, maxEnrichmentRetry)
 	case EnrichmentErrorPermanent:
 		return 30 * 24 * time.Hour

--- a/internal/ebooks/enrichment_queue.go
+++ b/internal/ebooks/enrichment_queue.go
@@ -17,7 +17,7 @@ const (
 	maxEnrichmentRetry     = 24 * time.Hour
 	transientRetryBase     = 5 * time.Minute
 	skippedRetryHorizon    = 15 * time.Minute
-	claimCandidateWindow   = 64
+	claimCandidateWindow   = maxEnrichWorkers
 )
 
 type EnrichmentOutcome string

--- a/internal/ebooks/enrichment_queue.go
+++ b/internal/ebooks/enrichment_queue.go
@@ -5,7 +5,6 @@ import (
 	"errors"
 	"fmt"
 	"strings"
-	"sync"
 	"time"
 
 	"github.com/jackc/pgx/v5/pgxpool"
@@ -39,29 +38,92 @@ const (
 var ErrEnrichmentLeaseLost = errors.New("ebook enrichment lease lost")
 
 type EnrichmentJob struct {
-	ContentID     string
-	Attempts      int
-	LastAttemptAt time.Time
+	ContentID       string
+	Token           string
+	Attempts        int
+	LastAttemptAt   time.Time
+	ProtectedFields []string
 }
 
 type EnrichmentQueue struct {
 	pool *pgxpool.Pool
-
-	claimsMu sync.Mutex
-	claims   map[string]EnrichmentJob
 }
 
 func NewEnrichmentQueue(pool *pgxpool.Pool) *EnrichmentQueue {
 	return &EnrichmentQueue{pool: pool}
 }
 
+const ebookProtectedFieldsSQL = `
+	ARRAY_REMOVE(ARRAY[
+		CASE WHEN lower(trim(mi.status)) = 'pending' AND trim(COALESCE(mi.title, '')) <> '' THEN 'title' END,
+		CASE WHEN lower(trim(mi.status)) = 'pending' AND COALESCE(mi.year, 0) > 0 THEN 'year' END,
+		CASE WHEN lower(trim(mi.status)) = 'pending' AND trim(COALESCE(mi.overview, '')) <> '' THEN 'overview' END,
+		CASE WHEN lower(trim(mi.status)) = 'pending' AND trim(COALESCE(mi.tagline, '')) <> '' THEN 'tagline' END,
+		CASE WHEN lower(trim(mi.status)) = 'pending' AND trim(COALESCE(mi.content_rating, '')) <> '' THEN 'content_rating' END,
+		CASE WHEN lower(trim(mi.status)) = 'pending' AND COALESCE(mi.runtime, 0) > 0 THEN 'runtime' END,
+		CASE WHEN lower(trim(mi.status)) = 'pending' AND trim(COALESCE(mi.release_date::text, '')) <> '' THEN 'release_date' END,
+		CASE WHEN lower(trim(mi.status)) = 'pending' AND cardinality(COALESCE(mi.genres, '{}'::text[])) > 0 THEN 'genres' END,
+		CASE WHEN lower(trim(mi.status)) = 'pending' AND cardinality(COALESCE(mi.studios, '{}'::text[])) > 0 THEN 'studios' END,
+		CASE WHEN lower(trim(mi.status)) = 'pending' AND EXISTS (
+			SELECT 1 FROM item_people ip WHERE ip.content_id = mi.content_id AND ip.kind = 7
+		) THEN 'authors' END,
+		CASE WHEN trim(COALESCE(mi.poster_path, '')) <> ''
+			AND lower(trim(mi.poster_path)) NOT LIKE 'http://%'
+			AND lower(trim(mi.poster_path)) NOT LIKE 'https://%'
+			AND lower(trim(mi.poster_path)) NOT LIKE 'ebook-metadata/ebooks/%'
+			THEN 'poster_path' END,
+		CASE WHEN trim(COALESCE(mi.backdrop_path, '')) <> ''
+			AND lower(trim(mi.backdrop_path)) NOT LIKE 'http://%'
+			AND lower(trim(mi.backdrop_path)) NOT LIKE 'https://%'
+			AND lower(trim(mi.backdrop_path)) NOT LIKE 'ebook-metadata/ebooks/%'
+			THEN 'backdrop_path' END,
+		CASE WHEN trim(COALESCE(mi.logo_path, '')) <> ''
+			AND lower(trim(mi.logo_path)) NOT LIKE 'http://%'
+			AND lower(trim(mi.logo_path)) NOT LIKE 'https://%'
+			AND lower(trim(mi.logo_path)) NOT LIKE 'ebook-metadata/ebooks/%'
+			THEN 'logo_path' END
+	]::text[], NULL)
+`
+
+const mergeEbookProtectedFieldsSQL = `
+	ARRAY(
+		SELECT DISTINCT field
+		FROM unnest(
+			ebook_enrichment_state.protected_fields ||
+			ARRAY(
+				SELECT candidate
+				FROM unnest(EXCLUDED.protected_fields) AS candidate
+				WHERE candidate IN ('poster_path', 'backdrop_path', 'logo_path')
+			)
+		) AS field
+		ORDER BY field
+	)
+`
+
 var enqueueEnrichmentJobQuery = `
 	INSERT INTO ebook_enrichment_state (
-		content_id, status, priority, next_attempt_at, updated_at
+		content_id, status, priority, next_attempt_at, protected_fields, updated_at
 	)
-	VALUES ($1, 'pending', $2, now(), now())
+	SELECT mi.content_id, 'pending', $2, now(), ` + ebookProtectedFieldsSQL + `, now()
+	FROM media_items mi
+	WHERE mi.content_id = $1
+	  AND mi.type = 'ebook'
+	  AND ` + catalog.MangaChapterExclusionWhere("mi") + `
 	ON CONFLICT (content_id) DO UPDATE SET
-		priority = GREATEST(ebook_enrichment_state.priority, EXCLUDED.priority),
+		status = CASE
+			WHEN ebook_enrichment_state.status = 'running' THEN ebook_enrichment_state.status
+			ELSE 'pending'
+		END,
+		priority = CASE
+			WHEN ebook_enrichment_state.status = 'running' THEN ebook_enrichment_state.priority
+			ELSE GREATEST(ebook_enrichment_state.priority, EXCLUDED.priority)
+		END,
+		next_attempt_at = CASE
+			WHEN ebook_enrichment_state.status = 'running' THEN ebook_enrichment_state.next_attempt_at
+			ELSE now()
+		END,
+		requeue_requested = ebook_enrichment_state.requeue_requested OR ebook_enrichment_state.status = 'running',
+		protected_fields = ` + mergeEbookProtectedFieldsSQL + `,
 		updated_at = now()
 `
 
@@ -78,14 +140,54 @@ func (q *EnrichmentQueue) Enqueue(ctx context.Context, contentID string, priorit
 
 var materializeEnrichmentJobsQuery = `
 	INSERT INTO ebook_enrichment_state (
-		content_id, status, priority, next_attempt_at, updated_at
+		content_id, status, priority, next_attempt_at, completed_at, protected_fields, updated_at
 	)
-	SELECT mi.content_id, 'pending', 100, now(), now()
+	SELECT
+		mi.content_id,
+		'pending',
+		CASE WHEN mi.last_refreshed IS NULL THEN 100 ELSE 0 END,
+		CASE
+			WHEN mi.last_refreshed IS NULL THEN now()
+			ELSE GREATEST(mi.last_refreshed + interval '90 days', now())
+		END,
+		mi.last_refreshed,
+		` + ebookProtectedFieldsSQL + `,
+		now()
 	FROM media_items mi
 	WHERE mi.type = 'ebook'
 	  AND ` + catalog.MangaChapterExclusionWhere("mi") + `
-	  AND mi.last_refreshed IS NULL
-	ON CONFLICT (content_id) DO NOTHING
+	ON CONFLICT (content_id) DO UPDATE SET
+		status = CASE
+			WHEN ebook_enrichment_state.status = 'running' THEN ebook_enrichment_state.status
+			WHEN ebook_enrichment_state.status = 'discarded' THEN 'pending'
+			ELSE ebook_enrichment_state.status
+		END,
+		priority = CASE
+			WHEN ebook_enrichment_state.status = 'running' THEN ebook_enrichment_state.priority
+			WHEN ebook_enrichment_state.status = 'discarded' THEN EXCLUDED.priority
+			WHEN EXCLUDED.completed_at IS NULL AND ebook_enrichment_state.completed_at IS NOT NULL THEN 100
+			ELSE ebook_enrichment_state.priority
+		END,
+		next_attempt_at = CASE
+			WHEN ebook_enrichment_state.status = 'running' THEN ebook_enrichment_state.next_attempt_at
+			WHEN ebook_enrichment_state.status = 'discarded' THEN EXCLUDED.next_attempt_at
+			WHEN EXCLUDED.completed_at IS NULL AND ebook_enrichment_state.completed_at IS NOT NULL THEN now()
+			ELSE ebook_enrichment_state.next_attempt_at
+		END,
+		completed_at = CASE
+			WHEN ebook_enrichment_state.status = 'running' THEN ebook_enrichment_state.completed_at
+			WHEN ebook_enrichment_state.status = 'discarded' THEN EXCLUDED.completed_at
+			WHEN EXCLUDED.completed_at IS NULL AND ebook_enrichment_state.completed_at IS NOT NULL THEN NULL
+			ELSE ebook_enrichment_state.completed_at
+		END,
+		outcome = CASE
+			WHEN ebook_enrichment_state.status = 'discarded'
+				OR (EXCLUDED.completed_at IS NULL AND ebook_enrichment_state.completed_at IS NOT NULL)
+			THEN NULL
+			ELSE ebook_enrichment_state.outcome
+		END,
+		protected_fields = ` + mergeEbookProtectedFieldsSQL + `,
+		updated_at = now()
 `
 
 func (q *EnrichmentQueue) MaterializeCandidates(ctx context.Context) error {
@@ -102,19 +204,24 @@ var claimEnrichmentJobsQuery = `
 		FROM ebook_enrichment_state
 		WHERE next_attempt_at <= now()
 		  AND (status = 'pending' OR (status = 'running' AND lease_until < now()))
-		ORDER BY priority DESC, next_attempt_at, updated_at
+		ORDER BY
+			(priority + FLOOR(EXTRACT(EPOCH FROM (now() - next_attempt_at)) / 3600)::integer) DESC,
+			priority DESC,
+			next_attempt_at,
+			updated_at
 		FOR UPDATE SKIP LOCKED
 		LIMIT $1
 	)
 	UPDATE ebook_enrichment_state state
 	SET status = 'running',
 		lease_until = now() + $2::interval,
+		claim_token = gen_random_uuid()::text,
 		last_attempt_at = now(),
 		attempts = attempts + 1,
 		updated_at = now()
 	FROM candidates
 	WHERE state.content_id = candidates.content_id
-	RETURNING state.content_id, state.attempts, state.last_attempt_at
+	RETURNING state.content_id, state.claim_token, state.attempts, state.last_attempt_at, state.protected_fields
 `
 
 func (q *EnrichmentQueue) ClaimBatch(ctx context.Context, limit int, leaseDuration time.Duration) ([]EnrichmentJob, error) {
@@ -137,11 +244,10 @@ func (q *EnrichmentQueue) ClaimBatch(ctx context.Context, limit int, leaseDurati
 	jobs := make([]EnrichmentJob, 0, limit)
 	for rows.Next() {
 		var job EnrichmentJob
-		if err := rows.Scan(&job.ContentID, &job.Attempts, &job.LastAttemptAt); err != nil {
+		if err := rows.Scan(&job.ContentID, &job.Token, &job.Attempts, &job.LastAttemptAt, &job.ProtectedFields); err != nil {
 			return nil, err
 		}
 		jobs = append(jobs, job)
-		q.rememberClaim(job)
 	}
 	if err := rows.Err(); err != nil {
 		return nil, err
@@ -153,36 +259,25 @@ var completeEnrichmentJobQuery = `
 	UPDATE ebook_enrichment_state
 	SET status = 'pending',
 		lease_until = NULL,
+		claim_token = NULL,
 		completed_at = now(),
-		next_attempt_at = now() + $3::interval,
+		next_attempt_at = CASE
+			WHEN requeue_requested THEN now()
+			ELSE now() + $3::interval
+		END,
 		outcome = $2,
 		attempts = 0,
-		priority = GREATEST(priority, 0),
+		priority = CASE WHEN requeue_requested THEN 100 ELSE 0 END,
+		requeue_requested = false,
 		last_error_class = NULL,
 		last_error = NULL,
 		updated_at = now()
 	WHERE content_id = $1
 	  AND status = 'running'
-	  AND last_attempt_at = $4
+	  AND claim_token = $4
 `
 
 func (q *EnrichmentQueue) Complete(
-	ctx context.Context,
-	contentID string,
-	outcome EnrichmentOutcome,
-	refreshAfter time.Duration,
-) error {
-	if q == nil || q.pool == nil {
-		return errors.New("ebook enrichment queue is not configured")
-	}
-	job, ok := q.claimedJob(contentID)
-	if !ok {
-		return ErrEnrichmentLeaseLost
-	}
-	return q.CompleteClaim(ctx, job, outcome, refreshAfter)
-}
-
-func (q *EnrichmentQueue) CompleteClaim(
 	ctx context.Context,
 	job EnrichmentJob,
 	outcome EnrichmentOutcome,
@@ -190,6 +285,9 @@ func (q *EnrichmentQueue) CompleteClaim(
 ) error {
 	if q == nil || q.pool == nil {
 		return errors.New("ebook enrichment queue is not configured")
+	}
+	if job.ContentID == "" || job.Token == "" {
+		return ErrEnrichmentLeaseLost
 	}
 	if refreshAfter <= 0 {
 		refreshAfter = enrichmentRefreshHorizon(outcome)
@@ -204,16 +302,14 @@ func (q *EnrichmentQueue) CompleteClaim(
 		job.ContentID,
 		string(outcome),
 		postgresInterval(refreshAfter),
-		job.LastAttemptAt,
+		job.Token,
 	)
 	if err != nil {
 		return err
 	}
 	if tag.RowsAffected() == 0 {
-		q.forgetClaim(job)
 		return ErrEnrichmentLeaseLost
 	}
-	q.forgetClaim(job)
 	return nil
 }
 
@@ -221,34 +317,23 @@ var failEnrichmentJobQuery = `
 	UPDATE ebook_enrichment_state
 	SET status = 'pending',
 		lease_until = NULL,
-		next_attempt_at = now() + $4::interval,
+		claim_token = NULL,
+		next_attempt_at = CASE
+			WHEN requeue_requested THEN now()
+			ELSE now() + $4::interval
+		END,
+		priority = CASE WHEN requeue_requested THEN 100 ELSE priority END,
+		requeue_requested = false,
 		outcome = 'failed',
 		last_error_class = $2,
 		last_error = $3,
 		updated_at = now()
 	WHERE content_id = $1
 	  AND status = 'running'
-	  AND last_attempt_at = $5
+	  AND claim_token = $5
 `
 
 func (q *EnrichmentQueue) Fail(
-	ctx context.Context,
-	contentID string,
-	errorClass EnrichmentErrorClass,
-	message string,
-	retryAfter time.Duration,
-) error {
-	if q == nil || q.pool == nil {
-		return errors.New("ebook enrichment queue is not configured")
-	}
-	job, ok := q.claimedJob(contentID)
-	if !ok {
-		return ErrEnrichmentLeaseLost
-	}
-	return q.FailClaim(ctx, job, errorClass, message, retryAfter)
-}
-
-func (q *EnrichmentQueue) FailClaim(
 	ctx context.Context,
 	job EnrichmentJob,
 	errorClass EnrichmentErrorClass,
@@ -258,6 +343,9 @@ func (q *EnrichmentQueue) FailClaim(
 	if q == nil || q.pool == nil {
 		return errors.New("ebook enrichment queue is not configured")
 	}
+	if job.ContentID == "" || job.Token == "" {
+		return ErrEnrichmentLeaseLost
+	}
 	delay := enrichmentRetryDelay(errorClass, job.Attempts, retryAfter)
 	tag, err := q.pool.Exec(
 		ctx,
@@ -266,16 +354,14 @@ func (q *EnrichmentQueue) FailClaim(
 		string(errorClass),
 		message,
 		postgresInterval(delay),
-		job.LastAttemptAt,
+		job.Token,
 	)
 	if err != nil {
 		return err
 	}
 	if tag.RowsAffected() == 0 {
-		q.forgetClaim(job)
 		return ErrEnrichmentLeaseLost
 	}
-	q.forgetClaim(job)
 	return nil
 }
 
@@ -283,62 +369,67 @@ var releaseEnrichmentJobQuery = `
 	UPDATE ebook_enrichment_state
 	SET status = 'pending',
 		lease_until = NULL,
+		claim_token = NULL,
 		attempts = GREATEST(attempts - 1, 0),
+		next_attempt_at = CASE WHEN requeue_requested THEN now() ELSE next_attempt_at END,
+		priority = CASE WHEN requeue_requested THEN 100 ELSE priority END,
+		requeue_requested = false,
 		updated_at = now()
 	WHERE content_id = $1
 	  AND status = 'running'
-	  AND last_attempt_at = $2
+	  AND claim_token = $2
 `
 
-func (q *EnrichmentQueue) Release(ctx context.Context, contentID string) error {
+func (q *EnrichmentQueue) Release(ctx context.Context, job EnrichmentJob) error {
 	if q == nil || q.pool == nil {
 		return errors.New("ebook enrichment queue is not configured")
 	}
-	job, ok := q.claimedJob(contentID)
-	if !ok {
+	if job.ContentID == "" || job.Token == "" {
 		return ErrEnrichmentLeaseLost
 	}
-	return q.ReleaseClaim(ctx, job)
-}
-
-func (q *EnrichmentQueue) ReleaseClaim(ctx context.Context, job EnrichmentJob) error {
-	if q == nil || q.pool == nil {
-		return errors.New("ebook enrichment queue is not configured")
-	}
-	tag, err := q.pool.Exec(ctx, releaseEnrichmentJobQuery, job.ContentID, job.LastAttemptAt)
+	tag, err := q.pool.Exec(ctx, releaseEnrichmentJobQuery, job.ContentID, job.Token)
 	if err != nil {
 		return err
 	}
-	q.forgetClaim(job)
 	if tag.RowsAffected() == 0 {
 		return ErrEnrichmentLeaseLost
 	}
 	return nil
 }
 
-func (q *EnrichmentQueue) rememberClaim(job EnrichmentJob) {
-	q.claimsMu.Lock()
-	defer q.claimsMu.Unlock()
-	if q.claims == nil {
-		q.claims = make(map[string]EnrichmentJob)
-	}
-	q.claims[job.ContentID] = job
-}
+var discardEnrichmentJobQuery = `
+	UPDATE ebook_enrichment_state
+	SET status = 'discarded',
+		lease_until = NULL,
+		claim_token = NULL,
+		completed_at = now(),
+		outcome = 'discarded',
+		attempts = 0,
+		priority = 0,
+		requeue_requested = false,
+		last_error_class = NULL,
+		last_error = NULL,
+		updated_at = now()
+	WHERE content_id = $1
+	  AND status = 'running'
+	  AND claim_token = $2
+`
 
-func (q *EnrichmentQueue) claimedJob(contentID string) (EnrichmentJob, bool) {
-	q.claimsMu.Lock()
-	defer q.claimsMu.Unlock()
-	job, ok := q.claims[contentID]
-	return job, ok
-}
-
-func (q *EnrichmentQueue) forgetClaim(job EnrichmentJob) {
-	q.claimsMu.Lock()
-	defer q.claimsMu.Unlock()
-	current, ok := q.claims[job.ContentID]
-	if ok && current.LastAttemptAt.Equal(job.LastAttemptAt) {
-		delete(q.claims, job.ContentID)
+func (q *EnrichmentQueue) Discard(ctx context.Context, job EnrichmentJob) error {
+	if q == nil || q.pool == nil {
+		return errors.New("ebook enrichment queue is not configured")
 	}
+	if job.ContentID == "" || job.Token == "" {
+		return ErrEnrichmentLeaseLost
+	}
+	tag, err := q.pool.Exec(ctx, discardEnrichmentJobQuery, job.ContentID, job.Token)
+	if err != nil {
+		return err
+	}
+	if tag.RowsAffected() == 0 {
+		return ErrEnrichmentLeaseLost
+	}
+	return nil
 }
 
 func enrichmentRefreshHorizon(outcome EnrichmentOutcome) time.Duration {

--- a/internal/ebooks/enrichment_queue.go
+++ b/internal/ebooks/enrichment_queue.go
@@ -129,6 +129,9 @@ const mergeEbookProtectedFieldsSQL = `
 	)
 `
 
+// Legacy-lane rows (priority < 0) may only leave the lane through a terminal
+// outcome (Complete/Discard); enqueue, fail, and release must preserve the
+// lane so the paced backfill task stays the sole drain for the backlog.
 var enqueueEnrichmentJobQuery = `
 	INSERT INTO ebook_enrichment_state (
 		content_id, status, priority, next_attempt_at, protected_fields, updated_at
@@ -145,6 +148,7 @@ var enqueueEnrichmentJobQuery = `
 		END,
 		priority = CASE
 			WHEN ebook_enrichment_state.status = 'running' THEN ebook_enrichment_state.priority
+			WHEN ebook_enrichment_state.priority < 0 THEN ebook_enrichment_state.priority
 			ELSE GREATEST(ebook_enrichment_state.priority, EXCLUDED.priority)
 		END,
 		next_attempt_at = CASE
@@ -670,7 +674,7 @@ var failEnrichmentJobQuery = `
 			WHEN requeue_requested THEN now()
 			ELSE now() + $4::interval
 		END,
-		priority = CASE WHEN requeue_requested THEN 100 ELSE priority END,
+		priority = CASE WHEN requeue_requested AND priority >= 0 THEN 100 ELSE priority END,
 		requeue_requested = false,
 		outcome = 'failed',
 		last_error_class = $2,
@@ -720,7 +724,7 @@ var releaseEnrichmentJobQuery = `
 		claim_token = NULL,
 		attempts = GREATEST(attempts - 1, 0),
 		next_attempt_at = CASE WHEN requeue_requested THEN now() ELSE next_attempt_at END,
-		priority = CASE WHEN requeue_requested THEN 100 ELSE priority END,
+		priority = CASE WHEN requeue_requested AND priority >= 0 THEN 100 ELSE priority END,
 		requeue_requested = false,
 		updated_at = now()
 	WHERE content_id = $1

--- a/internal/ebooks/enrichment_queue.go
+++ b/internal/ebooks/enrichment_queue.go
@@ -155,6 +155,44 @@ func (q *EnrichmentQueue) Enqueue(ctx context.Context, contentID string, priorit
 	return err
 }
 
+var reconcileMissingEnrichmentJobsQuery = `
+	WITH candidates AS MATERIALIZED (
+		SELECT mi.content_id, ` + ebookProtectedFieldsSQL + ` AS protected_fields
+		FROM media_item_libraries mil
+		JOIN media_items mi ON mi.content_id = mil.content_id
+		LEFT JOIN ebook_enrichment_state state ON state.content_id = mi.content_id
+		WHERE mil.media_folder_id = $1
+		  AND mi.type = 'ebook'
+		  AND ` + catalog.MangaChapterExclusionWhere("mi") + `
+		  AND state.content_id IS NULL
+		ORDER BY mi.content_id
+		LIMIT $3
+	)
+	INSERT INTO ebook_enrichment_state (
+		content_id, status, priority, next_attempt_at, protected_fields, updated_at
+	)
+	SELECT candidates.content_id, 'pending', $2, now(), candidates.protected_fields, now()
+	FROM candidates
+	ON CONFLICT (content_id) DO NOTHING
+`
+
+func (q *EnrichmentQueue) ReconcileMissing(ctx context.Context, folderID, priority, limit int) (int, error) {
+	if q == nil || q.pool == nil {
+		return 0, errors.New("ebook enrichment queue is not configured")
+	}
+	if folderID <= 0 {
+		return 0, errors.New("ebook enrichment folder id is required")
+	}
+	if limit <= 0 {
+		return 0, nil
+	}
+	tag, err := q.pool.Exec(ctx, reconcileMissingEnrichmentJobsQuery, folderID, priority, limit)
+	if err != nil {
+		return 0, err
+	}
+	return int(tag.RowsAffected()), nil
+}
+
 // Each indexed window is fixed-size; only their deduplicated union pays for
 // aging/ranking, while the oldest-due window guarantees eventual promotion.
 const claimEnrichmentJobsQueryTemplate = `
@@ -300,6 +338,50 @@ var (
 		"priority < 0",
 	)
 )
+
+const hasReadyEnrichmentJobsQueryTemplate = `
+	SELECT EXISTS (
+		SELECT 1
+		FROM ebook_enrichment_state
+		WHERE next_attempt_at <= now()
+		  AND (status = 'pending' OR (status = 'running' AND lease_until < now()))
+		  AND {{lane_predicate}}
+	)
+`
+
+var (
+	hasReadyIncrementalEnrichmentJobsQuery = strings.ReplaceAll(
+		hasReadyEnrichmentJobsQueryTemplate,
+		"{{lane_predicate}}",
+		"priority >= 0",
+	)
+	hasReadyLegacyEnrichmentJobsQuery = strings.ReplaceAll(
+		hasReadyEnrichmentJobsQueryTemplate,
+		"{{lane_predicate}}",
+		"priority < 0",
+	)
+)
+
+func hasReadyEnrichmentJobsQueryForScope(scope EnrichmentScope) string {
+	if scope == EnrichmentScopeLegacy {
+		return hasReadyLegacyEnrichmentJobsQuery
+	}
+	return hasReadyIncrementalEnrichmentJobsQuery
+}
+
+func (q *EnrichmentQueue) HasReady(ctx context.Context, scope EnrichmentScope) (bool, error) {
+	if q == nil || q.pool == nil {
+		return false, errors.New("ebook enrichment queue is not configured")
+	}
+	if err := scope.validate(); err != nil {
+		return false, err
+	}
+	var ready bool
+	if err := q.pool.QueryRow(ctx, hasReadyEnrichmentJobsQueryForScope(scope)).Scan(&ready); err != nil {
+		return false, err
+	}
+	return ready, nil
+}
 
 func countReadyEnrichmentJobsQueryForScope(scope EnrichmentScope) string {
 	if scope == EnrichmentScopeLegacy {

--- a/internal/ebooks/enrichment_queue.go
+++ b/internal/ebooks/enrichment_queue.go
@@ -177,13 +177,9 @@ var reconcileMissingEnrichmentJobsQuery = `
 		WHERE membership.media_folder_id = $1
 		  AND (
 			$4::timestamptz IS NULL
-			OR membership.first_seen_at < $4
-			OR (
-				membership.first_seen_at = $4
-				AND membership.content_id > $5
-			)
+			OR (membership.first_seen_at, membership.content_id) < ($4, $5)
 		  )
-		ORDER BY membership.first_seen_at DESC, membership.content_id
+		ORDER BY membership.first_seen_at DESC, membership.content_id DESC
 		LIMIT $3
 	),
 	candidates AS MATERIALIZED (
@@ -210,13 +206,13 @@ var reconcileMissingEnrichmentJobsQuery = `
 			(
 				SELECT first_seen_at
 				FROM membership_candidates
-				ORDER BY first_seen_at, content_id DESC
+				ORDER BY first_seen_at, content_id
 				LIMIT 1
 			) AS last_first_seen_at,
 			(
 				SELECT content_id
 				FROM membership_candidates
-				ORDER BY first_seen_at, content_id DESC
+				ORDER BY first_seen_at, content_id
 				LIMIT 1
 		) AS last_content_id
 		FROM membership_candidates
@@ -457,15 +453,15 @@ var (
 )
 
 const hasReadyEnrichmentJobsQueryTemplate = `
-	SELECT EXISTS (
-		SELECT 1
+	SELECT COALESCE((
+		SELECT true
 		FROM ebook_enrichment_state
 		WHERE next_attempt_at <= now()
 		  AND (status = 'pending' OR (status = 'running' AND lease_until < now()))
 		  AND {{lane_predicate}}
 		ORDER BY next_attempt_at, updated_at, priority DESC
 		LIMIT 1
-	)
+	), false)
 `
 
 var (

--- a/internal/ebooks/enrichment_queue.go
+++ b/internal/ebooks/enrichment_queue.go
@@ -155,42 +155,159 @@ func (q *EnrichmentQueue) Enqueue(ctx context.Context, contentID string, priorit
 	return err
 }
 
-var reconcileMissingEnrichmentJobsQuery = `
-	WITH candidates AS MATERIALIZED (
-		SELECT mi.content_id, ` + ebookProtectedFieldsSQL + ` AS protected_fields
-		FROM media_item_libraries mil
-		JOIN media_items mi ON mi.content_id = mil.content_id
-		LEFT JOIN ebook_enrichment_state state ON state.content_id = mi.content_id
-		WHERE mil.media_folder_id = $1
-		  AND mi.type = 'ebook'
-		  AND ` + catalog.MangaChapterExclusionWhere("mi") + `
-		  AND state.content_id IS NULL
-		ORDER BY mi.content_id
-		LIMIT $3
+const ensureEnrichmentReconcileCursorQuery = `
+	INSERT INTO ebook_enrichment_reconcile_cursors (
+		folder_id, after_first_seen_at, after_content_id, updated_at
 	)
-	INSERT INTO ebook_enrichment_state (
-		content_id, status, priority, next_attempt_at, protected_fields, updated_at
-	)
-	SELECT candidates.content_id, 'pending', $2, now(), candidates.protected_fields, now()
-	FROM candidates
-	ON CONFLICT (content_id) DO NOTHING
+	VALUES ($1, NULL, NULL, now())
+	ON CONFLICT (folder_id) DO NOTHING
 `
 
-func (q *EnrichmentQueue) ReconcileMissing(ctx context.Context, folderID, priority, limit int) (int, error) {
+const lockEnrichmentReconcileCursorQuery = `
+	SELECT after_first_seen_at, after_content_id
+	FROM ebook_enrichment_reconcile_cursors
+	WHERE folder_id = $1
+	FOR UPDATE
+`
+
+var reconcileMissingEnrichmentJobsQuery = `
+	WITH membership_candidates AS MATERIALIZED (
+		SELECT membership.content_id, membership.first_seen_at
+		FROM media_item_libraries membership
+		WHERE membership.media_folder_id = $1
+		  AND (
+			$4::timestamptz IS NULL
+			OR membership.first_seen_at < $4
+			OR (
+				membership.first_seen_at = $4
+				AND membership.content_id > $5
+			)
+		  )
+		ORDER BY membership.first_seen_at DESC, membership.content_id
+		LIMIT $3
+	),
+	candidates AS MATERIALIZED (
+		SELECT candidate.content_id, ` + ebookProtectedFieldsSQL + ` AS protected_fields
+		FROM membership_candidates candidate
+		JOIN media_items mi ON mi.content_id = candidate.content_id
+		LEFT JOIN ebook_enrichment_state state ON state.content_id = candidate.content_id
+		WHERE mi.type = 'ebook'
+		  AND ` + catalog.MangaChapterExclusionWhere("mi") + `
+		  AND state.content_id IS NULL
+	),
+	inserted AS (
+		INSERT INTO ebook_enrichment_state (
+			content_id, status, priority, next_attempt_at, protected_fields, updated_at
+		)
+		SELECT candidates.content_id, 'pending', $2, now(), candidates.protected_fields, now()
+		FROM candidates
+		ON CONFLICT (content_id) DO NOTHING
+		RETURNING content_id
+	),
+	window_stats AS MATERIALIZED (
+		SELECT
+			COUNT(*)::integer AS inspected,
+			(
+				SELECT first_seen_at
+				FROM membership_candidates
+				ORDER BY first_seen_at, content_id DESC
+				LIMIT 1
+			) AS last_first_seen_at,
+			(
+				SELECT content_id
+				FROM membership_candidates
+				ORDER BY first_seen_at, content_id DESC
+				LIMIT 1
+		) AS last_content_id
+		FROM membership_candidates
+	)
+	SELECT
+		(SELECT COUNT(*)::integer FROM inserted) AS reconciled,
+		window_stats.inspected,
+		window_stats.last_first_seen_at,
+		window_stats.last_content_id
+	FROM window_stats
+`
+
+const updateEnrichmentReconcileCursorQuery = `
+	UPDATE ebook_enrichment_reconcile_cursors
+	SET after_first_seen_at = $2,
+		after_content_id = $3,
+		updated_at = now()
+	WHERE folder_id = $1
+`
+
+// ReconcileMissing advances a database-persisted keyset cursor while holding
+// its folder row lock. Queue repairs and cursor movement commit atomically.
+// A server restart resumes from the persisted cursor; completed repairs remain
+// durable, and reaching the end resets the cursor so later passes wrap safely.
+func (q *EnrichmentQueue) ReconcileMissing(
+	ctx context.Context,
+	folderID, priority, limit int,
+) (reconciled, inspected int, wrapped bool, err error) {
 	if q == nil || q.pool == nil {
-		return 0, errors.New("ebook enrichment queue is not configured")
+		return 0, 0, false, errors.New("ebook enrichment queue is not configured")
 	}
 	if folderID <= 0 {
-		return 0, errors.New("ebook enrichment folder id is required")
+		return 0, 0, false, errors.New("ebook enrichment folder id is required")
 	}
 	if limit <= 0 {
-		return 0, nil
+		return 0, 0, false, nil
 	}
-	tag, err := q.pool.Exec(ctx, reconcileMissingEnrichmentJobsQuery, folderID, priority, limit)
+
+	tx, err := q.pool.Begin(ctx)
 	if err != nil {
-		return 0, err
+		return 0, 0, false, err
 	}
-	return int(tag.RowsAffected()), nil
+	defer func() {
+		_ = tx.Rollback(ctx)
+	}()
+
+	if _, err = tx.Exec(ctx, ensureEnrichmentReconcileCursorQuery, folderID); err != nil {
+		return 0, 0, false, err
+	}
+	var afterFirstSeenAt *time.Time
+	var afterContentID *string
+	if err = tx.QueryRow(
+		ctx,
+		lockEnrichmentReconcileCursorQuery,
+		folderID,
+	).Scan(&afterFirstSeenAt, &afterContentID); err != nil {
+		return 0, 0, false, err
+	}
+
+	var lastFirstSeenAt *time.Time
+	var lastContentID *string
+	err = tx.QueryRow(
+		ctx,
+		reconcileMissingEnrichmentJobsQuery,
+		folderID,
+		priority,
+		limit,
+		afterFirstSeenAt,
+		afterContentID,
+	).Scan(&reconciled, &inspected, &lastFirstSeenAt, &lastContentID)
+	if err != nil {
+		return 0, 0, false, err
+	}
+	wrapped = inspected < limit
+	if wrapped {
+		lastFirstSeenAt = nil
+		lastContentID = nil
+	}
+	if _, err = tx.Exec(
+		ctx,
+		updateEnrichmentReconcileCursorQuery,
+		folderID,
+		lastFirstSeenAt,
+		lastContentID,
+	); err != nil {
+		return 0, 0, false, err
+	}
+	if err = tx.Commit(ctx); err != nil {
+		return 0, 0, false, err
+	}
+	return reconciled, inspected, wrapped, nil
 }
 
 // Each indexed window is fixed-size; only their deduplicated union pays for
@@ -346,6 +463,8 @@ const hasReadyEnrichmentJobsQueryTemplate = `
 		WHERE next_attempt_at <= now()
 		  AND (status = 'pending' OR (status = 'running' AND lease_until < now()))
 		  AND {{lane_predicate}}
+		ORDER BY next_attempt_at, updated_at, priority DESC
+		LIMIT 1
 	)
 `
 

--- a/internal/ebooks/enrichment_queue.go
+++ b/internal/ebooks/enrichment_queue.go
@@ -138,66 +138,6 @@ func (q *EnrichmentQueue) Enqueue(ctx context.Context, contentID string, priorit
 	return err
 }
 
-var materializeEnrichmentJobsQuery = `
-	INSERT INTO ebook_enrichment_state (
-		content_id, status, priority, next_attempt_at, completed_at, protected_fields, updated_at
-	)
-	SELECT
-		mi.content_id,
-		'pending',
-		CASE WHEN mi.last_refreshed IS NULL THEN 100 ELSE 0 END,
-		CASE
-			WHEN mi.last_refreshed IS NULL THEN now()
-			ELSE GREATEST(mi.last_refreshed + interval '90 days', now())
-		END,
-		mi.last_refreshed,
-		` + ebookProtectedFieldsSQL + `,
-		now()
-	FROM media_items mi
-	WHERE mi.type = 'ebook'
-	  AND ` + catalog.MangaChapterExclusionWhere("mi") + `
-	ON CONFLICT (content_id) DO UPDATE SET
-		status = CASE
-			WHEN ebook_enrichment_state.status = 'running' THEN ebook_enrichment_state.status
-			WHEN ebook_enrichment_state.status = 'discarded' THEN 'pending'
-			ELSE ebook_enrichment_state.status
-		END,
-		priority = CASE
-			WHEN ebook_enrichment_state.status = 'running' THEN ebook_enrichment_state.priority
-			WHEN ebook_enrichment_state.status = 'discarded' THEN EXCLUDED.priority
-			WHEN EXCLUDED.completed_at IS NULL AND ebook_enrichment_state.completed_at IS NOT NULL THEN 100
-			ELSE ebook_enrichment_state.priority
-		END,
-		next_attempt_at = CASE
-			WHEN ebook_enrichment_state.status = 'running' THEN ebook_enrichment_state.next_attempt_at
-			WHEN ebook_enrichment_state.status = 'discarded' THEN EXCLUDED.next_attempt_at
-			WHEN EXCLUDED.completed_at IS NULL AND ebook_enrichment_state.completed_at IS NOT NULL THEN now()
-			ELSE ebook_enrichment_state.next_attempt_at
-		END,
-		completed_at = CASE
-			WHEN ebook_enrichment_state.status = 'running' THEN ebook_enrichment_state.completed_at
-			WHEN ebook_enrichment_state.status = 'discarded' THEN EXCLUDED.completed_at
-			WHEN EXCLUDED.completed_at IS NULL AND ebook_enrichment_state.completed_at IS NOT NULL THEN NULL
-			ELSE ebook_enrichment_state.completed_at
-		END,
-		outcome = CASE
-			WHEN ebook_enrichment_state.status = 'discarded'
-				OR (EXCLUDED.completed_at IS NULL AND ebook_enrichment_state.completed_at IS NOT NULL)
-			THEN NULL
-			ELSE ebook_enrichment_state.outcome
-		END,
-		protected_fields = ` + mergeEbookProtectedFieldsSQL + `,
-		updated_at = now()
-`
-
-func (q *EnrichmentQueue) MaterializeCandidates(ctx context.Context) error {
-	if q == nil || q.pool == nil {
-		return errors.New("ebook enrichment queue is not configured")
-	}
-	_, err := q.pool.Exec(ctx, materializeEnrichmentJobsQuery)
-	return err
-}
-
 var claimEnrichmentJobsQuery = `
 	WITH candidates AS (
 		SELECT content_id
@@ -253,6 +193,34 @@ func (q *EnrichmentQueue) ClaimBatch(ctx context.Context, limit int, leaseDurati
 		return nil, err
 	}
 	return jobs, nil
+}
+
+var checkEnrichmentClaimQuery = `
+	SELECT EXISTS (
+		SELECT 1
+		FROM ebook_enrichment_state
+		WHERE content_id = $1
+		  AND status = 'running'
+		  AND claim_token = $2
+		  AND lease_until > now()
+	)
+`
+
+func (q *EnrichmentQueue) CheckClaim(ctx context.Context, job EnrichmentJob) error {
+	if q == nil || q.pool == nil {
+		return errors.New("ebook enrichment queue is not configured")
+	}
+	if job.ContentID == "" || job.Token == "" {
+		return ErrEnrichmentLeaseLost
+	}
+	var owned bool
+	if err := q.pool.QueryRow(ctx, checkEnrichmentClaimQuery, job.ContentID, job.Token).Scan(&owned); err != nil {
+		return err
+	}
+	if !owned {
+		return ErrEnrichmentLeaseLost
+	}
+	return nil
 }
 
 var completeEnrichmentJobQuery = `

--- a/internal/ebooks/enrichment_queue.go
+++ b/internal/ebooks/enrichment_queue.go
@@ -1,0 +1,387 @@
+package ebooks
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/jackc/pgx/v5/pgxpool"
+
+	"github.com/Silo-Server/silo-server/internal/catalog"
+)
+
+const (
+	defaultEnrichmentLease = 10 * time.Minute
+	maxEnrichmentRetry     = 24 * time.Hour
+	transientRetryBase     = 5 * time.Minute
+	skippedRetryHorizon    = 15 * time.Minute
+)
+
+type EnrichmentOutcome string
+
+const (
+	EnrichmentOutcomeSuccess EnrichmentOutcome = "success"
+	EnrichmentOutcomeNoMatch EnrichmentOutcome = "no_match"
+	EnrichmentOutcomeSkipped EnrichmentOutcome = "skipped"
+)
+
+type EnrichmentErrorClass string
+
+const (
+	EnrichmentErrorTransient   EnrichmentErrorClass = "transient"
+	EnrichmentErrorRateLimited EnrichmentErrorClass = "rate_limited"
+	EnrichmentErrorPermanent   EnrichmentErrorClass = "permanent"
+)
+
+var ErrEnrichmentLeaseLost = errors.New("ebook enrichment lease lost")
+
+type EnrichmentJob struct {
+	ContentID     string
+	Attempts      int
+	LastAttemptAt time.Time
+}
+
+type EnrichmentQueue struct {
+	pool *pgxpool.Pool
+
+	claimsMu sync.Mutex
+	claims   map[string]EnrichmentJob
+}
+
+func NewEnrichmentQueue(pool *pgxpool.Pool) *EnrichmentQueue {
+	return &EnrichmentQueue{pool: pool}
+}
+
+var enqueueEnrichmentJobQuery = `
+	INSERT INTO ebook_enrichment_state (
+		content_id, status, priority, next_attempt_at, updated_at
+	)
+	VALUES ($1, 'pending', $2, now(), now())
+	ON CONFLICT (content_id) DO UPDATE SET
+		priority = GREATEST(ebook_enrichment_state.priority, EXCLUDED.priority),
+		updated_at = now()
+`
+
+func (q *EnrichmentQueue) Enqueue(ctx context.Context, contentID string, priority int) error {
+	if q == nil || q.pool == nil {
+		return errors.New("ebook enrichment queue is not configured")
+	}
+	if strings.TrimSpace(contentID) == "" {
+		return errors.New("ebook enrichment content id is required")
+	}
+	_, err := q.pool.Exec(ctx, enqueueEnrichmentJobQuery, contentID, priority)
+	return err
+}
+
+var materializeEnrichmentJobsQuery = `
+	INSERT INTO ebook_enrichment_state (
+		content_id, status, priority, next_attempt_at, updated_at
+	)
+	SELECT mi.content_id, 'pending', 100, now(), now()
+	FROM media_items mi
+	WHERE mi.type = 'ebook'
+	  AND ` + catalog.MangaChapterExclusionWhere("mi") + `
+	  AND mi.last_refreshed IS NULL
+	ON CONFLICT (content_id) DO NOTHING
+`
+
+func (q *EnrichmentQueue) MaterializeCandidates(ctx context.Context) error {
+	if q == nil || q.pool == nil {
+		return errors.New("ebook enrichment queue is not configured")
+	}
+	_, err := q.pool.Exec(ctx, materializeEnrichmentJobsQuery)
+	return err
+}
+
+var claimEnrichmentJobsQuery = `
+	WITH candidates AS (
+		SELECT content_id
+		FROM ebook_enrichment_state
+		WHERE next_attempt_at <= now()
+		  AND (status = 'pending' OR (status = 'running' AND lease_until < now()))
+		ORDER BY priority DESC, next_attempt_at, updated_at
+		FOR UPDATE SKIP LOCKED
+		LIMIT $1
+	)
+	UPDATE ebook_enrichment_state state
+	SET status = 'running',
+		lease_until = now() + $2::interval,
+		last_attempt_at = now(),
+		attempts = attempts + 1,
+		updated_at = now()
+	FROM candidates
+	WHERE state.content_id = candidates.content_id
+	RETURNING state.content_id, state.attempts, state.last_attempt_at
+`
+
+func (q *EnrichmentQueue) ClaimBatch(ctx context.Context, limit int, leaseDuration time.Duration) ([]EnrichmentJob, error) {
+	if q == nil || q.pool == nil {
+		return nil, errors.New("ebook enrichment queue is not configured")
+	}
+	if limit <= 0 {
+		return nil, nil
+	}
+	if leaseDuration <= 0 {
+		leaseDuration = defaultEnrichmentLease
+	}
+
+	rows, err := q.pool.Query(ctx, claimEnrichmentJobsQuery, limit, postgresInterval(leaseDuration))
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	jobs := make([]EnrichmentJob, 0, limit)
+	for rows.Next() {
+		var job EnrichmentJob
+		if err := rows.Scan(&job.ContentID, &job.Attempts, &job.LastAttemptAt); err != nil {
+			return nil, err
+		}
+		jobs = append(jobs, job)
+		q.rememberClaim(job)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return jobs, nil
+}
+
+var completeEnrichmentJobQuery = `
+	UPDATE ebook_enrichment_state
+	SET status = 'pending',
+		lease_until = NULL,
+		completed_at = now(),
+		next_attempt_at = now() + $3::interval,
+		outcome = $2,
+		attempts = 0,
+		priority = GREATEST(priority, 0),
+		last_error_class = NULL,
+		last_error = NULL,
+		updated_at = now()
+	WHERE content_id = $1
+	  AND status = 'running'
+	  AND last_attempt_at = $4
+`
+
+func (q *EnrichmentQueue) Complete(
+	ctx context.Context,
+	contentID string,
+	outcome EnrichmentOutcome,
+	refreshAfter time.Duration,
+) error {
+	if q == nil || q.pool == nil {
+		return errors.New("ebook enrichment queue is not configured")
+	}
+	job, ok := q.claimedJob(contentID)
+	if !ok {
+		return ErrEnrichmentLeaseLost
+	}
+	return q.CompleteClaim(ctx, job, outcome, refreshAfter)
+}
+
+func (q *EnrichmentQueue) CompleteClaim(
+	ctx context.Context,
+	job EnrichmentJob,
+	outcome EnrichmentOutcome,
+	refreshAfter time.Duration,
+) error {
+	if q == nil || q.pool == nil {
+		return errors.New("ebook enrichment queue is not configured")
+	}
+	if refreshAfter <= 0 {
+		refreshAfter = enrichmentRefreshHorizon(outcome)
+	}
+	if refreshAfter <= 0 {
+		return fmt.Errorf("unsupported ebook enrichment outcome %q", outcome)
+	}
+
+	tag, err := q.pool.Exec(
+		ctx,
+		completeEnrichmentJobQuery,
+		job.ContentID,
+		string(outcome),
+		postgresInterval(refreshAfter),
+		job.LastAttemptAt,
+	)
+	if err != nil {
+		return err
+	}
+	if tag.RowsAffected() == 0 {
+		q.forgetClaim(job)
+		return ErrEnrichmentLeaseLost
+	}
+	q.forgetClaim(job)
+	return nil
+}
+
+var failEnrichmentJobQuery = `
+	UPDATE ebook_enrichment_state
+	SET status = 'pending',
+		lease_until = NULL,
+		next_attempt_at = now() + $4::interval,
+		outcome = 'failed',
+		last_error_class = $2,
+		last_error = $3,
+		updated_at = now()
+	WHERE content_id = $1
+	  AND status = 'running'
+	  AND last_attempt_at = $5
+`
+
+func (q *EnrichmentQueue) Fail(
+	ctx context.Context,
+	contentID string,
+	errorClass EnrichmentErrorClass,
+	message string,
+	retryAfter time.Duration,
+) error {
+	if q == nil || q.pool == nil {
+		return errors.New("ebook enrichment queue is not configured")
+	}
+	job, ok := q.claimedJob(contentID)
+	if !ok {
+		return ErrEnrichmentLeaseLost
+	}
+	return q.FailClaim(ctx, job, errorClass, message, retryAfter)
+}
+
+func (q *EnrichmentQueue) FailClaim(
+	ctx context.Context,
+	job EnrichmentJob,
+	errorClass EnrichmentErrorClass,
+	message string,
+	retryAfter time.Duration,
+) error {
+	if q == nil || q.pool == nil {
+		return errors.New("ebook enrichment queue is not configured")
+	}
+	delay := enrichmentRetryDelay(errorClass, job.Attempts, retryAfter)
+	tag, err := q.pool.Exec(
+		ctx,
+		failEnrichmentJobQuery,
+		job.ContentID,
+		string(errorClass),
+		message,
+		postgresInterval(delay),
+		job.LastAttemptAt,
+	)
+	if err != nil {
+		return err
+	}
+	if tag.RowsAffected() == 0 {
+		q.forgetClaim(job)
+		return ErrEnrichmentLeaseLost
+	}
+	q.forgetClaim(job)
+	return nil
+}
+
+var releaseEnrichmentJobQuery = `
+	UPDATE ebook_enrichment_state
+	SET status = 'pending',
+		lease_until = NULL,
+		attempts = GREATEST(attempts - 1, 0),
+		updated_at = now()
+	WHERE content_id = $1
+	  AND status = 'running'
+	  AND last_attempt_at = $2
+`
+
+func (q *EnrichmentQueue) Release(ctx context.Context, contentID string) error {
+	if q == nil || q.pool == nil {
+		return errors.New("ebook enrichment queue is not configured")
+	}
+	job, ok := q.claimedJob(contentID)
+	if !ok {
+		return ErrEnrichmentLeaseLost
+	}
+	return q.ReleaseClaim(ctx, job)
+}
+
+func (q *EnrichmentQueue) ReleaseClaim(ctx context.Context, job EnrichmentJob) error {
+	if q == nil || q.pool == nil {
+		return errors.New("ebook enrichment queue is not configured")
+	}
+	tag, err := q.pool.Exec(ctx, releaseEnrichmentJobQuery, job.ContentID, job.LastAttemptAt)
+	if err != nil {
+		return err
+	}
+	q.forgetClaim(job)
+	if tag.RowsAffected() == 0 {
+		return ErrEnrichmentLeaseLost
+	}
+	return nil
+}
+
+func (q *EnrichmentQueue) rememberClaim(job EnrichmentJob) {
+	q.claimsMu.Lock()
+	defer q.claimsMu.Unlock()
+	if q.claims == nil {
+		q.claims = make(map[string]EnrichmentJob)
+	}
+	q.claims[job.ContentID] = job
+}
+
+func (q *EnrichmentQueue) claimedJob(contentID string) (EnrichmentJob, bool) {
+	q.claimsMu.Lock()
+	defer q.claimsMu.Unlock()
+	job, ok := q.claims[contentID]
+	return job, ok
+}
+
+func (q *EnrichmentQueue) forgetClaim(job EnrichmentJob) {
+	q.claimsMu.Lock()
+	defer q.claimsMu.Unlock()
+	current, ok := q.claims[job.ContentID]
+	if ok && current.LastAttemptAt.Equal(job.LastAttemptAt) {
+		delete(q.claims, job.ContentID)
+	}
+}
+
+func enrichmentRefreshHorizon(outcome EnrichmentOutcome) time.Duration {
+	switch outcome {
+	case EnrichmentOutcomeSuccess:
+		return 90 * 24 * time.Hour
+	case EnrichmentOutcomeNoMatch:
+		return 30 * 24 * time.Hour
+	case EnrichmentOutcomeSkipped:
+		return skippedRetryHorizon
+	default:
+		return 0
+	}
+}
+
+func enrichmentRetryDelay(errorClass EnrichmentErrorClass, attempts int, retryAfter time.Duration) time.Duration {
+	switch errorClass {
+	case EnrichmentErrorRateLimited:
+		if retryAfter <= 0 {
+			retryAfter = transientRetryDelay(attempts)
+		}
+		return min(retryAfter, maxEnrichmentRetry)
+	case EnrichmentErrorPermanent:
+		return 30 * 24 * time.Hour
+	default:
+		return transientRetryDelay(attempts)
+	}
+}
+
+func transientRetryDelay(attempts int) time.Duration {
+	if attempts < 1 {
+		attempts = 1
+	}
+	delay := transientRetryBase
+	for i := 1; i < attempts; i++ {
+		if delay >= maxEnrichmentRetry/2 {
+			return maxEnrichmentRetry
+		}
+		delay *= 2
+	}
+	return min(delay, maxEnrichmentRetry)
+}
+
+func postgresInterval(duration time.Duration) string {
+	return fmt.Sprintf("%d microseconds", duration.Microseconds())
+}

--- a/internal/ebooks/enrichment_queue.go
+++ b/internal/ebooks/enrichment_queue.go
@@ -37,6 +37,22 @@ const (
 
 var ErrEnrichmentLeaseLost = errors.New("ebook enrichment lease lost")
 
+type EnrichmentScope string
+
+const (
+	EnrichmentScopeIncremental EnrichmentScope = "incremental"
+	EnrichmentScopeLegacy      EnrichmentScope = "legacy"
+)
+
+func (s EnrichmentScope) validate() error {
+	switch s {
+	case EnrichmentScopeIncremental, EnrichmentScopeLegacy:
+		return nil
+	default:
+		return fmt.Errorf("unsupported ebook enrichment scope %q", s)
+	}
+}
+
 type EnrichmentJob struct {
 	ContentID       string
 	Token           string
@@ -144,6 +160,10 @@ var claimEnrichmentJobsQuery = `
 		FROM ebook_enrichment_state
 		WHERE next_attempt_at <= now()
 		  AND (status = 'pending' OR (status = 'running' AND lease_until < now()))
+		  AND (
+			($3 = 'incremental' AND priority >= 0)
+			OR ($3 = 'legacy' AND priority < 0)
+		  )
 		ORDER BY
 			(priority + FLOOR(EXTRACT(EPOCH FROM (now() - next_attempt_at)) / 3600)::integer) DESC,
 			priority DESC,
@@ -164,9 +184,17 @@ var claimEnrichmentJobsQuery = `
 	RETURNING state.content_id, state.claim_token, state.attempts, state.last_attempt_at, state.protected_fields
 `
 
-func (q *EnrichmentQueue) ClaimBatch(ctx context.Context, limit int, leaseDuration time.Duration) ([]EnrichmentJob, error) {
+func (q *EnrichmentQueue) ClaimBatch(
+	ctx context.Context,
+	scope EnrichmentScope,
+	limit int,
+	leaseDuration time.Duration,
+) ([]EnrichmentJob, error) {
 	if q == nil || q.pool == nil {
 		return nil, errors.New("ebook enrichment queue is not configured")
+	}
+	if err := scope.validate(); err != nil {
+		return nil, err
 	}
 	if limit <= 0 {
 		return nil, nil
@@ -175,7 +203,7 @@ func (q *EnrichmentQueue) ClaimBatch(ctx context.Context, limit int, leaseDurati
 		leaseDuration = defaultEnrichmentLease
 	}
 
-	rows, err := q.pool.Query(ctx, claimEnrichmentJobsQuery, limit, postgresInterval(leaseDuration))
+	rows, err := q.pool.Query(ctx, claimEnrichmentJobsQuery, limit, postgresInterval(leaseDuration), string(scope))
 	if err != nil {
 		return nil, err
 	}
@@ -193,6 +221,31 @@ func (q *EnrichmentQueue) ClaimBatch(ctx context.Context, limit int, leaseDurati
 		return nil, err
 	}
 	return jobs, nil
+}
+
+var countReadyEnrichmentJobsQuery = `
+	SELECT COUNT(*)
+	FROM ebook_enrichment_state
+	WHERE next_attempt_at <= now()
+	  AND (status = 'pending' OR (status = 'running' AND lease_until < now()))
+	  AND (
+		($1 = 'incremental' AND priority >= 0)
+		OR ($1 = 'legacy' AND priority < 0)
+	  )
+`
+
+func (q *EnrichmentQueue) ReadyCount(ctx context.Context, scope EnrichmentScope) (int, error) {
+	if q == nil || q.pool == nil {
+		return 0, errors.New("ebook enrichment queue is not configured")
+	}
+	if err := scope.validate(); err != nil {
+		return 0, err
+	}
+	var count int
+	if err := q.pool.QueryRow(ctx, countReadyEnrichmentJobsQuery, string(scope)).Scan(&count); err != nil {
+		return 0, err
+	}
+	return count, nil
 }
 
 var checkEnrichmentClaimQuery = `

--- a/internal/ebooks/enrichment_queue.go
+++ b/internal/ebooks/enrichment_queue.go
@@ -17,6 +17,7 @@ const (
 	maxEnrichmentRetry     = 24 * time.Hour
 	transientRetryBase     = 5 * time.Minute
 	skippedRetryHorizon    = 15 * time.Minute
+	claimCandidateWindow   = 64
 )
 
 type EnrichmentOutcome string
@@ -154,22 +155,54 @@ func (q *EnrichmentQueue) Enqueue(ctx context.Context, contentID string, priorit
 	return err
 }
 
+// Each indexed window is fixed-size; only their deduplicated union pays for
+// aging/ranking, while the oldest-due window guarantees eventual promotion.
 var claimEnrichmentJobsQuery = `
-	WITH candidates AS (
-		SELECT content_id
+	WITH high_priority_candidates AS MATERIALIZED (
+		SELECT content_id, priority, next_attempt_at, updated_at
 		FROM ebook_enrichment_state
 		WHERE next_attempt_at <= now()
 		  AND (status = 'pending' OR (status = 'running' AND lease_until < now()))
-		  AND (
-			($3 = 'incremental' AND priority >= 0)
-			OR ($3 = 'legacy' AND priority < 0)
-		  )
-		ORDER BY
-			(priority + FLOOR(EXTRACT(EPOCH FROM (now() - next_attempt_at)) / 3600)::integer) DESC,
-			priority DESC,
+		  AND (priority < 0) = ($3 = 'legacy')
+		ORDER BY priority DESC, next_attempt_at, updated_at
+		LIMIT $4
+	),
+	oldest_due_candidates AS MATERIALIZED (
+		SELECT content_id, priority, next_attempt_at, updated_at
+		FROM ebook_enrichment_state
+		WHERE next_attempt_at <= now()
+		  AND (status = 'pending' OR (status = 'running' AND lease_until < now()))
+		  AND (priority < 0) = ($3 = 'legacy')
+		ORDER BY next_attempt_at, updated_at, priority DESC
+		LIMIT $4
+	),
+	candidate_pool AS MATERIALIZED (
+		SELECT * FROM high_priority_candidates
+		UNION
+		SELECT * FROM oldest_due_candidates
+	),
+	ranked_candidates AS MATERIALIZED (
+		SELECT
+			content_id,
+			priority,
 			next_attempt_at,
-			updated_at
-		FOR UPDATE SKIP LOCKED
+			updated_at,
+			(priority + FLOOR(EXTRACT(EPOCH FROM (now() - next_attempt_at)) / 3600)::integer) AS effective_priority
+		FROM candidate_pool
+	),
+	candidates AS (
+		SELECT state.content_id
+		FROM ranked_candidates ranked
+		JOIN ebook_enrichment_state state ON state.content_id = ranked.content_id
+		WHERE state.next_attempt_at <= now()
+		  AND (state.status = 'pending' OR (state.status = 'running' AND state.lease_until < now()))
+		  AND (state.priority < 0) = ($3 = 'legacy')
+		ORDER BY
+			ranked.effective_priority DESC,
+			ranked.priority DESC,
+			ranked.next_attempt_at,
+			ranked.updated_at
+		FOR UPDATE OF state SKIP LOCKED
 		LIMIT $1
 	)
 	UPDATE ebook_enrichment_state state
@@ -203,7 +236,14 @@ func (q *EnrichmentQueue) ClaimBatch(
 		leaseDuration = defaultEnrichmentLease
 	}
 
-	rows, err := q.pool.Query(ctx, claimEnrichmentJobsQuery, limit, postgresInterval(leaseDuration), string(scope))
+	rows, err := q.pool.Query(
+		ctx,
+		claimEnrichmentJobsQuery,
+		limit,
+		postgresInterval(leaseDuration),
+		string(scope),
+		claimCandidateWindow,
+	)
 	if err != nil {
 		return nil, err
 	}
@@ -228,10 +268,7 @@ var countReadyEnrichmentJobsQuery = `
 	FROM ebook_enrichment_state
 	WHERE next_attempt_at <= now()
 	  AND (status = 'pending' OR (status = 'running' AND lease_until < now()))
-	  AND (
-		($1 = 'incremental' AND priority >= 0)
-		OR ($1 = 'legacy' AND priority < 0)
-	  )
+	  AND (priority < 0) = ($1 = 'legacy')
 `
 
 func (q *EnrichmentQueue) ReadyCount(ctx context.Context, scope EnrichmentScope) (int, error) {

--- a/internal/ebooks/enrichment_queue_test.go
+++ b/internal/ebooks/enrichment_queue_test.go
@@ -18,12 +18,21 @@ func TestEnrichmentQueueClaimQueryUsesAtomicLeasedClaims(t *testing.T) {
 	query := strings.Join(strings.Fields(claimEnrichmentJobsQuery), " ")
 
 	for _, fragment := range []string{
-		"WITH candidates AS",
-		"FOR UPDATE SKIP LOCKED",
+		"WITH high_priority_candidates AS MATERIALIZED",
+		"oldest_due_candidates AS MATERIALIZED",
+		"candidate_pool AS",
+		"UNION",
+		"ranked_candidates AS",
+		"FROM ranked_candidates ranked",
+		"JOIN ebook_enrichment_state state",
+		"FOR UPDATE OF state SKIP LOCKED",
 		"status = 'pending' OR (status = 'running' AND lease_until < now())",
 		"next_attempt_at <= now()",
-		"$3 = 'incremental' AND priority >= 0",
-		"$3 = 'legacy' AND priority < 0",
+		"(priority < 0) = ($3 = 'legacy')",
+		"(state.priority < 0) = ($3 = 'legacy')",
+		"ORDER BY priority DESC, next_attempt_at, updated_at",
+		"ORDER BY next_attempt_at, updated_at, priority DESC",
+		"LIMIT $4",
 		"priority + FLOOR(EXTRACT(EPOCH FROM (now() - next_attempt_at)) / 3600)::integer",
 		"SET status = 'running'",
 		"lease_until = now() + $2::interval",
@@ -36,6 +45,20 @@ func TestEnrichmentQueueClaimQueryUsesAtomicLeasedClaims(t *testing.T) {
 			t.Fatalf("claim query missing %q:\n%s", fragment, claimEnrichmentJobsQuery)
 		}
 	}
+	if got := strings.Count(query, "LIMIT $4"); got != 2 {
+		t.Fatalf("claim query has %d bounded candidate windows, want 2:\n%s", got, claimEnrichmentJobsQuery)
+	}
+	if got := strings.Count(query, "FLOOR(EXTRACT(EPOCH"); got != 1 {
+		t.Fatalf("aging expression count = %d, want exactly one bounded computation:\n%s", got, claimEnrichmentJobsQuery)
+	}
+	agingAt := strings.Index(query, "FLOOR(EXTRACT(EPOCH")
+	poolAt := strings.Index(query, "candidate_pool AS")
+	if agingAt < poolAt {
+		t.Fatalf("aging is computed before the bounded candidate pool:\n%s", claimEnrichmentJobsQuery)
+	}
+	if claimCandidateWindow <= 0 || claimCandidateWindow > 256 {
+		t.Fatalf("claim candidate window = %d, want a fixed sane bound", claimCandidateWindow)
+	}
 }
 
 func TestEnrichmentQueueReadyCountUsesTheSameScopeAsClaims(t *testing.T) {
@@ -44,8 +67,7 @@ func TestEnrichmentQueueReadyCountUsesTheSameScopeAsClaims(t *testing.T) {
 		"SELECT COUNT(*)",
 		"next_attempt_at <= now()",
 		"status = 'pending' OR (status = 'running' AND lease_until < now())",
-		"$1 = 'incremental' AND priority >= 0",
-		"$1 = 'legacy' AND priority < 0",
+		"(priority < 0) = ($1 = 'legacy')",
 	} {
 		if !strings.Contains(query, fragment) {
 			t.Fatalf("ready-count query missing %q:\n%s", fragment, countReadyEnrichmentJobsQuery)
@@ -142,8 +164,13 @@ func TestEnrichmentQueueMigrationIsCrashSafeAndSeedsAllLegacyEbooks(t *testing.T
 		"ON CONFLICT (content_id) DO NOTHING",
 		"NOT i.indisvalid",
 		"DROP INDEX public.ebook_enrichment_state_claim_idx",
+		"DROP INDEX public.ebook_enrichment_state_priority_claim_idx",
 		"CREATE INDEX CONCURRENTLY IF NOT EXISTS ebook_enrichment_state_claim_idx",
+		"CREATE INDEX CONCURRENTLY IF NOT EXISTS ebook_enrichment_state_priority_claim_idx",
+		"((priority < 0), next_attempt_at, updated_at, priority DESC)",
+		"((priority < 0), priority DESC, next_attempt_at, updated_at)",
 		"DROP INDEX CONCURRENTLY IF EXISTS ebook_enrichment_state_claim_idx",
+		"DROP INDEX CONCURRENTLY IF EXISTS ebook_enrichment_state_priority_claim_idx",
 	} {
 		if !strings.Contains(migration, fragment) {
 			t.Fatalf("legacy backlog migration missing %q:\n%s", fragment, body)

--- a/internal/ebooks/enrichment_queue_test.go
+++ b/internal/ebooks/enrichment_queue_test.go
@@ -151,6 +151,8 @@ func TestEnrichmentQueueHasReadyUsesBoundedExistenceQueries(t *testing.T) {
 				"next_attempt_at <= now()",
 				"status = 'pending' OR (status = 'running' AND lease_until < now())",
 				tt.predicate,
+				"ORDER BY next_attempt_at, updated_at, priority DESC",
+				"LIMIT 1",
 			} {
 				if !strings.Contains(query, fragment) {
 					t.Fatalf("has-ready query missing %q:\n%s", fragment, tt.query)
@@ -166,15 +168,66 @@ func TestEnrichmentQueueHasReadyUsesBoundedExistenceQueries(t *testing.T) {
 func TestEnrichmentQueueReconcileMissingIsBoundedAndLaneSafe(t *testing.T) {
 	query := strings.Join(strings.Fields(reconcileMissingEnrichmentJobsQuery), " ")
 	for _, fragment := range []string{
-		"WHERE mil.media_folder_id = $1",
+		"membership_candidates AS MATERIALIZED",
+		"WHERE membership.media_folder_id = $1",
+		"$4::timestamptz IS NULL",
+		"membership.first_seen_at < $4",
+		"membership.content_id > $5",
+		"ORDER BY membership.first_seen_at DESC, membership.content_id",
+		"LIMIT $3",
+		"FROM membership_candidates candidate",
 		"mi.type = 'ebook'",
 		"state.content_id IS NULL",
-		"LIMIT $3",
 		"SELECT candidates.content_id, 'pending', $2",
 		"ON CONFLICT (content_id) DO NOTHING",
+		"COUNT(*)::integer AS inspected",
+		"FROM membership_candidates",
+		"(SELECT COUNT(*)::integer FROM inserted) AS reconciled",
 	} {
 		if !strings.Contains(query, fragment) {
 			t.Fatalf("reconcile query missing %q:\n%s", fragment, reconcileMissingEnrichmentJobsQuery)
+		}
+	}
+	windowAt := strings.Index(query, "membership_candidates AS MATERIALIZED")
+	boundedQuery := query[windowAt:]
+	limitAt := strings.Index(boundedQuery, "LIMIT $3")
+	itemJoinAt := strings.Index(boundedQuery, "JOIN media_items mi")
+	stateJoinAt := strings.Index(boundedQuery, "LEFT JOIN ebook_enrichment_state state")
+	if windowAt < 0 || limitAt < 0 || itemJoinAt < 0 || stateJoinAt < 0 {
+		t.Fatalf("reconcile query is missing bounded traversal structure:\n%s", reconcileMissingEnrichmentJobsQuery)
+	}
+	if limitAt > itemJoinAt || limitAt > stateJoinAt {
+		t.Fatalf("reconcile query filters missing jobs before bounding raw membership traversal:\n%s", reconcileMissingEnrichmentJobsQuery)
+	}
+	statsAt := strings.Index(query, "COUNT(*)::integer AS inspected")
+	insertedAt := strings.Index(query, "(SELECT COUNT(*)::integer FROM inserted) AS reconciled")
+	if statsAt < 0 || insertedAt < 0 || statsAt > insertedAt {
+		t.Fatalf("cursor advancement is not derived independently from the inspected membership window:\n%s", reconcileMissingEnrichmentJobsQuery)
+	}
+
+	ensureQuery := strings.Join(strings.Fields(ensureEnrichmentReconcileCursorQuery), " ")
+	if !strings.Contains(ensureQuery, "ON CONFLICT (folder_id) DO NOTHING") {
+		t.Fatalf("cursor ensure query is not idempotent: %s", ensureEnrichmentReconcileCursorQuery)
+	}
+	lockQuery := strings.Join(strings.Fields(lockEnrichmentReconcileCursorQuery), " ")
+	for _, fragment := range []string{
+		"SELECT after_first_seen_at, after_content_id",
+		"WHERE folder_id = $1",
+		"FOR UPDATE",
+	} {
+		if !strings.Contains(lockQuery, fragment) {
+			t.Fatalf("cursor lock query missing %q: %s", fragment, lockEnrichmentReconcileCursorQuery)
+		}
+	}
+	updateQuery := strings.Join(strings.Fields(updateEnrichmentReconcileCursorQuery), " ")
+	for _, fragment := range []string{
+		"UPDATE ebook_enrichment_reconcile_cursors",
+		"SET after_first_seen_at = $2",
+		"after_content_id = $3",
+		"WHERE folder_id = $1",
+	} {
+		if !strings.Contains(updateQuery, fragment) {
+			t.Fatalf("cursor update query missing %q: %s", fragment, updateEnrichmentReconcileCursorQuery)
 		}
 	}
 }

--- a/internal/ebooks/enrichment_queue_test.go
+++ b/internal/ebooks/enrichment_queue_test.go
@@ -490,6 +490,38 @@ func TestEnrichmentRetryPolicy(t *testing.T) {
 		}
 	})
 
+	t.Run("rate limits never requeue below the cooldown floor", func(t *testing.T) {
+		// A provider's 1s RetryInfo is request-pacing advice, not a queue
+		// horizon; adopting it verbatim re-claims the same saturated tail.
+		if got := enrichmentRetryDelay(EnrichmentErrorRateLimited, 1, time.Second); got != 15*time.Minute {
+			t.Fatalf("short-hint rate-limited retry = %s, want 15m floor", got)
+		}
+		if got := enrichmentRetryDelay(EnrichmentErrorRateLimited, 1, 0); got != 15*time.Minute {
+			t.Fatalf("no-hint rate-limited retry = %s, want 15m floor", got)
+		}
+		if got := enrichmentRetryDelay(EnrichmentErrorRateLimited, 20, 0); got != 24*time.Hour {
+			t.Fatalf("no-hint high-attempt rate-limited retry = %s, want capped backoff", got)
+		}
+	})
+
+	t.Run("cooldown floor is env tunable with a tolerant fallback", func(t *testing.T) {
+		t.Setenv("SILO_EBOOK_RATE_LIMIT_COOLDOWN", "30m")
+		if got := enrichmentRetryDelay(EnrichmentErrorRateLimited, 1, time.Second); got != 30*time.Minute {
+			t.Fatalf("tuned floor retry = %s, want 30m", got)
+		}
+		if got := enrichmentRetryDelay(EnrichmentErrorRateLimited, 1, 45*time.Minute); got != 45*time.Minute {
+			t.Fatalf("hint above tuned floor = %s, want 45m", got)
+		}
+		t.Setenv("SILO_EBOOK_RATE_LIMIT_COOLDOWN", "banana")
+		if got := enrichmentRetryDelay(EnrichmentErrorRateLimited, 1, time.Second); got != 15*time.Minute {
+			t.Fatalf("invalid floor retry = %s, want 15m default", got)
+		}
+		t.Setenv("SILO_EBOOK_RATE_LIMIT_COOLDOWN", "-5m")
+		if got := enrichmentRetryDelay(EnrichmentErrorRateLimited, 1, time.Second); got != 15*time.Minute {
+			t.Fatalf("non-positive floor retry = %s, want 15m default", got)
+		}
+	})
+
 	t.Run("permanent failures refresh after 30 days", func(t *testing.T) {
 		if got := enrichmentRetryDelay(EnrichmentErrorPermanent, 1, 0); got != 30*24*time.Hour {
 			t.Fatalf("permanent retry = %s, want 30 days", got)

--- a/internal/ebooks/enrichment_queue_test.go
+++ b/internal/ebooks/enrichment_queue_test.go
@@ -135,7 +135,7 @@ func TestEnrichmentQueueReadyCountUsesTheSameLiteralLaneAsClaims(t *testing.T) {
 	}
 }
 
-func TestEnrichmentQueueHasReadyUsesBoundedExistenceQueries(t *testing.T) {
+func TestEnrichmentQueueHasReadyUsesBoundedOrderedScalarQueries(t *testing.T) {
 	for _, tt := range []struct {
 		name      string
 		query     string
@@ -147,16 +147,21 @@ func TestEnrichmentQueueHasReadyUsesBoundedExistenceQueries(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			query := strings.Join(strings.Fields(tt.query), " ")
 			for _, fragment := range []string{
-				"SELECT EXISTS",
+				"SELECT COALESCE((",
+				"SELECT true",
 				"next_attempt_at <= now()",
 				"status = 'pending' OR (status = 'running' AND lease_until < now())",
 				tt.predicate,
 				"ORDER BY next_attempt_at, updated_at, priority DESC",
 				"LIMIT 1",
+				"), false)",
 			} {
 				if !strings.Contains(query, fragment) {
 					t.Fatalf("has-ready query missing %q:\n%s", fragment, tt.query)
 				}
+			}
+			if strings.Contains(query, "EXISTS") {
+				t.Fatalf("has-ready query uses EXISTS, which lets PostgreSQL discard ordering:\n%s", tt.query)
 			}
 			if strings.Contains(query, "COUNT(") {
 				t.Fatalf("has-ready query performs an exact count:\n%s", tt.query)
@@ -171,9 +176,8 @@ func TestEnrichmentQueueReconcileMissingIsBoundedAndLaneSafe(t *testing.T) {
 		"membership_candidates AS MATERIALIZED",
 		"WHERE membership.media_folder_id = $1",
 		"$4::timestamptz IS NULL",
-		"membership.first_seen_at < $4",
-		"membership.content_id > $5",
-		"ORDER BY membership.first_seen_at DESC, membership.content_id",
+		"(membership.first_seen_at, membership.content_id) < ($4, $5)",
+		"ORDER BY membership.first_seen_at DESC, membership.content_id DESC",
 		"LIMIT $3",
 		"FROM membership_candidates candidate",
 		"mi.type = 'ebook'",

--- a/internal/ebooks/enrichment_queue_test.go
+++ b/internal/ebooks/enrichment_queue_test.go
@@ -1,0 +1,186 @@
+package ebooks
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"strings"
+	"testing"
+	"time"
+
+	"google.golang.org/genproto/googleapis/rpc/errdetails"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+	"google.golang.org/protobuf/types/known/durationpb"
+)
+
+func TestEnrichmentQueueClaimQueryUsesAtomicLeasedClaims(t *testing.T) {
+	query := strings.Join(strings.Fields(claimEnrichmentJobsQuery), " ")
+
+	for _, fragment := range []string{
+		"WITH candidates AS",
+		"FOR UPDATE SKIP LOCKED",
+		"status = 'pending' OR (status = 'running' AND lease_until < now())",
+		"next_attempt_at <= now()",
+		"ORDER BY priority DESC, next_attempt_at, updated_at",
+		"SET status = 'running'",
+		"lease_until = now() + $2::interval",
+		"attempts = attempts + 1",
+		"RETURNING state.content_id, state.attempts",
+	} {
+		if !strings.Contains(query, fragment) {
+			t.Fatalf("claim query missing %q:\n%s", fragment, claimEnrichmentJobsQuery)
+		}
+	}
+}
+
+func TestEnrichmentQueueMaterializesUnrefreshedEbooksRegardlessOfPoster(t *testing.T) {
+	query := strings.Join(strings.Fields(materializeEnrichmentJobsQuery), " ")
+
+	if !strings.Contains(query, "SELECT mi.content_id, 'pending', 100, now(), now()") {
+		t.Fatalf("newly discovered ebooks must enter ahead of legacy backfill:\n%s", materializeEnrichmentJobsQuery)
+	}
+	if !strings.Contains(query, "mi.last_refreshed IS NULL") {
+		t.Fatalf("materialization must use refresh state as its eligibility gate:\n%s", materializeEnrichmentJobsQuery)
+	}
+	if strings.Contains(query, "poster_path") {
+		t.Fatalf("local or embedded covers must not make ebooks ineligible for metadata enrichment:\n%s", materializeEnrichmentJobsQuery)
+	}
+}
+
+func TestEnrichmentQueueMigrationSeedsLegacyBacklogAtLowPriority(t *testing.T) {
+	body, err := os.ReadFile("../../migrations/sql/20260719090000_ebook_enrichment_jobs.sql")
+	if err != nil {
+		t.Fatalf("read enrichment queue migration: %v", err)
+	}
+	migration := strings.Join(strings.Fields(string(body)), " ")
+
+	for _, fragment := range []string{
+		"INSERT INTO ebook_enrichment_state",
+		"SELECT mi.content_id, 'pending', -100, 0, now(), now()",
+		"mi.type = 'ebook'",
+		"mi.last_refreshed IS NULL",
+		"NOT EXISTS",
+		"manga_chapters",
+		"ON CONFLICT (content_id) DO NOTHING",
+	} {
+		if !strings.Contains(migration, fragment) {
+			t.Fatalf("legacy backlog migration missing %q:\n%s", fragment, body)
+		}
+	}
+	if strings.Contains(migration, "poster_path") {
+		t.Fatalf("legacy backlog must include ebooks with local or embedded covers:\n%s", body)
+	}
+}
+
+func TestEnrichmentQueueTransitionsKeepDurableRowsAndReleaseLeases(t *testing.T) {
+	complete := strings.Join(strings.Fields(completeEnrichmentJobQuery), " ")
+	for _, fragment := range []string{
+		"UPDATE ebook_enrichment_state",
+		"status = 'pending'",
+		"lease_until = NULL",
+		"completed_at = now()",
+		"next_attempt_at = now() + $3::interval",
+		"outcome = $2",
+		"attempts = 0",
+		"priority = GREATEST(priority, 0)",
+		"AND last_attempt_at = $4",
+	} {
+		if !strings.Contains(complete, fragment) {
+			t.Fatalf("complete query missing %q:\n%s", fragment, completeEnrichmentJobQuery)
+		}
+	}
+	if strings.Contains(strings.ToUpper(complete), "DELETE") {
+		t.Fatalf("completion must retain durable queue state:\n%s", completeEnrichmentJobQuery)
+	}
+
+	release := strings.Join(strings.Fields(releaseEnrichmentJobQuery), " ")
+	for _, fragment := range []string{
+		"status = 'pending'",
+		"lease_until = NULL",
+		"attempts = GREATEST(attempts - 1, 0)",
+		"WHERE content_id = $1",
+		"AND status = 'running'",
+		"AND last_attempt_at = $2",
+	} {
+		if !strings.Contains(release, fragment) {
+			t.Fatalf("release query missing %q:\n%s", fragment, releaseEnrichmentJobQuery)
+		}
+	}
+
+	failure := strings.Join(strings.Fields(failEnrichmentJobQuery), " ")
+	if !strings.Contains(failure, "AND last_attempt_at = $5") {
+		t.Fatalf("failure transition must reject stale leases:\n%s", failEnrichmentJobQuery)
+	}
+}
+
+func TestEnrichmentRetryPolicy(t *testing.T) {
+	t.Run("outcome refresh horizons", func(t *testing.T) {
+		if got := enrichmentRefreshHorizon(EnrichmentOutcomeSuccess); got != 90*24*time.Hour {
+			t.Fatalf("success refresh horizon = %s, want 90 days", got)
+		}
+		if got := enrichmentRefreshHorizon(EnrichmentOutcomeNoMatch); got != 30*24*time.Hour {
+			t.Fatalf("no-match refresh horizon = %s, want 30 days", got)
+		}
+	})
+
+	t.Run("transient failures use capped exponential backoff", func(t *testing.T) {
+		if got := enrichmentRetryDelay(EnrichmentErrorTransient, 1, 0); got != 5*time.Minute {
+			t.Fatalf("first transient retry = %s, want 5m", got)
+		}
+		if got := enrichmentRetryDelay(EnrichmentErrorTransient, 2, 0); got != 10*time.Minute {
+			t.Fatalf("second transient retry = %s, want 10m", got)
+		}
+		if got := enrichmentRetryDelay(EnrichmentErrorTransient, 20, 0); got != 24*time.Hour {
+			t.Fatalf("capped transient retry = %s, want 24h", got)
+		}
+	})
+
+	t.Run("rate limits honor provider horizon with a 24 hour cap", func(t *testing.T) {
+		if got := enrichmentRetryDelay(EnrichmentErrorRateLimited, 1, 45*time.Minute); got != 45*time.Minute {
+			t.Fatalf("rate-limited retry = %s, want 45m", got)
+		}
+		if got := enrichmentRetryDelay(EnrichmentErrorRateLimited, 1, 72*time.Hour); got != 24*time.Hour {
+			t.Fatalf("capped rate-limited retry = %s, want 24h", got)
+		}
+	})
+
+	t.Run("permanent failures refresh after 30 days", func(t *testing.T) {
+		if got := enrichmentRetryDelay(EnrichmentErrorPermanent, 1, 0); got != 30*24*time.Hour {
+			t.Fatalf("permanent retry = %s, want 30 days", got)
+		}
+	})
+}
+
+func TestEnrichmentRetryPolicyClassifiesProviderErrors(t *testing.T) {
+	limited, err := status.New(codes.ResourceExhausted, "provider quota exhausted").WithDetails(
+		&errdetails.RetryInfo{RetryDelay: durationpb.New(45 * time.Minute)},
+	)
+	if err != nil {
+		t.Fatalf("attach retry info: %v", err)
+	}
+	providerErrors := errors.Join(fmt.Errorf("openlibrary search: %w", limited.Err()))
+	errorClass, retryAfter := classifyEnrichmentError(fmt.Errorf("no metadata obtained: %w", providerErrors))
+	if errorClass != EnrichmentErrorRateLimited || retryAfter != 45*time.Minute {
+		t.Fatalf("rate-limit classification = (%q, %s), want (rate_limited, 45m)", errorClass, retryAfter)
+	}
+
+	for _, code := range []codes.Code{
+		codes.InvalidArgument,
+		codes.NotFound,
+		codes.PermissionDenied,
+		codes.Unauthenticated,
+		codes.FailedPrecondition,
+		codes.Unimplemented,
+	} {
+		errorClass, retryAfter = classifyEnrichmentError(status.Error(code, "deterministic provider failure"))
+		if errorClass != EnrichmentErrorPermanent || retryAfter != 0 {
+			t.Fatalf("%s classification = (%q, %s), want (permanent, 0)", code, errorClass, retryAfter)
+		}
+	}
+
+	errorClass, retryAfter = classifyEnrichmentError(status.Error(codes.Unavailable, "provider down"))
+	if errorClass != EnrichmentErrorTransient || retryAfter != 0 {
+		t.Fatalf("unavailable classification = (%q, %s), want (transient, 0)", errorClass, retryAfter)
+	}
+}

--- a/internal/ebooks/enrichment_queue_test.go
+++ b/internal/ebooks/enrichment_queue_test.go
@@ -22,6 +22,8 @@ func TestEnrichmentQueueClaimQueryUsesAtomicLeasedClaims(t *testing.T) {
 		"FOR UPDATE SKIP LOCKED",
 		"status = 'pending' OR (status = 'running' AND lease_until < now())",
 		"next_attempt_at <= now()",
+		"$3 = 'incremental' AND priority >= 0",
+		"$3 = 'legacy' AND priority < 0",
 		"priority + FLOOR(EXTRACT(EPOCH FROM (now() - next_attempt_at)) / 3600)::integer",
 		"SET status = 'running'",
 		"lease_until = now() + $2::interval",
@@ -33,6 +35,32 @@ func TestEnrichmentQueueClaimQueryUsesAtomicLeasedClaims(t *testing.T) {
 		if !strings.Contains(query, fragment) {
 			t.Fatalf("claim query missing %q:\n%s", fragment, claimEnrichmentJobsQuery)
 		}
+	}
+}
+
+func TestEnrichmentQueueReadyCountUsesTheSameScopeAsClaims(t *testing.T) {
+	query := strings.Join(strings.Fields(countReadyEnrichmentJobsQuery), " ")
+	for _, fragment := range []string{
+		"SELECT COUNT(*)",
+		"next_attempt_at <= now()",
+		"status = 'pending' OR (status = 'running' AND lease_until < now())",
+		"$1 = 'incremental' AND priority >= 0",
+		"$1 = 'legacy' AND priority < 0",
+	} {
+		if !strings.Contains(query, fragment) {
+			t.Fatalf("ready-count query missing %q:\n%s", fragment, countReadyEnrichmentJobsQuery)
+		}
+	}
+}
+
+func TestEnrichmentScopeValidation(t *testing.T) {
+	for _, scope := range []EnrichmentScope{EnrichmentScopeIncremental, EnrichmentScopeLegacy} {
+		if err := scope.validate(); err != nil {
+			t.Fatalf("validate(%q) error = %v", scope, err)
+		}
+	}
+	if err := EnrichmentScope("everything").validate(); err == nil {
+		t.Fatal("unknown enrichment scope was accepted")
 	}
 }
 

--- a/internal/ebooks/enrichment_queue_test.go
+++ b/internal/ebooks/enrichment_queue_test.go
@@ -15,63 +15,123 @@ import (
 )
 
 func TestEnrichmentQueueClaimQueryUsesAtomicLeasedClaims(t *testing.T) {
-	query := strings.Join(strings.Fields(claimEnrichmentJobsQuery), " ")
-
-	for _, fragment := range []string{
-		"WITH high_priority_candidates AS MATERIALIZED",
-		"oldest_due_candidates AS MATERIALIZED",
-		"candidate_pool AS",
-		"UNION",
-		"ranked_candidates AS",
-		"FROM ranked_candidates ranked",
-		"JOIN ebook_enrichment_state state",
-		"FOR UPDATE OF state SKIP LOCKED",
-		"status = 'pending' OR (status = 'running' AND lease_until < now())",
-		"next_attempt_at <= now()",
-		"(priority < 0) = ($3 = 'legacy')",
-		"(state.priority < 0) = ($3 = 'legacy')",
-		"ORDER BY priority DESC, next_attempt_at, updated_at",
-		"ORDER BY next_attempt_at, updated_at, priority DESC",
-		"LIMIT $4",
-		"priority + FLOOR(EXTRACT(EPOCH FROM (now() - next_attempt_at)) / 3600)::integer",
-		"SET status = 'running'",
-		"lease_until = now() + $2::interval",
-		"claim_token = gen_random_uuid()::text",
-		"attempts = attempts + 1",
-		"RETURNING state.content_id, state.claim_token, state.attempts",
-		"state.protected_fields",
-	} {
-		if !strings.Contains(query, fragment) {
-			t.Fatalf("claim query missing %q:\n%s", fragment, claimEnrichmentJobsQuery)
-		}
+	tests := []struct {
+		name           string
+		query          string
+		lanePredicate  string
+		statePredicate string
+		rejected       string
+	}{
+		{
+			name:           "incremental",
+			query:          claimIncrementalEnrichmentJobsQuery,
+			lanePredicate:  "priority >= 0",
+			statePredicate: "state.priority >= 0",
+			rejected:       "priority < 0",
+		},
+		{
+			name:           "legacy",
+			query:          claimLegacyEnrichmentJobsQuery,
+			lanePredicate:  "priority < 0",
+			statePredicate: "state.priority < 0",
+			rejected:       "priority >= 0",
+		},
 	}
-	if got := strings.Count(query, "LIMIT $4"); got != 2 {
-		t.Fatalf("claim query has %d bounded candidate windows, want 2:\n%s", got, claimEnrichmentJobsQuery)
-	}
-	if got := strings.Count(query, "FLOOR(EXTRACT(EPOCH"); got != 1 {
-		t.Fatalf("aging expression count = %d, want exactly one bounded computation:\n%s", got, claimEnrichmentJobsQuery)
-	}
-	agingAt := strings.Index(query, "FLOOR(EXTRACT(EPOCH")
-	poolAt := strings.Index(query, "candidate_pool AS")
-	if agingAt < poolAt {
-		t.Fatalf("aging is computed before the bounded candidate pool:\n%s", claimEnrichmentJobsQuery)
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			query := strings.Join(strings.Fields(tt.query), " ")
+			for _, fragment := range []string{
+				"WITH high_priority_candidates AS MATERIALIZED",
+				"oldest_due_candidates AS MATERIALIZED",
+				"candidate_pool AS",
+				"UNION",
+				"ranked_candidates AS",
+				"FROM ranked_candidates ranked",
+				"JOIN ebook_enrichment_state state",
+				"FOR UPDATE OF state SKIP LOCKED",
+				"status = 'pending' OR (status = 'running' AND lease_until < now())",
+				"next_attempt_at <= now()",
+				tt.lanePredicate,
+				tt.statePredicate,
+				"ORDER BY priority DESC, next_attempt_at, updated_at",
+				"ORDER BY next_attempt_at, updated_at, priority DESC",
+				"LIMIT $3",
+				"priority + FLOOR(EXTRACT(EPOCH FROM (now() - next_attempt_at)) / 3600)::integer",
+				"SET status = 'running'",
+				"lease_until = now() + $2::interval",
+				"claim_token = gen_random_uuid()::text",
+				"attempts = attempts + 1",
+				"RETURNING state.content_id, state.claim_token, state.attempts",
+				"state.protected_fields",
+			} {
+				if !strings.Contains(query, fragment) {
+					t.Fatalf("claim query missing %q:\n%s", fragment, tt.query)
+				}
+			}
+			if strings.Contains(query, tt.rejected) {
+				t.Fatalf("claim query crosses lanes with %q:\n%s", tt.rejected, tt.query)
+			}
+			if strings.Contains(query, "$3 = 'legacy'") {
+				t.Fatalf("claim query uses a parameterized lane predicate:\n%s", tt.query)
+			}
+			if got := strings.Count(query, "LIMIT $3"); got != 2 {
+				t.Fatalf("claim query has %d bounded candidate windows, want 2:\n%s", got, tt.query)
+			}
+			if got := strings.Count(query, "FLOOR(EXTRACT(EPOCH"); got != 1 {
+				t.Fatalf("aging expression count = %d, want exactly one bounded computation:\n%s", got, tt.query)
+			}
+			agingAt := strings.Index(query, "FLOOR(EXTRACT(EPOCH")
+			poolAt := strings.Index(query, "candidate_pool AS")
+			if agingAt < poolAt {
+				t.Fatalf("aging is computed before the bounded candidate pool:\n%s", tt.query)
+			}
+		})
 	}
 	if claimCandidateWindow <= 0 || claimCandidateWindow > 256 {
 		t.Fatalf("claim candidate window = %d, want a fixed sane bound", claimCandidateWindow)
 	}
 }
 
-func TestEnrichmentQueueReadyCountUsesTheSameScopeAsClaims(t *testing.T) {
-	query := strings.Join(strings.Fields(countReadyEnrichmentJobsQuery), " ")
-	for _, fragment := range []string{
-		"SELECT COUNT(*)",
-		"next_attempt_at <= now()",
-		"status = 'pending' OR (status = 'running' AND lease_until < now())",
-		"(priority < 0) = ($1 = 'legacy')",
+func TestEnrichmentQueueSelectsLiteralLaneQueries(t *testing.T) {
+	if got := claimEnrichmentJobsQueryForScope(EnrichmentScopeIncremental); got != claimIncrementalEnrichmentJobsQuery {
+		t.Fatal("incremental scope did not select incremental claim SQL")
+	}
+	if got := claimEnrichmentJobsQueryForScope(EnrichmentScopeLegacy); got != claimLegacyEnrichmentJobsQuery {
+		t.Fatal("legacy scope did not select legacy claim SQL")
+	}
+	if got := countReadyEnrichmentJobsQueryForScope(EnrichmentScopeIncremental); got != countReadyIncrementalEnrichmentJobsQuery {
+		t.Fatal("incremental scope did not select incremental count SQL")
+	}
+	if got := countReadyEnrichmentJobsQueryForScope(EnrichmentScopeLegacy); got != countReadyLegacyEnrichmentJobsQuery {
+		t.Fatal("legacy scope did not select legacy count SQL")
+	}
+}
+
+func TestEnrichmentQueueReadyCountUsesTheSameLiteralLaneAsClaims(t *testing.T) {
+	for _, tt := range []struct {
+		name      string
+		query     string
+		predicate string
+	}{
+		{name: "incremental", query: countReadyIncrementalEnrichmentJobsQuery, predicate: "priority >= 0"},
+		{name: "legacy", query: countReadyLegacyEnrichmentJobsQuery, predicate: "priority < 0"},
 	} {
-		if !strings.Contains(query, fragment) {
-			t.Fatalf("ready-count query missing %q:\n%s", fragment, countReadyEnrichmentJobsQuery)
-		}
+		t.Run(tt.name, func(t *testing.T) {
+			query := strings.Join(strings.Fields(tt.query), " ")
+			for _, fragment := range []string{
+				"SELECT COUNT(*)",
+				"next_attempt_at <= now()",
+				"status = 'pending' OR (status = 'running' AND lease_until < now())",
+				tt.predicate,
+			} {
+				if !strings.Contains(query, fragment) {
+					t.Fatalf("ready-count query missing %q:\n%s", fragment, tt.query)
+				}
+			}
+			if strings.Contains(query, "$1 = 'legacy'") {
+				t.Fatalf("ready-count query uses a parameterized lane predicate:\n%s", tt.query)
+			}
+		})
 	}
 }
 
@@ -163,14 +223,20 @@ func TestEnrichmentQueueMigrationIsCrashSafeAndSeedsAllLegacyEbooks(t *testing.T
 		"manga_chapters",
 		"ON CONFLICT (content_id) DO NOTHING",
 		"NOT i.indisvalid",
-		"DROP INDEX public.ebook_enrichment_state_claim_idx",
-		"DROP INDEX public.ebook_enrichment_state_priority_claim_idx",
-		"CREATE INDEX CONCURRENTLY IF NOT EXISTS ebook_enrichment_state_claim_idx",
-		"CREATE INDEX CONCURRENTLY IF NOT EXISTS ebook_enrichment_state_priority_claim_idx",
-		"((priority < 0), next_attempt_at, updated_at, priority DESC)",
-		"((priority < 0), priority DESC, next_attempt_at, updated_at)",
-		"DROP INDEX CONCURRENTLY IF EXISTS ebook_enrichment_state_claim_idx",
-		"DROP INDEX CONCURRENTLY IF EXISTS ebook_enrichment_state_priority_claim_idx",
+		"DROP INDEX public.ebook_enrichment_incremental_due_idx",
+		"DROP INDEX public.ebook_enrichment_incremental_priority_idx",
+		"DROP INDEX public.ebook_enrichment_legacy_due_idx",
+		"DROP INDEX public.ebook_enrichment_legacy_priority_idx",
+		"CREATE INDEX CONCURRENTLY IF NOT EXISTS ebook_enrichment_incremental_due_idx",
+		"CREATE INDEX CONCURRENTLY IF NOT EXISTS ebook_enrichment_incremental_priority_idx",
+		"CREATE INDEX CONCURRENTLY IF NOT EXISTS ebook_enrichment_legacy_due_idx",
+		"CREATE INDEX CONCURRENTLY IF NOT EXISTS ebook_enrichment_legacy_priority_idx",
+		"WHERE status IN ('pending', 'running') AND priority >= 0",
+		"WHERE status IN ('pending', 'running') AND priority < 0",
+		"DROP INDEX CONCURRENTLY IF EXISTS ebook_enrichment_incremental_due_idx",
+		"DROP INDEX CONCURRENTLY IF EXISTS ebook_enrichment_incremental_priority_idx",
+		"DROP INDEX CONCURRENTLY IF EXISTS ebook_enrichment_legacy_due_idx",
+		"DROP INDEX CONCURRENTLY IF EXISTS ebook_enrichment_legacy_priority_idx",
 	} {
 		if !strings.Contains(migration, fragment) {
 			t.Fatalf("legacy backlog migration missing %q:\n%s", fragment, body)

--- a/internal/ebooks/enrichment_queue_test.go
+++ b/internal/ebooks/enrichment_queue_test.go
@@ -22,11 +22,13 @@ func TestEnrichmentQueueClaimQueryUsesAtomicLeasedClaims(t *testing.T) {
 		"FOR UPDATE SKIP LOCKED",
 		"status = 'pending' OR (status = 'running' AND lease_until < now())",
 		"next_attempt_at <= now()",
-		"ORDER BY priority DESC, next_attempt_at, updated_at",
+		"priority + FLOOR(EXTRACT(EPOCH FROM (now() - next_attempt_at)) / 3600)::integer",
 		"SET status = 'running'",
 		"lease_until = now() + $2::interval",
+		"claim_token = gen_random_uuid()::text",
 		"attempts = attempts + 1",
-		"RETURNING state.content_id, state.attempts",
+		"RETURNING state.content_id, state.claim_token, state.attempts",
+		"state.protected_fields",
 	} {
 		if !strings.Contains(query, fragment) {
 			t.Fatalf("claim query missing %q:\n%s", fragment, claimEnrichmentJobsQuery)
@@ -34,21 +36,76 @@ func TestEnrichmentQueueClaimQueryUsesAtomicLeasedClaims(t *testing.T) {
 	}
 }
 
-func TestEnrichmentQueueMaterializesUnrefreshedEbooksRegardlessOfPoster(t *testing.T) {
+func TestEnrichmentQueueMaterializesEveryStandaloneEbookAndReactivatesResets(t *testing.T) {
 	query := strings.Join(strings.Fields(materializeEnrichmentJobsQuery), " ")
 
-	if !strings.Contains(query, "SELECT mi.content_id, 'pending', 100, now(), now()") {
-		t.Fatalf("newly discovered ebooks must enter ahead of legacy backfill:\n%s", materializeEnrichmentJobsQuery)
+	for _, fragment := range []string{
+		"CASE WHEN mi.last_refreshed IS NULL THEN 100 ELSE 0 END",
+		"GREATEST(mi.last_refreshed + interval '90 days', now())",
+		"mi.type = 'ebook'",
+		"manga_chapters",
+		"ON CONFLICT (content_id) DO UPDATE SET",
+		"ebook_enrichment_state.status = 'discarded'",
+		"EXCLUDED.completed_at IS NULL AND ebook_enrichment_state.completed_at IS NOT NULL",
+		"protected_fields",
+		"lower(trim(mi.status)) = 'pending'",
+		"ip.kind = 7",
+		"poster_path",
+		"ebook_enrichment_state.protected_fields ||",
+		"WHERE candidate IN ('poster_path', 'backdrop_path', 'logo_path')",
+	} {
+		if !strings.Contains(query, fragment) {
+			t.Fatalf("materialization query missing %q:\n%s", fragment, materializeEnrichmentJobsQuery)
+		}
 	}
-	if !strings.Contains(query, "mi.last_refreshed IS NULL") {
-		t.Fatalf("materialization must use refresh state as its eligibility gate:\n%s", materializeEnrichmentJobsQuery)
-	}
-	if strings.Contains(query, "poster_path") {
-		t.Fatalf("local or embedded covers must not make ebooks ineligible for metadata enrichment:\n%s", materializeEnrichmentJobsQuery)
+	if strings.Contains(query, "AND mi.last_refreshed IS NULL") {
+		t.Fatalf("last_refreshed must schedule work, not exclude refreshed ebooks:\n%s", materializeEnrichmentJobsQuery)
 	}
 }
 
-func TestEnrichmentQueueMigrationSeedsLegacyBacklogAtLowPriority(t *testing.T) {
+func TestEnrichmentQueueCapturesEveryProviderWritablePendingField(t *testing.T) {
+	query := strings.Join(strings.Fields(ebookProtectedFieldsSQL), " ")
+	for _, field := range []string{
+		"title",
+		"year",
+		"overview",
+		"tagline",
+		"content_rating",
+		"runtime",
+		"release_date",
+		"genres",
+		"studios",
+		"authors",
+		"poster_path",
+		"backdrop_path",
+		"logo_path",
+	} {
+		if !strings.Contains(query, "'"+field+"'") {
+			t.Fatalf("protected-field capture missing %q:\n%s", field, ebookProtectedFieldsSQL)
+		}
+	}
+}
+
+func TestEnrichmentQueueEnqueueMakesPendingRowsDueAndDefersRunningRequeue(t *testing.T) {
+	query := strings.Join(strings.Fields(enqueueEnrichmentJobQuery), " ")
+	for _, fragment := range []string{
+		"INSERT INTO ebook_enrichment_state",
+		"FROM media_items mi",
+		"ON CONFLICT (content_id) DO UPDATE SET",
+		"WHEN ebook_enrichment_state.status = 'running' THEN ebook_enrichment_state.next_attempt_at",
+		"ELSE now()",
+		"requeue_requested = ebook_enrichment_state.requeue_requested OR ebook_enrichment_state.status = 'running'",
+	} {
+		if !strings.Contains(query, fragment) {
+			t.Fatalf("enqueue query missing %q:\n%s", fragment, enqueueEnrichmentJobQuery)
+		}
+	}
+	if strings.Contains(query, "lease_until =") || strings.Contains(query, "claim_token =") {
+		t.Fatalf("enqueue must not mutate an active lease:\n%s", enqueueEnrichmentJobQuery)
+	}
+}
+
+func TestEnrichmentQueueMigrationIsCrashSafeAndSeedsAllLegacyEbooks(t *testing.T) {
 	body, err := os.ReadFile("../../migrations/sql/20260719090000_ebook_enrichment_jobs.sql")
 	if err != nil {
 		t.Fatalf("read enrichment queue migration: %v", err)
@@ -56,20 +113,53 @@ func TestEnrichmentQueueMigrationSeedsLegacyBacklogAtLowPriority(t *testing.T) {
 	migration := strings.Join(strings.Fields(string(body)), " ")
 
 	for _, fragment := range []string{
+		"-- +goose NO TRANSACTION",
+		"ADD COLUMN IF NOT EXISTS claim_token text",
+		"ADD COLUMN IF NOT EXISTS requeue_requested boolean NOT NULL DEFAULT false",
+		"ADD COLUMN IF NOT EXISTS protected_fields text[] NOT NULL DEFAULT '{}'::text[]",
 		"INSERT INTO ebook_enrichment_state",
-		"SELECT mi.content_id, 'pending', -100, 0, now(), now()",
+		"CASE WHEN mi.last_refreshed IS NULL THEN -100 ELSE 0 END",
+		"GREATEST(mi.last_refreshed + interval '90 days', now())",
 		"mi.type = 'ebook'",
-		"mi.last_refreshed IS NULL",
 		"NOT EXISTS",
 		"manga_chapters",
 		"ON CONFLICT (content_id) DO NOTHING",
+		"NOT i.indisvalid",
+		"DROP INDEX public.ebook_enrichment_state_claim_idx",
+		"CREATE INDEX CONCURRENTLY IF NOT EXISTS ebook_enrichment_state_claim_idx",
+		"DROP INDEX CONCURRENTLY IF EXISTS ebook_enrichment_state_claim_idx",
 	} {
 		if !strings.Contains(migration, fragment) {
 			t.Fatalf("legacy backlog migration missing %q:\n%s", fragment, body)
 		}
 	}
-	if strings.Contains(migration, "poster_path") {
-		t.Fatalf("legacy backlog must include ebooks with local or embedded covers:\n%s", body)
+	if strings.Contains(migration, "AND mi.last_refreshed IS NULL") {
+		t.Fatalf("migration must seed refreshed ebooks too:\n%s", body)
+	}
+}
+
+func TestEnrichmentQueueMigrationDownPreservesCurrentFailureHistory(t *testing.T) {
+	body, err := os.ReadFile("../../migrations/sql/20260719090000_ebook_enrichment_jobs.sql")
+	if err != nil {
+		t.Fatalf("read enrichment queue migration: %v", err)
+	}
+	parts := strings.SplitN(strings.Join(strings.Fields(string(body)), " "), "-- +goose Down", 2)
+	if len(parts) != 2 {
+		t.Fatal("migration missing Down section")
+	}
+	down := parts[1]
+	for _, fragment := range []string{
+		"SET failures = attempts",
+		"WHERE outcome = 'failed'",
+		"DELETE FROM ebook_enrichment_state WHERE outcome IN ('success', 'no_match')",
+		"IF EXISTS",
+	} {
+		if !strings.Contains(down, fragment) {
+			t.Fatalf("down migration missing %q:\n%s", fragment, body)
+		}
+	}
+	if strings.Contains(down, "WHERE failures = 0") {
+		t.Fatalf("down migration must not erase post-migration failures based on the stale legacy counter:\n%s", body)
 	}
 }
 
@@ -80,11 +170,12 @@ func TestEnrichmentQueueTransitionsKeepDurableRowsAndReleaseLeases(t *testing.T)
 		"status = 'pending'",
 		"lease_until = NULL",
 		"completed_at = now()",
-		"next_attempt_at = now() + $3::interval",
+		"ELSE now() + $3::interval",
 		"outcome = $2",
 		"attempts = 0",
-		"priority = GREATEST(priority, 0)",
-		"AND last_attempt_at = $4",
+		"WHEN requeue_requested THEN 100 ELSE 0 END",
+		"requeue_requested = false",
+		"AND claim_token = $4",
 	} {
 		if !strings.Contains(complete, fragment) {
 			t.Fatalf("complete query missing %q:\n%s", fragment, completeEnrichmentJobQuery)
@@ -101,7 +192,7 @@ func TestEnrichmentQueueTransitionsKeepDurableRowsAndReleaseLeases(t *testing.T)
 		"attempts = GREATEST(attempts - 1, 0)",
 		"WHERE content_id = $1",
 		"AND status = 'running'",
-		"AND last_attempt_at = $2",
+		"AND claim_token = $2",
 	} {
 		if !strings.Contains(release, fragment) {
 			t.Fatalf("release query missing %q:\n%s", fragment, releaseEnrichmentJobQuery)
@@ -109,8 +200,28 @@ func TestEnrichmentQueueTransitionsKeepDurableRowsAndReleaseLeases(t *testing.T)
 	}
 
 	failure := strings.Join(strings.Fields(failEnrichmentJobQuery), " ")
-	if !strings.Contains(failure, "AND last_attempt_at = $5") {
-		t.Fatalf("failure transition must reject stale leases:\n%s", failEnrichmentJobQuery)
+	for _, fragment := range []string{
+		"WHEN requeue_requested THEN now()",
+		"WHEN requeue_requested THEN 100 ELSE priority END",
+		"AND claim_token = $5",
+	} {
+		if !strings.Contains(failure, fragment) {
+			t.Fatalf("failure transition missing %q:\n%s", fragment, failEnrichmentJobQuery)
+		}
+	}
+
+	discard := strings.Join(strings.Fields(discardEnrichmentJobQuery), " ")
+	for _, fragment := range []string{
+		"status = 'discarded'",
+		"lease_until = NULL",
+		"claim_token = NULL",
+		"outcome = 'discarded'",
+		"WHERE content_id = $1",
+		"AND claim_token = $2",
+	} {
+		if !strings.Contains(discard, fragment) {
+			t.Fatalf("discard transition missing %q:\n%s", fragment, discardEnrichmentJobQuery)
+		}
 	}
 }
 

--- a/internal/ebooks/enrichment_queue_test.go
+++ b/internal/ebooks/enrichment_queue_test.go
@@ -317,6 +317,7 @@ func TestEnrichmentQueueEnqueueMakesPendingRowsDueAndDefersRunningRequeue(t *tes
 		"ON CONFLICT (content_id) DO UPDATE SET",
 		"WHEN ebook_enrichment_state.status = 'running' THEN ebook_enrichment_state.next_attempt_at",
 		"ELSE now()",
+		"WHEN ebook_enrichment_state.priority < 0 THEN ebook_enrichment_state.priority",
 		"requeue_requested = ebook_enrichment_state.requeue_requested OR ebook_enrichment_state.status = 'running'",
 	} {
 		if !strings.Contains(query, fragment) {
@@ -325,6 +326,28 @@ func TestEnrichmentQueueEnqueueMakesPendingRowsDueAndDefersRunningRequeue(t *tes
 	}
 	if strings.Contains(query, "lease_until =") || strings.Contains(query, "claim_token =") {
 		t.Fatalf("enqueue must not mutate an active lease:\n%s", enqueueEnrichmentJobQuery)
+	}
+}
+
+func TestEnrichmentQueueKeepsLegacyLaneRowsUntilTerminalOutcome(t *testing.T) {
+	enqueue := strings.Join(strings.Fields(enqueueEnrichmentJobQuery), " ")
+	if !strings.Contains(enqueue, "WHEN ebook_enrichment_state.priority < 0 THEN ebook_enrichment_state.priority") {
+		t.Fatalf("enqueue must keep legacy-lane rows in the legacy lane:\n%s", enqueueEnrichmentJobQuery)
+	}
+	for _, tt := range []struct {
+		name  string
+		query string
+	}{
+		{name: "fail", query: failEnrichmentJobQuery},
+		{name: "release", query: releaseEnrichmentJobQuery},
+	} {
+		query := strings.Join(strings.Fields(tt.query), " ")
+		if strings.Contains(query, "WHEN requeue_requested THEN 100") {
+			t.Fatalf("%s requeue must not promote legacy-lane rows without a terminal outcome:\n%s", tt.name, tt.query)
+		}
+		if !strings.Contains(query, "WHEN requeue_requested AND priority >= 0 THEN 100 ELSE priority END") {
+			t.Fatalf("%s requeue must stay within the row's lane:\n%s", tt.name, tt.query)
+		}
 	}
 }
 
@@ -436,7 +459,7 @@ func TestEnrichmentQueueTransitionsKeepDurableRowsAndReleaseLeases(t *testing.T)
 	failure := strings.Join(strings.Fields(failEnrichmentJobQuery), " ")
 	for _, fragment := range []string{
 		"WHEN requeue_requested THEN now()",
-		"WHEN requeue_requested THEN 100 ELSE priority END",
+		"WHEN requeue_requested AND priority >= 0 THEN 100 ELSE priority END",
 		"AND claim_token = $5",
 	} {
 		if !strings.Contains(failure, fragment) {

--- a/internal/ebooks/enrichment_queue_test.go
+++ b/internal/ebooks/enrichment_queue_test.go
@@ -135,6 +135,50 @@ func TestEnrichmentQueueReadyCountUsesTheSameLiteralLaneAsClaims(t *testing.T) {
 	}
 }
 
+func TestEnrichmentQueueHasReadyUsesBoundedExistenceQueries(t *testing.T) {
+	for _, tt := range []struct {
+		name      string
+		query     string
+		predicate string
+	}{
+		{name: "incremental", query: hasReadyIncrementalEnrichmentJobsQuery, predicate: "priority >= 0"},
+		{name: "legacy", query: hasReadyLegacyEnrichmentJobsQuery, predicate: "priority < 0"},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			query := strings.Join(strings.Fields(tt.query), " ")
+			for _, fragment := range []string{
+				"SELECT EXISTS",
+				"next_attempt_at <= now()",
+				"status = 'pending' OR (status = 'running' AND lease_until < now())",
+				tt.predicate,
+			} {
+				if !strings.Contains(query, fragment) {
+					t.Fatalf("has-ready query missing %q:\n%s", fragment, tt.query)
+				}
+			}
+			if strings.Contains(query, "COUNT(") {
+				t.Fatalf("has-ready query performs an exact count:\n%s", tt.query)
+			}
+		})
+	}
+}
+
+func TestEnrichmentQueueReconcileMissingIsBoundedAndLaneSafe(t *testing.T) {
+	query := strings.Join(strings.Fields(reconcileMissingEnrichmentJobsQuery), " ")
+	for _, fragment := range []string{
+		"WHERE mil.media_folder_id = $1",
+		"mi.type = 'ebook'",
+		"state.content_id IS NULL",
+		"LIMIT $3",
+		"SELECT candidates.content_id, 'pending', $2",
+		"ON CONFLICT (content_id) DO NOTHING",
+	} {
+		if !strings.Contains(query, fragment) {
+			t.Fatalf("reconcile query missing %q:\n%s", fragment, reconcileMissingEnrichmentJobsQuery)
+		}
+	}
+}
+
 func TestEnrichmentScopeValidation(t *testing.T) {
 	for _, scope := range []EnrichmentScope{EnrichmentScopeIncremental, EnrichmentScopeLegacy} {
 		if err := scope.validate(); err != nil {

--- a/internal/ebooks/enrichment_queue_test.go
+++ b/internal/ebooks/enrichment_queue_test.go
@@ -87,8 +87,8 @@ func TestEnrichmentQueueClaimQueryUsesAtomicLeasedClaims(t *testing.T) {
 			}
 		})
 	}
-	if claimCandidateWindow <= 0 || claimCandidateWindow > 256 {
-		t.Fatalf("claim candidate window = %d, want a fixed sane bound", claimCandidateWindow)
+	if claimCandidateWindow != maxEnrichWorkers {
+		t.Fatalf("claim candidate window = %d, want worker ceiling %d", claimCandidateWindow, maxEnrichWorkers)
 	}
 }
 

--- a/internal/ebooks/enrichment_queue_test.go
+++ b/internal/ebooks/enrichment_queue_test.go
@@ -171,6 +171,30 @@ func TestEnrichmentQueueHasReadyUsesBoundedOrderedScalarQueries(t *testing.T) {
 }
 
 func TestEnrichmentQueueReconcileMissingIsBoundedAndLaneSafe(t *testing.T) {
+	recentQuery := strings.Join(strings.Fields(reconcileRecentMissingEnrichmentJobsQuery), " ")
+	for _, fragment := range []string{
+		"recent_memberships AS MATERIALIZED",
+		"WHERE membership.media_folder_id = $1",
+		"ORDER BY membership.first_seen_at DESC, membership.content_id DESC",
+		"LIMIT $3",
+		"FROM recent_memberships candidate",
+		"LEFT JOIN ebook_enrichment_state state ON state.content_id = candidate.content_id",
+		"state.content_id IS NULL",
+		"(SELECT COUNT(*)::integer FROM inserted) AS reconciled",
+		"(SELECT COUNT(*)::integer FROM recent_memberships) AS inspected",
+	} {
+		if !strings.Contains(recentQuery, fragment) {
+			t.Fatalf("recent reconcile query missing %q:\n%s", fragment, reconcileRecentMissingEnrichmentJobsQuery)
+		}
+	}
+	recentLimitAt := strings.Index(recentQuery, "LIMIT $3")
+	recentItemJoinAt := strings.Index(recentQuery, "JOIN media_items mi")
+	recentStateJoinAt := strings.Index(recentQuery, "LEFT JOIN ebook_enrichment_state state")
+	if recentLimitAt < 0 || recentItemJoinAt < 0 || recentStateJoinAt < 0 ||
+		recentLimitAt > recentItemJoinAt || recentLimitAt > recentStateJoinAt {
+		t.Fatalf("recent reconciliation is not bounded before catalog joins:\n%s", reconcileRecentMissingEnrichmentJobsQuery)
+	}
+
 	query := strings.Join(strings.Fields(reconcileMissingEnrichmentJobsQuery), " ")
 	for _, fragment := range []string{
 		"membership_candidates AS MATERIALIZED",

--- a/internal/ebooks/enrichment_queue_test.go
+++ b/internal/ebooks/enrichment_queue_test.go
@@ -36,33 +36,6 @@ func TestEnrichmentQueueClaimQueryUsesAtomicLeasedClaims(t *testing.T) {
 	}
 }
 
-func TestEnrichmentQueueMaterializesEveryStandaloneEbookAndReactivatesResets(t *testing.T) {
-	query := strings.Join(strings.Fields(materializeEnrichmentJobsQuery), " ")
-
-	for _, fragment := range []string{
-		"CASE WHEN mi.last_refreshed IS NULL THEN 100 ELSE 0 END",
-		"GREATEST(mi.last_refreshed + interval '90 days', now())",
-		"mi.type = 'ebook'",
-		"manga_chapters",
-		"ON CONFLICT (content_id) DO UPDATE SET",
-		"ebook_enrichment_state.status = 'discarded'",
-		"EXCLUDED.completed_at IS NULL AND ebook_enrichment_state.completed_at IS NOT NULL",
-		"protected_fields",
-		"lower(trim(mi.status)) = 'pending'",
-		"ip.kind = 7",
-		"poster_path",
-		"ebook_enrichment_state.protected_fields ||",
-		"WHERE candidate IN ('poster_path', 'backdrop_path', 'logo_path')",
-	} {
-		if !strings.Contains(query, fragment) {
-			t.Fatalf("materialization query missing %q:\n%s", fragment, materializeEnrichmentJobsQuery)
-		}
-	}
-	if strings.Contains(query, "AND mi.last_refreshed IS NULL") {
-		t.Fatalf("last_refreshed must schedule work, not exclude refreshed ebooks:\n%s", materializeEnrichmentJobsQuery)
-	}
-}
-
 func TestEnrichmentQueueCapturesEveryProviderWritablePendingField(t *testing.T) {
 	query := strings.Join(strings.Fields(ebookProtectedFieldsSQL), " ")
 	for _, field := range []string{
@@ -82,6 +55,21 @@ func TestEnrichmentQueueCapturesEveryProviderWritablePendingField(t *testing.T) 
 	} {
 		if !strings.Contains(query, "'"+field+"'") {
 			t.Fatalf("protected-field capture missing %q:\n%s", field, ebookProtectedFieldsSQL)
+		}
+	}
+}
+
+func TestEnrichmentQueueChecksExactClaimTokenBeforePersistence(t *testing.T) {
+	query := strings.Join(strings.Fields(checkEnrichmentClaimQuery), " ")
+	for _, fragment := range []string{
+		"SELECT EXISTS",
+		"content_id = $1",
+		"status = 'running'",
+		"claim_token = $2",
+		"lease_until > now()",
+	} {
+		if !strings.Contains(query, fragment) {
+			t.Fatalf("claim ownership query missing %q:\n%s", fragment, checkEnrichmentClaimQuery)
 		}
 	}
 }

--- a/internal/ebooks/enrichment_test.go
+++ b/internal/ebooks/enrichment_test.go
@@ -168,23 +168,153 @@ func TestRunBatchSkipsFailureRecordingOnCancellation(t *testing.T) {
 	}
 }
 
-func TestClaimBatchQueryAppliesFailureBackoffAndCap(t *testing.T) {
-	// Pin the starvation guard: failing items are deprioritized, not retried
-	// at the head of every sweep, and capped items are never re-claimed.
-	if !strings.Contains(claimBatchQuery, "LEFT JOIN ebook_enrichment_state ees ON ees.content_id = mi.content_id") {
-		t.Fatalf("claimBatchQuery must read dedicated ebook enrichment failure state:\n%s", claimBatchQuery)
+func TestEnrichmentQueriesKeepEbookAndAudiobookMetadataSeparate(t *testing.T) {
+	if !strings.Contains(materializeEnrichmentJobsQuery, "mi.type = 'ebook'") {
+		t.Fatalf("materialization query must target ebooks:\n%s", materializeEnrichmentJobsQuery)
 	}
-	if !strings.Contains(claimBatchQuery, "COALESCE(ees.failures, 0) < $2") {
-		t.Fatalf("claimBatchQuery must exclude items at the failure cap:\n%s", claimBatchQuery)
+	if !strings.Contains(materializeEnrichmentJobsQuery, "NOT EXISTS") ||
+		!strings.Contains(materializeEnrichmentJobsQuery, "manga_chapters") ||
+		!strings.Contains(materializeEnrichmentJobsQuery, "chapter_content_id") {
+		t.Fatalf("materialization query must exclude manga chapters:\n%s", materializeEnrichmentJobsQuery)
 	}
-	if !strings.Contains(claimBatchQuery, "ORDER BY COALESCE(ees.failures, 0) ASC, mi.created_at ASC") {
-		t.Fatalf("claimBatchQuery must claim least-failed items first:\n%s", claimBatchQuery)
+	if strings.Contains(loadEnrichmentItemsQuery, "narrator") ||
+		strings.Contains(loadEnrichmentItemsQuery, "asin") {
+		t.Fatalf("ebook load query must not introduce audiobook-only fields:\n%s", loadEnrichmentItemsQuery)
 	}
-	if strings.Contains(claimBatchQuery, "refresh_failures") {
-		t.Fatalf("claimBatchQuery must not read media_items.refresh_failures (owned by the metadata refresh-debt system):\n%s", claimBatchQuery)
+	if !strings.Contains(loadEnrichmentItemsQuery, "ip.kind = 7") {
+		t.Fatalf("ebook load query must load author credits only:\n%s", loadEnrichmentItemsQuery)
 	}
-	if enrichFailureCap < 1 {
-		t.Fatalf("enrichFailureCap = %d, want >= 1", enrichFailureCap)
+}
+
+func TestEnricherRunTransitionsClaimedJobsByOutcome(t *testing.T) {
+	queue := &fakeEnrichmentQueue{
+		jobs: []EnrichmentJob{
+			{ContentID: "success", Attempts: 1},
+			{ContentID: "no-match", Attempts: 1},
+			{ContentID: "skipped", Attempts: 1},
+			{ContentID: "failed", Attempts: 3},
+		},
+	}
+	items := []enrichmentItemRow{
+		{ContentID: "success"},
+		{ContentID: "no-match"},
+		{ContentID: "skipped"},
+		{ContentID: "failed"},
+	}
+	e := &Enricher{
+		queue:     queue,
+		batchSize: len(items),
+		workers:   2,
+		loadClaimedItemsFn: func(context.Context, []EnrichmentJob) ([]enrichmentItemRow, error) {
+			return items, nil
+		},
+		enrichClaimedItemFn: func(_ context.Context, item enrichmentItemRow) (EnrichmentOutcome, error) {
+			switch item.ContentID {
+			case "success":
+				return EnrichmentOutcomeSuccess, nil
+			case "no-match":
+				return EnrichmentOutcomeNoMatch, nil
+			case "skipped":
+				return EnrichmentOutcomeSkipped, nil
+			default:
+				return "", errors.New("provider unavailable")
+			}
+		},
+	}
+
+	enriched, err := e.Run(context.Background())
+	if err != nil {
+		t.Fatalf("Run() error = %v", err)
+	}
+	if enriched != 1 {
+		t.Fatalf("Run() enriched = %d, want 1", enriched)
+	}
+	if queue.materializeCalls != 1 || queue.claimCalls != 1 {
+		t.Fatalf("queue calls: materialize=%d claim=%d, want 1 each", queue.materializeCalls, queue.claimCalls)
+	}
+	if queue.claimLimit != len(items) || queue.leaseDuration <= 0 {
+		t.Fatalf("claim args: limit=%d lease=%s", queue.claimLimit, queue.leaseDuration)
+	}
+	for contentID, want := range map[string]EnrichmentOutcome{
+		"success":  EnrichmentOutcomeSuccess,
+		"no-match": EnrichmentOutcomeNoMatch,
+		"skipped":  EnrichmentOutcomeSkipped,
+	} {
+		if got := queue.completed[contentID]; got != want {
+			t.Fatalf("completed[%q] = %q, want %q", contentID, got, want)
+		}
+	}
+	if got := queue.failed["failed"]; got != EnrichmentErrorTransient {
+		t.Fatalf("failed class = %q, want transient", got)
+	}
+}
+
+func TestEnricherRunReleasesEveryLeaseOnCancellation(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	queue := &fakeEnrichmentQueue{
+		jobs: []EnrichmentJob{
+			{ContentID: "first", Attempts: 1},
+			{ContentID: "second", Attempts: 1},
+		},
+	}
+	items := []enrichmentItemRow{{ContentID: "first"}, {ContentID: "second"}}
+	e := &Enricher{
+		queue:     queue,
+		batchSize: len(items),
+		workers:   1,
+		loadClaimedItemsFn: func(context.Context, []EnrichmentJob) ([]enrichmentItemRow, error) {
+			return items, nil
+		},
+		enrichClaimedItemFn: func(context.Context, enrichmentItemRow) (EnrichmentOutcome, error) {
+			cancel()
+			return "", context.Canceled
+		},
+	}
+
+	_, err := e.Run(ctx)
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("Run() error = %v, want context.Canceled", err)
+	}
+	sort.Strings(queue.released)
+	if got := strings.Join(queue.released, ","); got != "first,second" {
+		t.Fatalf("released leases = %q, want first,second", got)
+	}
+	if queue.releaseSawCanceledContext {
+		t.Fatal("lease release used the canceled run context")
+	}
+	if len(queue.failed) != 0 {
+		t.Fatalf("cancellation recorded item failures: %v", queue.failed)
+	}
+}
+
+func TestEnricherRunReleasesLeaseWhenCompletionLosesContext(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	queue := &fakeEnrichmentQueue{
+		jobs:           []EnrichmentJob{{ContentID: "success", Attempts: 1}},
+		completeCancel: cancel,
+		completeErr:    context.Canceled,
+	}
+	e := &Enricher{
+		queue:     queue,
+		batchSize: 1,
+		workers:   1,
+		loadClaimedItemsFn: func(context.Context, []EnrichmentJob) ([]enrichmentItemRow, error) {
+			return []enrichmentItemRow{{ContentID: "success"}}, nil
+		},
+		enrichClaimedItemFn: func(context.Context, enrichmentItemRow) (EnrichmentOutcome, error) {
+			return EnrichmentOutcomeSuccess, nil
+		},
+	}
+
+	_, err := e.Run(ctx)
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("Run() error = %v, want context.Canceled", err)
+	}
+	if got := strings.Join(queue.released, ","); got != "success" {
+		t.Fatalf("released leases = %q, want success", got)
+	}
+	if queue.releaseSawCanceledContext {
+		t.Fatal("lease release used the canceled transition context")
 	}
 }
 
@@ -588,6 +718,109 @@ func TestBuildEbookMetadataRequestCarriesAccumulatedISBN(t *testing.T) {
 	}
 }
 
+func TestPreservePendingEbookLocalMetadata(t *testing.T) {
+	item := enrichmentItemRow{
+		Status:      "pending",
+		Year:        2021,
+		Overview:    "Embedded description",
+		ReleaseDate: "2021-03-04",
+		Genres:      []string{"Local genre"},
+		Studios:     []string{"Local publisher"},
+		PosterPath:  "local/ebooks/book/poster/original.webp",
+		Author:      "Embedded Author",
+	}
+	result := &metadata.MetadataResult{
+		HasMetadata: true,
+		Year:        2022,
+		Overview:    "Remote description",
+		ReleaseDate: "2022-04-05",
+		Genres:      []string{"Remote genre"},
+		Studios:     []string{"Remote publisher"},
+		PosterPath:  "https://example.test/remote.jpg",
+		Tagline:     "Remote-only field",
+		ProviderIDs: map[string]string{"isbn": "9780306406157"},
+		People: []models.ItemPerson{
+			{Person: models.Person{Name: "Remote Author"}, Kind: models.PersonKindAuthor},
+		},
+	}
+
+	preserveEbookLocalMetadata(item, result)
+
+	if result.Year != 0 || result.Overview != "" || result.ReleaseDate != "" ||
+		len(result.Genres) != 0 || len(result.Studios) != 0 || result.PosterPath != "" ||
+		len(result.People) != 0 {
+		t.Fatalf("remote fields would overwrite scanner metadata: %+v", result)
+	}
+	if result.Tagline != "Remote-only field" {
+		t.Fatalf("empty local field was not enrichable: tagline=%q", result.Tagline)
+	}
+	if result.ProviderIDs["isbn"] != "9780306406157" {
+		t.Fatalf("provider identity was discarded: %v", result.ProviderIDs)
+	}
+}
+
+func TestPreservePendingEbookLocalMetadataAllowsRefreshReplacement(t *testing.T) {
+	result := &metadata.MetadataResult{
+		HasMetadata: true,
+		Year:        2022,
+		Overview:    "Corrected remote description",
+	}
+
+	preserveEbookLocalMetadata(enrichmentItemRow{
+		Status:   "matched",
+		Year:     2021,
+		Overview: "Old remote description",
+	}, result)
+
+	if result.Year != 2022 || result.Overview != "Corrected remote description" {
+		t.Fatalf("controlled refresh fields were suppressed: %+v", result)
+	}
+}
+
+func TestPreserveEbookLocalPosterDuringControlledRefresh(t *testing.T) {
+	result := &metadata.MetadataResult{
+		HasMetadata:     true,
+		PosterPath:      "https://example.test/replacement.jpg",
+		PosterThumbhash: "remote-thumb",
+		Overview:        "Corrected remote description",
+	}
+
+	preserveEbookLocalMetadata(enrichmentItemRow{
+		Status:     "matched",
+		PosterPath: "local/ebooks/book/poster/original.webp",
+	}, result)
+
+	if result.PosterPath != "" || result.PosterThumbhash != "" {
+		t.Fatalf("controlled refresh would replace local poster: %+v", result)
+	}
+	if result.Overview != "Corrected remote description" {
+		t.Fatalf("non-artwork refresh field was suppressed: %+v", result)
+	}
+}
+
+func TestPreserveEbookLocalPosterAllowsProviderOwnedReplacement(t *testing.T) {
+	for _, current := range []string{
+		"",
+		"https://provider.test/old.jpg",
+		"ebook-metadata/ebooks/book/poster/original.webp",
+	} {
+		result := &metadata.MetadataResult{
+			HasMetadata:     true,
+			PosterPath:      "https://provider.test/new.jpg",
+			PosterThumbhash: "new-thumb",
+		}
+
+		preserveEbookLocalMetadata(enrichmentItemRow{
+			Status:     "matched",
+			PosterPath: current,
+		}, result)
+
+		if result.PosterPath == "" || result.PosterThumbhash == "" {
+			t.Fatalf("provider-owned poster %q was not replaceable: %+v", current, result)
+		}
+	}
+}
+
 type fakeEbookMetadataProvider struct {
 	slug      string
 	searchErr error
@@ -627,6 +860,68 @@ func (f *fakeEbookImageCacher) CacheImage(_ context.Context, req metadata.CacheI
 		Thumbhash: "thumb",
 		Ext:       ".webp",
 	}, nil
+}
+
+type fakeEnrichmentQueue struct {
+	mu                        sync.Mutex
+	jobs                      []EnrichmentJob
+	materializeCalls          int
+	claimCalls                int
+	claimLimit                int
+	leaseDuration             time.Duration
+	completed                 map[string]EnrichmentOutcome
+	failed                    map[string]EnrichmentErrorClass
+	released                  []string
+	releaseSawCanceledContext bool
+	completeCancel            context.CancelFunc
+	completeErr               error
+}
+
+func (f *fakeEnrichmentQueue) MaterializeCandidates(context.Context) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.materializeCalls++
+	return nil
+}
+
+func (f *fakeEnrichmentQueue) ClaimBatch(_ context.Context, limit int, leaseDuration time.Duration) ([]EnrichmentJob, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.claimCalls++
+	f.claimLimit = limit
+	f.leaseDuration = leaseDuration
+	return append([]EnrichmentJob(nil), f.jobs...), nil
+}
+
+func (f *fakeEnrichmentQueue) Complete(_ context.Context, contentID string, outcome EnrichmentOutcome, _ time.Duration) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	if f.completed == nil {
+		f.completed = make(map[string]EnrichmentOutcome)
+	}
+	f.completed[contentID] = outcome
+	if f.completeCancel != nil {
+		f.completeCancel()
+	}
+	return f.completeErr
+}
+
+func (f *fakeEnrichmentQueue) Fail(_ context.Context, contentID string, errorClass EnrichmentErrorClass, _ string, _ time.Duration) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	if f.failed == nil {
+		f.failed = make(map[string]EnrichmentErrorClass)
+	}
+	f.failed[contentID] = errorClass
+	return nil
+}
+
+func (f *fakeEnrichmentQueue) Release(ctx context.Context, contentID string) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.releaseSawCanceledContext = f.releaseSawCanceledContext || ctx.Err() != nil
+	f.released = append(f.released, contentID)
+	return nil
 }
 
 func TestCleanEbookSearchTitle(t *testing.T) {

--- a/internal/ebooks/enrichment_test.go
+++ b/internal/ebooks/enrichment_test.go
@@ -13,6 +13,10 @@ import (
 
 	"github.com/Silo-Server/silo-server/internal/metadata"
 	"github.com/Silo-Server/silo-server/internal/models"
+	"google.golang.org/genproto/googleapis/rpc/errdetails"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+	"google.golang.org/protobuf/types/known/durationpb"
 )
 
 func TestEbookContentType(t *testing.T) {
@@ -257,6 +261,44 @@ func TestEnricherRunTransitionsClaimedJobsByOutcome(t *testing.T) {
 		if job.Token != contentID+"-token" {
 			t.Fatalf("transition for %q used token %q", contentID, job.Token)
 		}
+	}
+}
+
+func TestEnricherRunCountsRateLimitedFailureAsDeferred(t *testing.T) {
+	const retryAfter = 45 * time.Minute
+	limited, err := status.New(codes.ResourceExhausted, "provider quota exhausted").WithDetails(
+		&errdetails.RetryInfo{RetryDelay: durationpb.New(retryAfter)},
+	)
+	if err != nil {
+		t.Fatalf("attach retry info: %v", err)
+	}
+	queue := &fakeEnrichmentQueue{
+		jobs: []EnrichmentJob{{ContentID: "rate-limited", Token: "token", Attempts: 1}},
+	}
+	e := &Enricher{
+		queue:     queue,
+		batchSize: 1,
+		workers:   1,
+		loadClaimedItemsFn: func(context.Context, []EnrichmentJob) ([]enrichmentItemRow, error) {
+			return []enrichmentItemRow{{ContentID: "rate-limited"}}, nil
+		},
+		enrichClaimedItemFn: func(context.Context, enrichmentItemRow) (EnrichmentOutcome, error) {
+			return "", limited.Err()
+		},
+	}
+
+	result, runErr := e.Run(context.Background(), EnrichmentScopeIncremental)
+	if runErr != nil {
+		t.Fatalf("Run() error = %v", runErr)
+	}
+	if result.Failed != 0 || result.Deferred != 1 {
+		t.Fatalf("Run() result = %+v, want one deferred and no failures", result)
+	}
+	if got := queue.failed["rate-limited"]; got != EnrichmentErrorRateLimited {
+		t.Fatalf("failure class = %q, want rate_limited", got)
+	}
+	if got := queue.retryAfter["rate-limited"]; got != retryAfter {
+		t.Fatalf("retry after = %s, want %s", got, retryAfter)
 	}
 }
 
@@ -1089,6 +1131,7 @@ type fakeEnrichmentQueue struct {
 	remaining                 int
 	completed                 map[string]EnrichmentOutcome
 	failed                    map[string]EnrichmentErrorClass
+	retryAfter                map[string]time.Duration
 	released                  []string
 	discarded                 []string
 	transitionedJobs          map[string]EnrichmentJob
@@ -1130,13 +1173,17 @@ func (f *fakeEnrichmentQueue) Complete(_ context.Context, job EnrichmentJob, out
 	return f.completeErr
 }
 
-func (f *fakeEnrichmentQueue) Fail(_ context.Context, job EnrichmentJob, errorClass EnrichmentErrorClass, _ string, _ time.Duration) error {
+func (f *fakeEnrichmentQueue) Fail(_ context.Context, job EnrichmentJob, errorClass EnrichmentErrorClass, _ string, retryAfter time.Duration) error {
 	f.mu.Lock()
 	defer f.mu.Unlock()
 	if f.failed == nil {
 		f.failed = make(map[string]EnrichmentErrorClass)
 	}
+	if f.retryAfter == nil {
+		f.retryAfter = make(map[string]time.Duration)
+	}
 	f.failed[job.ContentID] = errorClass
+	f.retryAfter[job.ContentID] = retryAfter
 	f.recordTransition(job)
 	return f.failErr
 }

--- a/internal/ebooks/enrichment_test.go
+++ b/internal/ebooks/enrichment_test.go
@@ -69,9 +69,14 @@ func TestEbookEnrichWorkersFromEnv(t *testing.T) {
 		t.Fatalf("ebookEnrichWorkers() with zero = %d, want default %d", got, defaultEnrichWorkers)
 	}
 
-	t.Setenv("SILO_EBOOK_ENRICH_WORKERS", "999")
-	if got := ebookEnrichWorkers(); got != defaultEnrichBatchSize {
-		t.Fatalf("ebookEnrichWorkers() capped = %d, want %d", got, defaultEnrichBatchSize)
+	t.Setenv("SILO_EBOOK_ENRICH_WORKERS", "5000")
+	if got := ebookEnrichWorkers(); got != 5000 {
+		t.Fatalf("ebookEnrichWorkers() = %d, want 5000", got)
+	}
+
+	t.Setenv("SILO_EBOOK_ENRICH_WORKERS", "9999")
+	if got := ebookEnrichWorkers(); got != maxEnrichWorkers {
+		t.Fatalf("ebookEnrichWorkers() capped = %d, want %d", got, maxEnrichWorkers)
 	}
 }
 

--- a/internal/ebooks/enrichment_test.go
+++ b/internal/ebooks/enrichment_test.go
@@ -1129,6 +1129,9 @@ type fakeEnrichmentQueue struct {
 	leaseDuration             time.Duration
 	claimScope                EnrichmentScope
 	remaining                 int
+	hasReady                  bool
+	readyCountCalls           int
+	hasReadyCalls             int
 	completed                 map[string]EnrichmentOutcome
 	failed                    map[string]EnrichmentErrorClass
 	retryAfter                map[string]time.Duration
@@ -1156,7 +1159,15 @@ func (f *fakeEnrichmentQueue) ClaimBatch(_ context.Context, scope EnrichmentScop
 func (f *fakeEnrichmentQueue) ReadyCount(_ context.Context, _ EnrichmentScope) (int, error) {
 	f.mu.Lock()
 	defer f.mu.Unlock()
+	f.readyCountCalls++
 	return f.remaining, nil
+}
+
+func (f *fakeEnrichmentQueue) HasReady(_ context.Context, _ EnrichmentScope) (bool, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.hasReadyCalls++
+	return f.hasReady, nil
 }
 
 func (f *fakeEnrichmentQueue) Complete(_ context.Context, job EnrichmentJob, outcome EnrichmentOutcome, _ time.Duration) error {
@@ -1211,6 +1222,31 @@ func (f *fakeEnrichmentQueue) CheckClaim(_ context.Context, job EnrichmentJob) e
 	f.claimCheckCalls++
 	f.recordTransition(job)
 	return f.claimCheckErr
+}
+
+func TestEnricherRunLimitedEnforcesClaimLimitBelowWorkerCount(t *testing.T) {
+	queue := &fakeEnrichmentQueue{}
+	e := &Enricher{
+		queue:     queue,
+		batchSize: 50,
+		workers:   50,
+		enrichClaimedItemFn: func(context.Context, enrichmentItemRow) (EnrichmentOutcome, error) {
+			return EnrichmentOutcomeSuccess, nil
+		},
+	}
+
+	if _, err := e.RunLimited(context.Background(), EnrichmentScopeLegacy, 3); err != nil {
+		t.Fatalf("RunLimited() error = %v", err)
+	}
+	if queue.claimLimit != 3 {
+		t.Fatalf("claim limit = %d, want hard caller cap 3", queue.claimLimit)
+	}
+	if queue.readyCountCalls != 0 {
+		t.Fatalf("per-batch exact ready counts = %d, want 0", queue.readyCountCalls)
+	}
+	if queue.hasReadyCalls != 1 {
+		t.Fatalf("bounded has-ready checks = %d, want 1", queue.hasReadyCalls)
+	}
 }
 
 func (f *fakeEnrichmentQueue) recordTransition(job EnrichmentJob) {

--- a/internal/ebooks/enrichment_test.go
+++ b/internal/ebooks/enrichment_test.go
@@ -402,7 +402,8 @@ func TestEnricherRunDiscardsClaimedRowsThatAreNoLongerEligible(t *testing.T) {
 		},
 	}
 
-	if _, err := e.Run(context.Background(), EnrichmentScopeIncremental); err != nil {
+	result, err := e.Run(context.Background(), EnrichmentScopeIncremental)
+	if err != nil {
 		t.Fatalf("Run() error = %v", err)
 	}
 	if got := strings.Join(queue.discarded, ","); got != "became-manga" {
@@ -413,6 +414,43 @@ func TestEnricherRunDiscardsClaimedRowsThatAreNoLongerEligible(t *testing.T) {
 	}
 	if len(queue.released) != 0 {
 		t.Fatalf("ineligible rows were released back into immediate churn: %v", queue.released)
+	}
+	if result.Discarded != 1 {
+		t.Fatalf("Discarded = %d, want 1", result.Discarded)
+	}
+	if result.Deferred != 1 {
+		t.Fatalf("Deferred = %d, want 1 (the skipped completion only); a discarded row is terminal, not deferred for retry", result.Deferred)
+	}
+}
+
+func TestEnricherRunCountsUpstreamCancellationAsTransientFailure(t *testing.T) {
+	queue := &fakeEnrichmentQueue{
+		jobs: []EnrichmentJob{{ContentID: "cancel-happy", Token: "cancel-token", Attempts: 1}},
+	}
+	e := &Enricher{
+		queue:     queue,
+		batchSize: 1,
+		workers:   1,
+		loadClaimedItemsFn: func(context.Context, []EnrichmentJob) ([]enrichmentItemRow, error) {
+			return []enrichmentItemRow{{ContentID: "cancel-happy"}}, nil
+		},
+		enrichClaimedItemFn: func(context.Context, enrichmentItemRow) (EnrichmentOutcome, error) {
+			return "", context.Canceled
+		},
+	}
+
+	result, err := e.Run(context.Background(), EnrichmentScopeIncremental)
+	if err != nil {
+		t.Fatalf("Run() error = %v", err)
+	}
+	if got := queue.failed["cancel-happy"]; got != EnrichmentErrorTransient {
+		t.Fatalf("failure class = %q, want transient", got)
+	}
+	if result.Failed != 1 {
+		t.Fatalf("Failed = %d, want 1; an uncounted claim blinds the no-progress circuit breaker", result.Failed)
+	}
+	if len(queue.released) != 0 {
+		t.Fatalf("provider-canceled work was released into immediate reclaim churn: %v", queue.released)
 	}
 }
 

--- a/internal/ebooks/enrichment_test.go
+++ b/internal/ebooks/enrichment_test.go
@@ -227,12 +227,13 @@ func TestEnricherRunTransitionsClaimedJobsByOutcome(t *testing.T) {
 		},
 	}
 
-	enriched, err := e.Run(context.Background())
+	result, err := e.Run(context.Background(), EnrichmentScopeIncremental)
 	if err != nil {
 		t.Fatalf("Run() error = %v", err)
 	}
-	if enriched != 1 {
-		t.Fatalf("Run() enriched = %d, want 1", enriched)
+	want := EnrichmentRunResult{Claimed: 4, Enriched: 1, NoMatch: 1, Failed: 1, Deferred: 1}
+	if result != want {
+		t.Fatalf("Run() result = %+v, want %+v", result, want)
 	}
 	if queue.claimCalls != 1 {
 		t.Fatalf("claim calls = %d, want 1", queue.claimCalls)
@@ -281,7 +282,7 @@ func TestEnricherRunReleasesEveryLeaseOnCancellation(t *testing.T) {
 		},
 	}
 
-	_, err := e.Run(ctx)
+	_, err := e.Run(ctx, EnrichmentScopeIncremental)
 	if !errors.Is(err, context.Canceled) {
 		t.Fatalf("Run() error = %v, want context.Canceled", err)
 	}
@@ -316,7 +317,7 @@ func TestEnricherRunReleasesLeaseWhenCompletionLosesContext(t *testing.T) {
 		},
 	}
 
-	_, err := e.Run(ctx)
+	_, err := e.Run(ctx, EnrichmentScopeIncremental)
 	if !errors.Is(err, context.Canceled) {
 		t.Fatalf("Run() error = %v, want context.Canceled", err)
 	}
@@ -347,7 +348,7 @@ func TestEnricherRunDiscardsClaimedRowsThatAreNoLongerEligible(t *testing.T) {
 		},
 	}
 
-	if _, err := e.Run(context.Background()); err != nil {
+	if _, err := e.Run(context.Background(), EnrichmentScopeIncremental); err != nil {
 		t.Fatalf("Run() error = %v", err)
 	}
 	if got := strings.Join(queue.discarded, ","); got != "became-manga" {
@@ -380,7 +381,7 @@ func TestEnricherRunBoundsEachItemBelowTheLease(t *testing.T) {
 	}
 
 	started := time.Now()
-	if _, err := e.Run(context.Background()); err != nil {
+	if _, err := e.Run(context.Background(), EnrichmentScopeIncremental); err != nil {
 		t.Fatalf("Run() error = %v", err)
 	}
 	if elapsed := time.Since(started); elapsed > time.Second {
@@ -408,7 +409,7 @@ func TestEnricherRunClaimsAtMostOneJobPerWorker(t *testing.T) {
 		},
 	}
 
-	if _, err := e.Run(context.Background()); err != nil {
+	if _, err := e.Run(context.Background(), EnrichmentScopeIncremental); err != nil {
 		t.Fatalf("Run() error = %v", err)
 	}
 	if queue.claimLimit != 4 {
@@ -437,7 +438,7 @@ func TestEnricherRunInjectsExactClaimOwnershipCheck(t *testing.T) {
 		},
 	}
 
-	if _, err := e.Run(context.Background()); err != nil {
+	if _, err := e.Run(context.Background(), EnrichmentScopeIncremental); err != nil {
 		t.Fatalf("Run() error = %v", err)
 	}
 	if queue.claimCheckCalls != 1 {
@@ -1084,6 +1085,8 @@ type fakeEnrichmentQueue struct {
 	claimCalls                int
 	claimLimit                int
 	leaseDuration             time.Duration
+	claimScope                EnrichmentScope
+	remaining                 int
 	completed                 map[string]EnrichmentOutcome
 	failed                    map[string]EnrichmentErrorClass
 	released                  []string
@@ -1097,13 +1100,20 @@ type fakeEnrichmentQueue struct {
 	completeErr               error
 }
 
-func (f *fakeEnrichmentQueue) ClaimBatch(_ context.Context, limit int, leaseDuration time.Duration) ([]EnrichmentJob, error) {
+func (f *fakeEnrichmentQueue) ClaimBatch(_ context.Context, scope EnrichmentScope, limit int, leaseDuration time.Duration) ([]EnrichmentJob, error) {
 	f.mu.Lock()
 	defer f.mu.Unlock()
 	f.claimCalls++
 	f.claimLimit = limit
 	f.leaseDuration = leaseDuration
+	f.claimScope = scope
 	return append([]EnrichmentJob(nil), f.jobs...), nil
+}
+
+func (f *fakeEnrichmentQueue) ReadyCount(_ context.Context, _ EnrichmentScope) (int, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return f.remaining, nil
 }
 
 func (f *fakeEnrichmentQueue) Complete(_ context.Context, job EnrichmentJob, outcome EnrichmentOutcome, _ time.Duration) error {

--- a/internal/ebooks/enrichment_test.go
+++ b/internal/ebooks/enrichment_test.go
@@ -184,15 +184,20 @@ func TestEnrichmentQueriesKeepEbookAndAudiobookMetadataSeparate(t *testing.T) {
 	if !strings.Contains(loadEnrichmentItemsQuery, "ip.kind = 7") {
 		t.Fatalf("ebook load query must load author credits only:\n%s", loadEnrichmentItemsQuery)
 	}
+	for _, field := range []string{"locked_fields", "backdrop_path", "logo_path"} {
+		if !strings.Contains(loadEnrichmentItemsQuery, field) {
+			t.Fatalf("ebook load query must load %s for protection decisions:\n%s", field, loadEnrichmentItemsQuery)
+		}
+	}
 }
 
 func TestEnricherRunTransitionsClaimedJobsByOutcome(t *testing.T) {
 	queue := &fakeEnrichmentQueue{
 		jobs: []EnrichmentJob{
-			{ContentID: "success", Attempts: 1},
-			{ContentID: "no-match", Attempts: 1},
-			{ContentID: "skipped", Attempts: 1},
-			{ContentID: "failed", Attempts: 3},
+			{ContentID: "success", Token: "success-token", Attempts: 1},
+			{ContentID: "no-match", Token: "no-match-token", Attempts: 1},
+			{ContentID: "skipped", Token: "skipped-token", Attempts: 1},
+			{ContentID: "failed", Token: "failed-token", Attempts: 3},
 		},
 	}
 	items := []enrichmentItemRow{
@@ -247,14 +252,19 @@ func TestEnricherRunTransitionsClaimedJobsByOutcome(t *testing.T) {
 	if got := queue.failed["failed"]; got != EnrichmentErrorTransient {
 		t.Fatalf("failed class = %q, want transient", got)
 	}
+	for contentID, job := range queue.transitionedJobs {
+		if job.Token != contentID+"-token" {
+			t.Fatalf("transition for %q used token %q", contentID, job.Token)
+		}
+	}
 }
 
 func TestEnricherRunReleasesEveryLeaseOnCancellation(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	queue := &fakeEnrichmentQueue{
 		jobs: []EnrichmentJob{
-			{ContentID: "first", Attempts: 1},
-			{ContentID: "second", Attempts: 1},
+			{ContentID: "first", Token: "first-token", Attempts: 1},
+			{ContentID: "second", Token: "second-token", Attempts: 1},
 		},
 	}
 	items := []enrichmentItemRow{{ContentID: "first"}, {ContentID: "second"}}
@@ -290,7 +300,7 @@ func TestEnricherRunReleasesEveryLeaseOnCancellation(t *testing.T) {
 func TestEnricherRunReleasesLeaseWhenCompletionLosesContext(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	queue := &fakeEnrichmentQueue{
-		jobs:           []EnrichmentJob{{ContentID: "success", Attempts: 1}},
+		jobs:           []EnrichmentJob{{ContentID: "success", Token: "success-token", Attempts: 1}},
 		completeCancel: cancel,
 		completeErr:    context.Canceled,
 	}
@@ -315,6 +325,72 @@ func TestEnricherRunReleasesLeaseWhenCompletionLosesContext(t *testing.T) {
 	}
 	if queue.releaseSawCanceledContext {
 		t.Fatal("lease release used the canceled transition context")
+	}
+}
+
+func TestEnricherRunDiscardsClaimedRowsThatAreNoLongerEligible(t *testing.T) {
+	queue := &fakeEnrichmentQueue{
+		jobs: []EnrichmentJob{
+			{ContentID: "became-manga", Token: "manga-token", Attempts: 1},
+			{ContentID: "folderless", Token: "folderless-token", Attempts: 1},
+		},
+	}
+	e := &Enricher{
+		queue:     queue,
+		batchSize: 2,
+		workers:   1,
+		loadClaimedItemsFn: func(context.Context, []EnrichmentJob) ([]enrichmentItemRow, error) {
+			return []enrichmentItemRow{{ContentID: "folderless", FolderID: 0}}, nil
+		},
+		enrichClaimedItemFn: func(context.Context, enrichmentItemRow) (EnrichmentOutcome, error) {
+			return EnrichmentOutcomeSkipped, nil
+		},
+	}
+
+	if _, err := e.Run(context.Background()); err != nil {
+		t.Fatalf("Run() error = %v", err)
+	}
+	if got := strings.Join(queue.discarded, ","); got != "became-manga" {
+		t.Fatalf("discarded = %q, want became-manga", got)
+	}
+	if got := queue.completed["folderless"]; got != EnrichmentOutcomeSkipped {
+		t.Fatalf("folderless outcome = %q, want skipped", got)
+	}
+	if len(queue.released) != 0 {
+		t.Fatalf("ineligible rows were released back into immediate churn: %v", queue.released)
+	}
+}
+
+func TestEnricherRunBoundsEachItemBelowTheLease(t *testing.T) {
+	queue := &fakeEnrichmentQueue{
+		jobs: []EnrichmentJob{{ContentID: "slow", Token: "slow-token", Attempts: 1}},
+	}
+	e := &Enricher{
+		queue:       queue,
+		batchSize:   1,
+		workers:     1,
+		itemTimeout: 20 * time.Millisecond,
+		loadClaimedItemsFn: func(context.Context, []EnrichmentJob) ([]enrichmentItemRow, error) {
+			return []enrichmentItemRow{{ContentID: "slow"}}, nil
+		},
+		enrichClaimedItemFn: func(ctx context.Context, _ enrichmentItemRow) (EnrichmentOutcome, error) {
+			<-ctx.Done()
+			return "", ctx.Err()
+		},
+	}
+
+	started := time.Now()
+	if _, err := e.Run(context.Background()); err != nil {
+		t.Fatalf("Run() error = %v", err)
+	}
+	if elapsed := time.Since(started); elapsed > time.Second {
+		t.Fatalf("per-item timeout took %s", elapsed)
+	}
+	if got := strings.Join(queue.released, ","); got != "slow" {
+		t.Fatalf("released = %q, want slow", got)
+	}
+	if defaultEnrichmentItemTimeout >= defaultEnrichmentLease/2 {
+		t.Fatalf("default item timeout %s is not materially shorter than lease %s", defaultEnrichmentItemTimeout, defaultEnrichmentLease)
 	}
 }
 
@@ -718,16 +794,12 @@ func TestBuildEbookMetadataRequestCarriesAccumulatedISBN(t *testing.T) {
 	}
 }
 
-func TestPreservePendingEbookLocalMetadata(t *testing.T) {
+func TestPreserveDurableEbookLocalMetadataAcrossRefreshes(t *testing.T) {
 	item := enrichmentItemRow{
-		Status:      "pending",
-		Year:        2021,
-		Overview:    "Embedded description",
-		ReleaseDate: "2021-03-04",
-		Genres:      []string{"Local genre"},
-		Studios:     []string{"Local publisher"},
-		PosterPath:  "local/ebooks/book/poster/original.webp",
-		Author:      "Embedded Author",
+		Status: "matched",
+		ProtectedFields: []string{
+			"year", "overview", "release_date", "genres", "studios", "poster_path", "authors",
+		},
 	}
 	result := &metadata.MetadataResult{
 		HasMetadata: true,
@@ -759,7 +831,7 @@ func TestPreservePendingEbookLocalMetadata(t *testing.T) {
 	}
 }
 
-func TestPreservePendingEbookLocalMetadataAllowsRefreshReplacement(t *testing.T) {
+func TestPreserveEbookMetadataAllowsProviderOwnedRefreshReplacement(t *testing.T) {
 	result := &metadata.MetadataResult{
 		HasMetadata: true,
 		Year:        2022,
@@ -767,9 +839,7 @@ func TestPreservePendingEbookLocalMetadataAllowsRefreshReplacement(t *testing.T)
 	}
 
 	preserveEbookLocalMetadata(enrichmentItemRow{
-		Status:   "matched",
-		Year:     2021,
-		Overview: "Old remote description",
+		Status: "matched",
 	}, result)
 
 	if result.Year != 2022 || result.Overview != "Corrected remote description" {
@@ -782,19 +852,64 @@ func TestPreserveEbookLocalPosterDuringControlledRefresh(t *testing.T) {
 		HasMetadata:     true,
 		PosterPath:      "https://example.test/replacement.jpg",
 		PosterThumbhash: "remote-thumb",
+		BackdropPath:    "https://example.test/backdrop.jpg",
+		LogoPath:        "https://example.test/logo.png",
 		Overview:        "Corrected remote description",
 	}
 
 	preserveEbookLocalMetadata(enrichmentItemRow{
-		Status:     "matched",
-		PosterPath: "local/ebooks/book/poster/original.webp",
+		Status:       "matched",
+		PosterPath:   "local/ebooks/book/poster/original.webp",
+		BackdropPath: "/books/book/backdrop.jpg",
+		LogoPath:     "embedded/book/logo.png",
 	}, result)
 
-	if result.PosterPath != "" || result.PosterThumbhash != "" {
+	if result.PosterPath != "" || result.PosterThumbhash != "" ||
+		result.BackdropPath != "" || result.LogoPath != "" {
 		t.Fatalf("controlled refresh would replace local poster: %+v", result)
 	}
 	if result.Overview != "Corrected remote description" {
 		t.Fatalf("non-artwork refresh field was suppressed: %+v", result)
+	}
+}
+
+func TestPreserveEbookMetadataHonorsGenericLockedFields(t *testing.T) {
+	result := &metadata.MetadataResult{
+		HasMetadata:   true,
+		Title:         "Remote title",
+		Overview:      "Remote overview",
+		Year:          2024,
+		ReleaseDate:   "2024-01-02",
+		Runtime:       500,
+		Genres:        []string{"Remote genre"},
+		Studios:       []string{"Remote publisher"},
+		ContentRating: "Teen",
+		PosterPath:    "https://example.test/poster.jpg",
+		BackdropPath:  "https://example.test/backdrop.jpg",
+		LogoPath:      "https://example.test/logo.png",
+		People: []models.ItemPerson{
+			{Person: models.Person{Name: "Remote Author"}, Kind: models.PersonKindAuthor},
+		},
+	}
+	item := enrichmentItemRow{LockedFields: []int{
+		int(metadata.FieldName),
+		int(metadata.FieldOverview),
+		int(metadata.FieldGenres),
+		int(metadata.FieldStudios),
+		int(metadata.FieldCrew),
+		int(metadata.FieldRuntime),
+		int(metadata.FieldContentRating),
+		int(metadata.FieldImages),
+		int(metadata.FieldReleaseDates),
+	}}
+
+	preserveEbookLocalMetadata(item, result)
+
+	if result.Title != "" || result.Overview != "" || result.Year != 0 || result.ReleaseDate != "" ||
+		result.Runtime != 0 || len(result.Genres) != 0 || len(result.Studios) != 0 ||
+		result.ContentRating != "" || result.PosterPath != "" || result.BackdropPath != "" ||
+		result.LogoPath != "" || len(result.People) != 0 {
+		t.Fatalf("locked metadata was not protected: %+v", result)
 	}
 }
 
@@ -872,6 +987,8 @@ type fakeEnrichmentQueue struct {
 	completed                 map[string]EnrichmentOutcome
 	failed                    map[string]EnrichmentErrorClass
 	released                  []string
+	discarded                 []string
+	transitionedJobs          map[string]EnrichmentJob
 	releaseSawCanceledContext bool
 	completeCancel            context.CancelFunc
 	completeErr               error
@@ -893,35 +1010,53 @@ func (f *fakeEnrichmentQueue) ClaimBatch(_ context.Context, limit int, leaseDura
 	return append([]EnrichmentJob(nil), f.jobs...), nil
 }
 
-func (f *fakeEnrichmentQueue) Complete(_ context.Context, contentID string, outcome EnrichmentOutcome, _ time.Duration) error {
+func (f *fakeEnrichmentQueue) Complete(_ context.Context, job EnrichmentJob, outcome EnrichmentOutcome, _ time.Duration) error {
 	f.mu.Lock()
 	defer f.mu.Unlock()
 	if f.completed == nil {
 		f.completed = make(map[string]EnrichmentOutcome)
 	}
-	f.completed[contentID] = outcome
+	f.completed[job.ContentID] = outcome
+	f.recordTransition(job)
 	if f.completeCancel != nil {
 		f.completeCancel()
 	}
 	return f.completeErr
 }
 
-func (f *fakeEnrichmentQueue) Fail(_ context.Context, contentID string, errorClass EnrichmentErrorClass, _ string, _ time.Duration) error {
+func (f *fakeEnrichmentQueue) Fail(_ context.Context, job EnrichmentJob, errorClass EnrichmentErrorClass, _ string, _ time.Duration) error {
 	f.mu.Lock()
 	defer f.mu.Unlock()
 	if f.failed == nil {
 		f.failed = make(map[string]EnrichmentErrorClass)
 	}
-	f.failed[contentID] = errorClass
+	f.failed[job.ContentID] = errorClass
+	f.recordTransition(job)
 	return nil
 }
 
-func (f *fakeEnrichmentQueue) Release(ctx context.Context, contentID string) error {
+func (f *fakeEnrichmentQueue) Release(ctx context.Context, job EnrichmentJob) error {
 	f.mu.Lock()
 	defer f.mu.Unlock()
 	f.releaseSawCanceledContext = f.releaseSawCanceledContext || ctx.Err() != nil
-	f.released = append(f.released, contentID)
+	f.released = append(f.released, job.ContentID)
+	f.recordTransition(job)
 	return nil
+}
+
+func (f *fakeEnrichmentQueue) Discard(_ context.Context, job EnrichmentJob) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.discarded = append(f.discarded, job.ContentID)
+	f.recordTransition(job)
+	return nil
+}
+
+func (f *fakeEnrichmentQueue) recordTransition(job EnrichmentJob) {
+	if f.transitionedJobs == nil {
+		f.transitionedJobs = make(map[string]EnrichmentJob)
+	}
+	f.transitionedJobs[job.ContentID] = job
 }
 
 func TestCleanEbookSearchTitle(t *testing.T) {

--- a/internal/ebooks/enrichment_test.go
+++ b/internal/ebooks/enrichment_test.go
@@ -169,13 +169,13 @@ func TestRunBatchSkipsFailureRecordingOnCancellation(t *testing.T) {
 }
 
 func TestEnrichmentQueriesKeepEbookAndAudiobookMetadataSeparate(t *testing.T) {
-	if !strings.Contains(materializeEnrichmentJobsQuery, "mi.type = 'ebook'") {
-		t.Fatalf("materialization query must target ebooks:\n%s", materializeEnrichmentJobsQuery)
+	if !strings.Contains(enqueueEnrichmentJobQuery, "mi.type = 'ebook'") {
+		t.Fatalf("enqueue query must target ebooks:\n%s", enqueueEnrichmentJobQuery)
 	}
-	if !strings.Contains(materializeEnrichmentJobsQuery, "NOT EXISTS") ||
-		!strings.Contains(materializeEnrichmentJobsQuery, "manga_chapters") ||
-		!strings.Contains(materializeEnrichmentJobsQuery, "chapter_content_id") {
-		t.Fatalf("materialization query must exclude manga chapters:\n%s", materializeEnrichmentJobsQuery)
+	if !strings.Contains(enqueueEnrichmentJobQuery, "NOT EXISTS") ||
+		!strings.Contains(enqueueEnrichmentJobQuery, "manga_chapters") ||
+		!strings.Contains(enqueueEnrichmentJobQuery, "chapter_content_id") {
+		t.Fatalf("enqueue query must exclude manga chapters:\n%s", enqueueEnrichmentJobQuery)
 	}
 	if strings.Contains(loadEnrichmentItemsQuery, "narrator") ||
 		strings.Contains(loadEnrichmentItemsQuery, "asin") {
@@ -234,10 +234,10 @@ func TestEnricherRunTransitionsClaimedJobsByOutcome(t *testing.T) {
 	if enriched != 1 {
 		t.Fatalf("Run() enriched = %d, want 1", enriched)
 	}
-	if queue.materializeCalls != 1 || queue.claimCalls != 1 {
-		t.Fatalf("queue calls: materialize=%d claim=%d, want 1 each", queue.materializeCalls, queue.claimCalls)
+	if queue.claimCalls != 1 {
+		t.Fatalf("claim calls = %d, want 1", queue.claimCalls)
 	}
-	if queue.claimLimit != len(items) || queue.leaseDuration <= 0 {
+	if queue.claimLimit != e.workers || queue.leaseDuration <= 0 {
 		t.Fatalf("claim args: limit=%d lease=%s", queue.claimLimit, queue.leaseDuration)
 	}
 	for contentID, want := range map[string]EnrichmentOutcome{
@@ -386,11 +386,68 @@ func TestEnricherRunBoundsEachItemBelowTheLease(t *testing.T) {
 	if elapsed := time.Since(started); elapsed > time.Second {
 		t.Fatalf("per-item timeout took %s", elapsed)
 	}
-	if got := strings.Join(queue.released, ","); got != "slow" {
-		t.Fatalf("released = %q, want slow", got)
+	if got := queue.failed["slow"]; got != EnrichmentErrorTransient {
+		t.Fatalf("timeout failure class = %q, want transient", got)
+	}
+	if len(queue.released) != 0 {
+		t.Fatalf("timed-out work was released immediately due: %v", queue.released)
 	}
 	if defaultEnrichmentItemTimeout >= defaultEnrichmentLease/2 {
 		t.Fatalf("default item timeout %s is not materially shorter than lease %s", defaultEnrichmentItemTimeout, defaultEnrichmentLease)
+	}
+}
+
+func TestEnricherRunClaimsAtMostOneJobPerWorker(t *testing.T) {
+	queue := &fakeEnrichmentQueue{}
+	e := &Enricher{
+		queue:     queue,
+		batchSize: 50,
+		workers:   4,
+		enrichClaimedItemFn: func(context.Context, enrichmentItemRow) (EnrichmentOutcome, error) {
+			return EnrichmentOutcomeSuccess, nil
+		},
+	}
+
+	if _, err := e.Run(context.Background()); err != nil {
+		t.Fatalf("Run() error = %v", err)
+	}
+	if queue.claimLimit != 4 {
+		t.Fatalf("claim limit = %d, want worker count 4", queue.claimLimit)
+	}
+	if queue.leaseDuration != defaultEnrichmentLease {
+		t.Fatalf("lease duration = %s, want %s", queue.leaseDuration, defaultEnrichmentLease)
+	}
+}
+
+func TestEnricherRunInjectsExactClaimOwnershipCheck(t *testing.T) {
+	queue := &fakeEnrichmentQueue{
+		jobs:          []EnrichmentJob{{ContentID: "lost", Token: "exact-token", Attempts: 1}},
+		claimCheckErr: ErrEnrichmentLeaseLost,
+		failErr:       ErrEnrichmentLeaseLost,
+	}
+	e := &Enricher{
+		queue:     queue,
+		batchSize: 1,
+		workers:   1,
+		loadClaimedItemsFn: func(context.Context, []EnrichmentJob) ([]enrichmentItemRow, error) {
+			return []enrichmentItemRow{{ContentID: "lost"}}, nil
+		},
+		enrichClaimedItemFn: func(ctx context.Context, _ enrichmentItemRow) (EnrichmentOutcome, error) {
+			return "", requireEnrichmentClaim(ctx)
+		},
+	}
+
+	if _, err := e.Run(context.Background()); err != nil {
+		t.Fatalf("Run() error = %v", err)
+	}
+	if queue.claimCheckCalls != 1 {
+		t.Fatalf("claim checks = %d, want 1", queue.claimCheckCalls)
+	}
+	if got := queue.transitionedJobs["lost"].Token; got != "exact-token" {
+		t.Fatalf("ownership check token = %q, want exact-token", got)
+	}
+	if len(queue.completed) != 0 {
+		t.Fatalf("lost claim completed: %v", queue.completed)
 	}
 }
 
@@ -410,6 +467,50 @@ func TestEnrichWithProvidersSkipsWhenNoProvidersConfigured(t *testing.T) {
 	err := e.enrichWithProviders(context.Background(), enrichmentItemRow{ContentID: "c1", FolderID: 7}, nil)
 	if !errors.Is(err, errEnrichmentSkipped) {
 		t.Fatalf("enrichWithProviders error = %v, want errEnrichmentSkipped", err)
+	}
+}
+
+func TestEnrichWithProvidersRejectsLostLeaseBeforePersistence(t *testing.T) {
+	tests := []struct {
+		name     string
+		provider metadata.Provider
+	}{
+		{
+			name: "matched metadata",
+			provider: &fakeEbookMetadataProvider{
+				slug: "provider",
+				result: &metadata.MetadataResult{
+					HasMetadata: true,
+					Overview:    "remote overview",
+				},
+			},
+		},
+		{
+			name:     "no match timestamp",
+			provider: &fakeEbookMetadataProvider{slug: "provider"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			checks := 0
+			ctx := withEnrichmentClaimCheck(context.Background(), func(context.Context) error {
+				checks++
+				return ErrEnrichmentLeaseLost
+			})
+			e := &Enricher{}
+
+			_, err := e.enrichWithProvidersOutcome(ctx, enrichmentItemRow{
+				ContentID: "lost",
+				FolderID:  7,
+			}, []metadata.Provider{tt.provider})
+			if !errors.Is(err, ErrEnrichmentLeaseLost) {
+				t.Fatalf("enrich error = %v, want ErrEnrichmentLeaseLost", err)
+			}
+			if checks != 1 {
+				t.Fatalf("claim ownership checks = %d, want 1", checks)
+			}
+		})
 	}
 }
 
@@ -980,7 +1081,6 @@ func (f *fakeEbookImageCacher) CacheImage(_ context.Context, req metadata.CacheI
 type fakeEnrichmentQueue struct {
 	mu                        sync.Mutex
 	jobs                      []EnrichmentJob
-	materializeCalls          int
 	claimCalls                int
 	claimLimit                int
 	leaseDuration             time.Duration
@@ -989,16 +1089,12 @@ type fakeEnrichmentQueue struct {
 	released                  []string
 	discarded                 []string
 	transitionedJobs          map[string]EnrichmentJob
+	claimCheckCalls           int
+	claimCheckErr             error
+	failErr                   error
 	releaseSawCanceledContext bool
 	completeCancel            context.CancelFunc
 	completeErr               error
-}
-
-func (f *fakeEnrichmentQueue) MaterializeCandidates(context.Context) error {
-	f.mu.Lock()
-	defer f.mu.Unlock()
-	f.materializeCalls++
-	return nil
 }
 
 func (f *fakeEnrichmentQueue) ClaimBatch(_ context.Context, limit int, leaseDuration time.Duration) ([]EnrichmentJob, error) {
@@ -1032,7 +1128,7 @@ func (f *fakeEnrichmentQueue) Fail(_ context.Context, job EnrichmentJob, errorCl
 	}
 	f.failed[job.ContentID] = errorClass
 	f.recordTransition(job)
-	return nil
+	return f.failErr
 }
 
 func (f *fakeEnrichmentQueue) Release(ctx context.Context, job EnrichmentJob) error {
@@ -1050,6 +1146,14 @@ func (f *fakeEnrichmentQueue) Discard(_ context.Context, job EnrichmentJob) erro
 	f.discarded = append(f.discarded, job.ContentID)
 	f.recordTransition(job)
 	return nil
+}
+
+func (f *fakeEnrichmentQueue) CheckClaim(_ context.Context, job EnrichmentJob) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.claimCheckCalls++
+	f.recordTransition(job)
+	return f.claimCheckErr
 }
 
 func (f *fakeEnrichmentQueue) recordTransition(job EnrichmentJob) {

--- a/internal/ebooks/enrichment_test.go
+++ b/internal/ebooks/enrichment_test.go
@@ -1318,6 +1318,43 @@ func TestEnricherRunLimitedEnforcesClaimLimitBelowWorkerCount(t *testing.T) {
 	}
 }
 
+func TestEbookHasCompleteLocalMetadata(t *testing.T) {
+	complete := enrichmentItemRow{
+		Title:      "A Book",
+		Author:     "An Author",
+		Overview:   "A useful description.",
+		PosterPath: "/library/A Book/cover.jpg",
+	}
+	if !ebookHasCompleteLocalMetadata(complete) {
+		t.Fatal("complete embedded metadata was not recognized")
+	}
+	if missing := ebookMissingMetadataFields(complete); len(missing) != 0 {
+		t.Fatalf("complete embedded metadata missing fields = %v", missing)
+	}
+
+	for name, tc := range map[string]struct {
+		field  string
+		mutate func(*enrichmentItemRow)
+	}{
+		"title":       {field: "title", mutate: func(item *enrichmentItemRow) { item.Title = "" }},
+		"author":      {field: "author", mutate: func(item *enrichmentItemRow) { item.Author = "" }},
+		"description": {field: "description", mutate: func(item *enrichmentItemRow) { item.Overview = "" }},
+		"cover":       {field: "cover", mutate: func(item *enrichmentItemRow) { item.PosterPath = "" }},
+	} {
+		t.Run(name, func(t *testing.T) {
+			item := complete
+			tc.mutate(&item)
+			if ebookHasCompleteLocalMetadata(item) {
+				t.Fatalf("metadata missing %s was treated as complete", name)
+			}
+			missing := ebookMissingMetadataFields(item)
+			if len(missing) != 1 || missing[0] != tc.field {
+				t.Fatalf("missing fields = %v, want [%s]", missing, tc.field)
+			}
+		})
+	}
+}
+
 func (f *fakeEnrichmentQueue) recordTransition(job EnrichmentJob) {
 	if f.transitionedJobs == nil {
 		f.transitionedJobs = make(map[string]EnrichmentJob)

--- a/internal/ebooks/enrichment_test.go
+++ b/internal/ebooks/enrichment_test.go
@@ -25,6 +25,13 @@ func TestEbookContentType(t *testing.T) {
 	}
 }
 
+func TestNewEnricherPreservesNilProviderIDRepository(t *testing.T) {
+	e := NewEnricher(nil, nil, nil, nil, nil, nil)
+	if e.providerIDs != nil {
+		t.Fatal("providerIDs is a non-nil typed interface for a nil repository")
+	}
+}
+
 func TestFilterEbookPeopleKeepsAuthorsOnly(t *testing.T) {
 	people := []models.ItemPerson{
 		{Person: models.Person{Name: "Author One"}, Kind: models.PersonKindAuthor, SortOrder: 7},
@@ -625,6 +632,9 @@ func TestCollectEbookMetadataAccumulatesProviderErrors(t *testing.T) {
 	if accumulator.Overview != "found" {
 		t.Fatalf("accumulator overview = %q, want metadata from the working provider", accumulator.Overview)
 	}
+	if !accumulator.HasMetadata {
+		t.Fatal("accumulator HasMetadata = false after a provider returned metadata")
+	}
 	if ids["openlibrary"] != "OL1M" {
 		t.Fatalf("accumulated IDs = %v, want search-result openlibrary ID", ids)
 	}
@@ -935,6 +945,60 @@ func TestBuildEbookMetadataRequestCarriesAccumulatedISBN(t *testing.T) {
 	}
 	if got := req.ProviderIDs["openlibrary"]; got != "OL1M" {
 		t.Fatalf("request openlibrary = %q, want OL1M", got)
+	}
+}
+
+type fakeEbookProviderIDRepository struct {
+	rows  map[string][]*models.MediaItemProviderID
+	err   error
+	calls [][]string
+}
+
+func (f *fakeEbookProviderIDRepository) GetByContentIDs(
+	_ context.Context,
+	contentIDs []string,
+) (map[string][]*models.MediaItemProviderID, error) {
+	f.calls = append(f.calls, append([]string(nil), contentIDs...))
+	return f.rows, f.err
+}
+
+func (f *fakeEbookProviderIDRepository) ReplaceByContentID(context.Context, string, map[string]string) error {
+	return nil
+}
+
+func (f *fakeEbookProviderIDRepository) FindContentIDByProviderIDs(
+	context.Context,
+	map[string]string,
+	string,
+	string,
+) (string, error) {
+	return "", nil
+}
+
+func TestEnricherLoadsProviderIDsInOneBatchAndSurfacesErrors(t *testing.T) {
+	repo := &fakeEbookProviderIDRepository{
+		rows: map[string][]*models.MediaItemProviderID{
+			"ebook-1": {
+				{ContentID: "ebook-1", ItemType: "ebook", Provider: "isbn", ProviderID: "9781982173456"},
+			},
+		},
+	}
+	e := &Enricher{providerIDs: repo}
+	items := []enrichmentItemRow{{ContentID: "ebook-1"}, {ContentID: "ebook-2"}}
+
+	if err := e.loadProviderIDs(context.Background(), []string{"ebook-1", "ebook-2"}, items); err != nil {
+		t.Fatalf("loadProviderIDs() error = %v", err)
+	}
+	if len(repo.calls) != 1 || strings.Join(repo.calls[0], ",") != "ebook-1,ebook-2" {
+		t.Fatalf("GetByContentIDs() calls = %#v, want one batch", repo.calls)
+	}
+	if got := items[0].ProviderIDs["isbn"]; got != "9781982173456" {
+		t.Fatalf("items[0].ProviderIDs[isbn] = %q", got)
+	}
+
+	repo.err = errors.New("provider IDs unavailable")
+	if err := e.loadProviderIDs(context.Background(), []string{"ebook-1"}, items[:1]); err == nil {
+		t.Fatal("loadProviderIDs() error = nil, want repository error")
 	}
 }
 

--- a/internal/libraryingest/executor.go
+++ b/internal/libraryingest/executor.go
@@ -334,20 +334,22 @@ func (e *Executor) ingest(ctx context.Context, folder *models.MediaFolder, mode 
 			return result, fmt.Errorf("match scope %q: %w", scopePath, err)
 		}
 
-		retryStarted := time.Now()
-		retried, stillUnmatched, err := e.matcher.RetryUnmatchedItemsByFolderAndPathPrefix(scanCtx, folder.ID, scopePath)
-		result.RetryDuration += time.Since(retryStarted)
-		result.RetriedItems += retried
-		result.StillUnmatchedWarnings += stillUnmatched
-		reportProgress(scanCtx, ProgressUpdate{
-			Phase:        "retrying",
-			Message:      "Retrying unmatched items",
-			CurrentScope: scopePath,
-			MatchedFiles: result.MatchedFiles,
-			RetriedItems: result.RetriedItems,
-		})
-		if err != nil {
-			return result, fmt.Errorf("retry scope %q: %w", scopePath, err)
+		if !usesDedicatedEnrichment(folder.Type) {
+			retryStarted := time.Now()
+			retried, stillUnmatched, err := e.matcher.RetryUnmatchedItemsByFolderAndPathPrefix(scanCtx, folder.ID, scopePath)
+			result.RetryDuration += time.Since(retryStarted)
+			result.RetriedItems += retried
+			result.StillUnmatchedWarnings += stillUnmatched
+			reportProgress(scanCtx, ProgressUpdate{
+				Phase:        "retrying",
+				Message:      "Retrying unmatched items",
+				CurrentScope: scopePath,
+				MatchedFiles: result.MatchedFiles,
+				RetriedItems: result.RetriedItems,
+			})
+			if err != nil {
+				return result, fmt.Errorf("retry scope %q: %w", scopePath, err)
+			}
 		}
 		if err := e.scanner.FinalizeVariantsByPathPrefix(scanCtx, folder, scopePath); err != nil {
 			return result, fmt.Errorf("finalize variants for scope %q: %w", scopePath, err)
@@ -461,6 +463,10 @@ func scopeMatchPaths(folder *models.MediaFolder, mode scopeMode, scopePath strin
 	default:
 		return nil
 	}
+}
+
+func usesDedicatedEnrichment(folderType string) bool {
+	return librarykind.Of(folderType).Ebook
 }
 
 func shouldWaitForTVQueueSettle(folder *models.MediaFolder, scanResult *scanner.ScanResult) bool {

--- a/internal/libraryingest/executor.go
+++ b/internal/libraryingest/executor.go
@@ -320,21 +320,21 @@ func (e *Executor) ingest(ctx context.Context, folder *models.MediaFolder, mode 
 		}),
 	})
 	for _, scopePath := range matchScopes {
-		matchStarted := time.Now()
-		matched, err := e.matcher.ProcessAllByFolderAndPathPrefix(scanCtx, folder.ID, scopePath, runStartedAt)
-		result.MatchDuration += time.Since(matchStarted)
-		result.MatchedFiles += matched
-		reportProgress(scanCtx, ProgressUpdate{
-			Phase:        "matching",
-			Message:      "Matching unmatched items",
-			CurrentScope: scopePath,
-			MatchedFiles: result.MatchedFiles,
-		})
-		if err != nil {
-			return result, fmt.Errorf("match scope %q: %w", scopePath, err)
-		}
-
 		if !usesDedicatedEnrichment(folder.Type) {
+			matchStarted := time.Now()
+			matched, err := e.matcher.ProcessAllByFolderAndPathPrefix(scanCtx, folder.ID, scopePath, runStartedAt)
+			result.MatchDuration += time.Since(matchStarted)
+			result.MatchedFiles += matched
+			reportProgress(scanCtx, ProgressUpdate{
+				Phase:        "matching",
+				Message:      "Matching unmatched items",
+				CurrentScope: scopePath,
+				MatchedFiles: result.MatchedFiles,
+			})
+			if err != nil {
+				return result, fmt.Errorf("match scope %q: %w", scopePath, err)
+			}
+
 			retryStarted := time.Now()
 			retried, stillUnmatched, err := e.matcher.RetryUnmatchedItemsByFolderAndPathPrefix(scanCtx, folder.ID, scopePath)
 			result.RetryDuration += time.Since(retryStarted)

--- a/internal/libraryingest/executor_test.go
+++ b/internal/libraryingest/executor_test.go
@@ -120,14 +120,16 @@ func (s *finalizeRecordingScanner) FinalizeVariantsByPathPrefix(context.Context,
 	return nil
 }
 
-func TestIngestFolderSkipsSynchronousRetryForDedicatedEnrichment(t *testing.T) {
+func TestIngestFolderSkipsGenericMatchingForDedicatedEnrichment(t *testing.T) {
 	tests := []struct {
-		name          string
-		folderType    string
-		expectedRetry int64
+		name               string
+		folderType         string
+		expectedProcessAll int64
+		expectedRetry      int64
 	}{
-		{name: "ebooks", folderType: "ebooks", expectedRetry: 0},
-		{name: "movies", folderType: "movies", expectedRetry: 1},
+		{name: "ebooks", folderType: "ebooks", expectedProcessAll: 0, expectedRetry: 0},
+		{name: "movies", folderType: "movies", expectedProcessAll: 1, expectedRetry: 1},
+		{name: "series", folderType: "series", expectedProcessAll: 1, expectedRetry: 1},
 	}
 
 	for _, tt := range tests {
@@ -144,8 +146,8 @@ func TestIngestFolderSkipsSynchronousRetryForDedicatedEnrichment(t *testing.T) {
 			if _, err := exec.IngestFolder(context.Background(), folder); err != nil {
 				t.Fatalf("ingest folder: %v", err)
 			}
-			if got := matcher.processAllCalls.Load(); got != 1 {
-				t.Fatalf("ProcessAllByFolderAndPathPrefix calls = %d, want 1", got)
+			if got := matcher.processAllCalls.Load(); got != tt.expectedProcessAll {
+				t.Fatalf("ProcessAllByFolderAndPathPrefix calls = %d, want %d", got, tt.expectedProcessAll)
 			}
 			if got := matcher.retryCalls.Load(); got != tt.expectedRetry {
 				t.Fatalf("RetryUnmatchedItemsByFolderAndPathPrefix calls = %d, want %d", got, tt.expectedRetry)

--- a/internal/libraryingest/executor_test.go
+++ b/internal/libraryingest/executor_test.go
@@ -80,6 +80,83 @@ func (s *settleStubScanner) FinalizeVariantsByPathPrefix(context.Context, *model
 	return nil
 }
 
+type retryRecordingMatcher struct {
+	processAllCalls atomic.Int64
+	retryCalls      atomic.Int64
+}
+
+func (m *retryRecordingMatcher) ProcessBatchByFolderAndPathPrefix(context.Context, int, string, time.Time) (int, error) {
+	return 0, nil
+}
+
+func (m *retryRecordingMatcher) ProcessAllByFolderAndPathPrefix(context.Context, int, string, time.Time) (int, error) {
+	m.processAllCalls.Add(1)
+	return 0, nil
+}
+
+func (m *retryRecordingMatcher) RetryUnmatchedItemsByFolderAndPathPrefix(context.Context, int, string) (int, int, error) {
+	m.retryCalls.Add(1)
+	return 0, 0, nil
+}
+
+type finalizeRecordingScanner struct {
+	finalizeCalls atomic.Int64
+}
+
+func (s *finalizeRecordingScanner) ScanFolder(context.Context, *models.MediaFolder) (*scanner.ScanResult, error) {
+	return &scanner.ScanResult{}, nil
+}
+
+func (s *finalizeRecordingScanner) ScanSubtree(context.Context, *models.MediaFolder, string) (*scanner.ScanResult, error) {
+	return &scanner.ScanResult{}, nil
+}
+
+func (s *finalizeRecordingScanner) ScanFile(context.Context, string, *models.MediaFolder) error {
+	return nil
+}
+
+func (s *finalizeRecordingScanner) FinalizeVariantsByPathPrefix(context.Context, *models.MediaFolder, string) error {
+	s.finalizeCalls.Add(1)
+	return nil
+}
+
+func TestIngestFolderSkipsSynchronousRetryForDedicatedEnrichment(t *testing.T) {
+	tests := []struct {
+		name          string
+		folderType    string
+		expectedRetry int64
+	}{
+		{name: "ebooks", folderType: "ebooks", expectedRetry: 0},
+		{name: "movies", folderType: "movies", expectedRetry: 1},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			matcher := &retryRecordingMatcher{}
+			scanner := &finalizeRecordingScanner{}
+			exec := &Executor{
+				scanner: scanner,
+				matcher: matcher,
+				now:     time.Now,
+			}
+			folder := &models.MediaFolder{ID: 5, Type: tt.folderType, Paths: []string{"/library"}}
+
+			if _, err := exec.IngestFolder(context.Background(), folder); err != nil {
+				t.Fatalf("ingest folder: %v", err)
+			}
+			if got := matcher.processAllCalls.Load(); got != 1 {
+				t.Fatalf("ProcessAllByFolderAndPathPrefix calls = %d, want 1", got)
+			}
+			if got := matcher.retryCalls.Load(); got != tt.expectedRetry {
+				t.Fatalf("RetryUnmatchedItemsByFolderAndPathPrefix calls = %d, want %d", got, tt.expectedRetry)
+			}
+			if got := scanner.finalizeCalls.Load(); got != 1 {
+				t.Fatalf("FinalizeVariantsByPathPrefix calls = %d, want 1", got)
+			}
+		})
+	}
+}
+
 // TestIngestFolderLetsActiveDrainerBatchFinishAfterSettleWindow is a regression
 // test for the settle-window cancellation bug: a TV library full scan was
 // recorded as "cancelled" because stopDrainers cancelled a drainer batch that

--- a/internal/scanner/ebook.go
+++ b/internal/scanner/ebook.go
@@ -93,8 +93,97 @@ func parseEbookFile(path string) (book parsedEbook, err error) {
 	default:
 		err = fmt.Errorf("unsupported ebook format: %s", filepath.Ext(path))
 	}
+	if err == nil {
+		if sidecarPath := ebookOPFSidecarPath(path); sidecarPath != "" {
+			sidecar, sidecarErr := parseEbookOPFSidecar(sidecarPath)
+			if sidecarErr != nil {
+				return book, sidecarErr
+			}
+			applyEbookSidecarMetadata(&book, sidecar)
+		}
+	}
 	book.sanitize()
 	return book, err
+}
+
+func ebookOPFSidecarPath(ebookPath string) string {
+	candidate := filepath.Join(filepath.Dir(ebookPath), ebookTitleFromPath(ebookPath)+".opf")
+	info, err := os.Lstat(candidate)
+	if err != nil || !info.Mode().IsRegular() || info.Mode()&os.ModeSymlink != 0 {
+		return ""
+	}
+	return candidate
+}
+
+func parseEbookOPFSidecar(sidecarPath string) (parsedEbook, error) {
+	var book parsedEbook
+	file, err := os.Open(sidecarPath)
+	if err != nil {
+		return book, fmt.Errorf("open ebook OPF sidecar %s: %w", sidecarPath, err)
+	}
+	defer file.Close()
+
+	info, err := file.Stat()
+	if err != nil {
+		return book, fmt.Errorf("stat ebook OPF sidecar %s: %w", sidecarPath, err)
+	}
+	if info.Size() > maxEPUBMetadataEntrySize {
+		return book, fmt.Errorf("ebook OPF sidecar too large: %s", sidecarPath)
+	}
+	data, err := io.ReadAll(io.LimitReader(file, maxEPUBMetadataEntrySize+1))
+	if err != nil {
+		return book, fmt.Errorf("read ebook OPF sidecar %s: %w", sidecarPath, err)
+	}
+	if len(data) > maxEPUBMetadataEntrySize {
+		return book, fmt.Errorf("ebook OPF sidecar too large: %s", sidecarPath)
+	}
+	if err := parseEPUBOPFMetadata(data, &book); err != nil {
+		return book, fmt.Errorf("parse ebook OPF sidecar %s: %w", sidecarPath, err)
+	}
+	book.sanitize()
+	return book, nil
+}
+
+func applyEbookSidecarMetadata(book *parsedEbook, sidecar parsedEbook) {
+	if book == nil {
+		return
+	}
+	if sidecar.Title != "" {
+		book.Title = sidecar.Title
+	}
+	if len(sidecar.Authors) > 0 {
+		book.Authors = append([]string(nil), sidecar.Authors...)
+	}
+	if sidecar.Description != "" {
+		book.Description = sidecar.Description
+	}
+	if sidecar.Publisher != "" {
+		book.Publisher = sidecar.Publisher
+	}
+	if !sidecar.PublishedAt.IsZero() {
+		book.PublishedAt = sidecar.PublishedAt
+	}
+	if sidecar.Year > 0 {
+		book.Year = sidecar.Year
+	}
+	if sidecar.Language != "" {
+		book.Language = sidecar.Language
+	}
+	if sidecar.ISBN != "" {
+		book.ISBN = sidecar.ISBN
+	}
+	if sidecar.Series != "" {
+		book.Series = sidecar.Series
+	}
+	if sidecar.SeriesIndex != "" {
+		book.SeriesIndex = sidecar.SeriesIndex
+	}
+	if len(sidecar.Genres) > 0 {
+		book.Genres = append([]string(nil), sidecar.Genres...)
+	}
+	if sidecar.PageCount > 0 {
+		book.PageCount = sidecar.PageCount
+	}
 }
 
 func parseEbookPDF(path string) (parsedEbook, error) {

--- a/internal/scanner/ebook.go
+++ b/internal/scanner/ebook.go
@@ -117,6 +117,13 @@ func ebookOPFSidecarPath(ebookPath string) string {
 
 func parseEbookOPFSidecar(sidecarPath string) (parsedEbook, error) {
 	var book parsedEbook
+	leafInfo, err := os.Lstat(sidecarPath)
+	if err != nil {
+		return book, fmt.Errorf("stat ebook OPF sidecar %s: %w", sidecarPath, err)
+	}
+	if !leafInfo.Mode().IsRegular() {
+		return book, fmt.Errorf("ebook OPF sidecar is not a regular file: %s", sidecarPath)
+	}
 	file, err := os.Open(sidecarPath)
 	if err != nil {
 		return book, fmt.Errorf("open ebook OPF sidecar %s: %w", sidecarPath, err)
@@ -126,6 +133,13 @@ func parseEbookOPFSidecar(sidecarPath string) (parsedEbook, error) {
 	info, err := file.Stat()
 	if err != nil {
 		return book, fmt.Errorf("stat ebook OPF sidecar %s: %w", sidecarPath, err)
+	}
+	// Close the symlink-swap window: os.Open follows symlinks, so a leaf swapped
+	// to a symlink between the Lstat above and this Open would be followed to its
+	// target. Reject unless the opened handle is the exact file Lstat inspected,
+	// so metadata can never be ingested from outside the library root.
+	if !os.SameFile(leafInfo, info) {
+		return book, fmt.Errorf("ebook OPF sidecar is not a regular file: %s", sidecarPath)
 	}
 	if info.Size() > maxEPUBMetadataEntrySize {
 		return book, fmt.Errorf("ebook OPF sidecar too large: %s", sidecarPath)

--- a/internal/scanner/ebook_scan.go
+++ b/internal/scanner/ebook_scan.go
@@ -489,6 +489,14 @@ func (s *Scanner) reconcileEbookFile(ctx context.Context, folder *models.MediaFo
 	}
 	size := info.Size()
 	modifiedAt := normalizeFileModifiedAt(info.ModTime())
+	if sidecarPath := ebookOPFSidecarPath(filePath); sidecarPath != "" {
+		if sidecarInfo, statErr := os.Stat(sidecarPath); statErr == nil {
+			sidecarModifiedAt := normalizeFileModifiedAt(sidecarInfo.ModTime())
+			if sidecarModifiedAt.After(modifiedAt) {
+				modifiedAt = sidecarModifiedAt
+			}
+		}
+	}
 
 	existingContentID, isUnchanged, skipErr := s.ebookFileShouldSkip(ctx, folder, filePath, size, modifiedAt)
 	if skipErr != nil {

--- a/internal/scanner/ebook_scan.go
+++ b/internal/scanner/ebook_scan.go
@@ -365,6 +365,9 @@ func (s *Scanner) emptyCleanupDecision(
 // reconcileEbookScan applies the post-walk safety policy and then performs
 // missing-file reconciliation for the roots that walked cleanly.
 func (s *Scanner) reconcileEbookScan(ctx context.Context, folder *models.MediaFolder, scans []ebookRootScan, seenPaths map[string]bool, fullScan bool) error {
+	if folder != nil {
+		defer s.reconcileMissingEbookEnrichment(ctx, folder.ID)
+	}
 	reconcileRoots, _ := splitEbookReconcileRoots(scans)
 	if len(reconcileRoots) == 0 {
 		if len(scans) > 0 {
@@ -559,6 +562,7 @@ func (s *Scanner) reconcileEbookFile(ctx context.Context, folder *models.MediaFo
 }
 
 const ebookEnrichmentPriority = 100
+const ebookEnrichmentReconcileLimit = 500
 
 func (s *Scanner) enqueueEbookEnrichment(ctx context.Context, contentID string) error {
 	if s == nil || s.ebookEnrichmentQueue == nil || strings.TrimSpace(contentID) == "" {
@@ -572,6 +576,34 @@ func (s *Scanner) enqueueEbookEnrichment(ctx context.Context, contentID string) 
 		)
 	}
 	return nil
+}
+
+func (s *Scanner) reconcileMissingEbookEnrichment(ctx context.Context, folderID int) {
+	if s == nil || s.ebookEnrichmentQueue == nil || folderID <= 0 {
+		return
+	}
+	reconciled, err := s.ebookEnrichmentQueue.ReconcileMissing(
+		ctx,
+		folderID,
+		ebookEnrichmentPriority,
+		ebookEnrichmentReconcileLimit,
+	)
+	if err != nil {
+		slog.WarnContext(ctx, "ebook scan: metadata enrichment reconciliation failed",
+			"component", "scanner",
+			"folder_id", folderID,
+			"limit", ebookEnrichmentReconcileLimit,
+			"error", err,
+		)
+		return
+	}
+	if reconciled > 0 {
+		slog.InfoContext(ctx, "ebook scan: repaired missing metadata enrichment jobs",
+			"component", "scanner",
+			"folder_id", folderID,
+			"reconciled", reconciled,
+		)
+	}
 }
 
 func (s *Scanner) autoLinkLiteraryWork(ctx context.Context, contentID string) {

--- a/internal/scanner/ebook_scan.go
+++ b/internal/scanner/ebook_scan.go
@@ -582,7 +582,7 @@ func (s *Scanner) reconcileMissingEbookEnrichment(ctx context.Context, folderID 
 	if s == nil || s.ebookEnrichmentQueue == nil || folderID <= 0 {
 		return
 	}
-	reconciled, err := s.ebookEnrichmentQueue.ReconcileMissing(
+	reconciled, inspected, wrapped, err := s.ebookEnrichmentQueue.ReconcileMissing(
 		ctx,
 		folderID,
 		ebookEnrichmentPriority,
@@ -604,6 +604,13 @@ func (s *Scanner) reconcileMissingEbookEnrichment(ctx context.Context, folderID 
 			"reconciled", reconciled,
 		)
 	}
+	slog.DebugContext(ctx, "ebook scan: metadata enrichment reconciliation window complete",
+		"component", "scanner",
+		"folder_id", folderID,
+		"inspected", inspected,
+		"reconciled", reconciled,
+		"wrapped", wrapped,
+	)
 }
 
 func (s *Scanner) autoLinkLiteraryWork(ctx context.Context, contentID string) {

--- a/internal/scanner/ebook_scan.go
+++ b/internal/scanner/ebook_scan.go
@@ -544,6 +544,9 @@ func (s *Scanner) reconcileEbookFile(ctx context.Context, folder *models.MediaFo
 			return fmt.Errorf("upsert ebook ISBN provider id: %w", err)
 		}
 	}
+	if err := s.enqueueEbookEnrichment(ctx, contentID); err != nil {
+		return fmt.Errorf("enqueue ebook enrichment: %w", err)
+	}
 	s.autoLinkLiteraryWork(ctx, contentID)
 	slog.InfoContext(ctx, "ebook scan: indexed", "component", "scanner",
 		"folder_id", folder.ID,
@@ -553,6 +556,15 @@ func (s *Scanner) reconcileEbookFile(ctx context.Context, folder *models.MediaFo
 		"path", filePath,
 	)
 	return nil
+}
+
+const ebookEnrichmentPriority = 100
+
+func (s *Scanner) enqueueEbookEnrichment(ctx context.Context, contentID string) error {
+	if s == nil || s.ebookEnrichmentQueue == nil || strings.TrimSpace(contentID) == "" {
+		return nil
+	}
+	return s.ebookEnrichmentQueue.Enqueue(ctx, contentID, ebookEnrichmentPriority)
 }
 
 func (s *Scanner) autoLinkLiteraryWork(ctx context.Context, contentID string) {

--- a/internal/scanner/ebook_scan.go
+++ b/internal/scanner/ebook_scan.go
@@ -1304,8 +1304,17 @@ func insertEbookISBNProviderID(ctx context.Context, exec ebookSQLExecutor, conte
 	_, err := exec.Exec(ctx, `
 		INSERT INTO media_item_provider_ids (content_id, provider, provider_id, item_type)
 		VALUES ($1, 'isbn', $2, 'ebook')
-		ON CONFLICT DO NOTHING
+		ON CONFLICT (content_id, provider) DO UPDATE SET
+			provider_id = EXCLUDED.provider_id,
+			updated_at = NOW()
+		WHERE media_item_provider_ids.provider_id IS DISTINCT FROM EXCLUDED.provider_id
 	`, contentID, isbn)
+	// A different item may already own this ISBN under the (provider, provider_id)
+	// unique constraint; duplicate copies must not fail the scan.
+	var pgErr *pgconn.PgError
+	if errors.As(err, &pgErr) && pgErr.Code == "23505" {
+		return nil
+	}
 	return err
 }
 

--- a/internal/scanner/ebook_scan.go
+++ b/internal/scanner/ebook_scan.go
@@ -53,6 +53,7 @@ func (s *Scanner) ScanEbookFolder(ctx context.Context, folder *models.MediaFolde
 type ebookRootScan struct {
 	root         string
 	files        []string
+	fileOnly     bool  // explicit single-file scan; index it but never reconcile a subtree
 	rootErr      error // root stat failed, or the root is not a directory
 	walkFailures int   // entries within the subtree the walk could not read or resolve
 }
@@ -88,7 +89,11 @@ func collectEbookRootScans(ctx context.Context, folderID int, roots []string) ([
 			// Unmounted/missing/permission-broken root: failed, not empty.
 			scan.rootErr = fmt.Errorf("stat root: %w", statErr)
 		case !info.IsDir():
-			scan.rootErr = fmt.Errorf("root is not a directory after symlink resolution")
+			if info.Mode().IsRegular() && SupportsEbookFile(cleanRoot) {
+				scan.fileOnly = true
+			} else {
+				scan.rootErr = fmt.Errorf("root is not a directory after symlink resolution")
+			}
 		}
 		if statErr == nil {
 			if err := walkLogicalTree(ctx, cleanRoot, cleanRoot, walkModeEbook, visitedPhysicalDirs, &scan.files, &scan.walkFailures); err != nil {
@@ -115,7 +120,7 @@ func splitEbookReconcileRoots(scans []ebookRootScan) (reconcileRoots []string, s
 	reconcileRoots = make([]string, 0, len(scans))
 	for i := range scans {
 		scan := &scans[i]
-		if scan.failed() {
+		if scan.failed() || scan.fileOnly {
 			continue
 		}
 		if len(scan.files) > 0 {
@@ -370,7 +375,14 @@ func (s *Scanner) reconcileEbookScan(ctx context.Context, folder *models.MediaFo
 	}
 	reconcileRoots, _ := splitEbookReconcileRoots(scans)
 	if len(reconcileRoots) == 0 {
-		if len(scans) > 0 {
+		allFailed := len(scans) > 0
+		for i := range scans {
+			if !scans[i].failed() {
+				allFailed = false
+				break
+			}
+		}
+		if allFailed {
 			slog.WarnContext(ctx, "ebook scan: every root walk failed; skipping missing-file reconciliation", "component", "scanner",
 				"folder_id", folder.ID,
 			)

--- a/internal/scanner/ebook_scan.go
+++ b/internal/scanner/ebook_scan.go
@@ -564,7 +564,14 @@ func (s *Scanner) enqueueEbookEnrichment(ctx context.Context, contentID string) 
 	if s == nil || s.ebookEnrichmentQueue == nil || strings.TrimSpace(contentID) == "" {
 		return nil
 	}
-	return s.ebookEnrichmentQueue.Enqueue(ctx, contentID, ebookEnrichmentPriority)
+	if err := s.ebookEnrichmentQueue.Enqueue(ctx, contentID, ebookEnrichmentPriority); err != nil {
+		slog.WarnContext(ctx, "ebook scan: metadata enrichment enqueue failed",
+			"component", "scanner",
+			"content_id", contentID,
+			"error", err,
+		)
+	}
+	return nil
 }
 
 func (s *Scanner) autoLinkLiteraryWork(ctx context.Context, contentID string) {

--- a/internal/scanner/ebook_test.go
+++ b/internal/scanner/ebook_test.go
@@ -1455,7 +1455,7 @@ func TestCollectEbookRootScansExcludesUnmountedRootFromReconciliation(t *testing
 	}
 }
 
-func TestCollectEbookRootScansTreatsNonDirectoryRootAsFailed(t *testing.T) {
+func TestCollectEbookRootScansTreatsSingleFileRootAsNonReconciling(t *testing.T) {
 	dir := t.TempDir()
 	fileRoot := filepath.Join(dir, "book.epub")
 	if err := os.WriteFile(fileRoot, []byte("x"), 0o644); err != nil {
@@ -1466,8 +1466,8 @@ func TestCollectEbookRootScansTreatsNonDirectoryRootAsFailed(t *testing.T) {
 	if err != nil {
 		t.Fatalf("collectEbookRootScans: %v", err)
 	}
-	if len(scans) != 1 || !scans[0].failed() {
-		t.Fatalf("scans = %+v, want one failed scan for a non-directory root", scans)
+	if len(scans) != 1 || scans[0].failed() || !scans[0].fileOnly {
+		t.Fatalf("scans = %+v, want one healthy file-only scan", scans)
 	}
 	// The file itself is still indexed; only reconciliation is withheld.
 	if len(scans[0].files) != 1 {

--- a/internal/scanner/ebook_test.go
+++ b/internal/scanner/ebook_test.go
@@ -43,14 +43,14 @@ func TestScannerEbookEnrichmentHookEnqueuesHighPriorityWork(t *testing.T) {
 	}
 }
 
-func TestScannerEbookEnrichmentHookPropagatesQueueFailure(t *testing.T) {
+func TestScannerEbookEnrichmentHookDoesNotFailScanOnQueueFailure(t *testing.T) {
 	queueErr := errors.New("queue unavailable")
 	s := &Scanner{}
 	s.SetEbookEnrichmentQueue(&fakeEbookEnrichmentQueue{err: queueErr})
 
 	err := s.enqueueEbookEnrichment(context.Background(), "ebook-1")
-	if !errors.Is(err, queueErr) {
-		t.Fatalf("enqueueEbookEnrichment() error = %v, want queue failure", err)
+	if err != nil {
+		t.Fatalf("enqueueEbookEnrichment() error = %v, want nil", err)
 	}
 }
 

--- a/internal/scanner/ebook_test.go
+++ b/internal/scanner/ebook_test.go
@@ -18,6 +18,42 @@ import (
 
 const ebookCoverTestThumbhash = "thumb"
 
+type fakeEbookEnrichmentQueue struct {
+	contentID string
+	priority  int
+	err       error
+}
+
+func (f *fakeEbookEnrichmentQueue) Enqueue(_ context.Context, contentID string, priority int) error {
+	f.contentID = contentID
+	f.priority = priority
+	return f.err
+}
+
+func TestScannerEbookEnrichmentHookEnqueuesHighPriorityWork(t *testing.T) {
+	queue := &fakeEbookEnrichmentQueue{}
+	s := &Scanner{}
+	s.SetEbookEnrichmentQueue(queue)
+
+	if err := s.enqueueEbookEnrichment(context.Background(), "ebook-1"); err != nil {
+		t.Fatalf("enqueueEbookEnrichment() error = %v", err)
+	}
+	if queue.contentID != "ebook-1" || queue.priority != 100 {
+		t.Fatalf("enqueue = (%q, %d), want (ebook-1, 100)", queue.contentID, queue.priority)
+	}
+}
+
+func TestScannerEbookEnrichmentHookPropagatesQueueFailure(t *testing.T) {
+	queueErr := errors.New("queue unavailable")
+	s := &Scanner{}
+	s.SetEbookEnrichmentQueue(&fakeEbookEnrichmentQueue{err: queueErr})
+
+	err := s.enqueueEbookEnrichment(context.Background(), "ebook-1")
+	if !errors.Is(err, queueErr) {
+		t.Fatalf("enqueueEbookEnrichment() error = %v, want queue failure", err)
+	}
+}
+
 type recordingEbookExecutor struct {
 	queries []string
 	args    [][]any

--- a/internal/scanner/ebook_test.go
+++ b/internal/scanner/ebook_test.go
@@ -337,6 +337,41 @@ func TestParseEbookEPUBMetadataHandlesWindows1251OPF(t *testing.T) {
 	}
 }
 
+func TestParseEbookFileAppliesExternalOPFSidecar(t *testing.T) {
+	dir := t.TempDir()
+	bookPath := filepath.Join(dir, "Dune.cbr")
+	if err := os.WriteFile(bookPath, nil, 0o644); err != nil {
+		t.Fatalf("write book: %v", err)
+	}
+	sidecar := `<?xml version="1.0" encoding="UTF-8"?>
+<package xmlns:dc="http://purl.org/dc/elements/1.1/">
+  <metadata>
+    <dc:title>Dune</dc:title>
+    <dc:creator>Frank Herbert</dc:creator>
+    <dc:description>A desert planet and a dangerous inheritance.</dc:description>
+    <dc:identifier>9780441172719</dc:identifier>
+    <dc:subject>Science Fiction</dc:subject>
+  </metadata>
+</package>`
+	if err := os.WriteFile(filepath.Join(dir, "Dune.opf"), []byte(sidecar), 0o644); err != nil {
+		t.Fatalf("write sidecar: %v", err)
+	}
+
+	got, err := parseEbookFile(bookPath)
+	if err != nil {
+		t.Fatalf("parseEbookFile: %v", err)
+	}
+	if got.Title != "Dune" || len(got.Authors) != 1 || got.Authors[0] != "Frank Herbert" {
+		t.Fatalf("sidecar identity = title %q authors %v", got.Title, got.Authors)
+	}
+	if got.Description == "" || got.ISBN != "9780441172719" {
+		t.Fatalf("sidecar metadata = description %q ISBN %q", got.Description, got.ISBN)
+	}
+	if got.Format != "cbr" {
+		t.Fatalf("Format = %q, want original file format cbr", got.Format)
+	}
+}
+
 func TestParseEbookEPUBMetadataAllowsXMLVersion11(t *testing.T) {
 	path := writeTestEPUBWithOPFBytes(t, []byte(`<?xml version="1.1" encoding="UTF-8"?>
 <package xmlns:dc="http://purl.org/dc/elements/1.1/"><metadata>

--- a/internal/scanner/ebook_test.go
+++ b/internal/scanner/ebook_test.go
@@ -25,6 +25,8 @@ type fakeEbookEnrichmentQueue struct {
 	reconcileCalls int
 	reconcileLimit int
 	reconcileErr   error
+	inspected      int
+	wrapped        bool
 }
 
 func (f *fakeEbookEnrichmentQueue) Enqueue(_ context.Context, contentID string, priority int) error {
@@ -33,10 +35,10 @@ func (f *fakeEbookEnrichmentQueue) Enqueue(_ context.Context, contentID string, 
 	return f.err
 }
 
-func (f *fakeEbookEnrichmentQueue) ReconcileMissing(_ context.Context, _ int, _ int, limit int) (int, error) {
+func (f *fakeEbookEnrichmentQueue) ReconcileMissing(_ context.Context, _ int, _ int, limit int) (int, int, bool, error) {
 	f.reconcileCalls++
 	f.reconcileLimit = limit
-	return 0, f.reconcileErr
+	return 0, f.inspected, f.wrapped, f.reconcileErr
 }
 
 func TestScannerEbookEnrichmentHookEnqueuesHighPriorityWork(t *testing.T) {

--- a/internal/scanner/ebook_test.go
+++ b/internal/scanner/ebook_test.go
@@ -372,6 +372,62 @@ func TestParseEbookFileAppliesExternalOPFSidecar(t *testing.T) {
 	}
 }
 
+func TestParseEbookOPFSidecarRejectsSymlinkedSidecar(t *testing.T) {
+	dir := t.TempDir()
+	target := filepath.Join(dir, "outside-library.opf")
+	sidecar := `<?xml version="1.0" encoding="UTF-8"?>
+<package xmlns:dc="http://purl.org/dc/elements/1.1/">
+  <metadata><dc:title>Smuggled</dc:title></metadata>
+</package>`
+	if err := os.WriteFile(target, []byte(sidecar), 0o644); err != nil {
+		t.Fatalf("write target: %v", err)
+	}
+	link := filepath.Join(dir, "Dune.opf")
+	if err := os.Symlink(target, link); err != nil {
+		t.Fatalf("symlink: %v", err)
+	}
+
+	if _, err := parseEbookOPFSidecar(link); err == nil {
+		t.Fatal("parseEbookOPFSidecar accepted a symlinked sidecar; a leaf swapped to a symlink after the Lstat gate would be followed to its target")
+	}
+}
+
+func TestInsertEbookISBNProviderIDReplacesStaleISBN(t *testing.T) {
+	exec := &recordingEbookExecutor{}
+	if err := insertEbookISBNProviderID(context.Background(), exec, "book-1", "9780441172719"); err != nil {
+		t.Fatalf("insertEbookISBNProviderID: %v", err)
+	}
+	if len(exec.queries) != 1 {
+		t.Fatalf("queries = %d, want 1", len(exec.queries))
+	}
+	query := strings.Join(strings.Fields(exec.queries[0]), " ")
+	if !strings.Contains(query, "ON CONFLICT (content_id, provider) DO UPDATE") ||
+		!strings.Contains(query, "provider_id = EXCLUDED.provider_id") {
+		t.Fatalf("ISBN insert does not replace a stale value on rescan:\n%s", query)
+	}
+}
+
+func TestInsertEbookISBNProviderIDToleratesISBNOwnedByAnotherItem(t *testing.T) {
+	exec := &erroringEbookExecutor{err: &pgconn.PgError{Code: "23505"}}
+	if err := insertEbookISBNProviderID(context.Background(), exec, "book-1", "9780441172719"); err != nil {
+		t.Fatalf("unique-violation on the (provider, provider_id) constraint must not fail the scan, got %v", err)
+	}
+
+	boom := errors.New("connection lost")
+	exec = &erroringEbookExecutor{err: boom}
+	if err := insertEbookISBNProviderID(context.Background(), exec, "book-1", "9780441172719"); !errors.Is(err, boom) {
+		t.Fatalf("non-unique-violation error = %v, want %v", err, boom)
+	}
+}
+
+type erroringEbookExecutor struct {
+	err error
+}
+
+func (e *erroringEbookExecutor) Exec(_ context.Context, _ string, _ ...any) (pgconn.CommandTag, error) {
+	return pgconn.CommandTag{}, e.err
+}
+
 func TestParseEbookEPUBMetadataAllowsXMLVersion11(t *testing.T) {
 	path := writeTestEPUBWithOPFBytes(t, []byte(`<?xml version="1.1" encoding="UTF-8"?>
 <package xmlns:dc="http://purl.org/dc/elements/1.1/"><metadata>

--- a/internal/scanner/ebook_test.go
+++ b/internal/scanner/ebook_test.go
@@ -1478,6 +1478,21 @@ func TestCollectEbookRootScansTreatsSingleFileRootAsNonReconciling(t *testing.T)
 	}
 }
 
+func TestCollectEbookRootScansIncludesCompoundFB2ZipFile(t *testing.T) {
+	fileRoot := filepath.Join(t.TempDir(), "book.fb2.zip")
+	if err := os.WriteFile(fileRoot, []byte("x"), 0o644); err != nil {
+		t.Fatalf("write ebook: %v", err)
+	}
+
+	scans, err := collectEbookRootScans(context.Background(), 44, []string{fileRoot})
+	if err != nil {
+		t.Fatalf("collectEbookRootScans: %v", err)
+	}
+	if len(scans) != 1 || len(scans[0].files) != 1 || scans[0].files[0] != fileRoot {
+		t.Fatalf("scans = %+v, want compound-extension file indexed", scans)
+	}
+}
+
 func TestCollectEbookRootScansMidWalkSubtreeErrorExcludesRoot(t *testing.T) {
 	if os.Getuid() == 0 {
 		t.Skip("permission-based subtree failure cannot be simulated as root")

--- a/internal/scanner/ebook_test.go
+++ b/internal/scanner/ebook_test.go
@@ -19,15 +19,24 @@ import (
 const ebookCoverTestThumbhash = "thumb"
 
 type fakeEbookEnrichmentQueue struct {
-	contentID string
-	priority  int
-	err       error
+	contentID      string
+	priority       int
+	err            error
+	reconcileCalls int
+	reconcileLimit int
+	reconcileErr   error
 }
 
 func (f *fakeEbookEnrichmentQueue) Enqueue(_ context.Context, contentID string, priority int) error {
 	f.contentID = contentID
 	f.priority = priority
 	return f.err
+}
+
+func (f *fakeEbookEnrichmentQueue) ReconcileMissing(_ context.Context, _ int, _ int, limit int) (int, error) {
+	f.reconcileCalls++
+	f.reconcileLimit = limit
+	return 0, f.reconcileErr
 }
 
 func TestScannerEbookEnrichmentHookEnqueuesHighPriorityWork(t *testing.T) {
@@ -51,6 +60,29 @@ func TestScannerEbookEnrichmentHookDoesNotFailScanOnQueueFailure(t *testing.T) {
 	err := s.enqueueEbookEnrichment(context.Background(), "ebook-1")
 	if err != nil {
 		t.Fatalf("enqueueEbookEnrichment() error = %v, want nil", err)
+	}
+}
+
+func TestScannerEbookEnrichmentReconciliationIsBoundedAndNonFatal(t *testing.T) {
+	queue := &fakeEbookEnrichmentQueue{reconcileErr: errors.New("queue unavailable")}
+	s := &Scanner{}
+	s.SetEbookEnrichmentQueue(queue)
+
+	if err := s.reconcileEbookScan(
+		context.Background(),
+		&models.MediaFolder{ID: 17},
+		nil,
+		nil,
+		true,
+	); err != nil {
+		t.Fatalf("reconcileEbookScan() error = %v", err)
+	}
+
+	if queue.reconcileCalls != 1 {
+		t.Fatalf("reconcile calls = %d, want 1", queue.reconcileCalls)
+	}
+	if queue.reconcileLimit <= 0 || queue.reconcileLimit > 1000 {
+		t.Fatalf("reconcile limit = %d, want bounded positive limit", queue.reconcileLimit)
 	}
 }
 

--- a/internal/scanner/scanner.go
+++ b/internal/scanner/scanner.go
@@ -1981,6 +1981,12 @@ func (s *Scanner) ScanFile(ctx context.Context, filePath string, folder *models.
 		}
 		return s.syncFolderScopedAudioLibraryState(ctx, folder.ID)
 	}
+	if librarykind.IsEbook(folder.Type) {
+		if !SupportsEbookFile(cleanFile) {
+			return fmt.Errorf("unrecognized ebook extension: %s", strings.ToLower(filepath.Ext(cleanFile)))
+		}
+		return s.scanEbookPaths(ctx, folder, []string{cleanFile}, false)
+	}
 
 	// Verify the file extension is recognized.
 	ext := strings.ToLower(filepath.Ext(cleanFile))

--- a/internal/scanner/scanner.go
+++ b/internal/scanner/scanner.go
@@ -161,12 +161,13 @@ type Scanner struct {
 	// emptying trash hard-deletes its row. Missing files are hidden from
 	// clients immediately; the grace only delays losing per-file state so a
 	// file that reappears (flapping mount, reverted upgrade) restores cheaply.
-	fileRemovalGrace   time.Duration
-	markerFetcher      func(context.Context, string) *IntroCreditsMarkers
-	metadataQueue      MetadataQueueProducer
-	movieQueueSyncer   MovieQueueSyncer
-	seriesQueueSyncer  SeriesQueueSyncer
-	literaryWorkLinker LiteraryWorkLinker
+	fileRemovalGrace     time.Duration
+	markerFetcher        func(context.Context, string) *IntroCreditsMarkers
+	metadataQueue        MetadataQueueProducer
+	ebookEnrichmentQueue EbookEnrichmentQueue
+	movieQueueSyncer     MovieQueueSyncer
+	seriesQueueSyncer    SeriesQueueSyncer
+	literaryWorkLinker   LiteraryWorkLinker
 }
 
 // SetImageCacher installs the imagecache.Cacher used by book scanners to push
@@ -197,6 +198,12 @@ const scanProgressLogInterval = 10 * time.Second
 type MetadataQueueProducer interface {
 	EnqueueMovieFile(ctx context.Context, fileID int) error
 	EnqueueSeriesRoot(ctx context.Context, folderID int, observedRootPath string) error
+}
+
+// EbookEnrichmentQueue durably schedules provider enrichment without running
+// provider work in the scanner.
+type EbookEnrichmentQueue interface {
+	Enqueue(ctx context.Context, contentID string, priority int) error
 }
 
 type LiteraryWorkLinker interface {
@@ -287,6 +294,13 @@ func (s *Scanner) SetMetadataQueueProducer(producer MetadataQueueProducer) {
 		return
 	}
 	s.metadataQueue = producer
+}
+
+func (s *Scanner) SetEbookEnrichmentQueue(queue EbookEnrichmentQueue) {
+	if s == nil {
+		return
+	}
+	s.ebookEnrichmentQueue = queue
 }
 
 // ScanFolder walks a media folder's directory tree, discovers media files,

--- a/internal/scanner/scanner.go
+++ b/internal/scanner/scanner.go
@@ -451,6 +451,13 @@ func (m walkMode) acceptsExt(ext string) bool {
 	}
 }
 
+func (m walkMode) acceptsPath(path string) bool {
+	if m == walkModeEbook {
+		return SupportsEbookFile(path)
+	}
+	return m.acceptsExt(strings.ToLower(filepath.Ext(path)))
+}
+
 func canonicalWalkPath(path string) (string, error) {
 	resolved, err := filepath.EvalSymlinks(path)
 	if err != nil {
@@ -518,7 +525,7 @@ func walkLogicalTree(
 		if mode == walkModeMovie && shouldSkipMovieSupplementalFile(logicalPath) {
 			return nil
 		}
-		if mode.acceptsExt(strings.ToLower(filepath.Ext(logicalPath))) {
+		if mode.acceptsPath(logicalPath) {
 			*filePaths = append(*filePaths, logicalPath)
 		}
 		return nil
@@ -528,7 +535,7 @@ func walkLogicalTree(
 		if mode == walkModeMovie && shouldSkipMovieSupplementalFile(logicalPath) {
 			return nil
 		}
-		if mode.acceptsExt(strings.ToLower(filepath.Ext(logicalPath))) {
+		if mode.acceptsPath(logicalPath) {
 			*filePaths = append(*filePaths, logicalPath)
 		}
 		return nil
@@ -590,7 +597,7 @@ func walkLogicalTree(
 			if mode == walkModeMovie && shouldSkipMovieSupplementalFile(logicalChild) {
 				continue
 			}
-			if mode.acceptsExt(strings.ToLower(filepath.Ext(entry.Name()))) {
+			if mode.acceptsPath(entry.Name()) {
 				*filePaths = append(*filePaths, logicalChild)
 			}
 			continue
@@ -606,7 +613,7 @@ func walkLogicalTree(
 		if mode == walkModeMovie && shouldSkipMovieSupplementalFile(logicalChild) {
 			continue
 		}
-		if mode.acceptsExt(strings.ToLower(filepath.Ext(entry.Name()))) {
+		if mode.acceptsPath(entry.Name()) {
 			*filePaths = append(*filePaths, logicalChild)
 		}
 	}
@@ -1976,14 +1983,29 @@ func (s *Scanner) ScanFile(ctx context.Context, filePath string, folder *models.
 		if err != nil {
 			return err
 		}
+		if handled, err := s.reconcileVanishedFileIfNeeded(ctx, folder, cleanFile); handled {
+			return err
+		}
 		if err := s.ScanAudiobookFolder(ctx, scopedFolderPaths(folder, []string{scanRoot}), false); err != nil {
 			return err
 		}
 		return s.syncFolderScopedAudioLibraryState(ctx, folder.ID)
 	}
+	if librarykind.IsManga(folder.Type) {
+		if !SupportsEbookFile(cleanFile) {
+			return fmt.Errorf("unrecognized manga extension: %s", strings.ToLower(filepath.Ext(cleanFile)))
+		}
+		if handled, err := s.reconcileVanishedFileIfNeeded(ctx, folder, cleanFile); handled {
+			return err
+		}
+		return s.scanMangaPaths(ctx, folder, []string{cleanFile}, false)
+	}
 	if librarykind.IsEbook(folder.Type) {
 		if !SupportsEbookFile(cleanFile) {
 			return fmt.Errorf("unrecognized ebook extension: %s", strings.ToLower(filepath.Ext(cleanFile)))
+		}
+		if handled, err := s.reconcileVanishedFileIfNeeded(ctx, folder, cleanFile); handled {
+			return err
 		}
 		return s.scanEbookPaths(ctx, folder, []string{cleanFile}, false)
 	}
@@ -1992,6 +2014,9 @@ func (s *Scanner) ScanFile(ctx context.Context, filePath string, folder *models.
 	ext := strings.ToLower(filepath.Ext(cleanFile))
 	if !videoExtensions[ext] {
 		return fmt.Errorf("unrecognized video extension: %s", ext)
+	}
+	if handled, err := s.reconcileVanishedFileIfNeeded(ctx, folder, cleanFile); handled {
+		return err
 	}
 
 	// Look up only this specific file instead of loading the entire folder.
@@ -2099,6 +2124,45 @@ func (s *Scanner) ScanFile(ctx context.Context, filePath string, folder *models.
 		)
 	}
 	return nil
+}
+
+func (s *Scanner) reconcileVanishedFileIfNeeded(ctx context.Context, folder *models.MediaFolder, filePath string) (bool, error) {
+	if _, err := os.Stat(filePath); err == nil {
+		return false, nil
+	} else if !errors.Is(err, os.ErrNotExist) {
+		return true, fmt.Errorf("stat media file %s: %w", filePath, err)
+	}
+	if s == nil || s.fileRepo == nil || folder == nil {
+		return true, fmt.Errorf("reconcile vanished file: scanner repositories not configured")
+	}
+
+	file, err := s.fileRepo.GetByPath(ctx, filePath)
+	if errors.Is(err, ErrFileNotFound) {
+		return true, nil
+	}
+	if err != nil {
+		return true, fmt.Errorf("loading vanished media file %s: %w", filePath, err)
+	}
+	if file.MediaFolderID != folder.ID {
+		return true, fmt.Errorf("vanished media file %s belongs to library %d, not %d", filePath, file.MediaFolderID, folder.ID)
+	}
+	if file.MissingSince == nil {
+		if err := s.fileRepo.MarkMissing(ctx, file.ID, time.Now().UTC()); err != nil {
+			return true, fmt.Errorf("marking vanished media file %s missing: %w", filePath, err)
+		}
+	}
+	if _, _, _, err := s.sweepMissingAndReconcile(ctx, folder, false); err != nil {
+		return true, err
+	}
+	if librarykind.IsManga(folder.Type) {
+		if err := s.deleteOrphanedMangaSeries(ctx, folder.ID); err != nil {
+			return true, err
+		}
+	}
+	if librarykind.IsEbook(folder.Type) || librarykind.IsManga(folder.Type) {
+		s.reconcileMissingEbookEnrichment(ctx, folder.ID)
+	}
+	return true, nil
 }
 
 func (s *Scanner) watchFolderContext(ctx context.Context, folderID int) (context.Context, context.CancelFunc) {

--- a/internal/scanner/scanner.go
+++ b/internal/scanner/scanner.go
@@ -204,7 +204,7 @@ type MetadataQueueProducer interface {
 // provider work in the scanner.
 type EbookEnrichmentQueue interface {
 	Enqueue(ctx context.Context, contentID string, priority int) error
-	ReconcileMissing(ctx context.Context, folderID, priority, limit int) (int, error)
+	ReconcileMissing(ctx context.Context, folderID, priority, limit int) (reconciled, inspected int, wrapped bool, err error)
 }
 
 type LiteraryWorkLinker interface {

--- a/internal/scanner/scanner.go
+++ b/internal/scanner/scanner.go
@@ -1984,7 +1984,17 @@ func (s *Scanner) ScanFile(ctx context.Context, filePath string, folder *models.
 			return err
 		}
 		if handled, err := s.reconcileVanishedFileIfNeeded(ctx, folder, cleanFile); handled {
-			return err
+			if err != nil {
+				return err
+			}
+			if info, statErr := os.Stat(scanRoot); statErr == nil && info.IsDir() {
+				if err := s.ScanAudiobookFolder(ctx, scopedFolderPaths(folder, []string{scanRoot}), false); err != nil {
+					return err
+				}
+			} else if statErr != nil && !errors.Is(statErr, os.ErrNotExist) {
+				return fmt.Errorf("stat audiobook directory %s: %w", scanRoot, statErr)
+			}
+			return s.syncFolderScopedAudioLibraryState(ctx, folder.ID)
 		}
 		if err := s.ScanAudiobookFolder(ctx, scopedFolderPaths(folder, []string{scanRoot}), false); err != nil {
 			return err
@@ -2016,7 +2026,10 @@ func (s *Scanner) ScanFile(ctx context.Context, filePath string, folder *models.
 		return fmt.Errorf("unrecognized video extension: %s", ext)
 	}
 	if handled, err := s.reconcileVanishedFileIfNeeded(ctx, folder, cleanFile); handled {
-		return err
+		if err != nil {
+			return err
+		}
+		return s.syncVanishedVideoQueues(ctx, folder.ID, cleanFile)
 	}
 
 	// Look up only this specific file instead of loading the entire folder.
@@ -2163,6 +2176,20 @@ func (s *Scanner) reconcileVanishedFileIfNeeded(ctx context.Context, folder *mod
 		s.reconcileMissingEbookEnrichment(ctx, folder.ID)
 	}
 	return true, nil
+}
+
+func (s *Scanner) syncVanishedVideoQueues(ctx context.Context, folderID int, filePath string) error {
+	if s.seriesQueueSyncer != nil {
+		if err := s.seriesQueueSyncer.SyncInScope(ctx, folderID, filepath.Dir(filePath)); err != nil {
+			return fmt.Errorf("syncing series match queue after vanished file: %w", err)
+		}
+	}
+	if s.movieQueueSyncer != nil {
+		if err := s.movieQueueSyncer.SyncInScope(ctx, folderID, filepath.Clean(filePath)); err != nil {
+			return fmt.Errorf("syncing movie match queue after vanished file: %w", err)
+		}
+	}
+	return nil
 }
 
 func (s *Scanner) watchFolderContext(ctx context.Context, folderID int) (context.Context, context.CancelFunc) {

--- a/internal/scanner/scanner.go
+++ b/internal/scanner/scanner.go
@@ -204,6 +204,7 @@ type MetadataQueueProducer interface {
 // provider work in the scanner.
 type EbookEnrichmentQueue interface {
 	Enqueue(ctx context.Context, contentID string, priority int) error
+	ReconcileMissing(ctx context.Context, folderID, priority, limit int) (int, error)
 }
 
 type LiteraryWorkLinker interface {

--- a/internal/scanner/scanner_test.go
+++ b/internal/scanner/scanner_test.go
@@ -233,6 +233,9 @@ func TestWalkModeEbookAcceptsEbookExtensionsOnly(t *testing.T) {
 			t.Fatalf("walkModeEbook should reject %s", ext)
 		}
 	}
+	if !walkModeEbook.acceptsPath("Book.fb2.zip") {
+		t.Fatal("walkModeEbook should accept .fb2.zip compound extension")
+	}
 }
 
 func TestScanFolderEbookLibraryRoutesToEbookScanner(t *testing.T) {
@@ -282,5 +285,23 @@ func TestScanFileEbookLibraryUsesEbookPipeline(t *testing.T) {
 	}
 	if !strings.Contains(err.Error(), "folder_id=44") {
 		t.Fatalf("error = %q, want ebook scanner aggregate failure", err)
+	}
+}
+
+func TestScanFileMangaLibraryUsesMangaPipeline(t *testing.T) {
+	filePath := filepath.Join(t.TempDir(), "chapter.cbz")
+	if err := os.WriteFile(filePath, []byte("not a real cbz"), 0o644); err != nil {
+		t.Fatalf("write fake manga: %v", err)
+	}
+
+	err := (&Scanner{}).ScanFile(context.Background(), filePath, &models.MediaFolder{ID: 45, Type: "manga"})
+	if err == nil {
+		t.Fatal("ScanFile returned nil, want manga parse failure")
+	}
+	if strings.Contains(err.Error(), "unrecognized video extension") {
+		t.Fatalf("ScanFile used video extension gate: %v", err)
+	}
+	if !strings.Contains(err.Error(), "folder_id=45") {
+		t.Fatalf("error = %q, want manga scanner aggregate failure", err)
 	}
 }

--- a/internal/scanner/scanner_test.go
+++ b/internal/scanner/scanner_test.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"path/filepath"
 	"sort"
+	"strings"
 	"testing"
 	"time"
 
@@ -263,5 +264,23 @@ func TestScanSubtreeEbookLibraryRoutesToEbookScanner(t *testing.T) {
 	}
 	if result == nil {
 		t.Fatal("ScanSubtree ebook result = nil, want empty result")
+	}
+}
+
+func TestScanFileEbookLibraryUsesEbookPipeline(t *testing.T) {
+	filePath := filepath.Join(t.TempDir(), "book.epub")
+	if err := os.WriteFile(filePath, []byte("not a real epub"), 0o644); err != nil {
+		t.Fatalf("write fake ebook: %v", err)
+	}
+
+	err := (&Scanner{}).ScanFile(context.Background(), filePath, &models.MediaFolder{ID: 44, Type: "ebooks"})
+	if err == nil {
+		t.Fatal("ScanFile returned nil, want ebook parse failure")
+	}
+	if strings.Contains(err.Error(), "unrecognized video extension") {
+		t.Fatalf("ScanFile used video extension gate: %v", err)
+	}
+	if !strings.Contains(err.Error(), "folder_id=44") {
+		t.Fatalf("error = %q, want ebook scanner aggregate failure", err)
 	}
 }

--- a/internal/scanner/scanner_test.go
+++ b/internal/scanner/scanner_test.go
@@ -12,6 +12,21 @@ import (
 	"github.com/Silo-Server/silo-server/internal/models"
 )
 
+type recordingQueueSyncer struct {
+	folderID int
+	scope    string
+}
+
+func (s *recordingQueueSyncer) SyncForFolder(context.Context, int) error {
+	return nil
+}
+
+func (s *recordingQueueSyncer) SyncInScope(_ context.Context, folderID int, scopePath string) error {
+	s.folderID = folderID
+	s.scope = scopePath
+	return nil
+}
+
 func TestCollectLogicalFilePaths_PreservesLogicalSymlinkRootPaths(t *testing.T) {
 	t.Parallel()
 
@@ -303,5 +318,22 @@ func TestScanFileMangaLibraryUsesMangaPipeline(t *testing.T) {
 	}
 	if !strings.Contains(err.Error(), "folder_id=45") {
 		t.Fatalf("error = %q, want manga scanner aggregate failure", err)
+	}
+}
+
+func TestSyncVanishedVideoQueuesUsesParentAndExactFileScopes(t *testing.T) {
+	series := &recordingQueueSyncer{}
+	movie := &recordingQueueSyncer{}
+	filePath := filepath.Join("/media", "Movie", "Movie.mkv")
+	scanner := &Scanner{seriesQueueSyncer: series, movieQueueSyncer: movie}
+
+	if err := scanner.syncVanishedVideoQueues(context.Background(), 17, filePath); err != nil {
+		t.Fatalf("syncVanishedVideoQueues: %v", err)
+	}
+	if series.folderID != 17 || series.scope != filepath.Dir(filePath) {
+		t.Fatalf("series sync = folder %d scope %q", series.folderID, series.scope)
+	}
+	if movie.folderID != 17 || movie.scope != filepath.Clean(filePath) {
+		t.Fatalf("movie sync = folder %d scope %q", movie.folderID, movie.scope)
 	}
 }

--- a/internal/scantrigger/scantrigger.go
+++ b/internal/scantrigger/scantrigger.go
@@ -143,7 +143,7 @@ func normalizeTrigger(trigger string) string {
 
 // ResolveVanishedPath resolves a change for a path that no longer exists on
 // disk (a file deleted by an upgrade/replacement, or a removed directory) to a
-// reconciling scan target. Paths with a supported video extension map to a
+// reconciling scan target. Paths with a supported media extension map to a
 // subtree scan of their parent directory; other paths map to a subtree scan of
 // the path itself. The scoped scan marks the vanished files missing so stale
 // versions stop being offered for playback.
@@ -177,7 +177,7 @@ func (r *Resolver) ResolveVanishedPath(ctx context.Context, path, trigger string
 	trigger = normalizeTrigger(trigger)
 
 	scope := cleanPath
-	if scanner.SupportsVideoFile(cleanPath) {
+	if supportsMediaFile(cleanPath) {
 		scope = filepath.Dir(cleanPath)
 	}
 	if filepath.Clean(scope) == filepath.Clean(matchedRoot) {
@@ -353,10 +353,16 @@ func ClassifyPath(targetPath, matchedRoot string) (string, error) {
 	if !info.Mode().IsRegular() {
 		return "", &RequestError{Status: http.StatusBadRequest, Code: "bad_request", Message: "Path must be a file or directory"}
 	}
-	if !scanner.SupportsVideoFile(targetPath) {
+	if !supportsMediaFile(targetPath) {
 		return "", &RequestError{Status: http.StatusBadRequest, Code: "bad_request", Message: "Unsupported media file extension"}
 	}
 	return ModeFile, nil
+}
+
+func supportsMediaFile(path string) bool {
+	return scanner.SupportsVideoFile(path) ||
+		scanner.SupportsAudioFile(path) ||
+		scanner.SupportsEbookFile(path)
 }
 
 func PathWithinRoot(targetPath, rootPath string) bool {

--- a/internal/scantrigger/scantrigger.go
+++ b/internal/scantrigger/scantrigger.go
@@ -145,9 +145,10 @@ func normalizeTrigger(trigger string) string {
 // ResolveVanishedPath resolves a change for a path that no longer exists on
 // disk (a file deleted by an upgrade/replacement, or a removed directory) to a
 // reconciling scan target. Paths with a supported extension for their library
-// map to an exact file scan; other paths map to a subtree scan of the path
-// itself. The scoped scan marks vanished files missing so stale versions stop
-// being offered for playback.
+// map to an exact file scan; paths with a media extension the library type
+// does not support are rejected; remaining paths map to a subtree scan of the
+// path itself. The scoped scan marks vanished files missing so stale versions
+// stop being offered for playback.
 //
 // Two guards keep this from turning transient storage loss into cleanup:
 // the path must actually be gone (a still-existing path is rejected — use

--- a/internal/scantrigger/scantrigger.go
+++ b/internal/scantrigger/scantrigger.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 
 	"github.com/Silo-Server/silo-server/internal/catalog"
+	"github.com/Silo-Server/silo-server/internal/librarykind"
 	"github.com/Silo-Server/silo-server/internal/models"
 	"github.com/Silo-Server/silo-server/internal/scanner"
 )
@@ -143,10 +144,10 @@ func normalizeTrigger(trigger string) string {
 
 // ResolveVanishedPath resolves a change for a path that no longer exists on
 // disk (a file deleted by an upgrade/replacement, or a removed directory) to a
-// reconciling scan target. Paths with a supported media extension map to a
-// subtree scan of their parent directory; other paths map to a subtree scan of
-// the path itself. The scoped scan marks the vanished files missing so stale
-// versions stop being offered for playback.
+// reconciling scan target. Paths with a supported extension for their library
+// map to an exact file scan; other paths map to a subtree scan of the path
+// itself. The scoped scan marks vanished files missing so stale versions stop
+// being offered for playback.
 //
 // Two guards keep this from turning transient storage loss into cleanup:
 // the path must actually be gone (a still-existing path is rejected — use
@@ -176,10 +177,13 @@ func (r *Resolver) ResolveVanishedPath(ctx context.Context, path, trigger string
 	}
 	trigger = normalizeTrigger(trigger)
 
-	scope := cleanPath
-	if supportsMediaFile(cleanPath) {
-		scope = filepath.Dir(cleanPath)
+	if supportsLibraryMediaFile(cleanPath, folder.Type) {
+		return &Target{Folder: folder, Mode: ModeFile, Path: cleanPath, Trigger: trigger}, nil
 	}
+	if supportsMediaFile(cleanPath) {
+		return nil, &RequestError{Status: http.StatusBadRequest, Code: "bad_request", Message: "Unsupported media file extension for library type"}
+	}
+	scope := cleanPath
 	if filepath.Clean(scope) == filepath.Clean(matchedRoot) {
 		// A vanished entry directly under the root reconciles via a full
 		// library scan, which keeps the empty-root guard in play.
@@ -247,7 +251,7 @@ func (r *Resolver) resolve(ctx context.Context, req Request, pathFolders []*mode
 		return nil, &RequestError{Status: http.StatusConflict, Code: "conflict", Message: "Library is disabled"}
 	}
 
-	mode, err := ClassifyPath(cleanPath, matchedRoot)
+	mode, err := ClassifyLibraryPath(cleanPath, matchedRoot, folder.Type)
 	if err != nil {
 		return nil, err
 	}
@@ -332,6 +336,10 @@ func MatchFolderForPath(targetPath string, folders []*models.MediaFolder) (*mode
 }
 
 func ClassifyPath(targetPath, matchedRoot string) (string, error) {
+	return ClassifyLibraryPath(targetPath, matchedRoot, "")
+}
+
+func ClassifyLibraryPath(targetPath, matchedRoot, folderType string) (string, error) {
 	if filepath.Clean(targetPath) == filepath.Clean(matchedRoot) {
 		return ModeLibrary, nil
 	}
@@ -353,10 +361,23 @@ func ClassifyPath(targetPath, matchedRoot string) (string, error) {
 	if !info.Mode().IsRegular() {
 		return "", &RequestError{Status: http.StatusBadRequest, Code: "bad_request", Message: "Path must be a file or directory"}
 	}
-	if !supportsMediaFile(targetPath) {
-		return "", &RequestError{Status: http.StatusBadRequest, Code: "bad_request", Message: "Unsupported media file extension"}
+	if !supportsLibraryMediaFile(targetPath, folderType) {
+		return "", &RequestError{Status: http.StatusBadRequest, Code: "bad_request", Message: "Unsupported media file extension for library type"}
 	}
 	return ModeFile, nil
+}
+
+func supportsLibraryMediaFile(path, folderType string) bool {
+	switch {
+	case librarykind.IsAudiobook(folderType):
+		return scanner.SupportsAudioFile(path)
+	case librarykind.IsEbook(folderType), librarykind.IsManga(folderType):
+		return scanner.SupportsEbookFile(path)
+	case librarykind.IsPodcast(folderType):
+		return false
+	default:
+		return scanner.SupportsVideoFile(path)
+	}
 }
 
 func supportsMediaFile(path string) bool {

--- a/internal/scantrigger/scantrigger_test.go
+++ b/internal/scantrigger/scantrigger_test.go
@@ -6,6 +6,7 @@ import (
 	"net/http"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/Silo-Server/silo-server/internal/catalog"
@@ -109,26 +110,31 @@ func TestResolverRejectsMissingSubtreeAtLibraryRoot(t *testing.T) {
 	}
 }
 
-func TestResolverResolvesVanishedFileToParentSubtree(t *testing.T) {
+func TestResolverResolvesVanishedMediaFileToParentSubtree(t *testing.T) {
 	root := t.TempDir()
-	movieDir := filepath.Join(root, "Movie (2026)")
-	if err := os.Mkdir(movieDir, 0o755); err != nil {
-		t.Fatal(err)
-	}
-	vanished := filepath.Join(movieDir, "Movie (2026).mkv")
 	repo := &fakeFolderRepo{folders: []*models.MediaFolder{{
 		ID:      20,
-		Name:    "Movies",
+		Name:    "Media",
 		Enabled: true,
 		Paths:   []string{root},
 	}}}
 
-	target, err := NewResolver(repo).ResolveVanishedPath(context.Background(), vanished, "autoscan")
-	if err != nil {
-		t.Fatalf("ResolveVanishedPath returned error: %v", err)
-	}
-	if target.Folder == nil || target.Folder.ID != 20 || target.Mode != ModeSubtree || target.Path != movieDir {
-		t.Fatalf("unexpected target: %#v", target)
+	for _, name := range []string{"Movie.mkv", "Book.epub", "Audiobook.m4b"} {
+		t.Run(name, func(t *testing.T) {
+			mediaDir := filepath.Join(root, strings.TrimSuffix(name, filepath.Ext(name)))
+			if err := os.Mkdir(mediaDir, 0o755); err != nil {
+				t.Fatal(err)
+			}
+			vanished := filepath.Join(mediaDir, name)
+
+			target, err := NewResolver(repo).ResolveVanishedPath(context.Background(), vanished, "autoscan")
+			if err != nil {
+				t.Fatalf("ResolveVanishedPath returned error: %v", err)
+			}
+			if target.Folder == nil || target.Folder.ID != 20 || target.Mode != ModeSubtree || target.Path != mediaDir {
+				t.Fatalf("unexpected target: %#v", target)
+			}
+		})
 	}
 }
 
@@ -280,6 +286,33 @@ func TestResolverClassifiesVideoFile(t *testing.T) {
 	}
 	if target.Folder == nil || target.Folder.ID != 9 || target.Mode != ModeFile || target.Path != filepath.Clean(filePath) {
 		t.Fatalf("unexpected target: %#v", target)
+	}
+}
+
+func TestResolverClassifiesAudioAndEbookFiles(t *testing.T) {
+	root := t.TempDir()
+	repo := &fakeFolderRepo{folders: []*models.MediaFolder{{
+		ID:      25,
+		Name:    "Media",
+		Enabled: true,
+		Paths:   []string{root},
+	}}}
+
+	for _, name := range []string{"Book.epub", "Book.fb2.zip", "Audiobook.m4b"} {
+		t.Run(name, func(t *testing.T) {
+			filePath := filepath.Join(root, name)
+			if err := os.WriteFile(filePath, []byte("test"), 0o644); err != nil {
+				t.Fatal(err)
+			}
+
+			target, err := NewResolver(repo).Resolve(context.Background(), Request{Path: filePath})
+			if err != nil {
+				t.Fatalf("Resolve returned error: %v", err)
+			}
+			if target.Mode != ModeFile || target.Path != filepath.Clean(filePath) {
+				t.Fatalf("unexpected target: %#v", target)
+			}
+		})
 	}
 }
 

--- a/internal/scantrigger/scantrigger_test.go
+++ b/internal/scantrigger/scantrigger_test.go
@@ -6,7 +6,6 @@ import (
 	"net/http"
 	"os"
 	"path/filepath"
-	"strings"
 	"testing"
 
 	"github.com/Silo-Server/silo-server/internal/catalog"
@@ -110,28 +109,35 @@ func TestResolverRejectsMissingSubtreeAtLibraryRoot(t *testing.T) {
 	}
 }
 
-func TestResolverResolvesVanishedMediaFileToParentSubtree(t *testing.T) {
-	root := t.TempDir()
-	repo := &fakeFolderRepo{folders: []*models.MediaFolder{{
-		ID:      20,
-		Name:    "Media",
-		Enabled: true,
-		Paths:   []string{root},
-	}}}
-
-	for _, name := range []string{"Movie.mkv", "Book.epub", "Audiobook.m4b"} {
-		t.Run(name, func(t *testing.T) {
-			mediaDir := filepath.Join(root, strings.TrimSuffix(name, filepath.Ext(name)))
+func TestResolverResolvesVanishedMediaFileAsExactFile(t *testing.T) {
+	for _, tc := range []struct {
+		name        string
+		libraryType string
+	}{
+		{name: "Movie.mkv", libraryType: "movies"},
+		{name: "Book.epub", libraryType: "ebooks"},
+		{name: "Audiobook.m4b", libraryType: "audiobooks"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			root := t.TempDir()
+			mediaDir := filepath.Join(root, "Title")
 			if err := os.Mkdir(mediaDir, 0o755); err != nil {
 				t.Fatal(err)
 			}
-			vanished := filepath.Join(mediaDir, name)
+			vanished := filepath.Join(mediaDir, tc.name)
+			repo := &fakeFolderRepo{folders: []*models.MediaFolder{{
+				ID:      20,
+				Name:    "Media",
+				Type:    tc.libraryType,
+				Enabled: true,
+				Paths:   []string{root},
+			}}}
 
 			target, err := NewResolver(repo).ResolveVanishedPath(context.Background(), vanished, "autoscan")
 			if err != nil {
 				t.Fatalf("ResolveVanishedPath returned error: %v", err)
 			}
-			if target.Folder == nil || target.Folder.ID != 20 || target.Mode != ModeSubtree || target.Path != mediaDir {
+			if target.Folder == nil || target.Folder.ID != 20 || target.Mode != ModeFile || target.Path != vanished {
 				t.Fatalf("unexpected target: %#v", target)
 			}
 		})
@@ -157,12 +163,13 @@ func TestResolverResolvesVanishedDirToItself(t *testing.T) {
 	}
 }
 
-func TestResolverResolvesVanishedFileDirectlyUnderRootToLibraryScan(t *testing.T) {
+func TestResolverResolvesVanishedFileDirectlyUnderRootAsExactFile(t *testing.T) {
 	root := t.TempDir()
 	vanished := filepath.Join(root, "Movie (2026).mkv")
 	repo := &fakeFolderRepo{folders: []*models.MediaFolder{{
 		ID:      22,
 		Name:    "Movies",
+		Type:    "movies",
 		Enabled: true,
 		Paths:   []string{root},
 	}}}
@@ -171,7 +178,7 @@ func TestResolverResolvesVanishedFileDirectlyUnderRootToLibraryScan(t *testing.T
 	if err != nil {
 		t.Fatalf("ResolveVanishedPath returned error: %v", err)
 	}
-	if target.Folder == nil || target.Folder.ID != 22 || target.Mode != ModeLibrary || target.Path != "" {
+	if target.Folder == nil || target.Folder.ID != 22 || target.Mode != ModeFile || target.Path != vanished {
 		t.Fatalf("unexpected target: %#v", target)
 	}
 }
@@ -290,20 +297,27 @@ func TestResolverClassifiesVideoFile(t *testing.T) {
 }
 
 func TestResolverClassifiesAudioAndEbookFiles(t *testing.T) {
-	root := t.TempDir()
-	repo := &fakeFolderRepo{folders: []*models.MediaFolder{{
-		ID:      25,
-		Name:    "Media",
-		Enabled: true,
-		Paths:   []string{root},
-	}}}
-
-	for _, name := range []string{"Book.epub", "Book.fb2.zip", "Audiobook.m4b"} {
-		t.Run(name, func(t *testing.T) {
-			filePath := filepath.Join(root, name)
+	for _, tc := range []struct {
+		name        string
+		libraryType string
+	}{
+		{name: "Book.epub", libraryType: "ebooks"},
+		{name: "Book.fb2.zip", libraryType: "ebooks"},
+		{name: "Audiobook.m4b", libraryType: "audiobooks"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			root := t.TempDir()
+			filePath := filepath.Join(root, tc.name)
 			if err := os.WriteFile(filePath, []byte("test"), 0o644); err != nil {
 				t.Fatal(err)
 			}
+			repo := &fakeFolderRepo{folders: []*models.MediaFolder{{
+				ID:      25,
+				Name:    "Media",
+				Type:    tc.libraryType,
+				Enabled: true,
+				Paths:   []string{root},
+			}}}
 
 			target, err := NewResolver(repo).Resolve(context.Background(), Request{Path: filePath})
 			if err != nil {
@@ -313,6 +327,30 @@ func TestResolverClassifiesAudioAndEbookFiles(t *testing.T) {
 				t.Fatalf("unexpected target: %#v", target)
 			}
 		})
+	}
+}
+
+func TestResolverRejectsPodcastFileTargetUntilPodcastPipelineSupportsIt(t *testing.T) {
+	root := t.TempDir()
+	filePath := filepath.Join(root, "Episode.mp3")
+	if err := os.WriteFile(filePath, []byte("test"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	repo := &fakeFolderRepo{folders: []*models.MediaFolder{{
+		ID:      26,
+		Name:    "Podcasts",
+		Type:    "podcasts",
+		Enabled: true,
+		Paths:   []string{root},
+	}}}
+
+	_, err := NewResolver(repo).Resolve(context.Background(), Request{Path: filePath})
+	var reqErr *RequestError
+	if !errors.As(err, &reqErr) {
+		t.Fatalf("expected RequestError, got %T: %v", err, err)
+	}
+	if reqErr.Status != http.StatusBadRequest || reqErr.Message != "Unsupported media file extension for library type" {
+		t.Fatalf("unexpected error: %#v", reqErr)
 	}
 }
 

--- a/internal/server/frontend.go
+++ b/internal/server/frontend.go
@@ -156,6 +156,15 @@ func (h *frontendHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
+	// A missing /assets/ file is a content-hashed chunk from another build,
+	// not an app route: answering with the shell makes dynamic imports fail
+	// on a text/html module. A 404 surfaces the real condition so the client
+	// preload-error handler can reload onto the current build.
+	if strings.HasPrefix(path, "/assets/") {
+		http.NotFound(w, r)
+		return
+	}
+
 	// SPA fallback: serve the (branded) index.html shell.
 	shell, ok := h.brandedShell(r)
 	if !ok {

--- a/internal/server/frontend_test.go
+++ b/internal/server/frontend_test.go
@@ -79,6 +79,31 @@ func TestFrontendHandlerServesStaticAssetsWithoutCSP(t *testing.T) {
 	}
 }
 
+func TestFrontendHandlerReturns404ForMissingAssets(t *testing.T) {
+	handler := newFrontendTestHandler(t)
+
+	// A content-hashed chunk from a previous build no longer exists after a
+	// deploy. Serving the SPA shell at a .js URL makes the browser fail with
+	// "Failed to fetch dynamically imported module"; a 404 lets clients (and
+	// the preload-error reload handler) see the real condition.
+	rr := httptest.NewRecorder()
+	handler.ServeHTTP(rr, httptest.NewRequest(http.MethodGet, "/assets/view-OldHash.js", nil))
+
+	if rr.Code != http.StatusNotFound {
+		t.Fatalf("missing asset status = %d, want 404", rr.Code)
+	}
+	if ct := rr.Header().Get("Content-Type"); strings.Contains(ct, "text/html") {
+		t.Fatalf("missing asset served as HTML (%q), the SPA fallback must not swallow /assets/", ct)
+	}
+
+	// Non-asset app routes still get the shell.
+	rr = httptest.NewRecorder()
+	handler.ServeHTTP(rr, httptest.NewRequest(http.MethodGet, "/library/ebooks", nil))
+	if rr.Code != http.StatusOK || !strings.Contains(rr.Header().Get("Content-Type"), "text/html") {
+		t.Fatalf("SPA route = %d %q, want 200 HTML", rr.Code, rr.Header().Get("Content-Type"))
+	}
+}
+
 func newFrontendTestHandler(t *testing.T) http.Handler {
 	t.Helper()
 	prev := WebDistFS

--- a/internal/taskmanager/tasks/sync_ebook_metadata.go
+++ b/internal/taskmanager/tasks/sync_ebook_metadata.go
@@ -231,6 +231,7 @@ func addEbookEnrichmentResult(total *ebooks.EnrichmentRunResult, batch ebooks.En
 	total.NoMatch += batch.NoMatch
 	total.Failed += batch.Failed
 	total.Deferred += batch.Deferred
+	total.Discarded += batch.Discarded
 }
 
 func reportEbookEnrichmentProgress(
@@ -246,12 +247,13 @@ func reportEbookEnrichmentProgress(
 		percent = 100
 	}
 	progress.Report(percent, fmt.Sprintf(
-		"Claimed %d, enriched %d, no match %d, failed %d, deferred %d, remaining %d",
+		"Claimed %d, enriched %d, no match %d, failed %d, deferred %d, discarded %d, remaining %d",
 		result.Claimed,
 		result.Enriched,
 		result.NoMatch,
 		result.Failed,
 		result.Deferred,
+		result.Discarded,
 		result.Remaining,
 	))
 }
@@ -287,13 +289,14 @@ func reportEbookEnrichmentPause(
 		percent = 99
 	}
 	progress.Report(percent, fmt.Sprintf(
-		"%s Claimed %d, enriched %d, no match %d, failed %d, deferred %d, remaining %d",
+		"%s Claimed %d, enriched %d, no match %d, failed %d, deferred %d, discarded %d, remaining %d",
 		message,
 		result.Claimed,
 		result.Enriched,
 		result.NoMatch,
 		result.Failed,
 		result.Deferred,
+		result.Discarded,
 		result.Remaining,
 	))
 }

--- a/internal/taskmanager/tasks/sync_ebook_metadata.go
+++ b/internal/taskmanager/tasks/sync_ebook_metadata.go
@@ -3,6 +3,7 @@ package tasks
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"os"
 	"strconv"
@@ -20,7 +21,8 @@ const (
 )
 
 type ebookMetadataEnricher interface {
-	Run(ctx context.Context, scope ebooks.EnrichmentScope) (ebooks.EnrichmentRunResult, error)
+	ReadyCount(ctx context.Context, scope ebooks.EnrichmentScope) (int, error)
+	RunLimited(ctx context.Context, scope ebooks.EnrichmentScope, maxClaims int) (ebooks.EnrichmentRunResult, error)
 }
 
 type ebookMetadataTask struct {
@@ -36,6 +38,7 @@ type ebookMetadataTask struct {
 	batchDelay  time.Duration
 	sleep       func(context.Context, time.Duration) error
 	errorPrefix string
+	configErr   error
 }
 
 // SyncEbookMetadataTask drains new and recurring ebook metadata work.
@@ -63,6 +66,8 @@ func NewSyncEbookMetadataTask(enricher ebookMetadataEnricher) *SyncEbookMetadata
 }
 
 func NewBackfillEbookMetadataTask(enricher ebookMetadataEnricher) *BackfillEbookMetadataTask {
+	maxClaims, maxClaimsErr := parseEbookBackfillMaxClaims(os.Getenv(ebookBackfillMaxClaimsEnv))
+	batchDelay, batchDelayErr := parseEbookBackfillBatchDelay(os.Getenv(ebookBackfillBatchDelayEnv))
 	return &BackfillEbookMetadataTask{ebookMetadataTask: &ebookMetadataTask{
 		enricher:    enricher,
 		scope:       ebooks.EnrichmentScopeLegacy,
@@ -71,10 +76,11 @@ func NewBackfillEbookMetadataTask(enricher ebookMetadataEnricher) *BackfillEbook
 		description: "Manually enriches the legacy ebook backlog without competing with scheduled metadata sync",
 		budget:      ebookMetadataExecutionBudget,
 		now:         time.Now,
-		maxClaims:   parseEbookBackfillMaxClaims(os.Getenv(ebookBackfillMaxClaimsEnv)),
-		batchDelay:  parseEbookBackfillBatchDelay(os.Getenv(ebookBackfillBatchDelayEnv)),
+		maxClaims:   maxClaims,
+		batchDelay:  batchDelay,
 		sleep:       sleepEbookBackfill,
 		errorPrefix: "ebook metadata backfill",
+		configErr:   errors.Join(maxClaimsErr, batchDelayErr),
 	}}
 }
 
@@ -91,20 +97,40 @@ func (t *ebookMetadataTask) DefaultTriggers() []taskmanager.TriggerConfig {
 }
 
 func (t *ebookMetadataTask) Execute(ctx context.Context, progress taskmanager.ProgressReporter) error {
+	if t.configErr != nil {
+		return fmt.Errorf("invalid ebook backfill configuration: %w", t.configErr)
+	}
 	progress.Report(0, fmt.Sprintf("%s started", t.name))
 	started := t.now()
-	total := ebooks.EnrichmentRunResult{}
+	initialReady, err := t.enricher.ReadyCount(ctx, t.scope)
+	if err != nil {
+		return fmt.Errorf("%s: count initial work: %w", t.errorPrefix, err)
+	}
+	total := ebooks.EnrichmentRunResult{Remaining: initialReady}
 
 	for {
 		if err := ctx.Err(); err != nil {
 			return err
 		}
 
-		batch, err := t.enricher.Run(ctx, t.scope)
+		claimLimit := 0
+		if t.maxClaims > 0 {
+			claimLimit = t.maxClaims - total.Claimed
+			if claimLimit <= 0 {
+				reportEbookEnrichmentPause(progress, total, fmt.Sprintf(
+					"Paused after reaching manual backfill claim cap of %d; remaining work will retry later.",
+					t.maxClaims,
+				))
+				return nil
+			}
+		}
+		batch, err := t.enricher.RunLimited(ctx, t.scope, claimLimit)
 		if err != nil {
 			return fmt.Errorf("%s: %w", t.errorPrefix, err)
 		}
 		addEbookEnrichmentResult(&total, batch)
+		total.Remaining = max(total.Remaining-batch.Claimed, 0)
+		total.HasMore = batch.HasMore
 		reportEbookEnrichmentProgress(progress, total, false)
 
 		if err := ctx.Err(); err != nil {
@@ -114,7 +140,7 @@ func (t *ebookMetadataTask) Execute(ctx context.Context, progress taskmanager.Pr
 			reportEbookEnrichmentCircuitBreak(progress, total)
 			return nil
 		}
-		if batch.Remaining == 0 {
+		if !batch.HasMore {
 			reportEbookEnrichmentProgress(progress, total, true)
 			return nil
 		}
@@ -122,7 +148,6 @@ func (t *ebookMetadataTask) Execute(ctx context.Context, progress taskmanager.Pr
 			return nil
 		}
 		if t.maxClaims > 0 && total.Claimed >= t.maxClaims {
-			deferEbookEnrichmentRemaining(&total)
 			reportEbookEnrichmentPause(progress, total, fmt.Sprintf(
 				"Paused after reaching manual backfill claim cap of %d; remaining work will retry later.",
 				t.maxClaims,
@@ -130,13 +155,11 @@ func (t *ebookMetadataTask) Execute(ctx context.Context, progress taskmanager.Pr
 			return nil
 		}
 		if t.now().Sub(started) >= t.budget {
-			deferEbookEnrichmentRemaining(&total)
 			reportEbookEnrichmentProgress(progress, total, false)
 			return nil
 		}
 		if t.batchDelay > 0 && ebookEnrichmentBatchMadeProgress(batch) {
 			if t.batchDelay >= t.budget-t.now().Sub(started) {
-				deferEbookEnrichmentRemaining(&total)
 				reportEbookEnrichmentPause(progress, total,
 					"Paused before the next batch because its delay would exceed the ebook metadata execution budget; remaining work will retry later.")
 				return nil
@@ -148,7 +171,6 @@ func (t *ebookMetadataTask) Execute(ctx context.Context, progress taskmanager.Pr
 				return err
 			}
 			if t.now().Sub(started) >= t.budget {
-				deferEbookEnrichmentRemaining(&total)
 				reportEbookEnrichmentPause(progress, total,
 					"Paused after reaching the ebook metadata execution budget; remaining work will retry later.")
 				return nil
@@ -157,20 +179,28 @@ func (t *ebookMetadataTask) Execute(ctx context.Context, progress taskmanager.Pr
 	}
 }
 
-func parseEbookBackfillMaxClaims(raw string) int {
-	value, err := strconv.Atoi(strings.TrimSpace(raw))
-	if err != nil || value <= 0 {
-		return 0
+func parseEbookBackfillMaxClaims(raw string) (int, error) {
+	raw = strings.TrimSpace(raw)
+	if raw == "" {
+		return 0, nil
 	}
-	return value
+	value, err := strconv.Atoi(raw)
+	if err != nil || value <= 0 {
+		return 0, fmt.Errorf("%s must be a positive integer, got %q", ebookBackfillMaxClaimsEnv, raw)
+	}
+	return value, nil
 }
 
-func parseEbookBackfillBatchDelay(raw string) time.Duration {
-	value, err := time.ParseDuration(strings.TrimSpace(raw))
-	if err != nil || value <= 0 {
-		return 0
+func parseEbookBackfillBatchDelay(raw string) (time.Duration, error) {
+	raw = strings.TrimSpace(raw)
+	if raw == "" {
+		return 0, nil
 	}
-	return value
+	value, err := time.ParseDuration(raw)
+	if err != nil || value <= 0 {
+		return 0, fmt.Errorf("%s must be a positive Go duration, got %q", ebookBackfillBatchDelayEnv, raw)
+	}
+	return value, nil
 }
 
 func sleepEbookBackfill(ctx context.Context, delay time.Duration) error {
@@ -195,17 +225,12 @@ func ebookEnrichmentBatchMadeProgress(batch ebooks.EnrichmentRunResult) bool {
 	return batch.Enriched > 0 || batch.NoMatch > 0
 }
 
-func deferEbookEnrichmentRemaining(result *ebooks.EnrichmentRunResult) {
-	result.Deferred += result.Remaining
-}
-
 func addEbookEnrichmentResult(total *ebooks.EnrichmentRunResult, batch ebooks.EnrichmentRunResult) {
 	total.Claimed += batch.Claimed
 	total.Enriched += batch.Enriched
 	total.NoMatch += batch.NoMatch
 	total.Failed += batch.Failed
 	total.Deferred += batch.Deferred
-	total.Remaining = batch.Remaining
 }
 
 func reportEbookEnrichmentProgress(
@@ -275,6 +300,9 @@ func reportEbookEnrichmentPause(
 
 func ebookEnrichmentPercent(result ebooks.EnrichmentRunResult) float64 {
 	if result.Remaining == 0 {
+		if result.HasMore {
+			return 99
+		}
 		return 100
 	}
 	total := result.Claimed + result.Remaining

--- a/internal/taskmanager/tasks/sync_ebook_metadata.go
+++ b/internal/taskmanager/tasks/sync_ebook_metadata.go
@@ -97,6 +97,10 @@ func (t *ebookMetadataTask) Execute(ctx context.Context, progress taskmanager.Pr
 		if err := ctx.Err(); err != nil {
 			return err
 		}
+		if ebookEnrichmentBatchMadeNoProgress(batch) {
+			reportEbookEnrichmentCircuitBreak(progress, total)
+			return nil
+		}
 		if batch.Remaining == 0 {
 			reportEbookEnrichmentProgress(progress, total, true)
 			return nil
@@ -110,6 +114,13 @@ func (t *ebookMetadataTask) Execute(ctx context.Context, progress taskmanager.Pr
 			return nil
 		}
 	}
+}
+
+func ebookEnrichmentBatchMadeNoProgress(batch ebooks.EnrichmentRunResult) bool {
+	return batch.Claimed > 0 &&
+		batch.Enriched == 0 &&
+		batch.NoMatch == 0 &&
+		batch.Failed+batch.Deferred >= batch.Claimed
 }
 
 func addEbookEnrichmentResult(total *ebooks.EnrichmentRunResult, batch ebooks.EnrichmentRunResult) {
@@ -138,6 +149,25 @@ func reportEbookEnrichmentProgress(
 		result.Claimed,
 		result.Enriched,
 		result.NoMatch,
+		result.Failed,
+		result.Deferred,
+		result.Remaining,
+	))
+}
+
+func reportEbookEnrichmentCircuitBreak(
+	progress taskmanager.ProgressReporter,
+	result ebooks.EnrichmentRunResult,
+) {
+	data, _ := json.Marshal(result)
+	progress.SetResultData(data)
+	percent := ebookEnrichmentPercent(result)
+	if percent >= 100 {
+		percent = 99
+	}
+	progress.Report(percent, fmt.Sprintf(
+		"Paused after a full batch made no progress; remaining work will retry later. Claimed %d, failed %d, deferred %d, remaining %d",
+		result.Claimed,
 		result.Failed,
 		result.Deferred,
 		result.Remaining,

--- a/internal/taskmanager/tasks/sync_ebook_metadata.go
+++ b/internal/taskmanager/tasks/sync_ebook_metadata.go
@@ -46,7 +46,9 @@ type SyncEbookMetadataTask struct {
 	*ebookMetadataTask
 }
 
-// BackfillEbookMetadataTask drains the legacy ebook backlog only when manually run.
+// BackfillEbookMetadataTask drains the legacy ebook backlog on its own
+// interval, isolated from the scheduled sync lane so backlog work never
+// competes with fresh-item enrichment.
 type BackfillEbookMetadataTask struct {
 	*ebookMetadataTask
 }
@@ -73,7 +75,8 @@ func NewBackfillEbookMetadataTask(enricher ebookMetadataEnricher) *BackfillEbook
 		scope:       ebooks.EnrichmentScopeLegacy,
 		key:         "backfill_ebook_metadata",
 		name:        "Backfill Ebook Metadata",
-		description: "Manually enriches the legacy ebook backlog without competing with scheduled metadata sync",
+		description: "Enriches the legacy ebook backlog without competing with scheduled metadata sync",
+		triggers:    []taskmanager.TriggerConfig{{Type: taskmanager.TriggerTypeInterval, IntervalMs: 15 * 60 * 1000}},
 		budget:      ebookMetadataExecutionBudget,
 		now:         time.Now,
 		maxClaims:   maxClaims,

--- a/internal/taskmanager/tasks/sync_ebook_metadata.go
+++ b/internal/taskmanager/tasks/sync_ebook_metadata.go
@@ -4,53 +4,157 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"time"
 
+	"github.com/Silo-Server/silo-server/internal/ebooks"
 	"github.com/Silo-Server/silo-server/internal/taskmanager"
 )
 
+const ebookMetadataExecutionBudget = 4 * time.Minute
+
 type ebookMetadataEnricher interface {
-	Run(ctx context.Context) (int, error)
+	Run(ctx context.Context, scope ebooks.EnrichmentScope) (ebooks.EnrichmentRunResult, error)
 }
 
-// SyncEbookMetadataTask runs the periodic ebook enrichment sweep.
-// It calls ebooks.Enricher.Run() which selects unenriched ebook media_items,
-// resolves the per-folder metadata-provider chain at content_level='ebook',
-// and writes results back to the database.
+type ebookMetadataTask struct {
+	enricher    ebookMetadataEnricher
+	scope       ebooks.EnrichmentScope
+	key         string
+	name        string
+	description string
+	triggers    []taskmanager.TriggerConfig
+	budget      time.Duration
+	now         func() time.Time
+	errorPrefix string
+}
+
+// SyncEbookMetadataTask drains new and recurring ebook metadata work.
 type SyncEbookMetadataTask struct {
-	enricher ebookMetadataEnricher
+	*ebookMetadataTask
 }
 
-// NewSyncEbookMetadataTask constructs the task.
+// BackfillEbookMetadataTask drains the legacy ebook backlog only when manually run.
+type BackfillEbookMetadataTask struct {
+	*ebookMetadataTask
+}
+
 func NewSyncEbookMetadataTask(enricher ebookMetadataEnricher) *SyncEbookMetadataTask {
-	return &SyncEbookMetadataTask{enricher: enricher}
+	return &SyncEbookMetadataTask{ebookMetadataTask: &ebookMetadataTask{
+		enricher:    enricher,
+		scope:       ebooks.EnrichmentScopeIncremental,
+		key:         "sync_ebook_metadata",
+		name:        "Sync Ebook Metadata",
+		description: "Fetches metadata for new ebooks and ebooks due for a recurring refresh",
+		triggers:    []taskmanager.TriggerConfig{{Type: taskmanager.TriggerTypeInterval, IntervalMs: 5 * 60 * 1000}},
+		budget:      ebookMetadataExecutionBudget,
+		now:         time.Now,
+		errorPrefix: "ebook metadata sync",
+	}}
 }
 
-func (t *SyncEbookMetadataTask) Key() string  { return "sync_ebook_metadata" }
-func (t *SyncEbookMetadataTask) Name() string { return "Sync Ebook Metadata" }
-func (t *SyncEbookMetadataTask) Description() string {
-	return "Fetches metadata (cover art, overview, authors) for ebooks that have not yet been enriched"
+func NewBackfillEbookMetadataTask(enricher ebookMetadataEnricher) *BackfillEbookMetadataTask {
+	return &BackfillEbookMetadataTask{ebookMetadataTask: &ebookMetadataTask{
+		enricher:    enricher,
+		scope:       ebooks.EnrichmentScopeLegacy,
+		key:         "backfill_ebook_metadata",
+		name:        "Backfill Ebook Metadata",
+		description: "Manually enriches the legacy ebook backlog without competing with scheduled metadata sync",
+		budget:      ebookMetadataExecutionBudget,
+		now:         time.Now,
+		errorPrefix: "ebook metadata backfill",
+	}}
 }
-func (t *SyncEbookMetadataTask) Category() taskmanager.TaskCategory {
+
+func (t *ebookMetadataTask) Key() string         { return t.key }
+func (t *ebookMetadataTask) Name() string        { return t.name }
+func (t *ebookMetadataTask) Description() string { return t.description }
+func (t *ebookMetadataTask) Category() taskmanager.TaskCategory {
 	return taskmanager.TaskCategoryMetadata
 }
-func (t *SyncEbookMetadataTask) IsHidden() bool { return false }
+func (t *ebookMetadataTask) IsHidden() bool { return false }
 
-func (t *SyncEbookMetadataTask) DefaultTriggers() []taskmanager.TriggerConfig {
-	return []taskmanager.TriggerConfig{
-		{Type: taskmanager.TriggerTypeInterval, IntervalMs: 5 * 60 * 1000},
+func (t *ebookMetadataTask) DefaultTriggers() []taskmanager.TriggerConfig {
+	return append([]taskmanager.TriggerConfig(nil), t.triggers...)
+}
+
+func (t *ebookMetadataTask) Execute(ctx context.Context, progress taskmanager.ProgressReporter) error {
+	progress.Report(0, fmt.Sprintf("%s started", t.name))
+	started := t.now()
+	total := ebooks.EnrichmentRunResult{}
+
+	for {
+		if err := ctx.Err(); err != nil {
+			return err
+		}
+
+		batch, err := t.enricher.Run(ctx, t.scope)
+		if err != nil {
+			return fmt.Errorf("%s: %w", t.errorPrefix, err)
+		}
+		addEbookEnrichmentResult(&total, batch)
+		reportEbookEnrichmentProgress(progress, total, false)
+
+		if err := ctx.Err(); err != nil {
+			return err
+		}
+		if batch.Remaining == 0 {
+			reportEbookEnrichmentProgress(progress, total, true)
+			return nil
+		}
+		if batch.Claimed == 0 {
+			return nil
+		}
+		if t.now().Sub(started) >= t.budget {
+			total.Deferred += total.Remaining
+			reportEbookEnrichmentProgress(progress, total, false)
+			return nil
+		}
 	}
 }
 
-func (t *SyncEbookMetadataTask) Execute(ctx context.Context, progress taskmanager.ProgressReporter) error {
-	progress.Report(0, "Scanning for unenriched ebooks")
+func addEbookEnrichmentResult(total *ebooks.EnrichmentRunResult, batch ebooks.EnrichmentRunResult) {
+	total.Claimed += batch.Claimed
+	total.Enriched += batch.Enriched
+	total.NoMatch += batch.NoMatch
+	total.Failed += batch.Failed
+	total.Deferred += batch.Deferred
+	total.Remaining = batch.Remaining
+}
 
-	enriched, err := t.enricher.Run(ctx)
-	if err != nil {
-		return fmt.Errorf("ebook metadata sync: %w", err)
+func reportEbookEnrichmentProgress(
+	progress taskmanager.ProgressReporter,
+	result ebooks.EnrichmentRunResult,
+	complete bool,
+) {
+	data, _ := json.Marshal(result)
+	progress.SetResultData(data)
+
+	percent := ebookEnrichmentPercent(result)
+	if complete && result.Remaining == 0 {
+		percent = 100
 	}
+	progress.Report(percent, fmt.Sprintf(
+		"Claimed %d, enriched %d, no match %d, failed %d, deferred %d, remaining %d",
+		result.Claimed,
+		result.Enriched,
+		result.NoMatch,
+		result.Failed,
+		result.Deferred,
+		result.Remaining,
+	))
+}
 
-	result, _ := json.Marshal(map[string]int{"items_enriched": enriched})
-	progress.SetResultData(result)
-	progress.Report(100, fmt.Sprintf("Ebook metadata sync complete (%d items enriched)", enriched))
-	return nil
+func ebookEnrichmentPercent(result ebooks.EnrichmentRunResult) float64 {
+	if result.Remaining == 0 {
+		return 100
+	}
+	total := result.Claimed + result.Remaining
+	if total <= 0 {
+		return 0
+	}
+	percent := float64(result.Claimed) * 100 / float64(total)
+	if percent >= 100 {
+		return 99
+	}
+	return percent
 }

--- a/internal/taskmanager/tasks/sync_ebook_metadata.go
+++ b/internal/taskmanager/tasks/sync_ebook_metadata.go
@@ -4,13 +4,20 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"os"
+	"strconv"
+	"strings"
 	"time"
 
 	"github.com/Silo-Server/silo-server/internal/ebooks"
 	"github.com/Silo-Server/silo-server/internal/taskmanager"
 )
 
-const ebookMetadataExecutionBudget = 4 * time.Minute
+const (
+	ebookMetadataExecutionBudget = 4 * time.Minute
+	ebookBackfillMaxClaimsEnv    = "SILO_EBOOK_BACKFILL_MAX_CLAIMS"
+	ebookBackfillBatchDelayEnv   = "SILO_EBOOK_BACKFILL_BATCH_DELAY"
+)
 
 type ebookMetadataEnricher interface {
 	Run(ctx context.Context, scope ebooks.EnrichmentScope) (ebooks.EnrichmentRunResult, error)
@@ -25,6 +32,9 @@ type ebookMetadataTask struct {
 	triggers    []taskmanager.TriggerConfig
 	budget      time.Duration
 	now         func() time.Time
+	maxClaims   int
+	batchDelay  time.Duration
+	sleep       func(context.Context, time.Duration) error
 	errorPrefix string
 }
 
@@ -61,6 +71,9 @@ func NewBackfillEbookMetadataTask(enricher ebookMetadataEnricher) *BackfillEbook
 		description: "Manually enriches the legacy ebook backlog without competing with scheduled metadata sync",
 		budget:      ebookMetadataExecutionBudget,
 		now:         time.Now,
+		maxClaims:   parseEbookBackfillMaxClaims(os.Getenv(ebookBackfillMaxClaimsEnv)),
+		batchDelay:  parseEbookBackfillBatchDelay(os.Getenv(ebookBackfillBatchDelayEnv)),
+		sleep:       sleepEbookBackfill,
 		errorPrefix: "ebook metadata backfill",
 	}}
 }
@@ -108,11 +121,66 @@ func (t *ebookMetadataTask) Execute(ctx context.Context, progress taskmanager.Pr
 		if batch.Claimed == 0 {
 			return nil
 		}
+		if t.maxClaims > 0 && total.Claimed >= t.maxClaims {
+			deferEbookEnrichmentRemaining(&total)
+			reportEbookEnrichmentPause(progress, total, fmt.Sprintf(
+				"Paused after reaching manual backfill claim cap of %d; remaining work will retry later.",
+				t.maxClaims,
+			))
+			return nil
+		}
 		if t.now().Sub(started) >= t.budget {
-			total.Deferred += total.Remaining
+			deferEbookEnrichmentRemaining(&total)
 			reportEbookEnrichmentProgress(progress, total, false)
 			return nil
 		}
+		if t.batchDelay > 0 && ebookEnrichmentBatchMadeProgress(batch) {
+			if t.batchDelay >= t.budget-t.now().Sub(started) {
+				deferEbookEnrichmentRemaining(&total)
+				reportEbookEnrichmentPause(progress, total,
+					"Paused before the next batch because its delay would exceed the ebook metadata execution budget; remaining work will retry later.")
+				return nil
+			}
+			if err := t.sleep(ctx, t.batchDelay); err != nil {
+				return err
+			}
+			if err := ctx.Err(); err != nil {
+				return err
+			}
+			if t.now().Sub(started) >= t.budget {
+				deferEbookEnrichmentRemaining(&total)
+				reportEbookEnrichmentPause(progress, total,
+					"Paused after reaching the ebook metadata execution budget; remaining work will retry later.")
+				return nil
+			}
+		}
+	}
+}
+
+func parseEbookBackfillMaxClaims(raw string) int {
+	value, err := strconv.Atoi(strings.TrimSpace(raw))
+	if err != nil || value <= 0 {
+		return 0
+	}
+	return value
+}
+
+func parseEbookBackfillBatchDelay(raw string) time.Duration {
+	value, err := time.ParseDuration(strings.TrimSpace(raw))
+	if err != nil || value <= 0 {
+		return 0
+	}
+	return value
+}
+
+func sleepEbookBackfill(ctx context.Context, delay time.Duration) error {
+	timer := time.NewTimer(delay)
+	defer timer.Stop()
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	case <-timer.C:
+		return nil
 	}
 }
 
@@ -121,6 +189,14 @@ func ebookEnrichmentBatchMadeNoProgress(batch ebooks.EnrichmentRunResult) bool {
 		batch.Enriched == 0 &&
 		batch.NoMatch == 0 &&
 		batch.Failed+batch.Deferred >= batch.Claimed
+}
+
+func ebookEnrichmentBatchMadeProgress(batch ebooks.EnrichmentRunResult) bool {
+	return batch.Enriched > 0 || batch.NoMatch > 0
+}
+
+func deferEbookEnrichmentRemaining(result *ebooks.EnrichmentRunResult) {
+	result.Deferred += result.Remaining
 }
 
 func addEbookEnrichmentResult(total *ebooks.EnrichmentRunResult, batch ebooks.EnrichmentRunResult) {
@@ -168,6 +244,29 @@ func reportEbookEnrichmentCircuitBreak(
 	progress.Report(percent, fmt.Sprintf(
 		"Paused after a full batch made no progress; remaining work will retry later. Claimed %d, failed %d, deferred %d, remaining %d",
 		result.Claimed,
+		result.Failed,
+		result.Deferred,
+		result.Remaining,
+	))
+}
+
+func reportEbookEnrichmentPause(
+	progress taskmanager.ProgressReporter,
+	result ebooks.EnrichmentRunResult,
+	message string,
+) {
+	data, _ := json.Marshal(result)
+	progress.SetResultData(data)
+	percent := ebookEnrichmentPercent(result)
+	if percent >= 100 {
+		percent = 99
+	}
+	progress.Report(percent, fmt.Sprintf(
+		"%s Claimed %d, enriched %d, no match %d, failed %d, deferred %d, remaining %d",
+		message,
+		result.Claimed,
+		result.Enriched,
+		result.NoMatch,
 		result.Failed,
 		result.Deferred,
 		result.Remaining,

--- a/internal/taskmanager/tasks/sync_ebook_metadata_test.go
+++ b/internal/taskmanager/tasks/sync_ebook_metadata_test.go
@@ -90,8 +90,11 @@ func TestEbookMetadataTaskPropertiesAndScopes(t *testing.T) {
 	if len(triggers) != 1 || triggers[0].Type != taskmanager.TriggerTypeInterval || triggers[0].IntervalMs != 5*60*1000 {
 		t.Fatalf("sync DefaultTriggers() = %#v", triggers)
 	}
-	if triggers := backfillTask.DefaultTriggers(); len(triggers) != 0 {
-		t.Fatalf("backfill DefaultTriggers() = %#v, want none", triggers)
+	backfillTriggers := backfillTask.DefaultTriggers()
+	if len(backfillTriggers) != 1 ||
+		backfillTriggers[0].Type != taskmanager.TriggerTypeInterval ||
+		backfillTriggers[0].IntervalMs != 15*60*1000 {
+		t.Fatalf("backfill DefaultTriggers() = %#v, want a 15m interval", backfillTriggers)
 	}
 }
 

--- a/internal/taskmanager/tasks/sync_ebook_metadata_test.go
+++ b/internal/taskmanager/tasks/sync_ebook_metadata_test.go
@@ -13,14 +13,30 @@ import (
 )
 
 type fakeEbookMetadataEnricher struct {
-	results []ebooks.EnrichmentRunResult
-	err     error
-	scopes  []ebooks.EnrichmentScope
-	onRun   func(int)
+	results         []ebooks.EnrichmentRunResult
+	err             error
+	countErr        error
+	scopes          []ebooks.EnrichmentScope
+	limits          []int
+	readyCountCalls int
+	initialReady    int
+	onRun           func(int)
 }
 
-func (f *fakeEbookMetadataEnricher) Run(_ context.Context, scope ebooks.EnrichmentScope) (ebooks.EnrichmentRunResult, error) {
+func (f *fakeEbookMetadataEnricher) ReadyCount(_ context.Context, _ ebooks.EnrichmentScope) (int, error) {
+	f.readyCountCalls++
+	if f.countErr != nil {
+		return 0, f.countErr
+	}
+	if f.initialReady > 0 || len(f.results) == 0 {
+		return f.initialReady, nil
+	}
+	return f.results[0].Claimed + f.results[0].Remaining, nil
+}
+
+func (f *fakeEbookMetadataEnricher) RunLimited(_ context.Context, scope ebooks.EnrichmentScope, limit int) (ebooks.EnrichmentRunResult, error) {
 	f.scopes = append(f.scopes, scope)
+	f.limits = append(f.limits, limit)
 	call := len(f.scopes)
 	if f.onRun != nil {
 		f.onRun(call)
@@ -31,7 +47,9 @@ func (f *fakeEbookMetadataEnricher) Run(_ context.Context, scope ebooks.Enrichme
 	if call > len(f.results) {
 		return ebooks.EnrichmentRunResult{}, nil
 	}
-	return f.results[call-1], nil
+	result := f.results[call-1]
+	result.HasMore = result.Remaining > 0
+	return result, nil
 }
 
 type ebookMetadataProgressReporter struct {
@@ -91,6 +109,9 @@ func TestEbookMetadataTaskDrainsBatchesAndReportsHonestProgress(t *testing.T) {
 	if len(enricher.scopes) != 2 {
 		t.Fatalf("Run calls = %d, want 2", len(enricher.scopes))
 	}
+	if enricher.readyCountCalls != 1 {
+		t.Fatalf("initial exact ready counts = %d, want 1", enricher.readyCountCalls)
+	}
 	for _, scope := range enricher.scopes {
 		if scope != ebooks.EnrichmentScopeIncremental {
 			t.Fatalf("sync scope = %q, want incremental", scope)
@@ -109,6 +130,24 @@ func TestEbookMetadataTaskDrainsBatchesAndReportsHonestProgress(t *testing.T) {
 	}
 	if got := progress.percents[len(progress.percents)-1]; got != 100 {
 		t.Fatalf("final progress = %.1f, want 100", got)
+	}
+}
+
+func TestEbookMetadataTaskDoesNotReportCompleteWhileBoundedCheckFindsMoreWork(t *testing.T) {
+	enricher := &fakeEbookMetadataEnricher{
+		initialReady: 1,
+		results: []ebooks.EnrichmentRunResult{
+			{Claimed: 1, Enriched: 1, Remaining: 1},
+			{Claimed: 1, Enriched: 1},
+		},
+	}
+	progress := &ebookMetadataProgressReporter{}
+
+	if err := NewSyncEbookMetadataTask(enricher).Execute(context.Background(), progress); err != nil {
+		t.Fatalf("Execute() error = %v", err)
+	}
+	if got := progress.percents[1]; got >= 100 {
+		t.Fatalf("first batch progress = %.1f, must stay below 100 while HasMore is true", got)
 	}
 }
 
@@ -166,7 +205,6 @@ func TestEbookMetadataTaskContinuesAfterMixedBatchWithProgress(t *testing.T) {
 
 func TestEbookMetadataBackfillStopsAtClaimCap(t *testing.T) {
 	t.Setenv("SILO_EBOOK_BACKFILL_MAX_CLAIMS", "4")
-	t.Setenv("SILO_EBOOK_BACKFILL_BATCH_DELAY", "0")
 	enricher := &fakeEbookMetadataEnricher{results: []ebooks.EnrichmentRunResult{
 		{Claimed: 2, Enriched: 2, Remaining: 10},
 		{Claimed: 2, Enriched: 2, Remaining: 8},
@@ -184,7 +222,7 @@ func TestEbookMetadataBackfillStopsAtClaimCap(t *testing.T) {
 	if err := json.Unmarshal(progress.results[len(progress.results)-1], &result); err != nil {
 		t.Fatalf("result JSON error: %v", err)
 	}
-	want := ebooks.EnrichmentRunResult{Claimed: 4, Enriched: 4, Deferred: 8, Remaining: 8}
+	want := ebooks.EnrichmentRunResult{Claimed: 4, Enriched: 4, Remaining: 8}
 	if result != want {
 		t.Fatalf("result JSON = %+v, want %+v", result, want)
 	}
@@ -194,6 +232,21 @@ func TestEbookMetadataBackfillStopsAtClaimCap(t *testing.T) {
 	message := strings.ToLower(progress.messages[len(progress.messages)-1])
 	if !strings.Contains(message, "claim cap") || !strings.Contains(message, "retry later") {
 		t.Fatalf("claim-cap progress message = %q", message)
+	}
+}
+
+func TestEbookMetadataBackfillPassesRemainingClaimAllowanceToEnricher(t *testing.T) {
+	t.Setenv("SILO_EBOOK_BACKFILL_MAX_CLAIMS", "3")
+	enricher := &fakeEbookMetadataEnricher{results: []ebooks.EnrichmentRunResult{
+		{Claimed: 2, Enriched: 2, Remaining: 8},
+		{Claimed: 1, Enriched: 1, Remaining: 7},
+	}}
+
+	if err := NewBackfillEbookMetadataTask(enricher).Execute(context.Background(), &ebookMetadataProgressReporter{}); err != nil {
+		t.Fatalf("Execute() error = %v", err)
+	}
+	if got := enricher.limits; len(got) != 2 || got[0] != 3 || got[1] != 1 {
+		t.Fatalf("claim limits = %v, want [3 1]", got)
 	}
 }
 
@@ -275,30 +328,50 @@ func TestEbookMetadataBackfillDoesNotDelayPastExecutionBudget(t *testing.T) {
 	}
 }
 
-func TestEbookMetadataBackfillInvalidEnvironmentFallsBackToDisabledControls(t *testing.T) {
+func TestEbookMetadataBackfillInvalidNonemptyEnvironmentFailsClosed(t *testing.T) {
 	for _, tc := range []struct {
-		name     string
-		max      string
-		delay    string
-		wantMax  int
-		wantWait time.Duration
+		name  string
+		max   string
+		delay string
 	}{
-		{name: "empty", max: "", delay: ""},
 		{name: "malformed", max: "many", delay: "later"},
 		{name: "negative", max: "-5", delay: "-1s"},
 		{name: "zero", max: "0", delay: "0"},
-		{name: "trimmed valid", max: " 20 ", delay: " 1s ", wantMax: 20, wantWait: time.Second},
+		{name: "invalid max only", max: "many", delay: "1s"},
+		{name: "invalid delay only", max: "20", delay: "later"},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Setenv("SILO_EBOOK_BACKFILL_MAX_CLAIMS", tc.max)
 			t.Setenv("SILO_EBOOK_BACKFILL_BATCH_DELAY", tc.delay)
-			task := NewBackfillEbookMetadataTask(&fakeEbookMetadataEnricher{})
-			if task.maxClaims != tc.wantMax || task.batchDelay != tc.wantWait {
-				t.Fatalf("controls = (%d, %s), want (%d, %s)",
-					task.maxClaims, task.batchDelay, tc.wantMax, tc.wantWait)
+			enricher := &fakeEbookMetadataEnricher{}
+			err := NewBackfillEbookMetadataTask(enricher).Execute(context.Background(), &ebookMetadataProgressReporter{})
+			if err == nil || !strings.Contains(err.Error(), "invalid ebook backfill configuration") {
+				t.Fatalf("Execute() error = %v, want clear invalid configuration error", err)
+			}
+			if len(enricher.scopes) != 0 || enricher.readyCountCalls != 0 {
+				t.Fatalf("invalid configuration reached queue: runs=%d counts=%d", len(enricher.scopes), enricher.readyCountCalls)
 			}
 		})
 	}
+}
+
+func TestEbookMetadataBackfillUnsetAndValidEnvironment(t *testing.T) {
+	t.Run("unset", func(t *testing.T) {
+		t.Setenv("SILO_EBOOK_BACKFILL_MAX_CLAIMS", "")
+		t.Setenv("SILO_EBOOK_BACKFILL_BATCH_DELAY", "")
+		task := NewBackfillEbookMetadataTask(&fakeEbookMetadataEnricher{})
+		if task.configErr != nil || task.maxClaims != 0 || task.batchDelay != 0 {
+			t.Fatalf("unset controls = (%d, %s, %v)", task.maxClaims, task.batchDelay, task.configErr)
+		}
+	})
+	t.Run("valid", func(t *testing.T) {
+		t.Setenv("SILO_EBOOK_BACKFILL_MAX_CLAIMS", " 20 ")
+		t.Setenv("SILO_EBOOK_BACKFILL_BATCH_DELAY", " 1s ")
+		task := NewBackfillEbookMetadataTask(&fakeEbookMetadataEnricher{})
+		if task.configErr != nil || task.maxClaims != 20 || task.batchDelay != time.Second {
+			t.Fatalf("valid controls = (%d, %s, %v)", task.maxClaims, task.batchDelay, task.configErr)
+		}
+	})
 }
 
 func TestEbookMetadataSyncIgnoresBackfillCanaryEnvironment(t *testing.T) {
@@ -391,8 +464,8 @@ func TestEbookMetadataTaskTreatsBudgetAsCleanDeferredCompletion(t *testing.T) {
 	if err := json.Unmarshal(progress.results[len(progress.results)-1], &result); err != nil {
 		t.Fatalf("result JSON error: %v", err)
 	}
-	if result.Remaining != 5 || result.Deferred != 5 {
-		t.Fatalf("budget result = %+v, want remaining=5 deferred=5", result)
+	if result.Remaining != 5 || result.Deferred != 0 {
+		t.Fatalf("budget result = %+v, want remaining=5 without double-counting it as deferred", result)
 	}
 	if got := progress.percents[len(progress.percents)-1]; got >= 100 {
 		t.Fatalf("budget-limited progress = %.1f, must remain below 100", got)

--- a/internal/taskmanager/tasks/sync_ebook_metadata_test.go
+++ b/internal/taskmanager/tasks/sync_ebook_metadata_test.go
@@ -113,13 +113,20 @@ func TestEbookMetadataTaskDrainsBatchesAndReportsHonestProgress(t *testing.T) {
 }
 
 func TestEbookMetadataTaskStopsAfterOneAllFailedBatch(t *testing.T) {
+	t.Setenv("SILO_EBOOK_BACKFILL_MAX_CLAIMS", "1")
+	t.Setenv("SILO_EBOOK_BACKFILL_BATCH_DELAY", "1h")
 	enricher := &fakeEbookMetadataEnricher{results: []ebooks.EnrichmentRunResult{
 		{Claimed: 4, Failed: 4, Remaining: 100},
 		{Claimed: 4, Enriched: 4, Remaining: 96},
 	}}
 	progress := &ebookMetadataProgressReporter{}
+	task := NewBackfillEbookMetadataTask(enricher)
+	task.sleep = func(context.Context, time.Duration) error {
+		t.Fatal("no-progress batch must circuit-break before pacing")
+		return nil
+	}
 
-	if err := NewBackfillEbookMetadataTask(enricher).Execute(context.Background(), progress); err != nil {
+	if err := task.Execute(context.Background(), progress); err != nil {
 		t.Fatalf("Execute() error = %v", err)
 	}
 	assertNoProgressCircuitBreak(t, enricher, progress, ebooks.EnrichmentRunResult{
@@ -154,6 +161,152 @@ func TestEbookMetadataTaskContinuesAfterMixedBatchWithProgress(t *testing.T) {
 	}
 	if len(enricher.scopes) != 2 {
 		t.Fatalf("Run calls = %d, want 2 when a mixed batch made progress", len(enricher.scopes))
+	}
+}
+
+func TestEbookMetadataBackfillStopsAtClaimCap(t *testing.T) {
+	t.Setenv("SILO_EBOOK_BACKFILL_MAX_CLAIMS", "4")
+	t.Setenv("SILO_EBOOK_BACKFILL_BATCH_DELAY", "0")
+	enricher := &fakeEbookMetadataEnricher{results: []ebooks.EnrichmentRunResult{
+		{Claimed: 2, Enriched: 2, Remaining: 10},
+		{Claimed: 2, Enriched: 2, Remaining: 8},
+		{Claimed: 2, Enriched: 2, Remaining: 6},
+	}}
+	progress := &ebookMetadataProgressReporter{}
+
+	if err := NewBackfillEbookMetadataTask(enricher).Execute(context.Background(), progress); err != nil {
+		t.Fatalf("Execute() error = %v", err)
+	}
+	if len(enricher.scopes) != 2 {
+		t.Fatalf("Run calls = %d, want 2 at claim cap", len(enricher.scopes))
+	}
+	var result ebooks.EnrichmentRunResult
+	if err := json.Unmarshal(progress.results[len(progress.results)-1], &result); err != nil {
+		t.Fatalf("result JSON error: %v", err)
+	}
+	want := ebooks.EnrichmentRunResult{Claimed: 4, Enriched: 4, Deferred: 8, Remaining: 8}
+	if result != want {
+		t.Fatalf("result JSON = %+v, want %+v", result, want)
+	}
+	if got := progress.percents[len(progress.percents)-1]; got >= 100 {
+		t.Fatalf("claim-capped progress = %.1f, must not report completion", got)
+	}
+	message := strings.ToLower(progress.messages[len(progress.messages)-1])
+	if !strings.Contains(message, "claim cap") || !strings.Contains(message, "retry later") {
+		t.Fatalf("claim-cap progress message = %q", message)
+	}
+}
+
+func TestEbookMetadataBackfillDelaysOnlyBetweenProductiveBatches(t *testing.T) {
+	enricher := &fakeEbookMetadataEnricher{results: []ebooks.EnrichmentRunResult{
+		{Claimed: 1, Enriched: 1, Remaining: 2},
+		{Claimed: 1, NoMatch: 1, Remaining: 1},
+		{Claimed: 1, Enriched: 1, Remaining: 0},
+	}}
+	task := NewBackfillEbookMetadataTask(enricher)
+	task.batchDelay = time.Second
+	var sleeps []time.Duration
+	task.sleep = func(_ context.Context, delay time.Duration) error {
+		sleeps = append(sleeps, delay)
+		return nil
+	}
+
+	if err := task.Execute(context.Background(), &ebookMetadataProgressReporter{}); err != nil {
+		t.Fatalf("Execute() error = %v", err)
+	}
+	if len(sleeps) != 2 || sleeps[0] != time.Second || sleeps[1] != time.Second {
+		t.Fatalf("sleeps = %v, want two 1s inter-batch delays", sleeps)
+	}
+}
+
+func TestEbookMetadataBackfillCancelsDuringBatchDelay(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	enricher := &fakeEbookMetadataEnricher{results: []ebooks.EnrichmentRunResult{
+		{Claimed: 1, Enriched: 1, Remaining: 2},
+		{Claimed: 1, Enriched: 1, Remaining: 1},
+	}}
+	task := NewBackfillEbookMetadataTask(enricher)
+	task.batchDelay = time.Second
+	task.sleep = func(ctx context.Context, _ time.Duration) error {
+		cancel()
+		<-ctx.Done()
+		return ctx.Err()
+	}
+
+	err := task.Execute(ctx, &ebookMetadataProgressReporter{})
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("Execute() error = %v, want context.Canceled", err)
+	}
+	if len(enricher.scopes) != 1 {
+		t.Fatalf("Run calls = %d, want 1 before cancellation", len(enricher.scopes))
+	}
+}
+
+func TestEbookMetadataBackfillDoesNotDelayPastExecutionBudget(t *testing.T) {
+	now := time.Date(2026, 7, 19, 12, 0, 0, 0, time.UTC)
+	enricher := &fakeEbookMetadataEnricher{results: []ebooks.EnrichmentRunResult{
+		{Claimed: 1, Enriched: 1, Remaining: 2},
+		{Claimed: 1, Enriched: 1, Remaining: 1},
+	}}
+	task := NewBackfillEbookMetadataTask(enricher)
+	task.now = func() time.Time { return now }
+	task.budget = 1500 * time.Millisecond
+	task.batchDelay = time.Second
+	var sleeps int
+	task.sleep = func(_ context.Context, delay time.Duration) error {
+		sleeps++
+		now = now.Add(delay)
+		return nil
+	}
+	progress := &ebookMetadataProgressReporter{}
+
+	if err := task.Execute(context.Background(), progress); err != nil {
+		t.Fatalf("Execute() error = %v", err)
+	}
+	if sleeps != 1 {
+		t.Fatalf("sleep calls = %d, want 1 before remaining budget became too short", sleeps)
+	}
+	if len(enricher.scopes) != 2 {
+		t.Fatalf("Run calls = %d, want 2", len(enricher.scopes))
+	}
+	message := strings.ToLower(progress.messages[len(progress.messages)-1])
+	if !strings.Contains(message, "execution budget") {
+		t.Fatalf("budget progress message = %q", message)
+	}
+}
+
+func TestEbookMetadataBackfillInvalidEnvironmentFallsBackToDisabledControls(t *testing.T) {
+	for _, tc := range []struct {
+		name     string
+		max      string
+		delay    string
+		wantMax  int
+		wantWait time.Duration
+	}{
+		{name: "empty", max: "", delay: ""},
+		{name: "malformed", max: "many", delay: "later"},
+		{name: "negative", max: "-5", delay: "-1s"},
+		{name: "zero", max: "0", delay: "0"},
+		{name: "trimmed valid", max: " 20 ", delay: " 1s ", wantMax: 20, wantWait: time.Second},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Setenv("SILO_EBOOK_BACKFILL_MAX_CLAIMS", tc.max)
+			t.Setenv("SILO_EBOOK_BACKFILL_BATCH_DELAY", tc.delay)
+			task := NewBackfillEbookMetadataTask(&fakeEbookMetadataEnricher{})
+			if task.maxClaims != tc.wantMax || task.batchDelay != tc.wantWait {
+				t.Fatalf("controls = (%d, %s), want (%d, %s)",
+					task.maxClaims, task.batchDelay, tc.wantMax, tc.wantWait)
+			}
+		})
+	}
+}
+
+func TestEbookMetadataSyncIgnoresBackfillCanaryEnvironment(t *testing.T) {
+	t.Setenv("SILO_EBOOK_BACKFILL_MAX_CLAIMS", "1")
+	t.Setenv("SILO_EBOOK_BACKFILL_BATCH_DELAY", "1h")
+	task := NewSyncEbookMetadataTask(&fakeEbookMetadataEnricher{})
+	if task.maxClaims != 0 || task.batchDelay != 0 {
+		t.Fatalf("sync controls = (%d, %s), want disabled", task.maxClaims, task.batchDelay)
 	}
 }
 

--- a/internal/taskmanager/tasks/sync_ebook_metadata_test.go
+++ b/internal/taskmanager/tasks/sync_ebook_metadata_test.go
@@ -112,6 +112,81 @@ func TestEbookMetadataTaskDrainsBatchesAndReportsHonestProgress(t *testing.T) {
 	}
 }
 
+func TestEbookMetadataTaskStopsAfterOneAllFailedBatch(t *testing.T) {
+	enricher := &fakeEbookMetadataEnricher{results: []ebooks.EnrichmentRunResult{
+		{Claimed: 4, Failed: 4, Remaining: 100},
+		{Claimed: 4, Enriched: 4, Remaining: 96},
+	}}
+	progress := &ebookMetadataProgressReporter{}
+
+	if err := NewBackfillEbookMetadataTask(enricher).Execute(context.Background(), progress); err != nil {
+		t.Fatalf("Execute() error = %v", err)
+	}
+	assertNoProgressCircuitBreak(t, enricher, progress, ebooks.EnrichmentRunResult{
+		Claimed: 4, Failed: 4, Remaining: 100,
+	})
+}
+
+func TestEbookMetadataTaskStopsAfterOneAllDeferredBatch(t *testing.T) {
+	enricher := &fakeEbookMetadataEnricher{results: []ebooks.EnrichmentRunResult{
+		{Claimed: 4, Deferred: 4, Remaining: 0},
+		{Claimed: 4, Enriched: 4, Remaining: 0},
+	}}
+	progress := &ebookMetadataProgressReporter{}
+
+	if err := NewBackfillEbookMetadataTask(enricher).Execute(context.Background(), progress); err != nil {
+		t.Fatalf("Execute() error = %v", err)
+	}
+	assertNoProgressCircuitBreak(t, enricher, progress, ebooks.EnrichmentRunResult{
+		Claimed: 4, Deferred: 4, Remaining: 0,
+	})
+}
+
+func TestEbookMetadataTaskContinuesAfterMixedBatchWithProgress(t *testing.T) {
+	enricher := &fakeEbookMetadataEnricher{results: []ebooks.EnrichmentRunResult{
+		{Claimed: 4, Enriched: 1, Failed: 2, Deferred: 1, Remaining: 2},
+		{Claimed: 2, NoMatch: 2, Remaining: 0},
+	}}
+	progress := &ebookMetadataProgressReporter{}
+
+	if err := NewBackfillEbookMetadataTask(enricher).Execute(context.Background(), progress); err != nil {
+		t.Fatalf("Execute() error = %v", err)
+	}
+	if len(enricher.scopes) != 2 {
+		t.Fatalf("Run calls = %d, want 2 when a mixed batch made progress", len(enricher.scopes))
+	}
+}
+
+func assertNoProgressCircuitBreak(
+	t *testing.T,
+	enricher *fakeEbookMetadataEnricher,
+	progress *ebookMetadataProgressReporter,
+	want ebooks.EnrichmentRunResult,
+) {
+	t.Helper()
+	if len(enricher.scopes) != 1 {
+		t.Fatalf("Run calls = %d, want exactly 1", len(enricher.scopes))
+	}
+	if len(progress.results) == 0 {
+		t.Fatal("no result JSON reported")
+	}
+	var result ebooks.EnrichmentRunResult
+	if err := json.Unmarshal(progress.results[len(progress.results)-1], &result); err != nil {
+		t.Fatalf("result JSON error: %v", err)
+	}
+	if result != want {
+		t.Fatalf("result JSON = %+v, want %+v", result, want)
+	}
+	if got := progress.percents[len(progress.percents)-1]; got >= 100 {
+		t.Fatalf("circuit-break progress = %.1f, must not report completion", got)
+	}
+	message := progress.messages[len(progress.messages)-1]
+	if !strings.Contains(strings.ToLower(message), "no progress") ||
+		!strings.Contains(strings.ToLower(message), "retry later") {
+		t.Fatalf("circuit-break progress message = %q", message)
+	}
+}
+
 func TestEbookMetadataBackfillUsesLegacyScope(t *testing.T) {
 	enricher := &fakeEbookMetadataEnricher{results: []ebooks.EnrichmentRunResult{{Remaining: 0}}}
 	task := NewBackfillEbookMetadataTask(enricher)

--- a/internal/taskmanager/tasks/sync_ebook_metadata_test.go
+++ b/internal/taskmanager/tasks/sync_ebook_metadata_test.go
@@ -6,86 +6,174 @@ import (
 	"errors"
 	"strings"
 	"testing"
+	"time"
 
+	"github.com/Silo-Server/silo-server/internal/ebooks"
 	"github.com/Silo-Server/silo-server/internal/taskmanager"
 )
 
 type fakeEbookMetadataEnricher struct {
-	enriched int
-	err      error
-	called   bool
+	results []ebooks.EnrichmentRunResult
+	err     error
+	scopes  []ebooks.EnrichmentScope
+	onRun   func(int)
 }
 
-func (f *fakeEbookMetadataEnricher) Run(context.Context) (int, error) {
-	f.called = true
-	return f.enriched, f.err
+func (f *fakeEbookMetadataEnricher) Run(_ context.Context, scope ebooks.EnrichmentScope) (ebooks.EnrichmentRunResult, error) {
+	f.scopes = append(f.scopes, scope)
+	call := len(f.scopes)
+	if f.onRun != nil {
+		f.onRun(call)
+	}
+	if f.err != nil {
+		return ebooks.EnrichmentRunResult{}, f.err
+	}
+	if call > len(f.results) {
+		return ebooks.EnrichmentRunResult{}, nil
+	}
+	return f.results[call-1], nil
 }
 
 type ebookMetadataProgressReporter struct {
+	percents []float64
 	messages []string
-	result   json.RawMessage
+	results  []json.RawMessage
 }
 
-func (p *ebookMetadataProgressReporter) Report(_ float64, message string) {
+func (p *ebookMetadataProgressReporter) Report(percent float64, message string) {
+	p.percents = append(p.percents, percent)
 	p.messages = append(p.messages, message)
 }
 
 func (p *ebookMetadataProgressReporter) SetResultData(data json.RawMessage) {
-	p.result = data
+	p.results = append(p.results, append(json.RawMessage(nil), data...))
 }
 
-func TestSyncEbookMetadataTaskProperties(t *testing.T) {
-	task := NewSyncEbookMetadataTask(&fakeEbookMetadataEnricher{})
+func TestEbookMetadataTaskPropertiesAndScopes(t *testing.T) {
+	enricher := &fakeEbookMetadataEnricher{}
+	syncTask := NewSyncEbookMetadataTask(enricher)
+	backfillTask := NewBackfillEbookMetadataTask(enricher)
 
-	if task.Key() != "sync_ebook_metadata" {
-		t.Fatalf("Key() = %q, want sync_ebook_metadata", task.Key())
+	if syncTask.Key() != "sync_ebook_metadata" || syncTask.Name() != "Sync Ebook Metadata" {
+		t.Fatalf("unexpected sync identity: %q %q", syncTask.Key(), syncTask.Name())
 	}
-	if task.Name() != "Sync Ebook Metadata" {
-		t.Fatalf("Name() = %q, want Sync Ebook Metadata", task.Name())
+	if backfillTask.Key() != "backfill_ebook_metadata" {
+		t.Fatalf("backfill Key() = %q", backfillTask.Key())
 	}
-	if task.Category() != taskmanager.TaskCategoryMetadata {
-		t.Fatalf("Category() = %q, want %q", task.Category(), taskmanager.TaskCategoryMetadata)
+	if !strings.Contains(strings.ToLower(backfillTask.Description()), "legacy") {
+		t.Fatalf("backfill description does not explain legacy work: %q", backfillTask.Description())
 	}
-	if task.IsHidden() {
-		t.Fatal("IsHidden() = true, want false")
+	for _, task := range []taskmanager.Task{syncTask, backfillTask} {
+		if task.Category() != taskmanager.TaskCategoryMetadata || task.IsHidden() {
+			t.Fatalf("unexpected task properties for %q", task.Key())
+		}
 	}
-	triggers := task.DefaultTriggers()
+	triggers := syncTask.DefaultTriggers()
 	if len(triggers) != 1 || triggers[0].Type != taskmanager.TriggerTypeInterval || triggers[0].IntervalMs != 5*60*1000 {
-		t.Fatalf("DefaultTriggers() = %#v, want one 5 minute interval", triggers)
+		t.Fatalf("sync DefaultTriggers() = %#v", triggers)
 	}
-	if strings.Contains(strings.ToLower(task.Description()), "narrator") {
-		t.Fatalf("Description() mentions narrator: %q", task.Description())
+	if triggers := backfillTask.DefaultTriggers(); len(triggers) != 0 {
+		t.Fatalf("backfill DefaultTriggers() = %#v, want none", triggers)
 	}
 }
 
-func TestSyncEbookMetadataTaskExecuteReportsResult(t *testing.T) {
-	enricher := &fakeEbookMetadataEnricher{enriched: 3}
+func TestEbookMetadataTaskDrainsBatchesAndReportsHonestProgress(t *testing.T) {
+	enricher := &fakeEbookMetadataEnricher{results: []ebooks.EnrichmentRunResult{
+		{Claimed: 4, Enriched: 2, NoMatch: 1, Failed: 1, Remaining: 3},
+		{Claimed: 3, Enriched: 1, Deferred: 2, Remaining: 0},
+	}}
 	task := NewSyncEbookMetadataTask(enricher)
 	progress := &ebookMetadataProgressReporter{}
 
 	if err := task.Execute(context.Background(), progress); err != nil {
 		t.Fatalf("Execute() error = %v", err)
 	}
-	if !enricher.called {
-		t.Fatal("enricher was not called")
+	if len(enricher.scopes) != 2 {
+		t.Fatalf("Run calls = %d, want 2", len(enricher.scopes))
 	}
-	var result map[string]int
-	if err := json.Unmarshal(progress.result, &result); err != nil {
-		t.Fatalf("result data JSON error: %v", err)
+	for _, scope := range enricher.scopes {
+		if scope != ebooks.EnrichmentScopeIncremental {
+			t.Fatalf("sync scope = %q, want incremental", scope)
+		}
 	}
-	if result["items_enriched"] != 3 {
-		t.Fatalf("items_enriched = %d, want 3", result["items_enriched"])
+	var result ebooks.EnrichmentRunResult
+	if err := json.Unmarshal(progress.results[len(progress.results)-1], &result); err != nil {
+		t.Fatalf("result JSON error: %v", err)
 	}
-	if len(progress.messages) == 0 || !strings.Contains(progress.messages[len(progress.messages)-1], "3 items enriched") {
-		t.Fatalf("progress messages = %#v, want completion count", progress.messages)
+	want := ebooks.EnrichmentRunResult{Claimed: 7, Enriched: 3, NoMatch: 1, Failed: 1, Deferred: 2}
+	if result != want {
+		t.Fatalf("result = %+v, want %+v", result, want)
+	}
+	if progress.percents[1] >= 100 {
+		t.Fatalf("first batch progress = %.1f, must be below 100 with remaining work", progress.percents[1])
+	}
+	if got := progress.percents[len(progress.percents)-1]; got != 100 {
+		t.Fatalf("final progress = %.1f, want 100", got)
 	}
 }
 
-func TestSyncEbookMetadataTaskExecuteWrapsError(t *testing.T) {
-	enricher := &fakeEbookMetadataEnricher{err: errors.New("boom")}
-	task := NewSyncEbookMetadataTask(enricher)
+func TestEbookMetadataBackfillUsesLegacyScope(t *testing.T) {
+	enricher := &fakeEbookMetadataEnricher{results: []ebooks.EnrichmentRunResult{{Remaining: 0}}}
+	task := NewBackfillEbookMetadataTask(enricher)
+	if err := task.Execute(context.Background(), &ebookMetadataProgressReporter{}); err != nil {
+		t.Fatalf("Execute() error = %v", err)
+	}
+	if len(enricher.scopes) != 1 || enricher.scopes[0] != ebooks.EnrichmentScopeLegacy {
+		t.Fatalf("backfill scopes = %#v, want legacy", enricher.scopes)
+	}
+}
 
-	err := task.Execute(context.Background(), &ebookMetadataProgressReporter{})
+func TestEbookMetadataTaskStopsBetweenBatchesOnCancellation(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	enricher := &fakeEbookMetadataEnricher{
+		results: []ebooks.EnrichmentRunResult{{Claimed: 1, Enriched: 1, Remaining: 2}},
+		onRun: func(int) {
+			cancel()
+		},
+	}
+	err := NewSyncEbookMetadataTask(enricher).Execute(ctx, &ebookMetadataProgressReporter{})
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("Execute() error = %v, want context.Canceled", err)
+	}
+	if len(enricher.scopes) != 1 {
+		t.Fatalf("Run calls = %d, want 1", len(enricher.scopes))
+	}
+}
+
+func TestEbookMetadataTaskTreatsBudgetAsCleanDeferredCompletion(t *testing.T) {
+	now := time.Date(2026, 7, 19, 12, 0, 0, 0, time.UTC)
+	enricher := &fakeEbookMetadataEnricher{
+		results: []ebooks.EnrichmentRunResult{{Claimed: 2, Enriched: 2, Remaining: 5}},
+		onRun: func(int) {
+			now = now.Add(5 * time.Minute)
+		},
+	}
+	task := NewSyncEbookMetadataTask(enricher)
+	task.now = func() time.Time { return now }
+	task.budget = 4 * time.Minute
+	progress := &ebookMetadataProgressReporter{}
+
+	if err := task.Execute(context.Background(), progress); err != nil {
+		t.Fatalf("Execute() error = %v", err)
+	}
+	if len(enricher.scopes) != 1 {
+		t.Fatalf("Run calls = %d, want 1", len(enricher.scopes))
+	}
+	var result ebooks.EnrichmentRunResult
+	if err := json.Unmarshal(progress.results[len(progress.results)-1], &result); err != nil {
+		t.Fatalf("result JSON error: %v", err)
+	}
+	if result.Remaining != 5 || result.Deferred != 5 {
+		t.Fatalf("budget result = %+v, want remaining=5 deferred=5", result)
+	}
+	if got := progress.percents[len(progress.percents)-1]; got >= 100 {
+		t.Fatalf("budget-limited progress = %.1f, must remain below 100", got)
+	}
+}
+
+func TestEbookMetadataTaskWrapsRunError(t *testing.T) {
+	enricher := &fakeEbookMetadataEnricher{err: errors.New("boom")}
+	err := NewSyncEbookMetadataTask(enricher).Execute(context.Background(), &ebookMetadataProgressReporter{})
 	if err == nil || !strings.Contains(err.Error(), "ebook metadata sync") {
 		t.Fatalf("Execute() error = %v, want wrapped ebook metadata sync error", err)
 	}

--- a/migrations/ebook_enrichment_reconcile_cursor_test.go
+++ b/migrations/ebook_enrichment_reconcile_cursor_test.go
@@ -1,0 +1,30 @@
+package migrations
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestEbookEnrichmentReconcileCursorPersistsAcrossRestartsAndUsesCoveringIndex(t *testing.T) {
+	migrationBytes, err := FS.ReadFile("sql/20260719173000_ebook_enrichment_reconcile_cursor.sql")
+	if err != nil {
+		t.Fatalf("read migration: %v", err)
+	}
+	migration := strings.Join(strings.Fields(string(migrationBytes)), " ")
+	for _, fragment := range []string{
+		"-- +goose NO TRANSACTION",
+		"CREATE TABLE IF NOT EXISTS ebook_enrichment_reconcile_cursors",
+		"folder_id integer PRIMARY KEY REFERENCES media_folders(id) ON DELETE CASCADE",
+		"after_first_seen_at timestamptz",
+		"after_content_id text",
+		"CHECK ((after_first_seen_at IS NULL) = (after_content_id IS NULL))",
+		"CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_item_libraries_folder_enrichment_cursor",
+		"ON public.media_item_libraries (media_folder_id, first_seen_at DESC, content_id)",
+		"DROP INDEX CONCURRENTLY IF EXISTS idx_item_libraries_folder_enrichment_cursor",
+		"DROP TABLE IF EXISTS ebook_enrichment_reconcile_cursors",
+	} {
+		if !strings.Contains(migration, fragment) {
+			t.Fatalf("cursor migration missing %q", fragment)
+		}
+	}
+}

--- a/migrations/ebook_enrichment_reconcile_cursor_test.go
+++ b/migrations/ebook_enrichment_reconcile_cursor_test.go
@@ -19,7 +19,7 @@ func TestEbookEnrichmentReconcileCursorPersistsAcrossRestartsAndUsesCoveringInde
 		"after_content_id text",
 		"CHECK ((after_first_seen_at IS NULL) = (after_content_id IS NULL))",
 		"CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_item_libraries_folder_enrichment_cursor",
-		"ON public.media_item_libraries (media_folder_id, first_seen_at DESC, content_id)",
+		"ON public.media_item_libraries (media_folder_id, first_seen_at DESC, content_id DESC)",
 		"DROP INDEX CONCURRENTLY IF EXISTS idx_item_libraries_folder_enrichment_cursor",
 		"DROP TABLE IF EXISTS ebook_enrichment_reconcile_cursors",
 	} {

--- a/migrations/sql/20260719090000_ebook_enrichment_jobs.sql
+++ b/migrations/sql/20260719090000_ebook_enrichment_jobs.sql
@@ -150,15 +150,31 @@ BEGIN
     ) THEN
         DROP INDEX public.ebook_enrichment_state_claim_idx;
     END IF;
+    IF EXISTS (
+        SELECT 1
+        FROM pg_class c
+        JOIN pg_namespace n ON n.oid = c.relnamespace
+        JOIN pg_index i ON i.indexrelid = c.oid
+        WHERE n.nspname = 'public'
+          AND c.relname = 'ebook_enrichment_state_priority_claim_idx'
+          AND NOT i.indisvalid
+    ) THEN
+        DROP INDEX public.ebook_enrichment_state_priority_claim_idx;
+    END IF;
 END;
 $$;
 -- +goose StatementEnd
 
 CREATE INDEX CONCURRENTLY IF NOT EXISTS ebook_enrichment_state_claim_idx
-    ON public.ebook_enrichment_state (priority, next_attempt_at, updated_at)
+    ON public.ebook_enrichment_state ((priority < 0), next_attempt_at, updated_at, priority DESC)
+    WHERE status IN ('pending', 'running');
+
+CREATE INDEX CONCURRENTLY IF NOT EXISTS ebook_enrichment_state_priority_claim_idx
+    ON public.ebook_enrichment_state ((priority < 0), priority DESC, next_attempt_at, updated_at)
     WHERE status IN ('pending', 'running');
 
 -- +goose Down
+DROP INDEX CONCURRENTLY IF EXISTS ebook_enrichment_state_priority_claim_idx;
 DROP INDEX CONCURRENTLY IF EXISTS ebook_enrichment_state_claim_idx;
 
 -- +goose StatementBegin

--- a/migrations/sql/20260719090000_ebook_enrichment_jobs.sql
+++ b/migrations/sql/20260719090000_ebook_enrichment_jobs.sql
@@ -1,0 +1,70 @@
+-- +goose Up
+ALTER TABLE ebook_enrichment_state
+    ADD COLUMN status text NOT NULL DEFAULT 'pending',
+    ADD COLUMN priority integer NOT NULL DEFAULT 0,
+    ADD COLUMN attempts integer NOT NULL DEFAULT 0,
+    ADD COLUMN next_attempt_at timestamptz NOT NULL DEFAULT now(),
+    ADD COLUMN lease_until timestamptz,
+    ADD COLUMN last_attempt_at timestamptz,
+    ADD COLUMN completed_at timestamptz,
+    ADD COLUMN outcome text,
+    ADD COLUMN last_error_class text,
+    ADD COLUMN last_error text,
+    ADD CONSTRAINT ebook_enrichment_state_status_check
+        CHECK (status IN ('pending', 'running')),
+    ADD CONSTRAINT ebook_enrichment_state_attempts_check
+        CHECK (attempts >= 0);
+
+-- Rows already tracked by the former failure counter belong to the legacy
+-- backlog. Preserve their history but keep them behind incremental work.
+UPDATE ebook_enrichment_state
+SET attempts = failures,
+    priority = -100;
+
+-- Snapshot the pre-migration library as durable low-priority backfill. Runtime
+-- materialization assigns new discoveries priority 100, so this backlog cannot
+-- occupy claim slots ahead of incremental or due refresh work.
+INSERT INTO ebook_enrichment_state (
+    content_id,
+    status,
+    priority,
+    attempts,
+    next_attempt_at,
+    updated_at
+)
+SELECT mi.content_id, 'pending', -100, 0, now(), now()
+FROM media_items mi
+WHERE mi.type = 'ebook'
+  AND NOT EXISTS (
+      SELECT 1
+      FROM manga_chapters mc
+      WHERE mc.chapter_content_id = mi.content_id
+  )
+  AND mi.last_refreshed IS NULL
+ON CONFLICT (content_id) DO NOTHING;
+
+CREATE INDEX ebook_enrichment_state_claim_idx
+    ON ebook_enrichment_state (priority DESC, next_attempt_at, updated_at)
+    WHERE status IN ('pending', 'running');
+
+-- +goose Down
+DROP INDEX IF EXISTS ebook_enrichment_state_claim_idx;
+
+-- The former state table only retained positive failure rows. Remove queue rows
+-- created by this migration/runtime before restoring that representation.
+DELETE FROM ebook_enrichment_state
+WHERE failures = 0;
+
+ALTER TABLE ebook_enrichment_state
+    DROP CONSTRAINT IF EXISTS ebook_enrichment_state_attempts_check,
+    DROP CONSTRAINT IF EXISTS ebook_enrichment_state_status_check,
+    DROP COLUMN IF EXISTS last_error,
+    DROP COLUMN IF EXISTS last_error_class,
+    DROP COLUMN IF EXISTS outcome,
+    DROP COLUMN IF EXISTS completed_at,
+    DROP COLUMN IF EXISTS last_attempt_at,
+    DROP COLUMN IF EXISTS lease_until,
+    DROP COLUMN IF EXISTS next_attempt_at,
+    DROP COLUMN IF EXISTS attempts,
+    DROP COLUMN IF EXISTS priority,
+    DROP COLUMN IF EXISTS status;

--- a/migrations/sql/20260719090000_ebook_enrichment_jobs.sql
+++ b/migrations/sql/20260719090000_ebook_enrichment_jobs.sql
@@ -135,7 +135,7 @@ WHERE mi.type = 'ebook'
 ON CONFLICT (content_id) DO NOTHING;
 
 -- A crashed CREATE INDEX CONCURRENTLY can leave an INVALID index which blocks
--- an IF NOT EXISTS retry. Match the repository's crash-safe index pattern.
+-- an IF NOT EXISTS retry. Clean each lane-specific index before rebuilding it.
 -- +goose StatementBegin
 DO $$
 BEGIN
@@ -145,10 +145,10 @@ BEGIN
         JOIN pg_namespace n ON n.oid = c.relnamespace
         JOIN pg_index i ON i.indexrelid = c.oid
         WHERE n.nspname = 'public'
-          AND c.relname = 'ebook_enrichment_state_claim_idx'
+          AND c.relname = 'ebook_enrichment_incremental_due_idx'
           AND NOT i.indisvalid
     ) THEN
-        DROP INDEX public.ebook_enrichment_state_claim_idx;
+        DROP INDEX public.ebook_enrichment_incremental_due_idx;
     END IF;
     IF EXISTS (
         SELECT 1
@@ -156,26 +156,58 @@ BEGIN
         JOIN pg_namespace n ON n.oid = c.relnamespace
         JOIN pg_index i ON i.indexrelid = c.oid
         WHERE n.nspname = 'public'
-          AND c.relname = 'ebook_enrichment_state_priority_claim_idx'
+          AND c.relname = 'ebook_enrichment_incremental_priority_idx'
           AND NOT i.indisvalid
     ) THEN
-        DROP INDEX public.ebook_enrichment_state_priority_claim_idx;
+        DROP INDEX public.ebook_enrichment_incremental_priority_idx;
+    END IF;
+    IF EXISTS (
+        SELECT 1
+        FROM pg_class c
+        JOIN pg_namespace n ON n.oid = c.relnamespace
+        JOIN pg_index i ON i.indexrelid = c.oid
+        WHERE n.nspname = 'public'
+          AND c.relname = 'ebook_enrichment_legacy_due_idx'
+          AND NOT i.indisvalid
+    ) THEN
+        DROP INDEX public.ebook_enrichment_legacy_due_idx;
+    END IF;
+    IF EXISTS (
+        SELECT 1
+        FROM pg_class c
+        JOIN pg_namespace n ON n.oid = c.relnamespace
+        JOIN pg_index i ON i.indexrelid = c.oid
+        WHERE n.nspname = 'public'
+          AND c.relname = 'ebook_enrichment_legacy_priority_idx'
+          AND NOT i.indisvalid
+    ) THEN
+        DROP INDEX public.ebook_enrichment_legacy_priority_idx;
     END IF;
 END;
 $$;
 -- +goose StatementEnd
 
-CREATE INDEX CONCURRENTLY IF NOT EXISTS ebook_enrichment_state_claim_idx
-    ON public.ebook_enrichment_state ((priority < 0), next_attempt_at, updated_at, priority DESC)
-    WHERE status IN ('pending', 'running');
+CREATE INDEX CONCURRENTLY IF NOT EXISTS ebook_enrichment_incremental_due_idx
+    ON public.ebook_enrichment_state (next_attempt_at, updated_at, priority DESC)
+    WHERE status IN ('pending', 'running') AND priority >= 0;
 
-CREATE INDEX CONCURRENTLY IF NOT EXISTS ebook_enrichment_state_priority_claim_idx
-    ON public.ebook_enrichment_state ((priority < 0), priority DESC, next_attempt_at, updated_at)
-    WHERE status IN ('pending', 'running');
+CREATE INDEX CONCURRENTLY IF NOT EXISTS ebook_enrichment_incremental_priority_idx
+    ON public.ebook_enrichment_state (priority DESC, next_attempt_at, updated_at)
+    WHERE status IN ('pending', 'running') AND priority >= 0;
+
+CREATE INDEX CONCURRENTLY IF NOT EXISTS ebook_enrichment_legacy_due_idx
+    ON public.ebook_enrichment_state (next_attempt_at, updated_at, priority DESC)
+    WHERE status IN ('pending', 'running') AND priority < 0;
+
+CREATE INDEX CONCURRENTLY IF NOT EXISTS ebook_enrichment_legacy_priority_idx
+    ON public.ebook_enrichment_state (priority DESC, next_attempt_at, updated_at)
+    WHERE status IN ('pending', 'running') AND priority < 0;
 
 -- +goose Down
-DROP INDEX CONCURRENTLY IF EXISTS ebook_enrichment_state_priority_claim_idx;
-DROP INDEX CONCURRENTLY IF EXISTS ebook_enrichment_state_claim_idx;
+DROP INDEX CONCURRENTLY IF EXISTS ebook_enrichment_legacy_priority_idx;
+DROP INDEX CONCURRENTLY IF EXISTS ebook_enrichment_legacy_due_idx;
+DROP INDEX CONCURRENTLY IF EXISTS ebook_enrichment_incremental_priority_idx;
+DROP INDEX CONCURRENTLY IF EXISTS ebook_enrichment_incremental_due_idx;
 
 -- +goose StatementBegin
 DO $$

--- a/migrations/sql/20260719090000_ebook_enrichment_jobs.sql
+++ b/migrations/sql/20260719090000_ebook_enrichment_jobs.sql
@@ -1,38 +1,130 @@
+-- +goose NO TRANSACTION
+
 -- +goose Up
+-- This ALTER is intentionally its own autocommitted statement so its table
+-- lock is released before the potentially large backfill runs separately.
 ALTER TABLE ebook_enrichment_state
-    ADD COLUMN status text NOT NULL DEFAULT 'pending',
-    ADD COLUMN priority integer NOT NULL DEFAULT 0,
-    ADD COLUMN attempts integer NOT NULL DEFAULT 0,
-    ADD COLUMN next_attempt_at timestamptz NOT NULL DEFAULT now(),
-    ADD COLUMN lease_until timestamptz,
-    ADD COLUMN last_attempt_at timestamptz,
-    ADD COLUMN completed_at timestamptz,
-    ADD COLUMN outcome text,
-    ADD COLUMN last_error_class text,
-    ADD COLUMN last_error text,
+    ADD COLUMN IF NOT EXISTS status text NOT NULL DEFAULT 'pending',
+    ADD COLUMN IF NOT EXISTS priority integer NOT NULL DEFAULT 0,
+    ADD COLUMN IF NOT EXISTS attempts integer NOT NULL DEFAULT 0,
+    ADD COLUMN IF NOT EXISTS next_attempt_at timestamptz NOT NULL DEFAULT now(),
+    ADD COLUMN IF NOT EXISTS lease_until timestamptz,
+    ADD COLUMN IF NOT EXISTS claim_token text,
+    ADD COLUMN IF NOT EXISTS requeue_requested boolean NOT NULL DEFAULT false,
+    ADD COLUMN IF NOT EXISTS protected_fields text[] NOT NULL DEFAULT '{}'::text[],
+    ADD COLUMN IF NOT EXISTS last_attempt_at timestamptz,
+    ADD COLUMN IF NOT EXISTS completed_at timestamptz,
+    ADD COLUMN IF NOT EXISTS outcome text,
+    ADD COLUMN IF NOT EXISTS last_error_class text,
+    ADD COLUMN IF NOT EXISTS last_error text;
+
+ALTER TABLE ebook_enrichment_state
+    DROP CONSTRAINT IF EXISTS ebook_enrichment_state_status_check,
+    DROP CONSTRAINT IF EXISTS ebook_enrichment_state_attempts_check;
+
+ALTER TABLE ebook_enrichment_state
     ADD CONSTRAINT ebook_enrichment_state_status_check
-        CHECK (status IN ('pending', 'running')),
+        CHECK (status IN ('pending', 'running', 'discarded')),
     ADD CONSTRAINT ebook_enrichment_state_attempts_check
         CHECK (attempts >= 0);
 
--- Rows already tracked by the former failure counter belong to the legacy
--- backlog. Preserve their history but keep them behind incremental work.
-UPDATE ebook_enrichment_state
-SET attempts = failures,
-    priority = -100;
+-- Existing failure rows are part of the legacy backlog. Refreshed rows retain
+-- their refresh date as the start of the 90-day schedule; unrefreshed rows keep
+-- their old failure count and enter at legacy priority -100.
+UPDATE ebook_enrichment_state state
+SET status = 'pending',
+    priority = CASE WHEN mi.last_refreshed IS NULL THEN -100 ELSE 0 END,
+    attempts = state.failures,
+    next_attempt_at = CASE
+        WHEN mi.last_refreshed IS NULL THEN now()
+        ELSE GREATEST(mi.last_refreshed + interval '90 days', now())
+    END,
+    completed_at = mi.last_refreshed,
+    protected_fields = ARRAY_REMOVE(ARRAY[
+        CASE WHEN lower(trim(mi.status)) = 'pending' AND trim(COALESCE(mi.title, '')) <> '' THEN 'title' END,
+        CASE WHEN lower(trim(mi.status)) = 'pending' AND COALESCE(mi.year, 0) > 0 THEN 'year' END,
+        CASE WHEN lower(trim(mi.status)) = 'pending' AND trim(COALESCE(mi.overview, '')) <> '' THEN 'overview' END,
+        CASE WHEN lower(trim(mi.status)) = 'pending' AND trim(COALESCE(mi.tagline, '')) <> '' THEN 'tagline' END,
+        CASE WHEN lower(trim(mi.status)) = 'pending' AND trim(COALESCE(mi.content_rating, '')) <> '' THEN 'content_rating' END,
+        CASE WHEN lower(trim(mi.status)) = 'pending' AND COALESCE(mi.runtime, 0) > 0 THEN 'runtime' END,
+        CASE WHEN lower(trim(mi.status)) = 'pending' AND trim(COALESCE(mi.release_date::text, '')) <> '' THEN 'release_date' END,
+        CASE WHEN lower(trim(mi.status)) = 'pending' AND cardinality(COALESCE(mi.genres, '{}'::text[])) > 0 THEN 'genres' END,
+        CASE WHEN lower(trim(mi.status)) = 'pending' AND cardinality(COALESCE(mi.studios, '{}'::text[])) > 0 THEN 'studios' END,
+        CASE WHEN lower(trim(mi.status)) = 'pending' AND EXISTS (
+            SELECT 1 FROM item_people ip WHERE ip.content_id = mi.content_id AND ip.kind = 7
+        ) THEN 'authors' END,
+        CASE WHEN trim(COALESCE(mi.poster_path, '')) <> ''
+            AND lower(trim(mi.poster_path)) NOT LIKE 'http://%'
+            AND lower(trim(mi.poster_path)) NOT LIKE 'https://%'
+            AND lower(trim(mi.poster_path)) NOT LIKE 'ebook-metadata/ebooks/%'
+            THEN 'poster_path' END,
+        CASE WHEN trim(COALESCE(mi.backdrop_path, '')) <> ''
+            AND lower(trim(mi.backdrop_path)) NOT LIKE 'http://%'
+            AND lower(trim(mi.backdrop_path)) NOT LIKE 'https://%'
+            AND lower(trim(mi.backdrop_path)) NOT LIKE 'ebook-metadata/ebooks/%'
+            THEN 'backdrop_path' END,
+        CASE WHEN trim(COALESCE(mi.logo_path, '')) <> ''
+            AND lower(trim(mi.logo_path)) NOT LIKE 'http://%'
+            AND lower(trim(mi.logo_path)) NOT LIKE 'https://%'
+            AND lower(trim(mi.logo_path)) NOT LIKE 'ebook-metadata/ebooks/%'
+            THEN 'logo_path' END
+    ]::text[], NULL),
+    updated_at = now()
+FROM media_items mi
+WHERE mi.content_id = state.content_id;
 
--- Snapshot the pre-migration library as durable low-priority backfill. Runtime
--- materialization assigns new discoveries priority 100, so this backlog cannot
--- occupy claim slots ahead of incremental or due refresh work.
+-- Snapshot every pre-migration standalone ebook. Refreshed rows become normal
+-- 90-day refresh work; only the unrefreshed legacy backlog starts at -100.
 INSERT INTO ebook_enrichment_state (
     content_id,
     status,
     priority,
     attempts,
     next_attempt_at,
+    completed_at,
+    protected_fields,
     updated_at
 )
-SELECT mi.content_id, 'pending', -100, 0, now(), now()
+SELECT
+    mi.content_id,
+    'pending',
+    CASE WHEN mi.last_refreshed IS NULL THEN -100 ELSE 0 END,
+    0,
+    CASE
+        WHEN mi.last_refreshed IS NULL THEN now()
+        ELSE GREATEST(mi.last_refreshed + interval '90 days', now())
+    END,
+    mi.last_refreshed,
+    ARRAY_REMOVE(ARRAY[
+        CASE WHEN lower(trim(mi.status)) = 'pending' AND trim(COALESCE(mi.title, '')) <> '' THEN 'title' END,
+        CASE WHEN lower(trim(mi.status)) = 'pending' AND COALESCE(mi.year, 0) > 0 THEN 'year' END,
+        CASE WHEN lower(trim(mi.status)) = 'pending' AND trim(COALESCE(mi.overview, '')) <> '' THEN 'overview' END,
+        CASE WHEN lower(trim(mi.status)) = 'pending' AND trim(COALESCE(mi.tagline, '')) <> '' THEN 'tagline' END,
+        CASE WHEN lower(trim(mi.status)) = 'pending' AND trim(COALESCE(mi.content_rating, '')) <> '' THEN 'content_rating' END,
+        CASE WHEN lower(trim(mi.status)) = 'pending' AND COALESCE(mi.runtime, 0) > 0 THEN 'runtime' END,
+        CASE WHEN lower(trim(mi.status)) = 'pending' AND trim(COALESCE(mi.release_date::text, '')) <> '' THEN 'release_date' END,
+        CASE WHEN lower(trim(mi.status)) = 'pending' AND cardinality(COALESCE(mi.genres, '{}'::text[])) > 0 THEN 'genres' END,
+        CASE WHEN lower(trim(mi.status)) = 'pending' AND cardinality(COALESCE(mi.studios, '{}'::text[])) > 0 THEN 'studios' END,
+        CASE WHEN lower(trim(mi.status)) = 'pending' AND EXISTS (
+            SELECT 1 FROM item_people ip WHERE ip.content_id = mi.content_id AND ip.kind = 7
+        ) THEN 'authors' END,
+        CASE WHEN trim(COALESCE(mi.poster_path, '')) <> ''
+            AND lower(trim(mi.poster_path)) NOT LIKE 'http://%'
+            AND lower(trim(mi.poster_path)) NOT LIKE 'https://%'
+            AND lower(trim(mi.poster_path)) NOT LIKE 'ebook-metadata/ebooks/%'
+            THEN 'poster_path' END,
+        CASE WHEN trim(COALESCE(mi.backdrop_path, '')) <> ''
+            AND lower(trim(mi.backdrop_path)) NOT LIKE 'http://%'
+            AND lower(trim(mi.backdrop_path)) NOT LIKE 'https://%'
+            AND lower(trim(mi.backdrop_path)) NOT LIKE 'ebook-metadata/ebooks/%'
+            THEN 'backdrop_path' END,
+        CASE WHEN trim(COALESCE(mi.logo_path, '')) <> ''
+            AND lower(trim(mi.logo_path)) NOT LIKE 'http://%'
+            AND lower(trim(mi.logo_path)) NOT LIKE 'https://%'
+            AND lower(trim(mi.logo_path)) NOT LIKE 'ebook-metadata/ebooks/%'
+            THEN 'logo_path' END
+    ]::text[], NULL),
+    now()
 FROM media_items mi
 WHERE mi.type = 'ebook'
   AND NOT EXISTS (
@@ -40,20 +132,58 @@ WHERE mi.type = 'ebook'
       FROM manga_chapters mc
       WHERE mc.chapter_content_id = mi.content_id
   )
-  AND mi.last_refreshed IS NULL
 ON CONFLICT (content_id) DO NOTHING;
 
-CREATE INDEX ebook_enrichment_state_claim_idx
-    ON ebook_enrichment_state (priority DESC, next_attempt_at, updated_at)
+-- A crashed CREATE INDEX CONCURRENTLY can leave an INVALID index which blocks
+-- an IF NOT EXISTS retry. Match the repository's crash-safe index pattern.
+-- +goose StatementBegin
+DO $$
+BEGIN
+    IF EXISTS (
+        SELECT 1
+        FROM pg_class c
+        JOIN pg_namespace n ON n.oid = c.relnamespace
+        JOIN pg_index i ON i.indexrelid = c.oid
+        WHERE n.nspname = 'public'
+          AND c.relname = 'ebook_enrichment_state_claim_idx'
+          AND NOT i.indisvalid
+    ) THEN
+        DROP INDEX public.ebook_enrichment_state_claim_idx;
+    END IF;
+END;
+$$;
+-- +goose StatementEnd
+
+CREATE INDEX CONCURRENTLY IF NOT EXISTS ebook_enrichment_state_claim_idx
+    ON public.ebook_enrichment_state (next_attempt_at, priority DESC, updated_at)
     WHERE status IN ('pending', 'running');
 
 -- +goose Down
-DROP INDEX IF EXISTS ebook_enrichment_state_claim_idx;
+DROP INDEX CONCURRENTLY IF EXISTS ebook_enrichment_state_claim_idx;
 
--- The former state table only retained positive failure rows. Remove queue rows
--- created by this migration/runtime before restoring that representation.
-DELETE FROM ebook_enrichment_state
-WHERE failures = 0;
+-- +goose StatementBegin
+DO $$
+BEGIN
+    IF EXISTS (
+        SELECT 1
+        FROM information_schema.columns
+        WHERE table_schema = 'public'
+          AND table_name = 'ebook_enrichment_state'
+          AND column_name = 'attempts'
+    ) THEN
+        UPDATE ebook_enrichment_state
+        SET failures = attempts
+        WHERE outcome = 'failed';
+
+        -- Success and no-match rows have no representation in the old
+        -- failure-only schema. Keep pending, skipped, discarded, and failed
+        -- rows; old code can faithfully interpret their copied failure count.
+        DELETE FROM ebook_enrichment_state
+        WHERE outcome IN ('success', 'no_match');
+    END IF;
+END;
+$$;
+-- +goose StatementEnd
 
 ALTER TABLE ebook_enrichment_state
     DROP CONSTRAINT IF EXISTS ebook_enrichment_state_attempts_check,
@@ -63,6 +193,9 @@ ALTER TABLE ebook_enrichment_state
     DROP COLUMN IF EXISTS outcome,
     DROP COLUMN IF EXISTS completed_at,
     DROP COLUMN IF EXISTS last_attempt_at,
+    DROP COLUMN IF EXISTS protected_fields,
+    DROP COLUMN IF EXISTS requeue_requested,
+    DROP COLUMN IF EXISTS claim_token,
     DROP COLUMN IF EXISTS lease_until,
     DROP COLUMN IF EXISTS next_attempt_at,
     DROP COLUMN IF EXISTS attempts,

--- a/migrations/sql/20260719090000_ebook_enrichment_jobs.sql
+++ b/migrations/sql/20260719090000_ebook_enrichment_jobs.sql
@@ -155,7 +155,7 @@ $$;
 -- +goose StatementEnd
 
 CREATE INDEX CONCURRENTLY IF NOT EXISTS ebook_enrichment_state_claim_idx
-    ON public.ebook_enrichment_state (next_attempt_at, priority DESC, updated_at)
+    ON public.ebook_enrichment_state (priority, next_attempt_at, updated_at)
     WHERE status IN ('pending', 'running');
 
 -- +goose Down

--- a/migrations/sql/20260719173000_ebook_enrichment_reconcile_cursor.sql
+++ b/migrations/sql/20260719173000_ebook_enrichment_reconcile_cursor.sql
@@ -30,7 +30,7 @@ $$;
 -- +goose StatementEnd
 
 CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_item_libraries_folder_enrichment_cursor
-    ON public.media_item_libraries (media_folder_id, first_seen_at DESC, content_id);
+    ON public.media_item_libraries (media_folder_id, first_seen_at DESC, content_id DESC);
 
 -- +goose Down
 DROP INDEX CONCURRENTLY IF EXISTS idx_item_libraries_folder_enrichment_cursor;

--- a/migrations/sql/20260719173000_ebook_enrichment_reconcile_cursor.sql
+++ b/migrations/sql/20260719173000_ebook_enrichment_reconcile_cursor.sql
@@ -1,0 +1,37 @@
+-- +goose NO TRANSACTION
+
+-- +goose Up
+CREATE TABLE IF NOT EXISTS ebook_enrichment_reconcile_cursors (
+    folder_id integer PRIMARY KEY REFERENCES media_folders(id) ON DELETE CASCADE,
+    after_first_seen_at timestamptz,
+    after_content_id text,
+    updated_at timestamptz NOT NULL DEFAULT now(),
+    CHECK ((after_first_seen_at IS NULL) = (after_content_id IS NULL))
+);
+
+-- A failed CREATE INDEX CONCURRENTLY can leave an invalid index that blocks an
+-- IF NOT EXISTS retry. Drop only that unusable artifact before rebuilding.
+-- +goose StatementBegin
+DO $$
+BEGIN
+    IF EXISTS (
+        SELECT 1
+        FROM pg_class c
+        JOIN pg_namespace n ON n.oid = c.relnamespace
+        JOIN pg_index i ON i.indexrelid = c.oid
+        WHERE n.nspname = 'public'
+          AND c.relname = 'idx_item_libraries_folder_enrichment_cursor'
+          AND NOT i.indisvalid
+    ) THEN
+        DROP INDEX public.idx_item_libraries_folder_enrichment_cursor;
+    END IF;
+END;
+$$;
+-- +goose StatementEnd
+
+CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_item_libraries_folder_enrichment_cursor
+    ON public.media_item_libraries (media_folder_id, first_seen_at DESC, content_id);
+
+-- +goose Down
+DROP INDEX CONCURRENTLY IF EXISTS idx_item_libraries_folder_enrichment_cursor;
+DROP TABLE IF EXISTS ebook_enrichment_reconcile_cursors;

--- a/web/src/lib/reloadOnPreloadError.test.ts
+++ b/web/src/lib/reloadOnPreloadError.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, it, vi } from "vitest";
+import { installPreloadErrorReload } from "./reloadOnPreloadError";
+
+function harness(now: () => number) {
+  const reload = vi.fn();
+  const storage = new Map<string, string>();
+  return {
+    reload,
+    deps: {
+      reload,
+      now,
+      getItem: (k: string) => storage.get(k) ?? null,
+      setItem: (k: string, v: string) => storage.set(k, v),
+    },
+  };
+}
+
+describe("installPreloadErrorReload", () => {
+  it("reloads when a dynamically imported chunk fails to load", () => {
+    const { reload, deps } = harness(() => 1_000_000);
+    installPreloadErrorReload(deps);
+
+    window.dispatchEvent(new Event("vite:preloadError"));
+    expect(reload).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not reload again within the loop-guard window", () => {
+    let clock = 1_000_000;
+    const { reload, deps } = harness(() => clock);
+
+    installPreloadErrorReload(deps);
+    window.dispatchEvent(new Event("vite:preloadError"));
+    expect(reload).toHaveBeenCalledTimes(1);
+
+    // Post-reload page still hits the error seconds later: give up instead
+    // of reload-looping.
+    clock += 5_000;
+    installPreloadErrorReload(deps);
+    window.dispatchEvent(new Event("vite:preloadError"));
+    expect(reload).toHaveBeenCalledTimes(1);
+  });
+
+  it("reloads again once the guard window has passed (a later deploy)", () => {
+    let clock = 1_000_000;
+    const { reload, deps } = harness(() => clock);
+
+    installPreloadErrorReload(deps);
+    window.dispatchEvent(new Event("vite:preloadError"));
+    expect(reload).toHaveBeenCalledTimes(1);
+
+    clock += 10 * 60_000;
+    installPreloadErrorReload(deps);
+    window.dispatchEvent(new Event("vite:preloadError"));
+    expect(reload).toHaveBeenCalledTimes(2);
+  });
+});

--- a/web/src/lib/reloadOnPreloadError.test.ts
+++ b/web/src/lib/reloadOnPreloadError.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it, vi } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import { installPreloadErrorReload } from "./reloadOnPreloadError";
 
 function harness(now: () => number) {
@@ -16,9 +16,16 @@ function harness(now: () => number) {
 }
 
 describe("installPreloadErrorReload", () => {
+  let cleanups: Array<() => void> = [];
+
+  afterEach(() => {
+    cleanups.forEach((cleanup) => cleanup());
+    cleanups = [];
+  });
+
   it("reloads when a dynamically imported chunk fails to load", () => {
     const { reload, deps } = harness(() => 1_000_000);
-    installPreloadErrorReload(deps);
+    cleanups.push(installPreloadErrorReload(deps));
 
     window.dispatchEvent(new Event("vite:preloadError"));
     expect(reload).toHaveBeenCalledTimes(1);
@@ -28,14 +35,14 @@ describe("installPreloadErrorReload", () => {
     let clock = 1_000_000;
     const { reload, deps } = harness(() => clock);
 
-    installPreloadErrorReload(deps);
+    cleanups.push(installPreloadErrorReload(deps));
     window.dispatchEvent(new Event("vite:preloadError"));
     expect(reload).toHaveBeenCalledTimes(1);
 
     // Post-reload page still hits the error seconds later: give up instead
     // of reload-looping.
     clock += 5_000;
-    installPreloadErrorReload(deps);
+    cleanups.push(installPreloadErrorReload(deps));
     window.dispatchEvent(new Event("vite:preloadError"));
     expect(reload).toHaveBeenCalledTimes(1);
   });
@@ -44,12 +51,12 @@ describe("installPreloadErrorReload", () => {
     let clock = 1_000_000;
     const { reload, deps } = harness(() => clock);
 
-    installPreloadErrorReload(deps);
+    cleanups.push(installPreloadErrorReload(deps));
     window.dispatchEvent(new Event("vite:preloadError"));
     expect(reload).toHaveBeenCalledTimes(1);
 
     clock += 10 * 60_000;
-    installPreloadErrorReload(deps);
+    cleanups.push(installPreloadErrorReload(deps));
     window.dispatchEvent(new Event("vite:preloadError"));
     expect(reload).toHaveBeenCalledTimes(2);
   });

--- a/web/src/lib/reloadOnPreloadError.ts
+++ b/web/src/lib/reloadOnPreloadError.ts
@@ -15,13 +15,13 @@ interface PreloadErrorReloadDeps {
   setItem: (key: string, value: string) => void;
 }
 
-export function installPreloadErrorReload(deps?: Partial<PreloadErrorReloadDeps>): void {
+export function installPreloadErrorReload(deps?: Partial<PreloadErrorReloadDeps>): () => void {
   const reload = deps?.reload ?? (() => window.location.reload());
   const now = deps?.now ?? Date.now;
   const getItem = deps?.getItem ?? ((k: string) => sessionStorage.getItem(k));
   const setItem = deps?.setItem ?? ((k: string, v: string) => sessionStorage.setItem(k, v));
 
-  window.addEventListener("vite:preloadError", (event) => {
+  const handler = (event: Event) => {
     const lastReloadAt = Number(getItem(GUARD_KEY) ?? 0);
     if (now() - lastReloadAt < GUARD_WINDOW_MS) {
       // We already reloaded moments ago and the chunk is still missing;
@@ -31,5 +31,8 @@ export function installPreloadErrorReload(deps?: Partial<PreloadErrorReloadDeps>
     event.preventDefault();
     setItem(GUARD_KEY, String(now()));
     reload();
-  });
+  };
+
+  window.addEventListener("vite:preloadError", handler);
+  return () => window.removeEventListener("vite:preloadError", handler);
 }

--- a/web/src/lib/reloadOnPreloadError.ts
+++ b/web/src/lib/reloadOnPreloadError.ts
@@ -1,0 +1,35 @@
+// After a deploy, an open tab's code still references the previous build's
+// content-hashed chunks; the first lazy navigation then fails with
+// "Failed to fetch dynamically imported module". Vite reports that as a
+// window "vite:preloadError" event — reload once so the tab picks up the
+// current build, with a time guard so a persistently broken chunk cannot
+// cause a reload loop.
+
+const GUARD_KEY = "silo:preload-error-reload-at";
+const GUARD_WINDOW_MS = 60_000;
+
+interface PreloadErrorReloadDeps {
+  reload: () => void;
+  now: () => number;
+  getItem: (key: string) => string | null;
+  setItem: (key: string, value: string) => void;
+}
+
+export function installPreloadErrorReload(deps?: Partial<PreloadErrorReloadDeps>): void {
+  const reload = deps?.reload ?? (() => window.location.reload());
+  const now = deps?.now ?? Date.now;
+  const getItem = deps?.getItem ?? ((k: string) => sessionStorage.getItem(k));
+  const setItem = deps?.setItem ?? ((k: string, v: string) => sessionStorage.setItem(k, v));
+
+  window.addEventListener("vite:preloadError", (event) => {
+    const lastReloadAt = Number(getItem(GUARD_KEY) ?? 0);
+    if (now() - lastReloadAt < GUARD_WINDOW_MS) {
+      // We already reloaded moments ago and the chunk is still missing;
+      // let the failure surface instead of reload-looping.
+      return;
+    }
+    event.preventDefault();
+    setItem(GUARD_KEY, String(now()));
+    reload();
+  });
+}

--- a/web/src/main.tsx
+++ b/web/src/main.tsx
@@ -1,6 +1,9 @@
 import { createRoot } from "react-dom/client";
 import App from "./App";
+import { installPreloadErrorReload } from "./lib/reloadOnPreloadError";
 import "./app.css";
+
+installPreloadErrorReload();
 
 const root = document.getElementById("root");
 if (root === null) throw new Error("Root element #root not found");


### PR DESCRIPTION
## Summary

Ebook library scans previously blocked on remote metadata providers: a synchronous retry loop inside the scan meant provider latency, outages, or rate limits stalled scanning, and interrupted runs lost their place. This PR decouples the two.

- Scans are now file-only for ebook libraries: filesystem reconciliation, embedded EPUB/PDF metadata, local artwork, and identifier hints complete in seconds with no network calls.
- Remote enrichment moves to a durable Postgres-backed queue (`FOR UPDATE SKIP LOCKED` claims, lease tokens with expiry, priority lanes: 0 for new/refresh work, -100 for the legacy backlog).
- Per-outcome retry horizons: success re-checks in 90d, no-match in 30d, transient failures back off exponentially (capped 24h); rate-limited items honor Retry-After but never requeue below a 15m cooldown floor (`SILO_EBOOK_RATE_LIMIT_COOLDOWN`) — provider RetryInfo hints are request-pacing advice, not queue horizons.
- The legacy backlog drains **automatically**: the backfill task ships a default 15-minute interval trigger, self-pacing via the cooldown + a zero-progress circuit breaker + a 4-minute execution budget. Canary knobs (`SILO_EBOOK_BACKFILL_MAX_CLAIMS`, `SILO_EBOOK_BACKFILL_BATCH_DELAY`) remain for gradual rollouts.
- User-edited fields are protected from remote overwrite via `protected_fields`.
- Operators can supply corrected metadata via `<book>.opf` sidecars; sidecar reads are fenced against symlink swaps (`os.SameFile`), corrected ISBNs replace stale provider ids on rescan, and sidecar edits trigger targeted rescans.

Migrations: `20260719090000_ebook_enrichment_jobs.sql`, `20260719173000_ebook_enrichment_reconcile_cursor.sql`.
Design docs: `docs/superpowers/plans/2026-07-19-ebook-enrichment-architecture.md`, `docs/superpowers/specs/2026-07-20-ebook-backfill-automation-design.md`.

## Production evidence (65k-book backlog, 2026-07-20)

- Scans complete in seconds; enrichment runs unattended every 15 minutes.
- First automated run: 100 claimed / 74 enriched / 17 no-match / 9 rate-deferred / 0 failed in 33s (with the metadata plugin narrowed to sanctioned API sources — see companion plugin PR).
- Cooldown floor verified: rate-limited rows requeue at exactly +15m instead of +1s.

## Notes for review

- Contains the two commits from #434 (`38d39726`, `cf1f0387`) because this exact tip is deployed; once #434 merges I'll rebase them out.
- Heads-up beyond the ebook framing: `scantrigger.ResolveVanishedPath` now resolves vanished *video* files to an exact-file scan (previously a parent-subtree scan); `reconcileVanishedFileIfNeeded` + `syncVanishedVideoQueues` reproduce the old mark-missing/sweep/queue-sync behavior for that path.
- Task `result_data` gains additive JSON fields (`claimed`, `deferred`, `discarded`, …) inside the existing envelope; progress message strings changed format.

## Tests

- `go test ./internal/ebooks ./internal/scanner ./internal/taskmanager/... ./internal/scantrigger ./internal/libraryingest ./internal/server -count=1`
- `pnpm exec vitest run src/lib/reloadOnPreloadError.test.ts`
- `make verify-local-paths`; `go build ./...`, `go vet`, `gofmt` clean

## AI-use disclosure

Implemented and reviewed with Claude Code (multi-agent review pass + TDD throughout).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Ebook metadata enrichment now runs through durable background processing with incremental sync and legacy backfill support.
  * Ebook scans can read metadata from adjacent OPF sidecar files while preserving existing local metadata.
  * Single-file ebook roots and additional ebook file formats are now supported.
  * Missing media paths are classified according to their library type for more precise rescans.

* **Bug Fixes**
  * Missing frontend assets now return a proper 404 instead of the application shell.
  * Improved retry handling and protection against overwriting local ebook metadata.
  * The app can automatically recover from failed frontend chunk loads.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->