### PR TITLE
ci(docker): publish multi-arch images (linux/amd64 + linux/arm64)

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -19,7 +19,15 @@ env:
 
 jobs:
   build:
-    runs-on: [self-hosted, linux]
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - platform: linux/amd64
+            runner: ubuntu-latest
+          - platform: linux/arm64
+            runner: ubuntu-24.04-arm
+    runs-on: ${{ matrix.runner }}
     permissions:
       contents: read
       packages: write
@@ -27,6 +35,13 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v5
+
+      - name: Prepare platform slug and lowercase image name
+        run: |
+          echo "PLATFORM_PAIR=${PLATFORM//\//-}" >> "$GITHUB_ENV"
+          echo "IMAGE_LC=${IMAGE_NAME,,}" >> "$GITHUB_ENV"
+        env:
+          PLATFORM: ${{ matrix.platform }}
 
       - name: Set up pnpm
         uses: pnpm/action-setup@v4
@@ -76,9 +91,69 @@ jobs:
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@v3
         with:
-          name: silo-builder
-          keep-state: true
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract metadata
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+
+      - name: Build and push by digest
+        id: build
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          platforms: ${{ matrix.platform }}
+          labels: ${{ steps.meta.outputs.labels }}
+          build-contexts: |
+            frontend_dist=./web/dist
+          build-args: |
+            BUILD_REVISION=${{ github.sha }}
+            BUILD_DIRTY=false
+          cache-from: type=gha,scope=docker-${{ env.PLATFORM_PAIR }}
+          cache-to: type=gha,scope=docker-${{ env.PLATFORM_PAIR }},mode=max
+          outputs: type=image,name=${{ env.REGISTRY }}/${{ env.IMAGE_LC }},push-by-digest=true,name-canonical=true,push=true
+
+      - name: Export digest
+        run: |
+          mkdir -p "${RUNNER_TEMP}/digests"
+          digest="${{ steps.build.outputs.digest }}"
+          touch "${RUNNER_TEMP}/digests/${digest#sha256:}"
+
+      - name: Upload digest
+        uses: actions/upload-artifact@v4
+        with:
+          name: digests-${{ env.PLATFORM_PAIR }}
+          path: ${{ runner.temp }}/digests/*
+          if-no-files-found: error
+          retention-days: 1
+
+  merge:
+    runs-on: ubuntu-latest
+    needs: build
+    permissions:
+      packages: write
+
+    steps:
+      - name: Prepare lowercase image name
+        run: echo "IMAGE_LC=${IMAGE_NAME,,}" >> "$GITHUB_ENV"
+
+      - name: Download digests
+        uses: actions/download-artifact@v4
+        with:
+          path: ${{ runner.temp }}/digests
+          pattern: digests-*
+          merge-multiple: true
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
 
       - name: Log in to GitHub Container Registry
         uses: docker/login-action@v3
@@ -96,16 +171,14 @@ jobs:
             type=raw,value=latest,enable={{is_default_branch}}
             type=sha,prefix=,format=short
 
-      - name: Build and push
-        uses: docker/build-push-action@v6
-        with:
-          context: .
-          platforms: linux/amd64,linux/arm64
-          push: true
-          tags: ${{ steps.meta.outputs.tags }}
-          labels: ${{ steps.meta.outputs.labels }}
-          build-contexts: |
-            frontend_dist=./web/dist
-          build-args: |
-            BUILD_REVISION=${{ github.sha }}
-            BUILD_DIRTY=false
+      - name: Create and push manifest list
+        working-directory: ${{ runner.temp }}/digests
+        run: |
+          # shellcheck disable=SC2046
+          docker buildx imagetools create \
+            $(jq -cr '.tags | map("-t " + .) | join(" ")' <<< "$DOCKER_METADATA_OUTPUT_JSON") \
+            $(printf "${REGISTRY}/${IMAGE_LC}@sha256:%s " *)
+
+      - name: Inspect manifest list
+        run: |
+          docker buildx imagetools inspect "${REGISTRY}/${IMAGE_LC}:${GITHUB_SHA::7}"

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -166,7 +166,7 @@ jobs:
         id: meta
         uses: docker/metadata-action@v5
         with:
-          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_LC }}
           tags: |
             type=raw,value=latest,enable={{is_default_branch}}
             type=sha,prefix=,format=short

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -100,6 +100,7 @@ jobs:
         uses: docker/build-push-action@v6
         with:
           context: .
+          platforms: linux/amd64,linux/arm64
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}


### PR DESCRIPTION
## Problem

The published `ghcr.io/silo-server/silo-server` image is amd64-only, so arm64 hosts (Apple Silicon via Docker Desktop/OrbStack, AWS Graviton, Raspberry Pi 4/5 on 64-bit OSes) either fail to pull or run under slow emulation. The build also depends on a single self-hosted runner (the Mac mini), which is a bus-factor and maintenance liability now that nothing requires it.

## Approach

Two commits:

1. **Multi-arch platforms** — add `linux/arm64` alongside `linux/amd64`. The Dockerfile was already arch-aware (`TARGETARCH` selects the Jellyfin apt repo arch) and all runtime deps ship arm64 debs.
2. **Move to GitHub-hosted runners** — replace the self-hosted job with a per-arch matrix (`ubuntu-latest` for amd64, `ubuntu-24.04-arm` for arm64; both free for public repos), each building natively with **no emulation** and pushing by digest, plus a `merge` job that stitches the digests into one tagged manifest list. Caching moves from the persistent local builder to `type=gha` per-platform scopes. The private-SDK constraint that originally forced self-hosted no longer applies — `silo-plugin-sdk` is public and resolves from `proxy.golang.org`.

Existing amd64 deployments are unaffected: `docker pull` transparently selects the right arch from the manifest list.

Other platforms were considered and rejected: armv7 (32-bit address-space limits with CGO/libvips, shrinking audience) and riscv64/ppc64le/s390x (no jellyfin-ffmpeg packages exist).

## Verification

- Full `linux/arm64` image built and smoke-tested locally (`silo` runs, `jellyfin-ffmpeg` 7.1.4 runs).
- `actionlint` clean.
- End-to-end `workflow_dispatch` test run of the new workflow on this branch (hosted runners, real digest push + manifest merge): run #29768620803.

## Risks / follow-up

- First hosted build per arch is cold (~no persistent Go build cache); `type=gha` layer caching (mode=max) keeps warm builds reasonable. GHA cache is capped at 10 GB per repo, so eviction slows builds rather than breaking them.
- `GOPRIVATE`/`GONOSUMDB` for `Silo-Server/*` are now unnecessary (SDK is public) and could be dropped in a follow-up to restore checksum-DB verification.
- The self-hosted runner can be decommissioned for this workflow once merged.
- No linked scope item: infra/CI change, no issue exists for it.

## AI-use disclosure

Authored by Claude Code (Fable 5), reviewed and directed by @Quick104.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated Docker image publishing to produce multi-architecture releases for both AMD64 and ARM64.
  * Builds now run per platform, generate platform-scoped cache entries, and publish images by digest.
  * A follow-up step aggregates the per-platform digests into a single multi-arch manifest and pushes the consolidated tagged image, including verification for the short commit tag.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->