### PR TITLE
fix(playback): composite bitmap subtitle burn-in on the GPU for QSV/VAAPI

### DIFF
--- a/internal/playback/transcode.go
+++ b/internal/playback/transcode.go
@@ -711,7 +711,7 @@ func appendAudioArgs(args []string, opts TranscodeOpts) []string {
 
 // appendBitmapSubtitleBurnInArgs adds burn-in arguments for BITMAP subtitle
 // codecs (PGS/VOBSUB/DVB). libass's subtitles= filter cannot render bitmap
-// tracks, so the decoded subtitle stream is composited onto the video with
+// tracks, so the decoded subtitle stream is composited onto the video with an
 // overlay in a -filter_complex graph (the "Plex route"). The graph's output
 // pad [vout] replaces the raw video stream in stream mapping (see
 // appendStreamSelectionArgs), so -vf must never be emitted alongside this.
@@ -722,32 +722,49 @@ func appendAudioArgs(args []string, opts TranscodeOpts) []string {
 // eof_action=pass keeps the video flowing untouched once the subtitle stream
 // ends instead of freezing the last overlay frame on screen.
 //
-// Hardware pipelines mirror appendSubtitleBurnInArgs: frames are downloaded
-// to CPU memory for the overlay, then re-uploaded for the hardware encoder.
+// QSV/VAAPI composite ON the GPU via overlay_vaapi: the decoded video never
+// leaves its VAAPI surface, and only the small, low-frequency subtitle bitmap is
+// uploaded. This avoids the full-frame GPU→CPU→GPU roundtrip a software overlay
+// forces — that roundtrip runs below realtime on 1080p sources (~0.7x), starving
+// the client, and can crash the QSV buffer path with SIGBUS. See
+// appendSubtitleBurnInArgs for the TEXT path, which must stay on CPU because
+// libass is a software renderer. NVENC and CPU encodes keep the software overlay:
+// overlay_cuda is unverified on this build, so the CUDA path retains the safe
+// (if slower) roundtrip rather than risk a broken graph.
 func appendBitmapSubtitleBurnInArgs(args []string, opts TranscodeOpts) []string {
 	// [0:s:N] indexes subtitle streams only, matching the si=N semantics of
 	// the text path — SubtitleTrackIndex is the embedded subtitle ordinal.
-	cpuFilters := fmt.Sprintf("[0:s:%d]overlay=eof_action=pass", opts.SubtitleTrackIndex)
-	if scale := resolutionToScale(opts.TargetResolution); scale != "" {
-		cpuFilters += "," + scale
-	}
+	subInput := fmt.Sprintf("[0:s:%d]", opts.SubtitleTrackIndex)
 
 	var graph string
 	switch opts.HWAccel {
 	case "qsv":
-		// VAAPI→QSV pipeline: download decoded frames to CPU, overlay, convert
-		// to nv12, upload back to VAAPI, then map to QSV for the encoder.
-		graph = "[0:v:0]hwdownload,format=yuv420p[vmain];[vmain]" + cpuFilters +
-			",format=nv12,hwupload,hwmap=derive_device=qsv,format=qsv[vout]"
+		// GPU composite: upload only the subtitle bitmap, overlay it onto the
+		// VAAPI video surface, scale, then map to QSV for the encoder. The scale
+		// helper already appends the hwmap=derive_device=qsv tail.
+		graph = subInput + "format=bgra,hwupload[sub];" +
+			"[0:v:0][sub]overlay_vaapi=eof_action=pass," + qsvScaleFilter(opts.TargetResolution) + "[vout]"
 	case "vaapi":
-		graph = "[0:v:0]hwdownload,format=yuv420p[vmain];[vmain]" + cpuFilters +
-			",format=nv12,hwupload[vout]"
-	case "nvenc":
-		graph = "[0:v:0]hwdownload,format=yuv420p[vmain];[vmain]" + cpuFilters +
-			",format=nv12,hwupload_cuda[vout]"
+		// GPU composite: same as QSV but the frames stay on VAAPI through the
+		// encoder, so no cross-device map is needed.
+		graph = subInput + "format=bgra,hwupload[sub];" +
+			"[0:v:0][sub]overlay_vaapi=eof_action=pass," + vaapiScaleFilter(opts.TargetResolution) + "[vout]"
 	default:
-		// CPU encoding: overlay directly on decoded frames.
-		graph = "[0:v:0]" + cpuFilters + "[vout]"
+		// NVENC and CPU: software overlay on CPU frames. Build the overlay
+		// fragment (subtitle input + optional post-scale) once, then wire it into
+		// the encode-specific pipeline.
+		cpuFilters := subInput + "overlay=eof_action=pass"
+		if scale := resolutionToScale(opts.TargetResolution); scale != "" {
+			cpuFilters += "," + scale
+		}
+		if opts.HWAccel == "nvenc" {
+			// Download to CPU for the overlay, then re-upload to CUDA.
+			graph = "[0:v:0]hwdownload,format=yuv420p[vmain];[vmain]" + cpuFilters +
+				",format=nv12,hwupload_cuda[vout]"
+		} else {
+			// CPU encoding: overlay directly on decoded frames.
+			graph = "[0:v:0]" + cpuFilters + "[vout]"
+		}
 	}
 
 	return append(args, "-filter_complex", graph)

--- a/internal/playback/transcode_args_test.go
+++ b/internal/playback/transcode_args_test.go
@@ -307,7 +307,7 @@ func TestBuildFFmpegArgs_BitmapBurnInNoScaleKeepsNativeResolution(t *testing.T) 
 	}
 }
 
-func TestBuildFFmpegArgs_BitmapBurnInVAAPIRoundTripsThroughCPU(t *testing.T) {
+func TestBuildFFmpegArgs_BitmapBurnInVAAPICompositesOnGPU(t *testing.T) {
 	args := buildFFmpegArgs(TranscodeOpts{
 		InputPath:          "/media/movie.mkv",
 		OutputDir:          "/tmp/out",
@@ -324,9 +324,14 @@ func TestBuildFFmpegArgs_BitmapBurnInVAAPIRoundTripsThroughCPU(t *testing.T) {
 	})
 
 	joined := strings.Join(args, " ")
-	want := "-filter_complex [0:v:0]hwdownload,format=yuv420p[vmain];[vmain][0:s:1]overlay=eof_action=pass,scale=-2:720,format=nv12,hwupload[vout]"
+	// Only the subtitle bitmap is uploaded; the video stays on the VAAPI surface
+	// and is composited with overlay_vaapi — no full-frame hwdownload roundtrip.
+	want := "-filter_complex [0:s:1]format=bgra,hwupload[sub];[0:v:0][sub]overlay_vaapi=eof_action=pass,scale_vaapi=w=-2:h=720:format=nv12[vout]"
 	if !strings.Contains(joined, want) {
-		t.Fatalf("vaapi bitmap burn-in should hwdownload → overlay → hwupload %q: %s", want, joined)
+		t.Fatalf("vaapi bitmap burn-in should composite on GPU %q: %s", want, joined)
+	}
+	if strings.Contains(joined, "hwdownload") {
+		t.Fatalf("vaapi bitmap burn-in must not roundtrip the video through CPU: %s", joined)
 	}
 	if !strings.Contains(joined, "-map [vout]") {
 		t.Fatalf("vaapi bitmap burn-in should map the filter graph output: %s", joined)
@@ -336,6 +341,68 @@ func TestBuildFFmpegArgs_BitmapBurnInVAAPIRoundTripsThroughCPU(t *testing.T) {
 	}
 	if !strings.Contains(joined, "-c:v h264_vaapi") {
 		t.Fatalf("vaapi bitmap burn-in should keep the hardware encoder: %s", joined)
+	}
+}
+
+func TestBuildFFmpegArgs_BitmapBurnInQSVCompositesOnGPU(t *testing.T) {
+	args := buildFFmpegArgs(TranscodeOpts{
+		InputPath:          "/media/movie.mkv",
+		OutputDir:          "/tmp/out",
+		SessionID:          "session-pgs-qsv",
+		SourceVideoCodec:   "h264",
+		TargetCodecVideo:   "h264",
+		TargetCodecAudio:   "aac",
+		SegmentDuration:    2,
+		HWAccel:            "qsv",
+		TargetResolution:   "720p",
+		SubtitleTrackIndex: 1,
+		SubtitleBurnIn:     true,
+		SubtitleCodec:      "hdmv_pgs_subtitle",
+	})
+
+	joined := strings.Join(args, " ")
+	// GPU composite via overlay_vaapi, then map the VAAPI surface to QSV for the
+	// encoder — the video never leaves hardware memory.
+	want := "-filter_complex [0:s:1]format=bgra,hwupload[sub];[0:v:0][sub]overlay_vaapi=eof_action=pass,scale_vaapi=w=-2:h=720:format=nv12,hwmap=derive_device=qsv,format=qsv[vout]"
+	if !strings.Contains(joined, want) {
+		t.Fatalf("qsv bitmap burn-in should composite on GPU %q: %s", want, joined)
+	}
+	if strings.Contains(joined, "hwdownload") {
+		t.Fatalf("qsv bitmap burn-in must not roundtrip the video through CPU: %s", joined)
+	}
+	if strings.Contains(joined, "-vf ") {
+		t.Fatalf("qsv bitmap burn-in must not emit -vf: %s", joined)
+	}
+	if !strings.Contains(joined, "-c:v h264_qsv") {
+		t.Fatalf("qsv bitmap burn-in should keep the hardware encoder: %s", joined)
+	}
+}
+
+func TestBuildFFmpegArgs_BitmapBurnInNVENCStaysOnCPUOverlay(t *testing.T) {
+	// overlay_cuda is unverified on the bundled ffmpeg, so NVENC keeps the safe
+	// software roundtrip: download the frame, overlay on CPU, re-upload to CUDA.
+	args := buildFFmpegArgs(TranscodeOpts{
+		InputPath:          "/media/movie.mkv",
+		OutputDir:          "/tmp/out",
+		SessionID:          "session-pgs-nvenc",
+		SourceVideoCodec:   "h264",
+		TargetCodecVideo:   "h264",
+		TargetCodecAudio:   "aac",
+		SegmentDuration:    2,
+		HWAccel:            "nvenc",
+		TargetResolution:   "720p",
+		SubtitleTrackIndex: 1,
+		SubtitleBurnIn:     true,
+		SubtitleCodec:      "hdmv_pgs_subtitle",
+	})
+
+	joined := strings.Join(args, " ")
+	want := "-filter_complex [0:v:0]hwdownload,format=yuv420p[vmain];[vmain][0:s:1]overlay=eof_action=pass,scale=-2:720,format=nv12,hwupload_cuda[vout]"
+	if !strings.Contains(joined, want) {
+		t.Fatalf("nvenc bitmap burn-in should keep the CPU roundtrip %q: %s", want, joined)
+	}
+	if strings.Contains(joined, "overlay_vaapi") {
+		t.Fatalf("nvenc bitmap burn-in must not use the VAAPI GPU overlay: %s", joined)
 	}
 }
 


### PR DESCRIPTION
Single commit: move bitmap subtitle burn-in off the CPU and onto the GPU for QSV/VAAPI.

## Problem

**Movies with burned-in bitmap subtitles buffer forever and sometimes crash the stream.**

On the live server, a viewer watching a 1080p movie with PGS ("image") subtitles burned in — e.g. *A.I. Artificial Intelligence* — never builds up a play buffer. The player sits right at the live edge: it asks for the next 2-second chunk, the server delivers it a beat late, the player asks for the next one, and so on for minutes on end. Any tiny hiccup turns into a visible stall/rebuffer. In the server logs this showed up as a session requesting one segment at a time, each arriving ~1.5–2.5s old against a 3.5s timeout, plus repeated transcode restarts and, on some runs, an outright `ffmpeg` crash (`bus error (core dumped)`) that froze playback for up to a minute while it recovered.

This only affects **bitmap** subtitles (PGS/VOBSUB/DVB) that are *burned into* the video during a transcode. Text subtitles (SRT/ASS) and direct/remux playback are unaffected.

The root cause is throughput: with the subtitle burn-in running on the CPU, the transcode encodes **slower than realtime**, so it can physically never get ahead of the viewer.

Measured on the exact file/hardware (`jellyfin-ffmpeg 7.1.4`, Intel QSV, 25s sample, seek to 10:00):

| Filter graph | Throughput | Stable? |
|---|---|---|
| **Before** — `hwdownload → software overlay → hwupload → qsv` | **0.68× realtime** (16 fps) | **No** — SIGBUS `bus error (core dumped)` on 2 of 3 runs |
| **After** — `overlay_vaapi → h264_vaapi` | **7.3×** (176 fps) | Yes |
| **After** — `overlay_vaapi → hwmap qsv → h264_qsv` *(the QSV drop-in)* | **7.67×** (185 fps) | Yes |

Below 1.0× is starvation by definition; the fix takes it to ~7×, i.e. from "can never keep up" to "roughly 7 seconds of headroom produced per second of playback."

## Solution

### fix(playback): composite bitmap subtitle burn-in on the GPU for QSV/VAAPI

The burn-in graph is built in `appendBitmapSubtitleBurnInArgs` (`internal/playback/transcode.go:727`). Previously every hardware path (qsv/vaapi/nvenc) used the same skeleton it inherited from the text path: pull the **entire decoded video frame** off the GPU to system RAM (`hwdownload,format=yuv420p`), composite the subtitle with the software `overlay` filter, convert, and push the whole frame back to the GPU (`hwupload`/`hwmap`). For a 1080p source that's ~70+ MB/s of full-frame PCIe traffic plus a per-frame CPU composite — purely to stamp on a subtitle bitmap that only changes every few seconds. That roundtrip is both the throughput wall and the source of the SIGBUS instability (the container's `/dev/shm` is only 64M, which the large QSV surface churn tips over).

The fix keeps the video **on the GPU** and uploads only the small subtitle bitmap:

```
[0:s:N]format=bgra,hwupload[sub];[0:v:0][sub]overlay_vaapi=eof_action=pass,<scale_vaapi…>[vout]
```

- **QSV** ends the chain with the existing `qsvScaleFilter` helper, whose tail (`scale_vaapi=…,hwmap=derive_device=qsv,format=qsv`) maps the composited VAAPI surface to QSV for `h264_qsv`.
- **VAAPI** ends with `vaapiScaleFilter`; the frames stay on VAAPI straight into `h264_vaapi`, so no cross-device map is needed.
- Overlay still happens at **native resolution first, then scale**, so bitmap subtitle geometry is preserved exactly as before, and `eof_action=pass` is carried over (verified supported by `overlay_vaapi`) so the video keeps flowing after the subtitle stream ends.

Deliberately **not** changed:
- The **libass text path** (`appendSubtitleBurnInArgs`) stays on CPU — libass is a software renderer with no GPU equivalent.
- **NVENC and CPU encodes** keep the software overlay. `overlay_cuda` exists in the build but I have no NVIDIA hardware to verify it on, and shipping an unverified hardware filtergraph could break working (if slow) NVIDIA burn-in. Left as a follow-up.

Tests: updated the VAAPI assertion to the GPU graph and added QSV and NVENC cases (`internal/playback/transcode_args_test.go`), locking in that QSV/VAAPI composite on the GPU with no `hwdownload`, and that NVENC still takes the CPU roundtrip.

## Risk / follow-ups

- **NVENC still starves** on bitmap burn-in — it keeps the CPU roundtrip. A follow-up should validate `overlay_cuda` on real NVIDIA hardware and switch it over.
- **PGS canvas vs. video size:** `overlay_vaapi` composites at 0,0, identical to the prior software `overlay`; PGS is authored at the video resolution in practice, so no positioning regression is expected, but it's worth an eyeball on a title with an oddly-authored PGS track.
- The two GPU graphs are validated by `ffmpeg` runs on one Intel iHD/QSV host (the production box). Other VAAPI drivers (AMD/older Intel) should be smoke-tested before assuming universal behavior.
- `/dev/shm` at 64M is small; the fix removes the pressure that was tipping it into SIGBUS, but the low limit is worth revisiting separately.
- No existing scope issue cleanly covers this; it was found by direct log analysis of the live deployment. A tracking issue can be filed if wanted (the repro was actually executed — real logs and real `ffmpeg` benchmarks).

## Verification

- `gofmt -l` — clean on both files.
- `go vet ./internal/playback/` — clean.
- `go test ./internal/playback/...` — pass (`ok … 6.096s`); all 9 burn-in tests pass, including the 3 new/updated ones.
- Real `ffmpeg` benchmarks on the production host against the actual starving file produced the table above (before: 0.68× + SIGBUS; after: 7.3–7.7×, stable), with `eof_action=pass` and a 720p downscale target both exercised.

## AI-use disclosure

- Tool(s): Claude Code
- Model(s): claude-opus-4-8[1m]
- Involvement: AI-assisted (human-directed: diagnosis, benchmarking, implementation, and tests by the agent; reviewed and merged by the maintainer)
- Adversarial review: Self-review of the diff checked (1) overlay-before-scale ordering is preserved so subtitle geometry is unchanged; (2) the scale helpers return valid no-scale chains when `TargetResolution` is empty, so an un-scaled 1080p→1080p burn-in still produces a valid graph; (3) `eof_action=pass` is actually accepted by `overlay_vaapi` (confirmed via `-h filter`); (4) NVENC/text/CPU paths are untouched and still covered by tests. Open risk left explicit above: `overlay_cuda` (NVENC) is unverified and intentionally left on the slow path rather than shipped blind.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance Improvements**
  * Improved bitmap subtitle burn-in for VAAPI and QSV hardware-accelerated playback by compositing subtitles directly on the GPU.
  * Reduced unnecessary video frame transfers between GPU and CPU memory, which can improve playback efficiency.

* **Bug Fixes**
  * Preserved the expected CPU-based subtitle overlay behavior for NVENC playback.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->