### PR TITLE
fix(playback): restore Safari Dolby Vision Profile 8 remux

### DIFF
--- a/cmd/playbackfixtures/main.go
+++ b/cmd/playbackfixtures/main.go
@@ -662,6 +662,10 @@ func goldenConformanceMatrix() playback.ConformanceMatrixV3 {
 	qualityChange.ReplanRequestID = "replan-quality-change-0001"
 	qualityChange.Failure = playback.FailureV3{}
 	qualityChange.QualityPreference = resolutionHD
+	outputChange := goldenReplanRequest()
+	outputChange.Operation = playback.ReplanOperationOutputChangeV3
+	outputChange.ReplanRequestID = "replan-output-change-0001"
+	outputChange.Failure = playback.FailureV3{}
 	seekReanchor := goldenReplanRequest()
 	seekReanchor.Operation = playback.ReplanOperationSeekReanchorV3
 	seekReanchor.ReplanRequestID = "replan-seek-reanchor-0001"
@@ -685,6 +689,7 @@ func goldenConformanceMatrix() playback.ConformanceMatrixV3 {
 	replans := []playback.ReplanScenarioV3{
 		{Name: "track_change", Category: "track_change_replan", Request: trackChange, Expected: playback.ReplanExpectationV3{HTTPStatus: http.StatusOK, PreserveUnmodifiedTracks: true}},
 		{Name: "quality_change", Category: "quality_change_replan", Request: qualityChange, Expected: playback.ReplanExpectationV3{HTTPStatus: http.StatusOK, SelectedQuality: resolutionHD}},
+		{Name: "output_change", Category: "output_change_replan", Request: outputChange, Expected: playback.ReplanExpectationV3{HTTPStatus: http.StatusOK, PreserveUnmodifiedTracks: true}},
 		{Name: "track_change_idempotent_duplicate", Category: "idempotent_replan", Request: trackDuplicate, Expected: playback.ReplanExpectationV3{SameRequestAndBodyStatus: http.StatusOK, ResponseReplayedVerbatim: true, ChangedBodyStatus: http.StatusConflict, ChangedBodyError: "idempotency_key_reused"}},
 		{Name: "quality_change_idempotent_duplicate", Category: "idempotent_replan", Request: qualityDuplicate, Expected: playback.ReplanExpectationV3{SameRequestAndBodyStatus: http.StatusOK, ResponseReplayedVerbatim: true, ChangedBodyStatus: http.StatusConflict, ChangedBodyError: "idempotency_key_reused"}},
 		{Name: "track_change_concurrent_duplicate", Category: "concurrent_replan", Request: trackConcurrent, Expected: playback.ReplanExpectationV3{WhileFirstLeaseActiveStatus: http.StatusConflict, ConcurrentError: "replan_in_progress", AfterCompletionStatus: http.StatusOK, ResponseReplayedVerbatim: true}},

--- a/docs/architecture/playback-protocol-v3.md
+++ b/docs/architecture/playback-protocol-v3.md
@@ -387,7 +387,9 @@ SMPTE ST 2086 shape before advertising HDR10. Dolby Vision likewise requires a
 definitive media-element answer for the exact `dvhe.05.06` or `dvhe.08.06`
 sample entry. Both claims are scoped to `progressive`: they are cleared from
 `original_http` and `hls` because those delivery paths were not tested by the
-same probe.
+same probe. An HDR10 claim can carry `hdr10_max_width`, `hdr10_max_height`,
+`hdr10_max_frame_rate`, and `hdr10_max_bitrate_kbps`; these ceilings keep a
+successful format probe from admitting an untested stream class.
 
 ---
 

--- a/docs/architecture/playback-protocol-v3.md
+++ b/docs/architecture/playback-protocol-v3.md
@@ -380,6 +380,15 @@ HDR10, and the plan carries the `hdr_range_assumed_hdr10` degradation warning.
 Refusing to play those outright would be worse than an assumption the client is
 told about.
 
+The web client does not promote the generic high-dynamic-range media query to a
+format claim by itself. It combines that active-output signal with Media
+Capabilities support for Silo's progressive 2160p HEVC Main10, Rec. 2020, PQ,
+SMPTE ST 2086 shape before advertising HDR10. Dolby Vision likewise requires a
+definitive media-element answer for the exact `dvhe.05.06` or `dvhe.08.06`
+sample entry. Both claims are scoped to `progressive`: they are cleared from
+`original_http` and `hls` because those delivery paths were not tested by the
+same probe.
+
 ---
 
 ## 4. Deliveries

--- a/docs/architecture/playback-protocol-v3.md
+++ b/docs/architecture/playback-protocol-v3.md
@@ -109,7 +109,7 @@ The eight feature strings above are the full set this server version advertises:
 | Feature | What it promises |
 | --- | --- |
 | `playback_plan_v3` | The three plan endpoints exist and behave as specified here |
-| `neutral_playback_v3_contract_v1` | The server mints opaque `plan_attempt_key` values that clients only echo, and exposes `track_change` / `quality_change` as intent replans distinct from failure recovery |
+| `neutral_playback_v3_contract_v1` | The server mints opaque `plan_attempt_key` values that clients only echo, and exposes `track_change` / `quality_change` / `output_change` as intent replans distinct from failure recovery |
 | `layout_aware_passthrough` | Audio passthrough is decided from channel *layouts*, not just channel counts (§3) |
 | `playback_route_diagnostics` | `POST /playback/route-events` is accepted |
 | `device_quirks_v1` | Plans may carry `applied_quirks` and `runtime_corrections` (§9) |
@@ -485,7 +485,7 @@ The media's full runtime, and nothing else. Specifically:
 Replan is the only way a plan changes. It covers both "that didn't work" and
 "the user asked for something else," and the distinction matters to the server.
 
-`operation` is one of five:
+`operation` is one of six:
 
 | Operation | Meaning | Requires |
 | --- | --- | --- |
@@ -494,6 +494,7 @@ Replan is the only way a plan changes. It covers both "that didn't work" and
 | `seek_reanchor` | Move a server-anchored timeline to a new position | — |
 | `track_change` | The user picked a different audio or subtitle track | — |
 | `quality_change` | The user picked a rung from `available_qualities` | non-empty `quality_preference` |
+| `output_change` | The active display/output capabilities changed | — |
 
 The asymmetry is intentional. A seek reanchor is a timeline operation, not a
 failed recipe — a classification is still accepted from older callers but never
@@ -504,23 +505,25 @@ normalizes to `auto`, which is a different user intent than the menu selection
 the operation models, so the server rejects it rather than silently doing
 something else.
 
-**User-intent operations behave differently from failure recovery.**
-`track_change` and `quality_change` replace what were separate v2 endpoints (an
-audio PATCH and a client-posted transcode start). Nothing failed, so the previous
-route stays eligible: neither the attempted-key history nor the failed-plan
-exclusion applies. A client may therefore be handed back a plan it has already
-tried — that is correct here, and a client must not treat a repeated
-`plan_attempt_key` as a loop.
+**Intent operations behave differently from failure recovery.**
+`track_change`, `quality_change`, and `output_change` keep the previous route
+eligible because nothing established that its recipe failed: neither attempted-
+key history nor the failed-plan exclusion applies. The first two replace what
+were separate v2 endpoints (an audio PATCH and a client-posted transcode start).
+A client may therefore be handed back a plan it has already tried — that is
+correct here, and a client must not treat a repeated `plan_attempt_key` as a
+loop.
 
-When such an operation actually changes something — the request's tracks or
-quality differ from what the session currently has — the server also tries to
-return to the *requested* edition rather than staying on whatever alternate
-version a previous fallback landed on, since a user switching tracks may well
-want the original file back. That is a preference, not a guarantee: if the
-requested edition no longer resolves or fails its preflight, the healthy active
-alternate is kept. Track identities are remapped only when the edition really
-changes, because remapping within one file would degrade an exact selection to a
-best-match lookup and could silently move a listener off a commentary track.
+When such an operation actually changes something — the request's tracks,
+quality, or output capabilities differ from what the session currently has —
+the server also tries to return to the *requested* edition rather than staying
+on whatever alternate version a previous fallback landed on, since the newly
+requested intent may fit the original file again. That is a preference, not a
+guarantee: if the requested edition no longer resolves or fails its preflight,
+the healthy active alternate is kept. Track identities are remapped only when
+the edition really changes, because remapping within one file would degrade an
+exact selection to a best-match lookup and could silently move a listener off a
+commentary track.
 
 Omitting `quality_preference` on any replan preserves the session's current
 preference; sending it replaces that preference. A track change therefore does

--- a/docs/architecture/playback-protocol-v3.md
+++ b/docs/architecture/playback-protocol-v3.md
@@ -97,23 +97,24 @@ the document is always the full one:
   "enabled": true,
   "protocol_versions": [3],
   "features": ["playback_plan_v3", "neutral_playback_v3_contract_v1", "layout_aware_passthrough", "playback_route_diagnostics",
-               "device_quirks_v1", "seek_reanchor_v1", "direct_stream_resume_v1",
+               "device_quirks_v1", "seek_reanchor_v1", "output_change_v1", "direct_stream_resume_v1",
                "plan_source_duration_v1"],
   "deliveries": ["original_http", "server_remux_progressive", "server_remux_hls", "server_transcode_hls"],
   "transformations": [{"name": "audio_to_aac", "executor": "server", "recipe_version": "1", "validated_claims": ["audio_decode"]}]
 }
 ```
 
-The eight feature strings above are the full set this server version advertises:
+The nine feature strings above are the full set this server version advertises:
 
 | Feature | What it promises |
 | --- | --- |
 | `playback_plan_v3` | The three plan endpoints exist and behave as specified here |
-| `neutral_playback_v3_contract_v1` | The server mints opaque `plan_attempt_key` values that clients only echo, and exposes `track_change` / `quality_change` / `output_change` as intent replans distinct from failure recovery |
+| `neutral_playback_v3_contract_v1` | The server mints opaque `plan_attempt_key` values that clients only echo, and exposes track/quality intent replans distinct from failure recovery |
 | `layout_aware_passthrough` | Audio passthrough is decided from channel *layouts*, not just channel counts (§3) |
 | `playback_route_diagnostics` | `POST /playback/route-events` is accepted |
 | `device_quirks_v1` | Plans may carry `applied_quirks` and `runtime_corrections` (§9) |
 | `seek_reanchor_v1` | The `seek_reanchor` replan operation is available (§6) |
+| `output_change_v1` | The `output_change` intent replan is available; clients must keep the active route when this feature is absent |
 | `direct_stream_resume_v1` | A direct route may resume mid-file rather than restarting |
 | `plan_source_duration_v1` | `source.duration_seconds` is populated when known, so its absence means *unknown* rather than *unsupported* (§5) |
 

--- a/docs/design/schemas/playback-v3/v3/decision-response.schema.json
+++ b/docs/design/schemas/playback-v3/v3/decision-response.schema.json
@@ -762,7 +762,9 @@
           "type": "integer"
         },
         "dolby_vision_level": {
-          "type": "integer"
+          "type": "integer",
+          "minimum": 1,
+          "maximum": 13
         },
         "dv_bl_compat_id": {
           "type": "integer"

--- a/docs/design/schemas/playback-v3/v3/decision-response.schema.json
+++ b/docs/design/schemas/playback-v3/v3/decision-response.schema.json
@@ -761,6 +761,9 @@
         "dolby_vision_profile": {
           "type": "integer"
         },
+        "dolby_vision_level": {
+          "type": "integer"
+        },
         "dv_bl_compat_id": {
           "type": "integer"
         },

--- a/docs/design/schemas/playback-v3/v3/replan-request.schema.json
+++ b/docs/design/schemas/playback-v3/v3/replan-request.schema.json
@@ -250,6 +250,16 @@
                 "type": "integer",
                 "minimum": 1,
                 "maximum": 13
+              },
+              "bl_compatibility_ids": {
+                "type": "array",
+                "maxItems": 16,
+                "uniqueItems": true,
+                "items": {
+                  "type": "integer",
+                  "minimum": 0,
+                  "maximum": 15
+                }
               }
             },
             "additionalProperties": true

--- a/docs/design/schemas/playback-v3/v3/replan-request.schema.json
+++ b/docs/design/schemas/playback-v3/v3/replan-request.schema.json
@@ -231,6 +231,29 @@
           "items": {
             "type": "integer"
           }
+        },
+        "dolby_vision_profile_levels": {
+          "type": "array",
+          "maxItems": 16,
+          "items": {
+            "type": "object",
+            "required": [
+              "profile",
+              "max_level"
+            ],
+            "properties": {
+              "profile": {
+                "type": "integer",
+                "minimum": 1
+              },
+              "max_level": {
+                "type": "integer",
+                "minimum": 1,
+                "maximum": 13
+              }
+            },
+            "additionalProperties": true
+          }
         }
       },
       "additionalProperties": true

--- a/docs/design/schemas/playback-v3/v3/replan-request.schema.json
+++ b/docs/design/schemas/playback-v3/v3/replan-request.schema.json
@@ -31,7 +31,8 @@
         "seek_reanchor",
         "seek_failure_recovery",
         "track_change",
-        "quality_change"
+        "quality_change",
+        "output_change"
       ],
       "maxLength": 32
     },
@@ -152,7 +153,7 @@
     },
     "failure": {
       "type": "object",
-      "description": "Required for failure_recovery and seek_failure_recovery: both need a non-empty classification. A track_change or quality_change carries no failure.",
+      "description": "Required for failure_recovery and seek_failure_recovery: both need a non-empty classification. Intent operations carry no failure.",
       "properties": {
         "classification": {
           "type": "string",

--- a/docs/design/schemas/playback-v3/v3/replan-request.schema.json
+++ b/docs/design/schemas/playback-v3/v3/replan-request.schema.json
@@ -226,6 +226,22 @@
         "hlg": {
           "type": "boolean"
         },
+        "hdr10_max_width": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "hdr10_max_height": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "hdr10_max_frame_rate": {
+          "type": "number",
+          "minimum": 0
+        },
+        "hdr10_max_bitrate_kbps": {
+          "type": "integer",
+          "minimum": 0
+        },
         "dolby_vision_profiles": {
           "type": "array",
           "maxItems": 16,
@@ -267,6 +283,22 @@
           }
         }
       },
+      "allOf": [
+        {
+          "if": {
+            "anyOf": [
+              { "required": ["hdr10_max_width"] },
+              { "required": ["hdr10_max_height"] },
+              { "required": ["hdr10_max_frame_rate"] },
+              { "required": ["hdr10_max_bitrate_kbps"] }
+            ]
+          },
+          "then": {
+            "required": ["hdr10"],
+            "properties": { "hdr10": { "const": true } }
+          }
+        }
+      ],
       "additionalProperties": true
     },
     "audio_passthrough": {
@@ -689,6 +721,30 @@
             "minLength": 1,
             "pattern": "\\S"
           }
+        }
+      }
+    },
+    {
+      "$comment": "Intent-only replans describe a user or output change and must not carry route-failure evidence.",
+      "if": {
+        "properties": {
+          "operation": {
+            "enum": [
+              "track_change",
+              "quality_change",
+              "output_change"
+            ]
+          }
+        },
+        "required": [
+          "operation"
+        ]
+      },
+      "then": {
+        "not": {
+          "required": [
+            "failure"
+          ]
         }
       }
     }

--- a/docs/design/schemas/playback-v3/v3/start-request.schema.json
+++ b/docs/design/schemas/playback-v3/v3/start-request.schema.json
@@ -202,6 +202,16 @@
                 "type": "integer",
                 "minimum": 1,
                 "maximum": 13
+              },
+              "bl_compatibility_ids": {
+                "type": "array",
+                "maxItems": 16,
+                "uniqueItems": true,
+                "items": {
+                  "type": "integer",
+                  "minimum": 0,
+                  "maximum": 15
+                }
               }
             },
             "additionalProperties": true

--- a/docs/design/schemas/playback-v3/v3/start-request.schema.json
+++ b/docs/design/schemas/playback-v3/v3/start-request.schema.json
@@ -177,6 +177,22 @@
         "hlg": {
           "type": "boolean"
         },
+        "hdr10_max_width": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "hdr10_max_height": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "hdr10_max_frame_rate": {
+          "type": "number",
+          "minimum": 0
+        },
+        "hdr10_max_bitrate_kbps": {
+          "type": "integer",
+          "minimum": 0
+        },
         "dolby_vision_profiles": {
           "type": "array",
           "maxItems": 16,
@@ -218,6 +234,22 @@
           }
         }
       },
+      "allOf": [
+        {
+          "if": {
+            "anyOf": [
+              { "required": ["hdr10_max_width"] },
+              { "required": ["hdr10_max_height"] },
+              { "required": ["hdr10_max_frame_rate"] },
+              { "required": ["hdr10_max_bitrate_kbps"] }
+            ]
+          },
+          "then": {
+            "required": ["hdr10"],
+            "properties": { "hdr10": { "const": true } }
+          }
+        }
+      ],
       "additionalProperties": true
     },
     "audio_passthrough": {

--- a/docs/design/schemas/playback-v3/v3/start-request.schema.json
+++ b/docs/design/schemas/playback-v3/v3/start-request.schema.json
@@ -183,6 +183,29 @@
           "items": {
             "type": "integer"
           }
+        },
+        "dolby_vision_profile_levels": {
+          "type": "array",
+          "maxItems": 16,
+          "items": {
+            "type": "object",
+            "required": [
+              "profile",
+              "max_level"
+            ],
+            "properties": {
+              "profile": {
+                "type": "integer",
+                "minimum": 1
+              },
+              "max_level": {
+                "type": "integer",
+                "minimum": 1,
+                "maximum": 13
+              }
+            },
+            "additionalProperties": true
+          }
         }
       },
       "additionalProperties": true

--- a/internal/api/handlers/playback_v3.go
+++ b/internal/api/handlers/playback_v3.go
@@ -430,7 +430,7 @@ func (h *PlaybackHandler) handleStartPlaybackV3(w http.ResponseWriter, r *http.R
 		Registry: h.transformationRegistryV3(r.Context()), HLSRegistry: h.lazyHLSPlanningRegistryV3(r.Context()), DVRPUStrippable: h.lazyDVRPUStrippableV3(r.Context(), effectiveFile), Now: time.Now(),
 		AdditionalSubtitles: h.downloadedSubtitleInventoryV3(r.Context(), effectiveFile),
 	})
-	if result.Terminal != nil && result.Terminal.Reason == "no_alternate_version" && shouldTryAlternateFileV3(req.QualityPreference) {
+	if terminalAllowsAlternateFileV3(result.Terminal) && shouldTryAlternateFileV3(req.QualityPreference) {
 		if alternate, alternateErr := h.findAlternateFile(r.Context(), requestedFile); alternateErr == nil && alternate != nil {
 			effectiveFile = h.ensurePlaybackProbe(r.Context(), alternate)
 			audioIndex = remapAudioIndexV3(requestedFile, effectiveFile, audioIndex)
@@ -1732,7 +1732,7 @@ func (h *PlaybackHandler) executeReplanV3(r *http.Request, record *playback.Atte
 	} else {
 		result = playback.PlanPlaybackV3(playback.PlannerInputV3{Request: start, RequestedFile: plannerRequestedFile, EffectiveFile: effectiveFile, AudioTrackIndex: audioIndex, Settings: h.plannerSettingsV3(r.Context()), Registry: h.transformationRegistryV3(r.Context()), HLSRegistry: h.lazyHLSPlanningRegistryV3(r.Context()), DVRPUStrippable: h.lazyDVRPUStrippableV3(r.Context(), effectiveFile), Now: time.Now(), AttemptedKeys: attemptedKeys, AdditionalSubtitles: h.downloadedSubtitleInventoryV3(r.Context(), effectiveFile)})
 	}
-	if result.Terminal != nil && result.Terminal.Reason == "no_alternate_version" && replanAllowsAlternateFileV3(operation, start.QualityPreference) {
+	if terminalAllowsAlternateFileV3(result.Terminal) && replanAllowsAlternateFileV3(operation, start.QualityPreference) {
 		if alternate, alternateErr := h.findAlternateFile(r.Context(), requestedFile); alternateErr == nil && alternate != nil {
 			alternate = h.ensurePlaybackProbe(r.Context(), alternate)
 			remappedAudio := remapAudioIndexV3(effectiveFile, alternate, audioIndex)
@@ -2334,6 +2334,18 @@ func shouldTryAlternateFileV3(qualityPreference string) bool {
 	return !strings.EqualFold(strings.TrimSpace(qualityPreference), "original")
 }
 
+const (
+	terminalNoAlternateVersionV3      = "no_alternate_version"
+	terminalHDRTranscodeUnsupportedV3 = "hdr_transcode_unsupported"
+)
+
+func terminalAllowsAlternateFileV3(terminal *playback.TerminalV3) bool {
+	if terminal == nil {
+		return false
+	}
+	return terminal.Reason == terminalNoAlternateVersionV3 || terminal.Reason == terminalHDRTranscodeUnsupportedV3
+}
+
 func replanAllowsAlternateFileV3(operation playback.ReplanOperationV3, qualityPreference string) bool {
 	switch operation {
 	case playback.ReplanOperationFailureRecoveryV3, playback.ReplanOperationQualityChangeV3:
@@ -2354,7 +2366,7 @@ func replanAlternateFilePinnedByOriginalQualityV3(operation playback.ReplanOpera
 }
 
 func (h *PlaybackHandler) clarifyOriginalQuality4KTerminalV3(ctx context.Context, terminal *playback.TerminalV3, requestedFile *models.MediaFile, alternateFilePinned bool) {
-	if !alternateFilePinned || terminal == nil || terminal.Reason != "no_alternate_version" || terminal.Message != playback.TerminalMessage4KTranscodeDisabledV3 {
+	if !alternateFilePinned || terminal == nil || terminal.Reason != terminalNoAlternateVersionV3 || terminal.Message != playback.TerminalMessage4KTranscodeDisabledV3 {
 		return
 	}
 	if alternate, err := h.findAlternateFile(ctx, requestedFile); err == nil && alternate != nil {

--- a/internal/api/handlers/playback_v3.go
+++ b/internal/api/handlers/playback_v3.go
@@ -1521,10 +1521,11 @@ func (h *PlaybackHandler) executeReplanV3(r *http.Request, record *playback.Atte
 	seekScopedRecovery := seekReanchor || seekFailureRecovery
 	trackChange := operation == playback.ReplanOperationTrackChangeV3
 	qualityChange := operation == playback.ReplanOperationQualityChangeV3
+	outputChange := operation == playback.ReplanOperationOutputChangeV3
 	// User-intent operations replace the legacy audio PATCH and client-recipe
 	// transcode start. Nothing failed, so their previous route stays eligible:
 	// neither attempted-key history nor the failed-plan exclusion applies.
-	userIntentOperation := trackChange || qualityChange
+	userIntentOperation := trackChange || qualityChange || outputChange
 	intentChange := false
 	if seekScopedRecovery {
 		if err := validateSeekRecoveryRequestV3(record, req); err != nil {
@@ -1559,6 +1560,8 @@ func (h *PlaybackHandler) executeReplanV3(r *http.Request, record *playback.Atte
 		case qualityChange:
 			nextQuality, _ := playback.NormalizeQualityV3(req.QualityPreference)
 			intentChange = nextQuality != start.QualityPreference
+		case outputChange:
+			intentChange = true
 		default:
 			switch req.Failure.Classification {
 			case "quality_changed":
@@ -2348,10 +2351,10 @@ func terminalAllowsAlternateFileV3(terminal *playback.TerminalV3) bool {
 
 func replanAllowsAlternateFileV3(operation playback.ReplanOperationV3, qualityPreference string) bool {
 	switch operation {
-	case playback.ReplanOperationFailureRecoveryV3, playback.ReplanOperationQualityChangeV3:
-		// A quality change carries the same "another version may fit better"
-		// semantics its legacy quality_changed failure classification had; seek
-		// operations and track changes stay pinned to the mounted source.
+	case playback.ReplanOperationFailureRecoveryV3, playback.ReplanOperationQualityChangeV3, playback.ReplanOperationOutputChangeV3:
+		// Quality and output changes both carry "another version may fit better"
+		// semantics; seek operations and track changes stay pinned to the mounted
+		// source.
 		return shouldTryAlternateFileV3(qualityPreference)
 	default:
 		return false
@@ -2362,7 +2365,7 @@ func replanAlternateFilePinnedByOriginalQualityV3(operation playback.ReplanOpera
 	if shouldTryAlternateFileV3(qualityPreference) {
 		return false
 	}
-	return operation == playback.ReplanOperationFailureRecoveryV3 || operation == playback.ReplanOperationQualityChangeV3
+	return operation == playback.ReplanOperationFailureRecoveryV3 || operation == playback.ReplanOperationQualityChangeV3 || operation == playback.ReplanOperationOutputChangeV3
 }
 
 func (h *PlaybackHandler) clarifyOriginalQuality4KTerminalV3(ctx context.Context, terminal *playback.TerminalV3, requestedFile *models.MediaFile, alternateFilePinned bool) {

--- a/internal/api/handlers/playback_v3.go
+++ b/internal/api/handlers/playback_v3.go
@@ -1654,13 +1654,20 @@ func (h *PlaybackHandler) executeReplanV3(r *http.Request, record *playback.Atte
 		// from an eng/ac3 commentary track to the identically-shaped main
 		// track on a quality change.
 		if currentEffectiveFile.ID != effectiveFile.ID {
-			if err := remapAudioSelectionV3(currentEffectiveFile, effectiveFile, &start); err != nil {
-				return playback.DecisionResponseV3{}, *record, nil, &transportErrorV3{reason: "track_unavailable", message: err.Error()}
+			candidateStart := start
+			remapErr := remapAudioSelectionV3(currentEffectiveFile, effectiveFile, &candidateStart)
+			if remapErr == nil && (candidateStart.SubtitleTrackIndex != nil || candidateStart.SubtitleTrackID != "") {
+				remapErr = h.remapSubtitleSelectionV3(r.Context(), currentEffectiveFile, effectiveFile, &candidateStart)
 			}
-			if start.SubtitleTrackIndex != nil || start.SubtitleTrackID != "" {
-				if err := h.remapSubtitleSelectionV3(r.Context(), currentEffectiveFile, effectiveFile, &start); err != nil {
-					return playback.DecisionResponseV3{}, *record, nil, &transportErrorV3{reason: "track_unavailable", message: err.Error()}
-				}
+			if remapErr != nil && outputChange {
+				// An output refresh may make the requested edition viable again,
+				// but it must not retire a healthy active alternate merely because
+				// the viewer selected a track unique to that alternate.
+				effectiveFile = currentEffectiveFile
+			} else if remapErr != nil {
+				return playback.DecisionResponseV3{}, *record, nil, &transportErrorV3{reason: "track_unavailable", message: remapErr.Error()}
+			} else {
+				start = candidateStart
 			}
 		}
 	}

--- a/internal/api/handlers/playback_v3.go
+++ b/internal/api/handlers/playback_v3.go
@@ -1641,6 +1641,7 @@ func (h *PlaybackHandler) executeReplanV3(r *http.Request, record *playback.Atte
 		return playback.DecisionResponseV3{}, *record, nil, &transportErrorV3{reason: "source_unavailable", message: "The effective media source is unavailable."}
 	}
 	effectiveFile := currentEffectiveFile
+	currentEffectiveStart := start
 	if intentChange && !trackChange {
 		// Prefer returning to the requested edition, but a quality/output/track
 		// change must not abandon a healthy active alternate merely because the
@@ -1740,6 +1741,20 @@ func (h *PlaybackHandler) executeReplanV3(r *http.Request, record *playback.Atte
 			}
 		}
 	} else {
+		result = playback.PlanPlaybackV3(playback.PlannerInputV3{Request: start, RequestedFile: plannerRequestedFile, EffectiveFile: effectiveFile, AudioTrackIndex: audioIndex, Settings: h.plannerSettingsV3(r.Context()), Registry: h.transformationRegistryV3(r.Context()), HLSRegistry: h.lazyHLSPlanningRegistryV3(r.Context()), DVRPUStrippable: h.lazyDVRPUStrippableV3(r.Context(), effectiveFile), Now: time.Now(), AttemptedKeys: attemptedKeys, AdditionalSubtitles: h.downloadedSubtitleInventoryV3(r.Context(), effectiveFile)})
+	}
+	if outputChange && result.Terminal != nil && effectiveFile.ID != currentEffectiveFile.ID {
+		// Returning to the requested edition is speculative during an output
+		// refresh. Any terminal from that probe must fall back to the edition
+		// already playing, not only HDR/alternate-selection terminals: its audio,
+		// subtitle, or delivery constraints may still differ from the active file.
+		start = currentEffectiveStart
+		start.FileID = currentEffectiveFile.ID
+		effectiveFile = currentEffectiveFile
+		audioIndex, err = resolveV3AudioIndex(effectiveFile, start.AudioTrackID, start.AudioTrackIndex)
+		if err != nil {
+			return playback.DecisionResponseV3{}, *record, nil, &transportErrorV3{reason: "track_unavailable", message: err.Error()}
+		}
 		result = playback.PlanPlaybackV3(playback.PlannerInputV3{Request: start, RequestedFile: plannerRequestedFile, EffectiveFile: effectiveFile, AudioTrackIndex: audioIndex, Settings: h.plannerSettingsV3(r.Context()), Registry: h.transformationRegistryV3(r.Context()), HLSRegistry: h.lazyHLSPlanningRegistryV3(r.Context()), DVRPUStrippable: h.lazyDVRPUStrippableV3(r.Context(), effectiveFile), Now: time.Now(), AttemptedKeys: attemptedKeys, AdditionalSubtitles: h.downloadedSubtitleInventoryV3(r.Context(), effectiveFile)})
 	}
 	if terminalAllowsAlternateFileV3(result.Terminal) && replanAllowsAlternateFileV3(operation, start.QualityPreference) {
@@ -2358,10 +2373,12 @@ func terminalAllowsAlternateFileV3(terminal *playback.TerminalV3) bool {
 
 func replanAllowsAlternateFileV3(operation playback.ReplanOperationV3, qualityPreference string) bool {
 	switch operation {
-	case playback.ReplanOperationFailureRecoveryV3, playback.ReplanOperationQualityChangeV3, playback.ReplanOperationOutputChangeV3:
-		// Quality and output changes both carry "another version may fit better"
-		// semantics; seek operations and track changes stay pinned to the mounted
-		// source.
+	case playback.ReplanOperationFailureRecoveryV3, playback.ReplanOperationQualityChangeV3, playback.ReplanOperationOutputChangeV3, playback.ReplanOperationTrackChangeV3:
+		// Quality, output, and track changes can make another version the only
+		// viable route. In particular, a bitmap subtitle can require video burn-in
+		// that an HDR source cannot support while an SDR alternate can. The
+		// subtitle identity is remapped before the alternate is adopted; seek-only
+		// operations remain pinned to the mounted source.
 		return shouldTryAlternateFileV3(qualityPreference)
 	default:
 		return false

--- a/internal/api/handlers/playback_v3_test.go
+++ b/internal/api/handlers/playback_v3_test.go
@@ -116,6 +116,17 @@ func TestShouldTryAlternateFileV3PinsOriginalQuality(t *testing.T) {
 	}
 }
 
+func TestTerminalAllowsAlternateFileV3IncludesHDRIncompatibility(t *testing.T) {
+	for _, reason := range []string{"no_alternate_version", "hdr_transcode_unsupported"} {
+		if !terminalAllowsAlternateFileV3(&playback.TerminalV3{Reason: reason}) {
+			t.Fatalf("terminal reason %q should permit alternate selection", reason)
+		}
+	}
+	if terminalAllowsAlternateFileV3(&playback.TerminalV3{Reason: "client_hls_unsupported"}) {
+		t.Fatal("unrelated terminal reason should not permit alternate selection")
+	}
+}
+
 func TestValidateAdvertisedTransformationsV3RejectsOldVideoRecipe(t *testing.T) {
 	plan := &playback.PlanV3{Transformations: []playback.TransformationV3{{
 		Name:          playback.TransformationVideoToH264V3,
@@ -192,6 +203,53 @@ func TestHandleStartPlaybackV3ExplainsOriginalQuality4KPinWhenAlternateExists(t 
 				t.Fatalf("terminal = %#v, want message containing %q", response.Terminal, test.wantMessage)
 			}
 		})
+	}
+}
+
+func TestHandleStartPlaybackV3TriesAlternateAfterHDRTerminal(t *testing.T) {
+	source := v3HandlerFixtureFile(t)
+	source.CodecVideo = "hevc"
+	source.Resolution = "2160p"
+	source.Bitrate = 32_000
+	source.VideoTracks[0] = models.VideoTrack{
+		Codec: "hevc", Profile: "main 10", Level: 150, Width: 3840, Height: 2160,
+		FrameRate: "24000/1001", Bitrate: 32_000, BitDepth: 10,
+		VideoRange: "DolbyVision", VideoRangeType: "DOVIWithHDR10", DVProfile: 8, DVBLCompatID: 1,
+	}
+	alternateValue := *source
+	alternate := &alternateValue
+	alternate.ID = 84
+	alternate.CodecVideo = "h264"
+	alternate.Resolution = "1080p"
+	alternate.Bitrate = 8_000
+	alternate.VideoTracks = []models.VideoTrack{{
+		Codec: "h264", Profile: "high", Level: 41, Width: 1920, Height: 1080,
+		FrameRate: "24000/1001", Bitrate: 8_000, BitDepth: 8, VideoRange: "SDR", VideoRangeType: "SDR",
+	}}
+
+	handler := NewPlaybackHandler(playback.NewSessionManager(0, 0), testPlaybackFileResolver{file: source})
+	handler.FileVersionFetcher = testPlaybackFileVersionFetcher{byContent: map[string][]*models.MediaFile{
+		source.ContentID: {source, alternate},
+	}}
+	handler.SettingsRepo = &mutablePlaybackSettingsV3{values: map[string]string{"allow_4k_transcode": "false"}}
+	handler.PlaybackConfig = playbackTestConfig("", "")
+	handler.ItemAccess = allowAllPlaybackItemAccess{}
+
+	start := v3HandlerStartRequest()
+	start.QualityPreference = "auto"
+	start.ClientPlaybackContext.Deliveries[playback.DeliveryClassHLSV3] = playback.DeliveryCapabilityV3{
+		Enabled: true, SupportedOnDevice: true, Containers: []string{"hls"},
+		VideoCodecs: []string{"h264"}, AudioDecodeCodecs: []string{"aac"},
+	}
+	rr := httptest.NewRecorder()
+	handler.HandleStartPlayback(rr, httptest.NewRequest(http.MethodPost, "/api/v1/playback/start", strings.NewReader(marshalV3StartRequest(t, start))).WithContext(newAuthorizedPlaybackContext()))
+
+	var response playback.DecisionResponseV3
+	if rr.Code != http.StatusCreated || json.Unmarshal(rr.Body.Bytes(), &response) != nil || response.PlaybackPlan == nil {
+		t.Fatalf("status=%d body=%s", rr.Code, rr.Body.String())
+	}
+	if response.PlaybackPlan.EffectiveMediaFileID != alternate.ID {
+		t.Fatalf("effective file = %d, want alternate %d", response.PlaybackPlan.EffectiveMediaFileID, alternate.ID)
 	}
 }
 

--- a/internal/api/handlers/playback_v3_test.go
+++ b/internal/api/handlers/playback_v3_test.go
@@ -262,6 +262,7 @@ func TestReplanAllowsAlternateFileV3PinsSeekOperations(t *testing.T) {
 	}{
 		{name: "ordinary failure may use another version", operation: playback.ReplanOperationFailureRecoveryV3, quality: "auto", want: true},
 		{name: "output change may use another version", operation: playback.ReplanOperationOutputChangeV3, quality: "auto", want: true},
+		{name: "track change may use another version", operation: playback.ReplanOperationTrackChangeV3, quality: "auto", want: true},
 		{name: "original quality remains pinned", operation: playback.ReplanOperationFailureRecoveryV3, quality: "original", want: false},
 		{name: "exact seek reanchor pins current version", operation: playback.ReplanOperationSeekReanchorV3, quality: "auto", want: false},
 		{name: "failed seek recovery pins current version", operation: playback.ReplanOperationSeekFailureRecoveryV3, quality: "auto", want: false},
@@ -2902,6 +2903,108 @@ func TestHandleReplanPlaybackV3PreservesOmittedSubtitleAndReportsUnavailableInFa
 	}
 }
 
+func TestHandleReplanPlaybackV3BitmapSubtitleFallsBackFromHDRToSDRVersion(t *testing.T) {
+	source := v3HandlerFixtureFile(t)
+	source.Container = "mkv"
+	source.FilePath = writePlaybackTestMediaFile(t, "movie-4k.mkv")
+	source.CodecVideo = "hevc"
+	source.Resolution = "2160p"
+	source.Bitrate = 64_000
+	source.VideoTracks = []models.VideoTrack{{
+		Codec: "hevc", Profile: "main 10", Level: 153, Width: 3840, Height: 2160,
+		FrameRate: "24000/1001", Bitrate: 64_000, BitDepth: 10,
+		VideoRange: "HDR10", VideoRangeType: "HDR10",
+	}}
+	source.SubtitleTracks = []models.SubtitleTrack{{Index: 4, Codec: "hdmv_pgs_subtitle", Language: "eng", Title: "English"}}
+
+	alternateValue := *source
+	alternate := &alternateValue
+	alternate.ID = 84
+	alternate.FilePath = writePlaybackTestMediaFile(t, "movie-1080p.mkv")
+	alternate.CodecVideo = "h264"
+	alternate.Resolution = "1080p"
+	alternate.Bitrate = 8_000
+	alternate.VideoTracks = []models.VideoTrack{{
+		Codec: "h264", Profile: "high", Level: 41, Width: 1920, Height: 1080,
+		FrameRate: "24000/1001", Bitrate: 8_000, BitDepth: 8,
+		VideoRange: "SDR", VideoRangeType: "SDR",
+	}}
+
+	files := map[int]*models.MediaFile{source.ID: source, alternate.ID: alternate}
+	manager := playback.NewSessionManager(0, 0)
+	handler := NewPlaybackHandler(manager, mapPlaybackFileResolver{files: files})
+	handler.FileVersionFetcher = testPlaybackFileVersionFetcher{byContent: map[string][]*models.MediaFile{
+		source.ContentID: {source, alternate},
+	}}
+	handler.SettingsRepo = &mutablePlaybackSettingsV3{values: map[string]string{"transcode_enabled": "true", "allow_4k_transcode": "true"}}
+	handler.PlaybackConfig = playbackTestConfig(writePlaybackTestFFmpeg(t), t.TempDir())
+	presetLocalRegistryV3(handler, playback.NewTransformationRegistryV3([]playback.TransformationSpecV3{
+		{Name: playback.TransformationAudioToAACV3, RecipeVersion: "1", Available: true},
+		{Name: playback.TransformationVideoToH264V3, RecipeVersion: "2", Available: true},
+	}))
+	handler.ItemAccess = allowAllPlaybackItemAccess{}
+
+	startRequest := v3HandlerStartRequest()
+	startRequest.QualityPreference = "auto"
+	startRequest.Capabilities.CodecsVideo = []string{"hevc", "h264"}
+	startRequest.Capabilities.CodecsVideoHardware = []string{"hevc", "h264"}
+	startRequest.Capabilities.Containers = []string{"mkv", "hls"}
+	startRequest.Capabilities.MaxResolution = "2160p"
+	startRequest.Capabilities.VideoDecode = []playback.VideoDecodeCapabilityV3{{
+		Codec: "hevc", Profiles: []string{"main 10"}, Levels: []int{153}, BitDepths: []int{10},
+		MaxWidth: 3840, MaxHeight: 2160, MaxFrameRate: 60, MaxBitrateKbps: 80_000, Hardware: true,
+	}}
+	hdr := &playback.HDRCapabilitiesV3{HDR10: true}
+	startRequest.Capabilities.HDRDetails = hdr
+	startRequest.ClientPlaybackContext.Output.HDRDetails = hdr
+	startRequest.ClientPlaybackContext.Deliveries = map[string]playback.DeliveryCapabilityV3{
+		playback.DeliveryClassOriginalHTTPV3: {
+			Enabled: true, SupportedOnDevice: true, Containers: []string{"mkv"},
+			VideoCodecs: []string{"hevc", "h264"}, AudioDecodeCodecs: []string{"aac"},
+		},
+		playback.DeliveryClassHLSV3: {
+			Enabled: true, SupportedOnDevice: true, Containers: []string{"hls"},
+			VideoCodecs: []string{"h264"}, AudioDecodeCodecs: []string{"aac"},
+		},
+	}
+
+	startRR := httptest.NewRecorder()
+	handler.HandleStartPlayback(startRR, httptest.NewRequest(http.MethodPost, "/api/v1/playback/start", strings.NewReader(marshalV3StartRequest(t, startRequest))).WithContext(newAuthorizedPlaybackContext()))
+	var started playback.DecisionResponseV3
+	if startRR.Code != http.StatusCreated || json.Unmarshal(startRR.Body.Bytes(), &started) != nil || started.PlaybackPlan == nil {
+		t.Fatalf("start status=%d body=%s", startRR.Code, startRR.Body.String())
+	}
+	if started.PlaybackPlan.EffectiveMediaFileID != source.ID {
+		t.Fatalf("start effective file = %d, want HDR source %d", started.PlaybackPlan.EffectiveMediaFileID, source.ID)
+	}
+
+	subtitleIndex := 0
+	replanned := postPlaybackReplanV3(t, handler, started.SessionID, playback.ReplanRequestV3{
+		ProtocolVersion: playback.ProtocolV3, Operation: playback.ReplanOperationTrackChangeV3,
+		PlaybackAttemptID: startRequest.PlaybackAttemptID, ReplanRequestID: "hdr-subtitle-fallback-0001",
+		FailedPlanID: started.PlaybackPlan.PlanID, PlanAttemptID: "hdr-subtitle-attempt-0001",
+		PlanAttemptKey: started.PlaybackPlan.PlanAttemptKey, AttemptCount: 1, PositionSeconds: 30,
+		QualityPreference: "auto",
+		SelectedTracks: playback.SelectedTracksV3{
+			Audio: started.PlaybackPlan.SelectedTracks.Audio,
+			Subtitle: &playback.TrackIdentityV3{
+				ID: playback.TrackIDV3(source.ID, "subtitle", subtitleIndex), Index: &subtitleIndex,
+			},
+		},
+		Capabilities: startRequest.Capabilities, ClientPlaybackContext: startRequest.ClientPlaybackContext,
+	})
+	if replanned.PlaybackPlan == nil || replanned.Terminal != nil {
+		t.Fatalf("subtitle replan = %#v", replanned)
+	}
+	if replanned.PlaybackPlan.EffectiveMediaFileID != alternate.ID {
+		t.Fatalf("subtitle effective file = %d, want SDR alternate %d", replanned.PlaybackPlan.EffectiveMediaFileID, alternate.ID)
+	}
+	if replanned.PlaybackPlan.Subtitle.Mode != playback.SubtitleBurnInV3 || replanned.PlaybackPlan.SelectedTracks.Subtitle == nil {
+		t.Fatalf("subtitle plan = %#v, want burn-in selection", replanned.PlaybackPlan)
+	}
+	t.Cleanup(func() { handler.tm.CloseTranscodeSession(started.SessionID, "") })
+}
+
 func TestHandleReplanPlaybackV3TrackChangeStaysOnEffectiveAlternate(t *testing.T) {
 	source := v3HandlerFixtureFile(t)
 	source.Resolution = "2160p"
@@ -2988,6 +3091,72 @@ func TestHandleReplanPlaybackV3TrackChangeStaysOnEffectiveAlternate(t *testing.T
 	}
 	if outputResponse.PlaybackPlan.SelectedTracks.Subtitle == nil || !strings.HasPrefix(outputResponse.PlaybackPlan.SelectedTracks.Subtitle.ID, "file:84:subtitle:") {
 		t.Fatalf("output change lost alternate subtitle: %#v", outputResponse.PlaybackPlan.SelectedTracks.Subtitle)
+	}
+}
+
+func TestHandleReplanPlaybackV3OutputChangeRetriesActiveAlternateAfterRequestedTerminal(t *testing.T) {
+	source := v3HandlerFixtureFile(t)
+	source.Resolution, source.Bitrate = "2160p", 32_000
+	source.VideoTracks = append([]models.VideoTrack(nil), source.VideoTracks...)
+	source.VideoTracks[0].Width, source.VideoTracks[0].Height = 3840, 2160
+	source.VideoTracks[0].Level, source.VideoTracks[0].Bitrate = 51, 32_000
+
+	alternateValue := *source
+	alternate := &alternateValue
+	alternate.ID, alternate.Container, alternate.Resolution, alternate.Bitrate = 84, "mp4", "1080p", 8_000
+	alternate.VideoTracks = append([]models.VideoTrack(nil), source.VideoTracks...)
+	alternate.VideoTracks[0].Width, alternate.VideoTracks[0].Height = 1920, 1080
+	alternate.VideoTracks[0].Level, alternate.VideoTracks[0].Bitrate = 41, 8_000
+
+	files := map[int]*models.MediaFile{source.ID: source, alternate.ID: alternate}
+	handler := NewPlaybackHandler(playback.NewSessionManager(0, 0), mapPlaybackFileResolver{files: files})
+	stubCopySeekAnchorV3(handler)
+	handler.FileVersionFetcher = testPlaybackFileVersionFetcher{byContent: map[string][]*models.MediaFile{source.ContentID: {source, alternate}}}
+	handler.SettingsRepo = &mutablePlaybackSettingsV3{values: map[string]string{"allow_4k_transcode": "false"}}
+	handler.ItemAccess = allowAllPlaybackItemAccess{}
+	startRequest := v3HandlerStartRequest()
+	startRequest.QualityPreference = "auto"
+	startRequest.ClientPlaybackContext.Deliveries[playback.DeliveryClassProgressiveV3] = playback.DeliveryCapabilityV3{
+		Enabled: true, SupportedOnDevice: true, Containers: []string{"mp4"},
+		VideoCodecs: []string{"h264"}, AudioDecodeCodecs: []string{"aac"},
+	}
+	startRequest.ClientPlaybackContext.Deliveries[playback.DeliveryClassHLSV3] = playback.DeliveryCapabilityV3{
+		Enabled: true, SupportedOnDevice: true, Containers: []string{"hls"},
+		VideoCodecs: []string{"h264"}, AudioDecodeCodecs: []string{"aac"},
+	}
+
+	startRR := httptest.NewRecorder()
+	handler.HandleStartPlayback(startRR, httptest.NewRequest(http.MethodPost, "/api/v1/playback/start", strings.NewReader(marshalV3StartRequest(t, startRequest))).WithContext(newAuthorizedPlaybackContext()))
+	var started playback.DecisionResponseV3
+	if startRR.Code != http.StatusCreated || json.Unmarshal(startRR.Body.Bytes(), &started) != nil || started.PlaybackPlan == nil || started.PlaybackPlan.EffectiveMediaFileID != alternate.ID {
+		t.Fatalf("alternate start status=%d body=%s", startRR.Code, startRR.Body.String())
+	}
+	// The inactive requested edition can acquire a different constraint before
+	// an output refresh (for example after a rescan). Its speculative terminal
+	// must not displace the already-playing alternate.
+	source.Container = "mkv"
+	source.CodecVideo = "av1"
+	source.VideoTracks[0].Codec = "av1"
+	handler.SettingsRepo = &mutablePlaybackSettingsV3{values: map[string]string{"transcode_enabled": "false", "allow_4k_transcode": "false"}}
+
+	upgradedCapabilities := startRequest.Capabilities
+	upgradedCapabilities.MaxResolution = "2160p"
+	upgradedCapabilities.VideoDecode = append([]playback.VideoDecodeCapabilityV3(nil), startRequest.Capabilities.VideoDecode...)
+	upgradedCapabilities.VideoDecode[0].Levels = []int{51}
+	upgradedCapabilities.VideoDecode[0].MaxWidth = 3840
+	upgradedCapabilities.VideoDecode[0].MaxHeight = 2160
+	upgradedCapabilities.VideoDecode[0].MaxBitrateKbps = 50_000
+	response := postPlaybackReplanV3(t, handler, started.SessionID, playback.ReplanRequestV3{
+		ProtocolVersion: playback.ProtocolV3, Operation: playback.ReplanOperationOutputChangeV3,
+		PlaybackAttemptID: startRequest.PlaybackAttemptID, ReplanRequestID: "alternate-terminal-output-0001",
+		FailedPlanID: started.PlaybackPlan.PlanID, PlanAttemptID: "alternate-terminal-attempt-0001",
+		PlanAttemptKey: started.PlaybackPlan.PlanAttemptKey, AttemptCount: 1, PositionSeconds: 33,
+		SelectedTracks:        started.PlaybackPlan.SelectedTracks,
+		Capabilities:          upgradedCapabilities,
+		ClientPlaybackContext: startRequest.ClientPlaybackContext,
+	})
+	if response.Terminal != nil || response.PlaybackPlan == nil || response.PlaybackPlan.EffectiveMediaFileID != alternate.ID {
+		t.Fatalf("requested-edition terminal abandoned active alternate: %#v", response)
 	}
 }
 

--- a/internal/api/handlers/playback_v3_test.go
+++ b/internal/api/handlers/playback_v3_test.go
@@ -261,6 +261,7 @@ func TestReplanAllowsAlternateFileV3PinsSeekOperations(t *testing.T) {
 		want      bool
 	}{
 		{name: "ordinary failure may use another version", operation: playback.ReplanOperationFailureRecoveryV3, quality: "auto", want: true},
+		{name: "output change may use another version", operation: playback.ReplanOperationOutputChangeV3, quality: "auto", want: true},
 		{name: "original quality remains pinned", operation: playback.ReplanOperationFailureRecoveryV3, quality: "original", want: false},
 		{name: "exact seek reanchor pins current version", operation: playback.ReplanOperationSeekReanchorV3, quality: "auto", want: false},
 		{name: "failed seek recovery pins current version", operation: playback.ReplanOperationSeekFailureRecoveryV3, quality: "auto", want: false},
@@ -1737,10 +1738,10 @@ func TestHandleReplanPlaybackV3SeekUsesEffectiveEditionWhenRequestedEditionIsGon
 		t.Fatal(err)
 	}
 	outputContext := current.NormalizedRequest.ClientPlaybackContext
-	outputContext.Output.OutputContextID = "route-2"
 	currentKey = playback.PlanAttemptKeyV3(current.CurrentPlan, current.NormalizedRequest.ClientPlaybackContext.Output.OutputContextID, nil)
 	ordinary := playback.ReplanRequestV3{
 		ProtocolVersion:       playback.ProtocolV3,
+		Operation:             playback.ReplanOperationOutputChangeV3,
 		PlaybackAttemptID:     current.PlaybackAttemptID,
 		ReplanRequestID:       "ordinary-missing-requested-0001",
 		FailedPlanID:          current.CurrentPlanID,
@@ -1751,7 +1752,7 @@ func TestHandleReplanPlaybackV3SeekUsesEffectiveEditionWhenRequestedEditionIsGon
 		QualityPreference:     current.NormalizedRequest.QualityPreference,
 		PositionSeconds:       320,
 		SelectedTracks:        current.CurrentPlan.SelectedTracks,
-		Failure:               playback.FailureV3{Classification: "output_route_changed"},
+		Failure:               playback.FailureV3{},
 		Capabilities:          current.NormalizedRequest.Capabilities,
 		ClientPlaybackContext: outputContext,
 	}

--- a/internal/api/handlers/playback_v3_test.go
+++ b/internal/api/handlers/playback_v3_test.go
@@ -2916,6 +2916,7 @@ func TestHandleReplanPlaybackV3TrackChangeStaysOnEffectiveAlternate(t *testing.T
 	alternate.VideoTracks[0].Level, alternate.VideoTracks[0].Bitrate = 41, 8_000
 	alternate.AudioTracks = append([]models.AudioTrack(nil), source.AudioTracks...)
 	alternate.AudioTracks = append(alternate.AudioTracks, models.AudioTrack{Codec: "aac", Channels: 2, Layout: "stereo", Language: "spa"})
+	alternate.ExternalSubtitles = []models.ExternalSubtitle{{Path: writePlaybackTestMediaFile(t, "alternate.eng.ass"), Language: "eng", Format: "ass"}}
 
 	files := map[int]*models.MediaFile{source.ID: source, alternate.ID: alternate}
 	manager := playback.NewSessionManager(0, 0)
@@ -2948,6 +2949,45 @@ func TestHandleReplanPlaybackV3TrackChangeStaysOnEffectiveAlternate(t *testing.T
 	}
 	if response.PlaybackPlan.SelectedTracks.Audio == nil || response.PlaybackPlan.SelectedTracks.Audio.Index == nil || *response.PlaybackPlan.SelectedTracks.Audio.Index != audioIndex {
 		t.Fatalf("alternate audio selection = %#v", response.PlaybackPlan.SelectedTracks.Audio)
+	}
+
+	subtitleIndex := 0
+	withSubtitle := postPlaybackReplanV3(t, handler, started.SessionID, playback.ReplanRequestV3{
+		ProtocolVersion: playback.ProtocolV3, Operation: playback.ReplanOperationTrackChangeV3,
+		PlaybackAttemptID: startRequest.PlaybackAttemptID, ReplanRequestID: "alternate-subtitle-change-0001",
+		FailedPlanID: response.PlaybackPlan.PlanID, PlanAttemptID: "alternate-subtitle-attempt-0001",
+		PlanAttemptKey: response.PlaybackPlan.PlanAttemptKey, AttemptCount: 1, PositionSeconds: 31,
+		SelectedTracks: playback.SelectedTracksV3{
+			Audio:    response.PlaybackPlan.SelectedTracks.Audio,
+			Subtitle: &playback.TrackIdentityV3{Index: &subtitleIndex},
+		},
+		Capabilities: startRequest.Capabilities, ClientPlaybackContext: startRequest.ClientPlaybackContext,
+	})
+	if withSubtitle.PlaybackPlan == nil || withSubtitle.PlaybackPlan.EffectiveMediaFileID != alternate.ID || withSubtitle.PlaybackPlan.SelectedTracks.Subtitle == nil {
+		t.Fatalf("alternate subtitle selection failed: %#v", withSubtitle)
+	}
+
+	upgradedCapabilities := startRequest.Capabilities
+	upgradedCapabilities.MaxResolution = "2160p"
+	upgradedCapabilities.VideoDecode = append([]playback.VideoDecodeCapabilityV3(nil), startRequest.Capabilities.VideoDecode...)
+	upgradedCapabilities.VideoDecode[0].Levels = []int{51}
+	upgradedCapabilities.VideoDecode[0].MaxWidth = 3840
+	upgradedCapabilities.VideoDecode[0].MaxHeight = 2160
+	upgradedCapabilities.VideoDecode[0].MaxBitrateKbps = 50_000
+	outputResponse := postPlaybackReplanV3(t, handler, started.SessionID, playback.ReplanRequestV3{
+		ProtocolVersion: playback.ProtocolV3, Operation: playback.ReplanOperationOutputChangeV3,
+		PlaybackAttemptID: startRequest.PlaybackAttemptID, ReplanRequestID: "alternate-output-change-0001",
+		FailedPlanID: withSubtitle.PlaybackPlan.PlanID, PlanAttemptID: "alternate-output-attempt-0001",
+		PlanAttemptKey: withSubtitle.PlaybackPlan.PlanAttemptKey, AttemptCount: 1, PositionSeconds: 32,
+		SelectedTracks:        withSubtitle.PlaybackPlan.SelectedTracks,
+		Capabilities:          upgradedCapabilities,
+		ClientPlaybackContext: startRequest.ClientPlaybackContext,
+	})
+	if outputResponse.PlaybackPlan == nil || outputResponse.PlaybackPlan.EffectiveMediaFileID != alternate.ID {
+		t.Fatalf("output change abandoned alternate-only subtitle: %#v", outputResponse)
+	}
+	if outputResponse.PlaybackPlan.SelectedTracks.Subtitle == nil || !strings.HasPrefix(outputResponse.PlaybackPlan.SelectedTracks.Subtitle.ID, "file:84:subtitle:") {
+		t.Fatalf("output change lost alternate subtitle: %#v", outputResponse.PlaybackPlan.SelectedTracks.Subtitle)
 	}
 }
 

--- a/internal/catalogseed/service.go
+++ b/internal/catalogseed/service.go
@@ -2567,6 +2567,7 @@ func toVideoTrackRecords(tracks []models.VideoTrack) []VideoTrackRecord {
 			Codec:           track.Codec,
 			DolbyVision:     track.DolbyVision,
 			DVProfile:       track.DVProfile,
+			DVLevel:         track.DVLevel,
 			DVBLCompatID:    track.DVBLCompatID,
 			DVELPresent:     track.DVELPresent,
 			HDR10Plus:       track.HDR10Plus,

--- a/internal/catalogseed/service_test.go
+++ b/internal/catalogseed/service_test.go
@@ -7,9 +7,9 @@ import (
 	"github.com/Silo-Server/silo-server/internal/models"
 )
 
-func TestToVideoTrackRecordsPreservesColorRange(t *testing.T) {
+func TestToVideoTrackRecordsPreservesVideoMetadata(t *testing.T) {
 	got := toVideoTrackRecords([]models.VideoTrack{
-		{ColorRange: "tv"},
+		{ColorRange: "tv", DVLevel: 6},
 		{ColorRange: "pc"},
 		{ColorRange: "unknown"},
 	})
@@ -24,6 +24,9 @@ func TestToVideoTrackRecordsPreservesColorRange(t *testing.T) {
 			got[1].ColorRange,
 			got[2].ColorRange,
 		)
+	}
+	if got[0].DVLevel != 6 {
+		t.Fatalf("DVLevel = %d, want 6", got[0].DVLevel)
 	}
 }
 

--- a/internal/catalogseed/types.go
+++ b/internal/catalogseed/types.go
@@ -143,6 +143,7 @@ type VideoTrackRecord struct {
 	Codec           string `json:"codec,omitempty"`
 	DolbyVision     string `json:"dolby_vision,omitempty"`
 	DVProfile       int    `json:"dv_profile,omitempty"`
+	DVLevel         int    `json:"dv_level,omitempty"`
 	DVBLCompatID    int    `json:"dv_bl_compat_id,omitempty"`
 	DVELPresent     bool   `json:"dv_el_present,omitempty"`
 	HDR10Plus       bool   `json:"hdr10_plus,omitempty"`

--- a/internal/models/media.go
+++ b/internal/models/media.go
@@ -292,6 +292,7 @@ type VideoTrack struct {
 	Codec              string `json:"codec,omitempty"`
 	DolbyVision        string `json:"dolby_vision,omitempty"`
 	DVProfile          int    `json:"dv_profile,omitempty"`
+	DVLevel            int    `json:"dv_level,omitempty"`
 	DVBLCompatID       int    `json:"dv_bl_compat_id,omitempty"`
 	DVELPresent        bool   `json:"dv_el_present,omitempty"`
 	DVEnhancementLayer string `json:"dv_enhancement_layer,omitempty"` // none, mel, fel, unknown

--- a/internal/playback/capabilities_v3.go
+++ b/internal/playback/capabilities_v3.go
@@ -53,7 +53,9 @@ func SourceDescriptorFromFileV3(file *models.MediaFile, audioIndex int) SourceDe
 		source.DynamicRange = normalizeDynamicRangeV3(track)
 		source.HDR10Plus = track.HDR10Plus || strings.Contains(strings.ToLower(track.VideoRangeType), "hdr10+")
 		source.DVProfile = track.DVProfile
-		source.DVLevel = track.DVLevel
+		if track.DVLevel >= 1 && track.DVLevel <= 13 {
+			source.DVLevel = track.DVLevel
+		}
 		source.DVBLCompatID = track.DVBLCompatID
 		source.VideoCopyUnsafe = videoCopyUnsafeFile(file)
 		switch EnhancementLayerV3(strings.ToLower(track.DVEnhancementLayer)) {

--- a/internal/playback/capabilities_v3.go
+++ b/internal/playback/capabilities_v3.go
@@ -53,6 +53,7 @@ func SourceDescriptorFromFileV3(file *models.MediaFile, audioIndex int) SourceDe
 		source.DynamicRange = normalizeDynamicRangeV3(track)
 		source.HDR10Plus = track.HDR10Plus || strings.Contains(strings.ToLower(track.VideoRangeType), "hdr10+")
 		source.DVProfile = track.DVProfile
+		source.DVLevel = track.DVLevel
 		source.DVBLCompatID = track.DVBLCompatID
 		source.VideoCopyUnsafe = videoCopyUnsafeFile(file)
 		switch EnhancementLayerV3(strings.ToLower(track.DVEnhancementLayer)) {
@@ -202,7 +203,7 @@ func outputRangeEligibleV3(source SourceDescriptorV3, request StartRequestV3) (b
 			claims.DolbyVisionReason = "profile_7_enhancement_layer_unknown"
 			return false, claims
 		}
-		if hdr != nil && containsIntV3(hdr.DolbyVisionProfiles, source.DVProfile) {
+		if hdr != nil && hdrSupportsDolbyVisionSourceV3(*hdr, source) {
 			claims.DolbyVision = true
 			claims.DolbyVisionReason = "native_profile_supported"
 			return true, claims

--- a/internal/playback/contract/contract_test.go
+++ b/internal/playback/contract/contract_test.go
@@ -121,6 +121,7 @@ var (
 		string(playback.ReplanOperationSeekFailureRecoveryV3),
 		string(playback.ReplanOperationTrackChangeV3),
 		string(playback.ReplanOperationQualityChangeV3),
+		string(playback.ReplanOperationOutputChangeV3),
 	}
 	// The two operations ReplanRequestV3.Validate rejects without a failure
 	// classification. The schema expresses the same rule as a conditional.
@@ -213,7 +214,7 @@ func TestConformanceMatrixEmbeddedWireBodiesSatisfySchemas(t *testing.T) {
 		request := scenario["request"].(map[string]any)
 		validate(name, "replan-request.schema.json", request)
 		switch request["operation"] {
-		case string(playback.ReplanOperationTrackChangeV3), string(playback.ReplanOperationQualityChangeV3), string(playback.ReplanOperationSeekReanchorV3):
+		case string(playback.ReplanOperationTrackChangeV3), string(playback.ReplanOperationQualityChangeV3), string(playback.ReplanOperationOutputChangeV3), string(playback.ReplanOperationSeekReanchorV3):
 			if failure, ok := request["failure"]; ok {
 				t.Errorf("scenario %q intent-only replan carries failure = %#v", name, failure)
 			}

--- a/internal/playback/contract/contract_test.go
+++ b/internal/playback/contract/contract_test.go
@@ -161,6 +161,25 @@ func TestClientProgressPersistenceRequiresExplicitStartPosition(t *testing.T) {
 	}
 }
 
+func TestIntentOnlyReplansRejectFailureEvidence(t *testing.T) {
+	schemas := compileSchemasV3(t)
+	for _, operation := range []playback.ReplanOperationV3{
+		playback.ReplanOperationTrackChangeV3,
+		playback.ReplanOperationQualityChangeV3,
+		playback.ReplanOperationOutputChangeV3,
+	} {
+		t.Run(string(operation), func(t *testing.T) {
+			request := decodeJSONValue(t, mustReadFile(t, filepath.Join(goldenRootV3, "replan_request.json"))).(map[string]any)
+			request["operation"] = string(operation)
+			request["quality_preference"] = "720p"
+			request["failure"] = map[string]any{"classification": "decoder_failure"}
+			if err := schemas["replan-request.schema.json"].Validate(request); err == nil {
+				t.Fatal("intent-only replan with failure satisfied the schema")
+			}
+		})
+	}
+}
+
 // TestGoldenFixturesSatisfyTheSchemas closes the loop the schemas exist for: a
 // schema that no longer accepts what cmd/playbackfixtures emits is a schema
 // that describes a server nobody runs.

--- a/internal/playback/plan_v3.go
+++ b/internal/playback/plan_v3.go
@@ -1191,7 +1191,7 @@ func hdrDetailsSupportPlanV3(hdr HDRCapabilitiesV3, plan PlanV3) bool {
 	case "", DynamicRangeSDRV3:
 		return true
 	case DynamicRangeHDR10V3, "hdr_unknown":
-		return hdr.HDR10
+		return hdr.HDR10 && hdr10LimitsSupportPlanV3(hdr, plan)
 	case DynamicRangeHDR10PlusV3:
 		return hdr.HDR10Plus
 	case DynamicRangeHLGV3:
@@ -1209,6 +1209,13 @@ func hdrDetailsSupportPlanV3(hdr HDRCapabilitiesV3, plan PlanV3) bool {
 	default:
 		return false
 	}
+}
+
+func hdr10LimitsSupportPlanV3(hdr HDRCapabilitiesV3, plan PlanV3) bool {
+	return !(hdr.HDR10MaxWidth > 0 && (plan.EffectiveRecipe.Width == nil || *plan.EffectiveRecipe.Width > hdr.HDR10MaxWidth) ||
+		hdr.HDR10MaxHeight > 0 && (plan.EffectiveRecipe.Height == nil || *plan.EffectiveRecipe.Height > hdr.HDR10MaxHeight) ||
+		hdr.HDR10MaxFrameRate > 0 && (plan.EffectiveRecipe.FrameRate == nil || *plan.EffectiveRecipe.FrameRate > hdr.HDR10MaxFrameRate) ||
+		hdr.HDR10MaxBitrateKbps > 0 && (plan.EffectiveRecipe.BitrateKbps == nil || *plan.EffectiveRecipe.BitrateKbps > hdr.HDR10MaxBitrateKbps))
 }
 
 func hdrSupportsDolbyVisionSourceV3(hdr HDRCapabilitiesV3, source SourceDescriptorV3) bool {

--- a/internal/playback/plan_v3.go
+++ b/internal/playback/plan_v3.go
@@ -772,9 +772,13 @@ func canStripDolbyVisionToHDR10V3(source SourceDescriptorV3, request StartReques
 }
 
 func canClientTransformDV7ToDV81V3(source SourceDescriptorV3, request StartRequestV3) bool {
-	return source.DynamicRange == DynamicRangeDolbyVisionV3 && source.DVProfile == 7 &&
-		clientSupportsDVProfileV3(request, source, 8) &&
-		clientTransformationAvailableV3(request, ClientDV7ToDV81V3, ClientDVTransformVersionV3)
+	if source.DynamicRange != DynamicRangeDolbyVisionV3 || source.DVProfile != 7 ||
+		!clientTransformationAvailableV3(request, ClientDV7ToDV81V3, ClientDVTransformVersionV3) {
+		return false
+	}
+	// The registered conversion recipe produces Profile 8.1.
+	source.DVBLCompatID = 1
+	return clientSupportsDVProfileV3(request, source, 8)
 }
 
 func canClientTransformDV7ToHDR10V3(source SourceDescriptorV3, request StartRequestV3) bool {
@@ -1193,15 +1197,14 @@ func hdrDetailsSupportPlanV3(hdr HDRCapabilitiesV3, plan PlanV3) bool {
 	case DynamicRangeHLGV3:
 		return hdr.HLG
 	case DynamicRangeDolbyVisionV3:
-		profile := plan.Source.DVProfile
+		candidate := plan.Source
 		for _, transformation := range plan.Transformations {
 			if transformation.Name == ClientDV7ToDV81V3 {
-				profile = 8
+				candidate.DVProfile = 8
+				candidate.DVBLCompatID = 1
 				break
 			}
 		}
-		candidate := plan.Source
-		candidate.DVProfile = profile
 		return hdrSupportsDolbyVisionSourceV3(hdr, candidate)
 	default:
 		return false
@@ -1212,21 +1215,28 @@ func hdrSupportsDolbyVisionSourceV3(hdr HDRCapabilitiesV3, source SourceDescript
 	if !containsIntV3(hdr.DolbyVisionProfiles, source.DVProfile) {
 		return false
 	}
-	maxLevel := 0
+	var matchedCapability DolbyVisionProfileCapabilityV3
+	foundCapability := false
 	for _, capability := range hdr.DolbyVisionProfileLevels {
-		if capability.Profile == source.DVProfile && (maxLevel == 0 || capability.MaxLevel < maxLevel) {
-			maxLevel = capability.MaxLevel
+		if capability.Profile == source.DVProfile {
+			matchedCapability = capability
+			foundCapability = true
+			break
 		}
 	}
-	if maxLevel == 0 {
+	if !foundCapability {
 		// Existing clients predate level-bounded Dolby Vision claims. Once a
 		// client sends any bounds, every advertised profile must have one.
 		return len(hdr.DolbyVisionProfileLevels) == 0
 	}
-	if source.DVLevel > 0 {
-		return source.DVLevel <= maxLevel
+	if len(matchedCapability.BLCompatibilityIDs) > 0 &&
+		!containsIntV3(matchedCapability.BLCompatibilityIDs, source.DVBLCompatID) {
+		return false
 	}
-	return dolbyVisionSourceFitsLevelV3(source, maxLevel)
+	if source.DVLevel > 0 {
+		return source.DVLevel <= matchedCapability.MaxLevel
+	}
+	return dolbyVisionSourceFitsLevelV3(source, matchedCapability.MaxLevel)
 }
 
 func dolbyVisionSourceFitsLevelV3(source SourceDescriptorV3, maxLevel int) bool {

--- a/internal/playback/plan_v3.go
+++ b/internal/playback/plan_v3.go
@@ -773,7 +773,7 @@ func canStripDolbyVisionToHDR10V3(source SourceDescriptorV3, request StartReques
 
 func canClientTransformDV7ToDV81V3(source SourceDescriptorV3, request StartRequestV3) bool {
 	return source.DynamicRange == DynamicRangeDolbyVisionV3 && source.DVProfile == 7 &&
-		clientSupportsDVProfileV3(request, 8) &&
+		clientSupportsDVProfileV3(request, source, 8) &&
 		clientTransformationAvailableV3(request, ClientDV7ToDV81V3, ClientDVTransformVersionV3)
 }
 
@@ -782,12 +782,13 @@ func canClientTransformDV7ToHDR10V3(source SourceDescriptorV3, request StartRequ
 		clientTransformationAvailableV3(request, ClientDV7ToHDR10V3, ClientDVTransformVersionV3)
 }
 
-func clientSupportsDVProfileV3(request StartRequestV3, profile int) bool {
+func clientSupportsDVProfileV3(request StartRequestV3, source SourceDescriptorV3, profile int) bool {
 	hdr := request.ClientPlaybackContext.Output.HDRDetails
 	if hdr == nil {
 		hdr = request.Capabilities.HDRDetails
 	}
-	return hdr != nil && containsIntV3(hdr.DolbyVisionProfiles, profile)
+	source.DVProfile = profile
+	return hdr != nil && hdrSupportsDolbyVisionSourceV3(*hdr, source)
 }
 
 func clientTransformationAvailableV3(request StartRequestV3, name, version string) bool {
@@ -1199,10 +1200,60 @@ func hdrDetailsSupportPlanV3(hdr HDRCapabilitiesV3, plan PlanV3) bool {
 				break
 			}
 		}
-		return containsIntV3(hdr.DolbyVisionProfiles, profile)
+		candidate := plan.Source
+		candidate.DVProfile = profile
+		return hdrSupportsDolbyVisionSourceV3(hdr, candidate)
 	default:
 		return false
 	}
+}
+
+func hdrSupportsDolbyVisionSourceV3(hdr HDRCapabilitiesV3, source SourceDescriptorV3) bool {
+	if !containsIntV3(hdr.DolbyVisionProfiles, source.DVProfile) {
+		return false
+	}
+	maxLevel := 0
+	for _, capability := range hdr.DolbyVisionProfileLevels {
+		if capability.Profile == source.DVProfile && (maxLevel == 0 || capability.MaxLevel < maxLevel) {
+			maxLevel = capability.MaxLevel
+		}
+	}
+	if maxLevel == 0 {
+		// Existing clients predate level-bounded Dolby Vision claims. Once a
+		// client sends any bounds, every advertised profile must have one.
+		return len(hdr.DolbyVisionProfileLevels) == 0
+	}
+	if source.DVLevel > 0 {
+		return source.DVLevel <= maxLevel
+	}
+	return dolbyVisionSourceFitsLevelV3(source, maxLevel)
+}
+
+func dolbyVisionSourceFitsLevelV3(source SourceDescriptorV3, maxLevel int) bool {
+	// Dolby Vision Version 2.0 defines levels by maximum pixel rate, decoded
+	// width, and high-tier bitrate. Use those physical bounds for legacy rows
+	// scanned before Silo persisted ffprobe's exact dv_level.
+	type levelLimit struct {
+		pixelRate   float64
+		width       int
+		bitrateKbps int
+	}
+	limits := map[int]levelLimit{
+		1: {22_118_400, 1280, 50_000}, 2: {27_648_000, 1280, 50_000},
+		3: {49_766_400, 1920, 70_000}, 4: {62_208_000, 2560, 70_000},
+		5: {124_416_000, 3840, 70_000}, 6: {199_065_600, 3840, 130_000},
+		7: {248_832_000, 3840, 130_000}, 8: {398_131_200, 3840, 130_000},
+		9: {497_664_000, 3840, 130_000}, 10: {995_328_000, 3840, 240_000},
+		11: {995_328_000, 7680, 240_000}, 12: {1_990_656_000, 7680, 480_000},
+		13: {3_981_312_000, 7680, 800_000},
+	}
+	limit, ok := limits[maxLevel]
+	if !ok || source.Width <= 0 || source.Height <= 0 || source.FrameRate <= 0 || source.BitrateKbps <= 0 {
+		return false
+	}
+	return source.Width <= limit.width &&
+		float64(source.Width*source.Height)*source.FrameRate <= limit.pixelRate &&
+		source.BitrateKbps <= limit.bitrateKbps
 }
 func ExplainPlannerResultV3(result PlannerResultV3) string {
 	if result.Plan != nil {

--- a/internal/playback/plan_v3.go
+++ b/internal/playback/plan_v3.go
@@ -699,11 +699,11 @@ func planVideoTranscodeV3(input PlannerInputV3, base PlanV3, source SourceDescri
 		}
 		return terminalPlannerResultV3(reason, "The source requires video adaptation, but transcoding is unavailable.", false)
 	}
-	if is4KSourceV3(input.EffectiveFile, source) && !input.Settings.Allow4KTranscode {
-		return terminalPlannerResultV3("no_alternate_version", TerminalMessage4KTranscodeDisabledV3, false)
-	}
 	if hdrTranscodeUnavailableV3(source) {
 		return terminalPlannerResultV3("hdr_transcode_unsupported", "This HDR source requires video encoding, but no validated HDR-preserving or tone-map recipe is installed.", false)
+	}
+	if is4KSourceV3(input.EffectiveFile, source) && !input.Settings.Allow4KTranscode {
+		return terminalPlannerResultV3("no_alternate_version", TerminalMessage4KTranscodeDisabledV3, false)
 	}
 	if !input.hlsRegistry().Available(TransformationVideoToH264V3) || !input.hlsRegistry().Available(TransformationAudioToAACV3) {
 		return terminalPlannerResultV3("conversion_tool_unavailable", "The required validated H.264/AAC conversion toolchain is unavailable.", true)

--- a/internal/playback/protocol_v3.go
+++ b/internal/playback/protocol_v3.go
@@ -395,6 +395,9 @@ const (
 	// legacy transcode start: the client sends a quality_preference chosen from
 	// the plan's available_qualities and no failure classification.
 	ReplanOperationQualityChangeV3 ReplanOperationV3 = "quality_change"
+	// ReplanOperationOutputChangeV3 refreshes output capabilities without
+	// declaring the active route failed, so an unchanged route stays eligible.
+	ReplanOperationOutputChangeV3 ReplanOperationV3 = "output_change"
 )
 
 type ReplanRequestV3 struct {
@@ -825,6 +828,8 @@ func (r ReplanRequestV3) Validate() error {
 		if strings.TrimSpace(r.QualityPreference) == "" {
 			return errors.New("quality_change requires a quality_preference")
 		}
+	case ReplanOperationOutputChangeV3:
+		// Output capability refreshes are intent changes, not route failures.
 	default:
 		return errors.New("invalid replan operation")
 	}

--- a/internal/playback/protocol_v3.go
+++ b/internal/playback/protocol_v3.go
@@ -194,6 +194,10 @@ type HDRCapabilitiesV3 struct {
 	HDR10                    bool                             `json:"hdr10"`
 	HDR10Plus                bool                             `json:"hdr10_plus"`
 	HLG                      bool                             `json:"hlg"`
+	HDR10MaxWidth            int                              `json:"hdr10_max_width,omitempty"`
+	HDR10MaxHeight           int                              `json:"hdr10_max_height,omitempty"`
+	HDR10MaxFrameRate        float64                          `json:"hdr10_max_frame_rate,omitempty"`
+	HDR10MaxBitrateKbps      int                              `json:"hdr10_max_bitrate_kbps,omitempty"`
 	DolbyVisionProfiles      []int                            `json:"dolby_vision_profiles"`
 	DolbyVisionProfileLevels []DolbyVisionProfileCapabilityV3 `json:"dolby_vision_profile_levels,omitempty"`
 }
@@ -820,6 +824,9 @@ func (r ReplanRequestV3) Validate() error {
 		// and never selects seek semantics.
 	case ReplanOperationTrackChangeV3:
 		// A user track change is not a failure; no classification is required.
+		if r.Failure != (FailureV3{}) {
+			return errors.New("track_change must not include failure")
+		}
 	case ReplanOperationQualityChangeV3:
 		// A user quality change is not a failure either, but it must actually
 		// name the wanted rung: an empty preference would silently mean "auto",
@@ -828,8 +835,14 @@ func (r ReplanRequestV3) Validate() error {
 		if strings.TrimSpace(r.QualityPreference) == "" {
 			return errors.New("quality_change requires a quality_preference")
 		}
+		if r.Failure != (FailureV3{}) {
+			return errors.New("quality_change must not include failure")
+		}
 	case ReplanOperationOutputChangeV3:
 		// Output capability refreshes are intent changes, not route failures.
+		if r.Failure != (FailureV3{}) {
+			return errors.New("output_change must not include failure")
+		}
 	default:
 		return errors.New("invalid replan operation")
 	}
@@ -982,6 +995,12 @@ func validateCapabilitiesV3(c *ClientCodecCapabilitiesV3, ctx *ClientPlaybackCon
 func validateHDRCapabilitiesV3(hdr *HDRCapabilitiesV3) error {
 	if hdr == nil {
 		return nil
+	}
+	if hdr.HDR10MaxWidth < 0 || hdr.HDR10MaxHeight < 0 || hdr.HDR10MaxFrameRate < 0 || hdr.HDR10MaxBitrateKbps < 0 {
+		return errors.New("invalid hdr10 capability limit")
+	}
+	if !hdr.HDR10 && (hdr.HDR10MaxWidth > 0 || hdr.HDR10MaxHeight > 0 || hdr.HDR10MaxFrameRate > 0 || hdr.HDR10MaxBitrateKbps > 0) {
+		return errors.New("hdr10 capability limits require hdr10 support")
 	}
 	if len(hdr.DolbyVisionProfiles) > 16 || len(hdr.DolbyVisionProfileLevels) > 16 {
 		return errors.New("dolby vision profile list exceeds supported size")

--- a/internal/playback/protocol_v3.go
+++ b/internal/playback/protocol_v3.go
@@ -191,10 +191,16 @@ const (
 )
 
 type HDRCapabilitiesV3 struct {
-	HDR10               bool  `json:"hdr10"`
-	HDR10Plus           bool  `json:"hdr10_plus"`
-	HLG                 bool  `json:"hlg"`
-	DolbyVisionProfiles []int `json:"dolby_vision_profiles"`
+	HDR10                    bool                             `json:"hdr10"`
+	HDR10Plus                bool                             `json:"hdr10_plus"`
+	HLG                      bool                             `json:"hlg"`
+	DolbyVisionProfiles      []int                            `json:"dolby_vision_profiles"`
+	DolbyVisionProfileLevels []DolbyVisionProfileCapabilityV3 `json:"dolby_vision_profile_levels,omitempty"`
+}
+
+type DolbyVisionProfileCapabilityV3 struct {
+	Profile  int `json:"profile"`
+	MaxLevel int `json:"max_level"`
 }
 
 type AudioPassthroughV3 struct {
@@ -543,6 +549,7 @@ type SourceDescriptorV3 struct {
 	DynamicRange       string             `json:"dynamic_range,omitempty"`
 	HDR10Plus          bool               `json:"hdr10_plus"`
 	DVProfile          int                `json:"dolby_vision_profile,omitempty"`
+	DVLevel            int                `json:"dolby_vision_level,omitempty"`
 	DVBLCompatID       int                `json:"dv_bl_compat_id,omitempty"`
 	DVEnhancementLayer EnhancementLayerV3 `json:"dv_enhancement_layer"`
 	AudioCodec         string             `json:"audio_codec,omitempty"`
@@ -902,16 +909,16 @@ func validateCapabilitiesV3(c *ClientCodecCapabilitiesV3, ctx *ClientPlaybackCon
 		}
 	}
 	for _, hdr := range []*HDRCapabilitiesV3{c.HDRDetails, ctx.Output.HDRDetails} {
-		if hdr != nil && len(hdr.DolbyVisionProfiles) > 16 {
-			return errors.New("dolby vision profile list exceeds supported size")
+		if err := validateHDRCapabilitiesV3(hdr); err != nil {
+			return err
 		}
 	}
 	for name, delivery := range ctx.Deliveries {
 		if len(name) > 64 || len(delivery.Containers) > 64 || len(delivery.VideoCodecs) > 64 || len(delivery.AudioDecodeCodecs) > 64 || len(delivery.AudioPassthroughCodecs) > 64 || len(delivery.Features) > 64 || len(delivery.ValidatedClaims) > 64 || len(delivery.Transformations) > 16 {
 			return errors.New("delivery capability exceeds supported size")
 		}
-		if delivery.HDRDetails != nil && len(delivery.HDRDetails.DolbyVisionProfiles) > 16 {
-			return errors.New("dolby vision profile list exceeds supported size")
+		if err := validateHDRCapabilitiesV3(delivery.HDRDetails); err != nil {
+			return err
 		}
 		for _, values := range [][]string{delivery.Containers, delivery.VideoCodecs, delivery.AudioDecodeCodecs, delivery.AudioPassthroughCodecs, delivery.Features, delivery.ValidatedClaims} {
 			for _, value := range values {
@@ -961,6 +968,21 @@ func validateCapabilitiesV3(c *ClientCodecCapabilitiesV3, ctx *ClientPlaybackCon
 			if len(entry.Codec) > 64 || len(entry.ChannelCounts) > 32 || len(entry.Layouts) > 32 {
 				return errors.New("audio passthrough entry exceeds supported size")
 			}
+		}
+	}
+	return nil
+}
+
+func validateHDRCapabilitiesV3(hdr *HDRCapabilitiesV3) error {
+	if hdr == nil {
+		return nil
+	}
+	if len(hdr.DolbyVisionProfiles) > 16 || len(hdr.DolbyVisionProfileLevels) > 16 {
+		return errors.New("dolby vision profile list exceeds supported size")
+	}
+	for _, capability := range hdr.DolbyVisionProfileLevels {
+		if capability.Profile <= 0 || capability.MaxLevel < 1 || capability.MaxLevel > 13 {
+			return errors.New("invalid dolby vision profile level capability")
 		}
 	}
 	return nil

--- a/internal/playback/protocol_v3.go
+++ b/internal/playback/protocol_v3.go
@@ -199,8 +199,9 @@ type HDRCapabilitiesV3 struct {
 }
 
 type DolbyVisionProfileCapabilityV3 struct {
-	Profile  int `json:"profile"`
-	MaxLevel int `json:"max_level"`
+	Profile            int   `json:"profile"`
+	MaxLevel           int   `json:"max_level"`
+	BLCompatibilityIDs []int `json:"bl_compatibility_ids,omitempty"`
 }
 
 type AudioPassthroughV3 struct {
@@ -980,9 +981,27 @@ func validateHDRCapabilitiesV3(hdr *HDRCapabilitiesV3) error {
 	if len(hdr.DolbyVisionProfiles) > 16 || len(hdr.DolbyVisionProfileLevels) > 16 {
 		return errors.New("dolby vision profile list exceeds supported size")
 	}
+	seenProfiles := make(map[int]struct{}, len(hdr.DolbyVisionProfileLevels))
 	for _, capability := range hdr.DolbyVisionProfileLevels {
 		if capability.Profile <= 0 || capability.MaxLevel < 1 || capability.MaxLevel > 13 {
 			return errors.New("invalid dolby vision profile level capability")
+		}
+		if _, exists := seenProfiles[capability.Profile]; exists {
+			return errors.New("duplicate dolby vision profile level capability")
+		}
+		seenProfiles[capability.Profile] = struct{}{}
+		if len(capability.BLCompatibilityIDs) > 16 {
+			return errors.New("dolby vision base-layer compatibility list exceeds supported size")
+		}
+		seenCompatibilityIDs := make(map[int]struct{}, len(capability.BLCompatibilityIDs))
+		for _, compatibilityID := range capability.BLCompatibilityIDs {
+			if compatibilityID < 0 || compatibilityID > 15 {
+				return errors.New("invalid dolby vision base-layer compatibility id")
+			}
+			if _, exists := seenCompatibilityIDs[compatibilityID]; exists {
+				return errors.New("duplicate dolby vision base-layer compatibility id")
+			}
+			seenCompatibilityIDs[compatibilityID] = struct{}{}
 		}
 	}
 	return nil

--- a/internal/playback/protocol_v3.go
+++ b/internal/playback/protocol_v3.go
@@ -19,6 +19,7 @@ const (
 	FeatureRouteDiagnostics       = "playback_route_diagnostics"
 	FeatureDeviceQuirksV3         = "device_quirks_v1"
 	FeatureSeekReanchorV3         = "seek_reanchor_v1"
+	FeatureOutputChangeV3         = "output_change_v1"
 	FeatureDirectStreamResumeV3   = "direct_stream_resume_v1"
 	FeaturePlanSourceDurationV3   = "plan_source_duration_v1"
 	PlanRecipeVersionV3           = "v3.4"
@@ -42,6 +43,7 @@ func ServerFeaturesV3() []string {
 		FeatureRouteDiagnostics,
 		FeatureDeviceQuirksV3,
 		FeatureSeekReanchorV3,
+		FeatureOutputChangeV3,
 		FeatureDirectStreamResumeV3,
 		// Advertised so a client can tell "this server does not populate
 		// source.duration_seconds" apart from "this server knows the runtime

--- a/internal/playback/protocol_v3_test.go
+++ b/internal/playback/protocol_v3_test.go
@@ -176,6 +176,12 @@ func TestReplanRequestV3OperationDefaultsAndValidates(t *testing.T) {
 		t.Fatalf("quality change without a failure classification: %v", err)
 	}
 
+	request.Operation = ReplanOperationOutputChangeV3
+	request.QualityPreference = ""
+	if err := request.Validate(); err != nil {
+		t.Fatalf("output change without a failure classification: %v", err)
+	}
+
 	request.Operation = "future_operation"
 	if err := request.Validate(); err == nil {
 		t.Fatal("unknown replan operation was accepted")
@@ -297,7 +303,7 @@ func TestProtocolV3ConformanceMatrixCoversReleaseTrain(t *testing.T) {
 	}
 	for _, required := range []string{
 		"evidence_tier_gating", "deliveries_negotiation", "attempt_key_echo_and_loop",
-		"track_change_replan", "quality_change_replan", "idempotent_replan",
+		"track_change_replan", "quality_change_replan", "output_change_replan", "idempotent_replan",
 		"concurrent_replan", "mid_seek_replan", "available_qualities",
 		"audio_only_planning", "output_context_invalidation", "legacy_426",
 		"hdr_dv_matrix", "audio_matrix", "subtitle_matrix", "recovery_matrix",

--- a/internal/playback/protocol_v3_test.go
+++ b/internal/playback/protocol_v3_test.go
@@ -945,6 +945,24 @@ func TestPlanPlaybackV3NeverClaimsUnimplementedHDRTranscode(t *testing.T) {
 	}
 }
 
+func TestPlanPlaybackV3ReportsHDRLimitationBefore4KPolicy(t *testing.T) {
+	file := detailedFixtureFileV3()
+	file.Resolution = "2160p"
+	file.VideoTracks[0].Width = 3840
+	file.VideoTracks[0].Height = 2160
+	req := validStartRequestV3()
+	req.Capabilities.HDRDetails = nil
+	req.ClientPlaybackContext.Output.HDRDetails = nil
+
+	result := PlanPlaybackV3(PlannerInputV3{
+		Request: req, RequestedFile: file, EffectiveFile: file, AudioTrackIndex: 0,
+		Settings: PlannerSettingsV3{TranscodeEnabled: true, Allow4KTranscode: false},
+	})
+	if result.Terminal == nil || result.Terminal.Reason != "hdr_transcode_unsupported" {
+		t.Fatalf("result = %s", ExplainPlannerResultV3(result))
+	}
+}
+
 func TestPlanPlaybackV3Profile7StripFallsBackToValidatedHLSCopy(t *testing.T) {
 	file := detailedFixtureFileV3()
 	file.VideoTracks[0].DVProfile = 7

--- a/internal/playback/protocol_v3_test.go
+++ b/internal/playback/protocol_v3_test.go
@@ -1000,6 +1000,14 @@ func TestPlanPlaybackV3HonorsDolbyVisionLevelBound(t *testing.T) {
 	}
 }
 
+func TestSourceDescriptorV3OmitsInvalidDolbyVisionLevel(t *testing.T) {
+	file := detailedFixtureFileV3()
+	file.VideoTracks[0].DVLevel = 14
+	if got := SourceDescriptorFromFileV3(file, 0).DVLevel; got != 0 {
+		t.Fatalf("DVLevel = %d, want omitted", got)
+	}
+}
+
 func TestPlanPlaybackV3Profile7StripFallsBackToValidatedHLSCopy(t *testing.T) {
 	file := detailedFixtureFileV3()
 	file.VideoTracks[0].DVProfile = 7

--- a/internal/playback/protocol_v3_test.go
+++ b/internal/playback/protocol_v3_test.go
@@ -28,6 +28,7 @@ func TestServerFeaturesV3ReturnsCompleteIndependentSlices(t *testing.T) {
 		FeatureRouteDiagnostics:     {},
 		FeatureDeviceQuirksV3:       {},
 		FeatureSeekReanchorV3:       {},
+		FeatureOutputChangeV3:       {},
 		FeatureDirectStreamResumeV3: {},
 		FeaturePlanSourceDurationV3: {},
 	}

--- a/internal/playback/protocol_v3_test.go
+++ b/internal/playback/protocol_v3_test.go
@@ -963,6 +963,43 @@ func TestPlanPlaybackV3ReportsHDRLimitationBefore4KPolicy(t *testing.T) {
 	}
 }
 
+func TestPlanPlaybackV3HonorsDolbyVisionLevelBound(t *testing.T) {
+	file := detailedFixtureFileV3()
+	file.VideoTracks[0].VideoRange = "DolbyVision"
+	file.VideoTracks[0].VideoRangeType = "DOVIWithHDR10"
+	file.VideoTracks[0].DVProfile = 8
+	file.VideoTracks[0].DVLevel = 7
+	file.VideoTracks[0].DVBLCompatID = 1
+	req := validStartRequestV3()
+	req.Capabilities.VideoDecode = []VideoDecodeCapabilityV3{{
+		Codec: "hevc", Profiles: []string{"main 10"}, Levels: []int{153}, BitDepths: []int{10},
+		MaxWidth: 3840, MaxHeight: 2160, MaxFrameRate: 60, MaxBitrateKbps: 80_000, Hardware: true,
+	}}
+	hdr := &HDRCapabilitiesV3{
+		DolbyVisionProfiles:      []int{8},
+		DolbyVisionProfileLevels: []DolbyVisionProfileCapabilityV3{{Profile: 8, MaxLevel: 6}},
+	}
+	req.Capabilities.HDRDetails = hdr
+	req.ClientPlaybackContext.Output.HDRDetails = hdr
+
+	result := PlanPlaybackV3(PlannerInputV3{
+		Request: req, RequestedFile: file, EffectiveFile: file, AudioTrackIndex: 0,
+		Settings: PlannerSettingsV3{TranscodeEnabled: true, Allow4KTranscode: true},
+	})
+	if result.Terminal == nil || result.Terminal.Reason != "hdr_transcode_unsupported" {
+		t.Fatalf("result = %s", ExplainPlannerResultV3(result))
+	}
+
+	file.VideoTracks[0].DVLevel = 6
+	result = PlanPlaybackV3(PlannerInputV3{
+		Request: req, RequestedFile: file, EffectiveFile: file, AudioTrackIndex: 0,
+		Settings: PlannerSettingsV3{TranscodeEnabled: true, Allow4KTranscode: true},
+	})
+	if result.Plan == nil || !result.Plan.Claims.Video.DolbyVision {
+		t.Fatalf("result = %s", ExplainPlannerResultV3(result))
+	}
+}
+
 func TestPlanPlaybackV3Profile7StripFallsBackToValidatedHLSCopy(t *testing.T) {
 	file := detailedFixtureFileV3()
 	file.VideoTracks[0].DVProfile = 7
@@ -1404,6 +1441,12 @@ func TestStartRequestV3ValidationBoundsInnerLists(t *testing.T) {
 			delivery := r.ClientPlaybackContext.Deliveries[DeliveryClassOriginalHTTPV3]
 			delivery.HDRDetails = &HDRCapabilitiesV3{DolbyVisionProfiles: make([]int, 17)}
 			r.ClientPlaybackContext.Deliveries[DeliveryClassOriginalHTTPV3] = delivery
+		}},
+		{"capability_dolby_vision_profile_levels", func(r *StartRequestV3) {
+			r.Capabilities.HDRDetails = &HDRCapabilitiesV3{DolbyVisionProfileLevels: make([]DolbyVisionProfileCapabilityV3, 17)}
+		}},
+		{"invalid_dolby_vision_profile_level", func(r *StartRequestV3) {
+			r.Capabilities.HDRDetails = &HDRCapabilitiesV3{DolbyVisionProfileLevels: []DolbyVisionProfileCapabilityV3{{Profile: 8, MaxLevel: 14}}}
 		}},
 		{"delivery_container_length", func(r *StartRequestV3) {
 			delivery := r.ClientPlaybackContext.Deliveries[DeliveryClassOriginalHTTPV3]

--- a/internal/playback/protocol_v3_test.go
+++ b/internal/playback/protocol_v3_test.go
@@ -165,6 +165,19 @@ func TestReplanRequestV3OperationDefaultsAndValidates(t *testing.T) {
 	if err := request.Validate(); err != nil {
 		t.Fatalf("track change without a failure classification: %v", err)
 	}
+	for _, operation := range []ReplanOperationV3{
+		ReplanOperationTrackChangeV3,
+		ReplanOperationQualityChangeV3,
+		ReplanOperationOutputChangeV3,
+	} {
+		request.Operation = operation
+		request.QualityPreference = "720p"
+		request.Failure = FailureV3{Classification: "decoder_failure"}
+		if err := request.Validate(); err == nil {
+			t.Fatalf("%s with failure was accepted", operation)
+		}
+	}
+	request.Failure = FailureV3{}
 
 	request.Operation = ReplanOperationQualityChangeV3
 	request.QualityPreference = ""
@@ -185,6 +198,26 @@ func TestReplanRequestV3OperationDefaultsAndValidates(t *testing.T) {
 	request.Operation = "future_operation"
 	if err := request.Validate(); err == nil {
 		t.Fatal("unknown replan operation was accepted")
+	}
+}
+
+func TestHDR10CapabilityLimitsBoundTheClaimedStreamClass(t *testing.T) {
+	width, height, frameRate, bitrate := 3840, 2160, 24.0, 80_000
+	plan := PlanV3{EffectiveRecipe: EffectiveRecipeV3{
+		VideoCodec: "hevc", Width: &width, Height: &height, FrameRate: &frameRate,
+		BitrateKbps: &bitrate, DynamicRange: DynamicRangeHDR10V3,
+	}}
+	hdr := HDRCapabilitiesV3{
+		HDR10: true, HDR10MaxWidth: 3840, HDR10MaxHeight: 2160,
+		HDR10MaxFrameRate: 24, HDR10MaxBitrateKbps: 80_000,
+	}
+	if !hdrDetailsSupportPlanV3(hdr, plan) {
+		t.Fatal("the exactly probed HDR10 stream class was rejected")
+	}
+	tooFast := 60.0
+	plan.EffectiveRecipe.FrameRate = &tooFast
+	if hdrDetailsSupportPlanV3(hdr, plan) {
+		t.Fatal("an HDR10 stream above the probed frame-rate ceiling was accepted")
 	}
 }
 

--- a/internal/playback/protocol_v3_test.go
+++ b/internal/playback/protocol_v3_test.go
@@ -976,8 +976,10 @@ func TestPlanPlaybackV3HonorsDolbyVisionLevelBound(t *testing.T) {
 		MaxWidth: 3840, MaxHeight: 2160, MaxFrameRate: 60, MaxBitrateKbps: 80_000, Hardware: true,
 	}}
 	hdr := &HDRCapabilitiesV3{
-		DolbyVisionProfiles:      []int{8},
-		DolbyVisionProfileLevels: []DolbyVisionProfileCapabilityV3{{Profile: 8, MaxLevel: 6}},
+		DolbyVisionProfiles: []int{8},
+		DolbyVisionProfileLevels: []DolbyVisionProfileCapabilityV3{{
+			Profile: 8, MaxLevel: 6, BLCompatibilityIDs: []int{1},
+		}},
 	}
 	req.Capabilities.HDRDetails = hdr
 	req.ClientPlaybackContext.Output.HDRDetails = hdr
@@ -996,6 +998,15 @@ func TestPlanPlaybackV3HonorsDolbyVisionLevelBound(t *testing.T) {
 		Settings: PlannerSettingsV3{TranscodeEnabled: true, Allow4KTranscode: true},
 	})
 	if result.Plan == nil || !result.Plan.Claims.Video.DolbyVision {
+		t.Fatalf("result = %s", ExplainPlannerResultV3(result))
+	}
+
+	file.VideoTracks[0].DVBLCompatID = 4
+	result = PlanPlaybackV3(PlannerInputV3{
+		Request: req, RequestedFile: file, EffectiveFile: file, AudioTrackIndex: 0,
+		Settings: PlannerSettingsV3{TranscodeEnabled: true, Allow4KTranscode: true},
+	})
+	if result.Terminal == nil || result.Terminal.Reason != "hdr_transcode_unsupported" {
 		t.Fatalf("result = %s", ExplainPlannerResultV3(result))
 	}
 }
@@ -1455,6 +1466,18 @@ func TestStartRequestV3ValidationBoundsInnerLists(t *testing.T) {
 		}},
 		{"invalid_dolby_vision_profile_level", func(r *StartRequestV3) {
 			r.Capabilities.HDRDetails = &HDRCapabilitiesV3{DolbyVisionProfileLevels: []DolbyVisionProfileCapabilityV3{{Profile: 8, MaxLevel: 14}}}
+		}},
+		{"duplicate_dolby_vision_profile_level", func(r *StartRequestV3) {
+			r.Capabilities.HDRDetails = &HDRCapabilitiesV3{DolbyVisionProfileLevels: []DolbyVisionProfileCapabilityV3{{Profile: 8, MaxLevel: 6}, {Profile: 8, MaxLevel: 7}}}
+		}},
+		{"dolby_vision_bl_compatibility_count", func(r *StartRequestV3) {
+			r.Capabilities.HDRDetails = &HDRCapabilitiesV3{DolbyVisionProfileLevels: []DolbyVisionProfileCapabilityV3{{Profile: 8, MaxLevel: 6, BLCompatibilityIDs: make([]int, 17)}}}
+		}},
+		{"invalid_dolby_vision_bl_compatibility_id", func(r *StartRequestV3) {
+			r.Capabilities.HDRDetails = &HDRCapabilitiesV3{DolbyVisionProfileLevels: []DolbyVisionProfileCapabilityV3{{Profile: 8, MaxLevel: 6, BLCompatibilityIDs: []int{16}}}}
+		}},
+		{"duplicate_dolby_vision_bl_compatibility_id", func(r *StartRequestV3) {
+			r.Capabilities.HDRDetails = &HDRCapabilitiesV3{DolbyVisionProfileLevels: []DolbyVisionProfileCapabilityV3{{Profile: 8, MaxLevel: 6, BLCompatibilityIDs: []int{1, 1}}}}
 		}},
 		{"delivery_container_length", func(r *StartRequestV3) {
 			delivery := r.ClientPlaybackContext.Deliveries[DeliveryClassOriginalHTTPV3]

--- a/internal/playback/testdata/protocol_v3/conformance_matrix.json
+++ b/internal/playback/testdata/protocol_v3/conformance_matrix.json
@@ -4148,6 +4148,124 @@
       }
     },
     {
+      "name": "output_change",
+      "category": "output_change_replan",
+      "request": {
+        "protocol_version": 3,
+        "client_features": [
+          "playback_plan_v3"
+        ],
+        "operation": "output_change",
+        "playback_attempt_id": "attempt-golden-0001",
+        "replan_request_id": "replan-output-change-0001",
+        "failed_plan_id": "plan:478677870860e5e5108c18bff749b34b",
+        "plan_attempt_id": "plan-attempt-golden-0001",
+        "plan_attempt_key": "v3:f0144c47fa349e3e",
+        "attempted_plan_keys": [
+          "v3:f0144c47fa349e3e"
+        ],
+        "attempt_count": 1,
+        "quality_preference": "auto",
+        "position_seconds": 42.5,
+        "metered": true,
+        "bandwidth_estimate_kbps": 3500,
+        "bandwidth_cap_kbps": 4000,
+        "selected_tracks": {
+          "audio": {
+            "id": "file:42:audio:0",
+            "index": 0
+          }
+        },
+        "client_capabilities": {
+          "video_evidence": "exact",
+          "audio_evidence": "exact",
+          "codecs_video": [
+            "h264"
+          ],
+          "codecs_video_hardware": [
+            "h264"
+          ],
+          "codecs_audio": [
+            "aac"
+          ],
+          "containers": [
+            "mp4"
+          ],
+          "max_resolution": "1080p",
+          "hdr": false,
+          "video_decode": [
+            {
+              "codec": "h264",
+              "profiles": [
+                "high"
+              ],
+              "levels": [
+                41
+              ],
+              "bit_depths": [
+                8
+              ],
+              "max_width": 1920,
+              "max_height": 1080,
+              "max_frame_rate": 60,
+              "max_bitrate_kbps": 20000,
+              "hardware": true
+            }
+          ]
+        },
+        "client_playback_context": {
+          "protocol_version": 3,
+          "form_factor": "tv",
+          "app_version": "3.0-test",
+          "device": {
+            "platform": "android",
+            "os_version": "15",
+            "manufacturer": "NVIDIA",
+            "model": "SHIELD Android TV",
+            "platform_details": {
+              "abis": "arm64-v8a",
+              "sdk_int": "35"
+            }
+          },
+          "output": {
+            "output_context_id": "7"
+          },
+          "deliveries": {
+            "original_http": {
+              "enabled": true,
+              "supported_on_device": true,
+              "containers": [
+                "mp4"
+              ],
+              "video_codecs": [
+                "h264"
+              ],
+              "audio_decode_codecs": [
+                "aac"
+              ],
+              "audio_passthrough_codecs": [],
+              "subtitles": {
+                "embedded_text": true,
+                "sidecar_text": true,
+                "ass_styling": false,
+                "embedded_bitmap": false,
+                "sidecar_bitmap": false,
+                "font_attachments": false
+              },
+              "features": [],
+              "auth_header_refresh": true,
+              "validated_claims": [],
+              "transformations": []
+            }
+          }
+        }
+      },
+      "expected": {
+        "http_status": 200,
+        "preserve_unmodified_tracks": true
+      }
+    },
+    {
       "name": "track_change_idempotent_duplicate",
       "category": "idempotent_replan",
       "request": {

--- a/internal/scanner/probe.go
+++ b/internal/scanner/probe.go
@@ -105,6 +105,7 @@ type ffprobeChapter struct {
 type ffprobeSideData struct {
 	SideDataType string `json:"side_data_type"`
 	DVProfile    int    `json:"dv_profile"`
+	DVLevel      int    `json:"dv_level"`
 	DVBlPresent  int    `json:"dv_bl_present"`
 	DVElPresent  int    `json:"dv_el_present"`
 	DVBLCompatID int    `json:"dv_bl_signal_compatibility_id"`
@@ -206,6 +207,7 @@ func convertProbeData(raw *ffprobeOutput) *ProbeData {
 				Codec:              s.CodecName,
 				DolbyVision:        dolbyVisionProfile(s.SideDataList),
 				DVProfile:          dvProfile,
+				DVLevel:            dolbyVisionLevel(s.SideDataList),
 				DVBLCompatID:       dolbyVisionBLCompatID(s.SideDataList),
 				DVELPresent:        dolbyVisionELPresent(s.SideDataList),
 				DVEnhancementLayer: dolbyVisionEnhancementLayer(dolbyVisionELPresent(s.SideDataList)),
@@ -788,6 +790,15 @@ func dolbyVisionProfileNumber(sideData []ffprobeSideData) int {
 	for _, data := range sideData {
 		if strings.EqualFold(data.SideDataType, "DOVI configuration record") && data.DVProfile > 0 {
 			return data.DVProfile
+		}
+	}
+	return 0
+}
+
+func dolbyVisionLevel(sideData []ffprobeSideData) int {
+	for _, data := range sideData {
+		if strings.EqualFold(data.SideDataType, "DOVI configuration record") && data.DVLevel > 0 {
+			return data.DVLevel
 		}
 	}
 	return 0

--- a/internal/scanner/probe_video_range_test.go
+++ b/internal/scanner/probe_video_range_test.go
@@ -47,6 +47,7 @@ func TestConvertProbeDataVideoRangeTypes(t *testing.T) {
 		wantRange     string
 		wantRangeType string
 		wantProfile   int
+		wantLevel     int
 		wantCompatID  int
 		wantEL        bool
 		wantHDR10Plus bool
@@ -92,12 +93,14 @@ func TestConvertProbeDataVideoRangeTypes(t *testing.T) {
 				SideDataList: []ffprobeSideData{{
 					SideDataType: "DOVI configuration record",
 					DVProfile:    8,
+					DVLevel:      6,
 					DVBLCompatID: 1,
 				}},
 			},
 			wantRange:     "DolbyVision",
 			wantRangeType: "DOVIWithHDR10",
 			wantProfile:   8,
+			wantLevel:     6,
 			wantCompatID:  1,
 		},
 		{
@@ -175,6 +178,9 @@ func TestConvertProbeDataVideoRangeTypes(t *testing.T) {
 			}
 			if track.DVProfile != tt.wantProfile {
 				t.Fatalf("DVProfile = %d, want %d", track.DVProfile, tt.wantProfile)
+			}
+			if track.DVLevel != tt.wantLevel {
+				t.Fatalf("DVLevel = %d, want %d", track.DVLevel, tt.wantLevel)
 			}
 			if track.DVBLCompatID != tt.wantCompatID {
 				t.Fatalf("DVBLCompatID = %d, want %d", track.DVBLCompatID, tt.wantCompatID)

--- a/internal/scanner/scanner.go
+++ b/internal/scanner/scanner.go
@@ -3661,6 +3661,7 @@ func applyProbeData(mf *models.MediaFile, probe *ProbeData, probeSource string) 
 			Codec:              vt.Codec,
 			DolbyVision:        vt.DolbyVision,
 			DVProfile:          vt.DVProfile,
+			DVLevel:            vt.DVLevel,
 			DVBLCompatID:       vt.DVBLCompatID,
 			DVELPresent:        vt.DVELPresent,
 			DVEnhancementLayer: vt.DVEnhancementLayer,

--- a/internal/scanner/types.go
+++ b/internal/scanner/types.go
@@ -59,6 +59,7 @@ type VideoTrackInfo struct {
 	Codec              string
 	DolbyVision        string
 	DVProfile          int
+	DVLevel            int
 	DVBLCompatID       int
 	DVELPresent        bool
 	DVEnhancementLayer string

--- a/web/src/player/client-context-v3.test.ts
+++ b/web/src/player/client-context-v3.test.ts
@@ -79,14 +79,15 @@ describe("structured HDR capabilities", () => {
     expect(buildClientPlaybackContextV3(probe).output.hdr_details).toEqual(probe.hdrDetails);
   });
 
-  it("scopes media-element Dolby Vision support to direct and progressive delivery", () => {
+  it("scopes the normalized Dolby Vision sample entry to progressive delivery", () => {
     const deliveries = buildDeliveriesV3(probe);
-    expect(deliveries.original_http?.hdr_details).toEqual(probe.hdrDetails);
     expect(deliveries.progressive?.hdr_details).toEqual(probe.hdrDetails);
-    expect(deliveries.hls?.hdr_details).toEqual({
+    const nonProgressiveHDRDetails = {
       ...probe.hdrDetails,
       dolby_vision_profiles: [],
       dolby_vision_profile_levels: [],
-    });
+    };
+    expect(deliveries.original_http?.hdr_details).toEqual(nonProgressiveHDRDetails);
+    expect(deliveries.hls?.hdr_details).toEqual(nonProgressiveHDRDetails);
   });
 });

--- a/web/src/player/client-context-v3.test.ts
+++ b/web/src/player/client-context-v3.test.ts
@@ -45,6 +45,7 @@ describe("buildDeliveriesV3", () => {
         hdr10_plus: false,
         hlg: false,
         dolby_vision_profiles: [],
+        dolby_vision_profile_levels: [],
       },
       hls: true,
     });
@@ -64,10 +65,11 @@ describe("structured HDR capabilities", () => {
     maxResolution: "2160p",
     hdr: true,
     hdrDetails: {
-      hdr10: true,
+      hdr10: false,
       hdr10_plus: false,
-      hlg: true,
+      hlg: false,
       dolby_vision_profiles: [8],
+      dolby_vision_profile_levels: [{ profile: 8, max_level: 6 }],
     },
     hls: true,
   };
@@ -77,9 +79,14 @@ describe("structured HDR capabilities", () => {
     expect(buildClientPlaybackContextV3(probe).output.hdr_details).toEqual(probe.hdrDetails);
   });
 
-  it("scopes the same output formats to every web delivery path", () => {
-    for (const delivery of Object.values(buildDeliveriesV3(probe))) {
-      expect(delivery.hdr_details).toEqual(probe.hdrDetails);
-    }
+  it("scopes media-element Dolby Vision support to direct and progressive delivery", () => {
+    const deliveries = buildDeliveriesV3(probe);
+    expect(deliveries.original_http?.hdr_details).toEqual(probe.hdrDetails);
+    expect(deliveries.progressive?.hdr_details).toEqual(probe.hdrDetails);
+    expect(deliveries.hls?.hdr_details).toEqual({
+      ...probe.hdrDetails,
+      dolby_vision_profiles: [],
+      dolby_vision_profile_levels: [],
+    });
   });
 });

--- a/web/src/player/client-context-v3.test.ts
+++ b/web/src/player/client-context-v3.test.ts
@@ -37,6 +37,7 @@ describe("buildDeliveriesV3", () => {
     const deliveries = buildDeliveriesV3({
       containers: ["mp4"],
       codecsVideo: ["h264"],
+      progressiveCodecsVideo: ["h264"],
       codecsAudio: ["aac"],
       maxResolution: "1080p",
       hdr: false,
@@ -61,6 +62,7 @@ describe("structured HDR capabilities", () => {
   const probe: WebCapabilityProbe = {
     containers: ["mp4"],
     codecsVideo: ["hevc"],
+    progressiveCodecsVideo: ["hevc"],
     codecsAudio: ["eac3"],
     maxResolution: "2160p",
     hdr: true,
@@ -69,7 +71,7 @@ describe("structured HDR capabilities", () => {
       hdr10_plus: false,
       hlg: false,
       dolby_vision_profiles: [8],
-      dolby_vision_profile_levels: [{ profile: 8, max_level: 6 }],
+      dolby_vision_profile_levels: [{ profile: 8, max_level: 6, bl_compatibility_ids: [1] }],
     },
     hls: true,
   };
@@ -89,5 +91,19 @@ describe("structured HDR capabilities", () => {
     };
     expect(deliveries.original_http?.hdr_details).toEqual(nonProgressiveHDRDetails);
     expect(deliveries.hls?.hdr_details).toEqual(nonProgressiveHDRDetails);
+  });
+
+  it("keeps media-element-only HEVC evidence out of original and HLS delivery", () => {
+    const progressiveOnlyProbe = {
+      ...probe,
+      codecsVideo: ["h264"],
+      progressiveCodecsVideo: ["h264", "hevc"],
+    };
+
+    expect(buildClientCapabilitiesV3(progressiveOnlyProbe).codecs_video).toEqual(["h264", "hevc"]);
+    const deliveries = buildDeliveriesV3(progressiveOnlyProbe);
+    expect(deliveries.original_http?.video_codecs).toEqual(["h264"]);
+    expect(deliveries.progressive?.video_codecs).toEqual(["h264", "hevc"]);
+    expect(deliveries.hls?.video_codecs).toEqual(["h264"]);
   });
 });

--- a/web/src/player/client-context-v3.test.ts
+++ b/web/src/player/client-context-v3.test.ts
@@ -67,7 +67,7 @@ describe("structured HDR capabilities", () => {
     maxResolution: "2160p",
     hdr: true,
     hdrDetails: {
-      hdr10: false,
+      hdr10: true,
       hdr10_plus: false,
       hlg: false,
       dolby_vision_profiles: [8],
@@ -81,11 +81,12 @@ describe("structured HDR capabilities", () => {
     expect(buildClientPlaybackContextV3(probe).output.hdr_details).toEqual(probe.hdrDetails);
   });
 
-  it("scopes the normalized Dolby Vision sample entry to progressive delivery", () => {
+  it("scopes normalized HDR sample entries to progressive delivery", () => {
     const deliveries = buildDeliveriesV3(probe);
     expect(deliveries.progressive?.hdr_details).toEqual(probe.hdrDetails);
     const nonProgressiveHDRDetails = {
       ...probe.hdrDetails,
+      hdr10: false,
       dolby_vision_profiles: [],
       dolby_vision_profile_levels: [],
     };

--- a/web/src/player/client-context-v3.test.ts
+++ b/web/src/player/client-context-v3.test.ts
@@ -7,6 +7,7 @@ import {
   detectHLSSupport,
   type WebCapabilityProbe,
 } from "./client-context-v3";
+import type { HDRCapabilitiesV3 } from "./protocol-v3";
 
 afterEach(() => {
   vi.unstubAllGlobals();
@@ -70,6 +71,10 @@ describe("structured HDR capabilities", () => {
       hdr10: true,
       hdr10_plus: false,
       hlg: false,
+      hdr10_max_width: 3840,
+      hdr10_max_height: 2160,
+      hdr10_max_frame_rate: 24,
+      hdr10_max_bitrate_kbps: 80_000,
       dolby_vision_profiles: [8],
       dolby_vision_profile_levels: [{ profile: 8, max_level: 6, bl_compatibility_ids: [1] }],
     },
@@ -84,12 +89,16 @@ describe("structured HDR capabilities", () => {
   it("scopes normalized HDR sample entries to progressive delivery", () => {
     const deliveries = buildDeliveriesV3(probe);
     expect(deliveries.progressive?.hdr_details).toEqual(probe.hdrDetails);
-    const nonProgressiveHDRDetails = {
+    const nonProgressiveHDRDetails: HDRCapabilitiesV3 = {
       ...probe.hdrDetails,
       hdr10: false,
       dolby_vision_profiles: [],
       dolby_vision_profile_levels: [],
     };
+    delete nonProgressiveHDRDetails.hdr10_max_width;
+    delete nonProgressiveHDRDetails.hdr10_max_height;
+    delete nonProgressiveHDRDetails.hdr10_max_frame_rate;
+    delete nonProgressiveHDRDetails.hdr10_max_bitrate_kbps;
     expect(deliveries.original_http?.hdr_details).toEqual(nonProgressiveHDRDetails);
     expect(deliveries.hls?.hdr_details).toEqual(nonProgressiveHDRDetails);
   });

--- a/web/src/player/client-context-v3.test.ts
+++ b/web/src/player/client-context-v3.test.ts
@@ -1,6 +1,12 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
 
-import { buildDeliveriesV3, detectHLSSupport } from "./client-context-v3";
+import {
+  buildClientCapabilitiesV3,
+  buildClientPlaybackContextV3,
+  buildDeliveriesV3,
+  detectHLSSupport,
+  type WebCapabilityProbe,
+} from "./client-context-v3";
 
 afterEach(() => {
   vi.unstubAllGlobals();
@@ -34,12 +40,46 @@ describe("buildDeliveriesV3", () => {
       codecsAudio: ["aac"],
       maxResolution: "1080p",
       hdr: false,
+      hdrDetails: {
+        hdr10: false,
+        hdr10_plus: false,
+        hlg: false,
+        dolby_vision_profiles: [],
+      },
       hls: true,
     });
 
     for (const delivery of Object.values(deliveries)) {
       expect(delivery.subtitles.embedded_text).toBe(true);
       expect(delivery.subtitles.sidecar_text).toBe(true);
+    }
+  });
+});
+
+describe("structured HDR capabilities", () => {
+  const probe: WebCapabilityProbe = {
+    containers: ["mp4"],
+    codecsVideo: ["hevc"],
+    codecsAudio: ["eac3"],
+    maxResolution: "2160p",
+    hdr: true,
+    hdrDetails: {
+      hdr10: true,
+      hdr10_plus: false,
+      hlg: true,
+      dolby_vision_profiles: [8],
+    },
+    hls: true,
+  };
+
+  it("publishes the structured formats in both device and active-output contexts", () => {
+    expect(buildClientCapabilitiesV3(probe).hdr_details).toEqual(probe.hdrDetails);
+    expect(buildClientPlaybackContextV3(probe).output.hdr_details).toEqual(probe.hdrDetails);
+  });
+
+  it("scopes the same output formats to every web delivery path", () => {
+    for (const delivery of Object.values(buildDeliveriesV3(probe))) {
+      expect(delivery.hdr_details).toEqual(probe.hdrDetails);
     }
   });
 });

--- a/web/src/player/client-context-v3.ts
+++ b/web/src/player/client-context-v3.ts
@@ -134,17 +134,18 @@ function buildDeliveryCapability(
 export function buildDeliveriesV3(
   probe: WebCapabilityProbe,
 ): Partial<Record<DeliveryClassV3, DeliveryCapabilityV3>> {
-  const progressiveOnlyHDRDetails: HDRCapabilitiesV3 = {
+  const nonProgressiveHDRDetails: HDRCapabilitiesV3 = {
     ...probe.hdrDetails,
-    // The Dolby Vision probe covers direct progressive playback through the
-    // media element after Silo normalizes the sample entry. It says nothing
-    // about an untouched original file or hls.js' MediaSource append path.
+    // The Dolby Vision and HDR10 probes cover direct progressive playback
+    // through the media element after Silo normalizes the sample entry. They
+    // say nothing about an untouched original or hls.js' MediaSource path.
+    hdr10: false,
     dolby_vision_profiles: [],
     dolby_vision_profile_levels: [],
   };
   return {
     original_http: buildDeliveryCapability(probe, {
-      hdr_details: progressiveOnlyHDRDetails,
+      hdr_details: nonProgressiveHDRDetails,
     }),
     progressive: buildDeliveryCapability(probe, {
       video_codecs: probe.progressiveCodecsVideo,
@@ -153,7 +154,7 @@ export function buildDeliveriesV3(
       supported_on_device: probe.hls,
       ...(probe.hls ? {} : { failure_reason: "media_source_extensions_unavailable" }),
       containers: ["hls"],
-      hdr_details: progressiveOnlyHDRDetails,
+      hdr_details: nonProgressiveHDRDetails,
     }),
   };
 }

--- a/web/src/player/client-context-v3.ts
+++ b/web/src/player/client-context-v3.ts
@@ -131,21 +131,24 @@ function buildDeliveryCapability(
 export function buildDeliveriesV3(
   probe: WebCapabilityProbe,
 ): Partial<Record<DeliveryClassV3, DeliveryCapabilityV3>> {
-  const hlsHDRDetails: HDRCapabilitiesV3 = {
+  const progressiveOnlyHDRDetails: HDRCapabilitiesV3 = {
     ...probe.hdrDetails,
     // The Dolby Vision probe covers direct progressive playback through the
-    // media element. It says nothing about hls.js' MediaSource append path.
+    // media element after Silo normalizes the sample entry. It says nothing
+    // about an untouched original file or hls.js' MediaSource append path.
     dolby_vision_profiles: [],
     dolby_vision_profile_levels: [],
   };
   return {
-    original_http: buildDeliveryCapability(probe, {}),
+    original_http: buildDeliveryCapability(probe, {
+      hdr_details: progressiveOnlyHDRDetails,
+    }),
     progressive: buildDeliveryCapability(probe, {}),
     hls: buildDeliveryCapability(probe, {
       supported_on_device: probe.hls,
       ...(probe.hls ? {} : { failure_reason: "media_source_extensions_unavailable" }),
       containers: ["hls"],
-      hdr_details: hlsHDRDetails,
+      hdr_details: progressiveOnlyHDRDetails,
     }),
   };
 }

--- a/web/src/player/client-context-v3.ts
+++ b/web/src/player/client-context-v3.ts
@@ -66,6 +66,8 @@ export interface WebCapabilityProbe {
   containers: string[];
   /** Video codec names the browser reported support for. */
   codecsVideo: string[];
+  /** Video codecs supported specifically by direct media-element playback. */
+  progressiveCodecsVideo: string[];
   /** Audio codec names the browser reported support for. */
   codecsAudio: string[];
   /** Best-effort screen-derived resolution ceiling. */
@@ -85,11 +87,12 @@ export interface WebCapabilityProbe {
  * server treats the two lists identically.
  */
 export function buildClientCapabilitiesV3(probe: WebCapabilityProbe): ClientCodecCapabilitiesV3 {
+  const codecsVideo = Array.from(new Set([...probe.codecsVideo, ...probe.progressiveCodecsVideo]));
   return {
     video_evidence: "declared",
     audio_evidence: "declared",
-    codecs_video: probe.codecsVideo,
-    codecs_video_hardware: probe.codecsVideo,
+    codecs_video: codecsVideo,
+    codecs_video_hardware: codecsVideo,
     codecs_audio: probe.codecsAudio,
     containers: probe.containers,
     max_resolution: probe.maxResolution,
@@ -143,7 +146,9 @@ export function buildDeliveriesV3(
     original_http: buildDeliveryCapability(probe, {
       hdr_details: progressiveOnlyHDRDetails,
     }),
-    progressive: buildDeliveryCapability(probe, {}),
+    progressive: buildDeliveryCapability(probe, {
+      video_codecs: probe.progressiveCodecsVideo,
+    }),
     hls: buildDeliveryCapability(probe, {
       supported_on_device: probe.hls,
       ...(probe.hls ? {} : { failure_reason: "media_source_extensions_unavailable" }),

--- a/web/src/player/client-context-v3.ts
+++ b/web/src/player/client-context-v3.ts
@@ -143,6 +143,10 @@ export function buildDeliveriesV3(
     dolby_vision_profiles: [],
     dolby_vision_profile_levels: [],
   };
+  delete nonProgressiveHDRDetails.hdr10_max_width;
+  delete nonProgressiveHDRDetails.hdr10_max_height;
+  delete nonProgressiveHDRDetails.hdr10_max_frame_rate;
+  delete nonProgressiveHDRDetails.hdr10_max_bitrate_kbps;
   return {
     original_http: buildDeliveryCapability(probe, {
       hdr_details: nonProgressiveHDRDetails,

--- a/web/src/player/client-context-v3.ts
+++ b/web/src/player/client-context-v3.ts
@@ -19,6 +19,7 @@ import {
   type DeliveryCapabilityV3,
   type DeliveryClassV3,
   type DeliverySubtitleCapabilitiesV3,
+  type HDRCapabilitiesV3,
 } from "./protocol-v3";
 
 /** App version reported to the server for diagnostics. */
@@ -71,6 +72,8 @@ export interface WebCapabilityProbe {
   maxResolution: string;
   /** Best-effort HDR display detection. */
   hdr: boolean;
+  /** Structured HDR formats supported by the active browser output path. */
+  hdrDetails: HDRCapabilitiesV3;
   /** Whether hls.js can be used on this browser. */
   hls: boolean;
 }
@@ -91,6 +94,7 @@ export function buildClientCapabilitiesV3(probe: WebCapabilityProbe): ClientCode
     containers: probe.containers,
     max_resolution: probe.maxResolution,
     hdr: probe.hdr,
+    hdr_details: probe.hdrDetails,
   };
 }
 
@@ -107,6 +111,7 @@ function buildDeliveryCapability(
     // A browser cannot bitstream audio to a receiver, and passthrough claims
     // are only ever honoured under the `exact` tier anyway.
     audio_passthrough_codecs: [],
+    hdr_details: probe.hdrDetails,
     subtitles: WEB_SUBTITLE_CAPABILITIES,
     features: [],
     // The stream URL carries its own token; the player reloads the source
@@ -219,7 +224,7 @@ export function buildClientPlaybackContextV3(probe: WebCapabilityProbe): ClientP
       platform: "web",
       ...(Object.keys(platformDetails).length > 0 ? { platform_details: platformDetails } : {}),
     },
-    output: {},
+    output: { hdr_details: probe.hdrDetails },
     deliveries: buildDeliveriesV3(probe),
   };
 }

--- a/web/src/player/client-context-v3.ts
+++ b/web/src/player/client-context-v3.ts
@@ -131,6 +131,13 @@ function buildDeliveryCapability(
 export function buildDeliveriesV3(
   probe: WebCapabilityProbe,
 ): Partial<Record<DeliveryClassV3, DeliveryCapabilityV3>> {
+  const hlsHDRDetails: HDRCapabilitiesV3 = {
+    ...probe.hdrDetails,
+    // The Dolby Vision probe covers direct progressive playback through the
+    // media element. It says nothing about hls.js' MediaSource append path.
+    dolby_vision_profiles: [],
+    dolby_vision_profile_levels: [],
+  };
   return {
     original_http: buildDeliveryCapability(probe, {}),
     progressive: buildDeliveryCapability(probe, {}),
@@ -138,6 +145,7 @@ export function buildDeliveriesV3(
       supported_on_device: probe.hls,
       ...(probe.hls ? {} : { failure_reason: "media_source_extensions_unavailable" }),
       containers: ["hls"],
+      hdr_details: hlsHDRDetails,
     }),
   };
 }

--- a/web/src/player/components/VideoPlayer.test.tsx
+++ b/web/src/player/components/VideoPlayer.test.tsx
@@ -6,6 +6,7 @@ import { PlayerConfigProvider, type PlayerConfig } from "../context/PlayerConfig
 import { fixturePlanV3 } from "../protocol-v3.fixtures";
 import type { PlaybackRealtimeEventEnvelope } from "../realtime-protocol";
 import type { PlayerSubtitleInfo } from "../types";
+import { HLS_STARTUP_TIMEOUT_MS } from "../utils/hlsStartupGuard";
 import { VideoPlayer } from "./VideoPlayer";
 
 const realtimeOptions = vi.hoisted(() => ({
@@ -150,6 +151,38 @@ describe("VideoPlayer plan failure recovery", () => {
     Object.defineProperty(video, "readyState", { configurable: true, value: 3 });
     fireEvent.canPlay(video);
     expect(play).not.toHaveBeenCalled();
+  });
+
+  it("does not report a startup timeout while HLS is intentionally paused", () => {
+    vi.useFakeTimers();
+    try {
+      const onPlanFailure = vi.fn();
+      const hlsPlan = fixturePlanV3({
+        delivery: "server_remux_hls",
+        stream: {
+          url: "/stream/session-1/master.m3u8",
+          protocol: "hls",
+          headers: {},
+          header_refresh: "none",
+        },
+      });
+      const { container } = renderPlayer({
+        plan: hlsPlan,
+        shouldAutoPlay: false,
+        onPlanFailure,
+      });
+      const video = container.querySelector("video");
+      if (!video) throw new Error("expected video element");
+
+      Object.defineProperty(video, "readyState", { configurable: true, value: 3 });
+      fireEvent.canPlay(video);
+      act(() => vi.advanceTimersByTime(HLS_STARTUP_TIMEOUT_MS));
+
+      expect(HTMLMediaElement.prototype.play).not.toHaveBeenCalled();
+      expect(onPlanFailure).not.toHaveBeenCalled();
+    } finally {
+      vi.useRealTimers();
+    }
   });
 
   it("surfaces a refused replan only for the transport-dead plan revision", async () => {

--- a/web/src/player/components/VideoPlayer.test.tsx
+++ b/web/src/player/components/VideoPlayer.test.tsx
@@ -140,6 +140,18 @@ describe("VideoPlayer plan failure recovery", () => {
     vi.restoreAllMocks();
   });
 
+  it("loads a replacement transport without resuming paused playback", async () => {
+    const play = vi.mocked(HTMLMediaElement.prototype.play);
+    const { container } = renderPlayer({ shouldAutoPlay: false });
+    const video = container.querySelector("video");
+    if (!video) throw new Error("expected video element");
+
+    await waitFor(() => expect(video.src).toContain("/api/v1/stream/session-1"));
+    Object.defineProperty(video, "readyState", { configurable: true, value: 3 });
+    fireEvent.canPlay(video);
+    expect(play).not.toHaveBeenCalled();
+  });
+
   it("surfaces a refused replan only for the transport-dead plan revision", async () => {
     const onPlanFailure = vi.fn();
     const { container, rerenderPlayer } = renderPlayer({ onPlanFailure });

--- a/web/src/player/components/VideoPlayer.tsx
+++ b/web/src/player/components/VideoPlayer.tsx
@@ -85,6 +85,8 @@ interface VideoPlayerProps {
   plan: PlanV3;
   /** Bumped on every adopted plan; stream-reload effects key on it. */
   planRevision: number;
+  /** Whether a newly adopted transport should begin playing immediately. */
+  shouldAutoPlay?: boolean;
   /** True while a replan is in flight, so the quality menu can show progress. */
   replanning?: boolean;
   /** Server-described replan error, if the last replan was refused. */
@@ -190,6 +192,7 @@ export function VideoPlayer({
   streamUrl,
   plan,
   planRevision,
+  shouldAutoPlay = true,
   replanning = false,
   replanError = null,
   sessionId,
@@ -1394,6 +1397,11 @@ export function VideoPlayer({
       if (video.readyState < HTMLMediaElement.HAVE_FUTURE_DATA) return;
       autoplayStarted = true;
       cleanupStartupListeners();
+      if (!shouldAutoPlay) {
+        setAwaitingFirstFrame(false);
+        setPlaying(false);
+        return;
+      }
       video.play().catch(() => setPlaying(false));
     };
 
@@ -1539,7 +1547,7 @@ export function VideoPlayer({
         // Direct play — set video src directly.
         video.src = effectiveStreamUrl;
         video.currentTime = effectiveInitialPosition;
-        video.play().catch(() => setPlaying(false));
+        if (shouldAutoPlay) video.play().catch(() => setPlaying(false));
       }
     }
 
@@ -1570,6 +1578,7 @@ export function VideoPlayer({
     planRevision,
     plannedBitrateKbps,
     reportCurrentPlanFailure,
+    shouldAutoPlay,
   ]);
 
   // -- Video event listeners --

--- a/web/src/player/components/VideoPlayer.tsx
+++ b/web/src/player/components/VideoPlayer.tsx
@@ -1398,6 +1398,7 @@ export function VideoPlayer({
       autoplayStarted = true;
       cleanupStartupListeners();
       if (!shouldAutoPlay) {
+        hlsStartupGuardRef.current?.markPlaybackStarted();
         setAwaitingFirstFrame(false);
         setPlaying(false);
         return;

--- a/web/src/player/components/WatchPage.test.ts
+++ b/web/src/player/components/WatchPage.test.ts
@@ -76,6 +76,7 @@ function playbackSession(
     durationSeconds: 3600,
     subtitleUrls: [],
     qualityPreference: "original",
+    shouldAutoPlay: true,
     loading: false,
     replacing: false,
     replanning: false,
@@ -89,7 +90,7 @@ function playbackSession(
     reanchorSeek: vi.fn(),
     refreshSubtitles: vi.fn(),
     applySubtitleTrack: vi.fn(),
-    updatePlaybackPosition: vi.fn(),
+    updatePlaybackState: vi.fn(),
     reportEvent: vi.fn(),
     ...overrides,
   };
@@ -144,9 +145,9 @@ describe("WatchPage playback errors", () => {
 
 describe("WatchPage playback state", () => {
   it("keeps the session resume anchor current while forwarding state", () => {
-    const updatePlaybackPosition = vi.fn();
+    const updatePlaybackState = vi.fn();
     const onPlaybackStateChange = vi.fn();
-    playbackSessionMock.mockReturnValue(playbackSession({ updatePlaybackPosition }));
+    playbackSessionMock.mockReturnValue(playbackSession({ updatePlaybackState }));
 
     render(createElement(WatchPage, { ...watchPageProps, onPlaybackStateChange }));
 
@@ -160,7 +161,7 @@ describe("WatchPage playback state", () => {
     const state = { currentTime: 321, duration: 3600, playing: true };
     props.onPlaybackStateChange?.(state);
 
-    expect(updatePlaybackPosition).toHaveBeenCalledWith(321);
+    expect(updatePlaybackState).toHaveBeenCalledWith(321, true);
     expect(onPlaybackStateChange).toHaveBeenCalledWith(state);
   });
 });

--- a/web/src/player/components/WatchPage.test.ts
+++ b/web/src/player/components/WatchPage.test.ts
@@ -9,12 +9,16 @@ import type { PlayerFileVersion, WatchPageProps } from "../types";
 import { WatchPage } from "./WatchPage";
 
 const playbackSessionMock = vi.hoisted(() => vi.fn());
+const videoPlayerMock = vi.hoisted(() => vi.fn());
 
 vi.mock("../hooks/usePlaybackSession", () => ({
   usePlaybackSession: playbackSessionMock,
 }));
 vi.mock("./VideoPlayer", () => ({
-  VideoPlayer: () => "Mounted video player",
+  VideoPlayer: (props: unknown) => {
+    videoPlayerMock(props);
+    return "Mounted video player";
+  },
 }));
 vi.mock("../context/PlayerConfigContext", () => ({
   usePlayerConfig: () => ({
@@ -85,6 +89,7 @@ function playbackSession(
     reanchorSeek: vi.fn(),
     refreshSubtitles: vi.fn(),
     applySubtitleTrack: vi.fn(),
+    updatePlaybackPosition: vi.fn(),
     reportEvent: vi.fn(),
     ...overrides,
   };
@@ -92,6 +97,7 @@ function playbackSession(
 
 beforeEach(() => {
   playbackSessionMock.mockReset();
+  videoPlayerMock.mockReset();
 });
 
 describe("derivePersistedSubtitleMode", () => {
@@ -133,5 +139,28 @@ describe("WatchPage playback errors", () => {
     expect(screen.getByText("Failed to start playback")).toBeInTheDocument();
     expect(screen.getByRole("button", { name: "Go Back" })).toBeInTheDocument();
     expect(screen.queryByText("Mounted video player")).not.toBeInTheDocument();
+  });
+});
+
+describe("WatchPage playback state", () => {
+  it("keeps the session resume anchor current while forwarding state", () => {
+    const updatePlaybackPosition = vi.fn();
+    const onPlaybackStateChange = vi.fn();
+    playbackSessionMock.mockReturnValue(playbackSession({ updatePlaybackPosition }));
+
+    render(createElement(WatchPage, { ...watchPageProps, onPlaybackStateChange }));
+
+    const props = videoPlayerMock.mock.calls[0]?.[0] as {
+      onPlaybackStateChange?: (state: {
+        currentTime: number;
+        duration: number;
+        playing: boolean;
+      }) => void;
+    };
+    const state = { currentTime: 321, duration: 3600, playing: true };
+    props.onPlaybackStateChange?.(state);
+
+    expect(updatePlaybackPosition).toHaveBeenCalledWith(321);
+    expect(onPlaybackStateChange).toHaveBeenCalledWith(state);
   });
 });

--- a/web/src/player/components/WatchPage.tsx
+++ b/web/src/player/components/WatchPage.tsx
@@ -1,6 +1,6 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useQueryClient } from "@tanstack/react-query";
-import type { PlayerFileVersion, WatchPageProps } from "../types";
+import type { PlayerFileVersion, PlayerPlaybackStateChange, WatchPageProps } from "../types";
 import type { PlaybackRealtimeEventEnvelope } from "../realtime-protocol";
 import type { SubtitleInventoryItemV3 } from "../protocol-v3";
 import { usePlaybackSession } from "../hooks/usePlaybackSession";
@@ -168,6 +168,15 @@ export function WatchPage({
       session.switchAudioTrack(index, currentPosition);
     },
     [session],
+  );
+
+  const updatePlaybackPosition = session.updatePlaybackPosition;
+  const handlePlaybackStateChange = useCallback(
+    (state: PlayerPlaybackStateChange) => {
+      updatePlaybackPosition(state.currentTime);
+      onPlaybackStateChange?.(state);
+    },
+    [onPlaybackStateChange, updatePlaybackPosition],
   );
 
   /**
@@ -475,7 +484,7 @@ export function WatchPage({
       displayMode={displayMode}
       onPictureInPictureChange={onPictureInPictureChange}
       autoEnterPictureInPicture={autoEnterPictureInPicture}
-      onPlaybackStateChange={onPlaybackStateChange}
+      onPlaybackStateChange={handlePlaybackStateChange}
       onPlaybackTransportReady={onPlaybackTransportReady}
       onRealtimeEvent={handleRealtimeEvent}
       onRealtimeConnectionStateChange={setRealtimeConnectionState}

--- a/web/src/player/components/WatchPage.tsx
+++ b/web/src/player/components/WatchPage.tsx
@@ -170,13 +170,13 @@ export function WatchPage({
     [session],
   );
 
-  const updatePlaybackPosition = session.updatePlaybackPosition;
+  const updatePlaybackState = session.updatePlaybackState;
   const handlePlaybackStateChange = useCallback(
     (state: PlayerPlaybackStateChange) => {
-      updatePlaybackPosition(state.currentTime);
+      updatePlaybackState(state.currentTime, state.playing);
       onPlaybackStateChange?.(state);
     },
-    [onPlaybackStateChange, updatePlaybackPosition],
+    [onPlaybackStateChange, updatePlaybackState],
   );
 
   /**
@@ -435,6 +435,7 @@ export function WatchPage({
       streamUrl={session.streamUrl}
       plan={session.plan}
       planRevision={session.planRevision}
+      shouldAutoPlay={session.shouldAutoPlay}
       replanning={session.replanning}
       replanError={session.error}
       sessionId={session.sessionId}

--- a/web/src/player/hooks/useCodecDetection.test.ts
+++ b/web/src/player/hooks/useCodecDetection.test.ts
@@ -166,6 +166,8 @@ describe("probeWebCapabilities", () => {
 
     const { result, unmount } = renderHook(() => useCodecDetection());
     expect(result.current.hdrDetails.hdr10).toBe(false);
+    expect(result.current.codecsVideo).not.toContain("hevc");
+    expect(result.current.progressiveCodecsVideo).not.toContain("hevc");
     await act(async () => Promise.resolve());
     expect(result.current.hdrDetails).toMatchObject({
       hdr10: true,
@@ -174,6 +176,8 @@ describe("probeWebCapabilities", () => {
       hdr10_max_frame_rate: 24,
       hdr10_max_bitrate_kbps: 80_000,
     });
+    expect(result.current.codecsVideo).not.toContain("hevc");
+    expect(result.current.progressiveCodecsVideo).toContain("hevc");
     unmount();
   });
 

--- a/web/src/player/hooks/useCodecDetection.test.ts
+++ b/web/src/player/hooks/useCodecDetection.test.ts
@@ -1,8 +1,10 @@
+import { act, renderHook } from "@testing-library/react";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import {
   detectHDRFromMatchMedia,
   detectMaxResolutionFromScreen,
   probeWebCapabilities,
+  useCodecDetection,
 } from "./useCodecDetection";
 
 afterEach(() => {
@@ -71,6 +73,41 @@ describe("probeWebCapabilities", () => {
     expect(capabilities.hdrDetails.dolby_vision_profiles).toEqual([]);
     expect(capabilities.hdrDetails.dolby_vision_profile_levels).toEqual([]);
     expect(canPlayType).not.toHaveBeenCalledWith('video/mp4; codecs="dvhe.08.06"');
+  });
+
+  it("does not promote an indeterminate media-element answer to Dolby Vision support", () => {
+    vi.stubGlobal("matchMedia", () => ({ matches: true }));
+    vi.spyOn(HTMLMediaElement.prototype, "canPlayType").mockImplementation((mime) =>
+      mime === 'video/mp4; codecs="dvhe.08.06"' ? "maybe" : "",
+    );
+
+    expect(probeWebCapabilities().hdrDetails.dolby_vision_profiles).toEqual([]);
+  });
+
+  it("refreshes Dolby Vision claims when the active HDR output changes", () => {
+    let hdr = false;
+    const listeners = new Set<() => void>();
+    const query = {
+      get matches() {
+        return hdr;
+      },
+      addEventListener: (_: string, listener: () => void) => listeners.add(listener),
+      removeEventListener: (_: string, listener: () => void) => listeners.delete(listener),
+    };
+    vi.stubGlobal("matchMedia", () => query);
+    vi.spyOn(HTMLMediaElement.prototype, "canPlayType").mockImplementation((mime) =>
+      mime === 'video/mp4; codecs="dvhe.08.06"' ? "probably" : "",
+    );
+
+    const { result, unmount } = renderHook(() => useCodecDetection());
+    expect(result.current.hdrDetails.dolby_vision_profiles).toEqual([]);
+
+    act(() => {
+      hdr = true;
+      for (const listener of listeners) listener();
+    });
+    expect(result.current.hdrDetails.dolby_vision_profiles).toEqual([8]);
+    unmount();
   });
 
   it("advertises browser-playable MP3, FLAC, and OGG audio", () => {

--- a/web/src/player/hooks/useCodecDetection.test.ts
+++ b/web/src/player/hooks/useCodecDetection.test.ts
@@ -167,7 +167,13 @@ describe("probeWebCapabilities", () => {
     const { result, unmount } = renderHook(() => useCodecDetection());
     expect(result.current.hdrDetails.hdr10).toBe(false);
     await act(async () => Promise.resolve());
-    expect(result.current.hdrDetails.hdr10).toBe(true);
+    expect(result.current.hdrDetails).toMatchObject({
+      hdr10: true,
+      hdr10_max_width: 3840,
+      hdr10_max_height: 2160,
+      hdr10_max_frame_rate: 24,
+      hdr10_max_bitrate_kbps: 80_000,
+    });
     unmount();
   });
 

--- a/web/src/player/hooks/useCodecDetection.test.ts
+++ b/web/src/player/hooks/useCodecDetection.test.ts
@@ -3,6 +3,7 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 import {
   detectHDRFromMatchMedia,
   detectMaxResolutionFromScreen,
+  probeHDR10PlaybackSupport,
   probeWebCapabilities,
   useCodecDetection,
 } from "./useCodecDetection";
@@ -44,6 +45,39 @@ describe("detectHDRFromMatchMedia", () => {
 });
 
 describe("probeWebCapabilities", () => {
+  it("advertises HDR10 only after the exact progressive Media Capabilities probe", async () => {
+    const decodingInfo = vi.fn().mockResolvedValue({
+      supported: true,
+      smooth: true,
+      powerEfficient: true,
+      keySystemAccess: null,
+    });
+    vi.stubGlobal("navigator", { mediaCapabilities: { decodingInfo } });
+    vi.stubGlobal("matchMedia", (query: string) => ({ matches: query.includes("high") }));
+
+    await expect(probeHDR10PlaybackSupport()).resolves.toBe(true);
+    expect(decodingInfo).toHaveBeenCalledWith(
+      expect.objectContaining({
+        type: "file",
+        video: expect.objectContaining({
+          contentType: 'video/mp4; codecs="hev1.2.4.L153.B0"',
+          colorGamut: "rec2020",
+          transferFunction: "pq",
+          hdrMetadataType: "smpteSt2086",
+        }),
+      }),
+    );
+  });
+
+  it("does not probe HDR10 decoding against an SDR output", async () => {
+    const decodingInfo = vi.fn();
+    vi.stubGlobal("navigator", { mediaCapabilities: { decodingInfo } });
+    vi.stubGlobal("matchMedia", () => ({ matches: false }));
+
+    await expect(probeHDR10PlaybackSupport()).resolves.toBe(false);
+    expect(decodingInfo).not.toHaveBeenCalled();
+  });
+
   it("advertises native Dolby Vision Profile 8 only on an HDR output", () => {
     vi.stubGlobal("matchMedia", (query: string) => ({ matches: query.includes("high") }));
     vi.spyOn(HTMLMediaElement.prototype, "canPlayType").mockImplementation((mime) =>
@@ -108,6 +142,32 @@ describe("probeWebCapabilities", () => {
       for (const listener of listeners) listener();
     });
     expect(result.current.hdrDetails.dolby_vision_profiles).toEqual([8]);
+    unmount();
+  });
+
+  it("refreshes the active capabilities after the async HDR10 probe", async () => {
+    const listeners = new Set<() => void>();
+    const query = {
+      matches: true,
+      addEventListener: (_: string, listener: () => void) => listeners.add(listener),
+      removeEventListener: (_: string, listener: () => void) => listeners.delete(listener),
+    };
+    vi.stubGlobal("matchMedia", () => query);
+    vi.stubGlobal("navigator", {
+      mediaCapabilities: {
+        decodingInfo: vi.fn().mockResolvedValue({
+          supported: true,
+          smooth: true,
+          powerEfficient: true,
+          keySystemAccess: null,
+        }),
+      },
+    });
+
+    const { result, unmount } = renderHook(() => useCodecDetection());
+    expect(result.current.hdrDetails.hdr10).toBe(false);
+    await act(async () => Promise.resolve());
+    expect(result.current.hdrDetails.hdr10).toBe(true);
     unmount();
   });
 

--- a/web/src/player/hooks/useCodecDetection.test.ts
+++ b/web/src/player/hooks/useCodecDetection.test.ts
@@ -7,6 +7,7 @@ import {
 
 afterEach(() => {
   vi.restoreAllMocks();
+  vi.unstubAllGlobals();
 });
 
 describe("detectMaxResolutionFromScreen", () => {
@@ -41,6 +42,34 @@ describe("detectHDRFromMatchMedia", () => {
 });
 
 describe("probeWebCapabilities", () => {
+  it("advertises native Dolby Vision Profile 8 only on an HDR output", () => {
+    vi.stubGlobal("matchMedia", (query: string) => ({ matches: query.includes("high") }));
+    vi.spyOn(HTMLMediaElement.prototype, "canPlayType").mockImplementation((mime) =>
+      mime === 'video/mp4; codecs="dvhe.08.06"' ? "probably" : "",
+    );
+
+    const capabilities = probeWebCapabilities();
+
+    expect(capabilities.hdrDetails).toEqual({
+      hdr10: true,
+      hdr10_plus: false,
+      hlg: true,
+      dolby_vision_profiles: [8],
+    });
+  });
+
+  it("does not advertise a Dolby Vision decoder against an SDR output", () => {
+    vi.stubGlobal("matchMedia", () => ({ matches: false }));
+    const canPlayType = vi
+      .spyOn(HTMLMediaElement.prototype, "canPlayType")
+      .mockImplementation((mime) => (mime === 'video/mp4; codecs="dvhe.08.06"' ? "probably" : ""));
+
+    const capabilities = probeWebCapabilities();
+
+    expect(capabilities.hdrDetails.dolby_vision_profiles).toEqual([]);
+    expect(canPlayType).not.toHaveBeenCalledWith('video/mp4; codecs="dvhe.08.06"');
+  });
+
   it("advertises browser-playable MP3, FLAC, and OGG audio", () => {
     vi.spyOn(HTMLMediaElement.prototype, "canPlayType").mockImplementation((mime) =>
       ["audio/mp4", "audio/mpeg", "audio/flac", "audio/ogg"].some((supported) =>

--- a/web/src/player/hooks/useCodecDetection.test.ts
+++ b/web/src/player/hooks/useCodecDetection.test.ts
@@ -57,9 +57,10 @@ describe("probeWebCapabilities", () => {
       hdr10_plus: false,
       hlg: false,
       dolby_vision_profiles: [8],
-      dolby_vision_profile_levels: [{ profile: 8, max_level: 6 }],
+      dolby_vision_profile_levels: [{ profile: 8, max_level: 6, bl_compatibility_ids: [1] }],
     });
-    expect(capabilities.codecsVideo).toContain("hevc");
+    expect(capabilities.codecsVideo).not.toContain("hevc");
+    expect(capabilities.progressiveCodecsVideo).toContain("hevc");
   });
 
   it("does not advertise a Dolby Vision decoder against an SDR output", () => {

--- a/web/src/player/hooks/useCodecDetection.test.ts
+++ b/web/src/player/hooks/useCodecDetection.test.ts
@@ -51,11 +51,13 @@ describe("probeWebCapabilities", () => {
     const capabilities = probeWebCapabilities();
 
     expect(capabilities.hdrDetails).toEqual({
-      hdr10: true,
+      hdr10: false,
       hdr10_plus: false,
-      hlg: true,
+      hlg: false,
       dolby_vision_profiles: [8],
+      dolby_vision_profile_levels: [{ profile: 8, max_level: 6 }],
     });
+    expect(capabilities.codecsVideo).toContain("hevc");
   });
 
   it("does not advertise a Dolby Vision decoder against an SDR output", () => {
@@ -67,6 +69,7 @@ describe("probeWebCapabilities", () => {
     const capabilities = probeWebCapabilities();
 
     expect(capabilities.hdrDetails.dolby_vision_profiles).toEqual([]);
+    expect(capabilities.hdrDetails.dolby_vision_profile_levels).toEqual([]);
     expect(canPlayType).not.toHaveBeenCalledWith('video/mp4; codecs="dvhe.08.06"');
   });
 

--- a/web/src/player/hooks/useCodecDetection.ts
+++ b/web/src/player/hooks/useCodecDetection.ts
@@ -256,6 +256,12 @@ export function useCodecDetection(): WebCapabilityProbe {
         if (disposed || generation !== probeGeneration || !hdr10) return;
         setCapabilities((current) => ({
           ...current,
+          // The exact HDR10 query proves the HEVC Main10 base codec for the
+          // progressive MP4 route even when the separate generic HEVC probe was
+          // rejected. Keep that evidence scoped away from original and HLS.
+          progressiveCodecsVideo: current.progressiveCodecsVideo.includes("hevc")
+            ? current.progressiveCodecsVideo
+            : [...current.progressiveCodecsVideo, "hevc"],
           hdrDetails: {
             ...current.hdrDetails,
             hdr10: true,

--- a/web/src/player/hooks/useCodecDetection.ts
+++ b/web/src/player/hooks/useCodecDetection.ts
@@ -256,7 +256,14 @@ export function useCodecDetection(): WebCapabilityProbe {
         if (disposed || generation !== probeGeneration || !hdr10) return;
         setCapabilities((current) => ({
           ...current,
-          hdrDetails: { ...current.hdrDetails, hdr10: true },
+          hdrDetails: {
+            ...current.hdrDetails,
+            hdr10: true,
+            hdr10_max_width: 3840,
+            hdr10_max_height: 2160,
+            hdr10_max_frame_rate: 24,
+            hdr10_max_bitrate_kbps: 80_000,
+          },
         }));
       });
     };

--- a/web/src/player/hooks/useCodecDetection.ts
+++ b/web/src/player/hooks/useCodecDetection.ts
@@ -24,6 +24,25 @@ const DOLBY_VISION_PROFILE_PROBES: Record<
   8: { mime: 'video/mp4; codecs="dvhe.08.06"', maxLevel: 6, blCompatibilityIds: [1] },
 };
 
+// Silo's Profile 7 fallback strips Dolby Vision metadata into a progressive
+// MP4 whose video is a 2160p HEVC Main10 HDR10 base layer. Media Capabilities
+// can query the codec, transfer function, gamut, and static metadata together,
+// avoiding the old mistake of treating a generic HDR output query as proof of
+// every HDR format.
+const HDR10_PROGRESSIVE_CONFIGURATION = {
+  type: "file",
+  video: {
+    contentType: 'video/mp4; codecs="hev1.2.4.L153.B0"',
+    width: 3840,
+    height: 2160,
+    bitrate: 80_000_000,
+    framerate: 24,
+    colorGamut: "rec2020",
+    transferFunction: "pq",
+    hdrMetadataType: "smpteSt2086",
+  },
+} satisfies MediaDecodingConfiguration;
+
 const AUDIO_CODEC_MAP: Record<string, string[]> = {
   aac: ['audio/mp4; codecs="mp4a.40.2"', 'video/mp4; codecs="mp4a.40.2"'],
   mp3: ["audio/mpeg"],
@@ -72,6 +91,23 @@ export function detectHDRFromMatchMedia(matchMediaFn: typeof matchMedia | undefi
     matchMediaFn("(dynamic-range: high)").matches ||
     matchMediaFn("(video-dynamic-range: high)").matches
   );
+}
+
+/** Probes the exact HDR10 progressive shape produced by Silo's remux path. */
+export async function probeHDR10PlaybackSupport(): Promise<boolean> {
+  const hdrOutput = detectHDRFromMatchMedia(
+    typeof matchMedia !== "undefined" ? (query) => matchMedia(query) : undefined,
+  );
+  if (!hdrOutput || typeof navigator === "undefined" || !navigator.mediaCapabilities) {
+    return false;
+  }
+
+  try {
+    const result = await navigator.mediaCapabilities.decodingInfo(HDR10_PROGRESSIVE_CONFIGURATION);
+    return result.supported && result.smooth;
+  } catch {
+    return false;
+  }
 }
 
 function testMediaType(mime: string): boolean {
@@ -204,16 +240,33 @@ export function useCodecDetection(): WebCapabilityProbe {
 
   useEffect(() => {
     if (typeof matchMedia === "undefined") return;
+    let disposed = false;
+    let probeGeneration = 0;
     const queries = [
       matchMedia("(dynamic-range: high)"),
       matchMedia("(video-dynamic-range: high)"),
     ];
-    const refresh = () => setCapabilities(probeWebCapabilities());
+    const refresh = () => {
+      const generation = ++probeGeneration;
+      const next = probeWebCapabilities();
+      setCapabilities(next);
+      if (!next.hdr) return;
+
+      void probeHDR10PlaybackSupport().then((hdr10) => {
+        if (disposed || generation !== probeGeneration || !hdr10) return;
+        setCapabilities((current) => ({
+          ...current,
+          hdrDetails: { ...current.hdrDetails, hdr10: true },
+        }));
+      });
+    };
+    refresh();
     for (const query of queries) {
       if (typeof query.addEventListener === "function") query.addEventListener("change", refresh);
       else query.addListener?.(refresh);
     }
     return () => {
+      disposed = true;
       for (const query of queries) {
         if (typeof query.removeEventListener === "function")
           query.removeEventListener("change", refresh);

--- a/web/src/player/hooks/useCodecDetection.ts
+++ b/web/src/player/hooks/useCodecDetection.ts
@@ -1,4 +1,4 @@
-import { useMemo } from "react";
+import { useEffect, useState } from "react";
 import { detectHLSSupport, type WebCapabilityProbe } from "../client-context-v3";
 
 /** Maps our codec names to the MIME declarations browsers expose for them. */
@@ -91,7 +91,10 @@ function testMediaType(mime: string): boolean {
 function testMediaElementType(mime: string): boolean {
   if (typeof document === "undefined") return false;
   try {
-    return document.createElement("video").canPlayType(mime) !== "";
+    // `maybe` only recognizes the container/type. Structured Dolby Vision
+    // claims require the media element's definitive answer for the exact
+    // sample entry.
+    return document.createElement("video").canPlayType(mime) === "probably";
   } catch {
     return false;
   }
@@ -178,9 +181,32 @@ export function probeWebCapabilities(): WebCapabilityProbe {
 }
 
 /**
- * Memoizes the browser capability probe for the lifetime of the component.
- * Nothing it measures changes while the page is open.
+ * Keeps the browser capability probe current with the active output route.
+ * Moving a window between SDR and HDR displays can change the media-query
+ * result without remounting the player, so refresh when either query changes.
  */
 export function useCodecDetection(): WebCapabilityProbe {
-  return useMemo(() => probeWebCapabilities(), []);
+  const [capabilities, setCapabilities] = useState(probeWebCapabilities);
+
+  useEffect(() => {
+    if (typeof matchMedia === "undefined") return;
+    const queries = [
+      matchMedia("(dynamic-range: high)"),
+      matchMedia("(video-dynamic-range: high)"),
+    ];
+    const refresh = () => setCapabilities(probeWebCapabilities());
+    for (const query of queries) {
+      if (typeof query.addEventListener === "function") query.addEventListener("change", refresh);
+      else query.addListener?.(refresh);
+    }
+    return () => {
+      for (const query of queries) {
+        if (typeof query.removeEventListener === "function")
+          query.removeEventListener("change", refresh);
+        else query.removeListener?.(refresh);
+      }
+    };
+  }, []);
+
+  return capabilities;
 }

--- a/web/src/player/hooks/useCodecDetection.ts
+++ b/web/src/player/hooks/useCodecDetection.ts
@@ -9,6 +9,15 @@ const VIDEO_CODEC_MAP: Record<string, string> = {
   vp9: "vp09.00.10.08",
 };
 
+// Silo's native Dolby Vision remux recipe preserves the DOVI configuration
+// record under a dvhe sample entry. Probe the exact shape the browser would
+// receive instead of inferring Dolby Vision support from generic HEVC decode.
+// Level 6 covers the 2160p24 source class involved in the web regression.
+const DOLBY_VISION_PROFILE_CODEC_MAP: Record<number, string> = {
+  5: 'video/mp4; codecs="dvhe.05.06"',
+  8: 'video/mp4; codecs="dvhe.08.06"',
+};
+
 const AUDIO_CODEC_MAP: Record<string, string[]> = {
   aac: ['audio/mp4; codecs="mp4a.40.2"', 'video/mp4; codecs="mp4a.40.2"'],
   mp3: ["audio/mpeg"],
@@ -78,6 +87,15 @@ function testMediaType(mime: string): boolean {
   }
 }
 
+function testMediaElementType(mime: string): boolean {
+  if (typeof document === "undefined") return false;
+  try {
+    return document.createElement("video").canPlayType(mime) !== "";
+  } catch {
+    return false;
+  }
+}
+
 /**
  * Probes what this browser will admit to decoding.
  *
@@ -124,6 +142,20 @@ export function probeWebCapabilities(): WebCapabilityProbe {
   const hdr = detectHDRFromMatchMedia(
     typeof matchMedia !== "undefined" ? (query) => matchMedia(query) : undefined,
   );
+  const dolbyVisionProfiles = hdr
+    ? Object.entries(DOLBY_VISION_PROFILE_CODEC_MAP)
+        .filter(([, mime]) => testMediaElementType(mime))
+        .map(([profile]) => Number(profile))
+    : [];
+  const hdrDetails = {
+    // Browsers expose active high-dynamic-range output eligibility, but not
+    // independent HDR10/HLG modes. This mirrors the platform's macOS
+    // attestation: both static HDR paths follow the same live output signal.
+    hdr10: hdr,
+    hdr10_plus: false,
+    hlg: hdr,
+    dolby_vision_profiles: dolbyVisionProfiles,
+  };
 
   return {
     containers,
@@ -131,6 +163,7 @@ export function probeWebCapabilities(): WebCapabilityProbe {
     codecsAudio,
     maxResolution,
     hdr,
+    hdrDetails,
     hls: detectHLSSupport(),
   };
 }

--- a/web/src/player/hooks/useCodecDetection.ts
+++ b/web/src/player/hooks/useCodecDetection.ts
@@ -13,11 +13,16 @@ const VIDEO_CODEC_MAP: Record<string, string> = {
 // record under a dvhe sample entry. Probe the exact shape the browser would
 // receive instead of inferring Dolby Vision support from generic HEVC decode.
 // Level 6 covers the 2160p24 source class involved in the web regression.
-const DOLBY_VISION_PROFILE_CODEC_MAP: Record<number, string> = {
-  5: 'video/mp4; codecs="dvhe.05.06"',
-  8: 'video/mp4; codecs="dvhe.08.06"',
+const DOLBY_VISION_PROFILE_PROBES: Record<
+  number,
+  { mime: string; maxLevel: number; blCompatibilityIds?: number[] }
+> = {
+  5: { mime: 'video/mp4; codecs="dvhe.05.06"', maxLevel: 6 },
+  // The MIME codec string identifies Profile 8 but not its base-layer
+  // compatibility ID. Conservatively claim only the Profile 8.1 shape that
+  // this regression and Safari's progressive remux path exercise.
+  8: { mime: 'video/mp4; codecs="dvhe.08.06"', maxLevel: 6, blCompatibilityIds: [1] },
 };
-const DOLBY_VISION_PROBE_LEVEL = 6;
 
 const AUDIO_CODEC_MAP: Record<string, string[]> = {
   aac: ['audio/mp4; codecs="mp4a.40.2"', 'video/mp4; codecs="mp4a.40.2"'],
@@ -147,14 +152,16 @@ export function probeWebCapabilities(): WebCapabilityProbe {
     typeof matchMedia !== "undefined" ? (query) => matchMedia(query) : undefined,
   );
   const dolbyVisionProfiles = hdr
-    ? Object.entries(DOLBY_VISION_PROFILE_CODEC_MAP)
-        .filter(([, mime]) => testMediaElementType(mime))
+    ? Object.entries(DOLBY_VISION_PROFILE_PROBES)
+        .filter(([, probe]) => testMediaElementType(probe.mime))
         .map(([profile]) => Number(profile))
     : [];
-  if (dolbyVisionProfiles.length > 0 && !codecsVideo.includes("hevc")) {
+  const progressiveCodecsVideo = [...codecsVideo];
+  if (dolbyVisionProfiles.length > 0 && !progressiveCodecsVideo.includes("hevc")) {
     // Every Dolby Vision profile probed above uses an HEVC base layer. The
-    // planner requires the flat base-codec claim as well as the HDR profile.
-    codecsVideo.push("hevc");
+    // planner requires the flat base-codec claim as well as the HDR profile,
+    // but this media-element evidence must not leak into hls.js' MSE path.
+    progressiveCodecsVideo.push("hevc");
   }
   const hdrDetails = {
     // Generic HDR output eligibility does not prove either static HDR format.
@@ -163,15 +170,22 @@ export function probeWebCapabilities(): WebCapabilityProbe {
     hdr10_plus: false,
     hlg: false,
     dolby_vision_profiles: dolbyVisionProfiles,
-    dolby_vision_profile_levels: dolbyVisionProfiles.map((profile) => ({
-      profile,
-      max_level: DOLBY_VISION_PROBE_LEVEL,
-    })),
+    dolby_vision_profile_levels: dolbyVisionProfiles.map((profile) => {
+      const profileProbe = DOLBY_VISION_PROFILE_PROBES[profile]!;
+      return {
+        profile,
+        max_level: profileProbe.maxLevel,
+        ...(profileProbe.blCompatibilityIds
+          ? { bl_compatibility_ids: profileProbe.blCompatibilityIds }
+          : {}),
+      };
+    }),
   };
 
   return {
     containers,
     codecsVideo,
+    progressiveCodecsVideo,
     codecsAudio,
     maxResolution,
     hdr,

--- a/web/src/player/hooks/useCodecDetection.ts
+++ b/web/src/player/hooks/useCodecDetection.ts
@@ -17,6 +17,7 @@ const DOLBY_VISION_PROFILE_CODEC_MAP: Record<number, string> = {
   5: 'video/mp4; codecs="dvhe.05.06"',
   8: 'video/mp4; codecs="dvhe.08.06"',
 };
+const DOLBY_VISION_PROBE_LEVEL = 6;
 
 const AUDIO_CODEC_MAP: Record<string, string[]> = {
   aac: ['audio/mp4; codecs="mp4a.40.2"', 'video/mp4; codecs="mp4a.40.2"'],
@@ -147,14 +148,22 @@ export function probeWebCapabilities(): WebCapabilityProbe {
         .filter(([, mime]) => testMediaElementType(mime))
         .map(([profile]) => Number(profile))
     : [];
+  if (dolbyVisionProfiles.length > 0 && !codecsVideo.includes("hevc")) {
+    // Every Dolby Vision profile probed above uses an HEVC base layer. The
+    // planner requires the flat base-codec claim as well as the HDR profile.
+    codecsVideo.push("hevc");
+  }
   const hdrDetails = {
-    // Browsers expose active high-dynamic-range output eligibility, but not
-    // independent HDR10/HLG modes. This mirrors the platform's macOS
-    // attestation: both static HDR paths follow the same live output signal.
-    hdr10: hdr,
+    // Generic HDR output eligibility does not prove either static HDR format.
+    // Only publish the exact Dolby Vision formats tested above.
+    hdr10: false,
     hdr10_plus: false,
-    hlg: hdr,
+    hlg: false,
     dolby_vision_profiles: dolbyVisionProfiles,
+    dolby_vision_profile_levels: dolbyVisionProfiles.map((profile) => ({
+      profile,
+      max_level: DOLBY_VISION_PROBE_LEVEL,
+    })),
   };
 
   return {

--- a/web/src/player/hooks/usePlaybackSession.test.ts
+++ b/web/src/player/hooks/usePlaybackSession.test.ts
@@ -752,6 +752,73 @@ describe("usePlaybackSession output capability changes", () => {
     unmount();
   });
 
+  it("retires after a queued user intent also refuses refreshed output", async () => {
+    const setHDR = outputProbe(true);
+    let resolveOutputReplan: ((response: Response) => void) | undefined;
+    const outputReplanResponse = new Promise<Response>((resolve) => {
+      resolveOutputReplan = resolve;
+    });
+    const replanOperations: string[] = [];
+    const stoppedSessions: string[] = [];
+    const fetchMock = vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+      const url = String(input);
+      if (url.endsWith("/playback/start")) {
+        return jsonResponse({
+          protocol_version: 3,
+          server_features: ["playback_plan_v3", "output_change_v1"],
+          outcome: "playable",
+          session_id: "session-hdr",
+          playback_plan: fixturePlanV3({ session_id: "session-hdr" }),
+        });
+      }
+      if (url.endsWith("/playback/session-hdr/replan")) {
+        replanOperations.push((JSON.parse(String(init?.body)) as { operation: string }).operation);
+        if (replanOperations.length === 1) return outputReplanResponse;
+        return jsonResponse({
+          protocol_version: 3,
+          server_features: ["playback_plan_v3", "output_change_v1"],
+          outcome: "terminal",
+          terminal: { reason: "hdr_transcode_unsupported", message: "HDR unsupported" },
+        });
+      }
+      if (url.endsWith("/playback/route-events")) return new Response(null, { status: 202 });
+      if (init?.method === "DELETE") {
+        stoppedSessions.push(url);
+        return new Response(null, { status: 204 });
+      }
+      throw new Error(`Unexpected request: ${url}`);
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    const { result, unmount } = renderHook(
+      () => usePlaybackSession("request-1", [], [], 7, 0, false, "auto"),
+      { wrapper },
+    );
+    await waitFor(() => expect(result.current.sessionId).toBe("session-hdr"));
+
+    act(() => setHDR(false));
+    await waitFor(() => expect(replanOperations).toEqual(["output_change"]));
+    act(() => result.current.changeQuality("1080p", 91));
+    expect(replanOperations).toEqual(["output_change"]);
+
+    await act(async () => {
+      resolveOutputReplan?.(
+        jsonResponse({
+          protocol_version: 3,
+          server_features: ["playback_plan_v3", "output_change_v1"],
+          outcome: "terminal",
+          terminal: { reason: "hdr_transcode_unsupported", message: "HDR unsupported" },
+        }),
+      );
+      await outputReplanResponse;
+    });
+
+    await waitFor(() => expect(replanOperations).toEqual(["output_change", "quality_change"]));
+    await waitFor(() => expect(result.current.plan).toBeNull());
+    expect(stoppedSessions).toContain("/api/v1/playback/session-hdr");
+    unmount();
+  });
+
   it("keeps the active plan when an output refresh request fails", async () => {
     const setHDR = outputProbe(true);
     const stoppedSessions: string[] = [];

--- a/web/src/player/hooks/usePlaybackSession.test.ts
+++ b/web/src/player/hooks/usePlaybackSession.test.ts
@@ -431,7 +431,6 @@ describe("usePlaybackSession output capability changes", () => {
       operation: string;
       position_seconds: number;
       selected_tracks: { audio?: typeof audio; subtitle?: typeof subtitle };
-      failure?: { classification?: string };
       client_capabilities: { hdr: boolean };
     }> = [];
     let startCount = 0;
@@ -484,9 +483,8 @@ describe("usePlaybackSession output capability changes", () => {
     expect(startCount).toBe(1);
     expect(replanBodies).toHaveLength(1);
     expect(replanBodies[0]).toMatchObject({
-      operation: "failure_recovery",
+      operation: "output_change",
       position_seconds: 321,
-      failure: { classification: "output_route_changed" },
       selected_tracks: { audio, subtitle },
       client_capabilities: { hdr: false },
     });
@@ -538,6 +536,81 @@ describe("usePlaybackSession output capability changes", () => {
     expect(result.current.sessionId).toBeNull();
     expect(result.current.error).not.toBeNull();
     await waitFor(() => expect(stoppedSessions).toContain("/api/v1/playback/session-hdr"));
+    unmount();
+  });
+
+  it("uses the latest capabilities when an output change queues behind another replan", async () => {
+    const setHDR = outputProbe(true);
+    let resolveFirstReplan: ((response: Response) => void) | undefined;
+    const firstReplanResponse = new Promise<Response>((resolve) => {
+      resolveFirstReplan = resolve;
+    });
+    const replanBodies: Array<{ operation: string; client_capabilities: { hdr: boolean } }> = [];
+    const fetchMock = vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+      const url = String(input);
+      if (url.endsWith("/playback/start")) {
+        return jsonResponse({
+          protocol_version: 3,
+          server_features: ["playback_plan_v3"],
+          outcome: "playable",
+          session_id: "session-hdr",
+          playback_plan: fixturePlanV3({ session_id: "session-hdr" }),
+        });
+      }
+      if (url.endsWith("/playback/session-hdr/replan")) {
+        replanBodies.push(JSON.parse(String(init?.body)) as (typeof replanBodies)[number]);
+        if (replanBodies.length === 1) return firstReplanResponse;
+        return jsonResponse({
+          protocol_version: 3,
+          server_features: ["playback_plan_v3"],
+          outcome: "playable",
+          session_id: "session-hdr",
+          playback_plan: fixturePlanV3({
+            session_id: "session-hdr",
+            plan_id: "plan:queuedoutput0001",
+            plan_attempt_key: "v3:queuedoutput0001",
+          }),
+        });
+      }
+      if (url.endsWith("/playback/route-events")) return new Response(null, { status: 202 });
+      if (init?.method === "DELETE") return new Response(null, { status: 204 });
+      throw new Error(`Unexpected request: ${url}`);
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    const { result, unmount } = renderHook(
+      () => usePlaybackSession("request-1", [], [], 7, 0, false, "auto"),
+      { wrapper },
+    );
+    await waitFor(() => expect(result.current.sessionId).toBe("session-hdr"));
+
+    act(() => result.current.refreshSubtitles(120));
+    await waitFor(() => expect(replanBodies).toHaveLength(1));
+    act(() => setHDR(false));
+    expect(replanBodies).toHaveLength(1);
+
+    await act(async () => {
+      resolveFirstReplan?.(
+        jsonResponse({
+          protocol_version: 3,
+          server_features: ["playback_plan_v3"],
+          outcome: "playable",
+          session_id: "session-hdr",
+          playback_plan: fixturePlanV3({
+            session_id: "session-hdr",
+            plan_id: "plan:trackrefresh0001",
+            plan_attempt_key: "v3:trackrefresh0001",
+          }),
+        }),
+      );
+      await firstReplanResponse;
+    });
+
+    await waitFor(() => expect(replanBodies).toHaveLength(2));
+    expect(replanBodies[1]).toMatchObject({
+      operation: "output_change",
+      client_capabilities: { hdr: false },
+    });
     unmount();
   });
 });

--- a/web/src/player/hooks/usePlaybackSession.test.ts
+++ b/web/src/player/hooks/usePlaybackSession.test.ts
@@ -386,14 +386,14 @@ describe("usePlaybackSession output capability changes", () => {
         if (startBodies.length === 1) {
           return jsonResponse({
             protocol_version: 3,
-            server_features: ["playback_plan_v3"],
+            server_features: ["playback_plan_v3", "output_change_v1"],
             outcome: "terminal",
             terminal: { reason: "hdr_transcode_unsupported", message: "HDR unsupported" },
           });
         }
         return jsonResponse({
           protocol_version: 3,
-          server_features: ["playback_plan_v3"],
+          server_features: ["playback_plan_v3", "output_change_v1"],
           outcome: "playable",
           session_id: "session-hdr",
           playback_plan: fixturePlanV3({ session_id: "session-hdr" }),
@@ -443,7 +443,7 @@ describe("usePlaybackSession output capability changes", () => {
         startCount += 1;
         return jsonResponse({
           protocol_version: 3,
-          server_features: ["playback_plan_v3"],
+          server_features: ["playback_plan_v3", "output_change_v1"],
           outcome: "playable",
           session_id: "session-hdr",
           playback_plan: initialPlan,
@@ -453,7 +453,7 @@ describe("usePlaybackSession output capability changes", () => {
         replanBodies.push(JSON.parse(String(init?.body)) as (typeof replanBodies)[number]);
         return jsonResponse({
           protocol_version: 3,
-          server_features: ["playback_plan_v3"],
+          server_features: ["playback_plan_v3", "output_change_v1"],
           outcome: "playable",
           session_id: "session-hdr",
           playback_plan: fixturePlanV3({
@@ -511,7 +511,7 @@ describe("usePlaybackSession output capability changes", () => {
       if (url.endsWith("/playback/start")) {
         return jsonResponse({
           protocol_version: 3,
-          server_features: ["playback_plan_v3"],
+          server_features: ["playback_plan_v3", "output_change_v1"],
           outcome: "playable",
           session_id: "session-hdr",
           playback_plan: resumedPlan,
@@ -521,7 +521,7 @@ describe("usePlaybackSession output capability changes", () => {
         replanBodies.push(JSON.parse(String(init?.body)) as { position_seconds: number });
         return jsonResponse({
           protocol_version: 3,
-          server_features: ["playback_plan_v3"],
+          server_features: ["playback_plan_v3", "output_change_v1"],
           outcome: "playable",
           session_id: "session-hdr",
           playback_plan: fixturePlanV3({
@@ -559,7 +559,7 @@ describe("usePlaybackSession output capability changes", () => {
       if (url.endsWith("/playback/start")) {
         return jsonResponse({
           protocol_version: 3,
-          server_features: ["playback_plan_v3"],
+          server_features: ["playback_plan_v3", "output_change_v1"],
           outcome: "playable",
           session_id: "session-hdr",
           playback_plan: fixturePlanV3({ session_id: "session-hdr" }),
@@ -568,7 +568,7 @@ describe("usePlaybackSession output capability changes", () => {
       if (url.endsWith("/playback/session-hdr/replan")) {
         return jsonResponse({
           protocol_version: 3,
-          server_features: ["playback_plan_v3"],
+          server_features: ["playback_plan_v3", "output_change_v1"],
           outcome: "terminal",
           terminal: { reason: "hdr_transcode_unsupported", message: "HDR unsupported" },
         });
@@ -613,7 +613,7 @@ describe("usePlaybackSession output capability changes", () => {
       if (url.endsWith("/playback/start")) {
         return jsonResponse({
           protocol_version: 3,
-          server_features: ["playback_plan_v3"],
+          server_features: ["playback_plan_v3", "output_change_v1"],
           outcome: "playable",
           session_id: "session-hdr",
           playback_plan: fixturePlanV3({ session_id: "session-hdr" }),
@@ -624,7 +624,7 @@ describe("usePlaybackSession output capability changes", () => {
         if (replanBodies.length === 1) return firstReplanResponse;
         return jsonResponse({
           protocol_version: 3,
-          server_features: ["playback_plan_v3"],
+          server_features: ["playback_plan_v3", "output_change_v1"],
           outcome: "playable",
           session_id: "session-hdr",
           playback_plan: fixturePlanV3({
@@ -656,7 +656,7 @@ describe("usePlaybackSession output capability changes", () => {
       resolveFirstReplan?.(
         jsonResponse({
           protocol_version: 3,
-          server_features: ["playback_plan_v3"],
+          server_features: ["playback_plan_v3", "output_change_v1"],
           outcome: "playable",
           session_id: "session-hdr",
           playback_plan: fixturePlanV3({
@@ -691,7 +691,7 @@ describe("usePlaybackSession output capability changes", () => {
       if (url.endsWith("/playback/start")) {
         return jsonResponse({
           protocol_version: 3,
-          server_features: ["playback_plan_v3"],
+          server_features: ["playback_plan_v3", "output_change_v1"],
           outcome: "playable",
           session_id: "session-hdr",
           playback_plan: fixturePlanV3({ session_id: "session-hdr" }),
@@ -704,7 +704,7 @@ describe("usePlaybackSession output capability changes", () => {
         if (replanBodies.length === 1) return firstReplanResponse;
         return jsonResponse({
           protocol_version: 3,
-          server_features: ["playback_plan_v3"],
+          server_features: ["playback_plan_v3", "output_change_v1"],
           outcome: "playable",
           session_id: "session-hdr",
           playback_plan: fixturePlanV3({
@@ -737,7 +737,7 @@ describe("usePlaybackSession output capability changes", () => {
       resolveFirstReplan?.(
         jsonResponse({
           protocol_version: 3,
-          server_features: ["playback_plan_v3"],
+          server_features: ["playback_plan_v3", "output_change_v1"],
           outcome: "terminal",
           terminal: { reason: "hdr_transcode_unsupported", message: "HDR unsupported" },
         }),
@@ -760,7 +760,7 @@ describe("usePlaybackSession output capability changes", () => {
       if (url.endsWith("/playback/start")) {
         return jsonResponse({
           protocol_version: 3,
-          server_features: ["playback_plan_v3"],
+          server_features: ["playback_plan_v3", "output_change_v1"],
           outcome: "playable",
           session_id: "session-hdr",
           playback_plan: fixturePlanV3({ session_id: "session-hdr" }),
@@ -811,7 +811,7 @@ describe("usePlaybackSession output capability changes", () => {
       if (url.endsWith("/playback/start")) {
         return jsonResponse({
           protocol_version: 3,
-          server_features: ["playback_plan_v3"],
+          server_features: ["playback_plan_v3", "output_change_v1"],
           outcome: "playable",
           session_id: "session-hdr",
           playback_plan: fixturePlanV3({ session_id: "session-hdr" }),
@@ -822,7 +822,7 @@ describe("usePlaybackSession output capability changes", () => {
         if (replanBodies.length === 1) return outputReplanResponse;
         return jsonResponse({
           protocol_version: 3,
-          server_features: ["playback_plan_v3"],
+          server_features: ["playback_plan_v3", "output_change_v1"],
           outcome: "playable",
           session_id: "session-hdr",
           playback_plan: fixturePlanV3({
@@ -854,7 +854,7 @@ describe("usePlaybackSession output capability changes", () => {
       resolveOutputReplan?.(
         jsonResponse({
           protocol_version: 3,
-          server_features: ["playback_plan_v3"],
+          server_features: ["playback_plan_v3", "output_change_v1"],
           outcome: "playable",
           session_id: "session-hdr",
           playback_plan: fixturePlanV3({ session_id: "session-hdr" }),
@@ -869,6 +869,107 @@ describe("usePlaybackSession output capability changes", () => {
       quality_preference: "1080p",
     });
     expect(result.current.qualityPreference).toBe("1080p");
+    unmount();
+  });
+
+  it("drops a predecessor failure after an output refresh adopts a new plan", async () => {
+    const setHDR = outputProbe(true);
+    let resolveOutputReplan: ((response: Response) => void) | undefined;
+    const outputReplanResponse = new Promise<Response>((resolve) => {
+      resolveOutputReplan = resolve;
+    });
+    const replanOperations: string[] = [];
+    const fetchMock = vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+      const url = String(input);
+      if (url.endsWith("/playback/start")) {
+        return jsonResponse({
+          protocol_version: 3,
+          server_features: ["playback_plan_v3", "output_change_v1"],
+          outcome: "playable",
+          session_id: "session-hdr",
+          playback_plan: fixturePlanV3({ session_id: "session-hdr" }),
+        });
+      }
+      if (url.endsWith("/playback/session-hdr/replan")) {
+        replanOperations.push((JSON.parse(String(init?.body)) as { operation: string }).operation);
+        return outputReplanResponse;
+      }
+      if (url.endsWith("/playback/route-events")) return new Response(null, { status: 202 });
+      if (init?.method === "DELETE") return new Response(null, { status: 204 });
+      throw new Error(`Unexpected request: ${url}`);
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    const { result, unmount } = renderHook(
+      () => usePlaybackSession("request-1", [], [], 7, 0, false, "auto"),
+      { wrapper },
+    );
+    await waitFor(() => expect(result.current.sessionId).toBe("session-hdr"));
+
+    act(() => setHDR(false));
+    await waitFor(() => expect(replanOperations).toEqual(["output_change"]));
+    act(() => result.current.recoverFromFailure({ classification: "decoder_failure" }, 120));
+
+    await act(async () => {
+      resolveOutputReplan?.(
+        jsonResponse({
+          protocol_version: 3,
+          server_features: ["playback_plan_v3", "output_change_v1"],
+          outcome: "playable",
+          session_id: "session-hdr",
+          playback_plan: fixturePlanV3({
+            session_id: "session-hdr",
+            plan_id: "plan:replacement0001",
+            plan_attempt_key: "v3:replacement0001",
+          }),
+        }),
+      );
+      await outputReplanResponse;
+    });
+
+    await waitFor(() => expect(result.current.plan?.plan_id).toBe("plan:replacement0001"));
+    expect(replanOperations).toEqual(["output_change"]);
+    unmount();
+  });
+
+  it("keeps playback unchanged when the server lacks output-change support", async () => {
+    const setHDR = outputProbe(true);
+    const replanOperations: string[] = [];
+    const fetchMock = vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+      const url = String(input);
+      if (url.endsWith("/playback/start")) {
+        return jsonResponse({
+          protocol_version: 3,
+          server_features: ["playback_plan_v3"],
+          outcome: "playable",
+          session_id: "session-hdr",
+          playback_plan: fixturePlanV3({ session_id: "session-hdr" }),
+        });
+      }
+      if (url.endsWith("/playback/session-hdr/replan")) {
+        replanOperations.push((JSON.parse(String(init?.body)) as { operation: string }).operation);
+        return jsonResponse({ error: "unsupported operation" }, { status: 400 });
+      }
+      if (url.endsWith("/playback/route-events")) return new Response(null, { status: 202 });
+      if (init?.method === "DELETE") return new Response(null, { status: 204 });
+      throw new Error(`Unexpected request: ${url}`);
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    const { result, unmount } = renderHook(
+      () => usePlaybackSession("request-1", [], [], 7, 0, false, "auto"),
+      { wrapper },
+    );
+    await waitFor(() => expect(result.current.sessionId).toBe("session-hdr"));
+
+    await act(async () => {
+      setHDR(false);
+      await Promise.resolve();
+    });
+
+    expect(replanOperations).toEqual([]);
+    expect(result.current.sessionId).toBe("session-hdr");
+    expect(result.current.plan).not.toBeNull();
     unmount();
   });
 });
@@ -997,7 +1098,7 @@ describe("usePlaybackSession version switches", () => {
 });
 
 describe("usePlaybackSession replans", () => {
-  it("runs a queued failure recovery after the in-flight replan settles", async () => {
+  it("drops a queued predecessor failure after the in-flight replan adopts a new plan", async () => {
     const initialPlan = fixturePlanV3();
     let resolveFirstReplan: ((response: Response) => void) | undefined;
     const firstReplanResponse = new Promise<Response>((resolve) => {
@@ -1022,17 +1123,7 @@ describe("usePlaybackSession replans", () => {
         replanBodies.push(
           JSON.parse(String(init?.body)) as { operation: string; position_seconds: number },
         );
-        if (replanBodies.length === 1) return firstReplanResponse;
-        return jsonResponse({
-          protocol_version: 3,
-          server_features: ["playback_plan_v3"],
-          outcome: "playable",
-          session_id: "session-1",
-          playback_plan: fixturePlanV3({
-            plan_id: "plan:2222222222222222",
-            plan_attempt_key: "v3:2222222222222222",
-          }),
-        });
+        return firstReplanResponse;
       }
       if (url.endsWith("/playback/route-events")) {
         return new Response(null, { status: 202 });
@@ -1076,13 +1167,10 @@ describe("usePlaybackSession replans", () => {
       await firstReplanResponse;
     });
 
-    await waitFor(() => expect(replanBodies).toHaveLength(2));
+    await waitFor(() => expect(result.current.plan?.plan_id).toBe("plan:1111111111111111"));
     expect(
       replanBodies.map(({ operation, position_seconds }) => ({ operation, position_seconds })),
-    ).toEqual([
-      { operation: "track_change", position_seconds: 120 },
-      { operation: "failure_recovery", position_seconds: 450 },
-    ]);
+    ).toEqual([{ operation: "track_change", position_seconds: 120 }]);
 
     unmount();
   });

--- a/web/src/player/hooks/usePlaybackSession.test.ts
+++ b/web/src/player/hooks/usePlaybackSession.test.ts
@@ -419,23 +419,102 @@ describe("usePlaybackSession output capability changes", () => {
     unmount();
   });
 
-  it("replaces an active HDR plan at the latest position after moving to SDR", async () => {
+  it("replans an active HDR route with its tracks and paused state after moving to SDR", async () => {
     const setHDR = outputProbe(true);
-    const startBodies: Array<{ start_position?: number; client_capabilities: { hdr: boolean } }> =
-      [];
-    const stoppedSessions: string[] = [];
+    const audio = { id: "file:7:audio:1", index: 1 };
+    const subtitle = { id: "file:7:subtitle:2", index: 2 };
+    const initialPlan = fixturePlanV3({
+      session_id: "session-hdr",
+      selected_tracks: { audio, subtitle },
+    });
+    const replanBodies: Array<{
+      operation: string;
+      position_seconds: number;
+      selected_tracks: { audio?: typeof audio; subtitle?: typeof subtitle };
+      failure?: { classification?: string };
+      client_capabilities: { hdr: boolean };
+    }> = [];
+    let startCount = 0;
     const fetchMock = vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
       const url = String(input);
       if (url.endsWith("/playback/start")) {
-        const body = JSON.parse(String(init?.body)) as (typeof startBodies)[number];
-        startBodies.push(body);
-        const sessionId = startBodies.length === 1 ? "session-hdr" : "session-sdr";
+        startCount += 1;
         return jsonResponse({
           protocol_version: 3,
           server_features: ["playback_plan_v3"],
           outcome: "playable",
-          session_id: sessionId,
-          playback_plan: fixturePlanV3({ session_id: sessionId }),
+          session_id: "session-hdr",
+          playback_plan: initialPlan,
+        });
+      }
+      if (url.endsWith("/playback/session-hdr/replan")) {
+        replanBodies.push(JSON.parse(String(init?.body)) as (typeof replanBodies)[number]);
+        return jsonResponse({
+          protocol_version: 3,
+          server_features: ["playback_plan_v3"],
+          outcome: "playable",
+          session_id: "session-hdr",
+          playback_plan: fixturePlanV3({
+            session_id: "session-hdr",
+            plan_id: "plan:outputchanged001",
+            plan_attempt_key: "v3:outputchanged001",
+            selected_tracks: { audio, subtitle },
+          }),
+        });
+      }
+      if (url.endsWith("/playback/route-events")) return new Response(null, { status: 202 });
+      if (init?.method === "DELETE") return new Response(null, { status: 204 });
+      throw new Error(`Unexpected request: ${url}`);
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    const { result, unmount } = renderHook(
+      () => usePlaybackSession("request-1", [], [], 7, 0, false, "auto"),
+      { wrapper },
+    );
+    await waitFor(() => expect(result.current.sessionId).toBe("session-hdr"));
+    act(() => {
+      result.current.updatePlaybackState(300, true);
+      result.current.updatePlaybackState(321, false);
+    });
+
+    act(() => setHDR(false));
+
+    await waitFor(() => expect(result.current.plan?.plan_id).toBe("plan:outputchanged001"));
+    expect(startCount).toBe(1);
+    expect(replanBodies).toHaveLength(1);
+    expect(replanBodies[0]).toMatchObject({
+      operation: "failure_recovery",
+      position_seconds: 321,
+      failure: { classification: "output_route_changed" },
+      selected_tracks: { audio, subtitle },
+      client_capabilities: { hdr: false },
+    });
+    expect(result.current.sessionId).toBe("session-hdr");
+    expect(result.current.shouldAutoPlay).toBe(false);
+    unmount();
+  });
+
+  it("retires an active plan when the refreshed output has no playable route", async () => {
+    const setHDR = outputProbe(true);
+    const stoppedSessions: string[] = [];
+    const fetchMock = vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+      const url = String(input);
+      if (url.endsWith("/playback/start")) {
+        return jsonResponse({
+          protocol_version: 3,
+          server_features: ["playback_plan_v3"],
+          outcome: "playable",
+          session_id: "session-hdr",
+          playback_plan: fixturePlanV3({ session_id: "session-hdr" }),
+        });
+      }
+      if (url.endsWith("/playback/session-hdr/replan")) {
+        return jsonResponse({
+          protocol_version: 3,
+          server_features: ["playback_plan_v3"],
+          outcome: "terminal",
+          terminal: { reason: "hdr_transcode_unsupported", message: "HDR unsupported" },
         });
       }
       if (url.endsWith("/playback/route-events")) return new Response(null, { status: 202 });
@@ -452,15 +531,12 @@ describe("usePlaybackSession output capability changes", () => {
       { wrapper },
     );
     await waitFor(() => expect(result.current.sessionId).toBe("session-hdr"));
-    act(() => result.current.updatePlaybackPosition(321));
 
     act(() => setHDR(false));
 
-    await waitFor(() => expect(result.current.sessionId).toBe("session-sdr"));
-    expect(startBodies[1]).toMatchObject({
-      start_position: 321,
-      client_capabilities: { hdr: false },
-    });
+    await waitFor(() => expect(result.current.plan).toBeNull());
+    expect(result.current.sessionId).toBeNull();
+    expect(result.current.error).not.toBeNull();
     await waitFor(() => expect(stoppedSessions).toContain("/api/v1/playback/session-hdr"));
     unmount();
   });

--- a/web/src/player/hooks/usePlaybackSession.test.ts
+++ b/web/src/player/hooks/usePlaybackSession.test.ts
@@ -751,6 +751,126 @@ describe("usePlaybackSession output capability changes", () => {
     expect(stoppedSessions).toEqual([]);
     unmount();
   });
+
+  it("keeps the active plan when an output refresh request fails", async () => {
+    const setHDR = outputProbe(true);
+    const stoppedSessions: string[] = [];
+    const fetchMock = vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+      const url = String(input);
+      if (url.endsWith("/playback/start")) {
+        return jsonResponse({
+          protocol_version: 3,
+          server_features: ["playback_plan_v3"],
+          outcome: "playable",
+          session_id: "session-hdr",
+          playback_plan: fixturePlanV3({ session_id: "session-hdr" }),
+        });
+      }
+      if (url.endsWith("/playback/session-hdr/replan")) {
+        return jsonResponse({ error: "temporary failure" }, { status: 503 });
+      }
+      if (url.endsWith("/playback/route-events")) return new Response(null, { status: 202 });
+      if (init?.method === "DELETE") {
+        stoppedSessions.push(url);
+        return new Response(null, { status: 204 });
+      }
+      throw new Error(`Unexpected request: ${url}`);
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    const { result, unmount } = renderHook(
+      () => usePlaybackSession("request-1", [], [], 7, 0, false, "auto"),
+      { wrapper },
+    );
+    await waitFor(() => expect(result.current.sessionId).toBe("session-hdr"));
+    const activePlan = result.current.plan;
+
+    act(() => setHDR(false));
+
+    await waitFor(() => expect(result.current.replanning).toBe(false));
+    expect(result.current.plan).toBe(activePlan);
+    expect(result.current.sessionId).toBe("session-hdr");
+    expect(result.current.error).toBeNull();
+    expect(stoppedSessions).toEqual([]);
+    unmount();
+  });
+
+  it("queues the latest user intent behind an output refresh", async () => {
+    const setHDR = outputProbe(true);
+    let resolveOutputReplan: ((response: Response) => void) | undefined;
+    const outputReplanResponse = new Promise<Response>((resolve) => {
+      resolveOutputReplan = resolve;
+    });
+    const replanBodies: Array<{
+      operation: string;
+      quality_preference: string;
+      selected_tracks: { audio?: { index?: number } };
+    }> = [];
+    const fetchMock = vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+      const url = String(input);
+      if (url.endsWith("/playback/start")) {
+        return jsonResponse({
+          protocol_version: 3,
+          server_features: ["playback_plan_v3"],
+          outcome: "playable",
+          session_id: "session-hdr",
+          playback_plan: fixturePlanV3({ session_id: "session-hdr" }),
+        });
+      }
+      if (url.endsWith("/playback/session-hdr/replan")) {
+        replanBodies.push(JSON.parse(String(init?.body)) as (typeof replanBodies)[number]);
+        if (replanBodies.length === 1) return outputReplanResponse;
+        return jsonResponse({
+          protocol_version: 3,
+          server_features: ["playback_plan_v3"],
+          outcome: "playable",
+          session_id: "session-hdr",
+          playback_plan: fixturePlanV3({
+            session_id: "session-hdr",
+            plan_id: "plan:userintent00001",
+            plan_attempt_key: "v3:userintent00001",
+          }),
+        });
+      }
+      if (url.endsWith("/playback/route-events")) return new Response(null, { status: 202 });
+      if (init?.method === "DELETE") return new Response(null, { status: 204 });
+      throw new Error(`Unexpected request: ${url}`);
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    const { result, unmount } = renderHook(
+      () => usePlaybackSession("request-1", [], [], 7, 0, false, "auto"),
+      { wrapper },
+    );
+    await waitFor(() => expect(result.current.sessionId).toBe("session-hdr"));
+
+    act(() => setHDR(false));
+    await waitFor(() => expect(replanBodies).toHaveLength(1));
+    act(() => result.current.switchAudioTrack(2, 90));
+    act(() => result.current.changeQuality("1080p", 91));
+    expect(replanBodies).toHaveLength(1);
+
+    await act(async () => {
+      resolveOutputReplan?.(
+        jsonResponse({
+          protocol_version: 3,
+          server_features: ["playback_plan_v3"],
+          outcome: "playable",
+          session_id: "session-hdr",
+          playback_plan: fixturePlanV3({ session_id: "session-hdr" }),
+        }),
+      );
+      await outputReplanResponse;
+    });
+
+    await waitFor(() => expect(replanBodies).toHaveLength(2));
+    expect(replanBodies[1]).toMatchObject({
+      operation: "quality_change",
+      quality_preference: "1080p",
+    });
+    expect(result.current.qualityPreference).toBe("1080p");
+    unmount();
+  });
 });
 
 describe("usePlaybackSession version switches", () => {

--- a/web/src/player/hooks/usePlaybackSession.test.ts
+++ b/web/src/player/hooks/usePlaybackSession.test.ts
@@ -375,6 +375,7 @@ describe("usePlaybackSession output capability changes", () => {
   it("retries a terminal start when the window moves onto an HDR output", async () => {
     const setHDR = outputProbe(false);
     const startBodies: Array<{
+      start_position?: number;
       client_capabilities: { hdr_details?: { dolby_vision_profiles: number[] } };
     }> = [];
     const fetchMock = vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
@@ -414,6 +415,8 @@ describe("usePlaybackSession output capability changes", () => {
 
     await waitFor(() => expect(result.current.sessionId).toBe("session-hdr"));
     expect(startBodies).toHaveLength(2);
+    expect(startBodies[0]).not.toHaveProperty("start_position");
+    expect(startBodies[1]).not.toHaveProperty("start_position");
     expect(startBodies[0]?.client_capabilities.hdr_details?.dolby_vision_profiles).toEqual([]);
     expect(startBodies[1]?.client_capabilities.hdr_details?.dolby_vision_profiles).toEqual([8]);
     unmount();
@@ -493,6 +496,61 @@ describe("usePlaybackSession output capability changes", () => {
     unmount();
   });
 
+  it("seeds an early output replan from the server-resolved source position", async () => {
+    const setHDR = outputProbe(true);
+    const resumedPlan = fixturePlanV3({ session_id: "session-hdr" });
+    resumedPlan.timeline = {
+      ...resumedPlan.timeline,
+      source_start_seconds: 275,
+      player_start_seconds: 5,
+      timeline_offset_seconds: 270,
+    };
+    const replanBodies: Array<{ position_seconds: number }> = [];
+    const fetchMock = vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+      const url = String(input);
+      if (url.endsWith("/playback/start")) {
+        return jsonResponse({
+          protocol_version: 3,
+          server_features: ["playback_plan_v3"],
+          outcome: "playable",
+          session_id: "session-hdr",
+          playback_plan: resumedPlan,
+        });
+      }
+      if (url.endsWith("/playback/session-hdr/replan")) {
+        replanBodies.push(JSON.parse(String(init?.body)) as { position_seconds: number });
+        return jsonResponse({
+          protocol_version: 3,
+          server_features: ["playback_plan_v3"],
+          outcome: "playable",
+          session_id: "session-hdr",
+          playback_plan: fixturePlanV3({
+            session_id: "session-hdr",
+            plan_id: "plan:resumedoutput001",
+            plan_attempt_key: "v3:resumedoutput001",
+          }),
+        });
+      }
+      if (url.endsWith("/playback/route-events")) return new Response(null, { status: 202 });
+      if (init?.method === "DELETE") return new Response(null, { status: 204 });
+      throw new Error(`Unexpected request: ${url}`);
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    const { result, unmount } = renderHook(
+      () => usePlaybackSession("request-1", [], [], 7, 0, false, "auto"),
+      { wrapper },
+    );
+    await waitFor(() => expect(result.current.sessionId).toBe("session-hdr"));
+
+    act(() => result.current.updatePlaybackState(0, false));
+    act(() => setHDR(false));
+
+    await waitFor(() => expect(replanBodies).toHaveLength(1));
+    expect(replanBodies[0]?.position_seconds).toBe(275);
+    unmount();
+  });
+
   it("retires an active plan when the refreshed output has no playable route", async () => {
     const setHDR = outputProbe(true);
     const stoppedSessions: string[] = [];
@@ -545,7 +603,11 @@ describe("usePlaybackSession output capability changes", () => {
     const firstReplanResponse = new Promise<Response>((resolve) => {
       resolveFirstReplan = resolve;
     });
-    const replanBodies: Array<{ operation: string; client_capabilities: { hdr: boolean } }> = [];
+    const replanBodies: Array<{
+      operation: string;
+      position_seconds: number;
+      client_capabilities: { hdr: boolean };
+    }> = [];
     const fetchMock = vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
       const url = String(input);
       if (url.endsWith("/playback/start")) {
@@ -587,6 +649,7 @@ describe("usePlaybackSession output capability changes", () => {
     act(() => result.current.refreshSubtitles(120));
     await waitFor(() => expect(replanBodies).toHaveLength(1));
     act(() => setHDR(false));
+    act(() => result.current.reanchorSeek(555));
     expect(replanBodies).toHaveLength(1);
 
     await act(async () => {
@@ -609,8 +672,83 @@ describe("usePlaybackSession output capability changes", () => {
     await waitFor(() => expect(replanBodies).toHaveLength(2));
     expect(replanBodies[1]).toMatchObject({
       operation: "output_change",
+      position_seconds: 555,
       client_capabilities: { hdr: false },
     });
+    unmount();
+  });
+
+  it("runs the latest output refresh before retiring a terminal replan", async () => {
+    const setHDR = outputProbe(true);
+    let resolveFirstReplan: ((response: Response) => void) | undefined;
+    const firstReplanResponse = new Promise<Response>((resolve) => {
+      resolveFirstReplan = resolve;
+    });
+    const replanBodies: Array<{ client_capabilities: { hdr: boolean } }> = [];
+    const stoppedSessions: string[] = [];
+    const fetchMock = vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+      const url = String(input);
+      if (url.endsWith("/playback/start")) {
+        return jsonResponse({
+          protocol_version: 3,
+          server_features: ["playback_plan_v3"],
+          outcome: "playable",
+          session_id: "session-hdr",
+          playback_plan: fixturePlanV3({ session_id: "session-hdr" }),
+        });
+      }
+      if (url.endsWith("/playback/session-hdr/replan")) {
+        replanBodies.push(
+          JSON.parse(String(init?.body)) as { client_capabilities: { hdr: boolean } },
+        );
+        if (replanBodies.length === 1) return firstReplanResponse;
+        return jsonResponse({
+          protocol_version: 3,
+          server_features: ["playback_plan_v3"],
+          outcome: "playable",
+          session_id: "session-hdr",
+          playback_plan: fixturePlanV3({
+            session_id: "session-hdr",
+            plan_id: "plan:latestoutput0001",
+            plan_attempt_key: "v3:latestoutput0001",
+          }),
+        });
+      }
+      if (url.endsWith("/playback/route-events")) return new Response(null, { status: 202 });
+      if (init?.method === "DELETE") {
+        stoppedSessions.push(url);
+        return new Response(null, { status: 204 });
+      }
+      throw new Error(`Unexpected request: ${url}`);
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    const { result, unmount } = renderHook(
+      () => usePlaybackSession("request-1", [], [], 7, 0, false, "auto"),
+      { wrapper },
+    );
+    await waitFor(() => expect(result.current.sessionId).toBe("session-hdr"));
+
+    act(() => setHDR(false));
+    await waitFor(() => expect(replanBodies).toHaveLength(1));
+    act(() => setHDR(true));
+
+    await act(async () => {
+      resolveFirstReplan?.(
+        jsonResponse({
+          protocol_version: 3,
+          server_features: ["playback_plan_v3"],
+          outcome: "terminal",
+          terminal: { reason: "hdr_transcode_unsupported", message: "HDR unsupported" },
+        }),
+      );
+      await firstReplanResponse;
+    });
+
+    await waitFor(() => expect(result.current.plan?.plan_id).toBe("plan:latestoutput0001"));
+    expect(replanBodies).toHaveLength(2);
+    expect(replanBodies[1]).toMatchObject({ client_capabilities: { hdr: true } });
+    expect(stoppedSessions).toEqual([]);
     unmount();
   });
 });

--- a/web/src/player/hooks/usePlaybackSession.test.ts
+++ b/web/src/player/hooks/usePlaybackSession.test.ts
@@ -36,6 +36,7 @@ function jsonResponse(body: unknown, init: ResponseInit = {}) {
 }
 
 afterEach(() => {
+  vi.restoreAllMocks();
   vi.unstubAllGlobals();
 });
 
@@ -346,6 +347,121 @@ describe("usePlaybackSession quality changes", () => {
       .map(([, init]) => JSON.parse(String(init?.body)) as { quality_preference: string });
     expect(replanBodies.map((body) => body.quality_preference)).toEqual(["720p", "original"]);
 
+    unmount();
+  });
+});
+
+describe("usePlaybackSession output capability changes", () => {
+  function outputProbe(initialHDR: boolean) {
+    let hdr = initialHDR;
+    const listeners = new Set<() => void>();
+    const query = {
+      get matches() {
+        return hdr;
+      },
+      addEventListener: (_: string, listener: () => void) => listeners.add(listener),
+      removeEventListener: (_: string, listener: () => void) => listeners.delete(listener),
+    };
+    vi.stubGlobal("matchMedia", () => query);
+    vi.spyOn(HTMLMediaElement.prototype, "canPlayType").mockImplementation((mime) =>
+      mime === 'video/mp4; codecs="dvhe.08.06"' ? "probably" : "",
+    );
+    return (nextHDR: boolean) => {
+      hdr = nextHDR;
+      for (const listener of listeners) listener();
+    };
+  }
+
+  it("retries a terminal start when the window moves onto an HDR output", async () => {
+    const setHDR = outputProbe(false);
+    const startBodies: Array<{
+      client_capabilities: { hdr_details?: { dolby_vision_profiles: number[] } };
+    }> = [];
+    const fetchMock = vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+      const url = String(input);
+      if (url.endsWith("/playback/start")) {
+        const body = JSON.parse(String(init?.body)) as (typeof startBodies)[number];
+        startBodies.push(body);
+        if (startBodies.length === 1) {
+          return jsonResponse({
+            protocol_version: 3,
+            server_features: ["playback_plan_v3"],
+            outcome: "terminal",
+            terminal: { reason: "hdr_transcode_unsupported", message: "HDR unsupported" },
+          });
+        }
+        return jsonResponse({
+          protocol_version: 3,
+          server_features: ["playback_plan_v3"],
+          outcome: "playable",
+          session_id: "session-hdr",
+          playback_plan: fixturePlanV3({ session_id: "session-hdr" }),
+        });
+      }
+      if (url.endsWith("/playback/route-events")) return new Response(null, { status: 202 });
+      if (init?.method === "DELETE") return new Response(null, { status: 204 });
+      throw new Error(`Unexpected request: ${url}`);
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    const { result, unmount } = renderHook(
+      () => usePlaybackSession("request-1", [], [], 7, 0, false, "auto"),
+      { wrapper },
+    );
+    await waitFor(() => expect(result.current.error).not.toBeNull());
+
+    act(() => setHDR(true));
+
+    await waitFor(() => expect(result.current.sessionId).toBe("session-hdr"));
+    expect(startBodies).toHaveLength(2);
+    expect(startBodies[0]?.client_capabilities.hdr_details?.dolby_vision_profiles).toEqual([]);
+    expect(startBodies[1]?.client_capabilities.hdr_details?.dolby_vision_profiles).toEqual([8]);
+    unmount();
+  });
+
+  it("replaces an active HDR plan at the latest position after moving to SDR", async () => {
+    const setHDR = outputProbe(true);
+    const startBodies: Array<{ start_position?: number; client_capabilities: { hdr: boolean } }> =
+      [];
+    const stoppedSessions: string[] = [];
+    const fetchMock = vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+      const url = String(input);
+      if (url.endsWith("/playback/start")) {
+        const body = JSON.parse(String(init?.body)) as (typeof startBodies)[number];
+        startBodies.push(body);
+        const sessionId = startBodies.length === 1 ? "session-hdr" : "session-sdr";
+        return jsonResponse({
+          protocol_version: 3,
+          server_features: ["playback_plan_v3"],
+          outcome: "playable",
+          session_id: sessionId,
+          playback_plan: fixturePlanV3({ session_id: sessionId }),
+        });
+      }
+      if (url.endsWith("/playback/route-events")) return new Response(null, { status: 202 });
+      if (init?.method === "DELETE") {
+        stoppedSessions.push(url);
+        return new Response(null, { status: 204 });
+      }
+      throw new Error(`Unexpected request: ${url}`);
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    const { result, unmount } = renderHook(
+      () => usePlaybackSession("request-1", [], [], 7, 0, false, "auto"),
+      { wrapper },
+    );
+    await waitFor(() => expect(result.current.sessionId).toBe("session-hdr"));
+    act(() => result.current.updatePlaybackPosition(321));
+
+    act(() => setHDR(false));
+
+    await waitFor(() => expect(result.current.sessionId).toBe("session-sdr"));
+    expect(startBodies[1]).toMatchObject({
+      start_position: 321,
+      client_capabilities: { hdr: false },
+    });
+    await waitFor(() => expect(stoppedSessions).toContain("/api/v1/playback/session-hdr"));
     unmount();
   });
 });

--- a/web/src/player/hooks/usePlaybackSession.ts
+++ b/web/src/player/hooks/usePlaybackSession.ts
@@ -808,10 +808,6 @@ export function usePlaybackSession(
       });
 
       const loadSequence = loadSequenceRef.current;
-      const hasPendingReplan = () => {
-        const pending = pendingReplanRef.current;
-        return pending?.loadSequence === loadSequence;
-      };
       replanInFlightRef.current = true;
       setState((current) => ({
         ...current,
@@ -840,8 +836,25 @@ export function usePlaybackSession(
         }
 
         const adopted = adoptDecision(decision);
-        if (!adopted && retireSessionOnRefusal && !hasPendingReplan()) {
-          retireActiveSession(sessionId);
+        if (!adopted && retireSessionOnRefusal) {
+          const pending = pendingReplanRef.current;
+          const pendingCanValidateOutput =
+            pending?.loadSequence === loadSequence &&
+            pending.options.operation !== "seek_reanchor" &&
+            pending.options.operation !== "seek_failure_recovery";
+          if (pending && pendingCanValidateOutput) {
+            // The output refusal proves the predecessor route is incompatible.
+            // Let a queued planner-backed intent try the latest output evidence,
+            // but require it to retire the session too if it is refused. Frozen
+            // seek replans cannot validate new output evidence, so they must not
+            // postpone retirement.
+            pendingReplanRef.current = {
+              ...pending,
+              retireSessionOnRefusal: true,
+            };
+          } else {
+            retireActiveSession(sessionId);
+          }
         }
         return adopted;
       } catch (err) {

--- a/web/src/player/hooks/usePlaybackSession.ts
+++ b/web/src/player/hooks/usePlaybackSession.ts
@@ -14,6 +14,7 @@ import { reportRouteEventV3 } from "../route-events-v3";
 import { buildPlayerStreamUrl } from "../stream-url";
 import { randomUUID } from "@/lib/uuid";
 import {
+  FEATURE_OUTPUT_CHANGE_V3,
   MAX_ATTEMPT_COUNT_V3,
   MAX_ATTEMPTED_PLAN_KEYS_V3,
   QUALITY_ORIGINAL_V3,
@@ -283,6 +284,7 @@ export function usePlaybackSession(
   const sessionIdRef = useRef<string | null>(null);
   const planRef = useRef<PlanV3 | null>(null);
   const planRevisionRef = useRef(0);
+  const serverFeaturesRef = useRef<string[]>([]);
   const stateRef = useRef(state);
   const activeRequestKeyRef = useRef<string | null>(null);
   const activeCapabilityRequestKeyRef = useRef<string | null>(null);
@@ -312,6 +314,7 @@ export function usePlaybackSession(
     loadSequence: number;
     retireSessionOnRefusal: boolean;
     resolve: (adopted: boolean) => void;
+    planId: string;
   } | null>(null);
   const issueReplanRef = useRef<
     (options: ReplanOptions, retireSessionOnRefusal?: boolean) => Promise<boolean>
@@ -350,6 +353,7 @@ export function usePlaybackSession(
    */
   const adoptDecision = useCallback(
     (decision: DecisionResponseV3): boolean => {
+      serverFeaturesRef.current = decision.server_features;
       const plan = decision.playback_plan;
       if (!plan) {
         const failure = describeDecisionWithoutPlan(decision);
@@ -758,6 +762,7 @@ export function usePlaybackSession(
               loadSequence: loadSequenceRef.current,
               retireSessionOnRefusal,
               resolve,
+              planId: plan.plan_id,
             };
           });
         }
@@ -860,12 +865,21 @@ export function usePlaybackSession(
         const pendingReplan = pendingReplanRef.current;
         pendingReplanRef.current = null;
         if (pendingReplan?.loadSequence === loadSequenceRef.current) {
-          // A capability change can queue behind a replan created by an older
-          // render. Dispatch through the latest callback so its request carries
-          // the current output evidence rather than the closed-over snapshot.
-          void issueReplanRef
-            .current(pendingReplan.options, pendingReplan.retireSessionOnRefusal)
-            .then(pendingReplan.resolve);
+          const recoveryAppliesToCurrentPlan =
+            pendingReplan.options.operation !== "failure_recovery" &&
+            pendingReplan.options.operation !== "seek_failure_recovery"
+              ? true
+              : pendingReplan.planId === planRef.current?.plan_id;
+          if (recoveryAppliesToCurrentPlan) {
+            // A capability change can queue behind a replan created by an older
+            // render. Dispatch through the latest callback so its request carries
+            // the current output evidence rather than the closed-over snapshot.
+            void issueReplanRef
+              .current(pendingReplan.options, pendingReplan.retireSessionOnRefusal)
+              .then(pendingReplan.resolve);
+          } else {
+            pendingReplan.resolve(false);
+          }
         } else {
           pendingReplan?.resolve(false);
         }
@@ -904,6 +918,10 @@ export function usePlaybackSession(
         replacementErrorMessage: "Failed to refresh playback output",
         initialErrorMessage: "Failed to refresh playback output",
       });
+      return;
+    }
+
+    if (!serverFeaturesRef.current.includes(FEATURE_OUTPUT_CHANGE_V3)) {
       return;
     }
 

--- a/web/src/player/hooks/usePlaybackSession.ts
+++ b/web/src/player/hooks/usePlaybackSession.ts
@@ -287,6 +287,12 @@ export function usePlaybackSession(
   const activeRequestKeyRef = useRef<string | null>(null);
   const activeCapabilityRequestKeyRef = useRef<string | null>(null);
   const playbackPositionRef = useRef(initialPosition);
+  const startIntentRef = useRef({
+    position: initialPosition,
+    forceStartPosition: forceInitialPosition,
+  });
+  const hasAdoptedPlanRef = useRef(false);
+  const awaitingInitialPlayerPositionRef = useRef(false);
   const playbackPlayingRef = useRef(true);
   const playbackStartedRef = useRef(false);
   const switchingRef = useRef(false);
@@ -368,6 +374,17 @@ export function usePlaybackSession(
       planRef.current = plan;
       sessionIdRef.current = sessionId ?? null;
       planRevisionRef.current += 1;
+      hasAdoptedPlanRef.current = true;
+      if (
+        Number.isFinite(plan.timeline.source_start_seconds) &&
+        plan.timeline.source_start_seconds >= 0
+      ) {
+        // Replan positions use the source timeline. Seed it immediately so an
+        // output refresh before the first timeupdate preserves server-resolved
+        // resume state instead of falling back to the caller's default zero.
+        playbackPositionRef.current = plan.timeline.source_start_seconds;
+        awaitingInitialPlayerPositionRef.current = plan.timeline.source_start_seconds > 0;
+      }
 
       setState(
         planToSessionState(
@@ -625,6 +642,12 @@ export function usePlaybackSession(
     activeCapabilityRequestKeyRef.current = capabilityRequestKey;
     qualityRef.current = qualityPreference?.trim() || "auto";
     playbackPositionRef.current = initialPosition;
+    startIntentRef.current = {
+      position: initialPosition,
+      forceStartPosition: forceInitialPosition,
+    };
+    hasAdoptedPlanRef.current = false;
+    awaitingInitialPlayerPositionRef.current = false;
     playbackPlayingRef.current = true;
     playbackStartedRef.current = false;
 
@@ -698,6 +721,23 @@ export function usePlaybackSession(
           queuedOperation === "failure_recovery" || queuedOperation === "seek_failure_recovery";
         const hasQueuedOutputChange = queuedOperation === "output_change";
         if (
+          options.operation === "seek_reanchor" &&
+          hasQueuedOutputChange &&
+          pendingReplanRef.current
+        ) {
+          // The output refresh will open a fresh route at its position anyway;
+          // fold a later seek into that queued intent rather than silently
+          // dropping the viewer's newest target.
+          pendingReplanRef.current = {
+            ...pendingReplanRef.current,
+            options: {
+              ...pendingReplanRef.current.options,
+              positionSeconds: options.positionSeconds,
+            },
+          };
+          return false;
+        }
+        if (
           isPendingFailureRecovery ||
           (isPendingOutputChange && !hasQueuedFailureRecovery) ||
           (options.operation === "seek_reanchor" &&
@@ -752,6 +792,12 @@ export function usePlaybackSession(
       });
 
       const loadSequence = loadSequenceRef.current;
+      const hasPendingOutputRefresh = () => {
+        const pending = pendingReplanRef.current;
+        return (
+          pending?.loadSequence === loadSequence && pending.options.operation === "output_change"
+        );
+      };
       replanInFlightRef.current = true;
       setState((current) => ({
         ...current,
@@ -780,7 +826,9 @@ export function usePlaybackSession(
         }
 
         const adopted = adoptDecision(decision);
-        if (!adopted && retireSessionOnRefusal) retireActiveSession(sessionId);
+        if (!adopted && retireSessionOnRefusal && !hasPendingOutputRefresh()) {
+          retireActiveSession(sessionId);
+        }
         return adopted;
       } catch (err) {
         if (loadSequence !== loadSequenceRef.current) return false;
@@ -791,7 +839,7 @@ export function usePlaybackSession(
           errorTitle: nextError.title,
           error: nextError.message,
         }));
-        if (retireSessionOnRefusal) retireActiveSession(sessionId);
+        if (retireSessionOnRefusal && !hasPendingOutputRefresh()) retireActiveSession(sessionId);
         return false;
       } finally {
         replanInFlightRef.current = false;
@@ -830,10 +878,12 @@ export function usePlaybackSession(
     const plan = planRef.current;
     const sessionId = sessionIdRef.current;
     if (!plan || !sessionId) {
+      const startIntent = startIntentRef.current;
+      const resumeFromAdoptedPlan = hasAdoptedPlanRef.current;
       void loadSession({
         preferredFileId: fileId,
-        position: playbackPositionRef.current,
-        forceStartPosition: true,
+        position: resumeFromAdoptedPlan ? playbackPositionRef.current : startIntent.position,
+        forceStartPosition: resumeFromAdoptedPlan ? true : startIntent.forceStartPosition,
         allowPreserveExistingSessionOnError: false,
         replacementErrorMessage: "Failed to refresh playback output",
         initialErrorMessage: "Failed to refresh playback output",
@@ -913,6 +963,8 @@ export function usePlaybackSession(
 
   const reanchorSeek = useCallback(
     (positionSeconds: number) => {
+      playbackPositionRef.current = positionSeconds;
+      awaitingInitialPlayerPositionRef.current = false;
       reportEvent("seek_reanchor_requested");
       void replan({ operation: "seek_reanchor", positionSeconds });
     },
@@ -960,7 +1012,15 @@ export function usePlaybackSession(
 
   const updatePlaybackState = useCallback((positionSeconds: number, playing: boolean) => {
     if (Number.isFinite(positionSeconds) && positionSeconds >= 0) {
-      playbackPositionRef.current = positionSeconds;
+      const isUninitializedPlayerZero =
+        awaitingInitialPlayerPositionRef.current &&
+        !playing &&
+        positionSeconds === 0 &&
+        playbackPositionRef.current > 0;
+      if (!isUninitializedPlayerZero) {
+        playbackPositionRef.current = positionSeconds;
+        awaitingInitialPlayerPositionRef.current = false;
+      }
     }
     if (playing) {
       playbackStartedRef.current = true;

--- a/web/src/player/hooks/usePlaybackSession.ts
+++ b/web/src/player/hooks/usePlaybackSession.ts
@@ -311,6 +311,7 @@ export function usePlaybackSession(
     options: ReplanOptions;
     loadSequence: number;
     retireSessionOnRefusal: boolean;
+    resolve: (adopted: boolean) => void;
   } | null>(null);
   const issueReplanRef = useRef<
     (options: ReplanOptions, retireSessionOnRefusal?: boolean) => Promise<boolean>
@@ -737,18 +738,28 @@ export function usePlaybackSession(
           };
           return false;
         }
-        if (
+        const isPendingUserIntent =
+          options.operation === "track_change" || options.operation === "quality_change";
+        const hasQueuedUserIntent =
+          queuedOperation === "track_change" || queuedOperation === "quality_change";
+        const shouldQueue =
           isPendingFailureRecovery ||
-          (isPendingOutputChange && !hasQueuedFailureRecovery) ||
+          (isPendingUserIntent && !hasQueuedFailureRecovery) ||
+          (isPendingOutputChange && !hasQueuedFailureRecovery && !hasQueuedUserIntent) ||
           (options.operation === "seek_reanchor" &&
             !hasQueuedFailureRecovery &&
-            !hasQueuedOutputChange)
-        ) {
-          pendingReplanRef.current = {
-            options,
-            loadSequence: loadSequenceRef.current,
-            retireSessionOnRefusal,
-          };
+            !hasQueuedOutputChange &&
+            !hasQueuedUserIntent);
+        if (shouldQueue) {
+          pendingReplanRef.current?.resolve(false);
+          return new Promise<boolean>((resolve) => {
+            pendingReplanRef.current = {
+              options,
+              loadSequence: loadSequenceRef.current,
+              retireSessionOnRefusal,
+              resolve,
+            };
+          });
         }
         return false;
       }
@@ -792,11 +803,9 @@ export function usePlaybackSession(
       });
 
       const loadSequence = loadSequenceRef.current;
-      const hasPendingOutputRefresh = () => {
+      const hasPendingReplan = () => {
         const pending = pendingReplanRef.current;
-        return (
-          pending?.loadSequence === loadSequence && pending.options.operation === "output_change"
-        );
+        return pending?.loadSequence === loadSequence;
       };
       replanInFlightRef.current = true;
       setState((current) => ({
@@ -826,12 +835,16 @@ export function usePlaybackSession(
         }
 
         const adopted = adoptDecision(decision);
-        if (!adopted && retireSessionOnRefusal && !hasPendingOutputRefresh()) {
+        if (!adopted && retireSessionOnRefusal && !hasPendingReplan()) {
           retireActiveSession(sessionId);
         }
         return adopted;
       } catch (err) {
         if (loadSequence !== loadSequenceRef.current) return false;
+        if (retireSessionOnRefusal) {
+          console.error("Failed to refresh playback output", err);
+          return false;
+        }
         const nextError = describePlaybackSessionError(err, "Failed to update playback");
         setState((current) => ({
           ...current,
@@ -839,7 +852,6 @@ export function usePlaybackSession(
           errorTitle: nextError.title,
           error: nextError.message,
         }));
-        if (retireSessionOnRefusal && !hasPendingOutputRefresh()) retireActiveSession(sessionId);
         return false;
       } finally {
         replanInFlightRef.current = false;
@@ -851,7 +863,11 @@ export function usePlaybackSession(
           // A capability change can queue behind a replan created by an older
           // render. Dispatch through the latest callback so its request carries
           // the current output evidence rather than the closed-over snapshot.
-          void issueReplanRef.current(pendingReplan.options, pendingReplan.retireSessionOnRefusal);
+          void issueReplanRef
+            .current(pendingReplan.options, pendingReplan.retireSessionOnRefusal)
+            .then(pendingReplan.resolve);
+        } else {
+          pendingReplan?.resolve(false);
         }
       }
     },

--- a/web/src/player/hooks/usePlaybackSession.ts
+++ b/web/src/player/hooks/usePlaybackSession.ts
@@ -91,6 +91,8 @@ export interface UsePlaybackSessionResult extends PlaybackSessionState {
   refreshSubtitles: (currentPosition: number) => void;
   /** Folds a realtime-delivered inventory entry in without a server round trip. */
   applySubtitleTrack: (track: SubtitleInventoryItemV3) => void;
+  /** Keeps the resume anchor current for output-capability restarts. */
+  updatePlaybackPosition: (positionSeconds: number) => void;
   /** Reports a playback route event as a diagnostic. Never affects playback. */
   reportEvent: (
     event: RouteEventNameV3,
@@ -250,6 +252,10 @@ export function usePlaybackSession(
   const probe = useCodecDetection();
   const clientCapabilities = useMemo(() => buildClientCapabilitiesV3(probe), [probe]);
   const clientPlaybackContext = useMemo(() => buildClientPlaybackContextV3(probe), [probe]);
+  const capabilityRequestKey = useMemo(
+    () => JSON.stringify([clientCapabilities, clientPlaybackContext]),
+    [clientCapabilities, clientPlaybackContext],
+  );
 
   const [state, setState] = useState<PlaybackSessionState>({
     plan: null,
@@ -275,6 +281,8 @@ export function usePlaybackSession(
   const planRevisionRef = useRef(0);
   const stateRef = useRef(state);
   const activeRequestKeyRef = useRef<string | null>(null);
+  const activeCapabilityRequestKeyRef = useRef<string | null>(null);
+  const playbackPositionRef = useRef(initialPosition);
   const switchingRef = useRef(false);
   const loadSequenceRef = useRef(0);
 
@@ -568,21 +576,35 @@ export function usePlaybackSession(
   );
 
   useEffect(() => {
-    if (activeRequestKeyRef.current === requestKey) {
+    const requestChanged = activeRequestKeyRef.current !== requestKey;
+    const capabilitiesChanged = activeCapabilityRequestKeyRef.current !== capabilityRequestKey;
+    if (!requestChanged && !capabilitiesChanged) {
       return;
     }
     activeRequestKeyRef.current = requestKey;
-    qualityRef.current = qualityPreference?.trim() || "auto";
+    activeCapabilityRequestKeyRef.current = capabilityRequestKey;
+    if (requestChanged) {
+      qualityRef.current = qualityPreference?.trim() || "auto";
+      playbackPositionRef.current = initialPosition;
+    }
 
     void loadSession({
-      preferredFileId: fileId,
-      position: initialPosition,
-      forceStartPosition: forceInitialPosition,
+      preferredFileId: requestChanged ? fileId : (stateRef.current.mediaFileId ?? fileId),
+      position: requestChanged ? initialPosition : playbackPositionRef.current,
+      forceStartPosition: requestChanged ? forceInitialPosition : true,
       allowPreserveExistingSessionOnError: false,
       replacementErrorMessage: "Failed to replace playback request",
       initialErrorMessage: "Failed to start playback",
     });
-  }, [fileId, forceInitialPosition, initialPosition, loadSession, qualityPreference, requestKey]);
+  }, [
+    capabilityRequestKey,
+    fileId,
+    forceInitialPosition,
+    initialPosition,
+    loadSession,
+    qualityPreference,
+    requestKey,
+  ]);
 
   // Clean up session on unmount.
   useEffect(() => {
@@ -841,6 +863,12 @@ export function usePlaybackSession(
     [config],
   );
 
+  const updatePlaybackPosition = useCallback((positionSeconds: number) => {
+    if (Number.isFinite(positionSeconds) && positionSeconds >= 0) {
+      playbackPositionRef.current = positionSeconds;
+    }
+  }, []);
+
   const switchVersion = useCallback(
     (newFileId: number, currentPosition: number) => {
       if (switchingRef.current) return;
@@ -878,6 +906,7 @@ export function usePlaybackSession(
     reanchorSeek,
     refreshSubtitles,
     applySubtitleTrack,
+    updatePlaybackPosition,
     reportEvent,
   };
 }

--- a/web/src/player/hooks/usePlaybackSession.ts
+++ b/web/src/player/hooks/usePlaybackSession.ts
@@ -306,6 +306,9 @@ export function usePlaybackSession(
     loadSequence: number;
     retireSessionOnRefusal: boolean;
   } | null>(null);
+  const issueReplanRef = useRef<
+    (options: ReplanOptions, retireSessionOnRefusal?: boolean) => Promise<boolean>
+  >(async () => false);
   const qualityRef = useRef(qualityPreference?.trim() || "auto");
 
   useEffect(() => {
@@ -689,12 +692,17 @@ export function usePlaybackSession(
       if (replanInFlightRef.current) {
         const isPendingFailureRecovery =
           options.operation === "failure_recovery" || options.operation === "seek_failure_recovery";
+        const isPendingOutputChange = options.operation === "output_change";
         const queuedOperation = pendingReplanRef.current?.options.operation;
         const hasQueuedFailureRecovery =
           queuedOperation === "failure_recovery" || queuedOperation === "seek_failure_recovery";
+        const hasQueuedOutputChange = queuedOperation === "output_change";
         if (
           isPendingFailureRecovery ||
-          (options.operation === "seek_reanchor" && !hasQueuedFailureRecovery)
+          (isPendingOutputChange && !hasQueuedFailureRecovery) ||
+          (options.operation === "seek_reanchor" &&
+            !hasQueuedFailureRecovery &&
+            !hasQueuedOutputChange)
         ) {
           pendingReplanRef.current = {
             options,
@@ -717,8 +725,8 @@ export function usePlaybackSession(
         return false;
       }
 
-      // On a track or quality change nothing failed, so the previous route
-      // stays eligible: the loop guard and the recovery counter reset. Only a
+      // On an intent change nothing failed, so the previous route stays
+      // eligible: the loop guard and the recovery counter reset. Only a
       // recovery accumulates them.
       const attemptedPlanKeys = isFailureRecovery
         ? [...attemptedPlanKeysRef.current, plan.plan_attempt_key].slice(
@@ -792,7 +800,10 @@ export function usePlaybackSession(
         const pendingReplan = pendingReplanRef.current;
         pendingReplanRef.current = null;
         if (pendingReplan?.loadSequence === loadSequenceRef.current) {
-          void issueReplan(pendingReplan.options, pendingReplan.retireSessionOnRefusal);
+          // A capability change can queue behind a replan created by an older
+          // render. Dispatch through the latest callback so its request carries
+          // the current output evidence rather than the closed-over snapshot.
+          void issueReplanRef.current(pendingReplan.options, pendingReplan.retireSessionOnRefusal);
         }
       }
     },
@@ -805,6 +816,7 @@ export function usePlaybackSession(
       retireActiveSession,
     ],
   );
+  issueReplanRef.current = replan;
 
   useEffect(() => {
     if (
@@ -831,9 +843,8 @@ export function usePlaybackSession(
 
     void replan(
       {
-        operation: "failure_recovery",
+        operation: "output_change",
         positionSeconds: playbackPositionRef.current,
-        failure: { classification: "output_route_changed" },
       },
       true,
     );

--- a/web/src/player/hooks/usePlaybackSession.ts
+++ b/web/src/player/hooks/usePlaybackSession.ts
@@ -57,6 +57,7 @@ interface PlaybackSessionState {
   durationSeconds: number | null;
   subtitleUrls: PlayerSubtitleInfo[];
   qualityPreference: string;
+  shouldAutoPlay: boolean;
   loading: boolean;
   replacing: boolean;
   replanning: boolean;
@@ -91,8 +92,8 @@ export interface UsePlaybackSessionResult extends PlaybackSessionState {
   refreshSubtitles: (currentPosition: number) => void;
   /** Folds a realtime-delivered inventory entry in without a server round trip. */
   applySubtitleTrack: (track: SubtitleInventoryItemV3) => void;
-  /** Keeps the resume anchor current for output-capability restarts. */
-  updatePlaybackPosition: (positionSeconds: number) => void;
+  /** Keeps transport state current for output-capability replans. */
+  updatePlaybackState: (positionSeconds: number, playing: boolean) => void;
   /** Reports a playback route event as a diagnostic. Never affects playback. */
   reportEvent: (
     event: RouteEventNameV3,
@@ -161,6 +162,7 @@ function planToSessionState(
   playbackAttemptId: string,
   planRevision: number,
   qualityPreference: string,
+  shouldAutoPlay: boolean,
   config: PlayerConfig,
 ): PlaybackSessionState {
   return {
@@ -179,6 +181,7 @@ function planToSessionState(
       config,
     ),
     qualityPreference,
+    shouldAutoPlay,
     loading: false,
     replacing: false,
     replanning: false,
@@ -269,6 +272,7 @@ export function usePlaybackSession(
     durationSeconds: null,
     subtitleUrls: [],
     qualityPreference: qualityPreference?.trim() || "auto",
+    shouldAutoPlay: true,
     loading: true,
     replacing: false,
     replanning: false,
@@ -283,6 +287,8 @@ export function usePlaybackSession(
   const activeRequestKeyRef = useRef<string | null>(null);
   const activeCapabilityRequestKeyRef = useRef<string | null>(null);
   const playbackPositionRef = useRef(initialPosition);
+  const playbackPlayingRef = useRef(true);
+  const playbackStartedRef = useRef(false);
   const switchingRef = useRef(false);
   const loadSequenceRef = useRef(0);
 
@@ -298,6 +304,7 @@ export function usePlaybackSession(
   const pendingReplanRef = useRef<{
     options: ReplanOptions;
     loadSequence: number;
+    retireSessionOnRefusal: boolean;
   } | null>(null);
   const qualityRef = useRef(qualityPreference?.trim() || "auto");
 
@@ -366,6 +373,7 @@ export function usePlaybackSession(
           playbackAttemptIdRef.current ?? "",
           planRevisionRef.current,
           qualityRef.current,
+          playbackPlayingRef.current,
           config,
         ),
       );
@@ -412,6 +420,37 @@ export function usePlaybackSession(
       });
     },
     [config],
+  );
+
+  const retireActiveSession = useCallback(
+    (expectedSessionId: string) => {
+      if (sessionIdRef.current !== expectedSessionId) return;
+      loadSequenceRef.current += 1;
+      void stopSession(expectedSessionId).catch(() => {
+        // Best effort — stale session will time out server-side.
+      });
+      planRef.current = null;
+      sessionIdRef.current = null;
+      planAttemptIdRef.current = randomUUID();
+      setState((current) => {
+        if (current.sessionId !== expectedSessionId) return current;
+        return {
+          ...current,
+          plan: null,
+          streamUrl: null,
+          sessionId: null,
+          mediaFileId: null,
+          initialPosition: 0,
+          audioTrackIndex: 0,
+          durationSeconds: null,
+          subtitleUrls: [],
+          loading: false,
+          replacing: false,
+          replanning: false,
+        };
+      });
+    },
+    [stopSession],
   );
 
   /**
@@ -576,22 +615,20 @@ export function usePlaybackSession(
   );
 
   useEffect(() => {
-    const requestChanged = activeRequestKeyRef.current !== requestKey;
-    const capabilitiesChanged = activeCapabilityRequestKeyRef.current !== capabilityRequestKey;
-    if (!requestChanged && !capabilitiesChanged) {
+    if (activeRequestKeyRef.current === requestKey) {
       return;
     }
     activeRequestKeyRef.current = requestKey;
     activeCapabilityRequestKeyRef.current = capabilityRequestKey;
-    if (requestChanged) {
-      qualityRef.current = qualityPreference?.trim() || "auto";
-      playbackPositionRef.current = initialPosition;
-    }
+    qualityRef.current = qualityPreference?.trim() || "auto";
+    playbackPositionRef.current = initialPosition;
+    playbackPlayingRef.current = true;
+    playbackStartedRef.current = false;
 
     void loadSession({
-      preferredFileId: requestChanged ? fileId : (stateRef.current.mediaFileId ?? fileId),
-      position: requestChanged ? initialPosition : playbackPositionRef.current,
-      forceStartPosition: requestChanged ? forceInitialPosition : true,
+      preferredFileId: fileId,
+      position: initialPosition,
+      forceStartPosition: forceInitialPosition,
       allowPreserveExistingSessionOnError: false,
       replacementErrorMessage: "Failed to replace playback request",
       initialErrorMessage: "Failed to start playback",
@@ -641,7 +678,10 @@ export function usePlaybackSession(
    * means the client never asks for one.
    */
   const replan = useCallback(
-    async function issueReplan(options: ReplanOptions): Promise<boolean> {
+    async function issueReplan(
+      options: ReplanOptions,
+      retireSessionOnRefusal = false,
+    ): Promise<boolean> {
       const plan = planRef.current;
       const sessionId = sessionIdRef.current;
       const playbackAttemptId = playbackAttemptIdRef.current;
@@ -659,6 +699,7 @@ export function usePlaybackSession(
           pendingReplanRef.current = {
             options,
             loadSequence: loadSequenceRef.current,
+            retireSessionOnRefusal,
           };
         }
         return false;
@@ -730,7 +771,9 @@ export function usePlaybackSession(
           attemptCountRef.current = 1;
         }
 
-        return adoptDecision(decision);
+        const adopted = adoptDecision(decision);
+        if (!adopted && retireSessionOnRefusal) retireActiveSession(sessionId);
+        return adopted;
       } catch (err) {
         if (loadSequence !== loadSequenceRef.current) return false;
         const nextError = describePlaybackSessionError(err, "Failed to update playback");
@@ -740,6 +783,7 @@ export function usePlaybackSession(
           errorTitle: nextError.title,
           error: nextError.message,
         }));
+        if (retireSessionOnRefusal) retireActiveSession(sessionId);
         return false;
       } finally {
         replanInFlightRef.current = false;
@@ -748,12 +792,52 @@ export function usePlaybackSession(
         const pendingReplan = pendingReplanRef.current;
         pendingReplanRef.current = null;
         if (pendingReplan?.loadSequence === loadSequenceRef.current) {
-          void issueReplan(pendingReplan.options);
+          void issueReplan(pendingReplan.options, pendingReplan.retireSessionOnRefusal);
         }
       }
     },
-    [adoptDecision, clientCapabilities, clientPlaybackContext, config, maxBitrateKbps],
+    [
+      adoptDecision,
+      clientCapabilities,
+      clientPlaybackContext,
+      config,
+      maxBitrateKbps,
+      retireActiveSession,
+    ],
   );
+
+  useEffect(() => {
+    if (
+      activeRequestKeyRef.current !== requestKey ||
+      activeCapabilityRequestKeyRef.current === capabilityRequestKey
+    ) {
+      return;
+    }
+    activeCapabilityRequestKeyRef.current = capabilityRequestKey;
+
+    const plan = planRef.current;
+    const sessionId = sessionIdRef.current;
+    if (!plan || !sessionId) {
+      void loadSession({
+        preferredFileId: fileId,
+        position: playbackPositionRef.current,
+        forceStartPosition: true,
+        allowPreserveExistingSessionOnError: false,
+        replacementErrorMessage: "Failed to refresh playback output",
+        initialErrorMessage: "Failed to refresh playback output",
+      });
+      return;
+    }
+
+    void replan(
+      {
+        operation: "failure_recovery",
+        positionSeconds: playbackPositionRef.current,
+        failure: { classification: "output_route_changed" },
+      },
+      true,
+    );
+  }, [capabilityRequestKey, fileId, loadSession, replan, requestKey, retireActiveSession]);
 
   const switchAudioTrack = useCallback(
     (index: number, currentPosition: number) => {
@@ -863,9 +947,15 @@ export function usePlaybackSession(
     [config],
   );
 
-  const updatePlaybackPosition = useCallback((positionSeconds: number) => {
+  const updatePlaybackState = useCallback((positionSeconds: number, playing: boolean) => {
     if (Number.isFinite(positionSeconds) && positionSeconds >= 0) {
       playbackPositionRef.current = positionSeconds;
+    }
+    if (playing) {
+      playbackStartedRef.current = true;
+      playbackPlayingRef.current = true;
+    } else if (playbackStartedRef.current) {
+      playbackPlayingRef.current = false;
     }
   }, []);
 
@@ -906,7 +996,7 @@ export function usePlaybackSession(
     reanchorSeek,
     refreshSubtitles,
     applySubtitleTrack,
-    updatePlaybackPosition,
+    updatePlaybackState,
     reportEvent,
   };
 }

--- a/web/src/player/protocol-v3.ts
+++ b/web/src/player/protocol-v3.ts
@@ -67,13 +67,14 @@ export function deliveryClassV3(delivery: DeliveryV3): DeliveryClassV3 {
  */
 export type CapabilityEvidenceV3 = "exact" | "platform_attested" | "declared";
 
-/** Which of the five replan intents a replan request expresses. */
+/** Which replan intent a replan request expresses. */
 export type ReplanOperationV3 =
   | "failure_recovery"
   | "seek_reanchor"
   | "seek_failure_recovery"
   | "track_change"
-  | "quality_change";
+  | "quality_change"
+  | "output_change";
 
 /** Transport protocol of a plan's stream URL. */
 export type StreamProtocolV3 = "http_progressive" | "hls";

--- a/web/src/player/protocol-v3.ts
+++ b/web/src/player/protocol-v3.ts
@@ -123,6 +123,9 @@ export const FEATURE_PLAYBACK_PLAN_V3 = "playback_plan_v3";
 /** Server-minted attempt keys and intent replans from the neutral v3 contract. */
 export const FEATURE_NEUTRAL_PLAYBACK_V3_CONTRACT = "neutral_playback_v3_contract_v1";
 
+/** Server accepts output-capability refreshes without treating the route as failed. */
+export const FEATURE_OUTPUT_CHANGE_V3 = "output_change_v1";
+
 /** The `original` rung label, which always preserves the source. */
 export const QUALITY_ORIGINAL_V3 = "original";
 

--- a/web/src/player/protocol-v3.ts
+++ b/web/src/player/protocol-v3.ts
@@ -139,6 +139,10 @@ export interface HDRCapabilitiesV3 {
   hdr10: boolean;
   hdr10_plus: boolean;
   hlg: boolean;
+  hdr10_max_width?: number;
+  hdr10_max_height?: number;
+  hdr10_max_frame_rate?: number;
+  hdr10_max_bitrate_kbps?: number;
   dolby_vision_profiles: number[];
   dolby_vision_profile_levels?: Array<{
     profile: number;

--- a/web/src/player/protocol-v3.ts
+++ b/web/src/player/protocol-v3.ts
@@ -139,6 +139,10 @@ export interface HDRCapabilitiesV3 {
   hdr10_plus: boolean;
   hlg: boolean;
   dolby_vision_profiles: number[];
+  dolby_vision_profile_levels?: Array<{
+    profile: number;
+    max_level: number;
+  }>;
 }
 
 export interface AudioPassthroughEntryV3 {
@@ -388,6 +392,7 @@ export interface SourceDescriptorV3 {
   dynamic_range?: string;
   hdr10_plus: boolean;
   dolby_vision_profile?: number;
+  dolby_vision_level?: number;
   dv_bl_compat_id?: number;
   dv_enhancement_layer: EnhancementLayerV3;
   audio_codec?: string;

--- a/web/src/player/protocol-v3.ts
+++ b/web/src/player/protocol-v3.ts
@@ -142,6 +142,7 @@ export interface HDRCapabilitiesV3 {
   dolby_vision_profile_levels?: Array<{
     profile: number;
     max_level: number;
+    bl_compatibility_ids?: number[];
   }>;
 }
 


### PR DESCRIPTION
## Problem

The web capability probe only sent the legacy `hdr` boolean. Playback V3 validates HDR and Dolby Vision against structured `hdr_details`, so Safari could decode the issue's Dolby Vision Profile 8.1 source but the server rejected it as requiring video adaptation. With 4K transcoding disabled, that surfaced as the misleading terminal reason `no_alternate_version`.

Fixes #609.

## Approach

- Probe progressive HDR10 with an exact 2160p HEVC Main10 / Rec. 2020 / PQ / static-HDR Media Capabilities configuration.
- Probe the exact progressive-remux Dolby Vision sample entries (`dvhe.05.06` and `dvhe.08.06`) through `HTMLMediaElement.canPlayType`.
- Advertise Dolby Vision only when the active output also reports high dynamic range.
- Send structured HDR capabilities at the device, active-output, and per-delivery scopes required by playback V3.
- Restrict media-element Dolby Vision and inferred HEVC evidence to progressive delivery; original and HLS keep only independently probed claims.
- Persist FFprobe's exact Dolby Vision level and enforce a per-profile maximum level, with bounded source-property fallback for existing rows.
- Retry terminal decisions and replan active sessions when output capabilities change, preserving the current file, position, quality, selected tracks, and paused state.
- Let automatic-quality requests try a compatible alternate version before returning the HDR terminal.
- Prefer `hdr_transcode_unsupported` over the 4K policy terminal when an HDR-incompatible client truly requires video encoding.
- Cover both capability propagation and the planner precedence with regression tests.

The probe deliberately does not use MediaSource support: this route plays the server's progressive MP4 remux directly through a media element.

## Runtime evidence

Validated against the shared development deployment with a real single-version 2160p HEVC Main10 Dolby Vision Profile 8 / BL compatibility ID 1 source:

- Before: the current web payload returned `adaptation_unavailable / no_alternate_version`.
- After structured Profile 8 attestation: the same file returned `playable / server_remux_progressive / container_normalization`.
- In the browser, the deployed UI sent `dolby_vision_profiles: [8]` plus max Level 6, kept HDR10/HLG false, and cleared the DV claim from HLS. The real source returned `201 playable / server_remux_progressive` and reached `HTMLMediaElement.readyState = 4` with no media error. On exact PR head `b0249e377630f60e4ccb8c6880053cabb3943a16`, a fresh request with HEVC and Profile 8.1 advertised only for progressive delivery again returned `playable / server_remux_progressive` with native Dolby Vision preserved. A live `output_change` replan with the same capabilities kept the same progressive route and plan-attempt key. A second live Profile 7 source that initially selected its 1080p SDR alternate stayed on requested file `236941` once this exact HDR10 evidence was present, using `server_remux_progressive` with `server_dv7_to_hdr10`.
- Negative control without structured HDR details now returned `hdr_transcode_unsupported`.
- The temporary playback sessions were closed after verification.

## Validation

- `go test ./internal/playback ./internal/scanner ./internal/catalogseed`
- `go test ./internal/api/handlers`
- `pnpm --dir web exec vitest run src/player/client-context-v3.test.ts src/player/hooks/useCodecDetection.test.ts` — 18 tests passed
- `pnpm --dir web exec vitest run src/player/hooks/usePlaybackSession.test.ts src/player/hooks/useCodecDetection.test.ts src/player/client-context-v3.test.ts src/player/components/WatchPage.test.ts src/player/components/VideoPlayer.test.tsx` — 63 tests passed
- `PATH="$DEV_CACHE_ROOT/bin:$PATH" golangci-lint run --new-from-merge-base="origin/main" ./...` — 0 issues
- `pnpm --dir web run lint` — 0 errors (151 inherited warnings)
- `pnpm --dir web run format:check`
- `pnpm --dir web run build`
- `make verify-local-paths`

Full local gates also exposed existing baseline failures outside this change:

- `make lint`: 300 inherited full-tree findings; the CI-equivalent changed-lines lint above is clean.
- `make test`: two unchanged macOS-only Jellycompat process-lock tests fail because the current process identity token is empty. The focused playback and API handler suites pass; CI runs the Go suite on Linux.

## Risk

The capability claim is conservative: exact Dolby Vision profiles are only published when both the media element and active HDR output attest support, are bounded to the probed level and Profile 8.1 base-layer shape, and are scoped away from original/HLS delivery. Browsers that do not recognize the sample entry continue to omit Dolby Vision and follow the existing adaptation path.

### AI Disclosure
- Tool(s): OpenAI Codex
- Model(s): gpt-5.6-sol
- Involvement: Fully AI-generated implementation, tests, runtime reproduction, browser verification, and PR text under maintainer direction.
- Adversarial review: Performed before and after submission. Fourteen material findings were addressed: generic HDR no longer implies HDR10/HLG, progressive evidence is excluded from original/HLS, Dolby Vision levels are preserved and enforced end-to-end, the HEVC base claim is limited to its proven delivery, Profile 8 support is constrained to the probed 8.1 base-layer shape, output capability changes invalidate stale decisions without losing tracks or pause state, paused HLS no longer triggers a false startup timeout, and progressive HDR10 is claimed only after an exact Media Capabilities probe, and HDR terminals retain alternate-version fallback. All threads were answered and resolved after focused tests and changed-lines lint.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Improved HDR and Dolby Vision capability detection across web playback environments.
  - Added Dolby Vision profile, level, and compatibility details to playback decisions.
  - Added output-change replanning, playback-state tracking, and configurable autoplay behavior.
  - Preserved Dolby Vision metadata from media scanning through playback planning.

- **Bug Fixes**
  - Improved fallback handling for incompatible HDR and restricted 4K sources.
  - Applied Dolby Vision profile, level, pixel-rate, width, and bitrate limits.
  - Prevented unnecessary Dolby Vision detection during SDR playback.

- **Tests**
  - Added regression coverage for HDR, Dolby Vision, fallback playback, autoplay, and session replanning.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->


