### PR TITLE
perf(literaryworks): match candidates via UNION branches instead of cross-table OR

### DIFF
--- a/internal/literaryworks/match_candidates_test.go
+++ b/internal/literaryworks/match_candidates_test.go
@@ -1,0 +1,211 @@
+package literaryworks
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/jackc/pgx/v5/pgxpool"
+)
+
+// The candidate lookup fans out across three independent match signals (title,
+// provider IDs, series position). These tests pin the result semantics so the
+// query shape can change underneath them without altering what comes back.
+
+func seedCandidateFixture(t *testing.T, pool *pgxpool.Pool) (folderID int, cleanup func()) {
+	t.Helper()
+	ctx := context.Background()
+	folderID = seedLiteraryFolder(t, pool)
+	cleanup = func() {
+		_, _ = pool.Exec(ctx, `DELETE FROM media_items WHERE content_id LIKE 'cand-%'`)
+		_, _ = pool.Exec(ctx, `DELETE FROM media_folders WHERE id = $1`, folderID)
+	}
+	t.Cleanup(cleanup)
+	return folderID, cleanup
+}
+
+func seedSeries(t *testing.T, pool *pgxpool.Pool, table, contentID, seriesName string, index float64) {
+	t.Helper()
+	if _, err := pool.Exec(context.Background(), fmt.Sprintf(`
+		INSERT INTO %s (content_id, series_name, series_index)
+		VALUES ($1, $2, $3)
+	`, table), contentID, seriesName, index); err != nil {
+		t.Fatalf("seed %s for %s: %v", table, contentID, err)
+	}
+}
+
+func TestListMatchCandidateIDsMatchesOppositeFormatByTitle(t *testing.T) {
+	pool := newLiteraryWorksTestPool(t)
+	folderID, _ := seedCandidateFixture(t, pool)
+	repo := NewRepository(pool)
+
+	seedLiteraryMediaItem(t, pool, "cand-src", FormatEbook, "Golden Margins", folderID)
+	seedLiteraryMediaItem(t, pool, "cand-hit", FormatAudiobook, "golden margins", folderID)
+	seedLiteraryMediaItem(t, pool, "cand-miss", FormatAudiobook, "Different Book", folderID)
+
+	ids, err := repo.listMatchCandidateIDs(context.Background(), MatchItem{
+		ContentID: "cand-src",
+		Type:      FormatEbook,
+		Title:     "Golden Margins",
+	}, 20)
+	if err != nil {
+		t.Fatalf("listMatchCandidateIDs: %v", err)
+	}
+
+	if len(ids) != 1 || ids[0] != "cand-hit" {
+		t.Fatalf("ids = %v, want [cand-hit] (case-insensitive title match, opposite format only)", ids)
+	}
+}
+
+func TestListMatchCandidateIDsMatchesBySeriesPosition(t *testing.T) {
+	pool := newLiteraryWorksTestPool(t)
+	folderID, _ := seedCandidateFixture(t, pool)
+	repo := NewRepository(pool)
+
+	seedLiteraryMediaItem(t, pool, "cand-src", FormatEbook, "Book One Title", folderID)
+	seedLiteraryMediaItem(t, pool, "cand-hit", FormatAudiobook, "Totally Other Title", folderID)
+	seedSeries(t, pool, "audiobook_series", "cand-hit", "Vaz", 1)
+
+	index := 1.0
+	ids, err := repo.listMatchCandidateIDs(context.Background(), MatchItem{
+		ContentID:   "cand-src",
+		Type:        FormatEbook,
+		Title:       "Book One Title",
+		SeriesName:  "vaz",
+		SeriesIndex: &index,
+	}, 20)
+	if err != nil {
+		t.Fatalf("listMatchCandidateIDs: %v", err)
+	}
+
+	if len(ids) != 1 || ids[0] != "cand-hit" {
+		t.Fatalf("ids = %v, want [cand-hit] matched on series despite differing titles", ids)
+	}
+}
+
+func TestListMatchCandidateIDsExcludesIgnoredDecisions(t *testing.T) {
+	pool := newLiteraryWorksTestPool(t)
+	folderID, _ := seedCandidateFixture(t, pool)
+	repo := NewRepository(pool)
+	ctx := context.Background()
+
+	seedLiteraryMediaItem(t, pool, "cand-src", FormatEbook, "Golden Margins", folderID)
+	seedLiteraryMediaItem(t, pool, "cand-hit", FormatAudiobook, "Golden Margins", folderID)
+	if _, err := pool.Exec(ctx, `
+		INSERT INTO literary_work_match_decisions (source_content_id, target_content_id, decision)
+		VALUES ('cand-src', 'cand-hit', 'ignored')
+	`); err != nil {
+		t.Fatalf("seed ignored decision: %v", err)
+	}
+
+	ids, err := repo.listMatchCandidateIDs(ctx, MatchItem{
+		ContentID: "cand-src",
+		Type:      FormatEbook,
+		Title:     "Golden Margins",
+	}, 20)
+	if err != nil {
+		t.Fatalf("listMatchCandidateIDs: %v", err)
+	}
+
+	if len(ids) != 0 {
+		t.Fatalf("ids = %v, want empty: an ignored decision must suppress the candidate", ids)
+	}
+}
+
+// TestMatchCandidateQueryUsesTitleIndex is the performance contract.
+//
+// The match signals are OR-ed together, but they live on different tables, so
+// PostgreSQL cannot combine them into a bitmap OR: it falls back to walking
+// every opposite-format book and applying the OR as a post-filter. On a real
+// library that is ~434k rows per call. The query must instead be shaped so each
+// signal rides its own index -- idx_media_items_books_title_lower for the title
+// branch -- which the plan proves by naming it.
+func TestMatchCandidateQueryUsesTitleIndex(t *testing.T) {
+	pool := newLiteraryWorksTestPool(t)
+	folderID, _ := seedCandidateFixture(t, pool)
+	ctx := context.Background()
+
+	// Enough rows that a sequential scan is never the planner's cheapest option.
+	if _, err := pool.Exec(ctx, `
+		INSERT INTO media_items (content_id, type, title, genres)
+		SELECT 'cand-bulk-' || g, 'audiobook', 'Bulk Title ' || g, '{}'::text[]
+		FROM generate_series(1, 30000) g
+	`); err != nil {
+		t.Fatalf("seed bulk audiobooks: %v", err)
+	}
+	if _, err := pool.Exec(ctx, `
+		INSERT INTO media_item_libraries (content_id, media_folder_id)
+		SELECT 'cand-bulk-' || g, $1 FROM generate_series(1, 30000) g
+	`, folderID); err != nil {
+		t.Fatalf("seed bulk libraries: %v", err)
+	}
+	if _, err := pool.Exec(ctx, `ANALYZE media_items`); err != nil {
+		t.Fatalf("analyze: %v", err)
+	}
+
+	index := 1.0
+	sql, args := buildMatchCandidateQuery(MatchItem{
+		ContentID:   "cand-src",
+		Type:        FormatEbook,
+		Title:       "Bulk Title 17",
+		SeriesName:  "Some Series",
+		SeriesIndex: &index,
+	}, 20)
+
+	rows, err := pool.Query(ctx, "EXPLAIN "+sql, args...)
+	if err != nil {
+		t.Fatalf("explain candidate query: %v", err)
+	}
+	defer rows.Close()
+	var plan strings.Builder
+	for rows.Next() {
+		var line string
+		if err := rows.Scan(&line); err != nil {
+			t.Fatalf("scan plan line: %v", err)
+		}
+		plan.WriteString(line)
+		plan.WriteString("\n")
+	}
+	if err := rows.Err(); err != nil {
+		t.Fatalf("read plan: %v", err)
+	}
+
+	if !strings.Contains(plan.String(), "idx_media_items_books_title_lower") {
+		t.Fatalf("title branch does not use idx_media_items_books_title_lower; plan was:\n%s", plan.String())
+	}
+}
+
+func TestListMatchCandidateIDsOrdersByTitleAndHonoursLimit(t *testing.T) {
+	pool := newLiteraryWorksTestPool(t)
+	folderID, _ := seedCandidateFixture(t, pool)
+	repo := NewRepository(pool)
+
+	seedLiteraryMediaItem(t, pool, "cand-src", FormatEbook, "Shared Title", folderID)
+	for _, id := range []string{"cand-c", "cand-a", "cand-b"} {
+		seedLiteraryMediaItem(t, pool, id, FormatAudiobook, "Shared Title", folderID)
+	}
+	// Distinct series rows must not multiply a candidate into duplicate IDs.
+	seedSeries(t, pool, "audiobook_series", "cand-a", "Shared Series", 1)
+
+	index := 1.0
+	ids, err := repo.listMatchCandidateIDs(context.Background(), MatchItem{
+		ContentID:   "cand-src",
+		Type:        FormatEbook,
+		Title:       "Shared Title",
+		SeriesName:  "Shared Series",
+		SeriesIndex: &index,
+	}, 2)
+	if err != nil {
+		t.Fatalf("listMatchCandidateIDs: %v", err)
+	}
+
+	if len(ids) != 2 {
+		t.Fatalf("ids = %v, want exactly 2 rows for limit=2", ids)
+	}
+	for _, id := range ids {
+		if strings.Contains(id, "src") {
+			t.Fatalf("ids = %v, must never contain the source item itself", ids)
+		}
+	}
+}

--- a/internal/literaryworks/match_candidates_test.go
+++ b/internal/literaryworks/match_candidates_test.go
@@ -3,6 +3,7 @@ package literaryworks
 import (
 	"context"
 	"fmt"
+	"slices"
 	"strings"
 	"testing"
 
@@ -81,6 +82,70 @@ func TestListMatchCandidateIDsMatchesBySeriesPosition(t *testing.T) {
 
 	if len(ids) != 1 || ids[0] != "cand-hit" {
 		t.Fatalf("ids = %v, want [cand-hit] matched on series despite differing titles", ids)
+	}
+}
+
+func seedProviderID(t *testing.T, pool *pgxpool.Pool, contentID, provider, providerID, itemType string) {
+	t.Helper()
+	if _, err := pool.Exec(context.Background(), `
+		INSERT INTO media_item_provider_ids (content_id, provider, provider_id, item_type)
+		VALUES ($1, $2, $3, $4)
+	`, contentID, provider, providerID, itemType); err != nil {
+		t.Fatalf("seed provider id for %s: %v", contentID, err)
+	}
+}
+
+func TestListMatchCandidateIDsMatchesBySharedProviderID(t *testing.T) {
+	pool := newLiteraryWorksTestPool(t)
+	folderID, _ := seedCandidateFixture(t, pool)
+	repo := NewRepository(pool)
+
+	// Titles differ and neither side has series data, so a shared provider ID
+	// is the only signal that can produce a match.
+	seedLiteraryMediaItem(t, pool, "cand-src", FormatEbook, "Golden Margins", folderID)
+	seedLiteraryMediaItem(t, pool, "cand-hit", FormatAudiobook, "Totally Unrelated Title", folderID)
+	seedLiteraryMediaItem(t, pool, "cand-miss", FormatAudiobook, "Another Unrelated Title", folderID)
+	seedProviderID(t, pool, "cand-hit", "openlibrary", "OL1618W", FormatAudiobook)
+
+	ids, err := repo.listMatchCandidateIDs(context.Background(), MatchItem{
+		ContentID:   "cand-src",
+		Type:        FormatEbook,
+		Title:       "Golden Margins",
+		ExternalIDs: map[string]string{"openlibrary": "OL1618W"},
+	}, 20)
+	if err != nil {
+		t.Fatalf("listMatchCandidateIDs: %v", err)
+	}
+
+	want := []string{"cand-hit"}
+	if !slices.Equal(ids, want) {
+		t.Fatalf("ids = %v, want %v (provider-ID branch is the only possible match)", ids, want)
+	}
+}
+
+func TestListMatchCandidateIDsIgnoresASINProviderID(t *testing.T) {
+	pool := newLiteraryWorksTestPool(t)
+	folderID, _ := seedCandidateFixture(t, pool)
+	repo := NewRepository(pool)
+
+	// ASIN identifies an edition rather than a work, so it must never be
+	// promoted into a candidate branch.
+	seedLiteraryMediaItem(t, pool, "cand-src", FormatEbook, "Golden Margins", folderID)
+	seedLiteraryMediaItem(t, pool, "cand-hit", FormatAudiobook, "Totally Unrelated Title", folderID)
+	seedProviderID(t, pool, "cand-hit", "asin", "B0FIXTURE1", FormatAudiobook)
+
+	ids, err := repo.listMatchCandidateIDs(context.Background(), MatchItem{
+		ContentID:   "cand-src",
+		Type:        FormatEbook,
+		Title:       "Golden Margins",
+		ExternalIDs: map[string]string{"asin": "B0FIXTURE1"},
+	}, 20)
+	if err != nil {
+		t.Fatalf("listMatchCandidateIDs: %v", err)
+	}
+
+	if len(ids) != 0 {
+		t.Fatalf("ids = %v, want empty: a shared ASIN must not match on its own", ids)
 	}
 }
 
@@ -200,12 +265,11 @@ func TestListMatchCandidateIDsOrdersByTitleAndHonoursLimit(t *testing.T) {
 		t.Fatalf("listMatchCandidateIDs: %v", err)
 	}
 
-	if len(ids) != 2 {
-		t.Fatalf("ids = %v, want exactly 2 rows for limit=2", ids)
-	}
-	for _, id := range ids {
-		if strings.Contains(id, "src") {
-			t.Fatalf("ids = %v, must never contain the source item itself", ids)
-		}
+	// Titles tie, so content_id breaks the tie: cand-a, cand-b, cand-c. The
+	// limit keeps the first two, and cand-a appears once despite also matching
+	// the series branch.
+	want := []string{"cand-a", "cand-b"}
+	if !slices.Equal(ids, want) {
+		t.Fatalf("ids = %v, want %v", ids, want)
 	}
 }

--- a/internal/literaryworks/repository.go
+++ b/internal/literaryworks/repository.go
@@ -198,59 +198,8 @@ func (r *Repository) listMatchCandidateIDs(ctx context.Context, source MatchItem
 	if r == nil || r.pool == nil {
 		return nil, fmt.Errorf("literary works repository requires a database pool")
 	}
-	// Candidates are the opposite format of the source; match their own series table.
-	seriesTable := "ebook_series"
-	if source.Type == "ebook" {
-		seriesTable = "audiobook_series"
-	}
-	args := []any{source.ContentID, source.Type}
-	matchFilters := make([]string, 0, 3)
-	if strings.TrimSpace(source.Title) != "" {
-		args = append(args, source.Title)
-		matchFilters = append(matchFilters, fmt.Sprintf("LOWER(mi.title) = LOWER($%d)", len(args)))
-	}
-	for provider, providerID := range source.ExternalIDs {
-		if provider == "" || provider == "asin" || providerID == "" {
-			continue
-		}
-		args = append(args, provider, providerID)
-		matchFilters = append(matchFilters, fmt.Sprintf(
-			"EXISTS (SELECT 1 FROM media_item_provider_ids mip WHERE mip.content_id = mi.content_id AND mip.provider = $%d AND mip.provider_id = $%d)",
-			len(args)-1,
-			len(args),
-		))
-	}
-	if strings.TrimSpace(source.SeriesName) != "" && source.SeriesIndex != nil {
-		args = append(args, source.SeriesName, *source.SeriesIndex)
-		matchFilters = append(matchFilters, fmt.Sprintf(
-			"EXISTS (SELECT 1 FROM %s bs WHERE bs.content_id = mi.content_id AND LOWER(bs.series_name) = LOWER($%d) AND bs.series_index = $%d)",
-			seriesTable,
-			len(args)-1,
-			len(args),
-		))
-	}
-	matchWhere := ""
-	if len(matchFilters) > 0 {
-		matchWhere = " AND (" + strings.Join(matchFilters, " OR ") + ")"
-	}
-	args = append(args, limit)
-	rows, err := r.pool.Query(ctx, `
-		SELECT mi.content_id
-		FROM media_items mi
-		WHERE mi.content_id <> $1
-		  AND mi.type IN ('ebook', 'audiobook')
-		  AND mi.type <> $2
-		  AND NOT EXISTS (
-			SELECT 1 FROM literary_work_match_decisions d
-			WHERE d.decision = 'ignored'
-			  AND (
-				(d.source_content_id = $1 AND d.target_content_id = mi.content_id)
-				OR (d.source_content_id = mi.content_id AND d.target_content_id = $1)
-			  )
-		  )`+matchWhere+`
-		ORDER BY mi.title ASC, mi.content_id ASC
-		LIMIT $`+fmt.Sprint(len(args))+`
-	`, args...)
+	sql, args := buildMatchCandidateQuery(source, limit)
+	rows, err := r.pool.Query(ctx, sql, args...)
 	if err != nil {
 		return nil, err
 	}
@@ -264,6 +213,77 @@ func (r *Repository) listMatchCandidateIDs(ctx context.Context, source MatchItem
 		ids = append(ids, id)
 	}
 	return ids, rows.Err()
+}
+
+// buildMatchCandidateQuery renders the candidate lookup and its arguments.
+func buildMatchCandidateQuery(source MatchItem, limit int) (string, []any) {
+	// Candidates are the opposite format of the source; match their own series table.
+	seriesTable := "ebook_series"
+	if source.Type == "ebook" {
+		seriesTable = "audiobook_series"
+	}
+	args := []any{source.ContentID, source.Type}
+	// Each match signal becomes its own UNION branch so it can ride its own
+	// index. OR-ing them inside a single WHERE spans three tables, which
+	// PostgreSQL cannot fold into a bitmap OR: it degrades to walking every
+	// opposite-format book and applying the OR as a post-filter.
+	branches := make([]string, 0, 3)
+	if strings.TrimSpace(source.Title) != "" {
+		args = append(args, source.Title)
+		// The type predicate is repeated here so the branch matches the partial
+		// index idx_media_items_books_title_lower.
+		branches = append(branches, fmt.Sprintf(`
+			SELECT t.content_id FROM media_items t
+			WHERE LOWER(t.title) = LOWER($%d)
+			  AND t.type IN ('ebook', 'audiobook')`, len(args)))
+	}
+	for provider, providerID := range source.ExternalIDs {
+		if provider == "" || provider == "asin" || providerID == "" {
+			continue
+		}
+		args = append(args, provider, providerID)
+		branches = append(branches, fmt.Sprintf(`
+			SELECT mip.content_id FROM media_item_provider_ids mip
+			WHERE mip.provider = $%d AND mip.provider_id = $%d`,
+			len(args)-1,
+			len(args),
+		))
+	}
+	if strings.TrimSpace(source.SeriesName) != "" && source.SeriesIndex != nil {
+		args = append(args, source.SeriesName, *source.SeriesIndex)
+		branches = append(branches, fmt.Sprintf(`
+			SELECT bs.content_id FROM %s bs
+			WHERE LOWER(bs.series_name) = LOWER($%d) AND bs.series_index = $%d`,
+			seriesTable,
+			len(args)-1,
+			len(args),
+		))
+	}
+	matchWhere := ""
+	if len(branches) > 0 {
+		matchWhere = `
+		  AND mi.content_id IN (` + strings.Join(branches, `
+			UNION`) + `
+		  )`
+	}
+	args = append(args, limit)
+	return `
+		SELECT mi.content_id
+		FROM media_items mi
+		WHERE mi.content_id <> $1
+		  AND mi.type IN ('ebook', 'audiobook')
+		  AND mi.type <> $2
+		  AND NOT EXISTS (
+			SELECT 1 FROM literary_work_match_decisions d
+			WHERE d.decision = 'ignored'
+			  AND (
+				(d.source_content_id = $1 AND d.target_content_id = mi.content_id)
+				OR (d.source_content_id = mi.content_id AND d.target_content_id = $1)
+			  )
+		  )` + matchWhere + `
+		ORDER BY mi.title ASC, mi.content_id ASC
+		LIMIT $` + fmt.Sprint(len(args)) + `
+	`, args
 }
 
 func (r *Repository) queryMatchItems(ctx context.Context, suffix string, args ...any) (pgx.Rows, error) {


### PR DESCRIPTION
## Problem

`listMatchCandidateIDs` OR-s its three match signals into a single `WHERE`:

```go
matchWhere = " AND (" + strings.Join(matchFilters, " OR ") + ")"
```

Those predicates live on three different tables (`media_items.title`, `media_item_provider_ids`, `{ebook,audiobook}_series`). PostgreSQL can bitmap-OR predicates on one relation, but not across relations — so it discards the partial index `idx_media_items_books_title_lower` and walks every opposite-format book, applying the OR as a post-filter.

Plan on a real 434k-book library (`EXPLAIN (ANALYZE, BUFFERS)`):

```
Index Scan using idx_media_items_type_year on media_items mi (actual rows=1.00 loops=1)
  Filter: (... AND ((lower(title) = 'golden margins') OR (ANY (content_id = (hashed SubPlan 2).col1))))
  Rows Removed by Filter: 434175
  Buffers: shared hit=346929
Execution Time: 578.718 ms
```

This matters because `AutoLinkContent` calls it once per **unlinked** book on every rescan. Its cheap guard only skips books already linked to a work. On my library 412,434 of 434,176 books (95%) are unlinked — most books exist in only one format, so they never link, and they are re-scanned in full every pass. That is ~65 CPU-hours per pass, indefinitely.

## Approach

Each match signal becomes its own `UNION` branch inside `mi.content_id IN (...)`, so each rides its own index. The title branch repeats `type IN ('ebook','audiobook')` so it matches the *partial* index.

No schema change and no new index — every index this needs already exists.

Semantics are unchanged: same result set, same `ORDER BY title, content_id`, same limit, same `ignored`-decision anti-join. `EXISTS (... x.content_id = mi.content_id ...)` becomes a `content_id` projection inside `IN (...)`, which is equivalent; `UNION` dedupes, and `IN` cannot multiply rows.

## Results

Same query, same data, before vs after:

| | before | after |
|---|---:|---:|
| Execution time | 578.718 ms | **0.135 ms** |
| Shared buffers hit | 346,932 | **11** |
| Rows removed by filter | 434,175 | 0 |
| Indexes used | `idx_media_items_type_year` | `idx_media_items_books_title_lower`, `audiobook_series_name_lower`, pkey |

A full pass over 412,434 unlinked books goes from ~65.5 CPU-hours to ~56 seconds.

## How it was tested

New `internal/literaryworks/match_candidates_test.go`:

- `TestMatchCandidateQueryUsesTitleIndex` — seeds 30k books, `ANALYZE`s, and asserts the plan names `idx_media_items_books_title_lower`. **Written first and watched fail** against the old query, where the plan showed `Seq Scan on media_items` with the OR as a post-filter.
- Four semantic tests written *before* the change and passing against the old code, pinning behavior across the rewrite: opposite-format case-insensitive title match, series-position match despite differing titles, `ignored`-decision suppression, and ordering/limit with no duplicate rows from multiple series rows.

Verification run locally against a `pgvector/pgvector:pg17` container with this repo's migrations applied:

- `go test ./internal/literaryworks` — 16/16 pass
- `gofmt -l` — clean
- `go vet` — clean
- `golangci-lint run ./internal/literaryworks/...` — **3 issues, identical to the pre-change baseline on the same commit.** No regression.

Two honest caveats:

1. **I did not run the app end-to-end.** I verified the query plan and timings directly against a real 434k-book production database, and ran the package tests, but I did not spin up the UI and click through book matching.
2. **`go build ./...` fails on `web/embed.go: pattern all:dist: no matching files found`** — this reproduces identically on unmodified `main` without a frontend build, so it is pre-existing and unrelated.

Also note: this repo's CI does not set `SILO_TEST_DATABASE_URL`, so these tests (like the existing DB tests) **skip in CI**. They only run against a local database.

## Watch out for

- `source.ExternalIDs` is a Go map, so provider branches are emitted in **non-deterministic order**. That varies the SQL text between calls, which fragments `pg_stat_statements` and the prepared-statement cache. This is pre-existing, and I deliberately left it out to keep one thing per MR — happy to send a follow-up that sorts the providers.
- This does not address the missing negative cache. Unmatched books are still re-scanned every pass; they are just ~4,300× cheaper now. A "no match found" marker would remove the work entirely, but that is a behavior change worth its own discussion.

### AI Disclosure
- **Tool(s):** Claude Code
- **Model(s):** `claude-opus-5[1m]` (Opus 5, 1M context)
- **Involvement:** fully AI-generated, human-directed and human-reviewed
- **Adversarial review:** The self-review found one real defect: the new test file introduced 9 `"ebook"` string literals, which pushed `goconst` over threshold and added a 4th lint issue versus baseline — a lint regression. Resolved by switching the tests to the existing `FormatEbook`/`FormatAudiobook` constants, matching the convention already used in `matcher_test.go`, `service_test.go`, and `repository_test.go`; lint then matched baseline exactly at 3 pre-existing issues. The review also checked the `EXISTS`→`IN` rewrite for NULL semantics (`content_id` is `NOT NULL` in all three source tables, so `IN` and `EXISTS` behave identically here) and for row multiplication (`UNION` dedupes; the ordering/limit test seeds a candidate with a series row specifically to catch duplicates). Two earlier hypotheses were investigated and **disproved** before landing on this one: table bloat/autovacuum starvation (`episodes` is correctly sized; autovacuum has legitimately not hit its threshold) and a missing index (all required indexes already exist). Both were discarded on evidence rather than carried into the diff.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved literary-work matching across formats using titles, provider IDs, and series information.
  * Matching now handles case differences and series positions more reliably.
  * Excludes ignored decisions, duplicate results, and items from the same source.
  * Preserves deterministic title ordering and result limits.

* **Tests**
  * Added comprehensive coverage for matching behavior, ordering, limits, duplicate prevention, and database query performance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->