### PR TITLE
fix(settings): declare ui.card_overlays for native clients

### DIFF
--- a/contracts/settings/v1/conformance.json
+++ b/contracts/settings/v1/conformance.json
@@ -1,6 +1,6 @@
 {
   "fixture_version": 1,
-  "manifest_revision": 3,
+  "manifest_revision": 4,
   "description": "Cross-platform conformance cases for settings resolution. Every case runs against the shipped manifest in this directory: definitions are referenced by key, never restated, so an expectation can only be satisfied by resolving the real contract. Each platform's resolver (Go in internal/settingsresolve, TypeScript in web/src/lib/settingsResolve.ts, Kotlin and Swift in the client repos) runs every case through a hand-written runner; a runner must fail on any fixture field it does not know, because schema drift in the fixture itself is drift. A case's constraint_bindings attach a constraint to a copy of a real definition so constraint semantics stay testable even while no shipped definition carries that constraint kind. In expected entries, constrained:true requires stored_value and constraint_kind to be present, and stored_value may be null to mean the authored value was JSON null.",
   "cases": [
     {

--- a/contracts/settings/v1/manifest.json
+++ b/contracts/settings/v1/manifest.json
@@ -1,6 +1,6 @@
 {
   "api_version": 1,
-  "revision": 3,
+  "revision": 4,
   "option_sets": {
     "playback_audio_languages": {
       "type": "language_tag",
@@ -801,7 +801,7 @@
         "nullable": true
       },
       "default_value": null,
-      "platforms": ["web"],
+      "platforms": ["web", "ios", "tvos", "macos", "android", "android_tv"],
       "category": "appearance",
       "label": "Poster badges",
       "description": "Which badges appear on poster cards, and where.",

--- a/internal/settingskeys/keys.go
+++ b/internal/settingskeys/keys.go
@@ -9,7 +9,7 @@
 package settingskeys
 
 // Revision is the manifest revision these bindings were generated from.
-const Revision = 3
+const Revision = 4
 
 // Setting keys, one constant per definition.
 const (

--- a/web/src/lib/overlays/schema.ts
+++ b/web/src/lib/overlays/schema.ts
@@ -13,6 +13,22 @@ export function buildDefaultPrefs(): CardOverlayPrefs {
   return { version: 2, preset: "classic", order: [], items: buildItems(undefined) };
 }
 
+// Ids that are legal in the contract schema (card-overlays.json) but have no
+// registry entry yet because no API field backs them. The web client neither
+// renders nor edits these, but their stored config must survive a round-trip:
+// the native clients' settings UIs can author them, and dropping them here
+// would erase another client's preference on the next web save. Their bases
+// mirror the native registries' defaults (ribbons: top-right, disabled).
+const PASSTHROUGH_IDS = ["imdb_top_250", "rt_certified_fresh"] as const satisfies readonly OverlayId[];
+const PASSTHROUGH_BASE: OverlayItemConfig = { enabled: false, position: "top-right" };
+
+function isKnownOverlayId(v: unknown): v is OverlayId {
+  return (
+    typeof v === "string" &&
+    (OVERLAY_MAP.has(v as OverlayId) || (PASSTHROUGH_IDS as readonly string[]).includes(v))
+  );
+}
+
 function isValidPosition(v: unknown): v is OverlayPosition {
   return typeof v === "string" && (OVERLAY_POSITIONS as readonly string[]).includes(v);
 }
@@ -61,6 +77,12 @@ function buildItems(
         ? applyItemPatch(base, entry as Record<string, unknown>)
         : base;
   }
+  for (const id of PASSTHROUGH_IDS) {
+    const entry = source?.[id];
+    if (entry && typeof entry === "object") {
+      items[id] = applyItemPatch(PASSTHROUGH_BASE, entry as Record<string, unknown>);
+    }
+  }
   return items;
 }
 
@@ -75,11 +97,7 @@ function parseV2(parsed: Record<string, unknown>): CardOverlayPrefs {
   return {
     version: 2,
     preset: isValidPreset(parsed.preset) ? parsed.preset : "classic",
-    order: Array.isArray(parsed.order)
-      ? (parsed.order as unknown[]).filter(
-          (id): id is OverlayId => typeof id === "string" && OVERLAY_MAP.has(id as OverlayId),
-        )
-      : [],
+    order: Array.isArray(parsed.order) ? (parsed.order as unknown[]).filter(isKnownOverlayId) : [],
     items: buildItems(sourceItems),
   };
 }

--- a/web/src/lib/settingsConformance.json
+++ b/web/src/lib/settingsConformance.json
@@ -1,6 +1,6 @@
 {
   "fixture_version": 1,
-  "manifest_revision": 3,
+  "manifest_revision": 4,
   "description": "Cross-platform conformance cases for settings resolution. Every case runs against the shipped manifest in this directory: definitions are referenced by key, never restated, so an expectation can only be satisfied by resolving the real contract. Each platform's resolver (Go in internal/settingsresolve, TypeScript in web/src/lib/settingsResolve.ts, Kotlin and Swift in the client repos) runs every case through a hand-written runner; a runner must fail on any fixture field it does not know, because schema drift in the fixture itself is drift. A case's constraint_bindings attach a constraint to a copy of a real definition so constraint semantics stay testable even while no shipped definition carries that constraint kind. In expected entries, constrained:true requires stored_value and constraint_kind to be present, and stored_value may be null to mean the authored value was JSON null.",
   "cases": [
     {

--- a/web/src/lib/settingsContract.ts
+++ b/web/src/lib/settingsContract.ts
@@ -8,7 +8,7 @@
  * is a manifest change plus a regeneration, never a hand-written key.
  */
 
-export const SETTINGS_REVISION = 3;
+export const SETTINGS_REVISION = 4;
 
 export interface SettingSuggestedOption {
   value: string;
@@ -934,7 +934,7 @@ export const SETTING_DEFINITIONS: Record<SettingKey, SettingDefinition> = {
     label: "Poster badges",
     description: "Which badges appear on poster cards, and where.",
     category: "appearance",
-    platforms: ["web"],
+    platforms: ["web", "ios", "tvos", "macos", "android", "android_tv"],
   },
   "ui.custom_css": {
     key: "ui.custom_css",


### PR DESCRIPTION
## Summary

Companion to Silo-Server/silo-apple#118 and Silo-Server/silo-android#158, which move the native clients onto the canonical `ui.card_overlays` settings key (fixing the report that `/settings/card-overlays` customizations only applied on web).

## Changes

1. **Manifest**: `ui.card_overlays` advisory `platforms` now lists `web, ios, tvos, macos, android, android_tv` (was `web` only). Revision bumped 3 → 4; Go/TS bindings and the conformance fixture regenerated (`make settings-bindings` + fixture copy). No other manifest changes, so no expectation re-derivation was needed. Kotlin/Swift bindings in the client repos will pick up the bump on their next regeneration — deliberately left out of this PR since their checkouts carry an unrelated pending key (`catalog.metadata_language_overrides`).

2. **Web schema round-trip fix**: `buildItems()` rebuilt the `items` map from the web registry alone, so the two schema-legal ribbon ids web doesn't render yet (`imdb_top_250`, `rt_certified_fresh`) were silently erased from both `items` and `order` on every web parse/save. Android's native settings editor can author these ids, and `card-overlays.json` accepts them — a web save would destroy another client's stored preference. They now pass through parse/serialize on the same defaults the native registries use (top-right, disabled) while staying invisible to web rendering and the settings UI. The registry's "only API-backed entries render" rule is unchanged.

## Validation

- `go test ./internal/settingscontract/... ./internal/settingsresolve/... ./internal/settingsmigrate/...` pass
- `make verify-settings-bindings` clean
- `pnpm exec tsc --noEmit` clean; overlay + card component vitest suites pass (34 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enabled card overlays across web, iOS, tvOS, macOS, Android, and Android TV.
  * Added support for recognized overlay options that were previously unavailable.
* **Updates**
  * Updated the settings contract and manifest revision to version 4.
  * Preserved existing settings and conformance behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->