### PR TITLE
fix(requests): return empty arrays for empty request lists

### DIFF
--- a/internal/api/handlers/requests.go
+++ b/internal/api/handlers/requests.go
@@ -52,6 +52,17 @@ type RequestsHandler struct {
 	service RequestService
 }
 
+type requestListResponse struct {
+	Requests []*mediarequests.Request `json:"requests"`
+}
+
+func newRequestListResponse(requests []*mediarequests.Request) requestListResponse {
+	if requests == nil {
+		requests = []*mediarequests.Request{}
+	}
+	return requestListResponse{Requests: requests}
+}
+
 func NewRequestsHandler(service RequestService) *RequestsHandler {
 	return &RequestsHandler{service: service}
 }
@@ -261,9 +272,7 @@ func (h *RequestsHandler) HandleListMine(w http.ResponseWriter, r *http.Request)
 		writeRequestServiceError(w, err)
 		return
 	}
-	writeJSON(w, http.StatusOK, struct {
-		Requests []*mediarequests.Request `json:"requests"`
-	}{Requests: requests})
+	writeJSON(w, http.StatusOK, newRequestListResponse(requests))
 }
 
 func (h *RequestsHandler) HandleGet(w http.ResponseWriter, r *http.Request) {
@@ -289,9 +298,7 @@ func (h *RequestsHandler) HandleAdminList(w http.ResponseWriter, r *http.Request
 		writeRequestServiceError(w, err)
 		return
 	}
-	writeJSON(w, http.StatusOK, struct {
-		Requests []*mediarequests.Request `json:"requests"`
-	}{Requests: requests})
+	writeJSON(w, http.StatusOK, newRequestListResponse(requests))
 }
 
 func (h *RequestsHandler) HandleApprove(w http.ResponseWriter, r *http.Request) {

--- a/internal/api/handlers/requests_test.go
+++ b/internal/api/handlers/requests_test.go
@@ -154,6 +154,45 @@ func authedRequest(method, target string) *http.Request {
 	return req.WithContext(ctx)
 }
 
+func authedAdminRequest(method, target string) *http.Request {
+	req := httptest.NewRequest(method, target, nil)
+	ctx := apimw.SetClaims(req.Context(), &auth.Claims{
+		UserID:    1,
+		Role:      "admin",
+		TokenType: auth.TokenTypeAccess,
+	})
+	ctx = apimw.SetProfileID(ctx, "profile-1")
+	return req.WithContext(ctx)
+}
+
+func TestHandleListMineReturnsEmptyArray(t *testing.T) {
+	h := NewRequestsHandler(&fakeRequestService{})
+
+	rec := httptest.NewRecorder()
+	h.HandleListMine(rec, authedRequest("GET", "/api/v1/requests/mine"))
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200", rec.Code)
+	}
+	if got, want := rec.Body.String(), "{\"requests\":[]}\n"; got != want {
+		t.Fatalf("body = %q, want %q", got, want)
+	}
+}
+
+func TestHandleAdminListReturnsEmptyArray(t *testing.T) {
+	h := NewRequestsHandler(&fakeRequestService{})
+
+	rec := httptest.NewRecorder()
+	h.HandleAdminList(rec, authedAdminRequest("GET", "/api/v1/admin/requests"))
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200", rec.Code)
+	}
+	if got, want := rec.Body.String(), "{\"requests\":[]}\n"; got != want {
+		t.Fatalf("body = %q, want %q", got, want)
+	}
+}
+
 func TestHandleListStudiosReturnsJSON(t *testing.T) {
 	logo := "https://image.tmdb.org/t/p/w300/x.png"
 	svc := &fakeRequestService{


### PR DESCRIPTION
## Problem

When a user has no media requests, the request service can return a nil Go slice. The list handlers encoded that slice directly, producing `{"requests":null}` even though the API field represents a collection. Strict clients that decode `requests` as an array reject the response instead of rendering an empty state.

The regression tests reproduced the current behavior before the fix:

```text
body = "{\"requests\":null}\n", want "{\"requests\":[]}\n"
```

## Approach

Add a shared HTTP response constructor that converts only nil request slices to an allocated empty slice. Use it for both the user's request list and the admin request list. Non-nil slices, including populated responses, pass through unchanged.

This keeps JSON contract normalization at the API boundary and does not change persistence, request-service behavior, or client code.

## Verification

- New user and admin handler regression tests failed on `main` with `{"requests":null}` and pass with `{"requests":[]}` after the fix.
- `GOWORK=off go build ./internal/... ./cmd/...` — passed.
- `GOWORK=off go test ./internal/api/handlers ./internal/requests` — passed.
- `GOWORK=off go test ./...` — passed.
- `GOWORK=off go run github.com/golangci/golangci-lint/v2/cmd/golangci-lint@latest run ./internal/...` — passed with no findings.
- `make verify-local-paths` — passed.

## Adversarial review

Independent Codex review verdict: **approve**, with no material findings. It confirmed that the helper only changes nil slices, preserves populated responses, covers both list endpoints, and that the tests use valid user and admin authentication contexts.

## Risks & follow-up

This is a backward-compatible wire-format correction from `null` to an empty array for an empty collection. There are no migrations or deployment-order requirements. Web and Android already tolerate the old response, so no coordinated client change is required.

Closes #577

### AI Disclosure

- Tool(s): OpenAI Codex
- Model(s): `gpt-5`
- Involvement: AI-assisted with human-authorized implementation and publication
- Adversarial review: Independent Codex pass approved the committed diff with no material findings


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Empty request lists now consistently return a successful response with an empty `requests` array.
  * Updated both personal and administrative request-list views for consistent response formatting.

* **Tests**
  * Added coverage for empty results in personal and administrative request-list endpoints.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->