### PR TITLE
feat(settings): add the canonical contract manifest and validator

### DIFF
--- a/contracts/settings/v1/embed.go
+++ b/contracts/settings/v1/embed.go
@@ -1,0 +1,18 @@
+// Package settingsv1 embeds the canonical cross-platform user settings
+// contract so the server binary carries the exact bytes it was built from.
+//
+// This package deliberately contains nothing but the embed directive. The
+// contract files are the artifact clients vendor and generate bindings from, so
+// they live at this stable path rather than inside an internal package; the
+// embed has to sit beside them because go:embed cannot reach outside its own
+// directory.
+//
+// Loading, validation, and lookup live in internal/settingscontract.
+package settingsv1
+
+import "embed"
+
+// FS holds manifest.json, manifest.schema.json, and schemas/.
+//
+//go:embed manifest.json manifest.schema.json schemas
+var FS embed.FS

--- a/contracts/settings/v1/manifest.json
+++ b/contracts/settings/v1/manifest.json
@@ -1,0 +1,675 @@
+{
+  "api_version": 1,
+  "revision": 1,
+  "definitions": [
+    {
+      "key": "playback.audio_language",
+      "introduced_in": 1,
+      "persistence": "remote",
+      "allowed_scopes": ["profile", "profile_device", "profile_library", "profile_series"],
+      "resolution_order": [
+        "profile_series",
+        "profile_library",
+        "profile_device",
+        "profile",
+        "default"
+      ],
+      "value_schema": { "type": "language_tag", "nullable": true },
+      "default_value": null,
+      "category": "playback",
+      "label": "Preferred audio language",
+      "description": "Choose which spoken language Silo should prefer first.",
+      "recommended_control": "select",
+      "notes": "Migrates user_profiles.language as the roaming fallback. Existing user_device_settings values become real overrides, and the per-series value comes from AudioPreference.audio_language. AudioPreference.audio_track_index and track_signature stay specialized: they identify a concrete track, not a default."
+    },
+    {
+      "key": "playback.subtitle_language",
+      "introduced_in": 1,
+      "persistence": "remote",
+      "allowed_scopes": ["profile", "profile_device", "profile_library", "profile_series"],
+      "resolution_order": [
+        "profile_series",
+        "profile_library",
+        "profile_device",
+        "profile",
+        "default"
+      ],
+      "value_schema": { "type": "language_tag", "nullable": true },
+      "default_value": null,
+      "category": "playback",
+      "label": "Preferred subtitle language",
+      "description": "Choose which subtitle language Silo should prefer first.",
+      "recommended_control": "select",
+      "notes": "Migrates user_profiles.subtitle_language, LibraryPlaybackPreference.subtitle_language, and SubtitlePreference.subtitle_language. SubtitlePreference.subtitle_track_index, external_subtitle_path, and track_signature stay specialized."
+    },
+    {
+      "key": "playback.subtitle_mode",
+      "introduced_in": 1,
+      "persistence": "remote",
+      "allowed_scopes": ["profile", "profile_device", "profile_library", "profile_series"],
+      "resolution_order": [
+        "profile_series",
+        "profile_library",
+        "profile_device",
+        "profile",
+        "default"
+      ],
+      "value_schema": {
+        "type": "enum",
+        "values": [
+          { "value": "auto", "label": "Auto" },
+          { "value": "always", "label": "Always on" },
+          { "value": "off", "label": "Off" }
+        ]
+      },
+      "default_value": "auto",
+      "category": "playback",
+      "label": "Subtitles",
+      "description": "When Silo should turn subtitles on.",
+      "recommended_control": "select",
+      "notes": "The legacy empty string means unset, not a fourth mode. Migration maps \"\" to no stored row so it resolves to the next scope."
+    },
+    {
+      "key": "playback.show_forced_subtitles",
+      "introduced_in": 1,
+      "persistence": "remote",
+      "allowed_scopes": ["profile", "profile_device", "profile_library", "profile_series"],
+      "resolution_order": [
+        "profile_series",
+        "profile_library",
+        "profile_device",
+        "profile",
+        "default"
+      ],
+      "value_schema": { "type": "boolean" },
+      "default_value": false,
+      "category": "playback",
+      "label": "Show forced subtitles",
+      "description": "Show subtitles for foreign-language dialogue even when subtitles are off.",
+      "recommended_control": "switch",
+      "notes": "The existing Has* companion booleans on LibraryPlaybackPreference and SubtitlePreference encode set-vs-unset. Migration writes a row only where Has* is true, so explicit false stays distinct from unset."
+    },
+    {
+      "key": "playback.subtitle_appearance",
+      "introduced_in": 1,
+      "persistence": "remote",
+      "allowed_scopes": ["profile", "profile_device"],
+      "resolution_order": ["profile_device", "profile", "default"],
+      "value_schema": { "type": "object", "schema_ref": "subtitle-appearance.json" },
+      "default_value": {
+        "fontSize": "large",
+        "fontFamily": "sans-serif",
+        "fontColor": "#ffffff",
+        "backgroundColor": "#000000",
+        "backgroundStyle": "shadow",
+        "backgroundOpacity": 75,
+        "textOutline": false,
+        "textOutlineColor": "#000000",
+        "position": "bottom"
+      },
+      "category": "playback",
+      "label": "Subtitle appearance",
+      "description": "How subtitles are drawn during playback.",
+      "recommended_control": "panel",
+      "notes": "Renamed from the unprefixed legacy key \"subtitle_appearance\". Every other canonical key carries a domain prefix, and preserving accidental key names is an explicit non-goal of the design. Migration copies the account-level legacy fallback to every existing profile and leaves device overrides unchanged."
+    },
+    {
+      "key": "playback.preferred_quality",
+      "introduced_in": 1,
+      "persistence": "remote",
+      "allowed_scopes": ["profile", "profile_device"],
+      "resolution_order": ["profile_device", "profile", "default"],
+      "value_schema": {
+        "type": "enum",
+        "ordered": true,
+        "values": [
+          { "value": "auto", "label": "Auto" },
+          { "value": "328p" },
+          { "value": "420p" },
+          { "value": "480p" },
+          { "value": "720p" },
+          { "value": "720p-medium" },
+          { "value": "720p-high" },
+          { "value": "1080p-8" },
+          { "value": "1080p" },
+          { "value": "1080p-medium" },
+          { "value": "1080p-high" },
+          { "value": "2160p" },
+          { "value": "original", "label": "Original quality" }
+        ]
+      },
+      "default_value": "auto",
+      "constrained_by": {
+        "policy_input": "max_playback_quality",
+        "constraint": "ceiling"
+      },
+      "category": "playback",
+      "label": "Preferred quality",
+      "description": "Pick the quality Silo should prefer.",
+      "recommended_control": "select",
+      "notes": "Members are listed ascending so the ceiling constraint has a defined direction; \"auto\" sorts lowest because it never exceeds a cap. Migrates user_profiles.quality_preference as the profile fallback. The account/profile max_playback_quality columns stay in internal/policy and are NOT settings."
+    },
+    {
+      "key": "playback.auto_skip_intro",
+      "introduced_in": 1,
+      "persistence": "remote",
+      "allowed_scopes": ["profile", "profile_device"],
+      "resolution_order": ["profile_device", "profile", "default"],
+      "value_schema": { "type": "boolean" },
+      "default_value": false,
+      "category": "playback",
+      "label": "Auto-skip intros",
+      "description": "Jump past intros automatically when Silo can detect them.",
+      "recommended_control": "switch"
+    },
+    {
+      "key": "playback.auto_skip_credits",
+      "introduced_in": 1,
+      "persistence": "remote",
+      "allowed_scopes": ["profile", "profile_device"],
+      "resolution_order": ["profile_device", "profile", "default"],
+      "value_schema": { "type": "boolean" },
+      "default_value": false,
+      "category": "playback",
+      "label": "Auto-skip credits",
+      "description": "Move through end credits automatically when a skip is available.",
+      "recommended_control": "switch"
+    },
+    {
+      "key": "playback.auto_skip_recap",
+      "introduced_in": 1,
+      "persistence": "remote",
+      "allowed_scopes": ["profile", "profile_device"],
+      "resolution_order": ["profile_device", "profile", "default"],
+      "value_schema": { "type": "boolean" },
+      "default_value": false,
+      "category": "playback",
+      "label": "Auto-skip recaps",
+      "description": "Skip \"previously on\" recaps automatically when Silo can detect them.",
+      "recommended_control": "switch"
+    },
+    {
+      "key": "playback.auto_play_next",
+      "introduced_in": 1,
+      "persistence": "remote",
+      "allowed_scopes": ["profile", "profile_device"],
+      "resolution_order": ["profile_device", "profile", "default"],
+      "value_schema": { "type": "boolean" },
+      "default_value": true,
+      "category": "playback",
+      "label": "Auto-play next episode",
+      "description": "Continue to the next episode automatically.",
+      "recommended_control": "switch"
+    },
+    {
+      "key": "playback.auto_play_next_preview",
+      "introduced_in": 1,
+      "persistence": "remote",
+      "allowed_scopes": ["profile", "profile_device"],
+      "resolution_order": ["profile_device", "profile", "default"],
+      "value_schema": { "type": "boolean" },
+      "default_value": false,
+      "category": "playback",
+      "label": "Preview next episode",
+      "description": "Show a preview of the next episode while credits play.",
+      "recommended_control": "switch"
+    },
+    {
+      "key": "playback.next_up_prompt_seconds",
+      "introduced_in": 1,
+      "persistence": "remote",
+      "allowed_scopes": ["profile", "profile_device"],
+      "resolution_order": ["profile_device", "profile", "default"],
+      "value_schema": { "type": "integer", "minimum": 0, "maximum": 120 },
+      "default_value": 30,
+      "unit": "seconds",
+      "category": "playback",
+      "label": "Next up prompt",
+      "description": "How long before the end of an episode the next-up prompt appears.",
+      "recommended_control": "slider",
+      "notes": "Android currently writes player.next_up_prompt_seconds. That alias is migrated to this key and removed from production writes."
+    },
+    {
+      "key": "catalog.metadata_language",
+      "introduced_in": 1,
+      "persistence": "remote",
+      "allowed_scopes": ["profile"],
+      "resolution_order": ["profile", "default"],
+      "value_schema": { "type": "language_tag", "nullable": true },
+      "default_value": null,
+      "constrained_by": {
+        "policy_input": "profile_preferred_metadata_language",
+        "constraint": "allowlist"
+      },
+      "category": "catalog",
+      "label": "Metadata language",
+      "description": "Language Silo prefers for titles, descriptions, and artwork.",
+      "recommended_control": "select",
+      "notes": "Migrates user_profiles.preferred_metadata_language."
+    },
+    {
+      "key": "player.hdr_enabled",
+      "introduced_in": 1,
+      "persistence": "remote",
+      "allowed_scopes": ["profile_device"],
+      "resolution_order": ["profile_device", "default"],
+      "value_schema": { "type": "boolean" },
+      "default_value": true,
+      "category": "player",
+      "label": "HDR",
+      "description": "Allow HDR output on this device.",
+      "recommended_control": "switch"
+    },
+    {
+      "key": "player.dolby_vision_enabled",
+      "introduced_in": 1,
+      "persistence": "remote",
+      "allowed_scopes": ["profile_device"],
+      "resolution_order": ["profile_device", "default"],
+      "value_schema": { "type": "boolean" },
+      "default_value": true,
+      "category": "player",
+      "label": "Dolby Vision",
+      "description": "Allow Dolby Vision output on this device.",
+      "recommended_control": "switch"
+    },
+    {
+      "key": "player.dv_profile7_hdr10_fallback",
+      "introduced_in": 1,
+      "persistence": "remote",
+      "allowed_scopes": ["profile_device"],
+      "resolution_order": ["profile_device", "default"],
+      "value_schema": { "type": "boolean" },
+      "default_value": false,
+      "category": "player",
+      "label": "Dolby Vision Profile 7 fallback",
+      "description": "Play Profile 7 sources as HDR10 when this device cannot decode them natively.",
+      "recommended_control": "switch",
+      "notes": "Android currently defaults this to true before hydration. The contract default is false, matching the server and Apple."
+    },
+    {
+      "key": "player.seek_cache_enabled",
+      "introduced_in": 1,
+      "persistence": "remote",
+      "allowed_scopes": ["profile_device"],
+      "resolution_order": ["profile_device", "default"],
+      "value_schema": { "type": "boolean" },
+      "default_value": true,
+      "category": "player",
+      "label": "Seek cache",
+      "description": "Keep recently played segments buffered for faster seeking.",
+      "recommended_control": "switch"
+    },
+    {
+      "key": "player.match_frame_rate",
+      "introduced_in": 1,
+      "persistence": "remote",
+      "allowed_scopes": ["profile_device"],
+      "resolution_order": ["profile_device", "default"],
+      "value_schema": { "type": "boolean" },
+      "default_value": false,
+      "platforms": ["android", "android_tv", "tvos"],
+      "category": "player",
+      "label": "Match content frame rate",
+      "description": "Switch the display refresh rate to match what is playing.",
+      "recommended_control": "switch",
+      "notes": "Previously an unregistered Android device-setting write, so every write and reset was rejected by the server. Registered here."
+    },
+    {
+      "key": "player.playback_speed",
+      "introduced_in": 1,
+      "persistence": "remote",
+      "allowed_scopes": ["profile_device"],
+      "resolution_order": ["profile_device", "default"],
+      "value_schema": { "type": "number", "minimum": 0.25, "maximum": 3.0, "step": 0.05 },
+      "default_value": 1.0,
+      "unit": "x",
+      "category": "player",
+      "label": "Playback speed",
+      "description": "Default playback speed on this device.",
+      "recommended_control": "slider",
+      "notes": "Android currently clamps to 4.0. The contract maximum is 3.0, matching the server; the Android clamp and its unit test are corrected to match."
+    },
+    {
+      "key": "player.audio_sync_ms",
+      "introduced_in": 1,
+      "persistence": "remote",
+      "allowed_scopes": ["profile_device"],
+      "resolution_order": ["profile_device", "default"],
+      "value_schema": { "type": "integer", "minimum": -5000, "maximum": 5000 },
+      "default_value": 0,
+      "unit": "milliseconds",
+      "category": "player",
+      "label": "Audio sync offset",
+      "description": "Shift audio earlier or later to correct lip sync on this device.",
+      "recommended_control": "slider"
+    },
+    {
+      "key": "player.subtitle_sync_ms",
+      "introduced_in": 1,
+      "persistence": "remote",
+      "allowed_scopes": ["profile_device"],
+      "resolution_order": ["profile_device", "default"],
+      "value_schema": { "type": "integer", "minimum": -10000, "maximum": 10000 },
+      "default_value": 0,
+      "unit": "milliseconds",
+      "category": "player",
+      "label": "Subtitle sync offset",
+      "description": "Shift subtitles earlier or later on this device.",
+      "recommended_control": "slider"
+    },
+    {
+      "key": "player.video_gravity",
+      "introduced_in": 1,
+      "persistence": "remote",
+      "allowed_scopes": ["profile_device"],
+      "resolution_order": ["profile_device", "default"],
+      "value_schema": {
+        "type": "enum",
+        "values": [
+          { "value": "fit", "label": "Fit" },
+          { "value": "fill", "label": "Fill" },
+          { "value": "stretch", "label": "Stretch" }
+        ]
+      },
+      "default_value": "fit",
+      "category": "player",
+      "label": "Video sizing",
+      "description": "How video fills the screen on this device.",
+      "recommended_control": "select"
+    },
+    {
+      "key": "player.orientation_mode",
+      "introduced_in": 1,
+      "persistence": "remote",
+      "allowed_scopes": ["profile_device"],
+      "resolution_order": ["profile_device", "default"],
+      "value_schema": {
+        "type": "enum",
+        "values": [
+          { "value": "landscapeLocked", "label": "Landscape" },
+          { "value": "rotateFreely", "label": "Rotate freely" }
+        ]
+      },
+      "default_value": "landscapeLocked",
+      "platforms": ["ios", "android"],
+      "category": "player",
+      "label": "Screen orientation",
+      "description": "Whether the player rotates with the device.",
+      "recommended_control": "select"
+    },
+    {
+      "key": "player.sleep_timer_default_minutes",
+      "introduced_in": 1,
+      "persistence": "remote",
+      "allowed_scopes": ["profile_device"],
+      "resolution_order": ["profile_device", "default"],
+      "value_schema": { "type": "integer", "minimum": 0, "maximum": 480 },
+      "default_value": 0,
+      "unit": "minutes",
+      "category": "player",
+      "label": "Default sleep timer",
+      "description": "Preset duration for the sleep timer. 0 leaves it off.",
+      "recommended_control": "stepper",
+      "notes": "Previously an unregistered Android device-setting write. The design classes transient sleep timers as private local; the persisted default duration is a real preference, so it is registered while the running timer stays client-local."
+    },
+    {
+      "key": "ui.theme",
+      "introduced_in": 1,
+      "persistence": "remote",
+      "allowed_scopes": ["profile"],
+      "resolution_order": ["profile", "default"],
+      "value_schema": {
+        "type": "enum",
+        "values": [
+          { "value": "midnight-cinema", "label": "Midnight Cinema" },
+          { "value": "cinema-light", "label": "Cinema Light" },
+          { "value": "cobalt-studio", "label": "Cobalt Studio" },
+          { "value": "oxblood-noir", "label": "Oxblood Noir" },
+          { "value": "evergreen-studio", "label": "Evergreen Studio" }
+        ]
+      },
+      "default_value": "midnight-cinema",
+      "platforms": ["web"],
+      "category": "appearance",
+      "label": "Theme",
+      "description": "Colour theme for the Silo interface.",
+      "recommended_control": "select",
+      "notes": "Renamed from the unregistered legacy key \"ui_theme\", which the extension bag accepted without validation. Moved from account to profile scope: appearance is per household member, and the account row is copied to every profile during migration. Adding a theme is an additive enum widening. The admin-set default theme stays in server_settings and is not a user setting."
+    },
+    {
+      "key": "ui.text_scale",
+      "introduced_in": 1,
+      "persistence": "remote",
+      "allowed_scopes": ["profile", "profile_device"],
+      "resolution_order": ["profile_device", "profile", "default"],
+      "value_schema": {
+        "type": "enum",
+        "ordered": true,
+        "values": [
+          { "value": "default", "label": "Default" },
+          { "value": "large", "label": "Large" },
+          { "value": "x-large", "label": "Extra large" }
+        ]
+      },
+      "default_value": "default",
+      "platforms": ["web"],
+      "category": "appearance",
+      "label": "Text size",
+      "description": "Overall interface text size.",
+      "recommended_control": "select",
+      "notes": "Renamed from the unregistered legacy key \"ui_text_scale\". Allows a device override because readable text size is partly a function of the screen you are sitting in front of."
+    },
+    {
+      "key": "ui.text_weight",
+      "introduced_in": 1,
+      "persistence": "remote",
+      "allowed_scopes": ["profile", "profile_device"],
+      "resolution_order": ["profile_device", "profile", "default"],
+      "value_schema": {
+        "type": "enum",
+        "values": [
+          { "value": "default", "label": "Default" },
+          { "value": "strong", "label": "Bolder" }
+        ]
+      },
+      "default_value": "default",
+      "platforms": ["web"],
+      "category": "appearance",
+      "label": "Text weight",
+      "description": "Use heavier interface text for readability.",
+      "recommended_control": "select",
+      "notes": "Renamed from the unregistered legacy key \"ui_text_weight\"."
+    },
+    {
+      "key": "ui.high_contrast",
+      "introduced_in": 1,
+      "persistence": "remote",
+      "allowed_scopes": ["profile", "profile_device"],
+      "resolution_order": ["profile_device", "profile", "default"],
+      "value_schema": { "type": "boolean" },
+      "default_value": false,
+      "platforms": ["web"],
+      "category": "appearance",
+      "label": "High contrast",
+      "description": "Increase contrast across the interface.",
+      "recommended_control": "switch",
+      "notes": "Renamed from the unregistered legacy key \"ui_high_contrast\"."
+    },
+    {
+      "key": "ui.custom_theme_vars",
+      "introduced_in": 1,
+      "persistence": "remote",
+      "allowed_scopes": ["profile"],
+      "resolution_order": ["profile", "default"],
+      "value_schema": {
+        "type": "object",
+        "schema_ref": "theme-var-overrides.json",
+        "nullable": true
+      },
+      "default_value": null,
+      "platforms": ["web"],
+      "category": "appearance",
+      "label": "Custom theme variables",
+      "description": "Per-token overrides applied on top of the selected theme.",
+      "recommended_control": "panel",
+      "notes": "Renamed from the unregistered legacy key \"ui_custom_theme_vars\", which stored arbitrary unvalidated JSON."
+    },
+    {
+      "key": "ui.custom_css",
+      "introduced_in": 1,
+      "persistence": "remote",
+      "allowed_scopes": ["profile"],
+      "resolution_order": ["profile", "default"],
+      "value_schema": { "type": "string", "max_length": 65536, "nullable": true },
+      "default_value": null,
+      "platforms": ["web"],
+      "category": "appearance",
+      "label": "Custom CSS",
+      "description": "Raw CSS applied on top of the selected theme.",
+      "recommended_control": "text",
+      "notes": "Renamed from the unregistered legacy key \"ui_custom_css\". Sanitization stays in the web client (web/src/lib/cssSanitizer.ts); the contract only bounds length. This value is per-profile and is never applied to another profile's session."
+    },
+    {
+      "key": "ui.date_format",
+      "introduced_in": 1,
+      "persistence": "remote",
+      "allowed_scopes": ["profile"],
+      "resolution_order": ["profile", "default"],
+      "value_schema": {
+        "type": "enum",
+        "values": [
+          { "value": "auto", "label": "Match device" },
+          { "value": "DD/MM/YYYY" },
+          { "value": "MM/DD/YYYY" },
+          { "value": "YYYY-MM-DD" }
+        ]
+      },
+      "default_value": "auto",
+      "category": "appearance",
+      "label": "Date format",
+      "description": "How dates are written across the interface.",
+      "recommended_control": "select",
+      "notes": "Moved from account to profile scope; the account row is copied to every profile during migration."
+    },
+    {
+      "key": "ui.time_format",
+      "introduced_in": 1,
+      "persistence": "remote",
+      "allowed_scopes": ["profile"],
+      "resolution_order": ["profile", "default"],
+      "value_schema": {
+        "type": "enum",
+        "values": [
+          { "value": "auto", "label": "Match device" },
+          { "value": "12h", "label": "12-hour" },
+          { "value": "24h", "label": "24-hour" }
+        ]
+      },
+      "default_value": "auto",
+      "category": "appearance",
+      "label": "Time format",
+      "description": "How clock times are written across the interface.",
+      "recommended_control": "select",
+      "notes": "Moved from account to profile scope; the account row is copied to every profile during migration."
+    },
+    {
+      "key": "ui.library_page_state",
+      "introduced_in": 1,
+      "persistence": "remote",
+      "allowed_scopes": ["profile_device"],
+      "resolution_order": ["profile_device", "default"],
+      "value_schema": {
+        "type": "object",
+        "schema_ref": "library-page-state.json",
+        "nullable": true
+      },
+      "default_value": null,
+      "platforms": ["web"],
+      "category": "navigation",
+      "label": "Remembered library view",
+      "description": "Saved browse state for each library.",
+      "notes": "Navigation state, not a user-authored preference. Stays tied to one profile on one device and is not shown as a normal setting control."
+    },
+    {
+      "key": "ui.remember_library_page_state",
+      "introduced_in": 1,
+      "persistence": "remote",
+      "allowed_scopes": ["profile_device"],
+      "resolution_order": ["profile_device", "default"],
+      "value_schema": { "type": "boolean" },
+      "default_value": true,
+      "platforms": ["web"],
+      "category": "navigation",
+      "label": "Remember library view",
+      "description": "Return to where you left off when reopening a library.",
+      "recommended_control": "switch"
+    },
+    {
+      "key": "search.media_scope",
+      "introduced_in": 1,
+      "persistence": "remote",
+      "allowed_scopes": ["profile"],
+      "resolution_order": ["profile", "default"],
+      "value_schema": {
+        "type": "enum",
+        "values": [
+          { "value": "all", "label": "Everything" },
+          { "value": "video", "label": "Movies and series" },
+          { "value": "audiobook", "label": "Audiobooks" }
+        ]
+      },
+      "default_value": "video",
+      "category": "search",
+      "label": "Search scope",
+      "description": "What search covers by default.",
+      "recommended_control": "select",
+      "notes": "Moved from account to profile scope; the account row is copied to every profile during migration."
+    },
+    {
+      "key": "downloads.wifi_only",
+      "introduced_in": 1,
+      "persistence": "client_local",
+      "allowed_scopes": ["client_local"],
+      "resolution_order": ["client_local", "default"],
+      "value_schema": { "type": "boolean" },
+      "default_value": true,
+      "platforms": ["ios", "android"],
+      "category": "downloads",
+      "label": "Download over Wi-Fi only",
+      "description": "Only download while connected to Wi-Fi.",
+      "recommended_control": "switch",
+      "notes": "Contract-known local: the value governs OS-level network constraints on the device holding the files, so it does not roam. Shared semantics across Apple and Android make it contract-owned rather than private."
+    },
+    {
+      "key": "downloads.keep_watched",
+      "introduced_in": 1,
+      "persistence": "client_local",
+      "allowed_scopes": ["client_local"],
+      "resolution_order": ["client_local", "default"],
+      "value_schema": { "type": "boolean" },
+      "default_value": false,
+      "platforms": ["ios", "android"],
+      "category": "downloads",
+      "label": "Keep watched downloads",
+      "description": "Do not suggest reclaiming space from downloads you have finished.",
+      "recommended_control": "switch",
+      "notes": "Contract-known local. Governs on-device storage cleanup prompts."
+    },
+    {
+      "key": "subtitle.matches_device",
+      "introduced_in": 1,
+      "persistence": "client_local",
+      "allowed_scopes": ["client_local"],
+      "resolution_order": ["client_local", "default"],
+      "value_schema": { "type": "boolean" },
+      "default_value": false,
+      "platforms": ["ios", "tvos", "macos", "android", "android_tv"],
+      "category": "playback",
+      "label": "Match device caption settings",
+      "description": "Use the operating system's caption style instead of Silo's.",
+      "recommended_control": "switch",
+      "notes": "Contract-known local: reads OS accessibility settings that only exist on the device. When enabled, playback.subtitle_appearance is not applied. Apple's existing copy separating this from profile subtitle behavior is the UX baseline."
+    }
+  ]
+}

--- a/contracts/settings/v1/manifest.json
+++ b/contracts/settings/v1/manifest.json
@@ -417,8 +417,8 @@
       "key": "ui.theme",
       "introduced_in": 1,
       "persistence": "remote",
-      "allowed_scopes": ["profile"],
-      "resolution_order": ["profile", "default"],
+      "allowed_scopes": ["profile", "profile_device"],
+      "resolution_order": ["profile_device", "profile", "default"],
       "value_schema": {
         "type": "enum",
         "values": [
@@ -435,7 +435,7 @@
       "label": "Theme",
       "description": "Colour theme for the Silo interface.",
       "recommended_control": "select",
-      "notes": "Renamed from the unregistered legacy key \"ui_theme\", which the extension bag accepted without validation. Moved from account to profile scope: appearance is per household member, and the account row is copied to every profile during migration. Adding a theme is an additive enum widening. The admin-set default theme stays in server_settings and is not a user setting."
+      "notes": "Renamed from the unregistered legacy key \"ui_theme\", which the extension bag accepted without validation. Moved from account to profile scope: appearance is per household member, and the account row is copied to every profile during migration. Carries a device override because the right theme is partly a function of the screen and the room — a light theme on a phone in daylight, a dark one on a TV at night — which is the same reasoning that gives ui.text_scale one. Note that ui.custom_theme_vars and ui.custom_css stay profile-wide, so a profile's custom styling still applies on top of a device's theme override. Adding a theme is an additive enum widening. The admin-set default theme stays in server_settings and is not a user setting."
     },
     {
       "key": "ui.text_scale",

--- a/contracts/settings/v1/manifest.schema.json
+++ b/contracts/settings/v1/manifest.schema.json
@@ -1,0 +1,263 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://silo-server.dev/contracts/settings/v1/manifest.schema.json",
+  "title": "Silo cross-platform user settings manifest",
+  "description": "Canonical contract for every production, user-facing setting. See docs/superpowers/specs/2026-07-10-cross-platform-user-settings-contract-design.md.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["api_version", "revision", "definitions"],
+  "properties": {
+    "api_version": {
+      "description": "Settings protocol version. Changes only for a change no revision rule can express.",
+      "type": "integer",
+      "minimum": 1
+    },
+    "revision": {
+      "description": "Monotonically increasing integer bumped by every manifest PR.",
+      "type": "integer",
+      "minimum": 1
+    },
+    "definitions": {
+      "type": "array",
+      "items": { "$ref": "#/$defs/definition" }
+    }
+  },
+  "$defs": {
+    "settingKey": {
+      "description": "Lowercase dot-separated identifier. Canonical names do not encode a platform.",
+      "type": "string",
+      "pattern": "^[a-z][a-z0-9_]*(\\.[a-z][a-z0-9_]*)+$",
+      "maxLength": 128
+    },
+    "revisionRef": {
+      "description": "Manifest revision in which this element was introduced.",
+      "type": "integer",
+      "minimum": 1
+    },
+    "scopeName": {
+      "description": "Storage identity a value attaches to. Whether a given scope is legal for a definition depends on its persistence class, which internal/settingscontract enforces.",
+      "type": "string",
+      "enum": [
+        "account",
+        "profile",
+        "profile_device",
+        "profile_library",
+        "profile_series",
+        "client_local"
+      ]
+    },
+    "scopeEntry": {
+      "description": "A scope, optionally tagged with the revision that added it to this definition.",
+      "oneOf": [
+        { "$ref": "#/$defs/scopeName" },
+        {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["scope"],
+          "properties": {
+            "scope": { "$ref": "#/$defs/scopeName" },
+            "introduced_in": { "$ref": "#/$defs/revisionRef" }
+          }
+        }
+      ]
+    },
+    "enumMember": {
+      "description": "Enum members are objects so members added later can carry their own revision.",
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["value"],
+      "properties": {
+        "value": { "type": ["string", "integer", "boolean"] },
+        "label": { "type": "string" },
+        "introduced_in": { "$ref": "#/$defs/revisionRef" },
+        "deprecated": { "type": "boolean", "default": false }
+      }
+    },
+    "valueSchema": {
+      "oneOf": [
+        {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["type"],
+          "properties": {
+            "type": { "const": "boolean" },
+            "nullable": { "type": "boolean", "default": false }
+          }
+        },
+        {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["type", "minimum", "maximum"],
+          "properties": {
+            "type": { "const": "integer" },
+            "minimum": { "type": "integer" },
+            "maximum": { "type": "integer" },
+            "step": { "type": "integer", "exclusiveMinimum": 0 },
+            "nullable": { "type": "boolean", "default": false },
+            "minimum_introduced_in": { "$ref": "#/$defs/revisionRef" },
+            "maximum_introduced_in": { "$ref": "#/$defs/revisionRef" }
+          }
+        },
+        {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["type", "minimum", "maximum"],
+          "properties": {
+            "type": { "const": "number" },
+            "minimum": { "type": "number" },
+            "maximum": { "type": "number" },
+            "step": { "type": "number", "exclusiveMinimum": 0 },
+            "nullable": { "type": "boolean", "default": false },
+            "minimum_introduced_in": { "$ref": "#/$defs/revisionRef" },
+            "maximum_introduced_in": { "$ref": "#/$defs/revisionRef" }
+          }
+        },
+        {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["type", "max_length"],
+          "properties": {
+            "type": { "const": "string" },
+            "min_length": { "type": "integer", "minimum": 0, "default": 0 },
+            "max_length": { "type": "integer", "minimum": 1 },
+            "pattern": { "type": "string", "format": "regex" },
+            "nullable": { "type": "boolean", "default": false }
+          }
+        },
+        {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["type", "values"],
+          "properties": {
+            "type": { "const": "enum" },
+            "values": {
+              "type": "array",
+              "minItems": 1,
+              "items": { "$ref": "#/$defs/enumMember" }
+            },
+            "ordered": {
+              "description": "Members form a meaningful progression. Required for ceiling/floor constraints.",
+              "type": "boolean",
+              "default": false
+            },
+            "nullable": { "type": "boolean", "default": false }
+          }
+        },
+        {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["type"],
+          "properties": {
+            "type": { "const": "language_tag" },
+            "nullable": { "type": "boolean", "default": false }
+          }
+        },
+        {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["type", "schema_ref"],
+          "properties": {
+            "type": { "const": "object" },
+            "schema_ref": {
+              "description": "Filename under contracts/settings/v1/schemas/.",
+              "type": "string",
+              "pattern": "^[a-z0-9-]+\\.json$"
+            },
+            "nullable": { "type": "boolean", "default": false }
+          }
+        }
+      ]
+    },
+    "constraint": {
+      "description": "Binding to a policy input that constrains this setting at resolution time.",
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["policy_input", "constraint"],
+      "properties": {
+        "policy_input": {
+          "description": "Field name produced by internal/policy.",
+          "type": "string",
+          "pattern": "^[a-z][a-z0-9_]*$"
+        },
+        "constraint": {
+          "type": "string",
+          "enum": ["ceiling", "floor", "allowlist", "locked"]
+        }
+      }
+    },
+    "definition": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "key",
+        "introduced_in",
+        "persistence",
+        "allowed_scopes",
+        "resolution_order",
+        "value_schema",
+        "default_value",
+        "category",
+        "label",
+        "description"
+      ],
+      "properties": {
+        "key": { "$ref": "#/$defs/settingKey" },
+        "introduced_in": { "$ref": "#/$defs/revisionRef" },
+        "persistence": {
+          "type": "string",
+          "enum": ["remote", "client_local"]
+        },
+        "allowed_scopes": {
+          "type": "array",
+          "minItems": 1,
+          "items": { "$ref": "#/$defs/scopeEntry" }
+        },
+        "resolution_order": {
+          "description": "Most specific first. Must end with \"default\".",
+          "type": "array",
+          "minItems": 1,
+          "items": {
+            "type": "string",
+            "enum": [
+              "account",
+              "profile",
+              "profile_device",
+              "profile_library",
+              "profile_series",
+              "client_local",
+              "default"
+            ]
+          }
+        },
+        "value_schema": { "$ref": "#/$defs/valueSchema" },
+        "default_value": {},
+        "constrained_by": { "$ref": "#/$defs/constraint" },
+        "platforms": {
+          "description": "Advisory UI metadata. Absent means \"expected everywhere\". Never server-enforced.",
+          "type": "array",
+          "minItems": 1,
+          "items": {
+            "type": "string",
+            "enum": ["web", "ios", "tvos", "macos", "android", "android_tv"]
+          }
+        },
+        "category": {
+          "type": "string",
+          "pattern": "^[a-z][a-z0-9_]*$"
+        },
+        "label": { "type": "string", "minLength": 1 },
+        "description": { "type": "string", "minLength": 1 },
+        "unit": { "type": "string" },
+        "recommended_control": {
+          "type": "string",
+          "enum": ["switch", "select", "slider", "stepper", "text", "color", "panel"]
+        },
+        "deprecated": { "type": "boolean", "default": false },
+        "notes": {
+          "description": "Maintainer commentary. Not served in the public manifest.",
+          "type": "string"
+        }
+      }
+    }
+  }
+}

--- a/contracts/settings/v1/schemas/library-page-state.json
+++ b/contracts/settings/v1/schemas/library-page-state.json
@@ -1,0 +1,28 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://silo-server.dev/contracts/settings/v1/schemas/library-page-state.json",
+  "title": "Library page state",
+  "description": "Remembered per-library browse state. Mirrors web/src/hooks/queries/libraryPageState.ts.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["version", "libraries"],
+  "properties": {
+    "version": { "const": 1 },
+    "libraries": {
+      "type": "object",
+      "propertyNames": {
+        "type": "string",
+        "pattern": "^[0-9]+$"
+      },
+      "additionalProperties": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["search"],
+        "properties": {
+          "search": { "type": "string", "maxLength": 256 }
+        }
+      },
+      "maxProperties": 512
+    }
+  }
+}

--- a/contracts/settings/v1/schemas/subtitle-appearance.json
+++ b/contracts/settings/v1/schemas/subtitle-appearance.json
@@ -1,0 +1,52 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://silo-server.dev/contracts/settings/v1/schemas/subtitle-appearance.json",
+  "title": "Subtitle appearance",
+  "description": "Rendering appearance for subtitle tracks. Mirrors web/src/lib/subtitleAppearance.ts.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "fontSize",
+    "fontFamily",
+    "fontColor",
+    "backgroundColor",
+    "backgroundStyle",
+    "backgroundOpacity",
+    "textOutline",
+    "textOutlineColor",
+    "position"
+  ],
+  "properties": {
+    "fontSize": {
+      "type": "string",
+      "enum": ["small", "medium", "large", "xlarge", "xxlarge"]
+    },
+    "fontFamily": {
+      "type": "string",
+      "enum": ["sans-serif", "serif", "monospace"]
+    },
+    "fontColor": { "$ref": "#/$defs/hexColor" },
+    "backgroundColor": { "$ref": "#/$defs/hexColor" },
+    "backgroundStyle": {
+      "type": "string",
+      "enum": ["box", "shadow", "outline", "none"]
+    },
+    "backgroundOpacity": {
+      "type": "integer",
+      "minimum": 0,
+      "maximum": 100
+    },
+    "textOutline": { "type": "boolean" },
+    "textOutlineColor": { "$ref": "#/$defs/hexColor" },
+    "position": {
+      "type": "string",
+      "enum": ["bottom", "lower-third", "top"]
+    }
+  },
+  "$defs": {
+    "hexColor": {
+      "type": "string",
+      "pattern": "^#[0-9a-fA-F]{6}$"
+    }
+  }
+}

--- a/contracts/settings/v1/schemas/theme-var-overrides.json
+++ b/contracts/settings/v1/schemas/theme-var-overrides.json
@@ -1,0 +1,18 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://silo-server.dev/contracts/settings/v1/schemas/theme-var-overrides.json",
+  "title": "Theme variable overrides",
+  "description": "Sparse map of theme token to CSS value. Token names mirror web/src/lib/themeTokens.ts; values are bounded to keep this from becoming an untyped blob.",
+  "type": "object",
+  "propertyNames": {
+    "type": "string",
+    "pattern": "^[a-z][a-z0-9-]*$",
+    "maxLength": 64
+  },
+  "additionalProperties": {
+    "type": "string",
+    "minLength": 1,
+    "maxLength": 128
+  },
+  "maxProperties": 256
+}

--- a/go.mod
+++ b/go.mod
@@ -12,7 +12,7 @@ require (
 	github.com/jackc/pgx/v5 v5.9.2
 	github.com/mattn/go-sqlite3 v1.14.34
 	github.com/prometheus/client_golang v1.23.2
-	github.com/prometheus/client_model v0.6.2 // indirect
+	github.com/prometheus/client_model v0.6.2
 	github.com/redis/go-redis/v9 v9.18.0
 	golang.org/x/crypto v0.52.0
 	golang.org/x/sys v0.45.0
@@ -33,6 +33,7 @@ require (
 	github.com/open-policy-agent/opa v1.18.2
 	github.com/pgvector/pgvector-go v0.3.0
 	github.com/pressly/goose/v3 v3.27.1
+	github.com/santhosh-tekuri/jsonschema/v6 v6.0.2
 	github.com/tetratelabs/wazero v1.12.0
 	github.com/wneessen/go-mail v0.7.3
 	github.com/zishang520/socket.io/v2 v2.5.0
@@ -80,7 +81,6 @@ require (
 	github.com/quic-go/quic-go v0.60.0 // indirect
 	github.com/quic-go/webtransport-go v0.10.0 // indirect
 	github.com/rcrowley/go-metrics v0.0.0-20250401214520-65e299d6c5c9 // indirect
-	github.com/santhosh-tekuri/jsonschema/v6 v6.0.2 // indirect
 	github.com/segmentio/asm v1.2.1 // indirect
 	github.com/sethvargo/go-retry v0.3.0 // indirect
 	github.com/sirupsen/logrus v1.9.4 // indirect

--- a/internal/settingscontract/canonical.go
+++ b/internal/settingscontract/canonical.go
@@ -1,0 +1,184 @@
+package settingscontract
+
+import (
+	"bytes"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"math"
+	"sort"
+	"strconv"
+)
+
+// CanonicalBytes returns the RFC 8785 (JCS) canonicalization of the manifest:
+// UTF-8, object keys sorted by code point, no insignificant whitespace.
+//
+// Two servers built from the same manifest produce identical bytes, which is
+// what makes the ETag comparable across deployments and generated client code
+// reproducible.
+func CanonicalBytes() ([]byte, error) {
+	raw, err := RawBytes()
+	if err != nil {
+		return nil, err
+	}
+	return canonicalize(raw)
+}
+
+// ETag returns the SHA-256 digest of the canonical bytes, formatted as a strong
+// HTTP entity tag.
+func ETag() (string, error) {
+	canonical, err := CanonicalBytes()
+	if err != nil {
+		return "", err
+	}
+	sum := sha256.Sum256(canonical)
+	return `"` + hex.EncodeToString(sum[:]) + `"`, nil
+}
+
+// PublicBytes returns the canonicalized manifest with maintainer-only fields
+// removed. This is what GET /api/v1/settings/manifest serves.
+//
+// Only "notes" is stripped today. Internal storage bindings, when they exist,
+// are stripped here too: the public manifest must never name a table or column.
+func PublicBytes() ([]byte, error) {
+	raw, err := RawBytes()
+	if err != nil {
+		return nil, err
+	}
+
+	var doc map[string]any
+	decoder := json.NewDecoder(bytes.NewReader(raw))
+	decoder.UseNumber()
+	if err := decoder.Decode(&doc); err != nil {
+		return nil, fmt.Errorf("parsing manifest: %w", err)
+	}
+
+	definitions, _ := doc["definitions"].([]any)
+	for _, entry := range definitions {
+		def, ok := entry.(map[string]any)
+		if !ok {
+			continue
+		}
+		delete(def, "notes")
+	}
+
+	encoded, err := json.Marshal(doc)
+	if err != nil {
+		return nil, fmt.Errorf("encoding public manifest: %w", err)
+	}
+	return canonicalize(encoded)
+}
+
+// PublicETag returns the entity tag for the public manifest projection. It
+// differs from ETag because stripping notes changes the bytes clients see.
+func PublicETag() (string, error) {
+	public, err := PublicBytes()
+	if err != nil {
+		return "", err
+	}
+	sum := sha256.Sum256(public)
+	return `"` + hex.EncodeToString(sum[:]) + `"`, nil
+}
+
+func canonicalize(raw []byte) ([]byte, error) {
+	var doc any
+	decoder := json.NewDecoder(bytes.NewReader(raw))
+	decoder.UseNumber()
+	if err := decoder.Decode(&doc); err != nil {
+		return nil, fmt.Errorf("parsing JSON for canonicalization: %w", err)
+	}
+
+	var out bytes.Buffer
+	if err := writeCanonical(&out, doc); err != nil {
+		return nil, err
+	}
+	return out.Bytes(), nil
+}
+
+func writeCanonical(out *bytes.Buffer, value any) error {
+	switch typed := value.(type) {
+	case nil:
+		out.WriteString("null")
+
+	case bool:
+		if typed {
+			out.WriteString("true")
+		} else {
+			out.WriteString("false")
+		}
+
+	case json.Number:
+		serialized, err := canonicalNumber(typed)
+		if err != nil {
+			return err
+		}
+		out.WriteString(serialized)
+
+	case string:
+		encoded, err := json.Marshal(typed)
+		if err != nil {
+			return fmt.Errorf("encoding string: %w", err)
+		}
+		out.Write(encoded)
+
+	case []any:
+		out.WriteByte('[')
+		for i, item := range typed {
+			if i > 0 {
+				out.WriteByte(',')
+			}
+			if err := writeCanonical(out, item); err != nil {
+				return err
+			}
+		}
+		out.WriteByte(']')
+
+	case map[string]any:
+		keys := make([]string, 0, len(typed))
+		for key := range typed {
+			keys = append(keys, key)
+		}
+		// JCS sorts by UTF-16 code unit. For the ASCII key space this contract
+		// uses, byte order and code-unit order agree.
+		sort.Strings(keys)
+
+		out.WriteByte('{')
+		for i, key := range keys {
+			if i > 0 {
+				out.WriteByte(',')
+			}
+			encodedKey, err := json.Marshal(key)
+			if err != nil {
+				return fmt.Errorf("encoding key %q: %w", key, err)
+			}
+			out.Write(encodedKey)
+			out.WriteByte(':')
+			if err := writeCanonical(out, typed[key]); err != nil {
+				return err
+			}
+		}
+		out.WriteByte('}')
+
+	default:
+		return fmt.Errorf("unexpected JSON value of type %T", value)
+	}
+
+	return nil
+}
+
+// canonicalNumber renders a number the way ECMAScript's Number::toString does,
+// which is what JCS requires: 3.0 becomes "3", 0.05 stays "0.05".
+func canonicalNumber(number json.Number) (string, error) {
+	parsed, err := number.Float64()
+	if err != nil {
+		return "", fmt.Errorf("parsing number %s: %w", number, err)
+	}
+	if math.IsNaN(parsed) || math.IsInf(parsed, 0) {
+		return "", fmt.Errorf("NaN and infinities cannot be canonicalized: %s", number)
+	}
+	if parsed == math.Trunc(parsed) && math.Abs(parsed) < 1e21 {
+		return strconv.FormatFloat(parsed, 'f', 0, 64), nil
+	}
+	return strconv.FormatFloat(parsed, 'g', -1, 64), nil
+}

--- a/internal/settingscontract/contract.go
+++ b/internal/settingscontract/contract.go
@@ -1,0 +1,292 @@
+// Package settingscontract loads and validates the canonical cross-platform
+// user settings manifest.
+//
+// The manifest in contracts/settings/v1 is the single source of truth for every
+// production, user-facing setting: its key, value type, constraints, storage
+// scopes, resolution order, default, and UX copy. The server embeds it, clients
+// vendor a pinned copy and generate bindings from it, and no production setting
+// may exist without an entry here.
+//
+// See docs/superpowers/specs/2026-07-10-cross-platform-user-settings-contract-design.md.
+package settingscontract
+
+import (
+	"encoding/json"
+	"fmt"
+)
+
+// Scope identifies the storage identity a value is attached to.
+type Scope string
+
+const (
+	ScopeAccount        Scope = "account"
+	ScopeProfile        Scope = "profile"
+	ScopeProfileDevice  Scope = "profile_device"
+	ScopeProfileLibrary Scope = "profile_library"
+	ScopeProfileSeries  Scope = "profile_series"
+	// ScopeClientLocal is not addressable by the server values API. It exists so
+	// client_local definitions can express a resolution order in the same shape
+	// as remote ones.
+	ScopeClientLocal Scope = "client_local"
+	// ScopeDefault terminates every resolution order.
+	ScopeDefault Scope = "default"
+)
+
+// remoteScopes are the scopes the server stores and authorizes.
+var remoteScopes = map[Scope]struct{}{
+	ScopeAccount:        {},
+	ScopeProfile:        {},
+	ScopeProfileDevice:  {},
+	ScopeProfileLibrary: {},
+	ScopeProfileSeries:  {},
+}
+
+// IsRemote reports whether the scope is stored and authorized by the server.
+func (s Scope) IsRemote() bool {
+	_, ok := remoteScopes[s]
+	return ok
+}
+
+// Persistence declares who stores a setting's value.
+type Persistence string
+
+const (
+	// PersistenceRemote values are stored by the server and roam per their scope.
+	PersistenceRemote Persistence = "remote"
+	// PersistenceClientLocal values are defined by the contract but stored only
+	// by the client. They are never sent to the API.
+	PersistenceClientLocal Persistence = "client_local"
+)
+
+// ValueType tags a value schema.
+type ValueType string
+
+const (
+	TypeBoolean     ValueType = "boolean"
+	TypeInteger     ValueType = "integer"
+	TypeNumber      ValueType = "number"
+	TypeString      ValueType = "string"
+	TypeEnum        ValueType = "enum"
+	TypeLanguageTag ValueType = "language_tag"
+	TypeObject      ValueType = "object"
+)
+
+// ConstraintKind describes how a policy input narrows a setting.
+type ConstraintKind string
+
+const (
+	// ConstraintCeiling caps the value at the policy input. Valid only on an
+	// ordered enum or a numeric type.
+	ConstraintCeiling ConstraintKind = "ceiling"
+	// ConstraintFloor raises the value to the policy input. Same restriction.
+	ConstraintFloor ConstraintKind = "floor"
+	// ConstraintAllowlist restricts the value to a policy-supplied set.
+	ConstraintAllowlist ConstraintKind = "allowlist"
+	// ConstraintLocked prevents the user from authoring the setting at all.
+	ConstraintLocked ConstraintKind = "locked"
+)
+
+// Manifest is the canonical settings contract.
+type Manifest struct {
+	// APIVersion identifies the settings protocol. It changes only for a change
+	// no revision rule can express.
+	APIVersion int `json:"api_version"`
+	// Revision is bumped by every manifest PR and is what clients filter
+	// definitions, scopes, enum members, and bounds against.
+	Revision int `json:"revision"`
+	// Definitions is ordered as authored; use Lookup for access by key.
+	Definitions []Definition `json:"definitions"`
+
+	byKey map[string]*Definition
+}
+
+// Definition is the canonical contract for one setting.
+type Definition struct {
+	Key             string          `json:"key"`
+	IntroducedIn    int             `json:"introduced_in"`
+	Persistence     Persistence     `json:"persistence"`
+	AllowedScopes   []ScopeEntry    `json:"allowed_scopes"`
+	ResolutionOrder []Scope         `json:"resolution_order"`
+	ValueSchema     ValueSchema     `json:"value_schema"`
+	DefaultValue    json.RawMessage `json:"default_value"`
+	ConstrainedBy   *Constraint     `json:"constrained_by,omitempty"`
+	Platforms       []string        `json:"platforms,omitempty"`
+	Category        string          `json:"category"`
+	Label           string          `json:"label"`
+	Description     string          `json:"description"`
+	Unit            string          `json:"unit,omitempty"`
+	Control         string          `json:"recommended_control,omitempty"`
+	Deprecated      bool            `json:"deprecated,omitempty"`
+	// Notes is maintainer commentary. It is stripped from the public manifest.
+	Notes string `json:"notes,omitempty"`
+}
+
+// ScopeEntry is a scope, optionally tagged with the revision that added it to
+// its definition. It unmarshals from either a bare string or an object so the
+// common case stays readable in the manifest.
+type ScopeEntry struct {
+	Scope        Scope `json:"scope"`
+	IntroducedIn int   `json:"introduced_in,omitempty"`
+}
+
+// UnmarshalJSON accepts "profile" or {"scope":"profile","introduced_in":14}.
+func (s *ScopeEntry) UnmarshalJSON(data []byte) error {
+	var bare string
+	if err := json.Unmarshal(data, &bare); err == nil {
+		s.Scope = Scope(bare)
+		s.IntroducedIn = 0
+		return nil
+	}
+	var tagged struct {
+		Scope        Scope `json:"scope"`
+		IntroducedIn int   `json:"introduced_in"`
+	}
+	if err := json.Unmarshal(data, &tagged); err != nil {
+		return fmt.Errorf("scope entry must be a string or an object: %w", err)
+	}
+	s.Scope = tagged.Scope
+	s.IntroducedIn = tagged.IntroducedIn
+	return nil
+}
+
+// MarshalJSON emits the bare string form when no revision tag is present, so
+// round-tripping the manifest does not rewrite unrelated entries.
+func (s ScopeEntry) MarshalJSON() ([]byte, error) {
+	if s.IntroducedIn == 0 {
+		return json.Marshal(string(s.Scope))
+	}
+	return json.Marshal(struct {
+		Scope        Scope `json:"scope"`
+		IntroducedIn int   `json:"introduced_in"`
+	}{s.Scope, s.IntroducedIn})
+}
+
+// ValueSchema is the tagged type system for setting values. Only the fields
+// belonging to Type are meaningful; Validate enforces that.
+type ValueSchema struct {
+	Type     ValueType `json:"type"`
+	Nullable bool      `json:"nullable,omitempty"`
+
+	// Numeric (integer, number).
+	Minimum *float64 `json:"minimum,omitempty"`
+	Maximum *float64 `json:"maximum,omitempty"`
+	Step    *float64 `json:"step,omitempty"`
+	// Revision tags for additively widened bounds.
+	MinimumIntroducedIn int `json:"minimum_introduced_in,omitempty"`
+	MaximumIntroducedIn int `json:"maximum_introduced_in,omitempty"`
+
+	// String.
+	MinLength *int   `json:"min_length,omitempty"`
+	MaxLength *int   `json:"max_length,omitempty"`
+	Pattern   string `json:"pattern,omitempty"`
+
+	// Enum.
+	Values  []EnumMember `json:"values,omitempty"`
+	Ordered bool         `json:"ordered,omitempty"`
+
+	// Object.
+	SchemaRef string `json:"schema_ref,omitempty"`
+}
+
+// EnumMember is one allowed enum value. Members are objects rather than bare
+// strings so a member added after the definition can carry its own revision.
+type EnumMember struct {
+	Value        any    `json:"value"`
+	Label        string `json:"label,omitempty"`
+	IntroducedIn int    `json:"introduced_in,omitempty"`
+	Deprecated   bool   `json:"deprecated,omitempty"`
+}
+
+// Constraint binds a definition to a policy input that narrows it at
+// resolution time. A constraint filters what a preference does; it never
+// validates what a preference is, so a mutation that exceeds a restriction is
+// still stored.
+type Constraint struct {
+	PolicyInput string         `json:"policy_input"`
+	Constraint  ConstraintKind `json:"constraint"`
+}
+
+// Lookup returns the definition for key.
+func (m *Manifest) Lookup(key string) (*Definition, bool) {
+	if m == nil || m.byKey == nil {
+		return nil, false
+	}
+	def, ok := m.byKey[key]
+	return def, ok
+}
+
+// Keys returns every definition key in manifest order.
+func (m *Manifest) Keys() []string {
+	if m == nil {
+		return nil
+	}
+	keys := make([]string, 0, len(m.Definitions))
+	for i := range m.Definitions {
+		keys = append(keys, m.Definitions[i].Key)
+	}
+	return keys
+}
+
+// index builds the by-key lookup. It reports duplicate keys as an error rather
+// than letting the last one silently win.
+func (m *Manifest) index() error {
+	m.byKey = make(map[string]*Definition, len(m.Definitions))
+	for i := range m.Definitions {
+		def := &m.Definitions[i]
+		if _, exists := m.byKey[def.Key]; exists {
+			return fmt.Errorf("duplicate setting key %q", def.Key)
+		}
+		m.byKey[def.Key] = def
+	}
+	return nil
+}
+
+// AllowsScope reports whether the definition may store a value at scope.
+func (d *Definition) AllowsScope(scope Scope) bool {
+	for _, entry := range d.AllowedScopes {
+		if entry.Scope == scope {
+			return true
+		}
+	}
+	return false
+}
+
+// IsRemote reports whether the server stores this setting's values.
+func (d *Definition) IsRemote() bool {
+	return d.Persistence == PersistenceRemote
+}
+
+// VisibleAtRevision reports whether a client pinned to revision may surface this
+// definition. A client hides definitions the connected server does not know.
+func (d *Definition) VisibleAtRevision(revision int) bool {
+	return d.IntroducedIn <= revision
+}
+
+// ScopesAtRevision returns the scopes valid against a peer at revision.
+func (d *Definition) ScopesAtRevision(revision int) []Scope {
+	scopes := make([]Scope, 0, len(d.AllowedScopes))
+	for _, entry := range d.AllowedScopes {
+		if entry.IntroducedIn > revision {
+			continue
+		}
+		scopes = append(scopes, entry.Scope)
+	}
+	return scopes
+}
+
+// EnumValuesAtRevision returns the enum members valid against a peer at
+// revision. Clients render from this so a newer client never offers a choice an
+// older server will reject.
+func (d *Definition) EnumValuesAtRevision(revision int) []EnumMember {
+	if d.ValueSchema.Type != TypeEnum {
+		return nil
+	}
+	members := make([]EnumMember, 0, len(d.ValueSchema.Values))
+	for _, member := range d.ValueSchema.Values {
+		if member.IntroducedIn > revision {
+			continue
+		}
+		members = append(members, member)
+	}
+	return members
+}

--- a/internal/settingscontract/contract_test.go
+++ b/internal/settingscontract/contract_test.go
@@ -1,0 +1,570 @@
+package settingscontract
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+)
+
+// Keys referenced by more than one test. These are deliberately test-scoped:
+// production code reads keys through generated bindings, not handwritten Go
+// constants, so a parallel set of literals here would be a second source of
+// truth for the very thing the manifest exists to own.
+const (
+	keyAudioLanguage      = "playback.audio_language"
+	keyAutoPlayNext       = "playback.auto_play_next"
+	keyNextUpPrompt       = "playback.next_up_prompt_seconds"
+	keyPlaybackSpeed      = "player.playback_speed"
+	keyPreferredQuality   = "playback.preferred_quality"
+	keySubtitleAppearance = "playback.subtitle_appearance"
+	keySubtitleMode       = "playback.subtitle_mode"
+
+	// fixtureKey names definitions built inside tests, never the manifest.
+	fixtureKey = "playback.example"
+
+	jsonNull = "null"
+)
+
+// TestEmbeddedManifestLoads is the gate the whole contract rests on: the
+// checked-in manifest parses, satisfies its own JSON Schema, and passes every
+// structural invariant.
+func TestEmbeddedManifestLoads(t *testing.T) {
+	manifest, err := Load()
+	if err != nil {
+		t.Fatalf("embedded manifest failed to load: %v", err)
+	}
+	if manifest.APIVersion != 1 {
+		t.Errorf("api_version = %d, want 1", manifest.APIVersion)
+	}
+	if manifest.Revision < 1 {
+		t.Errorf("revision = %d, want at least 1", manifest.Revision)
+	}
+	if len(manifest.Definitions) == 0 {
+		t.Fatal("manifest declares no definitions")
+	}
+}
+
+// TestEveryCurrentServerKeyIsRegistered pins the inventory. The design makes an
+// unregistered official key a release blocker, so a key that exists in the
+// legacy registry but not in the manifest has to fail here rather than be
+// discovered during migration.
+func TestEveryCurrentServerKeyIsRegistered(t *testing.T) {
+	// Keys the legacy settingsRegistry in internal/api/handlers/settings.go
+	// accepts today, mapped to their canonical names. A legacy key whose
+	// canonical name differs is renamed deliberately; see the manifest notes.
+	legacyToCanonical := map[string]string{
+		"playback.preferred_quality":        keyPreferredQuality,
+		"playback.audio_language":           keyAudioLanguage,
+		"playback.auto_skip_intro":          "playback.auto_skip_intro",
+		"playback.auto_skip_credits":        "playback.auto_skip_credits",
+		"playback.auto_skip_recap":          "playback.auto_skip_recap",
+		"playback.auto_play_next_preview":   "playback.auto_play_next_preview",
+		"playback.auto_play_next":           keyAutoPlayNext,
+		"playback.next_up_prompt_seconds":   keyNextUpPrompt,
+		"subtitle_appearance":               keySubtitleAppearance,
+		"ui.library_page_state":             "ui.library_page_state",
+		"ui.remember_library_page_state":    "ui.remember_library_page_state",
+		"search.media_scope":                "search.media_scope",
+		"ui.date_format":                    "ui.date_format",
+		"ui.time_format":                    "ui.time_format",
+		"player.hdr_enabled":                "player.hdr_enabled",
+		"player.dolby_vision_enabled":       "player.dolby_vision_enabled",
+		"player.dv_profile7_hdr10_fallback": "player.dv_profile7_hdr10_fallback",
+		"player.seek_cache_enabled":         "player.seek_cache_enabled",
+		"player.playback_speed":             keyPlaybackSpeed,
+		"player.audio_sync_ms":              "player.audio_sync_ms",
+		"player.subtitle_sync_ms":           "player.subtitle_sync_ms",
+		"player.video_gravity":              "player.video_gravity",
+		"player.orientation_mode":           "player.orientation_mode",
+
+		// Unregistered keys the extension bag accepted from the web client.
+		"ui_theme":             "ui.theme",
+		"ui_text_scale":        "ui.text_scale",
+		"ui_text_weight":       "ui.text_weight",
+		"ui_high_contrast":     "ui.high_contrast",
+		"ui_custom_theme_vars": "ui.custom_theme_vars",
+		"ui_custom_css":        "ui.custom_css",
+
+		// Unregistered device-setting keys Android writes today.
+		"player.match_frame_rate":            "player.match_frame_rate",
+		"player.sleep_timer_default_minutes": "player.sleep_timer_default_minutes",
+		"player.next_up_prompt_seconds":      keyNextUpPrompt,
+
+		// Profile columns that become settings.
+		"user_profiles.language":                    keyAudioLanguage,
+		"user_profiles.subtitle_language":           "playback.subtitle_language",
+		"user_profiles.subtitle_mode":               keySubtitleMode,
+		"user_profiles.quality_preference":          keyPreferredQuality,
+		"user_profiles.preferred_metadata_language": "catalog.metadata_language",
+		"user_profiles.show_forced_subtitles":       "playback.show_forced_subtitles",
+	}
+
+	manifest, err := Load()
+	if err != nil {
+		t.Fatalf("loading manifest: %v", err)
+	}
+
+	for legacy, canonical := range legacyToCanonical {
+		if _, ok := manifest.Lookup(canonical); !ok {
+			t.Errorf("legacy key %q maps to %q, which has no manifest definition", legacy, canonical)
+		}
+	}
+}
+
+func TestDefaultsValidateAgainstTheirOwnSchema(t *testing.T) {
+	manifest, err := Load()
+	if err != nil {
+		t.Fatalf("loading manifest: %v", err)
+	}
+
+	for i := range manifest.Definitions {
+		def := &manifest.Definitions[i]
+		t.Run(def.Key, func(t *testing.T) {
+			if len(def.DefaultValue) == 0 {
+				t.Fatal("default_value is missing")
+			}
+			if string(def.DefaultValue) == jsonNull {
+				if !def.ValueSchema.Nullable {
+					t.Fatal("default is null but the schema is not nullable")
+				}
+				return
+			}
+			if err := def.ValueSchema.ValidateValue(def.DefaultValue, objSchemas); err != nil {
+				t.Fatalf("default %s is invalid: %v", def.DefaultValue, err)
+			}
+		})
+	}
+}
+
+func TestResolutionOrdersAreComplete(t *testing.T) {
+	manifest, err := Load()
+	if err != nil {
+		t.Fatalf("loading manifest: %v", err)
+	}
+
+	for i := range manifest.Definitions {
+		def := &manifest.Definitions[i]
+		t.Run(def.Key, func(t *testing.T) {
+			order := def.ResolutionOrder
+			if len(order) == 0 {
+				t.Fatal("resolution_order is empty")
+			}
+			if order[len(order)-1] != ScopeDefault {
+				t.Fatalf("resolution_order ends with %q, want %q", order[len(order)-1], ScopeDefault)
+			}
+
+			seen := map[Scope]int{}
+			for _, scope := range order[:len(order)-1] {
+				seen[scope]++
+				if seen[scope] > 1 {
+					t.Errorf("resolution_order repeats %q", scope)
+				}
+				if !def.AllowsScope(scope) {
+					t.Errorf("resolution_order resolves %q, absent from allowed_scopes", scope)
+				}
+			}
+			for _, entry := range def.AllowedScopes {
+				if seen[entry.Scope] == 0 {
+					t.Errorf("scope %q is writable but never read", entry.Scope)
+				}
+			}
+		})
+	}
+}
+
+// TestCeilingConstraintsAreOrdered guards the failure the policy seam exists to
+// prevent: a ceiling declared on a type where "cap this" has no meaning would
+// silently do nothing.
+func TestCeilingConstraintsAreOrdered(t *testing.T) {
+	manifest, err := Load()
+	if err != nil {
+		t.Fatalf("loading manifest: %v", err)
+	}
+
+	for i := range manifest.Definitions {
+		def := &manifest.Definitions[i]
+		if def.ConstrainedBy == nil {
+			continue
+		}
+		kind := def.ConstrainedBy.Constraint
+		if kind != ConstraintCeiling && kind != ConstraintFloor {
+			continue
+		}
+		ordered := def.ValueSchema.Type == TypeInteger ||
+			def.ValueSchema.Type == TypeNumber ||
+			(def.ValueSchema.Type == TypeEnum && def.ValueSchema.Ordered)
+		if !ordered {
+			t.Errorf("%s declares a %s constraint on unordered type %s",
+				def.Key, kind, def.ValueSchema.Type)
+		}
+	}
+}
+
+func TestRevisionTagsNeverExceedManifestRevision(t *testing.T) {
+	manifest, err := Load()
+	if err != nil {
+		t.Fatalf("loading manifest: %v", err)
+	}
+
+	for i := range manifest.Definitions {
+		def := &manifest.Definitions[i]
+		if def.IntroducedIn > manifest.Revision {
+			t.Errorf("%s: introduced_in %d exceeds manifest revision %d",
+				def.Key, def.IntroducedIn, manifest.Revision)
+		}
+		for _, entry := range def.AllowedScopes {
+			if entry.IntroducedIn > manifest.Revision {
+				t.Errorf("%s: scope %q introduced_in %d exceeds manifest revision %d",
+					def.Key, entry.Scope, entry.IntroducedIn, manifest.Revision)
+			}
+		}
+		for _, member := range def.ValueSchema.Values {
+			if member.IntroducedIn > manifest.Revision {
+				t.Errorf("%s: enum member %v introduced_in %d exceeds manifest revision %d",
+					def.Key, member.Value, member.IntroducedIn, manifest.Revision)
+			}
+		}
+	}
+}
+
+func TestClientLocalDefinitionsNeverReachTheAPI(t *testing.T) {
+	manifest, err := Load()
+	if err != nil {
+		t.Fatalf("loading manifest: %v", err)
+	}
+
+	for i := range manifest.Definitions {
+		def := &manifest.Definitions[i]
+		if def.Persistence != PersistenceClientLocal {
+			continue
+		}
+		if def.IsRemote() {
+			t.Errorf("%s: client_local definition reports IsRemote", def.Key)
+		}
+		for _, entry := range def.AllowedScopes {
+			if entry.Scope.IsRemote() {
+				t.Errorf("%s: client_local definition allows remote scope %q", def.Key, entry.Scope)
+			}
+		}
+		if def.ConstrainedBy != nil {
+			t.Errorf("%s: client_local definition declares a policy constraint the server cannot apply", def.Key)
+		}
+	}
+}
+
+// TestPrivateLocalKeysAreRejected covers the escape hatch's boundary: a
+// local.* key must never appear in the shared contract.
+func TestPrivateLocalKeysAreRejected(t *testing.T) {
+	manifest, err := Load()
+	if err != nil {
+		t.Fatalf("loading manifest: %v", err)
+	}
+
+	for i := range manifest.Definitions {
+		if strings.HasPrefix(manifest.Definitions[i].Key, "local.") {
+			t.Errorf("%s: private local.* keys must stay out of the shared manifest",
+				manifest.Definitions[i].Key)
+		}
+	}
+}
+
+func TestCanonicalBytesAreStable(t *testing.T) {
+	first, err := CanonicalBytes()
+	if err != nil {
+		t.Fatalf("canonicalizing: %v", err)
+	}
+	second, err := CanonicalBytes()
+	if err != nil {
+		t.Fatalf("canonicalizing again: %v", err)
+	}
+	if string(first) != string(second) {
+		t.Fatal("canonical bytes differ between calls")
+	}
+
+	// Canonical output must itself be canonical, or the digest depends on how
+	// many times you ran it.
+	recanonicalized, err := canonicalize(first)
+	if err != nil {
+		t.Fatalf("re-canonicalizing: %v", err)
+	}
+	if string(recanonicalized) != string(first) {
+		t.Fatal("canonicalization is not idempotent")
+	}
+
+	tag, err := ETag()
+	if err != nil {
+		t.Fatalf("computing ETag: %v", err)
+	}
+	if !strings.HasPrefix(tag, `"`) || !strings.HasSuffix(tag, `"`) || len(tag) != 66 {
+		t.Fatalf("ETag %q is not a quoted SHA-256 hex digest", tag)
+	}
+}
+
+func TestCanonicalizationSortsKeysAndNormalizesNumbers(t *testing.T) {
+	got, err := canonicalize([]byte(`{"b":1,"a":{"d":3.0,"c":0.05},"e":[2.50,1e2]}`))
+	if err != nil {
+		t.Fatalf("canonicalizing: %v", err)
+	}
+	want := `{"a":{"c":0.05,"d":3},"b":1,"e":[2.5,100]}`
+	if string(got) != want {
+		t.Fatalf("canonicalize() = %s, want %s", got, want)
+	}
+}
+
+func TestPublicManifestStripsMaintainerNotes(t *testing.T) {
+	public, err := PublicBytes()
+	if err != nil {
+		t.Fatalf("building public manifest: %v", err)
+	}
+
+	var doc struct {
+		Definitions []map[string]json.RawMessage `json:"definitions"`
+	}
+	if err := json.Unmarshal(public, &doc); err != nil {
+		t.Fatalf("parsing public manifest: %v", err)
+	}
+	if len(doc.Definitions) == 0 {
+		t.Fatal("public manifest has no definitions")
+	}
+	for _, def := range doc.Definitions {
+		if _, present := def["notes"]; present {
+			t.Errorf("public manifest leaked maintainer notes: %s", def["key"])
+		}
+	}
+
+	// The private manifest is what carries notes; if it stopped carrying any,
+	// this test would pass vacuously.
+	raw, err := RawBytes()
+	if err != nil {
+		t.Fatalf("reading raw manifest: %v", err)
+	}
+	if !strings.Contains(string(raw), `"notes"`) {
+		t.Fatal("no definition carries notes, so the stripping test proves nothing")
+	}
+}
+
+func TestRevisionAwareFilteringHidesNewerElements(t *testing.T) {
+	def := &Definition{
+		Key:          fixtureKey,
+		IntroducedIn: 5,
+		AllowedScopes: []ScopeEntry{
+			{Scope: ScopeProfile},
+			{Scope: ScopeProfileDevice, IntroducedIn: 9},
+		},
+		ValueSchema: ValueSchema{
+			Type: TypeEnum,
+			Values: []EnumMember{
+				{Value: "old"},
+				{Value: "new", IntroducedIn: 9},
+			},
+		},
+	}
+
+	if def.VisibleAtRevision(4) {
+		t.Error("definition introduced at 5 should be hidden from a revision-4 peer")
+	}
+	if !def.VisibleAtRevision(5) {
+		t.Error("definition introduced at 5 should be visible to a revision-5 peer")
+	}
+
+	if got := def.ScopesAtRevision(5); len(got) != 1 || got[0] != ScopeProfile {
+		t.Errorf("ScopesAtRevision(5) = %v, want [profile]", got)
+	}
+	if got := def.ScopesAtRevision(9); len(got) != 2 {
+		t.Errorf("ScopesAtRevision(9) = %v, want both scopes", got)
+	}
+
+	if got := def.EnumValuesAtRevision(5); len(got) != 1 || got[0].Value != "old" {
+		t.Errorf("EnumValuesAtRevision(5) = %v, want [old]", got)
+	}
+	if got := def.EnumValuesAtRevision(9); len(got) != 2 {
+		t.Errorf("EnumValuesAtRevision(9) = %v, want both members", got)
+	}
+}
+
+func TestValidateValueRejectsOutOfContractValues(t *testing.T) {
+	manifest, err := Load()
+	if err != nil {
+		t.Fatalf("loading manifest: %v", err)
+	}
+
+	cases := []struct {
+		name    string
+		key     string
+		value   string
+		wantErr bool
+	}{
+		// The verified Android drift: the server contract stops at 3.0.
+		{name: "speed at contract maximum", key: keyPlaybackSpeed, value: "3.0"},
+		{name: "speed above contract maximum", key: keyPlaybackSpeed, value: "4.0", wantErr: true},
+		{name: "speed below contract minimum", key: keyPlaybackSpeed, value: "0.1", wantErr: true},
+
+		{name: "prompt seconds in range", key: keyNextUpPrompt, value: "30"},
+		{name: "prompt seconds above range", key: keyNextUpPrompt, value: "121", wantErr: true},
+		{name: "prompt seconds not an integer", key: keyNextUpPrompt, value: "30.5", wantErr: true},
+
+		{name: "boolean true", key: keyAutoPlayNext, value: "true"},
+		{name: "stringly boolean rejected", key: keyAutoPlayNext, value: `"true"`, wantErr: true},
+
+		{name: "known enum member", key: keySubtitleMode, value: `"always"`},
+		{name: "unknown enum member", key: keySubtitleMode, value: `"sometimes"`, wantErr: true},
+		{name: "legacy empty string is not a mode", key: keySubtitleMode, value: `""`, wantErr: true},
+
+		{name: "language tag", key: keyAudioLanguage, value: `"en-US"`},
+		{name: "language tag with script", key: keyAudioLanguage, value: `"zh-Hans-CN"`},
+		{name: "nullable language tag", key: keyAudioLanguage, value: jsonNull},
+		{name: "malformed language tag", key: keyAudioLanguage, value: `"not a language"`, wantErr: true},
+
+		{name: "non-nullable boolean rejects null", key: keyAutoPlayNext, value: jsonNull, wantErr: true},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			def, ok := manifest.Lookup(tc.key)
+			if !ok {
+				t.Fatalf("no definition for %q", tc.key)
+			}
+			err := def.ValueSchema.ValidateValue(json.RawMessage(tc.value), objSchemas)
+			if tc.wantErr && err == nil {
+				t.Fatalf("ValidateValue(%s) succeeded, want rejection", tc.value)
+			}
+			if !tc.wantErr && err != nil {
+				t.Fatalf("ValidateValue(%s) = %v, want success", tc.value, err)
+			}
+		})
+	}
+}
+
+func TestObjectValuesValidateAgainstTheirSchema(t *testing.T) {
+	manifest, err := Load()
+	if err != nil {
+		t.Fatalf("loading manifest: %v", err)
+	}
+	def, ok := manifest.Lookup(keySubtitleAppearance)
+	if !ok {
+		t.Fatal("playback.subtitle_appearance is not registered")
+	}
+
+	valid := `{
+		"fontSize": "large", "fontFamily": "sans-serif", "fontColor": "#ffffff",
+		"backgroundColor": "#000000", "backgroundStyle": "shadow", "backgroundOpacity": 75,
+		"textOutline": false, "textOutlineColor": "#000000", "position": "bottom"
+	}`
+	if err := def.ValueSchema.ValidateValue(json.RawMessage(valid), objSchemas); err != nil {
+		t.Fatalf("valid subtitle appearance rejected: %v", err)
+	}
+
+	for name, invalid := range map[string]string{
+		"unknown field": `{"fontSize":"large","fontFamily":"sans-serif","fontColor":"#ffffff",
+			"backgroundColor":"#000000","backgroundStyle":"shadow","backgroundOpacity":75,
+			"textOutline":false,"textOutlineColor":"#000000","position":"bottom","extra":1}`,
+		"opacity out of range": `{"fontSize":"large","fontFamily":"sans-serif","fontColor":"#ffffff",
+			"backgroundColor":"#000000","backgroundStyle":"shadow","backgroundOpacity":250,
+			"textOutline":false,"textOutlineColor":"#000000","position":"bottom"}`,
+		"malformed color": `{"fontSize":"large","fontFamily":"sans-serif","fontColor":"white",
+			"backgroundColor":"#000000","backgroundStyle":"shadow","backgroundOpacity":75,
+			"textOutline":false,"textOutlineColor":"#000000","position":"bottom"}`,
+		"missing field":  `{"fontSize":"large"}`,
+		"arbitrary json": `{"anything":"goes"}`,
+	} {
+		t.Run(name, func(t *testing.T) {
+			if err := def.ValueSchema.ValidateValue(json.RawMessage(invalid), objSchemas); err == nil {
+				t.Fatal("invalid subtitle appearance was accepted")
+			}
+		})
+	}
+}
+
+// TestValidateRejectsMalformedManifests exercises the invariant checks against
+// hand-built manifests, since the checked-in one is expected to be valid.
+func TestValidateRejectsMalformedManifests(t *testing.T) {
+	if _, err := Load(); err != nil {
+		t.Fatalf("loading manifest: %v", err)
+	}
+
+	base := func() Definition {
+		return Definition{
+			Key:             fixtureKey,
+			IntroducedIn:    1,
+			Persistence:     PersistenceRemote,
+			AllowedScopes:   []ScopeEntry{{Scope: ScopeProfile}},
+			ResolutionOrder: []Scope{ScopeProfile, ScopeDefault},
+			ValueSchema:     ValueSchema{Type: TypeBoolean},
+			DefaultValue:    json.RawMessage("false"),
+			Category:        "playback",
+			Label:           "Example",
+			Description:     "Example.",
+		}
+	}
+
+	cases := map[string]func(*Definition){
+		"resolution order missing default": func(d *Definition) {
+			d.ResolutionOrder = []Scope{ScopeProfile}
+		},
+		"resolution order references unlisted scope": func(d *Definition) {
+			d.ResolutionOrder = []Scope{ScopeProfileDevice, ScopeProfile, ScopeDefault}
+		},
+		"writable scope never read": func(d *Definition) {
+			d.AllowedScopes = append(d.AllowedScopes, ScopeEntry{Scope: ScopeProfileDevice})
+		},
+		"duplicate scope": func(d *Definition) {
+			d.AllowedScopes = []ScopeEntry{{Scope: ScopeProfile}, {Scope: ScopeProfile}}
+		},
+		"default violates schema": func(d *Definition) {
+			d.DefaultValue = json.RawMessage(`"yes"`)
+		},
+		"null default on non-nullable schema": func(d *Definition) {
+			d.DefaultValue = json.RawMessage(jsonNull)
+		},
+		"remote setting with client_local scope": func(d *Definition) {
+			d.AllowedScopes = []ScopeEntry{{Scope: ScopeClientLocal}}
+			d.ResolutionOrder = []Scope{ScopeClientLocal, ScopeDefault}
+		},
+		"client_local setting with remote scope": func(d *Definition) {
+			d.Persistence = PersistenceClientLocal
+		},
+		"ceiling on unordered enum": func(d *Definition) {
+			d.ValueSchema = ValueSchema{
+				Type:   TypeEnum,
+				Values: []EnumMember{{Value: "a"}, {Value: "b"}},
+			}
+			d.DefaultValue = json.RawMessage(`"a"`)
+			d.ConstrainedBy = &Constraint{PolicyInput: "example", Constraint: ConstraintCeiling}
+		},
+		"introduced_in after manifest revision": func(d *Definition) {
+			d.IntroducedIn = 99
+		},
+		"scope introduced before its definition": func(d *Definition) {
+			d.AllowedScopes = []ScopeEntry{{Scope: ScopeProfile, IntroducedIn: 1}}
+			d.IntroducedIn = 2
+		},
+	}
+
+	for name, mutate := range cases {
+		t.Run(name, func(t *testing.T) {
+			def := base()
+			mutate(&def)
+			manifest := &Manifest{APIVersion: 1, Revision: 2, Definitions: []Definition{def}}
+			if err := manifest.index(); err != nil {
+				t.Fatalf("indexing: %v", err)
+			}
+			if err := manifest.Validate(objSchemas); err == nil {
+				t.Fatal("Validate accepted a manifest that violates an invariant")
+			}
+		})
+	}
+}
+
+func TestDuplicateKeysAreRejected(t *testing.T) {
+	manifest := &Manifest{
+		APIVersion: 1,
+		Revision:   1,
+		Definitions: []Definition{
+			{Key: fixtureKey},
+			{Key: fixtureKey},
+		},
+	}
+	if err := manifest.index(); err == nil {
+		t.Fatal("index accepted a duplicate key")
+	}
+}

--- a/internal/settingscontract/load.go
+++ b/internal/settingscontract/load.go
@@ -1,0 +1,181 @@
+package settingscontract
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io/fs"
+	"path"
+	"sync"
+
+	"github.com/santhosh-tekuri/jsonschema/v6"
+
+	settingsv1 "github.com/Silo-Server/silo-server/contracts/settings/v1"
+)
+
+// contractFS is the embedded canonical contract. Clients vendor a pinned copy
+// of the same files.
+var contractFS = settingsv1.FS
+
+const (
+	manifestPath       = "manifest.json"
+	manifestSchemaPath = "manifest.schema.json"
+	schemasDir         = "schemas"
+)
+
+var (
+	loadOnce   sync.Once
+	loaded     *Manifest
+	loadedErr  error
+	loadedRaw  []byte
+	objSchemas map[string]*jsonschema.Schema
+)
+
+// Load returns the embedded canonical manifest, parsed and fully validated.
+//
+// It is loaded once per process. A malformed or self-inconsistent manifest is a
+// build-time defect, not a runtime condition: the contract tests fail on it, and
+// callers that reach this at runtime should treat the error as fatal at startup
+// rather than degrading.
+func Load() (*Manifest, error) {
+	loadOnce.Do(func() {
+		loaded, loadedRaw, loadedErr = load(contractFS)
+	})
+	return loaded, loadedErr
+}
+
+// MustLoad returns the embedded manifest or panics. For use in server startup
+// where a broken embedded contract cannot be recovered from.
+func MustLoad() *Manifest {
+	m, err := Load()
+	if err != nil {
+		panic(fmt.Sprintf("settingscontract: embedded manifest is invalid: %v", err))
+	}
+	return m
+}
+
+// RawBytes returns the embedded manifest file exactly as checked in.
+func RawBytes() ([]byte, error) {
+	if _, err := Load(); err != nil {
+		return nil, err
+	}
+	return append([]byte(nil), loadedRaw...), nil
+}
+
+// ObjectSchema returns the compiled JSON Schema for an object-typed value.
+func ObjectSchema(ref string) (*jsonschema.Schema, bool) {
+	if _, err := Load(); err != nil {
+		return nil, false
+	}
+	schema, ok := objSchemas[ref]
+	return schema, ok
+}
+
+func load(fsys fs.FS) (*Manifest, []byte, error) {
+	raw, err := fs.ReadFile(fsys, manifestPath)
+	if err != nil {
+		return nil, nil, fmt.Errorf("reading manifest: %w", err)
+	}
+
+	if err := validateAgainstManifestSchema(fsys, raw); err != nil {
+		return nil, nil, err
+	}
+
+	var manifest Manifest
+	decoder := json.NewDecoder(bytes.NewReader(raw))
+	decoder.DisallowUnknownFields()
+	if err := decoder.Decode(&manifest); err != nil {
+		return nil, nil, fmt.Errorf("parsing manifest: %w", err)
+	}
+
+	if err := manifest.index(); err != nil {
+		return nil, nil, err
+	}
+
+	schemas, err := compileObjectSchemas(fsys)
+	if err != nil {
+		return nil, nil, err
+	}
+	objSchemas = schemas
+
+	if err := manifest.Validate(schemas); err != nil {
+		return nil, nil, err
+	}
+
+	return &manifest, raw, nil
+}
+
+// validateAgainstManifestSchema checks the manifest file against its own JSON
+// Schema before Go decoding, so shape errors report as schema violations with a
+// location rather than as opaque unmarshal failures.
+func validateAgainstManifestSchema(fsys fs.FS, raw []byte) error {
+	schemaBytes, err := fs.ReadFile(fsys, manifestSchemaPath)
+	if err != nil {
+		return fmt.Errorf("reading manifest schema: %w", err)
+	}
+
+	schemaDoc, err := jsonschema.UnmarshalJSON(bytes.NewReader(schemaBytes))
+	if err != nil {
+		return fmt.Errorf("parsing manifest schema: %w", err)
+	}
+
+	compiler := jsonschema.NewCompiler()
+	if err := compiler.AddResource(manifestSchemaPath, schemaDoc); err != nil {
+		return fmt.Errorf("registering manifest schema: %w", err)
+	}
+	schema, err := compiler.Compile(manifestSchemaPath)
+	if err != nil {
+		return fmt.Errorf("compiling manifest schema: %w", err)
+	}
+
+	doc, err := jsonschema.UnmarshalJSON(bytes.NewReader(raw))
+	if err != nil {
+		return fmt.Errorf("parsing manifest: %w", err)
+	}
+	if err := schema.Validate(doc); err != nil {
+		return fmt.Errorf("manifest does not satisfy manifest.schema.json: %w", err)
+	}
+	return nil
+}
+
+// compileObjectSchemas compiles every schema under schemas/ so object-typed
+// values and their defaults can be validated. Compiling all of them up front
+// also catches a malformed schema file that no definition happens to reference
+// yet.
+func compileObjectSchemas(fsys fs.FS) (map[string]*jsonschema.Schema, error) {
+	entries, err := fs.ReadDir(fsys, schemasDir)
+	if err != nil {
+		return nil, fmt.Errorf("reading value schema directory: %w", err)
+	}
+
+	compiler := jsonschema.NewCompiler()
+	names := make([]string, 0, len(entries))
+	for _, entry := range entries {
+		if entry.IsDir() {
+			continue
+		}
+		name := entry.Name()
+		body, err := fs.ReadFile(fsys, path.Join(schemasDir, name))
+		if err != nil {
+			return nil, fmt.Errorf("reading value schema %s: %w", name, err)
+		}
+		doc, err := jsonschema.UnmarshalJSON(bytes.NewReader(body))
+		if err != nil {
+			return nil, fmt.Errorf("parsing value schema %s: %w", name, err)
+		}
+		if err := compiler.AddResource(name, doc); err != nil {
+			return nil, fmt.Errorf("registering value schema %s: %w", name, err)
+		}
+		names = append(names, name)
+	}
+
+	compiled := make(map[string]*jsonschema.Schema, len(names))
+	for _, name := range names {
+		schema, err := compiler.Compile(name)
+		if err != nil {
+			return nil, fmt.Errorf("compiling value schema %s: %w", name, err)
+		}
+		compiled[name] = schema
+	}
+	return compiled, nil
+}

--- a/internal/settingscontract/validate.go
+++ b/internal/settingscontract/validate.go
@@ -1,0 +1,435 @@
+package settingscontract
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"regexp"
+	"strings"
+
+	"github.com/santhosh-tekuri/jsonschema/v6"
+)
+
+// Validate checks every invariant the manifest schema cannot express: that
+// resolution orders are consistent with allowed scopes, that defaults satisfy
+// their own value schemas, that revision tags are internally ordered, and that
+// policy constraints are applicable to the type they are declared on.
+//
+// A failure here is a defect in the checked-in contract. It is surfaced by the
+// contract tests, and by startup if it somehow ships.
+func (m *Manifest) Validate(objectSchemas map[string]*jsonschema.Schema) error {
+	var errs []error
+
+	if m.APIVersion < 1 {
+		errs = append(errs, fmt.Errorf("api_version must be at least 1, got %d", m.APIVersion))
+	}
+	if m.Revision < 1 {
+		errs = append(errs, fmt.Errorf("revision must be at least 1, got %d", m.Revision))
+	}
+	if len(m.Definitions) == 0 {
+		errs = append(errs, errors.New("manifest declares no definitions"))
+	}
+
+	for i := range m.Definitions {
+		def := &m.Definitions[i]
+		if err := def.validate(m.Revision, objectSchemas); err != nil {
+			errs = append(errs, fmt.Errorf("%s: %w", def.Key, err))
+		}
+	}
+
+	return errors.Join(errs...)
+}
+
+func (d *Definition) validate(manifestRevision int, objectSchemas map[string]*jsonschema.Schema) error {
+	var errs []error
+
+	if d.IntroducedIn < 1 || d.IntroducedIn > manifestRevision {
+		errs = append(errs, fmt.Errorf(
+			"introduced_in %d is outside 1..%d (the manifest revision)", d.IntroducedIn, manifestRevision))
+	}
+
+	errs = append(errs, d.validateScopes(manifestRevision)...)
+	errs = append(errs, d.validateResolutionOrder()...)
+	errs = append(errs, d.ValueSchema.validate(manifestRevision, objectSchemas)...)
+	errs = append(errs, d.validateDefault(objectSchemas)...)
+	errs = append(errs, d.validateConstraint()...)
+
+	return errors.Join(errs...)
+}
+
+func (d *Definition) validateScopes(manifestRevision int) []error {
+	var errs []error
+
+	if len(d.AllowedScopes) == 0 {
+		return []error{errors.New("allowed_scopes is empty")}
+	}
+
+	seen := make(map[Scope]struct{}, len(d.AllowedScopes))
+	for _, entry := range d.AllowedScopes {
+		if _, dup := seen[entry.Scope]; dup {
+			errs = append(errs, fmt.Errorf("allowed_scopes repeats %q", entry.Scope))
+		}
+		seen[entry.Scope] = struct{}{}
+
+		if entry.IntroducedIn != 0 {
+			if entry.IntroducedIn < d.IntroducedIn {
+				errs = append(errs, fmt.Errorf(
+					"scope %q claims introduced_in %d, before the definition's own %d",
+					entry.Scope, entry.IntroducedIn, d.IntroducedIn))
+			}
+			if entry.IntroducedIn > manifestRevision {
+				errs = append(errs, fmt.Errorf(
+					"scope %q claims introduced_in %d, after the manifest revision %d",
+					entry.Scope, entry.IntroducedIn, manifestRevision))
+			}
+		}
+	}
+
+	// Persistence and scope have to agree, or a client cannot tell where a value
+	// lives from the definition alone.
+	switch d.Persistence {
+	case PersistenceRemote:
+		for _, entry := range d.AllowedScopes {
+			if !entry.Scope.IsRemote() {
+				errs = append(errs, fmt.Errorf(
+					"remote setting allows non-remote scope %q", entry.Scope))
+			}
+		}
+	case PersistenceClientLocal:
+		if len(d.AllowedScopes) != 1 || d.AllowedScopes[0].Scope != ScopeClientLocal {
+			errs = append(errs, errors.New(
+				`client_local setting must declare exactly one scope, "client_local"`))
+		}
+		if d.ConstrainedBy != nil {
+			errs = append(errs, errors.New(
+				"client_local setting declares constrained_by, but the server never resolves it"))
+		}
+	default:
+		errs = append(errs, fmt.Errorf("unknown persistence %q", d.Persistence))
+	}
+
+	return errs
+}
+
+func (d *Definition) validateResolutionOrder() []error {
+	var errs []error
+
+	order := d.ResolutionOrder
+	if len(order) == 0 {
+		return []error{errors.New("resolution_order is empty")}
+	}
+	if order[len(order)-1] != ScopeDefault {
+		return []error{fmt.Errorf(
+			"resolution_order must end with %q, got %q", ScopeDefault, order[len(order)-1])}
+	}
+
+	seen := make(map[Scope]struct{}, len(order))
+	for _, scope := range order[:len(order)-1] {
+		if _, dup := seen[scope]; dup {
+			errs = append(errs, fmt.Errorf("resolution_order repeats %q", scope))
+		}
+		seen[scope] = struct{}{}
+
+		if scope == ScopeDefault {
+			errs = append(errs, errors.New(`resolution_order lists "default" before the end`))
+			continue
+		}
+		if !d.AllowsScope(scope) {
+			errs = append(errs, fmt.Errorf(
+				"resolution_order resolves %q, which is not in allowed_scopes", scope))
+		}
+	}
+
+	// Every scope a value can be written at must be reachable when reading it,
+	// or the setting accepts writes it will never honor.
+	for _, entry := range d.AllowedScopes {
+		if _, ok := seen[entry.Scope]; !ok {
+			errs = append(errs, fmt.Errorf(
+				"scope %q is writable but never read: missing from resolution_order", entry.Scope))
+		}
+	}
+
+	return errs
+}
+
+func (v *ValueSchema) validate(manifestRevision int, objectSchemas map[string]*jsonschema.Schema) []error {
+	var errs []error
+
+	switch v.Type {
+	case TypeBoolean, TypeLanguageTag:
+		// No constraints beyond nullability.
+
+	case TypeInteger, TypeNumber:
+		if v.Minimum == nil || v.Maximum == nil {
+			errs = append(errs, fmt.Errorf("%s requires minimum and maximum", v.Type))
+			break
+		}
+		if *v.Minimum > *v.Maximum {
+			errs = append(errs, fmt.Errorf(
+				"minimum %g exceeds maximum %g", *v.Minimum, *v.Maximum))
+		}
+		if v.Step != nil && *v.Step <= 0 {
+			errs = append(errs, fmt.Errorf("step must be positive, got %g", *v.Step))
+		}
+		for label, rev := range map[string]int{
+			"minimum_introduced_in": v.MinimumIntroducedIn,
+			"maximum_introduced_in": v.MaximumIntroducedIn,
+		} {
+			if rev != 0 && rev > manifestRevision {
+				errs = append(errs, fmt.Errorf(
+					"%s is %d, after the manifest revision %d", label, rev, manifestRevision))
+			}
+		}
+
+	case TypeString:
+		if v.MaxLength == nil {
+			errs = append(errs, errors.New("string requires max_length"))
+		} else if *v.MaxLength < 1 {
+			errs = append(errs, fmt.Errorf("max_length must be positive, got %d", *v.MaxLength))
+		}
+		if v.MinLength != nil && v.MaxLength != nil && *v.MinLength > *v.MaxLength {
+			errs = append(errs, fmt.Errorf(
+				"min_length %d exceeds max_length %d", *v.MinLength, *v.MaxLength))
+		}
+		if v.Pattern != "" {
+			if _, err := regexp.Compile(v.Pattern); err != nil {
+				errs = append(errs, fmt.Errorf("pattern does not compile: %w", err))
+			}
+		}
+
+	case TypeEnum:
+		if len(v.Values) == 0 {
+			errs = append(errs, errors.New("enum requires at least one member"))
+		}
+		seen := make(map[string]struct{}, len(v.Values))
+		for _, member := range v.Values {
+			token := fmt.Sprintf("%v", member.Value)
+			if _, dup := seen[token]; dup {
+				errs = append(errs, fmt.Errorf("enum repeats value %q", token))
+			}
+			seen[token] = struct{}{}
+			if member.IntroducedIn != 0 && member.IntroducedIn > manifestRevision {
+				errs = append(errs, fmt.Errorf(
+					"enum member %q claims introduced_in %d, after the manifest revision %d",
+					token, member.IntroducedIn, manifestRevision))
+			}
+		}
+
+	case TypeObject:
+		if v.SchemaRef == "" {
+			errs = append(errs, errors.New("object requires schema_ref"))
+			break
+		}
+		if _, ok := objectSchemas[v.SchemaRef]; !ok {
+			errs = append(errs, fmt.Errorf(
+				"schema_ref %q has no file under contracts/settings/v1/schemas", v.SchemaRef))
+		}
+
+	default:
+		errs = append(errs, fmt.Errorf("unknown value type %q", v.Type))
+	}
+
+	return errs
+}
+
+func (d *Definition) validateDefault(objectSchemas map[string]*jsonschema.Schema) []error {
+	raw := bytes.TrimSpace(d.DefaultValue)
+	if len(raw) == 0 {
+		return []error{errors.New("default_value is required; use null for a nullable setting")}
+	}
+
+	if bytes.Equal(raw, []byte("null")) {
+		if !d.ValueSchema.Nullable {
+			return []error{errors.New("default_value is null but the value schema is not nullable")}
+		}
+		return nil
+	}
+
+	if err := d.ValueSchema.ValidateValue(raw, objectSchemas); err != nil {
+		return []error{fmt.Errorf("default_value is invalid: %w", err)}
+	}
+	return nil
+}
+
+func (d *Definition) validateConstraint() []error {
+	if d.ConstrainedBy == nil {
+		return nil
+	}
+
+	var errs []error
+	switch d.ConstrainedBy.Constraint {
+	case ConstraintCeiling, ConstraintFloor:
+		// Capping a value only means something where values are comparable.
+		// Declaring a ceiling on an unordered enum silently does nothing, which
+		// is worse than refusing it.
+		ordered := d.ValueSchema.Type == TypeInteger ||
+			d.ValueSchema.Type == TypeNumber ||
+			(d.ValueSchema.Type == TypeEnum && d.ValueSchema.Ordered)
+		if !ordered {
+			errs = append(errs, fmt.Errorf(
+				"%s constraint requires a numeric type or an ordered enum, got %s",
+				d.ConstrainedBy.Constraint, d.ValueSchema.Type))
+		}
+	case ConstraintAllowlist, ConstraintLocked:
+		// Applicable to any type.
+	default:
+		errs = append(errs, fmt.Errorf("unknown constraint %q", d.ConstrainedBy.Constraint))
+	}
+
+	if strings.TrimSpace(d.ConstrainedBy.PolicyInput) == "" {
+		errs = append(errs, errors.New("constrained_by requires a policy_input"))
+	}
+
+	return errs
+}
+
+// ValidateValue checks a JSON value against this schema. It is the single
+// validation path: the mutation endpoint, the migration, and the manifest's own
+// default checks all use it, so a value that validates in one place validates
+// everywhere.
+func (v *ValueSchema) ValidateValue(raw json.RawMessage, objectSchemas map[string]*jsonschema.Schema) error {
+	trimmed := bytes.TrimSpace(raw)
+	if bytes.Equal(trimmed, []byte("null")) {
+		if v.Nullable {
+			return nil
+		}
+		return errors.New("null is not allowed for this setting")
+	}
+
+	switch v.Type {
+	case TypeBoolean:
+		var value bool
+		if err := strictUnmarshal(trimmed, &value); err != nil {
+			return fmt.Errorf("expected a boolean: %w", err)
+		}
+
+	case TypeInteger:
+		var value json.Number
+		if err := strictUnmarshal(trimmed, &value); err != nil {
+			return fmt.Errorf("expected an integer: %w", err)
+		}
+		parsed, err := value.Int64()
+		if err != nil {
+			return fmt.Errorf("expected an integer, got %s", value)
+		}
+		return v.checkRange(float64(parsed))
+
+	case TypeNumber:
+		var value json.Number
+		if err := strictUnmarshal(trimmed, &value); err != nil {
+			return fmt.Errorf("expected a number: %w", err)
+		}
+		parsed, err := value.Float64()
+		if err != nil {
+			return fmt.Errorf("expected a number, got %s", value)
+		}
+		return v.checkRange(parsed)
+
+	case TypeString:
+		var value string
+		if err := strictUnmarshal(trimmed, &value); err != nil {
+			return fmt.Errorf("expected a string: %w", err)
+		}
+		return v.checkString(value)
+
+	case TypeEnum:
+		var value any
+		if err := strictUnmarshal(trimmed, &value); err != nil {
+			return fmt.Errorf("expected an enum value: %w", err)
+		}
+		token := fmt.Sprintf("%v", value)
+		for _, member := range v.Values {
+			if fmt.Sprintf("%v", member.Value) == token {
+				return nil
+			}
+		}
+		return fmt.Errorf("%q is not one of %s", token, v.enumTokens())
+
+	case TypeLanguageTag:
+		var value string
+		if err := strictUnmarshal(trimmed, &value); err != nil {
+			return fmt.Errorf("expected a language tag: %w", err)
+		}
+		if !languageTagPattern.MatchString(value) {
+			return fmt.Errorf("%q is not a well-formed BCP 47 language tag", value)
+		}
+
+	case TypeObject:
+		schema, ok := objectSchemas[v.SchemaRef]
+		if !ok {
+			return fmt.Errorf("no compiled schema for %q", v.SchemaRef)
+		}
+		doc, err := jsonschema.UnmarshalJSON(bytes.NewReader(trimmed))
+		if err != nil {
+			return fmt.Errorf("expected an object: %w", err)
+		}
+		if err := schema.Validate(doc); err != nil {
+			return fmt.Errorf("does not satisfy %s: %w", v.SchemaRef, err)
+		}
+
+	default:
+		return fmt.Errorf("unknown value type %q", v.Type)
+	}
+
+	return nil
+}
+
+func (v *ValueSchema) checkRange(value float64) error {
+	if v.Minimum != nil && value < *v.Minimum {
+		return fmt.Errorf("%g is below the minimum %g", value, *v.Minimum)
+	}
+	if v.Maximum != nil && value > *v.Maximum {
+		return fmt.Errorf("%g is above the maximum %g", value, *v.Maximum)
+	}
+	return nil
+}
+
+func (v *ValueSchema) checkString(value string) error {
+	length := len([]rune(value))
+	if v.MinLength != nil && length < *v.MinLength {
+		return fmt.Errorf("is shorter than the minimum %d characters", *v.MinLength)
+	}
+	if v.MaxLength != nil && length > *v.MaxLength {
+		return fmt.Errorf("is longer than the maximum %d characters", *v.MaxLength)
+	}
+	if v.Pattern != "" {
+		matcher, err := regexp.Compile(v.Pattern)
+		if err != nil {
+			return fmt.Errorf("pattern does not compile: %w", err)
+		}
+		if !matcher.MatchString(value) {
+			return fmt.Errorf("does not match %s", v.Pattern)
+		}
+	}
+	return nil
+}
+
+func (v *ValueSchema) enumTokens() string {
+	tokens := make([]string, 0, len(v.Values))
+	for _, member := range v.Values {
+		tokens = append(tokens, fmt.Sprintf("%v", member.Value))
+	}
+	return strings.Join(tokens, ", ")
+}
+
+// strictUnmarshal rejects trailing content and, for numbers, preserves the
+// literal so an integer field cannot silently accept 1.5.
+func strictUnmarshal(raw []byte, target any) error {
+	decoder := json.NewDecoder(bytes.NewReader(raw))
+	decoder.UseNumber()
+	if err := decoder.Decode(target); err != nil {
+		return err
+	}
+	if decoder.More() {
+		return errors.New("unexpected trailing content")
+	}
+	return nil
+}
+
+// languageTagPattern accepts well-formed BCP 47 tags of the shapes Silo
+// actually stores: language, language-region, and language-script-region.
+// Full RFC 5646 grammar is deliberately not implemented; anything this rejects
+// is a value no client currently produces.
+var languageTagPattern = regexp.MustCompile(
+	`^[a-zA-Z]{2,3}(-[a-zA-Z]{4})?(-([a-zA-Z]{2}|[0-9]{3}))?$`)


### PR DESCRIPTION
First implementation step for the settings contract (#477). Adds the artifact everything else depends on. **Nothing reads it yet** — no routes, no storage, no behavior change.

## What changed

**`contracts/settings/v1/`** — the artifact, at a stable path because clients vendor it and generate bindings from it
- `manifest.json` — **38 definitions** (35 remote, 3 contract-known `client_local`)
- `manifest.schema.json` — the contract format
- `schemas/` — object value schemas for subtitle appearance, theme variable overrides, library page state
- `embed.go` — a package containing nothing but the embed directive, because `go:embed` cannot reach outside its own directory

**`internal/settingscontract/`** — loading, structural validation, value validation, RFC 8785 canonicalization, ETag, and a public projection that strips maintainer notes

## What the inventory turned up

The manifest covers every key the legacy registry accepts, every key the extension bag was silently accepting, every unregistered device key Android writes, and the profile columns that become settings. Each non-obvious case is recorded in a `notes` field:

| Finding | Disposition |
|---|---|
| `ui_theme`, `ui_text_scale`, `ui_text_weight`, `ui_high_contrast`, `ui_custom_theme_vars`, `ui_custom_css` reached the server **only** via the unknown-key extension bag — untyped and unvalidated, with `ui_custom_theme_vars` storing arbitrary JSON | Registered, typed, renamed to the dotted convention, moved to profile scope |
| `player.match_frame_rate` and `player.sleep_timer_default_minutes` are written by Android against a server that registers neither, so **every write and every reset returns 400 today** | Registered |
| `player.next_up_prompt_seconds` is Android's alias for `playback.next_up_prompt_seconds` | Not a definition; pinned as a migration alias in the test matrix |
| Android clamps playback speed to `4.0`, the server to `3.0` | Contract maximum is `3.0` |
| `subtitle_appearance` is the only key with no domain prefix | Renamed to `playback.subtitle_appearance` |

## Validation is stricter than the schema

The JSON Schema checks shape. The Go layer checks what actually causes bugs:

- A resolution order must end in `default` and may only resolve scopes the definition allows
- **Every writable scope must actually be read** — a setting cannot accept writes at a scope it will never honor, which is the "I changed it and nothing happened" failure mode
- Defaults validate against their own value schema, so a default outside its own range or enum fails at load
- Revision tags can never exceed the manifest revision, which is what makes revision-aware client filtering trustworthy
- `ceiling`/`floor` policy constraints are rejected on unordered types, where capping would silently do nothing. This forced `playback.preferred_quality`'s enum to be ordered ascending so its `max_playback_quality` ceiling has a defined direction

`ValidateValue` is the single validation path, so the mutation endpoint, the migration, and the manifest's own default checks cannot diverge later. Numbers decode through `json.Number`, so an integer setting rejects `30.5` instead of truncating, and object values validate against their referenced schema rather than accepting any JSON the way `validateJSONSetting` does today.

## Verification

- **124 tests across 16 cases pass** — the inventory matrix, per-definition defaults and resolution orders, revision filtering in both directions, canonical-byte stability and idempotence, notes stripping, and a table of eleven malformed manifests that must be rejected
- `golangci-lint run ./internal/settingscontract/... ./contracts/...` → **0 issues**
- `make verify-local-paths` passes; `go build ./...` clean
- Two failures in `internal/api/handlers` reproduce unchanged on `main` and are unrelated (one needs ffmpeg, one is a temp-dir cleanup race)

## Notes for review

- Promotes `santhosh-tekuri/jsonschema/v6` from indirect to direct
- The three `client_local` definitions (`downloads.wifi_only`, `downloads.keep_watched`, `subtitle.matches_device`) are contract-owned because Apple and Android both implement them with shared semantics, but the value never leaves the device. Validation enforces exactly one `client_local` scope and no policy constraint
- The renames are sanctioned by the design's non-goal of preserving accidental key names and are free during a breaking cutover, but they are judgment calls worth confirming
- `ui.theme` carries a device override, added in the second commit — light theme on a phone in daylight, dark on a TV. `ui.custom_theme_vars` and `ui.custom_css` stay profile-wide, so custom tokens tuned against a dark theme will sit on top of a light one if a device overrides. Widening those later is an additive revision bump

Part of #376. Design: #477.

## AI-use disclosure

Implemented with AI assistance (Claude Opus 5) under maintainer direction. The inventory was derived by reading the current server registry, web manifest, Android `PlaybackSettingsKeys`, and the profile/library/series preference stores; every drift claim is reproducible from those sources.
