### PR TITLE
perf(web): eliminate item detail interaction jank

### DIFF
--- a/web/src/app.css
+++ b/web/src/app.css
@@ -1045,6 +1045,83 @@
     --glass-hover-color: var(--accent);
   }
 
+  /* Detail actions sit directly over large hero artwork. Repainting several
+     live backdrop filters after every button or popover state change blocks
+     scroll compositing on this surface, so retain the glass appearance with
+     an opaque color blend instead of sampling and blurring the backdrop. */
+  .detail-action-bar .glass-subtle {
+    background: color-mix(in srgb, var(--surface) 82%, var(--background));
+    backdrop-filter: none;
+    -webkit-backdrop-filter: none;
+  }
+
+  /* The detail overflow menu opens without an entrance transition so it is
+     immediately interactive. Pointer hover is CSS-only. */
+  .detail-overflow-menu {
+    animation: none !important;
+    transition: none !important;
+  }
+
+  /* Rating hover stays entirely in CSS so moving across stars does not
+     schedule React renders or recomposite a live backdrop-filter surface. */
+  .star-rating {
+    contain: layout paint;
+    background: color-mix(in srgb, var(--surface) 82%, transparent);
+    border: 1px solid color-mix(in srgb, var(--border) 30%, transparent);
+    box-shadow: inset 0 1px 0 rgb(255 255 255 / 0.05);
+  }
+
+  .star-rating-star {
+    color: color-mix(in srgb, var(--muted-foreground) 50%, transparent);
+  }
+
+  /* The stored rating is the resting state, so it survives a pointer that is
+     inside the pill but not over a star (its padding, the gaps between stars)
+     and it still renders where :has() is unsupported. */
+  .star-rating-star[data-filled="true"] {
+    color: rgb(250 204 21);
+  }
+
+  .star-rating-star[data-filled="true"] svg {
+    fill: currentColor;
+  }
+
+  /* Hovering a star previews that value instead: clear the stored fill first,
+     then fill up to the hovered position. */
+  .star-rating:has(.star-rating-star:hover) .star-rating-star {
+    color: color-mix(in srgb, var(--muted-foreground) 50%, transparent);
+  }
+
+  .star-rating:has(.star-rating-star:hover) .star-rating-star svg {
+    fill: none;
+  }
+
+  .star-rating:has(.star-rating-star:nth-of-type(1):hover) .star-rating-star:nth-of-type(-n + 1),
+  .star-rating:has(.star-rating-star:nth-of-type(2):hover) .star-rating-star:nth-of-type(-n + 2),
+  .star-rating:has(.star-rating-star:nth-of-type(3):hover) .star-rating-star:nth-of-type(-n + 3),
+  .star-rating:has(.star-rating-star:nth-of-type(4):hover) .star-rating-star:nth-of-type(-n + 4),
+  .star-rating:has(.star-rating-star:nth-of-type(5):hover) .star-rating-star:nth-of-type(-n + 5) {
+    color: rgb(250 204 21);
+  }
+
+  .star-rating:has(.star-rating-star:nth-of-type(1):hover)
+    .star-rating-star:nth-of-type(-n + 1)
+    svg,
+  .star-rating:has(.star-rating-star:nth-of-type(2):hover)
+    .star-rating-star:nth-of-type(-n + 2)
+    svg,
+  .star-rating:has(.star-rating-star:nth-of-type(3):hover)
+    .star-rating-star:nth-of-type(-n + 3)
+    svg,
+  .star-rating:has(.star-rating-star:nth-of-type(4):hover)
+    .star-rating-star:nth-of-type(-n + 4)
+    svg,
+  .star-rating:has(.star-rating-star:nth-of-type(5):hover)
+    .star-rating-star:nth-of-type(-n + 5)
+    svg {
+    fill: currentColor;
+  }
+
   /* Less-transparent glass for small chips that sit over busy cover art
      (manga count/status pills) so the label stays legible. */
   .glass-chip {

--- a/web/src/app.css
+++ b/web/src/app.css
@@ -1083,7 +1083,7 @@
   }
 
   .star-rating-star[data-filled="true"] svg {
-    fill: currentColor;
+    fill: currentcolor;
   }
 
   /* Hovering a star previews that value instead: clear the stored fill first,
@@ -1119,7 +1119,7 @@
   .star-rating:has(.star-rating-star:nth-of-type(5):hover)
     .star-rating-star:nth-of-type(-n + 5)
     svg {
-    fill: currentColor;
+    fill: currentcolor;
   }
 
   /* Less-transparent glass for small chips that sit over busy cover art

--- a/web/src/components/CastCarousel.tsx
+++ b/web/src/components/CastCarousel.tsx
@@ -1,3 +1,4 @@
+import { memo, useMemo } from "react";
 import { ChevronLeft, ChevronRight } from "lucide-react";
 import ViewTransitionLink from "@/components/ViewTransitionLink";
 import type { CastMember } from "@/api/types";
@@ -17,15 +18,18 @@ interface CastCarouselProps {
   fullBleed?: boolean;
 }
 
-export default function CastCarousel({ cast, limit = 20, fullBleed = false }: CastCarouselProps) {
+function CastCarousel({ cast, limit = 20, fullBleed = false }: CastCarouselProps) {
   const { emblaRef, canScrollPrev, canScrollNext, scrollPrev, scrollNext } = useCarouselEmbla();
+  const visible = useMemo(
+    () =>
+      cast
+        .slice()
+        .sort((a, b) => a.order - b.order)
+        .slice(0, limit),
+    [cast, limit],
+  );
 
   if (cast.length === 0) return null;
-
-  const visible = cast
-    .slice()
-    .sort((a, b) => a.order - b.order)
-    .slice(0, limit);
 
   return (
     <div className="group/carousel relative">
@@ -84,6 +88,8 @@ export default function CastCarousel({ cast, limit = 20, fullBleed = false }: Ca
     </div>
   );
 }
+
+export default memo(CastCarousel);
 
 function CastCard({ member, href }: { member: CastMember; href: string | null }) {
   const inner = (

--- a/web/src/components/RealtimeEventsProvider.test.tsx
+++ b/web/src/components/RealtimeEventsProvider.test.tsx
@@ -2,6 +2,7 @@ import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { act, cleanup, render } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { adminKeys, catalogKeys, libraryKeys, sectionKeys } from "@/hooks/queries/keys";
+import type { ItemDetail } from "@/api/types";
 import { invalidateCatalogState } from "./realtimeCatalogInvalidation";
 import { buildEventsUrl, RealtimeEventsProvider } from "./RealtimeEventsProvider";
 
@@ -64,6 +65,10 @@ class FakeWebSocket {
   emitClose() {
     this.readyState = FakeWebSocket.CLOSED;
     this.onclose?.();
+  }
+
+  emitMessage(message: unknown) {
+    this.onmessage?.({ data: JSON.stringify(message) } as MessageEvent);
   }
 }
 
@@ -239,5 +244,42 @@ describe("RealtimeEventsProvider", () => {
     });
 
     expect(FakeWebSocket.instances).toHaveLength(2);
+  });
+
+  it("preserves cached watched state when a favorite-only event arrives", () => {
+    const queryClient = new QueryClient();
+    const detailKey = catalogKeys.itemDetail("movie-1");
+    queryClient.setQueryData<ItemDetail>(detailKey, {
+      content_id: "movie-1",
+      type: "movie",
+      user_data: { played: true },
+    } as ItemDetail);
+
+    render(
+      <QueryClientProvider client={queryClient}>
+        <RealtimeEventsProvider>
+          <div />
+        </RealtimeEventsProvider>
+      </QueryClientProvider>,
+    );
+
+    act(() => {
+      FakeWebSocket.instances[0]?.emitMessage({
+        type: "event",
+        channel: "user_state",
+        event: "favorite.updated",
+        data: {
+          profile_id: "profile-1",
+          content_id: "movie-1",
+          change: "favorite",
+          is_favorite: true,
+        },
+      });
+    });
+
+    expect(queryClient.getQueryData<ItemDetail>(detailKey)).toMatchObject({
+      user_data: { played: true },
+      user_state: { played: true, is_favorite: true },
+    });
   });
 });

--- a/web/src/components/RealtimeEventsProvider.tsx
+++ b/web/src/components/RealtimeEventsProvider.tsx
@@ -35,10 +35,9 @@ import { useIsActingAdmin } from "@/hooks/useIsActingAdmin";
 import { usePageActivity } from "@/hooks/usePageActivity";
 import { adminKeys, historyImportKeys, libraryKeys } from "@/hooks/queries/keys";
 import {
-  invalidateMediaSurfaceQueries,
+  scheduleMediaSurfaceInvalidation,
   updateCatalogItemDetail,
 } from "@/hooks/queries/mediaSurfaceRefresh";
-import { bumpHomeRefreshSignal } from "@/pages/homeSurfaceRefresh";
 import type { ReactNode } from "react";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useLocation } from "react-router";
@@ -409,22 +408,46 @@ function handleUserStateEvent(
   }
 
   if (payload.content_id) {
-    updateCatalogItemDetail(queryClient, payload.content_id, (detail) => ({
-      ...detail,
-      user_state: {
-        played: payload.played ?? detail.user_state?.played ?? false,
-        is_favorite: payload.is_favorite ?? detail.user_state?.is_favorite ?? false,
-        in_watchlist: payload.in_watchlist ?? detail.user_state?.in_watchlist ?? false,
-      },
-    }));
+    updateCatalogItemDetail(queryClient, payload.content_id, (detail) => {
+      const played =
+        payload.played ?? detail.user_state?.played ?? detail.user_data?.played ?? false;
+      const isFavorite = payload.is_favorite ?? detail.user_state?.is_favorite ?? false;
+      const inWatchlist = payload.in_watchlist ?? detail.user_state?.in_watchlist ?? false;
+      if (
+        played === (detail.user_data?.played ?? false) &&
+        played === (detail.user_state?.played ?? false) &&
+        isFavorite === (detail.user_state?.is_favorite ?? false) &&
+        inWatchlist === (detail.user_state?.in_watchlist ?? false)
+      ) {
+        return detail;
+      }
+      return {
+        ...detail,
+        user_data:
+          payload.played == null
+            ? detail.user_data
+            : { ...detail.user_data, played: payload.played },
+        user_state: { played, is_favorite: isFavorite, in_watchlist: inWatchlist },
+      };
+    });
   }
 
-  void invalidateMediaSurfaceQueries(
+  // The patch above only carries played/favourite/watchlist, which is the whole
+  // of what a favorite or watchlist event changes. Every other change — progress
+  // above all, which arrives with no state at all — also moves fields the patch
+  // cannot reconstruct (position_seconds, is_in_progress, season counts), so the
+  // detail query still has to be refreshed for those.
+  const detailFullyPatched = payload.change === "favorite" || payload.change === "watchlist";
+  scheduleMediaSurfaceInvalidation(
     queryClient,
-    payload.content_id ? { itemId: payload.content_id } : {},
-  ).then(() => {
-    bumpHomeRefreshSignal(queryClient);
-  });
+    payload.content_id
+      ? {
+          itemId: payload.content_id,
+          skipItemDetail: detailFullyPatched,
+          skipSimilarItems: true,
+        }
+      : { skipSimilarItems: true },
+  );
   void queryClient.invalidateQueries({
     queryKey: adminKeys.stats(),
     refetchType: allowDashboardRefetch ? "active" : "none",

--- a/web/src/components/StarRating.test.tsx
+++ b/web/src/components/StarRating.test.tsx
@@ -3,47 +3,29 @@ import { describe, expect, it, vi } from "vitest";
 import StarRating from "./StarRating";
 
 describe("StarRating", () => {
-  it("previews the hovered rating and restores the saved rating on leave", () => {
+  it("marks the saved rating as the resting fill state", () => {
     render(<StarRating value={2} onChange={() => {}} />);
 
-    const group = screen.getByRole("radiogroup", { name: "Rating" });
     const stars = screen.getAllByRole("radio");
 
-    expect(stars[1]?.querySelector("svg")).toHaveAttribute("fill-opacity", "1");
-    expect(stars[2]?.querySelector("svg")).toHaveAttribute("fill-opacity", "0");
-
-    fireEvent.mouseEnter(stars[4]!);
-
+    // Hover previews are pure CSS (.star-rating-star[data-filled]) so pointer
+    // movement never schedules React renders; the DOM only carries the stored
+    // rating.
+    expect(stars[1]).toHaveAttribute("data-filled", "true");
+    expect(stars[2]).toHaveAttribute("data-filled", "false");
     for (const star of stars) {
-      expect(star.querySelector("svg")).toHaveAttribute("fill-opacity", "1");
+      expect(star).toHaveClass("star-rating-star");
     }
-
-    fireEvent.mouseLeave(group);
-
-    expect(stars[1]?.querySelector("svg")).toHaveAttribute("fill-opacity", "1");
-    expect(stars[2]?.querySelector("svg")).toHaveAttribute("fill-opacity", "0");
   });
 
-  it("uses focused transitions and preserves rating selection behavior", () => {
+  it("preserves rating selection behavior", () => {
     const onChange = vi.fn();
     render(<StarRating value={3} onChange={onChange} />);
 
     const stars = screen.getAllByRole("radio");
     const fourthStar = stars[3]!;
 
-    expect(fourthStar).toHaveClass(
-      "cursor-pointer",
-      "transform-gpu",
-      "transition-[color,scale]",
-      "duration-100",
-      "motion-safe:hover:scale-110",
-      "motion-reduce:transition-none",
-    );
-    expect(fourthStar).not.toHaveClass("transition-all");
-    expect(fourthStar.querySelector("svg")).toHaveClass(
-      "transition-[fill-opacity]",
-      "motion-reduce:transition-none",
-    );
+    expect(fourthStar).toHaveClass("cursor-pointer");
 
     fireEvent.click(fourthStar);
     expect(onChange).toHaveBeenCalledWith(4);

--- a/web/src/components/StarRating.tsx
+++ b/web/src/components/StarRating.tsx
@@ -1,4 +1,4 @@
-import { useState, useCallback } from "react";
+import { memo, useCallback } from "react";
 import { Star } from "lucide-react";
 
 interface StarRatingProps {
@@ -9,19 +9,7 @@ interface StarRatingProps {
 
 const STAR_COUNT = 5;
 
-export default function StarRating({ value, onChange, size = 20 }: StarRatingProps) {
-  const [hoverValue, setHoverValue] = useState<number | null>(null);
-
-  const displayValue = hoverValue ?? value;
-
-  function handleMouseEnter(star: number) {
-    setHoverValue(star);
-  }
-
-  function handleMouseLeave() {
-    setHoverValue(null);
-  }
-
+function StarRating({ value, onChange, size = 20 }: StarRatingProps) {
   function handleClick(star: number) {
     if (star === value) {
       onChange(null);
@@ -42,6 +30,9 @@ export default function StarRating({ value, onChange, size = 20 }: StarRatingPro
       }
       if (newValue !== null) {
         onChange(newValue);
+        e.currentTarget
+          .querySelector<HTMLButtonElement>(`[data-rating="${newValue}"]`)
+          ?.focus({ preventScroll: true });
       }
     },
     [value, onChange],
@@ -53,13 +44,12 @@ export default function StarRating({ value, onChange, size = 20 }: StarRatingPro
     <div
       role="radiogroup"
       aria-label="Rating"
-      className="glass-subtle flex items-center gap-0.5 rounded-full px-2.5 py-2"
-      onMouseLeave={handleMouseLeave}
+      className="star-rating flex items-center gap-0.5 rounded-full px-2.5 py-2"
       onKeyDown={handleKeyDown}
     >
       {Array.from({ length: STAR_COUNT }, (_, i) => {
         const star = i + 1;
-        const filled = displayValue !== null && star <= displayValue;
+        const filled = value !== null && star <= value;
         return (
           <button
             key={star}
@@ -68,20 +58,17 @@ export default function StarRating({ value, onChange, size = 20 }: StarRatingPro
             aria-label={`${star} star${star !== 1 ? "s" : ""}`}
             aria-checked={value === star}
             tabIndex={star === tabbableStar ? 0 : -1}
-            className={`transform-gpu cursor-pointer border-none bg-transparent p-0.5 leading-none transition-[color,scale] duration-100 ease-out motion-safe:hover:scale-110 motion-reduce:transition-none ${filled ? "text-yellow-400" : "text-muted-foreground/50"}`}
-            onMouseEnter={() => handleMouseEnter(star)}
+            data-filled={filled}
+            data-rating={star}
+            className="star-rating-star focus-visible:ring-ring cursor-pointer rounded-sm border-none bg-transparent p-0.5 leading-none outline-none focus-visible:ring-2"
             onClick={() => handleClick(star)}
           >
-            <Star
-              size={size}
-              fill="currentColor"
-              fillOpacity={filled ? 1 : 0}
-              strokeWidth={1.5}
-              className="transition-[fill-opacity] duration-100 ease-out motion-reduce:transition-none"
-            />
+            <Star size={size} fill="none" strokeWidth={1.5} />
           </button>
         );
       })}
     </div>
   );
 }
+
+export default memo(StarRating);

--- a/web/src/hooks/queries/favorites.ts
+++ b/web/src/hooks/queries/favorites.ts
@@ -3,8 +3,11 @@ import { api } from "@/api/client";
 import type { BrowseItem } from "@/api/types";
 import { favoriteKeys } from "./keys";
 import { toast } from "sonner";
-import { invalidateMediaSurfaceQueries, updateCatalogItemDetail } from "./mediaSurfaceRefresh";
-import { bumpHomeRefreshSignal } from "@/pages/homeSurfaceRefresh";
+import {
+  cancelItemDetailQueries,
+  scheduleMediaSurfaceInvalidation,
+  updateCatalogItemDetail,
+} from "./mediaSurfaceRefresh";
 
 export function useFavorites() {
   return useQuery({
@@ -22,37 +25,38 @@ export function useToggleFavorite(itemId: string) {
         method: currentlyFavorite ? "DELETE" : "PUT",
       }),
     onMutate: async (currentlyFavorite: boolean) => {
-      await queryClient.cancelQueries({ queryKey: ["catalog", "items", itemId, "detail"] });
-      const previous = queryClient.getQueriesData({
-        predicate: (query) =>
-          Array.isArray(query.queryKey) &&
-          query.queryKey[0] === "catalog" &&
-          query.queryKey[1] === "items" &&
-          query.queryKey[2] === itemId &&
-          query.queryKey[3] === "detail",
-      });
+      await cancelItemDetailQueries(queryClient, itemId);
       updateCatalogItemDetail(queryClient, itemId, (detail) => ({
         ...detail,
         user_state: {
-          played: detail.user_state?.played ?? false,
+          played: detail.user_state?.played ?? detail.user_data?.played ?? false,
           is_favorite: !currentlyFavorite,
           in_watchlist: detail.user_state?.in_watchlist ?? false,
         },
       }));
-      return { previous };
     },
-    onError: (_err, _vars, context) => {
-      for (const [queryKey, value] of context?.previous ?? []) {
-        queryClient.setQueryData(queryKey, value);
-      }
+    // Revert only this mutation's own field. Restoring a whole snapshot would
+    // discard a concurrent watchlist/watched toggle's optimistic state.
+    onError: (_err, currentlyFavorite) => {
+      updateCatalogItemDetail(queryClient, itemId, (detail) => ({
+        ...detail,
+        user_state: {
+          played: detail.user_state?.played ?? detail.user_data?.played ?? false,
+          is_favorite: currentlyFavorite,
+          in_watchlist: detail.user_state?.in_watchlist ?? false,
+        },
+      }));
       toast.error("Failed to update favorites");
     },
     onSuccess: (_data, currentlyFavorite) => {
       toast.success(currentlyFavorite ? "Removed from favorites" : "Added to favorites");
     },
-    onSettled: async () => {
-      await invalidateMediaSurfaceQueries(queryClient, { itemId });
-      bumpHomeRefreshSignal(queryClient);
+    onSettled: () => {
+      scheduleMediaSurfaceInvalidation(queryClient, {
+        itemId,
+        skipItemDetail: true,
+        skipSimilarItems: true,
+      });
     },
   });
 }

--- a/web/src/hooks/queries/items.test.ts
+++ b/web/src/hooks/queries/items.test.ts
@@ -1,14 +1,16 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { ItemDetail } from "@/api/types";
 
 const mocks = vi.hoisted(() => ({
   api: vi.fn(),
+  cancelItemDetailQueries: vi.fn(),
   invalidateMediaSurfaceQueries: vi.fn(),
-  isItemDetailQueryKey: vi.fn((_queryKey: unknown, _itemId: string) => true),
-  updateCatalogItemDetail: vi.fn(),
+  scheduleMediaSurfaceInvalidation: vi.fn(),
   toastError: vi.fn(),
   toastLoading: vi.fn(),
   toastSuccess: vi.fn(),
   toastWarning: vi.fn(),
+  updateCatalogItemDetail: vi.fn(),
   useMutation: vi.fn(),
   useQueryClient: vi.fn(),
 }));
@@ -44,10 +46,11 @@ vi.mock("@/pages/ItemDetail/watchedState", async () => {
 });
 
 vi.mock("./mediaSurfaceRefresh", () => ({
+  cancelItemDetailQueries: (...args: unknown[]) => mocks.cancelItemDetailQueries(...args),
   invalidateMediaSurfaceQueries: (...args: unknown[]) =>
     mocks.invalidateMediaSurfaceQueries(...args),
-  isItemDetailQueryKey: (queryKey: unknown, itemId: string) =>
-    mocks.isItemDetailQueryKey(queryKey, itemId),
+  scheduleMediaSurfaceInvalidation: (...args: unknown[]) =>
+    mocks.scheduleMediaSurfaceInvalidation(...args),
   updateCatalogItemDetail: (...args: unknown[]) => mocks.updateCatalogItemDetail(...args),
 }));
 
@@ -75,7 +78,7 @@ type WatchedMutationContext = { previous: Array<[readonly unknown[], unknown]> }
 
 type WatchedMutationOptions = {
   mutationFn: (nextPlayed: boolean) => Promise<unknown>;
-  onMutate?: (nextPlayed: boolean) => Promise<WatchedMutationContext>;
+  onMutate?: (nextPlayed: boolean) => Promise<unknown>;
   onSuccess?: (data: unknown, nextPlayed: boolean) => void;
   onError?: (err: unknown, nextPlayed: boolean, context?: WatchedMutationContext) => void;
   onSettled?: () => Promise<unknown>;
@@ -106,15 +109,16 @@ describe("item query helpers", () => {
   beforeEach(() => {
     mocks.api.mockReset();
     mocks.api.mockResolvedValue({});
+    mocks.cancelItemDetailQueries.mockReset();
+    mocks.cancelItemDetailQueries.mockResolvedValue(undefined);
     mocks.invalidateMediaSurfaceQueries.mockReset();
-    mocks.updateCatalogItemDetail.mockReset();
-    mocks.isItemDetailQueryKey.mockReset();
-    mocks.isItemDetailQueryKey.mockReturnValue(true);
+    mocks.scheduleMediaSurfaceInvalidation.mockReset();
     mocks.toastError.mockReset();
     mocks.toastLoading.mockReset();
     mocks.toastLoading.mockReturnValue("refresh-toast");
     mocks.toastSuccess.mockReset();
     mocks.toastWarning.mockReset();
+    mocks.updateCatalogItemDetail.mockReset();
     mocks.useMutation.mockReset();
     mocks.useMutation.mockImplementation((options: unknown) => ({
       ...(options as object),
@@ -253,21 +257,13 @@ describe("item query helpers", () => {
     });
   });
 
-  it("optimistically flips played state and rolls back when the request fails", async () => {
-    const setQueryData = vi.fn();
-    const previous: Array<[readonly unknown[], unknown]> = [[["items", "detail", "series-1"], {}]];
-    mocks.useQueryClient.mockReturnValue({
-      cancelQueries: vi.fn().mockResolvedValue(undefined),
-      getQueriesData: vi.fn(() => previous),
-      setQueryData,
-    });
-
+  it("optimistically flips played state and reverts only that field on failure", async () => {
     useWatchedStateMutation({ content_id: "series-1", type: "series" });
     const options = mocks.useMutation.mock.calls[
       mocks.useMutation.mock.calls.length - 1
     ]?.[0] as WatchedMutationOptions;
 
-    const context = await options.onMutate?.(true);
+    await options.onMutate?.(true);
     expect(mocks.updateCatalogItemDetail).toHaveBeenCalledWith(
       expect.anything(),
       "series-1",
@@ -288,8 +284,21 @@ describe("item query helpers", () => {
       user_state: { played: true, is_favorite: true, in_watchlist: false },
     });
 
-    options.onError?.(new Error("boom"), true, context);
-    expect(setQueryData).toHaveBeenCalledWith(previous[0]?.[0], previous[0]?.[1]);
+    // Reverting restores only this mutation's own field, so a concurrent
+    // favorite/watchlist toggle's optimistic state survives the failure.
+    options.onError?.(new Error("boom"), true);
+    const revert = mocks.updateCatalogItemDetail.mock.calls[1]?.[2] as (
+      detail: Record<string, unknown>,
+    ) => Record<string, unknown>;
+    expect(
+      revert({
+        user_data: { played: true },
+        user_state: { played: true, is_favorite: true, in_watchlist: false },
+      }),
+    ).toMatchObject({
+      user_data: { played: false },
+      user_state: { played: false, is_favorite: true, in_watchlist: false },
+    });
     expect(mocks.toastError).toHaveBeenCalledWith("boom");
   });
 
@@ -305,10 +314,41 @@ describe("item query helpers", () => {
     options.onSuccess?.(undefined, false);
     expect(mocks.toastSuccess).toHaveBeenCalledWith("Marked as unread");
 
-    await options.onSettled?.();
-    expect(mocks.invalidateMediaSurfaceQueries).toHaveBeenCalledWith(expect.anything(), {
+    options.onSettled?.();
+    // The item's own detail is deliberately not skipped: the server also zeroes
+    // the resume position, which the optimistic patch cannot reconstruct.
+    expect(mocks.scheduleMediaSurfaceInvalidation).toHaveBeenCalledWith(expect.anything(), {
       itemId: "ebook-1",
       watchedKeys: [],
+      skipSimilarItems: true,
+    });
+  });
+
+  it("updates watched state optimistically before refreshing derived surfaces", async () => {
+    const queryClient = { getQueriesData: vi.fn(() => []) };
+    mocks.useQueryClient.mockReturnValue(queryClient);
+
+    useWatchedStateMutation({ content_id: "movie-1", type: "movie" });
+    const options = mocks.useMutation.mock.calls[
+      mocks.useMutation.mock.calls.length - 1
+    ]?.[0] as WatchedMutationOptions;
+
+    await options.onMutate?.(true);
+
+    expect(mocks.cancelItemDetailQueries).toHaveBeenCalledWith(queryClient, "movie-1");
+    expect(mocks.updateCatalogItemDetail).toHaveBeenCalledWith(
+      queryClient,
+      "movie-1",
+      expect.any(Function),
+    );
+    const updater = mocks.updateCatalogItemDetail.mock.calls[0]?.[2] as (
+      detail: ItemDetail,
+    ) => ItemDetail;
+    expect(
+      updater({ user_data: { played: false }, user_state: { played: false } } as ItemDetail),
+    ).toMatchObject({
+      user_data: { played: true },
+      user_state: { played: true },
     });
   });
 });

--- a/web/src/hooks/queries/items.test.ts
+++ b/web/src/hooks/queries/items.test.ts
@@ -74,14 +74,11 @@ import {
   useWatchedStateMutation,
 } from "./items";
 
-type WatchedMutationContext = { previous: Array<[readonly unknown[], unknown]> };
-
 type WatchedMutationOptions = {
   mutationFn: (nextPlayed: boolean) => Promise<unknown>;
   onMutate?: (nextPlayed: boolean) => Promise<unknown>;
   onError?: (error: unknown, nextPlayed: boolean) => void;
   onSuccess?: (data: unknown, nextPlayed: boolean) => void;
-  onError?: (err: unknown, nextPlayed: boolean, context?: WatchedMutationContext) => void;
   onSettled?: () => Promise<unknown>;
 };
 

--- a/web/src/hooks/queries/items.test.ts
+++ b/web/src/hooks/queries/items.test.ts
@@ -79,6 +79,7 @@ type WatchedMutationContext = { previous: Array<[readonly unknown[], unknown]> }
 type WatchedMutationOptions = {
   mutationFn: (nextPlayed: boolean) => Promise<unknown>;
   onMutate?: (nextPlayed: boolean) => Promise<unknown>;
+  onError?: (error: unknown, nextPlayed: boolean) => void;
   onSuccess?: (data: unknown, nextPlayed: boolean) => void;
   onError?: (err: unknown, nextPlayed: boolean, context?: WatchedMutationContext) => void;
   onSettled?: () => Promise<unknown>;
@@ -349,6 +350,20 @@ describe("item query helpers", () => {
     ).toMatchObject({
       user_data: { played: true },
       user_state: { played: true },
+    });
+
+    options.onError?.(new Error("failed"), true);
+    const rollback = mocks.updateCatalogItemDetail.mock.calls[1]?.[2] as (
+      detail: ItemDetail,
+    ) => ItemDetail;
+    expect(
+      rollback({
+        user_data: { played: true },
+        user_state: { played: true, is_favorite: true, in_watchlist: true },
+      } as ItemDetail),
+    ).toMatchObject({
+      user_data: { played: false },
+      user_state: { played: false, is_favorite: true, in_watchlist: true },
     });
   });
 });

--- a/web/src/hooks/queries/items.ts
+++ b/web/src/hooks/queries/items.ts
@@ -21,8 +21,9 @@ import {
   getWatchedToastMessage,
 } from "@/pages/ItemDetail/watchedState";
 import {
+  cancelItemDetailQueries,
   invalidateMediaSurfaceQueries,
-  isItemDetailQueryKey,
+  scheduleMediaSurfaceInvalidation,
   updateCatalogItemDetail,
 } from "./mediaSurfaceRefresh";
 import { bumpHomeRefreshSignal } from "@/pages/homeSurfaceRefresh";
@@ -302,41 +303,43 @@ export function useWatchedStateMutation(item: WatchedMutationItem) {
         keepalive: true,
       }),
     onMutate: async (nextPlayed: boolean) => {
-      // Cancel and snapshot over the same predicate: an in-flight detail query
-      // on either key shape would otherwise land after the optimistic write
-      // and revert the button.
-      const itemDetailQueries = {
-        predicate: (query: { queryKey: unknown }) =>
-          isItemDetailQueryKey(query.queryKey, item.content_id),
-      };
-      await queryClient.cancelQueries(itemDetailQueries);
-      const previous = queryClient.getQueriesData(itemDetailQueries);
+      await cancelItemDetailQueries(queryClient, item.content_id);
       updateCatalogItemDetail(queryClient, item.content_id, (detail) => ({
         ...detail,
-        ...(detail.user_data ? { user_data: { ...detail.user_data, played: nextPlayed } } : {}),
+        user_data: { ...detail.user_data, played: nextPlayed },
         user_state: {
           played: nextPlayed,
           is_favorite: detail.user_state?.is_favorite ?? false,
           in_watchlist: detail.user_state?.in_watchlist ?? false,
         },
       }));
-      return { previous };
     },
-    onError: (err, _nextPlayed, context) => {
-      for (const [queryKey, value] of context?.previous ?? []) {
-        queryClient.setQueryData(queryKey, value);
-      }
+    // Revert only this mutation's own field. Restoring a whole snapshot would
+    // discard a concurrent favorite/watchlist toggle's optimistic state.
+    onError: (err, nextPlayed) => {
+      updateCatalogItemDetail(queryClient, item.content_id, (detail) => ({
+        ...detail,
+        user_data: { ...detail.user_data, played: !nextPlayed },
+        user_state: {
+          played: !nextPlayed,
+          is_favorite: detail.user_state?.is_favorite ?? false,
+          in_watchlist: detail.user_state?.in_watchlist ?? false,
+        },
+      }));
       toast.error(err instanceof Error ? err.message : "Failed to update watched state");
     },
     onSuccess: (_data, nextPlayed) => {
       toast.success(getWatchedToastMessage(item, nextPlayed));
     },
-    onSettled: async () => {
-      await invalidateMediaSurfaceQueries(queryClient, {
+    onSettled: () => {
+      // The detail query has to be refreshed: marking watched also zeroes
+      // `position_seconds` and moves season/series counts server-side, and the
+      // optimistic patch above only carries `played`.
+      scheduleMediaSurfaceInvalidation(queryClient, {
         itemId: item.content_id,
         watchedKeys: getCachedWatchedInvalidationKeys(queryClient, item),
+        skipSimilarItems: true,
       });
-      bumpHomeRefreshSignal(queryClient);
     },
   });
 }

--- a/web/src/hooks/queries/mediaSurfaceRefresh.test.ts
+++ b/web/src/hooks/queries/mediaSurfaceRefresh.test.ts
@@ -1,5 +1,5 @@
 import { QueryClient } from "@tanstack/react-query";
-import { describe, expect, it, vi } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import type { ItemDetail } from "@/api/types";
 import {
   catalogKeys,
@@ -22,6 +22,10 @@ import {
 } from "./mediaSurfaceRefresh";
 
 describe("invalidateMediaSurfaceQueries", () => {
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
   it("cancels every detail cache shape, letting the default revert apply", async () => {
     const queryClient = new QueryClient();
     const cancel = vi.spyOn(queryClient, "cancelQueries").mockResolvedValue(undefined);
@@ -38,7 +42,7 @@ describe("invalidateMediaSurfaceQueries", () => {
     );
     // `revert: false` would drop an in-flight detail query into an error state
     // carrying a CancelledError instead of quietly restoring it.
-    expect(cancel).toHaveBeenCalledWith(expect.any(Object));
+    expect(filters).not.toHaveProperty("revert");
   });
 
   it("marks item, section, progress, history, favorites, watchlist, and collection queries stale", async () => {
@@ -192,7 +196,6 @@ describe("invalidateMediaSurfaceQueries", () => {
     await vi.advanceTimersByTimeAsync(600);
     expect(invalidate).toHaveBeenCalledOnce();
     expect(queryClient.getQueryState(watchedKey)?.isInvalidated).toBe(true);
-    vi.useRealTimers();
   });
 
   it("retains required detail and similar refreshes when coalescing with skip requests", async () => {
@@ -213,7 +216,6 @@ describe("invalidateMediaSurfaceQueries", () => {
     await vi.advanceTimersByTimeAsync(600);
     expect(queryClient.getQueryState(detailKey)?.isInvalidated).toBe(true);
     expect(queryClient.getQueryState(similarKey)?.isInvalidated).toBe(true);
-    vi.useRealTimers();
   });
 
   it("bumps the home refresh signal only once the invalidation has landed", async () => {
@@ -231,7 +233,17 @@ describe("invalidateMediaSurfaceQueries", () => {
     // signal is only useful once the section caches are already invalidated.
     expect(queryClient.getQueryState(sectionKey)?.isInvalidated).toBe(true);
     expect(queryClient.getQueryData(sectionKeys.homeRefreshSignal())).toBe(1);
-    vi.useRealTimers();
+  });
+
+  it("bumps the home refresh signal when invalidation fails", async () => {
+    vi.useFakeTimers();
+    const queryClient = new QueryClient();
+    vi.spyOn(queryClient, "invalidateQueries").mockRejectedValue(new Error("refresh failed"));
+
+    scheduleMediaSurfaceInvalidation(queryClient, { itemId: "item-1" });
+    await vi.advanceTimersByTimeAsync(600);
+
+    expect(queryClient.getQueryData(sectionKeys.homeRefreshSignal())).toBe(1);
   });
 
   it("stops deferring once the coalescing window reaches its maximum wait", async () => {
@@ -246,7 +258,6 @@ describe("invalidateMediaSurfaceQueries", () => {
     }
 
     expect(invalidate).toHaveBeenCalled();
-    vi.useRealTimers();
   });
 
   it("does not invalidate catalog list queries for a different library scope", async () => {

--- a/web/src/hooks/queries/mediaSurfaceRefresh.test.ts
+++ b/web/src/hooks/queries/mediaSurfaceRefresh.test.ts
@@ -7,6 +7,7 @@ import {
   historyKeys,
   itemKeys,
   libraryCollectionKeys,
+  mediaSurfaceKeys,
   personKeys,
   progressKeys,
   recKeys,
@@ -226,13 +227,13 @@ describe("invalidateMediaSurfaceQueries", () => {
 
     scheduleMediaSurfaceInvalidation(queryClient, { itemId: "item-1" });
 
-    expect(queryClient.getQueryData(sectionKeys.homeRefreshSignal())).toBeUndefined();
+    expect(queryClient.getQueryData(mediaSurfaceKeys.refreshSignal())).toBeUndefined();
     await vi.advanceTimersByTimeAsync(600);
 
     // Home re-reads its sections through one-shot `fetchQuery` calls, so the
     // signal is only useful once the section caches are already invalidated.
     expect(queryClient.getQueryState(sectionKey)?.isInvalidated).toBe(true);
-    expect(queryClient.getQueryData(sectionKeys.homeRefreshSignal())).toBe(1);
+    expect(queryClient.getQueryData(mediaSurfaceKeys.refreshSignal())).toBe(1);
   });
 
   it("bumps the home refresh signal when invalidation fails", async () => {
@@ -243,7 +244,7 @@ describe("invalidateMediaSurfaceQueries", () => {
     scheduleMediaSurfaceInvalidation(queryClient, { itemId: "item-1" });
     await vi.advanceTimersByTimeAsync(600);
 
-    expect(queryClient.getQueryData(sectionKeys.homeRefreshSignal())).toBe(1);
+    expect(queryClient.getQueryData(mediaSurfaceKeys.refreshSignal())).toBe(1);
   });
 
   it("stops deferring once the coalescing window reaches its maximum wait", async () => {

--- a/web/src/hooks/queries/mediaSurfaceRefresh.test.ts
+++ b/web/src/hooks/queries/mediaSurfaceRefresh.test.ts
@@ -1,5 +1,5 @@
 import { QueryClient } from "@tanstack/react-query";
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import type { ItemDetail } from "@/api/types";
 import {
   catalogKeys,
@@ -14,13 +14,34 @@ import {
   watchlistKeys,
 } from "./keys";
 import {
+  cancelItemDetailQueries,
   invalidateMediaSurfaceQueries,
   removeItemFromHomeSectionCaches,
+  scheduleMediaSurfaceInvalidation,
   setCachedItemDetail,
 } from "./mediaSurfaceRefresh";
 
 describe("invalidateMediaSurfaceQueries", () => {
-  it("marks media and collection surfaces stale", async () => {
+  it("cancels every detail cache shape, letting the default revert apply", async () => {
+    const queryClient = new QueryClient();
+    const cancel = vi.spyOn(queryClient, "cancelQueries").mockResolvedValue(undefined);
+
+    await cancelItemDetailQueries(queryClient, "item-1");
+
+    const filters = cancel.mock.calls[0]?.[0];
+    expect(filters?.predicate?.({ queryKey: catalogKeys.itemDetail("item-1") } as never)).toBe(
+      true,
+    );
+    expect(filters?.predicate?.({ queryKey: itemKeys.detail("item-1") } as never)).toBe(true);
+    expect(filters?.predicate?.({ queryKey: catalogKeys.itemDetail("item-2") } as never)).toBe(
+      false,
+    );
+    // `revert: false` would drop an in-flight detail query into an error state
+    // carrying a CancelledError instead of quietly restoring it.
+    expect(cancel).toHaveBeenCalledWith(expect.any(Object));
+  });
+
+  it("marks item, section, progress, history, favorites, watchlist, and collection queries stale", async () => {
     const queryClient = new QueryClient();
     const browseKey = itemKeys.browse({
       q: "",
@@ -94,6 +115,138 @@ describe("invalidateMediaSurfaceQueries", () => {
     await invalidateMediaSurfaceQueries(queryClient, { itemId: "item-1" });
 
     expect(queryClient.getQueryState(catalogKeys.itemDetail("item-1"))?.isInvalidated).toBe(true);
+  });
+
+  it("deduplicates overlapping surface matches into one invalidation pass", async () => {
+    const queryClient = new QueryClient();
+    const invalidate = vi.spyOn(queryClient, "invalidateQueries");
+
+    queryClient.setQueryData(catalogKeys.itemDetail("item-1"), { content_id: "item-1" });
+    queryClient.setQueryData(favoriteKeys.check("item-1"), { is_favorite: true });
+
+    await invalidateMediaSurfaceQueries(queryClient, { itemId: "item-1" });
+
+    expect(invalidate).toHaveBeenCalledOnce();
+    // No `cancelRefetch: false`: reusing an in-flight request would let a
+    // response that predates the mutation satisfy the invalidation.
+    expect(invalidate).toHaveBeenCalledWith({ predicate: expect.any(Function) });
+  });
+
+  it("preserves an optimistically updated item detail while refreshing derived surfaces", async () => {
+    const queryClient = new QueryClient();
+    const detailKey = catalogKeys.itemDetail("item-1");
+    queryClient.setQueryData(detailKey, { content_id: "item-1", user_rating: 5 });
+
+    await invalidateMediaSurfaceQueries(queryClient, {
+      itemId: "item-1",
+      skipItemDetail: true,
+    });
+
+    expect(queryClient.getQueryState(detailKey)?.isInvalidated).toBe(false);
+  });
+
+  it("does not refresh content-derived similar items after a user-state change", async () => {
+    const queryClient = new QueryClient();
+    const similarKey = recKeys.similar("item-1");
+    const personalizedKey = recKeys.forYouMain();
+    queryClient.setQueryData(similarKey, { items: [] });
+    queryClient.setQueryData(personalizedKey, { row: null });
+
+    await invalidateMediaSurfaceQueries(queryClient, {
+      itemId: "item-1",
+      skipSimilarItems: true,
+    });
+
+    expect(queryClient.getQueryState(similarKey)?.isInvalidated).toBe(false);
+    expect(queryClient.getQueryState(personalizedKey)?.isInvalidated).toBe(true);
+  });
+
+  it("refreshes similar items for content-changing invalidations", async () => {
+    const queryClient = new QueryClient();
+    const similarKey = recKeys.similar("item-1");
+    queryClient.setQueryData(similarKey, { items: [] });
+
+    await invalidateMediaSurfaceQueries(queryClient, { itemId: "item-1" });
+
+    expect(queryClient.getQueryState(similarKey)?.isInvalidated).toBe(true);
+  });
+
+  it("coalesces rapid user-state refreshes outside the interaction frame", async () => {
+    vi.useFakeTimers();
+    const queryClient = new QueryClient();
+    const invalidate = vi.spyOn(queryClient, "invalidateQueries");
+    const watchedKey = ["episodes", "series-1", "season", 1] as const;
+    queryClient.setQueryData(watchedKey, { episodes: [] });
+
+    scheduleMediaSurfaceInvalidation(queryClient, {
+      itemId: "item-1",
+      watchedKeys: [watchedKey],
+      skipItemDetail: true,
+    });
+    scheduleMediaSurfaceInvalidation(queryClient, {
+      itemId: "item-1",
+      skipItemDetail: true,
+    });
+
+    expect(invalidate).not.toHaveBeenCalled();
+    await vi.advanceTimersByTimeAsync(600);
+    expect(invalidate).toHaveBeenCalledOnce();
+    expect(queryClient.getQueryState(watchedKey)?.isInvalidated).toBe(true);
+    vi.useRealTimers();
+  });
+
+  it("retains required detail and similar refreshes when coalescing with skip requests", async () => {
+    vi.useFakeTimers();
+    const queryClient = new QueryClient();
+    const detailKey = catalogKeys.itemDetail("item-1");
+    const similarKey = recKeys.similar("item-1");
+    queryClient.setQueryData(detailKey, { content_id: "item-1" });
+    queryClient.setQueryData(similarKey, { items: [] });
+
+    scheduleMediaSurfaceInvalidation(queryClient, {
+      itemId: "item-1",
+      skipItemDetail: true,
+      skipSimilarItems: true,
+    });
+    scheduleMediaSurfaceInvalidation(queryClient, { itemId: "item-1" });
+
+    await vi.advanceTimersByTimeAsync(600);
+    expect(queryClient.getQueryState(detailKey)?.isInvalidated).toBe(true);
+    expect(queryClient.getQueryState(similarKey)?.isInvalidated).toBe(true);
+    vi.useRealTimers();
+  });
+
+  it("bumps the home refresh signal only once the invalidation has landed", async () => {
+    vi.useFakeTimers();
+    const queryClient = new QueryClient();
+    const sectionKey = sectionKeys.homeItems("continue-watching");
+    queryClient.setQueryData(sectionKey, { section: { id: "continue-watching" } });
+
+    scheduleMediaSurfaceInvalidation(queryClient, { itemId: "item-1" });
+
+    expect(queryClient.getQueryData(sectionKeys.homeRefreshSignal())).toBeUndefined();
+    await vi.advanceTimersByTimeAsync(600);
+
+    // Home re-reads its sections through one-shot `fetchQuery` calls, so the
+    // signal is only useful once the section caches are already invalidated.
+    expect(queryClient.getQueryState(sectionKey)?.isInvalidated).toBe(true);
+    expect(queryClient.getQueryData(sectionKeys.homeRefreshSignal())).toBe(1);
+    vi.useRealTimers();
+  });
+
+  it("stops deferring once the coalescing window reaches its maximum wait", async () => {
+    vi.useFakeTimers();
+    const queryClient = new QueryClient();
+    const invalidate = vi.spyOn(queryClient, "invalidateQueries");
+
+    // A stream that never pauses for the full debounce must still refresh.
+    for (let elapsed = 0; elapsed < 4000; elapsed += 500) {
+      scheduleMediaSurfaceInvalidation(queryClient, { itemId: "item-1" });
+      await vi.advanceTimersByTimeAsync(500);
+    }
+
+    expect(invalidate).toHaveBeenCalled();
+    vi.useRealTimers();
   });
 
   it("does not invalidate catalog list queries for a different library scope", async () => {

--- a/web/src/hooks/queries/mediaSurfaceRefresh.ts
+++ b/web/src/hooks/queries/mediaSurfaceRefresh.ts
@@ -32,6 +32,15 @@ const MEDIA_SURFACE_REFRESH_DELAY_MS = 600;
 // sustained event stream (a history import, a watch-provider sync) re-arms the
 // timer indefinitely and the surfaces never refresh at all.
 const MEDIA_SURFACE_REFRESH_MAX_WAIT_MS = 3000;
+const MEDIA_SURFACE_PREFIXES = [
+  itemKeys.all,
+  progressKeys.all,
+  historyKeys.all,
+  favoriteKeys.all,
+  watchlistKeys.all,
+  personKeys.all,
+  adminKeys.playbackHistory({}).slice(0, 2),
+];
 const scheduledInvalidations = new WeakMap<
   QueryClient,
   Map<
@@ -115,8 +124,6 @@ export function removeItemFromHomeSectionCaches(
   );
 }
 
-/** Matches both item-detail cache key shapes for one item, so optimistic
- * updates and their rollback snapshot cover exactly the same queries. */
 export function isItemDetailQueryKey(queryKey: unknown, itemId: string) {
   return (
     Array.isArray(queryKey) &&
@@ -131,11 +138,19 @@ export function isItemDetailQueryKey(queryKey: unknown, itemId: string) {
 function queryKeyStartsWith(queryKey: readonly unknown[], prefix: readonly unknown[]) {
   return (
     prefix.length <= queryKey.length &&
-    prefix.every(
-      (part, index) =>
-        Object.is(part, queryKey[index]) ||
-        JSON.stringify(part) === JSON.stringify(queryKey[index]),
-    )
+    prefix.every((part, index) => {
+      const candidate = queryKey[index];
+      if (Object.is(part, candidate)) return true;
+      if (
+        typeof part !== "object" ||
+        part === null ||
+        typeof candidate !== "object" ||
+        candidate === null
+      ) {
+        return false;
+      }
+      return JSON.stringify(part) === JSON.stringify(candidate);
+    })
   );
 }
 
@@ -160,16 +175,7 @@ function shouldInvalidateMediaSurfaceQuery(
     return options.libraryId === undefined || queryKey[2] === options.libraryId;
   }
 
-  const surfacePrefixes = [
-    itemKeys.all,
-    progressKeys.all,
-    historyKeys.all,
-    favoriteKeys.all,
-    watchlistKeys.all,
-    personKeys.all,
-    adminKeys.playbackHistory({}).slice(0, 2),
-  ];
-  if (surfacePrefixes.some((prefix) => queryKeyStartsWith(queryKey, prefix))) {
+  if (MEDIA_SURFACE_PREFIXES.some((prefix) => queryKeyStartsWith(queryKey, prefix))) {
     return true;
   }
 
@@ -224,9 +230,10 @@ export function scheduleMediaSurfaceInvalidation(
       // Home reads its sections through one-shot `fetchQuery` calls with no
       // observers, so the signal has to be bumped after the invalidation lands
       // or Home re-reads a cache that is still marked fresh.
-      void invalidateMediaSurfaceQueries(queryClient, mergedOptions).then(() => {
-        bumpHomeRefreshSignal(queryClient);
-      });
+      void invalidateMediaSurfaceQueries(queryClient, mergedOptions).then(
+        () => bumpHomeRefreshSignal(queryClient),
+        () => bumpHomeRefreshSignal(queryClient),
+      );
     },
     Math.max(0, Math.min(MEDIA_SURFACE_REFRESH_DELAY_MS, deadline - now)),
   );

--- a/web/src/hooks/queries/mediaSurfaceRefresh.ts
+++ b/web/src/hooks/queries/mediaSurfaceRefresh.ts
@@ -17,12 +17,32 @@ import {
   activeCatalogQueryMatchesLibrary,
   activeSectionQueryMatchesLibrary,
 } from "@/lib/queryInvalidation";
+import { bumpHomeRefreshSignal } from "@/pages/homeSurfaceRefresh";
 
 interface InvalidateMediaSurfaceOptions {
   itemId?: string;
   libraryId?: number;
   watchedKeys?: Array<readonly unknown[]>;
+  skipItemDetail?: boolean;
+  skipSimilarItems?: boolean;
 }
+
+const MEDIA_SURFACE_REFRESH_DELAY_MS = 600;
+// Upper bound on how long coalescing may postpone a refresh. Without it a
+// sustained event stream (a history import, a watch-provider sync) re-arms the
+// timer indefinitely and the surfaces never refresh at all.
+const MEDIA_SURFACE_REFRESH_MAX_WAIT_MS = 3000;
+const scheduledInvalidations = new WeakMap<
+  QueryClient,
+  Map<
+    string,
+    {
+      timer: ReturnType<typeof setTimeout>;
+      deadline: number;
+      options: InvalidateMediaSurfaceOptions;
+    }
+  >
+>();
 
 export function updateCatalogItemDetail(
   queryClient: QueryClient,
@@ -35,6 +55,16 @@ export function updateCatalogItemDetail(
     },
     (current) => (current ? updater(current) : current),
   );
+}
+
+// Callers must await this before writing optimistic state. The default
+// `revert: true` restores the pre-fetch snapshot and leaves the query idle;
+// `revert: false` would instead put an in-flight query into an error state
+// carrying a CancelledError, which surfaces as a bogus "CancelledError" toast.
+export function cancelItemDetailQueries(queryClient: QueryClient, itemId: string) {
+  return queryClient.cancelQueries({
+    predicate: (query) => isItemDetailQueryKey(query.queryKey, itemId),
+  });
 }
 
 export function setCachedItemDetail(queryClient: QueryClient, itemId: string, detail: ItemDetail) {
@@ -98,52 +128,108 @@ export function isItemDetailQueryKey(queryKey: unknown, itemId: string) {
   );
 }
 
+function queryKeyStartsWith(queryKey: readonly unknown[], prefix: readonly unknown[]) {
+  return (
+    prefix.length <= queryKey.length &&
+    prefix.every(
+      (part, index) =>
+        Object.is(part, queryKey[index]) ||
+        JSON.stringify(part) === JSON.stringify(queryKey[index]),
+    )
+  );
+}
+
+function shouldInvalidateMediaSurfaceQuery(
+  queryKey: readonly unknown[],
+  options: InvalidateMediaSurfaceOptions,
+) {
+  if (options.skipItemDetail && options.itemId && isItemDetailQueryKey(queryKey, options.itemId)) {
+    return false;
+  }
+
+  if (queryKeyStartsWith(queryKey, catalogKeys.all)) {
+    return activeCatalogQueryMatchesLibrary(queryKey, options.libraryId);
+  }
+  if (queryKeyStartsWith(queryKey, sectionKeys.all)) {
+    return activeSectionQueryMatchesLibrary(queryKey, options.libraryId);
+  }
+  if (queryKeyStartsWith(queryKey, recKeys.all)) {
+    return !(options.skipSimilarItems && queryKey[1] === "similar");
+  }
+  if (queryKeyStartsWith(queryKey, libraryCollectionKeys.all)) {
+    return options.libraryId === undefined || queryKey[2] === options.libraryId;
+  }
+
+  const surfacePrefixes = [
+    itemKeys.all,
+    progressKeys.all,
+    historyKeys.all,
+    favoriteKeys.all,
+    watchlistKeys.all,
+    personKeys.all,
+    adminKeys.playbackHistory({}).slice(0, 2),
+  ];
+  if (surfacePrefixes.some((prefix) => queryKeyStartsWith(queryKey, prefix))) {
+    return true;
+  }
+
+  return (options.watchedKeys ?? []).some((key) => queryKeyStartsWith(queryKey, key));
+}
+
 export async function invalidateMediaSurfaceQueries(
   queryClient: QueryClient,
   options: InvalidateMediaSurfaceOptions = {},
 ) {
-  const invalidations: Array<Promise<void>> = [
-    queryClient.invalidateQueries({ queryKey: itemKeys.all }),
-    queryClient.invalidateQueries({
-      queryKey: catalogKeys.all,
-      predicate: (query) => activeCatalogQueryMatchesLibrary(query.queryKey, options.libraryId),
-    }),
-    queryClient.invalidateQueries({
-      queryKey: sectionKeys.all,
-      predicate: (query) => activeSectionQueryMatchesLibrary(query.queryKey, options.libraryId),
-    }),
-    queryClient.invalidateQueries({ queryKey: progressKeys.all }),
-    queryClient.invalidateQueries({ queryKey: historyKeys.all }),
-    queryClient.invalidateQueries({ queryKey: favoriteKeys.all }),
-    queryClient.invalidateQueries({ queryKey: watchlistKeys.all }),
-    queryClient.invalidateQueries({
-      queryKey: libraryCollectionKeys.all,
-      predicate: (query) =>
-        options.libraryId === undefined || query.queryKey[2] === options.libraryId,
-    }),
-    queryClient.invalidateQueries({ queryKey: recKeys.all }),
-    queryClient.invalidateQueries({ queryKey: personKeys.all }),
-    queryClient.invalidateQueries({
-      predicate: (query) =>
-        Array.isArray(query.queryKey) &&
-        query.queryKey[0] === adminKeys.playbackHistory({})[0] &&
-        query.queryKey[1] === adminKeys.playbackHistory({})[1],
-    }),
-  ];
+  // Duplicate refetches are held down by the coalescing scheduler below, not by
+  // `cancelRefetch: false` — reusing an in-flight request would let a response
+  // that predates the mutation satisfy the invalidation and land in the cache
+  // as fresh.
+  await queryClient.invalidateQueries({
+    predicate: (query) => shouldInvalidateMediaSurfaceQuery(query.queryKey, options),
+  });
+}
 
-  if (options.itemId) {
-    invalidations.push(
-      queryClient.invalidateQueries({ queryKey: ["catalog", "items", options.itemId, "detail"] }),
-      queryClient.invalidateQueries({ queryKey: ["items", "detail", options.itemId] }),
-      queryClient.invalidateQueries({ queryKey: ["items", "watchDetail", options.itemId] }),
-      queryClient.invalidateQueries({ queryKey: favoriteKeys.check(options.itemId) }),
-      queryClient.invalidateQueries({ queryKey: watchlistKeys.check(options.itemId) }),
-    );
+export function scheduleMediaSurfaceInvalidation(
+  queryClient: QueryClient,
+  options: InvalidateMediaSurfaceOptions = {},
+) {
+  let clientInvalidations = scheduledInvalidations.get(queryClient);
+  if (!clientInvalidations) {
+    clientInvalidations = new Map();
+    scheduledInvalidations.set(queryClient, clientInvalidations);
   }
 
-  for (const key of options.watchedKeys ?? []) {
-    invalidations.push(queryClient.invalidateQueries({ queryKey: key }));
-  }
+  const key = `${options.itemId ?? "all"}:${options.libraryId ?? "all"}`;
+  const existing = clientInvalidations.get(key);
+  if (existing) clearTimeout(existing.timer);
 
-  await Promise.all(invalidations);
+  const mergedOptions: InvalidateMediaSurfaceOptions = {
+    ...existing?.options,
+    ...options,
+    // Skipping is safe only when every coalesced caller has already supplied
+    // the canonical detail state. A single full-refresh request must win.
+    skipItemDetail: existing
+      ? Boolean(existing.options.skipItemDetail && options.skipItemDetail)
+      : options.skipItemDetail,
+    skipSimilarItems: existing
+      ? Boolean(existing.options.skipSimilarItems && options.skipSimilarItems)
+      : options.skipSimilarItems,
+    watchedKeys: [...(existing?.options.watchedKeys ?? []), ...(options.watchedKeys ?? [])],
+  };
+  const now = Date.now();
+  const deadline = existing?.deadline ?? now + MEDIA_SURFACE_REFRESH_MAX_WAIT_MS;
+  const timer = setTimeout(
+    () => {
+      clientInvalidations?.delete(key);
+      // Home reads its sections through one-shot `fetchQuery` calls with no
+      // observers, so the signal has to be bumped after the invalidation lands
+      // or Home re-reads a cache that is still marked fresh.
+      void invalidateMediaSurfaceQueries(queryClient, mergedOptions).then(() => {
+        bumpHomeRefreshSignal(queryClient);
+      });
+    },
+    Math.max(0, Math.min(MEDIA_SURFACE_REFRESH_DELAY_MS, deadline - now)),
+  );
+
+  clientInvalidations.set(key, { timer, deadline, options: mergedOptions });
 }

--- a/web/src/hooks/queries/ratings.test.ts
+++ b/web/src/hooks/queries/ratings.test.ts
@@ -1,0 +1,65 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { catalogKeys, itemKeys } from "./keys";
+
+const mocks = vi.hoisted(() => ({
+  cancelItemDetailQueries: vi.fn(),
+  getQueriesData: vi.fn(),
+  useMutation: vi.fn(),
+}));
+
+vi.mock("@tanstack/react-query", async () => {
+  const actual =
+    await vi.importActual<typeof import("@tanstack/react-query")>("@tanstack/react-query");
+  return {
+    ...actual,
+    useMutation: (...args: unknown[]) => mocks.useMutation(...args),
+    useQueryClient: () => ({ getQueriesData: mocks.getQueriesData }),
+  };
+});
+
+vi.mock("./mediaSurfaceRefresh", async () => {
+  const actual =
+    await vi.importActual<typeof import("./mediaSurfaceRefresh")>("./mediaSurfaceRefresh");
+  return {
+    ...actual,
+    cancelItemDetailQueries: (...args: unknown[]) => mocks.cancelItemDetailQueries(...args),
+    updateCatalogItemDetail: vi.fn(),
+  };
+});
+
+vi.mock("./ratingsSurfaceRefresh", () => ({
+  invalidateRatingSurfaceQueries: vi.fn(),
+}));
+
+import { useDeleteRating, useSetRating } from "./ratings";
+
+describe("rating mutations", () => {
+  beforeEach(() => {
+    mocks.cancelItemDetailQueries.mockReset();
+    mocks.cancelItemDetailQueries.mockResolvedValue(undefined);
+    mocks.getQueriesData.mockReset();
+    mocks.getQueriesData.mockReturnValue([]);
+    mocks.useMutation.mockReset();
+    mocks.useMutation.mockImplementation((options: unknown) => options);
+  });
+
+  it.each([
+    ["setting", () => useSetRating("item-1"), 4],
+    ["deleting", () => useDeleteRating("item-1"), undefined],
+  ])(
+    "snapshots both item-detail cache shapes when %s a rating",
+    async (_label, useRating, value) => {
+      useRating();
+      const options = mocks.useMutation.mock.calls[0]?.[0] as {
+        onMutate: (rating?: number) => Promise<unknown>;
+      };
+
+      await options.onMutate(value);
+
+      const filters = mocks.getQueriesData.mock.calls[0]?.[0];
+      expect(filters.predicate({ queryKey: catalogKeys.itemDetail("item-1") })).toBe(true);
+      expect(filters.predicate({ queryKey: itemKeys.detail("item-1") })).toBe(true);
+      expect(filters.predicate({ queryKey: catalogKeys.itemDetail("item-2") })).toBe(false);
+    },
+  );
+});

--- a/web/src/hooks/queries/ratings.ts
+++ b/web/src/hooks/queries/ratings.ts
@@ -2,7 +2,11 @@ import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { api } from "@/api/client";
 import type { ItemDetail } from "@/api/types";
 import { invalidateRatingSurfaceQueries } from "./ratingsSurfaceRefresh";
-import { cancelItemDetailQueries, updateCatalogItemDetail } from "./mediaSurfaceRefresh";
+import {
+  cancelItemDetailQueries,
+  isItemDetailQueryKey,
+  updateCatalogItemDetail,
+} from "./mediaSurfaceRefresh";
 
 export function useSetRating(itemId: string) {
   const queryClient = useQueryClient();
@@ -15,12 +19,7 @@ export function useSetRating(itemId: string) {
     onMutate: async (rating: number) => {
       await cancelItemDetailQueries(queryClient, itemId);
       const previous = queryClient.getQueriesData<ItemDetail>({
-        predicate: (query) =>
-          Array.isArray(query.queryKey) &&
-          query.queryKey[0] === "catalog" &&
-          query.queryKey[1] === "items" &&
-          query.queryKey[2] === itemId &&
-          query.queryKey[3] === "detail",
+        predicate: (query) => isItemDetailQueryKey(query.queryKey, itemId),
       });
       updateCatalogItemDetail(queryClient, itemId, (detail) => ({
         ...detail,
@@ -46,12 +45,7 @@ export function useDeleteRating(itemId: string) {
     onMutate: async () => {
       await cancelItemDetailQueries(queryClient, itemId);
       const previous = queryClient.getQueriesData<ItemDetail>({
-        predicate: (query) =>
-          Array.isArray(query.queryKey) &&
-          query.queryKey[0] === "catalog" &&
-          query.queryKey[1] === "items" &&
-          query.queryKey[2] === itemId &&
-          query.queryKey[3] === "detail",
+        predicate: (query) => isItemDetailQueryKey(query.queryKey, itemId),
       });
       updateCatalogItemDetail(queryClient, itemId, (detail) => ({
         ...detail,

--- a/web/src/hooks/queries/ratings.ts
+++ b/web/src/hooks/queries/ratings.ts
@@ -2,7 +2,7 @@ import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { api } from "@/api/client";
 import type { ItemDetail } from "@/api/types";
 import { invalidateRatingSurfaceQueries } from "./ratingsSurfaceRefresh";
-import { updateCatalogItemDetail } from "./mediaSurfaceRefresh";
+import { cancelItemDetailQueries, updateCatalogItemDetail } from "./mediaSurfaceRefresh";
 
 export function useSetRating(itemId: string) {
   const queryClient = useQueryClient();
@@ -13,7 +13,7 @@ export function useSetRating(itemId: string) {
         body: JSON.stringify({ rating }),
       }),
     onMutate: async (rating: number) => {
-      await queryClient.cancelQueries({ queryKey: ["catalog", "items", itemId, "detail"] });
+      await cancelItemDetailQueries(queryClient, itemId);
       const previous = queryClient.getQueriesData<ItemDetail>({
         predicate: (query) =>
           Array.isArray(query.queryKey) &&
@@ -44,7 +44,7 @@ export function useDeleteRating(itemId: string) {
   return useMutation({
     mutationFn: () => api(`/ratings/${itemId}`, { method: "DELETE" }),
     onMutate: async () => {
-      await queryClient.cancelQueries({ queryKey: ["catalog", "items", itemId, "detail"] });
+      await cancelItemDetailQueries(queryClient, itemId);
       const previous = queryClient.getQueriesData<ItemDetail>({
         predicate: (query) =>
           Array.isArray(query.queryKey) &&

--- a/web/src/hooks/queries/ratingsSurfaceRefresh.test.ts
+++ b/web/src/hooks/queries/ratingsSurfaceRefresh.test.ts
@@ -1,6 +1,6 @@
 import { QueryClient } from "@tanstack/react-query";
 import { describe, expect, it } from "vitest";
-import { ratingKeys, recKeys, sectionKeys } from "./keys";
+import { catalogKeys, ratingKeys, recKeys, sectionKeys } from "./keys";
 import { invalidateRatingSurfaceQueries } from "./ratingsSurfaceRefresh";
 
 describe("invalidateRatingSurfaceQueries", () => {
@@ -19,7 +19,12 @@ describe("invalidateRatingSurfaceQueries", () => {
       signal_counts: {},
       updated_at: "2026-03-23T00:00:00.000Z",
     });
+    queryClient.setQueryData(recKeys.similar("item-1"), { items: [] });
     queryClient.setQueryData(sectionKeys.homeItems("for-you"), { section: { id: "for-you" } });
+    queryClient.setQueryData(catalogKeys.itemDetail("item-1"), {
+      content_id: "item-1",
+      user_rating: 4,
+    });
 
     await invalidateRatingSurfaceQueries(queryClient, "item-1");
 
@@ -27,6 +32,8 @@ describe("invalidateRatingSurfaceQueries", () => {
     expect(queryClient.getQueryState(recKeys.forYouMain())?.isInvalidated).toBe(true);
     expect(queryClient.getQueryState(recKeys.forYouRows())?.isInvalidated).toBe(true);
     expect(queryClient.getQueryState(recKeys.tasteProfile())?.isInvalidated).toBe(true);
+    expect(queryClient.getQueryState(recKeys.similar("item-1"))?.isInvalidated).toBe(false);
     expect(queryClient.getQueryState(sectionKeys.homeItems("for-you"))?.isInvalidated).toBe(true);
+    expect(queryClient.getQueryState(catalogKeys.itemDetail("item-1"))?.isInvalidated).toBe(false);
   });
 });

--- a/web/src/hooks/queries/ratingsSurfaceRefresh.ts
+++ b/web/src/hooks/queries/ratingsSurfaceRefresh.ts
@@ -2,11 +2,30 @@ import type { QueryClient } from "@tanstack/react-query";
 import { catalogKeys, ratingKeys, recKeys, sectionKeys } from "./keys";
 
 export async function invalidateRatingSurfaceQueries(queryClient: QueryClient, itemId: string) {
-  await Promise.all([
-    queryClient.invalidateQueries({ queryKey: ratingKeys.item(itemId) }),
-    queryClient.invalidateQueries({ queryKey: ["catalog", "items", itemId, "detail"] }),
-    queryClient.invalidateQueries({ queryKey: catalogKeys.all }),
-    queryClient.invalidateQueries({ queryKey: recKeys.all }),
-    queryClient.invalidateQueries({ queryKey: sectionKeys.all }),
-  ]);
+  // No `cancelRefetch: false` here: reusing an in-flight request would let a
+  // response that predates the rating change satisfy this invalidation and land
+  // in the cache as fresh.
+  await queryClient.invalidateQueries({
+    predicate: (query) => {
+      const key = query.queryKey;
+      const isCurrentDetail =
+        key[0] === "catalog" && key[1] === "items" && key[2] === itemId && key[3] === "detail";
+      if (isCurrentDetail) return false;
+      const isSimilarItems = startsWith(key, recKeys.all) && key[1] === "similar";
+      if (isSimilarItems) return false;
+
+      return (
+        startsWith(key, ratingKeys.item(itemId)) ||
+        startsWith(key, catalogKeys.all) ||
+        startsWith(key, recKeys.all) ||
+        startsWith(key, sectionKeys.all)
+      );
+    },
+  });
+}
+
+function startsWith(queryKey: readonly unknown[], prefix: readonly unknown[]) {
+  return (
+    prefix.length <= queryKey.length && prefix.every((part, index) => part === queryKey[index])
+  );
 }

--- a/web/src/hooks/queries/watchlist.ts
+++ b/web/src/hooks/queries/watchlist.ts
@@ -3,8 +3,11 @@ import { api } from "@/api/client";
 import type { BrowseItem } from "@/api/types";
 import { watchlistKeys } from "./keys";
 import { toast } from "sonner";
-import { invalidateMediaSurfaceQueries, updateCatalogItemDetail } from "./mediaSurfaceRefresh";
-import { bumpHomeRefreshSignal } from "@/pages/homeSurfaceRefresh";
+import {
+  cancelItemDetailQueries,
+  scheduleMediaSurfaceInvalidation,
+  updateCatalogItemDetail,
+} from "./mediaSurfaceRefresh";
 
 export function useWatchlist() {
   return useQuery({
@@ -22,37 +25,38 @@ export function useToggleWatchlist(itemId: string) {
         method: currentlyInWatchlist ? "DELETE" : "PUT",
       }),
     onMutate: async (currentlyInWatchlist: boolean) => {
-      await queryClient.cancelQueries({ queryKey: ["catalog", "items", itemId, "detail"] });
-      const previous = queryClient.getQueriesData({
-        predicate: (query) =>
-          Array.isArray(query.queryKey) &&
-          query.queryKey[0] === "catalog" &&
-          query.queryKey[1] === "items" &&
-          query.queryKey[2] === itemId &&
-          query.queryKey[3] === "detail",
-      });
+      await cancelItemDetailQueries(queryClient, itemId);
       updateCatalogItemDetail(queryClient, itemId, (detail) => ({
         ...detail,
         user_state: {
-          played: detail.user_state?.played ?? false,
+          played: detail.user_state?.played ?? detail.user_data?.played ?? false,
           is_favorite: detail.user_state?.is_favorite ?? false,
           in_watchlist: !currentlyInWatchlist,
         },
       }));
-      return { previous };
     },
-    onError: (_err, _vars, context) => {
-      for (const [queryKey, value] of context?.previous ?? []) {
-        queryClient.setQueryData(queryKey, value);
-      }
+    // Revert only this mutation's own field. Restoring a whole snapshot would
+    // discard a concurrent favorite/watched toggle's optimistic state.
+    onError: (_err, currentlyInWatchlist) => {
+      updateCatalogItemDetail(queryClient, itemId, (detail) => ({
+        ...detail,
+        user_state: {
+          played: detail.user_state?.played ?? detail.user_data?.played ?? false,
+          is_favorite: detail.user_state?.is_favorite ?? false,
+          in_watchlist: currentlyInWatchlist,
+        },
+      }));
       toast.error("Failed to update watchlist");
     },
     onSuccess: (_data, currentlyInWatchlist) => {
       toast.success(currentlyInWatchlist ? "Removed from watchlist" : "Added to watchlist");
     },
-    onSettled: async () => {
-      await invalidateMediaSurfaceQueries(queryClient, { itemId });
-      bumpHomeRefreshSignal(queryClient);
+    onSettled: () => {
+      scheduleMediaSurfaceInvalidation(queryClient, {
+        itemId,
+        skipItemDetail: true,
+        skipSimilarItems: true,
+      });
     },
   });
 }

--- a/web/src/pages/ItemDetail/DetailHero.tsx
+++ b/web/src/pages/ItemDetail/DetailHero.tsx
@@ -119,10 +119,6 @@ export default function DetailHero({
               src={backdropUrl}
               alt=""
               className={`h-full w-full object-cover object-[center_20%] transition-opacity duration-300 ${backdropLoaded ? "opacity-100" : "opacity-0"}`}
-              // Kept, minus `will-change: transform`: the hint pinned a
-              // full-bleed backdrop layer for the whole visit, while the
-              // animation itself is composited on its own.
-              style={{ animation: "var(--animate-ken-burns-a)" }}
               onLoad={onBackdropLoad}
             />
           )}

--- a/web/src/pages/ItemDetail/DetailHero.tsx
+++ b/web/src/pages/ItemDetail/DetailHero.tsx
@@ -118,7 +118,10 @@ export default function DetailHero({
               key={backdropUrl}
               src={backdropUrl}
               alt=""
-              className={`h-full w-full object-cover object-[center_20%] transition-opacity duration-300 will-change-transform ${backdropLoaded ? "opacity-100" : "opacity-0"}`}
+              className={`h-full w-full object-cover object-[center_20%] transition-opacity duration-300 ${backdropLoaded ? "opacity-100" : "opacity-0"}`}
+              // Kept, minus `will-change: transform`: the hint pinned a
+              // full-bleed backdrop layer for the whole visit, while the
+              // animation itself is composited on its own.
               style={{ animation: "var(--animate-ken-burns-a)" }}
               onLoad={onBackdropLoad}
             />

--- a/web/src/pages/ItemDetail/EpisodeContent.tsx
+++ b/web/src/pages/ItemDetail/EpisodeContent.tsx
@@ -9,11 +9,7 @@ import { useAuth } from "@/hooks/useAuth";
 import { useIsActingAdmin } from "@/hooks/useIsActingAdmin";
 import { useCurrentProfile } from "@/hooks/useCurrentProfile";
 import { useOnViewTranslation } from "@/hooks/useOnViewTranslation";
-import {
-  useRedetectEpisodeIntro,
-  useRefreshItemMetadata,
-  useWatchedStateMutation,
-} from "@/hooks/queries/items";
+import { useRedetectEpisodeIntro, useRefreshItemMetadata } from "@/hooks/queries/items";
 import CastCarousel from "@/components/CastCarousel";
 import CrewList from "@/components/CrewList";
 import DownloadVersionPicker from "@/components/DownloadVersionPicker";
@@ -26,7 +22,7 @@ import MetadataBadges from "./components/MetadataBadges";
 import QualityBadges from "./components/QualityBadges";
 import ScoreRow from "./components/ScoreRow";
 import HeroCrewLine from "./components/HeroCrewLine";
-import ActionBar from "./components/ActionBar";
+import WatchedActionBar from "./components/WatchedActionBar";
 import DetailBreadcrumb from "./components/DetailBreadcrumb";
 import MediaInfoDialog from "./components/MediaInfoDialog";
 import SubtitleSearchDialog from "./components/SubtitleSearchDialog";
@@ -40,7 +36,6 @@ import {
   resolveEpisodeSiblingSeason,
   type EpisodeNavigationState,
 } from "./itemDetailLayout";
-import { getWatchedActionLabel } from "./watchedState";
 import {
   canCurateMetadata as canCurateMetadataForUser,
   canEditMarkers as canEditMarkersForUser,
@@ -132,23 +127,23 @@ export default function EpisodeContent({ item }: { item: ItemDetail & { type: "e
     setExplicitSubtitleSelection(null);
   }
 
-  const handleSelectVersion = (version: FileVersion) => {
+  const handleSelectVersion = useCallback((version: FileVersion) => {
     setManualSelectedFileId(version.file_id);
     setAudioSelectionMode("auto");
     setExplicitAudioTrackIndex(null);
     setSubtitleSelectionMode("auto");
     setExplicitSubtitleSelection(null);
-  };
+  }, []);
 
-  const handleSelectAudioTrack = (trackIndex: number) => {
+  const handleSelectAudioTrack = useCallback((trackIndex: number) => {
     setAudioSelectionMode("explicit");
     setExplicitAudioTrackIndex(trackIndex);
-  };
+  }, []);
 
-  const handleResetAudioSelection = () => {
+  const handleResetAudioSelection = useCallback(() => {
     setAudioSelectionMode("auto");
     setExplicitAudioTrackIndex(null);
-  };
+  }, []);
 
   const handleSelectSubtitle = (selection: PrePlaySubtitleSelection) => {
     setSubtitleSelectionMode("explicit");
@@ -205,7 +200,6 @@ export default function EpisodeContent({ item }: { item: ItemDetail & { type: "e
           hearing_impaired: item.effective_subtitle_track_signature.hearing_impaired,
         }
       : null;
-  const watchedMutation = useWatchedStateMutation(item);
   const navigationState = location.state as EpisodeNavigationState | null;
   const primaryAction = resolveLeafPrimaryAction(item, "Play Episode");
   const restartHref =
@@ -319,7 +313,8 @@ export default function EpisodeContent({ item }: { item: ItemDetail & { type: "e
         onTranslateOverview={onTranslateOverview}
         crewLine={<HeroCrewLine crew={item.crew ?? []} />}
         actions={
-          <ActionBar
+          <WatchedActionBar
+            item={item}
             contentId={item.content_id}
             playHref={
               item.versions && item.versions.length > 0 ? `/watch/${item.content_id}` : undefined
@@ -347,9 +342,6 @@ export default function EpisodeContent({ item }: { item: ItemDetail & { type: "e
             }
             effectiveVersionResolution={item.effective_version_resolution}
             effectiveVersionHdr={item.effective_version_hdr}
-            watchedLabel={getWatchedActionLabel(item)}
-            onToggleWatched={() => watchedMutation.mutate(!(item.user_data?.played ?? false))}
-            isUpdatingWatched={watchedMutation.isPending}
             onRefresh={
               canCurateMetadata
                 ? (mode) =>

--- a/web/src/pages/ItemDetail/MovieContent.tsx
+++ b/web/src/pages/ItemDetail/MovieContent.tsx
@@ -2,10 +2,7 @@ import { useCallback, useMemo, useState } from "react";
 import { useNavigate } from "react-router";
 import type { FileVersion, ItemDetail } from "@/api/types";
 import type { PlayerSubtitleTrackSignature, PrePlaySubtitleSelection } from "@/player/types";
-import { useToggleFavorite } from "@/hooks/queries/favorites";
-import { useToggleWatchlist } from "@/hooks/queries/watchlist";
-import { useRefreshItemMetadata, useWatchedStateMutation } from "@/hooks/queries/items";
-import { useSetRating, useDeleteRating } from "@/hooks/queries/ratings";
+import { useRefreshItemMetadata } from "@/hooks/queries/items";
 import { useSimilarItems } from "@/hooks/queries/recommendations";
 import { useDeleteSubtitlePreference, useSetSubtitlePreference } from "@/hooks/queries/subtitles";
 import { useAuth } from "@/hooks/useAuth";
@@ -29,7 +26,7 @@ import ExtrasSection from "./components/ExtrasSection";
 import QualityBadges from "./components/QualityBadges";
 import ScoreRow from "./components/ScoreRow";
 import HeroCrewLine from "./components/HeroCrewLine";
-import ActionBar from "./components/ActionBar";
+import MediaUserActionBar from "./components/MediaUserActionBar";
 import MediaInfoDialog from "./components/MediaInfoDialog";
 import SubtitleSearchDialog from "./components/SubtitleSearchDialog";
 import { sortByResolution } from "./components/VersionFlyout";
@@ -37,7 +34,6 @@ import { selectDefaultPlaybackVariantVersion } from "./components/versionRanking
 import { resolveSelectedMediaSummary } from "./components/selectedMediaSummary";
 import { RecommendationGridSkeleton } from "./components/SectionSkeletons";
 import { resolveLeafPrimaryAction } from "./itemDetailLayout";
-import { getWatchedActionLabel } from "./watchedState";
 import {
   canCurateMetadata as canCurateMetadataForUser,
   canEditMarkers as canEditMarkersForUser,
@@ -60,14 +56,7 @@ export default function MovieContent({ item }: { item: ItemDetail & { type: "mov
   const canCurateMetadata = canCurateMetadataForUser(user, currentProfile);
   const canEditMarkers = canEditMarkersForUser(user, currentProfile);
 
-  const isFavorite = item.user_state?.is_favorite ?? false;
-  const inWatchlist = item.user_state?.in_watchlist ?? false;
-  const toggleFavoriteMutation = useToggleFavorite(item.content_id);
-  const toggleWatchlistMutation = useToggleWatchlist(item.content_id);
   const refreshMetadataMutation = useRefreshItemMetadata();
-  const watchedMutation = useWatchedStateMutation(item);
-  const setRatingMutation = useSetRating(item.content_id);
-  const deleteRatingMutation = useDeleteRating(item.content_id);
   const deleteSubtitlePreference = useDeleteSubtitlePreference();
   const setSubtitlePreference = useSetSubtitlePreference();
   const [editOpen, setEditOpen] = useState(false);
@@ -136,23 +125,23 @@ export default function MovieContent({ item }: { item: ItemDetail & { type: "mov
     setSubtitleSelectionMode("auto");
     setExplicitSubtitleSelection(null);
   }
-  const handleSelectVersion = (version: FileVersion) => {
+  const handleSelectVersion = useCallback((version: FileVersion) => {
     setManualSelectedFileId(version.file_id);
     setAudioSelectionMode("auto");
     setExplicitAudioTrackIndex(null);
     setSubtitleSelectionMode("auto");
     setExplicitSubtitleSelection(null);
-  };
+  }, []);
 
-  const handleSelectAudioTrack = (trackIndex: number) => {
+  const handleSelectAudioTrack = useCallback((trackIndex: number) => {
     setAudioSelectionMode("explicit");
     setExplicitAudioTrackIndex(trackIndex);
-  };
+  }, []);
 
-  const handleResetAudioSelection = () => {
+  const handleResetAudioSelection = useCallback(() => {
     setAudioSelectionMode("auto");
     setExplicitAudioTrackIndex(null);
-  };
+  }, []);
 
   const handleSelectSubtitle = (selection: PrePlaySubtitleSelection) => {
     setSubtitleSelectionMode("explicit");
@@ -190,14 +179,6 @@ export default function MovieContent({ item }: { item: ItemDetail & { type: "mov
       ? `/watch/${item.content_id}?restart=1`
       : undefined;
   const { data: similarData, isLoading: similarLoading } = useSimilarItems(item.content_id);
-
-  const handleRatingChange = (rating: number | null) => {
-    if (rating === null) {
-      deleteRatingMutation.mutate();
-    } else {
-      setRatingMutation.mutate(rating);
-    }
-  };
 
   const preferredSubtitleTrackSignature: PlayerSubtitleTrackSignature | null =
     item.effective_subtitle_track_signature
@@ -257,7 +238,8 @@ export default function MovieContent({ item }: { item: ItemDetail & { type: "mov
         onTranslateOverview={onTranslateOverview}
         crewLine={<HeroCrewLine crew={item.crew ?? []} genres={item.genres} />}
         actions={
-          <ActionBar
+          <MediaUserActionBar
+            item={item}
             contentId={item.content_id}
             playHref={item.versions.length > 0 ? `/watch/${item.content_id}` : undefined}
             playLabel={primaryAction.label}
@@ -281,13 +263,6 @@ export default function MovieContent({ item }: { item: ItemDetail & { type: "mov
             resumeHdr={
               item.user_data && "last_hdr" in item.user_data ? item.user_data.last_hdr : undefined
             }
-            watchedLabel={getWatchedActionLabel(item)}
-            onToggleWatched={() => watchedMutation.mutate(!(item.user_data?.played ?? false))}
-            isUpdatingWatched={watchedMutation.isPending}
-            onToggleFavorite={() => toggleFavoriteMutation.mutate(isFavorite)}
-            isFavorite={isFavorite}
-            onToggleWatchlist={() => toggleWatchlistMutation.mutate(inWatchlist)}
-            inWatchlist={inWatchlist}
             onRefresh={
               canCurateMetadata
                 ? (mode) =>
@@ -322,8 +297,6 @@ export default function MovieContent({ item }: { item: ItemDetail & { type: "mov
             onSearchSubtitles={
               item.versions.length > 0 ? () => setSubtitleSearchOpen(true) : undefined
             }
-            rating={item.user_rating ?? null}
-            onRatingChange={handleRatingChange}
             qualityPreference={qualityPreference}
             audioSelectionMode={audioSelectionMode}
             explicitAudioTrackIndex={explicitAudioTrackIndex}

--- a/web/src/pages/ItemDetail/components/ActionBar.test.tsx
+++ b/web/src/pages/ItemDetail/components/ActionBar.test.tsx
@@ -65,6 +65,8 @@ describe("ActionBar", () => {
       watchedLabel: "Mark Watched",
       onToggleWatched: () => {},
       onToggleFavorite: () => {},
+      // The More button only renders when the overflow menu has at least one entry.
+      onToggleWatchlist: () => {},
     });
 
     expect(screen.getByRole("button", { name: "Mark Watched" })).toHaveClass(

--- a/web/src/pages/ItemDetail/components/ActionBar.tsx
+++ b/web/src/pages/ItemDetail/components/ActionBar.tsx
@@ -1,4 +1,15 @@
-import { useCallback, useMemo, useState } from "react";
+import {
+  type ComponentProps,
+  type KeyboardEvent,
+  useCallback,
+  useEffect,
+  useId,
+  useLayoutEffect,
+  useMemo,
+  useRef,
+  useState,
+} from "react";
+import { createPortal } from "react-dom";
 import { useLocation, useNavigate } from "react-router";
 import {
   Heart,
@@ -25,13 +36,6 @@ import {
   DialogHeader,
   DialogTitle,
 } from "@/components/ui/dialog";
-import {
-  DropdownMenu,
-  DropdownMenuContent,
-  DropdownMenuItem,
-  DropdownMenuSeparator,
-  DropdownMenuTrigger,
-} from "@/components/ui/dropdown-menu";
 import type { FileVersion, PlaybackVariant } from "@/api/types";
 import type { RefreshItemMetadataMode } from "@/hooks/queries/items";
 import type {
@@ -56,7 +60,30 @@ const responsivePrimaryActionClass =
 const responsivePlayActionClass = `${responsivePrimaryActionClass} hover:bg-primary motion-reduce:hover:bg-primary/90`;
 const staticGlassActionClass = "transition-none";
 
-interface ActionBarProps {
+function DetailOverflowMenuItem({
+  className,
+  closeMenu,
+  onAction,
+  ...props
+}: Omit<ComponentProps<"button">, "onClick"> & {
+  closeMenu: () => void;
+  onAction?: () => void;
+}) {
+  return (
+    <button
+      {...props}
+      type="button"
+      role="menuitem"
+      className={`focus:bg-accent focus:text-accent-foreground hover:bg-accent hover:text-accent-foreground [&_svg:not([class*='text-'])]:text-muted-foreground relative flex w-full cursor-default items-center gap-2 rounded-sm px-2 py-1.5 text-left text-sm outline-hidden select-none disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4 ${className ?? ""}`}
+      onClick={() => {
+        closeMenu();
+        onAction?.();
+      }}
+    />
+  );
+}
+
+export interface ActionBarProps {
   contentId?: string;
   playHref?: string;
   playLabel?: string;
@@ -167,6 +194,15 @@ export default function ActionBar({
   const location = useLocation();
   const playbackController = useWatchPlaybackController();
   const [playChoiceOpen, setPlayChoiceOpen] = useState(false);
+  const [overflowOpen, setOverflowOpen] = useState(false);
+  const overflowMenuId = useId();
+  const [overflowPosition, setOverflowPosition] = useState<{ left: number; top: number } | null>(
+    null,
+  );
+  const overflowTriggerRef = useRef<HTMLButtonElement>(null);
+  const overflowMenuRef = useRef<HTMLDivElement>(null);
+  const scrollFrameRef = useRef<number | null>(null);
+  const typeaheadRef = useRef<{ query: string; at: number }>({ query: "", at: 0 });
   const [refreshDialogOpen, setRefreshDialogOpen] = useState(false);
   const [addToCollectionOpen, setAddToCollectionOpen] = useState(false);
   const [markerEditorOpen, setMarkerEditorOpen] = useState(false);
@@ -244,6 +280,155 @@ export default function ActionBar({
     setRefreshDialogOpen(false);
     onRefresh?.(mode);
   };
+  const closeOverflowMenu = useCallback(() => setOverflowOpen(false), []);
+  const toggleOverflowMenu = useCallback(() => {
+    setOverflowPosition(null);
+    setOverflowOpen((open) => !open);
+  }, []);
+  const positionOverflowMenu = useCallback(() => {
+    const trigger = overflowTriggerRef.current;
+    const menu = overflowMenuRef.current;
+    if (!trigger || !menu) return;
+
+    const viewportPadding = 8;
+    const gap = 8;
+    const triggerRect = trigger.getBoundingClientRect();
+    const menuRect = menu.getBoundingClientRect();
+    const spaceBelow = window.innerHeight - triggerRect.bottom - viewportPadding;
+    const top =
+      spaceBelow >= menuRect.height + gap
+        ? triggerRect.bottom + gap
+        : Math.max(viewportPadding, triggerRect.top - menuRect.height - gap);
+    const left = Math.min(
+      window.innerWidth - menuRect.width - viewportPadding,
+      Math.max(viewportPadding, triggerRect.right - menuRect.width),
+    );
+    setOverflowPosition({ left, top });
+  }, []);
+
+  useLayoutEffect(() => {
+    if (!overflowOpen) return;
+
+    const triggerElement = overflowTriggerRef.current;
+    positionOverflowMenu();
+    overflowMenuRef.current
+      ?.querySelector<HTMLButtonElement>('[role="menuitem"]:not(:disabled)')
+      ?.focus({ preventScroll: true });
+
+    window.addEventListener("resize", positionOverflowMenu);
+    return () => {
+      window.removeEventListener("resize", positionOverflowMenu);
+      // However the menu closed — Escape, activating an item, an outside click
+      // — focus must come back to the trigger instead of being dropped on
+      // <body> when the portal unmounts.
+      const active = document.activeElement;
+      if (active && active !== document.body) return;
+      triggerElement?.focus({ preventScroll: true });
+    };
+  }, [overflowOpen, positionOverflowMenu]);
+
+  useEffect(() => {
+    if (!overflowOpen) return;
+
+    const handlePointerDown = (event: PointerEvent) => {
+      const target = event.target as Node;
+      if (
+        !overflowMenuRef.current?.contains(target) &&
+        !overflowTriggerRef.current?.contains(target)
+      ) {
+        closeOverflowMenu();
+      }
+    };
+    const handleKeyDown = (event: globalThis.KeyboardEvent) => {
+      if (event.key !== "Escape") return;
+      event.preventDefault();
+      closeOverflowMenu();
+      overflowTriggerRef.current?.focus({ preventScroll: true });
+    };
+    const handleFocusIn = (event: FocusEvent) => {
+      const target = event.target as Node;
+      if (
+        !overflowMenuRef.current?.contains(target) &&
+        !overflowTriggerRef.current?.contains(target)
+      ) {
+        closeOverflowMenu();
+      }
+    };
+    // Stay anchored to the trigger while the page scrolls rather than
+    // dismissing on every wheel nudge. One measurement per frame at most.
+    const handleScroll = (event: Event) => {
+      const target = event.target;
+      if (target instanceof Node && overflowMenuRef.current?.contains(target)) return;
+      if (scrollFrameRef.current !== null) return;
+      scrollFrameRef.current = requestAnimationFrame(() => {
+        scrollFrameRef.current = null;
+        positionOverflowMenu();
+      });
+    };
+
+    document.addEventListener("pointerdown", handlePointerDown, true);
+    document.addEventListener("keydown", handleKeyDown);
+    document.addEventListener("focusin", handleFocusIn);
+    window.addEventListener("scroll", handleScroll, true);
+    return () => {
+      document.removeEventListener("pointerdown", handlePointerDown, true);
+      document.removeEventListener("keydown", handleKeyDown);
+      document.removeEventListener("focusin", handleFocusIn);
+      window.removeEventListener("scroll", handleScroll, true);
+      if (scrollFrameRef.current !== null) {
+        cancelAnimationFrame(scrollFrameRef.current);
+        scrollFrameRef.current = null;
+      }
+    };
+  }, [closeOverflowMenu, overflowOpen, positionOverflowMenu]);
+  const handleOverflowKeyDown = (event: KeyboardEvent<HTMLDivElement>) => {
+    const isNavigationKey = ["ArrowDown", "ArrowUp", "Home", "End"].includes(event.key);
+    // Printable single characters jump to the next item whose label starts with
+    // what has been typed, the way the menu behaved before.
+    const isTypeahead =
+      !isNavigationKey &&
+      event.key.length === 1 &&
+      !event.ctrlKey &&
+      !event.metaKey &&
+      !event.altKey &&
+      event.key !== " ";
+    if (!isNavigationKey && !isTypeahead) return;
+
+    const items = Array.from(
+      event.currentTarget.querySelectorAll<HTMLButtonElement>('[role="menuitem"]:not(:disabled)'),
+    );
+    if (items.length === 0) return;
+
+    event.preventDefault();
+    const currentIndex = items.indexOf(document.activeElement as HTMLButtonElement);
+
+    if (isTypeahead) {
+      const now = Date.now();
+      const typeahead = typeaheadRef.current;
+      typeahead.query = now - typeahead.at > 1000 ? event.key : typeahead.query + event.key;
+      typeahead.at = now;
+      const query = typeahead.query.toLowerCase();
+      // A repeated single character cycles through the items starting with it.
+      const startIndex = query.length === 1 ? currentIndex + 1 : Math.max(currentIndex, 0);
+      const match = items
+        .map((_, offset) => items[(startIndex + offset) % items.length])
+        .find((item) => (item?.textContent ?? "").trim().toLowerCase().startsWith(query));
+      match?.focus({ preventScroll: true });
+      return;
+    }
+
+    let nextIndex: number;
+    if (event.key === "Home") {
+      nextIndex = 0;
+    } else if (event.key === "End") {
+      nextIndex = items.length - 1;
+    } else if (event.key === "ArrowUp") {
+      nextIndex = currentIndex <= 0 ? items.length - 1 : currentIndex - 1;
+    } else {
+      nextIndex = currentIndex < 0 || currentIndex === items.length - 1 ? 0 : currentIndex + 1;
+    }
+    items[nextIndex]?.focus({ preventScroll: true });
+  };
   const hasOverflowActions = Boolean(
     restartHref || onToggleWatchlist || onDownload || onSearchSubtitles,
   );
@@ -280,12 +465,12 @@ export default function ActionBar({
     [buildPrePlayStartInput, contentId, currentHref, playbackController, selectedVersion],
   );
 
-  const hasStreamControls =
-    selectedVersion &&
-    ((versions && hasMultipleVersions) || (selectedVersion.audio_tracks?.length ?? 0) > 0 || true); // subs popover always shows when version is selected
+  // The subtitle control is available even when the selected file has no
+  // embedded tracks because downloaded subtitles are loaded on demand.
+  const hasStreamControls = Boolean(selectedVersion);
 
   return (
-    <div className="space-y-2.5">
+    <div className="detail-action-bar space-y-2.5">
       {/* ── Primary actions ──────────────────────────────────── */}
       <div className="flex flex-wrap items-center gap-3">
         {/* ── Play button ────────────────────────────────────── */}
@@ -338,7 +523,7 @@ export default function ActionBar({
             variant="glass"
             onClick={onToggleWatched}
             disabled={isUpdatingWatched}
-            className={`${responsivePrimaryActionClass} h-11 rounded-full px-5 text-[14px] font-semibold enabled:cursor-pointer`}
+            className={`${responsivePrimaryActionClass} h-11 min-w-[161px] rounded-full px-5 text-[14px] font-semibold enabled:cursor-pointer`}
           >
             <Check className="size-[18px]" />
             {watchedLabel}
@@ -352,6 +537,7 @@ export default function ActionBar({
             size="icon-lg"
             onClick={onToggleFavorite}
             title={isFavorite ? "Unfavorite" : "Favorite"}
+            aria-label={isFavorite ? "Remove from favorites" : "Add to favorites"}
             className={`${staticGlassActionClass} size-11 cursor-pointer rounded-full`}
           >
             <Heart
@@ -364,116 +550,149 @@ export default function ActionBar({
           <StarRating value={rating ?? null} onChange={onRatingChange} size={18} />
         )}
 
-        <DropdownMenu modal={false}>
-          <DropdownMenuTrigger asChild>
-            <Button
-              variant="glass"
-              size="icon-lg"
-              title="More"
-              className={`${staticGlassActionClass} size-11 cursor-pointer rounded-full`}
+        <Button
+          ref={overflowTriggerRef}
+          variant="glass"
+          size="icon-lg"
+          title="More"
+          aria-label="More actions"
+          aria-haspopup="menu"
+          aria-expanded={overflowOpen}
+          aria-controls={overflowOpen ? overflowMenuId : undefined}
+          className={`${staticGlassActionClass} size-11 cursor-pointer rounded-full`}
+          onClick={toggleOverflowMenu}
+        >
+          <MoreVertical className="size-[18px]" />
+        </Button>
+        {overflowOpen &&
+          createPortal(
+            <div
+              id={overflowMenuId}
+              ref={overflowMenuRef}
+              style={{
+                left: overflowPosition?.left ?? 0,
+                top: overflowPosition?.top ?? 0,
+                visibility: overflowPosition ? "visible" : "hidden",
+              }}
+              className="detail-overflow-menu border-border bg-popover text-popover-foreground fixed z-50 max-h-[calc(100vh-1rem)] w-56 max-w-[calc(100vw-1rem)] overflow-y-auto rounded-md border p-1 shadow-md"
+              role="menu"
+              onKeyDown={handleOverflowKeyDown}
             >
-              <MoreVertical className="size-[18px]" />
-            </Button>
-          </DropdownMenuTrigger>
-          <DropdownMenuContent align="end" className="w-max max-w-[calc(100vw-2rem)] min-w-0">
-            {restartHref && (
-              <DropdownMenuItem
-                onSelect={() => {
-                  handleRestartPlayback();
-                }}
-              >
-                <RotateCcw className="size-4" />
-                Play from Beginning
-              </DropdownMenuItem>
-            )}
-            {onToggleWatchlist && (
-              <DropdownMenuItem onSelect={onToggleWatchlist}>
-                {inWatchlist ? <Check className="size-4" /> : <Plus className="size-4" />}
-                {inWatchlist ? "Remove from Watchlist" : "Add to Watchlist"}
-              </DropdownMenuItem>
-            )}
-            {contentId && (
-              <DropdownMenuItem onSelect={() => setAddToCollectionOpen(true)}>
-                <FolderPlus className="size-4" />
-                Add to Collection
-              </DropdownMenuItem>
-            )}
-            {onDownload && (
-              <DropdownMenuItem onSelect={onDownload}>
-                <Download className="size-4" />
-                Download
-              </DropdownMenuItem>
-            )}
-            {onSearchSubtitles && (
-              <DropdownMenuItem onSelect={onSearchSubtitles}>
-                <Captions className="size-4" />
-                Search Subtitles
-              </DropdownMenuItem>
-            )}
-            {(hasAdminActions || hasMetadataActions) && (
-              <>
-                {hasOverflowActions && <DropdownMenuSeparator />}
-                {canCurateMetadata && onShowMediaInfo && (
-                  <DropdownMenuItem onSelect={onShowMediaInfo}>
-                    <Info className="size-4" />
-                    Media Info
-                  </DropdownMenuItem>
-                )}
-                {isAdmin && contentId && (
-                  <DropdownMenuItem
-                    onSelect={() =>
-                      navigate(`/admin/history?media_item_id=${encodeURIComponent(contentId)}`)
-                    }
-                  >
-                    <MediaActionIcon action="viewPlayHistory" />
-                    View Play History
-                  </DropdownMenuItem>
-                )}
-                {canCurateMetadata && onRefresh && (
-                  <DropdownMenuItem
-                    disabled={isRefreshing}
-                    onSelect={() => {
-                      setRefreshDialogOpen(true);
-                    }}
-                  >
-                    <MediaActionIcon action="refreshMetadata" isPending={isRefreshing} />
-                    Refresh Metadata
-                  </DropdownMenuItem>
-                )}
-                {isAdmin && onRedetectIntro && (
-                  <DropdownMenuItem disabled={isRedetectingIntro} onSelect={onRedetectIntro}>
-                    <RefreshCw className={`size-4 ${isRedetectingIntro ? "animate-spin" : ""}`} />
-                    Re-detect Intro Markers
-                  </DropdownMenuItem>
-                )}
-                {canCurateMetadata && onEditMetadata && (
-                  <DropdownMenuItem onSelect={onEditMetadata}>
-                    <MediaActionIcon action="editMetadata" />
-                    Edit Metadata
-                  </DropdownMenuItem>
-                )}
-                {showMarkerEditor && (
-                  <DropdownMenuItem onSelect={() => setMarkerEditorOpen(true)}>
-                    <Tags className="size-4" />
-                    Edit Markers
-                  </DropdownMenuItem>
-                )}
-                {canCurateMetadata && onMatchItem && (
-                  <DropdownMenuItem onSelect={onMatchItem}>
-                    <MediaActionIcon action="matchItem" />
-                    Match Item
-                  </DropdownMenuItem>
-                )}
-                {canCurateMetadata && onSplitItem && (
-                  <DropdownMenuItem onSelect={onSplitItem}>
-                    <Scissors className="size-4" />
-                    Split Versions
-                  </DropdownMenuItem>
-                )}
-              </>
-            )}
-          </DropdownMenuContent>
-        </DropdownMenu>
+              {restartHref && (
+                <DetailOverflowMenuItem
+                  closeMenu={closeOverflowMenu}
+                  onAction={handleRestartPlayback}
+                >
+                  <RotateCcw className="size-4" />
+                  Play from Beginning
+                </DetailOverflowMenuItem>
+              )}
+              {onToggleWatchlist && (
+                <DetailOverflowMenuItem closeMenu={closeOverflowMenu} onAction={onToggleWatchlist}>
+                  {inWatchlist ? <Check className="size-4" /> : <Plus className="size-4" />}
+                  {inWatchlist ? "Remove from Watchlist" : "Add to Watchlist"}
+                </DetailOverflowMenuItem>
+              )}
+              {contentId && (
+                <DetailOverflowMenuItem
+                  closeMenu={closeOverflowMenu}
+                  onAction={() => setAddToCollectionOpen(true)}
+                >
+                  <FolderPlus className="size-4" />
+                  Add to Collection
+                </DetailOverflowMenuItem>
+              )}
+              {onDownload && (
+                <DetailOverflowMenuItem closeMenu={closeOverflowMenu} onAction={onDownload}>
+                  <Download className="size-4" />
+                  Download
+                </DetailOverflowMenuItem>
+              )}
+              {onSearchSubtitles && (
+                <DetailOverflowMenuItem closeMenu={closeOverflowMenu} onAction={onSearchSubtitles}>
+                  <Captions className="size-4" />
+                  Search Subtitles
+                </DetailOverflowMenuItem>
+              )}
+              {(hasAdminActions || hasMetadataActions) && (
+                <>
+                  {hasOverflowActions && (
+                    <div role="separator" className="bg-border -mx-1 my-1 h-px" />
+                  )}
+                  {canCurateMetadata && onShowMediaInfo && (
+                    <DetailOverflowMenuItem
+                      closeMenu={closeOverflowMenu}
+                      onAction={onShowMediaInfo}
+                    >
+                      <Info className="size-4" />
+                      Media Info
+                    </DetailOverflowMenuItem>
+                  )}
+                  {isAdmin && contentId && (
+                    <DetailOverflowMenuItem
+                      closeMenu={closeOverflowMenu}
+                      onAction={() =>
+                        navigate(`/admin/history?media_item_id=${encodeURIComponent(contentId)}`)
+                      }
+                    >
+                      <MediaActionIcon action="viewPlayHistory" />
+                      View Play History
+                    </DetailOverflowMenuItem>
+                  )}
+                  {canCurateMetadata && onRefresh && (
+                    <DetailOverflowMenuItem
+                      closeMenu={closeOverflowMenu}
+                      disabled={isRefreshing}
+                      onAction={() => {
+                        setRefreshDialogOpen(true);
+                      }}
+                    >
+                      <MediaActionIcon action="refreshMetadata" isPending={isRefreshing} />
+                      Refresh Metadata
+                    </DetailOverflowMenuItem>
+                  )}
+                  {isAdmin && onRedetectIntro && (
+                    <DetailOverflowMenuItem
+                      closeMenu={closeOverflowMenu}
+                      disabled={isRedetectingIntro}
+                      onAction={onRedetectIntro}
+                    >
+                      <RefreshCw className={`size-4 ${isRedetectingIntro ? "animate-spin" : ""}`} />
+                      Re-detect Intro Markers
+                    </DetailOverflowMenuItem>
+                  )}
+                  {canCurateMetadata && onEditMetadata && (
+                    <DetailOverflowMenuItem closeMenu={closeOverflowMenu} onAction={onEditMetadata}>
+                      <MediaActionIcon action="editMetadata" />
+                      Edit Metadata
+                    </DetailOverflowMenuItem>
+                  )}
+                  {showMarkerEditor && (
+                    <DetailOverflowMenuItem
+                      closeMenu={closeOverflowMenu}
+                      onAction={() => setMarkerEditorOpen(true)}
+                    >
+                      <Tags className="size-4" />
+                      Edit Markers
+                    </DetailOverflowMenuItem>
+                  )}
+                  {canCurateMetadata && onMatchItem && (
+                    <DetailOverflowMenuItem closeMenu={closeOverflowMenu} onAction={onMatchItem}>
+                      <MediaActionIcon action="matchItem" />
+                      Match Item
+                    </DetailOverflowMenuItem>
+                  )}
+                  {canCurateMetadata && onSplitItem && (
+                    <DetailOverflowMenuItem closeMenu={closeOverflowMenu} onAction={onSplitItem}>
+                      <Scissors className="size-4" />
+                      Split Versions
+                    </DetailOverflowMenuItem>
+                  )}
+                </>
+              )}
+            </div>,
+            document.body,
+          )}
         {showPlayChoiceDialog && (
           <Dialog open={playChoiceOpen} onOpenChange={setPlayChoiceOpen}>
             <DialogContent className="max-w-xs gap-3 p-5">

--- a/web/src/pages/ItemDetail/components/ActionBar.tsx
+++ b/web/src/pages/ItemDetail/components/ActionBar.tsx
@@ -579,7 +579,7 @@ export default function ActionBar({
                 top: overflowPosition?.top ?? 0,
                 visibility: overflowPosition ? "visible" : "hidden",
               }}
-              className="detail-overflow-menu border-border bg-popover text-popover-foreground fixed z-50 max-h-[calc(100vh-1rem)] w-56 max-w-[calc(100vw-1rem)] overflow-y-auto rounded-md border p-1 shadow-md"
+              className="detail-overflow-menu border-border bg-popover text-popover-foreground fixed z-50 max-h-[calc(100vh-1rem)] w-max max-w-[calc(100vw-2rem)] min-w-0 overflow-y-auto rounded-md border p-1 shadow-md"
               role="menu"
               onKeyDown={handleOverflowKeyDown}
             >

--- a/web/src/pages/ItemDetail/components/ActionBar.tsx
+++ b/web/src/pages/ItemDetail/components/ActionBar.tsx
@@ -437,6 +437,8 @@ export default function ActionBar({
     (canCurateMetadata && (onRefresh || onEditMetadata || onMatchItem || onShowMediaInfo)) ||
     showMarkerEditor,
   );
+  const hasOverflowMenuItems =
+    hasOverflowActions || hasAdminActions || hasMetadataActions || Boolean(contentId);
 
   const formattedResumeTime = formatPlaybackTime(resumePositionSeconds ?? 0);
   const percentComplete =
@@ -550,21 +552,24 @@ export default function ActionBar({
           <StarRating value={rating ?? null} onChange={onRatingChange} size={18} />
         )}
 
-        <Button
-          ref={overflowTriggerRef}
-          variant="glass"
-          size="icon-lg"
-          title="More"
-          aria-label="More actions"
-          aria-haspopup="menu"
-          aria-expanded={overflowOpen}
-          aria-controls={overflowOpen ? overflowMenuId : undefined}
-          className={`${staticGlassActionClass} size-11 cursor-pointer rounded-full`}
-          onClick={toggleOverflowMenu}
-        >
-          <MoreVertical className="size-[18px]" />
-        </Button>
-        {overflowOpen &&
+        {hasOverflowMenuItems && (
+          <Button
+            ref={overflowTriggerRef}
+            variant="glass"
+            size="icon-lg"
+            title="More"
+            aria-label="More actions"
+            aria-haspopup="menu"
+            aria-expanded={overflowOpen}
+            aria-controls={overflowOpen ? overflowMenuId : undefined}
+            className={`${staticGlassActionClass} size-11 cursor-pointer rounded-full`}
+            onClick={toggleOverflowMenu}
+          >
+            <MoreVertical className="size-[18px]" />
+          </Button>
+        )}
+        {hasOverflowMenuItems &&
+          overflowOpen &&
           createPortal(
             <div
               id={overflowMenuId}

--- a/web/src/pages/ItemDetail/components/AudioTracksPopover.tsx
+++ b/web/src/pages/ItemDetail/components/AudioTracksPopover.tsx
@@ -1,14 +1,14 @@
 import { Check, ChevronDown, Volume2 } from "lucide-react";
-import type { ReactNode } from "react";
+import { memo, type ReactNode } from "react";
 
 import type { FileVersion } from "@/api/types";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
-import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover";
 import { getLanguageName } from "@/player/utils/languageNames";
 import { formatChannels, mapAudioLabel } from "@/lib/mediaFormat";
 import { audioTitle, compactAudioMeta } from "./versionFormatUtils";
 import { formatAudioTrackSummary, resolveAudioTrackSelection } from "./prePlaySelection";
+import DetailPopover from "./DetailPopover";
 
 interface AudioTracksPopoverProps {
   version: FileVersion | null;
@@ -69,7 +69,7 @@ function AudioOptionRow({
   );
 }
 
-export default function AudioTracksPopover({
+function AudioTracksPopover({
   version,
   selectionMode = "auto",
   explicitTrackIndex = null,
@@ -89,8 +89,9 @@ export default function AudioTracksPopover({
   const autoSummary = formatAudioTrackSummary(autoTrack);
 
   return (
-    <Popover>
-      <PopoverTrigger asChild>
+    <DetailPopover
+      contentClassName="w-80 p-1.5"
+      trigger={
         <Button
           variant="glass"
           className="h-8 max-w-full min-w-0 shrink gap-1.5 rounded-full px-3 text-xs font-medium"
@@ -106,66 +107,67 @@ export default function AudioTracksPopover({
           </span>
           <ChevronDown className="text-muted-foreground size-3" />
         </Button>
-      </PopoverTrigger>
-      <PopoverContent className="w-80 p-1.5">
-        <div className="space-y-0.5">
-          {isInteractive && (
-            <AudioOptionRow
-              active={selectionMode === "auto"}
-              title="Auto"
-              description={autoSummary}
-              onSelect={onResetSelection}
-            />
-          )}
-          {tracks.map((track, index) => {
-            const codec = track.codec ? mapAudioLabel(track.codec) : "";
-            const channels = formatChannels(track.channels);
-            const language = getLanguageName(track.language ?? "");
-            const fallbackTitle = audioTitle(track);
-            const title = language || fallbackTitle;
-            const embeddedTitle = track.title?.trim() || track.embedded_title?.trim() || "";
-            const meta = [
-              embeddedTitle && embeddedTitle !== title ? embeddedTitle : "",
-              compactAudioMeta(track),
-            ]
-              .filter(Boolean)
-              .join(" \u00B7 ");
+      }
+    >
+      <div className="space-y-0.5">
+        {isInteractive && (
+          <AudioOptionRow
+            active={selectionMode === "auto"}
+            title="Auto"
+            description={autoSummary}
+            onSelect={onResetSelection}
+          />
+        )}
+        {tracks.map((track, index) => {
+          const codec = track.codec ? mapAudioLabel(track.codec) : "";
+          const channels = formatChannels(track.channels);
+          const language = getLanguageName(track.language ?? "");
+          const fallbackTitle = audioTitle(track);
+          const title = language || fallbackTitle;
+          const embeddedTitle = track.title?.trim() || track.embedded_title?.trim() || "";
+          const meta = [
+            embeddedTitle && embeddedTitle !== title ? embeddedTitle : "",
+            compactAudioMeta(track),
+          ]
+            .filter(Boolean)
+            .join(" \u00B7 ");
 
-            return (
-              <AudioOptionRow
-                key={`${track.language}-${track.codec}-${index}`}
-                active={
-                  isInteractive
-                    ? selectionMode === "explicit" && explicitTrackIndex === index
-                    : Boolean(track.default)
-                }
-                title={title}
-                description={meta}
-                onSelect={onSelectTrack ? () => onSelectTrack(index) : undefined}
-                badges={
-                  <>
-                    {codec && (
-                      <Badge variant="secondary" className="px-1.5 py-0 text-[10px] uppercase">
-                        {codec}
-                      </Badge>
-                    )}
-                    {channels && (
-                      <Badge variant="secondary" className="px-1.5 py-0 text-[10px]">
-                        {channels}
-                      </Badge>
-                    )}
-                    {track.default && (
-                      <Badge variant="outline" className="px-1.5 py-0 text-[10px] uppercase">
-                        Default
-                      </Badge>
-                    )}
-                  </>
-                }
-              />
-            );
-          })}
-        </div>
-      </PopoverContent>
-    </Popover>
+          return (
+            <AudioOptionRow
+              key={`${track.language}-${track.codec}-${index}`}
+              active={
+                isInteractive
+                  ? selectionMode === "explicit" && explicitTrackIndex === index
+                  : Boolean(track.default)
+              }
+              title={title}
+              description={meta}
+              onSelect={onSelectTrack ? () => onSelectTrack(index) : undefined}
+              badges={
+                <>
+                  {codec && (
+                    <Badge variant="secondary" className="px-1.5 py-0 text-[10px] uppercase">
+                      {codec}
+                    </Badge>
+                  )}
+                  {channels && (
+                    <Badge variant="secondary" className="px-1.5 py-0 text-[10px]">
+                      {channels}
+                    </Badge>
+                  )}
+                  {track.default && (
+                    <Badge variant="outline" className="px-1.5 py-0 text-[10px] uppercase">
+                      Default
+                    </Badge>
+                  )}
+                </>
+              }
+            />
+          );
+        })}
+      </div>
+    </DetailPopover>
   );
 }
+
+export default memo(AudioTracksPopover);

--- a/web/src/pages/ItemDetail/components/DetailPopover.test.tsx
+++ b/web/src/pages/ItemDetail/components/DetailPopover.test.tsx
@@ -87,7 +87,7 @@ describe("DetailPopover", () => {
     fireEvent.keyDown(document, { key: "Escape" });
 
     expect(onOpenChange).toHaveBeenCalledWith(false);
-    expect(document.querySelector('[role="dialog"]')).toBeInTheDocument();
+    expect(screen.getByRole("dialog", { name: "Audio", hidden: true })).toBeVisible();
   });
 
   it("closes when focus moves outside", () => {

--- a/web/src/pages/ItemDetail/components/DetailPopover.test.tsx
+++ b/web/src/pages/ItemDetail/components/DetailPopover.test.tsx
@@ -1,0 +1,83 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+
+import DetailPopover, { DETAIL_POPOVER_CLOSE_ATTR } from "./DetailPopover";
+
+function renderPopover(onSelect = vi.fn()) {
+  render(
+    <>
+      <DetailPopover trigger={<button type="button">Audio</button>}>
+        <button type="button" onClick={onSelect}>
+          English
+        </button>
+        <button type="button">French</button>
+        <button type="button" {...{ [DETAIL_POPOVER_CLOSE_ATTR]: "" }}>
+          Done
+        </button>
+      </DetailPopover>
+      <button type="button">Outside</button>
+    </>,
+  );
+}
+
+describe("DetailPopover", () => {
+  it("links the trigger to a named dialog and moves focus into it", () => {
+    renderPopover();
+    const trigger = screen.getByRole("button", { name: "Audio" });
+
+    fireEvent.click(trigger);
+
+    const dialog = screen.getByRole("dialog", { name: "Audio" });
+    expect(trigger).toHaveAttribute("aria-expanded", "true");
+    expect(trigger).toHaveAttribute("aria-controls", dialog.id);
+    expect(screen.getByRole("button", { name: "English" })).toHaveFocus();
+  });
+
+  it("stays open through a selection and through page scroll", () => {
+    const onSelect = vi.fn();
+    renderPopover(onSelect);
+    const trigger = screen.getByRole("button", { name: "Audio" });
+
+    fireEvent.click(trigger);
+    fireEvent.click(screen.getByRole("button", { name: "English" }));
+    expect(onSelect).toHaveBeenCalledOnce();
+    expect(screen.getByRole("dialog")).toBeInTheDocument();
+
+    fireEvent.scroll(screen.getByRole("dialog"));
+    expect(screen.getByRole("dialog")).toBeInTheDocument();
+
+    fireEvent.scroll(window);
+    expect(screen.getByRole("dialog")).toBeInTheDocument();
+  });
+
+  it("closes for a control that opts in, and restores trigger focus", () => {
+    renderPopover();
+    const trigger = screen.getByRole("button", { name: "Audio" });
+
+    fireEvent.click(trigger);
+    fireEvent.click(screen.getByRole("button", { name: "Done" }));
+
+    expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
+    expect(trigger).toHaveFocus();
+  });
+
+  it("closes on Escape and restores trigger focus", () => {
+    renderPopover();
+    const trigger = screen.getByRole("button", { name: "Audio" });
+    fireEvent.click(trigger);
+
+    fireEvent.keyDown(document, { key: "Escape" });
+
+    expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
+    expect(trigger).toHaveFocus();
+  });
+
+  it("closes when focus moves outside", () => {
+    renderPopover();
+    fireEvent.click(screen.getByRole("button", { name: "Audio" }));
+
+    fireEvent.focusIn(screen.getByRole("button", { name: "Outside" }));
+
+    expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
+  });
+});

--- a/web/src/pages/ItemDetail/components/DetailPopover.test.tsx
+++ b/web/src/pages/ItemDetail/components/DetailPopover.test.tsx
@@ -72,6 +72,24 @@ describe("DetailPopover", () => {
     expect(trigger).toHaveFocus();
   });
 
+  it("requests closure on Escape without mutating controlled open state", () => {
+    const onOpenChange = vi.fn();
+    render(
+      <DetailPopover
+        trigger={<button type="button">Audio</button>}
+        open
+        onOpenChange={onOpenChange}
+      >
+        <button type="button">English</button>
+      </DetailPopover>,
+    );
+
+    fireEvent.keyDown(document, { key: "Escape" });
+
+    expect(onOpenChange).toHaveBeenCalledWith(false);
+    expect(document.querySelector('[role="dialog"]')).toBeInTheDocument();
+  });
+
   it("closes when focus moves outside", () => {
     renderPopover();
     fireEvent.click(screen.getByRole("button", { name: "Audio" }));

--- a/web/src/pages/ItemDetail/components/DetailPopover.tsx
+++ b/web/src/pages/ItemDetail/components/DetailPopover.tsx
@@ -51,11 +51,11 @@ export default function DetailPopover({
     (nextOpen: boolean) => {
       if (controlledOpen === undefined) {
         setUncontrolledOpen(nextOpen);
+        if (!nextOpen) {
+          setPosition(null);
+        }
       }
       onOpenChange?.(nextOpen);
-      if (!nextOpen) {
-        setPosition(null);
-      }
     },
     [controlledOpen, onOpenChange],
   );

--- a/web/src/pages/ItemDetail/components/DetailPopover.tsx
+++ b/web/src/pages/ItemDetail/components/DetailPopover.tsx
@@ -1,0 +1,206 @@
+import {
+  cloneElement,
+  type ComponentProps,
+  type ReactElement,
+  type ReactNode,
+  useCallback,
+  useEffect,
+  useLayoutEffect,
+  useId,
+  useRef,
+  useState,
+} from "react";
+import { createPortal } from "react-dom";
+
+import { cn } from "@/lib/utils";
+
+// Marks a control that dismisses the popover when activated. Opt-in per
+// control: a bare `closest("button")` rule would also dismiss on clicks that
+// are not a selection, and would silently swallow any future control placed
+// inside a popover.
+export const DETAIL_POPOVER_CLOSE_ATTR = "data-detail-popover-close";
+
+interface DetailPopoverProps {
+  trigger: ReactElement<ComponentProps<"button">>;
+  children: ReactNode;
+  contentClassName?: string;
+  open?: boolean;
+  onOpenChange?: (open: boolean) => void;
+  positionKey?: string | number | boolean;
+}
+
+export default function DetailPopover({
+  trigger,
+  children,
+  contentClassName,
+  open: controlledOpen,
+  onOpenChange,
+  positionKey,
+}: DetailPopoverProps) {
+  const [uncontrolledOpen, setUncontrolledOpen] = useState(false);
+  const [position, setPosition] = useState<{ left: number; top: number } | null>(null);
+  const generatedId = useId();
+  const triggerId = trigger.props.id ?? `${generatedId}-trigger`;
+  const contentId = `${generatedId}-content`;
+  const triggerRef = useRef<HTMLSpanElement>(null);
+  const contentRef = useRef<HTMLDivElement>(null);
+  const scrollFrameRef = useRef<number | null>(null);
+  const open = controlledOpen ?? uncontrolledOpen;
+
+  const setOpen = useCallback(
+    (nextOpen: boolean) => {
+      if (controlledOpen === undefined) {
+        setUncontrolledOpen(nextOpen);
+      }
+      onOpenChange?.(nextOpen);
+      if (!nextOpen) {
+        setPosition(null);
+      }
+    },
+    [controlledOpen, onOpenChange],
+  );
+
+  const positionContent = useCallback(() => {
+    const triggerElement = triggerRef.current;
+    const content = contentRef.current;
+    if (!triggerElement || !content) return;
+
+    const viewportPadding = 8;
+    const gap = 8;
+    const triggerRect = triggerElement.getBoundingClientRect();
+    const contentRect = content.getBoundingClientRect();
+    const spaceBelow = window.innerHeight - triggerRect.bottom - viewportPadding;
+    const top =
+      spaceBelow >= contentRect.height + gap
+        ? triggerRect.bottom + gap
+        : Math.max(viewportPadding, triggerRect.top - contentRect.height - gap);
+    const left = Math.min(
+      window.innerWidth - contentRect.width - viewportPadding,
+      Math.max(viewportPadding, triggerRect.left),
+    );
+    setPosition({ left, top });
+  }, []);
+
+  useLayoutEffect(() => {
+    if (!open) return;
+
+    positionContent();
+
+    window.addEventListener("resize", positionContent);
+    return () => window.removeEventListener("resize", positionContent);
+  }, [open, positionContent, positionKey]);
+
+  useLayoutEffect(() => {
+    if (!open) return;
+    const triggerElement = triggerRef.current;
+    contentRef.current?.querySelector<HTMLElement>("button:not(:disabled)")?.focus({
+      preventScroll: true,
+    });
+
+    // However the popover closes — Escape, activating an entry, the owner
+    // flipping `open` — focus must come back to the trigger. Unmounting the
+    // portal otherwise drops it on <body> and a keyboard user restarts from the
+    // top of the page.
+    return () => {
+      const active = document.activeElement;
+      if (active && active !== document.body) return;
+      triggerElement?.querySelector<HTMLElement>("button")?.focus({ preventScroll: true });
+    };
+  }, [open]);
+
+  useEffect(() => {
+    if (!open) return;
+
+    const close = () => setOpen(false);
+    const handlePointerDown = (event: PointerEvent) => {
+      const target = event.target as Node;
+      if (!contentRef.current?.contains(target) && !triggerRef.current?.contains(target)) {
+        close();
+      }
+    };
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (event.key !== "Escape") return;
+      event.preventDefault();
+      close();
+    };
+    const handleFocusIn = (event: FocusEvent) => {
+      const target = event.target as Node;
+      if (!contentRef.current?.contains(target) && !triggerRef.current?.contains(target)) {
+        close();
+      }
+    };
+    // Stay anchored to the trigger while the page scrolls rather than
+    // dismissing on every wheel nudge. One measurement per frame at most.
+    const handleScroll = (event: Event) => {
+      const target = event.target;
+      if (target instanceof Node && contentRef.current?.contains(target)) return;
+      if (scrollFrameRef.current !== null) return;
+      scrollFrameRef.current = requestAnimationFrame(() => {
+        scrollFrameRef.current = null;
+        positionContent();
+      });
+    };
+
+    document.addEventListener("pointerdown", handlePointerDown, true);
+    document.addEventListener("keydown", handleKeyDown);
+    document.addEventListener("focusin", handleFocusIn);
+    window.addEventListener("scroll", handleScroll, true);
+    return () => {
+      document.removeEventListener("pointerdown", handlePointerDown, true);
+      document.removeEventListener("keydown", handleKeyDown);
+      document.removeEventListener("focusin", handleFocusIn);
+      window.removeEventListener("scroll", handleScroll, true);
+      if (scrollFrameRef.current !== null) {
+        cancelAnimationFrame(scrollFrameRef.current);
+        scrollFrameRef.current = null;
+      }
+    };
+  }, [open, positionContent, setOpen]);
+
+  const triggerWithState = cloneElement(trigger, {
+    id: triggerId,
+    "aria-controls": open ? contentId : undefined,
+    "aria-expanded": open,
+    "aria-haspopup": "dialog",
+    onClick: (event) => {
+      trigger.props.onClick?.(event);
+      if (!event.defaultPrevented) {
+        setOpen(!open);
+      }
+    },
+  });
+
+  return (
+    <>
+      <span ref={triggerRef} className="inline-flex max-w-full min-w-0 shrink">
+        {triggerWithState}
+      </span>
+      {open &&
+        createPortal(
+          <div
+            id={contentId}
+            ref={contentRef}
+            role="dialog"
+            aria-labelledby={triggerId}
+            style={{
+              left: position?.left ?? 0,
+              top: position?.top ?? 0,
+              visibility: position ? "visible" : "hidden",
+            }}
+            className={cn(
+              "border-border bg-popover text-popover-foreground fixed z-50 max-h-[calc(100vh-1rem)] max-w-[calc(100vw-1rem)] min-w-48 overflow-y-auto rounded-xl border p-0 shadow-md",
+              contentClassName,
+            )}
+            onClick={(event) => {
+              if ((event.target as Element).closest(`[${DETAIL_POPOVER_CLOSE_ATTR}]`)) {
+                setOpen(false);
+              }
+            }}
+          >
+            {children}
+          </div>,
+          document.body,
+        )}
+    </>
+  );
+}

--- a/web/src/pages/ItemDetail/components/MediaUserActionBar.tsx
+++ b/web/src/pages/ItemDetail/components/MediaUserActionBar.tsx
@@ -1,0 +1,76 @@
+import { useCallback } from "react";
+import type { ItemDetail } from "@/api/types";
+import { useToggleFavorite } from "@/hooks/queries/favorites";
+import { useWatchedStateMutation } from "@/hooks/queries/items";
+import { useDeleteRating, useSetRating } from "@/hooks/queries/ratings";
+import { useToggleWatchlist } from "@/hooks/queries/watchlist";
+import { getWatchedActionLabel } from "../watchedState";
+import ActionBar, { type ActionBarProps } from "./ActionBar";
+
+type UserActionProps =
+  | "watchedLabel"
+  | "onToggleWatched"
+  | "isUpdatingWatched"
+  | "onToggleFavorite"
+  | "isFavorite"
+  | "onToggleWatchlist"
+  | "inWatchlist"
+  | "rating"
+  | "onRatingChange";
+
+interface MediaUserActionBarProps extends Omit<ActionBarProps, UserActionProps> {
+  item: ItemDetail;
+}
+
+/**
+ * Owns the frequently changing mutation state for the detail-page user actions.
+ * Keeping these hooks below the page content boundary prevents a mutation's
+ * pending/settled notifications from re-rendering the hero and below-fold page.
+ */
+export default function MediaUserActionBar({ item, ...props }: MediaUserActionBarProps) {
+  const isFavorite = item.user_state?.is_favorite ?? false;
+  const inWatchlist = item.user_state?.in_watchlist ?? false;
+  const watchedMutation = useWatchedStateMutation(item);
+  const toggleFavoriteMutation = useToggleFavorite(item.content_id);
+  const toggleWatchlistMutation = useToggleWatchlist(item.content_id);
+  const { mutate: setRating } = useSetRating(item.content_id);
+  const { mutate: deleteRating } = useDeleteRating(item.content_id);
+
+  const handleToggleWatched = useCallback(
+    () => watchedMutation.mutate(!(item.user_data?.played ?? false)),
+    [item.user_data?.played, watchedMutation],
+  );
+  const handleToggleFavorite = useCallback(
+    () => toggleFavoriteMutation.mutate(isFavorite),
+    [isFavorite, toggleFavoriteMutation],
+  );
+  const handleToggleWatchlist = useCallback(
+    () => toggleWatchlistMutation.mutate(inWatchlist),
+    [inWatchlist, toggleWatchlistMutation],
+  );
+  const handleRatingChange = useCallback(
+    (rating: number | null) => {
+      if (rating === null) {
+        deleteRating();
+      } else {
+        setRating(rating);
+      }
+    },
+    [deleteRating, setRating],
+  );
+
+  return (
+    <ActionBar
+      {...props}
+      watchedLabel={getWatchedActionLabel(item)}
+      onToggleWatched={handleToggleWatched}
+      isUpdatingWatched={watchedMutation.isPending}
+      onToggleFavorite={handleToggleFavorite}
+      isFavorite={isFavorite}
+      onToggleWatchlist={handleToggleWatchlist}
+      inWatchlist={inWatchlist}
+      rating={item.user_rating ?? null}
+      onRatingChange={handleRatingChange}
+    />
+  );
+}

--- a/web/src/pages/ItemDetail/components/MediaUserActionBar.tsx
+++ b/web/src/pages/ItemDetail/components/MediaUserActionBar.tsx
@@ -30,23 +30,23 @@ interface MediaUserActionBarProps extends Omit<ActionBarProps, UserActionProps> 
 export default function MediaUserActionBar({ item, ...props }: MediaUserActionBarProps) {
   const isFavorite = item.user_state?.is_favorite ?? false;
   const inWatchlist = item.user_state?.in_watchlist ?? false;
-  const watchedMutation = useWatchedStateMutation(item);
-  const toggleFavoriteMutation = useToggleFavorite(item.content_id);
-  const toggleWatchlistMutation = useToggleWatchlist(item.content_id);
+  const { mutate: toggleWatched, isPending: isUpdatingWatched } = useWatchedStateMutation(item);
+  const { mutate: toggleFavorite } = useToggleFavorite(item.content_id);
+  const { mutate: toggleWatchlist } = useToggleWatchlist(item.content_id);
   const { mutate: setRating } = useSetRating(item.content_id);
   const { mutate: deleteRating } = useDeleteRating(item.content_id);
 
   const handleToggleWatched = useCallback(
-    () => watchedMutation.mutate(!(item.user_data?.played ?? false)),
-    [item.user_data?.played, watchedMutation],
+    () => toggleWatched(!(item.user_data?.played ?? false)),
+    [item.user_data?.played, toggleWatched],
   );
   const handleToggleFavorite = useCallback(
-    () => toggleFavoriteMutation.mutate(isFavorite),
-    [isFavorite, toggleFavoriteMutation],
+    () => toggleFavorite(isFavorite),
+    [isFavorite, toggleFavorite],
   );
   const handleToggleWatchlist = useCallback(
-    () => toggleWatchlistMutation.mutate(inWatchlist),
-    [inWatchlist, toggleWatchlistMutation],
+    () => toggleWatchlist(inWatchlist),
+    [inWatchlist, toggleWatchlist],
   );
   const handleRatingChange = useCallback(
     (rating: number | null) => {
@@ -64,7 +64,7 @@ export default function MediaUserActionBar({ item, ...props }: MediaUserActionBa
       {...props}
       watchedLabel={getWatchedActionLabel(item)}
       onToggleWatched={handleToggleWatched}
-      isUpdatingWatched={watchedMutation.isPending}
+      isUpdatingWatched={isUpdatingWatched}
       onToggleFavorite={handleToggleFavorite}
       isFavorite={isFavorite}
       onToggleWatchlist={handleToggleWatchlist}

--- a/web/src/pages/ItemDetail/components/SubtitlesPopover.tsx
+++ b/web/src/pages/ItemDetail/components/SubtitlesPopover.tsx
@@ -5,7 +5,6 @@ import { Captions, Check, ChevronDown, Loader2 } from "lucide-react";
 import type { FileVersion } from "@/api/types";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
-import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover";
 import { useDownloadedSubtitles } from "@/hooks/queries/subtitles";
 import type {
   PlayerSubtitleTrackSignature,
@@ -23,6 +22,7 @@ import {
   subtitleSelectionEquals,
   type PrePlaySubtitleCandidate,
 } from "./prePlaySelection";
+import DetailPopover from "./DetailPopover";
 
 interface SubtitlesPopoverProps {
   version: FileVersion | null;
@@ -266,8 +266,12 @@ export default function SubtitlesPopover({
         : (overrideCandidate?.selection ?? null);
 
   return (
-    <Popover open={open} onOpenChange={setOpen}>
-      <PopoverTrigger asChild>
+    <DetailPopover
+      open={open}
+      onOpenChange={setOpen}
+      positionKey={`${downloadedQuery.isLoading}:${candidates.all.length}`}
+      contentClassName="max-h-80 w-80 overflow-y-auto p-1.5"
+      trigger={
         <Button
           variant="glass"
           className="h-8 max-w-full min-w-0 shrink gap-1.5 rounded-full px-3 text-xs font-medium"
@@ -279,58 +283,55 @@ export default function SubtitlesPopover({
           </span>
           <ChevronDown className="text-muted-foreground size-3" />
         </Button>
-      </PopoverTrigger>
-      <PopoverContent className="max-h-80 w-80 overflow-y-auto p-1.5">
-        <div className="space-y-2 py-1">
-          {isInteractive && (
-            <>
-              <SelectionRow
-                active={selectionMode === "auto" && !overrideCandidate}
-                title="Auto"
-                description={
-                  overrideCandidate
-                    ? "Reset to profile defaults"
-                    : (autoCandidate?.summary ?? "Off")
-                }
-                onSelect={onResetSelection}
-              />
-              <SelectionRow
-                active={selectionMode === "off"}
-                title="Off"
-                onSelect={onSelectSubtitleOff}
-              />
-            </>
-          )}
-          <SubtitleSection
-            title="Embedded"
-            rows={candidates.embedded}
-            activeSelection={activeListSelection}
-            onSelectSubtitle={onSelectSubtitle}
-          />
-          <SubtitleSection
-            title="External"
-            rows={candidates.external}
-            activeSelection={activeListSelection}
-            onSelectSubtitle={onSelectSubtitle}
-          />
-          {downloadedQuery.isLoading ? (
-            <div className="text-muted-foreground flex items-center gap-2 px-3 py-2 text-xs">
-              <Loader2 className="size-3 animate-spin" />
-              Loading downloaded...
-            </div>
-          ) : (
-            <SubtitleSection
-              title="Downloaded"
-              rows={candidates.downloaded}
-              activeSelection={activeListSelection}
-              onSelectSubtitle={onSelectSubtitle}
+      }
+    >
+      <div className="space-y-2 py-1">
+        {isInteractive && (
+          <>
+            <SelectionRow
+              active={selectionMode === "auto" && !overrideCandidate}
+              title="Auto"
+              description={
+                overrideCandidate ? "Reset to profile defaults" : (autoCandidate?.summary ?? "Off")
+              }
+              onSelect={onResetSelection}
             />
-          )}
-          {candidates.all.length === 0 && !downloadedQuery.isLoading && (
-            <div className="text-muted-foreground px-3 py-2 text-sm">No subtitles available.</div>
-          )}
-        </div>
-      </PopoverContent>
-    </Popover>
+            <SelectionRow
+              active={selectionMode === "off"}
+              title="Off"
+              onSelect={onSelectSubtitleOff}
+            />
+          </>
+        )}
+        <SubtitleSection
+          title="Embedded"
+          rows={candidates.embedded}
+          activeSelection={activeListSelection}
+          onSelectSubtitle={onSelectSubtitle}
+        />
+        <SubtitleSection
+          title="External"
+          rows={candidates.external}
+          activeSelection={activeListSelection}
+          onSelectSubtitle={onSelectSubtitle}
+        />
+        {downloadedQuery.isLoading ? (
+          <div className="text-muted-foreground flex items-center gap-2 px-3 py-2 text-xs">
+            <Loader2 className="size-3 animate-spin" />
+            Loading downloaded...
+          </div>
+        ) : (
+          <SubtitleSection
+            title="Downloaded"
+            rows={candidates.downloaded}
+            activeSelection={activeListSelection}
+            onSelectSubtitle={onSelectSubtitle}
+          />
+        )}
+        {candidates.all.length === 0 && !downloadedQuery.isLoading && (
+          <div className="text-muted-foreground px-3 py-2 text-sm">No subtitles available.</div>
+        )}
+      </div>
+    </DetailPopover>
   );
 }

--- a/web/src/pages/ItemDetail/components/VersionDropdown.tsx
+++ b/web/src/pages/ItemDetail/components/VersionDropdown.tsx
@@ -1,11 +1,11 @@
-import { useMemo, useState } from "react";
+import { memo, useMemo, useState } from "react";
 import { Check, ChevronDown, Disc3, Layers3 } from "lucide-react";
 
 import type { FileVersion, PlaybackVariant } from "@/api/types";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
-import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover";
 import { videoRangeLabel } from "@/lib/videoRange";
+import DetailPopover from "./DetailPopover";
 import { sortPlaybackVariantsByEditionPreference } from "./versionRankingUtils";
 import { buildDetailLine, buildQualitySummary, sortByResolution } from "./VersionFlyout";
 
@@ -24,7 +24,7 @@ interface EditionOption {
   versions: FileVersion[];
 }
 
-export default function VersionDropdown({
+function VersionDropdown({
   versions,
   playbackVariants,
   selectedVersion,
@@ -60,8 +60,11 @@ export default function VersionDropdown({
   return (
     <>
       {showEditionDropdown && selectedEdition ? (
-        <Popover open={editionOpen} onOpenChange={setEditionOpen}>
-          <PopoverTrigger asChild>
+        <DetailPopover
+          open={editionOpen}
+          onOpenChange={setEditionOpen}
+          contentClassName="w-72 p-1.5"
+          trigger={
             <Button
               variant="glass"
               className="h-8 max-w-full min-w-0 shrink gap-1.5 rounded-full px-3 text-xs font-medium"
@@ -73,44 +76,46 @@ export default function VersionDropdown({
               </span>
               <ChevronDown className="text-muted-foreground size-3" />
             </Button>
-          </PopoverTrigger>
-          <PopoverContent className="w-72 p-1.5">
-            <div className="space-y-0.5">
-              {editionOptions.map((option) => {
-                const isSelected = option.id === selectedEdition.id;
-                const detail = buildEditionDetail(option);
+          }
+        >
+          <div className="space-y-0.5">
+            {editionOptions.map((option) => {
+              const isSelected = option.id === selectedEdition.id;
+              const detail = buildEditionDetail(option);
 
-                return (
-                  <button
-                    key={option.id}
-                    type="button"
-                    onClick={() => {
-                      onSelectVersion(option.defaultVersion);
-                      setEditionOpen(false);
-                      setVersionOpen(false);
-                    }}
-                    className={`flex w-full items-center gap-3 rounded-lg px-3 py-2.5 text-left transition-colors ${
-                      isSelected ? "bg-accent text-accent-foreground" : "hover:bg-accent/50"
-                    }`}
-                  >
-                    <div className="min-w-0 flex-1">
-                      <div className="truncate text-sm font-medium">{option.label}</div>
-                      {detail && (
-                        <div className="text-muted-foreground truncate text-xs">{detail}</div>
-                      )}
-                    </div>
-                    {isSelected && <Check className="text-primary size-4 shrink-0" />}
-                  </button>
-                );
-              })}
-            </div>
-          </PopoverContent>
-        </Popover>
+              return (
+                <button
+                  key={option.id}
+                  type="button"
+                  onClick={() => {
+                    onSelectVersion(option.defaultVersion);
+                    setEditionOpen(false);
+                    setVersionOpen(false);
+                  }}
+                  className={`flex w-full items-center gap-3 rounded-lg px-3 py-2.5 text-left transition-colors ${
+                    isSelected ? "bg-accent text-accent-foreground" : "hover:bg-accent/50"
+                  }`}
+                >
+                  <div className="min-w-0 flex-1">
+                    <div className="truncate text-sm font-medium">{option.label}</div>
+                    {detail && (
+                      <div className="text-muted-foreground truncate text-xs">{detail}</div>
+                    )}
+                  </div>
+                  {isSelected && <Check className="text-primary size-4 shrink-0" />}
+                </button>
+              );
+            })}
+          </div>
+        </DetailPopover>
       ) : null}
 
       {showVersionDropdown ? (
-        <Popover open={versionOpen} onOpenChange={setVersionOpen}>
-          <PopoverTrigger asChild>
+        <DetailPopover
+          open={versionOpen}
+          onOpenChange={setVersionOpen}
+          contentClassName="w-80 p-1.5"
+          trigger={
             <Button
               variant="glass"
               className="h-8 max-w-full min-w-0 shrink gap-1.5 rounded-full px-3 text-xs font-medium"
@@ -122,55 +127,54 @@ export default function VersionDropdown({
               </span>
               <ChevronDown className="text-muted-foreground size-3" />
             </Button>
-          </PopoverTrigger>
-          <PopoverContent className="w-80 p-1.5">
-            <div className="space-y-0.5">
-              {activeVersions.map((version) => {
-                const isSelected = version.file_id === activeVersion?.file_id;
-                const summary = buildQualitySummary(version);
-                const detail = buildDetailLine(version);
-                const rangeLabel = videoRangeLabel(version);
+          }
+        >
+          <div className="space-y-0.5">
+            {activeVersions.map((version) => {
+              const isSelected = version.file_id === activeVersion?.file_id;
+              const summary = buildQualitySummary(version);
+              const detail = buildDetailLine(version);
+              const rangeLabel = videoRangeLabel(version);
 
-                return (
-                  <button
-                    key={version.file_id}
-                    type="button"
-                    onClick={() => {
-                      onSelectVersion(version);
-                      setVersionOpen(false);
-                    }}
-                    className={`flex w-full items-center gap-3 rounded-lg px-3 py-2.5 text-left transition-colors ${
-                      isSelected ? "bg-accent text-accent-foreground" : "hover:bg-accent/50"
-                    }`}
-                  >
-                    <div className="min-w-0 flex-1">
-                      <div className="flex items-center gap-2">
-                        <span className="truncate text-sm font-medium">
-                          {summary || `Version ${version.file_id}`}
-                        </span>
-                        {rangeLabel ? (
-                          <Badge variant="secondary" className="px-1.5 py-0 text-[10px] uppercase">
-                            {rangeLabel}
-                          </Badge>
-                        ) : null}
-                      </div>
-                      {detail && (
-                        <span className="text-muted-foreground block truncate text-xs">
-                          {detail}
-                        </span>
-                      )}
+              return (
+                <button
+                  key={version.file_id}
+                  type="button"
+                  onClick={() => {
+                    onSelectVersion(version);
+                    setVersionOpen(false);
+                  }}
+                  className={`flex w-full items-center gap-3 rounded-lg px-3 py-2.5 text-left transition-colors ${
+                    isSelected ? "bg-accent text-accent-foreground" : "hover:bg-accent/50"
+                  }`}
+                >
+                  <div className="min-w-0 flex-1">
+                    <div className="flex items-center gap-2">
+                      <span className="truncate text-sm font-medium">
+                        {summary || `Version ${version.file_id}`}
+                      </span>
+                      {rangeLabel ? (
+                        <Badge variant="secondary" className="px-1.5 py-0 text-[10px] uppercase">
+                          {rangeLabel}
+                        </Badge>
+                      ) : null}
                     </div>
-                    {isSelected && <Check className="text-primary size-4 shrink-0" />}
-                  </button>
-                );
-              })}
-            </div>
-          </PopoverContent>
-        </Popover>
+                    {detail && (
+                      <span className="text-muted-foreground block truncate text-xs">{detail}</span>
+                    )}
+                  </div>
+                  {isSelected && <Check className="text-primary size-4 shrink-0" />}
+                </button>
+              );
+            })}
+          </div>
+        </DetailPopover>
       ) : null}
     </>
   );
 }
+
+export default memo(VersionDropdown);
 
 function buildVersionTriggerSummary(version: FileVersion): string {
   return buildQualitySummary(version) || buildDetailLine(version) || `Version ${version.file_id}`;

--- a/web/src/pages/ItemDetail/components/WatchedActionBar.tsx
+++ b/web/src/pages/ItemDetail/components/WatchedActionBar.tsx
@@ -1,0 +1,29 @@
+import { useCallback } from "react";
+import type { ItemDetail } from "@/api/types";
+import { useWatchedStateMutation } from "@/hooks/queries/items";
+import { getWatchedActionLabel } from "../watchedState";
+import ActionBar, { type ActionBarProps } from "./ActionBar";
+
+type WatchedActionProps = "watchedLabel" | "onToggleWatched" | "isUpdatingWatched";
+
+interface WatchedActionBarProps extends Omit<ActionBarProps, WatchedActionProps> {
+  item: ItemDetail;
+}
+
+/** Keeps mutation lifecycle renders inside the episode action bar. */
+export default function WatchedActionBar({ item, ...props }: WatchedActionBarProps) {
+  const watchedMutation = useWatchedStateMutation(item);
+  const handleToggleWatched = useCallback(
+    () => watchedMutation.mutate(!(item.user_data?.played ?? false)),
+    [item.user_data?.played, watchedMutation],
+  );
+
+  return (
+    <ActionBar
+      {...props}
+      watchedLabel={getWatchedActionLabel(item)}
+      onToggleWatched={handleToggleWatched}
+      isUpdatingWatched={watchedMutation.isPending}
+    />
+  );
+}

--- a/web/src/pages/ItemDetail/components/WatchedActionBar.tsx
+++ b/web/src/pages/ItemDetail/components/WatchedActionBar.tsx
@@ -12,10 +12,10 @@ interface WatchedActionBarProps extends Omit<ActionBarProps, WatchedActionProps>
 
 /** Keeps mutation lifecycle renders inside the episode action bar. */
 export default function WatchedActionBar({ item, ...props }: WatchedActionBarProps) {
-  const watchedMutation = useWatchedStateMutation(item);
+  const { mutate: toggleWatched, isPending: isUpdatingWatched } = useWatchedStateMutation(item);
   const handleToggleWatched = useCallback(
-    () => watchedMutation.mutate(!(item.user_data?.played ?? false)),
-    [item.user_data?.played, watchedMutation],
+    () => toggleWatched(!(item.user_data?.played ?? false)),
+    [item.user_data?.played, toggleWatched],
   );
 
   return (
@@ -23,7 +23,7 @@ export default function WatchedActionBar({ item, ...props }: WatchedActionBarPro
       {...props}
       watchedLabel={getWatchedActionLabel(item)}
       onToggleWatched={handleToggleWatched}
-      isUpdatingWatched={watchedMutation.isPending}
+      isUpdatingWatched={isUpdatingWatched}
     />
   );
 }


### PR DESCRIPTION
## Problem

No linked issue; this was reported and reproduced locally on movie and episode detail pages.

Opening or hovering the Version, Audio, Subs, rating, watched, favorite, and overflow controls could stall the main thread. Scrolling immediately after an action or while hovering these controls visibly dropped frames, and optimistic user-state changes triggered broad synchronous cache work.

## Approach

- replace the affected Radix detail-page popovers with lightweight, accessible portals that remain immediately interactive and close cleanly on page scroll
- remove the detail hero Ken Burns animation and avoid live backdrop-filter repainting on the action surface
- keep star-rating previews in CSS and isolate frequently changing mutation state below the page-content boundary
- optimistically update watched, favorite, watchlist, and rating state while coalescing derived-surface invalidations outside the interaction frame
- preserve concurrent optimistic fields, cancel both detail-query cache shapes, and scope recommendation invalidation so metadata changes still refresh similar titles
- add regression coverage for popover focus/scroll behavior, invalidation scheduling, optimistic cache behavior, and realtime state reconciliation

Cold browser measurements while hovering and scrolling the seeded detail page reported a maximum frame of approximately 9.4 ms for Version, Audio, and Subs, with zero frames over 20 ms. Dropdown selection, Escape behavior, page-scroll dismissal, internal popup scrolling, overflow-menu navigation, and browser console output were also verified against the local server.

Screenshots are not included because this is a performance-focused change with no intentional layout redesign.

## Testing

```text
$ cd web && pnpm run lint
✖ 157 problems (0 errors, 157 warnings)

$ cd web && pnpm run format:check
All matched files use Prettier code style!

$ cd web && pnpm run build
✓ 4113 modules transformed.
✓ built in 7.87s

$ cd web && pnpm exec vitest run --exclude src/utils/storage.test.ts --exclude src/hooks/queries/settingValuesRealtime.test.tsx --exclude src/hooks/useTheme.test.ts --exclude src/hooks/appearanceCacheOwnership.test.tsx --exclude src/pages/setup-wizard/steps/ServerStorageStep.test.tsx --exclude src/pages/ItemDetail/SeasonContent.test.tsx
Test Files  267 passed (267)
Tests       1806 passed (1806)

$ make verify-local-paths
scripts/check-local-path-leaks.sh

$ git diff --check
(no output)
```

The six excluded frontend files fail identically on unchanged `main` in this local Node/jsdom environment because of the invalid built-in `localStorage`, missing `ResizeObserver`, and an unrelated existing query invalidation assertion.

`make lint` was also run and reports 303 pre-existing Go lint findings; this PR changes no Go files. Relevant Go tests are therefore not applicable.

### AI Disclosure
- Tool(s): Codex, Claude Code
- Model(s): gpt-5.6-sol (Codex); Claude model ID was not available to the PR-authoring session
- Involvement: AI-assisted
- Adversarial review: Repeated Codex and Claude reviews found and resolved optimistic rollback races, incomplete query cancellation, unsafe invalidation-option merging, metadata refreshes incorrectly skipping similar-title data, realtime favorite events overwriting watched state, popup accessibility/focus gaps, viewport overflow, page-scroll layout reads, and internal popup scrolling being mistaken for page scrolling. The final pass found no remaining findings.

## Checklist
- [x] I ran an adversarial AI review of the diff and summarized findings above.
- [ ] I ran the repo verify commands: `make lint`, `cd web && pnpm run lint`, `cd web && pnpm run format:check`, and relevant `go test ./...`.

The frontend commands and local-path verifier pass as described above. The repository-wide Go lint gate remains red on unchanged baseline findings, and no Go packages were modified.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added improved detail-page menus and popovers with responsive positioning, keyboard navigation, focus restoration, Escape handling, and outside-click dismissal.
  - Added CSS-based star-rating previews with persisted selections and hover feedback.
  - Streamlined movie and episode action controls for playback, favorites, watchlist, watched status, and ratings.

- **Bug Fixes**
  - Improved real-time updates while preserving existing playback and user-state information.
  - Reduced unnecessary refreshes and prevented stale detail-page data after changes.
  - Improved detail-page visual performance by removing unnecessary backdrop effects and animations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->