### PR TITLE
fix(auth): bound device match codes to eight letters

### DIFF
--- a/internal/auth/device_login_words.go
+++ b/internal/auth/device_login_words.go
@@ -6,24 +6,14 @@ import (
 )
 
 var deviceMatchAdjectives = []string{
-	"amber", "brisk", "calm", "cedar", "clear", "cloud", "copper", "crisp",
-	"delta", "ember", "fable", "fern", "frost", "gentle", "golden", "harbor",
-	"hazel", "hollow", "indigo", "ivy", "jade", "juniper", "kindle", "lagoon",
-	"linen", "lunar", "maple", "meadow", "misty", "navy", "nova", "oak",
-	"olive", "opal", "orbit", "pepper", "pine", "plum", "prairie", "quiet",
-	"raven", "river", "rose", "rustic", "sable", "sage", "scarlet", "silver",
-	"smoky", "solstice", "spruce", "stone", "summer", "sunny", "timber", "topaz",
-	"velvet", "violet", "willow", "winter", "woodland", "zephyr",
+	"calm", "fern", "ivy", "jade", "navy", "nova",
+	"oak", "opal", "pine", "plum", "rose", "sage",
 }
 
 var deviceMatchNouns = []string{
-	"anchor", "apple", "birch", "brook", "canyon", "castle", "comet", "cove",
-	"crest", "dawn", "ember", "field", "fjord", "forest", "glade", "grove",
-	"harbor", "hawk", "hill", "island", "lake", "lantern", "meadow", "mesa",
-	"moon", "oasis", "ocean", "orchard", "owl", "pine", "planet", "pond",
-	"quartz", "rain", "reef", "ridge", "river", "rock", "shadow", "shore",
-	"signal", "snow", "spark", "star", "stone", "stream", "summit", "sun",
-	"thunder", "trail", "tree", "valley", "wave", "whisper", "wind", "wolf",
+	"cove", "dawn", "hawk", "hill", "lake", "mesa", "moon", "owl",
+	"pine", "pond", "rain", "reef", "rock", "snow", "star", "sun",
+	"tree", "wave", "wind", "wolf",
 }
 
 func randomMatchCode() (string, error) {

--- a/internal/auth/device_login_words.go
+++ b/internal/auth/device_login_words.go
@@ -6,14 +6,14 @@ import (
 )
 
 var deviceMatchAdjectives = []string{
-	"calm", "fern", "ivy", "jade", "navy", "nova",
-	"oak", "opal", "pine", "plum", "rose", "sage",
+	"blue", "busy", "calm", "cozy", "fast", "gold",
+	"kind", "soft", "tall", "tame", "tiny", "warm",
 }
 
 var deviceMatchNouns = []string{
-	"cove", "dawn", "hawk", "hill", "lake", "mesa", "moon", "owl",
-	"pine", "pond", "rain", "reef", "rock", "snow", "star", "sun",
-	"tree", "wave", "wind", "wolf",
+	"barn", "bell", "cart", "coop", "corn", "cow", "duck", "goat",
+	"hay", "hen", "lamb", "milk", "oats", "pail", "pond", "pony",
+	"rake", "shed", "silo", "wool",
 }
 
 func randomMatchCode() (string, error) {

--- a/internal/auth/device_login_words_test.go
+++ b/internal/auth/device_login_words_test.go
@@ -4,6 +4,7 @@ import "testing"
 
 func TestDeviceMatchCodeWordsStayWithinEightLetters(t *testing.T) {
 	const maxLetters = 8
+	const wantCombinations = 240
 	for _, adjective := range deviceMatchAdjectives {
 		for _, noun := range deviceMatchNouns {
 			if got := len(adjective) + len(noun); got > maxLetters {
@@ -14,7 +15,7 @@ func TestDeviceMatchCodeWordsStayWithinEightLetters(t *testing.T) {
 
 	// The match phrase is a human confirmation signal, not the login secret,
 	// but keep enough combinations that accidental collisions remain uncommon.
-	if combinations := len(deviceMatchAdjectives) * len(deviceMatchNouns); combinations < 128 {
-		t.Fatalf("match-code word lists have only %d combinations, want at least 128", combinations)
+	if combinations := len(deviceMatchAdjectives) * len(deviceMatchNouns); combinations != wantCombinations {
+		t.Fatalf("match-code word lists have %d combinations, want exactly %d", combinations, wantCombinations)
 	}
 }

--- a/internal/auth/device_login_words_test.go
+++ b/internal/auth/device_login_words_test.go
@@ -1,0 +1,20 @@
+package auth
+
+import "testing"
+
+func TestDeviceMatchCodeWordsStayWithinEightLetters(t *testing.T) {
+	const maxLetters = 8
+	for _, adjective := range deviceMatchAdjectives {
+		for _, noun := range deviceMatchNouns {
+			if got := len(adjective) + len(noun); got > maxLetters {
+				t.Fatalf("match code %q has %d letters, want at most %d", adjective+" "+noun, got, maxLetters)
+			}
+		}
+	}
+
+	// The match phrase is a human confirmation signal, not the login secret,
+	// but keep enough combinations that accidental collisions remain uncommon.
+	if combinations := len(deviceMatchAdjectives) * len(deviceMatchNouns); combinations < 128 {
+		t.Fatalf("match-code word lists have only %d combinations, want at least 128", combinations)
+	}
+}


### PR DESCRIPTION
## Problem

Fire TV's phone-confirmation card can clip long human-readable device match codes such as `SPRUCE TRAIL`. This is a Fire TV rc.1+4 QA follow-up; no issue was filed.

## Approach

- Restrict generated adjective/noun pairs to combinations with at most eight letters total (spaces excluded).
- Retain 240 possible phrases, above the 128-combination safety floor.
- Keep the existing API contract and confirmation flow unchanged.
- Coordinate with the Android client change, which also keeps legacy longer codes visually compatible.

## Testing

- `go test ./internal/auth -count=1`
- `go test ./internal/auth ./internal/api/handlers -count=1`
- `make verify-local-paths`
- `pnpm run lint` — 0 errors; 160 existing warnings
- `pnpm run format:check`
- `pnpm run build`
- `make lint` — repository-wide baseline remains red with 303 pre-existing issues, as documented in `AGENTS.md`; neither touched file was reported

### AI Disclosure

- Tool(s): OpenAI Codex
- Model(s): GPT-5.6
- Involvement: Implementation, tests, verification, commit, and PR drafting under maintainer direction.
- Adversarial review: Independent review found no blocking server issues and verified the length bound, 240-combination space, and API compatibility.

## Checklist

- [x] I ran an adversarial AI review and addressed all findings.
- [ ] I ran all repository verify commands successfully. (`make lint` remains blocked by the documented pre-existing repository baseline; focused tests and all other applicable gates above pass.)
- [x] I added tests for the match-code length and combination-count guarantees.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Updated device login match codes to use shorter, curated words, improving compatibility with the eight-letter limit and making codes easier to enter.

* **Tests**
  * Added coverage to verify match-code word lengths and ensure exactly 240 valid adjective-and-noun combinations for reliable device matching.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->