### PR TITLE
fix(autoscan): stop warning "No paths configured" on runtime-path sources

### DIFF
--- a/web/src/pages/admin/autoscan/sourceTargets.test.ts
+++ b/web/src/pages/admin/autoscan/sourceTargets.test.ts
@@ -107,11 +107,95 @@ describe("sourceTargets", () => {
     expect(got.libraries.map((l) => l.name)).toEqual(["Movies", "TV Shows"]);
   });
 
-  it("flags a source with no path information as unresolvable", () => {
+  it("flags a local watcher with no path information as unresolvable", () => {
     // The silent-failure case: looks configured, can never match anything.
     const got = sourceTargets(source(), pathDescriptor, libraries);
     expect(got.unresolvable).toBe(true);
+    expect(got.unknown).toBe(false);
     expect(got.libraries).toEqual([]);
+  });
+
+  it("treats a connection-backed poll source with no rewrites as unknown", () => {
+    // Empty rewrites are a valid passthrough: the provider already reports
+    // paths that are valid Silo library paths, so nothing needs mapping.
+    const got = sourceTargets(
+      source({ connection_id: "c1" }),
+      { delivery_modes: ["poll"], connection: "optional" },
+      libraries,
+    );
+    expect(got.unresolvable).toBe(false);
+    expect(got.unknown).toBe(true);
+  });
+
+  it("treats a webhook source with no rewrites as unknown", () => {
+    // The built-in ARR webhook descriptor does not declare emits_native_paths,
+    // but its paths arrive in the delivery payload, not from configuration.
+    const got = sourceTargets(
+      source({ delivery_mode: "webhook" }),
+      { delivery_modes: ["webhook"], connection: "none" },
+      libraries,
+    );
+    expect(got.unresolvable).toBe(false);
+    expect(got.unknown).toBe(true);
+  });
+
+  it("treats a native-path source with no rewrites as unknown", () => {
+    const got = sourceTargets(
+      source(),
+      { delivery_modes: ["poll"], connection: "none", emits_native_paths: true },
+      libraries,
+    );
+    expect(got.unresolvable).toBe(false);
+    expect(got.unknown).toBe(true);
+  });
+
+  it("still warns an optional-connection source with nothing bound", () => {
+    // `optional` plus no connection is a local watcher in practice: nothing
+    // will hand it paths at runtime, so empty path fields are a real fault.
+    const got = sourceTargets(
+      source({ connection_id: null }),
+      { ...pathDescriptor, connection: "optional" },
+      libraries,
+    );
+    expect(got.unresolvable).toBe(true);
+    expect(got.unknown).toBe(false);
+  });
+
+  it("does not warn a required-connection source that has none bound", () => {
+    // The row already reports the missing connection; a second warning about
+    // paths points at the wrong fault.
+    const got = sourceTargets(
+      source({ connection_id: null }),
+      { ...pathDescriptor, connection: "required" },
+      libraries,
+    );
+    expect(got.unresolvable).toBe(false);
+    expect(got.unknown).toBe(true);
+  });
+
+  it("does not warn a local watcher that declares no path fields", () => {
+    // Nothing for the operator to fill in, so "no paths configured" would point
+    // at a control that does not exist.
+    const got = sourceTargets(
+      source(),
+      { delivery_modes: ["poll"], connection: "none" },
+      libraries,
+    );
+    expect(got.unresolvable).toBe(false);
+    expect(got.unknown).toBe(true);
+  });
+
+  it("still matches libraries for a webhook source that has rewrites", () => {
+    const got = sourceTargets(
+      source({
+        delivery_mode: "webhook",
+        path_rewrites: [{ from: "/data/tv", to: "/mnt/media/tv" }],
+      }),
+      { delivery_modes: ["webhook"], connection: "none" },
+      libraries,
+    );
+    expect(got.unknown).toBe(false);
+    expect(got.libraries.map((l) => l.name)).toEqual(["TV Shows"]);
   });
 
   it("distinguishes configured-but-unmatched from unconfigured", () => {

--- a/web/src/pages/admin/autoscan/sourceTargets.ts
+++ b/web/src/pages/admin/autoscan/sourceTargets.ts
@@ -17,16 +17,17 @@ export interface SourceTargets {
   /** Libraries whose roots overlap this source's resolved paths. */
   libraries: Library[];
   /**
-   * True when the source has no path information at all, so nothing it reports
-   * could ever resolve to a library. This is the silent-failure case: the
-   * source looks configured and runs cleanly, but can never match.
+   * True when the source was asked for paths and given none, so nothing it
+   * reports could ever resolve to a library. This is the silent-failure case: a
+   * local watcher that looks configured and runs cleanly, but can never match.
+   * Reserved for sources that own their paths — see targetsAreKnowable.
    */
   unresolvable: boolean;
   /**
-   * True when the source declares emits_native_paths and has nothing configured
-   * to inspect. Its targets are simply not knowable up front — it discovers
-   * already-resolvable Silo paths while polling — so the UI must say "unknown"
-   * rather than warn that it is broken.
+   * True when the source's targets are not knowable up front: it learns its
+   * paths at runtime (from a provider it polls, from a webhook payload, or
+   * because it declares emits_native_paths) and has no rewrites narrowing them
+   * down. The UI must say "unknown" rather than warn that it is broken.
    */
   unknown: boolean;
 }
@@ -86,11 +87,44 @@ export function resolvedPathsFor(
 }
 
 /**
+ * Whether a source's targets could have been known from its stored
+ * configuration alone — which is what makes an empty result a misconfiguration
+ * rather than simply unknown.
+ *
+ * Three kinds of source learn their paths at runtime instead, so empty rewrites
+ * are a valid passthrough for them, not a silent failure:
+ *
+ * - a webhook source reads paths out of each delivery payload;
+ * - a source with a bound connection gets them from the provider's root folders
+ *   (`SuggestRewrites` deliberately proposes nothing when a reported root
+ *   already equals the Silo path, so "correctly configured" and "no rewrites"
+ *   are the same state);
+ * - an `emits_native_paths` source returns Silo paths directly.
+ *
+ * What remains is a source that must be handed its roots up front. It is only
+ * worth warning about when the descriptor gives the operator a field to put
+ * them in — otherwise the warning points at a control that does not exist.
+ */
+function targetsAreKnowable(
+  source: AutoscanSource,
+  descriptor: AutoscanScanSourceDescriptor,
+): boolean {
+  if (source.delivery_mode === "webhook") return false;
+  if (descriptor.emits_native_paths) return false;
+  // The bound connection is what matters, not just the descriptor's
+  // requirement: an `optional` source with nothing bound is a local watcher for
+  // this purpose, and must still be warned about when its path fields are
+  // empty. A `required` source with nothing bound is excluded because the row
+  // already reports the missing connection, and that is the fault to fix first.
+  if (source.connection_id || descriptor.connection === "required") return false;
+  return configFields(descriptor).length > 0;
+}
+
+/**
  * Match a source's resolved paths against library roots.
  *
- * A source that emits native paths but has neither rewrites nor path config is
- * still reported as unresolvable — it has genuinely told us nothing about where
- * its media lands.
+ * A source with no paths is only reported as unresolvable when it is one whose
+ * paths could have been known up front; otherwise its targets are unknown.
  */
 export function sourceTargets(
   source: AutoscanSource,
@@ -99,10 +133,7 @@ export function sourceTargets(
 ): SourceTargets {
   const paths = resolvedPathsFor(source, descriptor);
   if (paths.length === 0) {
-    // A native-path source needs no configured root: it emits Silo paths
-    // directly, discovered at poll time. Flagging that as broken would warn on
-    // exactly the case the descriptor field exists to describe.
-    if (descriptor.emits_native_paths) {
+    if (!targetsAreKnowable(source, descriptor)) {
       return { libraries: [], unresolvable: false, unknown: true };
     }
     return { libraries: [], unresolvable: true, unknown: false };


### PR DESCRIPTION
## Problem

Fixes #518

The Autoscan source row shows a red **"No paths configured — this source can't match anything yet."** on sources that are configured correctly and actively working.

`sourceTargets` derives a source's paths from its path rewrites or its path-shaped config values, and marks the source `unresolvable` when both are empty — unless the descriptor declares `emits_native_paths`. That treats "no configured paths" as a misconfiguration for *every* source, but only a local watcher is actually handed its roots up front:

- a **webhook** source reads paths out of each delivery payload;
- a source with a **bound connection** gets them from the provider's root folders.

For both, empty rewrites are the correct steady state rather than an omission. `suggestRewrites` deliberately proposes nothing when a reported root already equals the Silo path (`internal/autoscan/suggest.go:176`), so a shared-path-namespace deployment — arr and Silo seeing the same paths — lands on precisely the state the row flags as broken. The built-in ARR webhook descriptor doesn't declare `emits_native_paths` either (`internal/autoscan/discovery.go:36`), so it hits this too.

Reported as cosmetic, and it is: matching and scan enqueueing work correctly. But the row is the one place that tells an operator whether a source is wired up, so a false red warning there costs exactly the debugging time the summary was added to save.

## Approach

Gate the warning on whether the paths *could* have been known from stored config at all, via a new `targetsAreKnowable`. Three kinds of source learn their paths at runtime and are reported as **unknown** ("Targets determined at scan time") instead of warned about: webhook delivery, a bound connection, and `emits_native_paths`.

Two judgment calls worth flagging, both from reviewing my own diff:

- **Keyed on `source.connection_id`, not `descriptor.connection`.** My first version checked `descriptor.connection !== "none"`, which silently swallowed the warning for an `optional` source with nothing bound — a local watcher in practice, and a case that *should* warn. `optional` is also the default for any capability declaring nothing, so that version would have disabled the check for most plugins. Regression test: `still warns an optional-connection source with nothing bound`.
- **A `required` source with no connection bound is excluded.** The row already reports the missing connection, and that is the fault to fix first.

A local watcher whose descriptor declares no path fields is also treated as unknown — with no control to fill in, the warning points at nothing fixable.

The genuine silent-failure case the check was written for is untouched: a local watcher with declared path fields left empty still gets the red warning, and a source whose paths match no library root still gets the amber "Paths don't match any library root".

No API, server, or client-visible change — this is one frontend predicate. No follow-up needed in `silo-android` / `silo-apple`.

## Testing

Reproduced and verified against a real backend (local `silo-sandbox` instance, Vite dev server proxying to it), signed in as admin and navigated to Admin → Autoscan the way an operator would. The source under test is a built-in Sonarr/Radarr webhook source with `path_rewrites: []` — the issue's exact repro.

**Before** (fix stashed, same branch, same server) — row renders in red:

```
Sonarr/Radarr Webhook  [Webhook]
silo.autoscan.arr-webhook
⚠ No paths configured — this source can't match anything yet.
```
```
BODY_HAS_WARNING: true
```

**After** — red warning gone, replaced by the neutral muted line:

```
Sonarr/Radarr Webhook  [Webhook]
silo.autoscan.arr-webhook
Targets determined at scan time
```
```
HAS_NO_PATHS_WARNING: false
HAS_NO_MATCH_WARNING: false
HAS_UNKNOWN:          true
```

**The real misconfiguration still warns.** Same source, rewrites pointed at a path under no library root (`/data/tv` → `/nowhere/at/all`):

```
HAS_NO_PATHS_WARNING: false
HAS_NO_MATCH_WARNING: true      # amber "Paths don't match any library root"
HAS_UNKNOWN:          false
```

Browser console carried no errors beyond the expected 401/404s from unauthenticated pre-login probes. Screenshots captured at 1440×1000 for all three states; happy to attach them if useful — I have no way to upload binaries to GitHub's image CDN from this environment.

Unit tests — 8 new cases in `sourceTargets.test.ts` covering each branch (connection-backed poll, webhook, native-paths, field-less watcher, optional-with-nothing-bound, required-with-nothing-bound, and a webhook source with rewrites still matching):

```
$ cd web && pnpm test src/pages/admin/autoscan/
 Test Files  4 passed (4)
      Tests  74 passed (74)
```

```
$ cd web && pnpm run lint
✖ 157 problems (0 errors, 157 warnings)     # all pre-existing: vendor + ui primitives

$ cd web && pnpm run format:check
All matched files use Prettier code style!

$ cd web && pnpm exec tsc -b
                                            # clean, exit 0

$ make verify-local-paths
scripts/check-local-path-leaks.sh

$ go test ./internal/autoscan/...
ok  	github.com/Silo-Server/silo-server/internal/autoscan	0.061s
ok  	github.com/Silo-Server/silo-server/internal/autoscan/arrwebhook	0.056s
```

Full frontend suite:

```
$ cd web && pnpm test
 Test Files  2 failed | 252 passed (254)
      Tests  6 failed | 1644 passed (1650)
```

**The 6 failures are pre-existing and unrelated** — `SeasonContent.test.tsx` (3) and `ServerStorageStep.test.tsx` (3). I confirmed by stashing this diff and re-running on unmodified `origin/main` at `dc4b9a09`: same 6 fail. They're also the same set already listed as known-failing in #515.

`make lint` is not reported above because `golangci-lint run` covers the whole tree and reports 304 pre-existing findings unrelated to this change; **this PR touches no Go files**, so `go test ./internal/autoscan/...` is the relevant gate.

### AI Disclosure
- Tool(s): Claude Code
- Model(s): claude-opus-5[1m]
- Involvement: fully AI-generated
- Adversarial review: Reviewing my own diff caught a real bug before commit — the first version gated on `descriptor.connection !== "none"`, which disables the warning for any `optional`-connection source with nothing actually bound. Since `optional` is the default for a capability that declares nothing, that would have silently turned the check off for most plugins while appearing to fix only the reported case. Fixed by keying on `source.connection_id` (what is actually bound) and adding the regression test. The review also prompted the `required`-with-nothing-bound carve-out, and checking the built-in webhook descriptor directly is what confirmed it does not set `emits_native_paths` — so the descriptor flag alone was never going to cover the reported case. Separately, verifying against a real sandbox rather than only unit tests is what confirmed the amber "no matching library" path still fires, which a fixture-only run would not have exercised.

## Checklist
- [x] I ran an adversarial AI review of the diff and summarized findings above.
- [x] I ran the repo verify commands: `cd web && pnpm run lint`, `cd web && pnpm run format:check`, `make verify-local-paths`, and `go test ./internal/autoscan/...`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved autoscan source status reporting when path information is unavailable.
  * Sources are now more accurately identified as misconfigured, legitimately unknown, or matched to available libraries.
  * Added support for correctly matching webhook-delivered sources when path rewrites are configured.
  * Improved handling across optional, required, and unavailable connection configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->