### PR TITLE
feat(activity): identify native Silo clients

### DIFF
--- a/internal/api/handlers/playback_sessions.go
+++ b/internal/api/handlers/playback_sessions.go
@@ -74,6 +74,7 @@ type playbackSessionRow struct {
 	AudioDecision            string    `json:"audio_decision,omitempty"`
 	EffectivePlayMethod      string    `json:"effective_play_method,omitempty"`
 	IsJellyfinClient         bool      `json:"is_jellyfin_client,omitempty"`
+	IsNativeSiloClient       bool      `json:"is_native_silo_client,omitempty"`
 }
 
 // playbackSessionsCapabilitiesResponse advertises the additive fields of the
@@ -88,6 +89,8 @@ type playbackSessionsCapabilitiesResponse struct {
 	EffectivePlayMethodValues []string `json:"effective_play_method_values"`
 	// IsJellyfinClient reports that rows carry is_jellyfin_client.
 	IsJellyfinClient bool `json:"is_jellyfin_client"`
+	// IsNativeSiloClient reports that rows carry is_native_silo_client.
+	IsNativeSiloClient bool `json:"is_native_silo_client"`
 }
 
 // HandleGetSessionsCapabilities exposes additive feature support for the live
@@ -97,6 +100,7 @@ func (h *AdminHandler) HandleGetSessionsCapabilities(w http.ResponseWriter, _ *h
 		EffectivePlayMethod:       true,
 		EffectivePlayMethodValues: []string{"direct", "remux", "transcode", "audio"},
 		IsJellyfinClient:          true,
+		IsNativeSiloClient:        true,
 	})
 }
 
@@ -276,6 +280,7 @@ func enrichPlaybackSessionRow(row *playbackSessionRow, audioTracksJSON []byte) {
 	row.VideoDecision, row.AudioDecision = sessionComponentDecision(row.PlayMethod, row.TranscodeAudio, row.TargetVideoCodec)
 	row.EffectivePlayMethod = effectivePlayMethod(row.VideoDecision, row.AudioDecision)
 	row.IsJellyfinClient = isJellyfinEcosystemClient(row.ClientName, row.ClientUserAgent)
+	row.IsNativeSiloClient = isNativeSiloClient(row.ClientName)
 
 	var audioTracks []models.AudioTrack
 	if len(audioTracksJSON) > 0 {
@@ -434,6 +439,15 @@ func isJellyfinEcosystemClient(clientName, userAgent string) bool {
 		}
 	}
 	return false
+}
+
+// isNativeSiloClient identifies first-party clients that use Silo's native API.
+// The desktop client reports the stable product name without a release number,
+// allowing the UI to show a branded protocol pill without conflating it with
+// the Jellyfin compatibility surface.
+func isNativeSiloClient(clientName string) bool {
+	name := strings.ToLower(strings.TrimSpace(clientName))
+	return name == "silo for windows" || strings.HasPrefix(name, "silo ")
 }
 
 func firstNonEmptyValue(values ...string) string {

--- a/internal/api/handlers/playback_sessions_test.go
+++ b/internal/api/handlers/playback_sessions_test.go
@@ -65,8 +65,8 @@ func TestSessionsCapabilitiesAdvertisesActivityFields(t *testing.T) {
 	if err := json.Unmarshal(rr.Body.Bytes(), &resp); err != nil {
 		t.Fatalf("decode capabilities: %v", err)
 	}
-	if !resp.EffectivePlayMethod || !resp.IsJellyfinClient {
-		t.Fatalf("capabilities must advertise both fields: %+v", resp)
+	if !resp.EffectivePlayMethod || !resp.IsJellyfinClient || !resp.IsNativeSiloClient {
+		t.Fatalf("capabilities must advertise all fields: %+v", resp)
 	}
 	want := []string{"direct", "remux", "transcode", "audio"}
 	if len(resp.EffectivePlayMethodValues) != len(want) {
@@ -99,6 +99,28 @@ func TestIsJellyfinEcosystemClient(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			if got := isJellyfinEcosystemClient(tc.clientName, tc.userAgent); got != tc.want {
 				t.Fatalf("isJellyfinEcosystemClient(%q, %q) = %v, want %v", tc.clientName, tc.userAgent, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestIsNativeSiloClient(t *testing.T) {
+	cases := []struct {
+		name       string
+		clientName string
+		want       bool
+	}{
+		{"windows desktop", "Silo for Windows", true},
+		{"native android", "Silo Android", true},
+		{"case and whitespace", "  SILO FOR WINDOWS  ", true},
+		{"jellyfin client", "VidHub", false},
+		{"browser", "Chrome", false},
+		{"missing", "", false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := isNativeSiloClient(tc.clientName); got != tc.want {
+				t.Fatalf("isNativeSiloClient(%q) = %v, want %v", tc.clientName, got, tc.want)
 			}
 		})
 	}

--- a/web/src/api/types.ts
+++ b/web/src/api/types.ts
@@ -2405,6 +2405,7 @@ export interface AdminSession {
   client_version?: string;
   client_label?: string;
   client_user_agent?: string;
+  is_native_silo_client?: boolean;
   audio_track_index: number;
   transcode_audio: boolean;
   stream_bitrate_kbps: number | null;

--- a/web/src/components/JellyfinSessionPill.tsx
+++ b/web/src/components/JellyfinSessionPill.tsx
@@ -1,5 +1,5 @@
 import type { AdminSession } from "@/api/types";
-import { isJellyfinSession } from "@/pages/adminActivityPresentation";
+import { isJellyfinSession, isNativeSiloSession } from "@/pages/adminActivityPresentation";
 
 /**
  * Purple "JF" pill marking a session served through the Jellyfin compatibility
@@ -16,6 +16,21 @@ export function JellyfinSessionPill({ session }: { session: AdminSession }) {
       title="Jellyfin client"
     >
       JF
+    </span>
+  );
+}
+
+/** First-party native Silo client badge. */
+export function NativeSiloSessionPill({ session }: { session: AdminSession }) {
+  if (!isNativeSiloSession(session)) {
+    return null;
+  }
+  return (
+    <span
+      className="border-primary/30 bg-primary/15 text-primary inline-flex flex-shrink-0 rounded border px-1.5 py-0.5 text-[9px] font-semibold"
+      title="Native Silo client"
+    >
+      Silo
     </span>
   );
 }

--- a/web/src/pages/AdminActivity.tsx
+++ b/web/src/pages/AdminActivity.tsx
@@ -2,7 +2,7 @@ import type { ReactNode } from "react";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { Link } from "react-router";
 import { AdminSessionActions } from "@/components/AdminSessionActions";
-import { JellyfinSessionPill } from "@/components/JellyfinSessionPill";
+import { JellyfinSessionPill, NativeSiloSessionPill } from "@/components/JellyfinSessionPill";
 import { useRealtimeEvents } from "@/components/realtimeEventsContext";
 import { useOperationalLogs } from "@/hooks/queries/admin/logs";
 import { usePageActivity } from "@/hooks/usePageActivity";
@@ -18,6 +18,7 @@ import {
   compareActivityMethods,
   decisionBadgeClass,
   isJellyfinSession,
+  isNativeSiloSession,
   formatAudioDetail,
   formatContainerDetail,
   formatDeliveredAudioSummary,
@@ -526,7 +527,7 @@ function StreamRow({
   const sourceContainer = session.source_container?.trim().toUpperCase();
   const streamBitrate = formatSessionBitrate(session.stream_bitrate_kbps);
   const streamMeta = [sourceContainer, streamBitrate].filter(Boolean).join(" · ");
-  const clientIP = session.client_ip?.trim() || "";
+  const clientIP = isNativeSiloSession(session) ? "" : session.client_ip?.trim() || "";
   const clientLabel = getSessionClientLabel(session);
   const playbackPosition = formatPlaybackPosition(session);
   const transcodeMode = formatTranscodeModeSummary(session);
@@ -598,9 +599,13 @@ function StreamRow({
                 </span>
               </div>
             ) : null}
-            {(clientLabel || clientIP || isJellyfinSession(session)) && (
+            {(clientLabel ||
+              clientIP ||
+              isJellyfinSession(session) ||
+              isNativeSiloSession(session)) && (
               <div className="text-muted-foreground mt-1 flex min-w-0 items-center gap-1.5 text-[10px]">
                 <JellyfinSessionPill session={session} />
+                <NativeSiloSessionPill session={session} />
                 {clientLabel ? (
                   <span
                     title={session.client_user_agent || clientLabel}
@@ -786,6 +791,7 @@ function StreamRow({
               {activityMethod}
             </span>
             <JellyfinSessionPill session={session} />
+            <NativeSiloSessionPill session={session} />
           </div>
           <div className="text-muted-foreground mt-0.5 flex items-center gap-1.5 text-[11px]">
             {itemHref ? (

--- a/web/src/pages/adminActivityPresentation.test.ts
+++ b/web/src/pages/adminActivityPresentation.test.ts
@@ -4,6 +4,7 @@ import {
   classifyActivityMethod,
   compareActivityMethods,
   isJellyfinSession,
+  isNativeSiloSession,
   formatContainerDetail,
   formatDeliveredAudioSummary,
   formatDeliveredContainerSummary,
@@ -38,6 +39,7 @@ function makeSession(overrides: Partial<AdminSession> = {}): AdminSession {
     client_user_agent: overrides.client_user_agent,
     effective_play_method: overrides.effective_play_method,
     is_jellyfin_client: overrides.is_jellyfin_client,
+    is_native_silo_client: overrides.is_native_silo_client,
     audio_track_index: overrides.audio_track_index ?? 0,
     transcode_audio: overrides.transcode_audio ?? true,
     stream_bitrate_kbps: overrides.stream_bitrate_kbps ?? 8000,
@@ -275,6 +277,13 @@ describe("adminActivityPresentation", () => {
     // even when the client name looks like a Jellyfin client.
     expect(isJellyfinSession(makeSession({ client_name: "Jellyfin Web" }))).toBe(false);
     expect(isJellyfinSession(makeSession())).toBe(false);
+  });
+
+  it("tags first-party clients for the native Silo pill", () => {
+    expect(isNativeSiloSession(makeSession({ is_native_silo_client: true }))).toBe(true);
+    expect(isNativeSiloSession(makeSession({ is_native_silo_client: false }))).toBe(false);
+    expect(isNativeSiloSession(makeSession({ client_name: "Silo for Windows" }))).toBe(false);
+    expect(isNativeSiloSession(makeSession())).toBe(false);
   });
 
   it("labels HLS copy-original sessions as container HLS with copied video", () => {

--- a/web/src/pages/adminActivityPresentation.ts
+++ b/web/src/pages/adminActivityPresentation.ts
@@ -173,6 +173,11 @@ export function isJellyfinSession(session: AdminSession): boolean {
   return session.is_jellyfin_client === true;
 }
 
+/** Report whether a session is a first-party client using Silo's native API. */
+export function isNativeSiloSession(session: AdminSession): boolean {
+  return session.is_native_silo_client === true;
+}
+
 export function formatPlaybackDecisionSummary(session: AdminSession): string {
   const videoDecision = normalizeStreamDecision(session.video_decision || session.play_method);
   const audioDecision = normalizeStreamDecision(


### PR DESCRIPTION
## Problem

First-party native Silo clients are currently displayed as plain client text in Admin > Activity. The Windows client should be distinguishable from Jellyfin-compatibility clients, should not receive the purple `JF` marker, and should follow the compact native-client presentation without exposing its IP in the row.

## Changes

- add additive `is_native_silo_client` session and capability fields
- classify stable first-party names such as `Silo for Windows`
- render a branded `Silo` pill independently of the existing `JF` pill
- suppress the IP address for native Silo sessions in desktop and mobile Activity layouts
- preserve existing Jellyfin client detection and presentation

Part of #431.

## Validation

- Prettier check/write on all touched TypeScript files
- ESLint on all touched TypeScript files
- `tsc -b --pretty false`
- `vitest run src/pages/adminActivityPresentation.test.ts` (12 passed)
- Go files formatted with `gofmt`
- Focused Go package tests could not compile on this Windows checkout because the existing `bimg`/libvips native dependency is unavailable; the failure occurs before these tests execute.

## Risk and follow-up

This is additive within `/api/v1`. Older web clients ignore the new field. The native badge and IP suppression become visible after this server/WebUI change is merged and deployed.

## AI assistance disclosure

Implementation and test drafting were assisted by an AI coding agent and reviewed against the current source revision and live Activity behavior.