### PR TITLE
feat(admin): identify compat sessions and Android devices in the live session view

### DIFF
--- a/cmd/silo/session_sync.go
+++ b/cmd/silo/session_sync.go
@@ -40,5 +40,6 @@ func buildLiveSessionSync(s *playback.Session, reportingNode string) worker.Sess
 		PositionSeconds:      s.Position,
 		IsPaused:             s.IsPaused,
 		HasWebSocket:         s.HasWebSocket,
+		IsJellyfinCompat:     s.IsJellyfinCompat,
 	}
 }

--- a/internal/api/handlers/playback_sessions.go
+++ b/internal/api/handlers/playback_sessions.go
@@ -496,10 +496,6 @@ func playbackClientDisplayName(name, version, userAgent string) string {
 		return rule.label
 	}
 
-	if label := androidDeviceLabel(userAgent); label != "" {
-		return label
-	}
-
 	switch {
 	case strings.Contains(lower, "applecoremedia"):
 		return "Apple player"
@@ -514,6 +510,9 @@ func playbackClientDisplayName(name, version, userAgent string) string {
 	case strings.Contains(lower, "python-requests"):
 		return "Python requests"
 	default:
+		if label := androidDeviceLabel(userAgent); label != "" {
+			return label
+		}
 		return firstUserAgentProduct(userAgent)
 	}
 }
@@ -525,9 +524,10 @@ func playbackClientDisplayName(name, version, userAgent string) string {
 var knownAndroidDeviceLabels = map[string]string{
 	"AFTKRT":            "Fire TV Stick 4K Max",
 	"AFTMM":             "Fire TV Stick 4K",
-	"AFTKM":             "Fire TV Stick 4K Max (1st Gen)",
-	"AFTKA":             "Fire TV Stick 4K Max (2nd Gen)",
-	"AFTSS":             "Fire TV Stick (3rd Gen)",
+	"AFTKM":             "Fire TV Stick 4K (2nd Gen)",
+	"AFTKA":             "Fire TV Stick 4K Max (1st Gen)",
+	"AFTSSS":            "Fire TV Stick (3rd Gen)",
+	"AFTSS":             "Fire TV Stick Lite (1st Gen)",
 	"AFTT":              "Fire TV Stick (2nd Gen)",
 	"AFTB":              "Fire TV (1st Gen)",
 	"AFTS":              "Fire TV (2nd Gen)",
@@ -549,10 +549,24 @@ func androidDeviceLabel(userAgent string) string {
 		return ""
 	}
 
-	model := strings.TrimSpace(userAgent[:buildIndex])
-	if separator := strings.LastIndex(model, ";"); separator >= 0 {
-		model = model[separator+1:]
+	prefix := userAgent[:buildIndex]
+	separator := strings.LastIndex(prefix, ";")
+	if separator < 0 {
+		return ""
 	}
+	hasAndroidPlatform := false
+	for _, segment := range strings.Split(prefix[:separator], ";") {
+		segment = strings.TrimSpace(strings.Trim(segment, "()"))
+		if strings.HasPrefix(strings.ToLower(segment), "android ") {
+			hasAndroidPlatform = true
+			break
+		}
+	}
+	if !hasAndroidPlatform {
+		return ""
+	}
+
+	model := prefix[separator+1:]
 	model = strings.TrimSpace(strings.Trim(strings.TrimSpace(model), "();"))
 	if model == "" {
 		return ""

--- a/internal/api/handlers/playback_sessions.go
+++ b/internal/api/handlers/playback_sessions.go
@@ -74,6 +74,7 @@ type playbackSessionRow struct {
 	AudioDecision            string    `json:"audio_decision,omitempty"`
 	EffectivePlayMethod      string    `json:"effective_play_method,omitempty"`
 	IsJellyfinClient         bool      `json:"is_jellyfin_client,omitempty"`
+	CompatOrigin             bool      `json:"-"`
 }
 
 // playbackSessionsCapabilitiesResponse advertises the additive fields of the
@@ -199,7 +200,8 @@ func (l *PlaybackSessionsLoader) Load(
 			mf.audio_channels,
 			COALESCE(mf.audio_tracks::text, '[]'),
 			COALESCE(requested_mf.codec_video, ''),
-			COALESCE(requested_mf.resolution, '')
+			COALESCE(requested_mf.resolution, ''),
+			COALESCE(s.compat_origin, FALSE)
 		 FROM playback_sessions_sync s
 		 LEFT JOIN users u ON u.id = s.user_id
 		 LEFT JOIN media_files mf ON mf.id = s.media_file_id
@@ -241,6 +243,7 @@ func (l *PlaybackSessionsLoader) Load(
 			&s.TranscodeNodeURL, &s.TargetResolution, &s.TargetVideoCodec, &s.TargetAudioCodec, &targetBitrateKbps,
 			&s.TranscodeHWAccel, &s.SourceContainer, &sourceBitrateKbps, &s.SourceVideoCodec, &s.SourceVideoResolution,
 			&s.SourceAudioCodec, &sourceAudioChannels, &audioTracksJSON, &s.RequestedVideoCodec, &s.RequestedVideoResolution,
+			&s.CompatOrigin,
 		); err != nil {
 			return nil, fmt.Errorf("scanning playback session: %w", err)
 		}
@@ -275,7 +278,7 @@ func enrichPlaybackSessionRow(row *playbackSessionRow, audioTracksJSON []byte) {
 
 	row.VideoDecision, row.AudioDecision = sessionComponentDecision(row.PlayMethod, row.TranscodeAudio, row.TargetVideoCodec)
 	row.EffectivePlayMethod = effectivePlayMethod(row.VideoDecision, row.AudioDecision)
-	row.IsJellyfinClient = isJellyfinEcosystemClient(row.ClientName, row.ClientUserAgent)
+	row.IsJellyfinClient = row.CompatOrigin || isJellyfinEcosystemClient(row.ClientName, row.ClientUserAgent)
 
 	var audioTracks []models.AudioTrack
 	if len(audioTracksJSON) > 0 {
@@ -418,9 +421,8 @@ var jellyfinClientTokens = []string{
 }
 
 // isJellyfinEcosystemClient reports whether the session's client metadata
-// matches a known Jellyfin-ecosystem client. This is a heuristic: an
-// unrecognized fork simply gets no JF pill (cosmetic). Stamping a compat-origin
-// flag on the session at creation would be exact and is the eventual fix.
+// matches a known Jellyfin-ecosystem client. This heuristic remains a fallback
+// for rows created before compat-origin identity was persisted.
 func isJellyfinEcosystemClient(clientName, userAgent string) bool {
 	for _, value := range []string{clientName, userAgent} {
 		value = strings.ToLower(strings.TrimSpace(value))

--- a/internal/api/handlers/playback_sessions.go
+++ b/internal/api/handlers/playback_sessions.go
@@ -494,6 +494,10 @@ func playbackClientDisplayName(name, version, userAgent string) string {
 		return rule.label
 	}
 
+	if label := androidDeviceLabel(userAgent); label != "" {
+		return label
+	}
+
 	switch {
 	case strings.Contains(lower, "applecoremedia"):
 		return "Apple player"
@@ -510,6 +514,51 @@ func playbackClientDisplayName(name, version, userAgent string) string {
 	default:
 		return firstUserAgentProduct(userAgent)
 	}
+}
+
+// knownAndroidDeviceLabels maps Android / Fire OS build model codes to friendly
+// product names for the admin session view. Keys are uppercased so the lookup is
+// case-insensitive. This only affects the displayed label — the session still
+// stores the raw model code in its user agent.
+var knownAndroidDeviceLabels = map[string]string{
+	"AFTKRT":            "Fire TV Stick 4K Max",
+	"AFTMM":             "Fire TV Stick 4K",
+	"AFTKM":             "Fire TV Stick 4K Max (1st Gen)",
+	"AFTKA":             "Fire TV Stick 4K Max (2nd Gen)",
+	"AFTSS":             "Fire TV Stick (3rd Gen)",
+	"AFTT":              "Fire TV Stick (2nd Gen)",
+	"AFTB":              "Fire TV (1st Gen)",
+	"AFTS":              "Fire TV (2nd Gen)",
+	"AFTN":              "Fire TV (3rd Gen)",
+	"AFTR":              "Fire TV Cube (2nd Gen)",
+	"AFTA":              "Fire TV Cube (1st Gen)",
+	"SHIELD ANDROID TV": "NVIDIA Shield",
+}
+
+// androidDeviceLabel derives a friendly device label from a bare Android / Fire OS
+// user agent of the form "... (Linux; U; Android <ver>; <MODEL> Build/<build>)".
+// The model is the whole segment between the last ';' and 'Build/', so multi-word
+// models ("Pixel 7", "SHIELD Android TV") survive intact. Known model codes map to
+// a product name; anything else falls back to "Android · <MODEL>" rather than the
+// uninformative "Dalvik". Returns "" when no model can be parsed.
+func androidDeviceLabel(userAgent string) string {
+	buildIndex := strings.Index(userAgent, "Build/")
+	if buildIndex < 0 {
+		return ""
+	}
+
+	model := strings.TrimSpace(userAgent[:buildIndex])
+	if separator := strings.LastIndex(model, ";"); separator >= 0 {
+		model = model[separator+1:]
+	}
+	model = strings.TrimSpace(strings.Trim(strings.TrimSpace(model), "();"))
+	if model == "" {
+		return ""
+	}
+	if label, ok := knownAndroidDeviceLabels[strings.ToUpper(model)]; ok {
+		return label
+	}
+	return "Android · " + model
 }
 
 func containsAny(value string, needles []string) bool {

--- a/internal/api/handlers/playback_sessions_test.go
+++ b/internal/api/handlers/playback_sessions_test.go
@@ -105,15 +105,72 @@ func TestIsJellyfinEcosystemClient(t *testing.T) {
 }
 
 func TestPlaybackClientDisplayNameAndroidDevices(t *testing.T) {
+	const curlClientLabel = "curl"
+
 	cases := []struct {
 		name      string
 		userAgent string
 		want      string
 	}{
 		{
-			name:      "fire tv model",
+			name:      "fire tv stick 4k max",
 			userAgent: "Dalvik/2.1.0 (Linux; U; Android 11; AFTKRT Build/RS8180.3729N)",
 			want:      "Fire TV Stick 4K Max",
+		},
+		{
+			name:      "fire tv stick 4k",
+			userAgent: "Dalvik/2.1.0 (Linux; U; Android 9; AFTMM Build/PS7279)",
+			want:      "Fire TV Stick 4K",
+		},
+		{
+			name:      "fire tv stick 4k second generation",
+			userAgent: "Dalvik/2.1.0 (Linux; U; Android 11; AFTKM Build/RS8139)",
+			want:      "Fire TV Stick 4K (2nd Gen)",
+		},
+		{
+			name:      "fire tv stick 4k max first generation",
+			userAgent: "Dalvik/2.1.0 (Linux; U; Android 9; AFTKA Build/PS7646)",
+			want:      "Fire TV Stick 4K Max (1st Gen)",
+		},
+		{
+			name:      "fire tv stick third generation",
+			userAgent: "Dalvik/2.1.0 (Linux; U; Android 9; AFTSSS Build/PS7279)",
+			want:      "Fire TV Stick (3rd Gen)",
+		},
+		{
+			name:      "fire tv stick lite first generation",
+			userAgent: "Dalvik/2.1.0 (Linux; U; Android 9; AFTSS Build/PS7279)",
+			want:      "Fire TV Stick Lite (1st Gen)",
+		},
+		{
+			name:      "fire tv stick second generation",
+			userAgent: "Dalvik/2.1.0 (Linux; U; Android 5.1; AFTT Build/LVY48F)",
+			want:      "Fire TV Stick (2nd Gen)",
+		},
+		{
+			name:      "fire tv first generation",
+			userAgent: "Dalvik/2.1.0 (Linux; U; Android 4.2; AFTB Build/JDQ39)",
+			want:      "Fire TV (1st Gen)",
+		},
+		{
+			name:      "fire tv second generation",
+			userAgent: "Dalvik/2.1.0 (Linux; U; Android 5.1; AFTS Build/LVY48F)",
+			want:      "Fire TV (2nd Gen)",
+		},
+		{
+			name:      "fire tv third generation",
+			userAgent: "Dalvik/2.1.0 (Linux; U; Android 7.1; AFTN Build/NS6265)",
+			want:      "Fire TV (3rd Gen)",
+		},
+		{
+			name:      "fire tv cube second generation",
+			userAgent: "Dalvik/2.1.0 (Linux; U; Android 9; AFTR Build/PS7646)",
+			want:      "Fire TV Cube (2nd Gen)",
+		},
+		{
+			name:      "fire tv cube first generation",
+			userAgent: "Dalvik/2.1.0 (Linux; U; Android 7.1; AFTA Build/NS6265)",
+			want:      "Fire TV Cube (1st Gen)",
 		},
 		{
 			name:      "unmapped multi-word android model preserved",
@@ -129,6 +186,21 @@ func TestPlaybackClientDisplayNameAndroidDevices(t *testing.T) {
 			name:      "chrome remains browser label",
 			userAgent: "Mozilla/5.0 (X11; Linux x86_64) Chrome/120.0.0.0 Safari/537.36",
 			want:      "Chrome 120",
+		},
+		{
+			name:      "non-android build user agent keeps existing fallback",
+			userAgent: "curl/8.0 (Linux; Device Build/42)",
+			want:      curlClientLabel,
+		},
+		{
+			name:      "explicit client fallback wins over android device model",
+			userAgent: "curl/8.0 (Linux; U; Android 13; Pixel 7 Build/TQ3A)",
+			want:      curlClientLabel,
+		},
+		{
+			name:      "android substring is not an android platform token",
+			userAgent: "Dalvik/2.1.0 (Linux; U; NotAndroid 13; Pixel 7 Build/TQ3A)",
+			want:      "Dalvik",
 		},
 	}
 	for _, tc := range cases {

--- a/internal/api/handlers/playback_sessions_test.go
+++ b/internal/api/handlers/playback_sessions_test.go
@@ -103,3 +103,40 @@ func TestIsJellyfinEcosystemClient(t *testing.T) {
 		})
 	}
 }
+
+func TestPlaybackClientDisplayNameAndroidDevices(t *testing.T) {
+	cases := []struct {
+		name      string
+		userAgent string
+		want      string
+	}{
+		{
+			name:      "fire tv model",
+			userAgent: "Dalvik/2.1.0 (Linux; U; Android 11; AFTKRT Build/RS8180.3729N)",
+			want:      "Fire TV Stick 4K Max",
+		},
+		{
+			name:      "unmapped multi-word android model preserved",
+			userAgent: "Dalvik/2.1.0 (Linux; U; Android 13; Pixel 7 Build/TQ3A)",
+			want:      "Android · Pixel 7",
+		},
+		{
+			name:      "shield model",
+			userAgent: "Dalvik/2.1.0 (Linux; U; Android 11; SHIELD Android TV Build/RQ1A)",
+			want:      "NVIDIA Shield",
+		},
+		{
+			name:      "chrome remains browser label",
+			userAgent: "Mozilla/5.0 (X11; Linux x86_64) Chrome/120.0.0.0 Safari/537.36",
+			want:      "Chrome 120",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := playbackClientDisplayName("", "", tc.userAgent)
+			if got != tc.want {
+				t.Fatalf("playbackClientDisplayName() = %q, want %q", got, tc.want)
+			}
+		})
+	}
+}

--- a/internal/api/handlers/playback_sessions_test.go
+++ b/internal/api/handlers/playback_sessions_test.go
@@ -140,3 +140,17 @@ func TestPlaybackClientDisplayNameAndroidDevices(t *testing.T) {
 		})
 	}
 }
+
+func TestEnrichPlaybackSessionRowUsesCompatOrigin(t *testing.T) {
+	row := playbackSessionRow{
+		ClientName:      "Unrecognized Client",
+		ClientUserAgent: "Dalvik/2.1.0",
+		CompatOrigin:    true,
+	}
+
+	enrichPlaybackSessionRow(&row, nil)
+
+	if !row.IsJellyfinClient {
+		t.Fatal("compat-origin session must be marked as a Jellyfin client")
+	}
+}

--- a/internal/jellycompat/auth.go
+++ b/internal/jellycompat/auth.go
@@ -166,6 +166,7 @@ func compatPlaybackClientInfo(r *http.Request) playback.ClientInfo {
 		Name:      firstMediaBrowserAuthorizationValue(r, "Client"),
 		Version:   firstMediaBrowserAuthorizationValue(r, "Version"),
 		UserAgent: r.UserAgent(),
+		IsCompat:  true,
 	}
 }
 

--- a/internal/jellycompat/handlers_playback.go
+++ b/internal/jellycompat/handlers_playback.go
@@ -547,6 +547,7 @@ func (h *PlaybackHandler) persistTranscodeRecipe(
 			card.ClientName = upstream.ClientName
 			card.ClientVersion = upstream.ClientVersion
 			card.ClientUserAgent = upstream.ClientUserAgent
+			card.IsJellyfinCompat = upstream.IsJellyfinCompat
 			recipe = &card
 		}
 	}

--- a/internal/jellycompat/streams.go
+++ b/internal/jellycompat/streams.go
@@ -1402,8 +1402,9 @@ func (h *PlaybackHandler) ensureUpstreamPlayback(ctx context.Context, compatSess
 				// direct/remux fallback cards built here from scratch) carry
 				// none; the current compat request identifies the client, so
 				// the reconstructed session keeps its label and JF pill.
+				info := playback.ClientInfoFromContext(ctx)
+				card.IsJellyfinCompat = info.IsCompat
 				if card.ClientName == "" && card.ClientUserAgent == "" {
-					info := playback.ClientInfoFromContext(ctx)
 					card.ClientName, card.ClientVersion, card.ClientUserAgent = info.Name, info.Version, info.UserAgent
 				}
 				if reconstructed := h.tm.ReconstructSession(ctx, playSession.UpstreamSessionID, compatSession.StreamAppUserID, card); reconstructed != nil {

--- a/internal/playback/recipecard.go
+++ b/internal/playback/recipecard.go
@@ -38,9 +38,10 @@ type RecipeCard struct {
 	// Jellyfin pill) survive reconstruction. Carried only by stored cards —
 	// deliberately NOT projected into stream-token claims, where a user agent
 	// would bloat every stream URL.
-	ClientName      string `json:"client_name,omitempty"`
-	ClientVersion   string `json:"client_version,omitempty"`
-	ClientUserAgent string `json:"client_user_agent,omitempty"`
+	ClientName       string `json:"client_name,omitempty"`
+	ClientVersion    string `json:"client_version,omitempty"`
+	ClientUserAgent  string `json:"client_user_agent,omitempty"`
+	IsJellyfinCompat bool   `json:"is_jellyfin_compat,omitempty"`
 
 	// Encode parameters — mirror of the byte-affecting TranscodeOpts fields.
 	// Unused (zero) for direct/remux cards, which carry no segment-based encode.

--- a/internal/playback/session.go
+++ b/internal/playback/session.go
@@ -27,6 +27,7 @@ type Session struct {
 	ClientName           string // reported playback client name, when available
 	ClientVersion        string // reported playback client version, when available
 	ClientUserAgent      string // trimmed request user agent for the playback session
+	IsJellyfinCompat     bool   // immutable origin identity for Jellyfin compatibility sessions
 
 	TranscodeNodeURL     string // URL of assigned transcode node (empty = local/integrated)
 	TranscodeTransportID string // remote node process identity; empty means session ID
@@ -140,6 +141,7 @@ type ClientInfo struct {
 	Name      string
 	Version   string
 	UserAgent string
+	IsCompat  bool
 }
 
 // WithClientInfo stores playback client metadata on a context.
@@ -437,6 +439,7 @@ func newSession(
 		ClientName:           normalizeClientMetadataValue(clientInfo.Name, 128),
 		ClientVersion:        normalizeClientMetadataValue(clientInfo.Version, 64),
 		ClientUserAgent:      normalizeClientMetadataValue(clientInfo.UserAgent, 512),
+		IsJellyfinCompat:     clientInfo.IsCompat,
 		StartedAt:            now,
 		UpdatedAt:            now,
 		LastActivityAt:       now,

--- a/internal/playback/transcode_manager.go
+++ b/internal/playback/transcode_manager.go
@@ -424,9 +424,10 @@ func (m *TranscodeManager) ReconstructSession(ctx context.Context, sessionID str
 		TranscodeHWAccel:     card.HWAccel,
 		// Client metadata survives the restart so the admin views keep the
 		// client label and Jellyfin identification for the session's lifetime.
-		ClientName:      normalizeClientMetadataValue(card.ClientName, 128),
-		ClientVersion:   normalizeClientMetadataValue(card.ClientVersion, 64),
-		ClientUserAgent: normalizeClientMetadataValue(card.ClientUserAgent, 512),
+		ClientName:       normalizeClientMetadataValue(card.ClientName, 128),
+		ClientVersion:    normalizeClientMetadataValue(card.ClientVersion, 64),
+		ClientUserAgent:  normalizeClientMetadataValue(card.ClientUserAgent, 512),
+		IsJellyfinCompat: card.IsJellyfinCompat,
 		// Preserve the byte-affecting recipe so an audio switch after a restart
 		// rebuilds the same stream (subtitles/cadence) instead of dropping them.
 		SubtitleTrackIndex: card.SubtitleTrackIndex,

--- a/internal/worker/reconciler.go
+++ b/internal/worker/reconciler.go
@@ -44,6 +44,7 @@ type SessionSync struct {
 	PositionSeconds      float64
 	IsPaused             bool
 	HasWebSocket         bool
+	IsJellyfinCompat     bool
 }
 
 // AggregateData represents the aggregate counts for a single user that are
@@ -153,8 +154,8 @@ func (r *Reconciler) ReconcileNodeSessions(ctx context.Context, reportingNode st
 				 client_name, client_version, client_user_agent,
 				 audio_track_index, transcode_audio, stream_bitrate_kbps, transcode_node_url,
 				 target_resolution, target_video_codec, target_audio_codec, target_bitrate_kbps,
-				 transcode_hw_accel, position_seconds, is_paused, has_websocket)
-			VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, NOW(), $10::inet, $11, $12, $13, $14, $15, $16, $17, $18, $19, $20, $21, $22, $23, $24, $25)
+				 transcode_hw_accel, position_seconds, is_paused, has_websocket, compat_origin)
+			VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, NOW(), $10::inet, $11, $12, $13, $14, $15, $16, $17, $18, $19, $20, $21, $22, $23, $24, $25, $26)
 			ON CONFLICT (session_id) DO UPDATE SET
 				user_id             = EXCLUDED.user_id,
 				profile_id          = EXCLUDED.profile_id,
@@ -180,6 +181,7 @@ func (r *Reconciler) ReconcileNodeSessions(ctx context.Context, reportingNode st
 				position_seconds    = EXCLUDED.position_seconds,
 				is_paused           = EXCLUDED.is_paused,
 				has_websocket       = EXCLUDED.has_websocket,
+				compat_origin       = EXCLUDED.compat_origin,
 				last_sync_at        = NOW()
 		`, s.SessionID, s.UserID, s.ProfileID, s.MediaFileID, nullableInt(s.RequestedMediaFileID), s.PlayMethod,
 			sessionNode, s.StartedAt, s.UpdatedAt, nullableIP(s.ClientIP),
@@ -188,7 +190,7 @@ func (r *Reconciler) ReconcileNodeSessions(ctx context.Context, reportingNode st
 			nullableString(s.TargetResolution), nullableString(s.TargetVideoCodec),
 			nullableString(s.TargetAudioCodec), nullableInt(s.TargetBitrateKbps),
 			nullableString(s.TranscodeHWAccel), normalizePositionSeconds(s.PositionSeconds),
-			s.IsPaused, s.HasWebSocket)
+			s.IsPaused, s.HasWebSocket, s.IsJellyfinCompat)
 		if err != nil {
 			return fmt.Errorf("upserting session %s: %w", s.SessionID, err)
 		}
@@ -263,7 +265,8 @@ func loadNodeSessionsSnapshot(ctx context.Context, tx pgx.Tx, reportingNode stri
 			updated_at,
 			COALESCE(position_seconds, 0),
 			COALESCE(is_paused, FALSE),
-			COALESCE(has_websocket, FALSE)
+			COALESCE(has_websocket, FALSE),
+			COALESCE(compat_origin, FALSE)
 		FROM playback_sessions_sync
 		WHERE COALESCE(reporting_node, '') = $1
 		ORDER BY session_id
@@ -302,6 +305,7 @@ func loadNodeSessionsSnapshot(ctx context.Context, tx pgx.Tx, reportingNode stri
 			&s.PositionSeconds,
 			&s.IsPaused,
 			&s.HasWebSocket,
+			&s.IsJellyfinCompat,
 		); err != nil {
 			return nil, err
 		}
@@ -357,7 +361,8 @@ func sessionSnapshotsEqual(left, right []SessionSync) bool {
 			!left[i].UpdatedAt.Equal(right[i].UpdatedAt) ||
 			normalizePositionSeconds(left[i].PositionSeconds) != normalizePositionSeconds(right[i].PositionSeconds) ||
 			left[i].IsPaused != right[i].IsPaused ||
-			left[i].HasWebSocket != right[i].HasWebSocket {
+			left[i].HasWebSocket != right[i].HasWebSocket ||
+			left[i].IsJellyfinCompat != right[i].IsJellyfinCompat {
 			return false
 		}
 	}

--- a/migrations/sql/20260724101824_add_playback_session_compat_origin.sql
+++ b/migrations/sql/20260724101824_add_playback_session_compat_origin.sql
@@ -1,0 +1,7 @@
+-- +goose Up
+ALTER TABLE playback_sessions_sync
+    ADD COLUMN compat_origin boolean NOT NULL DEFAULT false;
+
+-- +goose Down
+ALTER TABLE playback_sessions_sync
+    DROP COLUMN compat_origin;


### PR DESCRIPTION
Extends #387, which introduced the play-method tags and the Jellyfin-client pill in the admin
live-session view. Two commits: one makes that pill exact instead of heuristic, one makes the
device column readable for Android and Fire TV clients.

## Problem

**Jellyfin clients that come through the compat surface don't always get the JF pill.** #387
decided the pill by looking at the words in the client's reported name and browser user agent,
matching them against a list of known Jellyfin app names. That works for apps that announce
themselves. It does not work for an app that signs in through Silo's Jellyfin-compatible API but
reports a bare, generic user agent and no app name at all — a Fire TV app is the case that
prompted this. In the admin activity view such a stream looks exactly like a native Silo stream,
so an operator watching live sessions cannot tell which of their streams are actually Jellyfin
traffic. The stream plainly arrived through the Jellyfin API; the pill just had no way to know it.

**Android and Fire TV devices all show up as "Dalvik".** Many Android and Fire OS apps send the
platform's default user agent, which looks like
`Dalvik/2.1.0 (Linux; U; Android 11; AFTKRT Build/RS8180.3729N)`. The admin live-session view had
no rule for that shape, so it fell back to the first word and displayed the device as **Dalvik**.
Every Fire TV Stick, Fire Cube and Shield in the household rendered as the same meaningless label,
which tells an operator nothing about which physical device is streaming. The device model was
sitting in the user agent the whole time, just never read.

## Solution

### feat(admin): identify Android devices by model in live session view

`androidDeviceLabel` (`internal/api/handlers/playback_sessions.go:546`) parses the model out of a
bare Android / Fire OS user agent of the form
`... (Linux; U; Android <ver>; <MODEL> Build/<build>)`. The model is taken as the whole segment
between the last `;` and `Build/`, so multi-word models (`Pixel 7`, `SHIELD Android TV`) survive
intact rather than being split on whitespace.

`knownAndroidDeviceLabels` maps the Amazon Fire TV family and NVIDIA Shield build codes to product
names (`AFTKRT` → `Fire TV Stick 4K Max`). Lookup is uppercased so it is case-insensitive. Anything
parseable but unrecognized falls back to `Android · <MODEL>`, which is still strictly more useful
than `Dalvik`; an unparseable UA returns `""` and the existing display rules take over unchanged.

The hook sits in `playbackClientDisplayName` *after* the existing explicit client rules, so a client
that properly identifies itself keeps its own label and this only ever fills a gap. This is
display-only: the session still stores the raw model code in its user agent, and no response field
or contract changes.

### feat(admin): mark Jellyfin-compat sessions with the JF pill by origin

Replaces read-time guessing with write-time identity. Compat origin is stamped once, at session
creation, and carried through to the admin view:

- `ClientInfo.IsCompat` is set in the jellycompat auth path (`internal/jellycompat/auth.go:169`),
  and `newSession` copies it onto `Session.IsJellyfinCompat`
  (`internal/playback/session.go:30`, `:442`).
- The flag rides the durable `RecipeCard` (`internal/playback/recipecard.go:44`) — next to the
  client metadata that already lives there — written at `internal/jellycompat/streams.go:1406` and
  restored on reconstruction at `internal/playback/transcode_manager.go:430`, so the pill survives
  a server restart rather than being silently lost when the session is rebuilt.
- It flows `buildLiveSessionSync` → `worker.SessionSync` → a new `compat_origin` column on
  `playback_sessions_sync` (migration `20260724101824`). The reconciler upserts it, reloads it in
  `loadNodeSessionsSnapshot`, and includes it in `sessionSnapshotsEqual`, so an origin change still
  publishes a sync while unchanged rows do not churn.
- The handler ORs the stored origin with the existing name/UA heuristic
  (`internal/api/handlers/playback_sessions.go:281`). The heuristic is deliberately kept, not
  deleted: rows written before this column existed have `compat_origin = false` and would otherwise
  lose a pill they currently have.

Why stamping rather than deriving: the alternative considered was joining the admin query against
the durable `jellycompat_playback_sessions` table to recognize compat sessions at read time. That
needs no migration, but it makes the pill depend on an unmerged branch, adds a query to a hot admin
endpoint, and is still an inference. The origin is known for certain at exactly one moment — when
the request authenticates through the compat surface — so recording it there is both cheaper and
exact.

`is_jellyfin_client` keeps the same name and type on the wire, per the additive-only v1 rule. It is
only sourced more accurately.

## Risk / follow-ups

- `compat_origin` defaults to `false`, so sessions already live when the migration lands, and all
  historical rows, still depend on the name/UA heuristic. The pill becomes exact only for sessions
  started after deploy. No backfill is possible — the origin was never recorded.
- The heuristic fallback means a non-compat client whose name happens to contain a Jellyfin token
  can still get a false-positive pill. Narrowing that is out of scope here; removing the fallback
  should wait until pre-column rows have aged out.
- The Fire TV / Shield model table is hand-maintained and will drift as new hardware ships. Unknown
  models degrade to `Android · <MODEL>` rather than breaking, so drift is cosmetic.
- The model parse assumes the standard `Build/` UA shape. Vendors that reformat their user agent
  fall through to the previous behavior.
- The migration's timestamp (`20260724101824`) is older than migrations already merged to `main`.
  This is safe here because the provider is built with `goose.WithAllowOutofOrder(true)`
  (`internal/database/migrate.go:133`), so it applies on top of higher-numbered rows.
- HW/SW transcode-label accuracy in the same admin view is a separate known gap and is not touched
  by this PR.

## Verification

- Rebased onto `origin/main` at `8dea4b90`; clean, no conflicts.
- `go build ./...` — passes.
- `go vet ./internal/api/handlers/... ./internal/playback/... ./internal/worker/... ./internal/jellycompat/...` — clean.
- `go test ./internal/worker/...` — `ok`.
- New tests pass: `TestPlaybackClientDisplayNameAndroidDevices` (Fire TV code → product name,
  multi-word model preserved, unknown model → `Android · <MODEL>`, non-Android UA untouched) and
  `TestEnrichPlaybackSessionRowUsesCompatOrigin` (stored origin sets the pill; heuristic still
  fires for a row without it).
- `TestIsJellyfinEcosystemClient` still passes, confirming the #387 heuristic is intact as a
  fallback.
- Two failures in `./internal/api/handlers/` are **pre-existing and unrelated**, reproduced
  identically on an unmodified `origin/main` worktree:
  `TestHandleReplanPlaybackV3SeekFailureRecoveryNeverChangesMediaVersion` (seek recovery returns
  `adaptation_unavailable`) and `TestRemoveJellyfinCompatWebDisablesWebSetting` (a `TempDir`
  cleanup error, `directory not empty`).
- `make lint` and the web lint/format checks were not run in this environment — `golangci-lint` and
  `pnpm` are unavailable on this host. There are no frontend changes in this PR.
- Not manually exercised against a live Fire TV session; the UA parsing is covered by unit tests
  using the real observed user agent string.

## AI Disclosure
- Tool(s): Claude Code
- Model(s): claude-opus-5
- Involvement: AI-assisted
- Adversarial review: the diff was re-reviewed before opening this PR, targeting the ways this
  change could regress silently. Three checks, no code changes needed as a result. (1) *Does the
  new column strand old rows?* Dropping the name/UA heuristic would have regressed the pill for
  every session predating the migration; the diff correctly keeps it as a fallback — recorded as a
  known limitation above rather than fixed, since no backfill is possible. (2) *Does the new
  `SessionSync` field actually propagate?* The reconciler skips writes when snapshots compare
  equal, so a field omitted from `sessionSnapshotsEqual` would never publish an origin change;
  confirmed it is included (`internal/worker/reconciler.go:365`). (3) *Is the out-of-order
  migration timestamp safe?* Verified against `internal/database/migrate.go:133`
  (`goose.WithAllowOutofOrder(true)`) rather than assumed. Separately, the two failing tests in
  the touched package were run against an unmodified `origin/main` worktree to confirm this branch
  did not cause them.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved recognition of Jellyfin-compatible playback sessions, including sessions restored after restart.
  * Added friendlier device labels for supported Android and Fire TV playback clients in the admin session view.
  * Preserved compatibility information during live session synchronization and session recovery.

* **Bug Fixes**
  * Compatibility detection now remains accurate when client names or user-agent details are unavailable.

* **Tests**
  * Added coverage for Android device labels, browser labels, and compatibility-based session detection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

---

## Maintainer remediation (Codex)

Commit 5a9e98a6 corrects the Android device parser review findings while preserving the contributor commits and approach:

- Corrects the AFTKM, AFTKA, and AFTSS Fire TV product labels and adds AFTSSS.
- Requires an exact semicolon-delimited Android <version> platform segment.
- Runs Android model parsing only after the existing explicit client fallbacks, so Android-shaped curl, okhttp, Dart, Go, Python, and AppleCoreMedia user agents retain their established labels.
- Adds regression coverage for every mapped Fire TV code, Shield, browser and fallback precedence, false Android substrings, and unknown multi-word models.

### Maintainer verification

- Focused Android-device, compat-origin, and Jellyfin-ecosystem handler tests — passed.
- go build ./... — passed.
- go vet ./internal/api/handlers/... — passed.
- golangci-lint against new changes from 7e73654fb4b67527a6d592b150f9558e52c0a769 — 0 issues.
- git diff --check against base, make verify-local-paths, and make migrate-validate — passed.
- Earlier affected-package worker, playback reconstruction, Jellyfin-compat restart and auth, frontend lint, frontend format and build, and focused handler checks — passed. The full handler-suite failure and repository-wide lint findings were reproduced as pre-existing baseline issues.
- Runtime backend verification: deployed the amended commit to the configured development backend while holding the shared deployment lock; compose remained healthy and /api/v1/ready returned status ok. Temporary live-session fixtures confirmed AFTKM maps to Fire TV Stick 4K (2nd Gen), an Android-shaped curl UA maps to curl, and NotAndroid 13 maps to Dalvik through /api/v1/admin/sessions.
- Real Admin Activity UI verification covered desktop and mobile layouts against the development backend. Expected device labels rendered exactly once, and the JF pill appeared on the compat-origin Fire TV row. Authenticated refresh had no unexpected console errors, failed requests, or bad HTTP responses.
- All temporary runtime rows were deleted; the scoped cleanup query returned zero remaining rows. Post-check readiness remained healthy and recent logs contained no new panic, fatal, migration-failure, or error-level entries.

### AI Disclosure
- Tool(s): Codex
- Model(s): gpt-5.6-sol
- Involvement: AI-assisted
- Adversarial review: The initial two-axis review found incorrect Fire TV model mappings plus overly broad Android parsing that could relabel established clients and accept NotAndroid substrings. The remediation fixed those defects and added focused regressions. Independent final Standards and Spec reviews found no remaining code or specification defect; repository process findings about mixed concerns, missing linked scope issue or spec, and missing attached visual evidence remain report-only.