### PR TITLE
feat(watchsync): add plugin-backed providers

### DIFF
--- a/cmd/silo/main.go
+++ b/cmd/silo/main.go
@@ -849,6 +849,7 @@ func main() {
 	}
 	var watchProviderService *watchsync.Service
 	var watchProviderRegistry *watchsync.Registry
+	var watchProviderRepo *watchsync.PostgresRepository
 	if deps.DB != nil {
 		watchProviderRegistry = watchsync.NewRegistry()
 		if err := watchProviderRegistry.Register(trakt.NewProvider(nil, "")); err != nil {
@@ -860,10 +861,8 @@ func main() {
 		if err := watchProviderRegistry.Register(watchmdblist.NewProvider(nil, "")); err != nil {
 			log.Fatalf("register watch provider: %v", err)
 		}
-		watchProviderService = watchsync.NewService(
-			watchsync.NewPostgresRepository(deps.DB, deps.SecretCipher),
-			watchProviderRegistry,
-		)
+		watchProviderRepo = watchsync.NewPostgresRepository(deps.DB, deps.SecretCipher)
+		watchProviderService = watchsync.NewService(watchProviderRepo, watchProviderRegistry)
 		deps.WatchProviderService = watchProviderService
 	}
 
@@ -1077,7 +1076,7 @@ func main() {
 		)
 		if watchProviderRegistry != nil {
 			reloadWatchProviders := func(ctx context.Context) {
-				if err := reloadWatchSyncPluginProviders(ctx, watchProviderRegistry, installationStore, pluginService); err != nil {
+				if err := reloadWatchSyncPluginProviders(ctx, watchProviderRegistry, installationStore, pluginService, watchProviderRepo); err != nil {
 					slog.WarnContext(ctx, "failed to reload watch sync plugin providers", "component", "app", "error", err)
 				}
 			}
@@ -3059,6 +3058,7 @@ func reloadWatchSyncPluginProviders(
 	registry *watchsync.Registry,
 	store markerPluginCapabilityStore,
 	service *plugins.Service,
+	repository watchsync.PluginCredentialRepository,
 ) error {
 	if registry == nil {
 		return nil
@@ -3119,6 +3119,10 @@ func reloadWatchSyncPluginProviders(
 				ResolveClient: func(callCtx context.Context, installationID int, capabilityID string) (watchsync.WatchSyncPluginClient, error) {
 					return service.WatchSyncProviderClient(callCtx, installationID, capabilityID)
 				},
+				ResolveConfig: func(callCtx context.Context, installationID int) (*pluginv1.WatchSyncProviderConfig, error) {
+					return service.WatchSyncProviderConfig(callCtx, installationID)
+				},
+				Repository: repository,
 			})
 			if err != nil {
 				slog.WarnContext(ctx, "skip unsupported watch sync plugin capability",

--- a/cmd/silo/main.go
+++ b/cmd/silo/main.go
@@ -19,6 +19,7 @@ import (
 	"sort"
 	"strconv"
 	"strings"
+	"sync"
 	"sync/atomic"
 	"syscall"
 	"time"
@@ -847,8 +848,9 @@ func main() {
 		)
 	}
 	var watchProviderService *watchsync.Service
+	var watchProviderRegistry *watchsync.Registry
 	if deps.DB != nil {
-		watchProviderRegistry := watchsync.NewRegistry()
+		watchProviderRegistry = watchsync.NewRegistry()
 		if err := watchProviderRegistry.Register(trakt.NewProvider(nil, "")); err != nil {
 			log.Fatalf("register watch provider: %v", err)
 		}
@@ -1073,6 +1075,15 @@ func main() {
 			installer,
 			plugins.NewHostAdapter(pluginHost),
 		)
+		if watchProviderRegistry != nil {
+			reloadWatchProviders := func(ctx context.Context) {
+				if err := reloadWatchSyncPluginProviders(ctx, watchProviderRegistry, installationStore, pluginService); err != nil {
+					slog.WarnContext(ctx, "failed to reload watch sync plugin providers", "component", "app", "error", err)
+				}
+			}
+			pluginService.AddLifecycleHook(reloadWatchProviders)
+			reloadWatchProviders(appCtx)
+		}
 		if deps.MarkerRegistry != nil && deps.MarkerProviderConfig != nil {
 			markerPluginResolver := markers.NewPluginResolverAdapter(pluginService)
 			pluginService.AddLifecycleHook(func(ctx context.Context) {
@@ -3036,9 +3047,92 @@ func metadataInt(value any) int {
 	}
 }
 
+var watchSyncPluginReloadMu sync.Mutex
+
 type markerPluginCapabilityStore interface {
 	ListEnabled(ctx context.Context) ([]*plugins.Installation, error)
 	ListCapabilities(ctx context.Context, installationID int) ([]*plugins.Capability, error)
+}
+
+func reloadWatchSyncPluginProviders(
+	ctx context.Context,
+	registry *watchsync.Registry,
+	store markerPluginCapabilityStore,
+	service *plugins.Service,
+) error {
+	if registry == nil {
+		return nil
+	}
+	watchSyncPluginReloadMu.Lock()
+	defer watchSyncPluginReloadMu.Unlock()
+
+	var providers []watchsync.Provider
+	if store == nil || service == nil {
+		return registry.ReplacePluginProviders(providers)
+	}
+	installations, err := store.ListEnabled(ctx)
+	if err != nil {
+		return fmt.Errorf("list enabled watch sync plugin installations: %w", err)
+	}
+	sort.Slice(installations, func(i, j int) bool {
+		if installations[i] == nil {
+			return false
+		}
+		if installations[j] == nil {
+			return true
+		}
+		return installations[i].ID < installations[j].ID
+	})
+	for _, installation := range installations {
+		if installation == nil || installation.IsBuiltin() {
+			continue
+		}
+		capabilities, err := store.ListCapabilities(ctx, installation.ID)
+		if err != nil {
+			slog.WarnContext(ctx, "skip watch sync plugin with unreadable capabilities",
+				"component", "app",
+				"installation_id", installation.ID,
+				"error", err,
+			)
+			continue
+		}
+		for _, capability := range capabilities {
+			if capability == nil || capability.Type != sdkcapability.WatchSyncProvider {
+				continue
+			}
+			descriptor, err := plugins.DecodeCapability(capability)
+			if err != nil {
+				slog.WarnContext(ctx, "skip invalid watch sync plugin capability",
+					"component", "app",
+					"installation_id", installation.ID,
+					"capability_id", capability.ID,
+					"error", err,
+				)
+				continue
+			}
+			provider, err := watchsync.NewPluginProvider(watchsync.PluginProviderOptions{
+				InstallationID: installation.ID,
+				ProviderKey:    fmt.Sprintf("plugin:%d:%s", installation.ID, capability.ID),
+				CapabilityID:   capability.ID,
+				DisplayName:    descriptor.GetDisplayName(),
+				Descriptor:     descriptor.GetWatchSyncProvider(),
+				ResolveClient: func(callCtx context.Context, installationID int, capabilityID string) (watchsync.WatchSyncPluginClient, error) {
+					return service.WatchSyncProviderClient(callCtx, installationID, capabilityID)
+				},
+			})
+			if err != nil {
+				slog.WarnContext(ctx, "skip unsupported watch sync plugin capability",
+					"component", "app",
+					"installation_id", installation.ID,
+					"capability_id", capability.ID,
+					"error", err,
+				)
+				continue
+			}
+			providers = append(providers, provider)
+		}
+	}
+	return registry.ReplacePluginProviders(providers)
 }
 
 type markerPluginRuntimeConfigStore interface {

--- a/cmd/silo/main_test.go
+++ b/cmd/silo/main_test.go
@@ -220,7 +220,7 @@ func TestReloadWatchSyncPluginProvidersDropsStaleProvidersOnCapabilityReadFailur
 	}
 
 	if err := reloadWatchSyncPluginProviders(
-		context.Background(), registry, failingWatchSyncCapabilityStore{}, &plugins.Service{},
+		context.Background(), registry, failingWatchSyncCapabilityStore{}, &plugins.Service{}, nil,
 	); err != nil {
 		t.Fatal(err)
 	}

--- a/cmd/silo/main_test.go
+++ b/cmd/silo/main_test.go
@@ -1,6 +1,8 @@
 package main
 
 import (
+	"context"
+	"errors"
 	"io"
 	"net/http"
 	"net/http/httptest"
@@ -8,9 +10,12 @@ import (
 	"sync"
 	"testing"
 
+	pluginv1 "github.com/Silo-Server/silo-plugin-sdk/pkg/pluginproto/silo/plugin/v1"
 	"github.com/Silo-Server/silo-server/internal/api"
 	"github.com/Silo-Server/silo-server/internal/config"
 	"github.com/Silo-Server/silo-server/internal/playback"
+	"github.com/Silo-Server/silo-server/internal/plugins"
+	"github.com/Silo-Server/silo-server/internal/watchsync"
 )
 
 func TestConfigureS3Clients_SetsCORSOnPublicAssetsBucket(t *testing.T) {
@@ -180,5 +185,46 @@ func TestBuildLiveSessionSync_UsesTransportPlayMethod(t *testing.T) {
 				t.Fatalf("TranscodeHWAccel = %q, want %q", got.TranscodeHWAccel, tc.session.TranscodeHWAccel)
 			}
 		})
+	}
+}
+
+type failingWatchSyncCapabilityStore struct{}
+
+func (failingWatchSyncCapabilityStore) ListEnabled(context.Context) ([]*plugins.Installation, error) {
+	return []*plugins.Installation{{ID: 2, Enabled: true, Kind: plugins.KindPlugin}}, nil
+}
+
+func (failingWatchSyncCapabilityStore) ListCapabilities(context.Context, int) ([]*plugins.Capability, error) {
+	return nil, errors.New("database unavailable")
+}
+
+func TestReloadWatchSyncPluginProvidersDropsStaleProvidersOnCapabilityReadFailure(t *testing.T) {
+	registry := watchsync.NewRegistry()
+	provider, err := watchsync.NewPluginProvider(watchsync.PluginProviderOptions{
+		InstallationID: 1,
+		ProviderKey:    "plugin:1:tracker",
+		CapabilityID:   "tracker",
+		Descriptor: &pluginv1.WatchSyncProviderDescriptor{
+			AuthMethods:   []pluginv1.WatchSyncAuthMethod{pluginv1.WatchSyncAuthMethod_WATCH_SYNC_AUTH_METHOD_API_KEY},
+			ExportWatched: true,
+		},
+		ResolveClient: func(context.Context, int, string) (watchsync.WatchSyncPluginClient, error) {
+			return nil, errors.New("not used")
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := registry.Register(provider); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := reloadWatchSyncPluginProviders(
+		context.Background(), registry, failingWatchSyncCapabilityStore{}, &plugins.Service{},
+	); err != nil {
+		t.Fatal(err)
+	}
+	if _, ok := registry.Get(provider.Key()); ok {
+		t.Fatalf("stale provider %q remained registered", provider.Key())
 	}
 }

--- a/docs/superpowers/specs/2026-07-25-plugin-watch-sync-provider-design.md
+++ b/docs/superpowers/specs/2026-07-25-plugin-watch-sync-provider-design.md
@@ -52,9 +52,12 @@ Plugins advertise `watch_sync_provider.v1` with a typed descriptor containing:
 - supported media types and external-ID namespaces;
 - maximum apply batch size.
 
-The host supports:
+The host uses `WatchSyncProvider` for the stable provider operations and a
+separate `WatchSyncDeviceAuthorizationService` for device-code start and poll.
+The split keeps direct Go implementations of the released v0.12 provider
+interface source-compatible. Together the services support:
 
-- `StartDeviceAuthorization` and `PollDeviceAuthorization`;
+- device authorization `Start` and `Poll`;
 - `ExchangeAPIKey`;
 - `RefreshCredentials`;
 - `GetAccount`;
@@ -122,8 +125,10 @@ Credential refresh remains host-initiated and serialized by the existing
 watchsync service. The host encrypts an authoritative credential bundle
 containing access token, refresh token, expiry, token type, scopes, and opaque
 secret attributes. Legacy access/refresh columns remain readable during the
-migration. Device codes are also encrypted at rest. Invalid-credential faults
-are persisted using only the plugin's safe message.
+migration. Device codes are also encrypted at rest. A pending device poll may
+rotate its opaque provider state, interval, or expiry; the host validates and
+persists the replacement before another poll. Invalid-credential faults are
+persisted using only the plugin's safe message.
 
 Authorization-code OAuth can be added separately to the existing watch-
 provider service after its client-secret storage and callback-state design are
@@ -175,8 +180,12 @@ contains the stable cursor for that family and an opaque page token. The host:
 4. advances the page token until the plugin reports no next page;
 5. commits the family cursor only after the traversal succeeds.
 
-Incremental list pages do not imply deletion of absent items. Complete snapshots
-may reconcile removals. Ordered watchlists preserve the plugin's list position.
+Incremental list pages do not imply deletion of absent items; they use explicit
+provider-key tombstones for removals. Complete snapshots may reconcile removals.
+Ordered watchlists preserve the plugin's list position and require complete
+snapshots because an incremental subset cannot define positions relative to
+omitted items. Traversals are bounded by both page and item count before their
+durable cursor advances.
 Progress items without a valid provider timestamp are rejected rather than
 being stamped with host time.
 

--- a/docs/superpowers/specs/2026-07-25-plugin-watch-sync-provider-design.md
+++ b/docs/superpowers/specs/2026-07-25-plugin-watch-sync-provider-design.md
@@ -2,39 +2,46 @@
 
 ## Status
 
-Local design for review against the released `silo-plugin-sdk` v0.12.0
-`watch_sync_provider.v1` contract. This specification does not introduce a
-second watch synchronization pipeline. Plugin-backed providers adapt the public
-plugin RPC contract to Silo's existing `watchsync` service, connection
-repository, history exports, scrobble sessions, rate-limit handling, and
-scheduled reconciliation.
+Implemented design for the expanded `silo-plugin-sdk` v0.13
+`watch_sync_provider.v1` contract. The server uses the immutable SDK commit
+associated with the v0.13 pull request until that version is released. This
+specification does not introduce a second watch synchronization pipeline.
+Plugin-backed providers adapt the public plugin RPC contract to Silo's existing
+`watchsync` service, connection repository, history exports, scrobble sessions,
+rate-limit handling, list reconciliation, and scheduled reconciliation.
 
 ## Goals
 
 - Allow an enabled plugin capability to appear as a profile-scoped watch
   provider.
 - Reuse Silo's encrypted watch-provider connections for personal credentials.
-- Deliver explicit mark-watched operations and normal playback completion.
+- Support API-key and device-code connection flows.
+- Import and export watched state, progress, favorites, and watchlists according
+  to each plugin's advertised capabilities.
+- Deliver explicit watched/unwatched and list operations plus live playback
+  start, pause, and stop events.
 - Preserve the existing durable history-export reconciliation path.
+- Preserve complete provider credential shapes, including token type, scopes,
+  expiry, and opaque secret attributes.
+- Supply declared installation configuration to provider calls without mixing
+  it with profile credentials.
 - Keep provider plugins stateless and prevent credentials from entering generic
   plugin configuration.
 - Avoid behavior changes for built-in Trakt, Simkl, and MDBList providers.
 
-## Non-goals for the first slice
+## Non-goals
 
 - Authorization-code OAuth UI and callback routes.
-- Importing remote watched state or progress.
-- Exporting manual unwatch operations.
-- Favorites and watchlist synchronization.
 - A second outbox or worker implementation.
-- Provider-specific configuration stored in generic plugin runtime settings.
-- Migrating built-in Trakt, Simkl, or MDBList providers into plugins; they can
-  adopt the same capability in a separate change.
+- Allowing plugins to persist or own personal provider credentials.
+- Removing built-in Trakt, Simkl, or MDBList providers in the same change. They
+  remain available while equivalent plugins are built and connections are
+  migrated deliberately.
 
-The initial connection flow accepts a manually-issued provider token through
-the existing API-key watch-provider endpoint. Silo validates it through the
-plugin, then stores only the returned credential in the encrypted watch
-connection record.
+Plugins may implement any subset of the state families and operations. A
+provider such as Floppy can advertise watched import/export, progress import,
+and live scrobbling without claiming favorites, watchlists, or unwatch support.
+Silo exposes only executable capabilities from the descriptor.
 
 ## SDK boundary
 
@@ -45,19 +52,25 @@ Plugins advertise `watch_sync_provider.v1` with a typed descriptor containing:
 - supported media types and external-ID namespaces;
 - maximum apply batch size.
 
-The first server slice uses:
+The host supports:
 
+- `StartDeviceAuthorization` and `PollDeviceAuthorization`;
 - `ExchangeAPIKey`;
 - `RefreshCredentials`;
 - `GetAccount`;
-- `ApplyEvents`.
+- `ApplyEvents` for watched, unwatched, favorite, watchlist, and live scrobble
+  operations;
+- `ListRemoteState` for watched, progress, favorite, and watchlist state.
 
-Other contract methods may return `Unimplemented` until corresponding host
-features are added.
+Authorization-code descriptors remain valid SDK contracts, but the host does
+not register a plugin that offers only authorization-code authentication until
+the public watch-provider callback flow exists.
 
-Every provider RPC receives credentials only for that call. Plugins must not
-persist or log credentials. Generic `Runtime.Configure` data is not a secret
-store and must not contain personal watch-provider tokens.
+Every provider RPC receives the complete current credentials and relevant
+installation configuration only for that call. Plugins must not persist or log
+credentials. Generic `Runtime.Configure` data is not a personal credential
+store. Returned credentials are an authoritative replacement, and the host
+persists them before interpreting results, pages, or faults from the same RPC.
 
 ## Discovery and lifecycle
 
@@ -83,14 +96,15 @@ registered because another installation could not be decoded.
 
 ## Existing watchsync interfaces
 
-The initial adapter admits only descriptors that support API-key auth and
-watched export, and that do not advertise import or unwatch operations. It
-implements:
+The adapter implements the existing interfaces corresponding to the
+descriptor's advertised capabilities:
 
 - `Provider`;
-- `AuthProvider` and `APIKeyAuthProvider`;
-- `WatchedExporter`;
-- `Scrobbler` and `OrderedScrobbler` for low-latency completed playback.
+- `AuthProvider`, `APIKeyAuthProvider`, and device authorization;
+- watched import/export and unwatch export;
+- progress import;
+- favorite and watchlist import/export/removal, including ordered watchlists;
+- `Scrobbler` and `OrderedScrobbler` for start, pause, and stop delivery.
 
 `LocalPlay` and `ScrobbleEvent` values become rich desired-state plugin events.
 The host supplies movie and series external IDs, season and episode numbers,
@@ -100,19 +114,16 @@ The plugin never needs a Silo API key or a callback into catalog HTTP routes.
 ## Authentication and credentials
 
 The existing watch-provider API-key connection route passes the entered token
-to `ExchangeAPIKey`. The plugin validates the token and returns normalized
-credentials plus provider account identity. Silo stores credentials in the
-existing encrypted connection columns scoped by user and profile.
+to `ExchangeAPIKey`. Device-code providers use the existing start and poll
+routes. The plugin validates or exchanges the credential and returns normalized
+credentials plus provider account identity.
 
 Credential refresh remains host-initiated and serialized by the existing
-watchsync service. The initial adapter accepts only access token, refresh token,
-expiry, and the standard Bearer token type that fit the existing encrypted
-connection behavior; it rejects
-opaque secret attributes and event-time credential rotation rather than
-silently discarding them. A later schema change is required before those SDK
-credential shapes can be supported. Invalid-credential faults are persisted
-using only the plugin's safe message; a dedicated reconnect-required connection
-state remains follow-up work.
+watchsync service. The host encrypts an authoritative credential bundle
+containing access token, refresh token, expiry, token type, scopes, and opaque
+secret attributes. Legacy access/refresh columns remain readable during the
+migration. Device codes are also encrypted at rest. Invalid-credential faults
+are persisted using only the plugin's safe message.
 
 Authorization-code OAuth can be added separately to the existing watch-
 provider service after its client-secret storage and callback-state design are
@@ -144,7 +155,43 @@ convergent, so an uncertain duplicate cannot lower progress or increment a play
 counter.
 
 Start, pause, and incomplete stop calls are no-ops for providers that only
-advertise watched export.
+advertise watched export. Providers advertising live scrobbling receive all
+three operations with playback position and duration.
+
+If the remote stop succeeds but the local history-export transition fails, the
+stop is not dispatched again. The scrobble session records a durable pending
+history-reconciliation marker, and the sweeper retries only the local database
+transition.
+
+## Remote state import and lists
+
+The scheduled sync path requests one state family at a time. Each request
+contains the stable cursor for that family and an opaque page token. The host:
+
+1. persists any credentials returned by the page;
+2. discards the page and retains its cursor on a top-level fault;
+3. applies valid items idempotently through existing watch-state and list
+   services;
+4. advances the page token until the plugin reports no next page;
+5. commits the family cursor only after the traversal succeeds.
+
+Incremental list pages do not imply deletion of absent items. Complete snapshots
+may reconcile removals. Ordered watchlists preserve the plugin's list position.
+Progress items without a valid provider timestamp are rejected rather than
+being stamped with host time.
+
+Imported history is tagged with the stable plugin provider key, not a generic
+import source. Echo suppression therefore filters only export back to the
+originating plugin; the same local event remains eligible for other connected
+providers.
+
+## Provider configuration
+
+Manifest-declared global configuration is resolved per installation before each
+provider call. Public fields are sent in `values`; secret and undeclared fields
+are sent in `secret_values`. Nested manifest fields use the stable
+`<config-key>.<field>` key form, such as `floppy.base_url`. Profile credentials
+remain separate and encrypted in watch-provider connection storage.
 
 ## Apply result handling
 
@@ -215,20 +262,30 @@ together rather than introduced only for plugins.
 
 The change is additive to `/api/v1`. Existing provider summaries and connection
 routes continue to work. A plugin provider appears through the same provider
-summary model and uses the existing API-key connection route. No mobile client
-changes are required for the first slice because no existing fields or status
-codes change.
+summary model and uses the existing API-key or device-code connection routes.
+No client changes are required because no existing fields or status codes
+change. SDK v0.12 plugins remain wire-compatible; descriptors only expose the
+capabilities the older contract can execute.
 
 ## Validation plan
 
 - capability enforcement in the plugin host client;
 - atomic registry replacement and built-in collision tests;
-- token validation and account identity conversion;
+- API-key and device-code authentication, full credential replacement, and
+  account identity conversion;
+- provider configuration routing and secret/public field classification;
 - rich movie and episode identity conversion;
+- watched, progress, favorite, and watchlist import pagination and cursor
+  behavior;
+- unwatch, favorite, watchlist, and ordered-list event conversion;
+- provider-specific import source keys and cross-provider export behavior;
 - completed playback persistence before plugin I/O;
 - `satisfied_by_scrobble` transition after success;
+- durable retry of a failed local post-stop history transition without another
+  remote stop;
 - immediate failure followed by scheduled history reconciliation;
 - typed rate-limit and invalid-credential handling;
+- complete credential encryption/decryption and legacy fallback;
 - plugin disable/re-enable lifecycle reload;
 - no regression in existing watchsync, pluginhost, and plugin service tests;
 - `go test`, targeted race tests, `go vet`, lint, formatting checks, and local

--- a/docs/superpowers/specs/2026-07-25-plugin-watch-sync-provider-design.md
+++ b/docs/superpowers/specs/2026-07-25-plugin-watch-sync-provider-design.md
@@ -1,0 +1,235 @@
+# Plugin-backed watch sync providers
+
+## Status
+
+Local design for review against the released `silo-plugin-sdk` v0.12.0
+`watch_sync_provider.v1` contract. This specification does not introduce a
+second watch synchronization pipeline. Plugin-backed providers adapt the public
+plugin RPC contract to Silo's existing `watchsync` service, connection
+repository, history exports, scrobble sessions, rate-limit handling, and
+scheduled reconciliation.
+
+## Goals
+
+- Allow an enabled plugin capability to appear as a profile-scoped watch
+  provider.
+- Reuse Silo's encrypted watch-provider connections for personal credentials.
+- Deliver explicit mark-watched operations and normal playback completion.
+- Preserve the existing durable history-export reconciliation path.
+- Keep provider plugins stateless and prevent credentials from entering generic
+  plugin configuration.
+- Avoid behavior changes for built-in Trakt, Simkl, and MDBList providers.
+
+## Non-goals for the first slice
+
+- Authorization-code OAuth UI and callback routes.
+- Importing remote watched state or progress.
+- Exporting manual unwatch operations.
+- Favorites and watchlist synchronization.
+- A second outbox or worker implementation.
+- Provider-specific configuration stored in generic plugin runtime settings.
+- Migrating built-in Trakt, Simkl, or MDBList providers into plugins; they can
+  adopt the same capability in a separate change.
+
+The initial connection flow accepts a manually-issued provider token through
+the existing API-key watch-provider endpoint. Silo validates it through the
+plugin, then stores only the returned credential in the encrypted watch
+connection record.
+
+## SDK boundary
+
+Plugins advertise `watch_sync_provider.v1` with a typed descriptor containing:
+
+- supported authentication methods;
+- import/export capabilities;
+- supported media types and external-ID namespaces;
+- maximum apply batch size.
+
+The first server slice uses:
+
+- `ExchangeAPIKey`;
+- `RefreshCredentials`;
+- `GetAccount`;
+- `ApplyEvents`.
+
+Other contract methods may return `Unimplemented` until corresponding host
+features are added.
+
+Every provider RPC receives credentials only for that call. Plugins must not
+persist or log credentials. Generic `Runtime.Configure` data is not a secret
+store and must not contain personal watch-provider tokens.
+
+## Discovery and lifecycle
+
+At startup and after plugin lifecycle changes, Silo:
+
+1. lists enabled, non-builtin plugin installations;
+2. selects `watch_sync_provider.v1` capabilities;
+3. decodes and validates their typed descriptors;
+4. constructs thin `watchsync.Provider` adapters;
+5. atomically replaces the registry's previous plugin-backed providers while
+   preserving built-ins.
+
+Provider keys bind persisted credentials to the installation and capability
+(`plugin:<installation-id>:<capability-id>`), while RPC routing continues to use
+the manifest capability ID. This prevents a subsequently installed plugin from
+inheriting credentials merely by reusing another plugin's capability ID.
+Provider keys must not shadow built-ins or other plugin providers. A conflicting
+lifecycle reload fails without partially replacing the registry. Invalid,
+unreadable, or currently unsupported descriptors are logged and omitted, and
+the successfully discovered set still replaces the previous plugin providers.
+This fail-closed behavior prevents a disabled or removed plugin from remaining
+registered because another installation could not be decoded.
+
+## Existing watchsync interfaces
+
+The initial adapter admits only descriptors that support API-key auth and
+watched export, and that do not advertise import or unwatch operations. It
+implements:
+
+- `Provider`;
+- `AuthProvider` and `APIKeyAuthProvider`;
+- `WatchedExporter`;
+- `Scrobbler` and `OrderedScrobbler` for low-latency completed playback.
+
+`LocalPlay` and `ScrobbleEvent` values become rich desired-state plugin events.
+The host supplies movie and series external IDs, season and episode numbers,
+local history identity, playback identity, timestamps, and completion values.
+The plugin never needs a Silo API key or a callback into catalog HTTP routes.
+
+## Authentication and credentials
+
+The existing watch-provider API-key connection route passes the entered token
+to `ExchangeAPIKey`. The plugin validates the token and returns normalized
+credentials plus provider account identity. Silo stores credentials in the
+existing encrypted connection columns scoped by user and profile.
+
+Credential refresh remains host-initiated and serialized by the existing
+watchsync service. The initial adapter accepts only access token, refresh token,
+expiry, and the standard Bearer token type that fit the existing encrypted
+connection behavior; it rejects
+opaque secret attributes and event-time credential rotation rather than
+silently discarding them. A later schema change is required before those SDK
+credential shapes can be supported. Invalid-credential faults are persisted
+using only the plugin's safe message; a dedicated reconnect-required connection
+state remains follow-up work.
+
+Authorization-code OAuth can be added separately to the existing watch-
+provider service after its client-secret storage and callback-state design are
+reviewed.
+
+## Watched export flow
+
+### Explicit mark watched
+
+The existing manual watch path records leaf history entries and invokes
+`HandleLocalWatchEvent`. The existing history-export table is populated before
+provider I/O. The plugin adapter sends each pending `LocalPlay` as an absolute
+`MARK_WATCHED` desired-state event. The interactive path sends one bounded
+plugin batch; additional queued events are delivered by scheduled
+reconciliation.
+
+### Playback completion
+
+The existing playback path invokes `ScrobbleStop` with rich identity. For a
+completed event and a provider that exports watched state, Silo first upserts a
+pending history-export record, then dispatches the immediate stop operation.
+
+On successful immediate delivery, the history export is marked
+`satisfied_by_scrobble`. If immediate delivery fails or the process exits, the
+existing scheduled history reconciliation retries the same local history. A
+compatibility playback path without a local history ID retains its own durable
+terminal event until the confirmed stop succeeds. The plugin operation is
+convergent, so an uncertain duplicate cannot lower progress or increment a play
+counter.
+
+Start, pause, and incomplete stop calls are no-ops for providers that only
+advertise watched export.
+
+## Apply result handling
+
+Each event has a stable ID. The adapter requires a matching result and maps it
+as follows:
+
+- `APPLIED` and `NO_CHANGE`: export sent;
+- `REJECTED`: permanent not-found/unmappable export;
+- `RETRY` with a temporary fault: failed export eligible for existing retry handling;
+- top-level or per-event rate limit: existing `RateLimitedError` and account
+  deferral, after committing any successfully applied events from the same RPC;
+- missing or unknown result: failed export eligible for retry, unless the same
+  RPC reported a rate limit, in which case unmentioned events remain pending;
+- plugin transport, process availability, and top-level temporary faults:
+  remain pending without consuming a per-event attempt.
+
+A top-level invalid-credential fault records a typed safe connection error.
+A dedicated reconnect-required connection state is deferred as described
+above. Plugin messages persisted by Silo must be explicitly safe for operator
+display and must not contain response bodies or secrets. The host redacts the
+connection credentials, normalizes control characters and whitespace, and
+bounds the displayed message length; transport details are replaced with
+host-owned text.
+
+## Ordering and batching
+
+Immediate scrobbles are ordered by connection and stable series identity using
+the existing ordered-scrobble queue. History reconciliation is ordered by local
+watch timestamp.
+
+Each synchronization run sends at most one plugin RPC, bounded by the
+descriptor's maximum batch size. The existing service commits every per-event
+result before a later run requests the next pending batch. Failures increment
+attempts only for events included in that RPC. This avoids partial-success loss,
+retry exhaustion within one run, and unbounded cumulative RPC time.
+
+## Reliability boundaries
+
+This design deliberately reuses the reliability guarantees currently accepted
+for built-in providers:
+
+- encrypted profile-scoped connections;
+- durable local watch history;
+- durable history-export rows;
+- immediate scrobble sessions;
+- scheduled reconciliation;
+- bounded retry attempts and safe recorded errors;
+- provider/account rate-limit deferral.
+
+It does not claim multi-node leased delivery or infinite retries. Those should
+be improved in the shared watchsync pipeline for built-in and plugin providers
+together rather than introduced only for plugins.
+
+## Security requirements
+
+- Personal tokens never enter plugin runtime config or user settings.
+- Tokens are decrypted only at the provider invocation boundary.
+- RPC request values containing credentials are never logged.
+- Plugin-returned errors are sanitized before persistence and API display;
+  transport errors are replaced by a generic message.
+- Account/profile scope remains enforced by the existing connection lookup.
+- Credential AAD and provider lookup include installation identity, preventing
+  sequential capability-ID reuse from exposing an old token to a new install.
+- Disabled plugins disappear from provider discovery; existing connections are
+  unavailable until that same installation and capability return.
+
+## Compatibility
+
+The change is additive to `/api/v1`. Existing provider summaries and connection
+routes continue to work. A plugin provider appears through the same provider
+summary model and uses the existing API-key connection route. No mobile client
+changes are required for the first slice because no existing fields or status
+codes change.
+
+## Validation plan
+
+- capability enforcement in the plugin host client;
+- atomic registry replacement and built-in collision tests;
+- token validation and account identity conversion;
+- rich movie and episode identity conversion;
+- completed playback persistence before plugin I/O;
+- `satisfied_by_scrobble` transition after success;
+- immediate failure followed by scheduled history reconciliation;
+- typed rate-limit and invalid-credential handling;
+- plugin disable/re-enable lifecycle reload;
+- no regression in existing watchsync, pluginhost, and plugin service tests;
+- `go test`, targeted race tests, `go vet`, lint, formatting checks, and local
+  path verification before proposing a merge request.

--- a/go.mod
+++ b/go.mod
@@ -109,7 +109,7 @@ require (
 )
 
 require (
-	github.com/Silo-Server/silo-plugin-sdk v0.12.0
+	github.com/Silo-Server/silo-plugin-sdk v0.12.1-0.20260805225241-3b705d7e882f
 	github.com/aws/aws-sdk-go-v2/aws/protocol/eventstream v1.7.14 // indirect
 	github.com/aws/aws-sdk-go-v2/internal/configsources v1.4.30 // indirect
 	github.com/aws/aws-sdk-go-v2/internal/endpoints/v2 v2.7.30 // indirect

--- a/go.mod
+++ b/go.mod
@@ -109,7 +109,7 @@ require (
 )
 
 require (
-	github.com/Silo-Server/silo-plugin-sdk v0.12.1-0.20260806020753-206f05f5bc88
+	github.com/Silo-Server/silo-plugin-sdk v0.13.0
 	github.com/aws/aws-sdk-go-v2/aws/protocol/eventstream v1.7.14 // indirect
 	github.com/aws/aws-sdk-go-v2/internal/configsources v1.4.30 // indirect
 	github.com/aws/aws-sdk-go-v2/internal/endpoints/v2 v2.7.30 // indirect

--- a/go.mod
+++ b/go.mod
@@ -109,7 +109,7 @@ require (
 )
 
 require (
-	github.com/Silo-Server/silo-plugin-sdk v0.12.1-0.20260806010851-d4b0770d7342
+	github.com/Silo-Server/silo-plugin-sdk v0.12.1-0.20260806020753-206f05f5bc88
 	github.com/aws/aws-sdk-go-v2/aws/protocol/eventstream v1.7.14 // indirect
 	github.com/aws/aws-sdk-go-v2/internal/configsources v1.4.30 // indirect
 	github.com/aws/aws-sdk-go-v2/internal/endpoints/v2 v2.7.30 // indirect

--- a/go.mod
+++ b/go.mod
@@ -12,7 +12,7 @@ require (
 	github.com/jackc/pgx/v5 v5.9.2
 	github.com/mattn/go-sqlite3 v1.14.34
 	github.com/prometheus/client_golang v1.23.2
-	github.com/prometheus/client_model v0.6.2 // indirect
+	github.com/prometheus/client_model v0.6.2
 	github.com/redis/go-redis/v9 v9.18.0
 	golang.org/x/crypto v0.52.0
 	golang.org/x/sys v0.45.0
@@ -109,7 +109,7 @@ require (
 )
 
 require (
-	github.com/Silo-Server/silo-plugin-sdk v0.12.1-0.20260805225241-3b705d7e882f
+	github.com/Silo-Server/silo-plugin-sdk v0.12.1-0.20260806010851-d4b0770d7342
 	github.com/aws/aws-sdk-go-v2/aws/protocol/eventstream v1.7.14 // indirect
 	github.com/aws/aws-sdk-go-v2/internal/configsources v1.4.30 // indirect
 	github.com/aws/aws-sdk-go-v2/internal/endpoints/v2 v2.7.30 // indirect

--- a/go.sum
+++ b/go.sum
@@ -4,10 +4,8 @@ github.com/PuerkitoBio/goquery v1.8.0 h1:PJTF7AmFCFKk1N6V6jmKfrNH9tV5pNE6lZMkG0g
 github.com/PuerkitoBio/goquery v1.8.0/go.mod h1:ypIiRMtY7COPGk+I/YbZLbxsxn9g5ejnI2HSMtkjZvI=
 github.com/SherClockHolmes/webpush-go v1.4.0 h1:ocnzNKWN23T9nvHi6IfyrQjkIc0oJWv1B1pULsf9i3s=
 github.com/SherClockHolmes/webpush-go v1.4.0/go.mod h1:XSq8pKX11vNV8MJEMwjrlTkxhAj1zKfxmyhdV7Pd6UA=
-github.com/Silo-Server/silo-plugin-sdk v0.12.0 h1:7MnaSIJBVdRE8FhfLXWx7Pe+Q2apJiaPMotfhb1VHoE=
-github.com/Silo-Server/silo-plugin-sdk v0.12.0/go.mod h1:etqmxLTwjxpFH9goAjBDfNDoqHMv2/sqUXu8yx3hNfA=
-github.com/Silo-Server/silo-plugin-sdk v0.12.1-0.20260805225241-3b705d7e882f h1:O2AM2KaUqDl11kzToGf964BQHBe+xNdvlANR5vh7dF0=
-github.com/Silo-Server/silo-plugin-sdk v0.12.1-0.20260805225241-3b705d7e882f/go.mod h1:etqmxLTwjxpFH9goAjBDfNDoqHMv2/sqUXu8yx3hNfA=
+github.com/Silo-Server/silo-plugin-sdk v0.12.1-0.20260806010851-d4b0770d7342 h1:bfvLTqtGNwbTEYHWFCM1xs4FTiVItm/asqTofNkb4z0=
+github.com/Silo-Server/silo-plugin-sdk v0.12.1-0.20260806010851-d4b0770d7342/go.mod h1:etqmxLTwjxpFH9goAjBDfNDoqHMv2/sqUXu8yx3hNfA=
 github.com/abadojack/whatlanggo v1.0.1 h1:19N6YogDnf71CTHm3Mp2qhYfkRdyvbgwWdd2EPxJRG4=
 github.com/abadojack/whatlanggo v1.0.1/go.mod h1:66WiQbSbJBIlOZMsvbKe5m6pzQovxCH9B/K8tQB2uoc=
 github.com/agnivade/levenshtein v1.2.1 h1:EHBY3UOn1gwdy/VbFwgo4cxecRznFk7fKWN1KOX7eoM=

--- a/go.sum
+++ b/go.sum
@@ -6,6 +6,8 @@ github.com/SherClockHolmes/webpush-go v1.4.0 h1:ocnzNKWN23T9nvHi6IfyrQjkIc0oJWv1
 github.com/SherClockHolmes/webpush-go v1.4.0/go.mod h1:XSq8pKX11vNV8MJEMwjrlTkxhAj1zKfxmyhdV7Pd6UA=
 github.com/Silo-Server/silo-plugin-sdk v0.12.0 h1:7MnaSIJBVdRE8FhfLXWx7Pe+Q2apJiaPMotfhb1VHoE=
 github.com/Silo-Server/silo-plugin-sdk v0.12.0/go.mod h1:etqmxLTwjxpFH9goAjBDfNDoqHMv2/sqUXu8yx3hNfA=
+github.com/Silo-Server/silo-plugin-sdk v0.12.1-0.20260805225241-3b705d7e882f h1:O2AM2KaUqDl11kzToGf964BQHBe+xNdvlANR5vh7dF0=
+github.com/Silo-Server/silo-plugin-sdk v0.12.1-0.20260805225241-3b705d7e882f/go.mod h1:etqmxLTwjxpFH9goAjBDfNDoqHMv2/sqUXu8yx3hNfA=
 github.com/abadojack/whatlanggo v1.0.1 h1:19N6YogDnf71CTHm3Mp2qhYfkRdyvbgwWdd2EPxJRG4=
 github.com/abadojack/whatlanggo v1.0.1/go.mod h1:66WiQbSbJBIlOZMsvbKe5m6pzQovxCH9B/K8tQB2uoc=
 github.com/agnivade/levenshtein v1.2.1 h1:EHBY3UOn1gwdy/VbFwgo4cxecRznFk7fKWN1KOX7eoM=

--- a/go.sum
+++ b/go.sum
@@ -4,8 +4,8 @@ github.com/PuerkitoBio/goquery v1.8.0 h1:PJTF7AmFCFKk1N6V6jmKfrNH9tV5pNE6lZMkG0g
 github.com/PuerkitoBio/goquery v1.8.0/go.mod h1:ypIiRMtY7COPGk+I/YbZLbxsxn9g5ejnI2HSMtkjZvI=
 github.com/SherClockHolmes/webpush-go v1.4.0 h1:ocnzNKWN23T9nvHi6IfyrQjkIc0oJWv1B1pULsf9i3s=
 github.com/SherClockHolmes/webpush-go v1.4.0/go.mod h1:XSq8pKX11vNV8MJEMwjrlTkxhAj1zKfxmyhdV7Pd6UA=
-github.com/Silo-Server/silo-plugin-sdk v0.12.1-0.20260806020753-206f05f5bc88 h1:1ekzgH+1DeGEr5t6RivTo4DvzOE+oB5d8asDv2ocdyc=
-github.com/Silo-Server/silo-plugin-sdk v0.12.1-0.20260806020753-206f05f5bc88/go.mod h1:etqmxLTwjxpFH9goAjBDfNDoqHMv2/sqUXu8yx3hNfA=
+github.com/Silo-Server/silo-plugin-sdk v0.13.0 h1:BXf4cuNbOIIsrVJrRdlQnbc1m04X6lcPSZI+AFLMeK0=
+github.com/Silo-Server/silo-plugin-sdk v0.13.0/go.mod h1:etqmxLTwjxpFH9goAjBDfNDoqHMv2/sqUXu8yx3hNfA=
 github.com/abadojack/whatlanggo v1.0.1 h1:19N6YogDnf71CTHm3Mp2qhYfkRdyvbgwWdd2EPxJRG4=
 github.com/abadojack/whatlanggo v1.0.1/go.mod h1:66WiQbSbJBIlOZMsvbKe5m6pzQovxCH9B/K8tQB2uoc=
 github.com/agnivade/levenshtein v1.2.1 h1:EHBY3UOn1gwdy/VbFwgo4cxecRznFk7fKWN1KOX7eoM=

--- a/go.sum
+++ b/go.sum
@@ -4,8 +4,8 @@ github.com/PuerkitoBio/goquery v1.8.0 h1:PJTF7AmFCFKk1N6V6jmKfrNH9tV5pNE6lZMkG0g
 github.com/PuerkitoBio/goquery v1.8.0/go.mod h1:ypIiRMtY7COPGk+I/YbZLbxsxn9g5ejnI2HSMtkjZvI=
 github.com/SherClockHolmes/webpush-go v1.4.0 h1:ocnzNKWN23T9nvHi6IfyrQjkIc0oJWv1B1pULsf9i3s=
 github.com/SherClockHolmes/webpush-go v1.4.0/go.mod h1:XSq8pKX11vNV8MJEMwjrlTkxhAj1zKfxmyhdV7Pd6UA=
-github.com/Silo-Server/silo-plugin-sdk v0.12.1-0.20260806010851-d4b0770d7342 h1:bfvLTqtGNwbTEYHWFCM1xs4FTiVItm/asqTofNkb4z0=
-github.com/Silo-Server/silo-plugin-sdk v0.12.1-0.20260806010851-d4b0770d7342/go.mod h1:etqmxLTwjxpFH9goAjBDfNDoqHMv2/sqUXu8yx3hNfA=
+github.com/Silo-Server/silo-plugin-sdk v0.12.1-0.20260806020753-206f05f5bc88 h1:1ekzgH+1DeGEr5t6RivTo4DvzOE+oB5d8asDv2ocdyc=
+github.com/Silo-Server/silo-plugin-sdk v0.12.1-0.20260806020753-206f05f5bc88/go.mod h1:etqmxLTwjxpFH9goAjBDfNDoqHMv2/sqUXu8yx3hNfA=
 github.com/abadojack/whatlanggo v1.0.1 h1:19N6YogDnf71CTHm3Mp2qhYfkRdyvbgwWdd2EPxJRG4=
 github.com/abadojack/whatlanggo v1.0.1/go.mod h1:66WiQbSbJBIlOZMsvbKe5m6pzQovxCH9B/K8tQB2uoc=
 github.com/agnivade/levenshtein v1.2.1 h1:EHBY3UOn1gwdy/VbFwgo4cxecRznFk7fKWN1KOX7eoM=

--- a/internal/api/handlers/watch_providers.go
+++ b/internal/api/handlers/watch_providers.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"net/http"
 	"strconv"
+	"time"
 
 	apimw "github.com/Silo-Server/silo-server/internal/api/middleware"
 	"github.com/Silo-Server/silo-server/internal/watchsync"
@@ -25,6 +26,15 @@ type WatchProviderService interface {
 
 type WatchProviderHandler struct {
 	service WatchProviderService
+}
+
+type watchProviderDeviceAuthResponse struct {
+	ID              string    `json:"id"`
+	Provider        string    `json:"provider"`
+	UserCode        string    `json:"user_code"`
+	VerificationURL string    `json:"verification_url"`
+	IntervalSeconds int       `json:"interval_seconds"`
+	ExpiresAt       time.Time `json:"expires_at"`
 }
 
 func NewWatchProviderHandler(service WatchProviderService) *WatchProviderHandler {
@@ -97,7 +107,14 @@ func (h *WatchProviderHandler) HandleStartDeviceAuth(w http.ResponseWriter, r *h
 		writeError(w, http.StatusBadRequest, "watch_provider_error", err.Error())
 		return
 	}
-	writeJSON(w, http.StatusOK, session)
+	writeJSON(w, http.StatusOK, watchProviderDeviceAuthResponse{
+		ID:              session.ID,
+		Provider:        session.Provider,
+		UserCode:        session.UserCode,
+		VerificationURL: session.VerificationURL,
+		IntervalSeconds: session.IntervalSeconds,
+		ExpiresAt:       session.ExpiresAt,
+	})
 }
 
 func (h *WatchProviderHandler) HandlePollDeviceAuth(w http.ResponseWriter, r *http.Request) {

--- a/internal/api/handlers/watch_providers_test.go
+++ b/internal/api/handlers/watch_providers_test.go
@@ -159,6 +159,11 @@ func TestWatchProviderHandlerStartsDeviceAuthWithFrontendJSONShape(t *testing.T)
 			t.Fatalf("response contains Go-style key %q: %#v", key, resp)
 		}
 	}
+	for _, key := range []string{"device_code", "user_id", "profile_id", "completed_at"} {
+		if _, ok := resp[key]; ok {
+			t.Fatalf("response exposes host-private field %q: %#v", key, resp)
+		}
+	}
 	if resp["id"] != "auth-1" {
 		t.Fatalf("id = %#v, want auth-1", resp["id"])
 	}

--- a/internal/pluginhost/client.go
+++ b/internal/pluginhost/client.go
@@ -80,8 +80,9 @@ type HTTPRoutesClient struct {
 }
 
 type WatchSyncProviderClient struct {
-	client  pluginv1.WatchSyncProviderClient
-	timeout time.Duration
+	client              pluginv1.WatchSyncProviderClient
+	deviceAuthorization pluginv1.WatchSyncDeviceAuthorizationServiceClient
+	timeout             time.Duration
 }
 
 func newClient(installationID int, rpc *sdkruntime.Client, manifest *pluginv1.PluginManifest) *Client {
@@ -218,8 +219,9 @@ func (c *Client) WatchSyncProvider(capabilityID string) (*WatchSyncProviderClien
 		return nil, err
 	}
 	return &WatchSyncProviderClient{
-		client:  c.rpc.WatchSyncProvider(),
-		timeout: DefaultWatchSyncTimeout,
+		client:              c.rpc.WatchSyncProvider(),
+		deviceAuthorization: c.rpc.WatchSyncDeviceAuthorization(),
+		timeout:             DefaultWatchSyncTimeout,
 	}, nil
 }
 
@@ -406,16 +408,16 @@ func (c *WatchSyncProviderClient) ExchangeAPIKey(ctx context.Context, req *plugi
 	return c.client.ExchangeAPIKey(callCtx, req)
 }
 
-func (c *WatchSyncProviderClient) StartDeviceAuthorization(ctx context.Context, req *pluginv1.WatchSyncStartDeviceAuthorizationRequest) (*pluginv1.WatchSyncStartDeviceAuthorizationResponse, error) {
+func (c *WatchSyncProviderClient) StartDeviceAuthorization(ctx context.Context, req *pluginv1.WatchSyncDeviceAuthorizationServiceStartRequest) (*pluginv1.WatchSyncDeviceAuthorizationServiceStartResponse, error) {
 	callCtx, cancel := ensureDeadline(ctx, c.timeout)
 	defer cancel()
-	return c.client.StartDeviceAuthorization(callCtx, req)
+	return c.deviceAuthorization.Start(callCtx, req)
 }
 
-func (c *WatchSyncProviderClient) PollDeviceAuthorization(ctx context.Context, req *pluginv1.WatchSyncPollDeviceAuthorizationRequest) (*pluginv1.WatchSyncPollDeviceAuthorizationResponse, error) {
+func (c *WatchSyncProviderClient) PollDeviceAuthorization(ctx context.Context, req *pluginv1.WatchSyncDeviceAuthorizationServicePollRequest) (*pluginv1.WatchSyncDeviceAuthorizationServicePollResponse, error) {
 	callCtx, cancel := ensureDeadline(ctx, c.timeout)
 	defer cancel()
-	return c.client.PollDeviceAuthorization(callCtx, req)
+	return c.deviceAuthorization.Poll(callCtx, req)
 }
 
 func (c *WatchSyncProviderClient) RefreshCredentials(ctx context.Context, req *pluginv1.WatchSyncRefreshCredentialsRequest) (*pluginv1.WatchSyncCredentialResponse, error) {

--- a/internal/pluginhost/client.go
+++ b/internal/pluginhost/client.go
@@ -406,6 +406,18 @@ func (c *WatchSyncProviderClient) ExchangeAPIKey(ctx context.Context, req *plugi
 	return c.client.ExchangeAPIKey(callCtx, req)
 }
 
+func (c *WatchSyncProviderClient) StartDeviceAuthorization(ctx context.Context, req *pluginv1.WatchSyncStartDeviceAuthorizationRequest) (*pluginv1.WatchSyncStartDeviceAuthorizationResponse, error) {
+	callCtx, cancel := ensureDeadline(ctx, c.timeout)
+	defer cancel()
+	return c.client.StartDeviceAuthorization(callCtx, req)
+}
+
+func (c *WatchSyncProviderClient) PollDeviceAuthorization(ctx context.Context, req *pluginv1.WatchSyncPollDeviceAuthorizationRequest) (*pluginv1.WatchSyncPollDeviceAuthorizationResponse, error) {
+	callCtx, cancel := ensureDeadline(ctx, c.timeout)
+	defer cancel()
+	return c.client.PollDeviceAuthorization(callCtx, req)
+}
+
 func (c *WatchSyncProviderClient) RefreshCredentials(ctx context.Context, req *pluginv1.WatchSyncRefreshCredentialsRequest) (*pluginv1.WatchSyncCredentialResponse, error) {
 	callCtx, cancel := ensureDeadline(ctx, c.timeout)
 	defer cancel()
@@ -422,6 +434,12 @@ func (c *WatchSyncProviderClient) ApplyEvents(ctx context.Context, req *pluginv1
 	callCtx, cancel := ensureDeadline(ctx, c.timeout)
 	defer cancel()
 	return c.client.ApplyEvents(callCtx, req)
+}
+
+func (c *WatchSyncProviderClient) ListRemoteState(ctx context.Context, req *pluginv1.WatchSyncListRemoteStateRequest) (*pluginv1.WatchSyncListRemoteStateResponse, error) {
+	callCtx, cancel := ensureDeadline(ctx, c.timeout)
+	defer cancel()
+	return c.client.ListRemoteState(callCtx, req)
 }
 
 func ensureDeadline(ctx context.Context, timeout time.Duration) (context.Context, context.CancelFunc) {

--- a/internal/pluginhost/client.go
+++ b/internal/pluginhost/client.go
@@ -79,6 +79,11 @@ type HTTPRoutesClient struct {
 	timeout time.Duration
 }
 
+type WatchSyncProviderClient struct {
+	client  pluginv1.WatchSyncProviderClient
+	timeout time.Duration
+}
+
 func newClient(installationID int, rpc *sdkruntime.Client, manifest *pluginv1.PluginManifest) *Client {
 	capabilities := make(map[string]*pluginv1.CapabilityDescriptor, len(manifest.GetCapabilities()))
 	for _, capability := range manifest.GetCapabilities() {
@@ -205,6 +210,16 @@ func (c *Client) HTTPRoutes(capabilityID string) (*HTTPRoutesClient, error) {
 	return &HTTPRoutesClient{
 		client:  c.rpc.HttpRoutes(),
 		timeout: DefaultRouteTimeout,
+	}, nil
+}
+
+func (c *Client) WatchSyncProvider(capabilityID string) (*WatchSyncProviderClient, error) {
+	if err := c.requireCapability("watch_sync_provider.v1", capabilityID); err != nil {
+		return nil, err
+	}
+	return &WatchSyncProviderClient{
+		client:  c.rpc.WatchSyncProvider(),
+		timeout: DefaultWatchSyncTimeout,
 	}, nil
 }
 
@@ -383,6 +398,30 @@ func (c *HTTPRoutesClient) Handle(ctx context.Context, req *pluginv1.HandleHTTPR
 	callCtx, cancel := ensureDeadline(ctx, c.timeout)
 	defer cancel()
 	return c.client.Handle(callCtx, req)
+}
+
+func (c *WatchSyncProviderClient) ExchangeAPIKey(ctx context.Context, req *pluginv1.WatchSyncExchangeAPIKeyRequest) (*pluginv1.WatchSyncCredentialResponse, error) {
+	callCtx, cancel := ensureDeadline(ctx, c.timeout)
+	defer cancel()
+	return c.client.ExchangeAPIKey(callCtx, req)
+}
+
+func (c *WatchSyncProviderClient) RefreshCredentials(ctx context.Context, req *pluginv1.WatchSyncRefreshCredentialsRequest) (*pluginv1.WatchSyncCredentialResponse, error) {
+	callCtx, cancel := ensureDeadline(ctx, c.timeout)
+	defer cancel()
+	return c.client.RefreshCredentials(callCtx, req)
+}
+
+func (c *WatchSyncProviderClient) GetAccount(ctx context.Context, req *pluginv1.WatchSyncGetAccountRequest) (*pluginv1.WatchSyncGetAccountResponse, error) {
+	callCtx, cancel := ensureDeadline(ctx, c.timeout)
+	defer cancel()
+	return c.client.GetAccount(callCtx, req)
+}
+
+func (c *WatchSyncProviderClient) ApplyEvents(ctx context.Context, req *pluginv1.WatchSyncApplyEventsRequest) (*pluginv1.WatchSyncApplyEventsResponse, error) {
+	callCtx, cancel := ensureDeadline(ctx, c.timeout)
+	defer cancel()
+	return c.client.ApplyEvents(callCtx, req)
 }
 
 func ensureDeadline(ctx context.Context, timeout time.Duration) (context.Context, context.CancelFunc) {

--- a/internal/pluginhost/handshake.go
+++ b/internal/pluginhost/handshake.go
@@ -23,6 +23,7 @@ const (
 	DefaultEventTimeout      = 10 * time.Second
 	DefaultAuthTimeout       = 10 * time.Second
 	DefaultRouteTimeout      = 10 * time.Second
+	DefaultWatchSyncTimeout  = 60 * time.Second
 	// DefaultRequestRouterTimeout bounds a single request_router RPC.
 	// Fulfillment hits remote arr instances, so allow generous headroom.
 	DefaultRequestRouterTimeout = 60 * time.Second

--- a/internal/plugins/service.go
+++ b/internal/plugins/service.go
@@ -37,6 +37,7 @@ type pluginClient interface {
 	EventConsumer(capabilityID string) (*pluginhost.EventConsumerClient, error)
 	AuthProvider(capabilityID string) (*pluginhost.AuthProviderClient, error)
 	HTTPRoutes(capabilityID string) (*pluginhost.HTTPRoutesClient, error)
+	WatchSyncProvider(capabilityID string) (*pluginhost.WatchSyncProviderClient, error)
 }
 
 type Host interface {
@@ -646,6 +647,18 @@ func (s *Service) ScanSourceClientByPluginID(
 		return nil, fmt.Errorf("scan source plugin %q is disabled", pluginID)
 	}
 	return s.ScanSourceClient(ctx, matches[0].ID, capabilityID)
+}
+
+func (s *Service) WatchSyncProviderClient(
+	ctx context.Context,
+	installationID int,
+	capabilityID string,
+) (*pluginhost.WatchSyncProviderClient, error) {
+	client, err := s.ensureClient(ctx, installationID)
+	if err != nil {
+		return nil, err
+	}
+	return client.WatchSyncProvider(capabilityID)
 }
 
 func (s *Service) EventConsumerClient(

--- a/internal/plugins/service_hot_reload_test.go
+++ b/internal/plugins/service_hot_reload_test.go
@@ -237,6 +237,10 @@ func (f *fakePluginClient) HTTPRoutes(string) (*pluginhost.HTTPRoutesClient, err
 	return nil, nil
 }
 
+func (f *fakePluginClient) WatchSyncProvider(string) (*pluginhost.WatchSyncProviderClient, error) {
+	return nil, nil
+}
+
 type fakeServiceInstallationStore struct {
 	byID             map[int]*Installation
 	byPluginID       map[string][]*Installation

--- a/internal/plugins/watch_sync_config.go
+++ b/internal/plugins/watch_sync_config.go
@@ -1,0 +1,94 @@
+package plugins
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"sort"
+	"strings"
+
+	pluginv1 "github.com/Silo-Server/silo-plugin-sdk/pkg/pluginproto/silo/plugin/v1"
+)
+
+// WatchSyncProviderConfig returns the installation's global configuration in
+// the transient, field-classified shape used by watch-sync RPCs. Undeclared
+// fields are treated as secret so manifest drift cannot expose credentials.
+func (s *Service) WatchSyncProviderConfig(
+	ctx context.Context,
+	installationID int,
+) (*pluginv1.WatchSyncProviderConfig, error) {
+	manifest, err := s.manifestForInstallation(ctx, installationID, false)
+	if err != nil {
+		return nil, err
+	}
+	if s.configs == nil {
+		return &pluginv1.WatchSyncProviderConfig{}, nil
+	}
+	configs, err := s.configs.ListGlobalConfigs(ctx, installationID)
+	if err != nil {
+		return nil, fmt.Errorf("list watch sync plugin config: %w", err)
+	}
+	return watchSyncProviderConfig(manifest, configs)
+}
+
+func watchSyncProviderConfig(
+	manifest *pluginv1.PluginManifest,
+	configs []*RuntimeConfig,
+) (*pluginv1.WatchSyncProviderConfig, error) {
+	result := &pluginv1.WatchSyncProviderConfig{
+		Values:       make(map[string]string),
+		SecretValues: make(map[string]string),
+	}
+	sort.Slice(configs, func(i, j int) bool {
+		if configs[i] == nil {
+			return false
+		}
+		if configs[j] == nil {
+			return true
+		}
+		return configs[i].Key < configs[j].Key
+	})
+	for _, config := range configs {
+		if config == nil {
+			continue
+		}
+		publicFields, _ := GlobalConfigFieldSets(manifest, config.Key)
+		public := stringSet(publicFields)
+		for field, raw := range config.Value {
+			value, err := watchSyncConfigString(raw)
+			if err != nil {
+				return nil, fmt.Errorf("encode watch sync plugin config %q.%s: %w", config.Key, field, err)
+			}
+			key := strings.TrimSpace(config.Key) + "." + strings.TrimSpace(field)
+			if key == "." {
+				continue
+			}
+			if _, isPublic := public[field]; isPublic {
+				result.Values[key] = value
+				continue
+			}
+			// Explicitly secret and undeclared fields both take the protected path.
+			result.SecretValues[key] = value
+		}
+	}
+	return result, nil
+}
+
+func stringSet(values []string) map[string]struct{} {
+	result := make(map[string]struct{}, len(values))
+	for _, value := range values {
+		result[value] = struct{}{}
+	}
+	return result
+}
+
+func watchSyncConfigString(value any) (string, error) {
+	if text, ok := value.(string); ok {
+		return text, nil
+	}
+	encoded, err := json.Marshal(value)
+	if err != nil {
+		return "", err
+	}
+	return string(encoded), nil
+}

--- a/internal/plugins/watch_sync_config.go
+++ b/internal/plugins/watch_sync_config.go
@@ -52,17 +52,22 @@ func watchSyncProviderConfig(
 		if config == nil {
 			continue
 		}
-		publicFields, _ := GlobalConfigFieldSets(manifest, config.Key)
+		configKey := strings.TrimSpace(config.Key)
+		if configKey == "" {
+			continue
+		}
+		publicFields, _ := GlobalConfigFieldSets(manifest, configKey)
 		public := stringSet(publicFields)
 		for field, raw := range config.Value {
-			value, err := watchSyncConfigString(raw)
-			if err != nil {
-				return nil, fmt.Errorf("encode watch sync plugin config %q.%s: %w", config.Key, field, err)
-			}
-			key := strings.TrimSpace(config.Key) + "." + strings.TrimSpace(field)
-			if key == "." {
+			field = strings.TrimSpace(field)
+			if field == "" {
 				continue
 			}
+			value, err := watchSyncConfigString(raw)
+			if err != nil {
+				return nil, fmt.Errorf("encode watch sync plugin config %q.%s: %w", configKey, field, err)
+			}
+			key := configKey + "." + field
 			if _, isPublic := public[field]; isPublic {
 				result.Values[key] = value
 				continue
@@ -77,7 +82,9 @@ func watchSyncProviderConfig(
 func stringSet(values []string) map[string]struct{} {
 	result := make(map[string]struct{}, len(values))
 	for _, value := range values {
-		result[value] = struct{}{}
+		if value = strings.TrimSpace(value); value != "" {
+			result[value] = struct{}{}
+		}
 	}
 	return result
 }

--- a/internal/plugins/watch_sync_config_test.go
+++ b/internal/plugins/watch_sync_config_test.go
@@ -14,12 +14,18 @@ func TestWatchSyncProviderConfigClassifiesManifestFields(t *testing.T) {
 			{Key: "client_secret", Control: pluginv1.AdminFormControl_ADMIN_FORM_CONTROL_PASSWORD, Secret: true},
 		}},
 	}}}
-	config, err := watchSyncProviderConfig(manifest, []*RuntimeConfig{{
-		Key: "provider",
+	config, err := watchSyncProviderConfig(manifest, []*RuntimeConfig{nil, {
+		Key: " provider ",
 		Value: map[string]any{
-			"base_url":      "https://floppy.example",
+			" base_url ":    "https://floppy.example",
 			"client_secret": "secret",
 			"undeclared":    map[string]any{"token": "also-secret"},
+			"   ":           "ignored-empty-field",
+		},
+	}, {
+		Key: "   ",
+		Value: map[string]any{
+			"base_url": "ignored-empty-key",
 		},
 	}})
 	if err != nil {
@@ -32,5 +38,8 @@ func TestWatchSyncProviderConfigClassifiesManifestFields(t *testing.T) {
 	}
 	if _, exposed := config.GetValues()["provider.undeclared"]; exposed {
 		t.Fatal("undeclared plugin config was exposed as public")
+	}
+	if _, present := config.GetSecretValues()["."]; present {
+		t.Fatal("empty plugin config key or field was emitted")
 	}
 }

--- a/internal/plugins/watch_sync_config_test.go
+++ b/internal/plugins/watch_sync_config_test.go
@@ -1,0 +1,36 @@
+package plugins
+
+import (
+	"testing"
+
+	pluginv1 "github.com/Silo-Server/silo-plugin-sdk/pkg/pluginproto/silo/plugin/v1"
+)
+
+func TestWatchSyncProviderConfigClassifiesManifestFields(t *testing.T) {
+	manifest := &pluginv1.PluginManifest{GlobalConfigSchema: []*pluginv1.ConfigSchema{{
+		Key: "provider",
+		AdminForm: &pluginv1.AdminFormDescriptor{Fields: []*pluginv1.AdminFormField{
+			{Key: "base_url", Control: pluginv1.AdminFormControl_ADMIN_FORM_CONTROL_TEXT},
+			{Key: "client_secret", Control: pluginv1.AdminFormControl_ADMIN_FORM_CONTROL_PASSWORD, Secret: true},
+		}},
+	}}}
+	config, err := watchSyncProviderConfig(manifest, []*RuntimeConfig{{
+		Key: "provider",
+		Value: map[string]any{
+			"base_url":      "https://floppy.example",
+			"client_secret": "secret",
+			"undeclared":    map[string]any{"token": "also-secret"},
+		},
+	}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if config.GetValues()["provider.base_url"] != "https://floppy.example" ||
+		config.GetSecretValues()["provider.client_secret"] != "secret" ||
+		config.GetSecretValues()["provider.undeclared"] != `{"token":"also-secret"}` {
+		t.Fatalf("config = %#v", config)
+	}
+	if _, exposed := config.GetValues()["provider.undeclared"]; exposed {
+		t.Fatal("undeclared plugin config was exposed as public")
+	}
+}

--- a/internal/watchsync/lists.go
+++ b/internal/watchsync/lists.go
@@ -296,8 +296,10 @@ func (s *Service) importList(ctx context.Context, conn Connection, cfg ServerCon
 	if err := s.repo.UpsertListItemStates(ctx, states); err != nil {
 		return result, err
 	}
-	if err := s.reconcileMissingRemoteListItems(ctx, conn, store, b, seenRemoteKeys, &result); err != nil {
-		return result, err
+	if !batch.Incremental {
+		if err := s.reconcileMissingRemoteListItems(ctx, conn, store, b, seenRemoteKeys, &result); err != nil {
+			return result, err
+		}
 	}
 	if b.applyOrder != nil && b.orderEnabled != nil && b.capOrder != nil &&
 		b.orderEnabled(conn) && b.capOrder(provider.Capabilities()) {

--- a/internal/watchsync/lists.go
+++ b/internal/watchsync/lists.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"log/slog"
+	"strings"
 	"time"
 
 	"github.com/Silo-Server/silo-server/internal/historyimport"
@@ -248,6 +249,10 @@ func (s *Service) importList(ctx context.Context, conn Connection, cfg ServerCon
 	}
 	rows := batch.Rows
 	result := ImportListResult{Found: len(rows), Warnings: append([]string{}, batch.Warnings...)}
+	existingByRemoteKey, err := s.listItemStatesByRemoteKey(ctx, conn.ID, b.kind, rows)
+	if err != nil {
+		return result, err
+	}
 	seenRemoteKeys := make(map[string]bool, len(rows))
 	states := make([]ListItemState, 0, len(rows))
 	// orderedIDs records matched local ids in the order the provider returned
@@ -255,6 +260,12 @@ func (s *Service) importList(ctx context.Context, conn Connection, cfg ServerCon
 	// sort locally.
 	orderedIDs := make([]string, 0, len(rows))
 	for _, row := range rows {
+		if row.Removed {
+			if err := s.applyRemoteListTombstone(ctx, conn, store, b, row, existingByRemoteKey, &result); err != nil {
+				return result, err
+			}
+			continue
+		}
 		match, reason, err := s.matcher.Match(ctx, row.HistoryRecord())
 		if err != nil {
 			return result, err
@@ -301,7 +312,9 @@ func (s *Service) importList(ctx context.Context, conn Connection, cfg ServerCon
 			return result, err
 		}
 	}
-	if b.applyOrder != nil && b.orderEnabled != nil && b.capOrder != nil &&
+	// An incremental response is only a delta; replacing the whole local order
+	// with that subset would discard every item absent from the delta.
+	if !batch.Incremental && b.applyOrder != nil && b.orderEnabled != nil && b.capOrder != nil &&
 		b.orderEnabled(conn) && b.capOrder(provider.Capabilities()) {
 		if err := b.applyOrder(ctx, store, conn.ProfileID, orderedIDs); err != nil {
 			return result, err
@@ -315,6 +328,69 @@ func (s *Service) importList(ctx context.Context, conn Connection, cfg ServerCon
 		return result, err
 	}
 	return result, nil
+}
+
+func (s *Service) listItemStatesByRemoteKey(
+	ctx context.Context,
+	connectionID string,
+	kind ListKind,
+	rows []RemoteFavorite,
+) (map[string]ListItemState, error) {
+	hasTombstone := false
+	for _, row := range rows {
+		if row.Removed {
+			hasTombstone = true
+			break
+		}
+	}
+	if !hasTombstone {
+		return nil, nil
+	}
+	states, err := s.repo.ListListItemStates(ctx, connectionID, kind)
+	if err != nil {
+		return nil, err
+	}
+	byRemoteKey := make(map[string]ListItemState, len(states))
+	for _, state := range states {
+		if key := strings.TrimSpace(state.ProviderItemKey); key != "" {
+			byRemoteKey[key] = state
+		}
+	}
+	return byRemoteKey, nil
+}
+
+func (s *Service) applyRemoteListTombstone(
+	ctx context.Context,
+	conn Connection,
+	store userstore.UserStore,
+	b listBinding,
+	row RemoteFavorite,
+	existingByRemoteKey map[string]ListItemState,
+	result *ImportListResult,
+) error {
+	key := strings.TrimSpace(row.ProviderItemKey)
+	state, ok := existingByRemoteKey[key]
+	if key == "" || !ok {
+		result.Warnings = append(result.Warnings, "watch sync provider returned an unknown list removal")
+		return nil
+	}
+	now := s.now()
+	if b.removalsEnabled(conn) && state.LocalPresent {
+		if err := b.localRemove(ctx, store, conn.ProfileID, state.MediaItemID); err != nil {
+			return err
+		}
+		if err := s.repo.MarkListItemLocalRemoved(ctx, conn.ID, b.kind, state.MediaItemID, now); err != nil {
+			return err
+		}
+		result.Removed++
+		state.LocalPresent = false
+	}
+	if err := s.repo.MarkListItemRemoteRemoved(ctx, conn.ID, b.kind, state.MediaItemID, now); err != nil {
+		return err
+	}
+	state.RemotePresent = false
+	existingByRemoteKey[key] = state
+	return nil
 }
 
 func (s *Service) reconcileMissingRemoteListItems(ctx context.Context, conn Connection, store userstore.UserStore, b listBinding, seenRemoteKeys map[string]bool, result *ImportListResult) error {

--- a/internal/watchsync/plugin_provider.go
+++ b/internal/watchsync/plugin_provider.go
@@ -2,6 +2,7 @@ package watchsync
 
 import (
 	"context"
+	"encoding/base64"
 	"errors"
 	"fmt"
 	"strings"
@@ -10,17 +11,26 @@ import (
 
 	pluginv1 "github.com/Silo-Server/silo-plugin-sdk/pkg/pluginproto/silo/plugin/v1"
 	"github.com/Silo-Server/silo-server/internal/historyimport"
+	"github.com/Silo-Server/silo-server/internal/userstore"
 	"google.golang.org/protobuf/types/known/timestamppb"
 )
 
 type WatchSyncPluginClient interface {
 	ExchangeAPIKey(context.Context, *pluginv1.WatchSyncExchangeAPIKeyRequest) (*pluginv1.WatchSyncCredentialResponse, error)
+	StartDeviceAuthorization(context.Context, *pluginv1.WatchSyncStartDeviceAuthorizationRequest) (*pluginv1.WatchSyncStartDeviceAuthorizationResponse, error)
+	PollDeviceAuthorization(context.Context, *pluginv1.WatchSyncPollDeviceAuthorizationRequest) (*pluginv1.WatchSyncPollDeviceAuthorizationResponse, error)
 	RefreshCredentials(context.Context, *pluginv1.WatchSyncRefreshCredentialsRequest) (*pluginv1.WatchSyncCredentialResponse, error)
 	GetAccount(context.Context, *pluginv1.WatchSyncGetAccountRequest) (*pluginv1.WatchSyncGetAccountResponse, error)
 	ApplyEvents(context.Context, *pluginv1.WatchSyncApplyEventsRequest) (*pluginv1.WatchSyncApplyEventsResponse, error)
+	ListRemoteState(context.Context, *pluginv1.WatchSyncListRemoteStateRequest) (*pluginv1.WatchSyncListRemoteStateResponse, error)
 }
 
 type WatchSyncPluginClientResolver func(context.Context, int, string) (WatchSyncPluginClient, error)
+type WatchSyncPluginConfigResolver func(context.Context, int) (*pluginv1.WatchSyncProviderConfig, error)
+
+type PluginCredentialRepository interface {
+	UpsertConnection(context.Context, Connection) (Connection, error)
+}
 
 type PluginProviderOptions struct {
 	InstallationID int
@@ -29,6 +39,8 @@ type PluginProviderOptions struct {
 	DisplayName    string
 	Descriptor     *pluginv1.WatchSyncProviderDescriptor
 	ResolveClient  WatchSyncPluginClientResolver
+	ResolveConfig  WatchSyncPluginConfigResolver
+	Repository     PluginCredentialRepository
 }
 
 type PluginProvider struct {
@@ -37,8 +49,11 @@ type PluginProvider struct {
 	capabilityID   string
 	displayName    string
 	descriptor     *pluginv1.WatchSyncProviderDescriptor
+	authMethod     string
 	supportedMedia map[pluginv1.WatchSyncMediaType]struct{}
 	resolveClient  WatchSyncPluginClientResolver
+	resolveConfig  WatchSyncPluginConfigResolver
+	repository     PluginCredentialRepository
 }
 
 const (
@@ -57,14 +72,9 @@ func NewPluginProvider(options PluginProviderOptions) (*PluginProvider, error) {
 	if options.Descriptor == nil {
 		return nil, fmt.Errorf("watch sync plugin descriptor is required")
 	}
-	if !supportsWatchSyncAPIKey(options.Descriptor) {
-		return nil, fmt.Errorf("watch sync plugin %q does not support API-key authentication", options.ProviderKey)
-	}
-	if !options.Descriptor.GetExportWatched() {
-		return nil, fmt.Errorf("watch sync plugin %q does not export watched state", options.ProviderKey)
-	}
-	if options.Descriptor.GetExportUnwatched() || options.Descriptor.GetImportWatched() || options.Descriptor.GetImportProgress() {
-		return nil, fmt.Errorf("watch sync plugin %q advertises operations unsupported by the initial server adapter", options.ProviderKey)
+	authMethod, err := supportedWatchSyncAuthMethod(options.Descriptor)
+	if err != nil {
+		return nil, fmt.Errorf("watch sync plugin %q %w", options.ProviderKey, err)
 	}
 	supportedMedia, err := supportedWatchSyncMediaTypes(options.Descriptor)
 	if err != nil {
@@ -79,8 +89,11 @@ func NewPluginProvider(options PluginProviderOptions) (*PluginProvider, error) {
 		capabilityID:   options.CapabilityID,
 		displayName:    options.DisplayName,
 		descriptor:     options.Descriptor,
+		authMethod:     authMethod,
 		supportedMedia: supportedMedia,
 		resolveClient:  options.ResolveClient,
+		resolveConfig:  options.ResolveConfig,
+		repository:     options.Repository,
 	}, nil
 }
 
@@ -95,6 +108,17 @@ func (p *PluginProvider) DisplayName() string {
 
 func (p *PluginProvider) ProviderSource() string { return providerSourcePlugin }
 
+// HistorySource is provider-specific so importing from one plugin suppresses
+// only the echo back to that same connection. A shared generic source would
+// also suppress legitimate Floppy-to-Trakt (or other cross-provider) sync.
+func (p *PluginProvider) HistorySource() userstore.WatchHistorySource {
+	return userstore.WatchHistorySource(p.providerKey)
+}
+
+func (p *PluginProvider) AuthMethod() string { return p.authMethod }
+
+func (p *PluginProvider) usesHostPluginConfig() {}
+
 func (p *PluginProvider) authoritativeRefreshProvider() {}
 
 func (p *PluginProvider) ExportBatchSize() int {
@@ -106,19 +130,37 @@ func (p *PluginProvider) ExportBatchSize() int {
 
 func (p *PluginProvider) Capabilities() Capabilities {
 	return Capabilities{
-		ExportWatched:    true,
-		ScrobblePlayback: true,
+		ImportWatched:          p.descriptor.GetImportWatched(),
+		ImportProgress:         p.descriptor.GetImportProgress(),
+		ExportWatched:          p.descriptor.GetExportWatched(),
+		ExportUnwatched:        p.descriptor.GetExportUnwatched(),
+		ImportFavorites:        p.descriptor.GetImportFavorites(),
+		ExportFavorites:        p.descriptor.GetExportFavorites(),
+		RemoveFavorites:        p.descriptor.GetRemoveFavorites(),
+		ImportWatchlist:        p.descriptor.GetImportWatchlist(),
+		ExportWatchlist:        p.descriptor.GetExportWatchlist(),
+		RemoveWatchlist:        p.descriptor.GetRemoveWatchlist(),
+		ProvidesWatchlistOrder: p.descriptor.GetProvidesWatchlistOrder(),
+		ScrobblePlayback:       p.descriptor.GetScrobblePlayback(),
 	}
 }
 
 func (p *PluginProvider) ConnectWithAPIKey(ctx context.Context, apiKey string) (TokenSet, ProviderAccount, error) {
+	if p.authMethod != AuthMethodAPIKey {
+		return TokenSet{}, ProviderAccount{}, errors.New("watch sync plugin does not support API-key authentication")
+	}
+	config, err := p.providerConfig(ctx)
+	if err != nil {
+		return TokenSet{}, ProviderAccount{}, err
+	}
 	client, err := p.resolveClient(ctx, p.installationID, p.capabilityID)
 	if err != nil {
 		return TokenSet{}, ProviderAccount{}, watchSyncUnavailableError()
 	}
 	response, err := client.ExchangeAPIKey(ctx, &pluginv1.WatchSyncExchangeAPIKeyRequest{
-		CapabilityId: p.capabilityID,
-		ApiKey:       apiKey,
+		CapabilityId:   p.capabilityID,
+		ProviderConfig: config,
+		ApiKey:         apiKey,
 	})
 	if err != nil {
 		return TokenSet{}, ProviderAccount{}, watchSyncRPCError()
@@ -137,21 +179,98 @@ func (p *PluginProvider) ConnectWithAPIKey(ctx context.Context, apiKey string) (
 	return tokens, account, nil
 }
 
-func (p *PluginProvider) StartDeviceAuth(context.Context, ServerConfig) (DeviceAuthSession, error) {
-	return DeviceAuthSession{}, errors.New("watch sync plugin does not support device authorization")
+func (p *PluginProvider) StartDeviceAuth(ctx context.Context, _ ServerConfig) (DeviceAuthSession, error) {
+	if p.authMethod != AuthMethodDeviceCode {
+		return DeviceAuthSession{}, errors.New("watch sync plugin does not support device authorization")
+	}
+	config, err := p.providerConfig(ctx)
+	if err != nil {
+		return DeviceAuthSession{}, err
+	}
+	client, err := p.resolveClient(ctx, p.installationID, p.capabilityID)
+	if err != nil {
+		return DeviceAuthSession{}, watchSyncUnavailableError()
+	}
+	response, err := client.StartDeviceAuthorization(ctx, &pluginv1.WatchSyncStartDeviceAuthorizationRequest{
+		CapabilityId:   p.capabilityID,
+		ProviderConfig: config,
+	})
+	if err != nil {
+		return DeviceAuthSession{}, watchSyncRPCError()
+	}
+	if err := watchSyncFaultError(p.Key(), response.GetFault()); err != nil {
+		return DeviceAuthSession{}, err
+	}
+	if strings.TrimSpace(response.GetUserCode()) == "" || strings.TrimSpace(response.GetVerificationUrl()) == "" ||
+		len(response.GetProviderState()) == 0 || response.GetExpiresAt() == nil {
+		return DeviceAuthSession{}, errors.New("watch sync plugin returned an incomplete device authorization")
+	}
+	interval := 5
+	if response.GetPollingInterval() != nil && response.GetPollingInterval().AsDuration() > 0 {
+		interval = max(1, int(response.GetPollingInterval().AsDuration().Seconds()))
+	}
+	verificationURL := response.GetVerificationUrl()
+	if complete := strings.TrimSpace(response.GetVerificationUrlComplete()); complete != "" {
+		verificationURL = complete
+	}
+	return DeviceAuthSession{
+		DeviceCode:      base64.RawURLEncoding.EncodeToString(response.GetProviderState()),
+		UserCode:        response.GetUserCode(),
+		VerificationURL: verificationURL,
+		IntervalSeconds: interval,
+		ExpiresAt:       response.GetExpiresAt().AsTime(),
+	}, nil
 }
 
-func (p *PluginProvider) PollDeviceAuth(context.Context, ServerConfig, DeviceAuthSession) (TokenSet, error) {
-	return TokenSet{}, errors.New("watch sync plugin does not support device authorization")
+func (p *PluginProvider) PollDeviceAuth(ctx context.Context, _ ServerConfig, session DeviceAuthSession) (TokenSet, error) {
+	state, err := base64.RawURLEncoding.DecodeString(session.DeviceCode)
+	if err != nil {
+		return TokenSet{}, errors.New("watch sync plugin device authorization state is invalid")
+	}
+	config, err := p.providerConfig(ctx)
+	if err != nil {
+		return TokenSet{}, err
+	}
+	client, err := p.resolveClient(ctx, p.installationID, p.capabilityID)
+	if err != nil {
+		return TokenSet{}, watchSyncUnavailableError()
+	}
+	response, err := client.PollDeviceAuthorization(ctx, &pluginv1.WatchSyncPollDeviceAuthorizationRequest{
+		CapabilityId:   p.capabilityID,
+		ProviderConfig: config,
+		ProviderState:  state,
+	})
+	if err != nil {
+		return TokenSet{}, watchSyncRPCError()
+	}
+	if err := watchSyncFaultError(p.Key(), response.GetFault()); err != nil {
+		return TokenSet{}, err
+	}
+	switch response.GetStatus() {
+	case pluginv1.WatchSyncDeviceAuthorizationStatus_WATCH_SYNC_DEVICE_AUTHORIZATION_STATUS_PENDING:
+		return TokenSet{}, errors.New("watch sync plugin device authorization is pending")
+	case pluginv1.WatchSyncDeviceAuthorizationStatus_WATCH_SYNC_DEVICE_AUTHORIZATION_STATUS_DENIED:
+		return TokenSet{}, errors.New("watch sync plugin device authorization was denied")
+	case pluginv1.WatchSyncDeviceAuthorizationStatus_WATCH_SYNC_DEVICE_AUTHORIZATION_STATUS_EXPIRED:
+		return TokenSet{}, errors.New("watch sync plugin device authorization expired")
+	case pluginv1.WatchSyncDeviceAuthorizationStatus_WATCH_SYNC_DEVICE_AUTHORIZATION_STATUS_AUTHORIZED:
+		return tokenSetFromProto(response.GetCredentials())
+	default:
+		return TokenSet{}, errors.New("watch sync plugin returned an invalid device authorization status")
+	}
 }
 
 func (p *PluginProvider) RefreshToken(ctx context.Context, _ ServerConfig, conn Connection) (TokenSet, error) {
+	authContext, err := p.authenticatedContext(ctx, conn)
+	if err != nil {
+		return TokenSet{}, err
+	}
 	client, err := p.resolveClient(ctx, p.installationID, p.capabilityID)
 	if err != nil {
 		return TokenSet{}, watchSyncUnavailableError()
 	}
 	response, err := client.RefreshCredentials(ctx, &pluginv1.WatchSyncRefreshCredentialsRequest{
-		Context: p.authenticatedContext(conn),
+		Context: authContext,
 	})
 	if err != nil {
 		return TokenSet{}, watchSyncRPCError()
@@ -173,12 +292,16 @@ func (p *PluginProvider) RefreshToken(ctx context.Context, _ ServerConfig, conn 
 }
 
 func (p *PluginProvider) LookupAccount(ctx context.Context, _ ServerConfig, conn Connection) (ProviderAccount, error) {
+	authContext, err := p.authenticatedContext(ctx, conn)
+	if err != nil {
+		return ProviderAccount{}, err
+	}
 	client, err := p.resolveClient(ctx, p.installationID, p.capabilityID)
 	if err != nil {
 		return ProviderAccount{}, watchSyncUnavailableError()
 	}
 	response, err := client.GetAccount(ctx, &pluginv1.WatchSyncGetAccountRequest{
-		Context: p.authenticatedContext(conn),
+		Context: authContext,
 	})
 	if err != nil {
 		return ProviderAccount{}, watchSyncRPCError()
@@ -226,15 +349,22 @@ func (p *PluginProvider) ExportHistory(ctx context.Context, _ ServerConfig, conn
 	if len(events) == 0 {
 		return result, nil
 	}
+	authContext, err := p.authenticatedContext(ctx, conn)
+	if err != nil {
+		return result, err
+	}
 	response, err := client.ApplyEvents(ctx, &pluginv1.WatchSyncApplyEventsRequest{
-		Context: p.authenticatedContext(conn),
+		Context: authContext,
 		Events:  events,
 	})
 	if err != nil {
 		return result, watchSyncRPCError()
 	}
 	if response.GetUpdatedCredentials() != nil {
-		return result, retryableProviderError{message: "watch sync plugin credential rotation during event application is not supported"}
+		conn, err = p.persistUpdatedCredentials(ctx, conn, response.GetUpdatedCredentials())
+		if err != nil {
+			return result, err
+		}
 	}
 	if err := watchSyncFaultError(p.Key(), response.GetFault(), conn.AccessToken, conn.RefreshToken); err != nil {
 		// Batch-level faults apply to the whole request; no per-event results
@@ -279,59 +409,42 @@ func (p *PluginProvider) ExportHistory(ctx context.Context, _ ServerConfig, conn
 	return result, rateLimited
 }
 
-func (p *PluginProvider) Start(context.Context, ServerConfig, Connection, ScrobbleEvent) error {
-	return nil
+func (p *PluginProvider) Start(ctx context.Context, _ ServerConfig, conn Connection, event ScrobbleEvent) error {
+	return p.applyScrobble(ctx, conn, event, pluginv1.WatchSyncOperation_WATCH_SYNC_OPERATION_SCROBBLE_START)
 }
 
-func (p *PluginProvider) Pause(context.Context, ServerConfig, Connection, ScrobbleEvent) error {
-	return nil
+func (p *PluginProvider) Pause(ctx context.Context, _ ServerConfig, conn Connection, event ScrobbleEvent) error {
+	return p.applyScrobble(ctx, conn, event, pluginv1.WatchSyncOperation_WATCH_SYNC_OPERATION_SCROBBLE_PAUSE)
 }
 
 func (p *PluginProvider) Stop(ctx context.Context, _ ServerConfig, conn Connection, event ScrobbleEvent) error {
-	if !event.Completed {
-		return nil
-	}
-	watchEvent := watchEventFromScrobble(event)
+	return p.applyScrobble(ctx, conn, event, pluginv1.WatchSyncOperation_WATCH_SYNC_OPERATION_SCROBBLE_STOP)
+}
+
+func (p *PluginProvider) applyScrobble(
+	ctx context.Context,
+	conn Connection,
+	event ScrobbleEvent,
+	operation pluginv1.WatchSyncOperation,
+) error {
+	watchEvent := watchEventFromScrobble(event, operation)
 	if !p.supportsMedia(watchEvent.GetMedia().GetMediaType()) {
 		return watchSyncProviderFaultError{message: unsupportedWatchSyncMediaMessage(watchEvent.GetMedia().GetMediaType())}
 	}
-	client, err := p.resolveClient(ctx, p.installationID, p.capabilityID)
+	result, err := p.applyPluginEvents(ctx, conn, []*pluginv1.WatchSyncEvent{watchEvent}, []string{watchEvent.GetEventId()})
 	if err != nil {
-		return watchSyncUnavailableError()
-	}
-	response, err := client.ApplyEvents(ctx, &pluginv1.WatchSyncApplyEventsRequest{
-		Context: p.authenticatedContext(conn),
-		Events:  []*pluginv1.WatchSyncEvent{watchEvent},
-	})
-	if err != nil {
-		return watchSyncRPCError()
-	}
-	if response.GetUpdatedCredentials() != nil {
-		return retryableProviderError{message: "watch sync plugin credential rotation during event application is not supported"}
-	}
-	if err := watchSyncFaultError(p.Key(), response.GetFault(), conn.AccessToken, conn.RefreshToken); err != nil {
 		return err
 	}
-	result := resultForEvent(response.GetResults(), watchEvent.GetEventId())
-	switch result.GetStatus() {
-	case pluginv1.WatchSyncApplyStatus_WATCH_SYNC_APPLY_STATUS_APPLIED,
-		pluginv1.WatchSyncApplyStatus_WATCH_SYNC_APPLY_STATUS_NO_CHANGE:
+	if len(result.Sent) == 1 {
 		return nil
-	case pluginv1.WatchSyncApplyStatus_WATCH_SYNC_APPLY_STATUS_REJECTED:
-		return errors.New(safeApplyMessage(result, conn.AccessToken, conn.RefreshToken))
-	case pluginv1.WatchSyncApplyStatus_WATCH_SYNC_APPLY_STATUS_RETRY:
-		if fault := result.GetFault(); fault != nil &&
-			fault.GetCode() == pluginv1.WatchSyncFaultCode_WATCH_SYNC_FAULT_CODE_RATE_LIMITED {
-			retry := time.Duration(0)
-			if fault.GetRetryAfter() != nil {
-				retry = fault.GetRetryAfter().AsDuration()
-			}
-			return RateLimitedError{Provider: p.Key(), RetryAfter: retry}
-		}
-		return fmt.Errorf("%s watch sync event needs retry: %s", p.Key(), safeApplyMessage(result, conn.AccessToken, conn.RefreshToken))
-	default:
-		return fmt.Errorf("%s watch sync plugin omitted a valid result for event %s", p.Key(), watchEvent.GetEventId())
 	}
+	if len(result.NotFound) > 0 {
+		return errors.New("watch sync plugin rejected the playback event")
+	}
+	if message := result.Failed[watchEvent.GetEventId()]; message != "" {
+		return errors.New(message)
+	}
+	return errors.New("watch sync plugin did not confirm the playback event")
 }
 
 func (p *PluginProvider) ScrobbleOrderingKey(conn Connection, event ScrobbleEvent) string {
@@ -339,11 +452,50 @@ func (p *PluginProvider) ScrobbleOrderingKey(conn Connection, event ScrobbleEven
 	return "plugin-watch-sync:" + conn.ID + ":" + seriesID
 }
 
-func (p *PluginProvider) authenticatedContext(conn Connection) *pluginv1.WatchSyncAuthenticatedContext {
-	return &pluginv1.WatchSyncAuthenticatedContext{
-		CapabilityId: p.capabilityID,
-		Credentials:  credentialsFromConnection(conn),
+func (p *PluginProvider) authenticatedContext(ctx context.Context, conn Connection) (*pluginv1.WatchSyncAuthenticatedContext, error) {
+	config, err := p.providerConfig(ctx)
+	if err != nil {
+		return nil, err
 	}
+	return &pluginv1.WatchSyncAuthenticatedContext{
+		CapabilityId:   p.capabilityID,
+		ProviderConfig: config,
+		Credentials:    credentialsFromConnection(conn),
+	}, nil
+}
+
+func (p *PluginProvider) providerConfig(ctx context.Context) (*pluginv1.WatchSyncProviderConfig, error) {
+	if p.resolveConfig == nil {
+		return &pluginv1.WatchSyncProviderConfig{}, nil
+	}
+	config, err := p.resolveConfig(ctx, p.installationID)
+	if err != nil {
+		return nil, retryableProviderError{message: "watch sync plugin configuration is unavailable"}
+	}
+	if config == nil {
+		config = &pluginv1.WatchSyncProviderConfig{}
+	}
+	return config, nil
+}
+
+func (p *PluginProvider) persistUpdatedCredentials(
+	ctx context.Context,
+	conn Connection,
+	credentials *pluginv1.WatchSyncCredentials,
+) (Connection, error) {
+	if p.repository == nil {
+		return Connection{}, retryableProviderError{message: "watch sync plugin credential storage is unavailable"}
+	}
+	tokens, err := tokenSetFromProto(credentials)
+	if err != nil {
+		return Connection{}, err
+	}
+	conn = connectionWithTokens(conn, tokens)
+	persisted, err := p.repository.UpsertConnection(ctx, conn)
+	if err != nil {
+		return Connection{}, retryableProviderError{message: "watch sync plugin credential update could not be persisted"}
+	}
+	return persisted, nil
 }
 
 func watchEventFromLocalPlay(play LocalPlay, origin pluginv1.WatchSyncOrigin) *pluginv1.WatchSyncEvent {
@@ -354,16 +506,17 @@ func watchEventFromLocalPlay(play LocalPlay, origin pluginv1.WatchSyncOrigin) *p
 		OccurredAt:      timestamppb.New(play.WatchedAt),
 		WatchHistoryId:  play.HistoryID,
 		DurationSeconds: play.DurationSeconds,
+		ProviderItemKey: play.ProviderItemKey,
 		Media: mediaFromIdentity(play.MediaItemID, play.Kind, play.Title, play.Year,
 			play.IMDbID, play.TMDBID, play.TVDBID, play.SeriesTitle, play.SeriesYear,
 			play.SeriesIMDbID, play.SeriesTMDBID, play.SeriesTVDBID, play.SeasonNumber, play.EpisodeNumber),
 	}
 }
 
-func watchEventFromScrobble(event ScrobbleEvent) *pluginv1.WatchSyncEvent {
-	eventID := event.HistoryID
-	if eventID == "" {
-		eventID = "scrobble:" + event.PlaybackSessionID
+func watchEventFromScrobble(event ScrobbleEvent, operation pluginv1.WatchSyncOperation) *pluginv1.WatchSyncEvent {
+	eventID := "scrobble:" + operation.String() + ":" + event.PlaybackSessionID
+	if operation == pluginv1.WatchSyncOperation_WATCH_SYNC_OPERATION_SCROBBLE_PAUSE {
+		eventID += fmt.Sprintf(":%.3f", event.PositionSeconds)
 	}
 	completion := 0.0
 	if event.DurationSeconds > 0 {
@@ -371,7 +524,7 @@ func watchEventFromScrobble(event ScrobbleEvent) *pluginv1.WatchSyncEvent {
 	}
 	return &pluginv1.WatchSyncEvent{
 		EventId:           eventID,
-		Operation:         pluginv1.WatchSyncOperation_WATCH_SYNC_OPERATION_MARK_WATCHED,
+		Operation:         operation,
 		Origin:            pluginv1.WatchSyncOrigin_WATCH_SYNC_ORIGIN_PLAYBACK_COMPLETION,
 		OccurredAt:        timestamppb.New(event.OccurredAt),
 		WatchHistoryId:    event.HistoryID,
@@ -379,6 +532,7 @@ func watchEventFromScrobble(event ScrobbleEvent) *pluginv1.WatchSyncEvent {
 		PositionSeconds:   event.PositionSeconds,
 		DurationSeconds:   event.DurationSeconds,
 		CompletionPercent: completion,
+		ProviderItemKey:   event.ProviderItemKey,
 		Media: mediaFromIdentity(event.MediaItemID, event.Kind, "", 0,
 			event.IMDbID, event.TMDBID, event.TVDBID, "", 0,
 			event.SeriesIMDbID, event.SeriesTMDBID, event.SeriesTVDBID, event.SeasonNumber, event.EpisodeNumber),
@@ -426,7 +580,13 @@ func watchIDs(imdbID, tmdbID, tvdbID string) map[string]string {
 }
 
 func credentialsFromConnection(conn Connection) *pluginv1.WatchSyncCredentials {
-	credentials := &pluginv1.WatchSyncCredentials{AccessToken: conn.AccessToken, RefreshToken: conn.RefreshToken}
+	credentials := &pluginv1.WatchSyncCredentials{
+		AccessToken:      conn.AccessToken,
+		RefreshToken:     conn.RefreshToken,
+		TokenType:        conn.TokenType,
+		Scopes:           append([]string(nil), conn.Scopes...),
+		SecretAttributes: cloneStringMap(conn.SecretAttributes),
+	}
 	if conn.TokenExpiresAt != nil {
 		credentials.ExpiresAt = timestamppb.New(*conn.TokenExpiresAt)
 	}
@@ -437,16 +597,22 @@ func tokenSetFromProto(credentials *pluginv1.WatchSyncCredentials) (TokenSet, er
 	if credentials == nil || strings.TrimSpace(credentials.GetAccessToken()) == "" {
 		return TokenSet{}, errors.New("watch sync plugin returned no access token")
 	}
-	tokenType := strings.TrimSpace(credentials.GetTokenType())
-	if (tokenType != "" && !strings.EqualFold(tokenType, "Bearer")) || len(credentials.GetScopes()) > 0 || len(credentials.GetSecretAttributes()) > 0 {
-		return TokenSet{}, errors.New("watch sync plugin returned a credential shape unsupported by the initial server adapter")
-	}
 	var expiresAt *time.Time
 	if credentials.GetExpiresAt() != nil {
+		if err := credentials.GetExpiresAt().CheckValid(); err != nil {
+			return TokenSet{}, errors.New("watch sync plugin returned an invalid credential expiry")
+		}
 		value := credentials.GetExpiresAt().AsTime()
 		expiresAt = &value
 	}
-	return TokenSet{AccessToken: credentials.GetAccessToken(), RefreshToken: credentials.GetRefreshToken(), TokenExpiresAt: expiresAt}, nil
+	return TokenSet{
+		AccessToken:      credentials.GetAccessToken(),
+		RefreshToken:     credentials.GetRefreshToken(),
+		TokenExpiresAt:   expiresAt,
+		TokenType:        strings.TrimSpace(credentials.GetTokenType()),
+		Scopes:           append([]string(nil), credentials.GetScopes()...),
+		SecretAttributes: cloneStringMap(credentials.GetSecretAttributes()),
+	}, nil
 }
 
 func accountFromProto(account *pluginv1.WatchSyncAccount) (ProviderAccount, error) {
@@ -465,13 +631,20 @@ func resultForEvent(results []*pluginv1.WatchSyncApplyResult, eventID string) *p
 	return nil
 }
 
-func supportsWatchSyncAPIKey(descriptor *pluginv1.WatchSyncProviderDescriptor) bool {
+func supportedWatchSyncAuthMethod(descriptor *pluginv1.WatchSyncProviderDescriptor) (string, error) {
+	var deviceCode bool
 	for _, method := range descriptor.GetAuthMethods() {
-		if method == pluginv1.WatchSyncAuthMethod_WATCH_SYNC_AUTH_METHOD_API_KEY {
-			return true
+		switch method {
+		case pluginv1.WatchSyncAuthMethod_WATCH_SYNC_AUTH_METHOD_API_KEY:
+			return AuthMethodAPIKey, nil
+		case pluginv1.WatchSyncAuthMethod_WATCH_SYNC_AUTH_METHOD_DEVICE_CODE:
+			deviceCode = true
 		}
 	}
-	return false
+	if deviceCode {
+		return AuthMethodDeviceCode, nil
+	}
+	return "", errors.New("does not advertise an authentication method supported by the host")
 }
 
 func supportedWatchSyncMediaTypes(descriptor *pluginv1.WatchSyncProviderDescriptor) (map[pluginv1.WatchSyncMediaType]struct{}, error) {

--- a/internal/watchsync/plugin_provider.go
+++ b/internal/watchsync/plugin_provider.go
@@ -5,6 +5,7 @@ import (
 	"encoding/base64"
 	"errors"
 	"fmt"
+	"net/url"
 	"strings"
 	"time"
 	"unicode"
@@ -17,8 +18,8 @@ import (
 
 type WatchSyncPluginClient interface {
 	ExchangeAPIKey(context.Context, *pluginv1.WatchSyncExchangeAPIKeyRequest) (*pluginv1.WatchSyncCredentialResponse, error)
-	StartDeviceAuthorization(context.Context, *pluginv1.WatchSyncStartDeviceAuthorizationRequest) (*pluginv1.WatchSyncStartDeviceAuthorizationResponse, error)
-	PollDeviceAuthorization(context.Context, *pluginv1.WatchSyncPollDeviceAuthorizationRequest) (*pluginv1.WatchSyncPollDeviceAuthorizationResponse, error)
+	StartDeviceAuthorization(context.Context, *pluginv1.WatchSyncDeviceAuthorizationServiceStartRequest) (*pluginv1.WatchSyncDeviceAuthorizationServiceStartResponse, error)
+	PollDeviceAuthorization(context.Context, *pluginv1.WatchSyncDeviceAuthorizationServicePollRequest) (*pluginv1.WatchSyncDeviceAuthorizationServicePollResponse, error)
 	RefreshCredentials(context.Context, *pluginv1.WatchSyncRefreshCredentialsRequest) (*pluginv1.WatchSyncCredentialResponse, error)
 	GetAccount(context.Context, *pluginv1.WatchSyncGetAccountRequest) (*pluginv1.WatchSyncGetAccountResponse, error)
 	ApplyEvents(context.Context, *pluginv1.WatchSyncApplyEventsRequest) (*pluginv1.WatchSyncApplyEventsResponse, error)
@@ -191,7 +192,7 @@ func (p *PluginProvider) StartDeviceAuth(ctx context.Context, _ ServerConfig) (D
 	if err != nil {
 		return DeviceAuthSession{}, watchSyncUnavailableError()
 	}
-	response, err := client.StartDeviceAuthorization(ctx, &pluginv1.WatchSyncStartDeviceAuthorizationRequest{
+	response, err := client.StartDeviceAuthorization(ctx, &pluginv1.WatchSyncDeviceAuthorizationServiceStartRequest{
 		CapabilityId:   p.capabilityID,
 		ProviderConfig: config,
 	})
@@ -201,21 +202,32 @@ func (p *PluginProvider) StartDeviceAuth(ctx context.Context, _ ServerConfig) (D
 	if err := watchSyncFaultError(p.Key(), response.GetFault()); err != nil {
 		return DeviceAuthSession{}, err
 	}
-	if strings.TrimSpace(response.GetUserCode()) == "" || strings.TrimSpace(response.GetVerificationUrl()) == "" ||
-		len(response.GetProviderState()) == 0 || response.GetExpiresAt() == nil {
+	if strings.TrimSpace(response.GetUserCode()) == "" || len(response.GetProviderState()) == 0 || response.GetExpiresAt() == nil {
 		return DeviceAuthSession{}, errors.New("watch sync plugin returned an incomplete device authorization")
 	}
-	interval := 5
-	if response.GetPollingInterval() != nil && response.GetPollingInterval().AsDuration() > 0 {
-		interval = max(1, int(response.GetPollingInterval().AsDuration().Seconds()))
+	if err := response.GetExpiresAt().CheckValid(); err != nil || !response.GetExpiresAt().AsTime().After(time.Now()) {
+		return DeviceAuthSession{}, errors.New("watch sync plugin returned an invalid device authorization expiry")
 	}
-	verificationURL := response.GetVerificationUrl()
+	interval := 5
+	if pollingInterval := response.GetPollingInterval(); pollingInterval != nil {
+		if err := pollingInterval.CheckValid(); err != nil || pollingInterval.AsDuration() <= 0 {
+			return DeviceAuthSession{}, errors.New("watch sync plugin returned an invalid device authorization polling interval")
+		}
+		interval = max(1, int(pollingInterval.AsDuration().Seconds()))
+	}
+	verificationURL, err := validDeviceVerificationURL(response.GetVerificationUrl())
+	if err != nil {
+		return DeviceAuthSession{}, err
+	}
 	if complete := strings.TrimSpace(response.GetVerificationUrlComplete()); complete != "" {
-		verificationURL = complete
+		verificationURL, err = validDeviceVerificationURL(complete)
+		if err != nil {
+			return DeviceAuthSession{}, err
+		}
 	}
 	return DeviceAuthSession{
 		DeviceCode:      base64.RawURLEncoding.EncodeToString(response.GetProviderState()),
-		UserCode:        response.GetUserCode(),
+		UserCode:        strings.TrimSpace(response.GetUserCode()),
 		VerificationURL: verificationURL,
 		IntervalSeconds: interval,
 		ExpiresAt:       response.GetExpiresAt().AsTime(),
@@ -235,7 +247,7 @@ func (p *PluginProvider) PollDeviceAuth(ctx context.Context, _ ServerConfig, ses
 	if err != nil {
 		return TokenSet{}, watchSyncUnavailableError()
 	}
-	response, err := client.PollDeviceAuthorization(ctx, &pluginv1.WatchSyncPollDeviceAuthorizationRequest{
+	response, err := client.PollDeviceAuthorization(ctx, &pluginv1.WatchSyncDeviceAuthorizationServicePollRequest{
 		CapabilityId:   p.capabilityID,
 		ProviderConfig: config,
 		ProviderState:  state,
@@ -248,7 +260,11 @@ func (p *PluginProvider) PollDeviceAuth(ctx context.Context, _ ServerConfig, ses
 	}
 	switch response.GetStatus() {
 	case pluginv1.WatchSyncDeviceAuthorizationStatus_WATCH_SYNC_DEVICE_AUTHORIZATION_STATUS_PENDING:
-		return TokenSet{}, errors.New("watch sync plugin device authorization is pending")
+		updated, err := updatedPendingDeviceAuthSession(session, response)
+		if err != nil {
+			return TokenSet{}, err
+		}
+		return TokenSet{}, deviceAuthorizationPendingError{session: updated}
 	case pluginv1.WatchSyncDeviceAuthorizationStatus_WATCH_SYNC_DEVICE_AUTHORIZATION_STATUS_DENIED:
 		return TokenSet{}, errors.New("watch sync plugin device authorization was denied")
 	case pluginv1.WatchSyncDeviceAuthorizationStatus_WATCH_SYNC_DEVICE_AUTHORIZATION_STATUS_EXPIRED:
@@ -258,6 +274,38 @@ func (p *PluginProvider) PollDeviceAuth(ctx context.Context, _ ServerConfig, ses
 	default:
 		return TokenSet{}, errors.New("watch sync plugin returned an invalid device authorization status")
 	}
+}
+
+func validDeviceVerificationURL(value string) (string, error) {
+	value = strings.TrimSpace(value)
+	parsed, err := url.Parse(value)
+	if err != nil || parsed == nil || !parsed.IsAbs() || parsed.Host == "" || parsed.User != nil ||
+		(parsed.Scheme != "http" && parsed.Scheme != "https") {
+		return "", errors.New("watch sync plugin returned an invalid device authorization verification URL")
+	}
+	return parsed.String(), nil
+}
+
+func updatedPendingDeviceAuthSession(
+	session DeviceAuthSession,
+	response *pluginv1.WatchSyncDeviceAuthorizationServicePollResponse,
+) (DeviceAuthSession, error) {
+	if len(response.GetProviderState()) > 0 {
+		session.DeviceCode = base64.RawURLEncoding.EncodeToString(response.GetProviderState())
+	}
+	if pollingInterval := response.GetPollingInterval(); pollingInterval != nil {
+		if err := pollingInterval.CheckValid(); err != nil || pollingInterval.AsDuration() <= 0 {
+			return DeviceAuthSession{}, errors.New("watch sync plugin returned an invalid device authorization polling interval")
+		}
+		session.IntervalSeconds = max(1, int(pollingInterval.AsDuration().Seconds()))
+	}
+	if expiresAt := response.GetExpiresAt(); expiresAt != nil {
+		if err := expiresAt.CheckValid(); err != nil || !expiresAt.AsTime().After(time.Now()) {
+			return DeviceAuthSession{}, errors.New("watch sync plugin returned an invalid device authorization expiry")
+		}
+		session.ExpiresAt = expiresAt.AsTime()
+	}
+	return session, nil
 }
 
 func (p *PluginProvider) RefreshToken(ctx context.Context, _ ServerConfig, conn Connection) (TokenSet, error) {
@@ -431,20 +479,27 @@ func (p *PluginProvider) applyScrobble(
 	if !p.supportsMedia(watchEvent.GetMedia().GetMediaType()) {
 		return watchSyncProviderFaultError{message: unsupportedWatchSyncMediaMessage(watchEvent.GetMedia().GetMediaType())}
 	}
-	result, err := p.applyPluginEvents(ctx, conn, []*pluginv1.WatchSyncEvent{watchEvent}, []string{watchEvent.GetEventId()})
+	result, statuses, err := p.applyPluginEventsDetailed(ctx, conn, []*pluginv1.WatchSyncEvent{watchEvent}, []string{watchEvent.GetEventId()})
 	if err != nil {
 		return err
 	}
-	if len(result.Sent) == 1 {
+	switch statuses[watchEvent.GetEventId()] {
+	case pluginv1.WatchSyncApplyStatus_WATCH_SYNC_APPLY_STATUS_APPLIED,
+		pluginv1.WatchSyncApplyStatus_WATCH_SYNC_APPLY_STATUS_NO_CHANGE:
 		return nil
+	case pluginv1.WatchSyncApplyStatus_WATCH_SYNC_APPLY_STATUS_RETRY:
+		return retryableProviderError{message: result.Failed[watchEvent.GetEventId()]}
+	case pluginv1.WatchSyncApplyStatus_WATCH_SYNC_APPLY_STATUS_REJECTED:
+		return watchSyncProviderFaultError{
+			code:    pluginv1.WatchSyncFaultCode_WATCH_SYNC_FAULT_CODE_PERMANENT,
+			message: "watch sync plugin rejected the playback event",
+		}
+	default:
+		return watchSyncProviderFaultError{
+			code:    pluginv1.WatchSyncFaultCode_WATCH_SYNC_FAULT_CODE_PERMANENT,
+			message: "watch sync plugin did not confirm the playback event",
+		}
 	}
-	if len(result.NotFound) > 0 {
-		return errors.New("watch sync plugin rejected the playback event")
-	}
-	if message := result.Failed[watchEvent.GetEventId()]; message != "" {
-		return errors.New(message)
-	}
-	return errors.New("watch sync plugin did not confirm the playback event")
 }
 
 func (p *PluginProvider) ScrobbleOrderingKey(conn Connection, event ScrobbleEvent) string {
@@ -632,16 +687,22 @@ func resultForEvent(results []*pluginv1.WatchSyncApplyResult, eventID string) *p
 }
 
 func supportedWatchSyncAuthMethod(descriptor *pluginv1.WatchSyncProviderDescriptor) (string, error) {
-	var deviceCode bool
+	supported := make(map[string]struct{}, 2)
 	for _, method := range descriptor.GetAuthMethods() {
 		switch method {
 		case pluginv1.WatchSyncAuthMethod_WATCH_SYNC_AUTH_METHOD_API_KEY:
-			return AuthMethodAPIKey, nil
+			supported[AuthMethodAPIKey] = struct{}{}
 		case pluginv1.WatchSyncAuthMethod_WATCH_SYNC_AUTH_METHOD_DEVICE_CODE:
-			deviceCode = true
+			supported[AuthMethodDeviceCode] = struct{}{}
 		}
 	}
-	if deviceCode {
+	if len(supported) > 1 {
+		return "", errors.New("advertises multiple host authentication methods; exactly one is required")
+	}
+	if _, ok := supported[AuthMethodAPIKey]; ok {
+		return AuthMethodAPIKey, nil
+	}
+	if _, ok := supported[AuthMethodDeviceCode]; ok {
 		return AuthMethodDeviceCode, nil
 	}
 	return "", errors.New("does not advertise an authentication method supported by the host")

--- a/internal/watchsync/plugin_provider.go
+++ b/internal/watchsync/plugin_provider.go
@@ -37,8 +37,15 @@ type PluginProvider struct {
 	capabilityID   string
 	displayName    string
 	descriptor     *pluginv1.WatchSyncProviderDescriptor
+	supportedMedia map[pluginv1.WatchSyncMediaType]struct{}
 	resolveClient  WatchSyncPluginClientResolver
 }
+
+const (
+	watchSyncUnsupportedMovieMediaMessage   = "watch sync plugin does not support movie media"
+	watchSyncUnsupportedEpisodeMediaMessage = "watch sync plugin does not support episode media"
+	watchSyncUnsupportedMediaMessage        = "watch sync plugin does not support this media type"
+)
 
 func NewPluginProvider(options PluginProviderOptions) (*PluginProvider, error) {
 	if options.InstallationID <= 0 || strings.TrimSpace(options.CapabilityID) == "" {
@@ -59,6 +66,10 @@ func NewPluginProvider(options PluginProviderOptions) (*PluginProvider, error) {
 	if options.Descriptor.GetExportUnwatched() || options.Descriptor.GetImportWatched() || options.Descriptor.GetImportProgress() {
 		return nil, fmt.Errorf("watch sync plugin %q advertises operations unsupported by the initial server adapter", options.ProviderKey)
 	}
+	supportedMedia, err := supportedWatchSyncMediaTypes(options.Descriptor)
+	if err != nil {
+		return nil, fmt.Errorf("watch sync plugin %q %w", options.ProviderKey, err)
+	}
 	if options.ResolveClient == nil {
 		return nil, fmt.Errorf("watch sync plugin client resolver is required")
 	}
@@ -68,6 +79,7 @@ func NewPluginProvider(options PluginProviderOptions) (*PluginProvider, error) {
 		capabilityID:   options.CapabilityID,
 		displayName:    options.DisplayName,
 		descriptor:     options.Descriptor,
+		supportedMedia: supportedMedia,
 		resolveClient:  options.ResolveClient,
 	}, nil
 }
@@ -185,8 +197,18 @@ func (p *PluginProvider) ExportHistory(ctx context.Context, _ ServerConfig, conn
 		batchSize = maximum
 	}
 	events := make([]*pluginv1.WatchSyncEvent, 0, batchSize)
+	selectedPlays := make([]LocalPlay, 0, batchSize)
 	for _, play := range plays[:batchSize] {
-		events = append(events, watchEventFromLocalPlay(play, pluginv1.WatchSyncOrigin_WATCH_SYNC_ORIGIN_RECONCILIATION))
+		event := watchEventFromLocalPlay(play, pluginv1.WatchSyncOrigin_WATCH_SYNC_ORIGIN_RECONCILIATION)
+		if !p.supportsMedia(event.GetMedia().GetMediaType()) {
+			result.Failed[play.HistoryID] = unsupportedWatchSyncMediaMessage(event.GetMedia().GetMediaType())
+			continue
+		}
+		events = append(events, event)
+		selectedPlays = append(selectedPlays, play)
+	}
+	if len(events) == 0 {
+		return result, nil
 	}
 	response, err := client.ApplyEvents(ctx, &pluginv1.WatchSyncApplyEventsRequest{
 		Context: p.authenticatedContext(conn),
@@ -218,7 +240,7 @@ func (p *PluginProvider) ExportHistory(ctx context.Context, _ ServerConfig, conn
 		}
 	}
 	for index, event := range events {
-		historyID := plays[index].HistoryID
+		historyID := selectedPlays[index].HistoryID
 		apply := resultForEvent(response.GetResults(), event.GetEventId())
 		switch apply.GetStatus() {
 		case pluginv1.WatchSyncApplyStatus_WATCH_SYNC_APPLY_STATUS_APPLIED,
@@ -253,11 +275,14 @@ func (p *PluginProvider) Stop(ctx context.Context, _ ServerConfig, conn Connecti
 	if !event.Completed {
 		return nil
 	}
+	watchEvent := watchEventFromScrobble(event)
+	if !p.supportsMedia(watchEvent.GetMedia().GetMediaType()) {
+		return watchSyncProviderFaultError{message: unsupportedWatchSyncMediaMessage(watchEvent.GetMedia().GetMediaType())}
+	}
 	client, err := p.resolveClient(ctx, p.installationID, p.capabilityID)
 	if err != nil {
 		return watchSyncUnavailableError()
 	}
-	watchEvent := watchEventFromScrobble(event)
 	response, err := client.ApplyEvents(ctx, &pluginv1.WatchSyncApplyEventsRequest{
 		Context: p.authenticatedContext(conn),
 		Events:  []*pluginv1.WatchSyncEvent{watchEvent},
@@ -431,6 +456,46 @@ func supportsWatchSyncAPIKey(descriptor *pluginv1.WatchSyncProviderDescriptor) b
 		}
 	}
 	return false
+}
+
+func supportedWatchSyncMediaTypes(descriptor *pluginv1.WatchSyncProviderDescriptor) (map[pluginv1.WatchSyncMediaType]struct{}, error) {
+	media := descriptor.GetSupportedMediaTypes()
+	if len(media) == 0 {
+		return map[pluginv1.WatchSyncMediaType]struct{}{
+			pluginv1.WatchSyncMediaType_WATCH_SYNC_MEDIA_TYPE_MOVIE:   {},
+			pluginv1.WatchSyncMediaType_WATCH_SYNC_MEDIA_TYPE_EPISODE: {},
+		}, nil
+	}
+	supported := make(map[pluginv1.WatchSyncMediaType]struct{}, len(media))
+	for _, mediaType := range media {
+		switch mediaType {
+		case pluginv1.WatchSyncMediaType_WATCH_SYNC_MEDIA_TYPE_MOVIE,
+			pluginv1.WatchSyncMediaType_WATCH_SYNC_MEDIA_TYPE_EPISODE:
+			supported[mediaType] = struct{}{}
+		default:
+			return nil, fmt.Errorf("advertises unsupported media type %q", mediaType.String())
+		}
+	}
+	return supported, nil
+}
+
+func (p *PluginProvider) supportsMedia(mediaType pluginv1.WatchSyncMediaType) bool {
+	if mediaType == pluginv1.WatchSyncMediaType_WATCH_SYNC_MEDIA_TYPE_UNSPECIFIED {
+		return true
+	}
+	_, ok := p.supportedMedia[mediaType]
+	return ok
+}
+
+func unsupportedWatchSyncMediaMessage(mediaType pluginv1.WatchSyncMediaType) string {
+	switch mediaType {
+	case pluginv1.WatchSyncMediaType_WATCH_SYNC_MEDIA_TYPE_MOVIE:
+		return watchSyncUnsupportedMovieMediaMessage
+	case pluginv1.WatchSyncMediaType_WATCH_SYNC_MEDIA_TYPE_EPISODE:
+		return watchSyncUnsupportedEpisodeMediaMessage
+	default:
+		return watchSyncUnsupportedMediaMessage
+	}
 }
 
 func safeApplyMessage(result *pluginv1.WatchSyncApplyResult, secrets ...string) string {

--- a/internal/watchsync/plugin_provider.go
+++ b/internal/watchsync/plugin_provider.go
@@ -95,6 +95,8 @@ func (p *PluginProvider) DisplayName() string {
 
 func (p *PluginProvider) ProviderSource() string { return providerSourcePlugin }
 
+func (p *PluginProvider) authoritativeRefreshProvider() {}
+
 func (p *PluginProvider) ExportBatchSize() int {
 	if size := int(p.descriptor.GetMaxBatchSize()); size > 0 {
 		return size
@@ -128,7 +130,11 @@ func (p *PluginProvider) ConnectWithAPIKey(ctx context.Context, apiKey string) (
 	if err != nil {
 		return TokenSet{}, ProviderAccount{}, err
 	}
-	return tokens, accountFromProto(response.GetAccount()), nil
+	account, err := accountFromProto(response.GetAccount())
+	if err != nil {
+		return TokenSet{}, ProviderAccount{}, err
+	}
+	return tokens, account, nil
 }
 
 func (p *PluginProvider) StartDeviceAuth(context.Context, ServerConfig) (DeviceAuthSession, error) {
@@ -150,10 +156,20 @@ func (p *PluginProvider) RefreshToken(ctx context.Context, _ ServerConfig, conn 
 	if err != nil {
 		return TokenSet{}, watchSyncRPCError()
 	}
-	if err := watchSyncFaultError(p.Key(), response.GetFault(), conn.AccessToken, conn.RefreshToken); err != nil {
-		return TokenSet{}, err
+	var tokens TokenSet
+	if response.GetCredentials() != nil {
+		tokens, err = tokenSetFromProto(response.GetCredentials())
+		if err != nil {
+			return TokenSet{}, err
+		}
 	}
-	return tokenSetFromProto(response.GetCredentials())
+	if err := watchSyncFaultError(p.Key(), response.GetFault(), conn.AccessToken, conn.RefreshToken, tokens.AccessToken, tokens.RefreshToken); err != nil {
+		return tokens, err
+	}
+	if response.GetCredentials() == nil {
+		return TokenSet{}, errors.New("watch sync plugin returned no access token")
+	}
+	return tokens, nil
 }
 
 func (p *PluginProvider) LookupAccount(ctx context.Context, _ ServerConfig, conn Connection) (ProviderAccount, error) {
@@ -170,7 +186,7 @@ func (p *PluginProvider) LookupAccount(ctx context.Context, _ ServerConfig, conn
 	if err := watchSyncFaultError(p.Key(), response.GetFault(), conn.AccessToken, conn.RefreshToken); err != nil {
 		return ProviderAccount{}, err
 	}
-	return accountFromProto(response.GetAccount()), nil
+	return accountFromProto(response.GetAccount())
 }
 
 func (p *PluginProvider) FetchHistory(context.Context, ServerConfig, Connection) ([]RemotePlay, error) {
@@ -433,11 +449,11 @@ func tokenSetFromProto(credentials *pluginv1.WatchSyncCredentials) (TokenSet, er
 	return TokenSet{AccessToken: credentials.GetAccessToken(), RefreshToken: credentials.GetRefreshToken(), TokenExpiresAt: expiresAt}, nil
 }
 
-func accountFromProto(account *pluginv1.WatchSyncAccount) ProviderAccount {
-	if account == nil {
-		return ProviderAccount{}
+func accountFromProto(account *pluginv1.WatchSyncAccount) (ProviderAccount, error) {
+	if account == nil || strings.TrimSpace(account.GetExternalSubject()) == "" {
+		return ProviderAccount{}, errors.New("watch sync plugin returned no provider account identity")
 	}
-	return ProviderAccount{ID: account.GetExternalSubject(), Username: account.GetUsername()}
+	return ProviderAccount{ID: account.GetExternalSubject(), Username: account.GetUsername()}, nil
 }
 
 func resultForEvent(results []*pluginv1.WatchSyncApplyResult, eventID string) *pluginv1.WatchSyncApplyResult {
@@ -481,7 +497,7 @@ func supportedWatchSyncMediaTypes(descriptor *pluginv1.WatchSyncProviderDescript
 
 func (p *PluginProvider) supportsMedia(mediaType pluginv1.WatchSyncMediaType) bool {
 	if mediaType == pluginv1.WatchSyncMediaType_WATCH_SYNC_MEDIA_TYPE_UNSPECIFIED {
-		return true
+		return false
 	}
 	_, ok := p.supportedMedia[mediaType]
 	return ok
@@ -506,15 +522,9 @@ func safeApplyMessage(result *pluginv1.WatchSyncApplyResult, secrets ...string) 
 }
 
 func sanitizeWatchSyncMessage(message string, fallback string, secrets ...string) string {
-	message = strings.Map(func(r rune) rune {
-		if unicode.IsControl(r) {
-			return ' '
-		}
-		return r
-	}, message)
-	message = strings.Join(strings.Fields(message), " ")
+	message = normalizeWatchSyncText(message)
 	for _, secret := range secrets {
-		if secret = strings.TrimSpace(secret); secret != "" {
+		if secret = normalizeWatchSyncText(secret); secret != "" {
 			message = strings.ReplaceAll(message, secret, "[REDACTED]")
 		}
 	}
@@ -527,6 +537,16 @@ func sanitizeWatchSyncMessage(message string, fallback string, secrets ...string
 		message = string(runes[:maxRunes]) + "…"
 	}
 	return message
+}
+
+func normalizeWatchSyncText(value string) string {
+	value = strings.Map(func(r rune) rune {
+		if unicode.IsControl(r) {
+			return ' '
+		}
+		return r
+	}, value)
+	return strings.Join(strings.Fields(value), " ")
 }
 
 func watchSyncUnavailableError() error {
@@ -543,6 +563,11 @@ type watchSyncProviderFaultError struct {
 }
 
 func (e watchSyncProviderFaultError) Error() string { return e.message }
+
+func isWatchSyncInvalidCredentialError(err error) bool {
+	var fault watchSyncProviderFaultError
+	return errors.As(err, &fault) && fault.code == pluginv1.WatchSyncFaultCode_WATCH_SYNC_FAULT_CODE_INVALID_CREDENTIAL
+}
 
 func watchSyncFaultError(provider string, fault *pluginv1.WatchSyncFault, secrets ...string) error {
 	if fault == nil || fault.GetCode() == pluginv1.WatchSyncFaultCode_WATCH_SYNC_FAULT_CODE_UNSPECIFIED {

--- a/internal/watchsync/plugin_provider.go
+++ b/internal/watchsync/plugin_provider.go
@@ -1,0 +1,507 @@
+package watchsync
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+	"time"
+	"unicode"
+
+	pluginv1 "github.com/Silo-Server/silo-plugin-sdk/pkg/pluginproto/silo/plugin/v1"
+	"github.com/Silo-Server/silo-server/internal/historyimport"
+	"google.golang.org/protobuf/types/known/timestamppb"
+)
+
+type WatchSyncPluginClient interface {
+	ExchangeAPIKey(context.Context, *pluginv1.WatchSyncExchangeAPIKeyRequest) (*pluginv1.WatchSyncCredentialResponse, error)
+	RefreshCredentials(context.Context, *pluginv1.WatchSyncRefreshCredentialsRequest) (*pluginv1.WatchSyncCredentialResponse, error)
+	GetAccount(context.Context, *pluginv1.WatchSyncGetAccountRequest) (*pluginv1.WatchSyncGetAccountResponse, error)
+	ApplyEvents(context.Context, *pluginv1.WatchSyncApplyEventsRequest) (*pluginv1.WatchSyncApplyEventsResponse, error)
+}
+
+type WatchSyncPluginClientResolver func(context.Context, int, string) (WatchSyncPluginClient, error)
+
+type PluginProviderOptions struct {
+	InstallationID int
+	ProviderKey    string
+	CapabilityID   string
+	DisplayName    string
+	Descriptor     *pluginv1.WatchSyncProviderDescriptor
+	ResolveClient  WatchSyncPluginClientResolver
+}
+
+type PluginProvider struct {
+	installationID int
+	providerKey    string
+	capabilityID   string
+	displayName    string
+	descriptor     *pluginv1.WatchSyncProviderDescriptor
+	resolveClient  WatchSyncPluginClientResolver
+}
+
+func NewPluginProvider(options PluginProviderOptions) (*PluginProvider, error) {
+	if options.InstallationID <= 0 || strings.TrimSpace(options.CapabilityID) == "" {
+		return nil, fmt.Errorf("watch sync plugin installation and capability are required")
+	}
+	if strings.TrimSpace(options.ProviderKey) == "" {
+		return nil, fmt.Errorf("watch sync plugin provider key is required")
+	}
+	if options.Descriptor == nil {
+		return nil, fmt.Errorf("watch sync plugin descriptor is required")
+	}
+	if !supportsWatchSyncAPIKey(options.Descriptor) {
+		return nil, fmt.Errorf("watch sync plugin %q does not support API-key authentication", options.ProviderKey)
+	}
+	if !options.Descriptor.GetExportWatched() {
+		return nil, fmt.Errorf("watch sync plugin %q does not export watched state", options.ProviderKey)
+	}
+	if options.Descriptor.GetExportUnwatched() || options.Descriptor.GetImportWatched() || options.Descriptor.GetImportProgress() {
+		return nil, fmt.Errorf("watch sync plugin %q advertises operations unsupported by the initial server adapter", options.ProviderKey)
+	}
+	if options.ResolveClient == nil {
+		return nil, fmt.Errorf("watch sync plugin client resolver is required")
+	}
+	return &PluginProvider{
+		installationID: options.InstallationID,
+		providerKey:    options.ProviderKey,
+		capabilityID:   options.CapabilityID,
+		displayName:    options.DisplayName,
+		descriptor:     options.Descriptor,
+		resolveClient:  options.ResolveClient,
+	}, nil
+}
+
+func (p *PluginProvider) Key() string { return p.providerKey }
+
+func (p *PluginProvider) DisplayName() string {
+	if strings.TrimSpace(p.displayName) != "" {
+		return p.displayName
+	}
+	return p.capabilityID
+}
+
+func (p *PluginProvider) ProviderSource() string { return providerSourcePlugin }
+
+func (p *PluginProvider) ExportBatchSize() int {
+	if size := int(p.descriptor.GetMaxBatchSize()); size > 0 {
+		return size
+	}
+	return 1
+}
+
+func (p *PluginProvider) Capabilities() Capabilities {
+	return Capabilities{
+		ExportWatched:    true,
+		ScrobblePlayback: true,
+	}
+}
+
+func (p *PluginProvider) ConnectWithAPIKey(ctx context.Context, apiKey string) (TokenSet, ProviderAccount, error) {
+	client, err := p.resolveClient(ctx, p.installationID, p.capabilityID)
+	if err != nil {
+		return TokenSet{}, ProviderAccount{}, watchSyncUnavailableError()
+	}
+	response, err := client.ExchangeAPIKey(ctx, &pluginv1.WatchSyncExchangeAPIKeyRequest{
+		CapabilityId: p.capabilityID,
+		ApiKey:       apiKey,
+	})
+	if err != nil {
+		return TokenSet{}, ProviderAccount{}, watchSyncRPCError()
+	}
+	if err := watchSyncFaultError(p.Key(), response.GetFault(), apiKey); err != nil {
+		return TokenSet{}, ProviderAccount{}, err
+	}
+	tokens, err := tokenSetFromProto(response.GetCredentials())
+	if err != nil {
+		return TokenSet{}, ProviderAccount{}, err
+	}
+	return tokens, accountFromProto(response.GetAccount()), nil
+}
+
+func (p *PluginProvider) StartDeviceAuth(context.Context, ServerConfig) (DeviceAuthSession, error) {
+	return DeviceAuthSession{}, errors.New("watch sync plugin does not support device authorization")
+}
+
+func (p *PluginProvider) PollDeviceAuth(context.Context, ServerConfig, DeviceAuthSession) (TokenSet, error) {
+	return TokenSet{}, errors.New("watch sync plugin does not support device authorization")
+}
+
+func (p *PluginProvider) RefreshToken(ctx context.Context, _ ServerConfig, conn Connection) (TokenSet, error) {
+	client, err := p.resolveClient(ctx, p.installationID, p.capabilityID)
+	if err != nil {
+		return TokenSet{}, watchSyncUnavailableError()
+	}
+	response, err := client.RefreshCredentials(ctx, &pluginv1.WatchSyncRefreshCredentialsRequest{
+		Context: p.authenticatedContext(conn),
+	})
+	if err != nil {
+		return TokenSet{}, watchSyncRPCError()
+	}
+	if err := watchSyncFaultError(p.Key(), response.GetFault(), conn.AccessToken, conn.RefreshToken); err != nil {
+		return TokenSet{}, err
+	}
+	return tokenSetFromProto(response.GetCredentials())
+}
+
+func (p *PluginProvider) LookupAccount(ctx context.Context, _ ServerConfig, conn Connection) (ProviderAccount, error) {
+	client, err := p.resolveClient(ctx, p.installationID, p.capabilityID)
+	if err != nil {
+		return ProviderAccount{}, watchSyncUnavailableError()
+	}
+	response, err := client.GetAccount(ctx, &pluginv1.WatchSyncGetAccountRequest{
+		Context: p.authenticatedContext(conn),
+	})
+	if err != nil {
+		return ProviderAccount{}, watchSyncRPCError()
+	}
+	if err := watchSyncFaultError(p.Key(), response.GetFault(), conn.AccessToken, conn.RefreshToken); err != nil {
+		return ProviderAccount{}, err
+	}
+	return accountFromProto(response.GetAccount()), nil
+}
+
+func (p *PluginProvider) FetchHistory(context.Context, ServerConfig, Connection) ([]RemotePlay, error) {
+	// A desired-state tracker is not a timestamped play-history source. Silo's
+	// durable local export rows provide reconciliation for this provider.
+	return nil, nil
+}
+
+func (p *PluginProvider) ExportHistory(ctx context.Context, _ ServerConfig, conn Connection, plays []LocalPlay) (ExportResult, error) {
+	result := ExportResult{Failed: map[string]string{}}
+	if len(plays) == 0 {
+		return result, nil
+	}
+	client, err := p.resolveClient(ctx, p.installationID, p.capabilityID)
+	if err != nil {
+		return result, watchSyncUnavailableError()
+	}
+
+	// Perform one bounded RPC per service iteration. This lets the existing
+	// exporter commit every per-event result before requesting the next batch,
+	// and avoids holding one sync run across many sequential plugin deadlines.
+	batchSize := len(plays)
+	if maximum := p.ExportBatchSize(); batchSize > maximum {
+		batchSize = maximum
+	}
+	events := make([]*pluginv1.WatchSyncEvent, 0, batchSize)
+	for _, play := range plays[:batchSize] {
+		events = append(events, watchEventFromLocalPlay(play, pluginv1.WatchSyncOrigin_WATCH_SYNC_ORIGIN_RECONCILIATION))
+	}
+	response, err := client.ApplyEvents(ctx, &pluginv1.WatchSyncApplyEventsRequest{
+		Context: p.authenticatedContext(conn),
+		Events:  events,
+	})
+	if err != nil {
+		return result, watchSyncRPCError()
+	}
+	if response.GetUpdatedCredentials() != nil {
+		return result, retryableProviderError{message: "watch sync plugin credential rotation during event application is not supported"}
+	}
+	if err := watchSyncFaultError(p.Key(), response.GetFault(), conn.AccessToken, conn.RefreshToken); err != nil {
+		// Batch-level faults apply to the whole request; no per-event results
+		// are committed when the host is told to ignore them.
+		return result, err
+	}
+
+	var rateLimited error
+	for _, event := range events {
+		apply := resultForEvent(response.GetResults(), event.GetEventId())
+		if fault := apply.GetFault(); apply.GetStatus() == pluginv1.WatchSyncApplyStatus_WATCH_SYNC_APPLY_STATUS_RETRY &&
+			fault != nil && fault.GetCode() == pluginv1.WatchSyncFaultCode_WATCH_SYNC_FAULT_CODE_RATE_LIMITED {
+			retry := time.Duration(0)
+			if fault.GetRetryAfter() != nil {
+				retry = fault.GetRetryAfter().AsDuration()
+			}
+			rateLimited = RateLimitedError{Provider: p.Key(), RetryAfter: retry}
+			break
+		}
+	}
+	for index, event := range events {
+		historyID := plays[index].HistoryID
+		apply := resultForEvent(response.GetResults(), event.GetEventId())
+		switch apply.GetStatus() {
+		case pluginv1.WatchSyncApplyStatus_WATCH_SYNC_APPLY_STATUS_APPLIED,
+			pluginv1.WatchSyncApplyStatus_WATCH_SYNC_APPLY_STATUS_NO_CHANGE:
+			result.Sent = append(result.Sent, historyID)
+		case pluginv1.WatchSyncApplyStatus_WATCH_SYNC_APPLY_STATUS_REJECTED:
+			result.NotFound = append(result.NotFound, historyID)
+		case pluginv1.WatchSyncApplyStatus_WATCH_SYNC_APPLY_STATUS_RETRY:
+			if fault := apply.GetFault(); fault != nil &&
+				fault.GetCode() == pluginv1.WatchSyncFaultCode_WATCH_SYNC_FAULT_CODE_RATE_LIMITED {
+				continue
+			}
+			result.Failed[historyID] = safeApplyMessage(apply, conn.AccessToken, conn.RefreshToken)
+		default:
+			if rateLimited == nil {
+				result.Failed[historyID] = "watch sync plugin omitted a valid event result"
+			}
+		}
+	}
+	return result, rateLimited
+}
+
+func (p *PluginProvider) Start(context.Context, ServerConfig, Connection, ScrobbleEvent) error {
+	return nil
+}
+
+func (p *PluginProvider) Pause(context.Context, ServerConfig, Connection, ScrobbleEvent) error {
+	return nil
+}
+
+func (p *PluginProvider) Stop(ctx context.Context, _ ServerConfig, conn Connection, event ScrobbleEvent) error {
+	if !event.Completed {
+		return nil
+	}
+	client, err := p.resolveClient(ctx, p.installationID, p.capabilityID)
+	if err != nil {
+		return watchSyncUnavailableError()
+	}
+	watchEvent := watchEventFromScrobble(event)
+	response, err := client.ApplyEvents(ctx, &pluginv1.WatchSyncApplyEventsRequest{
+		Context: p.authenticatedContext(conn),
+		Events:  []*pluginv1.WatchSyncEvent{watchEvent},
+	})
+	if err != nil {
+		return watchSyncRPCError()
+	}
+	if response.GetUpdatedCredentials() != nil {
+		return retryableProviderError{message: "watch sync plugin credential rotation during event application is not supported"}
+	}
+	if err := watchSyncFaultError(p.Key(), response.GetFault(), conn.AccessToken, conn.RefreshToken); err != nil {
+		return err
+	}
+	result := resultForEvent(response.GetResults(), watchEvent.GetEventId())
+	switch result.GetStatus() {
+	case pluginv1.WatchSyncApplyStatus_WATCH_SYNC_APPLY_STATUS_APPLIED,
+		pluginv1.WatchSyncApplyStatus_WATCH_SYNC_APPLY_STATUS_NO_CHANGE:
+		return nil
+	case pluginv1.WatchSyncApplyStatus_WATCH_SYNC_APPLY_STATUS_REJECTED:
+		return errors.New(safeApplyMessage(result, conn.AccessToken, conn.RefreshToken))
+	case pluginv1.WatchSyncApplyStatus_WATCH_SYNC_APPLY_STATUS_RETRY:
+		if fault := result.GetFault(); fault != nil &&
+			fault.GetCode() == pluginv1.WatchSyncFaultCode_WATCH_SYNC_FAULT_CODE_RATE_LIMITED {
+			retry := time.Duration(0)
+			if fault.GetRetryAfter() != nil {
+				retry = fault.GetRetryAfter().AsDuration()
+			}
+			return RateLimitedError{Provider: p.Key(), RetryAfter: retry}
+		}
+		return fmt.Errorf("%s watch sync event needs retry: %s", p.Key(), safeApplyMessage(result, conn.AccessToken, conn.RefreshToken))
+	default:
+		return fmt.Errorf("%s watch sync plugin omitted a valid result for event %s", p.Key(), watchEvent.GetEventId())
+	}
+}
+
+func (p *PluginProvider) ScrobbleOrderingKey(conn Connection, event ScrobbleEvent) string {
+	seriesID := firstNonEmptyWatchID(event.SeriesTVDBID, event.SeriesTMDBID, event.SeriesIMDbID, event.MediaItemID)
+	return "plugin-watch-sync:" + conn.ID + ":" + seriesID
+}
+
+func (p *PluginProvider) authenticatedContext(conn Connection) *pluginv1.WatchSyncAuthenticatedContext {
+	return &pluginv1.WatchSyncAuthenticatedContext{
+		CapabilityId: p.capabilityID,
+		Credentials:  credentialsFromConnection(conn),
+	}
+}
+
+func watchEventFromLocalPlay(play LocalPlay, origin pluginv1.WatchSyncOrigin) *pluginv1.WatchSyncEvent {
+	return &pluginv1.WatchSyncEvent{
+		EventId:         play.HistoryID,
+		Operation:       pluginv1.WatchSyncOperation_WATCH_SYNC_OPERATION_MARK_WATCHED,
+		Origin:          origin,
+		OccurredAt:      timestamppb.New(play.WatchedAt),
+		WatchHistoryId:  play.HistoryID,
+		DurationSeconds: play.DurationSeconds,
+		Media: mediaFromIdentity(play.MediaItemID, play.Kind, play.Title, play.Year,
+			play.IMDbID, play.TMDBID, play.TVDBID, play.SeriesTitle, play.SeriesYear,
+			play.SeriesIMDbID, play.SeriesTMDBID, play.SeriesTVDBID, play.SeasonNumber, play.EpisodeNumber),
+	}
+}
+
+func watchEventFromScrobble(event ScrobbleEvent) *pluginv1.WatchSyncEvent {
+	eventID := event.HistoryID
+	if eventID == "" {
+		eventID = "scrobble:" + event.PlaybackSessionID
+	}
+	completion := 0.0
+	if event.DurationSeconds > 0 {
+		completion = event.PositionSeconds / event.DurationSeconds * 100
+	}
+	return &pluginv1.WatchSyncEvent{
+		EventId:           eventID,
+		Operation:         pluginv1.WatchSyncOperation_WATCH_SYNC_OPERATION_MARK_WATCHED,
+		Origin:            pluginv1.WatchSyncOrigin_WATCH_SYNC_ORIGIN_PLAYBACK_COMPLETION,
+		OccurredAt:        timestamppb.New(event.OccurredAt),
+		WatchHistoryId:    event.HistoryID,
+		PlaybackSessionId: event.PlaybackSessionID,
+		PositionSeconds:   event.PositionSeconds,
+		DurationSeconds:   event.DurationSeconds,
+		CompletionPercent: completion,
+		Media: mediaFromIdentity(event.MediaItemID, event.Kind, "", 0,
+			event.IMDbID, event.TMDBID, event.TVDBID, "", 0,
+			event.SeriesIMDbID, event.SeriesTMDBID, event.SeriesTVDBID, event.SeasonNumber, event.EpisodeNumber),
+	}
+}
+
+func mediaFromIdentity(mediaItemID, kind, title string, year int, imdbID, tmdbID, tvdbID, seriesTitle string, seriesYear int, seriesIMDbID, seriesTMDBID, seriesTVDBID string, season, episode int) *pluginv1.WatchSyncMedia {
+	return &pluginv1.WatchSyncMedia{
+		MediaItemId:       mediaItemID,
+		MediaType:         watchSyncMediaType(kind),
+		Title:             title,
+		Year:              int32(year),
+		ExternalIds:       watchIDs(imdbID, tmdbID, tvdbID),
+		SeriesTitle:       seriesTitle,
+		SeriesYear:        int32(seriesYear),
+		SeriesExternalIds: watchIDs(seriesIMDbID, seriesTMDBID, seriesTVDBID),
+		SeasonNumber:      int32(season),
+		EpisodeNumber:     int32(episode),
+	}
+}
+
+func watchSyncMediaType(kind string) pluginv1.WatchSyncMediaType {
+	switch strings.ToLower(strings.TrimSpace(kind)) {
+	case historyimport.KindMovie:
+		return pluginv1.WatchSyncMediaType_WATCH_SYNC_MEDIA_TYPE_MOVIE
+	case historyimport.KindEpisode:
+		return pluginv1.WatchSyncMediaType_WATCH_SYNC_MEDIA_TYPE_EPISODE
+	default:
+		return pluginv1.WatchSyncMediaType_WATCH_SYNC_MEDIA_TYPE_UNSPECIFIED
+	}
+}
+
+func watchIDs(imdbID, tmdbID, tvdbID string) map[string]string {
+	ids := map[string]string{}
+	if imdbID != "" {
+		ids["imdb"] = imdbID
+	}
+	if tmdbID != "" {
+		ids["tmdb"] = tmdbID
+	}
+	if tvdbID != "" {
+		ids["tvdb"] = tvdbID
+	}
+	return ids
+}
+
+func credentialsFromConnection(conn Connection) *pluginv1.WatchSyncCredentials {
+	credentials := &pluginv1.WatchSyncCredentials{AccessToken: conn.AccessToken, RefreshToken: conn.RefreshToken}
+	if conn.TokenExpiresAt != nil {
+		credentials.ExpiresAt = timestamppb.New(*conn.TokenExpiresAt)
+	}
+	return credentials
+}
+
+func tokenSetFromProto(credentials *pluginv1.WatchSyncCredentials) (TokenSet, error) {
+	if credentials == nil || strings.TrimSpace(credentials.GetAccessToken()) == "" {
+		return TokenSet{}, errors.New("watch sync plugin returned no access token")
+	}
+	tokenType := strings.TrimSpace(credentials.GetTokenType())
+	if (tokenType != "" && !strings.EqualFold(tokenType, "Bearer")) || len(credentials.GetScopes()) > 0 || len(credentials.GetSecretAttributes()) > 0 {
+		return TokenSet{}, errors.New("watch sync plugin returned a credential shape unsupported by the initial server adapter")
+	}
+	var expiresAt *time.Time
+	if credentials.GetExpiresAt() != nil {
+		value := credentials.GetExpiresAt().AsTime()
+		expiresAt = &value
+	}
+	return TokenSet{AccessToken: credentials.GetAccessToken(), RefreshToken: credentials.GetRefreshToken(), TokenExpiresAt: expiresAt}, nil
+}
+
+func accountFromProto(account *pluginv1.WatchSyncAccount) ProviderAccount {
+	if account == nil {
+		return ProviderAccount{}
+	}
+	return ProviderAccount{ID: account.GetExternalSubject(), Username: account.GetUsername()}
+}
+
+func resultForEvent(results []*pluginv1.WatchSyncApplyResult, eventID string) *pluginv1.WatchSyncApplyResult {
+	for _, result := range results {
+		if result.GetEventId() == eventID {
+			return result
+		}
+	}
+	return nil
+}
+
+func supportsWatchSyncAPIKey(descriptor *pluginv1.WatchSyncProviderDescriptor) bool {
+	for _, method := range descriptor.GetAuthMethods() {
+		if method == pluginv1.WatchSyncAuthMethod_WATCH_SYNC_AUTH_METHOD_API_KEY {
+			return true
+		}
+	}
+	return false
+}
+
+func safeApplyMessage(result *pluginv1.WatchSyncApplyResult, secrets ...string) string {
+	if result == nil {
+		return "watch sync provider could not apply the event"
+	}
+	return sanitizeWatchSyncMessage(result.GetFault().GetSafeMessage(), "watch sync provider could not apply the event", secrets...)
+}
+
+func sanitizeWatchSyncMessage(message string, fallback string, secrets ...string) string {
+	message = strings.Map(func(r rune) rune {
+		if unicode.IsControl(r) {
+			return ' '
+		}
+		return r
+	}, message)
+	message = strings.Join(strings.Fields(message), " ")
+	for _, secret := range secrets {
+		if secret = strings.TrimSpace(secret); secret != "" {
+			message = strings.ReplaceAll(message, secret, "[REDACTED]")
+		}
+	}
+	if message == "" {
+		return fallback
+	}
+	const maxRunes = 256
+	runes := []rune(message)
+	if len(runes) > maxRunes {
+		message = string(runes[:maxRunes]) + "…"
+	}
+	return message
+}
+
+func watchSyncUnavailableError() error {
+	return retryableProviderError{message: "watch sync plugin is unavailable"}
+}
+
+func watchSyncRPCError() error {
+	return retryableProviderError{message: "watch sync plugin RPC failed"}
+}
+
+type watchSyncProviderFaultError struct {
+	code    pluginv1.WatchSyncFaultCode
+	message string
+}
+
+func (e watchSyncProviderFaultError) Error() string { return e.message }
+
+func watchSyncFaultError(provider string, fault *pluginv1.WatchSyncFault, secrets ...string) error {
+	if fault == nil || fault.GetCode() == pluginv1.WatchSyncFaultCode_WATCH_SYNC_FAULT_CODE_UNSPECIFIED {
+		return nil
+	}
+	message := sanitizeWatchSyncMessage(fault.GetSafeMessage(), "watch sync provider request failed", secrets...)
+	if fault.GetCode() == pluginv1.WatchSyncFaultCode_WATCH_SYNC_FAULT_CODE_RATE_LIMITED {
+		retry := time.Duration(0)
+		if fault.GetRetryAfter() != nil {
+			retry = fault.GetRetryAfter().AsDuration()
+		}
+		return RateLimitedError{Provider: provider, RetryAfter: retry}
+	}
+	if fault.GetCode() == pluginv1.WatchSyncFaultCode_WATCH_SYNC_FAULT_CODE_TEMPORARY {
+		return retryableProviderError{message: message}
+	}
+	return watchSyncProviderFaultError{code: fault.GetCode(), message: message}
+}
+
+func firstNonEmptyWatchID(values ...string) string {
+	for _, value := range values {
+		if value = strings.TrimSpace(value); value != "" {
+			return value
+		}
+	}
+	return "unknown"
+}

--- a/internal/watchsync/plugin_provider.go
+++ b/internal/watchsync/plugin_provider.go
@@ -290,7 +290,7 @@ func updatedPendingDeviceAuthSession(
 	session DeviceAuthSession,
 	response *pluginv1.WatchSyncDeviceAuthorizationServicePollResponse,
 ) (DeviceAuthSession, error) {
-	if len(response.GetProviderState()) > 0 {
+	if response.ProviderState != nil {
 		session.DeviceCode = base64.RawURLEncoding.EncodeToString(response.GetProviderState())
 	}
 	if pollingInterval := response.GetPollingInterval(); pollingInterval != nil {

--- a/internal/watchsync/plugin_provider_state.go
+++ b/internal/watchsync/plugin_provider_state.go
@@ -1,0 +1,483 @@
+package watchsync
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+	"time"
+
+	pluginv1 "github.com/Silo-Server/silo-plugin-sdk/pkg/pluginproto/silo/plugin/v1"
+	"github.com/Silo-Server/silo-server/internal/historyimport"
+	"google.golang.org/protobuf/types/known/timestamppb"
+)
+
+const (
+	pluginWatchedCursorKey   = "plugin.remote.watched"
+	pluginProgressCursorKey  = "plugin.remote.progress"
+	pluginFavoritesCursorKey = "plugin.remote.favorites"
+	pluginWatchlistCursorKey = "plugin.remote.watchlist"
+	maxRemoteStatePages      = 10_000
+)
+
+type pluginRemoteTraversal struct {
+	items            []*pluginv1.WatchSyncRemoteState
+	nextCursor       string
+	completeSnapshot bool
+	warnings         []string
+}
+
+func (p *PluginProvider) FetchWatched(
+	ctx context.Context,
+	cfg ServerConfig,
+	conn Connection,
+) ([]RemoteWatch, error) {
+	batch, err := p.FetchWatchedBatch(ctx, cfg, conn)
+	return batch.Rows, err
+}
+
+func (p *PluginProvider) FetchWatchedBatch(
+	ctx context.Context,
+	_ ServerConfig,
+	conn Connection,
+) (WatchedImportBatch, error) {
+	traversal, err := p.listRemoteState(ctx, conn, pluginWatchedCursorKey,
+		pluginv1.WatchSyncRemoteStateKind_WATCH_SYNC_REMOTE_STATE_KIND_WATCHED)
+	if err != nil {
+		return WatchedImportBatch{}, err
+	}
+	batch := WatchedImportBatch{
+		UpdatedCursors: cursorUpdate(pluginWatchedCursorKey, traversal.nextCursor),
+		Warnings:       traversal.warnings,
+	}
+	for _, state := range traversal.items {
+		if state.GetWatched() == nil {
+			continue
+		}
+		row, err := remoteWatchFromProto(p.Key(), state)
+		if err != nil {
+			batch.Warnings = append(batch.Warnings, err.Error())
+			continue
+		}
+		batch.Rows = append(batch.Rows, row)
+	}
+	return batch, nil
+}
+
+func (p *PluginProvider) FetchProgress(
+	ctx context.Context,
+	cfg ServerConfig,
+	conn Connection,
+) ([]RemoteProgress, error) {
+	batch, err := p.FetchProgressBatch(ctx, cfg, conn)
+	return batch.Rows, err
+}
+
+func (p *PluginProvider) FetchProgressBatch(
+	ctx context.Context,
+	_ ServerConfig,
+	conn Connection,
+) (ProgressImportBatch, error) {
+	traversal, err := p.listRemoteState(ctx, conn, pluginProgressCursorKey,
+		pluginv1.WatchSyncRemoteStateKind_WATCH_SYNC_REMOTE_STATE_KIND_PROGRESS)
+	if err != nil {
+		return ProgressImportBatch{}, err
+	}
+	batch := ProgressImportBatch{
+		UpdatedCursors: cursorUpdate(pluginProgressCursorKey, traversal.nextCursor),
+		Warnings:       traversal.warnings,
+	}
+	for _, state := range traversal.items {
+		if state.GetProgress() == nil {
+			continue
+		}
+		row, err := remoteProgressFromProto(p.Key(), state)
+		if err != nil {
+			batch.Warnings = append(batch.Warnings, err.Error())
+			continue
+		}
+		batch.Rows = append(batch.Rows, row)
+	}
+	return batch, nil
+}
+
+func (p *PluginProvider) FetchFavorites(
+	ctx context.Context,
+	cfg ServerConfig,
+	conn Connection,
+) ([]RemoteFavorite, error) {
+	batch, err := p.FetchFavoritesBatch(ctx, cfg, conn)
+	return batch.Rows, err
+}
+
+func (p *PluginProvider) FetchFavoritesBatch(
+	ctx context.Context,
+	_ ServerConfig,
+	conn Connection,
+) (FavoriteImportBatch, error) {
+	return p.fetchListState(ctx, conn, pluginFavoritesCursorKey,
+		pluginv1.WatchSyncRemoteStateKind_WATCH_SYNC_REMOTE_STATE_KIND_FAVORITE)
+}
+
+func (p *PluginProvider) FetchWatchlist(
+	ctx context.Context,
+	cfg ServerConfig,
+	conn Connection,
+) ([]RemoteFavorite, error) {
+	batch, err := p.FetchWatchlistBatch(ctx, cfg, conn)
+	return batch.Rows, err
+}
+
+func (p *PluginProvider) FetchWatchlistBatch(
+	ctx context.Context,
+	_ ServerConfig,
+	conn Connection,
+) (FavoriteImportBatch, error) {
+	return p.fetchListState(ctx, conn, pluginWatchlistCursorKey,
+		pluginv1.WatchSyncRemoteStateKind_WATCH_SYNC_REMOTE_STATE_KIND_WATCHLIST)
+}
+
+func (p *PluginProvider) fetchListState(
+	ctx context.Context,
+	conn Connection,
+	cursorKey string,
+	kind pluginv1.WatchSyncRemoteStateKind,
+) (FavoriteImportBatch, error) {
+	traversal, err := p.listRemoteState(ctx, conn, cursorKey, kind)
+	if err != nil {
+		return FavoriteImportBatch{}, err
+	}
+	batch := FavoriteImportBatch{
+		UpdatedCursors: cursorUpdate(cursorKey, traversal.nextCursor),
+		Warnings:       traversal.warnings,
+		Incremental:    !traversal.completeSnapshot,
+	}
+	for _, state := range traversal.items {
+		var listed *pluginv1.WatchSyncRemoteListState
+		if kind == pluginv1.WatchSyncRemoteStateKind_WATCH_SYNC_REMOTE_STATE_KIND_FAVORITE {
+			listed = state.GetFavorite()
+		} else {
+			listed = state.GetWatchlist()
+		}
+		if listed == nil {
+			continue
+		}
+		row, err := remoteFavoriteFromProto(p.Key(), state, listed)
+		if err != nil {
+			batch.Warnings = append(batch.Warnings, err.Error())
+			continue
+		}
+		batch.Rows = append(batch.Rows, row)
+	}
+	return batch, nil
+}
+
+func (p *PluginProvider) listRemoteState(
+	ctx context.Context,
+	conn Connection,
+	cursorKey string,
+	kind pluginv1.WatchSyncRemoteStateKind,
+) (pluginRemoteTraversal, error) {
+	client, err := p.resolveClient(ctx, p.installationID, p.capabilityID)
+	if err != nil {
+		return pluginRemoteTraversal{}, watchSyncUnavailableError()
+	}
+	cursor := conn.SyncCursors[cursorKey]
+	pageToken := ""
+	seenPageTokens := make(map[string]struct{})
+	result := pluginRemoteTraversal{}
+	snapshotSet := false
+	for page := 0; page < maxRemoteStatePages; page++ {
+		authContext, err := p.authenticatedContext(ctx, conn)
+		if err != nil {
+			return pluginRemoteTraversal{}, err
+		}
+		response, err := client.ListRemoteState(ctx, &pluginv1.WatchSyncListRemoteStateRequest{
+			Context:    authContext,
+			Cursor:     cursor,
+			PageToken:  pageToken,
+			PageSize:   int32(max(1, p.ExportBatchSize())),
+			StateKinds: []pluginv1.WatchSyncRemoteStateKind{kind},
+		})
+		if err != nil {
+			return pluginRemoteTraversal{}, watchSyncRPCError()
+		}
+		if response.GetUpdatedCredentials() != nil {
+			conn, err = p.persistUpdatedCredentials(ctx, conn, response.GetUpdatedCredentials())
+			if err != nil {
+				return pluginRemoteTraversal{}, err
+			}
+		}
+		if err := watchSyncFaultError(p.Key(), response.GetFault(), conn.AccessToken, conn.RefreshToken); err != nil {
+			return pluginRemoteTraversal{}, err
+		}
+		if snapshotSet && result.completeSnapshot != response.GetCompleteSnapshot() {
+			return pluginRemoteTraversal{}, errors.New("watch sync plugin changed snapshot mode during pagination")
+		}
+		result.completeSnapshot = response.GetCompleteSnapshot()
+		snapshotSet = true
+		result.items = append(result.items, response.GetItems()...)
+
+		nextPage := strings.TrimSpace(response.GetNextPageToken())
+		if nextPage == "" {
+			result.nextCursor = response.GetNextCursor()
+			return result, nil
+		}
+		if strings.TrimSpace(response.GetNextCursor()) != "" {
+			return pluginRemoteTraversal{}, errors.New("watch sync plugin returned a durable cursor before the final page")
+		}
+		if _, duplicate := seenPageTokens[nextPage]; duplicate {
+			return pluginRemoteTraversal{}, errors.New("watch sync plugin repeated a page token")
+		}
+		seenPageTokens[nextPage] = struct{}{}
+		pageToken = nextPage
+	}
+	return pluginRemoteTraversal{}, errors.New("watch sync plugin exceeded the remote-state page limit")
+}
+
+func (p *PluginProvider) RemoveHistory(
+	ctx context.Context,
+	_ ServerConfig,
+	conn Connection,
+	plays []LocalPlay,
+) (ExportResult, error) {
+	events := make([]*pluginv1.WatchSyncEvent, 0, len(plays))
+	keys := make([]string, 0, len(plays))
+	for _, play := range plays {
+		event := watchEventFromLocalPlay(play, pluginv1.WatchSyncOrigin_WATCH_SYNC_ORIGIN_MANUAL)
+		event.EventId = "unwatched:" + play.HistoryID
+		event.Operation = pluginv1.WatchSyncOperation_WATCH_SYNC_OPERATION_MARK_UNWATCHED
+		event.ProviderItemKey = play.ProviderItemKey
+		if !p.supportsMedia(event.GetMedia().GetMediaType()) {
+			continue
+		}
+		events = append(events, event)
+		keys = append(keys, play.HistoryID)
+	}
+	return p.applyPluginEvents(ctx, conn, events, keys)
+}
+
+func (p *PluginProvider) ExportFavorites(ctx context.Context, _ ServerConfig, conn Connection, items []LocalFavorite) (ExportResult, error) {
+	return p.applyListEvents(ctx, conn, items, pluginv1.WatchSyncOperation_WATCH_SYNC_OPERATION_ADD_FAVORITE)
+}
+
+func (p *PluginProvider) RemoveFavorites(ctx context.Context, _ ServerConfig, conn Connection, items []LocalFavorite) (ExportResult, error) {
+	return p.applyListEvents(ctx, conn, items, pluginv1.WatchSyncOperation_WATCH_SYNC_OPERATION_REMOVE_FAVORITE)
+}
+
+func (p *PluginProvider) ExportWatchlist(ctx context.Context, _ ServerConfig, conn Connection, items []LocalFavorite) (ExportResult, error) {
+	return p.applyListEvents(ctx, conn, items, pluginv1.WatchSyncOperation_WATCH_SYNC_OPERATION_ADD_TO_WATCHLIST)
+}
+
+func (p *PluginProvider) RemoveWatchlist(ctx context.Context, _ ServerConfig, conn Connection, items []LocalFavorite) (ExportResult, error) {
+	return p.applyListEvents(ctx, conn, items, pluginv1.WatchSyncOperation_WATCH_SYNC_OPERATION_REMOVE_FROM_WATCHLIST)
+}
+
+func (p *PluginProvider) applyListEvents(
+	ctx context.Context,
+	conn Connection,
+	items []LocalFavorite,
+	operation pluginv1.WatchSyncOperation,
+) (ExportResult, error) {
+	events := make([]*pluginv1.WatchSyncEvent, 0, len(items))
+	keys := make([]string, 0, len(items))
+	for index, item := range items {
+		media := mediaFromIdentity(item.MediaItemID, item.Kind, item.Title, item.Year,
+			item.IMDbID, item.TMDBID, item.TVDBID, "", 0,
+			item.SeriesIMDbID, item.SeriesTMDBID, item.SeriesTVDBID, 0, 0)
+		if !p.supportsMedia(media.GetMediaType()) {
+			continue
+		}
+		events = append(events, &pluginv1.WatchSyncEvent{
+			EventId:         fmt.Sprintf("%s:%s", operation.String(), item.MediaItemID),
+			Operation:       operation,
+			Origin:          pluginv1.WatchSyncOrigin_WATCH_SYNC_ORIGIN_MANUAL,
+			OccurredAt:      timestampOrNil(item.FavoritedAt),
+			Media:           media,
+			ListPosition:    int32(index),
+			ProviderItemKey: item.ProviderItemKey,
+		})
+		keys = append(keys, item.MediaItemID)
+	}
+	return p.applyPluginEvents(ctx, conn, events, keys)
+}
+
+func (p *PluginProvider) applyPluginEvents(
+	ctx context.Context,
+	conn Connection,
+	events []*pluginv1.WatchSyncEvent,
+	keys []string,
+) (ExportResult, error) {
+	result := ExportResult{Failed: make(map[string]string)}
+	if len(events) == 0 {
+		return result, nil
+	}
+	client, err := p.resolveClient(ctx, p.installationID, p.capabilityID)
+	if err != nil {
+		return result, watchSyncUnavailableError()
+	}
+	for offset := 0; offset < len(events); offset += max(1, p.ExportBatchSize()) {
+		end := min(len(events), offset+max(1, p.ExportBatchSize()))
+		authContext, err := p.authenticatedContext(ctx, conn)
+		if err != nil {
+			return result, err
+		}
+		response, err := client.ApplyEvents(ctx, &pluginv1.WatchSyncApplyEventsRequest{
+			Context: authContext,
+			Events:  events[offset:end],
+		})
+		if err != nil {
+			return result, watchSyncRPCError()
+		}
+		if response.GetUpdatedCredentials() != nil {
+			conn, err = p.persistUpdatedCredentials(ctx, conn, response.GetUpdatedCredentials())
+			if err != nil {
+				return result, err
+			}
+		}
+		if err := watchSyncFaultError(p.Key(), response.GetFault(), conn.AccessToken, conn.RefreshToken); err != nil {
+			return result, err
+		}
+		for index, event := range events[offset:end] {
+			key := keys[offset+index]
+			apply := resultForEvent(response.GetResults(), event.GetEventId())
+			switch apply.GetStatus() {
+			case pluginv1.WatchSyncApplyStatus_WATCH_SYNC_APPLY_STATUS_APPLIED,
+				pluginv1.WatchSyncApplyStatus_WATCH_SYNC_APPLY_STATUS_NO_CHANGE:
+				result.Sent = append(result.Sent, key)
+			case pluginv1.WatchSyncApplyStatus_WATCH_SYNC_APPLY_STATUS_REJECTED:
+				result.NotFound = append(result.NotFound, key)
+			case pluginv1.WatchSyncApplyStatus_WATCH_SYNC_APPLY_STATUS_RETRY:
+				fault := apply.GetFault()
+				if fault.GetCode() == pluginv1.WatchSyncFaultCode_WATCH_SYNC_FAULT_CODE_RATE_LIMITED {
+					retry := time.Duration(0)
+					if fault.GetRetryAfter() != nil {
+						retry = fault.GetRetryAfter().AsDuration()
+					}
+					return result, RateLimitedError{Provider: p.Key(), RetryAfter: retry}
+				}
+				result.Failed[key] = safeApplyMessage(apply, conn.AccessToken, conn.RefreshToken)
+			default:
+				result.Failed[key] = "watch sync plugin omitted a valid event result"
+			}
+		}
+	}
+	return result, nil
+}
+
+func remoteWatchFromProto(provider string, state *pluginv1.WatchSyncRemoteState) (RemoteWatch, error) {
+	identity, err := remoteIdentityFromProto(state)
+	if err != nil {
+		return RemoteWatch{}, err
+	}
+	watched := state.GetWatched()
+	if watched.GetPlayCount() < 1 {
+		return RemoteWatch{}, errors.New("watch sync plugin returned watched state with no plays")
+	}
+	return RemoteWatch{
+		Provider: provider, ProviderItemKey: state.GetProviderItemKey(),
+		Kind: identity.kind, Title: identity.title, Year: identity.year,
+		IMDbID: identity.imdbID, TMDBID: identity.tmdbID, TVDBID: identity.tvdbID,
+		SeriesTitle: identity.seriesTitle, SeriesYear: identity.seriesYear,
+		SeriesIMDbID: identity.seriesIMDbID, SeriesTMDBID: identity.seriesTMDBID, SeriesTVDBID: identity.seriesTVDBID,
+		SeasonNumber: identity.season, EpisodeNumber: identity.episode,
+		PlayCount: int(watched.GetPlayCount()), LastWatchedAt: timePointer(watched.GetLastWatchedAt()),
+	}, nil
+}
+
+func remoteProgressFromProto(provider string, state *pluginv1.WatchSyncRemoteState) (RemoteProgress, error) {
+	identity, err := remoteIdentityFromProto(state)
+	if err != nil {
+		return RemoteProgress{}, err
+	}
+	progress := state.GetProgress()
+	if progress.GetProgressPercent() < 0 || progress.GetProgressPercent() >= 100 {
+		return RemoteProgress{}, errors.New("watch sync plugin returned progress outside [0,100)")
+	}
+	pausedAt := timePointer(progress.GetPausedAt())
+	if pausedAt == nil {
+		return RemoteProgress{}, errors.New("watch sync plugin returned progress without a valid timestamp")
+	}
+	return RemoteProgress{
+		Provider: provider, ProviderItemKey: state.GetProviderItemKey(),
+		Kind: identity.kind, Title: identity.title, Year: identity.year,
+		IMDbID: identity.imdbID, TMDBID: identity.tmdbID, TVDBID: identity.tvdbID,
+		SeriesTitle: identity.seriesTitle, SeriesYear: identity.seriesYear,
+		SeriesIMDbID: identity.seriesIMDbID, SeriesTMDBID: identity.seriesTMDBID, SeriesTVDBID: identity.seriesTVDBID,
+		SeasonNumber: identity.season, EpisodeNumber: identity.episode,
+		ProgressPercent: progress.GetProgressPercent(), PausedAt: *pausedAt,
+	}, nil
+}
+
+func remoteFavoriteFromProto(provider string, state *pluginv1.WatchSyncRemoteState, listed *pluginv1.WatchSyncRemoteListState) (RemoteFavorite, error) {
+	identity, err := remoteIdentityFromProto(state)
+	if err != nil {
+		return RemoteFavorite{}, err
+	}
+	listedAt := time.Now().UTC()
+	if value := timePointer(listed.GetListedAt()); value != nil {
+		listedAt = *value
+	}
+	return RemoteFavorite{
+		Provider: provider, ProviderItemKey: state.GetProviderItemKey(),
+		Kind: identity.kind, Title: identity.title, Year: identity.year,
+		IMDbID: identity.imdbID, TMDBID: identity.tmdbID, TVDBID: identity.tvdbID,
+		SeriesTitle: identity.seriesTitle, SeriesYear: identity.seriesYear,
+		SeriesIMDbID: identity.seriesIMDbID, SeriesTMDBID: identity.seriesTMDBID, SeriesTVDBID: identity.seriesTVDBID,
+		SeasonNumber: identity.season, EpisodeNumber: identity.episode, FavoritedAt: listedAt,
+	}, nil
+}
+
+type remoteIdentity struct {
+	kind, title, imdbID, tmdbID, tvdbID                   string
+	seriesTitle, seriesIMDbID, seriesTMDBID, seriesTVDBID string
+	year, seriesYear, season, episode                     int
+}
+
+func remoteIdentityFromProto(state *pluginv1.WatchSyncRemoteState) (remoteIdentity, error) {
+	if state == nil || state.GetMedia() == nil || strings.TrimSpace(state.GetProviderItemKey()) == "" {
+		return remoteIdentity{}, errors.New("watch sync plugin returned remote state without identity")
+	}
+	media := state.GetMedia()
+	var kind string
+	switch media.GetMediaType() {
+	case pluginv1.WatchSyncMediaType_WATCH_SYNC_MEDIA_TYPE_MOVIE:
+		kind = historyimport.KindMovie
+	case pluginv1.WatchSyncMediaType_WATCH_SYNC_MEDIA_TYPE_EPISODE:
+		kind = historyimport.KindEpisode
+	default:
+		return remoteIdentity{}, errors.New("watch sync plugin returned unsupported remote media")
+	}
+	return remoteIdentity{
+		kind: kind, title: media.GetTitle(), year: int(media.GetYear()),
+		imdbID: media.GetExternalIds()["imdb"], tmdbID: media.GetExternalIds()["tmdb"], tvdbID: media.GetExternalIds()["tvdb"],
+		seriesTitle: media.GetSeriesTitle(), seriesYear: int(media.GetSeriesYear()),
+		seriesIMDbID: media.GetSeriesExternalIds()["imdb"], seriesTMDBID: media.GetSeriesExternalIds()["tmdb"], seriesTVDBID: media.GetSeriesExternalIds()["tvdb"],
+		season: int(media.GetSeasonNumber()), episode: int(media.GetEpisodeNumber()),
+	}, nil
+}
+
+func cursorUpdate(key, value string) map[string]string {
+	if strings.TrimSpace(value) == "" {
+		return nil
+	}
+	return map[string]string{key: value}
+}
+
+func timePointer(value interface {
+	AsTime() time.Time
+	CheckValid() error
+}) *time.Time {
+	if value == nil || value.CheckValid() != nil {
+		return nil
+	}
+	result := value.AsTime()
+	return &result
+}
+
+func timestampOrNil(value time.Time) *timestamppb.Timestamp {
+	if value.IsZero() {
+		return nil
+	}
+	return timestamppb.New(value)
+}

--- a/internal/watchsync/plugin_provider_state.go
+++ b/internal/watchsync/plugin_provider_state.go
@@ -18,6 +18,7 @@ const (
 	pluginFavoritesCursorKey = "plugin.remote.favorites"
 	pluginWatchlistCursorKey = "plugin.remote.watchlist"
 	maxRemoteStatePages      = 10_000
+	maxRemoteStateItems      = 100_000
 )
 
 type pluginRemoteTraversal struct {
@@ -211,12 +212,20 @@ func (p *PluginProvider) listRemoteState(
 		if err := watchSyncFaultError(p.Key(), response.GetFault(), conn.AccessToken, conn.RefreshToken); err != nil {
 			return pluginRemoteTraversal{}, err
 		}
+		if kind == pluginv1.WatchSyncRemoteStateKind_WATCH_SYNC_REMOTE_STATE_KIND_WATCHLIST &&
+			p.descriptor.GetProvidesWatchlistOrder() && !response.GetCompleteSnapshot() {
+			return pluginRemoteTraversal{}, errors.New("watch sync plugin returned an incremental traversal for an ordered watchlist")
+		}
 		if snapshotSet && result.completeSnapshot != response.GetCompleteSnapshot() {
 			return pluginRemoteTraversal{}, errors.New("watch sync plugin changed snapshot mode during pagination")
 		}
 		result.completeSnapshot = response.GetCompleteSnapshot()
 		snapshotSet = true
-		result.items = append(result.items, response.GetItems()...)
+		items := response.GetItems()
+		if len(items) > maxRemoteStateItems-len(result.items) {
+			return pluginRemoteTraversal{}, errors.New("watch sync plugin exceeded the remote-state item limit")
+		}
+		result.items = append(result.items, items...)
 
 		nextPage := strings.TrimSpace(response.GetNextPageToken())
 		if nextPage == "" {
@@ -241,6 +250,7 @@ func (p *PluginProvider) RemoveHistory(
 	conn Connection,
 	plays []LocalPlay,
 ) (ExportResult, error) {
+	result := ExportResult{Failed: make(map[string]string)}
 	events := make([]*pluginv1.WatchSyncEvent, 0, len(plays))
 	keys := make([]string, 0, len(plays))
 	for _, play := range plays {
@@ -249,12 +259,14 @@ func (p *PluginProvider) RemoveHistory(
 		event.Operation = pluginv1.WatchSyncOperation_WATCH_SYNC_OPERATION_MARK_UNWATCHED
 		event.ProviderItemKey = play.ProviderItemKey
 		if !p.supportsMedia(event.GetMedia().GetMediaType()) {
+			result.Failed[play.HistoryID] = unsupportedWatchSyncMediaMessage(event.GetMedia().GetMediaType())
 			continue
 		}
 		events = append(events, event)
 		keys = append(keys, play.HistoryID)
 	}
-	return p.applyPluginEvents(ctx, conn, events, keys)
+	applied, err := p.applyPluginEvents(ctx, conn, events, keys)
+	return mergeExportFailures(applied, result.Failed), err
 }
 
 func (p *PluginProvider) ExportFavorites(ctx context.Context, _ ServerConfig, conn Connection, items []LocalFavorite) (ExportResult, error) {
@@ -279,27 +291,34 @@ func (p *PluginProvider) applyListEvents(
 	items []LocalFavorite,
 	operation pluginv1.WatchSyncOperation,
 ) (ExportResult, error) {
+	result := ExportResult{Failed: make(map[string]string)}
 	events := make([]*pluginv1.WatchSyncEvent, 0, len(items))
 	keys := make([]string, 0, len(items))
-	for index, item := range items {
+	for _, item := range items {
 		media := mediaFromIdentity(item.MediaItemID, item.Kind, item.Title, item.Year,
 			item.IMDbID, item.TMDBID, item.TVDBID, "", 0,
 			item.SeriesIMDbID, item.SeriesTMDBID, item.SeriesTVDBID, 0, 0)
 		if !p.supportsMedia(media.GetMediaType()) {
+			result.Failed[item.MediaItemID] = unsupportedWatchSyncMediaMessage(media.GetMediaType())
 			continue
 		}
-		events = append(events, &pluginv1.WatchSyncEvent{
+		event := &pluginv1.WatchSyncEvent{
 			EventId:         fmt.Sprintf("%s:%s", operation.String(), item.MediaItemID),
 			Operation:       operation,
 			Origin:          pluginv1.WatchSyncOrigin_WATCH_SYNC_ORIGIN_MANUAL,
 			OccurredAt:      timestampOrNil(item.FavoritedAt),
 			Media:           media,
-			ListPosition:    int32(index),
 			ProviderItemKey: item.ProviderItemKey,
-		})
+		}
+		if operation == pluginv1.WatchSyncOperation_WATCH_SYNC_OPERATION_ADD_TO_WATCHLIST {
+			position := int32(len(events))
+			event.ListPosition = &position
+		}
+		events = append(events, event)
 		keys = append(keys, item.MediaItemID)
 	}
-	return p.applyPluginEvents(ctx, conn, events, keys)
+	applied, err := p.applyPluginEvents(ctx, conn, events, keys)
+	return mergeExportFailures(applied, result.Failed), err
 }
 
 func (p *PluginProvider) applyPluginEvents(
@@ -308,39 +327,51 @@ func (p *PluginProvider) applyPluginEvents(
 	events []*pluginv1.WatchSyncEvent,
 	keys []string,
 ) (ExportResult, error) {
+	result, _, err := p.applyPluginEventsDetailed(ctx, conn, events, keys)
+	return result, err
+}
+
+func (p *PluginProvider) applyPluginEventsDetailed(
+	ctx context.Context,
+	conn Connection,
+	events []*pluginv1.WatchSyncEvent,
+	keys []string,
+) (ExportResult, map[string]pluginv1.WatchSyncApplyStatus, error) {
 	result := ExportResult{Failed: make(map[string]string)}
+	statuses := make(map[string]pluginv1.WatchSyncApplyStatus, len(events))
 	if len(events) == 0 {
-		return result, nil
+		return result, statuses, nil
 	}
 	client, err := p.resolveClient(ctx, p.installationID, p.capabilityID)
 	if err != nil {
-		return result, watchSyncUnavailableError()
+		return result, statuses, watchSyncUnavailableError()
 	}
 	for offset := 0; offset < len(events); offset += max(1, p.ExportBatchSize()) {
 		end := min(len(events), offset+max(1, p.ExportBatchSize()))
 		authContext, err := p.authenticatedContext(ctx, conn)
 		if err != nil {
-			return result, err
+			return result, statuses, err
 		}
 		response, err := client.ApplyEvents(ctx, &pluginv1.WatchSyncApplyEventsRequest{
 			Context: authContext,
 			Events:  events[offset:end],
 		})
 		if err != nil {
-			return result, watchSyncRPCError()
+			return result, statuses, watchSyncRPCError()
 		}
 		if response.GetUpdatedCredentials() != nil {
 			conn, err = p.persistUpdatedCredentials(ctx, conn, response.GetUpdatedCredentials())
 			if err != nil {
-				return result, err
+				return result, statuses, err
 			}
 		}
 		if err := watchSyncFaultError(p.Key(), response.GetFault(), conn.AccessToken, conn.RefreshToken); err != nil {
-			return result, err
+			return result, statuses, err
 		}
 		for index, event := range events[offset:end] {
 			key := keys[offset+index]
 			apply := resultForEvent(response.GetResults(), event.GetEventId())
+			statuses[key] = apply.GetStatus()
 			switch apply.GetStatus() {
 			case pluginv1.WatchSyncApplyStatus_WATCH_SYNC_APPLY_STATUS_APPLIED,
 				pluginv1.WatchSyncApplyStatus_WATCH_SYNC_APPLY_STATUS_NO_CHANGE:
@@ -354,7 +385,7 @@ func (p *PluginProvider) applyPluginEvents(
 					if fault.GetRetryAfter() != nil {
 						retry = fault.GetRetryAfter().AsDuration()
 					}
-					return result, RateLimitedError{Provider: p.Key(), RetryAfter: retry}
+					return result, statuses, RateLimitedError{Provider: p.Key(), RetryAfter: retry}
 				}
 				result.Failed[key] = safeApplyMessage(apply, conn.AccessToken, conn.RefreshToken)
 			default:
@@ -362,7 +393,17 @@ func (p *PluginProvider) applyPluginEvents(
 			}
 		}
 	}
-	return result, nil
+	return result, statuses, nil
+}
+
+func mergeExportFailures(result ExportResult, failures map[string]string) ExportResult {
+	if result.Failed == nil {
+		result.Failed = make(map[string]string, len(failures))
+	}
+	for key, message := range failures {
+		result.Failed[key] = message
+	}
+	return result
 }
 
 func remoteWatchFromProto(provider string, state *pluginv1.WatchSyncRemoteState) (RemoteWatch, error) {
@@ -410,6 +451,20 @@ func remoteProgressFromProto(provider string, state *pluginv1.WatchSyncRemoteSta
 }
 
 func remoteFavoriteFromProto(provider string, state *pluginv1.WatchSyncRemoteState, listed *pluginv1.WatchSyncRemoteListState) (RemoteFavorite, error) {
+	if state == nil || listed == nil {
+		return RemoteFavorite{}, errors.New("watch sync plugin returned list state without identity")
+	}
+	providerItemKey := strings.TrimSpace(state.GetProviderItemKey())
+	if listed.GetRemoved() {
+		if providerItemKey == "" {
+			return RemoteFavorite{}, errors.New("watch sync plugin returned a list tombstone without provider identity")
+		}
+		return RemoteFavorite{
+			Provider:        provider,
+			ProviderItemKey: providerItemKey,
+			Removed:         true,
+		}, nil
+	}
 	identity, err := remoteIdentityFromProto(state)
 	if err != nil {
 		return RemoteFavorite{}, err
@@ -419,7 +474,7 @@ func remoteFavoriteFromProto(provider string, state *pluginv1.WatchSyncRemoteSta
 		listedAt = *value
 	}
 	return RemoteFavorite{
-		Provider: provider, ProviderItemKey: state.GetProviderItemKey(),
+		Provider: provider, ProviderItemKey: providerItemKey,
 		Kind: identity.kind, Title: identity.title, Year: identity.year,
 		IMDbID: identity.imdbID, TMDBID: identity.tmdbID, TVDBID: identity.tvdbID,
 		SeriesTitle: identity.seriesTitle, SeriesYear: identity.seriesYear,

--- a/internal/watchsync/plugin_provider_test.go
+++ b/internal/watchsync/plugin_provider_test.go
@@ -613,6 +613,46 @@ func TestPluginProviderPendingDeviceAuthorizationCarriesRotatedState(t *testing.
 	}
 }
 
+func TestPluginProviderPendingDeviceAuthorizationPreservesStatePresence(t *testing.T) {
+	originalState := base64.RawURLEncoding.EncodeToString([]byte("original-state"))
+	tests := map[string]struct {
+		providerState []byte
+		wantState     string
+	}{
+		"omitted retains state": {providerState: nil, wantState: originalState},
+		"explicit empty clears state": {
+			providerState: []byte{},
+			wantState:     "",
+		},
+	}
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			client := &fakeWatchSyncPluginClient{devicePollResponse: &pluginv1.WatchSyncDeviceAuthorizationServicePollResponse{
+				Status:        pluginv1.WatchSyncDeviceAuthorizationStatus_WATCH_SYNC_DEVICE_AUTHORIZATION_STATUS_PENDING,
+				ProviderState: test.providerState,
+			}}
+			provider := testPluginProviderWithDescriptor(t, client, &pluginv1.WatchSyncProviderDescriptor{
+				AuthMethods: []pluginv1.WatchSyncAuthMethod{
+					pluginv1.WatchSyncAuthMethod_WATCH_SYNC_AUTH_METHOD_DEVICE_CODE,
+				},
+			})
+			original := DeviceAuthSession{
+				ID: "auth-1", Provider: testPluginProviderKey, UserID: 7, ProfileID: "profile-1",
+				DeviceCode: originalState, UserCode: "ABCD", VerificationURL: "https://provider.example/activate",
+				IntervalSeconds: 5, ExpiresAt: time.Now().UTC().Add(10 * time.Minute),
+			}
+			_, err := provider.PollDeviceAuth(context.Background(), ServerConfig{}, original)
+			var pending deviceAuthorizationPendingError
+			if !errors.As(err, &pending) {
+				t.Fatalf("error = %#v, want deviceAuthorizationPendingError", err)
+			}
+			if pending.session.DeviceCode != test.wantState {
+				t.Fatalf("device state = %q, want %q", pending.session.DeviceCode, test.wantState)
+			}
+		})
+	}
+}
+
 func TestPluginProviderPaginatesRemoteStateAndPersistsRotatedCredentials(t *testing.T) {
 	now := time.Now().UTC()
 	remote := func(key, imdb string) *pluginv1.WatchSyncRemoteState {

--- a/internal/watchsync/plugin_provider_test.go
+++ b/internal/watchsync/plugin_provider_test.go
@@ -1,0 +1,244 @@
+package watchsync
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+	"time"
+
+	pluginv1 "github.com/Silo-Server/silo-plugin-sdk/pkg/pluginproto/silo/plugin/v1"
+	"github.com/Silo-Server/silo-server/internal/historyimport"
+	"google.golang.org/protobuf/types/known/durationpb"
+)
+
+const (
+	testPluginProviderKey  = "plugin:4:anilist"
+	testPluginCapabilityID = "anilist"
+	testWatchHistoryID     = "history-1"
+	testSecondHistoryID    = "history-2"
+	testPlaybackSessionID  = "playback-1"
+	testEpisodeMediaID     = "episode-1"
+)
+
+type fakeWatchSyncPluginClient struct {
+	exchangeResponse *pluginv1.WatchSyncCredentialResponse
+	applyResponse    *pluginv1.WatchSyncApplyEventsResponse
+	applyErr         error
+	applyRequest     *pluginv1.WatchSyncApplyEventsRequest
+	refreshRequest   *pluginv1.WatchSyncRefreshCredentialsRequest
+	accountRequest   *pluginv1.WatchSyncGetAccountRequest
+}
+
+func (f *fakeWatchSyncPluginClient) ExchangeAPIKey(_ context.Context, _ *pluginv1.WatchSyncExchangeAPIKeyRequest) (*pluginv1.WatchSyncCredentialResponse, error) {
+	return f.exchangeResponse, nil
+}
+func (f *fakeWatchSyncPluginClient) RefreshCredentials(_ context.Context, req *pluginv1.WatchSyncRefreshCredentialsRequest) (*pluginv1.WatchSyncCredentialResponse, error) {
+	f.refreshRequest = req
+	return &pluginv1.WatchSyncCredentialResponse{}, nil
+}
+func (f *fakeWatchSyncPluginClient) GetAccount(_ context.Context, req *pluginv1.WatchSyncGetAccountRequest) (*pluginv1.WatchSyncGetAccountResponse, error) {
+	f.accountRequest = req
+	return &pluginv1.WatchSyncGetAccountResponse{}, nil
+}
+func (f *fakeWatchSyncPluginClient) ApplyEvents(_ context.Context, req *pluginv1.WatchSyncApplyEventsRequest) (*pluginv1.WatchSyncApplyEventsResponse, error) {
+	f.applyRequest = req
+	return f.applyResponse, f.applyErr
+}
+
+func testPluginProvider(t *testing.T, client WatchSyncPluginClient) *PluginProvider {
+	t.Helper()
+	provider, err := NewPluginProvider(PluginProviderOptions{
+		InstallationID: 4,
+		ProviderKey:    testPluginProviderKey,
+		CapabilityID:   testPluginCapabilityID,
+		DisplayName:    "AniList",
+		Descriptor: &pluginv1.WatchSyncProviderDescriptor{
+			AuthMethods:   []pluginv1.WatchSyncAuthMethod{pluginv1.WatchSyncAuthMethod_WATCH_SYNC_AUTH_METHOD_API_KEY},
+			ExportWatched: true,
+			MaxBatchSize:  25,
+		},
+		ResolveClient: func(context.Context, int, string) (WatchSyncPluginClient, error) {
+			return client, nil
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	return provider
+}
+
+func TestPluginProviderRejectsUnsupportedInitialDescriptor(t *testing.T) {
+	_, err := NewPluginProvider(PluginProviderOptions{
+		InstallationID: 4,
+		ProviderKey:    testPluginProviderKey,
+		CapabilityID:   testPluginCapabilityID,
+		Descriptor: &pluginv1.WatchSyncProviderDescriptor{
+			AuthMethods:   []pluginv1.WatchSyncAuthMethod{pluginv1.WatchSyncAuthMethod_WATCH_SYNC_AUTH_METHOD_AUTHORIZATION_CODE},
+			ExportWatched: true,
+		},
+		ResolveClient: func(context.Context, int, string) (WatchSyncPluginClient, error) { return nil, nil },
+	})
+	if err == nil {
+		t.Fatal("expected authorization-code-only descriptor to be rejected")
+	}
+}
+
+func TestPluginProviderConnectsAPIKeyWithoutPersistingInPluginConfig(t *testing.T) {
+	client := &fakeWatchSyncPluginClient{exchangeResponse: &pluginv1.WatchSyncCredentialResponse{
+		Credentials: &pluginv1.WatchSyncCredentials{AccessToken: "validated-token", TokenType: "Bearer"},
+		Account:     &pluginv1.WatchSyncAccount{ExternalSubject: "7", Username: "alice"},
+	}}
+	provider := testPluginProvider(t, client)
+	if provider.Key() != testPluginProviderKey {
+		t.Fatalf("provider key = %q", provider.Key())
+	}
+	tokens, account, err := provider.ConnectWithAPIKey(context.Background(), "input-token")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if tokens.AccessToken != "validated-token" || account.ID != "7" || account.Username != "alice" {
+		t.Fatalf("tokens=%#v account=%#v", tokens, account)
+	}
+}
+
+func TestPluginProviderExportsRichEpisodeIdentity(t *testing.T) {
+	client := &fakeWatchSyncPluginClient{}
+	client.applyResponse = &pluginv1.WatchSyncApplyEventsResponse{Results: []*pluginv1.WatchSyncApplyResult{{
+		EventId: testWatchHistoryID, Status: pluginv1.WatchSyncApplyStatus_WATCH_SYNC_APPLY_STATUS_APPLIED,
+	}}}
+	provider := testPluginProvider(t, client)
+	result, err := provider.ExportHistory(context.Background(), ServerConfig{}, Connection{AccessToken: "secret"}, []LocalPlay{{
+		HistoryID:       testWatchHistoryID,
+		MediaItemID:     testEpisodeMediaID,
+		Kind:            historyimport.KindEpisode,
+		SeriesTVDBID:    "123",
+		SeriesTMDBID:    "456",
+		SeasonNumber:    2,
+		EpisodeNumber:   7,
+		WatchedAt:       time.Now().UTC(),
+		DurationSeconds: 1440,
+	}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(result.Sent) != 1 || result.Sent[0] != testWatchHistoryID {
+		t.Fatalf("result = %#v", result)
+	}
+	event := client.applyRequest.GetEvents()[0]
+	if client.applyRequest.GetContext().GetCredentials().GetAccessToken() != "secret" ||
+		event.GetMedia().GetSeriesExternalIds()["tvdb"] != "123" ||
+		event.GetMedia().GetEpisodeNumber() != 7 ||
+		event.GetMedia().GetMediaType() != pluginv1.WatchSyncMediaType_WATCH_SYNC_MEDIA_TYPE_EPISODE {
+		t.Fatalf("apply request = %#v", client.applyRequest)
+	}
+}
+
+func TestPluginProviderBatchesEventsInOneRPC(t *testing.T) {
+	client := &fakeWatchSyncPluginClient{applyResponse: &pluginv1.WatchSyncApplyEventsResponse{Results: []*pluginv1.WatchSyncApplyResult{
+		{EventId: testWatchHistoryID, Status: pluginv1.WatchSyncApplyStatus_WATCH_SYNC_APPLY_STATUS_APPLIED},
+		{EventId: testSecondHistoryID, Status: pluginv1.WatchSyncApplyStatus_WATCH_SYNC_APPLY_STATUS_REJECTED},
+	}}}
+	provider := testPluginProvider(t, client)
+	result, err := provider.ExportHistory(context.Background(), ServerConfig{}, Connection{}, []LocalPlay{
+		{HistoryID: testWatchHistoryID},
+		{HistoryID: testSecondHistoryID},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(client.applyRequest.GetEvents()) != 2 || len(result.Sent) != 1 || len(result.NotFound) != 1 {
+		t.Fatalf("request=%#v result=%#v", client.applyRequest, result)
+	}
+}
+
+func TestPluginProviderMapsPerEventRateLimitAndKeepsSuccesses(t *testing.T) {
+	client := &fakeWatchSyncPluginClient{applyResponse: &pluginv1.WatchSyncApplyEventsResponse{Results: []*pluginv1.WatchSyncApplyResult{
+		{EventId: testWatchHistoryID, Status: pluginv1.WatchSyncApplyStatus_WATCH_SYNC_APPLY_STATUS_APPLIED},
+		{
+			EventId: testSecondHistoryID,
+			Status:  pluginv1.WatchSyncApplyStatus_WATCH_SYNC_APPLY_STATUS_RETRY,
+			Fault: &pluginv1.WatchSyncFault{
+				Code:        pluginv1.WatchSyncFaultCode_WATCH_SYNC_FAULT_CODE_RATE_LIMITED,
+				SafeMessage: "slow down",
+				RetryAfter:  durationpb.New(45 * time.Second),
+			},
+		},
+	}}}
+	provider := testPluginProvider(t, client)
+	result, err := provider.ExportHistory(context.Background(), ServerConfig{}, Connection{}, []LocalPlay{
+		{HistoryID: testWatchHistoryID},
+		{HistoryID: testSecondHistoryID},
+		{HistoryID: "history-3"},
+	})
+	limited, ok := AsRateLimited(err)
+	if !ok || limited.RetryAfter != 45*time.Second {
+		t.Fatalf("error = %#v", err)
+	}
+	if len(result.Sent) != 1 || result.Sent[0] != testWatchHistoryID || len(result.Failed) != 0 {
+		t.Fatalf("result = %#v", result)
+	}
+}
+
+func TestPluginProviderTransportFailureIsRetryableAndSanitized(t *testing.T) {
+	client := &fakeWatchSyncPluginClient{applyErr: errors.New("rpc failed with access_token=secret")}
+	provider := testPluginProvider(t, client)
+	_, err := provider.ExportHistory(context.Background(), ServerConfig{}, Connection{}, []LocalPlay{{HistoryID: testWatchHistoryID}})
+	if !isRetryableProviderError(err) || strings.Contains(err.Error(), "secret") {
+		t.Fatalf("error = %#v", err)
+	}
+}
+
+func TestPluginProviderSanitizesFaultMessage(t *testing.T) {
+	message := safeApplyMessage(&pluginv1.WatchSyncApplyResult{Fault: &pluginv1.WatchSyncFault{
+		SafeMessage: "  failed\n\taccess-token " + strings.Repeat("x", 300),
+	}}, "access-token")
+	if strings.ContainsAny(message, "\n\t") || strings.Contains(message, "access-token") || len([]rune(message)) > 257 {
+		t.Fatalf("message was not sanitized: %q", message)
+	}
+}
+
+func TestPluginProviderMapsTemporaryRetryToFailed(t *testing.T) {
+	client := &fakeWatchSyncPluginClient{applyResponse: &pluginv1.WatchSyncApplyEventsResponse{Results: []*pluginv1.WatchSyncApplyResult{{
+		EventId: testWatchHistoryID,
+		Status:  pluginv1.WatchSyncApplyStatus_WATCH_SYNC_APPLY_STATUS_RETRY,
+		Fault: &pluginv1.WatchSyncFault{
+			Code:        pluginv1.WatchSyncFaultCode_WATCH_SYNC_FAULT_CODE_TEMPORARY,
+			SafeMessage: "temporary upstream failure",
+		},
+	}}}}
+	provider := testPluginProvider(t, client)
+	result, err := provider.ExportHistory(context.Background(), ServerConfig{}, Connection{}, []LocalPlay{{HistoryID: testWatchHistoryID}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result.Failed[testWatchHistoryID] != "temporary upstream failure" {
+		t.Fatalf("result = %#v", result)
+	}
+}
+
+func TestPluginProviderMapsRateLimitFault(t *testing.T) {
+	client := &fakeWatchSyncPluginClient{applyResponse: &pluginv1.WatchSyncApplyEventsResponse{Fault: &pluginv1.WatchSyncFault{
+		Code:       pluginv1.WatchSyncFaultCode_WATCH_SYNC_FAULT_CODE_RATE_LIMITED,
+		RetryAfter: durationpb.New(30 * time.Second),
+	}}}
+	provider := testPluginProvider(t, client)
+	_, err := provider.ExportHistory(context.Background(), ServerConfig{}, Connection{}, []LocalPlay{{HistoryID: "h", ProviderItemKey: "p"}})
+	limited, ok := AsRateLimited(err)
+	if !ok || limited.RetryAfter != 30*time.Second {
+		t.Fatalf("error = %#v", err)
+	}
+}
+
+func TestPluginProviderAuthenticatedContextUsesCapabilityAndCredentials(t *testing.T) {
+	client := &fakeWatchSyncPluginClient{}
+	provider := testPluginProvider(t, client)
+	if _, err := provider.LookupAccount(context.Background(), ServerConfig{}, Connection{AccessToken: "token"}); err != nil {
+		t.Fatal(err)
+	}
+	if client.accountRequest.GetContext().GetCapabilityId() != testPluginCapabilityID ||
+		client.accountRequest.GetContext().GetCredentials().GetAccessToken() != "token" {
+		t.Fatalf("account request = %#v", client.accountRequest)
+	}
+	_ = testPlaybackSessionID
+}

--- a/internal/watchsync/plugin_provider_test.go
+++ b/internal/watchsync/plugin_provider_test.go
@@ -48,16 +48,21 @@ func (f *fakeWatchSyncPluginClient) ApplyEvents(_ context.Context, req *pluginv1
 
 func testPluginProvider(t *testing.T, client WatchSyncPluginClient) *PluginProvider {
 	t.Helper()
+	return testPluginProviderWithDescriptor(t, client, &pluginv1.WatchSyncProviderDescriptor{
+		AuthMethods:   []pluginv1.WatchSyncAuthMethod{pluginv1.WatchSyncAuthMethod_WATCH_SYNC_AUTH_METHOD_API_KEY},
+		ExportWatched: true,
+		MaxBatchSize:  25,
+	})
+}
+
+func testPluginProviderWithDescriptor(t *testing.T, client WatchSyncPluginClient, descriptor *pluginv1.WatchSyncProviderDescriptor) *PluginProvider {
+	t.Helper()
 	provider, err := NewPluginProvider(PluginProviderOptions{
 		InstallationID: 4,
 		ProviderKey:    testPluginProviderKey,
 		CapabilityID:   testPluginCapabilityID,
 		DisplayName:    "AniList",
-		Descriptor: &pluginv1.WatchSyncProviderDescriptor{
-			AuthMethods:   []pluginv1.WatchSyncAuthMethod{pluginv1.WatchSyncAuthMethod_WATCH_SYNC_AUTH_METHOD_API_KEY},
-			ExportWatched: true,
-			MaxBatchSize:  25,
-		},
+		Descriptor:     descriptor,
 		ResolveClient: func(context.Context, int, string) (WatchSyncPluginClient, error) {
 			return client, nil
 		},
@@ -81,6 +86,21 @@ func TestPluginProviderRejectsUnsupportedInitialDescriptor(t *testing.T) {
 	})
 	if err == nil {
 		t.Fatal("expected authorization-code-only descriptor to be rejected")
+	}
+
+	_, err = NewPluginProvider(PluginProviderOptions{
+		InstallationID: 4,
+		ProviderKey:    testPluginProviderKey,
+		CapabilityID:   testPluginCapabilityID,
+		Descriptor: &pluginv1.WatchSyncProviderDescriptor{
+			AuthMethods:         []pluginv1.WatchSyncAuthMethod{pluginv1.WatchSyncAuthMethod_WATCH_SYNC_AUTH_METHOD_API_KEY},
+			ExportWatched:       true,
+			SupportedMediaTypes: []pluginv1.WatchSyncMediaType{pluginv1.WatchSyncMediaType_WATCH_SYNC_MEDIA_TYPE_UNSPECIFIED},
+		},
+		ResolveClient: func(context.Context, int, string) (WatchSyncPluginClient, error) { return nil, nil },
+	})
+	if err == nil {
+		t.Fatal("expected unsupported media descriptor to be rejected")
 	}
 }
 
@@ -149,6 +169,31 @@ func TestPluginProviderBatchesEventsInOneRPC(t *testing.T) {
 	}
 	if len(client.applyRequest.GetEvents()) != 2 || len(result.Sent) != 1 || len(result.NotFound) != 1 {
 		t.Fatalf("request=%#v result=%#v", client.applyRequest, result)
+	}
+}
+
+func TestPluginProviderSkipsUnsupportedExportMedia(t *testing.T) {
+	client := &fakeWatchSyncPluginClient{applyResponse: &pluginv1.WatchSyncApplyEventsResponse{Results: []*pluginv1.WatchSyncApplyResult{
+		{EventId: testWatchHistoryID, Status: pluginv1.WatchSyncApplyStatus_WATCH_SYNC_APPLY_STATUS_APPLIED},
+	}}}
+	provider := testPluginProviderWithDescriptor(t, client, &pluginv1.WatchSyncProviderDescriptor{
+		AuthMethods:         []pluginv1.WatchSyncAuthMethod{pluginv1.WatchSyncAuthMethod_WATCH_SYNC_AUTH_METHOD_API_KEY},
+		ExportWatched:       true,
+		MaxBatchSize:        25,
+		SupportedMediaTypes: []pluginv1.WatchSyncMediaType{pluginv1.WatchSyncMediaType_WATCH_SYNC_MEDIA_TYPE_MOVIE},
+	})
+	result, err := provider.ExportHistory(context.Background(), ServerConfig{}, Connection{}, []LocalPlay{
+		{HistoryID: testWatchHistoryID, Kind: historyimport.KindMovie},
+		{HistoryID: testSecondHistoryID, Kind: historyimport.KindEpisode},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(client.applyRequest.GetEvents()) != 1 || client.applyRequest.GetEvents()[0].GetEventId() != testWatchHistoryID {
+		t.Fatalf("apply request = %#v", client.applyRequest)
+	}
+	if got := result.Failed[testSecondHistoryID]; got != watchSyncUnsupportedEpisodeMediaMessage {
+		t.Fatalf("result = %#v", result)
 	}
 }
 
@@ -227,6 +272,29 @@ func TestPluginProviderMapsRateLimitFault(t *testing.T) {
 	limited, ok := AsRateLimited(err)
 	if !ok || limited.RetryAfter != 30*time.Second {
 		t.Fatalf("error = %#v", err)
+	}
+}
+
+func TestPluginProviderRejectsUnsupportedScrobbleMedia(t *testing.T) {
+	client := &fakeWatchSyncPluginClient{}
+	provider := testPluginProviderWithDescriptor(t, client, &pluginv1.WatchSyncProviderDescriptor{
+		AuthMethods:         []pluginv1.WatchSyncAuthMethod{pluginv1.WatchSyncAuthMethod_WATCH_SYNC_AUTH_METHOD_API_KEY},
+		ExportWatched:       true,
+		MaxBatchSize:        25,
+		SupportedMediaTypes: []pluginv1.WatchSyncMediaType{pluginv1.WatchSyncMediaType_WATCH_SYNC_MEDIA_TYPE_MOVIE},
+	})
+	err := provider.Stop(context.Background(), ServerConfig{}, Connection{}, ScrobbleEvent{
+		Completed:         true,
+		HistoryID:         testWatchHistoryID,
+		PlaybackSessionID: testPlaybackSessionID,
+		Kind:              historyimport.KindEpisode,
+		OccurredAt:        time.Now().UTC(),
+	})
+	if err == nil || err.Error() != watchSyncUnsupportedEpisodeMediaMessage {
+		t.Fatalf("error = %#v", err)
+	}
+	if client.applyRequest != nil {
+		t.Fatalf("unexpected apply request = %#v", client.applyRequest)
 	}
 }
 

--- a/internal/watchsync/plugin_provider_test.go
+++ b/internal/watchsync/plugin_provider_test.go
@@ -10,6 +10,7 @@ import (
 	pluginv1 "github.com/Silo-Server/silo-plugin-sdk/pkg/pluginproto/silo/plugin/v1"
 	"github.com/Silo-Server/silo-server/internal/historyimport"
 	"google.golang.org/protobuf/types/known/durationpb"
+	"google.golang.org/protobuf/types/known/timestamppb"
 )
 
 const (
@@ -22,14 +23,37 @@ const (
 )
 
 type fakeWatchSyncPluginClient struct {
-	exchangeResponse *pluginv1.WatchSyncCredentialResponse
-	refreshResponse  *pluginv1.WatchSyncCredentialResponse
-	accountResponse  *pluginv1.WatchSyncGetAccountResponse
-	applyResponse    *pluginv1.WatchSyncApplyEventsResponse
-	applyErr         error
-	applyRequest     *pluginv1.WatchSyncApplyEventsRequest
-	refreshRequest   *pluginv1.WatchSyncRefreshCredentialsRequest
-	accountRequest   *pluginv1.WatchSyncGetAccountRequest
+	exchangeResponse    *pluginv1.WatchSyncCredentialResponse
+	refreshResponse     *pluginv1.WatchSyncCredentialResponse
+	accountResponse     *pluginv1.WatchSyncGetAccountResponse
+	applyResponse       *pluginv1.WatchSyncApplyEventsResponse
+	deviceStartResponse *pluginv1.WatchSyncStartDeviceAuthorizationResponse
+	devicePollResponse  *pluginv1.WatchSyncPollDeviceAuthorizationResponse
+	listResponse        *pluginv1.WatchSyncListRemoteStateResponse
+	listResponses       []*pluginv1.WatchSyncListRemoteStateResponse
+	applyErr            error
+	applyRequest        *pluginv1.WatchSyncApplyEventsRequest
+	refreshRequest      *pluginv1.WatchSyncRefreshCredentialsRequest
+	accountRequest      *pluginv1.WatchSyncGetAccountRequest
+	deviceStartRequest  *pluginv1.WatchSyncStartDeviceAuthorizationRequest
+	devicePollRequest   *pluginv1.WatchSyncPollDeviceAuthorizationRequest
+	listRequests        []*pluginv1.WatchSyncListRemoteStateRequest
+}
+
+func (f *fakeWatchSyncPluginClient) StartDeviceAuthorization(_ context.Context, req *pluginv1.WatchSyncStartDeviceAuthorizationRequest) (*pluginv1.WatchSyncStartDeviceAuthorizationResponse, error) {
+	f.deviceStartRequest = req
+	if f.deviceStartResponse != nil {
+		return f.deviceStartResponse, nil
+	}
+	return &pluginv1.WatchSyncStartDeviceAuthorizationResponse{}, nil
+}
+
+func (f *fakeWatchSyncPluginClient) PollDeviceAuthorization(_ context.Context, req *pluginv1.WatchSyncPollDeviceAuthorizationRequest) (*pluginv1.WatchSyncPollDeviceAuthorizationResponse, error) {
+	f.devicePollRequest = req
+	if f.devicePollResponse != nil {
+		return f.devicePollResponse, nil
+	}
+	return &pluginv1.WatchSyncPollDeviceAuthorizationResponse{}, nil
 }
 
 func (f *fakeWatchSyncPluginClient) ExchangeAPIKey(_ context.Context, _ *pluginv1.WatchSyncExchangeAPIKeyRequest) (*pluginv1.WatchSyncCredentialResponse, error) {
@@ -52,6 +76,32 @@ func (f *fakeWatchSyncPluginClient) GetAccount(_ context.Context, req *pluginv1.
 func (f *fakeWatchSyncPluginClient) ApplyEvents(_ context.Context, req *pluginv1.WatchSyncApplyEventsRequest) (*pluginv1.WatchSyncApplyEventsResponse, error) {
 	f.applyRequest = req
 	return f.applyResponse, f.applyErr
+}
+
+func (f *fakeWatchSyncPluginClient) ListRemoteState(_ context.Context, req *pluginv1.WatchSyncListRemoteStateRequest) (*pluginv1.WatchSyncListRemoteStateResponse, error) {
+	f.listRequests = append(f.listRequests, req)
+	if len(f.listResponses) > 0 {
+		response := f.listResponses[0]
+		f.listResponses = f.listResponses[1:]
+		return response, nil
+	}
+	if f.listResponse != nil {
+		return f.listResponse, nil
+	}
+	return &pluginv1.WatchSyncListRemoteStateResponse{}, nil
+}
+
+type fakePluginCredentialRepository struct {
+	saved Connection
+	err   error
+}
+
+func (r *fakePluginCredentialRepository) UpsertConnection(_ context.Context, conn Connection) (Connection, error) {
+	if r.err != nil {
+		return Connection{}, r.err
+	}
+	r.saved = conn
+	return conn, nil
 }
 
 func testPluginProvider(t *testing.T, client WatchSyncPluginClient) *PluginProvider {
@@ -79,6 +129,13 @@ func testPluginProviderWithDescriptor(t *testing.T, client WatchSyncPluginClient
 		t.Fatal(err)
 	}
 	return provider
+}
+
+func TestPluginProviderUsesConnectionSpecificHistorySource(t *testing.T) {
+	provider := testPluginProvider(t, &fakeWatchSyncPluginClient{})
+	if got := provider.HistorySource(); got != testPluginProviderKey {
+		t.Fatalf("HistorySource() = %q, want %q", got, testPluginProviderKey)
+	}
 }
 
 func TestPluginProviderRejectsUnsupportedInitialDescriptor(t *testing.T) {
@@ -114,8 +171,8 @@ func TestPluginProviderRejectsUnsupportedInitialDescriptor(t *testing.T) {
 
 func TestPluginProviderConnectsAPIKeyWithoutPersistingInPluginConfig(t *testing.T) {
 	client := &fakeWatchSyncPluginClient{exchangeResponse: &pluginv1.WatchSyncCredentialResponse{
-		Credentials: &pluginv1.WatchSyncCredentials{AccessToken: "validated-token", TokenType: "Bearer"},
-		Account:     &pluginv1.WatchSyncAccount{ExternalSubject: "7", Username: "alice"},
+		Credentials: &pluginv1.WatchSyncCredentials{AccessToken: testValidatedToken, TokenType: testBearerTokenType},
+		Account:     &pluginv1.WatchSyncAccount{ExternalSubject: "7", Username: testPluginUsername},
 	}}
 	provider := testPluginProvider(t, client)
 	if provider.Key() != testPluginProviderKey {
@@ -125,7 +182,7 @@ func TestPluginProviderConnectsAPIKeyWithoutPersistingInPluginConfig(t *testing.
 	if err != nil {
 		t.Fatal(err)
 	}
-	if tokens.AccessToken != "validated-token" || account.ID != "7" || account.Username != "alice" {
+	if tokens.AccessToken != testValidatedToken || account.ID != "7" || account.Username != testPluginUsername {
 		t.Fatalf("tokens=%#v account=%#v", tokens, account)
 	}
 }
@@ -133,8 +190,8 @@ func TestPluginProviderConnectsAPIKeyWithoutPersistingInPluginConfig(t *testing.
 func TestPluginProviderRejectsMissingAccountIdentity(t *testing.T) {
 	for _, subject := range []string{"", " \t\n "} {
 		client := &fakeWatchSyncPluginClient{exchangeResponse: &pluginv1.WatchSyncCredentialResponse{
-			Credentials: &pluginv1.WatchSyncCredentials{AccessToken: "validated-token", TokenType: "Bearer"},
-			Account:     &pluginv1.WatchSyncAccount{ExternalSubject: subject, Username: "alice"},
+			Credentials: &pluginv1.WatchSyncCredentials{AccessToken: testValidatedToken, TokenType: testBearerTokenType},
+			Account:     &pluginv1.WatchSyncAccount{ExternalSubject: subject, Username: testPluginUsername},
 		}}
 		provider := testPluginProvider(t, client)
 		if _, _, err := provider.ConnectWithAPIKey(context.Background(), "input-token"); err == nil || !strings.Contains(err.Error(), "account identity") {
@@ -145,7 +202,7 @@ func TestPluginProviderRejectsMissingAccountIdentity(t *testing.T) {
 
 func TestPluginProviderRefreshReturnsCredentialsAlongsideFault(t *testing.T) {
 	client := &fakeWatchSyncPluginClient{refreshResponse: &pluginv1.WatchSyncCredentialResponse{
-		Credentials: &pluginv1.WatchSyncCredentials{AccessToken: "rotated-access", TokenType: "Bearer"},
+		Credentials: &pluginv1.WatchSyncCredentials{AccessToken: testRotatedAccessToken, TokenType: testBearerTokenType},
 		Fault: &pluginv1.WatchSyncFault{
 			Code:        pluginv1.WatchSyncFaultCode_WATCH_SYNC_FAULT_CODE_INVALID_CREDENTIAL,
 			SafeMessage: "credential rotated-access rejected; reconnect required",
@@ -153,16 +210,16 @@ func TestPluginProviderRefreshReturnsCredentialsAlongsideFault(t *testing.T) {
 	}}
 	provider := testPluginProvider(t, client)
 	tokens, err := provider.RefreshToken(context.Background(), ServerConfig{}, Connection{
-		AccessToken:  "old-access",
-		RefreshToken: "old-refresh",
+		AccessToken:  testOldAccessToken,
+		RefreshToken: testOldRefreshToken,
 	})
-	if tokens.AccessToken != "rotated-access" || tokens.RefreshToken != "" || tokens.TokenExpiresAt != nil {
+	if tokens.AccessToken != testRotatedAccessToken || tokens.RefreshToken != "" || tokens.TokenExpiresAt != nil {
 		t.Fatalf("tokens = %#v", tokens)
 	}
 	if !isWatchSyncInvalidCredentialError(err) {
 		t.Fatalf("error = %#v", err)
 	}
-	if strings.Contains(err.Error(), "rotated-access") || !strings.Contains(err.Error(), "[REDACTED]") {
+	if strings.Contains(err.Error(), testRotatedAccessToken) || !strings.Contains(err.Error(), "[REDACTED]") {
 		t.Fatalf("returned credentials were not redacted: %q", err)
 	}
 }
@@ -173,7 +230,7 @@ func TestPluginProviderExportsRichEpisodeIdentity(t *testing.T) {
 		EventId: testWatchHistoryID, Status: pluginv1.WatchSyncApplyStatus_WATCH_SYNC_APPLY_STATUS_APPLIED,
 	}}}
 	provider := testPluginProvider(t, client)
-	result, err := provider.ExportHistory(context.Background(), ServerConfig{}, Connection{AccessToken: "secret"}, []LocalPlay{{
+	result, err := provider.ExportHistory(context.Background(), ServerConfig{}, Connection{AccessToken: testSecretValue}, []LocalPlay{{
 		HistoryID:       testWatchHistoryID,
 		MediaItemID:     testEpisodeMediaID,
 		Kind:            historyimport.KindEpisode,
@@ -191,7 +248,7 @@ func TestPluginProviderExportsRichEpisodeIdentity(t *testing.T) {
 		t.Fatalf("result = %#v", result)
 	}
 	event := client.applyRequest.GetEvents()[0]
-	if client.applyRequest.GetContext().GetCredentials().GetAccessToken() != "secret" ||
+	if client.applyRequest.GetContext().GetCredentials().GetAccessToken() != testSecretValue ||
 		event.GetMedia().GetSeriesExternalIds()["tvdb"] != "123" ||
 		event.GetMedia().GetEpisodeNumber() != 7 ||
 		event.GetMedia().GetMediaType() != pluginv1.WatchSyncMediaType_WATCH_SYNC_MEDIA_TYPE_EPISODE {
@@ -289,7 +346,7 @@ func TestPluginProviderTransportFailureIsRetryableAndSanitized(t *testing.T) {
 	client := &fakeWatchSyncPluginClient{applyErr: errors.New("rpc failed with access_token=secret")}
 	provider := testPluginProvider(t, client)
 	_, err := provider.ExportHistory(context.Background(), ServerConfig{}, Connection{}, []LocalPlay{{HistoryID: testWatchHistoryID, Kind: historyimport.KindMovie}})
-	if !isRetryableProviderError(err) || strings.Contains(err.Error(), "secret") {
+	if !isRetryableProviderError(err) || strings.Contains(err.Error(), testSecretValue) {
 		t.Fatalf("error = %#v", err)
 	}
 }
@@ -378,4 +435,160 @@ func TestPluginProviderAuthenticatedContextUsesCapabilityAndCredentials(t *testi
 		t.Fatalf("account request = %#v", client.accountRequest)
 	}
 	_ = testPlaybackSessionID
+}
+
+func TestPluginProviderSupportsDeviceAuthorizationAndFullCredentials(t *testing.T) {
+	expiresAt := time.Now().UTC().Add(10 * time.Minute)
+	client := &fakeWatchSyncPluginClient{
+		deviceStartResponse: &pluginv1.WatchSyncStartDeviceAuthorizationResponse{
+			UserCode:        "ABCD",
+			VerificationUrl: "https://provider.example/activate",
+			ProviderState:   []byte("opaque-device-state"),
+			PollingInterval: durationpb.New(7 * time.Second),
+			ExpiresAt:       timestamppb.New(expiresAt),
+		},
+		devicePollResponse: &pluginv1.WatchSyncPollDeviceAuthorizationResponse{
+			Status: pluginv1.WatchSyncDeviceAuthorizationStatus_WATCH_SYNC_DEVICE_AUTHORIZATION_STATUS_AUTHORIZED,
+			Credentials: &pluginv1.WatchSyncCredentials{
+				AccessToken: testAccessToken, RefreshToken: testRefreshToken, TokenType: testDPoPTokenType,
+				Scopes: []string{testHistoryScope, "watchlist"}, SecretAttributes: map[string]string{"instance": testOneValue},
+				ExpiresAt: timestamppb.New(expiresAt),
+			},
+		},
+	}
+	provider, err := NewPluginProvider(PluginProviderOptions{
+		InstallationID: 4, ProviderKey: testPluginProviderKey, CapabilityID: testPluginCapabilityID,
+		Descriptor: &pluginv1.WatchSyncProviderDescriptor{
+			AuthMethods:   []pluginv1.WatchSyncAuthMethod{pluginv1.WatchSyncAuthMethod_WATCH_SYNC_AUTH_METHOD_DEVICE_CODE},
+			ImportWatched: true, MaxBatchSize: 25,
+		},
+		ResolveClient: func(context.Context, int, string) (WatchSyncPluginClient, error) { return client, nil },
+		ResolveConfig: func(context.Context, int) (*pluginv1.WatchSyncProviderConfig, error) {
+			return &pluginv1.WatchSyncProviderConfig{SecretValues: map[string]string{"provider.client_secret": testSecretValue}}, nil
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	session, err := provider.StartDeviceAuth(context.Background(), ServerConfig{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if session.UserCode != "ABCD" || session.IntervalSeconds != 7 ||
+		client.deviceStartRequest.GetProviderConfig().GetSecretValues()["provider.client_secret"] != testSecretValue {
+		t.Fatalf("session=%#v request=%#v", session, client.deviceStartRequest)
+	}
+	tokens, err := provider.PollDeviceAuth(context.Background(), ServerConfig{}, session)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(client.devicePollRequest.GetProviderState()) != "opaque-device-state" ||
+		tokens.TokenType != testDPoPTokenType || len(tokens.Scopes) != 2 || tokens.SecretAttributes["instance"] != testOneValue {
+		t.Fatalf("tokens=%#v request=%#v", tokens, client.devicePollRequest)
+	}
+}
+
+func TestPluginProviderPaginatesRemoteStateAndPersistsRotatedCredentials(t *testing.T) {
+	now := time.Now().UTC()
+	remote := func(key, imdb string) *pluginv1.WatchSyncRemoteState {
+		return &pluginv1.WatchSyncRemoteState{
+			ProviderItemKey: key,
+			Media: &pluginv1.WatchSyncMedia{
+				MediaType: pluginv1.WatchSyncMediaType_WATCH_SYNC_MEDIA_TYPE_MOVIE,
+				Title:     "Movie", ExternalIds: map[string]string{"imdb": imdb},
+			},
+			Watched: &pluginv1.WatchSyncRemoteWatchedState{PlayCount: 1, LastWatchedAt: timestamppb.New(now)},
+		}
+	}
+	client := &fakeWatchSyncPluginClient{listResponses: []*pluginv1.WatchSyncListRemoteStateResponse{
+		{
+			Items: []*pluginv1.WatchSyncRemoteState{remote(testOneValue, "tt1")}, NextPageToken: "page-2", CompleteSnapshot: true,
+			UpdatedCredentials: &pluginv1.WatchSyncCredentials{
+				AccessToken: "rotated", TokenType: testBearerTokenType, Scopes: []string{testHistoryScope},
+			},
+		},
+		{Items: []*pluginv1.WatchSyncRemoteState{remote("two", "tt2")}, NextCursor: "cursor-2", CompleteSnapshot: true},
+	}}
+	repository := &fakePluginCredentialRepository{}
+	provider, err := NewPluginProvider(PluginProviderOptions{
+		InstallationID: 4, ProviderKey: testPluginProviderKey, CapabilityID: testPluginCapabilityID,
+		Descriptor: &pluginv1.WatchSyncProviderDescriptor{
+			AuthMethods:   []pluginv1.WatchSyncAuthMethod{pluginv1.WatchSyncAuthMethod_WATCH_SYNC_AUTH_METHOD_API_KEY},
+			ImportWatched: true, MaxBatchSize: 25,
+		},
+		ResolveClient: func(context.Context, int, string) (WatchSyncPluginClient, error) { return client, nil },
+		Repository:    repository,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	batch, err := provider.FetchWatchedBatch(context.Background(), ServerConfig{}, Connection{
+		ID: "connection", Provider: testPluginProviderKey, UserID: 1, ProfileID: "profile",
+		AccessToken: "old", SyncCursors: map[string]string{pluginWatchedCursorKey: testCursorOne},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(batch.Rows) != 2 || batch.UpdatedCursors[pluginWatchedCursorKey] != "cursor-2" ||
+		len(client.listRequests) != 2 || client.listRequests[0].GetCursor() != testCursorOne ||
+		client.listRequests[1].GetCursor() != testCursorOne || client.listRequests[1].GetPageToken() != "page-2" {
+		t.Fatalf("batch=%#v requests=%#v", batch, client.listRequests)
+	}
+	if repository.saved.AccessToken != "rotated" || repository.saved.Scopes[0] != testHistoryScope {
+		t.Fatalf("persisted credentials = %#v", repository.saved)
+	}
+}
+
+func TestPluginProviderMapsAllCapabilitiesAndListOperations(t *testing.T) {
+	descriptor := &pluginv1.WatchSyncProviderDescriptor{
+		AuthMethods:   []pluginv1.WatchSyncAuthMethod{pluginv1.WatchSyncAuthMethod_WATCH_SYNC_AUTH_METHOD_API_KEY},
+		ImportWatched: true, ImportProgress: true, ExportWatched: true, ExportUnwatched: true,
+		ImportFavorites: true, ExportFavorites: true, RemoveFavorites: true,
+		ImportWatchlist: true, ExportWatchlist: true, RemoveWatchlist: true,
+		ProvidesWatchlistOrder: true, ScrobblePlayback: true, MaxBatchSize: 25,
+	}
+	client := &fakeWatchSyncPluginClient{}
+	provider := testPluginProviderWithDescriptor(t, client, descriptor)
+	if provider.Capabilities() != (Capabilities{
+		ImportWatched: true, ImportProgress: true, ExportWatched: true, ExportUnwatched: true,
+		ImportFavorites: true, ExportFavorites: true, RemoveFavorites: true,
+		ImportWatchlist: true, ExportWatchlist: true, RemoveWatchlist: true,
+		ProvidesWatchlistOrder: true, ScrobblePlayback: true,
+	}) {
+		t.Fatalf("capabilities = %#v", provider.Capabilities())
+	}
+
+	item := LocalFavorite{MediaItemID: testMovieMediaID, ProviderItemKey: "remote-1", Kind: historyimport.KindMovie, IMDbID: "tt1"}
+	eventID := pluginv1.WatchSyncOperation_WATCH_SYNC_OPERATION_ADD_TO_WATCHLIST.String() + ":movie-1"
+	client.applyResponse = &pluginv1.WatchSyncApplyEventsResponse{Results: []*pluginv1.WatchSyncApplyResult{{
+		EventId: eventID, Status: pluginv1.WatchSyncApplyStatus_WATCH_SYNC_APPLY_STATUS_APPLIED,
+	}}}
+	result, err := provider.ExportWatchlist(context.Background(), ServerConfig{}, Connection{}, []LocalFavorite{item})
+	if err != nil {
+		t.Fatal(err)
+	}
+	event := client.applyRequest.GetEvents()[0]
+	if len(result.Sent) != 1 || event.GetOperation() != pluginv1.WatchSyncOperation_WATCH_SYNC_OPERATION_ADD_TO_WATCHLIST ||
+		event.GetProviderItemKey() != "remote-1" {
+		t.Fatalf("result=%#v event=%#v", result, event)
+	}
+}
+
+func TestPluginProviderForwardsLiveScrobbleLifecycle(t *testing.T) {
+	client := &fakeWatchSyncPluginClient{}
+	provider := testPluginProviderWithDescriptor(t, client, &pluginv1.WatchSyncProviderDescriptor{
+		AuthMethods:      []pluginv1.WatchSyncAuthMethod{pluginv1.WatchSyncAuthMethod_WATCH_SYNC_AUTH_METHOD_API_KEY},
+		ScrobblePlayback: true, MaxBatchSize: 25,
+	})
+	event := ScrobbleEvent{PlaybackSessionID: testPlaybackSessionID, MediaItemID: testMovieMediaID, Kind: historyimport.KindMovie, PositionSeconds: 12.5}
+	eventID := "scrobble:" + pluginv1.WatchSyncOperation_WATCH_SYNC_OPERATION_SCROBBLE_START.String() + ":" + testPlaybackSessionID
+	client.applyResponse = &pluginv1.WatchSyncApplyEventsResponse{Results: []*pluginv1.WatchSyncApplyResult{{
+		EventId: eventID, Status: pluginv1.WatchSyncApplyStatus_WATCH_SYNC_APPLY_STATUS_APPLIED,
+	}}}
+	if err := provider.Start(context.Background(), ServerConfig{}, Connection{}, event); err != nil {
+		t.Fatal(err)
+	}
+	if got := client.applyRequest.GetEvents()[0]; got.GetOperation() != pluginv1.WatchSyncOperation_WATCH_SYNC_OPERATION_SCROBBLE_START || got.GetPositionSeconds() != 12.5 {
+		t.Fatalf("scrobble event = %#v", got)
+	}
 }

--- a/internal/watchsync/plugin_provider_test.go
+++ b/internal/watchsync/plugin_provider_test.go
@@ -23,6 +23,8 @@ const (
 
 type fakeWatchSyncPluginClient struct {
 	exchangeResponse *pluginv1.WatchSyncCredentialResponse
+	refreshResponse  *pluginv1.WatchSyncCredentialResponse
+	accountResponse  *pluginv1.WatchSyncGetAccountResponse
 	applyResponse    *pluginv1.WatchSyncApplyEventsResponse
 	applyErr         error
 	applyRequest     *pluginv1.WatchSyncApplyEventsRequest
@@ -35,11 +37,17 @@ func (f *fakeWatchSyncPluginClient) ExchangeAPIKey(_ context.Context, _ *pluginv
 }
 func (f *fakeWatchSyncPluginClient) RefreshCredentials(_ context.Context, req *pluginv1.WatchSyncRefreshCredentialsRequest) (*pluginv1.WatchSyncCredentialResponse, error) {
 	f.refreshRequest = req
+	if f.refreshResponse != nil {
+		return f.refreshResponse, nil
+	}
 	return &pluginv1.WatchSyncCredentialResponse{}, nil
 }
 func (f *fakeWatchSyncPluginClient) GetAccount(_ context.Context, req *pluginv1.WatchSyncGetAccountRequest) (*pluginv1.WatchSyncGetAccountResponse, error) {
 	f.accountRequest = req
-	return &pluginv1.WatchSyncGetAccountResponse{}, nil
+	if f.accountResponse != nil {
+		return f.accountResponse, nil
+	}
+	return &pluginv1.WatchSyncGetAccountResponse{Account: &pluginv1.WatchSyncAccount{ExternalSubject: testProviderAccountID}}, nil
 }
 func (f *fakeWatchSyncPluginClient) ApplyEvents(_ context.Context, req *pluginv1.WatchSyncApplyEventsRequest) (*pluginv1.WatchSyncApplyEventsResponse, error) {
 	f.applyRequest = req
@@ -122,6 +130,43 @@ func TestPluginProviderConnectsAPIKeyWithoutPersistingInPluginConfig(t *testing.
 	}
 }
 
+func TestPluginProviderRejectsMissingAccountIdentity(t *testing.T) {
+	for _, subject := range []string{"", " \t\n "} {
+		client := &fakeWatchSyncPluginClient{exchangeResponse: &pluginv1.WatchSyncCredentialResponse{
+			Credentials: &pluginv1.WatchSyncCredentials{AccessToken: "validated-token", TokenType: "Bearer"},
+			Account:     &pluginv1.WatchSyncAccount{ExternalSubject: subject, Username: "alice"},
+		}}
+		provider := testPluginProvider(t, client)
+		if _, _, err := provider.ConnectWithAPIKey(context.Background(), "input-token"); err == nil || !strings.Contains(err.Error(), "account identity") {
+			t.Fatalf("subject %q: error = %v", subject, err)
+		}
+	}
+}
+
+func TestPluginProviderRefreshReturnsCredentialsAlongsideFault(t *testing.T) {
+	client := &fakeWatchSyncPluginClient{refreshResponse: &pluginv1.WatchSyncCredentialResponse{
+		Credentials: &pluginv1.WatchSyncCredentials{AccessToken: "rotated-access", TokenType: "Bearer"},
+		Fault: &pluginv1.WatchSyncFault{
+			Code:        pluginv1.WatchSyncFaultCode_WATCH_SYNC_FAULT_CODE_INVALID_CREDENTIAL,
+			SafeMessage: "credential rotated-access rejected; reconnect required",
+		},
+	}}
+	provider := testPluginProvider(t, client)
+	tokens, err := provider.RefreshToken(context.Background(), ServerConfig{}, Connection{
+		AccessToken:  "old-access",
+		RefreshToken: "old-refresh",
+	})
+	if tokens.AccessToken != "rotated-access" || tokens.RefreshToken != "" || tokens.TokenExpiresAt != nil {
+		t.Fatalf("tokens = %#v", tokens)
+	}
+	if !isWatchSyncInvalidCredentialError(err) {
+		t.Fatalf("error = %#v", err)
+	}
+	if strings.Contains(err.Error(), "rotated-access") || !strings.Contains(err.Error(), "[REDACTED]") {
+		t.Fatalf("returned credentials were not redacted: %q", err)
+	}
+}
+
 func TestPluginProviderExportsRichEpisodeIdentity(t *testing.T) {
 	client := &fakeWatchSyncPluginClient{}
 	client.applyResponse = &pluginv1.WatchSyncApplyEventsResponse{Results: []*pluginv1.WatchSyncApplyResult{{
@@ -161,14 +206,29 @@ func TestPluginProviderBatchesEventsInOneRPC(t *testing.T) {
 	}}}
 	provider := testPluginProvider(t, client)
 	result, err := provider.ExportHistory(context.Background(), ServerConfig{}, Connection{}, []LocalPlay{
-		{HistoryID: testWatchHistoryID},
-		{HistoryID: testSecondHistoryID},
+		{HistoryID: testWatchHistoryID, Kind: historyimport.KindMovie},
+		{HistoryID: testSecondHistoryID, Kind: historyimport.KindMovie},
 	})
 	if err != nil {
 		t.Fatal(err)
 	}
 	if len(client.applyRequest.GetEvents()) != 2 || len(result.Sent) != 1 || len(result.NotFound) != 1 {
 		t.Fatalf("request=%#v result=%#v", client.applyRequest, result)
+	}
+}
+
+func TestPluginProviderRejectsUnspecifiedExportMedia(t *testing.T) {
+	client := &fakeWatchSyncPluginClient{}
+	provider := testPluginProvider(t, client)
+	result, err := provider.ExportHistory(context.Background(), ServerConfig{}, Connection{}, []LocalPlay{{HistoryID: testWatchHistoryID}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if client.applyRequest != nil {
+		t.Fatalf("unexpected apply request = %#v", client.applyRequest)
+	}
+	if result.Failed[testWatchHistoryID] != watchSyncUnsupportedMediaMessage {
+		t.Fatalf("result = %#v", result)
 	}
 }
 
@@ -212,9 +272,9 @@ func TestPluginProviderMapsPerEventRateLimitAndKeepsSuccesses(t *testing.T) {
 	}}}
 	provider := testPluginProvider(t, client)
 	result, err := provider.ExportHistory(context.Background(), ServerConfig{}, Connection{}, []LocalPlay{
-		{HistoryID: testWatchHistoryID},
-		{HistoryID: testSecondHistoryID},
-		{HistoryID: "history-3"},
+		{HistoryID: testWatchHistoryID, Kind: historyimport.KindMovie},
+		{HistoryID: testSecondHistoryID, Kind: historyimport.KindMovie},
+		{HistoryID: "history-3", Kind: historyimport.KindMovie},
 	})
 	limited, ok := AsRateLimited(err)
 	if !ok || limited.RetryAfter != 45*time.Second {
@@ -228,7 +288,7 @@ func TestPluginProviderMapsPerEventRateLimitAndKeepsSuccesses(t *testing.T) {
 func TestPluginProviderTransportFailureIsRetryableAndSanitized(t *testing.T) {
 	client := &fakeWatchSyncPluginClient{applyErr: errors.New("rpc failed with access_token=secret")}
 	provider := testPluginProvider(t, client)
-	_, err := provider.ExportHistory(context.Background(), ServerConfig{}, Connection{}, []LocalPlay{{HistoryID: testWatchHistoryID}})
+	_, err := provider.ExportHistory(context.Background(), ServerConfig{}, Connection{}, []LocalPlay{{HistoryID: testWatchHistoryID, Kind: historyimport.KindMovie}})
 	if !isRetryableProviderError(err) || strings.Contains(err.Error(), "secret") {
 		t.Fatalf("error = %#v", err)
 	}
@@ -243,6 +303,15 @@ func TestPluginProviderSanitizesFaultMessage(t *testing.T) {
 	}
 }
 
+func TestPluginProviderNormalizesSecretsBeforeRedaction(t *testing.T) {
+	message := safeApplyMessage(&pluginv1.WatchSyncApplyResult{Fault: &pluginv1.WatchSyncFault{
+		SafeMessage: "credential line one line two was rejected",
+	}}, "line one\nline two")
+	if strings.Contains(message, "line one line two") || !strings.Contains(message, "[REDACTED]") {
+		t.Fatalf("message was not redacted: %q", message)
+	}
+}
+
 func TestPluginProviderMapsTemporaryRetryToFailed(t *testing.T) {
 	client := &fakeWatchSyncPluginClient{applyResponse: &pluginv1.WatchSyncApplyEventsResponse{Results: []*pluginv1.WatchSyncApplyResult{{
 		EventId: testWatchHistoryID,
@@ -253,7 +322,7 @@ func TestPluginProviderMapsTemporaryRetryToFailed(t *testing.T) {
 		},
 	}}}}
 	provider := testPluginProvider(t, client)
-	result, err := provider.ExportHistory(context.Background(), ServerConfig{}, Connection{}, []LocalPlay{{HistoryID: testWatchHistoryID}})
+	result, err := provider.ExportHistory(context.Background(), ServerConfig{}, Connection{}, []LocalPlay{{HistoryID: testWatchHistoryID, Kind: historyimport.KindMovie}})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -268,7 +337,7 @@ func TestPluginProviderMapsRateLimitFault(t *testing.T) {
 		RetryAfter: durationpb.New(30 * time.Second),
 	}}}
 	provider := testPluginProvider(t, client)
-	_, err := provider.ExportHistory(context.Background(), ServerConfig{}, Connection{}, []LocalPlay{{HistoryID: "h", ProviderItemKey: "p"}})
+	_, err := provider.ExportHistory(context.Background(), ServerConfig{}, Connection{}, []LocalPlay{{HistoryID: "h", ProviderItemKey: "p", Kind: historyimport.KindMovie}})
 	limited, ok := AsRateLimited(err)
 	if !ok || limited.RetryAfter != 30*time.Second {
 		t.Fatalf("error = %#v", err)

--- a/internal/watchsync/plugin_provider_test.go
+++ b/internal/watchsync/plugin_provider_test.go
@@ -2,6 +2,7 @@ package watchsync
 
 import (
 	"context"
+	"encoding/base64"
 	"errors"
 	"strings"
 	"testing"
@@ -27,33 +28,33 @@ type fakeWatchSyncPluginClient struct {
 	refreshResponse     *pluginv1.WatchSyncCredentialResponse
 	accountResponse     *pluginv1.WatchSyncGetAccountResponse
 	applyResponse       *pluginv1.WatchSyncApplyEventsResponse
-	deviceStartResponse *pluginv1.WatchSyncStartDeviceAuthorizationResponse
-	devicePollResponse  *pluginv1.WatchSyncPollDeviceAuthorizationResponse
+	deviceStartResponse *pluginv1.WatchSyncDeviceAuthorizationServiceStartResponse
+	devicePollResponse  *pluginv1.WatchSyncDeviceAuthorizationServicePollResponse
 	listResponse        *pluginv1.WatchSyncListRemoteStateResponse
 	listResponses       []*pluginv1.WatchSyncListRemoteStateResponse
 	applyErr            error
 	applyRequest        *pluginv1.WatchSyncApplyEventsRequest
 	refreshRequest      *pluginv1.WatchSyncRefreshCredentialsRequest
 	accountRequest      *pluginv1.WatchSyncGetAccountRequest
-	deviceStartRequest  *pluginv1.WatchSyncStartDeviceAuthorizationRequest
-	devicePollRequest   *pluginv1.WatchSyncPollDeviceAuthorizationRequest
+	deviceStartRequest  *pluginv1.WatchSyncDeviceAuthorizationServiceStartRequest
+	devicePollRequest   *pluginv1.WatchSyncDeviceAuthorizationServicePollRequest
 	listRequests        []*pluginv1.WatchSyncListRemoteStateRequest
 }
 
-func (f *fakeWatchSyncPluginClient) StartDeviceAuthorization(_ context.Context, req *pluginv1.WatchSyncStartDeviceAuthorizationRequest) (*pluginv1.WatchSyncStartDeviceAuthorizationResponse, error) {
+func (f *fakeWatchSyncPluginClient) StartDeviceAuthorization(_ context.Context, req *pluginv1.WatchSyncDeviceAuthorizationServiceStartRequest) (*pluginv1.WatchSyncDeviceAuthorizationServiceStartResponse, error) {
 	f.deviceStartRequest = req
 	if f.deviceStartResponse != nil {
 		return f.deviceStartResponse, nil
 	}
-	return &pluginv1.WatchSyncStartDeviceAuthorizationResponse{}, nil
+	return &pluginv1.WatchSyncDeviceAuthorizationServiceStartResponse{}, nil
 }
 
-func (f *fakeWatchSyncPluginClient) PollDeviceAuthorization(_ context.Context, req *pluginv1.WatchSyncPollDeviceAuthorizationRequest) (*pluginv1.WatchSyncPollDeviceAuthorizationResponse, error) {
+func (f *fakeWatchSyncPluginClient) PollDeviceAuthorization(_ context.Context, req *pluginv1.WatchSyncDeviceAuthorizationServicePollRequest) (*pluginv1.WatchSyncDeviceAuthorizationServicePollResponse, error) {
 	f.devicePollRequest = req
 	if f.devicePollResponse != nil {
 		return f.devicePollResponse, nil
 	}
-	return &pluginv1.WatchSyncPollDeviceAuthorizationResponse{}, nil
+	return &pluginv1.WatchSyncDeviceAuthorizationServicePollResponse{}, nil
 }
 
 func (f *fakeWatchSyncPluginClient) ExchangeAPIKey(_ context.Context, _ *pluginv1.WatchSyncExchangeAPIKeyRequest) (*pluginv1.WatchSyncCredentialResponse, error) {
@@ -166,6 +167,20 @@ func TestPluginProviderRejectsUnsupportedInitialDescriptor(t *testing.T) {
 	})
 	if err == nil {
 		t.Fatal("expected unsupported media descriptor to be rejected")
+	}
+
+	_, err = NewPluginProvider(PluginProviderOptions{
+		InstallationID: 4,
+		ProviderKey:    testPluginProviderKey,
+		CapabilityID:   testPluginCapabilityID,
+		Descriptor: &pluginv1.WatchSyncProviderDescriptor{AuthMethods: []pluginv1.WatchSyncAuthMethod{
+			pluginv1.WatchSyncAuthMethod_WATCH_SYNC_AUTH_METHOD_DEVICE_CODE,
+			pluginv1.WatchSyncAuthMethod_WATCH_SYNC_AUTH_METHOD_API_KEY,
+		}},
+		ResolveClient: func(context.Context, int, string) (WatchSyncPluginClient, error) { return nil, nil },
+	})
+	if err == nil || !strings.Contains(err.Error(), "multiple host authentication methods") {
+		t.Fatalf("multiple auth methods error = %v", err)
 	}
 }
 
@@ -424,6 +439,41 @@ func TestPluginProviderRejectsUnsupportedScrobbleMedia(t *testing.T) {
 	}
 }
 
+func TestPluginProviderPreservesScrobbleRetryClassification(t *testing.T) {
+	client := &fakeWatchSyncPluginClient{}
+	provider := testPluginProviderWithDescriptor(t, client, &pluginv1.WatchSyncProviderDescriptor{
+		AuthMethods:      []pluginv1.WatchSyncAuthMethod{pluginv1.WatchSyncAuthMethod_WATCH_SYNC_AUTH_METHOD_API_KEY},
+		ScrobblePlayback: true,
+		MaxBatchSize:     25,
+	})
+	event := ScrobbleEvent{
+		PlaybackSessionID: testPlaybackSessionID,
+		MediaItemID:       testMovieMediaID,
+		Kind:              historyimport.KindMovie,
+		OccurredAt:        time.Now().UTC(),
+	}
+	eventID := "scrobble:" + pluginv1.WatchSyncOperation_WATCH_SYNC_OPERATION_SCROBBLE_START.String() + ":" + testPlaybackSessionID
+	client.applyResponse = &pluginv1.WatchSyncApplyEventsResponse{Results: []*pluginv1.WatchSyncApplyResult{{
+		EventId: eventID,
+		Status:  pluginv1.WatchSyncApplyStatus_WATCH_SYNC_APPLY_STATUS_RETRY,
+		Fault: &pluginv1.WatchSyncFault{
+			Code:        pluginv1.WatchSyncFaultCode_WATCH_SYNC_FAULT_CODE_TEMPORARY,
+			SafeMessage: "retry later",
+		},
+	}}}
+	if err := provider.Start(context.Background(), ServerConfig{}, Connection{}, event); !isRetryableProviderError(err) {
+		t.Fatalf("retry error = %#v, want retryableProviderError", err)
+	}
+
+	client.applyResponse = &pluginv1.WatchSyncApplyEventsResponse{Results: []*pluginv1.WatchSyncApplyResult{{
+		EventId: eventID,
+		Status:  pluginv1.WatchSyncApplyStatus_WATCH_SYNC_APPLY_STATUS_REJECTED,
+	}}}
+	if err := provider.Start(context.Background(), ServerConfig{}, Connection{}, event); err == nil || isRetryableProviderError(err) {
+		t.Fatalf("rejected error = %#v, want terminal error", err)
+	}
+}
+
 func TestPluginProviderAuthenticatedContextUsesCapabilityAndCredentials(t *testing.T) {
 	client := &fakeWatchSyncPluginClient{}
 	provider := testPluginProvider(t, client)
@@ -440,14 +490,15 @@ func TestPluginProviderAuthenticatedContextUsesCapabilityAndCredentials(t *testi
 func TestPluginProviderSupportsDeviceAuthorizationAndFullCredentials(t *testing.T) {
 	expiresAt := time.Now().UTC().Add(10 * time.Minute)
 	client := &fakeWatchSyncPluginClient{
-		deviceStartResponse: &pluginv1.WatchSyncStartDeviceAuthorizationResponse{
-			UserCode:        "ABCD",
-			VerificationUrl: "https://provider.example/activate",
-			ProviderState:   []byte("opaque-device-state"),
-			PollingInterval: durationpb.New(7 * time.Second),
-			ExpiresAt:       timestamppb.New(expiresAt),
+		deviceStartResponse: &pluginv1.WatchSyncDeviceAuthorizationServiceStartResponse{
+			UserCode:                "ABCD",
+			VerificationUrl:         "https://provider.example/activate",
+			VerificationUrlComplete: "https://provider.example/activate?code=ABCD",
+			ProviderState:           []byte("opaque-device-state"),
+			PollingInterval:         durationpb.New(7 * time.Second),
+			ExpiresAt:               timestamppb.New(expiresAt),
 		},
-		devicePollResponse: &pluginv1.WatchSyncPollDeviceAuthorizationResponse{
+		devicePollResponse: &pluginv1.WatchSyncDeviceAuthorizationServicePollResponse{
 			Status: pluginv1.WatchSyncDeviceAuthorizationStatus_WATCH_SYNC_DEVICE_AUTHORIZATION_STATUS_AUTHORIZED,
 			Credentials: &pluginv1.WatchSyncCredentials{
 				AccessToken: testAccessToken, RefreshToken: testRefreshToken, TokenType: testDPoPTokenType,
@@ -475,6 +526,7 @@ func TestPluginProviderSupportsDeviceAuthorizationAndFullCredentials(t *testing.
 		t.Fatal(err)
 	}
 	if session.UserCode != "ABCD" || session.IntervalSeconds != 7 ||
+		session.VerificationURL != "https://provider.example/activate?code=ABCD" ||
 		client.deviceStartRequest.GetProviderConfig().GetSecretValues()["provider.client_secret"] != testSecretValue {
 		t.Fatalf("session=%#v request=%#v", session, client.deviceStartRequest)
 	}
@@ -485,6 +537,79 @@ func TestPluginProviderSupportsDeviceAuthorizationAndFullCredentials(t *testing.
 	if string(client.devicePollRequest.GetProviderState()) != "opaque-device-state" ||
 		tokens.TokenType != testDPoPTokenType || len(tokens.Scopes) != 2 || tokens.SecretAttributes["instance"] != testOneValue {
 		t.Fatalf("tokens=%#v request=%#v", tokens, client.devicePollRequest)
+	}
+}
+
+func TestPluginProviderRejectsInvalidDeviceAuthorizationMetadata(t *testing.T) {
+	valid := func() *pluginv1.WatchSyncDeviceAuthorizationServiceStartResponse {
+		return &pluginv1.WatchSyncDeviceAuthorizationServiceStartResponse{
+			UserCode:        "ABCD",
+			VerificationUrl: "https://provider.example/activate",
+			ProviderState:   []byte("opaque"),
+			PollingInterval: durationpb.New(5 * time.Second),
+			ExpiresAt:       timestamppb.New(time.Now().UTC().Add(10 * time.Minute)),
+		}
+	}
+	tests := map[string]func(*pluginv1.WatchSyncDeviceAuthorizationServiceStartResponse){
+		"relative URL": func(response *pluginv1.WatchSyncDeviceAuthorizationServiceStartResponse) {
+			response.VerificationUrl = "/activate"
+		},
+		"URL userinfo": func(response *pluginv1.WatchSyncDeviceAuthorizationServiceStartResponse) {
+			response.VerificationUrl = "https://user:pass@provider.example/activate"
+		},
+		"unsafe complete URL": func(response *pluginv1.WatchSyncDeviceAuthorizationServiceStartResponse) {
+			response.VerificationUrlComplete = "javascript:alert(1)"
+		},
+		"invalid timestamp": func(response *pluginv1.WatchSyncDeviceAuthorizationServiceStartResponse) {
+			response.ExpiresAt = &timestamppb.Timestamp{Seconds: 253402300800}
+		},
+		"expired timestamp": func(response *pluginv1.WatchSyncDeviceAuthorizationServiceStartResponse) {
+			response.ExpiresAt = timestamppb.New(time.Now().UTC().Add(-time.Minute))
+		},
+		"invalid interval": func(response *pluginv1.WatchSyncDeviceAuthorizationServiceStartResponse) {
+			response.PollingInterval = durationpb.New(-time.Second)
+		},
+	}
+	for name, mutate := range tests {
+		t.Run(name, func(t *testing.T) {
+			response := valid()
+			mutate(response)
+			client := &fakeWatchSyncPluginClient{deviceStartResponse: response}
+			provider := testPluginProviderWithDescriptor(t, client, &pluginv1.WatchSyncProviderDescriptor{
+				AuthMethods: []pluginv1.WatchSyncAuthMethod{pluginv1.WatchSyncAuthMethod_WATCH_SYNC_AUTH_METHOD_DEVICE_CODE},
+			})
+			if _, err := provider.StartDeviceAuth(context.Background(), ServerConfig{}); err == nil {
+				t.Fatal("StartDeviceAuth error = nil")
+			}
+		})
+	}
+}
+
+func TestPluginProviderPendingDeviceAuthorizationCarriesRotatedState(t *testing.T) {
+	expiresAt := time.Now().UTC().Add(20 * time.Minute)
+	client := &fakeWatchSyncPluginClient{devicePollResponse: &pluginv1.WatchSyncDeviceAuthorizationServicePollResponse{
+		Status:          pluginv1.WatchSyncDeviceAuthorizationStatus_WATCH_SYNC_DEVICE_AUTHORIZATION_STATUS_PENDING,
+		ProviderState:   []byte("rotated-state"),
+		PollingInterval: durationpb.New(11 * time.Second),
+		ExpiresAt:       timestamppb.New(expiresAt),
+	}}
+	provider := testPluginProviderWithDescriptor(t, client, &pluginv1.WatchSyncProviderDescriptor{
+		AuthMethods: []pluginv1.WatchSyncAuthMethod{pluginv1.WatchSyncAuthMethod_WATCH_SYNC_AUTH_METHOD_DEVICE_CODE},
+	})
+	original := DeviceAuthSession{
+		ID: "auth-1", Provider: testPluginProviderKey, UserID: 7, ProfileID: "profile-1",
+		DeviceCode: base64.RawURLEncoding.EncodeToString([]byte("original-state")),
+		UserCode:   "ABCD", VerificationURL: "https://provider.example/activate",
+		IntervalSeconds: 5, ExpiresAt: time.Now().UTC().Add(10 * time.Minute),
+	}
+	_, err := provider.PollDeviceAuth(context.Background(), ServerConfig{}, original)
+	var pending deviceAuthorizationPendingError
+	if !errors.As(err, &pending) {
+		t.Fatalf("error = %#v, want deviceAuthorizationPendingError", err)
+	}
+	if pending.session.DeviceCode != base64.RawURLEncoding.EncodeToString([]byte("rotated-state")) ||
+		pending.session.IntervalSeconds != 11 || !pending.session.ExpiresAt.Equal(expiresAt) {
+		t.Fatalf("pending session = %#v", pending.session)
 	}
 }
 
@@ -539,6 +664,57 @@ func TestPluginProviderPaginatesRemoteStateAndPersistsRotatedCredentials(t *test
 	}
 }
 
+func TestPluginProviderBoundsRemoteStateTraversalByItemCount(t *testing.T) {
+	client := &fakeWatchSyncPluginClient{listResponses: []*pluginv1.WatchSyncListRemoteStateResponse{
+		{Items: make([]*pluginv1.WatchSyncRemoteState, maxRemoteStateItems), NextPageToken: "page-2"},
+		{Items: []*pluginv1.WatchSyncRemoteState{{}}, NextCursor: "must-not-commit"},
+	}}
+	provider := testPluginProvider(t, client)
+	batch, err := provider.FetchWatchedBatch(context.Background(), ServerConfig{}, Connection{
+		SyncCursors: map[string]string{pluginWatchedCursorKey: testCursorOne},
+	})
+	if err == nil || !strings.Contains(err.Error(), "item limit") {
+		t.Fatalf("error = %v, want item limit", err)
+	}
+	if len(batch.UpdatedCursors) != 0 || len(client.listRequests) != 2 || client.listRequests[1].GetCursor() != testCursorOne {
+		t.Fatalf("batch=%#v requests=%#v", batch, client.listRequests)
+	}
+}
+
+func TestPluginProviderRejectsIncrementalOrderedWatchlist(t *testing.T) {
+	client := &fakeWatchSyncPluginClient{listResponse: &pluginv1.WatchSyncListRemoteStateResponse{
+		NextCursor:       "must-not-commit",
+		CompleteSnapshot: false,
+	}}
+	provider := testPluginProviderWithDescriptor(t, client, &pluginv1.WatchSyncProviderDescriptor{
+		AuthMethods:            []pluginv1.WatchSyncAuthMethod{pluginv1.WatchSyncAuthMethod_WATCH_SYNC_AUTH_METHOD_API_KEY},
+		ImportWatchlist:        true,
+		ProvidesWatchlistOrder: true,
+		MaxBatchSize:           25,
+	})
+	batch, err := provider.FetchWatchlistBatch(context.Background(), ServerConfig{}, Connection{
+		SyncCursors: map[string]string{pluginWatchlistCursorKey: testCursorOne},
+	})
+	if err == nil || !strings.Contains(err.Error(), "incremental traversal for an ordered watchlist") {
+		t.Fatalf("error = %v, want ordered watchlist snapshot requirement", err)
+	}
+	if len(batch.UpdatedCursors) != 0 || len(client.listRequests) != 1 {
+		t.Fatalf("batch=%#v requests=%#v", batch, client.listRequests)
+	}
+}
+
+func TestPluginProviderDecodesKeyOnlyListTombstone(t *testing.T) {
+	row, err := remoteFavoriteFromProto(testPluginProviderKey, &pluginv1.WatchSyncRemoteState{
+		ProviderItemKey: "remote-1",
+	}, &pluginv1.WatchSyncRemoteListState{Removed: true})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !row.Removed || row.ProviderItemKey != "remote-1" || row.Kind != "" {
+		t.Fatalf("row = %#v", row)
+	}
+}
+
 func TestPluginProviderMapsAllCapabilitiesAndListOperations(t *testing.T) {
 	descriptor := &pluginv1.WatchSyncProviderDescriptor{
 		AuthMethods:   []pluginv1.WatchSyncAuthMethod{pluginv1.WatchSyncAuthMethod_WATCH_SYNC_AUTH_METHOD_API_KEY},
@@ -571,6 +747,65 @@ func TestPluginProviderMapsAllCapabilitiesAndListOperations(t *testing.T) {
 	if len(result.Sent) != 1 || event.GetOperation() != pluginv1.WatchSyncOperation_WATCH_SYNC_OPERATION_ADD_TO_WATCHLIST ||
 		event.GetProviderItemKey() != "remote-1" {
 		t.Fatalf("result=%#v event=%#v", result, event)
+	}
+}
+
+func TestPluginProviderListEventsKeepFailuresAndPresenceAwareOrder(t *testing.T) {
+	client := &fakeWatchSyncPluginClient{}
+	provider := testPluginProviderWithDescriptor(t, client, &pluginv1.WatchSyncProviderDescriptor{
+		AuthMethods:         []pluginv1.WatchSyncAuthMethod{pluginv1.WatchSyncAuthMethod_WATCH_SYNC_AUTH_METHOD_API_KEY},
+		ExportWatchlist:     true,
+		RemoveWatchlist:     true,
+		SupportedMediaTypes: []pluginv1.WatchSyncMediaType{pluginv1.WatchSyncMediaType_WATCH_SYNC_MEDIA_TYPE_MOVIE},
+		MaxBatchSize:        25,
+	})
+	items := []LocalFavorite{
+		{MediaItemID: testEpisodeMediaID, Kind: historyimport.KindEpisode},
+		{MediaItemID: testMovieMediaID, Kind: historyimport.KindMovie},
+	}
+	addEventID := pluginv1.WatchSyncOperation_WATCH_SYNC_OPERATION_ADD_TO_WATCHLIST.String() + ":" + testMovieMediaID
+	client.applyResponse = &pluginv1.WatchSyncApplyEventsResponse{Results: []*pluginv1.WatchSyncApplyResult{{
+		EventId: addEventID, Status: pluginv1.WatchSyncApplyStatus_WATCH_SYNC_APPLY_STATUS_APPLIED,
+	}}}
+	result, err := provider.ExportWatchlist(context.Background(), ServerConfig{}, Connection{}, items)
+	if err != nil {
+		t.Fatal(err)
+	}
+	event := client.applyRequest.GetEvents()[0]
+	if result.Failed[testEpisodeMediaID] != watchSyncUnsupportedEpisodeMediaMessage ||
+		event.ListPosition == nil || event.GetListPosition() != 0 {
+		t.Fatalf("result=%#v event=%#v", result, event)
+	}
+
+	removeEventID := pluginv1.WatchSyncOperation_WATCH_SYNC_OPERATION_REMOVE_FROM_WATCHLIST.String() + ":" + testMovieMediaID
+	client.applyResponse = &pluginv1.WatchSyncApplyEventsResponse{Results: []*pluginv1.WatchSyncApplyResult{{
+		EventId: removeEventID, Status: pluginv1.WatchSyncApplyStatus_WATCH_SYNC_APPLY_STATUS_APPLIED,
+	}}}
+	result, err = provider.RemoveWatchlist(context.Background(), ServerConfig{}, Connection{}, items)
+	if err != nil {
+		t.Fatal(err)
+	}
+	event = client.applyRequest.GetEvents()[0]
+	if result.Failed[testEpisodeMediaID] != watchSyncUnsupportedEpisodeMediaMessage || event.ListPosition != nil {
+		t.Fatalf("result=%#v event=%#v", result, event)
+	}
+}
+
+func TestPluginProviderRemoveHistoryRecordsUnsupportedMedia(t *testing.T) {
+	client := &fakeWatchSyncPluginClient{}
+	provider := testPluginProviderWithDescriptor(t, client, &pluginv1.WatchSyncProviderDescriptor{
+		AuthMethods:         []pluginv1.WatchSyncAuthMethod{pluginv1.WatchSyncAuthMethod_WATCH_SYNC_AUTH_METHOD_API_KEY},
+		ExportUnwatched:     true,
+		SupportedMediaTypes: []pluginv1.WatchSyncMediaType{pluginv1.WatchSyncMediaType_WATCH_SYNC_MEDIA_TYPE_MOVIE},
+	})
+	result, err := provider.RemoveHistory(context.Background(), ServerConfig{}, Connection{}, []LocalPlay{{
+		HistoryID: testWatchHistoryID, Kind: historyimport.KindEpisode,
+	}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result.Failed[testWatchHistoryID] != watchSyncUnsupportedEpisodeMediaMessage || client.applyRequest != nil {
+		t.Fatalf("result=%#v request=%#v", result, client.applyRequest)
 	}
 }
 

--- a/internal/watchsync/registry.go
+++ b/internal/watchsync/registry.go
@@ -6,6 +6,12 @@ import (
 	"sync"
 )
 
+const providerSourcePlugin = "plugin"
+
+type sourcedProvider interface {
+	ProviderSource() string
+}
+
 type Registry struct {
 	mu        sync.RWMutex
 	providers map[string]Provider
@@ -32,6 +38,36 @@ func (r *Registry) Register(provider Provider) error {
 		return fmt.Errorf("watchsync provider %q already registered", key)
 	}
 	r.providers[key] = provider
+	return nil
+}
+
+// ReplacePluginProviders atomically replaces providers discovered from enabled
+// plugin installations while preserving built-in providers. A plugin may not
+// shadow a built-in key, and duplicate plugin keys reject the entire reload.
+func (r *Registry) ReplacePluginProviders(providers []Provider) error {
+	if r == nil {
+		return fmt.Errorf("watchsync registry is nil")
+	}
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	next := make(map[string]Provider, len(r.providers)+len(providers))
+	for key, provider := range r.providers {
+		if sourced, ok := provider.(sourcedProvider); ok && sourced.ProviderSource() == providerSourcePlugin {
+			continue
+		}
+		next[key] = provider
+	}
+	for _, provider := range providers {
+		if provider == nil || provider.Key() == "" {
+			return fmt.Errorf("watchsync plugin provider and key are required")
+		}
+		if _, exists := next[provider.Key()]; exists {
+			return fmt.Errorf("watchsync plugin provider key %q conflicts with another provider", provider.Key())
+		}
+		next[provider.Key()] = provider
+	}
+	r.providers = next
 	return nil
 }
 

--- a/internal/watchsync/registry_test.go
+++ b/internal/watchsync/registry_test.go
@@ -24,6 +24,42 @@ func TestRegistryRejectsDuplicateProvider(t *testing.T) {
 	}
 }
 
+type stubPluginProvider struct{ stubProvider }
+
+func (stubPluginProvider) ProviderSource() string { return providerSourcePlugin }
+
+func TestRegistryReplacePluginProviders(t *testing.T) {
+	registry := NewRegistry()
+	if err := registry.Register(stubProvider{key: "trakt"}); err != nil {
+		t.Fatal(err)
+	}
+	if err := registry.ReplacePluginProviders([]Provider{stubPluginProvider{stubProvider{key: testPluginCapabilityID}}}); err != nil {
+		t.Fatal(err)
+	}
+	if _, ok := registry.Get("anilist"); !ok {
+		t.Fatal("plugin provider was not registered")
+	}
+	if err := registry.ReplacePluginProviders([]Provider{stubPluginProvider{stubProvider{key: "simkl-plugin"}}}); err != nil {
+		t.Fatal(err)
+	}
+	if _, ok := registry.Get("anilist"); ok {
+		t.Fatal("stale plugin provider was not removed")
+	}
+	if _, ok := registry.Get("trakt"); !ok {
+		t.Fatal("built-in provider was removed")
+	}
+}
+
+func TestRegistryReplacePluginProvidersRejectsBuiltinCollision(t *testing.T) {
+	registry := NewRegistry()
+	if err := registry.Register(stubProvider{key: "trakt"}); err != nil {
+		t.Fatal(err)
+	}
+	if err := registry.ReplacePluginProviders([]Provider{stubPluginProvider{stubProvider{key: "trakt"}}}); err == nil {
+		t.Fatal("expected built-in collision to fail")
+	}
+}
+
 func TestRegistryListWithCapabilities(t *testing.T) {
 	registry := NewRegistry()
 

--- a/internal/watchsync/repository.go
+++ b/internal/watchsync/repository.go
@@ -51,6 +51,8 @@ type Repository interface {
 	FailConfirmedScrobbleStop(ctx context.Context, playbackSessionID string, connectionID string, progress float64, historyID string, claimVersion time.Time, lastError string) error
 	UpdateScrobbleSession(ctx context.Context, playbackSessionID string, connectionID string, action string, progress float64, historyID string, lastError string, stopSentAt *time.Time) error
 	ListOpenScrobbleSessions(ctx context.Context) ([]ScrobbleSession, error)
+	ListPendingScrobbleReconciliations(ctx context.Context) ([]ScrobbleSession, error)
+	MarkScrobbleHistoryReconciled(ctx context.Context, playbackSessionID, connectionID string, reconciledAt time.Time) error
 }
 
 type confirmedStopPreparation uint8
@@ -68,7 +70,7 @@ var errConfirmedStopClaimLost = errors.New("confirmed scrobble stop claim lost")
 // it across every read query keeps the column set and scan order in lockstep.
 const connectionColumns = `
 	id::text, provider, user_id, profile_id, provider_account_id, provider_username,
-	access_token, refresh_token, token_expires_at, import_watched_enabled,
+	access_token, refresh_token, token_expires_at, plugin_credentials, import_watched_enabled,
 	import_progress_enabled, export_watched_enabled, export_unwatched_enabled,
 	import_favorites_enabled, export_favorites_enabled, sync_favorite_removals_enabled,
 	import_watchlist_enabled, export_watchlist_enabled, sync_watchlist_removals_enabled,
@@ -116,6 +118,10 @@ func TokenAAD(column, provider string, userID int, profileID string) string {
 	return secret.RowAAD("watch_provider_connections", column, provider+":"+strconv.Itoa(userID)+":"+profileID)
 }
 
+func authStateAAD(provider string, userID int, profileID string) string {
+	return secret.RowAAD("watch_provider_auth_sessions", "device_code", provider+":"+strconv.Itoa(userID)+":"+profileID)
+}
+
 func (r *PostgresRepository) GetServerSetting(ctx context.Context, key string) (string, error) {
 	var value string
 	err := r.pool.QueryRow(ctx, `SELECT value FROM server_settings WHERE key = $1`, key).Scan(&value)
@@ -139,6 +145,10 @@ func (r *PostgresRepository) UpsertAuthSession(
 	ctx context.Context,
 	session DeviceAuthSession,
 ) (DeviceAuthSession, error) {
+	deviceCode, err := r.cipher.Encrypt(session.DeviceCode, authStateAAD(session.Provider, session.UserID, session.ProfileID))
+	if err != nil {
+		return DeviceAuthSession{}, fmt.Errorf("encrypt watch provider authorization state: %w", err)
+	}
 	row := r.pool.QueryRow(ctx, `
 		INSERT INTO watch_provider_auth_sessions (
 			id, provider, user_id, profile_id, device_code, user_code,
@@ -167,14 +177,14 @@ func (r *PostgresRepository) UpsertAuthSession(
 		session.Provider,
 		session.UserID,
 		session.ProfileID,
-		session.DeviceCode,
+		deviceCode,
 		session.UserCode,
 		session.VerificationURL,
 		session.IntervalSeconds,
 		session.ExpiresAt,
 		session.CompletedAt,
 	)
-	saved, err := scanDeviceAuthSession(row)
+	saved, err := r.scanDeviceAuthSession(row)
 	if err != nil {
 		return DeviceAuthSession{}, fmt.Errorf("upsert watch provider auth session: %w", err)
 	}
@@ -189,7 +199,7 @@ func (r *PostgresRepository) GetAuthSession(ctx context.Context, id string) (Dev
 		FROM watch_provider_auth_sessions
 		WHERE id = $1::uuid
 	`, id)
-	session, err := scanDeviceAuthSession(row)
+	session, err := r.scanDeviceAuthSession(row)
 	if err != nil {
 		return DeviceAuthSession{}, fmt.Errorf("get watch provider auth session %q: %w", id, err)
 	}
@@ -205,10 +215,14 @@ func (r *PostgresRepository) UpsertConnection(ctx context.Context, conn Connecti
 	if err != nil {
 		return Connection{}, fmt.Errorf("encrypt watch refresh token: %w", err)
 	}
+	pluginCredentials, err := r.encodePluginCredentials(conn)
+	if err != nil {
+		return Connection{}, err
+	}
 	row := r.pool.QueryRow(ctx, `
 		INSERT INTO watch_provider_connections (
 			id, provider, user_id, profile_id, provider_account_id, provider_username,
-			access_token, refresh_token, token_expires_at, import_watched_enabled,
+			access_token, refresh_token, token_expires_at, plugin_credentials, import_watched_enabled,
 			import_progress_enabled, export_watched_enabled, export_unwatched_enabled,
 			import_favorites_enabled, export_favorites_enabled, sync_favorite_removals_enabled,
 			import_watchlist_enabled, export_watchlist_enabled, sync_watchlist_removals_enabled,
@@ -218,8 +232,8 @@ func (r *PostgresRepository) UpsertConnection(ctx context.Context, conn Connecti
 		)
 		VALUES (
 			COALESCE(NULLIF($1, '')::uuid, gen_random_uuid()),
-			$2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13,
-			$14, $15, $16, $17, $18, $19, $20, $21, $22, $23, $24, $25, $26, $27, $28, $29, $30::jsonb
+			$2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14,
+			$15, $16, $17, $18, $19, $20, $21, $22, $23, $24, $25, $26, $27, $28, $29, $30, $31::jsonb
 		)
 		ON CONFLICT (provider, user_id, profile_id) DO UPDATE SET
 			provider_account_id = EXCLUDED.provider_account_id,
@@ -227,6 +241,7 @@ func (r *PostgresRepository) UpsertConnection(ctx context.Context, conn Connecti
 			access_token = EXCLUDED.access_token,
 			refresh_token = EXCLUDED.refresh_token,
 			token_expires_at = EXCLUDED.token_expires_at,
+			plugin_credentials = EXCLUDED.plugin_credentials,
 			import_watched_enabled = EXCLUDED.import_watched_enabled,
 			import_progress_enabled = EXCLUDED.import_progress_enabled,
 			export_watched_enabled = EXCLUDED.export_watched_enabled,
@@ -260,6 +275,7 @@ func (r *PostgresRepository) UpsertConnection(ctx context.Context, conn Connecti
 		accessToken,
 		refreshToken,
 		conn.TokenExpiresAt,
+		pluginCredentials,
 		conn.ImportWatchedEnabled,
 		conn.ImportProgressEnabled,
 		conn.ExportWatchedEnabled,
@@ -1172,7 +1188,61 @@ func (r *PostgresRepository) ListOpenScrobbleSessions(ctx context.Context) ([]Sc
 	return sessions, nil
 }
 
-func scanDeviceAuthSession(row pgx.Row) (DeviceAuthSession, error) {
+func (r *PostgresRepository) ListPendingScrobbleReconciliations(ctx context.Context) ([]ScrobbleSession, error) {
+	rows, err := r.pool.Query(ctx, `
+		SELECT playback_session_id, connection_id::text, media_item_id, provider_item_key, kind,
+			imdb_id, tmdb_id, tvdb_id, series_imdb_id, series_tmdb_id, series_tvdb_id,
+			season_number, episode_number, history_id, started_at, last_progress,
+			duration_seconds, completed, last_action, stop_sent_at, history_reconciled_at, last_error
+		FROM watch_provider_scrobble_sessions
+		WHERE stop_sent_at IS NOT NULL AND completed = true AND history_id <> ''
+			AND history_reconciled_at IS NULL
+		ORDER BY stop_sent_at ASC
+	`)
+	if err != nil {
+		return nil, fmt.Errorf("list pending scrobble reconciliations: %w", err)
+	}
+	defer rows.Close()
+	var sessions []ScrobbleSession
+	for rows.Next() {
+		var session ScrobbleSession
+		if err := rows.Scan(
+			&session.PlaybackSessionID, &session.ConnectionID, &session.MediaItemID,
+			&session.ProviderItemKey, &session.Kind, &session.IMDbID, &session.TMDBID,
+			&session.TVDBID, &session.SeriesIMDbID, &session.SeriesTMDBID,
+			&session.SeriesTVDBID, &session.SeasonNumber, &session.EpisodeNumber,
+			&session.HistoryID, &session.StartedAt, &session.LastProgress,
+			&session.DurationSeconds, &session.Completed, &session.LastAction,
+			&session.StopSentAt, &session.HistoryReconciledAt, &session.LastError,
+		); err != nil {
+			return nil, fmt.Errorf("scan pending scrobble reconciliation: %w", err)
+		}
+		sessions = append(sessions, session)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("iterate pending scrobble reconciliations: %w", err)
+	}
+	return sessions, nil
+}
+
+func (r *PostgresRepository) MarkScrobbleHistoryReconciled(
+	ctx context.Context,
+	playbackSessionID string,
+	connectionID string,
+	reconciledAt time.Time,
+) error {
+	_, err := r.pool.Exec(ctx, `
+		UPDATE watch_provider_scrobble_sessions
+		SET history_reconciled_at = $3, last_error = '', updated_at = now()
+		WHERE playback_session_id = $1 AND connection_id = $2::uuid
+	`, playbackSessionID, connectionID, reconciledAt)
+	if err != nil {
+		return fmt.Errorf("mark scrobble history reconciled: %w", err)
+	}
+	return nil
+}
+
+func (r *PostgresRepository) scanDeviceAuthSession(row pgx.Row) (DeviceAuthSession, error) {
 	var session DeviceAuthSession
 	err := row.Scan(
 		&session.ID,
@@ -1189,6 +1259,14 @@ func scanDeviceAuthSession(row pgx.Row) (DeviceAuthSession, error) {
 	if err != nil {
 		return DeviceAuthSession{}, err
 	}
+	decrypted, err := r.cipher.DecryptIfEncrypted(
+		session.DeviceCode,
+		authStateAAD(session.Provider, session.UserID, session.ProfileID),
+	)
+	if err != nil {
+		return DeviceAuthSession{}, fmt.Errorf("decrypt watch provider authorization state: %w", err)
+	}
+	session.DeviceCode = decrypted
 	return session, nil
 }
 
@@ -1231,6 +1309,7 @@ func scanSyncRun(row pgx.Row) (SyncRun, error) {
 func (r *PostgresRepository) scanConnection(row pgx.Row) (Connection, error) {
 	var conn Connection
 	var rawSyncCursors []byte
+	var rawPluginCredentials string
 	err := row.Scan(
 		&conn.ID,
 		&conn.Provider,
@@ -1241,6 +1320,7 @@ func (r *PostgresRepository) scanConnection(row pgx.Row) (Connection, error) {
 		&conn.AccessToken,
 		&conn.RefreshToken,
 		&conn.TokenExpiresAt,
+		&rawPluginCredentials,
 		&conn.ImportWatchedEnabled,
 		&conn.ImportProgressEnabled,
 		&conn.ExportWatchedEnabled,
@@ -1276,8 +1356,77 @@ func (r *PostgresRepository) scanConnection(row pgx.Row) (Connection, error) {
 	if conn.RefreshToken, err = r.cipher.DecryptIfEncrypted(conn.RefreshToken, TokenAAD("refresh_token", conn.Provider, conn.UserID, conn.ProfileID)); err != nil {
 		return Connection{}, fmt.Errorf("decrypt watch refresh token: %w", err)
 	}
+	if err := r.decodePluginCredentials(&conn, rawPluginCredentials); err != nil {
+		return Connection{}, err
+	}
 	conn.SyncCursors = decodeSyncCursors(rawSyncCursors)
 	return conn, nil
+}
+
+type storedPluginCredentials struct {
+	AccessToken      string            `json:"access_token"`
+	RefreshToken     string            `json:"refresh_token,omitempty"`
+	TokenExpiresAt   *time.Time        `json:"expires_at,omitempty"`
+	TokenType        string            `json:"token_type,omitempty"`
+	Scopes           []string          `json:"scopes,omitempty"`
+	SecretAttributes map[string]string `json:"secret_attributes,omitempty"`
+}
+
+func (r *PostgresRepository) encodePluginCredentials(conn Connection) (string, error) {
+	payload, err := json.Marshal(storedPluginCredentials{
+		AccessToken:      conn.AccessToken,
+		RefreshToken:     conn.RefreshToken,
+		TokenExpiresAt:   conn.TokenExpiresAt,
+		TokenType:        conn.TokenType,
+		Scopes:           conn.Scopes,
+		SecretAttributes: conn.SecretAttributes,
+	})
+	if err != nil {
+		return "", fmt.Errorf("encode watch provider credentials: %w", err)
+	}
+	encoded, err := r.cipher.Encrypt(
+		string(payload),
+		TokenAAD("plugin_credentials", conn.Provider, conn.UserID, conn.ProfileID),
+	)
+	if err != nil {
+		return "", fmt.Errorf("encrypt watch provider credentials: %w", err)
+	}
+	return encoded, nil
+}
+
+func (r *PostgresRepository) decodePluginCredentials(conn *Connection, encoded string) error {
+	if conn == nil || strings.TrimSpace(encoded) == "" {
+		return nil
+	}
+	plaintext, err := r.cipher.DecryptIfEncrypted(
+		encoded,
+		TokenAAD("plugin_credentials", conn.Provider, conn.UserID, conn.ProfileID),
+	)
+	if err != nil {
+		return fmt.Errorf("decrypt watch provider credentials: %w", err)
+	}
+	var credentials storedPluginCredentials
+	if err := json.Unmarshal([]byte(plaintext), &credentials); err != nil {
+		return fmt.Errorf("decode watch provider credentials: %w", err)
+	}
+	conn.AccessToken = credentials.AccessToken
+	conn.RefreshToken = credentials.RefreshToken
+	conn.TokenExpiresAt = credentials.TokenExpiresAt
+	conn.TokenType = credentials.TokenType
+	conn.Scopes = append([]string(nil), credentials.Scopes...)
+	conn.SecretAttributes = cloneStringMap(credentials.SecretAttributes)
+	return nil
+}
+
+func cloneStringMap(values map[string]string) map[string]string {
+	if values == nil {
+		return nil
+	}
+	result := make(map[string]string, len(values))
+	for key, value := range values {
+		result[key] = value
+	}
+	return result
 }
 
 type listItemStateRows interface {

--- a/internal/watchsync/repository.go
+++ b/internal/watchsync/repository.go
@@ -215,7 +215,7 @@ func (r *PostgresRepository) UpsertConnection(ctx context.Context, conn Connecti
 	if err != nil {
 		return Connection{}, fmt.Errorf("encrypt watch refresh token: %w", err)
 	}
-	pluginCredentials, err := r.encodePluginCredentials(conn)
+	pluginCredentials, err := r.pluginCredentialsForConnection(conn)
 	if err != nil {
 		return Connection{}, err
 	}
@@ -1198,6 +1198,7 @@ func (r *PostgresRepository) ListPendingScrobbleReconciliations(ctx context.Cont
 		WHERE stop_sent_at IS NOT NULL AND completed = true AND history_id <> ''
 			AND history_reconciled_at IS NULL
 		ORDER BY stop_sent_at ASC
+		LIMIT 100
 	`)
 	if err != nil {
 		return nil, fmt.Errorf("list pending scrobble reconciliations: %w", err)
@@ -1370,6 +1371,16 @@ type storedPluginCredentials struct {
 	TokenType        string            `json:"token_type,omitempty"`
 	Scopes           []string          `json:"scopes,omitempty"`
 	SecretAttributes map[string]string `json:"secret_attributes,omitempty"`
+}
+
+func (r *PostgresRepository) pluginCredentialsForConnection(conn Connection) (string, error) {
+	if !strings.HasPrefix(conn.Provider, providerSourcePlugin+":") {
+		// Built-in providers have legacy token writers that update the dedicated
+		// token columns directly. Keeping a second authoritative bundle for them
+		// would let that bundle become stale and overwrite freshly rotated tokens.
+		return "", nil
+	}
+	return r.encodePluginCredentials(conn)
 }
 
 func (r *PostgresRepository) encodePluginCredentials(conn Connection) (string, error) {

--- a/internal/watchsync/repository.go
+++ b/internal/watchsync/repository.go
@@ -35,6 +35,7 @@ type Repository interface {
 	UpsertHistoryExports(ctx context.Context, exports []HistoryExport) error
 	ListPendingHistoryExports(ctx context.Context, connectionID string, limit int) ([]HistoryExport, error)
 	MarkHistoryExportStatus(ctx context.Context, id string, status string, lastError string) error
+	MarkHistoryExportSatisfiedByScrobble(ctx context.Context, connectionID string, historyID string) error
 	UpsertListItemStates(ctx context.Context, states []ListItemState) error
 	ListListItemStates(ctx context.Context, connectionID string, kind ListKind) ([]ListItemState, error)
 	ListPendingListItemExports(ctx context.Context, connectionID string, kind ListKind, limit int) ([]ListItemState, error)
@@ -688,7 +689,9 @@ func (r *PostgresRepository) UpsertHistoryExports(ctx context.Context, exports [
 			ON CONFLICT (connection_id, history_id) DO UPDATE SET
 				provider_item_key = EXCLUDED.provider_item_key,
 				status = CASE
-					WHEN watch_provider_history_exports.status IN ('sent', 'satisfied_by_scrobble') THEN watch_provider_history_exports.status
+					WHEN watch_provider_history_exports.status IN ('sent', 'satisfied_by_scrobble')
+						OR watch_provider_history_exports.attempt_count >= 5
+					THEN watch_provider_history_exports.status
 					ELSE EXCLUDED.status
 				END,
 				updated_at = now()
@@ -755,9 +758,26 @@ func (r *PostgresRepository) MarkHistoryExportStatus(ctx context.Context, id str
 			last_error = $3,
 			updated_at = now()
 		WHERE id = $1::uuid
+		  AND status NOT IN ('sent', 'satisfied_by_scrobble')
 	`, id, status, lastError)
 	if err != nil {
 		return fmt.Errorf("mark history export status: %w", err)
+	}
+	return nil
+}
+
+func (r *PostgresRepository) MarkHistoryExportSatisfiedByScrobble(ctx context.Context, connectionID string, historyID string) error {
+	_, err := r.pool.Exec(ctx, `
+		UPDATE watch_provider_history_exports
+		SET status = 'satisfied_by_scrobble',
+			last_attempt_at = now(),
+			last_error = '',
+			updated_at = now()
+		WHERE connection_id = $1::uuid AND history_id = $2
+		  AND status <> 'sent'
+	`, connectionID, historyID)
+	if err != nil {
+		return fmt.Errorf("mark history export satisfied by scrobble: %w", err)
 	}
 	return nil
 }

--- a/internal/watchsync/repository.go
+++ b/internal/watchsync/repository.go
@@ -689,7 +689,7 @@ func (r *PostgresRepository) UpsertHistoryExports(ctx context.Context, exports [
 			ON CONFLICT (connection_id, history_id) DO UPDATE SET
 				provider_item_key = EXCLUDED.provider_item_key,
 				status = CASE
-					WHEN watch_provider_history_exports.status IN ('sent', 'satisfied_by_scrobble')
+					WHEN watch_provider_history_exports.status IN ('sent', 'satisfied_by_scrobble', 'not_found')
 						OR watch_provider_history_exports.attempt_count >= 5
 					THEN watch_provider_history_exports.status
 					ELSE EXCLUDED.status
@@ -758,7 +758,7 @@ func (r *PostgresRepository) MarkHistoryExportStatus(ctx context.Context, id str
 			last_error = $3,
 			updated_at = now()
 		WHERE id = $1::uuid
-		  AND status NOT IN ('sent', 'satisfied_by_scrobble')
+		  AND status NOT IN ('sent', 'satisfied_by_scrobble', 'not_found')
 	`, id, status, lastError)
 	if err != nil {
 		return fmt.Errorf("mark history export status: %w", err)
@@ -774,7 +774,7 @@ func (r *PostgresRepository) MarkHistoryExportSatisfiedByScrobble(ctx context.Co
 			last_error = '',
 			updated_at = now()
 		WHERE connection_id = $1::uuid AND history_id = $2
-		  AND status <> 'sent'
+		  AND status NOT IN ('sent', 'not_found')
 	`, connectionID, historyID)
 	if err != nil {
 		return fmt.Errorf("mark history export satisfied by scrobble: %w", err)

--- a/internal/watchsync/repository_test.go
+++ b/internal/watchsync/repository_test.go
@@ -1,8 +1,12 @@
 package watchsync
 
 import (
+	"reflect"
 	"strings"
 	"testing"
+	"time"
+
+	"github.com/Silo-Server/silo-server/internal/secret"
 )
 
 func TestMediaDurationQueryUsesActiveMediaFilesPredicate(t *testing.T) {
@@ -11,5 +15,36 @@ func TestMediaDurationQueryUsesActiveMediaFilesPredicate(t *testing.T) {
 	}
 	if strings.Contains(mediaDurationQuery, "missing = false") {
 		t.Fatalf("media duration query references removed media_files.missing column:\n%s", mediaDurationQuery)
+	}
+}
+
+func TestPluginCredentialBundleRoundTrip(t *testing.T) {
+	cipher, err := secret.New([]byte("01234567890123456789012345678901"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	repository := NewPostgresRepository(nil, cipher)
+	expiresAt := time.Now().UTC().Truncate(time.Second)
+	input := Connection{
+		Provider: "plugin:4:tracker", UserID: 7, ProfileID: "profile",
+		AccessToken: testAccessToken, RefreshToken: testRefreshToken, TokenExpiresAt: &expiresAt,
+		TokenType: testDPoPTokenType, Scopes: []string{testHistoryScope, "watchlist"},
+		SecretAttributes: map[string]string{"instance": testOneValue},
+	}
+	encoded, err := repository.encodePluginCredentials(input)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if strings.Contains(encoded, input.AccessToken) || !strings.HasPrefix(encoded, "enc:v1:") {
+		t.Fatalf("credential bundle was not encrypted: %q", encoded)
+	}
+	output := Connection{Provider: input.Provider, UserID: input.UserID, ProfileID: input.ProfileID}
+	if err := repository.decodePluginCredentials(&output, encoded); err != nil {
+		t.Fatal(err)
+	}
+	if output.AccessToken != input.AccessToken || output.RefreshToken != input.RefreshToken ||
+		output.TokenType != input.TokenType || !output.TokenExpiresAt.Equal(expiresAt) ||
+		!reflect.DeepEqual(output.Scopes, input.Scopes) || !reflect.DeepEqual(output.SecretAttributes, input.SecretAttributes) {
+		t.Fatalf("decoded credentials = %#v", output)
 	}
 }

--- a/internal/watchsync/repository_test.go
+++ b/internal/watchsync/repository_test.go
@@ -48,3 +48,51 @@ func TestPluginCredentialBundleRoundTrip(t *testing.T) {
 		t.Fatalf("decoded credentials = %#v", output)
 	}
 }
+
+func TestPluginCredentialBundleUsesConnectionIdentityAsAAD(t *testing.T) {
+	cipher, err := secret.New([]byte("01234567890123456789012345678901"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	repository := NewPostgresRepository(nil, cipher)
+	input := Connection{
+		Provider: "plugin:4:tracker", UserID: 7, ProfileID: "profile-a",
+		AccessToken: testAccessToken,
+	}
+	encoded, err := repository.encodePluginCredentials(input)
+	if err != nil {
+		t.Fatal(err)
+	}
+	wrongIdentity := Connection{Provider: input.Provider, UserID: input.UserID, ProfileID: "profile-b"}
+	if err := repository.decodePluginCredentials(&wrongIdentity, encoded); err == nil {
+		t.Fatal("decodePluginCredentials with different profile identity succeeded")
+	}
+}
+
+func TestPluginCredentialBundleIsOnlyWrittenForPluginProviders(t *testing.T) {
+	cipher, err := secret.New([]byte("01234567890123456789012345678901"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	repository := NewPostgresRepository(nil, cipher)
+	for _, provider := range []string{"trakt", "simkl", "mdblist"} {
+		encoded, err := repository.pluginCredentialsForConnection(Connection{
+			Provider: provider, UserID: 7, ProfileID: "profile", AccessToken: testAccessToken,
+		})
+		if err != nil {
+			t.Fatalf("pluginCredentialsForConnection(%q): %v", provider, err)
+		}
+		if encoded != "" {
+			t.Fatalf("pluginCredentialsForConnection(%q) = %q, want empty", provider, encoded)
+		}
+	}
+	encoded, err := repository.pluginCredentialsForConnection(Connection{
+		Provider: "plugin:4:tracker", UserID: 7, ProfileID: "profile", AccessToken: testAccessToken,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.HasPrefix(encoded, "enc:v1:") {
+		t.Fatalf("plugin credential bundle = %q, want encrypted value", encoded)
+	}
+}

--- a/internal/watchsync/service.go
+++ b/internal/watchsync/service.go
@@ -499,6 +499,22 @@ func (s *Service) PollDeviceAuth(
 	}
 	tokens, err := authProvider.PollDeviceAuth(ctx, cfg, session)
 	if err != nil {
+		var pending deviceAuthorizationPendingError
+		if errors.As(err, &pending) {
+			updated := pending.session
+			// Keep host-owned scope and identity authoritative even if a provider
+			// accidentally copied or zeroed those fields in its pending state.
+			updated.ID = session.ID
+			updated.Provider = session.Provider
+			updated.UserID = session.UserID
+			updated.ProfileID = session.ProfileID
+			updated.UserCode = session.UserCode
+			updated.VerificationURL = session.VerificationURL
+			updated.CompletedAt = session.CompletedAt
+			if _, persistErr := s.repo.UpsertAuthSession(ctx, updated); persistErr != nil {
+				return Connection{}, errors.Join(err, fmt.Errorf("persist pending auth session: %w", persistErr))
+			}
+		}
 		return Connection{}, err
 	}
 
@@ -1520,7 +1536,7 @@ func (s *Service) exportLocalPlays(
 	_, limited := AsRateLimited(err)
 	retryable := isRetryableProviderError(err)
 	if err != nil && isWatchSyncInvalidCredentialError(err) {
-		return err
+		return errors.Join(err, s.persistConnectionError(ctx, conn, err.Error()))
 	}
 	if err != nil && !limited && !retryable {
 		var markErr error

--- a/internal/watchsync/service.go
+++ b/internal/watchsync/service.go
@@ -102,6 +102,9 @@ func (s *Service) GetConnectionStatus(ctx context.Context, userID int, profileID
 	}
 	authMethod := authMethodOf(provider)
 	credentialsConfigured := authMethod == AuthMethodAPIKey
+	if _, pluginConfig := provider.(interface{ usesHostPluginConfig() }); pluginConfig {
+		credentialsConfigured = true
+	}
 	if !credentialsConfigured {
 		cfg, _ := s.serverConfig(ctx, providerKey)
 		credentialsConfigured = cfg.Configured()
@@ -499,7 +502,7 @@ func (s *Service) PollDeviceAuth(
 		return Connection{}, err
 	}
 
-	account, err := authProvider.LookupAccount(ctx, cfg, Connection{AccessToken: tokens.AccessToken})
+	account, err := authProvider.LookupAccount(ctx, cfg, connectionWithTokens(Connection{}, tokens))
 	if err != nil {
 		return Connection{}, err
 	}
@@ -587,9 +590,7 @@ func (s *Service) persistConnection(
 	conn.Provider = providerKey
 	conn.UserID = userID
 	conn.ProfileID = profileID
-	conn.AccessToken = tokens.AccessToken
-	conn.RefreshToken = tokens.RefreshToken
-	conn.TokenExpiresAt = tokens.TokenExpiresAt
+	conn = connectionWithTokens(conn, tokens)
 	conn.ProviderAccountID = account.ID
 	conn.ProviderUsername = account.Username
 	conn.LastError = ""
@@ -1264,9 +1265,7 @@ func (s *Service) refreshConnectionIfNeeded(ctx context.Context, provider Provid
 	tokens, err := authProvider.RefreshToken(ctx, cfg, conn)
 	_, authoritative := provider.(authoritativeRefreshProvider)
 	if authoritative && strings.TrimSpace(tokens.AccessToken) != "" {
-		conn.AccessToken = tokens.AccessToken
-		conn.RefreshToken = tokens.RefreshToken
-		conn.TokenExpiresAt = tokens.TokenExpiresAt
+		conn = connectionWithTokens(conn, tokens)
 	} else if err == nil {
 		if tokens.AccessToken != "" {
 			conn.AccessToken = tokens.AccessToken
@@ -1295,6 +1294,16 @@ func (s *Service) refreshConnectionIfNeeded(ctx context.Context, provider Provid
 		return Connection{}, fmt.Errorf("refresh %s token: %w", conn.Provider, err)
 	}
 	return conn, nil
+}
+
+func connectionWithTokens(conn Connection, tokens TokenSet) Connection {
+	conn.AccessToken = tokens.AccessToken
+	conn.RefreshToken = tokens.RefreshToken
+	conn.TokenExpiresAt = tokens.TokenExpiresAt
+	conn.TokenType = tokens.TokenType
+	conn.Scopes = append([]string(nil), tokens.Scopes...)
+	conn.SecretAttributes = cloneStringMap(tokens.SecretAttributes)
+	return conn
 }
 
 type ExportWatchedResult struct {
@@ -2042,34 +2051,42 @@ func (s *Service) dispatchScrobble(ctx context.Context, scrobbler Scrobbler, cfg
 	}
 	if action == scrobbleActionStop {
 		stopSentAt := s.now()
-		if event.Completed && event.HistoryID != "" {
-			if err := s.repo.MarkHistoryExportSatisfiedByScrobble(ctx, conn.ID, event.HistoryID); err != nil {
-				slog.WarnContext(ctx, "failed to mark history export satisfied by scrobble",
-					"component", "watchsync",
-					"provider", conn.Provider,
-					"connection_id", conn.ID,
-					"history_id", event.HistoryID,
-					"error", err,
-				)
-			}
-		}
 		if confirmedClaim != nil {
-			return s.repo.CompleteConfirmedScrobbleStop(
+			if err := s.repo.CompleteConfirmedScrobbleStop(
 				ctx, event.PlaybackSessionID, conn.ID,
 				event.PositionSeconds, event.HistoryID, *confirmedClaim, stopSentAt,
-			)
-		}
-		if err := s.repo.UpdateScrobbleSession(ctx, event.PlaybackSessionID, conn.ID, action, event.PositionSeconds, event.HistoryID, "", &stopSentAt); err != nil {
+			); err != nil {
+				return err
+			}
+		} else if err := s.repo.UpdateScrobbleSession(ctx, event.PlaybackSessionID, conn.ID, action, event.PositionSeconds, event.HistoryID, "", &stopSentAt); err != nil {
 			return err
+		}
+		if event.Completed && event.HistoryID != "" {
+			return s.reconcileScrobbleHistory(ctx, ScrobbleSession{
+				PlaybackSessionID: event.PlaybackSessionID,
+				ConnectionID:      conn.ID,
+				HistoryID:         event.HistoryID,
+			})
 		}
 	}
 	return nil
 }
 
 func (s *Service) SweepOpenScrobbles(ctx context.Context) error {
+	var reconciliationErr error
+	pending, err := s.repo.ListPendingScrobbleReconciliations(ctx)
+	if err != nil {
+		reconciliationErr = err
+	} else {
+		for _, session := range pending {
+			if err := s.reconcileScrobbleHistory(ctx, session); err != nil {
+				reconciliationErr = errors.Join(reconciliationErr, err)
+			}
+		}
+	}
 	sessions, err := s.repo.ListOpenScrobbleSessions(ctx)
 	if err != nil {
-		return err
+		return errors.Join(reconciliationErr, err)
 	}
 	for _, session := range sessions {
 		conn, ok, err := s.repo.GetConnectionByID(ctx, session.ConnectionID)
@@ -2099,6 +2116,19 @@ func (s *Service) SweepOpenScrobbles(ctx context.Context) error {
 		}
 		_ = s.dispatchScrobble(ctx, scrobbler, cfg, conn, scrobbleEventFromSession(session, conn, s.now()), "stop", nil)
 	}
+	return reconciliationErr
+}
+
+func (s *Service) reconcileScrobbleHistory(ctx context.Context, session ScrobbleSession) error {
+	if session.PlaybackSessionID == "" || session.ConnectionID == "" || session.HistoryID == "" {
+		return errors.New("scrobble history reconciliation identity is incomplete")
+	}
+	if err := s.repo.MarkHistoryExportSatisfiedByScrobble(ctx, session.ConnectionID, session.HistoryID); err != nil {
+		return fmt.Errorf("mark history export satisfied by scrobble: %w", err)
+	}
+	if err := s.repo.MarkScrobbleHistoryReconciled(ctx, session.PlaybackSessionID, session.ConnectionID, s.now()); err != nil {
+		return err
+	}
 	return nil
 }
 
@@ -2127,6 +2157,9 @@ func scrobbleEventFromSession(session ScrobbleSession, conn Connection, occurred
 }
 
 func authMethodOf(provider Provider) string {
+	if provider, ok := provider.(interface{ AuthMethod() string }); ok {
+		return provider.AuthMethod()
+	}
 	if _, ok := provider.(APIKeyAuthProvider); ok {
 		return AuthMethodAPIKey
 	}
@@ -2134,6 +2167,11 @@ func authMethodOf(provider Provider) string {
 }
 
 func (s *Service) serverConfig(ctx context.Context, providerKey string) (ServerConfig, error) {
+	if provider, ok := s.registry.Get(providerKey); ok {
+		if _, pluginConfig := provider.(interface{ usesHostPluginConfig() }); pluginConfig {
+			return ServerConfig{}, nil
+		}
+	}
 	if provider, ok := s.registry.Get(providerKey); ok && authMethodOf(provider) == AuthMethodAPIKey {
 		// API-key providers carry their credential on the connection itself
 		// and don't consult server settings. Return a zero config so sync

--- a/internal/watchsync/service.go
+++ b/internal/watchsync/service.go
@@ -374,7 +374,13 @@ func (s *Service) processLocalWatchEvent(ctx context.Context, event LocalWatchEv
 				continue
 			}
 			if err := s.exportLocalPlays(ctx, conn, cfg, exporter, event.Plays); err != nil {
-				s.recordLocalWatchEventError(ctx, conn, err)
+				if limited, ok := AsRateLimited(err); ok {
+					if deferErr := s.deferRateLimitedConnection(ctx, conn, limited); deferErr != nil {
+						s.recordLocalWatchEventError(ctx, conn, errors.Join(err, deferErr))
+					}
+				} else {
+					s.recordLocalWatchEventError(ctx, conn, err)
+				}
 			}
 		case LocalWatchEventMarkedUnwatched:
 			if !provider.Capabilities().ExportUnwatched {
@@ -542,6 +548,9 @@ func (s *Service) ConnectAPIKey(
 		return Connection{}, err
 	}
 	if strings.TrimSpace(tokens.AccessToken) == "" {
+		if sourced, ok := provider.(sourcedProvider); ok && sourced.ProviderSource() == providerSourcePlugin {
+			return Connection{}, errors.New("watch sync plugin returned no access token")
+		}
 		tokens.AccessToken = apiKey
 	}
 	return s.persistConnection(ctx, providerKey, userID, profileID, tokens, account)
@@ -843,9 +852,15 @@ func (s *Service) deferRateLimitedConnection(ctx context.Context, conn Connectio
 		return err
 	}
 	retryAfter := rle.RetryAfter
-	if retryAfter <= 0 {
+	switch {
+	case retryAfter <= 0:
 		retryAfter = time.Hour
+	case retryAfter < time.Second:
+		retryAfter = time.Second
+	case retryAfter > 24*time.Hour:
+		retryAfter = 24 * time.Hour
 	}
+	rle.RetryAfter = retryAfter
 	until := s.now().Add(retryAfter)
 	lastError := fmt.Sprintf("%s; sync deferred until %s", rle.Error(), until.Format(time.RFC3339))
 	deferred := 1
@@ -1309,9 +1324,10 @@ func (s *Service) ExportWatched(
 
 	exports := reconcileHistoryExports(conn.ID, local, remote)
 	for _, export := range exports {
-		if export.Status == "remote_present" {
+		switch export.Status {
+		case historyExportStatusRemotePresent:
 			result.RemotePresent++
-		} else if export.Status == "pending" {
+		case historyExportStatusPending:
 			result.Queued++
 		}
 	}
@@ -1337,7 +1353,7 @@ func (s *Service) ExportWatched(
 		for _, export := range pending {
 			play, ok := localByHistoryID[export.HistoryID]
 			if !ok {
-				if err := s.repo.MarkHistoryExportStatus(ctx, export.ID, "not_found", "local history entry not found"); err != nil {
+				if err := s.repo.MarkHistoryExportStatus(ctx, export.ID, historyExportStatusNotFound, "local history entry not found"); err != nil {
 					return result, err
 				}
 				progressed = true
@@ -1349,26 +1365,30 @@ func (s *Service) ExportWatched(
 		if len(pendingPlays) == 0 {
 			continue
 		}
+		pendingPlays, singleBatch := limitWatchedExportBatch(exporter, pendingPlays)
 		exportResult, err := exporter.ExportHistory(ctx, cfg, conn, pendingPlays)
-		if err != nil {
-			// Rate-limited plays are not failures: leave them pending so the
-			// next run (after the deferral) retries without churning state.
-			if _, limited := AsRateLimited(err); limited {
-				return result, err
+		_, limited := AsRateLimited(err)
+		retryable := isRetryableProviderError(err)
+		if err != nil && !limited && !retryable {
+			for _, play := range pendingPlays {
+				export := exportByHistoryID[play.HistoryID]
+				if export.ID != "" {
+					_ = s.repo.MarkHistoryExportStatus(ctx, export.ID, historyExportStatusFailed, err.Error())
+				}
 			}
-			for _, export := range pending {
-				_ = s.repo.MarkHistoryExportStatus(ctx, export.ID, "failed", err.Error())
-			}
-			result.Failed += len(pending)
+			result.Failed += len(pendingPlays)
 			return result, err
 		}
+		// Commit per-event outcomes even when the provider also returned a
+		// connection-wide rate limit so successfully applied events are not
+		// retried after the deferral.
 		for _, historyID := range exportResult.Sent {
 			export := exportByHistoryID[historyID]
 			if export.ID == "" {
 				continue
 			}
-			if err := s.repo.MarkHistoryExportStatus(ctx, export.ID, "sent", ""); err != nil {
-				return result, err
+			if markErr := s.repo.MarkHistoryExportStatus(ctx, export.ID, historyExportStatusSent, ""); markErr != nil {
+				return result, markErr
 			}
 			result.Sent++
 			progressed = true
@@ -1378,8 +1398,8 @@ func (s *Service) ExportWatched(
 			if export.ID == "" {
 				continue
 			}
-			if err := s.repo.MarkHistoryExportStatus(ctx, export.ID, "not_found", "provider item not found"); err != nil {
-				return result, err
+			if markErr := s.repo.MarkHistoryExportStatus(ctx, export.ID, historyExportStatusNotFound, "provider item not found"); markErr != nil {
+				return result, markErr
 			}
 			progressed = true
 		}
@@ -1388,13 +1408,17 @@ func (s *Service) ExportWatched(
 			if export.ID == "" {
 				continue
 			}
-			if err := s.repo.MarkHistoryExportStatus(ctx, export.ID, "failed", message); err != nil {
-				return result, err
+			if markErr := s.repo.MarkHistoryExportStatus(ctx, export.ID, historyExportStatusFailed, message); markErr != nil {
+				return result, markErr
 			}
 			result.Failed++
 			progressed = true
 		}
-		if !progressed {
+		if limited || retryable {
+			// Leave unmentioned events pending for a later retry.
+			return result, err
+		}
+		if !progressed || singleBatch {
 			break
 		}
 	}
@@ -1426,7 +1450,7 @@ func (s *Service) exportLocalPlays(
 			MediaItemID:     play.MediaItemID,
 			WatchedAt:       play.WatchedAt,
 			ProviderItemKey: play.ProviderItemKey,
-			Status:          "pending",
+			Status:          historyExportStatusPending,
 		})
 	}
 	if len(exports) == 0 {
@@ -1456,14 +1480,16 @@ func (s *Service) exportLocalPlays(
 	if len(pendingPlays) == 0 {
 		return nil
 	}
+	pendingPlays, _ = limitWatchedExportBatch(exporter, pendingPlays)
 	exportResult, err := exporter.ExportHistory(ctx, cfg, conn, pendingPlays)
-	if err != nil {
-		// Leave rate-limited plays pending; the next scheduled sync retries.
-		if _, limited := AsRateLimited(err); limited {
-			return err
-		}
-		for _, export := range exportByHistoryID {
-			_ = s.repo.MarkHistoryExportStatus(ctx, export.ID, "failed", err.Error())
+	_, limited := AsRateLimited(err)
+	retryable := isRetryableProviderError(err)
+	if err != nil && !limited && !retryable {
+		for _, play := range pendingPlays {
+			export := exportByHistoryID[play.HistoryID]
+			if export.ID != "" {
+				_ = s.repo.MarkHistoryExportStatus(ctx, export.ID, historyExportStatusFailed, err.Error())
+			}
 		}
 		return err
 	}
@@ -1472,8 +1498,8 @@ func (s *Service) exportLocalPlays(
 		if export.ID == "" {
 			continue
 		}
-		if err := s.repo.MarkHistoryExportStatus(ctx, export.ID, "sent", ""); err != nil {
-			return err
+		if markErr := s.repo.MarkHistoryExportStatus(ctx, export.ID, historyExportStatusSent, ""); markErr != nil {
+			return markErr
 		}
 	}
 	for _, historyID := range exportResult.NotFound {
@@ -1481,8 +1507,8 @@ func (s *Service) exportLocalPlays(
 		if export.ID == "" {
 			continue
 		}
-		if err := s.repo.MarkHistoryExportStatus(ctx, export.ID, "not_found", "provider item not found"); err != nil {
-			return err
+		if markErr := s.repo.MarkHistoryExportStatus(ctx, export.ID, historyExportStatusNotFound, "provider item not found"); markErr != nil {
+			return markErr
 		}
 	}
 	for historyID, message := range exportResult.Failed {
@@ -1490,9 +1516,12 @@ func (s *Service) exportLocalPlays(
 		if export.ID == "" {
 			continue
 		}
-		if err := s.repo.MarkHistoryExportStatus(ctx, export.ID, "failed", message); err != nil {
-			return err
+		if markErr := s.repo.MarkHistoryExportStatus(ctx, export.ID, historyExportStatusFailed, message); markErr != nil {
+			return markErr
 		}
+	}
+	if limited || retryable {
+		return err
 	}
 	now := s.now()
 	conn.LastOutboundSyncAt = &now
@@ -1503,6 +1532,21 @@ func (s *Service) exportLocalPlays(
 	return nil
 }
 
+func limitWatchedExportBatch(exporter WatchedExporter, plays []LocalPlay) ([]LocalPlay, bool) {
+	bounded, ok := exporter.(singleBatchWatchedExporter)
+	if !ok {
+		return plays, false
+	}
+	limit := bounded.ExportBatchSize()
+	if limit <= 0 {
+		limit = 1
+	}
+	if len(plays) > limit {
+		plays = plays[:limit]
+	}
+	return plays, true
+}
+
 func reconcileHistoryExports(connectionID string, local []LocalPlay, remote []RemotePlay) []HistoryExport {
 	remoteExact := make(map[string]struct{}, len(remote))
 	for _, play := range remote {
@@ -1510,9 +1554,9 @@ func reconcileHistoryExports(connectionID string, local []LocalPlay, remote []Re
 	}
 	exports := make([]HistoryExport, 0, len(local))
 	for _, play := range local {
-		status := "pending"
+		status := historyExportStatusPending
 		if _, ok := remoteExact[remotePlayKey(play.ProviderItemKey, play.WatchedAt)]; ok {
-			status = "remote_present"
+			status = historyExportStatusRemotePresent
 		}
 		exports = append(exports, HistoryExport{
 			ConnectionID:    connectionID,
@@ -1683,6 +1727,8 @@ func parseInt(value string) int {
 	return parsed
 }
 
+const scrobbleActionStop = "stop"
+
 func (s *Service) ScrobbleStart(ctx context.Context, event ScrobbleEvent) error {
 	return s.scrobble(ctx, event, "start", false)
 }
@@ -1692,7 +1738,7 @@ func (s *Service) ScrobblePause(ctx context.Context, event ScrobbleEvent) error 
 }
 
 func (s *Service) ScrobbleStop(ctx context.Context, event ScrobbleEvent) error {
-	return s.scrobble(ctx, event, "stop", false)
+	return s.scrobble(ctx, event, scrobbleActionStop, false)
 }
 
 // ScrobbleStopConfirmed waits for each provider dispatch and reports provider
@@ -1753,6 +1799,19 @@ func (s *Service) scrobble(ctx context.Context, event ScrobbleEvent, action stri
 				return err
 			}
 		}
+		// Persist completed playback before provider I/O. Immediate scrobbling
+		// remains the low-latency path; the normal history-export reconciliation
+		// retries this desired state after crashes, plugin downtime, or uncertain
+		// upstream outcomes.
+		if action == scrobbleActionStop && event.Completed && provider.Capabilities().ExportWatched {
+			if err := s.persistCompletedScrobbleExport(ctx, conn, event); err != nil {
+				if confirm {
+					dispatchErrors = append(dispatchErrors, err)
+					continue
+				}
+				return err
+			}
+		}
 		if confirm {
 			confirmedTargets = append(confirmedTargets, confirmedScrobbleTarget{
 				provider: provider, scrobbler: scrobbler, connection: conn,
@@ -1793,6 +1852,38 @@ func (s *Service) scrobble(ctx context.Context, event ScrobbleEvent, action stri
 		}
 	}
 	return errors.Join(dispatchErrors...)
+}
+
+func (s *Service) persistCompletedScrobbleExport(ctx context.Context, conn Connection, event ScrobbleEvent) error {
+	if event.HistoryID == "" {
+		return nil
+	}
+	providerItemKey := event.ProviderItemKey
+	if providerItemKey == "" {
+		providerItemKey = providerItemKeyForLocalPlay(LocalPlay{
+			MediaItemID:   event.MediaItemID,
+			Kind:          event.Kind,
+			IMDbID:        event.IMDbID,
+			TMDBID:        event.TMDBID,
+			TVDBID:        event.TVDBID,
+			SeriesIMDbID:  event.SeriesIMDbID,
+			SeriesTMDBID:  event.SeriesTMDBID,
+			SeriesTVDBID:  event.SeriesTVDBID,
+			SeasonNumber:  event.SeasonNumber,
+			EpisodeNumber: event.EpisodeNumber,
+		})
+	}
+	if providerItemKey == "" {
+		return nil
+	}
+	return s.repo.UpsertHistoryExports(ctx, []HistoryExport{{
+		ConnectionID:    conn.ID,
+		HistoryID:       event.HistoryID,
+		MediaItemID:     event.MediaItemID,
+		WatchedAt:       event.OccurredAt,
+		ProviderItemKey: providerItemKey,
+		Status:          historyExportStatusPending,
+	}})
 }
 
 func (s *Service) dispatchScrobbleAsync(scrobbler Scrobbler, cfg ServerConfig, conn Connection, event ScrobbleEvent, action string) {
@@ -1879,12 +1970,17 @@ func (s *Service) dispatchScrobble(ctx context.Context, scrobbler Scrobbler, cfg
 	switch action {
 	case "pause":
 		err = scrobbler.Pause(ctx, cfg, conn, event)
-	case "stop":
+	case scrobbleActionStop:
 		err = scrobbler.Stop(ctx, cfg, conn, event)
 	default:
 		err = scrobbler.Start(ctx, cfg, conn, event)
 	}
 	if err != nil {
+		if limited, ok := AsRateLimited(err); ok {
+			if deferErr := s.deferRateLimitedConnection(ctx, conn, limited); deferErr != nil {
+				err = errors.Join(err, deferErr)
+			}
+		}
 		if confirmedClaim != nil {
 			_ = s.repo.FailConfirmedScrobbleStop(
 				ctx, event.PlaybackSessionID, conn.ID,
@@ -1895,8 +1991,19 @@ func (s *Service) dispatchScrobble(ctx context.Context, scrobbler Scrobbler, cfg
 		}
 		return err
 	}
-	if action == "stop" {
+	if action == scrobbleActionStop {
 		stopSentAt := s.now()
+		if event.Completed && event.HistoryID != "" {
+			if err := s.repo.MarkHistoryExportSatisfiedByScrobble(ctx, conn.ID, event.HistoryID); err != nil {
+				slog.WarnContext(ctx, "failed to mark history export satisfied by scrobble",
+					"component", "watchsync",
+					"provider", conn.Provider,
+					"connection_id", conn.ID,
+					"history_id", event.HistoryID,
+					"error", err,
+				)
+			}
+		}
 		if confirmedClaim != nil {
 			return s.repo.CompleteConfirmedScrobbleStop(
 				ctx, event.PlaybackSessionID, conn.ID,

--- a/internal/watchsync/service.go
+++ b/internal/watchsync/service.go
@@ -592,6 +592,7 @@ func (s *Service) persistConnection(
 	conn.TokenExpiresAt = tokens.TokenExpiresAt
 	conn.ProviderAccountID = account.ID
 	conn.ProviderUsername = account.Username
+	conn.LastError = ""
 
 	return s.repo.UpsertConnection(ctx, conn)
 }
@@ -1261,20 +1262,39 @@ func (s *Service) refreshConnectionIfNeeded(ctx context.Context, provider Provid
 		return Connection{}, fmt.Errorf("provider %q does not support token refresh", conn.Provider)
 	}
 	tokens, err := authProvider.RefreshToken(ctx, cfg, conn)
+	_, authoritative := provider.(authoritativeRefreshProvider)
+	if authoritative && strings.TrimSpace(tokens.AccessToken) != "" {
+		conn.AccessToken = tokens.AccessToken
+		conn.RefreshToken = tokens.RefreshToken
+		conn.TokenExpiresAt = tokens.TokenExpiresAt
+	} else if err == nil {
+		if tokens.AccessToken != "" {
+			conn.AccessToken = tokens.AccessToken
+		}
+		if tokens.RefreshToken != "" {
+			conn.RefreshToken = tokens.RefreshToken
+		}
+		if tokens.TokenExpiresAt != nil {
+			conn.TokenExpiresAt = tokens.TokenExpiresAt
+		}
+	}
+	if err != nil && isWatchSyncInvalidCredentialError(err) {
+		conn.LastError = err.Error()
+	} else if err == nil {
+		conn.LastError = ""
+	}
+	credentialsReturned := authoritative && strings.TrimSpace(tokens.AccessToken) != ""
+	if err == nil || credentialsReturned || isWatchSyncInvalidCredentialError(err) {
+		persisted, persistErr := s.repo.UpsertConnection(ctx, conn)
+		if persistErr != nil {
+			return Connection{}, fmt.Errorf("persist refreshed %s connection: %w", conn.Provider, persistErr)
+		}
+		conn = persisted
+	}
 	if err != nil {
 		return Connection{}, fmt.Errorf("refresh %s token: %w", conn.Provider, err)
 	}
-	if tokens.AccessToken != "" {
-		conn.AccessToken = tokens.AccessToken
-	}
-	if tokens.RefreshToken != "" {
-		conn.RefreshToken = tokens.RefreshToken
-	}
-	if tokens.TokenExpiresAt != nil {
-		conn.TokenExpiresAt = tokens.TokenExpiresAt
-	}
-	conn.LastError = ""
-	return s.repo.UpsertConnection(ctx, conn)
+	return conn, nil
 }
 
 type ExportWatchedResult struct {
@@ -1369,6 +1389,9 @@ func (s *Service) ExportWatched(
 		exportResult, err := exporter.ExportHistory(ctx, cfg, conn, pendingPlays)
 		_, limited := AsRateLimited(err)
 		retryable := isRetryableProviderError(err)
+		if err != nil && isWatchSyncInvalidCredentialError(err) {
+			return result, errors.Join(err, s.persistConnectionError(ctx, conn, err.Error()))
+		}
 		if err != nil && !limited && !retryable {
 			var markErr error
 			for _, play := range pendingPlays {
@@ -1487,6 +1510,9 @@ func (s *Service) exportLocalPlays(
 	exportResult, err := exporter.ExportHistory(ctx, cfg, conn, pendingPlays)
 	_, limited := AsRateLimited(err)
 	retryable := isRetryableProviderError(err)
+	if err != nil && isWatchSyncInvalidCredentialError(err) {
+		return err
+	}
 	if err != nil && !limited && !retryable {
 		var markErr error
 		for _, play := range pendingPlays {
@@ -1536,6 +1562,19 @@ func (s *Service) exportLocalPlays(
 		return err
 	}
 	return nil
+}
+
+func (s *Service) persistConnectionError(ctx context.Context, conn Connection, message string) error {
+	if conn.ID != "" {
+		fresh, err := s.reloadConnection(ctx, conn)
+		if err != nil {
+			return err
+		}
+		conn = fresh
+	}
+	conn.LastError = message
+	_, err := s.repo.UpsertConnection(ctx, conn)
+	return err
 }
 
 func limitWatchedExportBatch(exporter WatchedExporter, plays []LocalPlay) ([]LocalPlay, bool) {
@@ -1987,6 +2026,10 @@ func (s *Service) dispatchScrobble(ctx context.Context, scrobbler Scrobbler, cfg
 				err = errors.Join(err, deferErr)
 			}
 		}
+		var persistErr error
+		if isWatchSyncInvalidCredentialError(err) {
+			persistErr = s.persistConnectionError(ctx, conn, err.Error())
+		}
 		if confirmedClaim != nil {
 			_ = s.repo.FailConfirmedScrobbleStop(
 				ctx, event.PlaybackSessionID, conn.ID,
@@ -1995,7 +2038,7 @@ func (s *Service) dispatchScrobble(ctx context.Context, scrobbler Scrobbler, cfg
 		} else {
 			_ = s.repo.UpdateScrobbleSession(ctx, event.PlaybackSessionID, conn.ID, action, event.PositionSeconds, event.HistoryID, err.Error(), nil)
 		}
-		return err
+		return errors.Join(err, persistErr)
 	}
 	if action == scrobbleActionStop {
 		stopSentAt := s.now()

--- a/internal/watchsync/service.go
+++ b/internal/watchsync/service.go
@@ -1370,14 +1370,17 @@ func (s *Service) ExportWatched(
 		_, limited := AsRateLimited(err)
 		retryable := isRetryableProviderError(err)
 		if err != nil && !limited && !retryable {
+			var markErr error
 			for _, play := range pendingPlays {
 				export := exportByHistoryID[play.HistoryID]
 				if export.ID != "" {
-					_ = s.repo.MarkHistoryExportStatus(ctx, export.ID, historyExportStatusFailed, err.Error())
+					if statusErr := s.repo.MarkHistoryExportStatus(ctx, export.ID, historyExportStatusFailed, err.Error()); statusErr != nil {
+						markErr = errors.Join(markErr, statusErr)
+					}
 				}
 			}
 			result.Failed += len(pendingPlays)
-			return result, err
+			return result, errors.Join(err, markErr)
 		}
 		// Commit per-event outcomes even when the provider also returned a
 		// connection-wide rate limit so successfully applied events are not
@@ -1485,13 +1488,16 @@ func (s *Service) exportLocalPlays(
 	_, limited := AsRateLimited(err)
 	retryable := isRetryableProviderError(err)
 	if err != nil && !limited && !retryable {
+		var markErr error
 		for _, play := range pendingPlays {
 			export := exportByHistoryID[play.HistoryID]
 			if export.ID != "" {
-				_ = s.repo.MarkHistoryExportStatus(ctx, export.ID, historyExportStatusFailed, err.Error())
+				if statusErr := s.repo.MarkHistoryExportStatus(ctx, export.ID, historyExportStatusFailed, err.Error()); statusErr != nil {
+					markErr = errors.Join(markErr, statusErr)
+				}
 			}
 		}
-		return err
+		return errors.Join(err, markErr)
 	}
 	for _, historyID := range exportResult.Sent {
 		export := exportByHistoryID[historyID]

--- a/internal/watchsync/service_test.go
+++ b/internal/watchsync/service_test.go
@@ -11,6 +11,7 @@ import (
 	"testing"
 	"time"
 
+	pluginv1 "github.com/Silo-Server/silo-plugin-sdk/pkg/pluginproto/silo/plugin/v1"
 	"github.com/Silo-Server/silo-server/internal/historyimport"
 	"github.com/Silo-Server/silo-server/internal/userdb"
 	"github.com/Silo-Server/silo-server/internal/userstore"
@@ -283,7 +284,7 @@ func (r *serviceFakeRepo) UpsertHistoryExports(_ context.Context, exports []Hist
 				existing := r.historyExports[i]
 				export.ID = existing.ID
 				export.AttemptCount = existing.AttemptCount
-				if existing.Status == historyExportStatusSent || existing.Status == historyExportStatusSatisfiedByScrobble || existing.AttemptCount >= 5 {
+				if existing.Status == historyExportStatusSent || existing.Status == historyExportStatusSatisfiedByScrobble || existing.Status == historyExportStatusNotFound || existing.AttemptCount >= 5 {
 					export.Status = existing.Status
 				}
 				r.historyExports[i] = export
@@ -318,7 +319,7 @@ func (r *serviceFakeRepo) MarkHistoryExportStatus(_ context.Context, id string, 
 	}
 	for i := range r.historyExports {
 		if r.historyExports[i].ID == id {
-			if r.historyExports[i].Status == historyExportStatusSent || r.historyExports[i].Status == historyExportStatusSatisfiedByScrobble {
+			if r.historyExports[i].Status == historyExportStatusSent || r.historyExports[i].Status == historyExportStatusSatisfiedByScrobble || r.historyExports[i].Status == historyExportStatusNotFound {
 				return nil
 			}
 			r.historyExports[i].Status = status
@@ -336,7 +337,7 @@ func (r *serviceFakeRepo) MarkHistoryExportSatisfiedByScrobble(_ context.Context
 	}
 	for i := range r.historyExports {
 		if r.historyExports[i].ConnectionID == connectionID && r.historyExports[i].HistoryID == historyID {
-			if r.historyExports[i].Status == historyExportStatusSent {
+			if r.historyExports[i].Status == historyExportStatusSent || r.historyExports[i].Status == historyExportStatusNotFound {
 				return nil
 			}
 			r.historyExports[i].Status = historyExportStatusSatisfiedByScrobble
@@ -1428,6 +1429,43 @@ func TestServiceSyncConnectionRefreshesExpiredToken(t *testing.T) {
 	}
 	if updated.TokenExpiresAt == nil || !updated.TokenExpiresAt.Equal(refreshedExpiresAt) {
 		t.Fatalf("token expiry = %v, want %v", updated.TokenExpiresAt, refreshedExpiresAt)
+	}
+}
+
+func TestServicePluginRefreshPersistsAuthoritativeCredentialsBeforeFault(t *testing.T) {
+	repo := newServiceFakeRepo()
+	now := time.Date(2026, 7, 28, 12, 0, 0, 0, time.UTC)
+	expiresAt := now.Add(-time.Minute)
+	client := &fakeWatchSyncPluginClient{refreshResponse: &pluginv1.WatchSyncCredentialResponse{
+		Credentials: &pluginv1.WatchSyncCredentials{AccessToken: "rotated-access", TokenType: "Bearer"},
+		Fault: &pluginv1.WatchSyncFault{
+			Code:        pluginv1.WatchSyncFaultCode_WATCH_SYNC_FAULT_CODE_INVALID_CREDENTIAL,
+			SafeMessage: "reconnect required",
+		},
+	}}
+	provider := testPluginProvider(t, client)
+	service := NewService(repo, NewRegistry())
+	service.now = func() time.Time { return now }
+	conn := Connection{
+		ID:             "conn-1",
+		Provider:       provider.Key(),
+		UserID:         7,
+		ProfileID:      "profile-1",
+		AccessToken:    "old-access",
+		RefreshToken:   "old-refresh",
+		TokenExpiresAt: &expiresAt,
+	}
+	repo.connections[connectionKey(conn.Provider, conn.UserID, conn.ProfileID)] = conn
+
+	if _, err := service.refreshConnectionIfNeeded(context.Background(), provider, ServerConfig{}, conn); !isWatchSyncInvalidCredentialError(err) {
+		t.Fatalf("error = %#v", err)
+	}
+	updated := repo.connections[connectionKey(conn.Provider, conn.UserID, conn.ProfileID)]
+	if updated.AccessToken != "rotated-access" || updated.RefreshToken != "" || updated.TokenExpiresAt != nil {
+		t.Fatalf("connection credentials = %#v", updated)
+	}
+	if updated.LastError != "reconnect required" {
+		t.Fatalf("LastError = %q", updated.LastError)
 	}
 }
 
@@ -2799,6 +2837,35 @@ func TestServicePluginAPIKeyConnectRejectsEmptyReturnedCredential(t *testing.T) 
 	}
 }
 
+func TestServicePluginAPIKeyReconnectClearsConnectionError(t *testing.T) {
+	repo := newServiceFakeRepo()
+	client := &fakeWatchSyncPluginClient{exchangeResponse: &pluginv1.WatchSyncCredentialResponse{
+		Credentials: &pluginv1.WatchSyncCredentials{AccessToken: "new-access", TokenType: "Bearer"},
+		Account:     &pluginv1.WatchSyncAccount{ExternalSubject: "account-1", Username: "alice"},
+	}}
+	provider := testPluginProvider(t, client)
+	registry := NewRegistry()
+	if err := registry.Register(provider); err != nil {
+		t.Fatal(err)
+	}
+	conn := Connection{
+		ID:        "conn-1",
+		Provider:  provider.Key(),
+		UserID:    7,
+		ProfileID: "profile-1",
+		LastError: "reconnect required",
+	}
+	repo.connections[connectionKey(conn.Provider, conn.UserID, conn.ProfileID)] = conn
+
+	updated, err := NewService(repo, registry).ConnectAPIKey(context.Background(), conn.UserID, conn.ProfileID, provider.Key(), "replacement-key")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if updated.AccessToken != "new-access" || updated.LastError != "" {
+		t.Fatalf("connection = %#v", updated)
+	}
+}
+
 func TestServiceSyncConnectionDefersOnRateLimit(t *testing.T) {
 	db, err := sql.Open("sqlite3", ":memory:")
 	if err != nil {
@@ -2924,6 +2991,52 @@ func TestServicePluginTransportFailureLeavesExportPending(t *testing.T) {
 	}
 }
 
+func TestServicePluginInvalidCredentialLeavesExportPendingAndRecordsConnectionError(t *testing.T) {
+	repo := newServiceFakeRepo()
+	client := &fakeWatchSyncPluginClient{applyResponse: &pluginv1.WatchSyncApplyEventsResponse{
+		Fault: &pluginv1.WatchSyncFault{
+			Code:        pluginv1.WatchSyncFaultCode_WATCH_SYNC_FAULT_CODE_INVALID_CREDENTIAL,
+			SafeMessage: "credential revoked",
+		},
+	}}
+	provider := testPluginProvider(t, client)
+	registry := NewRegistry()
+	if err := registry.Register(provider); err != nil {
+		t.Fatal(err)
+	}
+	service := NewService(repo, registry)
+	conn := Connection{
+		ID:                   "conn-1",
+		Provider:             provider.Key(),
+		UserID:               7,
+		ProfileID:            "profile-1",
+		AccessToken:          "secret",
+		ExportWatchedEnabled: true,
+	}
+	repo.connections[connectionKey(conn.Provider, conn.UserID, conn.ProfileID)] = conn
+	err := service.processLocalWatchEvent(context.Background(), LocalWatchEvent{
+		Kind:      LocalWatchEventMarkedWatched,
+		UserID:    conn.UserID,
+		ProfileID: conn.ProfileID,
+		Plays: []LocalPlay{{
+			HistoryID:       "history-1",
+			MediaItemID:     "movie-1",
+			ProviderItemKey: "movie:tmdb:603",
+			Kind:            historyimport.KindMovie,
+		}},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(repo.historyExports) != 1 || repo.historyExports[0].Status != historyExportStatusPending || repo.historyExports[0].AttemptCount != 0 {
+		t.Fatalf("history exports = %#v", repo.historyExports)
+	}
+	updated := repo.connections[connectionKey(conn.Provider, conn.UserID, conn.ProfileID)]
+	if updated.LastError != "credential revoked" {
+		t.Fatalf("LastError = %q", updated.LastError)
+	}
+}
+
 func TestServiceExportLocalPlaysReturnsStatusPersistenceFailure(t *testing.T) {
 	repo := newServiceFakeRepo()
 	repo.markHistoryStatusErr = errors.New("persist failed")
@@ -2963,6 +3076,32 @@ func TestServiceFakeRepoMarkHistoryExportSatisfiedByScrobbleSkipsSent(t *testing
 	}
 }
 
+func TestServiceFakeRepoPreservesNotFoundHistoryExport(t *testing.T) {
+	repo := newServiceFakeRepo()
+	repo.historyExports = []HistoryExport{{
+		ID:           "export-1",
+		ConnectionID: "conn-1",
+		HistoryID:    "history-1",
+		Status:       historyExportStatusNotFound,
+	}}
+	if err := repo.UpsertHistoryExports(context.Background(), []HistoryExport{{
+		ConnectionID: "conn-1",
+		HistoryID:    "history-1",
+		Status:       historyExportStatusPending,
+	}}); err != nil {
+		t.Fatal(err)
+	}
+	if err := repo.MarkHistoryExportStatus(context.Background(), "export-1", historyExportStatusFailed, "retry"); err != nil {
+		t.Fatal(err)
+	}
+	if err := repo.MarkHistoryExportSatisfiedByScrobble(context.Background(), "conn-1", "history-1"); err != nil {
+		t.Fatal(err)
+	}
+	if repo.historyExports[0].Status != historyExportStatusNotFound || repo.historyExports[0].AttemptCount != 0 {
+		t.Fatalf("history exports = %#v", repo.historyExports)
+	}
+}
+
 func TestServiceScrobbleRateLimitDefersConnection(t *testing.T) {
 	repo := newServiceFakeRepo()
 	now := time.Date(2026, 7, 24, 12, 0, 0, 0, time.UTC)
@@ -2991,6 +3130,33 @@ func TestServiceScrobbleRateLimitDefersConnection(t *testing.T) {
 	wantUntil := now.Add(30 * time.Minute)
 	if updated.RateLimitedUntil == nil || !updated.RateLimitedUntil.Equal(wantUntil) {
 		t.Fatalf("RateLimitedUntil = %v, want %v", updated.RateLimitedUntil, wantUntil)
+	}
+}
+
+func TestServiceScrobbleInvalidCredentialRecordsConnectionError(t *testing.T) {
+	repo := newServiceFakeRepo()
+	service := NewService(repo, NewRegistry())
+	conn := Connection{
+		ID:        "conn-1",
+		Provider:  "plugin:15:probe",
+		UserID:    7,
+		ProfileID: "profile-1",
+	}
+	repo.connections[connectionKey(conn.Provider, conn.UserID, conn.ProfileID)] = conn
+	fault := watchSyncProviderFaultError{
+		code:    pluginv1.WatchSyncFaultCode_WATCH_SYNC_FAULT_CODE_INVALID_CREDENTIAL,
+		message: "reconnect required",
+	}
+	err := service.dispatchScrobble(
+		context.Background(), scrobblerStub{stopErr: fault}, ServerConfig{}, conn,
+		ScrobbleEvent{PlaybackSessionID: testPlaybackSessionID}, scrobbleActionStop, nil,
+	)
+	if !isWatchSyncInvalidCredentialError(err) {
+		t.Fatalf("error = %#v", err)
+	}
+	updated := repo.connections[connectionKey(conn.Provider, conn.UserID, conn.ProfileID)]
+	if updated.LastError != fault.Error() {
+		t.Fatalf("LastError = %q, want %q", updated.LastError, fault.Error())
 	}
 }
 

--- a/internal/watchsync/service_test.go
+++ b/internal/watchsync/service_test.go
@@ -16,6 +16,8 @@ import (
 	"github.com/Silo-Server/silo-server/internal/userstore"
 )
 
+const testProviderAccountID = "account-1"
+
 type serviceFakeRepo struct {
 	connections         map[string]Connection
 	dueConnections      []Connection
@@ -30,6 +32,7 @@ type serviceFakeRepo struct {
 	reopenedScrobbles   []scrobbleUpdate
 	confirmedScrobbles  map[string]bool
 	confirmingScrobbles map[string]time.Time
+	markSatisfiedErr    error
 	scrobbleMu          sync.Mutex
 }
 
@@ -234,6 +237,9 @@ func (r *serviceFakeRepo) ListLocalWatchEventConnections(_ context.Context, user
 		if conn.UserID != userID || conn.ProfileID != profileID {
 			continue
 		}
+		if conn.RateLimitedUntil != nil && conn.RateLimitedUntil.After(time.Now()) {
+			continue
+		}
 		switch kind {
 		case LocalWatchEventMarkedWatched:
 			if conn.ExportWatchedEnabled {
@@ -273,7 +279,12 @@ func (r *serviceFakeRepo) UpsertHistoryExports(_ context.Context, exports []Hist
 		replaced := false
 		for i := range r.historyExports {
 			if r.historyExports[i].HistoryID == export.HistoryID && r.historyExports[i].ConnectionID == export.ConnectionID {
-				export.ID = r.historyExports[i].ID
+				existing := r.historyExports[i]
+				export.ID = existing.ID
+				export.AttemptCount = existing.AttemptCount
+				if existing.Status == historyExportStatusSent || existing.Status == historyExportStatusSatisfiedByScrobble || existing.AttemptCount >= 5 {
+					export.Status = existing.Status
+				}
 				r.historyExports[i] = export
 				replaced = true
 				break
@@ -289,7 +300,8 @@ func (r *serviceFakeRepo) UpsertHistoryExports(_ context.Context, exports []Hist
 func (r *serviceFakeRepo) ListPendingHistoryExports(_ context.Context, connectionID string, limit int) ([]HistoryExport, error) {
 	var exports []HistoryExport
 	for _, export := range r.historyExports {
-		if export.ConnectionID == connectionID && export.Status == "pending" {
+		if export.ConnectionID == connectionID &&
+			(export.Status == historyExportStatusPending || export.Status == historyExportStatusFailed) && export.AttemptCount < 5 {
 			exports = append(exports, export)
 			if limit > 0 && len(exports) >= limit {
 				break
@@ -302,8 +314,25 @@ func (r *serviceFakeRepo) ListPendingHistoryExports(_ context.Context, connectio
 func (r *serviceFakeRepo) MarkHistoryExportStatus(_ context.Context, id string, status string, lastError string) error {
 	for i := range r.historyExports {
 		if r.historyExports[i].ID == id {
+			if r.historyExports[i].Status == historyExportStatusSent || r.historyExports[i].Status == historyExportStatusSatisfiedByScrobble {
+				return nil
+			}
 			r.historyExports[i].Status = status
+			r.historyExports[i].AttemptCount++
 			r.historyExports[i].LastError = lastError
+			return nil
+		}
+	}
+	return nil
+}
+
+func (r *serviceFakeRepo) MarkHistoryExportSatisfiedByScrobble(_ context.Context, connectionID string, historyID string) error {
+	if r.markSatisfiedErr != nil {
+		return r.markSatisfiedErr
+	}
+	for i := range r.historyExports {
+		if r.historyExports[i].ConnectionID == connectionID && r.historyExports[i].HistoryID == historyID {
+			r.historyExports[i].Status = historyExportStatusSatisfiedByScrobble
 			return nil
 		}
 	}
@@ -421,6 +450,9 @@ func (r *serviceFakeRepo) MarkListItemError(_ context.Context, connectionID stri
 func (r *serviceFakeRepo) ListScrobbleConnections(_ context.Context, _ int, _ string) ([]Connection, error) {
 	conns := make([]Connection, 0, len(r.scrobbleConnections))
 	for _, conn := range r.scrobbleConnections {
+		if conn.RateLimitedUntil != nil && conn.RateLimitedUntil.After(time.Now()) {
+			continue
+		}
 		conns = append(conns, cloneConnectionForTest(conn))
 	}
 	return conns, nil
@@ -589,6 +621,20 @@ func (p *authProviderStub) LookupAccount(
 	return ProviderAccount{ID: "trakt-user-1", Username: "alex"}, nil
 }
 
+type emptyPluginAPIKeyProvider struct{}
+
+func (emptyPluginAPIKeyProvider) Key() string { return "plugin:1:tracker" }
+
+func (emptyPluginAPIKeyProvider) DisplayName() string { return "Tracker" }
+
+func (emptyPluginAPIKeyProvider) Capabilities() Capabilities { return Capabilities{} }
+
+func (emptyPluginAPIKeyProvider) ProviderSource() string { return providerSourcePlugin }
+
+func (emptyPluginAPIKeyProvider) ConnectWithAPIKey(context.Context, string) (TokenSet, ProviderAccount, error) {
+	return TokenSet{}, ProviderAccount{ID: testProviderAccountID}, nil
+}
+
 type watchedImporterStub struct {
 	key    string
 	source userstore.WatchHistorySource
@@ -648,9 +694,10 @@ func (p progressBatchImporterStub) FetchProgressBatch(context.Context, ServerCon
 }
 
 type watchedExporterStub struct {
-	exportErr error
-	key       string
-	source    userstore.WatchHistorySource
+	exportErr    error
+	exportResult ExportResult
+	key          string
+	source       userstore.WatchHistorySource
 }
 
 func (p watchedExporterStub) Key() string {
@@ -673,10 +720,7 @@ func (p watchedExporterStub) FetchHistory(context.Context, ServerConfig, Connect
 }
 
 func (p watchedExporterStub) ExportHistory(context.Context, ServerConfig, Connection, []LocalPlay) (ExportResult, error) {
-	if p.exportErr != nil {
-		return ExportResult{}, p.exportErr
-	}
-	return ExportResult{}, nil
+	return p.exportResult, p.exportErr
 }
 
 func (p watchedExporterStub) HistorySource() userstore.WatchHistorySource {
@@ -769,6 +813,12 @@ func (p scrobblerStub) DisplayName() string {
 
 func (p scrobblerStub) Capabilities() Capabilities {
 	return Capabilities{ScrobblePlayback: true}
+}
+
+type watchedScrobblerStub struct{ scrobblerStub }
+
+func (watchedScrobblerStub) Capabilities() Capabilities {
+	return Capabilities{ScrobblePlayback: true, ExportWatched: true}
 }
 
 func (p scrobblerStub) Start(context.Context, ServerConfig, Connection, ScrobbleEvent) error {
@@ -1715,7 +1765,7 @@ func TestServiceExportWatchedDrainsPendingBatches(t *testing.T) {
 		t.Fatalf("sent = %d, want 101 (result=%+v)", result.Sent, result)
 	}
 	for _, export := range repo.historyExports {
-		if export.Status != "sent" {
+		if export.Status != historyExportStatusSent {
 			t.Fatalf("history exports = %+v, want all sent", repo.historyExports)
 		}
 	}
@@ -1778,8 +1828,62 @@ func TestServiceSyncConnectionMarksRunFailedWhenExportTransportFails(t *testing.
 	if latest.Error == "" {
 		t.Fatalf("latest run error is empty: %+v", latest)
 	}
-	if len(repo.historyExports) != 1 || repo.historyExports[0].Status != "failed" {
+	if len(repo.historyExports) != 1 || repo.historyExports[0].Status != historyExportStatusFailed {
 		t.Fatalf("history exports = %+v, want one failed export", repo.historyExports)
+	}
+}
+
+func TestServiceCompletedScrobblePersistsAndSatisfiesHistoryExport(t *testing.T) {
+	repo := newServiceFakeRepo()
+	service := NewService(repo, NewRegistry())
+	conn := Connection{ID: "conn-1"}
+	event := ScrobbleEvent{
+		PlaybackSessionID: testPlaybackSessionID,
+		MediaItemID:       testEpisodeMediaID,
+		Kind:              historyimport.KindEpisode,
+		SeriesTVDBID:      "123",
+		SeasonNumber:      1,
+		EpisodeNumber:     2,
+		HistoryID:         testWatchHistoryID,
+		OccurredAt:        time.Now().UTC(),
+		Completed:         true,
+	}
+	if err := service.persistCompletedScrobbleExport(context.Background(), conn, event); err != nil {
+		t.Fatal(err)
+	}
+	if len(repo.historyExports) != 1 || repo.historyExports[0].Status != historyExportStatusPending {
+		t.Fatalf("history exports = %#v", repo.historyExports)
+	}
+	if repo.historyExports[0].ProviderItemKey != "show:tvdb:123:s1:e2" {
+		t.Fatalf("provider item key = %q", repo.historyExports[0].ProviderItemKey)
+	}
+	if err := service.dispatchScrobble(context.Background(), watchedScrobblerStub{}, ServerConfig{}, conn, event, "stop", nil); err != nil {
+		t.Fatal(err)
+	}
+	if repo.historyExports[0].Status != historyExportStatusSatisfiedByScrobble {
+		t.Fatalf("history export status = %q", repo.historyExports[0].Status)
+	}
+}
+
+func TestServiceCompletedScrobbleClosesSessionWhenSatisfiedPersistenceFails(t *testing.T) {
+	repo := newServiceFakeRepo()
+	repo.markSatisfiedErr = errors.New("database unavailable")
+	service := NewService(repo, NewRegistry())
+	conn := Connection{ID: "conn-1", Provider: "trakt"}
+	event := ScrobbleEvent{
+		PlaybackSessionID: testPlaybackSessionID,
+		HistoryID:         testWatchHistoryID,
+		Completed:         true,
+	}
+	repo.historyExports = []HistoryExport{{ID: "export-1", ConnectionID: conn.ID, HistoryID: event.HistoryID, Status: historyExportStatusPending}}
+	if err := service.dispatchScrobble(context.Background(), watchedScrobblerStub{}, ServerConfig{}, conn, event, "stop", nil); err != nil {
+		t.Fatal(err)
+	}
+	if repo.historyExports[0].Status != historyExportStatusPending {
+		t.Fatalf("history export status = %q", repo.historyExports[0].Status)
+	}
+	if len(repo.scrobbleUpdates) != 1 || repo.scrobbleUpdates[0].stopSentAt == nil {
+		t.Fatalf("scrobble updates = %#v", repo.scrobbleUpdates)
 	}
 }
 
@@ -2618,6 +2722,22 @@ func (p rateLimitedImporterStub) HistorySource() userstore.WatchHistorySource {
 	return userstore.WatchHistorySourceTrakt
 }
 
+func TestServicePluginAPIKeyConnectRejectsEmptyReturnedCredential(t *testing.T) {
+	repo := newServiceFakeRepo()
+	registry := NewRegistry()
+	provider := emptyPluginAPIKeyProvider{}
+	if err := registry.Register(provider); err != nil {
+		t.Fatal(err)
+	}
+	service := NewService(repo, registry)
+	if _, err := service.ConnectAPIKey(context.Background(), 7, "profile-1", provider.Key(), "input-secret"); err == nil {
+		t.Fatal("ConnectAPIKey error = nil")
+	}
+	if len(repo.connections) != 0 {
+		t.Fatalf("connections = %#v", repo.connections)
+	}
+}
+
 func TestServiceSyncConnectionDefersOnRateLimit(t *testing.T) {
 	db, err := sql.Open("sqlite3", ":memory:")
 	if err != nil {
@@ -2679,6 +2799,101 @@ func TestServiceSyncConnectionDefersOnRateLimit(t *testing.T) {
 	}
 }
 
+func TestServiceLocalWatchEventCommitsPartialResultAndDefersRateLimit(t *testing.T) {
+	repo := newServiceFakeRepo()
+	provider := watchedExporterStub{
+		exportErr:    RateLimitedError{Provider: "trakt", RetryAfter: 72 * time.Hour},
+		exportResult: ExportResult{Sent: []string{"history-1"}},
+	}
+	registry := NewRegistry()
+	if err := registry.Register(provider); err != nil {
+		t.Fatal(err)
+	}
+	now := time.Date(2026, 7, 24, 12, 0, 0, 0, time.UTC)
+	service := NewService(repo, registry)
+	service.now = func() time.Time { return now }
+	conn := Connection{
+		ID:                   "conn-1",
+		Provider:             "trakt",
+		UserID:               7,
+		ProfileID:            "profile-1",
+		ProviderAccountID:    testProviderAccountID,
+		ExportWatchedEnabled: true,
+	}
+	repo.connections[connectionKey(conn.Provider, conn.UserID, conn.ProfileID)] = conn
+
+	if err := service.processLocalWatchEvent(context.Background(), LocalWatchEvent{
+		Kind:      LocalWatchEventMarkedWatched,
+		UserID:    conn.UserID,
+		ProfileID: conn.ProfileID,
+		Plays: []LocalPlay{{
+			HistoryID:       "history-1",
+			MediaItemID:     "movie-1",
+			ProviderItemKey: "movie:tmdb:603",
+		}},
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if len(repo.historyExports) != 1 || repo.historyExports[0].Status != historyExportStatusSent {
+		t.Fatalf("history exports = %#v", repo.historyExports)
+	}
+	updated := repo.connections[connectionKey(conn.Provider, conn.UserID, conn.ProfileID)]
+	wantUntil := now.Add(24 * time.Hour)
+	if updated.RateLimitedUntil == nil || !updated.RateLimitedUntil.Equal(wantUntil) {
+		t.Fatalf("RateLimitedUntil = %v, want %v", updated.RateLimitedUntil, wantUntil)
+	}
+}
+
+func TestServicePluginTransportFailureLeavesExportPending(t *testing.T) {
+	repo := newServiceFakeRepo()
+	service := NewService(repo, NewRegistry())
+	conn := Connection{ID: "conn-1"}
+	err := service.exportLocalPlays(context.Background(), conn, ServerConfig{}, watchedExporterStub{
+		exportErr: retryableProviderError{message: "watch sync plugin is unavailable"},
+	}, []LocalPlay{{
+		HistoryID:       "history-1",
+		MediaItemID:     "movie-1",
+		ProviderItemKey: "movie:tmdb:603",
+	}})
+	if !isRetryableProviderError(err) {
+		t.Fatalf("error = %#v", err)
+	}
+	if len(repo.historyExports) != 1 || repo.historyExports[0].Status != historyExportStatusPending || repo.historyExports[0].AttemptCount != 0 {
+		t.Fatalf("history exports = %#v", repo.historyExports)
+	}
+}
+
+func TestServiceScrobbleRateLimitDefersConnection(t *testing.T) {
+	repo := newServiceFakeRepo()
+	now := time.Date(2026, 7, 24, 12, 0, 0, 0, time.UTC)
+	service := NewService(repo, NewRegistry())
+	service.now = func() time.Time { return now }
+	conn := Connection{
+		ID:                "conn-1",
+		Provider:          "trakt",
+		UserID:            7,
+		ProfileID:         "profile-1",
+		ProviderAccountID: testProviderAccountID,
+	}
+	repo.connections[connectionKey(conn.Provider, conn.UserID, conn.ProfileID)] = conn
+	err := service.dispatchScrobble(
+		context.Background(),
+		scrobblerStub{stopErr: RateLimitedError{Provider: conn.Provider, RetryAfter: 30 * time.Minute}},
+		ServerConfig{}, conn,
+		ScrobbleEvent{PlaybackSessionID: testPlaybackSessionID},
+		scrobbleActionStop,
+		nil,
+	)
+	if _, ok := AsRateLimited(err); !ok {
+		t.Fatalf("error = %#v", err)
+	}
+	updated := repo.connections[connectionKey(conn.Provider, conn.UserID, conn.ProfileID)]
+	wantUntil := now.Add(30 * time.Minute)
+	if updated.RateLimitedUntil == nil || !updated.RateLimitedUntil.Equal(wantUntil) {
+		t.Fatalf("RateLimitedUntil = %v, want %v", updated.RateLimitedUntil, wantUntil)
+	}
+}
+
 func TestServiceSyncConnectionLeavesExportsPendingOnRateLimit(t *testing.T) {
 	db, err := sql.Open("sqlite3", ":memory:")
 	if err != nil {
@@ -2726,7 +2941,7 @@ func TestServiceSyncConnectionLeavesExportsPendingOnRateLimit(t *testing.T) {
 	if err := service.SyncConnection(context.Background(), conn, "scheduled"); err == nil {
 		t.Fatal("SyncConnection error = nil, want rate limit failure")
 	}
-	if len(repo.historyExports) != 1 || repo.historyExports[0].Status != "pending" {
+	if len(repo.historyExports) != 1 || repo.historyExports[0].Status != historyExportStatusPending {
 		t.Fatalf("history exports = %+v, want one still-pending export", repo.historyExports)
 	}
 	updated := repo.connections[connectionKey("trakt", 7, "profile-1")]

--- a/internal/watchsync/service_test.go
+++ b/internal/watchsync/service_test.go
@@ -590,7 +590,9 @@ func (r *serviceFakeRepo) UpdateScrobbleSession(_ context.Context, playbackSessi
 }
 
 func (r *serviceFakeRepo) ListOpenScrobbleSessions(_ context.Context) ([]ScrobbleSession, error) {
-	return r.scrobbleSessions, nil
+	r.scrobbleMu.Lock()
+	defer r.scrobbleMu.Unlock()
+	return append([]ScrobbleSession(nil), r.scrobbleSessions...), nil
 }
 
 func (r *serviceFakeRepo) ListPendingScrobbleReconciliations(_ context.Context) ([]ScrobbleSession, error) {
@@ -650,6 +652,7 @@ func cloneStringMapForTest(values map[string]string) map[string]string {
 type authProviderStub struct {
 	started       bool
 	polled        bool
+	pollErr       error
 	refreshed     bool
 	refreshTokens TokenSet
 	refreshErr    error
@@ -688,6 +691,9 @@ func (p *authProviderStub) PollDeviceAuth(
 	DeviceAuthSession,
 ) (TokenSet, error) {
 	p.polled = true
+	if p.pollErr != nil {
+		return TokenSet{}, p.pollErr
+	}
 	expires := time.Now().Add(time.Hour)
 	return TokenSet{AccessToken: testAccessToken, RefreshToken: testRefreshToken, TokenExpiresAt: &expires}, nil
 }
@@ -1161,6 +1167,42 @@ func TestServiceStartsAndPollsDeviceAuth(t *testing.T) {
 	storedSession := repo.sessions[session.ID]
 	if storedSession.CompletedAt == nil {
 		t.Fatalf("auth session was not marked completed: %+v", storedSession)
+	}
+}
+
+func TestServicePersistsRotatedPendingDeviceAuthorizationState(t *testing.T) {
+	repo := newServiceFakeRepo()
+	now := time.Date(2026, 8, 5, 12, 0, 0, 0, time.UTC)
+	original := DeviceAuthSession{
+		ID: "auth-1", Provider: "trakt", UserID: 7, ProfileID: "profile-1",
+		DeviceCode: "original", UserCode: "CODE", VerificationURL: "https://trakt.tv/activate",
+		IntervalSeconds: 5, ExpiresAt: now.Add(10 * time.Minute),
+	}
+	repo.sessions[original.ID] = original
+	provider := &authProviderStub{pollErr: deviceAuthorizationPendingError{session: DeviceAuthSession{
+		// These host-owned fields are intentionally wrong; only the rotated
+		// challenge state, interval, and expiry may be accepted from the provider.
+		ID: "wrong", Provider: "wrong", UserID: 99, ProfileID: "wrong",
+		DeviceCode: "rotated", UserCode: "WRONG", VerificationURL: "https://evil.example",
+		IntervalSeconds: 11, ExpiresAt: now.Add(20 * time.Minute),
+	}}}
+	reg := NewRegistry()
+	if err := reg.Register(provider); err != nil {
+		t.Fatal(err)
+	}
+	service := NewService(repo, reg)
+	service.now = func() time.Time { return now }
+	_, err := service.PollDeviceAuth(context.Background(), 7, "profile-1", "trakt", original.ID)
+	var pending deviceAuthorizationPendingError
+	if !errors.As(err, &pending) {
+		t.Fatalf("error = %#v, want pending", err)
+	}
+	stored := repo.sessions[original.ID]
+	if stored.ID != original.ID || stored.Provider != original.Provider || stored.UserID != original.UserID ||
+		stored.ProfileID != original.ProfileID || stored.UserCode != original.UserCode ||
+		stored.VerificationURL != original.VerificationURL || stored.DeviceCode != "rotated" ||
+		stored.IntervalSeconds != 11 || !stored.ExpiresAt.Equal(now.Add(20*time.Minute)) {
+		t.Fatalf("stored session = %#v", stored)
 	}
 }
 
@@ -3372,5 +3414,112 @@ func TestSyncDueConnectionsSkipsSiblingsOfRateLimitedAccount(t *testing.T) {
 	wantUntil := now.Add(30 * time.Minute)
 	if sibling.RateLimitedUntil == nil || !sibling.RateLimitedUntil.Equal(wantUntil) {
 		t.Fatalf("sibling RateLimitedUntil = %v, want %v", sibling.RateLimitedUntil, wantUntil)
+	}
+}
+
+type favoriteBatchProviderStub struct {
+	batch FavoriteImportBatch
+}
+
+func (favoriteBatchProviderStub) Key() string         { return "plugin:4:list" }
+func (favoriteBatchProviderStub) DisplayName() string { return "List" }
+func (favoriteBatchProviderStub) Capabilities() Capabilities {
+	return Capabilities{ImportFavorites: true}
+}
+func (p favoriteBatchProviderStub) FetchFavorites(context.Context, ServerConfig, Connection) ([]RemoteFavorite, error) {
+	return p.batch.Rows, nil
+}
+func (p favoriteBatchProviderStub) FetchFavoritesBatch(context.Context, ServerConfig, Connection) (FavoriteImportBatch, error) {
+	return p.batch, nil
+}
+
+func TestServiceAppliesIncrementalFavoriteTombstone(t *testing.T) {
+	db, err := sql.Open("sqlite3", ":memory:")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer db.Close()
+	if err := userdb.InitSchema(db); err != nil {
+		t.Fatal(err)
+	}
+	store := userdb.NewSQLiteUserStore(db)
+	ctx := context.Background()
+	if _, err := store.AddFavoriteAt(ctx, "profile-1", testMovieMediaID, time.Now().UTC()); err != nil {
+		t.Fatal(err)
+	}
+	repo := newServiceFakeRepo()
+	conn := Connection{
+		ID: "conn-1", Provider: "plugin:4:list", UserID: 7, ProfileID: "profile-1",
+		ImportFavoritesEnabled: true, SyncFavoriteRemovalsEnabled: true,
+	}
+	repo.listItemStates = []ListItemState{{
+		ConnectionID: conn.ID, ListKind: ListKindFavorites, MediaItemID: testMovieMediaID,
+		ProviderItemKey: testMovieProviderItemKey, RemotePresent: true, LocalPresent: true,
+	}}
+	service := NewService(repo, NewRegistry()).
+		WithMatcher(matchedMatcherStub{mediaItemID: testMovieMediaID}).
+		WithUserStoreProvider(staticStoreProvider{store: store})
+	provider := favoriteBatchProviderStub{batch: FavoriteImportBatch{
+		Rows:           []RemoteFavorite{{ProviderItemKey: testMovieProviderItemKey, Removed: true}},
+		UpdatedCursors: map[string]string{pluginFavoritesCursorKey: "cursor-2"},
+		Incremental:    true,
+	}}
+	result, err := service.importList(ctx, conn, ServerConfig{}, provider, service.favoritesBinding())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result.Removed != 1 {
+		t.Fatalf("result = %#v", result)
+	}
+	favorites, err := store.ListFavorites(ctx, conn.ProfileID, 10, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(favorites) != 0 || repo.listItemStates[0].RemotePresent || repo.listItemStates[0].LocalPresent {
+		t.Fatalf("favorites=%#v state=%#v", favorites, repo.listItemStates[0])
+	}
+	updated := repo.connections[connectionKey(conn.Provider, conn.UserID, conn.ProfileID)]
+	if updated.SyncCursors[pluginFavoritesCursorKey] != "cursor-2" {
+		t.Fatalf("connection cursors = %#v", updated.SyncCursors)
+	}
+}
+
+func TestServiceIncrementalFavoriteAbsenceIsNotRemoval(t *testing.T) {
+	db, err := sql.Open("sqlite3", ":memory:")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer db.Close()
+	if err := userdb.InitSchema(db); err != nil {
+		t.Fatal(err)
+	}
+	store := userdb.NewSQLiteUserStore(db)
+	ctx := context.Background()
+	if _, err := store.AddFavoriteAt(ctx, "profile-1", testMovieMediaID, time.Now().UTC()); err != nil {
+		t.Fatal(err)
+	}
+	repo := newServiceFakeRepo()
+	conn := Connection{
+		ID: "conn-1", Provider: "plugin:4:list", UserID: 7, ProfileID: "profile-1",
+		ImportFavoritesEnabled: true, SyncFavoriteRemovalsEnabled: true,
+	}
+	repo.listItemStates = []ListItemState{{
+		ConnectionID: conn.ID, ListKind: ListKindFavorites, MediaItemID: testMovieMediaID,
+		ProviderItemKey: testMovieProviderItemKey, RemotePresent: true, LocalPresent: true,
+	}}
+	service := NewService(repo, NewRegistry()).
+		WithMatcher(matchedMatcherStub{mediaItemID: testMovieMediaID}).
+		WithUserStoreProvider(staticStoreProvider{store: store})
+	provider := favoriteBatchProviderStub{batch: FavoriteImportBatch{Incremental: true}}
+	result, err := service.importList(ctx, conn, ServerConfig{}, provider, service.favoritesBinding())
+	if err != nil {
+		t.Fatal(err)
+	}
+	favorites, err := store.ListFavorites(ctx, conn.ProfileID, 10, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result.Removed != 0 || len(favorites) != 1 || !repo.listItemStates[0].RemotePresent || !repo.listItemStates[0].LocalPresent {
+		t.Fatalf("result=%#v favorites=%#v state=%#v", result, favorites, repo.listItemStates[0])
 	}
 }

--- a/internal/watchsync/service_test.go
+++ b/internal/watchsync/service_test.go
@@ -17,25 +17,47 @@ import (
 	"github.com/Silo-Server/silo-server/internal/userstore"
 )
 
-const testProviderAccountID = "account-1"
+const (
+	testProviderAccountID    = "account-1"
+	testAccessToken          = "access"
+	testBearerTokenType      = "Bearer"
+	testCursorOne            = "cursor-1"
+	testDPoPTokenType        = "DPoP"
+	testHistoryExportID      = "export-1"
+	testHistoryScope         = "history"
+	testMovieMediaID         = "movie-1"
+	testMovieProviderItemKey = "movie:tmdb:603"
+	testOldAccessToken       = "old-access"
+	testOldRefreshToken      = "old-refresh"
+	testOneValue             = "one"
+	testPluginUsername       = "alice"
+	testRefreshToken         = "refresh"
+	testReconnectRequired    = "reconnect required"
+	testRotatedAccessToken   = "rotated-access"
+	testSecretValue          = "secret"
+	testValidatedToken       = "validated-token"
+)
 
 type serviceFakeRepo struct {
-	connections          map[string]Connection
-	dueConnections       []Connection
-	sessions             map[string]DeviceAuthSession
-	settings             map[string]string
-	syncRuns             []SyncRun
-	historyExports       []HistoryExport
-	listItemStates       []ListItemState
-	scrobbleConnections  []Connection
-	scrobbleSessions     []ScrobbleSession
-	scrobbleUpdates      []scrobbleUpdate
-	reopenedScrobbles    []scrobbleUpdate
-	confirmedScrobbles   map[string]bool
-	confirmingScrobbles  map[string]time.Time
-	markSatisfiedErr     error
-	markHistoryStatusErr error
-	scrobbleMu           sync.Mutex
+	connections            map[string]Connection
+	dueConnections         []Connection
+	sessions               map[string]DeviceAuthSession
+	settings               map[string]string
+	syncRuns               []SyncRun
+	historyExports         []HistoryExport
+	listItemStates         []ListItemState
+	scrobbleConnections    []Connection
+	scrobbleSessions       []ScrobbleSession
+	pendingReconciliations []ScrobbleSession
+	reconciledScrobbles    map[string]time.Time
+	scrobbleUpdates        []scrobbleUpdate
+	reopenedScrobbles      []scrobbleUpdate
+	confirmedScrobbles     map[string]bool
+	confirmingScrobbles    map[string]time.Time
+	markSatisfiedErr       error
+	markHistoryStatusErr   error
+	syncRunMu              sync.Mutex
+	scrobbleMu             sync.Mutex
 }
 
 type scrobbleUpdate struct {
@@ -54,6 +76,7 @@ func newServiceFakeRepo() *serviceFakeRepo {
 		sessions:            make(map[string]DeviceAuthSession),
 		confirmedScrobbles:  make(map[string]bool),
 		confirmingScrobbles: make(map[string]time.Time),
+		reconciledScrobbles: make(map[string]time.Time),
 		settings: map[string]string{
 			"watchsync.trakt.client_id":     "client-id",
 			"watchsync.trakt.client_secret": "client-secret",
@@ -168,6 +191,8 @@ func (r *serviceFakeRepo) ListConnectionsDueForSync(
 }
 
 func (r *serviceFakeRepo) CreateSyncRun(_ context.Context, run SyncRun) (SyncRun, error) {
+	r.syncRunMu.Lock()
+	defer r.syncRunMu.Unlock()
 	if run.ID == "" {
 		run.ID = "run-" + strconv.Itoa(len(r.syncRuns)+1)
 	}
@@ -185,6 +210,8 @@ func (r *serviceFakeRepo) CreateSyncRun(_ context.Context, run SyncRun) (SyncRun
 }
 
 func (r *serviceFakeRepo) CompleteSyncRun(_ context.Context, run SyncRun) (SyncRun, error) {
+	r.syncRunMu.Lock()
+	defer r.syncRunMu.Unlock()
 	for i := range r.syncRuns {
 		if r.syncRuns[i].ID == run.ID {
 			if run.CreatedAt.IsZero() {
@@ -201,6 +228,8 @@ func (r *serviceFakeRepo) CompleteSyncRun(_ context.Context, run SyncRun) (SyncR
 }
 
 func (r *serviceFakeRepo) GetLatestSyncRun(_ context.Context, connectionID string) (SyncRun, bool, error) {
+	r.syncRunMu.Lock()
+	defer r.syncRunMu.Unlock()
 	for i := len(r.syncRuns) - 1; i >= 0; i-- {
 		if r.syncRuns[i].ConnectionID == connectionID {
 			return r.syncRuns[i], true, nil
@@ -210,6 +239,8 @@ func (r *serviceFakeRepo) GetLatestSyncRun(_ context.Context, connectionID strin
 }
 
 func (r *serviceFakeRepo) GetActiveSyncRun(_ context.Context, connectionID string) (SyncRun, bool, error) {
+	r.syncRunMu.Lock()
+	defer r.syncRunMu.Unlock()
 	for i := len(r.syncRuns) - 1; i >= 0; i-- {
 		run := r.syncRuns[i]
 		if run.ConnectionID == connectionID &&
@@ -221,6 +252,8 @@ func (r *serviceFakeRepo) GetActiveSyncRun(_ context.Context, connectionID strin
 }
 
 func (r *serviceFakeRepo) ListSyncRuns(_ context.Context, connectionID string, limit int) ([]SyncRun, error) {
+	r.syncRunMu.Lock()
+	defer r.syncRunMu.Unlock()
 	if limit <= 0 || limit > 50 {
 		limit = 10
 	}
@@ -509,6 +542,11 @@ func (r *serviceFakeRepo) CompleteConfirmedScrobbleStop(_ context.Context, playb
 		historyID:         historyID,
 		stopSentAt:        &stopSentAt,
 	})
+	if historyID != "" {
+		r.pendingReconciliations = append(r.pendingReconciliations, ScrobbleSession{
+			PlaybackSessionID: playbackSessionID, ConnectionID: connectionID, HistoryID: historyID,
+		})
+	}
 	return nil
 }
 
@@ -532,6 +570,8 @@ func (r *serviceFakeRepo) FailConfirmedScrobbleStop(_ context.Context, playbackS
 }
 
 func (r *serviceFakeRepo) UpdateScrobbleSession(_ context.Context, playbackSessionID string, connectionID string, action string, positionSeconds float64, historyID string, lastError string, stopSentAt *time.Time) error {
+	r.scrobbleMu.Lock()
+	defer r.scrobbleMu.Unlock()
 	r.scrobbleUpdates = append(r.scrobbleUpdates, scrobbleUpdate{
 		playbackSessionID: playbackSessionID,
 		connectionID:      connectionID,
@@ -541,11 +581,50 @@ func (r *serviceFakeRepo) UpdateScrobbleSession(_ context.Context, playbackSessi
 		lastError:         lastError,
 		stopSentAt:        stopSentAt,
 	})
+	if stopSentAt != nil && historyID != "" {
+		r.pendingReconciliations = append(r.pendingReconciliations, ScrobbleSession{
+			PlaybackSessionID: playbackSessionID, ConnectionID: connectionID, HistoryID: historyID,
+		})
+	}
 	return nil
 }
 
 func (r *serviceFakeRepo) ListOpenScrobbleSessions(_ context.Context) ([]ScrobbleSession, error) {
 	return r.scrobbleSessions, nil
+}
+
+func (r *serviceFakeRepo) ListPendingScrobbleReconciliations(_ context.Context) ([]ScrobbleSession, error) {
+	r.scrobbleMu.Lock()
+	defer r.scrobbleMu.Unlock()
+	return append([]ScrobbleSession(nil), r.pendingReconciliations...), nil
+}
+
+func (r *serviceFakeRepo) MarkScrobbleHistoryReconciled(_ context.Context, playbackSessionID, connectionID string, reconciledAt time.Time) error {
+	r.scrobbleMu.Lock()
+	defer r.scrobbleMu.Unlock()
+	key := playbackSessionID + "|" + connectionID
+	r.reconciledScrobbles[key] = reconciledAt
+	remaining := r.pendingReconciliations[:0]
+	for _, session := range r.pendingReconciliations {
+		if session.PlaybackSessionID == playbackSessionID && session.ConnectionID == connectionID {
+			continue
+		}
+		remaining = append(remaining, session)
+	}
+	r.pendingReconciliations = remaining
+	return nil
+}
+
+func (r *serviceFakeRepo) syncRunsSnapshot() []SyncRun {
+	r.syncRunMu.Lock()
+	defer r.syncRunMu.Unlock()
+	return append([]SyncRun(nil), r.syncRuns...)
+}
+
+func (r *serviceFakeRepo) scrobbleUpdatesSnapshot() []scrobbleUpdate {
+	r.scrobbleMu.Lock()
+	defer r.scrobbleMu.Unlock()
+	return append([]scrobbleUpdate(nil), r.scrobbleUpdates...)
 }
 
 func connectionKey(provider string, userID int, profileID string) string {
@@ -610,7 +689,7 @@ func (p *authProviderStub) PollDeviceAuth(
 ) (TokenSet, error) {
 	p.polled = true
 	expires := time.Now().Add(time.Hour)
-	return TokenSet{AccessToken: "access", RefreshToken: "refresh", TokenExpiresAt: &expires}, nil
+	return TokenSet{AccessToken: testAccessToken, RefreshToken: testRefreshToken, TokenExpiresAt: &expires}, nil
 }
 
 func (p *authProviderStub) RefreshToken(context.Context, ServerConfig, Connection) (TokenSet, error) {
@@ -1072,7 +1151,7 @@ func TestServiceStartsAndPollsDeviceAuth(t *testing.T) {
 	if err != nil {
 		t.Fatalf("PollDeviceAuth: %v", err)
 	}
-	if conn.ProviderUsername != "alex" || conn.AccessToken != "access" {
+	if conn.ProviderUsername != "alex" || conn.AccessToken != testAccessToken {
 		t.Fatalf("connection = %+v", conn)
 	}
 	if !conn.ImportWatchedEnabled || !conn.ImportProgressEnabled ||
@@ -1208,7 +1287,7 @@ func TestServicePollDeviceAuthPreservesExistingConnectionToggles(t *testing.T) {
 		!conn.ExportWatchedEnabled || !conn.ScrobbleEnabled {
 		t.Fatalf("connection toggles were not preserved: %+v", conn)
 	}
-	if conn.AccessToken != "access" || conn.ProviderUsername != "alex" {
+	if conn.AccessToken != testAccessToken || conn.ProviderUsername != "alex" {
 		t.Fatalf("connection credentials/account were not refreshed: %+v", conn)
 	}
 }
@@ -1251,7 +1330,7 @@ func TestServiceRequestManualSyncCreatesAsyncRun(t *testing.T) {
 			return
 		}
 		if time.Now().After(deadline) {
-			t.Fatalf("sync run did not complete: %+v", repo.syncRuns)
+			t.Fatalf("sync run did not complete: %+v", repo.syncRunsSnapshot())
 		}
 		time.Sleep(10 * time.Millisecond)
 	}
@@ -1411,8 +1490,8 @@ func TestServiceSyncConnectionRefreshesExpiredToken(t *testing.T) {
 		Provider:       "trakt",
 		UserID:         7,
 		ProfileID:      "profile-1",
-		AccessToken:    "old-access",
-		RefreshToken:   "old-refresh",
+		AccessToken:    testOldAccessToken,
+		RefreshToken:   testOldRefreshToken,
 		TokenExpiresAt: &expiresAt,
 	}
 	repo.connections[connectionKey("trakt", 7, "profile-1")] = conn
@@ -1437,10 +1516,10 @@ func TestServicePluginRefreshPersistsAuthoritativeCredentialsBeforeFault(t *test
 	now := time.Date(2026, 7, 28, 12, 0, 0, 0, time.UTC)
 	expiresAt := now.Add(-time.Minute)
 	client := &fakeWatchSyncPluginClient{refreshResponse: &pluginv1.WatchSyncCredentialResponse{
-		Credentials: &pluginv1.WatchSyncCredentials{AccessToken: "rotated-access", TokenType: "Bearer"},
+		Credentials: &pluginv1.WatchSyncCredentials{AccessToken: testRotatedAccessToken, TokenType: testBearerTokenType},
 		Fault: &pluginv1.WatchSyncFault{
 			Code:        pluginv1.WatchSyncFaultCode_WATCH_SYNC_FAULT_CODE_INVALID_CREDENTIAL,
-			SafeMessage: "reconnect required",
+			SafeMessage: testReconnectRequired,
 		},
 	}}
 	provider := testPluginProvider(t, client)
@@ -1451,8 +1530,8 @@ func TestServicePluginRefreshPersistsAuthoritativeCredentialsBeforeFault(t *test
 		Provider:       provider.Key(),
 		UserID:         7,
 		ProfileID:      "profile-1",
-		AccessToken:    "old-access",
-		RefreshToken:   "old-refresh",
+		AccessToken:    testOldAccessToken,
+		RefreshToken:   testOldRefreshToken,
 		TokenExpiresAt: &expiresAt,
 	}
 	repo.connections[connectionKey(conn.Provider, conn.UserID, conn.ProfileID)] = conn
@@ -1461,10 +1540,10 @@ func TestServicePluginRefreshPersistsAuthoritativeCredentialsBeforeFault(t *test
 		t.Fatalf("error = %#v", err)
 	}
 	updated := repo.connections[connectionKey(conn.Provider, conn.UserID, conn.ProfileID)]
-	if updated.AccessToken != "rotated-access" || updated.RefreshToken != "" || updated.TokenExpiresAt != nil {
+	if updated.AccessToken != testRotatedAccessToken || updated.RefreshToken != "" || updated.TokenExpiresAt != nil {
 		t.Fatalf("connection credentials = %#v", updated)
 	}
-	if updated.LastError != "reconnect required" {
+	if updated.LastError != testReconnectRequired {
 		t.Fatalf("LastError = %q", updated.LastError)
 	}
 }
@@ -1491,7 +1570,7 @@ func TestServiceSyncConnectionTreatsMatcherWarningsAsSuccess(t *testing.T) {
 		Provider:             "trakt",
 		UserID:               7,
 		ProfileID:            "profile-1",
-		AccessToken:          "access",
+		AccessToken:          testAccessToken,
 		ImportWatchedEnabled: true,
 	}
 
@@ -1526,7 +1605,7 @@ func TestServiceImportWatchedUsesProviderHistorySource(t *testing.T) {
 	}
 	watchState := &recordingWatchState{}
 	service := NewService(repo, NewRegistry()).
-		WithMatcher(matchedMatcherStub{mediaItemID: "movie-1"}).
+		WithMatcher(matchedMatcherStub{mediaItemID: testMovieMediaID}).
 		WithWatchState(watchState)
 
 	result, err := service.ImportWatched(context.Background(), Connection{
@@ -1544,7 +1623,7 @@ func TestServiceImportWatchedUsesProviderHistorySource(t *testing.T) {
 	if len(watchState.sources) != 1 || watchState.sources[0] != userstore.WatchHistorySourceSimkl {
 		t.Fatalf("recorded sources = %+v, want simkl", watchState.sources)
 	}
-	if len(watchState.targetIDs) != 1 || watchState.targetIDs[0] != "movie-1" {
+	if len(watchState.targetIDs) != 1 || watchState.targetIDs[0] != testMovieMediaID {
 		t.Fatalf("recorded target ids = %+v, want movie-1", watchState.targetIDs)
 	}
 	if len(watchState.completed) != 1 || !watchState.completed[0] {
@@ -1573,7 +1652,7 @@ func TestServiceImportWatchedSkipsRowsWithoutLastWatchedAt(t *testing.T) {
 	}
 	watchState := &recordingWatchState{}
 	service := NewService(repo, NewRegistry()).
-		WithMatcher(matchedMatcherStub{mediaItemID: "movie-1"}).
+		WithMatcher(matchedMatcherStub{mediaItemID: testMovieMediaID}).
 		WithWatchState(watchState)
 
 	result, err := service.ImportWatched(context.Background(), Connection{
@@ -1706,7 +1785,7 @@ func TestServiceSyncConnectionPreservesConnectionUpdatesAcrossFlows(t *testing.T
 	if err := userdb.AddHistory(db, userstore.WatchHistoryEntry{
 		ID:              "history-1",
 		ProfileID:       "profile-1",
-		MediaItemID:     "movie-1",
+		MediaItemID:     testMovieMediaID,
 		WatchedAt:       "2026-05-04T12:00:00Z",
 		DurationSeconds: 7200,
 		Completed:       true,
@@ -1737,7 +1816,7 @@ func TestServiceSyncConnectionPreservesConnectionUpdatesAcrossFlows(t *testing.T
 	}
 	repo := newServiceFakeRepo()
 	service := NewService(repo, reg).
-		WithMatcher(matchedMatcherStub{mediaItemID: "movie-1"}).
+		WithMatcher(matchedMatcherStub{mediaItemID: testMovieMediaID}).
 		WithWatchState(&recordingWatchState{}).
 		WithUserStoreProvider(staticStoreProvider{store: userdb.NewSQLiteUserStore(db)})
 	now := time.Date(2026, 5, 4, 14, 0, 0, 0, time.UTC)
@@ -1747,7 +1826,7 @@ func TestServiceSyncConnectionPreservesConnectionUpdatesAcrossFlows(t *testing.T
 		Provider:             "simkl",
 		UserID:               7,
 		ProfileID:            "profile-1",
-		AccessToken:          "access",
+		AccessToken:          testAccessToken,
 		ImportWatchedEnabled: true,
 		ExportWatchedEnabled: true,
 	}
@@ -1828,7 +1907,7 @@ func TestServiceSyncConnectionMarksRunFailedWhenExportTransportFails(t *testing.
 	if err := userdb.AddHistory(db, userstore.WatchHistoryEntry{
 		ID:              "history-1",
 		ProfileID:       "profile-1",
-		MediaItemID:     "movie-1",
+		MediaItemID:     testMovieMediaID,
 		WatchedAt:       "2026-05-04T12:00:00Z",
 		DurationSeconds: 7200,
 		Completed:       true,
@@ -1855,7 +1934,7 @@ func TestServiceSyncConnectionMarksRunFailedWhenExportTransportFails(t *testing.
 		Provider:             "trakt",
 		UserID:               7,
 		ProfileID:            "profile-1",
-		AccessToken:          "access",
+		AccessToken:          testAccessToken,
 		ExportWatchedEnabled: true,
 	}
 
@@ -1894,7 +1973,7 @@ func TestServiceExportWatchedReturnsStatusPersistenceFailure(t *testing.T) {
 	if err := userdb.AddHistory(db, userstore.WatchHistoryEntry{
 		ID:              "history-1",
 		ProfileID:       "profile-1",
-		MediaItemID:     "movie-1",
+		MediaItemID:     testMovieMediaID,
 		WatchedAt:       "2026-05-04T12:00:00Z",
 		DurationSeconds: 7200,
 		Completed:       true,
@@ -1964,7 +2043,7 @@ func TestServiceCompletedScrobblePersistsAndSatisfiesHistoryExport(t *testing.T)
 	}
 }
 
-func TestServiceCompletedScrobbleClosesSessionWhenSatisfiedPersistenceFails(t *testing.T) {
+func TestServiceCompletedScrobbleDurablyRetriesSatisfiedPersistenceWithoutResendingStop(t *testing.T) {
 	repo := newServiceFakeRepo()
 	repo.markSatisfiedErr = errors.New("database unavailable")
 	service := NewService(repo, NewRegistry())
@@ -1974,15 +2053,29 @@ func TestServiceCompletedScrobbleClosesSessionWhenSatisfiedPersistenceFails(t *t
 		HistoryID:         testWatchHistoryID,
 		Completed:         true,
 	}
-	repo.historyExports = []HistoryExport{{ID: "export-1", ConnectionID: conn.ID, HistoryID: event.HistoryID, Status: historyExportStatusPending}}
-	if err := service.dispatchScrobble(context.Background(), watchedScrobblerStub{}, ServerConfig{}, conn, event, "stop", nil); err != nil {
-		t.Fatal(err)
+	repo.historyExports = []HistoryExport{{ID: testHistoryExportID, ConnectionID: conn.ID, HistoryID: event.HistoryID, Status: historyExportStatusPending}}
+	if err := service.dispatchScrobble(context.Background(), watchedScrobblerStub{}, ServerConfig{}, conn, event, "stop", nil); err == nil {
+		t.Fatal("expected reconciliation persistence failure")
 	}
 	if repo.historyExports[0].Status != historyExportStatusPending {
 		t.Fatalf("history export status = %q", repo.historyExports[0].Status)
 	}
-	if len(repo.scrobbleUpdates) != 1 || repo.scrobbleUpdates[0].stopSentAt == nil {
-		t.Fatalf("scrobble updates = %#v", repo.scrobbleUpdates)
+	updates := repo.scrobbleUpdatesSnapshot()
+	if len(updates) != 1 || updates[0].stopSentAt == nil {
+		t.Fatalf("scrobble updates = %#v", updates)
+	}
+	if len(repo.pendingReconciliations) != 1 {
+		t.Fatalf("pending reconciliations = %#v", repo.pendingReconciliations)
+	}
+	repo.markSatisfiedErr = nil
+	if err := service.SweepOpenScrobbles(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+	if repo.historyExports[0].Status != historyExportStatusSatisfiedByScrobble || len(repo.pendingReconciliations) != 0 {
+		t.Fatalf("history exports=%#v pending=%#v", repo.historyExports, repo.pendingReconciliations)
+	}
+	if updates = repo.scrobbleUpdatesSnapshot(); len(updates) != 1 {
+		t.Fatalf("sweeper redispatched remote stop: %#v", updates)
 	}
 }
 
@@ -2006,7 +2099,7 @@ func TestServiceOrderedScrobblerDispatchesInQueueOrder(t *testing.T) {
 		UserID:            7,
 		ProfileID:         "profile-1",
 		Kind:              historyimport.KindMovie,
-		MediaItemID:       "movie-1",
+		MediaItemID:       testMovieMediaID,
 		PositionSeconds:   10,
 		DurationSeconds:   100,
 	}
@@ -2064,7 +2157,7 @@ func TestServiceScrobbleStopKeepsSessionOpenWhenProviderStopFails(t *testing.T) 
 		PlaybackSessionID: "playback-1",
 		UserID:            7,
 		ProfileID:         "profile-1",
-		MediaItemID:       "movie-1",
+		MediaItemID:       testMovieMediaID,
 		HistoryID:         "history-1",
 		PositionSeconds:   120,
 	})
@@ -2074,18 +2167,19 @@ func TestServiceScrobbleStopKeepsSessionOpenWhenProviderStopFails(t *testing.T) 
 
 	deadline := time.Now().Add(time.Second)
 	for {
-		for _, update := range repo.scrobbleUpdates {
+		updates := repo.scrobbleUpdatesSnapshot()
+		for _, update := range updates {
 			if update.lastError == "stop failed" {
-				for _, seen := range repo.scrobbleUpdates {
+				for _, seen := range updates {
 					if seen.stopSentAt != nil {
-						t.Fatalf("stop_sent_at was set despite provider failure: %+v", repo.scrobbleUpdates)
+						t.Fatalf("stop_sent_at was set despite provider failure: %+v", updates)
 					}
 				}
 				return
 			}
 		}
 		if time.Now().After(deadline) {
-			t.Fatalf("timed out waiting for failed stop update: %+v", repo.scrobbleUpdates)
+			t.Fatalf("timed out waiting for failed stop update: %+v", updates)
 		}
 		time.Sleep(10 * time.Millisecond)
 	}
@@ -2111,7 +2205,7 @@ func TestServiceConfirmedStopWaitsForProviderAndReopensFailedReplacement(t *test
 		PlaybackSessionID: "playback-1",
 		UserID:            7,
 		ProfileID:         "profile-1",
-		MediaItemID:       "movie-1",
+		MediaItemID:       testMovieMediaID,
 		HistoryID:         "history-1",
 		PositionSeconds:   120,
 	})
@@ -2125,9 +2219,10 @@ func TestServiceConfirmedStopWaitsForProviderAndReopensFailedReplacement(t *test
 	if reopened.positionSeconds != 120 || reopened.historyID != "history-1" {
 		t.Fatalf("reopened scrobble = %+v, want authoritative progress", reopened)
 	}
-	for _, update := range repo.scrobbleUpdates {
+	updates := repo.scrobbleUpdatesSnapshot()
+	for _, update := range updates {
 		if update.stopSentAt != nil {
-			t.Fatalf("failed confirmed stop marked session closed: %+v", repo.scrobbleUpdates)
+			t.Fatalf("failed confirmed stop marked session closed: %+v", updates)
 		}
 	}
 }
@@ -2156,7 +2251,7 @@ func TestServiceConfirmedStopRetriesImmediatelyAfterProviderFailure(t *testing.T
 		PlaybackSessionID: "session-1",
 		UserID:            7,
 		ProfileID:         "profile-1",
-		MediaItemID:       "movie-1",
+		MediaItemID:       testMovieMediaID,
 	}
 
 	if err := service.ScrobbleStopConfirmed(context.Background(), event); err == nil {
@@ -2189,7 +2284,7 @@ func TestServiceConfirmedStopWaitsInProviderOrder(t *testing.T) {
 		PlaybackSessionID: "session-1",
 		UserID:            7,
 		ProfileID:         "profile-1",
-		MediaItemID:       "movie-1",
+		MediaItemID:       testMovieMediaID,
 	}
 	if err := service.ScrobbleStart(context.Background(), event); err != nil {
 		t.Fatalf("ScrobbleStart: %v", err)
@@ -2270,7 +2365,7 @@ func TestServiceConfirmedStopDispatchesProvidersIndependently(t *testing.T) {
 		PlaybackSessionID: "session-1",
 		UserID:            7,
 		ProfileID:         "profile-1",
-		MediaItemID:       "movie-1",
+		MediaItemID:       testMovieMediaID,
 	}
 
 	result := make(chan error, 1)
@@ -2315,7 +2410,7 @@ func TestServiceConfirmedStopWaitsBehindFallbackWithoutProviderOrdering(t *testi
 		PlaybackSessionID: "session-1",
 		UserID:            7,
 		ProfileID:         "profile-1",
-		MediaItemID:       "movie-1",
+		MediaItemID:       testMovieMediaID,
 	}
 
 	if err := service.ScrobbleStop(context.Background(), event); err != nil {
@@ -2368,7 +2463,7 @@ func TestServiceConfirmedStopDoesNotResendSuccessfulProvider(t *testing.T) {
 		PlaybackSessionID: "session-1",
 		UserID:            7,
 		ProfileID:         "profile-1",
-		MediaItemID:       "movie-1",
+		MediaItemID:       testMovieMediaID,
 	}
 
 	if err := service.ScrobbleStopConfirmed(context.Background(), event); err != nil {
@@ -2414,7 +2509,7 @@ func TestServiceConfirmedStopSerializesConcurrentConfirmation(t *testing.T) {
 		PlaybackSessionID: "session-1",
 		UserID:            7,
 		ProfileID:         "profile-1",
-		MediaItemID:       "movie-1",
+		MediaItemID:       testMovieMediaID,
 	}
 
 	firstResult := make(chan error, 1)
@@ -2472,7 +2567,7 @@ func TestServiceConfirmedStopCannotCompleteReclaimedLease(t *testing.T) {
 		PlaybackSessionID: "session-1",
 		UserID:            7,
 		ProfileID:         "profile-1",
-		MediaItemID:       "movie-1",
+		MediaItemID:       testMovieMediaID,
 	}
 
 	result := make(chan error, 1)
@@ -2511,7 +2606,7 @@ func TestServiceConfirmedStopRejectsUnregisteredProvider(t *testing.T) {
 		PlaybackSessionID: "session-1",
 		UserID:            7,
 		ProfileID:         "profile-1",
-		MediaItemID:       "movie-1",
+		MediaItemID:       testMovieMediaID,
 	})
 	if err == nil || !strings.Contains(err.Error(), "not registered") {
 		t.Fatalf("ScrobbleStopConfirmed error = %v, want unregistered provider", err)
@@ -2528,8 +2623,8 @@ func TestServiceScrobbleRefreshesExpiredTokenBeforeDispatch(t *testing.T) {
 		Provider:        "trakt",
 		UserID:          7,
 		ProfileID:       "profile-1",
-		AccessToken:     "old-access",
-		RefreshToken:    "old-refresh",
+		AccessToken:     testOldAccessToken,
+		RefreshToken:    testOldRefreshToken,
 		TokenExpiresAt:  &expiresAt,
 		ScrobbleEnabled: true,
 	}}
@@ -2552,7 +2647,7 @@ func TestServiceScrobbleRefreshesExpiredTokenBeforeDispatch(t *testing.T) {
 		PlaybackSessionID: "playback-1",
 		UserID:            7,
 		ProfileID:         "profile-1",
-		MediaItemID:       "movie-1",
+		MediaItemID:       testMovieMediaID,
 		HistoryID:         "history-1",
 		PositionSeconds:   120,
 	})
@@ -2584,13 +2679,13 @@ func TestServiceSweepOpenScrobblesRetriesProviderStop(t *testing.T) {
 		Provider:        "trakt",
 		UserID:          7,
 		ProfileID:       "profile-1",
-		AccessToken:     "access",
+		AccessToken:     testAccessToken,
 		ScrobbleEnabled: true,
 	}
 	repo.scrobbleSessions = []ScrobbleSession{{
 		PlaybackSessionID: "playback-1",
 		ConnectionID:      "conn-1",
-		MediaItemID:       "movie-1",
+		MediaItemID:       testMovieMediaID,
 		Kind:              "movie",
 		TMDBID:            "603",
 		HistoryID:         "history-1",
@@ -2623,13 +2718,14 @@ func TestServiceSweepOpenScrobblesRetriesProviderStop(t *testing.T) {
 		t.Fatal("timed out waiting for provider stop retry")
 	}
 	foundClosed := false
-	for _, update := range repo.scrobbleUpdates {
+	updates := repo.scrobbleUpdatesSnapshot()
+	for _, update := range updates {
 		if update.action == "stop" && update.stopSentAt != nil {
 			foundClosed = true
 		}
 	}
 	if !foundClosed {
-		t.Fatalf("scrobble updates = %+v, want successful stop to mark session closed", repo.scrobbleUpdates)
+		t.Fatalf("scrobble updates = %+v, want successful stop to mark session closed", updates)
 	}
 }
 
@@ -2640,13 +2736,13 @@ func TestServiceSweepOpenScrobblesKeepsFailedStopOpen(t *testing.T) {
 		Provider:        "trakt",
 		UserID:          7,
 		ProfileID:       "profile-1",
-		AccessToken:     "access",
+		AccessToken:     testAccessToken,
 		ScrobbleEnabled: true,
 	}
 	repo.scrobbleSessions = []ScrobbleSession{{
 		PlaybackSessionID: "playback-1",
 		ConnectionID:      "conn-1",
-		MediaItemID:       "movie-1",
+		MediaItemID:       testMovieMediaID,
 		Kind:              "movie",
 		TMDBID:            "603",
 		HistoryID:         "history-1",
@@ -2663,15 +2759,16 @@ func TestServiceSweepOpenScrobblesKeepsFailedStopOpen(t *testing.T) {
 	if err := service.SweepOpenScrobbles(context.Background()); err != nil {
 		t.Fatalf("SweepOpenScrobbles: %v", err)
 	}
-	for _, update := range repo.scrobbleUpdates {
+	updates := repo.scrobbleUpdatesSnapshot()
+	for _, update := range updates {
 		if update.stopSentAt != nil {
-			t.Fatalf("stop_sent_at was set despite provider failure: %+v", repo.scrobbleUpdates)
+			t.Fatalf("stop_sent_at was set despite provider failure: %+v", updates)
 		}
 		if update.lastError == "provider offline" {
 			return
 		}
 	}
-	t.Fatalf("scrobble updates = %+v, want provider error recorded", repo.scrobbleUpdates)
+	t.Fatalf("scrobble updates = %+v, want provider error recorded", updates)
 }
 
 func TestAppendWarningSummarizesDuplicateReasons(t *testing.T) {
@@ -2714,20 +2811,20 @@ func TestHasVisibleCompletedHistoryAtOrAfterScopesTargetAndPaginates(t *testing.
 	for i := 0; i < 500; i++ {
 		rows[i] = userstore.WatchHistoryEntry{
 			ProfileID:   "profile-1",
-			MediaItemID: "movie-1",
+			MediaItemID: testMovieMediaID,
 			WatchedAt:   at.Add(-time.Duration(500-i) * time.Hour).Format(time.RFC3339),
 			Completed:   true,
 		}
 	}
 	rows[500] = userstore.WatchHistoryEntry{
 		ProfileID:   "profile-1",
-		MediaItemID: "movie-1",
+		MediaItemID: testMovieMediaID,
 		WatchedAt:   at.Add(time.Minute).Format(time.RFC3339),
 		Completed:   true,
 	}
 	store := &completedHistoryListerStub{rows: rows}
 
-	found, err := hasVisibleCompletedHistoryAtOrAfter(context.Background(), store, "profile-1", "movie-1", at)
+	found, err := hasVisibleCompletedHistoryAtOrAfter(context.Background(), store, "profile-1", testMovieMediaID, at)
 	if err != nil {
 		t.Fatalf("hasVisibleCompletedHistoryAtOrAfter: %v", err)
 	}
@@ -2738,7 +2835,7 @@ func TestHasVisibleCompletedHistoryAtOrAfterScopesTargetAndPaginates(t *testing.
 		t.Fatalf("query count = %d, want 2", len(store.queries))
 	}
 	for _, query := range store.queries {
-		if query.ProfileID != "profile-1" || len(query.MediaItemIDs) != 1 || query.MediaItemIDs[0] != "movie-1" {
+		if query.ProfileID != "profile-1" || len(query.MediaItemIDs) != 1 || query.MediaItemIDs[0] != testMovieMediaID {
 			t.Fatalf("query was not scoped to target media item: %+v", query)
 		}
 	}
@@ -2840,8 +2937,8 @@ func TestServicePluginAPIKeyConnectRejectsEmptyReturnedCredential(t *testing.T) 
 func TestServicePluginAPIKeyReconnectClearsConnectionError(t *testing.T) {
 	repo := newServiceFakeRepo()
 	client := &fakeWatchSyncPluginClient{exchangeResponse: &pluginv1.WatchSyncCredentialResponse{
-		Credentials: &pluginv1.WatchSyncCredentials{AccessToken: "new-access", TokenType: "Bearer"},
-		Account:     &pluginv1.WatchSyncAccount{ExternalSubject: "account-1", Username: "alice"},
+		Credentials: &pluginv1.WatchSyncCredentials{AccessToken: "new-access", TokenType: testBearerTokenType},
+		Account:     &pluginv1.WatchSyncAccount{ExternalSubject: "account-1", Username: testPluginUsername},
 	}}
 	provider := testPluginProvider(t, client)
 	registry := NewRegistry()
@@ -2853,7 +2950,7 @@ func TestServicePluginAPIKeyReconnectClearsConnectionError(t *testing.T) {
 		Provider:  provider.Key(),
 		UserID:    7,
 		ProfileID: "profile-1",
-		LastError: "reconnect required",
+		LastError: testReconnectRequired,
 	}
 	repo.connections[connectionKey(conn.Provider, conn.UserID, conn.ProfileID)] = conn
 
@@ -2885,7 +2982,7 @@ func TestServiceSyncConnectionDefersOnRateLimit(t *testing.T) {
 	}
 	now := time.Date(2026, 7, 5, 12, 0, 0, 0, time.UTC)
 	service := NewService(repo, reg).
-		WithMatcher(matchedMatcherStub{mediaItemID: "movie-1"}).
+		WithMatcher(matchedMatcherStub{mediaItemID: testMovieMediaID}).
 		WithWatchState(noOpWatchState{}).
 		WithUserStoreProvider(staticStoreProvider{store: userdb.NewSQLiteUserStore(db)})
 	service.now = func() time.Time { return now }
@@ -2894,7 +2991,7 @@ func TestServiceSyncConnectionDefersOnRateLimit(t *testing.T) {
 		Provider:              "trakt",
 		UserID:                7,
 		ProfileID:             "profile-1",
-		AccessToken:           "access",
+		AccessToken:           testAccessToken,
 		ImportWatchedEnabled:  true,
 		ImportProgressEnabled: true,
 	}
@@ -2956,8 +3053,8 @@ func TestServiceLocalWatchEventCommitsPartialResultAndDefersRateLimit(t *testing
 		ProfileID: conn.ProfileID,
 		Plays: []LocalPlay{{
 			HistoryID:       "history-1",
-			MediaItemID:     "movie-1",
-			ProviderItemKey: "movie:tmdb:603",
+			MediaItemID:     testMovieMediaID,
+			ProviderItemKey: testMovieProviderItemKey,
 		}},
 	}); err != nil {
 		t.Fatal(err)
@@ -2980,8 +3077,8 @@ func TestServicePluginTransportFailureLeavesExportPending(t *testing.T) {
 		exportErr: retryableProviderError{message: "watch sync plugin is unavailable"},
 	}, []LocalPlay{{
 		HistoryID:       "history-1",
-		MediaItemID:     "movie-1",
-		ProviderItemKey: "movie:tmdb:603",
+		MediaItemID:     testMovieMediaID,
+		ProviderItemKey: testMovieProviderItemKey,
 	}})
 	if !isRetryableProviderError(err) {
 		t.Fatalf("error = %#v", err)
@@ -3010,7 +3107,7 @@ func TestServicePluginInvalidCredentialLeavesExportPendingAndRecordsConnectionEr
 		Provider:             provider.Key(),
 		UserID:               7,
 		ProfileID:            "profile-1",
-		AccessToken:          "secret",
+		AccessToken:          testSecretValue,
 		ExportWatchedEnabled: true,
 	}
 	repo.connections[connectionKey(conn.Provider, conn.UserID, conn.ProfileID)] = conn
@@ -3020,8 +3117,8 @@ func TestServicePluginInvalidCredentialLeavesExportPendingAndRecordsConnectionEr
 		ProfileID: conn.ProfileID,
 		Plays: []LocalPlay{{
 			HistoryID:       "history-1",
-			MediaItemID:     "movie-1",
-			ProviderItemKey: "movie:tmdb:603",
+			MediaItemID:     testMovieMediaID,
+			ProviderItemKey: testMovieProviderItemKey,
 			Kind:            historyimport.KindMovie,
 		}},
 	})
@@ -3046,8 +3143,8 @@ func TestServiceExportLocalPlaysReturnsStatusPersistenceFailure(t *testing.T) {
 		exportErr: errors.New("provider offline"),
 	}, []LocalPlay{{
 		HistoryID:       "history-1",
-		MediaItemID:     "movie-1",
-		ProviderItemKey: "movie:tmdb:603",
+		MediaItemID:     testMovieMediaID,
+		ProviderItemKey: testMovieProviderItemKey,
 	}})
 	if err == nil {
 		t.Fatal("exportLocalPlays error = nil, want combined export and persistence failure")
@@ -3063,7 +3160,7 @@ func TestServiceExportLocalPlaysReturnsStatusPersistenceFailure(t *testing.T) {
 func TestServiceFakeRepoMarkHistoryExportSatisfiedByScrobbleSkipsSent(t *testing.T) {
 	repo := newServiceFakeRepo()
 	repo.historyExports = []HistoryExport{{
-		ID:           "export-1",
+		ID:           testHistoryExportID,
 		ConnectionID: "conn-1",
 		HistoryID:    "history-1",
 		Status:       historyExportStatusSent,
@@ -3079,7 +3176,7 @@ func TestServiceFakeRepoMarkHistoryExportSatisfiedByScrobbleSkipsSent(t *testing
 func TestServiceFakeRepoPreservesNotFoundHistoryExport(t *testing.T) {
 	repo := newServiceFakeRepo()
 	repo.historyExports = []HistoryExport{{
-		ID:           "export-1",
+		ID:           testHistoryExportID,
 		ConnectionID: "conn-1",
 		HistoryID:    "history-1",
 		Status:       historyExportStatusNotFound,
@@ -3091,7 +3188,7 @@ func TestServiceFakeRepoPreservesNotFoundHistoryExport(t *testing.T) {
 	}}); err != nil {
 		t.Fatal(err)
 	}
-	if err := repo.MarkHistoryExportStatus(context.Background(), "export-1", historyExportStatusFailed, "retry"); err != nil {
+	if err := repo.MarkHistoryExportStatus(context.Background(), testHistoryExportID, historyExportStatusFailed, "retry"); err != nil {
 		t.Fatal(err)
 	}
 	if err := repo.MarkHistoryExportSatisfiedByScrobble(context.Background(), "conn-1", "history-1"); err != nil {
@@ -3145,7 +3242,7 @@ func TestServiceScrobbleInvalidCredentialRecordsConnectionError(t *testing.T) {
 	repo.connections[connectionKey(conn.Provider, conn.UserID, conn.ProfileID)] = conn
 	fault := watchSyncProviderFaultError{
 		code:    pluginv1.WatchSyncFaultCode_WATCH_SYNC_FAULT_CODE_INVALID_CREDENTIAL,
-		message: "reconnect required",
+		message: testReconnectRequired,
 	}
 	err := service.dispatchScrobble(
 		context.Background(), scrobblerStub{stopErr: fault}, ServerConfig{}, conn,
@@ -3172,7 +3269,7 @@ func TestServiceSyncConnectionLeavesExportsPendingOnRateLimit(t *testing.T) {
 	if err := userdb.AddHistory(db, userstore.WatchHistoryEntry{
 		ID:              "history-1",
 		ProfileID:       "profile-1",
-		MediaItemID:     "movie-1",
+		MediaItemID:     testMovieMediaID,
 		WatchedAt:       "2026-05-04T12:00:00Z",
 		DurationSeconds: 7200,
 		Completed:       true,
@@ -3199,7 +3296,7 @@ func TestServiceSyncConnectionLeavesExportsPendingOnRateLimit(t *testing.T) {
 		Provider:             "trakt",
 		UserID:               7,
 		ProfileID:            "profile-1",
-		AccessToken:          "access",
+		AccessToken:          testAccessToken,
 		ExportWatchedEnabled: true,
 	}
 	repo.connections[connectionKey("trakt", 7, "profile-1")] = conn
@@ -3236,7 +3333,7 @@ func TestSyncDueConnectionsSkipsSiblingsOfRateLimitedAccount(t *testing.T) {
 	}
 	now := time.Date(2026, 7, 5, 12, 0, 0, 0, time.UTC)
 	service := NewService(repo, reg).
-		WithMatcher(matchedMatcherStub{mediaItemID: "movie-1"}).
+		WithMatcher(matchedMatcherStub{mediaItemID: testMovieMediaID}).
 		WithWatchState(noOpWatchState{}).
 		WithUserStoreProvider(staticStoreProvider{store: userdb.NewSQLiteUserStore(db)})
 	service.now = func() time.Time { return now }
@@ -3249,7 +3346,7 @@ func TestSyncDueConnectionsSkipsSiblingsOfRateLimitedAccount(t *testing.T) {
 		UserID:               7,
 		ProfileID:            "profile-1",
 		ProviderAccountID:    "acct-1",
-		AccessToken:          "access",
+		AccessToken:          testAccessToken,
 		ImportWatchedEnabled: true,
 	}
 	second := Connection{
@@ -3258,7 +3355,7 @@ func TestSyncDueConnectionsSkipsSiblingsOfRateLimitedAccount(t *testing.T) {
 		UserID:               7,
 		ProfileID:            "profile-2",
 		ProviderAccountID:    "acct-1",
-		AccessToken:          "access",
+		AccessToken:          testAccessToken,
 		ImportWatchedEnabled: true,
 	}
 	repo.connections[connectionKey("trakt", 7, "profile-1")] = first

--- a/internal/watchsync/service_test.go
+++ b/internal/watchsync/service_test.go
@@ -19,21 +19,22 @@ import (
 const testProviderAccountID = "account-1"
 
 type serviceFakeRepo struct {
-	connections         map[string]Connection
-	dueConnections      []Connection
-	sessions            map[string]DeviceAuthSession
-	settings            map[string]string
-	syncRuns            []SyncRun
-	historyExports      []HistoryExport
-	listItemStates      []ListItemState
-	scrobbleConnections []Connection
-	scrobbleSessions    []ScrobbleSession
-	scrobbleUpdates     []scrobbleUpdate
-	reopenedScrobbles   []scrobbleUpdate
-	confirmedScrobbles  map[string]bool
-	confirmingScrobbles map[string]time.Time
-	markSatisfiedErr    error
-	scrobbleMu          sync.Mutex
+	connections          map[string]Connection
+	dueConnections       []Connection
+	sessions             map[string]DeviceAuthSession
+	settings             map[string]string
+	syncRuns             []SyncRun
+	historyExports       []HistoryExport
+	listItemStates       []ListItemState
+	scrobbleConnections  []Connection
+	scrobbleSessions     []ScrobbleSession
+	scrobbleUpdates      []scrobbleUpdate
+	reopenedScrobbles    []scrobbleUpdate
+	confirmedScrobbles   map[string]bool
+	confirmingScrobbles  map[string]time.Time
+	markSatisfiedErr     error
+	markHistoryStatusErr error
+	scrobbleMu           sync.Mutex
 }
 
 type scrobbleUpdate struct {
@@ -312,6 +313,9 @@ func (r *serviceFakeRepo) ListPendingHistoryExports(_ context.Context, connectio
 }
 
 func (r *serviceFakeRepo) MarkHistoryExportStatus(_ context.Context, id string, status string, lastError string) error {
+	if r.markHistoryStatusErr != nil {
+		return r.markHistoryStatusErr
+	}
 	for i := range r.historyExports {
 		if r.historyExports[i].ID == id {
 			if r.historyExports[i].Status == historyExportStatusSent || r.historyExports[i].Status == historyExportStatusSatisfiedByScrobble {
@@ -332,6 +336,9 @@ func (r *serviceFakeRepo) MarkHistoryExportSatisfiedByScrobble(_ context.Context
 	}
 	for i := range r.historyExports {
 		if r.historyExports[i].ConnectionID == connectionID && r.historyExports[i].HistoryID == historyID {
+			if r.historyExports[i].Status == historyExportStatusSent {
+				return nil
+			}
 			r.historyExports[i].Status = historyExportStatusSatisfiedByScrobble
 			return nil
 		}
@@ -1833,6 +1840,60 @@ func TestServiceSyncConnectionMarksRunFailedWhenExportTransportFails(t *testing.
 	}
 }
 
+func TestServiceExportWatchedReturnsStatusPersistenceFailure(t *testing.T) {
+	db, err := sql.Open("sqlite3", ":memory:")
+	if err != nil {
+		t.Fatalf("open sqlite: %v", err)
+	}
+	defer func() {
+		if closeErr := db.Close(); closeErr != nil {
+			t.Fatalf("close sqlite: %v", closeErr)
+		}
+	}()
+	if err := userdb.InitSchema(db); err != nil {
+		t.Fatalf("InitSchema: %v", err)
+	}
+	if err := userdb.AddHistory(db, userstore.WatchHistoryEntry{
+		ID:              "history-1",
+		ProfileID:       "profile-1",
+		MediaItemID:     "movie-1",
+		WatchedAt:       "2026-05-04T12:00:00Z",
+		DurationSeconds: 7200,
+		Completed:       true,
+		Source:          userstore.WatchHistorySourcePlayback,
+		Identity: userstore.WatchIdentity{
+			StableType:  "movie",
+			ProviderIDs: map[string]string{"tmdb": "603"},
+		},
+	}); err != nil {
+		t.Fatalf("AddHistory: %v", err)
+	}
+
+	repo := newServiceFakeRepo()
+	repo.markHistoryStatusErr = errors.New("persist failed")
+	service := NewService(repo, NewRegistry()).WithUserStoreProvider(staticStoreProvider{
+		store: userdb.NewSQLiteUserStore(db),
+	})
+	result, err := service.ExportWatched(context.Background(), Connection{
+		ID:        "conn-1",
+		Provider:  "trakt",
+		UserID:    7,
+		ProfileID: "profile-1",
+	}, ServerConfig{}, watchedExporterStub{exportErr: errors.New("provider offline")})
+	if err == nil {
+		t.Fatal("ExportWatched error = nil, want combined export and persistence failure")
+	}
+	if !strings.Contains(err.Error(), "provider offline") || !strings.Contains(err.Error(), "persist failed") {
+		t.Fatalf("error = %v", err)
+	}
+	if result.Failed != 1 {
+		t.Fatalf("result = %+v", result)
+	}
+	if len(repo.historyExports) != 1 || repo.historyExports[0].Status != historyExportStatusPending {
+		t.Fatalf("history exports = %+v", repo.historyExports)
+	}
+}
+
 func TestServiceCompletedScrobblePersistsAndSatisfiesHistoryExport(t *testing.T) {
 	repo := newServiceFakeRepo()
 	service := NewService(repo, NewRegistry())
@@ -2859,6 +2920,45 @@ func TestServicePluginTransportFailureLeavesExportPending(t *testing.T) {
 		t.Fatalf("error = %#v", err)
 	}
 	if len(repo.historyExports) != 1 || repo.historyExports[0].Status != historyExportStatusPending || repo.historyExports[0].AttemptCount != 0 {
+		t.Fatalf("history exports = %#v", repo.historyExports)
+	}
+}
+
+func TestServiceExportLocalPlaysReturnsStatusPersistenceFailure(t *testing.T) {
+	repo := newServiceFakeRepo()
+	repo.markHistoryStatusErr = errors.New("persist failed")
+	service := NewService(repo, NewRegistry())
+	conn := Connection{ID: "conn-1"}
+	err := service.exportLocalPlays(context.Background(), conn, ServerConfig{}, watchedExporterStub{
+		exportErr: errors.New("provider offline"),
+	}, []LocalPlay{{
+		HistoryID:       "history-1",
+		MediaItemID:     "movie-1",
+		ProviderItemKey: "movie:tmdb:603",
+	}})
+	if err == nil {
+		t.Fatal("exportLocalPlays error = nil, want combined export and persistence failure")
+	}
+	if !strings.Contains(err.Error(), "provider offline") || !strings.Contains(err.Error(), "persist failed") {
+		t.Fatalf("error = %v", err)
+	}
+	if len(repo.historyExports) != 1 || repo.historyExports[0].Status != historyExportStatusPending || repo.historyExports[0].AttemptCount != 0 {
+		t.Fatalf("history exports = %#v", repo.historyExports)
+	}
+}
+
+func TestServiceFakeRepoMarkHistoryExportSatisfiedByScrobbleSkipsSent(t *testing.T) {
+	repo := newServiceFakeRepo()
+	repo.historyExports = []HistoryExport{{
+		ID:           "export-1",
+		ConnectionID: "conn-1",
+		HistoryID:    "history-1",
+		Status:       historyExportStatusSent,
+	}}
+	if err := repo.MarkHistoryExportSatisfiedByScrobble(context.Background(), "conn-1", "history-1"); err != nil {
+		t.Fatal(err)
+	}
+	if repo.historyExports[0].Status != historyExportStatusSent {
 		t.Fatalf("history exports = %#v", repo.historyExports)
 	}
 }

--- a/internal/watchsync/types.go
+++ b/internal/watchsync/types.go
@@ -58,6 +58,13 @@ type AuthProvider interface {
 	LookupAccount(ctx context.Context, cfg ServerConfig, conn Connection) (ProviderAccount, error)
 }
 
+// authoritativeRefreshProvider marks providers whose refreshed credentials are
+// a complete replacement rather than a patch. The unexported method keeps this
+// contract internal to watchsync until all providers can share it.
+type authoritativeRefreshProvider interface {
+	authoritativeRefreshProvider()
+}
+
 // APIKeyAuthProvider is implemented by providers that authenticate via a
 // user-supplied API key rather than an OAuth device flow. The key itself is
 // stored in Connection.AccessToken; LookupAccount and RefreshToken (no-op)

--- a/internal/watchsync/types.go
+++ b/internal/watchsync/types.go
@@ -323,6 +323,17 @@ type DeviceAuthSession struct {
 	CompletedAt     *time.Time `json:"completed_at,omitempty"`
 }
 
+// deviceAuthorizationPendingError carries an authoritative replacement for a
+// device challenge that must be persisted before the next poll. It remains an
+// error so the existing HTTP contract continues to report an incomplete flow.
+type deviceAuthorizationPendingError struct {
+	session DeviceAuthSession
+}
+
+func (deviceAuthorizationPendingError) Error() string {
+	return "watch sync plugin device authorization is pending"
+}
+
 type TokenSet struct {
 	AccessToken      string
 	RefreshToken     string
@@ -380,20 +391,23 @@ type RemoteProgress struct {
 type RemoteFavorite struct {
 	Provider        string
 	ProviderItemKey string
-	Kind            string
-	Title           string
-	Year            int
-	IMDbID          string
-	TMDBID          string
-	TVDBID          string
-	SeriesTitle     string
-	SeriesYear      int
-	SeriesIMDbID    string
-	SeriesTMDBID    string
-	SeriesTVDBID    string
-	SeasonNumber    int
-	EpisodeNumber   int
-	FavoritedAt     time.Time
+	// Removed is an explicit provider tombstone used by incremental list syncs.
+	// Tombstones are resolved through ProviderItemKey and do not require media.
+	Removed       bool
+	Kind          string
+	Title         string
+	Year          int
+	IMDbID        string
+	TMDBID        string
+	TVDBID        string
+	SeriesTitle   string
+	SeriesYear    int
+	SeriesIMDbID  string
+	SeriesTMDBID  string
+	SeriesTVDBID  string
+	SeasonNumber  int
+	EpisodeNumber int
+	FavoritedAt   time.Time
 }
 
 type RemotePlay struct {

--- a/internal/watchsync/types.go
+++ b/internal/watchsync/types.go
@@ -100,6 +100,12 @@ type WatchedExporter interface {
 	ExportHistory(ctx context.Context, cfg ServerConfig, conn Connection, plays []LocalPlay) (ExportResult, error)
 }
 
+// singleBatchWatchedExporter bounds one synchronization run to one provider
+// batch. This is used for plugin RPCs with independent per-call deadlines.
+type singleBatchWatchedExporter interface {
+	ExportBatchSize() int
+}
+
 type UnwatchedExporter interface {
 	RemoveHistory(ctx context.Context, cfg ServerConfig, conn Connection, plays []LocalPlay) (ExportResult, error)
 }
@@ -278,6 +284,19 @@ func AsRateLimited(err error) (RateLimitedError, bool) {
 	return rle, ok
 }
 
+type retryableProviderError struct {
+	message string
+}
+
+func (e retryableProviderError) Error() string {
+	return e.message
+}
+
+func isRetryableProviderError(err error) bool {
+	var retryable retryableProviderError
+	return errors.As(err, &retryable)
+}
+
 type DeviceAuthSession struct {
 	ID              string     `json:"id"`
 	Provider        string     `json:"provider"`
@@ -448,6 +467,15 @@ type LocalListEvent struct {
 	ProfileID string
 	Items     []LocalFavorite
 }
+
+const (
+	historyExportStatusPending             = "pending"
+	historyExportStatusFailed              = "failed"
+	historyExportStatusSent                = "sent"
+	historyExportStatusNotFound            = "not_found"
+	historyExportStatusRemotePresent       = "remote_present"
+	historyExportStatusSatisfiedByScrobble = "satisfied_by_scrobble"
+)
 
 type HistoryExport struct {
 	ID              string

--- a/internal/watchsync/types.go
+++ b/internal/watchsync/types.go
@@ -125,6 +125,9 @@ type FavoriteImportBatch struct {
 	Rows           []RemoteFavorite
 	UpdatedCursors map[string]string
 	Warnings       []string
+	// Incremental means absent remote items are not deletions. The zero value is
+	// an authoritative snapshot, preserving existing built-in provider behavior.
+	Incremental bool
 }
 
 type FavoriteBatchImporter interface {
@@ -188,6 +191,9 @@ type Connection struct {
 	AccessToken                  string
 	RefreshToken                 string
 	TokenExpiresAt               *time.Time
+	TokenType                    string
+	Scopes                       []string
+	SecretAttributes             map[string]string
 	ImportWatchedEnabled         bool
 	ImportProgressEnabled        bool
 	ExportWatchedEnabled         bool
@@ -318,9 +324,12 @@ type DeviceAuthSession struct {
 }
 
 type TokenSet struct {
-	AccessToken    string
-	RefreshToken   string
-	TokenExpiresAt *time.Time
+	AccessToken      string
+	RefreshToken     string
+	TokenExpiresAt   *time.Time
+	TokenType        string
+	Scopes           []string
+	SecretAttributes map[string]string
 }
 
 type ProviderAccount struct {
@@ -525,27 +534,28 @@ type ListItemState struct {
 }
 
 type ScrobbleSession struct {
-	PlaybackSessionID string
-	ConnectionID      string
-	MediaItemID       string
-	ProviderItemKey   string
-	Kind              string
-	IMDbID            string
-	TMDBID            string
-	TVDBID            string
-	SeriesIMDbID      string
-	SeriesTMDBID      string
-	SeriesTVDBID      string
-	SeasonNumber      int
-	EpisodeNumber     int
-	HistoryID         string
-	StartedAt         time.Time
-	LastProgress      float64
-	DurationSeconds   float64
-	Completed         bool
-	LastAction        string
-	StopSentAt        *time.Time
-	LastError         string
+	PlaybackSessionID   string
+	ConnectionID        string
+	MediaItemID         string
+	ProviderItemKey     string
+	Kind                string
+	IMDbID              string
+	TMDBID              string
+	TVDBID              string
+	SeriesIMDbID        string
+	SeriesTMDBID        string
+	SeriesTVDBID        string
+	SeasonNumber        int
+	EpisodeNumber       int
+	HistoryID           string
+	StartedAt           time.Time
+	LastProgress        float64
+	DurationSeconds     float64
+	Completed           bool
+	LastAction          string
+	StopSentAt          *time.Time
+	HistoryReconciledAt *time.Time
+	LastError           string
 }
 
 type ExportResult struct {

--- a/migrations/sql/20260805221735_add_watch_provider_plugin_credentials.sql
+++ b/migrations/sql/20260805221735_add_watch_provider_plugin_credentials.sql
@@ -1,0 +1,13 @@
+-- +goose Up
+ALTER TABLE watch_provider_connections
+    ADD COLUMN plugin_credentials text NOT NULL DEFAULT '';
+
+ALTER TABLE watch_provider_scrobble_sessions
+    ADD COLUMN history_reconciled_at timestamptz;
+
+-- +goose Down
+ALTER TABLE watch_provider_connections
+    DROP COLUMN IF EXISTS plugin_credentials;
+
+ALTER TABLE watch_provider_scrobble_sessions
+    DROP COLUMN IF EXISTS history_reconciled_at;

--- a/migrations/sql/20260805221735_add_watch_provider_plugin_credentials.sql
+++ b/migrations/sql/20260805221735_add_watch_provider_plugin_credentials.sql
@@ -5,21 +5,12 @@ ALTER TABLE watch_provider_connections
 ALTER TABLE watch_provider_scrobble_sessions
     ADD COLUMN history_reconciled_at timestamptz;
 
-CREATE INDEX watch_provider_scrobble_reconcile_pending_idx
-    ON watch_provider_scrobble_sessions (stop_sent_at)
-    WHERE stop_sent_at IS NOT NULL
-      AND completed = true
-      AND history_id <> ''
-      AND history_reconciled_at IS NULL;
-
 -- +goose Down
 -- Irreversible for plugin connections: TokenType, Scopes, and
 -- SecretAttributes exist only in plugin_credentials, so rolling back may
 -- require those providers to reconnect.
 ALTER TABLE watch_provider_connections
     DROP COLUMN IF EXISTS plugin_credentials;
-
-DROP INDEX IF EXISTS watch_provider_scrobble_reconcile_pending_idx;
 
 ALTER TABLE watch_provider_scrobble_sessions
     DROP COLUMN IF EXISTS history_reconciled_at;

--- a/migrations/sql/20260805221735_add_watch_provider_plugin_credentials.sql
+++ b/migrations/sql/20260805221735_add_watch_provider_plugin_credentials.sql
@@ -5,9 +5,21 @@ ALTER TABLE watch_provider_connections
 ALTER TABLE watch_provider_scrobble_sessions
     ADD COLUMN history_reconciled_at timestamptz;
 
+CREATE INDEX watch_provider_scrobble_reconcile_pending_idx
+    ON watch_provider_scrobble_sessions (stop_sent_at)
+    WHERE stop_sent_at IS NOT NULL
+      AND completed = true
+      AND history_id <> ''
+      AND history_reconciled_at IS NULL;
+
 -- +goose Down
+-- Irreversible for plugin connections: TokenType, Scopes, and
+-- SecretAttributes exist only in plugin_credentials, so rolling back may
+-- require those providers to reconnect.
 ALTER TABLE watch_provider_connections
     DROP COLUMN IF EXISTS plugin_credentials;
+
+DROP INDEX IF EXISTS watch_provider_scrobble_reconcile_pending_idx;
 
 ALTER TABLE watch_provider_scrobble_sessions
     DROP COLUMN IF EXISTS history_reconciled_at;

--- a/migrations/sql/20260806015420_add_watch_provider_scrobble_reconcile_index.sql
+++ b/migrations/sql/20260806015420_add_watch_provider_scrobble_reconcile_index.sql
@@ -1,0 +1,32 @@
+-- +goose NO TRANSACTION
+
+-- +goose Up
+-- A failed concurrent build can leave an invalid index that causes
+-- IF NOT EXISTS to skip every retry. Remove only that unusable artifact.
+-- +goose StatementBegin
+DO $$
+BEGIN
+    IF EXISTS (
+        SELECT 1
+        FROM pg_class c
+        JOIN pg_namespace n ON n.oid = c.relnamespace
+        JOIN pg_index i ON i.indexrelid = c.oid
+        WHERE n.nspname = 'public'
+          AND c.relname = 'watch_provider_scrobble_reconcile_pending_idx'
+          AND NOT i.indisvalid
+    ) THEN
+        DROP INDEX public.watch_provider_scrobble_reconcile_pending_idx;
+    END IF;
+END;
+$$;
+-- +goose StatementEnd
+
+CREATE INDEX CONCURRENTLY IF NOT EXISTS watch_provider_scrobble_reconcile_pending_idx
+    ON public.watch_provider_scrobble_sessions (stop_sent_at)
+    WHERE stop_sent_at IS NOT NULL
+      AND completed = true
+      AND history_id <> ''
+      AND history_reconciled_at IS NULL;
+
+-- +goose Down
+DROP INDEX CONCURRENTLY IF EXISTS public.watch_provider_scrobble_reconcile_pending_idx;


### PR DESCRIPTION
Adds a complete host adapter for plugins implementing watch_sync_provider.v1, using Silo's existing watch-sync connection, import, export, list, scrobble, retry, and reconciliation machinery.

## Problem

Silo's watch providers are compiled into the server. The released v0.12 plugin capability proved the RPC boundary, but PR 475 originally exposed only API-key authentication, watched export, and completed playback. That was not enough to extract Trakt, Simkl, MDBList, or to implement a Floppy provider without provider-specific host code.

## Approach

- Discover enabled watch_sync_provider.v1 capabilities and atomically replace plugin-backed registry entries while retaining built-in providers during migration.
- Support API-key and device-code authentication, refresh, and account lookup.
- Preserve full provider credentials: access/refresh tokens, expiry, token type, scopes, and opaque secret attributes. Returned credentials are authoritative and are encrypted/persisted before results, pages, or faults from the same RPC are interpreted.
- Resolve manifest-declared installation configuration for every call, separating public values, secret values, and profile credentials.
- Support watched and progress import; watched and unwatched export; favorite and watchlist import/add/remove; ordered watchlists; and live start, pause, and stop scrobbles according to the descriptor.
- Preserve family-specific cursors across paged imports, advance them only after a successful traversal, and avoid treating absent incremental-list items as deletions.
- Give every plugin connection a stable provider-specific history source so importing from Floppy suppresses echo only to Floppy, not legitimate export to a Trakt or Simkl plugin.
- Persist a durable local reconciliation marker when a remote stop succeeds but the history-export transition fails. The sweeper retries only the database transition and never sends a duplicate stop.
- Continue using Silo's existing rate-limit, outbox, ordered delivery, matching, connection lifecycle, and safe-error boundaries.

The public /api/v1 surface remains additive. Existing built-in Trakt, Simkl, and MDBList providers remain registered while equivalent plugins and migration tooling are developed.

## SDK dependency

Depends on [silo-plugin-sdk PR #13](https://github.com/Silo-Server/silo-plugin-sdk/pull/13), which expands the additive v0.13 contract with:

- device-code authentication
- typed remote-state families
- watched/unwatched, favorite, watchlist, and live-scrobble operations
- ordered-list positions and provider item keys
- complete credentials and provider configuration on every request

This PR is temporarily pinned to SDK commit 3b705d7e882f through its immutable Go pseudo-version. Replace it with v0.13.0 after the SDK PR merges and the release is tagged. Existing v0.12 plugins remain wire-compatible and expose only capabilities the older descriptor can execute.

## Reference provider

A Floppy reference implementation has been built in [Silo-Server/silo-plugin-watchprovider-floppy](https://github.com/Silo-Server/silo-plugin-watchprovider-floppy). It validates profile API tokens, imports watched history and durable progress, exports completed watches, and forwards live start/pause/stop events. It deliberately does not advertise favorites, watchlists, or unwatch because Floppy does not currently expose safe reconciliation semantics for those operations.

## Reliability and security

- Personal credentials remain encrypted and profile-scoped in Silo; plugins receive them only at the RPC boundary.
- Legacy access/refresh rows remain readable during migration, and device codes are encrypted at rest.
- Plugin safe messages are bounded/redacted before persistence; transport details remain host-owned.
- Provider credentials and configuration are never logged or placed in generic runtime settings.
- Completed delivery remains at-least-once at the host boundary; the Floppy reference checks exact remote history identity before applying a completed retry.

## Validation

Passed on the exact published head bcb31bca:

- go test ./internal/watchsync ./internal/plugins ./internal/pluginhost ./cmd/silo
- go test -race ./internal/watchsync ./internal/plugins ./internal/pluginhost ./cmd/silo
- golangci-lint v2.12.2 run --new-from-merge-base=origin/main ./... — 0 issues
- make verify-local-paths
- git diff --check

The repository-wide make test-go run reached the changed packages and migrations successfully, then failed two existing internal/jellycompat process-lock tests. Both tests fail identically on untouched main, confirming a baseline/environment failure rather than a PR regression.

The Floppy reference separately passes go test -race ./..., builds successfully, and renders a validated manifest through ./plugin manifest. The SDK branch passes go test ./....

## Deferred work

- Authorization-code-only plugins remain SDK-valid, but the host will reject them until Silo has a public callback-state and client-secret flow.
- Built-in provider removal and existing-connection migration should happen provider by provider after equivalent plugins ship.
- The SDK dependency must move from the pseudo-version to v0.13.0 before merge.
- The new Floppy repository still needs CI/release workflows added with a GitHub credential carrying workflow scope.

## AI disclosure

- Tool: Codex
- Model: GPT-5.6
- Involvement: AI-assisted architecture, implementation, live-source investigation, testing, and PR preparation on behalf of the project maintainer.
- Review notes: implementation was checked against current Silo host/SDK behavior and the live Floppy API source. The review caught credential-ordering, cross-provider echo suppression, incremental-list deletion, timestamp provenance, and duplicate-stop reconciliation hazards; each has regression coverage.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added plugin-backed watch-sync providers with API-key or device authorization.
  - Added syncing for history, progress, favorites, watchlists, remote state, and live scrobbling.
  - Providers now refresh automatically when plugins change.
  - Added secure credential storage and installation-specific configuration.

- **Bug Fixes**
  - Removed stale providers when plugin data is unavailable.
  - Improved retries, rate-limit handling, partial exports, reconciliation, and error reporting.
  - Improved incremental list updates, including removal handling and credential validation.

- **Documentation**
  - Added a design specification for plugin-backed watch synchronization.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->