### PR TITLE
fix(web): align hero editorial metadata

### DIFF
--- a/docs/feature-changelog.md
+++ b/docs/feature-changelog.md
@@ -2,6 +2,13 @@
 
 ## 2026-08-20
 
+### Make featured heroes read like editorial summaries
+Home and Library Recommended now present concise title metadata without taking technical quality details away from movie and episode pages.
+- Prefers catalog runtime over progress duration and safely omits invalid or unavailable values.
+- Orders movie and series metadata as year, runtime, IMDb rating, up to two normalized genres, and content rating.
+- Gives episode heroes their own season/episode, runtime, and content-rating presentation.
+- Keeps resolution, HDR, and audio-quality badges on movie and episode detail heroes.
+
 ### Give each profile its own watch-provider server
 Plugin watch providers can now ask for connection details per profile instead of forcing every profile on a Silo server to share one installation-wide configuration.
 - Lets a self-hosted provider give each household member their own server URL and credentials.

--- a/web/src/components/HeroBanner.test.tsx
+++ b/web/src/components/HeroBanner.test.tsx
@@ -3,8 +3,10 @@ import { renderToStaticMarkup } from "react-dom/server";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
+import type { SectionItem } from "@/api/types";
 
 import HeroBanner from "./HeroBanner";
+import { formatHeroMetadata } from "./heroMetadata";
 
 const playbackMocks = vi.hoisted(() => ({
   controller: null as null | {
@@ -44,6 +46,124 @@ function audiobookSlide() {
   };
 }
 
+function movieSlide(overrides: Partial<SectionItem> = {}): SectionItem {
+  return {
+    content_id: "movie-1",
+    type: "movie",
+    title: "Featured Movie",
+    year: 2025,
+    runtime: 125,
+    genres: ["Drama", "Mystery", "Thriller"],
+    content_rating: "PG-13",
+    status: "matched",
+    rating_imdb: 8.1,
+    overview: "Overview",
+    poster_url: "",
+    poster_thumbhash: "",
+    backdrop_url: "",
+    backdrop_thumbhash: "",
+    logo_url: "",
+    ...overrides,
+  };
+}
+
+function heroMetadata(container: HTMLElement): string[] {
+  return Array.from(container.querySelectorAll(".hero-meta-track > span")).map(
+    (node) => node.textContent ?? "",
+  );
+}
+
+describe("formatHeroMetadata", () => {
+  it("formats episode identity, runtime, and content rating without movie-only metadata", () => {
+    expect(
+      formatHeroMetadata(
+        movieSlide({
+          type: "episode",
+          season_number: 2,
+          episode_number: 3,
+          year: 2024,
+          runtime: 42,
+          rating_imdb: 7.6,
+          genres: ["Science Fiction", "Drama"],
+          content_rating: " tv-14 ",
+        }),
+      ),
+    ).toEqual([
+      { key: "episode-identity", label: "S2 · E3" },
+      { key: "runtime", label: "42 min" },
+      { key: "content-rating", label: "TV-14" },
+    ]);
+  });
+
+  it.each([Number.NaN, Number.NEGATIVE_INFINITY, Number.POSITIVE_INFINITY, -1, 0, 10.1])(
+    "omits invalid IMDb rating %s",
+    (ratingImdb) => {
+      expect(
+        formatHeroMetadata(
+          movieSlide({
+            runtime: undefined,
+            duration_seconds: undefined,
+            rating_imdb: ratingImdb,
+            genres: [],
+            content_rating: undefined,
+          }),
+        ),
+      ).toEqual([{ key: "year", label: "2025" }]);
+    },
+  );
+
+  it("keeps a valid upper-bound IMDb rating", () => {
+    expect(
+      formatHeroMetadata(
+        movieSlide({
+          runtime: undefined,
+          duration_seconds: undefined,
+          rating_imdb: 10,
+          genres: [],
+          content_rating: undefined,
+        }),
+      ),
+    ).toEqual([
+      { key: "year", label: "2025" },
+      { key: "imdb", label: "IMDb 10.0" },
+    ]);
+  });
+
+  it("normalizes genres and content rating before limiting and returns semantic keys", () => {
+    expect(
+      formatHeroMetadata(
+        movieSlide({
+          runtime: undefined,
+          duration_seconds: undefined,
+          rating_imdb: undefined,
+          genres: [" Drama ", "", "Drama", "  Mystery  ", "Mystery", "Thriller"],
+          content_rating: " r ",
+        }),
+      ),
+    ).toEqual([
+      { key: "year", label: "2025" },
+      { key: "genre-0", label: "Drama" },
+      { key: "genre-1", label: "Mystery" },
+      { key: "content-rating", label: "R" },
+    ]);
+  });
+
+  it("omits a fractional year", () => {
+    expect(
+      formatHeroMetadata(
+        movieSlide({
+          year: 2025.5,
+          runtime: undefined,
+          duration_seconds: undefined,
+          rating_imdb: undefined,
+          genres: [],
+          content_rating: undefined,
+        }),
+      ),
+    ).toEqual([]);
+  });
+});
+
 describe("HeroBanner", () => {
   beforeEach(() => {
     playbackMocks.controller = null;
@@ -78,6 +198,151 @@ describe("HeroBanner", () => {
     expect(markup).not.toContain("Now spotlighting");
     expect(markup).toContain("Featured Movie");
     expect(markup).toContain("More Info");
+  });
+
+  it("renders editorial metadata in the approved order and caps genres at two", () => {
+    const { container } = render(
+      <MemoryRouter>
+        <HeroBanner
+          items={[
+            movieSlide({
+              duration_seconds: 9_999,
+            }),
+          ]}
+        />
+      </MemoryRouter>,
+    );
+
+    expect(heroMetadata(container)).toEqual([
+      "2025",
+      "2h 5m",
+      "IMDb 8.1",
+      "Drama",
+      "Mystery",
+      "PG-13",
+    ]);
+    expect(container).not.toHaveTextContent("Thriller");
+    expect(container).not.toHaveTextContent("2h 47m");
+  });
+
+  it("falls back to a finite positive duration when catalog runtime is unavailable", () => {
+    const { container } = render(
+      <MemoryRouter>
+        <HeroBanner
+          items={[
+            movieSlide({
+              runtime: 0,
+              duration_seconds: 7_380,
+            }),
+          ]}
+        />
+      </MemoryRouter>,
+    );
+
+    expect(heroMetadata(container)).toEqual([
+      "2025",
+      "2h 3m",
+      "IMDb 8.1",
+      "Drama",
+      "Mystery",
+      "PG-13",
+    ]);
+  });
+
+  it("falls back when converting a finite catalog runtime overflows", () => {
+    const { container } = render(
+      <MemoryRouter>
+        <HeroBanner
+          items={[
+            movieSlide({
+              runtime: Number.MAX_VALUE,
+              duration_seconds: 7_380,
+            }),
+          ]}
+        />
+      </MemoryRouter>,
+    );
+
+    expect(heroMetadata(container)).toEqual([
+      "2025",
+      "2h 3m",
+      "IMDb 8.1",
+      "Drama",
+      "Mystery",
+      "PG-13",
+    ]);
+  });
+
+  it("omits a whitespace-only content rating", () => {
+    const { container } = render(
+      <MemoryRouter>
+        <HeroBanner
+          items={[
+            movieSlide({
+              content_rating: " \t ",
+            }),
+          ]}
+        />
+      </MemoryRouter>,
+    );
+
+    expect(heroMetadata(container)).toEqual(["2025", "2h 5m", "IMDb 8.1", "Drama", "Mystery"]);
+  });
+
+  it.each([
+    { runtime: -1, duration_seconds: 0 },
+    { runtime: 0, duration_seconds: 1 },
+    { runtime: Number.NaN, duration_seconds: Number.NaN },
+    { runtime: Number.POSITIVE_INFINITY, duration_seconds: Number.POSITIVE_INFINITY },
+  ])("omits invalid runtime values: $runtime / $duration_seconds", (runtimeValues) => {
+    const { container } = render(
+      <MemoryRouter>
+        <HeroBanner
+          items={[
+            movieSlide({
+              ...runtimeValues,
+              year: 0,
+              rating_imdb: null,
+              genres: [],
+              content_rating: "",
+            }),
+          ]}
+        />
+      </MemoryRouter>,
+    );
+
+    expect(container.querySelector(".hero-meta-track")).toBeNull();
+  });
+
+  it("uses the episode editorial policy for episode slides", () => {
+    const { container } = render(
+      <MemoryRouter>
+        <HeroBanner
+          items={[
+            movieSlide({
+              content_id: "episode-1",
+              type: "episode",
+              title: "Pilot",
+              season_number: 2,
+              episode_number: 3,
+              runtime: undefined,
+              duration_seconds: 2_520,
+              year: 2024,
+              rating_imdb: 7.6,
+              genres: ["Science Fiction", "Drama", "Adventure"],
+              content_rating: "TV-14",
+            }),
+          ]}
+        />
+      </MemoryRouter>,
+    );
+
+    expect(heroMetadata(container)).toEqual(["S2 · E3", "42 min", "TV-14"]);
+    expect(container).not.toHaveTextContent("2024");
+    expect(container).not.toHaveTextContent("IMDb");
+    expect(container).not.toHaveTextContent("Science Fiction");
+    expect(container).not.toHaveTextContent("Drama");
+    expect(container).not.toHaveTextContent("Adventure");
   });
 
   it("routes ebook hero actions to the reader", () => {

--- a/web/src/components/HeroBanner.tsx
+++ b/web/src/components/HeroBanner.tsx
@@ -9,6 +9,7 @@ import type { SectionItem } from "@/api/types";
 import { buildItemHref, buildMediaPlayHref } from "@/lib/mediaNavigation";
 import { useAudiobookPlaybackController } from "@/pages/audiobooks/player/audiobookPlaybackContext";
 import ViewTransitionLink from "@/components/ViewTransitionLink";
+import { formatHeroMetadata } from "./heroMetadata";
 
 interface HeroBannerProps {
   items: SectionItem[];
@@ -34,15 +35,6 @@ interface HeroBannerProps {
    * param so the watch/item routes can scope back to the right library.
    */
   libraryId?: number;
-}
-
-function formatRuntime(seconds: number | undefined | null): string | null {
-  if (!seconds || seconds <= 0) return null;
-  const minutes = Math.round(seconds / 60);
-  if (minutes < 60) return `${minutes} min`;
-  const hours = Math.floor(minutes / 60);
-  const remaining = minutes % 60;
-  return remaining === 0 ? `${hours}h` : `${hours}h ${remaining}m`;
 }
 
 function heroPlayLabel(item: SectionItem, activeAudiobookPlaying?: boolean | null): string {
@@ -131,12 +123,7 @@ export default function HeroBanner({
   if (slides.length === 0) return null;
   if (!current) return null;
 
-  const metaParts: string[] = [];
-  if (current.year > 0) metaParts.push(String(current.year));
-  if (current.rating_imdb != null) metaParts.push(`IMDb ${current.rating_imdb.toFixed(1)}`);
-  (current.genres ?? []).slice(0, 3).forEach((g) => metaParts.push(g));
-  const runtime = formatRuntime(current.duration_seconds);
-  if (runtime) metaParts.push(runtime);
+  const metadata = formatHeroMetadata(current);
 
   const slideCount = slides.length;
   const padded = (n: number) => String(n).padStart(2, "0");
@@ -238,10 +225,10 @@ export default function HeroBanner({
             >
               {current.title}
             </h1>
-            {metaParts.length > 0 && (
+            {metadata.length > 0 && (
               <div className="hero-meta-track mb-5 text-white/85">
-                {metaParts.map((part) => (
-                  <span key={part}>{part}</span>
+                {metadata.map((entry) => (
+                  <span key={entry.key}>{entry.label}</span>
                 ))}
               </div>
             )}

--- a/web/src/components/heroMetadata.ts
+++ b/web/src/components/heroMetadata.ts
@@ -1,0 +1,76 @@
+import type { SectionItem } from "@/api/types";
+
+function isPositiveFinite(value: number | undefined | null): value is number {
+  return value != null && Number.isFinite(value) && value > 0;
+}
+
+function resolveHeroRuntimeSeconds(item: SectionItem): number | null {
+  if (isPositiveFinite(item.runtime)) {
+    const runtimeSeconds = item.runtime * 60;
+    if (isPositiveFinite(runtimeSeconds)) {
+      return runtimeSeconds;
+    }
+  }
+  if (isPositiveFinite(item.duration_seconds)) {
+    return item.duration_seconds;
+  }
+  return null;
+}
+
+function formatRuntime(seconds: number | undefined | null): string | null {
+  if (!isPositiveFinite(seconds)) return null;
+  const minutes = Math.round(seconds / 60);
+  if (minutes <= 0) return null;
+  if (minutes < 60) return `${minutes} min`;
+  const hours = Math.floor(minutes / 60);
+  const remaining = minutes % 60;
+  return remaining === 0 ? `${hours}h` : `${hours}h ${remaining}m`;
+}
+
+export interface HeroMetadataEntry {
+  key: string;
+  label: string;
+}
+
+function isNonNegativeInteger(value: number | undefined | null): value is number {
+  return value != null && Number.isInteger(value) && value >= 0;
+}
+
+export function formatHeroMetadata(item: SectionItem): HeroMetadataEntry[] {
+  const entries: HeroMetadataEntry[] = [];
+  const runtime = formatRuntime(resolveHeroRuntimeSeconds(item));
+  const contentRating = item.content_rating?.trim().toUpperCase();
+
+  if (item.type === "episode") {
+    if (isNonNegativeInteger(item.season_number) && isNonNegativeInteger(item.episode_number)) {
+      entries.push({
+        key: "episode-identity",
+        label: `S${item.season_number} · E${item.episode_number}`,
+      });
+    }
+    if (runtime) entries.push({ key: "runtime", label: runtime });
+    if (contentRating) entries.push({ key: "content-rating", label: contentRating });
+    return entries;
+  }
+
+  if (Number.isInteger(item.year) && item.year > 0) {
+    entries.push({ key: "year", label: String(item.year) });
+  }
+  if (runtime) entries.push({ key: "runtime", label: runtime });
+  if (
+    item.rating_imdb != null &&
+    Number.isFinite(item.rating_imdb) &&
+    item.rating_imdb > 0 &&
+    item.rating_imdb <= 10
+  ) {
+    entries.push({ key: "imdb", label: `IMDb ${item.rating_imdb.toFixed(1)}` });
+  }
+
+  const genres = [...new Set((item.genres ?? []).map((genre) => genre.trim()).filter(Boolean))];
+  genres.slice(0, 2).forEach((genre, index) => {
+    entries.push({ key: `genre-${index}`, label: genre });
+  });
+
+  if (contentRating) entries.push({ key: "content-rating", label: contentRating });
+  return entries;
+}


### PR DESCRIPTION
## What this PR does now

This PR updates the shared featured hero used by Home and Library Recommended so its title metadata reads like an editorial summary:

- movie and series heroes show year, catalog runtime, valid IMDb rating, up to two normalized genres, and content rating
- episode heroes show season/episode identity, runtime, and content rating
- catalog runtime is preferred over progress duration, with duration used only as a fallback
- invalid years, ratings, runtimes, blank values, and duplicate genres are omitted

## What changed from the original PR

The original version also removed resolution, HDR, and audio-quality badges from movie and episode detail heroes. That part was deliberately removed after review.

- `QualityBadges` remains rendered on movie and episode detail pages
- selected-version runtime and all version, audio, subtitle, media-info, download, and playback controls are untouched
- the old implementation plan/spec files and detail-page changes are no longer in the diff
- the branch was rebased and reduced to one focused commit

This addresses the editorial-metadata portion of #516. It intentionally does **not** implement that issue's quality-badge removal request.

## Actual diff

- `web/src/components/heroMetadata.ts` — validates, normalizes, orders, and formats featured-hero metadata
- `web/src/components/HeroBanner.tsx` — renders the shared formatted metadata entries
- `web/src/components/HeroBanner.test.tsx` — covers movie, series-style, and episode policies plus invalid/fallback boundaries
- `docs/feature-changelog.md` — records the user-visible behavior

No backend, API, schema, migration, dependency, lockfile, or generated-type changes.

## Verification

- final head: `70690929ec79bc5ba5872c5e1377cea89584cc5f`
- focused suite: 5 files, 46 tests passed, including movie and episode detail coverage
- production web typecheck and Vite build passed
- focused ESLint and Prettier checks passed
- `make verify-local-paths` and `git diff --check` passed
- browser validation confirmed the Home movie order `2025 · 2h 5m · IMDb 8.1 · Drama · Mystery · PG-13`
- browser validation confirmed the Library episode order `S2 · E3 · 42 min · TV-14`, with movie-only metadata absent
- Go, Web, Docs hygiene, and CodeRabbit checks pass; GitHub reports the PR clean and mergeable

### AI Disclosure

- Tool(s): Codex in T3 Code
- Model(s): GPT-5.6
- Involvement: AI-assisted rewrite, rebase, review, testing, and browser validation on behalf of a maintainer
- Adversarial review: Re-reviewed the complete current-main diff and surrounding Home, Library Recommended, movie-detail, and episode-detail call sites; no unresolved defects found.
