### PR TITLE
feat(auth): support provider configuration connection checks

### DIFF
--- a/docs/plugins/auth-provider-connection-checks.md
+++ b/docs/plugins/auth-provider-connection-checks.md
@@ -1,0 +1,33 @@
+# Authentication-provider connection checks
+
+An `auth_provider.v1` plugin may opt into staged configuration checks through capability metadata:
+
+```json
+{
+  "type": "auth_provider.v1",
+  "id": "ldap",
+  "metadata": {
+    "connection_test": true
+  }
+}
+```
+
+When an administrator tests unsaved configuration, Silo starts a temporary plugin instance with the staged values and any preserved saved secrets. It then sends an `AuthenticateRequest` containing:
+
+```json
+{
+  "metadata": {
+    "connection_test": true
+  }
+}
+```
+
+The request contains no username or password. The provider must validate only the configured service connection and return success or a gRPC error. The temporary instance is stopped after the check, and the host applies a 20-second timeout.
+
+Providers must not interpret a normal password request as a connection check unless the metadata value is the boolean `true`. Capabilities that omit the flag, set it to another type, or set it to `false` are not eligible for the Test connection action.
+
+The provider is responsible for sanitizing its RPC error. Detailed service errors should be logged by the plugin; unauthenticated responses should expose only information safe for an administrator-facing configuration result.
+
+## Compatibility and future SDK work
+
+This convention uses the existing protobuf `Struct`, so the v1 wire schema remains additive. A future plugin SDK may define a dedicated connection-check RPC or typed metadata constant. Any replacement should preserve compatibility with providers already advertising and consuming this documented key.

--- a/internal/plugins/service_connection.go
+++ b/internal/plugins/service_connection.go
@@ -36,15 +36,45 @@ func (e *ConnectionTestError) Unwrap() error {
 	return e.Cause
 }
 
+type pluginConnectionCheckCapability struct {
+	kind string
+	id   string
+}
+
+const (
+	connectionCheckKindMetadata = "metadata_provider"
+	connectionCheckKindAuth     = "auth_provider"
+)
+
 var runPluginConnectionCheck = func(
 	ctx context.Context,
 	client pluginClient,
 	manifest *pluginv1.PluginManifest,
 ) error {
-	capabilityID, err := metadataProviderConnectionCheckCapabilityID(manifest)
+	capability, err := pluginConnectionCheckCapabilityForManifest(manifest)
 	if err != nil {
 		return err
 	}
+
+	switch capability.kind {
+	case connectionCheckKindMetadata:
+		return runMetadataProviderConnectionCheck(ctx, client, manifest, capability.id)
+	case connectionCheckKindAuth:
+		return runAuthProviderConnectionCheck(ctx, client, capability.id)
+	default:
+		return &ConnectionTestError{
+			Message: "Connection checks are not supported for this plugin yet.",
+			Cause:   ErrConnectionTestUnsupported,
+		}
+	}
+}
+
+func runMetadataProviderConnectionCheck(
+	ctx context.Context,
+	client pluginClient,
+	manifest *pluginv1.PluginManifest,
+	capabilityID string,
+) error {
 	capability := metadataProviderConnectionCheckCapability(manifest, capabilityID)
 	if !metadataProviderSupportsConnectionProbe(capability, "movie") {
 		slog.DebugContext(ctx,
@@ -79,6 +109,41 @@ var runPluginConnectionCheck = func(
 		}
 	}
 
+	return nil
+}
+
+func runAuthProviderConnectionCheck(
+	ctx context.Context,
+	client pluginClient,
+	capabilityID string,
+) error {
+	authClient, err := client.AuthProvider(capabilityID)
+	if err != nil {
+		return &ConnectionTestError{
+			Message: fmt.Sprintf("Failed to initialize the authentication provider: %v", err),
+			Cause:   err,
+		}
+	}
+
+	metadata, err := structpb.NewStruct(map[string]any{"connection_test": true})
+	if err != nil {
+		return &ConnectionTestError{
+			Message: "Failed to prepare the authentication-provider connection check.",
+			Cause:   err,
+		}
+	}
+
+	probeCtx, cancel := context.WithTimeout(ctx, 20*time.Second)
+	defer cancel()
+
+	if _, err := authClient.Authenticate(probeCtx, &pluginv1.AuthenticateRequest{
+		Metadata: metadata,
+	}); err != nil {
+		return &ConnectionTestError{
+			Message: fmt.Sprintf("Connection check failed: %v", err),
+			Cause:   err,
+		}
+	}
 	return nil
 }
 
@@ -143,7 +208,7 @@ func (s *Service) TestGlobalConfigWithClears(
 			Cause:   err,
 		}
 	}
-	if _, err := metadataProviderConnectionCheckCapabilityID(manifest); err != nil {
+	if _, err := pluginConnectionCheckCapabilityForManifest(manifest); err != nil {
 		return err
 	}
 
@@ -254,6 +319,42 @@ func cloneConfigMap(value map[string]any) map[string]any {
 		cloned[key] = entry
 	}
 	return cloned
+}
+
+func pluginConnectionCheckCapabilityForManifest(
+	manifest *pluginv1.PluginManifest,
+) (pluginConnectionCheckCapability, error) {
+	if capabilityID, err := metadataProviderConnectionCheckCapabilityID(manifest); err == nil {
+		return pluginConnectionCheckCapability{
+			kind: connectionCheckKindMetadata,
+			id:   capabilityID,
+		}, nil
+	}
+	if capabilityID, ok := authProviderConnectionCheckCapabilityID(manifest); ok {
+		return pluginConnectionCheckCapability{
+			kind: connectionCheckKindAuth,
+			id:   capabilityID,
+		}, nil
+	}
+	return pluginConnectionCheckCapability{}, &ConnectionTestError{
+		Message: "Connection checks are not supported for this plugin yet.",
+		Cause:   ErrConnectionTestUnsupported,
+	}
+}
+
+func authProviderConnectionCheckCapabilityID(
+	manifest *pluginv1.PluginManifest,
+) (string, bool) {
+	for _, capability := range manifest.GetCapabilities() {
+		if capability.GetType() != "auth_provider.v1" || capability.GetMetadata() == nil {
+			continue
+		}
+		enabled, ok := capability.GetMetadata().AsMap()["connection_test"].(bool)
+		if ok && enabled {
+			return capability.GetId(), true
+		}
+	}
+	return "", false
 }
 
 func metadataProviderConnectionCheckCapabilityID(manifest *pluginv1.PluginManifest) (string, error) {

--- a/internal/plugins/service_connection_auth_test.go
+++ b/internal/plugins/service_connection_auth_test.go
@@ -44,6 +44,25 @@ func TestPluginConnectionCheckCapabilityRejectsUnadvertisedAuthProvider(t *testi
 	}
 }
 
+func TestPluginConnectionCheckCapabilityRejectsDisabledAuthProbe(t *testing.T) {
+	metadata, err := structpb.NewStruct(map[string]any{"connection_test": false})
+	if err != nil {
+		t.Fatal(err)
+	}
+	manifest := &pluginv1.PluginManifest{Capabilities: []*pluginv1.CapabilityDescriptor{
+		{
+			Type:     "auth_provider.v1",
+			Id:       "disabled-auth",
+			Metadata: metadata,
+		},
+	}}
+
+	_, err = pluginConnectionCheckCapabilityForManifest(manifest)
+	if !errors.Is(err, ErrConnectionTestUnsupported) {
+		t.Fatalf("error = %v, want ErrConnectionTestUnsupported", err)
+	}
+}
+
 func TestPluginConnectionCheckCapabilityPreservesMetadataProviderPriority(t *testing.T) {
 	authMetadata, err := structpb.NewStruct(map[string]any{"connection_test": true})
 	if err != nil {

--- a/internal/plugins/service_connection_auth_test.go
+++ b/internal/plugins/service_connection_auth_test.go
@@ -1,0 +1,71 @@
+package plugins
+
+import (
+	"errors"
+	"testing"
+
+	pluginv1 "github.com/Silo-Server/silo-plugin-sdk/pkg/pluginproto/silo/plugin/v1"
+	"google.golang.org/protobuf/types/known/structpb"
+)
+
+func TestPluginConnectionCheckCapabilityUsesAdvertisedAuthProvider(t *testing.T) {
+	metadata, err := structpb.NewStruct(map[string]any{"connection_test": true})
+	if err != nil {
+		t.Fatal(err)
+	}
+	manifest := &pluginv1.PluginManifest{Capabilities: []*pluginv1.CapabilityDescriptor{
+		{
+			Type:     "auth_provider.v1",
+			Id:       "ldap",
+			Metadata: metadata,
+		},
+	}}
+
+	capability, err := pluginConnectionCheckCapabilityForManifest(manifest)
+	if err != nil {
+		t.Fatalf("pluginConnectionCheckCapabilityForManifest returned an error: %v", err)
+	}
+	if capability.kind != connectionCheckKindAuth || capability.id != "ldap" {
+		t.Fatalf("capability = %#v, want auth provider ldap", capability)
+	}
+}
+
+func TestPluginConnectionCheckCapabilityRejectsUnadvertisedAuthProvider(t *testing.T) {
+	manifest := &pluginv1.PluginManifest{Capabilities: []*pluginv1.CapabilityDescriptor{
+		{
+			Type: "auth_provider.v1",
+			Id:   "legacy-auth",
+		},
+	}}
+
+	_, err := pluginConnectionCheckCapabilityForManifest(manifest)
+	if !errors.Is(err, ErrConnectionTestUnsupported) {
+		t.Fatalf("error = %v, want ErrConnectionTestUnsupported", err)
+	}
+}
+
+func TestPluginConnectionCheckCapabilityPreservesMetadataProviderPriority(t *testing.T) {
+	authMetadata, err := structpb.NewStruct(map[string]any{"connection_test": true})
+	if err != nil {
+		t.Fatal(err)
+	}
+	manifest := &pluginv1.PluginManifest{Capabilities: []*pluginv1.CapabilityDescriptor{
+		{
+			Type:     "auth_provider.v1",
+			Id:       "ldap",
+			Metadata: authMetadata,
+		},
+		{
+			Type: "metadata_provider.v1",
+			Id:   "metadata",
+		},
+	}}
+
+	capability, err := pluginConnectionCheckCapabilityForManifest(manifest)
+	if err != nil {
+		t.Fatalf("pluginConnectionCheckCapabilityForManifest returned an error: %v", err)
+	}
+	if capability.kind != connectionCheckKindMetadata || capability.id != "metadata" {
+		t.Fatalf("capability = %#v, want metadata provider", capability)
+	}
+}


### PR DESCRIPTION
## Problem

Part of #554

The staged plugin configuration tester currently knows how to probe metadata providers, but an `auth_provider.v1` plugin cannot validate LDAP, OAuth, or other authentication-service connectivity before an administrator saves its settings.

The concrete consumer is techrelay/Silo-LDAP-Plugin#1.

## Approach

- let an authentication capability explicitly advertise boolean `metadata.connection_test=true`;
- preserve the current metadata-provider probe behavior and priority;
- start a temporary plugin instance with the staged values and preserved saved secrets;
- send an `AuthenticateRequest` containing boolean `metadata.connection_test=true` and no username or password;
- apply the existing 20-second probe timeout;
- stop the temporary instance after the test;
- reject authentication capabilities that do not explicitly advertise support;
- document the compatibility key and provider responsibilities in `docs/plugins/auth-provider-connection-checks.md`.

This uses existing protobuf `Struct` metadata and does not change the v1 wire schema. A future SDK RPC may replace the convention while retaining this key for compatibility.

## Compatibility and risks

- metadata-provider connection tests are unchanged and retain priority for plugins that expose both capability types;
- authentication providers that do not advertise the capability remain unsupported by the Test connection action;
- providers must treat the request as a service/configuration probe and must not require or log end-user credentials;
- error sanitization remains the provider's responsibility. The companion LDAP provider returns only a stable operation stage while logging the full directory error.

## Testing

Focused tests cover:

- discovery of an advertised auth-provider probe;
- rejection when the capability is unadvertised;
- rejection when `connection_test` is false;
- preservation of metadata-provider priority.

Required repository checks:

```text
make lint
make test
cd web && pnpm run lint && pnpm run format:check
make verify-local-paths
go test ./internal/plugins
```

### Current verification status

- No workflow jobs had started for this split fork PR at the time of this update. The earlier combined fork PR was held at GitHub's `action_required` approval gate before jobs were created.
- Local verification could not be executed in the available environment because it has Go 1.23.2, no local dependency cache for this repository, and no network access to install the required toolchain or dependencies.
- This remains a draft until upstream CI runs and its real output is pasted here.

### AI Disclosure
- Tool(s): ChatGPT with the GitHub connector
- Model(s): GPT-5.6 Thinking
- Involvement: AI-assisted; the human supplied the deployed LDAP use case and expected behavior, while AI implemented and adversarially reviewed the host change
- Adversarial review: confirmed that the original combined change violated the one-concern-per-PR rule, so connection testing was isolated from role synchronization. The review also verified opt-in capability discovery, metadata-provider precedence, staged-secret preservation, timeout behavior, temporary-instance cleanup, and the need to document provider-side error sanitization.

## Checklist

- [x] Linked scope issue
- [x] One concern: authentication-provider configuration checks
- [x] Focused unit tests and contract documentation
- [x] Documented current verification limitations without claiming unexecuted tests
- [ ] Upstream CI verification completed and output recorded
- [ ] Companion LDAP provider revalidated against a live directory
