### PR TITLE
fix(autoscan): match rewrite rules against UNC webhook paths

### DIFF
--- a/internal/autoscan/rewrite.go
+++ b/internal/autoscan/rewrite.go
@@ -23,7 +23,20 @@ func applyRewrites(path string, rewrites []PathRewrite) string {
 	// `\\NAS\Media\TV\...` becomes `//NAS/Media/TV/...`, while normalizePath
 	// collapses the From's leading `//` to `/NAS/Media/TV` — an asymmetry that
 	// made UNC roots unmatchable by any rewrite rule.
+	//
+	// A trailing separator is semantic downstream — filepath.Dir("/x/Show/")
+	// is the directory itself while filepath.Dir("/x/Show") is its parent, so
+	// legacy-scope changes rely on it to scan the notified directory rather
+	// than collapsing to a broader parent scan. normalizePath strips it for
+	// matching; restore it on whatever we return.
+	trailing := strings.HasSuffix(normalizeSeparators(strings.TrimSpace(path)), "/")
 	path = normalizePath(path)
+	restoreTrailing := func(p string) string {
+		if trailing && p != "/" {
+			return p + "/"
+		}
+		return p
+	}
 	bestIdx := -1
 	bestLen := -1
 	var bestTrimmed string
@@ -48,9 +61,9 @@ func applyRewrites(path string, rewrites []PathRewrite) string {
 		}
 	}
 	if bestIdx < 0 {
-		return path
+		return restoreTrailing(path)
 	}
 	// Normalize the joined result too: a To stored with a trailing slash would
 	// otherwise yield a doubled separator at the join point.
-	return normalizePath(strings.TrimSpace(rewrites[bestIdx].To) + strings.TrimPrefix(path, bestTrimmed))
+	return restoreTrailing(normalizePath(strings.TrimSpace(rewrites[bestIdx].To) + strings.TrimPrefix(path, bestTrimmed)))
 }

--- a/internal/autoscan/rewrite.go
+++ b/internal/autoscan/rewrite.go
@@ -10,7 +10,7 @@ func normalizeSeparators(path string) string {
 }
 
 // applyRewrites returns path with the MOST-SPECIFIC matching prefix rewrite
-// applied, or path unchanged when none match.
+// applied, or the normalized path unchanged when none match.
 //
 // "Most-specific" means the longest matching From wins, not the first one in the
 // slice. A first-match strategy lets a broad rewrite (From="/data") shadow a
@@ -18,6 +18,12 @@ func normalizeSeparators(path string) string {
 // be listed first; the arr plugin review flagged exactly this. Selecting the
 // longest matching prefix makes the result independent of rule ordering.
 func applyRewrites(path string, rewrites []PathRewrite) string {
+	// Normalize the incoming path the SAME way the stored From is normalized
+	// below. Separator swapping alone is not enough: a Windows UNC path like
+	// `\\NAS\Media\TV\...` becomes `//NAS/Media/TV/...`, while normalizePath
+	// collapses the From's leading `//` to `/NAS/Media/TV` — an asymmetry that
+	// made UNC roots unmatchable by any rewrite rule.
+	path = normalizePath(path)
 	bestIdx := -1
 	bestLen := -1
 	var bestTrimmed string
@@ -44,5 +50,7 @@ func applyRewrites(path string, rewrites []PathRewrite) string {
 	if bestIdx < 0 {
 		return path
 	}
-	return strings.TrimSpace(rewrites[bestIdx].To) + strings.TrimPrefix(path, bestTrimmed)
+	// Normalize the joined result too: a To stored with a trailing slash would
+	// otherwise yield a doubled separator at the join point.
+	return normalizePath(strings.TrimSpace(rewrites[bestIdx].To) + strings.TrimPrefix(path, bestTrimmed))
 }

--- a/internal/autoscan/rewrite_test.go
+++ b/internal/autoscan/rewrite_test.go
@@ -33,8 +33,7 @@ func TestApplyRewrites(t *testing.T) {
 
 // TestApplyRewritesNormalizesStoredFrom verifies that a Windows-style / dup-slash
 // stored From is normalized the same way coveredBy/normalizePath does, so a
-// rewrite the suggester reports as "covered" actually matches at poll time. The
-// incoming path is already separator-normalized by PollOnce before applyRewrites.
+// rewrite the suggester reports as "covered" actually matches at poll time.
 func TestApplyRewritesNormalizesStoredFrom(t *testing.T) {
 	// Backslash From: a Windows-hosted arr root stored verbatim.
 	winFrom := []PathRewrite{{From: `D:\data\tv`, To: "/mnt/media/tv"}}
@@ -50,6 +49,32 @@ func TestApplyRewritesNormalizesStoredFrom(t *testing.T) {
 	dupFrom := []PathRewrite{{From: "/data//tv/", To: "/mnt/media/tv"}}
 	if got := applyRewrites("/data/tv/Show/E.mkv", dupFrom); got != "/mnt/media/tv/Show/E.mkv" {
 		t.Fatalf("dup-slash From should match collapsed path, got %q", got)
+	}
+}
+
+// TestApplyRewritesUNCPath verifies a Windows UNC root (\\NAS\Media\TV) from a
+// Windows-hosted arr matches its rewrite rule. Separator swapping alone turns
+// the incoming path into //NAS/... while the From normalizes to /NAS/..., so
+// the prefix never matched — both sides must go through normalizePath.
+func TestApplyRewritesUNCPath(t *testing.T) {
+	incoming := `\\NAS\Media\TV\Show\S01\E01.mkv`
+	for _, from := range []string{`\\NAS\Media\TV`, "//NAS/Media/TV", "/NAS/Media/TV"} {
+		rw := []PathRewrite{{From: from, To: "/mnt/media/tv"}}
+		if got := applyRewrites(incoming, rw); got != "/mnt/media/tv/Show/S01/E01.mkv" {
+			t.Fatalf("UNC path with From=%q: got %q", from, got)
+		}
+	}
+
+	// An unmatched UNC path still comes back normalized (collapsed slashes),
+	// consistent with what the resolver sees for matched paths.
+	if got := applyRewrites(incoming, nil); got != "/NAS/Media/TV/Show/S01/E01.mkv" {
+		t.Fatalf("unmatched UNC path: got %q", got)
+	}
+
+	// A trailing-slash To must not produce a doubled separator at the join.
+	slashTo := []PathRewrite{{From: `\\NAS\Media\TV`, To: "/mnt/media/tv/"}}
+	if got := applyRewrites(incoming, slashTo); got != "/mnt/media/tv/Show/S01/E01.mkv" {
+		t.Fatalf("trailing-slash To: got %q", got)
 	}
 }
 

--- a/internal/autoscan/rewrite_test.go
+++ b/internal/autoscan/rewrite_test.go
@@ -78,6 +78,35 @@ func TestApplyRewritesUNCPath(t *testing.T) {
 	}
 }
 
+// TestApplyRewritesPreservesTrailingSlash verifies a trailing separator on the
+// incoming path survives normalization and rewriting. It is semantic for
+// legacy-scope changes: filepath.Dir("/x/Show/") is the directory itself while
+// filepath.Dir("/x/Show") is its parent, so dropping it would widen a targeted
+// directory notification into a parent/library scan.
+func TestApplyRewritesPreservesTrailingSlash(t *testing.T) {
+	rw := []PathRewrite{{From: "/data/tv", To: "/mnt/media/tv"}}
+	if got := applyRewrites("/data/tv/Show/", rw); got != "/mnt/media/tv/Show/" {
+		t.Fatalf("rewritten dir: got %q", got)
+	}
+	// Unmatched paths keep it too.
+	if got := applyRewrites("/other/Show/", rw); got != "/other/Show/" {
+		t.Fatalf("unmatched dir: got %q", got)
+	}
+	// Windows separator form: trailing backslash counts as a trailing separator.
+	unc := []PathRewrite{{From: `\\NAS\Media\TV`, To: "/mnt/media/tv"}}
+	if got := applyRewrites(`\\NAS\Media\TV\Show\`, unc); got != "/mnt/media/tv/Show/" {
+		t.Fatalf("UNC dir: got %q", got)
+	}
+	// Files without a trailing separator stay without one.
+	if got := applyRewrites("/data/tv/Show/E01.mkv", rw); got != "/mnt/media/tv/Show/E01.mkv" {
+		t.Fatalf("file: got %q", got)
+	}
+	// Bare root never doubles.
+	if got := applyRewrites("/", nil); got != "/" {
+		t.Fatalf("root: got %q", got)
+	}
+}
+
 // TestApplyRewritesMostSpecificWins verifies the longest matching From wins
 // regardless of slice ordering: a broad rule must not shadow a nested one.
 func TestApplyRewritesMostSpecificWins(t *testing.T) {

--- a/internal/autoscan/service.go
+++ b/internal/autoscan/service.go
@@ -629,7 +629,7 @@ func (s *Service) resolveConnection(ctx context.Context, connectionID string) (R
 func rewriteChanges(changes []Change, rewrites []PathRewrite) []Change {
 	rewritten := make([]Change, 0, len(changes))
 	for _, change := range changes {
-		path := applyRewrites(normalizeSeparators(change.SourcePath), rewrites)
+		path := applyRewrites(change.SourcePath, rewrites)
 		rewritten = append(rewritten, Change{SourcePath: path, Scope: change.Scope})
 	}
 	return rewritten


### PR DESCRIPTION
## Problem

Autoscan path rewrites can never match a Windows UNC path. When a Windows-hosted Sonarr with a UNC root (e.g. `\\NAS\Media\TV`) posts an import webhook, Silo accepts the delivery (202) but logs `autoscan: webhook paths matched no library folder` on every import, and no rewrite rule the admin configures will ever match.

Reported via internal Discord thread (Sonarr 4.x on Windows, Silo in Docker).

## Root cause

The two sides of the rewrite comparison were normalized asymmetrically:

- Incoming webhook paths went through `normalizeSeparators` only, so `\\NAS\Media\TV\...` became `//NAS/Media/TV/...` (leading double slash preserved).
- Rewrite `From` values went through `normalizePath`, which also collapses duplicate slashes, so any configured From becomes `/NAS/Media/TV`.

`strings.HasPrefix("//NAS/...", "/NAS/Media/TV/")` is never true, so UNC paths were structurally unmatchable — not a misconfiguration.

## Fix

- `applyRewrites` now normalizes the incoming path with the same `normalizePath` used for the stored `From`, making the comparison symmetric (UNC, backslash, and dup-slash forms all match).
- The joined result is normalized too, so a `To` stored with a trailing slash cannot produce a doubled separator.
- Dropped the now-redundant `normalizeSeparators` call at the `rewriteChanges` call site.
- Added `TestApplyRewritesUNCPath` covering the reported shape: `\\NAS\Media\TV\...` against backslash, `//`, and collapsed From forms, plus trailing-slash To.

No API surface changes; behavior change is strictly "paths that previously could never match now match their rewrite rule".

## Verification

- `go test ./internal/autoscan/...` passes (including new regression tests); gofmt/vet clean.

## Risks / follow-up

- Unmatched paths now also come back normalized (collapsed slashes, trimmed trailing slash) before library resolution — benign for POSIX library paths, and consistent with what matched paths already produced.
- The reporter's secondary observation (Sonarr's "Test" button appearing not to reach Silo) is not a defect: `arrwebhook.Parse` recognizes `Test` events and acks them as valid no-op deliveries; it just produces no visible scan activity.

## AI-use disclosure

Implemented with Claude Code (Claude Fable 5). The reporting user's AI-assisted analysis in the Discord thread correctly identified the root cause; it was independently verified against the code before implementing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved path rewrite matching for Windows and UNC-style paths.
  - Prevented rewritten results from containing duplicated separators.
  - Ensured unmatched paths return in a normalized form.
  - Preserved trailing separators correctly across directory and root rewrite scenarios.
  - Improved consistency between reported path coverage and actual rewrite behavior.
- **Tests**
  - Added coverage for UNC rewrite behavior and trailing-slash preservation.
  - Updated existing test commentary to reflect the intended normalization timing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->