### PR TITLE
fix(metadata): improve localized series matching

### DIFF
--- a/internal/metadata/episode_match_validation.go
+++ b/internal/metadata/episode_match_validation.go
@@ -10,11 +10,9 @@ import (
 	"strings"
 	"sync"
 	"time"
-	"unicode"
 	"unicode/utf8"
 
 	"github.com/Silo-Server/silo-server/internal/naming"
-	"golang.org/x/text/unicode/norm"
 )
 
 const (
@@ -552,8 +550,8 @@ func isDistinctiveSingleEpisodeTitle(title string) bool {
 }
 
 func episodeTitleSimilarity(left, right string) float64 {
-	leftComparable := foldEpisodeTitleDiacritics(normalizeTitleForScoring(left))
-	rightComparable := foldEpisodeTitleDiacritics(normalizeTitleForScoring(right))
+	leftComparable := normalizeTitleForScoring(left)
+	rightComparable := normalizeTitleForScoring(right)
 	if leftComparable == "" || rightComparable == "" {
 		return 0
 	}
@@ -564,14 +562,4 @@ func episodeTitleSimilarity(left, right string) float64 {
 		return 0.8
 	}
 	return 0
-}
-
-func foldEpisodeTitleDiacritics(value string) string {
-	var builder strings.Builder
-	for _, r := range norm.NFD.String(value) {
-		if !unicode.Is(unicode.Mn, r) {
-			builder.WriteRune(r)
-		}
-	}
-	return norm.NFC.String(builder.String())
 }

--- a/internal/metadata/match_candidates.go
+++ b/internal/metadata/match_candidates.go
@@ -642,6 +642,13 @@ func candidateTitles(candidate MatchCandidate) []string {
 }
 
 func bestCandidateTitleSimilarity(hint string, candidate MatchCandidate, year int) (float64, string) {
+	// A no-year local folder still has enough information to remove a provider's
+	// own trailing year decoration. Without this fallback, a corroborated result
+	// such as "Adventure Time (2010)" scores below an undecorated same-title
+	// competitor before the no-year consensus tie-break can run.
+	if year == 0 {
+		year = candidate.Year
+	}
 	bestScore := 0.0
 	bestTitle := ""
 	for _, title := range candidateTitles(candidate) {
@@ -1291,10 +1298,12 @@ var nonCombiningLetterFolds = strings.NewReplacer(
 	"ı", "i",
 )
 
-// foldTitleDiacritics strips combining marks so provider spellings that differ
-// only by accents compare equal ("Yeşilçam" vs a folder named "Yesilcam").
-// Deliberately avoids a shared transform.Chain: chained Transformers carry
-// per-call state and this runs concurrently across episode-validation workers.
+// foldTitleDiacritics strips Latin combining marks so provider spellings that
+// differ only by accents compare equal ("Yeşilçam" vs "Yesilcam"). Combining
+// marks remain significant in other scripts, where they can change lexical
+// identity rather than decorate an otherwise equivalent Latin letter.
+// Deliberately avoids a shared chained transformer: transformers carry per-call
+// state, and this runs concurrently across episode-validation workers.
 func foldTitleDiacritics(title string) string {
 	if isASCIIOnly(title) {
 		return title
@@ -1306,6 +1315,7 @@ func foldTitleDiacritics(title string) string {
 	decomposed := norm.NFD.String(title)
 	var builder strings.Builder
 	builder.Grow(len(decomposed))
+	var lastStarter rune
 	for _, r := range decomposed {
 		// Spacing kana marks otherwise fall through punctuation cleanup; convert
 		// them so NFC can recompose the voiced kana before title tokenization.
@@ -1315,12 +1325,13 @@ func foldTitleDiacritics(title string) string {
 		case '\u309c':
 			r = '\u309a'
 		}
-		// Kana voicing changes lexical identity rather than merely decorating a
-		// base letter, so ガ and カ must remain distinct on auto-match paths.
-		if unicode.Is(unicode.Mn, r) && r != '\u3099' && r != '\u309a' {
+		if unicode.Is(unicode.Mn, r) && unicode.Is(unicode.Latin, lastStarter) {
 			continue
 		}
 		builder.WriteRune(r)
+		if !unicode.Is(unicode.Mn, r) {
+			lastStarter = r
+		}
 	}
 	return norm.NFC.String(builder.String())
 }

--- a/internal/metadata/match_candidates.go
+++ b/internal/metadata/match_candidates.go
@@ -10,6 +10,9 @@ import (
 	"strconv"
 	"strings"
 	"unicode"
+	"unicode/utf8"
+
+	"golang.org/x/text/unicode/norm"
 
 	"github.com/Silo-Server/silo-server/internal/lang"
 	"github.com/Silo-Server/silo-server/internal/models"
@@ -986,12 +989,76 @@ func selectInitialMatchCandidate(hints *MatchHints, candidates []MatchCandidate,
 		return &best.candidate, true
 	}
 	if best.score-scoredCandidates[1].score < 15 {
+		if winner, ok := tmdbTVDBTitleConsensusWinner(hints, scoredCandidates); ok {
+			return winner, true
+		}
 		if winner, ok := duplicateTieBreakWinner(hints, scoredCandidates); ok {
 			return winner, true
 		}
 		return providerOrderExactTieBreakWinner(hints, scoredCandidates)
 	}
 	return &best.candidate, true
+}
+
+// tmdbTVDBTitleConsensusWinner resolves a narrow series-only ambiguity when
+// the local folder omits a year. It accepts only a candidate tied for the
+// existing highest score, and only when exactly one candidate has an exact
+// title match, a provider year, and independently retained TMDB and TVDB
+// identities. This deliberately does not merge any metadata or IDs from
+// competing candidates.
+func tmdbTVDBTitleConsensusWinner(hints *MatchHints, scoredCandidates []scoredMatchCandidate) (*MatchCandidate, bool) {
+	if hints == nil || !strings.EqualFold(strings.TrimSpace(hints.Type), "series") || hints.Year != 0 || len(scoredCandidates) < 2 {
+		return nil, false
+	}
+
+	qualifyingIndex := -1
+	for i := range scoredCandidates {
+		candidate := scoredCandidates[i].candidate
+		if !strings.EqualFold(strings.TrimSpace(candidate.ContentType), "series") || candidate.Year == 0 {
+			continue
+		}
+		if similarity, _ := bestCandidateTitleSimilarity(hints.Title, candidate, 0); similarity != 1 {
+			continue
+		}
+		if !candidateHasSource(candidate, "tmdb") || !candidateHasSource(candidate, "tvdb") {
+			continue
+		}
+		if !candidateRetainsCanonicalProviderID(candidate, "tmdb") || !candidateRetainsCanonicalProviderID(candidate, "tvdb") {
+			continue
+		}
+		if qualifyingIndex != -1 {
+			return nil, false
+		}
+		qualifyingIndex = i
+	}
+
+	if qualifyingIndex == -1 || scoredCandidates[qualifyingIndex].score != scoredCandidates[0].score {
+		return nil, false
+	}
+	winner := scoredCandidates[qualifyingIndex].candidate
+	if !slices.Contains(winner.MatchReasons, "tmdb_tvdb_title_consensus") {
+		winner.MatchReasons = append(winner.MatchReasons, "tmdb_tvdb_title_consensus")
+	}
+	return &winner, true
+}
+
+func candidateRetainsCanonicalProviderID(candidate MatchCandidate, provider string) bool {
+	provider = strings.ToLower(strings.TrimSpace(provider))
+	for _, conflictingKey := range candidate.ConflictingProviderIDKeys {
+		if strings.EqualFold(strings.TrimSpace(conflictingKey), provider) {
+			return strings.TrimSpace(candidate.ConfirmedProviderIDs[provider]) != ""
+		}
+	}
+	return strings.TrimSpace(candidate.ProviderIDs[provider]) != ""
+}
+
+func candidateHasSource(candidate MatchCandidate, provider string) bool {
+	for _, source := range candidate.Sources {
+		if strings.EqualFold(strings.TrimSpace(source), provider) {
+			return true
+		}
+	}
+	return false
 }
 
 func providerOrderExactTieBreakWinner(hints *MatchHints, scoredCandidates []scoredMatchCandidate) (*MatchCandidate, bool) {
@@ -1183,14 +1250,93 @@ func normalizeCandidateTitleForYear(title string, year int) string {
 	}
 	yearText := strconv.Itoa(year)
 	fields := strings.Fields(normalized)
-	if len(fields) <= 1 || fields[len(fields)-1] != yearText {
+	if len(fields) <= 1 {
+		return normalized
+	}
+	// Providers frequently disambiguate a reused title by appending the release
+	// year to the title string itself ("24 stjerners julikalender (DK) (2026)").
+	// The scanner strips "(YYYY)" from the folder name into a separate year, so
+	// without this the two sides can never compare equal. Only the known year is
+	// stripped, so an unrelated trailing number stays part of the title.
+	last := fields[len(fields)-1]
+	if last != yearText && trimYearDecoration(last) != yearText {
 		return normalized
 	}
 	return strings.Join(fields[:len(fields)-1], " ")
 }
 
+// trimYearDecoration unwraps a bracketed year token — "(2026)", "[2026]" — to
+// its bare digits. Returns the input unchanged when it is not so wrapped.
+func trimYearDecoration(token string) string {
+	for _, pair := range [][2]string{{"(", ")"}, {"[", "]"}} {
+		if inner, ok := strings.CutPrefix(token, pair[0]); ok {
+			if inner, ok := strings.CutSuffix(inner, pair[1]); ok {
+				return inner
+			}
+		}
+	}
+	return token
+}
+
+// nonCombiningLetterFolds covers letters that are not decomposable combining
+// forms, so NFD alone leaves them untouched. European library folders routinely
+// carry the ASCII spelling while providers return these.
+var nonCombiningLetterFolds = strings.NewReplacer(
+	"ø", "o", "Ø", "o",
+	"æ", "ae", "Æ", "ae",
+	"œ", "oe", "Œ", "oe",
+	"ß", "ss", "ẞ", "ss",
+	"đ", "d", "Đ", "d",
+	"ł", "l", "Ł", "l",
+	"ı", "i",
+)
+
+// foldTitleDiacritics strips combining marks so provider spellings that differ
+// only by accents compare equal ("Yeşilçam" vs a folder named "Yesilcam").
+// Deliberately avoids a shared transform.Chain: chained Transformers carry
+// per-call state and this runs concurrently across episode-validation workers.
+func foldTitleDiacritics(title string) string {
+	if isASCIIOnly(title) {
+		return title
+	}
+	title = nonCombiningLetterFolds.Replace(title)
+	if isASCIIOnly(title) {
+		return title
+	}
+	decomposed := norm.NFD.String(title)
+	var builder strings.Builder
+	builder.Grow(len(decomposed))
+	for _, r := range decomposed {
+		// Spacing kana marks otherwise fall through punctuation cleanup; convert
+		// them so NFC can recompose the voiced kana before title tokenization.
+		switch r {
+		case '\u309b':
+			r = '\u3099'
+		case '\u309c':
+			r = '\u309a'
+		}
+		// Kana voicing changes lexical identity rather than merely decorating a
+		// base letter, so ガ and カ must remain distinct on auto-match paths.
+		if unicode.Is(unicode.Mn, r) && r != '\u3099' && r != '\u309a' {
+			continue
+		}
+		builder.WriteRune(r)
+	}
+	return norm.NFC.String(builder.String())
+}
+
+func isASCIIOnly(value string) bool {
+	for i := range len(value) {
+		if value[i] >= utf8.RuneSelf {
+			return false
+		}
+	}
+	return true
+}
+
 func normalizeTitleForScoring(title string) string {
 	title = naming.StripComparisonSafeEditionSuffix(title)
+	title = foldTitleDiacritics(title)
 	title = strings.ToLower(strings.TrimSpace(title))
 	if title == "" {
 		return ""

--- a/internal/metadata/match_candidates_select_test.go
+++ b/internal/metadata/match_candidates_select_test.go
@@ -1,8 +1,275 @@
 package metadata
 
 import (
+	"slices"
 	"testing"
 )
+
+const (
+	adventureTimeTestTitle = "Adventure Time"
+	exampleSeriesTestTitle = "Example Series"
+	localizedEnglishTitle  = "Jubei-chan: The Ninja Girl"
+	localizedOriginalTitle = "十兵衛ちゃん"
+	localizedTVDBID        = "tvdb-series-1"
+	localizedTMDBID        = "tmdb-series-1"
+	testAlternateAliasKind = "alternate"
+	testNFOProvider        = "nfo"
+)
+
+//nolint:goconst // Keep the production-shaped provider fixtures readable in place.
+func TestSelectInitialMatchCandidate_LocalizedPrimaryTitleMatchesEnglishAlias(t *testing.T) {
+	hints := &MatchHints{Title: localizedEnglishTitle, Year: 1999, Type: anchoredItemTypeSeries}
+	candidates := []MatchCandidate{
+		{
+			Title:         localizedOriginalTitle,
+			OriginalTitle: localizedOriginalTitle,
+			TitleAliases: []TitleAlias{
+				{Title: localizedEnglishTitle, Language: "en", Kind: testAlternateAliasKind, Provider: testTVDBProvider},
+			},
+			Year:        1999,
+			ContentType: anchoredItemTypeSeries,
+			Sources:     []string{testTVDBProvider},
+			ProviderIDs: map[string]string{testTVDBProvider: localizedTVDBID, testTMDBProvider: localizedTMDBID},
+		},
+	}
+
+	got, ok := selectInitialMatchCandidate(hints, candidates, nil)
+	if !ok || got == nil {
+		t.Fatal("localized primary title with an exact English alias was not matched")
+	}
+	if got.MatchedTitle != localizedEnglishTitle {
+		t.Fatalf("MatchedTitle = %q, want English alias", got.MatchedTitle)
+	}
+}
+
+//nolint:goconst // Keep the production-shaped provider fixtures readable in place.
+func TestSelectInitialMatchCandidate_MissingYearTMDBTVDBTitleConsensus(t *testing.T) {
+	hints := &MatchHints{Title: adventureTimeTestTitle, Type: anchoredItemTypeSeries}
+	consensus := MatchCandidate{
+		Title:       adventureTimeTestTitle,
+		Year:        2010,
+		ContentType: anchoredItemTypeSeries,
+		Sources:     []string{testTVDBProvider, testTMDBProvider},
+		ProviderIDs: map[string]string{testTMDBProvider: "15260", testTVDBProvider: "152831", testIMDBProvider: "tt1305826"},
+	}
+	competitor := MatchCandidate{
+		Title:       adventureTimeTestTitle,
+		Year:        1967,
+		ContentType: "series",
+		Sources:     []string{"tmdb"},
+		ProviderIDs: map[string]string{"tmdb": "245745"},
+	}
+
+	for _, candidates := range [][]MatchCandidate{{consensus, competitor}, {competitor, consensus}} {
+		got, ok := selectInitialMatchCandidate(hints, candidates, nil)
+		if !ok || got == nil || got.ProviderIDs["tvdb"] != "152831" {
+			t.Fatalf("ordered candidates %+v returned ok=%v candidate=%+v", candidates, ok, got)
+		}
+		if !slices.Contains(got.MatchReasons, "tmdb_tvdb_title_consensus") {
+			t.Fatalf("MatchReasons = %v, want tmdb_tvdb_title_consensus", got.MatchReasons)
+		}
+	}
+}
+
+//nolint:goconst // Keep the production-shaped provider fixtures readable in place.
+func TestSelectInitialMatchCandidate_MissingYearConsensusIsOrderIndependentAtEqualScore(t *testing.T) {
+	hints := &MatchHints{Title: adventureTimeTestTitle, Type: anchoredItemTypeSeries}
+	consensus := MatchCandidate{
+		Title:       adventureTimeTestTitle,
+		Year:        2010,
+		ContentType: anchoredItemTypeSeries,
+		Sources:     []string{testTMDBProvider, testTVDBProvider},
+		ProviderIDs: map[string]string{testTMDBProvider: "15260", testTVDBProvider: "152831"},
+	}
+	equalScoreCompetitor := MatchCandidate{
+		Title:       adventureTimeTestTitle,
+		Year:        1967,
+		ContentType: anchoredItemTypeSeries,
+		Sources:     []string{testTMDBProvider, testTVDBProvider},
+		ProviderIDs: map[string]string{testTMDBProvider: "245745", testIMDBProvider: "tt0000001"},
+	}
+	if consensusScore, competitorScore := scoreMatchCandidate(hints, consensus), scoreMatchCandidate(hints, equalScoreCompetitor); consensusScore != competitorScore {
+		t.Fatalf("fixture scores differ: consensus=%v competitor=%v", consensusScore, competitorScore)
+	}
+
+	for _, candidates := range [][]MatchCandidate{{consensus, equalScoreCompetitor}, {equalScoreCompetitor, consensus}} {
+		got, ok := selectInitialMatchCandidate(hints, candidates, nil)
+		if !ok || got == nil || got.ProviderIDs[testTVDBProvider] != "152831" {
+			t.Fatalf("ordered candidates %+v returned ok=%v candidate=%+v", candidates, ok, got)
+		}
+	}
+}
+
+//nolint:goconst // Keep the production-shaped provider fixtures readable in place.
+func TestSelectInitialMatchCandidate_MissingYearConsensusBeatsSameYearSingleProvider(t *testing.T) {
+	hints := &MatchHints{Title: exampleSeriesTestTitle, Type: "series"}
+	candidates := []MatchCandidate{
+		{
+			Title:       exampleSeriesTestTitle,
+			Year:        2021,
+			ContentType: "series",
+			Sources:     []string{"tmdb", "tvdb"},
+			ProviderIDs: map[string]string{"tmdb": "101", "tvdb": "201"},
+		},
+		{
+			Title:       exampleSeriesTestTitle,
+			Year:        2021,
+			ContentType: "series",
+			Sources:     []string{"tmdb"},
+			ProviderIDs: map[string]string{"tmdb": "102"},
+		},
+	}
+
+	got, ok := selectInitialMatchCandidate(hints, candidates, nil)
+	if !ok || got == nil || got.ProviderIDs["tvdb"] != "201" {
+		t.Fatalf("same-year single-provider competitor displaced consensus: ok=%v candidate=%+v", ok, got)
+	}
+}
+
+//nolint:goconst // Keep the production-shaped provider fixtures readable in place.
+func TestSelectInitialMatchCandidate_MissingYearConsensusAllowsResolvedCanonicalIDConflict(t *testing.T) {
+	hints := &MatchHints{Title: exampleSeriesTestTitle, Type: anchoredItemTypeSeries}
+	candidates := NormalizeCandidatesForLanguage([]SearchResult{
+		{
+			Name:     exampleSeriesTestTitle,
+			Year:     2021,
+			Provider: testTVDBProvider,
+			ProviderIDs: map[string]string{
+				testIMDBProvider: "tt0000101",
+				testTMDBProvider: "101",
+				testTVDBProvider: "201",
+			},
+		},
+		{
+			Name:     exampleSeriesTestTitle,
+			Year:     2021,
+			Provider: testTMDBProvider,
+			ProviderIDs: map[string]string{
+				testIMDBProvider: "tt0000101",
+				testTMDBProvider: "101",
+				testTVDBProvider: "999",
+			},
+		},
+		{
+			Name:        exampleSeriesTestTitle,
+			Year:        1991,
+			Provider:    testTMDBProvider,
+			ProviderIDs: map[string]string{testTMDBProvider: "102"},
+		},
+	}, anchoredItemTypeSeries, "en")
+	if len(candidates) != 2 {
+		t.Fatalf("NormalizeCandidatesForLanguage() returned %d candidates, want 2", len(candidates))
+	}
+	if candidates[0].ProviderIDs[testTVDBProvider] != "" || candidates[0].ConfirmedProviderIDs[testTVDBProvider] != "201" {
+		t.Fatalf("resolved TVDB identity = provider:%q confirmed:%q", candidates[0].ProviderIDs[testTVDBProvider], candidates[0].ConfirmedProviderIDs[testTVDBProvider])
+	}
+
+	got, ok := selectInitialMatchCandidate(hints, candidates, nil)
+	if !ok || got == nil || got.ConfirmedProviderIDs[testTVDBProvider] != "201" {
+		t.Fatalf("resolved canonical ID conflict was not retained: ok=%v candidate=%+v", ok, got)
+	}
+}
+
+//nolint:goconst // Keep the production-shaped provider fixtures readable in place.
+func TestSelectInitialMatchCandidate_MissingYearConsensusNegativeControls(t *testing.T) {
+	baseConsensus := MatchCandidate{
+		Title:       adventureTimeTestTitle,
+		Year:        2010,
+		ContentType: "series",
+		Sources:     []string{"tmdb", "tvdb"},
+		ProviderIDs: map[string]string{"tmdb": "15260", "tvdb": "152831"},
+	}
+	baseCompetitor := MatchCandidate{
+		Title:       adventureTimeTestTitle,
+		Year:        1967,
+		ContentType: "series",
+		Sources:     []string{"tmdb"},
+		ProviderIDs: map[string]string{"tmdb": "245745"},
+	}
+
+	tests := []struct {
+		name       string
+		hints      *MatchHints
+		candidates []MatchCandidate
+	}{
+		{
+			name:  "movie content type",
+			hints: &MatchHints{Title: adventureTimeTestTitle, Type: anchoredItemTypeMovie},
+			candidates: []MatchCandidate{
+				{Title: adventureTimeTestTitle, Year: 2010, ContentType: anchoredItemTypeMovie, Sources: []string{testTMDBProvider, testTVDBProvider}, ProviderIDs: map[string]string{testTMDBProvider: "1", testTVDBProvider: "2"}},
+				{Title: adventureTimeTestTitle, Year: 1967, ContentType: anchoredItemTypeMovie, Sources: []string{testTMDBProvider}, ProviderIDs: map[string]string{testTMDBProvider: "3"}},
+			},
+		},
+		{
+			name:  "one remote provider even with cross references",
+			hints: &MatchHints{Title: adventureTimeTestTitle, Type: "series"},
+			candidates: []MatchCandidate{
+				{Title: adventureTimeTestTitle, Year: 2010, ContentType: "series", Sources: []string{"tmdb"}, ProviderIDs: map[string]string{"tmdb": "1", "tvdb": "2"}},
+				baseCompetitor,
+			},
+		},
+		{
+			name:  "two corroborated identities",
+			hints: &MatchHints{Title: adventureTimeTestTitle, Type: "series"},
+			candidates: []MatchCandidate{
+				baseConsensus,
+				{Title: adventureTimeTestTitle, Year: 1967, ContentType: "series", Sources: []string{"tmdb", "tvdb"}, ProviderIDs: map[string]string{"tmdb": "3", "tvdb": "4"}},
+			},
+		},
+		{
+			name:  "coherent title is not exact",
+			hints: &MatchHints{Title: "The Real History of the World War", Type: "series"},
+			candidates: []MatchCandidate{
+				{Title: "The Real History of the World War Europe", Year: 2010, ContentType: "series", Sources: []string{"tmdb", "tvdb"}, ProviderIDs: map[string]string{"tmdb": "1", "tvdb": "2"}},
+				{Title: "The Real History of the World War Pacific", Year: 2010, ContentType: "series", Sources: []string{"tmdb"}, ProviderIDs: map[string]string{"tmdb": "3"}},
+			},
+		},
+		{
+			name:  "missing retained tvdb id",
+			hints: &MatchHints{Title: adventureTimeTestTitle, Type: "series"},
+			candidates: []MatchCandidate{
+				{Title: adventureTimeTestTitle, Year: 2010, ContentType: "series", Sources: []string{"tmdb", "tvdb"}, ProviderIDs: map[string]string{"tmdb": "1"}},
+				baseCompetitor,
+			},
+		},
+		{
+			name:  "quarantined tvdb id",
+			hints: &MatchHints{Title: adventureTimeTestTitle, Type: "series"},
+			candidates: []MatchCandidate{
+				{Title: adventureTimeTestTitle, Year: 2010, ContentType: "series", Sources: []string{"tmdb", "tvdb"}, ProviderIDs: map[string]string{"tmdb": "1", "tvdb": "2"}, ConflictingProviderIDKeys: []string{"tvdb"}},
+				baseCompetitor,
+			},
+		},
+		{
+			name:  "nfo is not a second provider",
+			hints: &MatchHints{Title: adventureTimeTestTitle, Type: "series"},
+			candidates: []MatchCandidate{
+				{Title: adventureTimeTestTitle, Year: 2010, ContentType: anchoredItemTypeSeries, Sources: []string{testTMDBProvider, testNFOProvider}, ProviderIDs: map[string]string{testTMDBProvider: "1", testTVDBProvider: "2"}},
+				baseCompetitor,
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got, ok := selectInitialMatchCandidate(tt.hints, tt.candidates, nil); ok {
+				t.Fatalf("negative control matched candidate %+v", got)
+			}
+		})
+	}
+}
+
+//nolint:goconst // Keep the production-shaped provider fixtures readable in place.
+func TestTMDBTVDBTitleConsensusWinner_DoesNotPromoteLowerRankedCandidate(t *testing.T) {
+	hints := &MatchHints{Title: adventureTimeTestTitle, Type: "series"}
+	scored := []scoredMatchCandidate{
+		{candidate: MatchCandidate{Title: adventureTimeTestTitle, Year: 1967, ContentType: "series", Sources: []string{"tmdb"}, ProviderIDs: map[string]string{"tmdb": "1"}}, score: 80},
+		{candidate: MatchCandidate{Title: adventureTimeTestTitle, Year: 2010, ContentType: "series", Sources: []string{"tmdb", "tvdb"}, ProviderIDs: map[string]string{"tmdb": "2", "tvdb": "3"}}, score: 76},
+	}
+	if got, ok := tmdbTVDBTitleConsensusWinner(hints, scored); ok {
+		t.Fatalf("lower-ranked corroborated candidate was promoted: %+v", got)
+	}
+}
 
 func TestSelectInitialMatchCandidate_LoneResultYearMatchBelow70(t *testing.T) {
 	// Exact title, matching year, NO sources, NO provider IDs => score 45+20 = 65 (<70).

--- a/internal/metadata/match_candidates_select_test.go
+++ b/internal/metadata/match_candidates_select_test.go
@@ -72,6 +72,35 @@ func TestSelectInitialMatchCandidate_MissingYearTMDBTVDBTitleConsensus(t *testin
 }
 
 //nolint:goconst // Keep the production-shaped provider fixtures readable in place.
+func TestSelectInitialMatchCandidate_MissingYearConsensusStripsCandidateYearDecoration(t *testing.T) {
+	hints := &MatchHints{Title: adventureTimeTestTitle, Type: anchoredItemTypeSeries}
+	candidates := []MatchCandidate{
+		{
+			Title:       adventureTimeTestTitle + " (2010)",
+			Year:        2010,
+			ContentType: anchoredItemTypeSeries,
+			Sources:     []string{testTMDBProvider, testTVDBProvider},
+			ProviderIDs: map[string]string{testTMDBProvider: "15260", testTVDBProvider: "152831"},
+		},
+		{
+			Title:       adventureTimeTestTitle,
+			Year:        1967,
+			ContentType: anchoredItemTypeSeries,
+			Sources:     []string{testTMDBProvider},
+			ProviderIDs: map[string]string{testTMDBProvider: "245745"},
+		},
+	}
+
+	got, ok := selectInitialMatchCandidate(hints, candidates, nil)
+	if !ok || got == nil || got.ProviderIDs[testTVDBProvider] != "152831" {
+		t.Fatalf("decorated corroborated candidate lost to competitor: ok=%v candidate=%+v", ok, got)
+	}
+	if !slices.Contains(got.MatchReasons, "tmdb_tvdb_title_consensus") {
+		t.Fatalf("MatchReasons = %v, want tmdb_tvdb_title_consensus", got.MatchReasons)
+	}
+}
+
+//nolint:goconst // Keep the production-shaped provider fixtures readable in place.
 func TestSelectInitialMatchCandidate_MissingYearConsensusIsOrderIndependentAtEqualScore(t *testing.T) {
 	hints := &MatchHints{Title: adventureTimeTestTitle, Type: anchoredItemTypeSeries}
 	consensus := MatchCandidate{

--- a/internal/metadata/match_candidates_select_test.go
+++ b/internal/metadata/match_candidates_select_test.go
@@ -260,14 +260,38 @@ func TestSelectInitialMatchCandidate_MissingYearConsensusNegativeControls(t *tes
 }
 
 //nolint:goconst // Keep the production-shaped provider fixtures readable in place.
-func TestTMDBTVDBTitleConsensusWinner_DoesNotPromoteLowerRankedCandidate(t *testing.T) {
-	hints := &MatchHints{Title: adventureTimeTestTitle, Type: "series"}
-	scored := []scoredMatchCandidate{
-		{candidate: MatchCandidate{Title: adventureTimeTestTitle, Year: 1967, ContentType: "series", Sources: []string{"tmdb"}, ProviderIDs: map[string]string{"tmdb": "1"}}, score: 80},
-		{candidate: MatchCandidate{Title: adventureTimeTestTitle, Year: 2010, ContentType: "series", Sources: []string{"tmdb", "tvdb"}, ProviderIDs: map[string]string{"tmdb": "2", "tvdb": "3"}}, score: 76},
+func TestTMDBTVDBTitleConsensusWinner_NegativeControls(t *testing.T) {
+	consensus := MatchCandidate{Title: adventureTimeTestTitle, Year: 2010, ContentType: "series", Sources: []string{"tmdb", "tvdb"}, ProviderIDs: map[string]string{"tmdb": "2", "tvdb": "3"}}
+	competitor := MatchCandidate{Title: adventureTimeTestTitle, Year: 1967, ContentType: "series", Sources: []string{"tmdb"}, ProviderIDs: map[string]string{"tmdb": "1"}}
+	tests := []struct {
+		name   string
+		hints  *MatchHints
+		scored []scoredMatchCandidate
+	}{
+		{
+			name:  "hint year present",
+			hints: &MatchHints{Title: adventureTimeTestTitle, Year: 1967, Type: "series"},
+			scored: []scoredMatchCandidate{
+				{candidate: consensus, score: 80},
+				{candidate: competitor, score: 80},
+			},
+		},
+		{
+			name:  "corroborated candidate is lower ranked",
+			hints: &MatchHints{Title: adventureTimeTestTitle, Type: "series"},
+			scored: []scoredMatchCandidate{
+				{candidate: competitor, score: 80},
+				{candidate: consensus, score: 76},
+			},
+		},
 	}
-	if got, ok := tmdbTVDBTitleConsensusWinner(hints, scored); ok {
-		t.Fatalf("lower-ranked corroborated candidate was promoted: %+v", got)
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got, ok := tmdbTVDBTitleConsensusWinner(tt.hints, tt.scored); ok {
+				t.Fatalf("negative control returned candidate %+v", got)
+			}
+		})
 	}
 }
 

--- a/internal/metadata/match_queue_policy.go
+++ b/internal/metadata/match_queue_policy.go
@@ -15,7 +15,7 @@ var (
 )
 
 const (
-	movieMatcherRevision       = 9
+	movieMatcherRevision       = 10
 	seriesMatcherRevision      = 10
 	movieQueueRetryDelay       = 15 * time.Second
 	seriesRootQueueQuietWindow = 10 * time.Second

--- a/internal/metadata/match_queue_policy.go
+++ b/internal/metadata/match_queue_policy.go
@@ -15,7 +15,8 @@ var (
 )
 
 const (
-	matcherRevision            = 9
+	movieMatcherRevision       = 9
+	seriesMatcherRevision      = 10
 	movieQueueRetryDelay       = 15 * time.Second
 	seriesRootQueueQuietWindow = 10 * time.Second
 	seriesRootQueueRetryDelay  = 30 * time.Second
@@ -50,7 +51,7 @@ func matchQueueBackoffExpr(basePlaceholder, maxPlaceholder string) string {
 // matchQueueInputFingerprintSQL returns a deterministic SQL expression for
 // inputs that can change a result without changing the queue key. Arguments
 // are internal SQL expressions selected by repository code, never user input.
-func matchQueueInputFingerprintSQL(pathExpression, typeExpression, folderIDExpression, languageExpression string) string {
+func matchQueueInputFingerprintSQL(pathExpression, typeExpression, folderIDExpression, languageExpression string, matcherRevision int) string {
 	return fmt.Sprintf(`md5(%s || '|' || COALESCE(%s, '') || '|' || COALESCE(%s, '') || '|%d|' || COALESCE((
 		SELECT string_agg(
 			chain.priority::text || ':' || installation.id::text || ':' || installation.plugin_id || ':' ||
@@ -84,7 +85,7 @@ func seriesMatchQueueInputFingerprintSQL(rootExpression, folderIDExpression, lan
 		  AND shape_file.missing_since IS NULL
 		  AND shape_file.extra_id IS NULL
 	), ''))`, rootExpression, folderIDExpression, rootExpression)
-	return matchQueueInputFingerprintSQL(shapeExpression, "'series'", folderIDExpression, languageExpression)
+	return matchQueueInputFingerprintSQL(shapeExpression, "'series'", folderIDExpression, languageExpression, seriesMatcherRevision)
 }
 
 func boundedMatchFailureMessage(message string) string {

--- a/internal/metadata/match_queue_state_db_test.go
+++ b/internal/metadata/match_queue_state_db_test.go
@@ -77,11 +77,11 @@ func TestNormalizeMatchFailureKindTreatsUnknownAsTransient(t *testing.T) {
 
 func TestMatchQueueFingerprintIncludesMatcherAndProviderConfiguration(t *testing.T) {
 	t.Parallel()
-	expression := matchQueueInputFingerprintSQL("mf.file_path", "'movie'", "mf.media_folder_id", "folders.metadata_language")
+	expression := matchQueueInputFingerprintSQL("mf.file_path", "'movie'", "mf.media_folder_id", "folders.metadata_language", movieMatcherRevision)
 	for _, required := range []string{
 		"mf.file_path", "'movie'", "folders.metadata_language", "installation.version",
 		"chain.priority", "chain.capability_id", "plugin_runtime_configs", "config.updated_at::text",
-		fmt.Sprintf("|%d|", matcherRevision),
+		fmt.Sprintf("|%d|", movieMatcherRevision),
 	} {
 		if !strings.Contains(expression, required) {
 			t.Fatalf("fingerprint expression %q does not contain %q", expression, required)
@@ -92,10 +92,94 @@ func TestMatchQueueFingerprintIncludesMatcherAndProviderConfiguration(t *testing
 func TestSeriesMatchQueueFingerprintIncludesEpisodePathShape(t *testing.T) {
 	t.Parallel()
 	expression := seriesMatchQueueInputFingerprintSQL("q.observed_root_path", "q.media_folder_id", "folders.metadata_language")
-	for _, required := range []string{"shape_file.file_path", "shape_file.observed_root_path", "shape_file.missing_since", "shape_file.extra_id"} {
+	for _, required := range []string{"shape_file.file_path", "shape_file.observed_root_path", "shape_file.missing_since", "shape_file.extra_id", fmt.Sprintf("|%d|", seriesMatcherRevision)} {
 		if !strings.Contains(expression, required) {
 			t.Fatalf("series fingerprint expression %q does not contain %q", expression, required)
 		}
+	}
+	if movieMatcherRevision != 9 {
+		t.Fatalf("movie matcher revision = %d, want unchanged revision 9", movieMatcherRevision)
+	}
+	if seriesMatcherRevision != movieMatcherRevision+1 {
+		t.Fatalf("series matcher revision = %d, want movie revision + 1", seriesMatcherRevision)
+	}
+}
+
+func TestMatchQueueSeriesRevisionWakeDoesNotWakeMovies(t *testing.T) {
+	pool := chainBuiltinTestPool(t)
+	ctx := context.Background()
+
+	movieFolderID := insertTestFolder(t, pool, "movie")
+	moviePath := fmt.Sprintf("/test/revision-isolation-%d/Movie.mkv", time.Now().UnixNano())
+	var movieFileID int
+	if err := pool.QueryRow(ctx, `
+		INSERT INTO media_files (media_folder_id, file_path, base_type, file_size)
+		VALUES ($1, $2, 'movie', 0) RETURNING id
+	`, movieFolderID, moviePath).Scan(&movieFileID); err != nil {
+		t.Fatalf("seed movie file: %v", err)
+	}
+	movieRepo := NewMovieMatchQueueRepository(pool, scannerrepo.NewFileRepository(pool))
+	if err := movieRepo.EnqueueMovieFile(ctx, movieFileID); err != nil {
+		t.Fatalf("EnqueueMovieFile(): %v", err)
+	}
+	if _, err := pool.Exec(ctx, `
+		UPDATE movie_match_queue
+		SET state = 'parked', available_at = NOW() + interval '24 hours', parked_at = NOW()
+		WHERE media_file_id = $1
+	`, movieFileID); err != nil {
+		t.Fatalf("park movie row: %v", err)
+	}
+
+	seriesFolderID := insertTestFolder(t, pool, "series")
+	seriesRoot := fmt.Sprintf("/test/revision-isolation-%d/Series", time.Now().UnixNano())
+	if _, err := pool.Exec(ctx, `
+		INSERT INTO media_files (
+			media_folder_id, file_path, observed_root_path, base_type,
+			season_number, episode_number, file_size
+		) VALUES ($1, $2, $3, 'series', 1, 1, 0)
+	`, seriesFolderID, seriesRoot+"/Season 01/Series S01E01.mkv", seriesRoot); err != nil {
+		t.Fatalf("seed series file: %v", err)
+	}
+	seriesRepo := NewSeriesRootMatchQueueRepository(pool)
+	if err := seriesRepo.EnqueueSeriesRoot(ctx, seriesFolderID, seriesRoot); err != nil {
+		t.Fatalf("EnqueueSeriesRoot(): %v", err)
+	}
+	if _, err := pool.Exec(ctx, `
+		UPDATE series_root_match_queue
+		SET state = 'parked', available_at = NOW() + interval '24 hours', parked_at = NOW(),
+			matcher_revision = $3
+		WHERE media_folder_id = $1 AND observed_root_path = $2
+	`, seriesFolderID, seriesRoot, movieMatcherRevision); err != nil {
+		t.Fatalf("seed pre-change series revision: %v", err)
+	}
+
+	if _, err := movieRepo.WakeForChangedInputs(ctx); err != nil {
+		t.Fatalf("movie WakeForChangedInputs(): %v", err)
+	}
+	var movieState string
+	var movieRevision int
+	if err := pool.QueryRow(ctx, `
+		SELECT state, matcher_revision FROM movie_match_queue WHERE media_file_id = $1
+	`, movieFileID).Scan(&movieState, &movieRevision); err != nil {
+		t.Fatalf("load movie queue row: %v", err)
+	}
+	if movieState != "parked" || movieRevision != movieMatcherRevision {
+		t.Fatalf("movie row changed after series-only revision: state=%q revision=%d", movieState, movieRevision)
+	}
+
+	if _, err := seriesRepo.WakeForChangedInputs(ctx); err != nil {
+		t.Fatalf("series WakeForChangedInputs(): %v", err)
+	}
+	var seriesState string
+	var seriesRevision int
+	if err := pool.QueryRow(ctx, `
+		SELECT state, matcher_revision FROM series_root_match_queue
+		WHERE media_folder_id = $1 AND observed_root_path = $2
+	`, seriesFolderID, seriesRoot).Scan(&seriesState, &seriesRevision); err != nil {
+		t.Fatalf("load series queue row: %v", err)
+	}
+	if seriesState != queueStatePending || seriesRevision != seriesMatcherRevision {
+		t.Fatalf("series row was not awakened: state=%q revision=%d", seriesState, seriesRevision)
 	}
 }
 
@@ -249,7 +333,7 @@ func TestSeriesMatchQueueWakeForChangedInputsResetsOnlyChangedRows(t *testing.T)
 	`, folderID, root).Scan(&state, &failureKind, &lastError, &deterministicCount, &fingerprint, &revision, &availableAt, &parkedAt, &leaseToken, &rerunRequested); err != nil {
 		t.Fatalf("load woken row: %v", err)
 	}
-	if state != queueStatePending || failureKind != "" || lastError != "" || deterministicCount != 0 || fingerprint == "" || fingerprint == "old-fingerprint" || revision != matcherRevision || parkedAt != nil {
+	if state != queueStatePending || failureKind != "" || lastError != "" || deterministicCount != 0 || fingerprint == "" || fingerprint == "old-fingerprint" || revision != seriesMatcherRevision || parkedAt != nil {
 		t.Fatalf("woken row = state:%q failure:%q last:%q deterministic:%d fingerprint:%q revision:%d available:%v parked:%v", state, failureKind, lastError, deterministicCount, fingerprint, revision, availableAt, parkedAt)
 	}
 	if leaseToken != staleLeaseToken || !rerunRequested || availableAt.Before(time.Now().Add(time.Hour)) {

--- a/internal/metadata/match_queue_state_db_test.go
+++ b/internal/metadata/match_queue_state_db_test.go
@@ -97,17 +97,18 @@ func TestSeriesMatchQueueFingerprintIncludesEpisodePathShape(t *testing.T) {
 			t.Fatalf("series fingerprint expression %q does not contain %q", expression, required)
 		}
 	}
-	if movieMatcherRevision != 9 {
-		t.Fatalf("movie matcher revision = %d, want unchanged revision 9", movieMatcherRevision)
+	if movieMatcherRevision != 10 {
+		t.Fatalf("movie matcher revision = %d, want shared title-normalization revision 10", movieMatcherRevision)
 	}
-	if seriesMatcherRevision != movieMatcherRevision+1 {
-		t.Fatalf("series matcher revision = %d, want movie revision + 1", seriesMatcherRevision)
+	if seriesMatcherRevision != 10 {
+		t.Fatalf("series matcher revision = %d, want consensus revision 10", seriesMatcherRevision)
 	}
 }
 
-func TestMatchQueueSeriesRevisionWakeDoesNotWakeMovies(t *testing.T) {
+func TestMatchQueueSharedTitleRevisionWakesMoviesAndSeries(t *testing.T) {
 	pool := chainBuiltinTestPool(t)
 	ctx := context.Background()
+	previousMatcherRevision := movieMatcherRevision - 1
 
 	movieFolderID := insertTestFolder(t, pool, "movie")
 	moviePath := fmt.Sprintf("/test/revision-isolation-%d/Movie.mkv", time.Now().UnixNano())
@@ -124,9 +125,10 @@ func TestMatchQueueSeriesRevisionWakeDoesNotWakeMovies(t *testing.T) {
 	}
 	if _, err := pool.Exec(ctx, `
 		UPDATE movie_match_queue
-		SET state = 'parked', available_at = NOW() + interval '24 hours', parked_at = NOW()
+		SET state = 'parked', available_at = NOW() + interval '24 hours', parked_at = NOW(),
+			matcher_revision = $2
 		WHERE media_file_id = $1
-	`, movieFileID); err != nil {
+	`, movieFileID, previousMatcherRevision); err != nil {
 		t.Fatalf("park movie row: %v", err)
 	}
 
@@ -149,7 +151,7 @@ func TestMatchQueueSeriesRevisionWakeDoesNotWakeMovies(t *testing.T) {
 		SET state = 'parked', available_at = NOW() + interval '24 hours', parked_at = NOW(),
 			matcher_revision = $3
 		WHERE media_folder_id = $1 AND observed_root_path = $2
-	`, seriesFolderID, seriesRoot, movieMatcherRevision); err != nil {
+	`, seriesFolderID, seriesRoot, previousMatcherRevision); err != nil {
 		t.Fatalf("seed pre-change series revision: %v", err)
 	}
 
@@ -163,8 +165,8 @@ func TestMatchQueueSeriesRevisionWakeDoesNotWakeMovies(t *testing.T) {
 	`, movieFileID).Scan(&movieState, &movieRevision); err != nil {
 		t.Fatalf("load movie queue row: %v", err)
 	}
-	if movieState != "parked" || movieRevision != movieMatcherRevision {
-		t.Fatalf("movie row changed after series-only revision: state=%q revision=%d", movieState, movieRevision)
+	if movieState != queueStatePending || movieRevision != movieMatcherRevision {
+		t.Fatalf("movie row was not awakened: state=%q revision=%d", movieState, movieRevision)
 	}
 
 	if _, err := seriesRepo.WakeForChangedInputs(ctx); err != nil {

--- a/internal/metadata/match_title_normalization_test.go
+++ b/internal/metadata/match_title_normalization_test.go
@@ -64,6 +64,14 @@ func TestInferTitleSimilarity_PreservesKanaVoicing(t *testing.T) {
 	}
 }
 
+func TestInferTitleSimilarity_PreservesNonLatinCombiningMarks(t *testing.T) {
+	// Thai mai ek changes the word from ปา (throw) to ป่า (forest). It is a
+	// combining mark, but unlike a Latin accent it must remain match-significant.
+	if got := inferTitleSimilarity("ปา", "ป่า", 0); got != 0 {
+		t.Fatalf("Thai titles differing by a lexical combining mark must stay distinct, got %v", got)
+	}
+}
+
 // The dedicated episode-title fold was removed in favor of the shared
 // normalizer; episode comparison must keep folding diacritics.
 func TestEpisodeTitleSimilarity_StillFoldsDiacritics(t *testing.T) {

--- a/internal/metadata/match_title_normalization_test.go
+++ b/internal/metadata/match_title_normalization_test.go
@@ -1,0 +1,73 @@
+package metadata
+
+import "testing"
+
+const normalizedSomeShowTitle = "Some Show"
+
+func TestNormalizeCandidateTitleForYear_TrailingYearVariants(t *testing.T) {
+	cases := []struct {
+		name  string
+		title string
+		year  int
+		want  string
+	}{
+		{"bare year stripped", "Some Show 2026", 2026, normalizedSomeShowTitle},
+		{"parenthesised year stripped", "24 stjerners julikalender (DK) (2026)", 2026, "24 stjerners julikalender (DK)"},
+		{"bracketed year stripped", "Some Show [2026]", 2026, normalizedSomeShowTitle},
+		{"different year kept", "Some Show (1999)", 2026, "Some Show (1999)"},
+		{"no year hint keeps title", "Some Show (2026)", 0, "Some Show (2026)"},
+		{"single token never stripped", "2026", 2026, "2026"},
+		{"mid-title year kept", "2001 A Space Odyssey", 1968, "2001 A Space Odyssey"},
+	}
+	for _, tc := range cases {
+		if got := normalizeCandidateTitleForYear(tc.title, tc.year); got != tc.want {
+			t.Errorf("%s: normalizeCandidateTitleForYear(%q, %d) = %q, want %q",
+				tc.name, tc.title, tc.year, got, tc.want)
+		}
+	}
+}
+
+func TestInferTitleSimilarity_FoldsDiacritics(t *testing.T) {
+	cases := []struct {
+		name  string
+		left  string
+		right string
+		year  int
+		want  float64
+	}{
+		{"combining marks", "Ze do Caixao", "Zé do Caixão", 2015, 1},
+		{"turkish letters", "Konusanlar", "Konuşanlar", 2020, 1},
+		{"capital eszett", "STRASSE", "STRAẞE", 0, 1},
+		{"eszett", "Strasse", "Straße", 0, 1},
+		{"o slash", "Forbrydelsen Kobenhavn", "Forbrydelsen København", 0, 1},
+		{"ae ligature", "Baerbar", "Bærbar", 0, 1},
+		{"oe ligature", "Coeur", "Cœur", 0, 1},
+		{"unrelated titles stay distinct", "Miniverse", "Universe", 0, 0},
+	}
+	for _, tc := range cases {
+		if got := inferTitleSimilarity(tc.left, tc.right, tc.year); got != tc.want {
+			t.Errorf("%s: inferTitleSimilarity(%q, %q, %d) = %v, want %v",
+				tc.name, tc.left, tc.right, tc.year, got, tc.want)
+		}
+	}
+}
+
+func TestInferTitleSimilarity_PreservesKanaVoicing(t *testing.T) {
+	if got := inferTitleSimilarity("ガキの使い", "カキの使い", 0); got != 0 {
+		t.Fatalf("kana titles differing by voicing must stay distinct, got %v", got)
+	}
+	if got := inferTitleSimilarity("ガキの使い", "カ゛キの使い", 0); got != 1 {
+		t.Fatalf("spacing dakuten must normalize to the voiced kana, got %v", got)
+	}
+	if got := inferTitleSimilarity("カ゛キの使い", "カキの使い", 0); got != 0 {
+		t.Fatalf("spacing dakuten must remain distinct from unvoiced kana, got %v", got)
+	}
+}
+
+// The dedicated episode-title fold was removed in favor of the shared
+// normalizer; episode comparison must keep folding diacritics.
+func TestEpisodeTitleSimilarity_StillFoldsDiacritics(t *testing.T) {
+	if got := episodeTitleSimilarity("Cafe con Leche", "Café con Leche"); got != 1 {
+		t.Fatalf("episodeTitleSimilarity should fold diacritics, got %v", got)
+	}
+}

--- a/internal/metadata/movie_match_queue_repo.go
+++ b/internal/metadata/movie_match_queue_repo.go
@@ -97,8 +97,8 @@ func (r *MovieMatchQueueRepository) EnqueueMovieFile(ctx context.Context, fileID
 		SELECT
 			mf.id,
 			mf.media_folder_id,
-			`+matchQueueInputFingerprintSQL("mf.file_path", "'movie'", "mf.media_folder_id", "folders.metadata_language")+`,
-			`+fmt.Sprintf("%d", matcherRevision)+`,
+			`+matchQueueInputFingerprintSQL("mf.file_path", "'movie'", "mf.media_folder_id", "folders.metadata_language", movieMatcherRevision)+`,
+			`+fmt.Sprintf("%d", movieMatcherRevision)+`,
 			NOW(),
 			NOW()
 		FROM media_files mf
@@ -174,8 +174,8 @@ func (r *MovieMatchQueueRepository) SyncForFolder(ctx context.Context, folderID 
 		SELECT
 			mf.id,
 			mf.media_folder_id,
-			`+matchQueueInputFingerprintSQL("mf.file_path", "'movie'", "mf.media_folder_id", "folders.metadata_language")+`,
-			`+fmt.Sprintf("%d", matcherRevision)+`,
+			`+matchQueueInputFingerprintSQL("mf.file_path", "'movie'", "mf.media_folder_id", "folders.metadata_language", movieMatcherRevision)+`,
+			`+fmt.Sprintf("%d", movieMatcherRevision)+`,
 			NOW(),
 			NOW()
 		FROM media_files mf
@@ -256,8 +256,8 @@ func (r *MovieMatchQueueRepository) SyncInScope(ctx context.Context, folderID in
 		SELECT
 			mf.id,
 			mf.media_folder_id,
-			`+matchQueueInputFingerprintSQL("mf.file_path", "'movie'", "mf.media_folder_id", "folders.metadata_language")+`,
-			`+fmt.Sprintf("%d", matcherRevision)+`,
+			`+matchQueueInputFingerprintSQL("mf.file_path", "'movie'", "mf.media_folder_id", "folders.metadata_language", movieMatcherRevision)+`,
+			`+fmt.Sprintf("%d", movieMatcherRevision)+`,
 			NOW(),
 			NOW()
 		FROM media_files mf
@@ -588,7 +588,7 @@ func (r *MovieMatchQueueRepository) RetryNowByFolder(ctx context.Context, folder
 	tag, err := r.pool.Exec(ctx, `
 		WITH current_inputs AS (
 			SELECT q.media_file_id, mf.media_folder_id,
-				`+matchQueueInputFingerprintSQL("mf.file_path", "'movie'", "mf.media_folder_id", "folders.metadata_language")+` AS input_fingerprint
+				`+matchQueueInputFingerprintSQL("mf.file_path", "'movie'", "mf.media_folder_id", "folders.metadata_language", movieMatcherRevision)+` AS input_fingerprint
 			FROM movie_match_queue q
 			JOIN media_files mf ON mf.id = q.media_file_id
 			JOIN media_folders folders ON folders.id = mf.media_folder_id
@@ -601,7 +601,7 @@ func (r *MovieMatchQueueRepository) RetryNowByFolder(ctx context.Context, folder
 			failure_kind = '', failure_detail = '{}'::jsonb, last_error = '', parked_at = NULL,
 			rerun_requested = true,
 			media_folder_id = current_inputs.media_folder_id,
-			input_fingerprint = current_inputs.input_fingerprint, matcher_revision = `+fmt.Sprintf("%d", matcherRevision)+`, updated_at = NOW()
+			input_fingerprint = current_inputs.input_fingerprint, matcher_revision = `+fmt.Sprintf("%d", movieMatcherRevision)+`, updated_at = NOW()
 		FROM current_inputs
 		WHERE movie_match_queue.media_file_id = current_inputs.media_file_id
 	`, folderID)
@@ -618,7 +618,7 @@ func (r *MovieMatchQueueRepository) WakeForChangedInputs(ctx context.Context) (i
 	tag, err := r.pool.Exec(ctx, `
 		WITH changed AS (
 			SELECT q.media_file_id, mf.media_folder_id,
-				`+matchQueueInputFingerprintSQL("mf.file_path", "'movie'", "mf.media_folder_id", "folders.metadata_language")+` AS input_fingerprint
+				`+matchQueueInputFingerprintSQL("mf.file_path", "'movie'", "mf.media_folder_id", "folders.metadata_language", movieMatcherRevision)+` AS input_fingerprint
 			FROM movie_match_queue q
 			JOIN media_files mf ON mf.id = q.media_file_id
 			JOIN media_folders folders ON folders.id = mf.media_folder_id
@@ -630,10 +630,10 @@ func (r *MovieMatchQueueRepository) WakeForChangedInputs(ctx context.Context) (i
 			failure_kind = '', failure_detail = '{}'::jsonb, last_error = '', parked_at = NULL,
 			rerun_requested = true,
 			media_folder_id = changed.media_folder_id,
-			input_fingerprint = changed.input_fingerprint, matcher_revision = `+fmt.Sprintf("%d", matcherRevision)+`, updated_at = NOW()
+			input_fingerprint = changed.input_fingerprint, matcher_revision = `+fmt.Sprintf("%d", movieMatcherRevision)+`, updated_at = NOW()
 		FROM changed
 		WHERE changed.media_file_id = q.media_file_id
-		  AND (q.input_fingerprint <> changed.input_fingerprint OR q.matcher_revision <> `+fmt.Sprintf("%d", matcherRevision)+` OR q.media_folder_id <> changed.media_folder_id)
+		  AND (q.input_fingerprint <> changed.input_fingerprint OR q.matcher_revision <> `+fmt.Sprintf("%d", movieMatcherRevision)+` OR q.media_folder_id <> changed.media_folder_id)
 	`)
 	if err != nil {
 		return 0, fmt.Errorf("waking movie matches with changed inputs: %w", err)

--- a/internal/metadata/plugin_provider_test.go
+++ b/internal/metadata/plugin_provider_test.go
@@ -11,20 +11,28 @@ import (
 	pluginv1 "github.com/Silo-Server/silo-plugin-sdk/pkg/pluginproto/silo/plugin/v1"
 )
 
+const (
+	pluginInstallationIDSetting = "plugin_installation_id"
+	capabilityIDSetting         = "capability_id"
+)
+
 type fakePluginMetadataClient struct {
+	searchResponse *pluginv1.SearchMetadataResponse
 	response       *pluginv1.GetMetadataResponse
 	imagesResponse *pluginv1.GetImagesResponse
 	seasonsResp    *pluginv1.GetSeasonsResponse
 	episodesResp   *pluginv1.GetEpisodesResponse
 
+	searchReq      *pluginv1.SearchMetadataRequest
 	getMetadataReq *pluginv1.GetMetadataRequest
 	getImagesReq   *pluginv1.GetImagesRequest
 	getSeasonsReq  *pluginv1.GetSeasonsRequest
 	getEpisodesReq *pluginv1.GetEpisodesRequest
 }
 
-func (f *fakePluginMetadataClient) Search(context.Context, *pluginv1.SearchMetadataRequest) (*pluginv1.SearchMetadataResponse, error) {
-	return nil, nil
+func (f *fakePluginMetadataClient) Search(_ context.Context, req *pluginv1.SearchMetadataRequest) (*pluginv1.SearchMetadataResponse, error) {
+	f.searchReq = req
+	return f.searchResponse, nil
 }
 
 func (f *fakePluginMetadataClient) GetMetadata(_ context.Context, req *pluginv1.GetMetadataRequest) (*pluginv1.GetMetadataResponse, error) {
@@ -68,6 +76,75 @@ func setPluginMetadataItemReleaseDate(t *testing.T, item *pluginv1.MetadataItem,
 	}
 
 	item.ProtoReflect().Set(field, protoreflect.ValueOfString(value))
+}
+
+//nolint:goconst // Keep the production-shaped protobuf fixture readable in place.
+func TestPluginProviderSearch_MapsLocalizedTitlesAndCrossReferences(t *testing.T) {
+	client := &fakePluginMetadataClient{
+		searchResponse: &pluginv1.SearchMetadataResponse{Results: []*pluginv1.ProviderSearchResult{
+			{
+				ProviderId:       localizedTVDBID,
+				ItemType:         anchoredItemTypeSeries,
+				Title:            localizedOriginalTitle,
+				OriginalTitle:    localizedOriginalTitle,
+				Year:             1999,
+				TitleLanguage:    "ja",
+				TitleIsFallback:  true,
+				OriginalLanguage: "ja",
+				TitleAliases: []*pluginv1.TitleAlias{
+					{Title: localizedEnglishTitle, Language: "en", Kind: testAlternateAliasKind},
+				},
+				ProviderIds: mustStructFromStringMap(t, map[string]string{
+					testTVDBProvider: localizedTVDBID,
+					testTMDBProvider: localizedTMDBID,
+					testIMDBProvider: "tt0213338",
+				}),
+			},
+		}},
+	}
+
+	provider, err := NewPluginProviderWithClientFactory(map[string]string{
+		pluginInstallationIDSetting: "1",
+		capabilityIDSetting:         testTVDBProvider,
+	}, func(context.Context, int, string) (pluginMetadataClient, error) {
+		return client, nil
+	})
+	if err != nil {
+		t.Fatalf("NewPluginProviderWithClientFactory() error = %v", err)
+	}
+
+	results, err := provider.Search(context.Background(), SearchQuery{
+		Title:       localizedEnglishTitle,
+		ContentType: anchoredItemTypeSeries,
+		Language:    "en",
+	})
+	if err != nil {
+		t.Fatalf("Search() error = %v", err)
+	}
+	if client.searchReq == nil || client.searchReq.GetQuery() != localizedEnglishTitle || client.searchReq.GetItemType() != anchoredItemTypeSeries || client.searchReq.GetLanguage() != "en" {
+		t.Fatalf("captured search request = %+v", client.searchReq)
+	}
+	if len(results) != 1 {
+		t.Fatalf("Search() returned %d results, want 1", len(results))
+	}
+	got := results[0]
+	if got.Name != localizedOriginalTitle || got.OriginalTitle != localizedOriginalTitle || got.Year != 1999 {
+		t.Fatalf("localized identity fields = %+v", got)
+	}
+	if got.TitleLanguage != "ja" || !got.TitleIsFallback || got.OriginalLanguage != "ja" {
+		t.Fatalf("language/fallback fields = language:%q fallback:%v original:%q", got.TitleLanguage, got.TitleIsFallback, got.OriginalLanguage)
+	}
+	wantAliases := []TitleAlias{{Title: localizedEnglishTitle, Language: "en", Kind: testAlternateAliasKind, Provider: testTVDBProvider}}
+	if !reflect.DeepEqual(got.TitleAliases, wantAliases) {
+		t.Fatalf("TitleAliases = %#v, want %#v", got.TitleAliases, wantAliases)
+	}
+	if !reflect.DeepEqual(got.ProviderIDs, map[string]string{
+		testTVDBProvider: localizedTVDBID,
+		testTMDBProvider: localizedTMDBID,
+		testIMDBProvider: "tt0213338",
+	}) {
+		t.Fatalf("ProviderIDs = %#v", got.ProviderIDs)
+	}
 }
 
 func TestPluginProviderGetMetadata_MapsReleaseDate(t *testing.T) {

--- a/internal/metadata/plugin_provider_test.go
+++ b/internal/metadata/plugin_provider_test.go
@@ -80,12 +80,13 @@ func setPluginMetadataItemReleaseDate(t *testing.T, item *pluginv1.MetadataItem,
 
 //nolint:goconst // Keep the production-shaped protobuf fixture readable in place.
 func TestPluginProviderSearch_MapsLocalizedTitlesAndCrossReferences(t *testing.T) {
+	const localizedJapanesePrimaryTitle = "十兵衛ちゃん -ラブリー眼帯の秘密-"
 	client := &fakePluginMetadataClient{
 		searchResponse: &pluginv1.SearchMetadataResponse{Results: []*pluginv1.ProviderSearchResult{
 			{
 				ProviderId:       localizedTVDBID,
 				ItemType:         anchoredItemTypeSeries,
-				Title:            localizedOriginalTitle,
+				Title:            localizedJapanesePrimaryTitle,
 				OriginalTitle:    localizedOriginalTitle,
 				Year:             1999,
 				TitleLanguage:    "ja",
@@ -95,7 +96,6 @@ func TestPluginProviderSearch_MapsLocalizedTitlesAndCrossReferences(t *testing.T
 					{Title: localizedEnglishTitle, Language: "en", Kind: testAlternateAliasKind},
 				},
 				ProviderIds: mustStructFromStringMap(t, map[string]string{
-					testTVDBProvider: localizedTVDBID,
 					testTMDBProvider: localizedTMDBID,
 					testIMDBProvider: "tt0213338",
 				}),
@@ -128,7 +128,7 @@ func TestPluginProviderSearch_MapsLocalizedTitlesAndCrossReferences(t *testing.T
 		t.Fatalf("Search() returned %d results, want 1", len(results))
 	}
 	got := results[0]
-	if got.Name != localizedOriginalTitle || got.OriginalTitle != localizedOriginalTitle || got.Year != 1999 {
+	if got.Name != localizedJapanesePrimaryTitle || got.OriginalTitle != localizedOriginalTitle || got.Year != 1999 {
 		t.Fatalf("localized identity fields = %+v", got)
 	}
 	if got.TitleLanguage != "ja" || !got.TitleIsFallback || got.OriginalLanguage != "ja" {

--- a/internal/metadata/series_root_match_queue_repo.go
+++ b/internal/metadata/series_root_match_queue_repo.go
@@ -107,7 +107,7 @@ func (r *SeriesRootMatchQueueRepository) EnqueueSeriesRoot(ctx context.Context, 
 			roots.media_folder_id,
 			roots.observed_root_path,
 			`+seriesMatchQueueInputFingerprintSQL("roots.observed_root_path", "roots.media_folder_id", "roots.metadata_language")+`,
-			`+fmt.Sprintf("%d", matcherRevision)+`,
+			`+fmt.Sprintf("%d", seriesMatcherRevision)+`,
 			NOW() + $3::interval,
 			NOW()
 		FROM eligible_roots roots
@@ -214,7 +214,7 @@ func (r *SeriesRootMatchQueueRepository) SyncForFolder(ctx context.Context, fold
 			roots.media_folder_id,
 			roots.observed_root_path,
 			`+seriesMatchQueueInputFingerprintSQL("roots.observed_root_path", "roots.media_folder_id", "roots.metadata_language")+`,
-			`+fmt.Sprintf("%d", matcherRevision)+`,
+			`+fmt.Sprintf("%d", seriesMatcherRevision)+`,
 			NOW() + $2::interval,
 			NOW()
 		FROM eligible_roots roots
@@ -327,7 +327,7 @@ func (r *SeriesRootMatchQueueRepository) SyncInScope(ctx context.Context, folder
 		)
 		SELECT roots.media_folder_id, roots.observed_root_path,
 			`+seriesMatchQueueInputFingerprintSQL("roots.observed_root_path", "roots.media_folder_id", "roots.metadata_language")+`,
-			`+fmt.Sprintf("%d", matcherRevision)+`, NOW() + $4::interval, NOW()
+			`+fmt.Sprintf("%d", seriesMatcherRevision)+`, NOW() + $4::interval, NOW()
 		FROM in_scope_roots roots
 		ON CONFLICT (media_folder_id, observed_root_path)
 		DO UPDATE SET
@@ -745,7 +745,7 @@ func (r *SeriesRootMatchQueueRepository) RetryNowByFolder(ctx context.Context, f
 			deterministic_attempt_count = 0,
 			failure_kind = '', failure_detail = '{}'::jsonb, last_error = '', parked_at = NULL,
 			rerun_requested = true,
-			input_fingerprint = current_inputs.input_fingerprint, matcher_revision = `+fmt.Sprintf("%d", matcherRevision)+`, updated_at = NOW()
+			input_fingerprint = current_inputs.input_fingerprint, matcher_revision = `+fmt.Sprintf("%d", seriesMatcherRevision)+`, updated_at = NOW()
 		FROM current_inputs
 		WHERE series_root_match_queue.media_folder_id = current_inputs.media_folder_id
 		  AND series_root_match_queue.observed_root_path = current_inputs.observed_root_path
@@ -773,11 +773,11 @@ func (r *SeriesRootMatchQueueRepository) WakeForChangedInputs(ctx context.Contex
 			deterministic_attempt_count = 0,
 			failure_kind = '', failure_detail = '{}'::jsonb, last_error = '', parked_at = NULL,
 			rerun_requested = true,
-			input_fingerprint = changed.input_fingerprint, matcher_revision = `+fmt.Sprintf("%d", matcherRevision)+`, updated_at = NOW()
+			input_fingerprint = changed.input_fingerprint, matcher_revision = `+fmt.Sprintf("%d", seriesMatcherRevision)+`, updated_at = NOW()
 		FROM changed
 		WHERE changed.media_folder_id = q.media_folder_id
 		  AND changed.observed_root_path = q.observed_root_path
-		  AND (q.input_fingerprint <> changed.input_fingerprint OR q.matcher_revision <> `+fmt.Sprintf("%d", matcherRevision)+`)
+		  AND (q.input_fingerprint <> changed.input_fingerprint OR q.matcher_revision <> `+fmt.Sprintf("%d", seriesMatcherRevision)+`)
 	`)
 	if err != nil {
 		return 0, fmt.Errorf("waking series matches with changed inputs: %w", err)


### PR DESCRIPTION
## Summary

- preserve localized primary, original, and alias titles through the plugin adapter so English folder names can match original-language provider results
- add a narrowly scoped series-only, no-year TMDB+TVDB consensus tie-break without changing score floors or promoting lower-ranked candidates
- split movie and series matcher revisions so only parked series matches are awakened
- consolidate title normalization for provider year decorations and diacritic variants while preserving kana voicing distinctions

## Why

Production unmatched-series analysis identified two concentrated classes: localized provider titles where the folder uses the English alias, and missing-year folders where TMDB and TVDB corroborate one exact-title identity while alternatives are single-provider results. This resolves those classes without runtime matching, movie tie-breaking, global threshold changes, or metadata/ID merging from competitors.

Follow-up to #461.

## Safety

The consensus rule runs only when the hint is explicitly a series, the local year is absent, the existing top-score tie path is active, and exactly one top-scored candidate has an exact normalized title, a provider year, both TMDB and TVDB sources, and retained canonical IDs from both providers. Negative controls cover movies, fuzzy matches, false NFO corroboration, quarantined IDs, multiple consensus identities, candidate ordering, and lower-ranked corroborated candidates.

The movie matcher revision remains unchanged at 9; only the series revision advances to 10.

## Validation

- `SILO_TEST_DATABASE_URL=<fresh migrated PostgreSQL 18> go test ./internal/metadata -count=1` — pass
- `go test -race ./internal/metadata/` — pass
- `GOWORK=off golangci-lint run --new-from-rev=origin/main` — `0 issues`
- `make build` — pass
- `make verify-local-paths` — pass
- `cd web && pnpm run lint` — pass with existing warnings and zero errors
- `cd web && pnpm run format:check` — pass
- clean upstream TMDB and TVDB plugin `GOWORK=off go test -mod=mod ./...` — pass

The unrestricted `make lint` currently reports repository-wide baseline findings outside this diff; branch-only lint is clean. The full Go suite also encounters existing Jellycompat autoscan and playback NVENC failures that reproduce on clean `origin/main`.

## Adversarial review

Review found and resolved duplicated diacritic folding, a misleading non-decomposable-letter table entry, missing normalization regression coverage, and an ordering bug that could reject a uniquely corroborated candidate when it tied for top score but appeared second. The final review found no remaining actionable code or regression issues, and the patch applied cleanly after aligning with current `origin/main`.

### AI Disclosure
- Tool(s): Codex Desktop; Claude review supplied by the operator
- Model(s): gpt-5.6-sol; n/a (Claude model ID was not provided)
- Involvement: AI-assisted
- Adversarial review: Codex and Claude independently reviewed the diff. Their findings covered shared normalization, comments, regression coverage, ordering invariance, and merge safety; all material findings were resolved and retested.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved movie and series metadata matching across accented titles, localized names, aliases, and common year formats.
  - Improved episode-title comparisons while preserving meaningful script and kana distinctions.
  - Added more reliable provider agreement handling when series years are unavailable.
  - Preserved canonical provider identities when metadata sources disagree.

- **Reliability**
  - Movie and series metadata updates are now processed independently, preventing unrelated queued movie matches from being reprocessed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

---

## Maintainer remediation

A maintainer-assisted follow-up addressed three review findings:

- use the provider candidate year when a local folder has no year, so a decorated title such as `Adventure Time (2010)` can reach the bounded no-year consensus path
- fold combining marks only when attached to Latin letters, preserving lexical marks in scripts such as Thai while retaining Latin-diacritic and kana behavior
- advance both movie and series matcher revisions from 9 to 10 because the shared title normalizer changes both queue result sets

This corrects the earlier Safety statement that movie matcher revision remains at 9; both matcher revisions are now 10. The consensus tie-break itself remains series-only.

### Maintainer verification

- focused localized-title, decorated-year, non-Latin combining-mark, and queue-revision regression tests: pass
- `go test -count=1 ./internal/metadata`: pass
- `go test -race -count=1 ./internal/metadata`: pass
- GOWORK-off compile, `go vet`, and changed-lines `golangci-lint v2.12.2`: pass (`0 issues`)
- `make build`, `make verify-local-paths`, and `git diff --check`: pass
- `pnpm run format:check`: pass
- `pnpm run lint`: pass with 0 errors and 158 existing warnings
- target backend deployment: healthy; `/api/v1/ready` returned `{"status":"ok"}`
- PostgreSQL-backed `TestMatchQueueSharedTitleRevisionWakesMoviesAndSeries` on the target backend: pass
- post-deploy sampled logs: no new panic, migration failure, error loop, or readiness regression observed
- final independent Standards and Spec reviews: no findings

### Maintainer AI Disclosure
- Tool(s): T3 Code (Codex)
- Model(s): gpt-5.6-sol
- Involvement: AI-assisted maintainer remediation
- Adversarial review: Independent Standards and Spec passes reviewed the combined final diff after the fixes and found no remaining actionable findings.