### PR TITLE
feat(auth): support explicit provider-managed roles

### DIFF
--- a/docs/plugins/auth-provider-managed-roles.md
+++ b/docs/plugins/auth-provider-managed-roles.md
@@ -1,0 +1,42 @@
+# Authentication-provider managed roles
+
+An `auth_provider.v1` plugin may opt into managing the linked Silo account's coarse role after successful authentication.
+
+## Response contract
+
+The provider returns both claims:
+
+```json
+{
+  "silo_role_managed": true,
+  "silo_role": "admin"
+}
+```
+
+The supported role values are `user` and `admin`.
+
+The host ignores `silo_role` unless `silo_role_managed` is present and is the boolean `true`. If the managed marker is true, a missing, empty, non-string, or unsupported role fails authentication rather than partially applying authorization state.
+
+Providers that omit the managed marker retain existing behavior: new auto-provisioned accounts default to `user`, and existing linked accounts keep their locally assigned roles.
+
+## Synchronization behavior
+
+The managed role is evaluated when an account is provisioned and on every successful linked login, including OAuth completion.
+
+When the role changes:
+
+- promotion to `admin` clears the normal-user access group so its ceilings do not cap an administrator;
+- demotion to `user` restores default user permissions and assigns the current default access group;
+- the transition is written to structured logs with the plugin installation, capability, user, previous role, and new role.
+
+Demotion does not reconstruct custom permissions or access-group assignments that existed before promotion. A provider-managed account returns to the server's current default user policy. This is deliberate and should be considered before enabling external role management.
+
+## Trust model
+
+An installed authentication plugin executes trusted server-side code and receives credentials for its own provider. Returning `silo_role_managed=true` additionally allows that plugin to request promotion or demotion of accounts linked to its installation.
+
+The contract is intentionally narrow. A plugin cannot return arbitrary role names, permissions, library IDs, or access-group IDs. Administrators should install authentication providers only from trusted publishers and keep a working local administrator account for recovery.
+
+## Compatibility and future SDK work
+
+The claims use the existing protobuf `Struct`, so the v1 wire schema remains additive. A future plugin SDK may define typed fields or constants for this contract. Any replacement should preserve compatibility with providers already returning these documented claims.

--- a/internal/auth/plugin_provider.go
+++ b/internal/auth/plugin_provider.go
@@ -6,6 +6,7 @@ import (
 	"encoding/hex"
 	"errors"
 	"fmt"
+	"log/slog"
 	"strings"
 
 	"github.com/jackc/pgx/v5"
@@ -15,6 +16,11 @@ import (
 	"github.com/Silo-Server/silo-server/internal/models"
 	"github.com/Silo-Server/silo-server/internal/pluginhost"
 	"github.com/Silo-Server/silo-server/internal/plugins"
+)
+
+const (
+	pluginRoleClaimKey        = "silo_role"
+	pluginRoleManagedClaimKey = "silo_role_managed"
 )
 
 type pluginAuthClient interface {
@@ -103,7 +109,7 @@ func (p *PluginProvider) Authenticate(ctx context.Context, creds Credentials) (*
 		if !user.Enabled {
 			return nil, ErrUserDisabled
 		}
-		return user, nil
+		return p.synchronizeClaimedRole(ctx, user, response)
 	}
 	if err != nil && !errors.Is(err, ErrNotFound) {
 		return nil, err
@@ -137,7 +143,7 @@ func (p *PluginProvider) CompleteOAuth(ctx context.Context, response *pluginv1.A
 		if !user.Enabled {
 			return nil, ErrUserDisabled
 		}
-		return user, nil
+		return p.synchronizeClaimedRole(ctx, user, response)
 	}
 	if err != nil && !errors.Is(err, ErrNotFound) {
 		return nil, err
@@ -250,6 +256,15 @@ func (p *PluginProvider) autoProvisionUser(
 		email = fmt.Sprintf("%s@plugin-%d.local", usernameBase, p.config.InstallationID)
 	}
 
+	role := "user"
+	claimedRole, hasClaimedRole, err := pluginRoleFromResponse(response)
+	if err != nil {
+		return nil, err
+	}
+	if hasClaimedRole {
+		role = claimedRole
+	}
+
 	localPasswordLoginEnabled := false
 	password, err := randomPluginOnlyPassword()
 	if err != nil {
@@ -264,7 +279,7 @@ func (p *PluginProvider) autoProvisionUser(
 				Username:                  username,
 				Password:                  password,
 				LocalPasswordLoginEnabled: &localPasswordLoginEnabled,
-				Role:                      "user",
+				Role:                      role,
 			},
 		})
 		if err == nil {
@@ -276,6 +291,109 @@ func (p *PluginProvider) autoProvisionUser(
 		username = fmt.Sprintf("%s_%d", usernameBase, i+2)
 	}
 	return nil, fmt.Errorf("auto-provision plugin user: exhausted username attempts")
+}
+
+func (p *PluginProvider) synchronizeClaimedRole(
+	ctx context.Context,
+	user *models.User,
+	response *pluginv1.AuthenticateResponse,
+) (*models.User, error) {
+	desiredRole, present, err := pluginRoleFromResponse(response)
+	if err != nil {
+		return nil, err
+	}
+	if !present || user == nil || user.Role == desiredRole {
+		return user, nil
+	}
+
+	var defaultGroupID *int64
+	if desiredRole == "user" {
+		defaultGroupID, err = p.users.DefaultAccessGroupID(ctx)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	input, changed := roleSyncUpdateInput(user, desiredRole, defaultGroupID)
+	if !changed {
+		return user, nil
+	}
+	previousRole := user.Role
+	if err := p.users.Update(ctx, user.ID, input); err != nil {
+		return nil, fmt.Errorf("synchronize plugin-authenticated user role: %w", err)
+	}
+	slog.InfoContext(ctx, "synchronized plugin-authenticated user role",
+		"component", "auth",
+		"plugin_installation_id", p.config.InstallationID,
+		"plugin_capability_id", p.config.CapabilityID,
+		"user_id", user.ID,
+		"previous_role", previousRole,
+		"new_role", desiredRole,
+	)
+	updated, err := p.users.GetByID(ctx, user.ID)
+	if err != nil {
+		return nil, fmt.Errorf("reload plugin-authenticated user after role synchronization: %w", err)
+	}
+	return updated, nil
+}
+
+func pluginRoleFromResponse(response *pluginv1.AuthenticateResponse) (string, bool, error) {
+	if response == nil || response.GetClaims() == nil {
+		return "", false, nil
+	}
+	claims := response.GetClaims().AsMap()
+	managedRaw, exists := claims[pluginRoleManagedClaimKey]
+	if !exists || managedRaw == nil {
+		return "", false, nil
+	}
+	managed, ok := managedRaw.(bool)
+	if !ok {
+		return "", false, fmt.Errorf("plugin auth claim %q must be a boolean", pluginRoleManagedClaimKey)
+	}
+	if !managed {
+		return "", false, nil
+	}
+
+	raw, exists := claims[pluginRoleClaimKey]
+	if !exists || raw == nil {
+		return "", false, fmt.Errorf("plugin auth claim %q is required when %q is true", pluginRoleClaimKey, pluginRoleManagedClaimKey)
+	}
+	text, ok := raw.(string)
+	if !ok {
+		return "", false, fmt.Errorf("plugin auth claim %q must be a string", pluginRoleClaimKey)
+	}
+	role := strings.ToLower(strings.TrimSpace(text))
+	if role == "" {
+		return "", false, fmt.Errorf("plugin auth claim %q must not be empty when %q is true", pluginRoleClaimKey, pluginRoleManagedClaimKey)
+	}
+	if role != "user" && role != "admin" {
+		return "", false, fmt.Errorf("plugin auth claim %q contains unsupported role %q", pluginRoleClaimKey, text)
+	}
+	return role, true, nil
+}
+
+func roleSyncUpdateInput(
+	user *models.User,
+	desiredRole string,
+	defaultGroupID *int64,
+) (models.UpdateUserInput, bool) {
+	if user == nil || user.Role == desiredRole {
+		return models.UpdateUserInput{}, false
+	}
+
+	role := desiredRole
+	input := models.UpdateUserInput{Role: &role}
+	if desiredRole == "admin" {
+		input.AccessGroupIDSet = true
+		input.AccessGroupID = nil
+		return input, true
+	}
+
+	permissions := DefaultUserPermissions()
+	input.Permissions = &permissions
+	input.AccessGroupIDSet = true
+	input.AccessGroupID = defaultGroupID
+	return input, true
 }
 
 func randomPluginOnlyPassword() (string, error) {

--- a/internal/auth/plugin_provider_test.go
+++ b/internal/auth/plugin_provider_test.go
@@ -1,9 +1,13 @@
 package auth
 
 import (
+	"slices"
 	"testing"
 
+	pluginv1 "github.com/Silo-Server/silo-plugin-sdk/pkg/pluginproto/silo/plugin/v1"
+	"github.com/Silo-Server/silo-server/internal/models"
 	"golang.org/x/crypto/bcrypt"
+	"google.golang.org/protobuf/types/known/structpb"
 )
 
 func TestRandomPluginOnlyPasswordFitsBcryptLimit(t *testing.T) {
@@ -17,5 +21,118 @@ func TestRandomPluginOnlyPasswordFitsBcryptLimit(t *testing.T) {
 	}
 	if _, err := bcrypt.GenerateFromPassword([]byte(password), bcrypt.DefaultCost); err != nil {
 		t.Fatalf("bcrypt.GenerateFromPassword() error = %v", err)
+	}
+}
+
+func authResponseWithClaims(t *testing.T, values map[string]any) *pluginv1.AuthenticateResponse {
+	t.Helper()
+	claims, err := structpb.NewStruct(values)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return &pluginv1.AuthenticateResponse{Claims: claims}
+}
+
+func TestPluginRoleFromResponseRequiresManagedMarker(t *testing.T) {
+	response := authResponseWithClaims(t, map[string]any{pluginRoleClaimKey: "admin"})
+	role, present, err := pluginRoleFromResponse(response)
+	if err != nil {
+		t.Fatalf("pluginRoleFromResponse() error = %v", err)
+	}
+	if present || role != "" {
+		t.Fatalf("role = %q, present = %v; unmanaged role claim must be ignored", role, present)
+	}
+
+	response = authResponseWithClaims(t, map[string]any{
+		pluginRoleManagedClaimKey: false,
+		pluginRoleClaimKey:        "admin",
+	})
+	role, present, err = pluginRoleFromResponse(response)
+	if err != nil {
+		t.Fatalf("pluginRoleFromResponse() error = %v", err)
+	}
+	if present || role != "" {
+		t.Fatalf("role = %q, present = %v; disabled managed role claim must be ignored", role, present)
+	}
+}
+
+func TestPluginRoleFromResponseAcceptsManagedAdmin(t *testing.T) {
+	response := authResponseWithClaims(t, map[string]any{
+		pluginRoleManagedClaimKey: true,
+		pluginRoleClaimKey:        "ADMIN",
+	})
+	role, present, err := pluginRoleFromResponse(response)
+	if err != nil {
+		t.Fatalf("pluginRoleFromResponse() error = %v", err)
+	}
+	if !present || role != "admin" {
+		t.Fatalf("role = %q, present = %v; want admin, true", role, present)
+	}
+}
+
+func TestPluginRoleFromResponseRejectsMalformedManagedClaims(t *testing.T) {
+	tests := []struct {
+		name   string
+		claims map[string]any
+	}{
+		{
+			name: "managed marker is not boolean",
+			claims: map[string]any{
+				pluginRoleManagedClaimKey: "true",
+				pluginRoleClaimKey:        "admin",
+			},
+		},
+		{
+			name: "managed role is missing",
+			claims: map[string]any{
+				pluginRoleManagedClaimKey: true,
+			},
+		},
+		{
+			name: "managed role is empty",
+			claims: map[string]any{
+				pluginRoleManagedClaimKey: true,
+				pluginRoleClaimKey:        " ",
+			},
+		},
+		{
+			name: "managed role is unsupported",
+			claims: map[string]any{
+				pluginRoleManagedClaimKey: true,
+				pluginRoleClaimKey:        "owner",
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			if _, _, err := pluginRoleFromResponse(authResponseWithClaims(t, test.claims)); err == nil {
+				t.Fatal("expected malformed managed role claim to be rejected")
+			}
+		})
+	}
+}
+
+func TestRoleSyncUpdateInputPromotesAndDemotes(t *testing.T) {
+	groupID := int64(42)
+	user := &models.User{ID: 7, Role: "user", AccessGroupID: &groupID}
+	promote, changed := roleSyncUpdateInput(user, "admin", nil)
+	if !changed || promote.Role == nil || *promote.Role != "admin" {
+		t.Fatalf("promotion input = %#v, changed = %v", promote, changed)
+	}
+	if !promote.AccessGroupIDSet || promote.AccessGroupID != nil {
+		t.Fatalf("promotion must remove the normal access group: %#v", promote)
+	}
+
+	admin := &models.User{ID: 7, Role: "admin"}
+	demote, changed := roleSyncUpdateInput(admin, "user", &groupID)
+	if !changed || demote.Role == nil || *demote.Role != "user" {
+		t.Fatalf("demotion input = %#v, changed = %v", demote, changed)
+	}
+	if demote.Permissions == nil || !slices.Equal(*demote.Permissions, DefaultUserPermissions()) {
+		t.Fatalf("demotion permissions = %#v, want defaults", demote.Permissions)
+	}
+	if !demote.AccessGroupIDSet || demote.AccessGroupID == nil || *demote.AccessGroupID != groupID {
+		t.Fatalf("demotion must assign the default access group: %#v", demote)
 	}
 }

--- a/internal/auth/repository_access_group.go
+++ b/internal/auth/repository_access_group.go
@@ -1,0 +1,33 @@
+package auth
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"github.com/jackc/pgx/v5"
+)
+
+// DefaultAccessGroupID returns the configured default access group, or nil when
+// no default exists. Keeping this query on UserRepository avoids teaching an
+// authentication provider about the access_groups table.
+func (r *UserRepository) DefaultAccessGroupID(ctx context.Context) (*int64, error) {
+	if r == nil || r.pool == nil {
+		return nil, nil
+	}
+	var id int64
+	err := r.pool.QueryRow(ctx, `
+		SELECT id
+		FROM access_groups
+		WHERE is_default
+		ORDER BY id
+		LIMIT 1
+	`).Scan(&id)
+	if err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("load default access group: %w", err)
+	}
+	return &id, nil
+}


### PR DESCRIPTION
## Problem

Part of #554

Authentication providers can return identity claims, but only the Silo host owns local account roles, permissions, and access-group assignment. A directory provider therefore cannot synchronize Silo's coarse `user` / `admin` role from an external group without a host-side contract.

The concrete consumer is techrelay/Silo-LDAP-Plugin#1, which evaluates configured direct LDAP or Active Directory group membership.

## Approach

- recognize a role only when the authentication response contains boolean `silo_role_managed=true`;
- accept only `silo_role=user` or `silo_role=admin`;
- ignore bare or explicitly unmanaged role claims;
- reject malformed managed claims rather than partially applying account state;
- apply the managed role during auto-provisioning and every successful linked login, including OAuth completion;
- clear the normal-user access group when promoting to administrator;
- restore default user permissions and the current default access group when demoting to user;
- write every transition to structured logs with installation, capability, user, previous role, and new role;
- keep default access-group lookup in `UserRepository`, which owns the account persistence behavior;
- document the response contract, trust boundary, demotion semantics, and compatibility behavior in `docs/plugins/auth-provider-managed-roles.md`.

## Compatibility and risks

- providers that omit `silo_role_managed` cannot change existing roles, even if they already return a claim named `silo_role`;
- new plugin-authenticated accounts continue to default to `user` when no managed claim is present;
- malformed managed claims fail authentication so an operator sees a provider contract error instead of receiving partially applied authorization;
- demotion intentionally resets the account to default user permissions and the current default access group. It does not reconstruct custom policy that existed before promotion;
- installed authentication providers are trusted server-side code. Managed-role support additionally permits a trusted provider to request promotion or demotion for accounts linked to its installation;
- the contract is deliberately limited to `user` and `admin`; plugins cannot set arbitrary permissions, libraries, or access groups;
- the claims use the existing protobuf `Struct`. Issue #554 asks whether typed SDK fields or constants should supersede the compatibility keys before merge.

## Testing

Focused tests cover:

- ignoring a bare role claim;
- ignoring an explicitly unmanaged role claim;
- normalization of a managed administrator claim;
- rejection of a non-boolean marker, missing role, empty role, and unsupported role;
- promotion and demotion update behavior;
- the plugin-only password length constraint.

Required repository checks:

```text
make lint
make test
cd web && pnpm run lint && pnpm run format:check
make verify-local-paths
go test ./internal/auth
```

### Current verification status

- No workflow jobs had started for this split fork PR at the time of this update. The earlier combined fork PR was held at GitHub's `action_required` approval gate before jobs were created.
- Local verification could not be executed in the available environment because it has Go 1.23.2, no local dependency cache for this repository, and no network access to install the required toolchain or dependencies.
- This remains a draft until upstream CI runs and manual end-to-end role synchronization is revalidated.

### AI Disclosure
- Tool(s): ChatGPT with the GitHub connector
- Model(s): GPT-5.6 Thinking
- Involvement: AI-assisted; the human supplied the deployed Active Directory use case and expected role behavior, while AI implemented and adversarially reviewed the host contract
- Adversarial review: found that a bare role claim created an implicit trust boundary, transitions lacked an audit trail, access-group SQL was embedded in the provider, and demotion could silently destroy customized policy. The change now requires an explicit managed marker, logs transitions, moves lookup to the repository, and documents the deliberate default-reset behavior.

## Checklist

- [x] Linked scope issue
- [x] One concern: provider-managed coarse roles
- [x] Focused unit tests and contract documentation
- [x] Documented current verification limitations without claiming unexecuted tests
- [ ] Upstream CI verification completed and output recorded
- [ ] Companion LDAP provider revalidated for new-user provisioning, promotion, and demotion
