### PR TITLE
fix(jellycompat): populate MediaStream ColorRange (SDR washed out in clients)

### DIFF
--- a/internal/catalogseed/service.go
+++ b/internal/catalogseed/service.go
@@ -2583,6 +2583,7 @@ func toVideoTrackRecords(tracks []models.VideoTrack) []VideoTrackRecord {
 			ColorPrimaries:  track.ColorPrimaries,
 			ColorSpace:      track.ColorSpace,
 			ColorTransfer:   track.ColorTransfer,
+			ColorRange:      track.ColorRange,
 			BitDepth:        track.BitDepth,
 			PixelFormat:     track.PixelFormat,
 			ReferenceFrames: track.ReferenceFrames,

--- a/internal/catalogseed/types.go
+++ b/internal/catalogseed/types.go
@@ -159,6 +159,7 @@ type VideoTrackRecord struct {
 	ColorPrimaries  string `json:"color_primaries,omitempty"`
 	ColorSpace      string `json:"color_space,omitempty"`
 	ColorTransfer   string `json:"color_transfer,omitempty"`
+	ColorRange      string `json:"color_range,omitempty"`
 	BitDepth        int    `json:"bit_depth,omitempty"`
 	PixelFormat     string `json:"pixel_format,omitempty"`
 	ReferenceFrames int    `json:"reference_frames,omitempty"`

--- a/internal/jellycompat/dto.go
+++ b/internal/jellycompat/dto.go
@@ -267,6 +267,7 @@ type mediaStreamDTO struct {
 	ColorPrimaries         string  `json:"ColorPrimaries,omitempty"`
 	ColorSpace             string  `json:"ColorSpace,omitempty"`
 	ColorTransfer          string  `json:"ColorTransfer,omitempty"`
+	ColorRange             string  `json:"ColorRange,omitempty"`
 	PixelFormat            string  `json:"PixelFormat,omitempty"`
 	AudioSpatialFormat     string  `json:"AudioSpatialFormat,omitempty"`
 	AverageFrameRate       float64 `json:"AverageFrameRate,omitempty"`

--- a/internal/jellycompat/handlers_playback.go
+++ b/internal/jellycompat/handlers_playback.go
@@ -893,6 +893,7 @@ func buildMediaStreamsWithSelection(routeItemID, mediaSourceID string, version c
 			ColorPrimaries:         track.ColorPrimaries,
 			ColorSpace:             track.ColorSpace,
 			ColorTransfer:          track.ColorTransfer,
+			ColorRange:             track.ColorRange,
 			PixelFormat:            track.PixelFormat,
 			AudioSpatialFormat:     "None",
 			AverageFrameRate:       parseCompatFrameRate(track.FrameRate),

--- a/internal/models/media.go
+++ b/internal/models/media.go
@@ -222,6 +222,7 @@ type VideoTrack struct {
 	ColorPrimaries     string `json:"color_primaries,omitempty"`
 	ColorSpace         string `json:"color_space,omitempty"`
 	ColorTransfer      string `json:"color_transfer,omitempty"`
+	ColorRange         string `json:"color_range,omitempty"`
 	BitDepth           int    `json:"bit_depth,omitempty"`
 	PixelFormat        string `json:"pixel_format,omitempty"`
 	ReferenceFrames    int    `json:"reference_frames,omitempty"`

--- a/internal/scanner/probe.go
+++ b/internal/scanner/probe.go
@@ -79,6 +79,7 @@ type ffprobeStream struct {
 	ColorTransfer      string              `json:"color_transfer"`
 	ColorPrimaries     string              `json:"color_primaries"`
 	ColorSpace         string              `json:"color_space"`
+	ColorRange         string              `json:"color_range"`
 	PixFmt             string              `json:"pix_fmt"`
 	Refs               int                 `json:"refs"`
 	BitsPerRawSample   ffprobeScalarString `json:"bits_per_raw_sample"`
@@ -208,6 +209,7 @@ func convertProbeData(raw *ffprobeOutput) *ProbeData {
 				ColorPrimaries:     s.ColorPrimaries,
 				ColorSpace:         s.ColorSpace,
 				ColorTransfer:      s.ColorTransfer,
+				ColorRange:         s.ColorRange,
 				BitDepth:           models.NormalizeVideoBitDepth(parseBitDepth(s), s.PixFmt, s.Profile),
 				PixelFormat:        s.PixFmt,
 				ReferenceFrames:    s.Refs,

--- a/internal/scanner/scanner.go
+++ b/internal/scanner/scanner.go
@@ -3189,6 +3189,7 @@ func applyProbeData(mf *models.MediaFile, probe *ProbeData, probeSource string) 
 			ColorPrimaries:     vt.ColorPrimaries,
 			ColorSpace:         vt.ColorSpace,
 			ColorTransfer:      vt.ColorTransfer,
+			ColorRange:         vt.ColorRange,
 			BitDepth:           vt.BitDepth,
 			PixelFormat:        vt.PixelFormat,
 			ReferenceFrames:    vt.ReferenceFrames,

--- a/internal/scanner/types.go
+++ b/internal/scanner/types.go
@@ -70,6 +70,7 @@ type VideoTrackInfo struct {
 	ColorPrimaries     string
 	ColorSpace         string
 	ColorTransfer      string
+	ColorRange         string
 	BitDepth           int
 	PixelFormat        string
 	ReferenceFrames    int


### PR DESCRIPTION
Silo never captured or reported the video color range (limited/tv vs full/pc), so the Jellyfin-compat MediaStream omitted ColorRange. Clients (Infuse, etc.) then render limited-range content as full-range on direct play -> raised blacks, capped whites -> washed out / faded, even on plain SDR h264.

Thread ffprobe's color_range through to the API, mirroring the existing ColorSpace/ColorTransfer/ColorPrimaries handling:
- scanner/probe.go: capture color_range and set it on the built VideoTrack
- scanner/scanner.go: carry ColorRange through applyProbeData (persist path)
- scanner/types.go, models/media.go: add ColorRange to track structs
- jellycompat/dto.go: add ColorRange to mediaStreamDTO
- jellycompat/handlers_playback.go: populate ColorRange from the track
- catalogseed/{types,service}.go: carry it through catalog-seed import

Values pass through verbatim (tv/pc), same as Jellyfin; untagged files stay empty (omitempty). Existing libraries need a re-scan to repopulate video_tracks.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for detecting and preserving video color range metadata.
  * Color range information is now included in video track details and playback stream metadata when available.
  * Media exports and responses can now include the video `color_range` value.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->