### PR TITLE
feat(events): let websocket clients declare channels on connect

### DIFF
--- a/internal/api/handlers/events_capability.go
+++ b/internal/api/handlers/events_capability.go
@@ -1,0 +1,50 @@
+package handlers
+
+import (
+	"encoding/json"
+	"net/http"
+
+	evt "github.com/Silo-Server/silo-server/internal/events"
+)
+
+// eventsCapabilityResponse describes how a client may subscribe to the events
+// websocket, so it can pick a connection flow without version-sniffing.
+//
+// The field that matters is DeclaredChannels. A server predating that support
+// ignores ?channels=, answers required_action:"subscribe", and closes the
+// connection after the grace period — so a client that cannot send a subscribe
+// frame has no safe way to discover the difference from the socket itself.
+type eventsCapabilityResponse struct {
+	SchemaVersion int `json:"schema_version"`
+	// SubscribeFrame reports the handshake: connect, then send a subscribe
+	// frame. Always true; named so a future removal is detectable rather than
+	// silent.
+	SubscribeFrame bool `json:"subscribe_frame"`
+	// DeclaredChannels reports that ?channels= is honored on connect, that such
+	// a connection is exempt from the subscribe grace period, and that its
+	// hello frame carries required_action:"none".
+	DeclaredChannels bool `json:"declared_channels"`
+	// SubscribeGracePeriodSeconds is how long a connection that declared no
+	// channels may stay silent before it is closed. 0 would mean no deadline.
+	SubscribeGracePeriodSeconds int `json:"subscribe_grace_period_seconds"`
+	// Channels is every channel this server knows, independent of role. What
+	// the caller may actually subscribe to arrives as available_channels in the
+	// hello frame, which is role-filtered.
+	Channels []evt.EventChannel `json:"channels"`
+}
+
+// HandleCapability reports the events websocket's subscription capabilities.
+//
+// Per the v1 rules, new functionality is feature-detected rather than inferred
+// from a version. This follows the existing per-subsystem convention
+// (/notifications/capability, /playback/capability, /downloads/capability).
+func (h *EventsHandler) HandleCapability(w http.ResponseWriter, r *http.Request) {
+	w.Header().Set("Content-Type", "application/json")
+	_ = json.NewEncoder(w).Encode(eventsCapabilityResponse{
+		SchemaVersion:               1,
+		SubscribeFrame:              true,
+		DeclaredChannels:            true,
+		SubscribeGracePeriodSeconds: int(subscribeGracePeriod.Seconds()),
+		Channels:                    evt.AllChannels,
+	})
+}

--- a/internal/api/handlers/events_capability.go
+++ b/internal/api/handlers/events_capability.go
@@ -27,10 +27,18 @@ type eventsCapabilityResponse struct {
 	// a connection is exempt from the subscribe grace period, and that its
 	// hello frame carries required_action:"none".
 	DeclaredChannels bool `json:"declared_channels"`
-	// SubscribeGracePeriodSeconds is how long a connection that declared no
-	// channels may stay silent before it is closed. 0 would mean no deadline.
+	// SubscribeGracePeriodSeconds is how long a connection holding no
+	// subscription may stay silent before it is closed. 0 would mean no
+	// deadline.
 	SubscribeGracePeriodSeconds int `json:"subscribe_grace_period_seconds"`
-	// Channels is every channel this server knows, independent of role. What
+	// MaxRequestedChannels is the most channels one selection may name, on the
+	// URL or in a subscribe frame. Names past it are answered with a single
+	// too_many_channels rejection rather than one per name.
+	MaxRequestedChannels int `json:"max_requested_channels"`
+	// Channels is every channel a client may ask for on this server,
+	// independent of role — not every channel the server has: the plugins
+	// channel is host-to-plugin runtime dispatch and is granted to no role, so
+	// naming it here would advertise a request that can only be refused. What
 	// the caller may actually subscribe to arrives as available_channels in the
 	// hello frame, which is role-filtered.
 	Channels []evt.EventChannel `json:"channels"`
@@ -52,6 +60,7 @@ func (h *EventsHandler) HandleCapability(w http.ResponseWriter, r *http.Request)
 		SubscribeFrame:              true,
 		DeclaredChannels:            true,
 		SubscribeGracePeriodSeconds: int(subscribeGracePeriod.Seconds()),
-		Channels:                    evt.AllChannels,
+		MaxRequestedChannels:        maxRequestedChannels,
+		Channels:                    evt.ClientChannels,
 	})
 }

--- a/internal/api/handlers/events_capability.go
+++ b/internal/api/handlers/events_capability.go
@@ -8,12 +8,15 @@ import (
 )
 
 // eventsCapabilityResponse describes how a client may subscribe to the events
-// websocket, so it can pick a connection flow without version-sniffing.
+// websocket.
 //
-// The field that matters is DeclaredChannels. A server predating that support
-// ignores ?channels=, answers required_action:"subscribe", and closes the
-// connection after the grace period — so a client that cannot send a subscribe
-// frame has no safe way to discover the difference from the socket itself.
+// Clients are expected to run a current build rather than negotiate down to an
+// old server, so this is not a branch-on-capability contract. It is how a
+// client tells the difference between "this server does not do that" and "the
+// connection failed", which is what lets it say the deployment is out of date
+// instead of failing opaquely: a server predating declared channels ignores
+// ?channels=, answers required_action:"subscribe", and closes the connection
+// after the grace period, which is indistinguishable from a broken socket.
 type eventsCapabilityResponse struct {
 	SchemaVersion int `json:"schema_version"`
 	// SubscribeFrame reports the handshake: connect, then send a subscribe
@@ -38,6 +41,10 @@ type eventsCapabilityResponse struct {
 // Per the v1 rules, new functionality is feature-detected rather than inferred
 // from a version. This follows the existing per-subsystem convention
 // (/notifications/capability, /playback/capability, /downloads/capability).
+//
+// A client that finds declared_channels false is talking to a server older than
+// its own expectations; the useful response is to tell the user to update the
+// server, not to silently fall back.
 func (h *EventsHandler) HandleCapability(w http.ResponseWriter, r *http.Request) {
 	w.Header().Set("Content-Type", "application/json")
 	_ = json.NewEncoder(w).Encode(eventsCapabilityResponse{

--- a/internal/api/handlers/events_capability_test.go
+++ b/internal/api/handlers/events_capability_test.go
@@ -42,7 +42,39 @@ func TestEventsCapabilityReportsDeclaredChannelSupport(t *testing.T) {
 		t.Errorf("subscribe_grace_period_seconds = %d, want %d", got.SubscribeGracePeriodSeconds, want)
 	}
 
-	if len(got.Channels) != len(evt.AllChannels) {
-		t.Errorf("channels = %v, want all %d channels", got.Channels, len(evt.AllChannels))
+	if got.MaxRequestedChannels != maxRequestedChannels {
+		t.Errorf("max_requested_channels = %d, want %d", got.MaxRequestedChannels, maxRequestedChannels)
+	}
+
+	if len(got.Channels) != len(evt.ClientChannels) {
+		t.Errorf("channels = %v, want all %d client channels", got.Channels, len(evt.ClientChannels))
+	}
+}
+
+// TestEventsCapabilityAdvertisesOnlySubscribableChannels is the point of
+// publishing the list at all: a client that requests everything the endpoint
+// names must not be refused any of it. The plugins channel is the case — it is
+// in evt.AllChannels but granted to no role, admin included, so advertising it
+// would send a client to a request that can only fail.
+func TestEventsCapabilityAdvertisesOnlySubscribableChannels(t *testing.T) {
+	handler := &EventsHandler{}
+	rec := httptest.NewRecorder()
+	handler.HandleCapability(rec, httptest.NewRequest(http.MethodGet, "/events/capability", nil))
+
+	var got eventsCapabilityResponse
+	if err := json.Unmarshal(rec.Body.Bytes(), &got); err != nil {
+		t.Fatalf("decoding capability: %v (%s)", err, rec.Body.String())
+	}
+
+	// An admin, on a profile-bound connection, is the most permissive caller
+	// there is. Every advertised channel must resolve for them.
+	_, accepted, rejected := resolveChannelSelection(
+		got.Channels, allowedChannelsForRole("admin"), "profile-1")
+
+	if len(rejected) != 0 {
+		t.Errorf("capability advertises channels an admin cannot subscribe to: %v", rejected)
+	}
+	if len(accepted) != len(got.Channels) {
+		t.Errorf("accepted %d of %d advertised channels", len(accepted), len(got.Channels))
 	}
 }

--- a/internal/api/handlers/events_capability_test.go
+++ b/internal/api/handlers/events_capability_test.go
@@ -1,0 +1,48 @@
+package handlers
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	evt "github.com/Silo-Server/silo-server/internal/events"
+)
+
+func TestEventsCapabilityReportsDeclaredChannelSupport(t *testing.T) {
+	handler := &EventsHandler{}
+	rec := httptest.NewRecorder()
+	handler.HandleCapability(rec, httptest.NewRequest(http.MethodGet, "/events/capability", nil))
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200", rec.Code)
+	}
+	if ct := rec.Header().Get("Content-Type"); ct != "application/json" {
+		t.Errorf("Content-Type = %q, want application/json", ct)
+	}
+
+	var got eventsCapabilityResponse
+	if err := json.Unmarshal(rec.Body.Bytes(), &got); err != nil {
+		t.Fatalf("decoding capability: %v (%s)", err, rec.Body.String())
+	}
+
+	if !got.DeclaredChannels {
+		t.Error("declared_channels = false; a client cannot detect ?channels= support")
+	}
+	if !got.SubscribeFrame {
+		t.Error("subscribe_frame = false; the handshake is still supported")
+	}
+	if got.SchemaVersion != 1 {
+		t.Errorf("schema_version = %d, want 1", got.SchemaVersion)
+	}
+
+	// The advertised grace period must be the one the handler actually
+	// enforces, or a client will size its handshake timeout against fiction.
+	if want := int(subscribeGracePeriod.Seconds()); got.SubscribeGracePeriodSeconds != want {
+		t.Errorf("subscribe_grace_period_seconds = %d, want %d", got.SubscribeGracePeriodSeconds, want)
+	}
+
+	if len(got.Channels) != len(evt.AllChannels) {
+		t.Errorf("channels = %v, want all %d channels", got.Channels, len(evt.AllChannels))
+	}
+}

--- a/internal/api/handlers/events_ws.go
+++ b/internal/api/handlers/events_ws.go
@@ -5,6 +5,8 @@ import (
 	"encoding/json"
 	"log/slog"
 	"net/http"
+	"net/url"
+	"strings"
 	"time"
 
 	"github.com/Silo-Server/silo-server/internal/adminjob"
@@ -29,6 +31,19 @@ type taskInfoLister interface {
 }
 
 const maxRealtimeScanSnapshotRuns = 500
+
+// subscribeGracePeriod bounds how long a connection that did not declare its
+// channels on the URL may stay silent before it is closed. It exists to
+// distinguish a client mid-handshake from one that connected and stalled;
+// connections that arrived with ?channels= are never put on this clock.
+const subscribeGracePeriod = 5 * time.Second
+
+// required_action values in the hello frame: whether the client still owes a
+// subscribe frame, or already declared its channels on the URL.
+const (
+	requiredActionSubscribe = "subscribe"
+	requiredActionNone      = "none"
+)
 
 type activeScanLister interface {
 	ListActiveSnapshot(ctx context.Context, limit int) ([]evt.ScanRun, error)
@@ -138,15 +153,48 @@ func (h *EventsHandler) HandleWebSocket(w http.ResponseWriter, r *http.Request) 
 	})
 
 	allowedChannels := allowedChannelsForRole(claims.Role)
+
+	// A connection may declare its channels on the URL instead of sending a
+	// subscribe frame. That is all an observer needs — subscribe is the only
+	// inbound message this endpoint accepts — so declaring up front lets a
+	// read-only client skip the handshake, the grace period, and the write
+	// half of the socket entirely.
+	declaredChannels, declared := parseDeclaredChannels(r.URL.Query())
+
+	requiredAction := requiredActionSubscribe
+	if declared {
+		requiredAction = requiredActionNone
+	}
 	connectionID := ulid.Make().String()
 	if err := writeWebSocketJSON(conn, evt.EventsHelloMessage{
 		Type:              "hello",
 		SchemaVersion:     1,
 		ConnectionID:      connectionID,
 		AvailableChannels: allowedChannels,
-		RequiredAction:    "subscribe",
+		RequiredAction:    requiredAction,
 	}); err != nil {
 		return
+	}
+
+	subscriptions := make(map[evt.EventChannel]struct{})
+	if declared {
+		subs, accepted, rejected := resolveChannelSelection(declaredChannels, allowedChannels, boundProfileID)
+		subscriptions = subs
+		// The same subscribed frame the handshake produces, so a client sees
+		// one acknowledgement shape however it selected its channels — and
+		// still learns which of its requests were refused, and why.
+		if err := writeWebSocketJSON(conn, evt.EventsSubscribedMessage{
+			Type:     "subscribed",
+			Channels: accepted,
+			Rejected: rejected,
+		}); err != nil {
+			return
+		}
+		for _, channel := range accepted {
+			if err := h.writeSnapshotFrame(conn, r, claims, boundProfileID, channel); err != nil {
+				return
+			}
+		}
 	}
 
 	readMessages := make(chan []byte, 8)
@@ -166,11 +214,16 @@ func (h *EventsHandler) HandleWebSocket(w http.ResponseWriter, r *http.Request) 
 		}
 	}()
 
-	deadline := time.NewTimer(5 * time.Second)
-	defer deadline.Stop()
-
-	subscriptions := make(map[evt.EventChannel]struct{})
-	subscribedOnce := false
+	// A connection that declared its channels on the URL is already subscribed
+	// and has nothing left to say, so it is never put on the grace-period
+	// clock. Only a connection still owing a subscribe frame is. A nil channel
+	// blocks forever, which is exactly the disarmed case.
+	var deadlineC <-chan time.Time
+	if !declared {
+		deadline := time.NewTimer(subscribeGracePeriod)
+		defer deadline.Stop()
+		deadlineC = deadline.C
+	}
 
 	for {
 		select {
@@ -178,11 +231,8 @@ func (h *EventsHandler) HandleWebSocket(w http.ResponseWriter, r *http.Request) 
 			return
 		case <-readDone:
 			return
-		case <-deadline.C:
-			if subscribedOnce {
-				continue
-			}
-			writeWebSocketError(conn, "bad_request", "subscribe is required within 5 seconds")
+		case <-deadlineC:
+			writeWebSocketError(conn, "bad_request", "subscribe is required within "+subscribeGracePeriod.String())
 			_ = writeWebSocketControl(
 				conn,
 				websocket.CloseMessage,
@@ -197,13 +247,10 @@ func (h *EventsHandler) HandleWebSocket(w http.ResponseWriter, r *http.Request) 
 			if !handled {
 				continue
 			}
-			subscribedOnce = true
-			if !deadline.Stop() {
-				select {
-				case <-deadline.C:
-				default:
-				}
-			}
+			// Obligation discharged: detach the timer so a later tick cannot
+			// close a connection that has since subscribed. The timer itself
+			// is stopped by the deferred Stop above.
+			deadlineC = nil
 			subscriptions = nextSubs
 		case env, ok := <-eventsCh:
 			if !ok {
@@ -263,6 +310,40 @@ func (h *EventsHandler) handleEventsClientMessage(
 		return nil, false, false
 	}
 
+	nextSubs, accepted, rejected := resolveChannelSelection(message.Channels, allowed, boundProfileID)
+
+	if err := writeWebSocketJSON(conn, evt.EventsSubscribedMessage{
+		Type:      "subscribed",
+		RequestID: message.RequestID,
+		Channels:  accepted,
+		Rejected:  rejected,
+	}); err != nil {
+		return nil, false, false
+	}
+
+	for _, channel := range accepted {
+		if err := h.writeSnapshotFrame(conn, r, claims, boundProfileID, channel); err != nil {
+			return nil, false, false
+		}
+	}
+
+	return nextSubs, true, true
+}
+
+// resolveChannelSelection decides which of the requested channels a connection
+// may subscribe to. It is the single place that answers that question, shared
+// by the URL-declared path and the subscribe frame so the two cannot drift.
+//
+// Every rejection is reported rather than fatal: an unknown, forbidden, or
+// profile-requiring channel costs the caller that channel and nothing else.
+// Closing the connection instead would take down every other channel it holds
+// over one bad name, and a client cannot always know which channels its role
+// allows before it asks.
+func resolveChannelSelection(
+	requested []evt.EventChannel,
+	allowed []evt.EventChannel,
+	boundProfileID string,
+) (map[evt.EventChannel]struct{}, []evt.EventChannel, []evt.EventsRejectedChannel) {
 	allowedSet := make(map[evt.EventChannel]struct{}, len(allowed))
 	for _, channel := range allowed {
 		allowedSet[channel] = struct{}{}
@@ -272,19 +353,18 @@ func (h *EventsHandler) handleEventsClientMessage(
 		validSet[channel] = struct{}{}
 	}
 
-	nextSubs := make(map[evt.EventChannel]struct{}, len(message.Channels))
-	accepted := make([]evt.EventChannel, 0, len(message.Channels))
+	subs := make(map[evt.EventChannel]struct{}, len(requested))
+	accepted := make([]evt.EventChannel, 0, len(requested))
 	rejected := make([]evt.EventsRejectedChannel, 0)
 
-	for _, channel := range message.Channels {
+	for _, channel := range requested {
 		if _, ok := validSet[channel]; !ok {
-			writeWebSocketError(conn, "bad_request", "Invalid channel")
-			_ = writeWebSocketControl(
-				conn,
-				websocket.CloseMessage,
-				websocket.FormatCloseMessage(websocket.ClosePolicyViolation, "invalid channel"),
-			)
-			return nil, false, false
+			rejected = append(rejected, evt.EventsRejectedChannel{
+				Channel: channel,
+				Code:    "unknown_channel",
+				Message: "Unknown channel",
+			})
+			continue
 		}
 		if _, ok := allowedSet[channel]; !ok {
 			rejected = append(rejected, evt.EventsRejectedChannel{
@@ -304,29 +384,35 @@ func (h *EventsHandler) handleEventsClientMessage(
 			})
 			continue
 		}
-		if _, seen := nextSubs[channel]; seen {
+		if _, seen := subs[channel]; seen {
 			continue
 		}
-		nextSubs[channel] = struct{}{}
+		subs[channel] = struct{}{}
 		accepted = append(accepted, channel)
 	}
 
-	if err := writeWebSocketJSON(conn, evt.EventsSubscribedMessage{
-		Type:      "subscribed",
-		RequestID: message.RequestID,
-		Channels:  accepted,
-		Rejected:  rejected,
-	}); err != nil {
-		return nil, false, false
+	return subs, accepted, rejected
+}
+
+// parseDeclaredChannels reads the optional ?channels= selection a connection
+// may declare on the URL, letting a read-only observer skip the subscribe
+// handshake entirely. An absent parameter returns ok=false, which keeps the
+// handshake (and its grace period) in force; an empty or all-blank value is a
+// deliberate declaration of nothing, so it returns ok=true and no channels.
+func parseDeclaredChannels(query url.Values) ([]evt.EventChannel, bool) {
+	if !query.Has("channels") {
+		return nil, false
 	}
 
-	for _, channel := range accepted {
-		if err := h.writeSnapshotFrame(conn, r, claims, boundProfileID, channel); err != nil {
-			return nil, false, false
+	channels := make([]evt.EventChannel, 0, 4)
+	for _, raw := range strings.Split(query.Get("channels"), ",") {
+		name := strings.TrimSpace(raw)
+		if name == "" {
+			continue
 		}
+		channels = append(channels, evt.EventChannel(name))
 	}
-
-	return nextSubs, true, true
+	return channels, true
 }
 
 func allowedChannelsForRole(role string) []evt.EventChannel {

--- a/internal/api/handlers/events_ws.go
+++ b/internal/api/handlers/events_ws.go
@@ -6,6 +6,7 @@ import (
 	"log/slog"
 	"net/http"
 	"net/url"
+	"strconv"
 	"strings"
 	"time"
 
@@ -32,18 +33,40 @@ type taskInfoLister interface {
 
 const maxRealtimeScanSnapshotRuns = 500
 
-// subscribeGracePeriod bounds how long a connection that did not declare its
-// channels on the URL may stay silent before it is closed. It exists to
-// distinguish a client mid-handshake from one that connected and stalled;
-// connections that arrived with ?channels= are never put on this clock.
+// subscribeGracePeriod bounds how long a connection that is not subscribed to
+// anything may stay silent before it is closed. It exists to distinguish a
+// client mid-handshake from one that connected and stalled; a connection that
+// arrived with a usable ?channels= selection is never put on this clock.
 const subscribeGracePeriod = 5 * time.Second
 
+// maxRequestedChannels bounds how many distinct channels one selection may
+// name. Every refusal is echoed back with its channel name, so without a cap a
+// selection of many unknown names is an amplifier: the request is bounded by
+// the header/frame limit, the answer was not. Any real client names a subset of
+// the ten client channels; the slack is only so a caller learns it overshot
+// rather than silently losing channels.
+const maxRequestedChannels = 32
+
+// maxChannelNameLength bounds the channel name echoed in a rejection. A name
+// longer than any real channel is garbage by definition, and quoting it back in
+// full is the second half of the same amplification.
+const maxChannelNameLength = 64
+
+// maxEventsFrameBytes bounds an inbound frame on this socket. The only message
+// it accepts is a subscribe frame naming at most maxRequestedChannels channels,
+// which is orders of magnitude smaller; the limit exists so a client cannot
+// make the server buffer an arbitrarily large frame before it is rejected.
+const maxEventsFrameBytes = 64 * 1024
+
 // required_action values in the hello frame: whether the client still owes a
-// subscribe frame, or already declared its channels on the URL.
+// subscribe frame, or already holds a subscription it declared on the URL.
 const (
 	requiredActionSubscribe = "subscribe"
 	requiredActionNone      = "none"
 )
+
+// frameTypeSubscribed is the acknowledgement both selection paths answer with.
+const frameTypeSubscribed = "subscribed"
 
 type activeScanLister interface {
 	ListActiveSnapshot(ctx context.Context, limit int) ([]evt.ScanRun, error)
@@ -142,6 +165,7 @@ func (h *EventsHandler) HandleWebSocket(w http.ResponseWriter, r *http.Request) 
 	}
 	defer conn.Close()
 	configureWebSocket(conn)
+	conn.SetReadLimit(maxEventsFrameBytes)
 
 	ctx, cancel := context.WithCancel(r.Context())
 	defer cancel()
@@ -161,8 +185,24 @@ func (h *EventsHandler) HandleWebSocket(w http.ResponseWriter, r *http.Request) 
 	// half of the socket entirely.
 	declaredChannels, declared := parseDeclaredChannels(r.URL.Query())
 
-	requiredAction := requiredActionSubscribe
+	// Resolved before the hello frame so required_action can report what the
+	// connection actually owes. Resolution is pure — no query, no I/O — so
+	// nothing here can stall ahead of the reader that starts below; only the
+	// snapshots the accepted channels produce can, and those still run after
+	// it.
+	declaredSubs := make(map[evt.EventChannel]struct{})
+	var declaredAccepted []evt.EventChannel
+	var declaredRejected []evt.EventsRejectedChannel
 	if declared {
+		declaredSubs, declaredAccepted, declaredRejected =
+			resolveChannelSelection(declaredChannels, allowedChannels, boundProfileID)
+	}
+
+	// A declaration that yielded no subscription discharges nothing: the client
+	// still owes a subscribe frame, and saying "none" would send it to wait
+	// silently for events on a connection due to be closed in five seconds.
+	requiredAction := requiredActionSubscribe
+	if len(declaredSubs) > 0 {
 		requiredAction = requiredActionNone
 	}
 	connectionID := ulid.Make().String()
@@ -200,33 +240,36 @@ func (h *EventsHandler) HandleWebSocket(w http.ResponseWriter, r *http.Request) 
 		}
 	}()
 
-	subscriptions := make(map[evt.EventChannel]struct{})
+	subscriptions := declaredSubs
 	if declared {
-		subs, accepted, rejected := resolveChannelSelection(declaredChannels, allowedChannels, boundProfileID)
-		subscriptions = subs
 		// The same subscribed frame the handshake produces, so a client sees
 		// one acknowledgement shape however it selected its channels — and
 		// still learns which of its requests were refused, and why.
 		if err := writeWebSocketJSON(conn, evt.EventsSubscribedMessage{
-			Type:     "subscribed",
-			Channels: accepted,
-			Rejected: rejected,
+			Type:     frameTypeSubscribed,
+			Channels: declaredAccepted,
+			Rejected: declaredRejected,
 		}); err != nil {
 			return
 		}
-		for _, channel := range accepted {
+		for _, channel := range declaredAccepted {
 			if err := h.writeSnapshotFrame(conn, r, claims, boundProfileID, channel); err != nil {
 				return
 			}
 		}
 	}
 
-	// A connection that declared its channels on the URL is already subscribed
-	// and has nothing left to say, so it is never put on the grace-period
-	// clock. Only a connection still owing a subscribe frame is. A nil channel
-	// blocks forever, which is exactly the disarmed case.
+	// The clock is disarmed by holding a subscription, not by having declared
+	// one. A declaration that resolved to nothing — ?channels= with no names,
+	// or a selection every entry of which was refused — leaves the connection
+	// in exactly the state the grace period exists to reap: subscribed to
+	// nothing, with no reason to expect it to ever receive a frame, while still
+	// holding a hub subscriber, two goroutines, and an envelope channel that
+	// every published event fans into. Such a client still owes a subscribe
+	// frame, and its rejected list told it why. A nil channel blocks forever,
+	// which is exactly the disarmed case.
 	var deadlineC <-chan time.Time
-	if !declared {
+	if len(subscriptions) == 0 {
 		deadline := time.NewTimer(subscribeGracePeriod)
 		defer deadline.Stop()
 		deadlineC = deadline.C
@@ -320,7 +363,7 @@ func (h *EventsHandler) handleEventsClientMessage(
 	nextSubs, accepted, rejected := resolveChannelSelection(message.Channels, allowed, boundProfileID)
 
 	if err := writeWebSocketJSON(conn, evt.EventsSubscribedMessage{
-		Type:      "subscribed",
+		Type:      frameTypeSubscribed,
 		RequestID: message.RequestID,
 		Channels:  accepted,
 		Rejected:  rejected,
@@ -346,6 +389,11 @@ func (h *EventsHandler) handleEventsClientMessage(
 // Closing the connection instead would take down every other channel it holds
 // over one bad name, and a client cannot always know which channels its role
 // allows before it asks.
+//
+// Because refusals are answered instead of closing the connection, the answer
+// has to be bounded independently of the request: at most maxRequestedChannels
+// distinct names are considered, and an overrun is reported once rather than
+// per excess name.
 func resolveChannelSelection(
 	requested []evt.EventChannel,
 	allowed []evt.EventChannel,
@@ -355,20 +403,25 @@ func resolveChannelSelection(
 	for _, channel := range allowed {
 		allowedSet[channel] = struct{}{}
 	}
-	validSet := make(map[evt.EventChannel]struct{}, len(evt.AllChannels))
-	for _, channel := range evt.AllChannels {
+	validSet := make(map[evt.EventChannel]struct{}, len(evt.ClientChannels))
+	for _, channel := range evt.ClientChannels {
 		validSet[channel] = struct{}{}
 	}
 
-	subs := make(map[evt.EventChannel]struct{}, len(requested))
-	accepted := make([]evt.EventChannel, 0, len(requested))
-	rejected := make([]evt.EventsRejectedChannel, 0)
+	capacity := min(len(requested), maxRequestedChannels)
+	subs := make(map[evt.EventChannel]struct{}, capacity)
+	accepted := make([]evt.EventChannel, 0, capacity)
+	rejected := make([]evt.EventsRejectedChannel, 0, capacity)
 	// A repeated channel is answered once whether it was accepted or refused.
 	// Only the accepted side deduplicated before this change, so asking twice
 	// for one forbidden channel produced two identical rejections.
-	seen := make(map[evt.EventChannel]struct{}, len(requested))
+	seen := make(map[evt.EventChannel]struct{}, capacity)
 
 	reject := func(channel evt.EventChannel, code, message string) {
+		// A garbage name is echoed back only far enough to be recognizable.
+		if len(channel) > maxChannelNameLength {
+			channel = channel[:maxChannelNameLength]
+		}
 		rejected = append(rejected, evt.EventsRejectedChannel{
 			Channel: channel,
 			Code:    code,
@@ -380,13 +433,24 @@ func resolveChannelSelection(
 		if _, dup := seen[channel]; dup {
 			continue
 		}
+		if len(seen) >= maxRequestedChannels {
+			// One entry for the whole overrun, not one per name: the point of
+			// the cap is that the response cannot grow with the request.
+			reject("", "too_many_channels",
+				"At most "+strconv.Itoa(maxRequestedChannels)+" channels may be requested at once")
+			break
+		}
 		seen[channel] = struct{}{}
 
 		switch {
 		case !contains(validSet, channel):
 			reject(channel, "unknown_channel", "Unknown channel")
 		case !contains(allowedSet, channel):
-			reject(channel, "forbidden", "Admin access required")
+			// Deliberately not "admin access required": the caller's role is
+			// the usual reason a channel is refused but not the only one, and a
+			// remedy that does not exist reads as a bug in the client's own
+			// permissions rather than a channel it was never going to get.
+			reject(channel, "forbidden", "This channel is not available to this connection")
 		// The notifications channel is profile-scoped: it requires a
 		// connection bound to a profile via a websocket ticket.
 		case channel == evt.ChannelNotifications && boundProfileID == "":
@@ -410,18 +474,27 @@ func contains(set map[evt.EventChannel]struct{}, channel evt.EventChannel) bool 
 // handshake entirely. An absent parameter returns ok=false, which keeps the
 // handshake (and its grace period) in force; an empty or all-blank value is a
 // deliberate declaration of nothing, so it returns ok=true and no channels.
+//
+// Every occurrence of the parameter is read, not just the first. Repeating a
+// query parameter is as natural a spelling as a comma-separated list, and
+// honoring one and silently discarding the rest loses channels with no
+// diagnostic — the connection would come up subscribed to less than it asked
+// for and report nothing rejected.
 func parseDeclaredChannels(query url.Values) ([]evt.EventChannel, bool) {
-	if !query.Has("channels") {
+	values, ok := query["channels"]
+	if !ok {
 		return nil, false
 	}
 
 	channels := make([]evt.EventChannel, 0, 4)
-	for _, raw := range strings.Split(query.Get("channels"), ",") {
-		name := strings.TrimSpace(raw)
-		if name == "" {
-			continue
+	for _, value := range values {
+		for _, raw := range strings.Split(value, ",") {
+			name := strings.TrimSpace(raw)
+			if name == "" {
+				continue
+			}
+			channels = append(channels, evt.EventChannel(name))
 		}
-		channels = append(channels, evt.EventChannel(name))
 	}
 	return channels, true
 }

--- a/internal/api/handlers/events_ws.go
+++ b/internal/api/handlers/events_ws.go
@@ -176,6 +176,30 @@ func (h *EventsHandler) HandleWebSocket(w http.ResponseWriter, r *http.Request) 
 		return
 	}
 
+	// The reader starts before any snapshot query runs. configureWebSocket
+	// installs an absolute read deadline that only pongs extend, and gorilla
+	// processes pongs solely inside ReadMessage — so a snapshot slow enough to
+	// outlast the deadline (a loaded jobs/sessions/scans query) would kill an
+	// otherwise healthy connection the moment reading began. The handshake path
+	// is safe for free, building its snapshots downstream of an active reader;
+	// the declared path has to arrange that ordering deliberately.
+	readMessages := make(chan []byte, 8)
+	readDone := make(chan struct{})
+	go func() {
+		defer close(readDone)
+		for {
+			_, data, readErr := conn.ReadMessage()
+			if readErr != nil {
+				return
+			}
+			select {
+			case readMessages <- data:
+			case <-ctx.Done():
+				return
+			}
+		}
+	}()
+
 	subscriptions := make(map[evt.EventChannel]struct{})
 	if declared {
 		subs, accepted, rejected := resolveChannelSelection(declaredChannels, allowedChannels, boundProfileID)
@@ -196,23 +220,6 @@ func (h *EventsHandler) HandleWebSocket(w http.ResponseWriter, r *http.Request) 
 			}
 		}
 	}
-
-	readMessages := make(chan []byte, 8)
-	readDone := make(chan struct{})
-	go func() {
-		defer close(readDone)
-		for {
-			_, data, readErr := conn.ReadMessage()
-			if readErr != nil {
-				return
-			}
-			select {
-			case readMessages <- data:
-			case <-ctx.Done():
-				return
-			}
-		}
-	}()
 
 	// A connection that declared its channels on the URL is already subscribed
 	// and has nothing left to say, so it is never put on the grace-period
@@ -356,42 +363,46 @@ func resolveChannelSelection(
 	subs := make(map[evt.EventChannel]struct{}, len(requested))
 	accepted := make([]evt.EventChannel, 0, len(requested))
 	rejected := make([]evt.EventsRejectedChannel, 0)
+	// A repeated channel is answered once whether it was accepted or refused.
+	// Only the accepted side deduplicated before this change, so asking twice
+	// for one forbidden channel produced two identical rejections.
+	seen := make(map[evt.EventChannel]struct{}, len(requested))
+
+	reject := func(channel evt.EventChannel, code, message string) {
+		rejected = append(rejected, evt.EventsRejectedChannel{
+			Channel: channel,
+			Code:    code,
+			Message: message,
+		})
+	}
 
 	for _, channel := range requested {
-		if _, ok := validSet[channel]; !ok {
-			rejected = append(rejected, evt.EventsRejectedChannel{
-				Channel: channel,
-				Code:    "unknown_channel",
-				Message: "Unknown channel",
-			})
+		if _, dup := seen[channel]; dup {
 			continue
 		}
-		if _, ok := allowedSet[channel]; !ok {
-			rejected = append(rejected, evt.EventsRejectedChannel{
-				Channel: channel,
-				Code:    "forbidden",
-				Message: "Admin access required",
-			})
-			continue
-		}
+		seen[channel] = struct{}{}
+
+		switch {
+		case !contains(validSet, channel):
+			reject(channel, "unknown_channel", "Unknown channel")
+		case !contains(allowedSet, channel):
+			reject(channel, "forbidden", "Admin access required")
 		// The notifications channel is profile-scoped: it requires a
 		// connection bound to a profile via a websocket ticket.
-		if channel == evt.ChannelNotifications && boundProfileID == "" {
-			rejected = append(rejected, evt.EventsRejectedChannel{
-				Channel: channel,
-				Code:    "profile_required",
-				Message: "A profile-bound websocket ticket is required",
-			})
-			continue
+		case channel == evt.ChannelNotifications && boundProfileID == "":
+			reject(channel, "profile_required", "A profile-bound websocket ticket is required")
+		default:
+			subs[channel] = struct{}{}
+			accepted = append(accepted, channel)
 		}
-		if _, seen := subs[channel]; seen {
-			continue
-		}
-		subs[channel] = struct{}{}
-		accepted = append(accepted, channel)
 	}
 
 	return subs, accepted, rejected
+}
+
+func contains(set map[evt.EventChannel]struct{}, channel evt.EventChannel) bool {
+	_, ok := set[channel]
+	return ok
 }
 
 // parseDeclaredChannels reads the optional ?channels= selection a connection

--- a/internal/api/handlers/events_ws_declared_channels_test.go
+++ b/internal/api/handlers/events_ws_declared_channels_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/Silo-Server/silo-server/internal/auth"
 	"github.com/Silo-Server/silo-server/internal/cache"
 	evt "github.com/Silo-Server/silo-server/internal/events"
+	"github.com/Silo-Server/silo-server/internal/taskmanager"
 )
 
 // eventsWSTestConn dials the events websocket against a handler authenticated
@@ -29,8 +30,17 @@ func eventsWSTestConn(t *testing.T, hub *evt.Hub, claims *auth.Claims, query str
 	func(wantType string) map[string]json.RawMessage,
 ) {
 	t.Helper()
+	return eventsWSTestConnWithHandler(t, &EventsHandler{hub: hub}, claims, query)
+}
 
-	handler := &EventsHandler{hub: hub}
+func eventsWSTestConnWithHandler(
+	t *testing.T,
+	handler *EventsHandler,
+	claims *auth.Claims,
+	query string,
+) (*websocket.Conn, func(wantType string) map[string]json.RawMessage) {
+	t.Helper()
+
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		ctx := apimw.SetClaims(r.Context(), claims)
 		handler.HandleWebSocket(w, r.WithContext(ctx))
@@ -244,6 +254,66 @@ func TestEventsWebSocketUnknownChannelDoesNotCloseConnection(t *testing.T) {
 	}
 }
 
+// slowTaskLister stalls the tasks snapshot long enough to outlast the read
+// deadline configureWebSocket installs at connect.
+type slowTaskLister struct{ delay time.Duration }
+
+func (s slowTaskLister) ListTasks(bool) []taskmanager.TaskInfo {
+	time.Sleep(s.delay)
+	return []taskmanager.TaskInfo{}
+}
+
+// TestEventsWebSocketDeclaredChannelsSurviveSlowSnapshot pins the ordering the
+// declared path depends on. configureWebSocket sets an absolute read deadline
+// that only pongs extend, and gorilla processes pongs solely inside
+// ReadMessage — so if snapshot queries ran before the reader goroutine started,
+// a snapshot slower than the deadline would kill a healthy connection the
+// instant reading began. The handshake path gets this for free by building
+// snapshots downstream of an active reader; the declared path arranges it
+// deliberately.
+func TestEventsWebSocketDeclaredChannelsSurviveSlowSnapshot(t *testing.T) {
+	if testing.Short() {
+		t.Skip("stalls a snapshot past the websocket read deadline in real time")
+	}
+
+	hub := evt.NewHub("test", &cache.NoopEventBus{})
+	handler := &EventsHandler{
+		hub:   hub,
+		tasks: slowTaskLister{delay: wsPingInterval + wsPongTimeout + 2*time.Second},
+	}
+
+	conn, readFrame := eventsWSTestConnWithHandler(t, handler,
+		&auth.Claims{UserID: 1, Role: "admin"}, "?channels=tasks")
+
+	readFrame("hello")
+	readFrame("subscribed")
+
+	// The snapshot arrives late by design; allow for the stall plus slack.
+	if err := conn.SetReadDeadline(time.Now().Add(wsPingInterval + wsPongTimeout + 15*time.Second)); err != nil {
+		t.Fatalf("setting read deadline: %v", err)
+	}
+	_, data, err := conn.ReadMessage()
+	if err != nil {
+		t.Fatalf("connection died during a slow snapshot: %v", err)
+	}
+	var frame map[string]json.RawMessage
+	if err := json.Unmarshal(data, &frame); err != nil {
+		t.Fatalf("frame is not JSON: %v (%s)", err, data)
+	}
+	if string(frame["type"]) != `"snapshot"` {
+		t.Fatalf("frame type = %s, want \"snapshot\" (frame: %s)", frame["type"], data)
+	}
+
+	// And the connection is still live afterwards.
+	if err := hub.PublishJSON(context.Background(), evt.ChannelTasks, "tasks.changed",
+		map[string]string{"id": "t1"}, evt.PublishOptions{}); err != nil {
+		t.Fatalf("publishing: %v", err)
+	}
+	if event := readFrame("event"); string(event["channel"]) != `"tasks"` {
+		t.Errorf("event channel = %s, want tasks", event["channel"])
+	}
+}
+
 func TestParseDeclaredChannels(t *testing.T) {
 	tests := []struct {
 		name     string
@@ -321,11 +391,9 @@ func TestResolveChannelSelectionDeniesByDefault(t *testing.T) {
 }
 
 func TestResolveChannelSelectionDeduplicates(t *testing.T) {
-	allowed := allowedChannelsForRole("admin")
-
 	subs, accepted, rejected := resolveChannelSelection(
 		[]evt.EventChannel{evt.ChannelJobs, evt.ChannelJobs},
-		allowed,
+		allowedChannelsForRole("admin"),
 		"",
 	)
 
@@ -334,5 +402,23 @@ func TestResolveChannelSelectionDeduplicates(t *testing.T) {
 	}
 	if len(rejected) != 0 {
 		t.Fatalf("unexpected rejections: %v", rejected)
+	}
+}
+
+// TestResolveChannelSelectionDeduplicatesRejections covers the other half of
+// dedup: a channel asked for twice is answered once whether it was accepted or
+// refused. Only the accepted side deduplicated before.
+func TestResolveChannelSelectionDeduplicatesRejections(t *testing.T) {
+	_, _, rejected := resolveChannelSelection(
+		[]evt.EventChannel{
+			evt.ChannelSessions, evt.ChannelSessions, // forbidden for a user
+			"bogus", "bogus", // unknown
+		},
+		allowedChannelsForRole("user"),
+		"",
+	)
+
+	if len(rejected) != 2 {
+		t.Fatalf("rejected = %v, want one entry per distinct channel", rejected)
 	}
 }

--- a/internal/api/handlers/events_ws_declared_channels_test.go
+++ b/internal/api/handlers/events_ws_declared_channels_test.go
@@ -1,0 +1,338 @@
+package handlers
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/gorilla/websocket"
+
+	apimw "github.com/Silo-Server/silo-server/internal/api/middleware"
+	"github.com/Silo-Server/silo-server/internal/auth"
+	"github.com/Silo-Server/silo-server/internal/cache"
+	evt "github.com/Silo-Server/silo-server/internal/events"
+)
+
+// eventsWSTestConn dials the events websocket against a handler authenticated
+// as the given claims, and returns a frame reader. These tests go through the
+// real socket rather than calling the handler directly because the behavior
+// under test — what a connection is subscribed to before it has said anything,
+// and whether it survives the grace period — only exists in the connection
+// loop.
+func eventsWSTestConn(t *testing.T, hub *evt.Hub, claims *auth.Claims, query string) (
+	*websocket.Conn,
+	func(wantType string) map[string]json.RawMessage,
+) {
+	t.Helper()
+
+	handler := &EventsHandler{hub: hub}
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		ctx := apimw.SetClaims(r.Context(), claims)
+		handler.HandleWebSocket(w, r.WithContext(ctx))
+	}))
+	t.Cleanup(server.Close)
+
+	conn, resp, err := websocket.DefaultDialer.Dial("ws"+strings.TrimPrefix(server.URL, "http")+query, nil)
+	if err != nil {
+		t.Fatalf("dialing events websocket: %v", err)
+	}
+	if resp != nil && resp.Body != nil {
+		t.Cleanup(func() { _ = resp.Body.Close() })
+	}
+	t.Cleanup(func() { _ = conn.Close() })
+
+	readFrame := func(wantType string) map[string]json.RawMessage {
+		t.Helper()
+		if err := conn.SetReadDeadline(time.Now().Add(5 * time.Second)); err != nil {
+			t.Fatalf("setting read deadline: %v", err)
+		}
+		_, data, err := conn.ReadMessage()
+		if err != nil {
+			t.Fatalf("reading %s frame: %v", wantType, err)
+		}
+		var frame map[string]json.RawMessage
+		if err := json.Unmarshal(data, &frame); err != nil {
+			t.Fatalf("frame is not JSON: %v (%s)", err, data)
+		}
+		if string(frame["type"]) != `"`+wantType+`"` {
+			t.Fatalf("frame type = %s, want %q (frame: %s)", frame["type"], wantType, data)
+		}
+		return frame
+	}
+
+	return conn, readFrame
+}
+
+// TestEventsWebSocketDeclaredChannelsSkipHandshake is the point of the feature:
+// a connection that named its channels on the URL receives events without ever
+// writing to the socket.
+func TestEventsWebSocketDeclaredChannelsSkipHandshake(t *testing.T) {
+	hub := evt.NewHub("test", &cache.NoopEventBus{})
+	_, readFrame := eventsWSTestConn(t, hub,
+		&auth.Claims{UserID: 1, Role: "user"}, "?channels=user_settings")
+
+	hello := readFrame("hello")
+	if string(hello["required_action"]) != `"none"` {
+		t.Errorf("required_action = %s, want \"none\"", hello["required_action"])
+	}
+
+	subscribed := readFrame("subscribed")
+	if !strings.Contains(string(subscribed["channels"]), `"user_settings"`) {
+		t.Fatalf("declared channel was not accepted: %s", subscribed["channels"])
+	}
+
+	// Accepted channels hydrate with a snapshot, exactly as the handshake does.
+	if snapshot := readFrame("snapshot"); string(snapshot["channel"]) != `"user_settings"` {
+		t.Fatalf("snapshot channel = %s, want user_settings", snapshot["channel"])
+	}
+
+	publishUserSettingsEvent(context.Background(), hub, 1, "profile-1",
+		"playback.subtitle_language", "profile")
+
+	if event := readFrame("event"); string(event["channel"]) != `"user_settings"` {
+		t.Errorf("event channel = %s, want user_settings", event["channel"])
+	}
+}
+
+// TestEventsWebSocketDeclaredChannelsSurviveGracePeriod guards the core promise
+// of the change: an observer that connects and never speaks stays connected.
+// Before this, it was closed with a policy violation after five seconds.
+func TestEventsWebSocketDeclaredChannelsSurviveGracePeriod(t *testing.T) {
+	if testing.Short() {
+		t.Skip("waits out the subscribe grace period in real time")
+	}
+
+	hub := evt.NewHub("test", &cache.NoopEventBus{})
+	conn, readFrame := eventsWSTestConn(t, hub,
+		&auth.Claims{UserID: 1, Role: "user"}, "?channels=user_settings")
+
+	readFrame("hello")
+	readFrame("subscribed")
+	readFrame("snapshot")
+
+	// Stay silent well past the deadline that would have closed a
+	// handshake-style connection, then confirm the socket still delivers.
+	time.Sleep(subscribeGracePeriod + time.Second)
+
+	publishUserSettingsEvent(context.Background(), hub, 1, "profile-1",
+		"playback.subtitle_language", "profile")
+
+	if err := conn.SetReadDeadline(time.Now().Add(5 * time.Second)); err != nil {
+		t.Fatalf("setting read deadline: %v", err)
+	}
+	_, data, err := conn.ReadMessage()
+	if err != nil {
+		t.Fatalf("connection did not survive the grace period: %v", err)
+	}
+	var frame map[string]json.RawMessage
+	if err := json.Unmarshal(data, &frame); err != nil {
+		t.Fatalf("frame is not JSON: %v (%s)", err, data)
+	}
+	if string(frame["type"]) != `"event"` {
+		t.Fatalf("frame type = %s, want \"event\" (frame: %s)", frame["type"], data)
+	}
+}
+
+// TestEventsWebSocketSilentConnectionStillClosed pins the other half: the grace
+// period still applies to a connection that declared nothing, so the URL path
+// relaxes the rule rather than removing it.
+func TestEventsWebSocketSilentConnectionStillClosed(t *testing.T) {
+	if testing.Short() {
+		t.Skip("waits out the subscribe grace period in real time")
+	}
+
+	hub := evt.NewHub("test", &cache.NoopEventBus{})
+	conn, readFrame := eventsWSTestConn(t, hub, &auth.Claims{UserID: 1, Role: "user"}, "")
+
+	hello := readFrame("hello")
+	if string(hello["required_action"]) != `"subscribe"` {
+		t.Errorf("required_action = %s, want \"subscribe\"", hello["required_action"])
+	}
+
+	if err := conn.SetReadDeadline(time.Now().Add(subscribeGracePeriod + 5*time.Second)); err != nil {
+		t.Fatalf("setting read deadline: %v", err)
+	}
+	// The error frame, then the close.
+	if _, _, err := conn.ReadMessage(); err != nil {
+		t.Fatalf("reading error frame: %v", err)
+	}
+	_, _, err := conn.ReadMessage()
+	if err == nil {
+		t.Fatal("silent connection was not closed after the grace period")
+	}
+	if !websocket.IsCloseError(err, websocket.ClosePolicyViolation) {
+		t.Fatalf("close error = %v, want policy violation", err)
+	}
+}
+
+// TestEventsWebSocketDeclaredChannelsCannotEscalate is the authorization
+// guarantee: naming an admin-only channel on the URL must not grant it, and
+// must not grant the events published to it either.
+func TestEventsWebSocketDeclaredChannelsCannotEscalate(t *testing.T) {
+	hub := evt.NewHub("test", &cache.NoopEventBus{})
+	_, readFrame := eventsWSTestConn(t, hub,
+		&auth.Claims{UserID: 1, Role: "user"}, "?channels=sessions,user_settings")
+
+	readFrame("hello")
+	subscribed := readFrame("subscribed")
+
+	if strings.Contains(string(subscribed["channels"]), `"sessions"`) {
+		t.Fatalf("non-admin was granted the sessions channel: %s", subscribed["channels"])
+	}
+	if !strings.Contains(string(subscribed["rejected"]), `"forbidden"`) {
+		t.Errorf("sessions was not reported as forbidden: %s", subscribed["rejected"])
+	}
+	// The permitted channel in the same request still landed.
+	if !strings.Contains(string(subscribed["channels"]), `"user_settings"`) {
+		t.Errorf("a forbidden channel denied the rest of the request: %s", subscribed["channels"])
+	}
+
+	readFrame("snapshot") // user_settings
+
+	// An admin-only event on the refused channel must not be delivered. Publish
+	// it first, then a permitted event; receiving the second without the first
+	// proves the first was filtered rather than merely slow.
+	if err := hub.PublishJSON(context.Background(), evt.ChannelSessions, "sessions.replaced", nil,
+		evt.PublishOptions{AdminOnly: true}); err != nil {
+		t.Fatalf("publishing admin-only event: %v", err)
+	}
+	publishUserSettingsEvent(context.Background(), hub, 1, "profile-1",
+		"playback.subtitle_language", "profile")
+
+	event := readFrame("event")
+	if string(event["channel"]) != `"user_settings"` {
+		t.Fatalf("received an event on a channel this connection was refused: %s", event["channel"])
+	}
+}
+
+// TestEventsWebSocketUnknownChannelDoesNotCloseConnection covers the third
+// change: an unrecognized channel name used to close the socket outright,
+// taking down every other channel the client held over one bad name.
+func TestEventsWebSocketUnknownChannelDoesNotCloseConnection(t *testing.T) {
+	hub := evt.NewHub("test", &cache.NoopEventBus{})
+	conn, readFrame := eventsWSTestConn(t, hub, &auth.Claims{UserID: 1, Role: "user"}, "")
+
+	readFrame("hello")
+
+	if err := conn.WriteJSON(evt.EventsSubscribeMessage{
+		Type:      "subscribe",
+		RequestID: "r1",
+		Channels:  []evt.EventChannel{"not_a_channel", evt.ChannelUserSettings},
+	}); err != nil {
+		t.Fatalf("sending subscribe: %v", err)
+	}
+
+	subscribed := readFrame("subscribed")
+	if !strings.Contains(string(subscribed["rejected"]), `"unknown_channel"`) {
+		t.Errorf("unknown channel was not reported as such: %s", subscribed["rejected"])
+	}
+	if !strings.Contains(string(subscribed["channels"]), `"user_settings"`) {
+		t.Fatalf("an unknown channel denied the valid one alongside it: %s", subscribed["channels"])
+	}
+
+	// The connection is still usable.
+	readFrame("snapshot")
+	publishUserSettingsEvent(context.Background(), hub, 1, "profile-1",
+		"playback.subtitle_language", "profile")
+	if event := readFrame("event"); string(event["channel"]) != `"user_settings"` {
+		t.Errorf("event channel = %s, want user_settings", event["channel"])
+	}
+}
+
+func TestParseDeclaredChannels(t *testing.T) {
+	tests := []struct {
+		name     string
+		query    string
+		want     []evt.EventChannel
+		declared bool
+	}{
+		{
+			name:     "absent parameter keeps the handshake",
+			query:    "",
+			want:     nil,
+			declared: false,
+		},
+		{
+			name:     "empty value declares nothing, but still declares",
+			query:    "channels=",
+			want:     []evt.EventChannel{},
+			declared: true,
+		},
+		{
+			name:     "whitespace and empty entries are dropped",
+			query:    "channels=catalog,%20,,user_state%20",
+			want:     []evt.EventChannel{evt.ChannelCatalog, evt.ChannelUserState},
+			declared: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			query, err := url.ParseQuery(tt.query)
+			if err != nil {
+				t.Fatalf("parsing query: %v", err)
+			}
+			got, declared := parseDeclaredChannels(query)
+			if declared != tt.declared {
+				t.Fatalf("declared = %v, want %v", declared, tt.declared)
+			}
+			if len(got) != len(tt.want) {
+				t.Fatalf("channels = %v, want %v", got, tt.want)
+			}
+			for i := range got {
+				if got[i] != tt.want[i] {
+					t.Fatalf("channels = %v, want %v", got, tt.want)
+				}
+			}
+		})
+	}
+}
+
+func TestResolveChannelSelectionDeniesByDefault(t *testing.T) {
+	allowed := allowedChannelsForRole("user")
+
+	subs, accepted, rejected := resolveChannelSelection(
+		[]evt.EventChannel{evt.ChannelSessions, "bogus", evt.ChannelNotifications},
+		allowed,
+		"", // unbound: notifications requires a profile-bound ticket
+	)
+
+	if len(subs) != 0 || len(accepted) != 0 {
+		t.Fatalf("nothing should have been accepted: subs=%v accepted=%v", subs, accepted)
+	}
+	codes := make(map[string]evt.EventChannel, len(rejected))
+	for _, r := range rejected {
+		codes[r.Code] = r.Channel
+	}
+	if codes["forbidden"] != evt.ChannelSessions {
+		t.Errorf("sessions not rejected as forbidden: %v", rejected)
+	}
+	if codes["unknown_channel"] != "bogus" {
+		t.Errorf("bogus not rejected as unknown: %v", rejected)
+	}
+	if codes["profile_required"] != evt.ChannelNotifications {
+		t.Errorf("notifications not rejected as profile_required: %v", rejected)
+	}
+}
+
+func TestResolveChannelSelectionDeduplicates(t *testing.T) {
+	allowed := allowedChannelsForRole("admin")
+
+	subs, accepted, rejected := resolveChannelSelection(
+		[]evt.EventChannel{evt.ChannelJobs, evt.ChannelJobs},
+		allowed,
+		"",
+	)
+
+	if len(subs) != 1 || len(accepted) != 1 {
+		t.Fatalf("duplicate channel was not collapsed: subs=%v accepted=%v", subs, accepted)
+	}
+	if len(rejected) != 0 {
+		t.Fatalf("unexpected rejections: %v", rejected)
+	}
+}

--- a/internal/api/handlers/events_ws_declared_channels_test.go
+++ b/internal/api/handlers/events_ws_declared_channels_test.go
@@ -6,6 +6,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"net/url"
+	"strconv"
 	"strings"
 	"testing"
 	"time"
@@ -148,6 +149,106 @@ func TestEventsWebSocketDeclaredChannelsSurviveGracePeriod(t *testing.T) {
 	}
 }
 
+// TestEventsWebSocketEmptyDeclarationStillClosed pins what disarms the grace
+// period: holding a subscription, not having spelled ?channels=. A declaration
+// that resolved to nothing leaves the connection in the exact state the clock
+// exists to reap — no subscriptions, no reason to expect a frame, but still a
+// hub subscriber, two goroutines, and an envelope channel every published
+// event fans into.
+func TestEventsWebSocketEmptyDeclarationStillClosed(t *testing.T) {
+	if testing.Short() {
+		t.Skip("waits out the subscribe grace period in real time")
+	}
+
+	tests := []struct {
+		name  string
+		query string
+	}{
+		{name: "declares no channels", query: "?channels="},
+		// Every name refused: a non-admin naming only an admin channel is
+		// subscribed to nothing, exactly as if it had named nothing.
+		{name: "every declared channel refused", query: "?channels=sessions"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			hub := evt.NewHub("test", &cache.NoopEventBus{})
+			conn, readFrame := eventsWSTestConn(t, hub,
+				&auth.Claims{UserID: 1, Role: "user"}, tt.query)
+
+			hello := readFrame("hello")
+			// The obligation is real, so the hello frame has to say so rather
+			// than sending the client off to wait silently on a doomed socket.
+			if string(hello["required_action"]) != `"subscribe"` {
+				t.Errorf("required_action = %s, want \"subscribe\"", hello["required_action"])
+			}
+			readFrame("subscribed")
+
+			if err := conn.SetReadDeadline(time.Now().Add(subscribeGracePeriod + 5*time.Second)); err != nil {
+				t.Fatalf("setting read deadline: %v", err)
+			}
+			// The error frame, then the close.
+			if _, _, err := conn.ReadMessage(); err != nil {
+				t.Fatalf("reading error frame: %v", err)
+			}
+			if _, _, err := conn.ReadMessage(); !websocket.IsCloseError(err, websocket.ClosePolicyViolation) {
+				t.Fatalf("close error = %v, want policy violation", err)
+			}
+		})
+	}
+}
+
+// TestEventsWebSocketPartialDeclarationSurvives is the boundary case on the
+// other side: one accepted channel among refusals is a live subscription, so
+// the connection is not on the clock.
+func TestEventsWebSocketPartialDeclarationSurvives(t *testing.T) {
+	if testing.Short() {
+		t.Skip("waits out the subscribe grace period in real time")
+	}
+
+	hub := evt.NewHub("test", &cache.NoopEventBus{})
+	conn, readFrame := eventsWSTestConn(t, hub,
+		&auth.Claims{UserID: 1, Role: "user"}, "?channels=sessions,user_settings")
+
+	hello := readFrame("hello")
+	if string(hello["required_action"]) != `"none"` {
+		t.Errorf("required_action = %s, want \"none\"", hello["required_action"])
+	}
+	readFrame("subscribed")
+	readFrame("snapshot")
+
+	time.Sleep(subscribeGracePeriod + time.Second)
+
+	publishUserSettingsEvent(context.Background(), hub, 1, "profile-1",
+		"playback.subtitle_language", "profile")
+
+	if err := conn.SetReadDeadline(time.Now().Add(5 * time.Second)); err != nil {
+		t.Fatalf("setting read deadline: %v", err)
+	}
+	if _, _, err := conn.ReadMessage(); err != nil {
+		t.Fatalf("a partially accepted declaration did not survive the grace period: %v", err)
+	}
+}
+
+// TestEventsWebSocketRepeatedChannelsParameter covers the other natural
+// spelling of a selection. Honoring only the first occurrence dropped the rest
+// with an empty rejected array — the connection came up subscribed to less than
+// it asked for and reported nothing wrong.
+func TestEventsWebSocketRepeatedChannelsParameter(t *testing.T) {
+	hub := evt.NewHub("test", &cache.NoopEventBus{})
+	_, readFrame := eventsWSTestConn(t, hub, &auth.Claims{UserID: 1, Role: "user"},
+		"?channels=catalog&channels=user_settings")
+
+	readFrame("hello")
+	subscribed := readFrame("subscribed")
+
+	for _, want := range []string{`"catalog"`, `"user_settings"`} {
+		if !strings.Contains(string(subscribed["channels"]), want) {
+			t.Errorf("channel %s was dropped: %s", want, subscribed["channels"])
+		}
+	}
+}
+
 // TestEventsWebSocketSilentConnectionStillClosed pins the other half: the grace
 // period still applies to a connection that declared nothing, so the URL path
 // relaxes the rule rather than removing it.
@@ -254,6 +355,31 @@ func TestEventsWebSocketUnknownChannelDoesNotCloseConnection(t *testing.T) {
 	}
 }
 
+// TestEventsWebSocketRejectsOversizeFrame covers the one case that is still
+// fatal, and has to be: a frame is buffered whole before its type can be read,
+// so an oversize frame cannot be answered with a rejection the way a bad
+// channel name can — refusing it politely would mean first doing the thing the
+// limit exists to prevent.
+func TestEventsWebSocketRejectsOversizeFrame(t *testing.T) {
+	hub := evt.NewHub("test", &cache.NoopEventBus{})
+	conn, readFrame := eventsWSTestConn(t, hub, &auth.Claims{UserID: 1, Role: "user"}, "")
+	readFrame("hello")
+
+	oversize := `{"type":"subscribe","channels":["` +
+		strings.Repeat("x", maxEventsFrameBytes*2) + `"]}`
+	// The write itself may fail once the server has already torn the connection
+	// down, which is the same outcome; only accepting the frame is a failure.
+	if err := conn.WriteMessage(websocket.TextMessage, []byte(oversize)); err != nil {
+		return
+	}
+	if err := conn.SetReadDeadline(time.Now().Add(5 * time.Second)); err != nil {
+		t.Fatalf("setting read deadline: %v", err)
+	}
+	if _, _, err := conn.ReadMessage(); err == nil {
+		t.Fatal("a frame past the read limit was accepted")
+	}
+}
+
 // slowTaskLister stalls the tasks snapshot long enough to outlast the read
 // deadline configureWebSocket installs at connect.
 type slowTaskLister struct{ delay time.Duration }
@@ -339,6 +465,20 @@ func TestParseDeclaredChannels(t *testing.T) {
 			want:     []evt.EventChannel{evt.ChannelCatalog, evt.ChannelUserState},
 			declared: true,
 		},
+		{
+			// Repeating the parameter is as natural a spelling as one comma
+			// list; reading only the first occurrence lost the rest silently.
+			name:     "every occurrence of the parameter is read",
+			query:    "channels=catalog&channels=user_state,user_settings",
+			want:     []evt.EventChannel{evt.ChannelCatalog, evt.ChannelUserState, evt.ChannelUserSettings},
+			declared: true,
+		},
+		{
+			name:     "a repeated parameter with only blank values still declares",
+			query:    "channels=&channels=%20",
+			want:     []evt.EventChannel{},
+			declared: true,
+		},
 	}
 
 	for _, tt := range tests {
@@ -420,5 +560,79 @@ func TestResolveChannelSelectionDeduplicatesRejections(t *testing.T) {
 
 	if len(rejected) != 2 {
 		t.Fatalf("rejected = %v, want one entry per distinct channel", rejected)
+	}
+}
+
+// TestResolveChannelSelectionBoundsTheAnswer is the amplification guard.
+// Refusals quote the name they refuse, so once an unknown channel stopped
+// closing the connection, the response grew with the request: a large selection
+// of distinct garbage names produced a far larger subscribed frame, buffered
+// server-side. The answer has to be bounded independently of the request.
+func TestResolveChannelSelectionBoundsTheAnswer(t *testing.T) {
+	requested := make([]evt.EventChannel, 0, 5000)
+	for i := range 5000 {
+		requested = append(requested, evt.EventChannel("bogus-"+strconv.Itoa(i)))
+	}
+
+	subs, accepted, rejected := resolveChannelSelection(requested, allowedChannelsForRole("user"), "")
+
+	if len(subs) != 0 || len(accepted) != 0 {
+		t.Fatalf("garbage names were accepted: subs=%v accepted=%v", subs, accepted)
+	}
+	// Every considered name is refused, plus exactly one entry for the overrun.
+	if len(rejected) != maxRequestedChannels+1 {
+		t.Fatalf("rejected %d entries, want %d", len(rejected), maxRequestedChannels+1)
+	}
+	overrun := rejected[len(rejected)-1]
+	if overrun.Code != "too_many_channels" {
+		t.Errorf("last rejection code = %q, want too_many_channels", overrun.Code)
+	}
+
+	// The response must not scale with the request, whatever the constants are.
+	encoded, err := json.Marshal(evt.EventsSubscribedMessage{
+		Type:     "subscribed",
+		Channels: accepted,
+		Rejected: rejected,
+	})
+	if err != nil {
+		t.Fatalf("encoding subscribed frame: %v", err)
+	}
+	if len(encoded) > 8*1024 {
+		t.Errorf("subscribed frame is %d bytes for a garbage selection", len(encoded))
+	}
+}
+
+// TestResolveChannelSelectionTruncatesLongNames covers the per-name half of the
+// same concern: one enormous name is as good an amplifier as many small ones.
+func TestResolveChannelSelectionTruncatesLongNames(t *testing.T) {
+	long := evt.EventChannel(strings.Repeat("x", 4096))
+
+	_, _, rejected := resolveChannelSelection(
+		[]evt.EventChannel{long}, allowedChannelsForRole("user"), "")
+
+	if len(rejected) != 1 {
+		t.Fatalf("rejected = %v, want one entry", rejected)
+	}
+	if len(rejected[0].Channel) != maxChannelNameLength {
+		t.Errorf("echoed name is %d bytes, want it truncated to %d",
+			len(rejected[0].Channel), maxChannelNameLength)
+	}
+}
+
+// TestResolveChannelSelectionRefusesPluginsChannel pins that the host-to-plugin
+// dispatch channel is not reachable from a client connection, for any role.
+func TestResolveChannelSelectionRefusesPluginsChannel(t *testing.T) {
+	for _, role := range []string{"user", "admin"} {
+		t.Run(role, func(t *testing.T) {
+			subs, accepted, rejected := resolveChannelSelection(
+				[]evt.EventChannel{evt.ChannelPlugins}, allowedChannelsForRole(role), "profile-1")
+
+			if len(subs) != 0 || len(accepted) != 0 {
+				t.Fatalf("%s was granted the plugins channel: %v", role, accepted)
+			}
+			if len(rejected) != 1 || rejected[0].Code != "unknown_channel" {
+				t.Errorf("rejected = %v, want a single unknown_channel entry", rejected)
+			}
+		})
 	}
 }

--- a/internal/api/router.go
+++ b/internal/api/router.go
@@ -1996,6 +1996,7 @@ func NewRouter(deps Dependencies) chi.Router {
 					)
 					eventsHandler.SetNotificationsSystem(deps.Notifications)
 					r.Get("/events/ws", eventsHandler.HandleWebSocket)
+					r.Get("/events/capability", eventsHandler.HandleCapability)
 				}
 
 				// User notifications: profile-scoped inbox, preferences, and

--- a/internal/events/types.go
+++ b/internal/events/types.go
@@ -38,6 +38,24 @@ var AllChannels = []EventChannel{
 	ChannelNotifications,
 }
 
+// ClientChannels is every channel a websocket client may subscribe to: it is
+// AllChannels minus ChannelPlugins, which carries host-to-plugin runtime
+// dispatch and is granted to no role, not even admin. Naming it in a
+// capability response or accepting it as a valid subscription target would
+// point a client at a request that can never succeed.
+var ClientChannels = []EventChannel{
+	ChannelCatalog,
+	ChannelJobs,
+	ChannelSessions,
+	ChannelTasks,
+	ChannelScans,
+	ChannelHistoryImport,
+	ChannelUserState,
+	ChannelUserSettings,
+	ChannelSettings,
+	ChannelNotifications,
+}
+
 type Envelope struct {
 	Channel   EventChannel    `json:"channel"`
 	Event     string          `json:"event"`

--- a/web/src/api/types.ts
+++ b/web/src/api/types.ts
@@ -2896,9 +2896,11 @@ export interface EventsHelloMessage {
   connection_id: string;
   available_channels: EventChannel[];
   /**
-   * "subscribe" when the connection still owes a subscribe frame, "none" when
-   * it declared its channels as ?channels= on the URL and is already
-   * subscribed.
+   * "none" when the connection already holds at least one subscription,
+   * declared as ?channels= on the URL. "subscribe" when it still owes a
+   * subscribe frame — including when it declared channels but none of them
+   * resolved, since such a connection is subscribed to nothing and is closed
+   * after the grace period like any other silent one.
    */
   required_action: "subscribe" | "none";
 }

--- a/web/src/api/types.ts
+++ b/web/src/api/types.ts
@@ -2895,7 +2895,12 @@ export interface EventsHelloMessage {
   schema_version: number;
   connection_id: string;
   available_channels: EventChannel[];
-  required_action: "subscribe";
+  /**
+   * "subscribe" when the connection still owes a subscribe frame, "none" when
+   * it declared its channels as ?channels= on the URL and is already
+   * subscribed.
+   */
+  required_action: "subscribe" | "none";
 }
 
 export interface EventsSubscribeMessage {


### PR DESCRIPTION
Part of #523. Follows from closing #524 — [reasoning there](https://github.com/Silo-Server/silo-server/pull/524#issuecomment-5143655226).

## Problem

Observing the events hub over `GET /api/v1/events/ws` costs more than it should. A read-only consumer must send a `subscribe` frame within five seconds or be closed with a policy violation, so it has to implement the handshake and hold the write half of the socket open purely to satisfy it.

#523 proposed solving this with a second transport. But the cost is contract, not transport: `subscribe` is the only inbound message type this endpoint accepts. The friction is removable in place, without a parallel delivery path to keep in sync and without stranding the Android and Apple clients that ship against this endpoint.

## Approach

Accept the selection on the URL. `GET /api/v1/events/ws?channels=catalog,user_state` subscribes on connect, answers with the same `subscribed` frame and per-channel snapshot frames the handshake produces, and is not put on the grace-period clock.

An observer can now connect and never write to the socket again.

Two supporting changes:

- **One shared resolver.** Channel selection resolves through `resolveChannelSelection` for both the URL and the handshake, so the two cannot drift on who may subscribe to what. Role checks, profile-binding, validity, and dedup are moved verbatim, not rewritten.
- **Unknown channels are rejected, not fatal.** An unrecognized name is reported in the existing `rejected` array as `unknown_channel` instead of closing the connection. Closing took down every other channel the client held over one bad name, and a client cannot always know which channels its role allows before it asks. `forbidden` and `profile_required` were already handled this way; this makes the third case consistent.

The `subscribe` frame stays fully supported. The web client depends on it to ref-count channels and re-subscribe live as components mount (`RealtimeEventsProvider.tsx:482-501`), which a connect-time-only selection cannot express.

## What the grace period is keyed on

The clock is disarmed by **holding a subscription**, not by having spelled `?channels=`.

This is the correction that matters most from review. The first cut disarmed on `declared`, which meant `?channels=` (empty) and a non-admin's `?channels=sessions` both came up subscribed to nothing and were never reaped — each still holding a hub subscriber, two goroutines, and an envelope channel that every published event fans into. Those are exactly the connections the grace period exists to close.

Selection now resolves *before* the hello frame, so `required_action` reports what the connection actually owes: `"none"` only when at least one channel resolved, `"subscribe"` otherwise, including for a declaration where every entry was refused. Resolution is pure — no query, no I/O — so it cannot stall ahead of the reader goroutine; only the snapshots that accepted channels produce can, and those still run after it.

## Bounding the answer

Making an unknown channel non-fatal removed a brake that was doing real work: pre-change, one bad name closed the connection, so a bad selection was self-limiting. Now every refusal is *answered*, and each refusal quotes the name it refuses — so a large `?channels=` of distinct garbage names produced a much larger `subscribed` frame than the request, buffered server-side. A 900 KB query of ~180k unknown names produced a ~13 MB frame.

Four bounds, so the answer cannot scale with the request:

- At most **32** distinct channels are considered per selection. There are ten client channels; the slack exists only so a caller learns it overshot rather than silently losing channels.
- The overrun is reported as **one** `too_many_channels` entry, not one per excess name.
- An echoed channel name is truncated at **64** bytes — one enormous name is as good an amplifier as many small ones.
- A **64 KiB** read limit on the socket, so an oversize frame cannot be buffered whole before it is rejected. This is the one case that stays fatal, and has to be: a frame is buffered before its type can be read, so refusing it politely would mean first doing the thing the limit prevents.

`max_requested_channels` is published on the capability endpoint.

## Repeated query parameters

`?channels=catalog&channels=user_settings` honored only the first occurrence and returned an **empty** `rejected` array — the connection came up subscribed to less than it asked for and reported nothing wrong. Every occurrence is now read; repeating the parameter and comma-separating are equivalent spellings.

## The capability endpoint and the plugins channel

The endpoint advertised `evt.AllChannels`, which includes `plugins` — host-to-plugin runtime dispatch (`RuntimeHostServer.PublishEventTo`), granted to no role, admin included. An admin following the endpoint's own stated purpose would request it and be told `forbidden` / "Admin access required" while already being an admin, with no way forward.

`evt.ClientChannels` is now the subscribable set (AllChannels minus `plugins`), the capability endpoint advertises that, and `plugins` resolves as `unknown_channel` for every role. The `forbidden` message is reworded to "This channel is not available to this connection" — the hardcoded admin remedy is what turned a soft failure into a dead end, since a client acting on it loops forever.

`TestEventsCapabilityAdvertisesOnlySubscribableChannels` pins the invariant directly: it feeds the endpoint's own channel list to the resolver as the most permissive caller possible (admin, profile-bound) and fails if anything is rejected.

## Compatibility

Additive under the v1 rules — no field changes type, no field disappears, no status code is repurposed. `max_requested_channels` is a new field on a capability endpoint added in this same PR.

Observable changes on the existing handshake path, all strictly more permissive or previously unreachable:

- An unknown channel name previously closed the connection and now returns a `rejected` entry. No client can have depended on the close.
- The `forbidden` rejection's `message` text changed. `code` is unchanged, and it is the code clients branch on.
- `plugins` in a subscribe frame now answers `unknown_channel` instead of `forbidden`. It was never grantable to anyone, so no client could have been subscribed to it.
- A selection naming more than 32 channels is now partially refused. The maximum real selection is ten.

`required_action` in the hello frame is `"none"` for a connection holding a declared subscription, `"subscribe"` otherwise. `web/src/api/types.ts` typed it as the literal `"subscribe"` and is widened to the union — the web client never reads the field, so nothing changes at runtime. `silo-android` decodes it as a plain `String` (`NotificationModels.kt:210`), so it is unaffected.

No client change is required by this PR. Both client repos can adopt `?channels=` when convenient; the Apple realtime spec's handshake description (`silo-apple/docs/realtime-updates-spec.md:72-73`) stays accurate for the path it documents.

## Verification

Actual output.

```
$ go test ./internal/api/handlers/ -run "TestEventsWebSocket|TestParseDeclaredChannels|TestResolveChannelSelection|TestEventsCapability" -v
--- PASS: TestEventsCapabilityReportsDeclaredChannelSupport (0.00s)
--- PASS: TestEventsCapabilityAdvertisesOnlySubscribableChannels (0.00s)
--- PASS: TestEventsWebSocketDeclaredChannelsSkipHandshake (0.00s)
--- PASS: TestEventsWebSocketDeclaredChannelsSurviveGracePeriod (6.00s)
--- PASS: TestEventsWebSocketEmptyDeclarationStillClosed (10.01s)
    --- PASS: TestEventsWebSocketEmptyDeclarationStillClosed/declares_no_channels (5.01s)
    --- PASS: TestEventsWebSocketEmptyDeclarationStillClosed/every_declared_channel_refused (5.00s)
--- PASS: TestEventsWebSocketPartialDeclarationSurvives (6.00s)
--- PASS: TestEventsWebSocketRepeatedChannelsParameter (0.00s)
--- PASS: TestEventsWebSocketSilentConnectionStillClosed (5.00s)
--- PASS: TestEventsWebSocketDeclaredChannelsCannotEscalate (0.00s)
--- PASS: TestEventsWebSocketUnknownChannelDoesNotCloseConnection (0.00s)
--- PASS: TestEventsWebSocketRejectsOversizeFrame (0.00s)
--- PASS: TestEventsWebSocketDeclaredChannelsSurviveSlowSnapshot (32.00s)
--- PASS: TestParseDeclaredChannels (0.00s)
    --- PASS: TestParseDeclaredChannels/absent_parameter_keeps_the_handshake (0.00s)
    --- PASS: TestParseDeclaredChannels/empty_value_declares_nothing,_but_still_declares (0.00s)
    --- PASS: TestParseDeclaredChannels/whitespace_and_empty_entries_are_dropped (0.00s)
    --- PASS: TestParseDeclaredChannels/every_occurrence_of_the_parameter_is_read (0.00s)
    --- PASS: TestParseDeclaredChannels/a_repeated_parameter_with_only_blank_values_still_declares (0.00s)
--- PASS: TestResolveChannelSelectionDeniesByDefault (0.00s)
--- PASS: TestResolveChannelSelectionDeduplicates (0.00s)
--- PASS: TestResolveChannelSelectionDeduplicatesRejections (0.00s)
--- PASS: TestResolveChannelSelectionBoundsTheAnswer (0.00s)
--- PASS: TestResolveChannelSelectionTruncatesLongNames (0.00s)
--- PASS: TestResolveChannelSelectionRefusesPluginsChannel (0.00s)
    --- PASS: TestResolveChannelSelectionRefusesPluginsChannel/user (0.00s)
    --- PASS: TestResolveChannelSelectionRefusesPluginsChannel/admin (0.00s)
--- PASS: TestEventsWebSocketDeliversUserSettingsToNonAdmins (0.00s)
ok  	github.com/Silo-Server/silo-server/internal/api/handlers	59.128s

$ go test ./...          # with a stub web/dist, see note below
(all packages ok)

$ golangci-lint run --new-from-merge-base=origin/main ./internal/api/handlers/... ./internal/events/...
0 issues.

$ make verify-local-paths
(pass)

$ cd web && pnpm exec tsc -b
(exit 0)

$ cd web && pnpm run format:check
All matched files use Prettier code style!

$ cd web && pnpm run lint
✖ 157 problems (0 errors, 157 warnings)
```

The 157 web warnings are pre-existing and all in `web/vendor/foliate-js`.

`go test ./...` fails setup in `cmd/silo` and `web` with `pattern all:dist: no matching files found` unless the frontend has been built. I confirmed that failure is identical on a clean checkout with no changes applied, then re-ran the suite with a stub `web/dist/index.html` present — everything passes. The stub was removed afterwards; the tree is clean.

The websocket tests go through a real socket rather than calling the handler directly, because what a connection is subscribed to before it has said anything only exists in the connection loop. The ones that wait out the real five-second grace period are skipped under `-short`.

**Every guard was verified to bite** by reverting it and watching the test fail:

| Reverted to | Failing test | Output |
| --- | --- | --- |
| role check removed from `resolveChannelSelection` | `…CannotEscalate` | `non-admin was granted the sessions channel: ["sessions","user_settings"]` |
| `if !declared` for the grace period | `…EmptyDeclarationStillClosed` | both subtests time out waiting for the close that never comes |
| `query.Get("channels")` (first occurrence only) | `…RepeatedChannelsParameter` | `channel "user_settings" was dropped: ["catalog"]` |
| `maxRequestedChannels`/`maxChannelNameLength` raised to 1<<30 | `…BoundsTheAnswer`, `…TruncatesLongNames` | `rejected 5000 entries`; `echoed name is 4096 bytes` |
| capability advertising `evt.AllChannels` | `…AdvertisesOnlySubscribableChannels` | `capability advertises channels an admin cannot subscribe to: [{plugins unknown_channel Unknown channel}]` |
| read limit raised to 64 MiB | (temporary probe, removed) | a 200 KB frame was accepted |

## Risks

- **Privilege escalation via the query string** is the risk worth scrutinizing — a caller naming an admin-only channel on the URL must not receive it. The URL path runs the identical role check as the handshake because both call one function, and the test above covers it end to end, including that an admin-only event published to a refused channel is not delivered.
- **Notifications remain handshake-only in practice.** They require a profile-bound ws-ticket, which is unchanged; declaring `channels=notifications` on an unbound connection yields `profile_required`, as sending it in a subscribe frame already did.
- **Backpressure, hub fan-out, and per-event authorization are untouched.**

## What this does not address

`curl -N` debuggability, and not needing a WebSocket library in an external consumer. Both are real and neither is solved here. If an external consumer materializes, #523 is worth reopening — with SSE built as a projection over the shared resolver rather than a parallel handler.

## AI Disclosure

- **Tool(s):** Claude Code
- **Model(s):** claude-opus-5
- **Involvement:** fully AI-generated
- **Verification:** all commands above were run and their real output pasted. Each authorization and bounding guard was validated by deliberately reverting it and confirming the corresponding test fails — the table above lists what each one printed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * WebSocket connections can request channels directly through the connection URL.
  * Declared channels receive acknowledgements and initial snapshots without a separate subscription step.
  * The handshake indicates whether a subscription action is required.
  * Invalid or unauthorized channel requests are reported individually without closing the connection.
  * Added an events capability endpoint describing supported channels and connection features.

* **Bug Fixes**
  * Preserved the timeout for connections without an effective subscription.
  * Limited incoming WebSocket frames to 64 KiB.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->