### PR TITLE
fix(catalog): assign external subtitle track indexes

### DIFF
--- a/internal/catalog/detail.go
+++ b/internal/catalog/detail.go
@@ -3412,8 +3412,13 @@ func buildVersionSubtitleTracks(file *models.MediaFile) []VersionSubtitleTrack {
 			FileName:        sub.FileName,
 		})
 	}
-	for _, sub := range file.ExternalSubtitles {
+	for i, sub := range file.ExternalSubtitles {
 		tracks = append(tracks, VersionSubtitleTrack{
+			// Combined-index identity: externals occupy 0..n-1 in the playback
+			// selection space (session subtitle_urls, ResolveSubtitlePolicyV3).
+			// Without this every external serialized index 0 and clients keying
+			// on index got duplicates.
+			Index:           i,
 			Language:        sub.Language,
 			Codec:           sub.Format,
 			Title:           firstNonEmpty(sub.Title, filepath.Base(sub.Path)),

--- a/internal/catalog/detail.go
+++ b/internal/catalog/detail.go
@@ -3397,7 +3397,8 @@ func (s *DetailService) buildVersionChapters(ctx context.Context, file *models.M
 
 func buildVersionSubtitleTracks(file *models.MediaFile) []VersionSubtitleTrack {
 	tracks := make([]VersionSubtitleTrack, 0, len(file.SubtitleTracks)+len(file.ExternalSubtitles))
-	for _, sub := range file.SubtitleTracks {
+	nextExternalIndex := len(file.VideoTracks) + len(file.AudioTracks)
+	for i, sub := range file.SubtitleTracks {
 		tracks = append(tracks, VersionSubtitleTrack{
 			Index:           sub.Index,
 			Language:        sub.Language,
@@ -3411,14 +3412,23 @@ func buildVersionSubtitleTracks(file *models.MediaFile) []VersionSubtitleTrack {
 			External:        sub.External,
 			FileName:        sub.FileName,
 		})
+
+		index := sub.Index
+		if index <= 0 {
+			index = len(file.VideoTracks) + len(file.AudioTracks) + i
+		}
+		if index >= nextExternalIndex {
+			nextExternalIndex = index + 1
+		}
+	}
+	// Zero means "use positional fallback" to downstream consumers and is
+	// omitted from JSON, so external tracks always receive positive indexes.
+	if nextExternalIndex < 1 {
+		nextExternalIndex = 1
 	}
 	for i, sub := range file.ExternalSubtitles {
 		tracks = append(tracks, VersionSubtitleTrack{
-			// Combined-index identity: externals occupy 0..n-1 in the playback
-			// selection space (session subtitle_urls, ResolveSubtitlePolicyV3).
-			// Without this every external serialized index 0 and clients keying
-			// on index got duplicates.
-			Index:           i,
+			Index:           nextExternalIndex + i,
 			Language:        sub.Language,
 			Codec:           sub.Format,
 			Title:           firstNonEmpty(sub.Title, filepath.Base(sub.Path)),

--- a/internal/catalog/detail_subtitle_tracks_test.go
+++ b/internal/catalog/detail_subtitle_tracks_test.go
@@ -1,0 +1,44 @@
+package catalog
+
+import (
+	"testing"
+
+	"github.com/Silo-Server/silo-server/internal/models"
+)
+
+// External subtitles must carry their combined-index identity (externals
+// occupy 0..n-1 in the playback selection space; see
+// ResolveSubtitlePolicyV3 / session subtitle_urls). Before this test they all
+// serialized the zero value, so any file with two external subs — or one
+// external plus an embedded stream index 0 — published duplicate indexes and
+// clients keying rows on index crashed or selected the wrong track.
+func TestBuildVersionSubtitleTracksAssignsUniqueExternalIndexes(t *testing.T) {
+	file := &models.MediaFile{
+		SubtitleTracks: []models.SubtitleTrack{
+			{Index: 2, Codec: "subrip", Language: "en"},
+			{Index: 3, Codec: "hdmv_pgs_subtitle", Language: "de"},
+		},
+		ExternalSubtitles: []models.ExternalSubtitle{
+			{Path: "/media/movie.en.srt", Format: "srt", Language: "en"},
+			{Path: "/media/movie.nl.srt", Format: "srt", Language: "nl"},
+		},
+	}
+
+	tracks := buildVersionSubtitleTracks(file)
+	if len(tracks) != 4 {
+		t.Fatalf("tracks len = %d, want 4", len(tracks))
+	}
+
+	// Embedded entries keep their ffprobe stream indexes (existing contract).
+	if tracks[0].Index != 2 || tracks[1].Index != 3 {
+		t.Fatalf("embedded indexes = %d,%d, want 2,3", tracks[0].Index, tracks[1].Index)
+	}
+
+	// Externals carry their combined-space ordinal, not the zero value.
+	if tracks[2].Index != 0 || !tracks[2].External {
+		t.Fatalf("first external = index %d external %v, want 0/true", tracks[2].Index, tracks[2].External)
+	}
+	if tracks[3].Index != 1 || !tracks[3].External {
+		t.Fatalf("second external = index %d external %v, want 1/true", tracks[3].Index, tracks[3].External)
+	}
+}

--- a/internal/catalog/detail_subtitle_tracks_test.go
+++ b/internal/catalog/detail_subtitle_tracks_test.go
@@ -1,22 +1,24 @@
 package catalog
 
 import (
+	"encoding/json"
 	"testing"
 
 	"github.com/Silo-Server/silo-server/internal/models"
 )
 
-// External subtitles must carry their combined-index identity (externals
-// occupy 0..n-1 in the playback selection space; see
-// ResolveSubtitlePolicyV3 / session subtitle_urls). Before this test they all
-// serialized the zero value, so any file with two external subs — or one
-// external plus an embedded stream index 0 — published duplicate indexes and
-// clients keying rows on index crashed or selected the wrong track.
+// External subtitles must carry collision-free full stream indexes in catalog
+// responses. Before this test they all serialized the zero value, so files with
+// multiple external subtitles published duplicate identities to clients.
 func TestBuildVersionSubtitleTracksAssignsUniqueExternalIndexes(t *testing.T) {
 	file := &models.MediaFile{
+		VideoTracks: []models.VideoTrack{{Codec: "hevc"}},
+		AudioTracks: []models.AudioTrack{{Codec: "eac3"}},
 		SubtitleTracks: []models.SubtitleTrack{
-			{Index: 2, Codec: "subrip", Language: "en"},
-			{Index: 3, Codec: "hdmv_pgs_subtitle", Language: "de"},
+			// Attachments can leave gaps in ffprobe's full stream indexes. The
+			// zero-valued second track exercises the positional fallback contract.
+			{Index: 4, Codec: "subrip", Language: "en"},
+			{Index: 0, Codec: "hdmv_pgs_subtitle", Language: "de"},
 		},
 		ExternalSubtitles: []models.ExternalSubtitle{
 			{Path: "/media/movie.en.srt", Format: "srt", Language: "en"},
@@ -29,16 +31,31 @@ func TestBuildVersionSubtitleTracksAssignsUniqueExternalIndexes(t *testing.T) {
 		t.Fatalf("tracks len = %d, want 4", len(tracks))
 	}
 
-	// Embedded entries keep their ffprobe stream indexes (existing contract).
-	if tracks[0].Index != 2 || tracks[1].Index != 3 {
-		t.Fatalf("embedded indexes = %d,%d, want 2,3", tracks[0].Index, tracks[1].Index)
+	// Embedded entries keep their stored indexes. Downstream consumers treat
+	// zero as a fallback to video+audio+ordinal, which is 3 for tracks[1].
+	if tracks[0].Index != 4 || tracks[1].Index != 0 {
+		t.Fatalf("embedded indexes = %d,%d, want 4,0", tracks[0].Index, tracks[1].Index)
 	}
 
-	// Externals carry their combined-space ordinal, not the zero value.
-	if tracks[2].Index != 0 || !tracks[2].External {
-		t.Fatalf("first external = index %d external %v, want 0/true", tracks[2].Index, tracks[2].External)
+	// Externals start after every occupied full stream index. They must not use
+	// local ordinals, which collide with video/audio indexes and serialize zero
+	// as a missing field because VersionSubtitleTrack.Index uses omitempty.
+	if tracks[2].Index != 5 || !tracks[2].External {
+		t.Fatalf("first external = index %d external %v, want 5/true", tracks[2].Index, tracks[2].External)
 	}
-	if tracks[3].Index != 1 || !tracks[3].External {
-		t.Fatalf("second external = index %d external %v, want 1/true", tracks[3].Index, tracks[3].External)
+	if tracks[3].Index != 6 || !tracks[3].External {
+		t.Fatalf("second external = index %d external %v, want 6/true", tracks[3].Index, tracks[3].External)
+	}
+
+	encoded, err := json.Marshal(tracks[2:])
+	if err != nil {
+		t.Fatalf("marshal external tracks: %v", err)
+	}
+	var wire []map[string]any
+	if err := json.Unmarshal(encoded, &wire); err != nil {
+		t.Fatalf("unmarshal external tracks: %v", err)
+	}
+	if wire[0]["index"] != float64(5) || wire[1]["index"] != float64(6) {
+		t.Fatalf("serialized external indexes = %#v,%#v, want 5,6", wire[0]["index"], wire[1]["index"])
 	}
 }

--- a/internal/jellycompat/streams.go
+++ b/internal/jellycompat/streams.go
@@ -701,7 +701,17 @@ func subtitleTrackRouteIndex(file *models.MediaFile, ordinal int, track models.S
 }
 
 func externalSubtitleRouteIndex(file *models.MediaFile, ordinal int) int {
-	return len(file.VideoTracks) + len(file.AudioTracks) + len(file.SubtitleTracks) + ordinal
+	nextIndex := len(file.VideoTracks) + len(file.AudioTracks)
+	for i, track := range file.SubtitleTracks {
+		index := subtitleTrackRouteIndex(file, i, track)
+		if index >= nextIndex {
+			nextIndex = index + 1
+		}
+	}
+	if nextIndex < 1 {
+		nextIndex = 1
+	}
+	return nextIndex + ordinal
 }
 
 func subtitleCanServeSRT(format string) bool {

--- a/internal/jellycompat/subtitle_selection_test.go
+++ b/internal/jellycompat/subtitle_selection_test.go
@@ -110,6 +110,28 @@ func TestIsValidCompatSubtitleStreamIndex_ExcludesBitmapSubtitle(t *testing.T) {
 	}
 }
 
+func TestExternalSubtitleRouteIndexSkipsEmbeddedStreamIndexGaps(t *testing.T) {
+	file := &models.MediaFile{
+		VideoTracks: []models.VideoTrack{{Codec: "hevc"}},
+		AudioTracks: []models.AudioTrack{{Codec: "eac3"}},
+		SubtitleTracks: []models.SubtitleTrack{
+			{Index: 4, Codec: "subrip"},
+			{Index: 0, Codec: "hdmv_pgs_subtitle"},
+		},
+		ExternalSubtitles: []models.ExternalSubtitle{
+			{Format: "srt"},
+			{Format: "ass"},
+		},
+	}
+
+	if got := externalSubtitleRouteIndex(file, 0); got != 5 {
+		t.Fatalf("first external route index = %d, want 5", got)
+	}
+	if got := externalSubtitleRouteIndex(file, 1); got != 6 {
+		t.Fatalf("second external route index = %d, want 6", got)
+	}
+}
+
 func TestResolveSelectedSubtitleStreamIndex(t *testing.T) {
 	version := subtitleSelectionVersion()
 	const downloadedCount = 1


### PR DESCRIPTION
## Summary

- assign each external subtitle its ordinal in the playback combined-index space
- preserve existing ffprobe indexes for embedded subtitle streams
- add regression coverage for multiple external subtitles alongside embedded tracks

Without this, every external subtitle serialized with index `0`, producing duplicate client keys and allowing the wrong subtitle track to be selected.

## Verification

- `go test ./internal/catalog`
- `git diff --check upstream/main...HEAD`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed external subtitle tracks receiving duplicate or ambiguous indexes.
  * Improved subtitle selection and URL resolution when media includes both embedded and external subtitles.

* **Tests**
  * Added coverage verifying unique indexes and correct external-track identification.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->