### PR TITLE
fix(playback): degrade an unavailable track instead of refusing to play

### DIFF
--- a/internal/api/handlers/playback_v3.go
+++ b/internal/api/handlers/playback_v3.go
@@ -460,7 +460,10 @@ func (h *PlaybackHandler) handleStartPlaybackV3(w http.ResponseWriter, r *http.R
 			audioIndex = remapAudioIndexV3(requestedFile, effectiveFile, audioIndex)
 			subtitleDropped, subtitleErr := h.remapSubtitleSelectionV3(r.Context(), requestedFile, effectiveFile, &req)
 			if subtitleErr != nil {
-				writeJSON(w, http.StatusCreated, playback.NewTerminalResponseV3("subtitle_unavailable_in_version", subtitleErr.Error(), false))
+				// Post-degrade, remap errors are malformed-request-only
+				// (bad identity, negative index) — a client bug, not a
+				// content mismatch, matching the audio path above.
+				writeError(w, http.StatusBadRequest, "bad_request", subtitleErr.Error())
 				return
 			}
 			if subtitleDropped {
@@ -1114,6 +1117,8 @@ func (h *PlaybackHandler) HandleReplanPlaybackV3(w http.ResponseWriter, r *http.
 }
 
 func (h *PlaybackHandler) executeReplanV3(r *http.Request, record *playback.AttemptRecordV3, req playback.ReplanRequestV3) (playback.DecisionResponseV3, playback.AttemptRecordV3, *preparedTransportV3, *transportErrorV3) {
+	audioDegraded := false
+	subtitleDegraded := false
 	reservationHeld := false
 	reservationHandedOff := false
 	cancelReservation := func() {
@@ -1240,9 +1245,11 @@ func (h *PlaybackHandler) executeReplanV3(r *http.Request, record *playback.Atte
 				return playback.DecisionResponseV3{}, *record, nil, &transportErrorV3{reason: "track_unavailable", message: err.Error()}
 			}
 			if start.SubtitleTrackIndex != nil || start.SubtitleTrackID != "" {
-				if _, err := h.remapSubtitleSelectionV3(r.Context(), currentEffectiveFile, effectiveFile, &start); err != nil {
+				dropped, err := h.remapSubtitleSelectionV3(r.Context(), currentEffectiveFile, effectiveFile, &start)
+				if err != nil {
 					return playback.DecisionResponseV3{}, *record, nil, &transportErrorV3{reason: "track_unavailable", message: err.Error()}
 				}
+				subtitleDegraded = subtitleDegraded || dropped
 			}
 		}
 	}
@@ -1269,7 +1276,7 @@ func (h *PlaybackHandler) executeReplanV3(r *http.Request, record *playback.Atte
 	}
 	audioIndex := 0
 	if !seekReanchor {
-		audioIndex, _, err = resolveV3AudioIndex(effectiveFile, start.AudioTrackID, start.AudioTrackIndex)
+		audioIndex, audioDegraded, err = resolveV3AudioIndex(effectiveFile, start.AudioTrackID, start.AudioTrackIndex)
 		if err != nil {
 			return playback.DecisionResponseV3{}, *record, nil, &transportErrorV3{reason: "track_unavailable", message: err.Error()}
 		}
@@ -1312,7 +1319,8 @@ func (h *PlaybackHandler) executeReplanV3(r *http.Request, record *playback.Atte
 		if alternate, alternateErr := h.findAlternateFile(r.Context(), requestedFile); alternateErr == nil && alternate != nil {
 			alternate = h.ensurePlaybackProbe(r.Context(), alternate)
 			remappedAudio := remapAudioIndexV3(effectiveFile, alternate, audioIndex)
-			if _, err := h.remapSubtitleSelectionV3(r.Context(), effectiveFile, alternate, &start); err == nil {
+			if dropped, err := h.remapSubtitleSelectionV3(r.Context(), effectiveFile, alternate, &start); err == nil {
+				subtitleDegraded = subtitleDegraded || dropped
 				start.FileID = alternate.ID
 				if err := preflightPlaybackFile(r.Context(), alternate, h.MissingMarker, h.EventsHub); err == nil {
 					effectiveFile = alternate
@@ -1324,6 +1332,21 @@ func (h *PlaybackHandler) executeReplanV3(r *http.Request, record *playback.Atte
 	}
 	if result.Terminal != nil {
 		return playback.NewTerminalResponseV3(result.Terminal.Reason, result.Terminal.Message, result.Terminal.Retryable), *record, nil, nil
+	}
+	// Replans degrade the same two ways starts do, and clients read the same
+	// contract: silently swapping audio to the default or turning subtitles
+	// off mid-session is worse than the refusal this replaced.
+	if audioDegraded {
+		result.Plan.DegradationWarnings = append(result.Plan.DegradationWarnings, playback.DegradationWarningV3{
+			Code:    "audio_track_unavailable",
+			Message: "The selected audio track is not on this file; playing its default instead.",
+		})
+	}
+	if subtitleDegraded && !subtitlePlanWarnedV3(result.Plan.DegradationWarnings) {
+		result.Plan.DegradationWarnings = append(result.Plan.DegradationWarnings, playback.DegradationWarningV3{
+			Code:    "subtitle_track_unavailable",
+			Message: "The selected subtitle track is not in this version; starting without it.",
+		})
 	}
 	session, err := h.sessionMgr.GetSession(record.SessionID)
 	if err != nil {
@@ -1748,6 +1771,18 @@ func shouldTryAlternateFileV3(qualityPreference string) bool {
 	return !strings.EqualFold(strings.TrimSpace(qualityPreference), "original")
 }
 
+// subtitlePlanWarnedV3 reports whether the planner already attached the
+// subtitle degradation warning, so the handler does not add it twice when the
+// planner's policy fallback and the handler's remap both fire in one replan.
+func subtitlePlanWarnedV3(warnings []playback.DegradationWarningV3) bool {
+	for _, warning := range warnings {
+		if warning.Code == "subtitle_track_unavailable" {
+			return true
+		}
+	}
+	return false
+}
+
 func replanAllowsAlternateFileV3(operation playback.ReplanOperationV3, qualityPreference string) bool {
 	return operation == playback.ReplanOperationFailureRecoveryV3 && shouldTryAlternateFileV3(qualityPreference)
 }
@@ -2085,8 +2120,8 @@ func (h *PlaybackHandler) remapSubtitleSelectionV3(ctx context.Context, source, 
 		// No equivalent on the file we are actually going to play. Subtitles
 		// are an enhancement; refusing the start over one is disproportionate,
 		// and it is what made a missing track on the next episode surface as a
-		// dead screen the viewer had to replay out of. Clear the selection so
-		// the planner applies the profile default, and report the degradation.
+		// dead screen the viewer had to replay out of. Clear the selection —
+		// the planner then starts with subtitles off — and report it.
 		request.SubtitleTrackIndex = nil
 		request.SubtitleTrackID = ""
 		return true, nil

--- a/internal/api/handlers/playback_v3.go
+++ b/internal/api/handlers/playback_v3.go
@@ -431,10 +431,16 @@ func (h *PlaybackHandler) handleStartPlaybackV3(w http.ResponseWriter, r *http.R
 		return
 	}
 	requestedFile = h.ensurePlaybackProbe(r.Context(), requestedFile)
-	audioIndex, err := resolveV3AudioIndex(requestedFile, req.AudioTrackID, req.AudioTrackIndex)
+	audioIndex, audioDegraded, err := resolveV3AudioIndex(requestedFile, req.AudioTrackID, req.AudioTrackIndex)
 	if err != nil {
 		writeError(w, http.StatusBadRequest, "bad_request", err.Error())
 		return
+	}
+	if audioDegraded {
+		warnings = append(warnings, playback.DegradationWarningV3{
+			Code:    "audio_track_unavailable",
+			Message: "The selected audio track is not on this file; playing its default instead.",
+		})
 	}
 	effectiveFile := requestedFile
 	settings := h.plannerSettingsV3(r.Context())
@@ -452,9 +458,16 @@ func (h *PlaybackHandler) handleStartPlaybackV3(w http.ResponseWriter, r *http.R
 		if alternate, alternateErr := h.findAlternateFile(r.Context(), requestedFile); alternateErr == nil && alternate != nil {
 			effectiveFile = h.ensurePlaybackProbe(r.Context(), alternate)
 			audioIndex = remapAudioIndexV3(requestedFile, effectiveFile, audioIndex)
-			if err := h.remapSubtitleSelectionV3(r.Context(), requestedFile, effectiveFile, &req); err != nil {
-				writeJSON(w, http.StatusCreated, playback.NewTerminalResponseV3("subtitle_unavailable_in_version", err.Error(), false))
+			subtitleDropped, subtitleErr := h.remapSubtitleSelectionV3(r.Context(), requestedFile, effectiveFile, &req)
+			if subtitleErr != nil {
+				writeJSON(w, http.StatusCreated, playback.NewTerminalResponseV3("subtitle_unavailable_in_version", subtitleErr.Error(), false))
 				return
+			}
+			if subtitleDropped {
+				warnings = append(warnings, playback.DegradationWarningV3{
+					Code:    "subtitle_track_unavailable",
+					Message: "The selected subtitle track is not in this version; starting without it.",
+				})
 			}
 			if err := preflightPlaybackFile(r.Context(), effectiveFile, h.MissingMarker, h.EventsHub); err != nil {
 				writePlaybackFilePreflightError(w, err)
@@ -1227,7 +1240,7 @@ func (h *PlaybackHandler) executeReplanV3(r *http.Request, record *playback.Atte
 				return playback.DecisionResponseV3{}, *record, nil, &transportErrorV3{reason: "track_unavailable", message: err.Error()}
 			}
 			if start.SubtitleTrackIndex != nil || start.SubtitleTrackID != "" {
-				if err := h.remapSubtitleSelectionV3(r.Context(), currentEffectiveFile, effectiveFile, &start); err != nil {
+				if _, err := h.remapSubtitleSelectionV3(r.Context(), currentEffectiveFile, effectiveFile, &start); err != nil {
 					return playback.DecisionResponseV3{}, *record, nil, &transportErrorV3{reason: "track_unavailable", message: err.Error()}
 				}
 			}
@@ -1256,7 +1269,7 @@ func (h *PlaybackHandler) executeReplanV3(r *http.Request, record *playback.Atte
 	}
 	audioIndex := 0
 	if !seekReanchor {
-		audioIndex, err = resolveV3AudioIndex(effectiveFile, start.AudioTrackID, start.AudioTrackIndex)
+		audioIndex, _, err = resolveV3AudioIndex(effectiveFile, start.AudioTrackID, start.AudioTrackIndex)
 		if err != nil {
 			return playback.DecisionResponseV3{}, *record, nil, &transportErrorV3{reason: "track_unavailable", message: err.Error()}
 		}
@@ -1299,7 +1312,7 @@ func (h *PlaybackHandler) executeReplanV3(r *http.Request, record *playback.Atte
 		if alternate, alternateErr := h.findAlternateFile(r.Context(), requestedFile); alternateErr == nil && alternate != nil {
 			alternate = h.ensurePlaybackProbe(r.Context(), alternate)
 			remappedAudio := remapAudioIndexV3(effectiveFile, alternate, audioIndex)
-			if err := h.remapSubtitleSelectionV3(r.Context(), effectiveFile, alternate, &start); err == nil {
+			if _, err := h.remapSubtitleSelectionV3(r.Context(), effectiveFile, alternate, &start); err == nil {
 				start.FileID = alternate.ID
 				if err := preflightPlaybackFile(r.Context(), alternate, h.MissingMarker, h.EventsHub); err == nil {
 					effectiveFile = alternate
@@ -1944,27 +1957,33 @@ func (h *PlaybackHandler) plannerSettingsV3(ctx context.Context) playback.Planne
 	return settings
 }
 
-func resolveV3AudioIndex(file *models.MediaFile, trackID string, fallback *int) (int, error) {
+// resolveV3AudioIndex returns the audio index to play, whether the requested
+// selection had to be degraded to get there, and an error only when the request
+// itself is malformed.
+func resolveV3AudioIndex(file *models.MediaFile, trackID string, fallback *int) (int, bool, error) {
 	index := 0
 	if trackID != "" {
 		fileID, kind, ordinal, ok := playback.ParseTrackIDV3(trackID)
 		if !ok || kind != "audio" || file == nil || fileID != file.ID {
-			return 0, errors.New("selected audio track identity is invalid")
+			// A malformed identity is a client bug, not a content mismatch.
+			return 0, false, errors.New("selected audio track identity is invalid")
 		}
 		index = ordinal
 	} else if fallback != nil {
 		index = *fallback
 	}
 	if file == nil || len(file.AudioTracks) == 0 {
-		if index == 0 {
-			return 0, nil
-		}
-		return 0, errors.New("selected audio track is unavailable")
+		return 0, index != 0, nil
 	}
 	if index < 0 || index >= len(file.AudioTracks) {
-		return 0, errors.New("selected audio track is unavailable")
+		// A carried-over selection that does not exist on this file is not a
+		// reason to refuse playback. The commonest source is the next episode
+		// in a series having a different track layout to the one the viewer
+		// chose on, and failing there means a dead screen and a manual replay.
+		// Fall back to the file's own default and say so in the plan.
+		return normalizeAudioTrackIndex(file, index), true, nil
 	}
-	return index, nil
+	return index, false, nil
 }
 
 func remapAudioIndexV3(source, target *models.MediaFile, index int) int {
@@ -2004,26 +2023,29 @@ func remapAudioSelectionV3(source, target *models.MediaFile, request *playback.S
 	return nil
 }
 
-func (h *PlaybackHandler) remapSubtitleSelectionV3(ctx context.Context, source, target *models.MediaFile, request *playback.StartRequestV3) error {
+// remapSubtitleSelectionV3 rebases a subtitle selection onto the file that will
+// actually be played. It reports whether the selection had to be dropped, and
+// errors only when the request itself is malformed.
+func (h *PlaybackHandler) remapSubtitleSelectionV3(ctx context.Context, source, target *models.MediaFile, request *playback.StartRequestV3) (bool, error) {
 	if request == nil || source == nil || target == nil || source.ID == target.ID {
-		return nil
+		return false, nil
 	}
 	if request.SubtitleTrackIndex == nil {
 		// ID-only selections are equally file-bound: the stale ID would be
 		// parsed against the alternate file's track list downstream, so
 		// derive the source index from it and remap like any other.
 		if request.SubtitleTrackID == "" {
-			return nil
+			return false, nil
 		}
 		fileID, kind, ordinal, ok := playback.ParseTrackIDV3(request.SubtitleTrackID)
 		if !ok || kind != "subtitle" || fileID != source.ID {
-			return errors.New("The selected subtitle track identity is invalid for the source file.")
+			return false, errors.New("The selected subtitle track identity is invalid for the source file.")
 		}
 		request.SubtitleTrackIndex = &ordinal
 	}
 	index := *request.SubtitleTrackIndex
 	if index < 0 {
-		return errors.New("The selected subtitle track index is invalid.")
+		return false, errors.New("The selected subtitle track index is invalid.")
 	}
 	targetIndex := -1
 	switch {
@@ -2060,11 +2082,18 @@ func (h *PlaybackHandler) remapSubtitleSelectionV3(ctx context.Context, source, 
 		}
 	}
 	if targetIndex < 0 {
-		return errors.New("The selected subtitle track is unavailable in the effective file version.")
+		// No equivalent on the file we are actually going to play. Subtitles
+		// are an enhancement; refusing the start over one is disproportionate,
+		// and it is what made a missing track on the next episode surface as a
+		// dead screen the viewer had to replay out of. Clear the selection so
+		// the planner applies the profile default, and report the degradation.
+		request.SubtitleTrackIndex = nil
+		request.SubtitleTrackID = ""
+		return true, nil
 	}
 	request.SubtitleTrackIndex = &targetIndex
 	request.SubtitleTrackID = playback.TrackIDV3(target.ID, "subtitle", targetIndex)
-	return nil
+	return false, nil
 }
 
 func sessionStartErrorV3(err error) *transportErrorV3 {

--- a/internal/api/handlers/playback_v3_test.go
+++ b/internal/api/handlers/playback_v3_test.go
@@ -1983,8 +1983,8 @@ func TestResolveV3AudioIndexFallsBackWhenSelectionIsOutOfRange(t *testing.T) {
 	if !degraded {
 		t.Fatal("falling back was not reported as a degradation")
 	}
-	if index < 0 || index >= len(file.AudioTracks) {
-		t.Fatalf("fell back to an invalid index: %d", index)
+	if want := normalizeAudioTrackIndex(file, out); index != want {
+		t.Fatalf("fell back to %d, want the file default %d", index, want)
 	}
 }
 

--- a/internal/api/handlers/playback_v3_test.go
+++ b/internal/api/handlers/playback_v3_test.go
@@ -1923,8 +1923,68 @@ func TestRemapSubtitleSelectionV3RejectsNegativeIndex(t *testing.T) {
 	source := &models.MediaFile{ID: 1, ExternalSubtitles: []models.ExternalSubtitle{{Language: "eng", Format: "srt"}}}
 	target := &models.MediaFile{ID: 2, ExternalSubtitles: []models.ExternalSubtitle{{Language: "eng", Format: "srt"}}}
 	handler := NewPlaybackHandler(playback.NewSessionManager(0, 0))
-	if err := handler.remapSubtitleSelectionV3(context.Background(), source, target, &request); err == nil {
+	if _, err := handler.remapSubtitleSelectionV3(context.Background(), source, target, &request); err == nil {
 		t.Fatal("negative subtitle index was accepted")
+	}
+}
+
+// A track the viewer chose on one file need not exist on the file actually
+// played — the next episode in a series routinely differs. Refusing the start
+// there gave the viewer a dead screen to replay out of.
+func TestRemapSubtitleSelectionV3DropsSelectionWhenAbsentFromTarget(t *testing.T) {
+	index := 0
+	request := playback.StartRequestV3{SubtitleTrackIndex: &index}
+	source := &models.MediaFile{ID: 1, ExternalSubtitles: []models.ExternalSubtitle{{Language: "swe", Format: "srt"}}}
+	target := &models.MediaFile{ID: 2, ExternalSubtitles: []models.ExternalSubtitle{{Language: "eng", Format: "srt"}}}
+	handler := NewPlaybackHandler(playback.NewSessionManager(0, 0))
+
+	degraded, err := handler.remapSubtitleSelectionV3(context.Background(), source, target, &request)
+	if err != nil {
+		t.Fatalf("a missing subtitle must not fail the start: %v", err)
+	}
+	if !degraded {
+		t.Fatal("dropping the selection was not reported as a degradation")
+	}
+	if request.SubtitleTrackIndex != nil || request.SubtitleTrackID != "" {
+		t.Fatalf("stale selection survived: index=%v id=%q", request.SubtitleTrackIndex, request.SubtitleTrackID)
+	}
+}
+
+// The equivalent track on the target file is still preferred over dropping it.
+func TestRemapSubtitleSelectionV3RebasesWhenTargetHasTheTrack(t *testing.T) {
+	index := 0
+	request := playback.StartRequestV3{SubtitleTrackIndex: &index}
+	source := &models.MediaFile{ID: 1, ExternalSubtitles: []models.ExternalSubtitle{{Language: "eng", Format: "srt"}}}
+	target := &models.MediaFile{ID: 2, ExternalSubtitles: []models.ExternalSubtitle{
+		{Language: "swe", Format: "srt"},
+		{Language: "eng", Format: "srt"},
+	}}
+	handler := NewPlaybackHandler(playback.NewSessionManager(0, 0))
+
+	degraded, err := handler.remapSubtitleSelectionV3(context.Background(), source, target, &request)
+	if err != nil || degraded {
+		t.Fatalf("a track present on the target must rebase, not drop: degraded=%v err=%v", degraded, err)
+	}
+	if request.SubtitleTrackIndex == nil || *request.SubtitleTrackIndex != 1 {
+		t.Fatalf("rebased to the wrong index: %v", request.SubtitleTrackIndex)
+	}
+}
+
+// Audio cannot simply be dropped the way subtitles can, so it falls back to the
+// file's own default rather than refusing to play.
+func TestResolveV3AudioIndexFallsBackWhenSelectionIsOutOfRange(t *testing.T) {
+	out := 7
+	file := &models.MediaFile{ID: 1, AudioTracks: []models.AudioTrack{{Language: "eng"}, {Language: "swe"}}}
+
+	index, degraded, err := resolveV3AudioIndex(file, "", &out)
+	if err != nil {
+		t.Fatalf("an out-of-range audio selection must not fail the start: %v", err)
+	}
+	if !degraded {
+		t.Fatal("falling back was not reported as a degradation")
+	}
+	if index < 0 || index >= len(file.AudioTracks) {
+		t.Fatalf("fell back to an invalid index: %d", index)
 	}
 }
 

--- a/internal/playback/plan_v3.go
+++ b/internal/playback/plan_v3.go
@@ -202,6 +202,12 @@ func PlanPlaybackV3(input PlannerInputV3) PlannerResultV3 {
 		Timeline:               TimelineV3{SourceStartSeconds: floatOrZeroV3(input.Request.StartPosition), PlayerStartSeconds: floatOrZeroV3(input.Request.StartPosition), CanSeekAnywhere: true, SeekRestoration: "player_position"},
 	}
 	base.Claims.Audio.Passthrough = passthrough
+	if subtitle.Degraded {
+		base.DegradationWarnings = append(base.DegradationWarnings, DegradationWarningV3{
+			Code:    "subtitle_track_unavailable",
+			Message: "The selected subtitle track is not on this file; starting without it.",
+		})
+	}
 	if source.DynamicRange == "hdr_unknown" && rangeOK {
 		base.DegradationWarnings = append(base.DegradationWarnings, DegradationWarningV3{
 			Code:    "hdr_range_assumed_hdr10",

--- a/internal/playback/subtitle_policy_v3.go
+++ b/internal/playback/subtitle_policy_v3.go
@@ -16,6 +16,9 @@ type SubtitlePolicyResultV3 struct {
 	Source               string
 	DownloadedSubtitleID int
 	Terminal             *TerminalV3
+	// Degraded reports that a positive selection could not be honoured and
+	// the policy fell back to subtitles-off instead of refusing playback.
+	Degraded bool
 }
 
 type SubtitleInventoryEntryV3 struct {
@@ -48,7 +51,18 @@ func ResolveSubtitlePolicyV3(file *models.MediaFile, request StartRequestV3, tra
 	}
 	entry, ok := subtitleEntryAtCombinedIndexV3(file, index, additional)
 	if !ok {
-		return subtitleTerminalV3("subtitle_track_unavailable", "The selected subtitle track is unavailable.")
+		// A selection carried over from another file — the next episode in a
+		// series routinely has a different track layout — is not a reason to
+		// refuse playback. Nothing is broken: the file plays, one preference
+		// cannot be honoured. Degrade to subtitles-off and report it, exactly
+		// as the version-switch remap path does. A malformed identity or a
+		// negative index still errors above: those are client bugs.
+		return SubtitlePolicyResultV3{
+			Decision:       SubtitleDecisionV3{Mode: SubtitleOffV3},
+			SelectedIndex:  -1,
+			TransportIndex: -1,
+			Degraded:       true,
+		}
 	}
 	codec, source := entry.Codec, entry.Source
 	trackID := TrackIDV3(file.ID, "subtitle", index)

--- a/internal/playback/subtitle_policy_v3_test.go
+++ b/internal/playback/subtitle_policy_v3_test.go
@@ -116,3 +116,42 @@ func TestClientRenderableBitmapSubtitleV3UsesExactCodecFamilies(t *testing.T) {
 		}
 	}
 }
+
+// A selection carried over from another file — the next episode routinely has
+// a different track layout — must degrade to subtitles-off, not refuse
+// playback. This is the direct-start path; the version-switch remap in the
+// handlers degrades the same way.
+func TestResolveSubtitlePolicyV3DegradesOutOfRangeSelectionToOff(t *testing.T) {
+	file := detailedFixtureFileV3()
+	file.ExternalSubtitles = nil
+	file.SubtitleTracks = []models.SubtitleTrack{{Codec: "subrip"}}
+	req := validStartRequestV3()
+	index := 7
+	req.SubtitleTrackIndex = &index
+
+	result := ResolveSubtitlePolicyV3(file, req, true, EngineMedia3DirectV3, nil)
+
+	if result.Terminal != nil {
+		t.Fatalf("an out-of-range subtitle selection must not refuse playback: %#v", result.Terminal)
+	}
+	if result.Decision.Mode != SubtitleOffV3 || result.SelectedIndex != -1 {
+		t.Fatalf("expected subtitles-off fallback: %#v", result)
+	}
+	if !result.Degraded {
+		t.Fatal("the fallback was not reported as a degradation")
+	}
+}
+
+// Malformed selections stay terminal: a bad identity is a client bug, and
+// swallowing it would make that bug harder to find.
+func TestResolveSubtitlePolicyV3StillRejectsInvalidIdentity(t *testing.T) {
+	file := detailedFixtureFileV3()
+	req := validStartRequestV3()
+	req.SubtitleTrackID = "not-a-track-id"
+
+	result := ResolveSubtitlePolicyV3(file, req, true, EngineMedia3DirectV3, nil)
+
+	if result.Terminal == nil || result.Terminal.Reason != "subtitle_track_invalid" {
+		t.Fatalf("a malformed identity must stay terminal: %#v", result)
+	}
+}


### PR DESCRIPTION
## Problem

Starting the next episode could fail outright:

```
The selected subtitle track is unavailable in the effective file version.
selected audio track is unavailable
```

Both come from carrying a selection across files. A viewer picks a subtitle or audio track on one episode; the next episode — or an alternate version the planner falls back to — has a different track layout; the rebase finds no equivalent and the start is refused. On Android TV that surfaces as an error screen the viewer has to replay out of.

Refusing is disproportionate to what actually went wrong. Nothing is broken: the file is playable, only one preference cannot be honoured.

## Approach

- **Subtitles** are an enhancement, so an absent track clears the selection and lets the planner apply the profile default.
- **Audio** cannot simply be dropped, so an out-of-range selection falls back to the file's own default through the existing `normalizeAudioTrackIndex`.
- Both report a degradation warning on the plan — `subtitle_track_unavailable`, `audio_track_unavailable` — so clients can tell the viewer what happened rather than silently swapping tracks under them.

Malformed requests still error. An unparseable track identity, or a negative index, is a client bug rather than a content mismatch, and swallowing it would make that bug harder to find.

## Tests

- `TestRemapSubtitleSelectionV3DropsSelectionWhenAbsentFromTarget` — missing track drops the selection, reports degraded, does not error
- `TestRemapSubtitleSelectionV3RebasesWhenTargetHasTheTrack` — an equivalent track is still preferred over dropping
- `TestResolveV3AudioIndexFallsBackWhenSelectionIsOutOfRange` — falls back to a valid index, reports degraded
- existing `TestRemapSubtitleSelectionV3RejectsNegativeIndex` kept — malformed input must still fail

`go test ./internal/api/handlers/` passes. `./internal/playback/` has 4 pre-existing failures on this machine (`TestResolveHWAccel*`, `TestFFmpegSupportsNVENC*`) which reproduce identically on a pristine `main` — they probe for NVIDIA hardware.

## Note for client authors

Clients that treat a start response as all-or-nothing will now start playing where they previously showed an error. The degradation warnings are the signal to surface "the track you picked isn't on this episode" without blocking playback.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Playback now continues when selected audio is unavailable by falling back to the file’s default audio track.
  * Unavailable subtitle selections are safely removed instead of preventing playback.
  * Playback reports when audio or subtitle selections were degraded.
  * Valid subtitle selections are preserved and correctly remapped.
  * Invalid subtitle indices and malformed track selections are rejected.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->