### PR TITLE
docs: hand-tune CLAUDE.md — identity, glossary, dataflow map, and alpha API posture

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -31,6 +31,32 @@ the single-node and the multi-node deployment. Current posture: the 1.0 feature 
 essentially complete; the present era is QA, UX polish, and verifying everything does what it
 says. Prefer correctness and polish over new feature sprawl.
 
+## How it fits together
+
+Media enters through the scanner (`internal/scanner`, fed by `scanqueue`/`autoscan`), is
+classified by library kind (`librarykind`), ingested (`libraryingest`), and enriched by
+metadata plugins into the catalog: `media_items` keyed by deterministic content IDs
+(`contentid`), with `media_files` for the actual on-disk files. The catalog serves the v1 API
+and the home-screen sections (`sections`); `jellycompat` is a separate Jellyfin-protocol view
+over the same catalog. Playback resolves a play method (`internal/playback`) — direct play,
+direct stream, or transcode on a node from `nodepool` — and stream URLs are authorized by
+short-lived `streamtoken` JWTs. Per-user state (watch progress, settings) is stored
+server-side (`watchstate`, `userdb`, `settingsresolve`).
+
+## Glossary
+
+- **Account vs profile** — an account is a `users` row (login); a profile is a household
+  member on an account. Several profiles share one `user_id`. See the gotcha below.
+- **Library** — a media folder with a kind (movies, TV, audiobooks, ebooks, podcasts).
+- **Item vs file** — a `MediaItem` is a catalog entry (movie/series, `content_id` PK); a
+  `MediaFile` is one real file. One item can own many files (versions, extras, episodes).
+- **Section** — a home-screen row (Continue Watching, Recently Added…), not a library.
+- **Node** — a remote transcode/streaming worker in `nodepool`, not the API server.
+- **Session** — ambiguous; always say which: playback session (`internal/playback`) or login
+  session (`internal/auth`).
+- **jellycompat vs v1** — jellycompat is the Jellyfin-protocol surface for ecosystem clients;
+  "the API" or "v1" means Silo's native `/api/v1`.
+
 ## Priorities
 
 Performance and reliability first. Keep behavior predictable under load and during failures —
@@ -53,6 +79,8 @@ client suite at risk. This is settled product direction, not a design problem to
 write code for it, and say so plainly if asked.
 
 ## Gotchas
+
+The first two are irreversible — data loss, not inconvenience. Treat them as absolute.
 
 **Migrations.** New DB changes are Goose SQL migrations in `migrations/sql/`, created with
 `make migrate-create NAME=add_thing` so they get timestamped filenames. Never run `goose fix`,
@@ -88,16 +116,28 @@ Sibling repos are usually checked out side-by-side in the same parent directory.
 - First-party plugins (`silo-plugin-metadata-tmdb`, `silo-plugin-metadata-tvdb`, …) each have
   their own repo.
 
-Client-visible changes to API, auth, playback, session, library, or metadata behavior usually
-need follow-up in both client repos — prefer coordinated multi-repo changes over leaving a
-platform behind. When a task mentions plugins, work out first whether it belongs here, in the
-SDK, in the catalog, or in a specific plugin repo.
+When a task mentions plugins, work out first whether it belongs here, in the SDK, in the
+catalog, or in a specific plugin repo.
+
+A client-visible change (API, auth, playback, session, library, or metadata behavior) is not
+done until each of these has been handled or ruled out:
+
+- v1 API rules hold (additive only; new features expose a capability endpoint).
+- Follow-up work is done or filed for both `silo-apple` and `silo-android` — prefer
+  coordinated multi-repo changes over leaving a platform behind.
+- jellycompat parity was considered (does the Jellyfin surface need the same behavior?).
+- The relevant `docs/*-api.md` is updated, and `docs/feature-changelog.md` gets an entry if
+  the change is user-facing.
 
 ## Building and verifying
 
 `make build`, `make dev-backend`, `make dev-frontend`, `make lint`, `make test`, `make migrate-status`
 / `make migrate-up` — read the `Makefile` for the rest. Local services:
 `docker compose up -d postgres redis`.
+
+While iterating, run the focused tests for the packages you touched (`go test ./internal/<pkg>/...`)
+rather than the whole suite; the full gate below is for pre-PR. In tests, wait on observable
+state — job status, health endpoints, channel receipts — not fixed sleeps.
 
 `make test-go` runs the whole Go suite. A Go test that cannot pass yet carries a `t.Skip` and the
 reason in its own source, not an entry in a Makefile variable. `make test-web` still skips the

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -16,9 +16,9 @@ libraries, whether it's one node serving a household or a deployment streaming t
 users. Weigh every design against that full spectrum; treat a node dying mid-stream as a normal
 event, not an edge case.
 
-It is an open platform, not a walled garden: third-party clients are encouraged, which is why
-the additive-only v1 API rules and capability endpoints below are binding — other people's
-clients will depend on them. Jellyfin-protocol compatibility is a long-term commitment as an
+It is an open platform, not a walled garden: third-party clients are encouraged, and other
+people's clients will depend on the v1 API once it locks — see "v1 API rules" below for the
+current pre-1.0 posture. Jellyfin-protocol compatibility is a long-term commitment as an
 on-ramp for the existing ecosystem.
 
 The core/plugin line is about implementation multiplicity: library types (movies, TV,
@@ -122,7 +122,8 @@ catalog, or in a specific plugin repo.
 A client-visible change (API, auth, playback, session, library, or metadata behavior) is not
 done until each of these has been handled or ruled out:
 
-- v1 API rules hold (additive only; new features expose a capability endpoint).
+- The API change fits the current v1 posture (see "v1 API rules" below); new features still
+  expose a capability endpoint.
 - Follow-up work is done or filed for both `silo-apple` and `silo-android` — prefer
   coordinated multi-repo changes over leaving a platform behind.
 - jellycompat parity was considered (does the Jellyfin surface need the same behavior?).
@@ -173,7 +174,15 @@ checks it end to end.
 
 ## v1 API rules
 
-Additive-only within `/api/v1`:
+Silo is alpha and `/api/v1` is not locked yet. Until it locks, restructuring the API is in
+scope — if a shape is wrong, fix it now rather than carry it into 1.0. Prefer larger
+coordinated sweeps over a drip of small breaks, and don't build backwards-compatibility shims
+for pre-lock clients. A breaking change still needs coordination with `silo-apple` and
+`silo-android`, and removals get recorded in the pre-lock removals table in
+[docs/architecture/v1-scope.md](docs/architecture/v1-scope.md) so client authors can track
+them.
+
+At v1 lock (1.0), the contract becomes additive-only and binding:
 
 - Never rename or remove a response field, change a field's type, or repurpose a status code on
   an existing endpoint.
@@ -182,10 +191,7 @@ Additive-only within `/api/v1`:
 - New features expose capability endpoints for feature detection rather than relying on version
   sniffing. Contract strategy and tooling: issue #135.
 
-Treat this as binding. The one exception: `/api/v1` is not locked yet, so a removal taken before
-lock is in scope — but only when it is recorded in the pre-lock removals table in
-[docs/architecture/v1-scope.md](docs/architecture/v1-scope.md) and ships before the lock. Assume
-any removal not listed there is a mistake.
+Design new endpoints today so they can live under that regime tomorrow.
 
 ## Pull requests
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -7,6 +7,30 @@ entrypoint, backend code is under `internal/` by domain, the React frontend is `
 This repository is a VERY EARLY WIP. Proposing sweeping changes that improve long-term
 maintainability is encouraged.
 
+## What Silo is
+
+A modern, open-source media server built from the ground up on current infrastructure —
+Postgres, S3, Redis — rather than SQLite and local disk. The foundational bet is horizontal
+scale: Silo deploys as a cluster (Kubernetes, remote transcode nodes) and stays fast on large
+libraries, whether it's one node serving a household or a deployment streaming to thousands of
+users. Weigh every design against that full spectrum; treat a node dying mid-stream as a normal
+event, not an edge case.
+
+It is an open platform, not a walled garden: third-party clients are encouraged, which is why
+the additive-only v1 API rules and capability endpoints below are binding — other people's
+clients will depend on them. Jellyfin-protocol compatibility is a long-term commitment as an
+on-ramp for the existing ecosystem.
+
+The core/plugin line is about implementation multiplicity: library types (movies, TV,
+audiobooks, ebooks, podcasts) are core; plugins are for interfaces where many implementations
+will plausibly exist (metadata, subtitle, and watch providers). Plugins are never a loophole
+for the non-goals below.
+
+Taste: KISS and YAGNI win — the simple design beats the clever one, provided it survives both
+the single-node and the multi-node deployment. Current posture: the 1.0 feature set is
+essentially complete; the present era is QA, UX polish, and verifying everything does what it
+says. Prefer correctness and polish over new feature sprawl.
+
 ## Priorities
 
 Performance and reliability first. Keep behavior predictable under load and during failures —


### PR DESCRIPTION
## Problem

CLAUDE.md told agents *how* to work in this repo but nothing about *what Silo is* — the scale bet, the core-vs-plugin rule, the current QA-era posture all lived only in the maintainer's head. It also pinned none of the project's ambiguous nouns (account/profile, item/file, session), and stated the v1 API rules more strictly than the actual pre-lock policy.

## What this adds

Content comes from a maintainer interview; structure borrows from T3 Code's hand-written AGENTS.md (glossary, severity-ranked footguns, completeness checklist):

- **"What Silo is"** — cluster-first on Postgres/S3/Redis, open platform with third-party clients encouraged, Jellyfin-protocol compat as a long-term on-ramp, the implementation-multiplicity rule for core vs plugins, KISS/YAGNI taste, and the current QA/polish posture.
- **"How it fits together"** — a five-line scanner → catalog → API/sections/jellycompat → playback dataflow map, package names verified against `internal/`.
- **Glossary** — the seven ambiguous nouns: account vs profile, library, item vs file, section, node, session (playback vs login), jellycompat vs v1.
- **Done-checklist for client-visible changes** — v1 posture + capability endpoint, both client repos, jellycompat parity, API docs/changelog.
- **v1 API rules rewritten for alpha reality** — pre-lock, restructuring is in scope and larger coordinated sweeps beat incremental breaks with compat shims; the additive-only contract becomes binding at v1 lock. Matches what docs/architecture/v1-scope.md already said.
- Focused-tests-while-iterating guidance and a severity marker on the irreversible gotchas.

## Notes
- Deliberately names no other media-server projects.
- Independent of #671 (the docs prune); no overlap in changed hunks, either can merge first.

## AI-use disclosure
Authored by Claude (Fable 5) via Claude Code from a maintainer interview; the maintainer set the content direction and reviewed the framing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)