### PR TITLE
fix(playback): restore V3 subtitle timing and stability

### DIFF
--- a/docs/architecture/playback-protocol-v3.md
+++ b/docs/architecture/playback-protocol-v3.md
@@ -451,17 +451,19 @@ position, `can_seek_anywhere` is true when the runtime is known, and
 `seek_restoration` is `player_position` — the client seeks locally.
 
 **Copy remux over HLS** is served from FFmpeg's live, still-growing playlist,
-which starts at the requested position. So `player_start` is `0`,
-`stream_origin` and `timeline_offset` both equal the seek position,
-`seek_window_start_seconds` is that position, and **`seek_window_end_seconds` is
-deliberately absent**. An open end marks the window as incomplete; combined with
-`can_seek_anywhere: false` it routes every seek back through the server as a
-reanchor (§6), which is correct because the playlist has no bytes for positions
-FFmpeg has not reached yet. `seek_restoration` is `source_position`.
+which starts at the preceding keyframe selected by FFmpeg's input seek.
+`stream_origin` and `timeline_offset` both equal that resolved source position,
+while `player_start` is the requested position minus the resolved origin so the
+client advances past copied pre-roll. `seek_window_start_seconds` is the resolved
+origin, and **`seek_window_end_seconds` is deliberately absent**. An open end
+marks the window as incomplete; combined with `can_seek_anywhere: false` it
+routes every seek back through the server as a reanchor (§6), which is correct
+because the playlist has no bytes for positions FFmpeg has not reached yet.
+`seek_restoration` is `source_position`.
 
 **Progressive remux** is a freshly generated chunked response with no byte-range
-support, so it behaves the same way: player-zero is stream-zero is the seek
-position, the window is open-ended, and seeks go through the server.
+support, so it uses the same resolved keyframe origin and player pre-roll offset;
+the window is open-ended and seeks go through the server.
 
 ### `source.duration_seconds`
 

--- a/internal/api/handlers/playback.go
+++ b/internal/api/handlers/playback.go
@@ -133,6 +133,14 @@ type PlaybackOriginalLanguageLookup interface {
 	GetOriginalLanguage(ctx context.Context, contentID string) (string, error)
 }
 
+type copySeekAnchorResolver func(
+	ctx context.Context,
+	ffmpegPath string,
+	inputPath string,
+	requestedSeekSeconds float64,
+	segmentDuration int,
+) (float64, int, error)
+
 // PlaybackHandler handles playback session HTTP endpoints.
 type PlaybackHandler struct {
 	sessionMgr              SessionManagerInterface
@@ -175,6 +183,7 @@ type PlaybackHandler struct {
 	// playbackConfig(), which falls back to defaults when unset.
 	PlaybackConfig    func() config.PlaybackConfig
 	FFmpegLogSink     playback.FFmpegLogSink
+	copySeekAnchor    copySeekAnchorResolver
 	realtimeCommandMu sync.Mutex
 	realtimeCommands  map[string]playbackCommandRecord
 	// tm owns the transcode-session lifecycle (live map, recipe cards, and

--- a/internal/api/handlers/playback_v3.go
+++ b/internal/api/handlers/playback_v3.go
@@ -31,16 +31,17 @@ import (
 )
 
 const (
-	maxPlaybackV3BodyBytes      = 256 << 10
-	maxPlaybackV3EventBodyBytes = 32 << 10
-	replanLeaseDurationV3       = 15 * time.Second
-	replanReleaseTimeoutV3      = 3 * time.Second
-	v3NodeCapabilityTTL         = time.Minute
-	playbackNodeIntegratedV3    = "integrated"
-	subtitleFormatVTTV3         = "vtt"
-	subtitleMIMEVTTV3           = "text/vtt"
-	subtitleUnavailableReasonV3 = "subtitle_artifact_unavailable"
-	seekRestorationPlayerV3     = "player_position"
+	maxPlaybackV3BodyBytes       = 256 << 10
+	maxPlaybackV3EventBodyBytes  = 32 << 10
+	replanLeaseDurationV3        = 15 * time.Second
+	replanReleaseTimeoutV3       = 3 * time.Second
+	v3NodeCapabilityTTL          = time.Minute
+	playbackNodeIntegratedV3     = "integrated"
+	subtitleFormatVTTV3          = "vtt"
+	subtitleMIMEVTTV3            = "text/vtt"
+	subtitleUnavailableReasonV3  = "subtitle_artifact_unavailable"
+	transcodeStartFailedReasonV3 = "transcode_start_failed"
+	seekRestorationPlayerV3      = "player_position"
 	// Failed capability fetches are memoized briefly so an unreachable node
 	// costs one timeout per window instead of one per planning request.
 	v3NodeCapabilityErrorTTL = 15 * time.Second
@@ -66,6 +67,13 @@ type preparedTransportV3 struct {
 	rollback           func()
 	applySession       func() (func() error, error)
 	afterDurableCommit func()
+}
+
+type preparedTimelineV3 struct {
+	seekSeconds            float64
+	streamOriginSeconds    float64
+	startSegmentNumber     int
+	copySeekAnchorResolved bool
 }
 
 type transportErrorV3 struct {
@@ -633,8 +641,12 @@ func (h *PlaybackHandler) persistSeriesSelectionsV3(ctx context.Context, userID 
 }
 
 func (h *PlaybackHandler) prepareTransportV3(r *http.Request, session *playback.Session, file *models.MediaFile, result playback.PlannerResultV3) (preparedTransportV3, *transportErrorV3) {
+	timeline, timelineErr := h.prepareTransportTimelineV3(r.Context(), session, file, result)
+	if timelineErr != nil {
+		return preparedTransportV3{}, timelineErr
+	}
 	if result.Plan.Delivery != playback.DeliveryTranscodeHLSV3 && result.Plan.Delivery != playback.DeliveryRemuxHLSV3 {
-		return h.prepareIdentityTransportV3(session, result), nil
+		return h.prepareIdentityTransportV3(session, result, timeline), nil
 	}
 	if h.NodePlanner != nil {
 		plan := h.planNodeSessionV3(r.Context(), session, result)
@@ -644,7 +656,7 @@ func (h *PlaybackHandler) prepareTransportV3(r *http.Request, session *playback.
 				err = validateAdvertisedTransformationsV3(result.Plan, transformations)
 			}
 			if err == nil {
-				transport, transportErr := h.prepareRemoteTransportV3(r, session, file, result, plan)
+				transport, transportErr := h.prepareRemoteTransportV3(r, session, file, result, plan, timeline)
 				if transportErr != nil {
 					if releaser, ok := h.NodePlanner.(sessionReservationReleaserV3); ok {
 						releaser.ReleaseSession(session.ID)
@@ -674,7 +686,47 @@ func (h *PlaybackHandler) prepareTransportV3(r *http.Request, session *playback.
 			return preparedTransportV3{}, &transportErrorV3{reason: "transcode_node_capability_unavailable", message: "No available transcode executor can run the selected playback recipe.", retryable: true, cause: err}
 		}
 	}
-	return h.prepareLocalTransportV3(r, session, file, result)
+	return h.prepareLocalTransportV3(r, session, file, result, timeline)
+}
+
+func (h *PlaybackHandler) prepareTransportTimelineV3(ctx context.Context, session *playback.Session, file *models.MediaFile, result playback.PlannerResultV3) (preparedTimelineV3, *transportErrorV3) {
+	if result.Plan == nil {
+		return preparedTimelineV3{}, nil
+	}
+
+	requested := result.Plan.Timeline.SourceStartSeconds
+	switch result.Plan.Delivery {
+	case playback.DeliveryRemuxProgressiveV3, playback.DeliveryRemuxHLSV3:
+		origin, startSegment := 0.0, 0
+		if requested > 0 {
+			if file == nil || strings.TrimSpace(file.FilePath) == "" {
+				return preparedTimelineV3{}, &transportErrorV3{reason: transcodeStartFailedReasonV3, message: "Failed to resolve remux seek position.", retryable: true, cause: errors.New("copy seek anchor requires a media file path")}
+			}
+			resolver := h.copySeekAnchor
+			if resolver == nil {
+				resolver = playback.ResolveCopySeekAnchor
+			}
+			var err error
+			origin, startSegment, err = resolver(ctx, h.playbackConfig().FFmpegPath, file.FilePath, requested, 2)
+			if err != nil {
+				slog.ErrorContext(ctx, "failed to resolve protocol v3 copy-video seek anchor",
+					"component", "api",
+					"playback_session_id", session.ID,
+					"requested_seek_seconds", requested,
+					"error", err,
+				)
+				return preparedTimelineV3{}, &transportErrorV3{reason: transcodeStartFailedReasonV3, message: "Failed to resolve remux seek position.", retryable: true, cause: err}
+			}
+		}
+		configureCopyRemuxTimelineV3(result.Plan, origin)
+		return preparedTimelineV3{seekSeconds: requested, streamOriginSeconds: origin, startSegmentNumber: startSegment, copySeekAnchorResolved: true}, nil
+	case playback.DeliveryTranscodeHLSV3:
+		sourceMetadata := sourceExecutionMetadataV3(file, result)
+		seekSeconds, startSegment := configureHLSTimelineV3(result.Plan, result.TargetVideoCodec, 2, sourceMetadata.DurationSeconds)
+		return preparedTimelineV3{seekSeconds: seekSeconds, streamOriginSeconds: result.Plan.Timeline.StreamOriginSeconds, startSegmentNumber: startSegment}, nil
+	default:
+		return preparedTimelineV3{}, nil
+	}
 }
 
 // planRequiresServerTransformationsV3 reports whether the plan carries any
@@ -692,7 +744,7 @@ func planRequiresServerTransformationsV3(plan *playback.PlanV3) bool {
 	return false
 }
 
-func (h *PlaybackHandler) prepareIdentityTransportV3(session *playback.Session, result playback.PlannerResultV3) preparedTransportV3 {
+func (h *PlaybackHandler) prepareIdentityTransportV3(session *playback.Session, result playback.PlannerResultV3, timeline preparedTimelineV3) preparedTransportV3 {
 	routeSession := *session
 	routeSession.PlayMethod = result.PlayMethod
 	routeSession.BasePlayMethod = result.PlayMethod
@@ -709,8 +761,7 @@ func (h *PlaybackHandler) prepareIdentityTransportV3(session *playback.Session, 
 	committed := false
 	streamURL := h.playbackStreamURL(&routeSession)
 	if result.Plan != nil && result.Plan.Delivery == playback.DeliveryRemuxProgressiveV3 {
-		configureProgressiveRemuxTimelineV3(result.Plan)
-		if seek := result.Plan.Timeline.StreamOriginSeconds; seek > 0 {
+		if seek := timeline.seekSeconds; seek > 0 {
 			streamURL = appendPlaybackQueryV3(streamURL, "seek", strconv.FormatFloat(seek, 'f', -1, 64))
 		}
 	}
@@ -849,16 +900,16 @@ func (h *PlaybackHandler) resumePositionV3(ctx context.Context, userID int, prof
 	return &position, nil
 }
 
-// A progressive remux is a freshly generated, chunked MP4 response and does
-// not implement byte ranges. Its player clock therefore begins at zero at the
-// requested source origin, and arbitrary seeks must request another server
-// reanchor rather than issuing a Range request against the remux pipe.
-func configureProgressiveRemuxTimelineV3(plan *playback.PlanV3) {
+// A copy remux starts at the preceding keyframe selected by the demuxer, not
+// necessarily at the requested source position. Its player clock therefore
+// begins at the resolved stream origin and advances through the copied pre-roll
+// before reaching the requested position. Neither progressive nor growing HLS
+// copy transports can seek arbitrarily inside their current response.
+func configureCopyRemuxTimelineV3(plan *playback.PlanV3, origin float64) {
 	if plan == nil {
 		return
 	}
-	origin := plan.Timeline.SourceStartSeconds
-	plan.Timeline.PlayerStartSeconds = 0
+	plan.Timeline.PlayerStartSeconds = max(0, plan.Timeline.SourceStartSeconds-origin)
 	plan.Timeline.StreamOriginSeconds = origin
 	plan.Timeline.TimelineOffsetSeconds = origin
 	plan.Timeline.SeekWindowStartSeconds = &origin
@@ -875,7 +926,7 @@ func appendPlaybackQueryV3(rawURL, key, value string) string {
 	return rawURL + separator + key + "=" + value
 }
 
-func (h *PlaybackHandler) prepareLocalTransportV3(r *http.Request, session *playback.Session, file *models.MediaFile, result playback.PlannerResultV3) (preparedTransportV3, *transportErrorV3) {
+func (h *PlaybackHandler) prepareLocalTransportV3(r *http.Request, session *playback.Session, file *models.MediaFile, result playback.PlannerResultV3, timeline preparedTimelineV3) (preparedTransportV3, *transportErrorV3) {
 	cfg := h.playbackConfig()
 	if err := os.MkdirAll(cfg.TranscodeDir, 0o755); err != nil {
 		return preparedTransportV3{}, &transportErrorV3{reason: "internal_error", message: "Failed to prepare the transcode directory.", cause: err}
@@ -888,13 +939,12 @@ func (h *PlaybackHandler) prepareLocalTransportV3(r *http.Request, session *play
 	}
 	sourceMetadata := sourceExecutionMetadataV3(file, result)
 	sourceProfile, sourceBitDepth := sourceVideoTranscodeFactsV3(file, result)
-	seekSeconds, startSegment := configureHLSTimelineV3(result.Plan, videoCodec, 2, sourceMetadata.DurationSeconds)
 	unlock := h.tm.LockSessionLifecycle(session.ID)
-	opts := playback.TranscodeOpts{InputPath: file.FilePath, OutputDir: outputDir, OutputSubdir: outputSubdir, SessionID: session.ID, SourceVideoCodec: sourceMetadata.VideoCodec, SourceVideoProfile: sourceProfile, SourceVideoBitDepth: sourceBitDepth, SoftwareVideoDecode: sourceMetadata.SoftwareVideoDecode, VideoBitstreamFilter: videoBitstreamFilterForPlanV3(result.Plan), SeekSeconds: seekSeconds, StartSegmentNumber: startSegment, TargetResolution: result.TargetResolution, TargetCodecVideo: videoCodec, TargetCodecAudio: result.TargetAudioCodec, TargetAudioChannels: result.TargetAudioChannels, TargetAudioBitrateKbps: result.TargetAudioBitrateKbps, TargetBitrateKbps: result.TargetBitrateKbps, SegmentDuration: 2, FFmpegPath: cfg.FFmpegPath, HWAccel: cfg.HWAccel, HWDevice: cfg.HWDevice, AudioTrackIndex: plannedAudioTrackIndexV3(result, session.AudioTrackIndex), SubtitleTrackIndex: result.SubtitleTransportTrackIndex, SubtitleBurnIn: result.SubtitleBurnIn, SubtitleCodec: result.SubtitleCodec, TotalDuration: sourceMetadata.DurationSeconds, FastStart: true, NodeType: playbackNodeIntegratedV3, ExecutionMode: playbackNodeIntegratedV3, FFmpegLogSink: h.FFmpegLogSink}
+	opts := playback.TranscodeOpts{InputPath: file.FilePath, OutputDir: outputDir, OutputSubdir: outputSubdir, SessionID: session.ID, SourceVideoCodec: sourceMetadata.VideoCodec, SourceVideoProfile: sourceProfile, SourceVideoBitDepth: sourceBitDepth, SoftwareVideoDecode: sourceMetadata.SoftwareVideoDecode, VideoBitstreamFilter: videoBitstreamFilterForPlanV3(result.Plan), SeekSeconds: timeline.seekSeconds, StreamOriginSeconds: timeline.streamOriginSeconds, CopySeekAnchorResolved: timeline.copySeekAnchorResolved, StartSegmentNumber: timeline.startSegmentNumber, TargetResolution: result.TargetResolution, TargetCodecVideo: videoCodec, TargetCodecAudio: result.TargetAudioCodec, TargetAudioChannels: result.TargetAudioChannels, TargetAudioBitrateKbps: result.TargetAudioBitrateKbps, TargetBitrateKbps: result.TargetBitrateKbps, SegmentDuration: 2, FFmpegPath: cfg.FFmpegPath, HWAccel: cfg.HWAccel, HWDevice: cfg.HWDevice, AudioTrackIndex: plannedAudioTrackIndexV3(result, session.AudioTrackIndex), SubtitleTrackIndex: result.SubtitleTransportTrackIndex, SubtitleBurnIn: result.SubtitleBurnIn, SubtitleCodec: result.SubtitleCodec, TotalDuration: sourceMetadata.DurationSeconds, FastStart: true, NodeType: playbackNodeIntegratedV3, ExecutionMode: playbackNodeIntegratedV3, FFmpegLogSink: h.FFmpegLogSink}
 	ts, err := h.startLocalPlaybackTransport(r.Context(), opts)
 	if err != nil {
 		unlock()
-		return preparedTransportV3{}, &transportErrorV3{reason: "transcode_start_failed", message: "Failed to start the playback transport.", retryable: true, cause: err}
+		return preparedTransportV3{}, &transportErrorV3{reason: transcodeStartFailedReasonV3, message: "Failed to start the playback transport.", retryable: true, cause: err}
 	}
 	if _, readyErr := ts.WaitForManifest(playback.ManifestStartupTimeout); readyErr != nil {
 		wasRunning := ts.IsRunning()
@@ -921,7 +971,7 @@ func (h *PlaybackHandler) prepareLocalTransportV3(r *http.Request, session *play
 		ts, err = h.startLocalPlaybackTransport(r.Context(), retryOpts)
 		if err != nil {
 			unlock()
-			return preparedTransportV3{}, &transportErrorV3{reason: "transcode_start_failed", message: "Failed to start the playback transport.", retryable: true, cause: err}
+			return preparedTransportV3{}, &transportErrorV3{reason: transcodeStartFailedReasonV3, message: "Failed to start the playback transport.", retryable: true, cause: err}
 		}
 		if _, retryReadyErr := ts.WaitForManifest(playback.ManifestStartupTimeout); retryReadyErr != nil {
 			transportErr = manifestStartupTransportErrorV3(ts.IsRunning(), retryReadyErr)
@@ -973,10 +1023,10 @@ func manifestStartupTransportErrorV3(running bool, cause error) *transportErrorV
 	if running {
 		message = "The playback transport did not become ready in time."
 	}
-	return &transportErrorV3{reason: "transcode_start_failed", message: message, retryable: running, cause: cause}
+	return &transportErrorV3{reason: transcodeStartFailedReasonV3, message: message, retryable: running, cause: cause}
 }
 
-func (h *PlaybackHandler) prepareRemoteTransportV3(r *http.Request, session *playback.Session, file *models.MediaFile, result playback.PlannerResultV3, nodePlan nodepool.Plan) (preparedTransportV3, *transportErrorV3) {
+func (h *PlaybackHandler) prepareRemoteTransportV3(r *http.Request, session *playback.Session, file *models.MediaFile, result playback.PlannerResultV3, nodePlan nodepool.Plan, timeline preparedTimelineV3) (preparedTransportV3, *transportErrorV3) {
 	node := nodePlan.TranscodeNode
 	transportID := transportGenerationV3(session.ID, result.Plan.PlanID)
 	videoCodec := result.TargetVideoCodec
@@ -985,8 +1035,7 @@ func (h *PlaybackHandler) prepareRemoteTransportV3(r *http.Request, session *pla
 	}
 	sourceMetadata := sourceExecutionMetadataV3(file, result)
 	sourceProfile, sourceBitDepth := sourceVideoTranscodeFactsV3(file, result)
-	seekSeconds, startSegment := configureHLSTimelineV3(result.Plan, videoCodec, 2, sourceMetadata.DurationSeconds)
-	req := transcodenode.TranscodeStartRequest{SessionID: transportID, InputPath: file.FilePath, SourceVideoCodec: sourceMetadata.VideoCodec, SourceVideoProfile: sourceProfile, SourceVideoBitDepth: sourceBitDepth, SoftwareVideoDecode: sourceMetadata.SoftwareVideoDecode, VideoBitstreamFilter: videoBitstreamFilterForPlanV3(result.Plan), SeekSeconds: seekSeconds, StartSegmentNumber: startSegment, TargetResolution: result.TargetResolution, TargetCodecVideo: videoCodec, TargetCodecAudio: result.TargetAudioCodec, TargetAudioChannels: result.TargetAudioChannels, TargetAudioBitrateKbps: result.TargetAudioBitrateKbps, TargetBitrateKbps: result.TargetBitrateKbps, SegmentDuration: 2, HWAccel: h.playbackConfig().HWAccel, AudioTrackIndex: plannedAudioTrackIndexV3(result, session.AudioTrackIndex), SubtitleTrackIndex: result.SubtitleTransportTrackIndex, SubtitleBurnIn: result.SubtitleBurnIn, SubtitleCodec: result.SubtitleCodec, TotalDuration: sourceMetadata.DurationSeconds, RequireReady: true}
+	req := transcodenode.TranscodeStartRequest{SessionID: transportID, InputPath: file.FilePath, SourceVideoCodec: sourceMetadata.VideoCodec, SourceVideoProfile: sourceProfile, SourceVideoBitDepth: sourceBitDepth, SoftwareVideoDecode: sourceMetadata.SoftwareVideoDecode, VideoBitstreamFilter: videoBitstreamFilterForPlanV3(result.Plan), SeekSeconds: timeline.seekSeconds, StreamOriginSeconds: timeline.streamOriginSeconds, CopySeekAnchorResolved: timeline.copySeekAnchorResolved, StartSegmentNumber: timeline.startSegmentNumber, TargetResolution: result.TargetResolution, TargetCodecVideo: videoCodec, TargetCodecAudio: result.TargetAudioCodec, TargetAudioChannels: result.TargetAudioChannels, TargetAudioBitrateKbps: result.TargetAudioBitrateKbps, TargetBitrateKbps: result.TargetBitrateKbps, SegmentDuration: 2, HWAccel: h.playbackConfig().HWAccel, AudioTrackIndex: plannedAudioTrackIndexV3(result, session.AudioTrackIndex), SubtitleTrackIndex: result.SubtitleTransportTrackIndex, SubtitleBurnIn: result.SubtitleBurnIn, SubtitleCodec: result.SubtitleCodec, TotalDuration: sourceMetadata.DurationSeconds, RequireReady: true}
 	nodeResp, status, err := h.startRemotePlaybackTransport(r.Context(), node.URL, req)
 	if err != nil {
 		// A timeout can fire after the node actually started the job; the
@@ -997,10 +1046,10 @@ func (h *PlaybackHandler) prepareRemoteTransportV3(r *http.Request, session *pla
 	}
 	if status != http.StatusAccepted {
 		h.tm.StopRemoteTranscode(transportID, node.URL)
-		return preparedTransportV3{}, &transportErrorV3{reason: "transcode_start_failed", message: "The selected transcode node rejected the playback transport.", retryable: true}
+		return preparedTransportV3{}, &transportErrorV3{reason: transcodeStartFailedReasonV3, message: "The selected transcode node rejected the playback transport.", retryable: true}
 	}
 	hw := firstNonEmptyHandlerV3(strings.TrimSpace(nodeResp.HWAccel), strings.TrimSpace(req.HWAccel))
-	card := playback.NewRecipeCard(session.UserID, session.ProfileID, file.ID, node.URL, playback.TranscodeOpts{InputPath: req.InputPath, SessionID: session.ID, TranscodeTransportID: transportID, SourceVideoCodec: req.SourceVideoCodec, SourceVideoProfile: req.SourceVideoProfile, SourceVideoBitDepth: req.SourceVideoBitDepth, SoftwareVideoDecode: req.SoftwareVideoDecode, VideoBitstreamFilter: req.VideoBitstreamFilter, SeekSeconds: req.SeekSeconds, StartSegmentNumber: req.StartSegmentNumber, TargetResolution: req.TargetResolution, TargetCodecVideo: req.TargetCodecVideo, TargetCodecAudio: req.TargetCodecAudio, TargetAudioChannels: req.TargetAudioChannels, TargetAudioBitrateKbps: req.TargetAudioBitrateKbps, TargetBitrateKbps: req.TargetBitrateKbps, SegmentDuration: req.SegmentDuration, HWAccel: hw, AudioTrackIndex: req.AudioTrackIndex, SubtitleTrackIndex: req.SubtitleTrackIndex, SubtitleBurnIn: req.SubtitleBurnIn, SubtitleCodec: req.SubtitleCodec, TotalDuration: req.TotalDuration})
+	card := playback.NewRecipeCard(session.UserID, session.ProfileID, file.ID, node.URL, playback.TranscodeOpts{InputPath: req.InputPath, SessionID: session.ID, TranscodeTransportID: transportID, SourceVideoCodec: req.SourceVideoCodec, SourceVideoProfile: req.SourceVideoProfile, SourceVideoBitDepth: req.SourceVideoBitDepth, SoftwareVideoDecode: req.SoftwareVideoDecode, VideoBitstreamFilter: req.VideoBitstreamFilter, SeekSeconds: req.SeekSeconds, StreamOriginSeconds: req.StreamOriginSeconds, CopySeekAnchorResolved: req.CopySeekAnchorResolved, StartSegmentNumber: req.StartSegmentNumber, TargetResolution: req.TargetResolution, TargetCodecVideo: req.TargetCodecVideo, TargetCodecAudio: req.TargetCodecAudio, TargetAudioChannels: req.TargetAudioChannels, TargetAudioBitrateKbps: req.TargetAudioBitrateKbps, TargetBitrateKbps: req.TargetBitrateKbps, SegmentDuration: req.SegmentDuration, HWAccel: hw, AudioTrackIndex: req.AudioTrackIndex, SubtitleTrackIndex: req.SubtitleTrackIndex, SubtitleBurnIn: req.SubtitleBurnIn, SubtitleCodec: req.SubtitleCodec, TotalDuration: req.TotalDuration})
 	url := h.buildProxyManifestURL(card, nodePlan.ProxyNode)
 	committed := false
 	previousNodeURL := session.TranscodeNodeURL
@@ -2884,12 +2933,12 @@ func configureHLSTimelineV3(plan *playback.PlanV3, videoCodec string, segmentDur
 	seek := alignedSeekSeconds(requested, segmentDuration, videoCodec)
 	startSegment := computeStartSegment(seek, segmentDuration)
 	plan.Timeline.SourceStartSeconds = requested
-	usesGrowingManifest := strings.EqualFold(videoCodec, "copy") ||
-		!playback.CanGenerateSyntheticManifest(durationSeconds, segmentDuration)
+	usesGrowingManifest := !playback.CanGenerateSyntheticManifest(durationSeconds, segmentDuration)
 	if usesGrowingManifest {
 		// Encoded streams seek to the preceding segment boundary. Preserve the
 		// requested sub-segment offset so playback still begins at the exact
-		// requested source position. Copy seeks are already exact, making this 0.
+		// requested source position. Copy remuxes are configured separately with
+		// their probed keyframe origin.
 		plan.Timeline.PlayerStartSeconds = max(0, requested-seek)
 		plan.Timeline.StreamOriginSeconds = seek
 		plan.Timeline.TimelineOffsetSeconds = seek

--- a/internal/api/handlers/playback_v3.go
+++ b/internal/api/handlers/playback_v3.go
@@ -697,6 +697,12 @@ func (h *PlaybackHandler) prepareTransportTimelineV3(ctx context.Context, sessio
 	requested := result.Plan.Timeline.SourceStartSeconds
 	switch result.Plan.Delivery {
 	case playback.DeliveryRemuxProgressiveV3, playback.DeliveryRemuxHLSV3:
+		// Audio-only remuxes have no copied video keyframe to resolve. Keep the
+		// planner's progressive audio timeline and pass the requested input seek
+		// through to the remux transport unchanged.
+		if file != nil && file.IsAudioOnly() {
+			return preparedTimelineV3{seekSeconds: requested, streamOriginSeconds: result.Plan.Timeline.StreamOriginSeconds}, nil
+		}
 		origin, startSegment := 0.0, 0
 		if requested > 0 {
 			if file == nil || strings.TrimSpace(file.FilePath) == "" {

--- a/internal/api/handlers/playback_v3.go
+++ b/internal/api/handlers/playback_v3.go
@@ -698,10 +698,11 @@ func (h *PlaybackHandler) prepareTransportTimelineV3(ctx context.Context, sessio
 	switch result.Plan.Delivery {
 	case playback.DeliveryRemuxProgressiveV3, playback.DeliveryRemuxHLSV3:
 		// Audio-only remuxes have no copied video keyframe to resolve. Keep the
-		// planner's progressive audio timeline and pass the requested input seek
-		// through to the remux transport unchanged.
+		// requested position as their exact stream origin: the chunked output
+		// clock restarts at zero and later seeks require another server reanchor.
 		if file != nil && file.IsAudioOnly() {
-			return preparedTimelineV3{seekSeconds: requested, streamOriginSeconds: result.Plan.Timeline.StreamOriginSeconds}, nil
+			configureCopyRemuxTimelineV3(result.Plan, requested)
+			return preparedTimelineV3{seekSeconds: requested, streamOriginSeconds: requested}, nil
 		}
 		origin, startSegment := 0.0, 0
 		if requested > 0 {

--- a/internal/api/handlers/playback_v3_test.go
+++ b/internal/api/handlers/playback_v3_test.go
@@ -2102,6 +2102,59 @@ func TestPrepareTransportV3ProgressiveRemuxUsesResolvedCopyAnchor(t *testing.T) 
 	}
 }
 
+func TestPrepareTransportV3AudioOnlyRemuxSkipsVideoCopyAnchor(t *testing.T) {
+	handler := NewPlaybackHandler(playback.NewSessionManager(0, 0))
+	handler.JWTSecret = "test-secret"
+	probeCalls := 0
+	handler.copySeekAnchor = func(context.Context, string, string, float64, int) (float64, int, error) {
+		probeCalls++
+		return 0, 0, errors.New("audio-only remux must not probe a video keyframe")
+	}
+	requested := 321.25
+	plan := &playback.PlanV3{
+		PlanID:   "plan:audio-only-progressive",
+		Delivery: playback.DeliveryRemuxProgressiveV3,
+		Timeline: playback.TimelineV3{
+			SourceStartSeconds: requested,
+			PlayerStartSeconds: requested,
+			CanSeekAnywhere:    true,
+			SeekRestoration:    "player_position",
+		},
+	}
+	file := &models.MediaFile{
+		ID:          42,
+		BaseType:    "audiobook",
+		FilePath:    "/media/book.m4b",
+		CodecAudio:  "aac",
+		AudioTracks: []models.AudioTrack{{Codec: "aac", Channels: 2}},
+	}
+	transport, transportErr := handler.prepareTransportV3(
+		httptest.NewRequest(http.MethodPost, "/", nil),
+		&playback.Session{ID: "session-audio-only", MediaFileID: 42},
+		file,
+		playback.PlannerResultV3{Plan: plan, PlayMethod: playback.PlayRemux, TargetAudioCodec: "aac"},
+	)
+	if transportErr != nil {
+		t.Fatalf("prepare audio-only transport: %v", transportErr)
+	}
+	defer transport.rollback()
+	if probeCalls != 0 {
+		t.Fatalf("audio-only copy anchor probes = %d, want 0", probeCalls)
+	}
+	parsed, err := url.Parse(transport.url)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if parsed.Query().Get("seek") != strconv.FormatFloat(requested, 'f', -1, 64) {
+		t.Fatalf("audio-only seek URL = %q", transport.url)
+	}
+	if plan.Timeline.PlayerStartSeconds != requested || !plan.Timeline.CanSeekAnywhere ||
+		plan.Timeline.SeekRestoration != "player_position" || plan.Timeline.StreamOriginSeconds != 0 ||
+		plan.Timeline.TimelineOffsetSeconds != 0 {
+		t.Fatalf("audio-only timeline changed = %#v", plan.Timeline)
+	}
+}
+
 func TestPrepareTransportV3CopyAnchorFailureIsRetryable(t *testing.T) {
 	handler := NewPlaybackHandler(playback.NewSessionManager(0, 0))
 	handler.copySeekAnchor = func(context.Context, string, string, float64, int) (float64, int, error) {

--- a/internal/api/handlers/playback_v3_test.go
+++ b/internal/api/handlers/playback_v3_test.go
@@ -2148,9 +2148,10 @@ func TestPrepareTransportV3AudioOnlyRemuxSkipsVideoCopyAnchor(t *testing.T) {
 	if parsed.Query().Get("seek") != strconv.FormatFloat(requested, 'f', -1, 64) {
 		t.Fatalf("audio-only seek URL = %q", transport.url)
 	}
-	if plan.Timeline.PlayerStartSeconds != requested || !plan.Timeline.CanSeekAnywhere ||
-		plan.Timeline.SeekRestoration != "player_position" || plan.Timeline.StreamOriginSeconds != 0 ||
-		plan.Timeline.TimelineOffsetSeconds != 0 {
+	if plan.Timeline.PlayerStartSeconds != 0 || plan.Timeline.CanSeekAnywhere ||
+		plan.Timeline.SeekRestoration != "source_position" || plan.Timeline.StreamOriginSeconds != requested ||
+		plan.Timeline.TimelineOffsetSeconds != requested || plan.Timeline.SeekWindowStartSeconds == nil ||
+		*plan.Timeline.SeekWindowStartSeconds != requested || plan.Timeline.SeekWindowEndSeconds != nil {
 		t.Fatalf("audio-only timeline changed = %#v", plan.Timeline)
 	}
 }

--- a/internal/api/handlers/playback_v3_test.go
+++ b/internal/api/handlers/playback_v3_test.go
@@ -566,6 +566,7 @@ func TestHandleReplanPlaybackV3UpdatesSelectedAudioAndReplaysIdempotently(t *tes
 	file.AudioTracks = append(file.AudioTracks, models.AudioTrack{Codec: "aac", Channels: 2, Layout: "stereo", Language: "spa"})
 	manager := playback.NewSessionManager(0, 0)
 	handler := NewPlaybackHandler(manager, testPlaybackFileResolver{file: file})
+	stubCopySeekAnchorV3(handler)
 	handler.SettingsRepo = &mutablePlaybackSettingsV3{values: map[string]string{"allow_4k_transcode": "true"}}
 	handler.ItemAccess = allowAllPlaybackItemAccess{}
 	startRequest := v3HandlerStartRequest()
@@ -1186,6 +1187,7 @@ func TestHandleReplanPlaybackV3SeekReanchorPreservesFallbackRecipe(t *testing.T)
 	file := v3HandlerFixtureFile(t)
 	manager := playback.NewSessionManager(0, 0)
 	handler := NewPlaybackHandler(manager, testPlaybackFileResolver{file: file})
+	stubCopySeekAnchorV3(handler)
 	handler.PlaybackConfig = playbackTestConfig(writePlaybackTestFFmpeg(t), t.TempDir())
 	presetLocalRegistryV3(handler, playback.NewTransformationRegistryV3([]playback.TransformationSpecV3{
 		{Name: "audio_to_aac", RecipeVersion: "1", Available: true},
@@ -1269,6 +1271,7 @@ func TestHandleReplanPlaybackV3SeekReanchorWithoutFrozenRecipeFailsRetryably(t *
 	file := v3HandlerFixtureFile(t)
 	manager := playback.NewSessionManager(0, 0)
 	handler := NewPlaybackHandler(manager, testPlaybackFileResolver{file: file})
+	stubCopySeekAnchorV3(handler)
 	handler.SettingsRepo = &mutablePlaybackSettingsV3{values: map[string]string{}}
 	handler.ItemAccess = allowAllPlaybackItemAccess{}
 	startRequest := v3HandlerStartRequest()
@@ -1368,6 +1371,7 @@ func TestHandleReplanPlaybackV3SeekFailureRecoveryNeverChangesMediaVersion(t *te
 		source.ID: source, alternate.ID: alternate,
 	}
 	handler := NewPlaybackHandler(manager, mapPlaybackFileResolver{files: files})
+	stubCopySeekAnchorV3(handler)
 	handler.FileVersionFetcher = testPlaybackFileVersionFetcher{byContent: map[string][]*models.MediaFile{
 		source.ContentID: {source, alternate},
 	}}
@@ -2054,29 +2058,40 @@ func TestFrozenSubtitleIdentityV3RejectsExternalAndEmbeddedInventoryDrift(t *tes
 	}
 }
 
-func TestPrepareIdentityTransportV3ProgressiveRemuxNeverAdvertisesNativeSeek(t *testing.T) {
+func TestPrepareTransportV3ProgressiveRemuxUsesResolvedCopyAnchor(t *testing.T) {
 	handler := NewPlaybackHandler(playback.NewSessionManager(0, 0))
 	handler.JWTSecret = "test-secret"
+	handler.copySeekAnchor = func(_ context.Context, _ string, inputPath string, requested float64, segmentDuration int) (float64, int, error) {
+		if inputPath != "/media/movie.mkv" || segmentDuration != 2 {
+			t.Fatalf("copy seek probe input=%q segment=%d", inputPath, segmentDuration)
+		}
+		return requested - 0.75, int((requested - 0.75) / float64(segmentDuration)), nil
+	}
 	session := &playback.Session{ID: "session-progressive", UserID: 7, ProfileID: "profile-1", MediaFileID: 42, PlayMethod: playback.PlayRemux, BasePlayMethod: playback.PlayRemux, AudioTrackIndex: 0}
-	for index, origin := range []float64{321.25, 654.5} {
+	file := &models.MediaFile{ID: 42, FilePath: "/media/movie.mkv"}
+	for index, requested := range []float64{321.25, 654.5} {
 		plan := &playback.PlanV3{
 			PlanID:               "plan:progressive",
 			Delivery:             playback.DeliveryRemuxProgressiveV3,
 			EffectiveMediaFileID: 42,
-			Timeline:             playback.TimelineV3{SourceStartSeconds: origin, PlayerStartSeconds: origin, CanSeekAnywhere: true, SeekRestoration: "player_position"},
+			Timeline:             playback.TimelineV3{SourceStartSeconds: requested, PlayerStartSeconds: requested, CanSeekAnywhere: true, SeekRestoration: "player_position"},
 		}
-		transport := handler.prepareIdentityTransportV3(session, playback.PlannerResultV3{Plan: plan, PlayMethod: playback.PlayRemux})
+		transport, transportErr := handler.prepareTransportV3(httptest.NewRequest(http.MethodPost, "/", nil), session, file, playback.PlannerResultV3{Plan: plan, PlayMethod: playback.PlayRemux})
+		if transportErr != nil {
+			t.Fatalf("prepare progressive transport: %v", transportErr)
+		}
 
 		parsed, err := url.Parse(transport.url)
 		if err != nil {
 			transport.rollback()
 			t.Fatal(err)
 		}
-		if parsed.Query().Get("st") == "" || parsed.Query().Get("seek") != strconv.FormatFloat(origin, 'f', -1, 64) {
+		if parsed.Query().Get("st") == "" || parsed.Query().Get("seek") != strconv.FormatFloat(requested, 'f', -1, 64) {
 			transport.rollback()
 			t.Fatalf("progressive reanchor URL %d = %q", index, transport.url)
 		}
-		if plan.Timeline.PlayerStartSeconds != 0 || plan.Timeline.StreamOriginSeconds != origin ||
+		origin := requested - 0.75
+		if plan.Timeline.PlayerStartSeconds != 0.75 || plan.Timeline.StreamOriginSeconds != origin ||
 			plan.Timeline.TimelineOffsetSeconds != origin || plan.Timeline.CanSeekAnywhere ||
 			plan.Timeline.SeekWindowStartSeconds == nil || *plan.Timeline.SeekWindowStartSeconds != origin ||
 			plan.Timeline.SeekWindowEndSeconds != nil || plan.Timeline.SeekRestoration != "source_position" {
@@ -2084,6 +2099,23 @@ func TestPrepareIdentityTransportV3ProgressiveRemuxNeverAdvertisesNativeSeek(t *
 			t.Fatalf("progressive reanchor timeline %d = %#v", index, plan.Timeline)
 		}
 		transport.rollback()
+	}
+}
+
+func TestPrepareTransportV3CopyAnchorFailureIsRetryable(t *testing.T) {
+	handler := NewPlaybackHandler(playback.NewSessionManager(0, 0))
+	handler.copySeekAnchor = func(context.Context, string, string, float64, int) (float64, int, error) {
+		return 0, 0, errors.New("probe failed")
+	}
+	plan := &playback.PlanV3{PlanID: "plan:copy-failure", Delivery: playback.DeliveryRemuxHLSV3, Timeline: playback.TimelineV3{SourceStartSeconds: 120}}
+	_, transportErr := handler.prepareTransportV3(
+		httptest.NewRequest(http.MethodPost, "/", nil),
+		&playback.Session{ID: "session-copy-failure"},
+		&models.MediaFile{ID: 42, FilePath: "/media/movie.mkv"},
+		playback.PlannerResultV3{Plan: plan, PlayMethod: playback.PlayRemux},
+	)
+	if transportErr == nil || transportErr.reason != "transcode_start_failed" || !transportErr.retryable || transportErr.cause == nil || transportErr.cause.Error() != "probe failed" {
+		t.Fatalf("transport error = %#v, want retryable copy anchor failure", transportErr)
 	}
 }
 
@@ -2164,6 +2196,52 @@ func TestPrepareTransportV3RequiresRemoteManifestReadiness(t *testing.T) {
 	defer transport.rollback()
 	if !startRequest.RequireReady {
 		t.Fatal("protocol-v3 remote start did not require manifest readiness")
+	}
+}
+
+func TestPrepareTransportV3SendsResolvedCopyAnchorToRemoteExecutor(t *testing.T) {
+	var startRequest transcodenode.TranscodeStartRequest
+	remote := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == http.MethodGet && r.URL.Path == "/hw-capabilities":
+			writeJSON(w, http.StatusOK, playback.HWAccelInfo{})
+		case r.Method == http.MethodPost && r.URL.Path == "/transcode/start":
+			if err := json.NewDecoder(r.Body).Decode(&startRequest); err != nil {
+				t.Errorf("decode remote start: %v", err)
+			}
+			writeJSON(w, http.StatusAccepted, transcodenode.TranscodeStartResponse{SessionID: startRequest.SessionID, Status: "started"})
+		case r.Method == http.MethodDelete:
+			w.WriteHeader(http.StatusNoContent)
+		default:
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	defer remote.Close()
+
+	handler := NewPlaybackHandler(playback.NewSessionManager(0, 0))
+	handler.JWTSecret = "test-secret"
+	handler.NodePlanner = staticNodePlannerV3{plan: nodepool.Plan{TranscodeNode: &nodepool.Node{URL: remote.URL}}}
+	handler.copySeekAnchor = func(context.Context, string, string, float64, int) (float64, int, error) {
+		return 1085.501, 542, nil
+	}
+	plan := &playback.PlanV3{PlanID: "plan:remote-copy-anchor", Delivery: playback.DeliveryRemuxHLSV3, Timeline: playback.TimelineV3{SourceStartSeconds: 1086.2}}
+	transport, transportErr := handler.prepareTransportV3(
+		httptest.NewRequest(http.MethodPost, "/", nil),
+		&playback.Session{ID: "session-remote-copy-anchor", UserID: 7, ProfileID: "profile-1"},
+		&models.MediaFile{ID: 42, FilePath: "/media/movie.mkv", CodecVideo: "h264"},
+		playback.PlannerResultV3{Plan: plan, PlayMethod: playback.PlayRemux, TargetAudioCodec: "aac"},
+	)
+	if transportErr != nil {
+		t.Fatalf("prepare remote copy transport: %v", transportErr)
+	}
+	defer transport.rollback()
+	if startRequest.SeekSeconds != 1086.2 || startRequest.StreamOriginSeconds != 1085.501 ||
+		!startRequest.CopySeekAnchorResolved || startRequest.StartSegmentNumber != 542 {
+		t.Fatalf("remote copy timeline = %#v", startRequest)
+	}
+	if plan.Timeline.StreamOriginSeconds != 1085.501 || plan.Timeline.TimelineOffsetSeconds != 1085.501 ||
+		math.Abs(plan.Timeline.PlayerStartSeconds-0.699) > 0.0001 {
+		t.Fatalf("advertised copy timeline = %#v", plan.Timeline)
 	}
 }
 
@@ -2261,7 +2339,11 @@ func TestPrepareLocalTransportV3ReturnsStableTerminalWhenFFmpegExitsBeforeReady(
 		SubtitleTrackIndex: -1, SubtitleTransportTrackIndex: -1,
 	}
 	request := httptest.NewRequest(http.MethodPost, "/", nil)
-	transport, transportErr := handler.prepareLocalTransportV3(request, &playback.Session{ID: "session-startup-failure", UserID: 7, ProfileID: "profile-1"}, file, result)
+	timeline, timelineErr := handler.prepareTransportTimelineV3(request.Context(), &playback.Session{ID: "session-startup-failure"}, file, result)
+	if timelineErr != nil {
+		t.Fatalf("prepare timeline: %v", timelineErr)
+	}
+	transport, transportErr := handler.prepareLocalTransportV3(request, &playback.Session{ID: "session-startup-failure", UserID: 7, ProfileID: "profile-1"}, file, result, timeline)
 	if transportErr == nil {
 		transport.rollback()
 		t.Fatal("failed ffmpeg startup returned a playable transport")
@@ -2325,12 +2407,12 @@ func TestConfigureHLSTimelineV3MatchesTransportSeekSemantics(t *testing.T) {
 	// locally seekable — sending them past the produced head instead of back
 	// to the server. The runtime belongs on source.duration_seconds.
 	copyPlan := &playback.PlanV3{Timeline: playback.TimelineV3{SourceStartSeconds: 17.3}}
-	copySeek, copySegment := configureHLSTimelineV3(copyPlan, "copy", 2, 600)
-	if copySeek != 17.3 || copySegment != 8 || copyPlan.Timeline.StreamOriginSeconds != 17.3 || copyPlan.Timeline.TimelineOffsetSeconds != 17.3 || copyPlan.Timeline.PlayerStartSeconds != 0 || copyPlan.Timeline.CanSeekAnywhere ||
-		copyPlan.Timeline.SeekWindowStartSeconds == nil || *copyPlan.Timeline.SeekWindowStartSeconds != 17.3 ||
+	configureCopyRemuxTimelineV3(copyPlan, 16)
+	if copyPlan.Timeline.StreamOriginSeconds != 16 || copyPlan.Timeline.TimelineOffsetSeconds != 16 || math.Abs(copyPlan.Timeline.PlayerStartSeconds-1.3) > 0.0001 || copyPlan.Timeline.CanSeekAnywhere ||
+		copyPlan.Timeline.SeekWindowStartSeconds == nil || *copyPlan.Timeline.SeekWindowStartSeconds != 16 ||
 		copyPlan.Timeline.SeekWindowEndSeconds != nil ||
 		copyPlan.Timeline.SeekRestoration != "source_position" {
-		t.Fatalf("copy timeline=%#v seek=%v segment=%d", copyPlan.Timeline, copySeek, copySegment)
+		t.Fatalf("copy timeline=%#v", copyPlan.Timeline)
 	}
 
 	encodePlan := &playback.PlanV3{Timeline: playback.TimelineV3{SourceStartSeconds: 17.3}}
@@ -2532,6 +2614,12 @@ func v3HandlerFixtureFile(t *testing.T) *models.MediaFile {
 	return &models.MediaFile{ID: 42, ContentID: "movie-1", FilePath: writePlaybackTestMediaFile(t, "movie.mp4"), Container: "mp4", CodecVideo: "h264", CodecAudio: "aac", Resolution: "1080p", Bitrate: 8_000, AudioChannels: 2, Duration: 3600, VideoTracks: []models.VideoTrack{{Codec: "h264", Profile: "high", Level: 41, Width: 1920, Height: 1080, FrameRate: "24000/1001", Bitrate: 8_000, BitDepth: 8, VideoRange: "SDR", VideoRangeType: "SDR"}}, AudioTracks: []models.AudioTrack{{Codec: "aac", Channels: 2, Layout: "stereo", Default: true}}}
 }
 
+func stubCopySeekAnchorV3(handler *PlaybackHandler) {
+	handler.copySeekAnchor = func(_ context.Context, _ string, _ string, requested float64, segmentDuration int) (float64, int, error) {
+		return requested, computeStartSegment(requested, segmentDuration), nil
+	}
+}
+
 func v3HandlerStartRequest() playback.StartRequestV3 {
 	return playback.StartRequestV3{ProtocolVersion: playback.ProtocolV3, ClientFeatures: []string{playback.FeaturePlaybackPlanV3}, FileID: 42, ProfileID: "profile-1", PlaybackAttemptID: "attempt-handler-0001", QualityPreference: "original", SubtitleFidelityPreference: playback.SubtitleFidelityCompatibleV3, Capabilities: playback.ClientCodecCapabilitiesV3{VideoEvidence: playback.EvidenceExactV3, AudioEvidence: playback.EvidenceExactV3, CodecsVideo: []string{"h264"}, CodecsVideoHardware: []string{"h264"}, CodecsAudio: []string{"aac"}, Containers: []string{"mp4"}, MaxResolution: "1080p", VideoDecode: []playback.VideoDecodeCapabilityV3{{Codec: "h264", Profiles: []string{"high"}, Levels: []int{41}, BitDepths: []int{8}, MaxWidth: 1920, MaxHeight: 1080, MaxFrameRate: 60, MaxBitrateKbps: 20_000, Hardware: true}}}, ClientPlaybackContext: playback.ClientPlaybackContextV3{ProtocolVersion: playback.ProtocolV3, FormFactor: "tv", AppVersion: "test", Device: playback.DeviceContextV3{Platform: "android"}, Output: playback.OutputContextV3{OutputContextID: "route-1"}, Deliveries: map[string]playback.DeliveryCapabilityV3{playback.DeliveryClassOriginalHTTPV3: {Enabled: true, SupportedOnDevice: true, Subtitles: playback.DeliverySubtitleCapabilitiesV3{EmbeddedText: true, SidecarText: true}}}}}
 }
@@ -2637,6 +2725,7 @@ func TestHandleReplanPlaybackV3TrackChangeStaysOnEffectiveAlternate(t *testing.T
 	files := map[int]*models.MediaFile{source.ID: source, alternate.ID: alternate}
 	manager := playback.NewSessionManager(0, 0)
 	handler := NewPlaybackHandler(manager, mapPlaybackFileResolver{files: files})
+	stubCopySeekAnchorV3(handler)
 	handler.FileVersionFetcher = testPlaybackFileVersionFetcher{byContent: map[string][]*models.MediaFile{source.ContentID: {source, alternate}}}
 	handler.SettingsRepo = &mutablePlaybackSettingsV3{values: map[string]string{"allow_4k_transcode": "false"}}
 	handler.ItemAccess = allowAllPlaybackItemAccess{}
@@ -2683,6 +2772,7 @@ func TestHandleReplanPlaybackV3TrackChangeOperation(t *testing.T) {
 	file.AudioTracks = append(file.AudioTracks, models.AudioTrack{Codec: "aac", Channels: 2, Layout: "stereo", Language: "spa"})
 	manager := playback.NewSessionManager(0, 0)
 	handler := NewPlaybackHandler(manager, testPlaybackFileResolver{file: file})
+	stubCopySeekAnchorV3(handler)
 	handler.SettingsRepo = &mutablePlaybackSettingsV3{values: map[string]string{"allow_4k_transcode": "true"}}
 	handler.ItemAccess = allowAllPlaybackItemAccess{}
 	startRequest := v3HandlerStartRequest()

--- a/internal/playback/copy_seek_anchor.go
+++ b/internal/playback/copy_seek_anchor.go
@@ -108,7 +108,9 @@ func resolveCopySeekAnchor(
 	interval := strconv.FormatFloat(requestedSeekSeconds, 'f', 6, 64) + "%+0.001"
 	cmd := exec.CommandContext(ctx, ffprobePathFromFFmpeg(ffmpegPath),
 		"-v", "error",
-		"-select_streams", "v:0",
+		// Match the remux transport's 0:V:0 map. Uppercase V excludes attached
+		// pictures, thumbnails, and cover art from the video stream ordinal.
+		"-select_streams", "V:0",
 		"-read_intervals", interval,
 		"-show_entries", "packet=pts_time,dts_time,flags",
 		"-of", "json",

--- a/internal/playback/copy_seek_anchor_test.go
+++ b/internal/playback/copy_seek_anchor_test.go
@@ -17,10 +17,12 @@ func TestResolveCopySeekAnchorUsesKeyPacketTimestamp(t *testing.T) {
 	dir := t.TempDir()
 	ffmpegPath := filepath.Join(dir, "ffmpeg")
 	ffprobePath := filepath.Join(dir, "ffprobe")
+	argsPath := filepath.Join(dir, "ffprobe-args")
 	if err := os.WriteFile(ffmpegPath, []byte("#!/bin/sh\nexit 0\n"), 0o755); err != nil {
 		t.Fatalf("write fake ffmpeg: %v", err)
 	}
 	probe := `#!/bin/sh
+printf '%s\n' "$@" > "` + argsPath + `"
 printf '%s' '{"packets":[{"pts_time":"N/A","dts_time":"14.500000","flags":"K__"}]}'
 `
 	if err := os.WriteFile(ffprobePath, []byte(probe), 0o755); err != nil {
@@ -33,6 +35,13 @@ printf '%s' '{"packets":[{"pts_time":"N/A","dts_time":"14.500000","flags":"K__"}
 	}
 	if anchor != 14.5 || segment != 7 {
 		t.Fatalf("resolved anchor = %v, segment = %d; want 14.5, 7", anchor, segment)
+	}
+	args, err := os.ReadFile(argsPath)
+	if err != nil {
+		t.Fatalf("read ffprobe args: %v", err)
+	}
+	if !strings.Contains(string(args), "-select_streams\nV:0\n") {
+		t.Fatalf("ffprobe did not select the remux video stream:\n%s", args)
 	}
 }
 

--- a/web/src/pages/audiobooks/player/useAudiobookPlayback.test.ts
+++ b/web/src/pages/audiobooks/player/useAudiobookPlayback.test.ts
@@ -514,6 +514,72 @@ describe("useAudiobookPlayback", () => {
     expect(audio.currentTime).toBe(70);
   });
 
+  it("preserves negative timeline offsets and clamps absolute buffered ranges", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+        const url = String(input);
+        if (url.endsWith("/playback/start")) {
+          const body = JSON.parse(String(init?.body)) as { start_position: number };
+          return jsonResponse(
+            audioOnlyDecision("negative-offset", body.start_position, {
+              timeline_offset_seconds: -5,
+              player_start_seconds: 5,
+              can_seek_anywhere: true,
+            }),
+            { status: 201 },
+          );
+        }
+        if (url.endsWith("/playback/route-events")) return new Response(null, { status: 202 });
+        if (url.includes("/progress") || init?.method === "DELETE") {
+          return new Response(null, { status: 204 });
+        }
+        return jsonResponse({});
+      }),
+    );
+
+    const onPlayback = vi.fn<(playback: AudiobookPlayback) => void>();
+
+    function Harness() {
+      const playback = useAudiobookPlayback({
+        contentId: "c",
+        files,
+        initialPositionSeconds: 0,
+      });
+      useEffect(() => {
+        onPlayback(playback);
+      }, [playback]);
+      return createElement("audio", {
+        ref: playback.audioRef,
+        src: playback.streamUrl || undefined,
+      });
+    }
+
+    const { container } = render(createElement(Harness), { wrapper });
+    await flushAsyncWork();
+    const audio = container.querySelector("audio");
+    if (!audio) throw new Error("expected audio element");
+    Object.defineProperty(audio, "buffered", {
+      configurable: true,
+      value: {
+        length: 1,
+        start: () => 0,
+        end: () => 8,
+      } as TimeRanges,
+    });
+
+    act(() => {
+      audio.currentTime = 7;
+      fireEvent.timeUpdate(audio);
+      fireEvent.progress(audio);
+    });
+    await flushAsyncWork();
+
+    expect(onPlayback.mock.lastCall?.[0].currentTime).toBe(2);
+    expect(onPlayback.mock.lastCall?.[0].buffered?.start(0)).toBe(0);
+    expect(onPlayback.mock.lastCall?.[0].buffered?.end(0)).toBe(3);
+  });
+
   it("togglePlay invokes audio.play when paused, audio.pause otherwise", () => {
     const { result } = renderAudiobookPlayback();
     const audio = makeAudio();

--- a/web/src/pages/audiobooks/player/useAudiobookPlayback.test.ts
+++ b/web/src/pages/audiobooks/player/useAudiobookPlayback.test.ts
@@ -100,6 +100,7 @@ function audioOnlyDecision(
   startPosition: number,
   timeline: Partial<{
     stream_origin_seconds: number;
+    timeline_offset_seconds: number;
     player_start_seconds: number;
     can_seek_anywhere: boolean;
   }> = {},
@@ -442,6 +443,7 @@ describe("useAudiobookPlayback", () => {
           return jsonResponse(
             audioOnlyDecision(`anchored-${sessionCount}`, body.start_position, {
               stream_origin_seconds: body.start_position,
+              timeline_offset_seconds: body.start_position,
               player_start_seconds: 0,
               can_seek_anywhere: false,
             }),
@@ -474,6 +476,42 @@ describe("useAudiobookPlayback", () => {
       start_position: 360,
       progress_persistence: "client",
     });
+  });
+
+  it("maps native seeks with the contract timeline offset", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+        const url = String(input);
+        if (url.endsWith("/playback/start")) {
+          const body = JSON.parse(String(init?.body)) as { start_position: number };
+          return jsonResponse(
+            audioOnlyDecision("offset-contract", body.start_position, {
+              stream_origin_seconds: 300,
+              timeline_offset_seconds: 290,
+              player_start_seconds: 10,
+              can_seek_anywhere: true,
+            }),
+            { status: 201 },
+          );
+        }
+        if (url.endsWith("/playback/route-events")) return new Response(null, { status: 202 });
+        if (url.includes("/progress") || init?.method === "DELETE") {
+          return new Response(null, { status: 204 });
+        }
+        return jsonResponse({});
+      }),
+    );
+
+    const { result } = renderAudiobookPlayback({ initialPositionSeconds: 300 });
+    const audio = makeAudio();
+    act(() => {
+      (result.current.audioRef as MutableRefObject<HTMLAudioElement>).current = audio;
+    });
+    await flushAsyncWork();
+
+    act(() => result.current.seekTo(360));
+    expect(audio.currentTime).toBe(70);
   });
 
   it("togglePlay invokes audio.play when paused, audio.pause otherwise", () => {

--- a/web/src/pages/audiobooks/player/useAudiobookPlayback.ts
+++ b/web/src/pages/audiobooks/player/useAudiobookPlayback.ts
@@ -326,7 +326,7 @@ export function useAudiobookPlayback({
       planAttemptIdRef.current = planAttemptId;
       sessionIdRef.current = sessionId ?? null;
       failedPlanKeyRef.current = null;
-      streamOriginSecondsRef.current = plan.timeline.stream_origin_seconds;
+      streamOriginSecondsRef.current = plan.timeline.timeline_offset_seconds;
       canSeekAnywhereRef.current = plan.timeline.can_seek_anywhere;
       // The plan owns where the stream is anchored. On a converted part the
       // server anchors the stream at the seek position and restarts the player

--- a/web/src/pages/audiobooks/player/useAudiobookPlayback.ts
+++ b/web/src/pages/audiobooks/player/useAudiobookPlayback.ts
@@ -86,10 +86,11 @@ function safeNumber(value: number): number {
 
 export function audiobookAbsoluteTime(
   partStartSeconds: number,
-  streamOriginSeconds: number,
+  timelineOffsetSeconds: number,
   playerSeconds: number,
 ): number {
-  return safeNumber(partStartSeconds) + safeNumber(streamOriginSeconds) + safeNumber(playerSeconds);
+  const timelineOffset = Number.isFinite(timelineOffsetSeconds) ? timelineOffsetSeconds : 0;
+  return Math.max(0, safeNumber(partStartSeconds) + timelineOffset + safeNumber(playerSeconds));
 }
 
 function buildParts(files: AudiobookFile[]): AudiobookPart[] {
@@ -145,20 +146,21 @@ function absoluteBufferedRanges(
   ranges: TimeRanges,
   part: AudiobookPart | undefined,
   bookDuration: number,
-  streamOriginSeconds = 0,
+  timelineOffsetSeconds = 0,
 ): TimeRanges {
   if (!part) {
     return { length: 0, start: () => 0, end: () => 0 } as TimeRanges;
   }
+  const timelineOffset = Number.isFinite(timelineOffsetSeconds) ? timelineOffsetSeconds : 0;
   const out: Array<{ start: number; end: number }> = [];
   for (let i = 0; i < ranges.length; i++) {
-    const start = Math.min(
-      bookDuration,
-      part.start + streamOriginSeconds + safeNumber(ranges.start(i)),
+    const start = Math.max(
+      0,
+      Math.min(bookDuration, part.start + timelineOffset + safeNumber(ranges.start(i))),
     );
-    const end = Math.min(
-      bookDuration,
-      part.start + streamOriginSeconds + safeNumber(ranges.end(i)),
+    const end = Math.max(
+      0,
+      Math.min(bookDuration, part.start + timelineOffset + safeNumber(ranges.end(i))),
     );
     if (end > start) {
       out.push({ start, end });
@@ -258,7 +260,7 @@ export function useAudiobookPlayback({
   const attemptCountRef = useRef(1);
   const replanInFlightPlanKeyRef = useRef<string | null>(null);
   const failedPlanKeyRef = useRef<string | null>(null);
-  const streamOriginSecondsRef = useRef(0);
+  const timelineOffsetSecondsRef = useRef(0);
   const canSeekAnywhereRef = useRef(true);
   const reportRef = useRef<(pos: number) => void>(() => {});
   const reportSessionRef = useRef<(pos: number, isPaused: boolean, keepalive?: boolean) => void>(
@@ -326,7 +328,7 @@ export function useAudiobookPlayback({
       planAttemptIdRef.current = planAttemptId;
       sessionIdRef.current = sessionId ?? null;
       failedPlanKeyRef.current = null;
-      streamOriginSecondsRef.current = plan.timeline.timeline_offset_seconds;
+      timelineOffsetSecondsRef.current = plan.timeline.timeline_offset_seconds;
       canSeekAnywhereRef.current = plan.timeline.can_seek_anywhere;
       // The plan owns where the stream is anchored. On a converted part the
       // server anchors the stream at the seek position and restarts the player
@@ -511,7 +513,7 @@ export function useAudiobookPlayback({
     const target = clampedBookTime(initialPositionSeconds, duration);
     const index = findPartIndex(parts, target);
     pendingLocalSeekRef.current = localTimeForPart(parts[index], target);
-    streamOriginSecondsRef.current = 0;
+    timelineOffsetSecondsRef.current = 0;
     canSeekAnywhereRef.current = true;
     autoPlayPendingRef.current = autoPlay;
     setBuffered(null);
@@ -643,7 +645,7 @@ export function useAudiobookPlayback({
     if (!audio || !fileId || !activePart) return;
 
     const absoluteFromAudio = () =>
-      audiobookAbsoluteTime(activePart.start, streamOriginSecondsRef.current, audio.currentTime);
+      audiobookAbsoluteTime(activePart.start, timelineOffsetSecondsRef.current, audio.currentTime);
 
     const onTimeUpdate = () => setAbsoluteTime(absoluteFromAudio());
     const onProgress = () =>
@@ -652,7 +654,7 @@ export function useAudiobookPlayback({
           audio.buffered,
           activePart,
           duration,
-          streamOriginSecondsRef.current,
+          timelineOffsetSecondsRef.current,
         ),
       );
     const onDurationChange = () =>
@@ -661,7 +663,7 @@ export function useAudiobookPlayback({
           audio.buffered,
           activePart,
           duration,
-          streamOriginSecondsRef.current,
+          timelineOffsetSecondsRef.current,
         ),
       );
     const onLoadedMetadata = () => {
@@ -805,7 +807,7 @@ export function useAudiobookPlayback({
         setBuffered(null);
         setActiveFileIndex(nextIndex);
       } else if (audio && canSeekAnywhereRef.current) {
-        audio.currentTime = Math.max(0, local - streamOriginSecondsRef.current);
+        audio.currentTime = Math.max(0, local - timelineOffsetSecondsRef.current);
       } else {
         pendingLocalSeekRef.current = local;
         playAfterSourceSwitchRef.current = shouldContinuePlaying;

--- a/web/src/player/client-context-v3.test.ts
+++ b/web/src/player/client-context-v3.test.ts
@@ -1,6 +1,6 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
 
-import { detectHLSSupport } from "./client-context-v3";
+import { buildDeliveriesV3, detectHLSSupport } from "./client-context-v3";
 
 afterEach(() => {
   vi.unstubAllGlobals();
@@ -23,5 +23,23 @@ describe("detectHLSSupport", () => {
     vi.stubGlobal("MediaSource", { isTypeSupported: () => true });
 
     expect(detectHLSSupport()).toBe(true);
+  });
+});
+
+describe("buildDeliveriesV3", () => {
+  it("advertises the embedded text artifacts rendered by the web player", () => {
+    const deliveries = buildDeliveriesV3({
+      containers: ["mp4"],
+      codecsVideo: ["h264"],
+      codecsAudio: ["aac"],
+      maxResolution: "1080p",
+      hdr: false,
+      hls: true,
+    });
+
+    for (const delivery of Object.values(deliveries)) {
+      expect(delivery.subtitles.embedded_text).toBe(true);
+      expect(delivery.subtitles.sidecar_text).toBe(true);
+    }
   });
 });

--- a/web/src/player/client-context-v3.ts
+++ b/web/src/player/client-context-v3.ts
@@ -26,12 +26,13 @@ const WEB_APP_VERSION = "web";
 
 /**
  * Subtitle capabilities of the web player, identical for every delivery class:
- * it renders sidecar text (WebVTT and ASS via JASSUB, with container font
- * attachments) but has no bitmap subtitle renderer, so PGS/VOBSUB tracks must
- * be burned in server-side.
+ * the server exposes external and embedded text as session-scoped sidecars,
+ * which it renders as WebVTT or ASS via JASSUB (with container font
+ * attachments). It has no bitmap subtitle renderer, so PGS/VOBSUB tracks must
+ * still be burned in server-side.
  */
 const WEB_SUBTITLE_CAPABILITIES: DeliverySubtitleCapabilitiesV3 = {
-  embedded_text: false,
+  embedded_text: true,
   sidecar_text: true,
   ass_styling: true,
   embedded_bitmap: false,

--- a/web/src/player/components/VideoPlayer.test.tsx
+++ b/web/src/player/components/VideoPlayer.test.tsx
@@ -17,6 +17,10 @@ const controls = vi.hoisted(() => ({
     subtitleTracks: PlayerSubtitleInfo[];
   },
 }));
+const subtitleTimeline = vi.hoisted(() => ({
+  textOffsetSeconds: null as number | null,
+  assOffsetSeconds: null as number | null,
+}));
 
 vi.mock("../hooks/usePlaybackRealtime", () => ({
   usePlaybackRealtime: vi.fn((options) => {
@@ -31,9 +35,17 @@ vi.mock("../hooks/useKeyboardShortcuts", () => ({ useKeyboardShortcuts: vi.fn() 
 vi.mock("../hooks/useRemuxSeeking", () => ({
   useRemuxSeeking: () => ({ handleSeek: vi.fn() }),
 }));
-vi.mock("../hooks/useSubtitleTracks", () => ({ useSubtitleTracks: () => [] }));
+vi.mock("../hooks/useSubtitleTracks", () => ({
+  useSubtitleTracks: (...args: unknown[]) => {
+    subtitleTimeline.textOffsetSeconds = args[3] as number;
+    return [];
+  },
+}));
 vi.mock("../hooks/useASSSubtitles", () => ({
-  useASSSubtitles: () => ({ isActive: false }),
+  useASSSubtitles: (...args: unknown[]) => {
+    subtitleTimeline.assOffsetSeconds = args[4] as number;
+    return { isActive: false };
+  },
 }));
 vi.mock("../hooks/useSubtitleAppearance", () => ({
   useSubtitleAppearance: () => ({
@@ -115,6 +127,8 @@ describe("VideoPlayer plan failure recovery", () => {
   beforeEach(() => {
     realtimeOptions.current = null;
     controls.current = null;
+    subtitleTimeline.textOffsetSeconds = null;
+    subtitleTimeline.assOffsetSeconds = null;
     vi.spyOn(HTMLMediaElement.prototype, "play").mockResolvedValue(undefined);
     vi.spyOn(HTMLMediaElement.prototype, "pause").mockImplementation(() => {});
     vi.spyOn(HTMLMediaElement.prototype, "load").mockImplementation(() => {});
@@ -175,6 +189,8 @@ describe("VideoPlayer native HLS timeline", () => {
   beforeEach(() => {
     realtimeOptions.current = null;
     controls.current = null;
+    subtitleTimeline.textOffsetSeconds = null;
+    subtitleTimeline.assOffsetSeconds = null;
     vi.spyOn(HTMLMediaElement.prototype, "play").mockResolvedValue(undefined);
     vi.spyOn(HTMLMediaElement.prototype, "pause").mockImplementation(() => {});
     vi.spyOn(HTMLMediaElement.prototype, "load").mockImplementation(() => {});
@@ -214,6 +230,8 @@ describe("VideoPlayer native HLS timeline", () => {
     fireEvent.loadedMetadata(video);
 
     expect(video.currentTime).toBe(7);
+    expect(subtitleTimeline.textOffsetSeconds).toBe(0);
+    expect(subtitleTimeline.assOffsetSeconds).toBe(0);
   });
 });
 

--- a/web/src/player/components/VideoPlayer.test.tsx
+++ b/web/src/player/components/VideoPlayer.test.tsx
@@ -210,6 +210,18 @@ describe("VideoPlayer plan failure recovery", () => {
 
     await waitFor(() => expect(controls.current?.activeSubtitleIndex).toBeNull());
     expect(onSubtitleTrackChange).toHaveBeenCalledOnce();
+
+    const nextPlan = fixturePlanV3({
+      ...directPlan,
+      plan_id: "plan:next-session",
+      plan_attempt_key: "v3:next-session",
+      session_id: "session-2",
+    });
+    rerenderPlayer({ sessionId: "session-2", plan: nextPlan, replanError: null });
+
+    await waitFor(() => expect(controls.current?.activeSubtitleIndex).toBe(2));
+    expect(onSubtitleTrackChange).toHaveBeenCalledTimes(2);
+    expect(onSubtitleTrackChange).toHaveBeenLastCalledWith(2, 0);
   });
 });
 

--- a/web/src/player/components/VideoPlayer.test.tsx
+++ b/web/src/player/components/VideoPlayer.test.tsx
@@ -183,6 +183,34 @@ describe("VideoPlayer plan failure recovery", () => {
     fireEvent.error(video);
     expect(onPlanFailure).toHaveBeenCalledTimes(2);
   });
+
+  it("does not retry an auto-selected subtitle after its replan is refused", async () => {
+    const onSubtitleTrackChange = vi.fn();
+    const sidecarTrack: PlayerSubtitleInfo = {
+      index: 2,
+      media_file_id: 7,
+      track_id: "file:7:subtitle:2",
+      language: "en",
+      codec: "srt",
+      label: "English",
+      source: "external",
+      url: "/stream/session-1/subtitles/2.vtt",
+    };
+    const { rerenderPlayer } = renderPlayer({
+      subtitleUrls: [sidecarTrack],
+      subtitleMode: "always",
+      preferredSubtitleLanguage: "en",
+      onSubtitleTrackChange,
+    });
+
+    await waitFor(() => expect(onSubtitleTrackChange).toHaveBeenCalledOnce());
+    expect(onSubtitleTrackChange).toHaveBeenCalledWith(2, 0);
+
+    rerenderPlayer({ replanError: "Silo could not apply the subtitle selection." });
+
+    await waitFor(() => expect(controls.current?.activeSubtitleIndex).toBeNull());
+    expect(onSubtitleTrackChange).toHaveBeenCalledOnce();
+  });
 });
 
 describe("VideoPlayer native HLS timeline", () => {

--- a/web/src/player/components/VideoPlayer.tsx
+++ b/web/src/player/components/VideoPlayer.tsx
@@ -255,7 +255,7 @@ export function VideoPlayer({
   const lastRecoveryRef = useRef(0);
   const reportedPlanFailureKeyRef = useRef<string | null>(null);
   const transportFailedForPlanRevisionRef = useRef<number | null>(null);
-  const streamOriginRef = useRef(0);
+  const timelineOffsetRef = useRef(0);
   const subtitleFetchAnchorRef = useRef(initialPosition);
   const backendDurationRef = useRef(propDuration ?? 0);
   const autoEnterPictureInPictureAttemptedRef = useRef(false);
@@ -490,7 +490,7 @@ export function VideoPlayer({
     roomConnection: watchTogether,
     sessionId,
     videoRef,
-    streamOriginRef,
+    streamOriginRef: timelineOffsetRef,
   });
   const roomPlaybackActive = !!watchTogetherRoomId && !watchTogether.closedReason;
   const roomSyncWaiting = watchTogether.room?.playback_state === "waiting";
@@ -531,14 +531,14 @@ export function VideoPlayer({
   const isCopyOriginalHLS = plan.delivery === "server_remux_hls";
 
   // Keep the player-local clock mapped onto the canonical media timeline.
-  const streamOriginSeconds = plan.timeline.stream_origin_seconds;
-  streamOriginRef.current = streamOriginSeconds;
+  const timelineOffsetSeconds = plan.timeline.timeline_offset_seconds;
+  timelineOffsetRef.current = timelineOffsetSeconds;
 
   // Media-time position playback is heading to, for consumers that need a
   // position before the element has media loaded (when currentTime still
   // reads 0): an in-flight seek target, else the session's start position.
   subtitleFetchAnchorRef.current =
-    pendingSeekTime ?? toMediaTime(effectiveInitialPosition, streamOriginSeconds);
+    pendingSeekTime ?? toMediaTime(effectiveInitialPosition, timelineOffsetSeconds);
 
   useEffect(() => {
     if (backendDuration > 0) {
@@ -701,7 +701,7 @@ export function VideoPlayer({
       setPendingSeekTime(seconds);
       setCurrentTime(seconds);
 
-      const nativeSeconds = toPlayerTime(seconds, streamOriginRef.current);
+      const nativeSeconds = toPlayerTime(seconds, timelineOffsetRef.current);
       if (canSeekAnywhere) {
         if (isHlsStream) video.currentTime = nativeSeconds;
         else handleSeek(nativeSeconds);
@@ -773,17 +773,20 @@ export function VideoPlayer({
   // before dispatching the seek request.
   const handleKeyboardSeek = useCallback(
     (seconds: number) => {
-      handlePlayerSeek(toMediaTime(seconds, streamOriginRef.current));
+      handlePlayerSeek(toMediaTime(seconds, timelineOffsetRef.current));
     },
     [handlePlayerSeek],
   );
 
   // -- Watch progress reporting --
-  const flushWatchProgress = useWatchProgress(sessionId, videoRef, streamOriginRef);
+  const flushWatchProgress = useWatchProgress(sessionId, videoRef, timelineOffsetRef);
 
   const buildExitState = useCallback((): PlaybackExitState => {
     const video = videoRef.current;
-    const positionSeconds = toMediaTime(video?.currentTime ?? currentTime, streamOriginRef.current);
+    const positionSeconds = toMediaTime(
+      video?.currentTime ?? currentTime,
+      timelineOffsetRef.current,
+    );
     // positionSeconds is media time, so the runtime paired with it must be too.
     const durationSeconds = mediaDurationSeconds(backendDurationRef.current, duration);
 
@@ -1588,7 +1591,7 @@ export function VideoPlayer({
       setAwaitingFirstFrame(false);
     };
     const onTimeUpdate = () => {
-      const nextTime = toMediaTime(video.currentTime, streamOriginRef.current);
+      const nextTime = toMediaTime(video.currentTime, timelineOffsetRef.current);
       const resolved = resolvePendingSeekTime(nextTime, pendingSeekTime);
       setCurrentTime(resolved.currentTime);
       if (resolved.pendingSeekTime !== pendingSeekTime) {
@@ -1602,7 +1605,7 @@ export function VideoPlayer({
     };
     const onSeeked = () => {
       setPendingSeekTime(null);
-      setCurrentTime(toMediaTime(video.currentTime, streamOriginRef.current));
+      setCurrentTime(toMediaTime(video.currentTime, timelineOffsetRef.current));
       markPlaybackStarted();
       clearBuffering();
       if (roomSyncWaiting && watchTogetherSync.attachedSessionId === sessionId) {
@@ -1864,7 +1867,7 @@ export function VideoPlayer({
     videoRef,
     effectiveSubtitleTracks,
     activeSubtitleIndex,
-    streamOriginSeconds,
+    timelineOffsetSeconds,
     subtitleDelayMs,
     durationRef,
     subtitleFetchAnchorRef,
@@ -1879,7 +1882,7 @@ export function VideoPlayer({
     subtitleUrls,
     activeSubtitleIndex,
     isDetached,
-    streamOriginSeconds,
+    timelineOffsetSeconds,
     subtitleDelayMs,
   );
 

--- a/web/src/player/components/VideoPlayer.tsx
+++ b/web/src/player/components/VideoPlayer.tsx
@@ -1946,6 +1946,13 @@ export function VideoPlayer({
     }
   }, [plan.selected_tracks.subtitle?.index, replanError, replanning]);
 
+  // A refusal pin belongs only to the session that rejected the automatic
+  // selection. Clear it before the auto-selection effect evaluates a new
+  // session so the viewer's persisted subtitle mode applies to the next title.
+  useEffect(() => {
+    subtitleSelectionWasManualRef.current = false;
+  }, [sessionId]);
+
   // -- Auto-select subtitle track based on mode --
   useEffect(() => {
     if (subtitleSelectionWasManualRef.current) {
@@ -1997,11 +2004,8 @@ export function VideoPlayer({
     audioTracks,
     activeAudioIndex,
     selectedVersion,
+    sessionId,
   ]);
-
-  useEffect(() => {
-    subtitleSelectionWasManualRef.current = false;
-  }, [sessionId]);
 
   // -- Control callbacks --
   const handlePlayPause = useCallback(() => {

--- a/web/src/player/components/VideoPlayer.tsx
+++ b/web/src/player/components/VideoPlayer.tsx
@@ -1935,9 +1935,12 @@ export function VideoPlayer({
   // A refused replan leaves the previous stream playing, so the selection has
   // to roll back too: without this the menu would keep claiming a track is on
   // that the server never rendered, and re-picking it would be suppressed as an
-  // unchanged selection instead of retrying.
+  // unchanged selection instead of retrying. Pin the accepted selection just
+  // like a manual choice so auto-selection does not immediately request the
+  // rejected track again; a later user choice can still retry it explicitly.
   useEffect(() => {
     if (requestedSubtitleTrackChangeRef.current && replanError && !replanning) {
+      subtitleSelectionWasManualRef.current = true;
       setActiveSubtitleIndex(plan.selected_tracks.subtitle?.index ?? null);
       requestedSubtitleTrackChangeRef.current = null;
     }

--- a/web/src/player/utils/mediaTimeline.ts
+++ b/web/src/player/utils/mediaTimeline.ts
@@ -1,11 +1,11 @@
-export function toMediaTime(playerTimeSeconds: number, streamOriginSeconds = 0): number {
-  return Math.max(0, playerTimeSeconds + streamOriginSeconds);
+export function toMediaTime(playerTimeSeconds: number, timelineOffsetSeconds = 0): number {
+  return Math.max(0, playerTimeSeconds + timelineOffsetSeconds);
 }
 
-export function toPlayerTime(mediaTimeSeconds: number, streamOriginSeconds = 0): number {
+export function toPlayerTime(mediaTimeSeconds: number, timelineOffsetSeconds = 0): number {
   // Preserve negative offsets so callers can distinguish a target before the
   // current HLS window from the locally seekable position at zero.
-  return mediaTimeSeconds - streamOriginSeconds;
+  return mediaTimeSeconds - timelineOffsetSeconds;
 }
 
 export function subtitleStartPositionSeconds(


### PR DESCRIPTION
## Problem

Part of #135
Follow-up to #567

The neutral V3 migration stopped calling the existing copy-seek anchor resolver. FFmpeg copy remuxes begin on the preceding keyframe, but V3 advertised the requested seek as byte-zero. The web player also used `stream_origin_seconds` for source/player conversion instead of the contract's `timeline_offset_seconds`.

On the isolated real-media reproduction, a request for 1086.2 s emitted its first copied video packet from 1085.501 s. The old V3 response advertised both origin and player start as 1086.2/0, producing a measurable 699 ms subtitle error.

Follow-up runtime testing exposed the reported flashing. The merged web capability incorrectly advertised `embedded_text: false`, even though Silo exposes embedded text tracks to the web player through session-scoped VTT/ASS sidecars that it already renders. Selecting an embedded SRT therefore forced an unnecessary burn-in video transcode. Shared dev could not initialize its QSV device, so that replan was refused; rollback then cleared the automatic-selection guard and immediately selected the same rejected track again. One session issued 483 replans in 155 seconds, repeatedly toggling subtitle state and flashing the cues. Any refused automatically selected subtitle replan could trigger the feedback loop.

## Approach

- Resolve the actual copy keyframe before choosing progressive, local-HLS, or remote-HLS transport.
- Skip video-keyframe probing for audio-only remuxes, anchor their zero-based chunked timeline at the requested source position, and select the same non-attached `V:0` stream that FFmpeg maps for video remuxes.
- Keep the requested position as FFmpeg's input seek, but advertise the resolved origin, player pre-roll offset, seek window, and timeline offset.
- Carry the anchor through local transcode options, remote node requests, and reconstruction recipe cards.
- Return a retryable transport failure when the anchor cannot be established instead of publishing a false timeline.
- Make the video and audiobook players use `timeline_offset_seconds` for source/player conversions.
- Advertise embedded text support for every web delivery class so the V3 planner keeps embedded text on the existing session-scoped sidecar/rendering path instead of forcing burn-in.
- After a refused subtitle replan, pin the last server-accepted selection so automatic selection cannot request the same rejected track in a loop; explicit user selection can still retry it.
- Scope the refusal pin to its playback session so persisted automatic subtitle preferences apply normally to the next title.
- Update protocol documentation and add regression coverage for copy-remux timing, transport propagation, subtitle capability negotiation, player clock conversion, and refused subtitle replans.

## Impact

Resumed and reanchored copy remuxes now keep video, text/ASS subtitles, progress, and seeks on the same source clock. Embedded text subtitles remain client-rendered and no longer depend on a video encoder. A failed subtitle selection cannot cause a replan storm or flashing cues. Bitmap subtitles still correctly require burn-in, and direct/encoded route timeline shapes are unchanged.

The shared-dev QSV startup failure remains an operational issue for routes that genuinely require video encoding; this change removes that dependency from embedded text playback rather than masking encoder failures.

## Validation

- Isolated dev-builder frontend/backend production build: passed.
- Sandbox doctor: API, frontend, container, and database healthy.
- Real authenticated V3 route on the reproducing file:
  - requested/source start: 1086.2 s
  - resolved stream origin and timeline offset: 1085.501 s
  - player start: 0.699 s
  - subtitle artifact timing origin: 1085.501 s
  - delivery: `server_remux_progressive`
- Shared-dev flashing diagnosis:
  - 483 completed replans in 155 seconds for one session
  - the selected English track was embedded SubRip text
  - each forced-burn-in replan failed with `transcode_start_failed` after QSV/VAAPI initialization failed
  - rollback and automatic selection then repeated the same request
- Focused subtitle, capability, and audiobook timeline regression tests: 23 passed.
- Focused copy-anchor tests plus full `internal/api/handlers` and `internal/playback` package tests: passed.
- Current `make test-web`: passed 273 web test files / 1,876 tests.
- Current `pnpm run build`: passed.
- Original `make test`: passed all Go packages and 273 web test files / 1,873 tests.
- `go test ./internal/api/handlers ./internal/playback -count=1`: passed.
- `go vet ./...`: passed.
- Pinned CI-equivalent changed-line `golangci-lint v2.12.2`: 0 issues.
- Current `pnpm run lint`: 0 errors (151 existing warnings).
- Current `pnpm run format:check`: passed.
- `make verify-local-paths` and `git diff --check`: passed.

## Coverage gap

The collaborative browser reached the shared-dev sign-in screen but had no authenticated session, so the post-fix playback path was not visually replayed there and this branch was not deployed to the shared environment. The timing path was exercised through an authenticated isolated sandbox against real scanned media; the flashing cause was independently confirmed from shared-dev session, route-event, replan, and FFmpeg evidence; and both regressions are covered by focused tests plus the full web suite.

### AI Disclosure
- Tool(s): T3 Code; OpenAI Codex
- Model(s): gpt-5.6-sol
- Involvement: fully AI-generated
- Adversarial review: The final review corrected stale copy-remux contract prose, centralized a repeated failure reason, and rechecked local, remote, and reconstruction propagation. Follow-up review traced flashing through the full capability-to-planner-to-runtime path: the web client falsely denied embedded text support, forcing burn-in, while a refused replan fed back into automatic selection. The capability now matches the actual VTT/ASS renderer and the rollback guard independently prevents refusal loops without suppressing explicit user retries. The final automated review also caught signed audiobook timeline offsets being passed through a non-negative helper; the fix preserves signed offsets, clamps only final absolute values, and adds a negative-offset regression. Later review found and fixed audio-only remux probing and timestamp anchoring, attached-cover stream selection, and the refusal pin carrying into the next session; each now has regression coverage.

## Checklist
- [x] I ran an adversarial AI review of the diff and summarized findings above.
- [x] I ran the relevant repository verify commands and documented the browser coverage gap.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Improvements**
  - Improved playback start points and seeking for remuxed HLS and progressive video with more accurate timeline positioning.
  - Preserved requested player positions when playback begins from an earlier keyframe.
  - Improved buffering, watch-progress tracking, keyboard seeking, and subtitle timing across offset playback timelines.
  - Web playback now supports embedded text subtitles alongside sidecar subtitles.
  - Subtitle selections are less likely to be repeatedly retried after an unsuccessful playback replan.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->


