### PR TITLE
fix(watchsync): import MDBList episode history leaves

### DIFF
--- a/internal/watchsync/providers/mdblist/provider.go
+++ b/internal/watchsync/providers/mdblist/provider.go
@@ -278,8 +278,8 @@ func progressFromPlayback(providerKey string, item mdblistPlaybackItem) (watchsy
 	}, true
 }
 
-// MDBList exposes a watched snapshot rather than a per-play history, so each
-// watched record surfaces once with its last_watched_at as the play timestamp.
+// FetchWatched requests MDBList's per-play history, so preserve each returned
+// movie or episode play and its watched timestamp for exact export reconciliation.
 func (p *Provider) FetchHistory(ctx context.Context, cfg watchsync.ServerConfig, conn watchsync.Connection) ([]watchsync.RemotePlay, error) {
 	rows, err := p.FetchWatched(ctx, cfg, conn)
 	if err != nil {

--- a/internal/watchsync/providers/mdblist/provider.go
+++ b/internal/watchsync/providers/mdblist/provider.go
@@ -130,7 +130,9 @@ func (p *Provider) FetchWatched(ctx context.Context, _ watchsync.ServerConfig, c
 	page := mdblistPageState{}
 	for {
 		var payload mdblistWatchedResponse
-		path := page.path("/sync/watched")
+		// Request concrete play history. MDBList documents plays=all as returning
+		// movie and episode leaves only, avoiding ambiguous show/season rollups.
+		path := page.path("/sync/watched") + "&plays=all"
 		if err := p.do(ctx, http.MethodGet, path, conn.AccessToken, nil, &payload); err != nil {
 			return nil, err
 		}
@@ -149,7 +151,11 @@ func (p *Provider) FetchWatched(ctx context.Context, _ watchsync.ServerConfig, c
 }
 
 func watchedRowsFromPayload(providerKey string, payload mdblistWatchedResponse) []watchsync.RemoteWatch {
-	rows := make([]watchsync.RemoteWatch, 0, len(payload.Movies)+len(payload.Shows)+len(payload.Seasons)+len(payload.Episodes))
+	// The shows and seasons arrays are rollups of episode watched state, not
+	// independent proof that every episode in that scope was watched. Import
+	// only the playable leaves; Silo derives season and series completion from
+	// their episode state.
+	rows := make([]watchsync.RemoteWatch, 0, len(payload.Movies)+len(payload.Episodes))
 	for _, movie := range payload.Movies {
 		watchedAt := movie.LastWatchedAt
 		if watchedAt == nil {
@@ -168,53 +174,6 @@ func watchedRowsFromPayload(providerKey string, payload mdblistWatchedResponse) 
 			IMDbID:          movie.Movie.IDs.IMDb,
 			TMDBID:          intString(movie.Movie.IDs.TMDB),
 			TVDBID:          intString(movie.Movie.IDs.TVDB),
-			PlayCount:       1,
-			LastWatchedAt:   watchedAt,
-		})
-	}
-	for _, show := range payload.Shows {
-		watchedAt := show.LastWatchedAt
-		if watchedAt == nil {
-			continue
-		}
-		key := showKey(show.Show.IDs)
-		if key == "" {
-			continue
-		}
-		rows = append(rows, watchsync.RemoteWatch{
-			Provider:        providerKey,
-			ProviderItemKey: "show:" + key,
-			Kind:            historyimport.KindSeries,
-			Title:           show.Show.Title,
-			Year:            show.Show.Year,
-			IMDbID:          show.Show.IDs.IMDb,
-			TMDBID:          intString(show.Show.IDs.TMDB),
-			TVDBID:          intString(show.Show.IDs.TVDB),
-			PlayCount:       1,
-			LastWatchedAt:   watchedAt,
-		})
-	}
-	for _, season := range payload.Seasons {
-		watchedAt := season.LastWatchedAt
-		if watchedAt == nil {
-			continue
-		}
-		key := showKey(season.Season.Show.IDs)
-		if key == "" {
-			continue
-		}
-		rows = append(rows, watchsync.RemoteWatch{
-			Provider:        providerKey,
-			ProviderItemKey: fmt.Sprintf("show:%s:s%d", key, season.Season.Number),
-			Kind:            historyimport.KindSeason,
-			Title:           season.Season.Name,
-			TMDBID:          intString(season.Season.IDs.TMDB),
-			SeriesTitle:     season.Season.Show.Title,
-			SeriesYear:      season.Season.Show.Year,
-			SeriesIMDbID:    season.Season.Show.IDs.IMDb,
-			SeriesTMDBID:    intString(season.Season.Show.IDs.TMDB),
-			SeriesTVDBID:    intString(season.Season.Show.IDs.TVDB),
-			SeasonNumber:    season.Season.Number,
 			PlayCount:       1,
 			LastWatchedAt:   watchedAt,
 		})

--- a/internal/watchsync/providers/mdblist/provider_test.go
+++ b/internal/watchsync/providers/mdblist/provider_test.go
@@ -75,9 +75,12 @@ func TestConnectWithAPIKeyRejectsEmpty(t *testing.T) {
 	}
 }
 
-func TestFetchWatchedParsesCurrentMoviesShowsSeasonsAndEpisodes(t *testing.T) {
+func TestFetchWatchedImportsPlayableLeavesWithoutExpandingAggregateRows(t *testing.T) {
 	watched := time.Date(2025, time.October, 21, 12, 0, 0, 0, time.UTC)
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if got := r.URL.Query().Get("plays"); got != "all" {
+			t.Fatalf("plays query = %q, want all", got)
+		}
 		w.Header().Set("Content-Type", "application/json")
 		_ = json.NewEncoder(w).Encode(map[string]any{
 			"movies": []map[string]any{{
@@ -91,9 +94,9 @@ func TestFetchWatchedParsesCurrentMoviesShowsSeasonsAndEpisodes(t *testing.T) {
 			"shows": []map[string]any{{
 				"last_watched_at": watched.Format(time.RFC3339),
 				"show": map[string]any{
-					"title": "The Expanse",
-					"year":  2015,
-					"ids":   map[string]any{"tvdb": 280619, "tmdb": 63639},
+					"title": "Breaking Bad",
+					"year":  2008,
+					"ids":   map[string]any{"tvdb": 81189, "tmdb": 1396},
 				},
 			}},
 			"seasons": []map[string]any{{
@@ -133,23 +136,17 @@ func TestFetchWatchedParsesCurrentMoviesShowsSeasonsAndEpisodes(t *testing.T) {
 	if err != nil {
 		t.Fatalf("fetch watched: %v", err)
 	}
-	if len(rows) != 4 {
-		t.Fatalf("got %d rows, want 4", len(rows))
+	if len(rows) != 2 {
+		t.Fatalf("got %d rows, want 2", len(rows))
 	}
 	if rows[0].Kind != historyimport.KindMovie || rows[0].ProviderItemKey != "imdb:tt2049403" {
 		t.Fatalf("unexpected movie row: %#v", rows[0])
 	}
-	if rows[1].Kind != historyimport.KindSeries || rows[1].ProviderItemKey != "show:tvdb:280619" {
-		t.Fatalf("unexpected show row: %#v", rows[1])
+	if rows[1].Kind != historyimport.KindEpisode || rows[1].SeasonNumber != 1 || rows[1].EpisodeNumber != 2 {
+		t.Fatalf("unexpected episode row: %#v", rows[1])
 	}
-	if rows[2].Kind != historyimport.KindSeason || rows[2].SeasonNumber != 2 || rows[2].SeriesTMDBID != "1396" {
-		t.Fatalf("unexpected season row: %#v", rows[2])
-	}
-	if rows[3].Kind != historyimport.KindEpisode || rows[3].SeasonNumber != 1 || rows[3].EpisodeNumber != 2 {
-		t.Fatalf("unexpected episode row: %#v", rows[3])
-	}
-	if rows[3].Title != "Cat's in the Bag..." || rows[3].SeriesIMDbID != "tt0903747" {
-		t.Fatalf("expected nested episode/show fields propagated, got %#v", rows[3])
+	if rows[1].Title != "Cat's in the Bag..." || rows[1].SeriesIMDbID != "tt0903747" {
+		t.Fatalf("expected nested episode/show fields propagated, got %#v", rows[1])
 	}
 	for i, row := range rows {
 		if row.LastWatchedAt == nil || !row.LastWatchedAt.Equal(watched) {
@@ -255,8 +252,8 @@ func TestFetchWatchedOffsetCountsAggregateRows(t *testing.T) {
 	if err != nil {
 		t.Fatalf("fetch watched: %v", err)
 	}
-	if len(rows) != 2 {
-		t.Fatalf("got %d rows, want 2", len(rows))
+	if len(rows) != 0 {
+		t.Fatalf("got %d rows, want aggregate rows excluded", len(rows))
 	}
 	if len(offsets) != 2 || offsets[0] != "" || offsets[1] != "2" {
 		t.Fatalf("unexpected offsets: %#v", offsets)


### PR DESCRIPTION
## Problem

Fixes #642. Regression from #628.

MDBList watched responses can include show and season rollups alongside the concrete episodes a user watched. Treating those rollups as independent completion markers expands each one to every local episode released by `last_watched_at`, causing partially watched series to become fully watched in Silo.

## Change

- request MDBList concrete play history with `plays=all`, which the API documents as movie/episode-only
- import only movie and episode leaves even if a response contains aggregate show/season rows
- continue counting aggregate rows when advancing legacy offset pagination
- cover an overlapping response where the show, season, and watched episode all belong to the same series

Silo continues to derive season and series completion from imported episode state.

## Verification

```text
$ go test ./internal/watchsync/providers/mdblist ./internal/watchsync ./internal/historyimport
ok  github.com/Silo-Server/silo-server/internal/watchsync/providers/mdblist  4.016s
ok  github.com/Silo-Server/silo-server/internal/watchsync  (cached)
ok  github.com/Silo-Server/silo-server/internal/historyimport  (cached)

$ make verify-local-paths
scripts/check-local-path-leaks.sh

$ make lint
golangci-lint run
make: golangci-lint: No such file or directory
make: *** [Makefile:54: lint] Error 127

$ cd web && pnpm run lint && pnpm run format:check
zsh:1: command not found: pnpm
```

## Risk

An explicit show- or season-level watched action must still resolve to episodes. The request now uses `plays=all`; MDBList documents that mode as returning one row per movie/episode play, including episodes produced by server-side show/season expansion. The parser also defensively excludes aggregate rows, preventing mixed or legacy response shapes from restoring the regression.

### AI Disclosure
- Tool(s): Codex
- Model(s): gpt-5
- Involvement: fully AI-generated
- Adversarial review: Reviewed pagination, legacy response compatibility, duplicate play behavior, and explicit whole-show/season actions. Kept aggregate rows in pagination accounting, relied on documented `plays=all` leaf expansion for explicit aggregate actions, and retained service-level newest-timestamp deduplication for repeated plays.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved MDBList watched-history imports to include only playable movies and episodes.
  * Prevented duplicate or inaccurate records from show and season rollups.
  * Preserved exact play history for more reliable exports and synchronization.
  * Improved pagination handling when aggregate entries are skipped.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->