### PR TITLE
fix(web): make sidebar logo link to home

### DIFF
--- a/web/src/components/AppSidebar.tsx
+++ b/web/src/components/AppSidebar.tsx
@@ -476,7 +476,12 @@ export default function AppSidebar({ onNavigate, collapsed = false }: AppSidebar
       <div className="bg-sidebar/88 sidebar-inner flex h-full w-[260px] flex-col backdrop-blur-2xl">
         {/* Logo — the wordmark and the mark cross-fade in place. Swapping the
           variant outright would pop at the very start of the collapse. */}
-        <div className="sidebar-logo relative flex h-24 items-center">
+        <ViewTransitionLink
+          to="/"
+          onClick={onNavigate}
+          aria-label="Go to home"
+          className="sidebar-logo focus-visible:ring-ring/50 relative flex h-24 items-center transition-opacity hover:opacity-85 focus-visible:ring-[3px] focus-visible:outline-none"
+        >
           <span
             aria-hidden={!showLabels}
             className={`sidebar-fade absolute left-5 ${showLabels ? "opacity-100" : "opacity-0"}`}
@@ -489,7 +494,7 @@ export default function AppSidebar({ onNavigate, collapsed = false }: AppSidebar
           >
             <SiloBrand variant="mark" className="h-9 w-9" />
           </span>
-        </div>
+        </ViewTransitionLink>
 
         {/* Main nav */}
         <nav


### PR DESCRIPTION
## Problem
Part of #NNN

The sidebar logo was not interactive, so users could not use it to return to the home page.

## Approach
Wrap the sidebar logo in a `ViewTransitionLink` targeting `/`, preserving navigation callbacks and adding an accessible label plus visible hover and keyboard-focus states.

## Testing
Not run; this change was not accompanied by test output.

### AI Disclosure
- Tool(s): Codex
- Model(s): GPT-5
- Involvement: Generated the change request content from the commit and diff.
- Adversarial review: Not run.

## Checklist
- [ ] I ran an adversarial AI review of the diff and summarized findings above.
- [ ] I ran the repo verify commands: `make lint`, `cd web && pnpm run lint`, `cd web && pnpm run format:check`, and relevant `go test ./...`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit 83a6001fb0cce169263b0292770f65b592f3da6e. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->