### PR TITLE
fix(playback): accept constrained baseline on baseline decoders

### DIFF
--- a/cmd/playbackfixtures/main.go
+++ b/cmd/playbackfixtures/main.go
@@ -528,6 +528,25 @@ func goldenConformanceMatrix() playback.ConformanceMatrixV3 {
 		))
 	}
 
+	constrainedBaselineFile := conformanceFallbackFile()
+	constrainedBaselineFile.Container = containerMKV
+	constrainedBaselineFile.FilePath = "/media/constrained-baseline.mkv"
+	constrainedBaselineFile.VideoTracks[0].Profile = "Constrained Baseline"
+	constrainedBaselineRequest := conformanceStartRequest()
+	constrainedBaselineRequest.PlaybackAttemptID = "attempt-h264-constrained-baseline"
+	constrainedBaselineRequest.QualityPreference = "auto"
+	constrainedBaselineRequest.Capabilities.CodecsVideo = []string{codecH264}
+	constrainedBaselineRequest.Capabilities.CodecsVideoHardware = []string{codecH264}
+	constrainedBaselineRequest.Capabilities.Containers = []string{containerMKV}
+	constrainedBaselineRequest.Capabilities.VideoDecode = []playback.VideoDecodeCapabilityV3{{
+		Codec: codecH264, Profiles: []string{"baseline"}, Levels: []int{52}, BitDepths: []int{8},
+		MaxWidth: 3840, MaxHeight: 2160, MaxFrameRate: 60, MaxBitrateKbps: 20_000, Hardware: true,
+	}}
+	planner = append(planner, makePlannerScenario(
+		"h264_constrained_baseline_direct", "profile_compatibility", constrainedBaselineRequest,
+		constrainedBaselineFile, nil, playback.PlannerSettingsV3{TranscodeEnabled: false}, registry,
+	))
+
 	fallbackRequest := conformanceStartRequest()
 	fallbackRequest.Capabilities.VideoEvidence = playback.EvidenceDeclaredV3
 	fallbackRequest.Capabilities.VideoDecode = nil

--- a/docs/architecture/playback-protocol-v3.md
+++ b/docs/architecture/playback-protocol-v3.md
@@ -373,7 +373,7 @@ populating them:
 
 | Field | Match |
 | --- | --- |
-| `profiles` | Case-insensitive string equality against the source profile |
+| `profiles` | Case-insensitive profile identity against the source profile. H.264 ignores presentation separators, and a decoder reporting Baseline also accepts the narrower Constrained Baseline source profile; the reverse is not inferred |
 | `levels` | **At-least**: any listed level ≥ the source level passes |
 | `bit_depths` | Exact integer equality |
 

--- a/internal/api/handlers/playback_v3_test.go
+++ b/internal/api/handlers/playback_v3_test.go
@@ -1215,6 +1215,45 @@ func TestHandleStartPlaybackV3PersistsAndReplaysTerminalDecision(t *testing.T) {
 	}
 }
 
+func TestHandleStartPlaybackV3DirectPlaysH264ConstrainedBaselineWhenVideoTranscodingDisabled(t *testing.T) {
+	file := v3HandlerFixtureFile(t)
+	file.VideoTracks[0].Profile = "Constrained Baseline"
+	manager := playback.NewSessionManager(0, 0)
+	manager.SetLimitProvider(func(context.Context, int) (playback.SessionLimits, error) {
+		return playback.SessionLimits{
+			MaxTranscodes:            0,
+			TranscodingDisabled:      true,
+			AudioTranscodingDisabled: false,
+		}, nil
+	})
+	handler := NewPlaybackHandler(manager, testPlaybackFileResolver{file: file})
+	handler.SettingsRepo = &mutablePlaybackSettingsV3{values: map[string]string{"transcode_enabled": "true"}}
+	handler.ItemAccess = allowAllPlaybackItemAccess{}
+	request := v3HandlerStartRequest()
+	request.Capabilities.VideoDecode[0].Profiles = []string{"baseline"}
+
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/playback/start", strings.NewReader(marshalV3StartRequest(t, request))).WithContext(newAuthorizedPlaybackContext())
+	rr := httptest.NewRecorder()
+	handler.HandleStartPlayback(rr, req)
+	if rr.Code != http.StatusCreated {
+		t.Fatalf("status = %d, body = %s", rr.Code, rr.Body.String())
+	}
+	var response playback.DecisionResponseV3
+	if err := json.Unmarshal(rr.Body.Bytes(), &response); err != nil {
+		t.Fatal(err)
+	}
+	if response.Outcome != playback.OutcomePlayableV3 || response.Terminal != nil || response.PlaybackPlan == nil {
+		t.Fatalf("response = %#v, want playable direct plan", response)
+	}
+	if response.PlaybackPlan.Delivery != playback.DeliveryOriginalHTTPV3 || response.PlaybackPlan.DecisionReason != "validated_original_playback" {
+		t.Fatalf("plan = %#v, want validated original playback", response.PlaybackPlan)
+	}
+	sessions := manager.AllSessions()
+	if len(sessions) != 1 || sessions[0].PlayMethod != playback.PlayDirect || sessions[0].TranscodeAudio {
+		t.Fatalf("sessions = %#v, want one direct session without adaptation", sessions)
+	}
+}
+
 func TestHandleStartPlaybackV3RejectsProfileMismatch(t *testing.T) {
 	manager := playback.NewSessionManager(0, 0)
 	handler := NewPlaybackHandler(manager, testPlaybackFileResolver{file: v3HandlerFixtureFile(t)})

--- a/internal/playback/capabilities_v3.go
+++ b/internal/playback/capabilities_v3.go
@@ -3,6 +3,7 @@ package playback
 import (
 	"strconv"
 	"strings"
+	"unicode"
 
 	"github.com/Silo-Server/silo-server/internal/models"
 	"github.com/Silo-Server/silo-server/internal/tonemap"
@@ -111,6 +112,8 @@ func normalizeColorRangeV3(value string) string {
 // transcode.
 const EvidenceInsufficientForDirectV3 = "evidence_insufficient_for_direct"
 
+const h264BaselineProfileV3 = "baseline"
+
 // videoEligibleV3 reports whether the source's video stream is validated for
 // a copy/direct route under the request's video evidence tier. The second
 // result reports that the route was blocked by insufficient evidence for the
@@ -139,7 +142,7 @@ func videoEligibleV3(source SourceDescriptorV3, request StartRequestV3) (bool, b
 			matchedCodec = true
 			skipProfileLevel := request.Capabilities.VideoEvidence == EvidencePlatformAttestedV3 && capability.Hardware
 			if !skipProfileLevel {
-				if len(capability.Profiles) > 0 && (source.VideoProfile == "" || !containsFoldV3(capability.Profiles, source.VideoProfile)) {
+				if len(capability.Profiles) > 0 && !videoProfileSupportedV3(source.VideoCodec, source.VideoProfile, capability.Profiles) {
 					continue
 				}
 				if len(capability.Levels) > 0 && (source.VideoLevel <= 0 || !containsAtLeastV3(capability.Levels, source.VideoLevel)) {
@@ -161,6 +164,46 @@ func videoEligibleV3(source SourceDescriptorV3, request StartRequestV3) (bool, b
 	default:
 		return false, false
 	}
+}
+
+// videoProfileSupportedV3 compares a source profile with the profiles an exact
+// decoder capability reports. Most codecs retain strict case-insensitive
+// equality. H.264 additionally treats Constrained Baseline as a restricted
+// subset of Baseline, so a Baseline decoder validates a Constrained Baseline
+// source; the reverse direction intentionally remains unsupported.
+func videoProfileSupportedV3(codec string, sourceProfile string, decoderProfiles []string) bool {
+	if strings.TrimSpace(sourceProfile) == "" {
+		return false
+	}
+	if !strings.EqualFold(strings.TrimSpace(codec), "h264") {
+		return containsFoldV3(decoderProfiles, sourceProfile)
+	}
+
+	source := canonicalH264ProfileV3(sourceProfile)
+	if source == "" {
+		return false
+	}
+	for _, decoderProfile := range decoderProfiles {
+		decoder := canonicalH264ProfileV3(decoderProfile)
+		if decoder == source || source == "constrainedbaseline" && decoder == h264BaselineProfileV3 {
+			return true
+		}
+	}
+	return false
+}
+
+// canonicalH264ProfileV3 removes presentation-only separators while retaining
+// the profile identity. It is deliberately local to H.264 exact-evidence
+// comparison; source descriptors keep the original normalized probe value.
+func canonicalH264ProfileV3(profile string) string {
+	return strings.Map(func(r rune) rune {
+		switch {
+		case unicode.IsSpace(r), r == '-', r == '_', r == '.', r == ':':
+			return -1
+		default:
+			return unicode.ToLower(r)
+		}
+	}, profile)
 }
 
 // routeVideoMetadataCompleteV3 covers the fields every validated route needs.

--- a/internal/playback/protocol_v3_test.go
+++ b/internal/playback/protocol_v3_test.go
@@ -447,7 +447,7 @@ func TestProtocolV3ConformanceMatrixCoversReleaseTrain(t *testing.T) {
 		"concurrent_replan", "mid_seek_replan", "available_qualities",
 		"audio_only_planning", "output_context_invalidation", "legacy_426",
 		"hdr_dv_matrix", "audio_matrix", "subtitle_matrix", "recovery_matrix",
-		"restart_matrix", "capacity_matrix", "route_event_limits",
+		"restart_matrix", "capacity_matrix", "route_event_limits", "profile_compatibility",
 	} {
 		if !categories[required] {
 			t.Errorf("conformance matrix omits %q", required)
@@ -471,6 +471,7 @@ func TestProtocolV3ConformanceMatrixCoversReleaseTrain(t *testing.T) {
 		"embedded_pgs_sidecar":              DeliveryOriginalHTTPV3,
 		"embedded_ass_authored_render":      DeliveryOriginalHTTPV3,
 		"embedded_dvd_burn_in":              DeliveryTranscodeHLSV3,
+		"h264_constrained_baseline_direct":  DeliveryOriginalHTTPV3,
 	} {
 		value, ok := plannerByName[name]
 		if !ok || value.Expected.Outcome != OutcomePlayableV3 || value.Expected.Delivery != delivery {
@@ -479,6 +480,14 @@ func TestProtocolV3ConformanceMatrixCoversReleaseTrain(t *testing.T) {
 	}
 	if value := plannerByName["available_qualities"]; len(value.Expected.AvailableQualities) < 2 || value.Expected.AvailableQualities[0].Label != QualityOriginalV3 {
 		t.Errorf("available quality fixture = %#v", value.Expected.AvailableQualities)
+	}
+	constrainedBaseline := plannerByName["h264_constrained_baseline_direct"]
+	if constrainedBaseline.Source.VideoProfile != "constrained baseline" ||
+		len(constrainedBaseline.Request.Capabilities.VideoDecode) != 1 ||
+		len(constrainedBaseline.Request.Capabilities.VideoDecode[0].Profiles) != 1 ||
+		constrainedBaseline.Request.Capabilities.VideoDecode[0].Profiles[0] != h264BaselineProfileV3 ||
+		constrainedBaseline.Expected.DecisionReason != "validated_original_playback" {
+		t.Errorf("constrained baseline fixture = %#v", constrainedBaseline)
 	}
 	transformationNamed := func(value PlannerScenarioV3, name string) bool {
 		t.Helper()
@@ -700,6 +709,86 @@ func TestPlanPlaybackV3EvidenceTiersReachTierAppropriateRoutes(t *testing.T) {
 	result = PlanPlaybackV3(PlannerInputV3{Request: declared, RequestedFile: file, EffectiveFile: file, AudioTrackIndex: 0, Settings: PlannerSettingsV3{TranscodeEnabled: true, Allow4KTranscode: true}, Registry: testTransformationRegistryV3()})
 	if result.Plan == nil || result.Plan.Delivery != DeliveryOriginalHTTPV3 {
 		t.Fatalf("declared tier = %s", ExplainPlannerResultV3(result))
+	}
+}
+
+func TestVideoProfileSupportedV3(t *testing.T) {
+	tests := []struct {
+		name           string
+		codec          string
+		source         string
+		decoderProfile string
+		want           bool
+	}{
+		{name: "constrained baseline is a baseline subset", codec: "h264", source: "constrained baseline", decoderProfile: "baseline", want: true},
+		{name: "case and surrounding whitespace", codec: " H264 ", source: " Constrained Baseline ", decoderProfile: " BASELINE ", want: true},
+		{name: "hyphen variant", codec: "h264", source: "constrained-baseline", decoderProfile: "baseline", want: true},
+		{name: "underscore variant", codec: "h264", source: "constrained_baseline", decoderProfile: "baseline", want: true},
+		{name: "period variant", codec: "h264", source: "constrained.baseline", decoderProfile: "baseline", want: true},
+		{name: "unknown plus qualifier is preserved", codec: "h264", source: "baseline+", decoderProfile: "baseline", want: false},
+		{name: "unknown at-sign separator is preserved", codec: "h264", source: "constrained@baseline", decoderProfile: "baseline", want: false},
+		{name: "direction is not reversed", codec: "h264", source: "baseline", decoderProfile: "constrained baseline", want: false},
+		{name: "main is not baseline", codec: "h264", source: "main", decoderProfile: "baseline", want: false},
+		{name: "high is not baseline", codec: "h264", source: "high", decoderProfile: "baseline", want: false},
+		{name: "main identity", codec: "h264", source: "main", decoderProfile: "MAIN", want: true},
+		{name: "high identity", codec: "h264", source: "high", decoderProfile: "High", want: true},
+		{name: "high 10 identity", codec: "h264", source: "high 10", decoderProfile: "high-10", want: true},
+		{name: "colon variant matches compact spelling", codec: "h264", source: "high 4:2:2", decoderProfile: "high422", want: true},
+		{name: "colon variant matches mixed separators", codec: "h264", source: "high 4:4:4 predictive", decoderProfile: "high-4.4.4-predictive", want: true},
+		{name: "non h264 punctuation remains exact", codec: "hevc", source: "main 10", decoderProfile: "main-10", want: false},
+		{name: "non h264 case and trim remain compatible", codec: "hevc", source: " Main 10 ", decoderProfile: "main 10", want: true},
+		{name: "missing source profile", codec: "h264", source: "", decoderProfile: "baseline", want: false},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			if got := videoProfileSupportedV3(test.codec, test.source, []string{test.decoderProfile}); got != test.want {
+				t.Fatalf("videoProfileSupportedV3(%q, %q, [%q]) = %v, want %v", test.codec, test.source, test.decoderProfile, got, test.want)
+			}
+		})
+	}
+}
+
+func TestPlanPlaybackV3DirectPlaysH264ConstrainedBaselineWithoutTranscoding(t *testing.T) {
+	file := &models.MediaFile{
+		ID: 760460, FilePath: "/media/rebel-without-a-pause.mkv", Container: "mkv",
+		CodecVideo: "h264", CodecAudio: "eac3", Resolution: "1080p", Bitrate: 6_642,
+		AudioChannels: 6,
+		VideoTracks: []models.VideoTrack{{
+			Codec: "h264", Profile: "Constrained Baseline", Level: 40,
+			Width: 1920, Height: 1080, FrameRate: "24000/1001", Bitrate: 6_642,
+			BitDepth: 8, VideoRange: "SDR", VideoRangeType: "SDR",
+		}},
+		AudioTracks: []models.AudioTrack{{Codec: "eac3", Channels: 6, Layout: "5.1", Default: true}},
+	}
+	req := validStartRequestV3()
+	req.FileID = file.ID
+	req.QualityPreference = "auto"
+	req.Capabilities.CodecsVideo = []string{"h264"}
+	req.Capabilities.CodecsVideoHardware = []string{"h264"}
+	req.Capabilities.CodecsAudio = []string{"eac3"}
+	req.Capabilities.Containers = []string{"mkv"}
+	req.Capabilities.MaxResolution = "2160p"
+	req.Capabilities.VideoDecode = []VideoDecodeCapabilityV3{{
+		Codec: "h264", Profiles: []string{"baseline", "main", "high", "high 10"}, Levels: []int{52},
+		BitDepths: []int{8}, MaxWidth: 3840, MaxHeight: 2160, MaxFrameRate: 60,
+		MaxBitrateKbps: 20_000, Hardware: true,
+	}}
+
+	result := PlanPlaybackV3(PlannerInputV3{
+		Request: req, RequestedFile: file, EffectiveFile: file, AudioTrackIndex: 0,
+		Settings: PlannerSettingsV3{TranscodeEnabled: false},
+	})
+	if result.Terminal != nil || result.Plan == nil {
+		t.Fatalf("result = %s", ExplainPlannerResultV3(result))
+	}
+	if result.Plan.Delivery != DeliveryOriginalHTTPV3 || result.PlayMethod != PlayDirect {
+		t.Fatalf("route = delivery %q method %q, want original_http/direct", result.Plan.Delivery, result.PlayMethod)
+	}
+	if result.Plan.DecisionReason != "validated_original_playback" {
+		t.Fatalf("decision reason = %q", result.Plan.DecisionReason)
+	}
+	if result.TargetVideoCodec != "" || result.TranscodeAudio {
+		t.Fatalf("direct result requested adaptation: video=%q transcode_audio=%v", result.TargetVideoCodec, result.TranscodeAudio)
 	}
 }
 

--- a/internal/playback/testdata/protocol_v3/conformance_matrix.json
+++ b/internal/playback/testdata/protocol_v3/conformance_matrix.json
@@ -772,6 +772,221 @@
       }
     },
     {
+      "name": "h264_constrained_baseline_direct",
+      "category": "profile_compatibility",
+      "request": {
+        "protocol_version": 3,
+        "client_features": [
+          "playback_plan_v3"
+        ],
+        "file_id": 42,
+        "profile_id": "profile-1",
+        "playback_attempt_id": "attempt-h264-constrained-baseline",
+        "quality_preference": "auto",
+        "subtitle_fidelity_preference": "compatible",
+        "start_position": 12.5,
+        "progress_persistence": "client",
+        "audio_track_id": "file:42:audio:0",
+        "audio_track_index": 0,
+        "metered": false,
+        "client_capabilities": {
+          "video_evidence": "exact",
+          "audio_evidence": "exact",
+          "codecs_video": [
+            "h264"
+          ],
+          "codecs_video_hardware": [
+            "h264"
+          ],
+          "codecs_audio": [
+            "aac"
+          ],
+          "containers": [
+            "mkv"
+          ],
+          "max_resolution": "1080p",
+          "hdr": false,
+          "video_decode": [
+            {
+              "codec": "h264",
+              "profiles": [
+                "baseline"
+              ],
+              "levels": [
+                52
+              ],
+              "bit_depths": [
+                8
+              ],
+              "max_width": 3840,
+              "max_height": 2160,
+              "max_frame_rate": 60,
+              "max_bitrate_kbps": 20000,
+              "hardware": true
+            }
+          ]
+        },
+        "client_playback_context": {
+          "protocol_version": 3,
+          "form_factor": "tv",
+          "app_version": "3.0-test",
+          "device": {
+            "platform": "fixture"
+          },
+          "output": {
+            "output_context_id": "output-a"
+          },
+          "deliveries": {
+            "hls": {
+              "enabled": true,
+              "supported_on_device": true,
+              "containers": [
+                "hls"
+              ],
+              "video_codecs": [
+                "hevc",
+                "h264"
+              ],
+              "audio_decode_codecs": [
+                "aac"
+              ],
+              "audio_passthrough_codecs": [],
+              "subtitles": {
+                "embedded_text": false,
+                "sidecar_text": false,
+                "ass_styling": false,
+                "embedded_bitmap": false,
+                "sidecar_bitmap": false,
+                "font_attachments": false
+              },
+              "features": [],
+              "auth_header_refresh": false,
+              "validated_claims": [],
+              "transformations": []
+            },
+            "original_http": {
+              "enabled": true,
+              "supported_on_device": true,
+              "containers": [
+                "mkv",
+                "mp4"
+              ],
+              "video_codecs": [
+                "hevc",
+                "h264"
+              ],
+              "audio_decode_codecs": [
+                "aac"
+              ],
+              "audio_passthrough_codecs": [],
+              "subtitles": {
+                "embedded_text": false,
+                "sidecar_text": false,
+                "ass_styling": false,
+                "embedded_bitmap": false,
+                "sidecar_bitmap": false,
+                "font_attachments": false
+              },
+              "features": [],
+              "auth_header_refresh": false,
+              "validated_claims": [],
+              "transformations": []
+            },
+            "progressive": {
+              "enabled": true,
+              "supported_on_device": true,
+              "containers": [
+                "mp4"
+              ],
+              "video_codecs": [
+                "hevc",
+                "h264"
+              ],
+              "audio_decode_codecs": [
+                "aac"
+              ],
+              "audio_passthrough_codecs": [],
+              "subtitles": {
+                "embedded_text": false,
+                "sidecar_text": false,
+                "ass_styling": false,
+                "embedded_bitmap": false,
+                "sidecar_bitmap": false,
+                "font_attachments": false
+              },
+              "features": [],
+              "auth_header_refresh": false,
+              "validated_claims": [],
+              "transformations": []
+            }
+          }
+        }
+      },
+      "source": {
+        "media_file_id": 42,
+        "duration_seconds": 7200,
+        "container": "mkv",
+        "video_codec": "h264",
+        "video_profile": "constrained baseline",
+        "video_level": 41,
+        "bit_depth": 8,
+        "width": 1920,
+        "height": 1080,
+        "frame_rate": 23.976023976023978,
+        "bitrate_kbps": 8000,
+        "dynamic_range": "sdr",
+        "hdr10_plus": false,
+        "dv_enhancement_layer": "none",
+        "audio_codec": "aac",
+        "audio_channels": 2,
+        "audio_layout": "stereo"
+      },
+      "expected": {
+        "outcome": "playable",
+        "delivery": "original_http",
+        "decision_reason": "validated_original_playback",
+        "plan_id": "plan:ea7ae9cecded71f3a86ec20a152c8778",
+        "plan_attempt_key": "v3:706f66227a5cae0b",
+        "selected_tracks": {
+          "audio": {
+            "id": "file:42:audio:0",
+            "index": 0
+          }
+        },
+        "subtitle": {
+          "mode": "off",
+          "inventory": []
+        },
+        "claims": {
+          "video": {
+            "hdr10": false,
+            "hdr10_plus": false,
+            "hlg": false,
+            "dolby_vision": false
+          },
+          "audio": {
+            "codec": "aac",
+            "passthrough": false,
+            "atmos_preserved": false,
+            "reason": "client_decode_supported"
+          },
+          "subtitles": {
+            "ass_styling_preserved": false,
+            "bitmap_overlay": false,
+            "bitmap_sidecar": false
+          }
+        },
+        "available_qualities": [
+          {
+            "label": "original",
+            "height": 1080,
+            "bitrate_kbps": 8000,
+            "preserves_source": true
+          }
+        ]
+      }
+    },
+    {
       "name": "delivery_original",
       "category": "deliveries_negotiation",
       "request": {


### PR DESCRIPTION
## Summary

- accept H.264 Constrained Baseline sources when an exact-evidence decoder reports Baseline support
- keep compatibility directional and preserve strict matching for unrelated codecs and profiles
- document the profile rule and publish a protected cross-client conformance scenario
- cover server-level and per-user-transcoding-disabled playback paths

## Problem

A confirmed production playback attempt reported exact H.264 hardware support for Baseline, Main, High, and High 10, while ffprobe identified the source as Constrained Baseline. The protocol-v3 planner compared profile strings literally, rejected direct playback, selected a full HLS video transcode, and then returned `adaptation_unavailable/transcoding_disabled` because video transcoding was disabled for the user.

Constrained Baseline is a restricted subset of Baseline, so this source should use validated original playback without consuming video-transcode entitlement.

Scope source: confirmed production incident; no matching public GitHub issue was found.

Related issue: N/A — narrow fix

## Approach

The exact-evidence profile predicate now:

- normalizes presentation-only H.264 separators (whitespace, `-`, `_`, `.`, and `:` — the colon covers ffprobe's `High 4:2:2` / `High 4:4:4` family spellings)
- accepts Constrained Baseline source → Baseline decoder
- deliberately rejects the reverse direction
- preserves unknown punctuation and does not infer compatibility among Baseline, Main, High, High 10, or unknown profiles
- retains the prior trimmed, case-insensitive equality behavior for non-H.264 codecs

No API shape, schema, migration, planner flow, handler flow, or protocol-version change is included.

## Compatibility surfaces

- **jellycompat**: considered and deliberately left unchanged. The Jellyfin `VideoProfile` device-profile condition keeps literal token matching, which mirrors upstream Jellyfin's own condition evaluation; mainstream Jellyfin clients (jellyfin-web and derivatives) list `constrained baseline` explicitly in their H.264 conditions, so they are unaffected. Teaching jellycompat a Baseline ⊇ Constrained Baseline rule would diverge from Jellyfin-faithful behavior and can be revisited if a real client reports the gap.
- **silo-apple / silo-android**: no client change needed — clients already send `video_decode` capability profiles unchanged; this PR only widens what the server validates against them.

## Verification

```text
$ go test ./internal/playback -run 'Test.*(VideoProfile|ConstrainedBaseline)|TestProtocolV3ConformanceMatrixCoversReleaseTrain' -count=1
ok github.com/Silo-Server/silo-server/internal/playback

$ CGO_LDFLAGS='-L/opt/homebrew/opt/glib/lib' go test ./internal/api/handlers -run 'TestHandleStartPlaybackV3.*ConstrainedBaseline' -count=1
ok github.com/Silo-Server/silo-server/internal/api/handlers

$ make verify-playback-fixtures
playback fixtures are current

$ go test ./internal/playback -skip 'Test(ResolveHWAccelWithFFmpeg|FFmpegSupportsNVENC)'
ok github.com/Silo-Server/silo-server/internal/playback

$ CGO_LDFLAGS='-L/opt/homebrew/opt/glib/lib' golangci-lint run --new-from-rev=origin/main
0 issues.

$ make verify-local-paths
scripts/check-local-path-leaks.sh
```

The complete handler suite also passed. The repository-wide `make test-go` remains non-green on this macOS host because four existing GPU-probe tests select/kill host NVENC/QSV probes and two existing Jellyfin web-operation process-lock tests fail. Full `make lint` reports the repository's documented whole-tree backlog; changed-lines lint is clean.

## Risk and rollout

The compatibility expansion is limited to exact-evidence H.264 profile matching and protected by directional, malformed-punctuation, unsupported-profile, non-H.264, High 10, planner, handler, and generated conformance tests. Rollout requires no migration or feature flag. Verify affected playback decisions log `original_http`, `direct`, and `validated_original_playback`.

### AI Disclosure
- Tool(s): Codex desktop
- Model(s): gpt-5, gpt-5.6-sol
- Involvement: fully AI-generated
- Adversarial review: the first review found overbroad punctuation stripping and an unprotected generated conformance scenario. Normalization was restricted to the intended separators, malformed punctuation regressions were added, and the release-train test now requires and validates the scenario. A second full-diff review reported no findings.

### Maintainer update (2026-08-27)

Rebased onto current `main` (post software-decode negotiation, tone mapping, and quality-ladder work) and refreshed by a maintainer-side review pass (Claude Code / Claude Fable 5):

- Resolved the `protocol_v3_test.go` scenario→delivery map conflict as the union of both sides; an adversarial diff review against `main` confirmed no scenario or assertion from either side was dropped, and the single profile-check line in the merged `videoEligibleV3` means the fix now covers software-decode capability entries as well as hardware ones.
- Regenerated and verified the conformance matrix against the merged fixture generator (`make verify-playback-fixtures` passes).
- Added `:` to the stripped H.264 presentation separators so ffprobe's `High 4:2:2` / `High 4:4:4 Predictive` spellings match compact decoder spellings (e.g. `high422`), matching the documented "ignores presentation separators" rule; verified canonicalization keeps all fifteen ffmpeg H.264 profile names distinct. Two new test cases cover the colon variants.
- Re-ran the playback suite (minus host GPU probes), the `TestHandleStartPlaybackV3` handler tests, `gofmt`, `make verify-local-paths`, and changed-lines `golangci-lint` (only finding: the pre-existing `web/dist` embed typecheck on unbuilt worktrees) — all clean.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved H.264 profile compatibility matching, including support for Constrained Baseline media on Baseline-capable devices.
  - Enabled direct playback without video transcoding when compatible decoder support is advertised.
  - Preserved original HTTP delivery and media quality for eligible H.264 content.

- **Tests**
  - Added coverage for profile normalization, compatibility decisions, and direct-playback scenarios.
  - Added conformance validation for constrained-baseline H.264 playback across supported device capabilities.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
