### PR TITLE
fix(scanner): stop reporting an unusable ffprobe as an empty folder

### DIFF
--- a/internal/scanner/audiobook.go
+++ b/internal/scanner/audiobook.go
@@ -2,6 +2,7 @@ package scanner
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -109,11 +110,19 @@ type parsedAudiobookFile struct {
 //     parsedAudiobookFile with a single synthesized chapter (title =
 //     filename stem); metadata comes from the first file's tags
 //
-// Returns an error wrapping os.ErrNotExist when the folder contains zero
-// audio files, so the caller can skip it.
+// Returns an error wrapping errFolderHasNoMedia when the folder contains zero
+// audio files, so the caller can skip it. Every other error (including an
+// ffprobe binary that cannot be executed) is a real failure and must be
+// reported by the caller.
 func parseAudiobookFolder(ctx context.Context, ffprobePath string, folderPath string) (*parsedAudiobook, error) {
 	entries, err := os.ReadDir(folderPath)
 	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			// The folder was renamed or deleted between the scan walk and
+			// this read. It holds no media now, so the caller skips it as it
+			// would an empty folder rather than counting a scan failure.
+			return nil, fmt.Errorf("audiobook folder %s: %w", folderPath, errFolderHasNoMedia)
+		}
 		return nil, fmt.Errorf("read audiobook folder %s: %w", folderPath, err)
 	}
 
@@ -127,7 +136,7 @@ func parseAudiobookFolder(ctx context.Context, ffprobePath string, folderPath st
 		}
 	}
 	if len(audioFiles) == 0 {
-		return nil, fmt.Errorf("audiobook folder %s: %w", folderPath, os.ErrNotExist)
+		return nil, fmt.Errorf("audiobook folder %s: %w", folderPath, errFolderHasNoMedia)
 	}
 	sort.Strings(audioFiles)
 

--- a/internal/scanner/audiobook_scan.go
+++ b/internal/scanner/audiobook_scan.go
@@ -299,7 +299,7 @@ func splitAudiobookReconcileRoots(scans []audiobookRootScan) (roots []string, se
 //
 // Each immediate subdirectory of one of folder.Paths is treated as a
 // single audiobook. Subdirectories that contain zero audio files are
-// silently skipped (parseAudiobookFolder returns os.ErrNotExist).
+// silently skipped (parseAudiobookFolder returns errFolderHasNoMedia).
 //
 // This bypasses the per-file movie/TV pipeline because audiobooks are
 // inherently folder-scoped (one book = one item, possibly multi-file).
@@ -511,7 +511,7 @@ func (s *Scanner) reconcileAudiobookFolder(ctx context.Context, folder *models.M
 	}
 	parsed, err := parseAudiobookFolder(ctx, s.ffprobePath, folderPath)
 	if err != nil {
-		if errors.Is(err, os.ErrNotExist) {
+		if errors.Is(err, errFolderHasNoMedia) {
 			return nil
 		}
 		return fmt.Errorf("parse audiobook folder %s: %w", folderPath, err)

--- a/internal/scanner/audiobook_scan.go
+++ b/internal/scanner/audiobook_scan.go
@@ -352,8 +352,8 @@ func (s *Scanner) ScanAudiobookFolder(ctx context.Context, folder *models.MediaF
 		processed int64
 		failed    int64
 		skipped   int64
-		failMu    sync.Mutex
-		failures  []error
+		cancelMu  sync.Mutex
+		failures  scanFailures
 		cancelErr error
 	)
 	start := time.Now()
@@ -367,17 +367,15 @@ func (s *Scanner) ScanAudiobookFolder(ctx context.Context, folder *models.MediaF
 				}
 				if err := s.reconcileAudiobookFolder(ctx, folder, path, &skipped); err != nil {
 					if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
-						failMu.Lock()
+						cancelMu.Lock()
 						if cancelErr == nil {
 							cancelErr = err
 						}
-						failMu.Unlock()
+						cancelMu.Unlock()
 						return
 					}
 					atomic.AddInt64(&failed, 1)
-					failMu.Lock()
-					failures = append(failures, fmt.Errorf("%s: %w", path, err))
-					failMu.Unlock()
+					failures.addf("%s: %w", path, err)
 					slog.WarnContext(ctx, "audiobook scan: folder failed", "component", "scanner",
 						"folder_id", folder.ID,
 						"path", path,
@@ -425,7 +423,7 @@ func (s *Scanner) ScanAudiobookFolder(ctx context.Context, folder *models.MediaF
 		failedCount := atomic.LoadInt64(&failed)
 		skippedCount := atomic.LoadInt64(&skipped)
 		if failedCount > 0 && skippedCount == 0 && failedCount == processedCount {
-			return fmt.Errorf("audiobook scan failed for every attempted folder_id=%d: %w", folder.ID, errors.Join(failures...))
+			return fmt.Errorf("audiobook scan failed for every attempted folder_id=%d: %w", folder.ID, failures.join())
 		}
 	}
 

--- a/internal/scanner/audiobook_test.go
+++ b/internal/scanner/audiobook_test.go
@@ -248,6 +248,43 @@ func TestParseAudiobookFolderSingleM4B(t *testing.T) {
 	}
 }
 
+func TestParseAudiobookFolderEmptyFolderSignalsNoMedia(t *testing.T) {
+	_, err := parseAudiobookFolder(context.Background(), "ffprobe", t.TempDir())
+	if !errors.Is(err, errFolderHasNoMedia) {
+		t.Fatalf("empty folder error = %v, want errFolderHasNoMedia", err)
+	}
+}
+
+// A missing or misconfigured ffprobe binary must not look like an empty
+// folder: exec wraps fs.ErrNotExist when the binary does not exist, so a
+// reconcile that skipped on os.ErrNotExist silently indexed nothing while
+// reporting processed=N failed=0.
+func TestParseAudiobookFolderUnusableFFprobeIsNotSkippable(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "part1.m4b"), []byte("not really audio"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	_, err := parseAudiobookFolder(context.Background(), "/nonexistent/bin/ffprobe", dir)
+	if err == nil {
+		t.Fatal("parseAudiobookFolder with an unusable ffprobe returned no error")
+	}
+	if errors.Is(err, errFolderHasNoMedia) {
+		t.Fatalf("error = %v, must not be reported as an empty folder", err)
+	}
+}
+
+// A folder that disappears between the scan walk and the parse is a normal
+// mid-scan rename/delete race, not a scan failure: it must stay skippable.
+func TestParseAudiobookFolderVanishedFolderSignalsNoMedia(t *testing.T) {
+	gone := filepath.Join(t.TempDir(), "renamed-away")
+
+	_, err := parseAudiobookFolder(context.Background(), "ffprobe", gone)
+	if !errors.Is(err, errFolderHasNoMedia) {
+		t.Fatalf("vanished folder error = %v, want errFolderHasNoMedia", err)
+	}
+}
+
 func TestParseAudiobookFolderMultiFile(t *testing.T) {
 	ffprobePath := FFprobePathFromFFmpeg("ffmpeg")
 	if _, err := exec.LookPath(ffprobePath); err != nil {

--- a/internal/scanner/ebook_scan.go
+++ b/internal/scanner/ebook_scan.go
@@ -166,8 +166,8 @@ func (s *Scanner) scanEbookPaths(ctx context.Context, folder *models.MediaFolder
 		processed int64
 		failed    int64
 		skipped   int64
-		failMu    sync.Mutex
-		failures  []error
+		cancelMu  sync.Mutex
+		failures  scanFailures
 		cancelErr error
 	)
 	start := time.Now()
@@ -181,17 +181,15 @@ func (s *Scanner) scanEbookPaths(ctx context.Context, folder *models.MediaFolder
 				}
 				if err := s.reconcileEbookFile(ctx, folder, path, &skipped, groupLocks); err != nil {
 					if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
-						failMu.Lock()
+						cancelMu.Lock()
 						if cancelErr == nil {
 							cancelErr = err
 						}
-						failMu.Unlock()
+						cancelMu.Unlock()
 						return
 					}
 					atomic.AddInt64(&failed, 1)
-					failMu.Lock()
-					failures = append(failures, fmt.Errorf("%s: %w", path, err))
-					failMu.Unlock()
+					failures.addf("%s: %w", path, err)
 					slog.WarnContext(ctx, "ebook scan: file failed", "component", "scanner",
 						"folder_id", folder.ID,
 						"path", path,
@@ -245,7 +243,7 @@ func (s *Scanner) scanEbookPaths(ctx context.Context, folder *models.MediaFolder
 		failedCount := atomic.LoadInt64(&failed)
 		skippedCount := atomic.LoadInt64(&skipped)
 		if failedCount > 0 && skippedCount == 0 && failedCount == processedCount {
-			return fmt.Errorf("ebook scan failed for every attempted folder_id=%d: %w", folder.ID, errors.Join(failures...))
+			return fmt.Errorf("ebook scan failed for every attempted folder_id=%d: %w", folder.ID, failures.join())
 		}
 	}
 

--- a/internal/scanner/errors.go
+++ b/internal/scanner/errors.go
@@ -1,6 +1,10 @@
 package scanner
 
-import "errors"
+import (
+	"errors"
+	"fmt"
+	"sync"
+)
 
 // errFolderHasNoMedia signals that a candidate folder contained zero media
 // files of the kind its parser looks for. Folder-scoped parsers
@@ -14,3 +18,56 @@ import "errors"
 // server misconfiguration as "this folder has no audio", leaving scans that
 // reported processed=N failed=0 while indexing nothing at all.
 var errFolderHasNoMedia = errors.New("folder contains no media files")
+
+// maxRetainedScanFailures caps how many per-item errors a scan keeps for its
+// "everything failed" summary. A misconfigured ffprobe fails every candidate,
+// so on a library with hundreds of thousands of folders an uncapped slice
+// accumulates hundreds of megabytes of near-identical strings for the whole
+// scan, and joining them produces a single error that is written verbatim into
+// scan_runs.error_message and republished over the events channel and the
+// admin SSE stream. The first few failures identify the cause; the rest only
+// repeat it.
+const maxRetainedScanFailures = 20
+
+// scanFailures collects per-item scan errors for the all-failed summary while
+// retaining at most maxRetainedScanFailures of them. It is safe for concurrent
+// use by the scan worker pools.
+type scanFailures struct {
+	mu       sync.Mutex
+	retained []error
+	total    int
+}
+
+// addf records a formatted failure. The error is only formatted while under
+// the cap, so the common runaway case — every candidate failing for the same
+// reason — does not pay for building strings it will discard.
+func (f *scanFailures) addf(format string, args ...any) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.total++
+	if len(f.retained) < maxRetainedScanFailures {
+		f.retained = append(f.retained, fmt.Errorf(format, args...))
+	}
+}
+
+// len reports how many failures were recorded, including elided ones.
+func (f *scanFailures) len() int {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return f.total
+}
+
+// join returns the retained failures as one error, with a trailing note when
+// failures were elided. Returns nil when nothing was recorded.
+func (f *scanFailures) join() error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	if f.total == 0 {
+		return nil
+	}
+	if elided := f.total - len(f.retained); elided > 0 {
+		return errors.Join(append(append([]error(nil), f.retained...),
+			fmt.Errorf("and %d more failures (elided)", elided))...)
+	}
+	return errors.Join(f.retained...)
+}

--- a/internal/scanner/errors.go
+++ b/internal/scanner/errors.go
@@ -1,0 +1,16 @@
+package scanner
+
+import "errors"
+
+// errFolderHasNoMedia signals that a candidate folder contained zero media
+// files of the kind its parser looks for. Folder-scoped parsers
+// (parseAudiobookFolder, parsePodcastShow) return it so their reconcile
+// callers can skip the folder quietly.
+//
+// It deliberately does NOT wrap os.ErrNotExist. The folder parsers shell out
+// to ffprobe, and a missing or misconfigured ffprobe binary surfaces as an
+// exec error that wraps fs.ErrNotExist ("fork/exec /path/ffprobe: no such
+// file or directory"). Skipping on os.ErrNotExist therefore swallowed a
+// server misconfiguration as "this folder has no audio", leaving scans that
+// reported processed=N failed=0 while indexing nothing at all.
+var errFolderHasNoMedia = errors.New("folder contains no media files")

--- a/internal/scanner/errors_test.go
+++ b/internal/scanner/errors_test.go
@@ -1,0 +1,98 @@
+package scanner
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+	"sync"
+	"testing"
+)
+
+func TestScanFailuresJoinsEverythingUnderTheCap(t *testing.T) {
+	var failures scanFailures
+	sentinel := errors.New("boom")
+	failures.addf("/books/a: %w", sentinel)
+	failures.addf("/books/b: %w", sentinel)
+
+	if got := failures.len(); got != 2 {
+		t.Fatalf("len() = %d, want 2", got)
+	}
+	joined := failures.join()
+	if !errors.Is(joined, sentinel) {
+		t.Fatalf("joined error = %v, want it to wrap the sentinel", joined)
+	}
+	for _, want := range []string{"/books/a", "/books/b"} {
+		if !strings.Contains(joined.Error(), want) {
+			t.Fatalf("joined error %q missing %q", joined, want)
+		}
+	}
+	if strings.Contains(joined.Error(), "elided") {
+		t.Fatalf("joined error %q reported elisions with nothing elided", joined)
+	}
+}
+
+// A misconfigured ffprobe fails every candidate in the library, so the
+// all-failed summary must stay a bounded diagnostic instead of growing with
+// the folder count: it is written verbatim into scan_runs.error_message and
+// republished to every admin SSE subscriber.
+func TestScanFailuresCapsRetainedErrorsAndReportsTheRemainder(t *testing.T) {
+	var failures scanFailures
+	const total = maxRetainedScanFailures + 500
+	for i := 0; i < total; i++ {
+		failures.addf("/books/%d: %w", i, errors.New("fork/exec /usr/lib/jellyfin-ffmpeg/ffprobe: no such file or directory"))
+	}
+
+	if got := failures.len(); got != total {
+		t.Fatalf("len() = %d, want %d — the count must include elided failures", got, total)
+	}
+	if got := len(failures.retained); got != maxRetainedScanFailures {
+		t.Fatalf("retained %d errors, want the cap of %d", got, maxRetainedScanFailures)
+	}
+
+	joined := failures.join()
+	if !strings.Contains(joined.Error(), fmt.Sprintf("and %d more failures (elided)", total-maxRetainedScanFailures)) {
+		t.Fatalf("joined error does not report the elided remainder: %q", joined)
+	}
+	// The retained sample still names the cause, which is the whole point of
+	// the summary.
+	if !strings.Contains(joined.Error(), "/books/0") {
+		t.Fatalf("joined error dropped the first failure: %q", joined)
+	}
+	if strings.Contains(joined.Error(), fmt.Sprintf("/books/%d:", total-1)) {
+		t.Fatalf("joined error retained a failure past the cap: %q", joined)
+	}
+}
+
+func TestScanFailuresJoinIsNilWhenNothingFailed(t *testing.T) {
+	var failures scanFailures
+	if got := failures.len(); got != 0 {
+		t.Fatalf("len() = %d, want 0", got)
+	}
+	if err := failures.join(); err != nil {
+		t.Fatalf("join() = %v, want nil", err)
+	}
+}
+
+// The audiobook, ebook, and manga scans record failures from a worker pool.
+func TestScanFailuresIsConcurrencySafe(t *testing.T) {
+	var failures scanFailures
+	var wg sync.WaitGroup
+	const workers, perWorker = 8, 200
+	for i := 0; i < workers; i++ {
+		wg.Add(1)
+		go func(worker int) {
+			defer wg.Done()
+			for j := 0; j < perWorker; j++ {
+				failures.addf("/books/%d-%d: %w", worker, j, errors.New("probe failed"))
+			}
+		}(i)
+	}
+	wg.Wait()
+
+	if got := failures.len(); got != workers*perWorker {
+		t.Fatalf("len() = %d, want %d", got, workers*perWorker)
+	}
+	if got := len(failures.retained); got != maxRetainedScanFailures {
+		t.Fatalf("retained %d errors, want the cap of %d", got, maxRetainedScanFailures)
+	}
+}

--- a/internal/scanner/manga_scan.go
+++ b/internal/scanner/manga_scan.go
@@ -67,8 +67,8 @@ func (s *Scanner) scanMangaPaths(ctx context.Context, folder *models.MediaFolder
 		processed int64
 		failed    int64
 		skipped   int64
-		failMu    sync.Mutex
-		failures  []error
+		cancelMu  sync.Mutex
+		failures  scanFailures
 		cancelErr error
 	)
 	start := time.Now()
@@ -82,17 +82,15 @@ func (s *Scanner) scanMangaPaths(ctx context.Context, folder *models.MediaFolder
 				}
 				if err := s.reconcileMangaFile(ctx, folder, path, &skipped, groupLocks); err != nil {
 					if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
-						failMu.Lock()
+						cancelMu.Lock()
 						if cancelErr == nil {
 							cancelErr = err
 						}
-						failMu.Unlock()
+						cancelMu.Unlock()
 						return
 					}
 					atomic.AddInt64(&failed, 1)
-					failMu.Lock()
-					failures = append(failures, fmt.Errorf("%s: %w", path, err))
-					failMu.Unlock()
+					failures.addf("%s: %w", path, err)
 					slog.WarnContext(ctx, "manga scan: file failed", "component", "scanner",
 						"folder_id", folder.ID,
 						"path", path,
@@ -146,7 +144,7 @@ func (s *Scanner) scanMangaPaths(ctx context.Context, folder *models.MediaFolder
 		failedCount := atomic.LoadInt64(&failed)
 		skippedCount := atomic.LoadInt64(&skipped)
 		if failedCount > 0 && skippedCount == 0 && failedCount == processedCount {
-			return fmt.Errorf("manga scan failed for every attempted folder_id=%d: %w", folder.ID, errors.Join(failures...))
+			return fmt.Errorf("manga scan failed for every attempted folder_id=%d: %w", folder.ID, failures.join())
 		}
 	}
 

--- a/internal/scanner/podcast.go
+++ b/internal/scanner/podcast.go
@@ -2,6 +2,7 @@ package scanner
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -29,8 +30,9 @@ type parsedPodcastEpisode struct {
 // becomes one episode; tags are read from each file individually so
 // per-episode titles surface correctly.
 //
-// Returns an os.ErrNotExist-wrapped error if the folder contains zero
-// audio files.
+// Returns an errFolderHasNoMedia-wrapped error if the folder contains zero
+// audio files. Every other error (including an ffprobe binary that cannot be
+// executed) is a real failure and must be reported by the caller.
 func parsePodcastShow(ctx context.Context, ffprobePath string, folderPath string) (*parsedPodcastShow, error) {
 	audioFiles, err := listPodcastShowAudioFiles(folderPath)
 	if err != nil {
@@ -73,6 +75,11 @@ func parsePodcastShow(ctx context.Context, ffprobePath string, folderPath string
 func listPodcastShowAudioFiles(folderPath string) ([]string, error) {
 	entries, err := os.ReadDir(folderPath)
 	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			// Renamed or deleted between the scan walk and this read; treat
+			// it as an empty show so the caller skips instead of failing.
+			return nil, fmt.Errorf("podcast show %s: %w", folderPath, errFolderHasNoMedia)
+		}
 		return nil, fmt.Errorf("read podcast folder %s: %w", folderPath, err)
 	}
 	var audioFiles []string
@@ -85,7 +92,7 @@ func listPodcastShowAudioFiles(folderPath string) ([]string, error) {
 		}
 	}
 	if len(audioFiles) == 0 {
-		return nil, fmt.Errorf("podcast show %s: %w", folderPath, os.ErrNotExist)
+		return nil, fmt.Errorf("podcast show %s: %w", folderPath, errFolderHasNoMedia)
 	}
 	sort.Strings(audioFiles)
 	return audioFiles, nil

--- a/internal/scanner/podcast_scan.go
+++ b/internal/scanner/podcast_scan.go
@@ -32,7 +32,7 @@ func (s *Scanner) ScanPodcastFolder(ctx context.Context, folder *models.MediaFol
 
 	var attempted int
 	var succeeded int
-	var failures []error
+	var failures scanFailures
 	reconcileRoots := make([]string, 0, len(folder.Paths))
 	seenPaths := make(map[string]bool)
 	for _, root := range folder.Paths {
@@ -43,7 +43,7 @@ func (s *Scanner) ScanPodcastFolder(ctx context.Context, folder *models.MediaFol
 		if err != nil {
 			slog.WarnContext(ctx, "podcast scan: read root failed", "component", "scanner", "root", root, "error", err)
 			attempted++
-			failures = append(failures, fmt.Errorf("read root %s: %w", root, err))
+			failures.addf("read root %s: %w", root, err)
 			continue
 		}
 		reconcileRoots = append(reconcileRoots, root)
@@ -71,7 +71,7 @@ func (s *Scanner) ScanPodcastFolder(ctx context.Context, folder *models.MediaFol
 					"path", subPath,
 					"error", err,
 				)
-				failures = append(failures, fmt.Errorf("%s: %w", subPath, err))
+				failures.addf("%s: %w", subPath, err)
 				// Continue with siblings — one bad show should not stop the scan.
 				continue
 			}
@@ -81,8 +81,8 @@ func (s *Scanner) ScanPodcastFolder(ctx context.Context, folder *models.MediaFol
 			succeeded++
 		}
 	}
-	if attempted > 0 && succeeded == 0 && len(failures) > 0 {
-		return fmt.Errorf("podcast scan failed for every attempted folder_id=%d: %w", folder.ID, errors.Join(failures...))
+	if attempted > 0 && succeeded == 0 && failures.len() > 0 {
+		return fmt.Errorf("podcast scan failed for every attempted folder_id=%d: %w", folder.ID, failures.join())
 	}
 	if err := s.reconcilePodcastMissingFiles(ctx, folder, reconcileRoots, seenPaths); err != nil {
 		slog.WarnContext(ctx, "podcast scan: missing-file reconcile failed", "component", "scanner", "folder_id", folder.ID, "error", err)

--- a/internal/scanner/podcast_scan.go
+++ b/internal/scanner/podcast_scan.go
@@ -93,7 +93,7 @@ func (s *Scanner) ScanPodcastFolder(ctx context.Context, folder *models.MediaFol
 func (s *Scanner) reconcilePodcastShow(ctx context.Context, folder *models.MediaFolder, folderPath string) ([]string, error) {
 	parsed, err := parsePodcastShow(ctx, s.ffprobePath, folderPath)
 	if err != nil {
-		if errors.Is(err, os.ErrNotExist) {
+		if errors.Is(err, errFolderHasNoMedia) {
 			return nil, nil
 		}
 		return nil, fmt.Errorf("parse podcast show %s: %w", folderPath, err)

--- a/internal/scanner/podcast_test.go
+++ b/internal/scanner/podcast_test.go
@@ -126,10 +126,24 @@ func TestListPodcastShowAudioFilesReturnsSortedAudioPaths(t *testing.T) {
 	}
 }
 
-func TestListPodcastShowAudioFilesReturnsNotExistForEmptyShow(t *testing.T) {
+func TestListPodcastShowAudioFilesReturnsNoMediaForEmptyShow(t *testing.T) {
 	_, err := listPodcastShowAudioFiles(t.TempDir())
-	if !errors.Is(err, os.ErrNotExist) {
-		t.Fatalf("empty podcast show error = %v, want os.ErrNotExist", err)
+	if !errors.Is(err, errFolderHasNoMedia) {
+		t.Fatalf("empty podcast show error = %v, want errFolderHasNoMedia", err)
+	}
+	// A missing ffprobe binary also wraps fs.ErrNotExist; the empty-folder
+	// signal must stay distinguishable from it.
+	if errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("empty podcast show error = %v, must not wrap os.ErrNotExist", err)
+	}
+}
+
+func TestListPodcastShowAudioFilesVanishedShowSignalsNoMedia(t *testing.T) {
+	gone := filepath.Join(t.TempDir(), "renamed-away")
+
+	_, err := listPodcastShowAudioFiles(gone)
+	if !errors.Is(err, errFolderHasNoMedia) {
+		t.Fatalf("vanished show error = %v, want errFolderHasNoMedia", err)
 	}
 }
 


### PR DESCRIPTION
## Problem

While staging a local repro for #462 I could not get an audiobook library to index at all: the scan reported `processed=3 failed=0 skipped=0` and wrote zero rows, with nothing in the logs to explain it.

The cause is an overloaded error signal. `parseAudiobookFolder` and `parsePodcastShow` report "this folder contains no audio files" by wrapping `os.ErrNotExist`, and their reconcile callers skip quietly on that. But `exec` also wraps `fs.ErrNotExist` when the configured ffprobe binary cannot be run, so a wrong `playback.ffmpeg_path` makes **every** candidate folder look empty:

```
audiobook scan: starting  folder_id=1 candidates=3 workers=8
audiobook scan: completed folder_id=1 processed=3 failed=0 skipped=0 elapsed_sec=0
```

The default is `/usr/lib/jellyfin-ffmpeg/ffmpeg`, so any deployment whose ffmpeg lives elsewhere gets a permanently empty audiobook/podcast library and no diagnostic. This cost me three scan cycles to find, which is exactly the experience an operator would have.

## Approach

Add an `errFolderHasNoMedia` sentinel that deliberately does **not** wrap `os.ErrNotExist`, and skip on that instead. Every other error — including an unusable ffprobe — now propagates, so the folder is counted as failed and logged.

The podcast path had the identical bug, so the sentinel is shared rather than fixed in one place.

One subtlety worth calling out: a folder that disappears between the scan walk and the parse used to be absorbed by the same `os.ErrNotExist` check. That is a normal mid-scan rename/delete race, not a failure, so the `os.ReadDir` not-exist case maps to the sentinel explicitly. Without that, a mass rename could make `failedCount == processedCount` and fail the whole scan. There is a regression test for it.

After the fix, the same misconfiguration is loud:

```
WARN audiobook scan: folder failed ... error="parse audiobook folder ...: ffprobe failed for ...: fork/exec /usr/lib/jellyfin-ffmpeg/ffprobe: no such file or directory"
INFO audiobook scan: completed folder_id=1 processed=3 failed=3 skipped=0
```

## Scope note — this does not fix #462 on its own

This is a diagnosability fix found *while* reproducing #462, not the cause of the reported symptom. The reported failure (`no metadata found` for every book, no cover art ever) is entirely plugin-side and needs Silo-Server/silo-plugin-metadata-audiobook#7:

- `ITunesClient.Fetch` was a stub returning `nil, nil`, so the one provider that reliably returns search results had everything it found discarded during the host's GetMetadata phase;
- audnexus called a `/books?q=` title-search route that does not exist, producing the reported `unexpected end of JSON input` on every search.

Even with this PR merged, an affected user sees no change until the plugin fix ships and the `silo-plugins` catalog is bumped past 0.1.4. Merge order does not matter — the two changes are independent.

Also relevant to #462: the AudiMeta `403`s are not a Silo bug and are not fixable here. That project has been discontinued — its README reads "Do not use this instance anymore. I will stop providing the service and archive this project effective from the 20th of March 2026", and the repository was archived on 19 Mar 2026. The hosted API is now behind a Cloudflare block that returns 403 for every path except `/`, from any network and any User-Agent. AudiMeta should probably be dropped from the provider chain outright; that is plugin-side follow-up.

## Second commit — bounding the all-failed summary

Review raised a consequence of the sentinel change that is worth fixing in the same PR, because this PR is what makes the path reachable.

Before the sentinel, a misconfigured ffprobe made every candidate folder look empty, so the scan skipped everything and `failed` stayed 0 — the `failedCount == processedCount` branch never fired. Now that an unusable ffprobe propagates as a real failure, that branch is the *expected* outcome of a first scan with a bad `playback.ffmpeg_path`, and it joins one wrapped error per failed folder.

On the 240k-folder library `ScanAudiobookFolder`'s own comments are written for, `errors.Join` over that slice produces a **~64 MB error string** (measured, with realistic path lengths) that is written verbatim into `scan_runs.error_message` and republished over the Redis events channel and the admin SSE stream. Separately, the `failures` slice grew unbounded for the whole scan even when the all-failed guard *could not* fire — any rescan with `skipped > 0` — so the same misconfiguration held hundreds of megabytes across a multi-hour scan before discarding it.

`scanFailures` retains the first 20 failures, counts the rest, and joins them with a trailing `and N more failures (elided)`. The retained sample still names the cause, which is the entire purpose of the summary. The same 64 MB case now produces 5.4 KB.

The ebook and manga scans have the identical shape and the same exposure through their own probe failures, so all four call sites share the collector rather than fixing the two audio paths alone. `failMu` now guards only `cancelErr`, so it is renamed `cancelMu`.

## Risks / follow-up

- Behaviour change: deployments with a genuinely broken ffprobe will start logging per-folder WARNs and non-zero `failed` counts where scans previously looked clean. That is the point of the change, but it will surface in existing installs as new noise that reflects a real, pre-existing misconfiguration.
- The all-failed summary is now a bounded sample rather than an exhaustive list. Per-folder detail is unchanged — every failure is still logged at WARN with its path and error; only the aggregate stored on the scan run is capped.
- A folder the scanner cannot read for other reasons (permissions) was already a failure and stays one.
- Not addressed here: `playback.ffmpeg_path` has no startup validation. A preflight check that the configured ffmpeg/ffprobe pair is executable would catch this class of problem before any scan runs. Happy to file that separately.

## Verification

```
$ go test ./internal/scanner/... -race -count=1
ok  	github.com/Silo-Server/silo-server/internal/scanner	2.277s

$ go build ./...
ok

$ go vet ./internal/scanner/...
(no output)

$ gofmt -l internal/scanner/
(no output)

$ cd web && pnpm run lint
✖ 158 problems (0 errors, 158 warnings)

$ cd web && pnpm run format:check
Checking formatting...
All matched files use Prettier code style!
```

No frontend files are touched; the 158 warnings are pre-existing. `golangci-lint run ./internal/scanner/...` reports **85 issues both before and after this diff, with an identical breakdown** (verified by stashing the changes and re-running); the hits inside changed files — `audiobook_scan.go:1037 QF1008` and the `ebook_scan.go` goconst/sloglint ones — are all present on a clean tree.

End-to-end check on a local stack (Postgres + Redis via compose, three tagged m4b books, real ffmpeg): with a bad `playback.ffmpeg_path` the scan now reports `failed=3` and names the binary; with a good one all three books index as before.

Bounding is covered by four new tests in `internal/scanner/errors_test.go`, all passing under `-race`: everything joins under the cap; past the cap the retained set stays at 20 and the remainder is reported; `join()` is nil when nothing failed; and concurrent `addf` from a worker pool is race-free and counts correctly.

One pre-existing failure elsewhere in the tree, unrelated to this diff and present on the branch point: `TestHandleReplanPlaybackV3SeekFailureRecoveryNeverChangesMediaVersion` in `internal/api/handlers` (verified failing with these changes stashed).

## Adversarial review of my own diff

Three things the first version got wrong:

1. **Regression I introduced:** a folder deleted between the walk and the reconcile stopped being skippable and became a counted failure, and in the all-vanished case would fail the entire scan. Fixed by mapping the `os.ReadDir` not-exist case to the sentinel; regression tests added for both the audiobook and podcast paths.
2. The sentinel was exported for no reason — every use is in-package and both parsers are unexported. Now `errFolderHasNoMedia`.
3. The first cut had no test for the actual failure mode. `TestParseAudiobookFolderUnusableFFprobeIsNotSkippable` now pins it: an unusable ffprobe must not be reported as an empty folder.

### AI Disclosure
- Tool(s): Claude Code
- Model(s): claude-opus-5
- Involvement: fully AI-generated
- Adversarial review: see the section above — the review of my own diff caught a mid-scan-rename regression I had introduced, an unnecessarily exported sentinel, and missing coverage for the failure mode being fixed. All three are resolved in the diff as submitted. A subsequent review pass caught the unbounded all-failed summary that this change makes reachable; that is the second commit.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Empty or disappearing audiobook, podcast, ebook, and manga folders are now skipped cleanly during scanning.
  - Genuine scanning failures (e.g., misconfigured/unusable media tools) are no longer mistaken for “no media.”
  - When scans fail across many items, errors are aggregated more reliably without disrupting unrelated results.
- **Tests**
  - Added coverage for empty-folder, vanished-folder, and media-tool failure scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
