### PR TITLE
fix(playback): align default transcode directory

### DIFF
--- a/internal/database/transcode_dir_migration_test.go
+++ b/internal/database/transcode_dir_migration_test.go
@@ -1,0 +1,35 @@
+package database
+
+import (
+	"os"
+	"strings"
+	"testing"
+)
+
+func TestTranscodeDirDefaultsToSiloPath(t *testing.T) {
+	initialSchema, err := os.ReadFile("../../migrations/sql/001_schema.sql")
+	if err != nil {
+		t.Fatalf("read initial schema: %v", err)
+	}
+	schema := string(initialSchema)
+	if !strings.Contains(schema, "('playback.transcode_dir', '/tmp/silo-transcode')") {
+		t.Fatal("initial schema does not seed the Silo transcode directory")
+	}
+	if strings.Contains(schema, "('playback.transcode_dir', '/tmp/streamapp-transcode')") {
+		t.Fatal("initial schema still seeds the legacy StreamApp transcode directory")
+	}
+
+	migration, err := os.ReadFile("../../migrations/sql/20260809133921_rename_default_transcode_dir.sql")
+	if err != nil {
+		t.Fatalf("read transcode-dir migration: %v", err)
+	}
+	normalized := strings.Join(strings.Fields(string(migration)), " ")
+	for _, fragment := range []string{
+		"SET value = '/tmp/silo-transcode'",
+		"WHERE key = 'playback.transcode_dir' AND value = '/tmp/streamapp-transcode'",
+	} {
+		if !strings.Contains(normalized, fragment) {
+			t.Fatalf("transcode-dir migration missing %q:\n%s", fragment, migration)
+		}
+	}
+}

--- a/migrations/sql/001_schema.sql
+++ b/migrations/sql/001_schema.sql
@@ -2443,7 +2443,7 @@ INSERT INTO public.server_settings (key, value) VALUES
   ('s3.metadata_presign_expiry', '4h'),
   ('metadb.url', 'https://metadb.example.invalid'),
   ('playback.ffmpeg_path', '/usr/lib/jellyfin-ffmpeg/ffmpeg'),
-  ('playback.transcode_dir', '/tmp/streamapp-transcode'),
+  ('playback.transcode_dir', '/tmp/silo-transcode'),
   ('playback.hw_accel', 'auto'),
   ('playback.transcode_enabled', 'true'),
   ('playback.allow_hevc_encoding', 'false'),

--- a/migrations/sql/20260809133921_rename_default_transcode_dir.sql
+++ b/migrations/sql/20260809133921_rename_default_transcode_dir.sql
@@ -1,0 +1,10 @@
+-- +goose Up
+UPDATE server_settings
+SET value = '/tmp/silo-transcode'
+WHERE key = 'playback.transcode_dir'
+  AND value = '/tmp/streamapp-transcode';
+
+-- +goose Down
+-- Intentionally a no-op: after the update there is no reliable way to
+-- distinguish the migrated default from an operator-chosen path.
+SELECT 1;


### PR DESCRIPTION
## Problem

No linked issue — this is a small bug fix under the repository's `CONTRIBUTING.md` guidance.

Docker Compose mounts the host transcode directory at `/tmp/silo-transcode`, and the runtime and UI defaults use that path. However, the initial database schema still seeded `playback.transcode_dir` as `/tmp/streamapp-transcode`. Because persisted settings override runtime defaults, fresh Docker installs wrote transcodes into the container layer instead of the Compose bind mount.

## Approach

- Change the fresh-install seed to `/tmp/silo-transcode`.
- Add a Goose migration that changes only the exact legacy default. Operator-configured paths remain untouched.
- Keep the Down migration as a documented no-op because a migrated default cannot be distinguished from an operator-selected `/tmp/silo-transcode` path.
- Add regression coverage for the corrected seed, absence of the legacy seed, and the migration's exact-value guard.

No existing transient files are moved or deleted.

## Testing

Passed:

```text
$ make migrate-validate
go run github.com/pressly/goose/v3/cmd/goose@v3.27.1 -dir migrations/sql validate

$ go test ./internal/database -count=1
ok  github.com/Silo-Server/silo-server/internal/database  0.498s

$ go vet ./internal/database
(no output; exit 0)

$ golangci-lint run --new-from-merge-base=origin/main ./internal/database
0 issues.

$ cd web && pnpm run lint
✖ 157 problems (0 errors, 157 warnings)
0 errors and 1 warning potentially fixable with the `--fix` option.

$ cd web && pnpm run format:check
Checking formatting...
All matched files use Prettier code style!

$ make verify-local-paths
scripts/check-local-path-leaks.sh
```

Repository-wide checks were also attempted. This macOS environment does not have native `libvips`, which CI installs before Go checks, so both commands stop while type-checking `github.com/h2non/bimg`. The full Go run also reports existing sandbox-sensitive NVENC probe failures; the touched database package passes independently.

```text
$ go test ./...
Package 'vips' not found
FAIL  github.com/Silo-Server/silo-server/internal/imageutil [build failed]
--- FAIL: TestResolveHWAccelWithFFmpegAutoPrefersNVENCOverIntel
FAIL  github.com/Silo-Server/silo-server/internal/playback

$ make lint
internal/imageutil/imageutil.go:15:2: could not import github.com/h2non/bimg
Package 'vips' not found
make: *** [lint] Error 1
```

### AI Disclosure

- Tool(s): Codex desktop
- Model(s): GPT-5
- Involvement: AI-assisted
- Adversarial review: The first regression test proved that the corrected seed existed but would still have passed if the legacy seed were added alongside it. The test was strengthened to require the legacy seed's absence. The review also confirmed that the migration's exact-value predicate preserves custom paths and that the no-op Down migration avoids overwriting operator choices.

## Checklist

- [x] I ran an adversarial AI review of the diff and summarized findings above.
- [x] I ran the repo verify commands: `make lint`, `cd web && pnpm run lint`, `cd web && pnpm run format:check`, and relevant `go test ./...`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the default transcoding directory to `/tmp/silo-transcode`.
  * Existing installations using the legacy `/tmp/streamapp-transcode` path are automatically migrated to the new directory.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->