### PR TITLE
feat(auth): add provider connection checks and managed roles

### DIFF
--- a/docs/plugins/auth-provider-contracts.md
+++ b/docs/plugins/auth-provider-contracts.md
@@ -1,0 +1,65 @@
+# Authentication-provider host contracts
+
+This document describes the host-side conventions used by `auth_provider.v1` plugins for configuration checks and optional role synchronization. These conventions are additive: providers that do not advertise or return them keep the existing authentication behavior.
+
+## Configuration connection check
+
+An authentication capability opts into configuration checks through capability metadata:
+
+```json
+{
+  "type": "auth_provider.v1",
+  "id": "ldap",
+  "metadata": {
+    "connection_test": true
+  }
+}
+```
+
+When an administrator tests staged configuration, Silo starts a temporary plugin instance with the staged values and preserved saved secrets, then sends an `AuthenticateRequest` containing:
+
+```json
+{
+  "metadata": {
+    "connection_test": true
+  }
+}
+```
+
+The request intentionally contains no username or password. The provider must validate only the configured service connection and return success or a gRPC error. The temporary instance is stopped after the check.
+
+Until the plugin SDK exposes a dedicated connection-check RPC, the metadata key above is the compatibility contract. Providers must not interpret a normal password request as a connection check unless the value is the boolean `true`.
+
+## Provider-managed roles
+
+A provider may opt into managing the linked Silo account's coarse role by returning both claims below after successful authentication:
+
+```json
+{
+  "silo_role_managed": true,
+  "silo_role": "admin"
+}
+```
+
+The supported role values are `user` and `admin`.
+
+The host ignores `silo_role` unless `silo_role_managed` is present and is the boolean `true`. A malformed managed-role response fails authentication rather than partially applying authorization state.
+
+When the managed role changes:
+
+- promotion to `admin` clears the normal-user access group so its ceilings do not cap an administrator;
+- demotion to `user` restores default user permissions and assigns the current default access group;
+- the transition is applied on successful login and written to structured logs with the installation, capability, user, previous role, and new role;
+- providers that omit the managed marker cannot change an existing role and new accounts retain the normal `user` default.
+
+## Trust model
+
+An installed authentication plugin executes trusted server-side code and receives submitted credentials for its own provider. Enabling provider-managed roles additionally allows that plugin to request promotion or demotion of accounts linked to that installation.
+
+Administrators should install authentication providers only from trusted publishers, keep a working local administrator account for recovery, and review provider configuration before enabling directory-managed roles.
+
+The role contract is deliberately narrow. Plugins cannot return arbitrary role names, permissions, library IDs, or access-group IDs.
+
+## Compatibility and future SDK work
+
+These conventions use existing protobuf `Struct` metadata and claims so they do not change the v1 wire schema. A future plugin SDK may replace either convention with typed fields or dedicated RPCs. Any replacement must preserve backward compatibility for providers using these documented keys.

--- a/internal/auth/plugin_provider.go
+++ b/internal/auth/plugin_provider.go
@@ -6,6 +6,7 @@ import (
 	"encoding/hex"
 	"errors"
 	"fmt"
+	"log/slog"
 	"strings"
 
 	"github.com/jackc/pgx/v5"
@@ -17,7 +18,10 @@ import (
 	"github.com/Silo-Server/silo-server/internal/plugins"
 )
 
-const pluginRoleClaimKey = "silo_role"
+const (
+	pluginRoleClaimKey        = "silo_role"
+	pluginRoleManagedClaimKey = "silo_role_managed"
+)
 
 type pluginAuthClient interface {
 	Authenticate(ctx context.Context, req *pluginv1.AuthenticateRequest) (*pluginv1.AuthenticateResponse, error)
@@ -304,7 +308,7 @@ func (p *PluginProvider) synchronizeClaimedRole(
 
 	var defaultGroupID *int64
 	if desiredRole == "user" {
-		defaultGroupID, err = p.defaultAccessGroupID(ctx)
+		defaultGroupID, err = p.users.DefaultAccessGroupID(ctx)
 		if err != nil {
 			return nil, err
 		}
@@ -314,9 +318,18 @@ func (p *PluginProvider) synchronizeClaimedRole(
 	if !changed {
 		return user, nil
 	}
+	previousRole := user.Role
 	if err := p.users.Update(ctx, user.ID, input); err != nil {
 		return nil, fmt.Errorf("synchronize plugin-authenticated user role: %w", err)
 	}
+	slog.InfoContext(ctx, "synchronized plugin-authenticated user role",
+		"component", "auth",
+		"plugin_installation_id", p.config.InstallationID,
+		"plugin_capability_id", p.config.CapabilityID,
+		"user_id", user.ID,
+		"previous_role", previousRole,
+		"new_role", desiredRole,
+	)
 	updated, err := p.users.GetByID(ctx, user.ID)
 	if err != nil {
 		return nil, fmt.Errorf("reload plugin-authenticated user after role synchronization: %w", err)
@@ -328,9 +341,22 @@ func pluginRoleFromResponse(response *pluginv1.AuthenticateResponse) (string, bo
 	if response == nil || response.GetClaims() == nil {
 		return "", false, nil
 	}
-	raw, exists := response.GetClaims().AsMap()[pluginRoleClaimKey]
-	if !exists || raw == nil {
+	claims := response.GetClaims().AsMap()
+	managedRaw, exists := claims[pluginRoleManagedClaimKey]
+	if !exists || managedRaw == nil {
 		return "", false, nil
+	}
+	managed, ok := managedRaw.(bool)
+	if !ok {
+		return "", false, fmt.Errorf("plugin auth claim %q must be a boolean", pluginRoleManagedClaimKey)
+	}
+	if !managed {
+		return "", false, nil
+	}
+
+	raw, exists := claims[pluginRoleClaimKey]
+	if !exists || raw == nil {
+		return "", false, fmt.Errorf("plugin auth claim %q is required when %q is true", pluginRoleClaimKey, pluginRoleManagedClaimKey)
 	}
 	text, ok := raw.(string)
 	if !ok {
@@ -338,7 +364,7 @@ func pluginRoleFromResponse(response *pluginv1.AuthenticateResponse) (string, bo
 	}
 	role := strings.ToLower(strings.TrimSpace(text))
 	if role == "" {
-		return "", false, nil
+		return "", false, fmt.Errorf("plugin auth claim %q must not be empty when %q is true", pluginRoleClaimKey, pluginRoleManagedClaimKey)
 	}
 	if role != "user" && role != "admin" {
 		return "", false, fmt.Errorf("plugin auth claim %q contains unsupported role %q", pluginRoleClaimKey, text)
@@ -368,27 +394,6 @@ func roleSyncUpdateInput(
 	input.AccessGroupIDSet = true
 	input.AccessGroupID = defaultGroupID
 	return input, true
-}
-
-func (p *PluginProvider) defaultAccessGroupID(ctx context.Context) (*int64, error) {
-	if p.identityPool == nil {
-		return nil, nil
-	}
-	var id int64
-	err := p.identityPool.QueryRow(ctx, `
-		SELECT id
-		FROM access_groups
-		WHERE is_default
-		ORDER BY id
-		LIMIT 1
-	`).Scan(&id)
-	if err != nil {
-		if errors.Is(err, pgx.ErrNoRows) {
-			return nil, nil
-		}
-		return nil, fmt.Errorf("load default access group for role synchronization: %w", err)
-	}
-	return &id, nil
 }
 
 func randomPluginOnlyPassword() (string, error) {

--- a/internal/auth/plugin_provider.go
+++ b/internal/auth/plugin_provider.go
@@ -17,6 +17,8 @@ import (
 	"github.com/Silo-Server/silo-server/internal/plugins"
 )
 
+const pluginRoleClaimKey = "silo_role"
+
 type pluginAuthClient interface {
 	Authenticate(ctx context.Context, req *pluginv1.AuthenticateRequest) (*pluginv1.AuthenticateResponse, error)
 	InitAuthorize(ctx context.Context, req *pluginv1.InitAuthorizeRequest) (*pluginv1.InitAuthorizeResponse, error)
@@ -103,7 +105,7 @@ func (p *PluginProvider) Authenticate(ctx context.Context, creds Credentials) (*
 		if !user.Enabled {
 			return nil, ErrUserDisabled
 		}
-		return user, nil
+		return p.synchronizeClaimedRole(ctx, user, response)
 	}
 	if err != nil && !errors.Is(err, ErrNotFound) {
 		return nil, err
@@ -137,7 +139,7 @@ func (p *PluginProvider) CompleteOAuth(ctx context.Context, response *pluginv1.A
 		if !user.Enabled {
 			return nil, ErrUserDisabled
 		}
-		return user, nil
+		return p.synchronizeClaimedRole(ctx, user, response)
 	}
 	if err != nil && !errors.Is(err, ErrNotFound) {
 		return nil, err
@@ -250,6 +252,15 @@ func (p *PluginProvider) autoProvisionUser(
 		email = fmt.Sprintf("%s@plugin-%d.local", usernameBase, p.config.InstallationID)
 	}
 
+	role := "user"
+	claimedRole, hasClaimedRole, err := pluginRoleFromResponse(response)
+	if err != nil {
+		return nil, err
+	}
+	if hasClaimedRole {
+		role = claimedRole
+	}
+
 	localPasswordLoginEnabled := false
 	password, err := randomPluginOnlyPassword()
 	if err != nil {
@@ -264,7 +275,7 @@ func (p *PluginProvider) autoProvisionUser(
 				Username:                  username,
 				Password:                  password,
 				LocalPasswordLoginEnabled: &localPasswordLoginEnabled,
-				Role:                      "user",
+				Role:                      role,
 			},
 		})
 		if err == nil {
@@ -276,6 +287,108 @@ func (p *PluginProvider) autoProvisionUser(
 		username = fmt.Sprintf("%s_%d", usernameBase, i+2)
 	}
 	return nil, fmt.Errorf("auto-provision plugin user: exhausted username attempts")
+}
+
+func (p *PluginProvider) synchronizeClaimedRole(
+	ctx context.Context,
+	user *models.User,
+	response *pluginv1.AuthenticateResponse,
+) (*models.User, error) {
+	desiredRole, present, err := pluginRoleFromResponse(response)
+	if err != nil {
+		return nil, err
+	}
+	if !present || user == nil || user.Role == desiredRole {
+		return user, nil
+	}
+
+	var defaultGroupID *int64
+	if desiredRole == "user" {
+		defaultGroupID, err = p.defaultAccessGroupID(ctx)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	input, changed := roleSyncUpdateInput(user, desiredRole, defaultGroupID)
+	if !changed {
+		return user, nil
+	}
+	if err := p.users.Update(ctx, user.ID, input); err != nil {
+		return nil, fmt.Errorf("synchronize plugin-authenticated user role: %w", err)
+	}
+	updated, err := p.users.GetByID(ctx, user.ID)
+	if err != nil {
+		return nil, fmt.Errorf("reload plugin-authenticated user after role synchronization: %w", err)
+	}
+	return updated, nil
+}
+
+func pluginRoleFromResponse(response *pluginv1.AuthenticateResponse) (string, bool, error) {
+	if response == nil || response.GetClaims() == nil {
+		return "", false, nil
+	}
+	raw, exists := response.GetClaims().AsMap()[pluginRoleClaimKey]
+	if !exists || raw == nil {
+		return "", false, nil
+	}
+	text, ok := raw.(string)
+	if !ok {
+		return "", false, fmt.Errorf("plugin auth claim %q must be a string", pluginRoleClaimKey)
+	}
+	role := strings.ToLower(strings.TrimSpace(text))
+	if role == "" {
+		return "", false, nil
+	}
+	if role != "user" && role != "admin" {
+		return "", false, fmt.Errorf("plugin auth claim %q contains unsupported role %q", pluginRoleClaimKey, text)
+	}
+	return role, true, nil
+}
+
+func roleSyncUpdateInput(
+	user *models.User,
+	desiredRole string,
+	defaultGroupID *int64,
+) (models.UpdateUserInput, bool) {
+	if user == nil || user.Role == desiredRole {
+		return models.UpdateUserInput{}, false
+	}
+
+	role := desiredRole
+	input := models.UpdateUserInput{Role: &role}
+	if desiredRole == "admin" {
+		input.AccessGroupIDSet = true
+		input.AccessGroupID = nil
+		return input, true
+	}
+
+	permissions := DefaultUserPermissions()
+	input.Permissions = &permissions
+	input.AccessGroupIDSet = true
+	input.AccessGroupID = defaultGroupID
+	return input, true
+}
+
+func (p *PluginProvider) defaultAccessGroupID(ctx context.Context) (*int64, error) {
+	if p.identityPool == nil {
+		return nil, nil
+	}
+	var id int64
+	err := p.identityPool.QueryRow(ctx, `
+		SELECT id
+		FROM access_groups
+		WHERE is_default
+		ORDER BY id
+		LIMIT 1
+	`).Scan(&id)
+	if err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("load default access group for role synchronization: %w", err)
+	}
+	return &id, nil
 }
 
 func randomPluginOnlyPassword() (string, error) {

--- a/internal/auth/plugin_provider_test.go
+++ b/internal/auth/plugin_provider_test.go
@@ -1,9 +1,13 @@
 package auth
 
 import (
+	"slices"
 	"testing"
 
+	pluginv1 "github.com/Silo-Server/silo-plugin-sdk/pkg/pluginproto/silo/plugin/v1"
+	"github.com/Silo-Server/silo-server/internal/models"
 	"golang.org/x/crypto/bcrypt"
+	"google.golang.org/protobuf/types/known/structpb"
 )
 
 func TestRandomPluginOnlyPasswordFitsBcryptLimit(t *testing.T) {
@@ -17,5 +21,51 @@ func TestRandomPluginOnlyPasswordFitsBcryptLimit(t *testing.T) {
 	}
 	if _, err := bcrypt.GenerateFromPassword([]byte(password), bcrypt.DefaultCost); err != nil {
 		t.Fatalf("bcrypt.GenerateFromPassword() error = %v", err)
+	}
+}
+
+func TestPluginRoleFromResponse(t *testing.T) {
+	claims, err := structpb.NewStruct(map[string]any{pluginRoleClaimKey: "ADMIN"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	role, present, err := pluginRoleFromResponse(&pluginv1.AuthenticateResponse{Claims: claims})
+	if err != nil {
+		t.Fatalf("pluginRoleFromResponse() error = %v", err)
+	}
+	if !present || role != "admin" {
+		t.Fatalf("role = %q, present = %v; want admin, true", role, present)
+	}
+
+	claims, err = structpb.NewStruct(map[string]any{pluginRoleClaimKey: "owner"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, _, err := pluginRoleFromResponse(&pluginv1.AuthenticateResponse{Claims: claims}); err == nil {
+		t.Fatal("expected unsupported plugin role to be rejected")
+	}
+}
+
+func TestRoleSyncUpdateInputPromotesAndDemotes(t *testing.T) {
+	groupID := int64(42)
+	user := &models.User{ID: 7, Role: "user", AccessGroupID: &groupID}
+	promote, changed := roleSyncUpdateInput(user, "admin", nil)
+	if !changed || promote.Role == nil || *promote.Role != "admin" {
+		t.Fatalf("promotion input = %#v, changed = %v", promote, changed)
+	}
+	if !promote.AccessGroupIDSet || promote.AccessGroupID != nil {
+		t.Fatalf("promotion must remove the normal access group: %#v", promote)
+	}
+
+	admin := &models.User{ID: 7, Role: "admin"}
+	demote, changed := roleSyncUpdateInput(admin, "user", &groupID)
+	if !changed || demote.Role == nil || *demote.Role != "user" {
+		t.Fatalf("demotion input = %#v, changed = %v", demote, changed)
+	}
+	if demote.Permissions == nil || !slices.Equal(*demote.Permissions, DefaultUserPermissions()) {
+		t.Fatalf("demotion permissions = %#v, want defaults", demote.Permissions)
+	}
+	if !demote.AccessGroupIDSet || demote.AccessGroupID == nil || *demote.AccessGroupID != groupID {
+		t.Fatalf("demotion must assign the default access group: %#v", demote)
 	}
 }

--- a/internal/auth/plugin_provider_test.go
+++ b/internal/auth/plugin_provider_test.go
@@ -24,25 +24,92 @@ func TestRandomPluginOnlyPasswordFitsBcryptLimit(t *testing.T) {
 	}
 }
 
-func TestPluginRoleFromResponse(t *testing.T) {
-	claims, err := structpb.NewStruct(map[string]any{pluginRoleClaimKey: "ADMIN"})
+func authResponseWithClaims(t *testing.T, values map[string]any) *pluginv1.AuthenticateResponse {
+	t.Helper()
+	claims, err := structpb.NewStruct(values)
 	if err != nil {
 		t.Fatal(err)
 	}
-	role, present, err := pluginRoleFromResponse(&pluginv1.AuthenticateResponse{Claims: claims})
+	return &pluginv1.AuthenticateResponse{Claims: claims}
+}
+
+func TestPluginRoleFromResponseRequiresManagedMarker(t *testing.T) {
+	response := authResponseWithClaims(t, map[string]any{pluginRoleClaimKey: "admin"})
+	role, present, err := pluginRoleFromResponse(response)
+	if err != nil {
+		t.Fatalf("pluginRoleFromResponse() error = %v", err)
+	}
+	if present || role != "" {
+		t.Fatalf("role = %q, present = %v; unmanaged role claim must be ignored", role, present)
+	}
+
+	response = authResponseWithClaims(t, map[string]any{
+		pluginRoleManagedClaimKey: false,
+		pluginRoleClaimKey:        "admin",
+	})
+	role, present, err = pluginRoleFromResponse(response)
+	if err != nil {
+		t.Fatalf("pluginRoleFromResponse() error = %v", err)
+	}
+	if present || role != "" {
+		t.Fatalf("role = %q, present = %v; disabled managed role claim must be ignored", role, present)
+	}
+}
+
+func TestPluginRoleFromResponseAcceptsManagedAdmin(t *testing.T) {
+	response := authResponseWithClaims(t, map[string]any{
+		pluginRoleManagedClaimKey: true,
+		pluginRoleClaimKey:        "ADMIN",
+	})
+	role, present, err := pluginRoleFromResponse(response)
 	if err != nil {
 		t.Fatalf("pluginRoleFromResponse() error = %v", err)
 	}
 	if !present || role != "admin" {
 		t.Fatalf("role = %q, present = %v; want admin, true", role, present)
 	}
+}
 
-	claims, err = structpb.NewStruct(map[string]any{pluginRoleClaimKey: "owner"})
-	if err != nil {
-		t.Fatal(err)
+func TestPluginRoleFromResponseRejectsMalformedManagedClaims(t *testing.T) {
+	tests := []struct {
+		name   string
+		claims map[string]any
+	}{
+		{
+			name: "managed marker is not boolean",
+			claims: map[string]any{
+				pluginRoleManagedClaimKey: "true",
+				pluginRoleClaimKey:        "admin",
+			},
+		},
+		{
+			name: "managed role is missing",
+			claims: map[string]any{
+				pluginRoleManagedClaimKey: true,
+			},
+		},
+		{
+			name: "managed role is empty",
+			claims: map[string]any{
+				pluginRoleManagedClaimKey: true,
+				pluginRoleClaimKey:        " ",
+			},
+		},
+		{
+			name: "managed role is unsupported",
+			claims: map[string]any{
+				pluginRoleManagedClaimKey: true,
+				pluginRoleClaimKey:        "owner",
+			},
+		},
 	}
-	if _, _, err := pluginRoleFromResponse(&pluginv1.AuthenticateResponse{Claims: claims}); err == nil {
-		t.Fatal("expected unsupported plugin role to be rejected")
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			if _, _, err := pluginRoleFromResponse(authResponseWithClaims(t, test.claims)); err == nil {
+				t.Fatal("expected malformed managed role claim to be rejected")
+			}
+		})
 	}
 }
 

--- a/internal/auth/repository_access_group.go
+++ b/internal/auth/repository_access_group.go
@@ -1,0 +1,33 @@
+package auth
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"github.com/jackc/pgx/v5"
+)
+
+// DefaultAccessGroupID returns the configured default access group, or nil when
+// no default exists. Keeping this query on UserRepository avoids teaching an
+// authentication provider about the access_groups table.
+func (r *UserRepository) DefaultAccessGroupID(ctx context.Context) (*int64, error) {
+	if r == nil || r.pool == nil {
+		return nil, nil
+	}
+	var id int64
+	err := r.pool.QueryRow(ctx, `
+		SELECT id
+		FROM access_groups
+		WHERE is_default
+		ORDER BY id
+		LIMIT 1
+	`).Scan(&id)
+	if err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("load default access group: %w", err)
+	}
+	return &id, nil
+}

--- a/internal/plugins/service_connection.go
+++ b/internal/plugins/service_connection.go
@@ -36,15 +36,45 @@ func (e *ConnectionTestError) Unwrap() error {
 	return e.Cause
 }
 
+type pluginConnectionCheckCapability struct {
+	kind string
+	id   string
+}
+
+const (
+	connectionCheckKindMetadata = "metadata_provider"
+	connectionCheckKindAuth     = "auth_provider"
+)
+
 var runPluginConnectionCheck = func(
 	ctx context.Context,
 	client pluginClient,
 	manifest *pluginv1.PluginManifest,
 ) error {
-	capabilityID, err := metadataProviderConnectionCheckCapabilityID(manifest)
+	capability, err := pluginConnectionCheckCapabilityForManifest(manifest)
 	if err != nil {
 		return err
 	}
+
+	switch capability.kind {
+	case connectionCheckKindMetadata:
+		return runMetadataProviderConnectionCheck(ctx, client, manifest, capability.id)
+	case connectionCheckKindAuth:
+		return runAuthProviderConnectionCheck(ctx, client, capability.id)
+	default:
+		return &ConnectionTestError{
+			Message: "Connection checks are not supported for this plugin yet.",
+			Cause:   ErrConnectionTestUnsupported,
+		}
+	}
+}
+
+func runMetadataProviderConnectionCheck(
+	ctx context.Context,
+	client pluginClient,
+	manifest *pluginv1.PluginManifest,
+	capabilityID string,
+) error {
 	capability := metadataProviderConnectionCheckCapability(manifest, capabilityID)
 	if !metadataProviderSupportsConnectionProbe(capability, "movie") {
 		slog.DebugContext(ctx,
@@ -79,6 +109,41 @@ var runPluginConnectionCheck = func(
 		}
 	}
 
+	return nil
+}
+
+func runAuthProviderConnectionCheck(
+	ctx context.Context,
+	client pluginClient,
+	capabilityID string,
+) error {
+	authClient, err := client.AuthProvider(capabilityID)
+	if err != nil {
+		return &ConnectionTestError{
+			Message: fmt.Sprintf("Failed to initialize the authentication provider: %v", err),
+			Cause:   err,
+		}
+	}
+
+	metadata, err := structpb.NewStruct(map[string]any{"connection_test": true})
+	if err != nil {
+		return &ConnectionTestError{
+			Message: "Failed to prepare the authentication-provider connection check.",
+			Cause:   err,
+		}
+	}
+
+	probeCtx, cancel := context.WithTimeout(ctx, 20*time.Second)
+	defer cancel()
+
+	if _, err := authClient.Authenticate(probeCtx, &pluginv1.AuthenticateRequest{
+		Metadata: metadata,
+	}); err != nil {
+		return &ConnectionTestError{
+			Message: fmt.Sprintf("Connection check failed: %v", err),
+			Cause:   err,
+		}
+	}
 	return nil
 }
 
@@ -143,7 +208,7 @@ func (s *Service) TestGlobalConfigWithClears(
 			Cause:   err,
 		}
 	}
-	if _, err := metadataProviderConnectionCheckCapabilityID(manifest); err != nil {
+	if _, err := pluginConnectionCheckCapabilityForManifest(manifest); err != nil {
 		return err
 	}
 
@@ -254,6 +319,42 @@ func cloneConfigMap(value map[string]any) map[string]any {
 		cloned[key] = entry
 	}
 	return cloned
+}
+
+func pluginConnectionCheckCapabilityForManifest(
+	manifest *pluginv1.PluginManifest,
+) (pluginConnectionCheckCapability, error) {
+	if capabilityID, err := metadataProviderConnectionCheckCapabilityID(manifest); err == nil {
+		return pluginConnectionCheckCapability{
+			kind: connectionCheckKindMetadata,
+			id:   capabilityID,
+		}, nil
+	}
+	if capabilityID, ok := authProviderConnectionCheckCapabilityID(manifest); ok {
+		return pluginConnectionCheckCapability{
+			kind: connectionCheckKindAuth,
+			id:   capabilityID,
+		}, nil
+	}
+	return pluginConnectionCheckCapability{}, &ConnectionTestError{
+		Message: "Connection checks are not supported for this plugin yet.",
+		Cause:   ErrConnectionTestUnsupported,
+	}
+}
+
+func authProviderConnectionCheckCapabilityID(
+	manifest *pluginv1.PluginManifest,
+) (string, bool) {
+	for _, capability := range manifest.GetCapabilities() {
+		if capability.GetType() != "auth_provider.v1" || capability.GetMetadata() == nil {
+			continue
+		}
+		enabled, ok := capability.GetMetadata().AsMap()["connection_test"].(bool)
+		if ok && enabled {
+			return capability.GetId(), true
+		}
+	}
+	return "", false
 }
 
 func metadataProviderConnectionCheckCapabilityID(manifest *pluginv1.PluginManifest) (string, error) {

--- a/internal/plugins/service_connection_auth_test.go
+++ b/internal/plugins/service_connection_auth_test.go
@@ -44,6 +44,25 @@ func TestPluginConnectionCheckCapabilityRejectsUnadvertisedAuthProvider(t *testi
 	}
 }
 
+func TestPluginConnectionCheckCapabilityRejectsDisabledAuthProbe(t *testing.T) {
+	metadata, err := structpb.NewStruct(map[string]any{"connection_test": false})
+	if err != nil {
+		t.Fatal(err)
+	}
+	manifest := &pluginv1.PluginManifest{Capabilities: []*pluginv1.CapabilityDescriptor{
+		{
+			Type:     "auth_provider.v1",
+			Id:       "disabled-auth",
+			Metadata: metadata,
+		},
+	}}
+
+	_, err = pluginConnectionCheckCapabilityForManifest(manifest)
+	if !errors.Is(err, ErrConnectionTestUnsupported) {
+		t.Fatalf("error = %v, want ErrConnectionTestUnsupported", err)
+	}
+}
+
 func TestPluginConnectionCheckCapabilityPreservesMetadataProviderPriority(t *testing.T) {
 	authMetadata, err := structpb.NewStruct(map[string]any{"connection_test": true})
 	if err != nil {

--- a/internal/plugins/service_connection_auth_test.go
+++ b/internal/plugins/service_connection_auth_test.go
@@ -1,0 +1,71 @@
+package plugins
+
+import (
+	"errors"
+	"testing"
+
+	pluginv1 "github.com/Silo-Server/silo-plugin-sdk/pkg/pluginproto/silo/plugin/v1"
+	"google.golang.org/protobuf/types/known/structpb"
+)
+
+func TestPluginConnectionCheckCapabilityUsesAdvertisedAuthProvider(t *testing.T) {
+	metadata, err := structpb.NewStruct(map[string]any{"connection_test": true})
+	if err != nil {
+		t.Fatal(err)
+	}
+	manifest := &pluginv1.PluginManifest{Capabilities: []*pluginv1.CapabilityDescriptor{
+		{
+			Type:     "auth_provider.v1",
+			Id:       "ldap",
+			Metadata: metadata,
+		},
+	}}
+
+	capability, err := pluginConnectionCheckCapabilityForManifest(manifest)
+	if err != nil {
+		t.Fatalf("pluginConnectionCheckCapabilityForManifest returned an error: %v", err)
+	}
+	if capability.kind != connectionCheckKindAuth || capability.id != "ldap" {
+		t.Fatalf("capability = %#v, want auth provider ldap", capability)
+	}
+}
+
+func TestPluginConnectionCheckCapabilityRejectsUnadvertisedAuthProvider(t *testing.T) {
+	manifest := &pluginv1.PluginManifest{Capabilities: []*pluginv1.CapabilityDescriptor{
+		{
+			Type: "auth_provider.v1",
+			Id:   "legacy-auth",
+		},
+	}}
+
+	_, err := pluginConnectionCheckCapabilityForManifest(manifest)
+	if !errors.Is(err, ErrConnectionTestUnsupported) {
+		t.Fatalf("error = %v, want ErrConnectionTestUnsupported", err)
+	}
+}
+
+func TestPluginConnectionCheckCapabilityPreservesMetadataProviderPriority(t *testing.T) {
+	authMetadata, err := structpb.NewStruct(map[string]any{"connection_test": true})
+	if err != nil {
+		t.Fatal(err)
+	}
+	manifest := &pluginv1.PluginManifest{Capabilities: []*pluginv1.CapabilityDescriptor{
+		{
+			Type:     "auth_provider.v1",
+			Id:       "ldap",
+			Metadata: authMetadata,
+		},
+		{
+			Type: "metadata_provider.v1",
+			Id:   "metadata",
+		},
+	}}
+
+	capability, err := pluginConnectionCheckCapabilityForManifest(manifest)
+	if err != nil {
+		t.Fatalf("pluginConnectionCheckCapabilityForManifest returned an error: %v", err)
+	}
+	if capability.kind != connectionCheckKindMetadata || capability.id != "metadata" {
+		t.Fatalf("capability = %#v, want metadata provider", capability)
+	}
+}


### PR DESCRIPTION
## Problem

Part of #554

Authentication providers can validate credentials and return identity claims, but Silo has no generic way to test staged provider configuration or let a trusted provider opt into managing the linked account's coarse `user` / `admin` role.

The concrete use case is an LDAP provider that can evaluate Active Directory group membership but cannot directly modify Silo-owned account state.

Companion provider: techrelay/Silo-LDAP-Plugin#1.

## Approach

### Authentication-provider connection checks

- extend the existing staged configuration-test path to `auth_provider.v1` capabilities that advertise boolean `metadata.connection_test=true`;
- start a temporary plugin instance with staged values and preserved saved secrets;
- send an `AuthenticateRequest` with boolean `metadata.connection_test=true` and no username or password;
- retain metadata-provider connection-test priority and existing behavior;
- stop the temporary plugin instance after the check.

### Explicit managed-role claims

- consume roles only when the response contains boolean `silo_role_managed=true`;
- accept only `silo_role=user` or `silo_role=admin`;
- ignore bare or explicitly unmanaged role claims;
- fail authentication on malformed managed claims rather than partially updating account state;
- apply managed roles during auto-provisioning and each successful linked login, including OAuth completion;
- clear the normal access group on promotion;
- restore default user permissions and the current default access group on demotion;
- log each role transition with installation, capability, user, previous role, and new role.

Default access-group lookup now belongs to `UserRepository` instead of embedding access-group SQL in the plugin provider. The compatibility contract and trust model are documented in `docs/plugins/auth-provider-contracts.md`.

## Compatibility and risks

- providers that do not advertise connection testing are unchanged;
- providers that omit `silo_role_managed` cannot change roles, even if they already return a claim named `silo_role`;
- new plugin-authenticated accounts still default to `user` when no managed claim is present;
- demotion intentionally resets the account to default user permissions and the current default access group rather than attempting to reconstruct pre-promotion state;
- installed authentication plugins are trusted server-side code; managed-role support adds the explicit ability to request promotion or demotion for accounts linked to that installation;
- the metadata and claim keys are compatibility conventions over existing protobuf `Struct` fields. The issue asks whether they should move into typed SDK APIs before merge.

## Testing

Targeted tests cover:

- advertised and unadvertised auth-provider connection checks;
- preservation of metadata-provider priority;
- managed-role opt-in, normalization, and malformed claim rejection;
- promotion and demotion update inputs;
- the plugin-only password length constraint.

Required repository verification will be reported from CI and/or a local checkout:

```text
make lint
make test
cd web && pnpm run lint && pnpm run format:check
make verify-local-paths
go test ./internal/auth ./internal/plugins
```

Verification results will be added after the draft checks complete.

### AI Disclosure
- Tool(s): ChatGPT with the GitHub connector
- Model(s): GPT-5.6 Thinking
- Involvement: AI-assisted; the human supplied the real deployment requirements and expected behavior, while AI implemented and adversarially reviewed the changes
- Adversarial review: found that a bare role claim created an implicit trust boundary, transitions were not auditable, access-group SQL was placed in the provider, demotion semantics were undocumented, and the companion plugin exposed raw LDAP errors. The host now requires an explicit managed marker, logs transitions, uses repository-owned lookup, documents reset semantics, and links to the hardened provider.

## Checklist

- [x] Linked scope issue
- [x] One host capability area: authentication-provider operational contracts
- [x] Added focused tests and contract documentation
- [ ] Repository verification completed
- [ ] Companion plugin CI completed
- [ ] Manual end-to-end LDAP promotion and demotion revalidated
