### PR TITLE
feat(settings): add mobile-first settings overviews

### DIFF
--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -468,7 +468,6 @@ function AppRoutes() {
                     </RequireProfile>
                   }
                 >
-                  <Route index element={<Navigate to="playback" replace />} />
                   <Route path="appearance" element={<AppearanceSettings />} />
                   <Route path="theme-editor" element={<ThemeEditorSettings />} />
                   <Route path="accessibility" element={<AccessibilitySettings />} />

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -468,6 +468,7 @@ function AppRoutes() {
                     </RequireProfile>
                   }
                 >
+                  <Route index element={null} />
                   <Route path="appearance" element={<AppearanceSettings />} />
                   <Route path="theme-editor" element={<ThemeEditorSettings />} />
                   <Route path="accessibility" element={<AccessibilitySettings />} />

--- a/web/src/components/AppSidebar.tsx
+++ b/web/src/components/AppSidebar.tsx
@@ -928,7 +928,7 @@ export default function AppSidebar({ onNavigate, collapsed = false }: AppSidebar
 
               <DropdownMenuItem
                 onClick={() => {
-                  navigate("/settings/playback");
+                  navigate("/settings");
                 }}
                 className="gap-2.5 rounded-lg px-2.5 py-2 text-[13px]"
               >

--- a/web/src/components/Layout.tsx
+++ b/web/src/components/Layout.tsx
@@ -266,7 +266,7 @@ export default function Layout({ children }: LayoutProps) {
             </ViewTransitionLink>
             {showAdminActivity && <ServerActivity hideWhenEmpty />}
             <Link
-              to="/settings/playback"
+              to="/settings"
               className="bg-primary text-primary-foreground flex h-9 w-9 items-center justify-center rounded-xl text-xs font-bold shadow-[0_16px_32px_-22px_rgba(0,0,0,0.7)]"
             >
               {profile?.name?.charAt(0).toUpperCase() ??

--- a/web/src/components/settings/SettingsOverviewNav.tsx
+++ b/web/src/components/settings/SettingsOverviewNav.tsx
@@ -1,0 +1,82 @@
+import { ChevronRight } from "lucide-react";
+import type { LucideIcon } from "lucide-react";
+import { Link } from "react-router";
+
+export interface SettingsOverviewNavItem {
+  id: string;
+  label: string;
+  description: string;
+  icon: LucideIcon;
+  href: string;
+}
+
+export interface SettingsOverviewNavGroup {
+  label: string;
+  items: readonly SettingsOverviewNavItem[];
+}
+
+interface SettingsOverviewNavProps {
+  groups: readonly SettingsOverviewNavGroup[];
+  ariaLabel: string;
+  idPrefix: string;
+}
+
+export function SettingsOverviewNav({ groups, ariaLabel, idPrefix }: SettingsOverviewNavProps) {
+  if (groups.length === 0) {
+    return (
+      <div className="surface-panel-subtle rounded-2xl px-5 py-8 text-center">
+        <p className="font-medium">No matching settings</p>
+        <p className="text-muted-foreground mt-1 text-sm">
+          Try a category, feature, or setting name.
+        </p>
+      </div>
+    );
+  }
+
+  return (
+    <nav aria-label={ariaLabel} className="grid items-start gap-6 lg:grid-cols-2">
+      {groups.map((group) => {
+        const sectionId = `${idPrefix}-${group.label.toLowerCase().replace(/[^a-z0-9]+/g, "-")}`;
+
+        return (
+          <section key={group.label} aria-labelledby={sectionId}>
+            <h2
+              id={sectionId}
+              className="text-muted-foreground mb-2 px-1 text-[11px] font-semibold tracking-[0.16em] uppercase"
+            >
+              {group.label}
+            </h2>
+            <ul className="surface-panel overflow-hidden rounded-2xl border-0 shadow-none">
+              {group.items.map((item) => {
+                const Icon = item.icon;
+
+                return (
+                  <li key={item.id} className="border-border/60 border-b last:border-b-0">
+                    <Link
+                      to={item.href}
+                      className="hover:bg-surface-hover/70 focus-visible:bg-surface-hover/70 focus-visible:ring-ring/70 flex min-h-[4.5rem] items-center gap-3 px-4 py-3 transition-colors focus-visible:ring-2 focus-visible:outline-none focus-visible:ring-inset"
+                    >
+                      <span className="bg-accent text-foreground flex h-9 w-9 shrink-0 items-center justify-center rounded-xl">
+                        <Icon className="h-[18px] w-[18px]" aria-hidden="true" />
+                      </span>
+                      <span className="min-w-0 flex-1">
+                        <span className="block text-sm font-semibold">{item.label}</span>
+                        <span className="text-muted-foreground mt-0.5 block text-xs leading-snug">
+                          {item.description}
+                        </span>
+                      </span>
+                      <ChevronRight
+                        className="text-muted-foreground h-4 w-4 shrink-0"
+                        aria-hidden="true"
+                      />
+                    </Link>
+                  </li>
+                );
+              })}
+            </ul>
+          </section>
+        );
+      })}
+    </nav>
+  );
+}

--- a/web/src/components/settings/SettingsSearchInput.tsx
+++ b/web/src/components/settings/SettingsSearchInput.tsx
@@ -13,6 +13,7 @@ interface SettingsSearchInputProps {
   itemLabel?: string;
   emptyLabel?: string;
   className?: string;
+  shortcutMediaQuery?: string;
 }
 
 export function SettingsSearchInput({
@@ -24,6 +25,7 @@ export function SettingsSearchInput({
   itemLabel = "settings sections",
   emptyLabel = "No matching settings",
   className,
+  shortcutMediaQuery,
 }: SettingsSearchInputProps) {
   const inputId = useId();
   const inputRef = useRef<HTMLInputElement>(null);
@@ -38,6 +40,7 @@ export function SettingsSearchInput({
     const onKeyDown = (event: KeyboardEvent) => {
       if (event.defaultPrevented || !(event.metaKey || event.ctrlKey)) return;
       if (event.key.toLowerCase() !== "k") return;
+      if (shortcutMediaQuery && !window.matchMedia(shortcutMediaQuery).matches) return;
 
       event.preventDefault();
       event.stopPropagation();
@@ -52,7 +55,7 @@ export function SettingsSearchInput({
       window.removeEventListener("keydown", onKeyDown, { capture: true });
       document.removeEventListener("keydown", onKeyDown, { capture: true });
     };
-  }, []);
+  }, [shortcutMediaQuery]);
 
   return (
     <div className={cn("w-full", className)}>

--- a/web/src/pages/SettingsLayout.test.tsx
+++ b/web/src/pages/SettingsLayout.test.tsx
@@ -2,7 +2,7 @@ import { fireEvent, render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { renderToStaticMarkup } from "react-dom/server";
 import { MemoryRouter } from "react-router";
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 const mocks = vi.hoisted(() => ({
   useAuth: vi.fn(),
@@ -25,6 +25,10 @@ describe("SettingsLayout", () => {
     mocks.useAuth.mockReturnValue({
       user: { role: "admin" },
     });
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
   });
 
   it("includes a PageBack control at the top of the page", () => {
@@ -162,7 +166,7 @@ describe("SettingsLayout", () => {
 
   it("focuses personal settings search with Cmd+K", () => {
     render(
-      <MemoryRouter initialEntries={["/settings/playback"]}>
+      <MemoryRouter initialEntries={["/settings"]}>
         <SettingsLayout />
       </MemoryRouter>,
     );
@@ -171,5 +175,27 @@ describe("SettingsLayout", () => {
     fireEvent.keyDown(document, { key: "k", metaKey: true });
 
     expect(searchBox).toHaveFocus();
+  });
+
+  it("does not consume Cmd+K when the detail search is hidden", () => {
+    vi.stubGlobal(
+      "matchMedia",
+      vi.fn(() => ({ matches: false })),
+    );
+
+    render(
+      <MemoryRouter initialEntries={["/settings/playback"]}>
+        <SettingsLayout />
+      </MemoryRouter>,
+    );
+
+    const event = new KeyboardEvent("keydown", {
+      key: "k",
+      metaKey: true,
+      cancelable: true,
+    });
+
+    expect(document.dispatchEvent(event)).toBe(true);
+    expect(event.defaultPrevented).toBe(false);
   });
 });

--- a/web/src/pages/SettingsLayout.test.tsx
+++ b/web/src/pages/SettingsLayout.test.tsx
@@ -37,6 +37,34 @@ describe("SettingsLayout", () => {
     expect(markup).toContain('aria-label="Go back"');
   });
 
+  it("renders a grouped settings index at the root route", () => {
+    render(
+      <MemoryRouter initialEntries={["/settings"]}>
+        <SettingsLayout />
+      </MemoryRouter>,
+    );
+
+    expect(screen.getByRole("heading", { name: "Settings" })).toBeInTheDocument();
+    expect(screen.getByRole("heading", { name: "Playback" })).toBeInTheDocument();
+    expect(screen.getByRole("heading", { name: "Appearance" })).toBeInTheDocument();
+    expect(screen.getByRole("heading", { name: "Library & Data" })).toBeInTheDocument();
+    expect(screen.getByRole("heading", { name: "Account" })).toBeInTheDocument();
+    expect(
+      screen.getByRole("link", { name: /Playback.*Quality, language, and skipping/ }),
+    ).toHaveAttribute("href", "/settings/playback");
+    expect(screen.getByRole("link", { name: /Connect Apps.*Sign-in details/ })).toBeInTheDocument();
+  });
+
+  it("offers a clear return to the settings index from detail pages", () => {
+    render(
+      <MemoryRouter initialEntries={["/settings/playback"]}>
+        <SettingsLayout />
+      </MemoryRouter>,
+    );
+
+    expect(screen.getByRole("link", { name: "All settings" })).toHaveAttribute("href", "/settings");
+  });
+
   it("does not include a plugins section in personal settings", () => {
     const markup = renderToStaticMarkup(
       <MemoryRouter initialEntries={["/settings/playback"]}>
@@ -111,11 +139,10 @@ describe("SettingsLayout", () => {
 
     await userEvent.type(screen.getByRole("searchbox", { name: "Search settings" }), "pin");
 
-    // Both nav rails render, so each surviving item appears twice. "pin" hits
-    // Profiles (where PINs are set) and Connect Apps (where the password#PIN
-    // format is explained).
-    expect(screen.getAllByRole("link", { name: /Profiles/ })).toHaveLength(2);
-    expect(screen.getAllByRole("link", { name: /Connect Apps/ })).toHaveLength(2);
+    // "pin" hits Profiles (where PINs are set) and Connect Apps (where the
+    // password#PIN format is explained).
+    expect(screen.getAllByRole("link", { name: /Profiles/ })).toHaveLength(1);
+    expect(screen.getAllByRole("link", { name: /Connect Apps/ })).toHaveLength(1);
     expect(screen.queryByRole("link", { name: /Playback/ })).not.toBeInTheDocument();
     expect(screen.getByText("2 matches")).toBeInTheDocument();
   });
@@ -129,7 +156,7 @@ describe("SettingsLayout", () => {
 
     await userEvent.type(screen.getByRole("searchbox", { name: "Search settings" }), "font family");
 
-    expect(screen.getAllByRole("link", { name: /Subtitles/ })).toHaveLength(2);
+    expect(screen.getAllByRole("link", { name: /Subtitles/ })).toHaveLength(1);
     expect(screen.queryByRole("link", { name: /Playback/ })).not.toBeInTheDocument();
   });
 

--- a/web/src/pages/SettingsLayout.tsx
+++ b/web/src/pages/SettingsLayout.tsx
@@ -24,6 +24,7 @@ import {
 import type { LucideIcon } from "lucide-react";
 import PageBack from "@/components/PageBack";
 import { SideNavItem, SideNavSection } from "@/components/SideNav";
+import { SettingsOverviewNav } from "@/components/settings/SettingsOverviewNav";
 import { SettingsSearchInput } from "@/components/settings/SettingsSearchInput";
 import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
 import { useDocumentTitle } from "@/hooks/useDocumentTitle";
@@ -441,60 +442,20 @@ function SettingsOverview({
         className="w-full sm:max-w-md"
       />
 
-      {sections.length > 0 ? (
-        <nav aria-label="Settings sections" className="grid items-start gap-6 lg:grid-cols-2">
-          {sections.map((section) => {
-            const sectionId = `settings-index-${section.label
-              .toLowerCase()
-              .replace(/[^a-z0-9]+/g, "-")}`;
-
-            return (
-              <section key={section.label} aria-labelledby={sectionId}>
-                <h2
-                  id={sectionId}
-                  className="text-muted-foreground mb-2 px-1 text-[11px] font-semibold tracking-[0.16em] uppercase"
-                >
-                  {section.label}
-                </h2>
-                <ul className="surface-panel overflow-hidden rounded-2xl border-0 shadow-none">
-                  {section.items.map((item) => {
-                    const Icon = item.icon;
-                    return (
-                      <li key={item.path} className="border-border/60 border-b last:border-b-0">
-                        <Link
-                          to={`/settings/${item.path}`}
-                          className="hover:bg-surface-hover/70 focus-visible:bg-surface-hover/70 focus-visible:ring-ring/70 flex min-h-[4.5rem] items-center gap-3 px-4 py-3 transition-colors focus-visible:ring-2 focus-visible:outline-none focus-visible:ring-inset"
-                        >
-                          <span className="bg-accent text-foreground flex h-9 w-9 shrink-0 items-center justify-center rounded-xl">
-                            <Icon className="h-[18px] w-[18px]" aria-hidden="true" />
-                          </span>
-                          <span className="min-w-0 flex-1">
-                            <span className="block text-sm font-semibold">{item.label}</span>
-                            <span className="text-muted-foreground mt-0.5 block text-xs leading-snug">
-                              {item.description}
-                            </span>
-                          </span>
-                          <ChevronRight
-                            className="text-muted-foreground h-4 w-4 shrink-0"
-                            aria-hidden="true"
-                          />
-                        </Link>
-                      </li>
-                    );
-                  })}
-                </ul>
-              </section>
-            );
-          })}
-        </nav>
-      ) : (
-        <div className="surface-panel-subtle rounded-2xl px-5 py-8 text-center">
-          <p className="font-medium">No matching settings</p>
-          <p className="text-muted-foreground mt-1 text-sm">
-            Try a category, feature, or setting name.
-          </p>
-        </div>
-      )}
+      <SettingsOverviewNav
+        groups={sections.map((section) => ({
+          ...section,
+          items: section.items.map((item) => ({
+            id: item.path,
+            label: item.label,
+            description: item.description,
+            icon: item.icon,
+            href: `/settings/${item.path}`,
+          })),
+        }))}
+        ariaLabel="Settings sections"
+        idPrefix="settings-index"
+      />
     </div>
   );
 }

--- a/web/src/pages/SettingsLayout.tsx
+++ b/web/src/pages/SettingsLayout.tsx
@@ -1,6 +1,8 @@
 import { useMemo, useState } from "react";
 import { Link, Outlet, useLocation } from "react-router";
 import {
+  ChevronLeft,
+  ChevronRight,
   Play,
   Library,
   Cast,
@@ -23,6 +25,7 @@ import type { LucideIcon } from "lucide-react";
 import PageBack from "@/components/PageBack";
 import { SideNavItem, SideNavSection } from "@/components/SideNav";
 import { SettingsSearchInput } from "@/components/settings/SettingsSearchInput";
+import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
 import { useDocumentTitle } from "@/hooks/useDocumentTitle";
 import { useCurrentProfile } from "@/hooks/useCurrentProfile";
 import { useIsActingAdmin } from "@/hooks/useIsActingAdmin";
@@ -391,17 +394,122 @@ const NAV_SECTIONS: NavSection[] = [
   },
 ];
 
+interface SettingsOverviewProps {
+  sections: readonly { label: string; items: readonly NavItem[] }[];
+  profile: { name: string; avatar_url?: string } | null;
+  search: string;
+  onSearchChange: (value: string) => void;
+  resultCount: number;
+  totalCount: number;
+}
+
+function SettingsOverview({
+  sections,
+  profile,
+  search,
+  onSearchChange,
+  resultCount,
+  totalCount,
+}: SettingsOverviewProps) {
+  const profileName = profile?.name ?? "Your profile";
+
+  return (
+    <div className="mx-auto mt-6 w-full max-w-5xl space-y-6 sm:mt-8">
+      <Link
+        to="/profiles"
+        aria-label={`Current profile: ${profileName}`}
+        className="surface-panel-subtle hover:bg-surface-hover/70 focus-visible:ring-ring flex min-h-16 items-center gap-3 rounded-2xl px-4 py-3 transition-colors focus-visible:ring-2 focus-visible:outline-none sm:max-w-md"
+      >
+        <Avatar className="border-border h-10 w-10 border">
+          {profile?.avatar_url ? <AvatarImage src={profile.avatar_url} alt="" /> : null}
+          <AvatarFallback className="bg-accent text-foreground font-semibold">
+            {profileName.charAt(0).toUpperCase()}
+          </AvatarFallback>
+        </Avatar>
+        <div className="min-w-0 flex-1">
+          <p className="text-muted-foreground text-xs">Current profile</p>
+          <p className="truncate text-sm font-semibold">{profileName}</p>
+        </div>
+        <ChevronRight className="text-muted-foreground h-4 w-4 shrink-0" aria-hidden="true" />
+      </Link>
+
+      <SettingsSearchInput
+        value={search}
+        onChange={onSearchChange}
+        resultCount={resultCount}
+        totalCount={totalCount}
+        className="w-full sm:max-w-md"
+      />
+
+      {sections.length > 0 ? (
+        <nav aria-label="Settings sections" className="grid items-start gap-6 lg:grid-cols-2">
+          {sections.map((section) => {
+            const sectionId = `settings-index-${section.label
+              .toLowerCase()
+              .replace(/[^a-z0-9]+/g, "-")}`;
+
+            return (
+              <section key={section.label} aria-labelledby={sectionId}>
+                <h2
+                  id={sectionId}
+                  className="text-muted-foreground mb-2 px-1 text-[11px] font-semibold tracking-[0.16em] uppercase"
+                >
+                  {section.label}
+                </h2>
+                <ul className="surface-panel overflow-hidden rounded-2xl border-0 shadow-none">
+                  {section.items.map((item) => {
+                    const Icon = item.icon;
+                    return (
+                      <li key={item.path} className="border-border/60 border-b last:border-b-0">
+                        <Link
+                          to={`/settings/${item.path}`}
+                          className="hover:bg-surface-hover/70 focus-visible:bg-surface-hover/70 focus-visible:ring-ring/70 flex min-h-[4.5rem] items-center gap-3 px-4 py-3 transition-colors focus-visible:ring-2 focus-visible:outline-none focus-visible:ring-inset"
+                        >
+                          <span className="bg-accent text-foreground flex h-9 w-9 shrink-0 items-center justify-center rounded-xl">
+                            <Icon className="h-[18px] w-[18px]" aria-hidden="true" />
+                          </span>
+                          <span className="min-w-0 flex-1">
+                            <span className="block text-sm font-semibold">{item.label}</span>
+                            <span className="text-muted-foreground mt-0.5 block text-xs leading-snug">
+                              {item.description}
+                            </span>
+                          </span>
+                          <ChevronRight
+                            className="text-muted-foreground h-4 w-4 shrink-0"
+                            aria-hidden="true"
+                          />
+                        </Link>
+                      </li>
+                    );
+                  })}
+                </ul>
+              </section>
+            );
+          })}
+        </nav>
+      ) : (
+        <div className="surface-panel-subtle rounded-2xl px-5 py-8 text-center">
+          <p className="font-medium">No matching settings</p>
+          <p className="text-muted-foreground mt-1 text-sm">
+            Try a category, feature, or setting name.
+          </p>
+        </div>
+      )}
+    </div>
+  );
+}
+
 export default function SettingsLayout() {
   const location = useLocation();
   const [settingsSearch, setSettingsSearch] = useState("");
   const { profile } = useCurrentProfile();
   const actingAdmin = useIsActingAdmin();
   const segments = location.pathname.split("/");
-  const activeSegment = segments[2] || "playback";
+  const activeSegment = segments[2] || null;
   const canManageProfiles = actingAdmin || profile?.is_primary === true;
   // Most settings pages are a single column of rows and read best measured.
   // A page that is itself two panes needs the room, so it opts out.
-  const wideSetting = WIDE_SETTINGS_PAGES.has(activeSegment);
+  const wideSetting = activeSegment ? WIDE_SETTINGS_PAGES.has(activeSegment) : false;
 
   const visibleSections = useMemo(
     () =>
@@ -420,10 +528,6 @@ export default function SettingsLayout() {
     () => filterSettingsSearchGroups(visibleSections, settingsSearch),
     [settingsSearch, visibleSections],
   );
-  const filteredFlatItems = useMemo(
-    () => filteredSections.flatMap((section) => section.items),
-    [filteredSections],
-  );
   const filteredSettingsCount = countSettingsSearchItems(filteredSections);
 
   useDocumentTitle(resolveSettingsDocumentTitle(location.pathname));
@@ -431,93 +535,88 @@ export default function SettingsLayout() {
   return (
     <div className="min-h-[100dvh]">
       <main className="page-shell-wide relative flex min-h-[100dvh] flex-col py-4 sm:py-6">
-        <PageBack to="/" preferHistory={false} floating />
-        <div className="page-header mt-10 gap-5 sm:mt-12">
-          <div className="min-w-0 space-y-3">
-            <h1 className="page-title text-[clamp(2rem,4vw,3rem)]">Settings</h1>
-            <p className="page-subtitle text-sm sm:text-base">
-              Manage your playback preferences, libraries, and display options.
-            </p>
-          </div>
-          <SettingsSearchInput
-            value={settingsSearch}
-            onChange={setSettingsSearch}
-            resultCount={filteredSettingsCount}
-            totalCount={flatItems.length}
-            className="w-full sm:max-w-sm"
-          />
-        </div>
-
-        {/* Mobile: horizontal scrolling tab bar */}
-        <nav
-          aria-label="Settings sections"
-          className="surface-panel-subtle mt-6 overflow-x-auto rounded-[1.4rem] p-1 lg:hidden"
-          style={{
-            WebkitOverflowScrolling: "touch",
-            maskImage:
-              "linear-gradient(to right, transparent, black 40px, black calc(100% - 40px), transparent)",
-            WebkitMaskImage:
-              "linear-gradient(to right, transparent, black 40px, black calc(100% - 40px), transparent)",
-          }}
-        >
-          <div className="flex min-w-max items-stretch gap-1">
-            {filteredFlatItems.map((item) => {
-              const isActive = item.path === activeSegment;
-              const Icon = item.icon;
-              return (
-                <Link
-                  key={item.path}
-                  to={`/settings/${item.path}`}
-                  aria-current={isActive ? "page" : undefined}
-                  className={cn(
-                    "inline-flex items-center gap-2 rounded-[1rem] px-3 py-2.5 text-sm font-medium whitespace-nowrap transition-colors",
-                    isActive
-                      ? "bg-background text-foreground shadow-sm"
-                      : "text-muted-foreground hover:bg-background/70 hover:text-foreground",
-                  )}
-                >
-                  <Icon className="h-4 w-4" />
-                  {item.label}
-                </Link>
-              );
-            })}
-            {filteredFlatItems.length === 0 ? (
-              <p className="text-muted-foreground px-3 py-2.5 text-sm whitespace-nowrap">
-                No matching settings
-              </p>
-            ) : null}
-          </div>
-        </nav>
-
-        {/* Desktop: two-column with inline vertical sidebar */}
-        <div className="mt-8 min-w-0 flex-1 lg:mt-10 lg:flex lg:gap-10">
-          <aside className="hidden lg:block lg:w-[220px] lg:shrink-0">
-            <nav aria-label="Settings sections" className="sticky top-6 space-y-5 pl-3">
-              {filteredSections.map((section) => (
-                <SideNavSection key={section.label} label={section.label} idPrefix="settings-nav">
-                  {section.items.map((item) => (
-                    <SideNavItem
-                      key={item.path}
-                      label={item.label}
-                      icon={item.icon}
-                      href={`/settings/${item.path}`}
-                      active={item.path === activeSegment}
-                    />
-                  ))}
-                </SideNavSection>
-              ))}
-              {filteredSections.length === 0 ? (
-                <p className="text-muted-foreground px-2 text-sm">No matching settings</p>
-              ) : null}
-            </nav>
-          </aside>
-
-          <div className="min-w-0 flex-1 pt-8 lg:pt-0">
-            <div className={cn("mx-auto w-full", wideSetting ? "max-w-6xl" : "max-w-3xl")}>
-              <Outlet />
+        {activeSegment ? (
+          <>
+            <div className="hidden lg:block">
+              <PageBack to="/" preferHistory={false} floating />
             </div>
-          </div>
-        </div>
+            <Link
+              to="/settings"
+              className="text-muted-foreground hover:text-foreground focus-visible:ring-ring mt-1 inline-flex w-fit items-center gap-1.5 rounded-lg pr-2 text-sm font-medium transition-colors focus-visible:ring-2 focus-visible:outline-none lg:hidden"
+            >
+              <ChevronLeft className="h-4 w-4" aria-hidden="true" />
+              All settings
+            </Link>
+            <div className="page-header mt-10 hidden gap-5 sm:mt-12 lg:flex">
+              <div className="min-w-0 space-y-3">
+                <h1 className="page-title text-[clamp(2rem,4vw,3rem)]">Settings</h1>
+                <p className="page-subtitle text-sm sm:text-base">
+                  Manage your playback preferences, libraries, and display options.
+                </p>
+              </div>
+              <SettingsSearchInput
+                value={settingsSearch}
+                onChange={setSettingsSearch}
+                resultCount={filteredSettingsCount}
+                totalCount={flatItems.length}
+                className="w-full sm:max-w-sm"
+              />
+            </div>
+
+            <div className="mt-5 min-w-0 flex-1 lg:mt-10 lg:flex lg:gap-10">
+              <aside className="hidden lg:block lg:w-[220px] lg:shrink-0">
+                <nav aria-label="Settings sections" className="sticky top-6 space-y-5 pl-3">
+                  {filteredSections.map((section) => (
+                    <SideNavSection
+                      key={section.label}
+                      label={section.label}
+                      idPrefix="settings-nav"
+                    >
+                      {section.items.map((item) => (
+                        <SideNavItem
+                          key={item.path}
+                          label={item.label}
+                          icon={item.icon}
+                          href={`/settings/${item.path}`}
+                          active={item.path === activeSegment}
+                        />
+                      ))}
+                    </SideNavSection>
+                  ))}
+                  {filteredSections.length === 0 ? (
+                    <p className="text-muted-foreground px-2 text-sm">No matching settings</p>
+                  ) : null}
+                </nav>
+              </aside>
+
+              <div className="min-w-0 flex-1 pt-8 lg:pt-0">
+                <div className={cn("mx-auto w-full", wideSetting ? "max-w-6xl" : "max-w-3xl")}>
+                  <Outlet />
+                </div>
+              </div>
+            </div>
+          </>
+        ) : (
+          <>
+            <PageBack to="/" preferHistory={false} floating />
+            <div className="page-header mt-10 gap-5 sm:mt-12">
+              <div className="min-w-0 space-y-3">
+                <h1 className="page-title text-[clamp(2rem,4vw,3rem)]">Settings</h1>
+                <p className="page-subtitle text-sm sm:text-base">
+                  Make Silo work the way you like.
+                </p>
+              </div>
+            </div>
+            <SettingsOverview
+              sections={filteredSections}
+              profile={profile}
+              search={settingsSearch}
+              onSearchChange={setSettingsSearch}
+              resultCount={filteredSettingsCount}
+              totalCount={flatItems.length}
+            />
+          </>
+        )}
       </main>
     </div>
   );

--- a/web/src/pages/SettingsLayout.tsx
+++ b/web/src/pages/SettingsLayout.tsx
@@ -521,6 +521,7 @@ export default function SettingsLayout() {
                 resultCount={filteredSettingsCount}
                 totalCount={flatItems.length}
                 className="w-full sm:max-w-sm"
+                shortcutMediaQuery={activeSegment ? "(min-width: 64rem)" : undefined}
               />
             </div>
 

--- a/web/src/pages/admin-settings/AdminSettingsLayout.test.tsx
+++ b/web/src/pages/admin-settings/AdminSettingsLayout.test.tsx
@@ -92,11 +92,18 @@ describe("AdminSettingsLayout", () => {
     }
   });
 
-  it("defaults to the General tab", () => {
-    const markup = renderLayout();
+  it("renders the settings index at the root and preserves tab deep links", () => {
+    renderInteractiveLayout();
 
-    expect(markup).toContain('aria-current="page"');
-    expect(markup).toBe(renderLayout("?tab=general"));
+    expect(screen.getByRole("link", { name: /General.*Authentication/ })).toHaveAttribute(
+      "href",
+      "/admin/settings?tab=general",
+    );
+    expect(screen.queryByRole("link", { name: "All settings" })).not.toBeInTheDocument();
+
+    const detail = renderLayout("?tab=general");
+    expect(detail).toContain('aria-current="page"');
+    expect(detail).toContain('href="/admin/settings"');
   });
 
   it("surfaces durable restart-required state above the active tab", () => {
@@ -119,8 +126,8 @@ describe("AdminSettingsLayout", () => {
 
     await userEvent.type(screen.getByRole("searchbox", { name: "Search settings" }), "redis");
 
-    expect(screen.getAllByRole("button", { name: /Database/ })).toHaveLength(2);
-    expect(screen.queryByRole("button", { name: /Playback/ })).not.toBeInTheDocument();
+    expect(screen.getAllByRole("link", { name: /Database/ })).toHaveLength(1);
+    expect(screen.queryByRole("link", { name: /Playback/ })).not.toBeInTheDocument();
     expect(screen.getByText("1 match")).toBeInTheDocument();
   });
 
@@ -132,8 +139,8 @@ describe("AdminSettingsLayout", () => {
       "pool max open",
     );
 
-    expect(screen.getAllByRole("button", { name: /Database/ })).toHaveLength(2);
-    expect(screen.queryByRole("button", { name: /General/ })).not.toBeInTheDocument();
+    expect(screen.getAllByRole("link", { name: /Database/ })).toHaveLength(1);
+    expect(screen.queryByRole("link", { name: /General/ })).not.toBeInTheDocument();
   });
 
   it("focuses admin settings search with Cmd+K", () => {

--- a/web/src/pages/admin-settings/AdminSettingsLayout.test.tsx
+++ b/web/src/pages/admin-settings/AdminSettingsLayout.test.tsx
@@ -3,7 +3,7 @@ import { fireEvent, render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { renderToStaticMarkup } from "react-dom/server";
 import { MemoryRouter } from "react-router";
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import AdminSettingsLayout from "./AdminSettingsLayout";
 
@@ -16,6 +16,8 @@ const mocks = vi.hoisted(() => ({
 vi.mock("@/hooks/useSettingsForm", () => ({
   useSettingsForm: () => ({
     isLoading: true,
+    dirtyCount: 0,
+    getValue: () => "",
     sensitiveConfigured: [],
     sensitiveManagedByEnv: [],
   }),
@@ -28,6 +30,10 @@ vi.mock("@/hooks/queries/admin/settings", async (importOriginal) => ({
 
 beforeEach(() => {
   mocks.useAdminServerStatus.mockReturnValue({ data: { restart_required: false } });
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
 });
 
 function renderLayout(search = "") {
@@ -106,6 +112,40 @@ describe("AdminSettingsLayout", () => {
     expect(detail).toContain('href="/admin/settings"');
   });
 
+  it("focuses the detail heading and resets scroll when an overview link opens", async () => {
+    const scrollTo = vi.fn();
+    vi.stubGlobal("scrollTo", scrollTo);
+    renderInteractiveLayout();
+
+    await userEvent.click(screen.getByRole("link", { name: /Database.*Postgres/ }));
+
+    const detailRegion = await screen.findByRole("region", { name: "Database settings" });
+    expect(scrollTo).toHaveBeenCalledWith(0, 0);
+    expect(detailRegion).toHaveFocus();
+  });
+
+  it("adds a mobile detail heading when the settings component has none", () => {
+    vi.stubGlobal("scrollTo", vi.fn());
+
+    renderInteractiveLayout("?tab=branding");
+
+    expect(screen.getByRole("heading", { name: "Branding", level: 2 })).toHaveFocus();
+  });
+
+  it("resets the scrolling detail pane when switching admin tabs", async () => {
+    vi.stubGlobal("scrollTo", vi.fn());
+    renderInteractiveLayout("?tab=general");
+
+    const generalRegion = screen.getByRole("region", { name: "General settings" });
+    generalRegion.scrollTop = 400;
+
+    await userEvent.click(screen.getByRole("button", { name: "Database" }));
+
+    const databaseRegion = await screen.findByRole("region", { name: "Database settings" });
+    expect(databaseRegion.scrollTop).toBe(0);
+    expect(databaseRegion).toHaveFocus();
+  });
+
   it("surfaces durable restart-required state above the active tab", () => {
     mocks.useAdminServerStatus.mockReturnValue({ data: { restart_required: true } });
 
@@ -150,5 +190,23 @@ describe("AdminSettingsLayout", () => {
     fireEvent.keyDown(document, { key: "k", metaKey: true });
 
     expect(searchBox).toHaveFocus();
+  });
+
+  it("does not consume Cmd+K when the admin detail search is hidden", () => {
+    vi.stubGlobal(
+      "matchMedia",
+      vi.fn(() => ({ matches: false })),
+    );
+    vi.stubGlobal("scrollTo", vi.fn());
+    renderInteractiveLayout("?tab=general");
+
+    const event = new KeyboardEvent("keydown", {
+      key: "k",
+      metaKey: true,
+      cancelable: true,
+    });
+
+    expect(document.dispatchEvent(event)).toBe(true);
+    expect(event.defaultPrevented).toBe(false);
   });
 });

--- a/web/src/pages/admin-settings/AdminSettingsLayout.tsx
+++ b/web/src/pages/admin-settings/AdminSettingsLayout.tsx
@@ -1,8 +1,9 @@
 import { useMemo, useState, type ComponentType } from "react";
-import { AlertTriangle } from "lucide-react";
-import { useSearchParams } from "react-router";
+import { AlertTriangle, ChevronLeft } from "lucide-react";
+import { Link, useSearchParams } from "react-router";
 
 import { SideNavItem, SideNavSection } from "@/components/SideNav";
+import { SettingsOverviewNav } from "@/components/settings/SettingsOverviewNav";
 import { SettingsSearchInput } from "@/components/settings/SettingsSearchInput";
 import {
   countSettingsSearchItems,
@@ -92,14 +93,24 @@ export default function AdminSettingsLayout() {
   const [searchParams, setSearchParams] = useSearchParams();
   const [settingsSearch, setSettingsSearch] = useState("");
   const { data: serverStatus } = useAdminServerStatus();
-  const rawActiveId = searchParams.get("tab") || "general";
+  const rawActiveId = searchParams.get("tab");
   const activeId = rawActiveId === "jellyfin" ? "compatibility-proxies" : rawActiveId;
   const filteredSettingsGroups = useMemo(
     () => filterSettingsSearchGroups(SETTINGS_GROUPS, settingsSearch),
     [settingsSearch],
   );
-  const filteredSettingsNav = useMemo(
-    () => filteredSettingsGroups.flatMap((group) => group.items),
+  const overviewGroups = useMemo(
+    () =>
+      filteredSettingsGroups.map((group) => ({
+        ...group,
+        items: group.items.map((item) => ({
+          id: item.id,
+          label: item.label,
+          description: item.description,
+          icon: item.icon,
+          href: `/admin/settings?tab=${encodeURIComponent(item.id)}`,
+        })),
+      })),
     [filteredSettingsGroups],
   );
   const filteredSettingsCount = countSettingsSearchItems(filteredSettingsGroups);
@@ -107,12 +118,22 @@ export default function AdminSettingsLayout() {
   function setActiveId(id: string) {
     setSearchParams({ tab: id }, { replace: true });
   }
-  const active = SETTINGS_NAV.find((n) => n.id === activeId) ?? SETTINGS_NAV[0]!;
-  const ActiveComponent = active.component;
+  const active = activeId ? SETTINGS_NAV.find((item) => item.id === activeId) : undefined;
+  const ActiveComponent = active?.component;
 
   return (
     <div className="space-y-6">
-      <div className="page-header gap-5">
+      {active ? (
+        <Link
+          to="/admin/settings"
+          className="text-muted-foreground hover:text-foreground focus-visible:ring-ring inline-flex w-fit items-center gap-1.5 rounded-lg pr-2 text-sm font-medium transition-colors focus-visible:ring-2 focus-visible:outline-none lg:hidden"
+        >
+          <ChevronLeft className="h-4 w-4" aria-hidden="true" />
+          All settings
+        </Link>
+      ) : null}
+
+      <div className={cn("page-header gap-5", active && "hidden lg:flex")}>
         <div className="min-w-0 space-y-3">
           <h1 className="page-title text-[clamp(2rem,4vw,3rem)]">Settings</h1>
           <p className="page-subtitle text-sm sm:text-base">
@@ -142,70 +163,43 @@ export default function AdminSettingsLayout() {
         </div>
       )}
 
-      <div className="surface-panel flex min-h-[500px] flex-col overflow-hidden rounded-[1.8rem] border-0 lg:flex-row">
-        {/* Mobile: horizontal scrolling pill bar */}
-        <nav
-          aria-label="Admin settings sections"
-          className="border-border overflow-x-auto border-b p-2 lg:hidden"
-          style={{ WebkitOverflowScrolling: "touch" }}
-        >
-          <div className="flex min-w-max items-stretch gap-1">
-            {filteredSettingsNav.map((item) => {
-              const isActive = item.id === active.id;
-              return (
-                <button
-                  key={item.id}
-                  type="button"
-                  onClick={() => setActiveId(item.id)}
-                  aria-current={isActive ? "page" : undefined}
-                  className={cn(
-                    "inline-flex items-center gap-2 rounded-[1rem] px-3 py-2.5 text-[13px] font-medium whitespace-nowrap transition-colors",
-                    isActive
-                      ? "bg-background text-foreground shadow-sm"
-                      : "text-muted-foreground hover:bg-background/70 hover:text-foreground",
-                  )}
-                >
-                  <item.icon className="h-4 w-4" />
-                  {item.label}
-                </button>
-              );
-            })}
-            {filteredSettingsNav.length === 0 ? (
-              <p className="text-muted-foreground px-3 py-2.5 text-sm whitespace-nowrap">
-                No matching settings
-              </p>
+      {active && ActiveComponent ? (
+        <div className="surface-panel flex min-h-[500px] flex-col overflow-hidden rounded-[1.8rem] border-0 lg:flex-row">
+          <nav
+            aria-label="Admin settings sections"
+            className="border-border hidden space-y-5 border-r px-3 py-4 lg:block lg:w-60 lg:flex-shrink-0"
+          >
+            {filteredSettingsGroups.map((group) => (
+              <SideNavSection key={group.label} label={group.label} idPrefix="admin-settings-nav">
+                {group.items.map((item) => (
+                  <SideNavItem
+                    key={item.id}
+                    label={item.label}
+                    icon={item.icon}
+                    active={item.id === active.id}
+                    onClick={() => setActiveId(item.id)}
+                  />
+                ))}
+              </SideNavSection>
+            ))}
+            {filteredSettingsGroups.length === 0 ? (
+              <p className="text-muted-foreground px-2 text-sm">No matching settings</p>
             ) : null}
+          </nav>
+
+          <div className="flex-1 overflow-y-auto p-4 sm:p-6">
+            <ActiveComponent />
           </div>
-        </nav>
-
-        {/* Desktop: grouped vertical rail */}
-        <nav
-          aria-label="Admin settings sections"
-          className="border-border hidden space-y-5 border-r px-3 py-4 lg:block lg:w-60 lg:flex-shrink-0"
-        >
-          {filteredSettingsGroups.map((group) => (
-            <SideNavSection key={group.label} label={group.label} idPrefix="admin-settings-nav">
-              {group.items.map((item) => (
-                <SideNavItem
-                  key={item.id}
-                  label={item.label}
-                  icon={item.icon}
-                  active={item.id === active.id}
-                  onClick={() => setActiveId(item.id)}
-                />
-              ))}
-            </SideNavSection>
-          ))}
-          {filteredSettingsGroups.length === 0 ? (
-            <p className="text-muted-foreground px-2 text-sm">No matching settings</p>
-          ) : null}
-        </nav>
-
-        {/* Content area */}
-        <div className="flex-1 overflow-y-auto p-4 sm:p-6">
-          <ActiveComponent />
         </div>
-      </div>
+      ) : (
+        <div className="mx-auto w-full max-w-6xl">
+          <SettingsOverviewNav
+            groups={overviewGroups}
+            ariaLabel="Admin settings sections"
+            idPrefix="admin-settings-index"
+          />
+        </div>
+      )}
     </div>
   );
 }

--- a/web/src/pages/admin-settings/AdminSettingsLayout.tsx
+++ b/web/src/pages/admin-settings/AdminSettingsLayout.tsx
@@ -1,4 +1,4 @@
-import { useMemo, useState, type ComponentType } from "react";
+import { useEffect, useMemo, useRef, useState, type ComponentType } from "react";
 import { AlertTriangle, ChevronLeft } from "lucide-react";
 import { Link, useSearchParams } from "react-router";
 
@@ -89,9 +89,13 @@ const SETTINGS_NAV: SettingsNav[] = ADMIN_SETTINGS_NAV.map((item) => ({
   component: settingsComponent(item.id),
 }));
 
+const SHELL_HEADING_SETTINGS = new Set(["branding", "theming"]);
+
 export default function AdminSettingsLayout() {
   const [searchParams, setSearchParams] = useSearchParams();
   const [settingsSearch, setSettingsSearch] = useState("");
+  const activeContentRef = useRef<HTMLDivElement>(null);
+  const activeHeadingRef = useRef<HTMLHeadingElement>(null);
   const { data: serverStatus } = useAdminServerStatus();
   const rawActiveId = searchParams.get("tab");
   const activeId = rawActiveId === "jellyfin" ? "compatibility-proxies" : rawActiveId;
@@ -121,6 +125,16 @@ export default function AdminSettingsLayout() {
   const active = activeId ? SETTINGS_NAV.find((item) => item.id === activeId) : undefined;
   const ActiveComponent = active?.component;
 
+  useEffect(() => {
+    if (!active) return;
+
+    window.scrollTo(0, 0);
+    if (activeContentRef.current) {
+      activeContentRef.current.scrollTop = 0;
+    }
+    (activeHeadingRef.current ?? activeContentRef.current)?.focus({ preventScroll: true });
+  }, [active]);
+
   return (
     <div className="space-y-6">
       {active ? (
@@ -147,6 +161,7 @@ export default function AdminSettingsLayout() {
           resultCount={filteredSettingsCount}
           totalCount={SETTINGS_NAV.length}
           className="w-full sm:max-w-sm"
+          shortcutMediaQuery={active ? "(min-width: 64rem)" : undefined}
         />
       </div>
 
@@ -187,7 +202,22 @@ export default function AdminSettingsLayout() {
             ) : null}
           </nav>
 
-          <div className="flex-1 overflow-y-auto p-4 sm:p-6">
+          <div
+            ref={activeContentRef}
+            role="region"
+            aria-label={`${active.label} settings`}
+            tabIndex={-1}
+            className="flex-1 space-y-6 overflow-y-auto p-4 focus:outline-none sm:p-6"
+          >
+            {SHELL_HEADING_SETTINGS.has(active.id) ? (
+              <h2
+                ref={activeHeadingRef}
+                tabIndex={-1}
+                className="text-2xl font-semibold tracking-tight focus:outline-none sm:text-3xl lg:sr-only"
+              >
+                {active.label}
+              </h2>
+            ) : null}
             <ActiveComponent />
           </div>
         </div>

--- a/web/src/pages/settings/NotificationsSettings.tsx
+++ b/web/src/pages/settings/NotificationsSettings.tsx
@@ -1044,6 +1044,8 @@ export default function NotificationsSettings() {
 
   return (
     <div className="space-y-6">
+      <h2 className="text-2xl font-semibold tracking-tight sm:text-3xl">Notifications</h2>
+
       <PreferencesSection />
 
       <WebPushSection />


### PR DESCRIPTION
## Summary

- replace the horizontal mobile settings controls with grouped, searchable overview pages for both personal settings and admin settings
- add descriptive, icon-led rows with mobile-sized touch targets so destinations can be scanned before opening them
- provide a clear `All settings` return path from mobile detail pages while preserving existing `?tab=` deep links
- retain the desktop settings rails and reuse one overview component across both settings areas

## Why

The previous mobile layouts compressed many destinations into horizontally scrolling controls, making categories difficult to scan and settings difficult to discover. The new overviews prioritize findability, plain-language descriptions, and predictable navigation without changing persistence, scope, API contracts, or backend behavior.

Part of #376

## Validation

- `pnpm exec vitest run src/pages/SettingsLayout.test.tsx src/pages/admin-settings/AdminSettingsLayout.test.tsx src/components/Layout.test.tsx src/pages/Catalog.test.tsx` — 53 tests passed
- `pnpm exec tsc -b --pretty false` — passed
- targeted ESLint for the changed frontend files — passed
- `pnpm run format:check` — passed
- `pnpm run build` — passed
- `make verify-local-paths` — passed
- authenticated browser verification at 390×844 for personal settings and admin settings — overview, search, detail navigation, and `All settings` return path passed with no console errors or warnings
- desktop browser verification — existing settings rails and selected-state behavior preserved
- dev deployment — remote image built, container reported healthy, and `/api/v1/ready` returned `{"status":"ok"}`
- Codex autoreview — clean; no accepted or actionable findings

## Known gate limitations

- `make lint` initially could not run because `golangci-lint` was not installed. The repository-pinned v2.12.2 binary was installed; the CI-equivalent changed-line invocation reported no Go files to analyze because this PR is frontend-only.
- `make test` reached the full Go tree but four unrelated NVENC probe tests in `internal/playback` were killed during the concurrent suite. Rerunning `go test ./internal/playback` alone passed.

### AI Disclosure
- Tool(s): Codex
- Model(s): gpt-5; gpt-5.6-sol (adversarial review)
- Involvement: fully AI-generated
- Adversarial review: Codex autoreview inspected the complete local patch and reported no accepted or actionable findings.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added settings overview pages with profile information, search, and grouped navigation.
  * Added grouped navigation for administrative settings.
  * Added responsive back links from settings detail pages to their overview.
  * Updated profile menu Settings links to open the overview.
* **Improvements**
  * Replaced mobile settings tabs with overview and back navigation.
  * Improved accessible navigation with labels, descriptions, focus states, and links.
  * Limited the Cmd/Ctrl+K search shortcut to supported desktop views.
  * Added a Notifications heading for clearer organization.
* **Tests**
  * Expanded coverage for settings navigation, search, focus, and responsive behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->