### PR TITLE
fix(web): defuse date time bomb in push-relay admin settings test

### DIFF
--- a/web/src/pages/admin-settings/NotificationsAdminSettings.test.tsx
+++ b/web/src/pages/admin-settings/NotificationsAdminSettings.test.tsx
@@ -36,7 +36,10 @@ function makeForm() {
         case "notifications.push_relay_key_prefix":
           return "cap_v1_test";
         case "notifications.push_relay_expires_at":
-          return "2026-08-10T00:00:00Z";
+          // Relative so the "renews automatically" (not-yet-expired) branch
+          // stays stable — a hardcoded date turned into a time bomb once the
+          // calendar passed it.
+          return new Date(Date.now() + 30 * 24 * 60 * 60 * 1000).toISOString();
         default:
           return "";
       }


### PR DESCRIPTION
## Problem

`NotificationsAdminSettings.test.tsx > shows the Silo Push Relay channel status` started failing on every PR's Web CI as of today (2026-08-10) — including on clean `main`. The fixture hardcodes `notifications.push_relay_expires_at: "2026-08-10T00:00:00Z"`; now that the calendar has passed it, the component correctly renders the "Expired; Silo will renew…" branch instead of "…renews automatically", and the assertion fails. A date time bomb, not a code regression.

## Approach

Make the fixture expiration relative (`Date.now() + 30d`) so the not-yet-expired branch stays stable forever. No component changes; the expired branch's copy is unasserted either way.

## Verification

`npx vitest run src/pages/admin-settings/NotificationsAdminSettings.test.tsx` — 2/2 pass (was 1 failing). Lint 0 errors, format clean.

## Risks & follow-up

None — test-only. Unblocks Web CI for all open PRs (#308, #439, and anything else currently red on this assertion).

## AI-use disclosure
Implemented by Claude Code with human oversight.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated notification settings test data to use a dynamically generated expiration date, ensuring renewal scenarios remain reliable over time.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->