### PR TITLE
fix(requests): fill poster hover overlay

### DIFF
--- a/web/src/components/RequestPosterCard.test.tsx
+++ b/web/src/components/RequestPosterCard.test.tsx
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest";
 import { renderToStaticMarkup } from "react-dom/server";
+import { render, screen } from "@testing-library/react";
 import { MemoryRouter } from "react-router";
 import RequestPosterCard from "./RequestPosterCard";
 import type { RequestMediaResult } from "@/api/types";
@@ -27,6 +28,24 @@ describe("RequestPosterCard (discover variant)", () => {
     // Must render an actual <button> with the "Request" label, not just any "Request"
     // substring (the /requests/... URL would match a naive includes check).
     expect(markup).toMatch(/<button[^>]*>[\s\S]*?Request[\s\S]*?<\/button>/);
+  });
+
+  it("contains the hover overlay inside the poster frame", () => {
+    render(
+      <MemoryRouter>
+        <RequestPosterCard
+          variant="discover"
+          item={requestable}
+          isSubmitting={false}
+          onRequest={() => {}}
+        />
+      </MemoryRouter>,
+    );
+
+    const overlay = screen.getByTestId("request-poster-hover-overlay");
+    const posterFrame = overlay.closest(".media-card-image");
+
+    expect(posterFrame).not.toBeNull();
   });
 
   it("does not render the hover Request button when onRequest is omitted", () => {

--- a/web/src/components/RequestPosterCard.tsx
+++ b/web/src/components/RequestPosterCard.tsx
@@ -90,6 +90,12 @@ function DiscoverCard({
               reserveLibrarySpace={Boolean(item.library_content_id)}
             />
           )}
+          {requestable && onRequest && (
+            <div
+              data-testid="request-poster-hover-overlay"
+              className="pointer-events-none absolute inset-0 translate-y-2 bg-gradient-to-t from-black/85 via-black/45 to-transparent opacity-0 transition-all duration-200 ease-out group-focus-within/req-card:translate-y-0 group-focus-within/req-card:opacity-100 group-hover/req-card:translate-y-0 group-hover/req-card:opacity-100"
+            />
+          )}
         </PosterFrame>
 
         <CardMeta
@@ -101,7 +107,7 @@ function DiscoverCard({
       </Link>
 
       {requestable && onRequest && (
-        <div className="pointer-events-none absolute inset-x-0 top-0 flex aspect-[2/3] translate-y-2 items-end justify-center bg-gradient-to-t from-black/85 via-black/45 to-transparent p-3 opacity-0 transition-all duration-200 ease-out group-focus-within/req-card:translate-y-0 group-focus-within/req-card:opacity-100 group-hover/req-card:translate-y-0 group-hover/req-card:opacity-100">
+        <div className="pointer-events-none absolute top-0 left-0 flex aspect-[2/3] w-full translate-y-2 items-end justify-center pb-3 opacity-0 transition-all duration-200 ease-out group-focus-within/req-card:translate-y-0 group-focus-within/req-card:opacity-100 group-hover/req-card:translate-y-0 group-hover/req-card:opacity-100">
           <button
             type="button"
             disabled={Boolean(isSubmitting)}


### PR DESCRIPTION
## Problem
Follow-up to #7.

The Requests discovery card rendered its hover gradient in an absolutely positioned sibling of the poster frame. Its sizing could diverge from the poster, leaving a visible uncovered strip and shifting the Request button away from the poster center.

## Approach

- Render the black hover gradient inside the poster's clipped `.media-card-image` frame with `inset-0`.
- Keep the interactive Request button outside the card link to preserve valid DOM nesting and existing click propagation behavior.
- Make the button layer explicitly match the poster width.
- Add a regression test that requires the hover overlay to be contained by the poster frame.

## Testing

```text
$ pnpm exec vitest run src/components/RequestPosterCard.test.tsx
Test Files  1 passed (1)
Tests       3 passed (3)

$ pnpm exec eslint src/components/RequestPosterCard.tsx src/components/RequestPosterCard.test.tsx
(exit 0)

$ pnpm run format:check
All matched files use Prettier code style!

$ pnpm run build
✓ built in 15.79s

$ make verify-local-paths
scripts/check-local-path-leaks.sh
(exit 0)
```

Browser verification on a real rendered card measured the poster, gradient overlay, and button layer at the same `184 × 276 px` hover rectangle. The browser console had no warnings or errors.

Repository-wide baseline checks were also run and are not clean on this checkout:

```text
$ make test
FAIL internal/jellycompat
  TestBeginWebOperationRecoversDeadProcessLock
  TestBeginWebOperationRejectsLiveProcessLock
FAIL internal/playback
  TestResolveHWAccelWithFFmpegAutoPrefersNVENCOverIntel
  TestResolveHWAccelWithFFmpegUsesNVIDIADeviceNodesWithoutDRM
  TestFFmpegSupportsNVENCCachesByFFmpegPath
  TestFFmpegSupportsNVENCSmokeProbeUsesSafeFrameDimensions
FAIL internal/transcodenode
  TestHandleDownloadPrepareTrackingDoesNotBlockAndRemovesAfterTrack

$ make lint
300 pre-existing Go findings across untouched files

$ pnpm run lint
0 errors, 151 pre-existing warnings
```

The two jellycompat process-lock failures reproduce when that untouched package is run independently. The changed frontend files pass their focused lint, test, formatting, build, and browser checks.

### AI Disclosure
- Tool(s): Codex desktop app
- Model(s): gpt-5.6
- Involvement: fully AI-generated
- Adversarial review: A separate AI reviewer inspected the committed diff for requirements alignment, DOM validity, accessibility, styling edge cases, testing, and production readiness. It found no Critical, Important, or Minor issues. The review confirmed the gradient is clipped by the poster frame, the button remains outside the link with unchanged behavior, and the regression test protects the intended containment.

## Checklist
- [x] I ran an adversarial AI review of the diff and summarized findings above.
- [x] I ran the repo verify commands and documented the existing repository-wide failures above; focused checks for the changed frontend files pass.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved the hover and focus appearance of request cards by keeping the gradient overlay contained within the poster frame.
  - Preserved request button alignment and smooth hover transitions across the full card width.

- **Tests**
  - Added coverage confirming the request card hover overlay remains within the poster frame.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->