### PR TITLE
chore(playback): regenerate protocol_v3 fixtures for output_change_v1

### DIFF
--- a/docs/design/schemas/playback-v3/v3/fixtures/valid/capability_response.json
+++ b/docs/design/schemas/playback-v3/v3/fixtures/valid/capability_response.json
@@ -10,6 +10,7 @@
     "playback_route_diagnostics",
     "device_quirks_v1",
     "seek_reanchor_v1",
+    "output_change_v1",
     "direct_stream_resume_v1",
     "plan_source_duration_v1"
   ],

--- a/docs/design/schemas/playback-v3/v3/fixtures/valid/decision_response.json
+++ b/docs/design/schemas/playback-v3/v3/fixtures/valid/decision_response.json
@@ -7,6 +7,7 @@
     "playback_route_diagnostics",
     "device_quirks_v1",
     "seek_reanchor_v1",
+    "output_change_v1",
     "direct_stream_resume_v1",
     "plan_source_duration_v1"
   ],

--- a/internal/playback/testdata/protocol_v3/capability_response.json
+++ b/internal/playback/testdata/protocol_v3/capability_response.json
@@ -10,6 +10,7 @@
     "playback_route_diagnostics",
     "device_quirks_v1",
     "seek_reanchor_v1",
+    "output_change_v1",
     "direct_stream_resume_v1",
     "plan_source_duration_v1"
   ],

--- a/internal/playback/testdata/protocol_v3/conformance_matrix.json
+++ b/internal/playback/testdata/protocol_v3/conformance_matrix.json
@@ -5406,6 +5406,7 @@
             "playback_route_diagnostics",
             "device_quirks_v1",
             "seek_reanchor_v1",
+            "output_change_v1",
             "direct_stream_resume_v1",
             "plan_source_duration_v1"
           ],

--- a/internal/playback/testdata/protocol_v3/decision_response.json
+++ b/internal/playback/testdata/protocol_v3/decision_response.json
@@ -7,6 +7,7 @@
     "playback_route_diagnostics",
     "device_quirks_v1",
     "seek_reanchor_v1",
+    "output_change_v1",
     "direct_stream_resume_v1",
     "plan_source_duration_v1"
   ],


### PR DESCRIPTION
## Problem

`make verify-playback-fixtures` currently fails on `main`, which means it fails on **every open pull request** regardless of what that PR changes.

The `output_change_v1` capability feature was added to the playback feature list without regenerating the checked-in `protocol_v3` fixtures, so the committed fixtures no longer match generator output:

```
+            "output_change_v1",
::error::internal/playback/testdata/protocol_v3 is stale; run make playback-fixtures
```

Reproduced on a clean detached checkout of `ee9356aa` with no other changes applied.

## Fix

Ran `make playback-fixtures`.

The result is **5 insertions, 0 deletions** — the same missing feature string in each affected fixture, and nothing else:

```
docs/design/schemas/playback-v3/v3/fixtures/valid/capability_response.json | 1 +
docs/design/schemas/playback-v3/v3/fixtures/valid/decision_response.json   | 1 +
internal/playback/testdata/protocol_v3/capability_response.json            | 1 +
internal/playback/testdata/protocol_v3/conformance_matrix.json             | 1 +
internal/playback/testdata/protocol_v3/decision_response.json              | 1 +
```

Note the generator also updates two fixtures under `docs/design/schemas/playback-v3/` that the CI job does not check — those were stale for the same reason.

## Verification

`make verify-playback-fixtures` → exit `0`, `playback fixtures are current`.

No hand-editing: every changed byte is generator output.

## Watch out for

This is generated content only — no behavior change. If `output_change_v1` was added but is not yet meant to be advertised in the capability response, then the correct fix is the opposite one (remove it from the feature list rather than bless it into the fixtures), and this PR should be closed in favour of that. I do not have the context to know which was intended, so I regenerated to match the code as it stands on `main`.

Found while working on #621, whose CI failure is caused by this rather than by that PR's own changes.

### AI Disclosure
- **Tool(s):** Claude Code
- **Model(s):** `claude-opus-5[1m]` (Opus 5, 1M context)
- **Involvement:** fully AI-generated, human-directed and human-reviewed
- **Adversarial review:** The diff is entirely tool-generated output, so review focused on whether it was *only* that. Verified by diffing every changed line: 5 additions, 0 deletions, all the identical `output_change_v1` string — no reordering, whitespace churn, or unrelated regeneration drift. Also confirmed the failure reproduces on unmodified `ee9356aa`, ruling out any interaction with #621. The one judgement call worth flagging is noted above: regenerating assumes the feature *should* be advertised; if the intent was otherwise, the fix belongs in the feature list instead.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for advertising the `output_change_v1` capability in playback protocol v3 capability and decision responses.
* **Tests**
  * Updated playback protocol fixtures and conformance scenarios to include the new server feature.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->