### PR TITLE
fix(api): return has_more on favorites/watchlist/history so clients paginate

### DIFF
--- a/internal/api/handlers/favorites.go
+++ b/internal/api/handlers/favorites.go
@@ -155,7 +155,7 @@ func (h *PersonalDataHandler) HandleListFavorites(w http.ResponseWriter, r *http
 		return
 	}
 
-	writeJSON(w, http.StatusOK, itemsListResponse{Items: items})
+	writeJSON(w, http.StatusOK, itemsListResponse{Items: items, HasMore: len(favorites) == limit})
 }
 
 // HandleCheckFavorite handles GET /favorites/{item_id}.
@@ -304,6 +304,9 @@ func (h *PersonalDataHandler) HandleListWatchlist(w http.ResponseWriter, r *http
 		writeError(w, http.StatusInternalServerError, "internal_error", "Failed to list watchlist")
 		return
 	}
+	// Capture has_more from the raw store page, before hidden-series filtering
+	// shrinks it — a full page that filters down still has more to fetch.
+	watchlistHasMore := len(entries) == limit
 	entries, err = h.filterHiddenWatchlistSeries(r.Context(), store, profileID, entries)
 	if err != nil {
 		writeError(w, http.StatusInternalServerError, "internal_error", "Failed to filter watchlist")
@@ -316,7 +319,7 @@ func (h *PersonalDataHandler) HandleListWatchlist(w http.ResponseWriter, r *http
 		return
 	}
 
-	writeJSON(w, http.StatusOK, itemsListResponse{Items: items})
+	writeJSON(w, http.StatusOK, itemsListResponse{Items: items, HasMore: watchlistHasMore})
 }
 
 // filterHiddenWatchlistSeries drops fully-watched series from a watchlist page.
@@ -479,7 +482,7 @@ func (h *PersonalDataHandler) HandleListHistory(w http.ResponseWriter, r *http.R
 		return
 	}
 
-	writeJSON(w, http.StatusOK, itemsListResponse{Items: items})
+	writeJSON(w, http.StatusOK, itemsListResponse{Items: items, HasMore: len(entries) == limit})
 }
 
 // HandleRemoveHistory handles POST /history/remove.
@@ -552,6 +555,10 @@ func (h *PersonalDataHandler) HandleRemoveHistory(w http.ResponseWriter, r *http
 // itemsListResponse wraps a list of items for favorites/watchlist responses.
 type itemsListResponse struct {
 	Items []itemListResponse `json:"items"`
+	// HasMore lets clients paginate these personal lists. Computed from the
+	// raw store page size (== limit), not the resolved item count, so
+	// catalog-missing / hidden entries don't make a full page look final.
+	HasMore bool `json:"has_more"`
 }
 
 // resolveItems fetches full media item data for a list of entries.


### PR DESCRIPTION
## Problem

The favorites, watchlist, and history list endpoints (`GET /favorites`, `/watchlist`, `/history`) return only `{"items": [...]}` with **no `has_more` field**. Clients gate infinite-scroll pagination on `has_more` (absent → `false`), so they stop after the first page.

Reported as Silo-Server/silo-android#56: users see only the first ~page of favorites, and adding a favorite pushes the oldest off the visible window. Affects both the phone and TV clients (shared pagination logic). The `/catalog` (browse) endpoint already returns `has_more` and paginates correctly — these three personal-list endpoints were the odd ones out.

## Fix

Add `has_more` to `itemsListResponse`, computed from the **raw store page size** (`== limit`), not the resolved item count:
- `resolveItems` silently drops catalog-missing entries, and watchlist filters hidden series *after* the store call — so basing `has_more` on the returned/resolved length would make a full page look final and re-break pagination. Favorites/history use the raw store slice length; watchlist captures the count before hidden-series filtering.

Additive JSON field — backward compatible with existing clients.

## Verification
- `go build` / `go vet ./internal/api/handlers/` clean
- `go test ./internal/api/handlers/` green

Client side already implements the pagination correctly (shared `FavoritesViewModel` pageSize=40, `loadMore`/`hasMore`, scroll-triggered) — it was only ever missing the `has_more` signal from the server.

🤖 Generated with [Claude Code](https://claude.com/claude-code)