### PR TITLE
fix(web): restore test harness compatibility

### DIFF
--- a/web/src/pages/ItemDetail/SeasonContent.test.tsx
+++ b/web/src/pages/ItemDetail/SeasonContent.test.tsx
@@ -67,6 +67,10 @@ vi.mock("@/hooks/useOnViewTranslation", () => ({
   useOnViewTranslation: mocks.useOnViewTranslation,
 }));
 
+vi.mock("@/hooks/useOverlayPrefs", () => ({
+  useOverlayPrefs: () => ({ prefs: null }),
+}));
+
 vi.mock("@/components/MediaItemMenu", () => ({
   default: (props: Record<string, unknown>) => {
     mocks.capturedMediaMenuProps.push(props);

--- a/web/src/pages/setup-wizard/steps/ServerStorageStep.test.tsx
+++ b/web/src/pages/setup-wizard/steps/ServerStorageStep.test.tsx
@@ -5,6 +5,14 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 
 import { ServerStorageStep } from "./ServerStorageStep";
 
+class ResizeObserverStub {
+  observe() {}
+  unobserve() {}
+  disconnect() {}
+}
+
+globalThis.ResizeObserver ??= ResizeObserverStub as unknown as typeof ResizeObserver;
+
 const useSettingsFormMock = vi.fn();
 const useWizardContextMock = vi.fn();
 const useCheckAdminSettingsConnectionMock = vi.fn();

--- a/web/src/player/hooks/useIntroSkipPrompt.test.ts
+++ b/web/src/player/hooks/useIntroSkipPrompt.test.ts
@@ -1,7 +1,7 @@
 // @vitest-environment jsdom
 
 import { act, renderHook } from "@testing-library/react";
-import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, type Mock, vi } from "vitest";
 
 import type { IntroSkipMode } from "../types";
 import {
@@ -19,7 +19,7 @@ interface Props {
 
 describe("useIntroSkipPrompt", () => {
   const intro = { start: 10, end: 20 };
-  let onSeek: ReturnType<typeof vi.fn>;
+  let onSeek: Mock<(seconds: number) => boolean>;
 
   beforeEach(() => {
     vi.useFakeTimers();


### PR DESCRIPTION
## Problem

The Web CI job on current `main` stops during typechecking because the intro-skip test stores an untyped Vitest mock where the hook requires a callable seek function. Once typechecking proceeds, two existing component test harnesses also fail: `SeasonContent` reaches the overlay preferences hook without its query context, and `ServerStorageStep` renders a Radix control without jsdom's missing `ResizeObserver` API.

## Approach

Keep the fix test-only:

- Give the intro seek mock its actual `(seconds: number) => boolean` signature.
- Mock overlay preferences in the isolated `SeasonContent` unit test, which does not exercise overlay behavior.
- Add the same local no-op `ResizeObserver` used by neighboring Radix component tests.

No production code, dependencies, or runtime behavior change.

## Verification

- `pnpm run build` passes.
- `pnpm run lint` reports 0 errors and 151 existing warnings.
- `pnpm run format:check` passes.
- Focused tests: 19/19 pass across the three affected files.
- Full web suite: 2,000/2,000 tests pass.
- `git diff --check origin/main...HEAD` passes.
- Diff, commit metadata, and PR text scans found no local paths, hostnames, credentials, or personal data.

## Risks & follow-up

Low risk. This only restores the test environments and strengthens a mock type; application code is untouched.

After merge, PRs #336 and #368 can be rebased to pick up the fix and return their Web checks to green.

## AI-use disclosure

Implemented with a combination of Claude Code and Codex assistance, with human oversight.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved test isolation for season content overlay preferences.
  * Added compatibility coverage for environments without `ResizeObserver`.
  * Updated mock typing for intro-skip prompt seeking tests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->