### PR TITLE
fix(catalog): match TMDB ids stored in TMDB's own id-slug form

### DIFF
--- a/internal/catalog/provider_id_repo.go
+++ b/internal/catalog/provider_id_repo.go
@@ -118,14 +118,34 @@ func (r *ProviderIDRepository) AttachTMDBID(ctx context.Context, contentID, item
 	}
 
 	var existingOwnerContentID string
-	err = tx.QueryRow(ctx, `
+	ownerQuery := `
 		SELECT content_id
 		FROM media_items
-		WHERE type = $1
-		  AND tmdb_id = $2
+		WHERE tmdb_id >= $2
+		  AND type = $1
 		  AND content_id <> $3
+		  AND (tmdb_id = $2 OR tmdb_id LIKE $2 || '-%')
 		LIMIT 1
-	`, itemType, tmdbText, contentID).Scan(&existingOwnerContentID)
+	`
+	ownerArgs := []any{itemType, tmdbText, contentID}
+	// Bound ordinary slug candidates with the existing tmdb_id index. A run of
+	// nines has no same-width numeric successor, so that rare boundary uses the
+	// lower-bounded predicate above rather than an empty lexical range.
+	tmdbUpper := strconv.FormatUint(uint64(tmdbID)+1, 10)
+	if len(tmdbUpper) == len(tmdbText) {
+		ownerQuery = `
+			SELECT content_id
+			FROM media_items
+			WHERE tmdb_id >= $1
+			  AND tmdb_id < $2
+			  AND type = $3
+			  AND content_id <> $4
+			  AND (tmdb_id = $1 OR tmdb_id LIKE $1 || '-%')
+			LIMIT 1
+		`
+		ownerArgs = []any{tmdbText, tmdbUpper, itemType, contentID}
+	}
+	err = tx.QueryRow(ctx, ownerQuery, ownerArgs...).Scan(&existingOwnerContentID)
 	if err != nil && !errors.Is(err, pgx.ErrNoRows) {
 		return fmt.Errorf("checking tmdb id owner: %w", err)
 	}

--- a/internal/catalog/provider_id_repo.go
+++ b/internal/catalog/provider_id_repo.go
@@ -31,6 +31,39 @@ func NewProviderIDRepository(pool *pgxpool.Pool) *ProviderIDRepository {
 	return &ProviderIDRepository{pool: pool}
 }
 
+// sameTMDBID reports whether a stored TMDB identifier denotes the same title as
+// the numeric id we are attaching.
+//
+// TMDB's own URLs carry the id in "id-slug" form (/tv/1931-disney-s-adventures-
+// of-the-gummi-bears), and enough of that form has reached media_items.tmdb_id
+// that a plain string comparison rejects perfectly good matches — the presence
+// lookup then fails to backfill, and the client cannot tell that a title is
+// already in the library, so it offers to request something you own.
+//
+// The numeric prefix IS the id, so compare on that. Anything without one is not
+// a TMDB id and is left to fail the comparison as before.
+func sameTMDBID(stored, want string) bool {
+	return normalizeTMDBID(stored) == normalizeTMDBID(want)
+}
+
+// normalizeTMDBID reduces "1931-some-slug" to "1931" and leaves anything that
+// does not start with digits untouched.
+func normalizeTMDBID(value string) string {
+	trimmed := strings.TrimSpace(value)
+	end := 0
+	for end < len(trimmed) && trimmed[end] >= '0' && trimmed[end] <= '9' {
+		end++
+	}
+	if end == 0 {
+		return trimmed
+	}
+	// Only "digits" or "digits-anything" are an id; "12ab" is not.
+	if end < len(trimmed) && trimmed[end] != '-' {
+		return trimmed
+	}
+	return trimmed[:end]
+}
+
 func (r *ProviderIDRepository) AttachTMDBID(ctx context.Context, contentID, itemType string, tmdbID int) error {
 	contentID = strings.TrimSpace(contentID)
 	itemType = strings.TrimSpace(itemType)
@@ -66,7 +99,7 @@ func (r *ProviderIDRepository) AttachTMDBID(ctx context.Context, contentID, item
 	if existingType != itemType {
 		return fmt.Errorf("media item type mismatch: got %q, want %q", existingType, itemType)
 	}
-	if existingTMDBID != "" && existingTMDBID != tmdbText {
+	if existingTMDBID != "" && !sameTMDBID(existingTMDBID, tmdbText) {
 		return fmt.Errorf("media item tmdb id conflict: got %q, want %q", existingTMDBID, tmdbText)
 	}
 
@@ -80,7 +113,7 @@ func (r *ProviderIDRepository) AttachTMDBID(ctx context.Context, contentID, item
 	if err != nil && !errors.Is(err, pgx.ErrNoRows) {
 		return fmt.Errorf("loading media item tmdb provider id: %w", err)
 	}
-	if existingProviderTMDBID != "" && existingProviderTMDBID != tmdbText {
+	if existingProviderTMDBID != "" && !sameTMDBID(existingProviderTMDBID, tmdbText) {
 		return fmt.Errorf("media item tmdb provider id conflict: got %q, want %q", existingProviderTMDBID, tmdbText)
 	}
 

--- a/internal/catalog/provider_id_tmdb_match_test.go
+++ b/internal/catalog/provider_id_tmdb_match_test.go
@@ -1,6 +1,15 @@
 package catalog
 
-import "testing"
+import (
+	"context"
+	"fmt"
+	"os"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/jackc/pgx/v5/pgxpool"
+)
 
 // Real values seen rejected in production: media_items.tmdb_id held TMDB's
 // "id-slug" URL form while the presence lookup attached the bare numeric id, so
@@ -37,5 +46,54 @@ func TestNormalizeTMDBIDLeavesNonIdentifiersAlone(t *testing.T) {
 	}
 	if got := normalizeTMDBID(""); got != "" {
 		t.Errorf("normalizeTMDBID(%q) = %q", "", got)
+	}
+}
+
+func TestAttachTMDBIDRejectsEquivalentSlugOwner(t *testing.T) {
+	dsn := strings.TrimSpace(os.Getenv("SILO_TEST_DATABASE_URL"))
+	if dsn == "" {
+		t.Skip("SILO_TEST_DATABASE_URL is not set")
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+	pool, err := pgxpool.New(ctx, dsn)
+	if err != nil {
+		t.Fatalf("connect to test database: %v", err)
+	}
+	t.Cleanup(pool.Close)
+
+	suffix := time.Now().UnixNano()
+	// A run of nines guards the lexical range bound used by the owner lookup:
+	// incrementing the numeric id would produce a shorter, invalid upper bound.
+	tmdbID := 999_999_999
+	ownerContentID := fmt.Sprintf("test-tmdb-slug-owner-%d", suffix)
+	targetContentID := fmt.Sprintf("test-tmdb-slug-target-%d", suffix)
+	if _, err := pool.Exec(ctx, `
+		INSERT INTO media_items (content_id, type, title, tmdb_id)
+		VALUES ($1, 'series', 'TMDB slug owner test', $3),
+		       ($2, 'series', 'TMDB slug target test', '')
+	`, ownerContentID, targetContentID, fmt.Sprintf("%d-some-title", tmdbID)); err != nil {
+		t.Fatalf("insert test media items: %v", err)
+	}
+	t.Cleanup(func() {
+		cleanupCtx, cleanupCancel := context.WithTimeout(context.Background(), 10*time.Second)
+		defer cleanupCancel()
+		if _, err := pool.Exec(cleanupCtx, `DELETE FROM media_items WHERE content_id = ANY($1)`, []string{ownerContentID, targetContentID}); err != nil {
+			t.Errorf("clean up test media items: %v", err)
+		}
+	})
+
+	err = NewProviderIDRepository(pool).AttachTMDBID(ctx, targetContentID, "series", tmdbID)
+	if err == nil || !strings.Contains(err.Error(), "already belongs to content_id") {
+		t.Fatalf("AttachTMDBID() error = %v, want existing-owner conflict", err)
+	}
+
+	var targetTMDBID string
+	if err := pool.QueryRow(ctx, `SELECT tmdb_id FROM media_items WHERE content_id = $1`, targetContentID).Scan(&targetTMDBID); err != nil {
+		t.Fatalf("load target tmdb id: %v", err)
+	}
+	if targetTMDBID != "" {
+		t.Fatalf("target tmdb_id = %q, want unchanged", targetTMDBID)
 	}
 }

--- a/internal/catalog/provider_id_tmdb_match_test.go
+++ b/internal/catalog/provider_id_tmdb_match_test.go
@@ -1,0 +1,41 @@
+package catalog
+
+import "testing"
+
+// Real values seen rejected in production: media_items.tmdb_id held TMDB's
+// "id-slug" URL form while the presence lookup attached the bare numeric id, so
+// the backfill failed and the client kept offering to request titles already in
+// the library.
+func TestSameTMDBIDAcceptsTheSlugURLForm(t *testing.T) {
+	cases := []struct {
+		stored string
+		want   string
+		same   bool
+	}{
+		{"1931-disney-s-adventures-of-the-gummi-bears", "1931", true},
+		{"206709-belascoaran-pi", "206709", true},
+		{"1931", "1931", true},
+		{" 1931 ", "1931", true},
+		// Different titles must still conflict — the slug is decoration, the
+		// number is the identity.
+		{"1931-disney-s-adventures-of-the-gummi-bears", "19310", false},
+		{"206709-belascoaran-pi", "1931", false},
+		// Not an id at all: no digits, or digits not followed by a separator.
+		{"tt0111161", "1931", false},
+		{"12ab", "12", false},
+	}
+	for _, tc := range cases {
+		if got := sameTMDBID(tc.stored, tc.want); got != tc.same {
+			t.Errorf("sameTMDBID(%q, %q) = %v, want %v", tc.stored, tc.want, got, tc.same)
+		}
+	}
+}
+
+func TestNormalizeTMDBIDLeavesNonIdentifiersAlone(t *testing.T) {
+	if got := normalizeTMDBID("tt0111161"); got != "tt0111161" {
+		t.Errorf("normalizeTMDBID mangled a non-numeric id: %q", got)
+	}
+	if got := normalizeTMDBID(""); got != "" {
+		t.Errorf("normalizeTMDBID(%q) = %q", "", got)
+	}
+}


### PR DESCRIPTION
## Problem

Attaching a TMDB id compared the stored value byte-for-byte, so a `media_items` row holding TMDB's **id-slug** form conflicted with the bare numeric id being attached, and the presence-lookup backfill failed:

```
WARN requests: failed to backfill tmdb id from presence lookup
  content_id=series-tvdb-76081 media_type=series tmdb_id=1931 matched_provider=tvdb
  error="media item tmdb id conflict:
         got \"1931-disney-s-adventures-of-the-gummi-bears\", want \"1931\""
```

That form is not corrupt data — it is how TMDB writes its own URLs (`/tv/1931-disney-s-adventures-of-the-gummi-bears`) — and enough of it has reached the catalog to matter. Two different series hit it within a minute on my server.

The user-visible cost: a title already in the library never gets linked, so clients keep offering to **request something you already own**.

## Change

The numeric prefix is the identity, so compare on that. Values with no leading digits (`tt0111161`), or digits not followed by a separator (`12ab`), are not TMDB ids and still conflict exactly as before — the fix widens what counts as a match, it does not weaken the conflict check.

Applied to both comparisons in `AttachTMDBID`: the `media_items.tmdb_id` check and the `media_item_provider_ids` one.

## Testing

Table test using the real values from the log above, plus the negative cases (different ids must still conflict; non-TMDB identifiers untouched). `go test ./internal/catalog/` green.

## AI-use disclosure

Written by Claude Opus 5 (Claude Code) working with @RXWatcher, who spotted the warning on his server and directed the fix.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved TMDB identifier matching to treat numeric IDs and their slugged (and whitespace-padded) forms as equivalent.
  * Reduced incorrect “already belongs” conflict errors when only the slug portion differs, while still rejecting truly different or invalid identifiers.
  * Kept existing TMDB ownership behavior consistent when equivalent identities are already present.
* **Tests**
  * Added unit and integration coverage for TMDB ID normalization, equivalence rules, and conflict handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

---

### Maintainer remediation AI disclosure
- Tool(s): T3 Code through the Codex harness
- Model(s): gpt-5.6-sol
- Involvement: fully AI-generated maintainer remediation, explicitly authorized by the maintainer
- Adversarial review: The two-axis review found that equivalent slug-form TMDB ownership was checked only on the target row, allowing the bare ID to be attached to a second content row. The remediation added an index-bounded cross-record owner check and a DB-backed regression. A follow-up Standards pass found the all-nines fallback had dropped its index lower bound; that was corrected and live EXPLAIN verification confirmed the index scan. Final code Standards review found no code issue. The contributor-originated whitespace semantics remain report-only because the PR text and test conflict and a consistent indexed resolution may require a data/index decision.

### Maintainer remediation verification
```text
go test ./internal/catalog/ -count=1
ok  github.com/Silo-Server/silo-server/internal/catalog

go test -race ./internal/catalog/ -count=1
ok  github.com/Silo-Server/silo-server/internal/catalog

go test ./internal/requests/ -count=1
ok  github.com/Silo-Server/silo-server/internal/requests

go vet ./internal/catalog/ ./internal/requests/
PASS

GOWORK=off golangci-lint run --allow-parallel-runners --new-from-rev 02203d9e408c8f53ecbf8adf672d84d434180389 ./internal/catalog/...
0 issues.

make build
PASS (existing Vite font-resolution and chunk-size warnings only)

make verify-local-paths
PASS

cd web && pnpm run format:check
All matched files use Prettier code style!

Deployed to the configured dev backend under the shared backend lock.
/api/v1/ready -> {"status":"ok"}
DB-backed TestAttachTMDBIDRejectsEquivalentSlugOwner -> PASS
All-nines fallback EXPLAIN -> idx_media_items_tmdb_id, 0.186 ms, 9 shared buffers
GET /api/v1/requests/detail/series/1931 -> HTTP 200; temporary TVDB-matched target selected
Target tmdb_id remained empty; target TMDB provider rows remained 0; existing slug owner remained unchanged
Expected backfill-conflict warning persisted; temporary rows cleaned to 0
Fresh panic/fatal/migration-failure/error-loop log scan -> clean
Final /api/v1/ready -> {"status":"ok"}
```