### PR TITLE
fix(web): dedupe multi-library collection options

### DIFF
--- a/web/src/hooks/queries/useAllUserCollections.test.ts
+++ b/web/src/hooks/queries/useAllUserCollections.test.ts
@@ -1,0 +1,69 @@
+import { describe, expect, it } from "vitest";
+import type { LibraryCollection } from "@/api/types";
+import { buildAllUserCollectionOptions } from "./useAllUserCollections";
+
+function libraryCollection(id: string, title: string): LibraryCollection {
+  return {
+    id,
+    title,
+    collection_type: "smart",
+    source_config: {},
+    last_sync_status: "success",
+  } as LibraryCollection;
+}
+
+describe("buildAllUserCollectionOptions", () => {
+  it("keeps personal collections first and identifies their source", () => {
+    const options = buildAllUserCollectionOptions(
+      [{ id: 1, name: "Movies" }],
+      [{ id: "personal", name: "Weekend Picks" }],
+      [[libraryCollection("library", "Staff Picks")]],
+    );
+
+    expect(options.map(({ id, source, group }) => ({ id, source, group }))).toEqual([
+      { id: "personal", source: "user", group: "My Collections" },
+      { id: "library", source: "library", group: "Movies" },
+    ]);
+  });
+
+  it("lists a multi-library collection once with its combined scope", () => {
+    const shared = libraryCollection("shared", "Network Originals");
+
+    const options = buildAllUserCollectionOptions(
+      [
+        { id: 1, name: "Movies" },
+        { id: 2, name: "TV Shows" },
+      ],
+      undefined,
+      [[shared], [shared]],
+    );
+
+    expect(options).toHaveLength(1);
+    expect(options[0]).toMatchObject({
+      id: "shared",
+      title: "Network Originals",
+      source: "library",
+      group: "Movies, TV Shows",
+      library_name: "Movies, TV Shows",
+    });
+  });
+
+  it("keeps separate same-titled collections distinct", () => {
+    const options = buildAllUserCollectionOptions(
+      [
+        { id: 1, name: "Movies" },
+        { id: 2, name: "TV Shows" },
+      ],
+      undefined,
+      [
+        [libraryCollection("movies", "Network Originals")],
+        [libraryCollection("shows", "Network Originals")],
+      ],
+    );
+
+    expect(options.map(({ id, group }) => ({ id, group }))).toEqual([
+      { id: "movies", group: "Movies" },
+      { id: "shows", group: "TV Shows" },
+    ]);
+  });
+});

--- a/web/src/hooks/queries/useAllUserCollections.ts
+++ b/web/src/hooks/queries/useAllUserCollections.ts
@@ -1,5 +1,5 @@
 import { useQueries } from "@tanstack/react-query";
-import type { LibraryCollection } from "@/api/types";
+import type { Collection, LibraryCollection } from "@/api/types";
 import { useUserLibraries } from "./libraries";
 import { useCollections } from "./collections";
 import { getLibraryCollectionList, libraryCollectionsQueryOptions } from "./libraryCollections";
@@ -16,6 +16,60 @@ export interface CollectionOption {
   last_sync_status?: LibraryCollection["last_sync_status"];
 }
 
+type LibrarySummary = { id: number; name: string };
+type UserCollectionSummary = Pick<Collection, "id" | "name">;
+
+export function buildAllUserCollectionOptions(
+  libraries: readonly LibrarySummary[],
+  userCollections: readonly UserCollectionSummary[] | undefined,
+  libraryCollectionsByLibrary: ReadonlyArray<readonly LibraryCollection[] | undefined>,
+): CollectionOption[] {
+  const collections: CollectionOption[] = [];
+
+  for (const collection of userCollections ?? []) {
+    collections.push({
+      id: collection.id,
+      title: collection.name,
+      source: "user",
+      group: "My Collections",
+    });
+  }
+
+  const libraryOptions = new Map<string, { option: CollectionOption; libraryNames: string[] }>();
+
+  for (let i = 0; i < libraries.length; i++) {
+    const library = libraries[i]!;
+    for (const collection of libraryCollectionsByLibrary[i] ?? []) {
+      const existing = libraryOptions.get(collection.id);
+      if (existing) {
+        if (!existing.libraryNames.includes(library.name)) {
+          existing.libraryNames.push(library.name);
+          const group = existing.libraryNames.join(", ");
+          existing.option.group = group;
+          existing.option.library_name = group;
+        }
+        continue;
+      }
+
+      const option: CollectionOption = {
+        id: collection.id,
+        title: collection.title,
+        source: "library",
+        group: library.name,
+        library_id: library.id,
+        library_name: library.name,
+        collection_type: collection.collection_type,
+        source_config: collection.source_config,
+        last_sync_status: collection.last_sync_status,
+      };
+      libraryOptions.set(collection.id, { option, libraryNames: [library.name] });
+      collections.push(option);
+    }
+  }
+
+  return collections;
+}
+
 export function useAllUserCollections() {
   const { data: libraries } = useUserLibraries();
   const { data: userCollections, isLoading: userCollectionsLoading } = useCollections();
@@ -29,41 +83,14 @@ export function useAllUserCollections() {
 
   const isLoading = libraryQueries.some((q) => q.isLoading) || userCollectionsLoading;
 
-  const collections: CollectionOption[] = [];
-
-  // Add personal user collections first (grouped under "My Collections").
-  if (userCollections) {
-    for (const c of userCollections) {
-      collections.push({
-        id: c.id,
-        title: c.name,
-        source: "user",
-        group: "My Collections",
-      });
-    }
-  }
-
-  // Add library collections grouped by library name.
-  if (libraries) {
-    for (let i = 0; i < libraries.length; i++) {
-      const lib = libraries[i]!;
-      const result = libraryQueries[i];
-      const libraryCollections = Array.isArray(result?.data) ? result.data : [];
-      for (const c of libraryCollections) {
-        collections.push({
-          id: c.id,
-          title: c.title,
-          source: "library",
-          group: lib.name,
-          library_id: lib.id,
-          library_name: lib.name,
-          collection_type: c.collection_type,
-          source_config: c.source_config,
-          last_sync_status: c.last_sync_status,
-        });
-      }
-    }
-  }
+  const libraryCollectionsByLibrary = libraryQueries.map((result) =>
+    Array.isArray(result.data) ? result.data : undefined,
+  );
+  const collections = buildAllUserCollectionOptions(
+    libraries ?? [],
+    userCollections,
+    libraryCollectionsByLibrary,
+  );
 
   return { collections, isLoading };
 }


### PR DESCRIPTION
## Summary

- collapse repeated per-library responses for the same admin collection into one picker option
- label a multi-library collection with all visible library names
- keep distinct collections separate even when their titles match

Part of #194

## Root cause

A multi-library collection is returned by each member library's collections endpoint. The section picker appended every response, so one global collection ID appeared as several library-specific choices. Selection stores only that collection ID, and the display lookup then matched the first duplicate option, making a later choice appear to switch back to the first library.

Collection sections intentionally reference the global collection ID, not a library-specific facet. This change deduplicates by that stable ID and combines the visible library labels rather than adding a filter that would change the collection's meaning.

## User impact

Multi-library collections now appear once in section and recipe collection pickers, with a label such as `Network Originals (Movies, TV Shows)`. Separate same-titled collections still appear independently.

## Validation

```text
$ pnpm exec vitest run src/hooks/queries/useAllUserCollections.test.ts src/components/CollectionSearchableSelect.test.tsx src/components/sections/SectionEditorDrawer.test.ts
Test Files  3 passed (3)
Tests       6 passed (6)

$ pnpm exec eslint src/hooks/queries/useAllUserCollections.ts src/hooks/queries/useAllUserCollections.test.ts
(no findings)

$ pnpm exec prettier --check src/hooks/queries/useAllUserCollections.ts src/hooks/queries/useAllUserCollections.test.ts
All matched files use Prettier code style!

$ pnpm exec vite build --outDir <external-cache> --emptyOutDir
4114 modules transformed
built in 10.32s

$ make verify-local-paths
scripts/check-local-path-leaks.sh
```

Browser validation used the real picker with the reported duplicate-ID shape. It rendered one option under `Movies, TV Shows`; choosing it stored the shared collection ID and displayed `Network Originals (Movies, TV Shows)`. Screenshot capture was unavailable in the collaborative browser harness.

Repository-wide baseline notes:

- `pnpm run lint` completed with 0 errors and 151 existing warnings; `pnpm run format:check` passed.
- `pnpm exec tsc -b` remains blocked by existing errors in unrelated files; the same errors reproduce on untouched `origin/main`.
- `make test-web` ran 274 files: 267 passed and 7 unrelated files failed. Representative local-storage and settings failures reproduce on untouched `origin/main`.
- Full Go lint/tests remain red on existing repository debt and unrelated environment-sensitive Jellycompat, GPU-detection, and policy tests; this PR changes no Go code.

### AI Disclosure
- Tool(s): Codex
- Model(s): gpt-5.6-sol
- Involvement: fully AI-generated
- Adversarial review: Checked for accidental title-based deduplication and regressions to personal collection ordering. The implementation deduplicates only stable collection IDs, preserves distinct same-titled collections, and adds coverage for both personal and multi-library options.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved collection listing when the same collection is available through multiple libraries.
  * Combined library details for shared collections while preserving separate collections with matching titles.
  * Maintained consistent ordering and source labels for personal and library collections.

* **Tests**
  * Added coverage for collection ordering, source labels, deduplication, library merging, and distinct same-title collections.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->