### PR TITLE
feat(devices): user-set custom device names

### DIFF
--- a/internal/api/handlers/devices.go
+++ b/internal/api/handlers/devices.go
@@ -1,10 +1,14 @@
 package handlers
 
 import (
+	"encoding/json"
+	"errors"
+	"io"
 	"log/slog"
 	"net/http"
 	"sort"
 	"strings"
+	"unicode"
 
 	"github.com/go-chi/chi/v5"
 
@@ -46,9 +50,14 @@ type deviceResponse struct {
 	DeviceID       string `json:"device_id"`
 	DeviceName     string `json:"device_name"`
 	DevicePlatform string `json:"device_platform"`
-	LastSeenAt     string `json:"last_seen_at"`
-	ProfileID      string `json:"profile_id"`
-	ProfileName    string `json:"profile_name"`
+	// CustomName is the name this profile chose for the device, absent until
+	// one is set. DeviceName stays the client-reported name so clients render
+	// custom_name || device_name and can always show what a renamed device
+	// calls itself.
+	CustomName  string `json:"custom_name,omitempty"`
+	LastSeenAt  string `json:"last_seen_at"`
+	ProfileID   string `json:"profile_id"`
+	ProfileName string `json:"profile_name"`
 	// IsCurrentDevice marks the device this request came from, so a client can
 	// say "you're here" without repeating the header-matching rule.
 	IsCurrentDevice bool `json:"is_current_device"`
@@ -127,6 +136,7 @@ func (h *DeviceHandler) HandleListDevices(w http.ResponseWriter, r *http.Request
 			DeviceID:        device.DeviceID,
 			DeviceName:      device.DeviceName,
 			DevicePlatform:  device.DevicePlatform,
+			CustomName:      device.CustomName,
 			LastSeenAt:      device.LastSeenAt,
 			ProfileID:       device.ProfileID,
 			ProfileName:     profileNames[device.ProfileID],
@@ -264,6 +274,128 @@ func (h *DeviceHandler) removeDevice(w http.ResponseWriter, r *http.Request, for
 	})
 
 	w.WriteHeader(http.StatusNoContent)
+}
+
+type renameDeviceRequest struct {
+	// Name is a pointer so "clear the name" ({"name": ""}) and "no name sent"
+	// stay distinguishable; the latter is a malformed request.
+	Name *string `json:"name"`
+}
+
+// HandleRenameDevice handles PATCH /devices/{device_id}: set the profile's own
+// name for a device, or clear it (empty name) so the device shows its reported
+// name again. A household of identical clients is the point — three Apple TVs
+// all report "Apple TV".
+func (h *DeviceHandler) HandleRenameDevice(w http.ResponseWriter, r *http.Request) {
+	store, ok := h.storeFor(w, r)
+	if !ok {
+		return
+	}
+	profileID := strings.TrimSpace(apimw.GetProfileID(r.Context()))
+	if profileID == "" {
+		writeError(w, http.StatusBadRequest, "bad_request", "X-Profile-Id header is required")
+		return
+	}
+	deviceID := strings.TrimSpace(chi.URLParam(r, "device_id"))
+	if deviceID == "" {
+		writeError(w, http.StatusBadRequest, "bad_request", "A device id is required")
+		return
+	}
+
+	var body renameDeviceRequest
+	decoder := json.NewDecoder(http.MaxBytesReader(w, r.Body, 1<<20))
+	decoder.DisallowUnknownFields()
+	if err := decoder.Decode(&body); err != nil {
+		writeError(w, http.StatusBadRequest, "bad_request", "Body must be {\"name\": \"…\"}")
+		return
+	}
+	if _, err := decoder.Token(); !errors.Is(err, io.EOF) {
+		writeError(w, http.StatusBadRequest, "bad_request", "Body must be a single JSON document")
+		return
+	}
+	if body.Name == nil {
+		writeError(w, http.StatusBadRequest, "bad_request", "name is required")
+		return
+	}
+	// Control runes first: a JSON body can carry what a header cannot (net/http
+	// rejects them), and NUL in particular is a code point PostgreSQL refuses
+	// in TEXT while SQLite stores it — the same boundary problem jellycompat's
+	// stripCompatNUL exists for. Stripping keeps the two backends storing the
+	// same value. Then the same trim-and-clamp the reported X-Device-Name gets,
+	// so a chosen name can never carry more than the reported one may.
+	name := clampHeaderValue(stripControlRunes(*body.Name), 120)
+
+	// The household parent may rename a family member's device, on the same
+	// guard forget and clear use.
+	if named := strings.TrimSpace(r.URL.Query().Get("profile_id")); named != "" && named != profileID {
+		allowed, err := canManageHousehold(r, store, h.UserRepo, h.ProfileTokens)
+		if err != nil {
+			writeProfileManagementPermissionError(w, err)
+			return
+		}
+		if !allowed {
+			writeError(w, http.StatusForbidden, "forbidden",
+				"Managing another profile's devices requires the primary profile or admin access")
+			return
+		}
+		profile, err := store.GetProfile(r.Context(), named)
+		if err != nil {
+			writeError(w, http.StatusInternalServerError, "internal_error", "Failed to load profile")
+			return
+		}
+		if profile == nil {
+			writeError(w, http.StatusNotFound, "not_found", "Profile not found")
+			return
+		}
+		profileID = named
+	}
+
+	// A rename targets the registry row itself, so unlike forget and clear
+	// there is no settings-only fallback: no row, nothing to name. The 404
+	// deliberately covers another profile's device too — same anti-enumeration
+	// reasoning as removeDevice above.
+	registry, isRegistry := store.(userstore.DeviceRegistry)
+	if !isRegistry {
+		writeError(w, http.StatusNotFound, "not_found", "Device not found")
+		return
+	}
+	exists, err := registry.DeviceExists(r.Context(), profileID, deviceID)
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, "internal_error", "Failed to look up device")
+		return
+	}
+	if !exists {
+		writeError(w, http.StatusNotFound, "not_found", "Device not found")
+		return
+	}
+	if err := registry.RenameDevice(r.Context(), profileID, deviceID, name); err != nil {
+		writeError(w, http.StatusInternalServerError, "internal_error", "Failed to rename device")
+		return
+	}
+
+	// Identity only, like forget and clear: the chosen name is one profile's
+	// private label, not something the audit trail needs to hold. No Scope,
+	// unlike those two — a rename moves no stored settings.
+	auditSettingsForOther(r.Context(), settingsAuditRecord{
+		Action:          "rename_device",
+		ActorProfileID:  actingProfileID(r.Context()),
+		TargetProfileID: profileID,
+		TargetUserID:    apimw.GetUserID(r.Context()),
+		DeviceID:        deviceID,
+	})
+
+	w.WriteHeader(http.StatusNoContent)
+}
+
+// stripControlRunes drops every control rune, NUL included, from a
+// user-supplied name.
+func stripControlRunes(value string) string {
+	return strings.Map(func(r rune) rune {
+		if unicode.IsControl(r) {
+			return -1
+		}
+		return r
+	}, value)
 }
 
 type deviceKey struct {

--- a/internal/api/handlers/devices_test.go
+++ b/internal/api/handlers/devices_test.go
@@ -303,6 +303,175 @@ func TestClearDeviceSettings_KeepsRegistryRow(t *testing.T) {
 	}
 }
 
+// --- Rename ---
+
+func renameDevice(
+	t *testing.T, h *DeviceHandler, target, deviceID, profileID, body string,
+) *httptest.ResponseRecorder {
+	t.Helper()
+	req := httptest.NewRequest(http.MethodPatch, target, strings.NewReader(body))
+	req.Header.Set(deviceIDHeader, "device-1")
+	ctx := apimw.SetClaims(req.Context(), &auth.Claims{UserID: 1})
+	req = req.WithContext(apimw.SetProfileID(ctx, profileID))
+	routeCtx := chi.NewRouteContext()
+	routeCtx.URLParams.Add("device_id", deviceID)
+	req = req.WithContext(context.WithValue(req.Context(), chi.RouteCtxKey, routeCtx))
+
+	rec := httptest.NewRecorder()
+	h.HandleRenameDevice(rec, req)
+	return rec
+}
+
+// customNameFor reads a device's stored custom name straight from the
+// registry, so a test can check another profile's row without going through
+// the handler's own profile filtering.
+func customNameFor(t *testing.T, store userstore.UserStore, profileID, deviceID string) string {
+	t.Helper()
+	registry, ok := store.(userstore.DeviceRegistry)
+	if !ok {
+		t.Fatal("store does not implement DeviceRegistry")
+	}
+	devices, err := registry.ListDevices(context.Background())
+	if err != nil {
+		t.Fatalf("ListDevices: %v", err)
+	}
+	for _, device := range devices {
+		if device.ProfileID == profileID && device.DeviceID == deviceID {
+			return device.CustomName
+		}
+	}
+	t.Fatalf("device %s/%s is not registered", profileID, deviceID)
+	return ""
+}
+
+func TestRenameDevice_SetsCustomNameInListResponse(t *testing.T) {
+	handler, store := newDevicesTestHandler(t)
+	seedDevice(t, store, "profile-1", "device-2", "Apple TV")
+
+	rec := renameDevice(t, handler, "/devices/device-2", "device-2", "profile-1",
+		`{"name": "Bedroom TV"}`)
+	if rec.Code != http.StatusNoContent {
+		t.Fatalf("PATCH = %d: %s", rec.Code, rec.Body.String())
+	}
+
+	body := listDevices(t, handler, "", "profile-1")
+	if len(body.Devices) != 1 {
+		t.Fatalf("returned %d devices, want 1: %+v", len(body.Devices), body.Devices)
+	}
+	if body.Devices[0].CustomName != "Bedroom TV" {
+		t.Errorf("custom_name = %q, want Bedroom TV", body.Devices[0].CustomName)
+	}
+	// The reported name is what the device calls itself; a rename must not
+	// overwrite it.
+	if body.Devices[0].DeviceName != "Apple TV" {
+		t.Errorf("device_name = %q, want the reported Apple TV", body.Devices[0].DeviceName)
+	}
+}
+
+func TestRenameDevice_EmptyNameClears(t *testing.T) {
+	handler, store := newDevicesTestHandler(t)
+	seedDevice(t, store, "profile-1", "device-2", "Apple TV")
+
+	if rec := renameDevice(t, handler, "/devices/device-2", "device-2", "profile-1",
+		`{"name": "Bedroom TV"}`); rec.Code != http.StatusNoContent {
+		t.Fatalf("set PATCH = %d: %s", rec.Code, rec.Body.String())
+	}
+	if rec := renameDevice(t, handler, "/devices/device-2", "device-2", "profile-1",
+		`{"name": ""}`); rec.Code != http.StatusNoContent {
+		t.Fatalf("clear PATCH = %d: %s", rec.Code, rec.Body.String())
+	}
+
+	if got := customNameFor(t, store, "profile-1", "device-2"); got != "" {
+		t.Errorf("custom name = %q after clearing, want empty", got)
+	}
+}
+
+// A custom name gets the same trim-and-clamp the reported X-Device-Name does,
+// so it can never carry more than the reported name may.
+func TestRenameDevice_TrimsAndClampsTheName(t *testing.T) {
+	handler, store := newDevicesTestHandler(t)
+	seedDevice(t, store, "profile-1", "device-2", "Apple TV")
+
+	long := strings.Repeat("n", 200)
+	rec := renameDevice(t, handler, "/devices/device-2", "device-2", "profile-1",
+		`{"name": "  `+long+`  "}`)
+	if rec.Code != http.StatusNoContent {
+		t.Fatalf("PATCH = %d: %s", rec.Code, rec.Body.String())
+	}
+	if got := customNameFor(t, store, "profile-1", "device-2"); got != strings.Repeat("n", 120) {
+		t.Errorf("custom name has %d chars, want the 120-char clamp", len(got))
+	}
+}
+
+// A JSON body can carry control runes a header cannot — and NUL is stored by
+// SQLite but refused by Postgres TEXT, so without stripping, the same request
+// would 500 on one backend and succeed on the other.
+func TestRenameDevice_StripsControlRunes(t *testing.T) {
+	handler, store := newDevicesTestHandler(t)
+	seedDevice(t, store, "profile-1", "device-2", "Apple TV")
+
+	rec := renameDevice(t, handler, "/devices/device-2", "device-2", "profile-1",
+		`{"name": "Bed\u0000room\tTV"}`)
+	if rec.Code != http.StatusNoContent {
+		t.Fatalf("PATCH = %d: %s", rec.Code, rec.Body.String())
+	}
+	if got := customNameFor(t, store, "profile-1", "device-2"); got != "BedroomTV" {
+		t.Errorf("custom name = %q, want the control runes stripped (BedroomTV)", got)
+	}
+}
+
+func TestRenameDevice_UnknownDeviceIsNotFound(t *testing.T) {
+	handler, _ := newDevicesTestHandler(t)
+
+	rec := renameDevice(t, handler, "/devices/device-2", "device-2", "profile-1",
+		`{"name": "Bedroom TV"}`)
+	if rec.Code != http.StatusNotFound {
+		t.Fatalf("PATCH unknown device = %d, want 404: %s", rec.Code, rec.Body.String())
+	}
+}
+
+// Another profile's device takes the same 404 as one that never existed, for
+// the anti-enumeration reasons removeDevice documents.
+func TestRenameDevice_RejectsOtherProfilesDevice(t *testing.T) {
+	handler, store := newDevicesTestHandler(t)
+	seedDevice(t, store, "profile-2", "device-9", "Robin's iPad")
+
+	rec := renameDevice(t, handler, "/devices/device-9", "device-9", "profile-1",
+		`{"name": "Mine now"}`)
+	if rec.Code != http.StatusNotFound {
+		t.Fatalf("PATCH another profile's device = %d, want 404: %s", rec.Code, rec.Body.String())
+	}
+	if got := customNameFor(t, store, "profile-2", "device-9"); got != "" {
+		t.Errorf("another profile's device was renamed to %q", got)
+	}
+}
+
+func TestRenameDevice_RejectsMalformedBodies(t *testing.T) {
+	cases := []struct {
+		name string
+		body string
+	}{
+		{"empty body", ""},
+		{"missing name", `{}`},
+		{"unknown field", `{"label": "Bedroom TV"}`},
+		{"second document", `{"name": "Bedroom TV"}{"name": "again"}`},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			handler, store := newDevicesTestHandler(t)
+			seedDevice(t, store, "profile-1", "device-2", "Apple TV")
+
+			rec := renameDevice(t, handler, "/devices/device-2", "device-2", "profile-1", tc.body)
+			if rec.Code != http.StatusBadRequest {
+				t.Fatalf("PATCH = %d, want 400: %s", rec.Code, rec.Body.String())
+			}
+			if got := customNameFor(t, store, "profile-1", "device-2"); got != "" {
+				t.Errorf("malformed body still renamed the device to %q", got)
+			}
+		})
+	}
+}
+
 // --- Household scope ---
 
 func householdDevicesHandler(t *testing.T) (*DeviceHandler, userstore.UserStore) {
@@ -380,6 +549,35 @@ func TestForgetDevice_PrimaryMayForgetHouseholdDevice(t *testing.T) {
 	}
 	if exists {
 		t.Error("device survived the household forget")
+	}
+}
+
+func TestRenameDevice_PrimaryMayRenameHouseholdDevice(t *testing.T) {
+	handler, store := householdDevicesHandler(t)
+	seedDevice(t, store, "profile-2", "device-9", "Robin's iPad")
+
+	rec := renameDevice(t, handler, "/devices/device-9?profile_id=profile-2",
+		"device-9", "profile-1", `{"name": "Robin's school iPad"}`)
+	if rec.Code != http.StatusNoContent {
+		t.Fatalf("primary renaming a household device = %d: %s", rec.Code, rec.Body.String())
+	}
+	if got := customNameFor(t, store, "profile-2", "device-9"); got != "Robin's school iPad" {
+		t.Errorf("custom name = %q, want Robin's school iPad", got)
+	}
+}
+
+func TestRenameDevice_NonPrimaryCannotRenameSiblingsDevice(t *testing.T) {
+	handler, store := householdDevicesHandler(t)
+	seedDevice(t, store, "profile-1", "device-1", "Sam's laptop")
+
+	rec := renameDevice(t, handler, "/devices/device-1?profile_id=profile-1",
+		"device-1", "profile-2", `{"name": "Not yours"}`)
+	if rec.Code != http.StatusForbidden {
+		t.Fatalf("non-primary renaming a sibling's device = %d, want 403: %s",
+			rec.Code, rec.Body.String())
+	}
+	if got := customNameFor(t, store, "profile-1", "device-1"); got != "" {
+		t.Errorf("a non-primary profile renamed a sibling's device to %q", got)
 	}
 }
 

--- a/internal/api/router.go
+++ b/internal/api/router.go
@@ -2203,6 +2203,7 @@ func NewRouter(deps Dependencies) chi.Router {
 					r.Route("/devices", func(r chi.Router) {
 						r.Use(apimw.RequireProfile)
 						r.Get("/", deviceHandler.HandleListDevices)
+						r.Patch("/{device_id}", deviceHandler.HandleRenameDevice)
 						r.Delete("/{device_id}", deviceHandler.HandleForgetDevice)
 						r.Delete("/{device_id}/settings", deviceHandler.HandleClearDeviceSettings)
 					})

--- a/internal/userdb/conformance_test.go
+++ b/internal/userdb/conformance_test.go
@@ -42,6 +42,13 @@ func TestSQLiteJellycompatDisplayPrefs(t *testing.T) {
 	storetest.RunJellycompatDisplayPrefs(t, newConformanceStore)
 }
 
+// TestSQLiteDeviceRegistry runs the device-registry conformance tests —
+// custom-name rename semantics included — against the per-user SQLite backend;
+// the Postgres backend runs the same suite in internal/userstore/pgstore.
+func TestSQLiteDeviceRegistry(t *testing.T) {
+	storetest.RunDeviceRegistry(t, newConformanceStore)
+}
+
 func TestSQLiteAddFavoriteAtReportsInsertion(t *testing.T) {
 	ctx := context.Background()
 	store := newConformanceStore(t)

--- a/internal/userdb/migrate.go
+++ b/internal/userdb/migrate.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 )
 
-const schemaVersion = 18
+const schemaVersion = 19
 
 func runMigrations(db *sql.DB) error {
 	version, err := userVersion(db)
@@ -178,7 +178,30 @@ func runMigrations(db *sql.DB) error {
 		}
 	}
 
+	if version < 19 {
+		if err := migrateToV19(tx); err != nil {
+			return err
+		}
+		if _, err := tx.Exec("PRAGMA user_version = 19"); err != nil {
+			return fmt.Errorf("setting sqlite user_version 19: %w", err)
+		}
+	}
+
 	return tx.Commit()
+}
+
+// migrateToV19 adds the nullable user_devices.custom_name column: the name the
+// profile chose for a device. NULL means none is set and clients fall back to
+// the reported device_name, which registration keeps updating and must never
+// clobber this column.
+func migrateToV19(tx *sql.Tx) error {
+	if columnExists(tx, "user_devices", "custom_name") {
+		return nil
+	}
+	if _, err := tx.Exec("ALTER TABLE user_devices ADD COLUMN custom_name TEXT"); err != nil {
+		return fmt.Errorf("adding user_devices.custom_name: %w", err)
+	}
+	return nil
 }
 
 // migrateToV18 seeds the family-neutral navigation shortcut catalog from the

--- a/internal/userdb/migrate_v19_test.go
+++ b/internal/userdb/migrate_v19_test.go
@@ -1,0 +1,78 @@
+package userdb
+
+import (
+	"context"
+	"database/sql"
+	"testing"
+)
+
+const userDevicesSchemaV18 = `
+CREATE TABLE user_devices (
+    profile_id TEXT NOT NULL,
+    device_id TEXT NOT NULL,
+    device_name TEXT NOT NULL DEFAULT '',
+    device_platform TEXT NOT NULL DEFAULT '',
+    last_seen_at TEXT NOT NULL,
+    PRIMARY KEY (profile_id, device_id)
+);`
+
+func TestMigrateToV19AddsCustomNameKeepingRows(t *testing.T) {
+	db, err := sql.Open("sqlite3", ":memory:")
+	if err != nil {
+		t.Fatalf("open sqlite: %v", err)
+	}
+	t.Cleanup(func() { _ = db.Close() })
+	if err := InitSchema(db); err != nil {
+		t.Fatalf("initial InitSchema: %v", err)
+	}
+
+	// Replace only the devices table with its released v18 shape. On a real
+	// open, InitSchema sees exactly this table before runMigrations.
+	if _, err := db.Exec("DROP TABLE user_devices"); err != nil {
+		t.Fatalf("drop current devices table: %v", err)
+	}
+	if _, err := db.Exec(userDevicesSchemaV18); err != nil {
+		t.Fatalf("create v18 devices table: %v", err)
+	}
+	if _, err := db.Exec("PRAGMA user_version = 18"); err != nil {
+		t.Fatalf("set v18: %v", err)
+	}
+	if _, err := db.Exec(`
+INSERT INTO user_devices (profile_id, device_id, device_name, device_platform, last_seen_at)
+VALUES ('p1', 'apple-tv', 'Apple TV', 'tvOS', '2026-08-01T12:00:00Z')`); err != nil {
+		t.Fatalf("seed device: %v", err)
+	}
+
+	if err := runMigrations(db); err != nil {
+		t.Fatalf("runMigrations: %v", err)
+	}
+
+	var version int
+	if err := db.QueryRow("PRAGMA user_version").Scan(&version); err != nil {
+		t.Fatalf("read user_version: %v", err)
+	}
+	if version != schemaVersion {
+		t.Fatalf("user_version = %d, want %d", version, schemaVersion)
+	}
+
+	// The existing row survives with no custom name, and is renameable
+	// through the migrated column.
+	devices, err := ListDevices(db)
+	if err != nil {
+		t.Fatalf("ListDevices: %v", err)
+	}
+	if len(devices) != 1 || devices[0].DeviceName != "Apple TV" || devices[0].CustomName != "" {
+		t.Fatalf("migrated devices = %+v, want the seeded row with an empty custom name", devices)
+	}
+	store := NewSQLiteUserStore(db)
+	if err := store.RenameDevice(context.Background(), "p1", "apple-tv", "Bedroom TV"); err != nil {
+		t.Fatalf("RenameDevice after migration: %v", err)
+	}
+	devices, err = ListDevices(db)
+	if err != nil {
+		t.Fatalf("ListDevices after rename: %v", err)
+	}
+	if len(devices) != 1 || devices[0].CustomName != "Bedroom TV" {
+		t.Fatalf("renamed devices = %+v, want custom name %q", devices, "Bedroom TV")
+	}
+}

--- a/internal/userdb/schema.go
+++ b/internal/userdb/schema.go
@@ -213,6 +213,7 @@ CREATE TABLE IF NOT EXISTS user_devices (
     device_id TEXT NOT NULL,
     device_name TEXT NOT NULL DEFAULT '',
     device_platform TEXT NOT NULL DEFAULT '',
+    custom_name TEXT,
     last_seen_at TEXT NOT NULL,
     PRIMARY KEY (profile_id, device_id)
 );

--- a/internal/userdb/settings.go
+++ b/internal/userdb/settings.go
@@ -111,7 +111,7 @@ func RegisterDevice(db *sql.DB, entry userstore.DeviceEntry) error {
 
 func ListDevices(db *sql.DB) ([]userstore.DeviceEntry, error) {
 	rows, err := db.Query(
-		`SELECT profile_id, device_id, device_name, device_platform, last_seen_at
+		`SELECT profile_id, device_id, device_name, device_platform, COALESCE(custom_name, ''), last_seen_at
 		 FROM user_devices
 		 ORDER BY last_seen_at DESC, profile_id ASC, device_name ASC, device_id ASC`,
 	)
@@ -123,7 +123,7 @@ func ListDevices(db *sql.DB) ([]userstore.DeviceEntry, error) {
 	var entries []userstore.DeviceEntry
 	for rows.Next() {
 		var entry userstore.DeviceEntry
-		if err := rows.Scan(&entry.ProfileID, &entry.DeviceID, &entry.DeviceName, &entry.DevicePlatform, &entry.LastSeenAt); err != nil {
+		if err := rows.Scan(&entry.ProfileID, &entry.DeviceID, &entry.DeviceName, &entry.DevicePlatform, &entry.CustomName, &entry.LastSeenAt); err != nil {
 			return nil, fmt.Errorf("scanning device: %w", err)
 		}
 		entries = append(entries, entry)
@@ -148,6 +148,22 @@ func DeviceExists(db *sql.DB, profileID, deviceID string) (bool, error) {
 		return false, fmt.Errorf("checking device %q: %w", deviceID, err)
 	}
 	return exists, nil
+}
+
+func RenameDevice(db *sql.DB, profileID, deviceID, customName string) error {
+	if strings.TrimSpace(profileID) == "" || strings.TrimSpace(deviceID) == "" {
+		return nil
+	}
+	_, err := db.Exec(
+		`UPDATE user_devices
+		 SET custom_name = NULLIF(?, '')
+		 WHERE profile_id = ? AND device_id = ?`,
+		customName, profileID, deviceID,
+	)
+	if err != nil {
+		return fmt.Errorf("renaming device %q: %w", deviceID, err)
+	}
+	return nil
 }
 
 func ForgetDevice(db *sql.DB, profileID, deviceID string) error {

--- a/internal/userdb/sqlitestore.go
+++ b/internal/userdb/sqlitestore.go
@@ -354,6 +354,10 @@ func (s *SQLiteUserStore) ForgetDevice(_ context.Context, profileID, deviceID st
 	return ForgetDevice(s.db, profileID, deviceID)
 }
 
+func (s *SQLiteUserStore) RenameDevice(_ context.Context, profileID, deviceID, customName string) error {
+	return RenameDevice(s.db, profileID, deviceID, customName)
+}
+
 func (s *SQLiteUserStore) SetDeviceSetting(_ context.Context, entry userstore.DeviceSettingEntry) error {
 	return SetDeviceSetting(s.db, entry)
 }

--- a/internal/userstore/pgstore/conformance_test.go
+++ b/internal/userstore/pgstore/conformance_test.go
@@ -171,3 +171,45 @@ func TestPostgresJellycompatDisplayPrefs(t *testing.T) {
 		return newStore(pool, userID)
 	})
 }
+
+// TestPostgresDeviceRegistry runs the device-registry conformance tests —
+// custom-name rename semantics included — against the Postgres backend; the
+// per-user SQLite backend runs the same suite in internal/userdb. Skips unless
+// SILO_TEST_DATABASE_URL is set and the migration is applied.
+func TestPostgresDeviceRegistry(t *testing.T) {
+	dsn := os.Getenv("SILO_TEST_DATABASE_URL")
+	if dsn == "" {
+		t.Skip("SILO_TEST_DATABASE_URL is not set")
+	}
+	ctx := context.Background()
+	pool, err := pgxpool.New(ctx, dsn)
+	if err != nil {
+		t.Fatalf("connect test database: %v", err)
+	}
+	t.Cleanup(pool.Close)
+
+	var col *string
+	err = pool.QueryRow(ctx, `SELECT column_name FROM information_schema.columns
+		WHERE table_schema = 'public' AND table_name = 'user_devices' AND column_name = 'custom_name'`).Scan(&col)
+	if errors.Is(err, pgx.ErrNoRows) || col == nil {
+		t.Skip("user_devices custom-name migration has not been applied")
+	}
+	if err != nil {
+		t.Fatalf("check migration: %v", err)
+	}
+
+	storetest.RunDeviceRegistry(t, func(t *testing.T) userstore.UserStore {
+		var userID int
+		if err := pool.QueryRow(ctx,
+			`INSERT INTO users (username, role) VALUES ($1, 'user') RETURNING id`,
+			fmt.Sprintf("conf-devices-%d", time.Now().UnixNano()),
+		).Scan(&userID); err != nil {
+			t.Fatalf("seed user: %v", err)
+		}
+		// user_devices cascades from users; assert it, as above.
+		t.Cleanup(func() {
+			deleteUserAssertingCascade(t, pool, userID, "user_devices", "user_profiles")
+		})
+		return newStore(pool, userID)
+	})
+}

--- a/internal/userstore/pgstore/settings.go
+++ b/internal/userstore/pgstore/settings.go
@@ -114,7 +114,7 @@ func (s *PostgresUserStore) RegisterDevice(ctx context.Context, entry userstore.
 
 func (s *PostgresUserStore) ListDevices(ctx context.Context) ([]userstore.DeviceEntry, error) {
 	rows, err := s.pool.Query(ctx,
-		`SELECT profile_id, device_id, device_name, device_platform, last_seen_at::text
+		`SELECT profile_id, device_id, device_name, device_platform, COALESCE(custom_name, ''), last_seen_at::text
 		 FROM user_devices
 		 WHERE user_id = $1
 		 ORDER BY last_seen_at DESC, profile_id ASC, device_name ASC, device_id ASC`,
@@ -128,7 +128,7 @@ func (s *PostgresUserStore) ListDevices(ctx context.Context) ([]userstore.Device
 	var entries []userstore.DeviceEntry
 	for rows.Next() {
 		var entry userstore.DeviceEntry
-		if err := rows.Scan(&entry.ProfileID, &entry.DeviceID, &entry.DeviceName, &entry.DevicePlatform, &entry.LastSeenAt); err != nil {
+		if err := rows.Scan(&entry.ProfileID, &entry.DeviceID, &entry.DeviceName, &entry.DevicePlatform, &entry.CustomName, &entry.LastSeenAt); err != nil {
 			return nil, fmt.Errorf("scanning device: %w", err)
 		}
 		entries = append(entries, entry)
@@ -150,6 +150,22 @@ func (s *PostgresUserStore) DeviceExists(ctx context.Context, profileID, deviceI
 		return false, fmt.Errorf("checking device %q: %w", deviceID, err)
 	}
 	return exists, nil
+}
+
+func (s *PostgresUserStore) RenameDevice(ctx context.Context, profileID, deviceID, customName string) error {
+	if strings.TrimSpace(profileID) == "" || strings.TrimSpace(deviceID) == "" {
+		return nil
+	}
+	_, err := s.pool.Exec(ctx,
+		`UPDATE user_devices
+		 SET custom_name = NULLIF($4, '')
+		 WHERE user_id = $1 AND profile_id = $2 AND device_id = $3`,
+		s.userID, profileID, deviceID, customName,
+	)
+	if err != nil {
+		return fmt.Errorf("renaming device %q: %w", deviceID, err)
+	}
+	return nil
 }
 
 func (s *PostgresUserStore) ForgetDevice(ctx context.Context, profileID, deviceID string) error {

--- a/internal/userstore/store.go
+++ b/internal/userstore/store.go
@@ -243,4 +243,9 @@ type DeviceRegistry interface {
 	// are deleted separately through the scoped setting deletes, so forgetting
 	// a device shared by two profiles leaves the other profile's row intact.
 	ForgetDevice(ctx context.Context, profileID, deviceID string) error
+	// RenameDevice sets one profile's custom name for a device; an empty name
+	// clears it, returning the device to its reported name. It updates only an
+	// existing registry row — naming a device the profile never registered is
+	// an authorization question for the caller, not a reason to invent a row.
+	RenameDevice(ctx context.Context, profileID, deviceID, customName string) error
 }

--- a/internal/userstore/storetest/devices.go
+++ b/internal/userstore/storetest/devices.go
@@ -1,0 +1,170 @@
+package storetest
+
+import (
+	"context"
+	"testing"
+
+	"github.com/Silo-Server/silo-server/internal/userstore"
+)
+
+// RunDeviceRegistry runs the device-registry conformance tests, centered on
+// the custom-name rename semantics. It is exposed separately from RunSuite so
+// each backend pins this behavior next to its own migration tests: the custom
+// name is user data that registration's header-driven upserts must never
+// clobber, and the two backends must agree on when a rename takes effect.
+func RunDeviceRegistry(t *testing.T, newStore func(t *testing.T) userstore.UserStore) {
+	ctx := context.Background()
+
+	registryFor := func(t *testing.T) (userstore.UserStore, userstore.DeviceRegistry) {
+		t.Helper()
+		store := newStore(t)
+		registry, ok := store.(userstore.DeviceRegistry)
+		if !ok {
+			t.Skip("store does not implement DeviceRegistry")
+		}
+		return store, registry
+	}
+
+	register := func(t *testing.T, registry userstore.DeviceRegistry, profileID, name string) {
+		t.Helper()
+		if err := registry.RegisterDevice(ctx, userstore.DeviceEntry{
+			ProfileID: profileID, DeviceID: deviceApple, DeviceName: name, DevicePlatform: "tvOS",
+		}); err != nil {
+			t.Fatalf("RegisterDevice: %v", err)
+		}
+	}
+
+	// deviceRow finds one profile's registry row, or nil.
+	deviceRow := func(t *testing.T, registry userstore.DeviceRegistry, profileID string) *userstore.DeviceEntry {
+		t.Helper()
+		devices, err := registry.ListDevices(ctx)
+		if err != nil {
+			t.Fatalf("ListDevices: %v", err)
+		}
+		for _, device := range devices {
+			if device.ProfileID == profileID && device.DeviceID == deviceApple {
+				return &device
+			}
+		}
+		return nil
+	}
+
+	t.Run("RenameSetsCustomNameAndKeepsReportedName", func(t *testing.T) {
+		store, registry := registryFor(t)
+		seedSettingProfiles(t, ctx, store, "p1")
+		register(t, registry, "p1", "Apple TV")
+
+		if row := deviceRow(t, registry, "p1"); row == nil || row.CustomName != "" {
+			t.Fatalf("fresh registration = %+v, want an empty custom name", row)
+		}
+		if err := registry.RenameDevice(ctx, "p1", deviceApple, "Bedroom TV"); err != nil {
+			t.Fatalf("RenameDevice: %v", err)
+		}
+		row := deviceRow(t, registry, "p1")
+		if row == nil || row.CustomName != "Bedroom TV" {
+			t.Fatalf("after rename = %+v, want custom name %q", row, "Bedroom TV")
+		}
+		if row.DeviceName != "Apple TV" {
+			t.Errorf("rename changed the reported name to %q; it must stay untouched", row.DeviceName)
+		}
+	})
+
+	t.Run("EmptyNameClears", func(t *testing.T) {
+		store, registry := registryFor(t)
+		seedSettingProfiles(t, ctx, store, "p1")
+		register(t, registry, "p1", "Apple TV")
+
+		if err := registry.RenameDevice(ctx, "p1", deviceApple, "Bedroom TV"); err != nil {
+			t.Fatalf("RenameDevice: %v", err)
+		}
+		if err := registry.RenameDevice(ctx, "p1", deviceApple, ""); err != nil {
+			t.Fatalf("clearing rename: %v", err)
+		}
+		if row := deviceRow(t, registry, "p1"); row == nil || row.CustomName != "" {
+			t.Fatalf("after clear = %+v, want an empty custom name", row)
+		}
+	})
+
+	t.Run("RenameNeverInventsARow", func(t *testing.T) {
+		store, registry := registryFor(t)
+		seedSettingProfiles(t, ctx, store, "p1")
+
+		if err := registry.RenameDevice(ctx, "p1", deviceApple, "Bedroom TV"); err != nil {
+			t.Fatalf("RenameDevice on an unregistered device: %v", err)
+		}
+		if exists, err := registry.DeviceExists(ctx, "p1", deviceApple); err != nil || exists {
+			t.Fatalf("DeviceExists = (%v, %v) after a no-op rename, want (false, nil)", exists, err)
+		}
+	})
+
+	// Two profiles register the same TV separately, and one profile owns more
+	// than one device; a rename lands on exactly the (profile, device) pair it
+	// names. The second p1 device is what catches an UPDATE missing the
+	// device_id predicate — every other subtest has one device per profile, so
+	// "renamed all of p1's devices" would otherwise pass the suite.
+	t.Run("RenameIsScopedToOneProfileAndDevice", func(t *testing.T) {
+		store, registry := registryFor(t)
+		seedSettingProfiles(t, ctx, store, "p1", "p2")
+		register(t, registry, "p1", "Apple TV")
+		register(t, registry, "p2", "Apple TV")
+		const otherDevice = "web-browser"
+		if err := registry.RegisterDevice(ctx, userstore.DeviceEntry{
+			ProfileID: "p1", DeviceID: otherDevice, DeviceName: "Chrome", DevicePlatform: "web",
+		}); err != nil {
+			t.Fatalf("RegisterDevice(%s): %v", otherDevice, err)
+		}
+
+		if err := registry.RenameDevice(ctx, "p1", deviceApple, "Bedroom TV"); err != nil {
+			t.Fatalf("RenameDevice: %v", err)
+		}
+		if row := deviceRow(t, registry, "p2"); row == nil || row.CustomName != "" {
+			t.Fatalf("p2's row = %+v; p1's rename must not leak across profiles", row)
+		}
+		devices, err := registry.ListDevices(ctx)
+		if err != nil {
+			t.Fatalf("ListDevices: %v", err)
+		}
+		for _, device := range devices {
+			if device.ProfileID == "p1" && device.DeviceID == otherDevice && device.CustomName != "" {
+				t.Fatalf("p1's other device = %+v; the rename must not touch it", device)
+			}
+		}
+	})
+
+	// The last-seen upsert runs on every request; if it reset the custom name,
+	// a rename would survive only until the device was next used.
+	t.Run("ReRegistrationPreservesCustomName", func(t *testing.T) {
+		store, registry := registryFor(t)
+		seedSettingProfiles(t, ctx, store, "p1")
+		register(t, registry, "p1", "Apple TV")
+
+		if err := registry.RenameDevice(ctx, "p1", deviceApple, "Bedroom TV"); err != nil {
+			t.Fatalf("RenameDevice: %v", err)
+		}
+		register(t, registry, "p1", "Apple TV 4K")
+		row := deviceRow(t, registry, "p1")
+		if row == nil || row.CustomName != "Bedroom TV" {
+			t.Fatalf("after re-registration = %+v, want custom name %q kept", row, "Bedroom TV")
+		}
+		if row.DeviceName != "Apple TV 4K" {
+			t.Errorf("reported name = %q, want the re-registration's %q", row.DeviceName, "Apple TV 4K")
+		}
+	})
+
+	t.Run("ForgetDropsCustomNameWithTheRow", func(t *testing.T) {
+		store, registry := registryFor(t)
+		seedSettingProfiles(t, ctx, store, "p1")
+		register(t, registry, "p1", "Apple TV")
+
+		if err := registry.RenameDevice(ctx, "p1", deviceApple, "Bedroom TV"); err != nil {
+			t.Fatalf("RenameDevice: %v", err)
+		}
+		if err := registry.ForgetDevice(ctx, "p1", deviceApple); err != nil {
+			t.Fatalf("ForgetDevice: %v", err)
+		}
+		register(t, registry, "p1", "Apple TV")
+		if row := deviceRow(t, registry, "p1"); row == nil || row.CustomName != "" {
+			t.Fatalf("re-registration after forget = %+v, want a fresh row with no custom name", row)
+		}
+	})
+}

--- a/internal/userstore/storetest/suite.go
+++ b/internal/userstore/storetest/suite.go
@@ -80,6 +80,9 @@ func RunSuite(t *testing.T, newStore func(t *testing.T) userstore.UserStore) {
 	t.Run("SettingValues", func(t *testing.T) {
 		RunSettingValues(t, newStore)
 	})
+	t.Run("DeviceRegistry", func(t *testing.T) {
+		RunDeviceRegistry(t, newStore)
+	})
 	t.Run("JellycompatDisplayPrefs", func(t *testing.T) {
 		RunJellycompatDisplayPrefs(t, newStore)
 	})

--- a/internal/userstore/types.go
+++ b/internal/userstore/types.go
@@ -47,7 +47,12 @@ type DeviceEntry struct {
 	DeviceID       string
 	DeviceName     string
 	DevicePlatform string
-	LastSeenAt     string
+	// CustomName is the name the profile chose for this device; empty means
+	// none is set and clients fall back to the reported DeviceName. It is
+	// written only by RenameDevice — registration keeps updating DeviceName
+	// and never touches this.
+	CustomName string
+	LastSeenAt string
 }
 
 // UpdateProfileInput holds optional fields for updating a profile.

--- a/migrations/sql/20260811222701_add_user_devices_custom_name.sql
+++ b/migrations/sql/20260811222701_add_user_devices_custom_name.sql
@@ -1,0 +1,11 @@
+-- +goose Up
+-- The name a profile chose for one of its devices ("Bedroom Apple TV"), so a
+-- household with three identical clients can tell them apart. NULL means none
+-- is set and clients fall back to the reported device_name; registration keeps
+-- updating device_name from request headers and never touches this column.
+ALTER TABLE public.user_devices
+    ADD COLUMN custom_name text;
+
+-- +goose Down
+ALTER TABLE public.user_devices
+    DROP COLUMN custom_name;

--- a/web/src/api/types.ts
+++ b/web/src/api/types.ts
@@ -2996,8 +2996,11 @@ export interface AdminDeviceProfileSummary {
 /** One device the signed-in viewer watches on. */
 export interface UserDevice {
   device_id: string;
+  /** The client-reported name; registration keeps it current. */
   device_name: string;
   device_platform: string;
+  /** The name this profile chose; absent until set. Render custom_name || device_name. */
+  custom_name?: string;
   last_seen_at: string;
   profile_id: string;
   profile_name: string;

--- a/web/src/components/settings/DeviceList.test.tsx
+++ b/web/src/components/settings/DeviceList.test.tsx
@@ -174,6 +174,36 @@ describe("DeviceList", () => {
     const [onlyItem] = items;
     expect(within(onlyItem!).getByText("Living Room")).toBeInTheDocument();
   });
+
+  it("shows the chosen name over the reported one", () => {
+    renderList([device({ device_id: "tv", device_name: "Apple TV", custom_name: "Bedroom TV" })]);
+
+    expect(screen.getByText("Bedroom TV")).toBeInTheDocument();
+    expect(screen.queryByText("Apple TV")).not.toBeInTheDocument();
+  });
+
+  // The reported name stays searchable after a rename: it is still what the
+  // device calls itself in its own settings screens.
+  it("finds a renamed device by either name", () => {
+    const devices = [
+      device({ device_id: "tv", device_name: "Apple TV", custom_name: "Bedroom TV" }),
+      device({ device_id: "web", device_name: "Chrome" }),
+    ];
+    const props = {
+      devices,
+      selectedDeviceId: null,
+      onSelect: vi.fn(),
+      onSearchChange: vi.fn(),
+      now: NOW,
+    };
+    const { rerender } = render(<DeviceList {...props} search="bedroom" />);
+    expect(screen.getAllByRole("listitem")).toHaveLength(1);
+    expect(screen.getByText("Bedroom TV")).toBeInTheDocument();
+
+    rerender(<DeviceList {...props} search="apple" />);
+    expect(screen.getAllByRole("listitem")).toHaveLength(1);
+    expect(screen.getByText("Bedroom TV")).toBeInTheDocument();
+  });
 });
 
 describe("DeviceList at scale", () => {

--- a/web/src/components/settings/DeviceList.tsx
+++ b/web/src/components/settings/DeviceList.tsx
@@ -8,7 +8,11 @@ import {
   PlatformIcon,
   platformKindLabel,
 } from "@/components/admin/deviceOverrides";
-import { deviceRecencyGroup, type DeviceRecencyGroup } from "@/hooks/queries/devices";
+import {
+  deviceDisplayName,
+  deviceRecencyGroup,
+  type DeviceRecencyGroup,
+} from "@/hooks/queries/devices";
 import { cn } from "@/lib/utils";
 
 const GROUP_TITLES: Record<DeviceRecencyGroup, string> = {
@@ -95,8 +99,11 @@ export function DeviceList({
       if (profileFilter && device.profile_id !== profileFilter) return false;
       if (!query) return true;
       const platform = platformKindLabel(classifyPlatform(device.device_platform));
+      // Both names are searchable: the one on screen (custom) and the one the
+      // device still calls itself (reported).
       return (
         device.device_name.toLowerCase().includes(query) ||
+        (device.custom_name ?? "").toLowerCase().includes(query) ||
         device.device_platform.toLowerCase().includes(query) ||
         platform.toLowerCase().includes(query) ||
         device.profile_name.toLowerCase().includes(query)
@@ -341,7 +348,7 @@ function DeviceRow({
       </span>
       <span className="min-w-0 flex-1">
         <span className="block truncate text-sm font-medium xl:text-[13px]">
-          {device.device_name || "Unknown device"}
+          {deviceDisplayName(device) || "Unknown device"}
         </span>
         <span className="text-muted-foreground block truncate text-[12.5px] xl:text-[11.5px]">
           {device.is_current_device

--- a/web/src/hooks/queries/devices.test.ts
+++ b/web/src/hooks/queries/devices.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from "vitest";
 
 import type { UserDevice } from "@/api/types";
-import { deviceRecencyGroup } from "@/hooks/queries/devices";
+import { deviceDisplayName, deviceRecencyGroup } from "@/hooks/queries/devices";
 import { effectiveSettingsQueryKey } from "@/hooks/queries/settingValues";
 
 const NOW = Date.parse("2026-07-31T12:00:00Z");
@@ -38,6 +38,17 @@ describe("deviceRecencyGroup", () => {
 
   it("treats an unparseable timestamp as old rather than throwing", () => {
     expect(deviceRecencyGroup(device({ last_seen_at: "nonsense" }), NOW)).toBe("earlier");
+  });
+});
+
+describe("deviceDisplayName", () => {
+  it("prefers the chosen name", () => {
+    expect(deviceDisplayName(device({ custom_name: "Bedroom TV" }))).toBe("Bedroom TV");
+  });
+
+  it("falls back to the reported name when none is chosen", () => {
+    expect(deviceDisplayName(device())).toBe("Chrome");
+    expect(deviceDisplayName(device({ custom_name: "" }))).toBe("Chrome");
   });
 });
 

--- a/web/src/hooks/queries/devices.ts
+++ b/web/src/hooks/queries/devices.ts
@@ -66,6 +66,31 @@ export function useClearDeviceSettings() {
 }
 
 /**
+ * Set the profile's own name for a device, or clear it with an empty name so
+ * the device shows its reported name again. Renaming moves no settings, so
+ * only the device list needs invalidating.
+ */
+export function useRenameDevice() {
+  const qc = useQueryClient();
+
+  return useMutation({
+    mutationFn: ({ deviceId, profileId, name }: DeviceTarget & { name: string }) =>
+      api(`/devices/${encodeURIComponent(deviceId)}${targetQuery({ deviceId, profileId })}`, {
+        method: "PATCH",
+        body: JSON.stringify({ name }),
+      }),
+    onSettled: () => {
+      void qc.invalidateQueries({ queryKey: deviceKeys.all });
+    },
+  });
+}
+
+/** What to call a device: the name its owner chose, else what it reports. */
+export function deviceDisplayName(device: UserDevice): string {
+  return device.custom_name || device.device_name;
+}
+
+/**
  * Devices grouped the way the list reads them: by how recently they were used,
  * because that is how someone identifies a device they own.
  */

--- a/web/src/pages/settings/DeviceSettings.test.tsx
+++ b/web/src/pages/settings/DeviceSettings.test.tsx
@@ -9,6 +9,7 @@ import type { SettingsCapabilities } from "@/hooks/queries/settingValues";
 const mocks = vi.hoisted(() => ({
   refetchCapabilities: vi.fn(),
   useEffectiveSettings: vi.fn(),
+  renameDevice: vi.fn(),
   capabilities: {
     data: undefined as SettingsCapabilities | undefined,
     isLoading: false,
@@ -17,25 +18,30 @@ const mocks = vi.hoisted(() => ({
   },
 }));
 
-vi.mock("@/hooks/queries/devices", () => ({
-  useMyDevices: () => ({
-    data: [
-      {
-        device_id: "living-room",
-        device_name: "Living Room TV",
-        device_platform: "tvOS",
-        last_seen_at: "2026-08-04T00:00:00Z",
-        profile_id: "profile-1",
-        profile_name: "Taylor",
-        is_current_device: true,
-        changed_count: 0,
-      },
-    ],
-    isLoading: false,
-  }),
-  useClearDeviceSettings: () => ({ mutate: vi.fn(), isPending: false }),
-  useForgetDevice: () => ({ mutate: vi.fn(), isPending: false }),
-}));
+vi.mock("@/hooks/queries/devices", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@/hooks/queries/devices")>();
+  return {
+    ...actual,
+    useMyDevices: () => ({
+      data: [
+        {
+          device_id: "living-room",
+          device_name: "Living Room TV",
+          device_platform: "tvOS",
+          last_seen_at: "2026-08-04T00:00:00Z",
+          profile_id: "profile-1",
+          profile_name: "Taylor",
+          is_current_device: true,
+          changed_count: 0,
+        },
+      ],
+      isLoading: false,
+    }),
+    useClearDeviceSettings: () => ({ mutate: vi.fn(), isPending: false }),
+    useForgetDevice: () => ({ mutate: vi.fn(), isPending: false }),
+    useRenameDevice: () => ({ mutate: mocks.renameDevice, isPending: false }),
+  };
+});
 
 vi.mock("@/hooks/queries/settingValues", async (importOriginal) => {
   const actual = await importOriginal<typeof import("@/hooks/queries/settingValues")>();
@@ -149,5 +155,60 @@ describe("DeviceSettings capability discovery", () => {
     );
     expect(screen.getByText("Editable device defaults")).toBeInTheDocument();
     expect(screen.queryByRole("alert")).not.toBeInTheDocument();
+  });
+});
+
+describe("DeviceSettings rename", () => {
+  beforeEach(() => {
+    mocks.renameDevice.mockReset();
+    mocks.useEffectiveSettings.mockReset();
+    mocks.useEffectiveSettings.mockReturnValue({ data: {}, isLoading: false });
+    mocks.capabilities.data = undefined;
+    mocks.capabilities.isLoading = false;
+    mocks.capabilities.isError = true;
+    mocks.capabilities.isFetching = false;
+  });
+
+  it("renames the device through the header affordance", async () => {
+    const user = userEvent.setup();
+    render(<DeviceSettings />);
+
+    await user.click(screen.getByRole("button", { name: "Rename" }));
+    const input = screen.getByLabelText("Device name");
+    // The reported name sits in the placeholder, so an empty save reads as
+    // returning to it.
+    expect(input).toHaveAttribute("placeholder", "Living Room TV");
+    await user.type(input, "Den TV");
+    await user.click(screen.getByRole("button", { name: "Save" }));
+
+    expect(mocks.renameDevice).toHaveBeenCalledWith(
+      { deviceId: "living-room", profileId: undefined, name: "Den TV" },
+      expect.anything(),
+    );
+  });
+
+  it("clears the custom name by saving an empty field", async () => {
+    const user = userEvent.setup();
+    render(<DeviceSettings />);
+
+    await user.click(screen.getByRole("button", { name: "Rename" }));
+    await user.click(screen.getByRole("button", { name: "Save" }));
+
+    expect(mocks.renameDevice).toHaveBeenCalledWith(
+      { deviceId: "living-room", profileId: undefined, name: "" },
+      expect.anything(),
+    );
+  });
+
+  it("abandons the edit on cancel", async () => {
+    const user = userEvent.setup();
+    render(<DeviceSettings />);
+
+    await user.click(screen.getByRole("button", { name: "Rename" }));
+    await user.type(screen.getByLabelText("Device name"), "Den TV");
+    await user.click(screen.getByRole("button", { name: "Cancel" }));
+
+    expect(mocks.renameDevice).not.toHaveBeenCalled();
+    expect(screen.getByRole("heading", { name: "Living Room TV" })).toBeInTheDocument();
   });
 });

--- a/web/src/pages/settings/DeviceSettings.tsx
+++ b/web/src/pages/settings/DeviceSettings.tsx
@@ -1,9 +1,10 @@
 import { useEffect, useMemo, useState } from "react";
-import { ChevronLeft, Info, ShieldCheck, Trash2, Users } from "lucide-react";
+import { ChevronLeft, Info, Pencil, ShieldCheck, Trash2, Users } from "lucide-react";
 import { toast } from "sonner";
 
 import type { UserDevice } from "@/api/types";
 import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
 import { Skeleton } from "@/components/ui/skeleton";
 import {
   classifyPlatform,
@@ -13,7 +14,13 @@ import {
 import { DeviceList, lastSeenLabel } from "@/components/settings/DeviceList";
 import { DeviceSettingGroups } from "@/components/settings/DeviceSettingGroups";
 import { SubtitleAppearancePanelView } from "@/components/settings/SubtitleAppearancePanelView";
-import { useClearDeviceSettings, useForgetDevice, useMyDevices } from "@/hooks/queries/devices";
+import {
+  deviceDisplayName,
+  useClearDeviceSettings,
+  useForgetDevice,
+  useMyDevices,
+  useRenameDevice,
+} from "@/hooks/queries/devices";
 import {
   settingsCapabilitiesSupportKey,
   useSettingsCapabilities,
@@ -264,6 +271,28 @@ function DeviceDetail({
   const clearValue = useClearSettingValue();
   const clearDevice = useClearDeviceSettings();
   const forgetDevice = useForgetDevice();
+  const renameDevice = useRenameDevice();
+
+  // Renaming edits in place where the name is shown. The draft starts from the
+  // custom name only: the reported name sits in the placeholder, so an empty
+  // save reads as what it is — going back to what the device calls itself.
+  const [renaming, setRenaming] = useState(false);
+  const [draftName, setDraftName] = useState("");
+  const displayName = deviceDisplayName(device) || "Unknown device";
+
+  const submitRename = () => {
+    const name = draftName.trim();
+    renameDevice.mutate(
+      { deviceId: device.device_id, profileId: targetProfileId, name },
+      {
+        onSuccess: () => {
+          toast.success(name ? "Device renamed" : "Back to the device's own name");
+          setRenaming(false);
+        },
+        onError: (error) => toast.error(error instanceof Error ? error.message : "Couldn't rename"),
+      },
+    );
+  };
 
   const identity = {
     scope: "profile_device" as const,
@@ -299,23 +328,81 @@ function DeviceDetail({
             <PlatformIcon kind={kind} className="h-5 w-5" />
           </span>
           <div className="min-w-0 flex-1">
-            {/* Wraps rather than truncating: on a phone the name is the whole
-                subject of the screen, and "Living Room Apple…" is not it. */}
-            <h3 className="text-lg leading-tight font-semibold tracking-tight">
-              {device.device_name || "Unknown device"}
-            </h3>
+            {renaming ? (
+              <form
+                className="flex flex-col gap-2 sm:flex-row sm:items-center"
+                onSubmit={(event) => {
+                  event.preventDefault();
+                  submitRename();
+                }}
+              >
+                <Input
+                  value={draftName}
+                  onChange={(event) => setDraftName(event.target.value)}
+                  placeholder={device.device_name || "Device name"}
+                  aria-label="Device name"
+                  // The server clamps to the same 120 characters a reported
+                  // name may carry.
+                  maxLength={120}
+                  autoFocus
+                  className="h-11 text-base sm:h-9 sm:text-sm"
+                />
+                <div className="flex gap-2">
+                  <Button
+                    type="submit"
+                    variant="outline"
+                    disabled={renameDevice.isPending}
+                    className="min-h-11 sm:h-9 sm:min-h-0 sm:px-3 sm:text-sm"
+                  >
+                    Save
+                  </Button>
+                  <Button
+                    type="button"
+                    variant="ghost"
+                    onClick={() => setRenaming(false)}
+                    className="text-muted-foreground min-h-11 sm:h-9 sm:min-h-0 sm:px-3 sm:text-sm"
+                  >
+                    Cancel
+                  </Button>
+                </div>
+              </form>
+            ) : (
+              /* Wraps rather than truncating: on a phone the name is the whole
+                 subject of the screen, and "Living Room Apple…" is not it. */
+              <h3 className="text-lg leading-tight font-semibold tracking-tight">{displayName}</h3>
+            )}
             <p className="text-muted-foreground mt-0.5 text-[13px] leading-snug">
               {[
+                // With three renamed Apple TVs, the reported name is how you
+                // check you renamed the right one.
+                device.custom_name && device.device_name
+                  ? `reports as “${device.device_name}”`
+                  : null,
                 platformKindLabel(kind),
                 device.is_current_device ? "using now" : lastSeenLabel(device.last_seen_at, now),
                 changedCount > 0
                   ? `${changedCount} ${changedCount === 1 ? "thing" : "things"} set differently`
                   : "nothing changed here",
-              ].join(" · ")}
+              ]
+                .filter(Boolean)
+                .join(" · ")}
             </p>
           </div>
         </div>
         <div className="mt-3 flex flex-col gap-2 sm:flex-row sm:flex-wrap">
+          {!renaming ? (
+            <Button
+              variant="outline"
+              className="min-h-11 w-full sm:h-8 sm:min-h-0 sm:w-auto sm:px-3 sm:text-sm"
+              onClick={() => {
+                setDraftName(device.custom_name ?? "");
+                setRenaming(true);
+              }}
+            >
+              <Pencil className="h-3.5 w-3.5" />
+              Rename
+            </Button>
+          ) : null}
           {changedCount > 0 ? (
             <Button
               variant="outline"
@@ -324,7 +411,7 @@ function DeviceDetail({
               onClick={() => {
                 if (
                   !window.confirm(
-                    `Clear all ${changedCount} ${changedCount === 1 ? "change" : "changes"} on ${device.device_name}?`,
+                    `Clear all ${changedCount} ${changedCount === 1 ? "change" : "changes"} on ${displayName}?`,
                   )
                 ) {
                   return;
@@ -350,7 +437,7 @@ function DeviceDetail({
               onClick={() => {
                 if (
                   !window.confirm(
-                    `Forget ${device.device_name}? Its settings are removed and it disappears from this list until it's used again.`,
+                    `Forget ${displayName}? Its settings are removed and it disappears from this list until it's used again.`,
                   )
                 ) {
                   return;
@@ -482,7 +569,7 @@ function DeviceDetail({
           setAppearanceOpen(false);
         }}
         resetLabel={`Use ${ownerLabel} style`}
-        eyebrow={device.device_name || "This device"}
+        eyebrow={deviceDisplayName(device) || "This device"}
         status={setValue.isPending ? "Saving…" : "Changes saved automatically"}
       />
 


### PR DESCRIPTION
### Problem
Part of #603

The Devices settings page shows the client-reported device name
(`X-Device-Name`). Apple clients report the model, so a household with several
Apple TVs sees "Apple TV" repeated with nothing but last-seen times to tell
the rows apart — you can't know which one you're forgetting or configuring.

### Approach
A user-set custom name, stored per (profile, device) row in the device
registry, never overwriting the reported name:

- `DeviceRegistry.RenameDevice(ctx, profileID, deviceID, customName)`; empty
  clears. Blind UPDATE — the handler owns existence semantics. Both backends
  (Postgres `NULLIF`, per-user SQLite), goose migration + SQLite
  schemaVersion 18→19, and a shared storetest conformance suite so the
  backends are proven equivalent (including: re-registration/last-seen upserts
  preserve the custom name).
- `PATCH /api/v1/devices/{device_id}` `{"name": "Living Room"}` → 204.
  `*string` distinguishes clear from missing; trimmed and clamped to the same
  120 runes as `X-Device-Name`. Authorization mirrors the forget route
  exactly: own profile, or `?profile_id=` behind the household-parent guard;
  unknown/unowned → 404 (same anti-enumeration rationale as forget).
- `deviceResponse` gains `custom_name,omitempty` (additive); `device_name`
  stays the reported name so platform identification survives.
- Web: device rows render `custom_name || device_name` (search matches both);
  inline rename in the device detail header, placeholder = reported name, and
  a "reports as …" meta line when renamed.
- Audit: `rename_device` action via the existing identity-only audit record
  for household-parent renames (never logs the chosen name, matching policy).

Deliberately out of scope: the admin device console (account-wide roll-up of
per-profile names is a separate design question) and the native clients
(silo-apple / silo-android render `device_name` today; follow-up to prefer
`custom_name`).

### Testing
All commands run for real; excerpts below (full raw logs available on request).

```
$ go build ./...        # OK
$ go test ./internal/api/handlers/... ./internal/userstore/... ./internal/userdb/... -count=1
ok  github.com/Silo-Server/silo-server/internal/api/handlers   83.727s
ok  github.com/Silo-Server/silo-server/internal/userstore      0.015s
ok  github.com/Silo-Server/silo-server/internal/userstore/pgstore  0.614s
ok  github.com/Silo-Server/silo-server/internal/userdb         0.350s
```

Real-Postgres conformance (fresh disposable pgvector/pg17 container, repo's
goose runner applied the new migration — also exercised down→up), re-run after
every migration-file change:

```
$ SILO_TEST_DATABASE_URL=… go test ./internal/userstore/pgstore/... -count=1
=== RUN   TestPostgresDeviceRegistry/RenameIsScopedToOneProfileAndDevice
--- PASS: TestPostgresDeviceRegistry (0.05s)
ok  github.com/Silo-Server/silo-server/internal/userstore/pgstore  0.616s
```

- `golangci-lint run` scoped to changed packages: no findings on touched lines
  (full-repo run has pre-existing findings; CI gates on new lines per AGENTS.md).
- Web: `pnpm run lint` 0 errors; `pnpm run format:check` clean; full vitest
  suite with the Makefile's known-failure excludes: 273 files / 1884 tests passed.
- Note: full `go test ./...` had one unrelated flake (`internal/policy`, a
  25 ms eval timeout on a loaded host); the package passes when re-run alone.

Screenshots (from a running build of this branch — the household has two
devices both reporting "Apple TV"; one renamed to "Living Room"):

![Device list with duplicate Apple TVs and the renamed Living Room](https://raw.githubusercontent.com/Daicaa/silo-server/7564ad0f244cf5be65d99a2b9db668cadb10fa28/rename-01-device-list.png)
![Inline rename open, reported name as placeholder](https://raw.githubusercontent.com/Daicaa/silo-server/7564ad0f244cf5be65d99a2b9db668cadb10fa28/rename-02-detail-rename.png)

### AI Disclosure
- Tool(s): Claude Code
- Model(s): claude-fable-5
- Involvement: AI-assisted (implementation and tests AI-generated from my
  design; I reviewed the diff, ran all verification myself, and run this
  server in production)
- Adversarial review: an independent AI review (claude-fable-5) verified the
  SQL against the real PK, proved the registration upsert can't clobber
  custom names, and checked migration safety in all three SQLite states plus
  goose ordering. It confirmed two real defects, both fixed with tests: a NUL
  byte in the JSON name would 500 on Postgres while SQLite stored it (control
  runes now stripped before the clamp — the header path was immune, the body
  path wasn't), and the conformance suite couldn't have caught an UPDATE
  missing the device_id predicate (a second same-profile device now pins it).
  Also fixed per review: audit comment accuracy, `public.` prefix in the
  migration. Explicitly reviewed-and-accepted: blind-UPDATE rename racing a
  forget yields an idempotent 204 (matches the file's forget semantics);
  admin surfaces intentionally don't show per-profile custom names.

### Checklist
- [x] I ran an adversarial AI review of the diff and summarized findings above.
- [x] I ran the repo verify commands: `make lint`, `cd web && pnpm run lint`,
      `cd web && pnpm run format:check`, and relevant `go test ./...`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added custom device names in Settings, with inline editing, saving, clearing, and canceling.
  - Device names are trimmed and limited to 120 characters.
  - Custom names appear throughout device settings, while reported device names remain visible as supporting details.
  - Device search now matches both custom and reported names.
  - Authorized household profiles can rename permitted devices.

- **Bug Fixes**
  - Improved handling of invalid, unknown, or unauthorized rename requests.
  - Device names now safely remove unsupported control characters.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->