### PR TITLE
test: repair and isolate the DB-backed tests CI never runs

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -100,8 +100,15 @@ actually run them:
 
 ```sh
 docker compose up -d postgres
-go run ./cmd/silo/ --migrate-only            # applies migrations
-SILO_TEST_DATABASE_URL="$DATABASE_URL" go test ./...
+go run ./cmd/silo/ --migrate-only    # reads DATABASE_URL from .env
+
+# .env is read by the server, not by your shell, so name the database again
+# here. This is the URL the Local Development step above wrote into .env.
+export SILO_TEST_DATABASE_URL='postgres://silo:silo@localhost:5432/silo?sslmode=disable'
+go test ./...
+
+# Confirm they really ran rather than skipped — this should print nothing:
+go test ./... -count=1 -v 2>&1 | grep 'SILO_TEST_DATABASE_URL is not set'
 ```
 
 The database must be `pgvector/pgvector:pg18` or equivalent — the migrations

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -84,12 +84,31 @@ database URL should be read from a non-default env file.
 ## Running Tests
 
 ```sh
-# Go tests (uses testcontainers — Docker must be running)
+# Go tests
 go test ./...
 
 # Frontend tests
 cd web && pnpm test
 ```
+
+### Database-backed Go tests
+
+Tests that need PostgreSQL read `SILO_TEST_DATABASE_URL` and **skip themselves when
+it is unset**. `go test` prints nothing for a skip, so a run without it is green
+while several hundred tests never execute — point it at a migrated database to
+actually run them:
+
+```sh
+docker compose up -d postgres
+go run ./cmd/silo/ --migrate-only            # applies migrations
+SILO_TEST_DATABASE_URL="$DATABASE_URL" go test ./...
+```
+
+The database must be `pgvector/pgvector:pg18` or equivalent — the migrations
+`CREATE EXTENSION vector`, `citext` and `pg_trgm`, and stock `postgres` images
+ship only the last two. A few tests provision a throwaway database of their own
+on the same server (see `internal/dbtest`); they drop it on exit, but a test
+killed with SIGKILL can leave one behind.
 
 ## Linting
 

--- a/internal/api/handlers/notifications_apple_display_test.go
+++ b/internal/api/handlers/notifications_apple_display_test.go
@@ -3,11 +3,13 @@ package handlers
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"os"
 	"strings"
 	"testing"
+	"time"
 
 	apimw "github.com/Silo-Server/silo-server/internal/api/middleware"
 	"github.com/Silo-Server/silo-server/internal/notifications"
@@ -22,70 +24,64 @@ func TestHandleApplePushDisplayDB(t *testing.T) {
 	}
 
 	ctx := context.Background()
-	config, err := pgxpool.ParseConfig(dsn)
-	if err != nil {
-		t.Fatalf("parse db config: %v", err)
-	}
-	config.MaxConns = 1
-	pool, err := pgxpool.NewWithConfig(ctx, config)
+	pool, err := pgxpool.New(ctx, dsn)
 	if err != nil {
 		t.Fatalf("connect db: %v", err)
 	}
 	t.Cleanup(pool.Close)
 
+	suffix := fmt.Sprintf("%d", time.Now().UnixNano())
+	id := func(name string) string { return name + "-" + suffix }
+	profileID, seriesID := id("profile"), id("series")
+	episodeID, deliveryID, eventID := id("episode"), id("delivery"), id("event")
+
+	t.Cleanup(func() {
+		cleanupCtx := context.Background()
+		// Deliveries first: their release_event_id is ON DELETE SET NULL, so
+		// dropping the event first would orphan rather than remove them.
+		// episodes cascades from media_items.
+		for _, stmt := range []struct {
+			query string
+			arg   string
+		}{
+			{`DELETE FROM notification_deliveries WHERE profile_id = $1`, profileID},
+			{`DELETE FROM release_events WHERE id = $1`, eventID},
+			{`DELETE FROM media_items WHERE content_id = $1`, seriesID},
+		} {
+			if _, err := pool.Exec(cleanupCtx, stmt.query, stmt.arg); err != nil {
+				t.Errorf("cleanup %q: %v", stmt.query, err)
+			}
+		}
+	})
+
 	if _, err := pool.Exec(ctx, `
-		CREATE TEMP TABLE notification_deliveries (
-			id text PRIMARY KEY,
-			release_event_id text,
-			user_id integer NOT NULL,
-			profile_id text NOT NULL,
-			library_id integer,
-			series_id text,
-			episode_id text,
-			type text NOT NULL,
-			reason_flags jsonb NOT NULL,
-			status text NOT NULL DEFAULT 'delivered',
-			read_at timestamptz,
-			delivered_at timestamptz,
-			created_at timestamptz NOT NULL DEFAULT now()
-		);
-		CREATE TEMP TABLE episodes (
-			content_id text PRIMARY KEY,
-			title text,
-			season_number integer,
-			episode_number integer,
-			overview text
-		);
-		CREATE TEMP TABLE media_items (
-			content_id text PRIMARY KEY,
-			title text,
-			poster_path text,
-			poster_thumbhash text,
-			poster_source_path text,
-			type text,
-			year integer,
-			overview text,
-			genres text[],
-			content_rating text,
-			rating_imdb double precision,
-			rating_tmdb double precision,
-			imdb_id text,
-			tmdb_id text,
-			tvdb_id text
-		);
 		INSERT INTO media_items (content_id, title, type, genres)
-			VALUES ('series-1', 'Severance', 'series', ARRAY[]::text[]);
-		INSERT INTO episodes (content_id, title, season_number, episode_number)
-			VALUES ('episode-1', 'Hello, Ms. Cobel', 2, 1);
+		VALUES ($1, 'Severance', 'series', ARRAY[]::text[])`, seriesID); err != nil {
+		t.Fatalf("seed series: %v", err)
+	}
+	if _, err := pool.Exec(ctx, `
+		INSERT INTO episodes (content_id, series_id, title, season_number, episode_number)
+		VALUES ($1, $2, 'Hello, Ms. Cobel', 2, 1)`, episodeID, seriesID); err != nil {
+		t.Fatalf("seed episode: %v", err)
+	}
+	// release_events_kind_shape_check requires an episode event to carry the
+	// full series/episode identity, and release_events_ordinals_check requires
+	// episode_key to equal season*1000000 + episode.
+	if _, err := pool.Exec(ctx, `
+		INSERT INTO release_events (
+			id, library_id, available_at, dedupe_key,
+			kind, series_id, episode_id, season_number, episode_number, episode_key
+		) VALUES ($1, 7, now(), $1, 'episode', $2, $3, 2, 1, 2000001)`,
+		eventID, seriesID, episodeID); err != nil {
+		t.Fatalf("seed release event: %v", err)
+	}
+	if _, err := pool.Exec(ctx, `
 		INSERT INTO notification_deliveries (
 			id, release_event_id, user_id, profile_id, library_id, series_id, episode_id,
 			type, reason_flags, status
-		) VALUES (
-			'delivery-1', 'event-1', 42, 'profile-1', 7, 'series-1', 'episode-1',
-			'episode.available', '{"favorite":true}', 'delivered'
-		);
-	`); err != nil {
-		t.Fatalf("seed temp tables: %v", err)
+		) VALUES ($1, $2, 42, $3, 7, $4, $5, 'episode.available', '{"favorite":true}', 'delivered')`,
+		deliveryID, eventID, profileID, seriesID, episodeID); err != nil {
+		t.Fatalf("seed delivery: %v", err)
 	}
 
 	handler := NewNotificationsHandler(&notifications.System{
@@ -94,8 +90,8 @@ func TestHandleApplePushDisplayDB(t *testing.T) {
 	router := chi.NewRouter()
 	router.Get("/notifications/push/apple/display/{delivery_id}", handler.HandleApplePushDisplay)
 
-	req := httptest.NewRequest(http.MethodGet, "/notifications/push/apple/display/delivery-1", nil)
-	req = req.WithContext(apimw.SetProfileID(req.Context(), "profile-1"))
+	req := httptest.NewRequest(http.MethodGet, "/notifications/push/apple/display/"+deliveryID, nil)
+	req = req.WithContext(apimw.SetProfileID(req.Context(), profileID))
 	rr := httptest.NewRecorder()
 	router.ServeHTTP(rr, req)
 
@@ -109,16 +105,16 @@ func TestHandleApplePushDisplayDB(t *testing.T) {
 	if err := json.NewDecoder(rr.Body).Decode(&response); err != nil {
 		t.Fatalf("decode response: %v", err)
 	}
-	if response.DeliveryID != "delivery-1" ||
+	if response.DeliveryID != deliveryID ||
 		response.Title != "The latest episode of Severance S02E01 just dropped!" ||
 		response.Body != "Hello, Ms. Cobel" ||
-		response.ThreadID != "series:series-1" ||
+		response.ThreadID != "series:"+seriesID ||
 		response.Category != "episode_available" ||
-		response.URL != "/item/episode-1" {
+		response.URL != "/item/"+episodeID {
 		t.Fatalf("response = %+v", response)
 	}
 
-	req = httptest.NewRequest(http.MethodGet, "/notifications/push/apple/display/delivery-1", nil)
+	req = httptest.NewRequest(http.MethodGet, "/notifications/push/apple/display/"+deliveryID, nil)
 	req = req.WithContext(apimw.SetProfileID(req.Context(), "other-profile"))
 	rr = httptest.NewRecorder()
 	router.ServeHTTP(rr, req)

--- a/internal/auth/repository_access_group_test.go
+++ b/internal/auth/repository_access_group_test.go
@@ -245,14 +245,20 @@ func restoreAuthDefaultAccessGroup(t *testing.T, ctx context.Context, pool *pgxp
 	setAuthDefaultAccessGroup(t, ctx, pool, seedID)
 }
 
+// insertAuthAccessGroupTestUser seeds a row shaped like one UserRepository.Create
+// writes. email and password_hash are nullable in the schema but every
+// production create path populates them, and scanUser reads both into plain
+// strings — so omitting them here produced a row the repository cannot scan,
+// which is a fixture artifact rather than a defect this test is about.
 func insertAuthAccessGroupTestUser(t *testing.T, ctx context.Context, pool *pgxpool.Pool, suffix string) int {
 	t.Helper()
 	var id int
 	if err := pool.QueryRow(ctx, `
-		INSERT INTO users (username, role, enabled)
-		VALUES ($1, 'user', true)
+		INSERT INTO users (username, email, password_hash, role, enabled)
+		VALUES ($1, $2, 'x', 'user', true)
 		RETURNING id`,
 		"auth-access-group-test-"+suffix,
+		"auth-access-group-test-"+suffix+"@example.test",
 	).Scan(&id); err != nil {
 		t.Fatalf("insert user: %v", err)
 	}

--- a/internal/catalog/search_episode_db_test.go
+++ b/internal/catalog/search_episode_db_test.go
@@ -98,8 +98,14 @@ func TestEpisodeSearchPostgresAndDocumentSource(t *testing.T) {
 	if len(docs[0].LibraryIDs) != 1 || int(docs[0].LibraryIDs[0]) != folderID {
 		t.Fatalf("episode library ids = %v, want [%d]", docs[0].LibraryIDs, folderID)
 	}
-	if docs[0].Vectors != nil {
-		t.Fatalf("episode document unexpectedly has vectors: %#v", docs[0].Vectors)
+	// Episodes are keyword-only, but a userProvided embedder rejects any
+	// document that omits _vectors entirely and fails the whole indexing task
+	// with it, so an episode document opts out explicitly with a null vector
+	// rather than carrying no _vectors key at all.
+	vector, ok := docs[0].Vectors[DefaultMeilisearchEmbedder]
+	if len(docs[0].Vectors) != 1 || !ok || vector != nil {
+		t.Fatalf("episode document vectors = %#v, want an explicit %s null opt-out",
+			docs[0].Vectors, DefaultMeilisearchEmbedder)
 	}
 }
 

--- a/internal/database/migrate_downto_test.go
+++ b/internal/database/migrate_downto_test.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/jackc/pgx/v5/pgxpool"
 
+	"github.com/Silo-Server/silo-server/internal/dbtest"
 	"github.com/Silo-Server/silo-server/migrations"
 )
 
@@ -18,16 +19,7 @@ import (
 // --migrate-down-to — actually restores them, and that it reaches the Go
 // migrations the standalone goose CLI cannot see.
 func TestMigrateDownToRestoresLegacyDisplayPrefs(t *testing.T) {
-	dsn := os.Getenv("SILO_TEST_DATABASE_URL")
-	if dsn == "" {
-		t.Skip("SILO_TEST_DATABASE_URL is not set")
-	}
-	ctx := context.Background()
-	pool, err := pgxpool.New(ctx, dsn)
-	if err != nil {
-		t.Fatalf("connect: %v", err)
-	}
-	defer pool.Close()
+	ctx, pool := newRehearsalDatabase(t)
 
 	if err := RunMigrations(ctx, pool, migrations.FS, "sql"); err != nil {
 		t.Fatalf("migrate up: %v", err)
@@ -83,4 +75,36 @@ ON CONFLICT (username) DO UPDATE SET email=EXCLUDED.email RETURNING id`).Scan(&u
 	}
 
 	_, _ = pool.Exec(ctx, `DELETE FROM users WHERE id=$1`, userID)
+}
+
+// newRehearsalDatabase returns a pool on a database this test owns.
+//
+// MigrateDownTo rolls public back past columns other packages are querying, and
+// `go test ./...` runs package binaries concurrently against one database, so
+// rehearsing the rollback in the shared database turns unrelated packages red
+// at random — internal/markers loses marker_contributions.claim_active mid-run.
+func newRehearsalDatabase(t *testing.T) (context.Context, *pgxpool.Pool) {
+	t.Helper()
+	dsn := os.Getenv("SILO_TEST_DATABASE_URL")
+	if dsn == "" {
+		t.Skip("SILO_TEST_DATABASE_URL is not set")
+	}
+	ctx := context.Background()
+
+	// The rehearsal migrates up itself, so hand Provision a no-op.
+	config, drop, err := dbtest.Provision(ctx, dsn, "silo_migrate_rehearsal",
+		func(context.Context, *pgxpool.Pool) error { return nil })
+	if err != nil {
+		t.Fatalf("provision rehearsal database: %v", err)
+	}
+	pool, err := pgxpool.NewWithConfig(ctx, config.Copy())
+	if err != nil {
+		drop()
+		t.Fatalf("connect rehearsal database: %v", err)
+	}
+	t.Cleanup(func() {
+		pool.Close()
+		drop()
+	})
+	return ctx, pool
 }

--- a/internal/database/migrate_downto_test.go
+++ b/internal/database/migrate_downto_test.go
@@ -99,12 +99,14 @@ func newRehearsalDatabase(t *testing.T) (context.Context, *pgxpool.Pool) {
 	}
 	pool, err := pgxpool.NewWithConfig(ctx, config.Copy())
 	if err != nil {
-		drop()
+		_ = drop()
 		t.Fatalf("connect rehearsal database: %v", err)
 	}
 	t.Cleanup(func() {
 		pool.Close()
-		drop()
+		if err := drop(); err != nil {
+			t.Errorf("clean up rehearsal database: %v", err)
+		}
 	})
 	return ctx, pool
 }

--- a/internal/dbtest/dbtest.go
+++ b/internal/dbtest/dbtest.go
@@ -1,0 +1,81 @@
+// Package dbtest provisions throwaway databases for tests that cannot share
+// one.
+//
+// Most DB-backed tests in this repo run against the single database named by
+// SILO_TEST_DATABASE_URL and keep out of each other's way by suffixing the rows
+// they create. That works until a test's subject is global: a migration
+// rollback rewrites the schema every other package is reading, and a whole-table
+// pass like recommendations' EmbedAll cannot assert "nothing needed doing"
+// while any other writer exists. Those tests get a database instead of a
+// suffix.
+package dbtest
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgxpool"
+)
+
+// Migrate applies a schema to a freshly created database.
+type Migrate func(ctx context.Context, pool *pgxpool.Pool) error
+
+// Provision creates a uniquely-named database on the server that dsn points at,
+// applies migrate to it, and returns a config connected to it together with a
+// function that drops it. The returned drop function is safe to call once.
+//
+// Callers get a *pgxpool.Config rather than a connection string on purpose:
+// ConnConfig.ConnString reports the string it was parsed from and does not
+// reflect a later change to ConnConfig.Database, so round-tripping through a
+// string silently hands the caller the shared database back while the
+// migrations run somewhere else.
+func Provision(ctx context.Context, dsn, prefix string, migrate Migrate) (*pgxpool.Config, func(), error) {
+	admin, err := pgxpool.New(ctx, dsn)
+	if err != nil {
+		return nil, nil, fmt.Errorf("connect to provision %s database: %w", prefix, err)
+	}
+	// The name is generated, but CREATE/DROP DATABASE take no bind parameters,
+	// so the identifier is interpolated either way — quote it.
+	quoted := pgx.Identifier{fmt.Sprintf("%s_%d", prefix, time.Now().UnixNano())}.Sanitize()
+	_, err = admin.Exec(ctx, `CREATE DATABASE `+quoted)
+	admin.Close()
+	if err != nil {
+		return nil, nil, fmt.Errorf("create %s database: %w", prefix, err)
+	}
+
+	drop := func() {
+		dropper, err := pgxpool.New(context.WithoutCancel(ctx), dsn)
+		if err != nil {
+			return
+		}
+		defer dropper.Close()
+		// FORCE terminates connections the caller left behind; without it a
+		// straggler keeps the database alive and it survives into the next run.
+		_, _ = dropper.Exec(context.WithoutCancel(ctx), `DROP DATABASE IF EXISTS `+quoted+` WITH (FORCE)`)
+	}
+
+	config, err := pgxpool.ParseConfig(dsn)
+	if err != nil {
+		drop()
+		return nil, nil, fmt.Errorf("parse dsn: %w", err)
+	}
+	config.ConnConfig.Database = strings.Trim(quoted, `"`)
+
+	// Copy: a *pgxpool.Config may not back more than one pool, and this one is
+	// returned to the caller as a template.
+	pool, err := pgxpool.NewWithConfig(ctx, config.Copy())
+	if err != nil {
+		drop()
+		return nil, nil, fmt.Errorf("connect to %s database: %w", prefix, err)
+	}
+	err = migrate(ctx, pool)
+	pool.Close()
+	if err != nil {
+		drop()
+		return nil, nil, fmt.Errorf("migrate %s database: %w", prefix, err)
+	}
+	return config, drop, nil
+}

--- a/internal/dbtest/dbtest.go
+++ b/internal/dbtest/dbtest.go
@@ -25,14 +25,18 @@ type Migrate func(ctx context.Context, pool *pgxpool.Pool) error
 
 // Provision creates a uniquely-named database on the server that dsn points at,
 // applies migrate to it, and returns a config connected to it together with a
-// function that drops it. The returned drop function is safe to call once.
+// function that drops it.
+//
+// The drop function returns its error rather than swallowing it: a drop that
+// fails silently leaves a whole database behind, and the next run has no way to
+// tell that from a clean one.
 //
 // Callers get a *pgxpool.Config rather than a connection string on purpose:
 // ConnConfig.ConnString reports the string it was parsed from and does not
 // reflect a later change to ConnConfig.Database, so round-tripping through a
 // string silently hands the caller the shared database back while the
 // migrations run somewhere else.
-func Provision(ctx context.Context, dsn, prefix string, migrate Migrate) (*pgxpool.Config, func(), error) {
+func Provision(ctx context.Context, dsn, prefix string, migrate Migrate) (*pgxpool.Config, func() error, error) {
 	admin, err := pgxpool.New(ctx, dsn)
 	if err != nil {
 		return nil, nil, fmt.Errorf("connect to provision %s database: %w", prefix, err)
@@ -46,20 +50,24 @@ func Provision(ctx context.Context, dsn, prefix string, migrate Migrate) (*pgxpo
 		return nil, nil, fmt.Errorf("create %s database: %w", prefix, err)
 	}
 
-	drop := func() {
-		dropper, err := pgxpool.New(context.WithoutCancel(ctx), dsn)
+	drop := func() error {
+		dropCtx := context.WithoutCancel(ctx)
+		dropper, err := pgxpool.New(dropCtx, dsn)
 		if err != nil {
-			return
+			return fmt.Errorf("reconnect to drop %s: %w", quoted, err)
 		}
 		defer dropper.Close()
 		// FORCE terminates connections the caller left behind; without it a
 		// straggler keeps the database alive and it survives into the next run.
-		_, _ = dropper.Exec(context.WithoutCancel(ctx), `DROP DATABASE IF EXISTS `+quoted+` WITH (FORCE)`)
+		if _, err := dropper.Exec(dropCtx, `DROP DATABASE IF EXISTS `+quoted+` WITH (FORCE)`); err != nil {
+			return fmt.Errorf("drop %s: %w", quoted, err)
+		}
+		return nil
 	}
 
 	config, err := pgxpool.ParseConfig(dsn)
 	if err != nil {
-		drop()
+		_ = drop()
 		return nil, nil, fmt.Errorf("parse dsn: %w", err)
 	}
 	config.ConnConfig.Database = strings.Trim(quoted, `"`)
@@ -68,13 +76,13 @@ func Provision(ctx context.Context, dsn, prefix string, migrate Migrate) (*pgxpo
 	// returned to the caller as a template.
 	pool, err := pgxpool.NewWithConfig(ctx, config.Copy())
 	if err != nil {
-		drop()
+		_ = drop()
 		return nil, nil, fmt.Errorf("connect to %s database: %w", prefix, err)
 	}
 	err = migrate(ctx, pool)
 	pool.Close()
 	if err != nil {
-		drop()
+		_ = drop()
 		return nil, nil, fmt.Errorf("migrate %s database: %w", prefix, err)
 	}
 	return config, drop, nil

--- a/internal/dbtest/dbtest.go
+++ b/internal/dbtest/dbtest.go
@@ -12,8 +12,8 @@ package dbtest
 
 import (
 	"context"
+	"errors"
 	"fmt"
-	"strings"
 	"time"
 
 	"github.com/jackc/pgx/v5"
@@ -23,18 +23,32 @@ import (
 // Migrate applies a schema to a freshly created database.
 type Migrate func(ctx context.Context, pool *pgxpool.Pool) error
 
-// dropTimeout bounds the teardown. DROP DATABASE ... WITH (FORCE) is fast when
-// the server answers at all, so this only has to be long enough to outlast a
-// slow connect.
-const dropTimeout = 30 * time.Second
+const (
+	// setupTimeout bounds connecting to the server and CREATE DATABASE. Both
+	// are fast whenever the server answers, so this only has to outlast a slow
+	// connect — and an unbounded one hangs the test binary until
+	// `go test -timeout` kills it, with nothing to point at.
+	setupTimeout = 30 * time.Second
+
+	// dropTimeout bounds the teardown, for the same reason.
+	dropTimeout = 30 * time.Second
+)
 
 // Provision creates a uniquely-named database on the server that dsn points at,
 // applies migrate to it, and returns a config connected to it together with a
 // function that drops it.
 //
+// migrate runs on the caller's context, deliberately: how long a schema takes to
+// apply is the caller's business, not this package's, and guessing a bound here
+// would either fire on a slow machine or be too loose to mean anything. The
+// steps this package does own — connect, CREATE DATABASE, DROP DATABASE — are
+// bounded.
+//
 // The drop function returns its error rather than swallowing it: a drop that
 // fails silently leaves a whole database behind, and the next run has no way to
-// tell that from a clean one.
+// tell that from a clean one. When provisioning itself fails, a failed cleanup
+// is joined onto the returned error rather than discarded, so a leaked database
+// is never invisible.
 //
 // Callers get a *pgxpool.Config rather than a connection string on purpose:
 // ConnConfig.ConnString reports the string it was parsed from and does not
@@ -42,14 +56,20 @@ const dropTimeout = 30 * time.Second
 // string silently hands the caller the shared database back while the
 // migrations run somewhere else.
 func Provision(ctx context.Context, dsn, prefix string, migrate Migrate) (*pgxpool.Config, func() error, error) {
-	admin, err := pgxpool.New(ctx, dsn)
+	setupCtx, cancelSetup := context.WithTimeout(ctx, setupTimeout)
+	defer cancelSetup()
+
+	admin, err := pgxpool.New(setupCtx, dsn)
 	if err != nil {
 		return nil, nil, fmt.Errorf("connect to provision %s database: %w", prefix, err)
 	}
-	// The name is generated, but CREATE/DROP DATABASE take no bind parameters,
-	// so the identifier is interpolated either way — quote it.
-	quoted := pgx.Identifier{fmt.Sprintf("%s_%d", prefix, time.Now().UnixNano())}.Sanitize()
-	_, err = admin.Exec(ctx, `CREATE DATABASE `+quoted)
+	// name is what the connection config needs; quoted is what SQL needs.
+	// CREATE/DROP DATABASE take no bind parameters, so the identifier is
+	// interpolated either way — keep both rather than trying to recover one
+	// from the other, which Sanitize's quote-doubling makes lossy.
+	name := fmt.Sprintf("%s_%d", prefix, time.Now().UnixNano())
+	quoted := pgx.Identifier{name}.Sanitize()
+	_, err = admin.Exec(setupCtx, `CREATE DATABASE `+quoted)
 	admin.Close()
 	if err != nil {
 		return nil, nil, fmt.Errorf("create %s database: %w", prefix, err)
@@ -58,43 +78,46 @@ func Provision(ctx context.Context, dsn, prefix string, migrate Migrate) (*pgxpo
 	drop := func() error {
 		// WithoutCancel so the drop still runs when the caller's context is
 		// already done — cleanup usually happens after the work it belongs to.
-		// WithTimeout because WithoutCancel drops the deadline too, and an
-		// unbounded drop against an unreachable server hangs the test binary
-		// until `go test -timeout` kills it, with nothing to point at.
+		// WithTimeout because WithoutCancel drops the deadline along with the
+		// cancellation.
 		dropCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), dropTimeout)
 		defer cancel()
 		dropper, err := pgxpool.New(dropCtx, dsn)
 		if err != nil {
-			return fmt.Errorf("reconnect to drop %s: %w", quoted, err)
+			return fmt.Errorf("reconnect to drop %s: %w", name, err)
 		}
 		defer dropper.Close()
 		// FORCE terminates connections the caller left behind; without it a
 		// straggler keeps the database alive and it survives into the next run.
 		if _, err := dropper.Exec(dropCtx, `DROP DATABASE IF EXISTS `+quoted+` WITH (FORCE)`); err != nil {
-			return fmt.Errorf("drop %s: %w", quoted, err)
+			return fmt.Errorf("drop %s: %w", name, err)
 		}
 		return nil
 	}
 
+	// abandon reports why provisioning failed, and — when the database it
+	// already created could not be removed — that one was left behind and what
+	// it is called.
+	abandon := func(cause error) error {
+		return errors.Join(cause, drop())
+	}
+
 	config, err := pgxpool.ParseConfig(dsn)
 	if err != nil {
-		_ = drop()
-		return nil, nil, fmt.Errorf("parse dsn: %w", err)
+		return nil, nil, abandon(fmt.Errorf("parse dsn: %w", err))
 	}
-	config.ConnConfig.Database = strings.Trim(quoted, `"`)
+	config.ConnConfig.Database = name
 
 	// Copy: a *pgxpool.Config may not back more than one pool, and this one is
 	// returned to the caller as a template.
-	pool, err := pgxpool.NewWithConfig(ctx, config.Copy())
+	pool, err := pgxpool.NewWithConfig(setupCtx, config.Copy())
 	if err != nil {
-		_ = drop()
-		return nil, nil, fmt.Errorf("connect to %s database: %w", prefix, err)
+		return nil, nil, abandon(fmt.Errorf("connect to %s database: %w", prefix, err))
 	}
 	err = migrate(ctx, pool)
 	pool.Close()
 	if err != nil {
-		_ = drop()
-		return nil, nil, fmt.Errorf("migrate %s database: %w", prefix, err)
+		return nil, nil, abandon(fmt.Errorf("migrate %s database: %w", prefix, err))
 	}
 	return config, drop, nil
 }

--- a/internal/dbtest/dbtest.go
+++ b/internal/dbtest/dbtest.go
@@ -23,6 +23,11 @@ import (
 // Migrate applies a schema to a freshly created database.
 type Migrate func(ctx context.Context, pool *pgxpool.Pool) error
 
+// dropTimeout bounds the teardown. DROP DATABASE ... WITH (FORCE) is fast when
+// the server answers at all, so this only has to be long enough to outlast a
+// slow connect.
+const dropTimeout = 30 * time.Second
+
 // Provision creates a uniquely-named database on the server that dsn points at,
 // applies migrate to it, and returns a config connected to it together with a
 // function that drops it.
@@ -51,7 +56,13 @@ func Provision(ctx context.Context, dsn, prefix string, migrate Migrate) (*pgxpo
 	}
 
 	drop := func() error {
-		dropCtx := context.WithoutCancel(ctx)
+		// WithoutCancel so the drop still runs when the caller's context is
+		// already done — cleanup usually happens after the work it belongs to.
+		// WithTimeout because WithoutCancel drops the deadline too, and an
+		// unbounded drop against an unreachable server hangs the test binary
+		// until `go test -timeout` kills it, with nothing to point at.
+		dropCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), dropTimeout)
+		defer cancel()
 		dropper, err := pgxpool.New(dropCtx, dsn)
 		if err != nil {
 			return fmt.Errorf("reconnect to drop %s: %w", quoted, err)

--- a/internal/downloads/artifact_repo_test.go
+++ b/internal/downloads/artifact_repo_test.go
@@ -48,6 +48,14 @@ func newArtifactTestRepo(t *testing.T) (*ArtifactRepository, *pgxpool.Pool, int)
 		t.Fatalf("seed media file: %v", err)
 	}
 	t.Cleanup(func() {
+		// Orphans first, and by subquery: download_artifact_id carries no
+		// foreign key, so an orphan outlives the artifact it names and nothing
+		// ever collects it. They accumulate across runs until they crowd out
+		// ListRemoteOrphansDue's 100-row window, at which point tests stop
+		// finding the orphan they just enqueued.
+		_, _ = pool.Exec(ctx, `
+			DELETE FROM download_artifact_orphans
+			WHERE download_artifact_id IN (SELECT id FROM download_artifacts WHERE media_file_id = $1)`, fileID)
 		_, _ = pool.Exec(ctx, `DELETE FROM download_artifacts WHERE media_file_id = $1`, fileID)
 		_, _ = pool.Exec(ctx, `DELETE FROM media_files WHERE id = $1`, fileID)
 		_, _ = pool.Exec(ctx, `DELETE FROM media_folders WHERE id = $1`, folderID)
@@ -361,8 +369,8 @@ func TestArtifactRecoveryContinuesAfterStaleLocatorRefresh(t *testing.T) {
 	manager := &ArtifactManager{repo: repo, preparer: preparer}
 	manager.probeRemoteArtifactGroup(ctx, preparer, ready)
 
-	if len(preparer.statIDs) != 1 || preparer.statIDs[0] != ready[1].ID {
-		t.Fatalf("probed artifacts = %v, want only continuing artifact %s", preparer.statIDs, ready[1].ID)
+	if probed := preparer.probedIDs(); len(probed) != 1 || probed[0] != ready[1].ID {
+		t.Fatalf("probed artifacts = %v, want only continuing artifact %s", probed, ready[1].ID)
 	}
 	persisted, err := repo.GetByID(ctx, ready[1].ID)
 	if err != nil {
@@ -449,8 +457,8 @@ func TestArtifactRecoveryDeletesWrongSizedRemoteBeforeRequeue(t *testing.T) {
 	if len(orphans) != 1 || orphans[0].OriginNodeID != 17 || orphans[0].OriginArtifactID != "artifact-truncated" {
 		t.Fatalf("remote cleanup queue = %+v", orphans)
 	}
-	if preparer.deleted != "artifact-truncated" {
-		t.Fatalf("deleted remote artifact = %q, want artifact-truncated", preparer.deleted)
+	if preparer.lastDeleted() != "artifact-truncated" {
+		t.Fatalf("deleted remote artifact = %q, want artifact-truncated", preparer.lastDeleted())
 	}
 	t.Cleanup(func() { _ = repo.DeleteRemoteOrphan(ctx, orphans[0].ID) })
 }
@@ -631,7 +639,7 @@ func TestProxyMissingReportFencesCompleteRemoteLocator(t *testing.T) {
 }
 
 func TestRemoteCleanupBudgetBoundsUnreachableOrigins(t *testing.T) {
-	repo, _, fileID := newArtifactTestRepo(t)
+	repo, pool, fileID := newArtifactTestRepo(t)
 	ctx := context.Background()
 	row, _, err := repo.EnsureQueued(ctx, newArtifact(t, fileID, fmt.Sprintf("hash-cleanup-budget-%d", time.Now().UnixNano())))
 	if err != nil {
@@ -642,6 +650,15 @@ func TestRemoteCleanupBudgetBoundsUnreachableOrigins(t *testing.T) {
 	originURL := fmt.Sprintf("http://unreachable-%d", suffix)
 	if err := repo.EnqueueRemoteOrphan(ctx, row.ID, 31, originURL, originArtifactID); err != nil {
 		t.Fatal(err)
+	}
+	// EnqueueRemoteOrphan backs the first attempt off by 30 seconds, so the row
+	// it just wrote is not due and cleanupRemoteOrphans will not see it. Without
+	// this the test only ever passed on orphans left behind by earlier runs,
+	// which is why it went red the moment the queue was cleaned up.
+	if _, err := pool.Exec(ctx,
+		`UPDATE download_artifact_orphans SET next_retry_at = NULL
+		 WHERE origin_node_id = $1 AND origin_artifact_id = $2`, 31, originArtifactID); err != nil {
+		t.Fatalf("make orphan due: %v", err)
 	}
 	started := make(chan struct{})
 	preparer := &lifecycleTestPreparer{deleteStarted: started, deleteWait: true}

--- a/internal/downloads/artifact_repo_test.go
+++ b/internal/downloads/artifact_repo_test.go
@@ -48,17 +48,30 @@ func newArtifactTestRepo(t *testing.T) (*ArtifactRepository, *pgxpool.Pool, int)
 		t.Fatalf("seed media file: %v", err)
 	}
 	t.Cleanup(func() {
+		// Report failures rather than discarding them: a cleanup that silently
+		// half-ran leaves rows behind, and every table below is read by
+		// whole-table queries, so the next run fails somewhere unrelated.
+		//
 		// Orphans first, and by subquery: download_artifact_id carries no
 		// foreign key, so an orphan outlives the artifact it names and nothing
 		// ever collects it. They accumulate across runs until they crowd out
 		// ListRemoteOrphansDue's 100-row window, at which point tests stop
 		// finding the orphan they just enqueued.
-		_, _ = pool.Exec(ctx, `
-			DELETE FROM download_artifact_orphans
-			WHERE download_artifact_id IN (SELECT id FROM download_artifacts WHERE media_file_id = $1)`, fileID)
-		_, _ = pool.Exec(ctx, `DELETE FROM download_artifacts WHERE media_file_id = $1`, fileID)
-		_, _ = pool.Exec(ctx, `DELETE FROM media_files WHERE id = $1`, fileID)
-		_, _ = pool.Exec(ctx, `DELETE FROM media_folders WHERE id = $1`, folderID)
+		for _, step := range []struct {
+			what  string
+			query string
+			arg   int
+		}{
+			{"remote orphans", `DELETE FROM download_artifact_orphans
+				WHERE download_artifact_id IN (SELECT id FROM download_artifacts WHERE media_file_id = $1)`, fileID},
+			{"artifacts", `DELETE FROM download_artifacts WHERE media_file_id = $1`, fileID},
+			{"media file", `DELETE FROM media_files WHERE id = $1`, fileID},
+			{"media folder", `DELETE FROM media_folders WHERE id = $1`, folderID},
+		} {
+			if _, err := pool.Exec(ctx, step.query, step.arg); err != nil {
+				t.Errorf("clean up %s: %v", step.what, err)
+			}
+		}
 	})
 	return NewArtifactRepository(pool), pool, fileID
 }

--- a/internal/downloads/artifact_test.go
+++ b/internal/downloads/artifact_test.go
@@ -91,9 +91,12 @@ func (p *lifecycleTestPreparer) probedIDs() []string {
 	return slices.Clone(p.statIDs)
 }
 
+// PrepareFile returns the canned PreparedArtifact the test configured.
 func (p *lifecycleTestPreparer) PrepareFile(context.Context, string, playback.TranscodeOpts, string) (PreparedArtifact, error) {
 	return p.prepared, nil
 }
+
+// ResolveArtifact stamps the origin locator the test configured onto artifact.
 func (p *lifecycleTestPreparer) ResolveArtifact(_ context.Context, artifact *Artifact) error {
 	if p.resolvedNode != 0 {
 		artifact.OriginNodeID = p.resolvedNode
@@ -104,6 +107,10 @@ func (p *lifecycleTestPreparer) ResolveArtifact(_ context.Context, artifact *Art
 	}
 	return p.resolveErr
 }
+
+// StatArtifact records the artifact it was asked about and returns the canned
+// result. With statWait set it blocks until the context ends, standing in for an
+// origin that never answers.
 func (p *lifecycleTestPreparer) StatArtifact(ctx context.Context, artifact *Artifact) (downloadprepare.Result, error) {
 	if p.statWait {
 		p.statStarted.Add(1)
@@ -120,6 +127,10 @@ func (p *lifecycleTestPreparer) StatArtifact(ctx context.Context, artifact *Arti
 	p.mu.Unlock()
 	return stat, statErr
 }
+
+// DeleteArtifact records the delete and signals deleteStarted on the first call.
+// With deleteWait set it then blocks until the context ends, which is how the
+// budget tests observe a delete that outlives its deadline.
 func (p *lifecycleTestPreparer) DeleteArtifact(ctx context.Context, artifact *Artifact) error {
 	p.mu.Lock()
 	p.deleted = artifact.OriginArtifactID

--- a/internal/downloads/artifact_test.go
+++ b/internal/downloads/artifact_test.go
@@ -3,7 +3,9 @@ package downloads
 import (
 	"context"
 	"encoding/json"
+	"slices"
 	"strings"
+	"sync"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -52,7 +54,12 @@ func TestArtifactOutputPathDeterministic(t *testing.T) {
 	}
 }
 
+// lifecycleTestPreparer is called from the goroutines cleanupRemoteOrphans
+// fans out over, so its recorded state is mutex-guarded and deleteStarted is
+// closed at most once. Without that, a second concurrent delete panics the test
+// binary on a closed channel and takes the package's cleanup down with it.
 type lifecycleTestPreparer struct {
+	mu            sync.Mutex
 	deleted       string
 	prepared      PreparedArtifact
 	resolveErr    error
@@ -66,7 +73,22 @@ type lifecycleTestPreparer struct {
 	statWait      bool
 	deleteErr     error
 	deleteStarted chan struct{}
+	deleteOnce    sync.Once
 	deleteWait    bool
+}
+
+// lastDeleted reports the most recent OriginArtifactID passed to DeleteArtifact.
+func (p *lifecycleTestPreparer) lastDeleted() string {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	return p.deleted
+}
+
+// probedIDs reports the artifact IDs passed to StatArtifact, in call order.
+func (p *lifecycleTestPreparer) probedIDs() []string {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	return slices.Clone(p.statIDs)
 }
 
 func (p *lifecycleTestPreparer) PrepareFile(context.Context, string, playback.TranscodeOpts, string) (PreparedArtifact, error) {
@@ -92,13 +114,18 @@ func (p *lifecycleTestPreparer) StatArtifact(ctx context.Context, artifact *Arti
 			return downloadprepare.Result{}, context.DeadlineExceeded
 		}
 	}
+	p.mu.Lock()
 	p.statIDs = append(p.statIDs, artifact.ID)
-	return p.stat, p.statError
+	stat, statErr := p.stat, p.statError
+	p.mu.Unlock()
+	return stat, statErr
 }
 func (p *lifecycleTestPreparer) DeleteArtifact(ctx context.Context, artifact *Artifact) error {
+	p.mu.Lock()
 	p.deleted = artifact.OriginArtifactID
+	p.mu.Unlock()
 	if p.deleteStarted != nil {
-		close(p.deleteStarted)
+		p.deleteOnce.Do(func() { close(p.deleteStarted) })
 	}
 	if p.deleteWait {
 		<-ctx.Done()
@@ -114,8 +141,8 @@ func TestArtifactManagerDeletesRemoteBytesThroughOwningNode(t *testing.T) {
 	if !m.deleteArtifactBytes(context.Background(), artifact) {
 		t.Fatal("remote cleanup failed")
 	}
-	if preparer.deleted != "opaque-1" {
-		t.Fatalf("deleted = %q", preparer.deleted)
+	if preparer.lastDeleted() != "opaque-1" {
+		t.Fatalf("deleted = %q", preparer.lastDeleted())
 	}
 }
 

--- a/internal/historyimport/emby_favorites_test.go
+++ b/internal/historyimport/emby_favorites_test.go
@@ -30,7 +30,8 @@ func TestAddFavoriteUsesAtomicInsertResult(t *testing.T) {
 
 func TestEmbyFavoriteOnlyRecordAddsFavoriteWithoutProgress(t *testing.T) {
 	ctx := context.Background()
-	pool := newPlexWatchlistImportTestPool(t)
+	fixture := newHistoryImportFixture(t)
+	pool := fixture.pool
 	repo := NewRepository(pool, nil)
 	service := &Service{
 		repo:         repo,
@@ -44,14 +45,14 @@ func TestEmbyFavoriteOnlyRecordAddsFavoriteWithoutProgress(t *testing.T) {
 	if _, err := pool.Exec(ctx, `
 		INSERT INTO media_items (content_id, type, title, year, tvdb_id, status)
 		VALUES ($1, $2, $3, $4, $5, $6)`,
-		"series-371980", KindSeries, "Severance", 2022, "371980", "matched",
+		fixture.id("series-371980"), KindSeries, "Severance", 2022, "371980", "matched",
 	); err != nil {
 		t.Fatalf("seed media item: %v", err)
 	}
 	run, err := repo.CreateRun(ctx, Run{
-		ID:               "emby-favorites-run",
-		UserID:           42,
-		ProfileID:        "profile-1",
+		ID:               fixture.id("emby-favorites-run"),
+		UserID:           fixture.userID,
+		ProfileID:        fixture.profileID,
 		SourceType:       SourceTypeEmby,
 		ConnectionMode:   ConnectionModeCustom,
 		Status:           RunStatusQueued,
@@ -73,7 +74,7 @@ func TestEmbyFavoriteOnlyRecordAddsFavoriteWithoutProgress(t *testing.T) {
 	}
 	service.executeRun(run, staticWatchlistProvider{records: []Record{record, record}})
 
-	completed, err := repo.GetRunForUser(ctx, 42, run.ID)
+	completed, err := repo.GetRunForUser(ctx, fixture.userID, run.ID)
 	if err != nil {
 		t.Fatalf("GetRunForUser: %v", err)
 	}
@@ -88,7 +89,7 @@ func TestEmbyFavoriteOnlyRecordAddsFavoriteWithoutProgress(t *testing.T) {
 	if err := pool.QueryRow(ctx, `
 		SELECT COUNT(*) FROM user_favorites
 		WHERE user_id = $1 AND profile_id = $2 AND media_item_id = $3`,
-		42, "profile-1", "series-371980",
+		fixture.userID, fixture.profileID, fixture.id("series-371980"),
 	).Scan(&rows); err != nil {
 		t.Fatalf("count favorite rows: %v", err)
 	}

--- a/internal/historyimport/plex_watchlist_test.go
+++ b/internal/historyimport/plex_watchlist_test.go
@@ -294,6 +294,8 @@ func (p staticWatchlistProvider) Fetch(context.Context) ([]Record, []string, err
 	return p.records, nil, nil
 }
 
+// newHistoryImportFixture connects to SILO_TEST_DATABASE_URL (skipping when
+// unset) and seeds the account an import test runs as, removing it on cleanup.
 func newHistoryImportFixture(t *testing.T) historyImportFixture {
 	t.Helper()
 	dsn := os.Getenv("SILO_TEST_DATABASE_URL")
@@ -354,4 +356,6 @@ type historyImportFixture struct {
 	profileID string
 }
 
+// id returns name scoped to this fixture's run, so identifiers are unique
+// across binaries sharing one database.
 func (f historyImportFixture) id(name string) string { return name + "-" + f.suffix }

--- a/internal/historyimport/plex_watchlist_test.go
+++ b/internal/historyimport/plex_watchlist_test.go
@@ -218,7 +218,8 @@ func TestFetchWatchlistStopsOnEmptyPage(t *testing.T) {
 
 func TestPlexWatchlistImportCountsOnlyInsertedRows(t *testing.T) {
 	ctx := context.Background()
-	pool := newPlexWatchlistImportTestPool(t)
+	fixture := newHistoryImportFixture(t)
+	pool := fixture.pool
 	repo := NewRepository(pool, nil)
 	service := &Service{
 		repo:         repo,
@@ -232,14 +233,14 @@ func TestPlexWatchlistImportCountsOnlyInsertedRows(t *testing.T) {
 	if _, err := pool.Exec(ctx, `
 		INSERT INTO media_items (content_id, type, title, year, tmdb_id, status)
 		VALUES ($1, $2, $3, $4, $5, $6)`,
-		"movie-693134", KindMovie, "Dune: Part Two", 2024, "693134", "matched",
+		fixture.id("movie-693134"), KindMovie, "Dune: Part Two", 2024, "693134", "matched",
 	); err != nil {
 		t.Fatalf("seed media item: %v", err)
 	}
 	run, err := repo.CreateRun(ctx, Run{
-		ID:               "plex-watchlist-duplicate-run",
-		UserID:           42,
-		ProfileID:        "profile-1",
+		ID:               fixture.id("plex-watchlist-duplicate-run"),
+		UserID:           fixture.userID,
+		ProfileID:        fixture.profileID,
 		SourceType:       SourceTypePlex,
 		ConnectionMode:   ConnectionModePlexOAuth,
 		Status:           RunStatusQueued,
@@ -261,7 +262,7 @@ func TestPlexWatchlistImportCountsOnlyInsertedRows(t *testing.T) {
 	}
 	service.executeRun(run, staticWatchlistProvider{records: []Record{record, record}})
 
-	completed, err := repo.GetRunForUser(ctx, 42, run.ID)
+	completed, err := repo.GetRunForUser(ctx, fixture.userID, run.ID)
 	if err != nil {
 		t.Fatalf("GetRunForUser: %v", err)
 	}
@@ -276,7 +277,7 @@ func TestPlexWatchlistImportCountsOnlyInsertedRows(t *testing.T) {
 		SELECT COUNT(*)
 		FROM user_watchlist
 		WHERE user_id = $1 AND profile_id = $2 AND media_item_id = $3`,
-		42, "profile-1", "movie-693134",
+		fixture.userID, fixture.profileID, fixture.id("movie-693134"),
 	).Scan(&rows); err != nil {
 		t.Fatalf("count watchlist rows: %v", err)
 	}
@@ -293,78 +294,64 @@ func (p staticWatchlistProvider) Fetch(context.Context) ([]Record, []string, err
 	return p.records, nil, nil
 }
 
-func newPlexWatchlistImportTestPool(t *testing.T) *pgxpool.Pool {
+func newHistoryImportFixture(t *testing.T) historyImportFixture {
 	t.Helper()
 	dsn := os.Getenv("SILO_TEST_DATABASE_URL")
 	if dsn == "" {
 		t.Skip("SILO_TEST_DATABASE_URL is not set")
 	}
 	ctx := context.Background()
-	config, err := pgxpool.ParseConfig(dsn)
-	if err != nil {
-		t.Fatalf("parse db config: %v", err)
-	}
-	config.MaxConns = 1
-	pool, err := pgxpool.NewWithConfig(ctx, config)
+	pool, err := pgxpool.New(ctx, dsn)
 	if err != nil {
 		t.Fatalf("connect test database: %v", err)
 	}
 	t.Cleanup(pool.Close)
 
-	for _, stmt := range []string{
-		`CREATE TEMP TABLE media_items (
-			content_id text PRIMARY KEY,
-			type text NOT NULL,
-			title text NOT NULL,
-			year integer,
-			imdb_id text,
-			tmdb_id text,
-			tvdb_id text,
-			status text NOT NULL DEFAULT 'matched'
-		) ON COMMIT PRESERVE ROWS`,
-		`CREATE TEMP TABLE user_watchlist (
-			user_id integer NOT NULL,
-			profile_id text NOT NULL,
-			media_item_id text NOT NULL,
-			added_at timestamptz NOT NULL DEFAULT now(),
-			sort_index integer,
-			PRIMARY KEY (user_id, profile_id, media_item_id)
-		) ON COMMIT PRESERVE ROWS`,
-		`CREATE TEMP TABLE history_import_runs (
-			id text PRIMARY KEY,
-			user_id integer NOT NULL,
-			profile_id text NOT NULL,
-			source_type text NOT NULL,
-			connection_mode text NOT NULL,
-			status text NOT NULL,
-			mapping_id integer,
-			fetched integer NOT NULL DEFAULT 0,
-			matched integer NOT NULL DEFAULT 0,
-			unmatched integer NOT NULL DEFAULT 0,
-			progress_updated integer NOT NULL DEFAULT 0,
-			history_created integer NOT NULL DEFAULT 0,
-			watchlist_added integer NOT NULL DEFAULT 0,
-			favorites_imported integer NOT NULL DEFAULT 0,
-			skipped integer NOT NULL DEFAULT 0,
-			warnings jsonb NOT NULL DEFAULT '[]'::jsonb,
-			unmatched_samples jsonb NOT NULL DEFAULT '[]'::jsonb,
-			error_message text,
-			created_at timestamptz NOT NULL DEFAULT now(),
-			started_at timestamptz,
-			completed_at timestamptz,
-			last_heartbeat_at timestamptz
-		) ON COMMIT PRESERVE ROWS`,
-		`CREATE TEMP TABLE user_favorites (
-			user_id integer NOT NULL,
-			profile_id text NOT NULL,
-			media_item_id text NOT NULL,
-			added_at timestamptz NOT NULL DEFAULT now(),
-			PRIMARY KEY (user_id, profile_id, media_item_id)
-		) ON COMMIT PRESERVE ROWS`,
-	} {
-		if _, err := pool.Exec(ctx, stmt); err != nil {
-			t.Fatalf("create temp test table: %v", err)
-		}
+	// history_import_runs is keyed on (user_id, profile_id) against
+	// user_profiles, so the import path needs a real account behind it.
+	fixture := historyImportFixture{pool: pool, suffix: fmt.Sprintf("%d", time.Now().UnixNano())}
+	fixture.profileID = fixture.id("profile")
+
+	if err := pool.QueryRow(ctx, `
+		INSERT INTO users (username, email, password_hash, role)
+		VALUES ($1, $2, 'x', 'user')
+		RETURNING id`,
+		fixture.id("history-import-test"),
+		fixture.id("history-import-test")+"@example.test",
+	).Scan(&fixture.userID); err != nil {
+		t.Fatalf("seed user: %v", err)
 	}
-	return pool
+	t.Cleanup(func() {
+		cleanupCtx := context.Background()
+		// user_profiles, user_watchlist, user_favorites and
+		// history_import_runs all cascade from the user.
+		if _, err := pool.Exec(cleanupCtx,
+			`DELETE FROM users WHERE id = $1`, fixture.userID); err != nil {
+			t.Errorf("clean up user: %v", err)
+		}
+		if _, err := pool.Exec(cleanupCtx,
+			`DELETE FROM media_items WHERE content_id LIKE '%-' || $1`, fixture.suffix); err != nil {
+			t.Errorf("clean up media items: %v", err)
+		}
+	})
+
+	if _, err := pool.Exec(ctx,
+		`INSERT INTO user_profiles (id, user_id, name) VALUES ($1, $2, $3)`,
+		fixture.profileID, fixture.userID, "History Import Test",
+	); err != nil {
+		t.Fatalf("seed user profile: %v", err)
+	}
+	return fixture
 }
+
+// historyImportFixture holds the account an import test runs as. Identifiers
+// derived from it carry a nanosecond suffix so binaries sharing one database
+// stay off each other's rows, and so the fixture can clean up by suffix.
+type historyImportFixture struct {
+	pool      *pgxpool.Pool
+	suffix    string
+	userID    int
+	profileID string
+}
+
+func (f historyImportFixture) id(name string) string { return name + "-" + f.suffix }

--- a/internal/notifications/operational_dispatch_test.go
+++ b/internal/notifications/operational_dispatch_test.go
@@ -2,9 +2,11 @@ package notifications
 
 import (
 	"context"
+	"fmt"
 	"log/slog"
 	"os"
 	"testing"
+	"time"
 
 	"github.com/jackc/pgx/v5/pgxpool"
 )
@@ -16,94 +18,59 @@ func TestDispatchOperationalEnqueuesApplePushAttempts(t *testing.T) {
 	}
 
 	ctx := context.Background()
-	config, err := pgxpool.ParseConfig(dsn)
-	if err != nil {
-		t.Fatalf("parse db config: %v", err)
-	}
-	config.MaxConns = 1
-	pool, err := pgxpool.NewWithConfig(ctx, config)
+	pool, err := pgxpool.New(ctx, dsn)
 	if err != nil {
 		t.Fatalf("connect db: %v", err)
 	}
 	t.Cleanup(pool.Close)
 
-	if _, err := pool.Exec(ctx, `
-		CREATE TEMP TABLE notification_deliveries (
-			id text PRIMARY KEY,
-			release_event_id text,
-			user_id integer NOT NULL,
-			profile_id text NOT NULL,
-			library_id integer,
-			series_id text,
-			episode_id text,
-			type text NOT NULL,
-			reason_flags jsonb NOT NULL DEFAULT '{}'::jsonb,
-			status text NOT NULL DEFAULT 'delivered',
-			read_at timestamptz,
-			delivered_at timestamptz,
-			created_at timestamptz NOT NULL DEFAULT now()
-		) ON COMMIT PRESERVE ROWS;
+	// Every identifier carries the same nanosecond suffix so binaries sharing
+	// one database stay out of each other's rows.
+	suffix := fmt.Sprintf("%d", time.Now().UnixNano())
+	id := func(name string) string { return name + "-" + suffix }
+	primaryProfile, otherProfile := id("profile-1"), id("profile-2")
+	privateDevice := id("device-private")
+	deliveryID := id("delivery-request")
 
-		CREATE TEMP TABLE push_devices (
-			id text PRIMARY KEY,
-			user_id integer NOT NULL,
-			profile_id text NOT NULL,
-			device_id varchar(128) NOT NULL,
-			platform text NOT NULL,
-			provider text NOT NULL,
-			apns_environment text,
-			apns_topic text,
-			apns_token_ciphertext text,
-			apns_token_hash text,
-			server_device_id text NOT NULL,
-			push_mode text NOT NULL DEFAULT 'private_push',
-			enabled boolean NOT NULL DEFAULT true,
-			last_seen_at timestamptz,
-			last_success_at timestamptz,
-			last_failure_at timestamptz,
-			last_failure_code text,
-			created_at timestamptz NOT NULL DEFAULT now(),
-			updated_at timestamptz NOT NULL DEFAULT now()
-		) ON COMMIT PRESERVE ROWS;
+	t.Cleanup(func() {
+		cleanupCtx := context.Background()
+		// push_delivery_attempts cascades from both parents.
+		if _, err := pool.Exec(cleanupCtx,
+			`DELETE FROM notification_deliveries WHERE profile_id LIKE '%-' || $1`, suffix); err != nil {
+			t.Errorf("clean up notification deliveries: %v", err)
+		}
+		if _, err := pool.Exec(cleanupCtx,
+			`DELETE FROM push_devices WHERE profile_id LIKE '%-' || $1`, suffix); err != nil {
+			t.Errorf("clean up push devices: %v", err)
+		}
+	})
 
-		CREATE TEMP TABLE push_delivery_attempts (
-			id text PRIMARY KEY,
-			notification_delivery_id text,
-			push_device_id text NOT NULL,
-			trigger_type text NOT NULL,
-			provider text NOT NULL,
-			platform text NOT NULL,
-			attempt_number integer NOT NULL DEFAULT 0,
-			attempted_at timestamptz,
-			next_retry_at timestamptz,
-			outcome text NOT NULL DEFAULT 'pending',
-			relay_request_id text,
-			upstream_status integer,
-			upstream_reason text,
-			failure_message text,
-			created_at timestamptz NOT NULL DEFAULT now(),
-			updated_at timestamptz NOT NULL DEFAULT now(),
-			UNIQUE (notification_delivery_id, push_device_id, trigger_type)
-		) ON COMMIT PRESERVE ROWS;
-	`); err != nil {
-		t.Fatalf("create temp notification push tables: %v", err)
+	seedDevices := []struct {
+		deviceRowID string
+		profileID   string
+		installID   string
+		pushMode    string
+		enabled     bool
+	}{
+		{privateDevice, primaryProfile, id("local-private"), PushModePrivatePush, true},
+		{id("device-in-app"), primaryProfile, id("local-in-app"), PushModeInAppOnly, true},
+		{id("device-disabled"), primaryProfile, id("local-disabled"), PushModePrivatePush, false},
+		{id("device-other-profile"), otherProfile, id("local-other"), PushModePrivatePush, true},
 	}
-
-	if _, err := pool.Exec(ctx, `
-		INSERT INTO push_devices
-			(id, user_id, profile_id, device_id, platform, provider, apns_environment, apns_topic,
-			 apns_token_ciphertext, apns_token_hash, server_device_id, push_mode, enabled)
-		VALUES
-			('device-private', 42, 'profile-1', 'local-private', 'apple', 'silo_relay', 'sandbox',
-			 'org.siloserver.silo', 'ciphertext', 'hash-1', 'server-private', 'private_push', true),
-			('device-in-app', 42, 'profile-1', 'local-in-app', 'apple', 'silo_relay', 'sandbox',
-			 'org.siloserver.silo', 'ciphertext', 'hash-2', 'server-in-app', 'in_app_only', true),
-			('device-disabled', 42, 'profile-1', 'local-disabled', 'apple', 'silo_relay', 'sandbox',
-			 'org.siloserver.silo', 'ciphertext', 'hash-3', 'server-disabled', 'private_push', false),
-			('device-other-profile', 42, 'profile-2', 'local-other', 'apple', 'silo_relay', 'sandbox',
-			 'org.siloserver.silo', 'ciphertext', 'hash-4', 'server-other', 'private_push', true)
-	`); err != nil {
-		t.Fatalf("seed push devices: %v", err)
+	for _, device := range seedDevices {
+		if _, err := pool.Exec(ctx, `
+			INSERT INTO push_devices
+				(id, user_id, profile_id, device_id, platform, provider, apns_environment,
+				 apns_topic, apns_token_ciphertext, apns_token_hash, server_device_id,
+				 push_mode, enabled)
+			VALUES ($1, 42, $2, $3, 'apple', 'silo_relay', 'sandbox',
+				'org.siloserver.silo', 'ciphertext', $4, $5, $6, $7)`,
+			device.deviceRowID, device.profileID, device.installID,
+			"hash-"+device.deviceRowID, "server-"+device.deviceRowID,
+			device.pushMode, device.enabled,
+		); err != nil {
+			t.Fatalf("seed push device %s: %v", device.deviceRowID, err)
+		}
 	}
 
 	system := &System{
@@ -116,38 +83,44 @@ func TestDispatchOperationalEnqueuesApplePushAttempts(t *testing.T) {
 	}
 
 	inserted, err := system.DispatchOperational(ctx, Delivery{
-		ID:          "delivery-request-1",
+		ID:          deliveryID,
 		UserID:      42,
-		ProfileID:   "profile-1",
+		ProfileID:   primaryProfile,
 		Type:        DeliveryTypeRequestFulfilled,
 		ReasonFlags: []byte(`{}`),
 	}, OperationalDispatch{})
 	if err != nil {
 		t.Fatalf("dispatch operational: %v", err)
 	}
-	if inserted == nil || inserted.ID != "delivery-request-1" {
+	if inserted == nil || inserted.ID != deliveryID {
 		t.Fatalf("inserted = %+v", inserted)
 	}
 
-	var deliveryID, pushDeviceID, triggerType, provider, platform, outcome string
+	var gotDeliveryID, pushDeviceID, triggerType, provider, platform, outcome string
 	if err := pool.QueryRow(ctx, `
 		SELECT notification_delivery_id, push_device_id, trigger_type, provider, platform, outcome
 		FROM push_delivery_attempts
-	`).Scan(&deliveryID, &pushDeviceID, &triggerType, &provider, &platform, &outcome); err != nil {
+		WHERE notification_delivery_id = $1
+	`, inserted.ID).Scan(&gotDeliveryID, &pushDeviceID, &triggerType, &provider, &platform, &outcome); err != nil {
 		t.Fatalf("query push attempt: %v", err)
 	}
-	if deliveryID != inserted.ID ||
-		pushDeviceID != "device-private" ||
+	if gotDeliveryID != inserted.ID ||
+		pushDeviceID != privateDevice ||
 		triggerType != PushTriggerDelivery ||
 		provider != PushProviderSiloRelay ||
 		platform != PushPlatformApple ||
 		outcome != PushOutcomePending {
 		t.Fatalf("unexpected push attempt: delivery=%q device=%q trigger=%q provider=%q platform=%q outcome=%q",
-			deliveryID, pushDeviceID, triggerType, provider, platform, outcome)
+			gotDeliveryID, pushDeviceID, triggerType, provider, platform, outcome)
 	}
 
+	// Only the private-push device on the target profile is attempted: the
+	// in-app-only and disabled installs and the other profile's device are not.
 	var count int
-	if err := pool.QueryRow(ctx, `SELECT count(*) FROM push_delivery_attempts`).Scan(&count); err != nil {
+	if err := pool.QueryRow(ctx, `
+		SELECT count(*) FROM push_delivery_attempts
+		WHERE push_device_id IN (SELECT id FROM push_devices WHERE profile_id LIKE '%-' || $1)
+	`, suffix).Scan(&count); err != nil {
 		t.Fatalf("count push attempts: %v", err)
 	}
 	if count != 1 {

--- a/internal/notifications/push_devices_test.go
+++ b/internal/notifications/push_devices_test.go
@@ -3,9 +3,11 @@ package notifications
 import (
 	"context"
 	"errors"
+	"fmt"
 	"os"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/Silo-Server/silo-server/internal/secret"
 	"github.com/jackc/pgx/v5/pgxpool"
@@ -278,10 +280,21 @@ func TestPushDeviceAPNsTokenEncryptionUsesRowAAD(t *testing.T) {
 	}
 }
 
+// pushDeviceFixture owns a slice of the migrated push_devices table. Every
+// identifier it hands out ends in the same nanosecond suffix, so binaries
+// sharing one database never collide and cleanup deletes exactly the rows this
+// test created.
+type pushDeviceFixture struct {
+	repo   *PushDeviceRepository
+	pool   *pgxpool.Pool
+	suffix string
+}
+
+func (f pushDeviceFixture) id(name string) string { return name + "-" + f.suffix }
+
 // newPushDeviceTestRepo connects to SILO_TEST_DATABASE_URL (skipping when
-// unset) and shadows push_devices with a session-local temp table, pinning the
-// pool to one connection so every query sees it.
-func newPushDeviceTestRepo(t *testing.T) (*PushDeviceRepository, *pgxpool.Pool) {
+// unset) and returns a fixture over the migrated push_devices table.
+func newPushDeviceTestRepo(t *testing.T) pushDeviceFixture {
 	t.Helper()
 	dsn := os.Getenv("SILO_TEST_DATABASE_URL")
 	if dsn == "" {
@@ -289,54 +302,35 @@ func newPushDeviceTestRepo(t *testing.T) (*PushDeviceRepository, *pgxpool.Pool) 
 	}
 
 	ctx := context.Background()
-	config, err := pgxpool.ParseConfig(dsn)
-	if err != nil {
-		t.Fatalf("parse db config: %v", err)
-	}
-	config.MaxConns = 1
-	pool, err := pgxpool.NewWithConfig(ctx, config)
+	pool, err := pgxpool.New(ctx, dsn)
 	if err != nil {
 		t.Fatalf("connect db: %v", err)
 	}
 	t.Cleanup(pool.Close)
 
-	if _, err := pool.Exec(ctx, `
-		CREATE TEMP TABLE push_devices (
-			id text PRIMARY KEY,
-			user_id integer NOT NULL,
-			profile_id text NOT NULL,
-			device_id varchar(128) NOT NULL,
-			platform text NOT NULL,
-			provider text NOT NULL,
-			apns_environment text,
-			apns_topic text,
-			apns_token_ciphertext text,
-			apns_token_hash text,
-			server_device_id text NOT NULL,
-			push_mode text NOT NULL DEFAULT 'private_push',
-			enabled boolean NOT NULL DEFAULT true,
-			last_seen_at timestamptz,
-			last_success_at timestamptz,
-			last_failure_at timestamptz,
-			last_failure_code text,
-			created_at timestamptz NOT NULL DEFAULT now(),
-			updated_at timestamptz NOT NULL DEFAULT now(),
-			CONSTRAINT push_devices_profile_device_platform_key UNIQUE (profile_id, device_id, platform),
-			CONSTRAINT push_devices_server_device_id_key UNIQUE (server_device_id)
-		) ON COMMIT PRESERVE ROWS`); err != nil {
-		t.Fatalf("create temp push_devices table: %v", err)
+	fixture := pushDeviceFixture{
+		repo:   NewPushDeviceRepository(pool),
+		pool:   pool,
+		suffix: fmt.Sprintf("%d", time.Now().UnixNano()),
 	}
-	return NewPushDeviceRepository(pool), pool
+	t.Cleanup(func() {
+		if _, err := pool.Exec(context.Background(),
+			`DELETE FROM push_devices WHERE profile_id LIKE '%-' || $1`, fixture.suffix); err != nil {
+			t.Errorf("clean up push devices: %v", err)
+		}
+	})
+	return fixture
 }
 
 func TestPushDeviceRepositoryUpsertApplePreservesStableIDs(t *testing.T) {
 	ctx := context.Background()
-	repo, pool := newPushDeviceTestRepo(t)
+	fixture := newPushDeviceTestRepo(t)
+	repo, pool := fixture.repo, fixture.pool
 	cipher := testPushCipher(t)
 	registration := ApplePushDeviceRegistration{
 		UserID:          42,
-		ProfileID:       "profile-1",
-		DeviceID:        "local-device",
+		ProfileID:       fixture.id("profile-1"),
+		DeviceID:        fixture.id("local-device"),
 		APNsToken:       strings.Repeat("a", 64),
 		APNsEnvironment: APNsEnvironmentProd,
 		APNsTopic:       ApplePushTopicSilo,
@@ -378,7 +372,9 @@ func TestPushDeviceRepositoryUpsertApplePreservesStableIDs(t *testing.T) {
 	}
 
 	var count int
-	if err := pool.QueryRow(ctx, `SELECT count(*) FROM push_devices`).Scan(&count); err != nil {
+	if err := pool.QueryRow(ctx,
+		`SELECT count(*) FROM push_devices WHERE profile_id LIKE '%-' || $1`,
+		fixture.suffix).Scan(&count); err != nil {
 		t.Fatalf("count rows: %v", err)
 	}
 	if count != 1 {
@@ -388,13 +384,14 @@ func TestPushDeviceRepositoryUpsertApplePreservesStableIDs(t *testing.T) {
 
 func TestPushDeviceRepositoryUpsertApplePurgesOtherProfiles(t *testing.T) {
 	ctx := context.Background()
-	repo, pool := newPushDeviceTestRepo(t)
+	fixture := newPushDeviceTestRepo(t)
+	repo, pool := fixture.repo, fixture.pool
 	cipher := testPushCipher(t)
 
 	registration := ApplePushDeviceRegistration{
 		UserID:          42,
-		ProfileID:       "profile-parent",
-		DeviceID:        "shared-phone",
+		ProfileID:       fixture.id("profile-parent"),
+		DeviceID:        fixture.id("shared-phone"),
 		APNsToken:       strings.Repeat("a", 64),
 		APNsEnvironment: APNsEnvironmentProd,
 		APNsTopic:       ApplePushTopicSilo,
@@ -406,24 +403,27 @@ func TestPushDeviceRepositoryUpsertApplePurgesOtherProfiles(t *testing.T) {
 
 	// A different install on another profile must be untouched by the purge.
 	other := registration
-	other.ProfileID = "profile-parent"
-	other.DeviceID = "other-phone"
+	other.ProfileID = fixture.id("profile-parent")
+	other.DeviceID = fixture.id("other-phone")
 	if _, err := repo.UpsertApple(ctx, other, cipher); err != nil {
 		t.Fatalf("register unrelated device: %v", err)
 	}
 
 	// The shared phone switches profiles and re-registers: the old profile's
 	// row for that install must be gone, not left enabled.
-	registration.ProfileID = "profile-kid"
+	registration.ProfileID = fixture.id("profile-kid")
 	device, err := repo.UpsertApple(ctx, registration, cipher)
 	if err != nil {
 		t.Fatalf("register under second profile: %v", err)
 	}
-	if device.ProfileID != "profile-kid" {
-		t.Fatalf("profile = %q, want profile-kid", device.ProfileID)
+	if device.ProfileID != fixture.id("profile-kid") {
+		t.Fatalf("profile = %q, want %q", device.ProfileID, fixture.id("profile-kid"))
 	}
 
-	rows, err := pool.Query(ctx, `SELECT profile_id, device_id FROM push_devices ORDER BY profile_id`)
+	rows, err := pool.Query(ctx,
+		`SELECT profile_id, device_id FROM push_devices
+		 WHERE profile_id LIKE '%-' || $1
+		 ORDER BY profile_id`, fixture.suffix)
 	if err != nil {
 		t.Fatalf("list rows: %v", err)
 	}
@@ -439,8 +439,9 @@ func TestPushDeviceRepositoryUpsertApplePurgesOtherProfiles(t *testing.T) {
 	if err := rows.Err(); err != nil {
 		t.Fatalf("rows: %v", err)
 	}
-	want := map[string]string{"profile-kid": "shared-phone", "profile-parent": "other-phone"}
-	if len(got) != len(want) || got["profile-kid"] != want["profile-kid"] || got["profile-parent"] != want["profile-parent"] {
+	kid, parent := fixture.id("profile-kid"), fixture.id("profile-parent")
+	want := map[string]string{kid: fixture.id("shared-phone"), parent: fixture.id("other-phone")}
+	if len(got) != len(want) || got[kid] != want[kid] || got[parent] != want[parent] {
 		t.Fatalf("rows after reassignment = %v, want %v", got, want)
 	}
 }

--- a/internal/notifications/push_devices_test.go
+++ b/internal/notifications/push_devices_test.go
@@ -401,9 +401,9 @@ func TestPushDeviceRepositoryUpsertApplePurgesOtherProfiles(t *testing.T) {
 		t.Fatalf("register under first profile: %v", err)
 	}
 
-	// A different install on another profile must be untouched by the purge.
+	// A second install on the same profile must survive the purge below: the
+	// purge keys on device_id, so only the reassigned install is removed.
 	other := registration
-	other.ProfileID = fixture.id("profile-parent")
 	other.DeviceID = fixture.id("other-phone")
 	if _, err := repo.UpsertApple(ctx, other, cipher); err != nil {
 		t.Fatalf("register unrelated device: %v", err)

--- a/internal/notifications/push_devices_test.go
+++ b/internal/notifications/push_devices_test.go
@@ -290,6 +290,8 @@ type pushDeviceFixture struct {
 	suffix string
 }
 
+// id returns name scoped to this fixture's run, so identifiers are unique
+// across binaries sharing one database.
 func (f pushDeviceFixture) id(name string) string { return name + "-" + f.suffix }
 
 // newPushDeviceTestRepo connects to SILO_TEST_DATABASE_URL (skipping when

--- a/internal/recommendations/engine_test.go
+++ b/internal/recommendations/engine_test.go
@@ -2,12 +2,16 @@ package recommendations
 
 import (
 	"context"
+	"fmt"
 	"os"
 	"testing"
 
 	"github.com/jackc/pgx/v5/pgxpool"
 
 	"github.com/Silo-Server/silo-server/internal/catalog"
+	"github.com/Silo-Server/silo-server/internal/database"
+	"github.com/Silo-Server/silo-server/internal/dbtest"
+	"github.com/Silo-Server/silo-server/migrations"
 )
 
 // Compile-time assertions that *Engine satisfies both catalog provider
@@ -19,17 +23,47 @@ var (
 	_ catalog.CatalogSemanticModelProvider = (*Engine)(nil)
 )
 
-// newEngineTestPool mirrors internal/catalog/display_query_filter_test.go: it
-// skips when SILO_TEST_DATABASE_URL is unset and verifies the base schema is
-// present before returning a usable pool.
-func newEngineTestPool(t *testing.T) *pgxpool.Pool {
-	t.Helper()
+// ownedTestConfig points at the database TestMain provisioned for this binary.
+// It is nil when SILO_TEST_DATABASE_URL is unset, which makes every DB-backed
+// test in the package skip as before.
+var ownedTestConfig *pgxpool.Config
+
+// TestMain gives this package its own database.
+//
+// EmbedAll walks every embed-eligible row in media_items, so its tests can only
+// assert "nothing needed embedding" while no other writer exists. Prefix-scoping
+// inside the test cannot fix that — the operation under test is global.
+func TestMain(m *testing.M) {
 	dsn := os.Getenv("SILO_TEST_DATABASE_URL")
 	if dsn == "" {
+		os.Exit(m.Run())
+	}
+
+	config, drop, err := dbtest.Provision(context.Background(), dsn, "silo_recommendations",
+		func(ctx context.Context, pool *pgxpool.Pool) error {
+			return database.RunMigrations(ctx, pool, migrations.FS, "sql")
+		})
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "recommendations tests: %v\n", err)
+		os.Exit(1)
+	}
+	ownedTestConfig = config
+
+	code := m.Run()
+	drop()
+	os.Exit(code)
+}
+
+// newEngineTestPool returns a pool on the database TestMain provisioned for
+// this binary, skipping when SILO_TEST_DATABASE_URL is unset.
+func newEngineTestPool(t *testing.T) *pgxpool.Pool {
+	t.Helper()
+	if ownedTestConfig == nil {
 		t.Skip("SILO_TEST_DATABASE_URL is not set")
 	}
 	ctx := context.Background()
-	pool, err := pgxpool.New(ctx, dsn)
+	// Copy: a *pgxpool.Config may not back more than one pool.
+	pool, err := pgxpool.NewWithConfig(ctx, ownedTestConfig.Copy())
 	if err != nil {
 		t.Fatalf("connect test database: %v", err)
 	}

--- a/internal/recommendations/engine_test.go
+++ b/internal/recommendations/engine_test.go
@@ -50,7 +50,12 @@ func TestMain(m *testing.M) {
 	ownedTestConfig = config
 
 	code := m.Run()
-	drop()
+	if err := drop(); err != nil {
+		// Report but do not fail the run: the tests already passed or failed on
+		// their own merits, and a leaked database is a cleanup problem, not a
+		// verdict on the code under test.
+		fmt.Fprintf(os.Stderr, "recommendations tests: %v\n", err)
+	}
 	os.Exit(code)
 }
 


### PR DESCRIPTION
## Problem
Part of #599

`.github/workflows/ci.yml` provisions no PostgreSQL, so every DB-backed test hits its `t.Skip`. `go test` prints nothing for a skip, so `make test-go` reports green while **189 tests never execute**. They have not merely been unrun — they rotted, invisibly.

This PR is #599's Phases 1 and 2: make those tests correct and isolated. **It deliberately does not add the CI lane** (#599's Phase 3). That change needs a maintainer decision, and the ordering matters — a gate landing before the tests are stable would make `main` intermittently red, which is worse than the silent skip it replaces.

Seven tests failed deterministically against a real database, two packages were flaky, and one more package was found broken during the work:

| package | what was wrong |
|---|---|
| `notifications` ×3 | Fixture hand-wrote `CREATE TEMP TABLE push_devices`, shadowing the real table. It never gained `fcm_token_ciphertext` / `fcm_token_hash` from #409 (2026-07-14), so production code selecting those columns errored. Broken ~3 weeks. |
| `auth` ×1 | Fixture inserted a user with no `email`/`password_hash`; `scanUser` reads both into plain strings. |
| `catalog` ×1 | Assertion predated 6da6cf7a, which deliberately gave episode documents an explicit `_vectors.<embedder>: null` opt-out. |
| `markers` (flaky) | `TestMigrateDownToRestoresLegacyDisplayPrefs` rolled the **shared** schema down past `marker_contributions.claim_active` and never back up. |
| `recommendations` (flaky) | `EmbedAll` walks the whole `media_items` table; any concurrent writer breaks its "nothing needed embedding" assertion. |
| `downloads` (8/10 runs) | Three compounding defects — see below. Landed in #607/#608 **after** #599 was filed. |

`jellycompat`'s two failures are **not** in this PR: #616 already fixes them, and I verified that branch passes against a live database.

## Approach

**Fixtures derive from migrations; they never restate them.** All four `CREATE TEMP TABLE` fixtures now seed the real migrated tables, scoping identifiers with a nanosecond suffix and cleaning up through the real cascades. There are now **zero** `CREATE TEMP TABLE` in the repo. This paid off immediately: the real `release_events` carries `release_events_kind_shape_check` and `release_events_ordinals_check`, which the temp copy never had — the fixture had been seeding a row shape the real table rejects.

**Isolation only where the subject is genuinely global.** Most DB tests keep out of each other's way with unique suffixes, which is the existing idiom in 46 of 50 files and is left alone. Two cases cannot: a migration rollback rewrites the schema everyone reads, and `EmbedAll` is a whole-table pass. Those get their own database via `internal/dbtest`.

**`internal/dbtest` hands back a `*pgxpool.Config`, not a DSN string.** `ConnConfig.ConnString()` reports the string it was parsed from and does **not** reflect a later change to `ConnConfig.Database` — round-tripping through a string silently connects to the shared database while the migrations run somewhere else. That passes in isolation and fails only under `./...`, which is the worst failure signature available. It cost me a debugging cycle; the package doc says so.

**No production code changed.** The diff is test files, one new test-support package, and one `DEVELOPMENT.md` correction.

One thing I explicitly did **not** do: fix the `auth` failure by coalescing `email` in `UserRepository.Create`'s select. No production path writes a NULL email (`Create` always binds one; the plugin provider synthesizes `<user>@plugin-<id>.local`), so that would be a production change driven by a fixture artifact — and it only covers `email` before `password_hash` fails identically one column later. Whether `scanUser` should tolerate legacy rows carrying NULLs is a real question, but a separate one. Flagging in case you disagree.

### The `downloads` failures were three defects stacked

Worth spelling out, because each masked the next and the middle one made the package *look* healthy:

1. `lifecycleTestPreparer.DeleteArtifact` closed `deleteStarted` unconditionally and wrote its fields unguarded, but `cleanupRemoteOrphans` calls it from up to four goroutines. The second concurrent delete **panics on a closed channel**, killing the binary before any `t.Cleanup` runs — stranding a claimed artifact as `running`. `ClaimNext` and `ReclaimExpiredLeases` scan the whole table, so each leaked row broke `TestArtifactQueueClaimAndLeaseRecovery` on later runs.
2. `download_artifact_orphans.download_artifact_id` has no foreign key, so orphan rows outlive their artifact and nothing collects them. They accumulated until they crowded out `ListRemoteOrphansDue`'s 100-row window, and three tests stopped finding the orphan they had just enqueued.
3. Cleaning up (2) turned `TestRemoteCleanupBudgetBoundsUnreachableOrigins` red **12 of 12** — it never made its own orphan due (`EnqueueRemoteOrphan` backs the first attempt off 30s), so it had only ever passed on *stale orphans left by earlier runs*. The sibling test already cleared `next_retry_at`; this one now does too.

I report this because my first measurement of this package — "0 of 10 failures" — was wrong. It was measuring accumulated pollution, and only a clean table exposed it.

## Testing

Commands assume the repository root is the cwd. PostgreSQL must be `pgvector/pgvector:pg18` or equivalent — the migrations `CREATE EXTENSION vector`, `citext` and `pg_trgm`.

**Skips for a database reason, before and after — the headline number.** Counted by reason, not in total: a panicking package aborts its binary and its remaining tests never print a `SKIP` line at all, which makes the raw total move for reasons unrelated to the database.

```
$ go test ./... -count=1 -v 2>&1 | grep -B2 -- '--- SKIP' \
    | grep -oE '_test\.go:[0-9]+: .*' | sed 's/.*go:[0-9]*: //' | sort | uniq -c | sort -rn
    184 SILO_TEST_DATABASE_URL is not set
      2 set SILO_TEST_DATABASE_URL to run DB-backed push device repository test
      1 set SILO_TEST_DATABASE_URL to run DB-backed unmatched items handler test
      1 set SILO_TEST_DATABASE_URL to run DB-backed operational push dispatch test
      1 set SILO_TEST_DATABASE_URL to run DB-backed notification display handler test
      1 not a wire body

$ SILO_TEST_DATABASE_URL="$DSN" go test ./... -count=1 -v 2>&1 | grep -B2 -- '--- SKIP' \
    | grep -oE '_test\.go:[0-9]+: .*' | sed 's/.*go:[0-9]*: //' | sort | uniq -c | sort -rn
      1 not a wire body
```

**189 database skips → 0. `--- PASS` goes 9,090 → 9,354: 264 tests that had never run.**

**Every touched package, against a live database:**

```
$ SILO_TEST_DATABASE_URL="$DSN" go test -count=1 ./internal/notifications ./internal/auth \
    ./internal/catalog ./internal/database ./internal/recommendations ./internal/historyimport \
    ./internal/api/handlers ./internal/downloads ./internal/markers ./internal/dbtest
ok  	github.com/Silo-Server/silo-server/internal/notifications	0.515s
ok  	github.com/Silo-Server/silo-server/internal/auth	0.995s
ok  	github.com/Silo-Server/silo-server/internal/catalog	5.460s
ok  	github.com/Silo-Server/silo-server/internal/database	7.679s
ok  	github.com/Silo-Server/silo-server/internal/recommendations	7.587s
ok  	github.com/Silo-Server/silo-server/internal/historyimport	3.512s
ok  	github.com/Silo-Server/silo-server/internal/api/handlers	89.896s
ok  	github.com/Silo-Server/silo-server/internal/downloads	4.728s
ok  	github.com/Silo-Server/silo-server/internal/markers	0.638s
?   	github.com/Silo-Server/silo-server/internal/dbtest	[no test files]
```

**Flakiness, measured rather than asserted:**

| | before | after |
|---|---|---|
| `internal/database` + `internal/markers`, 18 runs | 2 failed | **0 failed** |
| `internal/downloads`, 10–12 runs | 8/10 failed | **0/12 failed**, no rows left behind |
| `internal/downloads` under `-race` | panic | `ok ... 5.749s` |

**Full suite at default parallelism, database attached** — the only failures are the two `jellycompat` tests #616 fixes:

```
run 1: --- FAIL: TestDurableCompatPlaybackStoreRevalidatesUnstartedNegotiationAcrossInstances
       --- FAIL: TestDurableCompatPlaybackStorePutNegotiatedReplacesAcrossInstances
run 2: (identical)
```

**Verify commands:**

```
$ make verify-local-paths
scripts/check-local-path-leaks.sh          # exit 0

$ gofmt -l . | grep -v '^web/'             # no output

$ go vet ./internal/dbtest ./internal/downloads ./internal/notifications ./internal/auth \
    ./internal/catalog ./internal/database ./internal/recommendations ./internal/historyimport \
    ./internal/api/handlers                # no output

$ golangci-lint run --new-from-merge-base=origin/main ./...
0 issues.
```

`golangci-lint` is shown the way CI runs it (`--new-from-merge-base`); a full-tree `make lint` still reports the repo's pre-existing findings, none of them from this branch. The web commands (`pnpm run lint`, `format:check`) were **not** run — `pnpm` is not installed on this machine, and this PR changes no frontend files.

### AI Disclosure
- Tool(s): Claude Code
- Model(s): claude-opus-5
- Involvement: AI-assisted
- Adversarial review: An adversarial audit of this diff ran before filing and changed it materially. It caught that (a) my skip counts were unreliable because a panicking package suppresses `SKIP` lines — the counting method above is the fix; (b) the per-database helper was **duplicated** across two packages, the same restated-logic failure this PR exists to remove, one layer up — extracted to `internal/dbtest`; (c) comment density was 21.8% against a ~3% repo baseline, mostly comments narrating what the code used to be — trimmed, that content lives here in the PR body instead; (d) `DEVELOPMENT.md` claimed the Go tests use testcontainers, which appears in no `go.mod` or `.go` file; (e) the service health check in the held-back CI job overclaims — measured locally, first-healthy leads first-queryable by 1.7–3.5s. It also produced the stack trace that led to the `downloads` double-close, which I had misdiagnosed as a timeout. Unverified: the "prove the gate gates" step needs a push and belongs with Phase 3.

## Checklist
- [x] I ran an adversarial AI review of the diff and summarized findings above.
- [ ] I ran the repo verify commands: `make lint`, `cd web && pnpm run lint`, `cd web && pnpm run format:check`, and relevant `go test ./...`. — *Go side yes, output above. The two `pnpm` commands were not run (`pnpm` unavailable here; no frontend files changed), so this is left unticked rather than overclaimed.*


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated Go test setup instructions with PostgreSQL configuration, migrations, and pgvector-compatible images.
  * Documented that database-backed tests skip when no test database URL is configured.

* **Tests**
  * Improved database test isolation, cleanup, fixtures, and concurrency safety.
  * Updated tests to use migrated schemas and isolated databases instead of temporary tables.
  * Added coverage for vector behavior and recommendations compatibility.
  * Improved notification, download, history import, and migration test reliability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->