### PR TITLE
fix(auth): make OAuth login reachable from the browser

### DIFF
--- a/internal/api/router.go
+++ b/internal/api/router.go
@@ -1837,6 +1837,9 @@ func NewRouter(deps Dependencies) chi.Router {
 					r.Post("/oauth/complete", oauthHandler.HandleComplete)
 					r.Route("/oauth/{install_id}", func(r chi.Router) {
 						r.Post("/init", oauthHandler.HandleInit)
+						// /start is what the SPA uses; /init's cross-origin
+						// redirect is blocked by the frontend's form-action CSP.
+						r.Post("/start", oauthHandler.HandleStart)
 						r.Get("/callback", oauthHandler.HandleCallback)
 					})
 				}

--- a/internal/auth/oauth_handler.go
+++ b/internal/auth/oauth_handler.go
@@ -88,10 +88,43 @@ var ErrMissingInstallID = errors.New("install_id required")
 
 // HandleInit serves POST /api/v1/auth/oauth/{install_id}/init.
 func (h *OAuthHandler) HandleInit(w http.ResponseWriter, r *http.Request) {
+	authorizeURL, ok := h.beginAuthorize(w, r)
+	if !ok {
+		return
+	}
+	http.Redirect(w, r, authorizeURL, http.StatusFound)
+}
+
+// HandleStart serves POST /api/v1/auth/oauth/{install_id}/start and returns the
+// IdP authorize URL as JSON instead of redirecting to it.
+//
+// The SPA cannot use HandleInit's redirect. Its login button submitted a form to
+// /init and let the 302 carry the browser to the IdP, but the frontend is served
+// with `form-action 'self'` (see internal/server/frontend.go), and browsers
+// enforce form-action across redirects. The cross-origin hop was blocked with no
+// console error and no navigation: the server logged a clean 302 while the IdP
+// never saw the request, so every external identity provider looked like a dead
+// button. Handing the URL back as JSON lets the SPA navigate with
+// window.location, which form-action does not govern.
+func (h *OAuthHandler) HandleStart(w http.ResponseWriter, r *http.Request) {
+	authorizeURL, ok := h.beginAuthorize(w, r)
+	if !ok {
+		return
+	}
+	w.Header().Set("Content-Type", "application/json")
+	_ = json.NewEncoder(w).Encode(struct {
+		AuthorizeURL string `json:"authorize_url"`
+	}{AuthorizeURL: authorizeURL})
+}
+
+// beginAuthorize mints the OAuth state, asks the plugin for an authorize URL and
+// stores the pending session. It writes its own error response and reports false
+// when it did, so callers only decide how to hand back the URL.
+func (h *OAuthHandler) beginAuthorize(w http.ResponseWriter, r *http.Request) (string, bool) {
 	installID, err := strconv.Atoi(chi.URLParam(r, "install_id"))
 	if err != nil || installID <= 0 {
 		http.Error(w, "invalid install_id", http.StatusBadRequest)
-		return
+		return "", false
 	}
 
 	next := normalizeOAuthNext(r.URL.Query().Get("next"))
@@ -99,13 +132,13 @@ func (h *OAuthHandler) HandleInit(w http.ResponseWriter, r *http.Request) {
 	client, _, err := h.deps.ResolveClient(r.Context(), installID)
 	if err != nil {
 		http.Error(w, "auth plugin unavailable", http.StatusBadGateway)
-		return
+		return "", false
 	}
 
 	nonce, err := randomHex(16)
 	if err != nil {
 		http.Error(w, "rand failure", http.StatusInternalServerError)
-		return
+		return "", false
 	}
 
 	now := time.Now().UTC()
@@ -124,11 +157,11 @@ func (h *OAuthHandler) HandleInit(w http.ResponseWriter, r *http.Request) {
 	if err != nil {
 		slog.WarnContext(r.Context(), "oauth init_authorize failed", "component", "auth", "installation_id", installID, "error", err)
 		http.Error(w, "plugin init_authorize failed", http.StatusBadGateway)
-		return
+		return "", false
 	}
 	if resp.GetAuthorizeUrl() == "" {
 		http.Error(w, "plugin returned empty authorize_url", http.StatusBadGateway)
-		return
+		return "", false
 	}
 
 	psBytes, _ := json.Marshal(resp.GetProviderState().AsMap())
@@ -145,10 +178,10 @@ func (h *OAuthHandler) HandleInit(w http.ResponseWriter, r *http.Request) {
 	if err := h.deps.Store.Insert(r.Context(), sess); err != nil {
 		slog.WarnContext(r.Context(), "oauth session insert failed", "component", "auth", "installation_id", installID, "error", err)
 		http.Error(w, "store insert failed", http.StatusInternalServerError)
-		return
+		return "", false
 	}
 
-	http.Redirect(w, r, resp.GetAuthorizeUrl(), http.StatusFound)
+	return resp.GetAuthorizeUrl(), true
 }
 
 // HandleCallback serves GET /api/v1/auth/oauth/{install_id}/callback.

--- a/internal/auth/oauth_handler_test.go
+++ b/internal/auth/oauth_handler_test.go
@@ -113,6 +113,93 @@ func TestOAuthInit_Redirects302WithAuthorizeURL(t *testing.T) {
 	}
 }
 
+// The SPA cannot follow HandleInit's redirect: the frontend is served with
+// `form-action 'self'`, and browsers enforce that across redirects, so the
+// cross-origin hop to the IdP is blocked silently — a clean 302 in the server
+// log and no request at the IdP. HandleStart must therefore hand the URL back
+// as a body the SPA can navigate to itself, never as a Location header.
+func TestOAuthStart_ReturnsAuthorizeURLAsJSONNotARedirect(t *testing.T) {
+	authorizeURL := "https://billing.example/oauth/authorize.php?client_id=x"
+	pState, _ := structpb.NewStruct(map[string]any{"pkce_verifier": "abc"})
+	fc := &fakeOAuthClient{initResp: &pluginv1.InitAuthorizeResponse{AuthorizeUrl: authorizeURL, ProviderState: pState}}
+	h, store := newOAuthHandlerForTest(t, fc, &fakeCompleter{})
+
+	r := withInstallID(httptest.NewRequest("POST", "/api/v1/auth/oauth/42/start?next=/me", nil), "42")
+	w := httptest.NewRecorder()
+	h.HandleStart(w, r)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("code = %d body = %s", w.Code, w.Body.String())
+	}
+	if loc := w.Header().Get("Location"); loc != "" {
+		t.Errorf("Location = %q, want none — a redirect is what form-action blocks", loc)
+	}
+	if ct := w.Header().Get("Content-Type"); ct != "application/json" {
+		t.Errorf("Content-Type = %q, want application/json", ct)
+	}
+	var body struct {
+		AuthorizeURL string `json:"authorize_url"`
+	}
+	if err := json.Unmarshal(w.Body.Bytes(), &body); err != nil {
+		t.Fatalf("decode body: %v (%s)", err, w.Body.String())
+	}
+	if body.AuthorizeURL != authorizeURL {
+		t.Errorf("authorize_url = %q, want %q", body.AuthorizeURL, authorizeURL)
+	}
+
+	// Same session bookkeeping as /init — one row, next_url kept, PKCE stored.
+	if got := len(store.rows); got != 1 {
+		t.Fatalf("rows = %d, want 1", got)
+	}
+	for _, row := range store.rows {
+		if row.InstallID != "42" {
+			t.Errorf("InstallID = %q", row.InstallID)
+		}
+		if row.NextURL != "/me" {
+			t.Errorf("NextURL = %q", row.NextURL)
+		}
+		if !strings.Contains(string(row.ProviderState), "pkce_verifier") {
+			t.Errorf("ProviderState missing PKCE: %s", row.ProviderState)
+		}
+	}
+}
+
+// The two entry points must not drift: /start is additive and /init keeps its
+// 302 for existing non-browser callers.
+func TestOAuthStart_ShareSessionSetupWithInit(t *testing.T) {
+	authorizeURL := "https://billing.example/oauth/authorize.php?client_id=x"
+	newHandler := func() (*OAuthHandler, *InMemoryOAuthStore) {
+		fc := &fakeOAuthClient{initResp: &pluginv1.InitAuthorizeResponse{AuthorizeUrl: authorizeURL}}
+		return newOAuthHandlerForTest(t, fc, &fakeCompleter{})
+	}
+
+	hInit, storeInit := newHandler()
+	wInit := httptest.NewRecorder()
+	hInit.HandleInit(wInit, withInstallID(httptest.NewRequest("POST", "/api/v1/auth/oauth/42/init?next=//evil.example/x", nil), "42"))
+
+	hStart, storeStart := newHandler()
+	wStart := httptest.NewRecorder()
+	hStart.HandleStart(wStart, withInstallID(httptest.NewRequest("POST", "/api/v1/auth/oauth/42/start?next=//evil.example/x", nil), "42"))
+
+	if wInit.Code != http.StatusFound {
+		t.Errorf("init code = %d, want 302", wInit.Code)
+	}
+	if wStart.Code != http.StatusOK {
+		t.Errorf("start code = %d, want 200", wStart.Code)
+	}
+	// Both normalise the open-redirect attempt identically.
+	for name, store := range map[string]*InMemoryOAuthStore{"init": storeInit, "start": storeStart} {
+		if len(store.rows) != 1 {
+			t.Fatalf("%s: rows = %d, want 1", name, len(store.rows))
+		}
+		for _, row := range store.rows {
+			if row.NextURL != "/" {
+				t.Errorf("%s: NextURL = %q, want /", name, row.NextURL)
+			}
+		}
+	}
+}
+
 func TestOAuthInit_NormalizesUnsafeNextURL(t *testing.T) {
 	authorizeURL := "https://billing.example/oauth/authorize.php?client_id=x"
 	fc := &fakeOAuthClient{initResp: &pluginv1.InitAuthorizeResponse{AuthorizeUrl: authorizeURL}}

--- a/internal/auth/service.go
+++ b/internal/auth/service.go
@@ -72,7 +72,7 @@ type LoginProviderInfo struct {
 	// auth_provider.v1 plugins that ship an icon (icon_url manifest field).
 	IconURL string `json:"icon_url,omitempty"`
 	// InstallationID is non-zero when the provider is backed by a plugin.
-	// The login UI uses it to build /api/v1/auth/oauth/{install_id}/init URLs.
+	// The login UI uses it to build /api/v1/auth/oauth/{install_id}/start URLs.
 	InstallationID int `json:"installation_id,omitempty"`
 }
 

--- a/web/src/pages/Login.tsx
+++ b/web/src/pages/Login.tsx
@@ -70,6 +70,7 @@ export default function Login() {
   const [provider, setProvider] = useState("");
   const [submitting, setSubmitting] = useState(false);
   const [startingDeviceLogin, setStartingDeviceLogin] = useState(false);
+  const [startingOauth, setStartingOauth] = useState<number | null>(null);
   const [deviceSession, setDeviceSession] = useState<DeviceLoginStartResponse | null>(null);
   const [deviceStatusMessage, setDeviceStatusMessage] = useState("");
   const [devicePolling, setDevicePolling] = useState(false);
@@ -244,6 +245,26 @@ export default function Login() {
     }
   }
 
+  // The IdP hop is a scripted navigation, not a form submit. Submitting a form
+  // to /init and following its 302 is blocked by the app's `form-action 'self'`
+  // CSP the moment the redirect leaves this origin — silently, with no console
+  // error — so the button appeared dead for every external provider.
+  async function handleStartOauth(installationId: number | undefined) {
+    if (!installationId) return;
+    setStartingOauth(installationId);
+    try {
+      const data = await api<{ authorize_url: string }>(
+        `/auth/oauth/${installationId}/start${nextParam}`,
+        { method: "POST" },
+      );
+      if (!data?.authorize_url) throw new Error("Server returned no authorize URL");
+      window.location.assign(data.authorize_url);
+    } catch (error) {
+      setStartingOauth(null);
+      toast.error(error instanceof Error ? error.message : "Could not start sign-in");
+    }
+  }
+
   async function handleStartDeviceLogin() {
     setStartingDeviceLogin(true);
     try {
@@ -283,16 +304,17 @@ export default function Login() {
           {oauthProviders.length > 0 && (
             <div className="space-y-2">
               {oauthProviders.map((entry) => (
-                <form
+                <Button
                   key={entry.id}
-                  method="post"
-                  action={`/api/v1/auth/oauth/${entry.installation_id}/init${nextParam}`}
+                  type="button"
+                  variant="outline"
+                  className="w-full justify-start gap-3"
+                  disabled={startingOauth !== null}
+                  onClick={() => void handleStartOauth(entry.installation_id)}
                 >
-                  <Button type="submit" variant="outline" className="w-full justify-start gap-3">
-                    {entry.icon_url && <img src={entry.icon_url} alt="" className="h-5 w-5" />}
-                    <span>{entry.display_name}</span>
-                  </Button>
-                </form>
+                  {entry.icon_url && <img src={entry.icon_url} alt="" className="h-5 w-5" />}
+                  <span>{entry.display_name}</span>
+                </Button>
               ))}
               <div className="text-muted-foreground flex items-center gap-2 pt-2 text-xs">
                 <div className="bg-border h-px flex-1" />


### PR DESCRIPTION
## Problem

The SPA's OAuth login button never worked against an external identity provider.

`Login.tsx` submitted a `<form method="post">` to
`POST /api/v1/auth/oauth/{install_id}/init` and let the `302` carry the browser
to the IdP. But the frontend is served with `form-action 'self'`
(`internal/server/frontend.go`), and browsers enforce `form-action` **across
redirects** — so the moment the redirect left our origin, the navigation was
blocked.

It fails invisibly from both ends: the server logs a clean `302`, and the IdP
never receives a request. No console error, no navigation, nothing in devtools
network beyond the successful POST. The button simply appears dead.

This was diagnosed against a live Authentik deployment. The user clicked the
button 29 times; the server logged 29 × `302` and Authentik logged zero
authorize requests in the same window. That asymmetry is the whole tell.

Prior art in this area: #30 (providers filtered out before render) and #31
(auto-provision bcrypt limit) fixed earlier links in the same chain — with
those resolved, this CSP interaction is what still stood between a configured
provider and a working login.

## Approach

Add `POST /api/v1/auth/oauth/{install_id}/start`, which returns the authorize
URL as JSON:

```json
{ "authorize_url": "https://idp.example/application/o/authorize/?..." }
```

The SPA fetches it and navigates with `window.location.assign(...)` — a
scripted navigation, which `form-action` does not govern.

- `/init` keeps its `302` untouched, so existing non-browser callers are
  unaffected and this stays additive under the v1 API rules in `CLAUDE.md`.
- State signing, PKCE provider-state, `next` normalisation and session
  insertion are extracted into `beginAuthorize` and shared by both handlers, so
  the two entry points cannot drift apart.

### Why not just widen the CSP

Adding IdP origins to `form-action` was the other option, and it is worse: the
server does not know the issuer origin (it lives in the plugin's own config,
not in `plugin_runtime_configs`), so it would have to interrogate every OAuth
plugin at page-render time and would silently regress to a dead button whenever
a plugin was slow or unavailable. The redirect is also the only part of the
flow that has to cross origins — removing the need for it is the smaller change.

## Risks and follow-ups

Called out honestly rather than buried:

- **`form-action` was accidental containment.** With the form POST, a
  compromised auth plugin returning a hostile `authorize_url` had its redirect
  blocked by CSP. Navigating by script removes that. The trust boundary is
  unchanged in practice — plugins are already trusted host-side code with far
  better options — but it is a real reduction in defence-in-depth and should be
  a conscious decision, not a side effect.
- **`/start` is unauthenticated and not rate-limited**, exactly like `/init`.
  Each call inserts an `oauth_sessions` row and makes a plugin RPC. This is
  pre-existing rather than introduced, but the surface is now doubled, and
  `/login` next door *is* rate-limited via `RateLimitMW.AuthEndpointHandler`.
  Worth a follow-up to bring both OAuth entry points under the same limiter; I
  left it out to keep this to one concern.
- **`/init` now has no first-party caller.** Kept deliberately for
  back-compat per the v1 rules; worth a Deprecation/Sunset decision later.
- **`startingOauth` is not reset on success**, since the page is navigating
  away. If a navigation were ever blocked the buttons would stay disabled.
  Considered and accepted — a same-gesture `location.assign` is not silently
  blocked the way form-action redirects are — but noted given that is precisely
  the failure mode this PR fixes.
- Minor upside: the button is now disabled while a start is in flight. The old
  form happily submitted 29 times.

## Tests

`TestOAuthStart_ReturnsAuthorizeURLAsJSONNotARedirect` asserts a 200, a JSON
body, and **no `Location` header** — the redirect is the thing that breaks.
`TestOAuthStart_ShareSessionSetupWithInit` pins that `/init` still returns 302,
that `/start` returns 200, and that both normalise an open-redirect `next`
identically.

Both were confirmed to fail against the old behaviour before being committed —
reverting `HandleStart` to `http.Redirect` produces:

```
--- FAIL: TestOAuthStart_ReturnsAuthorizeURLAsJSONNotARedirect (0.00s)
    oauth_handler_test.go:132: code = 302 body =
--- FAIL: TestOAuthStart_ShareSessionSetupWithInit (0.00s)
    oauth_handler_test.go:188: start code = 302, want 200
FAIL
```

## Verification

Real output, run on this branch.

`golangci-lint run --new-from-merge-base=upstream/main ./internal/auth/... ./internal/api/...`
(matching how CI invokes it):

```
0 issues.
```

`go test ./internal/auth/... ./internal/api/...`:

```
ok  	github.com/Silo-Server/silo-server/internal/auth	0.321s
ok  	github.com/Silo-Server/silo-server/internal/api	0.701s
ok  	github.com/Silo-Server/silo-server/internal/api/handlers	90.478s
ok  	github.com/Silo-Server/silo-server/internal/api/middleware	4.094s
```

`cd web && pnpm run lint`:

```
✖ 157 problems (0 errors, 157 warnings)
```

157 pre-existing warnings across the tree (`react-refresh/only-export-components`
and similar); **0 errors**, and zero findings in `src/pages/Login.tsx`.

`cd web && pnpm run format:check`:

```
Checking formatting...
All matched files use Prettier code style!
```

`make verify-local-paths`:

```
scripts/check-local-path-leaks.sh
```

`pnpm exec vitest run src/hooks/AuthProvider.test.tsx`:

```
 Test Files  1 passed (1)
      Tests  1 passed (1)
```

### End-to-end

Built and deployed to a live instance (Silo + Authentik over OIDC via
`silo-plugin-oidc-login`). Before: 29 × `302` server-side, zero authorize
requests at the IdP. After: the button reaches Authentik, authenticates, and
returns to `/api/v1/auth/oauth/{id}/callback`. Confirmed on the deployed build:

```
$ curl -s -X POST https://<host>/api/v1/auth/oauth/5/start
{"authorize_url":"https://<idp>/application/o/authorize/?client_id=...&code_challenge_method=S256&..."}

$ curl -s -o /dev/null -w "%{http_code}\n" -X POST https://<host>/api/v1/auth/oauth/5/init
302
```

The remaining failure after this fix was on the IdP side, not in this code
(Authentik's stock `email` scope mapping hardcodes `email_verified: False`,
which the plugin rejects) — noted only to be clear about how far the flow was
actually driven.

## Scope

No open scope item covers this; #30 and #31 are the closest, both closed. Happy
to file one and relink if you'd prefer it tracked under a capability epic.

### AI Disclosure
- Tool(s): Claude Code
- Model(s): claude-opus-5[1m]
- Involvement: fully AI-generated
- Adversarial review: my own review of the diff raised four things. (1) Losing
  `form-action` as incidental containment against a rogue plugin redirect —
  judged acceptable since plugins are already trusted host-side code, and
  disclosed above rather than silently accepted. (2) `/start` inherits `/init`'s
  lack of rate limiting while doubling that surface — left as a stated
  follow-up to keep one concern per PR. (3) `startingOauth` never resets on the
  success path — considered and accepted, documented above. (4) A stale comment
  in `internal/auth/service.go` still pointed the login UI at `/init`; that one
  was a real defect in the diff's blast radius and is fixed in 016aeab9. I also
  verified the new tests fail against the pre-fix behaviour rather than assuming
  they were meaningful, and confirmed no other in-tree caller of `/init` remains.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added OAuth sign-in support for single-page app navigation.
  * OAuth sign-in buttons now request authorization URLs and navigate browsers to the provider.
  * Sign-in buttons are disabled while requests are processing.

* **Bug Fixes**
  * Added clear notifications when authorization URLs are unavailable or requests fail.
  * Preserved OAuth session setup and return URL handling across sign-in flows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->