### PR TITLE
fix(requests): retire stalled targets when presence confirms the media

### DIFF
--- a/internal/requests/service.go
+++ b/internal/requests/service.go
@@ -1557,17 +1557,24 @@ func (s *Service) reconcileRequest(ctx context.Context, req Request, fc *fulfill
 		// orphan in-progress downloads. Only take the shortcut for legacy/no-live
 		// -target requests; otherwise let per-target reconcile + aggregate drive
 		// completion.
-		hasLiveTargets, err := s.hasLiveTargets(ctx, req.ID)
+		live, err := s.liveTargets(ctx, req.ID)
 		if err != nil {
 			return reconcileUnchanged, err
 		}
-		if !hasLiveTargets {
+		if len(live) == 0 {
 			if req.Status == StatusCompleted {
 				return reconcileUnchanged, nil
 			}
 			if _, err := s.store.SetStatus(ctx, req.ID, StatusCompleted, Viewer{}); err != nil {
 				return reconcileUnchanged, err
 			}
+			return reconcileCompleted, nil
+		}
+		updated, retired, err := s.retireStalledTargets(ctx, req, live)
+		if err != nil {
+			return reconcileUnchanged, err
+		}
+		if retired && updated != nil && updated.Status == StatusCompleted {
 			return reconcileCompleted, nil
 		}
 	}
@@ -1654,19 +1661,67 @@ func (s *Service) reconcileRequest(ctx context.Context, req Request, fc *fulfill
 	return change, nil
 }
 
-// hasLiveTargets reports whether the request has any non-terminal (queued or
-// downloading) fulfillment target.
-func (s *Service) hasLiveTargets(ctx context.Context, requestID string) (bool, error) {
+// liveTargets returns the request's non-terminal (queued or downloading)
+// fulfillment targets.
+func (s *Service) liveTargets(ctx context.Context, requestID string) ([]Target, error) {
 	targets, err := s.store.ListTargets(ctx, requestID)
 	if err != nil {
-		return false, err
+		return nil, err
 	}
+	var live []Target
 	for _, t := range targets {
 		if t.Status == StatusQueued || t.Status == StatusDownloading {
-			return true, nil
+			live = append(live, t)
 		}
 	}
-	return false, nil
+	return live, nil
+}
+
+// stalledTargetHorizon is how long a queued target may go without a single
+// status transition before presence-confirmed media is allowed to retire it.
+// Reconciliation runs on a schedule measured in minutes and only writes on a
+// real status change, so a target older than this has had many chances to move
+// and has not.
+const stalledTargetHorizon = 24 * time.Hour
+
+// retireStalledTargets is the backstop for a router that never reports
+// completion. The presence shortcut in reconcileRequest stays disabled for as
+// long as any target looks live, so a router that reports "queued" forever — a
+// buggy plugin, a connection pointing at an instance that no longer tracks the
+// item — pins the request open permanently even though the media is sitting in
+// the library.
+//
+// Targets that are actively downloading are never retired: those are exactly
+// the in-flight downloads the quality-agnostic presence check must not orphan.
+// Only targets stuck in queued past the horizon are closed out, and the request
+// status follows from the usual target aggregate. It returns the request as of
+// the last retirement, if any.
+func (s *Service) retireStalledTargets(ctx context.Context, req Request, live []Target) (*Request, bool, error) {
+	cutoff := s.now().Add(-stalledTargetHorizon)
+	var updated *Request
+	retired := false
+	for _, t := range live {
+		if t.Status != StatusQueued || t.UpdatedAt.After(cutoff) {
+			continue
+		}
+		next, err := s.store.UpdateTargetStatus(ctx, t.ID, StatusCompleted, "", "presence_confirmed", "", Viewer{})
+		if err != nil {
+			return updated, retired, err
+		}
+		updated, retired = next, true
+		slog.WarnContext(ctx, "requests: retired stalled target on presence", "component", "requests",
+			"request_id", req.ID,
+			"target_id", t.ID,
+			"media_type", req.MediaType,
+			"tmdb_id", req.TMDBID,
+			"quality", t.Quality,
+			"integration_kind", t.IntegrationKind,
+			"external_id", t.ExternalID,
+			"external_status", t.ExternalStatus,
+			"target_updated_at", t.UpdatedAt,
+		)
+	}
+	return updated, retired, nil
 }
 
 func (s *Service) requestAvailable(ctx context.Context, req Request) (bool, error) {

--- a/internal/requests/service.go
+++ b/internal/requests/service.go
@@ -1684,6 +1684,11 @@ func (s *Service) liveTargets(ctx context.Context, requestID string) ([]Target, 
 // and has not.
 const stalledTargetHorizon = 24 * time.Hour
 
+// ExternalStatusPresenceConfirmed marks a target closed out by the presence
+// backstop rather than by a router-reported completion. Exported so clients can
+// distinguish "the arr said it finished" from "we found the media ourselves".
+const ExternalStatusPresenceConfirmed = "presence_confirmed"
+
 // retireStalledTargets is the backstop for a router that never reports
 // completion. The presence shortcut in reconcileRequest stays disabled for as
 // long as any target looks live, so a router that reports "queued" forever — a
@@ -1704,7 +1709,7 @@ func (s *Service) retireStalledTargets(ctx context.Context, req Request, live []
 		if t.Status != StatusQueued || t.UpdatedAt.After(cutoff) {
 			continue
 		}
-		next, err := s.store.UpdateTargetStatus(ctx, t.ID, StatusCompleted, "", "presence_confirmed", "", Viewer{})
+		next, err := s.store.UpdateTargetStatus(ctx, t.ID, StatusCompleted, "", ExternalStatusPresenceConfirmed, "", Viewer{})
 		if err != nil {
 			return updated, retired, err
 		}

--- a/internal/requests/service_test.go
+++ b/internal/requests/service_test.go
@@ -829,6 +829,90 @@ func TestReconcileRequestsCompletesByStoredTVDBID(t *testing.T) {
 	}
 }
 
+// seedStalledPresenceRequest builds a presence-available request carrying one
+// live target whose last status transition was `age` ago.
+func seedStalledPresenceRequest(t *testing.T, status Status, age time.Duration) (*fakeStore, *Service, time.Time) {
+	t.Helper()
+	now := time.Date(2026, 7, 25, 12, 0, 0, 0, time.UTC)
+	store := newFakeStore()
+	req := &Request{ID: "req-1", MediaType: MediaTypeMovie, TMDBID: 550, Status: StatusQueued, Outcome: OutcomeActive}
+	store.candidates = []*Request{req}
+	store.requests["req-1"] = req
+	if _, err := store.CreateTarget(context.Background(), Target{
+		RequestID: "req-1", IntegrationID: "router-1", IntegrationKind: "radarr",
+		Quality: Quality1080p, Status: status, ExternalID: "123", ExternalStatus: "queued",
+		UpdatedAt: now.Add(-age),
+	}); err != nil {
+		t.Fatalf("seed target: %v", err)
+	}
+	service := NewService(store, &fakeTMDBClient{}, &fakePresence{available: map[MediaType]map[int]bool{
+		MediaTypeMovie: {550: true},
+	}})
+	service.Now = func() time.Time { return now }
+	return store, service, now
+}
+
+// A router that never reports completion would otherwise pin the request open
+// forever, because the presence shortcut stays disabled while a target is live.
+func TestReconcileRequestsRetiresStalledQueuedTargetOnPresence(t *testing.T) {
+	store, service, _ := seedStalledPresenceRequest(t, StatusQueued, 48*time.Hour)
+
+	result, err := service.ReconcileRequests(context.Background(), 100)
+	if err != nil {
+		t.Fatalf("ReconcileRequests returned error: %v", err)
+	}
+	if result.Completed != 1 {
+		t.Fatalf("result = %+v, want one completed", result)
+	}
+	targets, _ := store.ListTargets(context.Background(), "req-1")
+	if len(targets) != 1 || targets[0].Status != StatusCompleted {
+		t.Fatalf("targets = %+v, want the stalled target completed", targets)
+	}
+	if targets[0].ExternalStatus != "presence_confirmed" {
+		t.Fatalf("external status = %q, want presence_confirmed", targets[0].ExternalStatus)
+	}
+	if store.requests["req-1"].Status != StatusCompleted {
+		t.Fatalf("request status = %q, want completed", store.requests["req-1"].Status)
+	}
+}
+
+// Inside the horizon the router still owns the target — presence must not
+// short-circuit a submission that may simply be young.
+func TestReconcileRequestsKeepsRecentQueuedTargetOnPresence(t *testing.T) {
+	store, service, _ := seedStalledPresenceRequest(t, StatusQueued, time.Hour)
+
+	result, err := service.ReconcileRequests(context.Background(), 100)
+	if err != nil {
+		t.Fatalf("ReconcileRequests returned error: %v", err)
+	}
+	if result.Completed != 0 {
+		t.Fatalf("result = %+v, want nothing completed", result)
+	}
+	targets, _ := store.ListTargets(context.Background(), "req-1")
+	if targets[0].Status != StatusQueued {
+		t.Fatalf("target status = %q, want queued", targets[0].Status)
+	}
+}
+
+// The presence check is quality-agnostic, so a 2160p target still downloading
+// against an already-present 1080p copy must never be retired out from under
+// the in-flight download.
+func TestReconcileRequestsNeverRetiresDownloadingTargetOnPresence(t *testing.T) {
+	store, service, _ := seedStalledPresenceRequest(t, StatusDownloading, 30*24*time.Hour)
+
+	result, err := service.ReconcileRequests(context.Background(), 100)
+	if err != nil {
+		t.Fatalf("ReconcileRequests returned error: %v", err)
+	}
+	if result.Completed != 0 {
+		t.Fatalf("result = %+v, want nothing completed", result)
+	}
+	targets, _ := store.ListTargets(context.Background(), "req-1")
+	if targets[0].Status != StatusDownloading {
+		t.Fatalf("target status = %q, want downloading left alone", targets[0].Status)
+	}
+}
+
 func TestReconcileRequestsMarksDownloadingFromProvider(t *testing.T) {
 	store := newFakeStore()
 	store.integrations = []Integration{routerInst("router-1")}

--- a/internal/requests/service_test.go
+++ b/internal/requests/service_test.go
@@ -868,8 +868,8 @@ func TestReconcileRequestsRetiresStalledQueuedTargetOnPresence(t *testing.T) {
 	if len(targets) != 1 || targets[0].Status != StatusCompleted {
 		t.Fatalf("targets = %+v, want the stalled target completed", targets)
 	}
-	if targets[0].ExternalStatus != "presence_confirmed" {
-		t.Fatalf("external status = %q, want presence_confirmed", targets[0].ExternalStatus)
+	if targets[0].ExternalStatus != ExternalStatusPresenceConfirmed {
+		t.Fatalf("external status = %q, want %s", targets[0].ExternalStatus, ExternalStatusPresenceConfirmed)
 	}
 	if store.requests["req-1"].Status != StatusCompleted {
 		t.Fatalf("request status = %q, want completed", store.requests["req-1"].Status)
@@ -910,6 +910,42 @@ func TestReconcileRequestsNeverRetiresDownloadingTargetOnPresence(t *testing.T) 
 	targets, _ := store.ListTargets(context.Background(), "req-1")
 	if targets[0].Status != StatusDownloading {
 		t.Fatalf("target status = %q, want downloading left alone", targets[0].Status)
+	}
+}
+
+// Partial retirement: the stalled quality is closed out while a sibling target
+// that is genuinely downloading keeps the request open.
+func TestReconcileRequestsRetiresStalledQueuedWhileDownloadingStaysOpen(t *testing.T) {
+	store, service, now := seedStalledPresenceRequest(t, StatusQueued, 48*time.Hour)
+	if _, err := store.CreateTarget(context.Background(), Target{
+		RequestID: "req-1", IntegrationID: "router-1", IntegrationKind: "radarr",
+		Quality: Quality2160p, Status: StatusDownloading, ExternalID: "456", ExternalStatus: "downloading",
+		UpdatedAt: now,
+	}); err != nil {
+		t.Fatalf("seed target: %v", err)
+	}
+
+	result, err := service.ReconcileRequests(context.Background(), 100)
+	if err != nil {
+		t.Fatalf("ReconcileRequests returned error: %v", err)
+	}
+	if result.Completed != 0 {
+		t.Fatalf("result = %+v, want nothing completed while a download is in flight", result)
+	}
+
+	targets, _ := store.ListTargets(context.Background(), "req-1")
+	byQuality := map[Quality]Target{}
+	for _, t := range targets {
+		byQuality[t.Quality] = t
+	}
+	if got := byQuality[Quality1080p]; got.Status != StatusCompleted || got.ExternalStatus != ExternalStatusPresenceConfirmed {
+		t.Fatalf("1080p target = %+v, want completed via presence", got)
+	}
+	if got := byQuality[Quality2160p]; got.Status != StatusDownloading {
+		t.Fatalf("2160p target = %+v, want left downloading", got)
+	}
+	if store.requests["req-1"].Status != StatusDownloading {
+		t.Fatalf("request status = %q, want downloading (the live target keeps it open)", store.requests["req-1"].Status)
 	}
 }
 


### PR DESCRIPTION
## Problem

`reconcileRequest` will complete a request whose media presence-checks as available, but only
when `!hasLiveTargets`. That gate is deliberate and correct: the presence check is
quality-agnostic (TMDB id only), so completing a request with a live target could orphan a
2160p download that is still in flight behind an already-present 1080p copy.

The gate assumes the router eventually drives every target to a terminal state. When it does
not, the request is pinned open permanently. That is not hypothetical — the arr plugin could
never report completion at all (Silo-Server/silo-server#469, fixed in
Silo-Community/silo-plugins-requests-arr#5), so on this deployment 49 requests sat `active`/`queued`,
24 of them already in the library, with reconcile logging `completed: 0` every 30 minutes.

The plugin fix addresses the cause. This PR is the backstop, so no future router bug can
silently pin requests open again.

Part of #469

## Approach

When presence confirms the media and live targets exist, retire targets that have sat in
`queued` past a 24h horizon without a single status transition, then let the existing target
aggregate (`aggregateStatus`) derive the request status rather than force-setting it.

Two deliberate constraints keep the original orphan protection intact:

- **`downloading` targets are never retired.** Those are exactly the in-flight downloads the
  gate exists to protect. Only `queued` is eligible.
- **The horizon reads real transitions.** `UpdateTargetStatus` is only called when the status
  actually changes, so `updated_at` means "last real transition", not "last poll". A target
  older than 24h has had ~48 reconcile passes to move and has not.

Retirements log at WARN with the target's identity and age — reaching this path means a router
is misbehaving, and that should be visible rather than silently healed. `hasLiveTargets` becomes
`liveTargets` so the caller can inspect them.

## Verification

```
$ go test ./internal/requests/...
ok  	github.com/Silo-Server/silo-server/internal/requests	0.016s
ok  	github.com/Silo-Server/silo-server/internal/requests/arrclient	0.016s

$ make verify-local-paths
scripts/check-local-path-leaks.sh          # exit 0

$ cd web && pnpm run lint && pnpm run format:check
✖ 158 problems (0 errors, 158 warnings)    # pre-existing warnings, 0 errors
All matched files use Prettier code style!
```

`make lint` currently fails on `main` in this repo with a large body of pre-existing findings
(`misspell: 50`, `unused: 50`, `staticcheck: 49`, …), so a bare pass/fail says nothing. Instead I
diffed the findings for the touched files with and without this diff:

```
$ diff <lint before> <lint after>
< string `radarr` has 16 occurrences ...      > string `radarr` has 17 occurrences ...
< string `req-1` has 18 occurrences ...       > string `req-1` has 20 occurrences ...
< string `queued` has 4 occurrences ...       > string `queued` has 5 occurrences ...
```

No new findings — only occurrence counts on pre-existing `goconst` warnings in the test file.
No `sloglint` finding on the new log call.

New tests: a stalled queued target is retired and the request completes with
`external_status = presence_confirmed`; a target inside the horizon is left alone; a
`downloading` target stalled 30 days is never retired.

**Live validation.** Deployed after the plugin fix, so the two paths are distinguishable by
`external_status`:

```
 integration_kind |  external_status   |  status   | count
------------------+--------------------+-----------+-------
 radarr           | imported           | completed |    20     <- plugin fix
 radarr           | presence_confirmed | completed |    12     <- this PR
 sonarr           | presence_confirmed | completed |     2     <- this PR
```

14 WARN lines were emitted, one per retirement, e.g.:

```
level=WARN msg="requests: retired stalled target on presence" component=requests
request_id=129112453467340804 target_id=23 media_type=movie tmdb_id=1273221 quality=1080p
integration_kind=radarr external_id=33757 external_status=not_in_queue
target_updated_at=2026-07-23T15:28:17.065Z
```

Requests in the library but still `active` went 24 → 0, and the originally reported request
(`tmdb 1228710`) now reads `completed`. Subsequent passes are stable — no churn, no
re-completion.

## Risks

- The 24h horizon is a package constant, not a setting. Deliberate: adding a tunable means a
  migration plus admin surface for a backstop that should rarely fire. Easy to promote later.
- A request whose media is present at one quality while a *queued* (not downloading) target for
  another quality is genuinely still waiting on an indexer for >24h will be completed early. The
  alternative — leaving requests pinned open forever — is worse, and `downloading` targets are
  exempt, but this is the trade-off worth a maintainer's eye.
- One observed request now reads `queued`/`outcome=failed` with a retired 1080p target and a
  pre-existing failed 2160p target. That is `aggregateStatus`'s documented completed+failed
  behaviour (surface as failed so Retry can re-submit), not a regression from this change.

### AI Disclosure
- Tool(s): Claude Code
- Model(s): claude-opus-5[1m]
- Involvement: AI-assisted (investigation, patch, tests), human-directed
- Adversarial review: the main risk I chased was whether retiring a target could make
  `submitApprovedRequest` re-submit a duplicate for the same quality. It cannot — that path
  builds a `healthy` map and skips any quality with a non-failed target, and a retired target is
  `completed`. I also rejected an earlier design that keyed the horizon off request `updated_at`:
  it would have broken the moment reconcile started refreshing rows on unchanged polls, whereas
  target `updated_at` only advances on a real transition.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved request completion handling when media presence confirms availability.
  * Queued/stalled targets older than the 24-hour horizon are now retired and marked completed (with presence-confirmed external status).
  * Targets currently downloading are preserved and not prematurely completed.
  * Requests with multiple targets now complete only the stalled queued portion while any active downloading target remains in progress.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->