### PR TITLE
fix(web): recover from stale content-hashed chunks after deploys

### DIFF
--- a/internal/server/frontend.go
+++ b/internal/server/frontend.go
@@ -156,6 +156,15 @@ func (h *frontendHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
+	// A missing /assets/ file is a content-hashed chunk from another build,
+	// not an app route: answering with the shell makes dynamic imports fail
+	// on a text/html module. A 404 surfaces the real condition so the client
+	// preload-error handler can reload onto the current build.
+	if strings.HasPrefix(path, "/assets/") {
+		http.NotFound(w, r)
+		return
+	}
+
 	// SPA fallback: serve the (branded) index.html shell.
 	shell, ok := h.brandedShell(r)
 	if !ok {

--- a/internal/server/frontend_test.go
+++ b/internal/server/frontend_test.go
@@ -79,6 +79,31 @@ func TestFrontendHandlerServesStaticAssetsWithoutCSP(t *testing.T) {
 	}
 }
 
+func TestFrontendHandlerReturns404ForMissingAssets(t *testing.T) {
+	handler := newFrontendTestHandler(t)
+
+	// A content-hashed chunk from a previous build no longer exists after a
+	// deploy. Serving the SPA shell at a .js URL makes the browser fail with
+	// "Failed to fetch dynamically imported module"; a 404 lets clients (and
+	// the preload-error reload handler) see the real condition.
+	rr := httptest.NewRecorder()
+	handler.ServeHTTP(rr, httptest.NewRequest(http.MethodGet, "/assets/view-OldHash.js", nil))
+
+	if rr.Code != http.StatusNotFound {
+		t.Fatalf("missing asset status = %d, want 404", rr.Code)
+	}
+	if ct := rr.Header().Get("Content-Type"); strings.Contains(ct, "text/html") {
+		t.Fatalf("missing asset served as HTML (%q), the SPA fallback must not swallow /assets/", ct)
+	}
+
+	// Non-asset app routes still get the shell.
+	rr = httptest.NewRecorder()
+	handler.ServeHTTP(rr, httptest.NewRequest(http.MethodGet, "/library/ebooks", nil))
+	if rr.Code != http.StatusOK || !strings.Contains(rr.Header().Get("Content-Type"), "text/html") {
+		t.Fatalf("SPA route = %d %q, want 200 HTML", rr.Code, rr.Header().Get("Content-Type"))
+	}
+}
+
 func newFrontendTestHandler(t *testing.T) http.Handler {
 	t.Helper()
 	prev := WebDistFS

--- a/web/src/lib/reloadOnPreloadError.test.ts
+++ b/web/src/lib/reloadOnPreloadError.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, it, vi } from "vitest";
+import { installPreloadErrorReload } from "./reloadOnPreloadError";
+
+function harness(now: () => number) {
+  const reload = vi.fn();
+  const storage = new Map<string, string>();
+  return {
+    reload,
+    deps: {
+      reload,
+      now,
+      getItem: (k: string) => storage.get(k) ?? null,
+      setItem: (k: string, v: string) => storage.set(k, v),
+    },
+  };
+}
+
+describe("installPreloadErrorReload", () => {
+  it("reloads when a dynamically imported chunk fails to load", () => {
+    const { reload, deps } = harness(() => 1_000_000);
+    installPreloadErrorReload(deps);
+
+    window.dispatchEvent(new Event("vite:preloadError"));
+    expect(reload).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not reload again within the loop-guard window", () => {
+    let clock = 1_000_000;
+    const { reload, deps } = harness(() => clock);
+
+    installPreloadErrorReload(deps);
+    window.dispatchEvent(new Event("vite:preloadError"));
+    expect(reload).toHaveBeenCalledTimes(1);
+
+    // Post-reload page still hits the error seconds later: give up instead
+    // of reload-looping.
+    clock += 5_000;
+    installPreloadErrorReload(deps);
+    window.dispatchEvent(new Event("vite:preloadError"));
+    expect(reload).toHaveBeenCalledTimes(1);
+  });
+
+  it("reloads again once the guard window has passed (a later deploy)", () => {
+    let clock = 1_000_000;
+    const { reload, deps } = harness(() => clock);
+
+    installPreloadErrorReload(deps);
+    window.dispatchEvent(new Event("vite:preloadError"));
+    expect(reload).toHaveBeenCalledTimes(1);
+
+    clock += 10 * 60_000;
+    installPreloadErrorReload(deps);
+    window.dispatchEvent(new Event("vite:preloadError"));
+    expect(reload).toHaveBeenCalledTimes(2);
+  });
+});

--- a/web/src/lib/reloadOnPreloadError.test.ts
+++ b/web/src/lib/reloadOnPreloadError.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it, vi } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import { installPreloadErrorReload } from "./reloadOnPreloadError";
 
 function harness(now: () => number) {
@@ -16,9 +16,16 @@ function harness(now: () => number) {
 }
 
 describe("installPreloadErrorReload", () => {
+  let cleanups: Array<() => void> = [];
+
+  afterEach(() => {
+    cleanups.forEach((cleanup) => cleanup());
+    cleanups = [];
+  });
+
   it("reloads when a dynamically imported chunk fails to load", () => {
     const { reload, deps } = harness(() => 1_000_000);
-    installPreloadErrorReload(deps);
+    cleanups.push(installPreloadErrorReload(deps));
 
     window.dispatchEvent(new Event("vite:preloadError"));
     expect(reload).toHaveBeenCalledTimes(1);
@@ -28,14 +35,14 @@ describe("installPreloadErrorReload", () => {
     let clock = 1_000_000;
     const { reload, deps } = harness(() => clock);
 
-    installPreloadErrorReload(deps);
+    cleanups.push(installPreloadErrorReload(deps));
     window.dispatchEvent(new Event("vite:preloadError"));
     expect(reload).toHaveBeenCalledTimes(1);
 
     // Post-reload page still hits the error seconds later: give up instead
     // of reload-looping.
     clock += 5_000;
-    installPreloadErrorReload(deps);
+    cleanups.push(installPreloadErrorReload(deps));
     window.dispatchEvent(new Event("vite:preloadError"));
     expect(reload).toHaveBeenCalledTimes(1);
   });
@@ -44,12 +51,12 @@ describe("installPreloadErrorReload", () => {
     let clock = 1_000_000;
     const { reload, deps } = harness(() => clock);
 
-    installPreloadErrorReload(deps);
+    cleanups.push(installPreloadErrorReload(deps));
     window.dispatchEvent(new Event("vite:preloadError"));
     expect(reload).toHaveBeenCalledTimes(1);
 
     clock += 10 * 60_000;
-    installPreloadErrorReload(deps);
+    cleanups.push(installPreloadErrorReload(deps));
     window.dispatchEvent(new Event("vite:preloadError"));
     expect(reload).toHaveBeenCalledTimes(2);
   });

--- a/web/src/lib/reloadOnPreloadError.ts
+++ b/web/src/lib/reloadOnPreloadError.ts
@@ -15,13 +15,13 @@ interface PreloadErrorReloadDeps {
   setItem: (key: string, value: string) => void;
 }
 
-export function installPreloadErrorReload(deps?: Partial<PreloadErrorReloadDeps>): void {
+export function installPreloadErrorReload(deps?: Partial<PreloadErrorReloadDeps>): () => void {
   const reload = deps?.reload ?? (() => window.location.reload());
   const now = deps?.now ?? Date.now;
   const getItem = deps?.getItem ?? ((k: string) => sessionStorage.getItem(k));
   const setItem = deps?.setItem ?? ((k: string, v: string) => sessionStorage.setItem(k, v));
 
-  window.addEventListener("vite:preloadError", (event) => {
+  const handler = (event: Event) => {
     const lastReloadAt = Number(getItem(GUARD_KEY) ?? 0);
     if (now() - lastReloadAt < GUARD_WINDOW_MS) {
       // We already reloaded moments ago and the chunk is still missing;
@@ -31,5 +31,8 @@ export function installPreloadErrorReload(deps?: Partial<PreloadErrorReloadDeps>
     event.preventDefault();
     setItem(GUARD_KEY, String(now()));
     reload();
-  });
+  };
+
+  window.addEventListener("vite:preloadError", handler);
+  return () => window.removeEventListener("vite:preloadError", handler);
 }

--- a/web/src/lib/reloadOnPreloadError.ts
+++ b/web/src/lib/reloadOnPreloadError.ts
@@ -1,0 +1,35 @@
+// After a deploy, an open tab's code still references the previous build's
+// content-hashed chunks; the first lazy navigation then fails with
+// "Failed to fetch dynamically imported module". Vite reports that as a
+// window "vite:preloadError" event — reload once so the tab picks up the
+// current build, with a time guard so a persistently broken chunk cannot
+// cause a reload loop.
+
+const GUARD_KEY = "silo:preload-error-reload-at";
+const GUARD_WINDOW_MS = 60_000;
+
+interface PreloadErrorReloadDeps {
+  reload: () => void;
+  now: () => number;
+  getItem: (key: string) => string | null;
+  setItem: (key: string, value: string) => void;
+}
+
+export function installPreloadErrorReload(deps?: Partial<PreloadErrorReloadDeps>): void {
+  const reload = deps?.reload ?? (() => window.location.reload());
+  const now = deps?.now ?? Date.now;
+  const getItem = deps?.getItem ?? ((k: string) => sessionStorage.getItem(k));
+  const setItem = deps?.setItem ?? ((k: string, v: string) => sessionStorage.setItem(k, v));
+
+  window.addEventListener("vite:preloadError", (event) => {
+    const lastReloadAt = Number(getItem(GUARD_KEY) ?? 0);
+    if (now() - lastReloadAt < GUARD_WINDOW_MS) {
+      // We already reloaded moments ago and the chunk is still missing;
+      // let the failure surface instead of reload-looping.
+      return;
+    }
+    event.preventDefault();
+    setItem(GUARD_KEY, String(now()));
+    reload();
+  });
+}

--- a/web/src/main.tsx
+++ b/web/src/main.tsx
@@ -1,6 +1,9 @@
 import { createRoot } from "react-dom/client";
 import App from "./App";
+import { installPreloadErrorReload } from "./lib/reloadOnPreloadError";
 import "./app.css";
+
+installPreloadErrorReload();
 
 const root = document.getElementById("root");
 if (root === null) throw new Error("Root element #root not found");


### PR DESCRIPTION
## Summary

Every deploy changes the content-hashed `/assets/` chunk names. An open tab from before the deploy fails its next lazy navigation with "Failed to fetch dynamically imported module" — made worse by the SPA fallback answering the missing chunk URL with **200 + index.html**, so the browser rejects an HTML document as a JS module instead of seeing a clean miss.

Two fixes, observed and verified on a production install today:

- **Server**: `/assets/` paths that don't resolve to a bundled file now return 404 instead of falling through to the SPA shell. Fingerprinted assets are immutable; an unknown one is a stale reference, not an app route.
- **Web**: handle Vite's `vite:preloadError` by reloading once onto the current build, guarded to at most one reload per minute so a genuinely broken deploy cannot reload-loop.

## Tests

- `go test ./internal/server` (new: `TestFrontendHandlerReturns404ForMissingAssets`)
- `pnpm exec vitest run src/lib/reloadOnPreloadError.test.ts` (3 cases: reload, loop guard, guard expiry)
- Live-verified: stale chunk URL now 404s; SPA routes still serve the shell with CSP intact

## AI-use disclosure

Implemented with Claude Code (TDD).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Missing frontend asset files now return a clear 404 response instead of incorrectly serving the application shell.
  * Added automatic page recovery when a dynamically loaded application component fails after an update.
  * Recovery is limited to once per minute to prevent repeated reload loops.
  * Normal application routes continue to load as expected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->