### PR TITLE
fix(playback): isolate the DV7 HDR10 base layer

### DIFF
--- a/cmd/playbackfixtures/main.go
+++ b/cmd/playbackfixtures/main.go
@@ -335,7 +335,7 @@ func goldenCapabilityResponse() playback.CapabilityResponseV3 {
 		// fixture pins the full set so a client sees every shape it must parse.
 		Transformations: []playback.TransformationV3{
 			{Name: playback.TransformationAudioToAACV3, Executor: playback.ExecutorServerV3, RecipeVersion: "1", ValidatedClaims: []string{playback.ClaimAudioDecodeV3}},
-			{Name: playback.TransformationServerDV7HDR10V3, Executor: playback.ExecutorServerV3, RecipeVersion: "1", ValidatedClaims: playback.DV7ToHDR10ClaimsV3()},
+			{Name: playback.TransformationServerDV7HDR10V3, Executor: playback.ExecutorServerV3, RecipeVersion: playback.TransformationServerDV7HDR10RecipeVersionV3, ValidatedClaims: playback.DV7ToHDR10ClaimsV3()},
 			{Name: playback.TransformationVideoToH264V3, Executor: playback.ExecutorServerV3, RecipeVersion: playback.TransformationVideoToH264RecipeVersionV3, ValidatedClaims: []string{playback.ClaimH264DecodeV3}},
 		},
 	}
@@ -573,7 +573,7 @@ func goldenConformanceMatrix() playback.ConformanceMatrixV3 {
 	dv7File.VideoTracks[0].VideoRangeType = "DOVIWithEL"
 	dv7Request := conformanceHDRRequest()
 	dv7Request.PlaybackAttemptID = "attempt-dv7-hdr10"
-	dv7Registry := playback.NewTransformationRegistryV3([]playback.TransformationSpecV3{{Name: playback.TransformationServerDV7HDR10V3, RecipeVersion: "1", Available: true}})
+	dv7Registry := playback.NewTransformationRegistryV3([]playback.TransformationSpecV3{{Name: playback.TransformationServerDV7HDR10V3, RecipeVersion: playback.TransformationServerDV7HDR10RecipeVersionV3, Available: true}})
 	planner = append(planner, makePlannerScenario("dolby_vision_7_hdr10_fallback", "hdr_dv_matrix", dv7Request, dv7File, nil, settings, dv7Registry))
 
 	audioAdaptFile := conformanceHDRFile()
@@ -858,6 +858,6 @@ func conformanceRegistry() *playback.TransformationRegistryV3 {
 	return playback.NewTransformationRegistryV3([]playback.TransformationSpecV3{
 		{Name: playback.TransformationAudioToAACV3, RecipeVersion: "1", Available: true},
 		{Name: playback.TransformationVideoToH264V3, RecipeVersion: "1", Available: true},
-		{Name: playback.TransformationServerDV7HDR10V3, RecipeVersion: "1", Available: true},
+		{Name: playback.TransformationServerDV7HDR10V3, RecipeVersion: playback.TransformationServerDV7HDR10RecipeVersionV3, Available: true},
 	})
 }

--- a/docs/architecture/playback-protocol-v3.md
+++ b/docs/architecture/playback-protocol-v3.md
@@ -784,14 +784,14 @@ A transformation is a named, versioned media operation with claims attached.
 | --- | --- | --- | --- | --- |
 | `audio_to_aac` | `server` | `1` | — | `audio_decode` |
 | `video_to_h264` | `server` | `2` | `sdr` output | `h264_decode` |
-| `server_dv7_to_hdr10` | `server` | `1` | `hdr10` output | `dolby_vision_metadata_removed`, `hdr10_base_layer_preserved`, `enhancement_layer_discarded` |
+| `server_dv7_to_hdr10` | `server` | `2` | `hdr10` output | `dolby_vision_metadata_removed`, `hdr10_base_layer_preserved`, `enhancement_layer_discarded` |
 
 They are advertised only if the installed FFmpeg actually has the required
 capability, probed once at startup:
 
 | Transformation | Probe |
 | --- | --- |
-| `server_dv7_to_hdr10` | `ffmpeg -bsfs` contains `dovi_rpu` |
+| `server_dv7_to_hdr10` | `ffmpeg -bsfs` contains `dovi_rpu` and `filter_units` |
 | `audio_to_aac` | `ffmpeg -encoders` contains an `aac` encoder |
 | `video_to_h264` | `ffmpeg -encoders` contains any of `libx264`, `h264_qsv`, `h264_vaapi`, `h264_nvenc`, `h264_videotoolbox` |
 

--- a/docs/architecture/playback-protocol-v3.md
+++ b/docs/architecture/playback-protocol-v3.md
@@ -127,9 +127,9 @@ unknown, and both look like an absent field.
 delivery classes a client negotiates in. §4 gives the folding.
 
 `transformations` advertises only what the *installed* FFmpeg was probed for at
-startup — a server without a `dovi_rpu` bitstream filter does not list
-`server_dv7_to_hdr10`. A client must not assume a transformation exists because
-this document names it.
+startup — a server without both the `dovi_rpu` and `filter_units` bitstream
+filters does not list `server_dv7_to_hdr10`. A client must not assume a
+transformation exists because this document names it.
 
 `enabled` survives from the rollout period and is now constant `true`; the
 negative shape was deliberately removed before v1 lock because v3 is the only

--- a/docs/design/schemas/playback-v3/v3/fixtures/valid/capability_response.json
+++ b/docs/design/schemas/playback-v3/v3/fixtures/valid/capability_response.json
@@ -32,7 +32,7 @@
     {
       "name": "server_dv7_to_hdr10",
       "executor": "server",
-      "recipe_version": "1",
+      "recipe_version": "2",
       "validated_claims": [
         "dolby_vision_metadata_removed",
         "hdr10_base_layer_preserved",

--- a/internal/api/handlers/playback.go
+++ b/internal/api/handlers/playback.go
@@ -509,6 +509,7 @@ func identityRecipeCard(s *playback.Session) playback.RecipeCard {
 	switch s.PlayMethod {
 	case playback.PlayRemux:
 		card := playback.NewRemuxRecipeCard(s.ID, s.UserID, s.ProfileID, s.MediaFileID, s.TranscodeAudio, s.AudioTrackIndex, s.RemuxDVMode)
+		card.RemuxDVRecipeVersion = s.RemuxDVRecipeVersion
 		card.TargetCodecAudio = s.TargetAudioCodec
 		card.TargetAudioChannels = s.TargetAudioChannels
 		card.TargetAudioBitrateKbps = s.TargetAudioBitrateKbps

--- a/internal/api/handlers/playback_v3.go
+++ b/internal/api/handlers/playback_v3.go
@@ -878,6 +878,11 @@ func (h *PlaybackHandler) prepareIdentityTransportV3(r *http.Request, session *p
 			return preparedTransportV3{}, err
 		}
 	}
+	if !servedByProxy && planRequiresServerTransformationsV3(result.Plan) {
+		if err := validateAdvertisedTransformationsV3(result.Plan, h.transformationRegistryV3(r.Context()).Advertised()); err != nil {
+			return preparedTransportV3{}, &transportErrorV3{reason: "transcode_node_capability_unavailable", message: "No available playback executor can run the selected playback recipe.", retryable: true, cause: err}
+		}
+	}
 
 	previousNodeURL := session.TranscodeNodeURL
 	previousTransportID := remoteTransportID(session)

--- a/internal/api/handlers/playback_v3.go
+++ b/internal/api/handlers/playback_v3.go
@@ -857,6 +857,7 @@ func (h *PlaybackHandler) prepareIdentityTransportV3(r *http.Request, session *p
 	routeSession.TargetAudioChannels = result.TargetAudioChannels
 	routeSession.TargetAudioBitrateKbps = result.TargetAudioBitrateKbps
 	routeSession.RemuxDVMode = remuxDVModeForPlanV3(result.Plan)
+	routeSession.RemuxDVRecipeVersion = remuxDVRecipeVersionForPlanV3(result.Plan)
 
 	proxyNode, proxyErr := h.planIdentityProxyV3(r, session.ID, result)
 	if proxyErr != nil {
@@ -1034,9 +1035,10 @@ func identityStreamBitrateKbpsV3(result playback.PlannerResultV3) int {
 //
 // The proxy serves from the token alone, so the token has to carry everything
 // the API-local path would have read from the session and the file record: the
-// media path it opens, and the Dolby Vision profile its remux needs to strip a
-// dangling Profile 7 RPU. Omitting either would not fail loudly — the proxy
-// would serve a subtly different stream than the plan promised.
+// media path it opens, plus the Dolby Vision profile, mode, and recipe version
+// its remux needs for the complete Profile 7-to-HDR10 filter chain. Omitting
+// any of them would not fail loudly — the proxy would serve a subtly different
+// stream than the plan promised.
 //
 // The bool reports whether the returned URL is actually a proxy URL, so the
 // caller can release the planner reservation when it is not.
@@ -1386,7 +1388,7 @@ func sourceVideoTranscodeFactsV3(file *models.MediaFile, result playback.Planner
 }
 
 func (h *PlaybackHandler) v3SessionStreamState(ctx context.Context, session *playback.Session, file *models.MediaFile, result playback.PlannerResultV3, transport preparedTransportV3) playback.SessionStreamState {
-	state := playback.SessionStreamState{PlayMethod: result.PlayMethod, BasePlayMethod: result.PlayMethod, AudioTrackIndex: plannedAudioTrackIndexV3(result, session.AudioTrackIndex), TranscodeAudio: result.TranscodeAudio, RemuxDVMode: remuxDVModeForPlanV3(result.Plan), TranscodeNodeURL: transport.nodeURL, TranscodeTransportID: transport.transportID, TranscodeRouteSet: true, ClientIP: clientip.FromContext(ctx), ClientName: session.ClientName, ClientVersion: session.ClientVersion, ClientUserAgent: session.ClientUserAgent, StreamBitrateKbps: result.TargetBitrateKbps, TargetVideoCodec: result.TargetVideoCodec, TargetAudioCodec: result.TargetAudioCodec, TargetAudioChannels: result.TargetAudioChannels, TargetAudioBitrateKbps: result.TargetAudioBitrateKbps, TargetResolution: result.TargetResolution, SubtitleTrackIndex: result.SubtitleTransportTrackIndex, SubtitleBurnIn: result.SubtitleBurnIn}
+	state := playback.SessionStreamState{PlayMethod: result.PlayMethod, BasePlayMethod: result.PlayMethod, AudioTrackIndex: plannedAudioTrackIndexV3(result, session.AudioTrackIndex), TranscodeAudio: result.TranscodeAudio, RemuxDVMode: remuxDVModeForPlanV3(result.Plan), RemuxDVRecipeVersion: remuxDVRecipeVersionForPlanV3(result.Plan), TranscodeNodeURL: transport.nodeURL, TranscodeTransportID: transport.transportID, TranscodeRouteSet: true, ClientIP: clientip.FromContext(ctx), ClientName: session.ClientName, ClientVersion: session.ClientVersion, ClientUserAgent: session.ClientUserAgent, StreamBitrateKbps: result.TargetBitrateKbps, TargetVideoCodec: result.TargetVideoCodec, TargetAudioCodec: result.TargetAudioCodec, TargetAudioChannels: result.TargetAudioChannels, TargetAudioBitrateKbps: result.TargetAudioBitrateKbps, TargetResolution: result.TargetResolution, SubtitleTrackIndex: result.SubtitleTransportTrackIndex, SubtitleBurnIn: result.SubtitleBurnIn}
 	if result.Plan != nil && (result.Plan.Delivery == playback.DeliveryTranscodeHLSV3 || result.Plan.Delivery == playback.DeliveryRemuxHLSV3) {
 		state.SegmentDuration = 2
 	}
@@ -3207,7 +3209,7 @@ func remuxDVModeForPlanV3(plan *playback.PlanV3) playback.RemuxDVMode {
 		return ""
 	}
 	for _, transformation := range plan.Transformations {
-		if transformation.Name == playback.TransformationServerDV7HDR10V3 {
+		if isCurrentServerDV7ToHDR10TransformationV3(transformation) {
 			return playback.RemuxDVStripToHDR10V3
 		}
 	}
@@ -3215,8 +3217,8 @@ func remuxDVModeForPlanV3(plan *playback.PlanV3) playback.RemuxDVMode {
 		return ""
 	}
 	if plan.Source.DVProfile == 7 {
-		// Without the strip transformation a P7 remux would drop the
-		// enhancement layer and leave dangling RPUs. A P7 plan claiming Dolby
+		// Without the strip transformation a P7 remux would preserve both the
+		// interleaved enhancement layer and its RPUs. A P7 plan claiming Dolby
 		// Vision is a client-side transform of the original bytes, so any
 		// remux attempt against this session must still be rejected.
 		return playback.RemuxDVRejectP7V3
@@ -3227,13 +3229,31 @@ func remuxDVModeForPlanV3(plan *playback.PlanV3) playback.RemuxDVMode {
 	return ""
 }
 
+func isCurrentServerDV7ToHDR10TransformationV3(transformation playback.TransformationV3) bool {
+	return transformation.Executor == playback.ExecutorServerV3 &&
+		transformation.Name == playback.TransformationServerDV7HDR10V3 &&
+		transformation.RecipeVersion == playback.TransformationServerDV7HDR10RecipeVersionV3
+}
+
 func videoBitstreamFilterForPlanV3(plan *playback.PlanV3) string {
 	if plan == nil {
 		return ""
 	}
 	for _, transformation := range plan.Transformations {
-		if transformation.Executor == playback.ExecutorServerV3 && transformation.Name == playback.TransformationServerDV7HDR10V3 && transformation.RecipeVersion == "1" {
+		if isCurrentServerDV7ToHDR10TransformationV3(transformation) {
 			return playback.DV7ToHDR10BitstreamFilter
+		}
+	}
+	return ""
+}
+
+func remuxDVRecipeVersionForPlanV3(plan *playback.PlanV3) string {
+	if plan == nil {
+		return ""
+	}
+	for _, transformation := range plan.Transformations {
+		if isCurrentServerDV7ToHDR10TransformationV3(transformation) {
+			return transformation.RecipeVersion
 		}
 	}
 	return ""
@@ -3244,7 +3264,7 @@ func videoBitstreamFilterForPlanV3(plan *playback.PlanV3) string {
 // genuinely on the table; every other start never touches it.
 //
 // The probe belongs to planning, not to the transport: the plan's HDR10 promise
-// and the durable session's RemuxDVMode are both derived from the strip
+// and the durable session's remux mode/version are both derived from the strip
 // decision and are re-read by the restart and audio-switch paths, so
 // suppressing the filter downstream would leave those claims describing a
 // stream the server is no longer producing.

--- a/internal/api/handlers/playback_v3_test.go
+++ b/internal/api/handlers/playback_v3_test.go
@@ -3950,6 +3950,9 @@ func TestPrepareTransportV3KeepsRemuxLocalWhenProxyLacksTheRecipe(t *testing.T) 
 	handler := NewPlaybackHandler(playback.NewSessionManager(0, 0))
 	handler.JWTSecret = "test-secret"
 	stubCopySeekAnchorV3(handler)
+	presetLocalRegistryV3(handler, playback.NewTransformationRegistryV3([]playback.TransformationSpecV3{{
+		Name: playback.TransformationAudioToAACV3, RecipeVersion: "1", Available: true,
+	}}))
 	planner := &recordingNodePlannerV3{plan: nodepool.Plan{ProxyNode: &nodepool.Node{URL: proxy.URL}}}
 	handler.NodePlanner = planner
 

--- a/internal/api/handlers/playback_v3_test.go
+++ b/internal/api/handlers/playback_v3_test.go
@@ -1334,7 +1334,7 @@ func TestHandleReplanPlaybackV3SeekReanchorPreservesFallbackRecipe(t *testing.T)
 	presetLocalRegistryV3(handler, playback.NewTransformationRegistryV3([]playback.TransformationSpecV3{
 		{Name: "audio_to_aac", RecipeVersion: "1", Available: true},
 		{Name: "video_to_h264", RecipeVersion: "2", Available: true},
-		{Name: "server_dv7_to_hdr10", RecipeVersion: "1", Available: true},
+		{Name: playback.TransformationServerDV7HDR10V3, RecipeVersion: playback.TransformationServerDV7HDR10RecipeVersionV3, Available: true},
 	}))
 	handler.SettingsRepo = &mutablePlaybackSettingsV3{values: map[string]string{}}
 	handler.ItemAccess = allowAllPlaybackItemAccess{}
@@ -1998,7 +1998,7 @@ func TestFrozenSeekReanchorResultV3PreservesRouteMatrix(t *testing.T) {
 		}},
 		{name: "Dolby Vision transformation", mutate: func(plan *playback.PlanV3, _ *playback.PlannerResultV3) {
 			plan.EffectiveRecipe.DynamicRange = "hdr10"
-			plan.Transformations = []playback.TransformationV3{{Name: "server_dv7_to_hdr10", Executor: "server", RecipeVersion: "1"}}
+			plan.Transformations = []playback.TransformationV3{{Name: playback.TransformationServerDV7HDR10V3, Executor: playback.ExecutorServerV3, RecipeVersion: playback.TransformationServerDV7HDR10RecipeVersionV3}}
 		}},
 		{name: "pooled node only transformation", mutate: func(plan *playback.PlanV3, result *playback.PlannerResultV3) {
 			plan.Delivery = playback.DeliveryTranscodeHLSV3
@@ -2648,9 +2648,52 @@ func TestTransportGenerationV3IsUniqueAndSessionScoped(t *testing.T) {
 }
 
 func TestRemuxDVModeForPlanV3ExecutesProfile8Strip(t *testing.T) {
-	plan := &playback.PlanV3{Source: playback.SourceDescriptorV3{DVProfile: 8}, Transformations: []playback.TransformationV3{{Name: "server_dv7_to_hdr10"}}}
+	plan := &playback.PlanV3{Source: playback.SourceDescriptorV3{DVProfile: 8}, Transformations: []playback.TransformationV3{{Name: playback.TransformationServerDV7HDR10V3, Executor: playback.ExecutorServerV3, RecipeVersion: playback.TransformationServerDV7HDR10RecipeVersionV3}}}
 	if got := remuxDVModeForPlanV3(plan); got != playback.RemuxDVStripToHDR10V3 {
 		t.Fatalf("mode = %q", got)
+	}
+}
+
+func TestDV7ToHDR10ExecutionRequiresCurrentServerRecipe(t *testing.T) {
+	current := playback.TransformationV3{Name: playback.TransformationServerDV7HDR10V3, Executor: playback.ExecutorServerV3, RecipeVersion: playback.TransformationServerDV7HDR10RecipeVersionV3}
+	currentPlan := &playback.PlanV3{Source: playback.SourceDescriptorV3{DVProfile: 7}, Transformations: []playback.TransformationV3{current}}
+	if got := remuxDVModeForPlanV3(currentPlan); got != playback.RemuxDVStripToHDR10V3 {
+		t.Fatalf("current recipe remux mode = %q, want %q", got, playback.RemuxDVStripToHDR10V3)
+	}
+	if got := videoBitstreamFilterForPlanV3(currentPlan); got != playback.DV7ToHDR10BitstreamFilter {
+		t.Fatalf("current recipe bitstream filter = %q, want %q", got, playback.DV7ToHDR10BitstreamFilter)
+	}
+	if got := remuxDVRecipeVersionForPlanV3(currentPlan); got != playback.TransformationServerDV7HDR10RecipeVersionV3 {
+		t.Fatalf("current remux recipe version = %q, want %q", got, playback.TransformationServerDV7HDR10RecipeVersionV3)
+	}
+
+	invalid := []struct {
+		name           string
+		transformation playback.TransformationV3
+	}{
+		{name: "stale version", transformation: playback.TransformationV3{Name: playback.TransformationServerDV7HDR10V3, Executor: playback.ExecutorServerV3, RecipeVersion: "1"}},
+		{name: "client executor", transformation: playback.TransformationV3{Name: playback.TransformationServerDV7HDR10V3, Executor: playback.ExecutorClientV3, RecipeVersion: playback.TransformationServerDV7HDR10RecipeVersionV3}},
+		{name: "wrong transformation", transformation: playback.TransformationV3{Name: playback.TransformationAudioToAACV3, Executor: playback.ExecutorServerV3, RecipeVersion: playback.TransformationServerDV7HDR10RecipeVersionV3}},
+	}
+	for _, tt := range invalid {
+		t.Run(tt.name, func(t *testing.T) {
+			plan := &playback.PlanV3{Source: playback.SourceDescriptorV3{DVProfile: 7}, Transformations: []playback.TransformationV3{tt.transformation}}
+			if got := remuxDVModeForPlanV3(plan); got != playback.RemuxDVRejectP7V3 {
+				t.Fatalf("remux mode = %q, want %q", got, playback.RemuxDVRejectP7V3)
+			}
+			if got := videoBitstreamFilterForPlanV3(plan); got != "" {
+				t.Fatalf("selected bitstream filter %q", got)
+			}
+			if got := remuxDVRecipeVersionForPlanV3(plan); got != "" {
+				t.Fatalf("selected remux recipe version %q", got)
+			}
+		})
+	}
+	if got := videoBitstreamFilterForPlanV3(nil); got != "" {
+		t.Fatalf("nil plan selected bitstream filter %q", got)
+	}
+	if got := remuxDVRecipeVersionForPlanV3(nil); got != "" {
+		t.Fatalf("nil plan selected remux recipe version %q", got)
 	}
 }
 
@@ -3750,7 +3793,11 @@ func TestPrepareTransportV3RoutesProgressiveRemuxThroughProxyNodeWithSeekAndDV(t
 	file := v3HandlerFixtureFile(t)
 	file.VideoTracks[0].DVProfile = 7
 
-	plan := identityProxyPlanV3(playback.DeliveryRemuxProgressiveV3, playback.TransformationV3{Name: playback.TransformationAudioToAACV3, Executor: playback.ExecutorServerV3, RecipeVersion: "1"})
+	plan := identityProxyPlanV3(
+		playback.DeliveryRemuxProgressiveV3,
+		playback.TransformationV3{Name: playback.TransformationAudioToAACV3, Executor: playback.ExecutorServerV3, RecipeVersion: "1"},
+		playback.TransformationV3{Name: playback.TransformationServerDV7HDR10V3, Executor: playback.ExecutorServerV3, RecipeVersion: playback.TransformationServerDV7HDR10RecipeVersionV3},
+	)
 	plan.Timeline = playback.TimelineV3{SourceStartSeconds: 39.5}
 
 	transport, transportErr := handler.prepareTransportV3(
@@ -3777,7 +3824,10 @@ func TestPrepareTransportV3RoutesProgressiveRemuxThroughProxyNodeWithSeekAndDV(t
 		t.Fatalf("verify proxy stream token: %v", err)
 	}
 	if claims.DVProfile != 7 {
-		t.Fatalf("token DV profile = %d, want 7 so the proxy strips the dangling RPU", claims.DVProfile)
+		t.Fatalf("token DV profile = %d, want 7 so the proxy applies the planned HDR10 filter chain", claims.DVProfile)
+	}
+	if claims.RemuxDVMode != string(playback.RemuxDVStripToHDR10V3) || claims.RemuxDVRecipeVersion != playback.TransformationServerDV7HDR10RecipeVersionV3 {
+		t.Fatalf("token DV recipe = %q@%q, want %q@%q", claims.RemuxDVMode, claims.RemuxDVRecipeVersion, playback.RemuxDVStripToHDR10V3, playback.TransformationServerDV7HDR10RecipeVersionV3)
 	}
 	if !claims.TranscodeAudio {
 		t.Fatal("token must tell the proxy to convert audio")
@@ -3880,7 +3930,7 @@ func capableProxyStubV3(t *testing.T) *httptest.Server {
 		}
 		writeJSON(w, http.StatusOK, playback.HWAccelInfo{Transformations: []playback.TransformationV3{
 			{Name: playback.TransformationAudioToAACV3, Executor: playback.ExecutorServerV3, RecipeVersion: "1"},
-			{Name: playback.TransformationServerDV7HDR10V3, Executor: playback.ExecutorServerV3, RecipeVersion: "1"},
+			{Name: playback.TransformationServerDV7HDR10V3, Executor: playback.ExecutorServerV3, RecipeVersion: playback.TransformationServerDV7HDR10RecipeVersionV3},
 		}})
 	}))
 	t.Cleanup(server.Close)

--- a/internal/api/handlers/playback_v3_union_test.go
+++ b/internal/api/handlers/playback_v3_union_test.go
@@ -44,7 +44,7 @@ func TestHLSPlanningRegistryV3UnionsPooledNodeCapabilities(t *testing.T) {
 	presetLocalRegistryV3(handler, playback.NewTransformationRegistryV3([]playback.TransformationSpecV3{
 		{Name: "video_to_h264", RecipeVersion: "2"},
 		{Name: "audio_to_aac", RecipeVersion: "1"},
-		{Name: "server_dv7_to_hdr10", RecipeVersion: "1"},
+		{Name: playback.TransformationServerDV7HDR10V3, RecipeVersion: playback.TransformationServerDV7HDR10RecipeVersionV3},
 	}))
 	handler.NodePlanner = enumeratingNodePlannerV3{urls: []string{remote.URL}}
 

--- a/internal/api/handlers/playback_v3_union_test.go
+++ b/internal/api/handlers/playback_v3_union_test.go
@@ -2,6 +2,7 @@ package handlers
 
 import (
 	"context"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -180,6 +181,40 @@ func TestPrepareTransportV3LocalFallbackRejectsUnavailableTransformations(t *tes
 	_, transportErr := handler.prepareTransportV3(request, &playback.Session{ID: "session-local-capability"}, v3HandlerFixtureFile(t), playback.PlannerResultV3{Plan: plan, PlayMethod: playback.PlayTranscode, TargetVideoCodec: "h264", TargetAudioCodec: "aac"})
 	if transportErr == nil || transportErr.reason != "transcode_node_capability_unavailable" || !transportErr.retryable {
 		t.Fatalf("transport error = %#v", transportErr)
+	}
+}
+
+func TestPrepareTransportV3IdentityRejectsStaleDVRecipe(t *testing.T) {
+	for _, profile := range []int{7, 8} {
+		t.Run(fmt.Sprintf("profile_%d", profile), func(t *testing.T) {
+			handler := NewPlaybackHandler(playback.NewSessionManager(0, 0))
+			presetLocalRegistryV3(handler, playback.NewTransformationRegistryV3([]playback.TransformationSpecV3{{
+				Name:          playback.TransformationServerDV7HDR10V3,
+				RecipeVersion: playback.TransformationServerDV7HDR10RecipeVersionV3,
+				Available:     true,
+			}}))
+			plan := &playback.PlanV3{
+				PlanID:   "plan:stale-dv-recipe",
+				Delivery: playback.DeliveryRemuxProgressiveV3,
+				Source:   playback.SourceDescriptorV3{DVProfile: profile},
+				Claims:   playback.ValidationClaimsV3{Video: playback.VideoClaimsV3{HDR10: true}},
+				Transformations: []playback.TransformationV3{{
+					Name:          playback.TransformationServerDV7HDR10V3,
+					Executor:      playback.ExecutorServerV3,
+					RecipeVersion: "1",
+				}},
+			}
+
+			_, transportErr := handler.prepareTransportV3(
+				httptest.NewRequest(http.MethodPost, "/", nil),
+				&playback.Session{ID: "session-stale-dv-recipe"},
+				v3HandlerFixtureFile(t),
+				playback.PlannerResultV3{Plan: plan, PlayMethod: playback.PlayRemux, TargetVideoCodec: "copy"},
+			)
+			if transportErr == nil || transportErr.reason != "transcode_node_capability_unavailable" || !transportErr.retryable {
+				t.Fatalf("transport error = %#v, want retryable capability mismatch", transportErr)
+			}
+		})
 	}
 }
 

--- a/internal/api/handlers/stream.go
+++ b/internal/api/handlers/stream.go
@@ -171,6 +171,7 @@ func (h *StreamHandler) HandleStream(w http.ResponseWriter, r *http.Request) {
 		// response has to keep the same promise the plan made.
 		if err := playback.ServeRemuxWithOptions(w, r, file.FilePath, "mp4", seekSeconds, session.TranscodeAudio, session.AudioTrackIndex, file.PrimaryDVProfile(), playback.RemuxServeOptions{
 			DVMode:                 session.RemuxDVMode,
+			DVRecipeVersion:        session.RemuxDVRecipeVersion,
 			FFmpegPath:             h.ffmpegPath(),
 			ContentType:            playback.RemuxContentType(file.IsAudioOnly()),
 			AudioOnly:              file.IsAudioOnly(),

--- a/internal/playback/dovi_rpu_probe.go
+++ b/internal/playback/dovi_rpu_probe.go
@@ -23,12 +23,13 @@ import (
 //	    Invalid data found ... Invalid SEI message: payload_size too large
 //
 // Whether a given file survives the strip is a property of that file, not of
-// ffmpeg, so it cannot be answered by supportsDoviRPUFilter. It can be answered
-// in about a second by asking ffmpeg to strip a couple of seconds to nowhere.
+// ffmpeg, so it cannot be answered by supportsDV7HDR10FilterChain. It can be
+// answered in about a second by asking ffmpeg to strip a couple of seconds to
+// nowhere.
 //
 // The probe is a planning input, not a transport patch: a source that fails it
 // must not be planned onto a strip route at all, because the plan's HDR10
-// promise and the durable session's RemuxDVMode are both derived from that
+// promise and the durable session's remux recipe are both derived from that
 // decision and are re-read on every later restart.
 const (
 	// Enough packets to reach the RPU. This catches the observed failure, in
@@ -88,9 +89,9 @@ func NewDVRPUProbe() *DVRPUProbe {
 }
 
 // sharedDVRPUProbe backs DVRPUStrippable. One cache per process, like
-// doviRPUCache: the planner, the progressive remux and the restart endpoints
-// all ask the same question about the same files and must agree, and none of
-// them should pay for a probe another already ran.
+// dv7HDR10FilterSupportCache: the planner, progressive remux, and restart
+// endpoints all ask the same question about the same files and must agree, and
+// none of them should pay for a probe another already ran.
 var sharedDVRPUProbe = NewDVRPUProbe()
 
 // DVRPUStrippable reports whether the RPU strip should be attempted for this

--- a/internal/playback/plan_v3.go
+++ b/internal/playback/plan_v3.go
@@ -390,7 +390,7 @@ func PlanPlaybackV3(input PlannerInputV3) PlannerResultV3 {
 		}
 		dvStrip := dvStripEligible && (source.DVProfile == 7 || !rangeOK)
 		if dvStrip {
-			plan.Transformations = append(plan.Transformations, TransformationV3{Name: TransformationServerDV7HDR10V3, Executor: ExecutorServerV3, RecipeVersion: "1", ValidatedClaims: DV7ToHDR10ClaimsV3()})
+			plan.Transformations = append(plan.Transformations, TransformationV3{Name: TransformationServerDV7HDR10V3, Executor: ExecutorServerV3, RecipeVersion: TransformationServerDV7HDR10RecipeVersionV3, ValidatedClaims: DV7ToHDR10ClaimsV3()})
 			plan.EffectiveRecipe.DynamicRange = DynamicRangeHDR10V3
 			plan.Claims.Video = VideoClaimsV3{HDR10: true}
 			plan.DegradationWarnings = append(plan.DegradationWarnings, DegradationWarningV3{Code: "dolby_vision_removed", Message: "Dolby Vision metadata is removed and the validated HDR10 base layer is preserved."})

--- a/internal/playback/plan_v3_union_test.go
+++ b/internal/playback/plan_v3_union_test.go
@@ -14,7 +14,7 @@ func TestTransformationRegistryWithAdvertised(t *testing.T) {
 	registry := NewTransformationRegistryV3([]TransformationSpecV3{
 		{Name: "audio_to_aac", RecipeVersion: "1"},
 		{Name: "video_to_h264", RecipeVersion: "2"},
-		{Name: "server_dv7_to_hdr10", RecipeVersion: "1", Available: true},
+		{Name: TransformationServerDV7HDR10V3, RecipeVersion: TransformationServerDV7HDR10RecipeVersionV3, Available: true},
 	})
 	if got := registry.WithAdvertised(nil); got != registry {
 		t.Fatal("empty advertisement must return the receiver unchanged")
@@ -158,21 +158,21 @@ func TestPlanPlaybackV3NodeToolchainDoesNotMaskTerminalForProgressiveOnlyClient(
 }
 
 // The Profile 7 HDR10 strip must ride the HLS remux when only pooled nodes
-// carry the dovi_rpu filter: the progressive remux executes locally and is
-// not eligible without the local filter.
+// carry both required bitstream filters: the progressive remux executes
+// locally and is not eligible without the local recipe.
 func TestPlanPlaybackV3Profile7StripOffloadsToHLSRemux(t *testing.T) {
 	file := detailedFixtureFileV3()
 	file.VideoTracks[0].DVProfile = 7
 	file.VideoTracks[0].DVBLCompatID = 6
-	file.VideoTracks[0].DVELPresent = false
-	file.VideoTracks[0].DVEnhancementLayer = ""
+	file.VideoTracks[0].DVELPresent = true
+	file.VideoTracks[0].DVEnhancementLayer = string(EnhancementFELV3)
 	file.VideoTracks[0].VideoRange = "DolbyVision"
 	file.VideoTracks[0].VideoRangeType = "DOVIWithEL"
 	req := validStartRequestV3()
 	req.Capabilities.VideoDecode = []VideoDecodeCapabilityV3{{Codec: "hevc", Profiles: []string{"main 10"}, Levels: []int{153}, BitDepths: []int{10}, MaxWidth: 3840, MaxHeight: 2160, MaxFrameRate: 60, MaxBitrateKbps: 80_000, Hardware: true}}
 	req.Capabilities.HDRDetails = &HDRCapabilitiesV3{HDR10: true, DolbyVisionProfiles: []int{5, 8}}
 	req.ClientPlaybackContext.Output.HDRDetails = req.Capabilities.HDRDetails
-	local := NewTransformationRegistryV3([]TransformationSpecV3{{Name: "server_dv7_to_hdr10", RecipeVersion: "1"}})
+	local := NewTransformationRegistryV3([]TransformationSpecV3{{Name: TransformationServerDV7HDR10V3, RecipeVersion: TransformationServerDV7HDR10RecipeVersionV3}})
 	settings := PlannerSettingsV3{TranscodeEnabled: true, Allow4KTranscode: true}
 
 	withoutNodes := PlanPlaybackV3(PlannerInputV3{Request: req, RequestedFile: file, EffectiveFile: file, AudioTrackIndex: 0, Settings: settings, Registry: local})
@@ -180,12 +180,20 @@ func TestPlanPlaybackV3Profile7StripOffloadsToHLSRemux(t *testing.T) {
 		t.Fatalf("without nodes = %s", ExplainPlannerResultV3(withoutNodes))
 	}
 
-	union := local.WithAdvertised([]TransformationV3{{Name: "server_dv7_to_hdr10", Executor: "server", RecipeVersion: "1"}})
+	staleUnion := local.WithAdvertised([]TransformationV3{{Name: TransformationServerDV7HDR10V3, Executor: ExecutorServerV3, RecipeVersion: "1"}})
+	if staleUnion.Available(TransformationServerDV7HDR10V3) {
+		t.Fatal("a node advertising the incomplete v1 DV7 recipe must not widen availability")
+	}
+
+	union := local.WithAdvertised([]TransformationV3{{Name: TransformationServerDV7HDR10V3, Executor: ExecutorServerV3, RecipeVersion: TransformationServerDV7HDR10RecipeVersionV3}})
 	offloaded := PlanPlaybackV3(PlannerInputV3{Request: req, RequestedFile: file, EffectiveFile: file, AudioTrackIndex: 0, Settings: settings, Registry: local, HLSRegistry: staticHLSRegistryV3(union)})
 	if offloaded.Plan == nil || offloaded.Plan.Delivery != DeliveryRemuxHLSV3 || offloaded.TargetVideoCodec != "copy" {
 		t.Fatalf("with nodes = %s", ExplainPlannerResultV3(offloaded))
 	}
-	if len(offloaded.Plan.Transformations) != 1 || offloaded.Plan.Transformations[0].Name != "server_dv7_to_hdr10" {
+	if len(offloaded.Plan.Transformations) != 1 ||
+		offloaded.Plan.Transformations[0].Name != TransformationServerDV7HDR10V3 ||
+		offloaded.Plan.Transformations[0].Executor != ExecutorServerV3 ||
+		offloaded.Plan.Transformations[0].RecipeVersion != TransformationServerDV7HDR10RecipeVersionV3 {
 		t.Fatalf("transformations = %#v", offloaded.Plan.Transformations)
 	}
 	if offloaded.Plan.EffectiveRecipe.DynamicRange != "hdr10" || !offloaded.Plan.Claims.Video.HDR10 {

--- a/internal/playback/protocol_v3.go
+++ b/internal/playback/protocol_v3.go
@@ -133,7 +133,8 @@ const (
 	TransformationVideoToH264V3    = "video_to_h264"
 	TransformationServerDV7HDR10V3 = "server_dv7_to_hdr10"
 
-	TransformationVideoToH264RecipeVersionV3 = "2"
+	TransformationVideoToH264RecipeVersionV3    = "2"
+	TransformationServerDV7HDR10RecipeVersionV3 = "2"
 )
 
 // Transformation executors: who runs the transformation. A "server"

--- a/internal/playback/protocol_v3_test.go
+++ b/internal/playback/protocol_v3_test.go
@@ -825,21 +825,21 @@ func TestPlanPlaybackV3Profile7FallsBackToHDR10WithoutNativeP7(t *testing.T) {
 	file := detailedFixtureFileV3()
 	file.VideoTracks[0].DVProfile = 7
 	file.VideoTracks[0].DVBLCompatID = 6
-	file.VideoTracks[0].DVELPresent = false
-	file.VideoTracks[0].DVEnhancementLayer = ""
+	file.VideoTracks[0].DVELPresent = true
+	file.VideoTracks[0].DVEnhancementLayer = string(EnhancementFELV3)
 	file.VideoTracks[0].VideoRange = "DolbyVision"
 	file.VideoTracks[0].VideoRangeType = "DOVIWithEL"
 	req := validStartRequestV3()
 	req.Capabilities.VideoDecode = []VideoDecodeCapabilityV3{{Codec: "hevc", Profiles: []string{"main 10"}, Levels: []int{153}, BitDepths: []int{10}, MaxWidth: 3840, MaxHeight: 2160, MaxFrameRate: 60, MaxBitrateKbps: 80_000, Hardware: true}}
 	req.Capabilities.HDRDetails = &HDRCapabilitiesV3{HDR10: true, DolbyVisionProfiles: []int{5, 8}}
 	req.ClientPlaybackContext.Output.HDRDetails = req.Capabilities.HDRDetails
-	registry := NewTransformationRegistryV3([]TransformationSpecV3{{Name: "server_dv7_to_hdr10", Available: true}})
+	registry := NewTransformationRegistryV3([]TransformationSpecV3{{Name: TransformationServerDV7HDR10V3, RecipeVersion: TransformationServerDV7HDR10RecipeVersionV3, Available: true}})
 
 	result := PlanPlaybackV3(PlannerInputV3{Request: req, RequestedFile: file, EffectiveFile: file, AudioTrackIndex: 0, Settings: PlannerSettingsV3{TranscodeEnabled: true}, Registry: registry})
 	if result.Plan == nil || result.Plan.Delivery != DeliveryRemuxProgressiveV3 || !result.Plan.Claims.Video.HDR10 || result.Plan.Claims.Video.DolbyVision {
 		t.Fatalf("result = %#v", result)
 	}
-	if len(result.Plan.Transformations) != 1 || result.Plan.Transformations[0].Name != "server_dv7_to_hdr10" {
+	if len(result.Plan.Transformations) != 1 || result.Plan.Transformations[0].Name != TransformationServerDV7HDR10V3 || result.Plan.Transformations[0].Executor != ExecutorServerV3 || result.Plan.Transformations[0].RecipeVersion != TransformationServerDV7HDR10RecipeVersionV3 {
 		t.Fatalf("transformations = %#v", result.Plan.Transformations)
 	}
 }
@@ -1181,9 +1181,9 @@ func TestPlanPlaybackV3Profile8CompatibleBaseLayerStripsToHDR10(t *testing.T) {
 	req := validStartRequestV3()
 	req.Capabilities.VideoDecode = []VideoDecodeCapabilityV3{{Codec: "hevc", Profiles: []string{"main 10"}, Levels: []int{153}, BitDepths: []int{10}, MaxWidth: 3840, MaxHeight: 2160, MaxFrameRate: 60, MaxBitrateKbps: 80_000, Hardware: true}}
 	req.Capabilities.HDRDetails = &HDRCapabilitiesV3{HDR10: true}
-	registry := NewTransformationRegistryV3([]TransformationSpecV3{{Name: "server_dv7_to_hdr10", Available: true}})
+	registry := NewTransformationRegistryV3([]TransformationSpecV3{{Name: TransformationServerDV7HDR10V3, RecipeVersion: TransformationServerDV7HDR10RecipeVersionV3, Available: true}})
 	result := PlanPlaybackV3(PlannerInputV3{Request: req, RequestedFile: file, EffectiveFile: file, AudioTrackIndex: 0, Settings: PlannerSettingsV3{TranscodeEnabled: true, Allow4KTranscode: true}, Registry: registry})
-	if result.Plan == nil || result.Plan.Delivery != DeliveryRemuxProgressiveV3 || result.Plan.EffectiveRecipe.DynamicRange != "hdr10" || len(result.Plan.Transformations) != 1 || result.Plan.Transformations[0].Name != "server_dv7_to_hdr10" {
+	if result.Plan == nil || result.Plan.Delivery != DeliveryRemuxProgressiveV3 || result.Plan.EffectiveRecipe.DynamicRange != "hdr10" || len(result.Plan.Transformations) != 1 || result.Plan.Transformations[0].Name != TransformationServerDV7HDR10V3 || result.Plan.Transformations[0].Executor != ExecutorServerV3 || result.Plan.Transformations[0].RecipeVersion != TransformationServerDV7HDR10RecipeVersionV3 {
 		t.Fatalf("result = %#v", result)
 	}
 }

--- a/internal/playback/recipecard.go
+++ b/internal/playback/recipecard.go
@@ -33,6 +33,8 @@ type RecipeCard struct {
 	// re-encode vs repackage).
 	TranscodeAudio bool        `json:"transcode_audio,omitempty"`
 	RemuxDVMode    RemuxDVMode `json:"remux_dv_mode,omitempty"`
+	// RemuxDVRecipeVersion pins the byte-level operation selected by the plan.
+	RemuxDVRecipeVersion string `json:"remux_dv_recipe_version,omitempty"`
 
 	// Client metadata mirrored from the session so admin views (client label,
 	// Jellyfin pill) survive reconstruction. Carried only by stored cards —
@@ -215,6 +217,7 @@ func (c RecipeCard) ToClaims() streamtoken.Claims {
 		PlayMethod:             string(c.PlayMethod),
 		TranscodeAudio:         c.TranscodeAudio,
 		RemuxDVMode:            string(c.RemuxDVMode),
+		RemuxDVRecipeVersion:   c.RemuxDVRecipeVersion,
 		TranscodeNode:          c.TranscodeNodeURL,
 		TranscodeTransportID:   c.TranscodeTransportID,
 		TargetCodec:            c.TargetCodecVideo,
@@ -267,6 +270,7 @@ func RecipeCardFromClaims(c *streamtoken.Claims) RecipeCard {
 		PlayMethod:             method,
 		TranscodeAudio:         c.TranscodeAudio,
 		RemuxDVMode:            RemuxDVMode(c.RemuxDVMode),
+		RemuxDVRecipeVersion:   c.RemuxDVRecipeVersion,
 		InputPath:              c.MediaPath,
 		OutputSubdir:           c.OutputSubdir,
 		SourceVideoCodec:       c.SourceVideoCodec,

--- a/internal/playback/recipecard_test.go
+++ b/internal/playback/recipecard_test.go
@@ -16,7 +16,7 @@ func TestRecipeCardRoundTripOpts(t *testing.T) {
 		SourceVideoProfile:     "Main 10",
 		SourceVideoBitDepth:    10,
 		SoftwareVideoDecode:    true,
-		VideoBitstreamFilter:   "dovi_rpu=strip=1",
+		VideoBitstreamFilter:   DV7ToHDR10BitstreamFilter,
 		SeekSeconds:            900,
 		StreamOriginSeconds:    896,
 		CopySeekAnchorResolved: true,
@@ -69,7 +69,7 @@ func TestRecipeCardRoundTripOpts(t *testing.T) {
 	if got.TargetAudioChannels != 1 || got.TargetAudioBitrateKbps != 96 {
 		t.Errorf("audio encode params wrong: %+v", got)
 	}
-	if got.VideoBitstreamFilter != "dovi_rpu=strip=1" {
+	if got.VideoBitstreamFilter != DV7ToHDR10BitstreamFilter {
 		t.Errorf("VideoBitstreamFilter = %q", got.VideoBitstreamFilter)
 	}
 	if !got.SoftwareVideoDecode {
@@ -92,8 +92,15 @@ func TestRecipeCardPlayMethodConstructors(t *testing.T) {
 		t.Errorf("direct card wrong: %+v", d)
 	}
 	r := NewRemuxRecipeCard("r", 1, "p", 2, true, 3)
+	r.RemuxDVMode = RemuxDVStripToHDR10V3
+	r.RemuxDVRecipeVersion = TransformationServerDV7HDR10RecipeVersionV3
 	if r.PlayMethod != PlayRemux || !r.TranscodeAudio || r.AudioTrackIndex != 3 {
 		t.Errorf("remux card wrong: %+v", r)
+	}
+	claims := r.ToClaims()
+	back := RecipeCardFromClaims(&claims)
+	if back.RemuxDVMode != RemuxDVStripToHDR10V3 || back.RemuxDVRecipeVersion != TransformationServerDV7HDR10RecipeVersionV3 {
+		t.Errorf("remux DV recipe lost in token round trip: %+v", back)
 	}
 }
 
@@ -221,7 +228,7 @@ func TestRecipeCardClaimsRoundTrip(t *testing.T) {
 		SourceVideoProfile:     "Main 10",
 		SourceVideoBitDepth:    10,
 		SoftwareVideoDecode:    true,
-		VideoBitstreamFilter:   "dovi_rpu=strip=1",
+		VideoBitstreamFilter:   DV7ToHDR10BitstreamFilter,
 		SeekSeconds:            900,
 		StreamOriginSeconds:    896,
 		CopySeekAnchorResolved: true,

--- a/internal/playback/remux.go
+++ b/internal/playback/remux.go
@@ -1,7 +1,6 @@
 package playback
 
 import (
-	"bytes"
 	"context"
 	"fmt"
 	"io"
@@ -12,6 +11,7 @@ import (
 	"strconv"
 	"strings"
 	"sync"
+	"time"
 
 	"github.com/Silo-Server/silo-server/internal/httpstream"
 )
@@ -20,8 +20,8 @@ var (
 	resolvedFFmpegPath string
 	ffmpegOnce         sync.Once
 
-	doviRPUMu    sync.Mutex
-	doviRPUCache map[string]bool
+	dv7HDR10FilterSupportMu    sync.Mutex
+	dv7HDR10FilterSupportCache map[string]bool
 )
 
 // ffmpegBinary returns the path to the ffmpeg binary.
@@ -50,39 +50,41 @@ func ResolveFFmpegPath(configured string) string {
 	return ffmpegBinary()
 }
 
-// supportsDoviRPUFilter reports whether the given FFmpeg binary can strip
-// Dolby Vision RPU metadata via the dovi_rpu bitstream filter (FFmpeg 7.1+).
-// The enhancement layer itself is dropped by stream mapping, so stripping the
-// RPUs yields a clean HDR10 base layer. Probed once per binary path.
-func supportsDoviRPUFilter(bin string) bool {
-	doviRPUMu.Lock()
-	defer doviRPUMu.Unlock()
-	if available, ok := doviRPUCache[bin]; ok {
+// supportsDV7HDR10FilterChain reports whether the given FFmpeg binary can
+// produce a clean HDR10 base layer from Profile 7: dovi_rpu strips DV metadata
+// and filter_units removes the interleaved enhancement-layer NAL units. Probed
+// once per binary path.
+func supportsDV7HDR10FilterChain(bin string) bool {
+	dv7HDR10FilterSupportMu.Lock()
+	defer dv7HDR10FilterSupportMu.Unlock()
+	if available, ok := dv7HDR10FilterSupportCache[bin]; ok {
 		return available
 	}
-	out, err := exec.Command(bin, "-hide_banner", "-bsfs").Output()
-	available := err == nil && bytes.Contains(out, []byte("dovi_rpu"))
+	probeCtx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+	defer cancel()
+	out, err := exec.CommandContext(probeCtx, bin, "-hide_banner", "-bsfs").Output()
+	available := err == nil && hasDV7HDR10FilterChain(out)
 	if !available {
-		slog.Warn("ffmpeg lacks the dovi_rpu bitstream filter (needs FFmpeg 7.1+); validated Profile 7 HDR10 remux is disabled", "ffmpeg", bin)
+		slog.Warn("ffmpeg lacks the dovi_rpu/filter_units bitstream filters; validated Profile 7 HDR10 remux is disabled", "ffmpeg", bin)
 	}
-	if doviRPUCache == nil {
-		doviRPUCache = make(map[string]bool)
+	if dv7HDR10FilterSupportCache == nil {
+		dv7HDR10FilterSupportCache = make(map[string]bool)
 	}
-	doviRPUCache[bin] = available
+	dv7HDR10FilterSupportCache[bin] = available
 	return available
 }
 
 // remuxDVProfile neutralizes a Dolby Vision profile the local ffmpeg cannot
-// handle. Profile 7 is the only profile that triggers an RPU strip in
-// buildRemuxArgs; when the strip is unavailable — the dovi_rpu filter is
-// missing, or this source's RPU cannot be parsed — the remux must still start
-// (an unknown bitstream filter aborts ffmpeg immediately, and a filter that
-// rejects every packet hangs the session), so fall back to the pre-strip
+// handle. Profile 7 is the only profile that triggers the HDR10 base-layer
+// filter in buildRemuxArgs; when the filter is unavailable — either required
+// BSF is missing, or this source's RPU cannot be parsed — the remux must still
+// start (an unknown bitstream filter aborts ffmpeg immediately, and a filter
+// that rejects every packet hangs the session), so fall back to the pre-strip
 // behavior instead of failing playback. Only the legacy/auto mode takes this
 // route; the explicit v3 strip recipe fails loudly instead, because it has
 // promised the client an HDR10 output it could not then produce.
-func remuxDVProfile(dvProfile int, canStripRPU bool) int {
-	if dvProfile == 7 && !canStripRPU {
+func remuxDVProfile(dvProfile int, canProduceHDR10BaseLayer bool) int {
+	if dvProfile == 7 && !canProduceHDR10BaseLayer {
 		return 0
 	}
 	return dvProfile
@@ -114,10 +116,10 @@ const (
 // When transcodeAudio is true, video is copied but audio is transcoded to
 // stereo AAC (handles cases like DTS/TrueHD that browsers cannot decode).
 // dvProfile is the file's Dolby Vision profile (0 = none). Profile 7 remuxes
-// strip DV RPUs: the enhancement layer is dropped by the video map below, so
-// the RPUs would dangle — stripping yields a clean HDR10 base layer (the
-// Apple-parity fallback for devices without a P7 decoder). Profile 8 RPUs
-// stay: the base layer is self-contained and DV clients can render it.
+// strip DV metadata and the interleaved enhancement-layer NAL units, yielding
+// a clean HDR10 base layer (the Apple fallback for devices without a P7
+// decoder). Profile 8 RPUs stay: the base layer is self-contained and DV
+// clients can render it.
 func buildRemuxArgs(filePath, outputFormat string, seekSeconds float64, transcodeAudio bool, audioTrackIndex int, dvProfile int, tagSampleEntry, audioOnly bool) []string {
 	return buildRemuxArgsWithAudioV3(filePath, outputFormat, seekSeconds, transcodeAudio, audioTrackIndex, dvProfile, tagSampleEntry, audioOnly, 0, 0)
 }
@@ -173,7 +175,7 @@ func buildRemuxArgsWithAudioV3(filePath, outputFormat string, seekSeconds float6
 	args = append(args, "-sn", "-dn")
 
 	if dvProfile == 7 {
-		args = append(args, "-bsf:v", "dovi_rpu=strip=1")
+		args = append(args, "-bsf:v", DV7ToHDR10BitstreamFilter)
 		if tagSampleEntry {
 			// The explicit v3 strip recipe promised the client plain HDR10.
 			// Safari's media element only answers "probably" for hvc1 — the
@@ -255,23 +257,23 @@ func startRemuxWithOptions(ctx context.Context, filePath, outputFormat string, s
 	tagSampleEntry := false
 	switch mode {
 	case "", RemuxDVLegacyAutoV3:
-		effectiveProfile = remuxDVProfile(dvProfile, supportsDoviRPUFilter(bin) &&
+		effectiveProfile = remuxDVProfile(dvProfile, supportsDV7HDR10FilterChain(bin) &&
 			(dvProfile != 7 || sharedDVRPUProbe.CanStrip(ctx, bin, filePath)))
 	case RemuxDVStripToHDR10V3:
 		if dvProfile != 7 && dvProfile != 8 {
 			cancel()
 			return nil, fmt.Errorf("Dolby Vision HDR10 strip requires profile 7 or 8")
 		}
-		if !supportsDoviRPUFilter(bin) {
+		if !supportsDV7HDR10FilterChain(bin) {
 			cancel()
-			return nil, fmt.Errorf("Dolby Vision HDR10 remux requires the dovi_rpu bitstream filter")
+			return nil, fmt.Errorf("dolby vision HDR10 remux requires the dovi_rpu and filter_units bitstream filters")
 		}
 		// The planner refuses this recipe for a source that fails the probe,
 		// so reaching here means a session or stream token minted before the
-		// verdict was known. Fail definitively: copying the base layer without
-		// the strip would leave dangling RPUs (the decoder stall this recipe
-		// exists to prevent) while still claiming HDR10, and attempting the
-		// strip anyway is the per-packet rejection that hangs the session. The
+		// verdict was known. Fail definitively: an unfiltered copy would retain
+		// Dolby Vision metadata and enhancement-layer NAL units while still
+		// claiming HDR10, and attempting the strip anyway is the per-packet
+		// rejection that hangs the session. The
 		// next start re-plans against the now-cached verdict.
 		if !sharedDVRPUProbe.CanStrip(ctx, bin, filePath) {
 			cancel()
@@ -286,9 +288,9 @@ func startRemuxWithOptions(ctx context.Context, filePath, outputFormat string, s
 		tagSampleEntry = true
 	case RemuxDVPreserveV3:
 		if dvProfile == 7 {
-			// The remux maps only the base-layer stream, so dual-layer P7
-			// cannot be preserved: the EL is dropped and its RPUs would
-			// dangle. Callers must strip to HDR10 or transcode instead.
+			// Profile 7 preservation is not a validated remux recipe for this
+			// delivery. Callers must use the original bytes, strip to HDR10, or
+			// transcode instead.
 			cancel()
 			return nil, fmt.Errorf("Dolby Vision profile 7 cannot be preserved in a progressive remux")
 		}
@@ -359,6 +361,9 @@ type RemuxServeOptions struct {
 	// DVMode is the explicitly declared Dolby Vision recipe. The zero value
 	// decodes as the legacy auto behavior, matching old stream tokens.
 	DVMode RemuxDVMode
+	// DVRecipeVersion pins byte-level strip behavior across reconstruction and
+	// rolling upgrades. It is required whenever DVMode is strip_to_hdr10.
+	DVRecipeVersion string
 	// FFmpegPath selects the binary to execute (empty = global discovery).
 	FFmpegPath string
 	// ContentType overrides the container-derived response type. Audio-only
@@ -392,13 +397,22 @@ func ServeRemux(w http.ResponseWriter, r *http.Request, filePath, outputFormat s
 // ServeRemuxWithDVMode streams an explicitly declared Dolby Vision recipe.
 // ffmpegPath selects the binary to execute (empty = process-global discovery).
 func ServeRemuxWithDVMode(w http.ResponseWriter, r *http.Request, filePath, outputFormat string, seekSeconds float64, transcodeAudio bool, audioTrackIndex int, dvProfile int, mode RemuxDVMode, ffmpegPath string) error {
-	return ServeRemuxWithOptions(w, r, filePath, outputFormat, seekSeconds, transcodeAudio, audioTrackIndex, dvProfile, RemuxServeOptions{DVMode: mode, FFmpegPath: ffmpegPath})
+	version := ""
+	if mode == RemuxDVStripToHDR10V3 {
+		version = TransformationServerDV7HDR10RecipeVersionV3
+	}
+	return ServeRemuxWithOptions(w, r, filePath, outputFormat, seekSeconds, transcodeAudio, audioTrackIndex, dvProfile, RemuxServeOptions{DVMode: mode, DVRecipeVersion: version, FFmpegPath: ffmpegPath})
 }
 
 // ServeRemuxWithOptions is the full remux transport, taking its optional
 // serving concerns as a struct.
 func ServeRemuxWithOptions(w http.ResponseWriter, r *http.Request, filePath, outputFormat string, seekSeconds float64, transcodeAudio bool, audioTrackIndex int, dvProfile int, opts RemuxServeOptions) error {
 	mode, ffmpegPath := opts.DVMode, opts.FFmpegPath
+	if mode == RemuxDVStripToHDR10V3 && opts.DVRecipeVersion != TransformationServerDV7HDR10RecipeVersionV3 {
+		err := fmt.Errorf("unsupported Dolby Vision HDR10 remux recipe version %q", opts.DVRecipeVersion)
+		http.Error(w, "stale remux recipe", http.StatusConflict)
+		return err
+	}
 	// Remux output streams for the length of the title; roll the write
 	// deadline with progress instead of the server's absolute WriteTimeout.
 	w = httpstream.NewRollingDeadlineWriter(w)

--- a/internal/playback/remux.go
+++ b/internal/playback/remux.go
@@ -63,7 +63,11 @@ func supportsDV7HDR10FilterChain(bin string) bool {
 	probeCtx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
 	defer cancel()
 	out, err := exec.CommandContext(probeCtx, bin, "-hide_banner", "-bsfs").Output()
-	available := err == nil && hasDV7HDR10FilterChain(out)
+	if err != nil {
+		slog.Warn("failed to probe ffmpeg dovi_rpu/filter_units bitstream filters; validated Profile 7 HDR10 remux is disabled for this request", "ffmpeg", bin, "error", err)
+		return false
+	}
+	available := hasDV7HDR10FilterChain(out)
 	if !available {
 		slog.Warn("ffmpeg lacks the dovi_rpu/filter_units bitstream filters; validated Profile 7 HDR10 remux is disabled", "ffmpeg", bin)
 	}

--- a/internal/playback/remux_dv_test.go
+++ b/internal/playback/remux_dv_test.go
@@ -99,6 +99,12 @@ func TestSupportsDV7HDR10FilterChainTimesOut(t *testing.T) {
 	if elapsed := time.Since(started); elapsed > 5*time.Second {
 		t.Fatalf("FFmpeg capability probe took %v, want a bounded timeout", elapsed)
 	}
+	if err := os.WriteFile(bin, []byte("#!/bin/sh\necho dovi_rpu\necho filter_units\n"), 0o755); err != nil {
+		t.Fatalf("replace fake ffmpeg: %v", err)
+	}
+	if !supportsDV7HDR10FilterChain(bin) {
+		t.Fatal("an inconclusive timeout was cached instead of re-probing FFmpeg")
+	}
 }
 
 // Profile 8 base layers are self-contained: the RPU stays valid without an

--- a/internal/playback/remux_dv_test.go
+++ b/internal/playback/remux_dv_test.go
@@ -3,10 +3,13 @@ package playback
 import (
 	"context"
 	"io"
+	"net/http"
+	"net/http/httptest"
 	"os"
 	"path/filepath"
 	"strings"
 	"testing"
+	"time"
 )
 
 func argsContainPair(args []string, a, b string) bool {
@@ -18,14 +21,17 @@ func argsContainPair(args []string, a, b string) bool {
 	return false
 }
 
-// Profile 7 remuxes drop the enhancement-layer track (-map 0:v:0 keeps only
-// the base layer), which leaves dangling dual-layer RPU metadata on the BL.
-// Stripping the RPUs yields a clean HDR10 stream — both a correctness fix and
-// the Apple-parity fallback presentation for devices without a P7 decoder.
-func TestBuildRemuxArgsStripsDolbyVisionRPUForProfile7(t *testing.T) {
+// Profile 7 remuxes must remove both the DV metadata and the enhancement-layer
+// NAL units interleaved in the same video track. The result is a clean HDR10
+// base layer for devices without a P7 decoder.
+func TestBuildRemuxArgsIsolatesProfile7HDR10BaseLayer(t *testing.T) {
+	const wantFilter = "dovi_rpu=strip=1,filter_units=remove_types=63"
+	if DV7ToHDR10BitstreamFilter != wantFilter {
+		t.Fatalf("DV7 HDR10 filter = %q, want %q", DV7ToHDR10BitstreamFilter, wantFilter)
+	}
 	args := buildRemuxArgs("/x.mkv", "mp4", 0, false, -1, 7, false, false)
-	if !argsContainPair(args, "-bsf:v", "dovi_rpu=strip=1") {
-		t.Fatalf("profile 7 remux must strip DV RPUs from the base layer, args=%v", strings.Join(args, " "))
+	if !argsContainPair(args, "-bsf:v", wantFilter) {
+		t.Fatalf("profile 7 remux must isolate the HDR10 base layer, args=%v", strings.Join(args, " "))
 	}
 }
 
@@ -51,10 +57,10 @@ func TestBuildRemuxArgsRequiresVideoForVideoPlans(t *testing.T) {
 	}
 }
 
-// An ffmpeg without the dovi_rpu bitstream filter (pre-7.1) would abort on
-// the unknown filter before producing any output. The profile must be
-// neutralized so the remux still starts, keeping the pre-strip behavior.
-func TestRemuxDVProfileFallsBackWithoutFilterSupport(t *testing.T) {
+// An ffmpeg without either required bitstream filter would abort before
+// producing output. The profile must be neutralized so the remux still starts,
+// keeping the pre-strip behavior.
+func TestRemuxDVProfileFallsBackWithoutDV7FilterChainSupport(t *testing.T) {
 	if got := remuxDVProfile(7, false); got != 0 {
 		t.Errorf("remuxDVProfile(7, false) = %d, want 0 (no strip without filter support)", got)
 	}
@@ -70,12 +76,37 @@ func TestRemuxDVProfileFallsBackWithoutFilterSupport(t *testing.T) {
 	}
 }
 
+func TestSupportsDV7HDR10FilterChainRequiresBothBitstreamFilters(t *testing.T) {
+	bin := filepath.Join(t.TempDir(), "ffmpeg")
+	script := "#!/bin/sh\nif [ \"$2\" = \"-bsfs\" ]; then echo dovi_rpu; fi\n"
+	if err := os.WriteFile(bin, []byte(script), 0o755); err != nil {
+		t.Fatalf("write fake ffmpeg: %v", err)
+	}
+	if supportsDV7HDR10FilterChain(bin) {
+		t.Fatal("Profile 7 HDR10 fallback was advertised without filter_units")
+	}
+}
+
+func TestSupportsDV7HDR10FilterChainTimesOut(t *testing.T) {
+	bin := filepath.Join(t.TempDir(), "ffmpeg")
+	if err := os.WriteFile(bin, []byte("#!/bin/sh\nexec sleep 30\n"), 0o755); err != nil {
+		t.Fatalf("write fake ffmpeg: %v", err)
+	}
+	started := time.Now()
+	if supportsDV7HDR10FilterChain(bin) {
+		t.Fatal("stalled FFmpeg capability probe reported filter support")
+	}
+	if elapsed := time.Since(started); elapsed > 5*time.Second {
+		t.Fatalf("FFmpeg capability probe took %v, want a bounded timeout", elapsed)
+	}
+}
+
 // Profile 8 base layers are self-contained: the RPU stays valid without an
 // enhancement layer and DV-capable clients can render it. Never strip.
 func TestBuildRemuxArgsKeepsRPUForProfile8AndPlainFiles(t *testing.T) {
 	for _, profile := range []int{0, 5, 8} {
 		args := buildRemuxArgs("/x.mkv", "mp4", 0, false, -1, profile, false, false)
-		if argsContainPair(args, "-bsf:v", "dovi_rpu=strip=1") {
+		if argsContainPair(args, "-bsf:v", DV7ToHDR10BitstreamFilter) {
 			t.Fatalf("profile %d remux must not strip DV RPUs, args=%v", profile, strings.Join(args, " "))
 		}
 	}
@@ -108,7 +139,7 @@ func TestBuildRemuxArgsTagsPreservedDolbyVisionOnlyWhenRequested(t *testing.T) {
 // so neither needs the -strict relaxation.
 func TestBuildRemuxArgsTagsStrippedHDR10OnlyWhenRequested(t *testing.T) {
 	tagged := buildRemuxArgs("/x.mkv", "mp4", 0, false, -1, 7, true, false)
-	if !argsContainPair(tagged, "-bsf:v", "dovi_rpu=strip=1") || !argsContainPair(tagged, "-tag:v", "hvc1") {
+	if !argsContainPair(tagged, "-bsf:v", DV7ToHDR10BitstreamFilter) || !argsContainPair(tagged, "-tag:v", "hvc1") {
 		t.Fatalf("explicit strip must emit an hvc1-labeled HDR10 stream, args=%v", strings.Join(tagged, " "))
 	}
 	if argsContainPair(tagged, "-tag:v", "dvh1") || argsContainPair(tagged, "-strict", "unofficial") {
@@ -120,9 +151,8 @@ func TestBuildRemuxArgsTagsStrippedHDR10OnlyWhenRequested(t *testing.T) {
 	}
 }
 
-// Dual-layer Profile 7 cannot be preserved by a base-layer-only remux; the
-// explicit preserve recipe must fail fast instead of emitting a stream with
-// dangling RPUs and no enhancement layer.
+// Profile 7 preservation is not a validated remux recipe. The explicit
+// preserve mode must fail fast instead of emitting unpromised bytes.
 func TestStartRemuxRejectsPreservedProfile7(t *testing.T) {
 	if _, err := StartRemuxWithDVMode(t.Context(), "/nonexistent.mkv", "mp4", 0, false, -1, 7, RemuxDVPreserveV3, ""); err == nil {
 		t.Fatal("preserve mode accepted a profile 7 source")
@@ -135,6 +165,38 @@ func TestStartRemuxRejectsUnknownModeForAllProfiles(t *testing.T) {
 		if _, err := StartRemuxWithDVMode(t.Context(), "/nonexistent.mkv", "mp4", 0, false, -1, profile, RemuxDVMode("bogus"), ""); err == nil {
 			t.Fatalf("unknown remux DV mode accepted for profile %d", profile)
 		}
+	}
+}
+
+func TestServeRemuxPinsDV7RecipeVersion(t *testing.T) {
+	tests := []struct {
+		name       string
+		version    string
+		wantStatus int
+		wantStale  bool
+	}{
+		{name: "missing recipe", version: "", wantStatus: http.StatusConflict, wantStale: true},
+		{name: "stale recipe", version: "1", wantStatus: http.StatusConflict, wantStale: true},
+		{name: "current recipe", version: TransformationServerDV7HDR10RecipeVersionV3, wantStatus: http.StatusNotFound},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			recorder := httptest.NewRecorder()
+			request := httptest.NewRequest(http.MethodGet, "/stream/remux", nil)
+			err := ServeRemuxWithOptions(recorder, request, "/missing-dv7.mkv", "mp4", 0, false, -1, 7, RemuxServeOptions{
+				DVMode:          RemuxDVStripToHDR10V3,
+				DVRecipeVersion: tt.version,
+			})
+			if err == nil {
+				t.Fatal("expected remux error")
+			}
+			if stale := strings.Contains(err.Error(), "unsupported Dolby Vision HDR10 remux recipe version"); stale != tt.wantStale {
+				t.Fatalf("stale recipe error = %v, want %v (error=%v)", stale, tt.wantStale, err)
+			}
+			if recorder.Code != tt.wantStatus {
+				t.Fatalf("status = %d, want %d", recorder.Code, tt.wantStatus)
+			}
+		})
 	}
 }
 
@@ -156,7 +218,7 @@ func writeProbeAwareFFmpeg(t *testing.T) (bin, argLog string) {
 	argLog = filepath.Join(dir, "args")
 	script := "#!/bin/sh\n" +
 		"case \"$*\" in\n" +
-		"  *-bsfs*) echo dovi_rpu; exit 0;;\n" +
+		"  *-bsfs*) echo dovi_rpu; echo filter_units; exit 0;;\n" +
 		"  *'-f null'*) echo '[dovi_rpu @ 0x55] Failed to read unit 1 (type 39).' >&2; exit 0;;\n" +
 		"esac\n" +
 		"echo \"$*\" >> " + argLog + "\n" +
@@ -177,7 +239,7 @@ func writeRecordingFFmpeg(t *testing.T) (bin, argLog string) {
 	argLog = filepath.Join(dir, "args")
 	script := "#!/bin/sh\n" +
 		"case \"$*\" in\n" +
-		"  *-bsfs*) echo dovi_rpu; exit 0;;\n" +
+		"  *-bsfs*) echo dovi_rpu; echo filter_units; exit 0;;\n" +
 		"  *'-f null'*) exit 0;;\n" +
 		"esac\n" +
 		"echo \"$*\" >> " + argLog + "\n" +
@@ -224,8 +286,8 @@ func TestExplicitStripModeTagsHVC1(t *testing.T) {
 			t.Fatalf("strip remux refused profile %d: %v", profile, err)
 		}
 		recorded := recordedRemuxArgs(t, session, argLog)
-		if !strings.Contains(recorded, "dovi_rpu=strip=1") || !strings.Contains(recorded, "-tag:v hvc1") {
-			t.Fatalf("explicit strip must map to dovi_rpu + hvc1 for profile %d: %s", profile, recorded)
+		if !strings.Contains(recorded, DV7ToHDR10BitstreamFilter) || !strings.Contains(recorded, "-tag:v hvc1") {
+			t.Fatalf("explicit strip must map to the base-layer filter + hvc1 for profile %d: %s", profile, recorded)
 		}
 		if strings.Contains(recorded, "dvh1") || strings.Contains(recorded, "-strict unofficial") {
 			t.Fatalf("stripped output must not carry DV signaling for profile %d: %s", profile, recorded)
@@ -245,7 +307,7 @@ func remuxSourceFile(t *testing.T) string {
 // The legacy/auto mode derives the strip from the profile alone, with no plan
 // to consult — the web player, jellycompat and pre-v3 stream tokens all arrive
 // here. An unparseable RPU has to neutralize the profile the same way a missing
-// dovi_rpu filter does, or the filter rejects every packet and the response
+// DV7 filter chain does, or the filter rejects every packet and the response
 // never produces a byte.
 func TestLegacyRemuxDropsTheStripForAnUnstrippableSource(t *testing.T) {
 	bin, argLog := writeProbeAwareFFmpeg(t)

--- a/internal/playback/session.go
+++ b/internal/playback/session.go
@@ -25,6 +25,7 @@ type Session struct {
 	BasePlayMethod       PlayMethod
 	TranscodeAudio       bool // when true, remux should transcode audio to AAC
 	RemuxDVMode          RemuxDVMode
+	RemuxDVRecipeVersion string
 	ClientIP             string // resolved client IP for the playback session
 	ClientName           string // reported playback client name, when available
 	ClientVersion        string // reported playback client version, when available
@@ -81,6 +82,7 @@ type SessionStreamState struct {
 	AudioTrackIndex        int
 	TranscodeAudio         bool
 	RemuxDVMode            RemuxDVMode
+	RemuxDVRecipeVersion   string
 	ClientIP               string
 	ClientName             string
 	ClientVersion          string
@@ -871,8 +873,12 @@ func applySessionStreamStateLocked(s *Session, state SessionStreamState) {
 		// later remux request fails the profile check. Legacy partial updates
 		// never carry a mode and must not clobber one.
 		s.RemuxDVMode = state.RemuxDVMode
+		s.RemuxDVRecipeVersion = state.RemuxDVRecipeVersion
 	} else if state.RemuxDVMode != "" {
 		s.RemuxDVMode = state.RemuxDVMode
+		if state.RemuxDVRecipeVersion != "" {
+			s.RemuxDVRecipeVersion = state.RemuxDVRecipeVersion
+		}
 	}
 	s.ClientIP = state.ClientIP
 	if value := normalizeClientMetadataValue(state.ClientName, 128); value != "" {
@@ -914,6 +920,7 @@ func snapshotSessionStreamStateLocked(s *Session) SessionStreamState {
 		AudioTrackIndex:        s.AudioTrackIndex,
 		TranscodeAudio:         s.TranscodeAudio,
 		RemuxDVMode:            s.RemuxDVMode,
+		RemuxDVRecipeVersion:   s.RemuxDVRecipeVersion,
 		ClientIP:               s.ClientIP,
 		ClientName:             s.ClientName,
 		ClientVersion:          s.ClientVersion,
@@ -941,6 +948,7 @@ func restoreSessionStreamStateLocked(s *Session, state SessionStreamState) {
 	s.AudioTrackIndex = state.AudioTrackIndex
 	s.TranscodeAudio = state.TranscodeAudio
 	s.RemuxDVMode = state.RemuxDVMode
+	s.RemuxDVRecipeVersion = state.RemuxDVRecipeVersion
 	s.ClientIP = state.ClientIP
 	s.ClientName = state.ClientName
 	s.ClientVersion = state.ClientVersion

--- a/internal/playback/session_test.go
+++ b/internal/playback/session_test.go
@@ -1390,9 +1390,9 @@ func TestLegacyStreamUpdateKeepsReplacementReservation(t *testing.T) {
 	}
 }
 
-// A full v3 route description owns RemuxDVMode: a replan that lands on a
-// non-DV source must clear a stale strip mode, while legacy partial updates
-// must not clobber one.
+// A full v3 route description owns the complete remux DV recipe: a replan that
+// lands on a non-DV source must clear stale mode and version state, while legacy
+// partial updates must not clobber either.
 func TestUpdateStreamStateClearsRemuxDVModeOnRouteSet(t *testing.T) {
 	sm := playback.NewSessionManager(5, 2)
 
@@ -1400,7 +1400,7 @@ func TestUpdateStreamStateClearsRemuxDVModeOnRouteSet(t *testing.T) {
 	if err != nil {
 		t.Fatalf("StartSession: %v", err)
 	}
-	if err := sm.UpdateStreamState(session.ID, playback.SessionStreamState{RemuxDVMode: playback.RemuxDVStripToHDR10V3, TranscodeRouteSet: true}); err != nil {
+	if err := sm.UpdateStreamState(session.ID, playback.SessionStreamState{RemuxDVMode: playback.RemuxDVStripToHDR10V3, RemuxDVRecipeVersion: playback.TransformationServerDV7HDR10RecipeVersionV3, TranscodeRouteSet: true}); err != nil {
 		t.Fatalf("UpdateStreamState(set): %v", err)
 	}
 
@@ -1415,6 +1415,19 @@ func TestUpdateStreamStateClearsRemuxDVModeOnRouteSet(t *testing.T) {
 	if got.RemuxDVMode != playback.RemuxDVStripToHDR10V3 {
 		t.Fatalf("RemuxDVMode after legacy update = %q, want strip_to_hdr10", got.RemuxDVMode)
 	}
+	if got.RemuxDVRecipeVersion != playback.TransformationServerDV7HDR10RecipeVersionV3 {
+		t.Fatalf("RemuxDVRecipeVersion after legacy update = %q, want %q", got.RemuxDVRecipeVersion, playback.TransformationServerDV7HDR10RecipeVersionV3)
+	}
+	if err := sm.UpdateStreamState(session.ID, playback.SessionStreamState{RemuxDVMode: playback.RemuxDVStripToHDR10V3}); err != nil {
+		t.Fatalf("UpdateStreamState(partial DV mode): %v", err)
+	}
+	got, err = sm.GetSession(session.ID)
+	if err != nil {
+		t.Fatalf("GetSession after partial DV mode update: %v", err)
+	}
+	if got.RemuxDVRecipeVersion != playback.TransformationServerDV7HDR10RecipeVersionV3 {
+		t.Fatalf("RemuxDVRecipeVersion after partial DV mode update = %q, want %q", got.RemuxDVRecipeVersion, playback.TransformationServerDV7HDR10RecipeVersionV3)
+	}
 
 	// v3 route-set update for a non-DV source: mode clears.
 	if err := sm.UpdateStreamState(session.ID, playback.SessionStreamState{TranscodeRouteSet: true}); err != nil {
@@ -1426,5 +1439,8 @@ func TestUpdateStreamStateClearsRemuxDVModeOnRouteSet(t *testing.T) {
 	}
 	if got.RemuxDVMode != "" {
 		t.Fatalf("RemuxDVMode after route-set update = %q, want cleared", got.RemuxDVMode)
+	}
+	if got.RemuxDVRecipeVersion != "" {
+		t.Fatalf("RemuxDVRecipeVersion after route-set update = %q, want cleared", got.RemuxDVRecipeVersion)
 	}
 }

--- a/internal/playback/testdata/protocol_v3/capability_response.json
+++ b/internal/playback/testdata/protocol_v3/capability_response.json
@@ -32,7 +32,7 @@
     {
       "name": "server_dv7_to_hdr10",
       "executor": "server",
-      "recipe_version": "1",
+      "recipe_version": "2",
       "validated_claims": [
         "dolby_vision_metadata_removed",
         "hdr10_base_layer_preserved",

--- a/internal/playback/testdata/protocol_v3/conformance_matrix.json
+++ b/internal/playback/testdata/protocol_v3/conformance_matrix.json
@@ -2397,8 +2397,8 @@
         "outcome": "playable",
         "delivery": "server_remux_progressive",
         "decision_reason": "container_normalization",
-        "plan_id": "plan:e88fbdcf1a40478d50f19e6a1c9d2e41",
-        "plan_attempt_key": "v3:e3784d73c47008f0",
+        "plan_id": "plan:b0fabdf793bdfddfe228437da393616f",
+        "plan_attempt_key": "v3:11afdf62d282fb34",
         "selected_tracks": {
           "audio": {
             "id": "file:42:audio:0",
@@ -2432,7 +2432,7 @@
           {
             "name": "server_dv7_to_hdr10",
             "executor": "server",
-            "recipe_version": "1",
+            "recipe_version": "2",
             "validated_claims": [
               "dolby_vision_metadata_removed",
               "hdr10_base_layer_preserved",

--- a/internal/playback/transcode.go
+++ b/internal/playback/transcode.go
@@ -43,7 +43,7 @@ type TranscodeOpts struct {
 	SourceVideoCodec     string
 	SourceVideoProfile   string
 	SourceVideoBitDepth  int
-	VideoBitstreamFilter string // validated copy-mode BSF, e.g. dovi_rpu=strip=1
+	VideoBitstreamFilter string // validated copy-mode BSF selected by a server transformation
 	SeekSeconds          float64
 	// StreamOriginSeconds is the keyframe timestamp at which a copy-video
 	// stream actually begins. SeekSeconds remains the client-requested -ss so
@@ -94,9 +94,11 @@ type TranscodeOpts struct {
 	FFmpegLogSink          FFmpegLogSink
 }
 
-// DV7ToHDR10BitstreamFilter strips Dolby Vision RPU metadata during a
-// copy-mode HLS remux; the enhancement layer is dropped by stream mapping.
-const DV7ToHDR10BitstreamFilter = "dovi_rpu=strip=1"
+// DV7ToHDR10BitstreamFilter turns a single-track, dual-layer Profile 7 stream
+// into its plain HDR10 base layer during a copy-mode remux. dovi_rpu removes
+// the Dolby Vision configuration/RPUs; filter_units removes the interleaved
+// UNSPEC63 enhancement-layer NAL units that stream mapping cannot separate.
+const DV7ToHDR10BitstreamFilter = "dovi_rpu=strip=1,filter_units=remove_types=63"
 
 const (
 	transcodeCodecH264 = "h264"

--- a/internal/playback/transcode_args_test.go
+++ b/internal/playback/transcode_args_test.go
@@ -141,19 +141,20 @@ func TestBuildFFmpegArgs_CopyVideoFromStartUsesZeroBasedTimestamps(t *testing.T)
 	}
 }
 
-func TestBuildFFmpegArgs_CopyVideoAppliesValidatedBitstreamFilter(t *testing.T) {
+func TestBuildFFmpegArgs_CopyVideoAppliesValidatedDV7FilterChain(t *testing.T) {
+	const wantFilter = "dovi_rpu=strip=1,filter_units=remove_types=63"
 	args := buildFFmpegArgs(TranscodeOpts{
 		InputPath:            "/media/movie.mkv",
 		OutputDir:            "/tmp/out",
 		SessionID:            "session-dv7",
 		TargetCodecVideo:     "copy",
 		TargetCodecAudio:     "copy",
-		VideoBitstreamFilter: DV7ToHDR10BitstreamFilter,
+		VideoBitstreamFilter: wantFilter,
 		SegmentDuration:      2,
 	})
 
 	joined := strings.Join(args, " ")
-	if !strings.Contains(joined, "-c:v copy -bsf:v dovi_rpu=strip=1") {
+	if !strings.Contains(joined, "-c:v copy -bsf:v "+wantFilter) {
 		t.Fatalf("copy-video args should apply the validated DV bitstream filter: %s", joined)
 	}
 }

--- a/internal/playback/transcode_manager.go
+++ b/internal/playback/transcode_manager.go
@@ -417,6 +417,7 @@ func (m *TranscodeManager) ReconstructSession(ctx context.Context, sessionID str
 		AudioTrackIndex:        card.AudioTrackIndex,
 		TranscodeAudio:         card.TranscodeAudio,
 		RemuxDVMode:            card.RemuxDVMode,
+		RemuxDVRecipeVersion:   card.RemuxDVRecipeVersion,
 		TargetResolution:       card.TargetResolution,
 		TargetVideoCodec:       card.TargetCodecVideo,
 		TargetAudioCodec:       card.TargetCodecAudio,

--- a/internal/playback/transcode_manager_test.go
+++ b/internal/playback/transcode_manager_test.go
@@ -121,11 +121,13 @@ func TestLoadOrReconstructSession(t *testing.T) {
 		reg := &fakeSessionRegistry{}
 		m := newMgr(reg)
 		card := NewRemuxRecipeCard("s", 5, "p", 77, true, 2)
+		card.RemuxDVMode = RemuxDVStripToHDR10V3
+		card.RemuxDVRecipeVersion = TransformationServerDV7HDR10RecipeVersionV3
 		got, status := m.LoadOrReconstructSession(ctx, reg.GetSession, "s", 5, cardPtr(card))
 		if status != SessionLoaded || got == nil {
 			t.Fatalf("status=%v session=%+v", status, got)
 		}
-		if got.PlayMethod != PlayRemux || got.MediaFileID != 77 || !got.TranscodeAudio || got.AudioTrackIndex != 2 {
+		if got.PlayMethod != PlayRemux || got.MediaFileID != 77 || !got.TranscodeAudio || got.AudioTrackIndex != 2 || got.RemuxDVMode != RemuxDVStripToHDR10V3 || got.RemuxDVRecipeVersion != TransformationServerDV7HDR10RecipeVersionV3 {
 			t.Fatalf("reconstructed remux session wrong: %+v", got)
 		}
 		if _, err := reg.GetSession("s"); err != nil {

--- a/internal/playback/transformations_v3.go
+++ b/internal/playback/transformations_v3.go
@@ -35,10 +35,14 @@ func ProbeTransformationRegistryV3(ctx context.Context, ffmpegPath string) *Tran
 	cancelEncoders()
 	_, ffmpegErr := exec.LookPath(ffmpegPath)
 	return NewTransformationRegistryV3([]TransformationSpecV3{
-		{Name: TransformationServerDV7HDR10V3, RecipeVersion: "1", Available: bytes.Contains(bsfs, []byte("dovi_rpu")), RequiredCapability: "ffmpeg_bsf:dovi_rpu", PromisedDynamicRange: DynamicRangeHDR10V3, ValidatedClaims: DV7ToHDR10ClaimsV3(), TerminalReason: TerminalDVConversionUnsupportedV3},
+		{Name: TransformationServerDV7HDR10V3, RecipeVersion: TransformationServerDV7HDR10RecipeVersionV3, Available: hasDV7HDR10FilterChain(bsfs), RequiredCapability: "ffmpeg_bsf:dovi_rpu+filter_units", PromisedDynamicRange: DynamicRangeHDR10V3, ValidatedClaims: DV7ToHDR10ClaimsV3(), TerminalReason: TerminalDVConversionUnsupportedV3},
 		{Name: TransformationAudioToAACV3, RecipeVersion: "1", Available: ffmpegErr == nil && bytes.Contains(encoders, []byte(" aac ")), RequiredCapability: "ffmpeg_encoder:aac", ValidatedClaims: []string{ClaimAudioDecodeV3}, TerminalReason: TerminalAudioConversionUnsupportedV3},
 		{Name: TransformationVideoToH264V3, RecipeVersion: TransformationVideoToH264RecipeVersionV3, Available: ffmpegErr == nil && h264EncoderAvailableV3(encoders), RequiredCapability: "ffmpeg_encoder:h264", PromisedDynamicRange: DynamicRangeSDRV3, ValidatedClaims: []string{ClaimH264DecodeV3}, TerminalReason: TerminalVideoConversionUnsupportedV3},
 	})
+}
+
+func hasDV7HDR10FilterChain(bsfs []byte) bool {
+	return bytes.Contains(bsfs, []byte("dovi_rpu")) && bytes.Contains(bsfs, []byte("filter_units"))
 }
 
 // h264EncodersV3 lists every H.264 encoder the transcode pipeline can select

--- a/internal/playback/transformations_v3_test.go
+++ b/internal/playback/transformations_v3_test.go
@@ -32,7 +32,7 @@ func TestH264EncoderAvailabilityAcceptsAnyPipelineEncoder(t *testing.T) {
 
 func TestProbeTransformationRegistryV3AdvertisesVideoToH264RecipeVersion2(t *testing.T) {
 	ffmpeg := filepath.Join(t.TempDir(), "ffmpeg")
-	script := "#!/bin/sh\ncase \"$2\" in\n-bsfs) echo dovi_rpu ;;\n-encoders) echo ' V....D libx264 H.264'; echo ' A....D aac AAC' ;;\nesac\n"
+	script := "#!/bin/sh\ncase \"$2\" in\n-bsfs) echo dovi_rpu; echo filter_units ;;\n-encoders) echo ' V....D libx264 H.264'; echo ' A....D aac AAC' ;;\nesac\n"
 	if err := os.WriteFile(ffmpeg, []byte(script), 0o755); err != nil {
 		t.Fatal(err)
 	}
@@ -47,4 +47,61 @@ func TestProbeTransformationRegistryV3AdvertisesVideoToH264RecipeVersion2(t *tes
 		}
 	}
 	t.Fatal("video_to_h264 was not advertised")
+}
+
+func TestProbeTransformationRegistryV3RequiresBothDV7BaseLayerFilters(t *testing.T) {
+	tests := []struct {
+		name    string
+		listing string
+		want    bool
+	}{
+		{name: "metadata strip alone", listing: "dovi_rpu", want: false},
+		{name: "unit filter alone", listing: "filter_units", want: false},
+		{name: "complete base layer recipe", listing: "dovi_rpu\\nfilter_units", want: true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ffmpeg := filepath.Join(t.TempDir(), "ffmpeg")
+			script := "#!/bin/sh\nif [ \"$2\" = \"-bsfs\" ]; then printf \"" + tt.listing + "\\n\"; fi\n"
+			if err := os.WriteFile(ffmpeg, []byte(script), 0o755); err != nil {
+				t.Fatal(err)
+			}
+
+			registry := ProbeTransformationRegistryV3(context.Background(), ffmpeg)
+			if got := registry.Available(TransformationServerDV7HDR10V3); got != tt.want {
+				t.Fatalf("server_dv7_to_hdr10 available = %v, want %v", got, tt.want)
+			}
+			if !tt.want {
+				return
+			}
+			for _, transformation := range registry.Advertised() {
+				if transformation.Name == TransformationServerDV7HDR10V3 {
+					if transformation.RecipeVersion != TransformationServerDV7HDR10RecipeVersionV3 {
+						t.Fatalf("server_dv7_to_hdr10 recipe version = %q, want %q", transformation.RecipeVersion, TransformationServerDV7HDR10RecipeVersionV3)
+					}
+					return
+				}
+			}
+			t.Fatal("server_dv7_to_hdr10 was not advertised")
+		})
+	}
+}
+
+func TestHasDV7HDR10FilterChainRequiresBothFilters(t *testing.T) {
+	tests := []struct {
+		name    string
+		listing string
+		want    bool
+	}{
+		{name: "metadata strip alone", listing: "dovi_rpu", want: false},
+		{name: "unit filter alone", listing: "filter_units", want: false},
+		{name: "complete chain", listing: "dovi_rpu\nfilter_units", want: true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := hasDV7HDR10FilterChain([]byte(tt.listing)); got != tt.want {
+				t.Fatalf("hasDV7HDR10FilterChain() = %v, want %v", got, tt.want)
+			}
+		})
+	}
 }

--- a/internal/proxy/server.go
+++ b/internal/proxy/server.go
@@ -147,10 +147,11 @@ func (s *Server) Handler() http.Handler {
 // the same shape and at the same path as a transcode node.
 //
 // A proxy executes recipes too: /stream/remux runs ffmpeg to convert audio or
-// strip a Dolby Vision RPU. Without this endpoint the API has no way to tell
-// whether the proxy it just picked can run the transformations a plan froze, so
-// a pool whose proxies carry a different ffmpeg build (a rolling upgrade, a
-// custom image) would fail at stream time rather than at selection time.
+// isolate a Dolby Vision Profile 7 HDR10 base layer. Without this endpoint the
+// API has no way to tell whether the proxy it just picked can run the
+// transformations a plan froze, so a pool whose proxies carry a different
+// ffmpeg build (a rolling upgrade, a custom image) would fail at stream time
+// rather than at selection time.
 func (s *Server) handleHWCapabilities(w http.ResponseWriter, r *http.Request) {
 	ffmpegPath := ""
 	if cfg := s.watcher.Config(); cfg != nil {
@@ -367,6 +368,7 @@ func (s *Server) handleRemux(w http.ResponseWriter, r *http.Request) {
 	// server's stream handler serves the same claims.
 	_ = playback.ServeRemuxWithOptions(w, r, claims.MediaPath, "mp4", seekSeconds, claims.TranscodeAudio, claims.AudioTrackIndex, claims.DVProfile, playback.RemuxServeOptions{
 		DVMode:                 playback.RemuxDVMode(claims.RemuxDVMode),
+		DVRecipeVersion:        claims.RemuxDVRecipeVersion,
 		FFmpegPath:             s.watcher.Config().Playback.FFmpegPath,
 		ContentType:            playback.RemuxContentType(claims.AudioOnly),
 		AudioOnly:              claims.AudioOnly,

--- a/internal/streamtoken/token.go
+++ b/internal/streamtoken/token.go
@@ -36,13 +36,18 @@ type Claims struct {
 	AudioChannels        int    `json:"ach,omitempty"`
 	AudioTrackIndex      int    `json:"ati,omitempty"`
 	AudioOnly            bool   `json:"ao,omitempty"`
-	// DVProfile is the file's Dolby Vision profile (0 = none); remux nodes
-	// use it to strip dangling profile 7 RPUs. Absent in older tokens, which
-	// decodes as 0 (no strip — the pre-existing behavior).
+	// DVProfile is the file's Dolby Vision profile (0 = none); remux nodes use
+	// it to select the validated Dolby Vision byte-level recipe. Absent in older
+	// tokens, which decodes as 0 (the pre-existing behavior).
 	DVProfile int `json:"dvp,omitempty"`
-	// RemuxDVMode freezes whether a Profile 7 remux preserves or strips DV
-	// metadata. Empty is the legacy auto behavior for old tokens.
+	// RemuxDVMode freezes whether a Profile 7 remux preserves Dolby Vision or
+	// isolates its HDR10 base layer. Empty is the legacy auto behavior for old
+	// tokens.
 	RemuxDVMode string `json:"dvm,omitempty"`
+	// RemuxDVRecipeVersion pins the byte-level remux operation selected by the
+	// plan. A strip mode without the current version fails closed after an
+	// update.
+	RemuxDVRecipeVersion string `json:"dvrv,omitempty"`
 
 	// Ownership / authorization lookup keys (re-resolved at reconstruct).
 	// Not trust assertions.


### PR DESCRIPTION
## Problem
Fixes #656

Related: #653 (Safari transport for #648, submitted by a different contributor)

The `server_dv7_to_hdr10` transformation promised an HDR10 base layer with the Dolby Vision enhancement layer discarded, but its FFmpeg recipe only ran `dovi_rpu=strip=1`. Profile 7 enhancement-layer NAL units are interleaved in the selected HEVC stream as type 63, so stream mapping did not remove them.

That left HDR10-signalled output containing bytes the fallback client did not declare support for. This is directly relevant to macOS Safari, which cannot decode Profile 7 and relies on the server fallback, but the malformed output was server-side and affected every remux delivery.

PR #653 addresses how Safari receives HDR remuxes. This PR is deliberately separate: it makes the DV7-to-HDR10 bytes correct regardless of transport.

## Approach
- Apply `dovi_rpu=strip=1,filter_units=remove_types=63` to both progressive and HLS copy-video remuxes.
- Advertise the transformation only when FFmpeg provides both required bitstream filters, with a bounded capability probe.
- Bump `server_dv7_to_hdr10` from recipe v1 to v2 and require an exact server/name/version match.
- Carry the recipe version through progressive session state, reconstruction cards, signed stream claims, and proxy delivery. Stale or missing v1 tokens fail closed instead of silently executing different bytes.
- Regenerate the protocol fixtures and cover Profile 7, the existing compatible Profile 8 fallback, mixed-version nodes, local remux, HLS, reconstruction, and proxy paths.

I kept Safari native-HLS selection, sample-entry propagation, broader Dolby Vision routing, and Firefox behavior out of this PR because they are separate concerns.

## Testing
The raw real-media A/B probe is in #656. On the same two-second Profile 7 interval:

```text
current dovi_rpu-only recipe: 51 type-63 NAL units
corrected complete chain:       0 type-63 NAL units
```

The corrected output remained HEVC Main 10, 10-bit PQ/BT.2020 HDR and no longer exposed a Dolby Vision configuration record.

Actual local command output:

```text
$ go test ./internal/playback ./internal/playback/contract -skip 'NVENC|HWAccel' -count=1
ok  github.com/Silo-Server/silo-server/internal/playback           14.606s
ok  github.com/Silo-Server/silo-server/internal/playback/contract   0.760s

$ go test ./internal/proxy -count=1
ok  github.com/Silo-Server/silo-server/internal/proxy  0.341s

$ golangci-lint run --new-from-merge-base=upstream/main ./internal/playback/...
0 issues.

$ make verify-playback-fixtures
playback fixtures are current

$ make verify-local-paths
scripts/check-local-path-leaks.sh

$ git diff upstream/main...HEAD --check
<no output>
```

I also ran the final commit through the repository's exact [CI workflow on the fork](https://github.com/blurbery/silo-server/actions/runs/31936503495). All three jobs passed:

```text
Docs hygiene  pass
Web           pass  (lint, format, typecheck/build, tests, generated binding)
Go            pass  (build, gofmt, vet, changed-line lint, fixtures, full tests)
```

This is a server-only byte-stream change, so there is no UI screenshot.

### Follow-up review

Quick104 reviewed commit `34c4803` and found two runtime root causes plus a documentation mismatch. Commit `5cb55b9` now:

- rejects frozen Profile 7 and Profile 8 v1 recipes through the retryable capability-mismatch path before local progressive remux starts;
- treats FFmpeg capability-probe errors and timeouts as inconclusive, so they are not cached as a process-lifetime lack of support; and
- documents that both `dovi_rpu` and `filter_units` are required.

The follow-up regressions failed on `34c4803` and passed after the fix. The repository's [upstream CI run](https://github.com/Silo-Server/silo-server/actions/runs/32309181182) passed Go, Web, and docs hygiene, and the follow-up CodeRabbit review reported no actionable comments.

PR #657 is the first landing PR. PR #659 will be rebased onto the updated `main` afterward and will consolidate the DV path into its general versioned remux-filter contract instead of retaining parallel `dvrv` and `rfv` mechanisms.

### AI Disclosure
- Tool(s): OpenAI Codex
- Model(s): gpt-5
- Involvement: fully AI-generated, with human-provided playback context and approval
- Adversarial review: The initial scope review excluded Safari transport work already covered by #653. A stable-diff review traced recipe v2 through local, reconstructed, HLS, and proxy paths. CodeRabbit then identified three valid gaps: an unbounded FFmpeg capability probe, partial session updates clearing recipe versions, and a missing server-executor assertion. I fixed all three, added targeted regressions for the runtime cases, reran the full repository CI successfully, and confirmed all three review threads resolved. The repository's Codex companion script was not installed, so I used an independent read-only reviewer as the documented fallback.

## Checklist
- [x] I ran an adversarial AI review of the diff and summarized findings above.
- [x] I ran the repo verify commands: `make lint`, `cd web && pnpm run lint`, `cd web && pnpm run format:check`, and relevant `go test ./...`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Enhancements**
  * Improved Dolby Vision Profile 7 to HDR10 playback and remuxing.
  * Added support for preserving Dolby Vision playback settings across sessions, streams, and playback tokens.
  * Updated playback transformation handling to use the latest recipe version.

* **Bug Fixes**
  * Prevented playback from using outdated or incomplete Dolby Vision transformation settings.
  * Improved capability detection for HDR10 conversion and safer fallback behavior.
  * Updated FFmpeg filter requirements to correctly isolate the HDR10 base layer.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->