### PR TITLE
fix(web): make Add Section work on insecure (plain-HTTP) origins

### DIFF
--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -1,5 +1,6 @@
 import type { ApiError, RefreshResponse } from "./types";
 import { storage } from "../utils/storage";
+import { randomUUID } from "../lib/uuid";
 
 type ProfileUnverifiedListener = () => void;
 let profileUnverifiedListener: ProfileUnverifiedListener | null = null;
@@ -82,25 +83,14 @@ export function getProfileToken(): string | null {
   return profileToken;
 }
 
-function getOrCreateDeviceId(): string | null {
+function getOrCreateDeviceId(): string {
   const existing = storage.get(storage.KEYS.DEVICE_ID);
   if (existing) {
     return existing;
   }
 
-  let nextId: string | null = null;
-  try {
-    nextId =
-      typeof crypto !== "undefined" && typeof crypto.randomUUID === "function"
-        ? crypto.randomUUID()
-        : `web-${Date.now().toString(36)}-${Math.random().toString(36).slice(2, 10)}`;
-  } catch {
-    nextId = `web-${Date.now().toString(36)}-${Math.random().toString(36).slice(2, 10)}`;
-  }
-
-  if (nextId) {
-    storage.set(storage.KEYS.DEVICE_ID, nextId);
-  }
+  const nextId = randomUUID();
+  storage.set(storage.KEYS.DEVICE_ID, nextId);
   return nextId;
 }
 
@@ -137,10 +127,6 @@ function detectDeviceName(): string {
 
 function getDeviceHeaders(): Record<string, string> {
   const deviceId = getOrCreateDeviceId();
-  if (!deviceId) {
-    return {};
-  }
-
   return {
     "X-Silo-Device-Id": deviceId,
     "X-Silo-Device-Name": detectDeviceName(),

--- a/web/src/components/sections/SectionEditorDrawer.tsx
+++ b/web/src/components/sections/SectionEditorDrawer.tsx
@@ -38,6 +38,7 @@ import {
   useAllUserCollections,
   type CollectionOption,
 } from "@/hooks/queries/useAllUserCollections";
+import { randomUUID } from "@/lib/uuid";
 
 const CATEGORY_LABELS: Record<Category, string> = {
   library_staples: "Library",
@@ -142,7 +143,7 @@ export function buildProfileSectionSaveEntry({
   }
 
   return {
-    id: section?.id ?? crypto.randomUUID(),
+    id: section?.id ?? randomUUID(),
     section_type: sectionType,
     title: title || sectionTypeLabel(sectionType),
     featured,

--- a/web/src/lib/plexAuth.ts
+++ b/web/src/lib/plexAuth.ts
@@ -1,3 +1,5 @@
+import { randomUUID } from "./uuid";
+
 const PLEX_TV_BASE_URL = "https://plex.tv";
 const PLEX_AUTH_BASE_URL = "https://app.plex.tv/auth#?";
 const PLEX_PRODUCT = "Silo";
@@ -63,10 +65,7 @@ export function getPlexClientIdentifier(): string {
     return stored;
   }
 
-  const generated =
-    typeof crypto !== "undefined" && typeof crypto.randomUUID === "function"
-      ? crypto.randomUUID()
-      : `silo-${Date.now()}`;
+  const generated = randomUUID();
   setStoredPlexClientIdentifier(generated);
   return generated;
 }

--- a/web/src/lib/uuid.ts
+++ b/web/src/lib/uuid.ts
@@ -20,5 +20,11 @@ export function randomUUID(): string {
   bytes[6] = ((bytes[6] ?? 0) & 0x0f) | 0x40;
   bytes[8] = ((bytes[8] ?? 0) & 0x3f) | 0x80;
   const hex = Array.from(bytes, (byte) => byte.toString(16).padStart(2, "0")).join("");
-  return `${hex.slice(0, 8)}-${hex.slice(8, 12)}-${hex.slice(12, 16)}-${hex.slice(16, 20)}-${hex.slice(20)}`;
+  return [
+    hex.slice(0, 8),
+    hex.slice(8, 12),
+    hex.slice(12, 16),
+    hex.slice(16, 20),
+    hex.slice(20),
+  ].join("-");
 }

--- a/web/src/lib/uuid.ts
+++ b/web/src/lib/uuid.ts
@@ -1,0 +1,24 @@
+/**
+ * Generates an RFC 4122 version 4 UUID.
+ *
+ * `crypto.randomUUID` is only exposed in secure contexts, so self-hosted
+ * deployments served over plain HTTP need the `crypto.getRandomValues`
+ * fallback, which is available everywhere.
+ */
+export function randomUUID(): string {
+  if (typeof crypto !== "undefined" && typeof crypto.randomUUID === "function") {
+    return crypto.randomUUID();
+  }
+  const bytes = new Uint8Array(16);
+  if (typeof crypto !== "undefined" && typeof crypto.getRandomValues === "function") {
+    crypto.getRandomValues(bytes);
+  } else {
+    for (let i = 0; i < bytes.length; i += 1) {
+      bytes[i] = Math.floor(Math.random() * 256);
+    }
+  }
+  bytes[6] = ((bytes[6] ?? 0) & 0x0f) | 0x40;
+  bytes[8] = ((bytes[8] ?? 0) & 0x3f) | 0x80;
+  const hex = Array.from(bytes, (byte) => byte.toString(16).padStart(2, "0")).join("");
+  return `${hex.slice(0, 8)}-${hex.slice(8, 12)}-${hex.slice(12, 16)}-${hex.slice(16, 20)}-${hex.slice(20)}`;
+}

--- a/web/src/pages/settings/HomeScreenSettings.tsx
+++ b/web/src/pages/settings/HomeScreenSettings.tsx
@@ -27,6 +27,7 @@ import RecipeConfigDrawer from "@/components/RecipeGallery/RecipeConfigDrawer";
 import type { AddPayload } from "@/components/RecipeGallery/RecipeConfigDrawer";
 import type { GalleryPreset, RecipeDefinition } from "@/lib/recipes";
 import { fetchRecipeCatalog } from "@/lib/recipes";
+import { randomUUID } from "@/lib/uuid";
 import { Plus } from "lucide-react";
 import {
   SectionDragOverlay,
@@ -165,7 +166,7 @@ export function buildProfileGallerySection(
   position: number,
 ): SettingsSectionEntry {
   return {
-    id: crypto.randomUUID(),
+    id: randomUUID(),
     section_type: payload.section_type,
     title: payload.title,
     featured: payload.featured,


### PR DESCRIPTION
## Problem

Reported via an internal Discord thread (build `0a914441`): on Settings → Home Screen, neither "Add Section" nor "Add from gallery" can actually add a section — the "Add section" button appears completely dead while Cancel still works. Happens every time on the reporting deployment.

## Root cause

`buildProfileGallerySection` (`HomeScreenSettings.tsx`) and `buildProfileSectionSaveEntry` (`SectionEditorDrawer.tsx`) call `crypto.randomUUID()` unguarded. Browsers only expose `crypto.randomUUID` in **secure contexts**, so on a self-hosted server accessed over plain HTTP (typical LAN/docker setup) the call throws `TypeError` synchronously inside the click handler. Nothing visible happens: the drawer stays open (gallery flow) or closes without adding (editor flow), and only Cancel responds — exactly the reported symptom.

The codebase already knew about this failure mode: `api/client.ts` (device ID) and `lib/plexAuth.ts` (Plex client ID) both carry ad-hoc `typeof crypto.randomUUID === "function"` fallbacks — which is why everything else works over HTTP and only these two buttons break. `ProfileCustomizeHome` is unaffected because the server assigns IDs there.

## Fix

- New shared helper `web/src/lib/uuid.ts` — `randomUUID()` uses `crypto.randomUUID` when available and otherwise generates an RFC 4122 v4 UUID via `crypto.getRandomValues`, which *is* available in insecure contexts (with a `Math.random` last resort).
- Use it in both section-add paths.
- Replace the two duplicated ad-hoc fallbacks in `api/client.ts` and `lib/plexAuth.ts` with the same helper (removes non-UUID-shaped `web-…`/`silo-…` fallback IDs; existing stored IDs are untouched). `getOrCreateDeviceId` can no longer return `null`, so the dead null-branch in `getDeviceHeaders` is dropped.

Server-side, section override IDs are opaque strings, so client-generated v4 UUIDs remain fully compatible.

## Validation

- `pnpm run lint`, `pnpm run format:check`, `tsc -b`: clean.
- Targeted vitest run (SectionEditorDrawer, client, settings pages): 46/46 pass.
- Fallback path exercised in isolation with `crypto.randomUUID` absent: 1000/1000 unique, valid v4-format UUIDs.

## Risks / follow-ups

None expected; change is additive and confined to ID generation. Clients on secure origins keep using native `crypto.randomUUID`.

## Disclosure

Diagnosed and implemented with AI assistance (Claude Code); reviewed by a human before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability when generating unique identifiers across supported environments by using a consistent UUID helper.
  * Ensured device metadata consistently includes a device identifier in outgoing requests.
  * Improved identifier creation for saved sections, gallery-derived entries, and Plex client connections.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->