### PR TITLE
fix(watchsync): match episodes through duplicate series

### DIFF
--- a/internal/historyimport/matcher.go
+++ b/internal/historyimport/matcher.go
@@ -11,6 +11,7 @@ type matcherRepository interface {
 	MatchMediaByExternalID(ctx context.Context, kind, column, value string) ([]mediaLookupRow, error)
 	MatchMediaByTitleYear(ctx context.Context, kind, title string, year int) ([]mediaLookupRow, error)
 	MatchEpisodeByExternalID(ctx context.Context, column, value string) ([]mediaLookupRow, error)
+	MatchEpisodeBySeriesExternalID(ctx context.Context, column, value string, seasonNumber, episodeNumber int) ([]mediaLookupRow, error)
 	MatchEpisodeBySeries(ctx context.Context, seriesID string, seasonNumber, episodeNumber int) (*Match, error)
 	MatchEpisodesBySeries(ctx context.Context, seriesID string, seasonNumber *int, watchedAt *time.Time) ([]Match, error)
 }
@@ -135,6 +136,44 @@ func (m *Matcher) matchEpisode(ctx context.Context, record Record) (*Match, stri
 	if record.EpisodeNumber <= 0 {
 		attempts = append(attempts, "missing season or episode number")
 		return nil, strings.Join(attempts, "; "), nil
+	}
+
+	for _, candidate := range []struct {
+		column string
+		value  string
+		label  string
+	}{
+		{column: "tvdb_id", value: record.SeriesTVDBID, label: "series tvdb_id"},
+		{column: "tmdb_id", value: record.SeriesTMDBID, label: "series tmdb_id"},
+		{column: "imdb_id", value: record.SeriesIMDbID, label: "series imdb_id"},
+	} {
+		if candidate.value == "" {
+			continue
+		}
+		rows, err := m.repo.MatchEpisodeBySeriesExternalID(
+			ctx, candidate.column, candidate.value, record.SeasonNumber, record.EpisodeNumber,
+		)
+		if err != nil {
+			return nil, "", err
+		}
+		if len(rows) == 1 {
+			return &Match{
+				MediaItemID: rows[0].ContentID,
+				Kind:        KindEpisode,
+				Title:       rows[0].Title,
+				Year:        rows[0].Year,
+			}, "", nil
+		}
+		if len(rows) > 1 {
+			return nil, fmt.Sprintf(
+				"ambiguous episode %s match for %q S%02dE%02d (%d rows)",
+				candidate.label, candidate.value, record.SeasonNumber, record.EpisodeNumber, len(rows),
+			), nil
+		}
+		attempts = append(attempts, fmt.Sprintf(
+			"no episode %s match for %q S%02dE%02d",
+			candidate.label, candidate.value, record.SeasonNumber, record.EpisodeNumber,
+		))
 	}
 
 	seriesRecord := Record{

--- a/internal/historyimport/matcher_test.go
+++ b/internal/historyimport/matcher_test.go
@@ -37,6 +37,10 @@ func (s *matcherRepoStub) MatchEpisodeByExternalID(_ context.Context, column, va
 	return s.episodeByExternal[column+":"+value], nil
 }
 
+func (s *matcherRepoStub) MatchEpisodeBySeriesExternalID(_ context.Context, column, value string, seasonNumber, episodeNumber int) ([]mediaLookupRow, error) {
+	return s.episodeByExternal[fmt.Sprintf("series:%s:%s:%d:%d", column, value, seasonNumber, episodeNumber)], nil
+}
+
 func (s *matcherRepoStub) MatchEpisodeBySeries(_ context.Context, seriesID string, seasonNumber, episodeNumber int) (*Match, error) {
 	s.episodeBySeriesCalls++
 	s.episodeBySeriesID = seriesID
@@ -187,6 +191,41 @@ func TestMatcherMatchEpisode_AllowsSeasonZeroSpecials(t *testing.T) {
 	if repo.episodeBySeriesID != "series-1" || repo.episodeBySeriesSeason != 0 || repo.episodeBySeriesEpisode != 1 {
 		t.Fatalf("MatchEpisodeBySeries called with (%q, %d, %d), want (series-1, 0, 1)",
 			repo.episodeBySeriesID, repo.episodeBySeriesSeason, repo.episodeBySeriesEpisode)
+	}
+}
+
+func TestMatcherMatchEpisode_UsesCoordinatesBeforeAmbiguousSeriesRows(t *testing.T) {
+	t.Parallel()
+
+	repo := &matcherRepoStub{
+		mediaByExternal: map[string][]mediaLookupRow{
+			"series:tvdb_id:296188": {
+				{ContentID: "angie-library-a", Title: "Angie Tribeca", Year: 2016},
+				{ContentID: "angie-library-b", Title: "Angie Tribeca", Year: 2016},
+			},
+		},
+		episodeByExternal: map[string][]mediaLookupRow{
+			"series:tvdb_id:296188:1:8": {{ContentID: "angie-s01e08", Title: "Murder in the First Class", Year: 2016}},
+		},
+	}
+	matcher := NewMatcher(repo)
+
+	match, reason, err := matcher.Match(context.Background(), Record{
+		Kind:          KindEpisode,
+		SeriesTitle:   "Angie Tribeca",
+		SeriesYear:    2016,
+		SeriesTVDBID:  "296188",
+		SeasonNumber:  1,
+		EpisodeNumber: 8,
+	})
+	if err != nil {
+		t.Fatalf("Match returned error: %v", err)
+	}
+	if reason != "" {
+		t.Fatalf("reason = %q, want empty string", reason)
+	}
+	if match == nil || match.MediaItemID != "angie-s01e08" {
+		t.Fatalf("match = %+v, want angie-s01e08", match)
 	}
 }
 

--- a/internal/historyimport/repo.go
+++ b/internal/historyimport/repo.go
@@ -1032,6 +1032,45 @@ func (r *Repository) MatchEpisodeByExternalID(ctx context.Context, column, value
 	return matches, nil
 }
 
+func (r *Repository) MatchEpisodeBySeriesExternalID(
+	ctx context.Context,
+	column, value string,
+	seasonNumber, episodeNumber int,
+) ([]mediaLookupRow, error) {
+	if value == "" {
+		return nil, nil
+	}
+	rows, err := r.pool.Query(ctx, `
+		SELECT e.content_id, COALESCE(e.title, ''), COALESCE(series.year, 0)
+		FROM episodes e
+		JOIN media_items series ON series.content_id = e.series_id
+		WHERE series.type = 'series'
+		  AND series.status = 'matched'
+		  AND series.`+column+` = $1
+		  AND e.season_number = $2
+		  AND e.episode_number = $3
+		ORDER BY e.content_id ASC`,
+		value, seasonNumber, episodeNumber,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("matching episode by series %s: %w", column, err)
+	}
+	defer rows.Close()
+
+	var matches []mediaLookupRow
+	for rows.Next() {
+		var row mediaLookupRow
+		if err := rows.Scan(&row.ContentID, &row.Title, &row.Year); err != nil {
+			return nil, fmt.Errorf("scanning episode series lookup row: %w", err)
+		}
+		matches = append(matches, row)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("iterating episode series lookup rows: %w", err)
+	}
+	return matches, nil
+}
+
 func (r *Repository) MatchEpisodeBySeries(ctx context.Context, seriesID string, seasonNumber, episodeNumber int) (*Match, error) {
 	row := r.pool.QueryRow(ctx, `
 		SELECT e.content_id, COALESCE(e.title, ''), COALESCE(series.year, 0)


### PR DESCRIPTION
## Problem

MDBList episode rows can lack a directly usable episode external ID and therefore fall back to parent-series identity plus season/episode coordinates. The existing matcher resolves the parent series as a single row first. If that external ID belongs to multiple series rows, it rejects the parent as ambiguous before checking which candidate contains the requested episode.

On a real deployment this left Angie Tribeca with only episode 1 watched while MDBList reported eight watched episodes.

Fixes #650.

## Why this approach

Resolve the leaf that Silo actually needs in one repository query: matched parent-series external ID plus exact season and episode number. The matcher tries parent TVDB, TMDB, and IMDb identities in the same precedence used elsewhere, then retains the existing parent/title fallback when no combined match exists.

This narrows ambiguity instead of weakening it. A duplicate parent is acceptable only when the combined identity and coordinates produce one episode. Multiple exact episode rows still fail closed rather than marking an arbitrary item watched.

## Changes

- add an episode lookup through parent-series external identity and S/E coordinates;
- use it before resolving the parent series as a single catalog row;
- retain existing direct episode-ID and title/year fallbacks;
- add an Angie Tribeca regression test with duplicate parent rows and one exact episode result.

No API contract or migration changes.

## Real-server validation

The report was reproduced with a real MDBList account where Angie Tribeca had eight watched episodes remotely while Silo showed only episode 1. A local Silo server built from this branch, using the same show and account, completed the full-history MDBList sync and displayed the proper watched episode state.

Validation used the latest upstream main at `febf5c4a`. No credentials, usernames, server addresses, local paths, or raw provider payloads are included.

## Verification

```text
$ GOCACHE=/tmp/silo-go-cache GOMODCACHE=/tmp/silo-go-mod go test ./internal/historyimport ./internal/watchsync/providers/mdblist ./internal/watchsync
ok  github.com/Silo-Server/silo-server/internal/historyimport  (cached)
ok  github.com/Silo-Server/silo-server/internal/watchsync/providers/mdblist  (cached)
ok  github.com/Silo-Server/silo-server/internal/watchsync  (cached)

$ cd web && pnpm run lint && pnpm run format:check
# passed

$ make verify-local-paths
scripts/check-local-path-leaks.sh

$ make lint
golangci-lint run
make: golangci-lint: No such file or directory
make: *** [Makefile:54: lint] Error 127
```

## Risk

The new query adds up to three indexed parent-ID/S/E lookups only for episode rows that did not match a direct episode external ID. If multiple exact episodes remain, import continues to report ambiguity. Existing fallback behavior is unchanged when no combined match exists.

### AI Disclosure
- Tool(s): Codex CLI
- Model(s): gpt-5
- Involvement: fully AI-generated
- Adversarial review: Reviewed wrong-row writes, duplicate episode copies, identifier precedence, query scope, SQL parameterization, and fallback compatibility. Preserved fail-closed behavior for multiple exact episodes, constrained lookup to matched series plus exact season/episode coordinates, and retained the old fallback on no match.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved TV episode matching using series identifiers from TVDB, TMDB, and IMDb.
  - Uses season and episode numbers to select the correct episode when multiple matches exist.
  - Added clearer diagnostics for ambiguous or unsuccessful matches.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->