### PR TITLE
fix(playback): normalize macOS Firefox HEVC resume boundaries

### DIFF
--- a/cmd/playbackfixtures/main.go
+++ b/cmd/playbackfixtures/main.go
@@ -336,6 +336,7 @@ func goldenCapabilityResponse() playback.CapabilityResponseV3 {
 		Transformations: []playback.TransformationV3{
 			{Name: playback.TransformationAudioToAACV3, Executor: playback.ExecutorServerV3, RecipeVersion: "1", ValidatedClaims: []string{playback.ClaimAudioDecodeV3}},
 			{Name: playback.TransformationServerDV7HDR10V3, Executor: playback.ExecutorServerV3, RecipeVersion: "1", ValidatedClaims: playback.DV7ToHDR10ClaimsV3()},
+			{Name: playback.TransformationServerHEVCResumeLeadingPictureDropV3, Executor: playback.ExecutorServerV3, RecipeVersion: playback.TransformationServerHEVCResumeLeadingPictureDropVersionV3, ValidatedClaims: []string{playback.ClaimResumeLeadingPicturesRemovedV3}},
 			{Name: playback.TransformationVideoToH264V3, Executor: playback.ExecutorServerV3, RecipeVersion: playback.TransformationVideoToH264RecipeVersionV3, ValidatedClaims: []string{playback.ClaimH264DecodeV3}},
 		},
 	}

--- a/docs/architecture/playback-protocol-v3.md
+++ b/docs/architecture/playback-protocol-v3.md
@@ -785,6 +785,7 @@ A transformation is a named, versioned media operation with claims attached.
 | `audio_to_aac` | `server` | `1` | — | `audio_decode` |
 | `video_to_h264` | `server` | `2` | `sdr` output | `h264_decode` |
 | `server_dv7_to_hdr10` | `server` | `1` | `hdr10` output | `dolby_vision_metadata_removed`, `hdr10_base_layer_preserved`, `enhancement_layer_discarded` |
+| `server_hevc_resume_leading_picture_drop` | `server` | `1` | — | `resume_leading_pictures_removed` |
 
 They are advertised only if the installed FFmpeg actually has the required
 capability, probed once at startup:
@@ -792,6 +793,7 @@ capability, probed once at startup:
 | Transformation | Probe |
 | --- | --- |
 | `server_dv7_to_hdr10` | `ffmpeg -bsfs` contains `dovi_rpu` |
+| `server_hevc_resume_leading_picture_drop` | `ffmpeg -bsfs` contains the exact `noise` filter and `ffmpeg -h bsf=noise` exposes the expression-based `drop` option |
 | `audio_to_aac` | `ffmpeg -encoders` contains an `aac` encoder |
 | `video_to_h264` | `ffmpeg -encoders` contains any of `libx264`, `h264_qsv`, `h264_vaapi`, `h264_nvenc`, `h264_videotoolbox` |
 
@@ -800,10 +802,21 @@ pooled transcode nodes may still plan an HLS route using a transformation those
 nodes advertise but the local FFmpeg lacks, so the capability list is a floor,
 not a ceiling — one more reason a client must not precompute routes from it.
 
-An unavailable transformation is not silently skipped at plan time: it produces
-its own terminal reason (`dv_conversion_unsupported`,
+An unavailable conversion transformation is not silently skipped at plan time:
+it produces its own terminal reason (`dv_conversion_unsupported`,
 `audio_conversion_unsupported`, `video_conversion_unsupported`) so the client
-learns which conversion was missing rather than seeing a generic refusal.
+learns which conversion was missing rather than seeing a generic refusal. The
+HEVC resume transformation instead makes the unsafe progressive-copy candidate
+ineligible, allowing the existing HLS or encoded fallback policy to continue.
+
+`server_hevc_resume_leading_picture_drop` is frozen on macOS Firefox HEVC
+progressive-remux plans even when playback starts at zero. Its FFmpeg filter is
+executed only after a non-zero server seek, where it removes non-key open-GOP
+pictures presented before the resumed copy's first packet. The browser still
+applies `timeline.player_start_seconds`, preserving exact resume position.
+These plans use the version-fenced `/stream/remux-v3/` route on both integrated
+and proxy servers; older binaries do not mount that path and therefore cannot
+silently serve the same signed session without its frozen recipe.
 
 A client may advertise its *own* transformations in a delivery's
 `transformations[]` with `executor: "client"` — Dolby Vision profile 7 → 8.1

--- a/docs/design/schemas/playback-v3/v3/fixtures/valid/capability_response.json
+++ b/docs/design/schemas/playback-v3/v3/fixtures/valid/capability_response.json
@@ -40,6 +40,14 @@
       ]
     },
     {
+      "name": "server_hevc_resume_leading_picture_drop",
+      "executor": "server",
+      "recipe_version": "1",
+      "validated_claims": [
+        "resume_leading_pictures_removed"
+      ]
+    },
+    {
       "name": "video_to_h264",
       "executor": "server",
       "recipe_version": "2",

--- a/internal/api/handlers/playback.go
+++ b/internal/api/handlers/playback.go
@@ -489,7 +489,8 @@ func appendStreamToken(rawURL, token string) string {
 // identity stream token so a direct-play/remux session survives a restart (the
 // client re-supplies its byte position). Transcode sessions are told which URL
 // to play by their v3 plan; the URL here is an informational placeholder that
-// the plan's delivery URL supersedes.
+// the plan's delivery URL supersedes. A remux with a versioned server recipe
+// uses a route older binaries do not mount, fencing rolling deployments.
 func (h *PlaybackHandler) playbackStreamURL(s *playback.Session) string {
 	if s == nil {
 		return ""
@@ -498,13 +499,16 @@ func (h *PlaybackHandler) playbackStreamURL(s *playback.Session) string {
 		return fmt.Sprintf("/playback/transcode/%s/master.m3u8", s.ID)
 	}
 	card := identityRecipeCard(s)
-	return appendStreamToken(fmt.Sprintf("/stream/%s", s.ID), h.signSessionToken(card))
+	path := fmt.Sprintf("/stream/%s", s.ID)
+	if s.PlayMethod == playback.PlayRemux && (s.RemuxFilter != "" || s.RemuxFilterVersion != "") {
+		path = playback.RemuxRecipeStreamPathV3 + s.ID
+	}
+	return appendStreamToken(path, h.signSessionToken(card))
 }
 
-// identityRecipeCard builds the identity-only recipe for a direct-play or remux
-// session: reconstruction needs only ownership plus the audio selection, since
-// the bytes are served by HTTP Range / a re-spawned remux pipe at the
-// client-supplied position.
+// identityRecipeCard builds the durable recipe for a direct-play or remux
+// session. Direct reconstruction needs only ownership; remux reconstruction
+// also preserves its selected audio handling and versioned byte-level recipes.
 func identityRecipeCard(s *playback.Session) playback.RecipeCard {
 	switch s.PlayMethod {
 	case playback.PlayRemux:
@@ -512,6 +516,8 @@ func identityRecipeCard(s *playback.Session) playback.RecipeCard {
 		card.TargetCodecAudio = s.TargetAudioCodec
 		card.TargetAudioChannels = s.TargetAudioChannels
 		card.TargetAudioBitrateKbps = s.TargetAudioBitrateKbps
+		card.VideoBitstreamFilter = s.RemuxFilter
+		card.RemuxFilterVersion = s.RemuxFilterVersion
 		return card
 	default:
 		return playback.NewDirectRecipeCard(s.ID, s.UserID, s.ProfileID, s.MediaFileID)

--- a/internal/api/handlers/playback_v3.go
+++ b/internal/api/handlers/playback_v3.go
@@ -847,6 +847,10 @@ func planRequiresServerTransformationsV3(plan *playback.PlanV3) bool {
 }
 
 func (h *PlaybackHandler) prepareIdentityTransportV3(r *http.Request, session *playback.Session, file *models.MediaFile, result playback.PlannerResultV3, timeline preparedTimelineV3) (preparedTransportV3, *transportErrorV3) {
+	remuxFilter, remuxFilterVersion, filterErr := remuxVideoBitstreamFilterForPlanV3(result.Plan)
+	if filterErr != nil {
+		return preparedTransportV3{}, &transportErrorV3{reason: "transformation_recipe_unavailable", message: "The selected remux recipe is unavailable.", retryable: true, cause: filterErr}
+	}
 	routeSession := *session
 	routeSession.PlayMethod = result.PlayMethod
 	routeSession.BasePlayMethod = result.PlayMethod
@@ -857,6 +861,8 @@ func (h *PlaybackHandler) prepareIdentityTransportV3(r *http.Request, session *p
 	routeSession.TargetAudioChannels = result.TargetAudioChannels
 	routeSession.TargetAudioBitrateKbps = result.TargetAudioBitrateKbps
 	routeSession.RemuxDVMode = remuxDVModeForPlanV3(result.Plan)
+	routeSession.RemuxFilter = remuxFilter
+	routeSession.RemuxFilterVersion = remuxFilterVersion
 
 	proxyNode, proxyErr := h.planIdentityProxyV3(r, session.ID, result)
 	if proxyErr != nil {
@@ -1034,9 +1040,9 @@ func identityStreamBitrateKbpsV3(result playback.PlannerResultV3) int {
 //
 // The proxy serves from the token alone, so the token has to carry everything
 // the API-local path would have read from the session and the file record: the
-// media path it opens, and the Dolby Vision profile its remux needs to strip a
-// dangling Profile 7 RPU. Omitting either would not fail loudly — the proxy
-// would serve a subtly different stream than the plan promised.
+// media path it opens, source codec, and every versioned remux recipe. Omitting
+// one would not fail loudly — the proxy could serve different bytes than the
+// plan promised. Versioned recipes also use a route old proxies do not mount.
 //
 // The bool reports whether the returned URL is actually a proxy URL, so the
 // caller can release the planner reservation when it is not.
@@ -1046,6 +1052,7 @@ func (h *PlaybackHandler) identityStreamURLV3(s *playback.Session, file *models.
 	}
 	card := identityRecipeCard(s)
 	card.InputPath = file.FilePath
+	card.SourceVideoCodec = playback.SourceDescriptorFromFileV3(file, s.AudioTrackIndex).VideoCodec
 	claims := card.ToClaims()
 	claims.DVProfile = file.PrimaryDVProfile()
 	claims.AudioOnly = file.IsAudioOnly()
@@ -1055,6 +1062,9 @@ func (h *PlaybackHandler) identityStreamURLV3(s *playback.Session, file *models.
 	}
 	base := strings.TrimRight(proxyNode.URL, "/")
 	if s.PlayMethod == playback.PlayRemux {
+		if s.RemuxFilter != "" || s.RemuxFilterVersion != "" {
+			return base + playback.RemuxRecipeStreamPathV3 + token, true
+		}
 		return base + "/stream/remux/" + token, true
 	}
 	return base + "/stream/direct/" + token, true
@@ -1386,7 +1396,8 @@ func sourceVideoTranscodeFactsV3(file *models.MediaFile, result playback.Planner
 }
 
 func (h *PlaybackHandler) v3SessionStreamState(ctx context.Context, session *playback.Session, file *models.MediaFile, result playback.PlannerResultV3, transport preparedTransportV3) playback.SessionStreamState {
-	state := playback.SessionStreamState{PlayMethod: result.PlayMethod, BasePlayMethod: result.PlayMethod, AudioTrackIndex: plannedAudioTrackIndexV3(result, session.AudioTrackIndex), TranscodeAudio: result.TranscodeAudio, RemuxDVMode: remuxDVModeForPlanV3(result.Plan), TranscodeNodeURL: transport.nodeURL, TranscodeTransportID: transport.transportID, TranscodeRouteSet: true, ClientIP: clientip.FromContext(ctx), ClientName: session.ClientName, ClientVersion: session.ClientVersion, ClientUserAgent: session.ClientUserAgent, StreamBitrateKbps: result.TargetBitrateKbps, TargetVideoCodec: result.TargetVideoCodec, TargetAudioCodec: result.TargetAudioCodec, TargetAudioChannels: result.TargetAudioChannels, TargetAudioBitrateKbps: result.TargetAudioBitrateKbps, TargetResolution: result.TargetResolution, SubtitleTrackIndex: result.SubtitleTransportTrackIndex, SubtitleBurnIn: result.SubtitleBurnIn}
+	remuxFilter, remuxFilterVersion, _ := remuxVideoBitstreamFilterForPlanV3(result.Plan)
+	state := playback.SessionStreamState{PlayMethod: result.PlayMethod, BasePlayMethod: result.PlayMethod, AudioTrackIndex: plannedAudioTrackIndexV3(result, session.AudioTrackIndex), TranscodeAudio: result.TranscodeAudio, RemuxDVMode: remuxDVModeForPlanV3(result.Plan), RemuxFilter: remuxFilter, RemuxFilterVersion: remuxFilterVersion, TranscodeNodeURL: transport.nodeURL, TranscodeTransportID: transport.transportID, TranscodeRouteSet: true, ClientIP: clientip.FromContext(ctx), ClientName: session.ClientName, ClientVersion: session.ClientVersion, ClientUserAgent: session.ClientUserAgent, StreamBitrateKbps: result.TargetBitrateKbps, TargetVideoCodec: result.TargetVideoCodec, TargetAudioCodec: result.TargetAudioCodec, TargetAudioChannels: result.TargetAudioChannels, TargetAudioBitrateKbps: result.TargetAudioBitrateKbps, TargetResolution: result.TargetResolution, SubtitleTrackIndex: result.SubtitleTransportTrackIndex, SubtitleBurnIn: result.SubtitleBurnIn}
 	if result.Plan != nil && (result.Plan.Delivery == playback.DeliveryTranscodeHLSV3 || result.Plan.Delivery == playback.DeliveryRemuxHLSV3) {
 		state.SegmentDuration = 2
 	}
@@ -3237,6 +3248,28 @@ func videoBitstreamFilterForPlanV3(plan *playback.PlanV3) string {
 		}
 	}
 	return ""
+}
+
+func remuxVideoBitstreamFilterForPlanV3(plan *playback.PlanV3) (string, string, error) {
+	if plan == nil {
+		return "", "", nil
+	}
+	found := false
+	for _, transformation := range plan.Transformations {
+		if transformation.Name != playback.TransformationServerHEVCResumeLeadingPictureDropV3 {
+			continue
+		}
+		if found || transformation.Executor != playback.ExecutorServerV3 ||
+			transformation.RecipeVersion != playback.TransformationServerHEVCResumeLeadingPictureDropVersionV3 ||
+			plan.Delivery != playback.DeliveryRemuxProgressiveV3 || !strings.EqualFold(plan.Source.VideoCodec, "hevc") {
+			return "", "", fmt.Errorf("unsupported HEVC resume transformation identity")
+		}
+		found = true
+	}
+	if !found {
+		return "", "", nil
+	}
+	return playback.HEVCResumeLeadingPictureBitstreamFilter, playback.TransformationServerHEVCResumeLeadingPictureDropVersionV3, nil
 }
 
 // lazyDVRPUStrippableV3 defers (and memoizes) the per-source RPU probe so the

--- a/internal/api/handlers/playback_v3_test.go
+++ b/internal/api/handlers/playback_v3_test.go
@@ -2654,6 +2654,36 @@ func TestRemuxDVModeForPlanV3ExecutesProfile8Strip(t *testing.T) {
 	}
 }
 
+func TestRemuxVideoBitstreamFilterForPlanV3RequiresCurrentRecipe(t *testing.T) {
+	current := playback.TransformationV3{
+		Name:          playback.TransformationServerHEVCResumeLeadingPictureDropV3,
+		Executor:      playback.ExecutorServerV3,
+		RecipeVersion: playback.TransformationServerHEVCResumeLeadingPictureDropVersionV3,
+	}
+	plan := &playback.PlanV3{Delivery: playback.DeliveryRemuxProgressiveV3, Source: playback.SourceDescriptorV3{VideoCodec: "hevc"}, Transformations: []playback.TransformationV3{current}}
+	filter, version, err := remuxVideoBitstreamFilterForPlanV3(plan)
+	if err != nil || filter != playback.HEVCResumeLeadingPictureBitstreamFilter || version != playback.TransformationServerHEVCResumeLeadingPictureDropVersionV3 {
+		t.Fatalf("current recipe = %q@%q, err=%v", filter, version, err)
+	}
+
+	for name, mutate := range map[string]func(*playback.PlanV3){
+		"wrong version":   func(plan *playback.PlanV3) { plan.Transformations[0].RecipeVersion = "0" },
+		"client executor": func(plan *playback.PlanV3) { plan.Transformations[0].Executor = playback.ExecutorClientV3 },
+		"wrong delivery":  func(plan *playback.PlanV3) { plan.Delivery = playback.DeliveryRemuxHLSV3 },
+		"wrong codec":     func(plan *playback.PlanV3) { plan.Source.VideoCodec = "h264" },
+		"duplicate":       func(plan *playback.PlanV3) { plan.Transformations = append(plan.Transformations, current) },
+	} {
+		t.Run(name, func(t *testing.T) {
+			candidate := *plan
+			candidate.Transformations = append([]playback.TransformationV3(nil), plan.Transformations...)
+			mutate(&candidate)
+			if _, _, err := remuxVideoBitstreamFilterForPlanV3(&candidate); err == nil {
+				t.Fatalf("invalid transformation accepted: %#v", candidate)
+			}
+		})
+	}
+}
+
 func TestHandlePlaybackRouteEventV3RejectsMalformedEvents(t *testing.T) {
 	handler := NewPlaybackHandler(playback.NewSessionManager(0, 0))
 	req := httptest.NewRequest(http.MethodPost, "/api/v1/playback/route-events", strings.NewReader(`{}`)).WithContext(newAuthorizedPlaybackContext())
@@ -3784,6 +3814,96 @@ func TestPrepareTransportV3RoutesProgressiveRemuxThroughProxyNodeWithSeekAndDV(t
 	}
 }
 
+func TestPrepareTransportV3CarriesHEVCResumeRecipeToProxy(t *testing.T) {
+	handler := NewPlaybackHandler(playback.NewSessionManager(0, 0))
+	handler.JWTSecret = "test-secret"
+	stubCopySeekAnchorV3(handler)
+	proxy := capableProxyStubV3(t)
+	handler.NodePlanner = &recordingNodePlannerV3{plan: nodepool.Plan{ProxyNode: &nodepool.Node{URL: proxy.URL}}}
+
+	file := v3HandlerFixtureFile(t)
+	// The primary track is authoritative when a legacy aggregate row is stale.
+	file.CodecVideo = "h264"
+	file.VideoTracks[0].Codec = "hevc"
+	plan := identityProxyPlanV3(playback.DeliveryRemuxProgressiveV3, playback.TransformationV3{
+		Name:          playback.TransformationServerHEVCResumeLeadingPictureDropV3,
+		Executor:      playback.ExecutorServerV3,
+		RecipeVersion: playback.TransformationServerHEVCResumeLeadingPictureDropVersionV3,
+	})
+	plan.Source.VideoCodec = "hevc"
+	plan.Timeline = playback.TimelineV3{SourceStartSeconds: 39.5, PlayerStartSeconds: 39.5}
+
+	transport, transportErr := handler.prepareTransportV3(
+		httptest.NewRequest(http.MethodPost, "/", nil),
+		&playback.Session{ID: "session-hevc-resume-proxy", UserID: 7, ProfileID: "profile-1"},
+		file,
+		playback.PlannerResultV3{Plan: plan, PlayMethod: playback.PlayRemux},
+	)
+	if transportErr != nil {
+		t.Fatalf("prepare identity transport: %v", transportErr)
+	}
+	defer transport.rollback()
+
+	prefix := proxy.URL + playback.RemuxRecipeStreamPathV3
+	if !strings.HasPrefix(transport.url, prefix) || !strings.Contains(transport.url, "seek=39.5") {
+		t.Fatalf("remux stream url = %q", transport.url)
+	}
+	token := strings.TrimSuffix(strings.TrimPrefix(transport.url, prefix), "?seek=39.5")
+	claims, err := streamtoken.Verify(token, handler.JWTSecret)
+	if err != nil {
+		t.Fatalf("verify proxy stream token: %v", err)
+	}
+	if claims.SourceVideoCodec != "hevc" || claims.VideoBitstreamFilter != playback.HEVCResumeLeadingPictureBitstreamFilter ||
+		claims.RemuxFilterVersion != playback.TransformationServerHEVCResumeLeadingPictureDropVersionV3 {
+		t.Fatalf("token HEVC resume recipe = codec %q, %q@%q", claims.SourceVideoCodec, claims.VideoBitstreamFilter, claims.RemuxFilterVersion)
+	}
+}
+
+func TestPlaybackStreamURLFencesVersionedRemuxRecipe(t *testing.T) {
+	handler := NewPlaybackHandler(playback.NewSessionManager(0, 0))
+	handler.JWTSecret = "test-secret"
+	session := &playback.Session{
+		ID:                 "session-hevc-resume-local",
+		PlayMethod:         playback.PlayRemux,
+		RemuxFilter:        playback.HEVCResumeLeadingPictureBitstreamFilter,
+		RemuxFilterVersion: playback.TransformationServerHEVCResumeLeadingPictureDropVersionV3,
+	}
+	got := handler.playbackStreamURL(session)
+	wantPrefix := playback.RemuxRecipeStreamPathV3 + session.ID + "?st="
+	if !strings.HasPrefix(got, wantPrefix) {
+		t.Fatalf("versioned local remux URL = %q, want prefix %q", got, wantPrefix)
+	}
+
+	legacy := *session
+	legacy.ID = "session-legacy-remux"
+	legacy.RemuxFilter = ""
+	legacy.RemuxFilterVersion = ""
+	if got := handler.playbackStreamURL(&legacy); !strings.HasPrefix(got, "/stream/"+legacy.ID+"?st=") {
+		t.Fatalf("legacy remux URL = %q", got)
+	}
+}
+
+func TestPrepareTransportV3RejectsStaleHEVCResumeRecipe(t *testing.T) {
+	handler := NewPlaybackHandler(playback.NewSessionManager(0, 0))
+	plan := identityProxyPlanV3(playback.DeliveryRemuxProgressiveV3, playback.TransformationV3{
+		Name:          playback.TransformationServerHEVCResumeLeadingPictureDropV3,
+		Executor:      playback.ExecutorServerV3,
+		RecipeVersion: "0",
+	})
+	plan.Source.VideoCodec = "hevc"
+
+	_, transportErr := handler.prepareIdentityTransportV3(
+		httptest.NewRequest(http.MethodPost, "/", nil),
+		&playback.Session{ID: "session-stale-recipe"},
+		v3HandlerFixtureFile(t),
+		playback.PlannerResultV3{Plan: plan, PlayMethod: playback.PlayRemux},
+		preparedTimelineV3{},
+	)
+	if transportErr == nil || transportErr.reason != "transformation_recipe_unavailable" {
+		t.Fatalf("transport error = %#v, want transformation_recipe_unavailable", transportErr)
+	}
+}
+
 func TestPrepareTransportV3FallsBackLocallyWithoutEligibleProxy(t *testing.T) {
 	handler := NewPlaybackHandler(playback.NewSessionManager(0, 0))
 	handler.JWTSecret = "test-secret"
@@ -3881,6 +4001,7 @@ func capableProxyStubV3(t *testing.T) *httptest.Server {
 		writeJSON(w, http.StatusOK, playback.HWAccelInfo{Transformations: []playback.TransformationV3{
 			{Name: playback.TransformationAudioToAACV3, Executor: playback.ExecutorServerV3, RecipeVersion: "1"},
 			{Name: playback.TransformationServerDV7HDR10V3, Executor: playback.ExecutorServerV3, RecipeVersion: "1"},
+			{Name: playback.TransformationServerHEVCResumeLeadingPictureDropV3, Executor: playback.ExecutorServerV3, RecipeVersion: playback.TransformationServerHEVCResumeLeadingPictureDropVersionV3},
 		}})
 	}))
 	t.Cleanup(server.Close)

--- a/internal/api/handlers/stream.go
+++ b/internal/api/handlers/stream.go
@@ -169,8 +169,12 @@ func (h *StreamHandler) HandleStream(w http.ResponseWriter, r *http.Request) {
 		// audio/mp4 for it, and a declared-tier client refuses to attach a
 		// source buffer whose advertised type its probe rejected — so the
 		// response has to keep the same promise the plan made.
+		sourceVideoCodec := playback.SourceDescriptorFromFileV3(file, session.AudioTrackIndex).VideoCodec
 		if err := playback.ServeRemuxWithOptions(w, r, file.FilePath, "mp4", seekSeconds, session.TranscodeAudio, session.AudioTrackIndex, file.PrimaryDVProfile(), playback.RemuxServeOptions{
 			DVMode:                 session.RemuxDVMode,
+			VideoBitstreamFilter:   session.RemuxFilter,
+			VideoFilterVersion:     session.RemuxFilterVersion,
+			SourceVideoCodec:       sourceVideoCodec,
 			FFmpegPath:             h.ffmpegPath(),
 			ContentType:            playback.RemuxContentType(file.IsAudioOnly()),
 			AudioOnly:              file.IsAudioOnly(),

--- a/internal/api/router.go
+++ b/internal/api/router.go
@@ -2680,6 +2680,8 @@ func NewRouter(deps Dependencies) chi.Router {
 				if streamHandler != nil {
 					r.Get("/stream/{session_id}", streamHandler.HandleStream)
 					r.Head("/stream/{session_id}", streamHandler.HandleStream)
+					r.Get(playback.RemuxRecipeStreamPathV3+"{session_id}", streamHandler.HandleStream)
+					r.Head(playback.RemuxRecipeStreamPathV3+"{session_id}", streamHandler.HandleStream)
 					r.Get("/stream/{session_id}/subtitles/{track}", streamHandler.HandleSubtitle)
 					r.Head("/stream/{session_id}/subtitles/{track}", streamHandler.HandleSubtitle)
 					r.Get("/stream/{session_id}/subtitles/{track}/fonts", streamHandler.HandleSubtitleFonts)

--- a/internal/playback/device_quirks_v3.go
+++ b/internal/playback/device_quirks_v3.go
@@ -34,6 +34,23 @@ func high10DecodeOverrideV3(source SourceDescriptorV3, request StartRequestV3) (
 	return nil, false
 }
 
+// requiresFirefoxMacOSHEVCResumeNormalizationV3 identifies the evidenced
+// browser path where a server-reanchored progressive HEVC remux can expose
+// open-GOP leading pictures that Firefox's macOS decoder was observed to
+// reject. This is a server recipe, not a client-executed device quirk.
+func requiresFirefoxMacOSHEVCResumeNormalizationV3(source SourceDescriptorV3, request StartRequestV3) bool {
+	device := request.ClientPlaybackContext.Device
+	if !strings.EqualFold(device.Platform, "web") || !strings.EqualFold(source.VideoCodec, codecHEVCV3) {
+		return false
+	}
+	userAgent := strings.ToLower(strings.TrimSpace(device.PlatformDetails["user_agent"]))
+	if !strings.Contains(userAgent, "firefox/") || strings.Contains(userAgent, "seamonkey/") ||
+		(!strings.Contains(userAgent, "macintosh") && !strings.Contains(userAgent, "mac os x")) {
+		return false
+	}
+	return true
+}
+
 func hlsEAC3AudioCorrectionV3(source SourceDescriptorV3, request StartRequestV3) (*AppliedQuirkV3, bool) {
 	if !deviceQuirkProtocolAvailableV3(request) || !isAmazonModelV3(request, "AFTKRT") ||
 		!strings.EqualFold(source.AudioCodec, "eac3") || source.AudioChannels != 8 {

--- a/internal/playback/device_quirks_v3_test.go
+++ b/internal/playback/device_quirks_v3_test.go
@@ -139,6 +139,115 @@ func TestPlanAttemptKeyV3DeviceQuirkIsStable(t *testing.T) {
 	}
 }
 
+func TestFirefoxMacOSHEVCResumeNormalizationScope(t *testing.T) {
+	macFirefox := "Mozilla/5.0 (Macintosh; Intel Mac OS X 10.15; rv:153.0) Gecko/20100101 Firefox/153.0"
+	cases := []struct {
+		name       string
+		platform   string
+		userAgent  string
+		videoCodec string
+		want       bool
+	}{
+		{name: "macOS Firefox HEVC", platform: "web", userAgent: macFirefox, videoCodec: "hevc", want: true},
+		{name: "Windows Firefox", platform: "web", userAgent: "Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:153.0) Gecko/20100101 Firefox/153.0", videoCodec: "hevc"},
+		{name: "Linux Firefox", platform: "web", userAgent: "Mozilla/5.0 (X11; Linux x86_64; rv:153.0) Gecko/20100101 Firefox/153.0", videoCodec: "hevc"},
+		{name: "macOS Safari", platform: "web", userAgent: "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 Version/26.0 Safari/605.1.15", videoCodec: "hevc"},
+		{name: "macOS SeaMonkey", platform: "web", userAgent: macFirefox + " SeaMonkey/2.53", videoCodec: "hevc"},
+		{name: "macOS Firefox H264", platform: "web", userAgent: macFirefox, videoCodec: "h264"},
+		{name: "native client", platform: "macos", userAgent: macFirefox, videoCodec: "hevc"},
+	}
+	for _, test := range cases {
+		t.Run(test.name, func(t *testing.T) {
+			req := validStartRequestV3()
+			req.ClientPlaybackContext.Device = DeviceContextV3{Platform: test.platform, PlatformDetails: map[string]string{"user_agent": test.userAgent}}
+			got := requiresFirefoxMacOSHEVCResumeNormalizationV3(SourceDescriptorV3{VideoCodec: test.videoCodec}, req)
+			if got != test.want {
+				t.Fatalf("matched = %v, want %v", got, test.want)
+			}
+		})
+	}
+}
+
+func TestPlanPlaybackV3FreezesFirefoxMacOSHEVCResumeTransformation(t *testing.T) {
+	file := detailedFixtureFileV3()
+	file.VideoTracks[0].Profile = "Main"
+	file.VideoTracks[0].BitDepth = 8
+	file.VideoTracks[0].VideoRange = "SDR"
+	file.VideoTracks[0].VideoRangeType = "SDR"
+
+	request := validStartRequestV3()
+	request.ClientPlaybackContext.FormFactor = "desktop"
+	request.ClientPlaybackContext.Device = DeviceContextV3{Platform: "web", PlatformDetails: map[string]string{
+		"user_agent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10.15; rv:153.0) Gecko/20100101 Firefox/153.0",
+	}}
+	request.Capabilities.VideoEvidence = EvidenceDeclaredV3
+	request.Capabilities.AudioEvidence = EvidenceDeclaredV3
+	request.Capabilities.Containers = []string{"mp4"}
+	request.ClientPlaybackContext.Deliveries = map[string]DeliveryCapabilityV3{
+		DeliveryClassProgressiveV3: {
+			Enabled: true, SupportedOnDevice: true,
+			Containers: []string{"mp4"}, VideoCodecs: []string{"hevc"}, AudioDecodeCodecs: []string{"aac"},
+		},
+	}
+	registry := NewTransformationRegistryV3([]TransformationSpecV3{{
+		Name: TransformationServerHEVCResumeLeadingPictureDropV3, RecipeVersion: TransformationServerHEVCResumeLeadingPictureDropVersionV3, Available: true,
+	}})
+
+	for _, test := range []struct {
+		name  string
+		start float64
+	}{{name: "initial start", start: 0}, {name: "resume", start: 1_234.5}} {
+		t.Run(test.name, func(t *testing.T) {
+			request.StartPosition = floatPointerV3(test.start)
+			result := PlanPlaybackV3(PlannerInputV3{Request: request, RequestedFile: file, EffectiveFile: file, AudioTrackIndex: 0, Settings: PlannerSettingsV3{TranscodeEnabled: true}, Registry: registry})
+			if result.Plan == nil || result.Plan.Delivery != DeliveryRemuxProgressiveV3 {
+				t.Fatalf("result = %s", ExplainPlannerResultV3(result))
+			}
+			if result.Plan.Timeline.PlayerStartSeconds != test.start {
+				t.Fatalf("player start = %v, want %v", result.Plan.Timeline.PlayerStartSeconds, test.start)
+			}
+			if len(result.Plan.Transformations) != 1 || result.Plan.Transformations[0].Name != TransformationServerHEVCResumeLeadingPictureDropV3 ||
+				result.Plan.Transformations[0].Executor != ExecutorServerV3 || result.Plan.Transformations[0].RecipeVersion != TransformationServerHEVCResumeLeadingPictureDropVersionV3 {
+				t.Fatalf("transformations = %#v", result.Plan.Transformations)
+			}
+			if len(result.Plan.AppliedQuirks) != 0 {
+				t.Fatalf("server recipe must not publish an unnegotiated client quirk: %#v", result.Plan.AppliedQuirks)
+			}
+		})
+	}
+
+	withoutCapability := PlanPlaybackV3(PlannerInputV3{Request: request, RequestedFile: file, EffectiveFile: file, AudioTrackIndex: 0, Settings: PlannerSettingsV3{TranscodeEnabled: true}, Registry: NewTransformationRegistryV3(nil)})
+	if withoutCapability.Plan != nil && withoutCapability.Plan.Delivery == DeliveryRemuxProgressiveV3 {
+		t.Fatalf("progressive copy planned without the noise BSF: %#v", withoutCapability.Plan)
+	}
+	wrongVersion := NewTransformationRegistryV3([]TransformationSpecV3{{Name: TransformationServerHEVCResumeLeadingPictureDropV3, RecipeVersion: "0", Available: true}})
+	withStaleCapability := PlanPlaybackV3(PlannerInputV3{Request: request, RequestedFile: file, EffectiveFile: file, AudioTrackIndex: 0, Settings: PlannerSettingsV3{TranscodeEnabled: true}, Registry: wrongVersion})
+	if withStaleCapability.Plan != nil && withStaleCapability.Plan.Delivery == DeliveryRemuxProgressiveV3 {
+		t.Fatalf("progressive copy planned against a stale recipe: %#v", withStaleCapability.Plan)
+	}
+
+	hlsRequest := request
+	hlsRequest.ClientPlaybackContext.Deliveries = map[string]DeliveryCapabilityV3{
+		DeliveryClassProgressiveV3: {
+			Enabled: true, SupportedOnDevice: true,
+			Containers: []string{"mp4"}, VideoCodecs: []string{"hevc"}, AudioDecodeCodecs: []string{"aac"},
+		},
+		DeliveryClassHLSV3: {Enabled: true, SupportedOnDevice: true},
+	}
+	hlsResult := PlanPlaybackV3(PlannerInputV3{Request: hlsRequest, RequestedFile: file, EffectiveFile: file, AudioTrackIndex: 0, Settings: PlannerSettingsV3{TranscodeEnabled: true}, Registry: NewTransformationRegistryV3(nil)})
+	if hlsResult.Plan == nil || hlsResult.Plan.Delivery != DeliveryRemuxHLSV3 {
+		t.Fatalf("HLS fallback = %s", ExplainPlannerResultV3(hlsResult))
+	}
+	for _, transformation := range hlsResult.Plan.Transformations {
+		if transformation.Name == TransformationServerHEVCResumeLeadingPictureDropV3 {
+			t.Fatalf("progressive-only resume transformation leaked into HLS: %#v", hlsResult.Plan.Transformations)
+		}
+	}
+	if len(hlsResult.Plan.AppliedQuirks) != 0 {
+		t.Fatalf("server recipe unexpectedly published a client quirk: %#v", hlsResult.Plan.AppliedQuirks)
+	}
+}
+
 func quirkRequestV3() StartRequestV3 {
 	req := validStartRequestV3()
 	req.ClientFeatures = append(req.ClientFeatures, FeatureDeviceQuirksV3)

--- a/internal/playback/plan_v3.go
+++ b/internal/playback/plan_v3.go
@@ -398,17 +398,27 @@ func PlanPlaybackV3(input PlannerInputV3) PlannerResultV3 {
 		if !dvStrip {
 			applyCopiedVideoQuirksV3(&plan, source, input.Request, high10Quirk)
 		}
-		// The progressive remux executes on this process's ffmpeg, so its
-		// server transformations must be locally available; when only pooled
-		// nodes carry them, the HLS remux below ships the same recipe on a
-		// node-offloadable delivery instead.
-		progressiveExecutable := (!transcodeAudio || localAudioConvertOK) && (!dvStrip || dvStripEligibleLocal)
+		firefoxResumeRequired := requiresFirefoxMacOSHEVCResumeNormalizationV3(source, input.Request)
+		firefoxResumeAvailableLocal := !firefoxResumeRequired || input.Registry.AvailableRecipe(TransformationServerHEVCResumeLeadingPictureDropV3, TransformationServerHEVCResumeLeadingPictureDropVersionV3)
+		// Form the progressive candidate only when this process can execute its
+		// server recipes; proxy selection later checks the same recipe against
+		// the selected node. The HLS branch builds its own independently scoped
+		// candidate against the node-aware HLS registry.
+		progressiveExecutable := (!transcodeAudio || localAudioConvertOK) && (!dvStrip || dvStripEligibleLocal) && firefoxResumeAvailableLocal
 		if remuxSubtitleOK && progressiveExecutable {
-			applySubtitleDecisionV3(&plan, remuxSubtitle.Decision)
-			plan.Claims.Subtitles = remuxSubtitle.Claims
-			finalizePlanIdentityV3(&plan, input.Request.PlaybackAttemptID, input.Request.ClientPlaybackContext.Output.OutputContextID)
-			if deliverySupportsPlanV3(input.Request, DeliveryClassProgressiveV3, plan) && !planAttemptedV3(plan, input.Request.ClientPlaybackContext.Output.OutputContextID, input.AttemptedKeys) {
-				return PlannerResultV3{Plan: &plan, PlayMethod: PlayRemux, TranscodeAudio: transcodeAudio, TargetAudioCodec: plan.EffectiveRecipe.AudioCodec, TargetAudioChannels: progressiveAudioChannels, SubtitleTrackIndex: remuxSubtitle.SelectedIndex, SubtitleTransportTrackIndex: remuxSubtitle.TransportIndex, SubtitleCodec: remuxSubtitle.Codec, DownloadedSubtitleID: remuxSubtitle.DownloadedSubtitleID}
+			progressivePlan := plan
+			if firefoxResumeRequired {
+				progressivePlan.Transformations = append(progressivePlan.Transformations, TransformationV3{
+					Name: TransformationServerHEVCResumeLeadingPictureDropV3, Executor: ExecutorServerV3,
+					RecipeVersion:   TransformationServerHEVCResumeLeadingPictureDropVersionV3,
+					ValidatedClaims: []string{ClaimResumeLeadingPicturesRemovedV3},
+				})
+			}
+			applySubtitleDecisionV3(&progressivePlan, remuxSubtitle.Decision)
+			progressivePlan.Claims.Subtitles = remuxSubtitle.Claims
+			finalizePlanIdentityV3(&progressivePlan, input.Request.PlaybackAttemptID, input.Request.ClientPlaybackContext.Output.OutputContextID)
+			if deliverySupportsPlanV3(input.Request, DeliveryClassProgressiveV3, progressivePlan) && !planAttemptedV3(progressivePlan, input.Request.ClientPlaybackContext.Output.OutputContextID, input.AttemptedKeys) {
+				return PlannerResultV3{Plan: &progressivePlan, PlayMethod: PlayRemux, TranscodeAudio: transcodeAudio, TargetAudioCodec: progressivePlan.EffectiveRecipe.AudioCodec, TargetAudioChannels: progressiveAudioChannels, SubtitleTrackIndex: remuxSubtitle.SelectedIndex, SubtitleTransportTrackIndex: remuxSubtitle.TransportIndex, SubtitleCodec: remuxSubtitle.Codec, DownloadedSubtitleID: remuxSubtitle.DownloadedSubtitleID}
 			}
 		}
 		if deliveryAvailableV3(input.Request, DeliveryClassHLSV3) && hlsRemuxSubtitleOK {

--- a/internal/playback/protocol_v3.go
+++ b/internal/playback/protocol_v3.go
@@ -129,12 +129,19 @@ const (
 // Server transformation names. A plan names the transformations its serving
 // executor must run; the registry keys availability by the same names.
 const (
-	TransformationAudioToAACV3     = "audio_to_aac"
-	TransformationVideoToH264V3    = "video_to_h264"
-	TransformationServerDV7HDR10V3 = "server_dv7_to_hdr10"
+	TransformationAudioToAACV3                         = "audio_to_aac"
+	TransformationVideoToH264V3                        = "video_to_h264"
+	TransformationServerDV7HDR10V3                     = "server_dv7_to_hdr10"
+	TransformationServerHEVCResumeLeadingPictureDropV3 = "server_hevc_resume_leading_picture_drop"
 
-	TransformationVideoToH264RecipeVersionV3 = "2"
+	TransformationVideoToH264RecipeVersionV3                  = "2"
+	TransformationServerHEVCResumeLeadingPictureDropVersionV3 = "1"
 )
+
+// RemuxRecipeStreamPathV3 fences remuxes with versioned server recipes from
+// binaries that predate those recipes. Old API and proxy routers do not mount
+// this path, so a rolling deployment fails closed instead of omitting a filter.
+const RemuxRecipeStreamPathV3 = "/stream/remux-v3/"
 
 // Transformation executors: who runs the transformation. A "server"
 // transformation is performed by the serving executor before the bytes leave
@@ -147,11 +154,12 @@ const (
 // Validated claims a server transformation asserts about its output: neutral
 // statements about the bytes, not client-framework decoder names.
 const (
-	ClaimAudioDecodeV3                = "audio_decode"
-	ClaimH264DecodeV3                 = "h264_decode"
-	ClaimDolbyVisionMetadataRemovedV3 = "dolby_vision_metadata_removed"
-	ClaimHDR10BaseLayerPreservedV3    = "hdr10_base_layer_preserved"
-	ClaimEnhancementLayerDiscardedV3  = "enhancement_layer_discarded"
+	ClaimAudioDecodeV3                  = "audio_decode"
+	ClaimH264DecodeV3                   = "h264_decode"
+	ClaimDolbyVisionMetadataRemovedV3   = "dolby_vision_metadata_removed"
+	ClaimHDR10BaseLayerPreservedV3      = "hdr10_base_layer_preserved"
+	ClaimEnhancementLayerDiscardedV3    = "enhancement_layer_discarded"
+	ClaimResumeLeadingPicturesRemovedV3 = "resume_leading_pictures_removed"
 )
 
 // DV7ToHDR10ClaimsV3 returns the claims the server DV7→HDR10 transformation

--- a/internal/playback/recipecard.go
+++ b/internal/playback/recipecard.go
@@ -33,6 +33,9 @@ type RecipeCard struct {
 	// re-encode vs repackage).
 	TranscodeAudio bool        `json:"transcode_audio,omitempty"`
 	RemuxDVMode    RemuxDVMode `json:"remux_dv_mode,omitempty"`
+	// RemuxFilterVersion pins the remux-only filter recipe
+	// carried in VideoBitstreamFilter across restart and proxy reconstruction.
+	RemuxFilterVersion string `json:"remux_filter_version,omitempty"`
 
 	// Client metadata mirrored from the session so admin views (client label,
 	// Jellyfin pill) survive reconstruction. Carried only by stored cards —
@@ -44,8 +47,8 @@ type RecipeCard struct {
 	IsJellyfinCompat bool   `json:"is_jellyfin_compat,omitempty"`
 
 	// Encode parameters — mirror of the byte-affecting TranscodeOpts fields.
-	// Direct cards leave them zero; remux cards use the audio targets when the
-	// selected stream must be converted.
+	// Direct cards leave them zero; remux cards use the audio targets and
+	// versioned video-filter fields when the selected stream requires them.
 	InputPath              string  `json:"input_path"`
 	OutputSubdir           string  `json:"output_subdir,omitempty"`
 	SourceVideoCodec       string  `json:"source_video_codec,omitempty"`
@@ -215,6 +218,7 @@ func (c RecipeCard) ToClaims() streamtoken.Claims {
 		PlayMethod:             string(c.PlayMethod),
 		TranscodeAudio:         c.TranscodeAudio,
 		RemuxDVMode:            string(c.RemuxDVMode),
+		RemuxFilterVersion:     c.RemuxFilterVersion,
 		TranscodeNode:          c.TranscodeNodeURL,
 		TranscodeTransportID:   c.TranscodeTransportID,
 		TargetCodec:            c.TargetCodecVideo,
@@ -267,6 +271,7 @@ func RecipeCardFromClaims(c *streamtoken.Claims) RecipeCard {
 		PlayMethod:             method,
 		TranscodeAudio:         c.TranscodeAudio,
 		RemuxDVMode:            RemuxDVMode(c.RemuxDVMode),
+		RemuxFilterVersion:     c.RemuxFilterVersion,
 		InputPath:              c.MediaPath,
 		OutputSubdir:           c.OutputSubdir,
 		SourceVideoCodec:       c.SourceVideoCodec,

--- a/internal/playback/recipecard_test.go
+++ b/internal/playback/recipecard_test.go
@@ -97,6 +97,29 @@ func TestRecipeCardPlayMethodConstructors(t *testing.T) {
 	}
 }
 
+func TestRemuxRecipeCardPreservesHEVCResumeRecipe(t *testing.T) {
+	card := NewRemuxRecipeCard("resume", 7, "profile-1", 42, false, 0)
+	card.SourceVideoCodec = "hevc"
+	card.VideoBitstreamFilter = HEVCResumeLeadingPictureBitstreamFilter
+	card.RemuxFilterVersion = TransformationServerHEVCResumeLeadingPictureDropVersionV3
+
+	raw, err := json.Marshal(card)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var decoded RecipeCard
+	if err := json.Unmarshal(raw, &decoded); err != nil {
+		t.Fatal(err)
+	}
+	claims := decoded.ToClaims()
+	got := RecipeCardFromClaims(&claims)
+	if got.VideoBitstreamFilter != HEVCResumeLeadingPictureBitstreamFilter ||
+		got.RemuxFilterVersion != TransformationServerHEVCResumeLeadingPictureDropVersionV3 ||
+		got.SourceVideoCodec != "hevc" {
+		t.Fatalf("remux recipe round trip = %#v", got)
+	}
+}
+
 // A transcode card must record whether audio is actually re-encoded so the
 // reconstructed session classifies correctly in admin views: only an explicit
 // "copy" leaves the audio untouched (an empty codec runs ffmpeg's aac default).

--- a/internal/playback/remux.go
+++ b/internal/playback/remux.go
@@ -107,6 +107,14 @@ const (
 	RemuxDVRejectP7V3     RemuxDVMode = "reject_profile_7"
 )
 
+const (
+	// HEVCResumeLeadingPictureBitstreamFilter drops only non-key HEVC packets
+	// whose presentation timestamp precedes the first packet in a seeked copy.
+	// The escaped comma is part of one FFmpeg argv token.
+	HEVCResumeLeadingPictureBitstreamFilter = `noise=drop=lt(pts\,startpts)*not(key)`
+	codecHEVCV3                             = "hevc"
+)
+
 // buildRemuxArgs constructs the ffmpeg argument list for a remux operation.
 // The args perform codec copy (-c copy) into the target container format,
 // using fragmented output for streaming (frag_keyframe+delay_moov+default_base_moof) and
@@ -123,6 +131,10 @@ func buildRemuxArgs(filePath, outputFormat string, seekSeconds float64, transcod
 }
 
 func buildRemuxArgsWithAudioV3(filePath, outputFormat string, seekSeconds float64, transcodeAudio bool, audioTrackIndex int, dvProfile int, tagSampleEntry, audioOnly bool, targetAudioChannels, targetAudioBitrateKbps int) []string {
+	return buildRemuxArgsWithVideoBitstreamFilterV3(filePath, outputFormat, seekSeconds, transcodeAudio, audioTrackIndex, dvProfile, tagSampleEntry, audioOnly, targetAudioChannels, targetAudioBitrateKbps, "")
+}
+
+func buildRemuxArgsWithVideoBitstreamFilterV3(filePath, outputFormat string, seekSeconds float64, transcodeAudio bool, audioTrackIndex int, dvProfile int, tagSampleEntry, audioOnly bool, targetAudioChannels, targetAudioBitrateKbps int, videoBitstreamFilter string) []string {
 	args := []string{
 		"-nostdin",
 		"-hide_banner",
@@ -172,8 +184,17 @@ func buildRemuxArgsWithAudioV3(filePath, outputFormat string, seekSeconds float6
 	}
 	args = append(args, "-sn", "-dn")
 
+	videoBitstreamFilters := make([]string, 0, 2)
+	if videoBitstreamFilter != "" && seekSeconds > 0 && !audioOnly {
+		videoBitstreamFilters = append(videoBitstreamFilters, videoBitstreamFilter)
+	}
 	if dvProfile == 7 {
-		args = append(args, "-bsf:v", "dovi_rpu=strip=1")
+		videoBitstreamFilters = append(videoBitstreamFilters, DV7ToHDR10BitstreamFilter)
+	}
+	if len(videoBitstreamFilters) > 0 {
+		args = append(args, "-bsf:v", strings.Join(videoBitstreamFilters, ","))
+	}
+	if dvProfile == 7 {
 		if tagSampleEntry {
 			// The explicit v3 strip recipe promised the client plain HDR10.
 			// Safari's media element only answers "probably" for hvc1 — the
@@ -244,16 +265,23 @@ func StartRemux(ctx context.Context, filePath, outputFormat string, seekSeconds 
 // v3 callers must pass the configured playback path so the strip capability
 // promised by the planner's probe holds for the binary that actually runs.
 func StartRemuxWithDVMode(ctx context.Context, filePath, outputFormat string, seekSeconds float64, transcodeAudio bool, audioTrackIndex int, dvProfile int, mode RemuxDVMode, ffmpegPath string) (*RemuxSession, error) {
-	return startRemuxWithOptions(ctx, filePath, outputFormat, seekSeconds, transcodeAudio, audioTrackIndex, dvProfile, mode, ffmpegPath, false, 0, 0)
+	return startRemuxWithOptions(ctx, filePath, outputFormat, seekSeconds, transcodeAudio, audioTrackIndex, dvProfile, RemuxServeOptions{DVMode: mode, FFmpegPath: ffmpegPath})
 }
 
-func startRemuxWithOptions(ctx context.Context, filePath, outputFormat string, seekSeconds float64, transcodeAudio bool, audioTrackIndex int, dvProfile int, mode RemuxDVMode, ffmpegPath string, audioOnly bool, targetAudioChannels, targetAudioBitrateKbps int) (*RemuxSession, error) {
+func startRemuxWithOptions(ctx context.Context, filePath, outputFormat string, seekSeconds float64, transcodeAudio bool, audioTrackIndex int, dvProfile int, opts RemuxServeOptions) (*RemuxSession, error) {
+	if err := validateRemuxVideoBitstreamFilterV3(opts); err != nil {
+		return nil, err
+	}
 	ctx, cancel := context.WithCancel(ctx)
 
-	bin := ResolveFFmpegPath(ffmpegPath)
+	bin := ResolveFFmpegPath(opts.FFmpegPath)
+	if opts.VideoBitstreamFilter != "" && !supportsHEVCResumeLeadingPictureRecipeV3(ctx, bin) {
+		cancel()
+		return nil, fmt.Errorf("HEVC resume remux requires the expression-based noise bitstream filter")
+	}
 	effectiveProfile := dvProfile
 	tagSampleEntry := false
-	switch mode {
+	switch opts.DVMode {
 	case "", RemuxDVLegacyAutoV3:
 		effectiveProfile = remuxDVProfile(dvProfile, supportsDoviRPUFilter(bin) &&
 			(dvProfile != 7 || sharedDVRPUProbe.CanStrip(ctx, bin, filePath)))
@@ -300,9 +328,9 @@ func startRemuxWithOptions(ctx context.Context, filePath, outputFormat string, s
 		}
 	default:
 		cancel()
-		return nil, fmt.Errorf("unknown remux Dolby Vision mode %q", mode)
+		return nil, fmt.Errorf("unknown remux Dolby Vision mode %q", opts.DVMode)
 	}
-	args := buildRemuxArgsWithAudioV3(filePath, outputFormat, seekSeconds, transcodeAudio, audioTrackIndex, effectiveProfile, tagSampleEntry, audioOnly, targetAudioChannels, targetAudioBitrateKbps)
+	args := buildRemuxArgsWithVideoBitstreamFilterV3(filePath, outputFormat, seekSeconds, transcodeAudio, audioTrackIndex, effectiveProfile, tagSampleEntry, opts.AudioOnly, opts.TargetAudioChannels, opts.TargetAudioBitrateKbps, opts.VideoBitstreamFilter)
 	cmd := exec.CommandContext(ctx, bin, args...)
 
 	stdout, err := cmd.StdoutPipe()
@@ -359,6 +387,13 @@ type RemuxServeOptions struct {
 	// DVMode is the explicitly declared Dolby Vision recipe. The zero value
 	// decodes as the legacy auto behavior, matching old stream tokens.
 	DVMode RemuxDVMode
+	// VideoBitstreamFilter is a canonical, server-selected remux recipe. Its
+	// version is carried separately so stale signed tokens fail closed.
+	VideoBitstreamFilter string
+	VideoFilterVersion   string
+	// SourceVideoCodec validates that a remux-only HEVC recipe cannot be
+	// replayed against a different source codec.
+	SourceVideoCodec string
 	// FFmpegPath selects the binary to execute (empty = global discovery).
 	FFmpegPath string
 	// ContentType overrides the container-derived response type. Audio-only
@@ -370,6 +405,18 @@ type RemuxServeOptions struct {
 	// output. Zero values retain the historical stereo 192 kbps behavior.
 	TargetAudioChannels    int
 	TargetAudioBitrateKbps int
+}
+
+func validateRemuxVideoBitstreamFilterV3(opts RemuxServeOptions) error {
+	if opts.VideoBitstreamFilter == "" && opts.VideoFilterVersion == "" {
+		return nil
+	}
+	if opts.VideoBitstreamFilter != HEVCResumeLeadingPictureBitstreamFilter ||
+		opts.VideoFilterVersion != TransformationServerHEVCResumeLeadingPictureDropVersionV3 ||
+		normalizeCodecV3(opts.SourceVideoCodec) != codecHEVCV3 || opts.AudioOnly {
+		return fmt.Errorf("unsupported remux video bitstream filter recipe")
+	}
+	return nil
 }
 
 // RemuxContentType returns the override required for an audio-only fMP4.
@@ -398,7 +445,10 @@ func ServeRemuxWithDVMode(w http.ResponseWriter, r *http.Request, filePath, outp
 // ServeRemuxWithOptions is the full remux transport, taking its optional
 // serving concerns as a struct.
 func ServeRemuxWithOptions(w http.ResponseWriter, r *http.Request, filePath, outputFormat string, seekSeconds float64, transcodeAudio bool, audioTrackIndex int, dvProfile int, opts RemuxServeOptions) error {
-	mode, ffmpegPath := opts.DVMode, opts.FFmpegPath
+	if err := validateRemuxVideoBitstreamFilterV3(opts); err != nil {
+		http.Error(w, "stale remux recipe", http.StatusConflict)
+		return err
+	}
 	// Remux output streams for the length of the title; roll the write
 	// deadline with progress instead of the server's absolute WriteTimeout.
 	w = httpstream.NewRollingDeadlineWriter(w)
@@ -414,7 +464,7 @@ func ServeRemuxWithOptions(w http.ResponseWriter, r *http.Request, filePath, out
 		return err
 	}
 
-	session, err := startRemuxWithOptions(r.Context(), filePath, outputFormat, seekSeconds, transcodeAudio, audioTrackIndex, dvProfile, mode, ffmpegPath, opts.AudioOnly, opts.TargetAudioChannels, opts.TargetAudioBitrateKbps)
+	session, err := startRemuxWithOptions(r.Context(), filePath, outputFormat, seekSeconds, transcodeAudio, audioTrackIndex, dvProfile, opts)
 	if err != nil {
 		http.Error(w, "failed to start remux", http.StatusInternalServerError)
 		return err

--- a/internal/playback/remux_dv_test.go
+++ b/internal/playback/remux_dv_test.go
@@ -44,6 +44,77 @@ func TestBuildRemuxArgsHonorsPlannedAACOutput(t *testing.T) {
 	}
 }
 
+func TestBuildRemuxArgsAppliesHEVCResumeFilterOnlyAfterASeek(t *testing.T) {
+	initial := buildRemuxArgsWithVideoBitstreamFilterV3("/movie.mkv", "mp4", 0, false, -1, 0, false, false, 0, 0, HEVCResumeLeadingPictureBitstreamFilter)
+	if argsContainPair(initial, "-bsf:v", HEVCResumeLeadingPictureBitstreamFilter) {
+		t.Fatalf("zero-start remux unexpectedly changed its HEVC packets: %s", strings.Join(initial, " "))
+	}
+
+	resumed := buildRemuxArgsWithVideoBitstreamFilterV3("/movie.mkv", "mp4", 731.25, false, -1, 0, false, false, 0, 0, HEVCResumeLeadingPictureBitstreamFilter)
+	if !argsContainPair(resumed, "-bsf:v", HEVCResumeLeadingPictureBitstreamFilter) {
+		t.Fatalf("seeked remux did not normalize its HEVC resume boundary: %s", strings.Join(resumed, " "))
+	}
+
+	withDV := buildRemuxArgsWithVideoBitstreamFilterV3("/movie.mkv", "mp4", 731.25, false, -1, 7, true, false, 0, 0, HEVCResumeLeadingPictureBitstreamFilter)
+	wantCombined := HEVCResumeLeadingPictureBitstreamFilter + "," + DV7ToHDR10BitstreamFilter
+	if !argsContainPair(withDV, "-bsf:v", wantCombined) {
+		t.Fatalf("combined resume/DV recipe = %s, want one ordered -bsf:v value %q", strings.Join(withDV, " "), wantCombined)
+	}
+}
+
+func TestValidateRemuxVideoBitstreamFilterRecipe(t *testing.T) {
+	valid := RemuxServeOptions{
+		VideoBitstreamFilter: HEVCResumeLeadingPictureBitstreamFilter,
+		VideoFilterVersion:   TransformationServerHEVCResumeLeadingPictureDropVersionV3,
+		SourceVideoCodec:     "hevc",
+	}
+	if err := validateRemuxVideoBitstreamFilterV3(valid); err != nil {
+		t.Fatalf("current HEVC resume recipe rejected: %v", err)
+	}
+	alias := valid
+	alias.SourceVideoCodec = "h265"
+	if err := validateRemuxVideoBitstreamFilterV3(alias); err != nil {
+		t.Fatalf("normalized HEVC codec alias rejected: %v", err)
+	}
+	if err := validateRemuxVideoBitstreamFilterV3(RemuxServeOptions{}); err != nil {
+		t.Fatalf("legacy empty recipe rejected: %v", err)
+	}
+	for name, mutate := range map[string]func(*RemuxServeOptions){
+		"unknown expression": func(opts *RemuxServeOptions) { opts.VideoBitstreamFilter = "noise=drop=1" },
+		"wrong version":      func(opts *RemuxServeOptions) { opts.VideoFilterVersion = "0" },
+		"wrong codec":        func(opts *RemuxServeOptions) { opts.SourceVideoCodec = "h264" },
+		"audio only":         func(opts *RemuxServeOptions) { opts.AudioOnly = true },
+		"version only": func(opts *RemuxServeOptions) {
+			opts.VideoBitstreamFilter = ""
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			opts := valid
+			mutate(&opts)
+			if err := validateRemuxVideoBitstreamFilterV3(opts); err == nil {
+				t.Fatalf("invalid recipe accepted: %#v", opts)
+			}
+		})
+	}
+}
+
+func TestStartRemuxRejectsLegacyNoiseFilterBeforeServing(t *testing.T) {
+	ffmpeg := filepath.Join(t.TempDir(), "ffmpeg")
+	script := "#!/bin/sh\ncase \"$2\" in\n-h) echo '-dropamount <int>'; exit 0 ;;\n*) exit 99 ;;\nesac\n"
+	if err := os.WriteFile(ffmpeg, []byte(script), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	_, err := startRemuxWithOptions(context.Background(), "/unused.mkv", "mp4", 30, false, -1, 0, RemuxServeOptions{
+		VideoBitstreamFilter: HEVCResumeLeadingPictureBitstreamFilter,
+		VideoFilterVersion:   TransformationServerHEVCResumeLeadingPictureDropVersionV3,
+		SourceVideoCodec:     "hevc",
+		FFmpegPath:           ffmpeg,
+	})
+	if err == nil || !strings.Contains(err.Error(), "expression-based noise") {
+		t.Fatalf("legacy noise filter error = %v", err)
+	}
+}
+
 func TestBuildRemuxArgsRequiresVideoForVideoPlans(t *testing.T) {
 	args := buildRemuxArgs("/movie.mkv", "mp4", 0, false, -1, 0, false, false)
 	if !argsContainPair(args, "-map", "0:V:0") || argsContainPair(args, "-map", "0:V:0?") {

--- a/internal/playback/session.go
+++ b/internal/playback/session.go
@@ -25,6 +25,8 @@ type Session struct {
 	BasePlayMethod       PlayMethod
 	TranscodeAudio       bool // when true, remux should transcode audio to AAC
 	RemuxDVMode          RemuxDVMode
+	RemuxFilter          string
+	RemuxFilterVersion   string
 	ClientIP             string // resolved client IP for the playback session
 	ClientName           string // reported playback client name, when available
 	ClientVersion        string // reported playback client version, when available
@@ -81,6 +83,8 @@ type SessionStreamState struct {
 	AudioTrackIndex        int
 	TranscodeAudio         bool
 	RemuxDVMode            RemuxDVMode
+	RemuxFilter            string
+	RemuxFilterVersion     string
 	ClientIP               string
 	ClientName             string
 	ClientVersion          string
@@ -871,8 +875,16 @@ func applySessionStreamStateLocked(s *Session, state SessionStreamState) {
 		// later remux request fails the profile check. Legacy partial updates
 		// never carry a mode and must not clobber one.
 		s.RemuxDVMode = state.RemuxDVMode
+		s.RemuxFilter = state.RemuxFilter
+		s.RemuxFilterVersion = state.RemuxFilterVersion
 	} else if state.RemuxDVMode != "" {
 		s.RemuxDVMode = state.RemuxDVMode
+	}
+	if !state.TranscodeRouteSet && state.RemuxFilter != "" {
+		s.RemuxFilter = state.RemuxFilter
+		if state.RemuxFilterVersion != "" {
+			s.RemuxFilterVersion = state.RemuxFilterVersion
+		}
 	}
 	s.ClientIP = state.ClientIP
 	if value := normalizeClientMetadataValue(state.ClientName, 128); value != "" {
@@ -914,6 +926,8 @@ func snapshotSessionStreamStateLocked(s *Session) SessionStreamState {
 		AudioTrackIndex:        s.AudioTrackIndex,
 		TranscodeAudio:         s.TranscodeAudio,
 		RemuxDVMode:            s.RemuxDVMode,
+		RemuxFilter:            s.RemuxFilter,
+		RemuxFilterVersion:     s.RemuxFilterVersion,
 		ClientIP:               s.ClientIP,
 		ClientName:             s.ClientName,
 		ClientVersion:          s.ClientVersion,
@@ -941,6 +955,8 @@ func restoreSessionStreamStateLocked(s *Session, state SessionStreamState) {
 	s.AudioTrackIndex = state.AudioTrackIndex
 	s.TranscodeAudio = state.TranscodeAudio
 	s.RemuxDVMode = state.RemuxDVMode
+	s.RemuxFilter = state.RemuxFilter
+	s.RemuxFilterVersion = state.RemuxFilterVersion
 	s.ClientIP = state.ClientIP
 	s.ClientName = state.ClientName
 	s.ClientVersion = state.ClientVersion

--- a/internal/playback/session_test.go
+++ b/internal/playback/session_test.go
@@ -1390,17 +1390,22 @@ func TestLegacyStreamUpdateKeepsReplacementReservation(t *testing.T) {
 	}
 }
 
-// A full v3 route description owns RemuxDVMode: a replan that lands on a
-// non-DV source must clear a stale strip mode, while legacy partial updates
-// must not clobber one.
-func TestUpdateStreamStateClearsRemuxDVModeOnRouteSet(t *testing.T) {
+// A full v3 route description owns every remux recipe: a replan that lands on
+// an ordinary source must clear stale DV and HEVC-resume behavior, while
+// legacy partial updates must not clobber either one.
+func TestUpdateStreamStateClearsRemuxRecipesOnRouteSet(t *testing.T) {
 	sm := playback.NewSessionManager(5, 2)
 
 	session, err := sm.StartSession(1, "profile-1", 100, playback.PlayRemux, false)
 	if err != nil {
 		t.Fatalf("StartSession: %v", err)
 	}
-	if err := sm.UpdateStreamState(session.ID, playback.SessionStreamState{RemuxDVMode: playback.RemuxDVStripToHDR10V3, TranscodeRouteSet: true}); err != nil {
+	if err := sm.UpdateStreamState(session.ID, playback.SessionStreamState{
+		RemuxDVMode:        playback.RemuxDVStripToHDR10V3,
+		RemuxFilter:        playback.HEVCResumeLeadingPictureBitstreamFilter,
+		RemuxFilterVersion: playback.TransformationServerHEVCResumeLeadingPictureDropVersionV3,
+		TranscodeRouteSet:  true,
+	}); err != nil {
 		t.Fatalf("UpdateStreamState(set): %v", err)
 	}
 
@@ -1415,6 +1420,9 @@ func TestUpdateStreamStateClearsRemuxDVModeOnRouteSet(t *testing.T) {
 	if got.RemuxDVMode != playback.RemuxDVStripToHDR10V3 {
 		t.Fatalf("RemuxDVMode after legacy update = %q, want strip_to_hdr10", got.RemuxDVMode)
 	}
+	if got.RemuxFilter != playback.HEVCResumeLeadingPictureBitstreamFilter || got.RemuxFilterVersion != playback.TransformationServerHEVCResumeLeadingPictureDropVersionV3 {
+		t.Fatalf("HEVC resume recipe after legacy update = %q@%q", got.RemuxFilter, got.RemuxFilterVersion)
+	}
 
 	// v3 route-set update for a non-DV source: mode clears.
 	if err := sm.UpdateStreamState(session.ID, playback.SessionStreamState{TranscodeRouteSet: true}); err != nil {
@@ -1426,5 +1434,8 @@ func TestUpdateStreamStateClearsRemuxDVModeOnRouteSet(t *testing.T) {
 	}
 	if got.RemuxDVMode != "" {
 		t.Fatalf("RemuxDVMode after route-set update = %q, want cleared", got.RemuxDVMode)
+	}
+	if got.RemuxFilter != "" || got.RemuxFilterVersion != "" {
+		t.Fatalf("HEVC resume recipe after route-set update = %q@%q, want cleared", got.RemuxFilter, got.RemuxFilterVersion)
 	}
 }

--- a/internal/playback/testdata/protocol_v3/capability_response.json
+++ b/internal/playback/testdata/protocol_v3/capability_response.json
@@ -40,6 +40,14 @@
       ]
     },
     {
+      "name": "server_hevc_resume_leading_picture_drop",
+      "executor": "server",
+      "recipe_version": "1",
+      "validated_claims": [
+        "resume_leading_pictures_removed"
+      ]
+    },
+    {
       "name": "video_to_h264",
       "executor": "server",
       "recipe_version": "2",

--- a/internal/playback/transcode_manager.go
+++ b/internal/playback/transcode_manager.go
@@ -417,6 +417,8 @@ func (m *TranscodeManager) ReconstructSession(ctx context.Context, sessionID str
 		AudioTrackIndex:        card.AudioTrackIndex,
 		TranscodeAudio:         card.TranscodeAudio,
 		RemuxDVMode:            card.RemuxDVMode,
+		RemuxFilter:            card.VideoBitstreamFilter,
+		RemuxFilterVersion:     card.RemuxFilterVersion,
 		TargetResolution:       card.TargetResolution,
 		TargetVideoCodec:       card.TargetCodecVideo,
 		TargetAudioCodec:       card.TargetCodecAudio,

--- a/internal/playback/transcode_manager_test.go
+++ b/internal/playback/transcode_manager_test.go
@@ -121,12 +121,17 @@ func TestLoadOrReconstructSession(t *testing.T) {
 		reg := &fakeSessionRegistry{}
 		m := newMgr(reg)
 		card := NewRemuxRecipeCard("s", 5, "p", 77, true, 2)
+		card.VideoBitstreamFilter = HEVCResumeLeadingPictureBitstreamFilter
+		card.RemuxFilterVersion = TransformationServerHEVCResumeLeadingPictureDropVersionV3
 		got, status := m.LoadOrReconstructSession(ctx, reg.GetSession, "s", 5, cardPtr(card))
 		if status != SessionLoaded || got == nil {
 			t.Fatalf("status=%v session=%+v", status, got)
 		}
 		if got.PlayMethod != PlayRemux || got.MediaFileID != 77 || !got.TranscodeAudio || got.AudioTrackIndex != 2 {
 			t.Fatalf("reconstructed remux session wrong: %+v", got)
+		}
+		if got.RemuxFilter != HEVCResumeLeadingPictureBitstreamFilter || got.RemuxFilterVersion != TransformationServerHEVCResumeLeadingPictureDropVersionV3 {
+			t.Fatalf("reconstructed remux recipe wrong: %+v", got)
 		}
 		if _, err := reg.GetSession("s"); err != nil {
 			t.Fatalf("reconstructed session not registered: %v", err)

--- a/internal/playback/transformations_v3.go
+++ b/internal/playback/transformations_v3.go
@@ -28,17 +28,41 @@ func ProbeTransformationRegistryV3(ctx context.Context, ffmpegPath string) *Tran
 	// capability advertised here holds for the binary that later runs.
 	ffmpegPath = ResolveFFmpegPath(ffmpegPath)
 	bsfCtx, cancelBSF := context.WithTimeout(ctx, 3*time.Second)
-	bsfs, _ := exec.CommandContext(bsfCtx, ffmpegPath, "-hide_banner", "-bsfs").Output()
+	bsfs, bsfErr := exec.CommandContext(bsfCtx, ffmpegPath, "-hide_banner", "-bsfs").Output()
 	cancelBSF()
+	noiseRecipeAvailable := bsfErr == nil && bitstreamFilterAvailableV3(bsfs, "noise") &&
+		supportsHEVCResumeLeadingPictureRecipeV3(ctx, ffmpegPath)
 	encoderCtx, cancelEncoders := context.WithTimeout(ctx, 3*time.Second)
 	encoders, _ := exec.CommandContext(encoderCtx, ffmpegPath, "-hide_banner", "-encoders").Output()
 	cancelEncoders()
 	_, ffmpegErr := exec.LookPath(ffmpegPath)
 	return NewTransformationRegistryV3([]TransformationSpecV3{
 		{Name: TransformationServerDV7HDR10V3, RecipeVersion: "1", Available: bytes.Contains(bsfs, []byte("dovi_rpu")), RequiredCapability: "ffmpeg_bsf:dovi_rpu", PromisedDynamicRange: DynamicRangeHDR10V3, ValidatedClaims: DV7ToHDR10ClaimsV3(), TerminalReason: TerminalDVConversionUnsupportedV3},
+		{Name: TransformationServerHEVCResumeLeadingPictureDropV3, RecipeVersion: TransformationServerHEVCResumeLeadingPictureDropVersionV3, Available: noiseRecipeAvailable, RequiredCapability: "ffmpeg_bsf:noise.drop", ValidatedClaims: []string{ClaimResumeLeadingPicturesRemovedV3}},
 		{Name: TransformationAudioToAACV3, RecipeVersion: "1", Available: ffmpegErr == nil && bytes.Contains(encoders, []byte(" aac ")), RequiredCapability: "ffmpeg_encoder:aac", ValidatedClaims: []string{ClaimAudioDecodeV3}, TerminalReason: TerminalAudioConversionUnsupportedV3},
 		{Name: TransformationVideoToH264V3, RecipeVersion: TransformationVideoToH264RecipeVersionV3, Available: ffmpegErr == nil && h264EncoderAvailableV3(encoders), RequiredCapability: "ffmpeg_encoder:h264", PromisedDynamicRange: DynamicRangeSDRV3, ValidatedClaims: []string{ClaimH264DecodeV3}, TerminalReason: TerminalVideoConversionUnsupportedV3},
 	})
+}
+
+func bitstreamFilterAvailableV3(listing []byte, name string) bool {
+	for _, field := range strings.Fields(string(listing)) {
+		if field == name {
+			return true
+		}
+	}
+	return false
+}
+
+// supportsHEVCResumeLeadingPictureRecipeV3 distinguishes the expression-based
+// noise BSF from older builds that expose only the integer dropamount option.
+// The drop option was introduced with the startpts and key expression variables
+// used by this recipe. A bounded live probe also catches a replaced/downgraded
+// executable before a remux commits response headers.
+func supportsHEVCResumeLeadingPictureRecipeV3(ctx context.Context, ffmpegPath string) bool {
+	probeCtx, cancel := context.WithTimeout(ctx, 3*time.Second)
+	defer cancel()
+	help, err := exec.CommandContext(probeCtx, ffmpegPath, "-hide_banner", "-h", "bsf=noise").CombinedOutput()
+	return err == nil && bitstreamFilterAvailableV3(help, "-drop")
 }
 
 // h264EncodersV3 lists every H.264 encoder the transcode pipeline can select
@@ -71,6 +95,14 @@ func (r *TransformationRegistryV3) Available(name string) bool {
 	}
 	spec, ok := r.entries[name]
 	return ok && spec.Available
+}
+
+func (r *TransformationRegistryV3) AvailableRecipe(name, recipeVersion string) bool {
+	if r == nil {
+		return false
+	}
+	spec, ok := r.entries[name]
+	return ok && spec.Available && spec.RecipeVersion == recipeVersion
 }
 
 // WithAdvertised returns a registry whose known specs are additionally marked

--- a/internal/playback/transformations_v3_test.go
+++ b/internal/playback/transformations_v3_test.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"path/filepath"
 	"testing"
+	"time"
 )
 
 func TestH264EncoderAvailabilityAcceptsAnyPipelineEncoder(t *testing.T) {
@@ -47,4 +48,63 @@ func TestProbeTransformationRegistryV3AdvertisesVideoToH264RecipeVersion2(t *tes
 		}
 	}
 	t.Fatal("video_to_h264 was not advertised")
+}
+
+func TestProbeTransformationRegistryV3AdvertisesExactNoiseBitstreamFilter(t *testing.T) {
+	cases := []struct {
+		name      string
+		listing   string
+		help      string
+		bsfsExit  string
+		helpExit  string
+		available bool
+	}{
+		{name: "exact recipe", listing: "noise", help: "-drop <string>", bsfsExit: "0", helpExit: "0", available: true},
+		{name: "among filters", listing: "dovi_rpu noise filter_units", help: "-amount <string> -drop <string> -dropamount <int>", bsfsExit: "0", helpExit: "0", available: true},
+		{name: "legacy integer option", listing: "noise", help: "-dropamount <int>", bsfsExit: "0", helpExit: "0", available: false},
+		{name: "substring only", listing: "noise_reduction", help: "-drop <string>", bsfsExit: "0", helpExit: "0", available: false},
+		{name: "missing", listing: "dovi_rpu", help: "-drop <string>", bsfsExit: "0", helpExit: "0", available: false},
+		{name: "partial BSF output on failure", listing: "noise", help: "-drop <string>", bsfsExit: "1", helpExit: "0", available: false},
+		{name: "partial help output on failure", listing: "noise", help: "-drop <string>", bsfsExit: "0", helpExit: "1", available: false},
+	}
+	for _, test := range cases {
+		t.Run(test.name, func(t *testing.T) {
+			ffmpeg := filepath.Join(t.TempDir(), "ffmpeg")
+			script := "#!/bin/sh\ncase \"$2\" in\n-bsfs) printf '%s\\n' '" + test.listing + "'; exit " + test.bsfsExit + " ;;\n-h) printf '%s\\n' '" + test.help + "'; exit " + test.helpExit + " ;;\n-encoders) : ;;\nesac\n"
+			if err := os.WriteFile(ffmpeg, []byte(script), 0o755); err != nil {
+				t.Fatal(err)
+			}
+
+			registry := ProbeTransformationRegistryV3(context.Background(), ffmpeg)
+			if got := registry.Available(TransformationServerHEVCResumeLeadingPictureDropV3); got != test.available {
+				t.Fatalf("resume transformation available = %v, want %v", got, test.available)
+			}
+			advertised := false
+			for _, transformation := range registry.Advertised() {
+				if transformation.Name == TransformationServerHEVCResumeLeadingPictureDropV3 &&
+					(transformation.RecipeVersion != TransformationServerHEVCResumeLeadingPictureDropVersionV3 || len(transformation.ValidatedClaims) != 1 || transformation.ValidatedClaims[0] != ClaimResumeLeadingPicturesRemovedV3) {
+					t.Fatalf("resume transformation = %#v", transformation)
+				}
+				if transformation.Name == TransformationServerHEVCResumeLeadingPictureDropV3 {
+					advertised = true
+				}
+			}
+			if advertised != test.available {
+				t.Fatalf("resume transformation advertised = %v, want %v", advertised, test.available)
+			}
+		})
+	}
+}
+
+func TestSupportsHEVCResumeLeadingPictureRecipeRejectsPartialHelpOnTimeout(t *testing.T) {
+	ffmpeg := filepath.Join(t.TempDir(), "ffmpeg")
+	script := "#!/bin/sh\nprintf '%s\\n' '-drop <string>'\nexec sleep 1\n"
+	if err := os.WriteFile(ffmpeg, []byte(script), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 20*time.Millisecond)
+	defer cancel()
+	if supportsHEVCResumeLeadingPictureRecipeV3(ctx, ffmpeg) {
+		t.Fatal("timed-out help probe accepted partial output")
+	}
 }

--- a/internal/proxy/server.go
+++ b/internal/proxy/server.go
@@ -124,6 +124,8 @@ func (s *Server) Handler() http.Handler {
 		r.Get("/stream/direct/{token}", s.handleDirectPlay)
 		r.Head("/stream/remux/{token}", s.handleRemux)
 		r.Get("/stream/remux/{token}", s.handleRemux)
+		r.Head(playback.RemuxRecipeStreamPathV3+"{token}", s.handleRemux)
+		r.Get(playback.RemuxRecipeStreamPathV3+"{token}", s.handleRemux)
 		r.Head("/stream/transcode/{token}/master.m3u8", s.handleTranscodeManifest)
 		r.Get("/stream/transcode/{token}/master.m3u8", s.handleTranscodeManifest)
 		r.Get("/stream/transcode/{token}/segment/{name}", s.handleTranscodeSegment)
@@ -367,6 +369,9 @@ func (s *Server) handleRemux(w http.ResponseWriter, r *http.Request) {
 	// server's stream handler serves the same claims.
 	_ = playback.ServeRemuxWithOptions(w, r, claims.MediaPath, "mp4", seekSeconds, claims.TranscodeAudio, claims.AudioTrackIndex, claims.DVProfile, playback.RemuxServeOptions{
 		DVMode:                 playback.RemuxDVMode(claims.RemuxDVMode),
+		VideoBitstreamFilter:   claims.VideoBitstreamFilter,
+		VideoFilterVersion:     claims.RemuxFilterVersion,
+		SourceVideoCodec:       claims.SourceVideoCodec,
 		FFmpegPath:             s.watcher.Config().Playback.FFmpegPath,
 		ContentType:            playback.RemuxContentType(claims.AudioOnly),
 		AudioOnly:              claims.AudioOnly,

--- a/internal/streamtoken/token.go
+++ b/internal/streamtoken/token.go
@@ -43,6 +43,9 @@ type Claims struct {
 	// RemuxDVMode freezes whether a Profile 7 remux preserves or strips DV
 	// metadata. Empty is the legacy auto behavior for old tokens.
 	RemuxDVMode string `json:"dvm,omitempty"`
+	// RemuxFilterVersion identifies the signed remux-only
+	// recipe carried in VideoBitstreamFilter. Both must match exactly.
+	RemuxFilterVersion string `json:"rfv,omitempty"`
 
 	// Ownership / authorization lookup keys (re-resolved at reconstruct).
 	// Not trust assertions.
@@ -60,9 +63,9 @@ type Claims struct {
 	// ids are internal attempt handles and must never become saved filenames.
 	DownloadFilename string `json:"dfn,omitempty"`
 
-	// Reconstruction recipe — the byte-affecting encode parameters, mirroring the
-	// former playback.RecipeCard. Zero for direct/remux tokens, which reconstruct
-	// from identity alone plus the client-supplied position.
+	// Reconstruction recipe — the byte-affecting parameters that mirror the
+	// former playback.RecipeCard. Direct tokens leave them zero; remux tokens use
+	// the source codec and versioned bitstream filter fields when required.
 	SourceVideoCodec       string  `json:"svc,omitempty"`
 	SourceVideoProfile     string  `json:"svp,omitempty"`
 	SourceVideoBitDepth    int     `json:"svb,omitempty"`


### PR DESCRIPTION
## Problem
Closes #658

On macOS Firefox, resuming an HEVC `server_remux_progressive` stream at an open-GOP boundary can fail in VideoToolbox before the browser decodes a frame. Current protocol-v3 behavior correctly reanchors the copied stream at a preceding keyframe and then applies `timeline.player_start_seconds`; suppressing that browser seek avoids neither the malformed boundary nor the loss of exact resume semantics.

I reproduced this on current `main` with headed Firefox 153.0.4. With the same source, timestamp, chunked fMP4 transport, and exact browser seek, the unfiltered stream reached `MEDIA_ERR_DECODE` with zero decoded frames. Adding only `noise=drop=lt(pts\,startpts)*not(key)` produced `seeked` and `playing`, with 59 decoded frames, none dropped, and no media error. The full raw A/B output is in #658.

## Approach

I modelled the boundary normalization as the named, versioned server transformation `server_hevc_resume_leading_picture_drop@1` rather than exposing an arbitrary FFmpeg expression or adding a client workaround.

- Planning is limited to macOS Firefox, HEVC, and progressive remux. HLS, direct play, transcodes, other browsers, other operating systems, and zero-start media bytes are unchanged.
- The plan freezes the recipe from the initial start so later seeks keep the same execution contract. FFmpeg applies the filter only when the server seek is non-zero; the browser still applies `player_start_seconds` for exact resume.
- Capability discovery requires both the exact `noise` BSF and its expression-based `drop` option. The serving process repeats the bounded option probe before headers, so a replaced or downgraded FFmpeg fails before claiming a successful stream.
- The filter and recipe version survive session updates, restart reconstruction, signed stream tokens, and proxy execution. Source codec validation uses the same canonical primary-track metadata as planning.
- Recipe-bearing remuxes use the additive `/stream/remux-v3/` route. Older API or proxy binaries do not mount it, so mixed-version deployments fail closed instead of silently dropping the recipe.
- If the recipe is unavailable, the unsafe progressive candidate is skipped and the existing HLS/encoded fallback policy continues.

There is no web-client source change in this PR.

## Testing

Controlled headed-browser A/B from #658:

```text
baseline: MEDIA_ERR_DECODE, AppleVTDecoder ffffbae2, 0 decoded frames
filter-only: seeked, playing, 59 decoded, 0 dropped, no media error
```

The deployed Jellyfin FFmpeg exposes the required expression option:

```text
Bit stream filter noise
noise AVOptions:
  -amount            <string>     ...VA...B..
  -drop              <string>     ...VA...B..
  -dropamount        <int>        ...VA...B.. (from 0 to INT_MAX) (default 0)
```

Focused and relevant package verification:

```text
$ GOWORK=off go test ./internal/playback -skip '<four documented macOS NVENC probe flakes>' -count=1
ok  github.com/Silo-Server/silo-server/internal/playback  17.184s

$ GOWORK=off go test ./internal/proxy -count=1
ok  github.com/Silo-Server/silo-server/internal/proxy  0.557s

$ GOWORK=off go test ./internal/streamtoken ./cmd/playbackfixtures -count=1
?   github.com/Silo-Server/silo-server/internal/streamtoken      [no test files]
?   github.com/Silo-Server/silo-server/cmd/playbackfixtures     [no test files]

$ GOWORK=off go vet ./internal/playback ./internal/proxy ./internal/streamtoken ./cmd/playbackfixtures
(no output)

$ make verify-playback-fixtures
playback fixtures are current

$ make verify-local-paths
scripts/check-local-path-leaks.sh
```

The unfiltered full playback package run reached only the four known macOS NVENC smoke-probe failures documented by the repository; the complete remainder passes with those four skipped. Local compilation of `internal/api/handlers` was blocked by the machine's missing libvips/pkg-config dependency, so I also ran the fork's full Linux CI workflow on exact commit `e262a88f`. All Go, web, and docs jobs passed, including build, gofmt, vet, changed-lines lint, protocol fixtures, full tests, web lint/format/typecheck/build/tests, and local-path hygiene: [CI run 31941066928](https://github.com/blurbery/silo-server/actions/runs/31941066928). No `web/` files changed.

### AI Disclosure
- Tool(s): OpenAI Codex
- Model(s): gpt-5
- Involvement: AI-assisted implementation, test design, documentation, and review. I directed the scope and validated the playback behavior with the real macOS Firefox A/B described in #658.
- Adversarial review: The prescribed companion script was unavailable, so I used independent adversarial Codex passes. They found and I fixed four material gaps: exact FFmpeg option probing and live revalidation, mixed-version route fencing, canonical source-codec validation, and an unnegotiated client-quirk emission. The final passes found no remaining code-level issue. They noted that the real headed-browser A/B, rather than a committed binary fixture, proves the media behavior; an executable packet fixture would be useful follow-up coverage but was not judged a blocker.

## Risks & follow-up

Custom or older FFmpeg builds that lack expression-based `noise.drop` will no longer receive this progressive-copy recipe and will use existing fallback routing. The change is additive and requires no migration or coordinated Android/Apple client update. A small deterministic open-GOP fixture could strengthen byte-level regression coverage later; the current user-visible behavior is covered by the controlled real-browser A/B in #658.

## Checklist
- [x] I ran an adversarial AI review of the diff and summarized findings above.
- [x] I ran the repo verify commands: `make lint`, `cd web && pnpm run lint`, `cd web && pnpm run format:check`, and relevant `go test ./...`.

🤖 Developed with assistance from OpenAI Codex


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added improved HEVC resume playback for Firefox on macOS.
  * Resume handling now removes unsafe leading pictures after seeking while preserving playback position.
  * Added versioned remux streaming routes and capability reporting.
* **Bug Fixes**
  * Playback now validates remux recipes and rejects unsupported or outdated configurations.
  * Added fallback to HLS when progressive remuxing cannot safely support the requested playback.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->