### PR TITLE
Broaden TMDB anime detection

### DIFF
--- a/internal/metadata/tmdb/client.go
+++ b/internal/metadata/tmdb/client.go
@@ -873,6 +873,7 @@ func normalizeMovieDetail(resp *movieDetailResponse) *MediaDetail {
 		Year:             releaseYear(resp.ReleaseDate),
 		Runtime:          resp.Runtime,
 		Genres:           namesFromGenres(resp.Genres),
+		GenreIDs:         genreIDsFromEntries(resp.Genres),
 		VoteAverage:      resp.VoteAverage,
 		VoteCount:        resp.VoteCount,
 		Status:           resp.Status,
@@ -931,6 +932,7 @@ func normalizeTVDetail(resp *tvDetailResponse) *MediaDetail {
 		LastAirDate:      resp.LastAirDate,
 		Year:             releaseYear(resp.FirstAirDate),
 		Genres:           namesFromGenres(resp.Genres),
+		GenreIDs:         genreIDsFromEntries(resp.Genres),
 		VoteAverage:      resp.VoteAverage,
 		VoteCount:        resp.VoteCount,
 		Status:           resp.Status,
@@ -1002,6 +1004,18 @@ func keywordIDs(groups ...[]idEntry) []int {
 		for _, e := range g {
 			out = append(out, e.ID)
 		}
+	}
+	return out
+}
+
+// genreIDsFromEntries extracts the numeric IDs from raw TMDB genre entries.
+func genreIDsFromEntries(genres []genreEntry) []int {
+	if len(genres) == 0 {
+		return nil
+	}
+	out := make([]int, 0, len(genres))
+	for _, g := range genres {
+		out = append(out, g.ID)
 	}
 	return out
 }

--- a/internal/metadata/tmdb/client_test.go
+++ b/internal/metadata/tmdb/client_test.go
@@ -2,9 +2,11 @@ package tmdb
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -1136,5 +1138,122 @@ func TestGetCertificationSingleflightsConcurrentCallers(t *testing.T) {
 	}
 	if got := calls.Load(); got != 1 {
 		t.Fatalf("upstream calls = %d, want 1 (singleflight)", got)
+	}
+}
+
+func TestNormalizeMovieDetailGenreIDs(t *testing.T) {
+	resp := &movieDetailResponse{
+		ID:               603,
+		Title:            "The Matrix",
+		OriginalLanguage: "en",
+		Genres: []genreEntry{
+			{ID: 28, Name: "Action"},
+			{ID: 878, Name: "Science Fiction"},
+		},
+	}
+	detail := normalizeMovieDetail(resp)
+
+	if detail.MediaType != "movie" {
+		t.Fatalf("MediaType = %q, want movie", detail.MediaType)
+	}
+	if len(detail.Genres) != 2 || detail.Genres[0] != "Action" || detail.Genres[1] != "Science Fiction" {
+		t.Fatalf("Genres = %v, want [Action Science Fiction]", detail.Genres)
+	}
+	if len(detail.GenreIDs) != 2 || detail.GenreIDs[0] != 28 || detail.GenreIDs[1] != 878 {
+		t.Fatalf("GenreIDs = %v, want [28 878]", detail.GenreIDs)
+	}
+	if detail.OriginalLanguage != "en" {
+		t.Fatalf("OriginalLanguage = %q, want en", detail.OriginalLanguage)
+	}
+}
+
+func TestNormalizeTVDetailGenreIDs(t *testing.T) {
+	resp := &tvDetailResponse{
+		ID:               1396,
+		Name:             "Breaking Bad",
+		OriginalLanguage: "en",
+		Genres: []genreEntry{
+			{ID: 18, Name: "Drama"},
+			{ID: 80, Name: "Crime"},
+		},
+	}
+	detail := normalizeTVDetail(resp)
+
+	if detail.MediaType != "series" {
+		t.Fatalf("MediaType = %q, want series", detail.MediaType)
+	}
+	if len(detail.Genres) != 2 || detail.Genres[0] != "Drama" || detail.Genres[1] != "Crime" {
+		t.Fatalf("Genres = %v, want [Drama Crime]", detail.Genres)
+	}
+	if len(detail.GenreIDs) != 2 || detail.GenreIDs[0] != 18 || detail.GenreIDs[1] != 80 {
+		t.Fatalf("GenreIDs = %v, want [18 80]", detail.GenreIDs)
+	}
+}
+
+func TestNormalizeMovieDetailGenreIDsPreservesAnimation(t *testing.T) {
+	resp := &movieDetailResponse{
+		ID:               999,
+		Title:            "Gun Girls",
+		OriginalLanguage: "zh",
+		Genres: []genreEntry{
+			{ID: 16, Name: "Animation"},
+			{ID: 10759, Name: "Action & Adventure"},
+		},
+	}
+	detail := normalizeMovieDetail(resp)
+
+	if len(detail.GenreIDs) != 2 || detail.GenreIDs[0] != 16 || detail.GenreIDs[1] != 10759 {
+		t.Fatalf("GenreIDs = %v, want [16 10759]", detail.GenreIDs)
+	}
+	if detail.OriginalLanguage != "zh" {
+		t.Fatalf("OriginalLanguage = %q, want zh", detail.OriginalLanguage)
+	}
+	if len(detail.Genres) != 2 || detail.Genres[0] != "Animation" {
+		t.Fatalf("Genres = %v, want [Animation Action & Adventure]", detail.Genres)
+	}
+}
+
+func TestNormalizeTVDetailEmptyGenresNilIDs(t *testing.T) {
+	resp := &tvDetailResponse{
+		ID:               500,
+		Name:             "No Genre Show",
+		OriginalLanguage: "en",
+		Genres:           nil,
+	}
+	detail := normalizeTVDetail(resp)
+
+	if detail.Genres != nil {
+		t.Fatalf("Genres = %v, want nil", detail.Genres)
+	}
+	if detail.GenreIDs != nil {
+		t.Fatalf("GenreIDs = %v, want nil", detail.GenreIDs)
+	}
+}
+
+func TestMediaDetailGenreIDsNotInJSON(t *testing.T) {
+	detail := &MediaDetail{
+		MediaType:        "movie",
+		ID:               603,
+		Title:            "The Matrix",
+		Genres:           []string{"Animation"},
+		GenreIDs:         []int{16, 28, 878},
+		OriginalLanguage: "zh",
+		KeywordIDs:       []int{210024},
+	}
+
+	data, err := json.Marshal(detail)
+	if err != nil {
+		t.Fatalf("json.Marshal: %v", err)
+	}
+
+	s := string(data)
+	if strings.Contains(s, "GenreIDs") {
+		t.Fatalf("GenreIDs leaked into JSON output: %s", s)
+	}
+	if strings.Contains(s, "genre_ids") {
+		t.Fatalf("genre_ids leaked into JSON output: %s", s)
+	}
+	if !strings.Contains(s, `"Title":"The Matrix"`) {
+		t.Fatalf("expected Title in JSON, got: %s", s)
 	}
 }

--- a/internal/metadata/tmdb/types.go
+++ b/internal/metadata/tmdb/types.go
@@ -185,6 +185,7 @@ type MediaDetail struct {
 	Year                int
 	Runtime             int
 	Genres              []string
+	GenreIDs            []int `json:"-"`
 	VoteAverage         float64
 	VoteCount           int
 	Status              string

--- a/internal/requests/anime.go
+++ b/internal/requests/anime.go
@@ -1,13 +1,37 @@
 package requests
 
+import "strings"
+
 // animeKeywordID is TMDB's "anime" keyword id. Matches Seerr's ANIME_KEYWORD_ID
-// exactly (server/api/themoviedb/constants.ts). Detection is keyword-id only —
-// no genre/language fallback — to mirror upstream behavior.
+// exactly (server/api/themoviedb/constants.ts).
 const animeKeywordID = 210024
 
-func detectAnime(keywordIDs []int) bool {
+// animationGenreID is TMDB's "Animation" genre id, shared across movie and TV.
+const animationGenreID = 16
+
+// detectAnime reports whether the TMDB metadata classifies the title as anime.
+// Detection uses a keyword-first strategy: if the TMDB "anime" keyword (210024)
+// is present the title is anime regardless of genre or language. When the keyword
+// is absent, a fallback checks for Animation genre (16) combined with an
+// original language of ja, zh, or ko (case-insensitive, trimmed).
+func detectAnime(keywordIDs []int, genreIDs []int, language string) bool {
 	for _, id := range keywordIDs {
 		if id == animeKeywordID {
+			return true
+		}
+	}
+
+	lang := strings.ToLower(strings.TrimSpace(language))
+	if lang == "" || len(genreIDs) == 0 {
+		return false
+	}
+
+	if lang != "ja" && lang != "zh" && lang != "ko" {
+		return false
+	}
+
+	for _, id := range genreIDs {
+		if id == animationGenreID {
 			return true
 		}
 	}

--- a/internal/requests/anime_test.go
+++ b/internal/requests/anime_test.go
@@ -3,13 +3,179 @@ package requests
 import "testing"
 
 func TestDetectAnime(t *testing.T) {
-	if !detectAnime([]int{99, animeKeywordID, 7}) {
-		t.Fatal("expected anime when keyword 210024 present")
-	}
-	if detectAnime([]int{99, 7}) {
-		t.Fatal("expected non-anime when keyword 210024 absent")
-	}
-	if detectAnime(nil) {
-		t.Fatal("expected non-anime for empty keywords")
-	}
+	const genreAnimation = 16
+
+	t.Run("keyword_210024_detects_anime", func(t *testing.T) {
+		if !detectAnime([]int{99, animeKeywordID, 7}, nil, "") {
+			t.Fatal("expected anime when keyword 210024 present")
+		}
+	})
+
+	t.Run("keyword_only_no_genre", func(t *testing.T) {
+		if !detectAnime([]int{animeKeywordID}, nil, "") {
+			t.Fatal("expected anime for keyword-only match")
+		}
+	})
+
+	t.Run("keyword_with_genre_16", func(t *testing.T) {
+		if !detectAnime([]int{animeKeywordID}, []int{genreAnimation}, "ja") {
+			t.Fatal("expected anime when keyword and genre both present")
+		}
+	})
+
+	t.Run("no_keyword_no_genre", func(t *testing.T) {
+		if detectAnime([]int{99, 7}, nil, "") {
+			t.Fatal("expected non-anime when keyword 210024 absent and no genre")
+		}
+	})
+
+	t.Run("nil_keywords", func(t *testing.T) {
+		if detectAnime(nil, nil, "") {
+			t.Fatal("expected non-anime for nil keywords")
+		}
+	})
+
+	t.Run("empty_keywords", func(t *testing.T) {
+		if detectAnime([]int{}, nil, "") {
+			t.Fatal("expected non-anime for empty keywords")
+		}
+	})
+
+	t.Run("genre_16_ja_detects_anime", func(t *testing.T) {
+		if !detectAnime(nil, []int{genreAnimation}, "ja") {
+			t.Fatal("expected anime for genre 16 + language ja")
+		}
+	})
+
+	t.Run("genre_16_zh_detects_anime", func(t *testing.T) {
+		if !detectAnime(nil, []int{genreAnimation}, "zh") {
+			t.Fatal("expected anime for genre 16 + language zh")
+		}
+	})
+
+	t.Run("genre_16_ko_detects_anime", func(t *testing.T) {
+		if !detectAnime(nil, []int{genreAnimation}, "ko") {
+			t.Fatal("expected anime for genre 16 + language ko")
+		}
+	})
+
+	t.Run("genre_16_en_western_animation_false", func(t *testing.T) {
+		if detectAnime(nil, []int{genreAnimation}, "en") {
+			t.Fatal("expected non-anime for genre 16 + language en")
+		}
+	})
+
+	t.Run("genre_16_fr_western_animation_false", func(t *testing.T) {
+		if detectAnime(nil, []int{genreAnimation}, "fr") {
+			t.Fatal("expected non-anime for genre 16 + language fr")
+		}
+	})
+
+	t.Run("ja_without_genre_16_false", func(t *testing.T) {
+		if detectAnime(nil, []int{28}, "ja") {
+			t.Fatal("expected non-anime for language ja without genre 16")
+		}
+	})
+
+	t.Run("zh_without_genre_16_false", func(t *testing.T) {
+		if detectAnime(nil, []int{18, 10759}, "zh") {
+			t.Fatal("expected non-anime for language zh without genre 16")
+		}
+	})
+
+	t.Run("genre_16_no_language_false", func(t *testing.T) {
+		if detectAnime(nil, []int{genreAnimation}, "") {
+			t.Fatal("expected non-anime for genre 16 with empty language")
+		}
+	})
+
+	t.Run("language_whitespace_trimmed", func(t *testing.T) {
+		if !detectAnime(nil, []int{genreAnimation}, "  ja  ") {
+			t.Fatal("expected anime for genre 16 + language '  ja  ' (trimmed)")
+		}
+	})
+
+	t.Run("language_uppercase_normalized", func(t *testing.T) {
+		if !detectAnime(nil, []int{genreAnimation}, "JA") {
+			t.Fatal("expected anime for genre 16 + language 'JA' (lowercased)")
+		}
+	})
+
+	t.Run("language_mixed_case_whitespace", func(t *testing.T) {
+		if !detectAnime(nil, []int{genreAnimation}, "  ZH  ") {
+			t.Fatal("expected anime for genre 16 + language '  ZH  '")
+		}
+	})
+
+	t.Run("nil_genre_ids", func(t *testing.T) {
+		if detectAnime(nil, nil, "ja") {
+			t.Fatal("expected non-anime for nil genre IDs with language ja")
+		}
+	})
+
+	t.Run("empty_genre_ids", func(t *testing.T) {
+		if detectAnime(nil, []int{}, "ja") {
+			t.Fatal("expected non-anime for empty genre IDs with language ja")
+		}
+	})
+
+	t.Run("gun_gunners_shape_zh_plus_16", func(t *testing.T) {
+		if !detectAnime([]int{999}, []int{genreAnimation, 10759, 80}, "zh") {
+			t.Fatal("expected anime for Gun-Girls-shaped detail: zh + genre 16")
+		}
+	})
+
+	t.Run("multiple_genre_ids_with_16", func(t *testing.T) {
+		if !detectAnime(nil, []int{28, genreAnimation, 12}, "ko") {
+			t.Fatal("expected anime for genre 16 among multiple genres + ko")
+		}
+	})
+
+	t.Run("all_nil_and_empty", func(t *testing.T) {
+		if detectAnime(nil, nil, "") {
+			t.Fatal("expected non-anime for all-nil/empty inputs")
+		}
+	})
+
+	t.Run("literal_keyword_210024_independent_of_constant", func(t *testing.T) {
+		if !detectAnime([]int{210024}, nil, "") {
+			t.Fatal("expected anime for literal keyword ID 210024")
+		}
+	})
+
+	t.Run("literal_210024_with_fallback_fields_present", func(t *testing.T) {
+		if !detectAnime([]int{210024}, []int{16}, "en") {
+			t.Fatal("expected anime for literal 210024 even with western animation fields")
+		}
+	})
+
+	t.Run("negative_genre_id_ignored", func(t *testing.T) {
+		if detectAnime(nil, []int{-16}, "ja") {
+			t.Fatal("expected non-anime for negative genre ID -16")
+		}
+	})
+
+	t.Run("zero_genre_id_ignored", func(t *testing.T) {
+		if detectAnime(nil, []int{0}, "zh") {
+			t.Fatal("expected non-anime for zero genre ID")
+		}
+	})
+
+	t.Run("duplicate_genre_16_still_detects", func(t *testing.T) {
+		if !detectAnime(nil, []int{16, 16, 16}, "ko") {
+			t.Fatal("expected anime for duplicate genre 16 entries + ko")
+		}
+	})
+
+	t.Run("negative_keyword_ignored", func(t *testing.T) {
+		if detectAnime([]int{-210024}, nil, "") {
+			t.Fatal("expected non-anime for negative keyword ID")
+		}
+	})
+
+	t.Run("very_large_genre_id_ignored", func(t *testing.T) {
+		if detectAnime(nil, []int{999999}, "ja") {
+			t.Fatal("expected non-anime for very large non-animation genre ID")
+		}
+	})
 }

--- a/internal/requests/service.go
+++ b/internal/requests/service.go
@@ -1595,7 +1595,7 @@ func (s *Service) detectRequestAnime(ctx context.Context, mediaType MediaType, t
 	if err != nil || detail == nil {
 		return false
 	}
-	return detectAnime(detail.KeywordIDs)
+	return detectAnime(detail.KeywordIDs, detail.GenreIDs, detail.OriginalLanguage)
 }
 
 // integrationConfigured reports whether a fulfillment backend exists for the

--- a/internal/requests/service_test.go
+++ b/internal/requests/service_test.go
@@ -473,6 +473,230 @@ func TestCreateRequestClearsPriorFailedRequest(t *testing.T) {
 	}
 }
 
+func TestCreateRequestAnimeDetectionKeyword(t *testing.T) {
+	store := newFakeStore()
+	store.settings.RequestsEnabled = true
+	client := &fakeTMDBClient{
+		detail: &tmdb.MediaDetail{
+			KeywordIDs:       []int{210024},
+			GenreIDs:         []int{28},
+			OriginalLanguage: "en",
+		},
+	}
+	service := newTestServiceWithTMDB(store, client)
+
+	req, err := service.CreateRequest(context.Background(), testViewer(1), CreateRequestInput{
+		MediaType: MediaTypeMovie,
+		TMDBID:    999,
+		Title:     "Anime Movie",
+	})
+	if err != nil {
+		t.Fatalf("CreateRequest returned error: %v", err)
+	}
+	if !req.IsAnime {
+		t.Fatal("expected IsAnime=true for keyword 210024")
+	}
+	if len(store.created) != 1 {
+		t.Fatalf("created requests = %d, want 1", len(store.created))
+	}
+	if !store.created[0].IsAnime {
+		t.Fatal("expected stored CreateRequestRecord.IsAnime=true for keyword 210024")
+	}
+}
+
+func TestCreateRequestAnimeDetectionGenre16LanguageZH(t *testing.T) {
+	store := newFakeStore()
+	store.settings.RequestsEnabled = true
+	client := &fakeTMDBClient{
+		detail: &tmdb.MediaDetail{
+			KeywordIDs:       []int{999},
+			GenreIDs:         []int{16, 10759},
+			OriginalLanguage: "zh",
+		},
+	}
+	service := newTestServiceWithTMDB(store, client)
+
+	req, err := service.CreateRequest(context.Background(), testViewer(1), CreateRequestInput{
+		MediaType: MediaTypeMovie,
+		TMDBID:    999,
+		Title:     "Chinese Anime",
+	})
+	if err != nil {
+		t.Fatalf("CreateRequest returned error: %v", err)
+	}
+	if !req.IsAnime {
+		t.Fatal("expected IsAnime=true for genre 16 + language zh")
+	}
+	if len(store.created) != 1 {
+		t.Fatalf("created requests = %d, want 1", len(store.created))
+	}
+	if !store.created[0].IsAnime {
+		t.Fatal("expected stored CreateRequestRecord.IsAnime=true for genre 16 + language zh")
+	}
+}
+
+func TestCreateRequestAnimeDetectionGenre16LanguageJA(t *testing.T) {
+	store := newFakeStore()
+	store.settings.RequestsEnabled = true
+	client := &fakeTMDBClient{
+		detail: &tmdb.MediaDetail{
+			KeywordIDs:       nil,
+			GenreIDs:         []int{16, 28},
+			OriginalLanguage: "ja",
+		},
+	}
+	service := newTestServiceWithTMDB(store, client)
+
+	req, err := service.CreateRequest(context.Background(), testViewer(1), CreateRequestInput{
+		MediaType: MediaTypeSeries,
+		TMDBID:    999,
+		Title:     "Japanese Anime",
+	})
+	if err != nil {
+		t.Fatalf("CreateRequest returned error: %v", err)
+	}
+	if !req.IsAnime {
+		t.Fatal("expected IsAnime=true for genre 16 + language ja")
+	}
+	if !store.created[0].IsAnime {
+		t.Fatal("expected stored CreateRequestRecord.IsAnime=true for genre 16 + language ja")
+	}
+}
+
+func TestCreateRequestAnimeDetectionGenre16LanguageKO(t *testing.T) {
+	store := newFakeStore()
+	store.settings.RequestsEnabled = true
+	client := &fakeTMDBClient{
+		detail: &tmdb.MediaDetail{
+			KeywordIDs:       nil,
+			GenreIDs:         []int{16},
+			OriginalLanguage: "ko",
+		},
+	}
+	service := newTestServiceWithTMDB(store, client)
+
+	req, err := service.CreateRequest(context.Background(), testViewer(1), CreateRequestInput{
+		MediaType: MediaTypeMovie,
+		TMDBID:    999,
+		Title:     "Korean Anime",
+	})
+	if err != nil {
+		t.Fatalf("CreateRequest returned error: %v", err)
+	}
+	if !req.IsAnime {
+		t.Fatal("expected IsAnime=true for genre 16 + language ko")
+	}
+	if !store.created[0].IsAnime {
+		t.Fatal("expected stored CreateRequestRecord.IsAnime=true for genre 16 + language ko")
+	}
+}
+
+func TestCreateRequestAnimeDetectionGenreOnlyNoLanguage(t *testing.T) {
+	store := newFakeStore()
+	store.settings.RequestsEnabled = true
+	client := &fakeTMDBClient{
+		detail: &tmdb.MediaDetail{
+			KeywordIDs:       nil,
+			GenreIDs:         []int{16},
+			OriginalLanguage: "",
+		},
+	}
+	service := newTestServiceWithTMDB(store, client)
+
+	req, err := service.CreateRequest(context.Background(), testViewer(1), CreateRequestInput{
+		MediaType: MediaTypeMovie,
+		TMDBID:    999,
+		Title:     "Genre Only",
+	})
+	if err != nil {
+		t.Fatalf("CreateRequest returned error: %v", err)
+	}
+	if req.IsAnime {
+		t.Fatal("expected IsAnime=false for genre 16 without language")
+	}
+	if store.created[0].IsAnime {
+		t.Fatal("expected stored CreateRequestRecord.IsAnime=false for genre 16 without language")
+	}
+}
+
+func TestCreateRequestAnimeDetectionLanguageOnlyNoGenre(t *testing.T) {
+	store := newFakeStore()
+	store.settings.RequestsEnabled = true
+	client := &fakeTMDBClient{
+		detail: &tmdb.MediaDetail{
+			KeywordIDs:       nil,
+			GenreIDs:         []int{28},
+			OriginalLanguage: "ja",
+		},
+	}
+	service := newTestServiceWithTMDB(store, client)
+
+	req, err := service.CreateRequest(context.Background(), testViewer(1), CreateRequestInput{
+		MediaType: MediaTypeMovie,
+		TMDBID:    999,
+		Title:     "Language Only",
+	})
+	if err != nil {
+		t.Fatalf("CreateRequest returned error: %v", err)
+	}
+	if req.IsAnime {
+		t.Fatal("expected IsAnime=false for language ja without genre 16")
+	}
+	if store.created[0].IsAnime {
+		t.Fatal("expected stored CreateRequestRecord.IsAnime=false for language ja without genre 16")
+	}
+}
+
+func TestCreateRequestAnimeDetectionWrongLanguage(t *testing.T) {
+	store := newFakeStore()
+	store.settings.RequestsEnabled = true
+	client := &fakeTMDBClient{
+		detail: &tmdb.MediaDetail{
+			KeywordIDs:       nil,
+			GenreIDs:         []int{16},
+			OriginalLanguage: "en",
+		},
+	}
+	service := newTestServiceWithTMDB(store, client)
+
+	req, err := service.CreateRequest(context.Background(), testViewer(1), CreateRequestInput{
+		MediaType: MediaTypeMovie,
+		TMDBID:    999,
+		Title:     "Western Animation",
+	})
+	if err != nil {
+		t.Fatalf("CreateRequest returned error: %v", err)
+	}
+	if req.IsAnime {
+		t.Fatal("expected IsAnime=false for genre 16 + language en")
+	}
+	if store.created[0].IsAnime {
+		t.Fatal("expected stored CreateRequestRecord.IsAnime=false for genre 16 + language en")
+	}
+}
+
+func TestCreateRequestAnimeDetectionNilDetail(t *testing.T) {
+	store := newFakeStore()
+	store.settings.RequestsEnabled = true
+	client := &fakeTMDBClient{detail: nil}
+	service := newTestServiceWithTMDB(store, client)
+
+	req, err := service.CreateRequest(context.Background(), testViewer(1), CreateRequestInput{
+		MediaType: MediaTypeMovie,
+		TMDBID:    999,
+		Title:     "Nil Detail",
+	})
+	if err != nil {
+		t.Fatalf("CreateRequest returned error: %v", err)
+	}
+	if req.IsAnime {
+		t.Fatal("expected IsAnime=false for nil detail")
+	}
+	if store.created[0].IsAnime {
+		t.Fatal("expected stored CreateRequestRecord.IsAnime=false for nil detail")
+	}
+}
+
 func TestSearchMarksSeriesAvailableByHydratedTVDBID(t *testing.T) {
 	store := newFakeStore()
 	store.settings.RequestsEnabled = true
@@ -2065,6 +2289,7 @@ type fakeTMDBClient struct {
 	externalIDsByID   map[int]*tmdb.ExternalIDs
 	externalIDCalls   []int
 	detail            *tmdb.MediaDetail
+	detailErr         error
 	discoverPage      *tmdb.MediaPage
 	discoverErr       error
 	searchMediaType   string
@@ -2104,7 +2329,7 @@ func (f *fakeTMDBClient) GetExternalIDs(_ context.Context, _ string, id int) (*t
 }
 
 func (f *fakeTMDBClient) GetMediaDetail(context.Context, string, int) (*tmdb.MediaDetail, error) {
-	return f.detail, nil
+	return f.detail, f.detailErr
 }
 
 // certTMDBClient layers GetCertification onto fakeTMDBClient so a service
@@ -2880,5 +3105,105 @@ func TestSubmitApprovedPopulatesRequesterIdentity(t *testing.T) {
 	}
 	if router.gotRequesterEmail != "u@example.com" || router.gotRequesterUsername != "bob" {
 		t.Fatalf("descriptor identity = %q/%q, want u@example.com/bob", router.gotRequesterEmail, router.gotRequesterUsername)
+	}
+}
+
+func TestDetectRequestAnimePassesGenreIDsAndLanguage(t *testing.T) {
+	t.Run("genre_16_zh_classifies_anime", func(t *testing.T) {
+		store := newFakeStore()
+		store.settings = Settings{RequestsEnabled: true}
+		client := &fakeTMDBClient{
+			detail: &tmdb.MediaDetail{
+				GenreIDs:         []int{16, 10759},
+				OriginalLanguage: "zh",
+			},
+		}
+		svc := newTestServiceWithTMDB(store, client)
+		if !svc.detectRequestAnime(context.Background(), MediaTypeMovie, 999) {
+			t.Fatal("expected anime for genre 16 + language zh via detectRequestAnime")
+		}
+	})
+
+	t.Run("genre_16_en_classifies_non_anime", func(t *testing.T) {
+		store := newFakeStore()
+		store.settings = Settings{RequestsEnabled: true}
+		client := &fakeTMDBClient{
+			detail: &tmdb.MediaDetail{
+				GenreIDs:         []int{16},
+				OriginalLanguage: "en",
+			},
+		}
+		svc := newTestServiceWithTMDB(store, client)
+		if svc.detectRequestAnime(context.Background(), MediaTypeMovie, 888) {
+			t.Fatal("expected non-anime for genre 16 + language en via detectRequestAnime")
+		}
+	})
+
+	t.Run("keyword_210024_classifies_anime", func(t *testing.T) {
+		store := newFakeStore()
+		store.settings = Settings{RequestsEnabled: true}
+		client := &fakeTMDBClient{
+			detail: &tmdb.MediaDetail{
+				KeywordIDs:       []int{210024},
+				GenreIDs:         nil,
+				OriginalLanguage: "",
+			},
+		}
+		svc := newTestServiceWithTMDB(store, client)
+		if !svc.detectRequestAnime(context.Background(), MediaTypeSeries, 777) {
+			t.Fatal("expected anime for keyword 210024 via detectRequestAnime")
+		}
+	})
+
+	t.Run("nil_detail_returns_false", func(t *testing.T) {
+		store := newFakeStore()
+		store.settings = Settings{RequestsEnabled: true}
+		client := &fakeTMDBClient{detail: nil}
+		svc := newTestServiceWithTMDB(store, client)
+		if svc.detectRequestAnime(context.Background(), MediaTypeMovie, 666) {
+			t.Fatal("expected non-anime for nil detail")
+		}
+	})
+
+	t.Run("ja_without_genre_16_non_anime", func(t *testing.T) {
+		store := newFakeStore()
+		store.settings = Settings{RequestsEnabled: true}
+		client := &fakeTMDBClient{
+			detail: &tmdb.MediaDetail{
+				GenreIDs:         []int{28, 18},
+				OriginalLanguage: "ja",
+			},
+		}
+		svc := newTestServiceWithTMDB(store, client)
+		if svc.detectRequestAnime(context.Background(), MediaTypeMovie, 555) {
+			t.Fatal("expected non-anime for ja without genre 16 via detectRequestAnime")
+		}
+	})
+}
+
+func TestCreateRequestAnimeDetectionErrorDetail(t *testing.T) {
+	store := newFakeStore()
+	store.settings.RequestsEnabled = true
+	client := &fakeTMDBClient{
+		detailErr: errors.New("TMDB API error"),
+	}
+	service := newTestServiceWithTMDB(store, client)
+
+	req, err := service.CreateRequest(context.Background(), testViewer(1), CreateRequestInput{
+		MediaType: MediaTypeMovie,
+		TMDBID:    999,
+		Title:     "Error Detail",
+	})
+	if err != nil {
+		t.Fatalf("CreateRequest returned error: %v", err)
+	}
+	if req.IsAnime {
+		t.Fatal("expected IsAnime=false for error detail (fail-safe)")
+	}
+	if len(store.created) != 1 {
+		t.Fatalf("created requests = %d, want 1", len(store.created))
+	}
+	if store.created[0].IsAnime {
+		t.Fatal("expected stored CreateRequestRecord.IsAnime=false for error detail (fail-safe)")
 	}
 }


### PR DESCRIPTION
## Problem

TMDB's anime keyword (210024) is inconsistently applied. Some Japanese, Chinese and Korean
animation such as Gun Girls (枪娘FIRE, TMDB 107299) frequently lacks the
`anime` keyword entirely, causing Silo to route requests to the standard
Sonarr instead of a dedicated anime instance even when one is configured.

## Approach

Extend the anime classifier with a secondary rule: Animation genre (TMDB
genre ID 16) + Original language `ja`, `zh`, or `ko`. The existing keyword
210024 remains the primary signal and takes precedence. A title must carry
the Animation genre — language alone does not trigger anime routing, which
avoids false positives on Japanese/Chinese/Korean live-action content.

Internal `GenreIDs []int` added to normalized TMDB movie/TV details
(`json:"-"`, not exposed in any API response). No UI, migration, client, or
API-contract changes. No reclassification of existing requests.

## Testing

$ CGO_ENABLED=0 go test ./internal/metadata/tmdb ./internal/requests -count=2 -v
ok  github.com/Silo-Server/silo-server/internal/metadata/tmdb    0.877s
ok  github.com/Silo-Server/silo-server/internal/requests          0.026s
$ CGO_ENABLED=0 go vet ./internal/metadata/tmdb ./internal/requests
(no output — clean)

Test coverage includes:
- Keyword 210024 positive (unchanged behavior)
- Genre 16 + ja/zh/ko positive (new fallback)
- Genre 16 + en/fr negative (western animation excluded)
- Language without genre negative
- Genre without language negative
- Whitespace/case normalization
- Nil and error TMDB detail → fail-safe false
- JSON non-exposure of internal GenreIDs
- Service-level CreateRequest persistence for all paths
- Movie vs. TV genre-ID normalization

Full suite has pre-existing environment failures (CGO/sqlite, missing web
dist, literaryworks) unrelated to this change.

### AI Disclosure
- Tool(s): Opencode
- Model(s): xiaomi/mimo-v2.5-pro
- Involvement: AI-assisted (some implementations, tests, PR-Text)
- Adversarial review: independent oracle verified keyword precedence, genre+language positives/negatives, language-only and genre-only rejection, nil/error fail-safe, JSON non-exposure, movie vs TV normalization, scope fidelity. Clean — no blocking findings.

## Checklist
- [x] I ran an adversarial AI review of the diff and summarized findings above.
- [x] I ran the repo verify commands: `make lint`, `cd web && pnpm run lint`, `cd web && pnpm run format:check`, and relevant `go test ./...`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Anime detection now recognizes animation titles using TMDB genre and language information, in addition to anime keywords.
  * Movie and TV metadata now includes TMDB genre IDs for improved classification.

* **Bug Fixes**
  * Improved handling of language variations, empty metadata, and metadata retrieval errors during anime detection.
  * Preserved animation genre information during metadata normalization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->