### PR TITLE
fix(jellycompat): default server name to Silo

### DIFF
--- a/internal/database/jellycompat_server_name_migration_test.go
+++ b/internal/database/jellycompat_server_name_migration_test.go
@@ -1,0 +1,31 @@
+package database
+
+import (
+	"os"
+	"strings"
+	"testing"
+)
+
+func TestJellycompatServerNameDefaultsToSilo(t *testing.T) {
+	initialSchema, err := os.ReadFile("../../migrations/sql/001_schema.sql")
+	if err != nil {
+		t.Fatalf("read initial schema: %v", err)
+	}
+	if !strings.Contains(string(initialSchema), "('jellyfin_compat.server_name', 'Silo')") {
+		t.Fatal("initial schema does not seed the Jellyfin compat server name to Silo")
+	}
+
+	migration, err := os.ReadFile("../../migrations/sql/20260806224241_rename_default_jellycompat_server_to_silo.sql")
+	if err != nil {
+		t.Fatalf("read server-name migration: %v", err)
+	}
+	normalized := strings.Join(strings.Fields(string(migration)), " ")
+	for _, fragment := range []string{
+		"SET value = 'Silo'",
+		"WHERE key = 'jellyfin_compat.server_name' AND value = 'StreamApp'",
+	} {
+		if !strings.Contains(normalized, fragment) {
+			t.Fatalf("server-name migration missing %q:\n%s", fragment, migration)
+		}
+	}
+}

--- a/migrations/sql/001_schema.sql
+++ b/migrations/sql/001_schema.sql
@@ -2456,7 +2456,7 @@ INSERT INTO public.server_settings (key, value) VALUES
   ('matcher.batch_size', '500'),
   ('jellyfin_compat.public_url', 'http://127.0.0.1:8096'),
   ('jellyfin_compat.emulated_server_version', '10.12.0'),
-  ('jellyfin_compat.server_name', 'StreamApp'),
+  ('jellyfin_compat.server_name', 'Silo'),
   ('jellyfin_compat.session_ttl', '87600h'),
   ('jellyfin_compat.playback_session_ttl', '6h'),
   ('userdb.backend', 'postgres'),

--- a/migrations/sql/20260806224241_rename_default_jellycompat_server_to_silo.sql
+++ b/migrations/sql/20260806224241_rename_default_jellycompat_server_to_silo.sql
@@ -1,0 +1,10 @@
+-- +goose Up
+UPDATE server_settings
+SET value = 'Silo'
+WHERE key = 'jellyfin_compat.server_name'
+  AND value = 'StreamApp';
+
+-- +goose Down
+-- Intentionally a no-op: after the update there is no reliable way to
+-- distinguish the migrated default from an operator-chosen "Silo" name.
+SELECT 1;


### PR DESCRIPTION
## Summary

- default the Jellyfin compatibility server name to `Silo` for fresh databases
- migrate only the untouched legacy `StreamApp` value on existing databases
- add regression coverage for both the baseline seed and guarded upgrade predicate

## Why

The runtime fallback and admin-settings default already use `Silo`, but the initial schema still persisted `StreamApp`. Because the persisted database value wins, Jellyfin-compatible clients continued to see the legacy product name.

## Impact and risk

Existing installations are updated only when `jellyfin_compat.server_name` is exactly `StreamApp`; operator-customized names are preserved. The down migration is intentionally a no-op because a migrated `Silo` value cannot be distinguished safely from an operator-selected `Silo` value.

## Validation

- `make migrate-validate` — passed
- `go test ./internal/database ./internal/config -run 'TestJellycompatServerNameDefaultsToSilo|Test.*JellyfinCompat|Test.*RestartRequired' -count=1` — passed
- `golangci-lint run --new-from-merge-base=origin/main ./...` — `0 issues.`
- `cd web && pnpm run lint` — passed with 0 errors and 157 pre-existing warnings
- `cd web && pnpm run format:check` — passed
- `make verify-local-paths` — passed
- `git diff --check` — passed
- `make lint` — reports the repository's documented full-tree backlog (303 findings); none are on this diff
- `make test` — package tests for this change passed; the full run hit two unrelated macOS process-identity failures in `TestBeginWebOperationRecoversDeadProcessLock` and `TestBeginWebOperationRejectsLiveProcessLock`. An isolated playback-package rerun passed after the full run also encountered a flaky playback failure.

## Adversarial review

The review identified two data-safety risks: overwriting customized server names and changing an operator-selected `Silo` back to `StreamApp` on rollback. The migration now matches only the exact legacy default, and its down section is non-destructive.

### AI Disclosure
- Tool(s): OpenAI Codex
- Model(s): gpt-5
- Involvement: fully AI-generated
- Adversarial review: identified custom-name overwrite and destructive rollback risks; resolved them with an exact legacy-value predicate and a no-op down migration


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Data Updates**
  * Renamed the default Jellyfin-compatible server name from “StreamApp” to “Silo.”
  * Existing installations using the previous default are updated automatically during migration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->