### PR TITLE
feat(collections): add profile-scoped default sorting

### DIFF
--- a/internal/access/resolver_test.go
+++ b/internal/access/resolver_test.go
@@ -278,6 +278,15 @@ func (s stubStore) GetSeriesPlaybackPreference(context.Context, string, string) 
 func (s stubStore) DeleteSeriesPlaybackPreference(context.Context, string, string) error {
 	panic("unused")
 }
+func (s stubStore) SetCollectionSortPreference(context.Context, userstore.CollectionSortPreference) error {
+	panic("unused")
+}
+func (s stubStore) GetCollectionSortPreference(context.Context, string, string, string) (*userstore.CollectionSortPreference, error) {
+	panic("unused")
+}
+func (s stubStore) ClearCollectionSortPreference(context.Context, string, string, string) error {
+	panic("unused")
+}
 func (s stubStore) GetLibraryPlaybackPreference(context.Context, string, int) (*userstore.LibraryPlaybackPreference, error) {
 	panic("unused")
 }

--- a/internal/api/handlers/catalog.go
+++ b/internal/api/handlers/catalog.go
@@ -59,6 +59,16 @@ type catalogResponse struct {
 	Items             []itemListResponse `json:"items"`
 	Snapshot          string             `json:"snapshot,omitempty"`
 	SearchDiagnostics *searchDiagnostics `json:"search_diagnostics,omitempty"`
+	// EffectiveSort reports the order a collection source actually resolved in
+	// once the viewer's saved override and the collection's configured default
+	// were applied. Omitted for non-collection sources and when the collection
+	// resolved in its own source order.
+	EffectiveSort *effectiveSortResponse `json:"effective_sort,omitempty"`
+}
+
+type effectiveSortResponse struct {
+	Field string `json:"field"`
+	Order string `json:"order"`
 }
 
 // searchDiagnostics is an additive, per-query observability object emitted on
@@ -244,6 +254,11 @@ func (h *CatalogHandler) writeCatalogResponse(w http.ResponseWriter, result *cat
 		}
 	}
 
+	var effectiveSort *effectiveSortResponse
+	if field := strings.TrimSpace(result.EffectiveSort.Field); field != "" {
+		effectiveSort = &effectiveSortResponse{Field: field, Order: result.EffectiveSort.Order}
+	}
+
 	writeJSON(w, http.StatusOK, catalogResponse{
 		Total:             result.Total,
 		TotalExact:        result.TotalExact && !groupedByWork,
@@ -251,6 +266,7 @@ func (h *CatalogHandler) writeCatalogResponse(w http.ResponseWriter, result *cat
 		Items:             items,
 		Snapshot:          snapshot,
 		SearchDiagnostics: diag,
+		EffectiveSort:     effectiveSort,
 	})
 }
 

--- a/internal/api/handlers/collection_sort_prefs.go
+++ b/internal/api/handlers/collection_sort_prefs.go
@@ -1,0 +1,163 @@
+package handlers
+
+import (
+	"encoding/json"
+	"net/http"
+	"strings"
+
+	apimw "github.com/Silo-Server/silo-server/internal/api/middleware"
+	"github.com/Silo-Server/silo-server/internal/catalog"
+	"github.com/Silo-Server/silo-server/internal/userstore"
+)
+
+// collectionSortPreferenceRequest saves the sort a viewer chose while browsing a
+// collection. An empty Field is meaningful — it pins the viewer to the
+// collection's own source order even if its creator later configures a default.
+// To go back to following the creator's default, DELETE the preference instead.
+type collectionSortPreferenceRequest struct {
+	CollectionKind string `json:"collection_kind"`
+	CollectionID   string `json:"collection_id"`
+	Field          string `json:"field"`
+	Order          string `json:"order"`
+}
+
+type collectionSortPreferenceResponse struct {
+	CollectionKind string `json:"collection_kind"`
+	CollectionID   string `json:"collection_id"`
+	Field          string `json:"field"`
+	Order          string `json:"order"`
+}
+
+// NormalizeCollectionSortConfig validates the default sort a collection's
+// creator configured and returns its canonical sort_config JSON. Shared by the
+// personal and library collection handlers so both id spaces accept exactly the
+// same vocabulary.
+//
+// allowPersonalized must be false for library collection defaults because
+// those defaults are shared across profiles. Viewer overrides are validated
+// separately and may use profile-scoped fields for either collection kind.
+func NormalizeCollectionSortConfig(raw json.RawMessage, allowPersonalized bool) (string, error) {
+	trimmed := strings.TrimSpace(string(raw))
+	if trimmed == "" || trimmed == "null" || trimmed == "{}" {
+		return "{}", nil
+	}
+	var cfg struct {
+		Field string `json:"field"`
+		Order string `json:"order"`
+	}
+	if err := json.Unmarshal(raw, &cfg); err != nil {
+		return "", errInvalidSortConfig
+	}
+	if strings.TrimSpace(cfg.Field) == "" {
+		// sort_config predates default sorting and may contain independent
+		// collection modes such as {"mode":"manual_pins"}. Preserve those
+		// configurations byte-for-byte instead of erasing them merely because
+		// they do not contain a sort field.
+		return string(raw), nil
+	}
+	qs, ok := catalog.NormalizeCollectionSort(cfg.Field, cfg.Order, allowPersonalized)
+	if !ok {
+		return "", errInvalidSortConfig
+	}
+	return catalog.EncodeCollectionDefaultSort(qs, true)
+}
+
+var errInvalidSortConfig = &sortConfigError{}
+
+type sortConfigError struct{}
+
+func (*sortConfigError) Error() string {
+	return "sort_config must be {} or {\"field\":\"<supported sort>\",\"order\":\"asc|desc\"}"
+}
+
+// HandleSetCollectionSortPreference handles PUT /collections/sort-preference.
+func (h *CollectionHandler) HandleSetCollectionSortPreference(w http.ResponseWriter, r *http.Request) {
+	userID := apimw.GetUserID(r.Context())
+	profileID := apimw.GetProfileID(r.Context())
+
+	var req collectionSortPreferenceRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		writeError(w, http.StatusBadRequest, "bad_request", "Invalid request body")
+		return
+	}
+
+	kind, collectionID, ok := normalizeCollectionRef(req.CollectionKind, req.CollectionID)
+	if !ok {
+		writeError(w, http.StatusBadRequest, "bad_request", "collection_kind must be 'library' or 'user' and collection_id is required")
+		return
+	}
+
+	field := strings.ToLower(strings.TrimSpace(req.Field))
+	order := ""
+	if field != "" {
+		qs, valid := catalog.NormalizeCollectionSort(field, req.Order, true)
+		if !valid {
+			writeError(w, http.StatusBadRequest, "bad_request", "Unsupported sort field or order for this collection")
+			return
+		}
+		field, order = qs.Field, qs.Order
+	}
+
+	store, err := h.storeProvider.ForUser(r.Context(), userID)
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, "internal_error", "Failed to access user store")
+		return
+	}
+
+	if err := store.SetCollectionSortPreference(r.Context(), userstore.CollectionSortPreference{
+		ProfileID:      profileID,
+		CollectionKind: kind,
+		CollectionID:   collectionID,
+		SortField:      field,
+		SortOrder:      order,
+	}); err != nil {
+		writeError(w, http.StatusInternalServerError, "internal_error", "Failed to save sort preference")
+		return
+	}
+
+	writeJSON(w, http.StatusOK, collectionSortPreferenceResponse{
+		CollectionKind: kind,
+		CollectionID:   collectionID,
+		Field:          field,
+		Order:          order,
+	})
+}
+
+// HandleClearCollectionSortPreference handles DELETE /collections/sort-preference,
+// returning the collection to whatever default its creator configured.
+func (h *CollectionHandler) HandleClearCollectionSortPreference(w http.ResponseWriter, r *http.Request) {
+	userID := apimw.GetUserID(r.Context())
+	profileID := apimw.GetProfileID(r.Context())
+
+	values := r.URL.Query()
+	kind, collectionID, ok := normalizeCollectionRef(values.Get("collection_kind"), values.Get("collection_id"))
+	if !ok {
+		writeError(w, http.StatusBadRequest, "bad_request", "collection_kind must be 'library' or 'user' and collection_id is required")
+		return
+	}
+
+	store, err := h.storeProvider.ForUser(r.Context(), userID)
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, "internal_error", "Failed to access user store")
+		return
+	}
+
+	if err := store.ClearCollectionSortPreference(r.Context(), profileID, kind, collectionID); err != nil {
+		writeError(w, http.StatusInternalServerError, "internal_error", "Failed to clear sort preference")
+		return
+	}
+
+	w.WriteHeader(http.StatusNoContent)
+}
+
+func normalizeCollectionRef(rawKind, rawID string) (string, string, bool) {
+	kind := strings.ToLower(strings.TrimSpace(rawKind))
+	if kind != userstore.CollectionKindLibrary && kind != userstore.CollectionKindUser {
+		return "", "", false
+	}
+	collectionID := strings.TrimSpace(rawID)
+	if collectionID == "" {
+		return "", "", false
+	}
+	return kind, collectionID, true
+}

--- a/internal/api/handlers/collection_sort_prefs.go
+++ b/internal/api/handlers/collection_sort_prefs.go
@@ -38,7 +38,7 @@ type collectionSortPreferenceResponse struct {
 // separately and may use profile-scoped fields for either collection kind.
 func NormalizeCollectionSortConfig(raw json.RawMessage, allowPersonalized bool) (string, error) {
 	trimmed := strings.TrimSpace(string(raw))
-	if trimmed == "" || trimmed == "null" || trimmed == "{}" {
+	if trimmed == "" || trimmed == jsonNullLiteral || trimmed == "{}" {
 		return "{}", nil
 	}
 	var cfg struct {

--- a/internal/api/handlers/collection_sort_prefs.go
+++ b/internal/api/handlers/collection_sort_prefs.go
@@ -1,14 +1,20 @@
 package handlers
 
 import (
+	"context"
 	"encoding/json"
 	"net/http"
 	"strings"
 
 	apimw "github.com/Silo-Server/silo-server/internal/api/middleware"
 	"github.com/Silo-Server/silo-server/internal/catalog"
+	"github.com/Silo-Server/silo-server/internal/models"
 	"github.com/Silo-Server/silo-server/internal/userstore"
 )
+
+type collectionPreferenceLibraryReader interface {
+	GetByID(ctx context.Context, id string) (*models.LibraryCollection, error)
+}
 
 // collectionSortPreferenceRequest saves the sort a viewer chose while browsing a
 // collection. An empty Field is meaningful — it pins the viewer to the
@@ -103,6 +109,12 @@ func (h *CollectionHandler) HandleSetCollectionSortPreference(w http.ResponseWri
 		writeError(w, http.StatusInternalServerError, "internal_error", "Failed to access user store")
 		return
 	}
+	if !h.canSaveCollectionSortPreference(r, store, kind, collectionID) {
+		// Use one not-found response for absent and inaccessible collections so
+		// the preference endpoint cannot be used to enumerate hidden IDs.
+		writeError(w, http.StatusNotFound, "not_found", "Collection not found")
+		return
+	}
 
 	if err := store.SetCollectionSortPreference(r.Context(), userstore.CollectionSortPreference{
 		ProfileID:      profileID,
@@ -121,6 +133,26 @@ func (h *CollectionHandler) HandleSetCollectionSortPreference(w http.ResponseWri
 		Field:          field,
 		Order:          order,
 	})
+}
+
+func (h *CollectionHandler) canSaveCollectionSortPreference(
+	r *http.Request,
+	store userstore.UserStore,
+	kind, collectionID string,
+) bool {
+	switch kind {
+	case userstore.CollectionKindLibrary:
+		if h.LibraryCollections == nil {
+			return false
+		}
+		collection, err := h.LibraryCollections.GetByID(r.Context(), collectionID)
+		return err == nil && catalog.CanAccessLibraryCollection(collection, requestAccessFilter(r))
+	case userstore.CollectionKindUser:
+		collection, err := store.GetCollection(r.Context(), collectionID)
+		return err == nil && catalog.ProfileCanAccessCollection(collection, apimw.GetProfileID(r.Context()))
+	default:
+		return false
+	}
 }
 
 // HandleClearCollectionSortPreference handles DELETE /collections/sort-preference,

--- a/internal/api/handlers/collection_sort_prefs_test.go
+++ b/internal/api/handlers/collection_sort_prefs_test.go
@@ -11,11 +11,25 @@ import (
 
 	"github.com/jackc/pgx/v5/pgxpool"
 
+	"github.com/Silo-Server/silo-server/internal/access"
 	"github.com/Silo-Server/silo-server/internal/api/middleware"
 	"github.com/Silo-Server/silo-server/internal/auth"
+	"github.com/Silo-Server/silo-server/internal/catalog"
+	"github.com/Silo-Server/silo-server/internal/models"
 	"github.com/Silo-Server/silo-server/internal/userstore"
 	"github.com/Silo-Server/silo-server/internal/userstore/pgstore"
 )
+
+type sortPrefLibraryReader struct {
+	collection *models.LibraryCollection
+}
+
+func (r sortPrefLibraryReader) GetByID(_ context.Context, id string) (*models.LibraryCollection, error) {
+	if r.collection == nil || r.collection.ID != id {
+		return nil, catalog.ErrLibraryCollectionNotFound
+	}
+	return r.collection, nil
+}
 
 // These exercise the sort-preference endpoints through real HTTP handlers and a
 // real store, using middleware.SetClaims / SetProfileID to supply the auth
@@ -76,12 +90,23 @@ func TestCollectionSortPreferenceEndpoints(t *testing.T) {
 
 	provider := pgstore.NewPostgresProvider(pool)
 	handler := NewCollectionHandler(provider)
+	handler.LibraryCollections = sortPrefLibraryReader{collection: &models.LibraryCollection{
+		ID: collectionID, Visibility: "visible", LibraryIDs: []int{7},
+	}}
 	store, err := provider.ForUser(context.Background(), userID)
 	if err != nil {
 		t.Fatalf("user store: %v", err)
 	}
 	if err := store.CreateProfile(context.Background(), userstore.Profile{ID: profileID, Name: "HTTP sort preference"}); err != nil {
 		t.Fatalf("seed profile: %v", err)
+	}
+	personalCollection, err := store.CreateCollection(context.Background(), userstore.CreateCollectionInput{
+		CreatorProfileID: profileID,
+		Name:             "HTTP personal sort preference",
+		CollectionType:   "manual",
+	})
+	if err != nil {
+		t.Fatalf("seed personal collection: %v", err)
 	}
 	t.Cleanup(func() {
 		_ = store.DeleteProfile(context.Background(), profileID)
@@ -162,13 +187,31 @@ func TestCollectionSortPreferenceEndpoints(t *testing.T) {
 	})
 
 	t.Run("accepts a personalized sort on a personal collection", func(t *testing.T) {
-		rec := put(`{"collection_kind":"user","collection_id":"http-user-collection","field":"progress"}`)
+		rec := put(`{"collection_kind":"user","collection_id":"` + personalCollection.ID + `","field":"progress"}`)
 		if rec.Code != http.StatusOK {
 			t.Fatalf("status = %d, body = %s", rec.Code, rec.Body.String())
 		}
 		t.Cleanup(func() {
-			_ = store.ClearCollectionSortPreference(context.Background(), profileID, userstore.CollectionKindUser, "http-user-collection")
+			_ = store.ClearCollectionSortPreference(context.Background(), profileID, userstore.CollectionKindUser, personalCollection.ID)
 		})
+	})
+
+	t.Run("rejects a nonexistent collection", func(t *testing.T) {
+		rec := put(`{"collection_kind":"library","collection_id":"missing","field":"title"}`)
+		if rec.Code != http.StatusNotFound {
+			t.Fatalf("status = %d, want 404; body = %s", rec.Code, rec.Body.String())
+		}
+	})
+
+	t.Run("rejects a library collection outside the viewer scope", func(t *testing.T) {
+		req := authed(httptest.NewRequest(http.MethodPut, "/collections/sort-preference",
+			strings.NewReader(`{"collection_kind":"library","collection_id":"`+collectionID+`","field":"title"}`)), userID, profileID)
+		req = req.WithContext(access.SetScope(req.Context(), access.Scope{AllowedLibraryIDs: []int{99}}))
+		rec := httptest.NewRecorder()
+		handler.HandleSetCollectionSortPreference(rec, req)
+		if rec.Code != http.StatusNotFound {
+			t.Fatalf("status = %d, want 404; body = %s", rec.Code, rec.Body.String())
+		}
 	})
 
 	t.Run("rejects an unknown collection kind", func(t *testing.T) {

--- a/internal/api/handlers/collection_sort_prefs_test.go
+++ b/internal/api/handlers/collection_sort_prefs_test.go
@@ -1,0 +1,259 @@
+package handlers
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/jackc/pgx/v5/pgxpool"
+
+	"github.com/Silo-Server/silo-server/internal/api/middleware"
+	"github.com/Silo-Server/silo-server/internal/auth"
+	"github.com/Silo-Server/silo-server/internal/userstore"
+	"github.com/Silo-Server/silo-server/internal/userstore/pgstore"
+)
+
+// These exercise the sort-preference endpoints through real HTTP handlers and a
+// real store, using middleware.SetClaims / SetProfileID to supply the auth
+// context the middleware would normally attach. Set SILO_TEST_DATABASE_URL to a
+// migrated database to run them.
+
+func sortPrefHandlerPool(t *testing.T) *pgxpool.Pool {
+	t.Helper()
+	dsn := os.Getenv("SILO_TEST_DATABASE_URL")
+	if dsn == "" {
+		t.Skip("SILO_TEST_DATABASE_URL is not set")
+	}
+	pool, err := pgxpool.New(context.Background(), dsn)
+	if err != nil {
+		t.Fatalf("connect test database: %v", err)
+	}
+	t.Cleanup(pool.Close)
+	var tableName *string
+	if err := pool.QueryRow(context.Background(),
+		`SELECT to_regclass('public.user_collection_sort_preferences')::text`).Scan(&tableName); err != nil {
+		t.Fatalf("check preference table: %v", err)
+	}
+	if tableName == nil || *tableName == "" {
+		t.Skip("test database has not applied the collection sort preference migration")
+	}
+	return pool
+}
+
+func sortPrefFixtureUser(t *testing.T, pool *pgxpool.Pool) int {
+	t.Helper()
+	var userID int
+	if err := pool.QueryRow(context.Background(), `
+		INSERT INTO users (username, email, password_hash, role)
+		VALUES ('sort-pref-handler-fixture', 'sort-pref-handler@invalid.test', '', 'user')
+		RETURNING id
+	`).Scan(&userID); err != nil {
+		t.Fatalf("seed fixture user: %v", err)
+	}
+	t.Cleanup(func() {
+		_, _ = pool.Exec(context.Background(), `DELETE FROM users WHERE id = $1`, userID)
+	})
+	return userID
+}
+
+// authed attaches the user + profile scope the middleware chain would normally
+// have put on the request.
+func authed(r *http.Request, userID int, profileID string) *http.Request {
+	ctx := middleware.SetClaims(r.Context(), &auth.Claims{UserID: userID, Role: "user"})
+	ctx = middleware.SetProfileID(ctx, profileID)
+	return r.WithContext(ctx)
+}
+
+func TestCollectionSortPreferenceEndpoints(t *testing.T) {
+	pool := sortPrefHandlerPool(t)
+	userID := sortPrefFixtureUser(t, pool)
+	const profileID = "profile-http"
+	const collectionID = "http-collection-1"
+
+	provider := pgstore.NewPostgresProvider(pool)
+	handler := NewCollectionHandler(provider)
+	store, err := provider.ForUser(context.Background(), userID)
+	if err != nil {
+		t.Fatalf("user store: %v", err)
+	}
+	if err := store.CreateProfile(context.Background(), userstore.Profile{ID: profileID, Name: "HTTP sort preference"}); err != nil {
+		t.Fatalf("seed profile: %v", err)
+	}
+	t.Cleanup(func() {
+		_ = store.DeleteProfile(context.Background(), profileID)
+	})
+
+	put := func(body string) *httptest.ResponseRecorder {
+		req := authed(httptest.NewRequest(http.MethodPut, "/collections/sort-preference", strings.NewReader(body)), userID, profileID)
+		rec := httptest.NewRecorder()
+		handler.HandleSetCollectionSortPreference(rec, req)
+		return rec
+	}
+
+	t.Run("saves a sort the viewer picked", func(t *testing.T) {
+		rec := put(`{"collection_kind":"library","collection_id":"` + collectionID + `","field":"title","order":"asc"}`)
+		if rec.Code != http.StatusOK {
+			t.Fatalf("status = %d, body = %s", rec.Code, rec.Body.String())
+		}
+		var resp collectionSortPreferenceResponse
+		if err := json.Unmarshal(rec.Body.Bytes(), &resp); err != nil {
+			t.Fatalf("decode: %v", err)
+		}
+		if resp.Field != "title" || resp.Order != "asc" {
+			t.Fatalf("response = %+v", resp)
+		}
+
+		// Read it back through the store, not the response, so the assertion
+		// covers persistence rather than echo.
+		pref, err := store.GetCollectionSortPreference(context.Background(), profileID, userstore.CollectionKindLibrary, collectionID)
+		if err != nil || pref == nil {
+			t.Fatalf("stored preference = %v, err = %v", pref, err)
+		}
+		if pref.SortField != "title" || pref.SortOrder != "asc" {
+			t.Fatalf("stored preference = %+v", pref)
+		}
+	})
+
+	t.Run("fills in the field's default order", func(t *testing.T) {
+		rec := put(`{"collection_kind":"library","collection_id":"` + collectionID + `","field":"year"}`)
+		if rec.Code != http.StatusOK {
+			t.Fatalf("status = %d, body = %s", rec.Code, rec.Body.String())
+		}
+		pref, _ := store.GetCollectionSortPreference(context.Background(), profileID, userstore.CollectionKindLibrary, collectionID)
+		if pref == nil || pref.SortOrder != "desc" {
+			t.Fatalf("stored preference = %+v, want year/desc", pref)
+		}
+	})
+
+	t.Run("an empty field pins to source order", func(t *testing.T) {
+		rec := put(`{"collection_kind":"library","collection_id":"` + collectionID + `","field":""}`)
+		if rec.Code != http.StatusOK {
+			t.Fatalf("status = %d, body = %s", rec.Code, rec.Body.String())
+		}
+		pref, _ := store.GetCollectionSortPreference(context.Background(), profileID, userstore.CollectionKindLibrary, collectionID)
+		if pref == nil {
+			t.Fatal("pinning to source order removed the row; it must persist as an explicit choice")
+		}
+		if pref.SortField != "" {
+			t.Fatalf("stored field = %q, want empty", pref.SortField)
+		}
+	})
+
+	t.Run("accepts a personalized viewer sort on a library collection", func(t *testing.T) {
+		rec := put(`{"collection_kind":"library","collection_id":"` + collectionID + `","field":"progress"}`)
+		if rec.Code != http.StatusOK {
+			t.Fatalf("status = %d, body = %s", rec.Code, rec.Body.String())
+		}
+		pref, _ := store.GetCollectionSortPreference(context.Background(), profileID, userstore.CollectionKindLibrary, collectionID)
+		if pref == nil || pref.SortField != "progress" || pref.SortOrder != "desc" {
+			t.Fatalf("stored preference = %+v, want progress/desc", pref)
+		}
+	})
+
+	t.Run("rejects an invalid sort order", func(t *testing.T) {
+		rec := put(`{"collection_kind":"library","collection_id":"` + collectionID + `","field":"title","order":"sideways"}`)
+		if rec.Code != http.StatusBadRequest {
+			t.Fatalf("status = %d, want 400; body = %s", rec.Code, rec.Body.String())
+		}
+	})
+
+	t.Run("accepts a personalized sort on a personal collection", func(t *testing.T) {
+		rec := put(`{"collection_kind":"user","collection_id":"http-user-collection","field":"progress"}`)
+		if rec.Code != http.StatusOK {
+			t.Fatalf("status = %d, body = %s", rec.Code, rec.Body.String())
+		}
+		t.Cleanup(func() {
+			_ = store.ClearCollectionSortPreference(context.Background(), profileID, userstore.CollectionKindUser, "http-user-collection")
+		})
+	})
+
+	t.Run("rejects an unknown collection kind", func(t *testing.T) {
+		rec := put(`{"collection_kind":"nonsense","collection_id":"x","field":"title"}`)
+		if rec.Code != http.StatusBadRequest {
+			t.Fatalf("status = %d, want 400", rec.Code)
+		}
+	})
+
+	t.Run("clearing removes the override", func(t *testing.T) {
+		req := authed(httptest.NewRequest(http.MethodDelete,
+			"/collections/sort-preference?collection_kind=library&collection_id="+collectionID, nil), userID, profileID)
+		rec := httptest.NewRecorder()
+		handler.HandleClearCollectionSortPreference(rec, req)
+		if rec.Code != http.StatusNoContent {
+			t.Fatalf("status = %d, body = %s", rec.Code, rec.Body.String())
+		}
+		pref, err := store.GetCollectionSortPreference(context.Background(), profileID, userstore.CollectionKindLibrary, collectionID)
+		if err != nil {
+			t.Fatalf("reading cleared preference: %v", err)
+		}
+		if pref != nil {
+			t.Fatalf("preference still present after clear: %+v", pref)
+		}
+	})
+}
+
+// TestNormalizeCollectionSortConfigForCreators covers the validation the
+// collection create/update handlers apply to a creator-configured default.
+func TestNormalizeCollectionSortConfigForCreators(t *testing.T) {
+	cases := []struct {
+		name              string
+		raw               string
+		allowPersonalized bool
+		want              string
+		wantErr           bool
+	}{
+		{name: "absent", raw: "", want: "{}"},
+		{name: "explicit null", raw: `null`, want: "{}"},
+		{name: "legacy empty object", raw: `{}`, want: "{}"},
+		{name: "empty field remains source order", raw: `{"field":""}`, want: `{"field":""}`},
+		{name: "preserves manual pins mode", raw: `{"mode":"manual_pins"}`, want: `{"mode":"manual_pins"}`},
+		{name: "canonicalizes", raw: `{"field":"  Title ","order":"ASC"}`, want: `{"field":"title","order":"asc"}`},
+		{name: "fills the default order", raw: `{"field":"year"}`, want: `{"field":"year","order":"desc"}`},
+		{name: "rejects unknown fields", raw: `{"field":"not_a_sort"}`, wantErr: true},
+		{name: "rejects invalid orders", raw: `{"field":"year","order":"sideways"}`, wantErr: true},
+		{name: "rejects personalized for library", raw: `{"field":"progress"}`, wantErr: true},
+		{
+			name:              "allows personalized for personal",
+			raw:               `{"field":"progress"}`,
+			allowPersonalized: true,
+			want:              `{"field":"progress","order":"desc"}`,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := NormalizeCollectionSortConfig(json.RawMessage(tc.raw), tc.allowPersonalized)
+			if tc.wantErr {
+				if err == nil {
+					t.Fatalf("expected an error, got %q", got)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if got != tc.want {
+				t.Fatalf("got %s, want %s", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestNormalizeCollectionSortConfigPreservesManualPinsAcrossUpdates(t *testing.T) {
+	const manualPins = `{"mode":"manual_pins"}`
+	created, err := NormalizeCollectionSortConfig(json.RawMessage(manualPins), false)
+	if err != nil {
+		t.Fatalf("normalize on create: %v", err)
+	}
+	updated, err := NormalizeCollectionSortConfig(json.RawMessage(created), false)
+	if err != nil {
+		t.Fatalf("normalize on update: %v", err)
+	}
+	if updated != manualPins {
+		t.Fatalf("manual pins config changed across create/read/update: got %s, want %s", updated, manualPins)
+	}
+}

--- a/internal/api/handlers/collections.go
+++ b/internal/api/handlers/collections.go
@@ -106,8 +106,11 @@ type collectionCapabilitiesResponse struct {
 	// DisplayFilterFields are the catalog query fields a personal-collection
 	// display filter may use. Clients build a display_query_definition fragment
 	// from these rather than a bespoke enum.
-	DisplayFilterFields  []string                       `json:"display_filter_fields"`
-	DisplayFilterPresets collectionDisplayFilterPresets `json:"display_filter_presets"`
+	DisplayFilterFields       []string                       `json:"display_filter_fields"`
+	DisplayFilterPresets      collectionDisplayFilterPresets `json:"display_filter_presets"`
+	CollectionDefaultSort     bool                           `json:"collection_default_sort"`
+	CollectionSortPreferences bool                           `json:"collection_sort_preferences"`
+	EffectiveCollectionSort   bool                           `json:"effective_collection_sort"`
 }
 
 type collectionDisplayFilterPresets struct {
@@ -233,6 +236,9 @@ func (h *CollectionHandler) HandleCapabilities(w http.ResponseWriter, r *http.Re
 			Watched: []string{"all", "watched", "unwatched"},
 			Media:   []string{"all", "movie", "series"},
 		},
+		CollectionDefaultSort:     true,
+		CollectionSortPreferences: true,
+		EffectiveCollectionSort:   true,
 	})
 }
 
@@ -274,7 +280,11 @@ func (h *CollectionHandler) HandleCreateCollection(w http.ResponseWriter, r *htt
 		}
 	}
 	queryDefinition := string(queryDefinitionJSON)
-	sortConfig := string(defaultJSON(req.SortConfig))
+	sortConfig, err := NormalizeCollectionSortConfig(req.SortConfig, true)
+	if err != nil {
+		writeError(w, http.StatusBadRequest, "bad_request", err.Error())
+		return
+	}
 	displayQueryDefinition, err := catalog.NormalizeDisplayQueryFragment(req.DisplayQueryDefinition)
 	if err != nil {
 		writeError(w, http.StatusBadRequest, "bad_request", err.Error())
@@ -358,7 +368,11 @@ func (h *CollectionHandler) HandleUpdateCollection(w http.ResponseWriter, r *htt
 		input.QueryDefinition = &value
 	}
 	if len(req.SortConfig) > 0 {
-		value := string(req.SortConfig)
+		value, err := NormalizeCollectionSortConfig(req.SortConfig, true)
+		if err != nil {
+			writeError(w, http.StatusBadRequest, "bad_request", err.Error())
+			return
+		}
 		input.SortConfig = &value
 	}
 	input.IsShared = req.IsShared

--- a/internal/api/handlers/collections.go
+++ b/internal/api/handlers/collections.go
@@ -22,11 +22,12 @@ import (
 
 // CollectionHandler handles personal collection CRUD endpoints.
 type CollectionHandler struct {
-	storeProvider userstore.UserStoreProvider
-	Executor      *catalog.QueryExecutor
-	S3GP          *s3client.Client
-	HTTPClient    *http.Client
-	PresignTTL    time.Duration
+	storeProvider      userstore.UserStoreProvider
+	LibraryCollections collectionPreferenceLibraryReader
+	Executor           *catalog.QueryExecutor
+	S3GP               *s3client.Client
+	HTTPClient         *http.Client
+	PresignTTL         time.Duration
 }
 
 // NewCollectionHandler creates a new CollectionHandler.

--- a/internal/api/handlers/collections_capabilities_test.go
+++ b/internal/api/handlers/collections_capabilities_test.go
@@ -1,0 +1,25 @@
+package handlers
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestCollectionCapabilitiesAdvertiseSortSupport(t *testing.T) {
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/collections/capabilities", nil)
+	NewCollectionHandler(nil).HandleCapabilities(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, body = %s", rec.Code, rec.Body.String())
+	}
+	var got collectionCapabilitiesResponse
+	if err := json.Unmarshal(rec.Body.Bytes(), &got); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if !got.CollectionDefaultSort || !got.CollectionSortPreferences || !got.EffectiveCollectionSort {
+		t.Fatalf("sort capabilities not fully advertised: %+v", got)
+	}
+}

--- a/internal/api/handlers/library_collections.go
+++ b/internal/api/handlers/library_collections.go
@@ -377,21 +377,22 @@ type updateLibraryCollectionRequest struct {
 }
 
 type importMDBListRequest struct {
-	LibraryID         int    `json:"library_id"`
-	LibraryIDs        []int  `json:"library_ids"`
-	Title             string `json:"title"`
-	Description       string `json:"description"`
-	URL               string `json:"url"`
-	Limit             *int   `json:"limit,omitempty"`
-	Featured          bool   `json:"featured"`
-	SortOrder         int    `json:"sort_order,omitempty"`
-	PosterURL         string `json:"poster_url"`
-	PosterSourceURL   string `json:"poster_source_url"`
-	BackdropSourceURL string `json:"backdrop_source_url"`
-	SyncSchedule      string `json:"sync_schedule"`
-	ManagementMode    string `json:"management_mode,omitempty"`
-	ManagementSource  string `json:"management_source,omitempty"`
-	ManagementKey     string `json:"management_key,omitempty"`
+	SortConfig        json.RawMessage `json:"sort_config,omitempty"`
+	LibraryID         int             `json:"library_id"`
+	LibraryIDs        []int           `json:"library_ids"`
+	Title             string          `json:"title"`
+	Description       string          `json:"description"`
+	URL               string          `json:"url"`
+	Limit             *int            `json:"limit,omitempty"`
+	Featured          bool            `json:"featured"`
+	SortOrder         int             `json:"sort_order,omitempty"`
+	PosterURL         string          `json:"poster_url"`
+	PosterSourceURL   string          `json:"poster_source_url"`
+	BackdropSourceURL string          `json:"backdrop_source_url"`
+	SyncSchedule      string          `json:"sync_schedule"`
+	ManagementMode    string          `json:"management_mode,omitempty"`
+	ManagementSource  string          `json:"management_source,omitempty"`
+	ManagementKey     string          `json:"management_key,omitempty"`
 	// PosterFromTemplate marks the poster as supplied by a template bundle so
 	// future template applies can refresh it. Set programmatically by
 	// createCollectionFromTemplate; not user-settable via JSON.
@@ -399,24 +400,25 @@ type importMDBListRequest struct {
 }
 
 type importTMDBRequest struct {
-	LibraryID          int    `json:"library_id"`
-	LibraryIDs         []int  `json:"library_ids"`
-	Title              string `json:"title"`
-	Description        string `json:"description"`
-	Preset             string `json:"preset"`
-	TimeWindow         string `json:"time_window"`
-	MediaType          string `json:"media_type"`
-	Limit              *int   `json:"limit,omitempty"`
-	Featured           bool   `json:"featured"`
-	SortOrder          int    `json:"sort_order,omitempty"`
-	PosterURL          string `json:"poster_url"`
-	PosterSourceURL    string `json:"poster_source_url"`
-	BackdropSourceURL  string `json:"backdrop_source_url"`
-	SyncSchedule       string `json:"sync_schedule"`
-	ManagementMode     string `json:"management_mode,omitempty"`
-	ManagementSource   string `json:"management_source,omitempty"`
-	ManagementKey      string `json:"management_key,omitempty"`
-	PosterFromTemplate bool   `json:"-"`
+	SortConfig         json.RawMessage `json:"sort_config,omitempty"`
+	LibraryID          int             `json:"library_id"`
+	LibraryIDs         []int           `json:"library_ids"`
+	Title              string          `json:"title"`
+	Description        string          `json:"description"`
+	Preset             string          `json:"preset"`
+	TimeWindow         string          `json:"time_window"`
+	MediaType          string          `json:"media_type"`
+	Limit              *int            `json:"limit,omitempty"`
+	Featured           bool            `json:"featured"`
+	SortOrder          int             `json:"sort_order,omitempty"`
+	PosterURL          string          `json:"poster_url"`
+	PosterSourceURL    string          `json:"poster_source_url"`
+	BackdropSourceURL  string          `json:"backdrop_source_url"`
+	SyncSchedule       string          `json:"sync_schedule"`
+	ManagementMode     string          `json:"management_mode,omitempty"`
+	ManagementSource   string          `json:"management_source,omitempty"`
+	ManagementKey      string          `json:"management_key,omitempty"`
+	PosterFromTemplate bool            `json:"-"`
 }
 
 // importTMDBFranchiseRequest is the request body for creating a collection
@@ -487,13 +489,14 @@ type importTMDBDiscoverSpecBody struct {
 }
 
 type importTraktRequest struct {
-	LibraryID   int    `json:"library_id"`
-	LibraryIDs  []int  `json:"library_ids"`
-	Title       string `json:"title"`
-	Description string `json:"description"`
-	Preset      string `json:"preset"`
-	MediaType   string `json:"media_type"`
-	ProfileID   string `json:"profile_id,omitempty"`
+	SortConfig  json.RawMessage `json:"sort_config,omitempty"`
+	LibraryID   int             `json:"library_id"`
+	LibraryIDs  []int           `json:"library_ids"`
+	Title       string          `json:"title"`
+	Description string          `json:"description"`
+	Preset      string          `json:"preset"`
+	MediaType   string          `json:"media_type"`
+	ProfileID   string          `json:"profile_id,omitempty"`
 	// ListURL selects a user-authored Trakt list
 	// (https://trakt.tv/users/{user}/lists/{slug}) instead of a preset.
 	ListURL           string `json:"list_url,omitempty"`
@@ -1137,6 +1140,14 @@ func (h *LibraryCollectionHandler) HandleCreateAdminCollection(w http.ResponseWr
 		}
 	}
 
+	// Library collections resolve with user scope stripped, so per-profile sort
+	// fields are rejected here rather than failing at browse time.
+	sortConfig, err := NormalizeCollectionSortConfig(req.SortConfig, false)
+	if err != nil {
+		writeError(w, http.StatusBadRequest, "bad_request", err.Error())
+		return
+	}
+
 	var syncSchedule *string
 	if s := strings.TrimSpace(req.SyncSchedule); s != "" {
 		if err := catalog.ParseCronExpression(s); err != nil {
@@ -1166,7 +1177,7 @@ func (h *LibraryCollectionHandler) HandleCreateAdminCollection(w http.ResponseWr
 		BackdropURL:      req.BackdropURL,
 		SourceURL:        req.SourceURL,
 		QueryDefinition:  queryDefinition,
-		SortConfig:       defaultJSON(req.SortConfig),
+		SortConfig:       json.RawMessage(sortConfig),
 		SourceConfig:     defaultCollectionSourceConfig(req.SourceConfig),
 		ManagementMode:   managementMode,
 		ManagementSource: managementSource,
@@ -1225,6 +1236,16 @@ func (h *LibraryCollectionHandler) HandleUpdateAdminCollection(w http.ResponseWr
 		}
 	}
 
+	sortConfig := req.SortConfig
+	if len(req.SortConfig) > 0 {
+		normalized, err := NormalizeCollectionSortConfig(req.SortConfig, false)
+		if err != nil {
+			writeError(w, http.StatusBadRequest, "bad_request", err.Error())
+			return
+		}
+		sortConfig = json.RawMessage(normalized)
+	}
+
 	// Validate sync_schedule if provided.
 	if req.SyncSchedule != nil && *req.SyncSchedule != "" {
 		if err := catalog.ParseCronExpression(*req.SyncSchedule); err != nil {
@@ -1257,7 +1278,7 @@ func (h *LibraryCollectionHandler) HandleUpdateAdminCollection(w http.ResponseWr
 		BackdropURL:      req.BackdropURL,
 		SourceURL:        req.SourceURL,
 		QueryDefinition:  queryDefinition,
-		SortConfig:       req.SortConfig,
+		SortConfig:       sortConfig,
 		SourceConfig:     req.SourceConfig,
 		ManagementMode:   normalizeOptionalCollectionManagementMode(req.ManagementMode),
 		ManagementSource: req.ManagementSource,
@@ -2636,6 +2657,10 @@ func (h *LibraryCollectionHandler) createMDBListCollection(
 	if err != nil {
 		return nil, requestValidationError{err: err}
 	}
+	sortConfig, err := NormalizeCollectionSortConfig(req.SortConfig, false)
+	if err != nil {
+		return nil, requestValidationError{err: err}
+	}
 	collection, err := h.repo.Create(ctx, catalog.CreateLibraryCollectionInput{
 		LibraryID:          req.LibraryID,
 		LibraryIDs:         req.LibraryIDs,
@@ -2643,6 +2668,7 @@ func (h *LibraryCollectionHandler) createMDBListCollection(
 		Title:              req.Title,
 		Description:        req.Description,
 		CollectionType:     "mdblist",
+		SortConfig:         json.RawMessage(sortConfig),
 		Visibility:         "visible",
 		Featured:           req.Featured,
 		SortOrder:          req.SortOrder,
@@ -2696,6 +2722,10 @@ func (h *LibraryCollectionHandler) createTMDBCollection(
 	if err != nil {
 		return nil, requestValidationError{err: err}
 	}
+	tmdbSortConfig, err := NormalizeCollectionSortConfig(req.SortConfig, false)
+	if err != nil {
+		return nil, requestValidationError{err: err}
+	}
 	collection, err := h.repo.Create(ctx, catalog.CreateLibraryCollectionInput{
 		LibraryID:          req.LibraryID,
 		LibraryIDs:         req.LibraryIDs,
@@ -2703,6 +2733,7 @@ func (h *LibraryCollectionHandler) createTMDBCollection(
 		Title:              req.Title,
 		Description:        req.Description,
 		CollectionType:     "tmdb",
+		SortConfig:         json.RawMessage(tmdbSortConfig),
 		Visibility:         "visible",
 		Featured:           req.Featured,
 		SortOrder:          req.SortOrder,
@@ -3048,6 +3079,12 @@ func (h *LibraryCollectionHandler) HandleImportTraktCollection(w http.ResponseWr
 		return
 	}
 
+	traktSortConfig, err := NormalizeCollectionSortConfig(req.SortConfig, false)
+	if err != nil {
+		writeError(w, http.StatusBadRequest, "bad_request", err.Error())
+		return
+	}
+
 	collection, err := h.repo.Create(r.Context(), catalog.CreateLibraryCollectionInput{
 		LibraryID:        req.LibraryID,
 		LibraryIDs:       req.LibraryIDs,
@@ -3055,6 +3092,7 @@ func (h *LibraryCollectionHandler) HandleImportTraktCollection(w http.ResponseWr
 		Title:            req.Title,
 		Description:      req.Description,
 		CollectionType:   "trakt",
+		SortConfig:       json.RawMessage(traktSortConfig),
 		Visibility:       "visible",
 		Featured:         req.Featured,
 		PosterURL:        req.PosterURL,

--- a/internal/api/handlers/library_collections.go
+++ b/internal/api/handlers/library_collections.go
@@ -33,26 +33,28 @@ import (
 	"github.com/Silo-Server/silo-server/internal/s3client"
 	"github.com/Silo-Server/silo-server/internal/sections"
 	"github.com/Silo-Server/silo-server/internal/usercollections"
+	"github.com/Silo-Server/silo-server/internal/userstore"
 )
 
 type LibraryCollectionHandler struct {
-	repo                *catalog.LibraryCollectionRepository
-	service             *catalog.LibraryCollectionService
-	itemRepo            *catalog.ItemRepository
-	Executor            *catalog.QueryExecutor
-	detailSvc           *catalog.DetailService
-	presignTTL          time.Duration
-	httpClient          *http.Client
-	s3GP                *s3client.Client
-	FrontendFS          fs.FS
-	SectionRepo         *sections.Repository
-	UserCollectionPool  *pgxpool.Pool
-	GroupRepo           *catalog.LibraryCollectionGroupRepository
-	FolderRepo          *catalog.FolderRepository
-	TemplateRegistry    *templates.Registry
-	SmartCountRefresher *catalog.SmartCountRefresher
-	JobRepo             *adminjob.Repository
-	EventsHub           *evt.Hub
+	repo                  *catalog.LibraryCollectionRepository
+	service               *catalog.LibraryCollectionService
+	itemRepo              *catalog.ItemRepository
+	Executor              *catalog.QueryExecutor
+	detailSvc             *catalog.DetailService
+	presignTTL            time.Duration
+	httpClient            *http.Client
+	s3GP                  *s3client.Client
+	FrontendFS            fs.FS
+	SectionRepo           *sections.Repository
+	UserCollectionPool    *pgxpool.Pool
+	GroupRepo             *catalog.LibraryCollectionGroupRepository
+	FolderRepo            *catalog.FolderRepository
+	TemplateRegistry      *templates.Registry
+	SmartCountRefresher   *catalog.SmartCountRefresher
+	JobRepo               *adminjob.Repository
+	EventsHub             *evt.Hub
+	SortPreferenceCleaner *userstore.CollectionSortPreferenceCleaner
 }
 
 var errLibraryCollectionInUse = errors.New("collection is used by one or more sections")
@@ -1452,7 +1454,13 @@ func (h *LibraryCollectionHandler) deleteServerCollection(ctx context.Context, c
 		}
 	}
 
-	return h.repo.Delete(ctx, collectionID)
+	if err := h.repo.Delete(ctx, collectionID); err != nil {
+		return err
+	}
+	if h.SortPreferenceCleaner != nil {
+		h.SortPreferenceCleaner.DeleteForCollection(ctx, userstore.CollectionKindLibrary, collectionID)
+	}
+	return nil
 }
 
 type adminReorderCollectionsRequest struct {

--- a/internal/api/handlers/sections.go
+++ b/internal/api/handlers/sections.go
@@ -23,18 +23,19 @@ import (
 
 // SectionHandler handles section management and batch section endpoints.
 type SectionHandler struct {
-	repo           *sections.Repository
-	fetcher        *sections.Fetcher
-	previewFetcher sectionPreviewFetcher // set to fetcher at construction; separate for test injection
-	episodeFetcher sectionEpisodeFetcher
-	FolderRepo     *catalog.FolderRepository
-	EpisodeRepo    *catalog.EpisodeRepository
-	StoreProvider  userstore.UserStoreProvider
-	UserRepo       *auth.UserRepository
-	DetailSvc      *catalog.DetailService
-	Settings       catalog.SettingsStore
-	CollectionRepo *catalog.LibraryCollectionRepository
-	EbookProgress  EbookReaderProgressLister
+	repo                  *sections.Repository
+	fetcher               *sections.Fetcher
+	previewFetcher        sectionPreviewFetcher // set to fetcher at construction; separate for test injection
+	episodeFetcher        sectionEpisodeFetcher
+	FolderRepo            *catalog.FolderRepository
+	EpisodeRepo           *catalog.EpisodeRepository
+	StoreProvider         userstore.UserStoreProvider
+	UserRepo              *auth.UserRepository
+	DetailSvc             *catalog.DetailService
+	Settings              catalog.SettingsStore
+	CollectionRepo        *catalog.LibraryCollectionRepository
+	SortPreferenceCleaner *userstore.CollectionSortPreferenceCleaner
+	EbookProgress         EbookReaderProgressLister
 }
 
 // NewSectionHandler creates a new SectionHandler.
@@ -405,6 +406,8 @@ func (h *SectionHandler) deleteUnreferencedSectionManagedCollection(ctx context.
 	}
 	if err := h.CollectionRepo.Delete(ctx, collectionID); err != nil && !errors.Is(err, catalog.ErrLibraryCollectionNotFound) {
 		slog.WarnContext(ctx, "failed to delete unreferenced section-managed collection", "component", "api", "collection_id", collectionID, "error", err)
+	} else if err == nil && h.SortPreferenceCleaner != nil {
+		h.SortPreferenceCleaner.DeleteForCollection(ctx, userstore.CollectionKindLibrary, collectionID)
 	}
 }
 

--- a/internal/api/handlers/user_collection_imports.go
+++ b/internal/api/handlers/user_collection_imports.go
@@ -75,6 +75,7 @@ type userImportSharedFields struct {
 	PosterURL              string          `json:"poster_url"`
 	LibraryIDs             []int           `json:"library_ids,omitempty"`
 	DisplayQueryDefinition json.RawMessage `json:"display_query_definition,omitempty"`
+	SortConfig             json.RawMessage `json:"sort_config,omitempty"`
 }
 
 type userImportMDBListRequest struct {
@@ -217,6 +218,11 @@ func (h *UserCollectionImportHandler) createImportedCollection(
 		writeError(w, http.StatusBadRequest, "bad_request", err.Error())
 		return
 	}
+	sortConfig, err := NormalizeCollectionSortConfig(shared.SortConfig, true)
+	if err != nil {
+		writeError(w, http.StatusBadRequest, "bad_request", err.Error())
+		return
+	}
 
 	collection, err := store.CreateCollection(r.Context(), userstore.CreateCollectionInput{
 		CreatorProfileID:       profileID,
@@ -225,7 +231,7 @@ func (h *UserCollectionImportHandler) createImportedCollection(
 		CollectionType:         collectionType,
 		IsShared:               shared.IsShared,
 		QueryDefinition:        "{}",
-		SortConfig:             "{}",
+		SortConfig:             sortConfig,
 		SourceURL:              cfg.DisplayURL(),
 		SourceConfig:           sourceConfigJSON,
 		SyncSchedule:           schedule,

--- a/internal/api/router.go
+++ b/internal/api/router.go
@@ -2282,6 +2282,8 @@ func NewRouter(deps Dependencies) chi.Router {
 						r.Use(apimw.RequireProfile)
 						r.Get("/", collectionHandler.HandleListCollections)
 						r.Get("/capabilities", collectionHandler.HandleCapabilities)
+						r.Put("/sort-preference", collectionHandler.HandleSetCollectionSortPreference)
+						r.Delete("/sort-preference", collectionHandler.HandleClearCollectionSortPreference)
 						if libraryCollectionHandler != nil {
 							// Aggregated server (admin-curated) collections across
 							// every accessible library. Separate from "/" (personal,

--- a/internal/api/router.go
+++ b/internal/api/router.go
@@ -1438,6 +1438,14 @@ func NewRouter(deps Dependencies) chi.Router {
 		}
 
 		libraryCollectionRepo := catalog.NewLibraryCollectionRepository(deps.DB)
+		var collectionSortCleaner *userstore.CollectionSortPreferenceCleaner
+		if userRepo != nil && deps.UserStoreProvider != nil {
+			collectionSortCleaner = userstore.NewCollectionSortPreferenceCleaner(userRepo, deps.UserStoreProvider)
+		}
+		if collectionHandler != nil {
+			collectionHandler.LibraryCollections = libraryCollectionRepo
+		}
+		sectionHandler.SortPreferenceCleaner = collectionSortCleaner
 		if libraryCollectionService == nil {
 			libraryCollectionService = catalog.NewLibraryCollectionService(
 				libraryCollectionRepo,
@@ -1537,6 +1545,7 @@ func NewRouter(deps Dependencies) chi.Router {
 		libraryCollectionHandler.SectionRepo = sectionRepo
 		libraryCollectionHandler.UserCollectionPool = deps.DB
 		libraryCollectionHandler.EventsHub = deps.EventsHub
+		libraryCollectionHandler.SortPreferenceCleaner = collectionSortCleaner
 		if deps.FolderRepo != nil {
 			libraryCollectionHandler.FolderRepo = deps.FolderRepo
 		} else {

--- a/internal/catalog/access_filter.go
+++ b/internal/catalog/access_filter.go
@@ -8,6 +8,8 @@ import (
 	"github.com/Silo-Server/silo-server/internal/models"
 )
 
+const LibraryCollectionVisibilityVisible = "visible"
+
 // AccessFilter captures effective viewer access constraints for catalog reads.
 type AccessFilter struct {
 	AllowedLibraryIDs     []int
@@ -40,6 +42,29 @@ type AccessFilter struct {
 	// "podcast" — they're served by the ABS-compat API instead). Applied by
 	// every query builder that consumes an AccessFilter.
 	ExcludedMediaTypes []string
+}
+
+// CanAccessLibraryCollection reports whether a visible server collection is
+// reachable through at least one library in the viewer's effective scope.
+// Collections without explicit library scope retain their legacy unrestricted
+// visibility, but restricted viewers cannot address them by ID.
+func CanAccessLibraryCollection(collection *models.LibraryCollection, filter AccessFilter) bool {
+	if collection == nil || collection.Visibility != LibraryCollectionVisibilityVisible {
+		return false
+	}
+	if len(collection.LibraryIDs) == 0 {
+		return filter.AllowedLibraryIDs == nil && len(filter.DisabledLibraryIDs) == 0
+	}
+	for _, libraryID := range collection.LibraryIDs {
+		if filter.AllowedLibraryIDs != nil && !intInSlice(libraryID, filter.AllowedLibraryIDs) {
+			continue
+		}
+		if intInSlice(libraryID, filter.DisabledLibraryIDs) {
+			continue
+		}
+		return true
+	}
+	return false
 }
 
 func applyAccessFilter(alias string, filter AccessFilter, conditions *[]string, args *[]any, argIdx *int) {

--- a/internal/catalog/catalog_resolver.go
+++ b/internal/catalog/catalog_resolver.go
@@ -37,6 +37,12 @@ type CatalogResult struct {
 	SemanticUsed       bool
 	FallbackReason     string
 	IndexPendingEvents int
+	// EffectiveSort is the order collection sources actually resolved in, after
+	// applying the request's own sort, the viewer's saved override, and the
+	// collection's configured default in that order. An empty Field means the
+	// collection's source order. Only collection sources populate it; clients
+	// use it to show which sort is active when the request carried none.
+	EffectiveSort QuerySort
 }
 
 type CatalogFiltersResult struct {
@@ -491,6 +497,31 @@ func (r *CatalogResolver) resolveLibraryCollectionSource(ctx context.Context, re
 		return nil, ErrCatalogSourceNotFound
 	}
 
+	// A sort in the request is the viewer's live choice and always wins; only
+	// when there is none do the saved override and the collection's configured
+	// default come into play.
+	if req.UseSourceOrder {
+		if qs, ok := r.EffectiveCollectionSort(ctx, access, userstore.CollectionKindLibrary, collection.ID, collection.SortConfig); ok {
+			req.Query.Sort = qs
+			req.UseSourceOrder = false
+		}
+	}
+
+	result, err := r.resolveLibraryCollectionItems(ctx, req, access, collection, collectionRepo)
+	if err != nil {
+		return nil, err
+	}
+	result.EffectiveSort = req.Query.Sort
+	return result, nil
+}
+
+func (r *CatalogResolver) resolveLibraryCollectionItems(
+	ctx context.Context,
+	req CatalogRequest,
+	access AccessFilter,
+	collection *models.LibraryCollection,
+	collectionRepo *LibraryCollectionRepository,
+) (*CatalogResult, error) {
 	if IsLiveQueryType(collection.CollectionType) {
 		return r.resolveLiveLibraryCollectionSource(ctx, req, access, collection)
 	}
@@ -548,6 +579,30 @@ func (r *CatalogResolver) resolveUserCollectionSource(ctx context.Context, req C
 		return nil, ErrCatalogSourceNotFound
 	}
 
+	// See resolveLibraryCollectionSource: an explicit request sort wins, then
+	// the viewer's saved override, then the collection's configured default.
+	if req.UseSourceOrder {
+		if qs, ok := r.EffectiveCollectionSort(ctx, access, userstore.CollectionKindUser, collection.ID, []byte(collection.SortConfig)); ok {
+			req.Query.Sort = qs
+			req.UseSourceOrder = false
+		}
+	}
+
+	result, err := r.resolveUserCollectionItems(ctx, req, access, store, collection)
+	if err != nil {
+		return nil, err
+	}
+	result.EffectiveSort = req.Query.Sort
+	return result, nil
+}
+
+func (r *CatalogResolver) resolveUserCollectionItems(
+	ctx context.Context,
+	req CatalogRequest,
+	access AccessFilter,
+	store userstore.UserStore,
+	collection *userstore.Collection,
+) (*CatalogResult, error) {
 	if IsLiveQueryType(collection.CollectionType) {
 		def, err := parseCatalogCollectionQueryDefinition([]byte(collection.QueryDefinition))
 		if err != nil {

--- a/internal/catalog/catalog_resolver.go
+++ b/internal/catalog/catalog_resolver.go
@@ -493,26 +493,16 @@ func (r *CatalogResolver) resolveSectionBrowseSource(ctx context.Context, req Ca
 func (r *CatalogResolver) resolveLibraryCollectionSource(ctx context.Context, req CatalogRequest, access AccessFilter) (*CatalogResult, error) {
 	collectionRepo := NewLibraryCollectionRepository(r.itemRepo.pool)
 	collection, err := collectionRepo.GetByID(ctx, req.CollectionID)
-	if err != nil || collection.Visibility != "visible" {
+	if err != nil || !CanAccessLibraryCollection(collection, access) {
 		return nil, ErrCatalogSourceNotFound
 	}
 
-	// A sort in the request is the viewer's live choice and always wins; only
-	// when there is none do the saved override and the collection's configured
-	// default come into play.
-	if req.UseSourceOrder {
-		if qs, ok := r.EffectiveCollectionSort(ctx, access, userstore.CollectionKindLibrary, collection.ID, collection.SortConfig); ok {
-			req.Query.Sort = qs
-			req.UseSourceOrder = false
-		}
-	}
-
-	result, err := r.resolveLibraryCollectionItems(ctx, req, access, collection, collectionRepo)
-	if err != nil {
-		return nil, err
-	}
-	result.EffectiveSort = req.Query.Sort
-	return result, nil
+	return r.resolveCollectionWithEffectiveSort(
+		ctx, req, access, userstore.CollectionKindLibrary, collection.ID, collection.SortConfig,
+		func(req CatalogRequest) (*CatalogResult, error) {
+			return r.resolveLibraryCollectionItems(ctx, req, access, collection, collectionRepo)
+		},
+	)
 }
 
 func (r *CatalogResolver) resolveLibraryCollectionItems(
@@ -575,20 +565,41 @@ func (r *CatalogResolver) resolveUserCollectionSource(ctx context.Context, req C
 	}
 
 	collection, err := store.GetCollection(ctx, req.CollectionID)
-	if err != nil || !catalogProfileCanAccessCollection(collection, access.ProfileID) {
+	if err != nil || !ProfileCanAccessCollection(collection, access.ProfileID) {
 		return nil, ErrCatalogSourceNotFound
 	}
 
-	// See resolveLibraryCollectionSource: an explicit request sort wins, then
-	// the viewer's saved override, then the collection's configured default.
+	return r.resolveCollectionWithEffectiveSort(
+		ctx, req, access, userstore.CollectionKindUser, collection.ID, []byte(collection.SortConfig),
+		func(req CatalogRequest) (*CatalogResult, error) {
+			return r.resolveUserCollectionItems(ctx, req, access, store, collection)
+		},
+	)
+}
+
+// resolveCollectionWithEffectiveSort applies the shared collection-sort
+// precedence, delegates item resolution, and stamps the resolved order on the
+// response. Keeping this sequence in one place prevents the library and
+// personal collection paths from drifting.
+func (r *CatalogResolver) resolveCollectionWithEffectiveSort(
+	ctx context.Context,
+	req CatalogRequest,
+	access AccessFilter,
+	kind, collectionID string,
+	sortConfig []byte,
+	resolve func(CatalogRequest) (*CatalogResult, error),
+) (*CatalogResult, error) {
+	// A sort in the request is the viewer's live choice and always wins; only
+	// when there is none do the saved override and the collection's configured
+	// default come into play.
 	if req.UseSourceOrder {
-		if qs, ok := r.EffectiveCollectionSort(ctx, access, userstore.CollectionKindUser, collection.ID, []byte(collection.SortConfig)); ok {
+		if qs, ok := r.EffectiveCollectionSort(ctx, access, kind, collectionID, sortConfig); ok {
 			req.Query.Sort = qs
 			req.UseSourceOrder = false
 		}
 	}
 
-	result, err := r.resolveUserCollectionItems(ctx, req, access, store, collection)
+	result, err := resolve(req)
 	if err != nil {
 		return nil, err
 	}
@@ -1741,7 +1752,10 @@ func (r *CatalogResolver) catalogStoreForAccess(ctx context.Context, access Acce
 	return store, nil
 }
 
-func catalogProfileCanAccessCollection(collection *userstore.Collection, profileID string) bool {
+// ProfileCanAccessCollection reports whether profileID may view a personal
+// collection. Creator access is represented in AllowedProfileIDs at write time,
+// so this is the canonical check for both browse and preference endpoints.
+func ProfileCanAccessCollection(collection *userstore.Collection, profileID string) bool {
 	if collection == nil || strings.TrimSpace(profileID) == "" {
 		return false
 	}
@@ -1861,7 +1875,7 @@ func (r *CatalogResolver) loadCollectionSourceBaseItems(ctx context.Context, req
 	case CatalogSourceLibraryCollection:
 		collectionRepo := NewLibraryCollectionRepository(r.itemRepo.pool)
 		collection, err := collectionRepo.GetByID(ctx, req.CollectionID)
-		if err != nil || collection.Visibility != "visible" {
+		if err != nil || collection.Visibility != LibraryCollectionVisibilityVisible {
 			return nil, ErrCatalogSourceNotFound
 		}
 		if IsLiveQueryType(collection.CollectionType) || catalogCollectionUsesLiveQuery(collection.QueryDefinition) {
@@ -1892,7 +1906,7 @@ func (r *CatalogResolver) loadCollectionSourceBaseItems(ctx context.Context, req
 			return nil, err
 		}
 		collection, err := store.GetCollection(ctx, req.CollectionID)
-		if err != nil || !catalogProfileCanAccessCollection(collection, access.ProfileID) {
+		if err != nil || !ProfileCanAccessCollection(collection, access.ProfileID) {
 			return nil, ErrCatalogSourceNotFound
 		}
 		var items []*models.MediaItem

--- a/internal/catalog/collection_sort.go
+++ b/internal/catalog/collection_sort.go
@@ -2,6 +2,7 @@ package catalog
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"log/slog"
 	"strings"
@@ -11,6 +12,55 @@ import (
 	"github.com/Silo-Server/silo-server/internal/models"
 	"github.com/Silo-Server/silo-server/internal/userstore"
 )
+
+// QueryCollectionItemsBySort loads collection members through the catalog
+// query executor, applying an optional personal-collection display filter and
+// the resolved sort before the database limit. This keeps rail queries bounded
+// without changing the full-match total returned to callers.
+func QueryCollectionItemsBySort(
+	ctx context.Context,
+	pool *pgxpool.Pool,
+	contentIDs []string,
+	qs QuerySort,
+	access AccessFilter,
+	limit int,
+	displayQueryDefinition string,
+) ([]*models.MediaItem, int, error) {
+	if len(contentIDs) == 0 {
+		return []*models.MediaItem{}, 0, nil
+	}
+
+	def := QueryDefinition{Sort: qs}
+	if trimmed := strings.TrimSpace(displayQueryDefinition); trimmed != "" {
+		if err := json.Unmarshal([]byte(trimmed), &def); err != nil {
+			return nil, 0, fmt.Errorf("parsing collection display_query_definition: %w", err)
+		}
+		// Display fragments are filter-only. Never let stale or malformed stored
+		// execution fields expand scope, replace the selected sort, or set a
+		// different limit.
+		def.MediaScope = ""
+		def.LibraryIDs = nil
+		def.Sort = qs
+		def.Limit = nil
+	}
+
+	queryAccess := access
+	if access.AllowedContentIDs != nil {
+		queryAccess.AllowedContentIDs = intersectContentIDs(contentIDs, access.AllowedContentIDs)
+	} else {
+		queryAccess.AllowedContentIDs = contentIDs
+	}
+
+	if limit <= 0 || limit > len(contentIDs) {
+		limit = len(contentIDs)
+	}
+	executor := &QueryExecutor{Pool: pool}
+	items, total, err := executor.Preview(ctx, def.Normalize(), queryAccess, limit)
+	if err != nil {
+		return nil, 0, fmt.Errorf("querying collection items by %q: %w", qs.Field, err)
+	}
+	return items, total, nil
+}
 
 // EffectiveCollectionSort resolves the order a collection's items are shown in
 // when the request itself carries no sort. Precedence, highest first:
@@ -79,10 +129,7 @@ func OrderCollectionItemsBySort(
 		return items, nil
 	}
 
-	queryAccess := access
-	queryAccess.AllowedContentIDs = ids
-	executor := &QueryExecutor{Pool: pool}
-	ordered, _, err := executor.Preview(ctx, QueryDefinition{Sort: qs}.Normalize(), queryAccess, len(ids))
+	ordered, _, err := QueryCollectionItemsBySort(ctx, pool, ids, qs, access, len(ids), "")
 	if err != nil {
 		return nil, fmt.Errorf("ordering collection items by %q: %w", qs.Field, err)
 	}

--- a/internal/catalog/collection_sort.go
+++ b/internal/catalog/collection_sort.go
@@ -1,0 +1,138 @@
+package catalog
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"strings"
+
+	"github.com/jackc/pgx/v5/pgxpool"
+
+	"github.com/Silo-Server/silo-server/internal/models"
+	"github.com/Silo-Server/silo-server/internal/userstore"
+)
+
+// EffectiveCollectionSort resolves the order a collection's items are shown in
+// when the request itself carries no sort. Precedence, highest first:
+//
+//  1. the viewing profile's saved override — set by changing the sort while
+//     browsing the collection, and sticky from then on;
+//  2. the default sort the collection's creator configured (sort_config);
+//  3. the collection's own source order, signaled by ok == false.
+//
+// An override row with an empty sort field is a real choice ("keep source
+// order") and short-circuits the creator's default, which is why it returns
+// false rather than falling through.
+//
+// Creator defaults for library collections stay user-agnostic because they are
+// shared. A viewer override is profile-scoped, however, so personalized fields
+// (progress, date viewed, plays) are valid for either collection kind.
+func (r *CatalogResolver) EffectiveCollectionSort(
+	ctx context.Context,
+	access AccessFilter,
+	kind string,
+	collectionID string,
+	sortConfig []byte,
+) (QuerySort, bool) {
+	if pref := r.collectionSortOverride(ctx, access, kind, collectionID); pref != nil {
+		if strings.TrimSpace(pref.SortField) == "" {
+			return QuerySort{}, false
+		}
+		if qs, ok := NormalizeCollectionSort(pref.SortField, pref.SortOrder, true); ok {
+			return qs, true
+		}
+		// A stored override that no longer validates (a sort field retired from
+		// the vocabulary) falls back to the creator's default rather than
+		// failing the browse.
+	}
+
+	return ParseCollectionDefaultSort(sortConfig, kind == userstore.CollectionKindUser)
+}
+
+// OrderCollectionItemsBySort reorders already-loaded collection members by a
+// resolved sort, returning them in that order.
+//
+// Ordering runs through the catalog query executor constrained to the member
+// IDs, so a rail orders items exactly as the collection's browse page does —
+// same NULLS LAST handling, same sort_title collation — rather than through a
+// second, drifting in-memory comparator. An empty sort field returns items
+// untouched (source order). Items the executor does not return (no longer
+// visible to this access scope) are dropped, matching the browse path.
+func OrderCollectionItemsBySort(
+	ctx context.Context,
+	pool *pgxpool.Pool,
+	items []*models.MediaItem,
+	qs QuerySort,
+	access AccessFilter,
+) ([]*models.MediaItem, error) {
+	if strings.TrimSpace(qs.Field) == "" || len(items) == 0 {
+		return items, nil
+	}
+
+	ids := make([]string, 0, len(items))
+	for _, item := range items {
+		if item != nil && strings.TrimSpace(item.ContentID) != "" {
+			ids = append(ids, item.ContentID)
+		}
+	}
+	if len(ids) == 0 {
+		return items, nil
+	}
+
+	queryAccess := access
+	queryAccess.AllowedContentIDs = ids
+	executor := &QueryExecutor{Pool: pool}
+	ordered, _, err := executor.Preview(ctx, QueryDefinition{Sort: qs}.Normalize(), queryAccess, len(ids))
+	if err != nil {
+		return nil, fmt.Errorf("ordering collection items by %q: %w", qs.Field, err)
+	}
+
+	// Preview returns freshly loaded rows; re-project onto the caller's items so
+	// any enrichment already applied to them survives the reorder.
+	byID := make(map[string]*models.MediaItem, len(items))
+	for _, item := range items {
+		if item != nil {
+			byID[item.ContentID] = item
+		}
+	}
+	result := make([]*models.MediaItem, 0, len(ordered))
+	for _, item := range ordered {
+		if item == nil {
+			continue
+		}
+		if original, ok := byID[item.ContentID]; ok {
+			result = append(result, original)
+		}
+	}
+	return result, nil
+}
+
+// collectionSortOverride loads the viewing profile's saved sort for a
+// collection, or nil when there is none. A lookup failure is logged and treated
+// as "no override": a browse must not fail because a preference row could not
+// be read.
+func (r *CatalogResolver) collectionSortOverride(
+	ctx context.Context,
+	access AccessFilter,
+	kind string,
+	collectionID string,
+) *userstore.CollectionSortPreference {
+	if r.storeProvider == nil || access.UserID <= 0 || strings.TrimSpace(access.ProfileID) == "" {
+		return nil
+	}
+	store, err := r.storeProvider.ForUser(ctx, access.UserID)
+	if err != nil || store == nil {
+		if err != nil {
+			slog.WarnContext(ctx, "loading user store for collection sort preference",
+				"collection_kind", kind, "collection_id", collectionID, "error", err)
+		}
+		return nil
+	}
+	pref, err := store.GetCollectionSortPreference(ctx, access.ProfileID, kind, collectionID)
+	if err != nil {
+		slog.WarnContext(ctx, "loading collection sort preference",
+			"collection_kind", kind, "collection_id", collectionID, "error", err)
+		return nil
+	}
+	return pref
+}

--- a/internal/catalog/collection_sort_db_test.go
+++ b/internal/catalog/collection_sort_db_test.go
@@ -1,0 +1,273 @@
+package catalog
+
+import (
+	"context"
+	"os"
+	"testing"
+
+	"github.com/jackc/pgx/v5/pgxpool"
+
+	"github.com/Silo-Server/silo-server/internal/models"
+	"github.com/Silo-Server/silo-server/internal/userstore"
+	"github.com/Silo-Server/silo-server/internal/userstore/pgstore"
+)
+
+// These tests run the default-sort / saved-override flow against a real
+// Postgres: real SQL ordering through the query executor, and a real
+// PostgresUserStore writing the override row. They cover the reported
+// behavior end to end — a collection's creator picks a default order, a viewer
+// re-sorts, and the viewer's choice survives a fresh read.
+//
+// Set SILO_TEST_DATABASE_URL to a migrated database to run them.
+
+func collectionSortTestPool(t *testing.T) *pgxpool.Pool {
+	t.Helper()
+	dsn := os.Getenv("SILO_TEST_DATABASE_URL")
+	if dsn == "" {
+		t.Skip("SILO_TEST_DATABASE_URL is not set")
+	}
+	ctx := context.Background()
+	pool, err := pgxpool.New(ctx, dsn)
+	if err != nil {
+		t.Fatalf("connect test database: %v", err)
+	}
+	t.Cleanup(pool.Close)
+	var tableName *string
+	if err := pool.QueryRow(ctx, `SELECT to_regclass('public.user_collection_sort_preferences')::text`).Scan(&tableName); err != nil {
+		t.Fatalf("check user_collection_sort_preferences table: %v", err)
+	}
+	if tableName == nil || *tableName == "" {
+		t.Skip("test database has not applied the collection sort preference migration")
+	}
+	return pool
+}
+
+// seedSortableItem inserts one sortable item. Callers choose title/year pairs
+// that make a title sort and a year sort disagree, so an order assertion cannot
+// pass by coincidence.
+func seedSortableItem(t *testing.T, pool *pgxpool.Pool, contentID, title string, year int) {
+	t.Helper()
+	ctx := context.Background()
+	if _, err := pool.Exec(ctx, `
+		INSERT INTO media_items (content_id, type, title, sort_title, year, genres)
+		VALUES ($1, 'movie', $2, $2, $3, '{}'::text[])
+	`, contentID, title, year); err != nil {
+		t.Fatalf("seed media item %s: %v", contentID, err)
+	}
+	t.Cleanup(func() {
+		_, _ = pool.Exec(context.Background(), `DELETE FROM media_items WHERE content_id = $1`, contentID)
+	})
+}
+
+func seedSortTestUser(t *testing.T, pool *pgxpool.Pool) int {
+	t.Helper()
+	ctx := context.Background()
+	var userID int
+	// A bare fixture row: the override table has an FK to users(id) and the
+	// test needs something to point at. No credentials are set.
+	if err := pool.QueryRow(ctx, `
+		INSERT INTO users (username, email, password_hash, role)
+		VALUES ('collection-sort-fixture', 'collection-sort-fixture@invalid.test', '', 'user')
+		RETURNING id
+	`).Scan(&userID); err != nil {
+		t.Fatalf("seed fixture user: %v", err)
+	}
+	t.Cleanup(func() {
+		_, _ = pool.Exec(context.Background(), `DELETE FROM users WHERE id = $1`, userID)
+	})
+	return userID
+}
+
+func itemsForSort(contentIDs ...string) []*models.MediaItem {
+	items := make([]*models.MediaItem, 0, len(contentIDs))
+	for _, id := range contentIDs {
+		items = append(items, &models.MediaItem{ContentID: id})
+	}
+	return items
+}
+
+func orderedIDs(items []*models.MediaItem) []string {
+	ids := make([]string, 0, len(items))
+	for _, item := range items {
+		ids = append(ids, item.ContentID)
+	}
+	return ids
+}
+
+func assertOrder(t *testing.T, got []string, want ...string) {
+	t.Helper()
+	if len(got) != len(want) {
+		t.Fatalf("order = %v, want %v", got, want)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("order = %v, want %v", got, want)
+		}
+	}
+}
+
+// TestCollectionDefaultSortAndOverrideEndToEnd walks the whole reported
+// scenario against real Postgres, for both collection kinds.
+func TestCollectionDefaultSortAndOverrideEndToEnd(t *testing.T) {
+	pool := collectionSortTestPool(t)
+	ctx := context.Background()
+
+	// Years are shuffled against titles on purpose: title-asc gives A,B,C but
+	// year-desc gives B,C,A. If the two agreed, an assertion on the override's
+	// order would also pass when the override was ignored entirely.
+	seedSortableItem(t, pool, "cs-a", "Alpha", 2001)
+	seedSortableItem(t, pool, "cs-b", "Bravo", 2003)
+	seedSortableItem(t, pool, "cs-c", "Charlie", 2002)
+
+	// Source order is deliberately neither sorted order.
+	sourceOrder := itemsForSort("cs-c", "cs-a", "cs-b")
+
+	userID := seedSortTestUser(t, pool)
+	provider := pgstore.NewPostgresProvider(pool)
+	store, err := provider.ForUser(ctx, userID)
+	if err != nil {
+		t.Fatalf("user store: %v", err)
+	}
+	if err := store.CreateProfile(ctx, userstore.Profile{ID: "profile-e2e", Name: "E2E sort profile"}); err != nil {
+		t.Fatalf("seed profile: %v", err)
+	}
+	t.Cleanup(func() { _ = store.DeleteProfile(context.Background(), "profile-e2e") })
+
+	resolver := &CatalogResolver{storeProvider: provider}
+	access := AccessFilter{UserID: userID, ProfileID: "profile-e2e"}
+
+	for _, kind := range []string{userstore.CollectionKindLibrary, userstore.CollectionKindUser} {
+		t.Run(kind, func(t *testing.T) {
+			collectionID := "cs-collection-" + kind
+			t.Cleanup(func() {
+				_ = store.ClearCollectionSortPreference(ctx, access.ProfileID, kind, collectionID)
+			})
+
+			// 1. No default, no override — the collection keeps source order.
+			if _, ok := resolver.EffectiveCollectionSort(ctx, access, kind, collectionID, []byte(`{}`)); ok {
+				t.Fatal("a collection with no default reported a sort")
+			}
+
+			// 2. The creator sets a default of Title (A→Z).
+			defaultSort := []byte(`{"field":"title","order":"asc"}`)
+			qs, ok := resolver.EffectiveCollectionSort(ctx, access, kind, collectionID, defaultSort)
+			if !ok {
+				t.Fatal("configured default sort was not applied")
+			}
+			ordered, err := OrderCollectionItemsBySort(ctx, pool, sourceOrder, qs, access)
+			if err != nil {
+				t.Fatalf("ordering by default sort: %v", err)
+			}
+			assertOrder(t, orderedIDs(ordered), "cs-a", "cs-b", "cs-c")
+
+			// 3. The viewer re-sorts to Year (newest first) and it is saved.
+			if err := store.SetCollectionSortPreference(ctx, userstore.CollectionSortPreference{
+				ProfileID:      access.ProfileID,
+				CollectionKind: kind,
+				CollectionID:   collectionID,
+				SortField:      "year",
+				SortOrder:      "desc",
+			}); err != nil {
+				t.Fatalf("saving override: %v", err)
+			}
+
+			// 4. A fresh resolution — the "leave and come back" case — reads the
+			// override back out of the database and beats the creator's default.
+			freshResolver := &CatalogResolver{storeProvider: pgstore.NewPostgresProvider(pool)}
+			qs, ok = freshResolver.EffectiveCollectionSort(ctx, access, kind, collectionID, defaultSort)
+			if !ok {
+				t.Fatal("saved override was not applied on a fresh read")
+			}
+			if qs.Field != "year" || qs.Order != "desc" {
+				t.Fatalf("effective sort = %q/%q, want year/desc", qs.Field, qs.Order)
+			}
+			ordered, err = OrderCollectionItemsBySort(ctx, pool, sourceOrder, qs, access)
+			if err != nil {
+				t.Fatalf("ordering by override: %v", err)
+			}
+			// Distinct from both the default's A,B,C and source order's C,A,B.
+			assertOrder(t, orderedIDs(ordered), "cs-b", "cs-c", "cs-a")
+			assertOrder(t, orderedIDs(sourceOrder), "cs-c", "cs-a", "cs-b")
+
+			// 5. The viewer pins back to the collection's own order. That is a
+			// real choice and must suppress the creator's default, not fall
+			// through to it.
+			if err := store.SetCollectionSortPreference(ctx, userstore.CollectionSortPreference{
+				ProfileID:      access.ProfileID,
+				CollectionKind: kind,
+				CollectionID:   collectionID,
+				SortField:      "",
+				SortOrder:      "",
+			}); err != nil {
+				t.Fatalf("pinning to source order: %v", err)
+			}
+			if _, ok := resolver.EffectiveCollectionSort(ctx, access, kind, collectionID, defaultSort); ok {
+				t.Fatal("source-order override fell through to the creator's default")
+			}
+
+			// 6. Clearing the override returns the viewer to the default.
+			if err := store.ClearCollectionSortPreference(ctx, access.ProfileID, kind, collectionID); err != nil {
+				t.Fatalf("clearing override: %v", err)
+			}
+			qs, ok = resolver.EffectiveCollectionSort(ctx, access, kind, collectionID, defaultSort)
+			if !ok || qs.Field != "title" {
+				t.Fatalf("after clearing, effective sort = %q (ok=%v), want title", qs.Field, ok)
+			}
+		})
+	}
+}
+
+// TestCollectionSortOverrideIsPerProfile guards the isolation that makes a
+// server-wide collection safe to re-sort: one profile's choice must not change
+// what another profile sees.
+func TestCollectionSortOverrideIsPerProfile(t *testing.T) {
+	pool := collectionSortTestPool(t)
+	ctx := context.Background()
+
+	userID := seedSortTestUser(t, pool)
+	provider := pgstore.NewPostgresProvider(pool)
+	store, err := provider.ForUser(ctx, userID)
+	if err != nil {
+		t.Fatalf("user store: %v", err)
+	}
+	for _, profile := range []userstore.Profile{
+		{ID: "profile-one", Name: "Profile One"},
+		{ID: "profile-two", Name: "Profile Two"},
+	} {
+		if err := store.CreateProfile(ctx, profile); err != nil {
+			t.Fatalf("seed profile %s: %v", profile.ID, err)
+		}
+	}
+	t.Cleanup(func() {
+		_ = store.DeleteProfile(context.Background(), "profile-two")
+		_ = store.DeleteProfile(context.Background(), "profile-one")
+	})
+	resolver := &CatalogResolver{storeProvider: provider}
+
+	const collectionID = "cs-shared-collection"
+	defaultSort := []byte(`{"field":"title","order":"asc"}`)
+	kind := userstore.CollectionKindLibrary
+
+	if err := store.SetCollectionSortPreference(ctx, userstore.CollectionSortPreference{
+		ProfileID:      "profile-one",
+		CollectionKind: kind,
+		CollectionID:   collectionID,
+		SortField:      "year",
+		SortOrder:      "desc",
+	}); err != nil {
+		t.Fatalf("saving override: %v", err)
+	}
+	t.Cleanup(func() {
+		_ = store.ClearCollectionSortPreference(context.Background(), "profile-one", kind, collectionID)
+	})
+
+	one, ok := resolver.EffectiveCollectionSort(ctx, AccessFilter{UserID: userID, ProfileID: "profile-one"}, kind, collectionID, defaultSort)
+	if !ok || one.Field != "year" {
+		t.Fatalf("profile-one sort = %q (ok=%v), want year", one.Field, ok)
+	}
+
+	two, ok := resolver.EffectiveCollectionSort(ctx, AccessFilter{UserID: userID, ProfileID: "profile-two"}, kind, collectionID, defaultSort)
+	if !ok || two.Field != "title" {
+		t.Fatalf("profile-two sort = %q (ok=%v), want the collection default title", two.Field, ok)
+	}
+}

--- a/internal/catalog/collection_sort_db_test.go
+++ b/internal/catalog/collection_sort_db_test.go
@@ -121,6 +121,22 @@ func TestCollectionDefaultSortAndOverrideEndToEnd(t *testing.T) {
 
 	// Source order is deliberately neither sorted order.
 	sourceOrder := itemsForSort("cs-c", "cs-a", "cs-b")
+	limited, total, err := QueryCollectionItemsBySort(
+		ctx,
+		pool,
+		[]string{"cs-c", "cs-a", "cs-b"},
+		QuerySort{Field: "title", Order: "asc"},
+		AccessFilter{},
+		2,
+		"",
+	)
+	if err != nil {
+		t.Fatalf("querying limited sorted collection: %v", err)
+	}
+	assertOrder(t, orderedIDs(limited), "cs-a", "cs-b")
+	if total != 3 {
+		t.Fatalf("limited sorted collection total = %d, want 3", total)
+	}
 
 	userID := seedSortTestUser(t, pool)
 	provider := pgstore.NewPostgresProvider(pool)

--- a/internal/catalog/collection_sort_precedence_test.go
+++ b/internal/catalog/collection_sort_precedence_test.go
@@ -1,0 +1,189 @@
+package catalog
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/Silo-Server/silo-server/internal/userstore"
+)
+
+// sortPrefStore is a UserStore that only answers collection-sort-preference
+// lookups; every other method panics so a test that strays off this path fails
+// loudly rather than silently exercising unrelated behavior.
+type sortPrefStore struct {
+	userstore.UserStore
+	pref *userstore.CollectionSortPreference
+	err  error
+	// calls records the lookups made, so tests can assert the store is not
+	// consulted when there is no user scope to consult it with.
+	calls int
+}
+
+func (s *sortPrefStore) GetCollectionSortPreference(_ context.Context, _, _, _ string) (*userstore.CollectionSortPreference, error) {
+	s.calls++
+	if s.err != nil {
+		return nil, s.err
+	}
+	return s.pref, nil
+}
+
+type sortPrefProvider struct {
+	store *sortPrefStore
+	err   error
+}
+
+func (p *sortPrefProvider) ForUser(context.Context, int) (userstore.UserStore, error) {
+	if p.err != nil {
+		return nil, p.err
+	}
+	return p.store, nil
+}
+
+func (p *sortPrefProvider) Close() error { return nil }
+
+func TestEffectiveCollectionSortPrecedence(t *testing.T) {
+	const (
+		libraryDefault = `{"field":"added_at","order":"desc"}`
+		noDefault      = `{}`
+	)
+	scopedAccess := AccessFilter{UserID: 7, ProfileID: "profile-1"}
+
+	cases := []struct {
+		name       string
+		access     AccessFilter
+		sortConfig string
+		pref       *userstore.CollectionSortPreference
+		storeErr   error
+		wantOK     bool
+		wantField  string
+		wantOrder  string
+		wantCalls  int
+	}{
+		{
+			name:       "no override falls back to the collection default",
+			access:     scopedAccess,
+			sortConfig: libraryDefault,
+			wantOK:     true,
+			wantField:  "added_at",
+			wantOrder:  "desc",
+			wantCalls:  1,
+		},
+		{
+			// The reported behavior: admin defaults to Date Added, the viewer
+			// switches to Title, and Title is what they get from then on.
+			name:       "viewer override beats the collection default",
+			access:     scopedAccess,
+			sortConfig: libraryDefault,
+			pref:       &userstore.CollectionSortPreference{SortField: "title", SortOrder: "asc"},
+			wantOK:     true,
+			wantField:  "title",
+			wantOrder:  "asc",
+			wantCalls:  1,
+		},
+		{
+			// An empty stored field is a deliberate "put it back to the list's
+			// own order" and must not fall through to the creator's default.
+			name:       "override pinned to source order suppresses the default",
+			access:     scopedAccess,
+			sortConfig: libraryDefault,
+			pref:       &userstore.CollectionSortPreference{SortField: "", SortOrder: ""},
+			wantCalls:  1,
+		},
+		{
+			name:       "no override and no default means source order",
+			access:     scopedAccess,
+			sortConfig: noDefault,
+			wantCalls:  1,
+		},
+		{
+			name:       "personalized viewer override is valid on a library collection",
+			access:     scopedAccess,
+			sortConfig: libraryDefault,
+			pref:       &userstore.CollectionSortPreference{SortField: "progress", SortOrder: "desc"},
+			wantOK:     true,
+			wantField:  "progress",
+			wantOrder:  "desc",
+			wantCalls:  1,
+		},
+		{
+			name:       "unusable override falls back to the default",
+			access:     scopedAccess,
+			sortConfig: libraryDefault,
+			pref:       &userstore.CollectionSortPreference{SortField: "retired_sort", SortOrder: "desc"},
+			wantOK:     true,
+			wantField:  "added_at",
+			wantOrder:  "desc",
+			wantCalls:  1,
+		},
+		{
+			name:       "store failure degrades to the default",
+			access:     scopedAccess,
+			sortConfig: libraryDefault,
+			storeErr:   errors.New("boom"),
+			wantOK:     true,
+			wantField:  "added_at",
+			wantOrder:  "desc",
+			wantCalls:  1,
+		},
+		{
+			// Unauthenticated / profile-less reads (jellycompat, public paths)
+			// have no override to look up and must not query for one.
+			name:       "no user scope skips the override lookup",
+			access:     AccessFilter{},
+			sortConfig: libraryDefault,
+			pref:       &userstore.CollectionSortPreference{SortField: "title", SortOrder: "asc"},
+			wantOK:     true,
+			wantField:  "added_at",
+			wantOrder:  "desc",
+			wantCalls:  0,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			store := &sortPrefStore{pref: tc.pref, err: tc.storeErr}
+			resolver := &CatalogResolver{storeProvider: &sortPrefProvider{store: store}}
+
+			qs, ok := resolver.EffectiveCollectionSort(
+				context.Background(),
+				tc.access,
+				userstore.CollectionKindLibrary,
+				"collection-1",
+				[]byte(tc.sortConfig),
+			)
+
+			if ok != tc.wantOK {
+				t.Fatalf("ok = %v, want %v", ok, tc.wantOK)
+			}
+			if store.calls != tc.wantCalls {
+				t.Fatalf("override lookups = %d, want %d", store.calls, tc.wantCalls)
+			}
+			if !tc.wantOK {
+				return
+			}
+			if qs.Field != tc.wantField || qs.Order != tc.wantOrder {
+				t.Fatalf("got %q/%q, want %q/%q", qs.Field, qs.Order, tc.wantField, tc.wantOrder)
+			}
+		})
+	}
+}
+
+func TestEffectiveCollectionSortAllowsPersonalizedOnUserCollections(t *testing.T) {
+	store := &sortPrefStore{pref: &userstore.CollectionSortPreference{SortField: "progress", SortOrder: "desc"}}
+	resolver := &CatalogResolver{storeProvider: &sortPrefProvider{store: store}}
+
+	qs, ok := resolver.EffectiveCollectionSort(
+		context.Background(),
+		AccessFilter{UserID: 7, ProfileID: "profile-1"},
+		userstore.CollectionKindUser,
+		"collection-1",
+		[]byte(`{}`),
+	)
+	if !ok {
+		t.Fatal("personalized override rejected on a personal collection")
+	}
+	if qs.Field != "progress" || qs.Order != "desc" {
+		t.Fatalf("got %q/%q, want progress/desc", qs.Field, qs.Order)
+	}
+}

--- a/internal/catalog/collection_sort_test.go
+++ b/internal/catalog/collection_sort_test.go
@@ -1,0 +1,105 @@
+package catalog
+
+import "testing"
+
+func TestNormalizeCollectionSort(t *testing.T) {
+	cases := []struct {
+		name              string
+		field             string
+		order             string
+		allowPersonalized bool
+		wantOK            bool
+		wantField         string
+		wantOrder         string
+	}{
+		{name: "applies the field's default order", field: "release_date", wantOK: true, wantField: "release_date", wantOrder: "desc"},
+		{name: "title defaults ascending", field: "title", wantOK: true, wantField: "title", wantOrder: "asc"},
+		{name: "explicit order wins", field: "title", order: "desc", wantOK: true, wantField: "title", wantOrder: "desc"},
+		{name: "trims and lowercases", field: "  Title  ", order: "ASC", wantOK: true, wantField: "title", wantOrder: "asc"},
+		{name: "garbage order is rejected", field: "year", order: "sideways"},
+		{name: "empty field means source order", field: ""},
+		{name: "unknown field is rejected", field: "not_a_sort"},
+		{name: "personalized rejected for library collections", field: "progress"},
+		{
+			name:              "personalized allowed for personal collections",
+			field:             "progress",
+			allowPersonalized: true,
+			wantOK:            true,
+			wantField:         "progress",
+			wantOrder:         "desc",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			qs, ok := NormalizeCollectionSort(tc.field, tc.order, tc.allowPersonalized)
+			if ok != tc.wantOK {
+				t.Fatalf("ok = %v, want %v", ok, tc.wantOK)
+			}
+			if !tc.wantOK {
+				return
+			}
+			if qs.Field != tc.wantField || qs.Order != tc.wantOrder {
+				t.Fatalf("got %q/%q, want %q/%q", qs.Field, qs.Order, tc.wantField, tc.wantOrder)
+			}
+		})
+	}
+}
+
+func TestParseCollectionDefaultSort(t *testing.T) {
+	cases := []struct {
+		name      string
+		raw       string
+		wantOK    bool
+		wantField string
+		wantOrder string
+	}{
+		{name: "empty column", raw: ""},
+		{name: "legacy empty object", raw: `{}`},
+		{name: "json null", raw: `null`},
+		{name: "unparseable json", raw: `{`},
+		// The unimplemented manual-pin mode carries no field, so it must not be
+		// mistaken for a configured sort.
+		{name: "manual pins mode", raw: `{"mode":"manual_pins"}`},
+		{name: "configured sort", raw: `{"field":"title","order":"asc"}`, wantOK: true, wantField: "title", wantOrder: "asc"},
+		{name: "order filled in", raw: `{"field":"added_at"}`, wantOK: true, wantField: "added_at", wantOrder: "desc"},
+		{name: "invalid order is rejected", raw: `{"field":"title","order":"sideways"}`},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			qs, ok := ParseCollectionDefaultSort([]byte(tc.raw), false)
+			if ok != tc.wantOK {
+				t.Fatalf("ok = %v, want %v", ok, tc.wantOK)
+			}
+			if !tc.wantOK {
+				return
+			}
+			if qs.Field != tc.wantField || qs.Order != tc.wantOrder {
+				t.Fatalf("got %q/%q, want %q/%q", qs.Field, qs.Order, tc.wantField, tc.wantOrder)
+			}
+		})
+	}
+}
+
+func TestEncodeCollectionDefaultSort(t *testing.T) {
+	encoded, err := EncodeCollectionDefaultSort(QuerySort{Field: "title", Order: "asc"}, true)
+	if err != nil {
+		t.Fatalf("encoding: %v", err)
+	}
+	if encoded != `{"field":"title","order":"asc"}` {
+		t.Fatalf("encoded = %s", encoded)
+	}
+
+	// Source order round-trips through the empty object the column defaults to.
+	encoded, err = EncodeCollectionDefaultSort(QuerySort{}, false)
+	if err != nil {
+		t.Fatalf("encoding source order: %v", err)
+	}
+	if encoded != "{}" {
+		t.Fatalf("source order encoded = %s, want {}", encoded)
+	}
+	if _, ok := ParseCollectionDefaultSort([]byte(encoded), false); ok {
+		t.Fatal("re-parsing the source-order encoding reported a configured sort")
+	}
+}

--- a/internal/catalog/library_collection_repo.go
+++ b/internal/catalog/library_collection_repo.go
@@ -200,7 +200,7 @@ func (r *LibraryCollectionRepository) Create(ctx context.Context, input CreateLi
 		input.SortConfig = json.RawMessage(`{}`)
 	}
 	if input.Visibility == "" {
-		input.Visibility = "visible"
+		input.Visibility = LibraryCollectionVisibilityVisible
 	}
 	if input.CollectionType == "" {
 		input.CollectionType = "manual"

--- a/internal/catalog/query_definition.go
+++ b/internal/catalog/query_definition.go
@@ -1,6 +1,7 @@
 package catalog
 
 import (
+	"bytes"
 	"encoding/json"
 	"fmt"
 	"sort"
@@ -211,6 +212,70 @@ func NormalizePersonalListSort(field, order string) (QuerySort, bool) {
 		order = querySortDefs[field].defaultOrder
 	}
 	return QuerySort{Field: field, Order: order}, true
+}
+
+// NormalizeCollectionSort validates a collection's default sort (its stored
+// sort_config) or a viewer's saved override, applying the field's default order
+// when none is given. Returns false when the field or a supplied order is
+// unsupported. An empty field means the collection's own source order should
+// be kept.
+//
+// allowPersonalized gates the per-profile sort fields (progress, date viewed,
+// plays). They are legitimate for personal collections, which always resolve
+// with the owning profile in scope, but not for library collections: those
+// resolve with user scope stripped (see stripCatalogUserScope), so the query
+// builder's ensureUserScope would reject the sort at browse time.
+func NormalizeCollectionSort(field, order string, allowPersonalized bool) (QuerySort, bool) {
+	field = strings.ToLower(strings.TrimSpace(field))
+	def, ok := querySortDefs[field]
+	if !ok {
+		return QuerySort{}, false
+	}
+	if def.personalized && !allowPersonalized {
+		return QuerySort{}, false
+	}
+	order = strings.ToLower(strings.TrimSpace(order))
+	if order == "" {
+		order = def.defaultOrder
+	} else if order != "asc" && order != "desc" {
+		return QuerySort{}, false
+	}
+	return QuerySort{Field: field, Order: order}, true
+}
+
+// collectionSortConfig is the shape a collection's sort_config carries when it
+// pins a default order. Everything else the column may hold (legacy `{}`, the
+// unimplemented manual-pin mode) leaves the collection on source order.
+type collectionSortConfig struct {
+	Field string `json:"field"`
+	Order string `json:"order"`
+}
+
+// ParseCollectionDefaultSort reads the default sort a collection's creator
+// configured. An absent, empty, or unrecognized sort_config yields false,
+// meaning source order.
+func ParseCollectionDefaultSort(raw []byte, allowPersonalized bool) (QuerySort, bool) {
+	if len(bytes.TrimSpace(raw)) == 0 {
+		return QuerySort{}, false
+	}
+	var cfg collectionSortConfig
+	if err := json.Unmarshal(raw, &cfg); err != nil {
+		return QuerySort{}, false
+	}
+	return NormalizeCollectionSort(cfg.Field, cfg.Order, allowPersonalized)
+}
+
+// EncodeCollectionDefaultSort renders a validated default sort back into the
+// sort_config JSON shape. An empty field encodes as `{}` — source order.
+func EncodeCollectionDefaultSort(qs QuerySort, ok bool) (string, error) {
+	if !ok || strings.TrimSpace(qs.Field) == "" {
+		return "{}", nil
+	}
+	encoded, err := json.Marshal(collectionSortConfig(qs))
+	if err != nil {
+		return "", fmt.Errorf("encoding collection sort_config: %w", err)
+	}
+	return string(encoded), nil
 }
 
 func (q QueryDefinition) Normalize() QueryDefinition {

--- a/internal/jellycompat/content_direct_test.go
+++ b/internal/jellycompat/content_direct_test.go
@@ -526,6 +526,15 @@ func (s *progressCountingStore) GetSeriesPlaybackPreference(context.Context, str
 func (s *progressCountingStore) DeleteSeriesPlaybackPreference(context.Context, string, string) error {
 	panic("unused")
 }
+func (s *progressCountingStore) SetCollectionSortPreference(context.Context, userstore.CollectionSortPreference) error {
+	panic("unused")
+}
+func (s *progressCountingStore) GetCollectionSortPreference(context.Context, string, string, string) (*userstore.CollectionSortPreference, error) {
+	panic("unused")
+}
+func (s *progressCountingStore) ClearCollectionSortPreference(context.Context, string, string, string) error {
+	panic("unused")
+}
 func (s *progressCountingStore) GetLibraryPlaybackPreference(context.Context, string, int) (*userstore.LibraryPlaybackPreference, error) {
 	panic("unused")
 }

--- a/internal/sections/collection_rail_fetch_test.go
+++ b/internal/sections/collection_rail_fetch_test.go
@@ -3,13 +3,14 @@ package sections
 import (
 	"testing"
 
+	"github.com/Silo-Server/silo-server/internal/catalog"
 	"github.com/Silo-Server/silo-server/internal/models"
 )
 
 func TestCollectionRailItemsToFetchPreservesLegacyBoundWithoutDefaultSort(t *testing.T) {
 	items := make([]*models.LibraryCollectionItem, 100_000)
 
-	bounded := collectionRailItemsToFetch(items, 24, false)
+	bounded := collectionRailItemsToFetch(items, 24)
 	if len(bounded) != 24 {
 		t.Fatalf("unsorted rail selected %d items, want 24", len(bounded))
 	}
@@ -17,9 +18,26 @@ func TestCollectionRailItemsToFetchPreservesLegacyBoundWithoutDefaultSort(t *tes
 	if len(visible) != 24 || total != 24 {
 		t.Fatalf("unsorted rail result = %d items, total %d; want 24/24", len(visible), total)
 	}
+}
 
-	all := collectionRailItemsToFetch(items, 24, true)
-	if len(all) != len(items) {
-		t.Fatalf("default-sorted rail selected %d items, want full membership %d", len(all), len(items))
+func TestCollectionRailQueryAccessIntersectsExplicitLibrary(t *testing.T) {
+	requestedLibraryID := 7
+
+	matching := collectionRailQueryAccess(
+		catalog.AccessFilter{AllowedLibraryIDs: []int{4, 7}},
+		&requestedLibraryID,
+		nil,
+	)
+	if len(matching.AllowedLibraryIDs) != 1 || matching.AllowedLibraryIDs[0] != requestedLibraryID {
+		t.Fatalf("matching access = %v, want [%d]", matching.AllowedLibraryIDs, requestedLibraryID)
+	}
+
+	blocked := collectionRailQueryAccess(
+		catalog.AccessFilter{AllowedLibraryIDs: []int{4}},
+		&requestedLibraryID,
+		nil,
+	)
+	if blocked.AllowedLibraryIDs == nil || len(blocked.AllowedLibraryIDs) != 0 {
+		t.Fatalf("blocked access = %v, want non-nil empty scope", blocked.AllowedLibraryIDs)
 	}
 }

--- a/internal/sections/collection_rail_fetch_test.go
+++ b/internal/sections/collection_rail_fetch_test.go
@@ -1,0 +1,25 @@
+package sections
+
+import (
+	"testing"
+
+	"github.com/Silo-Server/silo-server/internal/models"
+)
+
+func TestCollectionRailItemsToFetchPreservesLegacyBoundWithoutDefaultSort(t *testing.T) {
+	items := make([]*models.LibraryCollectionItem, 100_000)
+
+	bounded := collectionRailItemsToFetch(items, 24, false)
+	if len(bounded) != 24 {
+		t.Fatalf("unsorted rail selected %d items, want 24", len(bounded))
+	}
+	visible, total := unsortedCollectionRailResult(make([]*models.MediaItem, len(bounded)))
+	if len(visible) != 24 || total != 24 {
+		t.Fatalf("unsorted rail result = %d items, total %d; want 24/24", len(visible), total)
+	}
+
+	all := collectionRailItemsToFetch(items, 24, true)
+	if len(all) != len(items) {
+		t.Fatalf("default-sorted rail selected %d items, want full membership %d", len(all), len(items))
+	}
+}

--- a/internal/sections/fetcher.go
+++ b/internal/sections/fetcher.go
@@ -1309,7 +1309,8 @@ func (f *Fetcher) fetchCollection(ctx context.Context, s ResolvedSection, librar
 		return []*models.MediaItem{}, 0, nil
 	}
 
-	if _, err := f.CollectionRepo.GetByID(ctx, cfg.LibraryCollectionID); err != nil {
+	collection, err := f.CollectionRepo.GetByID(ctx, cfg.LibraryCollectionID)
+	if err != nil {
 		return nil, 0, fmt.Errorf("loading library collection: %w", err)
 	}
 
@@ -1321,13 +1322,18 @@ func (f *Fetcher) fetchCollection(ctx context.Context, s ResolvedSection, librar
 		return []*models.MediaItem{}, 0, nil
 	}
 
-	limit := s.ItemLimit
-	if limit <= 0 || limit > len(collectionItems) {
-		limit = len(collectionItems)
-	}
+	// A rail sorted by the collection's default has to resolve the whole
+	// membership before truncating: taking ItemLimit rows off the source-ordered
+	// list first would sort the wrong slice. Library collection rails are shared
+	// across profiles (see isCacheableSectionType), so only the creator's
+	// user-agnostic default applies here — a viewer's personal override is
+	// honored on the collection's own browse page.
+	defaultSort, hasDefaultSort := catalog.ParseCollectionDefaultSort(collection.SortConfig, false)
 
-	contentIDs := make([]string, 0, limit)
-	for _, item := range collectionItems[:limit] {
+	selectedCollectionItems := collectionRailItemsToFetch(collectionItems, s.ItemLimit, hasDefaultSort)
+
+	contentIDs := make([]string, 0, len(selectedCollectionItems))
+	for _, item := range selectedCollectionItems {
 		contentIDs = append(contentIDs, item.MediaItemID)
 	}
 
@@ -1350,7 +1356,33 @@ func (f *Fetcher) fetchCollection(ctx context.Context, s ResolvedSection, librar
 		orderedItems = append(orderedItems, item)
 	}
 
-	return orderedItems, len(orderedItems), nil
+	if !hasDefaultSort {
+		// Historically total represented the number of visible rail items, not
+		// the collection membership. Keep that contract for unsorted rails.
+		orderedItems, total := unsortedCollectionRailResult(orderedItems)
+		return orderedItems, total, nil
+	}
+
+	orderedItems, err = catalog.OrderCollectionItemsBySort(ctx, f.pool, orderedItems, defaultSort, filter)
+	if err != nil {
+		return nil, 0, err
+	}
+
+	orderedItems, total := limitUserCollectionSectionItems(orderedItems, s.ItemLimit)
+	return orderedItems, total, nil
+}
+
+func collectionRailItemsToFetch(items []*models.LibraryCollectionItem, itemLimit int, hasDefaultSort bool) []*models.LibraryCollectionItem {
+	if !hasDefaultSort && itemLimit > 0 && itemLimit < len(items) {
+		// Preserve the legacy rail path when no default sort is configured:
+		// bound the lookup before expanding content IDs into SQL parameters.
+		return items[:itemLimit]
+	}
+	return items
+}
+
+func unsortedCollectionRailResult(items []*models.MediaItem) ([]*models.MediaItem, int) {
+	return items, len(items)
 }
 
 // fetchUserCollection resolves a personal (profile-scoped) user collection.
@@ -1472,6 +1504,16 @@ func (f *Fetcher) fetchUserCollection(ctx context.Context, s ResolvedSection, li
 	orderedItems, err = catalog.FilterCollectionItemsByDisplayQuery(ctx, f.pool, orderedItems, collection.DisplayQueryDefinition, displayAccess)
 	if err != nil {
 		return nil, 0, err
+	}
+
+	// Rails follow the collection's configured default only; the viewer's saved
+	// override applies on the collection's browse page, so a rail and its "see
+	// all" stay consistent with what the collection's owner set up.
+	if qs, ok := catalog.ParseCollectionDefaultSort([]byte(collection.SortConfig), true); ok {
+		orderedItems, err = catalog.OrderCollectionItemsBySort(ctx, f.pool, orderedItems, qs, displayAccess)
+		if err != nil {
+			return nil, 0, err
+		}
 	}
 
 	orderedItems, total := limitUserCollectionSectionItems(orderedItems, s.ItemLimit)

--- a/internal/sections/fetcher.go
+++ b/internal/sections/fetcher.go
@@ -1322,15 +1322,25 @@ func (f *Fetcher) fetchCollection(ctx context.Context, s ResolvedSection, librar
 		return []*models.MediaItem{}, 0, nil
 	}
 
-	// A rail sorted by the collection's default has to resolve the whole
-	// membership before truncating: taking ItemLimit rows off the source-ordered
-	// list first would sort the wrong slice. Library collection rails are shared
-	// across profiles (see isCacheableSectionType), so only the creator's
-	// user-agnostic default applies here — a viewer's personal override is
-	// honored on the collection's own browse page.
+	// Library collection rails are shared across profiles (see
+	// isCacheableSectionType), so only the creator's user-agnostic default
+	// applies here — a viewer's personal override is honored on the collection's
+	// own browse page.
 	defaultSort, hasDefaultSort := catalog.ParseCollectionDefaultSort(collection.SortConfig, false)
+	if hasDefaultSort {
+		contentIDs := make([]string, 0, len(collectionItems))
+		for _, item := range collectionItems {
+			contentIDs = append(contentIDs, item.MediaItemID)
+		}
+		queryAccess := collectionRailQueryAccess(filter, libraryID, libraryIDs)
+		items, total, err := catalog.QueryCollectionItemsBySort(ctx, f.pool, contentIDs, defaultSort, queryAccess, s.ItemLimit, "")
+		if err != nil {
+			return nil, 0, err
+		}
+		return items, total, nil
+	}
 
-	selectedCollectionItems := collectionRailItemsToFetch(collectionItems, s.ItemLimit, hasDefaultSort)
+	selectedCollectionItems := collectionRailItemsToFetch(collectionItems, s.ItemLimit)
 
 	contentIDs := make([]string, 0, len(selectedCollectionItems))
 	for _, item := range selectedCollectionItems {
@@ -1356,24 +1366,14 @@ func (f *Fetcher) fetchCollection(ctx context.Context, s ResolvedSection, librar
 		orderedItems = append(orderedItems, item)
 	}
 
-	if !hasDefaultSort {
-		// Historically total represented the number of visible rail items, not
-		// the collection membership. Keep that contract for unsorted rails.
-		orderedItems, total := unsortedCollectionRailResult(orderedItems)
-		return orderedItems, total, nil
-	}
-
-	orderedItems, err = catalog.OrderCollectionItemsBySort(ctx, f.pool, orderedItems, defaultSort, filter)
-	if err != nil {
-		return nil, 0, err
-	}
-
-	orderedItems, total := limitUserCollectionSectionItems(orderedItems, s.ItemLimit)
+	// Historically total represented the number of visible rail items, not the
+	// collection membership. Keep that contract for unsorted rails.
+	orderedItems, total := unsortedCollectionRailResult(orderedItems)
 	return orderedItems, total, nil
 }
 
-func collectionRailItemsToFetch(items []*models.LibraryCollectionItem, itemLimit int, hasDefaultSort bool) []*models.LibraryCollectionItem {
-	if !hasDefaultSort && itemLimit > 0 && itemLimit < len(items) {
+func collectionRailItemsToFetch(items []*models.LibraryCollectionItem, itemLimit int) []*models.LibraryCollectionItem {
+	if itemLimit > 0 && itemLimit < len(items) {
 		// Preserve the legacy rail path when no default sort is configured:
 		// bound the lookup before expanding content IDs into SQL parameters.
 		return items[:itemLimit]
@@ -1479,6 +1479,29 @@ func (f *Fetcher) fetchUserCollection(ctx context.Context, s ResolvedSection, li
 		contentIDs = append(contentIDs, item.MediaItemID)
 	}
 
+	displayAccess := collectionRailQueryAccess(filter, libraryID, libraryIDs)
+	displayAccess.UserID = userID
+	displayAccess.ProfileID = profileID
+
+	// A configured default is executed together with the display filter and
+	// rail limit. Querying before hydration avoids loading an entire large
+	// collection merely to render a bounded home rail.
+	if qs, ok := catalog.ParseCollectionDefaultSort([]byte(collection.SortConfig), true); ok {
+		items, total, err := catalog.QueryCollectionItemsBySort(
+			ctx,
+			f.pool,
+			contentIDs,
+			qs,
+			displayAccess,
+			s.ItemLimit,
+			collection.DisplayQueryDefinition,
+		)
+		if err != nil {
+			return nil, 0, err
+		}
+		return items, total, nil
+	}
+
 	items, err := f.fetchItemsByContentIDs(ctx, contentIDs, libraryID, libraryIDs, filter)
 	if err != nil {
 		return nil, 0, err
@@ -1498,22 +1521,9 @@ func (f *Fetcher) fetchUserCollection(ctx context.Context, s ResolvedSection, li
 		orderedItems = append(orderedItems, item)
 	}
 
-	displayAccess := filter
-	displayAccess.UserID = userID
-	displayAccess.ProfileID = profileID
 	orderedItems, err = catalog.FilterCollectionItemsByDisplayQuery(ctx, f.pool, orderedItems, collection.DisplayQueryDefinition, displayAccess)
 	if err != nil {
 		return nil, 0, err
-	}
-
-	// Rails follow the collection's configured default only; the viewer's saved
-	// override applies on the collection's browse page, so a rail and its "see
-	// all" stay consistent with what the collection's owner set up.
-	if qs, ok := catalog.ParseCollectionDefaultSort([]byte(collection.SortConfig), true); ok {
-		orderedItems, err = catalog.OrderCollectionItemsBySort(ctx, f.pool, orderedItems, qs, displayAccess)
-		if err != nil {
-			return nil, 0, err
-		}
 	}
 
 	orderedItems, total := limitUserCollectionSectionItems(orderedItems, s.ItemLimit)
@@ -2784,6 +2794,34 @@ func effectiveFetchLibraryIDs(libraryIDs []int, filter catalog.AccessFilter) []i
 		return filter.AllowedLibraryIDs
 	}
 	return nil
+}
+
+// collectionRailQueryAccess expresses the section's explicit library scope as
+// an AccessFilter for collection queries routed through QueryExecutor.
+func collectionRailQueryAccess(filter catalog.AccessFilter, libraryID *int, libraryIDs []int) catalog.AccessFilter {
+	result := filter
+	effectiveLibraryIDs := effectiveFetchLibraryIDs(libraryIDs, filter)
+	if libraryID == nil {
+		if effectiveLibraryIDs == nil {
+			result.AllowedLibraryIDs = nil
+		} else {
+			result.AllowedLibraryIDs = append([]int(nil), effectiveLibraryIDs...)
+		}
+		return result
+	}
+
+	if effectiveLibraryIDs == nil {
+		result.AllowedLibraryIDs = []int{*libraryID}
+		return result
+	}
+	for _, id := range effectiveLibraryIDs {
+		if id == *libraryID {
+			result.AllowedLibraryIDs = []int{*libraryID}
+			return result
+		}
+	}
+	result.AllowedLibraryIDs = []int{}
+	return result
 }
 
 func recentSeasonPremiereBadges(seasonNumber, episodeNumber int, airDate *time.Time) []string {

--- a/internal/userdb/collection_sort_prefs.go
+++ b/internal/userdb/collection_sort_prefs.go
@@ -1,0 +1,82 @@
+package userdb
+
+import (
+	"database/sql"
+	"fmt"
+
+	"github.com/Silo-Server/silo-server/internal/userstore"
+)
+
+// CollectionSortPreference is an alias for the canonical type in userstore.
+type CollectionSortPreference = userstore.CollectionSortPreference
+
+// SetCollectionSortPreference creates or replaces a profile's sort override for
+// a collection. Timestamps should be ISO 8601 UTC strings.
+func SetCollectionSortPreference(db *sql.DB, pref CollectionSortPreference) error {
+	if pref.UpdatedAt == "" {
+		pref.UpdatedAt = nowUTC()
+	}
+	_, err := db.Exec(`
+		INSERT INTO collection_sort_preferences (
+			profile_id, collection_kind, collection_id, sort_field, sort_order, updated_at
+		) VALUES (?, ?, ?, ?, ?, ?)
+		ON CONFLICT(profile_id, collection_kind, collection_id) DO UPDATE SET
+			sort_field = excluded.sort_field,
+			sort_order = excluded.sort_order,
+			updated_at = excluded.updated_at`,
+		pref.ProfileID,
+		pref.CollectionKind,
+		pref.CollectionID,
+		pref.SortField,
+		pref.SortOrder,
+		pref.UpdatedAt,
+	)
+	if err != nil {
+		return fmt.Errorf("setting collection sort preference for profile %q collection %q/%q: %w",
+			pref.ProfileID, pref.CollectionKind, pref.CollectionID, err)
+	}
+	return nil
+}
+
+// GetCollectionSortPreference returns nil (not an error) when the profile has
+// never changed this collection's sort. A preference with an empty SortField
+// means the viewer explicitly chose the collection's own source order.
+func GetCollectionSortPreference(db *sql.DB, profileID, collectionKind, collectionID string) (*CollectionSortPreference, error) {
+	var pref CollectionSortPreference
+	err := db.QueryRow(`
+		SELECT profile_id, collection_kind, collection_id, sort_field, sort_order, updated_at
+		FROM collection_sort_preferences
+		WHERE profile_id = ? AND collection_kind = ? AND collection_id = ?`,
+		profileID, collectionKind, collectionID,
+	).Scan(
+		&pref.ProfileID,
+		&pref.CollectionKind,
+		&pref.CollectionID,
+		&pref.SortField,
+		&pref.SortOrder,
+		&pref.UpdatedAt,
+	)
+	if err == sql.ErrNoRows {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, fmt.Errorf("getting collection sort preference for profile %q collection %q/%q: %w",
+			profileID, collectionKind, collectionID, err)
+	}
+	return &pref, nil
+}
+
+// ClearCollectionSortPreference drops the override so the collection falls back
+// to its creator-configured default.
+func ClearCollectionSortPreference(db *sql.DB, profileID, collectionKind, collectionID string) error {
+	_, err := db.Exec(`
+		DELETE FROM collection_sort_preferences
+		WHERE profile_id = ? AND collection_kind = ? AND collection_id = ?`,
+		profileID, collectionKind, collectionID,
+	)
+	if err != nil {
+		return fmt.Errorf("clearing collection sort preference for profile %q collection %q/%q: %w",
+			profileID, collectionKind, collectionID, err)
+	}
+	return nil
+}

--- a/internal/userdb/collections.go
+++ b/internal/userdb/collections.go
@@ -243,6 +243,11 @@ func DeleteCollection(db *sql.DB, id string) error {
 	if _, err := tx.Exec(`DELETE FROM personal_collection_items WHERE collection_id = ?`, id); err != nil {
 		return err
 	}
+	if _, err := tx.Exec(`
+		DELETE FROM collection_sort_preferences
+		WHERE collection_kind = 'user' AND collection_id = ?`, id); err != nil {
+		return err
+	}
 	if _, err := tx.Exec(`DELETE FROM personal_collections WHERE id = ?`, id); err != nil {
 		return err
 	}

--- a/internal/userdb/conformance_test.go
+++ b/internal/userdb/conformance_test.go
@@ -42,6 +42,10 @@ func TestSQLiteJellycompatDisplayPrefs(t *testing.T) {
 	storetest.RunJellycompatDisplayPrefs(t, newConformanceStore)
 }
 
+func TestSQLiteCollectionSortPreferences(t *testing.T) {
+	storetest.RunCollectionSortPreferences(t, newConformanceStore)
+}
+
 func TestSQLiteAddFavoriteAtReportsInsertion(t *testing.T) {
 	ctx := context.Background()
 	store := newConformanceStore(t)

--- a/internal/userdb/migrate.go
+++ b/internal/userdb/migrate.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 )
 
-const schemaVersion = 18
+const schemaVersion = 19
 
 func runMigrations(db *sql.DB) error {
 	version, err := userVersion(db)
@@ -178,7 +178,26 @@ func runMigrations(db *sql.DB) error {
 		}
 	}
 
+	if version < 19 {
+		if err := migrateToV19(tx); err != nil {
+			return err
+		}
+		if _, err := tx.Exec("PRAGMA user_version = 19"); err != nil {
+			return fmt.Errorf("setting sqlite user_version 19: %w", err)
+		}
+	}
+
 	return tx.Commit()
+}
+
+// migrateToV19 adds the per-profile collection sort override table. An empty
+// sort_field is a real choice ("keep this collection's own source order") and
+// is distinct from having no row.
+func migrateToV19(tx *sql.Tx) error {
+	if _, err := tx.Exec(collectionSortPreferencesSchema); err != nil {
+		return fmt.Errorf("creating collection_sort_preferences: %w", err)
+	}
+	return nil
 }
 
 // migrateToV18 seeds the family-neutral navigation shortcut catalog from the

--- a/internal/userdb/migrate_v19_test.go
+++ b/internal/userdb/migrate_v19_test.go
@@ -1,0 +1,42 @@
+package userdb
+
+import (
+	"database/sql"
+	"testing"
+)
+
+// An existing v18 store from main must gain the collection sort preferences
+// table without replaying or replacing any of main's earlier migrations.
+func TestMigrateToV19AddsCollectionSortPreferences(t *testing.T) {
+	db, err := sql.Open("sqlite3", ":memory:")
+	if err != nil {
+		t.Fatalf("open sqlite: %v", err)
+	}
+	t.Cleanup(func() { _ = db.Close() })
+	if err := InitSchema(db); err != nil {
+		t.Fatalf("InitSchema: %v", err)
+	}
+
+	if _, err := db.Exec(`DROP TABLE IF EXISTS collection_sort_preferences`); err != nil {
+		t.Fatalf("drop table: %v", err)
+	}
+	if _, err := db.Exec("PRAGMA user_version = 18"); err != nil {
+		t.Fatalf("set user_version: %v", err)
+	}
+
+	if err := runMigrations(db); err != nil {
+		t.Fatalf("runMigrations: %v", err)
+	}
+	version, err := userVersion(db)
+	if err != nil {
+		t.Fatalf("userVersion: %v", err)
+	}
+	if version != schemaVersion {
+		t.Fatalf("user_version = %d, want %d", version, schemaVersion)
+	}
+
+	var tableName string
+	if err := db.QueryRow(`SELECT name FROM sqlite_master WHERE type = 'table' AND name = 'collection_sort_preferences'`).Scan(&tableName); err != nil {
+		t.Fatalf("collection_sort_preferences table: %v", err)
+	}
+}

--- a/internal/userdb/profiles.go
+++ b/internal/userdb/profiles.go
@@ -292,6 +292,17 @@ func DeleteProfile(db *sql.DB, id string) error {
 	}
 	defer tx.Rollback() //nolint:errcheck
 
+	// Preferences belong to viewers, not creators, so deleting only this
+	// profile's rows below would leave other profiles' overrides pointing at
+	// personal collections that are about to be removed.
+	if _, err := tx.Exec(`
+		DELETE FROM collection_sort_preferences
+		WHERE collection_kind = 'user' AND collection_id IN (
+			SELECT id FROM personal_collections WHERE creator_profile_id = ?
+		)`, id); err != nil {
+		return fmt.Errorf("deleting collection sort preferences for profile %s: %w", id, err)
+	}
+
 	// Delete personal_collection_items for collections owned by this profile.
 	_, err = tx.Exec(`
 		DELETE FROM personal_collection_items

--- a/internal/userdb/profiles.go
+++ b/internal/userdb/profiles.go
@@ -312,6 +312,7 @@ func DeleteProfile(db *sql.DB, id string) error {
 		"favorites",
 		"watchlist",
 		"watch_progress",
+		"collection_sort_preferences",
 		"personal_collections",
 		"profile_allowed_libraries",
 		"series_playback_preferences",

--- a/internal/userdb/schema.go
+++ b/internal/userdb/schema.go
@@ -124,6 +124,16 @@ CREATE TABLE IF NOT EXISTS personal_collections (
     updated_at TEXT NOT NULL
 );
 
+CREATE TABLE IF NOT EXISTS collection_sort_preferences (
+    profile_id TEXT NOT NULL,
+    collection_kind TEXT NOT NULL,
+    collection_id TEXT NOT NULL,
+    sort_field TEXT NOT NULL DEFAULT '',
+    sort_order TEXT NOT NULL DEFAULT '',
+    updated_at TEXT NOT NULL,
+    PRIMARY KEY (profile_id, collection_kind, collection_id)
+);
+
 CREATE TABLE IF NOT EXISTS personal_collection_items (
     collection_id TEXT NOT NULL,
     media_item_id TEXT NOT NULL,
@@ -494,6 +504,20 @@ CREATE INDEX user_setting_values_library_idx
 	}
 	return nil
 }
+
+// collectionSortPreferencesSchema is kept as its own const (rather than only
+// inlined in Schema) so migrateToV19 can create the table on databases that
+// predate it. collection_kind separates the 'library' and 'user' id spaces.
+const collectionSortPreferencesSchema = `
+CREATE TABLE IF NOT EXISTS collection_sort_preferences (
+    profile_id TEXT NOT NULL,
+    collection_kind TEXT NOT NULL,
+    collection_id TEXT NOT NULL,
+    sort_field TEXT NOT NULL DEFAULT '',
+    sort_order TEXT NOT NULL DEFAULT '',
+    updated_at TEXT NOT NULL,
+    PRIMARY KEY (profile_id, collection_kind, collection_id)
+);`
 
 // watchProgressSyncTriggers stamps the server-owned cursor (synced_seq) on every
 // watch_progress write and owns the LWW key: event_at defaults to the write

--- a/internal/userdb/schema.go
+++ b/internal/userdb/schema.go
@@ -131,7 +131,9 @@ CREATE TABLE IF NOT EXISTS collection_sort_preferences (
     sort_field TEXT NOT NULL DEFAULT '',
     sort_order TEXT NOT NULL DEFAULT '',
     updated_at TEXT NOT NULL,
-    PRIMARY KEY (profile_id, collection_kind, collection_id)
+    PRIMARY KEY (profile_id, collection_kind, collection_id),
+    CHECK (collection_kind IN ('library', 'user')),
+    CHECK (sort_order IN ('', 'asc', 'desc'))
 );
 
 CREATE TABLE IF NOT EXISTS personal_collection_items (
@@ -516,7 +518,9 @@ CREATE TABLE IF NOT EXISTS collection_sort_preferences (
     sort_field TEXT NOT NULL DEFAULT '',
     sort_order TEXT NOT NULL DEFAULT '',
     updated_at TEXT NOT NULL,
-    PRIMARY KEY (profile_id, collection_kind, collection_id)
+    PRIMARY KEY (profile_id, collection_kind, collection_id),
+    CHECK (collection_kind IN ('library', 'user')),
+    CHECK (sort_order IN ('', 'asc', 'desc'))
 );`
 
 // watchProgressSyncTriggers stamps the server-owned cursor (synced_seq) on every

--- a/internal/userdb/sqlitestore.go
+++ b/internal/userdb/sqlitestore.go
@@ -422,6 +422,18 @@ func (s *SQLiteUserStore) DeleteSeriesPlaybackPreference(_ context.Context, prof
 	return DeleteSeriesPlaybackPreference(s.db, profileID, seriesID)
 }
 
+func (s *SQLiteUserStore) SetCollectionSortPreference(_ context.Context, pref userstore.CollectionSortPreference) error {
+	return SetCollectionSortPreference(s.db, pref)
+}
+
+func (s *SQLiteUserStore) GetCollectionSortPreference(_ context.Context, profileID, collectionKind, collectionID string) (*userstore.CollectionSortPreference, error) {
+	return GetCollectionSortPreference(s.db, profileID, collectionKind, collectionID)
+}
+
+func (s *SQLiteUserStore) ClearCollectionSortPreference(_ context.Context, profileID, collectionKind, collectionID string) error {
+	return ClearCollectionSortPreference(s.db, profileID, collectionKind, collectionID)
+}
+
 func (s *SQLiteUserStore) GetLibraryPlaybackPreference(_ context.Context, profileID string, libraryID int) (*userstore.LibraryPlaybackPreference, error) {
 	return GetLibraryPlaybackPreference(s.db, profileID, libraryID)
 }

--- a/internal/userstore/collection_sort_cleanup.go
+++ b/internal/userstore/collection_sort_cleanup.go
@@ -1,0 +1,62 @@
+package userstore
+
+import (
+	"context"
+	"log/slog"
+	"sort"
+)
+
+// CollectionSortPreferenceCleaner removes cross-user viewer preferences when
+// a shared library collection is deleted. Library collections live in the
+// central catalog while preferences may live in either shared PostgreSQL or
+// per-user SQLite, so database foreign keys cannot provide this cleanup.
+type CollectionSortPreferenceCleaner struct {
+	users  UserLister
+	stores UserStoreProvider
+	logger *slog.Logger
+}
+
+// NewCollectionSortPreferenceCleaner wires the cross-user cleanup sweep.
+func NewCollectionSortPreferenceCleaner(users UserLister, stores UserStoreProvider) *CollectionSortPreferenceCleaner {
+	return &CollectionSortPreferenceCleaner{
+		users:  users,
+		stores: stores,
+		logger: slog.Default().With("component", "userstore.collection_sort_cleanup"),
+	}
+}
+
+// DeleteForCollection clears every profile's preference for one collection.
+// Failures are logged per user and do not undo the owning collection delete;
+// stale rows are unreachable because preference writes and reads both require
+// the collection to remain accessible.
+func (c *CollectionSortPreferenceCleaner) DeleteForCollection(ctx context.Context, kind, collectionID string) {
+	if c == nil || c.users == nil || c.stores == nil {
+		return
+	}
+	users, err := c.users.List(ctx)
+	if err != nil {
+		c.logger.WarnContext(ctx, "collection sort cleanup: list users failed", "kind", kind, "collection_id", collectionID, "error", err)
+		return
+	}
+	sort.Slice(users, func(i, j int) bool { return users[i].ID < users[j].ID })
+	for _, user := range users {
+		if ctx.Err() != nil {
+			return
+		}
+		store, err := c.stores.ForUser(ctx, user.ID)
+		if err != nil {
+			c.logger.WarnContext(ctx, "collection sort cleanup: open user store failed", "kind", kind, "collection_id", collectionID, "user_id", user.ID, "error", err)
+			continue
+		}
+		profiles, err := store.ListProfiles(ctx)
+		if err != nil {
+			c.logger.WarnContext(ctx, "collection sort cleanup: list profiles failed", "kind", kind, "collection_id", collectionID, "user_id", user.ID, "error", err)
+			continue
+		}
+		for _, profile := range profiles {
+			if err := store.ClearCollectionSortPreference(ctx, profile.ID, kind, collectionID); err != nil {
+				c.logger.WarnContext(ctx, "collection sort cleanup: delete failed", "kind", kind, "collection_id", collectionID, "user_id", user.ID, "profile_id", profile.ID, "error", err)
+			}
+		}
+	}
+}

--- a/internal/userstore/collection_sort_cleanup_test.go
+++ b/internal/userstore/collection_sort_cleanup_test.go
@@ -1,0 +1,62 @@
+package userstore_test
+
+import (
+	"context"
+	"path/filepath"
+	"testing"
+
+	"github.com/Silo-Server/silo-server/internal/models"
+	"github.com/Silo-Server/silo-server/internal/userdb"
+	"github.com/Silo-Server/silo-server/internal/userstore"
+)
+
+type cleanupUserLister struct {
+	users []*models.User
+}
+
+func (l cleanupUserLister) List(context.Context) ([]*models.User, error) { return l.users, nil }
+
+type cleanupStoreProvider struct {
+	stores map[int]userstore.UserStore
+}
+
+func (p cleanupStoreProvider) ForUser(_ context.Context, userID int) (userstore.UserStore, error) {
+	return p.stores[userID], nil
+}
+
+func (cleanupStoreProvider) Close() error { return nil }
+
+func TestCollectionSortPreferenceCleanerDeletesAcrossUsers(t *testing.T) {
+	ctx := context.Background()
+	provider := cleanupStoreProvider{stores: make(map[int]userstore.UserStore)}
+	for _, userID := range []int{1, 2} {
+		db, err := userdb.NewUserDB(filepath.Join(t.TempDir(), "user.db"), userID)
+		if err != nil {
+			t.Fatalf("open user %d database: %v", userID, err)
+		}
+		t.Cleanup(func() { _ = db.Close() })
+		store := userdb.NewSQLiteUserStore(db.DB)
+		profileID := "profile-" + string(rune('0'+userID))
+		if err := store.CreateProfile(ctx, userstore.Profile{ID: profileID, Name: profileID}); err != nil {
+			t.Fatalf("create profile: %v", err)
+		}
+		if err := store.SetCollectionSortPreference(ctx, userstore.CollectionSortPreference{
+			ProfileID: profileID, CollectionKind: userstore.CollectionKindLibrary,
+			CollectionID: "library-collection", SortField: "title", SortOrder: "asc",
+		}); err != nil {
+			t.Fatalf("set preference: %v", err)
+		}
+		provider.stores[userID] = store
+	}
+
+	cleaner := userstore.NewCollectionSortPreferenceCleaner(cleanupUserLister{users: []*models.User{{ID: 1}, {ID: 2}}}, provider)
+	cleaner.DeleteForCollection(ctx, userstore.CollectionKindLibrary, "library-collection")
+
+	for userID, store := range provider.stores {
+		profileID := "profile-" + string(rune('0'+userID))
+		pref, err := store.GetCollectionSortPreference(ctx, profileID, userstore.CollectionKindLibrary, "library-collection")
+		if err != nil || pref != nil {
+			t.Fatalf("user %d preference = %+v, err = %v; want nil", userID, pref, err)
+		}
+	}
+}

--- a/internal/userstore/pgstore/collection_sort_prefs.go
+++ b/internal/userstore/pgstore/collection_sort_prefs.go
@@ -1,0 +1,85 @@
+package pgstore
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/jackc/pgx/v5"
+
+	"github.com/Silo-Server/silo-server/internal/userstore"
+)
+
+func (s *PostgresUserStore) SetCollectionSortPreference(ctx context.Context, pref userstore.CollectionSortPreference) error {
+	if pref.UpdatedAt == "" {
+		pref.UpdatedAt = nowUTC()
+	}
+	_, err := s.pool.Exec(ctx, `
+		INSERT INTO user_collection_sort_preferences (
+			user_id, profile_id, collection_kind, collection_id, sort_field, sort_order, updated_at
+		) VALUES ($1, $2, $3, $4, $5, $6, $7)
+		ON CONFLICT(user_id, profile_id, collection_kind, collection_id) DO UPDATE SET
+			sort_field = excluded.sort_field,
+			sort_order = excluded.sort_order,
+			updated_at = excluded.updated_at`,
+		s.userID,
+		pref.ProfileID,
+		pref.CollectionKind,
+		pref.CollectionID,
+		pref.SortField,
+		pref.SortOrder,
+		pref.UpdatedAt,
+	)
+	if err != nil {
+		return fmt.Errorf("setting collection sort preference for profile %q collection %q/%q: %w",
+			pref.ProfileID, pref.CollectionKind, pref.CollectionID, err)
+	}
+	return nil
+}
+
+// GetCollectionSortPreference returns (nil, nil) when the profile has never
+// changed this collection's sort. A returned preference with an empty SortField
+// means the viewer explicitly chose the collection's own source order.
+func (s *PostgresUserStore) GetCollectionSortPreference(ctx context.Context, profileID, collectionKind, collectionID string) (*userstore.CollectionSortPreference, error) {
+	var pref userstore.CollectionSortPreference
+	var updatedAt time.Time
+	err := s.pool.QueryRow(ctx, `
+		SELECT profile_id, collection_kind, collection_id, sort_field, sort_order, updated_at
+		FROM user_collection_sort_preferences
+		WHERE user_id = $1 AND profile_id = $2 AND collection_kind = $3 AND collection_id = $4`,
+		s.userID, profileID, collectionKind, collectionID,
+	).Scan(
+		&pref.ProfileID,
+		&pref.CollectionKind,
+		&pref.CollectionID,
+		&pref.SortField,
+		&pref.SortOrder,
+		&updatedAt,
+	)
+	if errors.Is(err, pgx.ErrNoRows) {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, fmt.Errorf("getting collection sort preference for profile %q collection %q/%q: %w",
+			profileID, collectionKind, collectionID, err)
+	}
+	pref.UpdatedAt = updatedAt.UTC().Format(time.RFC3339)
+	return &pref, nil
+}
+
+// ClearCollectionSortPreference drops the override so the collection falls back
+// to its creator-configured default. Distinct from storing an empty SortField,
+// which pins the viewer to source order.
+func (s *PostgresUserStore) ClearCollectionSortPreference(ctx context.Context, profileID, collectionKind, collectionID string) error {
+	_, err := s.pool.Exec(ctx, `
+		DELETE FROM user_collection_sort_preferences
+		WHERE user_id = $1 AND profile_id = $2 AND collection_kind = $3 AND collection_id = $4`,
+		s.userID, profileID, collectionKind, collectionID,
+	)
+	if err != nil {
+		return fmt.Errorf("clearing collection sort preference for profile %q collection %q/%q: %w",
+			profileID, collectionKind, collectionID, err)
+	}
+	return nil
+}

--- a/internal/userstore/pgstore/collections.go
+++ b/internal/userstore/pgstore/collections.go
@@ -365,6 +365,11 @@ func (s *PostgresUserStore) DeleteCollection(ctx context.Context, id string) err
 	if _, err := tx.Exec(ctx, `DELETE FROM user_personal_collection_items WHERE user_id = $1 AND collection_id = $2`, s.userID, id); err != nil {
 		return fmt.Errorf("deleting collection items: %w", err)
 	}
+	if _, err := tx.Exec(ctx, `
+		DELETE FROM user_collection_sort_preferences
+		WHERE user_id = $1 AND collection_kind = 'user' AND collection_id = $2`, s.userID, id); err != nil {
+		return fmt.Errorf("deleting collection sort preferences: %w", err)
+	}
 	if _, err := tx.Exec(ctx, `DELETE FROM user_personal_collections WHERE user_id = $1 AND id = $2`, s.userID, id); err != nil {
 		return fmt.Errorf("deleting collection: %w", err)
 	}

--- a/internal/userstore/pgstore/conformance_test.go
+++ b/internal/userstore/pgstore/conformance_test.go
@@ -171,3 +171,40 @@ func TestPostgresJellycompatDisplayPrefs(t *testing.T) {
 		return newStore(pool, userID)
 	})
 }
+
+func TestPostgresCollectionSortPreferences(t *testing.T) {
+	dsn := os.Getenv("SILO_TEST_DATABASE_URL")
+	if dsn == "" {
+		t.Skip("SILO_TEST_DATABASE_URL is not set")
+	}
+	ctx := context.Background()
+	pool, err := pgxpool.New(ctx, dsn)
+	if err != nil {
+		t.Fatalf("connect test database: %v", err)
+	}
+	t.Cleanup(pool.Close)
+
+	var tableName *string
+	if err := pool.QueryRow(ctx,
+		`SELECT to_regclass('public.user_collection_sort_preferences')::text`).Scan(&tableName); err != nil {
+		t.Fatalf("check preference table: %v", err)
+	}
+	if tableName == nil || *tableName == "" {
+		t.Skip("collection sort preference migration has not been applied")
+	}
+
+	storetest.RunCollectionSortPreferences(t, func(t *testing.T) userstore.UserStore {
+		var userID int
+		if err := pool.QueryRow(ctx,
+			`INSERT INTO users (username, role) VALUES ($1, 'user') RETURNING id`,
+			fmt.Sprintf("sort-pref-conf-%d", time.Now().UnixNano()),
+		).Scan(&userID); err != nil {
+			t.Fatalf("seed user: %v", err)
+		}
+		t.Cleanup(func() {
+			deleteUserAssertingCascade(t, pool, userID,
+				"user_collection_sort_preferences", "user_profiles")
+		})
+		return newStore(pool, userID)
+	})
+}

--- a/internal/userstore/pgstore/profiles.go
+++ b/internal/userstore/pgstore/profiles.go
@@ -299,6 +299,7 @@ func (s *PostgresUserStore) DeleteProfile(ctx context.Context, id string) error 
 		"user_favorites",
 		"user_watchlist",
 		"user_watch_progress",
+		"user_collection_sort_preferences",
 		"user_personal_collections",
 		"user_series_playback_preferences",
 		"user_library_playback_preferences",

--- a/internal/userstore/pgstore/profiles.go
+++ b/internal/userstore/pgstore/profiles.go
@@ -282,6 +282,16 @@ func (s *PostgresUserStore) DeleteProfile(ctx context.Context, id string) error 
 	}
 	defer tx.Rollback(ctx) //nolint:errcheck
 
+	// Preferences belong to viewers, not creators, so remove every override
+	// for collections owned by the profile before those collections disappear.
+	if _, err := tx.Exec(ctx, `
+		DELETE FROM user_collection_sort_preferences
+		WHERE user_id = $1 AND collection_kind = 'user' AND collection_id IN (
+			SELECT id FROM user_personal_collections WHERE user_id = $1 AND profile_id = $2
+		)`, s.userID, id); err != nil {
+		return fmt.Errorf("deleting collection sort preferences for profile %s: %w", id, err)
+	}
+
 	_, err = tx.Exec(ctx, `
 		DELETE FROM user_personal_collection_items
 		WHERE user_id = $1 AND collection_id IN (

--- a/internal/userstore/store.go
+++ b/internal/userstore/store.go
@@ -162,6 +162,11 @@ type UserStore interface {
 	DeleteAudioPreference(ctx context.Context, profileID, seriesID string) error
 	SetSeriesPlaybackPreference(ctx context.Context, pref SeriesPlaybackPreference) error
 	GetSeriesPlaybackPreference(ctx context.Context, profileID, seriesID string) (*SeriesPlaybackPreference, error)
+
+	// Collection sort preferences
+	SetCollectionSortPreference(ctx context.Context, pref CollectionSortPreference) error
+	GetCollectionSortPreference(ctx context.Context, profileID, collectionKind, collectionID string) (*CollectionSortPreference, error)
+	ClearCollectionSortPreference(ctx context.Context, profileID, collectionKind, collectionID string) error
 	DeleteSeriesPlaybackPreference(ctx context.Context, profileID, seriesID string) error
 	GetLibraryPlaybackPreference(ctx context.Context, profileID string, libraryID int) (*LibraryPlaybackPreference, error)
 	ListLibraryPlaybackPreferences(ctx context.Context, profileID string) ([]LibraryPlaybackPreference, error)

--- a/internal/userstore/storetest/suite.go
+++ b/internal/userstore/storetest/suite.go
@@ -26,6 +26,54 @@ func RunProgressSince(t *testing.T, newStore func(t *testing.T) userstore.UserSt
 	})
 }
 
+// RunCollectionSortPreferences runs the preference timestamp and profile
+// lifecycle conformance checks against a UserStore implementation.
+func RunCollectionSortPreferences(t *testing.T, newStore func(t *testing.T) userstore.UserStore) {
+	t.Run("TimestampAndProfileLifecycle", func(t *testing.T) {
+		testCollectionSortPreferences(t, newStore)
+	})
+}
+
+func testCollectionSortPreferences(t *testing.T, newStore func(t *testing.T) userstore.UserStore) {
+	ctx := context.Background()
+	store := newStore(t)
+	const profileID = "sort-pref-profile"
+
+	if err := store.CreateProfile(ctx, userstore.Profile{ID: profileID, Name: "Sort Pref"}); err != nil {
+		t.Fatalf("CreateProfile: %v", err)
+	}
+	if err := store.SetCollectionSortPreference(ctx, userstore.CollectionSortPreference{
+		ProfileID:      profileID,
+		CollectionKind: userstore.CollectionKindLibrary,
+		CollectionID:   "collection-1",
+		SortField:      "title",
+		SortOrder:      "asc",
+	}); err != nil {
+		t.Fatalf("SetCollectionSortPreference: %v", err)
+	}
+	pref, err := store.GetCollectionSortPreference(ctx, profileID, userstore.CollectionKindLibrary, "collection-1")
+	if err != nil || pref == nil {
+		t.Fatalf("GetCollectionSortPreference = %v, err = %v", pref, err)
+	}
+	if _, err := time.Parse(time.RFC3339, pref.UpdatedAt); err != nil {
+		t.Fatalf("UpdatedAt = %q, want RFC3339 timestamp: %v", pref.UpdatedAt, err)
+	}
+
+	if err := store.DeleteProfile(ctx, profileID); err != nil {
+		t.Fatalf("DeleteProfile: %v", err)
+	}
+	if err := store.CreateProfile(ctx, userstore.Profile{ID: profileID, Name: "Recreated"}); err != nil {
+		t.Fatalf("CreateProfile(recreate): %v", err)
+	}
+	pref, err = store.GetCollectionSortPreference(ctx, profileID, userstore.CollectionKindLibrary, "collection-1")
+	if err != nil {
+		t.Fatalf("GetCollectionSortPreference(recreated profile): %v", err)
+	}
+	if pref != nil {
+		t.Fatalf("stale preference survived profile recreation: %+v", pref)
+	}
+}
+
 // RunSuite runs all conformance tests against a UserStore implementation.
 // The newStore function should return a fresh, empty store for each test.
 func RunSuite(t *testing.T, newStore func(t *testing.T) userstore.UserStore) {

--- a/internal/userstore/storetest/suite.go
+++ b/internal/userstore/storetest/suite.go
@@ -38,9 +38,13 @@ func testCollectionSortPreferences(t *testing.T, newStore func(t *testing.T) use
 	ctx := context.Background()
 	store := newStore(t)
 	const profileID = "sort-pref-profile"
+	const viewerProfileID = "sort-pref-viewer"
 
 	if err := store.CreateProfile(ctx, userstore.Profile{ID: profileID, Name: "Sort Pref"}); err != nil {
 		t.Fatalf("CreateProfile: %v", err)
+	}
+	if err := store.CreateProfile(ctx, userstore.Profile{ID: viewerProfileID, Name: "Sort Pref Viewer"}); err != nil {
+		t.Fatalf("CreateProfile(viewer): %v", err)
 	}
 	if err := store.SetCollectionSortPreference(ctx, userstore.CollectionSortPreference{
 		ProfileID:      profileID,
@@ -59,8 +63,80 @@ func testCollectionSortPreferences(t *testing.T, newStore func(t *testing.T) use
 		t.Fatalf("UpdatedAt = %q, want RFC3339 timestamp: %v", pref.UpdatedAt, err)
 	}
 
+	for _, invalid := range []userstore.CollectionSortPreference{
+		{
+			ProfileID:      profileID,
+			CollectionKind: "invalid",
+			CollectionID:   "collection-invalid-kind",
+			SortField:      "title",
+			SortOrder:      "asc",
+		},
+		{
+			ProfileID:      profileID,
+			CollectionKind: userstore.CollectionKindLibrary,
+			CollectionID:   "collection-invalid-order",
+			SortField:      "title",
+			SortOrder:      "sideways",
+		},
+	} {
+		if err := store.SetCollectionSortPreference(ctx, invalid); err == nil {
+			t.Fatalf("SetCollectionSortPreference accepted invalid preference: %+v", invalid)
+		}
+	}
+
+	deletedCollection, err := store.CreateCollection(ctx, userstore.CreateCollectionInput{
+		CreatorProfileID: profileID,
+		Name:             "Deleted sort preference target",
+	})
+	if err != nil {
+		t.Fatalf("CreateCollection(delete target): %v", err)
+	}
+	if err := store.SetCollectionSortPreference(ctx, userstore.CollectionSortPreference{
+		ProfileID:      viewerProfileID,
+		CollectionKind: userstore.CollectionKindUser,
+		CollectionID:   deletedCollection.ID,
+		SortField:      "year",
+		SortOrder:      "desc",
+	}); err != nil {
+		t.Fatalf("SetCollectionSortPreference(delete target): %v", err)
+	}
+	if err := store.DeleteCollection(ctx, deletedCollection.ID); err != nil {
+		t.Fatalf("DeleteCollection: %v", err)
+	}
+	deletedPref, err := store.GetCollectionSortPreference(ctx, viewerProfileID, userstore.CollectionKindUser, deletedCollection.ID)
+	if err != nil {
+		t.Fatalf("GetCollectionSortPreference(deleted collection): %v", err)
+	}
+	if deletedPref != nil {
+		t.Fatalf("preference survived collection deletion: %+v", deletedPref)
+	}
+
+	profileDeletedCollection, err := store.CreateCollection(ctx, userstore.CreateCollectionInput{
+		CreatorProfileID: profileID,
+		Name:             "Profile-deleted sort preference target",
+	})
+	if err != nil {
+		t.Fatalf("CreateCollection(profile delete target): %v", err)
+	}
+	if err := store.SetCollectionSortPreference(ctx, userstore.CollectionSortPreference{
+		ProfileID:      viewerProfileID,
+		CollectionKind: userstore.CollectionKindUser,
+		CollectionID:   profileDeletedCollection.ID,
+		SortField:      "title",
+		SortOrder:      "asc",
+	}); err != nil {
+		t.Fatalf("SetCollectionSortPreference(profile delete target): %v", err)
+	}
+
 	if err := store.DeleteProfile(ctx, profileID); err != nil {
 		t.Fatalf("DeleteProfile: %v", err)
+	}
+	deletedPref, err = store.GetCollectionSortPreference(ctx, viewerProfileID, userstore.CollectionKindUser, profileDeletedCollection.ID)
+	if err != nil {
+		t.Fatalf("GetCollectionSortPreference(profile-deleted collection): %v", err)
+	}
+	if deletedPref != nil {
+		t.Fatalf("preference survived creator profile deletion: %+v", deletedPref)
 	}
 	if err := store.CreateProfile(ctx, userstore.Profile{ID: profileID, Name: "Recreated"}); err != nil {
 		t.Fatalf("CreateProfile(recreate): %v", err)

--- a/internal/userstore/storetest/suite.go
+++ b/internal/userstore/storetest/suite.go
@@ -37,8 +37,12 @@ func RunCollectionSortPreferences(t *testing.T, newStore func(t *testing.T) user
 func testCollectionSortPreferences(t *testing.T, newStore func(t *testing.T) userstore.UserStore) {
 	ctx := context.Background()
 	store := newStore(t)
-	const profileID = "sort-pref-profile"
-	const viewerProfileID = "sort-pref-viewer"
+	const (
+		profileID       = "sort-pref-profile"
+		viewerProfileID = "sort-pref-viewer"
+		titleSortField  = "title"
+		ascendingOrder  = "asc"
+	)
 
 	if err := store.CreateProfile(ctx, userstore.Profile{ID: profileID, Name: "Sort Pref"}); err != nil {
 		t.Fatalf("CreateProfile: %v", err)
@@ -50,8 +54,8 @@ func testCollectionSortPreferences(t *testing.T, newStore func(t *testing.T) use
 		ProfileID:      profileID,
 		CollectionKind: userstore.CollectionKindLibrary,
 		CollectionID:   "collection-1",
-		SortField:      "title",
-		SortOrder:      "asc",
+		SortField:      titleSortField,
+		SortOrder:      ascendingOrder,
 	}); err != nil {
 		t.Fatalf("SetCollectionSortPreference: %v", err)
 	}
@@ -68,14 +72,14 @@ func testCollectionSortPreferences(t *testing.T, newStore func(t *testing.T) use
 			ProfileID:      profileID,
 			CollectionKind: "invalid",
 			CollectionID:   "collection-invalid-kind",
-			SortField:      "title",
-			SortOrder:      "asc",
+			SortField:      titleSortField,
+			SortOrder:      ascendingOrder,
 		},
 		{
 			ProfileID:      profileID,
 			CollectionKind: userstore.CollectionKindLibrary,
 			CollectionID:   "collection-invalid-order",
-			SortField:      "title",
+			SortField:      titleSortField,
 			SortOrder:      "sideways",
 		},
 	} {
@@ -122,8 +126,8 @@ func testCollectionSortPreferences(t *testing.T, newStore func(t *testing.T) use
 		ProfileID:      viewerProfileID,
 		CollectionKind: userstore.CollectionKindUser,
 		CollectionID:   profileDeletedCollection.ID,
-		SortField:      "title",
-		SortOrder:      "asc",
+		SortField:      titleSortField,
+		SortOrder:      ascendingOrder,
 	}); err != nil {
 		t.Fatalf("SetCollectionSortPreference(profile delete target): %v", err)
 	}

--- a/internal/userstore/types.go
+++ b/internal/userstore/types.go
@@ -376,6 +376,27 @@ type SeriesPlaybackPreference struct {
 	UpdatedAt  string `json:"updated_at"`
 }
 
+// Collection kinds for CollectionSortPreference. Collection ids are unique
+// within a kind but not across the two id spaces, so the kind is part of the
+// preference's identity.
+const (
+	CollectionKindLibrary = "library"
+	CollectionKindUser    = "user"
+)
+
+// CollectionSortPreference records that a profile changed the sort order while
+// browsing a collection, overriding whatever default the collection's creator
+// configured. An empty SortField is a real choice — "show me this collection in
+// its own source order" — and is distinct from having no preference row at all.
+type CollectionSortPreference struct {
+	ProfileID      string `json:"profile_id"`
+	CollectionKind string `json:"collection_kind"`
+	CollectionID   string `json:"collection_id"`
+	SortField      string `json:"sort_field"`
+	SortOrder      string `json:"sort_order"`
+	UpdatedAt      string `json:"updated_at"`
+}
+
 // LibraryPlaybackPreference stores per-library playback settings.
 type LibraryPlaybackPreference struct {
 	ProfileID              string `json:"profile_id"`

--- a/migrations/sql/20260727094016_add_collection_sort_preferences.sql
+++ b/migrations/sql/20260727094016_add_collection_sort_preferences.sql
@@ -1,0 +1,38 @@
+-- +goose Up
+-- +goose StatementBegin
+-- Per-profile sort override for a collection's browse view. A collection's own
+-- sort_config supplies the default order its creator chose; a row here records
+-- that a viewer changed it, and wins over that default for this profile only.
+--
+-- sort_field = '' is meaningful: it records "this viewer explicitly chose the
+-- collection's own source order", which must survive even when the creator
+-- later sets a default sort. Absence of a row means "no choice made yet".
+--
+-- collection_kind separates the two id spaces ('library' = admin/server-wide
+-- collections, 'user' = personal ones); ids are unique within a kind but not
+-- across them.
+CREATE TABLE IF NOT EXISTS public.user_collection_sort_preferences (
+    user_id INTEGER NOT NULL,
+    profile_id TEXT NOT NULL,
+    collection_kind TEXT NOT NULL,
+    collection_id TEXT NOT NULL,
+    sort_field TEXT NOT NULL DEFAULT '',
+    sort_order TEXT NOT NULL DEFAULT '',
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+    PRIMARY KEY (user_id, profile_id, collection_kind, collection_id),
+    CONSTRAINT user_collection_sort_preferences_user_id_fkey
+        FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE CASCADE,
+    CONSTRAINT user_collection_sort_preferences_profile_fkey
+        FOREIGN KEY (user_id, profile_id)
+        REFERENCES user_profiles(user_id, id) ON DELETE CASCADE,
+    CONSTRAINT user_collection_sort_preferences_kind_check
+        CHECK (collection_kind IN ('library', 'user')),
+    CONSTRAINT user_collection_sort_preferences_order_check
+        CHECK (sort_order IN ('', 'asc', 'desc'))
+);
+-- +goose StatementEnd
+
+-- +goose Down
+-- +goose StatementBegin
+DROP TABLE IF EXISTS public.user_collection_sort_preferences;
+-- +goose StatementEnd

--- a/web/src/api/types.ts
+++ b/web/src/api/types.ts
@@ -1408,7 +1408,7 @@ export interface DisplayQueryDefinition {
  */
 export interface CollectionSortConfig {
   field?: string;
-  order?: string;
+  order?: "asc" | "desc";
   // Index signature keeps this assignable to the `Record<string, unknown>`
   // sort_config fields on the collection request types, which predate it.
   [key: string]: unknown;

--- a/web/src/api/types.ts
+++ b/web/src/api/types.ts
@@ -864,6 +864,13 @@ export interface CatalogResponse extends BrowseResponse {
   source?: CatalogSource;
   title?: string;
   snapshot?: string;
+  /**
+   * The order a collection source actually resolved in, after the viewer's
+   * saved override and the collection's configured default were applied.
+   * Absent for non-collection sources and when the collection kept its own
+   * source order.
+   */
+  effective_sort?: QuerySort;
 }
 
 export interface ItemFiltersResponse {
@@ -1374,6 +1381,9 @@ export interface CollectionCapabilitiesResponse {
     watched: UserCollectionWatchFilter[];
     media: UserCollectionMediaFilter[];
   };
+  collection_default_sort?: boolean;
+  collection_sort_preferences?: boolean;
+  effective_collection_sort?: boolean;
 }
 
 export interface QueryRule {
@@ -1390,6 +1400,18 @@ export interface QueryGroup {
 export interface DisplayQueryDefinition {
   match: "all" | "any";
   groups: QueryGroup[];
+}
+
+/**
+ * A collection's default sort. An empty object (or an absent field) means the
+ * collection keeps the order its source supplied.
+ */
+export interface CollectionSortConfig {
+  field?: string;
+  order?: string;
+  // Index signature keeps this assignable to the `Record<string, unknown>`
+  // sort_config fields on the collection request types, which predate it.
+  [key: string]: unknown;
 }
 
 export interface QuerySort {
@@ -1643,6 +1665,8 @@ export interface ImportMDBListCollectionRequest {
   management_mode?: LibraryCollectionManagementMode;
   management_source?: string;
   management_key?: string;
+  /** Default order viewers land on; `{}` keeps the source list's own order. */
+  sort_config?: CollectionSortConfig;
 }
 
 export interface ImportMDBListCollectionResponse {
@@ -1674,6 +1698,8 @@ export interface ImportTMDBCollectionRequest {
   management_mode?: LibraryCollectionManagementMode;
   management_source?: string;
   management_key?: string;
+  /** Default order viewers land on; `{}` keeps the source list's own order. */
+  sort_config?: CollectionSortConfig;
 }
 
 export interface ImportTMDBCollectionResponse {
@@ -1701,6 +1727,8 @@ export interface ImportTraktCollectionRequest {
   management_mode?: LibraryCollectionManagementMode;
   management_source?: string;
   management_key?: string;
+  /** Default order viewers land on; `{}` keeps the source list's own order. */
+  sort_config?: CollectionSortConfig;
 }
 
 export interface ImportTraktCollectionResponse {
@@ -1724,6 +1752,8 @@ export interface UserImportSharedFields {
   display_query_definition?: DisplayQueryDefinition;
   /** Restrict resolution to these libraries; omitted/empty = entire catalog the user can see. */
   library_ids?: number[];
+  /** Default order viewers land on; `{}` keeps the source list's own order. */
+  sort_config?: CollectionSortConfig;
 }
 
 export interface ImportUserMDBListCollectionRequest extends UserImportSharedFields {

--- a/web/src/components/CollectionTemplateGallery/CollectionTemplateConfigForm.tsx
+++ b/web/src/components/CollectionTemplateGallery/CollectionTemplateConfigForm.tsx
@@ -14,6 +14,7 @@ import {
   mediaKindLabel,
 } from "@/lib/collectionTemplates";
 import type { CollectionTemplate, LibraryEligibility } from "@/lib/collectionTemplates";
+import { COLLECTION_SOURCE_ORDER, selectValueToSortConfig } from "@/lib/collectionSortConfig";
 import {
   CollectionLibraryPicker,
   parseOptionalPositiveInteger,
@@ -31,6 +32,7 @@ import {
   SelectValue,
 } from "@/components/ui/select";
 import { Switch } from "@/components/ui/switch";
+import { CollectionDefaultSortField } from "@/components/collections/CollectionDefaultSortField";
 import { SyncScheduleField } from "@/components/collections/SyncScheduleField";
 
 import { MDBListBrowser } from "./MDBListBrowser";
@@ -103,6 +105,7 @@ export function CollectionTemplateConfigForm({
     template.poster_path ? "default" : "custom",
   );
   const [customPosterUrl, setCustomPosterUrl] = useState("");
+  const [defaultSort, setDefaultSort] = useState<string>(COLLECTION_SOURCE_ORDER);
 
   // Discover- and Collection-source templates are bundle-only: the spec is
   // backend-driven and can't be edited inline. Render a read-only summary so
@@ -144,6 +147,7 @@ export function CollectionTemplateConfigForm({
       featured,
       sync_schedule: syncSchedule.trim() || undefined,
       limit: parsedLimit,
+      sort_config: selectValueToSortConfig(defaultSort),
       ...(posterMode === "custom"
         ? { poster_source_url: customPosterUrl.trim() || undefined }
         : { poster_url: template.poster_path || undefined }),
@@ -328,6 +332,12 @@ export function CollectionTemplateConfigForm({
           </div>
         </div>
       </div>
+
+      <CollectionDefaultSortField
+        value={defaultSort}
+        onChange={setDefaultSort}
+        inputId="template-default-sort"
+      />
 
       <SyncScheduleField value={syncSchedule} onChange={setSyncSchedule} />
 

--- a/web/src/components/CollectionTemplateGallery/UserCollectionTemplateConfigForm.tsx
+++ b/web/src/components/CollectionTemplateGallery/UserCollectionTemplateConfigForm.tsx
@@ -20,6 +20,8 @@ import {
   COLLECTION_WATCH_FILTER_OPTIONS,
   displayFiltersToQueryDefinition,
 } from "@/lib/collectionDisplayFilters";
+import { COLLECTION_SOURCE_ORDER, selectValueToSortConfig } from "@/lib/collectionSortConfig";
+import { CollectionDefaultSortField } from "@/components/collections/CollectionDefaultSortField";
 import {
   COLLECTION_MAX_ITEMS,
   libraryEligibilityForMediaKind,
@@ -107,6 +109,7 @@ export function UserCollectionTemplateConfigForm({ template, onCancel, onCreated
     template.poster_path ? "default" : "custom",
   );
   const [customPosterUrl, setCustomPosterUrl] = useState("");
+  const [defaultSort, setDefaultSort] = useState<string>(COLLECTION_SOURCE_ORDER);
 
   const eligibility = libraryEligibilityForMediaKind(template.media_kind);
   const pickerLibraries = libraries.map((lib) => ({
@@ -137,6 +140,7 @@ export function UserCollectionTemplateConfigForm({ template, onCancel, onCreated
           : template.poster_path || undefined,
       library_ids: libraryIds.length > 0 ? libraryIds : undefined,
       display_query_definition: displayFiltersToQueryDefinition(watchFilter, mediaFilter),
+      sort_config: selectValueToSortConfig(defaultSort),
     };
 
     if (template.source === "tmdb" && template.tmdb) {
@@ -341,6 +345,13 @@ export function UserCollectionTemplateConfigForm({ template, onCancel, onCreated
           </Select>
         </div>
       </div>
+
+      <CollectionDefaultSortField
+        value={defaultSort}
+        onChange={setDefaultSort}
+        allowPersonalized
+        inputId="user-template-default-sort"
+      />
 
       <div className="border-border flex items-center justify-between rounded-md border px-3 py-2">
         <div className="space-y-0.5">

--- a/web/src/components/collections/CollectionDefaultSortField.tsx
+++ b/web/src/components/collections/CollectionDefaultSortField.tsx
@@ -1,0 +1,57 @@
+import { Label } from "@/components/ui/label";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import { collectionDefaultSortOptions } from "@/lib/collectionSortConfig";
+
+interface Props {
+  value: string;
+  onChange: (next: string) => void;
+  /** Personal collections may sort by per-profile fields; library ones may not. */
+  allowPersonalized?: boolean;
+  inputId?: string;
+  disabled?: boolean;
+}
+
+/**
+ * CollectionDefaultSortField picks the order viewers land on when they open a
+ * collection. It is the exact-collection counterpart to CollectionOrderingEditor
+ * (which owns ordering for smart collections through their query definition),
+ * so both kinds of collection expose a default order without duplicating the
+ * ordering-mode controls that only make sense for a query.
+ */
+export function CollectionDefaultSortField({
+  value,
+  onChange,
+  allowPersonalized = false,
+  inputId = "collection-default-sort",
+  disabled = false,
+}: Props) {
+  const options = collectionDefaultSortOptions(allowPersonalized);
+
+  return (
+    <div className="space-y-2">
+      <Label htmlFor={inputId}>Default Sort</Label>
+      <Select value={value} onValueChange={onChange} disabled={disabled}>
+        <SelectTrigger id={inputId}>
+          <SelectValue />
+        </SelectTrigger>
+        <SelectContent>
+          {options.map((option) => (
+            <SelectItem key={option.value} value={option.value}>
+              {option.label}
+            </SelectItem>
+          ))}
+        </SelectContent>
+      </Select>
+      <p className="text-muted-foreground text-xs">
+        The order viewers get when they open this collection. They can still sort it their own way,
+        and that choice is remembered for them.
+      </p>
+    </div>
+  );
+}

--- a/web/src/hooks/AuthProvider.test.tsx
+++ b/web/src/hooks/AuthProvider.test.tsx
@@ -1,8 +1,8 @@
-import { render, screen, waitFor } from "@testing-library/react";
+import { act, render, screen, waitFor } from "@testing-library/react";
 import type { ReactNode } from "react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
-import type { AuthProviderOption, SetupStatusResponse } from "@/api/types";
+import type { AuthProviderOption, Profile, SetupStatusResponse } from "@/api/types";
 import { storage } from "@/utils/storage";
 import { AuthProvider, useAuth } from "./useAuth";
 
@@ -15,6 +15,7 @@ const setAccessTokenMock = vi.hoisted(() => vi.fn());
 const setProfileIdMock = vi.hoisted(() => vi.fn());
 const setProfileTokenMock = vi.hoisted(() => vi.fn());
 const setRefreshTokenMock = vi.hoisted(() => vi.fn());
+const queryClientClearMock = vi.hoisted(() => vi.fn());
 
 vi.mock("@/api/client", async () => {
   const actual = await vi.importActual<typeof import("@/api/client")>("@/api/client");
@@ -33,6 +34,36 @@ vi.mock("@/api/client", async () => {
   };
 });
 
+vi.mock("@/lib/query-client", () => ({
+  queryClient: {
+    clear: queryClientClearMock,
+  },
+}));
+
+function makeProfile(id: string, name: string): Profile {
+  return {
+    id,
+    name,
+    avatar: "",
+    has_pin: false,
+    is_child: false,
+    is_primary: id === "profile-1",
+    max_content_rating: "",
+    quality_preference: "1080p",
+    language: "en",
+    subtitle_language: "",
+    subtitle_mode: "auto",
+    show_forced_subtitles: true,
+    auto_skip_intro: false,
+    auto_skip_credits: false,
+    library_restrictions_enabled: false,
+    allowed_library_ids: [],
+    max_playback_quality: "",
+    created_at: "2024-01-01T00:00:00Z",
+    updated_at: "2024-01-01T00:00:00Z",
+  };
+}
+
 function renderWithAuthProvider(children: ReactNode) {
   return render(<AuthProvider>{children}</AuthProvider>);
 }
@@ -43,6 +74,22 @@ function ProviderProbe() {
   return (
     <div data-testid="providers">
       {setupLoading ? "loading" : providers.map((entry) => `${entry.id}:${entry.mode}`).join(",")}
+    </div>
+  );
+}
+
+function ProfileSelectionProbe() {
+  const { profile, selectProfile } = useAuth();
+  const profileOne = makeProfile("profile-1", "Alex");
+  const renamedProfileOne = makeProfile("profile-1", "Alex Updated");
+  const profileTwo = makeProfile("profile-2", "Sam");
+
+  return (
+    <div>
+      <div data-testid="active-profile">{profile?.name ?? "none"}</div>
+      <button onClick={() => selectProfile(profileOne)}>Select profile one</button>
+      <button onClick={() => selectProfile(renamedProfileOne)}>Update profile one</button>
+      <button onClick={() => selectProfile(profileTwo)}>Select profile two</button>
     </div>
   );
 }
@@ -87,5 +134,58 @@ describe("AuthProvider", () => {
       expect(screen.getByTestId("providers")).toHaveTextContent("local:credentials");
       expect(screen.getByTestId("providers")).toHaveTextContent("plugin:41:oidc:oauth");
     });
+  });
+
+  it("clears cached profile-scoped data when the active profile changes", async () => {
+    apiMock.mockImplementation((path: string) => {
+      if (path === "/auth/setup") {
+        return Promise.resolve({ needs_setup: false });
+      }
+      if (path === "/auth/providers") {
+        return Promise.resolve([]);
+      }
+      return Promise.reject(new Error(`unexpected API call: ${path}`));
+    });
+
+    renderWithAuthProvider(<ProfileSelectionProbe />);
+
+    await act(async () => {
+      screen.getByRole("button", { name: "Select profile one" }).click();
+    });
+    expect(screen.getByTestId("active-profile")).toHaveTextContent("Alex");
+
+    queryClientClearMock.mockClear();
+    await act(async () => {
+      screen.getByRole("button", { name: "Select profile two" }).click();
+    });
+
+    expect(queryClientClearMock).toHaveBeenCalledTimes(1);
+    expect(screen.getByTestId("active-profile")).toHaveTextContent("Sam");
+  });
+
+  it("keeps cached data when updating the active profile without changing identity", async () => {
+    apiMock.mockImplementation((path: string) => {
+      if (path === "/auth/setup") {
+        return Promise.resolve({ needs_setup: false });
+      }
+      if (path === "/auth/providers") {
+        return Promise.resolve([]);
+      }
+      return Promise.reject(new Error(`unexpected API call: ${path}`));
+    });
+
+    renderWithAuthProvider(<ProfileSelectionProbe />);
+
+    await act(async () => {
+      screen.getByRole("button", { name: "Select profile one" }).click();
+    });
+    queryClientClearMock.mockClear();
+
+    await act(async () => {
+      screen.getByRole("button", { name: "Update profile one" }).click();
+    });
+
+    expect(queryClientClearMock).not.toHaveBeenCalled();
+    expect(screen.getByTestId("active-profile")).toHaveTextContent("Alex Updated");
   });
 });

--- a/web/src/hooks/queries/catalog.ts
+++ b/web/src/hooks/queries/catalog.ts
@@ -310,6 +310,10 @@ export function useCatalogWindow(
       title,
       totalItems,
       pages,
+      // Collection sources report the order they actually resolved in, after
+      // the viewer's saved override and the collection's configured default.
+      // Absent means the collection kept its own source order.
+      effectiveSort: page0Result.data?.effective_sort,
     },
     isLoading,
   };

--- a/web/src/hooks/queries/collections.test.tsx
+++ b/web/src/hooks/queries/collections.test.tsx
@@ -1,0 +1,68 @@
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { act, renderHook, waitFor } from "@testing-library/react";
+import type { ReactNode } from "react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { useSetCollectionSortPreference } from "./collections";
+
+const apiMock = vi.hoisted(() => vi.fn());
+
+vi.mock("@/api/client", async () => {
+  const actual = await vi.importActual<typeof import("@/api/client")>("@/api/client");
+  return { ...actual, api: apiMock };
+});
+
+function deferred<T>() {
+  let resolve!: (value: T) => void;
+  const promise = new Promise<T>((resolvePromise) => {
+    resolve = resolvePromise;
+  });
+  return { promise, resolve };
+}
+
+describe("useSetCollectionSortPreference", () => {
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("serializes writes so the latest sort choice is persisted last", async () => {
+    const first = deferred<unknown>();
+    const second = deferred<unknown>();
+    apiMock.mockReturnValueOnce(first.promise).mockReturnValueOnce(second.promise);
+
+    const queryClient = new QueryClient({
+      defaultOptions: { mutations: { retry: false }, queries: { retry: false } },
+    });
+    const wrapper = ({ children }: { children: ReactNode }) => (
+      <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+    );
+    const { result } = renderHook(() => useSetCollectionSortPreference(), { wrapper });
+
+    act(() => {
+      result.current.mutate({
+        collection_kind: "library",
+        collection_id: "collection-1",
+        field: "year",
+        order: "desc",
+      });
+      result.current.mutate({
+        collection_kind: "library",
+        collection_id: "collection-1",
+        field: "title",
+        order: "asc",
+      });
+    });
+
+    await waitFor(() => expect(apiMock).toHaveBeenCalledTimes(1));
+
+    first.resolve({});
+    await waitFor(() => expect(apiMock).toHaveBeenCalledTimes(2));
+    expect(JSON.parse(apiMock.mock.calls[1]?.[1]?.body as string)).toMatchObject({
+      field: "title",
+      order: "asc",
+    });
+
+    second.resolve({});
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+  });
+});

--- a/web/src/hooks/queries/collections.ts
+++ b/web/src/hooks/queries/collections.ts
@@ -10,7 +10,7 @@ import type {
   ServerCollectionsResponse,
   UpdateCollectionRequest,
 } from "@/api/types";
-import { collectionKeys } from "./keys";
+import { catalogKeys, collectionKeys } from "./keys";
 import { toast } from "sonner";
 import { invalidateUserCollectionQueries } from "./collectionSurfaceRefresh";
 
@@ -372,6 +372,41 @@ export function useDeleteUserCollectionImage() {
     },
     onError: (err) => {
       toast.error(err instanceof Error ? err.message : "Failed to remove poster");
+    },
+  });
+}
+
+/**
+ * Persists the sort a viewer picked while browsing a collection, so the choice
+ * survives leaving and re-entering it. Sending an empty field pins the viewer
+ * to the collection's own source order — distinct from clearing the preference,
+ * which returns them to whatever default the collection's creator configured.
+ *
+ * Failures are deliberately silent: the sort is already applied to the current
+ * view through the URL, and a toast for a preference that will be re-sent on
+ * the next change would be noise.
+ */
+export function useSetCollectionSortPreference() {
+  const queryClient = useQueryClient();
+  return useMutation({
+    // TanStack Query runs mutations sharing a scope serially. This prevents an
+    // earlier, slower request from completing after a later choice and
+    // overwriting the preference the viewer actually selected last.
+    scope: { id: "collection-sort-preference" },
+    mutationFn: (body: {
+      collection_kind: "library" | "user";
+      collection_id: string;
+      field: string;
+      order: string;
+    }) =>
+      api("/collections/sort-preference", {
+        method: "PUT",
+        body: JSON.stringify(body),
+      }),
+    onSuccess: () => {
+      // The next visit resolves through the server, so drop cached catalog
+      // pages that were built against the previous effective sort.
+      queryClient.invalidateQueries({ queryKey: catalogKeys.all });
     },
   });
 }

--- a/web/src/hooks/queries/collections.ts
+++ b/web/src/hooks/queries/collections.ts
@@ -5,6 +5,7 @@ import type {
   CollectionCapabilitiesResponse,
   CollectionGroup,
   CollectionItem,
+  CollectionSortConfig,
   CollectionsListResponse,
   CreateCollectionRequest,
   ServerCollectionsResponse,
@@ -397,7 +398,7 @@ export function useSetCollectionSortPreference() {
       collection_kind: "library" | "user";
       collection_id: string;
       field: string;
-      order: string;
+      order: NonNullable<CollectionSortConfig["order"]> | "";
     }) =>
       api("/collections/sort-preference", {
         method: "PUT",

--- a/web/src/hooks/useAuth.tsx
+++ b/web/src/hooks/useAuth.tsx
@@ -333,12 +333,20 @@ export function AuthProvider({ children }: { children: ReactNode }) {
     [],
   );
 
-  const selectProfile = useCallback((p: Profile, profileToken?: string) => {
-    setProfileId(p.id);
-    setProfileToken(profileToken ?? null);
-    storage.set(storage.KEYS.CURRENT_PROFILE, JSON.stringify(p));
-    setProfile(p);
-  }, []);
+  const selectProfile = useCallback(
+    (p: Profile, profileToken?: string) => {
+      const profileChanged = profile?.id !== p.id;
+
+      setProfileId(p.id);
+      setProfileToken(profileToken ?? null);
+      if (profileChanged) {
+        queryClient.clear();
+      }
+      storage.set(storage.KEYS.CURRENT_PROFILE, JSON.stringify(p));
+      setProfile(p);
+    },
+    [profile?.id],
+  );
 
   useEffect(() => {
     onProfileUnverified(clearProfile);

--- a/web/src/lib/collectionSortConfig.test.ts
+++ b/web/src/lib/collectionSortConfig.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  COLLECTION_SOURCE_ORDER,
+  selectValueToSortConfig,
+  sortConfigToSelectValue,
+} from "@/lib/collectionSortConfig";
+
+describe("collection sort config", () => {
+  it("round-trips source order as an empty config", () => {
+    expect(selectValueToSortConfig(COLLECTION_SOURCE_ORDER)).toEqual({});
+    expect(sortConfigToSelectValue({})).toBe(COLLECTION_SOURCE_ORDER);
+  });
+
+  it("normalizes an invalid select order to the field default", () => {
+    expect(selectValueToSortConfig("title:sideways")).toEqual({
+      field: "title",
+      order: "asc",
+    });
+  });
+});

--- a/web/src/lib/collectionSortConfig.test.ts
+++ b/web/src/lib/collectionSortConfig.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "vitest";
 
 import {
   COLLECTION_SOURCE_ORDER,
+  changedSortConfig,
   selectValueToSortConfig,
   sortConfigToSelectValue,
 } from "@/lib/collectionSortConfig";
@@ -17,5 +18,14 @@ describe("collection sort config", () => {
       field: "title",
       order: "asc",
     });
+  });
+
+  it("omits an unchanged sort so legacy modes are preserved", () => {
+    const initial = sortConfigToSelectValue({ mode: "manual_pins" });
+    expect(changedSortConfig(initial, initial)).toBeUndefined();
+  });
+
+  it("sends an explicit empty config when the user selects source order", () => {
+    expect(changedSortConfig("title:asc", COLLECTION_SOURCE_ORDER)).toEqual({});
   });
 });

--- a/web/src/lib/collectionSortConfig.ts
+++ b/web/src/lib/collectionSortConfig.ts
@@ -1,0 +1,61 @@
+import type { CollectionSortConfig, QuerySort } from "@/api/types";
+import { getDefaultQuerySortOrder, getQuerySortOptions } from "@/lib/querySortOptions";
+
+// COLLECTION_SOURCE_ORDER is the in-form sentinel for "no default sort" — the
+// collection keeps the order its source supplied (MDBList list order, manual
+// item order). Radix Select disallows empty-string item values, so the empty
+// sort_config is mapped to this sentinel only inside the form.
+export const COLLECTION_SOURCE_ORDER = "__source_order" as const;
+
+export interface CollectionDefaultSortOption {
+  value: string;
+  label: string;
+}
+
+/**
+ * Options for a collection's default sort. Personalized sorts (progress, date
+ * viewed, plays) are per-profile and only offered on personal collections;
+ * library collections resolve without a viewer in scope, so the backend rejects
+ * them there.
+ */
+export function collectionDefaultSortOptions(
+  allowPersonalized: boolean,
+): CollectionDefaultSortOption[] {
+  return [
+    { value: COLLECTION_SOURCE_ORDER, label: "Collection order (default)" },
+    ...getQuerySortOptions({ includePersonalized: allowPersonalized }).map((option) => ({
+      value: `${option.value}:${option.defaultOrder}`,
+      label: option.label,
+    })),
+  ];
+}
+
+/** Read the form's select value out of a stored sort_config. */
+export function sortConfigToSelectValue(config: CollectionSortConfig | undefined | null): string {
+  const field = typeof config?.field === "string" ? config.field.trim() : "";
+  if (!field) return COLLECTION_SOURCE_ORDER;
+  const order =
+    config?.order === "asc" || config?.order === "desc"
+      ? config.order
+      : getDefaultQuerySortOrder(field);
+  return `${field}:${order}`;
+}
+
+/**
+ * Build the sort_config to send. Returns `{}` for source order so an existing
+ * default is cleared rather than left in place — the backend treats `{}` and an
+ * absent field identically.
+ */
+export function selectValueToSortConfig(value: string): CollectionSortConfig {
+  if (!value || value === COLLECTION_SOURCE_ORDER) return {};
+  const [field, order] = value.split(":");
+  if (!field) return {};
+  return { field, order: order || getDefaultQuerySortOrder(field) };
+}
+
+/** The catalog filter bar's sort state expressed as a collection sort value. */
+export function querySortToSelectValue(sort: QuerySort | undefined | null): string {
+  const field = typeof sort?.field === "string" ? sort.field.trim() : "";
+  if (!field) return COLLECTION_SOURCE_ORDER;
+  return `${field}:${sort?.order || getDefaultQuerySortOrder(field)}`;
+}

--- a/web/src/lib/collectionSortConfig.ts
+++ b/web/src/lib/collectionSortConfig.ts
@@ -56,6 +56,20 @@ export function selectValueToSortConfig(value: string): CollectionSortConfig {
   };
 }
 
+/**
+ * Return a sort_config update only when the form control actually changed.
+ * Omitting the field preserves legacy/unknown modes (for example
+ * {"mode":"manual_pins"}) while an explicit source-order selection still
+ * clears the stored config with `{}`.
+ */
+export function changedSortConfig(
+  initialValue: string,
+  currentValue: string,
+): CollectionSortConfig | undefined {
+  if (currentValue === initialValue) return undefined;
+  return selectValueToSortConfig(currentValue);
+}
+
 /** The catalog filter bar's sort state expressed as a collection sort value. */
 export function querySortToSelectValue(sort: QuerySort | undefined | null): string {
   const field = typeof sort?.field === "string" ? sort.field.trim() : "";

--- a/web/src/lib/collectionSortConfig.ts
+++ b/web/src/lib/collectionSortConfig.ts
@@ -50,7 +50,10 @@ export function selectValueToSortConfig(value: string): CollectionSortConfig {
   if (!value || value === COLLECTION_SOURCE_ORDER) return {};
   const [field, order] = value.split(":");
   if (!field) return {};
-  return { field, order: order || getDefaultQuerySortOrder(field) };
+  return {
+    field,
+    order: order === "asc" || order === "desc" ? order : getDefaultQuerySortOrder(field),
+  };
 }
 
 /** The catalog filter bar's sort state expressed as a collection sort value. */

--- a/web/src/pages/Catalog.tsx
+++ b/web/src/pages/Catalog.tsx
@@ -9,6 +9,8 @@ import { Button } from "@/components/ui/button";
 import CatalogFiltersPanel from "@/components/catalog/CatalogFiltersPanel";
 import SearchScopeChips from "@/components/catalog/SearchScopeChips";
 import { useCatalogWindow } from "@/hooks/queries/catalog";
+import { useSetCollectionSortPreference } from "@/hooks/queries/collections";
+import { querySortToSelectValue } from "@/lib/collectionSortConfig";
 import { useSearchMediaScope, type SearchMediaScope } from "@/hooks/useSearchMediaScope";
 import { useRemoveHistory } from "@/hooks/queries/history";
 import { useRequestSearch } from "@/hooks/queries/useRequests";
@@ -29,6 +31,7 @@ import {
   catalogSourceAllowsOverlay,
   parseCatalogSearchParams,
 } from "./catalogSearchParams";
+import type { CatalogSearchState } from "./catalogSearchParams";
 
 const REQUEST_SEARCH_DEBOUNCE_MS = 100;
 
@@ -157,6 +160,50 @@ function CatalogResults({
     visibleRange,
     includeTotal: showExactResultCount,
   });
+  // The server resolves a collection's effective order (viewer override, then
+  // the collection's default, then source order) when the URL carries no sort.
+  // Reflect that back into the filter bar so the menu shows what is actually
+  // applied, without writing it into the URL — leaving it out of the URL is what
+  // lets a later change to the saved preference take effect on the next visit.
+  const effectiveSort = catalogQuery.data?.effectiveSort;
+  const sortedState = useMemo(() => {
+    if (!isCollectionSource || !effectiveState.uses_source_order || !effectiveSort?.field) {
+      return effectiveState;
+    }
+    return {
+      ...effectiveState,
+      uses_source_order: false,
+      sort_from_server: true,
+      query_definition: {
+        ...effectiveState.query_definition,
+        sort: { field: effectiveSort.field, order: effectiveSort.order },
+      },
+    };
+  }, [effectiveSort, effectiveState, isCollectionSource]);
+
+  const setCollectionSortPreference = useSetCollectionSortPreference();
+  const rememberCollectionSort = useCallback(
+    (nextState: CatalogSearchState) => {
+      const collectionId = nextState.collection_id?.trim();
+      if (!isCollectionSource || !collectionId) return;
+      const nextValue = nextState.uses_source_order
+        ? ""
+        : querySortToSelectValue(nextState.query_definition.sort);
+      const currentValue = sortedState.uses_source_order
+        ? ""
+        : querySortToSelectValue(sortedState.query_definition.sort);
+      if (nextValue === currentValue) return;
+      const [field, order] = nextValue ? nextValue.split(":") : ["", ""];
+      setCollectionSortPreference.mutate({
+        collection_kind: nextState.source === "library_collection" ? "library" : "user",
+        collection_id: collectionId,
+        field: field ?? "",
+        order: order ?? "",
+      });
+    },
+    [isCollectionSource, setCollectionSortPreference, sortedState],
+  );
+
   const canRequest = useCanRequest();
   // Add a short TMDB debounce on top of SearchBar's input debounce so the
   // TMDB plugin isn't hit at the same cadence as the local library query.
@@ -273,9 +320,17 @@ function CatalogResults({
       ) : null}
 
       <CatalogFiltersPanel
-        state={effectiveState}
+        state={sortedState}
         onStateChange={(nextState) => {
-          const nextSearchParams = buildCatalogFilterSearchParams(nextState);
+          const sortChanged =
+            nextState.uses_source_order !== sortedState.uses_source_order ||
+            querySortToSelectValue(nextState.query_definition.sort) !==
+              querySortToSelectValue(sortedState.query_definition.sort);
+          const stateForNavigation = sortChanged
+            ? { ...nextState, sort_from_server: false }
+            : nextState;
+          rememberCollectionSort(stateForNavigation);
+          const nextSearchParams = buildCatalogFilterSearchParams(stateForNavigation);
           if (nextSearchParams.toString() !== searchParams.toString()) {
             setSearchParams(nextSearchParams);
           }

--- a/web/src/pages/Catalog.tsx
+++ b/web/src/pages/Catalog.tsx
@@ -198,7 +198,7 @@ function CatalogResults({
         collection_kind: nextState.source === "library_collection" ? "library" : "user",
         collection_id: collectionId,
         field: field ?? "",
-        order: order ?? "",
+        order: order === "asc" || order === "desc" ? order : "",
       });
     },
     [isCollectionSource, setCollectionSortPreference, sortedState],

--- a/web/src/pages/ImportedCollectionEditor.tsx
+++ b/web/src/pages/ImportedCollectionEditor.tsx
@@ -51,7 +51,7 @@ import {
   queryDefinitionToDisplayFilters,
 } from "@/lib/collectionDisplayFilters";
 import { CollectionDefaultSortField } from "@/components/collections/CollectionDefaultSortField";
-import { selectValueToSortConfig, sortConfigToSelectValue } from "@/lib/collectionSortConfig";
+import { changedSortConfig, sortConfigToSelectValue } from "@/lib/collectionSortConfig";
 import { CollectionLibraryPicker } from "@/pages/adminCollectionsShared";
 
 import { isCollectionReadOnly } from "./userCollectionsShared";
@@ -212,10 +212,13 @@ export function ImportedCollectionEditor({ collection, onClose }: ImportedCollec
       allowed_profile_ids: allowedProfileIds,
       library_ids: libraryIds,
       display_query_definition: displayFiltersToQueryDefinition(watchFilter, mediaFilter),
-      sort_config: selectValueToSortConfig(defaultSort),
       include_in_server_collections: includeOnServer,
       poster_source_url: trimmedPosterSource || undefined,
     };
+    const sortConfig = changedSortConfig(initialDefaultSort, defaultSort);
+    if (sortConfig !== undefined) {
+      body.sort_config = sortConfig;
+    }
     if (descriptionDirty) {
       body.description = description;
     }

--- a/web/src/pages/ImportedCollectionEditor.tsx
+++ b/web/src/pages/ImportedCollectionEditor.tsx
@@ -242,6 +242,7 @@ export function ImportedCollectionEditor({ collection, onClose }: ImportedCollec
     setLibraryIds(initialLibraryIds);
     setWatchFilter(initialWatchFilter);
     setMediaFilter(initialMediaFilter);
+    setDefaultSort(initialDefaultSort);
     setIsShared(collection.is_shared);
     setAllowedProfileIds(collection.allowed_profile_ids ?? []);
     setIncludeOnServer(collection.include_in_server_collections ?? false);

--- a/web/src/pages/ImportedCollectionEditor.tsx
+++ b/web/src/pages/ImportedCollectionEditor.tsx
@@ -50,6 +50,8 @@ import {
   displayFiltersToQueryDefinition,
   queryDefinitionToDisplayFilters,
 } from "@/lib/collectionDisplayFilters";
+import { CollectionDefaultSortField } from "@/components/collections/CollectionDefaultSortField";
+import { selectValueToSortConfig, sortConfigToSelectValue } from "@/lib/collectionSortConfig";
 import { CollectionLibraryPicker } from "@/pages/adminCollectionsShared";
 
 import { isCollectionReadOnly } from "./userCollectionsShared";
@@ -123,12 +125,14 @@ export function ImportedCollectionEditor({ collection, onClose }: ImportedCollec
   );
   const initialWatchFilter = initialDisplayFilters.watch;
   const initialMediaFilter = initialDisplayFilters.media;
+  const initialDefaultSort = sortConfigToSelectValue(collection.sort_config);
 
   const [name, setName] = useState(collection.name);
   const [description, setDescription] = useState(initialDescription);
   const [libraryIds, setLibraryIds] = useState<number[]>(initialLibraryIds);
   const [watchFilter, setWatchFilter] = useState<UserCollectionWatchFilter>(initialWatchFilter);
   const [mediaFilter, setMediaFilter] = useState<UserCollectionMediaFilter>(initialMediaFilter);
+  const [defaultSort, setDefaultSort] = useState<string>(initialDefaultSort);
   const [isShared, setIsShared] = useState(collection.is_shared);
   const [allowedProfileIds, setAllowedProfileIds] = useState<string[]>(
     collection.allowed_profile_ids ?? [],
@@ -186,6 +190,7 @@ export function ImportedCollectionEditor({ collection, onClose }: ImportedCollec
     !arraysEqual(libraryIds, initialLibraryIds),
     watchFilter !== initialWatchFilter,
     mediaFilter !== initialMediaFilter,
+    defaultSort !== initialDefaultSort,
     isShared !== collection.is_shared,
     !arraysEqual(allowedProfileIds, collection.allowed_profile_ids ?? []),
     includeOnServer !== (collection.include_in_server_collections ?? false),
@@ -207,6 +212,7 @@ export function ImportedCollectionEditor({ collection, onClose }: ImportedCollec
       allowed_profile_ids: allowedProfileIds,
       library_ids: libraryIds,
       display_query_definition: displayFiltersToQueryDefinition(watchFilter, mediaFilter),
+      sort_config: selectValueToSortConfig(defaultSort),
       include_in_server_collections: includeOnServer,
       poster_source_url: trimmedPosterSource || undefined,
     };
@@ -364,6 +370,15 @@ export function ImportedCollectionEditor({ collection, onClose }: ImportedCollec
                   </SelectContent>
                 </Select>
               </div>
+            </div>
+            <div className="pt-1">
+              <CollectionDefaultSortField
+                value={defaultSort}
+                onChange={setDefaultSort}
+                allowPersonalized
+                inputId="imported-collection-default-sort"
+                disabled={readOnly}
+              />
             </div>
             <p className="text-muted-foreground text-xs leading-relaxed">
               Uses the active profile&rsquo;s watched state. Shared profiles may see different

--- a/web/src/pages/adminCollectionsShared.tsx
+++ b/web/src/pages/adminCollectionsShared.tsx
@@ -17,6 +17,12 @@ import {
 } from "@/hooks/queries/admin/collections";
 import { useProfiles } from "@/hooks/queries/profiles";
 import { ImageUploadField } from "@/components/ImageUploadField";
+import { CollectionDefaultSortField } from "@/components/collections/CollectionDefaultSortField";
+import {
+  COLLECTION_SOURCE_ORDER,
+  selectValueToSortConfig,
+  sortConfigToSelectValue,
+} from "@/lib/collectionSortConfig";
 import CollectionBuilder, {
   createCollectionBuilderValue,
   type CollectionBuilderValue,
@@ -692,6 +698,7 @@ export function TMDBPresetForm({
   const [posterSourceUrl, setPosterSourceUrl] = useState("");
   const [backdropSourceUrl, setBackdropSourceUrl] = useState("");
   const [tmdbSyncSchedule, setTmdbSyncSchedule] = useState("");
+  const [tmdbDefaultSort, setTmdbDefaultSort] = useState<string>(COLLECTION_SOURCE_ORDER);
   const parsedLimit = parseOptionalPositiveInteger(limit);
   const hasInvalidLimit = limit.trim().length > 0 && parsedLimit === undefined;
   const allowedMediaTypes = getTMDBAllowedMediaTypes(preset);
@@ -720,6 +727,7 @@ export function TMDBPresetForm({
           poster_source_url: posterSourceUrl.trim() || undefined,
           backdrop_source_url: backdropSourceUrl.trim() || undefined,
           sync_schedule: tmdbSyncSchedule.trim() || undefined,
+          sort_config: selectValueToSortConfig(tmdbDefaultSort),
         },
         poster: posterFile,
         backdrop: backdropFile,
@@ -882,6 +890,12 @@ export function TMDBPresetForm({
           />
         </div>
 
+        <CollectionDefaultSortField
+          value={tmdbDefaultSort}
+          onChange={setTmdbDefaultSort}
+          inputId="tmdb-default-sort"
+        />
+
         <SyncScheduleField value={tmdbSyncSchedule} onChange={setTmdbSyncSchedule} />
 
         <div className="border-border flex items-center justify-between rounded-lg border px-4 py-3">
@@ -934,6 +948,7 @@ export function TraktPresetForm({
   const [posterSourceUrl, setPosterSourceUrl] = useState("");
   const [backdropSourceUrl, setBackdropSourceUrl] = useState("");
   const [syncSchedule, setSyncSchedule] = useState("");
+  const [defaultSort, setDefaultSort] = useState<string>(COLLECTION_SOURCE_ORDER);
   const parsedLimit = parseOptionalPositiveInteger(limit);
   const hasInvalidLimit = limit.trim().length > 0 && parsedLimit === undefined;
   const isListMode = sourceKind === "list";
@@ -969,6 +984,7 @@ export function TraktPresetForm({
           poster_source_url: posterSourceUrl.trim() || undefined,
           backdrop_source_url: backdropSourceUrl.trim() || undefined,
           sync_schedule: syncSchedule.trim() || undefined,
+          sort_config: selectValueToSortConfig(defaultSort),
         },
         poster: posterFile,
         backdrop: backdropFile,
@@ -1153,6 +1169,12 @@ export function TraktPresetForm({
           />
         </div>
 
+        <CollectionDefaultSortField
+          value={defaultSort}
+          onChange={setDefaultSort}
+          inputId="trakt-default-sort"
+        />
+
         <SyncScheduleField value={syncSchedule} onChange={setSyncSchedule} />
 
         <div className="border-border flex items-center justify-between rounded-lg border px-4 py-3">
@@ -1206,6 +1228,7 @@ export function MDBListImportForm({
   const [posterSourceUrl, setPosterSourceUrl] = useState("");
   const [backdropSourceUrl, setBackdropSourceUrl] = useState("");
   const [syncSchedule, setSyncSchedule] = useState("");
+  const [defaultSort, setDefaultSort] = useState<string>(COLLECTION_SOURCE_ORDER);
   const parsedLimit = parseOptionalPositiveInteger(limit);
   const hasInvalidLimit = limit.trim().length > 0 && parsedLimit === undefined;
 
@@ -1223,6 +1246,7 @@ export function MDBListImportForm({
           poster_source_url: posterSourceUrl.trim() || undefined,
           backdrop_source_url: backdropSourceUrl.trim() || undefined,
           sync_schedule: syncSchedule.trim() || undefined,
+          sort_config: selectValueToSortConfig(defaultSort),
         },
         poster: posterFile,
         backdrop: backdropFile,
@@ -1325,6 +1349,12 @@ export function MDBListImportForm({
           />
         </div>
 
+        <CollectionDefaultSortField
+          value={defaultSort}
+          onChange={setDefaultSort}
+          inputId="mdblist-default-sort"
+        />
+
         <SyncScheduleField value={syncSchedule} onChange={setSyncSchedule} />
 
         <div className="border-border flex items-center justify-between rounded-lg border px-4 py-3">
@@ -1368,6 +1398,9 @@ export function CollectionEditForm({
   });
   const [title, setTitle] = useState(collection.title ?? "");
   const [description, setDescription] = useState(collection.description ?? "");
+  const [defaultSort, setDefaultSort] = useState<string>(() =>
+    sortConfigToSelectValue(collection.sort_config),
+  );
   const [featured, setFeatured] = useState(collection.featured ?? false);
   const [visibility, setVisibility] = useState<"visible" | "hidden">(collection.visibility);
   const [posterFile, setPosterFile] = useState<File | null>(null);
@@ -1487,6 +1520,7 @@ export function CollectionEditForm({
       source_url: sourceUrlValue,
       source_config: sourceConfig,
       sync_schedule: editSyncSchedule.trim(),
+      sort_config: selectValueToSortConfig(defaultSort),
     };
 
     updateMutation.mutate(
@@ -1624,6 +1658,12 @@ export function CollectionEditForm({
             </div>
           </div>
         ) : null}
+
+        <CollectionDefaultSortField
+          value={defaultSort}
+          onChange={setDefaultSort}
+          inputId="collection-edit-default-sort"
+        />
 
         <SyncScheduleField value={editSyncSchedule} onChange={setEditSyncSchedule} />
 

--- a/web/src/pages/catalogSearchParams.test.ts
+++ b/web/src/pages/catalogSearchParams.test.ts
@@ -252,6 +252,26 @@ describe("buildCatalogHref", () => {
     expect(explicitAddedAt.toString()).toBe("source=watchlist&sort=added_at&order=desc");
   });
 
+  it("does not leak a server-derived collection sort into an unrelated filter update", () => {
+    const built = buildCatalogFilterSearchParams({
+      source: "library_collection",
+      collection_id: "col-7",
+      type_override: "movie",
+      uses_source_order: false,
+      sort_from_server: true,
+      query_definition: {
+        library_ids: [],
+        match: "all",
+        groups: [],
+        sort: { field: "title", order: "asc" },
+      },
+    });
+
+    expect(built.get("type")).toBe("movie");
+    expect(built.has("sort")).toBe(false);
+    expect(built.has("order")).toBe(false);
+  });
+
   it("builds source-ordered personal catalog hrefs without a sort param", () => {
     expect(buildPersonalCatalogHref("watchlist")).toBe("/catalog?source=watchlist");
     expect(buildPersonalCatalogHref("favorites")).toBe("/catalog?source=favorites");

--- a/web/src/pages/catalogSearchParams.ts
+++ b/web/src/pages/catalogSearchParams.ts
@@ -23,6 +23,9 @@ export interface CatalogSearchState {
   person_id?: string;
   type_override?: string;
   uses_source_order?: boolean;
+  // True when the UI is displaying a collection sort resolved by the server,
+  // rather than an explicit sort read from the URL or chosen by the viewer.
+  sort_from_server?: boolean;
   query_definition: QueryDefinition;
 }
 
@@ -385,6 +388,7 @@ export function buildCatalogApiSearchParams(state: CatalogSearchState): URLSearc
     params.set("order", state.query_definition.sort.order);
   } else if (
     !state.uses_source_order &&
+    !state.sort_from_server &&
     state.query_definition.sort.field &&
     (state.query_definition.sort.field !== "added_at" ||
       (state.source === "query" && effectiveLibraryID != null) ||


### PR DESCRIPTION
## Problem

Admin/server collections did not expose the same configurable ordering and display-filter behavior as personal collections. Collection viewers also had no profile-scoped way to retain their own sort choice without changing the creator's default.

## Approach

- add creator-configured default sorts for library and personal collections
- resolve ordering as explicit request > profile preference > creator default > source order
- persist viewer overrides per profile in PostgreSQL and SQLite
- expose additive collection-sort capability flags for clients
- clear profile-sensitive frontend query state when switching profiles
- apply creator defaults to rails while keeping shared library rails independent of viewer overrides
- preserve existing manual-pin configuration and legacy unsorted-rail fetch/total behavior
- prevent server-derived effective sorts from becoming explicit URL parameters during unrelated filter changes

## Impact

Collection creators can choose a default order, while each viewer can retain a different order privately. Existing collections without a configured default keep their previous source ordering, bounded rail queries, and rail total semantics.

Part of #401.

## Risks and follow-up

- Collections with a configured default sort report the full accessible membership as the rail total; this is intentionally unchanged pending client coordination.
- Profile switching currently clears the complete TanStack Query cache. A narrower profile-key invalidation can be considered separately if the refetch cost or branding reload is undesirable.
- Preference lookup adds one profile-store read when resolving collection order. Negative caching can be added later if profiling shows this matters.
- Signed-in browser verification used an isolated local backend and exact test fixtures that were removed afterward. No production or shared database was modified.

## Verification

Passed:

- `GOWORK=off go test ./internal/catalog/... ./internal/sections/... ./internal/api/... ./internal/userstore/... ./internal/userdb/... ./internal/access/...`
- `go vet ./...`
- `make build`
- `make migrate-validate`
- `make verify-local-paths`
- `cd web && pnpm exec tsc -b --noEmit`
- `cd web && pnpm run lint` (0 errors; existing repository warnings only)
- `cd web && pnpm run format:check`
- targeted frontend regressions: 22/22 passed
- follow-up sort-config regression tests: 4/4 passed
- `golangci-lint run --new-from-rev=51d2b58e ./...` (0 issues)
- signed-in create/edit/save/reopen/view flow; browser console had no warnings or errors
- full frontend suite: 225/227 files and 1342/1348 tests passed
- `git diff --check`

Browser evidence:

- Reopened editor retained **Title** as the default sort: https://github.com/user-attachments/assets/e2d65d4e-c99b-40c1-b58d-a288c09a70d7
- Viewer applied **Title / Ascending** to a reverse-ordered source fixture: https://github.com/user-attachments/assets/c291215a-94ac-47c3-be9c-36f7bae100f6

Known unrelated failures observed in the broad suites:

- six frontend tests in `SeasonContent.test.tsx` and `ServerStorageStep.test.tsx` fail because their fixtures lack QueryClient/ResizeObserver setup
- the full Go suite has existing Jellyfin autoscan sidecar failures and environment-sensitive FFmpeg/NVENC probe failures

## Adversarial review

The review found and resolved seven material issues: unbounded unsorted rail hydration, changed legacy rail totals, destructive `manual_pins` normalization, server-derived sorts leaking into URLs, rejected personalized library-viewer sorts, orphaned preferences on profile deletion, and missing SQLite timestamps/capability discovery. It also added serialized preference writes and profile-switch cache isolation. Quick's follow-up review identified legacy manual-pin preservation, write-time collection access validation, deletion cleanup, UI evidence, and resolver duplication. Commit `84b0d217` addresses all five; preference writes remain authenticated, profile-scoped, access-checked, normalized, and parameterized. The per-viewer override is intentional product scope: it lets viewers retain a private sort without mutating the creator's default.

### AI Disclosure
- Tool(s): Codex desktop
- Model(s): gpt-5.6-sol
- Involvement: AI-assisted
- Adversarial review: Reviewed the full diff for regression, API compatibility, data lifecycle, privacy, and security. The seven findings listed above were fixed and covered by focused tests; the two product decisions in Risks and follow-up were intentionally left unchanged.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added configurable default sorting for library and personal collections.
  * Added per-profile collection sort preferences with endpoints to set and clear overrides.
  * Catalog views now expose and apply an effective resolved sort.
  * Admin and import/edit flows now support setting default sort (including preserving source order).
  * Added UI controls and capabilities flags advertising collection sort support.

* **Bug Fixes**
  * Improved sort normalization/validation across create, update, and imports with clearer bad-request handling.
  * Prevented stale catalog state by clearing cache when switching profiles.

* **Tests**
  * Added coverage for precedence, persistence, normalization, and effective-sort behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

### Maintainer-assisted conflict resolution disclosure
- Tool(s): T3 Code (Codex)
- Model(s): gpt-5.6-sol
- Involvement: AI-assisted merge conflict resolution
- Changes: merged current main without rewriting contributor history; preserved SQLite v14 onboarding and moved collection sort preferences to v15; updated affected test doubles for the combined UserStore interface.
- Verification: focused userdb/access/Jellycompat tests passed; make build, migrate validation, local-path verification, frontend lint/format/typecheck passed; the exact merged tree deployed successfully to the configured dev backend with healthy /api/v1/health and /api/v1/ready. Repository-wide Go lint still reports the existing 306-issue baseline, and broad handler tests retained known unrelated intermittent failures.



