### PR TITLE
feat(watchsync): add per-connection plugin config

### DIFF
--- a/cmd/silo/main.go
+++ b/cmd/silo/main.go
@@ -3191,11 +3191,12 @@ func reloadWatchSyncPluginProviders(
 				continue
 			}
 			provider, err := watchsync.NewPluginProvider(watchsync.PluginProviderOptions{
-				InstallationID: installation.ID,
-				ProviderKey:    fmt.Sprintf("plugin:%d:%s", installation.ID, capability.ID),
-				CapabilityID:   capability.ID,
-				DisplayName:    descriptor.GetDisplayName(),
-				Descriptor:     descriptor.GetWatchSyncProvider(),
+				InstallationID:         installation.ID,
+				ProviderKey:            fmt.Sprintf("plugin:%d:%s", installation.ID, capability.ID),
+				CapabilityID:           capability.ID,
+				DisplayName:            descriptor.GetDisplayName(),
+				Descriptor:             descriptor.GetWatchSyncProvider(),
+				ConnectionConfigSchema: descriptor.GetConfigSchema(),
 				ResolveClient: func(callCtx context.Context, installationID int, capabilityID string) (watchsync.WatchSyncPluginClient, error) {
 					return service.WatchSyncProviderClient(callCtx, installationID, capabilityID)
 				},

--- a/cmd/silo/main_test.go
+++ b/cmd/silo/main_test.go
@@ -198,6 +198,66 @@ func (failingWatchSyncCapabilityStore) ListCapabilities(context.Context, int) ([
 	return nil, errors.New("database unavailable")
 }
 
+type staticWatchSyncCapabilityStore struct {
+	capabilities []*plugins.Capability
+}
+
+func (s staticWatchSyncCapabilityStore) ListEnabled(context.Context) ([]*plugins.Installation, error) {
+	return []*plugins.Installation{{ID: 4, Enabled: true, Kind: plugins.KindPlugin}}, nil
+}
+
+func (s staticWatchSyncCapabilityStore) ListCapabilities(context.Context, int) ([]*plugins.Capability, error) {
+	return s.capabilities, nil
+}
+
+func TestReloadWatchSyncPluginProvidersPreservesConnectionForm(t *testing.T) {
+	manifest := &pluginv1.PluginManifest{Capabilities: []*pluginv1.CapabilityDescriptor{{
+		Type: "watch_sync_provider.v1", Id: "floppy", DisplayName: "Floppy",
+		ConfigSchema: []*pluginv1.ConfigSchema{{
+			Key: "floppy", Title: "Your Floppy server", Required: true,
+			JsonSchema: `{"type":"object","properties":{"base_url":{"type":"string"}},"required":["base_url"]}`,
+			AdminForm: &pluginv1.AdminFormDescriptor{Fields: []*pluginv1.AdminFormField{{
+				Key: "base_url", Label: "Server URL", Required: true,
+				Control: pluginv1.AdminFormControl_ADMIN_FORM_CONTROL_TEXT,
+			}}},
+		}},
+		WatchSyncProvider: &pluginv1.WatchSyncProviderDescriptor{
+			AuthMethods: []pluginv1.WatchSyncAuthMethod{pluginv1.WatchSyncAuthMethod_WATCH_SYNC_AUTH_METHOD_API_KEY},
+		},
+	}}}
+	records, err := plugins.CapabilityRecordsFromManifest(manifest)
+	if err != nil {
+		t.Fatal(err)
+	}
+	capabilities := make([]*plugins.Capability, 0, len(records))
+	for i := range records {
+		record := records[i]
+		capabilities = append(capabilities, &record)
+	}
+
+	registry := watchsync.NewRegistry()
+	if err := reloadWatchSyncPluginProviders(
+		context.Background(), registry, staticWatchSyncCapabilityStore{capabilities: capabilities}, &plugins.Service{}, nil,
+	); err != nil {
+		t.Fatal(err)
+	}
+	provider, ok := registry.Get("plugin:4:floppy")
+	if !ok {
+		t.Fatal("Floppy provider was not registered")
+	}
+	configurable, ok := provider.(interface {
+		ConnectionConfigSchema() []plugins.ConfigSchemaView
+	})
+	if !ok {
+		t.Fatal("Floppy provider does not expose connection configuration")
+	}
+	schemas := configurable.ConnectionConfigSchema()
+	if len(schemas) != 1 || schemas[0].AdminForm == nil || len(schemas[0].AdminForm.Fields) != 1 ||
+		schemas[0].AdminForm.Fields[0].Control != "TEXT" {
+		t.Fatalf("connection config schema = %#v", schemas)
+	}
+}
+
 func TestReloadWatchSyncPluginProvidersDropsStaleProvidersOnCapabilityReadFailure(t *testing.T) {
 	registry := watchsync.NewRegistry()
 	provider, err := watchsync.NewPluginProvider(watchsync.PluginProviderOptions{

--- a/docs/feature-changelog.md
+++ b/docs/feature-changelog.md
@@ -1,5 +1,14 @@
 # Feature Changelog
 
+## 2026-08-20
+
+### Give each profile its own watch-provider server
+Plugin watch providers can now ask for connection details per profile instead of forcing every profile on a Silo server to share one installation-wide configuration.
+- Lets a self-hosted provider give each household member their own server URL and credentials.
+- Renders the provider's own setup fields beside the API key on the profile's watch-provider screen, so connecting stays a single step.
+- Encrypts every field the provider declares as a secret and keeps submitted setup data out of admin-facing plugin configuration.
+- Prefers a profile's own values over installation-wide values of the same name, so existing connections keep working until they are reconnected.
+
 ## 2026-08-19
 
 ### Make published server builds easy to compare

--- a/go.mod
+++ b/go.mod
@@ -109,7 +109,7 @@ require (
 )
 
 require (
-	github.com/Silo-Server/silo-plugin-sdk v0.13.1-0.20260806165045-5894c9913073
+	github.com/Silo-Server/silo-plugin-sdk v0.13.1
 	github.com/aws/aws-sdk-go-v2/aws/protocol/eventstream v1.7.14 // indirect
 	github.com/aws/aws-sdk-go-v2/internal/configsources v1.4.30 // indirect
 	github.com/aws/aws-sdk-go-v2/internal/endpoints/v2 v2.7.30 // indirect

--- a/go.mod
+++ b/go.mod
@@ -109,7 +109,7 @@ require (
 )
 
 require (
-	github.com/Silo-Server/silo-plugin-sdk v0.13.0
+	github.com/Silo-Server/silo-plugin-sdk v0.13.1-0.20260806161915-6bd04a8878a5
 	github.com/aws/aws-sdk-go-v2/aws/protocol/eventstream v1.7.14 // indirect
 	github.com/aws/aws-sdk-go-v2/internal/configsources v1.4.30 // indirect
 	github.com/aws/aws-sdk-go-v2/internal/endpoints/v2 v2.7.30 // indirect

--- a/go.mod
+++ b/go.mod
@@ -109,7 +109,7 @@ require (
 )
 
 require (
-	github.com/Silo-Server/silo-plugin-sdk v0.13.1
+	github.com/Silo-Server/silo-plugin-sdk v0.13.2
 	github.com/aws/aws-sdk-go-v2/aws/protocol/eventstream v1.7.14 // indirect
 	github.com/aws/aws-sdk-go-v2/internal/configsources v1.4.30 // indirect
 	github.com/aws/aws-sdk-go-v2/internal/endpoints/v2 v2.7.30 // indirect

--- a/go.mod
+++ b/go.mod
@@ -109,7 +109,7 @@ require (
 )
 
 require (
-	github.com/Silo-Server/silo-plugin-sdk v0.13.1-0.20260806161915-6bd04a8878a5
+	github.com/Silo-Server/silo-plugin-sdk v0.13.1-0.20260806165045-5894c9913073
 	github.com/aws/aws-sdk-go-v2/aws/protocol/eventstream v1.7.14 // indirect
 	github.com/aws/aws-sdk-go-v2/internal/configsources v1.4.30 // indirect
 	github.com/aws/aws-sdk-go-v2/internal/endpoints/v2 v2.7.30 // indirect

--- a/go.sum
+++ b/go.sum
@@ -6,6 +6,8 @@ github.com/SherClockHolmes/webpush-go v1.4.0 h1:ocnzNKWN23T9nvHi6IfyrQjkIc0oJWv1
 github.com/SherClockHolmes/webpush-go v1.4.0/go.mod h1:XSq8pKX11vNV8MJEMwjrlTkxhAj1zKfxmyhdV7Pd6UA=
 github.com/Silo-Server/silo-plugin-sdk v0.13.0 h1:BXf4cuNbOIIsrVJrRdlQnbc1m04X6lcPSZI+AFLMeK0=
 github.com/Silo-Server/silo-plugin-sdk v0.13.0/go.mod h1:etqmxLTwjxpFH9goAjBDfNDoqHMv2/sqUXu8yx3hNfA=
+github.com/Silo-Server/silo-plugin-sdk v0.13.1-0.20260806161915-6bd04a8878a5 h1:dgsrthd5onCndS8Tq+bFvq4NZuyIM71Ll+Ts+WMq/7c=
+github.com/Silo-Server/silo-plugin-sdk v0.13.1-0.20260806161915-6bd04a8878a5/go.mod h1:etqmxLTwjxpFH9goAjBDfNDoqHMv2/sqUXu8yx3hNfA=
 github.com/abadojack/whatlanggo v1.0.1 h1:19N6YogDnf71CTHm3Mp2qhYfkRdyvbgwWdd2EPxJRG4=
 github.com/abadojack/whatlanggo v1.0.1/go.mod h1:66WiQbSbJBIlOZMsvbKe5m6pzQovxCH9B/K8tQB2uoc=
 github.com/agnivade/levenshtein v1.2.1 h1:EHBY3UOn1gwdy/VbFwgo4cxecRznFk7fKWN1KOX7eoM=

--- a/go.sum
+++ b/go.sum
@@ -4,8 +4,6 @@ github.com/PuerkitoBio/goquery v1.8.0 h1:PJTF7AmFCFKk1N6V6jmKfrNH9tV5pNE6lZMkG0g
 github.com/PuerkitoBio/goquery v1.8.0/go.mod h1:ypIiRMtY7COPGk+I/YbZLbxsxn9g5ejnI2HSMtkjZvI=
 github.com/SherClockHolmes/webpush-go v1.4.0 h1:ocnzNKWN23T9nvHi6IfyrQjkIc0oJWv1B1pULsf9i3s=
 github.com/SherClockHolmes/webpush-go v1.4.0/go.mod h1:XSq8pKX11vNV8MJEMwjrlTkxhAj1zKfxmyhdV7Pd6UA=
-github.com/Silo-Server/silo-plugin-sdk v0.13.1 h1:3vMaV+aPT/vu47CPk/f3nODsjXCp1OseI0QIoLnOvOM=
-github.com/Silo-Server/silo-plugin-sdk v0.13.1/go.mod h1:etqmxLTwjxpFH9goAjBDfNDoqHMv2/sqUXu8yx3hNfA=
 github.com/Silo-Server/silo-plugin-sdk v0.13.2 h1:w7U0mmljVPauKfzRLNKusuiYFpuoEhuCSX4Hp3s9eRw=
 github.com/Silo-Server/silo-plugin-sdk v0.13.2/go.mod h1:etqmxLTwjxpFH9goAjBDfNDoqHMv2/sqUXu8yx3hNfA=
 github.com/abadojack/whatlanggo v1.0.1 h1:19N6YogDnf71CTHm3Mp2qhYfkRdyvbgwWdd2EPxJRG4=

--- a/go.sum
+++ b/go.sum
@@ -4,8 +4,8 @@ github.com/PuerkitoBio/goquery v1.8.0 h1:PJTF7AmFCFKk1N6V6jmKfrNH9tV5pNE6lZMkG0g
 github.com/PuerkitoBio/goquery v1.8.0/go.mod h1:ypIiRMtY7COPGk+I/YbZLbxsxn9g5ejnI2HSMtkjZvI=
 github.com/SherClockHolmes/webpush-go v1.4.0 h1:ocnzNKWN23T9nvHi6IfyrQjkIc0oJWv1B1pULsf9i3s=
 github.com/SherClockHolmes/webpush-go v1.4.0/go.mod h1:XSq8pKX11vNV8MJEMwjrlTkxhAj1zKfxmyhdV7Pd6UA=
-github.com/Silo-Server/silo-plugin-sdk v0.13.1-0.20260806165045-5894c9913073 h1:WWOcoJz8XhYHNd1PCNP7lyi+pbU14/DFgc/O6RYj3ws=
-github.com/Silo-Server/silo-plugin-sdk v0.13.1-0.20260806165045-5894c9913073/go.mod h1:etqmxLTwjxpFH9goAjBDfNDoqHMv2/sqUXu8yx3hNfA=
+github.com/Silo-Server/silo-plugin-sdk v0.13.1 h1:3vMaV+aPT/vu47CPk/f3nODsjXCp1OseI0QIoLnOvOM=
+github.com/Silo-Server/silo-plugin-sdk v0.13.1/go.mod h1:etqmxLTwjxpFH9goAjBDfNDoqHMv2/sqUXu8yx3hNfA=
 github.com/abadojack/whatlanggo v1.0.1 h1:19N6YogDnf71CTHm3Mp2qhYfkRdyvbgwWdd2EPxJRG4=
 github.com/abadojack/whatlanggo v1.0.1/go.mod h1:66WiQbSbJBIlOZMsvbKe5m6pzQovxCH9B/K8tQB2uoc=
 github.com/agnivade/levenshtein v1.2.1 h1:EHBY3UOn1gwdy/VbFwgo4cxecRznFk7fKWN1KOX7eoM=

--- a/go.sum
+++ b/go.sum
@@ -6,6 +6,8 @@ github.com/SherClockHolmes/webpush-go v1.4.0 h1:ocnzNKWN23T9nvHi6IfyrQjkIc0oJWv1
 github.com/SherClockHolmes/webpush-go v1.4.0/go.mod h1:XSq8pKX11vNV8MJEMwjrlTkxhAj1zKfxmyhdV7Pd6UA=
 github.com/Silo-Server/silo-plugin-sdk v0.13.1 h1:3vMaV+aPT/vu47CPk/f3nODsjXCp1OseI0QIoLnOvOM=
 github.com/Silo-Server/silo-plugin-sdk v0.13.1/go.mod h1:etqmxLTwjxpFH9goAjBDfNDoqHMv2/sqUXu8yx3hNfA=
+github.com/Silo-Server/silo-plugin-sdk v0.13.2 h1:w7U0mmljVPauKfzRLNKusuiYFpuoEhuCSX4Hp3s9eRw=
+github.com/Silo-Server/silo-plugin-sdk v0.13.2/go.mod h1:etqmxLTwjxpFH9goAjBDfNDoqHMv2/sqUXu8yx3hNfA=
 github.com/abadojack/whatlanggo v1.0.1 h1:19N6YogDnf71CTHm3Mp2qhYfkRdyvbgwWdd2EPxJRG4=
 github.com/abadojack/whatlanggo v1.0.1/go.mod h1:66WiQbSbJBIlOZMsvbKe5m6pzQovxCH9B/K8tQB2uoc=
 github.com/agnivade/levenshtein v1.2.1 h1:EHBY3UOn1gwdy/VbFwgo4cxecRznFk7fKWN1KOX7eoM=

--- a/go.sum
+++ b/go.sum
@@ -4,10 +4,8 @@ github.com/PuerkitoBio/goquery v1.8.0 h1:PJTF7AmFCFKk1N6V6jmKfrNH9tV5pNE6lZMkG0g
 github.com/PuerkitoBio/goquery v1.8.0/go.mod h1:ypIiRMtY7COPGk+I/YbZLbxsxn9g5ejnI2HSMtkjZvI=
 github.com/SherClockHolmes/webpush-go v1.4.0 h1:ocnzNKWN23T9nvHi6IfyrQjkIc0oJWv1B1pULsf9i3s=
 github.com/SherClockHolmes/webpush-go v1.4.0/go.mod h1:XSq8pKX11vNV8MJEMwjrlTkxhAj1zKfxmyhdV7Pd6UA=
-github.com/Silo-Server/silo-plugin-sdk v0.13.0 h1:BXf4cuNbOIIsrVJrRdlQnbc1m04X6lcPSZI+AFLMeK0=
-github.com/Silo-Server/silo-plugin-sdk v0.13.0/go.mod h1:etqmxLTwjxpFH9goAjBDfNDoqHMv2/sqUXu8yx3hNfA=
-github.com/Silo-Server/silo-plugin-sdk v0.13.1-0.20260806161915-6bd04a8878a5 h1:dgsrthd5onCndS8Tq+bFvq4NZuyIM71Ll+Ts+WMq/7c=
-github.com/Silo-Server/silo-plugin-sdk v0.13.1-0.20260806161915-6bd04a8878a5/go.mod h1:etqmxLTwjxpFH9goAjBDfNDoqHMv2/sqUXu8yx3hNfA=
+github.com/Silo-Server/silo-plugin-sdk v0.13.1-0.20260806165045-5894c9913073 h1:WWOcoJz8XhYHNd1PCNP7lyi+pbU14/DFgc/O6RYj3ws=
+github.com/Silo-Server/silo-plugin-sdk v0.13.1-0.20260806165045-5894c9913073/go.mod h1:etqmxLTwjxpFH9goAjBDfNDoqHMv2/sqUXu8yx3hNfA=
 github.com/abadojack/whatlanggo v1.0.1 h1:19N6YogDnf71CTHm3Mp2qhYfkRdyvbgwWdd2EPxJRG4=
 github.com/abadojack/whatlanggo v1.0.1/go.mod h1:66WiQbSbJBIlOZMsvbKe5m6pzQovxCH9B/K8tQB2uoc=
 github.com/agnivade/levenshtein v1.2.1 h1:EHBY3UOn1gwdy/VbFwgo4cxecRznFk7fKWN1KOX7eoM=

--- a/internal/api/handlers/plugins.go
+++ b/internal/api/handlers/plugins.go
@@ -201,69 +201,10 @@ type pluginPresentationJSON struct {
 	LicenseSPDX         string `json:"license_spdx"`
 }
 
-type pluginConfigSchemaJSON struct {
-	Key         string               `json:"key"`
-	Title       string               `json:"title"`
-	Description string               `json:"description"`
-	JSONSchema  string               `json:"json_schema"`
-	Required    bool                 `json:"required"`
-	AdminForm   *pluginAdminFormJSON `json:"admin_form,omitempty"`
-}
-
-type pluginAdminFormJSON struct {
-	Fields      []pluginAdminFormFieldJSON   `json:"fields"`
-	SubmitLabel string                       `json:"submit_label,omitempty"`
-	Sections    []pluginAdminFormSectionJSON `json:"sections,omitempty"`
-}
-
-type pluginAdminFormFieldJSON struct {
-	Key                 string                         `json:"key"`
-	Label               string                         `json:"label"`
-	Description         string                         `json:"description,omitempty"`
-	Control             string                         `json:"control"`
-	Placeholder         string                         `json:"placeholder,omitempty"`
-	Required            bool                           `json:"required"`
-	Secret              bool                           `json:"secret"`
-	Multiline           bool                           `json:"multiline"`
-	DefaultValue        any                            `json:"default_value,omitempty"`
-	Options             []pluginAdminFormOptionJSON    `json:"options,omitempty"`
-	Rows                int32                          `json:"rows,omitempty"`
-	DynamicOptions      bool                           `json:"dynamic_options,omitempty"`
-	ShowWhen            []pluginAdminFormConditionJSON `json:"show_when,omitempty"`
-	Validation          *pluginAdminFormValidationJSON `json:"validation,omitempty"`
-	ExclusiveGroupField string                         `json:"exclusive_group_field,omitempty"`
-}
-
-type pluginAdminFormOptionJSON struct {
-	Value       string `json:"value"`
-	Label       string `json:"label"`
-	Description string `json:"description,omitempty"`
-}
-
-type pluginAdminFormConditionJSON struct {
-	Field  string   `json:"field"`
-	Equals []string `json:"equals"`
-}
-
-type pluginAdminFormValidationJSON struct {
-	HasMin    bool    `json:"has_min,omitempty"`
-	Min       float64 `json:"min,omitempty"`
-	HasMax    bool    `json:"has_max,omitempty"`
-	Max       float64 `json:"max,omitempty"`
-	Pattern   string  `json:"pattern,omitempty"`
-	MinLength int32   `json:"min_length,omitempty"`
-	MaxLength int32   `json:"max_length,omitempty"`
-}
-
-type pluginAdminFormSectionJSON struct {
-	Key              string                         `json:"key"`
-	Title            string                         `json:"title"`
-	Description      string                         `json:"description,omitempty"`
-	Collapsible      bool                           `json:"collapsible"`
-	CollapsedDefault bool                           `json:"collapsed_default"`
-	FieldKeys        []string                       `json:"field_keys"`
-	ShowWhen         []pluginAdminFormConditionJSON `json:"show_when,omitempty"`
-}
+type pluginConfigSchemaJSON = plugins.ConfigSchemaView
+type pluginAdminFormJSON = plugins.AdminFormView
+type pluginAdminFormFieldJSON = plugins.AdminFormFieldView
+type pluginAdminFormSectionJSON = plugins.AdminFormSectionView
 
 type pluginCapabilityJSON struct {
 	Type          string                   `json:"type"`
@@ -1567,117 +1508,11 @@ func toUserPluginSettingsSummary(
 }
 
 func configSchemasToJSON(schemas []*pluginv1.ConfigSchema) []pluginConfigSchemaJSON {
-	response := make([]pluginConfigSchemaJSON, 0, len(schemas))
-	for _, schema := range schemas {
-		if schema == nil {
-			continue
-		}
-		response = append(response, pluginConfigSchemaJSON{
-			Key:         schema.GetKey(),
-			Title:       schema.GetTitle(),
-			Description: schema.GetDescription(),
-			JSONSchema:  schema.GetJsonSchema(),
-			Required:    schema.GetRequired(),
-			AdminForm:   adminFormToJSON(schema.GetAdminForm()),
-		})
-	}
-	return response
+	return plugins.ConfigSchemaViews(schemas)
 }
 
 func adminFormToJSON(form *pluginv1.AdminFormDescriptor) *pluginAdminFormJSON {
-	if form == nil {
-		return nil
-	}
-	fields := make([]pluginAdminFormFieldJSON, 0, len(form.GetFields()))
-	for _, field := range form.GetFields() {
-		if field == nil {
-			continue
-		}
-		options := make([]pluginAdminFormOptionJSON, 0, len(field.GetOptions()))
-		for _, option := range field.GetOptions() {
-			if option == nil {
-				continue
-			}
-			options = append(options, pluginAdminFormOptionJSON{
-				Value:       option.GetValue(),
-				Label:       option.GetLabel(),
-				Description: option.GetDescription(),
-			})
-		}
-		var defaultValue any
-		if field.GetDefaultValue() != nil {
-			defaultValue = field.GetDefaultValue().AsInterface()
-		}
-		var validation *pluginAdminFormValidationJSON
-		if v := field.GetValidation(); v != nil {
-			validation = &pluginAdminFormValidationJSON{
-				HasMin:    v.GetHasMin(),
-				Min:       v.GetMin(),
-				HasMax:    v.GetHasMax(),
-				Max:       v.GetMax(),
-				Pattern:   v.GetPattern(),
-				MinLength: v.GetMinLength(),
-				MaxLength: v.GetMaxLength(),
-			}
-		}
-		fields = append(fields, pluginAdminFormFieldJSON{
-			Key:                 field.GetKey(),
-			Label:               field.GetLabel(),
-			Description:         field.GetDescription(),
-			Control:             strings.TrimPrefix(field.GetControl().String(), "ADMIN_FORM_CONTROL_"),
-			Placeholder:         field.GetPlaceholder(),
-			Required:            field.GetRequired(),
-			Secret:              field.GetSecret(),
-			Multiline:           field.GetMultiline(),
-			DefaultValue:        defaultValue,
-			Options:             options,
-			Rows:                field.GetRows(),
-			DynamicOptions:      field.GetDynamicOptions(),
-			ShowWhen:            adminFormConditionsToJSON(field.GetShowWhen()),
-			Validation:          validation,
-			ExclusiveGroupField: field.GetExclusiveGroupField(),
-		})
-	}
-	sections := make([]pluginAdminFormSectionJSON, 0, len(form.GetSections()))
-	for _, section := range form.GetSections() {
-		if section == nil {
-			continue
-		}
-		sections = append(sections, pluginAdminFormSectionJSON{
-			Key:              section.GetKey(),
-			Title:            section.GetTitle(),
-			Description:      section.GetDescription(),
-			Collapsible:      section.GetCollapsible(),
-			CollapsedDefault: section.GetCollapsedDefault(),
-			FieldKeys:        append([]string(nil), section.GetFieldKeys()...),
-			ShowWhen:         adminFormConditionsToJSON(section.GetShowWhen()),
-		})
-	}
-	return &pluginAdminFormJSON{
-		Fields:      fields,
-		SubmitLabel: form.GetSubmitLabel(),
-		Sections:    sections,
-	}
-}
-
-func adminFormConditionsToJSON(conditions []*pluginv1.AdminFormCondition) []pluginAdminFormConditionJSON {
-	if len(conditions) == 0 {
-		return nil
-	}
-	out := make([]pluginAdminFormConditionJSON, 0, len(conditions))
-	for _, condition := range conditions {
-		if condition == nil {
-			continue
-		}
-		out = append(out, pluginAdminFormConditionJSON{
-			Field:  condition.GetField(),
-			Equals: append([]string(nil), condition.GetEquals()...),
-		})
-	}
-	if len(out) == 0 {
-		return nil
-	}
-	return out
+	return plugins.AdminFormViewFromProto(form)
 }
 
 func capabilitiesToJSON(descriptors []*pluginv1.CapabilityDescriptor) []pluginCapabilityJSON {

--- a/internal/api/handlers/watch_providers.go
+++ b/internal/api/handlers/watch_providers.go
@@ -16,7 +16,7 @@ type WatchProviderService interface {
 	ListProviders() []watchsync.ProviderSummary
 	StartDeviceAuth(ctx context.Context, userID int, profileID string, providerKey string) (watchsync.DeviceAuthSession, error)
 	PollDeviceAuth(ctx context.Context, userID int, profileID string, providerKey string, sessionID string) (watchsync.Connection, error)
-	ConnectAPIKey(ctx context.Context, userID int, profileID string, providerKey string, apiKey string) (watchsync.Connection, error)
+	ConnectAPIKeyWithConfig(ctx context.Context, userID int, profileID string, providerKey string, apiKey string, connectionConfig watchsync.ConnectionConfigValues) (watchsync.Connection, error)
 	GetConnectionStatus(ctx context.Context, userID int, profileID string, provider string) (watchsync.ConnectionStatus, error)
 	UpdateConnection(ctx context.Context, userID int, profileID string, provider string, update watchsync.ConnectionUpdate) (watchsync.ConnectionStatus, error)
 	DeleteConnection(ctx context.Context, userID int, profileID string, provider string) error
@@ -147,13 +147,14 @@ func (h *WatchProviderHandler) HandleConnectAPIKey(w http.ResponseWriter, r *htt
 		return
 	}
 	var req struct {
-		APIKey string `json:"api_key"`
+		APIKey           string                           `json:"api_key"`
+		ConnectionConfig watchsync.ConnectionConfigValues `json:"connection_config"`
 	}
 	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
 		writeError(w, http.StatusBadRequest, "bad_request", "Invalid request body")
 		return
 	}
-	if _, err := h.service.ConnectAPIKey(r.Context(), userID, profileID, provider, req.APIKey); err != nil {
+	if _, err := h.service.ConnectAPIKeyWithConfig(r.Context(), userID, profileID, provider, req.APIKey, req.ConnectionConfig); err != nil {
 		writeError(w, http.StatusBadRequest, "watch_provider_error", err.Error())
 		return
 	}

--- a/internal/api/handlers/watch_providers_test.go
+++ b/internal/api/handlers/watch_providers_test.go
@@ -5,6 +5,8 @@ import (
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
+	"reflect"
+	"strings"
 	"testing"
 	"time"
 
@@ -23,6 +25,25 @@ type stubWatchProviderService struct {
 	runs      []watchsync.SyncRun
 }
 
+type capturingWatchProviderService struct {
+	stubWatchProviderService
+	apiKey string
+	config watchsync.ConnectionConfigValues
+}
+
+func (s *capturingWatchProviderService) ConnectAPIKeyWithConfig(
+	_ context.Context,
+	_ int,
+	_ string,
+	_ string,
+	apiKey string,
+	config watchsync.ConnectionConfigValues,
+) (watchsync.Connection, error) {
+	s.apiKey = apiKey
+	s.config = config
+	return watchsync.Connection{}, nil
+}
+
 func (s stubWatchProviderService) ListProviders() []watchsync.ProviderSummary {
 	return s.providers
 }
@@ -32,7 +53,7 @@ func (s stubWatchProviderService) StartDeviceAuth(context.Context, int, string, 
 func (s stubWatchProviderService) PollDeviceAuth(context.Context, int, string, string, string) (watchsync.Connection, error) {
 	return watchsync.Connection{}, nil
 }
-func (s stubWatchProviderService) ConnectAPIKey(context.Context, int, string, string, string) (watchsync.Connection, error) {
+func (s stubWatchProviderService) ConnectAPIKeyWithConfig(context.Context, int, string, string, string, watchsync.ConnectionConfigValues) (watchsync.Connection, error) {
 	return watchsync.Connection{}, nil
 }
 func (s stubWatchProviderService) GetConnectionStatus(context.Context, int, string, string) (watchsync.ConnectionStatus, error) {
@@ -89,7 +110,7 @@ func TestWatchProviderHandlerListsProviders(t *testing.T) {
 	if len(resp.Providers) != 1 {
 		t.Fatalf("providers length = %d, want 1", len(resp.Providers))
 	}
-	if resp.Providers[0] != service.providers[0] {
+	if !reflect.DeepEqual(resp.Providers[0], service.providers[0]) {
 		t.Fatalf("provider = %#v, want %#v", resp.Providers[0], service.providers[0])
 	}
 }
@@ -172,6 +193,31 @@ func TestWatchProviderHandlerStartsDeviceAuthWithFrontendJSONShape(t *testing.T)
 	}
 	if resp["verification_url"] != "https://trakt.tv/activate" {
 		t.Fatalf("verification_url = %#v, want https://trakt.tv/activate", resp["verification_url"])
+	}
+}
+
+func TestWatchProviderHandlerPassesConnectionConfigWithAPIKey(t *testing.T) {
+	service := &capturingWatchProviderService{}
+	handler := NewWatchProviderHandler(service)
+	req := httptest.NewRequest(http.MethodPost, "/watch-providers/plugin:4:floppy/auth/api-key", strings.NewReader(`{
+		"api_key":"token",
+		"connection_config":{"floppy":{"base_url":"https://floppy.example.com"}}
+	}`))
+	routeCtx := chi.NewRouteContext()
+	routeCtx.URLParams.Add("provider", "plugin:4:floppy")
+	ctx := context.WithValue(req.Context(), chi.RouteCtxKey, routeCtx)
+	ctx = middleware.SetClaims(ctx, &auth.Claims{UserID: 7})
+	ctx = middleware.SetProfileID(ctx, "profile-1")
+	req = req.WithContext(ctx)
+	rec := httptest.NewRecorder()
+
+	handler.HandleConnectAPIKey(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d; body=%s", rec.Code, http.StatusOK, rec.Body.String())
+	}
+	if service.apiKey != "token" || service.config["floppy"]["base_url"] != "https://floppy.example.com" {
+		t.Fatalf("api key = %q, config = %#v", service.apiKey, service.config)
 	}
 }
 

--- a/internal/pluginhost/handshake.go
+++ b/internal/pluginhost/handshake.go
@@ -23,7 +23,9 @@ const (
 	DefaultEventTimeout      = 10 * time.Second
 	DefaultAuthTimeout       = 10 * time.Second
 	DefaultRouteTimeout      = 10 * time.Second
-	DefaultWatchSyncTimeout  = 60 * time.Second
+	// Watch-sync providers may resolve cold external metadata before applying
+	// an event. Bound that work without cutting off valid slow provider calls.
+	DefaultWatchSyncTimeout = 2 * time.Minute
 	// DefaultRequestRouterTimeout bounds a single request_router RPC.
 	// Fulfillment hits remote arr instances, so allow generous headroom.
 	DefaultRequestRouterTimeout = 60 * time.Second

--- a/internal/plugins/config_schema_view.go
+++ b/internal/plugins/config_schema_view.go
@@ -1,0 +1,150 @@
+package plugins
+
+import (
+	"strings"
+
+	pluginv1 "github.com/Silo-Server/silo-plugin-sdk/pkg/pluginproto/silo/plugin/v1"
+)
+
+// ConfigSchemaView is the transport-safe representation of a manifest config
+// schema used by non-admin setup surfaces.
+type ConfigSchemaView struct {
+	Key         string         `json:"key"`
+	Title       string         `json:"title"`
+	Description string         `json:"description"`
+	JSONSchema  string         `json:"json_schema"`
+	Required    bool           `json:"required"`
+	AdminForm   *AdminFormView `json:"admin_form,omitempty"`
+}
+
+type AdminFormView struct {
+	Fields      []AdminFormFieldView   `json:"fields"`
+	SubmitLabel string                 `json:"submit_label,omitempty"`
+	Sections    []AdminFormSectionView `json:"sections,omitempty"`
+}
+
+type AdminFormFieldView struct {
+	Key                 string                   `json:"key"`
+	Label               string                   `json:"label"`
+	Description         string                   `json:"description,omitempty"`
+	Control             string                   `json:"control"`
+	Placeholder         string                   `json:"placeholder,omitempty"`
+	Required            bool                     `json:"required"`
+	Secret              bool                     `json:"secret"`
+	Multiline           bool                     `json:"multiline"`
+	DefaultValue        any                      `json:"default_value,omitempty"`
+	Options             []AdminFormOptionView    `json:"options,omitempty"`
+	Rows                int32                    `json:"rows,omitempty"`
+	DynamicOptions      bool                     `json:"dynamic_options,omitempty"`
+	ShowWhen            []AdminFormConditionView `json:"show_when,omitempty"`
+	Validation          *AdminFormValidationView `json:"validation,omitempty"`
+	ExclusiveGroupField string                   `json:"exclusive_group_field,omitempty"`
+}
+
+type AdminFormOptionView struct {
+	Value       string `json:"value"`
+	Label       string `json:"label"`
+	Description string `json:"description,omitempty"`
+}
+
+type AdminFormConditionView struct {
+	Field  string   `json:"field"`
+	Equals []string `json:"equals"`
+}
+
+type AdminFormValidationView struct {
+	HasMin    bool    `json:"has_min,omitempty"`
+	Min       float64 `json:"min,omitempty"`
+	HasMax    bool    `json:"has_max,omitempty"`
+	Max       float64 `json:"max,omitempty"`
+	Pattern   string  `json:"pattern,omitempty"`
+	MinLength int32   `json:"min_length,omitempty"`
+	MaxLength int32   `json:"max_length,omitempty"`
+}
+
+type AdminFormSectionView struct {
+	Key              string                   `json:"key"`
+	Title            string                   `json:"title"`
+	Description      string                   `json:"description,omitempty"`
+	Collapsible      bool                     `json:"collapsible"`
+	CollapsedDefault bool                     `json:"collapsed_default"`
+	FieldKeys        []string                 `json:"field_keys"`
+	ShowWhen         []AdminFormConditionView `json:"show_when,omitempty"`
+}
+
+func ConfigSchemaViews(schemas []*pluginv1.ConfigSchema) []ConfigSchemaView {
+	views := make([]ConfigSchemaView, 0, len(schemas))
+	for _, schema := range schemas {
+		if schema == nil {
+			continue
+		}
+		views = append(views, ConfigSchemaView{
+			Key:         schema.GetKey(),
+			Title:       schema.GetTitle(),
+			Description: schema.GetDescription(),
+			JSONSchema:  schema.GetJsonSchema(),
+			Required:    schema.GetRequired(),
+			AdminForm:   AdminFormViewFromProto(schema.GetAdminForm()),
+		})
+	}
+	return views
+}
+
+func AdminFormViewFromProto(form *pluginv1.AdminFormDescriptor) *AdminFormView {
+	if form == nil {
+		return nil
+	}
+	fields := make([]AdminFormFieldView, 0, len(form.GetFields()))
+	for _, field := range form.GetFields() {
+		if field == nil {
+			continue
+		}
+		options := make([]AdminFormOptionView, 0, len(field.GetOptions()))
+		for _, option := range field.GetOptions() {
+			if option != nil {
+				options = append(options, AdminFormOptionView{Value: option.GetValue(), Label: option.GetLabel(), Description: option.GetDescription()})
+			}
+		}
+		var defaultValue any
+		if field.GetDefaultValue() != nil {
+			defaultValue = field.GetDefaultValue().AsInterface()
+		}
+		var validation *AdminFormValidationView
+		if value := field.GetValidation(); value != nil {
+			validation = &AdminFormValidationView{
+				HasMin: value.GetHasMin(), Min: value.GetMin(), HasMax: value.GetHasMax(), Max: value.GetMax(),
+				Pattern: value.GetPattern(), MinLength: value.GetMinLength(), MaxLength: value.GetMaxLength(),
+			}
+		}
+		fields = append(fields, AdminFormFieldView{
+			Key: field.GetKey(), Label: field.GetLabel(), Description: field.GetDescription(),
+			Control:     strings.TrimPrefix(field.GetControl().String(), "ADMIN_FORM_CONTROL_"),
+			Placeholder: field.GetPlaceholder(), Required: field.GetRequired(), Secret: field.GetSecret(),
+			Multiline: field.GetMultiline(), DefaultValue: defaultValue, Options: options, Rows: field.GetRows(),
+			DynamicOptions: field.GetDynamicOptions(), ShowWhen: adminFormConditionViews(field.GetShowWhen()),
+			Validation: validation, ExclusiveGroupField: field.GetExclusiveGroupField(),
+		})
+	}
+	sections := make([]AdminFormSectionView, 0, len(form.GetSections()))
+	for _, section := range form.GetSections() {
+		if section == nil {
+			continue
+		}
+		sections = append(sections, AdminFormSectionView{
+			Key: section.GetKey(), Title: section.GetTitle(), Description: section.GetDescription(),
+			Collapsible: section.GetCollapsible(), CollapsedDefault: section.GetCollapsedDefault(),
+			FieldKeys: append([]string(nil), section.GetFieldKeys()...), ShowWhen: adminFormConditionViews(section.GetShowWhen()),
+		})
+	}
+	return &AdminFormView{Fields: fields, SubmitLabel: form.GetSubmitLabel(), Sections: sections}
+}
+
+func adminFormConditionViews(conditions []*pluginv1.AdminFormCondition) []AdminFormConditionView {
+	views := make([]AdminFormConditionView, 0, len(conditions))
+	for _, condition := range conditions {
+		if condition != nil {
+			views = append(views, AdminFormConditionView{Field: condition.GetField(), Equals: append([]string(nil), condition.GetEquals()...)})
+		}
+	}
+	return views
+}

--- a/internal/plugins/config_secrets.go
+++ b/internal/plugins/config_secrets.go
@@ -16,9 +16,16 @@ func GlobalConfigFieldSets(
 	manifest *pluginv1.PluginManifest,
 	configKey string,
 ) (publicFields, secretFields []string) {
+	return ConfigSchemaFieldSets(globalConfigSchema(manifest, configKey))
+}
+
+// ConfigSchemaFieldSets returns the top-level public and secret fields for one
+// configuration schema. JSON Schema annotations and Admin form controls are
+// both authoritative; undeclared fields are intentionally absent from both
+// sets so callers can keep them on the protected path.
+func ConfigSchemaFieldSets(schema *pluginv1.ConfigSchema) (publicFields, secretFields []string) {
 	declared := make(map[string]struct{})
 	secrets := make(map[string]struct{})
-	schema := globalConfigSchema(manifest, configKey)
 	if schema != nil {
 		if form := schema.GetAdminForm(); form != nil {
 			for _, field := range form.GetFields() {

--- a/internal/plugins/watch_sync_config_test.go
+++ b/internal/plugins/watch_sync_config_test.go
@@ -23,6 +23,11 @@ func TestWatchSyncProviderConfigClassifiesManifestFields(t *testing.T) {
 			"   ":           "ignored-empty-field",
 		},
 	}, {
+		Key: "legacy",
+		Value: map[string]any{
+			"base_url": "https://legacy-floppy.example",
+		},
+	}, {
 		Key: "   ",
 		Value: map[string]any{
 			"base_url": "ignored-empty-key",
@@ -33,7 +38,8 @@ func TestWatchSyncProviderConfigClassifiesManifestFields(t *testing.T) {
 	}
 	if config.GetValues()["provider.base_url"] != "https://floppy.example" ||
 		config.GetSecretValues()["provider.client_secret"] != "secret" ||
-		config.GetSecretValues()["provider.undeclared"] != `{"token":"also-secret"}` {
+		config.GetSecretValues()["provider.undeclared"] != `{"token":"also-secret"}` ||
+		config.GetSecretValues()["legacy.base_url"] != "https://legacy-floppy.example" {
 		t.Fatalf("config = %#v", config)
 	}
 	if _, exposed := config.GetValues()["provider.undeclared"]; exposed {

--- a/internal/watchsync/plugin_provider.go
+++ b/internal/watchsync/plugin_provider.go
@@ -86,6 +86,9 @@ func NewPluginProvider(options PluginProviderOptions) (*PluginProvider, error) {
 	if err != nil {
 		return nil, fmt.Errorf("watch sync plugin %q %w", options.ProviderKey, err)
 	}
+	if err := validateWatchSyncConnectionConfigSchemas(options.ConnectionConfigSchema); err != nil {
+		return nil, fmt.Errorf("watch sync plugin %q %w", options.ProviderKey, err)
+	}
 	if options.ResolveClient == nil {
 		return nil, fmt.Errorf("watch sync plugin client resolver is required")
 	}
@@ -172,7 +175,7 @@ func (p *PluginProvider) ConnectWithAPIKeyConfig(
 	if err != nil {
 		return TokenSet{}, ProviderAccount{}, err
 	}
-	connectionValues, err := p.connectionConfig(connectionConfig)
+	connectionValues, connectionSecrets, err := p.connectionConfig(connectionConfig)
 	if err != nil {
 		return TokenSet{}, ProviderAccount{}, err
 	}
@@ -189,7 +192,8 @@ func (p *PluginProvider) ConnectWithAPIKeyConfig(
 	if err != nil {
 		return TokenSet{}, ProviderAccount{}, watchSyncRPCError()
 	}
-	if err := watchSyncFaultError(p.Key(), response.GetFault(), apiKey); err != nil {
+	faultSecrets := append([]string{apiKey}, connectionSecrets...)
+	if err := watchSyncFaultError(p.Key(), response.GetFault(), faultSecrets...); err != nil {
 		return TokenSet{}, ProviderAccount{}, err
 	}
 	tokens, err := tokenSetFromProto(response.GetCredentials())
@@ -556,7 +560,7 @@ func (p *PluginProvider) providerConfig(ctx context.Context) (*pluginv1.WatchSyn
 	return config, nil
 }
 
-func (p *PluginProvider) connectionConfig(values ConnectionConfigValues) (*pluginv1.WatchSyncProviderConfig, error) {
+func (p *PluginProvider) connectionConfig(values ConnectionConfigValues) (*pluginv1.WatchSyncProviderConfig, []string, error) {
 	declared := make(map[string]*pluginv1.ConfigSchema, len(p.connectionConfigSchema))
 	for _, schema := range p.connectionConfigSchema {
 		if schema != nil && strings.TrimSpace(schema.GetKey()) != "" {
@@ -565,7 +569,7 @@ func (p *PluginProvider) connectionConfig(values ConnectionConfigValues) (*plugi
 	}
 	for key := range values {
 		if _, ok := declared[key]; !ok {
-			return nil, fmt.Errorf("watch sync connection config key %q is not declared", key)
+			return nil, nil, fmt.Errorf("watch sync connection config key %q is not declared", key)
 		}
 	}
 
@@ -573,6 +577,7 @@ func (p *PluginProvider) connectionConfig(values ConnectionConfigValues) (*plugi
 		Values:       make(map[string]string),
 		SecretValues: make(map[string]string),
 	}
+	var secrets []string
 	for _, schema := range p.connectionConfigSchema {
 		if schema == nil || strings.TrimSpace(schema.GetKey()) == "" {
 			continue
@@ -580,20 +585,17 @@ func (p *PluginProvider) connectionConfig(values ConnectionConfigValues) (*plugi
 		value, exists := values[schema.GetKey()]
 		if !exists {
 			if schema.GetRequired() {
-				return nil, fmt.Errorf("watch sync connection config %q is required", schema.GetKey())
+				return nil, nil, fmt.Errorf("watch sync connection config %q is required", schema.GetKey())
 			}
 			continue
 		}
 		if err := publicconfig.ValidateValue(schema, "watch sync connection config", schema.GetKey(), value); err != nil {
-			return nil, err
+			return nil, nil, err
 		}
-		publicFields := make(map[string]struct{})
-		if form := schema.GetAdminForm(); form != nil {
-			for _, field := range form.GetFields() {
-				if field != nil && !field.GetSecret() && field.GetControl() != pluginv1.AdminFormControl_ADMIN_FORM_CONTROL_PASSWORD {
-					publicFields[field.GetKey()] = struct{}{}
-				}
-			}
+		publicFieldNames, _ := hostplugins.ConfigSchemaFieldSets(schema)
+		publicFields := make(map[string]struct{}, len(publicFieldNames))
+		for _, field := range publicFieldNames {
+			publicFields[field] = struct{}{}
 		}
 		for field, raw := range value {
 			field = strings.TrimSpace(field)
@@ -602,17 +604,61 @@ func (p *PluginProvider) connectionConfig(values ConnectionConfigValues) (*plugi
 			}
 			encoded, err := connectionConfigString(raw)
 			if err != nil {
-				return nil, fmt.Errorf("encode watch sync connection config %q.%s: %w", schema.GetKey(), field, err)
+				return nil, nil, fmt.Errorf("encode watch sync connection config %q.%s: %w", schema.GetKey(), field, err)
 			}
 			key := schema.GetKey() + "." + field
 			if _, public := publicFields[field]; public {
 				result.Values[key] = encoded
 			} else {
 				result.SecretValues[key] = encoded
+				secrets = append(secrets, encoded)
+				secrets = append(secrets, connectionConfigSecretStrings(raw)...)
 			}
 		}
 	}
-	return result, nil
+	return result, secrets, nil
+}
+
+func connectionConfigSecretStrings(value any) []string {
+	switch typed := value.(type) {
+	case map[string]any:
+		var values []string
+		for _, child := range typed {
+			values = append(values, connectionConfigSecretStrings(child)...)
+		}
+		return values
+	case []any:
+		var values []string
+		for _, child := range typed {
+			values = append(values, connectionConfigSecretStrings(child)...)
+		}
+		return values
+	default:
+		encoded, err := connectionConfigString(typed)
+		if err != nil || strings.TrimSpace(encoded) == "" {
+			return nil
+		}
+		return []string{encoded}
+	}
+}
+
+func validateWatchSyncConnectionConfigSchemas(schemas []*pluginv1.ConfigSchema) error {
+	for _, schema := range schemas {
+		if schema == nil || schema.GetAdminForm() == nil {
+			continue
+		}
+		for _, field := range schema.GetAdminForm().GetFields() {
+			if field == nil || !field.GetDynamicOptions() || len(field.GetOptions()) > 0 {
+				continue
+			}
+			return fmt.Errorf(
+				"connection config %q field %q requires dynamic options, which watch provider setup does not support",
+				schema.GetKey(),
+				field.GetKey(),
+			)
+		}
+	}
+	return nil
 }
 
 func connectionConfigString(value any) (string, error) {

--- a/internal/watchsync/plugin_provider.go
+++ b/internal/watchsync/plugin_provider.go
@@ -761,6 +761,7 @@ func watchEventFromScrobble(event ScrobbleEvent, operation pluginv1.WatchSyncOpe
 		PositionSeconds:   event.PositionSeconds,
 		DurationSeconds:   event.DurationSeconds,
 		CompletionPercent: completion,
+		Completed:         event.Completed,
 		ProviderItemKey:   event.ProviderItemKey,
 		Media: mediaFromIdentity(event.MediaItemID, event.Kind, "", 0,
 			event.IMDbID, event.TMDBID, event.TVDBID, "", 0,

--- a/internal/watchsync/plugin_provider.go
+++ b/internal/watchsync/plugin_provider.go
@@ -89,6 +89,9 @@ func NewPluginProvider(options PluginProviderOptions) (*PluginProvider, error) {
 	if err := validateWatchSyncConnectionConfigSchemas(options.ConnectionConfigSchema); err != nil {
 		return nil, fmt.Errorf("watch sync plugin %q %w", options.ProviderKey, err)
 	}
+	if authMethod != AuthMethodAPIKey && hasWatchSyncConnectionConfigSchema(options.ConnectionConfigSchema) {
+		return nil, fmt.Errorf("watch sync plugin %q connection config requires API-key authentication", options.ProviderKey)
+	}
 	if options.ResolveClient == nil {
 		return nil, fmt.Errorf("watch sync plugin client resolver is required")
 	}
@@ -105,6 +108,15 @@ func NewPluginProvider(options PluginProviderOptions) (*PluginProvider, error) {
 		resolveConfig:          options.ResolveConfig,
 		repository:             options.Repository,
 	}, nil
+}
+
+func hasWatchSyncConnectionConfigSchema(schemas []*pluginv1.ConfigSchema) bool {
+	for _, schema := range schemas {
+		if schema != nil {
+			return true
+		}
+	}
+	return false
 }
 
 func (p *PluginProvider) Key() string { return p.providerKey }

--- a/internal/watchsync/plugin_provider.go
+++ b/internal/watchsync/plugin_provider.go
@@ -3,6 +3,7 @@ package watchsync
 import (
 	"context"
 	"encoding/base64"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"net/url"
@@ -11,7 +12,9 @@ import (
 	"unicode"
 
 	pluginv1 "github.com/Silo-Server/silo-plugin-sdk/pkg/pluginproto/silo/plugin/v1"
+	publicconfig "github.com/Silo-Server/silo-plugin-sdk/pkg/pluginsdk/config"
 	"github.com/Silo-Server/silo-server/internal/historyimport"
+	hostplugins "github.com/Silo-Server/silo-server/internal/plugins"
 	"github.com/Silo-Server/silo-server/internal/userstore"
 	"google.golang.org/protobuf/types/known/timestamppb"
 )
@@ -34,27 +37,29 @@ type PluginCredentialRepository interface {
 }
 
 type PluginProviderOptions struct {
-	InstallationID int
-	ProviderKey    string
-	CapabilityID   string
-	DisplayName    string
-	Descriptor     *pluginv1.WatchSyncProviderDescriptor
-	ResolveClient  WatchSyncPluginClientResolver
-	ResolveConfig  WatchSyncPluginConfigResolver
-	Repository     PluginCredentialRepository
+	InstallationID         int
+	ProviderKey            string
+	CapabilityID           string
+	DisplayName            string
+	Descriptor             *pluginv1.WatchSyncProviderDescriptor
+	ConnectionConfigSchema []*pluginv1.ConfigSchema
+	ResolveClient          WatchSyncPluginClientResolver
+	ResolveConfig          WatchSyncPluginConfigResolver
+	Repository             PluginCredentialRepository
 }
 
 type PluginProvider struct {
-	installationID int
-	providerKey    string
-	capabilityID   string
-	displayName    string
-	descriptor     *pluginv1.WatchSyncProviderDescriptor
-	authMethod     string
-	supportedMedia map[pluginv1.WatchSyncMediaType]struct{}
-	resolveClient  WatchSyncPluginClientResolver
-	resolveConfig  WatchSyncPluginConfigResolver
-	repository     PluginCredentialRepository
+	installationID         int
+	providerKey            string
+	capabilityID           string
+	displayName            string
+	descriptor             *pluginv1.WatchSyncProviderDescriptor
+	connectionConfigSchema []*pluginv1.ConfigSchema
+	authMethod             string
+	supportedMedia         map[pluginv1.WatchSyncMediaType]struct{}
+	resolveClient          WatchSyncPluginClientResolver
+	resolveConfig          WatchSyncPluginConfigResolver
+	repository             PluginCredentialRepository
 }
 
 const (
@@ -85,16 +90,17 @@ func NewPluginProvider(options PluginProviderOptions) (*PluginProvider, error) {
 		return nil, fmt.Errorf("watch sync plugin client resolver is required")
 	}
 	return &PluginProvider{
-		installationID: options.InstallationID,
-		providerKey:    options.ProviderKey,
-		capabilityID:   options.CapabilityID,
-		displayName:    options.DisplayName,
-		descriptor:     options.Descriptor,
-		authMethod:     authMethod,
-		supportedMedia: supportedMedia,
-		resolveClient:  options.ResolveClient,
-		resolveConfig:  options.ResolveConfig,
-		repository:     options.Repository,
+		installationID:         options.InstallationID,
+		providerKey:            options.ProviderKey,
+		capabilityID:           options.CapabilityID,
+		displayName:            options.DisplayName,
+		descriptor:             options.Descriptor,
+		connectionConfigSchema: append([]*pluginv1.ConfigSchema(nil), options.ConnectionConfigSchema...),
+		authMethod:             authMethod,
+		supportedMedia:         supportedMedia,
+		resolveClient:          options.ResolveClient,
+		resolveConfig:          options.ResolveConfig,
+		repository:             options.Repository,
 	}, nil
 }
 
@@ -117,6 +123,10 @@ func (p *PluginProvider) HistorySource() userstore.WatchHistorySource {
 }
 
 func (p *PluginProvider) AuthMethod() string { return p.authMethod }
+
+func (p *PluginProvider) ConnectionConfigSchema() []hostplugins.ConfigSchemaView {
+	return hostplugins.ConfigSchemaViews(p.connectionConfigSchema)
+}
 
 func (p *PluginProvider) usesHostPluginConfig() {}
 
@@ -147,6 +157,14 @@ func (p *PluginProvider) Capabilities() Capabilities {
 }
 
 func (p *PluginProvider) ConnectWithAPIKey(ctx context.Context, apiKey string) (TokenSet, ProviderAccount, error) {
+	return p.ConnectWithAPIKeyConfig(ctx, apiKey, nil)
+}
+
+func (p *PluginProvider) ConnectWithAPIKeyConfig(
+	ctx context.Context,
+	apiKey string,
+	connectionConfig ConnectionConfigValues,
+) (TokenSet, ProviderAccount, error) {
 	if p.authMethod != AuthMethodAPIKey {
 		return TokenSet{}, ProviderAccount{}, errors.New("watch sync plugin does not support API-key authentication")
 	}
@@ -154,6 +172,11 @@ func (p *PluginProvider) ConnectWithAPIKey(ctx context.Context, apiKey string) (
 	if err != nil {
 		return TokenSet{}, ProviderAccount{}, err
 	}
+	connectionValues, err := p.connectionConfig(connectionConfig)
+	if err != nil {
+		return TokenSet{}, ProviderAccount{}, err
+	}
+	config = mergeWatchSyncProviderConfig(config, connectionValues)
 	client, err := p.resolveClient(ctx, p.installationID, p.capabilityID)
 	if err != nil {
 		return TokenSet{}, ProviderAccount{}, watchSyncUnavailableError()
@@ -531,6 +554,99 @@ func (p *PluginProvider) providerConfig(ctx context.Context) (*pluginv1.WatchSyn
 		config = &pluginv1.WatchSyncProviderConfig{}
 	}
 	return config, nil
+}
+
+func (p *PluginProvider) connectionConfig(values ConnectionConfigValues) (*pluginv1.WatchSyncProviderConfig, error) {
+	declared := make(map[string]*pluginv1.ConfigSchema, len(p.connectionConfigSchema))
+	for _, schema := range p.connectionConfigSchema {
+		if schema != nil && strings.TrimSpace(schema.GetKey()) != "" {
+			declared[schema.GetKey()] = schema
+		}
+	}
+	for key := range values {
+		if _, ok := declared[key]; !ok {
+			return nil, fmt.Errorf("watch sync connection config key %q is not declared", key)
+		}
+	}
+
+	result := &pluginv1.WatchSyncProviderConfig{
+		Values:       make(map[string]string),
+		SecretValues: make(map[string]string),
+	}
+	for _, schema := range p.connectionConfigSchema {
+		if schema == nil || strings.TrimSpace(schema.GetKey()) == "" {
+			continue
+		}
+		value, exists := values[schema.GetKey()]
+		if !exists {
+			if schema.GetRequired() {
+				return nil, fmt.Errorf("watch sync connection config %q is required", schema.GetKey())
+			}
+			continue
+		}
+		if err := publicconfig.ValidateValue(schema, "watch sync connection config", schema.GetKey(), value); err != nil {
+			return nil, err
+		}
+		publicFields := make(map[string]struct{})
+		if form := schema.GetAdminForm(); form != nil {
+			for _, field := range form.GetFields() {
+				if field != nil && !field.GetSecret() && field.GetControl() != pluginv1.AdminFormControl_ADMIN_FORM_CONTROL_PASSWORD {
+					publicFields[field.GetKey()] = struct{}{}
+				}
+			}
+		}
+		for field, raw := range value {
+			field = strings.TrimSpace(field)
+			if field == "" {
+				continue
+			}
+			encoded, err := connectionConfigString(raw)
+			if err != nil {
+				return nil, fmt.Errorf("encode watch sync connection config %q.%s: %w", schema.GetKey(), field, err)
+			}
+			key := schema.GetKey() + "." + field
+			if _, public := publicFields[field]; public {
+				result.Values[key] = encoded
+			} else {
+				result.SecretValues[key] = encoded
+			}
+		}
+	}
+	return result, nil
+}
+
+func connectionConfigString(value any) (string, error) {
+	if text, ok := value.(string); ok {
+		return text, nil
+	}
+	encoded, err := json.Marshal(value)
+	if err != nil {
+		return "", err
+	}
+	return string(encoded), nil
+}
+
+func mergeWatchSyncProviderConfig(base, connection *pluginv1.WatchSyncProviderConfig) *pluginv1.WatchSyncProviderConfig {
+	merged := &pluginv1.WatchSyncProviderConfig{Values: map[string]string{}, SecretValues: map[string]string{}}
+	if base != nil {
+		for key, value := range base.GetValues() {
+			merged.Values[key] = value
+		}
+		for key, value := range base.GetSecretValues() {
+			merged.SecretValues[key] = value
+		}
+	}
+	if connection != nil {
+		for key, value := range connection.GetValues() {
+			delete(merged.SecretValues, key)
+			merged.Values[key] = value
+		}
+		for key, value := range connection.GetSecretValues() {
+			delete(merged.Values, key)
+			merged.SecretValues[key] = value
+		}
+	}
+	return merged
 }
 
 func (p *PluginProvider) persistUpdatedCredentials(

--- a/internal/watchsync/plugin_provider.go
+++ b/internal/watchsync/plugin_provider.go
@@ -70,6 +70,7 @@ const (
 	watchSyncUnsupportedEpisodeMediaMessage = "watch sync plugin does not support episode media"
 	watchSyncUnsupportedMediaMessage        = "watch sync plugin does not support this media type"
 	watchSyncJSONSchemaNumberType           = "number"
+	watchSyncJSONSchemaBooleanType          = "boolean"
 )
 
 func NewPluginProvider(options PluginProviderOptions) (*PluginProvider, error) {
@@ -597,6 +598,7 @@ func (p *PluginProvider) connectionConfig(values ConnectionConfigValues) (*plugi
 		Values:       make(map[string]string),
 		SecretValues: make(map[string]string),
 	}
+	flattenedFields := make(map[string]string)
 	for _, schema := range p.connectionConfigSchema {
 		if schema == nil || strings.TrimSpace(schema.GetKey()) == "" {
 			continue
@@ -620,6 +622,7 @@ func (p *PluginProvider) connectionConfig(values ConnectionConfigValues) (*plugi
 			publicFields[field] = struct{}{}
 		}
 		for field, raw := range value {
+			rawField := field
 			field = strings.TrimSpace(field)
 			if field == "" {
 				continue
@@ -632,6 +635,14 @@ func (p *PluginProvider) connectionConfig(values ConnectionConfigValues) (*plugi
 				)
 			}
 			key := schema.GetKey() + "." + field
+			source := fmt.Sprintf("config %q field %q", schema.GetKey(), rawField)
+			if previous, exists := flattenedFields[key]; exists {
+				return nil, nil, sanitizedConnectionConfigError(
+					fmt.Errorf("watch sync connection %s conflicts with %s after flattening to %q", source, previous, key),
+					secrets,
+				)
+			}
+			flattenedFields[key] = source
 			if _, public := publicFields[field]; public {
 				result.Values[key] = encoded
 			} else {
@@ -730,6 +741,17 @@ func validateWatchSyncConnectionConfigSchemas(schemas []*pluginv1.ConfigSchema) 
 					field.GetKey(),
 				)
 			}
+			if field.GetControl() == pluginv1.AdminFormControl_ADMIN_FORM_CONTROL_SELECT {
+				for _, option := range field.GetOptions() {
+					if option != nil && strings.TrimSpace(option.GetValue()) == "" {
+						return fmt.Errorf(
+							"connection config %q field %q has a blank select option value",
+							schema.GetKey(),
+							field.GetKey(),
+						)
+					}
+				}
+			}
 			if pattern := field.GetValidation().GetPattern(); pattern != "" {
 				if _, err := regexp.Compile(pattern); err != nil {
 					return fmt.Errorf(
@@ -778,12 +800,21 @@ func validateConnectionSchemaIsRenderable(schema *pluginv1.ConfigSchema) error {
 	for key, property := range document.Properties {
 		field := explicit[key]
 		switch property.Type {
-		case "string", watchSyncJSONSchemaNumberType, "integer", "boolean":
+		case "string", watchSyncJSONSchemaNumberType, "integer", watchSyncJSONSchemaBooleanType:
+			if field != nil && !connectionAdminFieldSupportsScalarType(field, property.Type) {
+				return fmt.Errorf(
+					"connection config %q field %q control %q cannot emit json_schema type %q",
+					schema.GetKey(),
+					key,
+					field.GetControl().String(),
+					property.Type,
+				)
+			}
 			continue
 		case "array":
 			if field != nil && field.GetControl() == pluginv1.AdminFormControl_ADMIN_FORM_CONTROL_MULTI_SELECT &&
 				(property.Items == nil || property.Items.Type == "string" || property.Items.Type == watchSyncJSONSchemaNumberType ||
-					property.Items.Type == "integer" || property.Items.Type == "boolean") {
+					property.Items.Type == "integer" || property.Items.Type == watchSyncJSONSchemaBooleanType) {
 				continue
 			}
 		default:
@@ -803,6 +834,17 @@ func validateConnectionSchemaIsRenderable(schema *pluginv1.ConfigSchema) error {
 		)
 	}
 	return nil
+}
+
+func connectionAdminFieldSupportsScalarType(field *pluginv1.AdminFormField, propertyType string) bool {
+	switch field.GetControl() {
+	case pluginv1.AdminFormControl_ADMIN_FORM_CONTROL_SWITCH:
+		return propertyType == watchSyncJSONSchemaBooleanType
+	case pluginv1.AdminFormControl_ADMIN_FORM_CONTROL_MULTI_SELECT:
+		return false
+	default:
+		return true
+	}
 }
 
 func connectionAdminFieldRendersValue(field *pluginv1.AdminFormField) bool {
@@ -828,11 +870,17 @@ func validateConnectionAdminFormValue(schema *pluginv1.ConfigSchema, value map[s
 		return nil
 	}
 	for _, field := range schema.GetAdminForm().GetFields() {
-		if field == nil || field.GetValidation() == nil {
+		if field == nil || !connectionAdminFieldIsVisible(schema.GetAdminForm(), field, value) {
 			continue
 		}
 		raw, exists := value[field.GetKey()]
-		if !exists || raw == nil {
+		if !exists || connectionConfigValueIsEmpty(raw) {
+			if field.GetRequired() {
+				return fmt.Errorf("connection config %q field %q is required", schema.GetKey(), field.GetKey())
+			}
+			continue
+		}
+		if field.GetValidation() == nil {
 			continue
 		}
 		validation := field.GetValidation()
@@ -864,6 +912,89 @@ func validateConnectionAdminFormValue(schema *pluginv1.ConfigSchema, value map[s
 		}
 	}
 	return nil
+}
+
+func connectionConfigValueIsEmpty(value any) bool {
+	switch typed := value.(type) {
+	case nil:
+		return true
+	case string:
+		return strings.TrimSpace(typed) == ""
+	case []any:
+		return len(typed) == 0
+	default:
+		return false
+	}
+}
+
+func connectionAdminFieldIsVisible(
+	form *pluginv1.AdminFormDescriptor,
+	field *pluginv1.AdminFormField,
+	values map[string]any,
+) bool {
+	if !connectionAdminConditionsMatch(field.GetShowWhen(), values, form.GetFields()) {
+		return false
+	}
+	contained := false
+	for _, section := range form.GetSections() {
+		if section == nil || !stringSliceContains(section.GetFieldKeys(), field.GetKey()) {
+			continue
+		}
+		contained = true
+		if connectionAdminConditionsMatch(section.GetShowWhen(), values, form.GetFields()) {
+			return true
+		}
+	}
+	return !contained
+}
+
+func connectionAdminConditionsMatch(
+	conditions []*pluginv1.AdminFormCondition,
+	values map[string]any,
+	fields []*pluginv1.AdminFormField,
+) bool {
+	for _, condition := range conditions {
+		if condition == nil {
+			continue
+		}
+		value, exists := values[condition.GetField()]
+		if !exists {
+			for _, field := range fields {
+				if field != nil && field.GetKey() == condition.GetField() && field.GetDefaultValue() != nil {
+					value = field.GetDefaultValue().AsInterface()
+					break
+				}
+			}
+		}
+		if !stringSliceContains(condition.GetEquals(), connectionAdminConditionString(value)) {
+			return false
+		}
+	}
+	return true
+}
+
+func connectionAdminConditionString(value any) string {
+	switch typed := value.(type) {
+	case nil:
+		return ""
+	case bool:
+		return strconv.FormatBool(typed)
+	case float64:
+		return strconv.FormatFloat(typed, 'f', -1, 64)
+	case string:
+		return typed
+	default:
+		return fmt.Sprint(typed)
+	}
+}
+
+func stringSliceContains(values []string, target string) bool {
+	for _, value := range values {
+		if value == target {
+			return true
+		}
+	}
+	return false
 }
 
 func connectionConfigNumber(value any) (float64, bool) {

--- a/internal/watchsync/plugin_provider.go
+++ b/internal/watchsync/plugin_provider.go
@@ -650,6 +650,13 @@ func (p *PluginProvider) connectionConfig(values ConnectionConfigValues) (*plugi
 			}
 		}
 	}
+	// Fields the schema never declared are classified as secret above, so redact
+	// every flattened secret rather than only the declared ones.
+	for _, encoded := range result.SecretValues {
+		if strings.TrimSpace(encoded) != "" {
+			secrets = append(secrets, encoded)
+		}
+	}
 	return result, secrets, nil
 }
 

--- a/internal/watchsync/plugin_provider.go
+++ b/internal/watchsync/plugin_provider.go
@@ -7,9 +7,11 @@ import (
 	"errors"
 	"fmt"
 	"net/url"
+	"regexp"
 	"strings"
 	"time"
 	"unicode"
+	"unicode/utf8"
 
 	pluginv1 "github.com/Silo-Server/silo-plugin-sdk/pkg/pluginproto/silo/plugin/v1"
 	publicconfig "github.com/Silo-Server/silo-plugin-sdk/pkg/pluginsdk/config"
@@ -66,6 +68,7 @@ const (
 	watchSyncUnsupportedMovieMediaMessage   = "watch sync plugin does not support movie media"
 	watchSyncUnsupportedEpisodeMediaMessage = "watch sync plugin does not support episode media"
 	watchSyncUnsupportedMediaMessage        = "watch sync plugin does not support this media type"
+	watchSyncJSONSchemaNumberType           = "number"
 )
 
 func NewPluginProvider(options PluginProviderOptions) (*PluginProvider, error) {
@@ -579,9 +582,13 @@ func (p *PluginProvider) connectionConfig(values ConnectionConfigValues) (*plugi
 			declared[schema.GetKey()] = schema
 		}
 	}
+	secrets := connectionConfigSecrets(p.connectionConfigSchema, values)
 	for key := range values {
 		if _, ok := declared[key]; !ok {
-			return nil, nil, fmt.Errorf("watch sync connection config key %q is not declared", key)
+			return nil, nil, sanitizedConnectionConfigError(
+				fmt.Errorf("watch sync connection config key %q is not declared", key),
+				secrets,
+			)
 		}
 	}
 
@@ -589,7 +596,6 @@ func (p *PluginProvider) connectionConfig(values ConnectionConfigValues) (*plugi
 		Values:       make(map[string]string),
 		SecretValues: make(map[string]string),
 	}
-	var secrets []string
 	for _, schema := range p.connectionConfigSchema {
 		if schema == nil || strings.TrimSpace(schema.GetKey()) == "" {
 			continue
@@ -602,7 +608,10 @@ func (p *PluginProvider) connectionConfig(values ConnectionConfigValues) (*plugi
 			continue
 		}
 		if err := publicconfig.ValidateValue(schema, "watch sync connection config", schema.GetKey(), value); err != nil {
-			return nil, nil, err
+			return nil, nil, sanitizedConnectionConfigError(err, secrets)
+		}
+		if err := validateConnectionAdminFormValue(schema, value); err != nil {
+			return nil, nil, sanitizedConnectionConfigError(err, secrets)
 		}
 		publicFieldNames, _ := hostplugins.ConfigSchemaFieldSets(schema)
 		publicFields := make(map[string]struct{}, len(publicFieldNames))
@@ -616,19 +625,53 @@ func (p *PluginProvider) connectionConfig(values ConnectionConfigValues) (*plugi
 			}
 			encoded, err := connectionConfigString(raw)
 			if err != nil {
-				return nil, nil, fmt.Errorf("encode watch sync connection config %q.%s: %w", schema.GetKey(), field, err)
+				return nil, nil, sanitizedConnectionConfigError(
+					fmt.Errorf("encode watch sync connection config %q.%s: %w", schema.GetKey(), field, err),
+					secrets,
+				)
 			}
 			key := schema.GetKey() + "." + field
 			if _, public := publicFields[field]; public {
 				result.Values[key] = encoded
 			} else {
 				result.SecretValues[key] = encoded
-				secrets = append(secrets, encoded)
-				secrets = append(secrets, connectionConfigSecretStrings(raw)...)
 			}
 		}
 	}
 	return result, secrets, nil
+}
+
+func connectionConfigSecrets(schemas []*pluginv1.ConfigSchema, values ConnectionConfigValues) []string {
+	var secrets []string
+	for _, schema := range schemas {
+		if schema == nil {
+			continue
+		}
+		value, exists := values[schema.GetKey()]
+		if !exists {
+			continue
+		}
+		_, secretFields := hostplugins.ConfigSchemaFieldSets(schema)
+		for _, field := range secretFields {
+			raw, exists := value[field]
+			if !exists {
+				continue
+			}
+			if encoded, err := connectionConfigString(raw); err == nil && strings.TrimSpace(encoded) != "" {
+				secrets = append(secrets, encoded)
+			}
+			secrets = append(secrets, connectionConfigSecretStrings(raw)...)
+		}
+	}
+	return secrets
+}
+
+func sanitizedConnectionConfigError(err error, secrets []string) error {
+	return errors.New(sanitizeWatchSyncMessage(
+		err.Error(),
+		"watch sync connection config is invalid",
+		secrets...,
+	))
 }
 
 func connectionConfigSecretStrings(value any) []string {
@@ -655,22 +698,179 @@ func connectionConfigSecretStrings(value any) []string {
 }
 
 func validateWatchSyncConnectionConfigSchemas(schemas []*pluginv1.ConfigSchema) error {
+	seen := make(map[string]struct{}, len(schemas))
 	for _, schema := range schemas {
-		if schema == nil || schema.GetAdminForm() == nil {
+		if schema == nil {
+			continue
+		}
+		key := strings.TrimSpace(schema.GetKey())
+		if _, exists := seen[key]; exists {
+			return fmt.Errorf("connection config key %q is duplicated", key)
+		}
+		seen[key] = struct{}{}
+		if schema.GetRequired() {
+			if err := validateRequiredConnectionSchemaIsRenderable(schema); err != nil {
+				return err
+			}
+		}
+		if schema.GetAdminForm() == nil {
 			continue
 		}
 		for _, field := range schema.GetAdminForm().GetFields() {
-			if field == nil || !field.GetDynamicOptions() || len(field.GetOptions()) > 0 {
+			if field == nil {
 				continue
 			}
-			return fmt.Errorf(
-				"connection config %q field %q requires dynamic options, which watch provider setup does not support",
-				schema.GetKey(),
-				field.GetKey(),
-			)
+			if strings.TrimSpace(field.GetExclusiveGroupField()) != "" {
+				return fmt.Errorf(
+					"connection config %q field %q uses exclusive_group_field, which watch provider setup does not support",
+					schema.GetKey(),
+					field.GetKey(),
+				)
+			}
+			if field.GetDynamicOptions() && len(field.GetOptions()) == 0 {
+				return fmt.Errorf(
+					"connection config %q field %q requires dynamic options, which watch provider setup does not support",
+					schema.GetKey(),
+					field.GetKey(),
+				)
+			}
+			if pattern := field.GetValidation().GetPattern(); pattern != "" {
+				if _, err := regexp.Compile(pattern); err != nil {
+					return fmt.Errorf(
+						"connection config %q field %q has invalid validation pattern: %w",
+						schema.GetKey(),
+						field.GetKey(),
+						err,
+					)
+				}
+			}
 		}
 	}
 	return nil
+}
+
+func validateRequiredConnectionSchemaIsRenderable(schema *pluginv1.ConfigSchema) error {
+	var document struct {
+		Type       string `json:"type"`
+		Properties map[string]struct {
+			Type  string `json:"type"`
+			Items *struct {
+				Type string `json:"type"`
+			} `json:"items"`
+		} `json:"properties"`
+	}
+	if err := json.Unmarshal([]byte(schema.GetJsonSchema()), &document); err != nil {
+		return fmt.Errorf("connection config %q has invalid json_schema: %w", schema.GetKey(), err)
+	}
+	if document.Type != "object" || document.Properties == nil {
+		return fmt.Errorf("required connection config %q must have a renderable object json_schema", schema.GetKey())
+	}
+	explicit := make(map[string]*pluginv1.AdminFormField)
+	if form := schema.GetAdminForm(); form != nil {
+		for _, field := range form.GetFields() {
+			if field != nil {
+				explicit[field.GetKey()] = field
+			}
+		}
+	}
+	for key, property := range document.Properties {
+		switch property.Type {
+		case "string", watchSyncJSONSchemaNumberType, "integer", "boolean":
+			continue
+		case "array":
+			field := explicit[key]
+			if field != nil && field.GetControl() == pluginv1.AdminFormControl_ADMIN_FORM_CONTROL_MULTI_SELECT &&
+				(property.Items == nil || property.Items.Type == "string" || property.Items.Type == watchSyncJSONSchemaNumberType ||
+					property.Items.Type == "integer" || property.Items.Type == "boolean") {
+				continue
+			}
+		default:
+		}
+		return fmt.Errorf(
+			"required connection config %q property %q needs a renderable admin_form field because type %q cannot be inferred",
+			schema.GetKey(),
+			key,
+			property.Type,
+		)
+	}
+	return nil
+}
+
+func validateConnectionAdminFormValue(schema *pluginv1.ConfigSchema, value map[string]any) error {
+	if schema == nil || schema.GetAdminForm() == nil {
+		return nil
+	}
+	for _, field := range schema.GetAdminForm().GetFields() {
+		if field == nil || field.GetValidation() == nil {
+			continue
+		}
+		raw, exists := value[field.GetKey()]
+		if !exists || raw == nil {
+			continue
+		}
+		validation := field.GetValidation()
+		if text, ok := raw.(string); ok {
+			if pattern := validation.GetPattern(); pattern != "" {
+				matched, err := regexp.MatchString(pattern, text)
+				if err != nil {
+					return fmt.Errorf("connection config %q field %q has an invalid validation pattern", schema.GetKey(), field.GetKey())
+				}
+				if !matched {
+					return fmt.Errorf("connection config %q field %q is invalid", schema.GetKey(), field.GetKey())
+				}
+			}
+			length := utf8.RuneCountInString(text)
+			if minimum := int(validation.GetMinLength()); minimum > 0 && length < minimum {
+				return fmt.Errorf("connection config %q field %q must be at least %d characters", schema.GetKey(), field.GetKey(), minimum)
+			}
+			if maximum := int(validation.GetMaxLength()); maximum > 0 && length > maximum {
+				return fmt.Errorf("connection config %q field %q must be at most %d characters", schema.GetKey(), field.GetKey(), maximum)
+			}
+		}
+		if number, ok := connectionConfigNumber(raw); ok {
+			if validation.GetHasMin() && number < validation.GetMin() {
+				return fmt.Errorf("connection config %q field %q must be at least %g", schema.GetKey(), field.GetKey(), validation.GetMin())
+			}
+			if validation.GetHasMax() && number > validation.GetMax() {
+				return fmt.Errorf("connection config %q field %q must be at most %g", schema.GetKey(), field.GetKey(), validation.GetMax())
+			}
+		}
+	}
+	return nil
+}
+
+func connectionConfigNumber(value any) (float64, bool) {
+	switch typed := value.(type) {
+	case float64:
+		return typed, true
+	case float32:
+		return float64(typed), true
+	case int:
+		return float64(typed), true
+	case int8:
+		return float64(typed), true
+	case int16:
+		return float64(typed), true
+	case int32:
+		return float64(typed), true
+	case int64:
+		return float64(typed), true
+	case uint:
+		return float64(typed), true
+	case uint8:
+		return float64(typed), true
+	case uint16:
+		return float64(typed), true
+	case uint32:
+		return float64(typed), true
+	case uint64:
+		return float64(typed), true
+	case json.Number:
+		number, err := typed.Float64()
+		return number, err == nil
+	default:
+		return 0, false
+	}
 }
 
 func connectionConfigString(value any) (string, error) {

--- a/internal/watchsync/plugin_provider.go
+++ b/internal/watchsync/plugin_provider.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"net/url"
 	"regexp"
+	"strconv"
 	"strings"
 	"time"
 	"unicode"
@@ -774,17 +775,24 @@ func validateRequiredConnectionSchemaIsRenderable(schema *pluginv1.ConfigSchema)
 		}
 	}
 	for key, property := range document.Properties {
+		field := explicit[key]
 		switch property.Type {
 		case "string", watchSyncJSONSchemaNumberType, "integer", "boolean":
 			continue
 		case "array":
-			field := explicit[key]
 			if field != nil && field.GetControl() == pluginv1.AdminFormControl_ADMIN_FORM_CONTROL_MULTI_SELECT &&
 				(property.Items == nil || property.Items.Type == "string" || property.Items.Type == watchSyncJSONSchemaNumberType ||
 					property.Items.Type == "integer" || property.Items.Type == "boolean") {
 				continue
 			}
 		default:
+			// A property whose shape comes from enum/const/$ref cannot be
+			// inferred from type alone, but an explicit scalar form control is
+			// still a complete input mechanism. Direct object properties remain
+			// unsupported because none of these controls produces an object.
+			if property.Type != "object" && connectionAdminFieldRendersValue(field) {
+				continue
+			}
 		}
 		return fmt.Errorf(
 			"required connection config %q property %q needs a renderable admin_form field because type %q cannot be inferred",
@@ -794,6 +802,24 @@ func validateRequiredConnectionSchemaIsRenderable(schema *pluginv1.ConfigSchema)
 		)
 	}
 	return nil
+}
+
+func connectionAdminFieldRendersValue(field *pluginv1.AdminFormField) bool {
+	if field == nil {
+		return false
+	}
+	switch field.GetControl() {
+	case pluginv1.AdminFormControl_ADMIN_FORM_CONTROL_TEXT,
+		pluginv1.AdminFormControl_ADMIN_FORM_CONTROL_TEXTAREA,
+		pluginv1.AdminFormControl_ADMIN_FORM_CONTROL_PASSWORD,
+		pluginv1.AdminFormControl_ADMIN_FORM_CONTROL_NUMBER,
+		pluginv1.AdminFormControl_ADMIN_FORM_CONTROL_SWITCH,
+		pluginv1.AdminFormControl_ADMIN_FORM_CONTROL_SELECT,
+		pluginv1.AdminFormControl_ADMIN_FORM_CONTROL_MULTI_SELECT:
+		return true
+	default:
+		return false
+	}
 }
 
 func validateConnectionAdminFormValue(schema *pluginv1.ConfigSchema, value map[string]any) error {
@@ -867,6 +893,9 @@ func connectionConfigNumber(value any) (float64, bool) {
 		return float64(typed), true
 	case json.Number:
 		number, err := typed.Float64()
+		return number, err == nil
+	case string:
+		number, err := strconv.ParseFloat(strings.TrimSpace(typed), 64)
 		return number, err == nil
 	default:
 		return 0, false

--- a/internal/watchsync/plugin_provider.go
+++ b/internal/watchsync/plugin_provider.go
@@ -705,18 +705,13 @@ func validateWatchSyncConnectionConfigSchemas(schemas []*pluginv1.ConfigSchema) 
 			continue
 		}
 		key := strings.TrimSpace(schema.GetKey())
+		if key == "" {
+			return fmt.Errorf("connection config key is required")
+		}
 		if _, exists := seen[key]; exists {
 			return fmt.Errorf("connection config key %q is duplicated", key)
 		}
 		seen[key] = struct{}{}
-		if schema.GetRequired() {
-			if err := validateRequiredConnectionSchemaIsRenderable(schema); err != nil {
-				return err
-			}
-		}
-		if schema.GetAdminForm() == nil {
-			continue
-		}
 		for _, field := range schema.GetAdminForm().GetFields() {
 			if field == nil {
 				continue
@@ -746,11 +741,17 @@ func validateWatchSyncConnectionConfigSchemas(schemas []*pluginv1.ConfigSchema) 
 				}
 			}
 		}
+		if err := validateConnectionSchemaIsRenderable(schema); err != nil {
+			return err
+		}
 	}
 	return nil
 }
 
-func validateRequiredConnectionSchemaIsRenderable(schema *pluginv1.ConfigSchema) error {
+func validateConnectionSchemaIsRenderable(schema *pluginv1.ConfigSchema) error {
+	if strings.TrimSpace(schema.GetJsonSchema()) == "" && !schema.GetRequired() {
+		return nil
+	}
 	var document struct {
 		Type       string `json:"type"`
 		Properties map[string]struct {
@@ -764,7 +765,7 @@ func validateRequiredConnectionSchemaIsRenderable(schema *pluginv1.ConfigSchema)
 		return fmt.Errorf("connection config %q has invalid json_schema: %w", schema.GetKey(), err)
 	}
 	if document.Type != "object" || document.Properties == nil {
-		return fmt.Errorf("required connection config %q must have a renderable object json_schema", schema.GetKey())
+		return fmt.Errorf("connection config %q must have a renderable object json_schema", schema.GetKey())
 	}
 	explicit := make(map[string]*pluginv1.AdminFormField)
 	if form := schema.GetAdminForm(); form != nil {
@@ -795,7 +796,7 @@ func validateRequiredConnectionSchemaIsRenderable(schema *pluginv1.ConfigSchema)
 			}
 		}
 		return fmt.Errorf(
-			"required connection config %q property %q needs a renderable admin_form field because type %q cannot be inferred",
+			"connection config %q property %q needs a renderable admin_form field because type %q cannot be inferred",
 			schema.GetKey(),
 			key,
 			property.Type,

--- a/internal/watchsync/plugin_provider_test.go
+++ b/internal/watchsync/plugin_provider_test.go
@@ -1016,3 +1016,29 @@ func TestPluginProviderForwardsLiveScrobbleLifecycle(t *testing.T) {
 		t.Fatalf("scrobble event = %#v", got)
 	}
 }
+
+func TestPluginProviderForwardsAuthoritativeScrobbleCompletion(t *testing.T) {
+	completed := watchEventFromScrobble(ScrobbleEvent{
+		PlaybackSessionID: testPlaybackSessionID,
+		MediaItemID:       testMovieMediaID,
+		Kind:              historyimport.KindMovie,
+		PositionSeconds:   90,
+		DurationSeconds:   100,
+		Completed:         true,
+	}, pluginv1.WatchSyncOperation_WATCH_SYNC_OPERATION_SCROBBLE_STOP)
+	if !completed.GetCompleted() {
+		t.Fatal("completed event = false, want true")
+	}
+
+	incomplete := watchEventFromScrobble(ScrobbleEvent{
+		PlaybackSessionID: testPlaybackSessionID,
+		MediaItemID:       testMovieMediaID,
+		Kind:              historyimport.KindMovie,
+		PositionSeconds:   10,
+		DurationSeconds:   100,
+		Completed:         false,
+	}, pluginv1.WatchSyncOperation_WATCH_SYNC_OPERATION_SCROBBLE_STOP)
+	if incomplete.GetCompleted() {
+		t.Fatal("incomplete event = true, want false")
+	}
+}

--- a/internal/watchsync/plugin_provider_test.go
+++ b/internal/watchsync/plugin_provider_test.go
@@ -261,6 +261,93 @@ func TestPluginProviderValidatesAndOverlaysConnectionConfig(t *testing.T) {
 	}
 }
 
+func TestPluginProviderClassifiesAndRedactsConnectionSecrets(t *testing.T) {
+	const nestedSecret = "nested-connection-secret"
+	client := &fakeWatchSyncPluginClient{exchangeResponse: &pluginv1.WatchSyncCredentialResponse{
+		Fault: &pluginv1.WatchSyncFault{
+			Code: pluginv1.WatchSyncFaultCode_WATCH_SYNC_FAULT_CODE_INVALID_CREDENTIAL,
+			SafeMessage: "credentials " + testSecretValue + " and " + nestedSecret +
+				" were rejected",
+		},
+	}}
+	schema := &pluginv1.ConfigSchema{
+		Key: "account",
+		JsonSchema: `{
+			"type":"object",
+			"properties":{
+				"base_url":{"type":"string","format":"uri"},
+				"client_secret":{"type":"string","format":"password"},
+				"advanced":{"type":"object","properties":{"password":{"type":"string","format":"password"}}}
+			},
+			"required":["base_url","client_secret","advanced"],
+			"additionalProperties":false
+		}`,
+		AdminForm: &pluginv1.AdminFormDescriptor{Fields: []*pluginv1.AdminFormField{
+			{Key: "base_url", Control: pluginv1.AdminFormControl_ADMIN_FORM_CONTROL_TEXT},
+			// JSON Schema remains authoritative even when a form incorrectly
+			// presents a credential as ordinary text.
+			{Key: "client_secret", Control: pluginv1.AdminFormControl_ADMIN_FORM_CONTROL_TEXT},
+			{Key: "advanced", Control: pluginv1.AdminFormControl_ADMIN_FORM_CONTROL_TEXT},
+		}},
+	}
+	provider, err := NewPluginProvider(PluginProviderOptions{
+		InstallationID: 4, ProviderKey: testPluginProviderKey, CapabilityID: testPluginCapabilityID,
+		Descriptor: &pluginv1.WatchSyncProviderDescriptor{AuthMethods: []pluginv1.WatchSyncAuthMethod{
+			pluginv1.WatchSyncAuthMethod_WATCH_SYNC_AUTH_METHOD_API_KEY,
+		}},
+		ConnectionConfigSchema: []*pluginv1.ConfigSchema{schema},
+		ResolveClient:          func(context.Context, int, string) (WatchSyncPluginClient, error) { return client, nil },
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, _, err = provider.ConnectWithAPIKeyConfig(context.Background(), "input-token", ConnectionConfigValues{
+		"account": {
+			"base_url":      "https://floppy.example.com",
+			"client_secret": testSecretValue,
+			"advanced":      map[string]any{"password": nestedSecret},
+		},
+	})
+	if !isWatchSyncInvalidCredentialError(err) {
+		t.Fatalf("error = %#v", err)
+	}
+	config := client.exchangeRequest.GetProviderConfig()
+	if config.GetValues()["account.base_url"] != "https://floppy.example.com" ||
+		config.GetSecretValues()["account.client_secret"] != testSecretValue ||
+		config.GetSecretValues()["account.advanced"] != `{"password":"nested-connection-secret"}` {
+		t.Fatalf("provider config = %#v", config)
+	}
+	if _, exposed := config.GetValues()["account.client_secret"]; exposed {
+		t.Fatal("JSON-schema password was exposed as a public provider value")
+	}
+	if strings.Contains(err.Error(), testSecretValue) || strings.Contains(err.Error(), nestedSecret) ||
+		!strings.Contains(err.Error(), "[REDACTED]") {
+		t.Fatalf("connection secrets were not redacted: %q", err)
+	}
+}
+
+func TestPluginProviderRejectsUnresolvableDynamicConnectionOptions(t *testing.T) {
+	_, err := NewPluginProvider(PluginProviderOptions{
+		InstallationID: 4, ProviderKey: testPluginProviderKey, CapabilityID: testPluginCapabilityID,
+		Descriptor: &pluginv1.WatchSyncProviderDescriptor{AuthMethods: []pluginv1.WatchSyncAuthMethod{
+			pluginv1.WatchSyncAuthMethod_WATCH_SYNC_AUTH_METHOD_API_KEY,
+		}},
+		ConnectionConfigSchema: []*pluginv1.ConfigSchema{{
+			Key: "server",
+			AdminForm: &pluginv1.AdminFormDescriptor{Fields: []*pluginv1.AdminFormField{{
+				Key: "library", Control: pluginv1.AdminFormControl_ADMIN_FORM_CONTROL_SELECT,
+				DynamicOptions: true,
+			}}},
+		}},
+		ResolveClient: func(context.Context, int, string) (WatchSyncPluginClient, error) {
+			return &fakeWatchSyncPluginClient{}, nil
+		},
+	})
+	if err == nil || !strings.Contains(err.Error(), "requires dynamic options") {
+		t.Fatalf("error = %v", err)
+	}
+}
+
 func TestPluginProviderRefreshReturnsCredentialsAlongsideFault(t *testing.T) {
 	client := &fakeWatchSyncPluginClient{refreshResponse: &pluginv1.WatchSyncCredentialResponse{
 		Credentials: &pluginv1.WatchSyncCredentials{AccessToken: testRotatedAccessToken, TokenType: testBearerTokenType},

--- a/internal/watchsync/plugin_provider_test.go
+++ b/internal/watchsync/plugin_provider_test.go
@@ -262,12 +262,10 @@ func TestPluginProviderValidatesAndOverlaysConnectionConfig(t *testing.T) {
 }
 
 func TestPluginProviderClassifiesAndRedactsConnectionSecrets(t *testing.T) {
-	const nestedSecret = "nested-connection-secret"
 	client := &fakeWatchSyncPluginClient{exchangeResponse: &pluginv1.WatchSyncCredentialResponse{
 		Fault: &pluginv1.WatchSyncFault{
-			Code: pluginv1.WatchSyncFaultCode_WATCH_SYNC_FAULT_CODE_INVALID_CREDENTIAL,
-			SafeMessage: "credentials " + testSecretValue + " and " + nestedSecret +
-				" were rejected",
+			Code:        pluginv1.WatchSyncFaultCode_WATCH_SYNC_FAULT_CODE_INVALID_CREDENTIAL,
+			SafeMessage: "credentials " + testSecretValue + " were rejected",
 		},
 	}}
 	schema := &pluginv1.ConfigSchema{
@@ -276,10 +274,9 @@ func TestPluginProviderClassifiesAndRedactsConnectionSecrets(t *testing.T) {
 			"type":"object",
 			"properties":{
 				"base_url":{"type":"string","format":"uri"},
-				"client_secret":{"type":"string","format":"password"},
-				"advanced":{"type":"object","properties":{"password":{"type":"string","format":"password"}}}
+				"client_secret":{"type":"string","format":"password"}
 			},
-			"required":["base_url","client_secret","advanced"],
+			"required":["base_url","client_secret"],
 			"additionalProperties":false
 		}`,
 		AdminForm: &pluginv1.AdminFormDescriptor{Fields: []*pluginv1.AdminFormField{
@@ -287,7 +284,6 @@ func TestPluginProviderClassifiesAndRedactsConnectionSecrets(t *testing.T) {
 			// JSON Schema remains authoritative even when a form incorrectly
 			// presents a credential as ordinary text.
 			{Key: "client_secret", Control: pluginv1.AdminFormControl_ADMIN_FORM_CONTROL_TEXT},
-			{Key: "advanced", Control: pluginv1.AdminFormControl_ADMIN_FORM_CONTROL_TEXT},
 		}},
 	}
 	provider, err := NewPluginProvider(PluginProviderOptions{
@@ -305,7 +301,6 @@ func TestPluginProviderClassifiesAndRedactsConnectionSecrets(t *testing.T) {
 		"account": {
 			"base_url":      "https://floppy.example.com",
 			"client_secret": testSecretValue,
-			"advanced":      map[string]any{"password": nestedSecret},
 		},
 	})
 	if !isWatchSyncInvalidCredentialError(err) {
@@ -313,16 +308,30 @@ func TestPluginProviderClassifiesAndRedactsConnectionSecrets(t *testing.T) {
 	}
 	config := client.exchangeRequest.GetProviderConfig()
 	if config.GetValues()["account.base_url"] != "https://floppy.example.com" ||
-		config.GetSecretValues()["account.client_secret"] != testSecretValue ||
-		config.GetSecretValues()["account.advanced"] != `{"password":"nested-connection-secret"}` {
+		config.GetSecretValues()["account.client_secret"] != testSecretValue {
 		t.Fatalf("provider config = %#v", config)
 	}
 	if _, exposed := config.GetValues()["account.client_secret"]; exposed {
 		t.Fatal("JSON-schema password was exposed as a public provider value")
 	}
-	if strings.Contains(err.Error(), testSecretValue) || strings.Contains(err.Error(), nestedSecret) ||
-		!strings.Contains(err.Error(), "[REDACTED]") {
+	if strings.Contains(err.Error(), testSecretValue) || !strings.Contains(err.Error(), "[REDACTED]") {
 		t.Fatalf("connection secrets were not redacted: %q", err)
+	}
+}
+
+func TestConnectionConfigValidationRedactsNestedSecrets(t *testing.T) {
+	const nestedSecret = "nested-connection-secret"
+	schema := &pluginv1.ConfigSchema{
+		Key:        "account",
+		JsonSchema: `{"type":"object","properties":{"advanced":{"type":"object","properties":{"password":{"type":"string","format":"password"}}}}}`,
+	}
+	secrets := connectionConfigSecrets(
+		[]*pluginv1.ConfigSchema{schema},
+		ConnectionConfigValues{"account": {"advanced": map[string]any{"password": nestedSecret}}},
+	)
+	err := sanitizedConnectionConfigError(errors.New("rejected "+nestedSecret), secrets)
+	if strings.Contains(err.Error(), nestedSecret) || !strings.Contains(err.Error(), "[REDACTED]") {
+		t.Fatalf("nested connection secret was not redacted: %q", err)
 	}
 }
 
@@ -367,6 +376,24 @@ func TestPluginProviderRejectsDuplicateConnectionConfigKeys(t *testing.T) {
 	}
 }
 
+func TestPluginProviderRejectsBlankConnectionConfigKey(t *testing.T) {
+	_, err := NewPluginProvider(PluginProviderOptions{
+		InstallationID: 4, ProviderKey: testPluginProviderKey, CapabilityID: testPluginCapabilityID,
+		Descriptor: &pluginv1.WatchSyncProviderDescriptor{AuthMethods: []pluginv1.WatchSyncAuthMethod{
+			pluginv1.WatchSyncAuthMethod_WATCH_SYNC_AUTH_METHOD_API_KEY,
+		}},
+		ConnectionConfigSchema: []*pluginv1.ConfigSchema{{
+			Key: " \t", Required: true, JsonSchema: `{"type":"object","properties":{}}`,
+		}},
+		ResolveClient: func(context.Context, int, string) (WatchSyncPluginClient, error) {
+			return &fakeWatchSyncPluginClient{}, nil
+		},
+	})
+	if err == nil || !strings.Contains(err.Error(), "key is required") {
+		t.Fatalf("error = %v", err)
+	}
+}
+
 func TestPluginProviderRejectsUnsupportedConnectionConfigExclusivity(t *testing.T) {
 	_, err := NewPluginProvider(PluginProviderOptions{
 		InstallationID: 4, ProviderKey: testPluginProviderKey, CapabilityID: testPluginCapabilityID,
@@ -401,6 +428,25 @@ func TestPluginProviderRejectsRequiredConnectionConfigTheWebCannotRender(t *test
 			AdminForm: &pluginv1.AdminFormDescriptor{Fields: []*pluginv1.AdminFormField{{
 				Key: "headers", Control: pluginv1.AdminFormControl_ADMIN_FORM_CONTROL_TEXTAREA,
 			}}},
+		}},
+		ResolveClient: func(context.Context, int, string) (WatchSyncPluginClient, error) {
+			return &fakeWatchSyncPluginClient{}, nil
+		},
+	})
+	if err == nil || !strings.Contains(err.Error(), "cannot be inferred") {
+		t.Fatalf("error = %v", err)
+	}
+}
+
+func TestPluginProviderRejectsOptionalConnectionConfigTheWebCannotRender(t *testing.T) {
+	_, err := NewPluginProvider(PluginProviderOptions{
+		InstallationID: 4, ProviderKey: testPluginProviderKey, CapabilityID: testPluginCapabilityID,
+		Descriptor: &pluginv1.WatchSyncProviderDescriptor{AuthMethods: []pluginv1.WatchSyncAuthMethod{
+			pluginv1.WatchSyncAuthMethod_WATCH_SYNC_AUTH_METHOD_API_KEY,
+		}},
+		ConnectionConfigSchema: []*pluginv1.ConfigSchema{{
+			Key:        "headers",
+			JsonSchema: `{"type":"object","properties":{"values":{"type":"object"}}}`,
 		}},
 		ResolveClient: func(context.Context, int, string) (WatchSyncPluginClient, error) {
 			return &fakeWatchSyncPluginClient{}, nil

--- a/internal/watchsync/plugin_provider_test.go
+++ b/internal/watchsync/plugin_provider_test.go
@@ -348,6 +348,147 @@ func TestPluginProviderRejectsUnresolvableDynamicConnectionOptions(t *testing.T)
 	}
 }
 
+func TestPluginProviderRejectsDuplicateConnectionConfigKeys(t *testing.T) {
+	_, err := NewPluginProvider(PluginProviderOptions{
+		InstallationID: 4, ProviderKey: testPluginProviderKey, CapabilityID: testPluginCapabilityID,
+		Descriptor: &pluginv1.WatchSyncProviderDescriptor{AuthMethods: []pluginv1.WatchSyncAuthMethod{
+			pluginv1.WatchSyncAuthMethod_WATCH_SYNC_AUTH_METHOD_API_KEY,
+		}},
+		ConnectionConfigSchema: []*pluginv1.ConfigSchema{
+			{Key: "server", JsonSchema: `{"type":"object","properties":{}}`},
+			{Key: "server", JsonSchema: `{"type":"object","properties":{}}`},
+		},
+		ResolveClient: func(context.Context, int, string) (WatchSyncPluginClient, error) {
+			return &fakeWatchSyncPluginClient{}, nil
+		},
+	})
+	if err == nil || !strings.Contains(err.Error(), "duplicated") {
+		t.Fatalf("error = %v", err)
+	}
+}
+
+func TestPluginProviderRejectsUnsupportedConnectionConfigExclusivity(t *testing.T) {
+	_, err := NewPluginProvider(PluginProviderOptions{
+		InstallationID: 4, ProviderKey: testPluginProviderKey, CapabilityID: testPluginCapabilityID,
+		Descriptor: &pluginv1.WatchSyncProviderDescriptor{AuthMethods: []pluginv1.WatchSyncAuthMethod{
+			pluginv1.WatchSyncAuthMethod_WATCH_SYNC_AUTH_METHOD_API_KEY,
+		}},
+		ConnectionConfigSchema: []*pluginv1.ConfigSchema{{
+			Key: "server", JsonSchema: `{"type":"object","properties":{"primary":{"type":"boolean"},"group":{"type":"string"}}}`,
+			AdminForm: &pluginv1.AdminFormDescriptor{Fields: []*pluginv1.AdminFormField{{
+				Key: "primary", Control: pluginv1.AdminFormControl_ADMIN_FORM_CONTROL_SWITCH,
+				ExclusiveGroupField: "group",
+			}}},
+		}},
+		ResolveClient: func(context.Context, int, string) (WatchSyncPluginClient, error) {
+			return &fakeWatchSyncPluginClient{}, nil
+		},
+	})
+	if err == nil || !strings.Contains(err.Error(), "exclusive_group_field") {
+		t.Fatalf("error = %v", err)
+	}
+}
+
+func TestPluginProviderRejectsRequiredConnectionConfigTheWebCannotRender(t *testing.T) {
+	_, err := NewPluginProvider(PluginProviderOptions{
+		InstallationID: 4, ProviderKey: testPluginProviderKey, CapabilityID: testPluginCapabilityID,
+		Descriptor: &pluginv1.WatchSyncProviderDescriptor{AuthMethods: []pluginv1.WatchSyncAuthMethod{
+			pluginv1.WatchSyncAuthMethod_WATCH_SYNC_AUTH_METHOD_API_KEY,
+		}},
+		ConnectionConfigSchema: []*pluginv1.ConfigSchema{{
+			Key: "server", Required: true,
+			JsonSchema: `{"type":"object","properties":{"headers":{"type":"object"}}}`,
+		}},
+		ResolveClient: func(context.Context, int, string) (WatchSyncPluginClient, error) {
+			return &fakeWatchSyncPluginClient{}, nil
+		},
+	})
+	if err == nil || !strings.Contains(err.Error(), "cannot be inferred") {
+		t.Fatalf("error = %v", err)
+	}
+}
+
+func TestPluginProviderAcceptsRequiredScalarFieldsMissingFromPartialAdminForm(t *testing.T) {
+	_, err := NewPluginProvider(PluginProviderOptions{
+		InstallationID: 4, ProviderKey: testPluginProviderKey, CapabilityID: testPluginCapabilityID,
+		Descriptor: &pluginv1.WatchSyncProviderDescriptor{AuthMethods: []pluginv1.WatchSyncAuthMethod{
+			pluginv1.WatchSyncAuthMethod_WATCH_SYNC_AUTH_METHOD_API_KEY,
+		}},
+		ConnectionConfigSchema: []*pluginv1.ConfigSchema{
+			{
+				Key: "server", Required: true,
+				JsonSchema: `{"type":"object","properties":{"base_url":{"type":"string"},"username":{"type":"string"}},"required":["base_url","username"]}`,
+				AdminForm: &pluginv1.AdminFormDescriptor{Fields: []*pluginv1.AdminFormField{{
+					Key: "base_url", Control: pluginv1.AdminFormControl_ADMIN_FORM_CONTROL_TEXT,
+				}}},
+			},
+			{
+				Key: "features", Required: true,
+				JsonSchema: `{"type":"object","properties":{"flags":{"type":"array","items":{"type":"boolean"}}}}`,
+				AdminForm: &pluginv1.AdminFormDescriptor{Fields: []*pluginv1.AdminFormField{{
+					Key: "flags", Control: pluginv1.AdminFormControl_ADMIN_FORM_CONTROL_MULTI_SELECT,
+					Options: []*pluginv1.AdminFormOption{{Value: "true", Label: "Enabled"}, {Value: "false", Label: "Disabled"}},
+				}}},
+			},
+		},
+		ResolveClient: func(context.Context, int, string) (WatchSyncPluginClient, error) {
+			return &fakeWatchSyncPluginClient{}, nil
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestPluginProviderEnforcesConnectionAdminFormValidation(t *testing.T) {
+	client := &fakeWatchSyncPluginClient{exchangeResponse: &pluginv1.WatchSyncCredentialResponse{
+		Credentials: &pluginv1.WatchSyncCredentials{AccessToken: testValidatedToken},
+		Account:     &pluginv1.WatchSyncAccount{ExternalSubject: "7"},
+	}}
+	provider, err := NewPluginProvider(PluginProviderOptions{
+		InstallationID: 4, ProviderKey: testPluginProviderKey, CapabilityID: testPluginCapabilityID,
+		Descriptor: &pluginv1.WatchSyncProviderDescriptor{AuthMethods: []pluginv1.WatchSyncAuthMethod{
+			pluginv1.WatchSyncAuthMethod_WATCH_SYNC_AUTH_METHOD_API_KEY,
+		}},
+		ConnectionConfigSchema: []*pluginv1.ConfigSchema{{
+			Key: "server", Required: true,
+			JsonSchema: `{"type":"object","properties":{"name":{"type":"string"},"port":{"type":"number"},"password":{"type":"string","format":"password"}},"required":["name","port","password"]}`,
+			AdminForm: &pluginv1.AdminFormDescriptor{Fields: []*pluginv1.AdminFormField{
+				{Key: "name", Control: pluginv1.AdminFormControl_ADMIN_FORM_CONTROL_TEXT, Validation: &pluginv1.AdminFormValidation{Pattern: `^[a-z]+$`, MinLength: 3, MaxLength: 8}},
+				{Key: "port", Control: pluginv1.AdminFormControl_ADMIN_FORM_CONTROL_NUMBER, Validation: &pluginv1.AdminFormValidation{HasMin: true, Min: 1, HasMax: true, Max: 65535}},
+				{Key: "password", Control: pluginv1.AdminFormControl_ADMIN_FORM_CONTROL_PASSWORD, Secret: true, Validation: &pluginv1.AdminFormValidation{MinLength: 8}},
+			}},
+		}},
+		ResolveClient: func(context.Context, int, string) (WatchSyncPluginClient, error) {
+			return client, nil
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	tests := []struct {
+		name    string
+		values  map[string]any
+		message string
+	}{
+		{name: "pattern", values: map[string]any{"name": "Bad", "port": 443.0, "password": "long-enough"}, message: "is invalid"},
+		{name: "number", values: map[string]any{"name": "good", "port": 70000.0, "password": "long-enough"}, message: "at most 65535"},
+		{name: "secret length", values: map[string]any{"name": "good", "port": 443.0, "password": "leaky"}, message: "at least 8 characters"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, _, err := provider.ConnectWithAPIKeyConfig(context.Background(), "token", ConnectionConfigValues{"server": tt.values})
+			if err == nil || !strings.Contains(err.Error(), tt.message) {
+				t.Fatalf("error = %v", err)
+			}
+			if strings.Contains(err.Error(), "leaky") {
+				t.Fatalf("secret leaked in validation error: %q", err)
+			}
+		})
+	}
+}
+
 func TestPluginProviderRejectsConnectionConfigForDeviceAuthorization(t *testing.T) {
 	_, err := NewPluginProvider(PluginProviderOptions{
 		InstallationID: 4, ProviderKey: testPluginProviderKey, CapabilityID: testPluginCapabilityID,

--- a/internal/watchsync/plugin_provider_test.go
+++ b/internal/watchsync/plugin_provider_test.go
@@ -34,6 +34,7 @@ type fakeWatchSyncPluginClient struct {
 	listResponses       []*pluginv1.WatchSyncListRemoteStateResponse
 	applyErr            error
 	applyRequest        *pluginv1.WatchSyncApplyEventsRequest
+	exchangeRequest     *pluginv1.WatchSyncExchangeAPIKeyRequest
 	refreshRequest      *pluginv1.WatchSyncRefreshCredentialsRequest
 	accountRequest      *pluginv1.WatchSyncGetAccountRequest
 	deviceStartRequest  *pluginv1.WatchSyncDeviceAuthorizationServiceStartRequest
@@ -57,7 +58,8 @@ func (f *fakeWatchSyncPluginClient) PollDeviceAuthorization(_ context.Context, r
 	return &pluginv1.WatchSyncDeviceAuthorizationServicePollResponse{}, nil
 }
 
-func (f *fakeWatchSyncPluginClient) ExchangeAPIKey(_ context.Context, _ *pluginv1.WatchSyncExchangeAPIKeyRequest) (*pluginv1.WatchSyncCredentialResponse, error) {
+func (f *fakeWatchSyncPluginClient) ExchangeAPIKey(_ context.Context, req *pluginv1.WatchSyncExchangeAPIKeyRequest) (*pluginv1.WatchSyncCredentialResponse, error) {
+	f.exchangeRequest = req
 	return f.exchangeResponse, nil
 }
 func (f *fakeWatchSyncPluginClient) RefreshCredentials(_ context.Context, req *pluginv1.WatchSyncRefreshCredentialsRequest) (*pluginv1.WatchSyncCredentialResponse, error) {
@@ -212,6 +214,50 @@ func TestPluginProviderRejectsMissingAccountIdentity(t *testing.T) {
 		if _, _, err := provider.ConnectWithAPIKey(context.Background(), "input-token"); err == nil || !strings.Contains(err.Error(), "account identity") {
 			t.Fatalf("subject %q: error = %v", subject, err)
 		}
+	}
+}
+
+func TestPluginProviderValidatesAndOverlaysConnectionConfig(t *testing.T) {
+	client := &fakeWatchSyncPluginClient{exchangeResponse: &pluginv1.WatchSyncCredentialResponse{
+		Credentials: &pluginv1.WatchSyncCredentials{AccessToken: testValidatedToken, TokenType: testBearerTokenType},
+		Account:     &pluginv1.WatchSyncAccount{ExternalSubject: "7", Username: testPluginUsername},
+	}}
+	schema := &pluginv1.ConfigSchema{
+		Key: "floppy", Title: "Floppy server", Required: true,
+		JsonSchema: `{"type":"object","properties":{"base_url":{"type":"string","format":"uri"}},"required":["base_url"],"additionalProperties":false}`,
+		AdminForm: &pluginv1.AdminFormDescriptor{Fields: []*pluginv1.AdminFormField{{
+			Key: "base_url", Label: "Base URL", Control: pluginv1.AdminFormControl_ADMIN_FORM_CONTROL_TEXT, Required: true,
+		}}},
+	}
+	provider, err := NewPluginProvider(PluginProviderOptions{
+		InstallationID: 4, ProviderKey: testPluginProviderKey, CapabilityID: testPluginCapabilityID,
+		DisplayName: "Floppy", Descriptor: &pluginv1.WatchSyncProviderDescriptor{
+			AuthMethods: []pluginv1.WatchSyncAuthMethod{pluginv1.WatchSyncAuthMethod_WATCH_SYNC_AUTH_METHOD_API_KEY},
+		},
+		ConnectionConfigSchema: []*pluginv1.ConfigSchema{schema},
+		ResolveClient:          func(context.Context, int, string) (WatchSyncPluginClient, error) { return client, nil },
+		ResolveConfig: func(context.Context, int) (*pluginv1.WatchSyncProviderConfig, error) {
+			return &pluginv1.WatchSyncProviderConfig{Values: map[string]string{"floppy.base_url": "https://legacy.example.com"}}, nil
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, _, err = provider.ConnectWithAPIKeyConfig(context.Background(), "token", ConnectionConfigValues{
+		"floppy": {"base_url": "https://personal.example.com"},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := client.exchangeRequest.GetProviderConfig().GetValues()["floppy.base_url"]; got != "https://personal.example.com" {
+		t.Fatalf("base URL = %q", got)
+	}
+	views := provider.ConnectionConfigSchema()
+	if len(views) != 1 || views[0].AdminForm == nil || views[0].AdminForm.Fields[0].Control != "TEXT" {
+		t.Fatalf("connection config schema = %#v", views)
+	}
+	if _, _, err := provider.ConnectWithAPIKeyConfig(context.Background(), "token", nil); err == nil || !strings.Contains(err.Error(), "required") {
+		t.Fatalf("missing config error = %v", err)
 	}
 }
 

--- a/internal/watchsync/plugin_provider_test.go
+++ b/internal/watchsync/plugin_provider_test.go
@@ -348,6 +348,22 @@ func TestPluginProviderRejectsUnresolvableDynamicConnectionOptions(t *testing.T)
 	}
 }
 
+func TestPluginProviderRejectsConnectionConfigForDeviceAuthorization(t *testing.T) {
+	_, err := NewPluginProvider(PluginProviderOptions{
+		InstallationID: 4, ProviderKey: testPluginProviderKey, CapabilityID: testPluginCapabilityID,
+		Descriptor: &pluginv1.WatchSyncProviderDescriptor{AuthMethods: []pluginv1.WatchSyncAuthMethod{
+			pluginv1.WatchSyncAuthMethod_WATCH_SYNC_AUTH_METHOD_DEVICE_CODE,
+		}},
+		ConnectionConfigSchema: []*pluginv1.ConfigSchema{{Key: "server"}},
+		ResolveClient: func(context.Context, int, string) (WatchSyncPluginClient, error) {
+			return &fakeWatchSyncPluginClient{}, nil
+		},
+	})
+	if err == nil || !strings.Contains(err.Error(), "connection config requires API-key authentication") {
+		t.Fatalf("error = %v", err)
+	}
+}
+
 func TestPluginProviderRefreshReturnsCredentialsAlongsideFault(t *testing.T) {
 	client := &fakeWatchSyncPluginClient{refreshResponse: &pluginv1.WatchSyncCredentialResponse{
 		Credentials: &pluginv1.WatchSyncCredentials{AccessToken: testRotatedAccessToken, TokenType: testBearerTokenType},

--- a/internal/watchsync/plugin_provider_test.go
+++ b/internal/watchsync/plugin_provider_test.go
@@ -398,6 +398,9 @@ func TestPluginProviderRejectsRequiredConnectionConfigTheWebCannotRender(t *test
 		ConnectionConfigSchema: []*pluginv1.ConfigSchema{{
 			Key: "server", Required: true,
 			JsonSchema: `{"type":"object","properties":{"headers":{"type":"object"}}}`,
+			AdminForm: &pluginv1.AdminFormDescriptor{Fields: []*pluginv1.AdminFormField{{
+				Key: "headers", Control: pluginv1.AdminFormControl_ADMIN_FORM_CONTROL_TEXTAREA,
+			}}},
 		}},
 		ResolveClient: func(context.Context, int, string) (WatchSyncPluginClient, error) {
 			return &fakeWatchSyncPluginClient{}, nil
@@ -408,7 +411,7 @@ func TestPluginProviderRejectsRequiredConnectionConfigTheWebCannotRender(t *test
 	}
 }
 
-func TestPluginProviderAcceptsRequiredScalarFieldsMissingFromPartialAdminForm(t *testing.T) {
+func TestPluginProviderAcceptsRenderableRequiredConnectionConfig(t *testing.T) {
 	_, err := NewPluginProvider(PluginProviderOptions{
 		InstallationID: 4, ProviderKey: testPluginProviderKey, CapabilityID: testPluginCapabilityID,
 		Descriptor: &pluginv1.WatchSyncProviderDescriptor{AuthMethods: []pluginv1.WatchSyncAuthMethod{
@@ -428,6 +431,21 @@ func TestPluginProviderAcceptsRequiredScalarFieldsMissingFromPartialAdminForm(t 
 				AdminForm: &pluginv1.AdminFormDescriptor{Fields: []*pluginv1.AdminFormField{{
 					Key: "flags", Control: pluginv1.AdminFormControl_ADMIN_FORM_CONTROL_MULTI_SELECT,
 					Options: []*pluginv1.AdminFormOption{{Value: "true", Label: "Enabled"}, {Value: "false", Label: "Disabled"}},
+				}}},
+			},
+			{
+				Key: "mode", Required: true,
+				JsonSchema: `{"type":"object","properties":{"value":{"enum":["standard","anime"]}}}`,
+				AdminForm: &pluginv1.AdminFormDescriptor{Fields: []*pluginv1.AdminFormField{{
+					Key: "value", Control: pluginv1.AdminFormControl_ADMIN_FORM_CONTROL_SELECT,
+					Options: []*pluginv1.AdminFormOption{{Value: "standard", Label: "Standard"}, {Value: "anime", Label: "Anime"}},
+				}}},
+			},
+			{
+				Key: "reference", Required: true,
+				JsonSchema: `{"type":"object","properties":{"endpoint":{"$ref":"#/$defs/endpoint"}},"$defs":{"endpoint":{"type":"string","format":"uri"}}}`,
+				AdminForm: &pluginv1.AdminFormDescriptor{Fields: []*pluginv1.AdminFormField{{
+					Key: "endpoint", Control: pluginv1.AdminFormControl_ADMIN_FORM_CONTROL_TEXT,
 				}}},
 			},
 		},
@@ -452,7 +470,7 @@ func TestPluginProviderEnforcesConnectionAdminFormValidation(t *testing.T) {
 		}},
 		ConnectionConfigSchema: []*pluginv1.ConfigSchema{{
 			Key: "server", Required: true,
-			JsonSchema: `{"type":"object","properties":{"name":{"type":"string"},"port":{"type":"number"},"password":{"type":"string","format":"password"}},"required":["name","port","password"]}`,
+			JsonSchema: `{"type":"object","properties":{"name":{"type":"string"},"port":{},"password":{"type":"string","format":"password"}},"required":["name","port","password"]}`,
 			AdminForm: &pluginv1.AdminFormDescriptor{Fields: []*pluginv1.AdminFormField{
 				{Key: "name", Control: pluginv1.AdminFormControl_ADMIN_FORM_CONTROL_TEXT, Validation: &pluginv1.AdminFormValidation{Pattern: `^[a-z]+$`, MinLength: 3, MaxLength: 8}},
 				{Key: "port", Control: pluginv1.AdminFormControl_ADMIN_FORM_CONTROL_NUMBER, Validation: &pluginv1.AdminFormValidation{HasMin: true, Min: 1, HasMax: true, Max: 65535}},
@@ -474,6 +492,7 @@ func TestPluginProviderEnforcesConnectionAdminFormValidation(t *testing.T) {
 	}{
 		{name: "pattern", values: map[string]any{"name": "Bad", "port": 443.0, "password": "long-enough"}, message: "is invalid"},
 		{name: "number", values: map[string]any{"name": "good", "port": 70000.0, "password": "long-enough"}, message: "at most 65535"},
+		{name: "numeric string", values: map[string]any{"name": "good", "port": "70000", "password": "long-enough"}, message: "at most 65535"},
 		{name: "secret length", values: map[string]any{"name": "good", "port": 443.0, "password": "leaky"}, message: "at least 8 characters"},
 	}
 	for _, tt := range tests {

--- a/internal/watchsync/plugin_provider_test.go
+++ b/internal/watchsync/plugin_provider_test.go
@@ -357,6 +357,29 @@ func TestPluginProviderRejectsUnresolvableDynamicConnectionOptions(t *testing.T)
 	}
 }
 
+func TestPluginProviderRejectsBlankConnectionSelectOption(t *testing.T) {
+	_, err := NewPluginProvider(PluginProviderOptions{
+		InstallationID: 4, ProviderKey: testPluginProviderKey, CapabilityID: testPluginCapabilityID,
+		Descriptor: &pluginv1.WatchSyncProviderDescriptor{AuthMethods: []pluginv1.WatchSyncAuthMethod{
+			pluginv1.WatchSyncAuthMethod_WATCH_SYNC_AUTH_METHOD_API_KEY,
+		}},
+		ConnectionConfigSchema: []*pluginv1.ConfigSchema{{
+			Key:        "server",
+			JsonSchema: `{"type":"object","properties":{"mode":{"type":"string"}}}`,
+			AdminForm: &pluginv1.AdminFormDescriptor{Fields: []*pluginv1.AdminFormField{{
+				Key: "mode", Control: pluginv1.AdminFormControl_ADMIN_FORM_CONTROL_SELECT,
+				Options: []*pluginv1.AdminFormOption{{Value: " ", Label: "Choose a mode"}},
+			}}},
+		}},
+		ResolveClient: func(context.Context, int, string) (WatchSyncPluginClient, error) {
+			return &fakeWatchSyncPluginClient{}, nil
+		},
+	})
+	if err == nil || !strings.Contains(err.Error(), "blank select option value") {
+		t.Fatalf("error = %v", err)
+	}
+}
+
 func TestPluginProviderRejectsDuplicateConnectionConfigKeys(t *testing.T) {
 	_, err := NewPluginProvider(PluginProviderOptions{
 		InstallationID: 4, ProviderKey: testPluginProviderKey, CapabilityID: testPluginCapabilityID,
@@ -501,6 +524,100 @@ func TestPluginProviderAcceptsRenderableRequiredConnectionConfig(t *testing.T) {
 	})
 	if err != nil {
 		t.Fatal(err)
+	}
+}
+
+func TestPluginProviderRejectsConnectionControlThatCannotEmitSchemaType(t *testing.T) {
+	_, err := NewPluginProvider(PluginProviderOptions{
+		InstallationID: 4, ProviderKey: testPluginProviderKey, CapabilityID: testPluginCapabilityID,
+		Descriptor: &pluginv1.WatchSyncProviderDescriptor{AuthMethods: []pluginv1.WatchSyncAuthMethod{
+			pluginv1.WatchSyncAuthMethod_WATCH_SYNC_AUTH_METHOD_API_KEY,
+		}},
+		ConnectionConfigSchema: []*pluginv1.ConfigSchema{{
+			Key:        "server",
+			JsonSchema: `{"type":"object","properties":{"name":{"type":"string"}}}`,
+			AdminForm: &pluginv1.AdminFormDescriptor{Fields: []*pluginv1.AdminFormField{{
+				Key: "name", Control: pluginv1.AdminFormControl_ADMIN_FORM_CONTROL_SWITCH,
+			}}},
+		}},
+		ResolveClient: func(context.Context, int, string) (WatchSyncPluginClient, error) {
+			return &fakeWatchSyncPluginClient{}, nil
+		},
+	})
+	if err == nil || !strings.Contains(err.Error(), "cannot emit json_schema type") {
+		t.Fatalf("error = %v", err)
+	}
+}
+
+func TestPluginProviderEnforcesVisibleRequiredConnectionAdminFields(t *testing.T) {
+	client := &fakeWatchSyncPluginClient{exchangeResponse: &pluginv1.WatchSyncCredentialResponse{
+		Credentials: &pluginv1.WatchSyncCredentials{AccessToken: testValidatedToken},
+		Account:     &pluginv1.WatchSyncAccount{ExternalSubject: "7"},
+	}}
+	provider, err := NewPluginProvider(PluginProviderOptions{
+		InstallationID: 4, ProviderKey: testPluginProviderKey, CapabilityID: testPluginCapabilityID,
+		Descriptor: &pluginv1.WatchSyncProviderDescriptor{AuthMethods: []pluginv1.WatchSyncAuthMethod{
+			pluginv1.WatchSyncAuthMethod_WATCH_SYNC_AUTH_METHOD_API_KEY,
+		}},
+		ConnectionConfigSchema: []*pluginv1.ConfigSchema{{
+			Key:        "server",
+			JsonSchema: `{"type":"object","properties":{"advanced":{"type":"boolean"},"endpoint":{"type":"string"}},"required":["advanced"],"additionalProperties":false}`,
+			AdminForm: &pluginv1.AdminFormDescriptor{Fields: []*pluginv1.AdminFormField{
+				{Key: "advanced", Control: pluginv1.AdminFormControl_ADMIN_FORM_CONTROL_SWITCH},
+				{
+					Key: "endpoint", Control: pluginv1.AdminFormControl_ADMIN_FORM_CONTROL_TEXT, Required: true,
+					ShowWhen: []*pluginv1.AdminFormCondition{{Field: "advanced", Equals: []string{"true"}}},
+				},
+			}},
+		}},
+		ResolveClient: func(context.Context, int, string) (WatchSyncPluginClient, error) {
+			return client, nil
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if _, _, err := provider.ConnectWithAPIKeyConfig(context.Background(), "token", ConnectionConfigValues{
+		"server": {"advanced": false},
+	}); err != nil {
+		t.Fatalf("hidden required field: %v", err)
+	}
+	if _, _, err := provider.ConnectWithAPIKeyConfig(context.Background(), "token", ConnectionConfigValues{
+		"server": {"advanced": true},
+	}); err == nil || !strings.Contains(err.Error(), `field "endpoint" is required`) {
+		t.Fatalf("visible required field error = %v", err)
+	}
+}
+
+func TestPluginProviderRejectsFlattenedConnectionConfigCollision(t *testing.T) {
+	client := &fakeWatchSyncPluginClient{}
+	provider, err := NewPluginProvider(PluginProviderOptions{
+		InstallationID: 4, ProviderKey: testPluginProviderKey, CapabilityID: testPluginCapabilityID,
+		Descriptor: &pluginv1.WatchSyncProviderDescriptor{AuthMethods: []pluginv1.WatchSyncAuthMethod{
+			pluginv1.WatchSyncAuthMethod_WATCH_SYNC_AUTH_METHOD_API_KEY,
+		}},
+		ConnectionConfigSchema: []*pluginv1.ConfigSchema{
+			{Key: "a", JsonSchema: `{"type":"object","properties":{"b.c":{"type":"string"}},"additionalProperties":false}`},
+			{Key: "a.b", JsonSchema: `{"type":"object","properties":{"c":{"type":"string"}},"additionalProperties":false}`},
+		},
+		ResolveClient: func(context.Context, int, string) (WatchSyncPluginClient, error) {
+			return client, nil
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	_, _, err = provider.ConnectWithAPIKeyConfig(context.Background(), "token", ConnectionConfigValues{
+		"a":   {"b.c": "first"},
+		"a.b": {"c": "second"},
+	})
+	if err == nil || !strings.Contains(err.Error(), "conflicts") || !strings.Contains(err.Error(), "after flattening") {
+		t.Fatalf("error = %v", err)
+	}
+	if client.exchangeRequest != nil {
+		t.Fatal("ambiguous connection config reached the plugin")
 	}
 }
 

--- a/internal/watchsync/plugin_provider_test.go
+++ b/internal/watchsync/plugin_provider_test.go
@@ -335,6 +335,52 @@ func TestConnectionConfigValidationRedactsNestedSecrets(t *testing.T) {
 	}
 }
 
+func TestPluginProviderRedactsUndeclaredConnectionSecrets(t *testing.T) {
+	const undeclaredSecret = "undeclared-connection-secret"
+	client := &fakeWatchSyncPluginClient{exchangeResponse: &pluginv1.WatchSyncCredentialResponse{
+		Fault: &pluginv1.WatchSyncFault{
+			Code:        pluginv1.WatchSyncFaultCode_WATCH_SYNC_FAULT_CODE_INVALID_CREDENTIAL,
+			SafeMessage: "credentials " + undeclaredSecret + " were rejected",
+		},
+	}}
+	// The schema permits additional properties, so an undeclared field reaches
+	// the plugin classified as a secret and must be redacted like a declared one.
+	schema := &pluginv1.ConfigSchema{
+		Key:        "account",
+		JsonSchema: `{"type":"object","properties":{"base_url":{"type":"string","format":"uri"}},"required":["base_url"]}`,
+		AdminForm: &pluginv1.AdminFormDescriptor{Fields: []*pluginv1.AdminFormField{
+			{Key: "base_url", Control: pluginv1.AdminFormControl_ADMIN_FORM_CONTROL_TEXT},
+		}},
+	}
+	provider, err := NewPluginProvider(PluginProviderOptions{
+		InstallationID: 4, ProviderKey: testPluginProviderKey, CapabilityID: testPluginCapabilityID,
+		Descriptor: &pluginv1.WatchSyncProviderDescriptor{AuthMethods: []pluginv1.WatchSyncAuthMethod{
+			pluginv1.WatchSyncAuthMethod_WATCH_SYNC_AUTH_METHOD_API_KEY,
+		}},
+		ConnectionConfigSchema: []*pluginv1.ConfigSchema{schema},
+		ResolveClient:          func(context.Context, int, string) (WatchSyncPluginClient, error) { return client, nil },
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, _, err = provider.ConnectWithAPIKeyConfig(context.Background(), "input-token", ConnectionConfigValues{
+		"account": {
+			"base_url":  "https://floppy.example.com",
+			"api_token": undeclaredSecret,
+		},
+	})
+	if !isWatchSyncInvalidCredentialError(err) {
+		t.Fatalf("error = %#v", err)
+	}
+	config := client.exchangeRequest.GetProviderConfig()
+	if config.GetSecretValues()["account.api_token"] != undeclaredSecret {
+		t.Fatalf("undeclared field was not classified as a secret: %#v", config)
+	}
+	if strings.Contains(err.Error(), undeclaredSecret) || !strings.Contains(err.Error(), "[REDACTED]") {
+		t.Fatalf("undeclared connection secret was not redacted: %q", err)
+	}
+}
+
 func TestPluginProviderRejectsUnresolvableDynamicConnectionOptions(t *testing.T) {
 	_, err := NewPluginProvider(PluginProviderOptions{
 		InstallationID: 4, ProviderKey: testPluginProviderKey, CapabilityID: testPluginCapabilityID,

--- a/internal/watchsync/registry.go
+++ b/internal/watchsync/registry.go
@@ -91,11 +91,15 @@ func (r *Registry) List() []ProviderSummary {
 
 	summaries := make([]ProviderSummary, 0, len(r.providers))
 	for key, provider := range r.providers {
-		summaries = append(summaries, ProviderSummary{
+		summary := ProviderSummary{
 			Key:          key,
 			DisplayName:  provider.DisplayName(),
 			Capabilities: provider.Capabilities(),
-		})
+		}
+		if configurable, ok := provider.(connectionConfigProvider); ok {
+			summary.ConnectionConfigSchema = configurable.ConnectionConfigSchema()
+		}
+		summaries = append(summaries, summary)
 	}
 	sort.Slice(summaries, func(i, j int) bool {
 		return summaries[i].Key < summaries[j].Key

--- a/internal/watchsync/repository.go
+++ b/internal/watchsync/repository.go
@@ -34,6 +34,7 @@ type Repository interface {
 	ListListEventConnections(ctx context.Context, userID int, profileID string, list ListKind) ([]Connection, error)
 	UpsertHistoryExports(ctx context.Context, exports []HistoryExport) error
 	ListPendingHistoryExports(ctx context.Context, connectionID string, limit int) ([]HistoryExport, error)
+	ListPendingHistoryExportsByHistoryIDs(ctx context.Context, connectionID string, historyIDs []string) ([]HistoryExport, error)
 	MarkHistoryExportStatus(ctx context.Context, id string, status string, lastError string) error
 	MarkHistoryExportSatisfiedByScrobble(ctx context.Context, connectionID string, historyID string) error
 	UpsertListItemStates(ctx context.Context, states []ListItemState) error
@@ -761,6 +762,55 @@ func (r *PostgresRepository) ListPendingHistoryExports(ctx context.Context, conn
 	}
 	if err := rows.Err(); err != nil {
 		return nil, fmt.Errorf("iterate pending history exports: %w", err)
+	}
+	return exports, nil
+}
+
+func (r *PostgresRepository) ListPendingHistoryExportsByHistoryIDs(
+	ctx context.Context,
+	connectionID string,
+	historyIDs []string,
+) ([]HistoryExport, error) {
+	if len(historyIDs) == 0 {
+		return nil, nil
+	}
+	rows, err := r.pool.Query(ctx, `
+		SELECT id::text, connection_id::text, history_id, media_item_id, watched_at,
+			provider_item_key, status, attempt_count, last_attempt_at, last_error, created_at, updated_at
+		FROM watch_provider_history_exports
+		WHERE connection_id = $1::uuid
+		  AND history_id = ANY($2::text[])
+		  AND status IN ('pending', 'failed')
+		  AND attempt_count < 5
+		ORDER BY watched_at ASC
+	`, connectionID, historyIDs)
+	if err != nil {
+		return nil, fmt.Errorf("list pending history exports by history ids: %w", err)
+	}
+	defer rows.Close()
+	var exports []HistoryExport
+	for rows.Next() {
+		var export HistoryExport
+		if err := rows.Scan(
+			&export.ID,
+			&export.ConnectionID,
+			&export.HistoryID,
+			&export.MediaItemID,
+			&export.WatchedAt,
+			&export.ProviderItemKey,
+			&export.Status,
+			&export.AttemptCount,
+			&export.LastAttemptAt,
+			&export.LastError,
+			&export.CreatedAt,
+			&export.UpdatedAt,
+		); err != nil {
+			return nil, fmt.Errorf("scan pending history export by history ids: %w", err)
+		}
+		exports = append(exports, export)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("iterate pending history exports by history ids: %w", err)
 	}
 	return exports, nil
 }

--- a/internal/watchsync/repository.go
+++ b/internal/watchsync/repository.go
@@ -34,7 +34,7 @@ type Repository interface {
 	ListListEventConnections(ctx context.Context, userID int, profileID string, list ListKind) ([]Connection, error)
 	UpsertHistoryExports(ctx context.Context, exports []HistoryExport) error
 	ListPendingHistoryExports(ctx context.Context, connectionID string, limit int) ([]HistoryExport, error)
-	ListPendingHistoryExportsByHistoryIDs(ctx context.Context, connectionID string, historyIDs []string) ([]HistoryExport, error)
+	ListPendingHistoryExportsByHistoryIDs(ctx context.Context, connectionID string, historyIDs []string, limit int) ([]HistoryExport, error)
 	MarkHistoryExportStatus(ctx context.Context, id string, status string, lastError string) error
 	MarkHistoryExportSatisfiedByScrobble(ctx context.Context, connectionID string, historyID string) error
 	UpsertListItemStates(ctx context.Context, states []ListItemState) error
@@ -770,9 +770,13 @@ func (r *PostgresRepository) ListPendingHistoryExportsByHistoryIDs(
 	ctx context.Context,
 	connectionID string,
 	historyIDs []string,
+	limit int,
 ) ([]HistoryExport, error) {
 	if len(historyIDs) == 0 {
 		return nil, nil
+	}
+	if limit <= 0 || limit > len(historyIDs) {
+		limit = len(historyIDs)
 	}
 	rows, err := r.pool.Query(ctx, `
 		SELECT id::text, connection_id::text, history_id, media_item_id, watched_at,
@@ -783,7 +787,8 @@ func (r *PostgresRepository) ListPendingHistoryExportsByHistoryIDs(
 		  AND status IN ('pending', 'failed')
 		  AND attempt_count < 5
 		ORDER BY watched_at ASC
-	`, connectionID, historyIDs)
+		LIMIT $3
+	`, connectionID, historyIDs, limit)
 	if err != nil {
 		return nil, fmt.Errorf("list pending history exports by history ids: %w", err)
 	}

--- a/internal/watchsync/service.go
+++ b/internal/watchsync/service.go
@@ -56,7 +56,10 @@ const (
 	// Built-in providers bind requests to this context and use HTTP client
 	// timeouts of at most 20 seconds. Keep dispatch below the reclaim lease;
 	// the per-session queue remains occupied until the worker itself exits.
-	confirmedStopDispatchTimeout = 25 * time.Second
+	// A completed stop may require a cold metadata lookup in a provider plugin.
+	// Match the plugin-host watch-sync deadline so the durable confirmation path
+	// does not cancel valid provider work before the RPC can finish.
+	confirmedStopDispatchTimeout = 2 * time.Minute
 	confirmedStopLease           = time.Minute
 )
 

--- a/internal/watchsync/service.go
+++ b/internal/watchsync/service.go
@@ -1578,7 +1578,14 @@ func (s *Service) exportLocalPlays(
 	if err := s.repo.UpsertHistoryExports(ctx, exports); err != nil {
 		return err
 	}
-	pending, err := s.repo.ListPendingHistoryExports(ctx, conn.ID, 100)
+	historyIDs := make([]string, 0, len(exports))
+	for _, export := range exports {
+		historyIDs = append(historyIDs, export.HistoryID)
+	}
+	// A live watch event must not wait behind a connection's historical
+	// backlog. Scheduled sync still drains that backlog oldest-first, while
+	// this path selects only the events the user just created.
+	pending, err := s.repo.ListPendingHistoryExportsByHistoryIDs(ctx, conn.ID, historyIDs)
 	if err != nil {
 		return err
 	}

--- a/internal/watchsync/service.go
+++ b/internal/watchsync/service.go
@@ -138,6 +138,9 @@ func (s *Service) GetConnectionStatus(ctx context.Context, userID int, profileID
 		SyncWatchlistOrderEnabled:    true,
 		ScrobbleEnabled:              true,
 	}
+	if configurable, ok := provider.(connectionConfigProvider); ok {
+		status.ConnectionConfigSchema = configurable.ConnectionConfigSchema()
+	}
 	if connected {
 		status.ProviderUsername = conn.ProviderUsername
 		status.ImportWatchedEnabled = conn.ImportWatchedEnabled
@@ -547,6 +550,17 @@ func (s *Service) ConnectAPIKey(
 	providerKey string,
 	apiKey string,
 ) (Connection, error) {
+	return s.ConnectAPIKeyWithConfig(ctx, userID, profileID, providerKey, apiKey, nil)
+}
+
+func (s *Service) ConnectAPIKeyWithConfig(
+	ctx context.Context,
+	userID int,
+	profileID string,
+	providerKey string,
+	apiKey string,
+	connectionConfig ConnectionConfigValues,
+) (Connection, error) {
 	if userID <= 0 {
 		return Connection{}, fmt.Errorf("user id is required")
 	}
@@ -566,7 +580,17 @@ func (s *Service) ConnectAPIKey(
 		return Connection{}, fmt.Errorf("provider %q does not support api-key auth", providerKey)
 	}
 
-	tokens, account, err := authProvider.ConnectWithAPIKey(ctx, apiKey)
+	var tokens TokenSet
+	var account ProviderAccount
+	var err error
+	if configured, ok := provider.(configuredAPIKeyAuthProvider); ok {
+		tokens, account, err = configured.ConnectWithAPIKeyConfig(ctx, apiKey, connectionConfig)
+	} else {
+		if len(connectionConfig) > 0 {
+			return Connection{}, fmt.Errorf("provider %q does not accept connection configuration", providerKey)
+		}
+		tokens, account, err = authProvider.ConnectWithAPIKey(ctx, apiKey)
+	}
 	if err != nil {
 		return Connection{}, err
 	}

--- a/internal/watchsync/service.go
+++ b/internal/watchsync/service.go
@@ -53,14 +53,13 @@ type watchStateImporter interface {
 const (
 	manualSyncCooldown = time.Hour
 	manualSyncTimeout  = 10 * time.Minute
-	// Built-in providers bind requests to this context and use HTTP client
-	// timeouts of at most 20 seconds. Keep dispatch below the reclaim lease;
-	// the per-session queue remains occupied until the worker itself exits.
 	// A completed stop may require a cold metadata lookup in a provider plugin.
 	// Match the plugin-host watch-sync deadline so the durable confirmation path
-	// does not cancel valid provider work before the RPC can finish.
+	// does not cancel valid provider work before the RPC can finish. The reclaim
+	// lease must remain longer than that entire dispatch and finalization window
+	// so a second request cannot take over while the first is still valid.
 	confirmedStopDispatchTimeout = 2 * time.Minute
-	confirmedStopLease           = time.Minute
+	confirmedStopLease           = confirmedStopDispatchTimeout + 30*time.Second
 )
 
 var errConfirmedStopInProgress = errors.New("watch provider stop confirmation already in progress")
@@ -1588,7 +1587,12 @@ func (s *Service) exportLocalPlays(
 	// A live watch event must not wait behind a connection's historical
 	// backlog. Scheduled sync still drains that backlog oldest-first, while
 	// this path selects only the events the user just created.
-	pending, err := s.repo.ListPendingHistoryExportsByHistoryIDs(ctx, conn.ID, historyIDs)
+	pending, err := s.repo.ListPendingHistoryExportsByHistoryIDs(
+		ctx,
+		conn.ID,
+		historyIDs,
+		watchedExportBatchSize(exporter, len(historyIDs)),
+	)
 	if err != nil {
 		return err
 	}
@@ -1681,18 +1685,23 @@ func (s *Service) persistConnectionError(ctx context.Context, conn Connection, m
 }
 
 func limitWatchedExportBatch(exporter WatchedExporter, plays []LocalPlay) ([]LocalPlay, bool) {
-	bounded, ok := exporter.(singleBatchWatchedExporter)
+	_, ok := exporter.(singleBatchWatchedExporter)
 	if !ok {
 		return plays, false
 	}
-	limit := bounded.ExportBatchSize()
-	if limit <= 0 {
-		limit = 1
-	}
+	limit := watchedExportBatchSize(exporter, len(plays))
 	if len(plays) > limit {
 		plays = plays[:limit]
 	}
 	return plays, true
+}
+
+func watchedExportBatchSize(exporter WatchedExporter, fallback int) int {
+	bounded, ok := exporter.(singleBatchWatchedExporter)
+	if !ok {
+		return max(1, fallback)
+	}
+	return max(1, bounded.ExportBatchSize())
 }
 
 func reconcileHistoryExports(connectionID string, local []LocalPlay, remote []RemotePlay) []HistoryExport {

--- a/internal/watchsync/service_test.go
+++ b/internal/watchsync/service_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"database/sql"
 	"errors"
+	"fmt"
 	"reflect"
 	"strconv"
 	"strings"
@@ -342,6 +343,22 @@ func (r *serviceFakeRepo) ListPendingHistoryExports(_ context.Context, connectio
 			if limit > 0 && len(exports) >= limit {
 				break
 			}
+		}
+	}
+	return exports, nil
+}
+
+func (r *serviceFakeRepo) ListPendingHistoryExportsByHistoryIDs(_ context.Context, connectionID string, historyIDs []string) ([]HistoryExport, error) {
+	wanted := make(map[string]struct{}, len(historyIDs))
+	for _, historyID := range historyIDs {
+		wanted[historyID] = struct{}{}
+	}
+	var exports []HistoryExport
+	for _, export := range r.historyExports {
+		_, matches := wanted[export.HistoryID]
+		if export.ConnectionID == connectionID && matches &&
+			(export.Status == historyExportStatusPending || export.Status == historyExportStatusFailed) && export.AttemptCount < 5 {
+			exports = append(exports, export)
 		}
 	}
 	return exports, nil
@@ -790,6 +807,7 @@ func (p progressBatchImporterStub) FetchProgressBatch(context.Context, ServerCon
 type watchedExporterStub struct {
 	exportErr    error
 	exportResult ExportResult
+	exported     *[]LocalPlay
 	key          string
 	source       userstore.WatchHistorySource
 }
@@ -813,7 +831,10 @@ func (p watchedExporterStub) FetchHistory(context.Context, ServerConfig, Connect
 	return nil, nil
 }
 
-func (p watchedExporterStub) ExportHistory(context.Context, ServerConfig, Connection, []LocalPlay) (ExportResult, error) {
+func (p watchedExporterStub) ExportHistory(_ context.Context, _ ServerConfig, _ Connection, plays []LocalPlay) (ExportResult, error) {
+	if p.exported != nil {
+		*p.exported = append(*p.exported, plays...)
+	}
 	return p.exportResult, p.exportErr
 }
 
@@ -3212,6 +3233,40 @@ func TestServicePluginTransportFailureLeavesExportPending(t *testing.T) {
 	}
 	if len(repo.historyExports) != 1 || repo.historyExports[0].Status != historyExportStatusPending || repo.historyExports[0].AttemptCount != 0 {
 		t.Fatalf("history exports = %#v", repo.historyExports)
+	}
+}
+
+func TestServiceLocalWatchEventBypassesHistoricalExportBacklog(t *testing.T) {
+	repo := newServiceFakeRepo()
+	for i := 0; i < 100; i++ {
+		repo.historyExports = append(repo.historyExports, HistoryExport{
+			ID:           fmt.Sprintf("old-export-%d", i),
+			ConnectionID: "conn-1",
+			HistoryID:    fmt.Sprintf("old-history-%d", i),
+			Status:       historyExportStatusPending,
+			WatchedAt:    time.Date(2025, time.January, 1, 0, i, 0, 0, time.UTC),
+		})
+	}
+	var exported []LocalPlay
+	service := NewService(repo, NewRegistry())
+	play := LocalPlay{
+		HistoryID:       "new-history",
+		MediaItemID:     testMovieMediaID,
+		ProviderItemKey: testMovieProviderItemKey,
+		WatchedAt:       time.Date(2026, time.August, 6, 12, 0, 0, 0, time.UTC),
+	}
+	err := service.exportLocalPlays(context.Background(), Connection{ID: "conn-1"}, ServerConfig{}, watchedExporterStub{
+		exported:     &exported,
+		exportResult: ExportResult{Sent: []string{play.HistoryID}},
+	}, []LocalPlay{play})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(exported) != 1 || exported[0].HistoryID != play.HistoryID {
+		t.Fatalf("exported = %#v, want only the live event", exported)
+	}
+	if got := repo.historyExports[len(repo.historyExports)-1].Status; got != historyExportStatusSent {
+		t.Fatalf("new export status = %q, want %q", got, historyExportStatusSent)
 	}
 }
 

--- a/internal/watchsync/service_test.go
+++ b/internal/watchsync/service_test.go
@@ -47,6 +47,8 @@ type serviceFakeRepo struct {
 	settings               map[string]string
 	syncRuns               []SyncRun
 	historyExports         []HistoryExport
+	historyLookupIDs       []string
+	historyLookupLimit     int
 	listItemStates         []ListItemState
 	scrobbleConnections    []Connection
 	scrobbleSessions       []ScrobbleSession
@@ -348,7 +350,9 @@ func (r *serviceFakeRepo) ListPendingHistoryExports(_ context.Context, connectio
 	return exports, nil
 }
 
-func (r *serviceFakeRepo) ListPendingHistoryExportsByHistoryIDs(_ context.Context, connectionID string, historyIDs []string) ([]HistoryExport, error) {
+func (r *serviceFakeRepo) ListPendingHistoryExportsByHistoryIDs(_ context.Context, connectionID string, historyIDs []string, limit int) ([]HistoryExport, error) {
+	r.historyLookupIDs = append([]string(nil), historyIDs...)
+	r.historyLookupLimit = limit
 	wanted := make(map[string]struct{}, len(historyIDs))
 	for _, historyID := range historyIDs {
 		wanted[historyID] = struct{}{}
@@ -359,6 +363,9 @@ func (r *serviceFakeRepo) ListPendingHistoryExportsByHistoryIDs(_ context.Contex
 		if export.ConnectionID == connectionID && matches &&
 			(export.Status == historyExportStatusPending || export.Status == historyExportStatusFailed) && export.AttemptCount < 5 {
 			exports = append(exports, export)
+			if limit > 0 && len(exports) >= limit {
+				break
+			}
 		}
 	}
 	return exports, nil
@@ -810,6 +817,15 @@ type watchedExporterStub struct {
 	exported     *[]LocalPlay
 	key          string
 	source       userstore.WatchHistorySource
+}
+
+type singleBatchWatchedExporterStub struct {
+	watchedExporterStub
+	batchSize int
+}
+
+func (p singleBatchWatchedExporterStub) ExportBatchSize() int {
+	return p.batchSize
 }
 
 func (p watchedExporterStub) Key() string {
@@ -2693,6 +2709,12 @@ func TestServiceConfirmedStopSerializesConcurrentConfirmation(t *testing.T) {
 	}
 }
 
+func TestConfirmedStopLeaseExceedsDispatchTimeout(t *testing.T) {
+	if confirmedStopLease <= confirmedStopDispatchTimeout {
+		t.Fatalf("confirmed stop lease %s must exceed dispatch timeout %s", confirmedStopLease, confirmedStopDispatchTimeout)
+	}
+}
+
 func TestServiceConfirmedStopCannotCompleteReclaimedLease(t *testing.T) {
 	repo := newServiceFakeRepo()
 	repo.scrobbleConnections = []Connection{{
@@ -3267,6 +3289,40 @@ func TestServiceLocalWatchEventBypassesHistoricalExportBacklog(t *testing.T) {
 	}
 	if got := repo.historyExports[len(repo.historyExports)-1].Status; got != historyExportStatusSent {
 		t.Fatalf("new export status = %q, want %q", got, historyExportStatusSent)
+	}
+}
+
+func TestServiceLocalWatchEventBoundsHistoryLookupToProviderBatch(t *testing.T) {
+	repo := newServiceFakeRepo()
+	var exported []LocalPlay
+	plays := make([]LocalPlay, 0, 25)
+	for i := 0; i < 25; i++ {
+		plays = append(plays, LocalPlay{
+			HistoryID:       fmt.Sprintf("history-%d", i),
+			MediaItemID:     testMovieMediaID,
+			ProviderItemKey: testMovieProviderItemKey,
+			WatchedAt:       time.Date(2026, time.August, 6, 12, i, 0, 0, time.UTC),
+		})
+	}
+	service := NewService(repo, NewRegistry())
+	err := service.exportLocalPlays(
+		context.Background(),
+		Connection{ID: "conn-1"},
+		ServerConfig{},
+		singleBatchWatchedExporterStub{
+			watchedExporterStub: watchedExporterStub{exported: &exported},
+			batchSize:           1,
+		},
+		plays,
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if repo.historyLookupLimit != 1 {
+		t.Fatalf("history lookup limit = %d, want 1", repo.historyLookupLimit)
+	}
+	if len(exported) != 1 {
+		t.Fatalf("exported %d plays, want 1", len(exported))
 	}
 }
 

--- a/internal/watchsync/types.go
+++ b/internal/watchsync/types.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/Silo-Server/silo-server/internal/historyimport"
+	"github.com/Silo-Server/silo-server/internal/plugins"
 	"github.com/Silo-Server/silo-server/internal/userstore"
 )
 
@@ -72,6 +73,18 @@ type authoritativeRefreshProvider interface {
 // working unchanged.
 type APIKeyAuthProvider interface {
 	ConnectWithAPIKey(ctx context.Context, apiKey string) (TokenSet, ProviderAccount, error)
+}
+
+// ConnectionConfigValues contains manifest-declared, per-connection setup
+// values keyed first by config-schema key and then by field key.
+type ConnectionConfigValues map[string]map[string]any
+
+type configuredAPIKeyAuthProvider interface {
+	ConnectWithAPIKeyConfig(ctx context.Context, apiKey string, config ConnectionConfigValues) (TokenSet, ProviderAccount, error)
+}
+
+type connectionConfigProvider interface {
+	ConnectionConfigSchema() []plugins.ConfigSchemaView
 }
 
 type WatchedImporter interface {
@@ -660,38 +673,40 @@ func (f RemoteFavorite) HistoryRecord() historyimport.Record {
 }
 
 type ProviderSummary struct {
-	Key          string       `json:"key"`
-	DisplayName  string       `json:"display_name"`
-	Capabilities Capabilities `json:"capabilities"`
+	Key                    string                     `json:"key"`
+	DisplayName            string                     `json:"display_name"`
+	Capabilities           Capabilities               `json:"capabilities"`
+	ConnectionConfigSchema []plugins.ConfigSchemaView `json:"connection_config_schema,omitempty"`
 }
 
 type ConnectionStatus struct {
-	Provider                     string       `json:"provider"`
-	DisplayName                  string       `json:"display_name"`
-	Capabilities                 Capabilities `json:"capabilities"`
-	AuthMethod                   string       `json:"auth_method"`
-	Connected                    bool         `json:"connected"`
-	ProviderUsername             string       `json:"provider_username,omitempty"`
-	ImportWatchedEnabled         bool         `json:"import_watched_enabled"`
-	ImportProgressEnabled        bool         `json:"import_progress_enabled"`
-	ExportWatchedEnabled         bool         `json:"export_watched_enabled"`
-	ExportUnwatchedEnabled       bool         `json:"export_unwatched_enabled"`
-	ImportFavoritesEnabled       bool         `json:"import_favorites_enabled"`
-	ExportFavoritesEnabled       bool         `json:"export_favorites_enabled"`
-	SyncFavoriteRemovalsEnabled  bool         `json:"sync_favorite_removals_enabled"`
-	ImportWatchlistEnabled       bool         `json:"import_watchlist_enabled"`
-	ExportWatchlistEnabled       bool         `json:"export_watchlist_enabled"`
-	SyncWatchlistRemovalsEnabled bool         `json:"sync_watchlist_removals_enabled"`
-	SyncWatchlistOrderEnabled    bool         `json:"sync_watchlist_order_enabled"`
-	ScrobbleEnabled              bool         `json:"scrobble_enabled"`
-	CredentialsConfigured        bool         `json:"credentials_configured"`
-	LastInboundSyncAt            *time.Time   `json:"last_inbound_sync_at,omitempty"`
-	LastProgressSyncAt           *time.Time   `json:"last_progress_sync_at,omitempty"`
-	LastOutboundSyncAt           *time.Time   `json:"last_outbound_sync_at,omitempty"`
-	LastFavoritesSyncAt          *time.Time   `json:"last_favorites_sync_at,omitempty"`
-	LastWatchlistSyncAt          *time.Time   `json:"last_watchlist_sync_at,omitempty"`
-	LastScrobbleErrorAt          *time.Time   `json:"last_scrobble_error_at,omitempty"`
-	LastError                    string       `json:"last_error,omitempty"`
+	Provider                     string                     `json:"provider"`
+	DisplayName                  string                     `json:"display_name"`
+	Capabilities                 Capabilities               `json:"capabilities"`
+	AuthMethod                   string                     `json:"auth_method"`
+	Connected                    bool                       `json:"connected"`
+	ProviderUsername             string                     `json:"provider_username,omitempty"`
+	ImportWatchedEnabled         bool                       `json:"import_watched_enabled"`
+	ImportProgressEnabled        bool                       `json:"import_progress_enabled"`
+	ExportWatchedEnabled         bool                       `json:"export_watched_enabled"`
+	ExportUnwatchedEnabled       bool                       `json:"export_unwatched_enabled"`
+	ImportFavoritesEnabled       bool                       `json:"import_favorites_enabled"`
+	ExportFavoritesEnabled       bool                       `json:"export_favorites_enabled"`
+	SyncFavoriteRemovalsEnabled  bool                       `json:"sync_favorite_removals_enabled"`
+	ImportWatchlistEnabled       bool                       `json:"import_watchlist_enabled"`
+	ExportWatchlistEnabled       bool                       `json:"export_watchlist_enabled"`
+	SyncWatchlistRemovalsEnabled bool                       `json:"sync_watchlist_removals_enabled"`
+	SyncWatchlistOrderEnabled    bool                       `json:"sync_watchlist_order_enabled"`
+	ScrobbleEnabled              bool                       `json:"scrobble_enabled"`
+	CredentialsConfigured        bool                       `json:"credentials_configured"`
+	ConnectionConfigSchema       []plugins.ConfigSchemaView `json:"connection_config_schema,omitempty"`
+	LastInboundSyncAt            *time.Time                 `json:"last_inbound_sync_at,omitempty"`
+	LastProgressSyncAt           *time.Time                 `json:"last_progress_sync_at,omitempty"`
+	LastOutboundSyncAt           *time.Time                 `json:"last_outbound_sync_at,omitempty"`
+	LastFavoritesSyncAt          *time.Time                 `json:"last_favorites_sync_at,omitempty"`
+	LastWatchlistSyncAt          *time.Time                 `json:"last_watchlist_sync_at,omitempty"`
+	LastScrobbleErrorAt          *time.Time                 `json:"last_scrobble_error_at,omitempty"`
+	LastError                    string                     `json:"last_error,omitempty"`
 }
 
 type ConnectionUpdate struct {

--- a/web/src/components/admin/plugins/PluginConfigForm.test.tsx
+++ b/web/src/components/admin/plugins/PluginConfigForm.test.tsx
@@ -36,6 +36,30 @@ const schema: PluginConfigSchema = {
 };
 
 describe("PluginConfigForm secrets", () => {
+  it("derives a form when a plugin only supplies JSON Schema", () => {
+    render(
+      <PluginConfigForm
+        schema={{
+          key: "server",
+          title: "Server",
+          json_schema: JSON.stringify({
+            type: "object",
+            properties: {
+              base_url: { type: "string", title: "Base URL" },
+              api_key: { type: "string", format: "password" },
+            },
+            required: ["base_url", "api_key"],
+          }),
+          required: true,
+        }}
+        onSave={vi.fn()}
+      />,
+    );
+
+    expect(screen.getByLabelText("Base URL")).toBeInTheDocument();
+    expect(screen.getByLabelText("Api Key")).toHaveAttribute("type", "password");
+  });
+
   it("shows redacted saved state and only clears through an explicit action", async () => {
     const onSave = vi.fn();
     render(

--- a/web/src/components/admin/plugins/PluginConfigForm.tsx
+++ b/web/src/components/admin/plugins/PluginConfigForm.tsx
@@ -10,10 +10,13 @@ import { ConnectionCheckAction } from "@/components/admin/ConnectionCheckAction"
 import { Button } from "@/components/ui/button";
 import { Label } from "@/components/ui/label";
 
+import { adminFormForConfigSchema, humanizeConfigKey } from "./configSchemaAdminForm";
 import { SchemaForm } from "./SchemaForm";
 import { buildSchemaValues } from "./schemaFormUtils";
 
 type PluginConfigValue = Record<string, unknown>;
+
+const EMPTY_FIELDS: PluginAdminFormField[] = [];
 
 type Props = {
   schema: PluginConfigSchema;
@@ -29,82 +32,7 @@ type Props = {
   isTesting?: boolean;
 };
 
-type SupportedField = PluginAdminFormField & {
-  inferredType?: "string" | "number" | "integer" | "boolean";
-};
-
-type ParsedObjectSchema = {
-  supported: boolean;
-  fields: SupportedField[];
-};
-
-function humanizeKey(value: string) {
-  return value
-    .split("_")
-    .filter(Boolean)
-    .map((part) => part.charAt(0).toUpperCase() + part.slice(1))
-    .join(" ");
-}
-
-function parseJSONSchema(schema: PluginConfigSchema): ParsedObjectSchema {
-  try {
-    const parsed = JSON.parse(schema.json_schema) as {
-      type?: string;
-      required?: string[];
-      properties?: Record<
-        string,
-        {
-          type?: string;
-          title?: string;
-          description?: string;
-          writeOnly?: boolean;
-          format?: string;
-        }
-      >;
-    };
-    if (parsed.type !== "object" || !parsed.properties) {
-      return { supported: false, fields: [] };
-    }
-
-    const fields = Object.entries(parsed.properties).map(([key, property]) => {
-      const propertyType = property.type;
-      if (!propertyType || !["string", "number", "integer", "boolean"].includes(propertyType)) {
-        return null;
-      }
-      const isSensitive = property.writeOnly === true || property.format === "password";
-      const control =
-        propertyType === "boolean"
-          ? "SWITCH"
-          : propertyType === "number" || propertyType === "integer"
-            ? "NUMBER"
-            : isSensitive
-              ? "PASSWORD"
-              : "TEXT";
-      return {
-        key,
-        label: property.title || humanizeKey(key),
-        description: property.description,
-        control,
-        placeholder: "",
-        required: parsed.required?.includes(key) ?? false,
-        secret: isSensitive,
-        multiline: false,
-        options: [],
-        rows: 0,
-        inferredType: propertyType as "string" | "number" | "integer" | "boolean",
-      } satisfies SupportedField;
-    });
-
-    if (fields.some((field) => field == null)) {
-      return { supported: false, fields: [] };
-    }
-    return { supported: true, fields: fields.filter(Boolean) as SupportedField[] };
-  } catch {
-    return { supported: false, fields: [] };
-  }
-}
-
-function defaultValueForField(field: SupportedField): string | boolean {
+function defaultValueForField(field: PluginAdminFormField): string | boolean {
   if (field.default_value !== undefined) {
     if (typeof field.default_value === "boolean") {
       return field.default_value;
@@ -122,7 +50,10 @@ function defaultValueForField(field: SupportedField): string | boolean {
   return "";
 }
 
-function valueForField(field: SupportedField, configValue?: PluginConfigValue): string | boolean {
+function valueForField(
+  field: PluginAdminFormField,
+  configValue?: PluginConfigValue,
+): string | boolean {
   const raw = configValue?.[field.key];
   if (typeof raw === "boolean") {
     return raw;
@@ -145,19 +76,12 @@ export function PluginConfigForm({
   isSaving = false,
   isTesting = false,
 }: Props) {
-  const parsedFallback = useMemo(() => parseJSONSchema(schema), [schema]);
-  const fields = useMemo<SupportedField[]>(() => {
-    if (schema.admin_form?.fields?.length) {
-      return schema.admin_form.fields;
-    }
-    return parsedFallback.fields;
-  }, [parsedFallback.fields, schema.admin_form?.fields]);
-
-  const supported =
-    fields.length > 0 && (schema.admin_form?.fields?.length ? true : parsedFallback.supported);
+  const inferredDescriptor = useMemo(() => adminFormForConfigSchema(schema), [schema]);
+  const fields = inferredDescriptor?.fields ?? EMPTY_FIELDS;
+  const supported = inferredDescriptor != null;
 
   const descriptor = useMemo<PluginAdminForm>(() => {
-    const base = schema.admin_form ?? { fields };
+    const base = inferredDescriptor ?? { fields };
     const configured = new Set(configuredSecrets);
     return {
       ...base,
@@ -167,7 +91,7 @@ export function PluginConfigForm({
           : field,
       ),
     };
-  }, [configuredSecrets, fields, schema.admin_form]);
+  }, [configuredSecrets, fields, inferredDescriptor]);
 
   const [values, setValues] = useState<PluginConfigValue>(() =>
     Object.fromEntries(fields.map((field) => [field.key, valueForField(field, value)])),
@@ -248,7 +172,7 @@ export function PluginConfigForm({
             return (
               <div key={key} className="flex items-center justify-between gap-3 text-xs">
                 <span className={clearing ? "text-destructive" : "text-muted-foreground"}>
-                  {field?.label || humanizeKey(key)}: {clearing ? "will be cleared" : "saved"}
+                  {field?.label || humanizeConfigKey(key)}: {clearing ? "will be cleared" : "saved"}
                   {required ? " (required)" : ""}
                 </span>
                 {!required ? (

--- a/web/src/components/admin/plugins/SchemaForm.test.tsx
+++ b/web/src/components/admin/plugins/SchemaForm.test.tsx
@@ -98,6 +98,32 @@ describe("SchemaForm", () => {
       "true",
     );
   });
+  it("uses a controlling field default when rendering a conditional field", () => {
+    const d: PluginAdminForm = {
+      fields: [
+        {
+          key: "advanced_enabled",
+          label: "Advanced",
+          control: "SWITCH",
+          required: false,
+          secret: false,
+          multiline: false,
+          default_value: true,
+        },
+        {
+          key: "endpoint",
+          label: "Endpoint",
+          control: "TEXT",
+          required: false,
+          secret: false,
+          multiline: false,
+          show_when: [{ field: "advanced_enabled", equals: ["true"] }],
+        },
+      ],
+    };
+    render(<SchemaForm descriptor={d} values={{}} onChange={vi.fn()} />);
+    expect(screen.getByText("Endpoint")).toBeTruthy();
+  });
   it("reports validity through onValidityChange (#14)", () => {
     const onValidityChange = vi.fn();
     const d: PluginAdminForm = {
@@ -192,6 +218,43 @@ describe("SchemaForm collapsible sections", () => {
     );
     fireEvent.click(screen.getByText("Show"));
     expect(screen.getByText("Verbose")).toBeTruthy();
+  });
+
+  it("uses a controlling field default when rendering a conditional section", () => {
+    const d: PluginAdminForm = {
+      fields: [
+        {
+          key: "advanced_enabled",
+          label: "Advanced",
+          control: "SWITCH",
+          required: false,
+          secret: false,
+          multiline: false,
+          default_value: true,
+        },
+        {
+          key: "endpoint",
+          label: "Endpoint",
+          control: "TEXT",
+          required: false,
+          secret: false,
+          multiline: false,
+        },
+      ],
+      sections: [
+        {
+          key: "advanced",
+          title: "Advanced options",
+          collapsible: false,
+          collapsed_default: false,
+          field_keys: ["endpoint"],
+          show_when: [{ field: "advanced_enabled", equals: ["true"] }],
+        },
+      ],
+    };
+    render(<SchemaForm descriptor={d} values={{}} onChange={vi.fn()} />);
+    expect(screen.getByText("Advanced options")).toBeTruthy();
+    expect(screen.getByText("Endpoint")).toBeTruthy();
   });
 });
 

--- a/web/src/components/admin/plugins/SchemaForm.tsx
+++ b/web/src/components/admin/plugins/SchemaForm.tsx
@@ -97,11 +97,13 @@ function ChipsSkeleton() {
 function SchemaFormSection({
   section,
   values,
+  fields,
   forceOpen,
   renderFields,
 }: {
   section: PluginAdminFormSection;
   values: Record<string, unknown>;
+  fields: PluginAdminFormField[];
   forceOpen: boolean;
   renderFields: (keys: string[]) => React.ReactNode;
 }) {
@@ -109,7 +111,7 @@ function SchemaFormSection({
   // (the section has unresolved errors) always wins so setup can't be hidden.
   const [userOpen, setUserOpen] = useState<boolean | null>(null);
 
-  if (!evaluateShowWhen(section.show_when, values)) {
+  if (!evaluateShowWhen(section.show_when, values, fields)) {
     return null;
   }
 
@@ -331,7 +333,9 @@ export function SchemaForm({
   // bordered, divided container so toggles read as a cohesive group instead of
   // a column of separate boxes. Honors show_when on each field.
   function renderFieldList(fields: PluginAdminFormField[]): React.ReactNode {
-    const visible = fields.filter((field) => evaluateShowWhen(field.show_when, values));
+    const visible = fields.filter((field) =>
+      evaluateShowWhen(field.show_when, values, descriptor.fields),
+    );
     const nodes: React.ReactNode[] = [];
     let run: PluginAdminFormField[] = [];
     // Key switch groups by their position in the list, not by their first
@@ -389,6 +393,7 @@ export function SchemaForm({
           key={section.key}
           section={section}
           values={values}
+          fields={descriptor.fields}
           forceOpen={section.field_keys.some((key) => mergedErrors[key] != null)}
           renderFields={(keys) => renderFieldList(resolveKeys(keys))}
         />

--- a/web/src/components/admin/plugins/configSchemaAdminForm.test.ts
+++ b/web/src/components/admin/plugins/configSchemaAdminForm.test.ts
@@ -89,4 +89,53 @@ describe("adminFormForConfigSchema", () => {
       explicit,
     );
   });
+
+  it("applies JSON Schema sensitivity to matching explicit fields", () => {
+    const form = adminFormForConfigSchema(
+      schema({
+        json_schema: JSON.stringify({
+          type: "object",
+          properties: {
+            api_key: { type: "string", writeOnly: true },
+            password: { type: "string", format: "password" },
+            advanced: { type: "object", writeOnly: true },
+          },
+        }),
+        admin_form: {
+          fields: [
+            {
+              key: "api_key",
+              label: "API Key",
+              control: "TEXT",
+              required: false,
+              secret: false,
+              multiline: false,
+            },
+            {
+              key: "password",
+              label: "Password",
+              control: "TEXT",
+              required: false,
+              secret: false,
+              multiline: false,
+            },
+            {
+              key: "advanced",
+              label: "Advanced",
+              control: "TEXTAREA",
+              required: false,
+              secret: false,
+              multiline: true,
+            },
+          ],
+        },
+      }),
+    );
+
+    expect(form?.fields.map(({ key, secret }) => ({ key, secret }))).toEqual([
+      { key: "api_key", secret: true },
+      { key: "password", secret: true },
+      { key: "advanced", secret: true },
+    ]);
+  });
 });

--- a/web/src/components/admin/plugins/configSchemaAdminForm.test.ts
+++ b/web/src/components/admin/plugins/configSchemaAdminForm.test.ts
@@ -1,0 +1,92 @@
+import { describe, expect, it } from "vitest";
+
+import type { PluginConfigSchema } from "@/api/types";
+
+import { adminFormForConfigSchema } from "./configSchemaAdminForm";
+
+function schema(overrides: Partial<PluginConfigSchema> = {}): PluginConfigSchema {
+  return {
+    key: "connection",
+    title: "Connection",
+    json_schema: JSON.stringify({
+      type: "object",
+      properties: {},
+      additionalProperties: false,
+    }),
+    required: true,
+    ...overrides,
+  };
+}
+
+describe("adminFormForConfigSchema", () => {
+  it("preserves primitive JSON Schema defaults on inferred fields", () => {
+    const form = adminFormForConfigSchema(
+      schema({
+        json_schema: JSON.stringify({
+          type: "object",
+          properties: {
+            base_url: { type: "string", default: "https://floppy.example.com" },
+            port: { type: "integer", default: 8080 },
+            verify_tls: { type: "boolean", default: true },
+          },
+        }),
+      }),
+    );
+
+    expect(form?.fields.map(({ key, default_value }) => ({ key, default_value }))).toEqual([
+      { key: "base_url", default_value: "https://floppy.example.com" },
+      { key: "port", default_value: 8080 },
+      { key: "verify_tls", default_value: true },
+    ]);
+  });
+
+  it("adds scalar schema properties omitted by a partial admin form", () => {
+    const form = adminFormForConfigSchema(
+      schema({
+        json_schema: JSON.stringify({
+          type: "object",
+          properties: {
+            base_url: { type: "string" },
+            username: { type: "string" },
+          },
+          required: ["base_url", "username"],
+        }),
+        admin_form: {
+          fields: [
+            {
+              key: "base_url",
+              label: "Custom URL",
+              control: "TEXT",
+              required: true,
+              secret: false,
+              multiline: false,
+            },
+          ],
+        },
+      }),
+    );
+
+    expect(form?.fields.map(({ key, label, required }) => ({ key, label, required }))).toEqual([
+      { key: "base_url", label: "Custom URL", required: true },
+      { key: "username", label: "Username", required: true },
+    ]);
+  });
+
+  it("preserves an explicit form when its schema cannot be inferred", () => {
+    const explicit = {
+      fields: [
+        {
+          key: "api_key",
+          label: "API Key",
+          control: "PASSWORD" as const,
+          required: true,
+          secret: true,
+          multiline: false,
+        },
+      ],
+    };
+    expect(adminFormForConfigSchema(schema({ json_schema: "", admin_form: explicit }))).toBe(
+      explicit,
+    );
+  });
+});

--- a/web/src/components/admin/plugins/configSchemaAdminForm.ts
+++ b/web/src/components/admin/plugins/configSchemaAdminForm.ts
@@ -1,0 +1,69 @@
+import type { PluginAdminForm, PluginAdminFormField, PluginConfigSchema } from "@/api/types";
+
+export function humanizeConfigKey(value: string) {
+  return value
+    .split("_")
+    .filter(Boolean)
+    .map((part) => part.charAt(0).toUpperCase() + part.slice(1))
+    .join(" ");
+}
+
+export function adminFormForConfigSchema(schema: PluginConfigSchema): PluginAdminForm | null {
+  if (schema.admin_form?.fields?.length) return schema.admin_form;
+
+  try {
+    const parsed = JSON.parse(schema.json_schema) as {
+      type?: string;
+      required?: string[];
+      properties?: Record<
+        string,
+        {
+          type?: string;
+          title?: string;
+          description?: string;
+          writeOnly?: boolean;
+          format?: string;
+        }
+      >;
+    };
+    if (parsed.type !== "object" || !parsed.properties) return null;
+
+    const fields = Object.entries(parsed.properties).map(
+      ([key, property]): PluginAdminFormField | null => {
+        const propertyType = property.type;
+        if (!propertyType || !["string", "number", "integer", "boolean"].includes(propertyType)) {
+          return null;
+        }
+        const secret = property.writeOnly === true || property.format === "password";
+        const control =
+          propertyType === "boolean"
+            ? "SWITCH"
+            : propertyType === "number" || propertyType === "integer"
+              ? "NUMBER"
+              : secret
+                ? "PASSWORD"
+                : "TEXT";
+        return {
+          key,
+          label: property.title || humanizeConfigKey(key),
+          description: property.description,
+          control,
+          placeholder: "",
+          required: parsed.required?.includes(key) ?? false,
+          secret,
+          multiline: false,
+          options: [],
+          rows: 0,
+        };
+      },
+    );
+    if (fields.some((field) => field == null)) return null;
+
+    return {
+      ...schema.admin_form,
+      fields: fields.filter((field): field is PluginAdminFormField => field != null),
+    };
+  } catch {
+    return null;
+  }
+}

--- a/web/src/components/admin/plugins/configSchemaAdminForm.ts
+++ b/web/src/components/admin/plugins/configSchemaAdminForm.ts
@@ -9,8 +9,7 @@ export function humanizeConfigKey(value: string) {
 }
 
 export function adminFormForConfigSchema(schema: PluginConfigSchema): PluginAdminForm | null {
-  if (schema.admin_form?.fields?.length) return schema.admin_form;
-
+  const explicitFields = schema.admin_form?.fields ?? [];
   try {
     const parsed = JSON.parse(schema.json_schema) as {
       type?: string;
@@ -23,12 +22,15 @@ export function adminFormForConfigSchema(schema: PluginConfigSchema): PluginAdmi
           description?: string;
           writeOnly?: boolean;
           format?: string;
+          default?: unknown;
         }
       >;
     };
-    if (parsed.type !== "object" || !parsed.properties) return null;
+    if (parsed.type !== "object" || !parsed.properties) {
+      return explicitFields.length > 0 ? schema.admin_form! : null;
+    }
 
-    const fields = Object.entries(parsed.properties).map(
+    const inferredFields = Object.entries(parsed.properties).map(
       ([key, property]): PluginAdminFormField | null => {
         const propertyType = property.type;
         if (!propertyType || !["string", "number", "integer", "boolean"].includes(propertyType)) {
@@ -52,18 +54,38 @@ export function adminFormForConfigSchema(schema: PluginConfigSchema): PluginAdmi
           required: parsed.required?.includes(key) ?? false,
           secret,
           multiline: false,
+          default_value:
+            typeof property.default === "string" ||
+            typeof property.default === "number" ||
+            typeof property.default === "boolean"
+              ? property.default
+              : undefined,
           options: [],
           rows: 0,
         };
       },
     );
-    if (fields.some((field) => field == null)) return null;
+
+    if (explicitFields.length > 0) {
+      const explicitKeys = new Set(explicitFields.map((field) => field.key));
+      return {
+        ...schema.admin_form,
+        fields: [
+          ...explicitFields,
+          ...inferredFields.filter(
+            (field): field is PluginAdminFormField => field != null && !explicitKeys.has(field.key),
+          ),
+        ],
+      };
+    }
+
+    if (inferredFields.some((field) => field == null)) return null;
 
     return {
       ...schema.admin_form,
-      fields: fields.filter((field): field is PluginAdminFormField => field != null),
+      fields: inferredFields.filter((field): field is PluginAdminFormField => field != null),
     };
   } catch {
-    return null;
+    return explicitFields.length > 0 ? schema.admin_form! : null;
   }
 }

--- a/web/src/components/admin/plugins/configSchemaAdminForm.ts
+++ b/web/src/components/admin/plugins/configSchemaAdminForm.ts
@@ -68,10 +68,17 @@ export function adminFormForConfigSchema(schema: PluginConfigSchema): PluginAdmi
 
     if (explicitFields.length > 0) {
       const explicitKeys = new Set(explicitFields.map((field) => field.key));
+      const sensitiveKeys = new Set(
+        Object.entries(parsed.properties)
+          .filter(([, property]) => property.writeOnly === true || property.format === "password")
+          .map(([key]) => key),
+      );
       return {
         ...schema.admin_form,
         fields: [
-          ...explicitFields,
+          ...explicitFields.map((field) =>
+            sensitiveKeys.has(field.key) ? { ...field, secret: true } : field,
+          ),
           ...inferredFields.filter(
             (field): field is PluginAdminFormField => field != null && !explicitKeys.has(field.key),
           ),

--- a/web/src/components/admin/plugins/schemaFormUtils.test.ts
+++ b/web/src/components/admin/plugins/schemaFormUtils.test.ts
@@ -172,6 +172,7 @@ describe("parseFieldTypes (#15)", () => {
         root_folder: { type: "string" },
         tags: { type: "array", items: { type: "integer" } },
         labels: { type: "array", items: { type: "string" } },
+        flags: { type: "array", items: { type: "boolean" } },
         enabled: { type: "boolean" },
       },
     });
@@ -180,6 +181,7 @@ describe("parseFieldTypes (#15)", () => {
       root_folder: "string",
       tags: "array:int",
       labels: "array",
+      flags: "array:bool",
       enabled: "boolean",
     });
   });
@@ -441,5 +443,65 @@ describe("coerceFieldValue array:num coercion (CodeRabbit #5)", () => {
   it("leaves array:int as integer-only and non-numeric strings untouched", () => {
     expect(coerceFieldValue(numArrayField, ["1.5", "2"], "array:int")).toEqual(["1.5", 2]);
     expect(coerceFieldValue(numArrayField, ["abc"], "array:num")).toEqual(["abc"]);
+  });
+});
+
+describe("coerceFieldValue array:bool coercion", () => {
+  it("coerces boolean multi-select values using their declared item type", () => {
+    expect(coerceFieldValue(numArrayField, ["true", "false", true], "array:bool")).toEqual([
+      true,
+      false,
+      true,
+    ]);
+  });
+});
+
+describe("section visibility", () => {
+  const sectionDescriptor: PluginAdminForm = {
+    fields: [
+      {
+        key: "advanced_enabled",
+        label: "Advanced",
+        control: "SWITCH",
+        required: false,
+        secret: false,
+        multiline: false,
+        default_value: false,
+      },
+      {
+        key: "endpoint",
+        label: "Endpoint",
+        control: "TEXT",
+        required: true,
+        secret: false,
+        multiline: false,
+      },
+    ],
+    sections: [
+      {
+        key: "advanced",
+        title: "Advanced",
+        collapsible: false,
+        collapsed_default: false,
+        field_keys: ["endpoint"],
+        show_when: [{ field: "advanced_enabled", equals: ["true"] }],
+      },
+    ],
+  };
+
+  it("does not validate required fields in a hidden section", () => {
+    expect(validateSchemaValues(sectionDescriptor, { endpoint: "stale" })).toEqual({});
+    expect(validateSchemaValues(sectionDescriptor, { advanced_enabled: true }).endpoint).toMatch(
+      /required/i,
+    );
+  });
+
+  it("does not persist stale values from a hidden section", () => {
+    expect(buildSchemaValues(sectionDescriptor, { endpoint: "stale" })).toEqual({
+      advanced_enabled: false,
+    });
+    expect(
+      buildSchemaValues(sectionDescriptor, { advanced_enabled: true, endpoint: "active" }),
+    ).toEqual({ advanced_enabled: true, endpoint: "active" });
   });
 });

--- a/web/src/components/admin/plugins/schemaFormUtils.ts
+++ b/web/src/components/admin/plugins/schemaFormUtils.ts
@@ -45,7 +45,7 @@ export function validateSchemaValues(
 ): Record<string, string> {
   const errors: Record<string, string> = {};
   for (const field of descriptor.fields) {
-    if (!evaluateShowWhen(field.show_when, values, descriptor.fields)) continue;
+    if (!fieldIsVisible(descriptor, field, values)) continue;
     const raw = effectiveValue(field, values);
     if (field.required && isEmpty(raw)) {
       errors[field.key] = `${field.label || field.key} is required`;
@@ -120,6 +120,7 @@ export type FieldType =
   | "number"
   | "boolean"
   | "array"
+  | "array:bool"
   | "array:int"
   | "array:num";
 
@@ -150,6 +151,7 @@ export function parseFieldTypes(jsonSchema: string | undefined | null): Record<s
         items && typeof items === "object" ? (items as { type?: unknown }).type : undefined;
       if (itemType === "integer") out[key] = "array:int";
       else if (itemType === "number") out[key] = "array:num";
+      else if (itemType === "boolean") out[key] = "array:bool";
       else out[key] = "array";
     } else if (type === "string" || type === "integer" || type === "number" || type === "boolean") {
       out[key] = type;
@@ -191,10 +193,12 @@ export function coerceFieldValue(
         return raw;
       }
       case "array":
+      case "array:bool":
       case "array:int":
       case "array:num": {
         const arr = Array.isArray(raw) ? raw : [];
         if (fieldType === "array") return arr;
+        if (fieldType === "array:bool") return arr.map((v) => coerceBoolean(v));
         if (fieldType === "array:int") return arr.map((v) => coerceNumericString(v));
         return arr.map((v) => coerceNumberString(v));
       }
@@ -237,6 +241,23 @@ export function effectiveValue(
   return values[field.key] !== undefined ? values[field.key] : field.default_value;
 }
 
+export function fieldIsVisible(
+  descriptor: PluginAdminForm,
+  field: PluginAdminFormField,
+  values: Record<string, unknown>,
+): boolean {
+  if (!evaluateShowWhen(field.show_when, values, descriptor.fields)) return false;
+  const containingSections = (descriptor.sections ?? []).filter((section) =>
+    section.field_keys.includes(field.key),
+  );
+  return (
+    containingSections.length === 0 ||
+    containingSections.some((section) =>
+      evaluateShowWhen(section.show_when, values, descriptor.fields),
+    )
+  );
+}
+
 export function buildSchemaValues(
   descriptor: PluginAdminForm,
   draft: Record<string, unknown>,
@@ -244,7 +265,7 @@ export function buildSchemaValues(
 ): Record<string, unknown> {
   const out: Record<string, unknown> = {};
   for (const field of descriptor.fields) {
-    if (!evaluateShowWhen(field.show_when, draft, descriptor.fields)) continue; // don't persist hidden fields' stale values
+    if (!fieldIsVisible(descriptor, field, draft)) continue; // don't persist hidden fields' stale values
     // Fall back to the declared default for untouched fields so an unmodified
     // default persists exactly as it is displayed.
     const rawSource = draft[field.key] !== undefined ? draft[field.key] : field.default_value;

--- a/web/src/hooks/queries/watchProviders.test.ts
+++ b/web/src/hooks/queries/watchProviders.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it, vi } from "vitest";
 import {
+  connectWatchProviderAPIKey,
   fetchWatchProviders,
   pollWatchProviderDeviceAuth,
   startWatchProviderDeviceAuth,
@@ -42,6 +43,7 @@ vi.mock("@/api/client", () => ({
     return {
       path,
       method: init?.method ?? "GET",
+      body: init?.body,
     };
   }),
 }));
@@ -60,6 +62,18 @@ describe("watch provider queries", () => {
     await expect(pollWatchProviderDeviceAuth("trakt", "auth-1")).resolves.toMatchObject({
       path: "/watch-providers/trakt/auth/poll",
       method: "POST",
+    });
+    await expect(
+      connectWatchProviderAPIKey("plugin:4:floppy", "token", {
+        floppy: { base_url: "https://floppy.example.com" },
+      }),
+    ).resolves.toMatchObject({
+      path: "/watch-providers/plugin:4:floppy/auth/api-key",
+      method: "POST",
+      body: JSON.stringify({
+        api_key: "token",
+        connection_config: { floppy: { base_url: "https://floppy.example.com" } },
+      }),
     });
     await expect(
       updateWatchProviderConnection("trakt", { scrobble_enabled: true }),

--- a/web/src/hooks/queries/watchProviders.ts
+++ b/web/src/hooks/queries/watchProviders.ts
@@ -3,11 +3,15 @@ import { api, ApiClientError } from "@/api/client";
 import { favoriteKeys, watchlistKeys, watchProviderKeys } from "./keys";
 import { toast } from "sonner";
 import { storage } from "@/utils/storage";
+import type { PluginConfigSchema } from "@/api/types";
+
+export type WatchProviderConnectionConfig = Record<string, Record<string, unknown>>;
 
 export interface WatchProviderSummary {
   key: string;
   display_name: string;
   capabilities: WatchProviderCapabilities;
+  connection_config_schema?: PluginConfigSchema[];
 }
 
 export const WatchProviderAuthMethod = {
@@ -52,6 +56,7 @@ export interface WatchProviderConnection {
   sync_watchlist_order_enabled: boolean;
   scrobble_enabled: boolean;
   credentials_configured: boolean;
+  connection_config_schema?: PluginConfigSchema[];
   last_inbound_sync_at?: string;
   last_progress_sync_at?: string;
   last_outbound_sync_at?: string;
@@ -159,10 +164,14 @@ export function pollWatchProviderDeviceAuth(provider: string, authSessionId: str
   });
 }
 
-export function connectWatchProviderAPIKey(provider: string, apiKey: string) {
+export function connectWatchProviderAPIKey(
+  provider: string,
+  apiKey: string,
+  connectionConfig: WatchProviderConnectionConfig = {},
+) {
   return api<WatchProviderConnection>(`/watch-providers/${provider}/auth/api-key`, {
     method: "POST",
-    body: JSON.stringify({ api_key: apiKey }),
+    body: JSON.stringify({ api_key: apiKey, connection_config: connectionConfig }),
   });
 }
 
@@ -248,7 +257,13 @@ export function usePollWatchProviderDeviceAuth(provider: string) {
 export function useConnectWatchProviderAPIKey(provider: string) {
   const queryClient = useQueryClient();
   return useMutation({
-    mutationFn: (apiKey: string) => connectWatchProviderAPIKey(provider, apiKey),
+    mutationFn: ({
+      apiKey,
+      connectionConfig,
+    }: {
+      apiKey: string;
+      connectionConfig?: WatchProviderConnectionConfig;
+    }) => connectWatchProviderAPIKey(provider, apiKey, connectionConfig),
     onSuccess: (connection) => {
       const profileId = getActiveProfileId();
       queryClient.setQueryData(watchProviderKeys.connection(profileId, provider), connection);

--- a/web/src/pages/settings/WatchProvidersSettings.tsx
+++ b/web/src/pages/settings/WatchProvidersSettings.tsx
@@ -671,7 +671,9 @@ function WatchProviderCard({ providerKey }: { providerKey: string }) {
                 description="When you mark something unwatched, remove matching history from this provider."
                 checked={connection.export_unwatched_enabled}
                 disabled={isBusy}
-                onChange={(checked) => updateConnection.mutate({ export_unwatched_enabled: checked })}
+                onChange={(checked) =>
+                  updateConnection.mutate({ export_unwatched_enabled: checked })
+                }
               />
             ) : null}
             {connection.capabilities.import_favorites ||

--- a/web/src/pages/settings/WatchProvidersSettings.tsx
+++ b/web/src/pages/settings/WatchProvidersSettings.tsx
@@ -33,6 +33,10 @@ import {
 } from "@/hooks/queries/watchProviders";
 import { Input } from "@/components/ui/input";
 import { formatRelativeTime as formatRelativeTimeBase } from "@/lib/date";
+import { SchemaForm } from "@/components/admin/plugins/SchemaForm";
+import { buildSchemaValues, parseFieldTypes } from "@/components/admin/plugins/schemaFormUtils";
+import type { PluginConfigSchema } from "@/api/types";
+import type { WatchProviderConnectionConfig } from "@/hooks/queries/watchProviders";
 
 function formatRelativeTime(value?: string) {
   return formatRelativeTimeBase(value, { rounding: "floor", justNowLabel: "Just now" }) ?? "Never";
@@ -206,17 +210,41 @@ function AuthCodeBlock({
 
 function APIKeyBlock({
   displayName,
+  configSchemas,
   pending,
   onSubmit,
   onCancel,
 }: {
   displayName: string;
+  configSchemas: PluginConfigSchema[];
   pending: boolean;
-  onSubmit: (apiKey: string) => void;
+  onSubmit: (apiKey: string, connectionConfig: WatchProviderConnectionConfig) => void;
   onCancel: () => void;
 }) {
   const [value, setValue] = useState("");
+  const [connectionConfig, setConnectionConfig] = useState<WatchProviderConnectionConfig>({});
+  const [configValidity, setConfigValidity] = useState<Record<string, boolean>>({});
   const trimmed = value.trim();
+  const configValid = configSchemas.every(
+    (schema) => configValidity[schema.key] ?? !schema.required,
+  );
+
+  const configuredValues = () =>
+    Object.fromEntries(
+      configSchemas.flatMap((schema) => {
+        if (!schema.admin_form) return [];
+        return [
+          [
+            schema.key,
+            buildSchemaValues(
+              schema.admin_form,
+              connectionConfig[schema.key] ?? {},
+              parseFieldTypes(schema.json_schema),
+            ),
+          ],
+        ];
+      }),
+    );
 
   return (
     <div className="border-primary/30 bg-primary/5 rounded-xl border border-dashed p-4">
@@ -237,6 +265,31 @@ function APIKeyBlock({
           <X className="h-4 w-4" />
         </Button>
       </div>
+      {configSchemas.map((schema) =>
+        schema.admin_form ? (
+          <div key={schema.key} className="mt-4 space-y-2">
+            <div>
+              <div className="text-sm font-medium">{schema.title || schema.key}</div>
+              {schema.description ? (
+                <div className="text-muted-foreground mt-0.5 text-xs leading-snug">
+                  {schema.description}
+                </div>
+              ) : null}
+            </div>
+            <SchemaForm
+              descriptor={schema.admin_form}
+              values={connectionConfig[schema.key] ?? {}}
+              onChange={(next) =>
+                setConnectionConfig((current) => ({ ...current, [schema.key]: next }))
+              }
+              idPrefix={`watch-provider-${schema.key}`}
+              onValidityChange={(valid) =>
+                setConfigValidity((current) => ({ ...current, [schema.key]: valid }))
+              }
+            />
+          </div>
+        ) : null,
+      )}
       <div className="mt-3 flex flex-col gap-2 sm:flex-row sm:items-stretch">
         <Input
           type="password"
@@ -250,8 +303,8 @@ function APIKeyBlock({
         <Button
           type="button"
           size="sm"
-          disabled={pending || trimmed.length === 0}
-          onClick={() => onSubmit(trimmed)}
+          disabled={pending || trimmed.length === 0 || !configValid}
+          onClick={() => onSubmit(trimmed, configuredValues())}
           className="sm:flex-none"
         >
           {pending ? <Loader2 className="h-4 w-4 animate-spin" /> : <Check className="h-4 w-4" />}
@@ -446,12 +499,15 @@ function WatchProviderCard({ providerKey }: { providerKey: string }) {
     });
   };
 
-  const handleSubmitAPIKey = (apiKey: string) => {
-    connectAPIKey.mutate(apiKey, {
-      onSuccess: () => {
-        setApiKeyPrompt(false);
+  const handleSubmitAPIKey = (apiKey: string, connectionConfig: WatchProviderConnectionConfig) => {
+    connectAPIKey.mutate(
+      { apiKey, connectionConfig },
+      {
+        onSuccess: () => {
+          setApiKeyPrompt(false);
+        },
       },
-    });
+    );
   };
 
   const handleCancelAPIKey = () => {
@@ -541,6 +597,7 @@ function WatchProviderCard({ providerKey }: { providerKey: string }) {
         <div className="mt-4">
           <APIKeyBlock
             displayName={displayName}
+            configSchemas={connection.connection_config_schema ?? []}
             pending={connectAPIKey.isPending}
             onSubmit={handleSubmitAPIKey}
             onCancel={handleCancelAPIKey}

--- a/web/src/pages/settings/WatchProvidersSettings.tsx
+++ b/web/src/pages/settings/WatchProvidersSettings.tsx
@@ -664,14 +664,16 @@ function WatchProviderCard({ providerKey }: { providerKey: string }) {
               disabled={isBusy}
               onChange={(checked) => updateConnection.mutate({ export_watched_enabled: checked })}
             />
-            <ToggleRow
-              id={`watch-provider-${providerKey}-export-unwatched`}
-              label="Send unwatched changes"
-              description="When you mark something unwatched, remove matching history from this provider."
-              checked={connection.export_unwatched_enabled}
-              disabled={isBusy}
-              onChange={(checked) => updateConnection.mutate({ export_unwatched_enabled: checked })}
-            />
+            {connection.capabilities.export_unwatched ? (
+              <ToggleRow
+                id={`watch-provider-${providerKey}-export-unwatched`}
+                label="Send unwatched changes"
+                description="When you mark something unwatched, remove matching history from this provider."
+                checked={connection.export_unwatched_enabled}
+                disabled={isBusy}
+                onChange={(checked) => updateConnection.mutate({ export_unwatched_enabled: checked })}
+              />
+            ) : null}
             {connection.capabilities.import_favorites ||
             connection.capabilities.export_favorites ? (
               <ToggleRow

--- a/web/src/pages/settings/WatchProvidersSettings.tsx
+++ b/web/src/pages/settings/WatchProvidersSettings.tsx
@@ -210,12 +210,14 @@ function AuthCodeBlock({
 
 function APIKeyBlock({
   displayName,
+  providerKey,
   configSchemas,
   pending,
   onSubmit,
   onCancel,
 }: {
   displayName: string;
+  providerKey: string;
   configSchemas: PluginConfigSchema[];
   pending: boolean;
   onSubmit: (apiKey: string, connectionConfig: WatchProviderConnectionConfig) => void;
@@ -225,25 +227,27 @@ function APIKeyBlock({
   const [connectionConfig, setConnectionConfig] = useState<WatchProviderConnectionConfig>({});
   const [configValidity, setConfigValidity] = useState<Record<string, boolean>>({});
   const trimmed = value.trim();
-  const configValid = configSchemas.every(
+  const renderableSchemas = configSchemas.filter(
+    (
+      schema,
+    ): schema is PluginConfigSchema & {
+      admin_form: NonNullable<PluginConfigSchema["admin_form"]>;
+    } => schema.admin_form != null,
+  );
+  const configValid = renderableSchemas.every(
     (schema) => configValidity[schema.key] ?? !schema.required,
   );
 
   const configuredValues = () =>
     Object.fromEntries(
-      configSchemas.flatMap((schema) => {
-        if (!schema.admin_form) return [];
-        return [
-          [
-            schema.key,
-            buildSchemaValues(
-              schema.admin_form,
-              connectionConfig[schema.key] ?? {},
-              parseFieldTypes(schema.json_schema),
-            ),
-          ],
-        ];
-      }),
+      renderableSchemas.map((schema) => [
+        schema.key,
+        buildSchemaValues(
+          schema.admin_form,
+          connectionConfig[schema.key] ?? {},
+          parseFieldTypes(schema.json_schema),
+        ),
+      ]),
     );
 
   return (
@@ -265,31 +269,29 @@ function APIKeyBlock({
           <X className="h-4 w-4" />
         </Button>
       </div>
-      {configSchemas.map((schema) =>
-        schema.admin_form ? (
-          <div key={schema.key} className="mt-4 space-y-2">
-            <div>
-              <div className="text-sm font-medium">{schema.title || schema.key}</div>
-              {schema.description ? (
-                <div className="text-muted-foreground mt-0.5 text-xs leading-snug">
-                  {schema.description}
-                </div>
-              ) : null}
-            </div>
-            <SchemaForm
-              descriptor={schema.admin_form}
-              values={connectionConfig[schema.key] ?? {}}
-              onChange={(next) =>
-                setConnectionConfig((current) => ({ ...current, [schema.key]: next }))
-              }
-              idPrefix={`watch-provider-${schema.key}`}
-              onValidityChange={(valid) =>
-                setConfigValidity((current) => ({ ...current, [schema.key]: valid }))
-              }
-            />
+      {renderableSchemas.map((schema) => (
+        <div key={schema.key} className="mt-4 space-y-2">
+          <div>
+            <div className="text-sm font-medium">{schema.title || schema.key}</div>
+            {schema.description ? (
+              <div className="text-muted-foreground mt-0.5 text-xs leading-snug">
+                {schema.description}
+              </div>
+            ) : null}
           </div>
-        ) : null,
-      )}
+          <SchemaForm
+            descriptor={schema.admin_form}
+            values={connectionConfig[schema.key] ?? {}}
+            onChange={(next) =>
+              setConnectionConfig((current) => ({ ...current, [schema.key]: next }))
+            }
+            idPrefix={`watch-provider-${providerKey}-${schema.key}`}
+            onValidityChange={(valid) =>
+              setConfigValidity((current) => ({ ...current, [schema.key]: valid }))
+            }
+          />
+        </div>
+      ))}
       <div className="mt-3 flex flex-col gap-2 sm:flex-row sm:items-stretch">
         <Input
           type="password"
@@ -597,6 +599,7 @@ function WatchProviderCard({ providerKey }: { providerKey: string }) {
         <div className="mt-4">
           <APIKeyBlock
             displayName={displayName}
+            providerKey={providerKey}
             configSchemas={connection.connection_config_schema ?? []}
             pending={connectAPIKey.isPending}
             onSubmit={handleSubmitAPIKey}

--- a/web/src/pages/settings/WatchProvidersSettings.tsx
+++ b/web/src/pages/settings/WatchProvidersSettings.tsx
@@ -39,7 +39,7 @@ import type { WatchProviderConnectionConfig } from "@/hooks/queries/watchProvide
 import {
   buildConnectionConfig,
   connectionSchemasAreValid,
-  type RenderableConnectionSchema,
+  renderableConnectionSchemas,
 } from "./watchProviderConnectionConfig";
 
 function formatRelativeTime(value?: string) {
@@ -231,9 +231,7 @@ function APIKeyBlock({
   const [connectionConfig, setConnectionConfig] = useState<WatchProviderConnectionConfig>({});
   const [configValidity, setConfigValidity] = useState<Record<string, boolean>>({});
   const trimmed = value.trim();
-  const renderableSchemas = configSchemas.filter(
-    (schema): schema is RenderableConnectionSchema => schema.admin_form != null,
-  );
+  const renderableSchemas = renderableConnectionSchemas(configSchemas);
   const configValid = connectionSchemasAreValid(
     renderableSchemas,
     connectionConfig,

--- a/web/src/pages/settings/WatchProvidersSettings.tsx
+++ b/web/src/pages/settings/WatchProvidersSettings.tsx
@@ -34,9 +34,13 @@ import {
 import { Input } from "@/components/ui/input";
 import { formatRelativeTime as formatRelativeTimeBase } from "@/lib/date";
 import { SchemaForm } from "@/components/admin/plugins/SchemaForm";
-import { buildSchemaValues, parseFieldTypes } from "@/components/admin/plugins/schemaFormUtils";
 import type { PluginConfigSchema } from "@/api/types";
 import type { WatchProviderConnectionConfig } from "@/hooks/queries/watchProviders";
+import {
+  buildConnectionConfig,
+  connectionSchemasAreValid,
+  type RenderableConnectionSchema,
+} from "./watchProviderConnectionConfig";
 
 function formatRelativeTime(value?: string) {
   return formatRelativeTimeBase(value, { rounding: "floor", justNowLabel: "Just now" }) ?? "Never";
@@ -228,27 +232,13 @@ function APIKeyBlock({
   const [configValidity, setConfigValidity] = useState<Record<string, boolean>>({});
   const trimmed = value.trim();
   const renderableSchemas = configSchemas.filter(
-    (
-      schema,
-    ): schema is PluginConfigSchema & {
-      admin_form: NonNullable<PluginConfigSchema["admin_form"]>;
-    } => schema.admin_form != null,
+    (schema): schema is RenderableConnectionSchema => schema.admin_form != null,
   );
-  const configValid = renderableSchemas.every(
-    (schema) => configValidity[schema.key] ?? !schema.required,
+  const configValid = connectionSchemasAreValid(
+    renderableSchemas,
+    connectionConfig,
+    configValidity,
   );
-
-  const configuredValues = () =>
-    Object.fromEntries(
-      renderableSchemas.map((schema) => [
-        schema.key,
-        buildSchemaValues(
-          schema.admin_form,
-          connectionConfig[schema.key] ?? {},
-          parseFieldTypes(schema.json_schema),
-        ),
-      ]),
-    );
 
   return (
     <div className="border-primary/30 bg-primary/5 rounded-xl border border-dashed p-4">
@@ -306,7 +296,9 @@ function APIKeyBlock({
           type="button"
           size="sm"
           disabled={pending || trimmed.length === 0 || !configValid}
-          onClick={() => onSubmit(trimmed, configuredValues())}
+          onClick={() =>
+            onSubmit(trimmed, buildConnectionConfig(renderableSchemas, connectionConfig))
+          }
           className="sm:flex-none"
         >
           {pending ? <Loader2 className="h-4 w-4 animate-spin" /> : <Check className="h-4 w-4" />}

--- a/web/src/pages/settings/watchProviderConnectionConfig.test.ts
+++ b/web/src/pages/settings/watchProviderConnectionConfig.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, it } from "vitest";
+
+import type { PluginConfigSchema } from "@/api/types";
+
+import {
+  activeConnectionSchemas,
+  buildConnectionConfig,
+  connectionSchemasAreValid,
+} from "./watchProviderConnectionConfig";
+
+const optionalSchema: PluginConfigSchema = {
+  key: "optional",
+  title: "Optional server settings",
+  description: "Only sent when configured.",
+  json_schema: JSON.stringify({
+    type: "object",
+    properties: { base_url: { type: "string" } },
+    required: ["base_url"],
+  }),
+  required: false,
+  admin_form: {
+    fields: [
+      {
+        key: "base_url",
+        label: "Server URL",
+        control: "TEXT",
+        required: true,
+        secret: false,
+        multiline: false,
+      },
+    ],
+  },
+};
+
+describe("watch provider connection config", () => {
+  it("omits an untouched optional schema without blocking Connect", () => {
+    expect(activeConnectionSchemas([optionalSchema], {})).toEqual([]);
+    expect(connectionSchemasAreValid([optionalSchema], {}, { optional: false })).toBe(true);
+    expect(buildConnectionConfig([optionalSchema], {})).toEqual({});
+  });
+
+  it("validates and submits an optional schema after the user enters a value", () => {
+    const drafts = { optional: { base_url: "https://floppy.example.com" } };
+    expect(connectionSchemasAreValid([optionalSchema], drafts, { optional: false })).toBe(false);
+    expect(connectionSchemasAreValid([optionalSchema], drafts, { optional: true })).toBe(true);
+    expect(buildConnectionConfig([optionalSchema], drafts)).toEqual({
+      optional: { base_url: "https://floppy.example.com" },
+    });
+  });
+
+  it("keeps required schemas active before any values are entered", () => {
+    const requiredSchema = { ...optionalSchema, key: "required", required: true };
+    expect(activeConnectionSchemas([requiredSchema], {})).toEqual([requiredSchema]);
+    expect(connectionSchemasAreValid([requiredSchema], {}, {})).toBe(false);
+  });
+});

--- a/web/src/pages/settings/watchProviderConnectionConfig.test.ts
+++ b/web/src/pages/settings/watchProviderConnectionConfig.test.ts
@@ -6,6 +6,7 @@ import {
   activeConnectionSchemas,
   buildConnectionConfig,
   connectionSchemasAreValid,
+  renderableConnectionSchemas,
 } from "./watchProviderConnectionConfig";
 
 const optionalSchema: PluginConfigSchema = {
@@ -52,5 +53,21 @@ describe("watch provider connection config", () => {
     const requiredSchema = { ...optionalSchema, key: "required", required: true };
     expect(activeConnectionSchemas([requiredSchema], {})).toEqual([requiredSchema]);
     expect(connectionSchemasAreValid([requiredSchema], {}, {})).toBe(false);
+  });
+
+  it("derives a usable form for a required JSON-schema-only block", () => {
+    const headless = { ...optionalSchema, required: true, admin_form: undefined };
+    const schemas = renderableConnectionSchemas([headless]);
+    expect(schemas).toHaveLength(1);
+    const renderable = schemas[0]!;
+    expect(renderable.admin_form.fields).toEqual([
+      expect.objectContaining({
+        key: "base_url",
+        label: "Base Url",
+        control: "TEXT",
+        required: true,
+      }),
+    ]);
+    expect(connectionSchemasAreValid([renderable], {}, {})).toBe(false);
   });
 });

--- a/web/src/pages/settings/watchProviderConnectionConfig.ts
+++ b/web/src/pages/settings/watchProviderConnectionConfig.ts
@@ -1,10 +1,20 @@
 import type { PluginConfigSchema } from "@/api/types";
+import { adminFormForConfigSchema } from "@/components/admin/plugins/configSchemaAdminForm";
 import { buildSchemaValues, parseFieldTypes } from "@/components/admin/plugins/schemaFormUtils";
 import type { WatchProviderConnectionConfig } from "@/hooks/queries/watchProviders";
 
 export type RenderableConnectionSchema = PluginConfigSchema & {
   admin_form: NonNullable<PluginConfigSchema["admin_form"]>;
 };
+
+export function renderableConnectionSchemas(
+  schemas: PluginConfigSchema[],
+): RenderableConnectionSchema[] {
+  return schemas.flatMap((schema) => {
+    const adminForm = adminFormForConfigSchema(schema);
+    return adminForm == null ? [] : [{ ...schema, admin_form: adminForm }];
+  });
+}
 
 function hasEnteredValue(value: unknown): boolean {
   if (value == null) return false;

--- a/web/src/pages/settings/watchProviderConnectionConfig.ts
+++ b/web/src/pages/settings/watchProviderConnectionConfig.ts
@@ -1,0 +1,49 @@
+import type { PluginConfigSchema } from "@/api/types";
+import { buildSchemaValues, parseFieldTypes } from "@/components/admin/plugins/schemaFormUtils";
+import type { WatchProviderConnectionConfig } from "@/hooks/queries/watchProviders";
+
+export type RenderableConnectionSchema = PluginConfigSchema & {
+  admin_form: NonNullable<PluginConfigSchema["admin_form"]>;
+};
+
+function hasEnteredValue(value: unknown): boolean {
+  if (value == null) return false;
+  if (typeof value === "string") return value.trim().length > 0;
+  if (Array.isArray(value)) return value.some(hasEnteredValue);
+  if (typeof value === "object") return Object.values(value).some(hasEnteredValue);
+  return true;
+}
+
+export function activeConnectionSchemas(
+  schemas: PluginConfigSchema[],
+  drafts: WatchProviderConnectionConfig,
+): RenderableConnectionSchema[] {
+  return schemas.filter(
+    (schema): schema is RenderableConnectionSchema =>
+      schema.admin_form != null && (schema.required || hasEnteredValue(drafts[schema.key])),
+  );
+}
+
+export function connectionSchemasAreValid(
+  schemas: PluginConfigSchema[],
+  drafts: WatchProviderConnectionConfig,
+  validity: Record<string, boolean>,
+): boolean {
+  return activeConnectionSchemas(schemas, drafts).every((schema) => validity[schema.key] ?? false);
+}
+
+export function buildConnectionConfig(
+  schemas: PluginConfigSchema[],
+  drafts: WatchProviderConnectionConfig,
+): WatchProviderConnectionConfig {
+  return Object.fromEntries(
+    activeConnectionSchemas(schemas, drafts).map((schema) => [
+      schema.key,
+      buildSchemaValues(
+        schema.admin_form,
+        drafts[schema.key] ?? {},
+        parseFieldTypes(schema.json_schema),
+      ),
+    ]),
+  );
+}


### PR DESCRIPTION
## Problem

Plugin watch providers could receive only installation-wide provider configuration during API-key setup. For self-hosted providers such as Floppy, that forced every profile on one Silo server to use the same remote instance.

Closes #549. Follow-up to #475.

## Approach

- expose capability-level config schemas in watch-provider discovery and connection status
- render those schemas beside API-key authentication in the profile watch-provider UI
- submit a new additive connection_config request field and validate every object against the manifest JSON schema
- preserve form defaults and JSON-schema types before submission
- classify declared secret/password fields into provider_config.secret_values and all other declared fields into provider_config.values
- let connection values override same-named installation values for a safe legacy migration
- keep submitted setup data out of generic plugin configuration; plugins return durable connection context through encrypted opaque credential attributes
- reuse the existing plugin schema/form JSON bridge so admin and connection forms cannot drift

The released SDK v0.13 contract already provides capability config_schema, WatchSyncProviderConfig, and encrypted WatchSyncCredentials.secret_attributes, so this change requires no SDK protobuf or release update.

The /api/v1 change is additive. Built-in providers and plugins without capability setup fields keep their previous behavior.

## Risk and compatibility

- Watch-provider connections remain profile-scoped; two profiles can now use different provider endpoints.
- Unknown config keys, missing required schemas, and JSON-schema violations are rejected before plugin RPC.
- Existing installation config can still be supplied transiently for plugin upgrade fallback, with undeclared fields classified as secret.
- Provider plugins control the outbound endpoint they accept. Floppy restricts its URL to absolute HTTP(S) without URL credentials, query, or fragment while retaining LAN/self-hosted support.

## Validation

Passed on commit b4542bb5:

- go test -timeout=120s ./internal/plugins ./internal/watchsync ./cmd/silo
- go test -timeout=180s ./internal/api/handlers
- go vet ./internal/watchsync ./internal/plugins ./internal/api/handlers ./cmd/silo
- golangci-lint v2.12.2 run --new-from-merge-base=origin/main ./... -- 0 issues
- pnpm vitest run src/hooks/queries/watchProviders.test.ts src/components/admin/plugins/schemaFormUtils.test.ts -- 24 tests passed
- pnpm exec eslint on all touched frontend files
- pnpm build
- pnpm exec prettier --check on all touched frontend files
- make verify-local-paths
- git diff --check

The production frontend build completed with the repository's existing default.woff2 and large-chunk warnings only.

## Adversarial review

The review found that directly forwarding form drafts would send numeric and boolean fields as strings and could omit displayed defaults; submission now uses the shared schema coercion/default builder. It also found a duplicate admin-form DTO bridge that could drift, so both plugin-admin and watch-provider surfaces now share one converter with the existing completeness regression test. Finally, exposing an optional legacy global Floppy URL still contradicted the requested model; the Floppy manifest removes that setting entirely while the host's fail-closed undeclared-config path preserves old encrypted values as an invisible upgrade fallback.

### AI Disclosure
- Tool(s): Codex
- Model(s): gpt-5.6
- Involvement: AI-assisted
- Adversarial review: Found and fixed typed/default form submission, duplicate schema DTO mapping, and visible global-fallback design issues; verified schema validation, secret classification, profile isolation, legacy upgrade behavior, and unchanged built-in-provider behavior.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Watch-provider API-key connections support provider-specific configuration fields.
  * Settings forms display supported fields, validation rules, conditional options, and appropriate input types.
  * Configuration schemas appear in provider and connection details.
  * Configuration is validated and submitted securely alongside API keys.
  * Plugin forms can be generated from supported schemas when custom definitions are unavailable.

* **Bug Fixes**
  * Existing API-key connections without additional configuration continue to work.
  * Provider settings are preserved when applying connection-specific values.
  * Local watch exports process newly created events without older pending exports interfering.
  * Watch-sync operations allow additional time for provider processing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->