### PR TITLE
feat(web): collapse per-scan rows on the admin Libraries page

### DIFF
--- a/web/src/lib/scanRuns.ts
+++ b/web/src/lib/scanRuns.ts
@@ -26,6 +26,14 @@ export function formatActiveScanMode(scan: Pick<ScanRun, "mode">) {
   }
 }
 
+export function formatActiveScanTarget(scan: Pick<ScanRun, "path">) {
+  if (!scan.path) {
+    return "Entire library";
+  }
+  const segments = scan.path.replace(/\/+$/, "").split("/");
+  return segments[segments.length - 1] || scan.path;
+}
+
 export function formatActiveScanTrigger(trigger: string) {
   switch (trigger) {
     case "autoscan":

--- a/web/src/pages/AdminLibraries.test.tsx
+++ b/web/src/pages/AdminLibraries.test.tsx
@@ -299,7 +299,9 @@ describe("AdminLibraries", () => {
     const markup = renderPage();
 
     expect(markup).toContain("Processing files · 10 / 20 (50%)");
-    expect(markup).toContain("Full library scan · Entire library");
+    // Mode and target render as separate compact-row elements.
+    expect(markup).toContain("Full library scan");
+    expect(markup).toContain("Entire library");
   });
 
   it("renders the collapsed Ambiguous Roots section when no roots exist", () => {

--- a/web/src/pages/AdminLibraries.tsx
+++ b/web/src/pages/AdminLibraries.tsx
@@ -95,6 +95,7 @@ import {
   compareActiveScans,
   formatActiveScanMode,
   formatActiveScanProgress,
+  formatActiveScanTarget,
   formatActiveScanTime,
   formatActiveScanTrigger,
 } from "@/lib/scanRuns";
@@ -789,93 +790,147 @@ function ScanQueuePopover({
         {/* Library groups */}
         <div className="max-h-[360px] overflow-y-auto px-3 py-2">
           {groups.map((group, gi) => (
-            <div key={group.libraryID}>
-              {/* Library header row */}
-              <div className="flex items-center gap-2 py-1.5">
-                <span className="text-muted-foreground/60 text-[10px] font-semibold tracking-widest uppercase">
-                  {getLibraryScanGroupName(group.library, group.libraryID)}
-                </span>
-                <div className="bg-border/25 h-px flex-1" />
-                <Button
-                  variant="ghost"
-                  size="sm"
-                  className="text-muted-foreground hover:text-destructive h-6 gap-1 px-2 text-[10px]"
-                  disabled={cancellingLibraryID === group.libraryID}
-                  onClick={() => onCancel(group.libraryID)}
-                >
-                  <Square className="h-2.5 w-2.5" />
-                  Cancel
-                </Button>
-              </div>
-
-              {/* Scan rows */}
-              {group.scans.map((scan, si) => (
-                <div
-                  key={scan.id}
-                  className={cn(
-                    "flex items-start gap-2.5 rounded-lg px-2.5 py-2 transition-colors",
-                    scan.status === "running" ? "bg-primary/[0.04]" : "",
-                  )}
-                  style={{
-                    animation: "fade-in 0.25s ease-out backwards",
-                    animationDelay: `${(gi * 4 + si) * 40}ms`,
-                  }}
-                >
-                  {/* Status dot */}
-                  <div className="relative mt-[5px] flex h-2.5 w-2.5 shrink-0 items-center justify-center">
-                    {scan.status === "running" ? (
-                      <>
-                        <span className="bg-success/20 absolute h-2.5 w-2.5 animate-ping rounded-full" />
-                        <span className="bg-success shadow-success/30 relative h-[7px] w-[7px] rounded-full shadow-[0_0_5px_1px]" />
-                      </>
-                    ) : (
-                      <span className="bg-muted-foreground/20 ring-muted-foreground/15 h-[5px] w-[5px] rounded-full ring-[1.5px]" />
-                    )}
-                  </div>
-
-                  {/* Details */}
-                  <div className="min-w-0 flex-1">
-                    <div className="flex items-baseline gap-1.5">
-                      <span className="text-xs leading-snug font-medium">
-                        {formatActiveScanMode(scan)}
-                      </span>
-                      {scan.trigger && (
-                        <span className="bg-muted/50 text-muted-foreground rounded px-1 py-px text-[9px] font-medium">
-                          {formatActiveScanTrigger(scan.trigger)}
-                        </span>
-                      )}
-                    </div>
-                    <div className="text-muted-foreground mt-px flex items-center gap-1 text-[10px] leading-relaxed">
-                      {scan.path ? (
-                        <code className="text-muted-foreground/70 max-w-[200px] truncate font-mono">
-                          {scan.path}
-                        </code>
-                      ) : (
-                        <span>Entire library</span>
-                      )}
-                      <span className="text-border/50 shrink-0">·</span>
-                      <span className="shrink-0">
-                        {scan.status === "running"
-                          ? formatActiveScanTime(scan.started_at, "Started")
-                          : "Waiting for capacity"}
-                      </span>
-                    </div>
-                    {formatActiveScanProgress(scan) && (
-                      <div className="text-muted-foreground/80 mt-1 truncate text-[10px] leading-relaxed">
-                        {formatActiveScanProgress(scan)}
-                      </div>
-                    )}
-                  </div>
-                </div>
-              ))}
-
-              {/* Separator between groups */}
-              {gi < groups.length - 1 && <div className="bg-border/20 my-1 h-px" />}
-            </div>
+            <ScanQueueGroup
+              key={group.libraryID}
+              group={group}
+              groupIndex={gi}
+              isLast={gi === groups.length - 1}
+              cancelling={cancellingLibraryID === group.libraryID}
+              onCancel={onCancel}
+            />
           ))}
         </div>
       </PopoverContent>
     </Popover>
+  );
+}
+
+function ScanQueueGroup({
+  group,
+  groupIndex,
+  isLast,
+  cancelling,
+  onCancel,
+}: {
+  group: {
+    libraryID: number;
+    library: Library | null;
+    scans: ScanRun[];
+    runningCount: number;
+    queuedCount: number;
+  };
+  groupIndex: number;
+  isLast: boolean;
+  cancelling: boolean;
+  onCancel: (libraryID: number) => void;
+}) {
+  const [expanded, setExpanded] = useState(false);
+  const visibleScans = expanded ? group.scans : group.scans.slice(0, COLLAPSED_SCAN_ROW_LIMIT);
+  const hiddenCount = group.scans.length - visibleScans.length;
+
+  return (
+    <div>
+      {/* Library header row */}
+      <div className="flex items-center gap-2 py-1.5">
+        <span className="text-muted-foreground/60 text-[10px] font-semibold tracking-widest uppercase">
+          {getLibraryScanGroupName(group.library, group.libraryID)}
+        </span>
+        <div className="bg-border/25 h-px flex-1" />
+        <Button
+          variant="ghost"
+          size="sm"
+          className="text-muted-foreground hover:text-destructive h-6 gap-1 px-2 text-[10px]"
+          disabled={cancelling}
+          onClick={() => onCancel(group.libraryID)}
+        >
+          <Square className="h-2.5 w-2.5" />
+          Cancel
+        </Button>
+      </div>
+
+      {/* Scan rows */}
+      {visibleScans.map((scan, si) => (
+        <div
+          key={scan.id}
+          className={cn(
+            "flex items-start gap-2.5 rounded-lg px-2.5 py-2 transition-colors",
+            scan.status === "running" ? "bg-primary/[0.04]" : "",
+          )}
+          style={{
+            animation: "fade-in 0.25s ease-out backwards",
+            animationDelay: `${Math.min(groupIndex * 4 + si, 12) * 40}ms`,
+          }}
+        >
+          {/* Status dot */}
+          <div className="relative mt-[5px] flex h-2.5 w-2.5 shrink-0 items-center justify-center">
+            {scan.status === "running" ? (
+              <>
+                <span className="bg-success/20 absolute h-2.5 w-2.5 animate-ping rounded-full" />
+                <span className="bg-success shadow-success/30 relative h-[7px] w-[7px] rounded-full shadow-[0_0_5px_1px]" />
+              </>
+            ) : (
+              <span className="bg-muted-foreground/20 ring-muted-foreground/15 h-[5px] w-[5px] rounded-full ring-[1.5px]" />
+            )}
+          </div>
+
+          {/* Details */}
+          <div className="min-w-0 flex-1">
+            <div className="flex items-baseline gap-1.5">
+              <span className="text-xs leading-snug font-medium">{formatActiveScanMode(scan)}</span>
+              {scan.trigger && (
+                <span className="bg-muted/50 text-muted-foreground rounded px-1 py-px text-[9px] font-medium">
+                  {formatActiveScanTrigger(scan.trigger)}
+                </span>
+              )}
+            </div>
+            <div className="text-muted-foreground mt-px flex items-center gap-1 text-[10px] leading-relaxed">
+              {scan.path ? (
+                <code
+                  className="text-muted-foreground/70 max-w-[200px] truncate font-mono"
+                  title={scan.path}
+                >
+                  {formatActiveScanTarget(scan)}
+                </code>
+              ) : (
+                <span>Entire library</span>
+              )}
+              <span className="text-border/50 shrink-0">·</span>
+              <span className="shrink-0">
+                {scan.status === "running"
+                  ? formatActiveScanTime(scan.started_at, "Started")
+                  : "Waiting for capacity"}
+              </span>
+            </div>
+            {formatActiveScanProgress(scan) && (
+              <div className="text-muted-foreground/80 mt-1 truncate text-[10px] leading-relaxed">
+                {formatActiveScanProgress(scan)}
+              </div>
+            )}
+          </div>
+        </div>
+      ))}
+      {group.scans.length > COLLAPSED_SCAN_ROW_LIMIT ? (
+        <button
+          type="button"
+          className="text-muted-foreground hover:text-foreground flex items-center gap-1 rounded-lg px-2.5 py-1.5 text-[10px] transition-colors"
+          onClick={() => setExpanded((current) => !current)}
+        >
+          {expanded ? (
+            <>
+              Show less <ChevronUp className="h-3 w-3" />
+            </>
+          ) : (
+            <>
+              + {hiddenCount} more{hiddenCount <= group.queuedCount ? " queued" : ""}{" "}
+              <ChevronDown className="h-3 w-3" />
+            </>
+          )}
+        </button>
+      ) : null}
+
+      {/* Separator between groups */}
+      {!isLast && <div className="bg-border/20 my-1 h-px" />}
+    </div>
   );
 }
 
@@ -954,57 +1009,121 @@ function LibraryActiveWorkRow({
               </div>
             </div>
           ) : null}
-          {activeLibraryScans.map((scan) => (
-            <LibraryScanTaskRow
-              key={scan.id}
-              scan={scan}
+          {activeLibraryScans.length > 0 ? (
+            <LibraryScanTasks
+              scans={activeLibraryScans}
               cancelling={cancellingLibraryID === libraryID}
               libraryID={libraryID}
               onCancelScans={onCancelScans}
             />
-          ))}
+          ) : null}
         </div>
       </TableCell>
     </TableRow>
   );
 }
 
-function LibraryScanTaskRow({
-  scan,
+// How many scan rows a library shows before the rest collapse behind "Show all".
+const COLLAPSED_SCAN_ROW_LIMIT = 4;
+
+function LibraryScanTasks({
+  scans,
   cancelling,
   libraryID,
   onCancelScans,
 }: {
-  scan: ScanRun;
+  scans: ScanRun[];
   cancelling: boolean;
   libraryID: number;
   onCancelScans: (libraryID: number) => void;
 }) {
-  const progress = formatActiveScanProgress(scan);
+  const [expanded, setExpanded] = useState(false);
+  const runningCount = scans.filter((scan) => scan.status === "running").length;
+  const queuedCount = scans.length - runningCount;
+  const visibleScans = expanded ? scans : scans.slice(0, COLLAPSED_SCAN_ROW_LIMIT);
+  const hiddenCount = scans.length - visibleScans.length;
 
   return (
-    <div className="flex min-w-0 items-start gap-1.5">
-      <StopTaskButton
-        disabled={cancelling}
-        label="Cancel library scans"
-        onClick={() => onCancelScans(libraryID)}
-      />
-      <RefreshCw
-        className={cn("mt-0.5 h-3 w-3 shrink-0", scan.status === "running" && "animate-spin")}
-      />
-      <div className="min-w-0 flex-1 space-y-0.5">
-        <div className="flex min-w-0 items-center gap-1.5">
-          <span className="text-foreground/80 font-medium">Scan</span>
-          <span className="shrink-0">{scan.status === "running" ? "Running" : "Queued"}</span>
-        </div>
-        <div className="text-muted-foreground/80 truncate text-[10px]">
-          {formatActiveScanMode(scan)}
-          {scan.path ? ` · ${scan.path}` : " · Entire library"}
-        </div>
-        {progress ? (
-          <div className="text-muted-foreground/80 truncate text-[10px]">{progress}</div>
+    <div className="flex min-w-0 flex-col gap-1">
+      <div className="flex min-w-0 items-center gap-1.5">
+        <StopTaskButton
+          disabled={cancelling}
+          label="Cancel library scans"
+          onClick={() => onCancelScans(libraryID)}
+        />
+        <RefreshCw
+          className={cn("h-3 w-3 shrink-0", runningCount > 0 && "animate-spin")}
+          style={{ animationDuration: "2s" }}
+        />
+        <span className="text-foreground/80 font-medium">Scan</span>
+        <span className="tabular-nums">
+          {runningCount > 0 ? `${runningCount} running` : null}
+          {runningCount > 0 && queuedCount > 0 ? " · " : null}
+          {queuedCount > 0 ? `${queuedCount} queued` : null}
+        </span>
+        {scans.length > COLLAPSED_SCAN_ROW_LIMIT ? (
+          <button
+            type="button"
+            className="text-muted-foreground hover:text-foreground flex items-center gap-0.5 rounded px-1 text-[10px] transition-colors"
+            onClick={() => setExpanded((current) => !current)}
+          >
+            {expanded ? (
+              <>
+                Show less <ChevronUp className="h-3 w-3" />
+              </>
+            ) : (
+              <>
+                Show all {scans.length} <ChevronDown className="h-3 w-3" />
+              </>
+            )}
+          </button>
         ) : null}
       </div>
+      <div
+        className={cn(
+          "flex min-w-0 flex-col gap-0.5 pl-[3.375rem]",
+          expanded && "max-h-56 overflow-y-auto",
+        )}
+      >
+        {visibleScans.map((scan) => (
+          <CompactScanRow key={scan.id} scan={scan} />
+        ))}
+        {hiddenCount > 0 ? (
+          <button
+            type="button"
+            className="text-muted-foreground/70 hover:text-foreground w-fit rounded text-left text-[10px] transition-colors"
+            onClick={() => setExpanded(true)}
+          >
+            + {hiddenCount} more{hiddenCount <= queuedCount ? " queued" : ""}
+          </button>
+        ) : null}
+      </div>
+    </div>
+  );
+}
+
+function CompactScanRow({ scan }: { scan: ScanRun }) {
+  const progress = scan.status === "running" ? formatActiveScanProgress(scan) : "";
+
+  return (
+    <div className="flex min-w-0 items-center gap-1.5" title={scan.path}>
+      <span
+        className={cn(
+          "h-1.5 w-1.5 shrink-0 rounded-full",
+          scan.status === "running" ? "bg-success" : "bg-muted-foreground/30",
+        )}
+      />
+      {scan.mode !== "file" ? (
+        <span className="shrink-0 text-[10px]">{formatActiveScanMode(scan)}</span>
+      ) : null}
+      {scan.path ? (
+        <code className="text-muted-foreground/80 truncate font-mono text-[10px]">
+          {formatActiveScanTarget(scan)}
+        </code>
+      ) : null}
+      {progress ? (
+        <span className="text-muted-foreground/60 truncate text-[10px]">· {progress}</span>
+      ) : null}
     </div>
   );
 }

--- a/web/src/pages/AdminLibraries.tsx
+++ b/web/src/pages/AdminLibraries.tsx
@@ -805,6 +805,21 @@ function ScanQueuePopover({
   );
 }
 
+// How many scan rows a group shows before the rest collapse behind an expander.
+const COLLAPSED_SCAN_ROW_LIMIT = 4;
+
+function useCollapsedScans(scans: ScanRun[]) {
+  const [expanded, setExpanded] = useState(false);
+  const visibleScans = expanded ? scans : scans.slice(0, COLLAPSED_SCAN_ROW_LIMIT);
+  return {
+    expanded,
+    setExpanded,
+    visibleScans,
+    hiddenCount: scans.length - visibleScans.length,
+    collapsible: scans.length > COLLAPSED_SCAN_ROW_LIMIT,
+  };
+}
+
 function ScanQueueGroup({
   group,
   groupIndex,
@@ -824,9 +839,9 @@ function ScanQueueGroup({
   cancelling: boolean;
   onCancel: (libraryID: number) => void;
 }) {
-  const [expanded, setExpanded] = useState(false);
-  const visibleScans = expanded ? group.scans : group.scans.slice(0, COLLAPSED_SCAN_ROW_LIMIT);
-  const hiddenCount = group.scans.length - visibleScans.length;
+  const { expanded, setExpanded, visibleScans, hiddenCount, collapsible } = useCollapsedScans(
+    group.scans,
+  );
 
   return (
     <div>
@@ -884,16 +899,12 @@ function ScanQueueGroup({
               )}
             </div>
             <div className="text-muted-foreground mt-px flex items-center gap-1 text-[10px] leading-relaxed">
-              {scan.path ? (
-                <code
-                  className="text-muted-foreground/70 max-w-[200px] truncate font-mono"
-                  title={scan.path}
-                >
-                  {formatActiveScanTarget(scan)}
-                </code>
-              ) : (
-                <span>Entire library</span>
-              )}
+              <code
+                className="text-muted-foreground/70 max-w-[200px] truncate font-mono"
+                title={scan.path}
+              >
+                {formatActiveScanTarget(scan)}
+              </code>
               <span className="text-border/50 shrink-0">·</span>
               <span className="shrink-0">
                 {scan.status === "running"
@@ -909,7 +920,7 @@ function ScanQueueGroup({
           </div>
         </div>
       ))}
-      {group.scans.length > COLLAPSED_SCAN_ROW_LIMIT ? (
+      {collapsible ? (
         <button
           type="button"
           className="text-muted-foreground hover:text-foreground flex items-center gap-1 rounded-lg px-2.5 py-1.5 text-[10px] transition-colors"
@@ -1023,9 +1034,6 @@ function LibraryActiveWorkRow({
   );
 }
 
-// How many scan rows a library shows before the rest collapse behind "Show all".
-const COLLAPSED_SCAN_ROW_LIMIT = 4;
-
 function LibraryScanTasks({
   scans,
   cancelling,
@@ -1037,11 +1045,9 @@ function LibraryScanTasks({
   libraryID: number;
   onCancelScans: (libraryID: number) => void;
 }) {
-  const [expanded, setExpanded] = useState(false);
+  const { expanded, setExpanded, visibleScans, collapsible } = useCollapsedScans(scans);
   const runningCount = scans.filter((scan) => scan.status === "running").length;
   const queuedCount = scans.length - runningCount;
-  const visibleScans = expanded ? scans : scans.slice(0, COLLAPSED_SCAN_ROW_LIMIT);
-  const hiddenCount = scans.length - visibleScans.length;
 
   return (
     <div className="flex min-w-0 flex-col gap-1">
@@ -1061,7 +1067,7 @@ function LibraryScanTasks({
           {runningCount > 0 && queuedCount > 0 ? " · " : null}
           {queuedCount > 0 ? `${queuedCount} queued` : null}
         </span>
-        {scans.length > COLLAPSED_SCAN_ROW_LIMIT ? (
+        {collapsible ? (
           <button
             type="button"
             className="text-muted-foreground hover:text-foreground flex items-center gap-0.5 rounded px-1 text-[10px] transition-colors"
@@ -1088,15 +1094,6 @@ function LibraryScanTasks({
         {visibleScans.map((scan) => (
           <CompactScanRow key={scan.id} scan={scan} />
         ))}
-        {hiddenCount > 0 ? (
-          <button
-            type="button"
-            className="text-muted-foreground/70 hover:text-foreground w-fit rounded text-left text-[10px] transition-colors"
-            onClick={() => setExpanded(true)}
-          >
-            + {hiddenCount} more{hiddenCount <= queuedCount ? " queued" : ""}
-          </button>
-        ) : null}
       </div>
     </div>
   );
@@ -1120,7 +1117,11 @@ function CompactScanRow({ scan }: { scan: ScanRun }) {
         <code className="text-muted-foreground/80 truncate font-mono text-[10px]">
           {formatActiveScanTarget(scan)}
         </code>
-      ) : null}
+      ) : (
+        <span className="text-muted-foreground/80 truncate text-[10px]">
+          {formatActiveScanTarget(scan)}
+        </span>
+      )}
       {progress ? (
         <span className="text-muted-foreground/60 truncate text-[10px]">· {progress}</span>
       ) : null}


### PR DESCRIPTION
## Problem

When autoscan picks up a batch of files (e.g. a season drop), the admin Libraries page renders one full-width row per scan under the library — with 70+ queued single-file scans the table becomes an unusable wall of full paths. Worse, every row had its own red stop button, but each one actually cancelled *all* scans for the library, which was misleading.

## What changed

- **Inline library rows**: a library's scans now collapse into one summary line (`Scan · 4 running · 67 queued`) with a single cancel control. Up to 4 compact rows follow (status dot, file basename with full path on hover, progress for running scans), then a "+ N more queued" link. "Show all N" expands into a height-capped scrollable list, so the table never blows out regardless of queue depth. Full-library/subtree scans still show their mode label.
- **Scan Queue popover**: same running-first collapse per library group behind a "+ N more queued" toggle; rows show basenames instead of full truncated paths (full path on hover); the staggered fade-in delay is capped so deep rows don't appear seconds late.
- `formatActiveScanTarget` helper added to `web/src/lib/scanRuns.ts` (basename of the scan path).

Pure frontend change; no API or server behavior touched.

## Verification

- `tsc`, ESLint, and Prettier pass (pre-existing warning baseline only).
- Verified visually in the Vite dev app with a seeded fixture matching the original report (4 running + 67 queued file scans + a full-library scan): collapsed and expanded inline views, and the popover in both states.

## Notes for review

- The "+ N more queued" label degrades to "+ N more" if hidden rows include running scans (only when >4 are running).
- Spotted in passing, not touched here: if `useAdminLibraries` errors with an empty cache, the `setOrderedLibraries` effect render-loops because the `= []` destructuring default is a new array each render (only reachable with the API down).

## Scope link

No existing issue covers this; UI/UX cleanup requested directly by the admin. Happy to link it to a capability epic if one fits.

## AI-use disclosure

Implemented and verified by Claude Code (Fable 5) under review of @Quick104.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added clearer active scan target labels, including “Entire library” when no specific path is available.
  * Added grouped, expandable/collapsible scan queue rendering with compact scan rows showing status, mode (when applicable), formatted target, and progress.
  * Added running and queued scan counts in library activity displays, plus “Show all/Show less” for long scan lists.

* **Usability Improvements**
  * Improved how scan target text is presented across both the scan-queue popover and per-library active work views.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->