### PR TITLE
fix(player): restart backward HLS seeks

### DIFF
--- a/web/src/player/utils/mediaTimeline.test.ts
+++ b/web/src/player/utils/mediaTimeline.test.ts
@@ -8,9 +8,9 @@ describe("toMediaTime / toPlayerTime", () => {
     expect(toPlayerTime(3060, 3000)).toBe(60);
   });
 
-  it("never returns a negative time", () => {
+  it("preserves an out-of-window target before the stream origin", () => {
     expect(toMediaTime(-10, 0)).toBe(0);
-    expect(toPlayerTime(10, 3000)).toBe(0);
+    expect(toPlayerTime(10, 3000)).toBe(-2990);
   });
 });
 

--- a/web/src/player/utils/mediaTimeline.ts
+++ b/web/src/player/utils/mediaTimeline.ts
@@ -3,7 +3,9 @@ export function toMediaTime(playerTimeSeconds: number, streamOriginSeconds = 0):
 }
 
 export function toPlayerTime(mediaTimeSeconds: number, streamOriginSeconds = 0): number {
-  return Math.max(0, mediaTimeSeconds - streamOriginSeconds);
+  // Preserve negative offsets so callers can distinguish a target before the
+  // current HLS window from the locally seekable position at zero.
+  return mediaTimeSeconds - streamOriginSeconds;
 }
 
 /**


### PR DESCRIPTION
## Problem

During copy-mode HLS playback, seeking to a media timestamp earlier than the current stream origin could leave playback near the current position instead of moving backward. I reproduced #498 against the shared debug deployment with the local Vite frontend: after seeking to 4150.8s, a seek to the beginning remained around 1:09 because the media element was asked to seek to local time zero inside the existing HLS window.

## Approach

Preserve negative player-time offsets when a media target precedes the current HLS stream origin. Copy-mode HLS already advertises `can_seek_anywhere=false`; the negative offset therefore falls outside the media element's seekable ranges and reaches the existing transcode restart path instead of being mistaken for local time zero.

The regression test locks in that pre-origin media targets remain negative while media-time output retains its existing non-negative clamp.

## Verification

- `pnpm exec vitest run src/player/utils/mediaTimeline.test.ts` — 6/6 passed.
- Real browser repro against `https://silo.arkyncdn.net` through the local Vite proxy — before: backward seek stayed near 1:09; after: the same seek showed 0:00, restarted ffmpeg with `seek_seconds=0`, and playback advanced from the beginning.
- `pnpm run lint` — passed with 0 errors (existing warnings only).
- `pnpm run format:check` — passed.
- `pnpm run build` — passed.
- `GOWORK=off GOCACHE="$DEV_CACHE_ROOT/go-build" GOMODCACHE="$DEV_CACHE_ROOT/go-mod" go build ./internal/... ./cmd/...` — passed.
- `make verify-local-paths` — passed.
- Full `pnpm test` — 1,367 passed; 6 unrelated failures remain in `SeasonContent.test.tsx` and `ServerStorageStep.test.tsx`. Both failing files are unchanged from `origin/main` (missing test QueryClient/ResizeObserver setup).

A browser recording and screenshot were captured locally under `output/playwright/issue-498/`. GitHub attachment is still needed if maintainers want the raw UI recording on the PR.

## Adversarial review

Clean — no material findings.

- Pre-commit autoreview: patch correct, confidence 0.99.
- Committed branch review against `main`: approved; confirmed copy-mode HLS sets `can_seek_anywhere=false`, the pre-origin target falls through to the server restart, and no other production consumer receives the negative value.

## Risks & follow-up

Low risk: `toPlayerTime` has one production caller, the web video player's seek path. Encoded HLS streams use origin zero, so their behavior is unchanged. No Android or Apple client follow-up is required because this change is isolated to the web player.

Closes #498

### AI Disclosure
- Tool(s): Codex in T3 Code
- Model(s): gpt-5.6-sol
- Involvement: fully AI-generated
- Adversarial review: two Codex reviews found no material issues; the branch-level review specifically verified the only production caller and copy-HLS restart semantics.

🤖 Generated with [Codex](https://openai.com/codex/)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved timeline handling for media targets that occur before the stream origin.
  * Preserved negative player-time offsets so earlier targets can be detected accurately.
  * Maintained existing handling for media times before the valid seekable range.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->