### PR TITLE
feat(playback): VideoToolbox hardware transcoding on macOS

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -12,7 +12,11 @@ pre-submission gate are in [CONTRIBUTING.md](CONTRIBUTING.md).
 - Node.js 22+ with pnpm 10.32.1
 - PostgreSQL 18 with pgvector
 - Redis
-- FFmpeg (transcoding)
+- FFmpeg (transcoding). On macOS, install Homebrew's keg-only full build so
+  text-subtitle burn-in and the complete filter set are available alongside
+  VideoToolbox: `brew install ffmpeg-full`. Silo discovers the Apple Silicon
+  and Intel keg paths automatically when the FFmpeg Path setting is blank; a
+  custom build can be selected explicitly in Admin Settings.
 - A C compiler and build toolchain (CGO dependencies)
 - pkg-config and the libvips development headers (image processing through bimg)
 

--- a/cmd/silo/main.go
+++ b/cmd/silo/main.go
@@ -479,6 +479,15 @@ func runCompatWebCommand(ctx context.Context, args []string) error {
 	}
 }
 
+// normalizeLoadedConfig repairs derived config values after every load: the
+// DB-seeded default is Jellyfin's Linux-only ffmpeg path, so resolve it
+// through the same discovery the playback pipeline uses. Registered as an
+// OnLoad hook on both config watchers so hot reloads cannot restore the
+// seeded value, and applied to the startup snapshot before the watchers run.
+func normalizeLoadedConfig(cfg *config.Config) {
+	cfg.Playback.FFmpegPath = playback.ResolveFFmpegPath(cfg.Playback.FFmpegPath)
+}
+
 // main starts the Silo server or a requested maintenance command.
 func main() {
 	if len(os.Args) > 1 && os.Args[1] == "compat-web" {
@@ -667,12 +676,7 @@ func main() {
 	if err != nil {
 		log.Fatalf("building config: %v", err)
 	}
-	// The DB-seeded default is Jellyfin's Linux-only ffmpeg path. Resolve it
-	// through the same discovery the playback pipeline uses so consumers that
-	// read the config directly (scanner ffprobe derivation, intro markers,
-	// audiobook enrichment) execute the discovered binary on hosts where the
-	// conventional default does not exist.
-	cfg.Playback.FFmpegPath = playback.ResolveFFmpegPath(cfg.Playback.FFmpegPath)
+	normalizeLoadedConfig(cfg)
 
 	// Step 7: Apply bootstrap overrides
 	cfg.Server.Listen = bc.Listen
@@ -790,6 +794,7 @@ func main() {
 			RedisURL:    bc.RedisURL,
 		}
 		watcher := nodeconfig.NewWatcher(pool, dataCipher, eventBus, bootstrap)
+		watcher.OnLoad(normalizeLoadedConfig)
 		if err := watcher.Start(appCtx); err != nil {
 			slog.Error("config watcher start failed", "error", err)
 			os.Exit(1)
@@ -878,6 +883,7 @@ func main() {
 		JFListen:    bc.JFListen,
 		RedisURL:    bc.RedisURL,
 	})
+	configWatcher.OnLoad(normalizeLoadedConfig)
 	if err := configWatcher.Start(appCtx); err != nil {
 		log.Fatalf("config watcher start: %v", err)
 	}

--- a/cmd/silo/main.go
+++ b/cmd/silo/main.go
@@ -667,6 +667,12 @@ func main() {
 	if err != nil {
 		log.Fatalf("building config: %v", err)
 	}
+	// The DB-seeded default is Jellyfin's Linux-only ffmpeg path. Resolve it
+	// through the same discovery the playback pipeline uses so consumers that
+	// read the config directly (scanner ffprobe derivation, intro markers,
+	// audiobook enrichment) execute the discovered binary on hosts where the
+	// conventional default does not exist.
+	cfg.Playback.FFmpegPath = playback.ResolveFFmpegPath(cfg.Playback.FFmpegPath)
 
 	// Step 7: Apply bootstrap overrides
 	cfg.Server.Listen = bc.Listen

--- a/internal/api/handlers/playback_v3.go
+++ b/internal/api/handlers/playback_v3.go
@@ -2583,19 +2583,6 @@ func (h *PlaybackHandler) startReadyLocalPlaybackTransportV3(ctx context.Context
 	return ts, nil
 }
 
-// retryTransportHWAccelV3 picks the acceleration for the single startup
-// retry after ffmpeg dies before its first segment. VideoToolbox has no
-// alternate render device to move to, so a startup failure there — e.g. an
-// encoder session the hardware cannot create at the requested dimensions —
-// retries with software encoding; every other accel keeps its configured
-// value and relies on AvoidHWDevice to move devices.
-func retryTransportHWAccelV3(configuredHWAccel, ffmpegPath string) string {
-	if playback.ResolveHWAccelWithFFmpeg(configuredHWAccel, ffmpegPath) == "videotoolbox" {
-		return "none"
-	}
-	return configuredHWAccel
-}
-
 // prepareLocalTransportV3 starts a local HLS generation for the selected plan.
 func (h *PlaybackHandler) prepareLocalTransportV3(r *http.Request, session *playback.Session, file *models.MediaFile, result playback.PlannerResultV3, timeline preparedTimelineV3, mode mediaAuthModeV3) (preparedTransportV3, *transportErrorV3) {
 	cfg := h.playbackConfig()
@@ -2677,7 +2664,7 @@ func (h *PlaybackHandler) prepareLocalTransportV3(r *http.Request, session *play
 			// become an immediate client-visible transport error.
 			retryOpts := opts
 			retryOpts.AvoidHWDevice = startupFailure.failedDevice
-			retryOpts.HWAccel = retryTransportHWAccelV3(opts.HWAccel, opts.FFmpegPath)
+			retryOpts.HWAccel = playback.StartupRetryHWAccel(opts.HWAccel, opts.FFmpegPath)
 			slog.WarnContext(r.Context(), "local transcode crashed during startup; retrying once",
 				logComponentKey, playbackLogValueV3,
 				"playback_session_id", session.ID,

--- a/internal/api/handlers/playback_v3.go
+++ b/internal/api/handlers/playback_v3.go
@@ -2583,6 +2583,19 @@ func (h *PlaybackHandler) startReadyLocalPlaybackTransportV3(ctx context.Context
 	return ts, nil
 }
 
+// retryTransportHWAccelV3 picks the acceleration for the single startup
+// retry after ffmpeg dies before its first segment. VideoToolbox has no
+// alternate render device to move to, so a startup failure there — e.g. an
+// encoder session the hardware cannot create at the requested dimensions —
+// retries with software encoding; every other accel keeps its configured
+// value and relies on AvoidHWDevice to move devices.
+func retryTransportHWAccelV3(configuredHWAccel, ffmpegPath string) string {
+	if playback.ResolveHWAccelWithFFmpeg(configuredHWAccel, ffmpegPath) == "videotoolbox" {
+		return "none"
+	}
+	return configuredHWAccel
+}
+
 // prepareLocalTransportV3 starts a local HLS generation for the selected plan.
 func (h *PlaybackHandler) prepareLocalTransportV3(r *http.Request, session *playback.Session, file *models.MediaFile, result playback.PlannerResultV3, timeline preparedTimelineV3, mode mediaAuthModeV3) (preparedTransportV3, *transportErrorV3) {
 	cfg := h.playbackConfig()
@@ -2664,6 +2677,7 @@ func (h *PlaybackHandler) prepareLocalTransportV3(r *http.Request, session *play
 			// become an immediate client-visible transport error.
 			retryOpts := opts
 			retryOpts.AvoidHWDevice = startupFailure.failedDevice
+			retryOpts.HWAccel = retryTransportHWAccelV3(opts.HWAccel, opts.FFmpegPath)
 			slog.WarnContext(r.Context(), "local transcode crashed during startup; retrying once",
 				logComponentKey, playbackLogValueV3,
 				"playback_session_id", session.ID,

--- a/internal/api/handlers/playback_v3.go
+++ b/internal/api/handlers/playback_v3.go
@@ -2664,7 +2664,7 @@ func (h *PlaybackHandler) prepareLocalTransportV3(r *http.Request, session *play
 			// become an immediate client-visible transport error.
 			retryOpts := opts
 			retryOpts.AvoidHWDevice = startupFailure.failedDevice
-			retryOpts.HWAccel = playback.StartupRetryHWAccel(opts.HWAccel, opts.FFmpegPath)
+			retryOpts.HWAccel = playback.StartupRetryHWAccel(opts)
 			slog.WarnContext(r.Context(), "local transcode crashed during startup; retrying once",
 				logComponentKey, playbackLogValueV3,
 				"playback_session_id", session.ID,

--- a/internal/api/handlers/playback_v3_test.go
+++ b/internal/api/handlers/playback_v3_test.go
@@ -5352,7 +5352,6 @@ func TestTerminalAllowsAlternateFileV3CoversSubtitleForcedRefusals(t *testing.T)
 		t.Fatal("a nil terminal must not trigger an alternate-version retry")
 	}
 }
-
 func TestPlaybackV3ToneMapBudgetsCoverColdNodeWork(t *testing.T) {
 	handler := NewPlaybackHandler(playback.NewSessionManager(0, 0))
 	handler.PlaybackConfig = func() config.PlaybackConfig {
@@ -5448,17 +5447,5 @@ func TestRemoteToneMapProbeTimeoutUsesTargetNodeBudget(t *testing.T) {
 	}
 	if got, want := handler.remoteToneMapProbeTimeoutV3(remote.URL), 5*time.Minute; got != want {
 		t.Fatalf("bounded remote probe timeout = %s, want %s", got, want)
-	}
-}
-
-func TestRetryTransportHWAccelV3(t *testing.T) {
-	// Explicit values bypass ffmpeg probing, keeping this host-independent.
-	if got := retryTransportHWAccelV3("videotoolbox", "/does/not/exist"); got != "none" {
-		t.Fatalf("videotoolbox retry accel = %q, want none (no alternate device to move to)", got)
-	}
-	for _, accel := range []string{"qsv", "vaapi", "nvenc", "none"} {
-		if got := retryTransportHWAccelV3(accel, "/does/not/exist"); got != accel {
-			t.Fatalf("%s retry accel = %q, want unchanged", accel, got)
-		}
 	}
 }

--- a/internal/api/handlers/playback_v3_test.go
+++ b/internal/api/handlers/playback_v3_test.go
@@ -5450,3 +5450,15 @@ func TestRemoteToneMapProbeTimeoutUsesTargetNodeBudget(t *testing.T) {
 		t.Fatalf("bounded remote probe timeout = %s, want %s", got, want)
 	}
 }
+
+func TestRetryTransportHWAccelV3(t *testing.T) {
+	// Explicit values bypass ffmpeg probing, keeping this host-independent.
+	if got := retryTransportHWAccelV3("videotoolbox", "/does/not/exist"); got != "none" {
+		t.Fatalf("videotoolbox retry accel = %q, want none (no alternate device to move to)", got)
+	}
+	for _, accel := range []string{"qsv", "vaapi", "nvenc", "none"} {
+		if got := retryTransportHWAccelV3(accel, "/does/not/exist"); got != accel {
+			t.Fatalf("%s retry accel = %q, want unchanged", accel, got)
+		}
+	}
+}

--- a/internal/chapterthumbs/extractor.go
+++ b/internal/chapterthumbs/extractor.go
@@ -33,6 +33,7 @@ const (
 	hwAccelNone                 = "none"
 	hwAccelQSV                  = "qsv"
 	hwAccelVAAPI                = "vaapi"
+	hwAccelVideoToolbox         = "videotoolbox"
 	reasonChapterExtractFailed  = "chapter_extract_failed"
 	reasonDecodeInvalidData     = "decode_invalid_data"
 	reasonFFmpegProbeFailed     = "ffmpeg_probe_failed"
@@ -185,6 +186,19 @@ func ExtractFrame(ctx context.Context, opts FrameExtractOptions) ([]byte, string
 
 	resolvedAccel := playback.ResolveHWAccelWithFFmpeg(opts.HWAccel, ffmpegPath)
 	if supportsHardwareFrameExtract(resolvedAccel) {
+		softwareToneMapFilter := ""
+		if resolvedAccel == hwAccelVideoToolbox && opts.ToneMap {
+			if !opts.AllowSoftwareToneMap {
+				err := errors.New("software HDR tone mapping is disabled")
+				return nil, reasonToneMapUnsupported, wrapReason(reasonToneMapUnsupported, err)
+			}
+			filter, reason, err := softwareToneMapResolver.resolve(ffmpegPath)
+			if err != nil {
+				return nil, reason, wrapReason(reason, err)
+			}
+			softwareToneMapFilter = filter
+		}
+
 		// Resolve a multi-device hw_device list to one concrete GPU for this
 		// extraction; the reservation spans only the hardware attempt below.
 		resolvedDevice, releaseHWDevice := playback.AcquireHWDevice(opts.HWDevice, resolvedAccel)
@@ -193,7 +207,14 @@ func ExtractFrame(ctx context.Context, opts FrameExtractOptions) ([]byte, string
 			resolvedDevice = playback.PickRenderDevice("")
 		}
 
-		args, buildErr := buildFrameExtractArgs(opts.InputPath, opts.SeekSeconds, resolvedAccel, resolvedDevice, opts.ToneMap)
+		args, buildErr := buildFrameExtractArgs(
+			opts.InputPath,
+			opts.SeekSeconds,
+			resolvedAccel,
+			resolvedDevice,
+			opts.ToneMap,
+			softwareToneMapFilter,
+		)
 		if buildErr == nil {
 			attemptCtx, cancel := context.WithTimeout(ctx, extractTimeoutForAttempt(true, opts.ToneMap))
 			data, err := runExtract(attemptCtx, ffmpegPath, args)
@@ -241,7 +262,7 @@ func ExtractFrame(ctx context.Context, opts FrameExtractOptions) ([]byte, string
 }
 
 func supportsHardwareFrameExtract(hwAccel string) bool {
-	return hwAccel == hwAccelQSV || hwAccel == hwAccelVAAPI
+	return hwAccel == hwAccelQSV || hwAccel == hwAccelVAAPI || hwAccel == hwAccelVideoToolbox
 }
 
 type cpuFrameExtractOptions struct {
@@ -376,7 +397,14 @@ func buildCPUFrameExtractArgs(inputPath string, seekSeconds float64, softwareTon
 	return args
 }
 
-func buildFrameExtractArgs(inputPath string, seekSeconds float64, hwAccel string, hwDevice string, toneMap bool) ([]string, error) {
+func buildFrameExtractArgs(
+	inputPath string,
+	seekSeconds float64,
+	hwAccel string,
+	hwDevice string,
+	toneMap bool,
+	softwareToneMapFilter string,
+) ([]string, error) {
 	args := []string{
 		"-hide_banner",
 		"-loglevel", "error",
@@ -403,18 +431,34 @@ func buildFrameExtractArgs(inputPath string, seekSeconds float64, hwAccel string
 			"-hwaccel", "vaapi",
 			"-hwaccel_output_format", "vaapi",
 		)
+	case hwAccelVideoToolbox:
+		// VideoToolbox decodes into system-memory frames unless an explicit
+		// output format is requested. Keep them there so MJPEG output and the
+		// optional software HDR tone-map filter need no download/upload roundtrip.
+		args = append(args, "-hwaccel", hwAccelVideoToolbox)
 	default:
 		return nil, fmt.Errorf("hardware chapter thumbnail extraction does not support %q", hwAccel)
 	}
 
-	filter := "hwdownload,format=nv12"
-	if toneMap {
+	var filter string
+	if hwAccel == hwAccelVideoToolbox {
+		if toneMap && softwareToneMapFilter == "" {
+			return nil, errors.New("videotoolbox HDR extraction requires a software tone-map filter")
+		}
+		filter = softwareToneMapFilter
+	} else if toneMap {
 		filter = "setparams=color_primaries=bt2020:color_trc=smpte2084:colorspace=bt2020nc,procamp_vaapi=b=16:c=1,tonemap_vaapi=format=nv12:p=bt709:t=bt709:m=bt709,hwdownload,format=nv12"
+	} else {
+		filter = "hwdownload,format=nv12"
 	}
 	args = append(args,
 		"-ss", fmt.Sprintf("%.3f", seekSeconds),
 		"-i", inputPath,
-		"-vf", filter,
+	)
+	if filter != "" {
+		args = append(args, "-vf", filter)
+	}
+	args = append(args,
 		"-frames:v", "1",
 		"-f", "image2pipe",
 		"-vcodec", "mjpeg",

--- a/internal/chapterthumbs/extractor.go
+++ b/internal/chapterthumbs/extractor.go
@@ -27,6 +27,7 @@ type FrameExtractOptions struct {
 	RunFunc              func(ctx context.Context, ffmpegPath string, args []string) ([]byte, error)
 
 	softwareToneMapResolver *softwareToneMapFilterResolver
+	resolveHWAccel          func(ctx context.Context, hwAccel, ffmpegPath string) string
 }
 
 const (
@@ -174,6 +175,10 @@ func ExtractFrame(ctx context.Context, opts FrameExtractOptions) ([]byte, string
 	if softwareToneMapResolver == nil {
 		softwareToneMapResolver = defaultSoftwareToneMapFilterResolver
 	}
+	resolveHWAccel := opts.resolveHWAccel
+	if resolveHWAccel == nil {
+		resolveHWAccel = playback.ResolveHWAccelWithFFmpegContext
+	}
 	cpuOpts := cpuFrameExtractOptions{
 		ctx:                     ctx,
 		inputPath:               opts.InputPath,
@@ -184,7 +189,7 @@ func ExtractFrame(ctx context.Context, opts FrameExtractOptions) ([]byte, string
 		softwareToneMapResolver: softwareToneMapResolver,
 	}
 
-	resolvedAccel := playback.ResolveHWAccelWithFFmpeg(opts.HWAccel, ffmpegPath)
+	resolvedAccel := resolveHWAccel(ctx, opts.HWAccel, ffmpegPath)
 	if supportsHardwareFrameExtract(resolvedAccel) {
 		softwareToneMapFilter := ""
 		if resolvedAccel == hwAccelVideoToolbox && opts.ToneMap {

--- a/internal/chapterthumbs/extractor_test.go
+++ b/internal/chapterthumbs/extractor_test.go
@@ -286,6 +286,58 @@ func TestExtractFrameUnsupportedHardwareUsesCPU(t *testing.T) {
 	}
 }
 
+func TestExtractFrameVideoToolboxUsesHardwareDecodeOnce(t *testing.T) {
+	calls := 0
+	data, reason, err := ExtractFrame(context.Background(), FrameExtractOptions{
+		InputPath:   "/media/movie.mkv",
+		SeekSeconds: 42.5,
+		HWAccel:     "videotoolbox",
+		RunFunc: func(_ context.Context, _ string, args []string) ([]byte, error) {
+			calls++
+			joined := strings.Join(args, " ")
+			if !strings.Contains(joined, "-hwaccel videotoolbox") {
+				t.Fatalf("VideoToolbox extraction missing hardware decode: %s", joined)
+			}
+			if strings.Contains(joined, "hwdownload") || strings.Contains(joined, "-hwaccel_output_format") {
+				t.Fatalf("VideoToolbox extraction must keep software frames: %s", joined)
+			}
+			return []byte("frame"), nil
+		},
+	})
+	if err != nil || reason != "" || string(data) != "frame" {
+		t.Fatalf("ExtractFrame() = %q, %q, %v", data, reason, err)
+	}
+	if calls != 1 {
+		t.Fatalf("extract calls = %d, want 1", calls)
+	}
+}
+
+func TestExtractFrameVideoToolboxHDRUsesSoftwareToneMap(t *testing.T) {
+	resolver := resolverWithFilters(t, "zscale", "tonemapx")
+	data, reason, err := ExtractFrame(context.Background(), FrameExtractOptions{
+		InputPath:               "/media/hdr.mkv",
+		SeekSeconds:             42.5,
+		FFmpegPath:              "/test/ffmpeg",
+		HWAccel:                 "videotoolbox",
+		ToneMap:                 true,
+		AllowSoftwareToneMap:    true,
+		softwareToneMapResolver: resolver,
+		RunFunc: func(_ context.Context, _ string, args []string) ([]byte, error) {
+			joined := strings.Join(args, " ")
+			if !strings.Contains(joined, "-hwaccel videotoolbox") {
+				t.Fatalf("VideoToolbox HDR extraction missing hardware decode: %s", joined)
+			}
+			if !strings.Contains(joined, softwareToneMapFilterBT2390) {
+				t.Fatalf("VideoToolbox HDR extraction missing software tone map: %s", joined)
+			}
+			return []byte("frame"), nil
+		},
+	})
+	if err != nil || reason != "" || string(data) != "frame" {
+		t.Fatalf("ExtractFrame() = %q, %q, %v", data, reason, err)
+	}
+}
+
 func TestExtractFrameUnsupportedHardwarePreservesSDRRetry(t *testing.T) {
 	calls := 0
 	var firstRemaining, retryRemaining time.Duration

--- a/internal/chapterthumbs/extractor_test.go
+++ b/internal/chapterthumbs/extractor_test.go
@@ -241,6 +241,34 @@ func TestExtractFrameSoftwareHDRWithoutHardware(t *testing.T) {
 	assertApproximateDeadline(t, remaining, cpuExtractTimeoutHDR)
 }
 
+func TestExtractFramePassesCallerContextToHWAccelResolution(t *testing.T) {
+	ctx, cancel := context.WithCancel(t.Context())
+	cancel()
+
+	called := false
+	_, _, _ = ExtractFrame(ctx, FrameExtractOptions{
+		InputPath:  "/media/movie.mkv",
+		FFmpegPath: "/test/ffmpeg",
+		HWAccel:    "auto",
+		resolveHWAccel: func(gotCtx context.Context, hwAccel, ffmpegPath string) string {
+			called = true
+			if gotCtx != ctx {
+				t.Fatal("hardware probe did not receive the extraction context")
+			}
+			if hwAccel != "auto" || ffmpegPath != "/test/ffmpeg" {
+				t.Fatalf("hardware probe arguments = %q, %q", hwAccel, ffmpegPath)
+			}
+			return hwAccelNone
+		},
+		RunFunc: func(context.Context, string, []string) ([]byte, error) {
+			return nil, context.Canceled
+		},
+	})
+	if !called {
+		t.Fatal("hardware probe was not called")
+	}
+}
+
 func TestExtractFrameSoftwareHDRDisabledByDefault(t *testing.T) {
 	resolver := newSoftwareToneMapFilterResolver(func(string) ([]byte, error) {
 		t.Fatal("software filter probe should not run while CPU tone mapping is disabled")

--- a/internal/chapterthumbs/service_test.go
+++ b/internal/chapterthumbs/service_test.go
@@ -47,7 +47,7 @@ func TestChapterCaptureTime(t *testing.T) {
 
 func TestBuildFrameExtractArgs(t *testing.T) {
 	t.Run("qsv uses hardware flags when render device exists", func(t *testing.T) {
-		args, err := buildFrameExtractArgs("/media/movie.mkv", 42.5, "qsv", "/dev/dri/renderD128", false)
+		args, err := buildFrameExtractArgs("/media/movie.mkv", 42.5, "qsv", "/dev/dri/renderD128", false, "")
 		if err != nil {
 			t.Fatalf("buildFrameExtractArgs() error = %v", err)
 		}
@@ -57,7 +57,7 @@ func TestBuildFrameExtractArgs(t *testing.T) {
 	})
 
 	t.Run("vaapi uses hardware flags when render device exists", func(t *testing.T) {
-		args, err := buildFrameExtractArgs("/media/movie.mkv", 42.5, "vaapi", "/dev/dri/renderD128", false)
+		args, err := buildFrameExtractArgs("/media/movie.mkv", 42.5, "vaapi", "/dev/dri/renderD128", false, "")
 		if err != nil {
 			t.Fatalf("buildFrameExtractArgs() error = %v", err)
 		}
@@ -67,7 +67,7 @@ func TestBuildFrameExtractArgs(t *testing.T) {
 	})
 
 	t.Run("unsupported hw accel does not masquerade as hardware extraction", func(t *testing.T) {
-		_, err := buildFrameExtractArgs("/media/movie.mkv", 42.5, "nvenc", "/dev/dri/renderD128", false)
+		_, err := buildFrameExtractArgs("/media/movie.mkv", 42.5, "nvenc", "/dev/dri/renderD128", false, "")
 		if err == nil || !strings.Contains(err.Error(), "does not support") {
 			t.Fatalf("buildFrameExtractArgs() error = %v, want unsupported accelerator error", err)
 		}

--- a/internal/config/admin_settings.go
+++ b/internal/config/admin_settings.go
@@ -71,7 +71,7 @@ var adminSettingDefaults = map[string]string{
 	"markers.mode":          "local",
 	"markers.lazy_playback": "false",
 
-	"playback.ffmpeg_path":                     "/usr/lib/jellyfin-ffmpeg/ffmpeg",
+	"playback.ffmpeg_path":                     "",
 	playbackTranscodeDirSettingKey:             DefaultTranscodeDir,
 	"playback.hw_accel":                        "auto",
 	"playback.transcode_enabled":               "true",
@@ -399,7 +399,7 @@ func NormalizeAdminSetting(key, raw string) (string, error) {
 	case "userdb.backend":
 		return normalizeAdminEnum(key, value, "postgres", "sqlite")
 	case "playback.hw_accel":
-		return normalizeAdminEnum(key, value, "auto", "qsv", "vaapi", "nvenc", "none")
+		return normalizeAdminEnum(key, value, "auto", "qsv", "vaapi", "nvenc", "videotoolbox", "none")
 	case "playback.chapter_thumbnail_execution":
 		return normalizeAdminEnum(key, value, "local", "prefer_transcode_nodes", "transcode_nodes_only")
 	case "playback.chapter_thumbnail_hdr_policy":

--- a/internal/config/admin_settings_test.go
+++ b/internal/config/admin_settings_test.go
@@ -264,6 +264,16 @@ func TestNormalizeAdminSettingAcceptsApprovedThemeCatalogURL(t *testing.T) {
 	}
 }
 
+func TestNormalizeAdminSettingAcceptsVideoToolbox(t *testing.T) {
+	got, err := NormalizeAdminSetting("playback.hw_accel", " VideoToolbox ")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got != "videotoolbox" {
+		t.Fatalf("normalized hardware acceleration = %q, want videotoolbox", got)
+	}
+}
+
 func TestValidateAdminSettingsChecksProspectiveRelationships(t *testing.T) {
 	values := map[string]string{
 		"auth.access_token_expiry":      "48h",

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -494,7 +494,7 @@ func setDefaults() *configRaw {
 			EnableTVSeriesRootQueue: true,
 		},
 		Playback: PlaybackConfig{
-			FFmpegPath:                   "/usr/lib/jellyfin-ffmpeg/ffmpeg",
+			FFmpegPath:                   "",
 			TranscodeDir:                 DefaultTranscodeDir,
 			HWAccel:                      "auto",
 			ChapterThumbnailWorkers:      1,

--- a/internal/config/db_loader.go
+++ b/internal/config/db_loader.go
@@ -317,7 +317,7 @@ func LoadFromDB(m map[string]string) (*Config, error) {
 	cfg.Metadata.CacheImages = cacheImages
 
 	// Playback
-	cfg.Playback.FFmpegPath = stringOr(m, "playback.ffmpeg_path", "/usr/lib/jellyfin-ffmpeg/ffmpeg")
+	cfg.Playback.FFmpegPath = stringOr(m, "playback.ffmpeg_path", "")
 	cfg.Playback.TranscodeDir = stringOr(m, playbackTranscodeDirSettingKey, DefaultTranscodeDir)
 	cfg.Playback.HWAccel = stringOr(m, "playback.hw_accel", "auto")
 	cfg.Playback.HWDevice = stringOr(m, "playback.hw_device", "")

--- a/internal/jellycompat/handlers_playback.go
+++ b/internal/jellycompat/handlers_playback.go
@@ -828,6 +828,50 @@ func is4KResolution(res string) bool {
 	return access.CompareQuality(res, "2160p") >= 0
 }
 
+// compatVideoToolboxToneMapBitrateKbps chooses a resolution-aware bitrate for
+// Jellyfin-compatible VideoToolbox tone maps. Those requests intentionally
+// preserve source dimensions, so leaving the bitrate unset would make the
+// encoder use its 1080p fallback even for 4K sources.
+func compatVideoToolboxToneMapBitrateKbps(version catalog.FileVersion, recipe compatToneMapRecipe) int {
+	if recipe.mode != tonemap.ModeHardware || recipe.hwAccel != tonemap.BackendVideoToolbox {
+		return 0
+	}
+
+	height := 0
+	for _, track := range version.VideoTracks {
+		if track.Height > 0 {
+			height = track.Height
+			break
+		}
+	}
+	if height == 0 {
+		resolution := strings.ToLower(strings.TrimSpace(version.Resolution))
+		switch resolution {
+		case "8k":
+			height = 4320
+		case "4k", "uhd":
+			height = 2160
+		default:
+			height, _ = strconv.Atoi(strings.TrimSuffix(resolution, "p"))
+		}
+	}
+
+	switch {
+	case height >= 2160:
+		return 20_000
+	case height >= 1080:
+		return 6_000
+	case height >= 720:
+		return 2_000
+	case height > 0:
+		return 1_500
+	case version.Bitrate > 0:
+		return version.Bitrate
+	default:
+		return 0
+	}
+}
+
 // NewPlaybackHandler creates a playback handler.
 func NewPlaybackHandler(
 	cfg *config.Config,
@@ -1203,6 +1247,10 @@ func (h *PlaybackHandler) startRemoteTranscodeWithToneMapMode(
 		reqBody.ToneMapDVRPUPresent = toneMapRecipe.dvRPUPresent
 		reqBody.HWAccel = toneMapRecipe.hwAccel
 	}
+	autoVideoToolboxBitrate := compatVideoToolboxToneMapBitrateKbps(source.Version, toneMapRecipe)
+	if autoVideoToolboxBitrate > 0 {
+		reqBody.TargetBitrateKbps = autoVideoToolboxBitrate
+	}
 	if source.TranscodeAudio {
 		reqBody.TargetCodecVideo = "copy"
 		reqBody.VideoSampleEntry = playback.VideoSampleEntryForDVCopy(file.PrimaryDVProfile())
@@ -1286,6 +1334,9 @@ func (h *PlaybackHandler) startRemoteTranscodeWithToneMapMode(
 	if retryWithSoftware {
 		reqBody.ToneMapMode = toneMapRecipe.mode
 		reqBody.HWAccel = toneMapRecipe.hwAccel
+		if autoVideoToolboxBitrate > 0 {
+			reqBody.TargetBitrateKbps = 0
+		}
 		nodeResponse, status, cleanupRequired, err = dispatch(reqBody)
 		validationErr = nil
 		if isCompatToneMapExecutionError(err) {
@@ -1383,6 +1434,8 @@ func (h *PlaybackHandler) startRemoteTranscodeWithToneMapMode(
 		StartSegmentNumber:  reqBody.StartSegmentNumber,
 		TargetCodecVideo:    reqBody.TargetCodecVideo,
 		TargetCodecAudio:    reqBody.TargetCodecAudio,
+		TargetResolution:    reqBody.TargetResolution,
+		TargetBitrateKbps:   reqBody.TargetBitrateKbps,
 		VideoSampleEntry:    reqBody.VideoSampleEntry,
 		SegmentDuration:     reqBody.SegmentDuration,
 		AudioTrackIndex:     reqBody.AudioTrackIndex,

--- a/internal/jellycompat/playback_4k_test.go
+++ b/internal/jellycompat/playback_4k_test.go
@@ -96,6 +96,36 @@ func TestCompatVideoToolboxToneMapBitrateKbps(t *testing.T) {
 	}
 }
 
+func TestDowngradeCompatLocalToneMapClearsOnlyAutomaticVideoToolboxBitrate(t *testing.T) {
+	capabilities := tonemap.Capabilities{{
+		Mode: tonemap.ModeSoftware, Backend: tonemap.BackendSoftware,
+		Filter: tonemap.SoftwareFilterHable, SourceKinds: []tonemap.SourceKind{tonemap.SourcePQ},
+	}}
+	newOpts := func() playback.TranscodeOpts {
+		return playback.TranscodeOpts{
+			ToneMapPolicy: tonemap.PolicyHardwareThenSoftware, ToneMapMode: tonemap.ModeHardware,
+			ToneMapSourceKind: tonemap.SourcePQ, ToneMapFilter: tonemap.HardwareFilterVideoToolbox,
+			HWAccel: tonemap.BackendVideoToolbox, TargetBitrateKbps: 20_000,
+		}
+	}
+
+	automatic := newOpts()
+	if !downgradeCompatLocalToneMap(&automatic, capabilities, 20_000) {
+		t.Fatal("automatic VideoToolbox recipe did not downgrade")
+	}
+	if automatic.TargetBitrateKbps != 0 || automatic.ToneMapMode != tonemap.ModeSoftware || automatic.HWAccel != playback.HWAccelNone {
+		t.Fatalf("automatic fallback = bitrate %d mode %q hw %q", automatic.TargetBitrateKbps, automatic.ToneMapMode, automatic.HWAccel)
+	}
+
+	explicit := newOpts()
+	if !downgradeCompatLocalToneMap(&explicit, capabilities, 0) {
+		t.Fatal("explicitly constrained recipe did not downgrade")
+	}
+	if explicit.TargetBitrateKbps != 20_000 {
+		t.Fatalf("explicit fallback bitrate = %d, want 20000", explicit.TargetBitrateKbps)
+	}
+}
+
 func TestBuildPlaybackSource4KVideoTranscodeGate(t *testing.T) {
 	version4K := catalog.FileVersion{
 		FileID:     1,

--- a/internal/jellycompat/playback_4k_test.go
+++ b/internal/jellycompat/playback_4k_test.go
@@ -69,6 +69,33 @@ func TestIs4KResolution(t *testing.T) {
 	}
 }
 
+func TestCompatVideoToolboxToneMapBitrateKbps(t *testing.T) {
+	videoToolbox := compatToneMapRecipe{mode: tonemap.ModeHardware, hwAccel: tonemap.BackendVideoToolbox}
+	tests := []struct {
+		name    string
+		version catalog.FileVersion
+		recipe  compatToneMapRecipe
+		want    int
+	}{
+		{name: "4K track", version: catalog.FileVersion{VideoTracks: []models.VideoTrack{{Height: 2160}}}, recipe: videoToolbox, want: 20_000},
+		{name: "4K label", version: catalog.FileVersion{Resolution: "4K"}, recipe: videoToolbox, want: 20_000},
+		{name: "1080p", version: catalog.FileVersion{VideoTracks: []models.VideoTrack{{Height: 1080}}}, recipe: videoToolbox, want: 6_000},
+		{name: "720p", version: catalog.FileVersion{Resolution: "720p"}, recipe: videoToolbox, want: 2_000},
+		{name: "SD", version: catalog.FileVersion{VideoTracks: []models.VideoTrack{{Height: 576}}}, recipe: videoToolbox, want: 1_500},
+		{name: "source bitrate fallback", version: catalog.FileVersion{Bitrate: 9_000}, recipe: videoToolbox, want: 9_000},
+		{name: "unknown source", recipe: videoToolbox},
+		{name: "software mode", version: catalog.FileVersion{Resolution: "2160p"}, recipe: compatToneMapRecipe{mode: tonemap.ModeSoftware, hwAccel: tonemap.BackendSoftware}},
+		{name: "other hardware", version: catalog.FileVersion{Resolution: "2160p"}, recipe: compatToneMapRecipe{mode: tonemap.ModeHardware, hwAccel: tonemap.BackendQSV}},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			if got := compatVideoToolboxToneMapBitrateKbps(test.version, test.recipe); got != test.want {
+				t.Fatalf("compatVideoToolboxToneMapBitrateKbps() = %d, want %d", got, test.want)
+			}
+		})
+	}
+}
+
 func TestBuildPlaybackSource4KVideoTranscodeGate(t *testing.T) {
 	version4K := catalog.FileVersion{
 		FileID:     1,

--- a/internal/jellycompat/remote_transcode_reconstruct_test.go
+++ b/internal/jellycompat/remote_transcode_reconstruct_test.go
@@ -811,6 +811,69 @@ func TestStartRemoteToneMapReportsConfirmedExecutorAndFallback(t *testing.T) {
 	}
 }
 
+func TestStartRemoteVideoToolboxToneMapUsesResolutionAwareBitrate(t *testing.T) {
+	var requests []transcodenode.TranscodeStartRequest
+	capabilities := tonemap.Capabilities{
+		{Mode: tonemap.ModeHardware, Backend: tonemap.BackendVideoToolbox, Filter: tonemap.HardwareFilterVideoToolbox, SourceKinds: []tonemap.SourceKind{tonemap.SourcePQ}},
+		{Mode: tonemap.ModeSoftware, Backend: tonemap.BackendSoftware, Filter: tonemap.SoftwareFilterHable, SourceKinds: []tonemap.SourceKind{tonemap.SourcePQ}},
+	}
+	node := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/hw-capabilities":
+			writeJSON(w, http.StatusOK, playback.HWAccelInfo{ToneMapCapabilities: capabilities})
+		case "/transcode/start":
+			var request transcodenode.TranscodeStartRequest
+			if err := json.NewDecoder(r.Body).Decode(&request); err != nil {
+				t.Errorf("decode start request: %v", err)
+				w.WriteHeader(http.StatusBadRequest)
+				return
+			}
+			requests = append(requests, request)
+			if request.ToneMapMode == tonemap.ModeHardware {
+				w.WriteHeader(http.StatusUnprocessableEntity)
+				return
+			}
+			writeJSON(w, http.StatusAccepted, transcodenode.TranscodeStartResponse{HWAccel: request.HWAccel, ToneMapMode: request.ToneMapMode})
+		default:
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	t.Cleanup(node.Close)
+
+	recipeStore := &stubRecipeNodeStore{}
+	handler, _, playbackStore := newRemoteTranscodeHandler(t, node.URL, recipeStore)
+	handler.SettingsRepo = stubSettingsReader{values: map[string]string{
+		config.Allow4KTranscodeSettingKey:                 "true",
+		config.PlaybackTranscodeHardwareToneMapSettingKey: "true",
+		config.PlaybackTranscodeSoftwareToneMapSettingKey: "true",
+	}}
+	playbackStore.Put(PlaybackSession{ID: "play-1", UpstreamSessionID: "upstream-1"})
+	source := testRemoteTranscodeSource()
+	source.Version.Resolution = "2160p"
+	source.Version.VideoTracks[0].Height = 2160
+	file := &models.MediaFile{ID: 42, FilePath: "/media/movie.mkv", HDR: true, VideoTracks: []models.VideoTrack{{Codec: "hevc", VideoRangeType: "HDR10", ColorTransfer: "smpte2084", ColorPrimaries: "bt2020", ColorSpace: "bt2020nc", BitDepth: 10}}}
+
+	if err := handler.startRemoteTranscode(t.Context(), "play-1", "upstream-1", source, file, 0, node.URL); err != nil {
+		t.Fatalf("startRemoteTranscode: %v", err)
+	}
+	if len(requests) != 2 {
+		t.Fatalf("start requests = %d, want hardware attempt plus software fallback", len(requests))
+	}
+	if got := requests[0].TargetBitrateKbps; got != 20_000 {
+		t.Fatalf("hardware target bitrate = %d, want 20000", got)
+	}
+	if requests[0].TargetResolution != "" {
+		t.Fatalf("hardware target resolution = %q, want source dimensions preserved", requests[0].TargetResolution)
+	}
+	if got := requests[1].TargetBitrateKbps; got != 0 {
+		t.Fatalf("software fallback target bitrate = %d, want unconstrained CRF", got)
+	}
+	card, ok := recipeStore.Get("upstream-1")
+	if !ok || card.TargetBitrateKbps != 0 || card.ToneMapMode != tonemap.ModeSoftware {
+		t.Fatalf("persisted fallback recipe = found %t bitrate %d mode %q", ok, card.TargetBitrateKbps, card.ToneMapMode)
+	}
+}
+
 func TestStartRemoteToneMapTimeoutFallsBackToSoftwareAfterCleanup(t *testing.T) {
 	previousTimeout := compatRemoteTranscodeStartTimeout
 	compatRemoteTranscodeStartTimeout = 200 * time.Millisecond

--- a/internal/jellycompat/streams.go
+++ b/internal/jellycompat/streams.go
@@ -2118,6 +2118,7 @@ func (h *PlaybackHandler) ensureTranscodeSessionWithToneMapMode(
 		opts.VideoSampleEntry = playback.VideoSampleEntryForDVCopy(file.PrimaryDVProfile())
 	}
 	var toneMapCapabilities tonemap.Capabilities
+	autoVideoToolboxBitrate := 0
 	if !source.TranscodeAudio {
 		metadata := tonemap.MetadataForFile(file)
 		if metadata.DynamicRange != "" && metadata.DynamicRange != playback.DynamicRangeSDRV3 {
@@ -2135,8 +2136,9 @@ func (h *PlaybackHandler) ensureTranscodeSessionWithToneMapMode(
 			return nil, toneMapErr
 		}
 		toneMapRecipe.apply(&opts)
-		if bitrateKbps := compatVideoToolboxToneMapBitrateKbps(source.Version, toneMapRecipe); bitrateKbps > 0 {
-			opts.TargetBitrateKbps = bitrateKbps
+		autoVideoToolboxBitrate = compatVideoToolboxToneMapBitrateKbps(source.Version, toneMapRecipe)
+		if autoVideoToolboxBitrate > 0 {
+			opts.TargetBitrateKbps = autoVideoToolboxBitrate
 		}
 	}
 	opts.SegmentDuration = h.compatSegmentDuration()
@@ -2163,10 +2165,7 @@ func (h *PlaybackHandler) ensureTranscodeSessionWithToneMapMode(
 	}
 	manifestDeadline := time.Now().Add(compatManifestStartupTimeout)
 	transcodeSession, err := playback.StartTranscode(ctx, opts)
-	if err != nil && downgradeToSoftwareToneMap(
-		opts.ToneMapPolicy, &opts.ToneMapMode, &opts.ToneMapFilter, &opts.HWAccel,
-		opts.ToneMapSourceKind, toneMapCapabilities,
-	) {
+	if err != nil && downgradeCompatLocalToneMap(&opts, toneMapCapabilities, autoVideoToolboxBitrate) {
 		transcodeSession, err = playback.StartTranscode(ctx, opts)
 		if err == nil {
 			manifestDeadline = time.Now().Add(compatManifestStartupTimeout)
@@ -2181,10 +2180,7 @@ func (h *PlaybackHandler) ensureTranscodeSessionWithToneMapMode(
 
 	if opts.ToneMapMode != "" {
 		if _, readyErr := transcodeSession.WaitForManifest(time.Until(manifestDeadline)); readyErr != nil {
-			fallbackEligible := downgradeToSoftwareToneMap(
-				opts.ToneMapPolicy, &opts.ToneMapMode, &opts.ToneMapFilter, &opts.HWAccel,
-				opts.ToneMapSourceKind, toneMapCapabilities,
-			)
+			fallbackEligible := downgradeCompatLocalToneMap(&opts, toneMapCapabilities, autoVideoToolboxBitrate)
 			replaceUnlock := h.tm.LockSessionLifecycle(upstreamSessionID)
 			if live := h.tm.GetTranscodeSession(upstreamSessionID); live != transcodeSession {
 				replaceUnlock()
@@ -2262,6 +2258,23 @@ func (h *PlaybackHandler) ensureTranscodeSessionWithToneMapMode(
 	publishUnlock()
 
 	return transcodeSession, nil
+}
+
+// downgradeCompatLocalToneMap removes the bitrate synthesized solely for a
+// VideoToolbox hardware attempt when the local session falls back to software.
+// Explicit client constraints are represented by a zero automatic bitrate and
+// remain intact.
+func downgradeCompatLocalToneMap(opts *playback.TranscodeOpts, capabilities tonemap.Capabilities, autoVideoToolboxBitrate int) bool {
+	if opts == nil || !downgradeToSoftwareToneMap(
+		opts.ToneMapPolicy, &opts.ToneMapMode, &opts.ToneMapFilter, &opts.HWAccel,
+		opts.ToneMapSourceKind, capabilities,
+	) {
+		return false
+	}
+	if autoVideoToolboxBitrate > 0 && opts.TargetBitrateKbps == autoVideoToolboxBitrate {
+		opts.TargetBitrateKbps = 0
+	}
+	return true
 }
 
 func compatLiveTranscodeMatchesAudioSource(transcodeSession *playback.TranscodeSession, source PlaybackMediaSource) bool {

--- a/internal/jellycompat/streams.go
+++ b/internal/jellycompat/streams.go
@@ -2135,6 +2135,9 @@ func (h *PlaybackHandler) ensureTranscodeSessionWithToneMapMode(
 			return nil, toneMapErr
 		}
 		toneMapRecipe.apply(&opts)
+		if bitrateKbps := compatVideoToolboxToneMapBitrateKbps(source.Version, toneMapRecipe); bitrateKbps > 0 {
+			opts.TargetBitrateKbps = bitrateKbps
+		}
 	}
 	opts.SegmentDuration = h.compatSegmentDuration()
 

--- a/internal/jellycompat/streams_test.go
+++ b/internal/jellycompat/streams_test.go
@@ -332,7 +332,7 @@ func TestEnsureTranscodeSessionGivesSoftwareFallbackFreshManifestBudget(t *testi
 
 	ffmpegPath := filepath.Join(t.TempDir(), "fallback-ffmpeg.sh")
 	script := "#!/bin/sh\n" +
-		"case \"$*\" in *tonemap_opencl*) sleep 30; exit 0;; esac\n" +
+		"case \"$*\" in *-hwaccels*) printf 'videotoolbox\\n'; exit 0;; *-encoders*) printf ' V..... h264_videotoolbox VideoToolbox H.264 encoder\\n'; exit 0;; *' -f lavfi '*) exit 0;; *scale_vt*) sleep 30; exit 0;; esac\n" +
 		"out=\"\"\n" +
 		"for arg in \"$@\"; do case \"$arg\" in *.m3u8) out=\"$(dirname \"$arg\")\";; esac; done\n" +
 		"mkdir -p \"$out\"\n" +
@@ -374,23 +374,23 @@ func TestEnsureTranscodeSessionGivesSoftwareFallbackFreshManifestBudget(t *testi
 			config.PlaybackTranscodeHardwareToneMapSettingKey: "true",
 			config.PlaybackTranscodeSoftwareToneMapSettingKey: "true",
 		}},
-		TranscodeDir: t.TempDir(), FFmpegPath: ffmpegPath, HWAccel: tonemap.BackendQSV,
+		TranscodeDir: t.TempDir(), FFmpegPath: ffmpegPath, HWAccel: tonemap.BackendVideoToolbox,
 		tm: playback.NewTranscodeManager(),
 		compatToneMapProbe: func(context.Context, string, string, string) (tonemap.Capabilities, error) {
 			return tonemap.Capabilities{
-				{Mode: tonemap.ModeHardware, Backend: tonemap.BackendQSV, Filter: tonemap.HardwareFilterOpenCL, SourceKinds: []tonemap.SourceKind{tonemap.SourcePQ}},
+				{Mode: tonemap.ModeHardware, Backend: tonemap.BackendVideoToolbox, Filter: tonemap.HardwareFilterVideoToolbox, SourceKinds: []tonemap.SourceKind{tonemap.SourcePQ}},
 				{Mode: tonemap.ModeSoftware, Backend: tonemap.BackendSoftware, Filter: tonemap.SoftwareFilterBT2390, SourceKinds: []tonemap.SourceKind{tonemap.SourcePQ}},
 			}, nil
 		},
 	}
 
-	session, err := handler.ensureTranscodeSession(context.Background(), "play-1", "upstream-1", source)
+	session, err := handler.ensureTranscodeSession(t.Context(), "play-1", "upstream-1", source)
 	if err != nil {
 		t.Fatalf("ensureTranscodeSession() error = %v, want software fallback ready", err)
 	}
 	t.Cleanup(func() { _ = session.Close() })
-	if opts := session.Opts(); opts.ToneMapMode != tonemap.ModeSoftware || opts.HWAccel != playback.HWAccelNone {
-		t.Fatalf("fallback opts = mode %q hw %q, want software/none", opts.ToneMapMode, opts.HWAccel)
+	if opts := session.Opts(); opts.ToneMapMode != tonemap.ModeSoftware || opts.HWAccel != playback.HWAccelNone || opts.TargetBitrateKbps != 0 {
+		t.Fatalf("fallback opts = mode %q hw %q bitrate %d, want software/none/unconstrained", opts.ToneMapMode, opts.HWAccel, opts.TargetBitrateKbps)
 	}
 }
 

--- a/internal/nodeconfig/watcher.go
+++ b/internal/nodeconfig/watcher.go
@@ -36,7 +36,11 @@ type Watcher struct {
 	eventBus  cache.EventBus
 	bootstrap BootstrapOverrides
 	onChange  []func(old, updated *config.Config)
-	reloadCh  chan struct{} // buffered(1), event bus writes here
+	// normalizers run on every config the watcher constructs, after bootstrap
+	// overrides and before the config becomes visible, so derived repairs
+	// (e.g. resolving the seeded ffmpeg path) survive hot reloads.
+	normalizers []func(*config.Config)
+	reloadCh    chan struct{} // buffered(1), event bus writes here
 }
 
 // NewWatcher creates a new config watcher. Call Start to begin watching. The
@@ -51,6 +55,12 @@ func NewWatcher(pool *pgxpool.Pool, cipher *secret.Cipher, eventBus cache.EventB
 		bootstrap: bootstrap,
 		reloadCh:  make(chan struct{}, 1),
 	}
+}
+
+// OnLoad registers a normalization applied to every config this watcher
+// constructs (initial load and every reload). Register before Start.
+func (w *Watcher) OnLoad(fn func(*config.Config)) {
+	w.normalizers = append(w.normalizers, fn)
 }
 
 // Config returns the current config. Safe for concurrent use.
@@ -184,6 +194,10 @@ func (w *Watcher) applySettings(m map[string]string) error {
 	}
 	if w.bootstrap.RedisURL != "" {
 		newCfg.Redis.URL = w.bootstrap.RedisURL
+	}
+
+	for _, normalize := range w.normalizers {
+		normalize(newCfg)
 	}
 
 	w.mu.Lock()

--- a/internal/nodeconfig/watcher_test.go
+++ b/internal/nodeconfig/watcher_test.go
@@ -101,3 +101,29 @@ func TestOnChangeAfterFirstApplySeesLaterChanges(t *testing.T) {
 		t.Errorf("callback saw old=%q new=%q, want old=info new=error", gotOld, gotNew)
 	}
 }
+
+func TestOnLoadNormalizersApplyOnEveryLoad(t *testing.T) {
+	w := &Watcher{}
+	w.OnLoad(func(c *config.Config) {
+		c.Playback.FFmpegPath = "/resolved/ffmpeg"
+	})
+
+	if err := w.applySettings(map[string]string{
+		"playback.ffmpeg_path": "/usr/lib/jellyfin-ffmpeg/ffmpeg",
+	}); err != nil {
+		t.Fatalf("applySettings() error = %v", err)
+	}
+	if got := w.Config().Playback.FFmpegPath; got != "/resolved/ffmpeg" {
+		t.Fatalf("Playback.FFmpegPath = %q, want normalized value", got)
+	}
+
+	// A reload constructs a fresh config; the normalizer must apply again.
+	if err := w.applySettings(map[string]string{
+		"playback.ffmpeg_path": "/usr/lib/jellyfin-ffmpeg/ffmpeg",
+	}); err != nil {
+		t.Fatalf("applySettings() reload error = %v", err)
+	}
+	if got := w.Config().Playback.FFmpegPath; got != "/resolved/ffmpeg" {
+		t.Fatalf("after reload Playback.FFmpegPath = %q, want normalized value", got)
+	}
+}

--- a/internal/playback/gpudetect.go
+++ b/internal/playback/gpudetect.go
@@ -45,6 +45,13 @@ var nvencProbeCache = struct {
 	byPath: make(map[string]nvencProbeCacheEntry),
 }
 
+var videoToolboxProbeCache = struct {
+	sync.Mutex
+	byPath map[string]nvencProbeResult
+}{
+	byPath: make(map[string]nvencProbeResult),
+}
+
 // HWAccelInfo describes the detected hardware acceleration capability.
 type HWAccelInfo struct {
 	Resolved            string               `json:"resolved"`
@@ -144,6 +151,16 @@ func ResolveHWAccelWithFFmpeg(hwAccel string, ffmpegPath string) string {
 func ResolveHWAccelWithFFmpegContext(ctx context.Context, hwAccel string, ffmpegPath string) string {
 	if hwAccel != "auto" {
 		return hwAccel
+	}
+	if currentGOOS == "darwin" {
+		if ok, reason := ffmpegSupportsVideoToolbox(ffmpegPath); ok {
+			slog.Info("hw_accel=auto: macOS detected, using VideoToolbox")
+			return "videotoolbox"
+		} else {
+			slog.Warn("hw_accel=auto: macOS detected but FFmpeg VideoToolbox probe failed",
+				"ffmpeg", normalizeFFmpegPath(ffmpegPath), "reason", reason)
+		}
+		return "none"
 	}
 	if currentGOOS != "linux" {
 		return "none"
@@ -272,6 +289,58 @@ func nvencProbeCacheKey(ffmpegPath string) string {
 		return ffmpegPath
 	}
 	return fmt.Sprintf("%s\x00%d\x00%d", identityPath, info.Size(), info.ModTime().UnixNano())
+}
+
+func ffmpegSupportsVideoToolbox(ffmpegPath string) (bool, string) {
+	ffmpegPath = normalizeFFmpegPath(ffmpegPath)
+	videoToolboxProbeCache.Lock()
+	if result, ok := videoToolboxProbeCache.byPath[ffmpegPath]; ok {
+		videoToolboxProbeCache.Unlock()
+		return result.available, result.reason
+	}
+	videoToolboxProbeCache.Unlock()
+
+	result := probeFFmpegVideoToolbox(ffmpegPath)
+	videoToolboxProbeCache.Lock()
+	videoToolboxProbeCache.byPath[ffmpegPath] = result
+	videoToolboxProbeCache.Unlock()
+	return result.available, result.reason
+}
+
+// probeFFmpegVideoToolbox verifies the configured FFmpeg exposes VideoToolbox
+// decode plus both encoders, then smoke-encodes one frame. No filter probes:
+// the videotoolbox pipeline keeps decoded frames in system memory, so the
+// regular software filter graph applies (see appendHWAccelArgs).
+func probeFFmpegVideoToolbox(ffmpegPath string) nvencProbeResult {
+	if output, err := runFFmpegProbe(ffmpegPath, "-hide_banner", "-hwaccels"); err != nil {
+		return nvencProbeResult{reason: "hwaccels probe failed: " + probeFailure(err, output)}
+	} else if !ffmpegOutputHasToken(output, "videotoolbox") {
+		return nvencProbeResult{reason: "videotoolbox hwaccel unavailable"}
+	}
+
+	if output, err := runFFmpegProbe(ffmpegPath, "-hide_banner", "-encoders"); err != nil {
+		return nvencProbeResult{reason: "encoders probe failed: " + probeFailure(err, output)}
+	} else if !ffmpegOutputHasToken(output, "h264_videotoolbox") {
+		return nvencProbeResult{reason: "h264_videotoolbox encoder unavailable"}
+	} else if !ffmpegOutputHasToken(output, "hevc_videotoolbox") {
+		return nvencProbeResult{reason: "hevc_videotoolbox encoder unavailable"}
+	}
+
+	if output, err := runFFmpegProbe(ffmpegPath,
+		"-hide_banner",
+		"-loglevel", "error",
+		"-f", "lavfi",
+		"-i", "testsrc2=size=640x360:rate=1",
+		"-frames:v", "1",
+		"-an",
+		"-c:v", "h264_videotoolbox",
+		"-f", "null",
+		"-",
+	); err != nil {
+		return nvencProbeResult{reason: "h264_videotoolbox smoke encode failed: " + probeFailure(err, output)}
+	}
+
+	return nvencProbeResult{available: true}
 }
 
 func normalizeFFmpegPath(ffmpegPath string) string {

--- a/internal/playback/gpudetect.go
+++ b/internal/playback/gpudetect.go
@@ -308,9 +308,12 @@ func ffmpegSupportsVideoToolbox(ffmpegPath string) (bool, string) {
 }
 
 // probeFFmpegVideoToolbox verifies the configured FFmpeg exposes VideoToolbox
-// decode plus both encoders, then smoke-encodes one frame. No filter probes:
-// the videotoolbox pipeline keeps decoded frames in system memory, so the
-// regular software filter graph applies (see appendHWAccelArgs).
+// decode plus both encoders, then smoke-encodes one frame per encoder in the
+// same constant-quality mode the uncapped transcode path emits (-q:v needs an
+// Apple Silicon compression session; Intel Macs must fail here so auto
+// resolves to software instead of approving commands that cannot run). No
+// filter probes: the videotoolbox pipeline keeps decoded frames in system
+// memory, so the regular software filter graph applies (see appendHWAccelArgs).
 func probeFFmpegVideoToolbox(ffmpegPath string) nvencProbeResult {
 	if output, err := runFFmpegProbe(ffmpegPath, "-hide_banner", "-hwaccels"); err != nil {
 		return nvencProbeResult{reason: "hwaccels probe failed: " + probeFailure(err, output)}
@@ -326,18 +329,27 @@ func probeFFmpegVideoToolbox(ffmpegPath string) nvencProbeResult {
 		return nvencProbeResult{reason: "hevc_videotoolbox encoder unavailable"}
 	}
 
-	if output, err := runFFmpegProbe(ffmpegPath,
-		"-hide_banner",
-		"-loglevel", "error",
-		"-f", "lavfi",
-		"-i", "testsrc2=size=640x360:rate=1",
-		"-frames:v", "1",
-		"-an",
-		"-c:v", "h264_videotoolbox",
-		"-f", "null",
-		"-",
-	); err != nil {
-		return nvencProbeResult{reason: "h264_videotoolbox smoke encode failed: " + probeFailure(err, output)}
+	for _, smoke := range []struct {
+		encoder string
+		quality string
+	}{
+		{"h264_videotoolbox", "65"},
+		{"hevc_videotoolbox", "60"},
+	} {
+		if output, err := runFFmpegProbe(ffmpegPath,
+			"-hide_banner",
+			"-loglevel", "error",
+			"-f", "lavfi",
+			"-i", "testsrc2=size=640x360:rate=1",
+			"-frames:v", "1",
+			"-an",
+			"-c:v", smoke.encoder,
+			"-q:v", smoke.quality,
+			"-f", "null",
+			"-",
+		); err != nil {
+			return nvencProbeResult{reason: smoke.encoder + " smoke encode failed: " + probeFailure(err, output)}
+		}
 	}
 
 	return nvencProbeResult{available: true}

--- a/internal/playback/gpudetect.go
+++ b/internal/playback/gpudetect.go
@@ -17,6 +17,8 @@ import (
 	"golang.org/x/sync/singleflight"
 )
 
+const darwinGOOS = "darwin"
+
 var (
 	defaultDRIDir              = "/dev/dri"
 	defaultNVIDIAControlDevice = "/dev/nvidiactl"
@@ -152,15 +154,15 @@ func ResolveHWAccelWithFFmpegContext(ctx context.Context, hwAccel string, ffmpeg
 	if hwAccel != "auto" {
 		return hwAccel
 	}
-	if currentGOOS == "darwin" {
+	if currentGOOS == darwinGOOS {
 		if ok, reason := ffmpegSupportsVideoToolbox(ffmpegPath); ok {
 			slog.Info("hw_accel=auto: macOS detected, using VideoToolbox")
-			return "videotoolbox"
+			return transcodeHWVideoToolbox
 		} else {
 			slog.Warn("hw_accel=auto: macOS detected but FFmpeg VideoToolbox probe failed",
 				"ffmpeg", normalizeFFmpegPath(ffmpegPath), "reason", reason)
 		}
-		return "none"
+		return transcodeHWNone
 	}
 	if currentGOOS != "linux" {
 		return "none"

--- a/internal/playback/gpudetect.go
+++ b/internal/playback/gpudetect.go
@@ -358,14 +358,17 @@ func probeFFmpegVideoToolbox(ffmpegPath string) hardwareProbeResult {
 		return hardwareProbeResult{reason: "h264_videotoolbox encoder unavailable"}
 	}
 
-	smoke := func(encoder string) ([]byte, error) {
-		return runFFmpegProbe(context.Background(), nvencProbeCommandTimeout, ffmpegPath,
+	smoke := func(encoder string, extraArgs ...string) ([]byte, error) {
+		args := []string{
 			"-hide_banner",
 			"-loglevel", "error",
 			"-f", "lavfi",
 			"-i", "testsrc2=size=640x360:rate=1",
 			"-frames:v", "1",
 			"-an",
+		}
+		args = append(args, extraArgs...)
+		args = append(args,
 			"-c:v", encoder,
 			"-b:v", "2000k",
 			"-maxrate", "2000k",
@@ -373,6 +376,7 @@ func probeFFmpegVideoToolbox(ffmpegPath string) hardwareProbeResult {
 			"-f", "null",
 			"-",
 		)
+		return runFFmpegProbe(context.Background(), nvencProbeCommandTimeout, ffmpegPath, args...)
 	}
 
 	h264Output, err := smoke("h264_videotoolbox")
@@ -382,7 +386,10 @@ func probeFFmpegVideoToolbox(ffmpegPath string) hardwareProbeResult {
 
 	result := hardwareProbeResult{available: true, h264Available: true}
 	if ffmpegOutputHasToken(output, "hevc_videotoolbox") {
-		hevcOutput, hevcErr := smoke("hevc_videotoolbox")
+		// Probe the 10-bit session the HEVC transcode path actually creates:
+		// hevc passes the source bit depth through (p010 for HDR10), so an
+		// 8-bit-only encoder must not advertise HEVC availability.
+		hevcOutput, hevcErr := smoke("hevc_videotoolbox", "-vf", "format=p010le")
 		result.hevcAvailable = hevcErr == nil
 		if hevcErr != nil {
 			result.reason = "hevc_videotoolbox smoke encode failed: " + FormatFFmpegProbeFailure(hevcErr, hevcOutput)

--- a/internal/playback/gpudetect.go
+++ b/internal/playback/gpudetect.go
@@ -326,11 +326,12 @@ func videoToolboxSupportsTargetCodec(ffmpegPath, codec string) (bool, string) {
 }
 
 func cachedVideoToolboxProbe(ffmpegPath string) hardwareProbeResult {
-	// Cache on the cleaned spelling, but execute the exact path the transcode
-	// will run: filepath.Clean turns "./ffmpeg-full" into a bare name, which
-	// would probe a PATH binary instead of the configured file.
+	// Execute the exact path the transcode will run and cache on that same
+	// spelling: filepath.Clean would turn "./ffmpeg" into a bare name that
+	// collides with the PATH-resolved executable, which can be a different
+	// binary with different capabilities.
 	execPath := probeExecFFmpegPath(ffmpegPath)
-	cacheKey := normalizeFFmpegPath(ffmpegPath)
+	cacheKey := execPath
 	videoToolboxProbeCache.Lock()
 	if result, ok := videoToolboxProbeCache.byPath[cacheKey]; ok {
 		videoToolboxProbeCache.Unlock()

--- a/internal/playback/gpudetect.go
+++ b/internal/playback/gpudetect.go
@@ -318,13 +318,13 @@ func ffmpegSupportsVideoToolbox(ffmpegPath string) (bool, string) {
 // memory, so the regular software filter graph applies (see appendHWAccelArgs).
 func probeFFmpegVideoToolbox(ffmpegPath string) nvencProbeResult {
 	if output, err := runFFmpegProbe(ffmpegPath, "-hide_banner", "-hwaccels"); err != nil {
-		return nvencProbeResult{reason: "hwaccels probe failed: " + probeFailure(err, output)}
+		return nvencProbeResult{reason: "hwaccels probe failed: " + FormatFFmpegProbeFailure(err, output)}
 	} else if !ffmpegOutputHasToken(output, "videotoolbox") {
 		return nvencProbeResult{reason: "videotoolbox hwaccel unavailable"}
 	}
 
 	if output, err := runFFmpegProbe(ffmpegPath, "-hide_banner", "-encoders"); err != nil {
-		return nvencProbeResult{reason: "encoders probe failed: " + probeFailure(err, output)}
+		return nvencProbeResult{reason: "encoders probe failed: " + FormatFFmpegProbeFailure(err, output)}
 	} else if !ffmpegOutputHasToken(output, "h264_videotoolbox") {
 		return nvencProbeResult{reason: "h264_videotoolbox encoder unavailable"}
 	} else if !ffmpegOutputHasToken(output, "hevc_videotoolbox") {
@@ -350,7 +350,7 @@ func probeFFmpegVideoToolbox(ffmpegPath string) nvencProbeResult {
 			"-f", "null",
 			"-",
 		); err != nil {
-			return nvencProbeResult{reason: smoke.encoder + " smoke encode failed: " + probeFailure(err, output)}
+			return nvencProbeResult{reason: smoke.encoder + " smoke encode failed: " + FormatFFmpegProbeFailure(err, output)}
 		}
 	}
 

--- a/internal/playback/gpudetect.go
+++ b/internal/playback/gpudetect.go
@@ -339,7 +339,7 @@ func videoToolboxSupportsTargetCodec(ffmpegPath, codec string) (bool, string) {
 
 func videoToolboxSupportsTargetCodecContext(ctx context.Context, ffmpegPath, codec string) (bool, string) {
 	result := cachedVideoToolboxProbeContext(ctx, ffmpegPath)
-	if strings.EqualFold(strings.TrimSpace(codec), "hevc") {
+	if strings.EqualFold(strings.TrimSpace(codec), transcodeCodecHEVC) {
 		if result.hevcAvailable {
 			return true, ""
 		}

--- a/internal/playback/gpudetect.go
+++ b/internal/playback/gpudetect.go
@@ -179,18 +179,22 @@ func ResolveHWAccelWithFFmpeg(hwAccel string, ffmpegPath string) string {
 	return ResolveHWAccelWithFFmpegContext(context.Background(), hwAccel, ffmpegPath)
 }
 
-// ResolveHWAccelWithFFmpegContext resolves auto hardware without allowing any
-// FFmpeg capability probe to outlive ctx.
+// ResolveHWAccelWithFFmpegContext resolves auto hardware without blocking the
+// caller past ctx. A coalesced probe may continue for other callers and cache
+// its bounded result after this caller leaves.
 func ResolveHWAccelWithFFmpegContext(ctx context.Context, hwAccel string, ffmpegPath string) string {
+	if ctx == nil {
+		ctx = context.Background()
+	}
 	if hwAccel != "auto" {
 		return hwAccel
 	}
 	if currentGOOS == darwinGOOS {
-		if ok, reason := ffmpegSupportsVideoToolbox(ffmpegPath); ok {
-			slog.Info("hw_accel=auto: macOS detected, using VideoToolbox")
+		if ok, reason := ffmpegSupportsVideoToolboxContext(ctx, ffmpegPath); ok {
+			slog.InfoContext(ctx, "hw_accel=auto: macOS detected, using VideoToolbox")
 			return transcodeHWVideoToolbox
 		} else {
-			slog.Warn("hw_accel=auto: macOS detected but FFmpeg VideoToolbox probe failed",
+			slog.WarnContext(ctx, "hw_accel=auto: macOS detected but FFmpeg VideoToolbox probe failed",
 				"ffmpeg", normalizeFFmpegPath(ffmpegPath), "reason", reason)
 		}
 		return transcodeHWNone
@@ -324,8 +328,8 @@ func nvencProbeCacheKey(ffmpegPath string) string {
 	return fmt.Sprintf("%s\x00%d\x00%d", identityPath, info.Size(), info.ModTime().UnixNano())
 }
 
-func ffmpegSupportsVideoToolbox(ffmpegPath string) (bool, string) {
-	result := cachedVideoToolboxProbe(ffmpegPath)
+func ffmpegSupportsVideoToolboxContext(ctx context.Context, ffmpegPath string) (bool, string) {
+	result := cachedVideoToolboxProbeContext(ctx, ffmpegPath)
 	return result.available, result.reason
 }
 
@@ -344,6 +348,13 @@ func videoToolboxSupportsTargetCodec(ffmpegPath, codec string) (bool, string) {
 }
 
 func cachedVideoToolboxProbe(ffmpegPath string) hardwareProbeResult {
+	return cachedVideoToolboxProbeContext(context.Background(), ffmpegPath)
+}
+
+func cachedVideoToolboxProbeContext(ctx context.Context, ffmpegPath string) hardwareProbeResult {
+	if ctx == nil {
+		ctx = context.Background()
+	}
 	// Execute the exact path the transcode will run and cache on that same
 	// spelling: filepath.Clean would turn "./ffmpeg" into a bare name that
 	// collides with the PATH-resolved executable, which can be a different
@@ -363,25 +374,41 @@ func cachedVideoToolboxProbe(ffmpegPath string) hardwareProbeResult {
 	// overwrite a success).
 	if call, ok := videoToolboxProbes.inFlight[cacheKey]; ok {
 		videoToolboxProbes.Unlock()
-		<-call.done
-		return call.result
+		select {
+		case <-call.done:
+			return call.result
+		case <-ctx.Done():
+			return hardwareProbeResult{reason: ctx.Err().Error()}
+		}
 	}
 	call := &videoToolboxProbeCall{done: make(chan struct{})}
 	videoToolboxProbes.inFlight[cacheKey] = call
 	videoToolboxProbes.Unlock()
 
-	result := probeFFmpegVideoToolbox(execPath)
-	entry := videoToolboxProbeEntry{result: result}
-	if !result.available || !result.hevcAvailable {
-		entry.expiresAt = time.Now().Add(videoToolboxProbeRetryDelay)
+	commandTimeout := nvencProbeCommandTimeout
+	retryDelay := videoToolboxProbeRetryDelay
+	go func() {
+		probeCtx, cancel := context.WithTimeout(context.Background(), 4*commandTimeout+time.Second)
+		defer cancel()
+		result := probeFFmpegVideoToolboxContext(probeCtx, execPath, commandTimeout)
+		entry := videoToolboxProbeEntry{result: result}
+		if !result.available || !result.hevcAvailable {
+			entry.expiresAt = time.Now().Add(retryDelay)
+		}
+		videoToolboxProbes.Lock()
+		videoToolboxProbes.byPath[cacheKey] = entry
+		call.result = result
+		delete(videoToolboxProbes.inFlight, cacheKey)
+		close(call.done)
+		videoToolboxProbes.Unlock()
+	}()
+
+	select {
+	case <-call.done:
+		return call.result
+	case <-ctx.Done():
+		return hardwareProbeResult{reason: ctx.Err().Error()}
 	}
-	videoToolboxProbes.Lock()
-	videoToolboxProbes.byPath[cacheKey] = entry
-	call.result = result
-	delete(videoToolboxProbes.inFlight, cacheKey)
-	close(call.done)
-	videoToolboxProbes.Unlock()
-	return result
 }
 
 // StartupRetryHWAccel returns the acceleration for the single retry after a
@@ -416,14 +443,14 @@ func probeExecFFmpegPath(ffmpegPath string) string {
 // an HEVC recipe falls back to software. No filter probes: the VideoToolbox
 // pipeline keeps decoded frames in system memory, so the regular software
 // filter graph applies (see appendHWAccelArgs).
-func probeFFmpegVideoToolbox(ffmpegPath string) hardwareProbeResult {
-	if output, err := runFFmpegProbe(context.Background(), nvencProbeCommandTimeout, ffmpegPath, "-hide_banner", "-hwaccels"); err != nil {
+func probeFFmpegVideoToolboxContext(ctx context.Context, ffmpegPath string, commandTimeout time.Duration) hardwareProbeResult {
+	if output, err := runFFmpegProbe(ctx, commandTimeout, ffmpegPath, "-hide_banner", "-hwaccels"); err != nil {
 		return hardwareProbeResult{reason: "hwaccels probe failed: " + FormatFFmpegProbeFailure(err, output)}
 	} else if !ffmpegOutputHasToken(output, "videotoolbox") {
 		return hardwareProbeResult{reason: "videotoolbox hwaccel unavailable"}
 	}
 
-	output, err := runFFmpegProbe(context.Background(), nvencProbeCommandTimeout, ffmpegPath, "-hide_banner", "-encoders")
+	output, err := runFFmpegProbe(ctx, commandTimeout, ffmpegPath, "-hide_banner", "-encoders")
 	if err != nil {
 		return hardwareProbeResult{reason: "encoders probe failed: " + FormatFFmpegProbeFailure(err, output)}
 	}
@@ -449,7 +476,7 @@ func probeFFmpegVideoToolbox(ffmpegPath string) hardwareProbeResult {
 			"-f", "null",
 			"-",
 		)
-		return runFFmpegProbe(context.Background(), nvencProbeCommandTimeout, ffmpegPath, args...)
+		return runFFmpegProbe(ctx, commandTimeout, ffmpegPath, args...)
 	}
 
 	h264Output, err := smoke("h264_videotoolbox")

--- a/internal/playback/gpudetect.go
+++ b/internal/playback/gpudetect.go
@@ -19,6 +19,12 @@ import (
 
 const darwinGOOS = "darwin"
 
+const (
+	ffmpegFlagHideBanner = "-hide_banner"
+	ffmpegFlagLogLevel   = "-loglevel"
+	ffmpegLogLevelError  = "error"
+)
+
 var (
 	defaultDRIDir              = "/dev/dri"
 	defaultNVIDIAControlDevice = "/dev/nvidiactl"
@@ -320,19 +326,34 @@ func videoToolboxSupportsTargetCodec(ffmpegPath, codec string) (bool, string) {
 }
 
 func cachedVideoToolboxProbe(ffmpegPath string) hardwareProbeResult {
-	ffmpegPath = normalizeFFmpegPath(ffmpegPath)
+	// Cache on the cleaned spelling, but execute the exact path the transcode
+	// will run: filepath.Clean turns "./ffmpeg-full" into a bare name, which
+	// would probe a PATH binary instead of the configured file.
+	execPath := probeExecFFmpegPath(ffmpegPath)
+	cacheKey := normalizeFFmpegPath(ffmpegPath)
 	videoToolboxProbeCache.Lock()
-	if result, ok := videoToolboxProbeCache.byPath[ffmpegPath]; ok {
+	if result, ok := videoToolboxProbeCache.byPath[cacheKey]; ok {
 		videoToolboxProbeCache.Unlock()
 		return result
 	}
 	videoToolboxProbeCache.Unlock()
 
-	result := probeFFmpegVideoToolbox(ffmpegPath)
+	result := probeFFmpegVideoToolbox(execPath)
 	videoToolboxProbeCache.Lock()
-	videoToolboxProbeCache.byPath[ffmpegPath] = result
+	videoToolboxProbeCache.byPath[cacheKey] = result
 	videoToolboxProbeCache.Unlock()
 	return result
+}
+
+// probeExecFFmpegPath returns the binary a capability probe must execute for
+// the configured path: the configured spelling verbatim (relative paths
+// included), or the process-global discovery when unset.
+func probeExecFFmpegPath(ffmpegPath string) string {
+	ffmpegPath = strings.TrimSpace(ffmpegPath)
+	if ffmpegPath == "" {
+		return ffmpegBinary()
+	}
+	return ffmpegPath
 }
 
 // probeFFmpegVideoToolbox verifies the configured FFmpeg exposes VideoToolbox
@@ -360,8 +381,8 @@ func probeFFmpegVideoToolbox(ffmpegPath string) hardwareProbeResult {
 
 	smoke := func(encoder string, extraArgs ...string) ([]byte, error) {
 		args := []string{
-			"-hide_banner",
-			"-loglevel", "error",
+			ffmpegFlagHideBanner,
+			ffmpegFlagLogLevel, ffmpegLogLevelError,
 			"-f", "lavfi",
 			"-i", "testsrc2=size=640x360:rate=1",
 			"-frames:v", "1",

--- a/internal/playback/gpudetect.go
+++ b/internal/playback/gpudetect.go
@@ -29,6 +29,13 @@ var (
 	nvencProbeNegativeTTL      = 15 * time.Second
 )
 
+type hardwareProbeResult struct {
+	available     bool
+	reason        string
+	h264Available bool
+	hevcAvailable bool
+}
+
 type nvencProbeResult struct {
 	available bool
 	reason    string
@@ -49,9 +56,9 @@ var nvencProbeCache = struct {
 
 var videoToolboxProbeCache = struct {
 	sync.Mutex
-	byPath map[string]nvencProbeResult
+	byPath map[string]hardwareProbeResult
 }{
-	byPath: make(map[string]nvencProbeResult),
+	byPath: make(map[string]hardwareProbeResult),
 }
 
 // HWAccelInfo describes the detected hardware acceleration capability.
@@ -294,11 +301,30 @@ func nvencProbeCacheKey(ffmpegPath string) string {
 }
 
 func ffmpegSupportsVideoToolbox(ffmpegPath string) (bool, string) {
+	result := cachedVideoToolboxProbe(ffmpegPath)
+	return result.available, result.reason
+}
+
+func videoToolboxSupportsTargetCodec(ffmpegPath, codec string) (bool, string) {
+	result := cachedVideoToolboxProbe(ffmpegPath)
+	if strings.EqualFold(strings.TrimSpace(codec), "hevc") {
+		if result.hevcAvailable {
+			return true, ""
+		}
+		return false, "hevc_videotoolbox encoder unavailable or failed its smoke encode"
+	}
+	if result.h264Available {
+		return true, ""
+	}
+	return false, result.reason
+}
+
+func cachedVideoToolboxProbe(ffmpegPath string) hardwareProbeResult {
 	ffmpegPath = normalizeFFmpegPath(ffmpegPath)
 	videoToolboxProbeCache.Lock()
 	if result, ok := videoToolboxProbeCache.byPath[ffmpegPath]; ok {
 		videoToolboxProbeCache.Unlock()
-		return result.available, result.reason
+		return result
 	}
 	videoToolboxProbeCache.Unlock()
 
@@ -306,55 +332,63 @@ func ffmpegSupportsVideoToolbox(ffmpegPath string) (bool, string) {
 	videoToolboxProbeCache.Lock()
 	videoToolboxProbeCache.byPath[ffmpegPath] = result
 	videoToolboxProbeCache.Unlock()
-	return result.available, result.reason
+	return result
 }
 
 // probeFFmpegVideoToolbox verifies the configured FFmpeg exposes VideoToolbox
-// decode plus both encoders, then smoke-encodes one frame per encoder in the
-// same constant-quality mode the uncapped transcode path emits (-q:v needs an
-// Apple Silicon compression session; Intel Macs must fail here so auto
-// resolves to software instead of approving commands that cannot run). No
-// filter probes: the videotoolbox pipeline keeps decoded frames in system
-// memory, so the regular software filter graph applies (see appendHWAccelArgs).
-func probeFFmpegVideoToolbox(ffmpegPath string) nvencProbeResult {
-	if output, err := runFFmpegProbe(ffmpegPath, "-hide_banner", "-hwaccels"); err != nil {
-		return nvencProbeResult{reason: "hwaccels probe failed: " + FormatFFmpegProbeFailure(err, output)}
+// decode plus H.264 encode, then smoke-encodes each advertised encoder in the
+// portable bitrate mode used by the transcode builder. H.264 is the required
+// baseline because Silo's current playback ladder targets H.264; HEVC is
+// recorded independently so older Intel Macs can still accelerate H.264 while
+// an HEVC recipe falls back to software. No filter probes: the VideoToolbox
+// pipeline keeps decoded frames in system memory, so the regular software
+// filter graph applies (see appendHWAccelArgs).
+func probeFFmpegVideoToolbox(ffmpegPath string) hardwareProbeResult {
+	if output, err := runFFmpegProbe(context.Background(), nvencProbeCommandTimeout, ffmpegPath, "-hide_banner", "-hwaccels"); err != nil {
+		return hardwareProbeResult{reason: "hwaccels probe failed: " + FormatFFmpegProbeFailure(err, output)}
 	} else if !ffmpegOutputHasToken(output, "videotoolbox") {
-		return nvencProbeResult{reason: "videotoolbox hwaccel unavailable"}
+		return hardwareProbeResult{reason: "videotoolbox hwaccel unavailable"}
 	}
 
-	if output, err := runFFmpegProbe(ffmpegPath, "-hide_banner", "-encoders"); err != nil {
-		return nvencProbeResult{reason: "encoders probe failed: " + FormatFFmpegProbeFailure(err, output)}
-	} else if !ffmpegOutputHasToken(output, "h264_videotoolbox") {
-		return nvencProbeResult{reason: "h264_videotoolbox encoder unavailable"}
-	} else if !ffmpegOutputHasToken(output, "hevc_videotoolbox") {
-		return nvencProbeResult{reason: "hevc_videotoolbox encoder unavailable"}
+	output, err := runFFmpegProbe(context.Background(), nvencProbeCommandTimeout, ffmpegPath, "-hide_banner", "-encoders")
+	if err != nil {
+		return hardwareProbeResult{reason: "encoders probe failed: " + FormatFFmpegProbeFailure(err, output)}
+	}
+	if !ffmpegOutputHasToken(output, "h264_videotoolbox") {
+		return hardwareProbeResult{reason: "h264_videotoolbox encoder unavailable"}
 	}
 
-	for _, smoke := range []struct {
-		encoder string
-		quality string
-	}{
-		{"h264_videotoolbox", "65"},
-		{"hevc_videotoolbox", "60"},
-	} {
-		if output, err := runFFmpegProbe(ffmpegPath,
+	smoke := func(encoder string) ([]byte, error) {
+		return runFFmpegProbe(context.Background(), nvencProbeCommandTimeout, ffmpegPath,
 			"-hide_banner",
 			"-loglevel", "error",
 			"-f", "lavfi",
 			"-i", "testsrc2=size=640x360:rate=1",
 			"-frames:v", "1",
 			"-an",
-			"-c:v", smoke.encoder,
-			"-q:v", smoke.quality,
+			"-c:v", encoder,
+			"-b:v", "2000k",
+			"-maxrate", "2000k",
+			"-bufsize", "4000k",
 			"-f", "null",
 			"-",
-		); err != nil {
-			return nvencProbeResult{reason: smoke.encoder + " smoke encode failed: " + FormatFFmpegProbeFailure(err, output)}
-		}
+		)
 	}
 
-	return nvencProbeResult{available: true}
+	h264Output, err := smoke("h264_videotoolbox")
+	if err != nil {
+		return hardwareProbeResult{reason: "h264_videotoolbox smoke encode failed: " + FormatFFmpegProbeFailure(err, h264Output)}
+	}
+
+	result := hardwareProbeResult{available: true, h264Available: true}
+	if ffmpegOutputHasToken(output, "hevc_videotoolbox") {
+		hevcOutput, hevcErr := smoke("hevc_videotoolbox")
+		result.hevcAvailable = hevcErr == nil
+		if hevcErr != nil {
+			result.reason = "hevc_videotoolbox smoke encode failed: " + FormatFFmpegProbeFailure(hevcErr, hevcOutput)
+		}
+	}
+	return result
 }
 
 func normalizeFFmpegPath(ffmpegPath string) string {

--- a/internal/playback/gpudetect.go
+++ b/internal/playback/gpudetect.go
@@ -60,11 +60,29 @@ var nvencProbeCache = struct {
 	byPath: make(map[string]nvencProbeCacheEntry),
 }
 
-var videoToolboxProbeCache = struct {
+// videoToolboxProbeRetryDelay bounds how long a negative probe result is
+// trusted. A transient failure (probe timeout, hardware session contention
+// during a burst of playback starts) must not pin auto mode to software for
+// the process lifetime; successful fully-capable probes are cached forever.
+var videoToolboxProbeRetryDelay = time.Minute
+
+type videoToolboxProbeEntry struct {
+	result    hardwareProbeResult
+	expiresAt time.Time // zero: cached for the process lifetime
+}
+
+type videoToolboxProbeCall struct {
+	done   chan struct{}
+	result hardwareProbeResult
+}
+
+var videoToolboxProbes = struct {
 	sync.Mutex
-	byPath map[string]hardwareProbeResult
+	byPath   map[string]videoToolboxProbeEntry
+	inFlight map[string]*videoToolboxProbeCall
 }{
-	byPath: make(map[string]hardwareProbeResult),
+	byPath:   make(map[string]videoToolboxProbeEntry),
+	inFlight: make(map[string]*videoToolboxProbeCall),
 }
 
 // HWAccelInfo describes the detected hardware acceleration capability.
@@ -332,18 +350,51 @@ func cachedVideoToolboxProbe(ffmpegPath string) hardwareProbeResult {
 	// binary with different capabilities.
 	execPath := probeExecFFmpegPath(ffmpegPath)
 	cacheKey := execPath
-	videoToolboxProbeCache.Lock()
-	if result, ok := videoToolboxProbeCache.byPath[cacheKey]; ok {
-		videoToolboxProbeCache.Unlock()
-		return result
+	videoToolboxProbes.Lock()
+	if entry, ok := videoToolboxProbes.byPath[cacheKey]; ok {
+		if entry.expiresAt.IsZero() || time.Now().Before(entry.expiresAt) {
+			videoToolboxProbes.Unlock()
+			return entry.result
+		}
+		delete(videoToolboxProbes.byPath, cacheKey)
 	}
-	videoToolboxProbeCache.Unlock()
+	// Coalesce concurrent cold-cache probes: a burst of playback starts must
+	// not race overlapping smoke encodes (and let a contention failure
+	// overwrite a success).
+	if call, ok := videoToolboxProbes.inFlight[cacheKey]; ok {
+		videoToolboxProbes.Unlock()
+		<-call.done
+		return call.result
+	}
+	call := &videoToolboxProbeCall{done: make(chan struct{})}
+	videoToolboxProbes.inFlight[cacheKey] = call
+	videoToolboxProbes.Unlock()
 
 	result := probeFFmpegVideoToolbox(execPath)
-	videoToolboxProbeCache.Lock()
-	videoToolboxProbeCache.byPath[cacheKey] = result
-	videoToolboxProbeCache.Unlock()
+	entry := videoToolboxProbeEntry{result: result}
+	if !result.available || !result.hevcAvailable {
+		entry.expiresAt = time.Now().Add(videoToolboxProbeRetryDelay)
+	}
+	videoToolboxProbes.Lock()
+	videoToolboxProbes.byPath[cacheKey] = entry
+	call.result = result
+	delete(videoToolboxProbes.inFlight, cacheKey)
+	close(call.done)
+	videoToolboxProbes.Unlock()
 	return result
+}
+
+// StartupRetryHWAccel returns the acceleration for the single retry after a
+// transcode dies before producing its first segment. VideoToolbox has no
+// alternate render device to move to, so its retry runs in software — e.g. an
+// encoder session the hardware cannot create at the requested dimensions
+// falls back to the working CPU encoder. Every other accel keeps its
+// configured value; the retry moves render devices via AvoidHWDevice instead.
+func StartupRetryHWAccel(configuredHWAccel, ffmpegPath string) string {
+	if ResolveHWAccelWithFFmpeg(configuredHWAccel, ffmpegPath) == transcodeHWVideoToolbox {
+		return transcodeHWNone
+	}
+	return configuredHWAccel
 }
 
 // probeExecFFmpegPath returns the binary a capability probe must execute for

--- a/internal/playback/gpudetect.go
+++ b/internal/playback/gpudetect.go
@@ -334,7 +334,11 @@ func ffmpegSupportsVideoToolboxContext(ctx context.Context, ffmpegPath string) (
 }
 
 func videoToolboxSupportsTargetCodec(ffmpegPath, codec string) (bool, string) {
-	result := cachedVideoToolboxProbe(ffmpegPath)
+	return videoToolboxSupportsTargetCodecContext(context.Background(), ffmpegPath, codec)
+}
+
+func videoToolboxSupportsTargetCodecContext(ctx context.Context, ffmpegPath, codec string) (bool, string) {
+	result := cachedVideoToolboxProbeContext(ctx, ffmpegPath)
 	if strings.EqualFold(strings.TrimSpace(codec), "hevc") {
 		if result.hevcAvailable {
 			return true, ""
@@ -360,7 +364,7 @@ func cachedVideoToolboxProbeContext(ctx context.Context, ffmpegPath string) hard
 	// collides with the PATH-resolved executable, which can be a different
 	// binary with different capabilities.
 	execPath := probeExecFFmpegPath(ffmpegPath)
-	cacheKey := execPath
+	cacheKey := videoToolboxProbeCacheKey(execPath)
 	videoToolboxProbes.Lock()
 	if entry, ok := videoToolboxProbes.byPath[cacheKey]; ok {
 		if entry.expiresAt.IsZero() || time.Now().Before(entry.expiresAt) {
@@ -409,6 +413,14 @@ func cachedVideoToolboxProbeContext(ctx context.Context, ffmpegPath string) hard
 	case <-ctx.Done():
 		return hardwareProbeResult{reason: ctx.Err().Error()}
 	}
+}
+
+// videoToolboxProbeCacheKey keeps configured spellings distinct while also
+// invalidating a cached verdict when that spelling resolves to a replaced
+// executable. This matters for Homebrew upgrades that swap a symlink target
+// while Silo remains running.
+func videoToolboxProbeCacheKey(execPath string) string {
+	return execPath + "\x00" + nvencProbeCacheKey(execPath)
 }
 
 // StartupRetryHWAccel returns the acceleration for the single retry after a

--- a/internal/playback/gpudetect.go
+++ b/internal/playback/gpudetect.go
@@ -425,15 +425,17 @@ func videoToolboxProbeCacheKey(execPath string) string {
 
 // StartupRetryHWAccel returns the acceleration for the single retry after a
 // transcode dies before producing its first segment. VideoToolbox has no
-// alternate render device to move to, so its retry runs in software — e.g. an
-// encoder session the hardware cannot create at the requested dimensions
-// falls back to the working CPU encoder. Every other accel keeps its
-// configured value; the retry moves render devices via AvoidHWDevice instead.
-func StartupRetryHWAccel(configuredHWAccel, ffmpegPath string) string {
-	if ResolveHWAccelWithFFmpeg(configuredHWAccel, ffmpegPath) == transcodeHWVideoToolbox {
+// alternate render device to move to, so an ordinary encode retries on the
+// CPU. A frozen hardware tone-map recipe cannot take that acceleration-only
+// shortcut because its mode and filter would no longer describe the executor;
+// the owner must replan it as a complete software recipe instead. Every other
+// accel keeps its configured value and moves render devices via AvoidHWDevice.
+func StartupRetryHWAccel(opts TranscodeOpts) string {
+	if opts.ToneMapMode != tonemap.ModeHardware &&
+		ResolveHWAccelWithFFmpeg(opts.HWAccel, opts.FFmpegPath) == transcodeHWVideoToolbox {
 		return transcodeHWNone
 	}
-	return configuredHWAccel
+	return opts.HWAccel
 }
 
 // probeExecFFmpegPath returns the binary a capability probe must execute for

--- a/internal/playback/gpudetect_test.go
+++ b/internal/playback/gpudetect_test.go
@@ -645,3 +645,17 @@ func TestExplicitVideoToolboxBypassesFFmpegProbe(t *testing.T) {
 		t.Fatalf("ResolveHWAccelWithFFmpeg() = %q, want videotoolbox", got)
 	}
 }
+
+func TestCachedVideoToolboxProbeExecutesConfiguredRelativePath(t *testing.T) {
+	setupHWAccelTest(t)
+	ffmpeg := writeFakeFFmpeg(t, successfulVideoToolboxProbe())
+	// Empty PATH: if the probe cleaned "./ffmpeg" to a bare name it would fall
+	// back to PATH lookup and fail instead of executing the configured file.
+	t.Setenv("PATH", t.TempDir())
+	t.Chdir(filepath.Dir(ffmpeg.path))
+
+	result := cachedVideoToolboxProbe("./" + filepath.Base(ffmpeg.path))
+	if !result.available {
+		t.Fatalf("probe must execute the configured relative path, got reason %q", result.reason)
+	}
+}

--- a/internal/playback/gpudetect_test.go
+++ b/internal/playback/gpudetect_test.go
@@ -502,6 +502,12 @@ func writeFakeFFmpeg(t *testing.T, probe fakeFFmpegProbe) fakeFFmpegBinary {
 	dir := t.TempDir()
 	path := filepath.Join(dir, "ffmpeg")
 	logPath := filepath.Join(dir, "probe.log")
+	writeFakeFFmpegScript(t, path, logPath, probe)
+	return fakeFFmpegBinary{path: path, logPath: logPath}
+}
+
+func writeFakeFFmpegScript(t *testing.T, path, logPath string, probe fakeFFmpegProbe) {
+	t.Helper()
 
 	script := "#!/bin/sh\n"
 	script += fmt.Sprintf("printf '%%s\\n' \"$*\" >> %q\n", logPath)
@@ -555,16 +561,15 @@ func writeFakeFFmpeg(t *testing.T, probe fakeFFmpegProbe) fakeFFmpegBinary {
 	if err := os.WriteFile(path, []byte(script), 0o755); err != nil {
 		t.Fatalf("write fake ffmpeg: %v", err)
 	}
-	return fakeFFmpegBinary{path: path, logPath: logPath}
 }
 
 func resetNVENCProbeCacheForTest() {
 	nvencProbeCache.Lock()
 	nvencProbeCache.byPath = make(map[string]nvencProbeCacheEntry)
 	nvencProbeCache.Unlock()
-	videoToolboxProbeCache.Lock()
-	videoToolboxProbeCache.byPath = make(map[string]hardwareProbeResult)
-	videoToolboxProbeCache.Unlock()
+	videoToolboxProbes.Lock()
+	videoToolboxProbes.byPath = make(map[string]videoToolboxProbeEntry)
+	videoToolboxProbes.Unlock()
 }
 
 func successfulVideoToolboxProbe() fakeFFmpegProbe {
@@ -675,5 +680,72 @@ func TestCachedVideoToolboxProbeKeepsRelativeAndPathSpellingsDistinct(t *testing
 	}
 	if result := cachedVideoToolboxProbe("ffmpeg"); result.available {
 		t.Fatal("PATH spelling should probe the incapable binary, not reuse the relative spelling's cache entry")
+	}
+}
+
+func TestStartupRetryHWAccel(t *testing.T) {
+	// Explicit values bypass ffmpeg probing, keeping this host-independent.
+	if got := StartupRetryHWAccel("videotoolbox", "/does/not/exist"); got != "none" {
+		t.Fatalf("videotoolbox retry accel = %q, want none (no alternate device to move to)", got)
+	}
+	for _, accel := range []string{"qsv", "vaapi", "nvenc", "none"} {
+		if got := StartupRetryHWAccel(accel, "/does/not/exist"); got != accel {
+			t.Fatalf("%s retry accel = %q, want unchanged", accel, got)
+		}
+	}
+}
+
+func TestCachedVideoToolboxProbeCoalescesConcurrentColdProbes(t *testing.T) {
+	setupHWAccelTest(t)
+	ffmpeg := writeFakeFFmpeg(t, fakeFFmpegProbe{hang: true})
+
+	var wg sync.WaitGroup
+	for range 8 {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			cachedVideoToolboxProbe(ffmpeg.path)
+		}()
+	}
+	wg.Wait()
+
+	log, err := os.ReadFile(ffmpeg.logPath)
+	if err != nil {
+		t.Fatalf("read probe log: %v", err)
+	}
+	if got := strings.Count(string(log), "-hwaccels"); got != 1 {
+		t.Fatalf("concurrent cold probes ran %d ffmpeg invocations, want 1 (coalesced):\n%s", got, log)
+	}
+}
+
+func TestCachedVideoToolboxProbeRetriesNegativeResultsAfterExpiry(t *testing.T) {
+	setupHWAccelTest(t)
+	oldDelay := videoToolboxProbeRetryDelay
+	videoToolboxProbeRetryDelay = 0
+	t.Cleanup(func() { videoToolboxProbeRetryDelay = oldDelay })
+
+	ffmpeg := writeFakeFFmpeg(t, fakeFFmpegProbe{})
+	if result := cachedVideoToolboxProbe(ffmpeg.path); result.available {
+		t.Fatal("failing fake should probe unavailable")
+	}
+
+	// The hardware "recovers": the same binary now answers every probe.
+	writeFakeFFmpegScript(t, ffmpeg.path, ffmpeg.logPath, successfulVideoToolboxProbe())
+	if result := cachedVideoToolboxProbe(ffmpeg.path); !result.available {
+		t.Fatalf("expired negative result should re-probe, got reason %q", result.reason)
+	}
+}
+
+func TestCachedVideoToolboxProbeCachesFullyCapableResultsForever(t *testing.T) {
+	setupHWAccelTest(t)
+	ffmpeg := writeFakeFFmpeg(t, successfulVideoToolboxProbe())
+	if result := cachedVideoToolboxProbe(ffmpeg.path); !result.available {
+		t.Fatalf("capable fake should probe available, got %q", result.reason)
+	}
+
+	// Break the binary; the cached positive verdict must keep serving.
+	writeFakeFFmpegScript(t, ffmpeg.path, ffmpeg.logPath, fakeFFmpegProbe{})
+	if result := cachedVideoToolboxProbe(ffmpeg.path); !result.available {
+		t.Fatal("fully capable results should be cached for the process lifetime")
 	}
 }

--- a/internal/playback/gpudetect_test.go
+++ b/internal/playback/gpudetect_test.go
@@ -630,7 +630,7 @@ func TestVideoToolboxProbeSmokesBothEncodersInPortableBitrateMode(t *testing.T) 
 	// H.264 acceleration available on older Intel Macs as well.
 	for _, want := range []string{
 		"-c:v h264_videotoolbox -b:v 2000k -maxrate 2000k -bufsize 4000k",
-		"-c:v hevc_videotoolbox -b:v 2000k -maxrate 2000k -bufsize 4000k",
+		"-vf format=p010le -c:v hevc_videotoolbox -b:v 2000k -maxrate 2000k -bufsize 4000k",
 	} {
 		if !strings.Contains(string(log), want) {
 			t.Fatalf("probe log missing %q:\n%s", want, log)

--- a/internal/playback/gpudetect_test.go
+++ b/internal/playback/gpudetect_test.go
@@ -757,16 +757,17 @@ func TestCachedVideoToolboxProbeRetriesNegativeResultsAfterExpiry(t *testing.T) 
 	}
 }
 
-func TestCachedVideoToolboxProbeCachesFullyCapableResultsForever(t *testing.T) {
+func TestCachedVideoToolboxProbeInvalidatesWhenExecutableIsReplaced(t *testing.T) {
 	setupHWAccelTest(t)
 	ffmpeg := writeFakeFFmpeg(t, successfulVideoToolboxProbe())
 	if result := cachedVideoToolboxProbe(ffmpeg.path); !result.available {
 		t.Fatalf("capable fake should probe available, got %q", result.reason)
 	}
 
-	// Break the binary; the cached positive verdict must keep serving.
+	// Replace the binary at the same configured spelling. Its identity is part
+	// of the cache key, so the old positive verdict must not survive.
 	writeFakeFFmpegScript(t, ffmpeg.path, ffmpeg.logPath, fakeFFmpegProbe{})
-	if result := cachedVideoToolboxProbe(ffmpeg.path); !result.available {
-		t.Fatal("fully capable results should be cached for the process lifetime")
+	if result := cachedVideoToolboxProbe(ffmpeg.path); result.available {
+		t.Fatal("replacement binary reused the previous executable's positive verdict")
 	}
 }

--- a/internal/playback/gpudetect_test.go
+++ b/internal/playback/gpudetect_test.go
@@ -659,3 +659,21 @@ func TestCachedVideoToolboxProbeExecutesConfiguredRelativePath(t *testing.T) {
 		t.Fatalf("probe must execute the configured relative path, got reason %q", result.reason)
 	}
 }
+
+func TestCachedVideoToolboxProbeKeepsRelativeAndPathSpellingsDistinct(t *testing.T) {
+	setupHWAccelTest(t)
+	capable := writeFakeFFmpeg(t, successfulVideoToolboxProbe())
+	incapable := writeFakeFFmpeg(t, fakeFFmpegProbe{})
+	// PATH resolves the bare "ffmpeg" name to the incapable binary while the
+	// dot-relative spelling names the capable one; a cleaned cache key would
+	// collide the two and let one spelling's verdict leak to the other.
+	t.Setenv("PATH", filepath.Dir(incapable.path))
+	t.Chdir(filepath.Dir(capable.path))
+
+	if result := cachedVideoToolboxProbe("./" + filepath.Base(capable.path)); !result.available {
+		t.Fatalf("relative spelling should probe the capable binary, got %q", result.reason)
+	}
+	if result := cachedVideoToolboxProbe("ffmpeg"); result.available {
+		t.Fatal("PATH spelling should probe the incapable binary, not reuse the relative spelling's cache entry")
+	}
+}

--- a/internal/playback/gpudetect_test.go
+++ b/internal/playback/gpudetect_test.go
@@ -161,6 +161,51 @@ func TestResolveFFmpegPathTrimsWithoutCleaningRelativeExecutable(t *testing.T) {
 	}
 }
 
+func TestDiscoverFFmpegPathDarwinPrefersFullHomebrewBuilds(t *testing.T) {
+	tests := []struct {
+		name      string
+		available map[string]bool
+		want      string
+	}{
+		{
+			name:      "Apple Silicon prefix",
+			available: map[string]bool{homebrewFFmpegFullAppleSilicon: true},
+			want:      homebrewFFmpegFullAppleSilicon,
+		},
+		{
+			name:      "Intel prefix",
+			available: map[string]bool{homebrewFFmpegFullIntel: true},
+			want:      homebrewFFmpegFullIntel,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			lookPath := func(path string) (string, error) {
+				if tt.available[path] {
+					return path, nil
+				}
+				return "", fmt.Errorf("not found")
+			}
+			if got := discoverFFmpegPath(darwinGOOS, lookPath); got != tt.want {
+				t.Fatalf("discoverFFmpegPath() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestResolveFFmpegPathFallsBackOnlyForMissingLegacyDefault(t *testing.T) {
+	missing := func(string) (string, error) { return "", fmt.Errorf("not found") }
+	discover := func() string { return homebrewFFmpegFullAppleSilicon }
+
+	if got := resolveFFmpegPath(jellyfinFFmpegPath, missing, discover); got != discover() {
+		t.Fatalf("legacy default resolved to %q, want discovery result", got)
+	}
+	if got := resolveFFmpegPath("/custom/missing/ffmpeg", missing, discover); got != "/custom/missing/ffmpeg" {
+		t.Fatalf("custom path resolved to %q, want the explicit value preserved", got)
+	}
+}
+
 func TestFFmpegSupportsNVENCRequiresCUDAEncodersFiltersAndSmoke(t *testing.T) {
 	setupHWAccelTest(t)
 	tests := []struct {
@@ -518,7 +563,7 @@ func resetNVENCProbeCacheForTest() {
 	nvencProbeCache.byPath = make(map[string]nvencProbeCacheEntry)
 	nvencProbeCache.Unlock()
 	videoToolboxProbeCache.Lock()
-	videoToolboxProbeCache.byPath = make(map[string]nvencProbeResult)
+	videoToolboxProbeCache.byPath = make(map[string]hardwareProbeResult)
 	videoToolboxProbeCache.Unlock()
 }
 
@@ -546,13 +591,16 @@ func TestResolveHWAccelWithFFmpegDarwinFallsBackToNoneWhenProbeFails(t *testing.
 	}
 }
 
-func TestResolveHWAccelWithFFmpegDarwinRequiresBothVTEncoders(t *testing.T) {
+func TestResolveHWAccelWithFFmpegDarwinAllowsH264OnlyVideoToolbox(t *testing.T) {
 	setupHWAccelTest(t)
 	currentGOOS = "darwin"
 	ffmpeg := writeFakeFFmpeg(t, fakeFFmpegProbe{videotoolbox: true, h264VT: true, smokeOK: true})
 
-	if got := ResolveHWAccelWithFFmpeg("auto", ffmpeg.path); got != "none" {
-		t.Fatalf("ResolveHWAccelWithFFmpeg() = %q, want none when hevc_videotoolbox is missing", got)
+	if got := ResolveHWAccelWithFFmpeg("auto", ffmpeg.path); got != "videotoolbox" {
+		t.Fatalf("ResolveHWAccelWithFFmpeg() = %q, want videotoolbox for H.264-only Mac", got)
+	}
+	if ok, _ := videoToolboxSupportsTargetCodec(ffmpeg.path, "hevc"); ok {
+		t.Fatal("HEVC target unexpectedly accepted without hevc_videotoolbox")
 	}
 }
 
@@ -566,7 +614,7 @@ func TestResolveHWAccelWithFFmpegDarwinFallsBackToNoneWhenSmokeEncodeFails(t *te
 	}
 }
 
-func TestVideoToolboxProbeSmokesBothEncodersInConstantQualityMode(t *testing.T) {
+func TestVideoToolboxProbeSmokesBothEncodersInPortableBitrateMode(t *testing.T) {
 	setupHWAccelTest(t)
 	currentGOOS = "darwin"
 	ffmpeg := writeFakeFFmpeg(t, successfulVideoToolboxProbe())
@@ -578,10 +626,12 @@ func TestVideoToolboxProbeSmokesBothEncodersInConstantQualityMode(t *testing.T) 
 	if err != nil {
 		t.Fatalf("read probe log: %v", err)
 	}
-	// The smoke encodes must exercise the exact uncapped (-q:v) mode the
-	// transcode arg builder emits — Intel Macs fail that mode at session
-	// creation, so probing without it would approve unrunnable commands.
-	for _, want := range []string{"-c:v h264_videotoolbox -q:v 65", "-c:v hevc_videotoolbox -q:v 60"} {
+	// FFmpeg restricts -q:v to Apple Silicon. The portable bitrate path keeps
+	// H.264 acceleration available on older Intel Macs as well.
+	for _, want := range []string{
+		"-c:v h264_videotoolbox -b:v 2000k -maxrate 2000k -bufsize 4000k",
+		"-c:v hevc_videotoolbox -b:v 2000k -maxrate 2000k -bufsize 4000k",
+	} {
 		if !strings.Contains(string(log), want) {
 			t.Fatalf("probe log missing %q:\n%s", want, log)
 		}

--- a/internal/playback/gpudetect_test.go
+++ b/internal/playback/gpudetect_test.go
@@ -556,6 +556,38 @@ func TestResolveHWAccelWithFFmpegDarwinRequiresBothVTEncoders(t *testing.T) {
 	}
 }
 
+func TestResolveHWAccelWithFFmpegDarwinFallsBackToNoneWhenSmokeEncodeFails(t *testing.T) {
+	setupHWAccelTest(t)
+	currentGOOS = "darwin"
+	ffmpeg := writeFakeFFmpeg(t, fakeFFmpegProbe{videotoolbox: true, h264VT: true, hevcVT: true})
+
+	if got := ResolveHWAccelWithFFmpeg("auto", ffmpeg.path); got != "none" {
+		t.Fatalf("ResolveHWAccelWithFFmpeg() = %q, want none when smoke encode fails", got)
+	}
+}
+
+func TestVideoToolboxProbeSmokesBothEncodersInConstantQualityMode(t *testing.T) {
+	setupHWAccelTest(t)
+	currentGOOS = "darwin"
+	ffmpeg := writeFakeFFmpeg(t, successfulVideoToolboxProbe())
+
+	if got := ResolveHWAccelWithFFmpeg("auto", ffmpeg.path); got != "videotoolbox" {
+		t.Fatalf("ResolveHWAccelWithFFmpeg() = %q, want videotoolbox", got)
+	}
+	log, err := os.ReadFile(ffmpeg.logPath)
+	if err != nil {
+		t.Fatalf("read probe log: %v", err)
+	}
+	// The smoke encodes must exercise the exact uncapped (-q:v) mode the
+	// transcode arg builder emits — Intel Macs fail that mode at session
+	// creation, so probing without it would approve unrunnable commands.
+	for _, want := range []string{"-c:v h264_videotoolbox -q:v 65", "-c:v hevc_videotoolbox -q:v 60"} {
+		if !strings.Contains(string(log), want) {
+			t.Fatalf("probe log missing %q:\n%s", want, log)
+		}
+	}
+}
+
 func TestExplicitVideoToolboxBypassesFFmpegProbe(t *testing.T) {
 	setupHWAccelTest(t)
 

--- a/internal/playback/gpudetect_test.go
+++ b/internal/playback/gpudetect_test.go
@@ -586,6 +586,27 @@ func TestResolveHWAccelWithFFmpegDarwinUsesVideoToolbox(t *testing.T) {
 	}
 }
 
+func TestResolveHWAccelWithFFmpegContextDarwinHonorsCallerDeadline(t *testing.T) {
+	setupHWAccelTest(t)
+	currentGOOS = "darwin"
+	ffmpeg := writeFakeFFmpeg(t, fakeFFmpegProbe{hang: true})
+
+	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Millisecond)
+	defer cancel()
+	started := time.Now()
+	if got := ResolveHWAccelWithFFmpegContext(ctx, "auto", ffmpeg.path); got != HWAccelNone {
+		t.Fatalf("ResolveHWAccelWithFFmpegContext() = %q, want none", got)
+	}
+	if elapsed := time.Since(started); elapsed >= 150*time.Millisecond {
+		t.Fatalf("caller deadline took %s, want less than per-command timeout", elapsed)
+	}
+	if ctx.Err() != context.DeadlineExceeded {
+		t.Fatalf("context error = %v, want deadline exceeded", ctx.Err())
+	}
+	// Let the bounded shared probe finish before test cleanup restores globals.
+	_ = cachedVideoToolboxProbe(ffmpeg.path)
+}
+
 func TestResolveHWAccelWithFFmpegDarwinFallsBackToNoneWhenProbeFails(t *testing.T) {
 	setupHWAccelTest(t)
 	currentGOOS = "darwin"

--- a/internal/playback/gpudetect_test.go
+++ b/internal/playback/gpudetect_test.go
@@ -9,6 +9,8 @@ import (
 	"sync"
 	"testing"
 	"time"
+
+	"github.com/Silo-Server/silo-server/internal/tonemap"
 )
 
 type hwAccelTestEnv struct {
@@ -706,13 +708,18 @@ func TestCachedVideoToolboxProbeKeepsRelativeAndPathSpellingsDistinct(t *testing
 
 func TestStartupRetryHWAccel(t *testing.T) {
 	// Explicit values bypass ffmpeg probing, keeping this host-independent.
-	if got := StartupRetryHWAccel("videotoolbox", "/does/not/exist"); got != "none" {
+	if got := StartupRetryHWAccel(TranscodeOpts{HWAccel: "videotoolbox", FFmpegPath: "/does/not/exist"}); got != "none" {
 		t.Fatalf("videotoolbox retry accel = %q, want none (no alternate device to move to)", got)
 	}
 	for _, accel := range []string{"qsv", "vaapi", "nvenc", "none"} {
-		if got := StartupRetryHWAccel(accel, "/does/not/exist"); got != accel {
+		if got := StartupRetryHWAccel(TranscodeOpts{HWAccel: accel, FFmpegPath: "/does/not/exist"}); got != accel {
 			t.Fatalf("%s retry accel = %q, want unchanged", accel, got)
 		}
+	}
+	if got := StartupRetryHWAccel(TranscodeOpts{
+		HWAccel: "videotoolbox", FFmpegPath: "/does/not/exist", ToneMapMode: tonemap.ModeHardware,
+	}); got != "videotoolbox" {
+		t.Fatalf("hardware tone-map retry accel = %q, want unchanged frozen executor", got)
 	}
 }
 

--- a/internal/playback/gpudetect_test.go
+++ b/internal/playback/gpudetect_test.go
@@ -18,14 +18,17 @@ type hwAccelTestEnv struct {
 }
 
 type fakeFFmpegProbe struct {
-	cuda       bool
-	h264NVENC  bool
-	hevcNVENC  bool
-	scaleCUDA  bool
-	uploadCUDA bool
-	smokeOK    bool
-	hang       bool
-	delay      time.Duration
+	cuda         bool
+	h264NVENC    bool
+	hevcNVENC    bool
+	scaleCUDA    bool
+	uploadCUDA   bool
+	videotoolbox bool
+	h264VT       bool
+	hevcVT       bool
+	smokeOK      bool
+	hang         bool
+	delay        time.Duration
 }
 
 type fakeFFmpegBinary struct {
@@ -469,6 +472,9 @@ func writeFakeFFmpeg(t *testing.T, probe fakeFFmpegProbe) fakeFFmpegBinary {
 	if probe.cuda {
 		script += "    echo 'cuda'\n"
 	}
+	if probe.videotoolbox {
+		script += "    echo 'videotoolbox'\n"
+	}
 	script += "    exit 0 ;;\n"
 	script += "  *-encoders*)\n"
 	if probe.h264NVENC {
@@ -476,6 +482,12 @@ func writeFakeFFmpeg(t *testing.T, probe fakeFFmpegProbe) fakeFFmpegBinary {
 	}
 	if probe.hevcNVENC {
 		script += "    echo ' V..... hevc_nvenc NVIDIA NVENC hevc encoder'\n"
+	}
+	if probe.h264VT {
+		script += "    echo ' V..... h264_videotoolbox VideoToolbox H.264 encoder'\n"
+	}
+	if probe.hevcVT {
+		script += "    echo ' V..... hevc_videotoolbox VideoToolbox hevc encoder'\n"
 	}
 	script += "    exit 0 ;;\n"
 	script += "  *-filters*)\n"
@@ -503,6 +515,51 @@ func writeFakeFFmpeg(t *testing.T, probe fakeFFmpegProbe) fakeFFmpegBinary {
 
 func resetNVENCProbeCacheForTest() {
 	nvencProbeCache.Lock()
-	defer nvencProbeCache.Unlock()
 	nvencProbeCache.byPath = make(map[string]nvencProbeCacheEntry)
+	nvencProbeCache.Unlock()
+	videoToolboxProbeCache.Lock()
+	videoToolboxProbeCache.byPath = make(map[string]nvencProbeResult)
+	videoToolboxProbeCache.Unlock()
+}
+
+func successfulVideoToolboxProbe() fakeFFmpegProbe {
+	return fakeFFmpegProbe{videotoolbox: true, h264VT: true, hevcVT: true, smokeOK: true}
+}
+
+func TestResolveHWAccelWithFFmpegDarwinUsesVideoToolbox(t *testing.T) {
+	setupHWAccelTest(t)
+	currentGOOS = "darwin"
+	ffmpeg := writeFakeFFmpeg(t, successfulVideoToolboxProbe())
+
+	if got := ResolveHWAccelWithFFmpeg("auto", ffmpeg.path); got != "videotoolbox" {
+		t.Fatalf("ResolveHWAccelWithFFmpeg() = %q, want videotoolbox", got)
+	}
+}
+
+func TestResolveHWAccelWithFFmpegDarwinFallsBackToNoneWhenProbeFails(t *testing.T) {
+	setupHWAccelTest(t)
+	currentGOOS = "darwin"
+	ffmpeg := writeFakeFFmpeg(t, fakeFFmpegProbe{})
+
+	if got := ResolveHWAccelWithFFmpeg("auto", ffmpeg.path); got != "none" {
+		t.Fatalf("ResolveHWAccelWithFFmpeg() = %q, want none", got)
+	}
+}
+
+func TestResolveHWAccelWithFFmpegDarwinRequiresBothVTEncoders(t *testing.T) {
+	setupHWAccelTest(t)
+	currentGOOS = "darwin"
+	ffmpeg := writeFakeFFmpeg(t, fakeFFmpegProbe{videotoolbox: true, h264VT: true, smokeOK: true})
+
+	if got := ResolveHWAccelWithFFmpeg("auto", ffmpeg.path); got != "none" {
+		t.Fatalf("ResolveHWAccelWithFFmpeg() = %q, want none when hevc_videotoolbox is missing", got)
+	}
+}
+
+func TestExplicitVideoToolboxBypassesFFmpegProbe(t *testing.T) {
+	setupHWAccelTest(t)
+
+	if got := ResolveHWAccelWithFFmpeg("videotoolbox", "/does/not/exist/ffmpeg"); got != "videotoolbox" {
+		t.Fatalf("ResolveHWAccelWithFFmpeg() = %q, want videotoolbox", got)
+	}
 }

--- a/internal/playback/prepare_file.go
+++ b/internal/playback/prepare_file.go
@@ -3,6 +3,7 @@ package playback
 import (
 	"context"
 	"fmt"
+	"log/slog"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -95,23 +96,44 @@ func PrepareFile(ctx context.Context, opts TranscodeOpts, outputPath string) err
 		return fmt.Errorf("prepare-file: %w", err)
 	}
 
-	args := buildPrepareFileArgs(opts, partPath)
-	bin := opts.FFmpegPath
-	if bin == "" {
-		bin = ffmpegBinary()
+	runOnce := func(runOpts TranscodeOpts) error {
+		args := buildPrepareFileArgs(runOpts, partPath)
+		bin := runOpts.FFmpegPath
+		if bin == "" {
+			bin = ffmpegBinary()
+		}
+
+		cmd := exec.CommandContext(ctx, bin, args...)
+		stderr := newBoundedTailBuffer(stderrTailMaxBytes)
+		cmd.Stderr = stderr
+		cmd.WaitDelay = 3 * time.Second
+
+		if err := cmd.Run(); err != nil {
+			_ = os.Remove(partPath)
+			if tail := truncateStderr(stderr.String()); tail != "" {
+				return fmt.Errorf("%w: %w (stderr: %s)", ErrTranscodeFailed, err, tail)
+			}
+			return fmt.Errorf("%w: %w", ErrTranscodeFailed, err)
+		}
+		return nil
 	}
 
-	cmd := exec.CommandContext(ctx, bin, args...)
-	stderr := newBoundedTailBuffer(stderrTailMaxBytes)
-	cmd.Stderr = stderr
-	cmd.WaitDelay = 3 * time.Second
-
-	if err := cmd.Run(); err != nil {
-		_ = os.Remove(partPath)
-		if tail := truncateStderr(stderr.String()); tail != "" {
-			return fmt.Errorf("%w: %w (stderr: %s)", ErrTranscodeFailed, err, tail)
+	err := runOnce(opts)
+	if err != nil && ctx.Err() == nil {
+		// Mirror the transport startup retry: a VideoToolbox encode the
+		// hardware cannot perform (e.g. at the artifact's dimensions) retries
+		// once in software instead of failing every artifact rebuild with the
+		// same hardware command.
+		if retryAccel := StartupRetryHWAccel(opts.HWAccel, opts.FFmpegPath); retryAccel != opts.HWAccel {
+			slog.Warn("prepared encode failed; retrying with software encoding",
+				"hw_accel", opts.HWAccel, "output", outputPath, "error", err)
+			retryOpts := opts
+			retryOpts.HWAccel = retryAccel
+			err = runOnce(retryOpts)
 		}
-		return fmt.Errorf("%w: %w", ErrTranscodeFailed, err)
+	}
+	if err != nil {
+		return err
 	}
 
 	if err := syncPreparedFile(partPath); err != nil {

--- a/internal/playback/prepare_file.go
+++ b/internal/playback/prepare_file.go
@@ -74,7 +74,7 @@ func PrepareFile(ctx context.Context, opts TranscodeOpts, outputPath string) err
 	if outputPath == "" {
 		return fmt.Errorf("prepare-file: empty output path")
 	}
-	opts = normalizeTranscodeOpts(opts)
+	opts = normalizeTranscodeOptsContext(ctx, opts)
 	if err := validateToneMapOpts(opts); err != nil {
 		return fmt.Errorf("prepare-file: %w", err)
 	}
@@ -119,11 +119,12 @@ func PrepareFile(ctx context.Context, opts TranscodeOpts, outputPath string) err
 	}
 
 	err := runOnce(opts)
-	if err != nil && ctx.Err() == nil {
+	if err != nil && ctx.Err() == nil && opts.ToneMapMode != tonemap.ModeHardware {
 		// Mirror the transport startup retry: a VideoToolbox encode the
 		// hardware cannot perform (e.g. at the artifact's dimensions) retries
-		// once in software instead of failing every artifact rebuild with the
-		// same hardware command.
+		// once in software. A frozen hardware tone-map recipe cannot take this
+		// shortcut: changing only HWAccel would drop its conversion graph while
+		// still tagging the unconverted output as SDR.
 		if retryAccel := StartupRetryHWAccel(opts.HWAccel, opts.FFmpegPath); retryAccel != opts.HWAccel {
 			slog.WarnContext(ctx, "prepared encode failed; retrying with software encoding",
 				"hw_accel", opts.HWAccel, "output", outputPath, "error", err)

--- a/internal/playback/prepare_file.go
+++ b/internal/playback/prepare_file.go
@@ -125,7 +125,7 @@ func PrepareFile(ctx context.Context, opts TranscodeOpts, outputPath string) err
 		// once in software instead of failing every artifact rebuild with the
 		// same hardware command.
 		if retryAccel := StartupRetryHWAccel(opts.HWAccel, opts.FFmpegPath); retryAccel != opts.HWAccel {
-			slog.Warn("prepared encode failed; retrying with software encoding",
+			slog.WarnContext(ctx, "prepared encode failed; retrying with software encoding",
 				"hw_accel", opts.HWAccel, "output", outputPath, "error", err)
 			retryOpts := opts
 			retryOpts.HWAccel = retryAccel

--- a/internal/playback/prepare_file.go
+++ b/internal/playback/prepare_file.go
@@ -125,7 +125,7 @@ func PrepareFile(ctx context.Context, opts TranscodeOpts, outputPath string) err
 		// once in software. A frozen hardware tone-map recipe cannot take this
 		// shortcut: changing only HWAccel would drop its conversion graph while
 		// still tagging the unconverted output as SDR.
-		if retryAccel := StartupRetryHWAccel(opts.HWAccel, opts.FFmpegPath); retryAccel != opts.HWAccel {
+		if retryAccel := StartupRetryHWAccel(opts); retryAccel != opts.HWAccel {
 			slog.WarnContext(ctx, "prepared encode failed; retrying with software encoding",
 				"hw_accel", opts.HWAccel, "output", outputPath, "error", err)
 			retryOpts := opts

--- a/internal/playback/prepare_file_test.go
+++ b/internal/playback/prepare_file_test.go
@@ -80,6 +80,12 @@ func TestBuildPrepareFileArgsSharesHigh10DecodeFallback(t *testing.T) {
 			want:      []string{"-c:v libx264", "-vf scale=-2:720"},
 			forbidden: []string{"-hwaccel cuda", "h264_nvenc", "scale_cuda"},
 		},
+		{
+			name:      "videotoolbox keeps hardware encode with software decode",
+			hwAccel:   "videotoolbox",
+			want:      []string{"-c:v h264_videotoolbox", "-vf scale=-2:720"},
+			forbidden: []string{"-hwaccel videotoolbox"},
+		},
 	}
 
 	for _, tt := range tests {

--- a/internal/playback/prepare_file_test.go
+++ b/internal/playback/prepare_file_test.go
@@ -99,7 +99,10 @@ func TestBuildPrepareFileArgsSharesHigh10DecodeFallback(t *testing.T) {
 				TargetCodecAudio:    "aac",
 				TargetResolution:    "720p",
 				HWAccel:             tt.hwAccel,
-				AudioTrackIndex:     -1,
+				// Fake VideoToolbox-capable ffmpeg so the encoder probe in
+				// resolveEffectiveTranscodeHWAccel succeeds on Linux CI too.
+				FFmpegPath:      videoToolboxTestFFmpeg(t),
+				AudioTrackIndex: -1,
 			}, "/artifacts/out.mp4")
 			joined := strings.Join(args, " ")
 			for _, want := range tt.want {

--- a/internal/playback/prepare_file_test.go
+++ b/internal/playback/prepare_file_test.go
@@ -236,3 +236,56 @@ func TestPrepareFileRemovesFailedPartialOutput(t *testing.T) {
 		t.Fatalf("failed prepared output left a partial file: %v", statErr)
 	}
 }
+
+func TestPrepareFileRetriesVideoToolboxFailureInSoftware(t *testing.T) {
+	setupHWAccelTest(t)
+	dir := t.TempDir()
+	script := filepath.Join(dir, "ffmpeg")
+	logPath := filepath.Join(dir, "invocations.log")
+	// Answers capability probes and smoke encodes, fails real VideoToolbox
+	// encodes, and succeeds software encodes by writing the output file
+	// (ffmpeg's contract PrepareFile finalizes on).
+	fake := "#!/bin/sh\n" +
+		"printf '%s\n' \"$*\" >> " + logPath + "\n" +
+		"case \"$*\" in\n" +
+		"  *-hwaccels*) echo videotoolbox; exit 0 ;;\n" +
+		"  *-encoders*) echo ' V..... h264_videotoolbox x'; echo ' V..... hevc_videotoolbox x'; exit 0 ;;\n" +
+		"  *videotoolbox*'-f null'*) exit 0 ;;\n" +
+		"  *videotoolbox*) exit 1 ;;\n" +
+		"  *) for last; do :; done; printf x > \"$last\"; exit 0 ;;\n" +
+		"esac\n"
+	if err := os.WriteFile(script, []byte(fake), 0o755); err != nil {
+		t.Fatalf("write fake ffmpeg: %v", err)
+	}
+
+	outputPath := filepath.Join(t.TempDir(), "artifact.mp4")
+	err := PrepareFile(context.Background(), TranscodeOpts{
+		InputPath:         "/media/movie.mkv",
+		SessionID:         "prepare-vt-retry",
+		FFmpegPath:        script,
+		SourceVideoCodec:  "h264",
+		TargetCodecVideo:  "h264",
+		TargetCodecAudio:  "aac",
+		TargetResolution:  "720p",
+		TargetBitrateKbps: 2000,
+		HWAccel:           "videotoolbox",
+		AudioTrackIndex:   -1,
+	}, outputPath)
+	if err != nil {
+		t.Fatalf("PrepareFile() error = %v, want software retry to succeed", err)
+	}
+	if _, err := os.Stat(outputPath); err != nil {
+		t.Fatalf("finalized artifact missing: %v", err)
+	}
+
+	log, err := os.ReadFile(logPath)
+	if err != nil {
+		t.Fatalf("read invocation log: %v", err)
+	}
+	if !strings.Contains(string(log), "h264_videotoolbox -pix_fmt") {
+		t.Fatalf("first attempt should encode with VideoToolbox:\n%s", log)
+	}
+	if !strings.Contains(string(log), "libx264") {
+		t.Fatalf("retry should encode with libx264:\n%s", log)
+	}
+}

--- a/internal/playback/prepare_file_test.go
+++ b/internal/playback/prepare_file_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 
 	"github.com/Silo-Server/silo-server/internal/models"
+	"github.com/Silo-Server/silo-server/internal/tonemap"
 )
 
 func TestBuildPrepareFileArgsEmitsFaststartMP4(t *testing.T) {
@@ -287,5 +288,67 @@ func TestPrepareFileRetriesVideoToolboxFailureInSoftware(t *testing.T) {
 	}
 	if !strings.Contains(string(log), "libx264") {
 		t.Fatalf("retry should encode with libx264:\n%s", log)
+	}
+}
+
+func TestPrepareFileDoesNotDropHardwareToneMapGraphOnSoftwareRetry(t *testing.T) {
+	setupHWAccelTest(t)
+	dir := t.TempDir()
+	inputPath := filepath.Join(dir, "movie.mkv")
+	if err := os.WriteFile(inputPath, []byte("source"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	info, err := os.Stat(inputPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	track := models.VideoTrack{
+		Codec: "hevc", Profile: "Main 10", Level: 153, Width: 3840, Height: 2160, FrameRate: "23.976",
+		ColorRange: "tv", ColorPrimaries: "bt2020", ColorTransfer: "smpte2084", ColorSpace: "bt2020nc",
+		BitDepth: 10, PixelFormat: "yuv420p10le",
+	}
+	revision := tonemap.RevisionForFile(&models.MediaFile{ID: 42, FileSize: info.Size(), VideoTracks: []models.VideoTrack{track}})
+
+	ffmpegPath := filepath.Join(dir, "ffmpeg")
+	logPath := filepath.Join(dir, "invocations.log")
+	ffmpegScript := "#!/bin/sh\n" +
+		"printf '%s\\n' \"$*\" >> " + logPath + "\n" +
+		"case \"$*\" in\n" +
+		"  *-hwaccels*) echo videotoolbox; exit 0 ;;\n" +
+		"  *-encoders*) echo ' V..... h264_videotoolbox x'; echo ' V..... hevc_videotoolbox x'; exit 0 ;;\n" +
+		"  *videotoolbox*'-f null'*) exit 0 ;;\n" +
+		"  *) exit 1 ;;\n" +
+		"esac\n"
+	if err := os.WriteFile(ffmpegPath, []byte(ffmpegScript), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	liveJSON := `{"streams":[{"index":0,"codec_name":"hevc","codec_type":"video","profile":"Main 10","level":153,"width":3840,"height":2160,"avg_frame_rate":"24000/1001","pix_fmt":"yuv420p10le","bits_per_raw_sample":"10","color_range":"tv","color_primaries":"bt2020","color_transfer":"smpte2084","color_space":"bt2020nc"}]}`
+	if err := os.WriteFile(filepath.Join(dir, "ffprobe"), []byte("#!/bin/sh\nprintf '%s' '"+liveJSON+"'\n"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	outputPath := filepath.Join(t.TempDir(), "artifact.mp4")
+	err = PrepareFile(t.Context(), TranscodeOpts{
+		InputPath: inputPath, FFmpegPath: ffmpegPath,
+		SourceVideoCodec: "hevc", SourceVideoBitDepth: 10,
+		TargetCodecVideo: "h264", TargetCodecAudio: "aac", TargetResolution: "1080p", TargetBitrateKbps: 8000,
+		HWAccel:       transcodeHWVideoToolbox,
+		ToneMapPolicy: tonemap.PolicyHardwareThenSoftware, ToneMapMode: tonemap.ModeHardware,
+		ToneMapSourceKind: tonemap.SourcePQ, ToneMapFilter: tonemap.HardwareFilterVideoToolbox,
+		ToneMapRecipeVersion: TransformationHDRToSDRToneMapRecipeVersionV3, ToneMapSourceRevision: revision,
+		AudioTrackIndex: -1,
+	}, outputPath)
+	if err == nil {
+		t.Fatal("PrepareFile() succeeded after the hardware tone-map encode failed")
+	}
+	logData, readErr := os.ReadFile(logPath)
+	if readErr != nil {
+		t.Fatal(readErr)
+	}
+	if strings.Contains(string(logData), "libx264") {
+		t.Fatalf("hardware tone-map failure retried without a valid software recipe:\n%s", logData)
+	}
+	if _, statErr := os.Stat(outputPath); !os.IsNotExist(statErr) {
+		t.Fatalf("invalid tone-mapped artifact was published: %v", statErr)
 	}
 }

--- a/internal/playback/remux.go
+++ b/internal/playback/remux.go
@@ -9,11 +9,19 @@ import (
 	"net/http"
 	"os"
 	"os/exec"
+	"runtime"
 	"strconv"
 	"strings"
 	"sync"
 
 	"github.com/Silo-Server/silo-server/internal/httpstream"
+)
+
+const (
+	jellyfinFFmpegPath             = "/usr/lib/jellyfin-ffmpeg/ffmpeg"
+	homebrewFFmpegFullAppleSilicon = "/opt/homebrew/opt/ffmpeg-full/bin/ffmpeg"
+	homebrewFFmpegFullIntel        = "/usr/local/opt/ffmpeg-full/bin/ffmpeg"
+	ffmpegExecutable               = ffmpegComponent
 )
 
 var (
@@ -28,14 +36,29 @@ var (
 // Resolved once at first call, then cached for the process lifetime.
 func ffmpegBinary() string {
 	ffmpegOnce.Do(func() {
-		const jellyfinPath = "/usr/lib/jellyfin-ffmpeg/ffmpeg"
-		if _, err := exec.LookPath(jellyfinPath); err == nil {
-			resolvedFFmpegPath = jellyfinPath
-			return
-		}
-		resolvedFFmpegPath = "ffmpeg"
+		resolvedFFmpegPath = discoverFFmpegPath(runtime.GOOS, exec.LookPath)
 	})
 	return resolvedFFmpegPath
+}
+
+func discoverFFmpegPath(goos string, lookPath func(string) (string, error)) string {
+	candidates := []string{jellyfinFFmpegPath}
+	if goos == darwinGOOS {
+		// Homebrew's regular FFmpeg omits libass and other filters Silo uses.
+		// Prefer the keg-only full build on both Apple Silicon and Intel Macs
+		// when it is installed; PATH remains the final portable fallback.
+		candidates = []string{
+			homebrewFFmpegFullAppleSilicon,
+			homebrewFFmpegFullIntel,
+			jellyfinFFmpegPath,
+		}
+	}
+	for _, candidate := range candidates {
+		if _, err := lookPath(candidate); err == nil {
+			return candidate
+		}
+	}
+	return ffmpegExecutable
 }
 
 // ResolveFFmpegPath returns the ffmpeg binary the playback pipeline executes
@@ -44,10 +67,27 @@ func ffmpegBinary() string {
 // probes must resolve through this same function so a feature advertised at
 // planning time is guaranteed present in the binary that later runs.
 func ResolveFFmpegPath(configured string) string {
-	if configured = strings.TrimSpace(configured); configured != "" {
-		return configured
+	return resolveFFmpegPath(configured, exec.LookPath, ffmpegBinary)
+}
+
+func resolveFFmpegPath(
+	configured string,
+	lookPath func(string) (string, error),
+	discover func() string,
+) string {
+	configured = strings.TrimSpace(configured)
+	if configured == "" {
+		return discover()
 	}
-	return ffmpegBinary()
+	// Older and container-oriented settings use Jellyfin's Linux-only path as
+	// the default. Treat that conventional default as discovery only when it is
+	// absent; genuinely custom invalid paths must still fail loudly.
+	if configured == jellyfinFFmpegPath {
+		if _, err := lookPath(configured); err != nil {
+			return discover()
+		}
+	}
+	return configured
 }
 
 // supportsDoviRPUFilter reports whether the given FFmpeg binary can strip

--- a/internal/playback/transcode.go
+++ b/internal/playback/transcode.go
@@ -145,6 +145,8 @@ const (
 	transcodeHWNVENC         = "nvenc"
 	transcodeHWVideoToolbox  = "videotoolbox"
 	transcodeHWNone          = "none"
+	transcodeResolution328p  = "328p"
+	transcodeResolution420p  = "420p"
 	transcodeResolution480p  = "480p"
 	transcodeResolution720p  = "720p"
 	transcodeResolution1080p = "1080p"
@@ -514,8 +516,12 @@ func validateToneMapOpts(opts TranscodeOpts) error {
 			if opts.ToneMapFilter != tonemap.HardwareFilterCUDA {
 				return fmt.Errorf("unsupported nvenc tone-map filter %q", opts.ToneMapFilter)
 			}
+		case transcodeHWVideoToolbox:
+			if opts.ToneMapFilter != tonemap.HardwareFilterVideoToolbox {
+				return fmt.Errorf("unsupported videotoolbox tone-map filter %q", opts.ToneMapFilter)
+			}
 		default:
-			return fmt.Errorf("hardware tone mapping requires qsv, vaapi, or nvenc")
+			return fmt.Errorf("hardware tone mapping requires qsv, vaapi, nvenc, or videotoolbox")
 		}
 	default:
 		return fmt.Errorf("unsupported tone-map mode %q", opts.ToneMapMode)
@@ -924,14 +930,19 @@ func appendHWAccelArgs(args []string, opts TranscodeOpts) []string {
 			args = append(args, "-hwaccel_device", hwDevice)
 		}
 	case transcodeHWVideoToolbox:
-		// No -hwaccel_output_format: decoded frames land in system memory,
-		// so the software filter graph (scale, subtitle burn-in, tone paths)
-		// applies unchanged and the *_videotoolbox encoders upload
-		// internally. HW decode + HW encode carries nearly all of the win.
+		// Hardware tone mapping keeps decoded frames as IOSurfaces for
+		// scale_vt/VTPixelTransferSession. Other VideoToolbox transcodes land
+		// frames in system memory so ordinary scale and subtitle filters apply
+		// unchanged and the encoder uploads internally.
 		// H.264 Hi10P decodes in software (VideoToolbox cannot), same as the
 		// QSV/VAAPI paths; the encoder still runs in hardware.
-		if !opts.SoftwareVideoDecode {
+		if opts.ToneMapMode == tonemap.ModeHardware && opts.SoftwareVideoDecode {
+			args = append(args, "-init_hw_device", "videotoolbox=vt", "-filter_hw_device", "vt")
+		} else if !opts.SoftwareVideoDecode {
 			args = append(args, "-hwaccel", "videotoolbox")
+			if opts.ToneMapMode == tonemap.ModeHardware {
+				args = append(args, "-hwaccel_output_format", "videotoolbox_vld")
+			}
 		}
 	}
 	return args
@@ -1024,9 +1035,14 @@ func appendVideoArgs(args []string, opts TranscodeOpts) []string {
 		}
 	case opts.HWAccel == transcodeHWVideoToolbox && codec == transcodeCodecH264:
 		// 8-bit output for browser MSE compatibility (mirrors the libx264
-		// path); VideoToolbox has no 10-bit H.264 encode.
-		args = append(args, "-c:v", "h264_videotoolbox",
-			"-pix_fmt", "yuv420p", "-profile:v", "high")
+		// path); VideoToolbox has no 10-bit H.264 encode. Hardware tone
+		// mapping already emits NV12. Re-requesting yuv420p at the encoder
+		// boundary makes FFmpeg 9.0.1 crash on 2160p scale_vt output.
+		args = append(args, "-c:v", "h264_videotoolbox")
+		if opts.ToneMapMode != tonemap.ModeHardware {
+			args = append(args, "-pix_fmt", "yuv420p")
+		}
+		args = append(args, "-profile:v", "high")
 		args = appendVideoToolboxRateControl(args, opts)
 	case opts.HWAccel == transcodeHWVideoToolbox && codec == "hevc":
 		// pix_fmt is left to the input: 10-bit sources encode as p010
@@ -1055,12 +1071,11 @@ func appendVideoArgs(args []string, opts TranscodeOpts) []string {
 			"-color_primaries", "bt709",
 			"-color_trc", "bt709",
 		)
-		// FFmpeg treats -colorspace as a requested pixel conversion for
-		// hardware frames. VAAPI then inserts an impossible auto_scale between
-		// tonemap_vaapi and h264_vaapi. Hardware filters already stamp m=bt709
-		// and the encoder propagates it into the bitstream; libx264 accepts the
-		// explicit mux-boundary option without a format transition.
-		if opts.ToneMapMode == tonemap.ModeSoftware {
+		// FFmpeg treats -colorspace as a requested pixel conversion for VAAPI,
+		// QSV, and CUDA frames. VideoToolbox has already downloaded an NV12
+		// software frame here and needs the explicit matrix because its encoder
+		// otherwise preserves the source BT.2020 matrix in the H.264 stream.
+		if opts.ToneMapMode == tonemap.ModeSoftware || opts.HWAccel == transcodeHWVideoToolbox {
 			args = append(args, "-colorspace", "bt709")
 		}
 	}
@@ -1167,6 +1182,8 @@ func toneMapScaleFilter(opts TranscodeOpts) string {
 				return filter + ",format=nv12,hwupload_cuda"
 			}
 			return tonemap.SourceParameters(opts.ToneMapSourceKind) + "," + tonemap.CUDAFilter() + "," + nvencScaleFilter(opts.TargetResolution) + "," + tonemap.HDRMetadataRemovalFilter()
+		case transcodeHWVideoToolbox:
+			return videoToolboxToneMapCPUFilter(opts) + "," + tonemap.HDRMetadataRemovalFilter()
 		}
 	}
 	return ""
@@ -1199,6 +1216,8 @@ func toneMappedTextSubtitleFilter(opts TranscodeOpts) string {
 			return nvencSDRFallbackDownload(opts) + "," + tonemap.SoftwareFilter(opts.ToneMapSourceKind, "") + "," + cpuTail + ",format=nv12,hwupload_cuda"
 		}
 		return tonemap.SourceParameters(opts.ToneMapSourceKind) + "," + tonemap.CUDAFilter() + ",hwdownload,format=nv12," + cpuTail + ",format=nv12,hwupload_cuda," + tonemap.HDRMetadataRemovalFilter()
+	case transcodeHWVideoToolbox:
+		return videoToolboxToneMapCPUFilter(opts) + "," + subFilter + "," + tonemap.HDRMetadataRemovalFilter()
 	default:
 		return ""
 	}
@@ -1239,6 +1258,9 @@ func appendToneMappedBitmapSubtitleArgs(args []string, opts TranscodeOpts) []str
 			graph += "," + scale
 		}
 		graph += ",format=nv12,hwupload_cuda," + tonemap.HDRMetadataRemovalFilter() + "[vout]"
+	case transcodeHWVideoToolbox:
+		graph = "[0:v:0]" + videoToolboxToneMapCPUFilter(opts) + "[vmain];[vmain]" +
+			subInput + "overlay=eof_action=pass," + tonemap.HDRMetadataRemovalFilter() + "[vout]"
 	}
 	if graph == "" {
 		return args
@@ -1263,6 +1285,38 @@ func softwareToneMapUploadFilter(opts TranscodeOpts) string {
 // SDR Dolby Vision base layer to the CPU for unsupported CUDA color conversion.
 func nvencSDRFallbackDownload(opts TranscodeOpts) string {
 	return "hwdownload,format=" + tonemap.NVENCSoftwareFallbackPixelFormat(opts.SourceVideoBitDepth)
+}
+
+// videoToolboxToneMapCPUFilter converts on an IOSurface, integrates scaling,
+// then returns an 8-bit software frame for VideoToolbox H.264 encoding or CPU
+// subtitle composition. Software-decoded sources are uploaded with explicit
+// source color attachments first.
+func videoToolboxToneMapCPUFilter(opts TranscodeOpts) string {
+	width, height := videoToolboxScaleDimensions(opts.TargetResolution)
+	filter := ""
+	if opts.SoftwareVideoDecode {
+		filter = tonemap.VideoToolboxUploadFilter(opts.ToneMapSourceKind, opts.SourceVideoBitDepth) + ","
+	}
+	return filter + tonemap.VideoToolboxFilter(width, height) + "," + tonemap.VideoToolboxDownloadFilter(opts.SourceVideoBitDepth)
+}
+
+func videoToolboxScaleDimensions(resolution string) (string, string) {
+	switch resolution {
+	case transcodeResolution2160p:
+		return "-2", "2160"
+	case transcodeResolution1080p:
+		return "-2", "1080"
+	case transcodeResolution720p:
+		return "-2", "720"
+	case transcodeResolution480p:
+		return "-2", "480"
+	case transcodeResolution420p:
+		return "-2", "420"
+	case transcodeResolution328p:
+		return "-2", "328"
+	default:
+		return "iw", "ih"
+	}
 }
 
 // TranscodesAudio reports whether a transcode with the given target audio
@@ -1506,9 +1560,9 @@ func resolutionToScale(res string) string {
 		return "scale=-2:720"
 	case "480p":
 		return "scale=-2:480"
-	case "420p":
+	case transcodeResolution420p:
 		return "scale=-2:420"
-	case "328p":
+	case transcodeResolution328p:
 		return "scale=-2:328"
 	default:
 		return ""
@@ -1534,9 +1588,9 @@ func qsvScaleFilterWithMapMode(res, mapMode string) string {
 		return "scale_vaapi=w=-2:h=720:format=nv12," + hwmap + ",format=qsv"
 	case "480p":
 		return "scale_vaapi=w=-2:h=480:format=nv12," + hwmap + ",format=qsv"
-	case "420p":
+	case transcodeResolution420p:
 		return "scale_vaapi=w=-2:h=420:format=nv12," + hwmap + ",format=qsv"
-	case "328p":
+	case transcodeResolution328p:
 		return "scale_vaapi=w=-2:h=328:format=nv12," + hwmap + ",format=qsv"
 	default:
 		return "scale_vaapi=format=nv12," + hwmap + ",format=qsv"
@@ -1575,9 +1629,9 @@ func vaapiScaleFilter(res string) string {
 		return "scale_vaapi=w=-2:h=720:format=nv12"
 	case "480p":
 		return "scale_vaapi=w=-2:h=480:format=nv12"
-	case "420p":
+	case transcodeResolution420p:
 		return "scale_vaapi=w=-2:h=420:format=nv12"
-	case "328p":
+	case transcodeResolution328p:
 		return "scale_vaapi=w=-2:h=328:format=nv12"
 	default:
 		return "scale_vaapi=format=nv12"
@@ -1602,9 +1656,9 @@ func nvencScaleFilter(res string) string {
 		return "scale_cuda=w=-2:h=720:format=nv12"
 	case "480p":
 		return "scale_cuda=w=-2:h=480:format=nv12"
-	case "420p":
+	case transcodeResolution420p:
 		return "scale_cuda=w=-2:h=420:format=nv12"
-	case "328p":
+	case transcodeResolution328p:
 		return "scale_cuda=w=-2:h=328:format=nv12"
 	default:
 		return "scale_cuda=format=nv12"

--- a/internal/playback/transcode.go
+++ b/internal/playback/transcode.go
@@ -138,13 +138,17 @@ func VideoSampleEntryForDVCopy(dvProfile int) string {
 }
 
 const (
-	transcodeCodecH264      = "h264"
-	HWAccelNone             = "none"
-	transcodeHWQSV          = "qsv"
-	transcodeHWVAAPI        = "vaapi"
-	transcodeHWNVENC        = "nvenc"
-	transcodeHWVideoToolbox = "videotoolbox"
-	transcodeHWNone         = "none"
+	transcodeCodecH264       = "h264"
+	HWAccelNone              = "none"
+	transcodeHWQSV           = "qsv"
+	transcodeHWVAAPI         = "vaapi"
+	transcodeHWNVENC         = "nvenc"
+	transcodeHWVideoToolbox  = "videotoolbox"
+	transcodeHWNone          = "none"
+	transcodeResolution480p  = "480p"
+	transcodeResolution720p  = "720p"
+	transcodeResolution1080p = "1080p"
+	transcodeResolution2160p = "2160p"
 )
 
 // TranscodeSession manages a running ffmpeg HLS transcode process.
@@ -462,6 +466,7 @@ func resolveSoftwareVideoDecode(opts TranscodeOpts) TranscodeOpts {
 // must pass through this helper so streaming and prepared-file recipes cannot
 // disagree about whether a source may use hardware decode or encode.
 func normalizeTranscodeOpts(opts TranscodeOpts) TranscodeOpts {
+	opts.FFmpegPath = ResolveFFmpegPath(opts.FFmpegPath)
 	opts = resolveSoftwareVideoDecode(opts)
 	if opts.ToneMapMode == tonemap.ModeSoftware {
 		opts.SoftwareVideoDecode = true
@@ -748,6 +753,13 @@ func resolveEffectiveTranscodeHWAccel(opts TranscodeOpts) string {
 	if IsMPEG4Part2VideoCodec(opts.SourceVideoCodec) {
 		return HWAccelNone
 	}
+	if hwAccel == transcodeHWVideoToolbox {
+		if ok, reason := videoToolboxSupportsTargetCodec(opts.FFmpegPath, opts.TargetCodecVideo); !ok {
+			slog.Warn("VideoToolbox target encoder unavailable; using software encoding",
+				"target_codec", opts.TargetCodecVideo, "reason", reason)
+			return transcodeHWNone
+		}
+	}
 	// The bundled CUDA software-decode upload path has not been validated.
 	// Prefer the established libx264 fallback over selecting a decoder known
 	// not to accept this source. Intel QSV/VAAPI have the explicit upload paths
@@ -1006,27 +1018,12 @@ func appendVideoArgs(args []string, opts TranscodeOpts) []string {
 		// path); VideoToolbox has no 10-bit H.264 encode.
 		args = append(args, "-c:v", "h264_videotoolbox",
 			"-pix_fmt", "yuv420p", "-profile:v", "high")
-		if hasBitrateCap {
-			args = append(args,
-				"-b:v", fmt.Sprintf("%dk", opts.TargetBitrateKbps),
-				"-maxrate", fmt.Sprintf("%dk", opts.TargetBitrateKbps),
-				"-bufsize", fmt.Sprintf("%dk", opts.TargetBitrateKbps*2))
-		} else {
-			// Constant-quality mode (1-100 scale, hardware-rate-controlled).
-			args = append(args, "-q:v", "65")
-		}
+		args = appendVideoToolboxRateControl(args, opts)
 	case opts.HWAccel == transcodeHWVideoToolbox && codec == "hevc":
 		// pix_fmt is left to the input: 10-bit sources encode as p010
 		// (HDR10 passthrough), matching the other hardware HEVC paths.
 		args = append(args, "-c:v", "hevc_videotoolbox")
-		if hasBitrateCap {
-			args = append(args,
-				"-b:v", fmt.Sprintf("%dk", opts.TargetBitrateKbps),
-				"-maxrate", fmt.Sprintf("%dk", opts.TargetBitrateKbps),
-				"-bufsize", fmt.Sprintf("%dk", opts.TargetBitrateKbps*2))
-		} else {
-			args = append(args, "-q:v", "60")
-		}
+		args = appendVideoToolboxRateControl(args, opts)
 	default:
 		// CPU fallback — match Jellyfin's proven browser-compatible settings.
 		// Force yuv420p to ensure 8-bit output (10-bit sources produce High 10
@@ -1060,6 +1057,26 @@ func appendVideoArgs(args []string, opts TranscodeOpts) []string {
 	}
 
 	return args
+}
+
+func appendVideoToolboxRateControl(args []string, opts TranscodeOpts) []string {
+	bitrateKbps := opts.TargetBitrateKbps
+	if bitrateKbps <= 0 {
+		bitrateKbps = map[string]int{
+			transcodeResolution480p:  1_500,
+			transcodeResolution720p:  2_000,
+			transcodeResolution1080p: 6_000,
+			transcodeResolution2160p: 20_000,
+		}[opts.TargetResolution]
+		if bitrateKbps == 0 {
+			bitrateKbps = 6_000
+		}
+	}
+	return append(args,
+		"-b:v", fmt.Sprintf("%dk", bitrateKbps),
+		"-maxrate", fmt.Sprintf("%dk", bitrateKbps),
+		"-bufsize", fmt.Sprintf("%dk", bitrateKbps*2),
+	)
 }
 
 // appendVideoFilterArgs appends the -vf selection for an encoding (non-copy)
@@ -1426,7 +1443,7 @@ func appendSubtitleBurnInArgs(args []string, opts TranscodeOpts) []string {
 	if opts.subtitleFilterInputPath != "" {
 		subtitleInputPath = opts.subtitleFilterInputPath
 	}
-	subFilter := fmt.Sprintf("subtitles='%s':si=%d",
+	subFilter := fmt.Sprintf("subtitles=filename='%s':si=%d",
 		escapeFilterPath(subtitleInputPath), opts.SubtitleTrackIndex)
 
 	// Build the CPU filter portion: scale (if any) then subtitle overlay.

--- a/internal/playback/transcode.go
+++ b/internal/playback/transcode.go
@@ -138,11 +138,12 @@ func VideoSampleEntryForDVCopy(dvProfile int) string {
 }
 
 const (
-	transcodeCodecH264 = "h264"
-	HWAccelNone        = "none"
-	transcodeHWQSV     = "qsv"
-	transcodeHWVAAPI   = "vaapi"
-	transcodeHWNVENC   = "nvenc"
+	transcodeCodecH264      = "h264"
+	HWAccelNone             = "none"
+	transcodeHWQSV          = "qsv"
+	transcodeHWVAAPI        = "vaapi"
+	transcodeHWNVENC        = "nvenc"
+	transcodeHWVideoToolbox = "videotoolbox"
 )
 
 // TranscodeSession manages a running ffmpeg HLS transcode process.
@@ -834,12 +835,13 @@ func appendSegmentBoundaryArgs(args []string, opts TranscodeOpts) []string {
 			fmt.Sprintf("expr:gte(t,n_forced*%d)", opts.SegmentDuration))
 	}
 
-	// Hardware encoders (QSV, VAAPI, NVENC) may not reliably honor
-	// force_key_frames expressions. Set explicit GOP size so segment
+	// Hardware encoders (QSV, VAAPI, NVENC, VideoToolbox) may not reliably
+	// honor force_key_frames expressions. Set explicit GOP size so segment
 	// boundaries always start with an intra frame. We assume 30 fps as a
 	// safe ceiling — the GOP will be at most segmentDuration * 30 frames.
 	// Matches Jellyfin's approach for hardware encoders.
-	if opts.HWAccel == transcodeHWQSV || opts.HWAccel == transcodeHWVAAPI || opts.HWAccel == transcodeHWNVENC {
+	if opts.HWAccel == transcodeHWQSV || opts.HWAccel == transcodeHWVAAPI ||
+		opts.HWAccel == transcodeHWNVENC || opts.HWAccel == transcodeHWVideoToolbox {
 		gopSize := fmt.Sprintf("%d", opts.SegmentDuration*30)
 		args = append(args, "-g", gopSize, "-keyint_min", gopSize)
 	}
@@ -899,6 +901,12 @@ func appendHWAccelArgs(args []string, opts TranscodeOpts) []string {
 		if hwDevice := strings.TrimSpace(opts.HWDevice); hwDevice != "" {
 			args = append(args, "-hwaccel_device", hwDevice)
 		}
+	case transcodeHWVideoToolbox:
+		// No -hwaccel_output_format: decoded frames land in system memory,
+		// so the software filter graph (scale, subtitle burn-in, tone paths)
+		// applies unchanged and the *_videotoolbox encoders upload
+		// internally. HW decode + HW encode carries nearly all of the win.
+		args = append(args, "-hwaccel", "videotoolbox")
 	}
 	return args
 }
@@ -987,6 +995,32 @@ func appendVideoArgs(args []string, opts TranscodeOpts) []string {
 				"-bufsize", fmt.Sprintf("%dk", opts.TargetBitrateKbps*2))
 		} else {
 			args = append(args, "-cq:v", "28", "-b:v", "0")
+		}
+	case opts.HWAccel == transcodeHWVideoToolbox && codec == transcodeCodecH264:
+		// 8-bit output for browser MSE compatibility (mirrors the libx264
+		// path); VideoToolbox has no 10-bit H.264 encode.
+		args = append(args, "-c:v", "h264_videotoolbox",
+			"-pix_fmt", "yuv420p", "-profile:v", "high")
+		if hasBitrateCap {
+			args = append(args,
+				"-b:v", fmt.Sprintf("%dk", opts.TargetBitrateKbps),
+				"-maxrate", fmt.Sprintf("%dk", opts.TargetBitrateKbps),
+				"-bufsize", fmt.Sprintf("%dk", opts.TargetBitrateKbps*2))
+		} else {
+			// Constant-quality mode (1-100 scale, hardware-rate-controlled).
+			args = append(args, "-q:v", "65")
+		}
+	case opts.HWAccel == transcodeHWVideoToolbox && codec == "hevc":
+		// pix_fmt is left to the input: 10-bit sources encode as p010
+		// (HDR10 passthrough), matching the other hardware HEVC paths.
+		args = append(args, "-c:v", "hevc_videotoolbox")
+		if hasBitrateCap {
+			args = append(args,
+				"-b:v", fmt.Sprintf("%dk", opts.TargetBitrateKbps),
+				"-maxrate", fmt.Sprintf("%dk", opts.TargetBitrateKbps),
+				"-bufsize", fmt.Sprintf("%dk", opts.TargetBitrateKbps*2))
+		} else {
+			args = append(args, "-q:v", "60")
 		}
 	default:
 		// CPU fallback — match Jellyfin's proven browser-compatible settings.

--- a/internal/playback/transcode.go
+++ b/internal/playback/transcode.go
@@ -62,7 +62,7 @@ type TranscodeOpts struct {
 	SegmentDuration        int    // seconds, default 6
 	StartSegmentNumber     int    // -hls_segment_start_number, default 0
 	FFmpegPath             string // optional explicit ffmpeg binary path
-	HWAccel                string // auto, qsv, vaapi, nvenc, none
+	HWAccel                string // auto, qsv, vaapi, nvenc, videotoolbox, none
 	HWDevice               string // e.g., /dev/dri/renderD128 (default if empty)
 	// AvoidHWDevice asks the initial multi-device allocator to prefer any other
 	// present render device. It is a process-local startup hint used after an
@@ -906,7 +906,11 @@ func appendHWAccelArgs(args []string, opts TranscodeOpts) []string {
 		// so the software filter graph (scale, subtitle burn-in, tone paths)
 		// applies unchanged and the *_videotoolbox encoders upload
 		// internally. HW decode + HW encode carries nearly all of the win.
-		args = append(args, "-hwaccel", "videotoolbox")
+		// H.264 Hi10P decodes in software (VideoToolbox cannot), same as the
+		// QSV/VAAPI paths; the encoder still runs in hardware.
+		if !opts.SoftwareVideoDecode {
+			args = append(args, "-hwaccel", "videotoolbox")
+		}
 	}
 	return args
 }

--- a/internal/playback/transcode.go
+++ b/internal/playback/transcode.go
@@ -759,6 +759,15 @@ func resolveEffectiveTranscodeHWAccel(opts TranscodeOpts) string {
 				"target_codec", opts.TargetCodecVideo, "reason", reason)
 			return transcodeHWNone
 		}
+		// A fully unconstrained request (no ladder rung, no bitrate cap —
+		// e.g. the jellycompat paths) has always encoded with quality-based
+		// CRF. VideoToolbox has no portable constant-quality mode and a flat
+		// bitrate fallback visibly degrades high-resolution sources, so keep
+		// these on the software encoder.
+		if opts.TargetBitrateKbps <= 0 && opts.TargetResolution == "" {
+			slog.Info("VideoToolbox skipped for unconstrained transcode; using quality-based software encoding")
+			return transcodeHWNone
+		}
 	}
 	// The bundled CUDA software-decode upload path has not been validated.
 	// Prefer the established libx264 fallback over selecting a decoder known

--- a/internal/playback/transcode.go
+++ b/internal/playback/transcode.go
@@ -144,6 +144,7 @@ const (
 	transcodeHWVAAPI        = "vaapi"
 	transcodeHWNVENC        = "nvenc"
 	transcodeHWVideoToolbox = "videotoolbox"
+	transcodeHWNone         = "none"
 )
 
 // TranscodeSession manages a running ffmpeg HLS transcode process.

--- a/internal/playback/transcode.go
+++ b/internal/playback/transcode.go
@@ -295,7 +295,7 @@ func StartTranscode(ctx context.Context, opts TranscodeOpts) (*TranscodeSession,
 	if opts.SegmentDuration <= 0 {
 		opts.SegmentDuration = defaultSegmentDuration
 	}
-	opts = normalizeTranscodeOpts(opts)
+	opts = normalizeTranscodeOptsContext(ctx, opts)
 	if err := validateToneMapOpts(opts); err != nil {
 		return nil, err
 	}
@@ -468,6 +468,10 @@ func resolveSoftwareVideoDecode(opts TranscodeOpts) TranscodeOpts {
 // must pass through this helper so streaming and prepared-file recipes cannot
 // disagree about whether a source may use hardware decode or encode.
 func normalizeTranscodeOpts(opts TranscodeOpts) TranscodeOpts {
+	return normalizeTranscodeOptsContext(context.Background(), opts)
+}
+
+func normalizeTranscodeOptsContext(ctx context.Context, opts TranscodeOpts) TranscodeOpts {
 	opts.FFmpegPath = ResolveFFmpegPath(opts.FFmpegPath)
 	opts = resolveSoftwareVideoDecode(opts)
 	if opts.ToneMapMode == tonemap.ModeSoftware {
@@ -475,7 +479,7 @@ func normalizeTranscodeOpts(opts TranscodeOpts) TranscodeOpts {
 		opts.HWAccel = HWAccelNone
 		return opts
 	}
-	opts.HWAccel = resolveEffectiveTranscodeHWAccel(opts)
+	opts.HWAccel = resolveEffectiveTranscodeHWAccelContext(ctx, opts)
 	return opts
 }
 
@@ -749,7 +753,11 @@ func buildFFmpegArgs(opts TranscodeOpts) []string {
 
 // resolveEffectiveTranscodeHWAccel returns the backend that will actually execute the recipe.
 func resolveEffectiveTranscodeHWAccel(opts TranscodeOpts) string {
-	hwAccel := ResolveHWAccelWithFFmpeg(opts.HWAccel, opts.FFmpegPath)
+	return resolveEffectiveTranscodeHWAccelContext(context.Background(), opts)
+}
+
+func resolveEffectiveTranscodeHWAccelContext(ctx context.Context, opts TranscodeOpts) string {
+	hwAccel := ResolveHWAccelWithFFmpegContext(ctx, opts.HWAccel, opts.FFmpegPath)
 	if hwAccel == "" {
 		return ""
 	}
@@ -760,8 +768,8 @@ func resolveEffectiveTranscodeHWAccel(opts TranscodeOpts) string {
 		return HWAccelNone
 	}
 	if hwAccel == transcodeHWVideoToolbox {
-		if ok, reason := videoToolboxSupportsTargetCodec(opts.FFmpegPath, opts.TargetCodecVideo); !ok {
-			slog.Warn("VideoToolbox target encoder unavailable; using software encoding",
+		if ok, reason := videoToolboxSupportsTargetCodecContext(ctx, opts.FFmpegPath, opts.TargetCodecVideo); !ok {
+			slog.WarnContext(ctx, "VideoToolbox target encoder unavailable; using software encoding",
 				"target_codec", opts.TargetCodecVideo, "reason", reason)
 			return transcodeHWNone
 		}
@@ -771,7 +779,7 @@ func resolveEffectiveTranscodeHWAccel(opts TranscodeOpts) string {
 		// bitrate fallback visibly degrades high-resolution sources, so keep
 		// these on the software encoder.
 		if opts.TargetBitrateKbps <= 0 && opts.TargetResolution == "" {
-			slog.Info("VideoToolbox skipped for unconstrained transcode; using quality-based software encoding")
+			slog.InfoContext(ctx, "VideoToolbox skipped for unconstrained transcode; using quality-based software encoding")
 			return transcodeHWNone
 		}
 	}

--- a/internal/playback/transcode.go
+++ b/internal/playback/transcode.go
@@ -463,6 +463,19 @@ func resolveSoftwareVideoDecode(opts TranscodeOpts) TranscodeOpts {
 	return opts
 }
 
+// resolveVideoToolboxToneMapDecode keeps hardware decoding only for the HEVC
+// source path exercised by the VideoToolbox tone-map capability probe. Other
+// codecs may still use scale_vt and the hardware encoder after CPU decoding,
+// but must upload their frames explicitly rather than requesting unsupported
+// VideoToolbox decoder surfaces.
+func resolveVideoToolboxToneMapDecode(opts TranscodeOpts) TranscodeOpts {
+	if opts.ToneMapMode == tonemap.ModeHardware && opts.HWAccel == transcodeHWVideoToolbox &&
+		normalizeCodecV3(opts.SourceVideoCodec) != "hevc" {
+		opts.SoftwareVideoDecode = true
+	}
+	return opts
+}
+
 // normalizeTranscodeOpts resolves source-specific decode safety and the
 // configured hardware execution mode in one place. Every FFmpeg entry point
 // must pass through this helper so streaming and prepared-file recipes cannot
@@ -480,6 +493,7 @@ func normalizeTranscodeOptsContext(ctx context.Context, opts TranscodeOpts) Tran
 		return opts
 	}
 	opts.HWAccel = resolveEffectiveTranscodeHWAccelContext(ctx, opts)
+	opts = resolveVideoToolboxToneMapDecode(opts)
 	return opts
 }
 

--- a/internal/playback/transcode.go
+++ b/internal/playback/transcode.go
@@ -139,6 +139,7 @@ func VideoSampleEntryForDVCopy(dvProfile int) string {
 
 const (
 	transcodeCodecH264       = "h264"
+	transcodeCodecHEVC       = "hevc"
 	HWAccelNone              = "none"
 	transcodeHWQSV           = "qsv"
 	transcodeHWVAAPI         = "vaapi"
@@ -470,7 +471,7 @@ func resolveSoftwareVideoDecode(opts TranscodeOpts) TranscodeOpts {
 // VideoToolbox decoder surfaces.
 func resolveVideoToolboxToneMapDecode(opts TranscodeOpts) TranscodeOpts {
 	if opts.ToneMapMode == tonemap.ModeHardware && opts.HWAccel == transcodeHWVideoToolbox &&
-		normalizeCodecV3(opts.SourceVideoCodec) != "hevc" {
+		normalizeCodecV3(opts.SourceVideoCodec) != transcodeCodecHEVC {
 		opts.SoftwareVideoDecode = true
 	}
 	return opts
@@ -1012,7 +1013,7 @@ func appendVideoArgs(args []string, opts TranscodeOpts) []string {
 		} else {
 			args = append(args, "-c:v", "h264_qsv", "-preset", preset, "-global_quality", "23")
 		}
-	case opts.HWAccel == "qsv" && codec == "hevc":
+	case opts.HWAccel == "qsv" && codec == transcodeCodecHEVC:
 		if hasBitrateCap {
 			args = append(args, "-c:v", "hevc_qsv", "-preset", preset,
 				"-b:v", fmt.Sprintf("%dk", opts.TargetBitrateKbps),
@@ -1028,7 +1029,7 @@ func appendVideoArgs(args []string, opts TranscodeOpts) []string {
 				"-maxrate", fmt.Sprintf("%dk", opts.TargetBitrateKbps),
 				"-bufsize", fmt.Sprintf("%dk", opts.TargetBitrateKbps*2))
 		}
-	case opts.HWAccel == "vaapi" && codec == "hevc":
+	case opts.HWAccel == "vaapi" && codec == transcodeCodecHEVC:
 		args = append(args, "-c:v", "hevc_vaapi", "-qp", "28")
 		if hasBitrateCap {
 			args = append(args,
@@ -1045,7 +1046,7 @@ func appendVideoArgs(args []string, opts TranscodeOpts) []string {
 		} else {
 			args = append(args, "-cq:v", "23", "-b:v", "0")
 		}
-	case opts.HWAccel == transcodeHWNVENC && codec == "hevc":
+	case opts.HWAccel == transcodeHWNVENC && codec == transcodeCodecHEVC:
 		args = append(args, "-c:v", "hevc_nvenc", "-rc:v", "vbr")
 		if hasBitrateCap {
 			args = append(args,
@@ -1066,7 +1067,7 @@ func appendVideoArgs(args []string, opts TranscodeOpts) []string {
 		}
 		args = append(args, "-profile:v", "high")
 		args = appendVideoToolboxRateControl(args, opts)
-	case opts.HWAccel == transcodeHWVideoToolbox && codec == "hevc":
+	case opts.HWAccel == transcodeHWVideoToolbox && codec == transcodeCodecHEVC:
 		// pix_fmt is left to the input: 10-bit sources encode as p010
 		// (HDR10 passthrough), matching the other hardware HEVC paths.
 		args = append(args, "-c:v", "hevc_videotoolbox")
@@ -1075,7 +1076,7 @@ func appendVideoArgs(args []string, opts TranscodeOpts) []string {
 		// CPU fallback — match Jellyfin's proven browser-compatible settings.
 		// Force yuv420p to ensure 8-bit output (10-bit sources produce High 10
 		// Profile which browsers cannot decode via MSE).
-		if codec == "hevc" {
+		if codec == transcodeCodecHEVC {
 			args = append(args, "-c:v", "libx265", "-preset", preset, "-crf", "28", "-pix_fmt", "yuv420p")
 		} else {
 			args = append(args, "-c:v", "libx264", "-preset", preset, "-crf", "23",

--- a/internal/playback/transcode.go
+++ b/internal/playback/transcode.go
@@ -436,8 +436,12 @@ func RequiresSoftwareVideoDecode(codec, profile string, bitDepth int) bool {
 	if normalizeCodecV3(codec) != transcodeCodecH264 {
 		return false
 	}
-	normalizedProfile := strings.NewReplacer(" ", "", "-", "", "_", "").Replace(strings.ToLower(strings.TrimSpace(profile)))
+	normalizedProfile := normalizeVideoProfile(profile)
 	return bitDepth > 8 || normalizedProfile == "high10" || normalizedProfile == "high10intra" || normalizedProfile == "hi10p"
+}
+
+func normalizeVideoProfile(profile string) string {
+	return strings.NewReplacer(" ", "", "-", "", "_", "").Replace(strings.ToLower(strings.TrimSpace(profile)))
 }
 
 // SourceVideoTranscodeFacts returns the primary source facts needed to choose
@@ -465,16 +469,21 @@ func resolveSoftwareVideoDecode(opts TranscodeOpts) TranscodeOpts {
 }
 
 // resolveVideoToolboxToneMapDecode keeps hardware decoding only for the HEVC
-// source path exercised by the VideoToolbox tone-map capability probe. Other
-// codecs may still use scale_vt and the hardware encoder after CPU decoding,
-// but must upload their frames explicitly rather than requesting unsupported
-// VideoToolbox decoder surfaces.
+// Main 10 HEVC source shape exercised by the VideoToolbox tone-map capability
+// probe. Other source shapes may still use scale_vt and the hardware encoder
+// after CPU decoding, but must upload their frames explicitly rather than
+// requesting unprobed VideoToolbox decoder surfaces.
 func resolveVideoToolboxToneMapDecode(opts TranscodeOpts) TranscodeOpts {
-	if opts.ToneMapMode == tonemap.ModeHardware && opts.HWAccel == transcodeHWVideoToolbox &&
-		normalizeCodecV3(opts.SourceVideoCodec) != transcodeCodecHEVC {
+	if opts.ToneMapMode == tonemap.ModeHardware && opts.HWAccel == transcodeHWVideoToolbox && !videoToolboxToneMapHardwareDecodeSupported(opts) {
 		opts.SoftwareVideoDecode = true
 	}
 	return opts
+}
+
+func videoToolboxToneMapHardwareDecodeSupported(opts TranscodeOpts) bool {
+	return normalizeCodecV3(opts.SourceVideoCodec) == transcodeCodecHEVC &&
+		normalizeVideoProfile(opts.SourceVideoProfile) == "main10" &&
+		opts.SourceVideoBitDepth == 10
 }
 
 // normalizeTranscodeOpts resolves source-specific decode safety and the
@@ -792,8 +801,10 @@ func resolveEffectiveTranscodeHWAccelContext(ctx context.Context, opts Transcode
 		// e.g. the jellycompat paths) has always encoded with quality-based
 		// CRF. VideoToolbox has no portable constant-quality mode and a flat
 		// bitrate fallback visibly degrades high-resolution sources, so keep
-		// these on the software encoder.
-		if opts.TargetBitrateKbps <= 0 && opts.TargetResolution == "" {
+		// ordinary unconstrained transcodes on the software encoder. A frozen
+		// hardware tone-map recipe cannot change executors here; VideoToolbox's
+		// default bitrate remains the safe executable form of that recipe.
+		if opts.TargetBitrateKbps <= 0 && opts.TargetResolution == "" && opts.ToneMapMode != tonemap.ModeHardware {
 			slog.InfoContext(ctx, "VideoToolbox skipped for unconstrained transcode; using quality-based software encoding")
 			return transcodeHWNone
 		}

--- a/internal/playback/transcode_args_test.go
+++ b/internal/playback/transcode_args_test.go
@@ -6,6 +6,7 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/Silo-Server/silo-server/internal/tonemap"
 )
@@ -1204,6 +1205,34 @@ func TestResolveEffectiveTranscodeHWAccelVideoToolboxChecksTargetEncoder(t *test
 	if got := resolveEffectiveTranscodeHWAccel(hevc); got != "none" {
 		t.Fatalf("HEVC target resolved to %q, want software fallback", got)
 	}
+}
+
+func TestNormalizeTranscodeOptsVideoToolboxHonorsCallerDeadline(t *testing.T) {
+	setupHWAccelTest(t)
+	ffmpeg := writeFakeFFmpeg(t, fakeFFmpegProbe{hang: true})
+	ctx, cancel := context.WithTimeout(t.Context(), 60*time.Millisecond)
+	defer cancel()
+
+	started := time.Now()
+	opts := normalizeTranscodeOptsContext(ctx, TranscodeOpts{
+		FFmpegPath:        ffmpeg.path,
+		HWAccel:           transcodeHWVideoToolbox,
+		TargetCodecVideo:  "h264",
+		TargetBitrateKbps: 2000,
+	})
+	if opts.HWAccel != HWAccelNone {
+		t.Fatalf("HWAccel = %q, want software after caller deadline", opts.HWAccel)
+	}
+	if elapsed := time.Since(started); elapsed >= 150*time.Millisecond {
+		t.Fatalf("normalization took %s, want less than the probe command timeout", elapsed)
+	}
+	if ctx.Err() != context.DeadlineExceeded {
+		t.Fatalf("context error = %v, want deadline exceeded", ctx.Err())
+	}
+
+	// Let the bounded shared probe finish before setupHWAccelTest restores its
+	// package globals during cleanup.
+	_ = cachedVideoToolboxProbe(ffmpeg.path)
 }
 
 func TestResolveEffectiveTranscodeHWAccelVideoToolboxUnconstrainedUsesSoftware(t *testing.T) {

--- a/internal/playback/transcode_args_test.go
+++ b/internal/playback/transcode_args_test.go
@@ -1323,11 +1323,22 @@ func TestAppendAudioArgsBoostsOnlyEncodedSurroundToStereo(t *testing.T) {
 	}
 }
 
+// videoToolboxTestFFmpeg supplies a fake VideoToolbox-capable ffmpeg so the
+// argument tests validate construction independent of the host OS: the
+// builder's encoder probe must succeed on Linux CI as well as macOS.
+func videoToolboxTestFFmpeg(t *testing.T) string {
+	t.Helper()
+	resetNVENCProbeCacheForTest()
+	t.Cleanup(resetNVENCProbeCacheForTest)
+	return writeFakeFFmpeg(t, successfulVideoToolboxProbe()).path
+}
+
 func TestBuildFFmpegArgs_VideoToolboxH264UsesSoftwareFilters(t *testing.T) {
 	args := buildFFmpegArgs(TranscodeOpts{
 		InputPath:         "/media/movie.mkv",
 		OutputDir:         "/tmp/out",
 		SessionID:         "session-vt",
+		FFmpegPath:        videoToolboxTestFFmpeg(t),
 		SourceVideoCodec:  "h264",
 		TargetCodecVideo:  "h264",
 		TargetCodecAudio:  "aac",
@@ -1369,6 +1380,7 @@ func TestBuildFFmpegArgs_VideoToolboxH264UsesPortableDefaultBitrate(t *testing.T
 		InputPath:        "/media/movie.mkv",
 		OutputDir:        "/tmp/out",
 		SessionID:        "session-vt-default-rate",
+		FFmpegPath:       videoToolboxTestFFmpeg(t),
 		SourceVideoCodec: "h264",
 		TargetCodecVideo: "h264",
 		TargetCodecAudio: "aac",
@@ -1391,6 +1403,7 @@ func TestBuildFFmpegArgs_VideoToolboxHi10PDecodesInSoftware(t *testing.T) {
 		InputPath:          "/media/movie.mkv",
 		OutputDir:          "/tmp/out",
 		SessionID:          "session-vt-hi10p",
+		FFmpegPath:         videoToolboxTestFFmpeg(t),
 		SourceVideoCodec:   "h264",
 		SourceVideoProfile: "High 10",
 		TargetCodecVideo:   "h264",
@@ -1414,6 +1427,7 @@ func TestBuildFFmpegArgs_VideoToolboxHEVCKeepsSourceBitDepth(t *testing.T) {
 		InputPath:        "/media/movie.mkv",
 		OutputDir:        "/tmp/out",
 		SessionID:        "session-vt-hevc",
+		FFmpegPath:       videoToolboxTestFFmpeg(t),
 		SourceVideoCodec: "hevc",
 		TargetCodecVideo: "hevc",
 		TargetCodecAudio: "copy",
@@ -1438,6 +1452,7 @@ func TestBuildFFmpegArgs_VideoToolboxTextBurnInStaysOnCPUFilters(t *testing.T) {
 		InputPath:          "/media/movie.mkv",
 		OutputDir:          "/tmp/out",
 		SessionID:          "session-vt-sub",
+		FFmpegPath:         videoToolboxTestFFmpeg(t),
 		SourceVideoCodec:   "h264",
 		TargetCodecVideo:   "h264",
 		TargetCodecAudio:   "aac",

--- a/internal/playback/transcode_args_test.go
+++ b/internal/playback/transcode_args_test.go
@@ -1298,3 +1298,93 @@ func TestAppendAudioArgsBoostsOnlyEncodedSurroundToStereo(t *testing.T) {
 		})
 	}
 }
+
+func TestBuildFFmpegArgs_VideoToolboxH264UsesSoftwareFilters(t *testing.T) {
+	args := buildFFmpegArgs(TranscodeOpts{
+		InputPath:         "/media/movie.mkv",
+		OutputDir:         "/tmp/out",
+		SessionID:         "session-vt",
+		SourceVideoCodec:  "h264",
+		TargetCodecVideo:  "h264",
+		TargetCodecAudio:  "aac",
+		SegmentDuration:   2,
+		HWAccel:           "videotoolbox",
+		TargetResolution:  "720p",
+		TargetBitrateKbps: 2000,
+	})
+
+	joined := strings.Join(args, " ")
+	if !strings.Contains(joined, "-hwaccel videotoolbox") {
+		t.Fatalf("videotoolbox args should enable videotoolbox hwaccel: %s", joined)
+	}
+	if strings.Contains(joined, "-hwaccel_output_format") {
+		t.Fatalf("videotoolbox decode must output software frames: %s", joined)
+	}
+	if !strings.Contains(joined, "-c:v h264_videotoolbox") {
+		t.Fatalf("videotoolbox args should use h264_videotoolbox encoder: %s", joined)
+	}
+	if !strings.Contains(joined, "-pix_fmt yuv420p") {
+		t.Fatalf("videotoolbox h264 should force 8-bit output: %s", joined)
+	}
+	if !strings.Contains(joined, "-vf scale=-2:720") {
+		t.Fatalf("videotoolbox args should use the software scale filter: %s", joined)
+	}
+	if !strings.Contains(joined, "-b:v 2000k -maxrate 2000k -bufsize 4000k") {
+		t.Fatalf("videotoolbox args should include bitrate cap controls: %s", joined)
+	}
+	if !strings.Contains(joined, "-g 60 -keyint_min 60") {
+		t.Fatalf("videotoolbox args should force GOP on segment boundaries: %s", joined)
+	}
+	if strings.Contains(joined, "-preset") {
+		t.Fatalf("videotoolbox encoder does not take x264-style presets: %s", joined)
+	}
+}
+
+func TestBuildFFmpegArgs_VideoToolboxHEVCKeepsSourceBitDepth(t *testing.T) {
+	args := buildFFmpegArgs(TranscodeOpts{
+		InputPath:        "/media/movie.mkv",
+		OutputDir:        "/tmp/out",
+		SessionID:        "session-vt-hevc",
+		SourceVideoCodec: "hevc",
+		TargetCodecVideo: "hevc",
+		TargetCodecAudio: "copy",
+		SegmentDuration:  2,
+		HWAccel:          "videotoolbox",
+	})
+
+	joined := strings.Join(args, " ")
+	if !strings.Contains(joined, "-c:v hevc_videotoolbox") {
+		t.Fatalf("videotoolbox args should use hevc_videotoolbox encoder: %s", joined)
+	}
+	if strings.Contains(joined, "-pix_fmt") {
+		t.Fatalf("videotoolbox hevc must not force a pixel format (HDR10 passthrough): %s", joined)
+	}
+	if !strings.Contains(joined, "-q:v 60") {
+		t.Fatalf("uncapped videotoolbox hevc should use constant-quality mode: %s", joined)
+	}
+}
+
+func TestBuildFFmpegArgs_VideoToolboxTextBurnInStaysOnCPUFilters(t *testing.T) {
+	args := buildFFmpegArgs(TranscodeOpts{
+		InputPath:          "/media/movie.mkv",
+		OutputDir:          "/tmp/out",
+		SessionID:          "session-vt-sub",
+		SourceVideoCodec:   "h264",
+		TargetCodecVideo:   "h264",
+		TargetCodecAudio:   "aac",
+		SegmentDuration:    2,
+		HWAccel:            "videotoolbox",
+		TargetResolution:   "720p",
+		SubtitleBurnIn:     true,
+		SubtitleTrackIndex: 0,
+		SubtitleCodec:      "subrip",
+	})
+
+	joined := strings.Join(args, " ")
+	if !strings.Contains(joined, "subtitles=") {
+		t.Fatalf("text burn-in should use the subtitles filter: %s", joined)
+	}
+	if strings.Contains(joined, "hwdownload") || strings.Contains(joined, "hwupload") {
+		t.Fatalf("videotoolbox burn-in runs on software frames, no hw round-trip: %s", joined)
+	}
+}

--- a/internal/playback/transcode_args_test.go
+++ b/internal/playback/transcode_args_test.go
@@ -1130,9 +1130,10 @@ func TestResolveEffectiveTranscodeHWAccelVideoToolboxChecksTargetEncoder(t *test
 	ffmpeg := writeFakeFFmpeg(t, fakeFFmpegProbe{videotoolbox: true, h264VT: true, smokeOK: true})
 
 	base := TranscodeOpts{
-		FFmpegPath:       ffmpeg.path,
-		HWAccel:          "videotoolbox",
-		SourceVideoCodec: "h264",
+		FFmpegPath:        ffmpeg.path,
+		HWAccel:           "videotoolbox",
+		SourceVideoCodec:  "h264",
+		TargetBitrateKbps: 2000,
 	}
 
 	h264 := base
@@ -1145,6 +1146,34 @@ func TestResolveEffectiveTranscodeHWAccelVideoToolboxChecksTargetEncoder(t *test
 	hevc.TargetCodecVideo = "hevc"
 	if got := resolveEffectiveTranscodeHWAccel(hevc); got != "none" {
 		t.Fatalf("HEVC target resolved to %q, want software fallback", got)
+	}
+}
+
+func TestResolveEffectiveTranscodeHWAccelVideoToolboxUnconstrainedUsesSoftware(t *testing.T) {
+	setupHWAccelTest(t)
+	currentGOOS = "darwin"
+	ffmpeg := writeFakeFFmpeg(t, successfulVideoToolboxProbe())
+
+	unconstrained := TranscodeOpts{
+		FFmpegPath:       ffmpeg.path,
+		HWAccel:          "videotoolbox",
+		SourceVideoCodec: "h264",
+		TargetCodecVideo: "h264",
+	}
+	if got := resolveEffectiveTranscodeHWAccel(unconstrained); got != "none" {
+		t.Fatalf("unconstrained transcode resolved to %q, want software (quality-based CRF)", got)
+	}
+
+	withResolution := unconstrained
+	withResolution.TargetResolution = "720p"
+	if got := resolveEffectiveTranscodeHWAccel(withResolution); got != "videotoolbox" {
+		t.Fatalf("resolution-constrained transcode resolved to %q, want videotoolbox", got)
+	}
+
+	withBitrate := unconstrained
+	withBitrate.TargetBitrateKbps = 2000
+	if got := resolveEffectiveTranscodeHWAccel(withBitrate); got != "videotoolbox" {
+		t.Fatalf("bitrate-constrained transcode resolved to %q, want videotoolbox", got)
 	}
 }
 
@@ -1433,6 +1462,7 @@ func TestBuildFFmpegArgs_VideoToolboxHEVCKeepsSourceBitDepth(t *testing.T) {
 		TargetCodecAudio: "copy",
 		SegmentDuration:  2,
 		HWAccel:          "videotoolbox",
+		TargetResolution: "1080p",
 	})
 
 	joined := strings.Join(args, " ")

--- a/internal/playback/transcode_args_test.go
+++ b/internal/playback/transcode_args_test.go
@@ -275,7 +275,7 @@ func TestPrepareSubtitleFilterInputCreatesParserSafeAlias(t *testing.T) {
 	if !strings.Contains(joined, "-i "+inputPath) {
 		t.Fatalf("media input should keep its original path: %s", joined)
 	}
-	if !strings.Contains(joined, "subtitles='"+wantAlias+"':si=2") {
+	if !strings.Contains(joined, "subtitles=filename='"+wantAlias+"':si=2") {
 		t.Fatalf("subtitle filter should use the parser-safe alias: %s", joined)
 	}
 }
@@ -795,7 +795,7 @@ func TestBuildFFmpegArgs_H264High10QSVASSBurnInUsesSoftwareFrames(t *testing.T) 
 	})
 
 	joined := strings.Join(args, " ")
-	want := "-vf format=yuv420p,scale=-2:720,subtitles='/media/high10.mkv':si=0,format=nv12,hwupload,hwmap=derive_device=qsv,format=qsv"
+	want := "-vf format=yuv420p,scale=-2:720,subtitles=filename='/media/high10.mkv':si=0,format=nv12,hwupload,hwmap=derive_device=qsv,format=qsv"
 	if !strings.Contains(joined, want) {
 		t.Fatalf("High 10 ASS burn-in should render on software frames then upload %q: %s", want, joined)
 	}
@@ -1007,7 +1007,7 @@ func TestBuildFFmpegArgs_TextBurnInStillUsesSubtitlesFilter(t *testing.T) {
 	})
 
 	joined := strings.Join(args, " ")
-	if !strings.Contains(joined, "-vf scale=-2:1080,subtitles='/media/movie.mkv':si=1") {
+	if !strings.Contains(joined, "-vf scale=-2:1080,subtitles=filename='/media/movie.mkv':si=1") {
 		t.Fatalf("text burn-in should keep the libass subtitles -vf path: %s", joined)
 	}
 	if strings.Contains(joined, "-filter_complex") {
@@ -1034,7 +1034,7 @@ func TestBuildFFmpegArgs_LegacyBurnInWithoutCodecKeepsTextPath(t *testing.T) {
 	})
 
 	joined := strings.Join(args, " ")
-	if !strings.Contains(joined, "subtitles='/media/movie.mkv':si=0") {
+	if !strings.Contains(joined, "subtitles=filename='/media/movie.mkv':si=0") {
 		t.Fatalf("legacy burn-in without codec should keep the subtitles filter: %s", joined)
 	}
 	if strings.Contains(joined, "-filter_complex") {
@@ -1121,6 +1121,30 @@ func TestResolveEffectiveTranscodeHWAccel(t *testing.T) {
 				t.Fatalf("resolveEffectiveTranscodeHWAccel() = %q, want %q", got, tt.want)
 			}
 		})
+	}
+}
+
+func TestResolveEffectiveTranscodeHWAccelVideoToolboxChecksTargetEncoder(t *testing.T) {
+	setupHWAccelTest(t)
+	currentGOOS = "darwin"
+	ffmpeg := writeFakeFFmpeg(t, fakeFFmpegProbe{videotoolbox: true, h264VT: true, smokeOK: true})
+
+	base := TranscodeOpts{
+		FFmpegPath:       ffmpeg.path,
+		HWAccel:          "videotoolbox",
+		SourceVideoCodec: "h264",
+	}
+
+	h264 := base
+	h264.TargetCodecVideo = "h264"
+	if got := resolveEffectiveTranscodeHWAccel(h264); got != "videotoolbox" {
+		t.Fatalf("H.264 target resolved to %q, want videotoolbox", got)
+	}
+
+	hevc := base
+	hevc.TargetCodecVideo = "hevc"
+	if got := resolveEffectiveTranscodeHWAccel(hevc); got != "none" {
+		t.Fatalf("HEVC target resolved to %q, want software fallback", got)
 	}
 }
 
@@ -1340,6 +1364,28 @@ func TestBuildFFmpegArgs_VideoToolboxH264UsesSoftwareFilters(t *testing.T) {
 	}
 }
 
+func TestBuildFFmpegArgs_VideoToolboxH264UsesPortableDefaultBitrate(t *testing.T) {
+	args := buildFFmpegArgs(TranscodeOpts{
+		InputPath:        "/media/movie.mkv",
+		OutputDir:        "/tmp/out",
+		SessionID:        "session-vt-default-rate",
+		SourceVideoCodec: "h264",
+		TargetCodecVideo: "h264",
+		TargetCodecAudio: "aac",
+		SegmentDuration:  2,
+		HWAccel:          "videotoolbox",
+		TargetResolution: "720p",
+	})
+
+	joined := strings.Join(args, " ")
+	if !strings.Contains(joined, "-b:v 2000k -maxrate 2000k -bufsize 4000k") {
+		t.Fatalf("uncapped VideoToolbox H.264 should use the portable 720p default bitrate: %s", joined)
+	}
+	if strings.Contains(joined, "-q:v") {
+		t.Fatalf("VideoToolbox must not use Apple-Silicon-only qscale mode: %s", joined)
+	}
+}
+
 func TestBuildFFmpegArgs_VideoToolboxHi10PDecodesInSoftware(t *testing.T) {
 	args := buildFFmpegArgs(TranscodeOpts{
 		InputPath:          "/media/movie.mkv",
@@ -1382,8 +1428,8 @@ func TestBuildFFmpegArgs_VideoToolboxHEVCKeepsSourceBitDepth(t *testing.T) {
 	if strings.Contains(joined, "-pix_fmt") {
 		t.Fatalf("videotoolbox hevc must not force a pixel format (HDR10 passthrough): %s", joined)
 	}
-	if !strings.Contains(joined, "-q:v 60") {
-		t.Fatalf("uncapped videotoolbox hevc should use constant-quality mode: %s", joined)
+	if !strings.Contains(joined, "-b:v 6000k -maxrate 6000k -bufsize 12000k") {
+		t.Fatalf("uncapped videotoolbox hevc should use the portable default bitrate: %s", joined)
 	}
 }
 

--- a/internal/playback/transcode_args_test.go
+++ b/internal/playback/transcode_args_test.go
@@ -31,6 +31,7 @@ func TestToneMapFFmpegGraphsCoverSupportedExecutors(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			args := buildFFmpegArgs(TranscodeOpts{
 				InputPath: "/media/hdr.mkv", OutputDir: t.TempDir(), TargetCodecVideo: "h264", TargetCodecAudio: "aac",
+				FFmpegPath:       videoToolboxTestFFmpegFor(t, tt.hwAccel),
 				TargetResolution: "1080p", HWAccel: tt.hwAccel, ToneMapPolicy: tonemap.PolicyHardwareThenSoftware,
 				ToneMapMode: tt.mode, ToneMapSourceKind: tt.sourceKind, ToneMapFilter: tt.filter,
 				ToneMapRecipeVersion: TransformationHDRToSDRToneMapRecipeVersionV3,
@@ -98,6 +99,7 @@ func TestEveryToneMapSourceKindBuildsEveryExecutorGraph(t *testing.T) {
 			t.Run(string(kind)+"/"+executor.name, func(t *testing.T) {
 				args := buildPrepareFileArgs(TranscodeOpts{
 					InputPath: "/media/source.mkv", SourceVideoBitDepth: 10, TargetCodecVideo: "h264", TargetCodecAudio: "aac",
+					FFmpegPath:       videoToolboxTestFFmpegFor(t, executor.hwAccel),
 					TargetResolution: "720p", ToneMapPolicy: tonemap.PolicyHardwareThenSoftware,
 					ToneMapMode: executor.mode, ToneMapSourceKind: kind, ToneMapFilter: executor.filter,
 					ToneMapRecipeVersion: TransformationHDRToSDRToneMapRecipeVersionV3, HWAccel: executor.hwAccel,
@@ -134,6 +136,7 @@ func TestHardwareToneMapRemovesMetadataAfterHardwareFormatConversion(t *testing.
 		t.Run(tt.name, func(t *testing.T) {
 			graph := strings.Join(buildFFmpegArgs(TranscodeOpts{
 				InputPath: "/media/hdr.mkv", OutputDir: t.TempDir(), TargetCodecVideo: "h264", TargetCodecAudio: "aac",
+				FFmpegPath:       videoToolboxTestFFmpegFor(t, tt.hwAccel),
 				TargetResolution: "1080p", HWAccel: tt.hwAccel, ToneMapPolicy: tonemap.PolicyHardwareOnly,
 				ToneMapMode: tonemap.ModeHardware, ToneMapSourceKind: tonemap.SourcePQ, ToneMapFilter: tt.filter,
 				ToneMapRecipeVersion: TransformationHDRToSDRToneMapRecipeVersionV3,
@@ -179,6 +182,7 @@ func TestToneMapGraphOrdersTextAndBitmapSubtitles(t *testing.T) {
 func TestVideoToolboxToneMapDownloadsBeforeSubtitleComposition(t *testing.T) {
 	base := TranscodeOpts{
 		InputPath: "/media/hdr.mkv", OutputDir: t.TempDir(), SourceVideoBitDepth: 10,
+		FFmpegPath:       videoToolboxTestFFmpeg(t),
 		TargetCodecVideo: "h264", TargetCodecAudio: "aac", TargetResolution: "1080p",
 		HWAccel: transcodeHWVideoToolbox, ToneMapPolicy: tonemap.PolicyHardwareOnly,
 		ToneMapMode: tonemap.ModeHardware, ToneMapSourceKind: tonemap.SourcePQ,
@@ -242,6 +246,7 @@ func TestSDRBaseGraphsBypassLuminanceToneMapping(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			args := buildFFmpegArgs(TranscodeOpts{
 				InputPath: "/media/dovi.mkv", OutputDir: t.TempDir(), SourceVideoBitDepth: 10,
+				FFmpegPath:       videoToolboxTestFFmpegFor(t, tt.hwAccel),
 				TargetCodecVideo: "h264", TargetCodecAudio: "aac", TargetResolution: "1080p", HWAccel: tt.hwAccel,
 				ToneMapPolicy: tonemap.PolicyHardwareThenSoftware, ToneMapMode: tt.mode,
 				ToneMapSourceKind: tt.sourceKind, ToneMapFilter: tt.filter, ToneMapRecipeVersion: TransformationHDRToSDRToneMapRecipeVersionV3,
@@ -1412,6 +1417,14 @@ func videoToolboxTestFFmpeg(t *testing.T) string {
 	resetNVENCProbeCacheForTest()
 	t.Cleanup(resetNVENCProbeCacheForTest)
 	return writeFakeFFmpeg(t, successfulVideoToolboxProbe()).path
+}
+
+func videoToolboxTestFFmpegFor(t *testing.T, hwAccel string) string {
+	t.Helper()
+	if hwAccel != transcodeHWVideoToolbox {
+		return ""
+	}
+	return videoToolboxTestFFmpeg(t)
 }
 
 func TestBuildFFmpegArgs_VideoToolboxH264UsesSoftwareFilters(t *testing.T) {

--- a/internal/playback/transcode_args_test.go
+++ b/internal/playback/transcode_args_test.go
@@ -33,6 +33,7 @@ func TestToneMapFFmpegGraphsCoverSupportedExecutors(t *testing.T) {
 			args := buildFFmpegArgs(TranscodeOpts{
 				InputPath: "/media/hdr.mkv", OutputDir: t.TempDir(), TargetCodecVideo: "h264", TargetCodecAudio: "aac",
 				FFmpegPath:       videoToolboxTestFFmpegFor(t, tt.hwAccel),
+				SourceVideoCodec: "hevc",
 				TargetResolution: "1080p", HWAccel: tt.hwAccel, ToneMapPolicy: tonemap.PolicyHardwareThenSoftware,
 				ToneMapMode: tt.mode, ToneMapSourceKind: tt.sourceKind, ToneMapFilter: tt.filter,
 				ToneMapRecipeVersion: TransformationHDRToSDRToneMapRecipeVersionV3,
@@ -56,6 +57,31 @@ func TestToneMapFFmpegGraphsCoverSupportedExecutors(t *testing.T) {
 				t.Fatalf("hardware graph requested a software pixel format conversion: %s", joined)
 			}
 		})
+	}
+}
+
+func TestBuildFFmpegArgs_VideoToolboxToneMapUnprobedCodecUsesSoftwareDecodeUpload(t *testing.T) {
+	args := buildFFmpegArgs(TranscodeOpts{
+		InputPath: "/media/hdr-av1.mkv", OutputDir: t.TempDir(), TargetCodecVideo: "h264", TargetCodecAudio: "aac",
+		FFmpegPath: videoToolboxTestFFmpeg(t), SourceVideoCodec: "av1", SourceVideoBitDepth: 10,
+		TargetResolution: "1080p", HWAccel: transcodeHWVideoToolbox, ToneMapPolicy: tonemap.PolicyHardwareThenSoftware,
+		ToneMapMode: tonemap.ModeHardware, ToneMapSourceKind: tonemap.SourcePQ, ToneMapFilter: tonemap.HardwareFilterVideoToolbox,
+		ToneMapRecipeVersion: TransformationHDRToSDRToneMapRecipeVersionV3,
+	})
+	joined := strings.Join(args, " ")
+	for _, forbidden := range []string{"-hwaccel videotoolbox", "-hwaccel_output_format videotoolbox_vld"} {
+		if strings.Contains(joined, forbidden) {
+			t.Fatalf("unprobed source codec must not use VideoToolbox decoding, found %q: %s", forbidden, joined)
+		}
+	}
+	for _, required := range []string{
+		"-init_hw_device videotoolbox=vt", "-filter_hw_device vt",
+		"setparams=range=tv:color_primaries=bt2020:color_trc=smpte2084:colorspace=bt2020nc,format=p010le,hwupload",
+		"scale_vt=w=-2:h=1080", "-c:v h264_videotoolbox",
+	} {
+		if !strings.Contains(joined, required) {
+			t.Fatalf("software-decode VideoToolbox tone map missing %q: %s", required, joined)
+		}
 	}
 }
 

--- a/internal/playback/transcode_args_test.go
+++ b/internal/playback/transcode_args_test.go
@@ -1340,6 +1340,29 @@ func TestBuildFFmpegArgs_VideoToolboxH264UsesSoftwareFilters(t *testing.T) {
 	}
 }
 
+func TestBuildFFmpegArgs_VideoToolboxHi10PDecodesInSoftware(t *testing.T) {
+	args := buildFFmpegArgs(TranscodeOpts{
+		InputPath:          "/media/movie.mkv",
+		OutputDir:          "/tmp/out",
+		SessionID:          "session-vt-hi10p",
+		SourceVideoCodec:   "h264",
+		SourceVideoProfile: "High 10",
+		TargetCodecVideo:   "h264",
+		TargetCodecAudio:   "aac",
+		SegmentDuration:    2,
+		HWAccel:            "videotoolbox",
+		TargetBitrateKbps:  2000,
+	})
+
+	joined := strings.Join(args, " ")
+	if strings.Contains(joined, "-hwaccel videotoolbox") {
+		t.Fatalf("Hi10P source must decode in software (VideoToolbox cannot): %s", joined)
+	}
+	if !strings.Contains(joined, "-c:v h264_videotoolbox") {
+		t.Fatalf("encode should still use the hardware encoder: %s", joined)
+	}
+}
+
 func TestBuildFFmpegArgs_VideoToolboxHEVCKeepsSourceBitDepth(t *testing.T) {
 	args := buildFFmpegArgs(TranscodeOpts{
 		InputPath:        "/media/movie.mkv",

--- a/internal/playback/transcode_args_test.go
+++ b/internal/playback/transcode_args_test.go
@@ -25,6 +25,7 @@ func TestToneMapFFmpegGraphsCoverSupportedExecutors(t *testing.T) {
 		{name: "QSV", mode: tonemap.ModeHardware, hwAccel: "qsv", filter: "tonemap_opencl", sourceKind: tonemap.SourcePQ, want: []string{"-init_hw_device opencl=ocl@va", "tonemap_opencl", "hwmap=derive_device=qsv:mode=read+write", "h264_qsv"}},
 		{name: "VAAPI", mode: tonemap.ModeHardware, hwAccel: "vaapi", filter: "tonemap_vaapi", sourceKind: tonemap.SourceHLG, want: []string{"tonemap_vaapi", "scale_vaapi", "h264_vaapi"}},
 		{name: "NVENC", mode: tonemap.ModeHardware, hwAccel: "nvenc", filter: "tonemap_cuda", sourceKind: tonemap.SourcePQ, want: []string{"color_trc=smpte2084", "tonemap_cuda", "scale_cuda", "h264_nvenc"}},
+		{name: "VideoToolbox", mode: tonemap.ModeHardware, hwAccel: "videotoolbox", filter: "scale_vt", sourceKind: tonemap.SourcePQ, want: []string{"-hwaccel videotoolbox", "-hwaccel_output_format videotoolbox_vld", "scale_vt=w=-2:h=1080", "hwdownload,format=p010le,format=nv12", "h264_videotoolbox"}},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -43,8 +44,11 @@ func TestToneMapFFmpegGraphsCoverSupportedExecutors(t *testing.T) {
 			if tt.mode == tonemap.ModeSoftware && !strings.Contains(joined, "-colorspace bt709") {
 				t.Fatalf("software args omit explicit output matrix: %s", joined)
 			}
-			if tt.mode == tonemap.ModeHardware && strings.Contains(joined, "-colorspace bt709") {
+			if tt.mode == tonemap.ModeHardware && tt.hwAccel != transcodeHWVideoToolbox && strings.Contains(joined, "-colorspace bt709") {
 				t.Fatalf("hardware args request an incompatible software colorspace conversion: %s", joined)
+			}
+			if tt.hwAccel == transcodeHWVideoToolbox && !strings.Contains(joined, "-colorspace bt709") {
+				t.Fatalf("VideoToolbox args omit the required output matrix: %s", joined)
 			}
 			if tt.mode == tonemap.ModeHardware && strings.Contains(joined, "-pix_fmt yuv420p") {
 				t.Fatalf("hardware graph requested a software pixel format conversion: %s", joined)
@@ -87,6 +91,7 @@ func TestEveryToneMapSourceKindBuildsEveryExecutorGraph(t *testing.T) {
 		{name: "qsv", mode: tonemap.ModeHardware, hwAccel: "qsv", filter: tonemap.HardwareFilterOpenCL, encoder: "h264_qsv"},
 		{name: "vaapi", mode: tonemap.ModeHardware, hwAccel: "vaapi", filter: tonemap.HardwareFilterVAAPI, encoder: "h264_vaapi"},
 		{name: "nvenc", mode: tonemap.ModeHardware, hwAccel: "nvenc", filter: tonemap.HardwareFilterCUDA, encoder: "h264_nvenc"},
+		{name: "videotoolbox", mode: tonemap.ModeHardware, hwAccel: "videotoolbox", filter: tonemap.HardwareFilterVideoToolbox, encoder: "h264_videotoolbox"},
 	}
 	for _, kind := range tonemap.AllSourceKinds() {
 		for _, executor := range executors {
@@ -104,7 +109,7 @@ func TestEveryToneMapSourceKindBuildsEveryExecutorGraph(t *testing.T) {
 					}
 				}
 				hasLuminanceToneMap := strings.Contains(joined, "tonemap=hable") || strings.Contains(joined, "tonemap_opencl") || strings.Contains(joined, "tonemap_vaapi") || strings.Contains(joined, "tonemap_cuda")
-				if hasLuminanceToneMap == tonemap.IsSDRSource(kind) {
+				if executor.hwAccel != transcodeHWVideoToolbox && hasLuminanceToneMap == tonemap.IsSDRSource(kind) {
 					t.Fatalf("%s/%s luminance tone-map decision is wrong: %s", kind, executor.name, joined)
 				}
 			})
@@ -123,6 +128,7 @@ func TestHardwareToneMapRemovesMetadataAfterHardwareFormatConversion(t *testing.
 		{name: "QSV", hwAccel: "qsv", filter: tonemap.HardwareFilterOpenCL, before: "hwmap=derive_device=qsv"},
 		{name: "VAAPI", hwAccel: "vaapi", filter: tonemap.HardwareFilterVAAPI, before: "scale_vaapi"},
 		{name: "NVENC", hwAccel: "nvenc", filter: tonemap.HardwareFilterCUDA, before: "scale_cuda"},
+		{name: "VideoToolbox", hwAccel: "videotoolbox", filter: tonemap.HardwareFilterVideoToolbox, before: "scale_vt"},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -170,6 +176,51 @@ func TestToneMapGraphOrdersTextAndBitmapSubtitles(t *testing.T) {
 	assertTokenOrder(bitmapGraph, "tonemapx=tonemap=bt2390", "overlay=eof_action=pass", "scale=-2:1080")
 }
 
+func TestVideoToolboxToneMapDownloadsBeforeSubtitleComposition(t *testing.T) {
+	base := TranscodeOpts{
+		InputPath: "/media/hdr.mkv", OutputDir: t.TempDir(), SourceVideoBitDepth: 10,
+		TargetCodecVideo: "h264", TargetCodecAudio: "aac", TargetResolution: "1080p",
+		HWAccel: transcodeHWVideoToolbox, ToneMapPolicy: tonemap.PolicyHardwareOnly,
+		ToneMapMode: tonemap.ModeHardware, ToneMapSourceKind: tonemap.SourcePQ,
+		ToneMapFilter:        tonemap.HardwareFilterVideoToolbox,
+		ToneMapRecipeVersion: TransformationHDRToSDRToneMapRecipeVersionV3,
+		SubtitleBurnIn:       true, SubtitleTrackIndex: 0,
+	}
+	for _, codec := range []string{"subrip", "hdmv_pgs_subtitle"} {
+		t.Run(codec, func(t *testing.T) {
+			opts := base
+			opts.SubtitleCodec = codec
+			graph := strings.Join(buildFFmpegArgs(opts), " ")
+			convert := strings.Index(graph, "scale_vt=w=-2:h=1080")
+			download := strings.Index(graph, "hwdownload,format=p010le,format=nv12")
+			compose := strings.Index(graph, "subtitles=")
+			if codec == "hdmv_pgs_subtitle" {
+				compose = strings.Index(graph, "overlay=eof_action=pass")
+			}
+			metadata := strings.Index(graph, "sidedata=mode=delete")
+			if convert < 0 || download <= convert || compose <= download || metadata <= compose {
+				t.Fatalf("unsafe VideoToolbox subtitle order: %s", graph)
+			}
+			if strings.Contains(graph, "scale=-2:1080") {
+				t.Fatalf("VideoToolbox scaling ran a second time on the CPU: %s", graph)
+			}
+		})
+	}
+}
+
+func TestValidateToneMapOptsAcceptsVideoToolbox(t *testing.T) {
+	err := validateToneMapOpts(TranscodeOpts{
+		TargetCodecVideo: "h264", HWAccel: transcodeHWVideoToolbox,
+		ToneMapPolicy: tonemap.PolicyHardwareOnly, ToneMapMode: tonemap.ModeHardware,
+		ToneMapSourceKind: tonemap.SourcePQ, ToneMapFilter: tonemap.HardwareFilterVideoToolbox,
+		ToneMapRecipeVersion:  TransformationHDRToSDRToneMapRecipeVersionV3,
+		ToneMapSourceRevision: tonemap.SourceRevision{MediaFileID: 1, FileSize: 1, FileModifiedUnixNano: 1, FileHash: "hash", ProbeUpdatedUnixNano: 1, StreamSignature: "stream"},
+	})
+	if err != nil {
+		t.Fatalf("VideoToolbox tone-map recipe rejected: %v", err)
+	}
+}
+
 // TestSDRBaseGraphsBypassLuminanceToneMapping verifies SDR-compatible bases avoid needless luminance mapping.
 func TestSDRBaseGraphsBypassLuminanceToneMapping(t *testing.T) {
 	tests := []struct {
@@ -185,6 +236,7 @@ func TestSDRBaseGraphsBypassLuminanceToneMapping(t *testing.T) {
 		{name: "QSV", mode: tonemap.ModeHardware, hwAccel: "qsv", filter: tonemap.HardwareFilterOpenCL, sourceKind: tonemap.SourceSDRBT709, want: []string{"scale_vaapi=format=nv12", "hwmap=derive_device=qsv"}},
 		{name: "VAAPI", mode: tonemap.ModeHardware, hwAccel: "vaapi", filter: tonemap.HardwareFilterVAAPI, sourceKind: tonemap.SourceSDRBT2020, want: []string{"scale_vaapi=format=nv12", "h264_vaapi"}},
 		{name: "NVENC", mode: tonemap.ModeHardware, hwAccel: "nvenc", filter: tonemap.HardwareFilterCUDA, sourceKind: tonemap.SourceSDRBT2020, want: []string{"hwdownload,format=p010le", "zscale=p=bt709", "hwupload_cuda", "h264_nvenc"}},
+		{name: "VideoToolbox", mode: tonemap.ModeHardware, hwAccel: "videotoolbox", filter: tonemap.HardwareFilterVideoToolbox, sourceKind: tonemap.SourceSDRBT2020, want: []string{"scale_vt", "hwdownload,format=p010le,format=nv12", "h264_videotoolbox"}},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/internal/playback/transcode_args_test.go
+++ b/internal/playback/transcode_args_test.go
@@ -33,7 +33,7 @@ func TestToneMapFFmpegGraphsCoverSupportedExecutors(t *testing.T) {
 			args := buildFFmpegArgs(TranscodeOpts{
 				InputPath: "/media/hdr.mkv", OutputDir: t.TempDir(), TargetCodecVideo: "h264", TargetCodecAudio: "aac",
 				FFmpegPath:       videoToolboxTestFFmpegFor(t, tt.hwAccel),
-				SourceVideoCodec: "hevc",
+				SourceVideoCodec: "hevc", SourceVideoProfile: "Main 10", SourceVideoBitDepth: 10,
 				TargetResolution: "1080p", HWAccel: tt.hwAccel, ToneMapPolicy: tonemap.PolicyHardwareThenSoftware,
 				ToneMapMode: tt.mode, ToneMapSourceKind: tt.sourceKind, ToneMapFilter: tt.filter,
 				ToneMapRecipeVersion: TransformationHDRToSDRToneMapRecipeVersionV3,
@@ -60,28 +60,68 @@ func TestToneMapFFmpegGraphsCoverSupportedExecutors(t *testing.T) {
 	}
 }
 
-func TestBuildFFmpegArgs_VideoToolboxToneMapUnprobedCodecUsesSoftwareDecodeUpload(t *testing.T) {
-	args := buildFFmpegArgs(TranscodeOpts{
-		InputPath: "/media/hdr-av1.mkv", OutputDir: t.TempDir(), TargetCodecVideo: "h264", TargetCodecAudio: "aac",
-		FFmpegPath: videoToolboxTestFFmpeg(t), SourceVideoCodec: "av1", SourceVideoBitDepth: 10,
-		TargetResolution: "1080p", HWAccel: transcodeHWVideoToolbox, ToneMapPolicy: tonemap.PolicyHardwareThenSoftware,
-		ToneMapMode: tonemap.ModeHardware, ToneMapSourceKind: tonemap.SourcePQ, ToneMapFilter: tonemap.HardwareFilterVideoToolbox,
-		ToneMapRecipeVersion: TransformationHDRToSDRToneMapRecipeVersionV3,
-	})
-	joined := strings.Join(args, " ")
-	for _, forbidden := range []string{"-hwaccel videotoolbox", "-hwaccel_output_format videotoolbox_vld"} {
-		if strings.Contains(joined, forbidden) {
-			t.Fatalf("unprobed source codec must not use VideoToolbox decoding, found %q: %s", forbidden, joined)
-		}
-	}
-	for _, required := range []string{
-		"-init_hw_device videotoolbox=vt", "-filter_hw_device vt",
-		"setparams=range=tv:color_primaries=bt2020:color_trc=smpte2084:colorspace=bt2020nc,format=p010le,hwupload",
-		"scale_vt=w=-2:h=1080", "-c:v h264_videotoolbox",
+func TestBuildFFmpegArgs_VideoToolboxToneMapUnprobedSourceUsesSoftwareDecodeUpload(t *testing.T) {
+	for _, tt := range []struct {
+		name     string
+		codec    string
+		profile  string
+		bitDepth int
+	}{
+		{name: "AV1", codec: "av1", profile: "Main", bitDepth: 10},
+		{name: "HEVC Main 12", codec: "hevc", profile: "Main 12", bitDepth: 12},
 	} {
-		if !strings.Contains(joined, required) {
-			t.Fatalf("software-decode VideoToolbox tone map missing %q: %s", required, joined)
-		}
+		t.Run(tt.name, func(t *testing.T) {
+			args := buildFFmpegArgs(TranscodeOpts{
+				InputPath: "/media/hdr.mkv", OutputDir: t.TempDir(), TargetCodecVideo: "h264", TargetCodecAudio: "aac",
+				FFmpegPath: videoToolboxTestFFmpeg(t), SourceVideoCodec: tt.codec, SourceVideoProfile: tt.profile, SourceVideoBitDepth: tt.bitDepth,
+				TargetResolution: "1080p", HWAccel: transcodeHWVideoToolbox, ToneMapPolicy: tonemap.PolicyHardwareThenSoftware,
+				ToneMapMode: tonemap.ModeHardware, ToneMapSourceKind: tonemap.SourcePQ, ToneMapFilter: tonemap.HardwareFilterVideoToolbox,
+				ToneMapRecipeVersion: TransformationHDRToSDRToneMapRecipeVersionV3,
+			})
+			joined := strings.Join(args, " ")
+			for _, forbidden := range []string{"-hwaccel videotoolbox", "-hwaccel_output_format videotoolbox_vld"} {
+				if strings.Contains(joined, forbidden) {
+					t.Fatalf("unprobed source shape must not use VideoToolbox decoding, found %q: %s", forbidden, joined)
+				}
+			}
+			for _, required := range []string{
+				"-init_hw_device videotoolbox=vt", "-filter_hw_device vt",
+				"setparams=range=tv:color_primaries=bt2020:color_trc=smpte2084:colorspace=bt2020nc,format=p010le,hwupload",
+				"scale_vt=w=-2:h=1080", "-c:v h264_videotoolbox",
+			} {
+				if !strings.Contains(joined, required) {
+					t.Fatalf("software-decode VideoToolbox tone map missing %q: %s", required, joined)
+				}
+			}
+		})
+	}
+}
+
+func TestResolveVideoToolboxToneMapDecodeUsesOnlyProbedSourceShape(t *testing.T) {
+	tests := []struct {
+		name     string
+		codec    string
+		profile  string
+		bitDepth int
+		wantCPU  bool
+	}{
+		{name: "HEVC Main 10", codec: "hevc", profile: "Main 10", bitDepth: 10},
+		{name: "HEVC Main 12", codec: "hevc", profile: "Main 12", bitDepth: 12, wantCPU: true},
+		{name: "HEVC range extensions", codec: "hevc", profile: "Rext", bitDepth: 10, wantCPU: true},
+		{name: "HEVC unknown bit depth", codec: "hevc", profile: "Main 10", wantCPU: true},
+		{name: "HEVC mismatched bit depth", codec: "hevc", profile: "Main 10", bitDepth: 12, wantCPU: true},
+		{name: "AV1", codec: "av1", profile: "Main", bitDepth: 10, wantCPU: true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			opts := resolveVideoToolboxToneMapDecode(TranscodeOpts{
+				HWAccel: transcodeHWVideoToolbox, ToneMapMode: tonemap.ModeHardware,
+				SourceVideoCodec: tt.codec, SourceVideoProfile: tt.profile, SourceVideoBitDepth: tt.bitDepth,
+			})
+			if opts.SoftwareVideoDecode != tt.wantCPU {
+				t.Fatalf("SoftwareVideoDecode = %v, want %v", opts.SoftwareVideoDecode, tt.wantCPU)
+			}
+		})
 	}
 }
 
@@ -1274,6 +1314,15 @@ func TestResolveEffectiveTranscodeHWAccelVideoToolboxUnconstrainedUsesSoftware(t
 	}
 	if got := resolveEffectiveTranscodeHWAccel(unconstrained); got != "none" {
 		t.Fatalf("unconstrained transcode resolved to %q, want software (quality-based CRF)", got)
+	}
+
+	toneMap := unconstrained
+	toneMap.SourceVideoCodec = transcodeCodecHEVC
+	toneMap.SourceVideoProfile = "Main 10"
+	toneMap.SourceVideoBitDepth = 10
+	toneMap.ToneMapMode = tonemap.ModeHardware
+	if got := resolveEffectiveTranscodeHWAccel(toneMap); got != transcodeHWVideoToolbox {
+		t.Fatalf("unconstrained hardware tone map resolved to %q, want VideoToolbox", got)
 	}
 
 	withResolution := unconstrained

--- a/internal/tonemap/preflight.go
+++ b/internal/tonemap/preflight.go
@@ -458,15 +458,22 @@ func sourceConversionPreflightArgs(request SourcePreflightRequest, position floa
 				device = "0"
 			}
 			args = append(args, "-init_hw_device", "cuda=cu:"+device, "-filter_hw_device", "cu", "-hwaccel", "cuda", "-hwaccel_output_format", "cuda")
+		case BackendVideoToolbox:
+			if request.SoftwareVideoDecode {
+				args = append(args, "-init_hw_device", "videotoolbox=vt", "-filter_hw_device", "vt")
+			} else {
+				args = append(args, "-hwaccel", BackendVideoToolbox, "-hwaccel_output_format", "videotoolbox_vld")
+			}
 		}
 	}
 	args = append(args, "-ss", strconv.FormatFloat(position, 'f', 3, 64), "-i", request.InputPath, "-map", "0:v:0", "-frames:v", "1", "-an", "-sn", "-dn", "-map_metadata", "-1", "-map_chapters", "-1")
 	filter := sourceConversionPreflightFilter(request)
 	args = append(args, "-vf", filter, "-c:v", sourcePreflightEncoder(request), "-color_range", "tv", "-color_primaries", colorBT709, "-color_trc", colorBT709)
-	// Hardware filters already stamp the BT.709 matrix on their output. Asking
-	// FFmpeg to apply -colorspace at the mux boundary can insert an unsupported
-	// software conversion between hardware frames and the hardware encoder.
-	if request.Mode == ModeSoftware {
+	// VAAPI/QSV/CUDA filters stamp the BT.709 matrix on hardware frames; an
+	// explicit mux-boundary colorspace can insert an unsupported conversion.
+	// VideoToolbox has downloaded an NV12 frame and needs the explicit matrix
+	// because its encoder otherwise preserves the source BT.2020 matrix.
+	if request.Mode == ModeSoftware || request.Backend == BackendVideoToolbox {
 		args = append(args, "-colorspace", colorBT709)
 	}
 	if outputPath == "" {
@@ -480,6 +487,13 @@ func sourceConversionPreflightArgs(request SourcePreflightRequest, position floa
 func sourceConversionPreflightFilter(request SourcePreflightRequest) string {
 	if request.Mode == ModeSoftware {
 		return SoftwareFilter(request.Kind, request.Filter)
+	}
+	if request.Backend == BackendVideoToolbox {
+		filter := ""
+		if request.SoftwareVideoDecode {
+			filter = VideoToolboxUploadFilter(request.Kind, request.SourceBitDepth) + ","
+		}
+		return filter + VideoToolboxFilter("iw", "ih") + "," + VideoToolboxDownloadFilter(request.SourceBitDepth) + "," + HDRMetadataRemovalFilter()
 	}
 	if request.Backend == BackendNVENC {
 		if IsSDRSource(request.Kind) {

--- a/internal/tonemap/preflight_test.go
+++ b/internal/tonemap/preflight_test.go
@@ -517,6 +517,30 @@ func TestSourceConversionPreflightMirrorsSoftwareDecodeForVAAPI(t *testing.T) {
 	}
 }
 
+func TestSourceConversionPreflightBuildsVideoToolboxPaths(t *testing.T) {
+	for _, softwareDecode := range []bool{false, true} {
+		t.Run(strconv.FormatBool(softwareDecode), func(t *testing.T) {
+			args := sourceConversionPreflightArgs(SourcePreflightRequest{
+				Mode: ModeHardware, Backend: BackendVideoToolbox, Kind: SourcePQ,
+				SourceBitDepth: 10, SoftwareVideoDecode: softwareDecode,
+			}, 0, "")
+			joined := strings.Join(args, " ")
+			for _, token := range []string{"scale_vt", "hwdownload,format=p010le,format=nv12", "sidedata=mode=delete:type=DOVI_RPU_BUFFER", "h264_videotoolbox"} {
+				if !strings.Contains(joined, token) {
+					t.Fatalf("VideoToolbox preflight missing %q: %s", token, joined)
+				}
+			}
+			if softwareDecode {
+				if !strings.Contains(joined, "-init_hw_device videotoolbox=vt") || !strings.Contains(joined, "format=p010le,hwupload") || strings.Contains(joined, "-hwaccel videotoolbox") {
+					t.Fatalf("software-decode VideoToolbox preflight is wrong: %s", joined)
+				}
+			} else if !strings.Contains(joined, "-hwaccel videotoolbox -hwaccel_output_format videotoolbox_vld") {
+				t.Fatalf("hardware-decode VideoToolbox preflight is wrong: %s", joined)
+			}
+		})
+	}
+}
+
 // TestSourceConversionPreflightOnlyRequestsSoftwareColorspaceConversion verifies hardware graphs avoid an invalid conversion.
 func TestSourceConversionPreflightOnlyRequestsSoftwareColorspaceConversion(t *testing.T) {
 	tests := []struct {
@@ -529,6 +553,7 @@ func TestSourceConversionPreflightOnlyRequestsSoftwareColorspaceConversion(t *te
 		{name: "QSV", mode: ModeHardware, backend: BackendQSV},
 		{name: "VAAPI", mode: ModeHardware, backend: BackendVAAPI},
 		{name: "NVENC", mode: ModeHardware, backend: BackendNVENC},
+		{name: "VideoToolbox", mode: ModeHardware, backend: BackendVideoToolbox, wantColorspace: true},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/internal/tonemap/probe.go
+++ b/internal/tonemap/probe.go
@@ -161,18 +161,28 @@ func probeCacheEntryCurrent(entry probeCacheEntry, now time.Time) bool {
 // not make a missing configured hardware executor permanent: temporary device
 // contention must be retried after the negative-cache interval.
 func probeCapabilitiesComplete(capabilities Capabilities, hardwareBackend string) bool {
-	if len(capabilities) == 0 {
+	if !capabilityCoversAllSourceKinds(capabilities, ModeSoftware, BackendSoftware) {
 		return false
 	}
 	backend := strings.ToLower(strings.TrimSpace(hardwareBackend))
 	switch backend {
 	case BackendQSV, BackendVAAPI, BackendNVENC, BackendVideoToolbox:
-		return slices.ContainsFunc(capabilities, func(capability Capability) bool {
-			return capability.Mode == ModeHardware && capability.Backend == backend
-		})
+		return capabilityCoversAllSourceKinds(capabilities, ModeHardware, backend)
 	default:
 		return true
 	}
+}
+
+func capabilityCoversAllSourceKinds(capabilities Capabilities, mode Mode, backend string) bool {
+	index := slices.IndexFunc(capabilities, func(capability Capability) bool {
+		return capability.Mode == mode && capability.Backend == backend
+	})
+	if index < 0 {
+		return false
+	}
+	return !slices.ContainsFunc(AllSourceKinds(), func(kind SourceKind) bool {
+		return !slices.Contains(capabilities[index].SourceKinds, kind)
+	})
 }
 
 // ProbeTotalTimeout budgets one bounded deadline for every listing and smoke

--- a/internal/tonemap/probe.go
+++ b/internal/tonemap/probe.go
@@ -139,7 +139,7 @@ func probeCacheKey(ffmpegPath, hardwareBackend, hardwareDevice string) string {
 	device := strings.TrimSpace(hardwareDevice)
 	driverIdentities := make([]string, 0)
 	switch backend {
-	case BackendQSV, BackendVAAPI, BackendNVENC:
+	case BackendQSV, BackendVAAPI, BackendNVENC, BackendVideoToolbox:
 		devices := probeDevices(device, backend)
 		driverIdentities = make([]string, 0, len(devices))
 		for _, configuredDevice := range devices {
@@ -161,7 +161,7 @@ func ProbeTotalTimeout(hardwareBackend, hardwareDevice string) time.Duration {
 	commandCount := 2 + len(AllSourceKinds())
 	backend := strings.ToLower(strings.TrimSpace(hardwareBackend))
 	switch backend {
-	case BackendQSV, BackendVAAPI, BackendNVENC:
+	case BackendQSV, BackendVAAPI, BackendNVENC, BackendVideoToolbox:
 		commandCount += len(AllSourceKinds()) * len(probeDevices(hardwareDevice, backend))
 	}
 	return time.Duration(commandCount)*probeCommandTimeout + probeTimeoutSlack
@@ -261,6 +261,9 @@ func probeDevices(value, backend string) []string {
 		if backend == BackendNVENC {
 			return []string{"0"}
 		}
+		if backend == BackendVideoToolbox {
+			return []string{""}
+		}
 		return []string{defaultDRIRenderDevice}
 	}
 	return devices
@@ -288,6 +291,8 @@ func hardwareFilter(backend string) string {
 		return HardwareFilterOpenCL
 	case BackendNVENC:
 		return HardwareFilterCUDA
+	case BackendVideoToolbox:
+		return HardwareFilterVideoToolbox
 	default:
 		return HardwareFilterVAAPI
 	}
@@ -322,6 +327,8 @@ func hardwareProbeAvailable(backend string, filters, encoders []byte) bool {
 		return hasToken(filters, HardwareFilterVAAPI) && hasToken(filters, "scale_vaapi") && hasToken(encoders, "h264_vaapi")
 	case BackendNVENC:
 		return hasToken(filters, HardwareFilterCUDA) && hasToken(filters, "scale_cuda") && hasToken(encoders, "h264_nvenc")
+	case BackendVideoToolbox:
+		return hasToken(filters, HardwareFilterVideoToolbox) && hasToken(filters, "hwdownload") && hasToken(filters, "sidedata") && hasToken(encoders, "h264_videotoolbox")
 	default:
 		return false
 	}
@@ -359,7 +366,7 @@ func softwareSmokeArgs(fixturePath string, kind SourceKind, filterName string) [
 // command for one hardware backend, device, and source kind.
 func hardwareSmokeArgs(fixturePath, backend, hardwareDevice string, kind SourceKind) []string {
 	device := firstDevice(hardwareDevice)
-	if device == "" && backend != BackendNVENC {
+	if device == "" && backend != BackendNVENC && backend != BackendVideoToolbox {
 		device = defaultDRIRenderDevice
 	}
 	base := []string{ffmpegHideBannerArg, ffmpegLogLevelArg, ffmpegErrorLogLevel}
@@ -380,6 +387,8 @@ func hardwareSmokeArgs(fixturePath, backend, hardwareDevice string, kind SourceK
 			cudaDevice = "0"
 		}
 		base = append(base, "-init_hw_device", "cuda=cu:"+cudaDevice, "-filter_hw_device", "cu", "-hwaccel", "cuda", "-hwaccel_output_format", "cuda")
+	case BackendVideoToolbox:
+		base = append(base, "-hwaccel", BackendVideoToolbox, "-hwaccel_output_format", "videotoolbox_vld")
 	}
 	base = append(base,
 		"-f", codecHEVC, "-i", fixturePath,
@@ -392,6 +401,9 @@ func hardwareSmokeArgs(fixturePath, backend, hardwareDevice string, kind SourceK
 // hardwareSmokeFilter builds the backend-specific graph used to validate both
 // HDR and already-SDR Dolby Vision base layers.
 func hardwareSmokeFilter(backend string, kind SourceKind, sourceVideoBitDepth int) string {
+	if backend == BackendVideoToolbox {
+		return VideoToolboxFilter("iw", "ih") + "," + VideoToolboxDownloadFilter(sourceVideoBitDepth) + "," + HDRMetadataRemovalFilter()
+	}
 	if backend == BackendNVENC {
 		if IsSDRSource(kind) {
 			return "hwdownload,format=" + NVENCSoftwareFallbackPixelFormat(sourceVideoBitDepth) + "," + SoftwareFilter(kind, "") + ",format=nv12,hwupload_cuda"
@@ -437,6 +449,8 @@ func hardwareEncoder(backend string) string {
 		return "h264_qsv"
 	case BackendVAAPI:
 		return "h264_vaapi"
+	case BackendVideoToolbox:
+		return "h264_videotoolbox"
 	default:
 		return "h264_nvenc"
 	}

--- a/internal/tonemap/probe.go
+++ b/internal/tonemap/probe.go
@@ -7,6 +7,7 @@ import (
 	"errors"
 	"os"
 	"os/exec"
+	"slices"
 	"strings"
 	"sync"
 	"time"
@@ -34,8 +35,8 @@ const decodeProbeFixtureBase64 = "AAAAAUABDAH//wIgAAADAJAAAAMAAAMAHpWUCQAAAAFCAQ
 // output. Tests inject it to model individual FFmpeg capabilities and failures.
 type CommandRunner func(context.Context, string, ...string) ([]byte, error)
 
-// probeCacheEntry stores either a permanent positive capability result or a
-// short-lived negative result that is eligible for retry.
+// probeCacheEntry stores either a permanent complete capability result or a
+// short-lived incomplete result that is eligible for retry.
 type probeCacheEntry struct {
 	capabilities Capabilities
 	expiresAt    time.Time
@@ -79,7 +80,7 @@ func probeCached(ctx context.Context, ffmpegPath, hardwareBackend, hardwareDevic
 			return nil, err
 		}
 		entry := probeCacheEntry{capabilities: append(Capabilities(nil), result...)}
-		if len(result) == 0 {
+		if !probeCapabilitiesComplete(result, hardwareBackend) {
 			entry.expiresAt = now().Add(probeNegativeTTL)
 		}
 		probeCache.Lock()
@@ -149,10 +150,29 @@ func probeCacheKey(ffmpegPath, hardwareBackend, hardwareDevice string) string {
 	return strings.Join([]string{binaryIdentity, backend, device, strings.Join(driverIdentities, ",")}, "\x00")
 }
 
-// probeCacheEntryCurrent reports whether a positive result or unexpired
-// negative result may be reused.
+// probeCacheEntryCurrent reports whether a complete result or unexpired
+// incomplete result may be reused.
 func probeCacheEntryCurrent(entry probeCacheEntry, now time.Time) bool {
-	return len(entry.capabilities) > 0 || now.Before(entry.expiresAt)
+	return entry.expiresAt.IsZero() || now.Before(entry.expiresAt)
+}
+
+// probeCapabilitiesComplete reports whether discovery found a reusable result
+// for every executor class it was asked to inspect. A software capability does
+// not make a missing configured hardware executor permanent: temporary device
+// contention must be retried after the negative-cache interval.
+func probeCapabilitiesComplete(capabilities Capabilities, hardwareBackend string) bool {
+	if len(capabilities) == 0 {
+		return false
+	}
+	backend := strings.ToLower(strings.TrimSpace(hardwareBackend))
+	switch backend {
+	case BackendQSV, BackendVAAPI, BackendNVENC, BackendVideoToolbox:
+		return slices.ContainsFunc(capabilities, func(capability Capability) bool {
+			return capability.Mode == ModeHardware && capability.Backend == backend
+		})
+	default:
+		return true
+	}
 }
 
 // ProbeTotalTimeout budgets one bounded deadline for every listing and smoke

--- a/internal/tonemap/probe.go
+++ b/internal/tonemap/probe.go
@@ -402,7 +402,7 @@ func hardwareSmokeArgs(fixturePath, backend, hardwareDevice string, kind SourceK
 // HDR and already-SDR Dolby Vision base layers.
 func hardwareSmokeFilter(backend string, kind SourceKind, sourceVideoBitDepth int) string {
 	if backend == BackendVideoToolbox {
-		return VideoToolboxFilter("iw", "ih") + "," + VideoToolboxDownloadFilter(sourceVideoBitDepth) + "," + HDRMetadataRemovalFilter()
+		return SourceParameters(kind) + "," + VideoToolboxFilter("iw", "ih") + "," + VideoToolboxDownloadFilter(sourceVideoBitDepth) + "," + HDRMetadataRemovalFilter()
 	}
 	if backend == BackendNVENC {
 		if IsSDRSource(kind) {

--- a/internal/tonemap/probe_test.go
+++ b/internal/tonemap/probe_test.go
@@ -36,6 +36,7 @@ func TestVideoToolboxSmokeUsesHardwareFramesAndEightBitOutput(t *testing.T) {
 	for _, token := range []string{
 		"-hwaccel videotoolbox",
 		"-hwaccel_output_format videotoolbox_vld",
+		SourceParameters(SourcePQ),
 		"scale_vt=w=iw:h=ih:color_matrix=bt709:color_primaries=bt709:color_transfer=bt709",
 		"hwdownload,format=p010le,format=nv12",
 		"sidedata=mode=delete:type=DOVI_RPU_BUFFER",
@@ -44,6 +45,17 @@ func TestVideoToolboxSmokeUsesHardwareFramesAndEightBitOutput(t *testing.T) {
 		if !strings.Contains(joined, token) {
 			t.Fatalf("VideoToolbox smoke args missing %q: %s", token, joined)
 		}
+	}
+}
+
+func TestVideoToolboxSmokeDeclaresEverySourceSignal(t *testing.T) {
+	for _, kind := range AllSourceKinds() {
+		t.Run(string(kind), func(t *testing.T) {
+			filter := hardwareSmokeFilter(BackendVideoToolbox, kind, decodeProbeFixtureBitDepth)
+			if !strings.HasPrefix(filter, SourceParameters(kind)+",") {
+				t.Fatalf("hardwareSmokeFilter() = %q, want source declaration %q first", filter, SourceParameters(kind))
+			}
+		})
 	}
 }
 

--- a/internal/tonemap/probe_test.go
+++ b/internal/tonemap/probe_test.go
@@ -179,6 +179,53 @@ func TestProbePartialHardwareCapabilitiesExpire(t *testing.T) {
 	}
 }
 
+func TestProbeIncompleteSourceKindCapabilitiesExpire(t *testing.T) {
+	resetProbeCache(t)
+	now := time.Unix(100, 0)
+	allKindsReady := false
+	calls := 0
+	runner := func(_ context.Context, _ string, args ...string) ([]byte, error) {
+		calls++
+		if len(args) > 0 && args[len(args)-1] == "-filters" {
+			return []byte(" .S. zscale V->V\n .S. tonemap V->V\n .S. scale_vt V->V\n .S. hwdownload V->V\n .S. sidedata V->V\n"), nil
+		}
+		if len(args) > 0 && args[len(args)-1] == "-encoders" {
+			return []byte("libx264 h264_videotoolbox"), nil
+		}
+		if !allKindsReady && strings.Contains(strings.Join(args, " "), SourceParameters(SourceHLGBT709)) {
+			return nil, errors.New("executor session temporarily unavailable")
+		}
+		return nil, nil
+	}
+
+	got, err := probeCached(t.Context(), "/ffmpeg-subset", BackendVideoToolbox, "", runner, func() time.Time { return now })
+	if err != nil {
+		t.Fatalf("subset probe error = %v", err)
+	}
+	if len(got) != 2 || !got.Supports(ModeSoftware, SourcePQ) || !got.Supports(ModeHardware, SourcePQ) ||
+		got.Supports(ModeSoftware, SourceHLGBT709) || got.Supports(ModeHardware, SourceHLGBT709) {
+		t.Fatalf("subset probe = %#v, want both executors without HLG BT.709", got)
+	}
+	firstCalls := calls
+	allKindsReady = true
+	got, err = probeCached(t.Context(), "/ffmpeg-subset", BackendVideoToolbox, "", runner, func() time.Time { return now })
+	if err != nil {
+		t.Fatalf("cached subset probe error = %v", err)
+	}
+	if calls != firstCalls || got.Supports(ModeSoftware, SourceHLGBT709) || got.Supports(ModeHardware, SourceHLGBT709) {
+		t.Fatalf("subset probe was not cached until expiry: calls = %d, capabilities = %#v", calls, got)
+	}
+
+	now = now.Add(probeNegativeTTL + time.Second)
+	got, err = probeCached(t.Context(), "/ffmpeg-subset", BackendVideoToolbox, "", runner, func() time.Time { return now })
+	if err != nil {
+		t.Fatalf("retried subset probe error = %v", err)
+	}
+	if calls == firstCalls || !got.Supports(ModeSoftware, SourceHLGBT709) || !got.Supports(ModeHardware, SourceHLGBT709) {
+		t.Fatalf("expired subset probe was not retried: calls = %d, capabilities = %#v", calls, got)
+	}
+}
+
 func TestProbeCommandDeadlineIsTransientAndNotCached(t *testing.T) {
 	resetProbeCache(t)
 	calls := 0

--- a/internal/tonemap/probe_test.go
+++ b/internal/tonemap/probe_test.go
@@ -133,6 +133,52 @@ func TestProbeEmptyCapabilitiesExpire(t *testing.T) {
 	}
 }
 
+func TestProbePartialHardwareCapabilitiesExpire(t *testing.T) {
+	resetProbeCache(t)
+	now := time.Unix(100, 0)
+	hardwareReady := false
+	calls := 0
+	runner := func(_ context.Context, _ string, args ...string) ([]byte, error) {
+		calls++
+		if len(args) > 0 && args[len(args)-1] == "-filters" {
+			return []byte(" .S. zscale V->V\n .S. tonemap V->V\n .S. scale_vt V->V\n .S. hwdownload V->V\n .S. sidedata V->V\n"), nil
+		}
+		if len(args) > 0 && args[len(args)-1] == "-encoders" {
+			return []byte("libx264 h264_videotoolbox"), nil
+		}
+		if strings.Contains(strings.Join(args, " "), "-hwaccel videotoolbox") && !hardwareReady {
+			return nil, errors.New("VideoToolbox session temporarily unavailable")
+		}
+		return nil, nil
+	}
+
+	got, err := probeCached(t.Context(), "/ffmpeg-partial", BackendVideoToolbox, "", runner, func() time.Time { return now })
+	if err != nil {
+		t.Fatalf("partial probe error = %v", err)
+	}
+	if len(got) != 1 || !got.Supports(ModeSoftware, SourcePQ) || got.Supports(ModeHardware, SourcePQ) {
+		t.Fatalf("partial probe = %#v, want software only", got)
+	}
+	firstCalls := calls
+	hardwareReady = true
+	got, err = probeCached(t.Context(), "/ffmpeg-partial", BackendVideoToolbox, "", runner, func() time.Time { return now })
+	if err != nil {
+		t.Fatalf("cached partial probe error = %v", err)
+	}
+	if calls != firstCalls || got.Supports(ModeHardware, SourcePQ) {
+		t.Fatalf("partial probe was not cached until expiry: calls = %d, capabilities = %#v", calls, got)
+	}
+
+	now = now.Add(probeNegativeTTL + time.Second)
+	got, err = probeCached(t.Context(), "/ffmpeg-partial", BackendVideoToolbox, "", runner, func() time.Time { return now })
+	if err != nil {
+		t.Fatalf("retried partial probe error = %v", err)
+	}
+	if calls == firstCalls || !got.Supports(ModeHardware, SourcePQ) {
+		t.Fatalf("expired partial probe was not retried: calls = %d, capabilities = %#v", calls, got)
+	}
+}
+
 func TestProbeCommandDeadlineIsTransientAndNotCached(t *testing.T) {
 	resetProbeCache(t)
 	calls := 0

--- a/internal/tonemap/probe_test.go
+++ b/internal/tonemap/probe_test.go
@@ -30,6 +30,34 @@ func TestHardwareSmokeFilterNVENCPreservesSourceBitDepth(t *testing.T) {
 	}
 }
 
+func TestVideoToolboxSmokeUsesHardwareFramesAndEightBitOutput(t *testing.T) {
+	args := hardwareSmokeArgs("/tmp/probe.hevc", BackendVideoToolbox, "", SourcePQ)
+	joined := strings.Join(args, " ")
+	for _, token := range []string{
+		"-hwaccel videotoolbox",
+		"-hwaccel_output_format videotoolbox_vld",
+		"scale_vt=w=iw:h=ih:color_matrix=bt709:color_primaries=bt709:color_transfer=bt709",
+		"hwdownload,format=p010le,format=nv12",
+		"sidedata=mode=delete:type=DOVI_RPU_BUFFER",
+		"-c:v h264_videotoolbox",
+	} {
+		if !strings.Contains(joined, token) {
+			t.Fatalf("VideoToolbox smoke args missing %q: %s", token, joined)
+		}
+	}
+}
+
+func TestVideoToolboxListingGateRequiresCompletePipeline(t *testing.T) {
+	filters := []byte("scale_vt hwdownload sidedata")
+	encoders := []byte("h264_videotoolbox")
+	if !hardwareProbeAvailable(BackendVideoToolbox, filters, encoders) {
+		t.Fatal("complete VideoToolbox pipeline was not accepted")
+	}
+	if hardwareProbeAvailable(BackendVideoToolbox, []byte("scale_vt hwdownload"), encoders) {
+		t.Fatal("VideoToolbox pipeline without metadata removal was accepted")
+	}
+}
+
 // TestProbeTotalTimeoutCoversBoundedCommandMatrix verifies the deadline covers every possible probe command.
 func TestProbeTotalTimeoutCoversBoundedCommandMatrix(t *testing.T) {
 	tests := []struct {
@@ -41,6 +69,7 @@ func TestProbeTotalTimeoutCoversBoundedCommandMatrix(t *testing.T) {
 		{name: "software", backend: BackendSoftware, count: 7},
 		{name: "one hardware device", backend: BackendQSV, device: "/dev/dri/renderD128", count: 12},
 		{name: "two hardware devices", backend: BackendVAAPI, device: "/dev/dri/renderD128,/dev/dri/renderD129", count: 17},
+		{name: "VideoToolbox", backend: BackendVideoToolbox, count: 12},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/internal/tonemap/tonemap.go
+++ b/internal/tonemap/tonemap.go
@@ -4,6 +4,7 @@ package tonemap
 
 import (
 	"bytes"
+	"cmp"
 	"slices"
 	"strings"
 
@@ -11,16 +12,18 @@ import (
 )
 
 const (
-	SoftwareFilterBT2390 = "tonemapx"
-	SoftwareFilterHable  = "tonemap"
-	HardwareFilterOpenCL = "tonemap_opencl"
-	HardwareFilterVAAPI  = "tonemap_vaapi"
-	HardwareFilterCUDA   = "tonemap_cuda"
+	SoftwareFilterBT2390       = "tonemapx"
+	SoftwareFilterHable        = "tonemap"
+	HardwareFilterOpenCL       = "tonemap_opencl"
+	HardwareFilterVAAPI        = "tonemap_vaapi"
+	HardwareFilterCUDA         = "tonemap_cuda"
+	HardwareFilterVideoToolbox = "scale_vt"
 
-	BackendSoftware = "software"
-	BackendQSV      = "qsv"
-	BackendVAAPI    = "vaapi"
-	BackendNVENC    = "nvenc"
+	BackendSoftware     = "software"
+	BackendQSV          = "qsv"
+	BackendVAAPI        = "vaapi"
+	BackendNVENC        = "nvenc"
+	BackendVideoToolbox = "videotoolbox"
 
 	DynamicRangeHDRUnknown  = "hdr_unknown"
 	DynamicRangeSDR         = "sdr"
@@ -649,6 +652,43 @@ func vaapiSDRFilter() string {
 // enhancement processing disabled so the validated base layer is used.
 func CUDAFilter() string {
 	return HardwareFilterCUDA + "=tonemap=bt2390:format=nv12:p=bt709:t=bt709:m=bt709:r=tv:apply_dovi=0"
+}
+
+// VideoToolboxFilter builds Apple's HDR-to-SDR pixel-transfer conversion.
+// VTPixelTransferSession performs tone mapping when HDR source attachments are
+// converted to the BT.709 destination properties. The output surface retains
+// the decoded bit depth, so callers must download it with
+// VideoToolboxDownloadFilter before an 8-bit H.264 encode.
+func VideoToolboxFilter(width, height string) string {
+	width = cmp.Or(strings.TrimSpace(width), "iw")
+	height = cmp.Or(strings.TrimSpace(height), "ih")
+	return HardwareFilterVideoToolbox + "=w=" + width + ":h=" + height + ":color_matrix=bt709:color_primaries=bt709:color_transfer=bt709"
+}
+
+// VideoToolboxDownloadFilter moves the converted IOSurface to system memory
+// and normalizes it to the 8-bit NV12 format accepted by the H.264 encoder and
+// CPU subtitle filters. scale_vt preserves its input surface depth.
+func VideoToolboxDownloadFilter(sourceVideoBitDepth int) string {
+	format := videoToolboxSurfacePixelFormat(sourceVideoBitDepth)
+	filter := "hwdownload,format=" + format
+	if format == "p010le" {
+		filter += ",format=nv12"
+	}
+	return filter
+}
+
+// VideoToolboxUploadFilter gives software-decoded frames the complete source
+// signal attachments that VTPixelTransferSession consumes before uploading
+// them to an IOSurface.
+func VideoToolboxUploadFilter(kind SourceKind, sourceVideoBitDepth int) string {
+	return SourceParameters(kind) + ",format=" + videoToolboxSurfacePixelFormat(sourceVideoBitDepth) + ",hwupload"
+}
+
+func videoToolboxSurfacePixelFormat(sourceVideoBitDepth int) string {
+	if sourceVideoBitDepth > 0 && sourceVideoBitDepth <= 8 {
+		return "nv12"
+	}
+	return "p010le"
 }
 
 // QSVInteropFilter normalizes the VAAPI tone-map surface before deriving the

--- a/internal/transcodenode/server.go
+++ b/internal/transcodenode/server.go
@@ -1122,7 +1122,7 @@ func (s *Server) handleStart(w http.ResponseWriter, r *http.Request) {
 			// alternate render device to move to), so a hardware encoder
 			// session this Mac cannot create does not fail clustered
 			// playback while CPU encoding was available.
-			retryAccel := playback.StartupRetryHWAccel(opts.HWAccel, opts.FFmpegPath)
+			retryAccel := playback.StartupRetryHWAccel(opts)
 			if wasRunning || retryAccel == opts.HWAccel {
 				unlock()
 				slog.ErrorContext(r.Context(), "transcode failed readiness check", "component", "transcodenode", "error", err, "session", req.SessionID, "playback_session_id", req.SessionID)
@@ -1415,7 +1415,7 @@ func (s *Server) spawnReconstruct(r *http.Request, sessionID string, requestedSe
 	// media as permanently missing. Mirror handleStart's software retry for
 	// the accel StartupRetryHWAccel would change; other accels keep the
 	// existing register-immediately behavior.
-	if retryAccel := playback.StartupRetryHWAccel(opts.HWAccel, opts.FFmpegPath); retryAccel != opts.HWAccel {
+	if retryAccel := playback.StartupRetryHWAccel(opts); retryAccel != opts.HWAccel {
 		if _, waitErr := session.WaitForManifest(playback.ManifestStartupTimeout); waitErr != nil {
 			if session.IsRunning() {
 				slog.WarnContext(r.Context(), "reconstructed transcode slow to produce a manifest", "component", "transcodenode",

--- a/internal/transcodenode/server.go
+++ b/internal/transcodenode/server.go
@@ -1115,11 +1115,38 @@ func (s *Server) handleStart(w http.ResponseWriter, r *http.Request) {
 	}
 	if req.RequireReady {
 		if _, err := session.WaitForManifest(TranscodeStartReadinessTimeout); err != nil {
+			wasRunning := session.IsRunning()
 			_ = session.Close()
-			unlock()
-			slog.ErrorContext(r.Context(), "transcode failed readiness check", "component", "transcodenode", "error", err, "session", req.SessionID, "playback_session_id", req.SessionID)
-			http.Error(w, "transcode did not become ready", http.StatusInternalServerError)
-			return
+			// Mirror the API server's local-transport retry: an early death
+			// under VideoToolbox retries once in software (there is no
+			// alternate render device to move to), so a hardware encoder
+			// session this Mac cannot create does not fail clustered
+			// playback while CPU encoding was available.
+			retryAccel := playback.StartupRetryHWAccel(opts.HWAccel, opts.FFmpegPath)
+			if wasRunning || retryAccel == opts.HWAccel {
+				unlock()
+				slog.ErrorContext(r.Context(), "transcode failed readiness check", "component", "transcodenode", "error", err, "session", req.SessionID, "playback_session_id", req.SessionID)
+				http.Error(w, "transcode did not become ready", http.StatusInternalServerError)
+				return
+			}
+			slog.WarnContext(r.Context(), "transcode crashed during startup; retrying with software encoding",
+				"component", "transcodenode", "error", err, "session", req.SessionID, "playback_session_id", req.SessionID)
+			retryOpts := opts
+			retryOpts.HWAccel = retryAccel
+			session, err = playback.StartTranscode(context.WithoutCancel(r.Context()), retryOpts)
+			if err != nil {
+				unlock()
+				slog.ErrorContext(r.Context(), "start transcode retry", "component", "transcodenode", "error", err, "session", req.SessionID, "playback_session_id", req.SessionID)
+				http.Error(w, "failed to start transcode", http.StatusInternalServerError)
+				return
+			}
+			if _, retryErr := session.WaitForManifest(TranscodeStartReadinessTimeout); retryErr != nil {
+				_ = session.Close()
+				unlock()
+				slog.ErrorContext(r.Context(), "transcode failed readiness check", "component", "transcodenode", "error", retryErr, "session", req.SessionID, "playback_session_id", req.SessionID)
+				http.Error(w, "transcode did not become ready", http.StatusInternalServerError)
+				return
+			}
 		}
 	}
 

--- a/internal/transcodenode/server.go
+++ b/internal/transcodenode/server.go
@@ -1409,6 +1409,34 @@ func (s *Server) spawnReconstruct(r *http.Request, sessionID string, requestedSe
 		return nil, err
 	}
 
+	// Readiness is normally the caller's concern, but a VideoToolbox session
+	// can die at encoder init (e.g. a session the hardware cannot create at
+	// these dimensions), and registering the dead session would serve this
+	// media as permanently missing. Mirror handleStart's software retry for
+	// the accel StartupRetryHWAccel would change; other accels keep the
+	// existing register-immediately behavior.
+	if retryAccel := playback.StartupRetryHWAccel(opts.HWAccel, opts.FFmpegPath); retryAccel != opts.HWAccel {
+		if _, waitErr := session.WaitForManifest(playback.ManifestStartupTimeout); waitErr != nil {
+			if session.IsRunning() {
+				slog.WarnContext(r.Context(), "reconstructed transcode slow to produce a manifest", "component", "transcodenode",
+					"error", waitErr, "session", sessionID, "playback_session_id", sessionID)
+			} else {
+				// Keep the shared output directory: the retry writes into it.
+				_ = session.CloseProcess()
+				slog.WarnContext(r.Context(), "reconstructed transcode crashed during startup; retrying with software encoding",
+					"component", "transcodenode", "error", waitErr, "session", sessionID, "playback_session_id", sessionID)
+				retryOpts := opts
+				retryOpts.HWAccel = retryAccel
+				session, err = playback.StartTranscode(context.WithoutCancel(r.Context()), retryOpts)
+				if err != nil {
+					slog.ErrorContext(r.Context(), "transcode node reconstruct retry failed", "component", "transcodenode", "error", err,
+						"session", sessionID, "playback_session_id", sessionID)
+					return nil
+				}
+			}
+		}
+	}
+
 	// Yield to a winner registered by another path; close only the duplicate ffmpeg,
 	// never the shared output directory the winner is actively serving.
 	s.mu.Lock()

--- a/internal/transcodenode/server.go
+++ b/internal/transcodenode/server.go
@@ -1431,7 +1431,7 @@ func (s *Server) spawnReconstruct(r *http.Request, sessionID string, requestedSe
 				if err != nil {
 					slog.ErrorContext(r.Context(), "transcode node reconstruct retry failed", "component", "transcodenode", "error", err,
 						"session", sessionID, "playback_session_id", sessionID)
-					return nil
+					return nil, err
 				}
 			}
 		}

--- a/internal/transcodenode/server.go
+++ b/internal/transcodenode/server.go
@@ -1433,6 +1433,12 @@ func (s *Server) spawnReconstruct(r *http.Request, sessionID string, requestedSe
 						"session", sessionID, "playback_session_id", sessionID)
 					return nil, err
 				}
+				if _, retryErr := session.WaitForManifest(playback.ManifestStartupTimeout); retryErr != nil {
+					_ = session.Close()
+					slog.ErrorContext(r.Context(), "reconstructed software retry failed readiness check", "component", "transcodenode", "error", retryErr,
+						"session", sessionID, "playback_session_id", sessionID)
+					return nil, retryErr
+				}
 			}
 		}
 	}

--- a/internal/transcodenode/server_test.go
+++ b/internal/transcodenode/server_test.go
@@ -2003,6 +2003,58 @@ func TestCopyModeReconstruct_SkipsFastSeek(t *testing.T) {
 	}
 }
 
+func TestSpawnReconstructDoesNotRegisterFailedSoftwareRetry(t *testing.T) {
+	server := newTestServer(t)
+	dir := t.TempDir()
+	ffmpegPath := filepath.Join(dir, "ffmpeg")
+	logPath := filepath.Join(dir, "invocations.log")
+	script := "#!/bin/sh\n" +
+		"printf '%s\\n' \"$*\" >> " + logPath + "\n" +
+		"case \"$*\" in\n" +
+		"  *-hwaccels*) echo videotoolbox; exit 0 ;;\n" +
+		"  *-encoders*) echo ' V..... h264_videotoolbox x'; exit 0 ;;\n" +
+		"  *videotoolbox*'-f null'*) exit 0 ;;\n" +
+		"  *) exit 1 ;;\n" +
+		"esac\n"
+	if err := os.WriteFile(ffmpegPath, []byte(script), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	cfg := server.watcher.Config()
+	cfg.Playback.FFmpegPath = ffmpegPath
+	cfg.Playback.HWAccel = tonemap.BackendVideoToolbox
+
+	const sessionID = "failed-reconstruct-retry"
+	card := playback.NewRecipeCard(7, "profile-1", 42, "", playback.TranscodeOpts{
+		SessionID: sessionID, InputPath: "/media/movie.mkv",
+		TargetCodecVideo: "h264", TargetCodecAudio: "aac", TargetResolution: "720p", TargetBitrateKbps: 2000,
+		SegmentDuration: 2,
+	})
+	session, err := server.spawnReconstruct(httptest.NewRequest(http.MethodGet, "/", nil), sessionID, -1, card)
+	if session != nil {
+		_ = session.Close()
+		t.Fatal("failed software retry returned a session")
+	}
+	if err == nil {
+		t.Fatal("failed software retry returned no error")
+	}
+	server.mu.RLock()
+	_, registered := server.sessions[sessionID]
+	server.mu.RUnlock()
+	if registered {
+		t.Fatal("failed software retry was registered")
+	}
+	logData, readErr := os.ReadFile(logPath)
+	if readErr != nil {
+		t.Fatal(readErr)
+	}
+	if got := strings.Count(string(logData), "-f hls"); got != 2 {
+		t.Fatalf("real transcode attempts = %d, want hardware plus software retry:\n%s", got, logData)
+	}
+	if !strings.Contains(string(logData), "libx264") {
+		t.Fatalf("reconstruction did not attempt the software retry:\n%s", logData)
+	}
+}
+
 // A fresh /transcode/start must resolve this node's configured hw_device list
 // through the shared GPU pool — the same path reconstruction uses — rather
 // than bypassing it with an empty device.

--- a/web/src/pages/admin-settings/PlaybackSettings.test.tsx
+++ b/web/src/pages/admin-settings/PlaybackSettings.test.tsx
@@ -1,7 +1,22 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
 import { renderToStaticMarkup } from "react-dom/server";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 import PlaybackSettings from "./PlaybackSettings";
+
+class ResizeObserverStub {
+  observe() {}
+  unobserve() {}
+  disconnect() {}
+}
+globalThis.ResizeObserver ??= ResizeObserverStub as unknown as typeof ResizeObserver;
+if (!window.HTMLElement.prototype.hasPointerCapture) {
+  window.HTMLElement.prototype.hasPointerCapture = () => false;
+}
+if (!window.HTMLElement.prototype.scrollIntoView) {
+  window.HTMLElement.prototype.scrollIntoView = () => {};
+}
 
 const useSettingsFormMock = vi.fn();
 const useHWAccelDetectionMock = vi.fn();
@@ -62,6 +77,15 @@ describe("PlaybackSettings CPU tone mapping", () => {
     );
     expect(toggle).toHaveAttribute("aria-checked", "false");
     expect(toggle).not.toHaveAttribute("disabled");
+  });
+
+  it("offers VideoToolbox hardware acceleration", async () => {
+    useSettingsFormMock.mockReturnValue(makeForm({ "playback.hw_accel": "auto" }));
+
+    render(<PlaybackSettings />);
+    await userEvent.click(screen.getByRole("combobox", { name: "Hardware Acceleration" }));
+
+    expect(screen.getByRole("option", { name: "VideoToolbox (macOS)" })).toBeInTheDocument();
   });
 
   it("disables the toggle while HDR chapter thumbnails are disabled", () => {

--- a/web/src/pages/admin-settings/PlaybackSettings.tsx
+++ b/web/src/pages/admin-settings/PlaybackSettings.tsx
@@ -300,6 +300,8 @@ function formatResolved(resolved: string): string {
       return "VA-API";
     case "nvenc":
       return "NVIDIA NVENC";
+    case "videotoolbox":
+      return "VideoToolbox (macOS)";
     case "none":
       return "Software";
     default:

--- a/web/src/pages/admin-settings/PlaybackSettings.tsx
+++ b/web/src/pages/admin-settings/PlaybackSettings.tsx
@@ -80,6 +80,7 @@ export default function PlaybackSettings() {
               { value: "qsv", label: "Intel Quick Sync (QSV)" },
               { value: "vaapi", label: "VA-API" },
               { value: "nvenc", label: "NVIDIA NVENC" },
+              { value: "videotoolbox", label: "VideoToolbox (macOS)" },
               { value: "none", label: "Software" },
             ]}
             value={form.getValue("playback.hw_accel")}

--- a/web/src/pages/adminActivityPresentation.test.ts
+++ b/web/src/pages/adminActivityPresentation.test.ts
@@ -151,6 +151,9 @@ describe("adminActivityPresentation", () => {
     expect(formatTranscodeModeSummary(makeSession({ transcode_hw_accel: "nvenc" }))).toBe(
       "HW NVENC",
     );
+    expect(formatTranscodeModeSummary(makeSession({ transcode_hw_accel: "videotoolbox" }))).toBe(
+      "HW VideoToolbox",
+    );
     expect(formatTranscodeModeSummary(makeSession({ transcode_hw_accel: "none" }))).toBe("SW");
     expect(
       formatTranscodeModeSummary(

--- a/web/src/pages/adminActivityPresentation.ts
+++ b/web/src/pages/adminActivityPresentation.ts
@@ -213,6 +213,8 @@ export function formatTranscodeModeSummary(session: AdminSession): string | null
       return "HW QSV";
     case "vaapi":
       return "HW VAAPI";
+    case "videotoolbox":
+      return "HW VideoToolbox";
     case "none":
       return "SW";
     case "auto":

--- a/web/src/pages/setup-wizard/steps/ServerStorageStep.test.tsx
+++ b/web/src/pages/setup-wizard/steps/ServerStorageStep.test.tsx
@@ -5,6 +5,17 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 
 import { ServerStorageStep } from "./ServerStorageStep";
 
+class ResizeObserverStub {
+  observe() {}
+  unobserve() {}
+  disconnect() {}
+}
+globalThis.ResizeObserver ??= ResizeObserverStub as unknown as typeof ResizeObserver;
+if (!window.HTMLElement.prototype.hasPointerCapture) {
+  window.HTMLElement.prototype.hasPointerCapture = () => false;
+  window.HTMLElement.prototype.scrollIntoView = () => {};
+}
+
 const useSettingsFormMock = vi.fn();
 const useWizardContextMock = vi.fn();
 const useCheckAdminSettingsConnectionMock = vi.fn();
@@ -120,6 +131,15 @@ describe("ServerStorageStep", () => {
     expect(markup).toContain("Pinned Web version");
     expect(markup).toContain("Web install directory");
     expect(markup).toContain("/var/lib/silo/compat/jellyfin-web");
+  });
+
+  it("offers VideoToolbox hardware acceleration during setup", async () => {
+    mockStep();
+
+    render(<ServerStorageStep />);
+    await userEvent.click(screen.getByRole("combobox", { name: "Hardware accel" }));
+
+    expect(screen.getByRole("option", { name: "VideoToolbox (macOS)" })).toBeInTheDocument();
   });
 
   it("uses Jellyfin runtime status when the explicit enabled setting is missing", () => {

--- a/web/src/pages/setup-wizard/steps/ServerStorageStep.test.tsx
+++ b/web/src/pages/setup-wizard/steps/ServerStorageStep.test.tsx
@@ -13,6 +13,8 @@ class ResizeObserverStub {
 globalThis.ResizeObserver ??= ResizeObserverStub as unknown as typeof ResizeObserver;
 if (!window.HTMLElement.prototype.hasPointerCapture) {
   window.HTMLElement.prototype.hasPointerCapture = () => false;
+}
+if (!window.HTMLElement.prototype.scrollIntoView) {
   window.HTMLElement.prototype.scrollIntoView = () => {};
 }
 

--- a/web/src/pages/setup-wizard/steps/ServerStorageStep.tsx
+++ b/web/src/pages/setup-wizard/steps/ServerStorageStep.tsx
@@ -342,6 +342,7 @@ export function ServerStorageStep() {
                 <SelectItem value="auto">Auto</SelectItem>
                 <SelectItem value="vaapi">VAAPI</SelectItem>
                 <SelectItem value="nvenc">NVENC</SelectItem>
+                <SelectItem value="videotoolbox">VideoToolbox (macOS)</SelectItem>
                 <SelectItem value="qsv">QSV</SelectItem>
                 <SelectItem value="none">None</SelectItem>
               </SelectContent>


### PR DESCRIPTION
## Problem

Silo has no hardware transcoding on macOS: `ResolveHWAccelWithFFmpeg` hard-returns `"none"` on non-Linux, and the transcode arg builder only implements `qsv`/`vaapi`/`nvenc` — so a Mac (including a native `--mode transcode` node) always burns CPU on x264/x265 despite Apple Silicon's media engine. Confirmed missing by inspection: `h264_videotoolbox` was already listed in the V3 encoder capability list but was never selectable.

## Approach

VideoToolbox reaches ffmpeg through stock flags, so this is pure Go-side plumbing following the existing NVENC/QSV templates:

- **Detection** (`gpudetect.go`): on `darwin`, `auto` probes the configured ffmpeg — `videotoolbox` hwaccel + both encoders present, then a one-frame smoke encode **per encoder in the exact constant-quality (`-q:v`) mode the uncapped path emits**. That last detail is load-bearing: `-q:v` needs an Apple Silicon compression session, so Intel Macs fail the probe and resolve to software instead of being approved for commands that would error at runtime. Results cached per ffmpeg path, mirroring the NVENC probe. Explicit `hw_accel=videotoolbox` bypasses probing, same as explicit `nvenc`.
- **Transcode args** (`transcode.go`): `-hwaccel videotoolbox` decode **with software output frames** — the entire existing CPU filter graph (scaling, text and bitmap subtitle burn-in) applies unchanged, sidestepping `scale_vt` availability and tone-mapping gaps; HW decode + HW encode carries nearly all the win. Encoders: `h264_videotoolbox` (forced 8-bit + high profile for browser MSE, like libx264) and `hevc_videotoolbox` (no forced pix_fmt → p010/HDR10 passthrough, like the other HW HEVC paths); bitrate-capped VBR or `-q:v` constant-quality; GOP forcing on segment boundaries like the other HW encoders; no x264-style `-preset`.
- **Chapter thumbnails**: no longer touched by this PR — main's own extractor refactor (`supportsHardwareFrameExtract` + the probing software tone-map resolver) landed while this branch was in review and supersedes the earlier chapterthumbs changes here: on macOS, `videotoolbox` now routes to the software extraction path with proper retry/tone-map handling out of the box. (A VideoToolbox decode-assist case for extraction remains possible as a small follow-up.)
- **UI**: `videotoolbox` option in the admin Playback settings and setup wizard dropdowns. V3 transformations needed no change (encoder already listed); the sessions Activity pill renders `HW VIDEOTOOLBOX` via its default branch.

`resolveEffectiveTranscodeHWAccel` downgrades (copy-video, MPEG-4 Part 2) apply to VideoToolbox unchanged.

## Verification

- New tests: darwin auto-resolution (success / probe-fail / missing-HEVC-encoder / smoke-fail → none), probe log asserts both `-q:v` smoke commands, explicit-value bypass; transcode args (software scale + no `-hwaccel_output_format`, encoder/rate-control flags, GOP forcing, 8-bit h264 vs unforced hevc, burn-in stays on CPU filters); chapterthumbs (HW decode without hw round-trip, HDR uses shared CPU tone-map chain).
- `GOWORK=off go test ./internal/playback/ ./internal/chapterthumbs/` — ok. Full `go build ./...` ok. golangci-lint: no findings in touched files. `make verify-local-paths` clean.
- Web: lint 0 errors, format clean, build ok, tests 1296 passed (7 failures are the known pre-existing baseline, reproduced on clean main).
- Not yet run on physical Apple Silicon hardware — the smoke-probe design means a misdetecting machine degrades to software rather than failing playback, but a hands-on pass on an M-series Mac before relying on it is recommended (see Risks).

## Adversarial review

2 iterations (Codex, `--base main`). Iteration 1 findings all fixed: Intel-Mac `-q:v` failure → probe now exercises the exact uncapped commands; chapterthumbs misclassifying CPU args as a hardware attempt → real videotoolbox case; HEVC session never verified → per-encoder smoke encodes. Iteration 2 findings rebutted with reasons:
- *Transient probe failures cached for process lifetime / no single-flight* — exact parity with the shipped NVENC probe's semantics; improving cache policy is a follow-up covering both probes.
- *No CPU fallback for failed HDR thumbnail attempts* — the codebase never offers CPU HDR tone-map as a fallback (VAAPI HDR failures also return immediately; the no-accel path refuses HDR outright). This PR makes macOS HDR thumbs strictly better (one HW-decode attempt vs. unconditional `tonemap_unsupported` before); adding a CPU-HDR fallback is a deliberate perf/product decision out of scope.
- *`hw_killed` shadows `hw_timeout` in error classification* — pre-existing classifier lines, untouched, affects VAAPI/QSV identically; logs-only impact.

## Risks & follow-up

- Requires a **native macOS process** with a videotoolbox-enabled ffmpeg (Homebrew default) — Docker on Mac cannot reach the GPU; docs should recommend the native transcode-node topology.
- Hardware validation on Apple Silicon still to be done (encode quality eyeball, HDR passthrough, multi-session load); failure mode is graceful (software fallback).
- Follow-up (tracked as a task): probe-cache TTL/single-flight for both NVENC and VideoToolbox probes.
- **Validated on Apple Silicon** (M-series, Homebrew ffmpeg 8.0.1): auto-detection resolves `videotoolbox` (0.36s probe), the exact builder-emitted commands produce valid HLS — h264 1080p→720p at ~15× realtime (High profile, yuv420p), hevc 10-bit→10-bit passthrough at ~7× realtime. An earlier zscale-availability caveat for HDR chapter thumbnails no longer applies: main's tone-map filter resolver probes the ffmpeg build and picks a supported chain.
- No client (silo-android/silo-apple) impact — server-side transcoding only; the settings enum is additive.

Closes #438

## AI-use disclosure
Implemented by Claude Code (issue-to-pr flow) with human oversight; adversarially reviewed by Codex.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added VideoToolbox (macOS) hardware acceleration for playback, transcoding, and chapter thumbnail extraction.
  * Added VideoToolbox options to playback settings and the setup wizard.
* **Improvements**
  * Enhanced automatic macOS hardware detection with capability checks and safe fallback behavior.
  * Improved HDR-to-SDR tone mapping, subtitle burn-in, and HLS segment alignment with VideoToolbox.
  * Improved macOS FFmpeg discovery, including Homebrew installations.
* **Documentation**
  * Added macOS setup guidance for FFmpeg and VideoToolbox.
* **Tests**
  * Added coverage for detection, transcoding, thumbnails, tone mapping, and subtitle burn-in.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

