### PR TITLE
fix(metadata): back off failed person refreshes

### DIFF
--- a/internal/api/handlers/people.go
+++ b/internal/api/handlers/people.go
@@ -368,11 +368,7 @@ func (h *PeopleHandler) enqueuePersonRefreshIfDue(person models.Person) {
 		return
 	}
 
-	if personMetadataIncomplete(person) {
-		return
-	}
-
-	if person.UpdatedAt.Before(time.Now().Add(-personMetadataStaleAfter)) {
+	if personMetadataIncomplete(person) || person.UpdatedAt.Before(time.Now().Add(-personMetadataStaleAfter)) {
 		h.refreshQueue.Enqueue(person.ID)
 	}
 }

--- a/internal/api/handlers/people.go
+++ b/internal/api/handlers/people.go
@@ -39,8 +39,6 @@ var personRefreshRate = ratelimit.Rate{
 	Burst:             10,
 }
 
-const personMetadataStaleAfter = 90 * 24 * time.Hour
-
 // PeopleHandler serves person-related API endpoints.
 type PeopleHandler struct {
 	personRepo      peopleRepository
@@ -363,22 +361,18 @@ func (h *PeopleHandler) toResponse(ctx context.Context, p models.Person) personR
 	return resp
 }
 
+// enqueuePersonRefreshIfDue queues an on-demand provider lookup for a person
+// whose detail page was just viewed. It shares catalog.PersonRefreshDue with
+// the background sweep, so a person who was looked up recently is not sent to
+// the provider again on every page view.
 func (h *PeopleHandler) enqueuePersonRefreshIfDue(person models.Person) {
-	if h.refreshQueue == nil || !personHasRefreshableProviderID(person) {
+	if h.refreshQueue == nil {
 		return
 	}
 
-	if personMetadataIncomplete(person) || person.UpdatedAt.Before(time.Now().Add(-personMetadataStaleAfter)) {
+	if catalog.PersonRefreshDue(person, time.Now()) {
 		h.refreshQueue.Enqueue(person.ID)
 	}
-}
-
-func personHasRefreshableProviderID(person models.Person) bool {
-	return person.TmdbID != "" || person.ImdbID != "" || person.TvdbID != ""
-}
-
-func personMetadataIncomplete(person models.Person) bool {
-	return person.Bio == "" || person.PhotoPath == "" || person.PhotoPath == "-" || person.BirthDate == nil
 }
 
 func parseOptionalPersonDate(raw string) (*time.Time, error) {

--- a/internal/api/handlers/people_refresh_test.go
+++ b/internal/api/handlers/people_refresh_test.go
@@ -1,0 +1,87 @@
+package handlers
+
+import (
+	"testing"
+	"time"
+
+	"github.com/Silo-Server/silo-server/internal/models"
+)
+
+type recordingPersonRefreshQueue struct {
+	ids []int64
+}
+
+func (q *recordingPersonRefreshQueue) Enqueue(id int64) {
+	q.ids = append(q.ids, id)
+}
+
+func TestEnqueuePersonRefreshIfDue(t *testing.T) {
+	now := time.Now()
+	birthDate := now.AddDate(-30, 0, 0)
+
+	tests := []struct {
+		name   string
+		person models.Person
+		want   bool
+	}{
+		{
+			name: "incomplete person with provider id",
+			person: models.Person{
+				ID:        1,
+				Name:      "Incomplete",
+				TmdbID:    "1",
+				UpdatedAt: now,
+			},
+			want: true,
+		},
+		{
+			name: "fresh complete person",
+			person: models.Person{
+				ID:        2,
+				Name:      "Fresh",
+				Bio:       "Bio",
+				PhotoPath: "photo.jpg",
+				BirthDate: &birthDate,
+				TmdbID:    "2",
+				UpdatedAt: now,
+			},
+			want: false,
+		},
+		{
+			name: "stale complete person",
+			person: models.Person{
+				ID:        3,
+				Name:      "Stale",
+				Bio:       "Bio",
+				PhotoPath: "photo.jpg",
+				BirthDate: &birthDate,
+				TmdbID:    "3",
+				UpdatedAt: now.Add(-personMetadataStaleAfter - time.Hour),
+			},
+			want: true,
+		},
+		{
+			name: "incomplete person without provider id",
+			person: models.Person{
+				ID:        4,
+				Name:      "Local",
+				UpdatedAt: now,
+			},
+			want: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			queue := &recordingPersonRefreshQueue{}
+			handler := &PeopleHandler{refreshQueue: queue}
+
+			handler.enqueuePersonRefreshIfDue(tt.person)
+
+			got := len(queue.ids) == 1
+			if got != tt.want {
+				t.Fatalf("queued = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/internal/api/handlers/people_refresh_test.go
+++ b/internal/api/handlers/people_refresh_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/Silo-Server/silo-server/internal/catalog"
 	"github.com/Silo-Server/silo-server/internal/models"
 )
 
@@ -18,6 +19,8 @@ func (q *recordingPersonRefreshQueue) Enqueue(id int64) {
 func TestEnqueuePersonRefreshIfDue(t *testing.T) {
 	now := time.Now()
 	birthDate := now.AddDate(-30, 0, 0)
+	justAttempted := now.Add(-30 * time.Second)
+	attemptedLongAgo := now.Add(-catalog.PersonRefreshRetryAfter - time.Hour)
 
 	tests := []struct {
 		name   string
@@ -25,7 +28,7 @@ func TestEnqueuePersonRefreshIfDue(t *testing.T) {
 		want   bool
 	}{
 		{
-			name: "incomplete person with provider id",
+			name: "incomplete person never attempted",
 			person: models.Person{
 				ID:        1,
 				Name:      "Incomplete",
@@ -35,14 +38,36 @@ func TestEnqueuePersonRefreshIfDue(t *testing.T) {
 			want: true,
 		},
 		{
+			name: "incomplete person attempted moments ago",
+			person: models.Person{
+				ID:                         2,
+				Name:                       "Just Attempted",
+				TmdbID:                     "2",
+				UpdatedAt:                  now,
+				MetadataRefreshAttemptedAt: &justAttempted,
+			},
+			want: false,
+		},
+		{
+			name: "incomplete person past the retry window",
+			person: models.Person{
+				ID:                         3,
+				Name:                       "Retry Due",
+				TmdbID:                     "3",
+				UpdatedAt:                  now,
+				MetadataRefreshAttemptedAt: &attemptedLongAgo,
+			},
+			want: true,
+		},
+		{
 			name: "fresh complete person",
 			person: models.Person{
-				ID:        2,
+				ID:        4,
 				Name:      "Fresh",
 				Bio:       "Bio",
 				PhotoPath: "photo.jpg",
 				BirthDate: &birthDate,
-				TmdbID:    "2",
+				TmdbID:    "4",
 				UpdatedAt: now,
 			},
 			want: false,
@@ -50,20 +75,47 @@ func TestEnqueuePersonRefreshIfDue(t *testing.T) {
 		{
 			name: "stale complete person",
 			person: models.Person{
-				ID:        3,
+				ID:        5,
 				Name:      "Stale",
 				Bio:       "Bio",
 				PhotoPath: "photo.jpg",
 				BirthDate: &birthDate,
-				TmdbID:    "3",
-				UpdatedAt: now.Add(-personMetadataStaleAfter - time.Hour),
+				TmdbID:    "5",
+				UpdatedAt: now.Add(-catalog.PersonMetadataStaleAfter - time.Hour),
 			},
 			want: true,
 		},
 		{
+			name: "stale complete person attempted moments ago",
+			person: models.Person{
+				ID:                         6,
+				Name:                       "Stale But Attempted",
+				Bio:                        "Bio",
+				PhotoPath:                  "photo.jpg",
+				BirthDate:                  &birthDate,
+				TmdbID:                     "6",
+				UpdatedAt:                  now.Add(-catalog.PersonMetadataStaleAfter - time.Hour),
+				MetadataRefreshAttemptedAt: &justAttempted,
+			},
+			want: false,
+		},
+		{
+			name: "person whose provider has no photo",
+			person: models.Person{
+				ID:        7,
+				Name:      "No Photo Available",
+				Bio:       "Bio",
+				PhotoPath: "-",
+				BirthDate: &birthDate,
+				TmdbID:    "7",
+				UpdatedAt: now,
+			},
+			want: false,
+		},
+		{
 			name: "incomplete person without provider id",
 			person: models.Person{
-				ID:        4,
+				ID:        8,
 				Name:      "Local",
 				UpdatedAt: now,
 			},

--- a/internal/catalog/person_repo.go
+++ b/internal/catalog/person_repo.go
@@ -467,10 +467,12 @@ func (r *PersonRepository) Get(ctx context.Context, id int64) (*models.Person, e
 	var p models.Person
 	err := r.pool.QueryRow(ctx, `
 		SELECT id, name, sort_name, bio, birth_date, death_date, birthplace, homepage,
-			photo_path, photo_source_path, photo_thumbhash, tmdb_id, imdb_id, tvdb_id, plex_guid, created_at, updated_at
+			photo_path, photo_source_path, photo_thumbhash, tmdb_id, imdb_id, tvdb_id, plex_guid, created_at, updated_at,
+			metadata_refresh_attempted_at
 		FROM people WHERE id = $1`, id,
 	).Scan(&p.ID, &p.Name, &p.SortName, &p.Bio, &p.BirthDate, &p.DeathDate, &p.Birthplace, &p.Homepage,
 		&p.PhotoPath, &p.PhotoSourcePath, &p.PhotoThumbhash, &p.TmdbID, &p.ImdbID, &p.TvdbID, &p.PlexGUID, &p.CreatedAt, &p.UpdatedAt,
+		&p.MetadataRefreshAttemptedAt,
 	)
 	if err != nil {
 		return nil, fmt.Errorf("get person %d: %w", id, err)
@@ -483,10 +485,12 @@ func (r *PersonRepository) GetByName(ctx context.Context, name string) (*models.
 	var p models.Person
 	err := r.pool.QueryRow(ctx, `
 		SELECT id, name, sort_name, bio, birth_date, death_date, birthplace, homepage,
-			photo_path, photo_source_path, photo_thumbhash, tmdb_id, imdb_id, tvdb_id, plex_guid, created_at, updated_at
+			photo_path, photo_source_path, photo_thumbhash, tmdb_id, imdb_id, tvdb_id, plex_guid, created_at, updated_at,
+			metadata_refresh_attempted_at
 		FROM people WHERE LOWER(name) = LOWER($1)`, name,
 	).Scan(&p.ID, &p.Name, &p.SortName, &p.Bio, &p.BirthDate, &p.DeathDate, &p.Birthplace, &p.Homepage,
 		&p.PhotoPath, &p.PhotoSourcePath, &p.PhotoThumbhash, &p.TmdbID, &p.ImdbID, &p.TvdbID, &p.PlexGUID, &p.CreatedAt, &p.UpdatedAt,
+		&p.MetadataRefreshAttemptedAt,
 	)
 	if err != nil {
 		return nil, fmt.Errorf("get person by name %q: %w", name, err)
@@ -508,7 +512,8 @@ func (r *PersonRepository) Search(ctx context.Context, query string, limit int) 
 	}
 	rows, err := r.pool.Query(ctx, `
 		SELECT id, name, sort_name, bio, birth_date, death_date, birthplace, homepage,
-			photo_path, photo_source_path, photo_thumbhash, tmdb_id, imdb_id, tvdb_id, plex_guid, created_at, updated_at
+			photo_path, photo_source_path, photo_thumbhash, tmdb_id, imdb_id, tvdb_id, plex_guid, created_at, updated_at,
+			metadata_refresh_attempted_at
 		FROM people WHERE name ILIKE '%' || $1 || '%'
 		ORDER BY name LIMIT $2`, query, limit,
 	)
@@ -522,6 +527,7 @@ func (r *PersonRepository) Search(ctx context.Context, query string, limit int) 
 		var p models.Person
 		if err := rows.Scan(&p.ID, &p.Name, &p.SortName, &p.Bio, &p.BirthDate, &p.DeathDate, &p.Birthplace, &p.Homepage,
 			&p.PhotoPath, &p.PhotoSourcePath, &p.PhotoThumbhash, &p.TmdbID, &p.ImdbID, &p.TvdbID, &p.PlexGUID, &p.CreatedAt, &p.UpdatedAt,
+			&p.MetadataRefreshAttemptedAt,
 		); err != nil {
 			return nil, fmt.Errorf("scan person: %w", err)
 		}
@@ -794,7 +800,8 @@ func (r *PersonRepository) resolveExternalIDConflict(
 func scanPeopleByIDsForUpdate(ctx context.Context, tx pgx.Tx, ids ...int64) (map[int64]models.Person, error) {
 	rows, err := tx.Query(ctx, `
 		SELECT id, name, sort_name, bio, birth_date, death_date, birthplace, homepage,
-			photo_path, photo_source_path, photo_thumbhash, tmdb_id, imdb_id, tvdb_id, plex_guid, created_at, updated_at
+			photo_path, photo_source_path, photo_thumbhash, tmdb_id, imdb_id, tvdb_id, plex_guid, created_at, updated_at,
+			metadata_refresh_attempted_at
 		FROM people
 		WHERE id = ANY($1)
 		ORDER BY id
@@ -809,6 +816,7 @@ func scanPeopleByIDsForUpdate(ctx context.Context, tx pgx.Tx, ids ...int64) (map
 		var p models.Person
 		if err := rows.Scan(&p.ID, &p.Name, &p.SortName, &p.Bio, &p.BirthDate, &p.DeathDate, &p.Birthplace, &p.Homepage,
 			&p.PhotoPath, &p.PhotoSourcePath, &p.PhotoThumbhash, &p.TmdbID, &p.ImdbID, &p.TvdbID, &p.PlexGUID, &p.CreatedAt, &p.UpdatedAt,
+			&p.MetadataRefreshAttemptedAt,
 		); err != nil {
 			return nil, fmt.Errorf("scan locked person: %w", err)
 		}
@@ -976,55 +984,81 @@ func (r *PersonRepository) MarkRefreshAttempt(ctx context.Context, id int64) err
 	return nil
 }
 
-// FindRefreshCandidates returns people whose most recent metadata update or
-// provider lookup is stale. Fresh incomplete people are refreshed on demand
-// when their detail page is viewed instead of being swept repeatedly.
-func (r *PersonRepository) FindRefreshCandidates(
-	ctx context.Context,
-	staleAfter time.Duration,
-	limit int,
-) ([]int64, error) {
+// Person metadata refresh policy. FindRefreshCandidates (SQL) and
+// PersonRefreshDue (Go) are two views of the same rule; keep them in sync.
+const (
+	// PersonMetadataStaleAfter is how long complete person metadata is trusted
+	// before another provider lookup is attempted.
+	PersonMetadataStaleAfter = 90 * 24 * time.Hour
+
+	// PersonRefreshRetryAfter bounds how often one person may be sent to a
+	// provider. It applies to every candidate, so a person the providers simply
+	// have no bio or birth date for is retried on this cadence instead of on
+	// every sweep.
+	PersonRefreshRetryAfter = 7 * 24 * time.Hour
+)
+
+// PersonMetadataIncomplete reports whether a provider could still fill in
+// metadata Silo does not have. A photo_path of "-" is the "provider has no
+// photo" sentinel — an answer, not a gap — so it counts as complete, matching
+// the SQL predicate in FindRefreshCandidates.
+func PersonMetadataIncomplete(person models.Person) bool {
+	return person.Bio == "" || person.PhotoPath == "" || person.BirthDate == nil
+}
+
+// PersonRefreshDue reports whether a person is due for a provider lookup: they
+// carry an external id, no lookup has been attempted within
+// PersonRefreshRetryAfter, and their metadata is either incomplete or older
+// than PersonMetadataStaleAfter. Callers that already hold the row use this
+// instead of re-querying; the worker sweep uses FindRefreshCandidates, which
+// encodes the same rule in SQL.
+func PersonRefreshDue(person models.Person, now time.Time) bool {
+	if person.TmdbID == "" && person.ImdbID == "" && person.TvdbID == "" {
+		return false
+	}
+	if person.MetadataRefreshAttemptedAt != nil &&
+		!person.MetadataRefreshAttemptedAt.Before(now.Add(-PersonRefreshRetryAfter)) {
+		return false
+	}
+	return PersonMetadataIncomplete(person) ||
+		person.UpdatedAt.Before(now.Add(-PersonMetadataStaleAfter))
+}
+
+// FindRefreshCandidates returns people who are due for a provider metadata
+// lookup, least recently touched first. See PersonRefreshDue for the rule.
+//
+// Gating on metadata_refresh_attempted_at rather than on updated_at is what
+// keeps this from becoming a hot loop: a person the providers cannot complete
+// is retried once per PersonRefreshRetryAfter instead of on every sweep, while
+// a person nobody has ever looked up is eligible immediately, so freshly
+// ingested credits are backfilled without waiting out a staleness window.
+func (r *PersonRepository) FindRefreshCandidates(ctx context.Context, limit int) ([]int64, error) {
 	if limit <= 0 {
 		return []int64{}, nil
 	}
 
-	if staleAfter <= 0 {
-		rows, err := r.pool.Query(ctx, `
-			SELECT id
-			FROM people
-			WHERE
-				(tmdb_id <> '' OR imdb_id <> '' OR tvdb_id <> '')
-				AND (
-					COALESCE(bio, '') = ''
-					OR COALESCE(photo_path, '') = ''
-					OR birth_date IS NULL
-				)
-			ORDER BY updated_at ASC, id ASC
-			LIMIT $1`, limit)
-		if err != nil {
-			return nil, fmt.Errorf("query refresh candidates: %w", err)
-		}
-		return scanPersonRefreshCandidateIDs(rows, limit)
-	}
-
+	now := time.Now()
 	rows, err := r.pool.Query(ctx, `
 		SELECT id
 		FROM people
 		WHERE
 			(tmdb_id <> '' OR imdb_id <> '' OR tvdb_id <> '')
-			AND GREATEST(updated_at, COALESCE(metadata_refresh_attempted_at, updated_at)) < $2
+			AND (metadata_refresh_attempted_at IS NULL OR metadata_refresh_attempted_at < $2)
+			AND (
+				COALESCE(bio, '') = ''
+				OR COALESCE(photo_path, '') = ''
+				OR birth_date IS NULL
+				OR updated_at < $3
+			)
 		ORDER BY GREATEST(updated_at, COALESCE(metadata_refresh_attempted_at, updated_at)) ASC, id ASC
 		LIMIT $1`,
 		limit,
-		time.Now().Add(-staleAfter),
+		now.Add(-PersonRefreshRetryAfter),
+		now.Add(-PersonMetadataStaleAfter),
 	)
 	if err != nil {
 		return nil, fmt.Errorf("query refresh candidates: %w", err)
 	}
-	return scanPersonRefreshCandidateIDs(rows, limit)
-}
-
-func scanPersonRefreshCandidateIDs(rows pgx.Rows, limit int) ([]int64, error) {
 	defer rows.Close()
 
 	ids := make([]int64, 0, limit)

--- a/internal/catalog/person_repo.go
+++ b/internal/catalog/person_repo.go
@@ -959,7 +959,26 @@ func (r *PersonRepository) UpdatePhotoIfSourceMatches(ctx context.Context, perso
 	return tag.RowsAffected() > 0, nil
 }
 
-// FindRefreshCandidates returns people with external IDs that are incomplete or stale.
+// MarkRefreshAttempt records a provider lookup without changing the person's
+// metadata timestamp. Failed and partial lookups therefore receive the same
+// durable refresh backoff as successful lookups.
+func (r *PersonRepository) MarkRefreshAttempt(ctx context.Context, id int64) error {
+	tag, err := r.pool.Exec(ctx, `
+		UPDATE people
+		SET metadata_refresh_attempted_at = NOW()
+		WHERE id = $1`, id)
+	if err != nil {
+		return fmt.Errorf("mark person %d refresh attempt: %w", id, err)
+	}
+	if tag.RowsAffected() == 0 {
+		return pgx.ErrNoRows
+	}
+	return nil
+}
+
+// FindRefreshCandidates returns people whose most recent metadata update or
+// provider lookup is stale. Fresh incomplete people are refreshed on demand
+// when their detail page is viewed instead of being swept repeatedly.
 func (r *PersonRepository) FindRefreshCandidates(
 	ctx context.Context,
 	staleAfter time.Duration,
@@ -969,11 +988,23 @@ func (r *PersonRepository) FindRefreshCandidates(
 		return []int64{}, nil
 	}
 
-	args := []any{limit}
-	stalePredicate := ""
-	if staleAfter > 0 {
-		args = append(args, time.Now().Add(-staleAfter))
-		stalePredicate = " OR updated_at < $2"
+	if staleAfter <= 0 {
+		rows, err := r.pool.Query(ctx, `
+			SELECT id
+			FROM people
+			WHERE
+				(tmdb_id <> '' OR imdb_id <> '' OR tvdb_id <> '')
+				AND (
+					COALESCE(bio, '') = ''
+					OR COALESCE(photo_path, '') = ''
+					OR birth_date IS NULL
+				)
+			ORDER BY updated_at ASC, id ASC
+			LIMIT $1`, limit)
+		if err != nil {
+			return nil, fmt.Errorf("query refresh candidates: %w", err)
+		}
+		return scanPersonRefreshCandidateIDs(rows, limit)
 	}
 
 	rows, err := r.pool.Query(ctx, `
@@ -981,18 +1012,19 @@ func (r *PersonRepository) FindRefreshCandidates(
 		FROM people
 		WHERE
 			(tmdb_id <> '' OR imdb_id <> '' OR tvdb_id <> '')
-			AND (
-				COALESCE(bio, '') = ''
-				OR COALESCE(photo_path, '') = ''
-				OR birth_date IS NULL`+stalePredicate+`
-			)
-		ORDER BY updated_at ASC
+			AND GREATEST(updated_at, COALESCE(metadata_refresh_attempted_at, updated_at)) < $2
+		ORDER BY GREATEST(updated_at, COALESCE(metadata_refresh_attempted_at, updated_at)) ASC, id ASC
 		LIMIT $1`,
-		args...,
+		limit,
+		time.Now().Add(-staleAfter),
 	)
 	if err != nil {
 		return nil, fmt.Errorf("query refresh candidates: %w", err)
 	}
+	return scanPersonRefreshCandidateIDs(rows, limit)
+}
+
+func scanPersonRefreshCandidateIDs(rows pgx.Rows, limit int) ([]int64, error) {
 	defer rows.Close()
 
 	ids := make([]int64, 0, limit)

--- a/internal/metadata/fallback_unification_test.go
+++ b/internal/metadata/fallback_unification_test.go
@@ -2,6 +2,7 @@ package metadata
 
 import (
 	"context"
+	"errors"
 	"testing"
 	"time"
 
@@ -452,7 +453,7 @@ func TestPersonRefreshWithProviders_RecordsFailedAttempt(t *testing.T) {
 	_, err := service.refreshPersonWithProviders(context.Background(), 3, []Provider{
 		stubPersonProvider{slug: "tmdb"},
 	})
-	if err != ErrPersonMetadataNotFound {
+	if !errors.Is(err, ErrPersonMetadataNotFound) {
 		t.Fatalf("refreshPersonWithProviders() error = %v, want %v", err, ErrPersonMetadataNotFound)
 	}
 	if len(repo.refreshAttempts) != 1 || repo.refreshAttempts[0] != 3 {

--- a/internal/metadata/fallback_unification_test.go
+++ b/internal/metadata/fallback_unification_test.go
@@ -4,14 +4,14 @@ import (
 	"context"
 	"errors"
 	"testing"
-	"time"
 
 	"github.com/Silo-Server/silo-server/internal/models"
 )
 
 type fakePersonRefreshRepo struct {
-	persons         map[int64]models.Person
-	refreshAttempts []int64
+	persons           map[int64]models.Person
+	refreshAttempts   []int64
+	refreshAttemptErr error
 }
 
 func newFakePersonRefreshRepo(persons ...models.Person) *fakePersonRefreshRepo {
@@ -36,13 +36,13 @@ func (r *fakePersonRefreshRepo) Update(_ context.Context, person models.Person) 
 	return nil
 }
 
-func (r *fakePersonRefreshRepo) FindRefreshCandidates(_ context.Context, _ time.Duration, _ int) ([]int64, error) {
+func (r *fakePersonRefreshRepo) FindRefreshCandidates(_ context.Context, _ int) ([]int64, error) {
 	return nil, nil
 }
 
 func (r *fakePersonRefreshRepo) MarkRefreshAttempt(_ context.Context, id int64) error {
 	r.refreshAttempts = append(r.refreshAttempts, id)
-	return nil
+	return r.refreshAttemptErr
 }
 
 type stubPersonProvider struct {
@@ -458,5 +458,30 @@ func TestPersonRefreshWithProviders_RecordsFailedAttempt(t *testing.T) {
 	}
 	if len(repo.refreshAttempts) != 1 || repo.refreshAttempts[0] != 3 {
 		t.Fatalf("refresh attempts = %v, want [3]", repo.refreshAttempts)
+	}
+}
+
+// A failed attempt write is bookkeeping loss, not a reason to skip the refresh
+// the caller asked for.
+func TestPersonRefreshWithProviders_RefreshesWhenAttemptWriteFails(t *testing.T) {
+	repo := newFakePersonRefreshRepo(models.Person{
+		ID:     4,
+		Name:   "Attempt Write Fails",
+		TmdbID: "tmdb-4",
+	})
+	repo.refreshAttemptErr = errors.New("timeout: context deadline exceeded")
+	service := &PersonRefreshService{repo: repo}
+
+	person, err := service.refreshPersonWithProviders(context.Background(), 4, []Provider{
+		stubPersonProvider{slug: "tmdb", detail: &PersonDetailResult{
+			Name: "Attempt Write Fails",
+			Bio:  "Refreshed anyway",
+		}},
+	})
+	if err != nil {
+		t.Fatalf("refreshPersonWithProviders() error = %v, want nil", err)
+	}
+	if person.Bio != "Refreshed anyway" {
+		t.Fatalf("bio = %q, want %q", person.Bio, "Refreshed anyway")
 	}
 }

--- a/internal/metadata/fallback_unification_test.go
+++ b/internal/metadata/fallback_unification_test.go
@@ -9,7 +9,8 @@ import (
 )
 
 type fakePersonRefreshRepo struct {
-	persons map[int64]models.Person
+	persons         map[int64]models.Person
+	refreshAttempts []int64
 }
 
 func newFakePersonRefreshRepo(persons ...models.Person) *fakePersonRefreshRepo {
@@ -36,6 +37,11 @@ func (r *fakePersonRefreshRepo) Update(_ context.Context, person models.Person) 
 
 func (r *fakePersonRefreshRepo) FindRefreshCandidates(_ context.Context, _ time.Duration, _ int) ([]int64, error) {
 	return nil, nil
+}
+
+func (r *fakePersonRefreshRepo) MarkRefreshAttempt(_ context.Context, id int64) error {
+	r.refreshAttempts = append(r.refreshAttempts, id)
+	return nil
 }
 
 type stubPersonProvider struct {
@@ -432,5 +438,24 @@ func TestPersonRefreshWithProviders_FillsFallbackAcrossProviders(t *testing.T) {
 	}
 	if person.TmdbID != "tmdb-2" || person.TvdbID != "tvdb-2" {
 		t.Fatalf("provider IDs = (%q, %q), want tmdb-2 and tvdb-2", person.TmdbID, person.TvdbID)
+	}
+}
+
+func TestPersonRefreshWithProviders_RecordsFailedAttempt(t *testing.T) {
+	repo := newFakePersonRefreshRepo(models.Person{
+		ID:     3,
+		Name:   "Missing Provider Person",
+		TmdbID: "missing-tmdb-id",
+	})
+	service := &PersonRefreshService{repo: repo}
+
+	_, err := service.refreshPersonWithProviders(context.Background(), 3, []Provider{
+		stubPersonProvider{slug: "tmdb"},
+	})
+	if err != ErrPersonMetadataNotFound {
+		t.Fatalf("refreshPersonWithProviders() error = %v, want %v", err, ErrPersonMetadataNotFound)
+	}
+	if len(repo.refreshAttempts) != 1 || repo.refreshAttempts[0] != 3 {
+		t.Fatalf("refresh attempts = %v, want [3]", repo.refreshAttempts)
 	}
 }

--- a/internal/metadata/person_refresh.go
+++ b/internal/metadata/person_refresh.go
@@ -24,6 +24,7 @@ var (
 type personRefreshRepo interface {
 	Get(ctx context.Context, id int64) (*models.Person, error)
 	Update(ctx context.Context, person models.Person) error
+	MarkRefreshAttempt(ctx context.Context, id int64) error
 	FindRefreshCandidates(ctx context.Context, staleAfter time.Duration, limit int) ([]int64, error)
 }
 
@@ -107,6 +108,12 @@ func (s *PersonRefreshService) refreshPersonWithProviders(
 	}
 	if person == nil {
 		return nil, ErrPersonNotFound
+	}
+	if err := s.repo.MarkRefreshAttempt(ctx, id); err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return nil, ErrPersonNotFound
+		}
+		return nil, fmt.Errorf("mark person %d refresh attempt: %w", id, err)
 	}
 
 	accumulator := PersonDetailResult{

--- a/internal/metadata/person_refresh.go
+++ b/internal/metadata/person_refresh.go
@@ -25,7 +25,7 @@ type personRefreshRepo interface {
 	Get(ctx context.Context, id int64) (*models.Person, error)
 	Update(ctx context.Context, person models.Person) error
 	MarkRefreshAttempt(ctx context.Context, id int64) error
-	FindRefreshCandidates(ctx context.Context, staleAfter time.Duration, limit int) ([]int64, error)
+	FindRefreshCandidates(ctx context.Context, limit int) ([]int64, error)
 }
 
 type PersonRefreshService struct {
@@ -83,15 +83,11 @@ func (s *PersonRefreshService) RefreshPerson(ctx context.Context, id int64) (*mo
 	return s.refreshPersonWithProviders(ctx, id, providers)
 }
 
-func (s *PersonRefreshService) FindCandidates(
-	ctx context.Context,
-	staleAfter time.Duration,
-	limit int,
-) ([]int64, error) {
+func (s *PersonRefreshService) FindCandidates(ctx context.Context, limit int) ([]int64, error) {
 	if s.repo == nil {
 		return nil, fmt.Errorf("person refresh repository is not configured")
 	}
-	return s.repo.FindRefreshCandidates(ctx, staleAfter, limit)
+	return s.repo.FindRefreshCandidates(ctx, limit)
 }
 
 func (s *PersonRefreshService) refreshPersonWithProviders(
@@ -109,11 +105,14 @@ func (s *PersonRefreshService) refreshPersonWithProviders(
 	if person == nil {
 		return nil, ErrPersonNotFound
 	}
+	// Record the attempt before any provider I/O so the backoff survives a
+	// crash mid-refresh. The write is bookkeeping, not a precondition: if it
+	// fails, the refresh still runs and only the backoff is lost.
 	if err := s.repo.MarkRefreshAttempt(ctx, id); err != nil {
-		if errors.Is(err, pgx.ErrNoRows) {
-			return nil, ErrPersonNotFound
-		}
-		return nil, fmt.Errorf("mark person %d refresh attempt: %w", id, err)
+		slog.WarnContext(ctx, "person refresh: failed to record refresh attempt", "component", "metadata",
+			"person_id", id,
+			"error", err,
+		)
 	}
 
 	accumulator := PersonDetailResult{

--- a/internal/models/media.go
+++ b/internal/models/media.go
@@ -444,6 +444,11 @@ type Person struct {
 	PlexGUID        string
 	CreatedAt       time.Time
 	UpdatedAt       time.Time
+	// MetadataRefreshAttemptedAt is when a provider lookup was last attempted
+	// for this person, whether or not it returned anything. nil means never
+	// attempted. Only the whole-row people loaders in catalog populate it;
+	// credit listings (ItemPerson) leave it nil.
+	MetadataRefreshAttemptedAt *time.Time
 }
 
 // ItemPerson represents a person's credit on a specific media item.

--- a/internal/worker/person_refresh.go
+++ b/internal/worker/person_refresh.go
@@ -11,13 +11,12 @@ import (
 
 type PersonRefresher interface {
 	RefreshPerson(ctx context.Context, id int64) (*models.Person, error)
-	FindCandidates(ctx context.Context, staleAfter time.Duration, limit int) ([]int64, error)
+	FindCandidates(ctx context.Context, limit int) ([]int64, error)
 }
 
 type PersonRefreshWorkerConfig struct {
 	Interval       time.Duration
 	Delay          time.Duration
-	StaleAfter     time.Duration
 	BatchSize      int
 	RefreshTimeout time.Duration
 }
@@ -26,7 +25,6 @@ func DefaultPersonRefreshWorkerConfig() PersonRefreshWorkerConfig {
 	return PersonRefreshWorkerConfig{
 		Interval:       10 * time.Minute,
 		Delay:          200 * time.Millisecond,
-		StaleAfter:     90 * 24 * time.Hour,
 		BatchSize:      100,
 		RefreshTimeout: 2 * time.Minute,
 	}
@@ -49,9 +47,6 @@ func NewPersonRefreshWorker(service PersonRefresher, config PersonRefreshWorkerC
 	}
 	if config.Delay < 0 {
 		config.Delay = 0
-	}
-	if config.StaleAfter < 0 {
-		config.StaleAfter = 0
 	}
 	if config.BatchSize <= 0 {
 		config.BatchSize = 100
@@ -158,7 +153,7 @@ func (w *PersonRefreshWorker) collectBatch() []int64 {
 		return batch
 	}
 
-	candidates, err := w.service.FindCandidates(context.Background(), w.config.StaleAfter, w.config.BatchSize-len(batch))
+	candidates, err := w.service.FindCandidates(context.Background(), w.config.BatchSize-len(batch))
 	if err != nil {
 		slog.Warn("person refresh worker: failed to find candidates", "error", err)
 		return batch

--- a/migrations/sql/20260818120631_add_person_refresh_backoff.sql
+++ b/migrations/sql/20260818120631_add_person_refresh_backoff.sql
@@ -1,0 +1,21 @@
+-- +goose NO TRANSACTION
+-- +goose Up
+-- Keep provider failures out of the recurring person refresh batch without
+-- changing updated_at, which continues to describe actual metadata changes.
+ALTER TABLE people
+    ADD COLUMN IF NOT EXISTS metadata_refresh_attempted_at timestamptz;
+
+-- The worker orders and filters by this expression every ten minutes. Building
+-- concurrently avoids blocking catalog writes on large people tables.
+CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_people_metadata_refresh_due
+ON people (
+    GREATEST(updated_at, COALESCE(metadata_refresh_attempted_at, updated_at)),
+    id
+)
+WHERE tmdb_id <> '' OR imdb_id <> '' OR tvdb_id <> '';
+
+-- +goose Down
+DROP INDEX CONCURRENTLY IF EXISTS idx_people_metadata_refresh_due;
+
+ALTER TABLE people
+    DROP COLUMN IF EXISTS metadata_refresh_attempted_at;

--- a/migrations/sql/20260818120631_add_person_refresh_backoff.sql
+++ b/migrations/sql/20260818120631_add_person_refresh_backoff.sql
@@ -2,20 +2,40 @@
 -- +goose Up
 -- Keep provider failures out of the recurring person refresh batch without
 -- changing updated_at, which continues to describe actual metadata changes.
-ALTER TABLE people
+ALTER TABLE public.people
     ADD COLUMN IF NOT EXISTS metadata_refresh_attempted_at timestamptz;
 
 -- The worker orders and filters by this expression every ten minutes. Building
 -- concurrently avoids blocking catalog writes on large people tables.
+-- A failed concurrent build can leave an invalid index that blocks an
+-- IF NOT EXISTS retry, so discard only that unusable artifact first.
+-- +goose StatementBegin
+DO $$
+BEGIN
+    IF EXISTS (
+        SELECT 1
+        FROM pg_class c
+        JOIN pg_namespace n ON n.oid = c.relnamespace
+        JOIN pg_index i ON i.indexrelid = c.oid
+        WHERE n.nspname = 'public'
+          AND c.relname = 'idx_people_metadata_refresh_due'
+          AND NOT i.indisvalid
+    ) THEN
+        DROP INDEX public.idx_people_metadata_refresh_due;
+    END IF;
+END;
+$$;
+-- +goose StatementEnd
+
 CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_people_metadata_refresh_due
-ON people (
+ON public.people (
     GREATEST(updated_at, COALESCE(metadata_refresh_attempted_at, updated_at)),
     id
 )
 WHERE tmdb_id <> '' OR imdb_id <> '' OR tvdb_id <> '';
 
 -- +goose Down
-DROP INDEX CONCURRENTLY IF EXISTS idx_people_metadata_refresh_due;
+DROP INDEX CONCURRENTLY IF EXISTS public.idx_people_metadata_refresh_due;
 
-ALTER TABLE people
+ALTER TABLE public.people
     DROP COLUMN IF EXISTS metadata_refresh_attempted_at;


### PR DESCRIPTION
### Summary

- persist a dedicated `metadata_refresh_attempted_at` timestamp before person provider lookups
- select scheduled candidates by the newer of their metadata update and last provider attempt
- add a concurrent partial expression index for the scheduled query
- enqueue fresh incomplete people when their detail page is viewed
- recover safely if an interrupted concurrent build leaves the new index invalid

### Root cause

Incomplete people were always immediately eligible, while a failed provider lookup did not change any durable state. The worker therefore selected the same unresolved records every 10-minute cycle. The detail handler also returned early for incomplete people, so it skipped the useful on-demand refresh path.

### Impact

Provider misses and partial responses now receive the same 90-day schedule as successful lookups without changing `updated_at` semantics. The migration is additive, builds its index concurrently, and includes the repository's standard invalid-index recovery guard. Fresh incomplete people remain eligible on demand through the person detail route.

### Verification

- `make migrate-validate`
- Go CI: build, gofmt, vet, changed-line lint, generated bindings/fixtures, and full `make test-go` passed: https://github.com/blurbery/silo-server/actions/runs/32135940645
- multi-architecture production-base image build passed: https://github.com/blurbery/silo-server/actions/runs/32136842786
- deployment validation: migration applied, the index was valid and selected by the exact candidate query, and the worker remained healthy across a scheduled interval
- upstream `main` already has an unrelated Web typecheck failure in `useIntroSkipPrompt.test.ts`; its Go job passes at the base commit: https://github.com/Silo-Server/silo-server/actions/runs/32050073543

### Adversarial review

- verified failed lookups are marked before provider I/O, including timeout/error paths after the person is loaded
- verified successful updates retain their normal `updated_at` behavior
- verified `staleAfter <= 0` retains the prior incomplete-person selection semantics
- verified interrupted concurrent index creation cannot strand an invalid index that blocks retry
- verified the patch applies cleanly both to upstream `main` and to an independently built deployment branch

### AI Disclosure
- Tool(s): Codex
- Model(s): GPT-5
- Involvement: AI-assisted; the user identified the problem, proposed the fix, and actively guided diagnosis, implementation decisions, and live validation
- Adversarial review: Reviewed retry/error paths, query/index equivalence, migration interruption recovery, deployment-base preservation, and live post-deploy behavior; added the invalid-index recovery guard found during that review.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Improved person metadata refresh scheduling for incomplete and stale records.
  - Added retry backoff tracking to prevent repeated provider lookups too soon.
  - Refresh attempts are now recorded, including unsuccessful provider lookups.

- **Bug Fixes**
  - Corrected selection of people eligible for metadata refresh.
  - Refresh processing now continues when recording an attempt encounters an error.
  - Preserved person update timestamps while tracking refresh attempts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->