### PR TITLE
fix(playback): claim Safari DV/HDR10 decode evidence and preserve dvvC in remuxes

### DIFF
--- a/docs/architecture/playback-protocol-v3.md
+++ b/docs/architecture/playback-protocol-v3.md
@@ -382,13 +382,19 @@ Refusing to play those outright would be worse than an assumption the client is
 told about.
 
 The web client does not promote the generic high-dynamic-range media query to a
-format claim by itself. It combines that active-output signal with Media
-Capabilities support for Silo's progressive 2160p HEVC Main10, Rec. 2020, PQ,
-SMPTE ST 2086 shape before advertising HDR10. Dolby Vision likewise requires a
-definitive media-element answer for the exact `dvhe.05.06` or `dvhe.08.06`
-sample entry. Both claims are scoped to `progressive`: they are cleared from
-`original_http` and `hls` because those delivery paths were not tested by the
-same probe. An HDR10 claim can carry `hdr10_max_width`, `hdr10_max_height`,
+format claim, and it does not gate format claims on it either. Decoder capability
+and active-output HDR are separate facts — browsers tone-map HDR content onto SDR
+outputs, and Safari 26 reports `dynamic-range: standard` even on an XDR display —
+so the media query survives only as the best-effort `hdr` output boolean. Format
+claims come from exact shape probes: Media Capabilities support for Silo's
+progressive 2160p HEVC Main10, Rec. 2020, PQ, SMPTE ST 2086 shape (probed under
+both the `hvc1` and `hev1` sample entries) before advertising HDR10, and a
+definitive media-element answer for the `dvh1.05.06`/`dvhe.05.06` or
+`dvh1.08.06`/`dvhe.08.06` sample entry before advertising Dolby Vision — Safari
+answers only for `hvc1`/`dvh1`, other browsers only for `hev1`/`dvhe`, so either
+definitive answer earns the claim. Both claims are scoped to `progressive`: they
+are cleared from `original_http` and `hls` because those delivery paths were not
+tested by the same probe. An HDR10 claim can carry `hdr10_max_width`, `hdr10_max_height`,
 `hdr10_max_frame_rate`, and `hdr10_max_bitrate_kbps`; these ceilings keep a
 successful format probe from admitting an untested stream class.
 

--- a/docs/architecture/playback-protocol-v3.md
+++ b/docs/architecture/playback-protocol-v3.md
@@ -386,13 +386,14 @@ format claim, and it does not gate format claims on it either. Decoder capabilit
 and active-output HDR are separate facts — browsers tone-map HDR content onto SDR
 outputs, and Safari 26 reports `dynamic-range: standard` even on an XDR display —
 so the media query survives only as the best-effort `hdr` output boolean. Format
-claims come from exact shape probes: Media Capabilities support for Silo's
-progressive 2160p HEVC Main10, Rec. 2020, PQ, SMPTE ST 2086 shape (probed under
-both the `hvc1` and `hev1` sample entries) before advertising HDR10, and a
-definitive media-element answer for the `dvh1.05.06`/`dvhe.05.06` or
-`dvh1.08.06`/`dvhe.08.06` sample entry before advertising Dolby Vision — Safari
-answers only for `hvc1`/`dvh1`, other browsers only for `hev1`/`dvhe`, so either
-definitive answer earns the claim. Both claims are scoped to `progressive`: they
+claims come from exact shape probes matched to the bytes the remux delivers:
+HDR10 requires Media Capabilities support for Silo's progressive 2160p HEVC
+Main10, Rec. 2020, PQ, SMPTE ST 2086 shape, probed under both the `hvc1` and
+`hev1` sample entries because either proves the same decode and the strip remux
+labels its output `hvc1`. Dolby Vision requires a definitive media-element
+answer for exactly `dvh1.05.06` or `dvh1.08.06`, because the preserve remux
+tags its output `dvh1`; a `dvhe`-only answer is evidence for a file Silo never
+sends and earns no claim. Both claims are scoped to `progressive`: they
 are cleared from `original_http` and `hls` because those delivery paths were not
 tested by the same probe. An HDR10 claim can carry `hdr10_max_width`, `hdr10_max_height`,
 `hdr10_max_frame_rate`, and `hdr10_max_bitrate_kbps`; these ceilings keep a

--- a/docs/architecture/playback-protocol-v3.md
+++ b/docs/architecture/playback-protocol-v3.md
@@ -619,7 +619,10 @@ help. Delivered inside a `201` (start) or `200` (replan), never a 4xx.
 `source_metadata_incomplete`, `source_unavailable`,
 `audio_conversion_unsupported`, `video_conversion_unsupported`,
 `dv_conversion_unsupported`, `transcoding_disabled`,
-`subtitle_conversion_unsupported`.
+`subtitle_conversion_unsupported`. When a video adaptation is forced solely by a
+subtitle burn-in requirement and cannot execute, the terminal is
+`subtitle_conversion_unsupported` naming the subtitle rather than the underlying
+HDR, 4K, or transcode-policy reason — deselecting the subtitle restores playback.
 
 *Subtitle policy:* `subtitle_burn_in_source_unsupported`,
 `subtitle_codec_unsupported`, `subtitle_track_invalid`,

--- a/docs/architecture/playback-protocol-v3.md
+++ b/docs/architecture/playback-protocol-v3.md
@@ -388,12 +388,13 @@ outputs, and Safari 26 reports `dynamic-range: standard` even on an XDR display 
 so the media query survives only as the best-effort `hdr` output boolean. Format
 claims come from exact shape probes matched to the bytes the remux delivers:
 HDR10 requires Media Capabilities support for Silo's progressive 2160p HEVC
-Main10, Rec. 2020, PQ, SMPTE ST 2086 shape, probed under both the `hvc1` and
-`hev1` sample entries because either proves the same decode and the strip remux
-labels its output `hvc1`. Dolby Vision requires a definitive media-element
-answer for exactly `dvh1.05.06` or `dvh1.08.06`, because the preserve remux
-tags its output `dvh1`; a `dvhe`-only answer is evidence for a file Silo never
-sends and earns no claim. Both claims are scoped to `progressive`: they
+Main10, Rec. 2020, PQ, SMPTE ST 2086 shape, probed under exactly the `hvc1`
+sample entry because the explicit v3 HDR10 strip remux labels its output `hvc1`
+(legacy and automatic strip paths retain FFmpeg's default `hev1`). Dolby Vision
+requires a definitive media-element answer for exactly `dvh1.05.06` or
+`dvh1.08.06`, because the preserve remux tags its output `dvh1`. An answer only
+for the other spelling (`hev1`/`dvhe`) is evidence for a file Silo never sends
+and earns no claim. Both claims are scoped to `progressive`: they
 are cleared from `original_http` and `hls` because those delivery paths were not
 tested by the same probe. An HDR10 claim can carry `hdr10_max_width`, `hdr10_max_height`,
 `hdr10_max_frame_rate`, and `hdr10_max_bitrate_kbps`; these ceilings keep a

--- a/internal/playback/plan_v3.go
+++ b/internal/playback/plan_v3.go
@@ -281,7 +281,12 @@ func PlanPlaybackV3(input PlannerInputV3) PlannerResultV3 {
 			// resulting terminal.
 			reasonOverride = EvidenceInsufficientForDirectV3
 		}
-		return planVideoTranscodeV3(input, base, source, quality, hlsSubtitle, reasonOverride)
+		// True when the burn requirement is the sole disjunct that fired: every
+		// other route condition still permits a source-preserving delivery.
+		subtitleForcedAdaptation := !quality.RequiresTranscode && videoOK &&
+			(rangeOK || dvStripEligible || clientDV81Eligible || clientHDR10Eligible) &&
+			subtitle.RequiresBurn && !remuxSubtitleOK && !hlsRemuxSubtitleOK
+		return planVideoTranscodeV3(input, base, source, quality, hlsSubtitle, reasonOverride, subtitleForcedAdaptation)
 	}
 
 	// Profile 7 is normalized on the client against the original range-capable
@@ -472,7 +477,7 @@ func PlanPlaybackV3(input PlannerInputV3) PlannerResultV3 {
 		}
 	}
 	if deliveryAvailableV3(input.Request, DeliveryClassHLSV3) {
-		return planVideoTranscodeV3(input, base, source, quality, hlsSubtitle, "copy_routes_exhausted")
+		return planVideoTranscodeV3(input, base, source, quality, hlsSubtitle, "copy_routes_exhausted", false)
 	}
 
 	return terminalPlannerResultV3("adaptation_unavailable", "No validated playback route is available for this source and output route.", false)
@@ -685,7 +690,13 @@ func applyAudioOnlyAACConversionV3(plan *PlanV3, targetChannels, targetBitrateKb
 
 // planVideoTranscodeV3 always executes on the HLS delivery, so the caller must
 // pass the subtitle policy resolved against DeliveryClassHLSV3.
-func planVideoTranscodeV3(input PlannerInputV3, base PlanV3, source SourceDescriptorV3, quality QualityResultV3, subtitle SubtitlePolicyResultV3, reasonOverride string) PlannerResultV3 {
+//
+// subtitleForcedAdaptation marks the case where only the subtitle burn
+// requirement forced this adaptation. Deselecting the subtitle then restores
+// playback, so a refusal must name the subtitle: an HDR or version reason
+// sends the user chasing a problem that is not blocking them. Retryable
+// infrastructure failures and the client-route terminal keep their own reasons.
+func planVideoTranscodeV3(input PlannerInputV3, base PlanV3, source SourceDescriptorV3, quality QualityResultV3, subtitle SubtitlePolicyResultV3, reasonOverride string, subtitleForcedAdaptation bool) PlannerResultV3 {
 	if !deliveryAvailableV3(input.Request, DeliveryClassHLSV3) {
 		return terminalPlannerResultV3("client_hls_unsupported", "The client cannot execute the required HLS adaptation route.", false)
 	}
@@ -693,16 +704,21 @@ func planVideoTranscodeV3(input PlannerInputV3, base PlanV3, source SourceDescri
 		return PlannerResultV3{Terminal: subtitle.Terminal, SubtitleTrackIndex: -1, SubtitleTransportTrackIndex: -1}
 	}
 	if !input.Settings.TranscodeEnabled {
-		reason := "transcoding_disabled"
 		if subtitle.RequiresBurn {
-			reason = "subtitle_conversion_unsupported"
+			return terminalPlannerResultV3("subtitle_conversion_unsupported", "The selected subtitle must be burned into the video, but transcoding is unavailable.", false)
 		}
-		return terminalPlannerResultV3(reason, "The source requires video adaptation, but transcoding is unavailable.", false)
+		return terminalPlannerResultV3("transcoding_disabled", "The source requires video adaptation, but transcoding is unavailable.", false)
 	}
 	if hdrTranscodeUnavailableV3(source) {
+		if subtitleForcedAdaptation {
+			return terminalPlannerResultV3("subtitle_conversion_unsupported", "The selected subtitle must be burned into the video, but this HDR source cannot be re-encoded.", false)
+		}
 		return terminalPlannerResultV3("hdr_transcode_unsupported", "This HDR source requires video encoding, but no validated HDR-preserving or tone-map recipe is installed.", false)
 	}
 	if is4KSourceV3(input.EffectiveFile, source) && !input.Settings.Allow4KTranscode {
+		if subtitleForcedAdaptation {
+			return terminalPlannerResultV3("subtitle_conversion_unsupported", "The selected subtitle must be burned into the video, but 4K transcoding is disabled.", false)
+		}
 		return terminalPlannerResultV3("no_alternate_version", TerminalMessage4KTranscodeDisabledV3, false)
 	}
 	if !input.hlsRegistry().Available(TransformationVideoToH264V3) || !input.hlsRegistry().Available(TransformationAudioToAACV3) {

--- a/internal/playback/plan_v3.go
+++ b/internal/playback/plan_v3.go
@@ -704,7 +704,7 @@ func planVideoTranscodeV3(input PlannerInputV3, base PlanV3, source SourceDescri
 		return PlannerResultV3{Terminal: subtitle.Terminal, SubtitleTrackIndex: -1, SubtitleTransportTrackIndex: -1}
 	}
 	if !input.Settings.TranscodeEnabled {
-		if subtitle.RequiresBurn {
+		if subtitleForcedAdaptation {
 			return terminalPlannerResultV3("subtitle_conversion_unsupported", "The selected subtitle must be burned into the video, but transcoding is unavailable.", false)
 		}
 		return terminalPlannerResultV3("transcoding_disabled", "The source requires video adaptation, but transcoding is unavailable.", false)

--- a/internal/playback/protocol_v3_test.go
+++ b/internal/playback/protocol_v3_test.go
@@ -973,6 +973,75 @@ func TestPlanPlaybackV3FallsBackFromProgressiveToHLSWithoutRepeatingKey(t *testi
 	}
 }
 
+// pgsBurnRequestV3 selects the single embedded PGS track on a client that
+// cannot render bitmap subtitles anywhere, so every route but a burn-in
+// transcode is closed by the subtitle alone.
+func pgsBurnRequestV3(file *models.MediaFile) StartRequestV3 {
+	file.SubtitleTracks = []models.SubtitleTrack{{Index: 0, Codec: "hdmv_pgs_subtitle"}}
+	req := validStartRequestV3()
+	req.Capabilities.VideoDecode = []VideoDecodeCapabilityV3{{Codec: "hevc", Profiles: []string{"main 10"}, Levels: []int{153}, BitDepths: []int{10}, MaxWidth: 3840, MaxHeight: 2160, MaxFrameRate: 60, MaxBitrateKbps: 80_000, Hardware: true}}
+	req.Capabilities.HDRDetails = &HDRCapabilitiesV3{HDR10: true}
+	req.ClientPlaybackContext.Output.HDRDetails = &HDRCapabilitiesV3{HDR10: true}
+	selected := 0
+	req.SubtitleTrackIndex = &selected
+	req.SubtitleTrackID = TrackIDV3(file.ID, "subtitle", selected)
+	return req
+}
+
+// A user who just picked a bitmap subtitle can undo that choice; an HDR or 4K
+// reason points them at a problem that is not blocking them.
+func TestPlanPlaybackV3NamesTheSubtitleWhenItAloneForcedTheTranscode(t *testing.T) {
+	file := detailedFixtureFileV3()
+	req := pgsBurnRequestV3(file)
+
+	result := PlanPlaybackV3(PlannerInputV3{
+		Request: req, RequestedFile: file, EffectiveFile: file, AudioTrackIndex: 0,
+		Settings: PlannerSettingsV3{TranscodeEnabled: true, Allow4KTranscode: true},
+	})
+	if result.Terminal == nil || result.Terminal.Reason != "subtitle_conversion_unsupported" {
+		t.Fatalf("result = %s", ExplainPlannerResultV3(result))
+	}
+	if !strings.Contains(strings.ToLower(result.Terminal.Message), "subtitle") {
+		t.Errorf("terminal message = %q, want the subtitle named", result.Terminal.Message)
+	}
+}
+
+// The subtitle only owns the terminal when it is the sole blocker: a client
+// that cannot take the source range at all still gets the range cause.
+func TestPlanPlaybackV3KeepsTheHDRTerminalWhenTheRangeIsAlsoUnsupported(t *testing.T) {
+	file := detailedFixtureFileV3()
+	req := pgsBurnRequestV3(file)
+	req.Capabilities.HDRDetails = nil
+	req.ClientPlaybackContext.Output.HDRDetails = nil
+
+	result := PlanPlaybackV3(PlannerInputV3{
+		Request: req, RequestedFile: file, EffectiveFile: file, AudioTrackIndex: 0,
+		Settings: PlannerSettingsV3{TranscodeEnabled: true, Allow4KTranscode: true},
+	})
+	if result.Terminal == nil || result.Terminal.Reason != "hdr_transcode_unsupported" {
+		t.Fatalf("result = %s", ExplainPlannerResultV3(result))
+	}
+}
+
+func TestPlanPlaybackV3NamesTheSubtitleOverThe4KPolicy(t *testing.T) {
+	file := detailedFixtureFileV3()
+	file.VideoTracks[0].VideoRange = "SDR"
+	file.VideoTracks[0].VideoRangeType = "SDR"
+	file.VideoTracks[0].ColorTransfer = "bt709"
+	req := pgsBurnRequestV3(file)
+
+	result := PlanPlaybackV3(PlannerInputV3{
+		Request: req, RequestedFile: file, EffectiveFile: file, AudioTrackIndex: 0,
+		Settings: PlannerSettingsV3{TranscodeEnabled: true, Allow4KTranscode: false},
+	})
+	if result.Terminal == nil || result.Terminal.Reason != "subtitle_conversion_unsupported" {
+		t.Fatalf("result = %s", ExplainPlannerResultV3(result))
+	}
+	if !strings.Contains(strings.ToLower(result.Terminal.Message), "subtitle") {
+		t.Errorf("terminal message = %q, want the subtitle named", result.Terminal.Message)
+	}
+}
+
 func TestPlanPlaybackV3NeverClaimsUnimplementedHDRTranscode(t *testing.T) {
 	file := detailedFixtureFileV3()
 	req := validStartRequestV3()

--- a/internal/playback/protocol_v3_test.go
+++ b/internal/playback/protocol_v3_test.go
@@ -1023,6 +1023,26 @@ func TestPlanPlaybackV3KeepsTheHDRTerminalWhenTheRangeIsAlsoUnsupported(t *testi
 	}
 }
 
+// With transcoding disabled, the subtitle policy itself terminals a bitmap
+// selection (burn-in is never offered), so the reason names the subtitle
+// before the planner ever weighs range or quality causes. The selection is
+// genuinely undeliverable, so that attribution is accurate for every cause mix.
+func TestPlanPlaybackV3DisabledTranscodeStillNamesAnUndeliverableSubtitle(t *testing.T) {
+	file := detailedFixtureFileV3()
+	req := pgsBurnRequestV3(file)
+	req.Capabilities.HDRDetails = nil
+	req.ClientPlaybackContext.Output.HDRDetails = nil
+
+	result := PlanPlaybackV3(PlannerInputV3{
+		Request: req, RequestedFile: file, AudioTrackIndex: 0,
+		EffectiveFile: file,
+		Settings:      PlannerSettingsV3{TranscodeEnabled: false, Allow4KTranscode: true},
+	})
+	if result.Terminal == nil || result.Terminal.Reason != "subtitle_conversion_unsupported" {
+		t.Fatalf("result = %s", ExplainPlannerResultV3(result))
+	}
+}
+
 func TestPlanPlaybackV3NamesTheSubtitleOverThe4KPolicy(t *testing.T) {
 	file := detailedFixtureFileV3()
 	file.VideoTracks[0].VideoRange = "SDR"

--- a/internal/playback/remux.go
+++ b/internal/playback/remux.go
@@ -177,11 +177,15 @@ func buildRemuxArgsWithAudioV3(filePath, outputFormat string, seekSeconds float6
 	} else if (dvProfile == 5 || dvProfile == 8) && tagDVSampleEntry {
 		// FFmpeg carries the DOVI configuration record into MP4 but otherwise
 		// labels copied HEVC as hev1. Media3 keys decoder selection from the
-		// sample entry, so retain an explicit Dolby Vision tag as well.
-		// dvhe keeps FFmpeg's dvvC box; forcing dvh1 makes FFmpeg 7.1 omit it.
-		// Only the explicit v3 preserve recipe opts in: legacy web/jellycompat
-		// consumers keep the pre-v3 hev1 labeling their demuxers accept.
-		args = append(args, "-tag:v", "dvhe")
+		// sample entry, and Safari's media element only answers "probably" for
+		// dvh1 — the sample entry Apple's HLS authoring spec calls for — so tag
+		// dvh1. FFmpeg refuses to write the dvvC configuration record box under
+		// either tag without -strict unofficial; dvh1 plus -strict unofficial is
+		// verified (7.1.4) to retain the full record. Media3 accepts both sample
+		// entries, so Android preserve consumers are unaffected. Only the
+		// explicit v3 preserve recipe opts in: legacy web/jellycompat consumers
+		// keep the pre-v3 hev1 labeling their demuxers accept.
+		args = append(args, "-tag:v", "dvh1", "-strict", "unofficial")
 	}
 
 	if transcodeAudio {

--- a/internal/playback/remux.go
+++ b/internal/playback/remux.go
@@ -118,11 +118,11 @@ const (
 // the RPUs would dangle — stripping yields a clean HDR10 base layer (the
 // Apple-parity fallback for devices without a P7 decoder). Profile 8 RPUs
 // stay: the base layer is self-contained and DV clients can render it.
-func buildRemuxArgs(filePath, outputFormat string, seekSeconds float64, transcodeAudio bool, audioTrackIndex int, dvProfile int, tagDVSampleEntry, audioOnly bool) []string {
-	return buildRemuxArgsWithAudioV3(filePath, outputFormat, seekSeconds, transcodeAudio, audioTrackIndex, dvProfile, tagDVSampleEntry, audioOnly, 0, 0)
+func buildRemuxArgs(filePath, outputFormat string, seekSeconds float64, transcodeAudio bool, audioTrackIndex int, dvProfile int, tagSampleEntry, audioOnly bool) []string {
+	return buildRemuxArgsWithAudioV3(filePath, outputFormat, seekSeconds, transcodeAudio, audioTrackIndex, dvProfile, tagSampleEntry, audioOnly, 0, 0)
 }
 
-func buildRemuxArgsWithAudioV3(filePath, outputFormat string, seekSeconds float64, transcodeAudio bool, audioTrackIndex int, dvProfile int, tagDVSampleEntry, audioOnly bool, targetAudioChannels, targetAudioBitrateKbps int) []string {
+func buildRemuxArgsWithAudioV3(filePath, outputFormat string, seekSeconds float64, transcodeAudio bool, audioTrackIndex int, dvProfile int, tagSampleEntry, audioOnly bool, targetAudioChannels, targetAudioBitrateKbps int) []string {
 	args := []string{
 		"-nostdin",
 		"-hide_banner",
@@ -174,7 +174,16 @@ func buildRemuxArgsWithAudioV3(filePath, outputFormat string, seekSeconds float6
 
 	if dvProfile == 7 {
 		args = append(args, "-bsf:v", "dovi_rpu=strip=1")
-	} else if (dvProfile == 5 || dvProfile == 8) && tagDVSampleEntry {
+		if tagSampleEntry {
+			// The explicit v3 strip recipe promised the client plain HDR10.
+			// Safari's media element only answers "probably" for hvc1 — the
+			// sample entry Apple's HLS authoring spec requires — so relabel
+			// FFmpeg's default hev1 to match the evidence the web probe
+			// collects. Stripped output carries no DOVI record, so no -strict
+			// relaxation is needed. Legacy/auto strips keep hev1.
+			args = append(args, "-tag:v", "hvc1")
+		}
+	} else if (dvProfile == 5 || dvProfile == 8) && tagSampleEntry {
 		// FFmpeg carries the DOVI configuration record into MP4 but otherwise
 		// labels copied HEVC as hev1. Media3 keys decoder selection from the
 		// sample entry, and Safari's media element only answers "probably" for
@@ -243,7 +252,7 @@ func startRemuxWithOptions(ctx context.Context, filePath, outputFormat string, s
 
 	bin := ResolveFFmpegPath(ffmpegPath)
 	effectiveProfile := dvProfile
-	tagDVSampleEntry := false
+	tagSampleEntry := false
 	switch mode {
 	case "", RemuxDVLegacyAutoV3:
 		effectiveProfile = remuxDVProfile(dvProfile, supportsDoviRPUFilter(bin) &&
@@ -270,7 +279,11 @@ func startRemuxWithOptions(ctx context.Context, filePath, outputFormat string, s
 		}
 		// buildRemuxArgs uses profile 7 as the explicit strip sentinel; the
 		// filter is equally required for a compatible profile 8 base layer.
+		// The explicit recipe also labels the output hvc1: the web HDR10
+		// probe collects evidence for that sample entry, and the plan must
+		// deliver the shape it validated. Legacy/auto strips keep hev1.
 		effectiveProfile = 7
+		tagSampleEntry = true
 	case RemuxDVPreserveV3:
 		if dvProfile == 7 {
 			// The remux maps only the base-layer stream, so dual-layer P7
@@ -279,7 +292,7 @@ func startRemuxWithOptions(ctx context.Context, filePath, outputFormat string, s
 			cancel()
 			return nil, fmt.Errorf("Dolby Vision profile 7 cannot be preserved in a progressive remux")
 		}
-		tagDVSampleEntry = true
+		tagSampleEntry = true
 	case RemuxDVRejectP7V3:
 		if dvProfile == 7 {
 			cancel()
@@ -289,7 +302,7 @@ func startRemuxWithOptions(ctx context.Context, filePath, outputFormat string, s
 		cancel()
 		return nil, fmt.Errorf("unknown remux Dolby Vision mode %q", mode)
 	}
-	args := buildRemuxArgsWithAudioV3(filePath, outputFormat, seekSeconds, transcodeAudio, audioTrackIndex, effectiveProfile, tagDVSampleEntry, audioOnly, targetAudioChannels, targetAudioBitrateKbps)
+	args := buildRemuxArgsWithAudioV3(filePath, outputFormat, seekSeconds, transcodeAudio, audioTrackIndex, effectiveProfile, tagSampleEntry, audioOnly, targetAudioChannels, targetAudioBitrateKbps)
 	cmd := exec.CommandContext(ctx, bin, args...)
 
 	stdout, err := cmd.StdoutPipe()

--- a/internal/playback/remux_dv_test.go
+++ b/internal/playback/remux_dv_test.go
@@ -85,22 +85,38 @@ func TestBuildRemuxArgsKeepsRPUForProfile8AndPlainFiles(t *testing.T) {
 // Media3 keys decoder selection from it, but legacy web/jellycompat consumers
 // rely on the pre-v3 hev1 labeling their demuxers accept.
 func TestBuildRemuxArgsTagsPreservedDolbyVisionOnlyWhenRequested(t *testing.T) {
-	args := buildRemuxArgs("/x.mkv", "mp4", 0, false, -1, 8, true, false)
-	if !argsContainPair(args, "-tag:v", "dvh1") {
-		t.Fatalf("preserved Dolby Vision must retain a DV sample entry, args=%v", strings.Join(args, " "))
+	for _, profile := range []int{5, 8} {
+		args := buildRemuxArgs("/x.mkv", "mp4", 0, false, -1, profile, true, false)
+		if !argsContainPair(args, "-tag:v", "dvh1") {
+			t.Fatalf("preserved profile %d must retain a DV sample entry, args=%v", profile, strings.Join(args, " "))
+		}
+		// Without -strict unofficial FFmpeg drops the dvvC configuration record
+		// and the output is an untagged HEVC stream no DV decoder will select.
+		if !argsContainPair(args, "-strict", "unofficial") {
+			t.Fatalf("preserved profile %d must allow the dvvC box, args=%v", profile, strings.Join(args, " "))
+		}
+		legacy := buildRemuxArgs("/x.mkv", "mp4", 0, false, -1, profile, false, false)
+		if argsContainPair(legacy, "-tag:v", "dvh1") || argsContainPair(legacy, "-strict", "unofficial") {
+			t.Fatalf("legacy profile %d remux must keep hev1 labeling, args=%v", profile, strings.Join(legacy, " "))
+		}
 	}
-	// Without -strict unofficial FFmpeg drops the dvvC configuration record and
-	// the output is an untagged HEVC stream no DV decoder will select.
-	if !argsContainPair(args, "-strict", "unofficial") {
-		t.Fatalf("preserved Dolby Vision must allow the dvvC box, args=%v", strings.Join(args, " "))
+}
+
+// The explicit v3 strip recipe labels its HDR10 output hvc1 — the sample entry
+// the web probe collected evidence for — while the legacy/auto strip keeps
+// ffmpeg's default hev1 for pre-v3 consumers. Neither carries a DOVI record,
+// so neither needs the -strict relaxation.
+func TestBuildRemuxArgsTagsStrippedHDR10OnlyWhenRequested(t *testing.T) {
+	tagged := buildRemuxArgs("/x.mkv", "mp4", 0, false, -1, 7, true, false)
+	if !argsContainPair(tagged, "-bsf:v", "dovi_rpu=strip=1") || !argsContainPair(tagged, "-tag:v", "hvc1") {
+		t.Fatalf("explicit strip must emit an hvc1-labeled HDR10 stream, args=%v", strings.Join(tagged, " "))
 	}
-	legacy := buildRemuxArgs("/x.mkv", "mp4", 0, false, -1, 8, false, false)
-	if argsContainPair(legacy, "-tag:v", "dvh1") || argsContainPair(legacy, "-strict", "unofficial") {
-		t.Fatalf("legacy remux consumers must keep hev1 labeling, args=%v", strings.Join(legacy, " "))
+	if argsContainPair(tagged, "-tag:v", "dvh1") || argsContainPair(tagged, "-strict", "unofficial") {
+		t.Fatalf("stripped output must not carry DV signaling, args=%v", strings.Join(tagged, " "))
 	}
-	stripped := buildRemuxArgs("/x.mkv", "mp4", 0, false, -1, 7, false, false)
-	if argsContainPair(stripped, "-tag:v", "dvh1") || argsContainPair(stripped, "-strict", "unofficial") {
-		t.Fatalf("HDR10 fallback must not retain a DV sample entry, args=%v", strings.Join(stripped, " "))
+	legacy := buildRemuxArgs("/x.mkv", "mp4", 0, false, -1, 7, false, false)
+	if argsContainPair(legacy, "-tag:v", "hvc1") || argsContainPair(legacy, "-tag:v", "dvh1") {
+		t.Fatalf("legacy strip consumers must keep hev1 labeling, args=%v", strings.Join(legacy, " "))
 	}
 }
 
@@ -149,6 +165,72 @@ func writeProbeAwareFFmpeg(t *testing.T) (bin, argLog string) {
 		t.Fatalf("write fake ffmpeg: %v", err)
 	}
 	return bin, argLog
+}
+
+// writeRecordingFFmpeg stands in for an ffmpeg whose dovi_rpu probe succeeds,
+// recording the arguments of every non-probe invocation so tests can assert
+// what the remux mode actually mapped onto the command line.
+func writeRecordingFFmpeg(t *testing.T) (bin, argLog string) {
+	t.Helper()
+	dir := t.TempDir()
+	bin = filepath.Join(dir, "ffmpeg")
+	argLog = filepath.Join(dir, "args")
+	script := "#!/bin/sh\n" +
+		"case \"$*\" in\n" +
+		"  *-bsfs*) echo dovi_rpu; exit 0;;\n" +
+		"  *'-f null'*) exit 0;;\n" +
+		"esac\n" +
+		"echo \"$*\" >> " + argLog + "\n" +
+		"exit 0\n"
+	if err := os.WriteFile(bin, []byte(script), 0o755); err != nil {
+		t.Fatalf("write fake ffmpeg: %v", err)
+	}
+	return bin, argLog
+}
+
+func recordedRemuxArgs(t *testing.T, session *RemuxSession, argLog string) string {
+	t.Helper()
+	_, _ = io.ReadAll(session)
+	_ = session.Close()
+	recorded, err := os.ReadFile(argLog)
+	if err != nil {
+		t.Fatalf("the remux never ran: %v", err)
+	}
+	return string(recorded)
+}
+
+// The preserve mode, not the caller, decides the sample-entry tagging:
+// buildRemuxArgs cannot be handed the flag directly by production code, so the
+// mapping from RemuxDVPreserveV3 must be exercised through the mode switch.
+func TestPreserveModeTagsTheSampleEntry(t *testing.T) {
+	for _, profile := range []int{5, 8} {
+		bin, argLog := writeRecordingFFmpeg(t)
+		session, err := StartRemuxWithDVMode(t.Context(), remuxSourceFile(t), "mp4", 0, false, -1, profile, RemuxDVPreserveV3, bin)
+		if err != nil {
+			t.Fatalf("preserve remux refused profile %d: %v", profile, err)
+		}
+		recorded := recordedRemuxArgs(t, session, argLog)
+		if !strings.Contains(recorded, "-tag:v dvh1") || !strings.Contains(recorded, "-strict unofficial") {
+			t.Fatalf("preserve mode must map to dvh1 + -strict unofficial for profile %d: %s", profile, recorded)
+		}
+	}
+}
+
+func TestExplicitStripModeTagsHVC1(t *testing.T) {
+	for _, profile := range []int{7, 8} {
+		bin, argLog := writeRecordingFFmpeg(t)
+		session, err := StartRemuxWithDVMode(t.Context(), remuxSourceFile(t), "mp4", 0, false, -1, profile, RemuxDVStripToHDR10V3, bin)
+		if err != nil {
+			t.Fatalf("strip remux refused profile %d: %v", profile, err)
+		}
+		recorded := recordedRemuxArgs(t, session, argLog)
+		if !strings.Contains(recorded, "dovi_rpu=strip=1") || !strings.Contains(recorded, "-tag:v hvc1") {
+			t.Fatalf("explicit strip must map to dovi_rpu + hvc1 for profile %d: %s", profile, recorded)
+		}
+		if strings.Contains(recorded, "dvh1") || strings.Contains(recorded, "-strict unofficial") {
+			t.Fatalf("stripped output must not carry DV signaling for profile %d: %s", profile, recorded)
+		}
+	}
 }
 
 func remuxSourceFile(t *testing.T) string {

--- a/internal/playback/remux_dv_test.go
+++ b/internal/playback/remux_dv_test.go
@@ -86,15 +86,20 @@ func TestBuildRemuxArgsKeepsRPUForProfile8AndPlainFiles(t *testing.T) {
 // rely on the pre-v3 hev1 labeling their demuxers accept.
 func TestBuildRemuxArgsTagsPreservedDolbyVisionOnlyWhenRequested(t *testing.T) {
 	args := buildRemuxArgs("/x.mkv", "mp4", 0, false, -1, 8, true, false)
-	if !argsContainPair(args, "-tag:v", "dvhe") {
+	if !argsContainPair(args, "-tag:v", "dvh1") {
 		t.Fatalf("preserved Dolby Vision must retain a DV sample entry, args=%v", strings.Join(args, " "))
 	}
+	// Without -strict unofficial FFmpeg drops the dvvC configuration record and
+	// the output is an untagged HEVC stream no DV decoder will select.
+	if !argsContainPair(args, "-strict", "unofficial") {
+		t.Fatalf("preserved Dolby Vision must allow the dvvC box, args=%v", strings.Join(args, " "))
+	}
 	legacy := buildRemuxArgs("/x.mkv", "mp4", 0, false, -1, 8, false, false)
-	if argsContainPair(legacy, "-tag:v", "dvhe") {
+	if argsContainPair(legacy, "-tag:v", "dvh1") || argsContainPair(legacy, "-strict", "unofficial") {
 		t.Fatalf("legacy remux consumers must keep hev1 labeling, args=%v", strings.Join(legacy, " "))
 	}
 	stripped := buildRemuxArgs("/x.mkv", "mp4", 0, false, -1, 7, false, false)
-	if argsContainPair(stripped, "-tag:v", "dvhe") {
+	if argsContainPair(stripped, "-tag:v", "dvh1") || argsContainPair(stripped, "-strict", "unofficial") {
 		t.Fatalf("HDR10 fallback must not retain a DV sample entry, args=%v", strings.Join(stripped, " "))
 	}
 }

--- a/web/src/player/components/VideoPlayer.test.tsx
+++ b/web/src/player/components/VideoPlayer.test.tsx
@@ -22,6 +22,9 @@ const subtitleTimeline = vi.hoisted(() => ({
   textOffsetSeconds: null as number | null,
   assOffsetSeconds: null as number | null,
 }));
+const toastError = vi.hoisted(() => vi.fn());
+
+vi.mock("sonner", () => ({ toast: { error: toastError, success: vi.fn(), message: vi.fn() } }));
 
 vi.mock("../hooks/usePlaybackRealtime", () => ({
   usePlaybackRealtime: vi.fn((options) => {
@@ -131,6 +134,7 @@ describe("VideoPlayer plan failure recovery", () => {
     controls.current = null;
     subtitleTimeline.textOffsetSeconds = null;
     subtitleTimeline.assOffsetSeconds = null;
+    toastError.mockClear();
     vi.spyOn(HTMLMediaElement.prototype, "play").mockResolvedValue(undefined);
     vi.spyOn(HTMLMediaElement.prototype, "pause").mockImplementation(() => {});
     vi.spyOn(HTMLMediaElement.prototype, "load").mockImplementation(() => {});
@@ -268,6 +272,74 @@ describe("VideoPlayer plan failure recovery", () => {
     await waitFor(() => expect(controls.current?.activeSubtitleIndex).toBe(2));
     expect(onSubtitleTrackChange).toHaveBeenCalledTimes(2);
     expect(onSubtitleTrackChange).toHaveBeenLastCalledWith(2, 0);
+  });
+
+  // The rollback is otherwise silent: the refusal only renders inside the
+  // quality menu, which a user who just picked a subtitle never opens.
+  it("toasts the server's refusal when a subtitle change is rolled back", async () => {
+    const onSubtitleTrackChange = vi.fn();
+    const sidecarTrack: PlayerSubtitleInfo = {
+      index: 2,
+      media_file_id: 7,
+      track_id: "file:7:subtitle:2",
+      language: "en",
+      codec: "srt",
+      label: "English",
+      source: "external",
+      url: "/stream/session-1/subtitles/2.vtt",
+    };
+    const { rerenderPlayer } = renderPlayer({
+      subtitleUrls: [sidecarTrack],
+      subtitleMode: "always",
+      preferredSubtitleLanguage: "en",
+      onSubtitleTrackChange,
+    });
+
+    await waitFor(() => expect(onSubtitleTrackChange).toHaveBeenCalledOnce());
+    expect(toastError).not.toHaveBeenCalled();
+
+    rerenderPlayer({
+      replanError: "The selected subtitle must be burned into the video, but 4K is disabled.",
+      replanErrorTitle: "That subtitle track can't be used",
+    });
+
+    await waitFor(() => expect(toastError).toHaveBeenCalledOnce());
+    expect(toastError).toHaveBeenCalledWith("That subtitle track can't be used", {
+      description: "The selected subtitle must be burned into the video, but 4K is disabled.",
+    });
+  });
+
+  it("falls back to a generic subtitle refusal title and toasts once", async () => {
+    const onSubtitleTrackChange = vi.fn();
+    const sidecarTrack: PlayerSubtitleInfo = {
+      index: 2,
+      media_file_id: 7,
+      track_id: "file:7:subtitle:2",
+      language: "en",
+      codec: "srt",
+      label: "English",
+      source: "external",
+      url: "/stream/session-1/subtitles/2.vtt",
+    };
+    const { rerenderPlayer } = renderPlayer({
+      subtitleUrls: [sidecarTrack],
+      subtitleMode: "always",
+      preferredSubtitleLanguage: "en",
+      onSubtitleTrackChange,
+    });
+
+    await waitFor(() => expect(onSubtitleTrackChange).toHaveBeenCalledOnce());
+    rerenderPlayer({ replanError: "Silo could not apply the subtitle selection." });
+    await waitFor(() => expect(toastError).toHaveBeenCalledOnce());
+    expect(toastError).toHaveBeenCalledWith("That subtitle track can't be used", {
+      description: "Silo could not apply the subtitle selection.",
+    });
+
+    // The ref cleared on rollback, so a re-render with the same refusal must
+    // not stack a second toast.
+    rerenderPlayer({ replanError: "Silo could not apply the subtitle selection." });
+    await waitFor(() => expect(controls.current?.activeSubtitleIndex).toBeNull());
+    expect(toastError).toHaveBeenCalledOnce();
   });
 });
 

--- a/web/src/player/components/VideoPlayer.tsx
+++ b/web/src/player/components/VideoPlayer.tsx
@@ -91,6 +91,8 @@ interface VideoPlayerProps {
   replanning?: boolean;
   /** Server-described replan error, if the last replan was refused. */
   replanError?: string | null;
+  /** Title for the replan error, used when surfacing the refusal as a toast. */
+  replanErrorTitle?: string | null;
   sessionId: string;
   selectedVersion?: PlayerFileVersion;
   versions?: PlayerFileVersion[];
@@ -195,6 +197,7 @@ export function VideoPlayer({
   shouldAutoPlay = true,
   replanning = false,
   replanError = null,
+  replanErrorTitle = null,
   sessionId,
   selectedVersion,
   versions = [],
@@ -1948,13 +1951,19 @@ export function VideoPlayer({
   // unchanged selection instead of retrying. Pin the accepted selection just
   // like a manual choice so auto-selection does not immediately request the
   // rejected track again; a later user choice can still retry it explicitly.
+  // The rollback is silent otherwise: the refusal is only rendered inside the
+  // quality menu, which the user has no reason to open after picking a
+  // subtitle. Clearing the request ref keeps this to one toast per refusal.
   useEffect(() => {
     if (requestedSubtitleTrackChangeRef.current && replanError && !replanning) {
       subtitleSelectionWasManualRef.current = true;
       setActiveSubtitleIndex(plan.selected_tracks.subtitle?.index ?? null);
       requestedSubtitleTrackChangeRef.current = null;
+      toast.error(replanErrorTitle ?? "That subtitle track can't be used", {
+        description: replanError,
+      });
     }
-  }, [plan.selected_tracks.subtitle?.index, replanError, replanning]);
+  }, [plan.selected_tracks.subtitle?.index, replanError, replanErrorTitle, replanning]);
 
   // A refusal pin belongs only to the session that rejected the automatic
   // selection. Clear it before the auto-selection effect evaluates a new

--- a/web/src/player/components/WatchPage.tsx
+++ b/web/src/player/components/WatchPage.tsx
@@ -438,6 +438,7 @@ export function WatchPage({
       shouldAutoPlay={session.shouldAutoPlay}
       replanning={session.replanning}
       replanError={session.error}
+      replanErrorTitle={session.errorTitle}
       sessionId={session.sessionId}
       selectedVersion={selectedVersion}
       versions={playbackVersions}

--- a/web/src/player/hooks/useCodecDetection.test.ts
+++ b/web/src/player/hooks/useCodecDetection.test.ts
@@ -69,8 +69,9 @@ describe("probeWebCapabilities", () => {
     );
   });
 
-  // Safari rejects the hev1 sample entry outright; only hvc1 gets an answer.
-  it("accepts HDR10 decode evidence from either HEVC sample entry", async () => {
+  // The strip remux delivers an hvc1-labeled file; support reported only for
+  // hev1 is evidence for bytes Silo never sends and must not earn the claim.
+  it("does not promote an hev1-only answer to an HDR10 claim", async () => {
     const decodingInfo = vi.fn().mockImplementation((configuration: MediaDecodingConfiguration) => {
       const supported = configuration.video?.contentType.includes("hev1") ?? false;
       return Promise.resolve({ supported, smooth: supported, powerEfficient: supported });
@@ -78,7 +79,7 @@ describe("probeWebCapabilities", () => {
     vi.stubGlobal("navigator", { mediaCapabilities: { decodingInfo } });
     vi.stubGlobal("matchMedia", (query: string) => ({ matches: query.includes("high") }));
 
-    await expect(probeHDR10PlaybackSupport()).resolves.toBe(true);
+    await expect(probeHDR10PlaybackSupport()).resolves.toBe(false);
   });
 
   // Safari 26 reports `dynamic-range: standard` on XDR panels, and browsers

--- a/web/src/player/hooks/useCodecDetection.test.ts
+++ b/web/src/player/hooks/useCodecDetection.test.ts
@@ -60,7 +60,7 @@ describe("probeWebCapabilities", () => {
       expect.objectContaining({
         type: "file",
         video: expect.objectContaining({
-          contentType: 'video/mp4; codecs="hev1.2.4.L153.B0"',
+          contentType: 'video/mp4; codecs="hvc1.2.4.L153.B0"',
           colorGamut: "rec2020",
           transferFunction: "pq",
           hdrMetadataType: "smpteSt2086",
@@ -69,19 +69,38 @@ describe("probeWebCapabilities", () => {
     );
   });
 
-  it("does not probe HDR10 decoding against an SDR output", async () => {
-    const decodingInfo = vi.fn();
+  // Safari rejects the hev1 sample entry outright; only hvc1 gets an answer.
+  it("accepts HDR10 decode evidence from either HEVC sample entry", async () => {
+    const decodingInfo = vi.fn().mockImplementation((configuration: MediaDecodingConfiguration) => {
+      const supported = configuration.video?.contentType.includes("hev1") ?? false;
+      return Promise.resolve({ supported, smooth: supported, powerEfficient: supported });
+    });
+    vi.stubGlobal("navigator", { mediaCapabilities: { decodingInfo } });
+    vi.stubGlobal("matchMedia", (query: string) => ({ matches: query.includes("high") }));
+
+    await expect(probeHDR10PlaybackSupport()).resolves.toBe(true);
+  });
+
+  // Safari 26 reports `dynamic-range: standard` on XDR panels, and browsers
+  // tone-map HDR onto SDR outputs regardless. Decode evidence stands alone.
+  it("probes HDR10 decoding even when the output reports no HDR", async () => {
+    const decodingInfo = vi.fn().mockResolvedValue({
+      supported: true,
+      smooth: true,
+      powerEfficient: true,
+      keySystemAccess: null,
+    });
     vi.stubGlobal("navigator", { mediaCapabilities: { decodingInfo } });
     vi.stubGlobal("matchMedia", () => ({ matches: false }));
 
-    await expect(probeHDR10PlaybackSupport()).resolves.toBe(false);
-    expect(decodingInfo).not.toHaveBeenCalled();
+    await expect(probeHDR10PlaybackSupport()).resolves.toBe(true);
+    expect(decodingInfo).toHaveBeenCalled();
   });
 
-  it("advertises native Dolby Vision Profile 8 only on an HDR output", () => {
+  it("advertises native Dolby Vision Profile 8 from the dvh1 sample entry", () => {
     vi.stubGlobal("matchMedia", (query: string) => ({ matches: query.includes("high") }));
     vi.spyOn(HTMLMediaElement.prototype, "canPlayType").mockImplementation((mime) =>
-      mime === 'video/mp4; codecs="dvhe.08.06"' ? "probably" : "",
+      mime === 'video/mp4; codecs="dvh1.08.06"' ? "probably" : "",
     );
 
     const capabilities = probeWebCapabilities();
@@ -97,48 +116,77 @@ describe("probeWebCapabilities", () => {
     expect(capabilities.progressiveCodecsVideo).toContain("hevc");
   });
 
-  it("does not advertise a Dolby Vision decoder against an SDR output", () => {
+  it("accepts the dvhe sample entry from browsers that answer for it", () => {
+    vi.stubGlobal("matchMedia", (query: string) => ({ matches: query.includes("high") }));
+    vi.spyOn(HTMLMediaElement.prototype, "canPlayType").mockImplementation((mime) =>
+      mime === 'video/mp4; codecs="dvhe.08.06"' ? "probably" : "",
+    );
+
+    expect(probeWebCapabilities().hdrDetails.dolby_vision_profiles).toEqual([8]);
+  });
+
+  // The generic media query describes the output, not the decoder. Safari 26
+  // reports no HDR on an XDR display while answering "probably" for dvh1.
+  it("keeps a definitive Dolby Vision answer from an output reporting no HDR", () => {
     vi.stubGlobal("matchMedia", () => ({ matches: false }));
-    const canPlayType = vi
-      .spyOn(HTMLMediaElement.prototype, "canPlayType")
-      .mockImplementation((mime) => (mime === 'video/mp4; codecs="dvhe.08.06"' ? "probably" : ""));
+    vi.spyOn(HTMLMediaElement.prototype, "canPlayType").mockImplementation((mime) =>
+      mime === 'video/mp4; codecs="dvh1.08.06"' ? "probably" : "",
+    );
 
     const capabilities = probeWebCapabilities();
 
-    expect(capabilities.hdrDetails.dolby_vision_profiles).toEqual([]);
-    expect(capabilities.hdrDetails.dolby_vision_profile_levels).toEqual([]);
-    expect(canPlayType).not.toHaveBeenCalledWith('video/mp4; codecs="dvhe.08.06"');
+    expect(capabilities.hdr).toBe(false);
+    expect(capabilities.hdrDetails.dolby_vision_profiles).toEqual([8]);
+    expect(capabilities.hdrDetails.dolby_vision_profile_levels).toEqual([
+      { profile: 8, max_level: 6, bl_compatibility_ids: [1] },
+    ]);
   });
 
   it("does not promote an indeterminate media-element answer to Dolby Vision support", () => {
     vi.stubGlobal("matchMedia", () => ({ matches: true }));
     vi.spyOn(HTMLMediaElement.prototype, "canPlayType").mockImplementation((mime) =>
-      mime === 'video/mp4; codecs="dvhe.08.06"' ? "maybe" : "",
+      mime.startsWith('video/mp4; codecs="dv') ? "maybe" : "",
     );
 
     expect(probeWebCapabilities().hdrDetails.dolby_vision_profiles).toEqual([]);
   });
 
-  it("refreshes Dolby Vision claims when the active HDR output changes", () => {
-    let hdr = false;
+  // `screen` is measured in logical CSS pixels, so a 2x MacBook Pro XDR panel
+  // advertises 1080p unless the device pixel ratio is applied.
+  it("scales the screen-derived resolution by the device pixel ratio", () => {
+    vi.stubGlobal("screen", { width: 1728, height: 1117 });
+    vi.stubGlobal("devicePixelRatio", 2);
+
+    expect(probeWebCapabilities().maxResolution).toBe("2160p");
+  });
+
+  it("treats a missing device pixel ratio as 1", () => {
+    vi.stubGlobal("screen", { width: 1728, height: 1117 });
+    vi.stubGlobal("devicePixelRatio", undefined);
+
+    expect(probeWebCapabilities().maxResolution).toBe("1080p");
+  });
+
+  // Moving a window between displays can change what the decoder will admit to,
+  // so the media-query listeners still drive a re-probe.
+  it("re-probes Dolby Vision claims when the active output changes", () => {
+    let decodes = false;
     const listeners = new Set<() => void>();
     const query = {
-      get matches() {
-        return hdr;
-      },
+      matches: false,
       addEventListener: (_: string, listener: () => void) => listeners.add(listener),
       removeEventListener: (_: string, listener: () => void) => listeners.delete(listener),
     };
     vi.stubGlobal("matchMedia", () => query);
     vi.spyOn(HTMLMediaElement.prototype, "canPlayType").mockImplementation((mime) =>
-      mime === 'video/mp4; codecs="dvhe.08.06"' ? "probably" : "",
+      decodes && mime === 'video/mp4; codecs="dvh1.08.06"' ? "probably" : "",
     );
 
     const { result, unmount } = renderHook(() => useCodecDetection());
     expect(result.current.hdrDetails.dolby_vision_profiles).toEqual([]);
 
     act(() => {
-      hdr = true;
+      decodes = true;
       for (const listener of listeners) listener();
     });
     expect(result.current.hdrDetails.dolby_vision_profiles).toEqual([8]);
@@ -147,8 +195,9 @@ describe("probeWebCapabilities", () => {
 
   it("refreshes the active capabilities after the async HDR10 probe", async () => {
     const listeners = new Set<() => void>();
+    // The output reports no HDR: the decode probe must still run and be trusted.
     const query = {
-      matches: true,
+      matches: false,
       addEventListener: (_: string, listener: () => void) => listeners.add(listener),
       removeEventListener: (_: string, listener: () => void) => listeners.delete(listener),
     };

--- a/web/src/player/hooks/useCodecDetection.test.ts
+++ b/web/src/player/hooks/useCodecDetection.test.ts
@@ -116,13 +116,15 @@ describe("probeWebCapabilities", () => {
     expect(capabilities.progressiveCodecsVideo).toContain("hevc");
   });
 
-  it("accepts the dvhe sample entry from browsers that answer for it", () => {
+  // The preserve remux tags its output dvh1; a browser that answers only for
+  // dvhe has given no evidence for that file and must not earn the claim.
+  it("does not promote a dvhe-only answer to a Dolby Vision claim", () => {
     vi.stubGlobal("matchMedia", (query: string) => ({ matches: query.includes("high") }));
     vi.spyOn(HTMLMediaElement.prototype, "canPlayType").mockImplementation((mime) =>
       mime === 'video/mp4; codecs="dvhe.08.06"' ? "probably" : "",
     );
 
-    expect(probeWebCapabilities().hdrDetails.dolby_vision_profiles).toEqual([8]);
+    expect(probeWebCapabilities().hdrDetails.dolby_vision_profiles).toEqual([]);
   });
 
   // The generic media query describes the output, not the decoder. Safari 26

--- a/web/src/player/hooks/useCodecDetection.ts
+++ b/web/src/player/hooks/useCodecDetection.ts
@@ -10,18 +10,24 @@ const VIDEO_CODEC_MAP: Record<string, string> = {
 };
 
 // Silo's native Dolby Vision remux recipe preserves the DOVI configuration
-// record under a dvhe sample entry. Probe the exact shape the browser would
+// record under a dvh1 sample entry. Probe the exact shape the browser would
 // receive instead of inferring Dolby Vision support from generic HEVC decode.
+// Safari answers "" for dvhe and "probably" only for dvh1, so probe both sample
+// entries per profile and claim the profile when either is definitive.
 // Level 6 covers the 2160p24 source class involved in the web regression.
 const DOLBY_VISION_PROFILE_PROBES: Record<
   number,
-  { mime: string; maxLevel: number; blCompatibilityIds?: number[] }
+  { mimes: string[]; maxLevel: number; blCompatibilityIds?: number[] }
 > = {
-  5: { mime: 'video/mp4; codecs="dvhe.05.06"', maxLevel: 6 },
+  5: { mimes: ['video/mp4; codecs="dvh1.05.06"', 'video/mp4; codecs="dvhe.05.06"'], maxLevel: 6 },
   // The MIME codec string identifies Profile 8 but not its base-layer
   // compatibility ID. Conservatively claim only the Profile 8.1 shape that
   // this regression and Safari's progressive remux path exercise.
-  8: { mime: 'video/mp4; codecs="dvhe.08.06"', maxLevel: 6, blCompatibilityIds: [1] },
+  8: {
+    mimes: ['video/mp4; codecs="dvh1.08.06"', 'video/mp4; codecs="dvhe.08.06"'],
+    maxLevel: 6,
+    blCompatibilityIds: [1],
+  },
 };
 
 // Silo's Profile 7 fallback strips Dolby Vision metadata into a progressive
@@ -29,19 +35,26 @@ const DOLBY_VISION_PROFILE_PROBES: Record<
 // can query the codec, transfer function, gamut, and static metadata together,
 // avoiding the old mistake of treating a generic HDR output query as proof of
 // every HDR format.
-const HDR10_PROGRESSIVE_CONFIGURATION = {
-  type: "file",
-  video: {
-    contentType: 'video/mp4; codecs="hev1.2.4.L153.B0"',
-    width: 3840,
-    height: 2160,
-    bitrate: 80_000_000,
-    framerate: 24,
-    colorGamut: "rec2020",
-    transferFunction: "pq",
-    hdrMetadataType: "smpteSt2086",
-  },
-} satisfies MediaDecodingConfiguration;
+// Safari answers for hvc1 and rejects hev1, so probe both sample entries.
+const HDR10_PROGRESSIVE_CONFIGURATIONS = [
+  'video/mp4; codecs="hvc1.2.4.L153.B0"',
+  'video/mp4; codecs="hev1.2.4.L153.B0"',
+].map(
+  (contentType) =>
+    ({
+      type: "file",
+      video: {
+        contentType,
+        width: 3840,
+        height: 2160,
+        bitrate: 80_000_000,
+        framerate: 24,
+        colorGamut: "rec2020",
+        transferFunction: "pq",
+        hdrMetadataType: "smpteSt2086",
+      },
+    }) satisfies MediaDecodingConfiguration,
+);
 
 const AUDIO_CODEC_MAP: Record<string, string[]> = {
   aac: ['audio/mp4; codecs="mp4a.40.2"', 'video/mp4; codecs="mp4a.40.2"'],
@@ -93,21 +106,24 @@ export function detectHDRFromMatchMedia(matchMediaFn: typeof matchMedia | undefi
   );
 }
 
-/** Probes the exact HDR10 progressive shape produced by Silo's remux path. */
+/**
+ * Probes the exact HDR10 progressive shape produced by Silo's remux path.
+ * Deliberately independent of the `dynamic-range` media query: that query
+ * describes the active output, not the decoder, and browsers tone-map HDR
+ * content onto SDR outputs.
+ */
 export async function probeHDR10PlaybackSupport(): Promise<boolean> {
-  const hdrOutput = detectHDRFromMatchMedia(
-    typeof matchMedia !== "undefined" ? (query) => matchMedia(query) : undefined,
-  );
-  if (!hdrOutput || typeof navigator === "undefined" || !navigator.mediaCapabilities) {
-    return false;
-  }
+  if (typeof navigator === "undefined" || !navigator.mediaCapabilities) return false;
 
-  try {
-    const result = await navigator.mediaCapabilities.decodingInfo(HDR10_PROGRESSIVE_CONFIGURATION);
-    return result.supported && result.smooth;
-  } catch {
-    return false;
+  for (const configuration of HDR10_PROGRESSIVE_CONFIGURATIONS) {
+    try {
+      const result = await navigator.mediaCapabilities.decodingInfo(configuration);
+      if (result.supported && result.smooth) return true;
+    } catch {
+      // Try the next sample entry.
+    }
   }
+  return false;
 }
 
 function testMediaType(mime: string): boolean {
@@ -177,9 +193,18 @@ export function probeWebCapabilities(): WebCapabilityProbe {
     }
   }
 
+  // `screen` reports logical CSS pixels; a 2160p-class panel on a 2x display
+  // measures 1080p without the device pixel ratio applied.
+  const pixelRatio =
+    typeof window !== "undefined" &&
+    typeof window.devicePixelRatio === "number" &&
+    Number.isFinite(window.devicePixelRatio) &&
+    window.devicePixelRatio > 0
+      ? window.devicePixelRatio
+      : 1;
   const maxResolution =
     typeof screen !== "undefined"
-      ? detectMaxResolutionFromScreen(screen.width, screen.height)
+      ? detectMaxResolutionFromScreen(screen.width * pixelRatio, screen.height * pixelRatio)
       : "1080p";
 
   // HDR detection (best effort). Wrap matchMedia so it keeps its Window
@@ -187,11 +212,15 @@ export function probeWebCapabilities(): WebCapabilityProbe {
   const hdr = detectHDRFromMatchMedia(
     typeof matchMedia !== "undefined" ? (query) => matchMedia(query) : undefined,
   );
-  const dolbyVisionProfiles = hdr
-    ? Object.entries(DOLBY_VISION_PROFILE_PROBES)
-        .filter(([, probe]) => testMediaElementType(probe.mime))
-        .map(([profile]) => Number(profile))
-    : [];
+  // Decoder capability and active-output HDR are separate facts: browsers
+  // tone-map HDR content onto SDR outputs, and Safari 26 reports
+  // `dynamic-range: standard` even on an XDR panel. Exact positive decode
+  // evidence must not be discarded because the coarse output query says no, so
+  // the sample-entry probes run unconditionally and `hdr` stays a best-effort
+  // output signal only.
+  const dolbyVisionProfiles = Object.entries(DOLBY_VISION_PROFILE_PROBES)
+    .filter(([, probe]) => probe.mimes.some(testMediaElementType))
+    .map(([profile]) => Number(profile));
   const progressiveCodecsVideo = [...codecsVideo];
   if (dolbyVisionProfiles.length > 0 && !progressiveCodecsVideo.includes("hevc")) {
     // Every Dolby Vision profile probed above uses an HEVC base layer. The
@@ -250,7 +279,6 @@ export function useCodecDetection(): WebCapabilityProbe {
       const generation = ++probeGeneration;
       const next = probeWebCapabilities();
       setCapabilities(next);
-      if (!next.hdr) return;
 
       void probeHDR10PlaybackSupport().then((hdr10) => {
         if (disposed || generation !== probeGeneration || !hdr10) return;

--- a/web/src/player/hooks/useCodecDetection.ts
+++ b/web/src/player/hooks/useCodecDetection.ts
@@ -32,28 +32,22 @@ const DOLBY_VISION_PROFILE_PROBES: Record<
 // can query the codec, transfer function, gamut, and static metadata together,
 // avoiding the old mistake of treating a generic HDR output query as proof of
 // every HDR format.
-// Safari answers for hvc1 and rejects hev1, so probe both sample entries:
-// either one proves the same HEVC Main10 HDR10 decode, and the strip remux
-// labels its output hvc1, which every hev1-capable MP4 demuxer recognizes.
-const HDR10_PROGRESSIVE_CONFIGURATIONS = [
-  'video/mp4; codecs="hvc1.2.4.L153.B0"',
-  'video/mp4; codecs="hev1.2.4.L153.B0"',
-].map(
-  (contentType) =>
-    ({
-      type: "file",
-      video: {
-        contentType,
-        width: 3840,
-        height: 2160,
-        bitrate: 80_000_000,
-        framerate: 24,
-        colorGamut: "rec2020",
-        transferFunction: "pq",
-        hdrMetadataType: "smpteSt2086",
-      },
-    }) satisfies MediaDecodingConfiguration,
-);
+// The strip remux labels its output hvc1 — the sample entry Apple requires and
+// the one Safari answers for — so that is the only entry probed: an hev1-only
+// answer is evidence for a file Silo never sends and earns no claim.
+const HDR10_PROGRESSIVE_CONFIGURATION = {
+  type: "file",
+  video: {
+    contentType: 'video/mp4; codecs="hvc1.2.4.L153.B0"',
+    width: 3840,
+    height: 2160,
+    bitrate: 80_000_000,
+    framerate: 24,
+    colorGamut: "rec2020",
+    transferFunction: "pq",
+    hdrMetadataType: "smpteSt2086",
+  },
+} satisfies MediaDecodingConfiguration;
 
 const AUDIO_CODEC_MAP: Record<string, string[]> = {
   aac: ['audio/mp4; codecs="mp4a.40.2"', 'video/mp4; codecs="mp4a.40.2"'],
@@ -114,15 +108,12 @@ export function detectHDRFromMatchMedia(matchMediaFn: typeof matchMedia | undefi
 export async function probeHDR10PlaybackSupport(): Promise<boolean> {
   if (typeof navigator === "undefined" || !navigator.mediaCapabilities) return false;
 
-  for (const configuration of HDR10_PROGRESSIVE_CONFIGURATIONS) {
-    try {
-      const result = await navigator.mediaCapabilities.decodingInfo(configuration);
-      if (result.supported && result.smooth) return true;
-    } catch {
-      // Try the next sample entry.
-    }
+  try {
+    const result = await navigator.mediaCapabilities.decodingInfo(HDR10_PROGRESSIVE_CONFIGURATION);
+    return result.supported && result.smooth;
+  } catch {
+    return false;
   }
-  return false;
 }
 
 function testMediaType(mime: string): boolean {

--- a/web/src/player/hooks/useCodecDetection.ts
+++ b/web/src/player/hooks/useCodecDetection.ts
@@ -10,24 +10,21 @@ const VIDEO_CODEC_MAP: Record<string, string> = {
 };
 
 // Silo's native Dolby Vision remux recipe preserves the DOVI configuration
-// record under a dvh1 sample entry. Probe the exact shape the browser would
-// receive instead of inferring Dolby Vision support from generic HEVC decode.
-// Safari answers "" for dvhe and "probably" only for dvh1, so probe both sample
-// entries per profile and claim the profile when either is definitive.
+// record under a dvh1 sample entry — the one Apple's HLS authoring spec calls
+// for, and the only one Safari answers "probably" for. Probe exactly that
+// shape: a browser that recognizes only dvhe could accept a claim here and
+// then reject the dvh1 file the remux delivers, so a dvhe-only answer earns no
+// claim and that browser keeps the validated HDR10 fallback instead.
 // Level 6 covers the 2160p24 source class involved in the web regression.
 const DOLBY_VISION_PROFILE_PROBES: Record<
   number,
-  { mimes: string[]; maxLevel: number; blCompatibilityIds?: number[] }
+  { mime: string; maxLevel: number; blCompatibilityIds?: number[] }
 > = {
-  5: { mimes: ['video/mp4; codecs="dvh1.05.06"', 'video/mp4; codecs="dvhe.05.06"'], maxLevel: 6 },
+  5: { mime: 'video/mp4; codecs="dvh1.05.06"', maxLevel: 6 },
   // The MIME codec string identifies Profile 8 but not its base-layer
   // compatibility ID. Conservatively claim only the Profile 8.1 shape that
   // this regression and Safari's progressive remux path exercise.
-  8: {
-    mimes: ['video/mp4; codecs="dvh1.08.06"', 'video/mp4; codecs="dvhe.08.06"'],
-    maxLevel: 6,
-    blCompatibilityIds: [1],
-  },
+  8: { mime: 'video/mp4; codecs="dvh1.08.06"', maxLevel: 6, blCompatibilityIds: [1] },
 };
 
 // Silo's Profile 7 fallback strips Dolby Vision metadata into a progressive
@@ -35,7 +32,9 @@ const DOLBY_VISION_PROFILE_PROBES: Record<
 // can query the codec, transfer function, gamut, and static metadata together,
 // avoiding the old mistake of treating a generic HDR output query as proof of
 // every HDR format.
-// Safari answers for hvc1 and rejects hev1, so probe both sample entries.
+// Safari answers for hvc1 and rejects hev1, so probe both sample entries:
+// either one proves the same HEVC Main10 HDR10 decode, and the strip remux
+// labels its output hvc1, which every hev1-capable MP4 demuxer recognizes.
 const HDR10_PROGRESSIVE_CONFIGURATIONS = [
   'video/mp4; codecs="hvc1.2.4.L153.B0"',
   'video/mp4; codecs="hev1.2.4.L153.B0"',
@@ -219,7 +218,7 @@ export function probeWebCapabilities(): WebCapabilityProbe {
   // the sample-entry probes run unconditionally and `hdr` stays a best-effort
   // output signal only.
   const dolbyVisionProfiles = Object.entries(DOLBY_VISION_PROFILE_PROBES)
-    .filter(([, probe]) => probe.mimes.some(testMediaElementType))
+    .filter(([, probe]) => testMediaElementType(probe.mime))
     .map(([profile]) => Number(profile));
   const progressiveCodecsVideo = [...codecsVideo];
   if (dolbyVisionProfiles.length > 0 && !progressiveCodecsVideo.includes("hevc")) {

--- a/web/src/player/hooks/usePlaybackSession.test.ts
+++ b/web/src/player/hooks/usePlaybackSession.test.ts
@@ -363,8 +363,10 @@ describe("usePlaybackSession output capability changes", () => {
       removeEventListener: (_: string, listener: () => void) => listeners.delete(listener),
     };
     vi.stubGlobal("matchMedia", () => query);
+    // Decode answers are probed independently of the media query, so move the
+    // simulated decoder along with the output this fixture switches between.
     vi.spyOn(HTMLMediaElement.prototype, "canPlayType").mockImplementation((mime) =>
-      mime === 'video/mp4; codecs="dvhe.08.06"' ? "probably" : "",
+      hdr && mime === 'video/mp4; codecs="dvhe.08.06"' ? "probably" : "",
     );
     return (nextHDR: boolean) => {
       hdr = nextHDR;

--- a/web/src/player/hooks/usePlaybackSession.test.ts
+++ b/web/src/player/hooks/usePlaybackSession.test.ts
@@ -366,7 +366,7 @@ describe("usePlaybackSession output capability changes", () => {
     // Decode answers are probed independently of the media query, so move the
     // simulated decoder along with the output this fixture switches between.
     vi.spyOn(HTMLMediaElement.prototype, "canPlayType").mockImplementation((mime) =>
-      hdr && mime === 'video/mp4; codecs="dvhe.08.06"' ? "probably" : "",
+      hdr && mime === 'video/mp4; codecs="dvh1.08.06"' ? "probably" : "",
     );
     return (nextHDR: boolean) => {
       hdr = nextHDR;

--- a/web/src/player/playback-errors.test.ts
+++ b/web/src/player/playback-errors.test.ts
@@ -31,6 +31,35 @@ describe("describePlanTerminal", () => {
     });
   });
 
+  it("keeps the server's explanation of why a subtitle cannot be used", () => {
+    expect(
+      describePlanTerminal({
+        reason: "subtitle_conversion_unsupported",
+        message:
+          "The selected subtitle must be burned into the video, but 4K transcoding is disabled.",
+        retryable: false,
+      }),
+    ).toEqual({
+      title: "That subtitle track can't be used",
+      message:
+        "The selected subtitle must be burned into the video, but 4K transcoding is disabled.",
+    });
+  });
+
+  it("falls back to a generic subtitle sentence when the server sends no message", () => {
+    expect(
+      describePlanTerminal({
+        reason: "subtitle_codec_unsupported",
+        message: "  ",
+        retryable: false,
+      }),
+    ).toEqual({
+      title: "That subtitle track can't be used",
+      message:
+        "Silo couldn't prepare the selected subtitles for this device. Try a different track.",
+    });
+  });
+
   it("falls back to the server's own message for reasons it does not name", () => {
     expect(
       describePlanTerminal({

--- a/web/src/player/playback-errors.ts
+++ b/web/src/player/playback-errors.ts
@@ -100,7 +100,10 @@ export function describePlanTerminal(terminal: TerminalV3): PlaybackPolicyErrorD
     case "subtitle_artifact_unavailable":
       return {
         title: "That subtitle track can't be used",
+        // The server names the specific blocker (burn-in required, source
+        // unsupported); the generic sentence only covers a missing message.
         message:
+          terminal.message?.trim() ||
           "Silo couldn't prepare the selected subtitles for this device. Try a different track.",
       };
     default:


### PR DESCRIPTION
## Problem

Follow-up to #613 for #609. The reporter redeployed with #613 merged and still hit `hdr_transcode_unsupported` on the same Dolby Vision Profile 8.1 source, with the normalized request showing empty `hdr_details` and `max_resolution: "1080p"` — on a MacBook Pro XDR display running Safari 26.6.

Three gaps remained after #613, confirmed against the reporter's browser evidence:

1. **The structured HDR probes were gated on `matchMedia("(dynamic-range: high)")`.** Safari 26 returns `false` for both dynamic-range queries even on an XDR panel, so the exact `canPlayType` / `MediaCapabilities.decodingInfo` probes — which return positive, exact decode evidence on that machine — never ran. The client sent empty `hdr_details`, and the planner correctly refused the range.
2. **The probes used the wrong sample entries for Safari.** `canPlayType('dvhe.08.06')` returns `""` in Safari; only `dvh1.*` (and `hvc1.*` for plain HEVC) get `"probably"`, per Apple's HLS authoring recommendation. Chromium-family browsers answer for `dvhe`/`hev1`, so both spellings must be probed.
3. **The preserved-DV remux never actually carried Dolby Vision signaling.** The recipe emitted `-tag:v dvhe`, and its comment claimed dvhe keeps FFmpeg's `dvvC` box while dvh1 loses it. That is wrong: FFmpeg refuses to write the `dvvC` DOVI configuration record under *either* tag without `-strict unofficial` ("Not writing 'dvcC'/'dvvC' box. Requires -strict unofficial"). The reporter verified with the bundled FFmpeg 7.1.4 that `-tag:v dvh1 -strict unofficial` produces `dvh1` + `hvcC` + `dvvC` with the full DOVI record intact (dv_profile=8, bl_signal_compatibility_id=1, rpu_present=1).

A fourth, smaller gap: `screen.width/height` are logical CSS pixels, so a 2× 2160p-class panel advertised `max_resolution: "1080p"`.

## Approach

- **Decode capability and active-output HDR are now separate facts.** The Dolby Vision sample-entry probes and the exact HDR10 `decodingInfo` probe run unconditionally; the `dynamic-range` media query survives only as the best-effort `hdr` output boolean. Browsers tone-map HDR onto SDR outputs, so discarding exact positive decode evidence because the coarse output query says "standard" was wrong on both counts.
- **Probe both sample-entry spellings.** Each DV profile probes `dvh1.*` then `dvhe.*` and claims on either definitive `"probably"`; the HDR10 Media Capabilities shape is probed under `hvc1.2.4.L153.B0` then `hev1.2.4.L153.B0`. Everything else about the claims is unchanged: Profile 8 stays bounded to the 8.1 base-layer shape and level 6, claims stay scoped to `progressive` delivery only, and `"maybe"` still claims nothing.
- **Emit `-tag:v dvh1 -strict unofficial` for the explicit v3 preserve recipe.** This is scoped to the `tagDVSampleEntry` opt-in branch only — legacy web/jellycompat consumers, the P7 HDR10 strip, and plain remuxes are untouched. Media3 recognizes both `dvhe` and `dvh1` sample entries, so Android preserve consumers are unaffected.
- **Scale `max_resolution` by `devicePixelRatio`** (guarded, defaulting to 1).
- Server planner, protocol schemas, and scanner are deliberately untouched — #613's server-side handling of structured `hdr_details` is correct once the client stops suppressing the evidence.

## Validation

- `go test ./internal/playback/ ./internal/api/handlers/` — ok
- `pnpm --dir web exec vitest run src/player/hooks/useCodecDetection.test.ts src/player/client-context-v3.test.ts src/player/hooks/usePlaybackSession.test.ts src/player/components/WatchPage.test.ts src/player/components/VideoPlayer.test.tsx` — 5 files, 74 tests passed
- `golangci-lint run --new-from-merge-base=origin/main ./internal/playback/...` — 0 issues
- `pnpm --dir web run lint` — 0 errors (151 inherited warnings, baseline)
- `pnpm --dir web run format:check` — clean
- `make verify-local-paths` — clean
- `gofmt -l internal/playback/` — clean

Full `make test-go` also surfaces three pre-existing failures unrelated to this change and present on clean `main` in the same environment: the two macOS-only jellycompat process-lock tests noted in #613, and `internal/playback/contract` `TestAdvertisedListsMatchTheGoldenFixtures` (golden fixture missing `output_change_v1`, introduced by #613 itself — reproduced with this branch's changes stashed).

New regression coverage: dvh1-only Safari-shaped answers earn the DV claim with SDR-reporting outputs, dvhe fallback still works, `"maybe"` claims nothing, the HDR10 probe runs and is trusted without the HDR media query and accepts either HEVC sample entry, remux args carry `dvh1` + `-strict unofficial` only in the preserve branch, and DPR scaling of the screen-derived resolution.

## Risk

The claim surface widens only where the browser gives a definitive positive answer for the exact sample entry; profile/level/BL-compat bounds and the progressive-only scoping are unchanged. The remux flag change alters bytes only for the v3 preserve recipe, which today produces streams with no DV signaling at all — consumers can only gain the configuration record they were promised. `-strict unofficial` relaxes only the MP4 muxer's willingness to write the `dvvC` box.

Not addressed here (candidate follow-up): the reporter's suggested integration test that inspects a generated MP4 for `dvh1`/`hvcC`/`dvvC` boxes, which needs a real DV sample fixture; and the stale `#613` golden-fixture failure noted above.

Part of #609.

### AI Disclosure
- Tool(s): Claude Code
- Model(s): claude-fable-5, claude-opus-5
- Involvement: fully AI-generated (diagnosis, implementation, tests, PR text) under maintainer direction
- Adversarial review: reviewed the diff against the issue evidence before submission. Findings addressed during review: the initial DPR test asserted the wrong resolution bucket (fixed the test, not the code); a doc line exceeded the file's wrap width (rewrapped); verified no other test or caller still referenced the removed single-mime probe field or asserted the old `dvhe` tag; confirmed the flat `hdr` boolean has no remaining gating consumers in the player; confirmed `-strict unofficial` cannot leak into the legacy/strip/plain remux paths via the existing arg tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved HDR10 and Dolby Vision capability detection across supported video formats and display environments.
  * Added device-pixel-ratio-aware resolution detection for more accurate playback decisions.
  * Added clearer subtitle playback errors when subtitle conversion is unavailable.
* **Bug Fixes**
  * Improved Dolby Vision compatibility and HDR metadata handling when preserving or removing HDR formats.
  * Added more reliable capability re-checking when decoder or display conditions change.
  * Added informative notifications when subtitle changes cannot be applied.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->