### PR TITLE
fix(watchstate): make series mark-watched atomic and unload-proof

### DIFF
--- a/internal/api/handlers/items.go
+++ b/internal/api/handlers/items.go
@@ -2264,15 +2264,40 @@ func (h *ItemsHandler) resolveWatchedTargets(ctx context.Context, contentID stri
 	}}, nil
 }
 
+// episodeTargets resolves the watched leaf targets for a season or series.
+// Durations come from one batched file lookup rather than a query per episode:
+// marking a long series used to issue one GetByEpisodeID per episode before it
+// wrote anything.
 func (h *ItemsHandler) episodeTargets(ctx context.Context, episodes []*models.Episode) []watchedLeafTarget {
+	episodeIDs := make([]string, 0, len(episodes))
+	for _, episode := range episodes {
+		episodeIDs = append(episodeIDs, episode.ContentID)
+	}
+	filesByEpisode := h.listEpisodeFiles(ctx, episodeIDs)
+
 	targets := make([]watchedLeafTarget, 0, len(episodes))
 	for _, episode := range episodes {
 		targets = append(targets, watchedLeafTarget{
 			ContentID:       episode.ContentID,
-			DurationSeconds: h.contentDurationSeconds(ctx, "", episode.ContentID, episode.Runtime),
+			DurationSeconds: mediaFileDurationSeconds(filesByEpisode[episode.ContentID], episode.Runtime),
 		})
 	}
 	return targets
+}
+
+// mediaFileDurationSeconds picks a playable duration from an item's files,
+// falling back to the catalog runtime. Mirrors contentDurationSeconds's
+// preference order so the batched and single-item paths agree.
+func mediaFileDurationSeconds(files []*models.MediaFile, fallbackRuntimeMinutes int) float64 {
+	for _, file := range files {
+		if file != nil && file.Duration > 0 {
+			return float64(file.Duration)
+		}
+	}
+	if fallbackRuntimeMinutes > 0 {
+		return float64(fallbackRuntimeMinutes * 60)
+	}
+	return 0
 }
 
 func (h *ItemsHandler) contentDurationSeconds(ctx context.Context, contentID, episodeID string, fallbackRuntimeMinutes int) float64 {
@@ -2294,18 +2319,10 @@ func (h *ItemsHandler) contentDurationSeconds(ctx context.Context, contentID, ep
 	case contentID != "":
 		files, err = h.fileRepo.GetByContentID(ctx, contentID)
 	}
-	if err == nil {
-		for _, file := range files {
-			if file != nil && file.Duration > 0 {
-				return float64(file.Duration)
-			}
-		}
+	if err != nil {
+		files = nil
 	}
-
-	if fallbackRuntimeMinutes > 0 {
-		return float64(fallbackRuntimeMinutes * 60)
-	}
-	return 0
+	return mediaFileDurationSeconds(files, fallbackRuntimeMinutes)
 }
 
 // isNotFound checks if an error is a "not found" sentinel.

--- a/internal/userdb/conformance_test.go
+++ b/internal/userdb/conformance_test.go
@@ -27,6 +27,14 @@ func TestSQLiteProgressSince(t *testing.T) {
 	storetest.RunProgressSince(t, newConformanceStore)
 }
 
+// TestSQLiteMarkWatchedBatch runs the batch mark-watched conformance test
+// (series/season mark-watched) against the real SQLite backend. The Postgres
+// backend runs the same suite in internal/userstore/pgstore, which is what
+// keeps the two transactional implementations from drifting.
+func TestSQLiteMarkWatchedBatch(t *testing.T) {
+	storetest.RunMarkWatchedBatch(t, newConformanceStore)
+}
+
 // TestSQLiteSettingValues runs the canonical settings-contract storage
 // conformance tests against the per-user SQLite backend. The Postgres backend
 // runs the same suite in internal/userstore/pgstore, which is what keeps the two

--- a/internal/userdb/progress.go
+++ b/internal/userdb/progress.go
@@ -1,6 +1,7 @@
 package userdb
 
 import (
+	"context"
 	"database/sql"
 	"encoding/json"
 	"fmt"
@@ -171,14 +172,9 @@ func SetProgressIfNewer(db *sql.DB, profileID, mediaItemID string, position, dur
 	return rows > 0, nil
 }
 
-// MarkWatched creates or replaces progress with a completed entry.
-func MarkWatched(db *sql.DB, profileID, mediaItemID string, duration float64) error {
-	if duration < 0 {
-		duration = 0
-	}
-
-	now := nowUTC()
-	query := `
+// markWatchedProgressSQL upserts one completed progress row, honoring the
+// hidden-history watermark.
+const markWatchedProgressSQL = `
 		INSERT INTO watch_progress (profile_id, media_item_id, position_seconds, duration_seconds, completed, updated_at)
 		SELECT ?, ?, 0, ?, 1, ` + visibleTimestampSQL + `
 		FROM (SELECT 1) seed
@@ -193,7 +189,133 @@ func MarkWatched(db *sql.DB, profileID, mediaItemID string, duration float64) er
 			updated_at = excluded.updated_at,
 			event_at = excluded.updated_at
 	`
-	_, err := db.Exec(query, profileID, mediaItemID, duration, now, now, profileID, mediaItemID)
+
+// markWatchedBatchProgressSQL is markWatchedProgressSQL with one difference: a
+// zero duration leaves any known duration in place. The batch path now also
+// serves jellycompat's series mark-played, which supplies no durations and
+// previously ran through MarkProgressBatch without touching the column.
+const markWatchedBatchProgressSQL = `
+		INSERT INTO watch_progress (profile_id, media_item_id, position_seconds, duration_seconds, completed, updated_at)
+		SELECT ?, ?, 0, ?, 1, ` + visibleTimestampSQL + `
+		FROM (SELECT 1) seed
+		LEFT JOIN hidden_history_items hhi
+		  ON hhi.profile_id = ?
+		 AND hhi.media_item_id = ?
+		WHERE true
+		ON CONFLICT(profile_id, media_item_id) DO UPDATE SET
+			position_seconds = 0,
+			duration_seconds = CASE
+				WHEN excluded.duration_seconds > 0 THEN excluded.duration_seconds
+				ELSE watch_progress.duration_seconds
+			END,
+			completed = 1,
+			updated_at = excluded.updated_at,
+			event_at = excluded.updated_at
+	`
+
+// addVisibleHistorySQL inserts one history row at a watermark-adjusted
+// timestamp and returns the timestamp actually stored.
+const addVisibleHistorySQL = `
+		INSERT INTO watch_history (id, profile_id, media_item_id, watched_at, duration_seconds, completed, source, watch_identity)
+		SELECT ?, ?, ?, ` + visibleTimestampSQL + `, ?, ?, ?, ?
+		FROM (SELECT 1) seed
+		LEFT JOIN hidden_history_items hhi
+		  ON hhi.profile_id = ?
+		 AND hhi.media_item_id = ?
+		WHERE true
+		RETURNING watched_at
+	`
+
+// MarkWatchedBatch marks every target watched and records its history entry
+// inside a single transaction, so a canceled series mark rolls back to
+// "nothing marked" rather than stranding a partial subset. SQLite round-trips
+// are local and cheap, so this reuses the same per-row statements as the
+// single-item path and buys atomicity rather than fewer queries.
+//
+// Unlike most of this package it honors ctx: cancellation safety is the whole
+// point of the transaction, and a caller that disconnects mid-mark must leave
+// the series untouched rather than half-watched.
+func MarkWatchedBatch(
+	ctx context.Context,
+	db *sql.DB,
+	profileID string,
+	targets []userstore.MarkWatchedTarget,
+	entries []userstore.WatchHistoryEntry,
+) ([]userstore.WatchHistoryEntry, error) {
+	if len(targets) == 0 {
+		return nil, nil
+	}
+
+	tx, err := db.BeginTx(ctx, nil)
+	if err != nil {
+		return nil, fmt.Errorf("begin mark watched batch: %w", err)
+	}
+	defer tx.Rollback() //nolint:errcheck // rollback after commit is a no-op
+
+	now := nowUTC()
+	seen := make(map[string]struct{}, len(targets))
+	for _, target := range targets {
+		mediaItemID := strings.TrimSpace(target.MediaItemID)
+		if mediaItemID == "" {
+			continue
+		}
+		if _, ok := seen[mediaItemID]; ok {
+			continue
+		}
+		seen[mediaItemID] = struct{}{}
+		duration := target.DurationSeconds
+		if duration < 0 {
+			duration = 0
+		}
+		if _, err := tx.ExecContext(ctx, markWatchedBatchProgressSQL,
+			profileID, mediaItemID, duration, now, now, profileID, mediaItemID,
+		); err != nil {
+			return nil, fmt.Errorf("marking watched batch: %w", err)
+		}
+	}
+
+	written := make([]userstore.WatchHistoryEntry, 0, len(entries))
+	for _, entry := range entries {
+		if strings.TrimSpace(entry.MediaItemID) == "" {
+			continue
+		}
+		if entry.ID == "" {
+			entry.ID = generateUUID()
+		}
+		if entry.WatchedAt == "" {
+			entry.WatchedAt = now
+		}
+		if entry.Source == "" {
+			entry.Source = userstore.WatchHistorySourceLegacy
+		}
+		identityJSON, err := json.Marshal(entry.Identity)
+		if err != nil {
+			return nil, fmt.Errorf("marshaling watch identity: %w", err)
+		}
+		if err := tx.QueryRowContext(ctx, addVisibleHistorySQL,
+			entry.ID, entry.ProfileID, entry.MediaItemID, entry.WatchedAt, entry.WatchedAt,
+			entry.DurationSeconds, entry.Completed, entry.Source, string(identityJSON),
+			entry.ProfileID, entry.MediaItemID,
+		).Scan(&entry.WatchedAt); err != nil {
+			return nil, fmt.Errorf("adding visible history batch: %w", err)
+		}
+		written = append(written, entry)
+	}
+
+	if err := tx.Commit(); err != nil {
+		return nil, fmt.Errorf("commit mark watched batch: %w", err)
+	}
+	return written, nil
+}
+
+// MarkWatched creates or replaces progress with a completed entry.
+func MarkWatched(db *sql.DB, profileID, mediaItemID string, duration float64) error {
+	if duration < 0 {
+		duration = 0
+	}
+
+	now := nowUTC()
+	_, err := db.Exec(markWatchedProgressSQL, profileID, mediaItemID, duration, now, now, profileID, mediaItemID)
 	if err != nil {
 		return fmt.Errorf("marking watched: %w", err)
 	}
@@ -584,16 +706,11 @@ func AddVisibleHistory(db *sql.DB, entry WatchHistoryEntry) (WatchHistoryEntry, 
 	if err != nil {
 		return entry, fmt.Errorf("marshaling watch identity: %w", err)
 	}
-	if err := db.QueryRow(`
-		INSERT INTO watch_history (id, profile_id, media_item_id, watched_at, duration_seconds, completed, source, watch_identity)
-		SELECT ?, ?, ?, `+visibleTimestampSQL+`, ?, ?, ?, ?
-		FROM (SELECT 1) seed
-		LEFT JOIN hidden_history_items hhi
-		  ON hhi.profile_id = ?
-		 AND hhi.media_item_id = ?
-		WHERE true
-		RETURNING watched_at
-	`, entry.ID, entry.ProfileID, entry.MediaItemID, entry.WatchedAt, entry.WatchedAt, entry.DurationSeconds, entry.Completed, entry.Source, string(identityJSON), entry.ProfileID, entry.MediaItemID).Scan(&entry.WatchedAt); err != nil {
+	if err := db.QueryRow(addVisibleHistorySQL,
+		entry.ID, entry.ProfileID, entry.MediaItemID, entry.WatchedAt, entry.WatchedAt,
+		entry.DurationSeconds, entry.Completed, entry.Source, string(identityJSON),
+		entry.ProfileID, entry.MediaItemID,
+	).Scan(&entry.WatchedAt); err != nil {
 		return entry, fmt.Errorf("adding visible history entry: %w", err)
 	}
 	return entry, nil

--- a/internal/userdb/sqlitestore.go
+++ b/internal/userdb/sqlitestore.go
@@ -24,6 +24,7 @@ func NewSQLiteUserStore(db *sql.DB) *SQLiteUserStore {
 // Compile-time interface check.
 var _ userstore.UserStore = (*SQLiteUserStore)(nil)
 var _ userstore.DeviceRegistry = (*SQLiteUserStore)(nil)
+var _ userstore.WatchedBatchWriter = (*SQLiteUserStore)(nil)
 
 // --- Profiles ---
 
@@ -79,6 +80,12 @@ func (s *SQLiteUserStore) MarkWatched(_ context.Context, profileID, mediaItemID 
 
 func (s *SQLiteUserStore) ClearProgress(_ context.Context, profileID, mediaItemID string) error {
 	return ClearProgress(s.db, profileID, mediaItemID)
+}
+
+// MarkWatchedBatch is one of the few paths here that forwards ctx: the write
+// is transactional precisely so a canceled request marks nothing.
+func (s *SQLiteUserStore) MarkWatchedBatch(ctx context.Context, profileID string, targets []userstore.MarkWatchedTarget, entries []userstore.WatchHistoryEntry) ([]userstore.WatchHistoryEntry, error) {
+	return MarkWatchedBatch(ctx, s.db, profileID, targets, entries)
 }
 
 func (s *SQLiteUserStore) MarkProgressBatch(_ context.Context, profileID string, mediaItemIDs []string, updatedAt time.Time) error {

--- a/internal/userstore/pgstore/conformance_test.go
+++ b/internal/userstore/pgstore/conformance_test.go
@@ -58,6 +58,42 @@ func TestPostgresProgressSince(t *testing.T) {
 	})
 }
 
+// TestPostgresMarkWatchedBatch runs the batch mark-watched conformance test
+// (series/season mark-watched) against the Postgres backend. The per-user
+// SQLite backend runs the same suite in internal/userdb, which is what keeps
+// the two transactional implementations from drifting. Skips unless
+// SILO_TEST_DATABASE_URL is set.
+func TestPostgresMarkWatchedBatch(t *testing.T) {
+	dsn := os.Getenv("SILO_TEST_DATABASE_URL")
+	if dsn == "" {
+		t.Skip("SILO_TEST_DATABASE_URL is not set")
+	}
+	ctx := context.Background()
+	pool, err := pgxpool.New(ctx, dsn)
+	if err != nil {
+		t.Fatalf("connect test database: %v", err)
+	}
+	t.Cleanup(pool.Close)
+
+	storetest.RunMarkWatchedBatch(t, func(t *testing.T) userstore.UserStore {
+		var userID int
+		if err := pool.QueryRow(ctx,
+			`INSERT INTO users (username, role) VALUES ($1, 'user') RETURNING id`,
+			fmt.Sprintf("conf-markwatched-%d", time.Now().UnixNano()),
+		).Scan(&userID); err != nil {
+			t.Fatalf("seed user: %v", err)
+		}
+		t.Cleanup(func() {
+			_, _ = pool.Exec(ctx, `DELETE FROM user_watch_history WHERE user_id = $1`, userID)
+			_, _ = pool.Exec(ctx, `DELETE FROM user_history_hidden_items WHERE user_id = $1`, userID)
+			_, _ = pool.Exec(ctx, `DELETE FROM user_watch_progress WHERE user_id = $1`, userID)
+			_, _ = pool.Exec(ctx, `DELETE FROM user_profiles WHERE user_id = $1`, userID)
+			_, _ = pool.Exec(ctx, `DELETE FROM users WHERE id = $1`, userID)
+		})
+		return newStore(pool, userID)
+	})
+}
+
 // TestPostgresSettingValues runs the canonical settings-contract storage
 // conformance tests against the Postgres backend. The per-user SQLite backend
 // runs the same suite in internal/userdb, which is what keeps the two from

--- a/internal/userstore/pgstore/pgstore.go
+++ b/internal/userstore/pgstore/pgstore.go
@@ -19,6 +19,7 @@ type PostgresUserStore struct {
 // Compile-time interface check.
 var _ userstore.UserStore = (*PostgresUserStore)(nil)
 var _ userstore.DeviceRegistry = (*PostgresUserStore)(nil)
+var _ userstore.WatchedBatchWriter = (*PostgresUserStore)(nil)
 
 // newStore creates a PostgresUserStore scoped to a user.
 func newStore(pool *pgxpool.Pool, userID int) *PostgresUserStore {

--- a/internal/userstore/pgstore/progress.go
+++ b/internal/userstore/pgstore/progress.go
@@ -316,6 +316,209 @@ func (s *PostgresUserStore) ClearProgress(ctx context.Context, profileID, mediaI
 	return nil
 }
 
+// MarkWatchedBatch marks every target watched and inserts its history row in
+// one transaction, so a series mark either lands whole or not at all. The
+// prior per-episode loop committed each episode separately, which left a large
+// series half-marked whenever the client disconnected mid-request.
+//
+// Two statements rather than a reuse of MarkProgressBatch: that one hardcodes
+// duration_seconds = 0, and the manual mark-watched path must preserve each
+// episode's real duration. Both statements carry the same
+// user_history_hidden_items watermark logic as their single-row counterparts
+// (MarkWatched, AddVisibleHistory) so a mark after a history removal stays
+// visible.
+func (s *PostgresUserStore) MarkWatchedBatch(
+	ctx context.Context,
+	profileID string,
+	targets []userstore.MarkWatchedTarget,
+	entries []userstore.WatchHistoryEntry,
+) ([]userstore.WatchHistoryEntry, error) {
+	if len(targets) == 0 {
+		return nil, nil
+	}
+
+	mediaItemIDs := make([]string, 0, len(targets))
+	durations := make([]float64, 0, len(targets))
+	seen := make(map[string]struct{}, len(targets))
+	for _, target := range targets {
+		mediaItemID := strings.TrimSpace(target.MediaItemID)
+		if mediaItemID == "" {
+			continue
+		}
+		if _, ok := seen[mediaItemID]; ok {
+			continue
+		}
+		seen[mediaItemID] = struct{}{}
+		duration := target.DurationSeconds
+		if duration < 0 {
+			duration = 0
+		}
+		mediaItemIDs = append(mediaItemIDs, mediaItemID)
+		durations = append(durations, duration)
+	}
+	if len(mediaItemIDs) == 0 {
+		return nil, nil
+	}
+
+	now := time.Now().UTC()
+
+	historyIDs := make([]string, 0, len(entries))
+	historyItemIDs := make([]string, 0, len(entries))
+	historyWatchedAt := make([]time.Time, 0, len(entries))
+	historyDurations := make([]float64, 0, len(entries))
+	historyCompleted := make([]bool, 0, len(entries))
+	historySources := make([]string, 0, len(entries))
+	historyIdentities := make([]string, 0, len(entries))
+	// Entries with a blank media ID are dropped, so keep an explicit map back
+	// to the caller's slice rather than assuming positional alignment.
+	historySourceIndex := make([]int, 0, len(entries))
+	for entryIndex, entry := range entries {
+		mediaItemID := strings.TrimSpace(entry.MediaItemID)
+		if mediaItemID == "" {
+			continue
+		}
+		id := entry.ID
+		if id == "" {
+			id = generateUUID()
+		}
+		watchedAt := now
+		if entry.WatchedAt != "" {
+			parsed, err := time.Parse(time.RFC3339, entry.WatchedAt)
+			if err != nil {
+				return nil, fmt.Errorf("parsing watched_at for %s: %w", mediaItemID, err)
+			}
+			watchedAt = parsed.UTC()
+		}
+		source := entry.Source
+		if source == "" {
+			source = userstore.WatchHistorySourceLegacy
+		}
+		identityJSON, err := json.Marshal(entry.Identity)
+		if err != nil {
+			return nil, fmt.Errorf("marshaling watch identity: %w", err)
+		}
+		historyIDs = append(historyIDs, id)
+		historyItemIDs = append(historyItemIDs, mediaItemID)
+		historyWatchedAt = append(historyWatchedAt, watchedAt)
+		historyDurations = append(historyDurations, entry.DurationSeconds)
+		historyCompleted = append(historyCompleted, entry.Completed)
+		historySources = append(historySources, string(source))
+		historyIdentities = append(historyIdentities, string(identityJSON))
+		historySourceIndex = append(historySourceIndex, entryIndex)
+	}
+
+	tx, err := s.pool.Begin(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("begin mark watched batch: %w", err)
+	}
+	defer tx.Rollback(ctx) //nolint:errcheck
+
+	if _, err := tx.Exec(ctx, `
+		WITH target(media_item_id, duration_seconds) AS (
+			SELECT * FROM unnest($3::text[], $4::double precision[])
+		),
+		visible AS (
+			SELECT
+				t.media_item_id,
+				t.duration_seconds,
+				CASE
+					WHEN hhi.hidden_before IS NOT NULL AND $5::timestamptz <= hhi.hidden_before
+					THEN hhi.hidden_before + interval '1 second'
+					ELSE $5::timestamptz
+				END AS updated_at
+			FROM target t
+			LEFT JOIN user_history_hidden_items hhi
+			  ON hhi.user_id = $1
+			 AND hhi.profile_id = $2
+			 AND hhi.media_item_id = t.media_item_id
+		)
+		INSERT INTO user_watch_progress
+			(user_id, profile_id, media_item_id, position_seconds, duration_seconds, completed, updated_at)
+		SELECT $1, $2, media_item_id, 0, duration_seconds, TRUE, updated_at
+		FROM visible
+		ON CONFLICT (user_id, profile_id, media_item_id) DO UPDATE SET
+			position_seconds = 0,
+			-- Keep a known duration when the caller has none: jellycompat's
+			-- series mark-played passes 0 for every target, and its previous
+			-- MarkProgressBatch path left duration_seconds untouched.
+			duration_seconds = CASE
+				WHEN EXCLUDED.duration_seconds > 0 THEN EXCLUDED.duration_seconds
+				ELSE user_watch_progress.duration_seconds
+			END,
+			completed = TRUE,
+			updated_at = EXCLUDED.updated_at,
+			event_at = EXCLUDED.updated_at`,
+		s.userID, profileID, mediaItemIDs, durations, now,
+	); err != nil {
+		return nil, fmt.Errorf("marking watched batch: %w", err)
+	}
+
+	written := make([]userstore.WatchHistoryEntry, 0, len(historyIDs))
+	if len(historyIDs) > 0 {
+		rows, err := tx.Query(ctx, `
+			WITH entry(id, media_item_id, watched_at, duration_seconds, completed, source, watch_identity, ord) AS (
+				SELECT * FROM unnest(
+					$3::text[], $4::text[], $5::timestamptz[], $6::double precision[],
+					$7::boolean[], $8::text[], $9::jsonb[]
+				) WITH ORDINALITY
+			)
+			INSERT INTO user_watch_history
+				(id, user_id, profile_id, media_item_id, watched_at, duration_seconds, completed, source, watch_identity)
+			SELECT
+				e.id, $1, $2, e.media_item_id,
+				CASE
+					WHEN hhi.hidden_before IS NOT NULL AND e.watched_at <= hhi.hidden_before
+					THEN hhi.hidden_before + interval '1 second'
+					ELSE e.watched_at
+				END,
+				e.duration_seconds, e.completed, e.source, e.watch_identity
+			FROM entry e
+			LEFT JOIN user_history_hidden_items hhi
+			  ON hhi.user_id = $1
+			 AND hhi.profile_id = $2
+			 AND hhi.media_item_id = e.media_item_id
+			ORDER BY e.ord
+			RETURNING id, media_item_id, watched_at`,
+			s.userID, profileID, historyIDs, historyItemIDs, historyWatchedAt,
+			historyDurations, historyCompleted, historySources, historyIdentities,
+		)
+		if err != nil {
+			return nil, fmt.Errorf("adding visible history batch: %w", err)
+		}
+		resolved := make(map[string]time.Time, len(historyIDs))
+		for rows.Next() {
+			var id, mediaItemID string
+			var watchedAt time.Time
+			if err := rows.Scan(&id, &mediaItemID, &watchedAt); err != nil {
+				rows.Close()
+				return nil, fmt.Errorf("scanning inserted history: %w", err)
+			}
+			resolved[id] = watchedAt
+		}
+		rows.Close()
+		if err := rows.Err(); err != nil {
+			return nil, fmt.Errorf("iterating inserted history: %w", err)
+		}
+		for i, id := range historyIDs {
+			entry := entries[historySourceIndex[i]]
+			entry.ID = id
+			entry.MediaItemID = historyItemIDs[i]
+			if entry.Source == "" {
+				entry.Source = userstore.WatchHistorySource(historySources[i])
+			}
+			if watchedAt, ok := resolved[id]; ok {
+				entry.WatchedAt = timeToString(watchedAt)
+			}
+			written = append(written, entry)
+		}
+	}
+
+	if err := tx.Commit(ctx); err != nil {
+		return nil, fmt.Errorf("commit mark watched batch: %w", err)
+	}
+	return written, nil
+}
+
 // MarkProgressBatch upserts a `completed = TRUE` progress row for every entry
 // in mediaItemIDs in a single statement. Used by the jellycompat series
 // mark-played path so a 200-episode mark collapses to one INSERT.

--- a/internal/userstore/progress_helpers.go
+++ b/internal/userstore/progress_helpers.go
@@ -31,6 +31,56 @@ func AddVisibleHistory(ctx context.Context, store UserStore, entry WatchHistoryE
 	return entry, nil
 }
 
+// MarkWatchedTarget is one leaf item to mark watched, carrying the duration
+// that belongs on its progress row.
+type MarkWatchedTarget struct {
+	MediaItemID     string
+	DurationSeconds float64
+}
+
+// WatchedBatchWriter is an optional store capability: mark every target
+// watched and insert its history row in a single transaction, so a canceled
+// request leaves nothing marked instead of a partial subset. Marking a large
+// series is the motivating case — the per-target fallback below commits each
+// episode independently, so losing the request mid-loop strands the series
+// half-watched.
+//
+// Semantics must match the fallback: per-target duration lands on the progress
+// row, each entry gets exactly one history row, and both respect the
+// hidden-history watermark the single-row MarkWatched/AddVisibleHistory paths
+// apply. The returned entries carry the resolved (possibly watermark-adjusted)
+// WatchedAt, in the order given.
+type WatchedBatchWriter interface {
+	MarkWatchedBatch(ctx context.Context, profileID string, targets []MarkWatchedTarget, entries []WatchHistoryEntry) ([]WatchHistoryEntry, error)
+}
+
+// MarkWatchedBatch marks every target watched and records its history entry,
+// atomically where the store supports it. targets and entries are parallel:
+// entries[i] is the history row for targets[i].
+func MarkWatchedBatch(ctx context.Context, store UserStore, profileID string, targets []MarkWatchedTarget, entries []WatchHistoryEntry) ([]WatchHistoryEntry, error) {
+	if len(targets) == 0 {
+		return nil, nil
+	}
+	if writer, ok := store.(WatchedBatchWriter); ok {
+		return writer.MarkWatchedBatch(ctx, profileID, targets, entries)
+	}
+	written := make([]WatchHistoryEntry, 0, len(entries))
+	for i, target := range targets {
+		if err := store.MarkWatched(ctx, profileID, target.MediaItemID, target.DurationSeconds); err != nil {
+			return written, err
+		}
+		if i >= len(entries) {
+			continue
+		}
+		entry, err := AddVisibleHistory(ctx, store, entries[i])
+		if err != nil {
+			return written, err
+		}
+		written = append(written, entry)
+	}
+	return written, nil
+}
+
 func VisibleHistoryTimestamps(ctx context.Context, store UserStore, profileID string, mediaItemIDs []string, at time.Time) (map[string]string, error) {
 	mediaItemIDs = compactHistoryMediaItemIDs(mediaItemIDs)
 	result := make(map[string]string, len(mediaItemIDs))

--- a/internal/userstore/storetest/suite.go
+++ b/internal/userstore/storetest/suite.go
@@ -11,6 +11,15 @@ import (
 	"github.com/Silo-Server/silo-server/internal/userstore"
 )
 
+// RunMarkWatchedBatch runs only the batch mark-watched conformance test. It is
+// exposed separately, like RunProgressSince, so each backend can pin the
+// series/season mark-watched path without the full suite.
+func RunMarkWatchedBatch(t *testing.T, newStore func(t *testing.T) userstore.UserStore) {
+	t.Run("MarkWatchedBatch", func(t *testing.T) {
+		testMarkWatchedBatch(t, newStore)
+	})
+}
+
 // RunProgressSince runs only the offline-sync progress-reconciliation
 // conformance test (invariant 1). It is exposed separately so a backend can
 // exercise the offline-sync behavior without the full suite.
@@ -171,6 +180,9 @@ func RunSuite(t *testing.T, newStore func(t *testing.T) userstore.UserStore) {
 	})
 	t.Run("BatchWritesAdvanceEventAt", func(t *testing.T) {
 		testBatchWritesAdvanceEventAt(t, newStore)
+	})
+	t.Run("MarkWatchedBatch", func(t *testing.T) {
+		testMarkWatchedBatch(t, newStore)
 	})
 	t.Run("Favorites", func(t *testing.T) {
 		testFavorites(t, newStore)
@@ -1129,6 +1141,162 @@ func testOnlineWriteAdvancesEventAt(t *testing.T, newStore func(t *testing.T) us
 				t.Fatalf("stale offline replay won LWW: position = %v, want 500 (online write)", got.PositionSeconds)
 			}
 		})
+	}
+}
+
+// testMarkWatchedBatch pins the batch mark-watched path used by the series and
+// season mark-watched handlers. It must be equivalent to a MarkWatched +
+// AddVisibleHistory loop: per-target durations land on progress rows, exactly
+// one history row appears per target, the hidden-history watermark still
+// pushes a mark after a removal back into visibility, and a zero duration
+// leaves a known duration alone (jellycompat's mark-played supplies none).
+func testMarkWatchedBatch(t *testing.T, newStore func(t *testing.T) userstore.UserStore) {
+	ctx := context.Background()
+	store := newStore(t)
+	if err := store.CreateProfile(ctx, userstore.Profile{ID: "p1", Name: "Test"}); err != nil {
+		t.Fatalf("CreateProfile: %v", err)
+	}
+
+	watchedAt := time.Date(2026, 5, 2, 9, 0, 0, 0, time.UTC)
+	targets := []userstore.MarkWatchedTarget{
+		{MediaItemID: "ep-1", DurationSeconds: 1200},
+		{MediaItemID: "ep-2", DurationSeconds: 1500},
+	}
+	entries := []userstore.WatchHistoryEntry{
+		{
+			ProfileID:       "p1",
+			MediaItemID:     "ep-1",
+			WatchedAt:       watchedAt.Format(time.RFC3339),
+			DurationSeconds: 1200,
+			Completed:       true,
+			Source:          userstore.WatchHistorySourceManual,
+		},
+		{
+			ProfileID:       "p1",
+			MediaItemID:     "ep-2",
+			WatchedAt:       watchedAt.Format(time.RFC3339),
+			DurationSeconds: 1500,
+			Completed:       true,
+			Source:          userstore.WatchHistorySourceManual,
+		},
+	}
+
+	written, err := userstore.MarkWatchedBatch(ctx, store, "p1", targets, entries)
+	if err != nil {
+		t.Fatalf("MarkWatchedBatch: %v", err)
+	}
+	if len(written) != 2 {
+		t.Fatalf("MarkWatchedBatch returned %d entries, want 2", len(written))
+	}
+	for _, entry := range written {
+		if entry.ID == "" {
+			t.Fatalf("returned entry %s has no ID; callers relay these to watch providers", entry.MediaItemID)
+		}
+		if entry.WatchedAt == "" {
+			t.Fatalf("returned entry %s has no WatchedAt", entry.MediaItemID)
+		}
+	}
+
+	for _, want := range targets {
+		progress, err := store.GetProgress(ctx, "p1", want.MediaItemID)
+		if err != nil {
+			t.Fatalf("GetProgress(%s): %v", want.MediaItemID, err)
+		}
+		if progress == nil || !progress.Completed {
+			t.Fatalf("GetProgress(%s) = %+v, want completed", want.MediaItemID, progress)
+		}
+		if progress.DurationSeconds != want.DurationSeconds {
+			t.Fatalf("GetProgress(%s) duration = %v, want %v — per-target durations must survive the batch",
+				want.MediaItemID, progress.DurationSeconds, want.DurationSeconds)
+		}
+		if progress.PositionSeconds != 0 {
+			t.Fatalf("GetProgress(%s) position = %v, want 0", want.MediaItemID, progress.PositionSeconds)
+		}
+	}
+
+	history, err := store.ListHistory(ctx, "p1", 50, 0)
+	if err != nil {
+		t.Fatalf("ListHistory: %v", err)
+	}
+	counts := map[string]int{}
+	for _, entry := range history {
+		counts[entry.MediaItemID]++
+	}
+	if counts["ep-1"] != 1 || counts["ep-2"] != 1 {
+		t.Fatalf("history counts = %v, want exactly one row per target", counts)
+	}
+
+	// A zero duration must not erase a duration the store already knows.
+	if _, err := userstore.MarkWatchedBatch(ctx, store, "p1",
+		[]userstore.MarkWatchedTarget{{MediaItemID: "ep-1"}},
+		[]userstore.WatchHistoryEntry{{
+			ProfileID:   "p1",
+			MediaItemID: "ep-1",
+			WatchedAt:   watchedAt.Add(time.Hour).Format(time.RFC3339),
+			Completed:   true,
+			Source:      userstore.WatchHistorySourceJellycompat,
+		}},
+	); err != nil {
+		t.Fatalf("MarkWatchedBatch(zero duration): %v", err)
+	}
+	progress, err := store.GetProgress(ctx, "p1", "ep-1")
+	if err != nil || progress == nil {
+		t.Fatalf("GetProgress(ep-1 after zero-duration mark) = %+v (%v)", progress, err)
+	}
+	if progress.DurationSeconds != 1200 {
+		t.Fatalf("duration = %v, want 1200 — a zero-duration mark must not clear a known duration",
+			progress.DurationSeconds)
+	}
+
+	// Marking watched after a history removal must land after the hidden
+	// watermark, otherwise the new mark is invisible.
+	removedAt := time.Date(2026, 5, 3, 9, 0, 0, 0, time.UTC)
+	if err := store.RemoveHistoryItems(ctx, "p1", []string{"ep-2"}, removedAt); err != nil {
+		t.Fatalf("RemoveHistoryItems(ep-2): %v", err)
+	}
+	remarked, err := userstore.MarkWatchedBatch(ctx, store, "p1",
+		[]userstore.MarkWatchedTarget{{MediaItemID: "ep-2", DurationSeconds: 1500}},
+		[]userstore.WatchHistoryEntry{{
+			ProfileID:       "p1",
+			MediaItemID:     "ep-2",
+			WatchedAt:       watchedAt.Format(time.RFC3339), // older than the removal
+			DurationSeconds: 1500,
+			Completed:       true,
+			Source:          userstore.WatchHistorySourceManual,
+		}},
+	)
+	if err != nil {
+		t.Fatalf("MarkWatchedBatch(after removal): %v", err)
+	}
+	if len(remarked) != 1 {
+		t.Fatalf("re-mark returned %d entries, want 1", len(remarked))
+	}
+	if remarked[0].WatchedAt <= removedAt.Format(time.RFC3339) {
+		t.Fatalf("re-marked WatchedAt = %q, want later than the %q removal watermark",
+			remarked[0].WatchedAt, removedAt.Format(time.RFC3339))
+	}
+	completed, err := store.ListCompletedHistoryItems(ctx, userstore.CompletedHistoryItemQuery{
+		ProfileID:    "p1",
+		MediaItemIDs: []string{"ep-2"},
+	})
+	if err != nil {
+		t.Fatalf("ListCompletedHistoryItems(ep-2): %v", err)
+	}
+	if len(completed) != 1 {
+		t.Fatalf("ep-2 completed history = %v, want the re-mark to be visible", completed)
+	}
+
+	// Blank IDs are compacted out rather than reaching SQL.
+	if _, err := userstore.MarkWatchedBatch(ctx, store, "p1",
+		[]userstore.MarkWatchedTarget{{MediaItemID: "  "}, {MediaItemID: ""}},
+		nil,
+	); err != nil {
+		t.Fatalf("MarkWatchedBatch(blank IDs): %v", err)
+	}
+	if blank, err := store.GetProgress(ctx, "p1", ""); err != nil {
+		t.Fatalf("GetProgress(blank): %v", err)
+	} else if blank != nil {
+		t.Fatalf("GetProgress(blank) = %+v, want nil", blank)
 	}
 }
 

--- a/internal/watchstate/identity.go
+++ b/internal/watchstate/identity.go
@@ -86,6 +86,165 @@ func (r *StableIdentityResolver) ResolveHistoryIdentity(ctx context.Context, med
 	}
 }
 
+// batchEpisodeLookup is an optional capability on the episode lookup: fetch
+// many episodes in one query. catalog.EpisodeRepository implements it.
+type batchEpisodeLookup interface {
+	GetByIDs(ctx context.Context, contentIDs []string) ([]*models.Episode, error)
+}
+
+// batchProviderIDLookup is the same idea for provider IDs, letting a series
+// mark resolve every distinct series in one query instead of one per episode.
+type batchProviderIDLookup interface {
+	GetByContentIDs(ctx context.Context, contentIDs []string) (map[string][]*models.MediaItemProviderID, error)
+}
+
+// ResolveHistoryIdentities resolves stable identities for many media items at
+// once. Marking a series watched previously resolved each episode on its own,
+// costing an episode lookup plus a series provider-ID lookup per episode; this
+// collapses that to one episode query plus one provider-ID query per distinct
+// series. Items that resolve to nothing are absent from the map, matching
+// ResolveHistoryIdentity's zero-value return.
+func (r *StableIdentityResolver) ResolveHistoryIdentities(ctx context.Context, mediaItemIDs []string) map[string]userstore.WatchIdentity {
+	result := make(map[string]userstore.WatchIdentity, len(mediaItemIDs))
+	if r == nil || r.providerIDs == nil || len(mediaItemIDs) == 0 {
+		return result
+	}
+
+	ids := make([]string, 0, len(mediaItemIDs))
+	seen := make(map[string]struct{}, len(mediaItemIDs))
+	for _, mediaItemID := range mediaItemIDs {
+		mediaItemID = strings.TrimSpace(mediaItemID)
+		if mediaItemID == "" {
+			continue
+		}
+		if _, ok := seen[mediaItemID]; ok {
+			continue
+		}
+		seen[mediaItemID] = struct{}{}
+		ids = append(ids, mediaItemID)
+	}
+	if len(ids) == 0 {
+		return result
+	}
+
+	episodes := r.loadEpisodes(ctx, ids)
+
+	// One provider-ID lookup per distinct series covers every episode of it.
+	seriesIDs := make([]string, 0, len(episodes))
+	seenSeries := make(map[string]struct{}, len(episodes))
+	for _, episode := range episodes {
+		seriesID := strings.TrimSpace(episode.SeriesID)
+		if seriesID == "" {
+			continue
+		}
+		if _, ok := seenSeries[seriesID]; ok {
+			continue
+		}
+		seenSeries[seriesID] = struct{}{}
+		seriesIDs = append(seriesIDs, seriesID)
+	}
+
+	// Anything that is not an episode may still be a movie; resolve those
+	// provider IDs in the same batch.
+	movieCandidates := make([]string, 0, len(ids))
+	for _, mediaItemID := range ids {
+		if _, ok := episodes[mediaItemID]; !ok {
+			movieCandidates = append(movieCandidates, mediaItemID)
+		}
+	}
+
+	providerIDsByContent := r.loadProviderIDsBatch(ctx, append(append([]string{}, seriesIDs...), movieCandidates...))
+
+	for _, mediaItemID := range ids {
+		if episode, ok := episodes[mediaItemID]; ok {
+			episodeIDs := episodeProviderIDs(episode)
+			seriesProviderIDs := providerIDMap(providerIDsByContent[episode.SeriesID])
+			// Mirrors ResolveHistoryIdentity: an episode carrying its own IDs
+			// is addressable without the nested show fallback.
+			if len(episodeIDs) == 0 && len(seriesProviderIDs) == 0 {
+				continue
+			}
+			seasonNumber := episode.SeasonNumber
+			episodeNumber := episode.EpisodeNumber
+			result[mediaItemID] = userstore.WatchIdentity{
+				StableType:        "episode",
+				ProviderIDs:       episodeIDs,
+				SeriesProviderIDs: seriesProviderIDs,
+				Season:            &seasonNumber,
+				Episode:           &episodeNumber,
+			}
+			continue
+		}
+
+		if r.items == nil {
+			continue
+		}
+		item, err := r.items.GetByID(ctx, mediaItemID)
+		if err != nil || item == nil || item.Type != "movie" {
+			continue
+		}
+		itemIDs := providerIDMap(providerIDsByContent[mediaItemID])
+		if len(itemIDs) == 0 {
+			continue
+		}
+		result[mediaItemID] = userstore.WatchIdentity{
+			StableType:  "movie",
+			ProviderIDs: itemIDs,
+		}
+	}
+
+	return result
+}
+
+// loadEpisodes returns the subset of ids that are episodes, batching when the
+// lookup supports it and falling back to per-ID reads otherwise.
+func (r *StableIdentityResolver) loadEpisodes(ctx context.Context, ids []string) map[string]*models.Episode {
+	episodes := make(map[string]*models.Episode, len(ids))
+	if r.episodes == nil {
+		return episodes
+	}
+	if batch, ok := r.episodes.(batchEpisodeLookup); ok {
+		found, err := batch.GetByIDs(ctx, ids)
+		if err == nil {
+			for _, episode := range found {
+				if episode != nil {
+					episodes[episode.ContentID] = episode
+				}
+			}
+			return episodes
+		}
+	}
+	for _, mediaItemID := range ids {
+		episode, err := r.episodes.GetByID(ctx, mediaItemID)
+		if err == nil && episode != nil {
+			episodes[mediaItemID] = episode
+		}
+	}
+	return episodes
+}
+
+// loadProviderIDsBatch groups provider IDs by content ID, batching when the
+// lookup supports it and falling back to per-ID reads otherwise.
+func (r *StableIdentityResolver) loadProviderIDsBatch(ctx context.Context, contentIDs []string) map[string][]*models.MediaItemProviderID {
+	result := make(map[string][]*models.MediaItemProviderID, len(contentIDs))
+	if len(contentIDs) == 0 {
+		return result
+	}
+	if batch, ok := r.providerIDs.(batchProviderIDLookup); ok {
+		found, err := batch.GetByContentIDs(ctx, contentIDs)
+		if err == nil {
+			return found
+		}
+	}
+	for _, contentID := range contentIDs {
+		if _, ok := result[contentID]; ok {
+			continue
+		}
+		result[contentID] = r.loadProviderIDs(ctx, contentID)
+	}
+	return result
+}
+
 func (r *StableIdentityResolver) ResolveMovieContentID(ctx context.Context, providerIDs map[string]string) (string, error) {
 	if r == nil || r.providerIDs == nil {
 		return "", nil

--- a/internal/watchstate/service.go
+++ b/internal/watchstate/service.go
@@ -325,12 +325,22 @@ func (s *Service) recordMarkWatched(
 	if watchedAt.IsZero() {
 		watchedAt = time.Now().UTC()
 	}
-	result := ManualMarkResult{Entries: make([]userstore.WatchHistoryEntry, 0, len(targets))}
+	// Resolve every identity up front: one episode query plus one provider-ID
+	// query per distinct series, instead of two lookups per episode.
+	completedIDs := make([]string, 0, len(targets))
 	for _, target := range targets {
-		if err := store.MarkWatched(ctx, profileID, target.MediaItemID, target.DurationSeconds); err != nil {
-			return result, err
-		}
-		histEntry := userstore.WatchHistoryEntry{
+		completedIDs = append(completedIDs, target.MediaItemID)
+	}
+	identities := s.resolveStableIdentities(ctx, completedIDs)
+
+	batchTargets := make([]userstore.MarkWatchedTarget, 0, len(targets))
+	entries := make([]userstore.WatchHistoryEntry, 0, len(targets))
+	for _, target := range targets {
+		batchTargets = append(batchTargets, userstore.MarkWatchedTarget{
+			MediaItemID:     target.MediaItemID,
+			DurationSeconds: target.DurationSeconds,
+		})
+		entries = append(entries, userstore.WatchHistoryEntry{
 			ID:              uuid.NewString(),
 			ProfileID:       profileID,
 			MediaItemID:     target.MediaItemID,
@@ -338,17 +348,16 @@ func (s *Service) recordMarkWatched(
 			DurationSeconds: target.DurationSeconds,
 			Completed:       true,
 			Source:          source,
-		}
-		s.applyStableIdentity(ctx, &histEntry)
-		histEntry, err = userstore.AddVisibleHistory(ctx, store, histEntry)
-		if err != nil {
-			return result, err
-		}
-		result.Entries = append(result.Entries, histEntry)
+			Identity:        identities[target.MediaItemID],
+		})
 	}
-	completedIDs := make([]string, 0, len(targets))
-	for _, target := range targets {
-		completedIDs = append(completedIDs, target.MediaItemID)
+
+	// One transaction for the whole set: a canceled request rolls back to
+	// "nothing marked" rather than leaving a series partially watched.
+	written, err := userstore.MarkWatchedBatch(ctx, store, profileID, batchTargets, entries)
+	result := ManualMarkResult{Entries: written}
+	if err != nil {
+		return result, err
 	}
 	s.notifyWatchedCompleted(ctx, userID, profileID, completedIDs)
 	return result, nil
@@ -445,24 +454,28 @@ func (s *Service) recordMarkWatchedBatch(
 	if watchedAt.IsZero() {
 		watchedAt = time.Now().UTC()
 	}
-	if err := store.MarkProgressBatch(ctx, profileID, targetIDs, watchedAt); err != nil {
-		return err
-	}
-	// Strategy A (audit 2026-05-01 §2.7): batch the progress upsert because it
-	// powers hot Continue-Watching queries. History inserts stay per-target so
-	// per-episode stable-identity resolution still applies.
+	// Shares recordMarkWatched's transactional store path (audit 2026-05-01
+	// §2.7 kept the progress upsert batched; this extends the same treatment
+	// to history so the whole mark commits or rolls back as one). Identities
+	// still resolve per episode, now in a single bulk lookup. No durations are
+	// available here, and the store leaves a known duration in place when a
+	// target supplies zero.
+	identities := s.resolveStableIdentities(ctx, targetIDs)
+	batchTargets := make([]userstore.MarkWatchedTarget, 0, len(targetIDs))
+	entries := make([]userstore.WatchHistoryEntry, 0, len(targetIDs))
 	for _, targetID := range targetIDs {
-		histEntry := userstore.WatchHistoryEntry{
+		batchTargets = append(batchTargets, userstore.MarkWatchedTarget{MediaItemID: targetID})
+		entries = append(entries, userstore.WatchHistoryEntry{
 			ProfileID:   profileID,
 			MediaItemID: targetID,
 			WatchedAt:   formatWatchedAt(watchedAt),
 			Completed:   true,
 			Source:      source,
-		}
-		s.applyStableIdentity(ctx, &histEntry)
-		if _, err := userstore.AddVisibleHistory(ctx, store, histEntry); err != nil {
-			return err
-		}
+			Identity:    identities[targetID],
+		})
+	}
+	if _, err := userstore.MarkWatchedBatch(ctx, store, profileID, batchTargets, entries); err != nil {
+		return err
 	}
 	s.notifyWatchedCompleted(ctx, userID, profileID, targetIDs)
 	return nil
@@ -534,6 +547,15 @@ func (s *Service) addImportedHistoryIfMissingWithSource(
 	}
 	s.applyStableIdentity(ctx, &entry)
 	return store.AddHistoryIfMissing(ctx, entry)
+}
+
+// resolveStableIdentities resolves identities for many media items in one go,
+// returning an empty map when no resolver is configured.
+func (s *Service) resolveStableIdentities(ctx context.Context, mediaItemIDs []string) map[string]userstore.WatchIdentity {
+	if s == nil || s.identity == nil || len(mediaItemIDs) == 0 {
+		return nil
+	}
+	return s.identity.ResolveHistoryIdentities(ctx, mediaItemIDs)
 }
 
 func (s *Service) applyStableIdentity(ctx context.Context, entry *userstore.WatchHistoryEntry) {

--- a/internal/watchstate/service_test.go
+++ b/internal/watchstate/service_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"database/sql"
 	"errors"
+	"fmt"
 	"testing"
 	"time"
 
@@ -674,5 +675,161 @@ func createWatchstateProfile(t *testing.T, store userstore.UserStore) {
 	t.Helper()
 	if err := store.CreateProfile(context.Background(), userstore.Profile{ID: "profile-1", Name: "Profile"}); err != nil {
 		t.Fatalf("CreateProfile: %v", err)
+	}
+}
+
+// batchTestEpisodeRepo is testEpisodeRepo plus the GetByIDs batch capability,
+// so the bulk identity path is what gets exercised. It counts calls to prove
+// a series mark no longer issues one lookup per episode.
+type batchTestEpisodeRepo struct {
+	testEpisodeRepo
+	batchCalls int
+}
+
+func (r *batchTestEpisodeRepo) GetByIDs(_ context.Context, contentIDs []string) ([]*models.Episode, error) {
+	r.batchCalls++
+	found := make([]*models.Episode, 0, len(contentIDs))
+	for _, contentID := range contentIDs {
+		if episode, ok := r.episodes[contentID]; ok {
+			found = append(found, episode)
+		}
+	}
+	return found, nil
+}
+
+// batchTestProviderIDRepo adds the GetByContentIDs batch capability and counts
+// calls, pinning that a whole series resolves in one provider-ID query.
+type batchTestProviderIDRepo struct {
+	testProviderIDRepo
+	batchCalls int
+}
+
+func (r *batchTestProviderIDRepo) GetByContentIDs(_ context.Context, contentIDs []string) (map[string][]*models.MediaItemProviderID, error) {
+	r.batchCalls++
+	out := make(map[string][]*models.MediaItemProviderID, len(contentIDs))
+	for _, contentID := range contentIDs {
+		if rows, ok := r.ids[contentID]; ok {
+			out[contentID] = rows
+		}
+	}
+	return out, nil
+}
+
+// TestManualMarkWatchedSeriesResolvesIdentitiesInBulk marks a whole series and
+// pins both halves of the fix: every episode gets its own history row with a
+// resolved identity, and the catalog lookups are batched rather than repeated
+// per episode.
+func TestManualMarkWatchedSeriesResolvesIdentitiesInBulk(t *testing.T) {
+	store, db := newTestUserStore(t)
+	t.Cleanup(func() { _ = db.Close() })
+
+	const episodeCount = 25
+	episodes := make(map[string]*models.Episode, episodeCount)
+	targets := make([]LeafWatchTarget, 0, episodeCount)
+	for i := 1; i <= episodeCount; i++ {
+		contentID := fmt.Sprintf("episode-%d", i)
+		episodes[contentID] = &models.Episode{
+			ContentID:     contentID,
+			SeriesID:      "series-1",
+			SeasonNumber:  1,
+			EpisodeNumber: i,
+		}
+		targets = append(targets, LeafWatchTarget{MediaItemID: contentID, DurationSeconds: 1800})
+	}
+
+	episodeRepo := &batchTestEpisodeRepo{testEpisodeRepo: testEpisodeRepo{episodes: episodes}}
+	providerRepo := &batchTestProviderIDRepo{testProviderIDRepo: testProviderIDRepo{
+		ids: map[string][]*models.MediaItemProviderID{
+			"series-1": {{ContentID: "series-1", ItemType: "series", Provider: "tvdb", ProviderID: "765"}},
+		},
+	}}
+	service := NewService(testStoreProvider{store: store}).WithStableIdentityResolver(
+		NewStableIdentityResolver(testItemRepo{}, episodeRepo, providerRepo),
+	)
+
+	result, err := service.RecordManualMarkWatchedWithResult(
+		context.Background(), 1, "profile-1", targets,
+		time.Date(2026, 4, 25, 12, 0, 0, 0, time.UTC),
+	)
+	if err != nil {
+		t.Fatalf("RecordManualMarkWatchedWithResult: %v", err)
+	}
+	if len(result.Entries) != episodeCount {
+		t.Fatalf("result entries = %d, want %d; watch-provider dispatch reads these",
+			len(result.Entries), episodeCount)
+	}
+
+	history, err := store.ListHistory(context.Background(), "profile-1", episodeCount*2, 0)
+	if err != nil {
+		t.Fatalf("ListHistory: %v", err)
+	}
+	if len(history) != episodeCount {
+		t.Fatalf("history len = %d, want %d", len(history), episodeCount)
+	}
+	for _, entry := range history {
+		if entry.Identity.StableType != "episode" {
+			t.Fatalf("%s identity = %q, want episode", entry.MediaItemID, entry.Identity.StableType)
+		}
+		if got := entry.Identity.SeriesProviderIDs["tvdb"]; got != "765" {
+			t.Fatalf("%s SeriesProviderIDs[tvdb] = %q, want 765", entry.MediaItemID, got)
+		}
+	}
+	for _, target := range targets {
+		progress, err := store.GetProgress(context.Background(), "profile-1", target.MediaItemID)
+		if err != nil || progress == nil || !progress.Completed {
+			t.Fatalf("GetProgress(%s) = %+v (%v), want completed", target.MediaItemID, progress, err)
+		}
+	}
+
+	// The whole point of the bulk path: constant lookups, not O(episodes).
+	if episodeRepo.batchCalls != 1 {
+		t.Fatalf("episode batch lookups = %d, want 1", episodeRepo.batchCalls)
+	}
+	if providerRepo.batchCalls != 1 {
+		t.Fatalf("provider-ID batch lookups = %d, want 1", providerRepo.batchCalls)
+	}
+}
+
+// TestManualMarkWatchedSeriesIsAtomicOnCancel is the regression test for the
+// reported bug: marking a large series while the client disconnects used to
+// leave the series partially watched, because each episode committed on its
+// own. The mark must now be all-or-nothing.
+func TestManualMarkWatchedSeriesIsAtomicOnCancel(t *testing.T) {
+	store, db := newTestUserStore(t)
+	t.Cleanup(func() { _ = db.Close() })
+
+	targets := make([]LeafWatchTarget, 0, 40)
+	for i := 1; i <= 40; i++ {
+		targets = append(targets, LeafWatchTarget{
+			MediaItemID:     fmt.Sprintf("episode-%d", i),
+			DurationSeconds: 1800,
+		})
+	}
+
+	service := NewService(testStoreProvider{store: store})
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel() // the tab closed before the write could run
+
+	if _, err := service.RecordManualMarkWatchedWithResult(
+		ctx, 1, "profile-1", targets, time.Date(2026, 4, 25, 12, 0, 0, 0, time.UTC),
+	); err == nil {
+		t.Fatal("RecordManualMarkWatchedWithResult on a canceled context returned nil error")
+	}
+
+	history, err := store.ListHistory(context.Background(), "profile-1", 100, 0)
+	if err != nil {
+		t.Fatalf("ListHistory: %v", err)
+	}
+	if len(history) != 0 {
+		t.Fatalf("history len = %d, want 0 — a canceled series mark must roll back, not leave a partial mark", len(history))
+	}
+	for _, target := range targets {
+		progress, err := store.GetProgress(context.Background(), "profile-1", target.MediaItemID)
+		if err != nil {
+			t.Fatalf("GetProgress(%s): %v", target.MediaItemID, err)
+		}
+		if progress != nil && progress.Completed {
+			t.Fatalf("%s is completed after a canceled mark; the write must be all-or-nothing", target.MediaItemID)
+		}
 	}
 }

--- a/web/src/hooks/queries/items.test.ts
+++ b/web/src/hooks/queries/items.test.ts
@@ -3,6 +3,9 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 const mocks = vi.hoisted(() => ({
   api: vi.fn(),
   invalidateMediaSurfaceQueries: vi.fn(),
+  isItemDetailQueryKey: vi.fn((_queryKey: unknown, _itemId: string) => true),
+  updateCatalogItemDetail: vi.fn(),
+  toastError: vi.fn(),
   toastSuccess: vi.fn(),
   useMutation: vi.fn(),
   useQueryClient: vi.fn(),
@@ -41,6 +44,9 @@ vi.mock("@/pages/ItemDetail/watchedState", async () => {
 vi.mock("./mediaSurfaceRefresh", () => ({
   invalidateMediaSurfaceQueries: (...args: unknown[]) =>
     mocks.invalidateMediaSurfaceQueries(...args),
+  isItemDetailQueryKey: (queryKey: unknown, itemId: string) =>
+    mocks.isItemDetailQueryKey(queryKey, itemId),
+  updateCatalogItemDetail: (...args: unknown[]) => mocks.updateCatalogItemDetail(...args),
 }));
 
 vi.mock("@/pages/homeSurfaceRefresh", () => ({
@@ -49,16 +55,20 @@ vi.mock("@/pages/homeSurfaceRefresh", () => ({
 
 vi.mock("sonner", () => ({
   toast: {
-    error: vi.fn(),
+    error: (...args: unknown[]) => mocks.toastError(...args),
     success: (...args: unknown[]) => mocks.toastSuccess(...args),
   },
 }));
 
 import { fetchWatchDetail, redetectEpisodeIntro, useWatchedStateMutation } from "./items";
 
+type WatchedMutationContext = { previous: Array<[readonly unknown[], unknown]> };
+
 type WatchedMutationOptions = {
   mutationFn: (nextPlayed: boolean) => Promise<unknown>;
+  onMutate?: (nextPlayed: boolean) => Promise<WatchedMutationContext>;
   onSuccess?: (data: unknown, nextPlayed: boolean) => void;
+  onError?: (err: unknown, nextPlayed: boolean, context?: WatchedMutationContext) => void;
   onSettled?: () => Promise<unknown>;
 };
 
@@ -67,6 +77,10 @@ describe("item query helpers", () => {
     mocks.api.mockReset();
     mocks.api.mockResolvedValue({});
     mocks.invalidateMediaSurfaceQueries.mockReset();
+    mocks.updateCatalogItemDetail.mockReset();
+    mocks.isItemDetailQueryKey.mockReset();
+    mocks.isItemDetailQueryKey.mockReturnValue(true);
+    mocks.toastError.mockReset();
     mocks.toastSuccess.mockReset();
     mocks.useMutation.mockReset();
     mocks.useMutation.mockImplementation((options: unknown) => ({
@@ -101,12 +115,71 @@ describe("item query helpers", () => {
     ]?.[0] as WatchedMutationOptions;
 
     await options.mutationFn(true);
-    expect(mocks.api).toHaveBeenCalledWith("/watched/ebook%201%2Fisbn%3A978", { method: "POST" });
+    expect(mocks.api).toHaveBeenCalledWith("/watched/ebook%201%2Fisbn%3A978", {
+      method: "POST",
+      keepalive: true,
+    });
 
     await options.mutationFn(false);
     expect(mocks.api).toHaveBeenCalledWith("/watched/ebook%201%2Fisbn%3A978", {
       method: "DELETE",
+      keepalive: true,
     });
+  });
+
+  it("sends watched-state writes with keepalive so they survive tab close", async () => {
+    useWatchedStateMutation({ content_id: "series-1", type: "series" });
+    const options = mocks.useMutation.mock.calls[
+      mocks.useMutation.mock.calls.length - 1
+    ]?.[0] as WatchedMutationOptions;
+
+    // Marking a large series expands to every episode server-side; without
+    // keepalive the request dies with the document and nothing is marked.
+    await options.mutationFn(true);
+    expect(mocks.api).toHaveBeenCalledWith("/watched/series-1", {
+      method: "POST",
+      keepalive: true,
+    });
+  });
+
+  it("optimistically flips played state and rolls back when the request fails", async () => {
+    const setQueryData = vi.fn();
+    const previous: Array<[readonly unknown[], unknown]> = [[["items", "detail", "series-1"], {}]];
+    mocks.useQueryClient.mockReturnValue({
+      cancelQueries: vi.fn().mockResolvedValue(undefined),
+      getQueriesData: vi.fn(() => previous),
+      setQueryData,
+    });
+
+    useWatchedStateMutation({ content_id: "series-1", type: "series" });
+    const options = mocks.useMutation.mock.calls[
+      mocks.useMutation.mock.calls.length - 1
+    ]?.[0] as WatchedMutationOptions;
+
+    const context = await options.onMutate?.(true);
+    expect(mocks.updateCatalogItemDetail).toHaveBeenCalledWith(
+      expect.anything(),
+      "series-1",
+      expect.any(Function),
+    );
+
+    // The updater must set played without dropping the other user_state flags.
+    const updater = mocks.updateCatalogItemDetail.mock.calls[0]?.[2] as (
+      detail: Record<string, unknown>,
+    ) => Record<string, unknown>;
+    expect(
+      updater({
+        user_data: { played: false },
+        user_state: { played: false, is_favorite: true, in_watchlist: false },
+      }),
+    ).toMatchObject({
+      user_data: { played: true },
+      user_state: { played: true, is_favorite: true, in_watchlist: false },
+    });
+
+    options.onError?.(new Error("boom"), true, context);
+    expect(setQueryData).toHaveBeenCalledWith(previous[0]?.[0], previous[0]?.[1]);
+    expect(mocks.toastError).toHaveBeenCalledWith("boom");
   });
 
   it("uses read toast copy and refreshes surfaces for ebook watched toggles", async () => {

--- a/web/src/hooks/queries/items.ts
+++ b/web/src/hooks/queries/items.ts
@@ -20,7 +20,11 @@ import {
   getCachedWatchedInvalidationKeys,
   getWatchedToastMessage,
 } from "@/pages/ItemDetail/watchedState";
-import { invalidateMediaSurfaceQueries } from "./mediaSurfaceRefresh";
+import {
+  invalidateMediaSurfaceQueries,
+  isItemDetailQueryKey,
+  updateCatalogItemDetail,
+} from "./mediaSurfaceRefresh";
 import { bumpHomeRefreshSignal } from "@/pages/homeSurfaceRefresh";
 
 function itemPathID(id: string): string {
@@ -267,8 +271,38 @@ export function useWatchedStateMutation(item: WatchedMutationItem) {
     mutationFn: (nextPlayed: boolean) =>
       api(`/watched/${itemPathID(item.content_id)}`, {
         method: nextPlayed ? "POST" : "DELETE",
+        // Marking a series expands to every episode server-side. keepalive
+        // lets the browser finish the request after a navigation or tab close,
+        // so a large series no longer depends on the user staying on the page.
+        // The server applies the mark in one transaction, so a request that
+        // never arrives leaves nothing marked rather than a partial subset.
+        keepalive: true,
       }),
-    onError: (err) => {
+    onMutate: async (nextPlayed: boolean) => {
+      // Cancel and snapshot over the same predicate: an in-flight detail query
+      // on either key shape would otherwise land after the optimistic write
+      // and revert the button.
+      const itemDetailQueries = {
+        predicate: (query: { queryKey: unknown }) =>
+          isItemDetailQueryKey(query.queryKey, item.content_id),
+      };
+      await queryClient.cancelQueries(itemDetailQueries);
+      const previous = queryClient.getQueriesData(itemDetailQueries);
+      updateCatalogItemDetail(queryClient, item.content_id, (detail) => ({
+        ...detail,
+        ...(detail.user_data ? { user_data: { ...detail.user_data, played: nextPlayed } } : {}),
+        user_state: {
+          played: nextPlayed,
+          is_favorite: detail.user_state?.is_favorite ?? false,
+          in_watchlist: detail.user_state?.in_watchlist ?? false,
+        },
+      }));
+      return { previous };
+    },
+    onError: (err, _nextPlayed, context) => {
+      for (const [queryKey, value] of context?.previous ?? []) {
+        queryClient.setQueryData(queryKey, value);
+      }
       toast.error(err instanceof Error ? err.message : "Failed to update watched state");
     },
     onSuccess: (_data, nextPlayed) => {

--- a/web/src/hooks/queries/mediaSurfaceRefresh.ts
+++ b/web/src/hooks/queries/mediaSurfaceRefresh.ts
@@ -84,7 +84,9 @@ export function removeItemFromHomeSectionCaches(
   );
 }
 
-function isItemDetailQueryKey(queryKey: unknown, itemId: string) {
+/** Matches both item-detail cache key shapes for one item, so optimistic
+ * updates and their rollback snapshot cover exactly the same queries. */
+export function isItemDetailQueryKey(queryKey: unknown, itemId: string) {
   return (
     Array.isArray(queryKey) &&
     ((queryKey[0] === "catalog" &&


### PR DESCRIPTION
## Problem

Marking a large series as watched in the web UI only marked *some* episodes when the user pressed back or closed the tab quickly.

The cause is server-side. `POST /watched/{id}` expands a series to every episode and then does **four sequential DB round-trips per episode**, all on the request context with no transaction:

- `episodeTargets` → `contentDurationSeconds` — one file query per episode (`internal/api/handlers/items.go`)
- `recordMarkWatched` loops per target: `MarkWatched` upsert → `ResolveHistoryIdentity` (itself an episode lookup **plus** a series provider-ID lookup) → history insert (`internal/watchstate/service.go`)

A 200-episode series is roughly 800 sequential queries. Each iteration commits independently, so when the browser cancels the request — closing the tab is the reliable trigger — the loop dies partway and everything already committed stays committed. That is exactly the partial mark users see.

The client compounded it: the watched mutation used a plain fetch with no `keepalive` and no optimistic update, so the button sat pending for the whole slow round-trip and the request died with the document.

Season marks took the identical path.

## Approach

**Batch the reads.** `episodeTargets` now resolves durations through the existing batched `listEpisodeFiles` helper rather than one query per episode. Extracted `mediaFileDurationSeconds` and reused it in `contentDurationSeconds` so the batched and single-item paths cannot drift.

**Bulk identity resolution.** New `ResolveHistoryIdentities` resolves a whole series in one episode query plus one provider-ID query per distinct series. Both batch lookups sit behind optional-capability interfaces with per-ID fallbacks, mirroring the existing `VisibleHistoryAdder` pattern — the narrow test fakes still compile unchanged.

**One transactional write.** New `userstore.WatchedBatchWriter` capability with a package-level helper that falls back to today's per-target loop. Implemented transactionally in both Postgres and SQLite. `recordMarkWatched` and jellycompat's `recordMarkWatchedBatch` both route through it, so the two share one implementation.

Notably this needs **no `context.WithoutCancel`**. With a single transaction, a cancelled request rolls back to a clean "nothing marked" state — all-or-nothing is the correct semantic here, and strictly better than a detached goroutine racing the response.

**Client.** `keepalive: true` so the request survives navigation and tab close, plus an optimistic `played` flip with rollback following the established `favorites.ts` pattern. Covers series, season, and episode in both directions, since all three call sites share the one hook.

## Two things worth reviewer attention

1. **jellycompat duration semantics.** Routing `recordMarkWatchedBatch` through the shared path would have clobbered known durations with `0`, because that caller supplies none and its previous `MarkProgressBatch` left the column untouched. The batch upsert now only ever *advances* a duration, never clears it. Pinned by a conformance assertion.

2. **SQLite context handling.** `internal/userdb` ignores `ctx` by package convention. My cancellation test failed at first because of it. I plumbed context through this one function only — cancellation safety is the entire point of the transaction — and said so in a comment at the call site.

## Testing

New coverage:

- `internal/userstore/storetest/suite.go` — shared conformance case for `MarkWatchedBatch`, run by **both** backends: per-target durations land, exactly one history row per target, the hidden-history watermark still pushes a re-mark back into visibility, a zero duration does not clear a known one, and blank IDs are compacted out.
- `internal/watchstate/service_test.go` — a 25-episode series resolves identities in **exactly one** episode lookup and one provider-ID lookup (asserted via call counters, so an O(n) regression fails the test), and a 40-episode mark on a cancelled context leaves **zero** rows.
- `web/src/hooks/queries/items.test.ts` — `keepalive` is sent, and the optimistic `played` flip applies then rolls back on error.

**The regression test was verified to actually bite.** With the transactional path stubbed back out to the per-item fallback, `TestManualMarkWatchedSeriesIsAtomicOnCancel` fails:

```
--- FAIL: TestManualMarkWatchedSeriesIsAtomicOnCancel (0.00s)
    service_test.go:816: RecordManualMarkWatchedWithResult on a cancelled context returned nil error
FAIL
```

Rather than let the Postgres tests skip, I stood up a `pgvector/pgvector:pg18` container, applied all migrations, and ran the real Postgres path:

```
=== RUN   TestPostgresMarkWatchedBatch/MarkWatchedBatch
--- PASS: TestPostgresMarkWatchedBatch (0.05s)
ok  	github.com/Silo-Server/silo-server/internal/userstore/pgstore	0.163s
=== RUN   TestSQLiteMarkWatchedBatch/MarkWatchedBatch
--- PASS: TestSQLiteMarkWatchedBatch (0.01s)
ok  	github.com/Silo-Server/silo-server/internal/userdb	0.096s
--- PASS: TestManualMarkWatchedSeriesResolvesIdentitiesInBulk (0.01s)
--- PASS: TestManualMarkWatchedSeriesIsAtomicOnCancel (0.00s)
ok  	github.com/Silo-Server/silo-server/internal/watchstate	0.158s
```

Touched packages, with a live database:

```
ok  	github.com/Silo-Server/silo-server/internal/watchstate
ok  	github.com/Silo-Server/silo-server/internal/userdb
ok  	github.com/Silo-Server/silo-server/internal/userstore
ok  	github.com/Silo-Server/silo-server/internal/userstore/pgstore	0.919s
ok  	github.com/Silo-Server/silo-server/internal/api/handlers	86.738s
```

Gates:

```
$ golangci-lint run --new-from-merge-base=origin/main ./...
0 issues.

$ cd web && pnpm run lint
✖ 151 problems (0 errors, 151 warnings)      # all pre-existing, none in changed files

$ cd web && pnpm run format:check
All matched files use Prettier code style!

$ make verify-local-paths
scripts/check-local-path-leaks.sh            # passes

$ make test-web
Test Files  276 passed (276)
     Tests  1927 passed (1927)
```

## Not green, and not mine

`go test ./internal/...` has **9 pre-existing failures** across `auth`, `catalog` search, `jellycompat` playback, and `notifications`. I verified these are byte-identical on a clean stash of this branch, so they are not from this change — and they are the same rot documented in #599. I did not fix them.

Without a test database the count is 4 (`jellycompat`), also identical on a clean tree.

## Not verified

I have **not** run this against a live server in a browser. The end-to-end check — mark a long series, close the tab within a second, reload, confirm every episode is watched — is the exact user-reported scenario and is still worth doing before merge. No screenshots for that reason; the UI itself is unchanged apart from the button responding immediately.

## Risks

- The two new batch SQL statements are the substantive risk; their hidden-watermark CTEs must match the single-row versions they mirror, which is what the shared conformance case pins.
- jellycompat's stored `duration_seconds` now carries a real value where the batch path previously wrote nothing. That is a fix, but it is a behaviour change in jellycompat.
- A very large series now holds a transaction longer than the previous drip of independent commits. These are per-user progress/history rows so contention should be negligible, but it is worth a look on the largest available series.

## Scope

No linked capability epic — this is a bug fix to existing behaviour, not new scope. Happy to file it under one if you would rather it were tracked there. No API contract change: same endpoints, same response shape, additive-only.

### AI Disclosure
- Tool(s): Claude Code
- Model(s): claude-opus-5[1m]
- Involvement: fully AI-generated
- Adversarial review: My own review of the diff found three real defects, all fixed before this PR. (1) In the Postgres batch, entries with a blank media ID are dropped, so `entries[i]` could misalign with the returned rows — replaced positional indexing with an explicit index map. (2) The client `onMutate` cancelled queries on only one of the two item-detail key shapes while snapshotting both, so an in-flight query on the other shape could land after the optimistic write and revert the button — both now use the same predicate. (3) Routing jellycompat through the shared path would have zeroed known durations, as described above. Separately, `tsc -b` caught four type errors in my new test file that vitest alone did not surface, and `golangci-lint` caught 8 findings on my lines (3 errcheck, 5 misspell) — all fixed, lint is now clean at 0 issues. What I could not close: no live browser verification, and the 9 pre-existing suite failures remain.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Marking multiple episodes as watched now updates progress and watch history together.
  - Series watch actions resolve episode identities in bulk for more consistent results.
  - Watch durations are selected more reliably from media details, with catalog runtime fallback.

- **Bug Fixes**
  - Watched-state updates now appear immediately across item and catalog views.
  - Failed updates restore the previous state and display an error.
  - Watch actions remain reliable when navigating away during a request.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->