### PR TITLE
fix(catalog): preserve access filters for match-any queries

### DIFF
--- a/internal/catalog/episode_catalog_entries_executor.go
+++ b/internal/catalog/episode_catalog_entries_executor.go
@@ -806,14 +806,19 @@ func buildEpisodeCatalogEntryQueryWhere(def QueryDefinition, argIdx int) (string
 	switch len(groupClauses) {
 	case 0:
 		return "", args, argIdx, true, nil
+	// The returned expression is always parenthesized, mirroring
+	// QueryBuilder.Build: a match-any group emits a top-level OR, and the
+	// callers AND library, rating, snapshot, and other access constraints
+	// onto the result. Without the parentheses, SQL precedence lets an OR
+	// arm bypass every one of them.
 	case 1:
-		return groupClauses[0], args, argIdx, true, nil
+		return "(" + groupClauses[0] + ")", args, argIdx, true, nil
 	default:
 		wrapped := make([]string, len(groupClauses))
 		for i, clause := range groupClauses {
 			wrapped[i] = "(" + clause + ")"
 		}
-		return strings.Join(wrapped, topJoiner), args, argIdx, true, nil
+		return "(" + strings.Join(wrapped, topJoiner) + ")", args, argIdx, true, nil
 	}
 }
 

--- a/internal/catalog/episode_catalog_entries_executor_test.go
+++ b/internal/catalog/episode_catalog_entries_executor_test.go
@@ -230,3 +230,37 @@ func TestExtractEpisodeCatalogUserStatePlanForLastWatched(t *testing.T) {
 		t.Fatalf("expected genre rule to remain in entry def, got %+v", plan.entryDef.Groups)
 	}
 }
+
+func TestBuildEpisodeCatalogEntryQueryWhereParenthesizesMatchAnyGroup(t *testing.T) {
+	// Both episode preview paths append this expression to an AND-joined
+	// whereParts list that already carries the library, content-rating, and
+	// series-parent-guard constraints. A match-any group emits a top-level OR,
+	// so the result must come back parenthesized — otherwise SQL precedence
+	// detaches an OR arm from every one of those constraints.
+	def := QueryDefinition{
+		MediaScope: "episode",
+		Match:      "all",
+		Groups: []QueryGroup{{
+			Match: "any",
+			Rules: []QueryRule{
+				{Field: "genre", Op: "contains", Value: "Action"},
+				{Field: "genre", Op: "contains", Value: "Adventure"},
+			},
+		}},
+	}.Normalize()
+
+	where, args, nextArgIdx, ok, err := buildEpisodeCatalogEntryQueryWhere(def, 5)
+	if err != nil {
+		t.Fatalf("buildEpisodeCatalogEntryQueryWhere returned error: %v", err)
+	}
+	if !ok {
+		t.Fatal("buildEpisodeCatalogEntryQueryWhere unexpectedly fell back")
+	}
+	want := "(ece.genres @> ARRAY[$5]::text[] OR ece.genres @> ARRAY[$6]::text[])"
+	if where != want {
+		t.Fatalf("WHERE = %q, want %q", where, want)
+	}
+	if nextArgIdx != 7 || len(args) != 2 {
+		t.Fatalf("nextArgIdx = %d, len(args) = %d; want 7, 2", nextArgIdx, len(args))
+	}
+}

--- a/internal/catalog/query_builder.go
+++ b/internal/catalog/query_builder.go
@@ -100,15 +100,20 @@ func (qb *QueryBuilder) Build(input any) (string, []any, error) {
 	if len(groupClauses) == 0 {
 		return "", nil, nil
 	}
+	// The returned expression is always parenthesized so it stays atomic when
+	// callers AND access, library, and other outer constraints onto it. A
+	// match-any group (or a match-any top level) emits a top-level OR; without
+	// the parentheses, SQL precedence lets the first OR arm bypass every
+	// constraint appended afterward.
 	if len(groupClauses) == 1 {
-		return groupClauses[0], qb.args, nil
+		return "(" + groupClauses[0] + ")", qb.args, nil
 	}
 
 	wrapped := make([]string, len(groupClauses))
 	for i, clause := range groupClauses {
 		wrapped[i] = "(" + clause + ")"
 	}
-	return strings.Join(wrapped, topJoiner), qb.args, nil
+	return "(" + strings.Join(wrapped, topJoiner) + ")", qb.args, nil
 }
 
 func normalizeBuilderInput(input any) (QueryDefinition, error) {

--- a/internal/catalog/query_builder_test.go
+++ b/internal/catalog/query_builder_test.go
@@ -1048,3 +1048,54 @@ func TestUserHistoryCTESQLIncludesCompletedEbookReaderProgress(t *testing.T) {
 		}
 	}
 }
+
+func TestBuildParenthesizesResultForSafeANDComposition(t *testing.T) {
+	// Build's callers (query_executor.go, handlers/catalog.go) AND library and
+	// access-filter constraints onto the returned expression. A match-any
+	// group emits a top-level OR, so the result must come back parenthesized —
+	// otherwise SQL precedence lets the first OR arm bypass every constraint
+	// appended afterward.
+	tests := []struct {
+		name string
+		def  QueryDefinition
+		want string
+	}{
+		{
+			name: "single match-any group",
+			def: QueryDefinition{
+				Match: "all",
+				Groups: []QueryGroup{{
+					Match: "any",
+					Rules: []QueryRule{
+						{Field: "genre", Op: "contains", Value: "Action"},
+						{Field: "genre", Op: "contains", Value: "Adventure"},
+					},
+				}},
+			},
+			want: "(mi.genres @> ARRAY[$1]::text[] OR mi.genres @> ARRAY[$2]::text[])",
+		},
+		{
+			name: "match-any top level",
+			def: QueryDefinition{
+				Match: "any",
+				Groups: []QueryGroup{
+					{Match: "all", Rules: []QueryRule{{Field: "genre", Op: "contains", Value: "Action"}}},
+					{Match: "all", Rules: []QueryRule{{Field: "genre", Op: "contains", Value: "Adventure"}}},
+				},
+			},
+			want: "((mi.genres @> ARRAY[$1]::text[]) OR (mi.genres @> ARRAY[$2]::text[]))",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			clause, _, err := NewQueryBuilder("mi").Build(tt.def)
+			if err != nil {
+				t.Fatalf("Build returned error: %v", err)
+			}
+			if clause != tt.want {
+				t.Fatalf("Build clause = %q, want %q", clause, tt.want)
+			}
+		})
+	}
+}

--- a/internal/catalog/query_executor.go
+++ b/internal/catalog/query_executor.go
@@ -281,6 +281,9 @@ func (e *QueryExecutor) buildPreviewPagePlan(
 	argIdx := builder.ArgIdx() + filterArgOffset
 
 	if filterWhere != "" {
+		// QueryBuilder.Build returns a parenthesized expression, so AND-ing
+		// access, library, and other outer constraints onto it cannot let a
+		// match-any OR arm escape them.
 		conditions = append(conditions, filterWhere)
 	}
 	if def.MediaScope != "" && !isEpisodeCatalogScope(def.MediaScope) {

--- a/internal/catalog/query_executor_access_test.go
+++ b/internal/catalog/query_executor_access_test.go
@@ -1,0 +1,40 @@
+package catalog
+
+import (
+	"reflect"
+	"slices"
+	"strings"
+	"testing"
+)
+
+func TestQueryExecutorGroupQueryPreservesAccessFilters(t *testing.T) {
+	executor := &QueryExecutor{}
+	def := QueryDefinition{
+		Match:      "all",
+		LibraryIDs: []int{42},
+		Groups: []QueryGroup{{
+			Match: "any",
+			Rules: []QueryRule{
+				{Field: "genre", Op: "contains", Value: "Action"},
+				{Field: "genre", Op: "contains", Value: "Adventure"},
+			},
+		}},
+	}
+
+	sql, args, err := executor.buildPreviewPageSQL(def, AccessFilter{MaxContentRating: "PG"}, 20, 0, false)
+	if err != nil {
+		t.Fatalf("build preview SQL: %v", err)
+	}
+	groupedFilter := "WHERE (mi.genres @> ARRAY[$1]::text[] OR mi.genres @> ARRAY[$2]::text[]) AND EXISTS"
+	if !strings.Contains(sql, groupedFilter) {
+		t.Fatalf("group predicate is not isolated from access filters:\n%s", sql)
+	}
+	if len(args) != 6 || args[0] != "Action" || args[1] != "Adventure" ||
+		!reflect.DeepEqual(args[2], []int{42}) || args[4] != 42 || args[5] != 21 {
+		t.Fatalf("unexpected query args: %#v", args)
+	}
+	allowedRatings, ok := args[3].([]string)
+	if !ok || !slices.Contains(allowedRatings, "PG") || slices.Contains(allowedRatings, "R") {
+		t.Fatalf("rating arg = %#v, want PG allowed and R blocked", args[3])
+	}
+}

--- a/internal/sections/seasonal_query_test.go
+++ b/internal/sections/seasonal_query_test.go
@@ -63,8 +63,12 @@ func TestSeasonalThemedFiltersItemsAboveProfileRating(t *testing.T) {
 		t.Fatalf("seed media folder: %v", err)
 	}
 	t.Cleanup(func() {
-		_, _ = pool.Exec(context.Background(), `DELETE FROM media_items WHERE content_id = ANY($1)`, []string{allowedID, blockedID})
-		_, _ = pool.Exec(context.Background(), `DELETE FROM media_folders WHERE id = $1`, libraryID)
+		if _, err := pool.Exec(context.Background(), `DELETE FROM media_items WHERE content_id = ANY($1)`, []string{allowedID, blockedID}); err != nil {
+			t.Errorf("cleanup media items: %v", err)
+		}
+		if _, err := pool.Exec(context.Background(), `DELETE FROM media_folders WHERE id = $1`, libraryID); err != nil {
+			t.Errorf("cleanup media folder: %v", err)
+		}
 	})
 	if _, err := pool.Exec(ctx, `
 		INSERT INTO media_items (content_id, type, title, genres, content_rating)

--- a/internal/sections/seasonal_query_test.go
+++ b/internal/sections/seasonal_query_test.go
@@ -1,10 +1,16 @@
 package sections
 
 import (
+	"context"
 	"encoding/json"
+	"fmt"
+	"os"
 	"testing"
+	"time"
 
+	"github.com/Silo-Server/silo-server/internal/catalog"
 	"github.com/Silo-Server/silo-server/internal/sections/recipes"
+	"github.com/jackc/pgx/v5/pgxpool"
 )
 
 // TestSeasonalThemeHasQueryCoversAllOrderedThemes ensures every theme that can
@@ -30,6 +36,68 @@ func TestSeasonalKeywordThemesHaveNoGenreQuery(t *testing.T) {
 		if _, ok := recipes.SeasonalPredicates[theme]; !ok {
 			t.Errorf("keyword theme %q has no seasonal predicate", theme)
 		}
+	}
+}
+
+func TestSeasonalThemedFiltersItemsAboveProfileRating(t *testing.T) {
+	dsn := os.Getenv("SILO_TEST_DATABASE_URL")
+	if dsn == "" {
+		t.Skip("SILO_TEST_DATABASE_URL is not set")
+	}
+
+	ctx := context.Background()
+	pool, err := pgxpool.New(ctx, dsn)
+	if err != nil {
+		t.Fatalf("connect test database: %v", err)
+	}
+	t.Cleanup(pool.Close)
+
+	suffix := time.Now().UnixNano()
+	allowedID := fmt.Sprintf("seasonal-rating-allowed-%d", suffix)
+	blockedID := fmt.Sprintf("seasonal-rating-blocked-%d", suffix)
+	var libraryID int
+	if err := pool.QueryRow(ctx, `
+		INSERT INTO media_folders (type, name, enabled)
+		VALUES ('movies', $1, true)
+		RETURNING id`, fmt.Sprintf("seasonal-rating-%d", suffix)).Scan(&libraryID); err != nil {
+		t.Fatalf("seed media folder: %v", err)
+	}
+	t.Cleanup(func() {
+		_, _ = pool.Exec(context.Background(), `DELETE FROM media_items WHERE content_id = ANY($1)`, []string{allowedID, blockedID})
+		_, _ = pool.Exec(context.Background(), `DELETE FROM media_folders WHERE id = $1`, libraryID)
+	})
+	if _, err := pool.Exec(ctx, `
+		INSERT INTO media_items (content_id, type, title, genres, content_rating)
+		VALUES ($1, 'movie', 'Allowed Seasonal Movie', ARRAY['Action'], 'PG'),
+		       ($2, 'movie', 'Blocked Seasonal Movie', ARRAY['Action'], 'R')`, allowedID, blockedID); err != nil {
+		t.Fatalf("seed media items: %v", err)
+	}
+	if _, err := pool.Exec(ctx, `
+		INSERT INTO media_item_libraries (content_id, media_folder_id)
+		VALUES ($1, $3), ($2, $3)`, allowedID, blockedID, libraryID); err != nil {
+		t.Fatalf("seed media item libraries: %v", err)
+	}
+
+	config, err := json.Marshal(recipes.SeasonalThemedParams{Theme: "summer_blockbuster", Mode: "pinned"})
+	if err != nil {
+		t.Fatalf("marshal seasonal config: %v", err)
+	}
+	fetcher := NewFetcher(pool)
+	items, _, err := fetcher.fetchSeasonalThemed(ctx, ResolvedSection{
+		ID:          "seasonal-rating-test",
+		SectionType: SectionSeasonalThemed,
+		ItemLimit:   10,
+		Config:      config,
+	}, &libraryID, nil, catalog.AccessFilter{MaxContentRating: "PG"})
+	if err != nil {
+		t.Fatalf("fetch seasonal section: %v", err)
+	}
+	if len(items) != 1 || items[0].ContentID != allowedID {
+		got := make([]string, 0, len(items))
+		for _, item := range items {
+			got = append(got, item.ContentID)
+		}
+		t.Fatalf("seasonal items = %v, want only %q", got, allowedID)
 	}
 }
 


### PR DESCRIPTION
## Problem
Part of #562
Fixes #562

Kids profiles with a maximum content rating could see over-limit posters in Seasonal Picks. Opening one of those items was correctly denied, but the home rail still disclosed its poster and metadata.

The seasonal query used a match-any genre predicate. It was composed with access constraints as an unparenthesized SQL OR expression, so SQL operator precedence allowed the first OR arm to bypass library, rating, and other constraints appended with AND.

## Approach

- Make QueryBuilder return its complete predicate as one parenthesized SQL operand.
- Apply the same invariant to the specialized episode catalog entry builder.
- Preserve the grouped expression when the preview executor appends access, scope, snapshot, prefix, and pagination constraints.
- Add SQL-shape regressions for ordinary and episode match-any queries.
- Add a database-backed Seasonal Picks regression containing one allowed PG Action title and one blocked R Action title.

This fixes Seasonal Picks and protects other QueryDefinition-based match-any catalog surfaces without changing API contracts.

## Testing

Passed:

```text
$ go test ./internal/catalog ./internal/api/handlers ./internal/sections
ok github.com/Silo-Server/silo-server/internal/catalog
ok github.com/Silo-Server/silo-server/internal/api/handlers
ok github.com/Silo-Server/silo-server/internal/sections

$ SILO_TEST_DATABASE_URL=postgres://... go test ./internal/sections -run TestSeasonalThemedFiltersItemsAboveProfileRating -count=1 -v
--- PASS: TestSeasonalThemedFiltersItemsAboveProfileRating
PASS

$ golangci-lint run --new-from-rev HEAD
0 issues.

$ cd web && pnpm run lint
157 warnings, 0 errors

$ cd web && pnpm run format:check
All matched files use Prettier code style!

$ make verify-local-paths
scripts/check-local-path-leaks.sh
```

The repository-wide `make lint` command still reports the existing lint backlog, including findings from a separate sibling worktree; none are on this branch according to `--new-from-rev HEAD`. A full Go test run also encountered existing macOS playback GPU-probe failures where fake FFmpeg processes were killed. The affected package suites and database regression pass.

Local feature verification used a PG kids profile with PG, PG-13, R, TV-PG, TV-14, and TV-MA fixtures. Seasonal Picks now contains only PG and TV-PG titles; Continue Watching, Hidden Gems, Trending, and catalog browse remain correctly filtered.

### AI Disclosure
- Tool(s): Codex, Claude Code
- Model(s): gpt-5; n/a for Claude (exact model ID was not available in the handoff)
- Involvement: fully AI-generated
- Adversarial review: A scoped review of only this branch found no actionable findings. It verified the general builder, executor, admin filter caller, and both episode catalog paths, then reran the affected package and database-backed regressions.

## Checklist
- [x] I ran an adversarial AI review of the diff and summarized findings above.
- [x] I ran the relevant Go tests, frontend lint/format checks, changed-line Go lint, and local-path verification. The repository-wide lint and playback exceptions are documented above.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed catalog filtering so combined match-any conditions consistently respect access, library, content-rating, and snapshot restrictions.
  - Prevented content-rating filters from being bypassed in seasonal content results.
  - Preserved correct pagination and filtering behavior for grouped catalog queries.

- **Tests**
  - Added regression coverage for combined catalog filters and query conditions.
  - Added integration coverage confirming seasonal results honor content-rating restrictions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->