### PR TITLE
fix(playback): preserve and expose video color range

### DIFF
--- a/internal/catalogseed/service.go
+++ b/internal/catalogseed/service.go
@@ -2580,6 +2580,7 @@ func toVideoTrackRecords(tracks []models.VideoTrack) []VideoTrackRecord {
 			Bitrate:         track.Bitrate,
 			VideoRange:      track.VideoRange,
 			VideoRangeType:  track.VideoRangeType,
+			ColorRange:      track.ColorRange,
 			ColorPrimaries:  track.ColorPrimaries,
 			ColorSpace:      track.ColorSpace,
 			ColorTransfer:   track.ColorTransfer,

--- a/internal/catalogseed/service_test.go
+++ b/internal/catalogseed/service_test.go
@@ -11,13 +11,19 @@ func TestToVideoTrackRecordsPreservesColorRange(t *testing.T) {
 	got := toVideoTrackRecords([]models.VideoTrack{
 		{ColorRange: "tv"},
 		{ColorRange: "pc"},
+		{ColorRange: "unknown"},
 	})
 
-	if len(got) != 2 {
-		t.Fatalf("records length = %d, want 2", len(got))
+	if len(got) != 3 {
+		t.Fatalf("records length = %d, want 3", len(got))
 	}
-	if got[0].ColorRange != "tv" || got[1].ColorRange != "pc" {
-		t.Fatalf("ColorRange values = [%q, %q], want [tv, pc]", got[0].ColorRange, got[1].ColorRange)
+	if got[0].ColorRange != "tv" || got[1].ColorRange != "pc" || got[2].ColorRange != "unknown" {
+		t.Fatalf(
+			"ColorRange values = [%q, %q, %q], want [tv, pc, unknown]",
+			got[0].ColorRange,
+			got[1].ColorRange,
+			got[2].ColorRange,
+		)
 	}
 }
 

--- a/internal/catalogseed/service_test.go
+++ b/internal/catalogseed/service_test.go
@@ -3,7 +3,23 @@ package catalogseed
 import (
 	"reflect"
 	"testing"
+
+	"github.com/Silo-Server/silo-server/internal/models"
 )
+
+func TestToVideoTrackRecordsPreservesColorRange(t *testing.T) {
+	got := toVideoTrackRecords([]models.VideoTrack{
+		{ColorRange: "tv"},
+		{ColorRange: "pc"},
+	})
+
+	if len(got) != 2 {
+		t.Fatalf("records length = %d, want 2", len(got))
+	}
+	if got[0].ColorRange != "tv" || got[1].ColorRange != "pc" {
+		t.Fatalf("ColorRange values = [%q, %q], want [tv, pc]", got[0].ColorRange, got[1].ColorRange)
+	}
+}
 
 func TestCatalogSeedSearchUpsertIDsIncludesChangedItemsAndEmbeddings(t *testing.T) {
 	itemStates := map[string]bool{

--- a/internal/catalogseed/types.go
+++ b/internal/catalogseed/types.go
@@ -156,6 +156,7 @@ type VideoTrackRecord struct {
 	Bitrate         int    `json:"bitrate,omitempty"`
 	VideoRange      string `json:"video_range,omitempty"`
 	VideoRangeType  string `json:"video_range_type,omitempty"`
+	ColorRange      string `json:"color_range,omitempty"`
 	ColorPrimaries  string `json:"color_primaries,omitempty"`
 	ColorSpace      string `json:"color_space,omitempty"`
 	ColorTransfer   string `json:"color_transfer,omitempty"`

--- a/internal/jellycompat/deviceprofile_conditions_test.go
+++ b/internal/jellycompat/deviceprofile_conditions_test.go
@@ -1,6 +1,7 @@
 package jellycompat
 
 import (
+	"encoding/json"
 	"strings"
 	"testing"
 
@@ -270,6 +271,39 @@ func TestBuildMediaStreamsUsesJellyfinVideoRangeType(t *testing.T) {
 	}
 	if streams[0].VideoRangeType != "DOVIWithEL" {
 		t.Fatalf("VideoRangeType = %q, want DOVIWithEL", streams[0].VideoRangeType)
+	}
+}
+
+func TestBuildMediaStreamsPreservesColorRange(t *testing.T) {
+	for _, colorRange := range []string{"tv", "pc"} {
+		t.Run(colorRange, func(t *testing.T) {
+			version := catalog.FileVersion{
+				VideoTracks: []models.VideoTrack{{
+					Codec:      "h264",
+					ColorRange: colorRange,
+				}},
+			}
+
+			streams := buildMediaStreams("item", "source", version)
+			if len(streams) != 1 {
+				t.Fatalf("streams length = %d, want 1", len(streams))
+			}
+			if got := streams[0].ColorRange; got != colorRange {
+				t.Fatalf("ColorRange = %q, want %q", got, colorRange)
+			}
+
+			payload, err := json.Marshal(streams[0])
+			if err != nil {
+				t.Fatalf("marshal media stream: %v", err)
+			}
+			var decoded map[string]any
+			if err := json.Unmarshal(payload, &decoded); err != nil {
+				t.Fatalf("unmarshal media stream: %v", err)
+			}
+			if got := decoded["ColorRange"]; got != colorRange {
+				t.Fatalf("JSON ColorRange = %#v, want %q", got, colorRange)
+			}
+		})
 	}
 }
 

--- a/internal/jellycompat/deviceprofile_conditions_test.go
+++ b/internal/jellycompat/deviceprofile_conditions_test.go
@@ -275,12 +275,24 @@ func TestBuildMediaStreamsUsesJellyfinVideoRangeType(t *testing.T) {
 }
 
 func TestBuildMediaStreamsPreservesColorRange(t *testing.T) {
-	for _, colorRange := range []string{"tv", "pc"} {
-		t.Run(colorRange, func(t *testing.T) {
+	tests := []struct {
+		name           string
+		colorRange     string
+		wantColorRange string
+		wantJSONField  bool
+	}{
+		{name: "limited", colorRange: "tv", wantColorRange: "tv", wantJSONField: true},
+		{name: "full", colorRange: "pc", wantColorRange: "pc", wantJSONField: true},
+		{name: "internal unknown sentinel", colorRange: "unknown"},
+		{name: "missing"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
 			version := catalog.FileVersion{
 				VideoTracks: []models.VideoTrack{{
 					Codec:      "h264",
-					ColorRange: colorRange,
+					ColorRange: tt.colorRange,
 				}},
 			}
 
@@ -288,8 +300,8 @@ func TestBuildMediaStreamsPreservesColorRange(t *testing.T) {
 			if len(streams) != 1 {
 				t.Fatalf("streams length = %d, want 1", len(streams))
 			}
-			if got := streams[0].ColorRange; got != colorRange {
-				t.Fatalf("ColorRange = %q, want %q", got, colorRange)
+			if got := streams[0].ColorRange; got != tt.wantColorRange {
+				t.Fatalf("ColorRange = %q, want %q", got, tt.wantColorRange)
 			}
 
 			payload, err := json.Marshal(streams[0])
@@ -300,8 +312,12 @@ func TestBuildMediaStreamsPreservesColorRange(t *testing.T) {
 			if err := json.Unmarshal(payload, &decoded); err != nil {
 				t.Fatalf("unmarshal media stream: %v", err)
 			}
-			if got := decoded["ColorRange"]; got != colorRange {
-				t.Fatalf("JSON ColorRange = %#v, want %q", got, colorRange)
+			got, present := decoded["ColorRange"]
+			if present != tt.wantJSONField {
+				t.Fatalf("JSON ColorRange present = %v, want %v (value %#v)", present, tt.wantJSONField, got)
+			}
+			if tt.wantJSONField && got != tt.wantColorRange {
+				t.Fatalf("JSON ColorRange = %#v, want %q", got, tt.wantColorRange)
 			}
 		})
 	}

--- a/internal/jellycompat/dto.go
+++ b/internal/jellycompat/dto.go
@@ -264,6 +264,7 @@ type mediaStreamDTO struct {
 	AspectRatio            string  `json:"AspectRatio,omitempty"`
 	VideoRange             string  `json:"VideoRange,omitempty"`
 	VideoRangeType         string  `json:"VideoRangeType,omitempty"`
+	ColorRange             string  `json:"ColorRange,omitempty"`
 	ColorPrimaries         string  `json:"ColorPrimaries,omitempty"`
 	ColorSpace             string  `json:"ColorSpace,omitempty"`
 	ColorTransfer          string  `json:"ColorTransfer,omitempty"`

--- a/internal/jellycompat/handlers_playback.go
+++ b/internal/jellycompat/handlers_playback.go
@@ -890,7 +890,7 @@ func buildMediaStreamsWithSelection(routeItemID, mediaSourceID string, version c
 			AspectRatio:            track.AspectRatio,
 			VideoRange:             compatVideoRange(track, version.HDR),
 			VideoRangeType:         compatVideoRangeType(track, version.HDR),
-			ColorRange:             track.ColorRange,
+			ColorRange:             compatColorRange(track.ColorRange),
 			ColorPrimaries:         track.ColorPrimaries,
 			ColorSpace:             track.ColorSpace,
 			ColorTransfer:          track.ColorTransfer,
@@ -969,6 +969,16 @@ func buildMediaStreamsWithSelection(routeItemID, mediaSourceID string, version c
 	}
 
 	return streams
+}
+
+func compatColorRange(colorRange string) string {
+	colorRange = strings.TrimSpace(colorRange)
+	if strings.EqualFold(colorRange, "unknown") {
+		// The scanner persists this sentinel so legacy probe repair converges,
+		// but Jellyfin omits ColorRange when ffprobe did not provide a value.
+		return ""
+	}
+	return colorRange
 }
 
 func mediaSourceETag(version catalog.FileVersion) string {

--- a/internal/jellycompat/handlers_playback.go
+++ b/internal/jellycompat/handlers_playback.go
@@ -890,6 +890,7 @@ func buildMediaStreamsWithSelection(routeItemID, mediaSourceID string, version c
 			AspectRatio:            track.AspectRatio,
 			VideoRange:             compatVideoRange(track, version.HDR),
 			VideoRangeType:         compatVideoRangeType(track, version.HDR),
+			ColorRange:             track.ColorRange,
 			ColorPrimaries:         track.ColorPrimaries,
 			ColorSpace:             track.ColorSpace,
 			ColorTransfer:          track.ColorTransfer,

--- a/internal/models/media.go
+++ b/internal/models/media.go
@@ -219,6 +219,7 @@ type VideoTrack struct {
 	Bitrate            int    `json:"bitrate,omitempty"`
 	VideoRange         string `json:"video_range,omitempty"`
 	VideoRangeType     string `json:"video_range_type,omitempty"`
+	ColorRange         string `json:"color_range,omitempty"`
 	ColorPrimaries     string `json:"color_primaries,omitempty"`
 	ColorSpace         string `json:"color_space,omitempty"`
 	ColorTransfer      string `json:"color_transfer,omitempty"`

--- a/internal/models/media_test.go
+++ b/internal/models/media_test.go
@@ -1,6 +1,9 @@
 package models
 
-import "testing"
+import (
+	"encoding/json"
+	"testing"
+)
 
 func TestPersonKindAudiobookRoles(t *testing.T) {
 	cases := []struct {
@@ -36,6 +39,37 @@ func TestNormalizeVideoBitDepth(t *testing.T) {
 		t.Run(test.name, func(t *testing.T) {
 			if got := NormalizeVideoBitDepth(test.explicit, test.pixelFormat, test.profile); got != test.want {
 				t.Fatalf("NormalizeVideoBitDepth(%d, %q, %q) = %d, want %d", test.explicit, test.pixelFormat, test.profile, got, test.want)
+			}
+		})
+	}
+}
+
+func TestVideoTrackColorRangeJSON(t *testing.T) {
+	for _, test := range []struct {
+		name    string
+		value   string
+		present bool
+	}{
+		{name: "limited", value: "tv", present: true},
+		{name: "full", value: "pc", present: true},
+		{name: "unspecified", value: "unknown", present: true},
+		{name: "empty omitted", value: "", present: false},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			data, err := json.Marshal(VideoTrack{ColorRange: test.value})
+			if err != nil {
+				t.Fatal(err)
+			}
+			var decoded map[string]any
+			if err := json.Unmarshal(data, &decoded); err != nil {
+				t.Fatal(err)
+			}
+			got, present := decoded["color_range"]
+			if present != test.present {
+				t.Fatalf("color_range present = %v, want %v (%s)", present, test.present, data)
+			}
+			if test.present && got != test.value {
+				t.Fatalf("color_range = %#v, want %q", got, test.value)
 			}
 		})
 	}

--- a/internal/playback/capabilities_v3.go
+++ b/internal/playback/capabilities_v3.go
@@ -26,6 +26,7 @@ func SourceDescriptorFromFileV3(file *models.MediaFile, audioIndex int) SourceDe
 		source.VideoProfile = strings.ToLower(strings.TrimSpace(track.Profile))
 		source.VideoLevel = track.Level
 		source.BitDepth = models.NormalizeVideoBitDepth(track.BitDepth, track.PixelFormat, track.Profile)
+		source.ColorRange = normalizeColorRangeV3(track.ColorRange)
 		source.Width = track.Width
 		source.Height = track.Height
 		source.FrameRate = parseFrameRateV3(track.FrameRate)
@@ -71,6 +72,15 @@ func SourceDescriptorFromFileV3(file *models.MediaFile, audioIndex int) SourceDe
 		}
 	}
 	return source
+}
+
+func normalizeColorRangeV3(value string) string {
+	switch normalized := strings.ToLower(strings.TrimSpace(value)); normalized {
+	case "tv", "pc", "unknown":
+		return normalized
+	default:
+		return ""
+	}
 }
 
 func detailedVideoEligibleV3(source SourceDescriptorV3, request StartRequestV3) bool {

--- a/internal/playback/protocol_v3.go
+++ b/internal/playback/protocol_v3.go
@@ -412,6 +412,7 @@ type SourceDescriptorV3 struct {
 	VideoProfile       string             `json:"video_profile,omitempty"`
 	VideoLevel         int                `json:"video_level,omitempty"`
 	BitDepth           int                `json:"bit_depth,omitempty"`
+	ColorRange         string             `json:"color_range,omitempty"`
 	Width              int                `json:"width,omitempty"`
 	Height             int                `json:"height,omitempty"`
 	FrameRate          float64            `json:"frame_rate,omitempty"`

--- a/internal/playback/protocol_v3_test.go
+++ b/internal/playback/protocol_v3_test.go
@@ -265,6 +265,28 @@ func TestSourceDescriptorV3NormalizesLegacyHEVCMetadata(t *testing.T) {
 	}
 }
 
+func TestSourceDescriptorV3PreservesCanonicalColorRange(t *testing.T) {
+	for _, test := range []struct {
+		name  string
+		input string
+		want  string
+	}{
+		{name: "limited", input: "tv", want: "tv"},
+		{name: "full", input: "pc", want: "pc"},
+		{name: "unspecified", input: "unknown", want: "unknown"},
+		{name: "normalizes case and whitespace", input: " PC ", want: "pc"},
+		{name: "rejects non-ffmpeg value", input: "limited", want: ""},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			file := detailedFixtureFileV3()
+			file.VideoTracks[0].ColorRange = test.input
+			if got := SourceDescriptorFromFileV3(file, 0).ColorRange; got != test.want {
+				t.Fatalf("color range = %q, want %q", got, test.want)
+			}
+		})
+	}
+}
+
 func TestPlanPlaybackV3DirectPlaysLegacyHDR10WithInferredBitDepth(t *testing.T) {
 	file := detailedFixtureFileV3()
 	file.VideoTracks[0].BitDepth = 0
@@ -933,7 +955,7 @@ func validStartRequestV3() StartRequestV3 {
 }
 
 func detailedFixtureFileV3() *models.MediaFile {
-	return &models.MediaFile{ID: 42, FilePath: "/media/movie.mkv", Container: "mkv", CodecVideo: "hevc", CodecAudio: "aac", Resolution: "2160p", Bitrate: 60_000, AudioChannels: 2, VideoTracks: []models.VideoTrack{{Codec: "hevc", Profile: "Main 10", Level: 153, Width: 3840, Height: 2160, FrameRate: "24000/1001", Bitrate: 60_000, BitDepth: 10, VideoRange: "HDR", VideoRangeType: "HDR10"}}, AudioTracks: []models.AudioTrack{{Codec: "aac", Channels: 2, Layout: "stereo"}}}
+	return &models.MediaFile{ID: 42, FilePath: "/media/movie.mkv", Container: "mkv", CodecVideo: "hevc", CodecAudio: "aac", Resolution: "2160p", Bitrate: 60_000, AudioChannels: 2, VideoTracks: []models.VideoTrack{{Codec: "hevc", Profile: "Main 10", Level: 153, Width: 3840, Height: 2160, FrameRate: "24000/1001", Bitrate: 60_000, BitDepth: 10, VideoRange: "HDR", VideoRangeType: "HDR10", ColorRange: "tv"}}, AudioTracks: []models.AudioTrack{{Codec: "aac", Channels: 2, Layout: "stereo"}}}
 }
 
 func testTransformationRegistryV3() *TransformationRegistryV3 {

--- a/internal/scanner/probe.go
+++ b/internal/scanner/probe.go
@@ -187,6 +187,9 @@ func convertProbeData(raw *ffprobeOutput) *ProbeData {
 		switch s.CodecType {
 		case "video":
 			dvProfile := dolbyVisionProfileNumber(s.SideDataList)
+			// ffprobe omits unspecified optional fields by default; "unknown" is
+			// FFmpeg's canonical name for AVCOL_RANGE_UNSPECIFIED.
+			colorRange := firstNonEmpty(s.ColorRange, "unknown")
 			track := VideoTrackInfo{
 				Title:              firstNonEmpty(s.Tags["title"], s.CodecLongName, strings.ToUpper(s.CodecName)),
 				Codec:              s.CodecName,
@@ -206,7 +209,7 @@ func convertProbeData(raw *ffprobeOutput) *ProbeData {
 				Bitrate:            parseNumeric(s.BitRate) / 1000,
 				VideoRange:         videoRangeLabel(s),
 				VideoRangeType:     videoRangeType(s),
-				ColorRange:         firstNonEmpty(s.ColorRange, "unknown"),
+				ColorRange:         colorRange,
 				ColorPrimaries:     s.ColorPrimaries,
 				ColorSpace:         s.ColorSpace,
 				ColorTransfer:      s.ColorTransfer,

--- a/internal/scanner/probe.go
+++ b/internal/scanner/probe.go
@@ -76,6 +76,7 @@ type ffprobeStream struct {
 	StartTime          string              `json:"start_time"`
 	Duration           string              `json:"duration"`
 	BitRate            string              `json:"bit_rate"`
+	ColorRange         string              `json:"color_range"`
 	ColorTransfer      string              `json:"color_transfer"`
 	ColorPrimaries     string              `json:"color_primaries"`
 	ColorSpace         string              `json:"color_space"`
@@ -205,6 +206,7 @@ func convertProbeData(raw *ffprobeOutput) *ProbeData {
 				Bitrate:            parseNumeric(s.BitRate) / 1000,
 				VideoRange:         videoRangeLabel(s),
 				VideoRangeType:     videoRangeType(s),
+				ColorRange:         firstNonEmpty(s.ColorRange, "unknown"),
 				ColorPrimaries:     s.ColorPrimaries,
 				ColorSpace:         s.ColorSpace,
 				ColorTransfer:      s.ColorTransfer,

--- a/internal/scanner/probe_repair.go
+++ b/internal/scanner/probe_repair.go
@@ -54,9 +54,21 @@ func NeedsCriticalProbeRepair(file *models.MediaFile) bool {
 		if strings.TrimSpace(file.CodecVideo) == "" || strings.TrimSpace(file.Resolution) == "" {
 			return true
 		}
+		if videoTracksMissingColorRange(file.VideoTracks) {
+			return true
+		}
 	}
 	if file.Chapters == nil {
 		return true
+	}
+	return false
+}
+
+func videoTracksMissingColorRange(tracks []models.VideoTrack) bool {
+	for _, track := range tracks {
+		if strings.TrimSpace(track.ColorRange) == "" {
+			return true
+		}
 	}
 	return false
 }

--- a/internal/scanner/probe_repair_audio_test.go
+++ b/internal/scanner/probe_repair_audio_test.go
@@ -47,6 +47,31 @@ func TestNeedsCriticalProbeRepair_ProbedVideoMissingResolutionStillRepairs(t *te
 	}
 }
 
+func TestNeedsCriticalProbeRepair_ProbedVideoMissingColorRangeRepairsOnce(t *testing.T) {
+	now := time.Now()
+	f := &models.MediaFile{
+		ProbeSource:    "local",
+		ProbeUpdatedAt: &now,
+		Duration:       7200,
+		Container:      "mkv",
+		CodecAudio:     "aac",
+		AudioTracks:    []models.AudioTrack{{Language: "eng"}},
+		CodecVideo:     "h264",
+		Resolution:     "1080p",
+		VideoTracks:    []models.VideoTrack{{Codec: "h264"}},
+		Chapters:       []models.MediaChapter{},
+	}
+
+	if !NeedsCriticalProbeRepair(f) {
+		t.Fatal("a legacy video without color range should need probe repair")
+	}
+
+	f.VideoTracks[0].ColorRange = "unknown"
+	if NeedsCriticalProbeRepair(f) {
+		t.Fatal("a reprobed video with unknown color range should not repair again")
+	}
+}
+
 func TestNeedsCriticalProbeRepair_UnprobedFileRepairs(t *testing.T) {
 	if !NeedsCriticalProbeRepair(&models.MediaFile{}) {
 		t.Fatal("an unprobed file must need probe repair")
@@ -64,7 +89,7 @@ func implausiblyShortLargeVideoFile(probedAt time.Time) *models.MediaFile {
 		AudioTracks:    []models.AudioTrack{{Language: "eng"}},
 		CodecVideo:     "h264",
 		Resolution:     "720p",
-		VideoTracks:    []models.VideoTrack{{Codec: "h264"}},
+		VideoTracks:    []models.VideoTrack{{Codec: "h264", ColorRange: "unknown"}},
 		Chapters:       []models.MediaChapter{},
 	}
 }

--- a/internal/scanner/probe_video_range_test.go
+++ b/internal/scanner/probe_video_range_test.go
@@ -1,6 +1,44 @@
 package scanner
 
-import "testing"
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/Silo-Server/silo-server/internal/models"
+)
+
+func TestProbePipelinePreservesVideoColorRange(t *testing.T) {
+	tests := []struct {
+		name           string
+		colorRange     string
+		wantColorRange string
+	}{
+		{name: "limited", colorRange: "tv", wantColorRange: "tv"},
+		{name: "full", colorRange: "pc", wantColorRange: "pc"},
+		{name: "unspecified", wantColorRange: "unknown"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			rawJSON := `{"streams":[{"codec_type":"video","codec_name":"h264","color_range":"` + tt.colorRange + `"}]}`
+			var raw ffprobeOutput
+			if err := json.Unmarshal([]byte(rawJSON), &raw); err != nil {
+				t.Fatalf("unmarshal ffprobe output: %v", err)
+			}
+
+			probe := convertProbeData(&raw)
+			file := &models.MediaFile{}
+			applyProbeData(file, probe, "local")
+
+			if len(file.VideoTracks) != 1 {
+				t.Fatalf("VideoTracks length = %d, want 1", len(file.VideoTracks))
+			}
+			if got := file.VideoTracks[0].ColorRange; got != tt.wantColorRange {
+				t.Fatalf("ColorRange = %q, want %q", got, tt.wantColorRange)
+			}
+		})
+	}
+}
 
 func TestConvertProbeDataVideoRangeTypes(t *testing.T) {
 	tests := []struct {

--- a/internal/scanner/scanner.go
+++ b/internal/scanner/scanner.go
@@ -3186,6 +3186,7 @@ func applyProbeData(mf *models.MediaFile, probe *ProbeData, probeSource string) 
 			Bitrate:            vt.Bitrate,
 			VideoRange:         vt.VideoRange,
 			VideoRangeType:     vt.VideoRangeType,
+			ColorRange:         vt.ColorRange,
 			ColorPrimaries:     vt.ColorPrimaries,
 			ColorSpace:         vt.ColorSpace,
 			ColorTransfer:      vt.ColorTransfer,

--- a/internal/scanner/types.go
+++ b/internal/scanner/types.go
@@ -67,6 +67,7 @@ type VideoTrackInfo struct {
 	Bitrate            int
 	VideoRange         string
 	VideoRangeType     string
+	ColorRange         string
 	ColorPrimaries     string
 	ColorSpace         string
 	ColorTransfer      string

--- a/web/src/api/types.ts
+++ b/web/src/api/types.ts
@@ -970,6 +970,7 @@ export interface VersionVideoTrack {
   bitrate?: number;
   video_range?: string;
   video_range_type?: string;
+  color_range?: string;
   color_primaries?: string;
   color_space?: string;
   color_transfer?: string;

--- a/web/src/player/playback-info.test.ts
+++ b/web/src/player/playback-info.test.ts
@@ -28,6 +28,7 @@ function makeVersion(overrides: Partial<PlayerFileVersion> = {}): PlayerFileVers
         height: 2160,
         bitrate: 21900,
         video_range: "HDR10",
+        color_range: "tv",
         dolby_vision: "Profile 8.1",
       },
     ],
@@ -95,6 +96,7 @@ describe("playback info helpers", () => {
     expect(rowValue(sections, "Current Source File", "Video range type")).toBe(
       "Dolby Vision Profile 8.1 (HDR10)",
     );
+    expect(rowValue(sections, "Current Source File", "Color range")).toBe("Limited (tv)");
     expect(rowValue(sections, "Current Source File", "Audio codec")).toBe(
       "EAC3 Dolby Digital Plus + Dolby Atmos",
     );
@@ -146,6 +148,27 @@ describe("playback info helpers", () => {
     expect(rowValue(sections, "Current Source File", "Container")).toBe("—");
     expect(rowValue(sections, "Current Source File", "Size")).toBe("—");
     expect(rowValue(sections, "Current Source File", "Audio sample rate")).toBe("—");
+    expect(rowValue(sections, "Current Source File", "Color range")).toBe("—");
+  });
+
+  it("formats full and unspecified source color ranges", () => {
+    const full = buildPlaybackInfoSections({
+      streamUrl: "/api/v1/stream/full",
+      playMethod: "direct",
+      playbackInfo: null,
+      currentSourceVersion: makeVersion({ video_tracks: [{ color_range: "pc" }] }),
+      runtimeStats: {},
+    });
+    const unknown = buildPlaybackInfoSections({
+      streamUrl: "/api/v1/stream/unknown",
+      playMethod: "direct",
+      playbackInfo: null,
+      currentSourceVersion: makeVersion({ video_tracks: [{ color_range: "unknown" }] }),
+      runtimeStats: {},
+    });
+
+    expect(rowValue(full, "Current Source File", "Color range")).toBe("Full (pc)");
+    expect(rowValue(unknown, "Current Source File", "Color range")).toBe("Unknown");
   });
 
   it("shows the requested source when playback auto-switches to a lower version", () => {

--- a/web/src/player/playback-info.ts
+++ b/web/src/player/playback-info.ts
@@ -148,6 +148,10 @@ export function buildPlaybackInfoSections({
           value: formatVideoRangeType(currentSourceVersion, videoTrack),
         },
         {
+          label: "Color range",
+          value: formatColorRange(videoTrack?.color_range),
+        },
+        {
           label: "Audio codec",
           value: formatOriginalAudioCodec(currentSourceVersion, audioTrack),
         },
@@ -338,6 +342,19 @@ export function formatVideoRangeType(
     return videoRangeLabel(version) || "SDR";
   }
   return "—";
+}
+
+export function formatColorRange(value?: string): string {
+  switch (value?.trim().toLowerCase()) {
+    case "tv":
+      return "Limited (tv)";
+    case "pc":
+      return "Full (pc)";
+    case "unknown":
+      return "Unknown";
+    default:
+      return "—";
+  }
 }
 
 export function formatOriginalAudioCodec(

--- a/web/src/player/types.ts
+++ b/web/src/player/types.ts
@@ -79,6 +79,7 @@ export interface PlayerVideoTrack {
   frame_rate?: string;
   bitrate?: number;
   video_range?: string;
+  color_range?: string;
   color_primaries?: string;
   color_space?: string;
   color_transfer?: string;


### PR DESCRIPTION
## Summary

- capture canonical ffprobe `color_range` values on scanned video tracks
- persist the field through media JSONB and catalog seed export/import
- expose Jellyfin-compatible `MediaStream.ColorRange` from item detail and PlaybackInfo responses
- lazily reprobe legacy video rows once, using an internal unknown sentinel when ffprobe provides no range
- expose the additive value as `source.color_range` in playback v3 for native clients
- show the source color range in the web playback diagnostics panel

## Root cause

Silo decoded adjacent ffprobe color fields but omitted `color_range` from its probe shape, stored model, and Jellycompat MediaStream DTO. Direct-play bytes remained untouched, but clients could not receive the limited-range `tv` or full-range `pc` metadata that FFmpeg and Jellyfin expose.

## FFmpeg semantics

FFmpeg names limited `AVCOL_RANGE_MPEG` as `tv`, full `AVCOL_RANGE_JPEG` as `pc`, and unspecified `AVCOL_RANGE_UNSPECIFIED` as `unknown`. ffprobe default JSON may omit an unspecified optional field, so Silo stores `unknown` internally to make one-time legacy repair converge. Jellyfin-compatible output omits that sentinel; playback v3 preserves the canonical source value so native clients can explicitly ignore `unknown`.

No client should use this metadata to override valid decoder or container signaling. The coordinated native changes use it only as a fallback when local range metadata is unspecified.

## Impact

Newly probed files preserve their exact range. Existing video rows are repaired on first detail or playback access, so users do not need to touch or re-import files. This is additive within `/api/v1` and requires no SQL migration because video tracks are stored as JSONB.

Part of #446.
Closes #446.

## Coordinated clients

- Apple: https://github.com/Silo-Server/silo-apple/pull/97
- Android: https://github.com/Silo-Server/silo-android/pull/86

The browser decoder remains authoritative in the web app because browser media APIs do not expose a safe limited/full-range override; the web change makes the server-probed source value visible for diagnostics.

## Validation

- `GOWORK=off go test ./internal/models ./internal/playback ./internal/scanner -count=1`
- focused Jellycompat ColorRange and VideoRangeType tests
- `cd web && pnpm run lint` (zero errors; existing warnings only)
- `cd web && pnpm run format:check`
- `cd web && pnpm run build`
- focused web playback-info tests (9 passed)
- `make verify-local-paths`
- autoreview clean with no accepted or actionable findings
- synthetic ffprobe verification: full range reports `pc`; unspecified is omitted by default and reports `unknown` with `-show_optional_fields always`

The broad `internal/jellycompat` suite still has two unrelated macOS process-lock identity failures involving an empty current-process token. Both failures reproduce unchanged on `origin/main`; the focused changed path passes.

## Risk and follow-up

The main server-side behavioral change is a one-time lazy ffprobe for legacy video rows whose tracks lack `color_range`. When ffprobe cannot determine the value, Silo stores `unknown` internally so subsequent requests do not repeatedly probe.

The original reporter should verify the same direct-play file after deploying this branch and confirm the Infuse and native client output.

## AI use

Implemented with OpenAI Codex. The patch was reviewed with the repository autoreview workflow, focused validation was run across server and web, and review findings in the coordinated native clients were addressed before publication.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added end-to-end handling of video color-range metadata (`tv`/`pc`/`unknown`) across scanning, export/import, API types, and playback planning.
  * The playback UI now shows the current “Color range” for the selected video track.

* **Bug Fixes**
  * Detects missing color-range metadata for video tracks and triggers re-probing when required.
  * Normalizes whitespace/casing and consistently treats unknown/missing values.

* **Tests**
  * Added unit and API/UI-focused coverage to verify correct preservation, JSON behavior, and displayed labels.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->