### PR TITLE
fix(settings): restore box subtitle appearance default

### DIFF
--- a/contracts/settings/v1/conformance.json
+++ b/contracts/settings/v1/conformance.json
@@ -1,6 +1,6 @@
 {
   "fixture_version": 1,
-  "manifest_revision": 5,
+  "manifest_revision": 6,
   "description": "Cross-platform conformance cases for settings resolution. Every case runs against the shipped manifest in this directory: definitions are referenced by key, never restated, so an expectation can only be satisfied by resolving the real contract. Each platform's resolver (Go in internal/settingsresolve, TypeScript in web/src/lib/settingsResolve.ts, Kotlin and Swift in the client repos) runs every case through a hand-written runner; a runner must fail on any fixture field it does not know, because schema drift in the fixture itself is drift. A case's constraint_bindings attach a constraint to a copy of a real definition so constraint semantics stay testable even while no shipped definition carries that constraint kind. In expected entries, constrained:true requires stored_value and constraint_kind to be present, and stored_value may be null to mean the authored value was JSON null.",
   "cases": [
     {
@@ -665,6 +665,30 @@
           "key": "playback.subtitle_appearance",
           "value": { "fontSize": "medium", "fontColor": "#ffcc00" },
           "source": "profile"
+        }
+      ]
+    },
+    {
+      "name": "subtitle_appearance_uses_shared_default",
+      "description": "With no stored profile or device value, every client receives the contract's shared Box 75% subtitle appearance.",
+      "keys": ["playback.subtitle_appearance"],
+      "context": { "profile_id": "p1", "device_id": "d1" },
+      "stored": [],
+      "expected": [
+        {
+          "key": "playback.subtitle_appearance",
+          "value": {
+            "fontSize": "large",
+            "fontFamily": "sans-serif",
+            "fontColor": "#ffffff",
+            "backgroundColor": "#000000",
+            "backgroundStyle": "box",
+            "backgroundOpacity": 75,
+            "textOutline": false,
+            "textOutlineColor": "#000000",
+            "position": "bottom"
+          },
+          "source": "default"
         }
       ]
     }

--- a/contracts/settings/v1/manifest.json
+++ b/contracts/settings/v1/manifest.json
@@ -1,6 +1,6 @@
 {
   "api_version": 1,
-  "revision": 5,
+  "revision": 6,
   "option_sets": {
     "playback_audio_languages": {
       "type": "language_tag",
@@ -233,7 +233,7 @@
         "fontFamily": "sans-serif",
         "fontColor": "#ffffff",
         "backgroundColor": "#000000",
-        "backgroundStyle": "shadow",
+        "backgroundStyle": "box",
         "backgroundOpacity": 75,
         "textOutline": false,
         "textOutlineColor": "#000000",
@@ -243,7 +243,7 @@
       "label": "Subtitle appearance",
       "description": "How subtitles are drawn during playback.",
       "recommended_control": "panel",
-      "notes": "Renamed from the unprefixed legacy key \"subtitle_appearance\". Every other canonical key carries a domain prefix, and preserving accidental key names is an explicit non-goal of the design. The rename touches three URL paths in internal/api/router.go, the admin device-settings routes, and the key constant in every client, so it cannot land without them. Migration copies the account-level legacy fallback to every existing profile and leaves device overrides unchanged, rewriting the key on each row. The default below is the web client's; Apple defaults to a box background and Android to no background with an outline, so migration must first write each platform's own default into a row for users who never opened the panel, or their subtitles silently change appearance at cutover."
+      "notes": "Renamed from the unprefixed legacy key \"subtitle_appearance\". Every other canonical key carries a domain prefix, and preserving accidental key names is an explicit non-goal of the design. The rename touches three URL paths in internal/api/router.go, the admin device-settings routes, and the key constant in every client, so it cannot land without them. Migration copies the account-level legacy fallback to every existing profile and leaves device overrides unchanged, rewriting the key on each row. Revision 6 changes the fallback background from shadow to a 75% opaque box, matching the previous intended web default and the current Apple fallback. Connected clients receive the complete effective default from the server; clients should adopt revision 6 so their local and sparse-object decoding fallbacks match it. Stored profile and device overrides remain authoritative."
     },
     {
       "key": "playback.preferred_quality",

--- a/internal/settingscontract/contract_test.go
+++ b/internal/settingscontract/contract_test.go
@@ -49,6 +49,29 @@ func TestEmbeddedManifestLoads(t *testing.T) {
 	}
 }
 
+func TestSubtitleAppearanceDefaultUsesBoxBackground(t *testing.T) {
+	manifest, err := Load()
+	if err != nil {
+		t.Fatalf("loading manifest: %v", err)
+	}
+	def, ok := manifest.Lookup(keySubtitleAppearance)
+	if !ok {
+		t.Fatal("playback.subtitle_appearance is not registered")
+	}
+
+	var appearance struct {
+		BackgroundStyle   string `json:"backgroundStyle"`
+		BackgroundOpacity int    `json:"backgroundOpacity"`
+	}
+	if err := json.Unmarshal(def.DefaultValue, &appearance); err != nil {
+		t.Fatalf("decoding subtitle appearance default: %v", err)
+	}
+	if appearance.BackgroundStyle != "box" || appearance.BackgroundOpacity != 75 {
+		t.Errorf("subtitle background default = %s %d%%, want box 75%%",
+			appearance.BackgroundStyle, appearance.BackgroundOpacity)
+	}
+}
+
 // TestEveryCurrentServerKeyIsRegistered pins the inventory. The design makes an
 // unregistered official key a release blocker, so a key that exists in the
 // legacy registry but not in the manifest has to fail here rather than be

--- a/internal/settingskeys/keys.go
+++ b/internal/settingskeys/keys.go
@@ -9,7 +9,7 @@
 package settingskeys
 
 // Revision is the manifest revision these bindings were generated from.
-const Revision = 5
+const Revision = 6
 
 // Setting keys, one constant per definition.
 const (

--- a/web/src/lib/settingsConformance.json
+++ b/web/src/lib/settingsConformance.json
@@ -1,6 +1,6 @@
 {
   "fixture_version": 1,
-  "manifest_revision": 5,
+  "manifest_revision": 6,
   "description": "Cross-platform conformance cases for settings resolution. Every case runs against the shipped manifest in this directory: definitions are referenced by key, never restated, so an expectation can only be satisfied by resolving the real contract. Each platform's resolver (Go in internal/settingsresolve, TypeScript in web/src/lib/settingsResolve.ts, Kotlin and Swift in the client repos) runs every case through a hand-written runner; a runner must fail on any fixture field it does not know, because schema drift in the fixture itself is drift. A case's constraint_bindings attach a constraint to a copy of a real definition so constraint semantics stay testable even while no shipped definition carries that constraint kind. In expected entries, constrained:true requires stored_value and constraint_kind to be present, and stored_value may be null to mean the authored value was JSON null.",
   "cases": [
     {
@@ -665,6 +665,30 @@
           "key": "playback.subtitle_appearance",
           "value": { "fontSize": "medium", "fontColor": "#ffcc00" },
           "source": "profile"
+        }
+      ]
+    },
+    {
+      "name": "subtitle_appearance_uses_shared_default",
+      "description": "With no stored profile or device value, every client receives the contract's shared Box 75% subtitle appearance.",
+      "keys": ["playback.subtitle_appearance"],
+      "context": { "profile_id": "p1", "device_id": "d1" },
+      "stored": [],
+      "expected": [
+        {
+          "key": "playback.subtitle_appearance",
+          "value": {
+            "fontSize": "large",
+            "fontFamily": "sans-serif",
+            "fontColor": "#ffffff",
+            "backgroundColor": "#000000",
+            "backgroundStyle": "box",
+            "backgroundOpacity": 75,
+            "textOutline": false,
+            "textOutlineColor": "#000000",
+            "position": "bottom"
+          },
+          "source": "default"
         }
       ]
     }

--- a/web/src/lib/settingsContract.ts
+++ b/web/src/lib/settingsContract.ts
@@ -9,7 +9,7 @@
  */
 
 export const SETTINGS_API_VERSION = 1;
-export const SETTINGS_REVISION = 5;
+export const SETTINGS_REVISION = 6;
 
 export interface SettingSuggestedOption {
   value: string;
@@ -626,7 +626,7 @@ export const SETTING_DEFINITIONS: Record<SettingKey, SettingDefinition> = {
       fontFamily: "sans-serif",
       fontColor: "#ffffff",
       backgroundColor: "#000000",
-      backgroundStyle: "shadow",
+      backgroundStyle: "box",
       backgroundOpacity: 75,
       textOutline: false,
       textOutlineColor: "#000000",

--- a/web/src/lib/subtitleAppearance.test.ts
+++ b/web/src/lib/subtitleAppearance.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest";
 
+import { SETTING_DEFINITIONS, SETTING_KEYS } from "./settingsContract";
 import {
   computeSubtitleFontScale,
   computeSubtitleFontSize,
@@ -75,6 +76,14 @@ describe("computeSubtitleFontSize", () => {
 });
 
 describe("computeSubtitleStyles", () => {
+  it("matches the contract's shared Box 75% fallback", () => {
+    expect(DEFAULT_SUBTITLE_APPEARANCE.backgroundStyle).toBe("box");
+    expect(DEFAULT_SUBTITLE_APPEARANCE.backgroundOpacity).toBe(75);
+    expect(DEFAULT_SUBTITLE_APPEARANCE).toEqual(
+      SETTING_DEFINITIONS[SETTING_KEYS.PLAYBACK_SUBTITLE_APPEARANCE].defaultValue,
+    );
+  });
+
   it("applies the font scale to the cue font size", () => {
     const unscaled = computeSubtitleStyles(DEFAULT_SUBTITLE_APPEARANCE);
     const scaled = computeSubtitleStyles(DEFAULT_SUBTITLE_APPEARANCE, 2);

--- a/web/src/lib/subtitleAppearance.ts
+++ b/web/src/lib/subtitleAppearance.ts
@@ -21,7 +21,7 @@ export const DEFAULT_SUBTITLE_APPEARANCE: SubtitleAppearance = {
   fontFamily: "sans-serif",
   fontColor: "#ffffff",
   backgroundColor: "#000000",
-  backgroundStyle: "shadow",
+  backgroundStyle: "box",
   backgroundOpacity: 75,
   textOutline: false,
   textOutlineColor: "#000000",


### PR DESCRIPTION
## Problem

Part of #376

The canonical settings contract currently defaults subtitle appearance to a 75% opaque drop shadow. That changed the default rendered appearance for connected clients from the earlier 75% opaque black box, even when users had not chosen an appearance override.

## Approach

- Restore the canonical `playback.subtitle_appearance` default to a 75% opaque black box.
- Advance the settings manifest revision from 5 to 6 and regenerate the Go and web bindings.
- Add a shared-default conformance vector and focused server/web regressions so the rendered fallback cannot silently drift back to shadow.
- Document current client compatibility in the manifest notes: Apple already has the matching local fallback; Android consumes the server effective value when connected and can adopt revision 6 independently for sparse/offline fallback parity.

Existing stored profile and device overrides are unchanged.

## Release note

Subtitle backgrounds now default to a 75% opaque black box when no appearance override is set, restoring the appearance used before the server-contract default changed.

## Validation

- `go test ./internal/settingscontract ./internal/settingsresolve`
- `make verify-settings-bindings-all`
- `cd web && pnpm exec vitest run src/lib/subtitleAppearance.test.ts src/lib/settingsConformance.test.ts` (42 tests passed)
- `git diff --check origin/main...HEAD`

### AI Disclosure

- Tool(s): OpenAI Codex
- Model(s): GPT-5
- Involvement: AI-assisted under human direction
- Adversarial review: Traced the canonical default through server resolution and generated web bindings, compared the live Apple and Android contract/fallback implementations, and added conformance plus focused regressions for the shared default. No material findings remain in the final eight-file diff.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Updated subtitle appearance defaults to use a box background with 75% opacity when no custom setting is configured.
* **Bug Fixes**
  * Improved consistency so subtitle appearance defaults are shared across supported clients.
* **Tests**
  * Added coverage confirming the revised default behavior and settings contract compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->