### PR TITLE
fix(playback): let original_http carry a client-selected audio track (client_audio_track_selection_v1)

### DIFF
--- a/docs/architecture/playback-protocol-v3.md
+++ b/docs/architecture/playback-protocol-v3.md
@@ -442,6 +442,16 @@ because "the user turned HLS off" and "this device has no HLS player" call for
 different degradation warnings and different diagnostics. A class the client
 omits entirely is unavailable — the server will not guess.
 
+One `features` string is load-bearing on `original_http`:
+`client_audio_track_selection_v1` declares that this delivery's executor selects
+`selected_tracks.audio` itself out of the container it is handed. Without it, a
+source-preserving route is only planned when the selection *is* the container's
+default track — the bytes are untouched, so a client that ignores the selection
+would silently play the default, usually in the wrong language, and the server
+routes it through a remux that maps the chosen stream explicitly instead. A
+client advertising the string must honour the selection on every original
+delivery, including after a `track_change` replan.
+
 `stream.header_refresh` tells the client what to do when the stream URL's auth
 expires: `none` means the URL is stable for the session, `session` means
 re-request headers from `header_refresh_url` rather than restarting playback.

--- a/internal/playback/plan_v3.go
+++ b/internal/playback/plan_v3.go
@@ -338,7 +338,7 @@ func PlanPlaybackV3(input PlannerInputV3) PlannerResultV3 {
 	}
 
 	if source.DVProfile != 7 && deliveryAvailableV3(input.Request, DeliveryClassOriginalHTTPV3) && containerOK && videoOK && rangeOK && audioOK && quality.PreservesSource &&
-		audioSelectionUsesContainerDefaultV3(file, input.AudioTrackIndex) && !subtitle.RequiresBurn {
+		originalAudioSelectionRealizableV3(input.Request, file, input.AudioTrackIndex) && !subtitle.RequiresBurn {
 		plan := base
 		plan.Delivery = DeliveryOriginalHTTPV3
 		plan.Stream = StreamV3{Protocol: StreamHTTPProgressiveV3, Container: source.Container, MIMEType: MimeFromExtension(file.FilePath), Headers: map[string]string{}, HeaderRefresh: HeaderRefreshNoneV3}
@@ -1033,6 +1033,21 @@ func audioSelectionUsesContainerDefaultV3(file *models.MediaFile, audioIndex int
 		audioIndex = defaultIndex
 	}
 	return audioIndex == defaultIndex
+}
+
+// originalAudioSelectionRealizableV3 reports whether the original_http delivery
+// can actually realize the selected audio track. The container default always
+// can. Anything else needs the delivery's executor to select the track itself:
+// the plan names it in selected_tracks, but the bytes are untouched, so a
+// client that ignores that selection would silently play the container default
+// instead — usually the wrong language, which is exactly what the remux route
+// exists to prevent. Clients that do perform the selection (AVPlayer media
+// selection, ExoPlayer track selection) say so per delivery, and forcing them
+// through a remux costs the source's own container, its Dolby Vision, and — on
+// deliveries the device cannot execute — playback itself.
+func originalAudioSelectionRealizableV3(request StartRequestV3, file *models.MediaFile, audioIndex int) bool {
+	return audioSelectionUsesContainerDefaultV3(file, audioIndex) ||
+		deliverySupportsFeatureV3(request, DeliveryClassOriginalHTTPV3, ClientAudioTrackSelectionV3)
 }
 
 func finalizePlanIdentityV3(plan *PlanV3, attemptID string, outputContextID string) {

--- a/internal/playback/plan_v3_original_audio_selection_test.go
+++ b/internal/playback/plan_v3_original_audio_selection_test.go
@@ -1,0 +1,178 @@
+package playback
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"testing"
+
+	"github.com/Silo-Server/silo-server/internal/models"
+)
+
+// appleDVFixtureRow mirrors the media_files columns the planner reads, with the
+// JSONB track columns decoded exactly as the repository decodes them.
+type appleDVFixtureRow struct {
+	ID                int                       `json:"id"`
+	ContentID         string                    `json:"content_id"`
+	Container         string                    `json:"container"`
+	CodecVideo        string                    `json:"codec_video"`
+	CodecAudio        string                    `json:"codec_audio"`
+	Resolution        string                    `json:"resolution"`
+	HDR               bool                      `json:"hdr"`
+	Bitrate           int                       `json:"bitrate"`
+	Duration          int                       `json:"duration"`
+	VideoTracks       []models.VideoTrack       `json:"video_tracks"`
+	AudioTracks       []models.AudioTrack       `json:"audio_tracks"`
+	SubtitleTracks    []models.SubtitleTrack    `json:"subtitle_tracks"`
+	ExternalSubtitles []models.ExternalSubtitle `json:"external_subtitles"`
+}
+
+func (r appleDVFixtureRow) mediaFile() *models.MediaFile {
+	return &models.MediaFile{
+		ID: r.ID, ContentID: r.ContentID, Container: r.Container,
+		CodecVideo: r.CodecVideo, CodecAudio: r.CodecAudio, Resolution: r.Resolution,
+		HDR: r.HDR, Bitrate: r.Bitrate, Duration: r.Duration,
+		FilePath:          fmt.Sprintf("/media/movies/file-%d.%s", r.ID, r.Container),
+		VideoTracks:       r.VideoTracks,
+		AudioTracks:       r.AudioTracks,
+		SubtitleTracks:    r.SubtitleTracks,
+		ExternalSubtitles: r.ExternalSubtitles,
+	}
+}
+
+func loadAppleDVFixturesV3(t *testing.T) (StartRequestV3, map[int]*models.MediaFile) {
+	t.Helper()
+	raw, err := os.ReadFile("testdata/apple_tvos_dv_start_request.json")
+	if err != nil {
+		t.Fatalf("read start request fixture: %v", err)
+	}
+	var request StartRequestV3
+	if err := json.Unmarshal(raw, &request); err != nil {
+		t.Fatalf("decode start request fixture: %v", err)
+	}
+	rawRows, err := os.ReadFile("testdata/apple_tvos_dv_media_files.json")
+	if err != nil {
+		t.Fatalf("read media file fixture: %v", err)
+	}
+	var rows []appleDVFixtureRow
+	if err := json.Unmarshal(rawRows, &rows); err != nil {
+		t.Fatalf("decode media file fixture: %v", err)
+	}
+	files := make(map[int]*models.MediaFile, len(rows))
+	for _, row := range rows {
+		files[row.ID] = row.mediaFile()
+	}
+	return request, files
+}
+
+// mirrorShippingAppleClientV3 upgrades the captured probe request to everything
+// the shipping tvOS client sends (silo-apple ApplePlaybackV3Capabilities.swift):
+// the full client_features list, the per-delivery executor features, and the
+// eight-channel ceiling. The captured probe omitted them, and a route gate must
+// be proven against what the real client advertises.
+func mirrorShippingAppleClientV3(request *StartRequestV3, originalHTTPFeatures []string) {
+	request.ClientFeatures = []string{
+		FeaturePlaybackPlanV3,
+		FeatureClientVideoTransforms,
+		FeatureRouteDiagnostics,
+		FeatureDeviceQuirksV3,
+		FeatureSeekReanchorV3,
+		FeatureDirectStreamResumeV3,
+	}
+	features := map[string][]string{
+		DeliveryClassOriginalHTTPV3: originalHTTPFeatures,
+		DeliveryClassProgressiveV3:  {"apple_avplayer_progressive"},
+		DeliveryClassHLSV3:          {"apple_avplayer_hls"},
+	}
+	// Rebuild the map so each case owns its deliveries: the fixture request is
+	// copied by value and would otherwise share one map across subtests.
+	deliveries := make(map[string]DeliveryCapabilityV3, len(request.ClientPlaybackContext.Deliveries))
+	for class, capability := range request.ClientPlaybackContext.Deliveries {
+		capability.Features = features[class]
+		channels := 8
+		capability.MaxChannels = &channels
+		deliveries[class] = capability
+	}
+	request.ClientPlaybackContext.Deliveries = deliveries
+}
+
+func appleDVPlannerInputV3(request StartRequestV3, file *models.MediaFile, audioIndex int) PlannerInputV3 {
+	request.FileID = file.ID
+	return PlannerInputV3{
+		Request: request, RequestedFile: file, EffectiveFile: file, AudioTrackIndex: audioIndex,
+		Settings: PlannerSettingsV3{TranscodeEnabled: true},
+		Registry: testTransformationRegistryV3(),
+	}
+}
+
+// TestPlanPlaybackV3AppleOriginalHTTPHonorsClientAudioTrackSelection replays the
+// three real dev media rows that exposed the defect: an Apple TV that advertises
+// Dolby Vision was handed server_remux_progressive for the two DV titles and
+// original_http for the HDR10 title. Dolby Vision was coincidental — the DV rows
+// carry a non-English container default (zh, de) while the HDR10 row's only
+// alternative is Spanish, so the profile's English audio preference resolved to
+// a non-default track only for the DV rows.
+func TestPlanPlaybackV3AppleOriginalHTTPHonorsClientAudioTrackSelection(t *testing.T) {
+	baseRequest, files := loadAppleDVFixturesV3(t)
+
+	tests := []struct {
+		name string
+		// audioIndex is what the handler's preferredAudioTrackIndexV3 resolves
+		// for this profile: the English track, which is the container default
+		// only for the HDR10 row (it has no English track at all).
+		fileID     int
+		audioIndex int
+		wantDV     bool
+	}{
+		{name: "dolby vision profile 5", fileID: 741, audioIndex: 1, wantDV: true},
+		{name: "dolby vision profile 8", fileID: 223792, audioIndex: 1, wantDV: true},
+		{name: "hdr10 container default", fileID: 223805, audioIndex: 0},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			file := files[test.fileID]
+			if file == nil {
+				t.Fatalf("fixture row %d missing", test.fileID)
+			}
+			request := baseRequest
+			mirrorShippingAppleClientV3(&request, []string{
+				"apple_native_direct", "apple_local_loopback", "apple_playercore",
+				ClientAudioTrackSelectionV3,
+			})
+			result := PlanPlaybackV3(appleDVPlannerInputV3(request, file, test.audioIndex))
+			if result.Plan == nil || result.Plan.Delivery != DeliveryOriginalHTTPV3 ||
+				result.Plan.DecisionReason != "validated_original_playback" || result.PlayMethod != PlayDirect {
+				t.Fatalf("result = %s", ExplainPlannerResultV3(result))
+			}
+			if result.Plan.Stream.Container != "mkv" {
+				t.Fatalf("stream container = %q, want mkv", result.Plan.Stream.Container)
+			}
+			// The route only holds because the plan tells the client which
+			// embedded audio track to select from the untouched container.
+			if result.Plan.SelectedTracks.Audio == nil || result.Plan.SelectedTracks.Audio.Index == nil ||
+				*result.Plan.SelectedTracks.Audio.Index != test.audioIndex {
+				t.Fatalf("selected audio = %#v, want index %d", result.Plan.SelectedTracks.Audio, test.audioIndex)
+			}
+			if result.Plan.Claims.Video.DolbyVision != test.wantDV {
+				t.Fatalf("dolby vision claim = %#v, want %v", result.Plan.Claims.Video, test.wantDV)
+			}
+		})
+	}
+}
+
+// TestPlanPlaybackV3OriginalHTTPKeepsRemuxWithoutAudioSelectionFeature pins the
+// other half of the gate: a client that does not advertise the selection
+// capability still gets the remux that maps its chosen track explicitly.
+func TestPlanPlaybackV3OriginalHTTPKeepsRemuxWithoutAudioSelectionFeature(t *testing.T) {
+	baseRequest, files := loadAppleDVFixturesV3(t)
+	file := files[741]
+	if file == nil {
+		t.Fatal("fixture row 741 missing")
+	}
+	request := baseRequest
+	mirrorShippingAppleClientV3(&request, []string{"apple_native_direct", "apple_local_loopback", "apple_playercore"})
+	result := PlanPlaybackV3(appleDVPlannerInputV3(request, file, 1))
+	if result.Plan == nil || result.Plan.Delivery != DeliveryRemuxProgressiveV3 {
+		t.Fatalf("result = %s", ExplainPlannerResultV3(result))
+	}
+}

--- a/internal/playback/protocol_v3.go
+++ b/internal/playback/protocol_v3.go
@@ -27,6 +27,13 @@ const (
 	ClientDV7ToHDR10V3            = "client_dv7_to_hdr10"
 	ClientDVTransformVersionV3    = "1"
 	ClientDV8HDR10PlusSanitizerV3 = "client_dv8_hdr10plus_sanitizer_v1"
+	// ClientAudioTrackSelectionV3 is advertised in a delivery's features when
+	// that delivery's executor selects the plan's audio track itself from the
+	// container it is handed. It is the only evidence that lets a
+	// source-preserving delivery carry a non-default audio selection: the
+	// bytes are untouched, so a client without it plays the container default
+	// no matter what selected_tracks says.
+	ClientAudioTrackSelectionV3   = "client_audio_track_selection_v1"
 	ClientPostResumeRecoveryV3    = "client_post_resume_video_recovery_v1"
 	ClientSurfaceRecoveryV3       = "client_surface_recovery_v1"
 	DeviceQuirkRegistryRevisionV3 = "2026-07-13.1"

--- a/internal/playback/testdata/apple_tvos_dv_media_files.json
+++ b/internal/playback/testdata/apple_tvos_dv_media_files.json
@@ -1,0 +1,658 @@
+[
+ {
+  "id": 741,
+  "content_id": "movie-tmdb-513347",
+  "container": "mkv",
+  "codec_video": "hevc",
+  "codec_audio": "eac3",
+  "resolution": "1080p",
+  "hdr": true,
+  "bitrate": 2943,
+  "duration": 4451,
+  "video_tracks": [
+   {
+    "codec": "hevc",
+    "level": 120,
+    "title": "H.265 / HEVC (High Efficiency Video Coding)",
+    "width": 1920,
+    "height": 1080,
+    "profile": "Main 10",
+    "dv_level": 3,
+    "bit_depth": 10,
+    "dv_profile": 5,
+    "frame_rate": "24.000",
+    "interlaced": false,
+    "color_range": "pc",
+    "video_range": "DolbyVision",
+    "aspect_ratio": "16:9",
+    "dolby_vision": "Profile 5",
+    "pixel_format": "yuv420p10le",
+    "reference_frames": 1,
+    "video_range_type": "DOVI",
+    "dv_enhancement_layer": "none"
+   }
+  ],
+  "audio_tracks": [
+   {
+    "codec": "eac3",
+    "title": "ATSC A/52B (AC-3, E-AC-3)",
+    "layout": "stereo",
+    "bitrate": 128,
+    "default": true,
+    "channels": 2,
+    "language": "zh",
+    "sample_rate": 48000
+   },
+   {
+    "codec": "eac3",
+    "title": "ATSC A/52B (AC-3, E-AC-3)",
+    "layout": "stereo",
+    "bitrate": 128,
+    "default": false,
+    "channels": 2,
+    "language": "en",
+    "sample_rate": 48000
+   }
+  ],
+  "subtitle_tracks": [
+   {
+    "codec": "subrip",
+    "index": 3,
+    "title": "SUBRIP",
+    "forced": false,
+    "default": false,
+    "external": false,
+    "language": "en",
+    "hearing_impaired": false
+   },
+   {
+    "codec": "subrip",
+    "index": 4,
+    "title": "SUBRIP",
+    "forced": false,
+    "default": false,
+    "external": false,
+    "language": "ar",
+    "hearing_impaired": false
+   },
+   {
+    "codec": "subrip",
+    "index": 5,
+    "title": "SUBRIP",
+    "forced": false,
+    "default": false,
+    "external": false,
+    "language": "da",
+    "hearing_impaired": false
+   },
+   {
+    "codec": "subrip",
+    "index": 6,
+    "title": "SUBRIP",
+    "forced": false,
+    "default": false,
+    "external": false,
+    "language": "de",
+    "hearing_impaired": false
+   },
+   {
+    "codec": "subrip",
+    "index": 7,
+    "title": "SUBRIP",
+    "forced": false,
+    "default": false,
+    "external": false,
+    "language": "el",
+    "hearing_impaired": false
+   },
+   {
+    "codec": "subrip",
+    "index": 8,
+    "title": "Latin American",
+    "forced": false,
+    "default": false,
+    "external": false,
+    "language": "es",
+    "embedded_title": "Latin American",
+    "hearing_impaired": false
+   },
+   {
+    "codec": "subrip",
+    "index": 9,
+    "title": "European",
+    "forced": false,
+    "default": false,
+    "external": false,
+    "language": "es",
+    "embedded_title": "European",
+    "hearing_impaired": false
+   },
+   {
+    "codec": "subrip",
+    "index": 10,
+    "title": "SUBRIP",
+    "forced": false,
+    "default": false,
+    "external": false,
+    "language": "fi",
+    "hearing_impaired": false
+   },
+   {
+    "codec": "subrip",
+    "index": 11,
+    "title": "SUBRIP",
+    "forced": false,
+    "default": false,
+    "external": false,
+    "language": "fr",
+    "hearing_impaired": false
+   },
+   {
+    "codec": "subrip",
+    "index": 12,
+    "title": "SUBRIP",
+    "forced": false,
+    "default": false,
+    "external": false,
+    "language": "he",
+    "hearing_impaired": false
+   },
+   {
+    "codec": "subrip",
+    "index": 13,
+    "title": "SUBRIP",
+    "forced": false,
+    "default": false,
+    "external": false,
+    "language": "it",
+    "hearing_impaired": false
+   },
+   {
+    "codec": "subrip",
+    "index": 14,
+    "title": "SDH",
+    "forced": false,
+    "default": false,
+    "external": false,
+    "language": "ja",
+    "embedded_title": "SDH",
+    "hearing_impaired": false
+   },
+   {
+    "codec": "subrip",
+    "index": 15,
+    "title": "SUBRIP",
+    "forced": false,
+    "default": false,
+    "external": false,
+    "language": "ko",
+    "hearing_impaired": false
+   },
+   {
+    "codec": "subrip",
+    "index": 16,
+    "title": "SUBRIP",
+    "forced": false,
+    "default": false,
+    "external": false,
+    "language": "nb",
+    "hearing_impaired": false
+   },
+   {
+    "codec": "subrip",
+    "index": 17,
+    "title": "SUBRIP",
+    "forced": false,
+    "default": false,
+    "external": false,
+    "language": "nl",
+    "hearing_impaired": false
+   },
+   {
+    "codec": "subrip",
+    "index": 18,
+    "title": "SUBRIP",
+    "forced": false,
+    "default": false,
+    "external": false,
+    "language": "pl",
+    "hearing_impaired": false
+   },
+   {
+    "codec": "subrip",
+    "index": 19,
+    "title": "Brazilian",
+    "forced": false,
+    "default": false,
+    "external": false,
+    "language": "pt",
+    "embedded_title": "Brazilian",
+    "hearing_impaired": false
+   },
+   {
+    "codec": "subrip",
+    "index": 20,
+    "title": "European",
+    "forced": false,
+    "default": false,
+    "external": false,
+    "language": "pt",
+    "embedded_title": "European",
+    "hearing_impaired": false
+   },
+   {
+    "codec": "subrip",
+    "index": 21,
+    "title": "SUBRIP",
+    "forced": false,
+    "default": false,
+    "external": false,
+    "language": "ro",
+    "hearing_impaired": false
+   },
+   {
+    "codec": "subrip",
+    "index": 22,
+    "title": "SUBRIP",
+    "forced": false,
+    "default": false,
+    "external": false,
+    "language": "sv",
+    "hearing_impaired": false
+   },
+   {
+    "codec": "subrip",
+    "index": 23,
+    "title": "SUBRIP",
+    "forced": false,
+    "default": false,
+    "external": false,
+    "language": "th",
+    "hearing_impaired": false
+   },
+   {
+    "codec": "subrip",
+    "index": 24,
+    "title": "SUBRIP",
+    "forced": false,
+    "default": false,
+    "external": false,
+    "language": "tr",
+    "hearing_impaired": false
+   },
+   {
+    "codec": "subrip",
+    "index": 25,
+    "title": "Simplified",
+    "forced": false,
+    "default": false,
+    "external": false,
+    "language": "zh",
+    "embedded_title": "Simplified",
+    "hearing_impaired": false
+   },
+   {
+    "codec": "subrip",
+    "index": 26,
+    "title": "Traditional",
+    "forced": false,
+    "default": false,
+    "external": false,
+    "language": "zh",
+    "embedded_title": "Traditional",
+    "hearing_impaired": false
+   }
+  ],
+  "external_subtitles": [
+   {
+    "path": "/media/movies/file-741/subtitles.ar.srt",
+    "title": "subtitles.ar.srt",
+    "forced": false,
+    "format": "srt",
+    "default": false,
+    "language": "ar",
+    "hearing_impaired": false
+   },
+   {
+    "path": "/media/movies/file-741/subtitles.da.srt",
+    "title": "subtitles.da.srt",
+    "forced": false,
+    "format": "srt",
+    "default": false,
+    "language": "da",
+    "hearing_impaired": false
+   },
+   {
+    "path": "/media/movies/file-741/subtitles.de.srt",
+    "title": "subtitles.de.srt",
+    "forced": false,
+    "format": "srt",
+    "default": false,
+    "language": "de",
+    "hearing_impaired": false
+   },
+   {
+    "path": "/media/movies/file-741/subtitles.es.srt",
+    "title": "subtitles.es.srt",
+    "forced": false,
+    "format": "srt",
+    "default": false,
+    "language": "es",
+    "hearing_impaired": false
+   },
+   {
+    "path": "/media/movies/file-741/subtitles.fr.srt",
+    "title": "subtitles.fr.srt",
+    "forced": false,
+    "format": "srt",
+    "default": false,
+    "language": "fr",
+    "hearing_impaired": false
+   },
+   {
+    "path": "/media/movies/file-741/subtitles.ja.srt",
+    "title": "subtitles.ja.srt",
+    "forced": false,
+    "format": "srt",
+    "default": false,
+    "language": "ja",
+    "hearing_impaired": false
+   },
+   {
+    "path": "/media/movies/file-741/subtitles.nl.srt",
+    "title": "subtitles.nl.srt",
+    "forced": false,
+    "format": "srt",
+    "default": false,
+    "language": "nl",
+    "hearing_impaired": false
+   }
+  ]
+ },
+ {
+  "id": 223792,
+  "content_id": "movie-tmdb-1117126",
+  "container": "mkv",
+  "codec_video": "hevc",
+  "codec_audio": "eac3",
+  "resolution": "2160p",
+  "hdr": true,
+  "bitrate": 17151,
+  "duration": 6035,
+  "video_tracks": [
+   {
+    "codec": "hevc",
+    "level": 150,
+    "title": "H.265 / HEVC (High Efficiency Video Coding)",
+    "width": 3840,
+    "height": 1600,
+    "profile": "Main 10",
+    "bit_depth": 10,
+    "dv_profile": 8,
+    "frame_rate": "23.976",
+    "interlaced": false,
+    "color_range": "tv",
+    "color_space": "bt2020nc",
+    "video_range": "DolbyVision",
+    "aspect_ratio": "12:5",
+    "dolby_vision": "Profile 8",
+    "pixel_format": "yuv420p10le",
+    "color_transfer": "smpte2084",
+    "color_primaries": "bt2020",
+    "dv_bl_compat_id": 1,
+    "reference_frames": 1,
+    "video_range_type": "DOVIWithHDR10",
+    "dv_enhancement_layer": "none"
+   }
+  ],
+  "audio_tracks": [
+   {
+    "codec": "eac3",
+    "title": "German",
+    "layout": "5.1(side)",
+    "bitrate": 640,
+    "default": true,
+    "channels": 6,
+    "language": "de",
+    "sample_rate": 48000,
+    "embedded_title": "German"
+   },
+   {
+    "codec": "eac3",
+    "title": "English",
+    "layout": "5.1(side)",
+    "bitrate": 640,
+    "default": false,
+    "channels": 6,
+    "language": "en",
+    "sample_rate": 48000,
+    "embedded_title": "English"
+   }
+  ],
+  "subtitle_tracks": [
+   {
+    "codec": "subrip",
+    "index": 3,
+    "title": "German (Forced)",
+    "forced": true,
+    "default": true,
+    "external": false,
+    "language": "de",
+    "embedded_title": "German (Forced)",
+    "hearing_impaired": false
+   },
+   {
+    "codec": "subrip",
+    "index": 4,
+    "title": "German",
+    "forced": false,
+    "default": false,
+    "external": false,
+    "language": "de",
+    "embedded_title": "German",
+    "hearing_impaired": false
+   }
+  ],
+  "external_subtitles": []
+ },
+ {
+  "id": 223805,
+  "content_id": "movie-tmdb-852590",
+  "container": "mkv",
+  "codec_video": "hevc",
+  "codec_audio": "eac3",
+  "resolution": "2160p",
+  "hdr": true,
+  "bitrate": 20358,
+  "duration": 6152,
+  "video_tracks": [
+   {
+    "codec": "hevc",
+    "level": 150,
+    "title": "H.265 / HEVC (High Efficiency Video Coding)",
+    "width": 3840,
+    "height": 2160,
+    "profile": "Main 10",
+    "bit_depth": 10,
+    "frame_rate": "24.000",
+    "interlaced": false,
+    "color_range": "tv",
+    "color_space": "bt2020nc",
+    "video_range": "HDR",
+    "aspect_ratio": "16:9",
+    "pixel_format": "yuv420p10le",
+    "color_transfer": "smpte2084",
+    "color_primaries": "bt2020",
+    "reference_frames": 1,
+    "video_range_type": "HDR10",
+    "dv_enhancement_layer": "none"
+   }
+  ],
+  "audio_tracks": [
+   {
+    "codec": "eac3",
+    "title": "Polish E-AC3 640 kbps",
+    "layout": "5.1(side)",
+    "bitrate": 640,
+    "default": true,
+    "channels": 6,
+    "language": "pl",
+    "sample_rate": 48000,
+    "embedded_title": "Polish E-AC3 640 kbps"
+   },
+   {
+    "codec": "eac3",
+    "title": "Spanish E-AC3 640 kbps",
+    "layout": "5.1(side)",
+    "bitrate": 640,
+    "default": false,
+    "channels": 6,
+    "language": "es",
+    "sample_rate": 48000,
+    "embedded_title": "Spanish E-AC3 640 kbps"
+   }
+  ],
+  "subtitle_tracks": [
+   {
+    "codec": "subrip",
+    "index": 3,
+    "title": "Polish (Forced)",
+    "forced": true,
+    "default": true,
+    "external": false,
+    "language": "pl",
+    "embedded_title": "Polish (Forced)",
+    "hearing_impaired": false
+   },
+   {
+    "codec": "subrip",
+    "index": 4,
+    "title": "Polish",
+    "forced": false,
+    "default": false,
+    "external": false,
+    "language": "pl",
+    "embedded_title": "Polish",
+    "hearing_impaired": false
+   },
+   {
+    "codec": "subrip",
+    "index": 5,
+    "title": "English",
+    "forced": false,
+    "default": false,
+    "external": false,
+    "language": "en",
+    "embedded_title": "English",
+    "hearing_impaired": false
+   },
+   {
+    "codec": "subrip",
+    "index": 6,
+    "title": "English",
+    "forced": false,
+    "default": false,
+    "external": false,
+    "language": "en",
+    "embedded_title": "English",
+    "hearing_impaired": false
+   },
+   {
+    "codec": "subrip",
+    "index": 7,
+    "title": "English (SDH)",
+    "forced": false,
+    "default": false,
+    "external": false,
+    "language": "en",
+    "embedded_title": "English (SDH)",
+    "hearing_impaired": false
+   },
+   {
+    "codec": "subrip",
+    "index": 8,
+    "title": "Spanish (SDH)",
+    "forced": false,
+    "default": false,
+    "external": false,
+    "language": "es",
+    "embedded_title": "Spanish (SDH)",
+    "hearing_impaired": false
+   }
+  ],
+  "external_subtitles": [
+   {
+    "path": "/media/movies/file-223805/subtitles.ar.srt",
+    "title": "subtitles.ar.srt",
+    "forced": false,
+    "format": "srt",
+    "default": false,
+    "language": "ar",
+    "hearing_impaired": false
+   },
+   {
+    "path": "/media/movies/file-223805/subtitles.da.srt",
+    "title": "subtitles.da.srt",
+    "forced": false,
+    "format": "srt",
+    "default": false,
+    "language": "da",
+    "hearing_impaired": false
+   },
+   {
+    "path": "/media/movies/file-223805/subtitles.de.srt",
+    "title": "subtitles.de.srt",
+    "forced": false,
+    "format": "srt",
+    "default": false,
+    "language": "de",
+    "hearing_impaired": false
+   },
+   {
+    "path": "/media/movies/file-223805/subtitles.en.srt",
+    "title": "subtitles.en.srt",
+    "forced": false,
+    "format": "srt",
+    "default": false,
+    "language": "en",
+    "hearing_impaired": false
+   },
+   {
+    "path": "/media/movies/file-223805/subtitles.es.sdh.srt",
+    "title": "subtitles.es.sdh.srt",
+    "forced": false,
+    "format": "srt",
+    "default": false,
+    "language": "es",
+    "hearing_impaired": false
+   },
+   {
+    "path": "/media/movies/file-223805/subtitles.fr.srt",
+    "title": "subtitles.fr.srt",
+    "forced": false,
+    "format": "srt",
+    "default": false,
+    "language": "fr",
+    "hearing_impaired": false
+   },
+   {
+    "path": "/media/movies/file-223805/subtitles.ja.srt",
+    "title": "subtitles.ja.srt",
+    "forced": false,
+    "format": "srt",
+    "default": false,
+    "language": "ja",
+    "hearing_impaired": false
+   },
+   {
+    "path": "/media/movies/file-223805/subtitles.nl.srt",
+    "title": "subtitles.nl.srt",
+    "forced": false,
+    "format": "srt",
+    "default": false,
+    "language": "nl",
+    "hearing_impaired": false
+   }
+  ]
+ }
+]

--- a/internal/playback/testdata/apple_tvos_dv_start_request.json
+++ b/internal/playback/testdata/apple_tvos_dv_start_request.json
@@ -1,0 +1,259 @@
+{
+ "protocol_version": 3,
+ "client_features": [
+  "playback_plan_v3",
+  "client_video_transforms"
+ ],
+ "file_id": 223805,
+ "playback_attempt_id": "apple:probe2-223805",
+ "quality_preference": "auto",
+ "subtitle_fidelity_preference": "compatible",
+ "start_position": 0,
+ "progress_persistence": "client",
+ "metered": false,
+ "client_capabilities": {
+  "video_evidence": "platform_attested",
+  "audio_evidence": "declared",
+  "codecs_video": [
+   "h264",
+   "hevc"
+  ],
+  "codecs_video_hardware": [
+   "h264",
+   "hevc"
+  ],
+  "codecs_audio": [
+   "aac",
+   "ac3",
+   "eac3",
+   "dts",
+   "truehd",
+   "flac",
+   "alac",
+   "mp3",
+   "opus",
+   "vorbis",
+   "pcm",
+   "pcm_s16le",
+   "pcm_s24le"
+  ],
+  "containers": [
+   "mp4",
+   "mov",
+   "m4v",
+   "mkv",
+   "matroska",
+   "webm",
+   "avi",
+   "ts",
+   "m2ts",
+   "mpegts",
+   "mp3",
+   "m4a",
+   "m4b",
+   "aac",
+   "flac",
+   "wav"
+  ],
+  "max_resolution": "2160p",
+  "hdr": true,
+  "hdr_details": {
+   "hdr10": true,
+   "hdr10_plus": false,
+   "hlg": false,
+   "dolby_vision_profiles": [
+    5,
+    8
+   ]
+  },
+  "video_decode": [
+   {
+    "codec": "h264",
+    "bit_depths": [
+     8
+    ],
+    "max_width": 3840,
+    "max_height": 2160,
+    "max_frame_rate": 60,
+    "max_bitrate_kbps": 120000,
+    "hardware": true
+   },
+   {
+    "codec": "hevc",
+    "bit_depths": [
+     8,
+     10
+    ],
+    "max_width": 3840,
+    "max_height": 2160,
+    "max_frame_rate": 60,
+    "max_bitrate_kbps": 120000,
+    "hardware": true
+   }
+  ]
+ },
+ "client_playback_context": {
+  "protocol_version": 3,
+  "form_factor": "tv",
+  "app_version": "probe",
+  "device": {
+   "platform": "tvos",
+   "os_version": "26",
+   "manufacturer": "Apple",
+   "model": "AppleTV14,1"
+  },
+  "output": {
+   "output_context_id": "apple:probe",
+   "sink_type": "HDMIOutput",
+   "hdr_details": {
+    "hdr10": true,
+    "hdr10_plus": false,
+    "hlg": false,
+    "dolby_vision_profiles": [
+     5,
+     8
+    ]
+   }
+  },
+  "deliveries": {
+   "original_http": {
+    "enabled": true,
+    "supported_on_device": true,
+    "containers": [
+     "mp4",
+     "mov",
+     "m4v",
+     "mkv",
+     "matroska",
+     "ts",
+     "m2ts",
+     "mpegts",
+     "mp3",
+     "m4a",
+     "m4b",
+     "aac",
+     "flac",
+     "wav"
+    ],
+    "video_codecs": [
+     "h264",
+     "hevc"
+    ],
+    "audio_decode_codecs": [
+     "aac",
+     "ac3",
+     "eac3",
+     "dts",
+     "truehd",
+     "flac",
+     "alac",
+     "mp3",
+     "opus",
+     "vorbis",
+     "pcm",
+     "pcm_s16le",
+     "pcm_s24le"
+    ],
+    "audio_passthrough_codecs": [],
+    "subtitles": {
+     "embedded_text": true,
+     "sidecar_text": true,
+     "ass_styling": true,
+     "embedded_bitmap": true,
+     "sidecar_bitmap": false,
+     "font_attachments": true
+    },
+    "features": [],
+    "auth_header_refresh": true,
+    "validated_claims": [],
+    "transformations": [],
+    "hdr_details": {
+     "hdr10": true,
+     "hdr10_plus": false,
+     "hlg": false,
+     "dolby_vision_profiles": [
+      5,
+      8
+     ]
+    }
+   },
+   "progressive": {
+    "enabled": true,
+    "supported_on_device": true,
+    "containers": [
+     "mp4"
+    ],
+    "video_codecs": [
+     "h264",
+     "hevc"
+    ],
+    "audio_decode_codecs": [
+     "aac",
+     "ac3",
+     "eac3"
+    ],
+    "audio_passthrough_codecs": [],
+    "subtitles": {
+     "embedded_text": false,
+     "sidecar_text": true,
+     "ass_styling": true,
+     "embedded_bitmap": false,
+     "sidecar_bitmap": false,
+     "font_attachments": false
+    },
+    "features": [],
+    "auth_header_refresh": true,
+    "validated_claims": [],
+    "transformations": [],
+    "hdr_details": {
+     "hdr10": true,
+     "hdr10_plus": false,
+     "hlg": false,
+     "dolby_vision_profiles": [
+      5,
+      8
+     ]
+    }
+   },
+   "hls": {
+    "enabled": true,
+    "supported_on_device": true,
+    "containers": [
+     "hls"
+    ],
+    "video_codecs": [
+     "h264",
+     "hevc"
+    ],
+    "audio_decode_codecs": [
+     "aac",
+     "ac3",
+     "eac3"
+    ],
+    "audio_passthrough_codecs": [],
+    "subtitles": {
+     "embedded_text": false,
+     "sidecar_text": true,
+     "ass_styling": true,
+     "embedded_bitmap": false,
+     "sidecar_bitmap": false,
+     "font_attachments": false
+    },
+    "features": [],
+    "auth_header_refresh": true,
+    "validated_claims": [],
+    "transformations": [],
+    "hdr_details": {
+     "hdr10": true,
+     "hdr10_plus": false,
+     "hlg": false,
+     "dolby_vision_profiles": [
+      5,
+      8
+     ]
+    }
+   }
+  }
+ },
+ "profile_id": "00000000-0000-4000-8000-000000000001"
+}


### PR DESCRIPTION
## Problem

For an Apple TV client that advertises Dolby Vision, the V3 planner returned `server_remux_progressive` / `container_normalization` for DV Profile 5 and Profile 8 HEVC MKVs, while an HDR10 HEVC MKV with the same request got `original_http` / `validated_original_playback`. Reproduced on shared dev and production. Downstream on tvOS: the progressive remux is a live fMP4 pipe without byte-range support and AVPlayer fails it every time (`-11850` / `-12939`), then the HLS remux strips DV to HDR10.

**Root cause is not Dolby Vision.** The profile's audio preference (`en`) resolves to a **non-default** audio track on the foreign-release DV titles, and the direct branch requires the container default (`audioSelectionUsesContainerDefaultV3`, `internal/playback/plan_v3.go:341`). The HDR10 title had no English track, so the preference fell back to the default and passed. Evidence: `playback_v3_attempts` for the captured probe attempts shows `selected_tracks.audio.index` = 1 / 1 / 0 ↔ remux / remux / original.

## Change

Capability-scoped rather than a blanket removal (a browser cannot select an audio track and must keep getting the remux):

- `protocol_v3.go`: new per-delivery feature `client_audio_track_selection_v1` — advertised by a delivery whose executor selects the plan's audio track itself.
- `plan_v3.go`: the direct branch uses `originalAudioSelectionRealizableV3` = container default **or** the `original_http` delivery advertises the feature.
- `docs/architecture/playback-protocol-v3.md` §4: contract paragraph.
- Tests: `TestPlanPlaybackV3AppleOriginalHTTPHonorsClientAudioTrackSelection` (real dev rows for DV P5 / DV P8 / HDR10 + the captured tvOS request, sanitized fixtures under `internal/playback/testdata/apple_tvos_dv_*.json`) and `TestPlanPlaybackV3OriginalHTTPKeepsRemuxWithoutAudioSelectionFeature`; the pre-existing `TestPlanPlaybackV3NonDefaultAudioSelectionCannotUseOriginalHTTP` still passes untouched.

Inert until a client advertises the flag. silo-apple advertises it in `player/architecture-remediation` (and routes non-default audio to its loopback executor); Android honours `selected_tracks.audio.index` too and can add the same line.

## Validation

- `go test ./internal/playback/... ./internal/api/...` green (branch merged with current `main`).
- Deployed to shared dev and replayed the captured request: DV P5 / DV P8 → `original_http` / `validated_original_playback` (audio idx 1) with the feature; unchanged legacy remux without it; HDR10 unchanged. 9/9 scenarios matched.

## Follow-ups (not in this PR)

- Two same-shaped sibling gates still require the container default: `plan_v3.go:297` (Profile 7 client-transform direct branch) and `:573` (audio-only route).
- `server_remux_progressive` is never playable by AVPlayer on tvOS/iOS (live fMP4 pipe, no Range); the Apple client now advertises `progressive` as `supported_on_device: false`, so the planner falls to HLS remux. No server-side gate added on purpose (platform-neutral contract).
- Data note: 3 P8 rows on dev lack `dv_bl_compat_id` and conservatively lose the P8→HDR10 strip; 23 rows carry compat id 6 (possibly over-conservative to exclude).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Original HTTP playback can now honor explicitly selected non-default audio tracks when supported by the client.
  - Audio-track selections remain honored after playback replanning.
  - Unsupported audio-track selections continue using remuxed playback.

- **Bug Fixes**
  - Improved direct playback behavior for Apple TV Dolby Vision and HDR10 content while preserving selected audio tracks.

- **Documentation**
  - Documented the client audio-track selection capability for source-preserving playback.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->