### PR TITLE
fix(jellycompat): resolve item duration probed-first with runtime fallback

### DIFF
--- a/internal/catalog/detail.go
+++ b/internal/catalog/detail.go
@@ -34,6 +34,11 @@ type extraFileFetcher interface {
 	GetByExtraID(ctx context.Context, extraID string) ([]*models.MediaFile, error)
 }
 
+type batchDurationFetcher interface {
+	FirstDurationsByContentIDs(ctx context.Context, ids []string) (map[string]int, error)
+	FirstDurationsByEpisodeIDs(ctx context.Context, ids []string) (map[string]int, error)
+}
+
 type PlaybackProbeEnsurer interface {
 	Ensure(ctx context.Context, file *models.MediaFile) (*models.MediaFile, error)
 }
@@ -88,6 +93,42 @@ type WorkFormatSummary struct {
 	Type      string `json:"type"`
 	ContentID string `json:"content_id"`
 	LibraryID int    `json:"library_id,omitempty"`
+}
+
+// ProbedDurationsByContentIDs resolves first-file probed durations when the
+// configured file fetcher supports the optional batch extension.
+func (s *DetailService) ProbedDurationsByContentIDs(ctx context.Context, ids []string) map[string]int {
+	if s == nil || s.fileFetcher == nil || len(ids) == 0 {
+		return nil
+	}
+	fetcher, ok := s.fileFetcher.(batchDurationFetcher)
+	if !ok {
+		return nil
+	}
+	durations, err := fetcher.FirstDurationsByContentIDs(ctx, ids)
+	if err != nil {
+		slog.Warn("failed to fetch probed content durations", "error", err, "id_count", len(ids))
+		return nil
+	}
+	return durations
+}
+
+// ProbedDurationsByEpisodeIDs resolves first-file probed durations when the
+// configured file fetcher supports the optional batch extension.
+func (s *DetailService) ProbedDurationsByEpisodeIDs(ctx context.Context, ids []string) map[string]int {
+	if s == nil || s.fileFetcher == nil || len(ids) == 0 {
+		return nil
+	}
+	fetcher, ok := s.fileFetcher.(batchDurationFetcher)
+	if !ok {
+		return nil
+	}
+	durations, err := fetcher.FirstDurationsByEpisodeIDs(ctx, ids)
+	if err != nil {
+		slog.Warn("failed to fetch probed episode durations", "error", err, "id_count", len(ids))
+		return nil
+	}
+	return durations
 }
 
 // ItemDetail is the full detail response for a single media item, including

--- a/internal/jellycompat/batch_loaders.go
+++ b/internal/jellycompat/batch_loaders.go
@@ -107,6 +107,7 @@ func (h *ItemsHandler) fetchCompatItemsByContentIDs(ctx context.Context, session
 		listItems = append(listItems, mediaItemToListItem(item))
 	}
 	presignCompatListItems(ctx, h.detailSvc, listItems)
+	fillListItemDurations(ctx, h.durationSrc, listItems)
 	result := make(map[string]upstreamListItem, len(listItems))
 	for _, listItem := range listItems {
 		result[listItem.ContentID] = listItem
@@ -136,6 +137,7 @@ func (h *ItemsHandler) fetchCompatItemsByContentIDsFallback(ctx context.Context,
 		listItems = append(listItems, mediaItemToListItem(item))
 	}
 	presignCompatListItems(ctx, h.detailSvc, listItems)
+	fillListItemDurations(ctx, h.durationSrc, listItems)
 	for _, listItem := range listItems {
 		result[listItem.ContentID] = listItem
 	}
@@ -362,6 +364,17 @@ func (h *ItemsHandler) fetchCompatEpisodeTargetsByContentIDs(ctx context.Context
 		return nil, fmt.Errorf("iterating compat episode targets: %w", err)
 	}
 
+	listItems := make([]upstreamListItem, 0, len(result))
+	for _, target := range result {
+		listItems = append(listItems, target.Item)
+	}
+	fillListItemDurations(ctx, h.durationSrc, listItems)
+	for _, item := range listItems {
+		target := result[item.ContentID]
+		target.Item = item
+		result[item.ContentID] = target
+	}
+
 	return result, nil
 }
 
@@ -469,6 +482,17 @@ func (h *ItemsHandler) fetchCompatEpisodeTargetsByContentIDsFallback(ctx context
 			},
 			SeasonID: episode.SeasonID,
 		}
+	}
+
+	listItems := make([]upstreamListItem, 0, len(result))
+	for _, target := range result {
+		listItems = append(listItems, target.Item)
+	}
+	fillListItemDurations(ctx, h.durationSrc, listItems)
+	for _, item := range listItems {
+		target := result[item.ContentID]
+		target.Item = item
+		result[item.ContentID] = target
 	}
 
 	return result, nil

--- a/internal/jellycompat/batch_loaders.go
+++ b/internal/jellycompat/batch_loaders.go
@@ -364,18 +364,19 @@ func (h *ItemsHandler) fetchCompatEpisodeTargetsByContentIDs(ctx context.Context
 		return nil, fmt.Errorf("iterating compat episode targets: %w", err)
 	}
 
-	listItems := make([]upstreamListItem, 0, len(result))
-	for _, target := range result {
-		listItems = append(listItems, target.Item)
-	}
-	fillListItemDurations(ctx, h.durationSrc, listItems)
-	for _, item := range listItems {
-		target := result[item.ContentID]
-		target.Item = item
-		result[item.ContentID] = target
-	}
-
 	return result, nil
+}
+
+// fetchCompatEpisodeTargetsByContentIDsWithDurations is for paths that build
+// their DTO directly from target.Item. List-page overlay paths must use the
+// metadata-only loader above because their list items are already enriched.
+func (h *ItemsHandler) fetchCompatEpisodeTargetsByContentIDsWithDurations(ctx context.Context, session *Session, contentIDs []string, libraryID *int) (map[string]compatEpisodeTarget, error) {
+	targets, err := h.fetchCompatEpisodeTargetsByContentIDs(ctx, session, contentIDs, libraryID)
+	if err != nil {
+		return nil, err
+	}
+	fillEpisodeTargetDurations(ctx, h.durationSrc, targets)
+	return targets, nil
 }
 
 func (h *ItemsHandler) fetchCompatEpisodeTargetsByContentIDsFallback(ctx context.Context, session *Session, contentIDs []string, libraryID *int) (map[string]compatEpisodeTarget, error) {
@@ -482,17 +483,6 @@ func (h *ItemsHandler) fetchCompatEpisodeTargetsByContentIDsFallback(ctx context
 			},
 			SeasonID: episode.SeasonID,
 		}
-	}
-
-	listItems := make([]upstreamListItem, 0, len(result))
-	for _, target := range result {
-		listItems = append(listItems, target.Item)
-	}
-	fillListItemDurations(ctx, h.durationSrc, listItems)
-	for _, item := range listItems {
-		target := result[item.ContentID]
-		target.Item = item
-		result[item.ContentID] = target
 	}
 
 	return result, nil

--- a/internal/jellycompat/batch_loaders_test.go
+++ b/internal/jellycompat/batch_loaders_test.go
@@ -330,3 +330,57 @@ func TestFetchCompatEpisodeTargetsByContentIDsFallback_UsesBatchedSeriesAccess(t
 		t.Errorf("expected zero plain GetByIDs calls in the episode fallback; got %d", itemRepo.getByIDsCalls)
 	}
 }
+
+// Overlay callers already receive duration-enriched list items from the
+// content service, so fetching episode metadata must not repeat the duration
+// query. Callers that render target.Item opt into the enriched wrapper.
+func TestFetchCompatEpisodeTargetsByContentIDs_ResolvesDurationOnlyWhenRequested(t *testing.T) {
+	itemRepo := &countingItemRepo{
+		itemsByID: map[string]*models.MediaItem{
+			"series-1": {ContentID: "series-1", Type: "series", Title: "Show"},
+		},
+	}
+	episodeRepo := &countingEpisodeRepo{
+		episodesByID: map[string]*models.Episode{
+			"ep-1": {ContentID: "ep-1", SeriesID: "series-1", Title: "Pilot"},
+		},
+	}
+	durations := &countingProbedDurationSource{episodes: map[string]int{"ep-1": 1500}}
+	h := &ItemsHandler{
+		itemRepo:    itemRepo,
+		episodeRepo: episodeRepo,
+		durationSrc: durations,
+	}
+
+	metadataOnly, err := h.fetchCompatEpisodeTargetsByContentIDs(
+		context.Background(),
+		&Session{},
+		[]string{"ep-1"},
+		nil,
+	)
+	if err != nil {
+		t.Fatalf("fetch metadata-only episode targets: %v", err)
+	}
+	if durations.episodeCalls != 0 {
+		t.Fatalf("metadata-only duration calls = %d, want 0", durations.episodeCalls)
+	}
+	if got := metadataOnly["ep-1"].Item.DurationSeconds; got != 0 {
+		t.Fatalf("metadata-only duration = %d, want 0", got)
+	}
+
+	withDurations, err := h.fetchCompatEpisodeTargetsByContentIDsWithDurations(
+		context.Background(),
+		&Session{},
+		[]string{"ep-1"},
+		nil,
+	)
+	if err != nil {
+		t.Fatalf("fetch duration-enriched episode targets: %v", err)
+	}
+	if durations.episodeCalls != 1 {
+		t.Fatalf("duration-enriched calls = %d, want 1", durations.episodeCalls)
+	}
+	if got := withDurations["ep-1"].Item.DurationSeconds; got != 1500 {
+		t.Fatalf("duration-enriched duration = %d, want 1500", got)
+	}
+}

--- a/internal/jellycompat/content_direct.go
+++ b/internal/jellycompat/content_direct.go
@@ -506,6 +506,7 @@ func (s *directContentService) BrowseItems(ctx context.Context, session *Session
 	if len(collected) > requestedLimit {
 		collected = collected[:requestedLimit]
 	}
+	fillListItemDurations(ctx, s.detailSvc, collected)
 
 	// The handler's resolveUserStateForContentIDs overlay only covers items
 	// with their own progress rows, which a series never has — aggregate
@@ -594,6 +595,7 @@ func (s *directContentService) SearchItems(ctx context.Context, session *Session
 		listItems = append(listItems, mediaItemToListItem(mi))
 	}
 	presignCompatListItems(ctx, s.detailSvc, listItems)
+	fillListItemDurations(ctx, s.detailSvc, listItems)
 	s.enrichListItemsUserData(ctx, session, listItems)
 
 	return &upstreamBrowseResponse{

--- a/internal/jellycompat/handlers_items.go
+++ b/internal/jellycompat/handlers_items.go
@@ -1650,7 +1650,7 @@ func (h *ItemsHandler) writeEpisodeModelsPage(w http.ResponseWriter, r *http.Req
 		writeCompatUpstreamError(w, err)
 		return
 	}
-	episodeTargets, err := h.fetchCompatEpisodeTargetsByContentIDs(r.Context(), session, contentIDs, nil)
+	episodeTargets, err := h.fetchCompatEpisodeTargetsByContentIDsWithDurations(r.Context(), session, contentIDs, nil)
 	if err != nil {
 		writeCompatUpstreamError(w, err)
 		return
@@ -1884,7 +1884,7 @@ func (h *ItemsHandler) writeNextUpResponse(w http.ResponseWriter, r *http.Reques
 		writeCompatUpstreamError(w, err)
 		return
 	}
-	episodeTargets, err := h.fetchCompatEpisodeTargetsByContentIDs(r.Context(), session, contentIDs, nil)
+	episodeTargets, err := h.fetchCompatEpisodeTargetsByContentIDsWithDurations(r.Context(), session, contentIDs, nil)
 	if err != nil {
 		writeCompatUpstreamError(w, err)
 		return
@@ -2913,7 +2913,7 @@ func (h *ItemsHandler) hydrateProgressItems(ctx context.Context, session *Sessio
 	if err != nil {
 		return nil, err
 	}
-	episodesByID, err := h.fetchCompatEpisodeTargetsByContentIDs(ctx, session, contentIDs, libraryID)
+	episodesByID, err := h.fetchCompatEpisodeTargetsByContentIDsWithDurations(ctx, session, contentIDs, libraryID)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/jellycompat/handlers_items.go
+++ b/internal/jellycompat/handlers_items.go
@@ -39,6 +39,7 @@ type ItemsHandler struct {
 	browseRepo   *catalog.BrowseRepository
 	personRepo   *catalog.PersonRepository
 	detailSvc    *catalog.DetailService
+	durationSrc  probedDurationSource
 	itemRepo     itemRepoForBatchLoader
 	episodeRepo  episodeRepoForBatchLoader
 	seasonRepo   imageSeasonRepository
@@ -75,6 +76,7 @@ func NewItemsHandler(content ContentService, userData UserDataService, codec *Re
 		browseRepo:   browseRepo,
 		personRepo:   personRepo,
 		detailSvc:    detailSvc,
+		durationSrc:  detailSvc,
 		itemRepo:     itemRepo,
 		episodeRepo:  episodeRepo,
 		accessFilter: accessFilter,
@@ -1322,6 +1324,7 @@ func (h *ItemsHandler) compatListItemsFromModels(ctx context.Context, filter cat
 		listItems = append(listItems, mediaItemToListItem(mi))
 	}
 	presignCompatListItems(ctx, h.detailSvc, listItems)
+	fillListItemDurations(ctx, h.durationSrc, listItems)
 	return listItems
 }
 
@@ -1705,6 +1708,7 @@ func (h *ItemsHandler) writeEpisodeModelsPage(w http.ResponseWriter, r *http.Req
 			upstreamEpisode.StillURL = firstNonEmpty(target.Item.StillURL, target.Item.PosterURL, upstreamEpisode.StillURL)
 			upstreamEpisode.SeriesTitle = firstNonEmpty(target.Item.SeriesTitle, upstreamEpisode.SeriesTitle)
 			upstreamEpisode.HasMediaFiles = target.Item.HasMediaFiles
+			upstreamEpisode.DurationSeconds = target.Item.DurationSeconds
 		}
 		dto := h.mapper.episodeFromUpstream(upstreamEpisode, favorites[episode.ContentID], progress[episode.ContentID])
 		dto.SeasonName = firstNonEmpty(seasonTitleByID[episode.SeasonID], seasonTitleByNumber[episode.SeasonNumber])
@@ -2058,7 +2062,7 @@ func (h *ItemsHandler) HandleSearchHints(w http.ResponseWriter, r *http.Request)
 			Name:             item.Title,
 			Type:             jellyfinItemType(item.Type),
 			ProductionYear:   item.Year,
-			RunTimeTicks:     minutesToTicks(item.Runtime),
+			RunTimeTicks:     runtimeTicks(item.DurationSeconds, item.Runtime),
 			PrimaryImageTag:  tagValue(item.PosterURL),
 			BackdropImageTag: tagValue(item.BackdropURL),
 			Series:           item.SeriesTitle,
@@ -2226,6 +2230,7 @@ func (h *ItemsHandler) handleFavoriteItems(w http.ResponseWriter, r *http.Reques
 			listItems = append(listItems, mediaItemToListItem(mi))
 		}
 		presignCompatListItems(r.Context(), h.detailSvc, listItems)
+		fillListItemDurations(r.Context(), h.durationSrc, listItems)
 		h.rememberListImages(listItems)
 
 		progress, progressErr := resolveProgressForContentIDs(r.Context(), session, h.userData, contentIDsFromListItems(listItems))

--- a/internal/jellycompat/handlers_recommendations.go
+++ b/internal/jellycompat/handlers_recommendations.go
@@ -24,6 +24,7 @@ type recommendationDTO struct {
 type RecommendationsHandler struct {
 	recommender  recommendations.Recommender
 	itemRepo     *catalog.ItemRepository
+	detailSvc    *catalog.DetailService
 	content      ContentService
 	userData     UserDataService
 	codec        *ResourceIDCodec
@@ -35,6 +36,7 @@ type RecommendationsHandler struct {
 func NewRecommendationsHandler(
 	recommender recommendations.Recommender,
 	itemRepo *catalog.ItemRepository,
+	detailSvc *catalog.DetailService,
 	content ContentService,
 	userData UserDataService,
 	codec *ResourceIDCodec,
@@ -44,6 +46,7 @@ func NewRecommendationsHandler(
 	return &RecommendationsHandler{
 		recommender:  recommender,
 		itemRepo:     itemRepo,
+		detailSvc:    detailSvc,
 		content:      content,
 		userData:     userData,
 		codec:        codec,
@@ -117,6 +120,14 @@ func (h *RecommendationsHandler) HandleRecommendations(w http.ResponseWriter, r 
 	itemsByID := make(map[string]upstreamListItem, len(mediaItems))
 	for _, mi := range mediaItems {
 		itemsByID[mi.ContentID] = mediaItemToListItem(mi)
+	}
+	listItems := make([]upstreamListItem, 0, len(itemsByID))
+	for _, item := range itemsByID {
+		listItems = append(listItems, item)
+	}
+	fillListItemDurations(r.Context(), h.detailSvc, listItems)
+	for _, item := range listItems {
+		itemsByID[item.ContentID] = item
 	}
 
 	favorites, progress, err := resolveUserStateForContentIDs(r.Context(), session, h.userData, contentIDs)

--- a/internal/jellycompat/mapping.go
+++ b/internal/jellycompat/mapping.go
@@ -100,8 +100,8 @@ func (m *mapper) itemFromList(item upstreamListItem, isFavorite bool, progress *
 	if mt := jellyfinMediaType(item.Type); mt != "" {
 		dto.MediaType = mt
 	}
-	if item.Runtime > 0 {
-		dto.RunTimeTicks = minutesToTicks(item.Runtime)
+	if ticks := runtimeTicks(item.DurationSeconds, item.Runtime); ticks > 0 {
+		dto.RunTimeTicks = ticks
 	}
 	if item.Type == "movie" || item.Type == "episode" {
 		applyPlayableLocation(&dto, item.HasMediaFiles == nil || *item.HasMediaFiles)
@@ -482,7 +482,7 @@ func (m *mapper) episodeFromUpstream(ep upstreamEpisode, isFavorite bool, progre
 		Name:         ep.Title,
 		ServerID:     m.serverID,
 		Overview:     ep.Overview,
-		RunTimeTicks: minutesToTicks(ep.Runtime),
+		RunTimeTicks: runtimeTicks(ep.DurationSeconds, ep.Runtime),
 		ImageTags:    map[string]string{},
 		SeriesName:   ep.SeriesTitle,
 		UserData:     userDataDTO(m.codec.EncodeStringID(EncodedIDItem, ep.ContentID), ep.UserData, isFavorite, progress),
@@ -765,6 +765,20 @@ func minutesToTicks(minutes int) int64 {
 
 func secondsToTicks(seconds float64) int64 {
 	return int64(seconds * 10_000_000)
+}
+
+// runtimeTicks resolves RunTimeTicks probed-duration-first with the catalog
+// runtime as fallback, matching the v1 API's contentDurationSeconds. Returns
+// 0 when neither is known; RunTimeTicks is omitempty, so the field stays
+// absent rather than being emitted as a bogus 0.
+func runtimeTicks(durationSeconds, runtimeMinutes int) int64 {
+	if durationSeconds > 0 {
+		return secondsToTicks(float64(durationSeconds))
+	}
+	if runtimeMinutes > 0 {
+		return minutesToTicks(runtimeMinutes)
+	}
+	return 0
 }
 
 // clampResumeSeconds normalizes a stored resume position for client-facing

--- a/internal/jellycompat/probed_runtime.go
+++ b/internal/jellycompat/probed_runtime.go
@@ -1,0 +1,68 @@
+package jellycompat
+
+import (
+	"context"
+	"strings"
+)
+
+// probedDurationSource is the DetailService subset used to resolve probed
+// file durations. Declared as an interface so tests can substitute a
+// counting fake without standing up a Postgres pool.
+type probedDurationSource interface {
+	ProbedDurationsByContentIDs(ctx context.Context, ids []string) map[string]int
+	ProbedDurationsByEpisodeIDs(ctx context.Context, ids []string) map[string]int
+}
+
+// fillListItemDurations resolves movie and episode durations in separate
+// batches and mutates items in place.
+func fillListItemDurations(ctx context.Context, src probedDurationSource, items []upstreamListItem) {
+	if src == nil || len(items) == 0 {
+		return
+	}
+
+	movieIDs := make([]string, 0, len(items))
+	episodeIDs := make([]string, 0, len(items))
+	seenMovies := make(map[string]struct{}, len(items))
+	seenEpisodes := make(map[string]struct{}, len(items))
+	for _, item := range items {
+		switch {
+		case strings.EqualFold(item.Type, "movie"):
+			if item.ContentID != "" {
+				if _, ok := seenMovies[item.ContentID]; !ok {
+					seenMovies[item.ContentID] = struct{}{}
+					movieIDs = append(movieIDs, item.ContentID)
+				}
+			}
+		case strings.EqualFold(item.Type, "episode"):
+			if item.ContentID != "" {
+				if _, ok := seenEpisodes[item.ContentID]; !ok {
+					seenEpisodes[item.ContentID] = struct{}{}
+					episodeIDs = append(episodeIDs, item.ContentID)
+				}
+			}
+		}
+	}
+
+	var movieDurations, episodeDurations map[string]int
+	if len(movieIDs) > 0 {
+		movieDurations = src.ProbedDurationsByContentIDs(ctx, movieIDs)
+	}
+	if len(episodeIDs) > 0 {
+		episodeDurations = src.ProbedDurationsByEpisodeIDs(ctx, episodeIDs)
+	}
+	// Only a positive lookup overwrites the field: an absent id, or a nil map
+	// from a failed query, must leave an already-resolved duration intact
+	// rather than silently zeroing it back to "unknown".
+	for i := range items {
+		switch {
+		case strings.EqualFold(items[i].Type, "movie"):
+			if duration := movieDurations[items[i].ContentID]; duration > 0 {
+				items[i].DurationSeconds = duration
+			}
+		case strings.EqualFold(items[i].Type, "episode"):
+			if duration := episodeDurations[items[i].ContentID]; duration > 0 {
+				items[i].DurationSeconds = duration
+			}
+		}
+	}
+}

--- a/internal/jellycompat/probed_runtime.go
+++ b/internal/jellycompat/probed_runtime.go
@@ -66,3 +66,23 @@ func fillListItemDurations(ctx context.Context, src probedDurationSource, items 
 		}
 	}
 }
+
+// fillEpisodeTargetDurations resolves durations when a caller builds its DTOs
+// directly from compat episode targets. Overlay-only callers already have an
+// enriched list item and must not pay for the same lookup again.
+func fillEpisodeTargetDurations(ctx context.Context, src probedDurationSource, targets map[string]compatEpisodeTarget) {
+	if len(targets) == 0 {
+		return
+	}
+
+	items := make([]upstreamListItem, 0, len(targets))
+	for _, target := range targets {
+		items = append(items, target.Item)
+	}
+	fillListItemDurations(ctx, src, items)
+	for _, item := range items {
+		target := targets[item.ContentID]
+		target.Item = item
+		targets[item.ContentID] = target
+	}
+}

--- a/internal/jellycompat/probed_runtime_test.go
+++ b/internal/jellycompat/probed_runtime_test.go
@@ -1,0 +1,226 @@
+package jellycompat
+
+import (
+	"context"
+	"encoding/json"
+	"reflect"
+	"testing"
+	"time"
+
+	"github.com/Silo-Server/silo-server/internal/config"
+	"github.com/Silo-Server/silo-server/internal/models"
+)
+
+func TestRuntimeTicks(t *testing.T) {
+	tests := []struct {
+		name            string
+		durationSeconds int
+		runtimeMinutes  int
+		want            int64
+	}{
+		{name: "probe only", durationSeconds: 3600, want: secondsToTicks(3600)},
+		{name: "runtime only", runtimeMinutes: 60, want: minutesToTicks(60)},
+		{name: "neither", want: 0},
+		{name: "probe wins", durationSeconds: 120, runtimeMinutes: 90, want: secondsToTicks(120)},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := runtimeTicks(tt.durationSeconds, tt.runtimeMinutes); got != tt.want {
+				t.Fatalf("runtimeTicks(%d, %d) = %d, want %d", tt.durationSeconds, tt.runtimeMinutes, got, tt.want)
+			}
+		})
+	}
+
+	if secondsToTicks(3600) != minutesToTicks(60) {
+		t.Fatalf("unit mismatch: 3600 seconds = %d ticks, 60 minutes = %d ticks", secondsToTicks(3600), minutesToTicks(60))
+	}
+}
+
+func TestItemFromListRuntimeResolution(t *testing.T) {
+	m := newMapper(NewResourceIDCodec(), &config.Config{})
+	dto := m.itemFromList(upstreamListItem{
+		ContentID:       "movie-1",
+		Type:            "movie",
+		Title:           "Movie",
+		DurationSeconds: 5400,
+	}, false, nil, nil)
+	if dto.RunTimeTicks != secondsToTicks(5400) {
+		t.Fatalf("RunTimeTicks = %d, want %d", dto.RunTimeTicks, secondsToTicks(5400))
+	}
+
+	unknown := m.itemFromList(upstreamListItem{ContentID: "movie-2", Type: "movie", Title: "Unknown"}, false, nil, nil)
+	raw, err := json.Marshal(unknown)
+	if err != nil {
+		t.Fatalf("marshal dto: %v", err)
+	}
+	var fields map[string]json.RawMessage
+	if err := json.Unmarshal(raw, &fields); err != nil {
+		t.Fatalf("unmarshal dto: %v", err)
+	}
+	if _, ok := fields["RunTimeTicks"]; ok {
+		t.Fatalf("RunTimeTicks should be absent when neither duration is known: %s", raw)
+	}
+}
+
+func TestEpisodeFromUpstreamRuntimeResolution(t *testing.T) {
+	m := newMapper(NewResourceIDCodec(), &config.Config{})
+	tests := []struct {
+		name            string
+		durationSeconds int
+		runtimeMinutes  int
+		want            int64
+	}{
+		{name: "probe only", durationSeconds: 1800, want: secondsToTicks(1800)},
+		{name: "runtime only", runtimeMinutes: 30, want: minutesToTicks(30)},
+		{name: "neither", want: 0},
+		{name: "probe wins", durationSeconds: 1800, runtimeMinutes: 45, want: secondsToTicks(1800)},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			dto := m.episodeFromUpstream(upstreamEpisode{
+				ContentID:       "episode-1",
+				Title:           "Episode",
+				Runtime:         tt.runtimeMinutes,
+				DurationSeconds: tt.durationSeconds,
+			}, false, nil)
+			if dto.RunTimeTicks != tt.want {
+				t.Fatalf("RunTimeTicks = %d, want %d", dto.RunTimeTicks, tt.want)
+			}
+		})
+	}
+}
+
+type countingProbedDurationSource struct {
+	contentCalls int
+	episodeCalls int
+	contentIDs   []string
+	episodeIDs   []string
+	content      map[string]int
+	episodes     map[string]int
+}
+
+func (s *countingProbedDurationSource) ProbedDurationsByContentIDs(_ context.Context, ids []string) map[string]int {
+	s.contentCalls++
+	s.contentIDs = append([]string(nil), ids...)
+	return s.content
+}
+
+func (s *countingProbedDurationSource) ProbedDurationsByEpisodeIDs(_ context.Context, ids []string) map[string]int {
+	s.episodeCalls++
+	s.episodeIDs = append([]string(nil), ids...)
+	return s.episodes
+}
+
+func TestFillListItemDurationsBucketsAndDeduplicates(t *testing.T) {
+	src := &countingProbedDurationSource{
+		content:  map[string]int{"movie-1": 600},
+		episodes: map[string]int{"episode-1": 1200},
+	}
+	items := []upstreamListItem{
+		{ContentID: "movie-1", Type: "movie"},
+		{ContentID: "movie-1", Type: "MOVIE"},
+		{ContentID: "episode-1", Type: "episode"},
+		{ContentID: "episode-1", Type: "Episode"},
+		{ContentID: "series-1", Type: "series"},
+		{ContentID: "season-1", Type: "season"},
+	}
+
+	fillListItemDurations(context.Background(), src, items)
+
+	if src.contentCalls != 1 || !reflect.DeepEqual(src.contentIDs, []string{"movie-1"}) {
+		t.Fatalf("content calls/ids = %d/%v, want 1/[movie-1]", src.contentCalls, src.contentIDs)
+	}
+	if src.episodeCalls != 1 || !reflect.DeepEqual(src.episodeIDs, []string{"episode-1"}) {
+		t.Fatalf("episode calls/ids = %d/%v, want 1/[episode-1]", src.episodeCalls, src.episodeIDs)
+	}
+	if items[0].DurationSeconds != 600 || items[1].DurationSeconds != 600 {
+		t.Fatalf("movie durations = %d/%d, want 600/600", items[0].DurationSeconds, items[1].DurationSeconds)
+	}
+	if items[2].DurationSeconds != 1200 || items[3].DurationSeconds != 1200 {
+		t.Fatalf("episode durations = %d/%d, want 1200/1200", items[2].DurationSeconds, items[3].DurationSeconds)
+	}
+	if items[4].DurationSeconds != 0 || items[5].DurationSeconds != 0 {
+		t.Fatalf("non-playable durations changed: %d/%d", items[4].DurationSeconds, items[5].DurationSeconds)
+	}
+}
+
+func TestFillListItemDurationsSkipsEmptyBucketsAndNilSource(t *testing.T) {
+	src := &countingProbedDurationSource{content: nil}
+	items := []upstreamListItem{{ContentID: "movie-1", Type: "movie", Runtime: 90}}
+	fillListItemDurations(context.Background(), src, items)
+	if src.contentCalls != 1 || src.episodeCalls != 0 {
+		t.Fatalf("content/episode calls = %d/%d, want 1/0", src.contentCalls, src.episodeCalls)
+	}
+	if items[0].DurationSeconds != 0 {
+		t.Fatalf("DurationSeconds = %d, want 0 after nil result", items[0].DurationSeconds)
+	}
+	dto := newMapper(NewResourceIDCodec(), &config.Config{}).itemFromList(items[0], false, nil, nil)
+	if dto.RunTimeTicks != minutesToTicks(90) {
+		t.Fatalf("nil probe result did not fall back to catalog runtime: %d", dto.RunTimeTicks)
+	}
+
+	before := append([]upstreamListItem(nil), items...)
+	fillListItemDurations(context.Background(), nil, items)
+	if !reflect.DeepEqual(items, before) {
+		t.Fatalf("nil source mutated items: got %+v, want %+v", items, before)
+	}
+}
+
+// A failed lookup returns a nil map. That must not wipe a duration an earlier
+// producer already resolved, otherwise a transient DB error would downgrade an
+// item that was already correct.
+func TestFillListItemDurationsKeepsResolvedDurationOnEmptyResult(t *testing.T) {
+	src := &countingProbedDurationSource{content: nil, episodes: nil}
+	items := []upstreamListItem{
+		{ContentID: "movie-1", Type: "movie", DurationSeconds: 5400},
+		{ContentID: "episode-1", Type: "episode", DurationSeconds: 1500},
+	}
+
+	fillListItemDurations(context.Background(), src, items)
+
+	if items[0].DurationSeconds != 5400 || items[1].DurationSeconds != 1500 {
+		t.Fatalf("durations = %d/%d, want 5400/1500 preserved", items[0].DurationSeconds, items[1].DurationSeconds)
+	}
+}
+
+func TestWriteEpisodeModelsPageUsesProbedTargetDuration(t *testing.T) {
+	codec := NewResourceIDCodec()
+	seriesID := "series-1"
+	seasonID := "season-1"
+	episodeID := "episode-1"
+	episodeRepo := &fakeSeasonEpisodeRepo{bySeason: map[string][]*models.Episode{
+		episodeBySeasonKey(seriesID, 1): {
+			{
+				ContentID:     episodeID,
+				SeriesID:      seriesID,
+				SeasonID:      seasonID,
+				SeasonNumber:  1,
+				EpisodeNumber: 1,
+				Title:         "Episode",
+				Runtime:       0,
+			},
+		},
+	}}
+	itemRepo := &countingItemRepo{itemsByID: map[string]*models.MediaItem{
+		seriesID: {ContentID: seriesID, Type: "series", Title: "Series"},
+	}}
+	durationSrc := &countingProbedDurationSource{episodes: map[string]int{episodeID: 1500}}
+	h := &ItemsHandler{
+		content:     &countingContentService{seasons: []upstreamSeason{{ContentID: seasonID, SeasonNumber: 1, Title: "Season 1", EpisodeCount: 1}}},
+		userData:    &mockUserDataService{},
+		codec:       codec,
+		mapper:      newMapper(codec, &config.Config{}),
+		images:      NewImageCache(time.Hour, time.Now),
+		itemRepo:    itemRepo,
+		episodeRepo: episodeRepo,
+		durationSrc: durationSrc,
+	}
+
+	result := performEpisodesRequest(t, h, "/Shows/"+codec.EncodeStringID(EncodedIDItem, seriesID)+"/Episodes", codec.EncodeStringID(EncodedIDItem, seriesID))
+	if len(result.Items) != 1 {
+		t.Fatalf("len(Items) = %d, want 1", len(result.Items))
+	}
+	if result.Items[0].RunTimeTicks != secondsToTicks(1500) {
+		t.Fatalf("RunTimeTicks = %d, want %d", result.Items[0].RunTimeTicks, secondsToTicks(1500))
+	}
+}

--- a/internal/jellycompat/router.go
+++ b/internal/jellycompat/router.go
@@ -131,7 +131,7 @@ func NewRouter(deps Dependencies) chi.Router {
 	imagesHandler.collections = itemsHandler.collections
 	imagesHandler.frontendFS = deps.FrontendFS
 	displayPrefsHandler := NewDisplayPreferencesHandler(deps.UserStoreProvider)
-	recsHandler := NewRecommendationsHandler(deps.Recommender, deps.ItemRepo, deps.ContentService, deps.UserDataService, deps.IDCodec, deps.Config, deps.AccessFilterFn)
+	recsHandler := NewRecommendationsHandler(deps.Recommender, deps.ItemRepo, deps.DetailSvc, deps.ContentService, deps.UserDataService, deps.IDCodec, deps.Config, deps.AccessFilterFn)
 
 	r.Get("/System/Info/Public", systemHandler.HandlePublicInfo)
 	r.Get("/System/Info", systemHandler.HandleInfo)

--- a/internal/jellycompat/upstream_types.go
+++ b/internal/jellycompat/upstream_types.go
@@ -55,6 +55,10 @@ type upstreamListItem struct {
 	Tagline           string                  `json:"tagline,omitempty"`
 	RatingTMDB        *float64                `json:"rating_tmdb,omitempty"`
 	UserData          *catalog.SeasonUserData `json:"user_data,omitempty"`
+	// DurationSeconds is the probed duration of the backing media file, 0 when
+	// unknown. Read-time only -- never persisted onto the item row, because one
+	// item can have several versions of different lengths.
+	DurationSeconds int `json:"-"`
 	// HasMediaFiles reports whether at least one live media file backs this
 	// item. nil means unknown (the producing query did not check); the mapper
 	// then keeps the historical LocationType=FileSystem default.
@@ -150,6 +154,10 @@ type upstreamEpisode struct {
 	SeriesID       string                  `json:"series_id,omitempty"`
 	SeriesTitle    string                  `json:"series_title,omitempty"`
 	SeasonID       string                  `json:"season_id,omitempty"`
+	// DurationSeconds is the probed duration of the backing media file, 0 when
+	// unknown. Read-time only -- never persisted onto the item row, because one
+	// item can have several versions of different lengths.
+	DurationSeconds int `json:"-"`
 	// HasMediaFiles reports whether at least one live media file backs this
 	// episode. nil means unknown; the mapper then keeps the historical
 	// LocationType=FileSystem default.

--- a/internal/jellycompat/userdata_direct.go
+++ b/internal/jellycompat/userdata_direct.go
@@ -99,6 +99,7 @@ func (s *directUserDataService) ListFavorites(ctx context.Context, session *Sess
 	// type into one PresignImageURLsWithExpiry call for the whole page.
 	result := slicePage(ordered, offset, limit)
 	presignCompatListItems(ctx, s.detailSvc, result)
+	fillListItemDurations(ctx, s.detailSvc, result)
 	if result == nil {
 		result = []upstreamListItem{}
 	}

--- a/internal/scanner/file_repo.go
+++ b/internal/scanner/file_repo.go
@@ -2926,6 +2926,44 @@ func (r *FileRepository) GetByContentID(ctx context.Context, contentID string) (
 	return scanMediaFiles(rows)
 }
 
+// FirstDurationsByContentIDs returns the probed duration (seconds) of the
+// first live file backing each content id, using the same "first file with
+// duration > 0, ordered by id" rule as the v1 API's contentDurationSeconds.
+// Ids with no live probed file are absent from the map. Resolution is
+// intentionally not access-scoped; callers have already filtered the items.
+func (r *FileRepository) FirstDurationsByContentIDs(ctx context.Context, contentIDs []string) (map[string]int, error) {
+	result := make(map[string]int)
+	if len(contentIDs) == 0 {
+		return result, nil
+	}
+
+	rows, err := r.pool.Query(ctx, `
+		SELECT DISTINCT ON (content_id) content_id, duration
+		FROM media_files
+		WHERE content_id = ANY($1)
+		  AND episode_id IS NULL
+		  AND missing_since IS NULL
+		  AND duration > 0
+		ORDER BY content_id, id ASC`, contentIDs)
+	if err != nil {
+		return nil, fmt.Errorf("querying first durations by content ids: %w", err)
+	}
+	defer rows.Close()
+
+	for rows.Next() {
+		var contentID string
+		var duration int
+		if err := rows.Scan(&contentID, &duration); err != nil {
+			return nil, fmt.Errorf("scanning first duration by content id: %w", err)
+		}
+		result[contentID] = duration
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("iterating first durations by content ids: %w", err)
+	}
+	return result, nil
+}
+
 // GetByExtraID returns the live files backing a local extra
 // (media_extras.content_id). Extras files carry no content_id/episode_id, so
 // this is their only ownership lookup.
@@ -3537,6 +3575,43 @@ func (r *FileRepository) GetByEpisodeID(ctx context.Context, episodeID string) (
 	defer rows.Close()
 
 	return scanMediaFiles(rows)
+}
+
+// FirstDurationsByEpisodeIDs returns the probed duration (seconds) of the
+// first live file backing each episode id, using the same "first file with
+// duration > 0, ordered by id" rule as the v1 API's contentDurationSeconds.
+// Ids with no live probed file are absent from the map. Resolution is
+// intentionally not access-scoped; callers have already filtered the items.
+func (r *FileRepository) FirstDurationsByEpisodeIDs(ctx context.Context, episodeIDs []string) (map[string]int, error) {
+	result := make(map[string]int)
+	if len(episodeIDs) == 0 {
+		return result, nil
+	}
+
+	rows, err := r.pool.Query(ctx, `
+		SELECT DISTINCT ON (episode_id) episode_id, duration
+		FROM media_files
+		WHERE episode_id = ANY($1)
+		  AND missing_since IS NULL
+		  AND duration > 0
+		ORDER BY episode_id, id ASC`, episodeIDs)
+	if err != nil {
+		return nil, fmt.Errorf("querying first durations by episode ids: %w", err)
+	}
+	defer rows.Close()
+
+	for rows.Next() {
+		var episodeID string
+		var duration int
+		if err := rows.Scan(&episodeID, &duration); err != nil {
+			return nil, fmt.Errorf("scanning first duration by episode id: %w", err)
+		}
+		result[episodeID] = duration
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("iterating first durations by episode ids: %w", err)
+	}
+	return result, nil
 }
 
 // ListMissingChapterThumbnails returns present media files in enabled,

--- a/internal/scanner/file_repo_duration_test.go
+++ b/internal/scanner/file_repo_duration_test.go
@@ -1,0 +1,117 @@
+package scanner
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"reflect"
+	"testing"
+	"time"
+
+	"github.com/jackc/pgx/v5/pgxpool"
+)
+
+func TestFirstDurationsByIDs(t *testing.T) {
+	dsn := os.Getenv("SILO_TEST_DATABASE_URL")
+	if dsn == "" {
+		t.Skip("SILO_TEST_DATABASE_URL is not set")
+	}
+
+	ctx := context.Background()
+	pool, err := pgxpool.New(ctx, dsn)
+	if err != nil {
+		t.Fatalf("connect test database: %v", err)
+	}
+	t.Cleanup(pool.Close)
+
+	suffix := time.Now().UnixNano()
+	movieID := fmt.Sprintf("duration-movie-%d", suffix)
+	seriesID := fmt.Sprintf("duration-series-%d", suffix)
+	episodeOneID := fmt.Sprintf("duration-episode-one-%d", suffix)
+	episodeTwoID := fmt.Sprintf("duration-episode-two-%d", suffix)
+
+	var folderID int
+	if err := pool.QueryRow(ctx, `
+		INSERT INTO media_folders (type, name, enabled)
+		VALUES ('mixed', 'Duration Lookup Test', true)
+		RETURNING id
+	`).Scan(&folderID); err != nil {
+		t.Fatalf("seed folder: %v", err)
+	}
+	t.Cleanup(func() {
+		_, _ = pool.Exec(ctx, `DELETE FROM media_files WHERE media_folder_id = $1`, folderID)
+		_, _ = pool.Exec(ctx, `DELETE FROM media_items WHERE content_id = ANY($1)`, []string{movieID, seriesID})
+		_, _ = pool.Exec(ctx, `DELETE FROM media_folders WHERE id = $1`, folderID)
+	})
+
+	if _, err := pool.Exec(ctx, `
+		INSERT INTO media_items (content_id, type, title, status, genres)
+		VALUES
+			($1, 'movie', 'Duration Movie', 'matched', '{}'::text[]),
+			($2, 'series', 'Duration Series', 'matched', '{}'::text[])
+	`, movieID, seriesID); err != nil {
+		t.Fatalf("seed items: %v", err)
+	}
+	if _, err := pool.Exec(ctx, `
+		INSERT INTO episodes (content_id, series_id, season_number, episode_number, title)
+		VALUES
+			($1, $3, 1, 1, 'Episode One'),
+			($2, $3, 1, 2, 'Episode Two')
+	`, episodeOneID, episodeTwoID, seriesID); err != nil {
+		t.Fatalf("seed episodes: %v", err)
+	}
+
+	fileNumber := 0
+	seedFile := func(contentID, episodeID string, duration int, missing bool) {
+		t.Helper()
+		fileNumber++
+		var episodeValue any
+		if episodeID != "" {
+			episodeValue = episodeID
+		}
+		if _, err := pool.Exec(ctx, `
+			INSERT INTO media_files (
+				content_id, episode_id, media_folder_id, file_path, file_size,
+				duration, missing_since
+			) VALUES ($1, $2, $3, $4, 1024, $5,
+				CASE WHEN $6 THEN NOW() ELSE NULL END)
+		`, contentID, episodeValue, folderID,
+			fmt.Sprintf("/tmp/duration-lookup-%d-%d.mkv", suffix, fileNumber),
+			duration, missing,
+		); err != nil {
+			t.Fatalf("seed file %d: %v", fileNumber, err)
+		}
+	}
+
+	// Content lookup: skip missing and zero-duration files, then choose the
+	// first positive live file by id.
+	seedFile(movieID, "", 900, true)
+	seedFile(movieID, "", 0, false)
+	seedFile(movieID, "", 120, false)
+	seedFile(movieID, "", 240, false)
+	// Episode files share the parent series content_id and must never make the
+	// series appear to have a directly-backed duration. The episode lookup
+	// independently follows the same live/positive/first-id rule.
+	seedFile(seriesID, episodeOneID, 800, true)
+	seedFile(seriesID, episodeOneID, 0, false)
+	seedFile(seriesID, episodeOneID, 300, false)
+	seedFile(seriesID, episodeOneID, 600, false)
+	seedFile(seriesID, episodeTwoID, 0, false)
+
+	repo := NewFileRepository(pool)
+	contentDurations, err := repo.FirstDurationsByContentIDs(ctx, []string{movieID, seriesID})
+	if err != nil {
+		t.Fatalf("FirstDurationsByContentIDs: %v", err)
+	}
+	if want := map[string]int{movieID: 120}; !reflect.DeepEqual(contentDurations, want) {
+		t.Fatalf("content durations = %v, want %v", contentDurations, want)
+	}
+
+	episodeDurations, err := repo.FirstDurationsByEpisodeIDs(ctx, []string{episodeOneID, episodeTwoID})
+	if err != nil {
+		t.Fatalf("FirstDurationsByEpisodeIDs: %v", err)
+	}
+	if want := map[string]int{episodeOneID: 300}; !reflect.DeepEqual(episodeDurations, want) {
+		t.Fatalf("episode durations = %v, want %v", episodeDurations, want)
+	}
+}


### PR DESCRIPTION
Closes #492.

## Problem

**Movies with no runtime never start playing in Infuse.** On the production deployment 5,245
movies have a catalog runtime of 0, because no metadata provider ever supplied one. The Jellyfin
compatibility API omits the runtime field entirely for those items rather than sending a zero,
and Jellyfin-protocol clients treat a title with no duration as unplayable — Infuse either
refuses to start or abandons the stream immediately.

The files are fine. 5,239 of those 5,245 movies have a correct duration probed from the file
itself. Silo's own clients play them without trouble, because the native API resolves duration
from the file and only falls back to the catalog runtime. Only the Jellyfin surface was reading
the catalog runtime alone.

This is not an unmatched-item problem — 4,326 of the affected movies are fully matched to a
metadata provider and simply have no runtime in that provider's data.

Measured over a 16-day window of Infuse/Jellyfin movie sessions (series excluded, since a series'
runtime is legitimately 0 and its episodes carry it), holding the content-id form constant:
movies with a runtime reached playback 49.9% of the time (n=385), movies without one 11.1%
(n=18). A 4.5x drop attributable to runtime alone.

The same gap affected episode listings, search results, Continue Watching, Next Up, recommendations,
and favourites — every Jellyfin surface that lists items rather than opening one.

## Solution

### fix(jellycompat): resolve item duration probed-first with runtime fallback

Duration is now resolved at read time the way `/api/v1` already does it — probed file duration
first, catalog runtime as the fallback. `media_items.runtime` is deliberately **not** backfilled:
one item can have several versions of different lengths, so per-file data does not belong on the
item row.

The reason this is not a one-line mapper change is that the compat *list* path never had duration
data at all. `upstreamListItem` carried only `Runtime int` (minutes, from `media_items`); the
probed duration lives in `media_files`, and nothing in that path queried that table. Most of the
diff is getting the value into the list path. The preference logic itself is eight lines.

**Batched lookups** — `FirstDurationsByContentIDs` and `FirstDurationsByEpisodeIDs` in
`internal/scanner/file_repo.go:2929` and `:3585`. Both use the same rule as v1's
`contentDurationSeconds` (`internal/api/handlers/items.go:1957`): the first live file with
`duration > 0`, ordered by `id`. Expressed as `DISTINCT ON (key) … ORDER BY key, id ASC`, so it is
one query per page rather than v1's per-item fetch.

The `episode_id IS NULL` predicate on the content-id query is load-bearing: every episode file row
carries its parent *series* `content_id` (all 1,159,756 of them on production), so without it a
series card would report a random episode's duration.

**Catalog accessor** — `internal/catalog/detail.go:98` adds an optional `batchDurationFetcher`
extension resolved by type assertion, following the existing `extraFileFetcher` pattern at
`detail.go:33`. Being optional means no existing `FileVersionFetcher` test fake needed changing.
The methods are nil-receiver safe, which matters because callers pass a possibly-nil
`*catalog.DetailService` into an interface parameter and that yields a non-nil interface.

**Shared resolver** — `runtimeTicks` at `internal/jellycompat/mapping.go:767`. Returns 0 when
neither source is known so `omitempty` keeps the field absent rather than emitting a bogus zero.
`minutesToTicks` takes minutes and `secondsToTicks` takes seconds; mixing them is a silent 60x
error, so the tests assert `secondsToTicks(3600) == minutesToTicks(60)`.

Wired into the three sites that had no fallback: `itemFromList` (`mapping.go:103`),
`episodeFromUpstream` (`mapping.go:485`), and `HandleSearchHints`
(`internal/jellycompat/handlers_items.go:2065`). Fixing `itemFromList` also fixes the stub media
source at `mapping.go:269`, which mirrors the DTO's value. The detail and PlaybackInfo paths
(`mapping.go:391`, `handlers_playback.go:839`) were already correct and are untouched.

**Page-level enrichment** — `internal/jellycompat/probed_runtime.go` buckets a page into movies
(keyed by content id) and episodes (keyed by episode id — for an episode list item the ContentID
*is* the episode id), skips an empty bucket without querying, de-duplicates ids, and never lets a
series or season reach the content-id lookup. Only a positive result overwrites the field, so a
failed query cannot silently downgrade an already-resolved duration.

It is called from the nine functions that produce a page of items. There is no single choke point
in this package — browse, search, favourites, recommendations and four batch loaders each build
pages from their own source. Seven of the nine already call the analogous `presignCompatListItems`,
so this follows an established set. `BrowseItems` fills once on the trimmed page
(`content_direct.go:509`) rather than per over-fetch chunk.

Lookups are fail-soft: a query error logs and degrades to the catalog runtime rather than failing
the page. A list response should not 500 because a runtime hint could not be resolved.

This is additive under the v1 rules — it populates a field that was previously omitted. No field is
renamed, removed, retyped, or repurposed.

## Risk / follow-ups

- Runtime resolution is deliberately not access-scoped. `/api/v1`'s `contentDurationSeconds` is
  equally unscoped, so this preserves parity rather than introducing a third rule, and the item has
  already passed access filtering before it reaches the enricher. For a multi-version item spanning
  libraries the reported duration could come from a version the viewer cannot play. Only a duration
  integer is exposed, never a path or a stream.
- The list path picks the first file by id; the detail path picks a quality-sorted `Versions[0]`
  (`mapping.go:391`). For an item with editions of genuinely different lengths (theatrical vs
  extended) list and detail can disagree. That divergence predates this change — worth unifying
  separately, but out of scope here.
- Stacked multi-part movies report the first part's duration rather than the sum. Identical to what
  the detail path already does, so not a regression.
- Adds one indexed query per populated type bucket per page. Measured on production: 4.0 ms for 100
  movie ids, 1.1 ms for 50 episode ids. A mixed browse page can reach three duration queries because
  the episode-target overlay re-resolves episodes already covered by the browse page. Accepted;
  collapsing it would mean threading state between the two loaders.
- Scope of the claim: this fixes runtime resolution, not every Infuse playback failure.
  Locally-identified items sit at 0.0% success (0 of 57) versus 11.1% for provider-prefixed
  zero-runtime items, so something additional affects them. That gap is not addressed here and
  warrants its own issue.
- `upstreamEpisodeFile` (`upstream_types.go:126`) is dead — never constructed outside tests, and
  `upstreamEpisode.Files` is never populated. Left alone here; a candidate for removal.

## Verification

- `go test ./internal/jellycompat/... ./internal/catalog/... ./internal/scanner/...` — `catalog`,
  `catalog/reattribute` and `scanner` pass. `jellycompat` reports 3 failures, all
  `TestAutoscanMediaUpdated*`, which fail identically on a stashed clean tree and are unrelated to
  this change. `internal/api/...` likewise fails only on the pre-existing
  `TestHandleReplanPlaybackV3SeekFailureRecoveryNeverChangesMediaVersion`.
- 8 new tests in `internal/jellycompat/probed_runtime_test.go`, all passing: the resolver matrix,
  the seconds/minutes unit equivalence, `RunTimeTicks` absent from marshalled JSON when neither
  source is known, movie/episode bucketing with series and seasons excluded, id de-duplication,
  empty buckets issuing no query, nil source and nil result handled, a resolved duration surviving an
  empty result, and an endpoint-level test through `writeEpisodeModelsPage`.
- `go vet ./internal/jellycompat/... ./internal/catalog/... ./internal/scanner/...` — clean.
  `gofmt -l` clean for every changed file. `go build ./cmd/silo` passes.
- `make lint` — golangci-lint reports 306 issues repo-wide, all pre-existing. Exactly one falls in a
  file this branch touches (`mapping.go:808: func backdropTags is unused`) and it is present on the
  clean tree too. Note the target fails outright on a stock shell because `golangci-lint` lives in
  `~/go/bin`, which is not on the default PATH.
- `make verify-local-paths` — passes, exit 0.
- Web lint and format checks were not run: `pnpm` is not installed on this host, and this branch
  changes no files under `web/`.
- Live-deployment verification against production Postgres: 5,245 movies have `runtime = 0` and
  5,239 of them resolve a real duration under the new query. `EXPLAIN (ANALYZE, BUFFERS)` confirms a
  single `Index Scan using idx_media_files_unlinked` with `Index Cond: (content_id = ANY (...))` —
  no bitmap-OR fallback, 4.0 ms for 100 ids. The episode query plans as a single
  `Index Scan using idx_media_files_episode`, 1.1 ms for 50 ids.

### AI Disclosure
- Tool(s): Claude Code, Codex CLI
- Model(s): claude-opus-5, gpt-5.6-sol
- Involvement: AI-assisted
- Adversarial review: the plan was reviewed by gpt-5.6-sol before implementation and the diff was
  reviewed again afterwards. The pre-implementation review caught three real defects, all verified
  against the code and fixed before any of it was written: the original plan aggregated with
  `MAX(duration)`, which matched neither v1 nor the detail path; it would have left the main episode
  listing broken, because `writeEpisodeModelsPage` copies only three fields off the episode target
  and would have dropped the new one; and it wired enrichment into `ListEpisodes`, a path that
  flattens back to `models.Episode` and discards the field. A separate review of the committed diff
  found three more issues, all fixed before this PR: adding duration to `itemEtag` made the same
  item hash differently from the list and detail endpoints (reverted); the `episode_id = ''` half of
  a defensive predicate forced a bitmap-OR whose second branch was not constrained by content id,
  confirmed by `EXPLAIN` on production and by the column having zero empty-string rows (dropped); and
  the enricher zeroed the duration field unconditionally, so a failed query could undo an already
  resolved value (now only a positive result writes). The final adversarial pass over the branch
  found no defects. All measurements quoted above are real command output, not synthesized.

## Maintainer remediation (2026-07-28)

Commit `b11e3989` resolves the final review concerns. Episode metadata overlay paths no longer issue a second duration lookup after list-item enrichment; DTO-producing episode paths explicitly opt into duration enrichment. It also adds a PostgreSQL-backed contract test for live, positive, first-by-ID selection and content/episode separation. This supersedes the Risk / follow-ups note above that the episode-target overlay intentionally re-resolves episodes.

### Maintainer AI disclosure

- Tool(s): Codex via T3 Code
- Model(s): `gpt-5.6-sol`
- Involvement: AI-assisted
- Adversarial review: independent Standards and Spec agents reviewed the final diff; neither found actionable issues.
- Verification: `go test ./internal/jellycompat -run 'Duration|EpisodeModelsPage'`; `go test ./internal/catalog/... ./internal/scanner/...`; the database-backed `TestFirstDurationsByIDs` against the configured dev PostgreSQL; focused `go test -race`; focused `go vet`; `go build ./cmd/silo`; formatting, `git diff --check`, and `make verify-local-paths` all passed.
- Runtime verification: on the configured dev backend, `/Search/Hints` for “Borat VHS Cassette” returned `RunTimeTicks = 14480000000`, matching the probed duration of 1,448 seconds. Readiness passed and recent logs showed no new panic or error loop.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved media duration accuracy across browsing, search, recommendations, favorites, playback progress, and episode listings.
  * Probed file durations now take precedence when available, with existing runtime information used as a fallback.
  * Episode pages and search hints now reflect more reliable runtime values.

* **Tests**
  * Added coverage for duration resolution, duplicate handling, missing data, and episode display scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->