### PR TITLE
feat(reader): chapter navigation, appearance system, and reading stats

### DIFF
--- a/cmd/silo/main.go
+++ b/cmd/silo/main.go
@@ -137,6 +137,13 @@ func resolvePluginCacheDir() string {
 	return filepath.Join(os.TempDir(), "silo-plugins")
 }
 
+func resolveReaderFontsDir() string {
+	if v := strings.TrimSpace(os.Getenv("SILO_READER_FONTS_DIR")); v != "" {
+		return v
+	}
+	return "/var/lib/silo/reader-fonts"
+}
+
 func buildBaseHandler(format string, level slog.Leveler, otelHandler slog.Handler) slog.Handler {
 	opts := &slog.HandlerOptions{Level: level}
 	var console slog.Handler
@@ -751,6 +758,7 @@ func main() {
 		OpsLogRepo:                   opsRepo,
 		FFmpegLogSink:                playback.NewSlogFFmpegLogSink(slog.Default(), nodeID),
 		PublicURL:                    os.Getenv("SILO_PUBLIC_URL"),
+		ReaderFontsDir:               resolveReaderFontsDir(),
 		RequestServerRestart: func(context.Context) error {
 			if !restartRequested.CompareAndSwap(false, true) {
 				return handlers.ErrServerRestartAlreadyRequested

--- a/docs/superpowers/plans/2026-07-20-reader-appearance.md
+++ b/docs/superpowers/plans/2026-07-20-reader-appearance.md
@@ -1,0 +1,657 @@
+# Reader Appearance Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Ten paired-palette reader themes with an independent light/dark toggle, per-profile custom font uploads, 1–4 columns with gap control, and a justification toggle.
+
+**Architecture:** A pure palette module (`readerThemes.ts`) feeds the existing `readerStyles`/`readerColors` pipeline in `FoliateBookReader.tsx`; settings gain `themeName`/`themeVariant`/`columns`/`columnGap`/`justify` with legacy migration in `normalizeReaderSettings`. Fonts are a small Go feature beside the existing reader handlers: a `reader_fonts` table + filesystem blobs under `SILO_READER_FONTS_DIR`, four routes in the `/ebooks` group, and client `@font-face` injection through `renderer.setStyles`.
+
+**Tech Stack:** React 19 + TypeScript + vitest; Go + chi + pgx + Goose migrations.
+
+## Global Constraints
+
+- Spec: `docs/superpowers/specs/2026-07-20-reader-appearance-design.md` — binding values live there; re-read before starting.
+- Themes: Default, Sepia, Gray, Dawnlight, Ember, Aurora, Ocean, Meadow, Rosewood, AMOLED (dark-only; variant toggle disabled). Palette hexes in Task 1 are the approved values — copy verbatim.
+- Legacy mapping: `light → Default/light`, `sepia → Sepia/light`, `dark → Default/dark`; unknown → Default/light. Keep writing legacy `theme` ("light"|"sepia"|"dark", from themeVariant + Sepia special-case: Sepia/light → "sepia", any dark → "dark", else "light").
+- Fonts: `.ttf/.otf/.woff/.woff2`, magic-byte validation (sfnt `00 01 00 00` or `OTTO`, `wOFF`, `wOF2`), 5 MB/file, 10 fonts/profile, scoped user_id+profile_id, routes inside the `/ebooks` group.
+- Columns `auto|1|2|3|4` (strings in the select, number|"auto" in settings), `columnGap` 0–50 (percent), `justify` boolean; all inert for comics (the settings UI for them is already gated by `!isComicFormat` alongside existing typography controls).
+- API rules: additive only; new endpoints, no changes to existing response fields.
+- Gates for every task: focused vitest/`go test` per step; before each commit the touched-language gate (`pnpm exec tsc --noEmit -p tsconfig.app.json` 0 errors, `pnpm run lint` 0 errors/159-warning baseline, prettier for web; `gofmt`/`go vet` clean for Go). Conventional Commits with trailer `Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>`.
+- Web commands run from `web/`; commits from repo root.
+
+---
+
+### Task 1: Palette module
+
+**Files:**
+- Create: `web/src/reader/readerThemes.ts`
+- Test: `web/src/reader/readerThemes.test.ts`
+
+**Interfaces:**
+- Produces (Tasks 2–4 depend on these exact names):
+
+```typescript
+export type ReaderThemeVariant = "light" | "dark";
+export type ReaderThemeName =
+  | "default" | "sepia" | "gray" | "dawnlight" | "ember"
+  | "aurora" | "ocean" | "meadow" | "rosewood" | "amoled";
+export type ReaderPalette = { background: string; foreground: string; link: string };
+export const READER_THEMES: Record<ReaderThemeName, { label: string; darkOnly?: true; light: ReaderPalette; dark: ReaderPalette }>;
+export function readerPalette(name: ReaderThemeName, variant: ReaderThemeVariant): ReaderPalette & { scheme: ReaderThemeVariant };
+export function legacyThemeFor(name: ReaderThemeName, variant: ReaderThemeVariant): "light" | "sepia" | "dark";
+export function themeFromLegacy(theme: string): { themeName: ReaderThemeName; themeVariant: ReaderThemeVariant };
+```
+
+- [ ] **Step 1: Write the failing tests**
+
+```typescript
+// web/src/reader/readerThemes.test.ts
+import { describe, expect, it } from "vitest";
+import {
+  READER_THEMES,
+  legacyThemeFor,
+  readerPalette,
+  themeFromLegacy,
+} from "./readerThemes";
+
+const HEX = /^#[0-9a-f]{6}$/;
+
+describe("READER_THEMES", () => {
+  it("defines ten themes with valid hex palettes in both variants", () => {
+    const names = Object.keys(READER_THEMES);
+    expect(names).toHaveLength(10);
+    for (const theme of Object.values(READER_THEMES)) {
+      for (const variant of ["light", "dark"] as const) {
+        const palette = theme[variant];
+        expect(palette.background).toMatch(HEX);
+        expect(palette.foreground).toMatch(HEX);
+        expect(palette.link).toMatch(HEX);
+      }
+    }
+  });
+
+  it("aliases AMOLED's light variant to its dark palette", () => {
+    expect(READER_THEMES.amoled.darkOnly).toBe(true);
+    expect(readerPalette("amoled", "light")).toEqual(readerPalette("amoled", "dark"));
+    expect(readerPalette("amoled", "light").scheme).toBe("dark");
+  });
+
+  it("keeps the existing default and sepia palettes stable", () => {
+    expect(readerPalette("default", "light").background).toBe("#ffffff");
+    expect(readerPalette("sepia", "light")).toMatchObject({
+      background: "#f4ecd8",
+      foreground: "#2f261b",
+    });
+  });
+});
+
+describe("legacy mapping", () => {
+  it("maps stored legacy themes onto palette pairs", () => {
+    expect(themeFromLegacy("light")).toEqual({ themeName: "default", themeVariant: "light" });
+    expect(themeFromLegacy("sepia")).toEqual({ themeName: "sepia", themeVariant: "light" });
+    expect(themeFromLegacy("dark")).toEqual({ themeName: "default", themeVariant: "dark" });
+    expect(themeFromLegacy("nonsense")).toEqual({ themeName: "default", themeVariant: "light" });
+  });
+
+  it("derives the legacy field for backward-compatible persistence", () => {
+    expect(legacyThemeFor("sepia", "light")).toBe("sepia");
+    expect(legacyThemeFor("ocean", "dark")).toBe("dark");
+    expect(legacyThemeFor("amoled", "light")).toBe("dark");
+    expect(legacyThemeFor("meadow", "light")).toBe("light");
+  });
+});
+```
+
+- [ ] **Step 2: Run to verify failure**
+
+Run: `cd web && pnpm exec vitest run src/reader/readerThemes.test.ts`
+Expected: FAIL — "Cannot find module './readerThemes'"
+
+- [ ] **Step 3: Implement**
+
+```typescript
+// web/src/reader/readerThemes.ts
+
+// Reader content palettes. Each theme is a light/dark pair; AMOLED is
+// dark-only (its light slot aliases the dark palette so the variant toggle
+// can be disabled without a special data shape).
+
+export type ReaderThemeVariant = "light" | "dark";
+
+export type ReaderThemeName =
+  | "default"
+  | "sepia"
+  | "gray"
+  | "dawnlight"
+  | "ember"
+  | "aurora"
+  | "ocean"
+  | "meadow"
+  | "rosewood"
+  | "amoled";
+
+export type ReaderPalette = { background: string; foreground: string; link: string };
+
+type ReaderThemeDefinition = {
+  label: string;
+  darkOnly?: true;
+  light: ReaderPalette;
+  dark: ReaderPalette;
+};
+
+const AMOLED_PALETTE: ReaderPalette = {
+  background: "#000000",
+  foreground: "#c9c9c9",
+  link: "#7aa2f7",
+};
+
+export const READER_THEMES: Record<ReaderThemeName, ReaderThemeDefinition> = {
+  default: {
+    label: "Default",
+    light: { background: "#ffffff", foreground: "#171717", link: "#2563eb" },
+    dark: { background: "#111827", foreground: "#f8fafc", link: "#93c5fd" },
+  },
+  sepia: {
+    label: "Sepia",
+    light: { background: "#f4ecd8", foreground: "#2f261b", link: "#8b5a2b" },
+    dark: { background: "#211b12", foreground: "#c8b697", link: "#c99a5b" },
+  },
+  gray: {
+    label: "Gray",
+    light: { background: "#eceef0", foreground: "#33383d", link: "#4a6fa5" },
+    dark: { background: "#23262a", foreground: "#b9bfc6", link: "#8ab0dd" },
+  },
+  dawnlight: {
+    label: "Dawnlight",
+    light: { background: "#fdf6e3", foreground: "#586e75", link: "#268bd2" },
+    dark: { background: "#002b36", foreground: "#93a1a1", link: "#268bd2" },
+  },
+  ember: {
+    label: "Ember",
+    light: { background: "#fbf1c7", foreground: "#3c3836", link: "#af3a03" },
+    dark: { background: "#282828", foreground: "#ebdbb2", link: "#fe8019" },
+  },
+  aurora: {
+    label: "Aurora",
+    light: { background: "#eceff4", foreground: "#2e3440", link: "#5e81ac" },
+    dark: { background: "#2e3440", foreground: "#d8dee9", link: "#88c0d0" },
+  },
+  ocean: {
+    label: "Ocean",
+    light: { background: "#e8f0f7", foreground: "#1e3a52", link: "#2471a3" },
+    dark: { background: "#0d1b2a", foreground: "#a9c1d9", link: "#64a8dd" },
+  },
+  meadow: {
+    label: "Meadow",
+    light: { background: "#eef3e7", foreground: "#2f3b2a", link: "#3f7d44" },
+    dark: { background: "#1a2318", foreground: "#b8c9a8", link: "#7fb069" },
+  },
+  rosewood: {
+    label: "Rosewood",
+    light: { background: "#f7edee", foreground: "#4a2f33", link: "#a4494f" },
+    dark: { background: "#241a1c", foreground: "#d3b8bc", link: "#d98a90" },
+  },
+  amoled: {
+    label: "AMOLED",
+    darkOnly: true,
+    light: AMOLED_PALETTE,
+    dark: AMOLED_PALETTE,
+  },
+};
+
+export function readerPalette(
+  name: ReaderThemeName,
+  variant: ReaderThemeVariant,
+): ReaderPalette & { scheme: ReaderThemeVariant } {
+  const theme = READER_THEMES[name] ?? READER_THEMES.default;
+  const effective: ReaderThemeVariant = theme.darkOnly ? "dark" : variant;
+  return { ...theme[effective], scheme: effective };
+}
+
+export function legacyThemeFor(
+  name: ReaderThemeName,
+  variant: ReaderThemeVariant,
+): "light" | "sepia" | "dark" {
+  if (readerPalette(name, variant).scheme === "dark") return "dark";
+  if (name === "sepia") return "sepia";
+  return "light";
+}
+
+export function themeFromLegacy(theme: string): {
+  themeName: ReaderThemeName;
+  themeVariant: ReaderThemeVariant;
+} {
+  switch (theme) {
+    case "sepia":
+      return { themeName: "sepia", themeVariant: "light" };
+    case "dark":
+      return { themeName: "default", themeVariant: "dark" };
+    default:
+      return { themeName: "default", themeVariant: "light" };
+  }
+}
+```
+
+- [ ] **Step 4: Run to verify pass**
+
+Run: `cd web && pnpm exec vitest run src/reader/readerThemes.test.ts`
+Expected: PASS (5 tests)
+
+- [ ] **Step 5: Format, gate, commit**
+
+```bash
+cd web && pnpm exec prettier --write src/reader/readerThemes.ts src/reader/readerThemes.test.ts && pnpm exec tsc --noEmit -p tsconfig.app.json && cd ..
+git add web/src/reader/readerThemes.ts web/src/reader/readerThemes.test.ts
+git commit -m "feat(reader): paired-palette theme table
+
+Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>"
+```
+
+---
+
+### Task 2: Settings shape + normalization migration
+
+**Files:**
+- Modify: `web/src/reader/FoliateBookReader.tsx` (ReaderSettings type ~line 74-90, `DEFAULT_READER_SETTINGS` ~line 172, `normalizeReaderSettings`)
+- Test: `web/src/reader/FoliateBookReader.test.ts` (extend — it already tests `normalizeReaderSettings`)
+
+**Interfaces:**
+- Consumes: `themeFromLegacy`, `legacyThemeFor`, types from Task 1.
+- Produces (Tasks 3–4 rely on these exact fields): `ReaderSettings` gains
+  `themeName: ReaderThemeName; themeVariant: ReaderThemeVariant; columns: "auto" | 1 | 2 | 3 | 4; columnGap: number; justify: boolean; customFontID: number | null;`
+  and keeps `theme: ReaderTheme` (legacy, derived on write). `spread` field REMOVED from the type (normalization maps stored `spread: "none"` → `columns: 1`).
+
+- [ ] **Step 1: Write failing tests** (add to the existing `normalizeReaderSettings` describe block in `FoliateBookReader.test.ts`; match its existing call style)
+
+```typescript
+it("migrates legacy theme and spread values", () => {
+  const settings = normalizeReaderSettings({ theme: "sepia", spread: "none" });
+  expect(settings.themeName).toBe("sepia");
+  expect(settings.themeVariant).toBe("light");
+  expect(settings.theme).toBe("sepia"); // legacy field still written
+  expect(settings.columns).toBe(1);
+});
+
+it("prefers explicit themeName/themeVariant over the legacy field", () => {
+  const settings = normalizeReaderSettings({ theme: "light", themeName: "ocean", themeVariant: "dark" });
+  expect(settings.themeName).toBe("ocean");
+  expect(settings.themeVariant).toBe("dark");
+  expect(settings.theme).toBe("dark"); // legacy derived from the pair
+});
+
+it("clamps columns, columnGap, and defaults justify", () => {
+  expect(normalizeReaderSettings({ columns: 4 }).columns).toBe(4);
+  expect(normalizeReaderSettings({ columns: 7 }).columns).toBe("auto");
+  expect(normalizeReaderSettings({ columnGap: 80 }).columnGap).toBe(50);
+  expect(normalizeReaderSettings({ columnGap: -3 }).columnGap).toBe(0);
+  expect(normalizeReaderSettings({}).justify).toBe(false);
+  expect(normalizeReaderSettings({}).columns).toBe("auto");
+  expect(normalizeReaderSettings({}).customFontID).toBeNull();
+});
+```
+
+- [ ] **Step 2: Run to verify failure**
+
+Run: `cd web && pnpm exec vitest run src/reader/FoliateBookReader.test.ts`
+Expected: FAIL — new fields undefined
+
+- [ ] **Step 3: Implement**
+
+In `FoliateBookReader.tsx`:
+
+```typescript
+import {
+  legacyThemeFor,
+  themeFromLegacy,
+  READER_THEMES,
+  type ReaderThemeName,
+  type ReaderThemeVariant,
+} from "./readerThemes";
+
+export type ReaderColumns = "auto" | 1 | 2 | 3 | 4;
+
+// ReaderSettings: remove `spread: ReaderSpread` and add:
+  themeName: ReaderThemeName;
+  themeVariant: ReaderThemeVariant;
+  columns: ReaderColumns;
+  columnGap: number; // percent, 0-50
+  justify: boolean;
+  customFontID: number | null;
+// keep `theme: ReaderTheme` in the type (legacy mirror, always rewritten on normalize)
+
+// DEFAULT_READER_SETTINGS: remove `spread: "auto"`, add:
+  themeName: "default",
+  themeVariant: "light",
+  columns: "auto",
+  columnGap: 7,
+  justify: false,
+  customFontID: null,
+```
+
+In `normalizeReaderSettings` (which already clamps each field — follow its existing per-field style):
+
+```typescript
+const rawName = typeof raw.themeName === "string" && raw.themeName in READER_THEMES
+  ? (raw.themeName as ReaderThemeName)
+  : null;
+const rawVariant = raw.themeVariant === "dark" || raw.themeVariant === "light"
+  ? (raw.themeVariant as ReaderThemeVariant)
+  : null;
+const fromLegacy = themeFromLegacy(typeof raw.theme === "string" ? raw.theme : "light");
+const themeName = rawName ?? fromLegacy.themeName;
+const themeVariant = rawVariant ?? fromLegacy.themeVariant;
+const theme = legacyThemeFor(themeName, themeVariant);
+
+const columns: ReaderColumns =
+  raw.columns === 1 || raw.columns === 2 || raw.columns === 3 || raw.columns === 4
+    ? raw.columns
+    : raw.spread === "none"
+      ? 1
+      : "auto";
+const columnGap = Math.min(50, Math.max(0, Number.isFinite(Number(raw.columnGap)) ? Number(raw.columnGap) : 7));
+const justify = raw.justify === true;
+const customFontID =
+  typeof raw.customFontID === "number" && Number.isInteger(raw.customFontID) && raw.customFontID > 0
+    ? raw.customFontID
+    : null;
+```
+
+(Adapt the exact `raw` access pattern to how the function currently reads unknown input; delete the `spread` normalization and the `ReaderSpread` export, fixing the one consumer found by tsc — the settings panel select replaced in Task 4.)
+
+To keep this task compiling before Task 4 lands, update `readerRendererAttributes` minimally in this task: replace the `spread`-based `maxColumnCount` with
+
+```typescript
+maxColumnCount: scrolled ? "1" : settings.columns === "auto" ? "2" : String(settings.columns),
+gap: `${settings.columnGap}%`,
+```
+
+and in `readerStyles` add (with the existing `!important` style):
+
+```typescript
+`text-align: ${settings.justify ? "justify" : "initial"} !important;`
+```
+
+in the `html, body` block, and switch `readerColors(theme)` calls to `readerPalette(settings.themeName, settings.themeVariant)` (delete `readerColors`; keep the returned `{background, foreground, link, scheme}` contract). Also update the temporary settings panel references: the Spread `<select>` in `web/src/pages/EbookReader.tsx` (~line 1414-1427) must be deleted in THIS task (its replacement lands in Task 4; removing it now keeps tsc green) and the Theme `<select>` (~line 1257) changes its `onChange` to `updateReaderSettings(themeFromLegacy(value))` — a stopgap Task 4 replaces. Check `READER_PROFILES` in `EbookReader.tsx` for `spread` references and drop them.
+
+- [ ] **Step 4: Run suites**
+
+Run: `cd web && pnpm exec vitest run src/reader/FoliateBookReader.test.ts src/pages/EbookReader.test.tsx src/reader/readerThemes.test.ts`
+Expected: PASS (update any EbookReader test that asserted the Spread select — delete those assertions; keep intent by asserting the Columns control in Task 4)
+
+- [ ] **Step 5: Gate + commit**
+
+```bash
+cd web && pnpm exec prettier --write src/reader/FoliateBookReader.tsx src/reader/FoliateBookReader.test.ts src/pages/EbookReader.tsx && pnpm exec tsc --noEmit -p tsconfig.app.json && pnpm run lint && cd ..
+git add -A web/src
+git commit -m "feat(reader): palette-pair settings with columns and justify
+
+Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>"
+```
+
+---
+
+### Task 3: Fonts backend — migration, store, handlers, routes
+
+**Files:**
+- Create: `migrations/sql/20260720190000_reader_fonts.sql`
+- Create: `internal/api/handlers/reader_fonts.go`
+- Create: `internal/api/handlers/reader_fonts_test.go`
+- Modify: `internal/api/router.go` (~line 2218 `/ebooks` group; handler wiring near `ebookConfigStore` ~line 514)
+- Modify: `cmd/silo/main.go` (fonts dir resolution, beside `resolvePluginCacheDir` ~line 133)
+
+**Interfaces:**
+- Produces (Task 4's client calls these): routes inside the `/ebooks` group —
+  `GET /reader-fonts` → `{"fonts": [{"id":1,"name":"Literata","filename":"literata.woff2","created_at":"…"}]}`;
+  `POST /reader-fonts` (multipart field `font`) → 201 with one font object; errors: 400 `bad_request` (missing/invalid), 413 `too_large`, 409 `limit_reached`, 415 `unsupported_type`;
+  `DELETE /reader-fonts/{font_id}` → 204; `GET /reader-fonts/{font_id}/file` → blob, `Cache-Control: private, max-age=31536000, immutable`.
+- Go surface: `type ReaderFontsHandler struct { Store ReaderFontStore; Dir string }`, `NewPGReaderFontStore(pool)`.
+
+- [ ] **Step 1: Migration**
+
+```sql
+-- migrations/sql/20260720190000_reader_fonts.sql
+-- +goose Up
+CREATE TABLE IF NOT EXISTS reader_fonts (
+    id BIGINT GENERATED ALWAYS AS IDENTITY PRIMARY KEY,
+    user_id INTEGER NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+    profile_id TEXT NOT NULL,
+    name TEXT NOT NULL,
+    filename TEXT NOT NULL,
+    format TEXT NOT NULL,
+    size_bytes BIGINT NOT NULL,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+CREATE INDEX IF NOT EXISTS idx_reader_fonts_owner ON reader_fonts (user_id, profile_id);
+
+-- +goose Down
+DROP TABLE IF EXISTS reader_fonts;
+```
+
+Run: `make migrate-validate` — expected: passes.
+
+- [ ] **Step 2: Write failing handler tests**
+
+`internal/api/handlers/reader_fonts_test.go` — use a fake store (in-memory map implementing `ReaderFontStore`) and a `t.TempDir()` fonts dir; follow the package's existing handler-test style (httptest + chi context params). Cover, with real multipart bodies:
+
+```go
+func TestReaderFontUploadValidatesMagicBytes(t *testing.T)
+// woff2 magic "wOF2" + padding accepted (201, metadata persisted, file on disk at <dir>/<user>/<profile>/<id>.woff2);
+// a body starting "GIF8" rejected 415 unsupported_type; nothing on disk.
+
+func TestReaderFontUploadEnforcesCaps(t *testing.T)
+// store seeded with 10 fonts for the profile → 409 limit_reached;
+// >5MB body → 413 too_large.
+
+func TestReaderFontListScopedToProfile(t *testing.T)
+// store holds fonts for (user 1, profile "a") and (user 1, profile "b");
+// request as profile "a" lists only profile a's fonts.
+
+func TestReaderFontServeAndDeleteAuthorize(t *testing.T)
+// GET file for a font owned by another profile → 404;
+// DELETE own font → 204, row gone, file gone;
+// GET own font → 200, Content-Type font/woff2, immutable Cache-Control.
+```
+
+Write the four tests fully (assemble multipart with `mime/multipart.Writer`, magic bytes: sfnt `\x00\x01\x00\x00`, `OTTO`, `wOFF`, `wOF2`), asserting exact status codes and JSON error codes above.
+
+- [ ] **Step 3: Run to verify failure**
+
+Run: `go test ./internal/api/handlers -run TestReaderFont -count=1`
+Expected: FAIL — undefined types/handlers
+
+- [ ] **Step 4: Implement `reader_fonts.go`**
+
+```go
+// internal/api/handlers/reader_fonts.go
+package handlers
+
+// ReaderFont metadata row.
+type ReaderFont struct {
+    ID        int64     `json:"id"`
+    UserID    int       `json:"-"`
+    ProfileID string    `json:"-"`
+    Name      string    `json:"name"`
+    Filename  string    `json:"filename"`
+    Format    string    `json:"format"`
+    SizeBytes int64     `json:"-"`
+    CreatedAt time.Time `json:"created_at"`
+}
+
+type ReaderFontStore interface {
+    List(ctx context.Context, userID int, profileID string) ([]ReaderFont, error)
+    Count(ctx context.Context, userID int, profileID string) (int, error)
+    Insert(ctx context.Context, font ReaderFont) (ReaderFont, error)
+    Get(ctx context.Context, userID int, profileID string, id int64) (*ReaderFont, error)
+    Delete(ctx context.Context, userID int, profileID string, id int64) (bool, error)
+}
+
+const (
+    readerFontMaxBytes   = 5 << 20
+    readerFontMaxPerProfile = 10
+)
+
+type ReaderFontsHandler struct {
+    Store ReaderFontStore
+    Dir   string
+}
+```
+
+Handlers: `HandleList`, `HandleUpload`, `HandleDelete`, `HandleServeFile`. Upload follows the branding pattern verbatim: `r.ParseMultipartForm(readerFontMaxBytes + (1 << 20))`, `r.FormFile("font")`, `io.ReadAll(io.LimitReader(file, readerFontMaxBytes+1))`, 413 on overflow. Format detection:
+
+```go
+func readerFontFormat(data []byte) (format, contentType string, ok bool) {
+    switch {
+    case len(data) >= 4 && string(data[:4]) == "wOF2":
+        return "woff2", "font/woff2", true
+    case len(data) >= 4 && string(data[:4]) == "wOFF":
+        return "woff", "font/woff", true
+    case len(data) >= 4 && (string(data[:4]) == "OTTO"):
+        return "otf", "font/otf", true
+    case len(data) >= 4 && bytes.Equal(data[:4], []byte{0x00, 0x01, 0x00, 0x00}):
+        return "ttf", "font/ttf", true
+    }
+    return "", "", false
+}
+```
+
+415 `unsupported_type` when !ok; 409 `limit_reached` when `Count >= readerFontMaxPerProfile`. Name: sanitized upload filename minus extension (font name-table parsing is NOT required — the spec allows filename fallback; keep it simple, note in the doc comment). Blob path: `filepath.Join(h.Dir, strconv.Itoa(userID), profileID, fmt.Sprintf("%d.%s", font.ID, format))` — insert row first (to get the ID), write file 0o644 with `os.MkdirAll` 0o755, delete the row on write failure. Serve: `Get` (404 when nil), open file (404 on missing), set `Content-Type` from format, `Cache-Control: private, max-age=31536000, immutable`, `X-Content-Type-Options: nosniff`, `http.ServeContent`. Delete: `Delete` row (404 when not found), then best-effort `os.Remove`.
+
+PG store in the same file (mirror `PGEbookReaderConfigStore` style at `ebook_reader.go:715`): `PGReaderFontStore` with the five methods over the `reader_fonts` table, `ORDER BY created_at, id` for List.
+
+- [ ] **Step 5: Wire routes and config**
+
+`internal/api/router.go` inside the `/ebooks` group (after the annotations routes):
+
+```go
+if readerFontsHandler != nil {
+    r.Get("/reader-fonts", readerFontsHandler.HandleList)
+    r.Post("/reader-fonts", readerFontsHandler.HandleUpload)
+    r.Delete("/reader-fonts/{font_id}", readerFontsHandler.HandleDelete)
+    r.Get("/reader-fonts/{font_id}/file", readerFontsHandler.HandleServeFile)
+}
+```
+
+Wire near `ebookConfigStore` (~line 514): `readerFontsHandler = &handlers.ReaderFontsHandler{Store: handlers.NewPGReaderFontStore(deps.DB), Dir: deps.ReaderFontsDir}` — add `ReaderFontsDir string` to the router deps struct, threaded from `cmd/silo/main.go`:
+
+```go
+func resolveReaderFontsDir() string {
+    if v := strings.TrimSpace(os.Getenv("SILO_READER_FONTS_DIR")); v != "" {
+        return v
+    }
+    return "/var/lib/silo/reader-fonts"
+}
+```
+
+(match how `resolvePluginCacheDir` at main.go:133 is defined and where its value is consumed; pass through the same deps plumbing the other handlers use).
+
+- [ ] **Step 6: Run tests + gates**
+
+Run: `go test ./internal/api/handlers -run TestReaderFont -count=1 && go build ./... && go vet ./internal/api/... && gofmt -l internal/ cmd/ | (! grep .)`
+Expected: PASS / clean
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add migrations/sql/20260720190000_reader_fonts.sql internal/api/handlers/reader_fonts.go internal/api/handlers/reader_fonts_test.go internal/api/router.go cmd/silo/main.go
+git commit -m "feat(reader): per-profile custom font uploads
+
+Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>"
+```
+
+---
+
+### Task 4: Settings panel — theme grid, columns/gap/justify, font uploads
+
+**Files:**
+- Create: `web/src/reader/readerFontsApi.ts`
+- Modify: `web/src/pages/EbookReader.tsx` (settings panel: Theme select region ~1257, font select ~1273; regroup into Theme/Typography/Layout)
+- Modify: `web/src/reader/FoliateBookReader.tsx` (`readerStyles`: @font-face injection + custom font family)
+- Test: `web/src/reader/readerFontsApi.test.ts`, extend `web/src/pages/EbookReader.test.tsx`
+
+**Interfaces:**
+- Consumes: Task 1 palettes, Task 2 settings fields, Task 3 endpoints.
+- Produces:
+
+```typescript
+// readerFontsApi.ts
+export type ReaderFontMeta = { id: number; name: string; filename: string; created_at: string };
+export function fetchReaderFonts(): Promise<ReaderFontMeta[]>;
+export function uploadReaderFont(file: File): Promise<ReaderFontMeta>;
+export function deleteReaderFont(id: number): Promise<void>;
+export function readerFontFileUrl(id: number): string; // "/api/v1/ebooks/reader-fonts/{id}/file"
+```
+
+- [ ] **Step 1: readerFontsApi + tests (TDD)**
+
+Test first (`readerFontsApi.test.ts`): mock `fetch` (follow `ebookReaderApi.ts`'s transport — reuse its helper if one exists, else the same `apiFetch` the file uses); assert list unwraps `{fonts:[…]}`, upload posts `FormData` with field `font`, delete hits the id route, `readerFontFileUrl(3)` returns the exact path. Then implement mirroring `ebookReaderApi.ts`'s style. Run: `pnpm exec vitest run src/reader/readerFontsApi.test.ts` — RED then GREEN.
+
+- [ ] **Step 2: Failing UI tests**
+
+Add to `EbookReader.test.tsx` (mock `readerFontsApi` module like the other API mocks in the file):
+
+```typescript
+it("renders the theme grid and switches palette pairs", async () => {
+  await renderReader();
+  const ocean = document.querySelector('[data-theme-choice="ocean"]') as HTMLElement;
+  act(() => ocean.click());
+  // settings saved with themeName ocean + legacy theme mirror
+  // (assert via the captured saveEbookReaderConfig payload like existing settings tests)
+});
+
+it("disables the variant toggle for AMOLED", async () => {
+  await renderReader();
+  act(() => (document.querySelector('[data-theme-choice="amoled"]') as HTMLElement).click());
+  const toggle = document.querySelector('[aria-label="Reader dark mode"]') as HTMLButtonElement;
+  expect(toggle.disabled).toBe(true);
+});
+
+it("offers uploaded fonts in the font picker and falls back on delete", async () => {
+  mocks.fetchReaderFonts.mockResolvedValue([{ id: 3, name: "Literata", filename: "l.woff2", created_at: "" }]);
+  await renderReader();
+  // font select contains an "Uploaded" optgroup with Literata (value "custom:3")
+  // deleting via mocked deleteReaderFont + selecting a missing font resets to inherit
+});
+```
+
+(Adapt selectors/assertions to the harness's existing settings-panel test patterns; the assertions above are the required behaviors.)
+
+- [ ] **Step 3: Implement panel + font-face**
+
+- Theme section: a grid of 10 swatch buttons (`data-theme-choice={name}`, background from `READER_THEMES[name][variant].background`, title = label) + a "Reader dark mode" toggle button (`aria-label="Reader dark mode"`, disabled when `READER_THEMES[settings.themeName].darkOnly`), writing `updateReaderSettings({ themeName, themeVariant })` (normalization keeps the legacy mirror).
+- Typography: existing font select gains an `<optgroup label="Uploaded">` from `fetchReaderFonts()` (loaded once when the panel opens; value format `custom:<id>` → `updateReaderSettings({ customFontID: id, fontFamily: "custom" })`; built-ins clear `customFontID`). Below it an upload input (accept `.ttf,.otf,.woff,.woff2`) calling `uploadReaderFont`, and per-font delete buttons calling `deleteReaderFont`; upload errors render inline (`too_large`/`limit_reached`/`unsupported_type` message text from the error response). Justify toggle beside hyphenation.
+- Layout: Columns select (`auto|1|2|3|4`, aria-label "Columns") + Column gap slider (0–50, aria-label "Column gap") replacing the removed Spread select.
+- `FoliateBookReader.tsx` `readerStyles`: when `settings.customFontID != null`, prepend
+
+```typescript
+`@font-face { font-family: "silo-custom-font"; src: url("${readerFontFileUrl(settings.customFontID)}"); font-display: swap; }`
+```
+
+and use `font-family: "silo-custom-font"` when `settings.fontFamily === "custom"`. (Import `readerFontFileUrl` from `./readerFontsApi`; the URL is same-origin so the existing CSP `font-src 'self'` allows it.)
+- Delete-referenced-font fallback: when the fonts list loads and `customFontID` isn't in it, `updateReaderSettings({ customFontID: null, fontFamily: "inherit" })`.
+
+- [ ] **Step 4: Run suites + gates**
+
+Run: `cd web && pnpm exec vitest run src/pages/EbookReader.test.tsx src/reader && pnpm exec tsc --noEmit -p tsconfig.app.json && pnpm run lint && pnpm run format:check`
+Expected: all green, 0 lint errors
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add -A web/src
+git commit -m "feat(reader): theme grid, font uploads, columns and justify controls
+
+Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>"
+```
+
+---
+
+### Task 5: Full verification pass
+
+**Files:** none expected (fix what gates surface)
+
+- [ ] **Step 1:** `cd web && pnpm exec vitest run` — green except the 7 pre-existing upstream failures (SeasonContent/CompatibilityProxiesSettings/ServerStorageStep — QueryClientProvider/ResizeObserver, documented on the navigation branch).
+- [ ] **Step 2:** `cd web && pnpm run lint && pnpm run format:check && pnpm build` — 0 errors, build succeeds.
+- [ ] **Step 3:** `go test ./internal/api/handlers -count=1 && go build ./...` — green.
+- [ ] **Step 4:** `make migrate-validate && make verify-local-paths` — pass.
+- [ ] **Step 5:** Note for reviewer: manual pass — pick each theme in both variants, upload a real .woff2, select it, read a page; set 3 columns on a wide window; verify comics unaffected.
+- [ ] **Step 6:** Commit any gate fixes as `test(reader): stabilize appearance suites` (skip if clean).

--- a/docs/superpowers/plans/2026-07-20-reader-page-navigation.md
+++ b/docs/superpowers/plans/2026-07-20-reader-page-navigation.md
@@ -1,0 +1,889 @@
+# Reader Page Navigation Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Replace the header fraction slider with a chapter-aware footer bar, add tap-zone/auto-hide chrome and a discoverable keyboard map to the prose ebook reader.
+
+**Architecture:** Pure decision helpers in a new `readerNavigation.ts` (unit-tested first), location plumbing lifted out of `FoliateBookReader` via a new `onLocationChange` callback + `getSectionFractions()` handle method, a presentational `ReaderFooter`, and integration in `EbookReader.tsx` (chrome visibility state, tap layer, extended key handler, shortcuts overlay). No server or schema changes.
+
+**Tech Stack:** React 19 + TypeScript, foliate-js (vendored, already exposes `getSectionFractions()` at `web/vendor/foliate-js/view.js:539` and relocate `fraction`/`tocItem`), vitest + jsdom, Tailwind classes matching the existing reader chrome.
+
+## Global Constraints
+
+- Spec: `docs/superpowers/specs/2026-07-20-reader-page-navigation-design.md` — re-read before starting.
+- Prose formats only: everything below is inert when `isComicFormat` is true (existing helper in `web/src/pages/EbookReader.tsx`).
+- Single-letter shortcuts must not fire when a text input has focus — reuse the existing `isEditableTarget` guard (`EbookReader.tsx`, used at the ArrowLeft/ArrowRight handler ~line 464).
+- Left/right tap zones are disabled in `flow: "scrolled"`; middle-tap chrome toggle works in both flows.
+- A tap that ends a text-selection gesture must NOT page.
+- No TOC → no chapter band, no chapter title; the slider still works on fractions.
+- Time-remaining is OUT of scope (stats sub-project); the footer right slot shows percentage only.
+- All commands run from `web/`: `pnpm exec vitest run <file>`; format with `pnpm exec prettier --write <files>`; commit from repo root.
+- Commit messages: Conventional Commits, `Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>` trailer.
+
+---
+
+### Task 1: Pure navigation helpers
+
+**Files:**
+- Create: `web/src/reader/readerNavigation.ts`
+- Test: `web/src/reader/readerNavigation.test.ts`
+
+**Interfaces:**
+- Consumes: nothing (pure module).
+- Produces:
+  - `chapterExtent(sectionFractions: number[], fraction: number): { start: number; end: number; index: number } | null`
+  - `tapZoneAction(input: { xRatio: number; flow: "paginated" | "scrolled"; hasSelection: boolean }): "prev" | "next" | "toggle-chrome" | null`
+  - `READER_SHORTCUTS: ReadonlyArray<{ key: string; description: string }>` (display data for the overlay)
+
+- [ ] **Step 1: Write the failing tests**
+
+```typescript
+// web/src/reader/readerNavigation.test.ts
+import { describe, expect, it } from "vitest";
+import { chapterExtent, tapZoneAction, READER_SHORTCUTS } from "./readerNavigation";
+
+describe("chapterExtent", () => {
+  // foliate's getSectionFractions() returns cumulative fraction boundaries
+  // starting at 0, e.g. [0, 0.25, 0.6, 1] for a 3-section book.
+  it("maps a whole-book fraction to its section's extent", () => {
+    expect(chapterExtent([0, 0.25, 0.6, 1], 0.3)).toEqual({ start: 0.25, end: 0.6, index: 1 });
+  });
+
+  it("clamps to the last section at fraction 1", () => {
+    expect(chapterExtent([0, 0.25, 0.6, 1], 1)).toEqual({ start: 0.6, end: 1, index: 2 });
+  });
+
+  it("returns null without enough boundaries", () => {
+    expect(chapterExtent([], 0.5)).toBeNull();
+    expect(chapterExtent([0], 0.5)).toBeNull();
+  });
+
+  it("treats a trailing boundary below 1 as extending to the book end", () => {
+    expect(chapterExtent([0, 0.5], 0.75)).toEqual({ start: 0.5, end: 1, index: 1 });
+  });
+});
+
+describe("tapZoneAction", () => {
+  it("pages back on the left third and forward on the right third", () => {
+    expect(tapZoneAction({ xRatio: 0.1, flow: "paginated", hasSelection: false })).toBe("prev");
+    expect(tapZoneAction({ xRatio: 0.9, flow: "paginated", hasSelection: false })).toBe("next");
+  });
+
+  it("toggles chrome on the middle third", () => {
+    expect(tapZoneAction({ xRatio: 0.5, flow: "paginated", hasSelection: false })).toBe(
+      "toggle-chrome",
+    );
+  });
+
+  it("never pages while a selection is active", () => {
+    expect(tapZoneAction({ xRatio: 0.1, flow: "paginated", hasSelection: true })).toBeNull();
+    expect(tapZoneAction({ xRatio: 0.5, flow: "paginated", hasSelection: true })).toBeNull();
+  });
+
+  it("disables edge zones in scrolled flow but keeps the chrome toggle", () => {
+    expect(tapZoneAction({ xRatio: 0.1, flow: "scrolled", hasSelection: false })).toBeNull();
+    expect(tapZoneAction({ xRatio: 0.5, flow: "scrolled", hasSelection: false })).toBe(
+      "toggle-chrome",
+    );
+  });
+});
+
+describe("READER_SHORTCUTS", () => {
+  it("documents every shortcut the reader binds", () => {
+    const keys = READER_SHORTCUTS.map((s) => s.key);
+    for (const key of ["←/→", "Home/End", "t", "s", "b", "f", "?", "Esc"]) {
+      expect(keys).toContain(key);
+    }
+  });
+});
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `cd web && pnpm exec vitest run src/reader/readerNavigation.test.ts`
+Expected: FAIL — "Cannot find module './readerNavigation'"
+
+- [ ] **Step 3: Write the implementation**
+
+```typescript
+// web/src/reader/readerNavigation.ts
+
+// Navigation decision helpers for the prose reader. Pure functions so the
+// footer band, tap zones, and shortcuts overlay stay unit-testable apart
+// from foliate and the DOM.
+
+export type ChapterExtent = { start: number; end: number; index: number };
+
+// sectionFractions are foliate's cumulative boundaries (view.getSectionFractions()),
+// e.g. [0, 0.25, 0.6, 1]. A trailing boundary below 1 means the list omits the
+// book-end marker; the final section then runs to 1.
+export function chapterExtent(
+  sectionFractions: number[],
+  fraction: number,
+): ChapterExtent | null {
+  if (sectionFractions.length < 2) return null;
+  const clamped = Math.min(1, Math.max(0, fraction));
+  for (let i = sectionFractions.length - 1; i >= 0; i--) {
+    if (clamped >= sectionFractions[i]) {
+      const start = sectionFractions[i];
+      const end = i + 1 < sectionFractions.length ? sectionFractions[i + 1] : 1;
+      if (start >= end) continue; // zero-width section: attribute to the previous one
+      return { start, end, index: i };
+    }
+  }
+  return { start: 0, end: sectionFractions[1] ?? 1, index: 0 };
+}
+
+export type TapZoneInput = {
+  xRatio: number; // pointer X within the reading surface, 0..1
+  flow: "paginated" | "scrolled";
+  hasSelection: boolean;
+};
+
+export type TapZoneResult = "prev" | "next" | "toggle-chrome" | null;
+
+export function tapZoneAction({ xRatio, flow, hasSelection }: TapZoneInput): TapZoneResult {
+  if (hasSelection) return null;
+  if (xRatio < 1 / 3) return flow === "paginated" ? "prev" : null;
+  if (xRatio > 2 / 3) return flow === "paginated" ? "next" : null;
+  return "toggle-chrome";
+}
+
+export const READER_SHORTCUTS = [
+  { key: "←/→", description: "Previous / next page" },
+  { key: "Home/End", description: "Start / end of chapter" },
+  { key: "t", description: "Contents panel" },
+  { key: "s", description: "Search panel" },
+  { key: "b", description: "Toggle bookmark" },
+  { key: "f", description: "Fullscreen" },
+  { key: "?", description: "This shortcut list" },
+  { key: "Esc", description: "Close overlay, or hide/show controls" },
+] as const;
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `cd web && pnpm exec vitest run src/reader/readerNavigation.test.ts`
+Expected: PASS (9 tests)
+
+- [ ] **Step 5: Format and commit**
+
+```bash
+cd web && pnpm exec prettier --write src/reader/readerNavigation.ts src/reader/readerNavigation.test.ts && cd ..
+git add web/src/reader/readerNavigation.ts web/src/reader/readerNavigation.test.ts
+git commit -m "feat(reader): add navigation decision helpers
+
+Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>"
+```
+
+---
+
+### Task 2: Surface location data from FoliateBookReader
+
+**Files:**
+- Modify: `web/src/reader/FoliateBookReader.tsx` (RelocateDetail type ~line 131, handle assembly ~line 649, relocate listener ~line 839, props interface)
+- Test: `web/src/reader/FoliateBookReader.component.test.tsx` (extend)
+
+**Interfaces:**
+- Consumes: foliate view events; `RelocateDetail` currently `{ cfi?, location? }`.
+- Produces (used by Task 4):
+  - New prop `onLocationChange?: (info: ReaderLocationInfo) => void` where
+    `export type ReaderLocationInfo = { fraction: number; sectionIndex: number | null; tocLabel: string | null }`
+  - New handle method `getSectionFractions: () => number[]` on `FoliateBookReaderHandle`.
+
+- [ ] **Step 1: Write the failing test**
+
+Add to `web/src/reader/FoliateBookReader.component.test.tsx` (follow the file's existing pattern for mounting the component and dispatching a `relocate` CustomEvent on the fake `<foliate-view>` element; reuse its existing fixtures/mocks):
+
+```typescript
+it("reports location info on relocate", async () => {
+  const onLocationChange = vi.fn();
+  // mount with the same fixture the surrounding tests use, passing onLocationChange
+  // ... (mount helper from this file)
+  fakeView.dispatchEvent(
+    new CustomEvent("relocate", {
+      detail: {
+        cfi: "epubcfi(/6/8!/4/2)",
+        fraction: 0.3,
+        index: 1,
+        tocItem: { label: "Chapter 2" },
+        location: { current: 29, total: 100 },
+      },
+    }),
+  );
+  expect(onLocationChange).toHaveBeenCalledWith({
+    fraction: 0.3,
+    sectionIndex: 1,
+    tocLabel: "Chapter 2",
+  });
+});
+
+it("exposes section fractions through the handle", async () => {
+  fakeView.getSectionFractions = () => [0, 0.25, 1];
+  // handleRef obtained from the mount helper
+  expect(handleRef.current?.getSectionFractions()).toEqual([0, 0.25, 1]);
+});
+```
+
+- [ ] **Step 2: Run to verify failure**
+
+Run: `cd web && pnpm exec vitest run src/reader/FoliateBookReader.component.test.tsx`
+Expected: FAIL — `onLocationChange` never called / `getSectionFractions` is not a function
+
+- [ ] **Step 3: Implement**
+
+In `web/src/reader/FoliateBookReader.tsx`:
+
+Widen the relocate type (~line 131):
+
+```typescript
+type RelocateDetail = {
+  cfi?: string;
+  fraction?: number;
+  index?: number;
+  tocItem?: { label?: string };
+  location?: {
+    current?: number;
+    total?: number;
+  };
+};
+
+export type ReaderLocationInfo = {
+  fraction: number;
+  sectionIndex: number | null;
+  tocLabel: string | null;
+};
+```
+
+Add to the props interface (next to `onProgressChange`):
+
+```typescript
+onLocationChange?: (info: ReaderLocationInfo) => void;
+```
+
+Add to `FoliateBookReaderHandle` (type ~line 56) and the `useImperativeHandle` block (~line 649):
+
+```typescript
+// type:
+getSectionFractions: () => number[];
+
+// handle assembly (viewRef.current is the foliate view; its getSectionFractions
+// exists at web/vendor/foliate-js/view.js:539):
+getSectionFractions: () =>
+  (viewRef.current as { getSectionFractions?: () => number[] } | null)
+    ?.getSectionFractions?.() ?? [],
+```
+
+In the relocate listener (~line 839), after the existing `onProgressChange` call:
+
+```typescript
+const detail = (event as CustomEvent<RelocateDetail>).detail;
+if (typeof detail.fraction === "number") {
+  onLocationChange?.({
+    fraction: Math.min(1, Math.max(0, detail.fraction)),
+    sectionIndex: typeof detail.index === "number" ? detail.index : null,
+    tocLabel: detail.tocItem?.label?.trim() || null,
+  });
+}
+```
+
+(Keep the existing `progressFromRelocate` flow untouched; `onLocationChange` is additive.)
+
+- [ ] **Step 4: Run the component suite**
+
+Run: `cd web && pnpm exec vitest run src/reader/FoliateBookReader.component.test.tsx src/reader/FoliateBookReader.test.ts`
+Expected: PASS, including the two new tests
+
+- [ ] **Step 5: Format and commit**
+
+```bash
+cd web && pnpm exec prettier --write src/reader/FoliateBookReader.tsx src/reader/FoliateBookReader.component.test.tsx && cd ..
+git add web/src/reader/FoliateBookReader.tsx web/src/reader/FoliateBookReader.component.test.tsx
+git commit -m "feat(reader): surface relocate location info and section fractions
+
+Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>"
+```
+
+---
+
+### Task 3: ReaderFooter component
+
+**Files:**
+- Create: `web/src/reader/ReaderFooter.tsx`
+- Test: `web/src/reader/ReaderFooter.test.tsx`
+
+**Interfaces:**
+- Consumes: `ChapterExtent` from Task 1.
+- Produces (used by Task 4):
+
+```typescript
+export type ReaderFooterProps = {
+  fraction: number; // 0..1 current position
+  extent: ChapterExtent | null; // null hides band + title
+  chapterLabel: string | null;
+  onScrub: (fraction: number) => void;
+  onShowShortcuts: () => void;
+};
+export default function ReaderFooter(props: ReaderFooterProps): JSX.Element;
+```
+
+- [ ] **Step 1: Write the failing test**
+
+```typescript
+// web/src/reader/ReaderFooter.test.tsx
+// @vitest-environment jsdom
+import { act } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import ReaderFooter from "./ReaderFooter";
+
+let container: HTMLDivElement;
+let root: Root;
+
+beforeEach(() => {
+  container = document.createElement("div");
+  document.body.appendChild(container);
+  root = createRoot(container);
+});
+
+afterEach(() => {
+  act(() => root.unmount());
+  container.remove();
+});
+
+function render(props: Partial<React.ComponentProps<typeof ReaderFooter>> = {}) {
+  const defaults = {
+    fraction: 0.34,
+    extent: { start: 0.28, end: 0.42, index: 6 },
+    chapterLabel: "The Duke",
+    onScrub: vi.fn(),
+    onShowShortcuts: vi.fn(),
+  };
+  const merged = { ...defaults, ...props };
+  act(() => root.render(<ReaderFooter {...merged} />));
+  return merged;
+}
+
+describe("ReaderFooter", () => {
+  it("shows chapter label, percentage, and the chapter band", () => {
+    render();
+    expect(container.textContent).toContain("The Duke");
+    expect(container.textContent).toContain("34%");
+    const band = container.querySelector("[data-chapter-band]") as HTMLElement;
+    expect(band).not.toBeNull();
+    expect(band.style.left).toBe("28%");
+    expect(band.style.width).toBe("14.000000000000002%");
+  });
+
+  it("hides band and label without an extent", () => {
+    render({ extent: null, chapterLabel: null });
+    expect(container.querySelector("[data-chapter-band]")).toBeNull();
+  });
+
+  it("scrubs the whole book from the slider", () => {
+    const { onScrub } = render();
+    const slider = container.querySelector('input[type="range"]') as HTMLInputElement;
+    slider.value = "62";
+    act(() => {
+      slider.dispatchEvent(new Event("input", { bubbles: true }));
+    });
+    expect(onScrub).toHaveBeenCalledWith(0.62);
+  });
+
+  it("opens the shortcuts overlay from the ? affordance", () => {
+    const { onShowShortcuts } = render();
+    const btn = container.querySelector('[aria-label="Keyboard shortcuts"]') as HTMLButtonElement;
+    act(() => btn.click());
+    expect(onShowShortcuts).toHaveBeenCalled();
+  });
+});
+```
+
+- [ ] **Step 2: Run to verify failure**
+
+Run: `cd web && pnpm exec vitest run src/reader/ReaderFooter.test.tsx`
+Expected: FAIL — "Cannot find module './ReaderFooter'"
+
+- [ ] **Step 3: Implement**
+
+```tsx
+// web/src/reader/ReaderFooter.tsx
+import { Keyboard } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import type { ChapterExtent } from "./readerNavigation";
+
+export type ReaderFooterProps = {
+  fraction: number;
+  extent: ChapterExtent | null;
+  chapterLabel: string | null;
+  onScrub: (fraction: number) => void;
+  onShowShortcuts: () => void;
+};
+
+export default function ReaderFooter({
+  fraction,
+  extent,
+  chapterLabel,
+  onScrub,
+  onShowShortcuts,
+}: ReaderFooterProps) {
+  const percent = Math.round(Math.min(1, Math.max(0, fraction)) * 100);
+  return (
+    <footer className="border-border/70 bg-background/95 sticky bottom-0 z-20 border-t backdrop-blur">
+      <div className="flex flex-col gap-1 px-4 py-2">
+        <div className="relative h-2">
+          {extent && (
+            <div
+              data-chapter-band
+              title={chapterLabel ?? undefined}
+              className="bg-primary/25 pointer-events-none absolute top-0 h-2 rounded"
+              style={{ left: `${extent.start * 100}%`, width: `${(extent.end - extent.start) * 100}%` }}
+            />
+          )}
+          <input
+            aria-label="Reading progress"
+            type="range"
+            min="0"
+            max="100"
+            step="1"
+            value={percent}
+            onInput={(event) => onScrub(Number((event.target as HTMLInputElement).value) / 100)}
+            className="accent-primary absolute inset-0 h-2 w-full min-w-0"
+          />
+        </div>
+        <div className="text-muted-foreground flex items-center justify-between text-xs">
+          <span className="min-w-0 truncate">{chapterLabel ?? ""}</span>
+          <span className="tabular-nums">{percent}%</span>
+          <Button
+            variant="ghost"
+            size="icon-sm"
+            aria-label="Keyboard shortcuts"
+            title="Keyboard shortcuts"
+            onClick={onShowShortcuts}
+          >
+            <Keyboard className="size-4" />
+          </Button>
+        </div>
+      </div>
+    </footer>
+  );
+}
+```
+
+- [ ] **Step 4: Run to verify pass**
+
+Run: `cd web && pnpm exec vitest run src/reader/ReaderFooter.test.tsx`
+Expected: PASS (4 tests). If the band-width assertion fails on float formatting, assert with `expect(parseFloat(band.style.width)).toBeCloseTo(14)` instead — adjust the test, not the component.
+
+- [ ] **Step 5: Format and commit**
+
+```bash
+cd web && pnpm exec prettier --write src/reader/ReaderFooter.tsx src/reader/ReaderFooter.test.tsx && cd ..
+git add web/src/reader/ReaderFooter.tsx web/src/reader/ReaderFooter.test.tsx
+git commit -m "feat(reader): chapter-aware footer bar
+
+Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>"
+```
+
+---
+
+### Task 4: Wire footer into EbookReader (slider moves out of header)
+
+**Files:**
+- Modify: `web/src/pages/EbookReader.tsx` (header slider row ~lines 718–731 removed; footer rendered after `<main>`; new location state; FoliateBookReader gets `onLocationChange`)
+- Test: `web/src/pages/EbookReader.test.tsx` (extend the FoliateBookReader mock + new tests)
+
+**Interfaces:**
+- Consumes: `ReaderFooter` (Task 3), `chapterExtent` (Task 1), `onLocationChange` + `getSectionFractions` (Task 2), existing `handleProgressScrub` (~line 359) and `readerProgress` state.
+- Produces: `shortcutsOpen` boolean state + `setShortcutsOpen` (Task 6 renders the overlay from it).
+
+- [ ] **Step 1: Extend the mock and write failing tests**
+
+In `web/src/pages/EbookReader.test.tsx`, extend the `vi.mock("@/reader/FoliateBookReader", …)` stub: accept and store `onLocationChange` in a module-level `mocks.lastOnLocationChange`, add `getSectionFractions: () => [0, 0.25, 0.6, 1]` to the imperative handle, and invoke `onLocationChange` from a test via `act`. Then add:
+
+```typescript
+it("renders the chapter-aware footer instead of a header slider", async () => {
+  await renderReader(); // existing helper in this file
+  act(() => {
+    mocks.lastOnLocationChange?.({ fraction: 0.3, sectionIndex: 1, tocLabel: "Chapter 2" });
+  });
+  const header = document.querySelector("header")!;
+  expect(header.querySelector('input[type="range"]')).toBeNull();
+  const footer = document.querySelector("footer")!;
+  expect(footer.textContent).toContain("Chapter 2");
+  expect(footer.textContent).toContain("30%");
+  expect(footer.querySelector("[data-chapter-band]")).not.toBeNull();
+});
+```
+
+- [ ] **Step 2: Run to verify failure**
+
+Run: `cd web && pnpm exec vitest run src/pages/EbookReader.test.tsx -t "chapter-aware footer"`
+Expected: FAIL — header still contains the range input / no footer
+
+- [ ] **Step 3: Implement in EbookReader.tsx**
+
+1. New state near the other reader state hooks:
+
+```typescript
+const [locationInfo, setLocationInfo] = useState<ReaderLocationInfo | null>(null);
+const [shortcutsOpen, setShortcutsOpen] = useState(false);
+```
+
+2. Pass to `<FoliateBookReader …>`:
+
+```tsx
+onLocationChange={setLocationInfo}
+```
+
+3. Compute the extent (memoized, near other derived values):
+
+```typescript
+const chapterBand = useMemo(() => {
+  if (!locationInfo || isComic) return null;
+  const fractions = readerRef.current?.getSectionFractions() ?? [];
+  return chapterExtent(fractions, locationInfo.fraction);
+}, [locationInfo, isComic]);
+```
+
+4. Delete the header's slider row (the `div` with the `BookOpen` icon + range input + `progressLabel`, ~lines 718–731).
+
+5. Render after `</main>` (prose only):
+
+```tsx
+{!isComic && (
+  <ReaderFooter
+    fraction={locationInfo?.fraction ?? readerProgress ?? 0}
+    extent={chapterBand}
+    chapterLabel={locationInfo?.tocLabel ?? null}
+    onScrub={(fraction) => void readerRef.current?.goToFraction(fraction)}
+    onShowShortcuts={() => setShortcutsOpen(true)}
+  />
+)}
+```
+
+Imports: `ReaderFooter` from `@/reader/ReaderFooter`, `chapterExtent` from `@/reader/readerNavigation`, `type ReaderLocationInfo` from `@/reader/FoliateBookReader`. Use the file's actual comic flag name (`isComicFormat`-derived variable) — match what the surrounding code calls it.
+
+- [ ] **Step 4: Run the page suite**
+
+Run: `cd web && pnpm exec vitest run src/pages/EbookReader.test.tsx`
+Expected: PASS — new test green; any existing test that asserted the header slider must be updated to target the footer instead (update assertions, keep their intent).
+
+- [ ] **Step 5: Format and commit**
+
+```bash
+cd web && pnpm exec prettier --write src/pages/EbookReader.tsx src/pages/EbookReader.test.tsx && cd ..
+git add web/src/pages/EbookReader.tsx web/src/pages/EbookReader.test.tsx
+git commit -m "feat(reader): move progress into chapter-aware footer
+
+Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>"
+```
+
+---
+
+### Task 5: Tap zones and chrome auto-hide
+
+**Files:**
+- Modify: `web/src/pages/EbookReader.tsx` (chrome visibility state; pointer handler on the reading surface wrapper; header/footer conditional rendering)
+- Test: `web/src/pages/EbookReader.test.tsx`
+
+**Interfaces:**
+- Consumes: `tapZoneAction` (Task 1); existing `readerRef.current?.prev()/next()`; reader settings `flow`; existing selection state (the page already tracks the current selection for the highlight button — reuse that state variable as `hasSelection`).
+- Produces: `chromeVisible` boolean state (Task 6's Esc handling flips it).
+
+- [ ] **Step 1: Write failing tests**
+
+```typescript
+it("pages on edge taps and toggles chrome on middle tap", async () => {
+  await renderReader();
+  const surface = document.querySelector("[data-reader-surface]") as HTMLElement;
+  surface.getBoundingClientRect = () =>
+    ({ left: 0, width: 300, top: 0, height: 500 }) as DOMRect;
+
+  act(() => {
+    surface.dispatchEvent(new PointerEvent("pointerup", { clientX: 30, bubbles: true }));
+  });
+  expect(mocks.readerPrev).toHaveBeenCalled();
+
+  act(() => {
+    surface.dispatchEvent(new PointerEvent("pointerup", { clientX: 270, bubbles: true }));
+  });
+  expect(mocks.readerNext).toHaveBeenCalled();
+
+  expect(document.querySelector("header")).not.toBeNull();
+  act(() => {
+    surface.dispatchEvent(new PointerEvent("pointerup", { clientX: 150, bubbles: true }));
+  });
+  expect(document.querySelector("header")).toBeNull();
+  expect(document.querySelector("footer")).toBeNull();
+  act(() => {
+    surface.dispatchEvent(new PointerEvent("pointerup", { clientX: 150, bubbles: true }));
+  });
+  expect(document.querySelector("header")).not.toBeNull();
+});
+```
+
+(jsdom lacks `PointerEvent` — if the suite errors on it, construct with `new MouseEvent("pointerup", …)` in the test; the handler reads only `clientX`.)
+
+- [ ] **Step 2: Run to verify failure**
+
+Run: `cd web && pnpm exec vitest run src/pages/EbookReader.test.tsx -t "pages on edge taps"`
+Expected: FAIL — no `[data-reader-surface]` element / prev not called
+
+- [ ] **Step 3: Implement**
+
+1. State: `const [chromeVisible, setChromeVisible] = useState(true);`
+2. Wrap the reading surface (the container around `<FoliateBookReader>` inside `<main>`) with `data-reader-surface` and a `onPointerUp` handler:
+
+```tsx
+const handleSurfacePointerUp = useCallback(
+  (event: React.PointerEvent<HTMLDivElement>) => {
+    if (isComic) return;
+    const rect = event.currentTarget.getBoundingClientRect();
+    if (rect.width <= 0) return;
+    const action = tapZoneAction({
+      xRatio: (event.clientX - rect.left) / rect.width,
+      flow: readerSettings.flow,
+      hasSelection: Boolean(activeSelection),
+    });
+    if (action === "prev") readerRef.current?.prev();
+    else if (action === "next") readerRef.current?.next();
+    else if (action === "toggle-chrome") setChromeVisible((v) => !v);
+  },
+  [isComic, readerSettings.flow, activeSelection],
+);
+```
+
+(`activeSelection` = the page's existing selection state variable; use its real name.)
+
+3. Gate chrome rendering: wrap the existing `<header>` and the Task-4 `<ReaderFooter>` in `{chromeVisible && (…)}`. Comics always render chrome (`chromeVisible || isComic`).
+4. Reappear on mouse-move-to-edge (pointer devices):
+
+```typescript
+useEffect(() => {
+  if (chromeVisible) return;
+  const onMove = (event: MouseEvent) => {
+    if (event.clientY < 24 || window.innerHeight - event.clientY < 24) {
+      setChromeVisible(true);
+    }
+  };
+  window.addEventListener("mousemove", onMove);
+  return () => window.removeEventListener("mousemove", onMove);
+}, [chromeVisible]);
+```
+
+- [ ] **Step 4: Run the page suite**
+
+Run: `cd web && pnpm exec vitest run src/pages/EbookReader.test.tsx`
+Expected: PASS
+
+- [ ] **Step 5: Format and commit**
+
+```bash
+cd web && pnpm exec prettier --write src/pages/EbookReader.tsx src/pages/EbookReader.test.tsx && cd ..
+git add web/src/pages/EbookReader.tsx web/src/pages/EbookReader.test.tsx
+git commit -m "feat(reader): tap zones with auto-hiding chrome
+
+Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>"
+```
+
+---
+
+### Task 6: Keyboard map and shortcuts overlay
+
+**Files:**
+- Create: `web/src/reader/ReaderShortcutsOverlay.tsx`
+- Modify: `web/src/pages/EbookReader.tsx` (extend the keydown effect ~line 462; render overlay)
+- Test: `web/src/pages/EbookReader.test.tsx`
+
+**Interfaces:**
+- Consumes: `READER_SHORTCUTS` (Task 1), `shortcutsOpen`/`setShortcutsOpen` (Task 4), `chromeVisible`/`setChromeVisible` (Task 5), existing `isEditableTarget`, panel/bookmark/fullscreen handlers already in the file (reuse the exact handlers the existing header buttons call).
+- Produces: nothing further.
+
+- [ ] **Step 1: Write failing tests**
+
+```typescript
+it("binds the reader keyboard map with an input guard", async () => {
+  await renderReader();
+  const press = (key: string, target?: EventTarget) =>
+    act(() => {
+      window.dispatchEvent(new KeyboardEvent("keydown", { key, bubbles: true }));
+    });
+
+  press("?");
+  expect(document.body.textContent).toContain("Keyboard shortcuts");
+  press("Escape"); // closes overlay first
+  expect(document.body.textContent).not.toContain("Previous / next page");
+
+  press("Escape"); // then toggles chrome
+  expect(document.querySelector("header")).toBeNull();
+
+  // single letters do nothing from inputs
+  const input = document.createElement("input");
+  document.body.appendChild(input);
+  input.focus();
+  press("t");
+  // panel did not open — assert via the panel's test id/text used elsewhere in this file
+});
+
+it("Home and End jump to chapter bounds", async () => {
+  await renderReader();
+  act(() => {
+    mocks.lastOnLocationChange?.({ fraction: 0.3, sectionIndex: 1, tocLabel: "Ch 2" });
+  });
+  act(() => {
+    window.dispatchEvent(new KeyboardEvent("keydown", { key: "Home" }));
+  });
+  expect(mocks.readerGoToFraction).toHaveBeenCalledWith(0.25);
+  act(() => {
+    window.dispatchEvent(new KeyboardEvent("keydown", { key: "End" }));
+  });
+  expect(mocks.readerGoToFraction).toHaveBeenCalledWith(0.6);
+});
+```
+
+- [ ] **Step 2: Run to verify failure**
+
+Run: `cd web && pnpm exec vitest run src/pages/EbookReader.test.tsx -t "keyboard map"`
+Expected: FAIL — overlay text absent, goToFraction not called
+
+- [ ] **Step 3: Implement**
+
+`web/src/reader/ReaderShortcutsOverlay.tsx`:
+
+```tsx
+import { READER_SHORTCUTS } from "./readerNavigation";
+import { Button } from "@/components/ui/button";
+
+export default function ReaderShortcutsOverlay({ onClose }: { onClose: () => void }) {
+  return (
+    <div
+      role="dialog"
+      aria-modal="true"
+      aria-label="Keyboard shortcuts"
+      className="fixed inset-0 z-40 flex items-center justify-center bg-black/50"
+      onClick={onClose}
+    >
+      <div
+        className="bg-background border-border w-80 rounded-lg border p-4 shadow-lg"
+        onClick={(event) => event.stopPropagation()}
+      >
+        <h2 className="mb-3 text-sm font-semibold">Keyboard shortcuts</h2>
+        <dl className="space-y-1.5 text-sm">
+          {READER_SHORTCUTS.map((shortcut) => (
+            <div key={shortcut.key} className="flex justify-between gap-4">
+              <dt className="text-muted-foreground">{shortcut.description}</dt>
+              <dd className="font-mono">{shortcut.key}</dd>
+            </div>
+          ))}
+        </dl>
+        <Button className="mt-4 w-full" variant="outline" size="sm" onClick={onClose} autoFocus>
+          Close
+        </Button>
+      </div>
+    </div>
+  );
+}
+```
+
+In `EbookReader.tsx`, replace the arrow-key effect (~line 462) with the full map. Reuse the exact existing handlers the header buttons call for TOC/search panel toggles, bookmark, and fullscreen (find them where the header buttons are defined; do not invent new ones):
+
+```typescript
+useEffect(() => {
+  const handleKeyDown = (event: KeyboardEvent) => {
+    if (event.defaultPrevented || isEditableTarget(event.target)) return;
+    switch (event.key) {
+      case "ArrowLeft":
+        readerRef.current?.prev();
+        break;
+      case "ArrowRight":
+        readerRef.current?.next();
+        break;
+      case "Home":
+      case "End": {
+        if (isComic) return;
+        const fractions = readerRef.current?.getSectionFractions() ?? [];
+        const extent = chapterExtent(fractions, locationInfoRef.current?.fraction ?? 0);
+        if (!extent) return;
+        event.preventDefault();
+        void readerRef.current?.goToFraction(event.key === "Home" ? extent.start : extent.end);
+        break;
+      }
+      case "t":
+        toggleContentsPanel(); // existing handler name — use the real one
+        break;
+      case "s":
+        toggleSearchPanel(); // existing handler name — use the real one
+        break;
+      case "b":
+        toggleBookmark(); // existing handler name — use the real one
+        break;
+      case "f":
+        toggleFullscreen(); // existing handler name — use the real one
+        break;
+      case "?":
+        setShortcutsOpen(true);
+        break;
+      case "Escape":
+        if (shortcutsOpen) setShortcutsOpen(false);
+        else setChromeVisible((v) => !v);
+        break;
+    }
+  };
+  window.addEventListener("keydown", handleKeyDown);
+  return () => window.removeEventListener("keydown", handleKeyDown);
+}, [isComic, shortcutsOpen /*, the real handler deps */]);
+```
+
+Keep `locationInfo` mirrored in a ref (`locationInfoRef`) updated alongside `setLocationInfo` so the handler avoids re-binding per relocate. Render the overlay next to the footer: `{shortcutsOpen && <ReaderShortcutsOverlay onClose={() => setShortcutsOpen(false)} />}`.
+
+- [ ] **Step 4: Run the page suite**
+
+Run: `cd web && pnpm exec vitest run src/pages/EbookReader.test.tsx`
+Expected: PASS
+
+- [ ] **Step 5: Format and commit**
+
+```bash
+cd web && pnpm exec prettier --write src/pages/EbookReader.tsx src/reader/ReaderShortcutsOverlay.tsx src/pages/EbookReader.test.tsx && cd ..
+git add web/src/pages/EbookReader.tsx web/src/reader/ReaderShortcutsOverlay.tsx web/src/pages/EbookReader.test.tsx
+git commit -m "feat(reader): full keyboard map with shortcuts overlay
+
+Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>"
+```
+
+---
+
+### Task 7: Full verification pass
+
+**Files:**
+- Modify: none expected (fix what the gates surface)
+
+- [ ] **Step 1: Full web test suite**
+
+Run: `cd web && pnpm exec vitest run`
+Expected: all green (fix regressions before proceeding)
+
+- [ ] **Step 2: Lint + format + build**
+
+Run: `cd web && pnpm run lint && pnpm run format:check && pnpm build`
+Expected: 0 errors (pre-existing warnings acceptable), build succeeds
+
+- [ ] **Step 3: Local-path check (spec/plan hygiene)**
+
+Run: `make verify-local-paths` (repo root)
+Expected: passes
+
+- [ ] **Step 4: Manual smoke (deferred to review)**
+
+Note for the reviewer: run `make dev-frontend` against a backend with an ebook library and verify on a phone-width viewport: tap zones page correctly, middle-tap hides all chrome, selection near an edge does not page, footer band tracks chapters, `?` overlay opens/closes.
+
+- [ ] **Step 5: Commit any gate fixes**
+
+```bash
+git add -A && git commit -m "test(reader): stabilize navigation suites
+
+Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>"
+```
+
+(Skip if nothing changed.)

--- a/docs/superpowers/plans/2026-07-20-reading-motivation.md
+++ b/docs/superpowers/plans/2026-07-20-reading-motivation.md
@@ -32,7 +32,17 @@
 - Produces:
   - `func requestLocation(r *http.Request) *time.Location` — parses `tz` query param, `time.LoadLocation`, fallback `time.UTC` (empty/invalid/`Local`-rejected).
   - `reading_goals` + `reading_achievements` tables per spec.
-  - `type ReadingGoals struct { BooksPerYear *int; HoursPerYear *int }`, store methods on a new `ReadingMotivationStore` interface: `GetGoals(ctx, userID, profileID) (*ReadingGoals, error)`, `PutGoals(ctx, userID, profileID string, g ReadingGoals) error`, `AchievedAt(ctx, userID, profileID) (map[string]time.Time, error)`, `PersistAchievement(ctx, userID, profileID, achievementID string, at time.Time) error`, plus `SessionsSince(ctx, userID, profileID string, since time.Time) ([]ReadingSession, error)` (raw rows for the pure math), `FinishedBooksInRange(ctx, userID, profileID string, from, to time.Time) (int, error)`, `GenreSeconds(ctx, userID, profileID string) ([]GenreSeconds, error)`, `AuthorSeconds(ctx, userID, profileID string) ([]AuthorSeconds, error)` — implemented on `PGReadingMotivationStore` (pool).
+  - `type ReadingGoals struct { BooksPerYear *int; HoursPerYear *int }`, store methods on a new `ReadingMotivationStore` interface:
+    - `GetGoals(ctx context.Context, userID int, profileID string) (*ReadingGoals, error)`
+    - `PutGoals(ctx context.Context, userID int, profileID string, g ReadingGoals) error`
+    - `AchievedAt(ctx context.Context, userID int, profileID string) (map[string]time.Time, error)`
+    - `PersistAchievement(ctx context.Context, userID int, profileID, achievementID string, at time.Time) error`
+    - `SessionsSince(ctx context.Context, userID int, profileID string, since time.Time) ([]ReadingSession, error)` (raw rows for the pure math)
+    - `FinishedBooksInRange(ctx context.Context, userID int, profileID string, from, to time.Time) (int, error)`
+    - `HasBookReadAbove(ctx context.Context, userID int, profileID string, threshold float64) (bool, error)` (Task-3-era addition for finisher badge)
+    - `GenreSeconds(ctx context.Context, userID int, profileID string) ([]GenreSeconds, error)`
+    - `AuthorSeconds(ctx context.Context, userID int, profileID string) ([]AuthorSeconds, error)`
+    — implemented on `PGReadingMotivationStore` (pool).
   - `PUT /ebooks/reading-goals` handler (`HandlePutGoals` on `ReadingMotivationHandler{Store; Now func() time.Time}`).
   - History endpoint behavior change (additive): totals/days computed in `requestLocation(r)`.
 
@@ -106,7 +116,14 @@ func requestLocation(r *http.Request) *time.Location {
 }
 ```
 
-Goals: `PUT` decodes `{BooksPerYear *int \`json:"books_per_year"\`; HoursPerYear *int \`json:"hours_per_year"\`}`, validates each non-nil value 1..100000 (400 `invalid_goal` "books_per_year must be between 1 and 100000" / same for hours), `Store.PutGoals` upsert (`INSERT … ON CONFLICT (user_id, profile_id) DO UPDATE SET books_per_year=$3, hours_per_year=$4, updated_at=now()`), 204.
+Goals: `PUT` decodes the following struct, validates each non-nil value 1..100000 (400 `invalid_goal` "books_per_year must be between 1 and 100000" / same for hours), calls `Store.PutGoals` to upsert, 204:
+
+```go
+type putGoalsRequest struct {
+	BooksPerYear *int `json:"books_per_year"`
+	HoursPerYear *int `json:"hours_per_year"`
+}
+```
 
 History tz: in the existing history handler (`reading_sessions.go`), replace the UTC-fixed day computations (today/week/month boundaries + `DailyRollup` day grouping) to use `loc := requestLocation(r)`. For SQL day grouping pass the zone name: `date_trunc('day', started_at AT TIME ZONE $n)` (pass `loc.String()`; `"UTC"` for UTC) — adjust `DailyRollup`/`TotalsSince` signatures to accept `loc *time.Location` and compute range boundaries in that zone. Keep response field names unchanged.
 

--- a/docs/superpowers/plans/2026-07-20-reading-motivation.md
+++ b/docs/superpowers/plans/2026-07-20-reading-motivation.md
@@ -1,0 +1,302 @@
+# Reading Motivation Layer Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Streaks, yearly goals, auto monthly challenges, 18 persistent achievements, and Reading DNA — computed over existing sessions in the requester's timezone, rendered as new sections on `/reading-stats`.
+
+**Architecture:** One new Go file (`reading_motivation.go`) beside the sessions handlers holds pure aggregation math (streaks/challenge/goals/DNA/badge criteria over fetched session rows), two small tables (`reading_goals`, `reading_achievements`), and two routes; a `tz` request param resolved via `time.LoadLocation` governs all day/hour boundaries and is also threaded (additively) into the existing history endpoint. Client: one motivation query hook + four presentational sections appended to `ReadingStats.tsx`.
+
+**Tech Stack:** Go + chi + pgx + Goose; React 19 + TypeScript + React Query + vitest.
+
+## Global Constraints
+
+- Spec: `docs/superpowers/specs/2026-07-20-reading-motivation-design.md` — binding values: 300s streak-day minimum; streak alive until a full local day missed; challenge target `max(prev calendar month seconds, 10800)`; goals ints 1..100000 or null; finished book = progress ≥ `models.EbookFinishedProgressThreshold` (0.9, `internal/models/ebook_progress.go`) with progress-row `updated_at` in the current local year; the 18 badge ids/criteria exactly as listed; diversity = round((1 − Σ share²) × 100); genre seconds split evenly across a book's genres, top 8 + "other"; authors via item_people kind 7; hour buckets morning 05–12 / afternoon 12–17 / evening 17–22 / night 22–05.
+- Timezone: `tz` query param (IANA) on motivation + history endpoints; `time.LoadLocation`, invalid/absent → UTC. Sessions stay stored UTC. Achievement unlocks evaluated with the request's tz, never revoked.
+- Motivation endpoint degrades per-section (partial payload, log the failed section) — never a whole-endpoint 500 for a section failure; goals PUT 400s with field-specific messages; badge persistence failures are silent skips.
+- Routes additive in the `/ebooks` group; conventions identical to `reading_sessions.go` (identity via `apimw`, `writeJSON`/`writeError`).
+- Gates per task: web — vitest focused suites, `pnpm exec tsc --noEmit -p tsconfig.app.json` 0 errors, `pnpm run lint` 0 errors (warnings baseline), prettier; Go — named test runs, `go vet ./internal/api/...`, `gofmt` clean, `make migrate-validate`.
+- Conventional Commits + trailer `Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>`; web commands from `web/`, commits from repo root.
+
+---
+
+### Task 1: Migration + timezone plumbing + goals store/PUT
+
+**Files:**
+- Create: `migrations/sql/20260720230000_reading_motivation.sql`
+- Create: `internal/api/handlers/reading_motivation.go`
+- Create: `internal/api/handlers/reading_motivation_test.go`
+- Modify: `internal/api/handlers/reading_sessions.go` (history handler gains tz-aware day math via the shared helper)
+- Modify: `internal/api/router.go` (PUT route; motivation handler wiring — GET route lands in Task 3)
+
+**Interfaces:**
+- Produces:
+  - `func requestLocation(r *http.Request) *time.Location` — parses `tz` query param, `time.LoadLocation`, fallback `time.UTC` (empty/invalid/`Local`-rejected).
+  - `reading_goals` + `reading_achievements` tables per spec.
+  - `type ReadingGoals struct { BooksPerYear *int; HoursPerYear *int }`, store methods on a new `ReadingMotivationStore` interface: `GetGoals(ctx, userID, profileID) (*ReadingGoals, error)`, `PutGoals(ctx, userID, profileID string, g ReadingGoals) error`, `AchievedAt(ctx, userID, profileID) (map[string]time.Time, error)`, `PersistAchievement(ctx, userID, profileID, achievementID string, at time.Time) error`, plus `SessionsSince(ctx, userID, profileID string, since time.Time) ([]ReadingSession, error)` (raw rows for the pure math), `FinishedBooksInRange(ctx, userID, profileID string, from, to time.Time) (int, error)`, `GenreSeconds(ctx, userID, profileID string) ([]GenreSeconds, error)`, `AuthorSeconds(ctx, userID, profileID string) ([]AuthorSeconds, error)` — implemented on `PGReadingMotivationStore` (pool).
+  - `PUT /ebooks/reading-goals` handler (`HandlePutGoals` on `ReadingMotivationHandler{Store; Now func() time.Time}`).
+  - History endpoint behavior change (additive): totals/days computed in `requestLocation(r)`.
+
+- [ ] **Step 1: Migration**
+
+```sql
+-- migrations/sql/20260720230000_reading_motivation.sql
+-- +goose Up
+CREATE TABLE IF NOT EXISTS reading_goals (
+    user_id INTEGER NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+    profile_id TEXT NOT NULL,
+    books_per_year INTEGER,
+    hours_per_year INTEGER,
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    PRIMARY KEY (user_id, profile_id)
+);
+CREATE TABLE IF NOT EXISTS reading_achievements (
+    user_id INTEGER NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+    profile_id TEXT NOT NULL,
+    achievement_id TEXT NOT NULL,
+    achieved_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    PRIMARY KEY (user_id, profile_id, achievement_id)
+);
+
+-- +goose Down
+DROP TABLE IF EXISTS reading_achievements;
+DROP TABLE IF EXISTS reading_goals;
+```
+
+`make migrate-validate` → passes.
+
+- [ ] **Step 2: Failing tests**
+
+In `reading_motivation_test.go` (fake store maps; identity-context helpers as in `reading_sessions_test.go`):
+
+```go
+func TestRequestLocation(t *testing.T)
+// ?tz=Europe/Amsterdam → that location; absent → UTC; ?tz=Nonsense → UTC; ?tz=Local → UTC.
+
+func TestPutGoalsValidatesAndPersists(t *testing.T)
+// {"books_per_year":30,"hours_per_year":200} → 204, stored;
+// {"books_per_year":null,"hours_per_year":200} → books cleared, hours 200 (PUT replaces
+//   BOTH fields; absent field = null = cleared — assert a second PUT omitting hours clears it);
+// {"books_per_year":0} and {"hours_per_year":100001} → 400 with field-named message;
+// non-JSON → 400.
+
+func TestHistoryUsesRequestTimezone(t *testing.T)
+// fake sessions store already exists in reading_sessions_test.go — a session at
+// 2026-07-19T23:30:00Z with ?tz=Europe/Amsterdam (UTC+2) lands on local day
+// 2026-07-20; without tz on day 2026-07-19. Assert the days rollup date strings differ.
+// (Drive the EXISTING history handler; this pins the additive tz behavior.)
+```
+
+Run: `go test ./internal/api/handlers -run 'TestRequestLocation|TestPutGoals|TestHistoryUsesRequestTimezone' -count=1` → FAIL undefined.
+
+- [ ] **Step 3: Implement**
+
+`requestLocation` in `reading_motivation.go`:
+
+```go
+func requestLocation(r *http.Request) *time.Location {
+    name := strings.TrimSpace(r.URL.Query().Get("tz"))
+    if name == "" || name == "Local" {
+        return time.UTC
+    }
+    loc, err := time.LoadLocation(name)
+    if err != nil {
+        return time.UTC
+    }
+    return loc
+}
+```
+
+Goals: `PUT` decodes `{BooksPerYear *int \`json:"books_per_year"\`; HoursPerYear *int \`json:"hours_per_year"\`}`, validates each non-nil value 1..100000 (400 `invalid_goal` "books_per_year must be between 1 and 100000" / same for hours), `Store.PutGoals` upsert (`INSERT … ON CONFLICT (user_id, profile_id) DO UPDATE SET books_per_year=$3, hours_per_year=$4, updated_at=now()`), 204.
+
+History tz: in the existing history handler (`reading_sessions.go`), replace the UTC-fixed day computations (today/week/month boundaries + `DailyRollup` day grouping) to use `loc := requestLocation(r)`. For SQL day grouping pass the zone name: `date_trunc('day', started_at AT TIME ZONE $n)` (pass `loc.String()`; `"UTC"` for UTC) — adjust `DailyRollup`/`TotalsSince` signatures to accept `loc *time.Location` and compute range boundaries in that zone. Keep response field names unchanged.
+
+Wire `readingMotivationHandler` in router.go beside `readingSessionsHandler`; route `r.Put("/reading-goals", readingMotivationHandler.HandlePutGoals)` (nil-guarded).
+
+- [ ] **Step 4: Run + gates** — the three named tests PASS; existing `TestReadingStats*`/`TestReadingHeartbeat*` still green; vet/gofmt/migrate-validate clean.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add migrations/sql/20260720230000_reading_motivation.sql internal/api/handlers/reading_motivation.go internal/api/handlers/reading_motivation_test.go internal/api/handlers/reading_sessions.go internal/api/router.go
+git commit -m "feat(reader): reading goals and requester-timezone day math
+
+Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>"
+```
+
+---
+
+### Task 2: Pure aggregation math — streaks, challenge, goals progress, DNA, badge criteria
+
+**Files:**
+- Modify: `internal/api/handlers/reading_motivation.go`
+- Modify: `internal/api/handlers/reading_motivation_test.go`
+
+**Interfaces:**
+- Consumes: `ReadingSession` rows (Task 1's `SessionsSince`).
+- Produces (Task 3 calls these; all pure, no I/O):
+
+```go
+type DaySeconds map[string]int // "YYYY-MM-DD" in loc → seconds
+func sessionDaySeconds(sessions []ReadingSession, loc *time.Location) DaySeconds
+func streakFrom(days DaySeconds, today string) (current, longest int) // 300s minimum per spec
+func monthChallenge(days DaySeconds, now time.Time, loc *time.Location) (targetSec, monthSec int)
+func goalProjection(ytd float64, yearElapsedFraction float64) float64 // linear on-track-for
+type dnaAggregates struct { Genres []GenreSeconds; Authors []AuthorSeconds; AvgSessionSeconds int; HoursByBucket map[string]int; ProjectedYearHours float64; DiversityScore int }
+func computeDNA(sessions []ReadingSession, genres []GenreSeconds, authors []AuthorSeconds, now time.Time, loc *time.Location) dnaAggregates
+type achievementInput struct { TotalSeconds int; LongestSessionSeconds int; CurrentStreak, LongestStreak int; BooksFinished int; NightSeconds, EarlyBirdSeconds, WeekendSeconds int; DistinctGenres int; MaxBookSeconds int; FinishedWithHighRead bool }
+func evaluateAchievements(in achievementInput) []string // ids of satisfied badges
+var achievementDefinitions []AchievementDefinition // 18 entries: {ID, Category, Name, Description}
+```
+
+- [ ] **Step 1: Failing tests** (table-driven; write fully — key cases):
+
+```go
+func TestSessionDaySecondsUsesLocation(t *testing.T)
+// 23:30Z session, Europe/Amsterdam → next local day.
+
+func TestStreakMath(t *testing.T)
+// days {d-2:400, d-1:400, d:100} today=d → current 2 (today unqualified but alive), longest 2
+// days {d-1:400, d:400} → current 2; gap breaks: {d-3:400, d-1:400, d:400} → current 2, longest 2
+// sub-300s days never count; empty → 0,0.
+
+func TestMonthChallenge(t *testing.T)
+// prev month 20000s → target 20000; prev month 3600s → target 10800 (floor);
+// month boundaries computed in loc (a session at prev-month-end 23:30Z with +02:00 counts current month).
+
+func TestComputeDNA(t *testing.T)
+// diversity: single genre → 0; two equal genres → 50; bucket assignment at 05/12/17/22 boundaries;
+// avg session length; projection = ytdHours / elapsedFraction.
+
+func TestEvaluateAchievements(t *testing.T)
+// each of the 18 at its boundary: satisfied at exactly the threshold, unsatisfied just below
+// (3600s→first-hour, 7200s single session→marathon, streak 3/7/30/100, books 1/10/50,
+//  36000s night→night-owl, 36000s early→early-bird, 72000s weekend→weekender,
+//  5 genres→genre-hopper, 36000s one book→deep-diver, FinishedWithHighRead→finisher).
+```
+
+Run → FAIL undefined.
+
+- [ ] **Step 2: Implement** the pure functions per spec. Notes: `streakFrom` walks back from `today`; today counts if qualified but does not break the streak while unqualified; `monthChallenge` uses `time.Date(y, m, 1, 0,0,0,0, loc)` boundaries; `computeDNA` buckets by `started_at.In(loc).Hour()` (morning 5–11, afternoon 12–16, evening 17–21, night 22–4), diversity over genre-seconds shares, projection guards `elapsedFraction < 0.01` → use ytd as projection. 18 definitions in a package-level slice, ids exactly as spec.
+
+- [ ] **Step 3: Run + gates** — named tests PASS; vet/gofmt.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add internal/api/handlers/reading_motivation.go internal/api/handlers/reading_motivation_test.go
+git commit -m "feat(reader): motivation aggregation math
+
+Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>"
+```
+
+---
+
+### Task 3: Motivation endpoint — assembly, achievement persistence, DNA queries
+
+**Files:**
+- Modify: `internal/api/handlers/reading_motivation.go` (+`HandleGetMotivation`, PG store queries for `FinishedBooksInRange`/`GenreSeconds`/`AuthorSeconds`)
+- Modify: `internal/api/handlers/reading_motivation_test.go`
+- Modify: `internal/api/router.go` (`r.Get("/reading-motivation", …)`)
+
+**Interfaces:**
+- Produces: `GET /ebooks/reading-motivation?tz=…` → the spec's exact payload (field names verbatim from the spec's API section). Achievements evaluated + newly-satisfied persisted via `PersistAchievement` (`ON CONFLICT DO NOTHING`), response's `achieved_at` from the merged map (existing ∪ new). Per-section degradation: each section computed in its own step; on error, log via `slog` and emit that section's zero value (empty arrays / zeroed struct), never abort.
+
+- [ ] **Step 1: Failing tests**
+
+```go
+func TestMotivationEndpointShape(t *testing.T)
+// fake store with sessions/goals/achievements fixtures → 200; assert exact JSON keys:
+// streak{current_days,longest_days,today_seconds,today_qualified}, goals{...6 fields},
+// challenge{target_seconds,month_seconds,percent}, achievements[18]{id,category,name,description,achieved_at},
+// dna{genres,authors,diversity_score,avg_session_seconds,hours_by_bucket,projected_year_hours}.
+
+func TestMotivationPersistsNewUnlocks(t *testing.T)
+// fixtures satisfying first-hour + streak-3, store already has first-hour →
+// PersistAchievement called ONLY for streak-3; response shows both achieved.
+
+func TestMotivationDegradesPerSection(t *testing.T)
+// GenreSeconds returns error → 200 with dna.genres = [] and other sections intact.
+
+func TestMotivationUsesTimezone(t *testing.T)
+// same 23:30Z-session trick: ?tz shifts streak/today attribution.
+```
+
+Run → FAIL.
+
+- [ ] **Step 2: Implement.** SQL: `FinishedBooksInRange` = `SELECT COUNT(*) FROM ebook_reader_progress WHERE user_id=$1 AND profile_id=$2 AND progress >= $3 AND updated_at >= $4 AND updated_at < $5` (`$3 = models.EbookFinishedProgressThreshold`); `GenreSeconds` = per-genre even split:
+
+```sql
+SELECT g.genre, SUM(rs.duration_seconds::float / GREATEST(cardinality(mi.genres), 1))::bigint
+FROM reading_sessions rs
+JOIN media_items mi ON mi.content_id = rs.content_id
+CROSS JOIN LATERAL unnest(mi.genres) AS g(genre)
+WHERE rs.user_id=$1 AND rs.profile_id=$2
+GROUP BY g.genre ORDER BY 2 DESC
+```
+
+`AuthorSeconds` joins `item_people ip ON ip.content_id = rs.content_id AND ip.kind = 7` + `people p ON p.id = ip.person_id`, grouped by `p.name`, top 8. Handler assembles: sessions (since epoch for totals; the pure funcs slice as needed), goals row, finished counts (local-year range), achievements merge+persist, DNA. Percent = `min(100, round(month/target*100))`.
+
+- [ ] **Step 3: Run + gates** — all motivation tests + full handlers package PASS; vet/gofmt.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add internal/api/handlers/reading_motivation.go internal/api/handlers/reading_motivation_test.go internal/api/router.go
+git commit -m "feat(reader): reading motivation endpoint with persistent achievements
+
+Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>"
+```
+
+---
+
+### Task 4: Client — hooks, tz param, four page sections
+
+**Files:**
+- Modify: `web/src/hooks/queries/readingStats.ts` (+`useReadingMotivation`, `putReadingGoals`; existing hooks gain the `tz` param via a shared `clientTimezone()` helper)
+- Create: `web/src/components/stats/MotivationSections.tsx` (streak+challenge row, goals card, badge grid, DNA card — four exported components)
+- Create: `web/src/components/stats/MotivationSections.test.tsx`
+- Modify: `web/src/pages/ReadingStats.tsx` (render the sections after totals)
+- Modify: `web/src/pages/ReadingStats.test.tsx`
+
+**Interfaces:**
+- Consumes: motivation endpoint payload (Task 3 shape), `formatDuration`.
+- Produces: `clientTimezone(): string` (`Intl.DateTimeFormat().resolvedOptions().timeZone ?? "UTC"`) exported from `readingStats.ts` and appended as `tz` to motivation AND history fetches; `useReadingMotivation()` (staleTime 5 min); `putReadingGoals({books_per_year, hours_per_year})`.
+
+- [ ] **Step 1: Failing tests**
+
+```typescript
+// MotivationSections.test.tsx (fixture payload):
+// streak row shows current/longest and challenge percent bar width;
+// goals card: inputs prefilled, blur with changed value calls putReadingGoals (mocked),
+//   invalid (0/negative) shows inline error and does not call; empty state when both null;
+// badge grid renders 18, locked dimmed (aria-disabled or data-locked), achieved show date;
+// DNA card renders top genres bars, authors, diversity number, buckets, projection.
+// ReadingStats.test.tsx: sections render from mocked useReadingMotivation; history fetch
+//   URL includes tz=<mocked zone> (mock Intl.DateTimeFormat resolvedOptions).
+```
+
+Run → FAIL (module missing).
+
+- [ ] **Step 2: Implement.** Hooks per Task 4 interface (key `ebookKeys.readingMotivation()`); sections as presentational components taking the payload slices as props (page passes `data?.streak` etc., each section null-tolerant rendering its empty state). Styling: existing card conventions from the page (same wrappers as totals/heatmap sections); no new dependencies; badge grid = CSS grid of bordered tiles grouped by category headings.
+
+- [ ] **Step 3: Run + gates** — new suites + ReadingStats + full `src/components/stats src/hooks src/pages/ReadingStats.test.tsx` green; tsc 0; lint 0; prettier.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add web/src/hooks/queries/readingStats.ts web/src/components/stats/MotivationSections.tsx web/src/components/stats/MotivationSections.test.tsx web/src/pages/ReadingStats.tsx web/src/pages/ReadingStats.test.tsx
+git commit -m "feat(reader): streaks, goals, badges, and Reading DNA on the stats page
+
+Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>"
+```
+
+---
+
+### Task 5: Full verification pass
+
+- [ ] **Step 1:** `cd web && pnpm exec vitest run` — green except the 7 documented pre-existing upstream failures.
+- [ ] **Step 2:** `cd web && pnpm run lint && pnpm run format:check && pnpm build`.
+- [ ] **Step 3:** `go test ./internal/api/handlers -count=1 && go build ./...` (after pnpm build).
+- [ ] **Step 4:** `make migrate-validate && make verify-local-paths`.
+- [ ] **Step 5:** Reviewer note: manual pass — set goals, read past midnight local, confirm streak day attribution in CEST, unlock first-hour badge, DNA populates.
+- [ ] **Step 6:** Commit fixes as `test(reader): stabilize motivation suites` (skip if clean).

--- a/docs/superpowers/plans/2026-07-20-reading-stats-foundation.md
+++ b/docs/superpowers/plans/2026-07-20-reading-stats-foundation.md
@@ -1,0 +1,319 @@
+# Reading Stats Foundation Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Server-side reading sessions from client heartbeats, pace/time-remaining in the reader footer, and a per-profile Reading Stats page with heatmap, totals, top books, and a session timeline.
+
+**Architecture:** A `reading_sessions` table fed by a coalescing heartbeat handler (all logic in one new Go file beside the reader handlers); two read endpoints (per-book pace, profile history rollups) computed by query; a fake-timer-testable `useReadingHeartbeat` hook mounted by the prose reader; the footer's reserved time-left slot fed by a React Query hook; a new `/reading-stats` page of presentational components.
+
+**Tech Stack:** Go + chi + pgx + Goose; React 19 + TypeScript + React Query + vitest.
+
+## Global Constraints
+
+- Spec: `docs/superpowers/specs/2026-07-20-reading-stats-foundation-design.md` — constants and payload shapes there are binding: 30s heartbeat cadence, 60s activity window, 120s session gap, 90s per-beat credit cap, 14-day pace window, 10-min book / 30-min profile pace minimums, 5-min footer refresh, most-recent-50 sessions, UTC day boundaries.
+- Routes additive, inside the `/ebooks` group (`internal/api/router.go` ~2230, `apimw.RequireProfile`); identity via `apimw.GetUserID`/`apimw.GetProfileID`; helpers `writeJSON`/`writeError` (handlers/auth.go:583); date params parsed like `calendar.go:101` (`time.Parse("2006-01-02", …)`).
+- Comics never heartbeat; heartbeat responses ignored client-side; failures silent.
+- Gates per task: focused tests; before commit — web: `pnpm exec tsc --noEmit -p tsconfig.app.json` 0 errors, `pnpm run lint` 0 errors (159-warning baseline), prettier; Go: `go test ./internal/api/handlers -run TestReadingSession -count=1` (plus new names), `go vet ./internal/api/...`, `gofmt` clean, `make migrate-validate`.
+- Conventional Commits, trailer `Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>`; web commands from `web/`, commits from repo root.
+
+---
+
+### Task 1: Sessions backend — migration, store, heartbeat coalescing
+
+**Files:**
+- Create: `migrations/sql/20260720210000_reading_sessions.sql`
+- Create: `internal/api/handlers/reading_sessions.go`
+- Create: `internal/api/handlers/reading_sessions_test.go`
+- Modify: `internal/api/router.go` (route + handler wiring beside `readerFontsHandler`)
+
+**Interfaces:**
+- Produces: `POST /ebooks/{content_id}/reading-heartbeat` body `{"fraction": number}` → 204 (400 invalid fraction). Go: `type ReadingSessionsHandler struct { Store ReadingSessionStore; Now func() time.Time }`, `ReadingSessionStore` interface (Task 2 adds its read methods to this same interface and file), `NewPGReadingSessionStore(pool)`. Constants `heartbeatSessionGap = 120 * time.Second`, `heartbeatMaxCredit = 90 * time.Second`.
+
+- [ ] **Step 1: Migration**
+
+```sql
+-- migrations/sql/20260720210000_reading_sessions.sql
+-- +goose Up
+CREATE TABLE IF NOT EXISTS reading_sessions (
+    id BIGINT GENERATED ALWAYS AS IDENTITY PRIMARY KEY,
+    user_id INTEGER NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+    profile_id TEXT NOT NULL,
+    content_id TEXT NOT NULL,
+    started_at TIMESTAMPTZ NOT NULL,
+    last_heartbeat_at TIMESTAMPTZ NOT NULL,
+    duration_seconds INTEGER NOT NULL DEFAULT 0,
+    start_fraction REAL NOT NULL,
+    end_fraction REAL NOT NULL
+);
+CREATE INDEX IF NOT EXISTS idx_reading_sessions_recency
+    ON reading_sessions (user_id, profile_id, last_heartbeat_at);
+CREATE INDEX IF NOT EXISTS idx_reading_sessions_book
+    ON reading_sessions (user_id, profile_id, content_id);
+
+-- +goose Down
+DROP TABLE IF EXISTS reading_sessions;
+```
+
+Run: `make migrate-validate` → passes.
+
+- [ ] **Step 2: Failing tests (fake store, injected clock)**
+
+In `reading_sessions_test.go` build `fakeReadingSessionStore` (in-memory slice implementing the store interface with a `latestOpen(user, profile, content)` helper) and drive the handler with `httptest` + chi route params + `apimw` test context (copy the identity-context setup pattern from `reader_fonts_test.go`). `Now` is a swappable `func() time.Time` on the handler. Write fully:
+
+```go
+func TestReadingHeartbeatStartsAndExtendsSessions(t *testing.T)
+// t0: POST fraction 0.10 → 204; store has one session: duration 0, start=end=0.10.
+// t0+30s: fraction 0.12 → same session: duration 30, end_fraction 0.12.
+// t0+30s+200s (gap > 120s): fraction 0.13 → NEW session row; first session untouched.
+
+func TestReadingHeartbeatCapsCredit(t *testing.T)
+// beats at t0, t0+100s (gap 100 < 120 extends, credit min(100,90)=90): duration 90.
+
+func TestReadingHeartbeatValidatesFraction(t *testing.T)
+// fraction -0.1, 1.5, NaN (json "NaN" is invalid → decode error), missing → 400; store untouched.
+
+func TestReadingHeartbeatScopedToProfile(t *testing.T)
+// beats from profile A then profile B on same book → two separate sessions.
+```
+
+Run: `go test ./internal/api/handlers -run TestReadingHeartbeat -count=1` → FAIL undefined symbols.
+
+- [ ] **Step 3: Implement**
+
+`reading_sessions.go`:
+
+```go
+type ReadingSession struct {
+    ID              int64
+    UserID          int
+    ProfileID       string
+    ContentID       string
+    StartedAt       time.Time
+    LastHeartbeatAt time.Time
+    DurationSeconds int
+    StartFraction   float64
+    EndFraction     float64
+}
+
+type ReadingSessionStore interface {
+    LatestOpen(ctx context.Context, userID int, profileID, contentID string, since time.Time) (*ReadingSession, error)
+    Insert(ctx context.Context, s ReadingSession) error
+    Extend(ctx context.Context, id int64, lastHeartbeatAt time.Time, addSeconds int, endFraction float64) error
+}
+```
+
+`HandleHeartbeat`: identity from `apimw`; decode `{Fraction float64}` (reject !(<0..1> finite)); `now := h.Now()`; `open, _ := Store.LatestOpen(..., now.Add(-heartbeatSessionGap))`; if open → `credit := min(now.Sub(open.LastHeartbeatAt), heartbeatMaxCredit)`, `Store.Extend(open.ID, now, int(credit.Seconds()), fraction)`; else `Store.Insert` with duration 0, start=end=fraction, started=lastHeartbeat=now. Respond 204 always on success; store errors → 500 (client ignores). PG store: `LatestOpen` = `SELECT … WHERE user_id=$1 AND profile_id=$2 AND content_id=$3 AND last_heartbeat_at >= $4 ORDER BY last_heartbeat_at DESC LIMIT 1`; `Extend` = `UPDATE … SET last_heartbeat_at=$2, duration_seconds=duration_seconds+$3, end_fraction=$4 WHERE id=$1`.
+
+Route in the `/ebooks` group: `if readingSessionsHandler != nil { r.Post("/{content_id}/reading-heartbeat", readingSessionsHandler.HandleHeartbeat) }`; wire `readingSessionsHandler = &handlers.ReadingSessionsHandler{Store: handlers.NewPGReadingSessionStore(deps.DB), Now: func() time.Time { return time.Now().UTC() }}` beside `readerFontsHandler`.
+
+- [ ] **Step 4: Run + gates**
+
+`go test ./internal/api/handlers -run TestReadingHeartbeat -count=1` PASS; `go vet ./internal/api/...`; `gofmt -l internal/` clean for touched files; `make migrate-validate`.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add migrations/sql/20260720210000_reading_sessions.sql internal/api/handlers/reading_sessions.go internal/api/handlers/reading_sessions_test.go internal/api/router.go
+git commit -m "feat(reader): coalesce reading heartbeats into sessions
+
+Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>"
+```
+
+---
+
+### Task 2: Stats read endpoints — pace/time-left + history rollups
+
+**Files:**
+- Modify: `internal/api/handlers/reading_sessions.go` (+ store methods, two handlers, route lines)
+- Modify: `internal/api/handlers/reading_sessions_test.go`
+- Modify: `internal/api/router.go` (two `r.Get` lines in the same block)
+
+**Interfaces:**
+- Produces:
+  - `GET /ebooks/{content_id}/reading-stats` → `{"pace_fraction_per_hour": number|null, "time_left_seconds": number|null, "book_seconds": number}`
+  - `GET /ebooks/reading-stats?from=YYYY-MM-DD&to=YYYY-MM-DD` → the spec's `{totals, days, books, sessions}` shape (field names exactly as spec; `sessions` capped 50, newest first; `books` newest-read first; missing titles → `"Removed book"`).
+- Store gains: `PaceWindow(ctx, userID int, profileID, contentID string, since time.Time) (fractions float64, seconds int, err error)` (contentID `""` = all books), `BookSeconds(ctx, …) (int, error)`, `DailyRollup(ctx, userID int, profileID string, from, to time.Time) ([]DayTotal, error)`, `BookTotals(…) ([]BookTotal, error)`, `RecentSessions(…, limit int) ([]SessionRow, error)`, `TotalsSince(ctx, …, since time.Time) (int, error)`.
+- Pure, unit-tested: `func paceAndTimeLeft(bookF float64, bookSec int, allF float64, allSec int, progress float64) (paceFPH *float64, timeLeftSec *int64)` implementing the spec thresholds (book ≥600s wins; else all ≥1800s; else nil).
+
+- [ ] **Step 1: Failing tests**
+
+```go
+func TestPaceAndTimeLeftThresholds(t *testing.T)
+// book 0.2 fractions over 1200s, progress 0.5 → pace 0.6/h, timeLeft (0.5/0.0001667)≈3000s (assert ±1)
+// book only 300s of data, all-books 0.3 over 3600s → falls back to all-books pace
+// both under minimums → nil, nil
+// zero/negative fraction deltas with enough seconds → nil (guard divide + nonsense pace)
+
+func TestReadingStatsBookHandler(t *testing.T)
+// fake store returns canned PaceWindow/BookSeconds + progress via a fake progress getter;
+// asserts exact JSON field names and null handling.
+
+func TestReadingStatsHistoryHandler(t *testing.T)
+// fake store: days/books/sessions fixtures; default range (no params) = last 366 days;
+// bad from/to → 400; titles LEFT-JOIN fallback "Removed book" (fake returns empty title);
+// sessions capped at 50 (fixture 60 → assert 50).
+```
+
+Progress lookup: the per-book handler needs the profile's current fraction — reuse the existing progress store the reader handlers already use (`EbookReaderHandler`'s progress path in `ebook_reader.go`; inject as a small interface `readingProgressGetter { GetProgress(ctx, userID, profileID, contentID) (float64, bool, error) }` implemented by the existing PG progress store — check its exact type and wrap if needed).
+
+Run: FAIL undefined.
+
+- [ ] **Step 2: Implement**
+
+`paceAndTimeLeft` exactly per spec (return values as pointers; `paceFPH = fractions/seconds*3600`). Handlers: per-book — identity, progress lookup (no progress row → progress 0), two `PaceWindow` calls (`since = now-14d`), `BookSeconds`, respond with the trio (nulls when pace nil). History — parse optional from/to (`calendar.go` pattern), default `to=today`, `from=to-365d`, clamp `from<=to`; `TotalsSince` × today/-7d/-30d/all (zero time); assemble spec shape. SQL: `DailyRollup` = `SELECT date_trunc('day', started_at)::date, SUM(duration_seconds) … GROUP BY 1 ORDER BY 1`; `BookTotals` joins `media_items mi ON mi.content_id = reading_sessions.content_id` LEFT for title; `RecentSessions` same join, `ORDER BY started_at DESC LIMIT $n`.
+
+Routes: `r.Get("/reading-stats", h.HandleHistory)` MUST be registered before chi's `/{content_id}/…` wildcard routes in the group so the literal path wins (chi matches literals first regardless of order, but keep it adjacent and add a route test if in doubt — `TestReadingStatsHistoryHandler` covers the handler; add one router-level assertion only if a conflict actually surfaces).
+
+- [ ] **Step 3: Run + gates** — `go test ./internal/api/handlers -run 'TestPaceAndTimeLeft|TestReadingStats' -count=1` PASS; vet/gofmt clean.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add internal/api/handlers/reading_sessions.go internal/api/handlers/reading_sessions_test.go internal/api/router.go
+git commit -m "feat(reader): pace, time-left, and history endpoints
+
+Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>"
+```
+
+---
+
+### Task 3: useReadingHeartbeat hook + reader mount
+
+**Files:**
+- Create: `web/src/hooks/useReadingHeartbeat.ts`
+- Create: `web/src/hooks/useReadingHeartbeat.test.ts`
+- Modify: `web/src/pages/EbookReader.tsx` (mount beside `useTTS()`/`useScreenWakeLock` ~line 299; feed activity from existing relocate/pointer/key paths)
+
+**Interfaces:**
+- Produces:
+
+```typescript
+export function shouldHeartbeat(input: { visible: boolean; lastActivityAt: number; now: number }): boolean; // activity within 60_000ms and visible
+export function useReadingHeartbeat(options: {
+  contentId: string | null;      // null disables (comics, no book)
+  getFraction: () => number;     // current position
+  send?: (contentId: string, fraction: number) => void; // default posts the API
+}): { noteActivity: () => void };
+```
+
+- Default `send` posts `/ebooks/{id}/reading-heartbeat` via the same api client as `ebookReaderApi.ts`, `.catch(() => {})`.
+
+- [ ] **Step 1: Failing tests (vi.useFakeTimers)**
+
+```typescript
+// shouldHeartbeat: visible+fresh → true; hidden → false; stale (>60s) → false.
+// hook (renderHook or a tiny harness component like other hook tests — check
+// web/src/hooks/*.test.* for the convention; if none exists, mount via a test component):
+it("sends immediately on first activity, then every 30s while active", ...)
+// noteActivity() → send called once; advance 30s → second call; advance 30s → third.
+it("stops when idle or hidden and resumes on activity", ...)
+// advance 90s with no activity → no further sends; noteActivity() → immediate send again.
+// simulate visibilitychange hidden → no sends even with activity.
+it("does nothing when contentId is null", ...)
+```
+
+Run: FAIL — module missing.
+
+- [ ] **Step 2: Implement**
+
+Interval started lazily on first `noteActivity`; every tick evaluates `shouldHeartbeat({visible: !document.hidden, lastActivityAt, now: Date.now()})`; sends `send(contentId, clamp01(getFraction()))`. `visibilitychange` listener updates and can trigger an immediate re-check. Cleanup on unmount/contentId change. Refs for callbacks (stable interval).
+
+- [ ] **Step 3: Mount in EbookReader**
+
+```tsx
+const { noteActivity: noteReadingActivity } = useReadingHeartbeat({
+  contentId: isComicFormat ? null : contentId || null,
+  getFraction: () => locationInfoRef.current?.fraction ?? readerProgress ?? 0,
+});
+```
+
+Call `noteReadingActivity()` from: the existing `handleLocationChange` (relocate), `dispatchSurfaceTap`, and the keydown handler (one line each). Extend the FoliateBookReader mock in `EbookReader.test.tsx` only if tsc requires; add one page-level test: relocate then 30s advance → mocked heartbeat api called (mock `@/hooks/useReadingHeartbeat`'s default send via module mock OR pass-through — prefer mocking the api module `useReadingHeartbeat` imports).
+
+- [ ] **Step 4: Suites + gates** — `pnpm exec vitest run src/hooks/useReadingHeartbeat.test.ts src/pages/EbookReader.test.tsx` PASS; tsc/lint/prettier clean.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add web/src/hooks/useReadingHeartbeat.ts web/src/hooks/useReadingHeartbeat.test.ts web/src/pages/EbookReader.tsx web/src/pages/EbookReader.test.tsx
+git commit -m "feat(reader): activity-gated reading heartbeats
+
+Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>"
+```
+
+---
+
+### Task 4: Footer time-left
+
+**Files:**
+- Create: `web/src/hooks/queries/readingStats.ts`
+- Modify: `web/src/reader/ReaderFooter.tsx` (right slot: `34% · 2h 10m left`)
+- Create: `web/src/lib/formatDuration.ts` (+ `formatDuration.test.ts`)
+- Modify: `web/src/pages/EbookReader.tsx` (pass `timeLeftSeconds` to footer)
+- Test: extend `web/src/reader/ReaderFooter.test.tsx`
+
+**Interfaces:**
+- Produces: `formatDuration(seconds: number): string` — `"2h 10m"`, `"45m"`, `"<1m"` (floor minutes; hours+minutes; under 60s → `"<1m"`). `useBookReadingStats(contentId: string | undefined)` React Query hook (queryKey `["reading-stats", contentId]`, `staleTime`/`refetchInterval` 5 minutes, enabled on prose contentId) returning the per-book endpoint shape. `ReaderFooterProps` gains `timeLeftSeconds?: number | null`.
+
+- [ ] **Step 1: Failing tests** — `formatDuration` cases above; ReaderFooter: `timeLeftSeconds: 7800` renders `2h 10m left` beside the percentage, `null`/undefined renders percentage only (assert absence of "left").
+
+- [ ] **Step 2: Implement** — formatter; hook (mirror `useEbookReaderProgress` in `web/src/hooks/queries/ebookReaderProgress.ts`); footer right slot `<span>{percent}%{timeLeftSeconds != null && ` · ${formatDuration(timeLeftSeconds)} left`}</span>`; EbookReader calls the hook (prose only) and passes `data?.time_left_seconds ?? null`.
+
+- [ ] **Step 3: Suites + gates** — footer/lib/page suites + tsc/lint/prettier.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add web/src/lib/formatDuration.ts web/src/lib/formatDuration.test.ts web/src/hooks/queries/readingStats.ts web/src/reader/ReaderFooter.tsx web/src/reader/ReaderFooter.test.tsx web/src/pages/EbookReader.tsx
+git commit -m "feat(reader): time-remaining estimate in the footer
+
+Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>"
+```
+
+---
+
+### Task 5: Reading Stats page
+
+**Files:**
+- Create: `web/src/pages/ReadingStats.tsx`
+- Create: `web/src/pages/ReadingStats.test.tsx`
+- Create: `web/src/components/stats/ReadingHeatmap.tsx` (+ pure helper `heatmapBuckets` in the same file, exported for tests)
+- Modify: `web/src/hooks/queries/readingStats.ts` (add `useReadingHistory(from?, to?)`)
+- Modify: `web/src/App.tsx` (route) and `web/src/components/SideNav.tsx` (nav entry)
+
+**Interfaces:**
+- Consumes: history endpoint shape (Task 2), `formatDuration` (Task 4).
+- Produces: route `/reading-stats` wrapped `<RequireProfile><Layout><ReadingStats /></Layout></RequireProfile>` (match the exact wrapper nesting used by `/catalog` in App.tsx ~L493); SideNav entry "Reading stats" with the `BookOpen` lucide icon following the file's existing entry structure.
+
+- [ ] **Step 1: Failing tests**
+
+```typescript
+// heatmapBuckets(days, max): 0 → bucket 0; quartiles of max → 1..4; returns 366-cell grid
+// aligned to weeks (leading blanks for partial first week).
+// ReadingStats page (mock useReadingHistory): renders totals row (formatDuration applied),
+// top books list with titles incl. "Removed book" fallback rows, sessions timeline entries,
+// and a heatmap cell count matching fixture range.
+```
+
+- [ ] **Step 2: Implement** — page skeleton per `AccessibilitySettings.tsx` conventions (`space-y-6`, `text-2xl font-semibold tracking-tight` header) but as a full page under Layout: totals as a 4-stat row, `ReadingHeatmap` (CSS grid, 53×7, `bg-primary` opacity steps via bucket classes, title tooltip `date · Xm`), top books (link to `/item/{content_id}` unless removed), sessions list (date, book, duration, fraction range). Hook: `useReadingHistory` with default range (no params → server default).
+
+- [ ] **Step 3: Suites + gates** — new suites + `pnpm exec vitest run src/pages/ReadingStats.test.tsx src/components` and the standard web gates.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add web/src/pages/ReadingStats.tsx web/src/pages/ReadingStats.test.tsx web/src/components/stats/ReadingHeatmap.tsx web/src/hooks/queries/readingStats.ts web/src/App.tsx web/src/components/SideNav.tsx
+git commit -m "feat(reader): reading stats page with heatmap and history
+
+Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>"
+```
+
+---
+
+### Task 6: Full verification pass
+
+- [ ] **Step 1:** `cd web && pnpm exec vitest run` — green except the 7 documented pre-existing upstream failures.
+- [ ] **Step 2:** `cd web && pnpm run lint && pnpm run format:check && pnpm build` — 0 errors; build ok.
+- [ ] **Step 3:** `go test ./internal/api/handlers -count=1 && go build ./...` (after pnpm build) — green.
+- [ ] **Step 4:** `make migrate-validate && make verify-local-paths` — pass.
+- [ ] **Step 5:** Reviewer note: manual pass — read a book 2+ minutes, confirm a session row, footer estimate appears after enough data, stats page populates; comics produce no heartbeats.
+- [ ] **Step 6:** Commit fixes as `test(reader): stabilize stats suites` (skip if clean).

--- a/docs/superpowers/specs/2026-07-20-reader-appearance-design.md
+++ b/docs/superpowers/specs/2026-07-20-reader-appearance-design.md
@@ -41,19 +41,21 @@ column layouts.
 
 - Upload .ttf/.otf/.woff/.woff2, max 5 MB per file, max 10 fonts per
   profile.
-- New API under the existing ebook reader route group:
-  - `GET /api/v1/reader/fonts` — list `{ id, name, filename, created_at }`
-  - `POST /api/v1/reader/fonts` — multipart upload; server validates
+- New API inside the existing `/api/v1/ebooks` route group (same
+  `RequireProfile` middleware as all reader endpoints):
+  - `GET /api/v1/ebooks/reader-fonts` — list `{ id, name, filename, created_at }`
+  - `POST /api/v1/ebooks/reader-fonts` — multipart upload; server validates
     magic bytes (sfnt/woff/woff2 signatures), size, and per-profile count caps;
     display name derived from the font's name table when parseable, else
     the filename.
-  - `DELETE /api/v1/reader/fonts/{id}`
-  - `GET /api/v1/reader/fonts/{id}/file` — serves the blob with immutable
+  - `DELETE /api/v1/ebooks/reader-fonts/{id}`
+  - `GET /api/v1/ebooks/reader-fonts/{id}/file` — serves the blob with immutable
     cache headers, per-profile authorization (resolved from the session's
     active profile, like the other reader endpoints), and a font content
     type.
-- Storage: filesystem under the existing app data dir
-  (`fonts/<user_id>/<profile_id>/<id>.<ext>`), metadata in a new
+- Storage: filesystem at `SILO_READER_FONTS_DIR` (default
+  `/var/lib/silo/reader-fonts`, matching the container's `/var/lib/silo/*`
+  bind convention), laid out `<user_id>/<profile_id>/<id>.<ext>`, metadata in a new
   `reader_fonts` table (id, user_id, profile_id, name, filename, format,
   size, created_at). **Per-profile scope**, matching the existing reader
   state tables (`ebook_reader_config`, `ebook_reader_annotations`,

--- a/docs/superpowers/specs/2026-07-20-reader-appearance-design.md
+++ b/docs/superpowers/specs/2026-07-20-reader-appearance-design.md
@@ -68,10 +68,12 @@ column layouts.
 
 ### Columns and justification
 
-- `columns: 1 | 2 | auto` replacing/subsuming the current `spread`
-  control where foliate's paginator supports it (foliate `maxColumnCount`);
-  "auto" keeps today's width-based behavior. (BookOrbit offers up to 4;
-  beyond 2 is poster-size territory — YAGNI, revisit on demand.)
+- `columns: auto | 1 | 2 | 3 | 4` replacing/subsuming the current
+  `spread` control (foliate `maxColumnCount`); "auto" keeps today's
+  width-based behavior. Matches BookOrbit's range; foliate still collapses
+  to fewer columns when the viewport can't fit readable lines.
+- `columnGap: 0–50%` (default matches foliate's current gap), applied with
+  the column count through the content CSS.
 - `justify: boolean` toggle beside the existing hyphenation toggle, applied
   through the same content-CSS path.
 - Both persist in reader settings like every other knob; both inert for
@@ -105,7 +107,7 @@ ruler untouched.
   cap), authorization (cross-user access denied), list/delete; name-table
   parsing fallback.
 - Reader: font-face injection present when an uploaded font is selected;
-  columns/justify reach the content CSS; comics unaffected.
+  columns/columnGap/justify reach the content CSS; comics unaffected.
 
 ## Out of scope
 

--- a/docs/superpowers/specs/2026-07-20-reader-appearance-design.md
+++ b/docs/superpowers/specs/2026-07-20-reader-appearance-design.md
@@ -1,0 +1,109 @@
+# Ebook Reader Appearance: Themes, Custom Fonts, Columns, Justification
+
+Date: 2026-07-20
+Status: approved (visual palette review)
+
+Second of the planned reader improvements, following the page-navigation
+redesign (this branch stacks on `feat/reader-navigation` because both rework
+the reader settings surface). Reading stats, dictionary/translate, and the
+PDF engine remain separate future sub-projects.
+
+## Problem
+
+The reader offers three fixed themes (light/sepia/dark), four built-in font
+stacks, no multi-column layout, and no justification control. Comparable
+readers ship rich paired-palette theme sets, user-supplied fonts, and 1–4
+column layouts.
+
+## Design
+
+### Themes
+
+- Ten themes, each defined as a **palette pair** (light + dark variant):
+  Default, Sepia, Gray, Dawnlight (Solarized), Ember (Gruvbox), Aurora
+  (Nord), Ocean, Meadow, Rosewood, and AMOLED (dark-only: its "light"
+  variant is the same true-black palette).
+- Palette values are those approved in the visual review (hex pairs for
+  background/foreground per variant; highlight/accent derived from the
+  existing annotation color logic, unchanged).
+- The reader gains a **light/dark variant toggle independent of the app
+  theme**. Theme selection = palette name + variant toggle, replacing the
+  current single `theme: light|sepia|dark` enum.
+- Settings migration: stored `theme` values map as `light → Default/light`,
+  `sepia → Sepia/light`, `dark → Default/dark`. Unknown values fall back to
+  Default. The persisted settings shape adds `themeName` and `themeVariant`
+  and keeps writing the legacy `theme` field for one release so older
+  clients/settings snapshots stay coherent.
+- Theme colors apply through the existing foliate styling path
+  (`applyReaderSettings`); no reader-content CSS rework.
+
+### Custom fonts (per-user, server-stored)
+
+- Upload .ttf/.otf/.woff/.woff2, max 5 MB per file, max 10 fonts per user.
+- New API under the existing ebook reader route group:
+  - `GET /api/v1/reader/fonts` — list `{ id, name, filename, created_at }`
+  - `POST /api/v1/reader/fonts` — multipart upload; server validates
+    magic bytes (sfnt/woff/woff2 signatures), size, and count caps;
+    display name derived from the font's name table when parseable, else
+    the filename.
+  - `DELETE /api/v1/reader/fonts/{id}`
+  - `GET /api/v1/reader/fonts/{id}/file` — serves the blob with immutable
+    cache headers, per-user authorization, and a font content type.
+- Storage: filesystem under the existing app data dir
+  (`fonts/<user_id>/<id>.<ext>`), metadata in a new `reader_fonts` table
+  (id, user_id, name, filename, format, size, created_at). Per-user scope
+  (account-level, not profile-level — fonts are assets, not preferences).
+- Reader font picker gains an "Uploaded" group; selecting one injects a
+  `@font-face` into the foliate content styles pointing at the file URL.
+  Books with embedded fonts keep the existing "Book default" behavior.
+- Additive API only; capability discovery via the fonts list endpoint
+  itself (404/501 absent on older servers is not a concern — same-build
+  web UI).
+
+### Columns and justification
+
+- `columns: 1 | 2 | auto` replacing/subsuming the current `spread`
+  control where foliate's paginator supports it (foliate `maxColumnCount`);
+  "auto" keeps today's width-based behavior. (BookOrbit offers up to 4;
+  beyond 2 is poster-size territory — YAGNI, revisit on demand.)
+- `justify: boolean` toggle beside the existing hyphenation toggle, applied
+  through the same content-CSS path.
+- Both persist in reader settings like every other knob; both inert for
+  comics.
+
+### Settings panel layout
+
+The settings panel groups into "Theme" (palette grid with variant toggle),
+"Typography" (font incl. uploads, size, weight, line height, justify,
+hyphenate), and "Layout" (margins, width, columns, flow, writing mode,
+brightness) — same controls plus the new ones, organized; profiles and
+ruler untouched.
+
+## Error handling
+
+- Font upload rejections return structured errors (too large, bad type,
+  cap reached); UI surfaces them inline in the picker.
+- Deleting a font that's referenced by current settings falls back to
+  "Book default" locally.
+- Missing/corrupt stored font file → font-face simply fails to load;
+  browser falls back through the stack; no reader breakage.
+- AMOLED + variant toggle: toggle is disabled (single-variant theme).
+
+## Testing
+
+- Palette table: unit test that every theme has both variants (AMOLED
+  aliased) and valid hex values.
+- Settings migration: legacy `theme` values map correctly; round-trip
+  persistence includes the legacy field.
+- Fonts API: Go handler tests for upload validation (magic bytes, size,
+  cap), authorization (cross-user access denied), list/delete; name-table
+  parsing fallback.
+- Reader: font-face injection present when an uploaded font is selected;
+  columns/justify reach the content CSS; comics unaffected.
+
+## Out of scope
+
+- Reading stats, dictionary/translate, PDF engine (later sub-projects).
+- Per-book font/theme overrides (global reader settings remain global).
+- Font sharing between users or server-wide font libraries.
+- App-shell theming (this is reader-content theming only).

--- a/docs/superpowers/specs/2026-07-20-reader-appearance-design.md
+++ b/docs/superpowers/specs/2026-07-20-reader-appearance-design.md
@@ -39,20 +39,26 @@ column layouts.
 
 ### Custom fonts (per-user, server-stored)
 
-- Upload .ttf/.otf/.woff/.woff2, max 5 MB per file, max 10 fonts per user.
+- Upload .ttf/.otf/.woff/.woff2, max 5 MB per file, max 10 fonts per
+  profile.
 - New API under the existing ebook reader route group:
   - `GET /api/v1/reader/fonts` — list `{ id, name, filename, created_at }`
   - `POST /api/v1/reader/fonts` — multipart upload; server validates
-    magic bytes (sfnt/woff/woff2 signatures), size, and count caps;
+    magic bytes (sfnt/woff/woff2 signatures), size, and per-profile count caps;
     display name derived from the font's name table when parseable, else
     the filename.
   - `DELETE /api/v1/reader/fonts/{id}`
   - `GET /api/v1/reader/fonts/{id}/file` — serves the blob with immutable
-    cache headers, per-user authorization, and a font content type.
+    cache headers, per-profile authorization (resolved from the session's
+    active profile, like the other reader endpoints), and a font content
+    type.
 - Storage: filesystem under the existing app data dir
-  (`fonts/<user_id>/<id>.<ext>`), metadata in a new `reader_fonts` table
-  (id, user_id, name, filename, format, size, created_at). Per-user scope
-  (account-level, not profile-level — fonts are assets, not preferences).
+  (`fonts/<user_id>/<profile_id>/<id>.<ext>`), metadata in a new
+  `reader_fonts` table (id, user_id, profile_id, name, filename, format,
+  size, created_at). **Per-profile scope**, matching the existing reader
+  state tables (`ebook_reader_config`, `ebook_reader_annotations`,
+  `ebook_reader_progress` are all user+profile scoped) — each household
+  profile manages its own font list. Caps apply per profile.
 - Reader font picker gains an "Uploaded" group; selecting one injects a
   `@font-face` into the foliate content styles pointing at the file URL.
   Books with embedded fonts keep the existing "Book default" behavior.

--- a/docs/superpowers/specs/2026-07-20-reader-appearance-design.md
+++ b/docs/superpowers/specs/2026-07-20-reader-appearance-design.md
@@ -46,8 +46,8 @@ column layouts.
   - `GET /api/v1/ebooks/reader-fonts` — list `{ id, name, filename, created_at }`
   - `POST /api/v1/ebooks/reader-fonts` — multipart upload; server validates
     magic bytes (sfnt/woff/woff2 signatures), size, and per-profile count caps;
-    display name derived from the font's name table when parseable, else
-    the filename.
+    display name derived from the sanitized filename (no font name-table
+    parsing).
   - `DELETE /api/v1/ebooks/reader-fonts/{id}`
   - `GET /api/v1/ebooks/reader-fonts/{id}/file` — serves the blob with immutable
     cache headers, per-profile authorization (resolved from the session's
@@ -106,8 +106,7 @@ ruler untouched.
 - Settings migration: legacy `theme` values map correctly; round-trip
   persistence includes the legacy field.
 - Fonts API: Go handler tests for upload validation (magic bytes, size,
-  cap), authorization (cross-user access denied), list/delete; name-table
-  parsing fallback.
+  cap), authorization (cross-profile access denied), list/delete.
 - Reader: font-face injection present when an uploaded font is selected;
   columns/columnGap/justify reach the content CSS; comics unaffected.
 

--- a/docs/superpowers/specs/2026-07-20-reader-page-navigation-design.md
+++ b/docs/superpowers/specs/2026-07-20-reader-page-navigation-design.md
@@ -1,0 +1,106 @@
+# Ebook Reader Page Navigation Redesign
+
+Date: 2026-07-20
+Status: approved (visual mockup review)
+
+First of four planned reader improvements (navigation → reading stats →
+dictionary/translate → PDF engine). This spec covers navigation only.
+
+## Problem
+
+The prose reader's navigation chrome is minimal to a fault. A bare fraction
+slider in the header says "34%" with no sense of position within the chapter —
+the orientation readers actually feel. There is no touch navigation (edge
+buttons only), chrome is always visible and eats vertical space on phones,
+and keyboard support stops at arrow keys with nothing discoverable.
+
+## Design
+
+Modeled on BookOrbit's footer, adapted for silo's touch usage. Applies to
+prose formats only; comics/manga keep their existing dedicated navigation.
+
+### Footer bar (replaces the header slider)
+
+- Progress slider spanning the whole book, with the **current chapter's
+  extent rendered as a highlighted band** under the thumb. Dragging scrubs
+  the whole book; the band recomputes on chapter change and shows the
+  chapter title as a tooltip.
+- Left slot: current chapter title. Books without a TOC hide the band and
+  title and degrade to the plain slider.
+- Right slot: percentage, plus an estimated time-remaining once the
+  reading-stats feature (next sub-project) provides session/pace data. Until
+  then the slot shows percentage only — no placeholder.
+- A `?` affordance opens the keyboard-shortcuts overlay.
+
+### Tap zones and chrome auto-hide
+
+- The page area splits into three tap regions: left third pages back, right
+  third pages forward, middle third toggles chrome visibility.
+- Hidden chrome means both header and footer; the page fills the viewport.
+  Chrome reappears on middle tap, `Esc`, or mouse movement to the top/bottom
+  viewport edge (pointer devices).
+- In scrolled flow, left/right tap zones are disabled (taps would fight text
+  selection and scrolling); middle-tap chrome toggle still applies.
+- Text selection within a tap zone must win over paging: a tap that ends a
+  selection gesture does not turn the page.
+
+### Keyboard
+
+- Existing: `←`/`→` page turns.
+- New: `Home`/`End` jump to current chapter start/end, `t` TOC panel,
+  `s` search panel, `b` toggle bookmark, `f` fullscreen, `?` shortcuts
+  overlay, `Esc` closes overlay/panels or toggles chrome.
+- The shortcuts overlay is a dismissable modal listing the map; it must not
+  capture keys while a text input (search, notes) has focus — none of the
+  single-letter shortcuts fire from inputs.
+
+### Header (unchanged tools, less clutter)
+
+Bookmark, highlight, ruler, TTS, settings, and panel toggles stay in the
+header. The slider leaves it, which is the only header change.
+
+## Implementation shape
+
+Client-only — no API or schema changes.
+
+- `web/src/reader/ReaderFooter.tsx` (new): slider + chapter band + labels +
+  shortcuts affordance. Pure presentational; receives fraction, chapter
+  metadata, and callbacks.
+- Chapter extent: derived from foliate's section sizes and the current
+  section index on `relocate` events (the loader already exposes section
+  fractions); computed in a small pure helper so it is unit-testable.
+- Tap zones: a pointer-event layer in the reader page container
+  (`web/src/pages/EbookReader.tsx`), gated on flow mode and on selection
+  state; unit-tested as a pure decision helper (given pointer event +
+  selection + flow → action).
+- Chrome visibility: single `chromeVisible` state driving header/footer
+  render; auto-hide interactions listed above.
+- Shortcuts overlay: `web/src/reader/ReaderShortcutsOverlay.tsx` (new),
+  static content, focus-trapped.
+- Keyboard handling: extend the existing key handler in `EbookReader.tsx`
+  with the input-focus guard.
+
+## Error handling
+
+- No TOC / single-section books: band and chapter title hidden.
+- Fraction-only formats (position without CFI): slider and band operate on
+  fractions exactly as today's slider does.
+- Time-remaining renders only when pace data exists (feature-detected from
+  the stats API once built); no layout shift when absent.
+
+## Testing
+
+- Pure helpers (chapter extent, tap-zone decision, shortcut dispatch) get
+  focused vitest suites written first.
+- `EbookReader.test.tsx` extended: footer renders chapter metadata, chrome
+  toggling, input-focus guard, comics unaffected.
+- Manual pass on phone-sized viewport for tap zones and auto-hide.
+
+## Out of scope
+
+- Reading stats and the time-remaining data source (next sub-project).
+- Printed page numbers / go-to-page (deferred; revisit if EPUB page-list
+  demand appears).
+- Comics/manga navigation, PDF navigation (PDF engine is a later
+  sub-project).
+- Any server-side change.

--- a/docs/superpowers/specs/2026-07-20-reading-motivation-design.md
+++ b/docs/superpowers/specs/2026-07-20-reading-motivation-design.md
@@ -1,0 +1,142 @@
+# Reading Stats: Motivation Layer
+
+Date: 2026-07-20
+Status: approved (design review)
+
+Fourth reader sub-project; branch stacks on `feat/reader-stats`. Pure
+aggregation over `reading_sessions` and the existing ebook progress data —
+no new tracking, no reader-side changes. Everything lands as new sections on
+the `/reading-stats` page.
+
+## Problem
+
+The stats foundation records time but offers no motivation loop: no streaks,
+goals, challenges, badges, or taste profile.
+
+## Design
+
+### Streaks
+
+- A UTC day counts toward a streak with **≥ 300 seconds** of reading (sum of
+  session `duration_seconds` attributed to `started_at`'s UTC day).
+- Computed on read from sessions: current streak (ending today or yesterday —
+  a streak is "alive" until a full UTC day is missed) and longest streak.
+  No storage.
+
+### Goals (per profile, editable)
+
+- `reading_goals` table: `user_id, profile_id, books_per_year int NULL,
+  hours_per_year int NULL, updated_at` (PK user+profile). NULL = unset.
+- `PUT /api/v1/ebooks/reading-goals` `{books_per_year?, hours_per_year?}`
+  (null clears; positive ints ≤ 100000 validated).
+- Progress computed on read for the current UTC year:
+  - hours: YTD session seconds.
+  - books: ebooks whose progress crossed the existing finished threshold
+    (`models.EbookFinishedProgressThreshold`) with the progress row's
+    `updated_at` in the current year — an approximation of "finished this
+    year" (documented; the progress row's last write when finished is the
+    best available signal without new tracking).
+- Pace projection: linear from year elapsed → "on track for N".
+
+### Monthly challenge (auto-generated)
+
+- Target for the current month = `max(last calendar month's total seconds,
+  10800)` (3-hour floor so an empty month doesn't trivialize it).
+- Response includes target, current month seconds, and percent. No storage;
+  no curated content.
+
+### Achievements (persistent unlocks)
+
+- `reading_achievements` table: `user_id, profile_id, achievement_id text,
+  achieved_at timestamptz` (PK user+profile+achievement_id).
+- Definitions live in Go as a fixed table (id, category, name, description,
+  criteria over the computed aggregates). Evaluated **idempotently** during
+  the motivation endpoint call: any newly satisfied badge is inserted with
+  `ON CONFLICT DO NOTHING`; response returns all definitions with
+  achieved_at (null = locked). Unlocks never revoke.
+- Starter set (18), categories in parentheses:
+  1. `first-hour` (time) — 1 hour total
+  2. `ten-hours` (time) — 10 hours
+  3. `fifty-hours` (time) — 50 hours
+  4. `hundred-hours` (time) — 100 hours
+  5. `marathon-session` (time) — a single session ≥ 2 hours
+  6. `streak-3` (streak) — 3-day streak
+  7. `streak-7` (streak) — 7-day streak
+  8. `streak-30` (streak) — 30-day streak
+  9. `streak-100` (streak) — 100-day streak
+  10. `first-book` (books) — 1 book finished
+  11. `ten-books` (books) — 10 books finished
+  12. `fifty-books` (books) — 50 books finished
+  13. `night-owl` (habits) — ≥ 10 hours read between 00:00–05:00 UTC-local*
+  14. `early-bird` (habits) — ≥ 10 hours read between 05:00–08:00
+  15. `weekender` (habits) — ≥ 20 hours on weekends
+  16. `genre-hopper` (exploration) — sessions in ≥ 5 distinct genres
+  17. `deep-diver` (exploration) — ≥ 10 hours on a single book
+  18. `finisher` (exploration) — finished a book with ≥ 95% read
+  *Habit hours use the session's `started_at` hour; UTC (consistent with all
+  other day math — documented as such in the UI copy).
+
+### Reading DNA (computed, no storage)
+
+- Genre breakdown: session seconds joined through the book's `media_items`
+  genres (seconds split evenly across a book's genres), top 8 + "other".
+- Top authors by reading time (via the ebook author credits, kind 7).
+- Diversity score 0–100: `(1 - Σ share²)` over genre shares (complement of
+  the Herfindahl index), scaled ×100, rounded.
+- Average session length, most-read hour-of-day buckets (morning/afternoon/
+  evening/night), and a year-end projection of hours from YTD pace.
+
+### API
+
+- `GET /api/v1/ebooks/reading-motivation` → one payload:
+  `{streak: {current_days, longest_days, today_seconds, today_qualified},
+    goals: {books_per_year, hours_per_year, books_finished_ytd,
+            hours_ytd, books_on_track_for, hours_on_track_for},
+    challenge: {target_seconds, month_seconds, percent},
+    achievements: [{id, category, name, description, achieved_at}],
+    dna: {genres: [{name, seconds}], authors: [{name, seconds}],
+          diversity_score, avg_session_seconds,
+          hours_by_bucket: {morning, afternoon, evening, night},
+          projected_year_hours}}`
+  Evaluating achievements happens inside this call (insert-new-unlocks).
+- `PUT /api/v1/ebooks/reading-goals` as above; both routes in the `/ebooks`
+  group (RequireProfile), additive.
+
+### UI (new sections on `/reading-stats`, top to bottom after totals)
+
+- Streak + challenge row: current/longest streak with a flame count, the
+  month challenge as a progress bar.
+- Goals card: two editable number inputs (books/year, hours/year) saving on
+  blur via the PUT; progress bars with "on track for N" captions; empty
+  state invites setting a goal.
+- Badge grid: all 18, locked ones dimmed with description; achieved show
+  date. Category grouping.
+- Reading DNA card: genre bar list, top authors, diversity score dial (plain
+  number styling — no chart dependency), hour-bucket row, projection line.
+
+## Error handling
+
+- Motivation endpoint degrades per-section: a failed genre join yields empty
+  DNA genres, never a 500 for the whole payload (partial data over hard
+  failure; log the section error).
+- Goals PUT validates and 400s with field-specific messages.
+- Achievement evaluation failures skip persisting that badge silently (next
+  load retries) — never block the response.
+
+## Testing
+
+- Go: streak math (alive-until-missed-day, longest), goal progress incl.
+  year boundaries and the finished-book approximation, challenge floor,
+  each achievement criterion satisfied/unsatisfied at its boundary,
+  idempotent unlock persistence, DNA math (even genre split, diversity
+  score, buckets, projection); endpoint shape.
+- Client: goals editor save/validation, badge grid locked/unlocked render,
+  streak/challenge/DNA sections from fixtures; graceful partial-payload
+  rendering.
+
+## Out of scope
+
+- Notifications on unlock (future hook; achieved_at persistence enables it).
+- Cross-profile/household leaderboards; sharing.
+- Audiobook time (joins when listening data merges into sessions).
+- Curated/rotating challenge content.

--- a/docs/superpowers/specs/2026-07-20-reading-motivation-design.md
+++ b/docs/superpowers/specs/2026-07-20-reading-motivation-design.md
@@ -67,7 +67,7 @@ goals, challenges, badges, or taste profile.
   10. `first-book` (books) — 1 book finished
   11. `ten-books` (books) — 10 books finished
   12. `fifty-books` (books) — 50 books finished
-  13. `night-owl` (habits) — ≥ 10 hours read between 00:00–05:00 UTC-local*
+  13. `night-owl` (habits) — ≥ 10 hours read between 00:00–05:00*
   14. `early-bird` (habits) — ≥ 10 hours read between 05:00–08:00
   15. `weekender` (habits) — ≥ 20 hours on weekends
   16. `genre-hopper` (exploration) — sessions in ≥ 5 distinct genres

--- a/docs/superpowers/specs/2026-07-20-reading-motivation-design.md
+++ b/docs/superpowers/specs/2026-07-20-reading-motivation-design.md
@@ -17,10 +17,19 @@ goals, challenges, badges, or taste profile.
 
 ### Streaks
 
-- A UTC day counts toward a streak with **≥ 300 seconds** of reading (sum of
-  session `duration_seconds` attributed to `started_at`'s UTC day).
+- All day/hour interpretation in this layer uses the **requester's
+  timezone**: the client sends `tz=<IANA name>` (from
+  `Intl.DateTimeFormat().resolvedOptions().timeZone`) on the motivation and
+  history endpoints; the server resolves it with `time.LoadLocation`,
+  falling back to UTC when absent/invalid. Sessions remain stored in UTC —
+  only aggregation boundaries shift. The existing history endpoint gains
+  the same optional `tz` param (additive; the totals and daily rollup use
+  it so heatmap days match the reader's local midnight).
+- A local-timezone day counts toward a streak with **≥ 300 seconds** of
+  reading (session `duration_seconds` attributed to `started_at` in the
+  requester's zone).
 - Computed on read from sessions: current streak (ending today or yesterday —
-  a streak is "alive" until a full UTC day is missed) and longest streak.
+  a streak is "alive" until a full local day is missed) and longest streak.
   No storage.
 
 ### Goals (per profile, editable)
@@ -29,7 +38,7 @@ goals, challenges, badges, or taste profile.
   hours_per_year int NULL, updated_at` (PK user+profile). NULL = unset.
 - `PUT /api/v1/ebooks/reading-goals` `{books_per_year?, hours_per_year?}`
   (null clears; positive ints ≤ 100000 validated).
-- Progress computed on read for the current UTC year:
+- Progress computed on read for the current year in the requester's zone:
   - hours: YTD session seconds.
   - books: ebooks whose progress crossed the existing finished threshold
     (`models.EbookFinishedProgressThreshold`) with the progress row's
@@ -40,7 +49,7 @@ goals, challenges, badges, or taste profile.
 
 ### Monthly challenge (auto-generated)
 
-- Target for the current month = `max(last calendar month's total seconds,
+- Target for the current month (requester's timezone) = `max(last calendar month's total seconds,
   10800)` (3-hour floor so an empty month doesn't trivialize it).
 - Response includes target, current month seconds, and percent. No storage;
   no curated content.
@@ -73,8 +82,10 @@ goals, challenges, badges, or taste profile.
   16. `genre-hopper` (exploration) — sessions in ≥ 5 distinct genres
   17. `deep-diver` (exploration) — ≥ 10 hours on a single book
   18. `finisher` (exploration) — finished a book with ≥ 95% read
-  *Habit hours use the session's `started_at` hour; UTC (consistent with all
-  other day math — documented as such in the UI copy).
+  *Habit hours and weekend determination use the session's `started_at`
+  in the requester's timezone (see the tz mechanism above). Achievement
+  unlocks are evaluated with the tz of the evaluating request and never
+  revoke; minor tz-dependence at boundaries is accepted.
 
 ### Reading DNA (computed, no storage)
 
@@ -84,7 +95,8 @@ goals, challenges, badges, or taste profile.
 - Diversity score 0–100: `(1 - Σ share²)` over genre shares (complement of
   the Herfindahl index), scaled ×100, rounded.
 - Average session length, most-read hour-of-day buckets (morning/afternoon/
-  evening/night), and a year-end projection of hours from YTD pace.
+  evening/night, requester's timezone), and a year-end projection of hours
+  from YTD pace.
 
 ### API
 

--- a/docs/superpowers/specs/2026-07-20-reading-stats-foundation-design.md
+++ b/docs/superpowers/specs/2026-07-20-reading-stats-foundation-design.md
@@ -1,0 +1,113 @@
+# Reading Stats: Foundation + History
+
+Date: 2026-07-20
+Status: approved (approach review)
+
+Third reader sub-project (after navigation and appearance; branch stacks on
+`feat/reader-appearance`). This spec covers the session engine and history
+visuals. The motivation layer (streaks, goals, achievements, Reading DNA) is
+a separate follow-up spec that aggregates this data and adds no tracking.
+
+## Problem
+
+Silo records only reading position. There is no notion of time spent
+reading, so it cannot show reading history, estimate time remaining (the
+navigation footer reserved a slot for exactly this), or support any future
+goals/achievements layer.
+
+## Design
+
+### Session tracking (heartbeats)
+
+- While the prose reader is genuinely active — document visible AND user
+  interaction (relocate, pointer, key) within the last 60 seconds — the
+  client posts a heartbeat every 30 seconds:
+  `POST /api/v1/ebooks/{content_id}/reading-heartbeat` with
+  `{ "fraction": <current 0..1> }`. Fire-and-forget; a lost heartbeat loses
+  at most 30 seconds of credit. First heartbeat fires immediately on
+  activity, not after the first interval. Comics excluded (this is the
+  prose reader; the comic reader has no session tracking in this spec).
+- Server coalesces heartbeats into sessions (`reading_sessions` table). A
+  heartbeat within 120 seconds of the profile+book's open session extends
+  it: `duration_seconds += min(elapsed_since_last, 90)`, `end_fraction`
+  and `last_heartbeat_at` updated. A larger gap (or no open session)
+  starts a new row with `duration_seconds = 0` and
+  `start_fraction = end_fraction = fraction`. Server clock only; client
+  timestamps are ignored.
+- Table: `reading_sessions(id identity PK, user_id int FK cascade,
+  profile_id text, content_id text, started_at timestamptz,
+  last_heartbeat_at timestamptz, duration_seconds int, start_fraction
+  real, end_fraction real)`, indexes on `(user_id, profile_id,
+  last_heartbeat_at)` and `(user_id, profile_id, content_id)`.
+
+### Pace and time remaining
+
+- Pace = fractions-per-second over recent sessions:
+  `sum(end_fraction - start_fraction) / sum(duration_seconds)` over the
+  profile's sessions for THIS book in the last 14 days (min 10 minutes of
+  data); fallback: same formula across all the profile's books (last 14
+  days, min 30 minutes); else no estimate.
+- `GET /api/v1/ebooks/{content_id}/reading-stats` →
+  `{ "pace_fraction_per_hour": number|null, "time_left_seconds": number|null,
+     "book_seconds": number }` where time-left uses the profile's current
+  progress fraction for that book. The navigation footer shows the
+  "· 2h 10m left" segment when `time_left_seconds` is non-null; absent
+  otherwise (no layout shift — the slot was designed for this).
+- Footer fetches once on book open and refreshes at most every 5 minutes;
+  no per-heartbeat recomputation.
+
+### History API and stats page
+
+- `GET /api/v1/ebooks/reading-stats?from=YYYY-MM-DD&to=YYYY-MM-DD` →
+  `{ "totals": { "today_seconds", "week_seconds", "month_seconds",
+     "all_time_seconds" },
+     "days": [ { "date", "seconds" } … ],           // rollup for range
+     "books": [ { "content_id", "title", "seconds", "last_read_at" } … ],
+     "sessions": [ { "content_id", "title", "started_at",
+                     "duration_seconds", "start_fraction",
+                     "end_fraction" } … ] }          // most recent 50
+  Rollups computed by query (`date_trunc('day', started_at)` grouped) —
+  no aggregate tables. Day boundaries use the server's timezone setting.
+- New per-profile page "Reading stats", reached from the user/profile menu
+  (same placement pattern as other profile-scoped pages): a 12-month
+  contribution-style heatmap (calendar grid of `days`), totals row,
+  top-books-by-time list, and a recent-sessions timeline. Reuses the
+  app's existing card/list components; no new charting dependency — the
+  heatmap is a CSS grid of tinted cells (5 intensity buckets scaled to
+  the profile's max day).
+
+### Wiring
+
+- Routes live in the existing `/ebooks` group (RequireProfile); the
+  heartbeat and per-book stats are content-scoped, the history endpoint is
+  profile-scoped. All additive.
+- Client: a `useReadingHeartbeat` hook owns the activity gate and interval
+  (fake-timer testable, pure decision helper for "is active"); the reader
+  page mounts it for prose books only.
+
+## Error handling
+
+- Heartbeat failures are silent (console-debug at most); no retry queue.
+- Sessions never block reading: handler errors return 4xx/5xx but the
+  client ignores heartbeat responses entirely.
+- Books deleted from the library keep their sessions (content_id has no
+  FK; titles resolve via LEFT JOIN and fall back to "Removed book").
+- Zero-progress sessions (opened, never turned a page) still count time;
+  `start_fraction = end_fraction` is valid.
+
+## Testing
+
+- Go: coalescing rules (extend vs new session, 90s cap, 120s gap),
+  pace/time-left math incl. both fallbacks and the null case, rollup
+  query correctness over fixture sessions, profile scoping.
+- Client: activity gate + interval scheduling with fake timers (visible /
+  hidden / idle transitions), heartbeat payload, footer time-left
+  rendering (present/absent), stats page rendering from fixture data.
+
+## Out of scope
+
+- Streaks, goals, achievements, Reading DNA (follow-up spec).
+- Audiobook/podcast listening time (merges later from the playback
+  system's data).
+- Offline heartbeat queueing; comic reader sessions; cross-device session
+  dedup (two devices reading simultaneously double-count — acceptable).

--- a/docs/superpowers/specs/2026-07-20-reading-stats-foundation-design.md
+++ b/docs/superpowers/specs/2026-07-20-reading-stats-foundation-design.md
@@ -67,9 +67,10 @@ goals/achievements layer.
                      "duration_seconds", "start_fraction",
                      "end_fraction" } … ] }          // most recent 50
   Rollups computed by query (`date_trunc('day', started_at)` grouped) —
-  no aggregate tables. Day boundaries use the server's timezone setting.
-- New per-profile page "Reading stats", reached from the user/profile menu
-  (same placement pattern as other profile-scoped pages): a 12-month
+  no aggregate tables. Day boundaries use UTC (the server has no timezone
+  setting; all handler timestamps are already `time.Now().UTC()`).
+- New per-profile page "Reading stats" at `/reading-stats` (RequireProfile +
+  Layout route like other top-level pages) with a sidebar nav entry: a 12-month
   contribution-style heatmap (calendar grid of `days`), totals row,
   top-books-by-time list, and a recent-sessions timeline. Reuses the
   app's existing card/list components; no new charting dependency — the

--- a/internal/api/handlers/reader_fonts.go
+++ b/internal/api/handlers/reader_fonts.go
@@ -1,0 +1,448 @@
+package handlers
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/go-chi/chi/v5"
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgxpool"
+
+	apimw "github.com/Silo-Server/silo-server/internal/api/middleware"
+)
+
+// ReaderFont is a persisted custom reader font uploaded by a profile.
+type ReaderFont struct {
+	ID        int64     `json:"id"`
+	UserID    int       `json:"-"`
+	ProfileID string    `json:"-"`
+	Name      string    `json:"name"`
+	Filename  string    `json:"filename"`
+	Format    string    `json:"format"`
+	SizeBytes int64     `json:"-"`
+	CreatedAt time.Time `json:"created_at"`
+}
+
+// ReaderFontStore persists reader font metadata scoped to (user, profile).
+type ReaderFontStore interface {
+	List(ctx context.Context, userID int, profileID string) ([]ReaderFont, error)
+	Count(ctx context.Context, userID int, profileID string) (int, error)
+	Insert(ctx context.Context, font ReaderFont) (ReaderFont, error)
+	Get(ctx context.Context, userID int, profileID string, id int64) (*ReaderFont, error)
+	Delete(ctx context.Context, userID int, profileID string, id int64) (bool, error)
+}
+
+const (
+	// readerFontMaxBytes caps an individual font upload's file size.
+	readerFontMaxBytes = 5 << 20
+	// readerFontMaxPerProfile caps the number of custom fonts a single
+	// profile may store.
+	readerFontMaxPerProfile = 10
+)
+
+// ReaderFontsHandler serves per-profile custom reader font uploads: list,
+// upload, delete, and blob serving. Metadata lives in Store; font blobs are
+// written to disk under Dir, namespaced by user ID and profile ID.
+type ReaderFontsHandler struct {
+	Store ReaderFontStore
+	Dir   string
+}
+
+type readerFontsListResponse struct {
+	Fonts []ReaderFont `json:"fonts"`
+}
+
+// readerFontFormat sniffs a font's format from its magic bytes. Font
+// name-table parsing is intentionally not performed here — the display name
+// falls back to the uploaded filename (see HandleUpload).
+func readerFontFormat(data []byte) (format, contentType string, ok bool) {
+	switch {
+	case len(data) >= 4 && string(data[:4]) == "wOF2":
+		return "woff2", "font/woff2", true
+	case len(data) >= 4 && string(data[:4]) == "wOFF":
+		return "woff", "font/woff", true
+	case len(data) >= 4 && string(data[:4]) == "OTTO":
+		return "otf", "font/otf", true
+	case len(data) >= 4 && bytes.Equal(data[:4], []byte{0x00, 0x01, 0x00, 0x00}):
+		return "ttf", "font/ttf", true
+	}
+	return "", "", false
+}
+
+// readerFontBlobPath returns the on-disk path for a stored font blob. The
+// filename is <id>.<format> — content-addressed by primary key, not by the
+// user-supplied filename, so it never needs sanitizing on its own.
+func readerFontBlobPath(dir string, userID int, profileID string, id int64, format string) string {
+	return filepath.Join(dir, strconv.Itoa(userID), profileID, fmt.Sprintf("%d.%s", id, format))
+}
+
+// sanitizeReaderFontFilename strips any directory components from a
+// user-supplied upload filename, keeping only the base name.
+func sanitizeReaderFontFilename(name string) string {
+	name = filepath.Base(strings.TrimSpace(name))
+	if name == "." || name == string(filepath.Separator) {
+		return ""
+	}
+	return name
+}
+
+// HandleList returns the custom reader fonts uploaded by the active profile.
+func (h *ReaderFontsHandler) HandleList(w http.ResponseWriter, r *http.Request) {
+	userID := apimw.GetUserID(r.Context())
+	profileID := apimw.GetProfileID(r.Context())
+	if userID == 0 {
+		writeError(w, http.StatusUnauthorized, "unauthorized", "Authentication required")
+		return
+	}
+	if h == nil || h.Store == nil {
+		writeError(w, http.StatusServiceUnavailable, "unavailable", "Reader fonts are not configured")
+		return
+	}
+
+	fonts, err := h.Store.List(r.Context(), userID, profileID)
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, "internal_error", "Failed to list reader fonts")
+		return
+	}
+	if fonts == nil {
+		fonts = []ReaderFont{}
+	}
+	writeJSON(w, http.StatusOK, readerFontsListResponse{Fonts: fonts})
+}
+
+// HandleUpload accepts a multipart font upload (field "font"), validates its
+// size and format, enforces the per-profile font cap, and persists both the
+// metadata row and the blob. The row is inserted first so its ID can be used
+// to build the blob path; if writing the blob fails, the row is removed so
+// metadata and disk state never diverge.
+func (h *ReaderFontsHandler) HandleUpload(w http.ResponseWriter, r *http.Request) {
+	userID := apimw.GetUserID(r.Context())
+	profileID := apimw.GetProfileID(r.Context())
+	if userID == 0 {
+		writeError(w, http.StatusUnauthorized, "unauthorized", "Authentication required")
+		return
+	}
+	if h == nil || h.Store == nil || h.Dir == "" {
+		writeError(w, http.StatusServiceUnavailable, "unavailable", "Reader fonts are not configured")
+		return
+	}
+
+	if err := r.ParseMultipartForm(readerFontMaxBytes + (1 << 20)); err != nil {
+		writeError(w, http.StatusBadRequest, "bad_request", "Invalid multipart form")
+		return
+	}
+	file, header, err := r.FormFile("font")
+	if err != nil {
+		writeError(w, http.StatusBadRequest, "bad_request", "Missing font field")
+		return
+	}
+	defer file.Close()
+
+	data, err := io.ReadAll(io.LimitReader(file, readerFontMaxBytes+1))
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, "internal_error", "Failed to read upload")
+		return
+	}
+	if int64(len(data)) > readerFontMaxBytes {
+		writeError(w, http.StatusRequestEntityTooLarge, "too_large", "Font file exceeds the maximum size")
+		return
+	}
+
+	format, _, ok := readerFontFormat(data)
+	if !ok {
+		writeError(w, http.StatusUnsupportedMediaType, "unsupported_type", "Unsupported font file type")
+		return
+	}
+
+	count, err := h.Store.Count(r.Context(), userID, profileID)
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, "internal_error", "Failed to check reader font limit")
+		return
+	}
+	if count >= readerFontMaxPerProfile {
+		writeError(w, http.StatusConflict, "limit_reached", "Reader font limit reached")
+		return
+	}
+
+	filename := sanitizeReaderFontFilename(header.Filename)
+	name := strings.TrimSuffix(filename, filepath.Ext(filename))
+	if name == "" {
+		name = "Untitled"
+	}
+	if filename == "" {
+		filename = name
+	}
+
+	inserted, err := h.Store.Insert(r.Context(), ReaderFont{
+		UserID:    userID,
+		ProfileID: profileID,
+		Name:      name,
+		Filename:  filename,
+		Format:    format,
+		SizeBytes: int64(len(data)),
+	})
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, "internal_error", "Failed to save reader font")
+		return
+	}
+
+	path := readerFontBlobPath(h.Dir, userID, profileID, inserted.ID, format)
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		_, _ = h.Store.Delete(r.Context(), userID, profileID, inserted.ID)
+		writeError(w, http.StatusInternalServerError, "internal_error", "Failed to store reader font")
+		return
+	}
+	if err := os.WriteFile(path, data, 0o644); err != nil {
+		_, _ = h.Store.Delete(r.Context(), userID, profileID, inserted.ID)
+		writeError(w, http.StatusInternalServerError, "internal_error", "Failed to store reader font")
+		return
+	}
+
+	writeJSON(w, http.StatusCreated, inserted)
+}
+
+// HandleDelete removes a reader font's metadata row and best-effort deletes
+// its blob from disk. Scoped to the active (user, profile); a font owned by
+// another profile is reported as not found.
+func (h *ReaderFontsHandler) HandleDelete(w http.ResponseWriter, r *http.Request) {
+	userID := apimw.GetUserID(r.Context())
+	profileID := apimw.GetProfileID(r.Context())
+	if userID == 0 {
+		writeError(w, http.StatusUnauthorized, "unauthorized", "Authentication required")
+		return
+	}
+	if h == nil || h.Store == nil {
+		writeError(w, http.StatusServiceUnavailable, "unavailable", "Reader fonts are not configured")
+		return
+	}
+
+	id, err := strconv.ParseInt(chi.URLParam(r, "font_id"), 10, 64)
+	if err != nil || id <= 0 {
+		writeError(w, http.StatusBadRequest, "bad_request", "font_id is required")
+		return
+	}
+
+	deleted, err := h.Store.Delete(r.Context(), userID, profileID, id)
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, "internal_error", "Failed to delete reader font")
+		return
+	}
+	if !deleted {
+		writeError(w, http.StatusNotFound, "not_found", "Reader font not found")
+		return
+	}
+
+	if h.Dir != "" {
+		pattern := filepath.Join(h.Dir, strconv.Itoa(userID), profileID, fmt.Sprintf("%d.*", id))
+		if matches, globErr := filepath.Glob(pattern); globErr == nil {
+			for _, match := range matches {
+				_ = os.Remove(match)
+			}
+		}
+	}
+
+	w.WriteHeader(http.StatusNoContent)
+}
+
+// readerFontContentType maps a stored format to its serving Content-Type.
+func readerFontContentType(format string) string {
+	switch format {
+	case "woff2":
+		return "font/woff2"
+	case "woff":
+		return "font/woff"
+	case "otf":
+		return "font/otf"
+	case "ttf":
+		return "font/ttf"
+	default:
+		return "application/octet-stream"
+	}
+}
+
+// HandleServeFile streams a reader font's blob. Scoped to the active (user,
+// profile); a font owned by another profile is reported as not found. Blobs
+// are content-addressed and immutable once uploaded, so they are served with
+// a long-lived private cache lifetime.
+func (h *ReaderFontsHandler) HandleServeFile(w http.ResponseWriter, r *http.Request) {
+	userID := apimw.GetUserID(r.Context())
+	profileID := apimw.GetProfileID(r.Context())
+	if userID == 0 {
+		writeError(w, http.StatusUnauthorized, "unauthorized", "Authentication required")
+		return
+	}
+	if h == nil || h.Store == nil {
+		writeError(w, http.StatusServiceUnavailable, "unavailable", "Reader fonts are not configured")
+		return
+	}
+
+	id, err := strconv.ParseInt(chi.URLParam(r, "font_id"), 10, 64)
+	if err != nil || id <= 0 {
+		writeError(w, http.StatusBadRequest, "bad_request", "font_id is required")
+		return
+	}
+
+	font, err := h.Store.Get(r.Context(), userID, profileID, id)
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, "internal_error", "Failed to load reader font")
+		return
+	}
+	if font == nil {
+		writeError(w, http.StatusNotFound, "not_found", "Reader font not found")
+		return
+	}
+
+	path := readerFontBlobPath(h.Dir, userID, profileID, id, font.Format)
+	f, err := os.Open(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			writeError(w, http.StatusNotFound, "not_found", "Reader font file not found")
+			return
+		}
+		writeError(w, http.StatusInternalServerError, "internal_error", "Failed to open reader font")
+		return
+	}
+	defer f.Close()
+
+	stat, err := f.Stat()
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, "internal_error", "Failed to stat reader font")
+		return
+	}
+
+	w.Header().Set("Content-Type", readerFontContentType(font.Format))
+	w.Header().Set("Cache-Control", "private, max-age=31536000, immutable")
+	w.Header().Set("X-Content-Type-Options", "nosniff")
+	http.ServeContent(w, r, stat.Name(), stat.ModTime(), f)
+}
+
+// PGReaderFontStore is the Postgres-backed ReaderFontStore.
+type PGReaderFontStore struct {
+	pool *pgxpool.Pool
+}
+
+// NewPGReaderFontStore constructs a PGReaderFontStore.
+func NewPGReaderFontStore(pool *pgxpool.Pool) *PGReaderFontStore {
+	return &PGReaderFontStore{pool: pool}
+}
+
+func (s *PGReaderFontStore) List(ctx context.Context, userID int, profileID string) ([]ReaderFont, error) {
+	if s == nil || s.pool == nil {
+		return nil, fmt.Errorf("reader font store is not configured")
+	}
+	rows, err := s.pool.Query(ctx, `
+		SELECT id, user_id, profile_id, name, filename, format, size_bytes, created_at
+		FROM reader_fonts
+		WHERE user_id = $1 AND profile_id = $2
+		ORDER BY created_at, id`,
+		userID, profileID,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("list reader fonts: %w", err)
+	}
+	defer rows.Close()
+
+	var fonts []ReaderFont
+	for rows.Next() {
+		var font ReaderFont
+		if err := rows.Scan(
+			&font.ID,
+			&font.UserID,
+			&font.ProfileID,
+			&font.Name,
+			&font.Filename,
+			&font.Format,
+			&font.SizeBytes,
+			&font.CreatedAt,
+		); err != nil {
+			return nil, fmt.Errorf("scan reader font: %w", err)
+		}
+		fonts = append(fonts, font)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("list reader fonts: %w", err)
+	}
+	return fonts, nil
+}
+
+func (s *PGReaderFontStore) Count(ctx context.Context, userID int, profileID string) (int, error) {
+	if s == nil || s.pool == nil {
+		return 0, fmt.Errorf("reader font store is not configured")
+	}
+	var count int
+	if err := s.pool.QueryRow(ctx, `
+		SELECT COUNT(*) FROM reader_fonts WHERE user_id = $1 AND profile_id = $2`,
+		userID, profileID,
+	).Scan(&count); err != nil {
+		return 0, fmt.Errorf("count reader fonts: %w", err)
+	}
+	return count, nil
+}
+
+func (s *PGReaderFontStore) Insert(ctx context.Context, font ReaderFont) (ReaderFont, error) {
+	if s == nil || s.pool == nil {
+		return ReaderFont{}, fmt.Errorf("reader font store is not configured")
+	}
+	err := s.pool.QueryRow(ctx, `
+		INSERT INTO reader_fonts (user_id, profile_id, name, filename, format, size_bytes)
+		VALUES ($1, $2, $3, $4, $5, $6)
+		RETURNING id, created_at`,
+		font.UserID, font.ProfileID, font.Name, font.Filename, font.Format, font.SizeBytes,
+	).Scan(&font.ID, &font.CreatedAt)
+	if err != nil {
+		return ReaderFont{}, fmt.Errorf("insert reader font: %w", err)
+	}
+	return font, nil
+}
+
+func (s *PGReaderFontStore) Get(ctx context.Context, userID int, profileID string, id int64) (*ReaderFont, error) {
+	if s == nil || s.pool == nil {
+		return nil, fmt.Errorf("reader font store is not configured")
+	}
+	var font ReaderFont
+	err := s.pool.QueryRow(ctx, `
+		SELECT id, user_id, profile_id, name, filename, format, size_bytes, created_at
+		FROM reader_fonts
+		WHERE user_id = $1 AND profile_id = $2 AND id = $3`,
+		userID, profileID, id,
+	).Scan(
+		&font.ID,
+		&font.UserID,
+		&font.ProfileID,
+		&font.Name,
+		&font.Filename,
+		&font.Format,
+		&font.SizeBytes,
+		&font.CreatedAt,
+	)
+	if errors.Is(err, pgx.ErrNoRows) {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, fmt.Errorf("get reader font: %w", err)
+	}
+	return &font, nil
+}
+
+func (s *PGReaderFontStore) Delete(ctx context.Context, userID int, profileID string, id int64) (bool, error) {
+	if s == nil || s.pool == nil {
+		return false, fmt.Errorf("reader font store is not configured")
+	}
+	tag, err := s.pool.Exec(ctx, `
+		DELETE FROM reader_fonts WHERE user_id = $1 AND profile_id = $2 AND id = $3`,
+		userID, profileID, id,
+	)
+	if err != nil {
+		return false, fmt.Errorf("delete reader font: %w", err)
+	}
+	return tag.RowsAffected() > 0, nil
+}

--- a/internal/api/handlers/reader_fonts.go
+++ b/internal/api/handlers/reader_fonts.go
@@ -114,18 +114,41 @@ func safeReaderFontPathComponent(s string) bool {
 }
 
 // sanitizeReaderFontFilename strips any directory components from a
-// user-supplied upload filename, keeping only the base name. Names that
-// still fail the strict path-component check after that (e.g. "..", or
-// anything containing characters unsafe for a path component) fall back to
-// an empty string so callers apply their default naming.
+// user-supplied upload filename, keeping only the base name. It removes
+// NUL and control characters (0x00-0x1F, 0x7F), trims whitespace, and caps
+// at 255 runes. This is a display-only field; the actual blob is stored
+// content-addressed as <id>.<format> (see readerFontBlobPath). Rejects to
+// an empty string only if the result is empty, ".", or ".." so callers
+// apply their default naming.
 func sanitizeReaderFontFilename(name string) string {
 	name = filepath.Base(strings.TrimSpace(name))
 	if name == "." || name == string(filepath.Separator) {
 		return ""
 	}
-	if !safeReaderFontPathComponent(name) {
+
+	// Remove NUL and control characters (0x00-0x1F, 0x7F) to prevent
+	// filesystem or display issues.
+	var filtered strings.Builder
+	for _, r := range name {
+		if (r >= 0x00 && r <= 0x1F) || r == 0x7F {
+			continue
+		}
+		filtered.WriteRune(r)
+	}
+	name = filtered.String()
+	name = strings.TrimSpace(name)
+
+	// Cap at 255 runes (typical filesystem limit).
+	if len([]rune(name)) > 255 {
+		runes := []rune(name)
+		name = string(runes[:255])
+	}
+
+	// Reject if the result is empty, ".", or ".."
+	if name == "" || name == "." || name == ".." {
 		return ""
 	}
+
 	return name
 }
 

--- a/internal/api/handlers/reader_fonts.go
+++ b/internal/api/handlers/reader_fonts.go
@@ -85,11 +85,45 @@ func readerFontBlobPath(dir string, userID int, profileID string, id int64, form
 	return filepath.Join(dir, strconv.Itoa(userID), profileID, fmt.Sprintf("%d.%s", id, format))
 }
 
+// safeReaderFontPathComponent reports whether s is safe to use as a single
+// path component (user ID, profile ID) when building on-disk font paths.
+// profile_id in particular is populated straight from the client-supplied
+// X-Profile-Id header — RequireProfile only checks that it's non-empty — so
+// every handler MUST validate it with this function before it reaches any
+// filepath.Join, filepath.Glob, or filesystem call. An empty string, ".",
+// "..", any substring of "..", or any character outside [A-Za-z0-9._-] is
+// rejected.
+func safeReaderFontPathComponent(s string) bool {
+	if s == "" || s == "." || s == ".." {
+		return false
+	}
+	if strings.Contains(s, "..") {
+		return false
+	}
+	for _, c := range s {
+		switch {
+		case c >= 'a' && c <= 'z':
+		case c >= 'A' && c <= 'Z':
+		case c >= '0' && c <= '9':
+		case c == '.' || c == '_' || c == '-':
+		default:
+			return false
+		}
+	}
+	return true
+}
+
 // sanitizeReaderFontFilename strips any directory components from a
-// user-supplied upload filename, keeping only the base name.
+// user-supplied upload filename, keeping only the base name. Names that
+// still fail the strict path-component check after that (e.g. "..", or
+// anything containing characters unsafe for a path component) fall back to
+// an empty string so callers apply their default naming.
 func sanitizeReaderFontFilename(name string) string {
 	name = filepath.Base(strings.TrimSpace(name))
 	if name == "." || name == string(filepath.Separator) {
+		return ""
+	}
+	if !safeReaderFontPathComponent(name) {
 		return ""
 	}
 	return name
@@ -105,6 +139,10 @@ func (h *ReaderFontsHandler) HandleList(w http.ResponseWriter, r *http.Request) 
 	}
 	if h == nil || h.Store == nil {
 		writeError(w, http.StatusServiceUnavailable, "unavailable", "Reader fonts are not configured")
+		return
+	}
+	if !safeReaderFontPathComponent(profileID) {
+		writeError(w, http.StatusBadRequest, "bad_request", "Invalid profile")
 		return
 	}
 
@@ -133,6 +171,10 @@ func (h *ReaderFontsHandler) HandleUpload(w http.ResponseWriter, r *http.Request
 	}
 	if h == nil || h.Store == nil || h.Dir == "" {
 		writeError(w, http.StatusServiceUnavailable, "unavailable", "Reader fonts are not configured")
+		return
+	}
+	if !safeReaderFontPathComponent(profileID) {
+		writeError(w, http.StatusBadRequest, "bad_request", "Invalid profile")
 		return
 	}
 
@@ -203,6 +245,7 @@ func (h *ReaderFontsHandler) HandleUpload(w http.ResponseWriter, r *http.Request
 	}
 	if err := os.WriteFile(path, data, 0o644); err != nil {
 		_, _ = h.Store.Delete(r.Context(), userID, profileID, inserted.ID)
+		_ = os.Remove(path)
 		writeError(w, http.StatusInternalServerError, "internal_error", "Failed to store reader font")
 		return
 	}
@@ -222,6 +265,10 @@ func (h *ReaderFontsHandler) HandleDelete(w http.ResponseWriter, r *http.Request
 	}
 	if h == nil || h.Store == nil {
 		writeError(w, http.StatusServiceUnavailable, "unavailable", "Reader fonts are not configured")
+		return
+	}
+	if !safeReaderFontPathComponent(profileID) {
+		writeError(w, http.StatusBadRequest, "bad_request", "Invalid profile")
 		return
 	}
 
@@ -282,6 +329,10 @@ func (h *ReaderFontsHandler) HandleServeFile(w http.ResponseWriter, r *http.Requ
 	}
 	if h == nil || h.Store == nil {
 		writeError(w, http.StatusServiceUnavailable, "unavailable", "Reader fonts are not configured")
+		return
+	}
+	if !safeReaderFontPathComponent(profileID) {
+		writeError(w, http.StatusBadRequest, "bad_request", "Invalid profile")
 		return
 	}
 

--- a/internal/api/handlers/reader_fonts.go
+++ b/internal/api/handlers/reader_fonts.go
@@ -201,7 +201,16 @@ func (h *ReaderFontsHandler) HandleUpload(w http.ResponseWriter, r *http.Request
 		return
 	}
 
+	// Caps the raw request body before ParseMultipartForm buffers it, so an
+	// oversized upload is rejected while reading instead of after silently
+	// consuming memory (pattern: HandleUploadInstallation in plugins.go).
+	r.Body = http.MaxBytesReader(w, r.Body, readerFontMaxBytes+(1<<20))
 	if err := r.ParseMultipartForm(readerFontMaxBytes + (1 << 20)); err != nil {
+		var maxBytesErr *http.MaxBytesError
+		if errors.As(err, &maxBytesErr) {
+			writeError(w, http.StatusRequestEntityTooLarge, "too_large", "Font file exceeds the maximum size")
+			return
+		}
 		writeError(w, http.StatusBadRequest, "bad_request", "Invalid multipart form")
 		return
 	}

--- a/internal/api/handlers/reader_fonts_test.go
+++ b/internal/api/handlers/reader_fonts_test.go
@@ -20,17 +20,31 @@ import (
 	"github.com/Silo-Server/silo-server/internal/auth"
 )
 
-// fakeReaderFontStore is an in-memory ReaderFontStore keyed by font ID.
+// fakeReaderFontStore is an in-memory ReaderFontStore keyed by font ID. Each
+// method bumps a call counter so tests can assert the store was never
+// touched (e.g. when a handler must reject a request before reaching the
+// store or filesystem).
 type fakeReaderFontStore struct {
 	fonts  map[int64]ReaderFont
 	nextID int64
+
+	listCalls   int
+	countCalls  int
+	insertCalls int
+	getCalls    int
+	deleteCalls int
 }
 
 func newFakeReaderFontStore() *fakeReaderFontStore {
 	return &fakeReaderFontStore{fonts: map[int64]ReaderFont{}}
 }
 
+func (f *fakeReaderFontStore) totalCalls() int {
+	return f.listCalls + f.countCalls + f.insertCalls + f.getCalls + f.deleteCalls
+}
+
 func (f *fakeReaderFontStore) List(_ context.Context, userID int, profileID string) ([]ReaderFont, error) {
+	f.listCalls++
 	var out []ReaderFont
 	for _, font := range f.fonts {
 		if font.UserID == userID && font.ProfileID == profileID {
@@ -42,14 +56,18 @@ func (f *fakeReaderFontStore) List(_ context.Context, userID int, profileID stri
 }
 
 func (f *fakeReaderFontStore) Count(ctx context.Context, userID int, profileID string) (int, error) {
-	fonts, err := f.List(ctx, userID, profileID)
-	if err != nil {
-		return 0, err
+	f.countCalls++
+	var out []ReaderFont
+	for _, font := range f.fonts {
+		if font.UserID == userID && font.ProfileID == profileID {
+			out = append(out, font)
+		}
 	}
-	return len(fonts), nil
+	return len(out), nil
 }
 
 func (f *fakeReaderFontStore) Insert(_ context.Context, font ReaderFont) (ReaderFont, error) {
+	f.insertCalls++
 	f.nextID++
 	font.ID = f.nextID
 	font.CreatedAt = time.Now().UTC()
@@ -58,6 +76,7 @@ func (f *fakeReaderFontStore) Insert(_ context.Context, font ReaderFont) (Reader
 }
 
 func (f *fakeReaderFontStore) Get(_ context.Context, userID int, profileID string, id int64) (*ReaderFont, error) {
+	f.getCalls++
 	font, ok := f.fonts[id]
 	if !ok || font.UserID != userID || font.ProfileID != profileID {
 		return nil, nil
@@ -66,6 +85,7 @@ func (f *fakeReaderFontStore) Get(_ context.Context, userID int, profileID strin
 }
 
 func (f *fakeReaderFontStore) Delete(_ context.Context, userID int, profileID string, id int64) (bool, error) {
+	f.deleteCalls++
 	font, ok := f.fonts[id]
 	if !ok || font.UserID != userID || font.ProfileID != profileID {
 		return false, nil
@@ -362,5 +382,90 @@ func TestReaderFontServeAndDeleteAuthorize(t *testing.T) {
 	blobPath := filepath.Join(dir, "1", "profile-a", strconv.FormatInt(font2.ID, 10)+".woff2")
 	if _, err := os.Stat(blobPath); err != nil {
 		t.Fatalf("expected surviving font file on disk at %s: %v", blobPath, err)
+	}
+}
+
+// TestReaderFontRejectsTraversalProfileID is a regression test for a path
+// traversal vulnerability: profile_id is populated from the client-supplied
+// X-Profile-Id header (RequireProfile only checks it is non-empty) and used
+// to build filesystem paths for upload, serve, and delete. A profile ID
+// containing path separators or ".." components must be rejected with 400
+// before any store or filesystem operation happens, so a request such as
+// `X-Profile-Id: ../../../../tmp/evil` cannot escape the fonts directory.
+func TestReaderFontRejectsTraversalProfileID(t *testing.T) {
+	maliciousProfileIDs := []string{
+		"../../tmp/evil",
+		"a/b",
+		"..",
+	}
+
+	for _, profileID := range maliciousProfileIDs {
+		t.Run(profileID, func(t *testing.T) {
+			dir := t.TempDir()
+			store := newFakeReaderFontStore()
+			h := &ReaderFontsHandler{Store: store, Dir: dir}
+
+			// Upload.
+			body := append([]byte("wOF2"), bytes.Repeat([]byte{0x00}, 32)...)
+			uploadReq := newReaderFontUploadRequest(t, 1, profileID, "evil.woff2", body)
+			uploadRR := httptest.NewRecorder()
+			h.HandleUpload(uploadRR, uploadReq)
+			if uploadRR.Code != http.StatusBadRequest {
+				t.Fatalf("upload status = %d, want 400; body = %s", uploadRR.Code, uploadRR.Body.String())
+			}
+			if errResp := decodeReaderFontError(t, uploadRR); errResp.Error != "bad_request" {
+				t.Fatalf("upload error code = %q, want bad_request", errResp.Error)
+			}
+
+			// Serve.
+			serveReq := httptest.NewRequest(http.MethodGet, "/ebooks/reader-fonts/1/file", nil)
+			serveReq = serveReq.WithContext(readerFontAuthContext(1, profileID))
+			serveReq = withReaderFontIDParam(serveReq, 1)
+			serveRR := httptest.NewRecorder()
+			h.HandleServeFile(serveRR, serveReq)
+			if serveRR.Code != http.StatusBadRequest {
+				t.Fatalf("serve status = %d, want 400; body = %s", serveRR.Code, serveRR.Body.String())
+			}
+			if errResp := decodeReaderFontError(t, serveRR); errResp.Error != "bad_request" {
+				t.Fatalf("serve error code = %q, want bad_request", errResp.Error)
+			}
+
+			// Delete.
+			deleteReq := httptest.NewRequest(http.MethodDelete, "/ebooks/reader-fonts/1", nil)
+			deleteReq = deleteReq.WithContext(readerFontAuthContext(1, profileID))
+			deleteReq = withReaderFontIDParam(deleteReq, 1)
+			deleteRR := httptest.NewRecorder()
+			h.HandleDelete(deleteRR, deleteReq)
+			if deleteRR.Code != http.StatusBadRequest {
+				t.Fatalf("delete status = %d, want 400; body = %s", deleteRR.Code, deleteRR.Body.String())
+			}
+			if errResp := decodeReaderFontError(t, deleteRR); errResp.Error != "bad_request" {
+				t.Fatalf("delete error code = %q, want bad_request", errResp.Error)
+			}
+
+			// The store must never have been reached: rejection happens
+			// before any List/Count/Insert/Get/Delete call.
+			if calls := store.totalCalls(); calls != 0 {
+				t.Fatalf("expected store to be untouched, got %d calls (%+v)", calls, store)
+			}
+
+			// Nothing must have been written to disk under the fonts dir.
+			var found []string
+			walkErr := filepath.Walk(dir, func(path string, info os.FileInfo, err error) error {
+				if err != nil {
+					return err
+				}
+				if path != dir {
+					found = append(found, path)
+				}
+				return nil
+			})
+			if walkErr != nil {
+				t.Fatalf("walk fonts dir: %v", walkErr)
+			}
+			if len(found) != 0 {
+				t.Fatalf("expected no files written to fonts dir, found %+v", found)
+			}
+		})
 	}
 }

--- a/internal/api/handlers/reader_fonts_test.go
+++ b/internal/api/handlers/reader_fonts_test.go
@@ -309,6 +309,33 @@ func TestReaderFontUploadEnforcesCaps(t *testing.T) {
 			t.Fatalf("expected no font persisted, got %+v", store.fonts)
 		}
 	})
+
+	// Regression test: before MaxBytesReader was wired in, a request body far
+	// exceeding readerFontMaxBytes was fully buffered by ParseMultipartForm
+	// before the handler's own size check ever ran. This drives the raw body
+	// past the MaxBytesReader cap so ParseMultipartForm itself fails, and
+	// asserts that failure still maps to 413 (not the generic 400 "Invalid
+	// multipart form").
+	t.Run("raw body exceeds the hard multipart cap", func(t *testing.T) {
+		dir := t.TempDir()
+		store := newFakeReaderFontStore()
+		h := &ReaderFontsHandler{Store: store, Dir: dir}
+
+		hugeBody := append([]byte("wOF2"), bytes.Repeat([]byte{0x00}, readerFontMaxBytes+2<<20)...)
+		req := newReaderFontUploadRequest(t, 1, "profile-a", "huge.woff2", hugeBody)
+		rr := httptest.NewRecorder()
+		h.HandleUpload(rr, req)
+
+		if rr.Code != http.StatusRequestEntityTooLarge {
+			t.Fatalf("status = %d, want 413; body = %s", rr.Code, rr.Body.String())
+		}
+		if errResp := decodeReaderFontError(t, rr); errResp.Error != "too_large" {
+			t.Fatalf("error code = %q, want too_large", errResp.Error)
+		}
+		if len(store.fonts) != 0 {
+			t.Fatalf("expected no font persisted, got %+v", store.fonts)
+		}
+	})
 }
 
 func TestReaderFontListScopedToProfile(t *testing.T) {

--- a/internal/api/handlers/reader_fonts_test.go
+++ b/internal/api/handlers/reader_fonts_test.go
@@ -183,6 +183,49 @@ func TestReaderFontUploadValidatesMagicBytes(t *testing.T) {
 		t.Fatalf("expected font file on disk at %s: %v", blobPath, err)
 	}
 
+	// Test that real filenames with spaces and special characters are preserved
+	t.Run("preserves real filenames", func(t *testing.T) {
+		testCases := []struct {
+			uploadName string
+			expectName string
+			expectFile string
+		}{
+			{"Literata Bold (2).ttf", "Literata Bold (2)", "Literata Bold (2).ttf"},
+			{"Times New Roman.ttf", "Times New Roman", "Times New Roman.ttf"},
+			{"font-name_v1.2.otf", "font-name_v1.2", "font-name_v1.2.otf"},
+			{"Раш́ски́й.ttf", "Раш́ски́й", "Раш́ски́й.ttf"}, // Cyrillic with combining marks
+		}
+
+		for _, tc := range testCases {
+			t.Run(tc.uploadName, func(t *testing.T) {
+				dir := t.TempDir()
+				store := newFakeReaderFontStore()
+				h := &ReaderFontsHandler{Store: store, Dir: dir}
+
+				body := append([]byte("wOF2"), bytes.Repeat([]byte{0x00}, 32)...)
+				req := newReaderFontUploadRequest(t, 1, "profile-a", tc.uploadName, body)
+				rr := httptest.NewRecorder()
+				h.HandleUpload(rr, req)
+
+				if rr.Code != http.StatusCreated {
+					t.Fatalf("status = %d, want 201; body = %s", rr.Code, rr.Body.String())
+				}
+
+				var font ReaderFont
+				if err := json.Unmarshal(rr.Body.Bytes(), &font); err != nil {
+					t.Fatalf("decode response: %v", err)
+				}
+
+				if font.Name != tc.expectName {
+					t.Fatalf("name = %q, want %q", font.Name, tc.expectName)
+				}
+				if font.Filename != tc.expectFile {
+					t.Fatalf("filename = %q, want %q", font.Filename, tc.expectFile)
+				}
+			})
+		}
+	})
+
 	// A body that doesn't match any known font magic bytes must be rejected
 	// with 415 and must leave neither a metadata row nor a file behind.
 	rejectStore := newFakeReaderFontStore()
@@ -441,6 +484,18 @@ func TestReaderFontRejectsTraversalProfileID(t *testing.T) {
 			}
 			if errResp := decodeReaderFontError(t, deleteRR); errResp.Error != "bad_request" {
 				t.Fatalf("delete error code = %q, want bad_request", errResp.Error)
+			}
+
+			// List.
+			listReq := httptest.NewRequest(http.MethodGet, "/ebooks/reader-fonts", nil)
+			listReq = listReq.WithContext(readerFontAuthContext(1, profileID))
+			listRR := httptest.NewRecorder()
+			h.HandleList(listRR, listReq)
+			if listRR.Code != http.StatusBadRequest {
+				t.Fatalf("list status = %d, want 400; body = %s", listRR.Code, listRR.Body.String())
+			}
+			if errResp := decodeReaderFontError(t, listRR); errResp.Error != "bad_request" {
+				t.Fatalf("list error code = %q, want bad_request", errResp.Error)
 			}
 
 			// The store must never have been reached: rejection happens

--- a/internal/api/handlers/reader_fonts_test.go
+++ b/internal/api/handlers/reader_fonts_test.go
@@ -1,0 +1,366 @@
+package handlers
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"mime/multipart"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"sort"
+	"strconv"
+	"testing"
+	"time"
+
+	"github.com/go-chi/chi/v5"
+
+	apimw "github.com/Silo-Server/silo-server/internal/api/middleware"
+	"github.com/Silo-Server/silo-server/internal/auth"
+)
+
+// fakeReaderFontStore is an in-memory ReaderFontStore keyed by font ID.
+type fakeReaderFontStore struct {
+	fonts  map[int64]ReaderFont
+	nextID int64
+}
+
+func newFakeReaderFontStore() *fakeReaderFontStore {
+	return &fakeReaderFontStore{fonts: map[int64]ReaderFont{}}
+}
+
+func (f *fakeReaderFontStore) List(_ context.Context, userID int, profileID string) ([]ReaderFont, error) {
+	var out []ReaderFont
+	for _, font := range f.fonts {
+		if font.UserID == userID && font.ProfileID == profileID {
+			out = append(out, font)
+		}
+	}
+	sort.Slice(out, func(i, j int) bool { return out[i].ID < out[j].ID })
+	return out, nil
+}
+
+func (f *fakeReaderFontStore) Count(ctx context.Context, userID int, profileID string) (int, error) {
+	fonts, err := f.List(ctx, userID, profileID)
+	if err != nil {
+		return 0, err
+	}
+	return len(fonts), nil
+}
+
+func (f *fakeReaderFontStore) Insert(_ context.Context, font ReaderFont) (ReaderFont, error) {
+	f.nextID++
+	font.ID = f.nextID
+	font.CreatedAt = time.Now().UTC()
+	f.fonts[font.ID] = font
+	return font, nil
+}
+
+func (f *fakeReaderFontStore) Get(_ context.Context, userID int, profileID string, id int64) (*ReaderFont, error) {
+	font, ok := f.fonts[id]
+	if !ok || font.UserID != userID || font.ProfileID != profileID {
+		return nil, nil
+	}
+	return &font, nil
+}
+
+func (f *fakeReaderFontStore) Delete(_ context.Context, userID int, profileID string, id int64) (bool, error) {
+	font, ok := f.fonts[id]
+	if !ok || font.UserID != userID || font.ProfileID != profileID {
+		return false, nil
+	}
+	delete(f.fonts, id)
+	return true, nil
+}
+
+// newReaderFontUploadRequest builds a POST request with a real multipart
+// body carrying a single "font" field, authenticated as userID/profileID.
+func newReaderFontUploadRequest(t *testing.T, userID int, profileID, filename string, content []byte) *http.Request {
+	t.Helper()
+	var buf bytes.Buffer
+	mw := multipart.NewWriter(&buf)
+	part, err := mw.CreateFormFile("font", filename)
+	if err != nil {
+		t.Fatalf("CreateFormFile: %v", err)
+	}
+	if _, err := part.Write(content); err != nil {
+		t.Fatalf("write multipart content: %v", err)
+	}
+	if err := mw.Close(); err != nil {
+		t.Fatalf("close multipart writer: %v", err)
+	}
+
+	req := httptest.NewRequest(http.MethodPost, "/ebooks/reader-fonts", &buf)
+	req.Header.Set("Content-Type", mw.FormDataContentType())
+	return req.WithContext(readerFontAuthContext(userID, profileID))
+}
+
+func readerFontAuthContext(userID int, profileID string) context.Context {
+	ctx := apimw.SetClaims(context.Background(), &auth.Claims{
+		UserID:    userID,
+		Role:      "user",
+		TokenType: auth.TokenTypeAccess,
+	})
+	return apimw.SetProfileID(ctx, profileID)
+}
+
+func withReaderFontIDParam(req *http.Request, fontID int64) *http.Request {
+	routeCtx := chi.NewRouteContext()
+	routeCtx.URLParams.Add("font_id", strconv.FormatInt(fontID, 10))
+	return req.WithContext(context.WithValue(req.Context(), chi.RouteCtxKey, routeCtx))
+}
+
+func decodeReaderFontError(t *testing.T, rr *httptest.ResponseRecorder) errorResponse {
+	t.Helper()
+	var errResp errorResponse
+	if err := json.Unmarshal(rr.Body.Bytes(), &errResp); err != nil {
+		t.Fatalf("decode error response: %v; body = %s", err, rr.Body.String())
+	}
+	return errResp
+}
+
+func TestReaderFontUploadValidatesMagicBytes(t *testing.T) {
+	dir := t.TempDir()
+	store := newFakeReaderFontStore()
+	h := &ReaderFontsHandler{Store: store, Dir: dir}
+
+	validBody := append([]byte("wOF2"), bytes.Repeat([]byte{0x00}, 32)...)
+	req := newReaderFontUploadRequest(t, 1, "profile-a", "Literata.woff2", validBody)
+	rr := httptest.NewRecorder()
+	h.HandleUpload(rr, req)
+
+	if rr.Code != http.StatusCreated {
+		t.Fatalf("status = %d, want 201; body = %s", rr.Code, rr.Body.String())
+	}
+	var font ReaderFont
+	if err := json.Unmarshal(rr.Body.Bytes(), &font); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if font.ID == 0 {
+		t.Fatal("expected a non-zero font ID")
+	}
+	if font.Name != "Literata" {
+		t.Fatalf("name = %q, want Literata", font.Name)
+	}
+	if font.Filename != "Literata.woff2" {
+		t.Fatalf("filename = %q, want Literata.woff2", font.Filename)
+	}
+
+	stored, ok := store.fonts[font.ID]
+	if !ok {
+		t.Fatal("expected font metadata to be persisted")
+	}
+	if stored.UserID != 1 || stored.ProfileID != "profile-a" {
+		t.Fatalf("stored scope = user %d profile %q, want user 1 profile-a", stored.UserID, stored.ProfileID)
+	}
+	if stored.Format != "woff2" {
+		t.Fatalf("format = %q, want woff2", stored.Format)
+	}
+
+	blobPath := readerFontBlobPath(dir, 1, "profile-a", font.ID, "woff2")
+	if _, err := os.Stat(blobPath); err != nil {
+		t.Fatalf("expected font file on disk at %s: %v", blobPath, err)
+	}
+
+	// A body that doesn't match any known font magic bytes must be rejected
+	// with 415 and must leave neither a metadata row nor a file behind.
+	rejectStore := newFakeReaderFontStore()
+	rejectDir := t.TempDir()
+	rejectHandler := &ReaderFontsHandler{Store: rejectStore, Dir: rejectDir}
+
+	badBody := append([]byte("GIF8"), bytes.Repeat([]byte{0x00}, 16)...)
+	badReq := newReaderFontUploadRequest(t, 1, "profile-a", "not-a-font.gif", badBody)
+	badRR := httptest.NewRecorder()
+	rejectHandler.HandleUpload(badRR, badReq)
+
+	if badRR.Code != http.StatusUnsupportedMediaType {
+		t.Fatalf("status = %d, want 415; body = %s", badRR.Code, badRR.Body.String())
+	}
+	if errResp := decodeReaderFontError(t, badRR); errResp.Error != "unsupported_type" {
+		t.Fatalf("error code = %q, want unsupported_type", errResp.Error)
+	}
+	if len(rejectStore.fonts) != 0 {
+		t.Fatalf("expected no font metadata persisted, got %+v", rejectStore.fonts)
+	}
+	entries, err := os.ReadDir(rejectDir)
+	if err != nil {
+		t.Fatalf("read reject dir: %v", err)
+	}
+	if len(entries) != 0 {
+		t.Fatalf("expected no files written to disk, got %+v", entries)
+	}
+}
+
+func TestReaderFontUploadEnforcesCaps(t *testing.T) {
+	t.Run("limit reached", func(t *testing.T) {
+		dir := t.TempDir()
+		store := newFakeReaderFontStore()
+		for i := 0; i < readerFontMaxPerProfile; i++ {
+			store.fonts[int64(i+1)] = ReaderFont{
+				ID:        int64(i + 1),
+				UserID:    1,
+				ProfileID: "profile-a",
+				Name:      "Font",
+				Filename:  "font.woff2",
+				Format:    "woff2",
+				CreatedAt: time.Now().UTC(),
+			}
+		}
+		store.nextID = readerFontMaxPerProfile
+		h := &ReaderFontsHandler{Store: store, Dir: dir}
+
+		body := append([]byte("wOF2"), bytes.Repeat([]byte{0x00}, 32)...)
+		req := newReaderFontUploadRequest(t, 1, "profile-a", "eleventh.woff2", body)
+		rr := httptest.NewRecorder()
+		h.HandleUpload(rr, req)
+
+		if rr.Code != http.StatusConflict {
+			t.Fatalf("status = %d, want 409; body = %s", rr.Code, rr.Body.String())
+		}
+		if errResp := decodeReaderFontError(t, rr); errResp.Error != "limit_reached" {
+			t.Fatalf("error code = %q, want limit_reached", errResp.Error)
+		}
+		if len(store.fonts) != readerFontMaxPerProfile {
+			t.Fatalf("expected no new font persisted, got %d fonts", len(store.fonts))
+		}
+	})
+
+	t.Run("body too large", func(t *testing.T) {
+		dir := t.TempDir()
+		store := newFakeReaderFontStore()
+		h := &ReaderFontsHandler{Store: store, Dir: dir}
+
+		oversized := append([]byte("wOF2"), bytes.Repeat([]byte{0x00}, readerFontMaxBytes+1024)...)
+		req := newReaderFontUploadRequest(t, 1, "profile-a", "huge.woff2", oversized)
+		rr := httptest.NewRecorder()
+		h.HandleUpload(rr, req)
+
+		if rr.Code != http.StatusRequestEntityTooLarge {
+			t.Fatalf("status = %d, want 413; body = %s", rr.Code, rr.Body.String())
+		}
+		if errResp := decodeReaderFontError(t, rr); errResp.Error != "too_large" {
+			t.Fatalf("error code = %q, want too_large", errResp.Error)
+		}
+		if len(store.fonts) != 0 {
+			t.Fatalf("expected no font persisted, got %+v", store.fonts)
+		}
+	})
+}
+
+func TestReaderFontListScopedToProfile(t *testing.T) {
+	store := newFakeReaderFontStore()
+	store.fonts[1] = ReaderFont{ID: 1, UserID: 1, ProfileID: "a", Name: "Font A1", Filename: "a1.woff2", Format: "woff2"}
+	store.fonts[2] = ReaderFont{ID: 2, UserID: 1, ProfileID: "a", Name: "Font A2", Filename: "a2.woff2", Format: "woff2"}
+	store.fonts[3] = ReaderFont{ID: 3, UserID: 1, ProfileID: "b", Name: "Font B1", Filename: "b1.woff2", Format: "woff2"}
+	store.nextID = 3
+
+	h := &ReaderFontsHandler{Store: store, Dir: t.TempDir()}
+
+	req := httptest.NewRequest(http.MethodGet, "/ebooks/reader-fonts", nil)
+	req = req.WithContext(readerFontAuthContext(1, "a"))
+	rr := httptest.NewRecorder()
+	h.HandleList(rr, req)
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200; body = %s", rr.Code, rr.Body.String())
+	}
+	var resp readerFontsListResponse
+	if err := json.Unmarshal(rr.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if len(resp.Fonts) != 2 {
+		t.Fatalf("fonts = %+v, want 2 fonts scoped to profile a", resp.Fonts)
+	}
+	for _, font := range resp.Fonts {
+		if font.Name == "Font B1" {
+			t.Fatalf("list leaked profile b's font: %+v", resp.Fonts)
+		}
+	}
+}
+
+func TestReaderFontServeAndDeleteAuthorize(t *testing.T) {
+	dir := t.TempDir()
+	store := newFakeReaderFontStore()
+	h := &ReaderFontsHandler{Store: store, Dir: dir}
+
+	// Upload two fonts as profile a: one will be deleted, the other kept
+	// around to exercise the authorized-GET path afterward.
+	uploadBody := append([]byte("wOF2"), bytes.Repeat([]byte{0x00}, 32)...)
+
+	uploadReq1 := newReaderFontUploadRequest(t, 1, "profile-a", "to-delete.woff2", uploadBody)
+	uploadRR1 := httptest.NewRecorder()
+	h.HandleUpload(uploadRR1, uploadReq1)
+	if uploadRR1.Code != http.StatusCreated {
+		t.Fatalf("setup upload 1 status = %d, want 201; body = %s", uploadRR1.Code, uploadRR1.Body.String())
+	}
+	var font1 ReaderFont
+	if err := json.Unmarshal(uploadRR1.Body.Bytes(), &font1); err != nil {
+		t.Fatalf("decode upload 1 response: %v", err)
+	}
+
+	uploadReq2 := newReaderFontUploadRequest(t, 1, "profile-a", "to-keep.woff2", uploadBody)
+	uploadRR2 := httptest.NewRecorder()
+	h.HandleUpload(uploadRR2, uploadReq2)
+	if uploadRR2.Code != http.StatusCreated {
+		t.Fatalf("setup upload 2 status = %d, want 201; body = %s", uploadRR2.Code, uploadRR2.Body.String())
+	}
+	var font2 ReaderFont
+	if err := json.Unmarshal(uploadRR2.Body.Bytes(), &font2); err != nil {
+		t.Fatalf("decode upload 2 response: %v", err)
+	}
+
+	// GET the first font as a different profile: must 404, not leak
+	// existence of a font owned by another profile.
+	wrongProfileReq := httptest.NewRequest(http.MethodGet, "/ebooks/reader-fonts/"+strconv.FormatInt(font1.ID, 10)+"/file", nil)
+	wrongProfileReq = wrongProfileReq.WithContext(readerFontAuthContext(1, "profile-b"))
+	wrongProfileReq = withReaderFontIDParam(wrongProfileReq, font1.ID)
+	wrongProfileRR := httptest.NewRecorder()
+	h.HandleServeFile(wrongProfileRR, wrongProfileReq)
+	if wrongProfileRR.Code != http.StatusNotFound {
+		t.Fatalf("cross-profile GET status = %d, want 404; body = %s", wrongProfileRR.Code, wrongProfileRR.Body.String())
+	}
+
+	// DELETE the first font as its owning profile: 204, row and file gone.
+	deleteReq := httptest.NewRequest(http.MethodDelete, "/ebooks/reader-fonts/"+strconv.FormatInt(font1.ID, 10), nil)
+	deleteReq = deleteReq.WithContext(readerFontAuthContext(1, "profile-a"))
+	deleteReq = withReaderFontIDParam(deleteReq, font1.ID)
+	deleteRR := httptest.NewRecorder()
+	h.HandleDelete(deleteRR, deleteReq)
+	if deleteRR.Code != http.StatusNoContent {
+		t.Fatalf("delete status = %d, want 204; body = %s", deleteRR.Code, deleteRR.Body.String())
+	}
+	if _, ok := store.fonts[font1.ID]; ok {
+		t.Fatal("expected font row to be removed after delete")
+	}
+	deletedPath := readerFontBlobPath(dir, 1, "profile-a", font1.ID, "woff2")
+	if _, err := os.Stat(deletedPath); !os.IsNotExist(err) {
+		t.Fatalf("expected font file removed from disk, stat err = %v", err)
+	}
+
+	// GET the surviving font as its owning profile: 200 with the expected
+	// headers and content type.
+	getReq := httptest.NewRequest(http.MethodGet, "/ebooks/reader-fonts/"+strconv.FormatInt(font2.ID, 10)+"/file", nil)
+	getReq = getReq.WithContext(readerFontAuthContext(1, "profile-a"))
+	getReq = withReaderFontIDParam(getReq, font2.ID)
+	getRR := httptest.NewRecorder()
+	h.HandleServeFile(getRR, getReq)
+
+	if getRR.Code != http.StatusOK {
+		t.Fatalf("owned GET status = %d, want 200; body = %s", getRR.Code, getRR.Body.String())
+	}
+	if ct := getRR.Header().Get("Content-Type"); ct != "font/woff2" {
+		t.Fatalf("Content-Type = %q, want font/woff2", ct)
+	}
+	if cc := getRR.Header().Get("Cache-Control"); cc != "private, max-age=31536000, immutable" {
+		t.Fatalf("Cache-Control = %q, want private, max-age=31536000, immutable", cc)
+	}
+	if !bytes.Equal(getRR.Body.Bytes(), uploadBody) {
+		t.Fatal("served font content does not match the uploaded content")
+	}
+
+	blobPath := filepath.Join(dir, "1", "profile-a", strconv.FormatInt(font2.ID, 10)+".woff2")
+	if _, err := os.Stat(blobPath); err != nil {
+		t.Fatalf("expected surviving font file on disk at %s: %v", blobPath, err)
+	}
+}

--- a/internal/api/handlers/reading_motivation.go
+++ b/internal/api/handlers/reading_motivation.go
@@ -4,7 +4,9 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"math"
 	"net/http"
+	"sort"
 	"strings"
 	"time"
 
@@ -80,6 +82,319 @@ type ReadingMotivationStore interface {
 	// AuthorSeconds returns all-time per-author reading-time totals,
 	// highest first.
 	AuthorSeconds(ctx context.Context, userID int, profileID string) ([]AuthorSeconds, error)
+}
+
+// streakMinSeconds is the minimum local-day reading time for that day to
+// count toward a streak, per spec.
+const streakMinSeconds = 300
+
+// monthChallengeFloorSeconds is the minimum monthly challenge target, so an
+// empty previous month doesn't trivialize the current one.
+const monthChallengeFloorSeconds = 10800
+
+// dayKeyLayout is the "YYYY-MM-DD" layout DaySeconds keys and streakFrom's
+// "today" argument use.
+const dayKeyLayout = "2006-01-02"
+
+// DaySeconds maps a "YYYY-MM-DD" local calendar day (already resolved
+// against the caller's *time.Location) to the total reading seconds
+// attributed to it.
+type DaySeconds map[string]int
+
+// sessionDaySeconds buckets sessions by the local calendar day their
+// started_at falls on in loc, summing duration_seconds per day. Sessions
+// store started_at in UTC; only the bucketing is timezone-aware.
+func sessionDaySeconds(sessions []ReadingSession, loc *time.Location) DaySeconds {
+	days := make(DaySeconds)
+	for _, s := range sessions {
+		key := s.StartedAt.In(loc).Format(dayKeyLayout)
+		days[key] += s.DurationSeconds
+	}
+	return days
+}
+
+// streakFrom computes the current and longest streaks over days, a map of
+// local calendar day to reading seconds. A day qualifies with >=
+// streakMinSeconds. The current streak is alive until a full local day is
+// missed: if today doesn't qualify, the streak isn't broken yet (it just
+// hasn't been extended) so current counts back from yesterday; if yesterday
+// also fails to qualify, the streak is dead and current is 0.
+func streakFrom(days DaySeconds, today string) (current, longest int) {
+	qualifies := func(day string) bool {
+		return days[day] >= streakMinSeconds
+	}
+
+	runEndingAt := func(start time.Time) int {
+		n := 0
+		d := start
+		for qualifies(d.Format(dayKeyLayout)) {
+			n++
+			d = d.AddDate(0, 0, -1)
+		}
+		return n
+	}
+
+	todayTime, err := time.Parse(dayKeyLayout, today)
+	if err != nil {
+		return 0, 0
+	}
+
+	if qualifies(today) {
+		current = runEndingAt(todayTime)
+	} else {
+		yesterday := todayTime.AddDate(0, 0, -1)
+		if qualifies(yesterday.Format(dayKeyLayout)) {
+			current = runEndingAt(yesterday)
+		}
+	}
+
+	var qualifyingDays []time.Time
+	for day, secs := range days {
+		if secs < streakMinSeconds {
+			continue
+		}
+		t, err := time.Parse(dayKeyLayout, day)
+		if err != nil {
+			continue
+		}
+		qualifyingDays = append(qualifyingDays, t)
+	}
+	sort.Slice(qualifyingDays, func(i, j int) bool { return qualifyingDays[i].Before(qualifyingDays[j]) })
+
+	run := 0
+	var prev time.Time
+	for i, t := range qualifyingDays {
+		if i > 0 && t.Sub(prev) == 24*time.Hour {
+			run++
+		} else {
+			run = 1
+		}
+		if run > longest {
+			longest = run
+		}
+		prev = t
+	}
+
+	return current, longest
+}
+
+// monthChallenge computes the current month's challenge target (the greater
+// of last calendar month's total seconds and monthChallengeFloorSeconds) and
+// the current month's seconds so far, both with month boundaries drawn in
+// loc against now.
+func monthChallenge(days DaySeconds, now time.Time, loc *time.Location) (targetSec, monthSec int) {
+	nowLocal := now.In(loc)
+	y, m, _ := nowLocal.Date()
+
+	prevY, prevM := y, m-1
+	if prevM < time.January {
+		prevM = time.December
+		prevY--
+	}
+
+	var prevMonthSec int
+	for day, secs := range days {
+		t, err := time.Parse(dayKeyLayout, day)
+		if err != nil {
+			continue
+		}
+		dy, dm, _ := t.Date()
+		switch {
+		case dy == y && dm == m:
+			monthSec += secs
+		case dy == prevY && dm == prevM:
+			prevMonthSec += secs
+		}
+	}
+
+	targetSec = prevMonthSec
+	if targetSec < monthChallengeFloorSeconds {
+		targetSec = monthChallengeFloorSeconds
+	}
+	return targetSec, monthSec
+}
+
+// goalProjection linearly extrapolates a year-end total from year-to-date
+// progress and the fraction of the year elapsed. When elapsedFraction is too
+// small to extrapolate meaningfully (< 0.01, i.e. very early in the year)
+// ytd itself is returned rather than dividing by a near-zero denominator.
+func goalProjection(ytd float64, yearElapsedFraction float64) float64 {
+	if yearElapsedFraction < 0.01 {
+		return ytd
+	}
+	return ytd / yearElapsedFraction
+}
+
+// hourBucket classifies an hour-of-day (0-23, local) into one of the four
+// spec buckets: morning 05-11, afternoon 12-16, evening 17-21, night 22-04.
+func hourBucket(hour int) string {
+	switch {
+	case hour >= 5 && hour <= 11:
+		return "morning"
+	case hour >= 12 && hour <= 16:
+		return "afternoon"
+	case hour >= 17 && hour <= 21:
+		return "evening"
+	default:
+		return "night"
+	}
+}
+
+// diversityScore is the complement of the Herfindahl index over genre-second
+// shares, scaled to 0-100 and rounded: (1 - Sum(share^2)) * 100.
+func diversityScore(genres []GenreSeconds) int {
+	var total int
+	for _, g := range genres {
+		total += g.Seconds
+	}
+	if total <= 0 {
+		return 0
+	}
+	var sumSquares float64
+	for _, g := range genres {
+		share := float64(g.Seconds) / float64(total)
+		sumSquares += share * share
+	}
+	return int(math.Round((1 - sumSquares) * 100))
+}
+
+// dnaAggregates is the computed "Reading DNA" profile: taste breakdown,
+// habits, and a year-end pace projection.
+type dnaAggregates struct {
+	Genres             []GenreSeconds
+	Authors            []AuthorSeconds
+	AvgSessionSeconds  int
+	HoursByBucket      map[string]int
+	ProjectedYearHours float64
+	DiversityScore     int
+}
+
+// computeDNA derives dnaAggregates from raw sessions plus the store's
+// all-time genre/author rollups. Hour-of-day buckets and average session
+// length are computed over every session passed in; the year-end projection
+// uses only sessions whose local start falls in now's local year.
+func computeDNA(sessions []ReadingSession, genres []GenreSeconds, authors []AuthorSeconds, now time.Time, loc *time.Location) dnaAggregates {
+	buckets := map[string]int{"morning": 0, "afternoon": 0, "evening": 0, "night": 0}
+	year := now.In(loc).Year()
+
+	var totalSeconds, ytdSeconds int
+	for _, s := range sessions {
+		totalSeconds += s.DurationSeconds
+		local := s.StartedAt.In(loc)
+		buckets[hourBucket(local.Hour())] += s.DurationSeconds
+		if local.Year() == year {
+			ytdSeconds += s.DurationSeconds
+		}
+	}
+
+	avgSessionSeconds := 0
+	if len(sessions) > 0 {
+		avgSessionSeconds = totalSeconds / len(sessions)
+	}
+
+	hoursByBucket := make(map[string]int, len(buckets))
+	for bucket, secs := range buckets {
+		hoursByBucket[bucket] = int(math.Round(float64(secs) / 3600.0))
+	}
+
+	yearStart := time.Date(year, 1, 1, 0, 0, 0, 0, loc)
+	nextYearStart := time.Date(year+1, 1, 1, 0, 0, 0, 0, loc)
+	elapsedFraction := float64(now.In(loc).Sub(yearStart)) / float64(nextYearStart.Sub(yearStart))
+	projected := goalProjection(float64(ytdSeconds)/3600.0, elapsedFraction)
+
+	return dnaAggregates{
+		Genres:             genres,
+		Authors:            authors,
+		AvgSessionSeconds:  avgSessionSeconds,
+		HoursByBucket:      hoursByBucket,
+		ProjectedYearHours: projected,
+		DiversityScore:     diversityScore(genres),
+	}
+}
+
+// achievementInput is the set of computed aggregates evaluateAchievements
+// checks badge criteria against. All fields are already local-timezone-
+// resolved and lifetime (not reset) totals where applicable.
+type achievementInput struct {
+	TotalSeconds          int
+	LongestSessionSeconds int
+	CurrentStreak         int
+	LongestStreak         int
+	BooksFinished         int
+	NightSeconds          int
+	EarlyBirdSeconds      int
+	WeekendSeconds        int
+	DistinctGenres        int
+	MaxBookSeconds        int
+	FinishedWithHighRead  bool
+}
+
+// AchievementDefinition is a fixed badge definition: id, display grouping,
+// name, and description. Criteria live in evaluateAchievements, not here.
+type AchievementDefinition struct {
+	ID          string
+	Category    string
+	Name        string
+	Description string
+}
+
+// achievementDefinitions is the fixed 18-badge starter set. Ids are load-
+// bearing (persisted in reading_achievements) and must never change once
+// shipped.
+var achievementDefinitions = []AchievementDefinition{
+	{ID: "first-hour", Category: "time", Name: "First Hour", Description: "Read for 1 hour total"},
+	{ID: "ten-hours", Category: "time", Name: "Ten Hours", Description: "Read for 10 hours total"},
+	{ID: "fifty-hours", Category: "time", Name: "Fifty Hours", Description: "Read for 50 hours total"},
+	{ID: "hundred-hours", Category: "time", Name: "Hundred Hours", Description: "Read for 100 hours total"},
+	{ID: "marathon-session", Category: "time", Name: "Marathon Session", Description: "Read for 2 hours in a single session"},
+	{ID: "streak-3", Category: "streak", Name: "3-Day Streak", Description: "Read 3 days in a row"},
+	{ID: "streak-7", Category: "streak", Name: "7-Day Streak", Description: "Read 7 days in a row"},
+	{ID: "streak-30", Category: "streak", Name: "30-Day Streak", Description: "Read 30 days in a row"},
+	{ID: "streak-100", Category: "streak", Name: "100-Day Streak", Description: "Read 100 days in a row"},
+	{ID: "first-book", Category: "books", Name: "First Book", Description: "Finish 1 book"},
+	{ID: "ten-books", Category: "books", Name: "Ten Books", Description: "Finish 10 books"},
+	{ID: "fifty-books", Category: "books", Name: "Fifty Books", Description: "Finish 50 books"},
+	{ID: "night-owl", Category: "habits", Name: "Night Owl", Description: "Read 10 hours between midnight and 5am"},
+	{ID: "early-bird", Category: "habits", Name: "Early Bird", Description: "Read 10 hours between 5am and 8am"},
+	{ID: "weekender", Category: "habits", Name: "Weekender", Description: "Read 20 hours on weekends"},
+	{ID: "genre-hopper", Category: "exploration", Name: "Genre Hopper", Description: "Read across 5 distinct genres"},
+	{ID: "deep-diver", Category: "exploration", Name: "Deep Diver", Description: "Read 10 hours on a single book"},
+	{ID: "finisher", Category: "exploration", Name: "Finisher", Description: "Finish a book with at least 95% read"},
+}
+
+// evaluateAchievements returns the ids of every badge in achievementDefinitions
+// whose criteria in is satisfies. It is pure and idempotent: callers merge
+// the result against previously persisted unlocks (never revoked) and
+// persist only the newly satisfied ones.
+func evaluateAchievements(in achievementInput) []string {
+	satisfied := map[string]bool{
+		"first-hour":       in.TotalSeconds >= 3600,
+		"ten-hours":        in.TotalSeconds >= 36000,
+		"fifty-hours":      in.TotalSeconds >= 180000,
+		"hundred-hours":    in.TotalSeconds >= 360000,
+		"marathon-session": in.LongestSessionSeconds >= 7200,
+		"streak-3":         in.LongestStreak >= 3,
+		"streak-7":         in.LongestStreak >= 7,
+		"streak-30":        in.LongestStreak >= 30,
+		"streak-100":       in.LongestStreak >= 100,
+		"first-book":       in.BooksFinished >= 1,
+		"ten-books":        in.BooksFinished >= 10,
+		"fifty-books":      in.BooksFinished >= 50,
+		"night-owl":        in.NightSeconds >= 36000,
+		"early-bird":       in.EarlyBirdSeconds >= 36000,
+		"weekender":        in.WeekendSeconds >= 72000,
+		"genre-hopper":     in.DistinctGenres >= 5,
+		"deep-diver":       in.MaxBookSeconds >= 36000,
+		"finisher":         in.FinishedWithHighRead,
+	}
+
+	var ids []string
+	for _, def := range achievementDefinitions {
+		if satisfied[def.ID] {
+			ids = append(ids, def.ID)
+		}
+	}
+	return ids
 }
 
 // ReadingMotivationHandler serves the reading-goals PUT endpoint (and, from

--- a/internal/api/handlers/reading_motivation.go
+++ b/internal/api/handlers/reading_motivation.go
@@ -77,6 +77,12 @@ type ReadingMotivationStore interface {
 	// models.EbookFinishedProgressThreshold with the progress row's
 	// updated_at in [from, to).
 	FinishedBooksInRange(ctx context.Context, userID int, profileID string, from, to time.Time) (int, error)
+	// HasBookReadAbove reports whether any of the profile's ebooks has ever
+	// (all-time, not year-scoped) reached at least threshold progress. This
+	// is the "finisher" badge's real criterion (>=95% per spec), distinct
+	// from and stricter than models.EbookFinishedProgressThreshold, which
+	// only gates whether a book counts as "finished" at all.
+	HasBookReadAbove(ctx context.Context, userID int, profileID string, threshold float64) (bool, error)
 	// GenreSeconds returns all-time per-genre reading-time totals,
 	// highest first.
 	GenreSeconds(ctx context.Context, userID int, profileID string) ([]GenreSeconds, error)
@@ -92,6 +98,18 @@ const streakMinSeconds = 300
 // monthChallengeFloorSeconds is the minimum monthly challenge target, so an
 // empty previous month doesn't trivialize the current one.
 const monthChallengeFloorSeconds = 10800
+
+// farFutureYears bounds the upper end of the "all-time" FinishedBooksInRange
+// call used to feed the lifetime books-count achievement badges: any
+// progress row's updated_at is guaranteed to fall before now plus this many
+// years.
+const farFutureYears = 100
+
+// finisherProgressThreshold is the "finisher" badge's minimum all-time
+// per-book progress (>=95%, per spec). It's intentionally stricter than
+// models.EbookFinishedProgressThreshold, which only gates whether a book
+// counts as "finished" at all for the books-count badges and goals card.
+const finisherProgressThreshold = 0.95
 
 // dayKeyLayout is the "YYYY-MM-DD" layout DaySeconds keys and streakFrom's
 // "today" argument use.
@@ -575,15 +593,33 @@ func (h *ReadingMotivationHandler) HandleGetMotivation(w http.ResponseWriter, r 
 		percent = 100
 	}
 
-	// "Finished book" is scoped to the current local year throughout (both
-	// the goals card's year-to-date count and the achievement badges' book
-	// totals), per spec.
+	// "Finished book" is scoped to the current local year for the goals
+	// card's year-to-date count, but the books-count achievement badges
+	// ("first-book"/"ten-books"/"fifty-books") are lifetime totals per
+	// spec, so they're fed by a separate all-time call rather than
+	// finishedYTD. Each call degrades independently.
 	yearStart := time.Date(nowLocal.Year(), 1, 1, 0, 0, 0, 0, loc)
 	yearEnd := yearStart.AddDate(1, 0, 0)
 	finishedYTD, err := h.Store.FinishedBooksInRange(ctx, userID, profileID, yearStart, yearEnd)
 	if err != nil {
 		logSectionErr("finished_books", err)
 		finishedYTD = 0
+	}
+
+	finishedAllTime, err := h.Store.FinishedBooksInRange(ctx, userID, profileID, time.Time{}, now.AddDate(farFutureYears, 0, 0))
+	if err != nil {
+		logSectionErr("finished_books_all_time", err)
+		finishedAllTime = 0
+	}
+
+	// The "finisher" badge is a real, independent criterion: has any book
+	// ever (all-time) reached finisherProgressThreshold, not just "at least
+	// one book was finished this year" (which duplicates "first-book" and
+	// uses the looser models.EbookFinishedProgressThreshold).
+	highRead, err := h.Store.HasBookReadAbove(ctx, userID, profileID, finisherProgressThreshold)
+	if err != nil {
+		logSectionErr("finisher_high_read", err)
+		highRead = false
 	}
 
 	goalsRow, err := h.Store.GetGoals(ctx, userID, profileID)
@@ -664,13 +700,13 @@ func (h *ReadingMotivationHandler) HandleGetMotivation(w http.ResponseWriter, r 
 		LongestSessionSeconds: longestSessionSeconds,
 		CurrentStreak:         currentStreak,
 		LongestStreak:         longestStreak,
-		BooksFinished:         finishedYTD,
+		BooksFinished:         finishedAllTime,
 		NightSeconds:          nightSeconds,
 		EarlyBirdSeconds:      earlyBirdSeconds,
 		WeekendSeconds:        weekendSeconds,
 		DistinctGenres:        len(genres),
 		MaxBookSeconds:        maxBookSeconds,
-		FinishedWithHighRead:  finishedYTD > 0,
+		FinishedWithHighRead:  highRead,
 	})
 	for _, id := range satisfied {
 		if _, already := achievedAt[id]; already {
@@ -884,6 +920,24 @@ func (s *PGReadingMotivationStore) FinishedBooksInRange(ctx context.Context, use
 		return 0, fmt.Errorf("finished books in range: %w", err)
 	}
 	return count, nil
+}
+
+func (s *PGReadingMotivationStore) HasBookReadAbove(ctx context.Context, userID int, profileID string, threshold float64) (bool, error) {
+	if s == nil || s.pool == nil {
+		return false, fmt.Errorf("reading motivation store is not configured")
+	}
+	var exists bool
+	err := s.pool.QueryRow(ctx, `
+		SELECT EXISTS(
+			SELECT 1 FROM ebook_reader_progress
+			WHERE user_id = $1 AND profile_id = $2 AND progress >= $3
+		)`,
+		userID, profileID, threshold,
+	).Scan(&exists)
+	if err != nil {
+		return false, fmt.Errorf("has book read above: %w", err)
+	}
+	return exists, nil
 }
 
 func (s *PGReadingMotivationStore) GenreSeconds(ctx context.Context, userID int, profileID string) ([]GenreSeconds, error) {

--- a/internal/api/handlers/reading_motivation.go
+++ b/internal/api/handlers/reading_motivation.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"log/slog"
 	"math"
 	"net/http"
 	"sort"
@@ -452,6 +453,286 @@ func (h *ReadingMotivationHandler) HandlePutGoals(w http.ResponseWriter, r *http
 		return
 	}
 	w.WriteHeader(http.StatusNoContent)
+}
+
+// earlyBirdStartHour/earlyBirdEndHour bound the "early-bird" badge's habit
+// window (5am-8am local), which is narrower than hourBucket's "morning"
+// bucket (5-11) used for the DNA hour-of-day breakdown.
+const (
+	earlyBirdStartHour = 5
+	earlyBirdEndHour   = 8
+)
+
+type readingMotivationStreakResponse struct {
+	CurrentDays    int  `json:"current_days"`
+	LongestDays    int  `json:"longest_days"`
+	TodaySeconds   int  `json:"today_seconds"`
+	TodayQualified bool `json:"today_qualified"`
+}
+
+type readingMotivationGoalsResponse struct {
+	BooksPerYear     *int    `json:"books_per_year"`
+	HoursPerYear     *int    `json:"hours_per_year"`
+	BooksFinishedYTD int     `json:"books_finished_ytd"`
+	HoursYTD         float64 `json:"hours_ytd"`
+	BooksOnTrackFor  int     `json:"books_on_track_for"`
+	HoursOnTrackFor  int     `json:"hours_on_track_for"`
+}
+
+type readingMotivationChallengeResponse struct {
+	TargetSeconds int `json:"target_seconds"`
+	MonthSeconds  int `json:"month_seconds"`
+	Percent       int `json:"percent"`
+}
+
+type readingMotivationAchievementResponse struct {
+	ID          string  `json:"id"`
+	Category    string  `json:"category"`
+	Name        string  `json:"name"`
+	Description string  `json:"description"`
+	AchievedAt  *string `json:"achieved_at"`
+}
+
+type readingMotivationGenreResponse struct {
+	Name    string `json:"name"`
+	Seconds int    `json:"seconds"`
+}
+
+type readingMotivationAuthorResponse struct {
+	Name    string `json:"name"`
+	Seconds int    `json:"seconds"`
+}
+
+type readingMotivationDNAResponse struct {
+	Genres             []readingMotivationGenreResponse  `json:"genres"`
+	Authors            []readingMotivationAuthorResponse `json:"authors"`
+	DiversityScore     int                               `json:"diversity_score"`
+	AvgSessionSeconds  int                               `json:"avg_session_seconds"`
+	HoursByBucket      map[string]int                    `json:"hours_by_bucket"`
+	ProjectedYearHours float64                           `json:"projected_year_hours"`
+}
+
+type readingMotivationResponse struct {
+	Streak       readingMotivationStreakResponse        `json:"streak"`
+	Goals        readingMotivationGoalsResponse         `json:"goals"`
+	Challenge    readingMotivationChallengeResponse     `json:"challenge"`
+	Achievements []readingMotivationAchievementResponse `json:"achievements"`
+	DNA          readingMotivationDNAResponse           `json:"dna"`
+}
+
+// HandleGetMotivation assembles the full reading-motivation payload: streak,
+// yearly goals progress, the auto monthly challenge, the 18-badge
+// achievement grid (evaluating and persisting any newly satisfied ones),
+// and the Reading DNA taste/habit breakdown.
+//
+// Each section is computed from its own store call(s): a failing call is
+// logged and that section falls back to its zero value (empty slice/zeroed
+// struct) rather than aborting the whole response. Only the identity check
+// and a nil store/Now are request-level preconditions that can fail the
+// endpoint outright.
+func (h *ReadingMotivationHandler) HandleGetMotivation(w http.ResponseWriter, r *http.Request) {
+	userID := apimw.GetUserID(r.Context())
+	profileID := apimw.GetProfileID(r.Context())
+	if userID == 0 {
+		writeError(w, http.StatusUnauthorized, "unauthorized", "Authentication required")
+		return
+	}
+	if h == nil || h.Store == nil || h.Now == nil {
+		writeError(w, http.StatusServiceUnavailable, "unavailable", "Reading motivation is not configured")
+		return
+	}
+
+	ctx := r.Context()
+	loc := requestLocation(r)
+	now := h.Now()
+	nowLocal := now.In(loc)
+
+	logSectionErr := func(section string, err error) {
+		slog.ErrorContext(ctx, "reading motivation: section failed, degrading to zero value",
+			"component", "api", "section", section, "error", err)
+	}
+
+	// Sessions feed streak/challenge/DNA/achievement math; a failure here
+	// degrades every section that reads from it to its own zero value
+	// rather than a hard 500, same as any other section.
+	sessions, err := h.Store.SessionsSince(ctx, userID, profileID, time.Time{})
+	if err != nil {
+		logSectionErr("sessions", err)
+		sessions = nil
+	}
+
+	days := sessionDaySeconds(sessions, loc)
+	todayKey := nowLocal.Format(dayKeyLayout)
+	currentStreak, longestStreak := streakFrom(days, todayKey)
+	todaySeconds := days[todayKey]
+
+	targetSeconds, monthSeconds := monthChallenge(days, now, loc)
+	percent := 0
+	if targetSeconds > 0 {
+		percent = int(math.Round(float64(monthSeconds) / float64(targetSeconds) * 100))
+	}
+	if percent > 100 {
+		percent = 100
+	}
+
+	// "Finished book" is scoped to the current local year throughout (both
+	// the goals card's year-to-date count and the achievement badges' book
+	// totals), per spec.
+	yearStart := time.Date(nowLocal.Year(), 1, 1, 0, 0, 0, 0, loc)
+	yearEnd := yearStart.AddDate(1, 0, 0)
+	finishedYTD, err := h.Store.FinishedBooksInRange(ctx, userID, profileID, yearStart, yearEnd)
+	if err != nil {
+		logSectionErr("finished_books", err)
+		finishedYTD = 0
+	}
+
+	goalsRow, err := h.Store.GetGoals(ctx, userID, profileID)
+	if err != nil {
+		logSectionErr("goals", err)
+		goalsRow = nil
+	}
+
+	genres, err := h.Store.GenreSeconds(ctx, userID, profileID)
+	if err != nil {
+		logSectionErr("genre_seconds", err)
+		genres = nil
+	}
+
+	authors, err := h.Store.AuthorSeconds(ctx, userID, profileID)
+	if err != nil {
+		logSectionErr("author_seconds", err)
+		authors = nil
+	}
+
+	dna := computeDNA(sessions, genres, authors, now, loc)
+
+	elapsedFraction := float64(nowLocal.Sub(yearStart)) / float64(yearEnd.Sub(yearStart))
+	var ytdSeconds int
+	var totalSeconds, longestSessionSeconds, maxBookSeconds int
+	var nightSeconds, earlyBirdSeconds, weekendSeconds int
+	bookSeconds := make(map[string]int)
+	for _, s := range sessions {
+		totalSeconds += s.DurationSeconds
+		if s.DurationSeconds > longestSessionSeconds {
+			longestSessionSeconds = s.DurationSeconds
+		}
+		bookSeconds[s.ContentID] += s.DurationSeconds
+
+		local := s.StartedAt.In(loc)
+		if local.Year() == nowLocal.Year() {
+			ytdSeconds += s.DurationSeconds
+		}
+		hour := local.Hour()
+		if hourBucket(hour) == "night" {
+			nightSeconds += s.DurationSeconds
+		}
+		if hour >= earlyBirdStartHour && hour < earlyBirdEndHour {
+			earlyBirdSeconds += s.DurationSeconds
+		}
+		if wd := local.Weekday(); wd == time.Saturday || wd == time.Sunday {
+			weekendSeconds += s.DurationSeconds
+		}
+	}
+	for _, secs := range bookSeconds {
+		if secs > maxBookSeconds {
+			maxBookSeconds = secs
+		}
+	}
+
+	goalsResp := readingMotivationGoalsResponse{
+		BooksFinishedYTD: finishedYTD,
+		HoursYTD:         float64(ytdSeconds) / 3600.0,
+		BooksOnTrackFor:  int(math.Round(goalProjection(float64(finishedYTD), elapsedFraction))),
+		HoursOnTrackFor:  int(math.Round(goalProjection(float64(ytdSeconds)/3600.0, elapsedFraction))),
+	}
+	if goalsRow != nil {
+		goalsResp.BooksPerYear = goalsRow.BooksPerYear
+		goalsResp.HoursPerYear = goalsRow.HoursPerYear
+	}
+
+	achievedAt, err := h.Store.AchievedAt(ctx, userID, profileID)
+	if err != nil {
+		logSectionErr("achievements", err)
+		achievedAt = nil
+	}
+	if achievedAt == nil {
+		achievedAt = make(map[string]time.Time)
+	}
+
+	satisfied := evaluateAchievements(achievementInput{
+		TotalSeconds:          totalSeconds,
+		LongestSessionSeconds: longestSessionSeconds,
+		CurrentStreak:         currentStreak,
+		LongestStreak:         longestStreak,
+		BooksFinished:         finishedYTD,
+		NightSeconds:          nightSeconds,
+		EarlyBirdSeconds:      earlyBirdSeconds,
+		WeekendSeconds:        weekendSeconds,
+		DistinctGenres:        len(genres),
+		MaxBookSeconds:        maxBookSeconds,
+		FinishedWithHighRead:  finishedYTD > 0,
+	})
+	for _, id := range satisfied {
+		if _, already := achievedAt[id]; already {
+			continue
+		}
+		if err := h.Store.PersistAchievement(ctx, userID, profileID, id, now); err != nil {
+			// Persistence failure is a silent skip: the badge shows locked
+			// in this response and the next call retries the unlock.
+			slog.ErrorContext(ctx, "reading motivation: persist achievement failed",
+				"component", "api", "achievement_id", id, "error", err)
+			continue
+		}
+		achievedAt[id] = now
+	}
+
+	achievementsResp := make([]readingMotivationAchievementResponse, 0, len(achievementDefinitions))
+	for _, def := range achievementDefinitions {
+		item := readingMotivationAchievementResponse{
+			ID:          def.ID,
+			Category:    def.Category,
+			Name:        def.Name,
+			Description: def.Description,
+		}
+		if at, ok := achievedAt[def.ID]; ok {
+			formatted := at.UTC().Format(time.RFC3339)
+			item.AchievedAt = &formatted
+		}
+		achievementsResp = append(achievementsResp, item)
+	}
+
+	genresResp := make([]readingMotivationGenreResponse, 0, len(dna.Genres))
+	for _, g := range dna.Genres {
+		genresResp = append(genresResp, readingMotivationGenreResponse{Name: g.Genre, Seconds: g.Seconds})
+	}
+	authorsResp := make([]readingMotivationAuthorResponse, 0, len(dna.Authors))
+	for _, a := range dna.Authors {
+		authorsResp = append(authorsResp, readingMotivationAuthorResponse{Name: a.Author, Seconds: a.Seconds})
+	}
+
+	writeJSON(w, http.StatusOK, readingMotivationResponse{
+		Streak: readingMotivationStreakResponse{
+			CurrentDays:    currentStreak,
+			LongestDays:    longestStreak,
+			TodaySeconds:   todaySeconds,
+			TodayQualified: todaySeconds >= streakMinSeconds,
+		},
+		Goals: goalsResp,
+		Challenge: readingMotivationChallengeResponse{
+			TargetSeconds: targetSeconds,
+			MonthSeconds:  monthSeconds,
+			Percent:       percent,
+		},
+		Achievements: achievementsResp,
+		DNA: readingMotivationDNAResponse{
+			Genres:             genresResp,
+			Authors:            authorsResp,
+			DiversityScore:     dna.DiversityScore,
+			AvgSessionSeconds:  dna.AvgSessionSeconds,
+			HoursByBucket:      dna.HoursByBucket,
+			ProjectedYearHours: dna.ProjectedYearHours,
+		},
+	})
 }
 
 // PGReadingMotivationStore is the Postgres-backed ReadingMotivationStore.

--- a/internal/api/handlers/reading_motivation.go
+++ b/internal/api/handlers/reading_motivation.go
@@ -259,6 +259,41 @@ func hourBucket(hour int) string {
 	}
 }
 
+// topGenreCount is how many genres the motivation endpoint surfaces
+// individually before collapsing the remainder into an "other" bucket.
+const topGenreCount = 8
+
+// otherGenreLabel is the display name of the collapsed bucket summing every
+// genre beyond the top topGenreCount by seconds.
+const otherGenreLabel = "other"
+
+// collapseGenresToTopEight collapses genres to the top topGenreCount by
+// seconds plus a trailing "other" entry summing the remainder. It's a
+// display-only transform: diversity score and distinct-genre counts must be
+// computed from the uncollapsed list before calling this, since collapsing
+// would otherwise understate both.
+func collapseGenresToTopEight(genres []GenreSeconds) []GenreSeconds {
+	if len(genres) <= topGenreCount {
+		return genres
+	}
+
+	sorted := make([]GenreSeconds, len(genres))
+	copy(sorted, genres)
+	sort.Slice(sorted, func(i, j int) bool { return sorted[i].Seconds > sorted[j].Seconds })
+
+	out := make([]GenreSeconds, 0, topGenreCount+1)
+	var otherSeconds int
+	for i, g := range sorted {
+		if i < topGenreCount {
+			out = append(out, g)
+			continue
+		}
+		otherSeconds += g.Seconds
+	}
+	out = append(out, GenreSeconds{Genre: otherGenreLabel, Seconds: otherSeconds})
+	return out
+}
+
 // diversityScore is the complement of the Herfindahl index over genre-second
 // shares, scaled to 0-100 and rounded: (1 - Sum(share^2)) * 100.
 func diversityScore(genres []GenreSeconds) int {
@@ -746,8 +781,12 @@ func (h *ReadingMotivationHandler) HandleGetMotivation(w http.ResponseWriter, r 
 		achievementsResp = append(achievementsResp, item)
 	}
 
-	genresResp := make([]readingMotivationGenreResponse, 0, len(dna.Genres))
-	for _, g := range dna.Genres {
+	// dna.Genres is the uncollapsed all-time list (diversityScore and
+	// DistinctGenres above are already computed from it); collapse only for
+	// this display projection.
+	displayGenres := collapseGenresToTopEight(dna.Genres)
+	genresResp := make([]readingMotivationGenreResponse, 0, len(displayGenres))
+	for _, g := range displayGenres {
 		genresResp = append(genresResp, readingMotivationGenreResponse{Name: g.Genre, Seconds: g.Seconds})
 	}
 	authorsResp := make([]readingMotivationAuthorResponse, 0, len(dna.Authors))

--- a/internal/api/handlers/reading_motivation.go
+++ b/internal/api/handlers/reading_motivation.go
@@ -1,0 +1,358 @@
+package handlers
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgxpool"
+
+	apimw "github.com/Silo-Server/silo-server/internal/api/middleware"
+	"github.com/Silo-Server/silo-server/internal/models"
+)
+
+// requestLocation resolves the requester's timezone from the "tz" query
+// param (an IANA zone name, typically Intl.DateTimeFormat().resolvedOptions().timeZone
+// from the client), falling back to UTC when the param is absent, invalid,
+// or "Local". "Local" is rejected explicitly even though time.LoadLocation
+// would resolve it successfully, since it means "the server's zone", not a
+// meaningful request-scoped default.
+func requestLocation(r *http.Request) *time.Location {
+	name := strings.TrimSpace(r.URL.Query().Get("tz"))
+	if name == "" || name == "Local" {
+		return time.UTC
+	}
+	loc, err := time.LoadLocation(name)
+	if err != nil {
+		return time.UTC
+	}
+	return loc
+}
+
+// ReadingGoals is a profile's yearly reading goals. A nil field is unset.
+type ReadingGoals struct {
+	BooksPerYear *int
+	HoursPerYear *int
+}
+
+// GenreSeconds is a per-genre reading-time rollup. A book's duration is
+// split evenly across its genres.
+type GenreSeconds struct {
+	Genre   string
+	Seconds int
+}
+
+// AuthorSeconds is a per-author reading-time rollup.
+type AuthorSeconds struct {
+	Author  string
+	Seconds int
+}
+
+// ReadingMotivationStore persists reading goals and achievement unlocks, and
+// supplies the raw aggregates the motivation endpoint's pure math (streaks,
+// challenge, DNA, badge criteria) is built from.
+type ReadingMotivationStore interface {
+	GetGoals(ctx context.Context, userID int, profileID string) (*ReadingGoals, error)
+	PutGoals(ctx context.Context, userID int, profileID string, g ReadingGoals) error
+
+	// AchievedAt returns the profile's unlocked achievement ids mapped to
+	// when they were unlocked.
+	AchievedAt(ctx context.Context, userID int, profileID string) (map[string]time.Time, error)
+	// PersistAchievement records a newly satisfied badge. Implementations
+	// must be idempotent (a badge, once unlocked, is never revoked or
+	// re-timestamped).
+	PersistAchievement(ctx context.Context, userID int, profileID, achievementID string, at time.Time) error
+
+	// SessionsSince returns raw session rows since the given time for the
+	// pure aggregation math to consume.
+	SessionsSince(ctx context.Context, userID int, profileID string, since time.Time) ([]ReadingSession, error)
+	// FinishedBooksInRange counts ebooks whose progress crossed
+	// models.EbookFinishedProgressThreshold with the progress row's
+	// updated_at in [from, to).
+	FinishedBooksInRange(ctx context.Context, userID int, profileID string, from, to time.Time) (int, error)
+	// GenreSeconds returns all-time per-genre reading-time totals,
+	// highest first.
+	GenreSeconds(ctx context.Context, userID int, profileID string) ([]GenreSeconds, error)
+	// AuthorSeconds returns all-time per-author reading-time totals,
+	// highest first.
+	AuthorSeconds(ctx context.Context, userID int, profileID string) ([]AuthorSeconds, error)
+}
+
+// ReadingMotivationHandler serves the reading-goals PUT endpoint (and, from
+// a later task, the reading-motivation GET endpoint). Now is injected so
+// achievement-unlock and goal-year math is deterministic under test.
+type ReadingMotivationHandler struct {
+	Store ReadingMotivationStore
+	Now   func() time.Time
+}
+
+const (
+	// minYearlyGoal and maxYearlyGoal bound both books_per_year and
+	// hours_per_year, per spec.
+	minYearlyGoal = 1
+	maxYearlyGoal = 100000
+)
+
+type putGoalsRequest struct {
+	BooksPerYear *int `json:"books_per_year"`
+	HoursPerYear *int `json:"hours_per_year"`
+}
+
+// HandlePutGoals replaces the profile's reading goals wholesale: this is PUT
+// semantics, not PATCH, so an absent field decodes to nil and clears that
+// goal rather than leaving the stored value untouched.
+func (h *ReadingMotivationHandler) HandlePutGoals(w http.ResponseWriter, r *http.Request) {
+	userID := apimw.GetUserID(r.Context())
+	profileID := apimw.GetProfileID(r.Context())
+	if userID == 0 {
+		writeError(w, http.StatusUnauthorized, "unauthorized", "Authentication required")
+		return
+	}
+	if h == nil || h.Store == nil {
+		writeError(w, http.StatusServiceUnavailable, "unavailable", "Reading goals are not configured")
+		return
+	}
+
+	var req putGoalsRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		writeError(w, http.StatusBadRequest, "bad_request", "Invalid goals body")
+		return
+	}
+	if req.BooksPerYear != nil && (*req.BooksPerYear < minYearlyGoal || *req.BooksPerYear > maxYearlyGoal) {
+		writeError(w, http.StatusBadRequest, "invalid_goal", "books_per_year must be between 1 and 100000")
+		return
+	}
+	if req.HoursPerYear != nil && (*req.HoursPerYear < minYearlyGoal || *req.HoursPerYear > maxYearlyGoal) {
+		writeError(w, http.StatusBadRequest, "invalid_goal", "hours_per_year must be between 1 and 100000")
+		return
+	}
+
+	goals := ReadingGoals{BooksPerYear: req.BooksPerYear, HoursPerYear: req.HoursPerYear}
+	if err := h.Store.PutGoals(r.Context(), userID, profileID, goals); err != nil {
+		writeError(w, http.StatusInternalServerError, "internal_error", "Failed to save reading goals")
+		return
+	}
+	w.WriteHeader(http.StatusNoContent)
+}
+
+// PGReadingMotivationStore is the Postgres-backed ReadingMotivationStore.
+type PGReadingMotivationStore struct {
+	pool *pgxpool.Pool
+}
+
+// NewPGReadingMotivationStore constructs a PGReadingMotivationStore.
+func NewPGReadingMotivationStore(pool *pgxpool.Pool) *PGReadingMotivationStore {
+	return &PGReadingMotivationStore{pool: pool}
+}
+
+func (s *PGReadingMotivationStore) GetGoals(ctx context.Context, userID int, profileID string) (*ReadingGoals, error) {
+	if s == nil || s.pool == nil {
+		return nil, fmt.Errorf("reading motivation store is not configured")
+	}
+	var g ReadingGoals
+	err := s.pool.QueryRow(ctx, `
+		SELECT books_per_year, hours_per_year
+		FROM reading_goals
+		WHERE user_id = $1 AND profile_id = $2`,
+		userID, profileID,
+	).Scan(&g.BooksPerYear, &g.HoursPerYear)
+	if err != nil {
+		if err == pgx.ErrNoRows {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("get goals: %w", err)
+	}
+	return &g, nil
+}
+
+func (s *PGReadingMotivationStore) PutGoals(ctx context.Context, userID int, profileID string, g ReadingGoals) error {
+	if s == nil || s.pool == nil {
+		return fmt.Errorf("reading motivation store is not configured")
+	}
+	_, err := s.pool.Exec(ctx, `
+		INSERT INTO reading_goals (user_id, profile_id, books_per_year, hours_per_year, updated_at)
+		VALUES ($1, $2, $3, $4, now())
+		ON CONFLICT (user_id, profile_id) DO UPDATE
+		SET books_per_year = $3, hours_per_year = $4, updated_at = now()`,
+		userID, profileID, g.BooksPerYear, g.HoursPerYear,
+	)
+	if err != nil {
+		return fmt.Errorf("put goals: %w", err)
+	}
+	return nil
+}
+
+func (s *PGReadingMotivationStore) AchievedAt(ctx context.Context, userID int, profileID string) (map[string]time.Time, error) {
+	if s == nil || s.pool == nil {
+		return nil, fmt.Errorf("reading motivation store is not configured")
+	}
+	rows, err := s.pool.Query(ctx, `
+		SELECT achievement_id, achieved_at
+		FROM reading_achievements
+		WHERE user_id = $1 AND profile_id = $2`,
+		userID, profileID,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("achieved at: %w", err)
+	}
+	defer rows.Close()
+
+	out := make(map[string]time.Time)
+	for rows.Next() {
+		var id string
+		var at time.Time
+		if err := rows.Scan(&id, &at); err != nil {
+			return nil, fmt.Errorf("scan achieved at: %w", err)
+		}
+		out[id] = at
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("iterate achieved at: %w", err)
+	}
+	return out, nil
+}
+
+func (s *PGReadingMotivationStore) PersistAchievement(ctx context.Context, userID int, profileID, achievementID string, at time.Time) error {
+	if s == nil || s.pool == nil {
+		return fmt.Errorf("reading motivation store is not configured")
+	}
+	_, err := s.pool.Exec(ctx, `
+		INSERT INTO reading_achievements (user_id, profile_id, achievement_id, achieved_at)
+		VALUES ($1, $2, $3, $4)
+		ON CONFLICT (user_id, profile_id, achievement_id) DO NOTHING`,
+		userID, profileID, achievementID, at,
+	)
+	if err != nil {
+		return fmt.Errorf("persist achievement: %w", err)
+	}
+	return nil
+}
+
+func (s *PGReadingMotivationStore) SessionsSince(ctx context.Context, userID int, profileID string, since time.Time) ([]ReadingSession, error) {
+	if s == nil || s.pool == nil {
+		return nil, fmt.Errorf("reading motivation store is not configured")
+	}
+	rows, err := s.pool.Query(ctx, `
+		SELECT id, user_id, profile_id, content_id, started_at, last_heartbeat_at,
+		       duration_seconds, start_fraction, end_fraction
+		FROM reading_sessions
+		WHERE user_id = $1 AND profile_id = $2 AND started_at >= $3
+		ORDER BY started_at`,
+		userID, profileID, since,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("sessions since: %w", err)
+	}
+	defer rows.Close()
+
+	var out []ReadingSession
+	for rows.Next() {
+		var sess ReadingSession
+		if err := rows.Scan(
+			&sess.ID,
+			&sess.UserID,
+			&sess.ProfileID,
+			&sess.ContentID,
+			&sess.StartedAt,
+			&sess.LastHeartbeatAt,
+			&sess.DurationSeconds,
+			&sess.StartFraction,
+			&sess.EndFraction,
+		); err != nil {
+			return nil, fmt.Errorf("scan sessions since: %w", err)
+		}
+		out = append(out, sess)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("iterate sessions since: %w", err)
+	}
+	return out, nil
+}
+
+func (s *PGReadingMotivationStore) FinishedBooksInRange(ctx context.Context, userID int, profileID string, from, to time.Time) (int, error) {
+	if s == nil || s.pool == nil {
+		return 0, fmt.Errorf("reading motivation store is not configured")
+	}
+	var count int
+	err := s.pool.QueryRow(ctx, `
+		SELECT COUNT(*)
+		FROM ebook_reader_progress
+		WHERE user_id = $1 AND profile_id = $2 AND progress >= $3 AND updated_at >= $4 AND updated_at < $5`,
+		userID, profileID, models.EbookFinishedProgressThreshold, from, to,
+	).Scan(&count)
+	if err != nil {
+		return 0, fmt.Errorf("finished books in range: %w", err)
+	}
+	return count, nil
+}
+
+func (s *PGReadingMotivationStore) GenreSeconds(ctx context.Context, userID int, profileID string) ([]GenreSeconds, error) {
+	if s == nil || s.pool == nil {
+		return nil, fmt.Errorf("reading motivation store is not configured")
+	}
+	rows, err := s.pool.Query(ctx, `
+		SELECT g.genre, SUM(rs.duration_seconds::float / GREATEST(cardinality(mi.genres), 1))::bigint
+		FROM reading_sessions rs
+		JOIN media_items mi ON mi.content_id = rs.content_id
+		CROSS JOIN LATERAL unnest(mi.genres) AS g(genre)
+		WHERE rs.user_id = $1 AND rs.profile_id = $2
+		GROUP BY g.genre
+		ORDER BY 2 DESC`,
+		userID, profileID,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("genre seconds: %w", err)
+	}
+	defer rows.Close()
+
+	var out []GenreSeconds
+	for rows.Next() {
+		var g GenreSeconds
+		if err := rows.Scan(&g.Genre, &g.Seconds); err != nil {
+			return nil, fmt.Errorf("scan genre seconds: %w", err)
+		}
+		out = append(out, g)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("iterate genre seconds: %w", err)
+	}
+	return out, nil
+}
+
+func (s *PGReadingMotivationStore) AuthorSeconds(ctx context.Context, userID int, profileID string) ([]AuthorSeconds, error) {
+	if s == nil || s.pool == nil {
+		return nil, fmt.Errorf("reading motivation store is not configured")
+	}
+	rows, err := s.pool.Query(ctx, `
+		SELECT p.name, SUM(rs.duration_seconds)
+		FROM reading_sessions rs
+		JOIN item_people ip ON ip.content_id = rs.content_id AND ip.kind = $3
+		JOIN people p ON p.id = ip.person_id
+		WHERE rs.user_id = $1 AND rs.profile_id = $2
+		GROUP BY p.name
+		ORDER BY 2 DESC
+		LIMIT 8`,
+		userID, profileID, int(models.PersonKindAuthor),
+	)
+	if err != nil {
+		return nil, fmt.Errorf("author seconds: %w", err)
+	}
+	defer rows.Close()
+
+	var out []AuthorSeconds
+	for rows.Next() {
+		var a AuthorSeconds
+		if err := rows.Scan(&a.Author, &a.Seconds); err != nil {
+			return nil, fmt.Errorf("scan author seconds: %w", err)
+		}
+		out = append(out, a)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("iterate author seconds: %w", err)
+	}
+	return out, nil
+}

--- a/internal/api/handlers/reading_motivation.go
+++ b/internal/api/handlers/reading_motivation.go
@@ -481,6 +481,11 @@ const (
 	earlyBirdEndHour   = 8
 )
 
+// nightOwlEndHour bounds the "night-owl" badge's habit window: local hours
+// [0, nightOwlEndHour), i.e. midnight-5am, per spec. This is distinct from
+// hourBucket's "night" DNA bucket (22-04), which wraps across midnight.
+const nightOwlEndHour = 5
+
 type readingMotivationStreakResponse struct {
 	CurrentDays    int  `json:"current_days"`
 	LongestDays    int  `json:"longest_days"`
@@ -659,7 +664,11 @@ func (h *ReadingMotivationHandler) HandleGetMotivation(w http.ResponseWriter, r 
 			ytdSeconds += s.DurationSeconds
 		}
 		hour := local.Hour()
-		if hourBucket(hour) == "night" {
+		// The "night-owl" badge's window is midnight-5am (per spec),
+		// narrower than and offset from hourBucket's "night" DNA bucket
+		// (22-04), so it's accumulated separately rather than reusing
+		// hourBucket here.
+		if hour < nightOwlEndHour {
 			nightSeconds += s.DurationSeconds
 		}
 		if hour >= earlyBirdStartHour && hour < earlyBirdEndHour {

--- a/internal/api/handlers/reading_motivation_test.go
+++ b/internal/api/handlers/reading_motivation_test.go
@@ -25,8 +25,21 @@ type fakeReadingMotivationStore struct {
 	sessions    []ReadingSession
 	sessionsErr error
 
-	finishedBooks    int
+	// finishedBooksYTD/finishedBooksErr back the year-scoped
+	// FinishedBooksInRange(from=yearStart, ...) call (goals.books_finished_ytd).
+	finishedBooksYTD int
 	finishedBooksErr error
+
+	// finishedBooksAllTime/finishedBooksAllTimeErr back the all-time
+	// FinishedBooksInRange(from=zero time, ...) call that feeds the
+	// books-count achievement badges, independent of the YTD call.
+	finishedBooksAllTime    int
+	finishedBooksAllTimeErr error
+
+	// hasBookReadAbove/hasBookReadAboveErr back HasBookReadAbove, the
+	// all-time "finisher" badge criterion.
+	hasBookReadAbove    bool
+	hasBookReadAboveErr error
 
 	genres    []GenreSeconds
 	genresErr error
@@ -94,11 +107,28 @@ func (f *fakeReadingMotivationStore) SessionsSince(_ context.Context, _ int, _ s
 	return f.sessions, nil
 }
 
-func (f *fakeReadingMotivationStore) FinishedBooksInRange(_ context.Context, _ int, _ string, _, _ time.Time) (int, error) {
+// FinishedBooksInRange distinguishes the year-scoped YTD call from the
+// all-time call by whether from is the zero time: the handler always passes
+// a non-zero yearStart for the YTD count and time.Time{} for the all-time
+// count, so each call degrades independently via its own error field.
+func (f *fakeReadingMotivationStore) FinishedBooksInRange(_ context.Context, _ int, _ string, from, _ time.Time) (int, error) {
+	if from.IsZero() {
+		if f.finishedBooksAllTimeErr != nil {
+			return 0, f.finishedBooksAllTimeErr
+		}
+		return f.finishedBooksAllTime, nil
+	}
 	if f.finishedBooksErr != nil {
 		return 0, f.finishedBooksErr
 	}
-	return f.finishedBooks, nil
+	return f.finishedBooksYTD, nil
+}
+
+func (f *fakeReadingMotivationStore) HasBookReadAbove(_ context.Context, _ int, _ string, _ float64) (bool, error) {
+	if f.hasBookReadAboveErr != nil {
+		return false, f.hasBookReadAboveErr
+	}
+	return f.hasBookReadAbove, nil
 }
 
 func (f *fakeReadingMotivationStore) GenreSeconds(_ context.Context, _ int, _ string) ([]GenreSeconds, error) {
@@ -657,11 +687,11 @@ func TestMotivationEndpointShape(t *testing.T) {
 		sessions: []ReadingSession{
 			{ContentID: "book-1", StartedAt: now.Add(-2 * time.Hour), DurationSeconds: 3600},
 		},
-		goals:         map[string]ReadingGoals{},
-		achievements:  map[string]time.Time{"first-hour": now.Add(-24 * time.Hour)},
-		finishedBooks: 3,
-		genres:        []GenreSeconds{{Genre: "Sci-Fi", Seconds: 3600}},
-		authors:       []AuthorSeconds{{Author: "Jane Doe", Seconds: 3600}},
+		goals:            map[string]ReadingGoals{},
+		achievements:     map[string]time.Time{"first-hour": now.Add(-24 * time.Hour)},
+		finishedBooksYTD: 3,
+		genres:           []GenreSeconds{{Genre: "Sci-Fi", Seconds: 3600}},
+		authors:          []AuthorSeconds{{Author: "Jane Doe", Seconds: 3600}},
 	}
 	books, hours := 20, 100
 	store.goals[goalsKey(1, "profile-a")] = ReadingGoals{BooksPerYear: &books, HoursPerYear: &hours}
@@ -773,9 +803,9 @@ func TestMotivationDegradesPerSection(t *testing.T) {
 		sessions: []ReadingSession{
 			{ContentID: "book-1", StartedAt: now.Add(-2 * time.Hour), DurationSeconds: 3600},
 		},
-		authors:       []AuthorSeconds{{Author: "Jane Doe", Seconds: 3600}},
-		finishedBooks: 2,
-		genresErr:     fmt.Errorf("genre join exploded"),
+		authors:          []AuthorSeconds{{Author: "Jane Doe", Seconds: 3600}},
+		finishedBooksYTD: 2,
+		genresErr:        fmt.Errorf("genre join exploded"),
 	}
 
 	h := &ReadingMotivationHandler{Store: store, Now: func() time.Time { return now }}
@@ -860,4 +890,109 @@ func TestMotivationUsesTimezone(t *testing.T) {
 	if !amsterdam.Streak.TodayQualified {
 		t.Error("Europe/Amsterdam today_qualified = false, want true (900s >= 300s minimum)")
 	}
+}
+
+// achievementByID finds an achievement in resp by id, failing the test if
+// it's missing (every response must carry all 18 fixed definitions).
+func achievementByID(t *testing.T, resp readingMotivationResponse, id string) readingMotivationAchievementResponse {
+	t.Helper()
+	for _, a := range resp.Achievements {
+		if a.ID == id {
+			return a
+		}
+	}
+	t.Fatalf("achievement %q not present in response", id)
+	return readingMotivationAchievementResponse{}
+}
+
+// TestMotivationBooksBadgesUseLifetimeCount pins the books-count badge
+// contract: "first-book"/"ten-books"/"fifty-books" are lifetime totals, not
+// the current-year count that feeds goals.books_finished_ytd. The fake
+// store reports 6 books finished this year but 10 all-time, so "ten-books"
+// must show achieved even though the YTD figure the goals card surfaces is
+// only 6.
+func TestMotivationBooksBadgesUseLifetimeCount(t *testing.T) {
+	now := time.Date(2026, 7, 20, 12, 0, 0, 0, time.UTC)
+	store := &fakeReadingMotivationStore{
+		finishedBooksYTD:     6,
+		finishedBooksAllTime: 10,
+	}
+
+	h := &ReadingMotivationHandler{Store: store, Now: func() time.Time { return now }}
+	rr := httptest.NewRecorder()
+	h.HandleGetMotivation(rr, motivationRequest(1, "profile-a", ""))
+	if rr.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200; body = %s", rr.Code, rr.Body.String())
+	}
+
+	var resp readingMotivationResponse
+	if err := json.Unmarshal(rr.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("unmarshal response: %v; body = %s", err, rr.Body.String())
+	}
+
+	if resp.Goals.BooksFinishedYTD != 6 {
+		t.Errorf("goals.books_finished_ytd = %d, want 6 (year-scoped, unaffected by the all-time badge count)", resp.Goals.BooksFinishedYTD)
+	}
+	if ach := achievementByID(t, resp, "ten-books"); ach.AchievedAt == nil {
+		t.Error(`achievements["ten-books"].achieved_at = nil, want set (10 all-time books clears the threshold, even though YTD is only 6)`)
+	}
+	if ach := achievementByID(t, resp, "fifty-books"); ach.AchievedAt != nil {
+		t.Error(`achievements["fifty-books"].achieved_at set, want nil (10 all-time books doesn't clear 50)`)
+	}
+}
+
+// TestMotivationFinisherUsesHighReadThreshold pins the "finisher" badge
+// contract: it's driven by HasBookReadAbove(0.95), an all-time, independent
+// signal from the books-finished counts, not "at least one YTD-finished
+// book" (which is boolean-identical to "first-book" and uses the wrong,
+// looser 90% threshold).
+func TestMotivationFinisherUsesHighReadThreshold(t *testing.T) {
+	now := time.Date(2026, 7, 20, 12, 0, 0, 0, time.UTC)
+
+	t.Run("finished counts positive but no book cleared 95%: finisher locked, first-book achieved", func(t *testing.T) {
+		store := &fakeReadingMotivationStore{
+			finishedBooksYTD:     1,
+			finishedBooksAllTime: 1,
+			hasBookReadAbove:     false,
+		}
+		h := &ReadingMotivationHandler{Store: store, Now: func() time.Time { return now }}
+		rr := httptest.NewRecorder()
+		h.HandleGetMotivation(rr, motivationRequest(1, "profile-a", ""))
+		if rr.Code != http.StatusOK {
+			t.Fatalf("status = %d, want 200; body = %s", rr.Code, rr.Body.String())
+		}
+		var resp readingMotivationResponse
+		if err := json.Unmarshal(rr.Body.Bytes(), &resp); err != nil {
+			t.Fatalf("unmarshal response: %v; body = %s", err, rr.Body.String())
+		}
+
+		if ach := achievementByID(t, resp, "first-book"); ach.AchievedAt == nil {
+			t.Error(`achievements["first-book"].achieved_at = nil, want set (1 all-time book finished)`)
+		}
+		if ach := achievementByID(t, resp, "finisher"); ach.AchievedAt != nil {
+			t.Error(`achievements["finisher"].achieved_at set, want nil (no book has ever reached the 95% threshold)`)
+		}
+	})
+
+	t.Run("a book cleared 95%: finisher achieved", func(t *testing.T) {
+		store := &fakeReadingMotivationStore{
+			finishedBooksYTD:     1,
+			finishedBooksAllTime: 1,
+			hasBookReadAbove:     true,
+		}
+		h := &ReadingMotivationHandler{Store: store, Now: func() time.Time { return now }}
+		rr := httptest.NewRecorder()
+		h.HandleGetMotivation(rr, motivationRequest(1, "profile-a", ""))
+		if rr.Code != http.StatusOK {
+			t.Fatalf("status = %d, want 200; body = %s", rr.Code, rr.Body.String())
+		}
+		var resp readingMotivationResponse
+		if err := json.Unmarshal(rr.Body.Bytes(), &resp); err != nil {
+			t.Fatalf("unmarshal response: %v; body = %s", err, rr.Body.String())
+		}
+
+		if ach := achievementByID(t, resp, "finisher"); ach.AchievedAt == nil {
+			t.Error(`achievements["finisher"].achieved_at = nil, want set (a book cleared the 95% threshold)`)
+		}
+	})
 }

--- a/internal/api/handlers/reading_motivation_test.go
+++ b/internal/api/handlers/reading_motivation_test.go
@@ -1,0 +1,291 @@
+package handlers
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+)
+
+// fakeReadingMotivationStore is an in-memory ReadingMotivationStore backed
+// by maps, mirroring fakeReadingSessionStore's style. Only the goals
+// methods are exercised by this task's tests; the remaining methods are
+// present to satisfy the interface for later tasks.
+type fakeReadingMotivationStore struct {
+	goals map[string]ReadingGoals
+
+	putGoalsErr error
+
+	achievements map[string]time.Time
+	sessions     []ReadingSession
+}
+
+func goalsKey(userID int, profileID string) string {
+	return fmt.Sprintf("%d|%s", userID, profileID)
+}
+
+func (f *fakeReadingMotivationStore) GetGoals(_ context.Context, userID int, profileID string) (*ReadingGoals, error) {
+	if f.goals == nil {
+		return nil, nil
+	}
+	g, ok := f.goals[goalsKey(userID, profileID)]
+	if !ok {
+		return nil, nil
+	}
+	cp := g
+	return &cp, nil
+}
+
+func (f *fakeReadingMotivationStore) PutGoals(_ context.Context, userID int, profileID string, g ReadingGoals) error {
+	if f.putGoalsErr != nil {
+		return f.putGoalsErr
+	}
+	if f.goals == nil {
+		f.goals = make(map[string]ReadingGoals)
+	}
+	f.goals[goalsKey(userID, profileID)] = g
+	return nil
+}
+
+func (f *fakeReadingMotivationStore) AchievedAt(_ context.Context, _ int, _ string) (map[string]time.Time, error) {
+	return f.achievements, nil
+}
+
+func (f *fakeReadingMotivationStore) PersistAchievement(_ context.Context, _ int, _, achievementID string, at time.Time) error {
+	if f.achievements == nil {
+		f.achievements = make(map[string]time.Time)
+	}
+	f.achievements[achievementID] = at
+	return nil
+}
+
+func (f *fakeReadingMotivationStore) SessionsSince(_ context.Context, _ int, _ string, _ time.Time) ([]ReadingSession, error) {
+	return f.sessions, nil
+}
+
+func (f *fakeReadingMotivationStore) FinishedBooksInRange(_ context.Context, _ int, _ string, _, _ time.Time) (int, error) {
+	return 0, nil
+}
+
+func (f *fakeReadingMotivationStore) GenreSeconds(_ context.Context, _ int, _ string) ([]GenreSeconds, error) {
+	return nil, nil
+}
+
+func (f *fakeReadingMotivationStore) AuthorSeconds(_ context.Context, _ int, _ string) ([]AuthorSeconds, error) {
+	return nil, nil
+}
+
+func TestRequestLocation(t *testing.T) {
+	cases := []struct {
+		name   string
+		tz     string
+		wantID string
+	}{
+		{"named IANA zone", "Europe/Amsterdam", "Europe/Amsterdam"},
+		{"absent", "", "UTC"},
+		{"nonsense zone", "Nonsense", "UTC"},
+		{"Local is rejected", "Local", "UTC"},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			url := "/ebooks/reading-stats"
+			if tc.tz != "" {
+				url += "?tz=" + tc.tz
+			}
+			req := httptest.NewRequest(http.MethodGet, url, nil)
+			loc := requestLocation(req)
+			if loc == nil {
+				t.Fatal("expected a non-nil location")
+			}
+			if loc.String() != tc.wantID {
+				t.Fatalf("location = %q, want %q", loc.String(), tc.wantID)
+			}
+		})
+	}
+}
+
+func putGoals(t *testing.T, h *ReadingMotivationHandler, userID int, profileID string, body []byte) *httptest.ResponseRecorder {
+	t.Helper()
+	var req *http.Request
+	if body == nil {
+		req = httptest.NewRequest(http.MethodPut, "/ebooks/reading-goals", nil)
+	} else {
+		req = httptest.NewRequest(http.MethodPut, "/ebooks/reading-goals", bytes.NewReader(body))
+	}
+	req = req.WithContext(readingSessionAuthContext(userID, profileID))
+	rr := httptest.NewRecorder()
+	h.HandlePutGoals(rr, req)
+	return rr
+}
+
+func TestPutGoalsValidatesAndPersists(t *testing.T) {
+	t.Run("valid goals are stored and 204", func(t *testing.T) {
+		store := &fakeReadingMotivationStore{}
+		h := &ReadingMotivationHandler{Store: store, Now: func() time.Time { return time.Now() }}
+
+		rr := putGoals(t, h, 1, "profile-a", []byte(`{"books_per_year":30,"hours_per_year":200}`))
+		if rr.Code != http.StatusNoContent {
+			t.Fatalf("status = %d, want 204; body = %s", rr.Code, rr.Body.String())
+		}
+		got, err := store.GetGoals(context.Background(), 1, "profile-a")
+		if err != nil {
+			t.Fatalf("GetGoals: %v", err)
+		}
+		if got == nil || got.BooksPerYear == nil || *got.BooksPerYear != 30 {
+			t.Fatalf("books_per_year = %+v, want 30", got)
+		}
+		if got.HoursPerYear == nil || *got.HoursPerYear != 200 {
+			t.Fatalf("hours_per_year = %+v, want 200", got)
+		}
+	})
+
+	t.Run("PUT replaces both fields; absent field clears it", func(t *testing.T) {
+		store := &fakeReadingMotivationStore{}
+		h := &ReadingMotivationHandler{Store: store, Now: func() time.Time { return time.Now() }}
+
+		rr := putGoals(t, h, 1, "profile-a", []byte(`{"books_per_year":30,"hours_per_year":200}`))
+		if rr.Code != http.StatusNoContent {
+			t.Fatalf("first PUT status = %d, want 204; body = %s", rr.Code, rr.Body.String())
+		}
+
+		// books_per_year explicitly null, hours_per_year present: books
+		// cleared, hours set to 200.
+		rr = putGoals(t, h, 1, "profile-a", []byte(`{"books_per_year":null,"hours_per_year":200}`))
+		if rr.Code != http.StatusNoContent {
+			t.Fatalf("second PUT status = %d, want 204; body = %s", rr.Code, rr.Body.String())
+		}
+		got, err := store.GetGoals(context.Background(), 1, "profile-a")
+		if err != nil {
+			t.Fatalf("GetGoals: %v", err)
+		}
+		if got.BooksPerYear != nil {
+			t.Fatalf("books_per_year = %v, want cleared (nil)", *got.BooksPerYear)
+		}
+		if got.HoursPerYear == nil || *got.HoursPerYear != 200 {
+			t.Fatalf("hours_per_year = %+v, want 200", got.HoursPerYear)
+		}
+
+		// A third PUT omitting hours_per_year entirely (absent = null =
+		// cleared) must clear it too, since PUT replaces both fields
+		// wholesale rather than patching.
+		rr = putGoals(t, h, 1, "profile-a", []byte(`{"books_per_year":50}`))
+		if rr.Code != http.StatusNoContent {
+			t.Fatalf("third PUT status = %d, want 204; body = %s", rr.Code, rr.Body.String())
+		}
+		got, err = store.GetGoals(context.Background(), 1, "profile-a")
+		if err != nil {
+			t.Fatalf("GetGoals: %v", err)
+		}
+		if got.BooksPerYear == nil || *got.BooksPerYear != 50 {
+			t.Fatalf("books_per_year = %+v, want 50", got.BooksPerYear)
+		}
+		if got.HoursPerYear != nil {
+			t.Fatalf("hours_per_year = %v, want cleared (nil) since the PUT omitted it", *got.HoursPerYear)
+		}
+	})
+
+	t.Run("out-of-range values are rejected with field-named messages", func(t *testing.T) {
+		cases := []struct {
+			name       string
+			body       []byte
+			wantInBody string
+		}{
+			{"books_per_year zero", []byte(`{"books_per_year":0}`), "books_per_year"},
+			{"hours_per_year above max", []byte(`{"hours_per_year":100001}`), "hours_per_year"},
+		}
+		for _, tc := range cases {
+			t.Run(tc.name, func(t *testing.T) {
+				store := &fakeReadingMotivationStore{}
+				h := &ReadingMotivationHandler{Store: store, Now: func() time.Time { return time.Now() }}
+
+				rr := putGoals(t, h, 1, "profile-a", tc.body)
+				if rr.Code != http.StatusBadRequest {
+					t.Fatalf("status = %d, want 400; body = %s", rr.Code, rr.Body.String())
+				}
+				if !bytes.Contains(rr.Body.Bytes(), []byte(tc.wantInBody)) {
+					t.Fatalf("body = %s, want it to mention %q", rr.Body.String(), tc.wantInBody)
+				}
+				if len(store.goals) != 0 {
+					t.Fatalf("expected store untouched on validation failure, got %v", store.goals)
+				}
+			})
+		}
+	})
+
+	t.Run("non-JSON body is a 400", func(t *testing.T) {
+		store := &fakeReadingMotivationStore{}
+		h := &ReadingMotivationHandler{Store: store, Now: func() time.Time { return time.Now() }}
+
+		rr := putGoals(t, h, 1, "profile-a", []byte(`not json`))
+		if rr.Code != http.StatusBadRequest {
+			t.Fatalf("status = %d, want 400; body = %s", rr.Code, rr.Body.String())
+		}
+	})
+}
+
+// TestHistoryUsesRequestTimezone pins the additive tz behavior on the
+// existing history endpoint: a session at 2026-07-19T23:30:00Z lands on
+// local day 2026-07-20 in Europe/Amsterdam (UTC+2 in July) but 2026-07-19 in
+// UTC. The fake's dailyRollupFn mimics the real DailyRollup's
+// date_trunc('day', started_at AT TIME ZONE $n) bucketing by converting the
+// fixed session timestamp into the requested location itself.
+func TestHistoryUsesRequestTimezone(t *testing.T) {
+	now := time.Date(2026, 7, 20, 12, 0, 0, 0, time.UTC)
+	sessionStart := time.Date(2026, 7, 19, 23, 30, 0, 0, time.UTC)
+
+	newStore := func() *fakeReadingSessionStore {
+		return &fakeReadingSessionStore{
+			totalsSinceFn: func(_ time.Time, _ *time.Location) (int, error) { return 0, nil },
+			dailyRollupFn: func(_, _ time.Time, loc *time.Location) ([]DayTotal, error) {
+				local := sessionStart.In(loc)
+				day := time.Date(local.Year(), local.Month(), local.Day(), 0, 0, 0, 0, loc)
+				return []DayTotal{{Date: day, Seconds: 1800}}, nil
+			},
+		}
+	}
+
+	runHistory := func(url string) []struct {
+		Date    string `json:"date"`
+		Seconds int    `json:"seconds"`
+	} {
+		h := &ReadingSessionsHandler{Store: newStore(), Now: func() time.Time { return now }}
+		req := httptest.NewRequest(http.MethodGet, url, nil)
+		req = req.WithContext(readingSessionAuthContext(1, "profile-a"))
+		rr := httptest.NewRecorder()
+		h.HandleHistory(rr, req)
+		if rr.Code != http.StatusOK {
+			t.Fatalf("status = %d, want 200; body = %s", rr.Code, rr.Body.String())
+		}
+		var resp struct {
+			Days []struct {
+				Date    string `json:"date"`
+				Seconds int    `json:"seconds"`
+			} `json:"days"`
+		}
+		if err := json.Unmarshal(rr.Body.Bytes(), &resp); err != nil {
+			t.Fatalf("decode response: %v; body = %s", err, rr.Body.String())
+		}
+		return resp.Days
+	}
+
+	daysUTC := runHistory("/ebooks/reading-stats")
+	daysAmsterdam := runHistory("/ebooks/reading-stats?tz=Europe/Amsterdam")
+
+	if len(daysUTC) != 1 || len(daysAmsterdam) != 1 {
+		t.Fatalf("expected exactly one day in each response; utc=%v amsterdam=%v", daysUTC, daysAmsterdam)
+	}
+	if daysUTC[0].Date != "2026-07-19" {
+		t.Fatalf("UTC day = %q, want 2026-07-19", daysUTC[0].Date)
+	}
+	if daysAmsterdam[0].Date != "2026-07-20" {
+		t.Fatalf("Europe/Amsterdam day = %q, want 2026-07-20", daysAmsterdam[0].Date)
+	}
+	if daysUTC[0].Date == daysAmsterdam[0].Date {
+		t.Fatal("expected the days rollup date strings to differ between UTC and Europe/Amsterdam")
+	}
+}

--- a/internal/api/handlers/reading_motivation_test.go
+++ b/internal/api/handlers/reading_motivation_test.go
@@ -1042,3 +1042,58 @@ func TestNightOwlWindowIsMidnightToFiveAM(t *testing.T) {
 		if err := json.Unmarshal(rr.Body.Bytes(), &resp); err != nil {
 			t.Fatalf("unmarshal response: %v; body = %s", err, rr.Body.String())
 		}
+		if ach := achievementByID(t, resp, "night-owl"); ach.AchievedAt == nil {
+			t.Error(`achievements["night-owl"].achieved_at = nil, want set (01:00 local is within the 00:00-05:00 window)`)
+		}
+	})
+}
+
+// TestMotivationCollapsesGenresToTopEight pins the DNA genre display
+// contract: given more than topGenreCount genres, the response collapses to
+// the top 8 by seconds plus a trailing "other" entry summing the rest,
+// computed in the handler after diversity/distinct-genre math (which must
+// still see the full, uncollapsed list).
+func TestMotivationCollapsesGenresToTopEight(t *testing.T) {
+	now := time.Date(2026, 7, 20, 12, 0, 0, 0, time.UTC)
+	genres := []GenreSeconds{
+		{Genre: "g1", Seconds: 1000},
+		{Genre: "g2", Seconds: 900},
+		{Genre: "g3", Seconds: 800},
+		{Genre: "g4", Seconds: 700},
+		{Genre: "g5", Seconds: 600},
+		{Genre: "g6", Seconds: 500},
+		{Genre: "g7", Seconds: 400},
+		{Genre: "g8", Seconds: 300},
+		{Genre: "g9", Seconds: 200},
+		{Genre: "g10", Seconds: 100},
+	}
+	store := &fakeReadingMotivationStore{genres: genres}
+	h := &ReadingMotivationHandler{Store: store, Now: func() time.Time { return now }}
+	rr := httptest.NewRecorder()
+	h.HandleGetMotivation(rr, motivationRequest(1, "profile-a", ""))
+	if rr.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200; body = %s", rr.Code, rr.Body.String())
+	}
+
+	var resp readingMotivationResponse
+	if err := json.Unmarshal(rr.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("unmarshal response: %v; body = %s", err, rr.Body.String())
+	}
+
+	if len(resp.DNA.Genres) != 9 {
+		t.Fatalf("len(dna.genres) = %d, want 9 (top 8 + other)", len(resp.DNA.Genres))
+	}
+	last := resp.DNA.Genres[len(resp.DNA.Genres)-1]
+	if last.Name != otherGenreLabel {
+		t.Fatalf("last genre name = %q, want %q", last.Name, otherGenreLabel)
+	}
+	if last.Seconds != 300 { // g9 (200) + g10 (100)
+		t.Fatalf("other seconds = %d, want 300 (g9+g10)", last.Seconds)
+	}
+
+	// Diversity must be computed over all 10 genres, not the collapsed 9.
+	wantDiversity := diversityScore(genres)
+	if resp.DNA.DiversityScore != wantDiversity {
+		t.Fatalf("diversity_score = %d, want %d (computed over the uncollapsed 10-genre list)", resp.DNA.DiversityScore, wantDiversity)
+	}
+}

--- a/internal/api/handlers/reading_motivation_test.go
+++ b/internal/api/handlers/reading_motivation_test.go
@@ -38,8 +38,9 @@ type fakeReadingMotivationStore struct {
 
 	// hasBookReadAbove/hasBookReadAboveErr back HasBookReadAbove, the
 	// all-time "finisher" badge criterion.
-	hasBookReadAbove    bool
-	hasBookReadAboveErr error
+	hasBookReadAbove       bool
+	hasBookReadAboveErr    error
+	hasBookReadAboveThresh float64
 
 	genres    []GenreSeconds
 	genresErr error
@@ -124,10 +125,11 @@ func (f *fakeReadingMotivationStore) FinishedBooksInRange(_ context.Context, _ i
 	return f.finishedBooksYTD, nil
 }
 
-func (f *fakeReadingMotivationStore) HasBookReadAbove(_ context.Context, _ int, _ string, _ float64) (bool, error) {
+func (f *fakeReadingMotivationStore) HasBookReadAbove(_ context.Context, _ int, _ string, threshold float64) (bool, error) {
 	if f.hasBookReadAboveErr != nil {
 		return false, f.hasBookReadAboveErr
 	}
+	f.hasBookReadAboveThresh = threshold
 	return f.hasBookReadAbove, nil
 }
 
@@ -993,6 +995,9 @@ func TestMotivationFinisherUsesHighReadThreshold(t *testing.T) {
 
 		if ach := achievementByID(t, resp, "finisher"); ach.AchievedAt == nil {
 			t.Error(`achievements["finisher"].achieved_at = nil, want set (a book cleared the 95% threshold)`)
+		}
+		if store.hasBookReadAboveThresh != 0.95 {
+			t.Errorf("handler passed HasBookReadAbove threshold %v, want 0.95", store.hasBookReadAboveThresh)
 		}
 	})
 }

--- a/internal/api/handlers/reading_motivation_test.go
+++ b/internal/api/handlers/reading_motivation_test.go
@@ -13,16 +13,32 @@ import (
 )
 
 // fakeReadingMotivationStore is an in-memory ReadingMotivationStore backed
-// by maps, mirroring fakeReadingSessionStore's style. Only the goals
-// methods are exercised by this task's tests; the remaining methods are
-// present to satisfy the interface for later tasks.
+// by maps, mirroring fakeReadingSessionStore's style.
 type fakeReadingMotivationStore struct {
 	goals map[string]ReadingGoals
 
 	putGoalsErr error
 
-	achievements map[string]time.Time
-	sessions     []ReadingSession
+	achievements  map[string]time.Time
+	achievedAtErr error
+
+	sessions    []ReadingSession
+	sessionsErr error
+
+	finishedBooks    int
+	finishedBooksErr error
+
+	genres    []GenreSeconds
+	genresErr error
+
+	authors    []AuthorSeconds
+	authorsErr error
+
+	// persistCalls records the achievement ids PersistAchievement was
+	// invoked with, in call order, so tests can assert only newly
+	// satisfied badges trigger a persist.
+	persistCalls []string
+	persistErr   error
 }
 
 func goalsKey(userID int, profileID string) string {
@@ -53,10 +69,17 @@ func (f *fakeReadingMotivationStore) PutGoals(_ context.Context, userID int, pro
 }
 
 func (f *fakeReadingMotivationStore) AchievedAt(_ context.Context, _ int, _ string) (map[string]time.Time, error) {
+	if f.achievedAtErr != nil {
+		return nil, f.achievedAtErr
+	}
 	return f.achievements, nil
 }
 
 func (f *fakeReadingMotivationStore) PersistAchievement(_ context.Context, _ int, _, achievementID string, at time.Time) error {
+	if f.persistErr != nil {
+		return f.persistErr
+	}
+	f.persistCalls = append(f.persistCalls, achievementID)
 	if f.achievements == nil {
 		f.achievements = make(map[string]time.Time)
 	}
@@ -65,19 +88,31 @@ func (f *fakeReadingMotivationStore) PersistAchievement(_ context.Context, _ int
 }
 
 func (f *fakeReadingMotivationStore) SessionsSince(_ context.Context, _ int, _ string, _ time.Time) ([]ReadingSession, error) {
+	if f.sessionsErr != nil {
+		return nil, f.sessionsErr
+	}
 	return f.sessions, nil
 }
 
 func (f *fakeReadingMotivationStore) FinishedBooksInRange(_ context.Context, _ int, _ string, _, _ time.Time) (int, error) {
-	return 0, nil
+	if f.finishedBooksErr != nil {
+		return 0, f.finishedBooksErr
+	}
+	return f.finishedBooks, nil
 }
 
 func (f *fakeReadingMotivationStore) GenreSeconds(_ context.Context, _ int, _ string) ([]GenreSeconds, error) {
-	return nil, nil
+	if f.genresErr != nil {
+		return nil, f.genresErr
+	}
+	return f.genres, nil
 }
 
 func (f *fakeReadingMotivationStore) AuthorSeconds(_ context.Context, _ int, _ string) ([]AuthorSeconds, error) {
-	return nil, nil
+	if f.authorsErr != nil {
+		return nil, f.authorsErr
+	}
+	return f.authors, nil
 }
 
 func TestRequestLocation(t *testing.T) {
@@ -579,4 +614,250 @@ func TestEvaluateAchievements(t *testing.T) {
 			}
 		}
 	})
+}
+
+// motivationRequest builds an authenticated GET request against the
+// reading-motivation endpoint, optionally with a raw query string (e.g.
+// "tz=Europe/Amsterdam").
+func motivationRequest(userID int, profileID, rawQuery string) *http.Request {
+	url := "/ebooks/reading-motivation"
+	if rawQuery != "" {
+		url += "?" + rawQuery
+	}
+	req := httptest.NewRequest(http.MethodGet, url, nil)
+	return req.WithContext(readingSessionAuthContext(userID, profileID))
+}
+
+// assertKeys unmarshals raw as a JSON object and fails the test if its key
+// set isn't exactly want (order-independent).
+func assertKeys(t *testing.T, raw json.RawMessage, want []string) {
+	t.Helper()
+	var m map[string]json.RawMessage
+	if err := json.Unmarshal(raw, &m); err != nil {
+		t.Fatalf("unmarshal object: %v; raw = %s", err, raw)
+	}
+	for _, k := range want {
+		if _, ok := m[k]; !ok {
+			t.Errorf("missing key %q; raw = %s", k, raw)
+		}
+	}
+	if len(m) != len(want) {
+		got := make([]string, 0, len(m))
+		for k := range m {
+			got = append(got, k)
+		}
+		sort.Strings(got)
+		t.Errorf("keys = %v, want exactly %v", got, want)
+	}
+}
+
+func TestMotivationEndpointShape(t *testing.T) {
+	now := time.Date(2026, 7, 20, 12, 0, 0, 0, time.UTC)
+	store := &fakeReadingMotivationStore{
+		sessions: []ReadingSession{
+			{ContentID: "book-1", StartedAt: now.Add(-2 * time.Hour), DurationSeconds: 3600},
+		},
+		goals:         map[string]ReadingGoals{},
+		achievements:  map[string]time.Time{"first-hour": now.Add(-24 * time.Hour)},
+		finishedBooks: 3,
+		genres:        []GenreSeconds{{Genre: "Sci-Fi", Seconds: 3600}},
+		authors:       []AuthorSeconds{{Author: "Jane Doe", Seconds: 3600}},
+	}
+	books, hours := 20, 100
+	store.goals[goalsKey(1, "profile-a")] = ReadingGoals{BooksPerYear: &books, HoursPerYear: &hours}
+
+	h := &ReadingMotivationHandler{Store: store, Now: func() time.Time { return now }}
+	rr := httptest.NewRecorder()
+	h.HandleGetMotivation(rr, motivationRequest(1, "profile-a", ""))
+	if rr.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200; body = %s", rr.Code, rr.Body.String())
+	}
+
+	var top map[string]json.RawMessage
+	if err := json.Unmarshal(rr.Body.Bytes(), &top); err != nil {
+		t.Fatalf("unmarshal top level: %v; body = %s", err, rr.Body.String())
+	}
+	wantTop := []string{"streak", "goals", "challenge", "achievements", "dna"}
+	for _, k := range wantTop {
+		if _, ok := top[k]; !ok {
+			t.Errorf("missing top-level key %q; body = %s", k, rr.Body.String())
+		}
+	}
+	if len(top) != len(wantTop) {
+		t.Errorf("top-level keys = %v, want exactly %v", top, wantTop)
+	}
+
+	assertKeys(t, top["streak"], []string{"current_days", "longest_days", "today_seconds", "today_qualified"})
+	assertKeys(t, top["goals"], []string{
+		"books_per_year", "hours_per_year", "books_finished_ytd",
+		"hours_ytd", "books_on_track_for", "hours_on_track_for",
+	})
+	assertKeys(t, top["challenge"], []string{"target_seconds", "month_seconds", "percent"})
+	assertKeys(t, top["dna"], []string{
+		"genres", "authors", "diversity_score", "avg_session_seconds",
+		"hours_by_bucket", "projected_year_hours",
+	})
+
+	var achievements []map[string]json.RawMessage
+	if err := json.Unmarshal(top["achievements"], &achievements); err != nil {
+		t.Fatalf("unmarshal achievements: %v", err)
+	}
+	if len(achievements) != 18 {
+		t.Fatalf("len(achievements) = %d, want 18", len(achievements))
+	}
+	for i, a := range achievements {
+		for _, k := range []string{"id", "category", "name", "description", "achieved_at"} {
+			if _, ok := a[k]; !ok {
+				t.Errorf("achievements[%d] missing key %q: %v", i, k, a)
+			}
+		}
+	}
+}
+
+// TestMotivationPersistsNewUnlocks fixtures three consecutive qualifying
+// days (>=300s each) totaling 3900s, which satisfies both "first-hour"
+// (>=3600s total) and "streak-3" (LongestStreak>=3). The store already has
+// "first-hour" persisted, so only "streak-3" should trigger a new
+// PersistAchievement call; the response must show both as achieved.
+func TestMotivationPersistsNewUnlocks(t *testing.T) {
+	now := time.Date(2026, 7, 20, 12, 0, 0, 0, time.UTC)
+	earlierUnlock := now.Add(-48 * time.Hour)
+
+	store := &fakeReadingMotivationStore{
+		sessions: []ReadingSession{
+			{ContentID: "book-1", StartedAt: time.Date(2026, 7, 18, 10, 0, 0, 0, time.UTC), DurationSeconds: 1300},
+			{ContentID: "book-1", StartedAt: time.Date(2026, 7, 19, 10, 0, 0, 0, time.UTC), DurationSeconds: 1300},
+			{ContentID: "book-1", StartedAt: time.Date(2026, 7, 20, 10, 0, 0, 0, time.UTC), DurationSeconds: 1300},
+		},
+		achievements: map[string]time.Time{"first-hour": earlierUnlock},
+	}
+
+	h := &ReadingMotivationHandler{Store: store, Now: func() time.Time { return now }}
+	rr := httptest.NewRecorder()
+	h.HandleGetMotivation(rr, motivationRequest(1, "profile-a", ""))
+	if rr.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200; body = %s", rr.Code, rr.Body.String())
+	}
+
+	if len(store.persistCalls) != 1 || store.persistCalls[0] != "streak-3" {
+		t.Fatalf("persistCalls = %v, want exactly [\"streak-3\"]", store.persistCalls)
+	}
+
+	var resp readingMotivationResponse
+	if err := json.Unmarshal(rr.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("unmarshal response: %v; body = %s", err, rr.Body.String())
+	}
+	var gotFirstHour, gotStreak3 bool
+	for _, a := range resp.Achievements {
+		switch a.ID {
+		case "first-hour":
+			gotFirstHour = a.AchievedAt != nil
+		case "streak-3":
+			gotStreak3 = a.AchievedAt != nil
+		}
+	}
+	if !gotFirstHour {
+		t.Error("first-hour should show as achieved in the response")
+	}
+	if !gotStreak3 {
+		t.Error("streak-3 should show as newly achieved in the response")
+	}
+}
+
+// TestMotivationDegradesPerSection pins the per-section degradation
+// contract: a failing store call for one section never 500s the whole
+// request, and only that section falls back to its zero value.
+func TestMotivationDegradesPerSection(t *testing.T) {
+	now := time.Date(2026, 7, 20, 12, 0, 0, 0, time.UTC)
+	store := &fakeReadingMotivationStore{
+		sessions: []ReadingSession{
+			{ContentID: "book-1", StartedAt: now.Add(-2 * time.Hour), DurationSeconds: 3600},
+		},
+		authors:       []AuthorSeconds{{Author: "Jane Doe", Seconds: 3600}},
+		finishedBooks: 2,
+		genresErr:     fmt.Errorf("genre join exploded"),
+	}
+
+	h := &ReadingMotivationHandler{Store: store, Now: func() time.Time { return now }}
+	rr := httptest.NewRecorder()
+	h.HandleGetMotivation(rr, motivationRequest(1, "profile-a", ""))
+	if rr.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200 (section failure must degrade, not abort); body = %s", rr.Code, rr.Body.String())
+	}
+
+	var resp readingMotivationResponse
+	if err := json.Unmarshal(rr.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("unmarshal response: %v; body = %s", err, rr.Body.String())
+	}
+	if len(resp.DNA.Genres) != 0 {
+		t.Errorf("dna.genres = %v, want empty", resp.DNA.Genres)
+	}
+
+	var top map[string]json.RawMessage
+	if err := json.Unmarshal(rr.Body.Bytes(), &top); err != nil {
+		t.Fatalf("unmarshal top level: %v", err)
+	}
+	var dna map[string]json.RawMessage
+	if err := json.Unmarshal(top["dna"], &dna); err != nil {
+		t.Fatalf("unmarshal dna: %v", err)
+	}
+	if string(dna["genres"]) != "[]" {
+		t.Errorf(`dna.genres raw JSON = %s, want "[]" (not null)`, dna["genres"])
+	}
+
+	// Other sections stay intact: authors survived (unaffected store call),
+	// and streak/goals math over the still-good sessions/finished-books
+	// data is unaffected by the genre failure.
+	if len(resp.DNA.Authors) != 1 {
+		t.Errorf("dna.authors = %v, want the one fixture author to survive", resp.DNA.Authors)
+	}
+	if resp.Goals.BooksFinishedYTD != 2 {
+		t.Errorf("goals.books_finished_ytd = %d, want 2", resp.Goals.BooksFinishedYTD)
+	}
+	if resp.Streak.TodaySeconds != 3600 {
+		t.Errorf("streak.today_seconds = %d, want 3600", resp.Streak.TodaySeconds)
+	}
+}
+
+// TestMotivationUsesTimezone reuses the 23:30Z-session trick from
+// TestHistoryUsesRequestTimezone: a session at 2026-07-19T23:30:00Z lands on
+// local day 2026-07-20 in Europe/Amsterdam (UTC+2 in July) but 2026-07-19 in
+// UTC, shifting which day "today" attribution lands on.
+func TestMotivationUsesTimezone(t *testing.T) {
+	now := time.Date(2026, 7, 20, 10, 0, 0, 0, time.UTC)
+	store := &fakeReadingMotivationStore{
+		sessions: []ReadingSession{
+			{ContentID: "book-1", StartedAt: time.Date(2026, 7, 19, 23, 30, 0, 0, time.UTC), DurationSeconds: 900},
+		},
+	}
+
+	run := func(rawQuery string) readingMotivationResponse {
+		h := &ReadingMotivationHandler{Store: store, Now: func() time.Time { return now }}
+		rr := httptest.NewRecorder()
+		h.HandleGetMotivation(rr, motivationRequest(1, "profile-a", rawQuery))
+		if rr.Code != http.StatusOK {
+			t.Fatalf("status = %d, want 200; body = %s", rr.Code, rr.Body.String())
+		}
+		var resp readingMotivationResponse
+		if err := json.Unmarshal(rr.Body.Bytes(), &resp); err != nil {
+			t.Fatalf("unmarshal response: %v; body = %s", err, rr.Body.String())
+		}
+		return resp
+	}
+
+	utc := run("")
+	amsterdam := run("tz=Europe/Amsterdam")
+
+	if utc.Streak.TodaySeconds != 0 {
+		t.Errorf("UTC today_seconds = %d, want 0 (session falls on yesterday in UTC)", utc.Streak.TodaySeconds)
+	}
+	if utc.Streak.TodayQualified {
+		t.Error("UTC today_qualified = true, want false")
+	}
+	if amsterdam.Streak.TodaySeconds != 900 {
+		t.Errorf("Europe/Amsterdam today_seconds = %d, want 900 (session falls on today in +02:00)", amsterdam.Streak.TodaySeconds)
+	}
+	if !amsterdam.Streak.TodayQualified {
+		t.Error("Europe/Amsterdam today_qualified = false, want true (900s >= 300s minimum)")
+	}
 }

--- a/internal/api/handlers/reading_motivation_test.go
+++ b/internal/api/handlers/reading_motivation_test.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"net/http"
 	"net/http/httptest"
+	"sort"
 	"testing"
 	"time"
 )
@@ -288,4 +289,294 @@ func TestHistoryUsesRequestTimezone(t *testing.T) {
 	if daysUTC[0].Date == daysAmsterdam[0].Date {
 		t.Fatal("expected the days rollup date strings to differ between UTC and Europe/Amsterdam")
 	}
+}
+
+func TestSessionDaySecondsUsesLocation(t *testing.T) {
+	loc, err := time.LoadLocation("Europe/Amsterdam")
+	if err != nil {
+		t.Fatalf("load location: %v", err)
+	}
+	// 2026-07-19T23:30:00Z is CEST (UTC+2) in Amsterdam, so local time is
+	// 2026-07-20T01:30 -- the next day.
+	sessions := []ReadingSession{
+		{StartedAt: time.Date(2026, 7, 19, 23, 30, 0, 0, time.UTC), DurationSeconds: 900},
+	}
+
+	utcDays := sessionDaySeconds(sessions, time.UTC)
+	if utcDays["2026-07-19"] != 900 {
+		t.Fatalf("UTC bucketing = %v, want 2026-07-19: 900", utcDays)
+	}
+
+	amsDays := sessionDaySeconds(sessions, loc)
+	if amsDays["2026-07-20"] != 900 {
+		t.Fatalf("Europe/Amsterdam bucketing = %v, want 2026-07-20: 900", amsDays)
+	}
+	if _, ok := amsDays["2026-07-19"]; ok {
+		t.Fatalf("Europe/Amsterdam bucketing = %v, did not expect a 2026-07-19 entry", amsDays)
+	}
+}
+
+func TestStreakMath(t *testing.T) {
+	const today = "2026-07-20"
+	const dMinus1 = "2026-07-19"
+	const dMinus2 = "2026-07-18"
+	const dMinus3 = "2026-07-17"
+
+	cases := []struct {
+		name        string
+		days        DaySeconds
+		today       string
+		wantCurrent int
+		wantLongest int
+	}{
+		{
+			name:        "today unqualified but alive off yesterday",
+			days:        DaySeconds{dMinus2: 400, dMinus1: 400, today: 100},
+			today:       today,
+			wantCurrent: 2,
+			wantLongest: 2,
+		},
+		{
+			name:        "today qualified extends the streak",
+			days:        DaySeconds{dMinus1: 400, today: 400},
+			today:       today,
+			wantCurrent: 2,
+			wantLongest: 2,
+		},
+		{
+			name:        "gap breaks the streak but an earlier run still counts toward longest",
+			days:        DaySeconds{dMinus3: 400, dMinus1: 400, today: 400},
+			today:       today,
+			wantCurrent: 2,
+			wantLongest: 2,
+		},
+		{
+			name:        "sub-300s days never qualify",
+			days:        DaySeconds{today: 299},
+			today:       today,
+			wantCurrent: 0,
+			wantLongest: 0,
+		},
+		{
+			name:        "empty days",
+			days:        DaySeconds{},
+			today:       today,
+			wantCurrent: 0,
+			wantLongest: 0,
+		},
+		{
+			name:        "both today and yesterday missed kills the streak even with older history",
+			days:        DaySeconds{dMinus3: 400, dMinus2: 0},
+			today:       today,
+			wantCurrent: 0,
+			wantLongest: 1,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			current, longest := streakFrom(tc.days, tc.today)
+			if current != tc.wantCurrent {
+				t.Errorf("current = %d, want %d", current, tc.wantCurrent)
+			}
+			if longest != tc.wantLongest {
+				t.Errorf("longest = %d, want %d", longest, tc.wantLongest)
+			}
+		})
+	}
+}
+
+func TestMonthChallenge(t *testing.T) {
+	loc := time.UTC
+	now := time.Date(2026, 7, 15, 12, 0, 0, 0, loc)
+
+	t.Run("previous month above the floor sets the target", func(t *testing.T) {
+		days := DaySeconds{"2026-06-15": 20000}
+		target, month := monthChallenge(days, now, loc)
+		if target != 20000 {
+			t.Errorf("target = %d, want 20000", target)
+		}
+		if month != 0 {
+			t.Errorf("month = %d, want 0", month)
+		}
+	})
+
+	t.Run("previous month below the floor is clamped to it", func(t *testing.T) {
+		days := DaySeconds{"2026-06-15": 3600}
+		target, _ := monthChallenge(days, now, loc)
+		if target != monthChallengeFloorSeconds {
+			t.Errorf("target = %d, want %d", target, monthChallengeFloorSeconds)
+		}
+	})
+
+	t.Run("month boundaries are drawn in loc, not UTC", func(t *testing.T) {
+		amsterdam, err := time.LoadLocation("Europe/Amsterdam")
+		if err != nil {
+			t.Fatalf("load location: %v", err)
+		}
+		// 2026-06-30T23:30:00Z is CEST (UTC+2), so locally it's
+		// 2026-07-01T01:30 -- the first day of July, not the last day of
+		// June. It must count toward the current month, not the previous
+		// one used to derive the target.
+		sessions := []ReadingSession{
+			{StartedAt: time.Date(2026, 6, 30, 23, 30, 0, 0, time.UTC), DurationSeconds: 1800},
+		}
+		days := sessionDaySeconds(sessions, amsterdam)
+		nowAmsterdam := now.In(amsterdam)
+
+		target, month := monthChallenge(days, nowAmsterdam, amsterdam)
+		if month != 1800 {
+			t.Errorf("month = %d, want 1800 (the boundary session counted as July)", month)
+		}
+		if target != monthChallengeFloorSeconds {
+			t.Errorf("target = %d, want the floor %d (June had no seconds)", target, monthChallengeFloorSeconds)
+		}
+	})
+}
+
+func TestComputeDNA(t *testing.T) {
+	t.Run("diversity: single genre scores 0", func(t *testing.T) {
+		dna := computeDNA(nil, []GenreSeconds{{Genre: "Sci-Fi", Seconds: 100}}, nil, time.Now(), time.UTC)
+		if dna.DiversityScore != 0 {
+			t.Errorf("diversity = %d, want 0", dna.DiversityScore)
+		}
+	})
+
+	t.Run("diversity: two equal genres scores 50", func(t *testing.T) {
+		genres := []GenreSeconds{{Genre: "Sci-Fi", Seconds: 100}, {Genre: "Fantasy", Seconds: 100}}
+		dna := computeDNA(nil, genres, nil, time.Now(), time.UTC)
+		if dna.DiversityScore != 50 {
+			t.Errorf("diversity = %d, want 50", dna.DiversityScore)
+		}
+	})
+
+	t.Run("hour buckets, average session length, and year-end projection", func(t *testing.T) {
+		loc := time.UTC
+		now := time.Date(2026, 7, 2, 0, 0, 0, 0, loc)
+
+		mk := func(hour int) ReadingSession {
+			return ReadingSession{
+				StartedAt:       time.Date(2026, 6, 1, hour, 0, 0, 0, loc),
+				DurationSeconds: 3600,
+			}
+		}
+		sessions := []ReadingSession{
+			mk(5),  // morning, lower boundary
+			mk(11), // morning, upper boundary
+			mk(12), // afternoon, lower boundary
+			mk(16), // afternoon, upper boundary
+			mk(17), // evening, lower boundary
+			mk(21), // evening, upper boundary
+			mk(22), // night, lower boundary
+			mk(4),  // night, upper boundary (wraps past midnight)
+		}
+
+		dna := computeDNA(sessions, nil, nil, now, loc)
+
+		wantBuckets := map[string]int{"morning": 2, "afternoon": 2, "evening": 2, "night": 2}
+		for bucket, want := range wantBuckets {
+			if dna.HoursByBucket[bucket] != want {
+				t.Errorf("HoursByBucket[%q] = %d, want %d (buckets: %v)", bucket, dna.HoursByBucket[bucket], want, dna.HoursByBucket)
+			}
+		}
+
+		if dna.AvgSessionSeconds != 3600 {
+			t.Errorf("AvgSessionSeconds = %d, want 3600", dna.AvgSessionSeconds)
+		}
+
+		yearStart := time.Date(2026, 1, 1, 0, 0, 0, 0, loc)
+		nextYearStart := time.Date(2027, 1, 1, 0, 0, 0, 0, loc)
+		elapsedFraction := float64(now.Sub(yearStart)) / float64(nextYearStart.Sub(yearStart))
+		ytdHours := 8.0 // 8 one-hour sessions, all in 2026
+		wantProjected := goalProjection(ytdHours, elapsedFraction)
+
+		if diff := dna.ProjectedYearHours - wantProjected; diff > 1e-9 || diff < -1e-9 {
+			t.Errorf("ProjectedYearHours = %v, want %v", dna.ProjectedYearHours, wantProjected)
+		}
+	})
+}
+
+func TestEvaluateAchievements(t *testing.T) {
+	base := func() achievementInput { return achievementInput{} }
+
+	cases := []struct {
+		id    string
+		atMin func() achievementInput
+		below func() achievementInput
+	}{
+		{"first-hour", func() achievementInput { in := base(); in.TotalSeconds = 3600; return in }, func() achievementInput { in := base(); in.TotalSeconds = 3599; return in }},
+		{"ten-hours", func() achievementInput { in := base(); in.TotalSeconds = 36000; return in }, func() achievementInput { in := base(); in.TotalSeconds = 35999; return in }},
+		{"fifty-hours", func() achievementInput { in := base(); in.TotalSeconds = 180000; return in }, func() achievementInput { in := base(); in.TotalSeconds = 179999; return in }},
+		{"hundred-hours", func() achievementInput { in := base(); in.TotalSeconds = 360000; return in }, func() achievementInput { in := base(); in.TotalSeconds = 359999; return in }},
+		{"marathon-session", func() achievementInput { in := base(); in.LongestSessionSeconds = 7200; return in }, func() achievementInput { in := base(); in.LongestSessionSeconds = 7199; return in }},
+		{"streak-3", func() achievementInput { in := base(); in.LongestStreak = 3; return in }, func() achievementInput { in := base(); in.LongestStreak = 2; return in }},
+		{"streak-7", func() achievementInput { in := base(); in.LongestStreak = 7; return in }, func() achievementInput { in := base(); in.LongestStreak = 6; return in }},
+		{"streak-30", func() achievementInput { in := base(); in.LongestStreak = 30; return in }, func() achievementInput { in := base(); in.LongestStreak = 29; return in }},
+		{"streak-100", func() achievementInput { in := base(); in.LongestStreak = 100; return in }, func() achievementInput { in := base(); in.LongestStreak = 99; return in }},
+		{"first-book", func() achievementInput { in := base(); in.BooksFinished = 1; return in }, func() achievementInput { in := base(); in.BooksFinished = 0; return in }},
+		{"ten-books", func() achievementInput { in := base(); in.BooksFinished = 10; return in }, func() achievementInput { in := base(); in.BooksFinished = 9; return in }},
+		{"fifty-books", func() achievementInput { in := base(); in.BooksFinished = 50; return in }, func() achievementInput { in := base(); in.BooksFinished = 49; return in }},
+		{"night-owl", func() achievementInput { in := base(); in.NightSeconds = 36000; return in }, func() achievementInput { in := base(); in.NightSeconds = 35999; return in }},
+		{"early-bird", func() achievementInput { in := base(); in.EarlyBirdSeconds = 36000; return in }, func() achievementInput { in := base(); in.EarlyBirdSeconds = 35999; return in }},
+		{"weekender", func() achievementInput { in := base(); in.WeekendSeconds = 72000; return in }, func() achievementInput { in := base(); in.WeekendSeconds = 71999; return in }},
+		{"genre-hopper", func() achievementInput { in := base(); in.DistinctGenres = 5; return in }, func() achievementInput { in := base(); in.DistinctGenres = 4; return in }},
+		{"deep-diver", func() achievementInput { in := base(); in.MaxBookSeconds = 36000; return in }, func() achievementInput { in := base(); in.MaxBookSeconds = 35999; return in }},
+		{"finisher", func() achievementInput { in := base(); in.FinishedWithHighRead = true; return in }, func() achievementInput { in := base(); in.FinishedWithHighRead = false; return in }},
+	}
+
+	if len(cases) != 18 {
+		t.Fatalf("test table has %d cases, want 18 (one per badge)", len(cases))
+	}
+
+	contains := func(ids []string, id string) bool {
+		for _, got := range ids {
+			if got == id {
+				return true
+			}
+		}
+		return false
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.id, func(t *testing.T) {
+			atMin := evaluateAchievements(tc.atMin())
+			if !contains(atMin, tc.id) {
+				t.Errorf("at threshold: ids = %v, want %q present", atMin, tc.id)
+			}
+
+			below := evaluateAchievements(tc.below())
+			if contains(below, tc.id) {
+				t.Errorf("below threshold: ids = %v, want %q absent", below, tc.id)
+			}
+		})
+	}
+
+	t.Run("18 definitions with the exact spec ids", func(t *testing.T) {
+		wantIDs := make([]string, len(cases))
+		for i, tc := range cases {
+			wantIDs[i] = tc.id
+		}
+		sort.Strings(wantIDs)
+
+		if len(achievementDefinitions) != 18 {
+			t.Fatalf("len(achievementDefinitions) = %d, want 18", len(achievementDefinitions))
+		}
+		gotIDs := make([]string, len(achievementDefinitions))
+		for i, def := range achievementDefinitions {
+			if def.Category == "" || def.Name == "" || def.Description == "" {
+				t.Errorf("achievementDefinitions[%d] (%s) has an empty Category/Name/Description", i, def.ID)
+			}
+			gotIDs[i] = def.ID
+		}
+		sort.Strings(gotIDs)
+
+		if len(gotIDs) != len(wantIDs) {
+			t.Fatalf("id count mismatch: got %v want %v", gotIDs, wantIDs)
+		}
+		for i := range gotIDs {
+			if gotIDs[i] != wantIDs[i] {
+				t.Errorf("achievementDefinitions ids = %v, want (sorted) %v", gotIDs, wantIDs)
+			}
+		}
+	})
 }

--- a/internal/api/handlers/reading_motivation_test.go
+++ b/internal/api/handlers/reading_motivation_test.go
@@ -996,3 +996,49 @@ func TestMotivationFinisherUsesHighReadThreshold(t *testing.T) {
 		}
 	})
 }
+
+// TestNightOwlWindowIsMidnightToFiveAM pins the "night-owl" badge's
+// accumulation window to local hours [0, 5) per spec, distinct from
+// hourBucket's "night" DNA bucket (22-04). A 10-hour session starting at
+// local 23:00 clears hourBucket's "night" bucket but must NOT count toward
+// the badge; the same duration starting at local 01:00 must.
+func TestNightOwlWindowIsMidnightToFiveAM(t *testing.T) {
+	now := time.Date(2026, 7, 20, 12, 0, 0, 0, time.UTC)
+
+	t.Run("23:00 local does not count toward night-owl", func(t *testing.T) {
+		store := &fakeReadingMotivationStore{
+			sessions: []ReadingSession{
+				{ContentID: "book-1", StartedAt: time.Date(2026, 7, 19, 23, 0, 0, 0, time.UTC), DurationSeconds: 36000},
+			},
+		}
+		h := &ReadingMotivationHandler{Store: store, Now: func() time.Time { return now }}
+		rr := httptest.NewRecorder()
+		h.HandleGetMotivation(rr, motivationRequest(1, "profile-a", ""))
+		if rr.Code != http.StatusOK {
+			t.Fatalf("status = %d, want 200; body = %s", rr.Code, rr.Body.String())
+		}
+		var resp readingMotivationResponse
+		if err := json.Unmarshal(rr.Body.Bytes(), &resp); err != nil {
+			t.Fatalf("unmarshal response: %v; body = %s", err, rr.Body.String())
+		}
+		if ach := achievementByID(t, resp, "night-owl"); ach.AchievedAt != nil {
+			t.Error(`achievements["night-owl"].achieved_at set, want nil (23:00 local is outside the 00:00-05:00 window)`)
+		}
+	})
+
+	t.Run("01:00 local counts toward night-owl", func(t *testing.T) {
+		store := &fakeReadingMotivationStore{
+			sessions: []ReadingSession{
+				{ContentID: "book-1", StartedAt: time.Date(2026, 7, 20, 1, 0, 0, 0, time.UTC), DurationSeconds: 36000},
+			},
+		}
+		h := &ReadingMotivationHandler{Store: store, Now: func() time.Time { return now }}
+		rr := httptest.NewRecorder()
+		h.HandleGetMotivation(rr, motivationRequest(1, "profile-a", ""))
+		if rr.Code != http.StatusOK {
+			t.Fatalf("status = %d, want 200; body = %s", rr.Code, rr.Body.String())
+		}
+		var resp readingMotivationResponse
+		if err := json.Unmarshal(rr.Body.Bytes(), &resp); err != nil {
+			t.Fatalf("unmarshal response: %v; body = %s", err, rr.Body.String())
+		}

--- a/internal/api/handlers/reading_sessions.go
+++ b/internal/api/handlers/reading_sessions.go
@@ -1,0 +1,216 @@
+package handlers
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"math"
+	"net/http"
+	"time"
+
+	"github.com/go-chi/chi/v5"
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgxpool"
+
+	apimw "github.com/Silo-Server/silo-server/internal/api/middleware"
+)
+
+const (
+	// heartbeatSessionGap is the maximum time between two heartbeats for
+	// them to be coalesced into the same reading session. A heartbeat
+	// arriving after a longer gap than this starts a new session instead.
+	heartbeatSessionGap = 120 * time.Second
+	// heartbeatMaxCredit caps how much duration a single heartbeat can add
+	// to a session, regardless of the actual gap since the last heartbeat.
+	// This bounds the reading-time credit given for e.g. a client that was
+	// suspended and resumed just inside the session gap.
+	heartbeatMaxCredit = 90 * time.Second
+)
+
+// ReadingSession is a coalesced span of reading activity for a single
+// (user, profile, content), built up from a stream of heartbeats.
+type ReadingSession struct {
+	ID              int64
+	UserID          int
+	ProfileID       string
+	ContentID       string
+	StartedAt       time.Time
+	LastHeartbeatAt time.Time
+	DurationSeconds int
+	StartFraction   float64
+	EndFraction     float64
+}
+
+// ReadingSessionStore persists reading sessions and coalesces heartbeats
+// into them.
+type ReadingSessionStore interface {
+	// LatestOpen returns the most recently touched session for (user,
+	// profile, content) whose last heartbeat is at or after since, or nil
+	// if none exists.
+	LatestOpen(ctx context.Context, userID int, profileID, contentID string, since time.Time) (*ReadingSession, error)
+	Insert(ctx context.Context, s ReadingSession) error
+	Extend(ctx context.Context, id int64, lastHeartbeatAt time.Time, addSeconds int, endFraction float64) error
+}
+
+// ReadingSessionsHandler accepts reader heartbeats and coalesces them into
+// reading_sessions rows. Now is injected so heartbeat gap/credit math is
+// deterministic under test.
+type ReadingSessionsHandler struct {
+	Store ReadingSessionStore
+	Now   func() time.Time
+}
+
+type readingHeartbeatRequest struct {
+	Fraction float64 `json:"fraction"`
+}
+
+// HandleHeartbeat records a reading heartbeat for the active profile,
+// extending the most recent still-open session if the last heartbeat was
+// within heartbeatSessionGap, or starting a new one otherwise. Responds 204
+// on success regardless of whether a session was extended or created, since
+// the client does not act on the response body.
+func (h *ReadingSessionsHandler) HandleHeartbeat(w http.ResponseWriter, r *http.Request) {
+	userID := apimw.GetUserID(r.Context())
+	profileID := apimw.GetProfileID(r.Context())
+	if userID == 0 {
+		writeError(w, http.StatusUnauthorized, "unauthorized", "Authentication required")
+		return
+	}
+	if h == nil || h.Store == nil || h.Now == nil {
+		writeError(w, http.StatusServiceUnavailable, "unavailable", "Reading sessions are not configured")
+		return
+	}
+
+	contentID := chi.URLParam(r, "content_id")
+	if contentID == "" {
+		writeError(w, http.StatusBadRequest, "bad_request", "content_id is required")
+		return
+	}
+
+	var req readingHeartbeatRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		writeError(w, http.StatusBadRequest, "invalid_fraction", "Invalid heartbeat body")
+		return
+	}
+	if math.IsNaN(req.Fraction) || math.IsInf(req.Fraction, 0) || req.Fraction < 0 || req.Fraction > 1 {
+		writeError(w, http.StatusBadRequest, "invalid_fraction", "fraction must be a finite number between 0 and 1")
+		return
+	}
+
+	ctx := r.Context()
+	now := h.Now()
+
+	open, err := h.Store.LatestOpen(ctx, userID, profileID, contentID, now.Add(-heartbeatSessionGap))
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, "internal_error", "Failed to load reading session")
+		return
+	}
+
+	if open != nil {
+		credit := now.Sub(open.LastHeartbeatAt)
+		if credit > heartbeatMaxCredit {
+			credit = heartbeatMaxCredit
+		}
+		if credit < 0 {
+			credit = 0
+		}
+		if err := h.Store.Extend(ctx, open.ID, now, int(credit.Seconds()), req.Fraction); err != nil {
+			writeError(w, http.StatusInternalServerError, "internal_error", "Failed to update reading session")
+			return
+		}
+	} else {
+		session := ReadingSession{
+			UserID:          userID,
+			ProfileID:       profileID,
+			ContentID:       contentID,
+			StartedAt:       now,
+			LastHeartbeatAt: now,
+			DurationSeconds: 0,
+			StartFraction:   req.Fraction,
+			EndFraction:     req.Fraction,
+		}
+		if err := h.Store.Insert(ctx, session); err != nil {
+			writeError(w, http.StatusInternalServerError, "internal_error", "Failed to start reading session")
+			return
+		}
+	}
+
+	w.WriteHeader(http.StatusNoContent)
+}
+
+// PGReadingSessionStore is the Postgres-backed ReadingSessionStore.
+type PGReadingSessionStore struct {
+	pool *pgxpool.Pool
+}
+
+// NewPGReadingSessionStore constructs a PGReadingSessionStore.
+func NewPGReadingSessionStore(pool *pgxpool.Pool) *PGReadingSessionStore {
+	return &PGReadingSessionStore{pool: pool}
+}
+
+func (s *PGReadingSessionStore) LatestOpen(ctx context.Context, userID int, profileID, contentID string, since time.Time) (*ReadingSession, error) {
+	if s == nil || s.pool == nil {
+		return nil, fmt.Errorf("reading session store is not configured")
+	}
+	var session ReadingSession
+	err := s.pool.QueryRow(ctx, `
+		SELECT id, user_id, profile_id, content_id, started_at, last_heartbeat_at,
+		       duration_seconds, start_fraction, end_fraction
+		FROM reading_sessions
+		WHERE user_id = $1 AND profile_id = $2 AND content_id = $3 AND last_heartbeat_at >= $4
+		ORDER BY last_heartbeat_at DESC
+		LIMIT 1`,
+		userID, profileID, contentID, since,
+	).Scan(
+		&session.ID,
+		&session.UserID,
+		&session.ProfileID,
+		&session.ContentID,
+		&session.StartedAt,
+		&session.LastHeartbeatAt,
+		&session.DurationSeconds,
+		&session.StartFraction,
+		&session.EndFraction,
+	)
+	if err != nil {
+		if err == pgx.ErrNoRows {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("latest open reading session: %w", err)
+	}
+	return &session, nil
+}
+
+func (s *PGReadingSessionStore) Insert(ctx context.Context, session ReadingSession) error {
+	if s == nil || s.pool == nil {
+		return fmt.Errorf("reading session store is not configured")
+	}
+	_, err := s.pool.Exec(ctx, `
+		INSERT INTO reading_sessions
+			(user_id, profile_id, content_id, started_at, last_heartbeat_at, duration_seconds, start_fraction, end_fraction)
+		VALUES ($1, $2, $3, $4, $5, $6, $7, $8)`,
+		session.UserID, session.ProfileID, session.ContentID,
+		session.StartedAt, session.LastHeartbeatAt, session.DurationSeconds,
+		session.StartFraction, session.EndFraction,
+	)
+	if err != nil {
+		return fmt.Errorf("insert reading session: %w", err)
+	}
+	return nil
+}
+
+func (s *PGReadingSessionStore) Extend(ctx context.Context, id int64, lastHeartbeatAt time.Time, addSeconds int, endFraction float64) error {
+	if s == nil || s.pool == nil {
+		return fmt.Errorf("reading session store is not configured")
+	}
+	_, err := s.pool.Exec(ctx, `
+		UPDATE reading_sessions
+		SET last_heartbeat_at = $2, duration_seconds = duration_seconds + $3, end_fraction = $4
+		WHERE id = $1`,
+		id, lastHeartbeatAt, addSeconds, endFraction,
+	)
+	if err != nil {
+		return fmt.Errorf("extend reading session: %w", err)
+	}
+	return nil
+}

--- a/internal/api/handlers/reading_sessions.go
+++ b/internal/api/handlers/reading_sessions.go
@@ -61,7 +61,7 @@ type ReadingSessionsHandler struct {
 }
 
 type readingHeartbeatRequest struct {
-	Fraction float64 `json:"fraction"`
+	Fraction *float64 `json:"fraction"`
 }
 
 // HandleHeartbeat records a reading heartbeat for the active profile,
@@ -92,7 +92,11 @@ func (h *ReadingSessionsHandler) HandleHeartbeat(w http.ResponseWriter, r *http.
 		writeError(w, http.StatusBadRequest, "invalid_fraction", "Invalid heartbeat body")
 		return
 	}
-	if math.IsNaN(req.Fraction) || math.IsInf(req.Fraction, 0) || req.Fraction < 0 || req.Fraction > 1 {
+	if req.Fraction == nil {
+		writeError(w, http.StatusBadRequest, "invalid_fraction", "fraction is required")
+		return
+	}
+	if math.IsNaN(*req.Fraction) || math.IsInf(*req.Fraction, 0) || *req.Fraction < 0 || *req.Fraction > 1 {
 		writeError(w, http.StatusBadRequest, "invalid_fraction", "fraction must be a finite number between 0 and 1")
 		return
 	}
@@ -114,7 +118,7 @@ func (h *ReadingSessionsHandler) HandleHeartbeat(w http.ResponseWriter, r *http.
 		if credit < 0 {
 			credit = 0
 		}
-		if err := h.Store.Extend(ctx, open.ID, now, int(credit.Seconds()), req.Fraction); err != nil {
+		if err := h.Store.Extend(ctx, open.ID, now, int(credit.Seconds()), *req.Fraction); err != nil {
 			writeError(w, http.StatusInternalServerError, "internal_error", "Failed to update reading session")
 			return
 		}
@@ -126,8 +130,8 @@ func (h *ReadingSessionsHandler) HandleHeartbeat(w http.ResponseWriter, r *http.
 			StartedAt:       now,
 			LastHeartbeatAt: now,
 			DurationSeconds: 0,
-			StartFraction:   req.Fraction,
-			EndFraction:     req.Fraction,
+			StartFraction:   *req.Fraction,
+			EndFraction:     *req.Fraction,
 		}
 		if err := h.Store.Insert(ctx, session); err != nil {
 			writeError(w, http.StatusInternalServerError, "internal_error", "Failed to start reading session")

--- a/internal/api/handlers/reading_sessions.go
+++ b/internal/api/handlers/reading_sessions.go
@@ -85,17 +85,20 @@ type ReadingSessionStore interface {
 	PaceWindow(ctx context.Context, userID int, profileID, contentID string, since time.Time) (fractions float64, seconds int, err error)
 	// BookSeconds is the all-time total reading duration for one book.
 	BookSeconds(ctx context.Context, userID int, profileID, contentID string) (int, error)
-	// DailyRollup groups duration by UTC calendar day over [from, to]
+	// DailyRollup groups duration by calendar day (in loc) over [from, to]
 	// (inclusive of both endpoint days).
-	DailyRollup(ctx context.Context, userID int, profileID string, from, to time.Time) ([]DayTotal, error)
+	DailyRollup(ctx context.Context, userID int, profileID string, from, to time.Time, loc *time.Location) ([]DayTotal, error)
 	// BookTotals returns all-time per-book totals, newest-read first.
 	BookTotals(ctx context.Context, userID int, profileID string) ([]BookTotal, error)
 	// RecentSessions returns the most recent sessions, newest-first,
 	// capped at limit.
 	RecentSessions(ctx context.Context, userID int, profileID string, limit int) ([]SessionRow, error)
 	// TotalsSince sums duration for sessions started at or after since. A
-	// zero since returns the all-time total.
-	TotalsSince(ctx context.Context, userID int, profileID string, since time.Time) (int, error)
+	// zero since returns the all-time total. loc is accepted for interface
+	// symmetry with DailyRollup; since is already an absolute instant (the
+	// caller computes it from the requester's local day boundary), so it
+	// does not affect the SQL comparison.
+	TotalsSince(ctx context.Context, userID int, profileID string, since time.Time, loc *time.Location) (int, error)
 }
 
 // readingProgressGetter is the minimal progress lookup the per-book
@@ -396,13 +399,14 @@ func (h *ReadingSessionsHandler) HandleHistory(w http.ResponseWriter, r *http.Re
 		return
 	}
 
+	loc := requestLocation(r)
 	now := h.Now()
-	today := time.Date(now.Year(), now.Month(), now.Day(), 0, 0, 0, 0, time.UTC)
+	today := time.Date(now.Year(), now.Month(), now.Day(), 0, 0, 0, 0, loc)
 
 	q := r.URL.Query()
 	to := today
 	if v := q.Get("to"); v != "" {
-		parsed, err := time.Parse("2006-01-02", v)
+		parsed, err := time.ParseInLocation("2006-01-02", v, loc)
 		if err != nil {
 			writeError(w, http.StatusBadRequest, "bad_request", "to must be a valid date (YYYY-MM-DD)")
 			return
@@ -411,7 +415,7 @@ func (h *ReadingSessionsHandler) HandleHistory(w http.ResponseWriter, r *http.Re
 	}
 	from := to.AddDate(0, 0, -defaultHistoryRangeDays)
 	if v := q.Get("from"); v != "" {
-		parsed, err := time.Parse("2006-01-02", v)
+		parsed, err := time.ParseInLocation("2006-01-02", v, loc)
 		if err != nil {
 			writeError(w, http.StatusBadRequest, "bad_request", "from must be a valid date (YYYY-MM-DD)")
 			return
@@ -424,28 +428,28 @@ func (h *ReadingSessionsHandler) HandleHistory(w http.ResponseWriter, r *http.Re
 
 	ctx := r.Context()
 
-	todaySeconds, err := h.Store.TotalsSince(ctx, userID, profileID, today)
+	todaySeconds, err := h.Store.TotalsSince(ctx, userID, profileID, today, loc)
 	if err != nil {
 		writeError(w, http.StatusInternalServerError, "internal_error", "Failed to load reading totals")
 		return
 	}
-	weekSeconds, err := h.Store.TotalsSince(ctx, userID, profileID, today.AddDate(0, 0, -6))
+	weekSeconds, err := h.Store.TotalsSince(ctx, userID, profileID, today.AddDate(0, 0, -6), loc)
 	if err != nil {
 		writeError(w, http.StatusInternalServerError, "internal_error", "Failed to load reading totals")
 		return
 	}
-	monthSeconds, err := h.Store.TotalsSince(ctx, userID, profileID, today.AddDate(0, 0, -29))
+	monthSeconds, err := h.Store.TotalsSince(ctx, userID, profileID, today.AddDate(0, 0, -29), loc)
 	if err != nil {
 		writeError(w, http.StatusInternalServerError, "internal_error", "Failed to load reading totals")
 		return
 	}
-	allTimeSeconds, err := h.Store.TotalsSince(ctx, userID, profileID, time.Time{})
+	allTimeSeconds, err := h.Store.TotalsSince(ctx, userID, profileID, time.Time{}, loc)
 	if err != nil {
 		writeError(w, http.StatusInternalServerError, "internal_error", "Failed to load reading totals")
 		return
 	}
 
-	days, err := h.Store.DailyRollup(ctx, userID, profileID, from, to)
+	days, err := h.Store.DailyRollup(ctx, userID, profileID, from, to, loc)
 	if err != nil {
 		writeError(w, http.StatusInternalServerError, "internal_error", "Failed to load daily reading rollup")
 		return
@@ -618,23 +622,23 @@ func (s *PGReadingSessionStore) BookSeconds(ctx context.Context, userID int, pro
 	return seconds, nil
 }
 
-func (s *PGReadingSessionStore) DailyRollup(ctx context.Context, userID int, profileID string, from, to time.Time) ([]DayTotal, error) {
+func (s *PGReadingSessionStore) DailyRollup(ctx context.Context, userID int, profileID string, from, to time.Time, loc *time.Location) ([]DayTotal, error) {
 	if s == nil || s.pool == nil {
 		return nil, fmt.Errorf("reading session store is not configured")
 	}
-	// Bucketing is pinned to UTC via "AT TIME ZONE 'UTC'" rather than a bare
-	// date_trunc('day', started_at): date_trunc on a timestamptz truncates in
-	// the DB session's timezone, which this pool never sets, so the bucket
-	// boundary would otherwise depend on server/connection config instead of
-	// being deterministic. Day bucketing is intentionally UTC for now; a
-	// follow-up may add requester-timezone support.
+	// Bucketing is pinned to an explicit zone via "AT TIME ZONE $5" rather
+	// than a bare date_trunc('day', started_at): date_trunc on a timestamptz
+	// truncates in the DB session's timezone, which this pool never sets, so
+	// the bucket boundary would otherwise depend on server/connection config
+	// instead of being deterministic. The zone name comes from the
+	// requester's tz param (loc), defaulting to "UTC".
 	rows, err := s.pool.Query(ctx, `
-		SELECT date_trunc('day', started_at AT TIME ZONE 'UTC')::date AS day, SUM(duration_seconds)
+		SELECT date_trunc('day', started_at AT TIME ZONE $5)::date AS day, SUM(duration_seconds)
 		FROM reading_sessions
 		WHERE user_id = $1 AND profile_id = $2 AND started_at >= $3 AND started_at < $4
 		GROUP BY 1
 		ORDER BY 1`,
-		userID, profileID, from, to.AddDate(0, 0, 1),
+		userID, profileID, from, to.AddDate(0, 0, 1), loc.String(),
 	)
 	if err != nil {
 		return nil, fmt.Errorf("daily rollup: %w", err)
@@ -719,7 +723,7 @@ func (s *PGReadingSessionStore) RecentSessions(ctx context.Context, userID int, 
 	return out, nil
 }
 
-func (s *PGReadingSessionStore) TotalsSince(ctx context.Context, userID int, profileID string, since time.Time) (int, error) {
+func (s *PGReadingSessionStore) TotalsSince(ctx context.Context, userID int, profileID string, since time.Time, _ *time.Location) (int, error) {
 	if s == nil || s.pool == nil {
 		return 0, fmt.Errorf("reading session store is not configured")
 	}

--- a/internal/api/handlers/reading_sessions.go
+++ b/internal/api/handlers/reading_sessions.go
@@ -41,6 +41,34 @@ type ReadingSession struct {
 	EndFraction     float64
 }
 
+// DayTotal is a single day's reading-time rollup (UTC calendar day).
+type DayTotal struct {
+	Date    time.Time
+	Seconds int
+}
+
+// BookTotal is a per-book reading-time rollup. Title is resolved via a LEFT
+// JOIN against media_items and is empty when the book has been removed from
+// the library; callers map that to a "Removed book" placeholder.
+type BookTotal struct {
+	ContentID  string
+	Title      string
+	Seconds    int
+	LastReadAt time.Time
+}
+
+// SessionRow is a single reading session as surfaced in history/recent
+// listings. Title has the same LEFT JOIN / empty-means-removed semantics as
+// BookTotal.Title.
+type SessionRow struct {
+	ContentID       string
+	Title           string
+	StartedAt       time.Time
+	DurationSeconds int
+	StartFraction   float64
+	EndFraction     float64
+}
+
 // ReadingSessionStore persists reading sessions and coalesces heartbeats
 // into them.
 type ReadingSessionStore interface {
@@ -50,14 +78,66 @@ type ReadingSessionStore interface {
 	LatestOpen(ctx context.Context, userID int, profileID, contentID string, since time.Time) (*ReadingSession, error)
 	Insert(ctx context.Context, s ReadingSession) error
 	Extend(ctx context.Context, id int64, lastHeartbeatAt time.Time, addSeconds int, endFraction float64) error
+
+	// PaceWindow sums fraction deltas and durations for the profile's
+	// sessions since the given time. contentID == "" sums across all of the
+	// profile's books; otherwise it is scoped to that book.
+	PaceWindow(ctx context.Context, userID int, profileID, contentID string, since time.Time) (fractions float64, seconds int, err error)
+	// BookSeconds is the all-time total reading duration for one book.
+	BookSeconds(ctx context.Context, userID int, profileID, contentID string) (int, error)
+	// DailyRollup groups duration by UTC calendar day over [from, to]
+	// (inclusive of both endpoint days).
+	DailyRollup(ctx context.Context, userID int, profileID string, from, to time.Time) ([]DayTotal, error)
+	// BookTotals returns all-time per-book totals, newest-read first.
+	BookTotals(ctx context.Context, userID int, profileID string) ([]BookTotal, error)
+	// RecentSessions returns the most recent sessions, newest-first,
+	// capped at limit.
+	RecentSessions(ctx context.Context, userID int, profileID string, limit int) ([]SessionRow, error)
+	// TotalsSince sums duration for sessions started at or after since. A
+	// zero since returns the all-time total.
+	TotalsSince(ctx context.Context, userID int, profileID string, since time.Time) (int, error)
+}
+
+// readingProgressGetter is the minimal progress lookup the per-book
+// reading-stats handler needs: the profile's current fraction through a
+// book. It is satisfied by EbookProgressAdapter, which wraps the existing
+// EbookReaderProgressStore so this package doesn't need its full interface.
+type readingProgressGetter interface {
+	GetProgress(ctx context.Context, userID int, profileID, contentID string) (progress float64, found bool, err error)
+}
+
+// EbookProgressAdapter adapts an EbookReaderProgressStore (the store the
+// ebook reader already uses for position tracking) to the narrower
+// readingProgressGetter interface the reading-stats handlers need.
+type EbookProgressAdapter struct {
+	Store EbookReaderProgressStore
+}
+
+// GetProgress returns the profile's current progress fraction for a book,
+// or found=false if no progress has been recorded yet.
+func (a EbookProgressAdapter) GetProgress(ctx context.Context, userID int, profileID, contentID string) (float64, bool, error) {
+	if a.Store == nil {
+		return 0, false, nil
+	}
+	progress, err := a.Store.Get(ctx, userID, profileID, contentID)
+	if err != nil {
+		return 0, false, err
+	}
+	if progress == nil {
+		return 0, false, nil
+	}
+	return progress.Progress, true, nil
 }
 
 // ReadingSessionsHandler accepts reader heartbeats and coalesces them into
-// reading_sessions rows. Now is injected so heartbeat gap/credit math is
-// deterministic under test.
+// reading_sessions rows, and serves the pace/time-left and history read
+// endpoints built on top of them. Now is injected so heartbeat gap/credit
+// math and time-window boundaries are deterministic under test. Progress is
+// nil-tolerant: without it, the per-book handler falls back to progress 0.
 type ReadingSessionsHandler struct {
-	Store ReadingSessionStore
-	Now   func() time.Time
+	Store    ReadingSessionStore
+	Now      func() time.Time
+	Progress readingProgressGetter
 }
 
 type readingHeartbeatRequest struct {
@@ -142,6 +222,287 @@ func (h *ReadingSessionsHandler) HandleHeartbeat(w http.ResponseWriter, r *http.
 	w.WriteHeader(http.StatusNoContent)
 }
 
+const (
+	// paceLookbackWindow is how far back pace calculations look for
+	// sessions, per spec.
+	paceLookbackWindow = 14 * 24 * time.Hour
+	// paceThisBookMinSeconds is the minimum this-book reading time in the
+	// lookback window before this-book pace is trusted.
+	paceThisBookMinSeconds = 600
+	// paceAllBooksMinSeconds is the minimum all-books reading time in the
+	// lookback window before the all-books fallback pace is trusted.
+	paceAllBooksMinSeconds = 1800
+	// maxRecentSessions caps the history endpoint's sessions list.
+	maxRecentSessions = 50
+	// defaultHistoryRangeDays is the default from/to span (in days) when
+	// the history endpoint is called with no range params.
+	defaultHistoryRangeDays = 365
+)
+
+// paceAndTimeLeft computes a reading pace estimate and, from it, an
+// estimated time remaining in the book. bookF/bookSec are the summed
+// fraction delta and duration over the lookback window for this book;
+// allF/allSec are the same summed across all of the profile's books.
+// progress is the profile's current fraction through the book.
+//
+// This-book pace is used if it clears paceThisBookMinSeconds and has a
+// positive fraction delta (a zero or negative delta is guarded against,
+// since it would produce a zero, infinite, or backwards pace). Otherwise
+// the all-books pace is used under the same conditions with
+// paceAllBooksMinSeconds. If neither qualifies, both return values are nil.
+func paceAndTimeLeft(bookF float64, bookSec int, allF float64, allSec int, progress float64) (paceFPH *float64, timeLeftSec *int64) {
+	var pace float64
+	switch {
+	case bookSec >= paceThisBookMinSeconds && bookF > 0:
+		pace = bookF / float64(bookSec) * 3600
+	case allSec >= paceAllBooksMinSeconds && allF > 0:
+		pace = allF / float64(allSec) * 3600
+	default:
+		return nil, nil
+	}
+
+	remaining := 1 - progress
+	if remaining < 0 {
+		remaining = 0
+	}
+	paceFractionPerSecond := pace / 3600
+	seconds := int64(math.Round(remaining / paceFractionPerSecond))
+
+	return &pace, &seconds
+}
+
+type bookReadingStatsResponse struct {
+	PaceFractionPerHour *float64 `json:"pace_fraction_per_hour"`
+	TimeLeftSeconds     *int64   `json:"time_left_seconds"`
+	BookSeconds         int      `json:"book_seconds"`
+}
+
+// HandleBookStats returns the pace and time-left estimate for one book, plus
+// the all-time reading duration for it.
+func (h *ReadingSessionsHandler) HandleBookStats(w http.ResponseWriter, r *http.Request) {
+	userID := apimw.GetUserID(r.Context())
+	profileID := apimw.GetProfileID(r.Context())
+	if userID == 0 {
+		writeError(w, http.StatusUnauthorized, "unauthorized", "Authentication required")
+		return
+	}
+	if h == nil || h.Store == nil || h.Now == nil {
+		writeError(w, http.StatusServiceUnavailable, "unavailable", "Reading sessions are not configured")
+		return
+	}
+
+	contentID := chi.URLParam(r, "content_id")
+	if contentID == "" {
+		writeError(w, http.StatusBadRequest, "bad_request", "content_id is required")
+		return
+	}
+
+	ctx := r.Context()
+	since := h.Now().Add(-paceLookbackWindow)
+
+	bookF, bookSec, err := h.Store.PaceWindow(ctx, userID, profileID, contentID, since)
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, "internal_error", "Failed to load reading pace")
+		return
+	}
+	allF, allSec, err := h.Store.PaceWindow(ctx, userID, profileID, "", since)
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, "internal_error", "Failed to load reading pace")
+		return
+	}
+	bookSeconds, err := h.Store.BookSeconds(ctx, userID, profileID, contentID)
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, "internal_error", "Failed to load book reading time")
+		return
+	}
+
+	var progress float64
+	if h.Progress != nil {
+		p, found, err := h.Progress.GetProgress(ctx, userID, profileID, contentID)
+		if err != nil {
+			writeError(w, http.StatusInternalServerError, "internal_error", "Failed to load reading progress")
+			return
+		}
+		if found {
+			progress = p
+		}
+	}
+
+	pace, timeLeft := paceAndTimeLeft(bookF, bookSec, allF, allSec, progress)
+	writeJSON(w, http.StatusOK, bookReadingStatsResponse{
+		PaceFractionPerHour: pace,
+		TimeLeftSeconds:     timeLeft,
+		BookSeconds:         bookSeconds,
+	})
+}
+
+type readingStatsTotalsResponse struct {
+	TodaySeconds   int `json:"today_seconds"`
+	WeekSeconds    int `json:"week_seconds"`
+	MonthSeconds   int `json:"month_seconds"`
+	AllTimeSeconds int `json:"all_time_seconds"`
+}
+
+type readingStatsDayResponse struct {
+	Date    string `json:"date"`
+	Seconds int    `json:"seconds"`
+}
+
+type readingStatsBookResponse struct {
+	ContentID  string `json:"content_id"`
+	Title      string `json:"title"`
+	Seconds    int    `json:"seconds"`
+	LastReadAt string `json:"last_read_at"`
+}
+
+type readingStatsSessionResponse struct {
+	ContentID       string  `json:"content_id"`
+	Title           string  `json:"title"`
+	StartedAt       string  `json:"started_at"`
+	DurationSeconds int     `json:"duration_seconds"`
+	StartFraction   float64 `json:"start_fraction"`
+	EndFraction     float64 `json:"end_fraction"`
+}
+
+type readingStatsHistoryResponse struct {
+	Totals   readingStatsTotalsResponse    `json:"totals"`
+	Days     []readingStatsDayResponse     `json:"days"`
+	Books    []readingStatsBookResponse    `json:"books"`
+	Sessions []readingStatsSessionResponse `json:"sessions"`
+}
+
+// readingStatsTitle maps an empty LEFT-JOIN-resolved title (book removed
+// from the library) to a stable placeholder.
+func readingStatsTitle(title string) string {
+	if title == "" {
+		return "Removed book"
+	}
+	return title
+}
+
+// HandleHistory returns the profile's reading history: fixed-window totals
+// (today/week/month/all-time), a daily rollup over an optional [from, to]
+// range (defaulting to the last defaultHistoryRangeDays+1 days), all-time
+// per-book totals, and the most recent sessions.
+func (h *ReadingSessionsHandler) HandleHistory(w http.ResponseWriter, r *http.Request) {
+	userID := apimw.GetUserID(r.Context())
+	profileID := apimw.GetProfileID(r.Context())
+	if userID == 0 {
+		writeError(w, http.StatusUnauthorized, "unauthorized", "Authentication required")
+		return
+	}
+	if h == nil || h.Store == nil || h.Now == nil {
+		writeError(w, http.StatusServiceUnavailable, "unavailable", "Reading sessions are not configured")
+		return
+	}
+
+	now := h.Now()
+	today := time.Date(now.Year(), now.Month(), now.Day(), 0, 0, 0, 0, time.UTC)
+
+	q := r.URL.Query()
+	to := today
+	if v := q.Get("to"); v != "" {
+		parsed, err := time.Parse("2006-01-02", v)
+		if err != nil {
+			writeError(w, http.StatusBadRequest, "bad_request", "to must be a valid date (YYYY-MM-DD)")
+			return
+		}
+		to = parsed
+	}
+	from := to.AddDate(0, 0, -defaultHistoryRangeDays)
+	if v := q.Get("from"); v != "" {
+		parsed, err := time.Parse("2006-01-02", v)
+		if err != nil {
+			writeError(w, http.StatusBadRequest, "bad_request", "from must be a valid date (YYYY-MM-DD)")
+			return
+		}
+		from = parsed
+	}
+	if from.After(to) {
+		from = to
+	}
+
+	ctx := r.Context()
+
+	todaySeconds, err := h.Store.TotalsSince(ctx, userID, profileID, today)
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, "internal_error", "Failed to load reading totals")
+		return
+	}
+	weekSeconds, err := h.Store.TotalsSince(ctx, userID, profileID, today.AddDate(0, 0, -6))
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, "internal_error", "Failed to load reading totals")
+		return
+	}
+	monthSeconds, err := h.Store.TotalsSince(ctx, userID, profileID, today.AddDate(0, 0, -29))
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, "internal_error", "Failed to load reading totals")
+		return
+	}
+	allTimeSeconds, err := h.Store.TotalsSince(ctx, userID, profileID, time.Time{})
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, "internal_error", "Failed to load reading totals")
+		return
+	}
+
+	days, err := h.Store.DailyRollup(ctx, userID, profileID, from, to)
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, "internal_error", "Failed to load daily reading rollup")
+		return
+	}
+	books, err := h.Store.BookTotals(ctx, userID, profileID)
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, "internal_error", "Failed to load book reading totals")
+		return
+	}
+	sessions, err := h.Store.RecentSessions(ctx, userID, profileID, maxRecentSessions)
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, "internal_error", "Failed to load recent reading sessions")
+		return
+	}
+	if len(sessions) > maxRecentSessions {
+		sessions = sessions[:maxRecentSessions]
+	}
+
+	resp := readingStatsHistoryResponse{
+		Totals: readingStatsTotalsResponse{
+			TodaySeconds:   todaySeconds,
+			WeekSeconds:    weekSeconds,
+			MonthSeconds:   monthSeconds,
+			AllTimeSeconds: allTimeSeconds,
+		},
+		Days:     make([]readingStatsDayResponse, 0, len(days)),
+		Books:    make([]readingStatsBookResponse, 0, len(books)),
+		Sessions: make([]readingStatsSessionResponse, 0, len(sessions)),
+	}
+	for _, d := range days {
+		resp.Days = append(resp.Days, readingStatsDayResponse{
+			Date:    d.Date.Format("2006-01-02"),
+			Seconds: d.Seconds,
+		})
+	}
+	for _, b := range books {
+		resp.Books = append(resp.Books, readingStatsBookResponse{
+			ContentID:  b.ContentID,
+			Title:      readingStatsTitle(b.Title),
+			Seconds:    b.Seconds,
+			LastReadAt: b.LastReadAt.Format(time.RFC3339),
+		})
+	}
+	for _, s := range sessions {
+		resp.Sessions = append(resp.Sessions, readingStatsSessionResponse{
+			ContentID:       s.ContentID,
+			Title:           readingStatsTitle(s.Title),
+			StartedAt:       s.StartedAt.Format(time.RFC3339),
+			DurationSeconds: s.DurationSeconds,
+			StartFraction:   s.StartFraction,
+			EndFraction:     s.EndFraction,
+		})
+	}
+
+	writeJSON(w, http.StatusOK, resp)
+}
+
 // PGReadingSessionStore is the Postgres-backed ReadingSessionStore.
 type PGReadingSessionStore struct {
 	pool *pgxpool.Pool
@@ -217,4 +578,154 @@ func (s *PGReadingSessionStore) Extend(ctx context.Context, id int64, lastHeartb
 		return fmt.Errorf("extend reading session: %w", err)
 	}
 	return nil
+}
+
+func (s *PGReadingSessionStore) PaceWindow(ctx context.Context, userID int, profileID, contentID string, since time.Time) (float64, int, error) {
+	if s == nil || s.pool == nil {
+		return 0, 0, fmt.Errorf("reading session store is not configured")
+	}
+	query := `
+		SELECT COALESCE(SUM(end_fraction - start_fraction), 0), COALESCE(SUM(duration_seconds), 0)
+		FROM reading_sessions
+		WHERE user_id = $1 AND profile_id = $2 AND last_heartbeat_at >= $3`
+	args := []any{userID, profileID, since}
+	if contentID != "" {
+		query += " AND content_id = $4"
+		args = append(args, contentID)
+	}
+	var fractions float64
+	var seconds int
+	if err := s.pool.QueryRow(ctx, query, args...).Scan(&fractions, &seconds); err != nil {
+		return 0, 0, fmt.Errorf("pace window: %w", err)
+	}
+	return fractions, seconds, nil
+}
+
+func (s *PGReadingSessionStore) BookSeconds(ctx context.Context, userID int, profileID, contentID string) (int, error) {
+	if s == nil || s.pool == nil {
+		return 0, fmt.Errorf("reading session store is not configured")
+	}
+	var seconds int
+	err := s.pool.QueryRow(ctx, `
+		SELECT COALESCE(SUM(duration_seconds), 0)
+		FROM reading_sessions
+		WHERE user_id = $1 AND profile_id = $2 AND content_id = $3`,
+		userID, profileID, contentID,
+	).Scan(&seconds)
+	if err != nil {
+		return 0, fmt.Errorf("book seconds: %w", err)
+	}
+	return seconds, nil
+}
+
+func (s *PGReadingSessionStore) DailyRollup(ctx context.Context, userID int, profileID string, from, to time.Time) ([]DayTotal, error) {
+	if s == nil || s.pool == nil {
+		return nil, fmt.Errorf("reading session store is not configured")
+	}
+	rows, err := s.pool.Query(ctx, `
+		SELECT date_trunc('day', started_at)::date AS day, SUM(duration_seconds)
+		FROM reading_sessions
+		WHERE user_id = $1 AND profile_id = $2 AND started_at >= $3 AND started_at < $4
+		GROUP BY 1
+		ORDER BY 1`,
+		userID, profileID, from, to.AddDate(0, 0, 1),
+	)
+	if err != nil {
+		return nil, fmt.Errorf("daily rollup: %w", err)
+	}
+	defer rows.Close()
+
+	var out []DayTotal
+	for rows.Next() {
+		var d DayTotal
+		if err := rows.Scan(&d.Date, &d.Seconds); err != nil {
+			return nil, fmt.Errorf("scan daily rollup: %w", err)
+		}
+		out = append(out, d)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("iterate daily rollup: %w", err)
+	}
+	return out, nil
+}
+
+func (s *PGReadingSessionStore) BookTotals(ctx context.Context, userID int, profileID string) ([]BookTotal, error) {
+	if s == nil || s.pool == nil {
+		return nil, fmt.Errorf("reading session store is not configured")
+	}
+	rows, err := s.pool.Query(ctx, `
+		SELECT rs.content_id, COALESCE(mi.title, ''), SUM(rs.duration_seconds), MAX(rs.last_heartbeat_at)
+		FROM reading_sessions rs
+		LEFT JOIN media_items mi ON mi.content_id = rs.content_id
+		WHERE rs.user_id = $1 AND rs.profile_id = $2
+		GROUP BY rs.content_id, mi.title
+		ORDER BY MAX(rs.last_heartbeat_at) DESC`,
+		userID, profileID,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("book totals: %w", err)
+	}
+	defer rows.Close()
+
+	var out []BookTotal
+	for rows.Next() {
+		var b BookTotal
+		if err := rows.Scan(&b.ContentID, &b.Title, &b.Seconds, &b.LastReadAt); err != nil {
+			return nil, fmt.Errorf("scan book totals: %w", err)
+		}
+		out = append(out, b)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("iterate book totals: %w", err)
+	}
+	return out, nil
+}
+
+func (s *PGReadingSessionStore) RecentSessions(ctx context.Context, userID int, profileID string, limit int) ([]SessionRow, error) {
+	if s == nil || s.pool == nil {
+		return nil, fmt.Errorf("reading session store is not configured")
+	}
+	rows, err := s.pool.Query(ctx, `
+		SELECT rs.content_id, COALESCE(mi.title, ''), rs.started_at, rs.duration_seconds, rs.start_fraction, rs.end_fraction
+		FROM reading_sessions rs
+		LEFT JOIN media_items mi ON mi.content_id = rs.content_id
+		WHERE rs.user_id = $1 AND rs.profile_id = $2
+		ORDER BY rs.started_at DESC
+		LIMIT $3`,
+		userID, profileID, limit,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("recent sessions: %w", err)
+	}
+	defer rows.Close()
+
+	var out []SessionRow
+	for rows.Next() {
+		var s SessionRow
+		if err := rows.Scan(&s.ContentID, &s.Title, &s.StartedAt, &s.DurationSeconds, &s.StartFraction, &s.EndFraction); err != nil {
+			return nil, fmt.Errorf("scan recent sessions: %w", err)
+		}
+		out = append(out, s)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("iterate recent sessions: %w", err)
+	}
+	return out, nil
+}
+
+func (s *PGReadingSessionStore) TotalsSince(ctx context.Context, userID int, profileID string, since time.Time) (int, error) {
+	if s == nil || s.pool == nil {
+		return 0, fmt.Errorf("reading session store is not configured")
+	}
+	var seconds int
+	err := s.pool.QueryRow(ctx, `
+		SELECT COALESCE(SUM(duration_seconds), 0)
+		FROM reading_sessions
+		WHERE user_id = $1 AND profile_id = $2 AND started_at >= $3`,
+		userID, profileID, since,
+	).Scan(&seconds)
+	if err != nil {
+		return 0, fmt.Errorf("totals since: %w", err)
+	}
+	return seconds, nil
 }

--- a/internal/api/handlers/reading_sessions.go
+++ b/internal/api/handlers/reading_sessions.go
@@ -41,7 +41,9 @@ type ReadingSession struct {
 	EndFraction     float64
 }
 
-// DayTotal is a single day's reading-time rollup (UTC calendar day).
+// DayTotal is a single day's reading-time rollup (calendar day in the
+// requester's timezone, per the "tz" query param resolved by
+// requestLocation; defaults to UTC).
 type DayTotal struct {
 	Date    time.Time
 	Seconds int
@@ -401,7 +403,8 @@ func (h *ReadingSessionsHandler) HandleHistory(w http.ResponseWriter, r *http.Re
 
 	loc := requestLocation(r)
 	now := h.Now()
-	today := time.Date(now.Year(), now.Month(), now.Day(), 0, 0, 0, 0, loc)
+	nowLocal := now.In(loc)
+	today := time.Date(nowLocal.Year(), nowLocal.Month(), nowLocal.Day(), 0, 0, 0, 0, loc)
 
 	q := r.URL.Query()
 	to := today

--- a/internal/api/handlers/reading_sessions.go
+++ b/internal/api/handlers/reading_sessions.go
@@ -622,8 +622,14 @@ func (s *PGReadingSessionStore) DailyRollup(ctx context.Context, userID int, pro
 	if s == nil || s.pool == nil {
 		return nil, fmt.Errorf("reading session store is not configured")
 	}
+	// Bucketing is pinned to UTC via "AT TIME ZONE 'UTC'" rather than a bare
+	// date_trunc('day', started_at): date_trunc on a timestamptz truncates in
+	// the DB session's timezone, which this pool never sets, so the bucket
+	// boundary would otherwise depend on server/connection config instead of
+	// being deterministic. Day bucketing is intentionally UTC for now; a
+	// follow-up may add requester-timezone support.
 	rows, err := s.pool.Query(ctx, `
-		SELECT date_trunc('day', started_at)::date AS day, SUM(duration_seconds)
+		SELECT date_trunc('day', started_at AT TIME ZONE 'UTC')::date AS day, SUM(duration_seconds)
 		FROM reading_sessions
 		WHERE user_id = $1 AND profile_id = $2 AND started_at >= $3 AND started_at < $4
 		GROUP BY 1

--- a/internal/api/handlers/reading_sessions_test.go
+++ b/internal/api/handlers/reading_sessions_test.go
@@ -1,0 +1,288 @@
+package handlers
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/go-chi/chi/v5"
+
+	apimw "github.com/Silo-Server/silo-server/internal/api/middleware"
+	"github.com/Silo-Server/silo-server/internal/auth"
+)
+
+var errSessionNotFound = errors.New("reading session not found")
+
+// fakeReadingSessionStore is an in-memory ReadingSessionStore backed by a
+// slice, mirroring fakeReaderFontStore's style.
+type fakeReadingSessionStore struct {
+	sessions []ReadingSession
+	nextID   int64
+}
+
+func (f *fakeReadingSessionStore) LatestOpen(_ context.Context, userID int, profileID, contentID string, since time.Time) (*ReadingSession, error) {
+	var best *ReadingSession
+	for i := range f.sessions {
+		s := &f.sessions[i]
+		if s.UserID != userID || s.ProfileID != profileID || s.ContentID != contentID {
+			continue
+		}
+		if s.LastHeartbeatAt.Before(since) {
+			continue
+		}
+		if best == nil || s.LastHeartbeatAt.After(best.LastHeartbeatAt) {
+			best = s
+		}
+	}
+	if best == nil {
+		return nil, nil
+	}
+	cp := *best
+	return &cp, nil
+}
+
+func (f *fakeReadingSessionStore) Insert(_ context.Context, s ReadingSession) error {
+	f.nextID++
+	s.ID = f.nextID
+	f.sessions = append(f.sessions, s)
+	return nil
+}
+
+func (f *fakeReadingSessionStore) Extend(_ context.Context, id int64, lastHeartbeatAt time.Time, addSeconds int, endFraction float64) error {
+	for i := range f.sessions {
+		if f.sessions[i].ID == id {
+			f.sessions[i].LastHeartbeatAt = lastHeartbeatAt
+			f.sessions[i].DurationSeconds += addSeconds
+			f.sessions[i].EndFraction = endFraction
+			return nil
+		}
+	}
+	return errSessionNotFound
+}
+
+// latestOpen is a test-only helper (not part of the store interface) that
+// returns the most recently touched session for (user, profile, content),
+// regardless of gap, so tests can assert on session state directly.
+func (f *fakeReadingSessionStore) latestOpen(userID int, profileID, contentID string) *ReadingSession {
+	var best *ReadingSession
+	for i := range f.sessions {
+		s := &f.sessions[i]
+		if s.UserID != userID || s.ProfileID != profileID || s.ContentID != contentID {
+			continue
+		}
+		if best == nil || s.LastHeartbeatAt.After(best.LastHeartbeatAt) {
+			best = s
+		}
+	}
+	return best
+}
+
+func readingSessionAuthContext(userID int, profileID string) context.Context {
+	ctx := apimw.SetClaims(context.Background(), &auth.Claims{
+		UserID:    userID,
+		Role:      "user",
+		TokenType: auth.TokenTypeAccess,
+	})
+	return apimw.SetProfileID(ctx, profileID)
+}
+
+func withReadingSessionContentIDParam(req *http.Request, contentID string) *http.Request {
+	routeCtx := chi.NewRouteContext()
+	routeCtx.URLParams.Add("content_id", contentID)
+	return req.WithContext(context.WithValue(req.Context(), chi.RouteCtxKey, routeCtx))
+}
+
+// newReadingHeartbeatRequest builds an authenticated POST request against
+// the reading-heartbeat endpoint. A nil body produces a request with no
+// body at all (simulating a client that sends nothing), matching the
+// "missing" case in TestReadingHeartbeatValidatesFraction.
+func newReadingHeartbeatRequest(t *testing.T, userID int, profileID, contentID string, body []byte) *http.Request {
+	t.Helper()
+	var req *http.Request
+	if body == nil {
+		req = httptest.NewRequest(http.MethodPost, "/ebooks/"+contentID+"/reading-heartbeat", nil)
+	} else {
+		req = httptest.NewRequest(http.MethodPost, "/ebooks/"+contentID+"/reading-heartbeat", bytes.NewReader(body))
+	}
+	req = req.WithContext(readingSessionAuthContext(userID, profileID))
+	return withReadingSessionContentIDParam(req, contentID)
+}
+
+func postHeartbeat(t *testing.T, h *ReadingSessionsHandler, userID int, profileID, contentID string, body []byte) *httptest.ResponseRecorder {
+	t.Helper()
+	req := newReadingHeartbeatRequest(t, userID, profileID, contentID, body)
+	rr := httptest.NewRecorder()
+	h.HandleHeartbeat(rr, req)
+	return rr
+}
+
+func TestReadingHeartbeatStartsAndExtendsSessions(t *testing.T) {
+	store := &fakeReadingSessionStore{}
+	t0 := time.Date(2026, 7, 20, 12, 0, 0, 0, time.UTC)
+	now := t0
+	h := &ReadingSessionsHandler{Store: store, Now: func() time.Time { return now }}
+
+	rr := postHeartbeat(t, h, 1, "profile-a", "book-1", []byte(`{"fraction":0.10}`))
+	if rr.Code != http.StatusNoContent {
+		t.Fatalf("status = %d, want 204; body = %s", rr.Code, rr.Body.String())
+	}
+	if len(store.sessions) != 1 {
+		t.Fatalf("sessions = %d, want 1", len(store.sessions))
+	}
+	s := store.latestOpen(1, "profile-a", "book-1")
+	if s == nil {
+		t.Fatal("expected an open session")
+	}
+	if s.DurationSeconds != 0 {
+		t.Fatalf("duration = %d, want 0", s.DurationSeconds)
+	}
+	if s.StartFraction != 0.10 || s.EndFraction != 0.10 {
+		t.Fatalf("start/end fraction = %v/%v, want 0.10/0.10", s.StartFraction, s.EndFraction)
+	}
+	firstID := s.ID
+
+	// t0+30s: same session extends.
+	now = t0.Add(30 * time.Second)
+	rr = postHeartbeat(t, h, 1, "profile-a", "book-1", []byte(`{"fraction":0.12}`))
+	if rr.Code != http.StatusNoContent {
+		t.Fatalf("status = %d, want 204; body = %s", rr.Code, rr.Body.String())
+	}
+	if len(store.sessions) != 1 {
+		t.Fatalf("sessions = %d, want 1 (extended, not new)", len(store.sessions))
+	}
+	s = store.latestOpen(1, "profile-a", "book-1")
+	if s.ID != firstID {
+		t.Fatalf("session id = %d, want extended session %d", s.ID, firstID)
+	}
+	if s.DurationSeconds != 30 {
+		t.Fatalf("duration = %d, want 30", s.DurationSeconds)
+	}
+	if s.EndFraction != 0.12 {
+		t.Fatalf("end fraction = %v, want 0.12", s.EndFraction)
+	}
+
+	// t0+30s+200s: gap > 120s, so a new session starts; the first session
+	// is left untouched.
+	now = t0.Add(30 * time.Second).Add(200 * time.Second)
+	rr = postHeartbeat(t, h, 1, "profile-a", "book-1", []byte(`{"fraction":0.13}`))
+	if rr.Code != http.StatusNoContent {
+		t.Fatalf("status = %d, want 204; body = %s", rr.Code, rr.Body.String())
+	}
+	if len(store.sessions) != 2 {
+		t.Fatalf("sessions = %d, want 2 (new session after gap)", len(store.sessions))
+	}
+	var firstSession *ReadingSession
+	for i := range store.sessions {
+		if store.sessions[i].ID == firstID {
+			firstSession = &store.sessions[i]
+		}
+	}
+	if firstSession == nil {
+		t.Fatal("expected first session to still exist")
+	}
+	if firstSession.DurationSeconds != 30 || firstSession.EndFraction != 0.12 {
+		t.Fatalf("first session mutated: duration=%d end=%v, want 30/0.12", firstSession.DurationSeconds, firstSession.EndFraction)
+	}
+	newSession := store.latestOpen(1, "profile-a", "book-1")
+	if newSession.ID == firstID {
+		t.Fatal("expected a distinct new session row")
+	}
+	if newSession.DurationSeconds != 0 {
+		t.Fatalf("new session duration = %d, want 0", newSession.DurationSeconds)
+	}
+	if newSession.StartFraction != 0.13 || newSession.EndFraction != 0.13 {
+		t.Fatalf("new session start/end = %v/%v, want 0.13/0.13", newSession.StartFraction, newSession.EndFraction)
+	}
+}
+
+func TestReadingHeartbeatCapsCredit(t *testing.T) {
+	store := &fakeReadingSessionStore{}
+	t0 := time.Date(2026, 7, 20, 12, 0, 0, 0, time.UTC)
+	now := t0
+	h := &ReadingSessionsHandler{Store: store, Now: func() time.Time { return now }}
+
+	rr := postHeartbeat(t, h, 1, "profile-a", "book-1", []byte(`{"fraction":0.10}`))
+	if rr.Code != http.StatusNoContent {
+		t.Fatalf("status = %d, want 204; body = %s", rr.Code, rr.Body.String())
+	}
+
+	// Gap of 100s (< 120s session gap) extends the session, but the credited
+	// duration is capped at heartbeatMaxCredit (90s), not the full 100s gap.
+	now = t0.Add(100 * time.Second)
+	rr = postHeartbeat(t, h, 1, "profile-a", "book-1", []byte(`{"fraction":0.20}`))
+	if rr.Code != http.StatusNoContent {
+		t.Fatalf("status = %d, want 204; body = %s", rr.Code, rr.Body.String())
+	}
+	if len(store.sessions) != 1 {
+		t.Fatalf("sessions = %d, want 1", len(store.sessions))
+	}
+	s := store.latestOpen(1, "profile-a", "book-1")
+	if s.DurationSeconds != 90 {
+		t.Fatalf("duration = %d, want 90 (capped)", s.DurationSeconds)
+	}
+}
+
+func TestReadingHeartbeatValidatesFraction(t *testing.T) {
+	cases := []struct {
+		name string
+		body []byte
+	}{
+		{"negative", []byte(`{"fraction":-0.1}`)},
+		{"above one", []byte(`{"fraction":1.5}`)},
+		{"NaN literal is invalid JSON", []byte(`{"fraction":NaN}`)},
+		{"missing body", nil},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			store := &fakeReadingSessionStore{}
+			now := time.Date(2026, 7, 20, 12, 0, 0, 0, time.UTC)
+			h := &ReadingSessionsHandler{Store: store, Now: func() time.Time { return now }}
+
+			rr := postHeartbeat(t, h, 1, "profile-a", "book-1", tc.body)
+			if rr.Code != http.StatusBadRequest {
+				t.Fatalf("status = %d, want 400; body = %s", rr.Code, rr.Body.String())
+			}
+			if len(store.sessions) != 0 {
+				t.Fatalf("expected store untouched, got %d sessions", len(store.sessions))
+			}
+		})
+	}
+}
+
+func TestReadingHeartbeatScopedToProfile(t *testing.T) {
+	store := &fakeReadingSessionStore{}
+	now := time.Date(2026, 7, 20, 12, 0, 0, 0, time.UTC)
+	h := &ReadingSessionsHandler{Store: store, Now: func() time.Time { return now }}
+
+	rrA := postHeartbeat(t, h, 1, "profile-a", "book-1", []byte(`{"fraction":0.10}`))
+	if rrA.Code != http.StatusNoContent {
+		t.Fatalf("profile A status = %d, want 204; body = %s", rrA.Code, rrA.Body.String())
+	}
+	rrB := postHeartbeat(t, h, 1, "profile-b", "book-1", []byte(`{"fraction":0.50}`))
+	if rrB.Code != http.StatusNoContent {
+		t.Fatalf("profile B status = %d, want 204; body = %s", rrB.Code, rrB.Body.String())
+	}
+
+	if len(store.sessions) != 2 {
+		t.Fatalf("sessions = %d, want 2 (one per profile)", len(store.sessions))
+	}
+	sessionA := store.latestOpen(1, "profile-a", "book-1")
+	sessionB := store.latestOpen(1, "profile-b", "book-1")
+	if sessionA == nil || sessionB == nil {
+		t.Fatal("expected a session for each profile")
+	}
+	if sessionA.ID == sessionB.ID {
+		t.Fatal("expected distinct sessions per profile")
+	}
+	if sessionA.StartFraction != 0.10 {
+		t.Fatalf("profile A start fraction = %v, want 0.10", sessionA.StartFraction)
+	}
+	if sessionB.StartFraction != 0.50 {
+		t.Fatalf("profile B start fraction = %v, want 0.50", sessionB.StartFraction)
+	}
+}

--- a/internal/api/handlers/reading_sessions_test.go
+++ b/internal/api/handlers/reading_sessions_test.go
@@ -32,10 +32,10 @@ type fakeReadingSessionStore struct {
 
 	paceWindowFn     func(contentID string, since time.Time) (float64, int, error)
 	bookSecondsFn    func(contentID string) (int, error)
-	dailyRollupFn    func(from, to time.Time) ([]DayTotal, error)
+	dailyRollupFn    func(from, to time.Time, loc *time.Location) ([]DayTotal, error)
 	bookTotalsFn     func() ([]BookTotal, error)
 	recentSessionsFn func(limit int) ([]SessionRow, error)
-	totalsSinceFn    func(since time.Time) (int, error)
+	totalsSinceFn    func(since time.Time, loc *time.Location) (int, error)
 }
 
 func (f *fakeReadingSessionStore) PaceWindow(_ context.Context, _ int, _, contentID string, since time.Time) (float64, int, error) {
@@ -52,11 +52,11 @@ func (f *fakeReadingSessionStore) BookSeconds(_ context.Context, _ int, _, conte
 	return f.bookSecondsFn(contentID)
 }
 
-func (f *fakeReadingSessionStore) DailyRollup(_ context.Context, _ int, _ string, from, to time.Time) ([]DayTotal, error) {
+func (f *fakeReadingSessionStore) DailyRollup(_ context.Context, _ int, _ string, from, to time.Time, loc *time.Location) ([]DayTotal, error) {
 	if f.dailyRollupFn == nil {
 		return nil, nil
 	}
-	return f.dailyRollupFn(from, to)
+	return f.dailyRollupFn(from, to, loc)
 }
 
 func (f *fakeReadingSessionStore) BookTotals(_ context.Context, _ int, _ string) ([]BookTotal, error) {
@@ -73,11 +73,11 @@ func (f *fakeReadingSessionStore) RecentSessions(_ context.Context, _ int, _ str
 	return f.recentSessionsFn(limit)
 }
 
-func (f *fakeReadingSessionStore) TotalsSince(_ context.Context, _ int, _ string, since time.Time) (int, error) {
+func (f *fakeReadingSessionStore) TotalsSince(_ context.Context, _ int, _ string, since time.Time, loc *time.Location) (int, error) {
 	if f.totalsSinceFn == nil {
 		return 0, nil
 	}
-	return f.totalsSinceFn(since)
+	return f.totalsSinceFn(since, loc)
 }
 
 // fakeReadingProgressGetter is a settable fake for readingProgressGetter.
@@ -569,7 +569,7 @@ func TestReadingStatsHistoryHandler(t *testing.T) {
 	var capturedLimit int
 	newStore := func() *fakeReadingSessionStore {
 		return &fakeReadingSessionStore{
-			totalsSinceFn: func(since time.Time) (int, error) {
+			totalsSinceFn: func(since time.Time, _ *time.Location) (int, error) {
 				switch {
 				case since.Equal(today):
 					return 100, nil
@@ -583,7 +583,7 @@ func TestReadingStatsHistoryHandler(t *testing.T) {
 					return 0, fmt.Errorf("unexpected TotalsSince(since=%v)", since)
 				}
 			},
-			dailyRollupFn: func(from, to time.Time) ([]DayTotal, error) {
+			dailyRollupFn: func(from, to time.Time, _ *time.Location) ([]DayTotal, error) {
 				capturedFrom, capturedTo = from, to
 				return []DayTotal{
 					{Date: today.AddDate(0, 0, -1), Seconds: 200},

--- a/internal/api/handlers/reading_sessions_test.go
+++ b/internal/api/handlers/reading_sessions_test.go
@@ -699,3 +699,44 @@ func TestReadingStatsHistoryHandler(t *testing.T) {
 		}
 	})
 }
+
+// TestHistoryTodayUsesRequestTimezone pins the "today" window boundary to
+// the requester's local calendar day, not a UTC-derived one. now is
+// 2026-07-19T23:30:00Z, which is local 2026-07-20T01:30 in Europe/Amsterdam
+// (CEST, UTC+2): a UTC-derived "today" would incorrectly pin the boundary to
+// 2026-07-19, one full local day early, so a session at local 01:00 on the
+// 20th (23:00Z on the 19th) would be missing from today_seconds.
+func TestHistoryTodayUsesRequestTimezone(t *testing.T) {
+	now := time.Date(2026, 7, 19, 23, 30, 0, 0, time.UTC)
+	loc, err := time.LoadLocation("Europe/Amsterdam")
+	if err != nil {
+		t.Fatalf("load location: %v", err)
+	}
+	wantToday := time.Date(2026, 7, 20, 0, 0, 0, 0, loc)
+
+	var sawTodayBoundary bool
+	store := &fakeReadingSessionStore{
+		totalsSinceFn: func(since time.Time, _ *time.Location) (int, error) {
+			if since.Equal(wantToday) {
+				sawTodayBoundary = true
+			}
+			return 0, nil
+		},
+		dailyRollupFn: func(_, _ time.Time, _ *time.Location) ([]DayTotal, error) {
+			return nil, nil
+		},
+	}
+	h := &ReadingSessionsHandler{Store: store, Now: func() time.Time { return now }}
+
+	req := httptest.NewRequest(http.MethodGet, "/ebooks/reading-stats?tz=Europe/Amsterdam", nil)
+	req = req.WithContext(readingSessionAuthContext(1, "profile-a"))
+	rr := httptest.NewRecorder()
+	h.HandleHistory(rr, req)
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200; body = %s", rr.Code, rr.Body.String())
+	}
+	if !sawTodayBoundary {
+		t.Fatalf("TotalsSince was never called with the local-midnight boundary %v (today derived from UTC instead of the requester's local now)", wantToday)
+	}
+}

--- a/internal/api/handlers/reading_sessions_test.go
+++ b/internal/api/handlers/reading_sessions_test.go
@@ -3,7 +3,10 @@ package handlers
 import (
 	"bytes"
 	"context"
+	"encoding/json"
 	"errors"
+	"fmt"
+	"math"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -18,10 +21,74 @@ import (
 var errSessionNotFound = errors.New("reading session not found")
 
 // fakeReadingSessionStore is an in-memory ReadingSessionStore backed by a
-// slice, mirroring fakeReaderFontStore's style.
+// slice, mirroring fakeReaderFontStore's style. The read-side rollup methods
+// (PaceWindow, BookSeconds, DailyRollup, BookTotals, RecentSessions,
+// TotalsSince) are backed by settable func fields so tests can supply canned
+// responses without reimplementing the SQL rollup logic in memory; tests
+// that don't touch them (e.g. the heartbeat tests) get harmless zero values.
 type fakeReadingSessionStore struct {
 	sessions []ReadingSession
 	nextID   int64
+
+	paceWindowFn     func(contentID string, since time.Time) (float64, int, error)
+	bookSecondsFn    func(contentID string) (int, error)
+	dailyRollupFn    func(from, to time.Time) ([]DayTotal, error)
+	bookTotalsFn     func() ([]BookTotal, error)
+	recentSessionsFn func(limit int) ([]SessionRow, error)
+	totalsSinceFn    func(since time.Time) (int, error)
+}
+
+func (f *fakeReadingSessionStore) PaceWindow(_ context.Context, _ int, _, contentID string, since time.Time) (float64, int, error) {
+	if f.paceWindowFn == nil {
+		return 0, 0, nil
+	}
+	return f.paceWindowFn(contentID, since)
+}
+
+func (f *fakeReadingSessionStore) BookSeconds(_ context.Context, _ int, _, contentID string) (int, error) {
+	if f.bookSecondsFn == nil {
+		return 0, nil
+	}
+	return f.bookSecondsFn(contentID)
+}
+
+func (f *fakeReadingSessionStore) DailyRollup(_ context.Context, _ int, _ string, from, to time.Time) ([]DayTotal, error) {
+	if f.dailyRollupFn == nil {
+		return nil, nil
+	}
+	return f.dailyRollupFn(from, to)
+}
+
+func (f *fakeReadingSessionStore) BookTotals(_ context.Context, _ int, _ string) ([]BookTotal, error) {
+	if f.bookTotalsFn == nil {
+		return nil, nil
+	}
+	return f.bookTotalsFn()
+}
+
+func (f *fakeReadingSessionStore) RecentSessions(_ context.Context, _ int, _ string, limit int) ([]SessionRow, error) {
+	if f.recentSessionsFn == nil {
+		return nil, nil
+	}
+	return f.recentSessionsFn(limit)
+}
+
+func (f *fakeReadingSessionStore) TotalsSince(_ context.Context, _ int, _ string, since time.Time) (int, error) {
+	if f.totalsSinceFn == nil {
+		return 0, nil
+	}
+	return f.totalsSinceFn(since)
+}
+
+// fakeReadingProgressGetter is a settable fake for readingProgressGetter.
+type fakeReadingProgressGetter struct {
+	progress float64
+	found    bool
+	err      error
+}
+
+func (f *fakeReadingProgressGetter) GetProgress(_ context.Context, _ int, _, _ string) (float64, bool, error) {
+	return f.progress, f.found, f.err
 }
 
 func (f *fakeReadingSessionStore) LatestOpen(_ context.Context, userID int, profileID, contentID string, since time.Time) (*ReadingSession, error) {
@@ -335,4 +402,300 @@ func TestReadingHeartbeatScopedToProfile(t *testing.T) {
 	if sessionB.StartFraction != 0.50 {
 		t.Fatalf("profile B start fraction = %v, want 0.50", sessionB.StartFraction)
 	}
+}
+
+func TestPaceAndTimeLeftThresholds(t *testing.T) {
+	t.Run("book pace wins when this-book data clears the 600s minimum", func(t *testing.T) {
+		pace, timeLeft := paceAndTimeLeft(0.2, 1200, 0, 0, 0.5)
+		if pace == nil {
+			t.Fatal("expected non-nil pace")
+		}
+		if math.Abs(*pace-0.6) > 1e-9 {
+			t.Fatalf("pace = %v, want 0.6", *pace)
+		}
+		if timeLeft == nil {
+			t.Fatal("expected non-nil timeLeft")
+		}
+		if diff := *timeLeft - 3000; diff < -1 || diff > 1 {
+			t.Fatalf("timeLeft = %d, want ~3000 (+/-1)", *timeLeft)
+		}
+	})
+
+	t.Run("falls back to all-books pace when this-book data is under 600s", func(t *testing.T) {
+		// Book has only 300s of data (below the 600s minimum); all-books
+		// has 0.3 fractions over 3600s (clears the 1800s minimum), so the
+		// all-books rate is used instead.
+		pace, timeLeft := paceAndTimeLeft(0.05, 300, 0.3, 3600, 0.5)
+		if pace == nil {
+			t.Fatal("expected non-nil pace from all-books fallback")
+		}
+		if math.Abs(*pace-0.3) > 1e-9 {
+			t.Fatalf("pace = %v, want 0.3 (all-books rate, not this-book rate)", *pace)
+		}
+		if timeLeft == nil {
+			t.Fatal("expected non-nil timeLeft")
+		}
+	})
+
+	t.Run("both under their minimums yields no estimate", func(t *testing.T) {
+		pace, timeLeft := paceAndTimeLeft(0.05, 300, 0.1, 900, 0.5)
+		if pace != nil || timeLeft != nil {
+			t.Fatalf("pace/timeLeft = %v/%v, want nil/nil", pace, timeLeft)
+		}
+	})
+
+	t.Run("zero or negative fraction deltas are guarded to nil", func(t *testing.T) {
+		// This-book clears the 600s minimum but has a zero fraction delta;
+		// all-books clears the 1800s minimum but has a negative delta.
+		// Both are guarded against (no divide-by-zero, no nonsense negative
+		// pace), so the overall result is nil.
+		pace, timeLeft := paceAndTimeLeft(0, 1200, -0.1, 3600, 0.5)
+		if pace != nil || timeLeft != nil {
+			t.Fatalf("pace/timeLeft = %v/%v, want nil/nil", pace, timeLeft)
+		}
+	})
+}
+
+func TestReadingStatsBookHandler(t *testing.T) {
+	now := time.Date(2026, 7, 20, 12, 0, 0, 0, time.UTC)
+
+	t.Run("computes pace, time-left, and book seconds from the store and progress", func(t *testing.T) {
+		store := &fakeReadingSessionStore{
+			paceWindowFn: func(contentID string, since time.Time) (float64, int, error) {
+				if !since.Equal(now.Add(-14 * 24 * time.Hour)) {
+					t.Fatalf("pace window since = %v, want now-14d", since)
+				}
+				if contentID == "book-1" {
+					return 0.2, 1200, nil
+				}
+				return 0.9, 9000, nil // all-books window; unused since book-1 wins
+			},
+			bookSecondsFn: func(contentID string) (int, error) {
+				if contentID != "book-1" {
+					t.Fatalf("book seconds contentID = %q, want book-1", contentID)
+				}
+				return 4000, nil
+			},
+		}
+		progress := &fakeReadingProgressGetter{progress: 0.5, found: true}
+		h := &ReadingSessionsHandler{Store: store, Now: func() time.Time { return now }, Progress: progress}
+
+		req := httptest.NewRequest(http.MethodGet, "/ebooks/book-1/reading-stats", nil)
+		req = req.WithContext(readingSessionAuthContext(1, "profile-a"))
+		req = withReadingSessionContentIDParam(req, "book-1")
+		rr := httptest.NewRecorder()
+		h.HandleBookStats(rr, req)
+
+		if rr.Code != http.StatusOK {
+			t.Fatalf("status = %d, want 200; body = %s", rr.Code, rr.Body.String())
+		}
+
+		var resp struct {
+			PaceFractionPerHour *float64 `json:"pace_fraction_per_hour"`
+			TimeLeftSeconds     *int64   `json:"time_left_seconds"`
+			BookSeconds         int      `json:"book_seconds"`
+		}
+		if err := json.Unmarshal(rr.Body.Bytes(), &resp); err != nil {
+			t.Fatalf("decode response: %v; body = %s", err, rr.Body.String())
+		}
+		if resp.PaceFractionPerHour == nil || math.Abs(*resp.PaceFractionPerHour-0.6) > 1e-9 {
+			t.Fatalf("pace_fraction_per_hour = %v, want 0.6", resp.PaceFractionPerHour)
+		}
+		if resp.TimeLeftSeconds == nil {
+			t.Fatal("expected non-nil time_left_seconds")
+		}
+		if resp.BookSeconds != 4000 {
+			t.Fatalf("book_seconds = %d, want 4000", resp.BookSeconds)
+		}
+	})
+
+	t.Run("no progress row and insufficient pace data yields nulls", func(t *testing.T) {
+		store := &fakeReadingSessionStore{
+			paceWindowFn: func(string, time.Time) (float64, int, error) { return 0, 100, nil },
+			bookSecondsFn: func(string) (int, error) {
+				return 0, nil
+			},
+		}
+		progress := &fakeReadingProgressGetter{found: false}
+		h := &ReadingSessionsHandler{Store: store, Now: func() time.Time { return now }, Progress: progress}
+
+		req := httptest.NewRequest(http.MethodGet, "/ebooks/book-2/reading-stats", nil)
+		req = req.WithContext(readingSessionAuthContext(1, "profile-a"))
+		req = withReadingSessionContentIDParam(req, "book-2")
+		rr := httptest.NewRecorder()
+		h.HandleBookStats(rr, req)
+
+		if rr.Code != http.StatusOK {
+			t.Fatalf("status = %d, want 200; body = %s", rr.Code, rr.Body.String())
+		}
+
+		var resp struct {
+			PaceFractionPerHour *float64 `json:"pace_fraction_per_hour"`
+			TimeLeftSeconds     *int64   `json:"time_left_seconds"`
+			BookSeconds         int      `json:"book_seconds"`
+		}
+		if err := json.Unmarshal(rr.Body.Bytes(), &resp); err != nil {
+			t.Fatalf("decode response: %v; body = %s", err, rr.Body.String())
+		}
+		if resp.PaceFractionPerHour != nil {
+			t.Fatalf("pace_fraction_per_hour = %v, want null", *resp.PaceFractionPerHour)
+		}
+		if resp.TimeLeftSeconds != nil {
+			t.Fatalf("time_left_seconds = %v, want null", *resp.TimeLeftSeconds)
+		}
+		if resp.BookSeconds != 0 {
+			t.Fatalf("book_seconds = %d, want 0", resp.BookSeconds)
+		}
+	})
+}
+
+func TestReadingStatsHistoryHandler(t *testing.T) {
+	now := time.Date(2026, 7, 20, 15, 30, 0, 0, time.UTC)
+	today := time.Date(2026, 7, 20, 0, 0, 0, 0, time.UTC)
+
+	manySessions := make([]SessionRow, 60)
+	for i := range manySessions {
+		manySessions[i] = SessionRow{
+			ContentID:       fmt.Sprintf("book-%d", i),
+			Title:           fmt.Sprintf("Book %d", i),
+			StartedAt:       today.Add(-time.Duration(i) * time.Hour),
+			DurationSeconds: 60,
+			StartFraction:   0.1,
+			EndFraction:     0.2,
+		}
+	}
+
+	var capturedFrom, capturedTo time.Time
+	var capturedLimit int
+	newStore := func() *fakeReadingSessionStore {
+		return &fakeReadingSessionStore{
+			totalsSinceFn: func(since time.Time) (int, error) {
+				switch {
+				case since.Equal(today):
+					return 100, nil
+				case since.Equal(today.AddDate(0, 0, -6)):
+					return 500, nil
+				case since.Equal(today.AddDate(0, 0, -29)):
+					return 2000, nil
+				case since.IsZero():
+					return 9000, nil
+				default:
+					return 0, fmt.Errorf("unexpected TotalsSince(since=%v)", since)
+				}
+			},
+			dailyRollupFn: func(from, to time.Time) ([]DayTotal, error) {
+				capturedFrom, capturedTo = from, to
+				return []DayTotal{
+					{Date: today.AddDate(0, 0, -1), Seconds: 200},
+					{Date: today, Seconds: 100},
+				}, nil
+			},
+			bookTotalsFn: func() ([]BookTotal, error) {
+				return []BookTotal{
+					{ContentID: "book-1", Title: "The Hobbit", Seconds: 3000, LastReadAt: today},
+					{ContentID: "book-2", Title: "", Seconds: 1000, LastReadAt: today.AddDate(0, 0, -2)},
+				}, nil
+			},
+			recentSessionsFn: func(limit int) ([]SessionRow, error) {
+				capturedLimit = limit
+				if limit < len(manySessions) {
+					return manySessions[:limit], nil
+				}
+				return manySessions, nil
+			},
+		}
+	}
+
+	t.Run("default range, totals, title fallback, and session cap", func(t *testing.T) {
+		store := newStore()
+		h := &ReadingSessionsHandler{Store: store, Now: func() time.Time { return now }}
+
+		req := httptest.NewRequest(http.MethodGet, "/ebooks/reading-stats", nil)
+		req = req.WithContext(readingSessionAuthContext(1, "profile-a"))
+		rr := httptest.NewRecorder()
+		h.HandleHistory(rr, req)
+
+		if rr.Code != http.StatusOK {
+			t.Fatalf("status = %d, want 200; body = %s", rr.Code, rr.Body.String())
+		}
+
+		var resp struct {
+			Totals struct {
+				TodaySeconds   int `json:"today_seconds"`
+				WeekSeconds    int `json:"week_seconds"`
+				MonthSeconds   int `json:"month_seconds"`
+				AllTimeSeconds int `json:"all_time_seconds"`
+			} `json:"totals"`
+			Days []struct {
+				Date    string `json:"date"`
+				Seconds int    `json:"seconds"`
+			} `json:"days"`
+			Books []struct {
+				ContentID  string `json:"content_id"`
+				Title      string `json:"title"`
+				Seconds    int    `json:"seconds"`
+				LastReadAt string `json:"last_read_at"`
+			} `json:"books"`
+			Sessions []struct {
+				ContentID       string  `json:"content_id"`
+				Title           string  `json:"title"`
+				StartedAt       string  `json:"started_at"`
+				DurationSeconds int     `json:"duration_seconds"`
+				StartFraction   float64 `json:"start_fraction"`
+				EndFraction     float64 `json:"end_fraction"`
+			} `json:"sessions"`
+		}
+		if err := json.Unmarshal(rr.Body.Bytes(), &resp); err != nil {
+			t.Fatalf("decode response: %v; body = %s", err, rr.Body.String())
+		}
+
+		if resp.Totals.TodaySeconds != 100 || resp.Totals.WeekSeconds != 500 ||
+			resp.Totals.MonthSeconds != 2000 || resp.Totals.AllTimeSeconds != 9000 {
+			t.Fatalf("totals = %+v, want today=100 week=500 month=2000 all_time=9000", resp.Totals)
+		}
+
+		wantFrom := today.AddDate(0, 0, -365)
+		if !capturedFrom.Equal(wantFrom) {
+			t.Fatalf("DailyRollup from = %v, want %v (default range = last 366 days)", capturedFrom, wantFrom)
+		}
+		if !capturedTo.Equal(today) {
+			t.Fatalf("DailyRollup to = %v, want %v", capturedTo, today)
+		}
+
+		if len(resp.Days) != 2 {
+			t.Fatalf("days = %d, want 2", len(resp.Days))
+		}
+
+		if len(resp.Books) != 2 {
+			t.Fatalf("books = %d, want 2", len(resp.Books))
+		}
+		if resp.Books[0].Title != "The Hobbit" {
+			t.Fatalf("books[0].title = %q, want %q", resp.Books[0].Title, "The Hobbit")
+		}
+		if resp.Books[1].Title != "Removed book" {
+			t.Fatalf("books[1].title = %q, want fallback %q for an empty joined title", resp.Books[1].Title, "Removed book")
+		}
+
+		if capturedLimit != 50 {
+			t.Fatalf("RecentSessions limit = %d, want 50", capturedLimit)
+		}
+		if len(resp.Sessions) != 50 {
+			t.Fatalf("sessions = %d, want capped at 50 (fixture has 60)", len(resp.Sessions))
+		}
+	})
+
+	t.Run("bad from/to query params are rejected", func(t *testing.T) {
+		store := newStore()
+		h := &ReadingSessionsHandler{Store: store, Now: func() time.Time { return now }}
+
+		for _, qs := range []string{"from=not-a-date", "to=also-not-a-date", "from=2026-13-40"} {
+			req := httptest.NewRequest(http.MethodGet, "/ebooks/reading-stats?"+qs, nil)
+			req = req.WithContext(readingSessionAuthContext(1, "profile-a"))
+			rr := httptest.NewRecorder()
+			h.HandleHistory(rr, req)
+			if rr.Code != http.StatusBadRequest {
+				t.Fatalf("qs=%q: status = %d, want 400; body = %s", qs, rr.Code, rr.Body.String())
+			}
+		}
+	})
 }

--- a/internal/api/handlers/reading_sessions_test.go
+++ b/internal/api/handlers/reading_sessions_test.go
@@ -235,6 +235,8 @@ func TestReadingHeartbeatValidatesFraction(t *testing.T) {
 		{"above one", []byte(`{"fraction":1.5}`)},
 		{"NaN literal is invalid JSON", []byte(`{"fraction":NaN}`)},
 		{"missing body", nil},
+		{"empty object (missing fraction key)", []byte(`{}`)},
+		{"other field only", []byte(`{"other":1}`)},
 	}
 
 	for _, tc := range cases {
@@ -251,6 +253,54 @@ func TestReadingHeartbeatValidatesFraction(t *testing.T) {
 				t.Fatalf("expected store untouched, got %d sessions", len(store.sessions))
 			}
 		})
+	}
+}
+
+func TestReadingHeartbeatAcceptsExplicitZeroFraction(t *testing.T) {
+	store := &fakeReadingSessionStore{}
+	now := time.Date(2026, 7, 20, 12, 0, 0, 0, time.UTC)
+	h := &ReadingSessionsHandler{Store: store, Now: func() time.Time { return now }}
+
+	rr := postHeartbeat(t, h, 1, "profile-a", "book-1", []byte(`{"fraction":0}`))
+	if rr.Code != http.StatusNoContent {
+		t.Fatalf("status = %d, want 204; body = %s", rr.Code, rr.Body.String())
+	}
+	if len(store.sessions) != 1 {
+		t.Fatalf("expected 1 session, got %d", len(store.sessions))
+	}
+	s := store.latestOpen(1, "profile-a", "book-1")
+	if s == nil {
+		t.Fatal("expected a session")
+	}
+	if s.StartFraction != 0.0 || s.EndFraction != 0.0 {
+		t.Fatalf("fractions = %v/%v, want 0/0", s.StartFraction, s.EndFraction)
+	}
+}
+
+func TestReadingHeartbeatExtendsAtExactSessionGap(t *testing.T) {
+	store := &fakeReadingSessionStore{}
+	t0 := time.Date(2026, 7, 20, 12, 0, 0, 0, time.UTC)
+	now := t0
+	h := &ReadingSessionsHandler{Store: store, Now: func() time.Time { return now }}
+
+	rr := postHeartbeat(t, h, 1, "profile-a", "book-1", []byte(`{"fraction":0.10}`))
+	if rr.Code != http.StatusNoContent {
+		t.Fatalf("status = %d, want 204; body = %s", rr.Code, rr.Body.String())
+	}
+	firstID := store.latestOpen(1, "profile-a", "book-1").ID
+
+	// Exactly 120s later: should still extend the existing session (>= check).
+	now = t0.Add(120 * time.Second)
+	rr = postHeartbeat(t, h, 1, "profile-a", "book-1", []byte(`{"fraction":0.20}`))
+	if rr.Code != http.StatusNoContent {
+		t.Fatalf("status = %d, want 204; body = %s", rr.Code, rr.Body.String())
+	}
+	if len(store.sessions) != 1 {
+		t.Fatalf("sessions = %d, want 1 (should extend, not create new)", len(store.sessions))
+	}
+	s := store.latestOpen(1, "profile-a", "book-1")
+	if s.ID != firstID {
+		t.Fatalf("session id = %d, want extended session %d", s.ID, firstID)
 	}
 }
 

--- a/internal/api/router.go
+++ b/internal/api/router.go
@@ -2271,6 +2271,7 @@ func NewRouter(deps Dependencies) chi.Router {
 
 						if readingMotivationHandler != nil {
 							r.Put("/reading-goals", readingMotivationHandler.HandlePutGoals)
+							r.Get("/reading-motivation", readingMotivationHandler.HandleGetMotivation)
 						}
 					})
 				}

--- a/internal/api/router.go
+++ b/internal/api/router.go
@@ -187,6 +187,11 @@ type Dependencies struct {
 	// clients hitting /login, /api/*, /abs/api/*, and /abs/socket.io/* all
 	// resolve correctly. May be nil; no ABS routes are registered in that case.
 	ABSHandler absHandler
+
+	// ReaderFontsDir is the base directory for custom reader font blobs
+	// (see handlers.ReaderFontsHandler). Empty disables the
+	// /ebooks/reader-fonts routes even when DB is set.
+	ReaderFontsDir string
 }
 
 // absHandler is the narrow interface the router needs from the ABS handler.
@@ -513,10 +518,17 @@ func NewRouter(deps Dependencies) chi.Router {
 	var ebookProgressStore *handlers.PGEbookReaderProgressStore
 	var ebookConfigStore *handlers.PGEbookReaderConfigStore
 	var ebookAnnotationStore *handlers.PGEbookReaderAnnotationStore
+	var readerFontsHandler *handlers.ReaderFontsHandler
 	if deps.DB != nil {
 		ebookProgressStore = handlers.NewPGEbookReaderProgressStore(deps.DB)
 		ebookConfigStore = handlers.NewPGEbookReaderConfigStore(deps.DB)
 		ebookAnnotationStore = handlers.NewPGEbookReaderAnnotationStore(deps.DB)
+		if deps.ReaderFontsDir != "" {
+			readerFontsHandler = &handlers.ReaderFontsHandler{
+				Store: handlers.NewPGReaderFontStore(deps.DB),
+				Dir:   deps.ReaderFontsDir,
+			}
+		}
 		browseRepo := catalog.NewBrowseRepository(deps.DB)
 		itemRepo = catalog.NewItemRepository(deps.DB)
 		searchIndexEvents := catalog.NewSearchIndexEventRepository(deps.DB)
@@ -2229,6 +2241,13 @@ func NewRouter(deps Dependencies) chi.Router {
 						r.Post("/{content_id}/annotations", ebookReaderHandler.HandleCreateAnnotation)
 						r.Patch("/{content_id}/annotations/{annotation_id}", ebookReaderHandler.HandleUpdateAnnotation)
 						r.Delete("/{content_id}/annotations/{annotation_id}", ebookReaderHandler.HandleDeleteAnnotation)
+
+						if readerFontsHandler != nil {
+							r.Get("/reader-fonts", readerFontsHandler.HandleList)
+							r.Post("/reader-fonts", readerFontsHandler.HandleUpload)
+							r.Delete("/reader-fonts/{font_id}", readerFontsHandler.HandleDelete)
+							r.Get("/reader-fonts/{font_id}/file", readerFontsHandler.HandleServeFile)
+						}
 					})
 				}
 

--- a/internal/api/router.go
+++ b/internal/api/router.go
@@ -2227,20 +2227,23 @@ func NewRouter(deps Dependencies) chi.Router {
 					})
 				}
 
-				if ebookReaderHandler != nil {
+				if ebookReaderHandler != nil || readerFontsHandler != nil {
 					r.Route("/ebooks", func(r chi.Router) {
 						r.Use(apimw.RequireProfile)
-						r.Get("/capability", ebookReaderHandler.HandleConversionCapability)
-						r.Get("/{content_id}/files/{file_id}/read", ebookReaderHandler.HandleReadFile)
-						r.Head("/{content_id}/files/{file_id}/read", ebookReaderHandler.HandleReadFile)
-						r.Get("/{content_id}/progress", ebookReaderHandler.HandleGetProgress)
-						r.Put("/{content_id}/progress", ebookReaderHandler.HandleSaveProgress)
-						r.Get("/{content_id}/reader-config", ebookReaderHandler.HandleGetConfig)
-						r.Put("/{content_id}/reader-config", ebookReaderHandler.HandleSaveConfig)
-						r.Get("/{content_id}/annotations", ebookReaderHandler.HandleListAnnotations)
-						r.Post("/{content_id}/annotations", ebookReaderHandler.HandleCreateAnnotation)
-						r.Patch("/{content_id}/annotations/{annotation_id}", ebookReaderHandler.HandleUpdateAnnotation)
-						r.Delete("/{content_id}/annotations/{annotation_id}", ebookReaderHandler.HandleDeleteAnnotation)
+
+						if ebookReaderHandler != nil {
+							r.Get("/capability", ebookReaderHandler.HandleConversionCapability)
+							r.Get("/{content_id}/files/{file_id}/read", ebookReaderHandler.HandleReadFile)
+							r.Head("/{content_id}/files/{file_id}/read", ebookReaderHandler.HandleReadFile)
+							r.Get("/{content_id}/progress", ebookReaderHandler.HandleGetProgress)
+							r.Put("/{content_id}/progress", ebookReaderHandler.HandleSaveProgress)
+							r.Get("/{content_id}/reader-config", ebookReaderHandler.HandleGetConfig)
+							r.Put("/{content_id}/reader-config", ebookReaderHandler.HandleSaveConfig)
+							r.Get("/{content_id}/annotations", ebookReaderHandler.HandleListAnnotations)
+							r.Post("/{content_id}/annotations", ebookReaderHandler.HandleCreateAnnotation)
+							r.Patch("/{content_id}/annotations/{annotation_id}", ebookReaderHandler.HandleUpdateAnnotation)
+							r.Delete("/{content_id}/annotations/{annotation_id}", ebookReaderHandler.HandleDeleteAnnotation)
+						}
 
 						if readerFontsHandler != nil {
 							r.Get("/reader-fonts", readerFontsHandler.HandleList)

--- a/internal/api/router.go
+++ b/internal/api/router.go
@@ -531,8 +531,9 @@ func NewRouter(deps Dependencies) chi.Router {
 			}
 		}
 		readingSessionsHandler = &handlers.ReadingSessionsHandler{
-			Store: handlers.NewPGReadingSessionStore(deps.DB),
-			Now:   func() time.Time { return time.Now().UTC() },
+			Store:    handlers.NewPGReadingSessionStore(deps.DB),
+			Now:      func() time.Time { return time.Now().UTC() },
+			Progress: handlers.EbookProgressAdapter{Store: ebookProgressStore},
 		}
 		browseRepo := catalog.NewBrowseRepository(deps.DB)
 		itemRepo = catalog.NewItemRepository(deps.DB)
@@ -2259,6 +2260,8 @@ func NewRouter(deps Dependencies) chi.Router {
 
 						if readingSessionsHandler != nil {
 							r.Post("/{content_id}/reading-heartbeat", readingSessionsHandler.HandleHeartbeat)
+							r.Get("/reading-stats", readingSessionsHandler.HandleHistory)
+							r.Get("/{content_id}/reading-stats", readingSessionsHandler.HandleBookStats)
 						}
 					})
 				}

--- a/internal/api/router.go
+++ b/internal/api/router.go
@@ -520,6 +520,7 @@ func NewRouter(deps Dependencies) chi.Router {
 	var ebookAnnotationStore *handlers.PGEbookReaderAnnotationStore
 	var readerFontsHandler *handlers.ReaderFontsHandler
 	var readingSessionsHandler *handlers.ReadingSessionsHandler
+	var readingMotivationHandler *handlers.ReadingMotivationHandler
 	if deps.DB != nil {
 		ebookProgressStore = handlers.NewPGEbookReaderProgressStore(deps.DB)
 		ebookConfigStore = handlers.NewPGEbookReaderConfigStore(deps.DB)
@@ -534,6 +535,10 @@ func NewRouter(deps Dependencies) chi.Router {
 			Store:    handlers.NewPGReadingSessionStore(deps.DB),
 			Now:      func() time.Time { return time.Now().UTC() },
 			Progress: handlers.EbookProgressAdapter{Store: ebookProgressStore},
+		}
+		readingMotivationHandler = &handlers.ReadingMotivationHandler{
+			Store: handlers.NewPGReadingMotivationStore(deps.DB),
+			Now:   func() time.Time { return time.Now().UTC() },
 		}
 		browseRepo := catalog.NewBrowseRepository(deps.DB)
 		itemRepo = catalog.NewItemRepository(deps.DB)
@@ -2233,7 +2238,7 @@ func NewRouter(deps Dependencies) chi.Router {
 					})
 				}
 
-				if ebookReaderHandler != nil || readerFontsHandler != nil || readingSessionsHandler != nil {
+				if ebookReaderHandler != nil || readerFontsHandler != nil || readingSessionsHandler != nil || readingMotivationHandler != nil {
 					r.Route("/ebooks", func(r chi.Router) {
 						r.Use(apimw.RequireProfile)
 
@@ -2262,6 +2267,10 @@ func NewRouter(deps Dependencies) chi.Router {
 							r.Post("/{content_id}/reading-heartbeat", readingSessionsHandler.HandleHeartbeat)
 							r.Get("/reading-stats", readingSessionsHandler.HandleHistory)
 							r.Get("/{content_id}/reading-stats", readingSessionsHandler.HandleBookStats)
+						}
+
+						if readingMotivationHandler != nil {
+							r.Put("/reading-goals", readingMotivationHandler.HandlePutGoals)
 						}
 					})
 				}

--- a/internal/api/router.go
+++ b/internal/api/router.go
@@ -519,6 +519,7 @@ func NewRouter(deps Dependencies) chi.Router {
 	var ebookConfigStore *handlers.PGEbookReaderConfigStore
 	var ebookAnnotationStore *handlers.PGEbookReaderAnnotationStore
 	var readerFontsHandler *handlers.ReaderFontsHandler
+	var readingSessionsHandler *handlers.ReadingSessionsHandler
 	if deps.DB != nil {
 		ebookProgressStore = handlers.NewPGEbookReaderProgressStore(deps.DB)
 		ebookConfigStore = handlers.NewPGEbookReaderConfigStore(deps.DB)
@@ -528,6 +529,10 @@ func NewRouter(deps Dependencies) chi.Router {
 				Store: handlers.NewPGReaderFontStore(deps.DB),
 				Dir:   deps.ReaderFontsDir,
 			}
+		}
+		readingSessionsHandler = &handlers.ReadingSessionsHandler{
+			Store: handlers.NewPGReadingSessionStore(deps.DB),
+			Now:   func() time.Time { return time.Now().UTC() },
 		}
 		browseRepo := catalog.NewBrowseRepository(deps.DB)
 		itemRepo = catalog.NewItemRepository(deps.DB)
@@ -2227,7 +2232,7 @@ func NewRouter(deps Dependencies) chi.Router {
 					})
 				}
 
-				if ebookReaderHandler != nil || readerFontsHandler != nil {
+				if ebookReaderHandler != nil || readerFontsHandler != nil || readingSessionsHandler != nil {
 					r.Route("/ebooks", func(r chi.Router) {
 						r.Use(apimw.RequireProfile)
 
@@ -2250,6 +2255,10 @@ func NewRouter(deps Dependencies) chi.Router {
 							r.Post("/reader-fonts", readerFontsHandler.HandleUpload)
 							r.Delete("/reader-fonts/{font_id}", readerFontsHandler.HandleDelete)
 							r.Get("/reader-fonts/{font_id}/file", readerFontsHandler.HandleServeFile)
+						}
+
+						if readingSessionsHandler != nil {
+							r.Post("/{content_id}/reading-heartbeat", readingSessionsHandler.HandleHeartbeat)
 						}
 					})
 				}

--- a/migrations/sql/20260720190000_reader_fonts.sql
+++ b/migrations/sql/20260720190000_reader_fonts.sql
@@ -1,0 +1,15 @@
+-- +goose Up
+CREATE TABLE IF NOT EXISTS reader_fonts (
+    id BIGINT GENERATED ALWAYS AS IDENTITY PRIMARY KEY,
+    user_id INTEGER NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+    profile_id TEXT NOT NULL,
+    name TEXT NOT NULL,
+    filename TEXT NOT NULL,
+    format TEXT NOT NULL,
+    size_bytes BIGINT NOT NULL,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+CREATE INDEX IF NOT EXISTS idx_reader_fonts_owner ON reader_fonts (user_id, profile_id);
+
+-- +goose Down
+DROP TABLE IF EXISTS reader_fonts;

--- a/migrations/sql/20260720210000_reading_sessions.sql
+++ b/migrations/sql/20260720210000_reading_sessions.sql
@@ -1,0 +1,19 @@
+-- +goose Up
+CREATE TABLE IF NOT EXISTS reading_sessions (
+    id BIGINT GENERATED ALWAYS AS IDENTITY PRIMARY KEY,
+    user_id INTEGER NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+    profile_id TEXT NOT NULL,
+    content_id TEXT NOT NULL,
+    started_at TIMESTAMPTZ NOT NULL,
+    last_heartbeat_at TIMESTAMPTZ NOT NULL,
+    duration_seconds INTEGER NOT NULL DEFAULT 0,
+    start_fraction REAL NOT NULL,
+    end_fraction REAL NOT NULL
+);
+CREATE INDEX IF NOT EXISTS idx_reading_sessions_recency
+    ON reading_sessions (user_id, profile_id, last_heartbeat_at);
+CREATE INDEX IF NOT EXISTS idx_reading_sessions_book
+    ON reading_sessions (user_id, profile_id, content_id);
+
+-- +goose Down
+DROP TABLE IF EXISTS reading_sessions;

--- a/migrations/sql/20260720230000_reading_motivation.sql
+++ b/migrations/sql/20260720230000_reading_motivation.sql
@@ -1,0 +1,20 @@
+-- +goose Up
+CREATE TABLE IF NOT EXISTS reading_goals (
+    user_id INTEGER NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+    profile_id TEXT NOT NULL,
+    books_per_year INTEGER,
+    hours_per_year INTEGER,
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    PRIMARY KEY (user_id, profile_id)
+);
+CREATE TABLE IF NOT EXISTS reading_achievements (
+    user_id INTEGER NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+    profile_id TEXT NOT NULL,
+    achievement_id TEXT NOT NULL,
+    achieved_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    PRIMARY KEY (user_id, profile_id, achievement_id)
+);
+
+-- +goose Down
+DROP TABLE IF EXISTS reading_achievements;
+DROP TABLE IF EXISTS reading_goals;

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -36,6 +36,7 @@ import Catalog from "@/pages/Catalog";
 import LibraryPage from "@/pages/LibraryPage";
 import ItemDetail from "@/pages/ItemDetail/index";
 import EbookReader from "@/pages/EbookReader";
+import ReadingStats from "@/pages/ReadingStats";
 import PersonDetail from "@/pages/PersonDetail";
 import Collections from "@/pages/Collections";
 import CollectionEditor from "@/pages/CollectionEditor";
@@ -491,6 +492,7 @@ function AppRoutes() {
                             }
                           />
                           <Route path="/catalog" element={<Catalog />} />
+                          <Route path="/reading-stats" element={<ReadingStats />} />
                           <Route path="/library/:libraryId" element={<LibraryPage />} />
                           <Route path="/search" element={<LegacySearchRedirect />} />
                           <Route path="/browse" element={<LegacyBrowseRedirect />} />

--- a/web/src/components/AppSidebar.tsx
+++ b/web/src/components/AppSidebar.tsx
@@ -60,6 +60,7 @@ import {
   LayoutGrid,
   Puzzle,
   BookHeadphones,
+  BookOpen,
   Send,
   Bell,
 } from "lucide-react";
@@ -721,6 +722,23 @@ export default function AppSidebar({ onNavigate, collapsed = false }: AppSidebar
                 )}
                 <Clock className="h-[18px] w-[18px] shrink-0" />
                 <SidebarLabel show={showLabels}>History</SidebarLabel>
+              </ViewTransitionLink>
+            </li>
+            <li>
+              <ViewTransitionLink
+                to="/reading-stats"
+                onClick={onNavigate}
+                className={navLinkClass("/reading-stats")}
+                aria-current={isActive("/reading-stats") ? "page" : undefined}
+              >
+                {isActive("/reading-stats") && (
+                  <span
+                    className="absolute top-1/2 left-0 h-[18px] w-[3px] -translate-y-1/2 rounded-r-sm"
+                    style={{ background: "var(--primary)" }}
+                  />
+                )}
+                <BookOpen className="h-[18px] w-[18px] shrink-0" />
+                <SidebarLabel show={showLabels}>Reading stats</SidebarLabel>
               </ViewTransitionLink>
             </li>
           </ul>

--- a/web/src/components/stats/MotivationSections.test.tsx
+++ b/web/src/components/stats/MotivationSections.test.tsx
@@ -1,12 +1,17 @@
-import { render, screen } from "@testing-library/react";
+import { render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { renderToStaticMarkup } from "react-dom/server";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
-const mockPutReadingGoals = vi.fn();
+// Stubs useSaveReadingGoals's mutateAsync directly (rather than routing
+// through a real QueryClientProvider + react-query mutation) so these tests
+// stay focused on GoalsForm's own save/error/retry bookkeeping. The
+// invalidate-on-success behavior of the real useSaveReadingGoals hook is
+// covered at the hook level in readingStats.test.ts.
+const mockSaveGoals = vi.fn();
 
 vi.mock("@/hooks/queries/readingStats", () => ({
-  putReadingGoals: (...args: unknown[]) => mockPutReadingGoals(...args),
+  useSaveReadingGoals: () => ({ mutateAsync: (...args: unknown[]) => mockSaveGoals(...args) }),
 }));
 
 import {
@@ -111,8 +116,8 @@ describe("StreakChallengeSection", () => {
 
 describe("GoalsSection", () => {
   beforeEach(() => {
-    mockPutReadingGoals.mockReset();
-    mockPutReadingGoals.mockResolvedValue(undefined);
+    mockSaveGoals.mockReset();
+    mockSaveGoals.mockResolvedValue(undefined);
   });
 
   it("prefills inputs from the goals payload", () => {
@@ -130,7 +135,7 @@ describe("GoalsSection", () => {
     await user.type(booksInput, "30");
     await user.tab();
 
-    expect(mockPutReadingGoals).toHaveBeenCalledWith({
+    expect(mockSaveGoals).toHaveBeenCalledWith({
       books_per_year: 30,
       hours_per_year: 100,
     });
@@ -144,7 +149,7 @@ describe("GoalsSection", () => {
     await user.click(booksInput);
     await user.tab();
 
-    expect(mockPutReadingGoals).not.toHaveBeenCalled();
+    expect(mockSaveGoals).not.toHaveBeenCalled();
   });
 
   it("shows an inline error and does not call putReadingGoals for an invalid (0) value", async () => {
@@ -157,7 +162,7 @@ describe("GoalsSection", () => {
     await user.tab();
 
     expect(await screen.findByText(/between 1 and 100000/)).toBeInTheDocument();
-    expect(mockPutReadingGoals).not.toHaveBeenCalled();
+    expect(mockSaveGoals).not.toHaveBeenCalled();
   });
 
   it("shows an inline error and does not call putReadingGoals for a negative value", async () => {
@@ -170,12 +175,58 @@ describe("GoalsSection", () => {
     await user.tab();
 
     expect(await screen.findByText(/between 1 and 100000/)).toBeInTheDocument();
-    expect(mockPutReadingGoals).not.toHaveBeenCalled();
+    expect(mockSaveGoals).not.toHaveBeenCalled();
   });
 
   it("renders an empty state when goals is null", () => {
     render(<GoalsSection goals={null} />);
     expect(screen.getByText(/No goals data yet/)).toBeInTheDocument();
+  });
+
+  it("shows an inline error and keeps the value retryable when the save rejects", async () => {
+    mockSaveGoals.mockRejectedValueOnce(new Error("boom"));
+    const user = userEvent.setup();
+    render(<GoalsSection goals={goalsFixture} />);
+
+    const booksInput = screen.getByLabelText(/Books per year/);
+    await user.clear(booksInput);
+    await user.type(booksInput, "30");
+    await user.tab();
+
+    expect(await screen.findByText(/Failed to save reading goals/)).toBeInTheDocument();
+    expect(mockSaveGoals).toHaveBeenCalledTimes(1);
+
+    // The ref was NOT advanced on failure, so blurring again with the same
+    // (still-unsaved) value must retry the PUT rather than short-circuiting.
+    await user.click(booksInput);
+    await user.tab();
+
+    expect(mockSaveGoals).toHaveBeenCalledTimes(2);
+    expect(mockSaveGoals).toHaveBeenLastCalledWith({
+      books_per_year: 30,
+      hours_per_year: 100,
+    });
+  });
+
+  it("clears the inline error once a retry succeeds", async () => {
+    mockSaveGoals.mockRejectedValueOnce(new Error("boom"));
+    const user = userEvent.setup();
+    render(<GoalsSection goals={goalsFixture} />);
+
+    const booksInput = screen.getByLabelText(/Books per year/);
+    await user.clear(booksInput);
+    await user.type(booksInput, "30");
+    await user.tab();
+    expect(await screen.findByText(/Failed to save reading goals/)).toBeInTheDocument();
+
+    mockSaveGoals.mockResolvedValueOnce(undefined);
+    await user.click(booksInput);
+    await user.tab();
+
+    expect(mockSaveGoals).toHaveBeenCalledTimes(2);
+    await waitFor(() =>
+      expect(screen.queryByText(/Failed to save reading goals/)).not.toBeInTheDocument(),
+    );
   });
 });
 

--- a/web/src/components/stats/MotivationSections.test.tsx
+++ b/web/src/components/stats/MotivationSections.test.tsx
@@ -208,6 +208,52 @@ describe("GoalsSection", () => {
     });
   });
 
+  it("carries the live value of the other field when two saves race", async () => {
+    const user = userEvent.setup();
+    render(<GoalsSection goals={goalsFixture} />);
+
+    let resolveFirst: (() => void) | undefined;
+    let resolveSecond: (() => void) | undefined;
+    mockSaveGoals.mockImplementationOnce(
+      () =>
+        new Promise<void>((resolve) => {
+          resolveFirst = resolve;
+        }),
+    );
+    mockSaveGoals.mockImplementationOnce(
+      () =>
+        new Promise<void>((resolve) => {
+          resolveSecond = resolve;
+        }),
+    );
+
+    const booksInput = screen.getByLabelText(/Books per year/);
+    const hoursInput = screen.getByLabelText(/Hours per year/);
+
+    // Blur books=30 while its PUT is still pending (not yet resolved, so
+    // savedRef.current.books has NOT advanced past the old saved value 24).
+    await user.clear(booksInput);
+    await user.type(booksInput, "30");
+    await user.tab();
+
+    // Blur hours=150 before the first PUT resolves. The second PUT's payload
+    // must carry the LIVE books value (30) typed into the input, not the
+    // stale savedRef value (24).
+    await user.clear(hoursInput);
+    await user.type(hoursInput, "150");
+    await user.tab();
+
+    expect(mockSaveGoals).toHaveBeenCalledTimes(2);
+    expect(mockSaveGoals).toHaveBeenNthCalledWith(2, {
+      books_per_year: 30,
+      hours_per_year: 150,
+    });
+
+    resolveFirst?.();
+    resolveSecond?.();
+    await waitFor(() => expect(screen.queryByText(/Failed to save reading goals/)).toBeNull());
+  });
+
   it("clears the inline error once a retry succeeds", async () => {
     mockSaveGoals.mockRejectedValueOnce(new Error("boom"));
     const user = userEvent.setup();

--- a/web/src/components/stats/MotivationSections.test.tsx
+++ b/web/src/components/stats/MotivationSections.test.tsx
@@ -1,0 +1,235 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { renderToStaticMarkup } from "react-dom/server";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mockPutReadingGoals = vi.fn();
+
+vi.mock("@/hooks/queries/readingStats", () => ({
+  putReadingGoals: (...args: unknown[]) => mockPutReadingGoals(...args),
+}));
+
+import {
+  AchievementsSection,
+  GoalsSection,
+  ReadingDnaSection,
+  StreakChallengeSection,
+} from "./MotivationSections";
+import type {
+  ReadingMotivationAchievement,
+  ReadingMotivationChallenge,
+  ReadingMotivationDNA,
+  ReadingMotivationGoals,
+  ReadingMotivationStreak,
+} from "@/hooks/queries/readingStats";
+
+const streakFixture: ReadingMotivationStreak = {
+  current_days: 5,
+  longest_days: 12,
+  today_seconds: 900,
+  today_qualified: true,
+};
+
+const challengeFixture: ReadingMotivationChallenge = {
+  target_seconds: 10000,
+  month_seconds: 4000,
+  percent: 40,
+};
+
+const goalsFixture: ReadingMotivationGoals = {
+  books_per_year: 24,
+  hours_per_year: 100,
+  books_finished_ytd: 6,
+  hours_ytd: 42.5,
+  books_on_track_for: 12,
+  hours_on_track_for: 85,
+};
+
+function achievement(
+  overrides: Partial<ReadingMotivationAchievement> & Pick<ReadingMotivationAchievement, "id">,
+): ReadingMotivationAchievement {
+  return {
+    category: "time",
+    name: overrides.id,
+    description: `Description for ${overrides.id}`,
+    achieved_at: null,
+    ...overrides,
+  };
+}
+
+const eighteenAchievements: ReadingMotivationAchievement[] = [
+  achievement({ id: "first-hour", category: "time", achieved_at: "2026-01-05T00:00:00Z" }),
+  achievement({ id: "ten-hours", category: "time" }),
+  achievement({ id: "fifty-hours", category: "time" }),
+  achievement({ id: "hundred-hours", category: "time" }),
+  achievement({ id: "marathon-session", category: "time" }),
+  achievement({ id: "streak-3", category: "streak", achieved_at: "2026-02-01T00:00:00Z" }),
+  achievement({ id: "streak-7", category: "streak" }),
+  achievement({ id: "streak-30", category: "streak" }),
+  achievement({ id: "streak-100", category: "streak" }),
+  achievement({ id: "first-book", category: "books", achieved_at: "2026-03-01T00:00:00Z" }),
+  achievement({ id: "ten-books", category: "books" }),
+  achievement({ id: "fifty-books", category: "books" }),
+  achievement({ id: "night-owl", category: "habits" }),
+  achievement({ id: "early-bird", category: "habits" }),
+  achievement({ id: "weekender", category: "habits" }),
+  achievement({ id: "genre-hopper", category: "exploration" }),
+  achievement({ id: "deep-diver", category: "exploration" }),
+  achievement({ id: "finisher", category: "exploration" }),
+];
+
+const dnaFixture: ReadingMotivationDNA = {
+  genres: [
+    { name: "Sci-Fi", seconds: 7200 },
+    { name: "Fantasy", seconds: 3600 },
+  ],
+  authors: [
+    { name: "Andy Weir", seconds: 5400 },
+    { name: "N.K. Jemisin", seconds: 1800 },
+  ],
+  diversity_score: 62,
+  avg_session_seconds: 1500,
+  hours_by_bucket: { morning: 2, afternoon: 1, evening: 4, night: 0 },
+  projected_year_hours: 87.3,
+};
+
+describe("StreakChallengeSection", () => {
+  it("shows current/longest streak and the challenge percent bar width", () => {
+    render(<StreakChallengeSection streak={streakFixture} challenge={challengeFixture} />);
+    expect(screen.getByText("5 days")).toBeInTheDocument();
+    expect(screen.getByText(/Longest streak: 12 days/)).toBeInTheDocument();
+
+    const bar = screen.getByRole("progressbar");
+    expect(bar).toHaveAttribute("aria-valuenow", "40");
+  });
+
+  it("renders an empty state when both streak and challenge are missing", () => {
+    render(<StreakChallengeSection streak={null} challenge={undefined} />);
+    expect(screen.getByText(/No streak data yet/)).toBeInTheDocument();
+  });
+});
+
+describe("GoalsSection", () => {
+  beforeEach(() => {
+    mockPutReadingGoals.mockReset();
+    mockPutReadingGoals.mockResolvedValue(undefined);
+  });
+
+  it("prefills inputs from the goals payload", () => {
+    render(<GoalsSection goals={goalsFixture} />);
+    expect(screen.getByLabelText(/Books per year/)).toHaveValue("24");
+    expect(screen.getByLabelText(/Hours per year/)).toHaveValue("100");
+  });
+
+  it("calls putReadingGoals on blur with a changed value, sending both current fields", async () => {
+    const user = userEvent.setup();
+    render(<GoalsSection goals={goalsFixture} />);
+
+    const booksInput = screen.getByLabelText(/Books per year/);
+    await user.clear(booksInput);
+    await user.type(booksInput, "30");
+    await user.tab();
+
+    expect(mockPutReadingGoals).toHaveBeenCalledWith({
+      books_per_year: 30,
+      hours_per_year: 100,
+    });
+  });
+
+  it("does not call putReadingGoals on blur when the value is unchanged", async () => {
+    const user = userEvent.setup();
+    render(<GoalsSection goals={goalsFixture} />);
+
+    const booksInput = screen.getByLabelText(/Books per year/);
+    await user.click(booksInput);
+    await user.tab();
+
+    expect(mockPutReadingGoals).not.toHaveBeenCalled();
+  });
+
+  it("shows an inline error and does not call putReadingGoals for an invalid (0) value", async () => {
+    const user = userEvent.setup();
+    render(<GoalsSection goals={goalsFixture} />);
+
+    const booksInput = screen.getByLabelText(/Books per year/);
+    await user.clear(booksInput);
+    await user.type(booksInput, "0");
+    await user.tab();
+
+    expect(await screen.findByText(/between 1 and 100000/)).toBeInTheDocument();
+    expect(mockPutReadingGoals).not.toHaveBeenCalled();
+  });
+
+  it("shows an inline error and does not call putReadingGoals for a negative value", async () => {
+    const user = userEvent.setup();
+    render(<GoalsSection goals={goalsFixture} />);
+
+    const hoursInput = screen.getByLabelText(/Hours per year/);
+    await user.clear(hoursInput);
+    await user.type(hoursInput, "-5");
+    await user.tab();
+
+    expect(await screen.findByText(/between 1 and 100000/)).toBeInTheDocument();
+    expect(mockPutReadingGoals).not.toHaveBeenCalled();
+  });
+
+  it("renders an empty state when goals is null", () => {
+    render(<GoalsSection goals={null} />);
+    expect(screen.getByText(/No goals data yet/)).toBeInTheDocument();
+  });
+});
+
+describe("AchievementsSection", () => {
+  it("renders all 18 achievements grouped by category", () => {
+    const markup = renderToStaticMarkup(
+      <AchievementsSection achievements={eighteenAchievements} />,
+    );
+    for (const a of eighteenAchievements) {
+      expect(markup).toContain(a.description);
+    }
+  });
+
+  it("dims locked achievements with data-locked and aria-disabled", () => {
+    render(<AchievementsSection achievements={eighteenAchievements} />);
+    const locked = document.querySelector('[data-locked="true"]');
+    expect(locked).not.toBeNull();
+    expect(locked).toHaveAttribute("aria-disabled", "true");
+  });
+
+  it("shows the achieved date for achieved badges", () => {
+    render(<AchievementsSection achievements={eighteenAchievements} />);
+    // first-hour achieved_at is 2026-01-05T00:00:00Z
+    expect(screen.getByText("Jan 5, 2026")).toBeInTheDocument();
+  });
+
+  it("renders an empty state when achievements is null", () => {
+    render(<AchievementsSection achievements={null} />);
+    expect(screen.getByText(/No achievements yet/)).toBeInTheDocument();
+  });
+
+  it("renders an empty state when achievements is an empty array", () => {
+    render(<AchievementsSection achievements={[]} />);
+    expect(screen.getByText(/No achievements yet/)).toBeInTheDocument();
+  });
+});
+
+describe("ReadingDnaSection", () => {
+  it("renders top genre bars, authors, diversity score, buckets, and projection", () => {
+    render(<ReadingDnaSection dna={dnaFixture} />);
+    expect(screen.getByText("Sci-Fi")).toBeInTheDocument();
+    expect(screen.getByText("Andy Weir")).toBeInTheDocument();
+    expect(screen.getByText("62")).toBeInTheDocument();
+    expect(screen.getByText("evening")).toBeInTheDocument();
+    expect(screen.getByText(/On pace for 87h this year/)).toBeInTheDocument();
+  });
+
+  it("renders an empty state when dna is null", () => {
+    render(<ReadingDnaSection dna={null} />);
+    expect(screen.getByText(/No reading DNA yet/)).toBeInTheDocument();
+  });
+
+  it("renders an empty state when both genres and authors are empty", () => {
+    render(<ReadingDnaSection dna={{ ...dnaFixture, genres: [], authors: [] }} />);
+    expect(screen.getByText(/No reading DNA yet/)).toBeInTheDocument();
+  });
+});

--- a/web/src/components/stats/MotivationSections.test.tsx
+++ b/web/src/components/stats/MotivationSections.test.tsx
@@ -100,9 +100,14 @@ const dnaFixture: ReadingMotivationDNA = {
 
 describe("StreakChallengeSection", () => {
   it("shows current/longest streak and the challenge percent bar width", () => {
-    render(<StreakChallengeSection streak={streakFixture} challenge={challengeFixture} />);
+    const { container } = render(
+      <StreakChallengeSection streak={streakFixture} challenge={challengeFixture} />,
+    );
     expect(screen.getByText("5 days")).toBeInTheDocument();
     expect(screen.getByText(/Longest streak: 12 days/)).toBeInTheDocument();
+
+    // The streak count carries a flame icon, per the streaks/goals spec.
+    expect(container.querySelector("svg.lucide-flame")).toBeInTheDocument();
 
     const bar = screen.getByRole("progressbar");
     expect(bar).toHaveAttribute("aria-valuenow", "40");

--- a/web/src/components/stats/MotivationSections.tsx
+++ b/web/src/components/stats/MotivationSections.tsx
@@ -154,15 +154,29 @@ function GoalsForm({ goals }: { goals: ReadingMotivationGoals }) {
 
   const { mutateAsync: saveGoals } = useSaveReadingGoals();
 
-  // Tracks the last value actually *persisted*, so a blur that didn't change
-  // anything skips the PUT, and so a PUT for one field can still send the
-  // other field's current value. Only advanced after a successful save —
-  // if the PUT fails, the ref stays put so the next blur (even with the same
-  // unsaved value) retries instead of silently no-opping forever.
+  // Tracks the last value actually *persisted*, used only to (a) short-
+  // circuit a blur that didn't change anything, and (b) retry semantics
+  // after a failed save (see below). Only advanced after a successful save
+  // — if the PUT fails, the ref stays put so the next blur (even with the
+  // same unsaved value) retries instead of silently no-opping forever.
+  //
+  // NEVER read from this ref to build a PUT payload's *contents* — blurring
+  // one field while the other field's save is still in flight would read a
+  // savedRef value that hasn't advanced yet, sending a stale value that can
+  // land after (and silently revert) the other field's in-flight save.
+  // Payloads must always be built from the live controlled input state of
+  // both fields instead.
   const savedRef = useRef({ books: savedBooks, hours: savedHours });
 
   function saveFailureMessage(err: unknown): string {
     return err instanceof ApiClientError ? err.message : "Failed to save reading goals.";
+  }
+
+  // Resolves the *other* field's live value for a PUT payload: the input's
+  // own current text if it currently parses, else its last-saved value.
+  function otherFieldValue(input: string, saved: number | null): number | null {
+    const parsed = parseGoalInput(input);
+    return parsed === "invalid" ? saved : parsed;
   }
 
   async function commitBooks() {
@@ -173,9 +187,10 @@ function GoalsForm({ goals }: { goals: ReadingMotivationGoals }) {
     }
     setBooksError(null);
     if (parsed === savedRef.current.books) return;
+    const hours = otherFieldValue(hoursInput, savedRef.current.hours);
     try {
-      await saveGoals({ books_per_year: parsed, hours_per_year: savedRef.current.hours });
-      savedRef.current.books = parsed;
+      await saveGoals({ books_per_year: parsed, hours_per_year: hours });
+      savedRef.current = { books: parsed, hours };
       setSaveError(null);
     } catch (err) {
       setSaveError(saveFailureMessage(err));
@@ -190,9 +205,10 @@ function GoalsForm({ goals }: { goals: ReadingMotivationGoals }) {
     }
     setHoursError(null);
     if (parsed === savedRef.current.hours) return;
+    const books = otherFieldValue(booksInput, savedRef.current.books);
     try {
-      await saveGoals({ books_per_year: savedRef.current.books, hours_per_year: parsed });
-      savedRef.current.hours = parsed;
+      await saveGoals({ books_per_year: books, hours_per_year: parsed });
+      savedRef.current = { books, hours: parsed };
       setSaveError(null);
     } catch (err) {
       setSaveError(saveFailureMessage(err));

--- a/web/src/components/stats/MotivationSections.tsx
+++ b/web/src/components/stats/MotivationSections.tsx
@@ -1,3 +1,4 @@
+import { Flame } from "lucide-react";
 import { useRef, useState, type FormEvent } from "react";
 
 import { ApiClientError } from "@/api/client";
@@ -59,7 +60,14 @@ export function StreakChallengeSection({ streak, challenge }: StreakChallengeSec
         <CardContent>
           {streak ? (
             <div className="space-y-1">
-              <div className="text-3xl font-semibold tracking-tight">
+              <div className="flex items-center gap-2 text-3xl font-semibold tracking-tight">
+                <Flame
+                  className={cn(
+                    "h-6 w-6",
+                    streak.today_qualified ? "text-primary" : "text-muted-foreground",
+                  )}
+                  aria-hidden="true"
+                />
                 {streak.current_days} {streak.current_days === 1 ? "day" : "days"}
               </div>
               <p className="text-muted-foreground text-sm">

--- a/web/src/components/stats/MotivationSections.tsx
+++ b/web/src/components/stats/MotivationSections.tsx
@@ -1,0 +1,392 @@
+import { useRef, useState, type FormEvent } from "react";
+
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Input } from "@/components/ui/input";
+import { Progress } from "@/components/ui/progress";
+import {
+  putReadingGoals,
+  type ReadingMotivationAchievement,
+  type ReadingMotivationChallenge,
+  type ReadingMotivationDNA,
+  type ReadingMotivationGoals,
+  type ReadingMotivationStreak,
+} from "@/hooks/queries/readingStats";
+import { formatDate } from "@/lib/datetime";
+import { formatDuration } from "@/lib/formatDuration";
+import { cn } from "@/lib/utils";
+
+// Yearly goal bounds, mirrored client-side from HandlePutGoals so an
+// obviously invalid value is caught before round-tripping to the server.
+const MIN_YEARLY_GOAL = 1;
+const MAX_YEARLY_GOAL = 100000;
+const GOAL_RANGE_ERROR = `Enter a number between ${MIN_YEARLY_GOAL} and ${MAX_YEARLY_GOAL}.`;
+
+function EmptyCard({ title, message }: { title: string; message: string }) {
+  return (
+    <Card className="rounded-2xl border-0 shadow-none">
+      <CardHeader>
+        <CardTitle className="text-base font-semibold">{title}</CardTitle>
+      </CardHeader>
+      <CardContent>
+        <p className="text-muted-foreground text-sm">{message}</p>
+      </CardContent>
+    </Card>
+  );
+}
+
+export interface StreakChallengeSectionProps {
+  streak: ReadingMotivationStreak | null | undefined;
+  challenge: ReadingMotivationChallenge | null | undefined;
+}
+
+export function StreakChallengeSection({ streak, challenge }: StreakChallengeSectionProps) {
+  if (!streak && !challenge) {
+    return (
+      <EmptyCard
+        title="Streaks & challenge"
+        message="No streak data yet — start reading to build one up."
+      />
+    );
+  }
+
+  return (
+    <div className="grid grid-cols-1 gap-4 sm:grid-cols-2">
+      <Card className="rounded-2xl border-0 shadow-none">
+        <CardHeader>
+          <CardTitle className="text-base font-semibold">Reading streak</CardTitle>
+        </CardHeader>
+        <CardContent>
+          {streak ? (
+            <div className="space-y-1">
+              <div className="text-3xl font-semibold tracking-tight">
+                {streak.current_days} {streak.current_days === 1 ? "day" : "days"}
+              </div>
+              <p className="text-muted-foreground text-sm">
+                Longest streak: {streak.longest_days} {streak.longest_days === 1 ? "day" : "days"}
+              </p>
+              <p className="text-muted-foreground text-xs">
+                {streak.today_qualified
+                  ? "Today counts toward your streak."
+                  : `${formatDuration(streak.today_seconds)} read today.`}
+              </p>
+            </div>
+          ) : (
+            <p className="text-muted-foreground text-sm">No streak data yet.</p>
+          )}
+        </CardContent>
+      </Card>
+
+      <Card className="rounded-2xl border-0 shadow-none">
+        <CardHeader>
+          <CardTitle className="text-base font-semibold">Monthly challenge</CardTitle>
+        </CardHeader>
+        <CardContent>
+          {challenge ? (
+            <div className="space-y-2">
+              <p className="text-muted-foreground text-sm">
+                {formatDuration(challenge.month_seconds)} of{" "}
+                {formatDuration(challenge.target_seconds)}
+              </p>
+              <Progress value={challenge.percent} />
+              <p className="text-muted-foreground text-xs">{challenge.percent}% complete</p>
+            </div>
+          ) : (
+            <p className="text-muted-foreground text-sm">No challenge data yet.</p>
+          )}
+        </CardContent>
+      </Card>
+    </div>
+  );
+}
+
+export interface GoalsSectionProps {
+  goals: ReadingMotivationGoals | null | undefined;
+}
+
+function goalDisplayValue(value: number | null): string {
+  return value == null ? "" : String(value);
+}
+
+/** Parses a goal input's raw text: "" -> cleared (null), else a validated integer. */
+function parseGoalInput(raw: string): number | null | "invalid" {
+  const trimmed = raw.trim();
+  if (trimmed === "") return null;
+  const parsed = Number(trimmed);
+  if (!Number.isInteger(parsed) || parsed < MIN_YEARLY_GOAL || parsed > MAX_YEARLY_GOAL) {
+    return "invalid";
+  }
+  return parsed;
+}
+
+export function GoalsSection({ goals }: GoalsSectionProps) {
+  if (!goals) {
+    return (
+      <EmptyCard
+        title="Reading goals"
+        message="No goals data yet — set a books or hours target below once it loads."
+      />
+    );
+  }
+
+  // Remounted (via key, below) whenever the server's saved values change, so
+  // each instance's local input/error state simply starts fresh from props
+  // instead of needing an effect to re-sync it.
+  return (
+    <GoalsForm
+      key={`${goals.books_per_year ?? "none"}-${goals.hours_per_year ?? "none"}`}
+      goals={goals}
+    />
+  );
+}
+
+function GoalsForm({ goals }: { goals: ReadingMotivationGoals }) {
+  const savedBooks = goals.books_per_year;
+  const savedHours = goals.hours_per_year;
+
+  const [booksInput, setBooksInput] = useState(() => goalDisplayValue(savedBooks));
+  const [hoursInput, setHoursInput] = useState(() => goalDisplayValue(savedHours));
+  const [booksError, setBooksError] = useState<string | null>(null);
+  const [hoursError, setHoursError] = useState<string | null>(null);
+
+  // Tracks the last value actually persisted, so a blur that didn't change
+  // anything skips the PUT, and so a PUT for one field can still send the
+  // other field's current value.
+  const savedRef = useRef({ books: savedBooks, hours: savedHours });
+
+  async function commitBooks() {
+    const parsed = parseGoalInput(booksInput);
+    if (parsed === "invalid") {
+      setBooksError(GOAL_RANGE_ERROR);
+      return;
+    }
+    setBooksError(null);
+    if (parsed === savedRef.current.books) return;
+    savedRef.current.books = parsed;
+    await putReadingGoals({ books_per_year: parsed, hours_per_year: savedRef.current.hours });
+  }
+
+  async function commitHours() {
+    const parsed = parseGoalInput(hoursInput);
+    if (parsed === "invalid") {
+      setHoursError(GOAL_RANGE_ERROR);
+      return;
+    }
+    setHoursError(null);
+    if (parsed === savedRef.current.hours) return;
+    savedRef.current.hours = parsed;
+    await putReadingGoals({ books_per_year: savedRef.current.books, hours_per_year: parsed });
+  }
+
+  function preventSubmit(e: FormEvent) {
+    e.preventDefault();
+  }
+
+  return (
+    <Card className="rounded-2xl border-0 shadow-none">
+      <CardHeader>
+        <CardTitle className="text-base font-semibold">Reading goals</CardTitle>
+      </CardHeader>
+      <CardContent>
+        <form className="grid grid-cols-1 gap-4 sm:grid-cols-2" onSubmit={preventSubmit}>
+          <div className="space-y-1.5">
+            <label htmlFor="goal-books-per-year" className="text-sm font-medium">
+              Books per year
+            </label>
+            <Input
+              id="goal-books-per-year"
+              inputMode="numeric"
+              value={booksInput}
+              aria-invalid={booksError != null}
+              onChange={(e) => setBooksInput(e.target.value)}
+              onBlur={() => void commitBooks()}
+            />
+            {booksError ? <p className="text-destructive text-xs">{booksError}</p> : null}
+            <p className="text-muted-foreground text-xs">
+              {goals.books_finished_ytd} finished this year · on track for{" "}
+              {goals.books_on_track_for}
+            </p>
+          </div>
+
+          <div className="space-y-1.5">
+            <label htmlFor="goal-hours-per-year" className="text-sm font-medium">
+              Hours per year
+            </label>
+            <Input
+              id="goal-hours-per-year"
+              inputMode="numeric"
+              value={hoursInput}
+              aria-invalid={hoursError != null}
+              onChange={(e) => setHoursInput(e.target.value)}
+              onBlur={() => void commitHours()}
+            />
+            {hoursError ? <p className="text-destructive text-xs">{hoursError}</p> : null}
+            <p className="text-muted-foreground text-xs">
+              {Math.round(goals.hours_ytd)}h this year · on track for {goals.hours_on_track_for}h
+            </p>
+          </div>
+        </form>
+      </CardContent>
+    </Card>
+  );
+}
+
+export interface AchievementsSectionProps {
+  achievements: ReadingMotivationAchievement[] | null | undefined;
+}
+
+function groupByCategory(
+  achievements: ReadingMotivationAchievement[],
+): [string, ReadingMotivationAchievement[]][] {
+  const order: string[] = [];
+  const groups = new Map<string, ReadingMotivationAchievement[]>();
+  for (const achievement of achievements) {
+    let bucket = groups.get(achievement.category);
+    if (!bucket) {
+      bucket = [];
+      groups.set(achievement.category, bucket);
+      order.push(achievement.category);
+    }
+    bucket.push(achievement);
+  }
+  return order.map((category) => [category, groups.get(category)!]);
+}
+
+export function AchievementsSection({ achievements }: AchievementsSectionProps) {
+  if (!achievements || achievements.length === 0) {
+    return (
+      <EmptyCard
+        title="Achievements"
+        message="No achievements yet — badges unlock automatically as you read."
+      />
+    );
+  }
+
+  return (
+    <Card className="rounded-2xl border-0 shadow-none">
+      <CardHeader>
+        <CardTitle className="text-base font-semibold">Achievements</CardTitle>
+      </CardHeader>
+      <CardContent className="space-y-6">
+        {groupByCategory(achievements).map(([category, items]) => (
+          <div key={category}>
+            <h3 className="text-muted-foreground mb-2 text-sm font-semibold capitalize">
+              {category}
+            </h3>
+            <div className="grid grid-cols-2 gap-3 sm:grid-cols-3 md:grid-cols-4">
+              {items.map((achievement) => {
+                const locked = !achievement.achieved_at;
+                return (
+                  <div
+                    key={achievement.id}
+                    data-locked={locked ? "true" : undefined}
+                    aria-disabled={locked}
+                    className={cn(
+                      "rounded-lg border p-3 text-sm",
+                      locked ? "border-border/60 opacity-50" : "border-primary/40",
+                    )}
+                  >
+                    <div className="font-medium">{achievement.name}</div>
+                    <div className="text-muted-foreground text-xs">{achievement.description}</div>
+                    {achievement.achieved_at ? (
+                      <div className="text-muted-foreground mt-1 text-[11px] tabular-nums">
+                        {formatDate(achievement.achieved_at, "medium")}
+                      </div>
+                    ) : null}
+                  </div>
+                );
+              })}
+            </div>
+          </div>
+        ))}
+      </CardContent>
+    </Card>
+  );
+}
+
+export interface ReadingDnaSectionProps {
+  dna: ReadingMotivationDNA | null | undefined;
+}
+
+const HOUR_BUCKET_ORDER = ["morning", "afternoon", "evening", "night"];
+
+export function ReadingDnaSection({ dna }: ReadingDnaSectionProps) {
+  if (!dna || (dna.genres.length === 0 && dna.authors.length === 0)) {
+    return (
+      <EmptyCard
+        title="Reading DNA"
+        message="No reading DNA yet — genre and author breakdowns appear once you've read a bit."
+      />
+    );
+  }
+
+  const maxGenreSeconds = dna.genres.reduce((max, g) => Math.max(max, g.seconds), 0) || 1;
+  const bucketEntries = HOUR_BUCKET_ORDER.filter((bucket) => bucket in dna.hours_by_bucket).map(
+    (bucket) => [bucket, dna.hours_by_bucket[bucket]!] as const,
+  );
+
+  return (
+    <Card className="rounded-2xl border-0 shadow-none">
+      <CardHeader>
+        <CardTitle className="text-base font-semibold">Reading DNA</CardTitle>
+      </CardHeader>
+      <CardContent className="space-y-6">
+        {dna.genres.length > 0 ? (
+          <div>
+            <h3 className="text-muted-foreground mb-2 text-sm font-semibold">Top genres</h3>
+            <ul className="space-y-2">
+              {dna.genres.map((genre) => (
+                <li key={genre.name} className="space-y-1">
+                  <div className="flex items-center justify-between text-sm">
+                    <span className="font-medium">{genre.name}</span>
+                    <span className="text-muted-foreground tabular-nums">
+                      {formatDuration(genre.seconds)}
+                    </span>
+                  </div>
+                  <div className="bg-muted h-1.5 overflow-hidden rounded-sm">
+                    <div
+                      className="bg-primary h-full"
+                      style={{ width: `${Math.round((genre.seconds / maxGenreSeconds) * 100)}%` }}
+                    />
+                  </div>
+                </li>
+              ))}
+            </ul>
+          </div>
+        ) : null}
+
+        {dna.authors.length > 0 ? (
+          <div>
+            <h3 className="text-muted-foreground mb-2 text-sm font-semibold">Top authors</h3>
+            <ul className="divide-border/60 divide-y text-sm">
+              {dna.authors.map((author) => (
+                <li key={author.name} className="flex items-center justify-between py-1.5">
+                  <span>{author.name}</span>
+                  <span className="text-muted-foreground tabular-nums">
+                    {formatDuration(author.seconds)}
+                  </span>
+                </li>
+              ))}
+            </ul>
+          </div>
+        ) : null}
+
+        <div className="grid grid-cols-2 gap-4 sm:grid-cols-4">
+          <div>
+            <div className="text-muted-foreground text-xs">Diversity</div>
+            <div className="text-xl font-semibold tabular-nums">{dna.diversity_score}</div>
+          </div>
+          {bucketEntries.map(([bucket, hours]) => (
+            <div key={bucket}>
+              <div className="text-muted-foreground text-xs capitalize">{bucket}</div>
+              <div className="text-xl font-semibold tabular-nums">{hours}h</div>
+            </div>
+          ))}
+        </div>
+
+        <p className="text-muted-foreground text-sm">
+          On pace for {Math.round(dna.projected_year_hours)}h this year.
+        </p>
+      </CardContent>
+    </Card>
+  );
+}

--- a/web/src/components/stats/MotivationSections.tsx
+++ b/web/src/components/stats/MotivationSections.tsx
@@ -1,10 +1,11 @@
 import { useRef, useState, type FormEvent } from "react";
 
+import { ApiClientError } from "@/api/client";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Input } from "@/components/ui/input";
 import { Progress } from "@/components/ui/progress";
 import {
-  putReadingGoals,
+  useSaveReadingGoals,
   type ReadingMotivationAchievement,
   type ReadingMotivationChallenge,
   type ReadingMotivationDNA,
@@ -147,11 +148,22 @@ function GoalsForm({ goals }: { goals: ReadingMotivationGoals }) {
   const [hoursInput, setHoursInput] = useState(() => goalDisplayValue(savedHours));
   const [booksError, setBooksError] = useState<string | null>(null);
   const [hoursError, setHoursError] = useState<string | null>(null);
+  // Surfaces a failed save (network/server error), distinct from the
+  // client-side range validation above. Cleared on the next successful save.
+  const [saveError, setSaveError] = useState<string | null>(null);
 
-  // Tracks the last value actually persisted, so a blur that didn't change
+  const { mutateAsync: saveGoals } = useSaveReadingGoals();
+
+  // Tracks the last value actually *persisted*, so a blur that didn't change
   // anything skips the PUT, and so a PUT for one field can still send the
-  // other field's current value.
+  // other field's current value. Only advanced after a successful save —
+  // if the PUT fails, the ref stays put so the next blur (even with the same
+  // unsaved value) retries instead of silently no-opping forever.
   const savedRef = useRef({ books: savedBooks, hours: savedHours });
+
+  function saveFailureMessage(err: unknown): string {
+    return err instanceof ApiClientError ? err.message : "Failed to save reading goals.";
+  }
 
   async function commitBooks() {
     const parsed = parseGoalInput(booksInput);
@@ -161,8 +173,13 @@ function GoalsForm({ goals }: { goals: ReadingMotivationGoals }) {
     }
     setBooksError(null);
     if (parsed === savedRef.current.books) return;
-    savedRef.current.books = parsed;
-    await putReadingGoals({ books_per_year: parsed, hours_per_year: savedRef.current.hours });
+    try {
+      await saveGoals({ books_per_year: parsed, hours_per_year: savedRef.current.hours });
+      savedRef.current.books = parsed;
+      setSaveError(null);
+    } catch (err) {
+      setSaveError(saveFailureMessage(err));
+    }
   }
 
   async function commitHours() {
@@ -173,8 +190,13 @@ function GoalsForm({ goals }: { goals: ReadingMotivationGoals }) {
     }
     setHoursError(null);
     if (parsed === savedRef.current.hours) return;
-    savedRef.current.hours = parsed;
-    await putReadingGoals({ books_per_year: savedRef.current.books, hours_per_year: parsed });
+    try {
+      await saveGoals({ books_per_year: savedRef.current.books, hours_per_year: parsed });
+      savedRef.current.hours = parsed;
+      setSaveError(null);
+    } catch (err) {
+      setSaveError(saveFailureMessage(err));
+    }
   }
 
   function preventSubmit(e: FormEvent) {
@@ -225,6 +247,7 @@ function GoalsForm({ goals }: { goals: ReadingMotivationGoals }) {
             </p>
           </div>
         </form>
+        {saveError ? <p className="text-destructive mt-3 text-xs">{saveError}</p> : null}
       </CardContent>
     </Card>
   );

--- a/web/src/components/stats/ReadingHeatmap.test.tsx
+++ b/web/src/components/stats/ReadingHeatmap.test.tsx
@@ -1,7 +1,7 @@
 import { renderToStaticMarkup } from "react-dom/server";
 import { describe, expect, it } from "vitest";
 
-import ReadingHeatmap, { heatmapBuckets, type HeatmapDay } from "./ReadingHeatmap";
+import ReadingHeatmap, { densifyDays, heatmapBuckets, type HeatmapDay } from "./ReadingHeatmap";
 
 function addDays(date: string, count: number): string {
   const d = new Date(`${date}T00:00:00Z`);
@@ -66,6 +66,57 @@ describe("heatmapBuckets", () => {
   });
 });
 
+describe("densifyDays", () => {
+  it("fills gap days with zero seconds across the given range", () => {
+    const days: HeatmapDay[] = [
+      { date: "2026-07-01", seconds: 100 },
+      { date: "2026-07-03", seconds: 200 },
+    ];
+    expect(densifyDays(days, "2026-07-01", "2026-07-05")).toEqual([
+      { date: "2026-07-01", seconds: 100 },
+      { date: "2026-07-02", seconds: 0 },
+      { date: "2026-07-03", seconds: 200 },
+      { date: "2026-07-04", seconds: 0 },
+      { date: "2026-07-05", seconds: 0 },
+    ]);
+  });
+
+  it("returns an empty range unchanged when it collapses to nothing", () => {
+    expect(densifyDays([], "2026-07-05", "2026-07-01")).toEqual([]);
+  });
+
+  it("returns a single-day list when from equals to", () => {
+    expect(densifyDays([{ date: "2026-07-04", seconds: 30 }], "2026-07-04", "2026-07-04")).toEqual([
+      { date: "2026-07-04", seconds: 30 },
+    ]);
+  });
+});
+
+describe("heatmapBuckets + densifyDays (sparse history regression)", () => {
+  it("keeps the day after a gap in its correct weekday cell instead of compressing the grid", () => {
+    // 2026-07-01 is a Wednesday (getUTCDay() === 3); 2026-07-03 is a Friday
+    // (getUTCDay() === 5). A gap on 2026-07-02 (no session that day) must not
+    // shift 2026-07-03 left by one cell, or its weekday row would be wrong.
+    const sparseDays: HeatmapDay[] = [
+      { date: "2026-07-01", seconds: 100 },
+      { date: "2026-07-03", seconds: 200 },
+    ];
+    const densified = densifyDays(sparseDays, "2026-07-01", "2026-07-05");
+    expect(densified).toHaveLength(5);
+
+    const cells = heatmapBuckets(densified, 200);
+    // 3 leading blanks (Wednesday) + 5 densified days.
+    expect(cells).toHaveLength(8);
+    expect(cells[3]).toEqual({ date: "2026-07-01", seconds: 100, bucket: 2 });
+    expect(cells[4]).toEqual({ date: "2026-07-02", seconds: 0, bucket: 0 }); // gap day
+    expect(cells[5]).toEqual({ date: "2026-07-03", seconds: 200, bucket: 4 });
+
+    // Weekday alignment: a cell's index modulo 7 must equal its date's UTC
+    // weekday for the GitHub-style grid to read correctly.
+    expect(5 % 7).toBe(new Date("2026-07-03T00:00:00Z").getUTCDay());
+  });
+});
+
 describe("ReadingHeatmap", () => {
   it("renders one cell per day plus leading blanks, with a date · Xm tooltip", () => {
     const days: HeatmapDay[] = [
@@ -79,5 +130,18 @@ describe("ReadingHeatmap", () => {
   it("renders an empty grid without crashing when there is no data", () => {
     const markup = renderToStaticMarkup(<ReadingHeatmap days={[]} />);
     expect(typeof markup).toBe("string");
+  });
+
+  it("densifies gap days when given a from/to range, rendering a filled-in cell for the gap", () => {
+    const days: HeatmapDay[] = [
+      { date: "2026-07-01", seconds: 100 },
+      { date: "2026-07-03", seconds: 200 },
+    ];
+    const markup = renderToStaticMarkup(
+      <ReadingHeatmap days={days} from="2026-07-01" to="2026-07-05" />,
+    );
+    // The gap day (2026-07-02) must render its own zero-second tooltip cell
+    // rather than being skipped.
+    expect(markup).toContain("2026-07-02 · 0m");
   });
 });

--- a/web/src/components/stats/ReadingHeatmap.test.tsx
+++ b/web/src/components/stats/ReadingHeatmap.test.tsx
@@ -1,0 +1,83 @@
+import { renderToStaticMarkup } from "react-dom/server";
+import { describe, expect, it } from "vitest";
+
+import ReadingHeatmap, { heatmapBuckets, type HeatmapDay } from "./ReadingHeatmap";
+
+function addDays(date: string, count: number): string {
+  const d = new Date(`${date}T00:00:00Z`);
+  d.setUTCDate(d.getUTCDate() + count);
+  return d.toISOString().slice(0, 10);
+}
+
+function range(start: string, days: number): HeatmapDay[] {
+  return Array.from({ length: days }, (_, i) => ({ date: addDays(start, i), seconds: 0 }));
+}
+
+describe("heatmapBuckets", () => {
+  it("buckets zero seconds as 0 regardless of max", () => {
+    const days: HeatmapDay[] = [{ date: "2026-01-04", seconds: 0 }];
+    const cells = heatmapBuckets(days, 400);
+    expect(cells[0]).toEqual({ date: "2026-01-04", seconds: 0, bucket: 0 });
+  });
+
+  it("buckets seconds into quartiles of the given max", () => {
+    // 2026-01-04 is a Sunday, so no leading blanks — cell index == day index.
+    const days: HeatmapDay[] = [
+      { date: "2026-01-04", seconds: 0 },
+      { date: "2026-01-05", seconds: 100 },
+      { date: "2026-01-06", seconds: 101 },
+      { date: "2026-01-07", seconds: 200 },
+      { date: "2026-01-08", seconds: 201 },
+      { date: "2026-01-09", seconds: 300 },
+      { date: "2026-01-10", seconds: 301 },
+      { date: "2026-01-11", seconds: 400 },
+    ];
+    const buckets = heatmapBuckets(days, 400).map((c) => c?.bucket);
+    expect(buckets).toEqual([0, 1, 2, 2, 3, 3, 4, 4]);
+  });
+
+  it("treats a zero or negative max as all-zero buckets", () => {
+    const days: HeatmapDay[] = [{ date: "2026-01-04", seconds: 0 }];
+    expect(heatmapBuckets(days, 0)[0]?.bucket).toBe(0);
+  });
+
+  it("pads leading blanks so the first day lands in its weekday row", () => {
+    // 2026-01-01 is a Thursday (getUTCDay() === 4), so the grid should be
+    // padded with 4 leading blank cells before the first real day.
+    const days: HeatmapDay[] = [{ date: "2026-01-01", seconds: 5 }];
+    const cells = heatmapBuckets(days, 5);
+    expect(cells).toHaveLength(5);
+    expect(cells.slice(0, 4)).toEqual([null, null, null, null]);
+    expect(cells[4]).toEqual({ date: "2026-01-01", seconds: 5, bucket: 4 });
+  });
+
+  it("returns an empty grid for an empty range", () => {
+    expect(heatmapBuckets([], 100)).toEqual([]);
+  });
+
+  it("produces a 366-cell grid for a full default range starting on a week boundary", () => {
+    // 2026-01-04 is a Sunday, so there are no leading blanks and the grid
+    // length matches the day count exactly (the server's default range is
+    // 366 days: today plus the prior 365).
+    const days = range("2026-01-04", 366);
+    const cells = heatmapBuckets(days, 100);
+    expect(cells).toHaveLength(366);
+    expect(cells.every((c) => c !== null)).toBe(true);
+  });
+});
+
+describe("ReadingHeatmap", () => {
+  it("renders one cell per day plus leading blanks, with a date · Xm tooltip", () => {
+    const days: HeatmapDay[] = [
+      { date: "2026-01-01", seconds: 0 },
+      { date: "2026-01-02", seconds: 90 },
+    ];
+    const markup = renderToStaticMarkup(<ReadingHeatmap days={days} />);
+    expect(markup).toContain("2026-01-02 · 2m");
+  });
+
+  it("renders an empty grid without crashing when there is no data", () => {
+    const markup = renderToStaticMarkup(<ReadingHeatmap days={[]} />);
+    expect(typeof markup).toBe("string");
+  });
+});

--- a/web/src/components/stats/ReadingHeatmap.tsx
+++ b/web/src/components/stats/ReadingHeatmap.tsx
@@ -40,8 +40,9 @@ function bucketFor(seconds: number, max: number): HeatmapBucket {
  * left-to-right, days run top-to-bottom starting Sunday).
  */
 export function heatmapBuckets(days: HeatmapDay[], max: number): (HeatmapCell | null)[] {
-  if (days.length === 0) return [];
-  const leadingBlanks = new Date(`${days[0].date}T00:00:00Z`).getUTCDay();
+  const firstDay = days[0];
+  if (!firstDay) return [];
+  const leadingBlanks = new Date(`${firstDay.date}T00:00:00Z`).getUTCDay();
   const blanks: null[] = new Array(leadingBlanks).fill(null);
   const cells: HeatmapCell[] = days.map((day) => ({
     date: day.date,

--- a/web/src/components/stats/ReadingHeatmap.tsx
+++ b/web/src/components/stats/ReadingHeatmap.tsx
@@ -1,0 +1,83 @@
+import { useMemo } from "react";
+
+import { cn } from "@/lib/utils";
+
+export interface HeatmapDay {
+  date: string;
+  seconds: number;
+}
+
+export type HeatmapBucket = 0 | 1 | 2 | 3 | 4;
+
+export interface HeatmapCell {
+  date: string;
+  seconds: number;
+  bucket: HeatmapBucket;
+}
+
+const BUCKET_CLASSES: Record<HeatmapBucket, string> = {
+  0: "bg-muted",
+  1: "bg-primary/25",
+  2: "bg-primary/50",
+  3: "bg-primary/75",
+  4: "bg-primary",
+};
+
+function bucketFor(seconds: number, max: number): HeatmapBucket {
+  if (seconds <= 0 || max <= 0) return 0;
+  const quartile = max / 4;
+  if (seconds <= quartile) return 1;
+  if (seconds <= quartile * 2) return 2;
+  if (seconds <= quartile * 3) return 3;
+  return 4;
+}
+
+/**
+ * Buckets each day's reading seconds into a 0-4 intensity level (0 = no
+ * reading, 1-4 = quartiles of the profile's busiest day in the range) and
+ * pads the front of the list with blank cells so the first day lands in its
+ * correct weekday row of a GitHub-style column-per-week grid (weeks run
+ * left-to-right, days run top-to-bottom starting Sunday).
+ */
+export function heatmapBuckets(days: HeatmapDay[], max: number): (HeatmapCell | null)[] {
+  if (days.length === 0) return [];
+  const leadingBlanks = new Date(`${days[0].date}T00:00:00Z`).getUTCDay();
+  const blanks: null[] = new Array(leadingBlanks).fill(null);
+  const cells: HeatmapCell[] = days.map((day) => ({
+    date: day.date,
+    seconds: day.seconds,
+    bucket: bucketFor(day.seconds, max),
+  }));
+  return [...blanks, ...cells];
+}
+
+export interface ReadingHeatmapProps {
+  days: HeatmapDay[];
+}
+
+export default function ReadingHeatmap({ days }: ReadingHeatmapProps) {
+  const max = useMemo(() => days.reduce((acc, day) => Math.max(acc, day.seconds), 0), [days]);
+  const cells = useMemo(() => heatmapBuckets(days, max), [days, max]);
+  const columns = Math.max(1, Math.ceil(cells.length / 7));
+
+  return (
+    <div
+      role="img"
+      aria-label="Reading activity heatmap"
+      className="grid w-full grid-flow-col grid-rows-7 gap-1 overflow-x-auto"
+      style={{ gridTemplateColumns: `repeat(${columns}, minmax(0.5rem, 1fr))` }}
+    >
+      {cells.map((cell, i) =>
+        cell ? (
+          <div
+            key={cell.date}
+            title={`${cell.date} · ${Math.round(cell.seconds / 60)}m`}
+            className={cn("aspect-square rounded-[2px]", BUCKET_CLASSES[cell.bucket])}
+          />
+        ) : (
+          <div key={`blank-${i}`} aria-hidden="true" className="aspect-square" />
+        ),
+      )}
+    </div>
+  );
+}

--- a/web/src/components/stats/ReadingHeatmap.tsx
+++ b/web/src/components/stats/ReadingHeatmap.tsx
@@ -32,12 +32,38 @@ function bucketFor(seconds: number, max: number): HeatmapBucket {
   return 4;
 }
 
+const MS_PER_DAY = 24 * 60 * 60 * 1000;
+
+/**
+ * Fills every date in [from, to] (inclusive, UTC calendar days) with a
+ * `{date, seconds: 0}` entry where `days` has none. The server's daily
+ * rollup only returns days that had at least one session, so any gap must be
+ * densified client-side before `heatmapBuckets` lays days into consecutive
+ * grid cells — otherwise a gap silently shifts every later day left by one
+ * cell, compressing the calendar and putting it on the wrong weekday row.
+ */
+export function densifyDays(days: HeatmapDay[], from: string, to: string): HeatmapDay[] {
+  const secondsByDate = new Map(days.map((day) => [day.date, day.seconds]));
+  const start = new Date(`${from}T00:00:00Z`).getTime();
+  const end = new Date(`${to}T00:00:00Z`).getTime();
+  const filled: HeatmapDay[] = [];
+  for (let t = start; t <= end; t += MS_PER_DAY) {
+    const date = new Date(t).toISOString().slice(0, 10);
+    filled.push({ date, seconds: secondsByDate.get(date) ?? 0 });
+  }
+  return filled;
+}
+
 /**
  * Buckets each day's reading seconds into a 0-4 intensity level (0 = no
  * reading, 1-4 = quartiles of the profile's busiest day in the range) and
  * pads the front of the list with blank cells so the first day lands in its
  * correct weekday row of a GitHub-style column-per-week grid (weeks run
  * left-to-right, days run top-to-bottom starting Sunday).
+ *
+ * Assumes `days` has no gaps — pass it through `densifyDays` first if it
+ * might be sparse (e.g. the server's daily rollup), or later days will land
+ * in the wrong weekday row.
  */
 export function heatmapBuckets(days: HeatmapDay[], max: number): (HeatmapCell | null)[] {
   const firstDay = days[0];
@@ -54,11 +80,26 @@ export function heatmapBuckets(days: HeatmapDay[], max: number): (HeatmapCell | 
 
 export interface ReadingHeatmapProps {
   days: HeatmapDay[];
+  /**
+   * The exact [from, to] range `days` was requested for (YYYY-MM-DD, UTC).
+   * When given, gap days (no session that day) are densified to zero-second
+   * entries before bucketing, so the grid can't compress and misalign
+   * weekday rows. Optional for callers that already pass a dense list.
+   */
+  from?: string;
+  to?: string;
 }
 
-export default function ReadingHeatmap({ days }: ReadingHeatmapProps) {
-  const max = useMemo(() => days.reduce((acc, day) => Math.max(acc, day.seconds), 0), [days]);
-  const cells = useMemo(() => heatmapBuckets(days, max), [days, max]);
+export default function ReadingHeatmap({ days, from, to }: ReadingHeatmapProps) {
+  const denseDays = useMemo(
+    () => (from && to ? densifyDays(days, from, to) : days),
+    [days, from, to],
+  );
+  const max = useMemo(
+    () => denseDays.reduce((acc, day) => Math.max(acc, day.seconds), 0),
+    [denseDays],
+  );
+  const cells = useMemo(() => heatmapBuckets(denseDays, max), [denseDays, max]);
   const columns = Math.max(1, Math.ceil(cells.length / 7));
 
   return (

--- a/web/src/hooks/queries/keys.ts
+++ b/web/src/hooks/queries/keys.ts
@@ -192,8 +192,9 @@ export const episodeKeys = {
 export const ebookKeys = {
   readerProgress: (contentId: string | undefined) => ["ebook-reader-progress", contentId] as const,
   readingStats: (contentId: string | undefined) => ["reading-stats", contentId] as const,
-  readingHistory: (from?: string, to?: string) =>
-    ["reading-history", from ?? "default", to ?? "default"] as const,
+  readingHistory: (from?: string, to?: string, tz?: string) =>
+    ["reading-history", from ?? "default", to ?? "default", tz ?? "default"] as const,
+  readingMotivation: () => ["reading-motivation"] as const,
 };
 
 export const libraryKeys = {

--- a/web/src/hooks/queries/keys.ts
+++ b/web/src/hooks/queries/keys.ts
@@ -192,6 +192,8 @@ export const episodeKeys = {
 export const ebookKeys = {
   readerProgress: (contentId: string | undefined) => ["ebook-reader-progress", contentId] as const,
   readingStats: (contentId: string | undefined) => ["reading-stats", contentId] as const,
+  readingHistory: (from?: string, to?: string) =>
+    ["reading-history", from ?? "default", to ?? "default"] as const,
 };
 
 export const libraryKeys = {

--- a/web/src/hooks/queries/keys.ts
+++ b/web/src/hooks/queries/keys.ts
@@ -194,7 +194,13 @@ export const ebookKeys = {
   readingStats: (contentId: string | undefined) => ["reading-stats", contentId] as const,
   readingHistory: (from?: string, to?: string, tz?: string) =>
     ["reading-history", from ?? "default", to ?? "default", tz ?? "default"] as const,
-  readingMotivation: () => ["reading-motivation"] as const,
+  // Unlike readingHistory, tz has no "default" placeholder here: the hook
+  // always resolves and passes a concrete tz, while callers that want to
+  // invalidate every tz variant (e.g. after a goal save) call this with no
+  // argument to get the bare ["reading-motivation"] prefix that matches all
+  // of them under react-query's default partial-key matching.
+  readingMotivation: (tz?: string) =>
+    tz ? (["reading-motivation", tz] as const) : (["reading-motivation"] as const),
 };
 
 export const libraryKeys = {

--- a/web/src/hooks/queries/keys.ts
+++ b/web/src/hooks/queries/keys.ts
@@ -191,6 +191,7 @@ export const episodeKeys = {
 
 export const ebookKeys = {
   readerProgress: (contentId: string | undefined) => ["ebook-reader-progress", contentId] as const,
+  readingStats: (contentId: string | undefined) => ["reading-stats", contentId] as const,
 };
 
 export const libraryKeys = {

--- a/web/src/hooks/queries/readingStats.test.ts
+++ b/web/src/hooks/queries/readingStats.test.ts
@@ -1,0 +1,133 @@
+// @vitest-environment jsdom
+
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { act, renderHook, waitFor } from "@testing-library/react";
+import { createElement } from "react";
+import type { ReactNode } from "react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { ebookKeys } from "./keys";
+import { useReadingMotivation, useSaveReadingGoals } from "./readingStats";
+
+function jsonResponse(body: unknown, status = 200): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { "Content-Type": "application/json" },
+  });
+}
+
+function createWrapper(client: QueryClient) {
+  return function Wrapper({ children }: { children: ReactNode }) {
+    return createElement(QueryClientProvider, { client }, children);
+  };
+}
+
+function newClient() {
+  return new QueryClient({
+    defaultOptions: {
+      queries: { retry: false },
+      mutations: { retry: false },
+    },
+  });
+}
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe("useReadingMotivation", () => {
+  it("includes the viewer's timezone in the query key", async () => {
+    const mockedZone = "Europe/Amsterdam";
+    const resolvedOptionsSpy = vi
+      .spyOn(Intl.DateTimeFormat.prototype, "resolvedOptions")
+      .mockReturnValue({ timeZone: mockedZone } as Intl.ResolvedDateTimeFormatOptions);
+
+    vi.stubGlobal(
+      "fetch",
+      vi.fn<typeof fetch>(async () =>
+        jsonResponse({
+          streak: { current_days: 1, longest_days: 1, today_seconds: 1, today_qualified: true },
+          goals: {
+            books_per_year: null,
+            hours_per_year: null,
+            books_finished_ytd: 0,
+            hours_ytd: 0,
+            books_on_track_for: 0,
+            hours_on_track_for: 0,
+          },
+          challenge: { target_seconds: 0, month_seconds: 0, percent: 0 },
+          achievements: [],
+          dna: {
+            genres: [],
+            authors: [],
+            diversity_score: 0,
+            avg_session_seconds: 0,
+            hours_by_bucket: {},
+            projected_year_hours: 0,
+          },
+        }),
+      ),
+    );
+
+    try {
+      const client = newClient();
+      const { result } = renderHook(() => useReadingMotivation(), {
+        wrapper: createWrapper(client),
+      });
+
+      await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+      expect(client.getQueryData(ebookKeys.readingMotivation(mockedZone))).toBeDefined();
+    } finally {
+      resolvedOptionsSpy.mockRestore();
+    }
+  });
+});
+
+describe("useSaveReadingGoals", () => {
+  it("invalidates the reading-motivation query on a successful save", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn<typeof fetch>(async (input, init) => {
+        expect(String(input)).toBe("/api/v1/ebooks/reading-goals");
+        expect(init?.method).toBe("PUT");
+        return new Response(null, { status: 204 });
+      }),
+    );
+
+    const client = newClient();
+    const invalidateSpy = vi.spyOn(client, "invalidateQueries");
+    const { result } = renderHook(() => useSaveReadingGoals(), {
+      wrapper: createWrapper(client),
+    });
+
+    await act(async () => {
+      await result.current.mutateAsync({ books_per_year: 30, hours_per_year: 100 });
+    });
+
+    expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: ebookKeys.readingMotivation() });
+  });
+
+  it("rejects mutateAsync when the save fails, without invalidating", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn<typeof fetch>(async () =>
+        jsonResponse({ error: "server_error", message: "Nope" }, 500),
+      ),
+    );
+
+    const client = newClient();
+    const invalidateSpy = vi.spyOn(client, "invalidateQueries");
+    const { result } = renderHook(() => useSaveReadingGoals(), {
+      wrapper: createWrapper(client),
+    });
+
+    await expect(
+      act(async () => {
+        await result.current.mutateAsync({ books_per_year: 30, hours_per_year: 100 });
+      }),
+    ).rejects.toThrow();
+
+    expect(invalidateSpy).not.toHaveBeenCalled();
+  });
+});

--- a/web/src/hooks/queries/readingStats.ts
+++ b/web/src/hooks/queries/readingStats.ts
@@ -1,4 +1,4 @@
-import { useQuery } from "@tanstack/react-query";
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 
 import { api } from "@/api/client";
 import { ebookKeys } from "./keys";
@@ -183,7 +183,7 @@ export async function fetchReadingMotivation(tz: string): Promise<ReadingMotivat
 export function useReadingMotivation() {
   const tz = clientTimezone();
   return useQuery({
-    queryKey: ebookKeys.readingMotivation(),
+    queryKey: ebookKeys.readingMotivation(tz),
     queryFn: () => fetchReadingMotivation(tz),
     staleTime: READING_MOTIVATION_STALE_TIME,
   });
@@ -201,5 +201,20 @@ export async function putReadingGoals(goals: ReadingGoalsInput): Promise<void> {
   await api<void>("/ebooks/reading-goals", {
     method: "PUT",
     body: JSON.stringify(goals),
+  });
+}
+
+// Wraps putReadingGoals in the repo's mutation convention: on a successful
+// save, invalidate reading-motivation so goals/progress refetch with the
+// server's latest values. Callers use mutateAsync so a rejected save
+// propagates back to them (see GoalsForm in MotivationSections.tsx, which
+// relies on that rejection to avoid marking an unsaved value as saved).
+export function useSaveReadingGoals() {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: (goals: ReadingGoalsInput) => putReadingGoals(goals),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ebookKeys.readingMotivation() });
+    },
   });
 }

--- a/web/src/hooks/queries/readingStats.ts
+++ b/web/src/hooks/queries/readingStats.ts
@@ -33,3 +33,63 @@ export function useBookReadingStats(contentId: string | undefined) {
     refetchInterval: READING_STATS_STALE_TIME,
   });
 }
+
+export interface ReadingHistoryTotals {
+  today_seconds: number;
+  week_seconds: number;
+  month_seconds: number;
+  all_time_seconds: number;
+}
+
+export interface ReadingHistoryDay {
+  date: string;
+  seconds: number;
+}
+
+export interface ReadingHistoryBook {
+  content_id: string;
+  title: string;
+  seconds: number;
+  last_read_at: string;
+}
+
+export interface ReadingHistorySession {
+  content_id: string;
+  title: string;
+  started_at: string;
+  duration_seconds: number;
+  start_fraction: number;
+  end_fraction: number;
+}
+
+export interface ReadingHistory {
+  totals: ReadingHistoryTotals;
+  days: ReadingHistoryDay[];
+  books: ReadingHistoryBook[];
+  sessions: ReadingHistorySession[];
+}
+
+// History defaults to the server's built-in range (the last year) when no
+// from/to bounds are given, so the reading stats page can render a full
+// heatmap without the caller having to compute dates itself.
+const READING_HISTORY_STALE_TIME = 5 * 60 * 1000;
+
+function readingHistoryPath(from?: string, to?: string): string {
+  const params = new URLSearchParams();
+  if (from) params.set("from", from);
+  if (to) params.set("to", to);
+  const query = params.toString();
+  return query ? `/ebooks/reading-stats?${query}` : "/ebooks/reading-stats";
+}
+
+export async function fetchReadingHistory(from?: string, to?: string): Promise<ReadingHistory> {
+  return api<ReadingHistory>(readingHistoryPath(from, to));
+}
+
+export function useReadingHistory(from?: string, to?: string) {
+  return useQuery({
+    queryKey: ebookKeys.readingHistory(from, to),
+    queryFn: () => fetchReadingHistory(from, to),
+    staleTime: READING_HISTORY_STALE_TIME,
+  });
+}

--- a/web/src/hooks/queries/readingStats.ts
+++ b/web/src/hooks/queries/readingStats.ts
@@ -1,0 +1,35 @@
+import { useQuery } from "@tanstack/react-query";
+
+import { api } from "@/api/client";
+import { ebookKeys } from "./keys";
+
+// Pace/time-left aren't yet meaningful until enough reading heartbeats have
+// landed for the book, so the server returns null rather than a misleading
+// estimate.
+export type BookReadingStats = {
+  pace_fraction_per_hour: number | null;
+  time_left_seconds: number | null;
+  book_seconds: number;
+};
+
+// Aligned with the footer's refetch cadence: pace estimates move slowly
+// enough that polling faster would just add load without a visible change.
+const READING_STATS_STALE_TIME = 5 * 60 * 1000;
+
+function readingStatsPath(contentID: string): string {
+  return `/ebooks/${encodeURIComponent(contentID)}/reading-stats`;
+}
+
+export async function fetchBookReadingStats(contentID: string): Promise<BookReadingStats> {
+  return api<BookReadingStats>(readingStatsPath(contentID));
+}
+
+export function useBookReadingStats(contentId: string | undefined) {
+  return useQuery({
+    queryKey: ebookKeys.readingStats(contentId),
+    queryFn: () => fetchBookReadingStats(contentId!),
+    enabled: !!contentId,
+    staleTime: READING_STATS_STALE_TIME,
+    refetchInterval: READING_STATS_STALE_TIME,
+  });
+}

--- a/web/src/hooks/queries/readingStats.ts
+++ b/web/src/hooks/queries/readingStats.ts
@@ -3,6 +3,17 @@ import { useQuery } from "@tanstack/react-query";
 import { api } from "@/api/client";
 import { ebookKeys } from "./keys";
 
+/**
+ * The viewer's IANA timezone (e.g. "Europe/Amsterdam"), as reported by the
+ * browser. Sent as the `tz` query param on reading-history and
+ * reading-motivation fetches so the server can attribute streaks/totals to
+ * the viewer's local calendar days rather than UTC. Falls back to "UTC" when
+ * the runtime can't resolve one (e.g. some test/SSR environments).
+ */
+export function clientTimezone(): string {
+  return Intl.DateTimeFormat().resolvedOptions().timeZone ?? "UTC";
+}
+
 // Pace/time-left aren't yet meaningful until enough reading heartbeats have
 // landed for the book, so the server returns null rather than a misleading
 // estimate.
@@ -74,22 +85,121 @@ export interface ReadingHistory {
 // heatmap without the caller having to compute dates itself.
 const READING_HISTORY_STALE_TIME = 5 * 60 * 1000;
 
-function readingHistoryPath(from?: string, to?: string): string {
+function readingHistoryPath(from?: string, to?: string, tz?: string): string {
   const params = new URLSearchParams();
   if (from) params.set("from", from);
   if (to) params.set("to", to);
+  if (tz) params.set("tz", tz);
   const query = params.toString();
   return query ? `/ebooks/reading-stats?${query}` : "/ebooks/reading-stats";
 }
 
-export async function fetchReadingHistory(from?: string, to?: string): Promise<ReadingHistory> {
-  return api<ReadingHistory>(readingHistoryPath(from, to));
+export async function fetchReadingHistory(
+  from?: string,
+  to?: string,
+  tz?: string,
+): Promise<ReadingHistory> {
+  return api<ReadingHistory>(readingHistoryPath(from, to, tz));
 }
 
-export function useReadingHistory(from?: string, to?: string) {
+export function useReadingHistory(from?: string, to?: string, tz?: string) {
   return useQuery({
-    queryKey: ebookKeys.readingHistory(from, to),
-    queryFn: () => fetchReadingHistory(from, to),
+    queryKey: ebookKeys.readingHistory(from, to, tz),
+    queryFn: () => fetchReadingHistory(from, to, tz),
     staleTime: READING_HISTORY_STALE_TIME,
+  });
+}
+
+// --- Reading motivation (streaks, goals, achievements, Reading DNA) ---
+
+export interface ReadingMotivationStreak {
+  current_days: number;
+  longest_days: number;
+  today_seconds: number;
+  today_qualified: boolean;
+}
+
+export interface ReadingMotivationGoals {
+  books_per_year: number | null;
+  hours_per_year: number | null;
+  books_finished_ytd: number;
+  hours_ytd: number;
+  books_on_track_for: number;
+  hours_on_track_for: number;
+}
+
+export interface ReadingMotivationChallenge {
+  target_seconds: number;
+  month_seconds: number;
+  percent: number;
+}
+
+export interface ReadingMotivationAchievement {
+  id: string;
+  category: string;
+  name: string;
+  description: string;
+  achieved_at: string | null;
+}
+
+export interface ReadingMotivationGenre {
+  name: string;
+  seconds: number;
+}
+
+export interface ReadingMotivationAuthor {
+  name: string;
+  seconds: number;
+}
+
+export interface ReadingMotivationDNA {
+  genres: ReadingMotivationGenre[];
+  authors: ReadingMotivationAuthor[];
+  diversity_score: number;
+  avg_session_seconds: number;
+  hours_by_bucket: Record<string, number>;
+  projected_year_hours: number;
+}
+
+export interface ReadingMotivation {
+  streak: ReadingMotivationStreak;
+  goals: ReadingMotivationGoals;
+  challenge: ReadingMotivationChallenge;
+  achievements: ReadingMotivationAchievement[];
+  dna: ReadingMotivationDNA;
+}
+
+const READING_MOTIVATION_STALE_TIME = 5 * 60 * 1000;
+
+function readingMotivationPath(tz: string): string {
+  const params = new URLSearchParams({ tz });
+  return `/ebooks/reading-motivation?${params.toString()}`;
+}
+
+export async function fetchReadingMotivation(tz: string): Promise<ReadingMotivation> {
+  return api<ReadingMotivation>(readingMotivationPath(tz));
+}
+
+export function useReadingMotivation() {
+  const tz = clientTimezone();
+  return useQuery({
+    queryKey: ebookKeys.readingMotivation(),
+    queryFn: () => fetchReadingMotivation(tz),
+    staleTime: READING_MOTIVATION_STALE_TIME,
+  });
+}
+
+export interface ReadingGoalsInput {
+  books_per_year: number | null;
+  hours_per_year: number | null;
+}
+
+// PUT semantics: both fields are always sent, even when only one changed —
+// an absent field would clear the corresponding goal server-side (see
+// HandlePutGoals), so callers must always send the current value of both.
+export async function putReadingGoals(goals: ReadingGoalsInput): Promise<void> {
+  await api<void>("/ebooks/reading-goals", {
+    method: "PUT",
+    body: JSON.stringify(goals),
   });
 }

--- a/web/src/hooks/useReadingHeartbeat.test.ts
+++ b/web/src/hooks/useReadingHeartbeat.test.ts
@@ -1,0 +1,104 @@
+// @vitest-environment jsdom
+
+import { act, cleanup, renderHook } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { shouldHeartbeat, useReadingHeartbeat } from "./useReadingHeartbeat";
+
+function setHidden(hidden: boolean) {
+  Object.defineProperty(document, "hidden", {
+    value: hidden,
+    configurable: true,
+  });
+}
+
+describe("shouldHeartbeat", () => {
+  it("is true when visible and activity is fresh", () => {
+    expect(shouldHeartbeat({ visible: true, lastActivityAt: 1_000, now: 1_000 })).toBe(true);
+    expect(shouldHeartbeat({ visible: true, lastActivityAt: 0, now: 60_000 })).toBe(true);
+  });
+
+  it("is false when hidden even if activity is fresh", () => {
+    expect(shouldHeartbeat({ visible: false, lastActivityAt: 1_000, now: 1_000 })).toBe(false);
+  });
+
+  it("is false when activity is stale (>60s)", () => {
+    expect(shouldHeartbeat({ visible: true, lastActivityAt: 0, now: 60_001 })).toBe(false);
+  });
+});
+
+describe("useReadingHeartbeat", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(0);
+    setHidden(false);
+  });
+
+  afterEach(() => {
+    cleanup();
+    vi.useRealTimers();
+  });
+
+  it("sends immediately on first activity, then every 30s while active", () => {
+    const send = vi.fn();
+    const { result } = renderHook(() =>
+      useReadingHeartbeat({ contentId: "book-1", getFraction: () => 0.5, send }),
+    );
+
+    act(() => result.current.noteActivity());
+    expect(send).toHaveBeenCalledTimes(1);
+    expect(send).toHaveBeenLastCalledWith("book-1", 0.5);
+
+    act(() => vi.advanceTimersByTime(30_000));
+    expect(send).toHaveBeenCalledTimes(2);
+
+    act(() => vi.advanceTimersByTime(30_000));
+    expect(send).toHaveBeenCalledTimes(3);
+  });
+
+  it("stops when idle or hidden and resumes on activity", () => {
+    const send = vi.fn();
+    const { result } = renderHook(() =>
+      useReadingHeartbeat({ contentId: "book-1", getFraction: () => 0.2, send }),
+    );
+
+    act(() => result.current.noteActivity());
+    expect(send).toHaveBeenCalledTimes(1);
+
+    // No further activity: the 60s freshness window lapses somewhere in
+    // here, and once it does the interval must stop ticking on its own.
+    act(() => vi.advanceTimersByTime(90_000));
+    const callsAfterIdle = send.mock.calls.length;
+
+    // Idle for even longer: no additional sends once stale.
+    act(() => vi.advanceTimersByTime(60_000));
+    expect(send).toHaveBeenCalledTimes(callsAfterIdle);
+
+    // Fresh activity resumes immediately, without waiting for a tick.
+    act(() => result.current.noteActivity());
+    expect(send).toHaveBeenCalledTimes(callsAfterIdle + 1);
+
+    // Hidden: activity no longer produces sends, and any running interval
+    // stops.
+    send.mockClear();
+    setHidden(true);
+    act(() => document.dispatchEvent(new Event("visibilitychange")));
+    act(() => result.current.noteActivity());
+    act(() => vi.advanceTimersByTime(60_000));
+    expect(send).not.toHaveBeenCalled();
+
+    setHidden(false);
+  });
+
+  it("does nothing when contentId is null", () => {
+    const send = vi.fn();
+    const { result } = renderHook(() =>
+      useReadingHeartbeat({ contentId: null, getFraction: () => 0.9, send }),
+    );
+
+    act(() => result.current.noteActivity());
+    act(() => vi.advanceTimersByTime(120_000));
+
+    expect(send).not.toHaveBeenCalled();
+  });
+});

--- a/web/src/hooks/useReadingHeartbeat.ts
+++ b/web/src/hooks/useReadingHeartbeat.ts
@@ -1,0 +1,122 @@
+import { useCallback, useEffect, useRef } from "react";
+
+import { sendReadingHeartbeat } from "@/reader/ebookReaderApi";
+
+const HEARTBEAT_INTERVAL_MS = 30_000;
+const ACTIVITY_WINDOW_MS = 60_000;
+
+export function shouldHeartbeat(input: {
+  visible: boolean;
+  lastActivityAt: number;
+  now: number;
+}): boolean {
+  return input.visible && input.now - input.lastActivityAt <= ACTIVITY_WINDOW_MS;
+}
+
+function clamp01(value: number): number {
+  if (!Number.isFinite(value)) return 0;
+  if (value < 0) return 0;
+  if (value > 1) return 1;
+  return value;
+}
+
+function defaultSend(contentId: string, fraction: number): void {
+  sendReadingHeartbeat(contentId, fraction).catch(() => {});
+}
+
+export function useReadingHeartbeat(options: {
+  contentId: string | null;
+  getFraction: () => number;
+  send?: (contentId: string, fraction: number) => void;
+}): { noteActivity: () => void } {
+  const { contentId, getFraction, send } = options;
+
+  // Mirror the latest callbacks into refs so the interval and event
+  // listeners below never need to rebind when the caller passes fresh
+  // closures on every render.
+  const contentIdRef = useRef(contentId);
+  useEffect(() => {
+    contentIdRef.current = contentId;
+  }, [contentId]);
+  const getFractionRef = useRef(getFraction);
+  useEffect(() => {
+    getFractionRef.current = getFraction;
+  }, [getFraction]);
+  const sendRef = useRef(send);
+  useEffect(() => {
+    sendRef.current = send;
+  }, [send]);
+
+  const lastActivityAtRef = useRef<number | null>(null);
+  const intervalRef = useRef<ReturnType<typeof setInterval> | null>(null);
+
+  const stopInterval = useCallback(() => {
+    if (intervalRef.current != null) {
+      clearInterval(intervalRef.current);
+      intervalRef.current = null;
+    }
+  }, []);
+
+  // Pure re-derivation of shouldHeartbeat from the current activity ref and
+  // document visibility; used both by the interval tick and to decide
+  // whether to (re)start ticking at all.
+  const isFresh = useCallback(() => {
+    const lastActivityAt = lastActivityAtRef.current;
+    if (lastActivityAt == null) return false;
+    const visible = typeof document === "undefined" || !document.hidden;
+    return shouldHeartbeat({ visible, lastActivityAt, now: Date.now() });
+  }, []);
+
+  const fire = useCallback(() => {
+    const id = contentIdRef.current;
+    if (!id) return;
+    const fraction = clamp01(getFractionRef.current());
+    const sendFn = sendRef.current ?? defaultSend;
+    sendFn(id, fraction);
+  }, []);
+
+  // Starts the interval only if idle/hidden isn't already blocking it, and
+  // sends one beat immediately rather than waiting up to 30s for the first
+  // tick — covers both the very first activity and resuming from idle.
+  const beginActiveWindow = useCallback(() => {
+    if (intervalRef.current != null) return;
+    if (!isFresh()) return;
+    fire();
+    intervalRef.current = setInterval(() => {
+      if (!isFresh()) {
+        stopInterval();
+        return;
+      }
+      fire();
+    }, HEARTBEAT_INTERVAL_MS);
+  }, [fire, isFresh, stopInterval]);
+
+  const noteActivity = useCallback(() => {
+    if (!contentIdRef.current) return;
+    lastActivityAtRef.current = Date.now();
+    beginActiveWindow();
+  }, [beginActiveWindow]);
+
+  useEffect(() => {
+    const onVisibilityChange = () => {
+      if (document.hidden) {
+        stopInterval();
+        return;
+      }
+      beginActiveWindow();
+    };
+    document.addEventListener("visibilitychange", onVisibilityChange);
+    return () => document.removeEventListener("visibilitychange", onVisibilityChange);
+  }, [beginActiveWindow, stopInterval]);
+
+  // A new (or null) contentId means a different book context — require a
+  // fresh activity signal before beating again rather than carrying stale
+  // activity across content.
+  useEffect(() => {
+    lastActivityAtRef.current = null;
+    stopInterval();
+    return () => stopInterval();
+  }, [contentId, stopInterval]);
+
+  return { noteActivity };
+}

--- a/web/src/lib/formatDuration.test.ts
+++ b/web/src/lib/formatDuration.test.ts
@@ -1,0 +1,39 @@
+// @vitest-environment node
+
+import { describe, expect, it } from "vitest";
+
+import { formatDuration } from "./formatDuration";
+
+describe("formatDuration", () => {
+  it("formats hours and minutes", () => {
+    expect(formatDuration(7800)).toBe("2h 10m");
+  });
+
+  it("formats minutes only, under an hour", () => {
+    expect(formatDuration(2700)).toBe("45m");
+  });
+
+  it("formats an exact hour with zero minutes", () => {
+    expect(formatDuration(3600)).toBe("1h 0m");
+  });
+
+  it("floors partial minutes", () => {
+    expect(formatDuration(119)).toBe("1m");
+  });
+
+  it("returns <1m for durations under a minute", () => {
+    expect(formatDuration(45)).toBe("<1m");
+  });
+
+  it("returns <1m for zero seconds", () => {
+    expect(formatDuration(0)).toBe("<1m");
+  });
+
+  it("returns <1m just under the one-minute boundary", () => {
+    expect(formatDuration(59)).toBe("<1m");
+  });
+
+  it("formats exactly one minute", () => {
+    expect(formatDuration(60)).toBe("1m");
+  });
+});

--- a/web/src/lib/formatDuration.ts
+++ b/web/src/lib/formatDuration.ts
@@ -1,0 +1,14 @@
+/**
+ * Formats a duration in seconds as a short human label: "2h 10m", "45m", or
+ * "<1m" for anything under a minute. Minutes are floored rather than rounded
+ * so the label never overstates time remaining.
+ */
+export function formatDuration(seconds: number): string {
+  if (!Number.isFinite(seconds) || seconds < 60) {
+    return "<1m";
+  }
+  const totalMinutes = Math.floor(seconds / 60);
+  const hours = Math.floor(totalMinutes / 60);
+  const minutes = totalMinutes % 60;
+  return hours > 0 ? `${hours}h ${minutes}m` : `${minutes}m`;
+}

--- a/web/src/pages/EbookReader.test.tsx
+++ b/web/src/pages/EbookReader.test.tsx
@@ -1529,19 +1529,34 @@ describe("EbookReader", () => {
       });
     };
 
+    // Escape precedence: shortcuts overlay, then the side panel, then chrome.
     press("?");
     expect(container.textContent).toContain("Keyboard shortcuts");
     expect(container.textContent).toContain("Previous / next page");
+    expect(container.querySelector("aside")).not.toBeNull(); // panel open by default
 
     press("Escape"); // overlay open — Escape closes it first
     expect(container.textContent).not.toContain("Previous / next page");
     expect(container.querySelector("header")).not.toBeNull();
+    expect(container.querySelector("aside")).not.toBeNull(); // panel untouched
 
-    press("Escape"); // overlay already closed — Escape now toggles chrome
+    press("Escape"); // overlay closed, panel open — Escape closes the panel next
+    expect(container.querySelector("aside")).toBeNull();
+    expect(container.querySelector("header")).not.toBeNull(); // chrome untouched
+
+    press("Escape"); // overlay closed, panel closed — Escape now toggles chrome
     expect(container.querySelector("header")).toBeNull();
 
     press("Escape"); // bring chrome back so the panel toggle button is reachable
     expect(container.querySelector("header")).not.toBeNull();
+
+    const openPanel = container.querySelector<HTMLButtonElement>(
+      'button[aria-label="Open reader panel"]',
+    );
+    await act(async () => {
+      openPanel?.click();
+    });
+    expect(container.querySelector("aside")).not.toBeNull();
 
     const closePanel = container.querySelector<HTMLButtonElement>(
       'button[aria-label="Close reader panel"]',

--- a/web/src/pages/EbookReader.test.tsx
+++ b/web/src/pages/EbookReader.test.tsx
@@ -25,6 +25,10 @@ const mocks = vi.hoisted(() => ({
   lastOnLocationChange: undefined as
     | ((info: { fraction: number; sectionIndex: number | null; tocLabel: string | null }) => void)
     | undefined,
+  lastOnContentPointerUp: undefined as
+    | ((point: { clientX: number; clientY: number }) => void)
+    | undefined,
+  lastOnContentPointerMove: undefined as ((point: { clientY: number }) => void) | undefined,
 }));
 
 vi.mock("@/hooks/queries/catalogRead", () => ({
@@ -78,6 +82,8 @@ vi.mock("@/reader/FoliateBookReader", async () => {
           sectionIndex: number | null;
           tocLabel: string | null;
         }) => void;
+        onContentPointerUp?: (point: { clientX: number; clientY: number }) => void;
+        onContentPointerMove?: (point: { clientY: number }) => void;
         onReady?: (state: {
           toc: Array<{
             id: number;
@@ -96,6 +102,8 @@ vi.mock("@/reader/FoliateBookReader", async () => {
         onFileLoaded,
         onSelectionChange,
         onLocationChange,
+        onContentPointerUp,
+        onContentPointerMove,
         onReady,
       },
       ref,
@@ -104,6 +112,12 @@ vi.mock("@/reader/FoliateBookReader", async () => {
       useEffect(() => {
         mocks.lastOnLocationChange = onLocationChange;
       }, [onLocationChange]);
+      useEffect(() => {
+        mocks.lastOnContentPointerUp = onContentPointerUp;
+      }, [onContentPointerUp]);
+      useEffect(() => {
+        mocks.lastOnContentPointerMove = onContentPointerMove;
+      }, [onContentPointerMove]);
       useImperativeHandle(ref, () => ({
         prev: mocks.readerPrev,
         next: mocks.readerNext,
@@ -928,6 +942,86 @@ describe("EbookReader", () => {
     expect(container.querySelector("footer")).toBeNull();
     act(() => {
       surface.dispatchEvent(new MouseEvent("pointerup", { clientX: 150, bubbles: true }));
+    });
+    expect(container.querySelector("header")).not.toBeNull();
+  });
+
+  // FoliateBookReader is mocked in this file, so these tests only exercise
+  // EbookReader's own dispatch logic once it receives already-converted
+  // viewport coordinates from onContentPointerUp/onContentPointerMove. The
+  // real bridging across the content iframe boundary — translating iframe
+  // pointer/mousemove events into those viewport coordinates via the frame
+  // element's getBoundingClientRect() — is covered by the component test in
+  // FoliateBookReader.component.test.tsx ("forwards pointerup and mousemove
+  // from content iframes with viewport-adjusted coordinates").
+  it("pages on edge taps and toggles chrome on middle tap reported through the content pointer bridge", async () => {
+    await act(async () => {
+      root.render(
+        <MemoryRouter initialEntries={["/reader/ebook/ebook-1"]}>
+          <Routes>
+            <Route path="/reader/ebook/:contentId" element={<EbookReader />} />
+          </Routes>
+        </MemoryRouter>,
+      );
+    });
+
+    // The mock reader reports an active selection on mount; clear it via the
+    // highlight action so tap zones are free to page/toggle chrome.
+    const highlight = container.querySelector<HTMLButtonElement>(
+      'button[aria-label="Highlight selection"]',
+    );
+    await act(async () => {
+      highlight?.click();
+    });
+
+    const surface = container.querySelector("[data-reader-surface]") as HTMLElement;
+    expect(surface).not.toBeNull();
+    surface.getBoundingClientRect = () =>
+      ({
+        left: 0,
+        width: 300,
+        top: 0,
+        height: 500,
+        right: 300,
+        bottom: 500,
+        x: 0,
+        y: 0,
+        toJSON() {
+          return {};
+        },
+      }) as DOMRect;
+
+    expect(mocks.lastOnContentPointerUp).toBeTypeOf("function");
+    expect(mocks.lastOnContentPointerMove).toBeTypeOf("function");
+
+    act(() => {
+      mocks.lastOnContentPointerUp?.({ clientX: 30, clientY: 10 });
+    });
+    expect(mocks.readerPrev).toHaveBeenCalled();
+
+    act(() => {
+      mocks.lastOnContentPointerUp?.({ clientX: 270, clientY: 10 });
+    });
+    expect(mocks.readerNext).toHaveBeenCalled();
+
+    expect(container.querySelector("header")).not.toBeNull();
+    act(() => {
+      mocks.lastOnContentPointerUp?.({ clientX: 150, clientY: 10 });
+    });
+    // Middle tap toggled chrome off.
+    expect(container.querySelector("header")).toBeNull();
+    expect(container.querySelector("footer")).toBeNull();
+
+    // With chrome hidden, a content mousemove near the top viewport edge
+    // (converted to outer coordinates by FoliateBookReader in real usage)
+    // must reveal chrome again, mirroring the window-level mousemove path.
+    act(() => {
+      mocks.lastOnContentPointerMove?.({ clientY: 500 });
+    });
+    expect(container.querySelector("header")).toBeNull();
+
+    act(() => {
+      mocks.lastOnContentPointerMove?.({ clientY: 5 });
     });
     expect(container.querySelector("header")).not.toBeNull();
   });

--- a/web/src/pages/EbookReader.test.tsx
+++ b/web/src/pages/EbookReader.test.tsx
@@ -814,6 +814,64 @@ describe("EbookReader", () => {
     expect(handle?.getAttribute("aria-valuenow")).toBe("50");
   });
 
+  it("does not turn the page when releasing the reading-ruler drag", async () => {
+    await act(async () => {
+      root.render(
+        <MemoryRouter initialEntries={["/reader/ebook/ebook-1"]}>
+          <Routes>
+            <Route path="/reader/ebook/:contentId" element={<EbookReader />} />
+          </Routes>
+        </MemoryRouter>,
+      );
+    });
+
+    const ruler = container.querySelector<HTMLButtonElement>(
+      'button[aria-label="Toggle reading ruler"]',
+    );
+    await act(async () => {
+      ruler?.click();
+    });
+
+    const surface = container.querySelector("[data-reader-surface]") as HTMLElement;
+    surface.getBoundingClientRect = () =>
+      ({
+        left: 0,
+        width: 300,
+        top: 0,
+        height: 500,
+        right: 300,
+        bottom: 500,
+        x: 0,
+        y: 0,
+        toJSON() {
+          return {};
+        },
+      }) as DOMRect;
+
+    const grip = container.querySelector<HTMLButtonElement>(
+      '[role="slider"][aria-label="Reading ruler position"]',
+    )!;
+    // jsdom has no pointer-capture implementation; the grip's handlers call
+    // these unconditionally, so stub them the way a real button would provide.
+    grip.setPointerCapture = vi.fn();
+    grip.releasePointerCapture = vi.fn();
+
+    act(() => {
+      grip.dispatchEvent(
+        new PointerEvent("pointerdown", { clientY: 250, pointerId: 1, bubbles: true }),
+      );
+    });
+    act(() => {
+      // The grip sits near the reading surface's right edge; if this pointerup
+      // bubbles up to the surface's tap handler it reads as a next-page tap.
+      grip.dispatchEvent(
+        new PointerEvent("pointerup", { clientY: 250, pointerId: 1, bubbles: true }),
+      );
+    });
+
+    expect(mocks.readerNext).not.toHaveBeenCalled();
+  });
+
   it("constrains the reader grid so the side panel stays inside the viewport", async () => {
     await act(async () => {
       root.render(

--- a/web/src/pages/EbookReader.test.tsx
+++ b/web/src/pages/EbookReader.test.tsx
@@ -23,6 +23,7 @@ const mocks = vi.hoisted(() => ({
   fetchEbookReaderAnnotations: vi.fn(),
   createEbookReaderAnnotation: vi.fn(),
   deleteEbookReaderAnnotation: vi.fn(),
+  sendReadingHeartbeat: vi.fn(),
   fetchReaderFonts: vi.fn(),
   fetchReaderFontObjectUrl: vi.fn(),
   uploadReaderFont: vi.fn(),
@@ -51,6 +52,7 @@ vi.mock("@/reader/ebookReaderApi", () => ({
   fetchEbookReaderConfig: mocks.fetchEbookReaderConfig,
   saveEbookReaderConfig: mocks.saveEbookReaderConfig,
   saveEbookReaderConfigKeepalive: mocks.saveEbookReaderConfigKeepalive,
+  sendReadingHeartbeat: mocks.sendReadingHeartbeat,
 }));
 
 vi.mock("@/reader/readerFontsApi", () => ({
@@ -304,6 +306,7 @@ describe("EbookReader", () => {
     mocks.fetchEbookReaderAnnotations.mockReset();
     mocks.createEbookReaderAnnotation.mockReset();
     mocks.deleteEbookReaderAnnotation.mockReset();
+    mocks.sendReadingHeartbeat.mockReset();
     mocks.fetchReaderFonts.mockReset();
     mocks.fetchReaderFontObjectUrl.mockReset();
     mocks.uploadReaderFont.mockReset();
@@ -328,6 +331,7 @@ describe("EbookReader", () => {
       color: "#facc15",
     });
     mocks.deleteEbookReaderAnnotation.mockResolvedValue(undefined);
+    mocks.sendReadingHeartbeat.mockResolvedValue(undefined);
     localStorage.clear();
     mocks.useCatalogItemDetail.mockReturnValue({
       data: makeEbookItem(),
@@ -1330,6 +1334,35 @@ describe("EbookReader", () => {
     expect(footer.textContent).toContain("Chapter 2");
     expect(footer.textContent).toContain("30%");
     expect(footer.querySelector("[data-chapter-band]")).not.toBeNull();
+  });
+
+  it("sends a reading heartbeat on relocate, then again every 30s", async () => {
+    vi.useFakeTimers();
+
+    await act(async () => {
+      root.render(
+        <MemoryRouter initialEntries={["/reader/ebook/ebook-1"]}>
+          <Routes>
+            <Route path="/reader/ebook/:contentId" element={<EbookReader />} />
+          </Routes>
+        </MemoryRouter>,
+      );
+    });
+
+    // Relocate is one of the activity signals: it should beat immediately
+    // rather than waiting up to 30s for the first tick.
+    act(() => {
+      mocks.lastOnLocationChange?.({ fraction: 0.3, sectionIndex: 1, tocLabel: "Chapter 2" });
+    });
+    expect(mocks.sendReadingHeartbeat).toHaveBeenCalledWith("ebook-1", 0.3);
+
+    mocks.sendReadingHeartbeat.mockClear();
+    await act(async () => {
+      vi.advanceTimersByTime(30_000);
+    });
+    expect(mocks.sendReadingHeartbeat).toHaveBeenCalledWith("ebook-1", 0.3);
+
+    vi.useRealTimers();
   });
 
   it("scrubs reader progress and supports keyboard page navigation", async () => {

--- a/web/src/pages/EbookReader.test.tsx
+++ b/web/src/pages/EbookReader.test.tsx
@@ -1806,6 +1806,55 @@ describe("EbookReader", () => {
     );
   });
 
+  it("toggles the bookmark at the current location on repeated `b` presses: creates, then deletes", async () => {
+    // The mock reader reports a live selection on mount (cfi
+    // "epubcfi(/6/4,/1:0,/1:12)"), so both presses resolve to the same
+    // location — handleToggleBookmark never clears it the way highlighting
+    // does.
+    mocks.createEbookReaderAnnotation.mockResolvedValueOnce({
+      id: "bm-1",
+      content_id: "ebook-1",
+      kind: "bookmark",
+      location: "epubcfi(/6/4,/1:0,/1:12)",
+      selected_text: "",
+      note: "Reader Book",
+      style: "",
+      color: "",
+    });
+
+    await act(async () => {
+      root.render(
+        <MemoryRouter initialEntries={["/reader/ebook/ebook-1"]}>
+          <Routes>
+            <Route path="/reader/ebook/:contentId" element={<EbookReader />} />
+          </Routes>
+        </MemoryRouter>,
+      );
+    });
+
+    await act(async () => {
+      window.dispatchEvent(new KeyboardEvent("keydown", { key: "b" }));
+    });
+
+    expect(mocks.createEbookReaderAnnotation).toHaveBeenCalledTimes(1);
+    expect(mocks.createEbookReaderAnnotation).toHaveBeenCalledWith("ebook-1", {
+      kind: "bookmark",
+      location: "epubcfi(/6/4,/1:0,/1:12)",
+      note: "Reader Book",
+    });
+    expect(mocks.deleteEbookReaderAnnotation).not.toHaveBeenCalled();
+
+    await act(async () => {
+      window.dispatchEvent(new KeyboardEvent("keydown", { key: "b" }));
+    });
+
+    // Second press at the same location deletes the bookmark just created,
+    // and must not create a second one.
+    expect(mocks.deleteEbookReaderAnnotation).toHaveBeenCalledTimes(1);
+    expect(mocks.deleteEbookReaderAnnotation).toHaveBeenCalledWith("ebook-1", "bm-1");
+    expect(mocks.createEbookReaderAnnotation).toHaveBeenCalledTimes(1);
+  });
+
   it("navigates fraction bookmarks through goToFraction and CFI annotations through goTo", async () => {
     mocks.fetchEbookReaderAnnotations.mockResolvedValue([
       {

--- a/web/src/pages/EbookReader.test.tsx
+++ b/web/src/pages/EbookReader.test.tsx
@@ -1405,6 +1405,43 @@ describe("EbookReader", () => {
     vi.useRealTimers();
   });
 
+  it("does not send a heartbeat or enable the reading-stats query while the item detail is still loading", async () => {
+    // isComicFormat is derived from the loaded item's file versions, so
+    // while useCatalogItemDetail is still pending it's false — the same as
+    // a prose book. Without gating on the item being loaded, a keypress
+    // during this window would fire a stats GET and a spurious heartbeat
+    // for a book that might turn out to be a comic (which the reader must
+    // never track).
+    vi.useFakeTimers();
+    mocks.useCatalogItemDetail.mockReturnValue({
+      data: undefined,
+      isLoading: true,
+      error: null,
+    });
+
+    await act(async () => {
+      root.render(
+        <MemoryRouter initialEntries={["/reader/ebook/ebook-1"]}>
+          <Routes>
+            <Route path="/reader/ebook/:contentId" element={<EbookReader />} />
+          </Routes>
+        </MemoryRouter>,
+      );
+    });
+
+    await act(async () => {
+      window.dispatchEvent(new KeyboardEvent("keydown", { key: "ArrowRight" }));
+      vi.advanceTimersByTime(60_000);
+    });
+
+    expect(mocks.sendReadingHeartbeat).not.toHaveBeenCalled();
+    const lastReadingStatsCall =
+      mocks.useBookReadingStats.mock.calls[mocks.useBookReadingStats.mock.calls.length - 1];
+    expect(lastReadingStatsCall?.[0]).toBeUndefined();
+
+    vi.useRealTimers();
+  });
+
   it("scrubs reader progress and supports keyboard page navigation", async () => {
     await act(async () => {
       root.render(

--- a/web/src/pages/EbookReader.test.tsx
+++ b/web/src/pages/EbookReader.test.tsx
@@ -1424,6 +1424,114 @@ describe("EbookReader", () => {
     expect(value?.className).toContain("justify-self-end");
   });
 
+  it("binds the reader keyboard map with an input guard", async () => {
+    await act(async () => {
+      root.render(
+        <MemoryRouter initialEntries={["/reader/ebook/ebook-1"]}>
+          <Routes>
+            <Route path="/reader/ebook/:contentId" element={<EbookReader />} />
+          </Routes>
+        </MemoryRouter>,
+      );
+    });
+
+    const press = (key: string) => {
+      act(() => {
+        window.dispatchEvent(new KeyboardEvent("keydown", { key, bubbles: true }));
+      });
+    };
+
+    press("?");
+    expect(container.textContent).toContain("Keyboard shortcuts");
+    expect(container.textContent).toContain("Previous / next page");
+
+    press("Escape"); // overlay open — Escape closes it first
+    expect(container.textContent).not.toContain("Previous / next page");
+    expect(container.querySelector("header")).not.toBeNull();
+
+    press("Escape"); // overlay already closed — Escape now toggles chrome
+    expect(container.querySelector("header")).toBeNull();
+
+    press("Escape"); // bring chrome back so the panel toggle button is reachable
+    expect(container.querySelector("header")).not.toBeNull();
+
+    const closePanel = container.querySelector<HTMLButtonElement>(
+      'button[aria-label="Close reader panel"]',
+    );
+    await act(async () => {
+      closePanel?.click();
+    });
+    expect(container.querySelector("aside")).toBeNull();
+
+    // A keydown originating from an editable target (event.target is the
+    // input, not window) must be ignored by the reader shortcut map.
+    const input = document.createElement("input");
+    document.body.appendChild(input);
+    input.focus();
+    act(() => {
+      input.dispatchEvent(new KeyboardEvent("keydown", { key: "t", bubbles: true }));
+    });
+    expect(container.querySelector("aside")).toBeNull();
+    document.body.removeChild(input);
+
+    // Outside of an editable target, "t" reopens the contents panel.
+    press("t");
+    expect(container.querySelector("aside")).not.toBeNull();
+  });
+
+  it("jumps to chapter bounds on Home and End using section fractions", async () => {
+    await act(async () => {
+      root.render(
+        <MemoryRouter initialEntries={["/reader/ebook/ebook-1"]}>
+          <Routes>
+            <Route path="/reader/ebook/:contentId" element={<EbookReader />} />
+          </Routes>
+        </MemoryRouter>,
+      );
+    });
+
+    act(() => {
+      mocks.lastOnLocationChange?.({ fraction: 0.3, sectionIndex: 1, tocLabel: "Ch 2" });
+    });
+
+    act(() => {
+      window.dispatchEvent(new KeyboardEvent("keydown", { key: "Home" }));
+    });
+    expect(mocks.readerGoToFraction).toHaveBeenCalledWith(0.25);
+
+    act(() => {
+      window.dispatchEvent(new KeyboardEvent("keydown", { key: "End" }));
+    });
+    expect(mocks.readerGoToFraction).toHaveBeenCalledWith(0.6);
+  });
+
+  it("keeps Home and End inert for comic formats", async () => {
+    mocks.useCatalogItemDetail.mockReturnValue({
+      data: makeEbookItem({
+        versions: [makeVersion({ file_id: 8, file_name: "Comic.cbz", container: "cbz" })],
+      }),
+      isLoading: false,
+      error: null,
+    });
+
+    await act(async () => {
+      root.render(
+        <MemoryRouter initialEntries={["/reader/ebook/ebook-1"]}>
+          <Routes>
+            <Route path="/reader/ebook/:contentId" element={<EbookReader />} />
+          </Routes>
+        </MemoryRouter>,
+      );
+    });
+
+    act(() => {
+      window.dispatchEvent(new KeyboardEvent("keydown", { key: "Home" }));
+      window.dispatchEvent(new KeyboardEvent("keydown", { key: "End" }));
+    });
+
+    expect(mocks.readerGoToFraction).not.toHaveBeenCalled();
+  });
+
   it("hides paginated-only controls in scrolled flow", async () => {
     await act(async () => {
       root.render(

--- a/web/src/pages/EbookReader.test.tsx
+++ b/web/src/pages/EbookReader.test.tsx
@@ -945,6 +945,36 @@ describe("EbookReader", () => {
     expect(mocks.readerNext).toHaveBeenCalledTimes(1);
   });
 
+  it("does not snap the progress bar back after scrubbing", async () => {
+    await act(async () => {
+      root.render(
+        <MemoryRouter initialEntries={["/reader/ebook/ebook-1"]}>
+          <Routes>
+            <Route path="/reader/ebook/:contentId" element={<EbookReader />} />
+          </Routes>
+        </MemoryRouter>,
+      );
+    });
+
+    // A prior relocate reported a stale fraction (30%); the footer prefers
+    // locationInfo.fraction over readerProgress, so scrubbing must update it
+    // too or the bar snaps back to 30% on the next render.
+    act(() => {
+      mocks.lastOnLocationChange?.({ fraction: 0.3, sectionIndex: 1, tocLabel: "Chapter 2" });
+    });
+
+    const scrubber = container.querySelector<HTMLInputElement>(
+      'input[aria-label="Reading progress"]',
+    );
+    await act(async () => {
+      if (!scrubber) return;
+      setInputValue(scrubber, "65");
+    });
+
+    expect(scrubber?.value).toBe("65");
+    expect(container.querySelector("footer")?.textContent).toContain("65%");
+  });
+
   it("pages on edge taps and toggles chrome on middle tap", async () => {
     await act(async () => {
       root.render(

--- a/web/src/pages/EbookReader.test.tsx
+++ b/web/src/pages/EbookReader.test.tsx
@@ -22,6 +22,9 @@ const mocks = vi.hoisted(() => ({
   fetchEbookReaderAnnotations: vi.fn(),
   createEbookReaderAnnotation: vi.fn(),
   deleteEbookReaderAnnotation: vi.fn(),
+  lastOnLocationChange: undefined as
+    | ((info: { fraction: number; sectionIndex: number | null; tocLabel: string | null }) => void)
+    | undefined,
 }));
 
 vi.mock("@/hooks/queries/catalogRead", () => ({
@@ -61,6 +64,7 @@ vi.mock("@/reader/FoliateBookReader", async () => {
         clearSelection: () => void;
         createSelectionAnnotation: () => { cfi: string; selectedText: string } | null;
         getReadableText: () => string;
+        getSectionFractions: () => number[];
       },
       {
         file: FileVersion;
@@ -69,6 +73,11 @@ vi.mock("@/reader/FoliateBookReader", async () => {
         onProgressChange?: (progress: number | null) => void;
         onFileLoaded?: (state: { objectUrl: string; filename: string } | null) => void;
         onSelectionChange?: (selection: { cfi: string; selectedText: string } | null) => void;
+        onLocationChange?: (info: {
+          fraction: number;
+          sectionIndex: number | null;
+          tocLabel: string | null;
+        }) => void;
         onReady?: (state: {
           toc: Array<{
             id: number;
@@ -80,10 +89,21 @@ vi.mock("@/reader/FoliateBookReader", async () => {
         }) => void;
       }
     >(function MockFoliateBookReader(
-      { file, settings, onProgressChange, onFileLoaded, onSelectionChange, onReady },
+      {
+        file,
+        settings,
+        onProgressChange,
+        onFileLoaded,
+        onSelectionChange,
+        onLocationChange,
+        onReady,
+      },
       ref,
     ) {
       mocks.captureReaderSettings(settings);
+      useEffect(() => {
+        mocks.lastOnLocationChange = onLocationChange;
+      }, [onLocationChange]);
       useImperativeHandle(ref, () => ({
         prev: mocks.readerPrev,
         next: mocks.readerNext,
@@ -97,6 +117,7 @@ vi.mock("@/reader/FoliateBookReader", async () => {
           selectedText: "sample text",
         }),
         getReadableText: () => "Readable text for speech",
+        getSectionFractions: () => [0, 0.25, 0.6, 1],
       }));
       useEffect(() => {
         onFileLoaded?.({ objectUrl: "blob:ebook", filename: "Reader.epub" });
@@ -797,6 +818,29 @@ describe("EbookReader", () => {
     expect(main?.className).toContain("overflow-hidden");
     expect(readerPane?.className).toContain("min-w-0");
     expect(sidePanel?.className).toContain("min-w-0");
+  });
+
+  it("renders the chapter-aware footer instead of a header slider", async () => {
+    await act(async () => {
+      root.render(
+        <MemoryRouter initialEntries={["/reader/ebook/ebook-1"]}>
+          <Routes>
+            <Route path="/reader/ebook/:contentId" element={<EbookReader />} />
+          </Routes>
+        </MemoryRouter>,
+      );
+    });
+
+    act(() => {
+      mocks.lastOnLocationChange?.({ fraction: 0.3, sectionIndex: 1, tocLabel: "Chapter 2" });
+    });
+
+    const header = container.querySelector("header")!;
+    expect(header.querySelector('input[type="range"]')).toBeNull();
+    const footer = container.querySelector("footer")!;
+    expect(footer.textContent).toContain("Chapter 2");
+    expect(footer.textContent).toContain("30%");
+    expect(footer.querySelector("[data-chapter-band]")).not.toBeNull();
   });
 
   it("scrubs reader progress and supports keyboard page navigation", async () => {

--- a/web/src/pages/EbookReader.test.tsx
+++ b/web/src/pages/EbookReader.test.tsx
@@ -873,6 +873,111 @@ describe("EbookReader", () => {
     expect(mocks.readerNext).toHaveBeenCalledTimes(1);
   });
 
+  it("pages on edge taps and toggles chrome on middle tap", async () => {
+    await act(async () => {
+      root.render(
+        <MemoryRouter initialEntries={["/reader/ebook/ebook-1"]}>
+          <Routes>
+            <Route path="/reader/ebook/:contentId" element={<EbookReader />} />
+          </Routes>
+        </MemoryRouter>,
+      );
+    });
+
+    // The mock reader reports an active selection on mount; clear it via the
+    // highlight action so tap zones are free to page/toggle chrome.
+    const highlight = container.querySelector<HTMLButtonElement>(
+      'button[aria-label="Highlight selection"]',
+    );
+    await act(async () => {
+      highlight?.click();
+    });
+
+    const surface = container.querySelector("[data-reader-surface]") as HTMLElement;
+    expect(surface).not.toBeNull();
+    surface.getBoundingClientRect = () =>
+      ({
+        left: 0,
+        width: 300,
+        top: 0,
+        height: 500,
+        right: 300,
+        bottom: 500,
+        x: 0,
+        y: 0,
+        toJSON() {
+          return {};
+        },
+      }) as DOMRect;
+
+    act(() => {
+      surface.dispatchEvent(new MouseEvent("pointerup", { clientX: 30, bubbles: true }));
+    });
+    expect(mocks.readerPrev).toHaveBeenCalled();
+
+    act(() => {
+      surface.dispatchEvent(new MouseEvent("pointerup", { clientX: 270, bubbles: true }));
+    });
+    expect(mocks.readerNext).toHaveBeenCalled();
+
+    expect(container.querySelector("header")).not.toBeNull();
+    act(() => {
+      surface.dispatchEvent(new MouseEvent("pointerup", { clientX: 150, bubbles: true }));
+    });
+    expect(container.querySelector("header")).toBeNull();
+    expect(container.querySelector("footer")).toBeNull();
+    act(() => {
+      surface.dispatchEvent(new MouseEvent("pointerup", { clientX: 150, bubbles: true }));
+    });
+    expect(container.querySelector("header")).not.toBeNull();
+  });
+
+  it("always shows chrome and ignores tap zones for comic formats", async () => {
+    mocks.useCatalogItemDetail.mockReturnValue({
+      data: makeEbookItem({
+        versions: [makeVersion({ file_id: 8, file_name: "Comic.cbz", container: "cbz" })],
+      }),
+      isLoading: false,
+      error: null,
+    });
+
+    await act(async () => {
+      root.render(
+        <MemoryRouter initialEntries={["/reader/ebook/ebook-1"]}>
+          <Routes>
+            <Route path="/reader/ebook/:contentId" element={<EbookReader />} />
+          </Routes>
+        </MemoryRouter>,
+      );
+    });
+
+    const surface = container.querySelector("[data-reader-surface]") as HTMLElement;
+    expect(surface).not.toBeNull();
+    surface.getBoundingClientRect = () =>
+      ({
+        left: 0,
+        width: 300,
+        top: 0,
+        height: 500,
+        right: 300,
+        bottom: 500,
+        x: 0,
+        y: 0,
+        toJSON() {
+          return {};
+        },
+      }) as DOMRect;
+
+    expect(container.querySelector("header")).not.toBeNull();
+    act(() => {
+      surface.dispatchEvent(new MouseEvent("pointerup", { clientX: 150, bubbles: true }));
+    });
+    // Comics never hide chrome, and the tap-zone handler is inert for them.
+    expect(container.querySelector("header")).not.toBeNull();
+    expect(mocks.readerPrev).not.toHaveBeenCalled();
+    expect(mocks.readerNext).not.toHaveBeenCalled();
+  });
+
   it("loads annotations, creates highlights, and deletes annotations", async () => {
     mocks.fetchEbookReaderAnnotations.mockResolvedValue([
       {

--- a/web/src/pages/EbookReader.test.tsx
+++ b/web/src/pages/EbookReader.test.tsx
@@ -10,6 +10,7 @@ import EbookReader from "./EbookReader";
 
 const mocks = vi.hoisted(() => ({
   useCatalogItemDetail: vi.fn(),
+  useBookReadingStats: vi.fn(),
   readerPrev: vi.fn(),
   readerNext: vi.fn(),
   readerGoTo: vi.fn(),
@@ -39,6 +40,10 @@ const mocks = vi.hoisted(() => ({
 
 vi.mock("@/hooks/queries/catalogRead", () => ({
   useCatalogItemDetail: mocks.useCatalogItemDetail,
+}));
+
+vi.mock("@/hooks/queries/readingStats", () => ({
+  useBookReadingStats: mocks.useBookReadingStats,
 }));
 
 vi.mock("@/components/PageBack", () => ({
@@ -293,6 +298,7 @@ describe("EbookReader", () => {
     root = createRoot(container);
     installStorage();
     mocks.useCatalogItemDetail.mockReset();
+    mocks.useBookReadingStats.mockReset();
     mocks.readerPrev.mockReset();
     mocks.readerNext.mockReset();
     mocks.readerGoTo.mockReset();
@@ -338,6 +344,7 @@ describe("EbookReader", () => {
       isLoading: false,
       error: null,
     });
+    mocks.useBookReadingStats.mockReturnValue({ data: undefined });
   });
 
   afterEach(async () => {
@@ -375,6 +382,39 @@ describe("EbookReader", () => {
 
     expect(mocks.readerPrev).toHaveBeenCalledTimes(1);
     expect(mocks.readerNext).toHaveBeenCalledTimes(1);
+  });
+
+  it("shows the time remaining in the footer once reading stats resolve", async () => {
+    mocks.useBookReadingStats.mockReturnValue({
+      data: { pace_fraction_per_hour: 0.1, time_left_seconds: 7800, book_seconds: 36000 },
+    });
+
+    await act(async () => {
+      root.render(
+        <MemoryRouter initialEntries={["/reader/ebook/ebook-1"]}>
+          <Routes>
+            <Route path="/reader/ebook/:contentId" element={<EbookReader />} />
+          </Routes>
+        </MemoryRouter>,
+      );
+    });
+
+    expect(container.textContent).toContain("2h 10m left");
+    expect(mocks.useBookReadingStats).toHaveBeenCalledWith("ebook-1");
+  });
+
+  it("omits the time remaining when reading stats haven't resolved", async () => {
+    await act(async () => {
+      root.render(
+        <MemoryRouter initialEntries={["/reader/ebook/ebook-1"]}>
+          <Routes>
+            <Route path="/reader/ebook/:contentId" element={<EbookReader />} />
+          </Routes>
+        </MemoryRouter>,
+      );
+    });
+
+    expect(container.textContent).not.toContain("left");
   });
 
   it("preserves library context on the back-to-ebook link", async () => {

--- a/web/src/pages/EbookReader.test.tsx
+++ b/web/src/pages/EbookReader.test.tsx
@@ -16,6 +16,7 @@ const mocks = vi.hoisted(() => ({
   readerGoTo: vi.fn(),
   readerGoToFraction: vi.fn(),
   readerSearch: vi.fn(),
+  hasLiveSelection: vi.fn(),
   captureReaderSettings: vi.fn(),
   captureCustomFontUrl: vi.fn(),
   fetchEbookReaderConfig: vi.fn(),
@@ -89,6 +90,7 @@ vi.mock("@/reader/FoliateBookReader", async () => {
         createSelectionAnnotation: () => { cfi: string; selectedText: string } | null;
         getReadableText: () => string;
         getSectionFractions: () => number[];
+        hasLiveSelection: () => boolean;
       },
       {
         file: FileVersion;
@@ -155,6 +157,7 @@ vi.mock("@/reader/FoliateBookReader", async () => {
         }),
         getReadableText: () => "Readable text for speech",
         getSectionFractions: () => [0, 0.25, 0.6, 1],
+        hasLiveSelection: mocks.hasLiveSelection,
       }));
       useEffect(() => {
         onFileLoaded?.({ objectUrl: "blob:ebook", filename: "Reader.epub" });
@@ -304,6 +307,8 @@ describe("EbookReader", () => {
     mocks.readerGoTo.mockReset();
     mocks.readerGoToFraction.mockReset();
     mocks.readerSearch.mockReset();
+    mocks.hasLiveSelection.mockReset();
+    mocks.hasLiveSelection.mockReturnValue(false);
     mocks.captureReaderSettings.mockReset();
     mocks.captureCustomFontUrl.mockReset();
     mocks.fetchEbookReaderConfig.mockReset();
@@ -1559,6 +1564,57 @@ describe("EbookReader", () => {
       surface.dispatchEvent(new MouseEvent("pointerup", { clientX: 150, bubbles: true }));
     });
     expect(container.querySelector("header")).not.toBeNull();
+  });
+
+  it("does not page-turn an edge tap that just finished a selection, even though React selection state already reads null", async () => {
+    await act(async () => {
+      root.render(
+        <MemoryRouter initialEntries={["/reader/ebook/ebook-1"]}>
+          <Routes>
+            <Route path="/reader/ebook/:contentId" element={<EbookReader />} />
+          </Routes>
+        </MemoryRouter>,
+      );
+    });
+
+    // Clear the selection the mock reports on mount so React's `selection`
+    // state is null, mirroring the race: the pointerup ending a selection
+    // fires before FoliateBookReader's deferred onSelectionChange lands, so
+    // by the time dispatchSurfaceTap runs, `selection` is stale/null.
+    const highlight = container.querySelector<HTMLButtonElement>(
+      'button[aria-label="Highlight selection"]',
+    );
+    await act(async () => {
+      highlight?.click();
+    });
+
+    // The reader's synchronous live-selection signal still reports true —
+    // this is what dispatchSurfaceTap must also consult.
+    mocks.hasLiveSelection.mockReturnValue(true);
+
+    const surface = container.querySelector("[data-reader-surface]") as HTMLElement;
+    expect(surface).not.toBeNull();
+    surface.getBoundingClientRect = () =>
+      ({
+        left: 0,
+        width: 300,
+        top: 0,
+        height: 500,
+        right: 300,
+        bottom: 500,
+        x: 0,
+        y: 0,
+        toJSON() {
+          return {};
+        },
+      }) as DOMRect;
+
+    act(() => {
+      // An edge tap, which would otherwise page forward.
+      surface.dispatchEvent(new MouseEvent("pointerup", { clientX: 270, bubbles: true }));
+    });
+
+    expect(mocks.readerNext).not.toHaveBeenCalled();
   });
 
   // FoliateBookReader is mocked in this file, so these tests only exercise

--- a/web/src/pages/EbookReader.test.tsx
+++ b/web/src/pages/EbookReader.test.tsx
@@ -22,6 +22,9 @@ const mocks = vi.hoisted(() => ({
   fetchEbookReaderAnnotations: vi.fn(),
   createEbookReaderAnnotation: vi.fn(),
   deleteEbookReaderAnnotation: vi.fn(),
+  fetchReaderFonts: vi.fn(),
+  uploadReaderFont: vi.fn(),
+  deleteReaderFont: vi.fn(),
   lastOnLocationChange: undefined as
     | ((info: { fraction: number; sectionIndex: number | null; tocLabel: string | null }) => void)
     | undefined,
@@ -46,6 +49,13 @@ vi.mock("@/reader/ebookReaderApi", () => ({
   fetchEbookReaderConfig: mocks.fetchEbookReaderConfig,
   saveEbookReaderConfig: mocks.saveEbookReaderConfig,
   saveEbookReaderConfigKeepalive: mocks.saveEbookReaderConfigKeepalive,
+}));
+
+vi.mock("@/reader/readerFontsApi", () => ({
+  fetchReaderFonts: mocks.fetchReaderFonts,
+  uploadReaderFont: mocks.uploadReaderFont,
+  deleteReaderFont: mocks.deleteReaderFont,
+  readerFontFileUrl: (id: number) => `/api/v1/ebooks/reader-fonts/${id}/file`,
 }));
 
 vi.mock("@/reader/FoliateBookReader", async () => {
@@ -253,6 +263,14 @@ function setInputValue(input: HTMLInputElement, value: string) {
   input.dispatchEvent(new Event("input", { bubbles: true }));
 }
 
+function clickThemeSwatch(container: HTMLDivElement, name: string) {
+  container.querySelector<HTMLButtonElement>(`[data-theme-choice="${name}"]`)?.click();
+}
+
+function clickDarkModeToggle(container: HTMLDivElement) {
+  container.querySelector<HTMLButtonElement>('[aria-label="Reader dark mode"]')?.click();
+}
+
 describe("EbookReader", () => {
   let container: HTMLDivElement;
   let root: Root;
@@ -279,6 +297,10 @@ describe("EbookReader", () => {
     mocks.fetchEbookReaderAnnotations.mockReset();
     mocks.createEbookReaderAnnotation.mockReset();
     mocks.deleteEbookReaderAnnotation.mockReset();
+    mocks.fetchReaderFonts.mockReset();
+    mocks.uploadReaderFont.mockReset();
+    mocks.deleteReaderFont.mockReset();
+    mocks.fetchReaderFonts.mockResolvedValue([]);
     mocks.readerSearch.mockResolvedValue([
       { cfi: "epubcfi(/6/8)", label: "Chapter 2", excerpt: "Shanghai harbor" },
     ]);
@@ -575,11 +597,9 @@ describe("EbookReader", () => {
       settingsTab?.click();
     });
 
-    const theme = container.querySelector<HTMLSelectElement>('select[aria-label="Theme"]');
     await act(async () => {
-      if (!theme) return;
-      theme.value = "dark";
-      theme.dispatchEvent(new Event("change", { bubbles: true }));
+      clickThemeSwatch(container, "default");
+      clickDarkModeToggle(container);
     });
 
     await act(async () => {
@@ -620,11 +640,9 @@ describe("EbookReader", () => {
       settingsTab?.click();
     });
 
-    const theme = container.querySelector<HTMLSelectElement>('select[aria-label="Theme"]');
     await act(async () => {
-      if (!theme) return;
-      theme.value = "dark";
-      theme.dispatchEvent(new Event("change", { bubbles: true }));
+      clickThemeSwatch(container, "default");
+      clickDarkModeToggle(container);
     });
     expect(mocks.saveEbookReaderConfig).not.toHaveBeenCalled();
 
@@ -663,11 +681,8 @@ describe("EbookReader", () => {
       settingsTab?.click();
     });
 
-    const theme = container.querySelector<HTMLSelectElement>('select[aria-label="Theme"]');
     await act(async () => {
-      if (!theme) return;
-      theme.value = "sepia";
-      theme.dispatchEvent(new Event("change", { bubbles: true }));
+      clickThemeSwatch(container, "sepia");
     });
 
     await act(async () => {
@@ -786,6 +801,127 @@ describe("EbookReader", () => {
       }),
     );
     expect(comfortable?.getAttribute("aria-pressed")).toBe("true");
+  });
+
+  it("renders the theme grid and switches palette pairs", async () => {
+    await act(async () => {
+      root.render(
+        <MemoryRouter initialEntries={["/reader/ebook/ebook-1"]}>
+          <Routes>
+            <Route path="/reader/ebook/:contentId" element={<EbookReader />} />
+          </Routes>
+        </MemoryRouter>,
+      );
+    });
+
+    const settingsTab = container.querySelector<HTMLButtonElement>(
+      'button[aria-label="Reader settings"]',
+    );
+    await act(async () => {
+      settingsTab?.click();
+    });
+
+    const ocean = container.querySelector<HTMLButtonElement>('[data-theme-choice="ocean"]');
+    expect(ocean).not.toBeNull();
+    await act(async () => {
+      ocean?.click();
+    });
+
+    expect(mocks.captureReaderSettings).toHaveBeenLastCalledWith(
+      expect.objectContaining({ themeName: "ocean", theme: "light" }),
+    );
+
+    await act(async () => {
+      clickDarkModeToggle(container);
+    });
+
+    expect(mocks.captureReaderSettings).toHaveBeenLastCalledWith(
+      expect.objectContaining({ themeName: "ocean", themeVariant: "dark", theme: "dark" }),
+    );
+  });
+
+  it("disables the variant toggle for AMOLED", async () => {
+    await act(async () => {
+      root.render(
+        <MemoryRouter initialEntries={["/reader/ebook/ebook-1"]}>
+          <Routes>
+            <Route path="/reader/ebook/:contentId" element={<EbookReader />} />
+          </Routes>
+        </MemoryRouter>,
+      );
+    });
+
+    const settingsTab = container.querySelector<HTMLButtonElement>(
+      'button[aria-label="Reader settings"]',
+    );
+    await act(async () => {
+      settingsTab?.click();
+    });
+
+    await act(async () => {
+      clickThemeSwatch(container, "amoled");
+    });
+
+    const toggle = container.querySelector<HTMLButtonElement>('[aria-label="Reader dark mode"]');
+    expect(toggle?.disabled).toBe(true);
+  });
+
+  it("offers uploaded fonts in the font picker and falls back on delete", async () => {
+    mocks.fetchReaderFonts.mockResolvedValue([
+      { id: 3, name: "Literata", filename: "l.woff2", created_at: "" },
+    ]);
+    mocks.deleteReaderFont.mockResolvedValue(undefined);
+
+    await act(async () => {
+      root.render(
+        <MemoryRouter initialEntries={["/reader/ebook/ebook-1"]}>
+          <Routes>
+            <Route path="/reader/ebook/:contentId" element={<EbookReader />} />
+          </Routes>
+        </MemoryRouter>,
+      );
+    });
+
+    const settingsTab = container.querySelector<HTMLButtonElement>(
+      'button[aria-label="Reader settings"]',
+    );
+    await act(async () => {
+      settingsTab?.click();
+    });
+    await act(async () => {
+      await Promise.resolve();
+    });
+
+    const font = container.querySelector<HTMLSelectElement>('select[aria-label="Font family"]');
+    const uploadedGroup = font?.querySelector('optgroup[label="Uploaded"]');
+    expect(uploadedGroup).not.toBeNull();
+    const option = uploadedGroup?.querySelector<HTMLOptionElement>('option[value="custom:3"]');
+    expect(option?.textContent).toBe("Literata");
+
+    await act(async () => {
+      if (!font) return;
+      font.value = "custom:3";
+      font.dispatchEvent(new Event("change", { bubbles: true }));
+    });
+
+    expect(mocks.captureReaderSettings).toHaveBeenLastCalledWith(
+      expect.objectContaining({ fontFamily: "custom", customFontID: 3 }),
+    );
+
+    const deleteButton = container.querySelector<HTMLButtonElement>(
+      'button[aria-label="Delete font Literata"]',
+    );
+    await act(async () => {
+      deleteButton?.click();
+    });
+    await act(async () => {
+      await Promise.resolve();
+    });
+
+    expect(mocks.deleteReaderFont).toHaveBeenCalledWith(3);
+    expect(mocks.captureReaderSettings).toHaveBeenLastCalledWith(
+      expect.objectContaining({ fontFamily: "inherit", customFontID: null }),
+    );
   });
 
   it("toggles the persisted reading ruler overlay", async () => {
@@ -1308,11 +1444,9 @@ describe("EbookReader", () => {
       settingsTab?.click();
     });
 
-    const theme = container.querySelector<HTMLSelectElement>('select[aria-label="Theme"]');
     await act(async () => {
-      if (!theme) return;
-      theme.value = "dark";
-      theme.dispatchEvent(new Event("change", { bubbles: true }));
+      clickThemeSwatch(container, "default");
+      clickDarkModeToggle(container);
     });
 
     await act(async () => {

--- a/web/src/pages/EbookReader.test.tsx
+++ b/web/src/pages/EbookReader.test.tsx
@@ -924,6 +924,184 @@ describe("EbookReader", () => {
     );
   });
 
+  it("keeps a saved custom font selection through a transient fonts-list fetch failure", async () => {
+    mocks.fetchReaderFonts.mockReset();
+    mocks.fetchReaderFonts.mockRejectedValue(new Error("network error"));
+    mocks.fetchEbookReaderConfig.mockResolvedValue({
+      settings: { customFontID: 3, fontFamily: "custom" },
+    });
+    vi.useFakeTimers();
+
+    await act(async () => {
+      root.render(
+        <MemoryRouter initialEntries={["/reader/ebook/ebook-1"]}>
+          <Routes>
+            <Route path="/reader/ebook/:contentId" element={<EbookReader />} />
+          </Routes>
+        </MemoryRouter>,
+      );
+    });
+
+    await act(async () => {
+      await Promise.resolve();
+    });
+
+    const settingsTab = container.querySelector<HTMLButtonElement>(
+      'button[aria-label="Reader settings"]',
+    );
+    await act(async () => {
+      settingsTab?.click();
+    });
+
+    // Let the rejected fetchReaderFonts() promise settle.
+    await act(async () => {
+      await Promise.resolve();
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    await act(async () => {
+      vi.advanceTimersByTime(1000);
+    });
+
+    expect(mocks.saveEbookReaderConfig).not.toHaveBeenCalledWith(
+      "ebook-1",
+      expect.objectContaining({
+        settings: expect.objectContaining({ customFontID: null }),
+      }),
+    );
+
+    vi.useRealTimers();
+  });
+
+  it("retries the fonts fetch after a failure the next time the panel opens", async () => {
+    mocks.fetchReaderFonts.mockReset();
+    mocks.fetchReaderFonts.mockRejectedValueOnce(new Error("network error"));
+    mocks.fetchReaderFonts.mockResolvedValueOnce([
+      { id: 3, name: "Literata", filename: "l.woff2", created_at: "" },
+    ]);
+
+    await act(async () => {
+      root.render(
+        <MemoryRouter initialEntries={["/reader/ebook/ebook-1"]}>
+          <Routes>
+            <Route path="/reader/ebook/:contentId" element={<EbookReader />} />
+          </Routes>
+        </MemoryRouter>,
+      );
+    });
+
+    const settingsTab = container.querySelector<HTMLButtonElement>(
+      'button[aria-label="Reader settings"]',
+    );
+    const tocTab = container.querySelector<HTMLButtonElement>(
+      'button[aria-label="Table of contents"]',
+    );
+    await act(async () => {
+      settingsTab?.click();
+    });
+    await act(async () => {
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    expect(mocks.fetchReaderFonts).toHaveBeenCalledTimes(1);
+
+    await act(async () => {
+      tocTab?.click();
+    });
+    await act(async () => {
+      settingsTab?.click();
+    });
+    await act(async () => {
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    expect(mocks.fetchReaderFonts).toHaveBeenCalledTimes(2);
+
+    const font = container.querySelector<HTMLSelectElement>('select[aria-label="Font family"]');
+    const uploadedGroup = font?.querySelector('optgroup[label="Uploaded"]');
+    expect(uploadedGroup).not.toBeNull();
+  });
+
+  it("skips the fonts fetch entirely for comic formats", async () => {
+    mocks.useCatalogItemDetail.mockReturnValue({
+      data: makeEbookItem({
+        versions: [makeVersion({ file_id: 8, file_name: "Comic.cbz", container: "cbz" })],
+      }),
+      isLoading: false,
+      error: null,
+    });
+
+    await act(async () => {
+      root.render(
+        <MemoryRouter initialEntries={["/reader/ebook/ebook-1"]}>
+          <Routes>
+            <Route path="/reader/ebook/:contentId" element={<EbookReader />} />
+          </Routes>
+        </MemoryRouter>,
+      );
+    });
+
+    const settingsTab = container.querySelector<HTMLButtonElement>(
+      'button[aria-label="Reader settings"]',
+    );
+    await act(async () => {
+      settingsTab?.click();
+    });
+    await act(async () => {
+      await Promise.resolve();
+    });
+
+    expect(mocks.fetchReaderFonts).not.toHaveBeenCalled();
+  });
+
+  it("surfaces a delete-font failure as an inline error instead of an unhandled rejection", async () => {
+    mocks.fetchReaderFonts.mockResolvedValue([
+      { id: 3, name: "Literata", filename: "l.woff2", created_at: "" },
+    ]);
+    mocks.deleteReaderFont.mockRejectedValue(new Error("boom"));
+
+    await act(async () => {
+      root.render(
+        <MemoryRouter initialEntries={["/reader/ebook/ebook-1"]}>
+          <Routes>
+            <Route path="/reader/ebook/:contentId" element={<EbookReader />} />
+          </Routes>
+        </MemoryRouter>,
+      );
+    });
+
+    const settingsTab = container.querySelector<HTMLButtonElement>(
+      'button[aria-label="Reader settings"]',
+    );
+    await act(async () => {
+      settingsTab?.click();
+    });
+    await act(async () => {
+      await Promise.resolve();
+    });
+
+    const deleteButton = container.querySelector<HTMLButtonElement>(
+      'button[aria-label="Delete font Literata"]',
+    );
+    await act(async () => {
+      deleteButton?.click();
+    });
+    await act(async () => {
+      await Promise.resolve();
+    });
+
+    expect(mocks.deleteReaderFont).toHaveBeenCalledWith(3);
+    // The font must still be listed — the optimistic removal never happened.
+    const uploadedGroup = container
+      .querySelector<HTMLSelectElement>('select[aria-label="Font family"]')
+      ?.querySelector('optgroup[label="Uploaded"]');
+    expect(uploadedGroup?.querySelector('option[value="custom:3"]')).not.toBeNull();
+    expect(container.textContent).toContain("Font delete failed.");
+  });
+
   it("toggles the persisted reading ruler overlay", async () => {
     await act(async () => {
       root.render(

--- a/web/src/pages/EbookReader.test.tsx
+++ b/web/src/pages/EbookReader.test.tsx
@@ -16,6 +16,7 @@ const mocks = vi.hoisted(() => ({
   readerGoToFraction: vi.fn(),
   readerSearch: vi.fn(),
   captureReaderSettings: vi.fn(),
+  captureCustomFontUrl: vi.fn(),
   fetchEbookReaderConfig: vi.fn(),
   saveEbookReaderConfig: vi.fn(),
   saveEbookReaderConfigKeepalive: vi.fn(),
@@ -23,6 +24,7 @@ const mocks = vi.hoisted(() => ({
   createEbookReaderAnnotation: vi.fn(),
   deleteEbookReaderAnnotation: vi.fn(),
   fetchReaderFonts: vi.fn(),
+  fetchReaderFontObjectUrl: vi.fn(),
   uploadReaderFont: vi.fn(),
   deleteReaderFont: vi.fn(),
   lastOnLocationChange: undefined as
@@ -53,6 +55,7 @@ vi.mock("@/reader/ebookReaderApi", () => ({
 
 vi.mock("@/reader/readerFontsApi", () => ({
   fetchReaderFonts: mocks.fetchReaderFonts,
+  fetchReaderFontObjectUrl: mocks.fetchReaderFontObjectUrl,
   uploadReaderFont: mocks.uploadReaderFont,
   deleteReaderFont: mocks.deleteReaderFont,
   readerFontFileUrl: (id: number) => `/api/v1/ebooks/reader-fonts/${id}/file`,
@@ -83,6 +86,7 @@ vi.mock("@/reader/FoliateBookReader", async () => {
       {
         file: FileVersion;
         settings?: unknown;
+        customFontUrl?: string | null;
         annotations?: unknown[];
         onProgressChange?: (progress: number | null) => void;
         onFileLoaded?: (state: { objectUrl: string; filename: string } | null) => void;
@@ -108,6 +112,7 @@ vi.mock("@/reader/FoliateBookReader", async () => {
       {
         file,
         settings,
+        customFontUrl,
         onProgressChange,
         onFileLoaded,
         onSelectionChange,
@@ -119,6 +124,7 @@ vi.mock("@/reader/FoliateBookReader", async () => {
       ref,
     ) {
       mocks.captureReaderSettings(settings);
+      mocks.captureCustomFontUrl(customFontUrl);
       useEffect(() => {
         mocks.lastOnLocationChange = onLocationChange;
       }, [onLocationChange]);
@@ -291,6 +297,7 @@ describe("EbookReader", () => {
     mocks.readerGoToFraction.mockReset();
     mocks.readerSearch.mockReset();
     mocks.captureReaderSettings.mockReset();
+    mocks.captureCustomFontUrl.mockReset();
     mocks.fetchEbookReaderConfig.mockReset();
     mocks.saveEbookReaderConfig.mockReset();
     mocks.saveEbookReaderConfigKeepalive.mockReset();
@@ -298,9 +305,12 @@ describe("EbookReader", () => {
     mocks.createEbookReaderAnnotation.mockReset();
     mocks.deleteEbookReaderAnnotation.mockReset();
     mocks.fetchReaderFonts.mockReset();
+    mocks.fetchReaderFontObjectUrl.mockReset();
     mocks.uploadReaderFont.mockReset();
     mocks.deleteReaderFont.mockReset();
     mocks.fetchReaderFonts.mockResolvedValue([]);
+    mocks.fetchReaderFontObjectUrl.mockImplementation(async (id: number) => `blob:mock-font-${id}`);
+    URL.revokeObjectURL = vi.fn();
     mocks.readerSearch.mockResolvedValue([
       { cfi: "epubcfi(/6/8)", label: "Chapter 2", excerpt: "Shanghai harbor" },
     ]);
@@ -908,6 +918,15 @@ describe("EbookReader", () => {
       expect.objectContaining({ fontFamily: "custom", customFontID: 3 }),
     );
 
+    await act(async () => {
+      await Promise.resolve();
+    });
+
+    // The reader must receive an authenticated blob: URL for the font, never
+    // the raw API path (a browser-native @font-face fetch can't carry auth).
+    expect(mocks.fetchReaderFontObjectUrl).toHaveBeenCalledWith(3);
+    expect(mocks.captureCustomFontUrl).toHaveBeenLastCalledWith("blob:mock-font-3");
+
     const deleteButton = container.querySelector<HTMLButtonElement>(
       'button[aria-label="Delete font Literata"]',
     );
@@ -922,6 +941,90 @@ describe("EbookReader", () => {
     expect(mocks.captureReaderSettings).toHaveBeenLastCalledWith(
       expect.objectContaining({ fontFamily: "inherit", customFontID: null }),
     );
+    // Falling back off the deleted font must revoke the blob: URL it created.
+    expect(URL.revokeObjectURL).toHaveBeenCalledWith("blob:mock-font-3");
+    expect(mocks.captureCustomFontUrl).toHaveBeenLastCalledWith(null);
+  });
+
+  it("falls back to the book's own typeface when the font blob fetch fails", async () => {
+    mocks.fetchReaderFonts.mockResolvedValue([
+      { id: 3, name: "Literata", filename: "l.woff2", created_at: "" },
+    ]);
+    mocks.fetchReaderFontObjectUrl.mockRejectedValue(new Error("network error"));
+
+    await act(async () => {
+      root.render(
+        <MemoryRouter initialEntries={["/reader/ebook/ebook-1"]}>
+          <Routes>
+            <Route path="/reader/ebook/:contentId" element={<EbookReader />} />
+          </Routes>
+        </MemoryRouter>,
+      );
+    });
+
+    const settingsTab = container.querySelector<HTMLButtonElement>(
+      'button[aria-label="Reader settings"]',
+    );
+    await act(async () => {
+      settingsTab?.click();
+    });
+    await act(async () => {
+      await Promise.resolve();
+    });
+
+    const font = container.querySelector<HTMLSelectElement>('select[aria-label="Font family"]');
+    await act(async () => {
+      if (!font) return;
+      font.value = "custom:3";
+      font.dispatchEvent(new Event("change", { bubbles: true }));
+    });
+    await act(async () => {
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    expect(mocks.fetchReaderFontObjectUrl).toHaveBeenCalledWith(3);
+    // A rejected fetch must leave the font url null rather than passing a
+    // stale/undefined value through to the reader's CSS.
+    expect(mocks.captureCustomFontUrl).toHaveBeenLastCalledWith(null);
+  });
+
+  it("shows a loading placeholder instead of a blank select while a saved custom font hasn't loaded yet", async () => {
+    mocks.fetchEbookReaderConfig.mockResolvedValue({
+      settings: { customFontID: 3, fontFamily: "custom" },
+    });
+    // Never resolves within this test, simulating the fonts list still loading.
+    mocks.fetchReaderFonts.mockReturnValue(new Promise(() => {}));
+
+    await act(async () => {
+      root.render(
+        <MemoryRouter initialEntries={["/reader/ebook/ebook-1"]}>
+          <Routes>
+            <Route path="/reader/ebook/:contentId" element={<EbookReader />} />
+          </Routes>
+        </MemoryRouter>,
+      );
+    });
+    await act(async () => {
+      await Promise.resolve();
+    });
+
+    const settingsTab = container.querySelector<HTMLButtonElement>(
+      'button[aria-label="Reader settings"]',
+    );
+    await act(async () => {
+      settingsTab?.click();
+    });
+    await act(async () => {
+      await Promise.resolve();
+    });
+
+    const font = container.querySelector<HTMLSelectElement>('select[aria-label="Font family"]');
+    expect(font?.value).toBe("custom:3");
+    const placeholder = font?.querySelector<HTMLOptionElement>('option[value="custom:3"]');
+    expect(placeholder).not.toBeNull();
+    expect(placeholder?.disabled).toBe(true);
+    expect(placeholder?.textContent).toBe("Loading uploaded font…");
   });
 
   it("keeps a saved custom font selection through a transient fonts-list fetch failure", async () => {

--- a/web/src/pages/EbookReader.test.tsx
+++ b/web/src/pages/EbookReader.test.tsx
@@ -1654,7 +1654,6 @@ describe("EbookReader", () => {
     });
 
     expect(container.querySelector('input[aria-label="Width"]')).not.toBeNull();
-    expect(container.querySelector('select[aria-label="Spread"]')).not.toBeNull();
 
     const flow = container.querySelector<HTMLSelectElement>('select[aria-label="Flow"]');
     await act(async () => {
@@ -1664,6 +1663,5 @@ describe("EbookReader", () => {
     });
 
     expect(container.querySelector('input[aria-label="Width"]')).toBeNull();
-    expect(container.querySelector('select[aria-label="Spread"]')).toBeNull();
   });
 });

--- a/web/src/pages/EbookReader.tsx
+++ b/web/src/pages/EbookReader.tsx
@@ -268,6 +268,12 @@ export default function EbookReader() {
   // ruler) is meaningless and the side panel steals width the pages need, so
   // it starts closed (the toggle still opens it).
   const isComicFormat = format === "cbz" || format === "cbr";
+  // isComicFormat is derived from the loaded item's file versions, so while
+  // the detail query is still pending it defaults to false — indistinguishable
+  // from a prose book. Trackers below must stay off until the item has
+  // actually loaded, or a keypress during that window can fire a stats GET
+  // and a spurious heartbeat for what turns out to be a comic.
+  const readerKindKnown = Boolean(item);
   const readerRef = useRef<FoliateBookReaderHandle>(null);
   const [loadedFile, setLoadedFile] = useState<ReaderLoadState | null>(null);
   const [readerProgress, setReaderProgress] = useState<number | null>(null);
@@ -301,12 +307,14 @@ export default function EbookReader() {
   const tts = useTTS();
   useScreenWakeLock(wakeLockEnabled);
   const { noteActivity: noteReadingActivity } = useReadingHeartbeat({
-    contentId: isComicFormat ? null : contentId || null,
+    contentId: readerKindKnown && !isComicFormat ? contentId || null : null,
     getFraction: () => locationInfoRef.current?.fraction ?? readerProgress ?? 0,
   });
   // Pace/time-left estimates only make sense for prose; comics have no
   // reading-speed signal to project against.
-  const readingStats = useBookReadingStats(!isComicFormat && contentId ? contentId : undefined);
+  const readingStats = useBookReadingStats(
+    readerKindKnown && !isComicFormat && contentId ? contentId : undefined,
+  );
   const configLoadedRef = useRef(false);
   // Tracks settings the user changed in this session so a slow server config
   // fetch cannot clobber them after the fact.

--- a/web/src/pages/EbookReader.tsx
+++ b/web/src/pages/EbookReader.tsx
@@ -79,6 +79,7 @@ import {
 import { chapterExtent, tapZoneAction } from "@/reader/readerNavigation";
 import {
   deleteReaderFont,
+  fetchReaderFontObjectUrl,
   fetchReaderFonts,
   uploadReaderFont,
   type ReaderFontMeta,
@@ -422,6 +423,56 @@ export default function EbookReader() {
     if (readerFonts.some((font) => font.id === readerSettings.customFontID)) return;
     updateReaderSettings({ customFontID: null, fontFamily: READER_FONT_STACKS.inherit });
   }, [readerFontsLoadOk, readerFonts, readerSettings.customFontID, updateReaderSettings]);
+  // Holds an authenticated blob: URL for the selected custom font, since the
+  // reader's injected CSS can't fetch the protected font file itself (see
+  // readerFontsApi.fetchReaderFontObjectUrl for why). Re-fetched whenever the
+  // selection changes. The currently-live URL is tracked in a ref (rather
+  // than only in state) so it can be revoked exactly once it's superseded by
+  // a freshly fetched one, or on unmount — never while it's still the URL
+  // referenced by readerStyles, which would leave the reader pointed at a
+  // dead blob until the replacement arrives.
+  const [customFontUrl, setCustomFontUrl] = useState<string | null>(null);
+  const customFontUrlRef = useRef<string | null>(null);
+  useEffect(() => {
+    if (isComicFormat || readerSettings.customFontID == null) {
+      if (customFontUrlRef.current) {
+        URL.revokeObjectURL(customFontUrlRef.current);
+        customFontUrlRef.current = null;
+      }
+      setCustomFontUrl(null);
+      return;
+    }
+    let cancelled = false;
+    fetchReaderFontObjectUrl(readerSettings.customFontID)
+      .then((url) => {
+        if (cancelled) {
+          URL.revokeObjectURL(url);
+          return;
+        }
+        const previous = customFontUrlRef.current;
+        customFontUrlRef.current = url;
+        setCustomFontUrl(url);
+        if (previous) URL.revokeObjectURL(previous);
+      })
+      .catch(() => {
+        // Leave customFontUrl null; readerStyles falls back to the book's own
+        // typeface when no font url is available.
+        if (!cancelled) setCustomFontUrl(null);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [isComicFormat, readerSettings.customFontID]);
+  // Revokes whatever URL is still live when the reader itself unmounts (a
+  // font-selection change is handled above, inline with the fetch).
+  useEffect(() => {
+    return () => {
+      if (customFontUrlRef.current) {
+        URL.revokeObjectURL(customFontUrlRef.current);
+        customFontUrlRef.current = null;
+      }
+    };
+  }, []);
   const handleFontUpload = useCallback(async (event: ReactChangeEvent<HTMLInputElement>) => {
     const file = event.target.files?.[0];
     event.target.value = "";
@@ -995,6 +1046,7 @@ export default function EbookReader() {
               file={selectedFile}
               title={item.title}
               settings={readerSettings}
+              customFontUrl={customFontUrl}
               annotations={annotations}
               onFileLoaded={handleFileLoaded}
               onProgressChange={handleProgressChange}
@@ -1417,6 +1469,16 @@ export default function EbookReader() {
                           readerSettings.fontFamily !== "custom" && (
                             <option value={readerSettings.fontFamily}>Custom</option>
                           )}
+                        {readerSettings.customFontID != null && !readerFontsLoadOk && (
+                          // The uploaded-fonts list (and thus the matching
+                          // <option>) hasn't loaded yet for a saved custom-font
+                          // selection; without this the select's value has no
+                          // matching option and renders blank instead of
+                          // showing what's selected.
+                          <option value={`custom:${readerSettings.customFontID}`} disabled>
+                            Loading uploaded font…
+                          </option>
+                        )}
                         {readerFonts.length > 0 && (
                           <optgroup label="Uploaded">
                             {readerFonts.map((font) => (

--- a/web/src/pages/EbookReader.tsx
+++ b/web/src/pages/EbookReader.tsx
@@ -69,7 +69,7 @@ import {
   saveEbookReaderConfigKeepalive,
   type EbookReaderAnnotation,
 } from "@/reader/ebookReaderApi";
-import { chapterExtent } from "@/reader/readerNavigation";
+import { chapterExtent, tapZoneAction } from "@/reader/readerNavigation";
 import ReaderFooter from "@/reader/ReaderFooter";
 
 export const EBOOK_READER_SETTINGS_STORAGE_KEY = "silo.ebook.reader.settings";
@@ -280,6 +280,9 @@ export default function EbookReader() {
   const [searchText, setSearchText] = useState("");
   const [searchResults, setSearchResults] = useState<ReaderSearchResult[]>([]);
   const [searching, setSearching] = useState(false);
+  // Comics always keep chrome visible (see the render gate below); this state
+  // only ever toggles for prose/paginated formats.
+  const [chromeVisible, setChromeVisible] = useState(true);
   const progressLabel = formatReaderProgress(readerProgress);
   const tocEntries = useMemo(() => flattenToc(toc), [toc]);
   const chapterBand = useMemo(() => {
@@ -367,6 +370,22 @@ export default function EbookReader() {
     setReaderProgress(next);
     void readerRef.current?.goToFraction(next);
   }, []);
+  const handleSurfacePointerUp = useCallback(
+    (event: PointerEvent<HTMLElement>) => {
+      if (isComicFormat) return;
+      const rect = event.currentTarget.getBoundingClientRect();
+      if (rect.width <= 0) return;
+      const action = tapZoneAction({
+        xRatio: (event.clientX - rect.left) / rect.width,
+        flow: readerSettings.flow,
+        hasSelection: Boolean(selection),
+      });
+      if (action === "prev") readerRef.current?.prev();
+      else if (action === "next") readerRef.current?.next();
+      else if (action === "toggle-chrome") setChromeVisible((visible) => !visible);
+    },
+    [isComicFormat, readerSettings.flow, selection],
+  );
   const handleCreateHighlight = useCallback(async () => {
     if (!contentId || !selection) return;
     const created = await createEbookReaderAnnotation(contentId, {
@@ -539,6 +558,19 @@ export default function EbookReader() {
   useEffect(() => {
     void reloadAnnotations();
   }, [reloadAnnotations]);
+
+  // Lets a mouse hovering near the top/bottom edge bring hidden chrome back
+  // without a click, mirroring desktop reader/video-player conventions.
+  useEffect(() => {
+    if (chromeVisible) return;
+    const onMove = (event: MouseEvent) => {
+      if (event.clientY < 24 || window.innerHeight - event.clientY < 24) {
+        setChromeVisible(true);
+      }
+    };
+    window.addEventListener("mousemove", onMove);
+    return () => window.removeEventListener("mousemove", onMove);
+  }, [chromeVisible]);
   if (isLoading) {
     return (
       <div className="flex min-h-[70vh] items-center justify-center">
@@ -600,129 +632,135 @@ export default function EbookReader() {
     );
   }
 
+  const showChrome = chromeVisible || isComicFormat;
+
   return (
     <div className="bg-background flex h-screen flex-col">
-      <header className="border-border/70 bg-background/95 sticky top-0 z-20 border-b backdrop-blur">
-        <div className="flex h-14 items-center gap-3 px-4">
-          <Button asChild variant="ghost" size="icon" aria-label="Back">
-            <Link to={backHref}>
-              <ArrowLeft className="size-5" />
-            </Link>
-          </Button>
-          <div className="min-w-0 flex-1">
-            <div className="truncate text-sm font-semibold">{item.title}</div>
-            <div className="text-muted-foreground truncate text-xs">{format.toUpperCase()}</div>
-          </div>
-          {nextChapterHref && nextChapter && (
-            <Button
-              asChild
-              variant="ghost"
-              size="sm"
-              className="hidden gap-1 sm:inline-flex"
-              title={`Next: ${nextChapter.label}`}
-            >
-              <Link to={nextChapterHref}>
-                <span className="text-muted-foreground max-w-36 truncate text-xs">
-                  {nextChapter.label}
-                </span>
-                <ChevronRight className="size-4" />
+      {showChrome && (
+        <header className="border-border/70 bg-background/95 sticky top-0 z-20 border-b backdrop-blur">
+          <div className="flex h-14 items-center gap-3 px-4">
+            <Button asChild variant="ghost" size="icon" aria-label="Back">
+              <Link to={backHref}>
+                <ArrowLeft className="size-5" />
               </Link>
             </Button>
-          )}
-          {progressLabel && (
-            <div className="text-muted-foreground hidden min-w-12 text-center text-xs tabular-nums sm:block">
-              {progressLabel}
+            <div className="min-w-0 flex-1">
+              <div className="truncate text-sm font-semibold">{item.title}</div>
+              <div className="text-muted-foreground truncate text-xs">{format.toUpperCase()}</div>
             </div>
-          )}
-          {isReaderSupportedFile(selectedFile) && readerFiles.length > 1 && (
-            <select
-              aria-label="Reader file"
-              value={selectedFile.file_id}
-              onChange={(event) => handleFileChange(event.target.value)}
-              className="border-border bg-background text-foreground focus-visible:border-ring focus-visible:ring-ring/50 hidden h-8 max-w-44 rounded-md border px-2 text-xs outline-none focus-visible:ring-[3px] sm:block"
-            >
-              {readerFiles.map((file) => (
-                <option key={file.file_id} value={file.file_id}>
-                  {readerFileLabel(file)}
-                </option>
-              ))}
-            </select>
-          )}
-          <div className="flex shrink-0 items-center gap-1">
-            {selection && (
+            {nextChapterHref && nextChapter && (
               <Button
-                variant="secondary"
+                asChild
+                variant="ghost"
                 size="sm"
-                aria-label="Highlight selection"
-                title="Highlight selection"
-                onClick={() => void handleCreateHighlight()}
+                className="hidden gap-1 sm:inline-flex"
+                title={`Next: ${nextChapter.label}`}
               >
-                <Highlighter className="size-4" />
-                Highlight
+                <Link to={nextChapterHref}>
+                  <span className="text-muted-foreground max-w-36 truncate text-xs">
+                    {nextChapter.label}
+                  </span>
+                  <ChevronRight className="size-4" />
+                </Link>
               </Button>
             )}
-            <Button
-              variant="ghost"
-              size="icon-sm"
-              aria-label="Add bookmark"
-              title="Add bookmark"
-              onClick={() => void handleCreateBookmark()}
-            >
-              <Bookmark className="size-4" />
-            </Button>
-            {!isComicFormat && (
-              <Button
-                variant={readerSettings.readingRuler ? "secondary" : "ghost"}
-                size="icon-sm"
-                aria-label="Toggle reading ruler"
-                title="Reading ruler"
-                onClick={() => updateReaderSettings({ readingRuler: !readerSettings.readingRuler })}
-              >
-                <Ruler className="size-4" />
-              </Button>
+            {progressLabel && (
+              <div className="text-muted-foreground hidden min-w-12 text-center text-xs tabular-nums sm:block">
+                {progressLabel}
+              </div>
             )}
-            <Button
-              variant="ghost"
-              size="icon-sm"
-              aria-label={panelOpen ? "Close reader panel" : "Open reader panel"}
-              title={panelOpen ? "Close reader panel" : "Open reader panel"}
-              onClick={() => setPanelOpen((open) => !open)}
-            >
-              {panelOpen ? (
-                <PanelRightClose className="size-4" />
-              ) : (
-                <PanelRightOpen className="size-4" />
+            {isReaderSupportedFile(selectedFile) && readerFiles.length > 1 && (
+              <select
+                aria-label="Reader file"
+                value={selectedFile.file_id}
+                onChange={(event) => handleFileChange(event.target.value)}
+                className="border-border bg-background text-foreground focus-visible:border-ring focus-visible:ring-ring/50 hidden h-8 max-w-44 rounded-md border px-2 text-xs outline-none focus-visible:ring-[3px] sm:block"
+              >
+                {readerFiles.map((file) => (
+                  <option key={file.file_id} value={file.file_id}>
+                    {readerFileLabel(file)}
+                  </option>
+                ))}
+              </select>
+            )}
+            <div className="flex shrink-0 items-center gap-1">
+              {selection && (
+                <Button
+                  variant="secondary"
+                  size="sm"
+                  aria-label="Highlight selection"
+                  title="Highlight selection"
+                  onClick={() => void handleCreateHighlight()}
+                >
+                  <Highlighter className="size-4" />
+                  Highlight
+                </Button>
               )}
-            </Button>
-            <Button
-              variant="ghost"
-              size="icon-sm"
-              aria-label="Previous page"
-              title="Previous page"
-              onClick={() => readerRef.current?.prev()}
-            >
-              <ChevronLeft className="size-5" />
-            </Button>
-            <Button
-              variant="ghost"
-              size="icon-sm"
-              aria-label="Next page"
-              title="Next page"
-              onClick={() => readerRef.current?.next()}
-            >
-              <ChevronRight className="size-5" />
-            </Button>
+              <Button
+                variant="ghost"
+                size="icon-sm"
+                aria-label="Add bookmark"
+                title="Add bookmark"
+                onClick={() => void handleCreateBookmark()}
+              >
+                <Bookmark className="size-4" />
+              </Button>
+              {!isComicFormat && (
+                <Button
+                  variant={readerSettings.readingRuler ? "secondary" : "ghost"}
+                  size="icon-sm"
+                  aria-label="Toggle reading ruler"
+                  title="Reading ruler"
+                  onClick={() =>
+                    updateReaderSettings({ readingRuler: !readerSettings.readingRuler })
+                  }
+                >
+                  <Ruler className="size-4" />
+                </Button>
+              )}
+              <Button
+                variant="ghost"
+                size="icon-sm"
+                aria-label={panelOpen ? "Close reader panel" : "Open reader panel"}
+                title={panelOpen ? "Close reader panel" : "Open reader panel"}
+                onClick={() => setPanelOpen((open) => !open)}
+              >
+                {panelOpen ? (
+                  <PanelRightClose className="size-4" />
+                ) : (
+                  <PanelRightOpen className="size-4" />
+                )}
+              </Button>
+              <Button
+                variant="ghost"
+                size="icon-sm"
+                aria-label="Previous page"
+                title="Previous page"
+                onClick={() => readerRef.current?.prev()}
+              >
+                <ChevronLeft className="size-5" />
+              </Button>
+              <Button
+                variant="ghost"
+                size="icon-sm"
+                aria-label="Next page"
+                title="Next page"
+                onClick={() => readerRef.current?.next()}
+              >
+                <ChevronRight className="size-5" />
+              </Button>
+            </div>
+            {loadedFile && (
+              <Button asChild variant="outline" size="sm">
+                <a href={loadedFile.objectUrl} download={loadedFile.filename}>
+                  <Download className="size-4" />
+                  File
+                </a>
+              </Button>
+            )}
           </div>
-          {loadedFile && (
-            <Button asChild variant="outline" size="sm">
-              <a href={loadedFile.objectUrl} download={loadedFile.filename}>
-                <Download className="size-4" />
-                File
-              </a>
-            </Button>
-          )}
-        </div>
-      </header>
+        </header>
+      )}
 
       <main
         className={cn(
@@ -731,7 +769,12 @@ export default function EbookReader() {
         )}
       >
         {isReaderSupportedFile(selectedFile) ? (
-          <section ref={readingSurfaceRef} className="relative min-h-0 min-w-0 overflow-hidden">
+          <section
+            ref={readingSurfaceRef}
+            data-reader-surface
+            onPointerUp={handleSurfacePointerUp}
+            className="relative min-h-0 min-w-0 overflow-hidden"
+          >
             <FoliateBookReader
               ref={readerRef}
               contentID={contentId}
@@ -1267,7 +1310,7 @@ export default function EbookReader() {
           </aside>
         )}
       </main>
-      {!isComicFormat && (
+      {!isComicFormat && chromeVisible && (
         <ReaderFooter
           fraction={locationInfo?.fraction ?? readerProgress ?? 0}
           extent={chapterBand}

--- a/web/src/pages/EbookReader.tsx
+++ b/web/src/pages/EbookReader.tsx
@@ -45,6 +45,7 @@ import { buildItemHref, buildMediaPlayHref } from "@/lib/mediaNavigation";
 import { buildMangaList, flattenMangaList } from "@/lib/mangaChapters";
 import { cn } from "@/lib/utils";
 import type { TOCItem } from "@/reader/readest/libs/document";
+import { themeFromLegacy } from "@/reader/readerThemes";
 import FoliateBookReader, {
   DEFAULT_READER_SETTINGS,
   READER_FONT_STACKS,
@@ -1259,9 +1260,9 @@ export default function EbookReader() {
                       aria-label="Theme"
                       value={readerSettings.theme}
                       onChange={(event) =>
-                        updateReaderSettings({
-                          theme: event.target.value as ReaderSettings["theme"],
-                        })
+                        updateReaderSettings(
+                          themeFromLegacy(event.target.value as ReaderSettings["theme"]),
+                        )
                       }
                       className="border-border bg-background focus-visible:border-ring focus-visible:ring-ring/50 h-9 w-full rounded-md border px-2 text-sm outline-none focus-visible:ring-[3px]"
                     >
@@ -1408,24 +1409,6 @@ export default function EbookReader() {
                         <option value="auto">Auto</option>
                         <option value="horizontal-tb">Horizontal</option>
                         <option value="vertical-rl">Vertical</option>
-                      </select>
-                    </label>
-                  )}
-                  {readerSettings.flow !== "scrolled" && (
-                    <label className="block space-y-1 text-sm">
-                      <span className="text-muted-foreground text-xs font-medium">Spread</span>
-                      <select
-                        aria-label="Spread"
-                        value={readerSettings.spread}
-                        onChange={(event) =>
-                          updateReaderSettings({
-                            spread: event.target.value as ReaderSettings["spread"],
-                          })
-                        }
-                        className="border-border bg-background focus-visible:border-ring focus-visible:ring-ring/50 h-9 w-full rounded-md border px-2 text-sm outline-none focus-visible:ring-[3px]"
-                      >
-                        <option value="auto">Auto</option>
-                        <option value="none">Single page</option>
                       </select>
                     </label>
                   )}

--- a/web/src/pages/EbookReader.tsx
+++ b/web/src/pages/EbookReader.tsx
@@ -44,6 +44,7 @@ import { ApiClientError } from "@/api/client";
 import type { FileVersion } from "@/api/types";
 import PageBack from "@/components/PageBack";
 import { Button } from "@/components/ui/button";
+import { useReadingHeartbeat } from "@/hooks/useReadingHeartbeat";
 import { useScreenWakeLock } from "@/hooks/useScreenWakeLock";
 import { useTTS } from "@/hooks/useTTS";
 import { useCatalogItemDetail } from "@/hooks/queries/catalogRead";
@@ -298,6 +299,10 @@ export default function EbookReader() {
   const readingSurfaceRef = useRef<HTMLElement | null>(null);
   const tts = useTTS();
   useScreenWakeLock(wakeLockEnabled);
+  const { noteActivity: noteReadingActivity } = useReadingHeartbeat({
+    contentId: isComicFormat ? null : contentId || null,
+    getFraction: () => locationInfoRef.current?.fraction ?? readerProgress ?? 0,
+  });
   const configLoadedRef = useRef(false);
   // Tracks settings the user changed in this session so a slow server config
   // fetch cannot clobber them after the fact.
@@ -331,10 +336,14 @@ export default function EbookReader() {
   const handleFileLoaded = useCallback((state: ReaderLoadState | null) => {
     setLoadedFile(state);
   }, []);
-  const handleLocationChange = useCallback((info: ReaderLocationInfo) => {
-    locationInfoRef.current = info;
-    setLocationInfo(info);
-  }, []);
+  const handleLocationChange = useCallback(
+    (info: ReaderLocationInfo) => {
+      locationInfoRef.current = info;
+      setLocationInfo(info);
+      noteReadingActivity();
+    },
+    [noteReadingActivity],
+  );
   const handleProgressChange = useCallback((progress: number | null) => {
     setReaderProgress(progress);
   }, []);
@@ -546,8 +555,9 @@ export default function EbookReader() {
       if (action === "prev") readerRef.current?.prev();
       else if (action === "next") readerRef.current?.next();
       else if (action === "toggle-chrome") setChromeVisible((visible) => !visible);
+      noteReadingActivity();
     },
-    [isComicFormat, readerSettings.flow, selection],
+    [isComicFormat, readerSettings.flow, selection, noteReadingActivity],
   );
   const handleSurfacePointerUp = useCallback(
     (event: PointerEvent<HTMLElement>) => {
@@ -701,6 +711,7 @@ export default function EbookReader() {
   useEffect(() => {
     const handleKeyDown = (event: KeyboardEvent) => {
       if (event.defaultPrevented || isEditableTarget(event.target)) return;
+      noteReadingActivity();
       switch (event.key) {
         case "ArrowLeft":
           readerRef.current?.prev();
@@ -763,7 +774,7 @@ export default function EbookReader() {
     };
     window.addEventListener("keydown", handleKeyDown);
     return () => window.removeEventListener("keydown", handleKeyDown);
-  }, [isComicFormat, shortcutsOpen, panelOpen, panel, toggleFullscreen]);
+  }, [isComicFormat, shortcutsOpen, panelOpen, panel, toggleFullscreen, noteReadingActivity]);
 
   useEffect(() => {
     if (!contentId) return;

--- a/web/src/pages/EbookReader.tsx
+++ b/web/src/pages/EbookReader.tsx
@@ -607,9 +607,22 @@ export default function EbookReader() {
     readerRef.current?.clearSelection();
     setSelection(null);
   }, [contentId, selection]);
-  const handleCreateBookmark = useCallback(async () => {
+  // Toggle semantics: a bookmark "at" a location is identified by an exact
+  // match on the same location string handleCreateBookmark would compute for
+  // the current spot. If one already exists there, this removes it (same
+  // delete path the Notes panel uses); otherwise it creates one. Shared by
+  // both the `b` shortcut and the header bookmark button.
+  const handleToggleBookmark = useCallback(async () => {
     if (!contentId) return;
     const location = selection?.cfi || `fraction:${(readerProgress ?? 0).toFixed(6)}`;
+    const existing = annotations.find(
+      (annotation) => annotation.kind === "bookmark" && annotation.location === location,
+    );
+    if (existing) {
+      await deleteEbookReaderAnnotation(contentId, existing.id);
+      setAnnotations((current) => current.filter((annotation) => annotation.id !== existing.id));
+      return;
+    }
     const created = await createEbookReaderAnnotation(contentId, {
       kind: "bookmark",
       location,
@@ -617,15 +630,15 @@ export default function EbookReader() {
     });
     setAnnotations((current) => [created, ...current]);
     setPanel("notes");
-  }, [contentId, item?.title, readerProgress, selection]);
-  // Mirrors handleCreateBookmark so the keyboard-shortcut handler can call the
+  }, [annotations, contentId, item?.title, readerProgress, selection]);
+  // Mirrors handleToggleBookmark so the keyboard-shortcut handler can call the
   // latest version without listing it as a dependency — it closes over
-  // readerProgress, which changes on every relocate, and would otherwise
+  // readerProgress and annotations, which change often, and would otherwise
   // force the window keydown listener to rebind constantly.
-  const bookmarkActionRef = useRef(handleCreateBookmark);
+  const bookmarkActionRef = useRef(handleToggleBookmark);
   useEffect(() => {
-    bookmarkActionRef.current = handleCreateBookmark;
-  }, [handleCreateBookmark]);
+    bookmarkActionRef.current = handleToggleBookmark;
+  }, [handleToggleBookmark]);
   const toggleFullscreen = useCallback(() => {
     if (typeof document === "undefined") return;
     try {
@@ -991,9 +1004,9 @@ export default function EbookReader() {
               <Button
                 variant="ghost"
                 size="icon-sm"
-                aria-label="Add bookmark"
-                title="Add bookmark"
-                onClick={() => void handleCreateBookmark()}
+                aria-label="Toggle bookmark"
+                title="Toggle bookmark"
+                onClick={() => void handleToggleBookmark()}
               >
                 <Bookmark className="size-4" />
               </Button>

--- a/web/src/pages/EbookReader.tsx
+++ b/web/src/pages/EbookReader.tsx
@@ -71,6 +71,7 @@ import {
 } from "@/reader/ebookReaderApi";
 import { chapterExtent, tapZoneAction } from "@/reader/readerNavigation";
 import ReaderFooter from "@/reader/ReaderFooter";
+import ReaderShortcutsOverlay from "@/reader/ReaderShortcutsOverlay";
 
 export const EBOOK_READER_SETTINGS_STORAGE_KEY = "silo.ebook.reader.settings";
 
@@ -270,7 +271,11 @@ export default function EbookReader() {
   const [annotations, setAnnotations] = useState<EbookReaderAnnotation[]>([]);
   const [selection, setSelection] = useState<ReaderSelection | null>(null);
   const [locationInfo, setLocationInfo] = useState<ReaderLocationInfo | null>(null);
-  const [_shortcutsOpen, setShortcutsOpen] = useState(false);
+  // Mirrors locationInfo synchronously so the keyboard-shortcut handler can
+  // read the latest fraction without listing locationInfo as a dependency —
+  // that would rebind the window keydown listener on every relocate.
+  const locationInfoRef = useRef<ReaderLocationInfo | null>(null);
+  const [shortcutsOpen, setShortcutsOpen] = useState(false);
   const [wakeLockEnabled, setWakeLockEnabled] = useState(false);
   const [ttsRate, setTtsRate] = useState(1);
   const [ttsVoiceURI, setTtsVoiceURI] = useState("");
@@ -302,6 +307,10 @@ export default function EbookReader() {
   }, [locationInfo, isComicFormat]);
   const handleFileLoaded = useCallback((state: ReaderLoadState | null) => {
     setLoadedFile(state);
+  }, []);
+  const handleLocationChange = useCallback((info: ReaderLocationInfo) => {
+    locationInfoRef.current = info;
+    setLocationInfo(info);
   }, []);
   const handleProgressChange = useCallback((progress: number | null) => {
     setReaderProgress(progress);
@@ -446,6 +455,27 @@ export default function EbookReader() {
     setAnnotations((current) => [created, ...current]);
     setPanel("notes");
   }, [contentId, item?.title, readerProgress, selection]);
+  // Mirrors handleCreateBookmark so the keyboard-shortcut handler can call the
+  // latest version without listing it as a dependency — it closes over
+  // readerProgress, which changes on every relocate, and would otherwise
+  // force the window keydown listener to rebind constantly.
+  const bookmarkActionRef = useRef(handleCreateBookmark);
+  useEffect(() => {
+    bookmarkActionRef.current = handleCreateBookmark;
+  }, [handleCreateBookmark]);
+  const toggleFullscreen = useCallback(() => {
+    if (typeof document === "undefined") return;
+    try {
+      if (document.fullscreenElement) {
+        void document.exitFullscreen?.()?.catch(() => {});
+      } else {
+        void document.documentElement.requestFullscreen?.()?.catch(() => {});
+      }
+    } catch {
+      // Fullscreen API unsupported or blocked (e.g. embedded without
+      // allow="fullscreen"); ignore rather than surface a console error.
+    }
+  }, []);
   const handleAnnotationNavigate = useCallback((annotation: EbookReaderAnnotation) => {
     // Toolbar bookmarks store synthetic "fraction:<n>" locations that foliate's
     // goTo cannot resolve; route those through goToFraction instead.
@@ -526,15 +556,64 @@ export default function EbookReader() {
   useEffect(() => {
     const handleKeyDown = (event: KeyboardEvent) => {
       if (event.defaultPrevented || isEditableTarget(event.target)) return;
-      if (event.key === "ArrowLeft") {
-        readerRef.current?.prev();
-      } else if (event.key === "ArrowRight") {
-        readerRef.current?.next();
+      switch (event.key) {
+        case "ArrowLeft":
+          readerRef.current?.prev();
+          break;
+        case "ArrowRight":
+          readerRef.current?.next();
+          break;
+        case "Home":
+        case "End": {
+          if (isComicFormat) return;
+          const fractions = readerRef.current?.getSectionFractions() ?? [];
+          const extent = chapterExtent(fractions, locationInfoRef.current?.fraction ?? 0);
+          if (!extent) return;
+          event.preventDefault();
+          void readerRef.current?.goToFraction(event.key === "Home" ? extent.start : extent.end);
+          break;
+        }
+        case "t":
+          // Mirrors the header's panel-open toggle plus the Contents tab
+          // click: reopen onto Contents, or close if already showing it.
+          if (panelOpen && panel === "toc") {
+            setPanelOpen(false);
+          } else {
+            setPanelOpen(true);
+            setPanel("toc");
+          }
+          break;
+        case "s":
+          if (panelOpen && panel === "search") {
+            setPanelOpen(false);
+          } else {
+            setPanelOpen(true);
+            setPanel("search");
+          }
+          break;
+        case "b":
+          void bookmarkActionRef.current();
+          break;
+        case "f":
+          toggleFullscreen();
+          break;
+        case "?":
+          setShortcutsOpen(true);
+          break;
+        case "Escape":
+          if (shortcutsOpen) {
+            setShortcutsOpen(false);
+          } else {
+            setChromeVisible((visible) => !visible);
+          }
+          break;
+        default:
+          break;
       }
     };
     window.addEventListener("keydown", handleKeyDown);
     return () => window.removeEventListener("keydown", handleKeyDown);
-  }, []);
+  }, [isComicFormat, shortcutsOpen, panelOpen, panel, toggleFullscreen]);
 
   useEffect(() => {
     if (!contentId) return;
@@ -822,7 +901,7 @@ export default function EbookReader() {
               onProgressChange={handleProgressChange}
               onReady={handleReaderReady}
               onSelectionChange={setSelection}
-              onLocationChange={setLocationInfo}
+              onLocationChange={handleLocationChange}
               onContentPointerUp={handleContentPointerUp}
               onContentPointerMove={handleContentPointerMove}
             />
@@ -1357,6 +1436,7 @@ export default function EbookReader() {
           onShowShortcuts={() => setShortcutsOpen(true)}
         />
       )}
+      {shortcutsOpen && <ReaderShortcutsOverlay onClose={() => setShortcutsOpen(false)} />}
       {showEndOfBookNext && nextChapter && nextChapterHref && (
         <div className="fixed inset-x-0 bottom-6 z-30 flex justify-center px-4">
           <Button

--- a/web/src/pages/EbookReader.tsx
+++ b/web/src/pages/EbookReader.tsx
@@ -618,8 +618,13 @@ export default function EbookReader() {
           setShortcutsOpen(true);
           break;
         case "Escape":
+          // Precedence: shortcuts overlay, then the side panel, then chrome —
+          // each Escape closes the topmost thing the user opened before
+          // falling through to the next layer.
           if (shortcutsOpen) {
             setShortcutsOpen(false);
+          } else if (panelOpen) {
+            setPanelOpen(false);
           } else {
             setChromeVisible((visible) => !visible);
           }

--- a/web/src/pages/EbookReader.tsx
+++ b/web/src/pages/EbookReader.tsx
@@ -10,7 +10,6 @@ import {
 import {
   ArrowLeft,
   Bookmark,
-  BookOpen,
   Check,
   ChevronLeft,
   ChevronRight,
@@ -56,6 +55,7 @@ import FoliateBookReader, {
   readerFileFormat,
   type FoliateBookReaderHandle,
   type ReaderLoadState,
+  type ReaderLocationInfo,
   type ReaderSearchResult,
   type ReaderSelection,
   type ReaderSettings,
@@ -69,6 +69,8 @@ import {
   saveEbookReaderConfigKeepalive,
   type EbookReaderAnnotation,
 } from "@/reader/ebookReaderApi";
+import { chapterExtent } from "@/reader/readerNavigation";
+import ReaderFooter from "@/reader/ReaderFooter";
 
 export const EBOOK_READER_SETTINGS_STORAGE_KEY = "silo.ebook.reader.settings";
 
@@ -257,6 +259,8 @@ export default function EbookReader() {
   );
   const [annotations, setAnnotations] = useState<EbookReaderAnnotation[]>([]);
   const [selection, setSelection] = useState<ReaderSelection | null>(null);
+  const [locationInfo, setLocationInfo] = useState<ReaderLocationInfo | null>(null);
+  const [shortcutsOpen, setShortcutsOpen] = useState(false);
   const [wakeLockEnabled, setWakeLockEnabled] = useState(false);
   const [ttsRate, setTtsRate] = useState(1);
   const [ttsVoiceURI, setTtsVoiceURI] = useState("");
@@ -278,6 +282,11 @@ export default function EbookReader() {
   const [searching, setSearching] = useState(false);
   const progressLabel = formatReaderProgress(readerProgress);
   const tocEntries = useMemo(() => flattenToc(toc), [toc]);
+  const chapterBand = useMemo(() => {
+    if (!locationInfo || isComicFormat) return null;
+    const fractions = readerRef.current?.getSectionFractions() ?? [];
+    return chapterExtent(fractions, locationInfo.fraction);
+  }, [locationInfo, isComicFormat]);
   const handleFileLoaded = useCallback((state: ReaderLoadState | null) => {
     setLoadedFile(state);
   }, []);
@@ -352,8 +361,8 @@ export default function EbookReader() {
       setSearching(false);
     }
   }, [searchText]);
-  const handleProgressScrub = useCallback((value: string) => {
-    const next = Math.min(1, Math.max(0, Number(value) / 100));
+  const handleProgressScrub = useCallback((fraction: number) => {
+    const next = Math.min(1, Math.max(0, fraction));
     if (!Number.isFinite(next)) return;
     setReaderProgress(next);
     void readerRef.current?.goToFraction(next);
@@ -713,22 +722,6 @@ export default function EbookReader() {
             </Button>
           )}
         </div>
-        <div className="border-border/60 flex h-10 items-center gap-3 border-t px-4">
-          <BookOpen className="text-muted-foreground size-4 shrink-0" />
-          <input
-            aria-label="Reading progress"
-            type="range"
-            min="0"
-            max="100"
-            step="1"
-            value={Math.round((readerProgress ?? 0) * 100)}
-            onChange={(event) => handleProgressScrub(event.target.value)}
-            className="accent-primary h-2 min-w-0 flex-1"
-          />
-          <div className="text-muted-foreground w-11 text-right text-xs tabular-nums">
-            {progressLabel ?? "0%"}
-          </div>
-        </div>
       </header>
 
       <main
@@ -750,6 +743,7 @@ export default function EbookReader() {
               onProgressChange={handleProgressChange}
               onReady={handleReaderReady}
               onSelectionChange={setSelection}
+              onLocationChange={setLocationInfo}
             />
             {readerSettings.readingRuler && (
               <div
@@ -1273,6 +1267,15 @@ export default function EbookReader() {
           </aside>
         )}
       </main>
+      {!isComicFormat && (
+        <ReaderFooter
+          fraction={locationInfo?.fraction ?? readerProgress ?? 0}
+          extent={chapterBand}
+          chapterLabel={locationInfo?.tocLabel ?? null}
+          onScrub={handleProgressScrub}
+          onShowShortcuts={() => setShortcutsOpen(true)}
+        />
+      )}
       {showEndOfBookNext && nextChapter && nextChapterHref && (
         <div className="fixed inset-x-0 bottom-6 z-30 flex justify-center px-4">
           <Button

--- a/web/src/pages/EbookReader.tsx
+++ b/web/src/pages/EbookReader.tsx
@@ -601,7 +601,7 @@ export default function EbookReader() {
   }
 
   return (
-    <div className="bg-background min-h-screen">
+    <div className="bg-background flex h-screen flex-col">
       <header className="border-border/70 bg-background/95 sticky top-0 z-20 border-b backdrop-blur">
         <div className="flex h-14 items-center gap-3 px-4">
           <Button asChild variant="ghost" size="icon" aria-label="Back">
@@ -726,7 +726,7 @@ export default function EbookReader() {
 
       <main
         className={cn(
-          "grid h-[calc(100vh-6rem)] min-h-0 w-full overflow-hidden",
+          "grid min-h-0 w-full flex-1 overflow-hidden",
           panelOpen ? "grid-cols-1 lg:grid-cols-[minmax(0,1fr)_20rem]" : "grid-cols-1",
         )}
       >

--- a/web/src/pages/EbookReader.tsx
+++ b/web/src/pages/EbookReader.tsx
@@ -195,6 +195,16 @@ function isEditableTarget(target: EventTarget | null): boolean {
   return ["INPUT", "TEXTAREA", "SELECT"].includes(target.tagName);
 }
 
+// Distance from the top/bottom viewport edge (in px) within which a hovering
+// mouse brings hidden chrome back, mirroring desktop reader/video-player
+// conventions. Shared by the window-level mousemove listener (margin taps)
+// and the content-iframe pointer bridge (taps over the book text itself).
+const CHROME_REVEAL_EDGE_PX = 24;
+
+function isNearViewportEdge(clientY: number): boolean {
+  return clientY < CHROME_REVEAL_EDGE_PX || window.innerHeight - clientY < CHROME_REVEAL_EDGE_PX;
+}
+
 export default function EbookReader() {
   const { contentId = "" } = useParams<{ contentId: string }>();
   const navigate = useNavigate();
@@ -370,13 +380,20 @@ export default function EbookReader() {
     setReaderProgress(next);
     void readerRef.current?.goToFraction(next);
   }, []);
-  const handleSurfacePointerUp = useCallback(
-    (event: PointerEvent<HTMLElement>) => {
+  // Shared by both tap paths below: margin taps land on the outer section via
+  // a normal React pointerup, but taps on the book text itself are reported
+  // by FoliateBookReader through onContentPointerUp (see the comment on that
+  // prop) since foliate renders prose inside a same-origin iframe whose
+  // events never bubble to this page. Both read the surface element's rect
+  // through a ref rather than event.currentTarget so the same geometry
+  // applies regardless of which path fired.
+  const dispatchSurfaceTap = useCallback(
+    (clientX: number) => {
       if (isComicFormat) return;
-      const rect = event.currentTarget.getBoundingClientRect();
-      if (rect.width <= 0) return;
+      const rect = readingSurfaceRef.current?.getBoundingClientRect();
+      if (!rect || rect.width <= 0) return;
       const action = tapZoneAction({
-        xRatio: (event.clientX - rect.left) / rect.width,
+        xRatio: (clientX - rect.left) / rect.width,
         flow: readerSettings.flow,
         hasSelection: Boolean(selection),
       });
@@ -385,6 +402,25 @@ export default function EbookReader() {
       else if (action === "toggle-chrome") setChromeVisible((visible) => !visible);
     },
     [isComicFormat, readerSettings.flow, selection],
+  );
+  const handleSurfacePointerUp = useCallback(
+    (event: PointerEvent<HTMLElement>) => {
+      dispatchSurfaceTap(event.clientX);
+    },
+    [dispatchSurfaceTap],
+  );
+  const handleContentPointerUp = useCallback(
+    (point: { clientX: number; clientY: number }) => {
+      dispatchSurfaceTap(point.clientX);
+    },
+    [dispatchSurfaceTap],
+  );
+  const handleContentPointerMove = useCallback(
+    (point: { clientY: number }) => {
+      if (chromeVisible) return;
+      if (isNearViewportEdge(point.clientY)) setChromeVisible(true);
+    },
+    [chromeVisible],
   );
   const handleCreateHighlight = useCallback(async () => {
     if (!contentId || !selection) return;
@@ -564,7 +600,7 @@ export default function EbookReader() {
   useEffect(() => {
     if (chromeVisible) return;
     const onMove = (event: MouseEvent) => {
-      if (event.clientY < 24 || window.innerHeight - event.clientY < 24) {
+      if (isNearViewportEdge(event.clientY)) {
         setChromeVisible(true);
       }
     };
@@ -787,6 +823,8 @@ export default function EbookReader() {
               onReady={handleReaderReady}
               onSelectionChange={setSelection}
               onLocationChange={setLocationInfo}
+              onContentPointerUp={handleContentPointerUp}
+              onContentPointerMove={handleContentPointerMove}
             />
             {readerSettings.readingRuler && (
               <div

--- a/web/src/pages/EbookReader.tsx
+++ b/web/src/pages/EbookReader.tsx
@@ -260,7 +260,7 @@ export default function EbookReader() {
   const [annotations, setAnnotations] = useState<EbookReaderAnnotation[]>([]);
   const [selection, setSelection] = useState<ReaderSelection | null>(null);
   const [locationInfo, setLocationInfo] = useState<ReaderLocationInfo | null>(null);
-  const [shortcutsOpen, setShortcutsOpen] = useState(false);
+  const [_shortcutsOpen, setShortcutsOpen] = useState(false);
   const [wakeLockEnabled, setWakeLockEnabled] = useState(false);
   const [ttsRate, setTtsRate] = useState(1);
   const [ttsVoiceURI, setTtsVoiceURI] = useState("");

--- a/web/src/pages/EbookReader.tsx
+++ b/web/src/pages/EbookReader.tsx
@@ -48,6 +48,7 @@ import { useReadingHeartbeat } from "@/hooks/useReadingHeartbeat";
 import { useScreenWakeLock } from "@/hooks/useScreenWakeLock";
 import { useTTS } from "@/hooks/useTTS";
 import { useCatalogItemDetail } from "@/hooks/queries/catalogRead";
+import { useBookReadingStats } from "@/hooks/queries/readingStats";
 import { buildItemHref, buildMediaPlayHref } from "@/lib/mediaNavigation";
 import { buildMangaList, flattenMangaList } from "@/lib/mangaChapters";
 import { cn } from "@/lib/utils";
@@ -303,6 +304,9 @@ export default function EbookReader() {
     contentId: isComicFormat ? null : contentId || null,
     getFraction: () => locationInfoRef.current?.fraction ?? readerProgress ?? 0,
   });
+  // Pace/time-left estimates only make sense for prose; comics have no
+  // reading-speed signal to project against.
+  const readingStats = useBookReadingStats(!isComicFormat && contentId ? contentId : undefined);
   const configLoadedRef = useRef(false);
   // Tracks settings the user changed in this session so a slow server config
   // fetch cannot clobber them after the fact.
@@ -1743,6 +1747,7 @@ export default function EbookReader() {
           chapterLabel={locationInfo?.tocLabel ?? null}
           onScrub={handleProgressScrub}
           onShowShortcuts={() => setShortcutsOpen(true)}
+          timeLeftSeconds={readingStats.data?.time_left_seconds ?? null}
         />
       )}
       {shortcutsOpen && <ReaderShortcutsOverlay onClose={() => setShortcutsOpen(false)} />}

--- a/web/src/pages/EbookReader.tsx
+++ b/web/src/pages/EbookReader.tsx
@@ -312,7 +312,11 @@ export default function EbookReader() {
   // only ever toggles for prose/paginated formats.
   const [chromeVisible, setChromeVisible] = useState(true);
   const [readerFonts, setReaderFonts] = useState<ReaderFontMeta[]>([]);
-  const [readerFontsLoaded, setReaderFontsLoaded] = useState(false);
+  // Tracks a *successful* font-list load, separately from "a fetch attempt
+  // finished" — a transient failure must not be treated as "the list is
+  // empty" by the fallback-reset effect below, or it wipes a legitimately
+  // saved custom font selection.
+  const [readerFontsLoadOk, setReaderFontsLoadOk] = useState(false);
   const readerFontsRequestedRef = useRef(false);
   const [fontUploading, setFontUploading] = useState(false);
   const [fontUploadError, setFontUploadError] = useState<string | null>(null);
@@ -389,23 +393,35 @@ export default function EbookReader() {
   }, [contentId]);
   // Uploaded fonts are fetched once, lazily, the first time the settings
   // panel is opened rather than on mount — most reader sessions never touch
-  // it and this endpoint is per-profile, not per-book.
+  // it and this endpoint is per-profile, not per-book. Comics never show the
+  // font controls, so skip the fetch entirely for them.
   useEffect(() => {
-    if (panel !== "settings" || readerFontsRequestedRef.current) return;
+    if (isComicFormat || panel !== "settings" || readerFontsRequestedRef.current) return;
     readerFontsRequestedRef.current = true;
     void fetchReaderFonts()
-      .then(setReaderFonts)
-      .catch(() => {})
-      .finally(() => setReaderFontsLoaded(true));
-  }, [panel]);
+      .then((fonts) => {
+        setReaderFonts(fonts);
+        setReaderFontsLoadOk(true);
+      })
+      .catch(() => {
+        // A transient failure shouldn't latch permanently — clear the guard
+        // so reopening the settings panel retries the fetch instead of
+        // leaving the font list (and the fallback-reset effect below)
+        // permanently unresolved.
+        readerFontsRequestedRef.current = false;
+      });
+  }, [panel, isComicFormat]);
   // If the font a saved config points at no longer exists (deleted from this
   // session or another one), fall back to the book's own typeface instead of
   // silently rendering with whatever the browser last resolved "custom" to.
+  // Gated on a *successful* load (not just "a fetch attempt finished") so a
+  // transient fetch failure can't be mistaken for "the list is empty" and
+  // wipe a legitimately saved selection.
   useEffect(() => {
-    if (!readerFontsLoaded || readerSettings.customFontID == null) return;
+    if (!readerFontsLoadOk || readerSettings.customFontID == null) return;
     if (readerFonts.some((font) => font.id === readerSettings.customFontID)) return;
     updateReaderSettings({ customFontID: null, fontFamily: READER_FONT_STACKS.inherit });
-  }, [readerFontsLoaded, readerFonts, readerSettings.customFontID, updateReaderSettings]);
+  }, [readerFontsLoadOk, readerFonts, readerSettings.customFontID, updateReaderSettings]);
   const handleFontUpload = useCallback(async (event: ReactChangeEvent<HTMLInputElement>) => {
     const file = event.target.files?.[0];
     event.target.value = "";
@@ -422,8 +438,13 @@ export default function EbookReader() {
     }
   }, []);
   const handleDeleteFont = useCallback(async (id: number) => {
-    await deleteReaderFont(id);
-    setReaderFonts((current) => current.filter((font) => font.id !== id));
+    setFontUploadError(null);
+    try {
+      await deleteReaderFont(id);
+      setReaderFonts((current) => current.filter((font) => font.id !== id));
+    } catch (err) {
+      setFontUploadError(err instanceof ApiClientError ? err.message : "Font delete failed.");
+    }
   }, []);
   const handleSearchSubmit = useCallback(async () => {
     const query = searchText.trim();

--- a/web/src/pages/EbookReader.tsx
+++ b/web/src/pages/EbookReader.tsx
@@ -559,10 +559,14 @@ export default function EbookReader() {
       if (isComicFormat) return;
       const rect = readingSurfaceRef.current?.getBoundingClientRect();
       if (!rect || rect.width <= 0) return;
+      // Belt and braces: React's `selection` state lags a same-tick pointerup
+      // that just finished a text selection (FoliateBookReader defers the
+      // state update with setTimeout(0) to let native selection settle), so
+      // also consult the reader's synchronous live-selection signal.
       const action = tapZoneAction({
         xRatio: (clientX - rect.left) / rect.width,
         flow: readerSettings.flow,
-        hasSelection: Boolean(selection),
+        hasSelection: Boolean(selection) || (readerRef.current?.hasLiveSelection?.() ?? false),
       });
       if (action === "prev") readerRef.current?.prev();
       else if (action === "next") readerRef.current?.next();

--- a/web/src/pages/EbookReader.tsx
+++ b/web/src/pages/EbookReader.tsx
@@ -387,6 +387,15 @@ export default function EbookReader() {
     const next = Math.min(1, Math.max(0, fraction));
     if (!Number.isFinite(next)) return;
     setReaderProgress(next);
+    // The footer prefers locationInfo.fraction over readerProgress, and that
+    // only otherwise updates from the next foliate relocate event — which can
+    // lag or never land mid-drag. Patch it optimistically too so the bar
+    // doesn't snap back to the last relocate's fraction after a scrub.
+    setLocationInfo((current) =>
+      current
+        ? { ...current, fraction: next }
+        : { fraction: next, sectionIndex: null, tocLabel: null },
+    );
     void readerRef.current?.goToFraction(next);
   }, []);
   // Shared by both tap paths below: margin taps land on the outer section via

--- a/web/src/pages/EbookReader.tsx
+++ b/web/src/pages/EbookReader.tsx
@@ -4,6 +4,7 @@ import {
   useMemo,
   useRef,
   useState,
+  type ChangeEvent as ReactChangeEvent,
   type KeyboardEvent as ReactKeyboardEvent,
   type PointerEvent,
 } from "react";
@@ -13,14 +14,17 @@ import {
   Check,
   ChevronLeft,
   ChevronRight,
+  Columns,
   Download,
   GripHorizontal,
   Highlighter,
   Library,
   ListTree,
   Loader2,
+  Moon,
   PanelRightClose,
   PanelRightOpen,
+  Palette,
   Pause,
   Play,
   RotateCcw,
@@ -31,10 +35,12 @@ import {
   Square,
   Trash2,
   Type,
+  Upload,
   Volume2,
 } from "lucide-react";
 import { Link, useNavigate, useParams, useSearchParams } from "react-router";
 
+import { ApiClientError } from "@/api/client";
 import type { FileVersion } from "@/api/types";
 import PageBack from "@/components/PageBack";
 import { Button } from "@/components/ui/button";
@@ -45,7 +51,7 @@ import { buildItemHref, buildMediaPlayHref } from "@/lib/mediaNavigation";
 import { buildMangaList, flattenMangaList } from "@/lib/mangaChapters";
 import { cn } from "@/lib/utils";
 import type { TOCItem } from "@/reader/readest/libs/document";
-import { themeFromLegacy } from "@/reader/readerThemes";
+import { READER_THEMES, type ReaderThemeName } from "@/reader/readerThemes";
 import FoliateBookReader, {
   DEFAULT_READER_SETTINGS,
   READER_FONT_STACKS,
@@ -71,6 +77,12 @@ import {
   type EbookReaderAnnotation,
 } from "@/reader/ebookReaderApi";
 import { chapterExtent, tapZoneAction } from "@/reader/readerNavigation";
+import {
+  deleteReaderFont,
+  fetchReaderFonts,
+  uploadReaderFont,
+  type ReaderFontMeta,
+} from "@/reader/readerFontsApi";
 import ReaderFooter from "@/reader/ReaderFooter";
 import ReaderShortcutsOverlay from "@/reader/ReaderShortcutsOverlay";
 
@@ -299,6 +311,11 @@ export default function EbookReader() {
   // Comics always keep chrome visible (see the render gate below); this state
   // only ever toggles for prose/paginated formats.
   const [chromeVisible, setChromeVisible] = useState(true);
+  const [readerFonts, setReaderFonts] = useState<ReaderFontMeta[]>([]);
+  const [readerFontsLoaded, setReaderFontsLoaded] = useState(false);
+  const readerFontsRequestedRef = useRef(false);
+  const [fontUploading, setFontUploading] = useState(false);
+  const [fontUploadError, setFontUploadError] = useState<string | null>(null);
   const progressLabel = formatReaderProgress(readerProgress);
   const tocEntries = useMemo(() => flattenToc(toc), [toc]);
   const chapterBand = useMemo(() => {
@@ -370,6 +387,44 @@ export default function EbookReader() {
       void saveEbookReaderConfig(contentId, { settings: defaults });
     }
   }, [contentId]);
+  // Uploaded fonts are fetched once, lazily, the first time the settings
+  // panel is opened rather than on mount — most reader sessions never touch
+  // it and this endpoint is per-profile, not per-book.
+  useEffect(() => {
+    if (panel !== "settings" || readerFontsRequestedRef.current) return;
+    readerFontsRequestedRef.current = true;
+    void fetchReaderFonts()
+      .then(setReaderFonts)
+      .catch(() => {})
+      .finally(() => setReaderFontsLoaded(true));
+  }, [panel]);
+  // If the font a saved config points at no longer exists (deleted from this
+  // session or another one), fall back to the book's own typeface instead of
+  // silently rendering with whatever the browser last resolved "custom" to.
+  useEffect(() => {
+    if (!readerFontsLoaded || readerSettings.customFontID == null) return;
+    if (readerFonts.some((font) => font.id === readerSettings.customFontID)) return;
+    updateReaderSettings({ customFontID: null, fontFamily: READER_FONT_STACKS.inherit });
+  }, [readerFontsLoaded, readerFonts, readerSettings.customFontID, updateReaderSettings]);
+  const handleFontUpload = useCallback(async (event: ReactChangeEvent<HTMLInputElement>) => {
+    const file = event.target.files?.[0];
+    event.target.value = "";
+    if (!file) return;
+    setFontUploadError(null);
+    setFontUploading(true);
+    try {
+      const font = await uploadReaderFont(file);
+      setReaderFonts((current) => [...current, font]);
+    } catch (err) {
+      setFontUploadError(err instanceof ApiClientError ? err.message : "Font upload failed.");
+    } finally {
+      setFontUploading(false);
+    }
+  }, []);
+  const handleDeleteFont = useCallback(async (id: number) => {
+    await deleteReaderFont(id);
+    setReaderFonts((current) => current.filter((font) => font.id !== id));
+  }, []);
   const handleSearchSubmit = useCallback(async () => {
     const query = searchText.trim();
     if (!query) {
@@ -1251,35 +1306,83 @@ export default function EbookReader() {
                     </label>
                   </div>
                   <div className="flex items-center gap-2 text-sm font-medium">
+                    <Palette className="size-4" />
+                    Theme
+                  </div>
+                  <div className="space-y-2">
+                    <div role="group" aria-label="Reader theme" className="grid grid-cols-5 gap-2">
+                      {(Object.keys(READER_THEMES) as ReaderThemeName[]).map((name) => {
+                        const definition = READER_THEMES[name];
+                        const swatch = definition[readerSettings.themeVariant] ?? definition.light;
+                        const active = readerSettings.themeName === name;
+                        return (
+                          <button
+                            key={name}
+                            type="button"
+                            data-theme-choice={name}
+                            title={definition.label}
+                            aria-label={definition.label}
+                            aria-pressed={active}
+                            onClick={() =>
+                              updateReaderSettings({
+                                themeName: name,
+                                themeVariant: readerSettings.themeVariant,
+                              })
+                            }
+                            style={{
+                              background: swatch.background,
+                              borderColor: swatch.foreground,
+                            }}
+                            className={cn(
+                              "focus-visible:ring-ring/50 size-8 rounded-full border-2 outline-none focus-visible:ring-[3px]",
+                              active ? "ring-ring ring-2 ring-offset-2" : "",
+                            )}
+                          />
+                        );
+                      })}
+                    </div>
+                    <Button
+                      type="button"
+                      variant="outline"
+                      size="sm"
+                      aria-label="Reader dark mode"
+                      aria-pressed={readerSettings.themeVariant === "dark"}
+                      disabled={READER_THEMES[readerSettings.themeName].darkOnly === true}
+                      onClick={() =>
+                        updateReaderSettings({
+                          themeVariant: readerSettings.themeVariant === "dark" ? "light" : "dark",
+                        })
+                      }
+                      className="w-full justify-center gap-2"
+                    >
+                      <Moon className="size-4" />
+                      Dark mode
+                    </Button>
+                  </div>
+                  <div className="flex items-center gap-2 text-sm font-medium">
                     <Type className="size-4" />
                     Typography
                   </div>
-                  <label className="block space-y-1 text-sm">
-                    <span className="text-muted-foreground text-xs font-medium">Theme</span>
-                    <select
-                      aria-label="Theme"
-                      value={readerSettings.theme}
-                      onChange={(event) =>
-                        updateReaderSettings(
-                          themeFromLegacy(event.target.value as ReaderSettings["theme"]),
-                        )
-                      }
-                      className="border-border bg-background focus-visible:border-ring focus-visible:ring-ring/50 h-9 w-full rounded-md border px-2 text-sm outline-none focus-visible:ring-[3px]"
-                    >
-                      <option value="light">Light</option>
-                      <option value="sepia">Sepia</option>
-                      <option value="dark">Dark</option>
-                    </select>
-                  </label>
                   {!isComicFormat && (
                     <label className="block space-y-1 text-sm">
                       <span className="text-muted-foreground text-xs font-medium">Font</span>
                       <select
                         aria-label="Font family"
-                        value={readerSettings.fontFamily}
-                        onChange={(event) =>
-                          updateReaderSettings({ fontFamily: event.target.value })
+                        value={
+                          readerSettings.fontFamily === "custom" &&
+                          readerSettings.customFontID != null
+                            ? `custom:${readerSettings.customFontID}`
+                            : readerSettings.fontFamily
                         }
+                        onChange={(event) => {
+                          const raw = event.target.value;
+                          if (raw.startsWith("custom:")) {
+                            const id = Number(raw.slice("custom:".length));
+                            updateReaderSettings({ fontFamily: "custom", customFontID: id });
+                          } else {
+                            updateReaderSettings({ fontFamily: raw, customFontID: null });
+                          }
+                        }}
                         className="border-border bg-background focus-visible:border-ring focus-visible:ring-ring/50 h-9 w-full rounded-md border px-2 text-sm outline-none focus-visible:ring-[3px]"
                       >
                         {READER_FONT_OPTIONS.map((option) => (
@@ -1289,9 +1392,64 @@ export default function EbookReader() {
                         ))}
                         {!READER_FONT_OPTIONS.some(
                           (option) => option.value === readerSettings.fontFamily,
-                        ) && <option value={readerSettings.fontFamily}>Custom</option>}
+                        ) &&
+                          readerSettings.fontFamily !== "custom" && (
+                            <option value={readerSettings.fontFamily}>Custom</option>
+                          )}
+                        {readerFonts.length > 0 && (
+                          <optgroup label="Uploaded">
+                            {readerFonts.map((font) => (
+                              <option key={font.id} value={`custom:${font.id}`}>
+                                {font.name}
+                              </option>
+                            ))}
+                          </optgroup>
+                        )}
                       </select>
                     </label>
+                  )}
+                  {!isComicFormat && (
+                    <div className="space-y-2">
+                      <div className="flex items-center justify-between gap-2">
+                        <span className="text-muted-foreground text-xs font-medium">
+                          Uploaded fonts
+                        </span>
+                        <label className="text-foreground inline-flex cursor-pointer items-center gap-1 text-xs font-medium">
+                          <Upload className="size-3.5" />
+                          {fontUploading ? "Uploading…" : "Upload"}
+                          <input
+                            type="file"
+                            accept=".ttf,.otf,.woff,.woff2"
+                            aria-label="Upload font"
+                            disabled={fontUploading}
+                            onChange={(event) => void handleFontUpload(event)}
+                            className="sr-only"
+                          />
+                        </label>
+                      </div>
+                      {fontUploadError && <p className="text-xs text-red-600">{fontUploadError}</p>}
+                      {readerFonts.length > 0 && (
+                        <ul className="space-y-1">
+                          {readerFonts.map((font) => (
+                            <li
+                              key={font.id}
+                              className="flex items-center justify-between gap-2 text-sm"
+                            >
+                              <span className="min-w-0 truncate">{font.name}</span>
+                              <Button
+                                variant="ghost"
+                                size="icon-xs"
+                                aria-label={`Delete font ${font.name}`}
+                                title={`Delete font ${font.name}`}
+                                onClick={() => void handleDeleteFont(font.id)}
+                              >
+                                <Trash2 className="size-3" />
+                              </Button>
+                            </li>
+                          ))}
+                        </ul>
+                      )}
+                    </div>
                   )}
                   {!isComicFormat && (
                     <ReaderRange
@@ -1343,6 +1501,45 @@ export default function EbookReader() {
                       onChange={(maxWidth) => updateReaderSettings({ maxWidth })}
                     />
                   )}
+                  {!isComicFormat && (
+                    <>
+                      <div className="flex items-center gap-2 text-sm font-medium">
+                        <Columns className="size-4" />
+                        Layout
+                      </div>
+                      <label className="block space-y-1 text-sm">
+                        <span className="text-muted-foreground text-xs font-medium">Columns</span>
+                        <select
+                          aria-label="Columns"
+                          value={String(readerSettings.columns)}
+                          onChange={(event) =>
+                            updateReaderSettings({
+                              columns:
+                                event.target.value === "auto"
+                                  ? "auto"
+                                  : (Number(event.target.value) as ReaderSettings["columns"]),
+                            })
+                          }
+                          className="border-border bg-background focus-visible:border-ring focus-visible:ring-ring/50 h-9 w-full rounded-md border px-2 text-sm outline-none focus-visible:ring-[3px]"
+                        >
+                          <option value="auto">Auto</option>
+                          <option value="1">1</option>
+                          <option value="2">2</option>
+                          <option value="3">3</option>
+                          <option value="4">4</option>
+                        </select>
+                      </label>
+                      <ReaderRange
+                        label="Column gap"
+                        value={readerSettings.columnGap}
+                        min={0}
+                        max={50}
+                        step={1}
+                        suffix="%"
+                        onChange={(columnGap) => updateReaderSettings({ columnGap })}
+                      />
+                    </>
+                  )}
                   <div className="border-border space-y-2 border-t pt-3">
                     {!isComicFormat && (
                       <label className="flex items-center justify-between gap-3 text-sm">
@@ -1353,6 +1550,19 @@ export default function EbookReader() {
                           checked={readerSettings.hyphenation}
                           onChange={(event) =>
                             updateReaderSettings({ hyphenation: event.target.checked })
+                          }
+                        />
+                      </label>
+                    )}
+                    {!isComicFormat && (
+                      <label className="flex items-center justify-between gap-3 text-sm">
+                        <span>Justify text</span>
+                        <input
+                          aria-label="Justify text"
+                          type="checkbox"
+                          checked={readerSettings.justify}
+                          onChange={(event) =>
+                            updateReaderSettings({ justify: event.target.checked })
                           }
                         />
                       </label>

--- a/web/src/pages/EbookReader.tsx
+++ b/web/src/pages/EbookReader.tsx
@@ -528,6 +528,11 @@ export default function EbookReader() {
   }, []);
   const handleRulerPointerUp = useCallback(
     (event: PointerEvent<HTMLButtonElement>) => {
+      // The grip lives inside [data-reader-surface], which also listens for
+      // pointerup to turn pages on tap. Without this, releasing a drag (the
+      // grip sits near the surface's right edge) bubbles into that handler
+      // and reads as a next-page tap.
+      event.stopPropagation();
       const drag = rulerDragRef.current;
       if (!drag) return;
       rulerDragRef.current = null;
@@ -537,7 +542,10 @@ export default function EbookReader() {
     },
     [updateReaderSettings],
   );
-  const handleRulerPointerCancel = useCallback(() => {
+  const handleRulerPointerCancel = useCallback((event: PointerEvent<HTMLButtonElement>) => {
+    // See handleRulerPointerUp: stop this from bubbling into the surface's
+    // page-turn tap handler too.
+    event.stopPropagation();
     rulerDragRef.current = null;
     setRulerDragTop(null);
   }, []);

--- a/web/src/pages/ReadingStats.test.tsx
+++ b/web/src/pages/ReadingStats.test.tsx
@@ -15,8 +15,16 @@ vi.mock("@/hooks/useDocumentTitle", () => ({
 }));
 
 vi.mock("@/components/stats/ReadingHeatmap", () => ({
-  default: ({ days }: { days: { date: string; seconds: number }[] }) => (
-    <div data-kind="reading-heatmap">
+  default: ({
+    days,
+    from,
+    to,
+  }: {
+    days: { date: string; seconds: number }[];
+    from?: string;
+    to?: string;
+  }) => (
+    <div data-kind="reading-heatmap" data-from={from} data-to={to}>
       {days.map((d) => (
         <span key={d.date} data-kind="heatmap-cell">
           {d.date}
@@ -140,9 +148,37 @@ describe("ReadingStats page", () => {
     expect(matches).toHaveLength(fixture.days.length);
   });
 
-  it("requests the default range (no explicit from/to)", () => {
-    mockUseReadingHistory.mockReturnValue({ data: fixture, isLoading: false, isError: false });
-    renderPage();
-    expect(mockUseReadingHistory).toHaveBeenCalledWith();
+  it("requests the server's default range explicitly (today UTC, minus 365 days)", () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-07-20T12:34:56Z"));
+    try {
+      mockUseReadingHistory.mockReturnValue({ data: fixture, isLoading: false, isError: false });
+      renderPage();
+      // Mirrors the server default in HandleHistory: to = today at UTC
+      // midnight, from = to minus 365 days. Passed explicitly (rather than
+      // omitted) so the same range can be handed to the heatmap for
+      // densifying gap days.
+      expect(mockUseReadingHistory).toHaveBeenCalledWith("2025-07-20", "2026-07-20");
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("passes the same range to the heatmap that it requests from the history hook", () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-07-20T12:34:56Z"));
+    try {
+      mockUseReadingHistory.mockReturnValue({ data: fixture, isLoading: false, isError: false });
+      const markup = renderPage();
+      // Both the hook call and the heatmap's from/to props must agree on the
+      // exact same range, or the client-side densify (which uses the
+      // heatmap's range) would disagree with what the server actually
+      // rolled up into `data.days`.
+      const [hookFrom, hookTo] = mockUseReadingHistory.mock.calls[0] ?? [];
+      expect(markup).toContain(`data-from="${hookFrom}"`);
+      expect(markup).toContain(`data-to="${hookTo}"`);
+    } finally {
+      vi.useRealTimers();
+    }
   });
 });

--- a/web/src/pages/ReadingStats.test.tsx
+++ b/web/src/pages/ReadingStats.test.tsx
@@ -127,6 +127,10 @@ describe("ReadingStats page", () => {
     expect(markup).toContain("30m");
     expect(markup).toContain("10%");
     expect(markup).toContain("25%");
+    // session 2 (removed book): shows title but suppresses item link
+    expect(markup).toContain("Removed book");
+    const bookTwoLinks = (markup.match(/\/item\/book-2/g) ?? []).length;
+    expect(bookTwoLinks).toBe(0);
   });
 
   it("renders one heatmap cell per fixture day", () => {

--- a/web/src/pages/ReadingStats.test.tsx
+++ b/web/src/pages/ReadingStats.test.tsx
@@ -203,21 +203,47 @@ describe("ReadingStats page", () => {
     expect(matches).toHaveLength(fixture.days.length);
   });
 
-  it("requests the server's default range explicitly (today UTC, minus 365 days)", () => {
+  it("requests the server's default range explicitly (today in the viewer's timezone, minus 365 days)", () => {
     vi.useFakeTimers();
     vi.setSystemTime(new Date("2026-07-20T12:34:56Z"));
+    const resolvedOptionsSpy = vi
+      .spyOn(Intl.DateTimeFormat.prototype, "resolvedOptions")
+      .mockReturnValue({ timeZone: "UTC" } as Intl.ResolvedDateTimeFormatOptions);
     try {
       mockUseReadingHistory.mockReturnValue({ data: fixture, isLoading: false, isError: false });
       renderPage();
-      // Mirrors the server default in HandleHistory: to = today at UTC
-      // midnight, from = to minus 365 days. Passed explicitly (rather than
-      // omitted) so the same range can be handed to the heatmap for
-      // densifying gap days. The third arg is the viewer's IANA timezone.
+      // Mirrors the server default in HandleHistory: to = today in the
+      // viewer's timezone, from = to minus 365 days. Passed explicitly
+      // (rather than omitted) so the same range can be handed to the
+      // heatmap for densifying gap days. The third arg is the viewer's IANA
+      // timezone.
       const [callFrom, callTo] = mockUseReadingHistory.mock.calls[0] ?? [];
       expect(callFrom).toBe("2025-07-20");
       expect(callTo).toBe("2026-07-20");
     } finally {
       vi.useRealTimers();
+      resolvedOptionsSpy.mockRestore();
+    }
+  });
+
+  it("derives today from the viewer's local timezone, not UTC", () => {
+    // 2026-07-19T23:30:00Z is local 2026-07-20T01:30 in Europe/Amsterdam
+    // (CEST, UTC+2): a UTC-derived "today" would request "2026-07-19" here,
+    // one full local day early.
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-07-19T23:30:00Z"));
+    const resolvedOptionsSpy = vi
+      .spyOn(Intl.DateTimeFormat.prototype, "resolvedOptions")
+      .mockReturnValue({ timeZone: "Europe/Amsterdam" } as Intl.ResolvedDateTimeFormatOptions);
+    try {
+      mockUseReadingHistory.mockReturnValue({ data: fixture, isLoading: false, isError: false });
+      renderPage();
+      const [callFrom, callTo] = mockUseReadingHistory.mock.calls[0] ?? [];
+      expect(callTo).toBe("2026-07-20");
+      expect(callFrom).toBe("2025-07-20");
+    } finally {
+      vi.useRealTimers();
+      resolvedOptionsSpy.mockRestore();
     }
   });
 

--- a/web/src/pages/ReadingStats.test.tsx
+++ b/web/src/pages/ReadingStats.test.tsx
@@ -253,6 +253,38 @@ describe("ReadingStats page", () => {
     expect(markup).toContain('data-kind="reading-dna-section" data-has-dna="true"');
   });
 
+  it("renders the motivation sections even when the history query errors", () => {
+    // The four motivation sections are driven entirely by useReadingMotivation
+    // and must not be gated behind the (independent) reading-history query's
+    // error state.
+    mockUseReadingHistory.mockReturnValue({ data: undefined, isLoading: false, isError: true });
+    mockUseReadingMotivation.mockReturnValue({
+      data: motivationFixture,
+      isLoading: false,
+      isError: false,
+    });
+    const markup = renderPage();
+    expect(markup.toLowerCase()).toContain("failed");
+    expect(markup).toContain('data-kind="streak-challenge-section" data-has-streak="true"');
+    expect(markup).toContain('data-kind="goals-section" data-has-goals="true"');
+    expect(markup).toContain('data-kind="achievements-section" data-count="1"');
+    expect(markup).toContain('data-kind="reading-dna-section" data-has-dna="true"');
+  });
+
+  it("renders the motivation sections even while the history query is loading", () => {
+    mockUseReadingHistory.mockReturnValue({ data: undefined, isLoading: true, isError: false });
+    mockUseReadingMotivation.mockReturnValue({
+      data: motivationFixture,
+      isLoading: false,
+      isError: false,
+    });
+    const markup = renderPage();
+    expect(markup).toContain('data-kind="streak-challenge-section" data-has-streak="true"');
+    expect(markup).toContain('data-kind="goals-section" data-has-goals="true"');
+    expect(markup).toContain('data-kind="achievements-section" data-count="1"');
+    expect(markup).toContain('data-kind="reading-dna-section" data-has-dna="true"');
+  });
+
   it("passes null-tolerant undefined slices to the motivation sections before motivation data loads", () => {
     mockUseReadingHistory.mockReturnValue({ data: fixture, isLoading: false, isError: false });
     mockUseReadingMotivation.mockReturnValue({ data: undefined, isLoading: true, isError: false });

--- a/web/src/pages/ReadingStats.test.tsx
+++ b/web/src/pages/ReadingStats.test.tsx
@@ -338,4 +338,19 @@ describe("ReadingStats page", () => {
       vi.useRealTimers();
     }
   });
+
+  it("places the totals row before the motivation sections", () => {
+    mockUseReadingHistory.mockReturnValue({ data: fixture, isLoading: false, isError: false });
+    mockUseReadingMotivation.mockReturnValue({
+      data: motivationFixture,
+      isLoading: false,
+      isError: false,
+    });
+    const markup = renderPage();
+    const totalsIndex = markup.indexOf("All time");
+    const motivationIndex = markup.indexOf('data-kind="streak-challenge-section"');
+    expect(totalsIndex).toBeGreaterThan(-1);
+    expect(motivationIndex).toBeGreaterThan(-1);
+    expect(totalsIndex).toBeLessThan(motivationIndex);
+  });
 });

--- a/web/src/pages/ReadingStats.test.tsx
+++ b/web/src/pages/ReadingStats.test.tsx
@@ -2,13 +2,21 @@ import { renderToStaticMarkup } from "react-dom/server";
 import { MemoryRouter, Route, Routes } from "react-router";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
-import type { ReadingHistory } from "@/hooks/queries/readingStats";
+import type { ReadingHistory, ReadingMotivation } from "@/hooks/queries/readingStats";
 
 const mockUseReadingHistory = vi.fn();
+const mockUseReadingMotivation = vi.fn();
 
-vi.mock("@/hooks/queries/readingStats", () => ({
-  useReadingHistory: (...args: unknown[]) => mockUseReadingHistory(...args),
-}));
+vi.mock("@/hooks/queries/readingStats", async () => {
+  const actual = await vi.importActual<typeof import("@/hooks/queries/readingStats")>(
+    "@/hooks/queries/readingStats",
+  );
+  return {
+    ...actual,
+    useReadingHistory: (...args: unknown[]) => mockUseReadingHistory(...args),
+    useReadingMotivation: (...args: unknown[]) => mockUseReadingMotivation(...args),
+  };
+});
 
 vi.mock("@/hooks/useDocumentTitle", () => ({
   useDocumentTitle: () => undefined,
@@ -31,6 +39,21 @@ vi.mock("@/components/stats/ReadingHeatmap", () => ({
         </span>
       ))}
     </div>
+  ),
+}));
+
+vi.mock("@/components/stats/MotivationSections", () => ({
+  StreakChallengeSection: ({ streak }: { streak: unknown }) => (
+    <div data-kind="streak-challenge-section" data-has-streak={String(streak != null)} />
+  ),
+  GoalsSection: ({ goals }: { goals: unknown }) => (
+    <div data-kind="goals-section" data-has-goals={String(goals != null)} />
+  ),
+  AchievementsSection: ({ achievements }: { achievements: unknown[] | null | undefined }) => (
+    <div data-kind="achievements-section" data-count={String(achievements?.length ?? 0)} />
+  ),
+  ReadingDnaSection: ({ dna }: { dna: unknown }) => (
+    <div data-kind="reading-dna-section" data-has-dna={String(dna != null)} />
   ),
 }));
 
@@ -92,9 +115,41 @@ const fixture: ReadingHistory = {
   ],
 };
 
+const motivationFixture: ReadingMotivation = {
+  streak: { current_days: 5, longest_days: 12, today_seconds: 900, today_qualified: true },
+  goals: {
+    books_per_year: 24,
+    hours_per_year: 100,
+    books_finished_ytd: 6,
+    hours_ytd: 42.5,
+    books_on_track_for: 12,
+    hours_on_track_for: 85,
+  },
+  challenge: { target_seconds: 10000, month_seconds: 4000, percent: 40 },
+  achievements: [
+    {
+      id: "first-hour",
+      category: "time",
+      name: "First Hour",
+      description: "Read for 1 hour total",
+      achieved_at: "2026-01-05T00:00:00Z",
+    },
+  ],
+  dna: {
+    genres: [{ name: "Sci-Fi", seconds: 7200 }],
+    authors: [{ name: "Andy Weir", seconds: 5400 }],
+    diversity_score: 62,
+    avg_session_seconds: 1500,
+    hours_by_bucket: { morning: 2, afternoon: 1, evening: 4, night: 0 },
+    projected_year_hours: 87.3,
+  },
+};
+
 describe("ReadingStats page", () => {
   beforeEach(() => {
     mockUseReadingHistory.mockReset();
+    mockUseReadingMotivation.mockReset();
+    mockUseReadingMotivation.mockReturnValue({ data: undefined, isLoading: false, isError: false });
   });
 
   it("shows a loading state while the history query is in flight", () => {
@@ -157,11 +212,55 @@ describe("ReadingStats page", () => {
       // Mirrors the server default in HandleHistory: to = today at UTC
       // midnight, from = to minus 365 days. Passed explicitly (rather than
       // omitted) so the same range can be handed to the heatmap for
-      // densifying gap days.
-      expect(mockUseReadingHistory).toHaveBeenCalledWith("2025-07-20", "2026-07-20");
+      // densifying gap days. The third arg is the viewer's IANA timezone.
+      const [callFrom, callTo] = mockUseReadingHistory.mock.calls[0] ?? [];
+      expect(callFrom).toBe("2025-07-20");
+      expect(callTo).toBe("2026-07-20");
     } finally {
       vi.useRealTimers();
     }
+  });
+
+  it("appends the viewer's timezone as the tz argument on the history fetch", () => {
+    const mockedZone = "Europe/Amsterdam";
+    const resolvedOptionsSpy = vi
+      .spyOn(Intl.DateTimeFormat.prototype, "resolvedOptions")
+      .mockReturnValue({ timeZone: mockedZone } as Intl.ResolvedDateTimeFormatOptions);
+    try {
+      mockUseReadingHistory.mockReturnValue({ data: fixture, isLoading: false, isError: false });
+      renderPage();
+      expect(mockUseReadingHistory).toHaveBeenCalledWith(
+        expect.any(String),
+        expect.any(String),
+        mockedZone,
+      );
+    } finally {
+      resolvedOptionsSpy.mockRestore();
+    }
+  });
+
+  it("renders the motivation sections wired from the mocked useReadingMotivation hook", () => {
+    mockUseReadingHistory.mockReturnValue({ data: fixture, isLoading: false, isError: false });
+    mockUseReadingMotivation.mockReturnValue({
+      data: motivationFixture,
+      isLoading: false,
+      isError: false,
+    });
+    const markup = renderPage();
+    expect(markup).toContain('data-kind="streak-challenge-section" data-has-streak="true"');
+    expect(markup).toContain('data-kind="goals-section" data-has-goals="true"');
+    expect(markup).toContain('data-kind="achievements-section" data-count="1"');
+    expect(markup).toContain('data-kind="reading-dna-section" data-has-dna="true"');
+  });
+
+  it("passes null-tolerant undefined slices to the motivation sections before motivation data loads", () => {
+    mockUseReadingHistory.mockReturnValue({ data: fixture, isLoading: false, isError: false });
+    mockUseReadingMotivation.mockReturnValue({ data: undefined, isLoading: true, isError: false });
+    const markup = renderPage();
+    expect(markup).toContain('data-kind="streak-challenge-section" data-has-streak="false"');
+    expect(markup).toContain('data-kind="goals-section" data-has-goals="false"');
+    expect(markup).toContain('data-kind="achievements-section" data-count="0"');
+    expect(markup).toContain('data-kind="reading-dna-section" data-has-dna="false"');
   });
 
   it("passes the same range to the heatmap that it requests from the history hook", () => {

--- a/web/src/pages/ReadingStats.test.tsx
+++ b/web/src/pages/ReadingStats.test.tsx
@@ -1,0 +1,144 @@
+import { renderToStaticMarkup } from "react-dom/server";
+import { MemoryRouter, Route, Routes } from "react-router";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import type { ReadingHistory } from "@/hooks/queries/readingStats";
+
+const mockUseReadingHistory = vi.fn();
+
+vi.mock("@/hooks/queries/readingStats", () => ({
+  useReadingHistory: (...args: unknown[]) => mockUseReadingHistory(...args),
+}));
+
+vi.mock("@/hooks/useDocumentTitle", () => ({
+  useDocumentTitle: () => undefined,
+}));
+
+vi.mock("@/components/stats/ReadingHeatmap", () => ({
+  default: ({ days }: { days: { date: string; seconds: number }[] }) => (
+    <div data-kind="reading-heatmap">
+      {days.map((d) => (
+        <span key={d.date} data-kind="heatmap-cell">
+          {d.date}
+        </span>
+      ))}
+    </div>
+  ),
+}));
+
+import ReadingStats from "./ReadingStats";
+
+function renderPage() {
+  return renderToStaticMarkup(
+    <MemoryRouter initialEntries={["/reading-stats"]}>
+      <Routes>
+        <Route path="/reading-stats" element={<ReadingStats />} />
+      </Routes>
+    </MemoryRouter>,
+  );
+}
+
+const fixture: ReadingHistory = {
+  totals: {
+    today_seconds: 600,
+    week_seconds: 3600,
+    month_seconds: 36000,
+    all_time_seconds: 360000,
+  },
+  days: [
+    { date: "2026-07-18", seconds: 0 },
+    { date: "2026-07-19", seconds: 1800 },
+    { date: "2026-07-20", seconds: 600 },
+  ],
+  books: [
+    {
+      content_id: "book-1",
+      title: "Project Hail Mary",
+      seconds: 7200,
+      last_read_at: "2026-07-20T10:00:00Z",
+    },
+    {
+      content_id: "book-2",
+      title: "",
+      seconds: 1200,
+      last_read_at: "2026-07-15T10:00:00Z",
+    },
+  ],
+  sessions: [
+    {
+      content_id: "book-1",
+      title: "Project Hail Mary",
+      started_at: "2026-07-20T09:00:00Z",
+      duration_seconds: 1800,
+      start_fraction: 0.1,
+      end_fraction: 0.25,
+    },
+    {
+      content_id: "book-2",
+      title: "",
+      started_at: "2026-07-19T09:00:00Z",
+      duration_seconds: 600,
+      start_fraction: 0.4,
+      end_fraction: 0.42,
+    },
+  ],
+};
+
+describe("ReadingStats page", () => {
+  beforeEach(() => {
+    mockUseReadingHistory.mockReset();
+  });
+
+  it("shows a loading state while the history query is in flight", () => {
+    mockUseReadingHistory.mockReturnValue({ data: undefined, isLoading: true, isError: false });
+    const markup = renderPage();
+    expect(markup).toContain("Reading stats");
+  });
+
+  it("shows an error state when the history query fails", () => {
+    mockUseReadingHistory.mockReturnValue({ data: undefined, isLoading: false, isError: true });
+    const markup = renderPage();
+    expect(markup.toLowerCase()).toContain("failed");
+  });
+
+  it("renders the totals row with formatDuration applied", () => {
+    mockUseReadingHistory.mockReturnValue({ data: fixture, isLoading: false, isError: false });
+    const markup = renderPage();
+    // today_seconds=600 -> 10m, week=3600 -> 1h 0m, month=36000 -> 10h 0m, all-time=360000 -> 100h 0m
+    expect(markup).toContain("10m");
+    expect(markup).toContain("1h 0m");
+    expect(markup).toContain("10h 0m");
+    expect(markup).toContain("100h 0m");
+  });
+
+  it("renders the top books list with a Removed book fallback and item links", () => {
+    mockUseReadingHistory.mockReturnValue({ data: fixture, isLoading: false, isError: false });
+    const markup = renderPage();
+    expect(markup).toContain("Project Hail Mary");
+    expect(markup).toContain("/item/book-1");
+    expect(markup).toContain("Removed book");
+    expect(markup).not.toContain("/item/book-2");
+  });
+
+  it("renders the sessions timeline with duration and fraction range", () => {
+    mockUseReadingHistory.mockReturnValue({ data: fixture, isLoading: false, isError: false });
+    const markup = renderPage();
+    // session 1: duration 1800s -> 30m, fraction 10%-25%
+    expect(markup).toContain("30m");
+    expect(markup).toContain("10%");
+    expect(markup).toContain("25%");
+  });
+
+  it("renders one heatmap cell per fixture day", () => {
+    mockUseReadingHistory.mockReturnValue({ data: fixture, isLoading: false, isError: false });
+    const markup = renderPage();
+    const matches = markup.match(/data-kind="heatmap-cell"/g) ?? [];
+    expect(matches).toHaveLength(fixture.days.length);
+  });
+
+  it("requests the default range (no explicit from/to)", () => {
+    mockUseReadingHistory.mockReturnValue({ data: fixture, isLoading: false, isError: false });
+    renderPage();
+    expect(mockUseReadingHistory).toHaveBeenCalledWith();
+  });
+});

--- a/web/src/pages/ReadingStats.test.tsx
+++ b/web/src/pages/ReadingStats.test.tsx
@@ -59,7 +59,7 @@ const fixture: ReadingHistory = {
     },
     {
       content_id: "book-2",
-      title: "",
+      title: "Removed book",
       seconds: 1200,
       last_read_at: "2026-07-15T10:00:00Z",
     },
@@ -75,7 +75,7 @@ const fixture: ReadingHistory = {
     },
     {
       content_id: "book-2",
-      title: "",
+      title: "Removed book",
       started_at: "2026-07-19T09:00:00Z",
       duration_seconds: 600,
       start_fraction: 0.4,

--- a/web/src/pages/ReadingStats.tsx
+++ b/web/src/pages/ReadingStats.tsx
@@ -2,11 +2,21 @@ import { CalendarDays, CalendarRange, Clock, Infinity as InfinityIcon } from "lu
 import { useMemo, type ReactNode } from "react";
 import { Link } from "react-router";
 
+import {
+  AchievementsSection,
+  GoalsSection,
+  ReadingDnaSection,
+  StreakChallengeSection,
+} from "@/components/stats/MotivationSections";
 import ReadingHeatmap from "@/components/stats/ReadingHeatmap";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Skeleton } from "@/components/ui/skeleton";
 import { useDocumentTitle } from "@/hooks/useDocumentTitle";
-import { useReadingHistory } from "@/hooks/queries/readingStats";
+import {
+  clientTimezone,
+  useReadingHistory,
+  useReadingMotivation,
+} from "@/hooks/queries/readingStats";
 import { formatDate } from "@/lib/datetime";
 import { formatDuration } from "@/lib/formatDuration";
 
@@ -58,7 +68,9 @@ export default function ReadingStats() {
   useDocumentTitle("Reading stats");
   const to = useMemo(() => todayUTC(), []);
   const from = useMemo(() => subDaysUTC(to, DEFAULT_HISTORY_RANGE_DAYS), [to]);
-  const { data, isLoading, isError } = useReadingHistory(from, to);
+  const tz = useMemo(() => clientTimezone(), []);
+  const { data, isLoading, isError } = useReadingHistory(from, to, tz);
+  const { data: motivation } = useReadingMotivation();
 
   return (
     <div className="space-y-6">
@@ -99,6 +111,11 @@ export default function ReadingStats() {
               icon={<InfinityIcon className="h-4 w-4" />}
             />
           </div>
+
+          <StreakChallengeSection streak={motivation?.streak} challenge={motivation?.challenge} />
+          <GoalsSection goals={motivation?.goals} />
+          <AchievementsSection achievements={motivation?.achievements} />
+          <ReadingDnaSection dna={motivation?.dna} />
 
           <Card className="rounded-2xl border-0 shadow-none">
             <CardHeader>

--- a/web/src/pages/ReadingStats.tsx
+++ b/web/src/pages/ReadingStats.tsx
@@ -95,52 +95,53 @@ export default function ReadingStats() {
     <div className="space-y-6">
       <h1 className="text-2xl font-semibold tracking-tight sm:text-3xl">Reading stats</h1>
 
+      {isError ? (
+        <p className="text-muted-foreground text-sm">Failed to load reading stats.</p>
+      ) : isLoading || !data ? (
+        <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 md:grid-cols-4">
+          {Array.from({ length: 4 }).map((_, i) => (
+            <Skeleton key={i} className="h-[108px] rounded-2xl" />
+          ))}
+        </div>
+      ) : (
+        <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 md:grid-cols-4">
+          <StatCard
+            title="Today"
+            seconds={data.totals.today_seconds}
+            icon={<Clock className="h-4 w-4" />}
+          />
+          <StatCard
+            title="This week"
+            seconds={data.totals.week_seconds}
+            icon={<CalendarDays className="h-4 w-4" />}
+          />
+          <StatCard
+            title="This month"
+            seconds={data.totals.month_seconds}
+            icon={<CalendarRange className="h-4 w-4" />}
+          />
+          <StatCard
+            title="All time"
+            seconds={data.totals.all_time_seconds}
+            icon={<InfinityIcon className="h-4 w-4" />}
+          />
+        </div>
+      )}
+
       {/* Driven entirely by useReadingMotivation, independent of the reading-
-          history query below — a history failure/loading state must not hide
-          streaks, goals, achievements, or Reading DNA. Each section is
-          null-tolerant and renders its own empty/skeleton state while
+          history query above/below — a history failure/loading state must
+          not hide streaks, goals, achievements, or Reading DNA. Each section
+          is null-tolerant and renders its own empty/skeleton state while
           `motivation` is undefined. */}
       <StreakChallengeSection streak={motivation?.streak} challenge={motivation?.challenge} />
       <GoalsSection goals={motivation?.goals} />
       <AchievementsSection achievements={motivation?.achievements} />
       <ReadingDnaSection dna={motivation?.dna} />
 
-      {isError ? (
-        <p className="text-muted-foreground text-sm">Failed to load reading stats.</p>
-      ) : isLoading || !data ? (
-        <div className="space-y-6">
-          <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 md:grid-cols-4">
-            {Array.from({ length: 4 }).map((_, i) => (
-              <Skeleton key={i} className="h-[108px] rounded-2xl" />
-            ))}
-          </div>
-          <Skeleton className="h-32 w-full rounded-2xl" />
-        </div>
+      {isError ? null : isLoading || !data ? (
+        <Skeleton className="h-32 w-full rounded-2xl" />
       ) : (
         <>
-          <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 md:grid-cols-4">
-            <StatCard
-              title="Today"
-              seconds={data.totals.today_seconds}
-              icon={<Clock className="h-4 w-4" />}
-            />
-            <StatCard
-              title="This week"
-              seconds={data.totals.week_seconds}
-              icon={<CalendarDays className="h-4 w-4" />}
-            />
-            <StatCard
-              title="This month"
-              seconds={data.totals.month_seconds}
-              icon={<CalendarRange className="h-4 w-4" />}
-            />
-            <StatCard
-              title="All time"
-              seconds={data.totals.all_time_seconds}
-              icon={<InfinityIcon className="h-4 w-4" />}
-            />
-          </div>
-
           <Card className="rounded-2xl border-0 shadow-none">
             <CardHeader>
               <CardTitle className="text-base font-semibold">Activity</CardTitle>

--- a/web/src/pages/ReadingStats.tsx
+++ b/web/src/pages/ReadingStats.tsx
@@ -76,6 +76,16 @@ export default function ReadingStats() {
     <div className="space-y-6">
       <h1 className="text-2xl font-semibold tracking-tight sm:text-3xl">Reading stats</h1>
 
+      {/* Driven entirely by useReadingMotivation, independent of the reading-
+          history query below — a history failure/loading state must not hide
+          streaks, goals, achievements, or Reading DNA. Each section is
+          null-tolerant and renders its own empty/skeleton state while
+          `motivation` is undefined. */}
+      <StreakChallengeSection streak={motivation?.streak} challenge={motivation?.challenge} />
+      <GoalsSection goals={motivation?.goals} />
+      <AchievementsSection achievements={motivation?.achievements} />
+      <ReadingDnaSection dna={motivation?.dna} />
+
       {isError ? (
         <p className="text-muted-foreground text-sm">Failed to load reading stats.</p>
       ) : isLoading || !data ? (
@@ -111,11 +121,6 @@ export default function ReadingStats() {
               icon={<InfinityIcon className="h-4 w-4" />}
             />
           </div>
-
-          <StreakChallengeSection streak={motivation?.streak} challenge={motivation?.challenge} />
-          <GoalsSection goals={motivation?.goals} />
-          <AchievementsSection achievements={motivation?.achievements} />
-          <ReadingDnaSection dna={motivation?.dna} />
 
           <Card className="rounded-2xl border-0 shadow-none">
             <CardHeader>

--- a/web/src/pages/ReadingStats.tsx
+++ b/web/src/pages/ReadingStats.tsx
@@ -1,0 +1,176 @@
+import { CalendarDays, CalendarRange, Clock, Infinity as InfinityIcon } from "lucide-react";
+import type { ReactNode } from "react";
+import { Link } from "react-router";
+
+import ReadingHeatmap from "@/components/stats/ReadingHeatmap";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Skeleton } from "@/components/ui/skeleton";
+import { useDocumentTitle } from "@/hooks/useDocumentTitle";
+import { useReadingHistory } from "@/hooks/queries/readingStats";
+import { formatDate } from "@/lib/datetime";
+import { formatDuration } from "@/lib/formatDuration";
+
+function fractionLabel(fraction: number): string {
+  return `${Math.round(fraction * 100)}%`;
+}
+
+function StatCard({ title, seconds, icon }: { title: string; seconds: number; icon: ReactNode }) {
+  return (
+    <Card className="rounded-2xl border-0 shadow-none">
+      <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
+        <CardTitle className="text-muted-foreground text-sm font-medium">{title}</CardTitle>
+        <div className="text-muted-foreground">{icon}</div>
+      </CardHeader>
+      <CardContent>
+        <div className="text-3xl font-semibold tracking-tight">{formatDuration(seconds)}</div>
+      </CardContent>
+    </Card>
+  );
+}
+
+export default function ReadingStats() {
+  useDocumentTitle("Reading stats");
+  const { data, isLoading, isError } = useReadingHistory();
+
+  return (
+    <div className="space-y-6">
+      <h1 className="text-2xl font-semibold tracking-tight sm:text-3xl">Reading stats</h1>
+
+      {isError ? (
+        <p className="text-muted-foreground text-sm">Failed to load reading stats.</p>
+      ) : isLoading || !data ? (
+        <div className="space-y-6">
+          <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 md:grid-cols-4">
+            {Array.from({ length: 4 }).map((_, i) => (
+              <Skeleton key={i} className="h-[108px] rounded-2xl" />
+            ))}
+          </div>
+          <Skeleton className="h-32 w-full rounded-2xl" />
+        </div>
+      ) : (
+        <>
+          <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 md:grid-cols-4">
+            <StatCard
+              title="Today"
+              seconds={data.totals.today_seconds}
+              icon={<Clock className="h-4 w-4" />}
+            />
+            <StatCard
+              title="This week"
+              seconds={data.totals.week_seconds}
+              icon={<CalendarDays className="h-4 w-4" />}
+            />
+            <StatCard
+              title="This month"
+              seconds={data.totals.month_seconds}
+              icon={<CalendarRange className="h-4 w-4" />}
+            />
+            <StatCard
+              title="All time"
+              seconds={data.totals.all_time_seconds}
+              icon={<InfinityIcon className="h-4 w-4" />}
+            />
+          </div>
+
+          <Card className="rounded-2xl border-0 shadow-none">
+            <CardHeader>
+              <CardTitle className="text-base font-semibold">Activity</CardTitle>
+            </CardHeader>
+            <CardContent>
+              {data.days.length === 0 ? (
+                <p className="text-muted-foreground text-sm">No reading activity yet.</p>
+              ) : (
+                <ReadingHeatmap days={data.days} />
+              )}
+            </CardContent>
+          </Card>
+
+          <Card className="rounded-2xl border-0 shadow-none">
+            <CardHeader>
+              <CardTitle className="text-base font-semibold">Top books</CardTitle>
+            </CardHeader>
+            <CardContent>
+              {data.books.length === 0 ? (
+                <p className="text-muted-foreground text-sm">No books read yet.</p>
+              ) : (
+                <ul className="divide-border/60 divide-y">
+                  {data.books.map((book) => {
+                    const isRemoved = !book.title;
+                    const label = isRemoved ? "Removed book" : book.title;
+                    return (
+                      <li
+                        key={book.content_id}
+                        className="flex items-center justify-between gap-3 py-2.5 text-sm"
+                      >
+                        {isRemoved ? (
+                          <span className="text-muted-foreground min-w-0 truncate italic">
+                            {label}
+                          </span>
+                        ) : (
+                          <Link
+                            to={`/item/${book.content_id}`}
+                            className="hover:text-primary min-w-0 truncate font-medium"
+                          >
+                            {label}
+                          </Link>
+                        )}
+                        <span className="text-muted-foreground shrink-0 tabular-nums">
+                          {formatDuration(book.seconds)}
+                        </span>
+                      </li>
+                    );
+                  })}
+                </ul>
+              )}
+            </CardContent>
+          </Card>
+
+          <Card className="rounded-2xl border-0 shadow-none">
+            <CardHeader>
+              <CardTitle className="text-base font-semibold">Recent sessions</CardTitle>
+            </CardHeader>
+            <CardContent>
+              {data.sessions.length === 0 ? (
+                <p className="text-muted-foreground text-sm">No reading sessions yet.</p>
+              ) : (
+                <ul className="divide-border/60 divide-y">
+                  {data.sessions.map((session) => {
+                    const isRemoved = !session.title;
+                    const label = isRemoved ? "Removed book" : session.title;
+                    return (
+                      <li
+                        key={`${session.content_id}-${session.started_at}-${session.start_fraction}`}
+                        className="flex flex-wrap items-center justify-between gap-x-3 gap-y-1 py-2.5 text-sm"
+                      >
+                        <div className="min-w-0">
+                          <span className="text-muted-foreground text-xs">
+                            {formatDate(session.started_at, "medium")}
+                          </span>{" "}
+                          {isRemoved ? (
+                            <span className="text-muted-foreground truncate italic">{label}</span>
+                          ) : (
+                            <Link
+                              to={`/item/${session.content_id}`}
+                              className="hover:text-primary truncate font-medium"
+                            >
+                              {label}
+                            </Link>
+                          )}
+                        </div>
+                        <span className="text-muted-foreground shrink-0 tabular-nums">
+                          {formatDuration(session.duration_seconds)} ·{" "}
+                          {fractionLabel(session.start_fraction)}–
+                          {fractionLabel(session.end_fraction)}
+                        </span>
+                      </li>
+                    );
+                  })}
+                </ul>
+              )}
+            </CardContent>
+          </Card>
+        </>
+      )}
+    </div>
+  );
+}

--- a/web/src/pages/ReadingStats.tsx
+++ b/web/src/pages/ReadingStats.tsx
@@ -10,6 +10,8 @@ import { useReadingHistory } from "@/hooks/queries/readingStats";
 import { formatDate } from "@/lib/datetime";
 import { formatDuration } from "@/lib/formatDuration";
 
+const REMOVED_BOOK_TITLE = "Removed book";
+
 function fractionLabel(fraction: number): string {
   return `${Math.round(fraction * 100)}%`;
 }
@@ -95,8 +97,8 @@ export default function ReadingStats() {
               ) : (
                 <ul className="divide-border/60 divide-y">
                   {data.books.map((book) => {
-                    const isRemoved = !book.title;
-                    const label = isRemoved ? "Removed book" : book.title;
+                    const isRemoved = book.title === REMOVED_BOOK_TITLE;
+                    const label = book.title;
                     return (
                       <li
                         key={book.content_id}
@@ -135,8 +137,8 @@ export default function ReadingStats() {
               ) : (
                 <ul className="divide-border/60 divide-y">
                   {data.sessions.map((session) => {
-                    const isRemoved = !session.title;
-                    const label = isRemoved ? "Removed book" : session.title;
+                    const isRemoved = session.title === REMOVED_BOOK_TITLE;
+                    const label = session.title;
                     return (
                       <li
                         key={`${session.content_id}-${session.started_at}-${session.start_fraction}`}

--- a/web/src/pages/ReadingStats.tsx
+++ b/web/src/pages/ReadingStats.tsx
@@ -23,23 +23,42 @@ import { formatDuration } from "@/lib/formatDuration";
 const REMOVED_BOOK_TITLE = "Removed book";
 
 // Mirrors the server's default history window (HandleHistory in
-// internal/api/handlers/reading_sessions.go): `to` = today at UTC midnight,
-// `from` = to minus 365 days (366 calendar days inclusive). Computed
-// explicitly here, rather than relying on the hook's server-side default,
-// so the exact same range can be handed to the heatmap — it needs `from`/`to`
-// to densify gap days across the range the server actually rolled up, not
-// just whatever the (possibly sparse) returned `days` list happens to span.
+// internal/api/handlers/reading_sessions.go): `to` = today in the viewer's
+// local timezone, `from` = to minus 365 days (366 calendar days inclusive).
+// Computed explicitly here, rather than relying on the hook's server-side
+// default, so the exact same range can be handed to the heatmap — it needs
+// `from`/`to` to densify gap days across the range the server actually
+// rolled up, not just whatever the (possibly sparse) returned `days` list
+// happens to span.
 const DEFAULT_HISTORY_RANGE_DAYS = 365;
 
 function isoDateUTC(date: Date): string {
   return date.toISOString().slice(0, 10);
 }
 
-function todayUTC(): string {
-  const now = new Date();
-  return isoDateUTC(new Date(Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), now.getUTCDate())));
+// Formats `date` as a "YYYY-MM-DD" calendar-day string in `timeZone`. The
+// en-CA locale is a well-known trick for getting Intl to emit ISO-ordered
+// digits directly, without hand-rolling a formatToParts reassembly.
+function isoDateInZone(date: Date, timeZone: string): string {
+  return new Intl.DateTimeFormat("en-CA", {
+    timeZone,
+    year: "numeric",
+    month: "2-digit",
+    day: "2-digit",
+  }).format(date);
 }
 
+// Today's date string in the viewer's local timezone, matching the calendar
+// day the server's HandleHistory resolves `to` to for the same `tz` param
+// (see requestLocation in internal/api/handlers/reading_motivation.go).
+function todayInZone(timeZone: string): string {
+  return isoDateInZone(new Date(), timeZone);
+}
+
+// Subtracts `days` from a "YYYY-MM-DD" date string. Pure calendar-day
+// arithmetic on the string itself (via a fixed UTC midnight anchor to dodge
+// DST edge cases) — independent of any timezone, since `dateStr` is already
+// resolved to the viewer's local calendar day by the caller.
 function subDaysUTC(dateStr: string, days: number): string {
   const d = new Date(`${dateStr}T00:00:00Z`);
   d.setUTCDate(d.getUTCDate() - days);
@@ -66,9 +85,9 @@ function StatCard({ title, seconds, icon }: { title: string; seconds: number; ic
 
 export default function ReadingStats() {
   useDocumentTitle("Reading stats");
-  const to = useMemo(() => todayUTC(), []);
-  const from = useMemo(() => subDaysUTC(to, DEFAULT_HISTORY_RANGE_DAYS), [to]);
   const tz = useMemo(() => clientTimezone(), []);
+  const to = useMemo(() => todayInZone(tz), [tz]);
+  const from = useMemo(() => subDaysUTC(to, DEFAULT_HISTORY_RANGE_DAYS), [to]);
   const { data, isLoading, isError } = useReadingHistory(from, to, tz);
   const { data: motivation } = useReadingMotivation();
 

--- a/web/src/pages/ReadingStats.tsx
+++ b/web/src/pages/ReadingStats.tsx
@@ -1,5 +1,5 @@
 import { CalendarDays, CalendarRange, Clock, Infinity as InfinityIcon } from "lucide-react";
-import type { ReactNode } from "react";
+import { useMemo, type ReactNode } from "react";
 import { Link } from "react-router";
 
 import ReadingHeatmap from "@/components/stats/ReadingHeatmap";
@@ -11,6 +11,30 @@ import { formatDate } from "@/lib/datetime";
 import { formatDuration } from "@/lib/formatDuration";
 
 const REMOVED_BOOK_TITLE = "Removed book";
+
+// Mirrors the server's default history window (HandleHistory in
+// internal/api/handlers/reading_sessions.go): `to` = today at UTC midnight,
+// `from` = to minus 365 days (366 calendar days inclusive). Computed
+// explicitly here, rather than relying on the hook's server-side default,
+// so the exact same range can be handed to the heatmap — it needs `from`/`to`
+// to densify gap days across the range the server actually rolled up, not
+// just whatever the (possibly sparse) returned `days` list happens to span.
+const DEFAULT_HISTORY_RANGE_DAYS = 365;
+
+function isoDateUTC(date: Date): string {
+  return date.toISOString().slice(0, 10);
+}
+
+function todayUTC(): string {
+  const now = new Date();
+  return isoDateUTC(new Date(Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), now.getUTCDate())));
+}
+
+function subDaysUTC(dateStr: string, days: number): string {
+  const d = new Date(`${dateStr}T00:00:00Z`);
+  d.setUTCDate(d.getUTCDate() - days);
+  return isoDateUTC(d);
+}
 
 function fractionLabel(fraction: number): string {
   return `${Math.round(fraction * 100)}%`;
@@ -32,7 +56,9 @@ function StatCard({ title, seconds, icon }: { title: string; seconds: number; ic
 
 export default function ReadingStats() {
   useDocumentTitle("Reading stats");
-  const { data, isLoading, isError } = useReadingHistory();
+  const to = useMemo(() => todayUTC(), []);
+  const from = useMemo(() => subDaysUTC(to, DEFAULT_HISTORY_RANGE_DAYS), [to]);
+  const { data, isLoading, isError } = useReadingHistory(from, to);
 
   return (
     <div className="space-y-6">
@@ -82,7 +108,7 @@ export default function ReadingStats() {
               {data.days.length === 0 ? (
                 <p className="text-muted-foreground text-sm">No reading activity yet.</p>
               ) : (
-                <ReadingHeatmap days={data.days} />
+                <ReadingHeatmap days={data.days} from={from} to={to} />
               )}
             </CardContent>
           </Card>

--- a/web/src/reader/FoliateBookReader.component.test.tsx
+++ b/web/src/reader/FoliateBookReader.component.test.tsx
@@ -63,6 +63,8 @@ class FakeFoliateView extends HTMLElement {
   init = vi.fn(async () => {});
   goToFraction = vi.fn(async () => {});
   getSectionFractions = vi.fn((): number[] => []);
+  renderer: { getContents?: () => Array<{ doc: Document; index?: number }> } | undefined =
+    undefined;
   open = vi.fn((book: unknown) => {
     this.book = book;
     const behavior = viewOpenBehaviors.shift();
@@ -118,6 +120,34 @@ function viewAt(index: number): FakeFoliateView {
   return view;
 }
 
+// Builds a standalone Document (not attached to any real iframe) standing in
+// for one of foliate's content docs, with `defaultView.frameElement` stubbed
+// to report the given frame offset — mirroring the real relationship between
+// a content doc and the same-origin iframe foliate renders it into.
+function makeFakeContentDoc(frameRect: { left: number; top: number }): Document {
+  const doc = document.implementation.createHTMLDocument("content");
+  const frameElement = document.createElement("div");
+  frameElement.getBoundingClientRect = () =>
+    ({
+      left: frameRect.left,
+      top: frameRect.top,
+      width: 0,
+      height: 0,
+      right: frameRect.left,
+      bottom: frameRect.top,
+      x: frameRect.left,
+      y: frameRect.top,
+      toJSON() {
+        return {};
+      },
+    }) as DOMRect;
+  Object.defineProperty(doc, "defaultView", {
+    configurable: true,
+    value: { frameElement },
+  });
+  return doc;
+}
+
 function relocateEvent(current: number, cfi?: string) {
   return new CustomEvent("relocate", {
     detail: { cfi, location: { current, total: 10 } },
@@ -137,6 +167,8 @@ describe("FoliateBookReader open flow", () => {
     props: {
       onReady?: (state: ReaderReadyState) => void;
       onLocationChange?: (info: ReaderLocationInfo) => void;
+      onContentPointerUp?: (point: { clientX: number; clientY: number }) => void;
+      onContentPointerMove?: (point: { clientY: number }) => void;
     } = {},
     ref?: Ref<FoliateBookReaderHandle>,
   ) {
@@ -477,5 +509,61 @@ describe("FoliateBookReader open flow", () => {
     view.getSectionFractions = vi.fn(() => [0, 0.25, 1]);
 
     expect(handleRef.current?.getSectionFractions()).toEqual([0, 0.25, 1]);
+  });
+
+  it("forwards pointerup and mousemove from content iframes with viewport-adjusted coordinates", async () => {
+    const book = makeBook("A");
+    mocks.loaderOpen.mockResolvedValue({ book });
+    const onContentPointerUp = vi.fn();
+    const onContentPointerMove = vi.fn();
+
+    await act(async () => {
+      root.render(ui(fileA, { onContentPointerUp, onContentPointerMove }));
+    });
+    const view = viewAt(0);
+
+    // foliate re-creates content docs and fires "create-overlay" for each;
+    // the frame sits at (40, 20) in outer viewport coordinates.
+    const contentDoc = makeFakeContentDoc({ left: 40, top: 20 });
+    view.renderer = { getContents: () => [{ doc: contentDoc, index: 0 }] };
+
+    await act(async () => {
+      view.dispatchEvent(new CustomEvent("create-overlay"));
+    });
+
+    await act(async () => {
+      contentDoc.dispatchEvent(new MouseEvent("pointerup", { clientX: 10, clientY: 5 }));
+    });
+    // iframe-local (10, 5) + frame offset (40, 20) => outer viewport (50, 25).
+    expect(onContentPointerUp).toHaveBeenCalledWith({ clientX: 50, clientY: 25 });
+
+    await act(async () => {
+      contentDoc.dispatchEvent(new MouseEvent("mousemove", { clientY: 5 }));
+    });
+    expect(onContentPointerMove).toHaveBeenCalledWith({ clientY: 25 });
+  });
+
+  it("does not forward content pointer events when the callbacks are absent", async () => {
+    const book = makeBook("A");
+    mocks.loaderOpen.mockResolvedValue({ book });
+
+    await act(async () => {
+      root.render(ui(fileA));
+    });
+    const view = viewAt(0);
+
+    const contentDoc = makeFakeContentDoc({ left: 0, top: 0 });
+    view.renderer = { getContents: () => [{ doc: contentDoc, index: 0 }] };
+
+    await act(async () => {
+      view.dispatchEvent(new CustomEvent("create-overlay"));
+    });
+
+    // No onContentPointerUp/onContentPointerMove prop was supplied; dispatching
+    // must be a silent no-op rather than throwing.
+    expect(() => {
+      contentDoc.dispatchEvent(new MouseEvent("pointerup", { clientX: 10, clientY: 5 }));
+      contentDoc.dispatchEvent(new MouseEvent("mousemove", { clientY: 5 }));
+    }).not.toThrow();
   });
 });

--- a/web/src/reader/FoliateBookReader.component.test.tsx
+++ b/web/src/reader/FoliateBookReader.component.test.tsx
@@ -497,6 +497,33 @@ describe("FoliateBookReader open flow", () => {
     });
   });
 
+  it("ignores a relocate event reporting a non-finite fraction", async () => {
+    const book = makeBook("A");
+    mocks.loaderOpen.mockResolvedValue({ book });
+    const onLocationChange = vi.fn();
+
+    await act(async () => {
+      root.render(ui(fileA, { onLocationChange }));
+    });
+    const view = viewAt(0);
+
+    await act(async () => {
+      view.dispatchEvent(
+        new CustomEvent("relocate", {
+          detail: {
+            cfi: "epubcfi(/6/8!/4/2)",
+            fraction: Number.NaN,
+            index: 1,
+            tocItem: { label: "Chapter 2" },
+            location: { current: 29, total: 100 },
+          },
+        }),
+      );
+    });
+
+    expect(onLocationChange).not.toHaveBeenCalled();
+  });
+
   it("exposes section fractions through the handle", async () => {
     const book = makeBook("A");
     mocks.loaderOpen.mockResolvedValue({ book });

--- a/web/src/reader/FoliateBookReader.component.test.tsx
+++ b/web/src/reader/FoliateBookReader.component.test.tsx
@@ -1,6 +1,6 @@
 // @vitest-environment jsdom
 
-import { act } from "react";
+import { act, createRef, type Ref } from "react";
 import { createRoot, type Root } from "react-dom/client";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
@@ -45,6 +45,8 @@ vi.mock("foliate-js/view.js", () => ({}));
 
 import FoliateBookReader, {
   ebookReaderProgressQueryKey,
+  type FoliateBookReaderHandle,
+  type ReaderLocationInfo,
   type ReaderReadyState,
 } from "@/reader/FoliateBookReader";
 
@@ -60,6 +62,7 @@ class FakeFoliateView extends HTMLElement {
   close = vi.fn();
   init = vi.fn(async () => {});
   goToFraction = vi.fn(async () => {});
+  getSectionFractions = vi.fn((): number[] => []);
   open = vi.fn((book: unknown) => {
     this.book = book;
     const behavior = viewOpenBehaviors.shift();
@@ -129,10 +132,17 @@ describe("FoliateBookReader open flow", () => {
   const fileA = makeFile(7, "a.epub");
   const fileB = makeFile(8, "b.epub");
 
-  function ui(file: FileVersion, props: { onReady?: (state: ReaderReadyState) => void } = {}) {
+  function ui(
+    file: FileVersion,
+    props: {
+      onReady?: (state: ReaderReadyState) => void;
+      onLocationChange?: (info: ReaderLocationInfo) => void;
+    } = {},
+    ref?: Ref<FoliateBookReaderHandle>,
+  ) {
     return (
       <QueryClientProvider client={queryClient}>
-        <FoliateBookReader contentID="book-1" file={file} title="Book" {...props} />
+        <FoliateBookReader contentID="book-1" file={file} title="Book" {...props} ref={ref} />
       </QueryClientProvider>
     );
   }
@@ -422,5 +432,50 @@ describe("FoliateBookReader open flow", () => {
       location: "epubcfi(/6/8)",
       progress: 0.5,
     });
+  });
+
+  it("reports location info on relocate", async () => {
+    const book = makeBook("A");
+    mocks.loaderOpen.mockResolvedValue({ book });
+    const onLocationChange = vi.fn();
+
+    await act(async () => {
+      root.render(ui(fileA, { onLocationChange }));
+    });
+    const view = viewAt(0);
+
+    await act(async () => {
+      view.dispatchEvent(
+        new CustomEvent("relocate", {
+          detail: {
+            cfi: "epubcfi(/6/8!/4/2)",
+            fraction: 0.3,
+            index: 1,
+            tocItem: { label: "Chapter 2" },
+            location: { current: 29, total: 100 },
+          },
+        }),
+      );
+    });
+
+    expect(onLocationChange).toHaveBeenCalledWith({
+      fraction: 0.3,
+      sectionIndex: 1,
+      tocLabel: "Chapter 2",
+    });
+  });
+
+  it("exposes section fractions through the handle", async () => {
+    const book = makeBook("A");
+    mocks.loaderOpen.mockResolvedValue({ book });
+    const handleRef = createRef<FoliateBookReaderHandle>();
+
+    await act(async () => {
+      root.render(ui(fileA, {}, handleRef));
+    });
+    const view = viewAt(0);
+    view.getSectionFractions = vi.fn(() => [0, 0.25, 1]);
+
+    expect(handleRef.current?.getSectionFractions()).toEqual([0, 0.25, 1]);
   });
 });

--- a/web/src/reader/FoliateBookReader.component.test.tsx
+++ b/web/src/reader/FoliateBookReader.component.test.tsx
@@ -570,6 +570,47 @@ describe("FoliateBookReader open flow", () => {
     expect(onContentPointerMove).toHaveBeenCalledWith({ clientY: 25 });
   });
 
+  it("updates hasLiveSelection synchronously, ahead of the deferred selection-change callback", async () => {
+    const book = makeBook("A");
+    mocks.loaderOpen.mockResolvedValue({ book });
+    const handleRef = createRef<FoliateBookReaderHandle>();
+
+    await act(async () => {
+      root.render(ui(fileA, {}, handleRef));
+    });
+    const view = viewAt(0);
+
+    const contentDoc = makeFakeContentDoc({ left: 0, top: 0 });
+    let fakeSelection: { isCollapsed: boolean; rangeCount: number; toString: () => string } = {
+      isCollapsed: true,
+      rangeCount: 0,
+      toString: () => "",
+    };
+    contentDoc.getSelection = () => fakeSelection as unknown as Selection;
+    view.renderer = { getContents: () => [{ doc: contentDoc, index: 0 }] };
+
+    await act(async () => {
+      view.dispatchEvent(new CustomEvent("create-overlay"));
+    });
+    expect(handleRef.current?.hasLiveSelection()).toBe(false);
+
+    fakeSelection = { isCollapsed: false, rangeCount: 1, toString: () => "chosen text" };
+    act(() => {
+      contentDoc.dispatchEvent(new Event("selectionchange"));
+    });
+    // True immediately after the synchronous dispatch — this assertion runs
+    // before the listener's setTimeout(0) deferral could ever have fired, so
+    // it proves the ref updates synchronously rather than relying on that
+    // deferred emitSelectionChange callback.
+    expect(handleRef.current?.hasLiveSelection()).toBe(true);
+
+    fakeSelection = { isCollapsed: true, rangeCount: 0, toString: () => "" };
+    act(() => {
+      contentDoc.dispatchEvent(new Event("selectionchange"));
+    });
+    expect(handleRef.current?.hasLiveSelection()).toBe(false);
+  });
+
   it("does not forward content pointer events when the callbacks are absent", async () => {
     const book = makeBook("A");
     mocks.loaderOpen.mockResolvedValue({ book });

--- a/web/src/reader/FoliateBookReader.test.ts
+++ b/web/src/reader/FoliateBookReader.test.ts
@@ -291,24 +291,38 @@ describe("FoliateBookReader helpers", () => {
     expect(styles).toContain("writing-mode: vertical-rl !important");
   });
 
-  it("injects an @font-face rule and uses it when a custom font is selected", () => {
+  it("injects an @font-face rule using the caller-supplied font url, never the raw API path", () => {
     const styles = readerStyles(
       normalizeReaderSettings({
         fontFamily: "custom",
         customFontID: 5,
       }),
+      "blob:http://localhost/font-object-url",
     );
 
     expect(styles).toContain(
-      '@font-face { font-family: "silo-custom-font"; src: url("/api/v1/ebooks/reader-fonts/5/file"); font-display: swap; }',
+      '@font-face { font-family: "silo-custom-font"; src: url("blob:http://localhost/font-object-url"); font-display: swap; }',
     );
     expect(styles).toContain('font-family: "silo-custom-font" !important');
+    // The endpoint requires a Bearer token + X-Profile-Id header a browser-native
+    // CSS fetch can never carry, so the raw API path must never land in the CSS.
+    expect(styles).not.toContain("/api/v1/");
   });
 
   it("omits the @font-face rule when no custom font is selected", () => {
     const styles = readerStyles(normalizeReaderSettings({}));
 
     expect(styles).not.toContain("@font-face");
+  });
+
+  it("omits the @font-face rule when the font url hasn't loaded (e.g. a rejected blob fetch), even though a custom font is selected", () => {
+    const settings = normalizeReaderSettings({ fontFamily: "custom", customFontID: 5 });
+
+    expect(readerStyles(settings, null)).not.toContain("@font-face");
+    expect(readerStyles(settings, undefined)).not.toContain("@font-face");
+    // Without a usable url the font-family also must not reference the custom
+    // family name (there is no matching @font-face to back it).
+    expect(readerStyles(settings, null)).not.toContain('"silo-custom-font"');
   });
 
   it("uses full available width in scrolled flow", () => {

--- a/web/src/reader/FoliateBookReader.test.ts
+++ b/web/src/reader/FoliateBookReader.test.ts
@@ -276,6 +276,7 @@ describe("FoliateBookReader helpers", () => {
         hyphenation: false,
         rtl: true,
         writingMode: "vertical-rl",
+        justify: true,
       }),
     );
 
@@ -287,6 +288,7 @@ describe("FoliateBookReader helpers", () => {
     expect(styles).toContain("hyphens: none !important");
     expect(styles).toContain("line-height: 1.8 !important");
     expect(styles).toContain("max-width: 68ch !important");
+    expect(styles).toContain("text-align: justify !important");
     expect(styles).toContain("direction: rtl !important");
     expect(styles).toContain("writing-mode: vertical-rl !important");
   });
@@ -368,6 +370,20 @@ describe("FoliateBookReader helpers", () => {
       margin: "20px",
       maxColumnCount: "1",
       maxInlineSize: "9999px",
+    });
+  });
+
+  it("computes explicit column count and gap from settings", () => {
+    expect(
+      readerRendererAttributes(
+        normalizeReaderSettings({
+          columns: 3,
+          columnGap: 20,
+        }),
+      ),
+    ).toMatchObject({
+      maxColumnCount: "3",
+      gap: "20%",
     });
   });
 });

--- a/web/src/reader/FoliateBookReader.test.ts
+++ b/web/src/reader/FoliateBookReader.test.ts
@@ -236,6 +236,18 @@ describe("FoliateBookReader helpers", () => {
     ).toBe(READER_FONT_STACKS.serif);
   });
 
+  it("falls back to inherit when fontFamily is custom but customFontID is missing", () => {
+    expect(normalizeReaderSettings({ fontFamily: "custom" }).fontFamily).toBe("inherit");
+    expect(normalizeReaderSettings({ fontFamily: "custom" }).customFontID).toBeNull();
+    expect(normalizeReaderSettings({ fontFamily: "custom", customFontID: -1 }).fontFamily).toBe(
+      "inherit",
+    );
+    // A valid pairing is left untouched.
+    expect(normalizeReaderSettings({ fontFamily: "custom", customFontID: 5 }).fontFamily).toBe(
+      "custom",
+    );
+  });
+
   it("normalizes persisted reading ruler settings", () => {
     expect(
       normalizeReaderSettings({

--- a/web/src/reader/FoliateBookReader.test.ts
+++ b/web/src/reader/FoliateBookReader.test.ts
@@ -175,7 +175,6 @@ describe("FoliateBookReader helpers", () => {
         maxWidth: 200,
         theme: "sepia",
         flow: "scrolled",
-        spread: "none",
       }),
     ).toMatchObject({
       fontSize: 180,
@@ -184,8 +183,36 @@ describe("FoliateBookReader helpers", () => {
       maxWidth: 96,
       theme: "sepia",
       flow: "scrolled",
-      spread: "none",
     });
+  });
+
+  it("migrates legacy theme and spread values", () => {
+    const settings = normalizeReaderSettings({ theme: "sepia", spread: "none" });
+    expect(settings.themeName).toBe("sepia");
+    expect(settings.themeVariant).toBe("light");
+    expect(settings.theme).toBe("sepia"); // legacy field still written
+    expect(settings.columns).toBe(1);
+  });
+
+  it("prefers explicit themeName/themeVariant over the legacy field", () => {
+    const settings = normalizeReaderSettings({
+      theme: "light",
+      themeName: "ocean",
+      themeVariant: "dark",
+    });
+    expect(settings.themeName).toBe("ocean");
+    expect(settings.themeVariant).toBe("dark");
+    expect(settings.theme).toBe("dark"); // legacy derived from the pair
+  });
+
+  it("clamps columns, columnGap, and defaults justify", () => {
+    expect(normalizeReaderSettings({ columns: 4 }).columns).toBe(4);
+    expect(normalizeReaderSettings({ columns: 7 }).columns).toBe("auto");
+    expect(normalizeReaderSettings({ columnGap: 80 }).columnGap).toBe(50);
+    expect(normalizeReaderSettings({ columnGap: -3 }).columnGap).toBe(0);
+    expect(normalizeReaderSettings({}).justify).toBe(false);
+    expect(normalizeReaderSettings({}).columns).toBe("auto");
+    expect(normalizeReaderSettings({}).customFontID).toBeNull();
   });
 
   it("defaults to the ebook publisher font instead of an unloaded named font", () => {

--- a/web/src/reader/FoliateBookReader.test.ts
+++ b/web/src/reader/FoliateBookReader.test.ts
@@ -279,6 +279,26 @@ describe("FoliateBookReader helpers", () => {
     expect(styles).toContain("writing-mode: vertical-rl !important");
   });
 
+  it("injects an @font-face rule and uses it when a custom font is selected", () => {
+    const styles = readerStyles(
+      normalizeReaderSettings({
+        fontFamily: "custom",
+        customFontID: 5,
+      }),
+    );
+
+    expect(styles).toContain(
+      '@font-face { font-family: "silo-custom-font"; src: url("/api/v1/ebooks/reader-fonts/5/file"); font-display: swap; }',
+    );
+    expect(styles).toContain('font-family: "silo-custom-font" !important');
+  });
+
+  it("omits the @font-face rule when no custom font is selected", () => {
+    const styles = readerStyles(normalizeReaderSettings({}));
+
+    expect(styles).not.toContain("@font-face");
+  });
+
   it("uses full available width in scrolled flow", () => {
     const scrolledStyles = readerStyles(
       normalizeReaderSettings({

--- a/web/src/reader/FoliateBookReader.tsx
+++ b/web/src/reader/FoliateBookReader.tsx
@@ -5,6 +5,7 @@ import { api, apiBlob, apiKeepalive } from "@/api/client";
 import type { FileVersion } from "@/api/types";
 import { ebookKeys } from "@/hooks/queries/keys";
 import type { EbookReaderAnnotation } from "@/reader/ebookReaderApi";
+import { readerFontFileUrl } from "@/reader/readerFontsApi";
 import { DocumentLoader, type BookDoc, type TOCItem } from "@/reader/readest/libs/document";
 import {
   legacyThemeFor,
@@ -464,10 +465,19 @@ export async function saveEbookReaderProgress(
   });
 }
 
+const CUSTOM_FONT_FAMILY = "silo-custom-font";
+
 export function readerStyles(settings: ReaderSettings = DEFAULT_READER_SETTINGS) {
   const colors = readerPalette(settings.themeName, settings.themeVariant);
   const contentMaxWidth = settings.flow === "scrolled" ? "none" : `${settings.maxWidth}ch`;
+  const fontFamily =
+    settings.fontFamily === "custom" ? `"${CUSTOM_FONT_FAMILY}"` : settings.fontFamily;
+  const fontFace =
+    settings.customFontID != null
+      ? `@font-face { font-family: "${CUSTOM_FONT_FAMILY}"; src: url("${readerFontFileUrl(settings.customFontID)}"); font-display: swap; }`
+      : "";
   return `
+    ${fontFace}
     :root {
       --theme-bg-color: ${colors.background};
       --theme-fg-color: ${colors.foreground};
@@ -477,7 +487,7 @@ export function readerStyles(settings: ReaderSettings = DEFAULT_READER_SETTINGS)
     html, body {
       background: ${colors.background} !important;
       color: ${colors.foreground} !important;
-      font-family: ${settings.fontFamily} !important;
+      font-family: ${fontFamily} !important;
       font-size: ${settings.fontSize}% !important;
       font-weight: ${settings.fontWeight} !important;
       hyphens: ${settings.hyphenation ? "auto" : "none"} !important;

--- a/web/src/reader/FoliateBookReader.tsx
+++ b/web/src/reader/FoliateBookReader.tsx
@@ -6,6 +6,14 @@ import type { FileVersion } from "@/api/types";
 import { ebookKeys } from "@/hooks/queries/keys";
 import type { EbookReaderAnnotation } from "@/reader/ebookReaderApi";
 import { DocumentLoader, type BookDoc, type TOCItem } from "@/reader/readest/libs/document";
+import {
+  legacyThemeFor,
+  READER_THEMES,
+  readerPalette,
+  themeFromLegacy,
+  type ReaderThemeName,
+  type ReaderThemeVariant,
+} from "@/reader/readerThemes";
 
 type FoliateViewElement = HTMLElement & {
   open: (book: BookDoc) => Promise<void>;
@@ -69,11 +77,15 @@ export type FoliateBookReaderHandle = {
 
 export type ReaderTheme = "light" | "sepia" | "dark";
 export type ReaderFlow = "paginated" | "scrolled";
-export type ReaderSpread = "auto" | "none";
+export type ReaderColumns = "auto" | 1 | 2 | 3 | 4;
 export type ReaderWritingMode = "auto" | "horizontal-tb" | "vertical-rl";
 
 export type ReaderSettings = {
+  // Legacy tri-state theme, kept in sync with themeName/themeVariant on every
+  // normalize so settings persisted by older clients keep rendering correctly.
   theme: ReaderTheme;
+  themeName: ReaderThemeName;
+  themeVariant: ReaderThemeVariant;
   fontFamily: string;
   fontSize: number;
   fontWeight: number;
@@ -81,13 +93,24 @@ export type ReaderSettings = {
   lineHeight: number;
   margin: number;
   maxWidth: number;
-  spread: ReaderSpread;
+  columns: ReaderColumns;
+  columnGap: number;
+  justify: boolean;
+  customFontID: number | null;
   flow: ReaderFlow;
   fontBrightness: number;
   rtl: boolean;
   writingMode: ReaderWritingMode;
   readingRuler: boolean;
   readingRulerTop: number;
+};
+
+// normalizeReaderSettings sanitizes both freshly typed updates and untyped
+// input (parsed JSON from localStorage/server config, which may still carry
+// fields from older settings shapes, e.g. the removed `spread`). Every known
+// field is accepted as `unknown` so per-field guards below decide validity.
+type ReaderSettingsInput = Partial<Record<keyof ReaderSettings, unknown>> & {
+  spread?: unknown;
 };
 
 export type ReaderReadyState = {
@@ -171,6 +194,8 @@ const LEGACY_READER_FONT_ALIASES: Record<string, string> = {
 
 export const DEFAULT_READER_SETTINGS: ReaderSettings = {
   theme: "light",
+  themeName: "default",
+  themeVariant: "light",
   fontFamily: READER_FONT_STACKS.inherit,
   fontSize: 112,
   fontWeight: 400,
@@ -178,7 +203,10 @@ export const DEFAULT_READER_SETTINGS: ReaderSettings = {
   lineHeight: 1.65,
   margin: 24,
   maxWidth: 74,
-  spread: "auto",
+  columns: "auto",
+  columnGap: 7,
+  justify: false,
+  customFontID: null,
   flow: "paginated",
   fontBrightness: 100,
   rtl: false,
@@ -322,12 +350,16 @@ function isReaderFlow(value: unknown): value is ReaderFlow {
   return value === "paginated" || value === "scrolled";
 }
 
-function isReaderSpread(value: unknown): value is ReaderSpread {
-  return value === "auto" || value === "none";
-}
-
 function isReaderWritingMode(value: unknown): value is ReaderWritingMode {
   return value === "auto" || value === "horizontal-tb" || value === "vertical-rl";
+}
+
+function isReaderThemeName(value: unknown): value is ReaderThemeName {
+  return typeof value === "string" && value in READER_THEMES;
+}
+
+function isReaderThemeVariant(value: unknown): value is ReaderThemeVariant {
+  return value === "light" || value === "dark";
 }
 
 function normalizeReaderFontFamily(value: unknown): string {
@@ -336,37 +368,66 @@ function normalizeReaderFontFamily(value: unknown): string {
   return LEGACY_READER_FONT_ALIASES[trimmed] ?? trimmed;
 }
 
-export function normalizeReaderSettings(settings?: Partial<ReaderSettings>): ReaderSettings {
+export function normalizeReaderSettings(settings?: ReaderSettingsInput): ReaderSettings {
+  const raw = settings ?? {};
+
+  // The theme-pair fields win when present; otherwise fall back to whatever
+  // the legacy tri-state `theme` value (or its own default) maps to, so
+  // settings saved before the palette-pair model existed still resolve.
+  const explicitName = isReaderThemeName(raw.themeName) ? raw.themeName : null;
+  const explicitVariant = isReaderThemeVariant(raw.themeVariant) ? raw.themeVariant : null;
+  const legacyTheme = isReaderTheme(raw.theme) ? raw.theme : DEFAULT_READER_SETTINGS.theme;
+  const fromLegacy = themeFromLegacy(legacyTheme);
+  const themeName = explicitName ?? fromLegacy.themeName;
+  const themeVariant = explicitVariant ?? fromLegacy.themeVariant;
+
+  // `spread: "none"` was the pre-columns way to request single-page mode;
+  // migrate it to columns only when the caller didn't already send columns.
+  const columns: ReaderColumns =
+    raw.columns === 1 || raw.columns === 2 || raw.columns === 3 || raw.columns === 4
+      ? raw.columns
+      : raw.spread === "none"
+        ? 1
+        : DEFAULT_READER_SETTINGS.columns;
+
   return {
-    theme: isReaderTheme(settings?.theme) ? settings.theme : DEFAULT_READER_SETTINGS.theme,
-    fontFamily: normalizeReaderFontFamily(settings?.fontFamily),
-    fontSize: clampNumber(settings?.fontSize, DEFAULT_READER_SETTINGS.fontSize, 80, 180),
-    fontWeight: clampNumber(settings?.fontWeight, DEFAULT_READER_SETTINGS.fontWeight, 300, 800),
+    theme: legacyThemeFor(themeName, themeVariant),
+    themeName,
+    themeVariant,
+    fontFamily: normalizeReaderFontFamily(raw.fontFamily),
+    fontSize: clampNumber(raw.fontSize, DEFAULT_READER_SETTINGS.fontSize, 80, 180),
+    fontWeight: clampNumber(raw.fontWeight, DEFAULT_READER_SETTINGS.fontWeight, 300, 800),
     hyphenation:
-      typeof settings?.hyphenation === "boolean"
-        ? settings.hyphenation
-        : DEFAULT_READER_SETTINGS.hyphenation,
-    lineHeight: clampNumber(settings?.lineHeight, DEFAULT_READER_SETTINGS.lineHeight, 1.1, 2.4),
-    margin: clampNumber(settings?.margin, DEFAULT_READER_SETTINGS.margin, 0, 64),
-    maxWidth: clampNumber(settings?.maxWidth, DEFAULT_READER_SETTINGS.maxWidth, 42, 96),
-    spread: isReaderSpread(settings?.spread) ? settings.spread : DEFAULT_READER_SETTINGS.spread,
-    flow: isReaderFlow(settings?.flow) ? settings.flow : DEFAULT_READER_SETTINGS.flow,
+      typeof raw.hyphenation === "boolean" ? raw.hyphenation : DEFAULT_READER_SETTINGS.hyphenation,
+    lineHeight: clampNumber(raw.lineHeight, DEFAULT_READER_SETTINGS.lineHeight, 1.1, 2.4),
+    margin: clampNumber(raw.margin, DEFAULT_READER_SETTINGS.margin, 0, 64),
+    maxWidth: clampNumber(raw.maxWidth, DEFAULT_READER_SETTINGS.maxWidth, 42, 96),
+    columns,
+    columnGap: clampNumber(raw.columnGap, DEFAULT_READER_SETTINGS.columnGap, 0, 50),
+    justify: raw.justify === true,
+    customFontID:
+      typeof raw.customFontID === "number" &&
+      Number.isInteger(raw.customFontID) &&
+      raw.customFontID > 0
+        ? raw.customFontID
+        : null,
+    flow: isReaderFlow(raw.flow) ? raw.flow : DEFAULT_READER_SETTINGS.flow,
     fontBrightness: clampNumber(
-      settings?.fontBrightness,
+      raw.fontBrightness,
       DEFAULT_READER_SETTINGS.fontBrightness,
       70,
       125,
     ),
-    rtl: typeof settings?.rtl === "boolean" ? settings.rtl : DEFAULT_READER_SETTINGS.rtl,
-    writingMode: isReaderWritingMode(settings?.writingMode)
-      ? settings.writingMode
+    rtl: typeof raw.rtl === "boolean" ? raw.rtl : DEFAULT_READER_SETTINGS.rtl,
+    writingMode: isReaderWritingMode(raw.writingMode)
+      ? raw.writingMode
       : DEFAULT_READER_SETTINGS.writingMode,
     readingRuler:
-      typeof settings?.readingRuler === "boolean"
-        ? settings.readingRuler
+      typeof raw.readingRuler === "boolean"
+        ? raw.readingRuler
         : DEFAULT_READER_SETTINGS.readingRuler,
     readingRulerTop: clampNumber(
-      settings?.readingRulerTop,
+      raw.readingRulerTop,
       DEFAULT_READER_SETTINGS.readingRulerTop,
       0,
       100,
@@ -403,34 +464,8 @@ export async function saveEbookReaderProgress(
   });
 }
 
-function readerColors(theme: ReaderTheme) {
-  switch (theme) {
-    case "dark":
-      return {
-        background: "#111827",
-        foreground: "#f8fafc",
-        link: "#93c5fd",
-        scheme: "dark",
-      };
-    case "sepia":
-      return {
-        background: "#f4ecd8",
-        foreground: "#2f261b",
-        link: "#8b5a2b",
-        scheme: "light",
-      };
-    default:
-      return {
-        background: "#ffffff",
-        foreground: "#171717",
-        link: "#2563eb",
-        scheme: "light",
-      };
-  }
-}
-
 export function readerStyles(settings: ReaderSettings = DEFAULT_READER_SETTINGS) {
-  const colors = readerColors(settings.theme);
+  const colors = readerPalette(settings.themeName, settings.themeVariant);
   const contentMaxWidth = settings.flow === "scrolled" ? "none" : `${settings.maxWidth}ch`;
   return `
     :root {
@@ -448,6 +483,7 @@ export function readerStyles(settings: ReaderSettings = DEFAULT_READER_SETTINGS)
       hyphens: ${settings.hyphenation ? "auto" : "none"} !important;
       line-height: ${settings.lineHeight} !important;
       max-width: ${contentMaxWidth} !important;
+      text-align: ${settings.justify ? "justify" : "initial"} !important;
       direction: ${settings.rtl ? "rtl" : "inherit"} !important;
       writing-mode: ${settings.writingMode === "auto" ? "inherit" : settings.writingMode} !important;
       filter: brightness(${settings.fontBrightness}%) !important;
@@ -467,10 +503,10 @@ export function readerRendererAttributes(settings: ReaderSettings) {
   const maxInlinePx = Math.round(settings.maxWidth * 10);
   return {
     flow: scrolled ? "scrolled" : null,
-    gap: "7%",
+    gap: `${settings.columnGap}%`,
     margin: `${settings.margin}px`,
     maxInlineSize: scrolled ? "9999px" : `${maxInlinePx}px`,
-    maxColumnCount: scrolled ? "1" : settings.spread === "none" ? "1" : "2",
+    maxColumnCount: scrolled ? "1" : settings.columns === "auto" ? "2" : String(settings.columns),
   };
 }
 

--- a/web/src/reader/FoliateBookReader.tsx
+++ b/web/src/reader/FoliateBookReader.tsx
@@ -73,6 +73,14 @@ export type FoliateBookReaderHandle = {
   createSelectionAnnotation: () => ReaderSelection | null;
   getReadableText: () => string;
   getSectionFractions: () => number[];
+  // Synchronous read of whether any content doc currently holds a
+  // non-collapsed selection. Unlike onSelectionChange (which the caller
+  // learns about through a state update that FoliateBookReader itself
+  // defers with setTimeout(0) to let native selection settle), this reads
+  // the live DOM selection directly, so it is safe to consult from a
+  // pointerup handler that must decide same-tick whether a tap ending a
+  // selection should also page-turn.
+  hasLiveSelection: () => boolean;
 };
 
 export type ReaderTheme = "light" | "sepia" | "dark";
@@ -627,6 +635,11 @@ const FoliateBookReader = forwardRef<FoliateBookReaderHandle, FoliateBookReaderP
     const annotationsRef = useRef<EbookReaderAnnotation[]>(annotations);
     const drawnCfisRef = useRef<Set<string>>(new Set());
     const selectionCleanupRef = useRef<(() => void)[]>([]);
+    // Synchronous mirror of "is there a live, non-collapsed selection",
+    // updated directly inside the selection listeners below (before their
+    // setTimeout(0) deferral) so hasLiveSelection() never reports stale data
+    // to a same-tick caller. See the FoliateBookReaderHandle doc comment.
+    const hasLiveSelectionRef = useRef(false);
     // Held in refs (updated every render, read from listeners) rather than
     // effect dependencies so the content-doc listeners below never need to be
     // torn down and re-attached just because a caller passed a new inline
@@ -696,6 +709,19 @@ const FoliateBookReader = forwardRef<FoliateBookReaderHandle, FoliateBookReaderP
       }
     }, []);
 
+    // Mirrors the collapsed/empty-text checks createSelectionAnnotation uses
+    // below, but only answers "is there a live selection" — no CFI/rect work
+    // — so it's cheap enough to call from every selection-related listener.
+    const computeHasLiveSelection = useCallback((): boolean => {
+      const contents = viewRef.current?.renderer?.getContents?.() ?? [];
+      for (const content of contents) {
+        const selection = content.doc.getSelection();
+        if (!selection || selection.isCollapsed || selection.rangeCount === 0) continue;
+        if (selection.toString().trim()) return true;
+      }
+      return false;
+    }, []);
+
     const createSelectionAnnotation = useCallback((): ReaderSelection | null => {
       const view = viewRef.current;
       const contents = view?.renderer?.getContents?.() ?? [];
@@ -735,10 +761,19 @@ const FoliateBookReader = forwardRef<FoliateBookReaderHandle, FoliateBookReaderP
     const attachSelectionListeners = useCallback(() => {
       for (const cleanup of selectionCleanupRef.current) cleanup();
       selectionCleanupRef.current = [];
+      // Content docs are being (re)attached, so any previously live selection
+      // no longer applies.
+      hasLiveSelectionRef.current = false;
       const contents = viewRef.current?.renderer?.getContents?.() ?? [];
       for (const content of contents) {
         const doc = content.doc;
-        const handler = () => window.setTimeout(emitSelectionChange, 0);
+        const handler = () => {
+          // Synchronous, ahead of the deferred emitSelectionChange below, so
+          // a same-tick pointerup handler (e.g. EbookReader's tap dispatch)
+          // reading hasLiveSelection() never sees a stale value.
+          hasLiveSelectionRef.current = computeHasLiveSelection();
+          window.setTimeout(emitSelectionChange, 0);
+        };
         doc.addEventListener("selectionchange", handler);
         doc.addEventListener("pointerup", handler);
         doc.addEventListener("keyup", handler);
@@ -769,7 +804,7 @@ const FoliateBookReader = forwardRef<FoliateBookReaderHandle, FoliateBookReaderP
           doc.removeEventListener("mousemove", contentPointerMove);
         });
       }
-    }, [emitSelectionChange]);
+    }, [computeHasLiveSelection, emitSelectionChange]);
 
     const getReadableText = useCallback(() => {
       const contents = viewRef.current?.renderer?.getContents?.() ?? [];
@@ -804,11 +839,13 @@ const FoliateBookReader = forwardRef<FoliateBookReaderHandle, FoliateBookReaderP
         clearSearch: () => viewRef.current?.clearSearch?.(),
         clearSelection: () => {
           viewRef.current?.deselect?.();
+          hasLiveSelectionRef.current = false;
           onSelectionChange?.(null);
         },
         createSelectionAnnotation,
         getReadableText,
         getSectionFractions: () => viewRef.current?.getSectionFractions?.() ?? [],
+        hasLiveSelection: () => hasLiveSelectionRef.current,
       }),
       [createSelectionAnnotation, getReadableText, onSelectionChange],
     );

--- a/web/src/reader/FoliateBookReader.tsx
+++ b/web/src/reader/FoliateBookReader.tsx
@@ -5,7 +5,6 @@ import { api, apiBlob, apiKeepalive } from "@/api/client";
 import type { FileVersion } from "@/api/types";
 import { ebookKeys } from "@/hooks/queries/keys";
 import type { EbookReaderAnnotation } from "@/reader/ebookReaderApi";
-import { readerFontFileUrl } from "@/reader/readerFontsApi";
 import { DocumentLoader, type BookDoc, type TOCItem } from "@/reader/readest/libs/document";
 import {
   legacyThemeFor,
@@ -475,15 +474,30 @@ export async function saveEbookReaderProgress(
 
 const CUSTOM_FONT_FAMILY = "silo-custom-font";
 
-export function readerStyles(settings: ReaderSettings = DEFAULT_READER_SETTINGS) {
+/**
+ * Builds the CSS injected into foliate's srcdoc iframes. `customFontUrl` must
+ * be an already-authenticated `blob:` URL (see `fetchReaderFontObjectUrl` in
+ * `readerFontsApi.ts`) rather than the raw `/api/v1/...` font file path: the
+ * iframe's CSS engine fetches `@font-face` src URLs itself and cannot attach
+ * the bearer token or X-Profile-Id header the reader-fonts endpoint requires,
+ * so an API path here would 401 silently and the font would never render.
+ * When the url hasn't loaded yet (or failed to), the @font-face rule and the
+ * "silo-custom-font" family are both omitted so the book falls back to its
+ * own typeface instead of an unstyled custom font.
+ */
+export function readerStyles(
+  settings: ReaderSettings = DEFAULT_READER_SETTINGS,
+  customFontUrl?: string | null,
+) {
   const colors = readerPalette(settings.themeName, settings.themeVariant);
   const contentMaxWidth = settings.flow === "scrolled" ? "none" : `${settings.maxWidth}ch`;
   const fontFamily =
-    settings.fontFamily === "custom" ? `"${CUSTOM_FONT_FAMILY}"` : settings.fontFamily;
-  const fontFace =
-    settings.customFontID != null
-      ? `@font-face { font-family: "${CUSTOM_FONT_FAMILY}"; src: url("${readerFontFileUrl(settings.customFontID)}"); font-display: swap; }`
-      : "";
+    settings.fontFamily === "custom" && customFontUrl
+      ? `"${CUSTOM_FONT_FAMILY}"`
+      : settings.fontFamily;
+  const fontFace = customFontUrl
+    ? `@font-face { font-family: "${CUSTOM_FONT_FAMILY}"; src: url("${customFontUrl}"); font-display: swap; }`
+    : "";
   return `
     ${fontFace}
     :root {
@@ -563,6 +577,10 @@ type FoliateBookReaderProps = {
   title: string;
   annotations?: EbookReaderAnnotation[];
   settings?: Partial<ReaderSettings>;
+  // Authenticated blob: URL for settings.customFontID's file, or null while
+  // it's loading/failed to load. See readerStyles' doc comment for why this
+  // can't just be derived from customFontID inside this component.
+  customFontUrl?: string | null;
   onFileLoaded?: (state: ReaderLoadState | null) => void;
   onProgressChange?: (progress: number | null) => void;
   onLocationChange?: (info: ReaderLocationInfo) => void;
@@ -586,6 +604,7 @@ const FoliateBookReader = forwardRef<FoliateBookReaderHandle, FoliateBookReaderP
       title,
       annotations = [],
       settings,
+      customFontUrl,
       onFileLoaded,
       onProgressChange,
       onLocationChange,
@@ -616,6 +635,12 @@ const FoliateBookReader = forwardRef<FoliateBookReaderHandle, FoliateBookReaderP
     onContentPointerUpRef.current = onContentPointerUp;
     const onContentPointerMoveRef = useRef(onContentPointerMove);
     onContentPointerMoveRef.current = onContentPointerMove;
+    // Same ref-mirroring pattern: applyReaderSettings reads the latest font
+    // url without needing to be redeclared (and re-diffed against the
+    // renderer) on every render just because a caller passed a new prop
+    // identity.
+    const customFontUrlRef = useRef<string | null | undefined>(customFontUrl);
+    customFontUrlRef.current = customFontUrl;
     const [loading, setLoading] = useState(true);
     const [error, setError] = useState("");
 
@@ -624,7 +649,7 @@ const FoliateBookReader = forwardRef<FoliateBookReaderHandle, FoliateBookReaderP
       settingsRef.current = normalized;
       const renderer = viewRef.current?.renderer;
       if (!renderer) return;
-      const styles = readerStyles(normalized);
+      const styles = readerStyles(normalized, customFontUrlRef.current);
       const attributes = readerRendererAttributes(normalized);
       // Settings such as the reading ruler never reach the renderer; re-styling and
       // re-rendering the book for those (or for any no-op update) causes visible jank.
@@ -790,7 +815,9 @@ const FoliateBookReader = forwardRef<FoliateBookReaderHandle, FoliateBookReaderP
 
     useEffect(() => {
       applyReaderSettings(settings);
-    }, [applyReaderSettings, settings]);
+      // customFontUrl is not part of `settings`, but changing it (font
+      // finishes loading, is replaced, or fails) still needs a re-style.
+    }, [applyReaderSettings, settings, customFontUrl]);
 
     useEffect(() => {
       annotationsRef.current = annotations;

--- a/web/src/reader/FoliateBookReader.tsx
+++ b/web/src/reader/FoliateBookReader.tsx
@@ -63,6 +63,7 @@ export type FoliateBookReaderHandle = {
   clearSelection: () => void;
   createSelectionAnnotation: () => ReaderSelection | null;
   getReadableText: () => string;
+  getSectionFractions: () => number[];
 };
 
 export type ReaderTheme = "light" | "sepia" | "dark";
@@ -130,10 +131,19 @@ type FoliateSearchResult = {
 
 type RelocateDetail = {
   cfi?: string;
+  fraction?: number;
+  index?: number;
+  tocItem?: { label?: string };
   location?: {
     current?: number;
     total?: number;
   };
+};
+
+export type ReaderLocationInfo = {
+  fraction: number;
+  sectionIndex: number | null;
+  tocLabel: string | null;
 };
 
 // foliate book documents expose destroy() to release cached resource blob URLs,
@@ -497,6 +507,7 @@ type FoliateBookReaderProps = {
   settings?: Partial<ReaderSettings>;
   onFileLoaded?: (state: ReaderLoadState | null) => void;
   onProgressChange?: (progress: number | null) => void;
+  onLocationChange?: (info: ReaderLocationInfo) => void;
   onReady?: (state: ReaderReadyState) => void;
   onSelectionChange?: (selection: ReaderSelection | null) => void;
 };
@@ -511,6 +522,7 @@ const FoliateBookReader = forwardRef<FoliateBookReaderHandle, FoliateBookReaderP
       settings,
       onFileLoaded,
       onProgressChange,
+      onLocationChange,
       onReady,
       onSelectionChange,
     },
@@ -669,6 +681,10 @@ const FoliateBookReader = forwardRef<FoliateBookReaderHandle, FoliateBookReaderP
         },
         createSelectionAnnotation,
         getReadableText,
+        getSectionFractions: () =>
+          (
+            viewRef.current as { getSectionFractions?: () => number[] } | null
+          )?.getSectionFractions?.() ?? [],
       }),
       [createSelectionAnnotation, getReadableText, onSelectionChange],
     );
@@ -840,13 +856,18 @@ const FoliateBookReader = forwardRef<FoliateBookReaderHandle, FoliateBookReaderP
             // Only the run that owns the live view may save progress for its file;
             // a superseded view firing late relocates must not overwrite it.
             if (!initializedRef.current || viewRef.current !== view) return;
-            const progress = progressFromRelocate(
-              (event as CustomEvent<RelocateDetail>).detail,
-              file.file_id,
-            );
+            const detail = (event as CustomEvent<RelocateDetail>).detail;
+            const progress = progressFromRelocate(detail, file.file_id);
             if (progress) {
               onProgressChange?.(progress.progress);
               scheduleProgressSave(progress);
+            }
+            if (typeof detail.fraction === "number") {
+              onLocationChange?.({
+                fraction: Math.min(1, Math.max(0, detail.fraction)),
+                sectionIndex: typeof detail.index === "number" ? detail.index : null,
+                tocLabel: detail.tocItem?.label?.trim() || null,
+              });
             }
           });
           await view.open(book);
@@ -914,6 +935,7 @@ const FoliateBookReader = forwardRef<FoliateBookReaderHandle, FoliateBookReaderP
       drawAnnotations,
       file,
       onFileLoaded,
+      onLocationChange,
       onProgressChange,
       onReady,
       queryClient,

--- a/web/src/reader/FoliateBookReader.tsx
+++ b/web/src/reader/FoliateBookReader.tsx
@@ -499,6 +499,9 @@ function flattenSearchResult(result: FoliateSearchResult): ReaderSearchResult[] 
   );
 }
 
+export type ReaderContentPoint = { clientX: number; clientY: number };
+export type ReaderContentVerticalPoint = { clientY: number };
+
 type FoliateBookReaderProps = {
   contentID: string;
   file: FileVersion;
@@ -510,6 +513,14 @@ type FoliateBookReaderProps = {
   onLocationChange?: (info: ReaderLocationInfo) => void;
   onReady?: (state: ReaderReadyState) => void;
   onSelectionChange?: (selection: ReaderSelection | null) => void;
+  // foliate renders prose content inside a same-origin iframe that fills the
+  // reading surface, so a page's own pointerup/mousemove listeners never see
+  // taps or hovers over the book text (iframe events do not bubble to the
+  // parent document). These callbacks bridge that boundary: they fire with
+  // coordinates already translated into the outer viewport's space so
+  // callers can treat them like any other page-level pointer event.
+  onContentPointerUp?: (point: ReaderContentPoint) => void;
+  onContentPointerMove?: (point: ReaderContentVerticalPoint) => void;
 };
 
 const FoliateBookReader = forwardRef<FoliateBookReaderHandle, FoliateBookReaderProps>(
@@ -525,6 +536,8 @@ const FoliateBookReader = forwardRef<FoliateBookReaderHandle, FoliateBookReaderP
       onLocationChange,
       onReady,
       onSelectionChange,
+      onContentPointerUp,
+      onContentPointerMove,
     },
     ref,
   ) {
@@ -540,6 +553,14 @@ const FoliateBookReader = forwardRef<FoliateBookReaderHandle, FoliateBookReaderP
     const annotationsRef = useRef<EbookReaderAnnotation[]>(annotations);
     const drawnCfisRef = useRef<Set<string>>(new Set());
     const selectionCleanupRef = useRef<(() => void)[]>([]);
+    // Held in refs (updated every render, read from listeners) rather than
+    // effect dependencies so the content-doc listeners below never need to be
+    // torn down and re-attached just because a caller passed a new inline
+    // callback identity.
+    const onContentPointerUpRef = useRef(onContentPointerUp);
+    onContentPointerUpRef.current = onContentPointerUp;
+    const onContentPointerMoveRef = useRef(onContentPointerMove);
+    onContentPointerMoveRef.current = onContentPointerMove;
     const [loading, setLoading] = useState(true);
     const [error, setError] = useState("");
 
@@ -626,6 +647,11 @@ const FoliateBookReader = forwardRef<FoliateBookReaderHandle, FoliateBookReaderP
       onSelectionChange?.(createSelectionAnnotation());
     }, [createSelectionAnnotation, onSelectionChange]);
 
+    // Wires listeners directly onto each content doc (one per rendered
+    // section/page, foliate re-creates them on "create-overlay"). This is the
+    // only reliable way to observe interaction with the book text: foliate
+    // renders it inside a same-origin iframe that fills the reading surface,
+    // and iframe-internal events never bubble out to the host page.
     const attachSelectionListeners = useCallback(() => {
       for (const cleanup of selectionCleanupRef.current) cleanup();
       selectionCleanupRef.current = [];
@@ -636,10 +662,31 @@ const FoliateBookReader = forwardRef<FoliateBookReaderHandle, FoliateBookReaderP
         doc.addEventListener("selectionchange", handler);
         doc.addEventListener("pointerup", handler);
         doc.addEventListener("keyup", handler);
+        // Translate the iframe-local coordinates into outer viewport
+        // coordinates by adding the content iframe's own frame offset, the
+        // same technique createSelectionAnnotation uses above for selection
+        // rects.
+        const contentPointerUp = (event: PointerEvent) => {
+          const frameRect = doc.defaultView?.frameElement?.getBoundingClientRect();
+          onContentPointerUpRef.current?.({
+            clientX: event.clientX + (frameRect?.left ?? 0),
+            clientY: event.clientY + (frameRect?.top ?? 0),
+          });
+        };
+        const contentPointerMove = (event: MouseEvent) => {
+          const frameRect = doc.defaultView?.frameElement?.getBoundingClientRect();
+          onContentPointerMoveRef.current?.({
+            clientY: event.clientY + (frameRect?.top ?? 0),
+          });
+        };
+        doc.addEventListener("pointerup", contentPointerUp);
+        doc.addEventListener("mousemove", contentPointerMove);
         selectionCleanupRef.current.push(() => {
           doc.removeEventListener("selectionchange", handler);
           doc.removeEventListener("pointerup", handler);
           doc.removeEventListener("keyup", handler);
+          doc.removeEventListener("pointerup", contentPointerUp);
+          doc.removeEventListener("mousemove", contentPointerMove);
         });
       }
     }, [emitSelectionChange]);

--- a/web/src/reader/FoliateBookReader.tsx
+++ b/web/src/reader/FoliateBookReader.tsx
@@ -25,6 +25,7 @@ type FoliateViewElement = HTMLElement & {
     options: ReaderSearchOptions & { query: string },
   ) => AsyncGenerator<FoliateSearchResult>;
   clearSearch?: () => void;
+  getSectionFractions?: () => number[];
   renderer?: HTMLElement & {
     primaryIndex?: number;
     getContents?: () => Array<{ doc: Document; index?: number }>;
@@ -728,10 +729,7 @@ const FoliateBookReader = forwardRef<FoliateBookReaderHandle, FoliateBookReaderP
         },
         createSelectionAnnotation,
         getReadableText,
-        getSectionFractions: () =>
-          (
-            viewRef.current as { getSectionFractions?: () => number[] } | null
-          )?.getSectionFractions?.() ?? [],
+        getSectionFractions: () => viewRef.current?.getSectionFractions?.() ?? [],
       }),
       [createSelectionAnnotation, getReadableText, onSelectionChange],
     );
@@ -909,9 +907,13 @@ const FoliateBookReader = forwardRef<FoliateBookReaderHandle, FoliateBookReaderP
               onProgressChange?.(progress.progress);
               scheduleProgressSave(progress);
             }
-            if (typeof detail.fraction === "number") {
+            const fraction = detail.fraction;
+            // typeof narrows fraction to number for the Math calls below;
+            // Number.isFinite on top of that rejects NaN/Infinity, which
+            // `typeof` alone would let through as a "number".
+            if (typeof fraction === "number" && Number.isFinite(fraction)) {
               onLocationChange?.({
-                fraction: Math.min(1, Math.max(0, detail.fraction)),
+                fraction: Math.min(1, Math.max(0, fraction)),
                 sectionIndex: typeof detail.index === "number" ? detail.index : null,
                 tocLabel: detail.tocItem?.label?.trim() || null,
               });

--- a/web/src/reader/FoliateBookReader.tsx
+++ b/web/src/reader/FoliateBookReader.tsx
@@ -391,11 +391,24 @@ export function normalizeReaderSettings(settings?: ReaderSettingsInput): ReaderS
         ? 1
         : DEFAULT_READER_SETTINGS.columns;
 
+  const fontFamily = normalizeReaderFontFamily(raw.fontFamily);
+  const customFontID =
+    typeof raw.customFontID === "number" &&
+    Number.isInteger(raw.customFontID) &&
+    raw.customFontID > 0
+      ? raw.customFontID
+      : null;
+
   return {
     theme: legacyThemeFor(themeName, themeVariant),
     themeName,
     themeVariant,
-    fontFamily: normalizeReaderFontFamily(raw.fontFamily),
+    // "custom" only means anything paired with a customFontID; without one
+    // (e.g. hand-edited or partially-migrated persisted settings) there's no
+    // font to render, so fall back to the book's own typeface rather than
+    // rendering an unstyled "silo-custom-font" with no @font-face rule.
+    fontFamily:
+      fontFamily === "custom" && customFontID == null ? READER_FONT_STACKS.inherit : fontFamily,
     fontSize: clampNumber(raw.fontSize, DEFAULT_READER_SETTINGS.fontSize, 80, 180),
     fontWeight: clampNumber(raw.fontWeight, DEFAULT_READER_SETTINGS.fontWeight, 300, 800),
     hyphenation:
@@ -406,12 +419,7 @@ export function normalizeReaderSettings(settings?: ReaderSettingsInput): ReaderS
     columns,
     columnGap: clampNumber(raw.columnGap, DEFAULT_READER_SETTINGS.columnGap, 0, 50),
     justify: raw.justify === true,
-    customFontID:
-      typeof raw.customFontID === "number" &&
-      Number.isInteger(raw.customFontID) &&
-      raw.customFontID > 0
-        ? raw.customFontID
-        : null,
+    customFontID,
     flow: isReaderFlow(raw.flow) ? raw.flow : DEFAULT_READER_SETTINGS.flow,
     fontBrightness: clampNumber(
       raw.fontBrightness,

--- a/web/src/reader/ReaderFooter.test.tsx
+++ b/web/src/reader/ReaderFooter.test.tsx
@@ -1,0 +1,66 @@
+// @vitest-environment jsdom
+import { act } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import ReaderFooter from "./ReaderFooter";
+
+let container: HTMLDivElement;
+let root: Root;
+
+beforeEach(() => {
+  container = document.createElement("div");
+  document.body.appendChild(container);
+  root = createRoot(container);
+});
+
+afterEach(() => {
+  act(() => root.unmount());
+  container.remove();
+});
+
+function render(props: Partial<React.ComponentProps<typeof ReaderFooter>> = {}) {
+  const defaults = {
+    fraction: 0.34,
+    extent: { start: 0.28, end: 0.42, index: 6 },
+    chapterLabel: "The Duke",
+    onScrub: vi.fn(),
+    onShowShortcuts: vi.fn(),
+  };
+  const merged = { ...defaults, ...props };
+  act(() => root.render(<ReaderFooter {...merged} />));
+  return merged;
+}
+
+describe("ReaderFooter", () => {
+  it("shows chapter label, percentage, and the chapter band", () => {
+    render();
+    expect(container.textContent).toContain("The Duke");
+    expect(container.textContent).toContain("34%");
+    const band = container.querySelector("[data-chapter-band]") as HTMLElement;
+    expect(band).not.toBeNull();
+    expect(parseFloat(band.style.left)).toBeCloseTo(28);
+    expect(parseFloat(band.style.width)).toBeCloseTo(14);
+  });
+
+  it("hides band and label without an extent", () => {
+    render({ extent: null, chapterLabel: null });
+    expect(container.querySelector("[data-chapter-band]")).toBeNull();
+  });
+
+  it("scrubs the whole book from the slider", () => {
+    const { onScrub } = render();
+    const slider = container.querySelector('input[type="range"]') as HTMLInputElement;
+    slider.value = "62";
+    act(() => {
+      slider.dispatchEvent(new Event("input", { bubbles: true }));
+    });
+    expect(onScrub).toHaveBeenCalledWith(0.62);
+  });
+
+  it("opens the shortcuts overlay from the ? affordance", () => {
+    const { onShowShortcuts } = render();
+    const btn = container.querySelector('[aria-label="Keyboard shortcuts"]') as HTMLButtonElement;
+    act(() => btn.click());
+    expect(onShowShortcuts).toHaveBeenCalled();
+  });
+});

--- a/web/src/reader/ReaderFooter.test.tsx
+++ b/web/src/reader/ReaderFooter.test.tsx
@@ -43,8 +43,9 @@ describe("ReaderFooter", () => {
   });
 
   it("hides band and label without an extent", () => {
-    render({ extent: null, chapterLabel: null });
+    render({ extent: null, chapterLabel: "The Duke" });
     expect(container.querySelector("[data-chapter-band]")).toBeNull();
+    expect(container.textContent).not.toContain("The Duke");
   });
 
   it("scrubs the whole book from the slider", () => {

--- a/web/src/reader/ReaderFooter.test.tsx
+++ b/web/src/reader/ReaderFooter.test.tsx
@@ -64,4 +64,22 @@ describe("ReaderFooter", () => {
     act(() => btn.click());
     expect(onShowShortcuts).toHaveBeenCalled();
   });
+
+  it("shows the time remaining beside the percentage when provided", () => {
+    render({ timeLeftSeconds: 7800 });
+    expect(container.textContent).toContain("34%");
+    expect(container.textContent).toContain("2h 10m left");
+  });
+
+  it("omits the time remaining when null", () => {
+    render({ timeLeftSeconds: null });
+    expect(container.textContent).toContain("34%");
+    expect(container.textContent).not.toContain("left");
+  });
+
+  it("omits the time remaining when undefined", () => {
+    render();
+    expect(container.textContent).toContain("34%");
+    expect(container.textContent).not.toContain("left");
+  });
 });

--- a/web/src/reader/ReaderFooter.tsx
+++ b/web/src/reader/ReaderFooter.tsx
@@ -1,0 +1,63 @@
+import { Keyboard } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import type { ChapterExtent } from "./readerNavigation";
+
+export type ReaderFooterProps = {
+  fraction: number;
+  extent: ChapterExtent | null;
+  chapterLabel: string | null;
+  onScrub: (fraction: number) => void;
+  onShowShortcuts: () => void;
+};
+
+export default function ReaderFooter({
+  fraction,
+  extent,
+  chapterLabel,
+  onScrub,
+  onShowShortcuts,
+}: ReaderFooterProps) {
+  const percent = Math.round(Math.min(1, Math.max(0, fraction)) * 100);
+  return (
+    <footer className="border-border/70 bg-background/95 sticky bottom-0 z-20 border-t backdrop-blur">
+      <div className="flex flex-col gap-1 px-4 py-2">
+        <div className="relative h-2">
+          {extent && (
+            <div
+              data-chapter-band
+              title={chapterLabel ?? undefined}
+              className="bg-primary/25 pointer-events-none absolute top-0 h-2 rounded"
+              style={{
+                left: `${extent.start * 100}%`,
+                width: `${(extent.end - extent.start) * 100}%`,
+              }}
+            />
+          )}
+          <input
+            aria-label="Reading progress"
+            type="range"
+            min="0"
+            max="100"
+            step="1"
+            value={percent}
+            onInput={(event) => onScrub(Number((event.target as HTMLInputElement).value) / 100)}
+            className="accent-primary absolute inset-0 h-2 w-full min-w-0"
+          />
+        </div>
+        <div className="text-muted-foreground flex items-center justify-between text-xs">
+          <span className="min-w-0 truncate">{chapterLabel ?? ""}</span>
+          <span className="tabular-nums">{percent}%</span>
+          <Button
+            variant="ghost"
+            size="icon-sm"
+            aria-label="Keyboard shortcuts"
+            title="Keyboard shortcuts"
+            onClick={onShowShortcuts}
+          >
+            <Keyboard className="size-4" />
+          </Button>
+        </div>
+      </div>
+    </footer>
+  );
+}

--- a/web/src/reader/ReaderFooter.tsx
+++ b/web/src/reader/ReaderFooter.tsx
@@ -45,7 +45,7 @@ export default function ReaderFooter({
           />
         </div>
         <div className="text-muted-foreground flex items-center justify-between text-xs">
-          <span className="min-w-0 truncate">{chapterLabel ?? ""}</span>
+          <span className="min-w-0 truncate">{extent ? (chapterLabel ?? "") : ""}</span>
           <span className="tabular-nums">{percent}%</span>
           <Button
             variant="ghost"

--- a/web/src/reader/ReaderFooter.tsx
+++ b/web/src/reader/ReaderFooter.tsx
@@ -1,5 +1,6 @@
 import { Keyboard } from "lucide-react";
 import { Button } from "@/components/ui/button";
+import { formatDuration } from "@/lib/formatDuration";
 import type { ChapterExtent } from "./readerNavigation";
 
 export type ReaderFooterProps = {
@@ -8,6 +9,7 @@ export type ReaderFooterProps = {
   chapterLabel: string | null;
   onScrub: (fraction: number) => void;
   onShowShortcuts: () => void;
+  timeLeftSeconds?: number | null;
 };
 
 export default function ReaderFooter({
@@ -16,6 +18,7 @@ export default function ReaderFooter({
   chapterLabel,
   onScrub,
   onShowShortcuts,
+  timeLeftSeconds,
 }: ReaderFooterProps) {
   const percent = Math.round(Math.min(1, Math.max(0, fraction)) * 100);
   return (
@@ -46,7 +49,9 @@ export default function ReaderFooter({
         </div>
         <div className="text-muted-foreground flex items-center justify-between text-xs">
           <span className="min-w-0 truncate">{extent ? (chapterLabel ?? "") : ""}</span>
-          <span className="tabular-nums">{percent}%</span>
+          <span className="tabular-nums">
+            {percent}%{timeLeftSeconds != null && ` · ${formatDuration(timeLeftSeconds)} left`}
+          </span>
           <Button
             variant="ghost"
             size="icon-sm"

--- a/web/src/reader/ReaderShortcutsOverlay.test.tsx
+++ b/web/src/reader/ReaderShortcutsOverlay.test.tsx
@@ -1,0 +1,86 @@
+// @vitest-environment jsdom
+
+import { act } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import ReaderShortcutsOverlay from "./ReaderShortcutsOverlay";
+
+describe("ReaderShortcutsOverlay", () => {
+  let container: HTMLDivElement;
+  let root: Root;
+
+  beforeEach(() => {
+    (
+      globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean }
+    ).IS_REACT_ACT_ENVIRONMENT = true;
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    root = createRoot(container);
+  });
+
+  afterEach(() => {
+    act(() => {
+      root.unmount();
+    });
+    container.remove();
+  });
+
+  it("autofocuses the Close button", async () => {
+    await act(async () => {
+      root.render(<ReaderShortcutsOverlay onClose={vi.fn()} />);
+    });
+
+    const closeButton = container.querySelector("button");
+    expect(document.activeElement).toBe(closeButton);
+  });
+
+  it("pulls focus back into the dialog on Tab", async () => {
+    await act(async () => {
+      root.render(<ReaderShortcutsOverlay onClose={vi.fn()} />);
+    });
+
+    const closeButton = container.querySelector<HTMLButtonElement>("button")!;
+    const dialog = container.querySelector<HTMLElement>('[role="dialog"]')!;
+
+    // Simulate focus having ended up outside the dialog (e.g. via a stray
+    // browser action) — the only way to exercise the trap in jsdom, which
+    // does not implement native Tab focus movement.
+    const outsideButton = document.createElement("button");
+    document.body.appendChild(outsideButton);
+    outsideButton.focus();
+    expect(document.activeElement).toBe(outsideButton);
+
+    act(() => {
+      dialog.dispatchEvent(
+        new KeyboardEvent("keydown", { key: "Tab", bubbles: true, cancelable: true }),
+      );
+    });
+
+    expect(document.activeElement).toBe(closeButton);
+    document.body.removeChild(outsideButton);
+  });
+
+  it("keeps focus on the Close button when it is both the first and last stop", async () => {
+    await act(async () => {
+      root.render(<ReaderShortcutsOverlay onClose={vi.fn()} />);
+    });
+
+    const closeButton = container.querySelector<HTMLButtonElement>("button")!;
+    const dialog = container.querySelector<HTMLElement>('[role="dialog"]')!;
+    closeButton.focus();
+
+    act(() => {
+      dialog.dispatchEvent(
+        new KeyboardEvent("keydown", {
+          key: "Tab",
+          shiftKey: true,
+          bubbles: true,
+          cancelable: true,
+        }),
+      );
+    });
+
+    expect(document.activeElement).toBe(closeButton);
+  });
+});

--- a/web/src/reader/ReaderShortcutsOverlay.tsx
+++ b/web/src/reader/ReaderShortcutsOverlay.tsx
@@ -1,0 +1,36 @@
+import { Button } from "@/components/ui/button";
+import { READER_SHORTCUTS } from "./readerNavigation";
+
+export type ReaderShortcutsOverlayProps = {
+  onClose: () => void;
+};
+
+export default function ReaderShortcutsOverlay({ onClose }: ReaderShortcutsOverlayProps) {
+  return (
+    <div
+      role="dialog"
+      aria-modal="true"
+      aria-label="Keyboard shortcuts"
+      className="fixed inset-0 z-40 flex items-center justify-center bg-black/50"
+      onClick={onClose}
+    >
+      <div
+        className="bg-background border-border w-80 rounded-lg border p-4 shadow-lg"
+        onClick={(event) => event.stopPropagation()}
+      >
+        <h2 className="mb-3 text-sm font-semibold">Keyboard shortcuts</h2>
+        <dl className="space-y-1.5 text-sm">
+          {READER_SHORTCUTS.map((shortcut) => (
+            <div key={shortcut.key} className="flex justify-between gap-4">
+              <dt className="text-muted-foreground">{shortcut.description}</dt>
+              <dd className="font-mono">{shortcut.key}</dd>
+            </div>
+          ))}
+        </dl>
+        <Button className="mt-4 w-full" variant="outline" size="sm" onClick={onClose} autoFocus>
+          Close
+        </Button>
+      </div>
+    </div>
+  );
+}

--- a/web/src/reader/ReaderShortcutsOverlay.tsx
+++ b/web/src/reader/ReaderShortcutsOverlay.tsx
@@ -1,3 +1,4 @@
+import { useRef, type KeyboardEvent } from "react";
 import { Button } from "@/components/ui/button";
 import { READER_SHORTCUTS } from "./readerNavigation";
 
@@ -5,14 +6,43 @@ export type ReaderShortcutsOverlayProps = {
   onClose: () => void;
 };
 
+const FOCUSABLE_SELECTOR =
+  'a[href], button:not([disabled]), textarea, input, select, [tabindex]:not([tabindex="-1"])';
+
 export default function ReaderShortcutsOverlay({ onClose }: ReaderShortcutsOverlayProps) {
+  const dialogRef = useRef<HTMLDivElement>(null);
+
+  // Keeps Tab/Shift+Tab focus cycling within the dialog instead of escaping
+  // into the page behind it. Written generically over whatever is focusable
+  // inside at the time — today that's just the Close button, so Tab simply
+  // keeps focus there, but this keeps working unchanged if more controls are
+  // added later.
+  const trapTabFocus = (event: KeyboardEvent<HTMLDivElement>) => {
+    if (event.key !== "Tab") return;
+    const focusable = Array.from(
+      dialogRef.current?.querySelectorAll<HTMLElement>(FOCUSABLE_SELECTOR) ?? [],
+    );
+    const first = focusable[0];
+    const last = focusable[focusable.length - 1];
+    if (!first || !last) return;
+    const active = document.activeElement;
+    const atEdge = event.shiftKey ? active === first : active === last;
+    const outside = !focusable.includes(active as HTMLElement);
+    if (atEdge || outside) {
+      event.preventDefault();
+      (event.shiftKey ? last : first).focus();
+    }
+  };
+
   return (
     <div
+      ref={dialogRef}
       role="dialog"
       aria-modal="true"
       aria-label="Keyboard shortcuts"
       className="fixed inset-0 z-40 flex items-center justify-center bg-black/50"
       onClick={onClose}
+      onKeyDown={trapTabFocus}
     >
       <div
         className="bg-background border-border w-80 rounded-lg border p-4 shadow-lg"

--- a/web/src/reader/ebookReaderApi.ts
+++ b/web/src/reader/ebookReaderApi.ts
@@ -40,6 +40,17 @@ export function ebookReaderAnnotationPath(contentID: string, annotationID: strin
   return `${ebookReaderAnnotationsPath(contentID)}/${encodeURIComponent(annotationID)}`;
 }
 
+export function readingHeartbeatPath(contentID: string): string {
+  return `/ebooks/${encodeURIComponent(contentID)}/reading-heartbeat`;
+}
+
+export async function sendReadingHeartbeat(contentID: string, fraction: number): Promise<void> {
+  await api<void>(readingHeartbeatPath(contentID), {
+    method: "POST",
+    body: JSON.stringify({ fraction }),
+  });
+}
+
 export async function fetchEbookReaderConfig(contentID: string): Promise<Record<string, unknown>> {
   const envelope = await api<EbookReaderConfigEnvelope>(ebookReaderConfigPath(contentID));
   return envelope.config && typeof envelope.config === "object" && !Array.isArray(envelope.config)

--- a/web/src/reader/readerFontsApi.test.ts
+++ b/web/src/reader/readerFontsApi.test.ts
@@ -1,0 +1,100 @@
+// @vitest-environment jsdom
+
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import {
+  deleteReaderFont,
+  fetchReaderFonts,
+  readerFontFileUrl,
+  uploadReaderFont,
+} from "./readerFontsApi";
+
+function jsonResponse(body: unknown, status = 200) {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { "Content-Type": "application/json" },
+  });
+}
+
+describe("readerFontsApi", () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("fetches and unwraps the reader font list", async () => {
+    const fonts = [
+      { id: 3, name: "Literata", filename: "literata.woff2", created_at: "2026-07-19T00:00:00Z" },
+    ];
+    const fetchMock = vi.fn<typeof fetch>(async (input, init) => {
+      expect(String(input)).toBe("/api/v1/ebooks/reader-fonts");
+      expect(init?.method ?? "GET").toBe("GET");
+      return jsonResponse({ fonts });
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    await expect(fetchReaderFonts()).resolves.toEqual(fonts);
+  });
+
+  it("tolerates a missing fonts array in the envelope", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn<typeof fetch>(async () => jsonResponse({})),
+    );
+
+    await expect(fetchReaderFonts()).resolves.toEqual([]);
+  });
+
+  it("uploads a font as multipart form data under the 'font' field", async () => {
+    const created = {
+      id: 5,
+      name: "custom.ttf",
+      filename: "custom.ttf",
+      created_at: "2026-07-20T00:00:00Z",
+    };
+    const fetchMock = vi.fn<typeof fetch>(async (input, init) => {
+      expect(String(input)).toBe("/api/v1/ebooks/reader-fonts");
+      expect(init?.method).toBe("POST");
+      expect(init?.body).toBeInstanceOf(FormData);
+      const body = init?.body as FormData;
+      const uploaded = body.get("font");
+      expect(uploaded).toBeInstanceOf(File);
+      expect((uploaded as File).name).toBe("custom.ttf");
+      return jsonResponse(created, 201);
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    const file = new File(["binary"], "custom.ttf", { type: "font/ttf" });
+    await expect(uploadReaderFont(file)).resolves.toEqual(created);
+  });
+
+  it("surfaces the server error message and code on a failed upload", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn<typeof fetch>(async () =>
+        jsonResponse({ error: "too_large", message: "Font file exceeds the maximum size" }, 413),
+      ),
+    );
+
+    const file = new File(["binary"], "huge.ttf", { type: "font/ttf" });
+    await expect(uploadReaderFont(file)).rejects.toMatchObject({
+      status: 413,
+      code: "too_large",
+      message: "Font file exceeds the maximum size",
+    });
+  });
+
+  it("deletes a font by id", async () => {
+    const fetchMock = vi.fn<typeof fetch>(async (input, init) => {
+      expect(String(input)).toBe("/api/v1/ebooks/reader-fonts/3");
+      expect(init?.method).toBe("DELETE");
+      return new Response(null, { status: 204 });
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    await expect(deleteReaderFont(3)).resolves.toBeUndefined();
+  });
+
+  it("builds the reader font file url", () => {
+    expect(readerFontFileUrl(3)).toBe("/api/v1/ebooks/reader-fonts/3/file");
+  });
+});

--- a/web/src/reader/readerFontsApi.ts
+++ b/web/src/reader/readerFontsApi.ts
@@ -1,4 +1,4 @@
-import { api } from "@/api/client";
+import { api, apiBlob } from "@/api/client";
 
 export type ReaderFontMeta = {
   id: number;
@@ -33,4 +33,24 @@ export async function deleteReaderFont(id: number): Promise<void> {
 
 export function readerFontFileUrl(id: number): string {
   return `/api/v1${readerFontPath(id)}/file`;
+}
+
+/**
+ * Fetches an uploaded reader font's bytes through the authenticated API
+ * client (bearer token + X-Profile-Id header) and hands back a `blob:` URL
+ * for it. The reader's CSS cannot point `@font-face { src: url(...) }`
+ * directly at the `readerFontFileUrl` path: that's a browser-native fetch
+ * triggered by the rendering engine, which never carries our in-memory
+ * bearer token or profile header, so the request 401s silently and the font
+ * never renders. A `blob:` URL created here (in the parent document) sidesteps
+ * that: it can be dereferenced from the same-origin `srcdoc` iframes foliate
+ * renders book content into, so it works as an `@font-face` src without a
+ * second authenticated request from inside the iframe.
+ *
+ * Callers own the returned URL and must `URL.revokeObjectURL` it once no
+ * longer needed to avoid leaking the underlying blob.
+ */
+export async function fetchReaderFontObjectUrl(id: number): Promise<string> {
+  const blob = await apiBlob(`${readerFontPath(id)}/file`);
+  return URL.createObjectURL(blob);
 }

--- a/web/src/reader/readerFontsApi.ts
+++ b/web/src/reader/readerFontsApi.ts
@@ -1,0 +1,36 @@
+import { api } from "@/api/client";
+
+export type ReaderFontMeta = {
+  id: number;
+  name: string;
+  filename: string;
+  created_at: string;
+};
+
+const READER_FONTS_PATH = "/ebooks/reader-fonts";
+
+function readerFontPath(id: number): string {
+  return `${READER_FONTS_PATH}/${id}`;
+}
+
+export async function fetchReaderFonts(): Promise<ReaderFontMeta[]> {
+  const envelope = await api<{ fonts?: ReaderFontMeta[] }>(READER_FONTS_PATH);
+  return Array.isArray(envelope.fonts) ? envelope.fonts : [];
+}
+
+export async function uploadReaderFont(file: File): Promise<ReaderFontMeta> {
+  const formData = new FormData();
+  formData.append("font", file);
+  return api<ReaderFontMeta>(READER_FONTS_PATH, {
+    method: "POST",
+    body: formData,
+  });
+}
+
+export async function deleteReaderFont(id: number): Promise<void> {
+  await api<void>(readerFontPath(id), { method: "DELETE" });
+}
+
+export function readerFontFileUrl(id: number): string {
+  return `/api/v1${readerFontPath(id)}/file`;
+}

--- a/web/src/reader/readerNavigation.test.ts
+++ b/web/src/reader/readerNavigation.test.ts
@@ -54,4 +54,8 @@ describe("READER_SHORTCUTS", () => {
       expect(keys).toContain(key);
     }
   });
+
+  it("describes the b shortcut as a toggle, since it now un-bookmarks a matching location", () => {
+    expect(READER_SHORTCUTS.find((s) => s.key === "b")?.description).toBe("Toggle bookmark");
+  });
 });

--- a/web/src/reader/readerNavigation.test.ts
+++ b/web/src/reader/readerNavigation.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, it } from "vitest";
+import { chapterExtent, tapZoneAction, READER_SHORTCUTS } from "./readerNavigation";
+
+describe("chapterExtent", () => {
+  // foliate's getSectionFractions() returns cumulative fraction boundaries
+  // starting at 0, e.g. [0, 0.25, 0.6, 1] for a 3-section book.
+  it("maps a whole-book fraction to its section's extent", () => {
+    expect(chapterExtent([0, 0.25, 0.6, 1], 0.3)).toEqual({ start: 0.25, end: 0.6, index: 1 });
+  });
+
+  it("clamps to the last section at fraction 1", () => {
+    expect(chapterExtent([0, 0.25, 0.6, 1], 1)).toEqual({ start: 0.6, end: 1, index: 2 });
+  });
+
+  it("returns null without enough boundaries", () => {
+    expect(chapterExtent([], 0.5)).toBeNull();
+    expect(chapterExtent([0], 0.5)).toBeNull();
+  });
+
+  it("treats a trailing boundary below 1 as extending to the book end", () => {
+    expect(chapterExtent([0, 0.5], 0.75)).toEqual({ start: 0.5, end: 1, index: 1 });
+  });
+});
+
+describe("tapZoneAction", () => {
+  it("pages back on the left third and forward on the right third", () => {
+    expect(tapZoneAction({ xRatio: 0.1, flow: "paginated", hasSelection: false })).toBe("prev");
+    expect(tapZoneAction({ xRatio: 0.9, flow: "paginated", hasSelection: false })).toBe("next");
+  });
+
+  it("toggles chrome on the middle third", () => {
+    expect(tapZoneAction({ xRatio: 0.5, flow: "paginated", hasSelection: false })).toBe(
+      "toggle-chrome",
+    );
+  });
+
+  it("never pages while a selection is active", () => {
+    expect(tapZoneAction({ xRatio: 0.1, flow: "paginated", hasSelection: true })).toBeNull();
+    expect(tapZoneAction({ xRatio: 0.5, flow: "paginated", hasSelection: true })).toBeNull();
+  });
+
+  it("disables edge zones in scrolled flow but keeps the chrome toggle", () => {
+    expect(tapZoneAction({ xRatio: 0.1, flow: "scrolled", hasSelection: false })).toBeNull();
+    expect(tapZoneAction({ xRatio: 0.5, flow: "scrolled", hasSelection: false })).toBe(
+      "toggle-chrome",
+    );
+  });
+});
+
+describe("READER_SHORTCUTS", () => {
+  it("documents every shortcut the reader binds", () => {
+    const keys = READER_SHORTCUTS.map((s) => s.key);
+    for (const key of ["←/→", "Home/End", "t", "s", "b", "f", "?", "Esc"]) {
+      expect(keys).toContain(key);
+    }
+  });
+});

--- a/web/src/reader/readerNavigation.ts
+++ b/web/src/reader/readerNavigation.ts
@@ -11,12 +11,11 @@ export function chapterExtent(sectionFractions: number[], fraction: number): Cha
   if (sectionFractions.length < 2) return null;
   const clamped = Math.min(1, Math.max(0, fraction));
   for (let i = sectionFractions.length - 1; i >= 0; i--) {
-    if (clamped >= sectionFractions[i]) {
-      const start = sectionFractions[i];
-      const end = i + 1 < sectionFractions.length ? sectionFractions[i + 1] : 1;
-      if (start >= end) continue; // zero-width section: attribute to the previous one
-      return { start, end, index: i };
-    }
+    const start = sectionFractions[i];
+    if (start === undefined || clamped < start) continue;
+    const end = i + 1 < sectionFractions.length ? (sectionFractions[i + 1] ?? 1) : 1;
+    if (start >= end) continue; // zero-width section: attribute to the previous one
+    return { start, end, index: i };
   }
   return { start: 0, end: sectionFractions[1] ?? 1, index: 0 };
 }

--- a/web/src/reader/readerNavigation.ts
+++ b/web/src/reader/readerNavigation.ts
@@ -40,7 +40,7 @@ export const READER_SHORTCUTS = [
   { key: "Home/End", description: "Start / end of chapter" },
   { key: "t", description: "Contents panel" },
   { key: "s", description: "Search panel" },
-  { key: "b", description: "Toggle bookmark" },
+  { key: "b", description: "Add bookmark" },
   { key: "f", description: "Fullscreen" },
   { key: "?", description: "This shortcut list" },
   { key: "Esc", description: "Close overlay, or hide/show controls" },

--- a/web/src/reader/readerNavigation.ts
+++ b/web/src/reader/readerNavigation.ts
@@ -40,7 +40,7 @@ export const READER_SHORTCUTS = [
   { key: "Home/End", description: "Start / end of chapter" },
   { key: "t", description: "Contents panel" },
   { key: "s", description: "Search panel" },
-  { key: "b", description: "Add bookmark" },
+  { key: "b", description: "Toggle bookmark" },
   { key: "f", description: "Fullscreen" },
   { key: "?", description: "This shortcut list" },
   { key: "Esc", description: "Close overlay, or hide/show controls" },

--- a/web/src/reader/readerNavigation.ts
+++ b/web/src/reader/readerNavigation.ts
@@ -1,0 +1,48 @@
+// Navigation decision helpers for the prose reader. Pure functions so the
+// footer band, tap zones, and shortcuts overlay stay unit-testable apart
+// from foliate and the DOM.
+
+export type ChapterExtent = { start: number; end: number; index: number };
+
+// sectionFractions are foliate's cumulative boundaries (view.getSectionFractions()),
+// e.g. [0, 0.25, 0.6, 1]. A trailing boundary below 1 means the list omits the
+// book-end marker; the final section then runs to 1.
+export function chapterExtent(sectionFractions: number[], fraction: number): ChapterExtent | null {
+  if (sectionFractions.length < 2) return null;
+  const clamped = Math.min(1, Math.max(0, fraction));
+  for (let i = sectionFractions.length - 1; i >= 0; i--) {
+    if (clamped >= sectionFractions[i]) {
+      const start = sectionFractions[i];
+      const end = i + 1 < sectionFractions.length ? sectionFractions[i + 1] : 1;
+      if (start >= end) continue; // zero-width section: attribute to the previous one
+      return { start, end, index: i };
+    }
+  }
+  return { start: 0, end: sectionFractions[1] ?? 1, index: 0 };
+}
+
+export type TapZoneInput = {
+  xRatio: number; // pointer X within the reading surface, 0..1
+  flow: "paginated" | "scrolled";
+  hasSelection: boolean;
+};
+
+export type TapZoneResult = "prev" | "next" | "toggle-chrome" | null;
+
+export function tapZoneAction({ xRatio, flow, hasSelection }: TapZoneInput): TapZoneResult {
+  if (hasSelection) return null;
+  if (xRatio < 1 / 3) return flow === "paginated" ? "prev" : null;
+  if (xRatio > 2 / 3) return flow === "paginated" ? "next" : null;
+  return "toggle-chrome";
+}
+
+export const READER_SHORTCUTS = [
+  { key: "←/→", description: "Previous / next page" },
+  { key: "Home/End", description: "Start / end of chapter" },
+  { key: "t", description: "Contents panel" },
+  { key: "s", description: "Search panel" },
+  { key: "b", description: "Toggle bookmark" },
+  { key: "f", description: "Fullscreen" },
+  { key: "?", description: "This shortcut list" },
+  { key: "Esc", description: "Close overlay, or hide/show controls" },
+] as const;

--- a/web/src/reader/readerThemes.test.ts
+++ b/web/src/reader/readerThemes.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, it } from "vitest";
+import { READER_THEMES, legacyThemeFor, readerPalette, themeFromLegacy } from "./readerThemes";
+
+const HEX = /^#[0-9a-f]{6}$/;
+
+describe("READER_THEMES", () => {
+  it("defines ten themes with valid hex palettes in both variants", () => {
+    const names = Object.keys(READER_THEMES);
+    expect(names).toHaveLength(10);
+    for (const theme of Object.values(READER_THEMES)) {
+      for (const variant of ["light", "dark"] as const) {
+        const palette = theme[variant];
+        expect(palette.background).toMatch(HEX);
+        expect(palette.foreground).toMatch(HEX);
+        expect(palette.link).toMatch(HEX);
+      }
+    }
+  });
+
+  it("aliases AMOLED's light variant to its dark palette", () => {
+    expect(READER_THEMES.amoled.darkOnly).toBe(true);
+    expect(readerPalette("amoled", "light")).toEqual(readerPalette("amoled", "dark"));
+    expect(readerPalette("amoled", "light").scheme).toBe("dark");
+  });
+
+  it("keeps the existing default and sepia palettes stable", () => {
+    expect(readerPalette("default", "light").background).toBe("#ffffff");
+    expect(readerPalette("sepia", "light")).toMatchObject({
+      background: "#f4ecd8",
+      foreground: "#2f261b",
+    });
+  });
+});
+
+describe("legacy mapping", () => {
+  it("maps stored legacy themes onto palette pairs", () => {
+    expect(themeFromLegacy("light")).toEqual({
+      themeName: "default",
+      themeVariant: "light",
+    });
+    expect(themeFromLegacy("sepia")).toEqual({
+      themeName: "sepia",
+      themeVariant: "light",
+    });
+    expect(themeFromLegacy("dark")).toEqual({
+      themeName: "default",
+      themeVariant: "dark",
+    });
+    expect(themeFromLegacy("nonsense")).toEqual({
+      themeName: "default",
+      themeVariant: "light",
+    });
+  });
+
+  it("derives the legacy field for backward-compatible persistence", () => {
+    expect(legacyThemeFor("sepia", "light")).toBe("sepia");
+    expect(legacyThemeFor("ocean", "dark")).toBe("dark");
+    expect(legacyThemeFor("amoled", "light")).toBe("dark");
+    expect(legacyThemeFor("meadow", "light")).toBe("light");
+  });
+});

--- a/web/src/reader/readerThemes.ts
+++ b/web/src/reader/readerThemes.ts
@@ -1,0 +1,122 @@
+// Reader content palettes. Each theme is a light/dark pair; AMOLED is
+// dark-only (its light slot aliases the dark palette so the variant toggle
+// can be disabled without a special data shape).
+
+export type ReaderThemeVariant = "light" | "dark";
+
+export type ReaderThemeName =
+  | "default"
+  | "sepia"
+  | "gray"
+  | "dawnlight"
+  | "ember"
+  | "aurora"
+  | "ocean"
+  | "meadow"
+  | "rosewood"
+  | "amoled";
+
+export type ReaderPalette = {
+  background: string;
+  foreground: string;
+  link: string;
+};
+
+type ReaderThemeDefinition = {
+  label: string;
+  darkOnly?: true;
+  light: ReaderPalette;
+  dark: ReaderPalette;
+};
+
+const AMOLED_PALETTE: ReaderPalette = {
+  background: "#000000",
+  foreground: "#c9c9c9",
+  link: "#7aa2f7",
+};
+
+export const READER_THEMES: Record<ReaderThemeName, ReaderThemeDefinition> = {
+  default: {
+    label: "Default",
+    light: { background: "#ffffff", foreground: "#171717", link: "#2563eb" },
+    dark: { background: "#111827", foreground: "#f8fafc", link: "#93c5fd" },
+  },
+  sepia: {
+    label: "Sepia",
+    light: { background: "#f4ecd8", foreground: "#2f261b", link: "#8b5a2b" },
+    dark: { background: "#211b12", foreground: "#c8b697", link: "#c99a5b" },
+  },
+  gray: {
+    label: "Gray",
+    light: { background: "#eceef0", foreground: "#33383d", link: "#4a6fa5" },
+    dark: { background: "#23262a", foreground: "#b9bfc6", link: "#8ab0dd" },
+  },
+  dawnlight: {
+    label: "Dawnlight",
+    light: { background: "#fdf6e3", foreground: "#586e75", link: "#268bd2" },
+    dark: { background: "#002b36", foreground: "#93a1a1", link: "#268bd2" },
+  },
+  ember: {
+    label: "Ember",
+    light: { background: "#fbf1c7", foreground: "#3c3836", link: "#af3a03" },
+    dark: { background: "#282828", foreground: "#ebdbb2", link: "#fe8019" },
+  },
+  aurora: {
+    label: "Aurora",
+    light: { background: "#eceff4", foreground: "#2e3440", link: "#5e81ac" },
+    dark: { background: "#2e3440", foreground: "#d8dee9", link: "#88c0d0" },
+  },
+  ocean: {
+    label: "Ocean",
+    light: { background: "#e8f0f7", foreground: "#1e3a52", link: "#2471a3" },
+    dark: { background: "#0d1b2a", foreground: "#a9c1d9", link: "#64a8dd" },
+  },
+  meadow: {
+    label: "Meadow",
+    light: { background: "#eef3e7", foreground: "#2f3b2a", link: "#3f7d44" },
+    dark: { background: "#1a2318", foreground: "#b8c9a8", link: "#7fb069" },
+  },
+  rosewood: {
+    label: "Rosewood",
+    light: { background: "#f7edee", foreground: "#4a2f33", link: "#a4494f" },
+    dark: { background: "#241a1c", foreground: "#d3b8bc", link: "#d98a90" },
+  },
+  amoled: {
+    label: "AMOLED",
+    darkOnly: true,
+    light: AMOLED_PALETTE,
+    dark: AMOLED_PALETTE,
+  },
+};
+
+export function readerPalette(
+  name: ReaderThemeName,
+  variant: ReaderThemeVariant,
+): ReaderPalette & { scheme: ReaderThemeVariant } {
+  const theme = READER_THEMES[name] ?? READER_THEMES.default;
+  const effective: ReaderThemeVariant = theme.darkOnly ? "dark" : variant;
+  return { ...theme[effective], scheme: effective };
+}
+
+export function legacyThemeFor(
+  name: ReaderThemeName,
+  variant: ReaderThemeVariant,
+): "light" | "sepia" | "dark" {
+  if (readerPalette(name, variant).scheme === "dark") return "dark";
+  if (name === "sepia") return "sepia";
+  return "light";
+}
+
+export function themeFromLegacy(theme: string): {
+  themeName: ReaderThemeName;
+  themeVariant: ReaderThemeVariant;
+} {
+  switch (theme) {
+    case "sepia":
+      return { themeName: "sepia", themeVariant: "light" };
+    case "dark":
+      return { themeName: "default", themeVariant: "dark" };
+    default:
+      return { themeName: "default", themeVariant: "light" };
+  }
+}


### PR DESCRIPTION
## Summary

Three stacked reader improvements, modeled on the strongest ideas from comparable ebook apps (BookOrbit et al.) and adapted to silo's architecture. Each was spec'd, planned, TDD-implemented, and adversarially reviewed; all three are running on a production install.

### 1. Page navigation
- Chapter-aware footer: progress slider with the current chapter's extent as a band, chapter title, percentage — replacing the bare header slider.
- Tap zones (left/right page turn, middle toggles chrome) with events **bridged across foliate's content iframe** (pointer events don't bubble out of it; the bridge follows the existing selection-listener pattern), auto-hiding chrome, selection-safe.
- Full keyboard map (`←/→`, `Home/End` chapter jumps, `t/s/b/f`, `?` shortcuts overlay, `Esc` overlay→panel→chrome precedence) with an editable-target guard.

### 2. Appearance
- Ten paired-palette themes (Default, Sepia, Gray, Dawnlight, Ember, Aurora, Ocean, Meadow, Rosewood, AMOLED) with a reader dark-mode toggle independent of the app theme; legacy `theme` values migrate and keep being written for one release.
- **Per-profile custom font uploads**: `reader_fonts` table + four additive `/api/v1/ebooks/reader-fonts` endpoints (magic-byte validation, 5 MB / 10-per-profile caps, `SILO_READER_FONTS_DIR`), fonts delivered into the reader via authenticated blob fetch → object URL (CSS `@font-face` can't carry auth headers; no API URLs ever enter content CSS). Profile path components are strictly validated before any filesystem use.
- Columns 1–4 + gap control (subsumes `spread`), justification toggle, settings panel regrouped Theme/Typography/Layout.

### 3. Reading stats (foundation)
- Heartbeat sessions: 30s activity-gated beats (visible + interaction within 60s), server coalescing (120s gap, 90s per-beat credit cap), server clock only, comics inert.
- Pace + time-remaining endpoints; the footer's reserved slot now shows "· 2h 10m left" once ~10 minutes of pace data exists (14-day window, per-book with profile-wide fallback).
- `/reading-stats` page: 12-month heatmap (client-densified daily rollups), today/week/month/all-time totals, top books, session timeline. All rollups computed by query; UTC day boundaries.

Migrations: `20260720190000_reader_fonts.sql`, `20260720210000_reading_sessions.sql`.
Specs and plans included under `docs/superpowers/{specs,plans}/2026-07-20-*`.

## Review-hardened items worth reviewer attention
- Path traversal via `X-Profile-Id` reaching `filepath.Join` — caught in review, fixed with strict component validation + regression tests on all four font handlers.
- `@font-face` auth-unreachability — caught in whole-branch review, fixed via blob URLs.
- Sparse-day heatmap misalignment, absent-fraction heartbeat acceptance, removed-book link suppression, ruler-drag page turns — all caught and fixed with pinned tests.

## API surface
Additive only: new endpoints under `/api/v1/ebooks` (reader-fonts CRUD/file, reading-heartbeat, reading-stats × 2); task/result contracts untouched.

## Tests
- Web: full vitest suite green (only the 7 pre-existing upstream failures — QueryClientProvider/ResizeObserver in unrelated suites — remain); `pnpm build`, lint, format clean.
- Go: `go test ./internal/api/handlers`, `go vet`, `gofmt`, `make migrate-validate`, `make verify-local-paths` clean.
- Live-verified on a production install (navigation/appearance/stats all exercised).

## AI-use disclosure

Implemented and reviewed with Claude Code (spec → plan → TDD subagents with per-task and whole-branch adversarial review).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added enhanced reader appearance: palette-based light/dark themes, multi-column layout controls (including column gap), text justification, and per-profile custom font upload/management.
  * Introduced chapter-aware reader footer with progress scrubber, chapter band, keyboard shortcuts, and a shortcuts overlay.
  * Added reading stats dashboard, including reading activity heatmap, pace/time-left estimates, and reading motivation with editable goals.
* **Documentation**
  * Published updated reader appearance, navigation, reading stats, and motivation design/specification plans.
* **Tests**
  * Added/expanded unit and integration test coverage for the above reader, navigation, stats, heatmap, and fonts behaviors.
* **Chores**
  * Made reader-fonts storage location configurable at startup via environment setting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->