### PR TITLE
feat(settings): add player.apple.control_plane rollout switch (contract rev 8)

### DIFF
--- a/contracts/settings/v1/conformance.json
+++ b/contracts/settings/v1/conformance.json
@@ -1,6 +1,6 @@
 {
   "fixture_version": 1,
-  "manifest_revision": 7,
+  "manifest_revision": 8,
   "description": "Cross-platform conformance cases for settings resolution. Every case runs against the shipped manifest in this directory: definitions are referenced by key, never restated, so an expectation can only be satisfied by resolving the real contract. Each platform's resolver (Go in internal/settingsresolve, TypeScript in web/src/lib/settingsResolve.ts, Kotlin and Swift in the client repos) runs every case through a hand-written runner; a runner must fail on any fixture field it does not know, because schema drift in the fixture itself is drift. A case's constraint_bindings attach a constraint to a copy of a real definition so constraint semantics stay testable even while no shipped definition carries that constraint kind. In expected entries, constrained:true requires stored_value and constraint_kind to be present, and stored_value may be null to mean the authored value was JSON null.",
   "cases": [
     {
@@ -706,6 +706,42 @@
         {
           "key": "playback.intro_skip_mode",
           "value": "always",
+          "source": "profile_device"
+        }
+      ]
+    },
+    {
+      "name": "apple_control_plane_defaults_to_off",
+      "description": "An Apple device nobody has enrolled resolves to the legacy player path, so the new control plane ships dark until a deliberate write turns it on.",
+      "keys": ["player.apple.control_plane"],
+      "context": { "profile_id": "p1", "device_id": "d1" },
+      "stored": [],
+      "expected": [
+        {
+          "key": "player.apple.control_plane",
+          "value": "off",
+          "source": "default"
+        }
+      ]
+    },
+    {
+      "name": "apple_control_plane_enrolls_one_device",
+      "description": "Enabling the control plane for direct routes on one Apple TV leaves every other device on the legacy path, which is what makes the rollback targeted.",
+      "keys": ["player.apple.control_plane"],
+      "context": { "profile_id": "p1", "device_id": "d1" },
+      "stored": [
+        {
+          "key": "player.apple.control_plane",
+          "scope": "profile_device",
+          "profile_id": "p1",
+          "device_id": "d1",
+          "value": "native_direct"
+        }
+      ],
+      "expected": [
+        {
+          "key": "player.apple.control_plane",
+          "value": "native_direct",
           "source": "profile_device"
         }
       ]

--- a/contracts/settings/v1/manifest.json
+++ b/contracts/settings/v1/manifest.json
@@ -1,6 +1,6 @@
 {
   "api_version": 1,
-  "revision": 7,
+  "revision": 8,
   "option_sets": {
     "playback_audio_languages": {
       "type": "language_tag",
@@ -598,6 +598,29 @@
       "description": "Duration the sleep timer starts on when you turn it on. 0 leaves it off.",
       "recommended_control": "stepper",
       "notes": "Android keeps this device-local today and clamps to 0..240; it was never written to the server rather than written and rejected. The maximum matches that clamp rather than exceeding it, and the default matches Android's shipped 30, because a manifest that disagrees with the only client implementing a setting is the drift this contract exists to remove — and a default of 0 would silently turn the preset off for everyone at cutover. Raising the maximum later is additive under the widening rule: replace the bare maximum with its history so a client can still see the 240 an older server enforces. This is the duration the timer starts on, not whether one is running: the design classes a running sleep timer as private local, so only the persisted default is registered."
+    },
+    {
+      "key": "player.apple.control_plane",
+      "introduced_in": 8,
+      "persistence": "remote",
+      "allowed_scopes": ["profile_device"],
+      "resolution_order": ["profile_device", "default"],
+      "value_schema": {
+        "type": "enum",
+        "values": [
+          { "value": "off", "label": "Legacy player" },
+          { "value": "native_direct", "label": "New control plane, direct routes only" },
+          { "value": "loopback", "label": "New control plane, loopback routes only" },
+          { "value": "all", "label": "New control plane everywhere" }
+        ]
+      },
+      "default_value": "off",
+      "platforms": ["ios", "tvos", "macos"],
+      "category": "player",
+      "label": "Apple playback control plane",
+      "description": "Which playback routes the Apple client's new control plane handles on this device. \"off\" keeps every route on the legacy player path. \"native_direct\" enables the control plane only for direct-play routes, \"loopback\" only for loopback routes, and \"all\" enables it for every route.",
+      "recommended_control": "select",
+      "notes": "Rollout kill-switch for the Apple playback control plane (silo-apple architecture remediation, stage 2), not a viewer preference. The client ships the control plane dark: \"off\" is the default and the shipped behaviour, so enabling it is a deliberate server-side act and rolling it back is a settings write rather than a TestFlight release. The value names a route family rather than a percentage because the two families fail differently — a direct route that regresses can be returned to the legacy path without also reverting loopback, and vice versa. Device scope matches every other remote player.* key and is what makes the rollback targeted: one misbehaving Apple TV goes back to \"off\" without moving the rest of the fleet. Widening to profile scope later is additive under the scope rule (add the scope with its own introduced_in). This key is deliberately hidden from the web device settings screen — it is an operations flag, and the surface that flips it is the admin device-overrides view, which iterates every device-scoped key. The name encodes a platform, which the schema's key description says canonical names do not do; that exception is owner-approved and intentional, because the control plane being rolled out is one client's playback stack and no other platform can honour the value. Retiring it once the control plane is unconditional removes the key rather than generalizing it."
     },
     {
       "key": "ui.theme",

--- a/internal/settingskeys/keys.go
+++ b/internal/settingskeys/keys.go
@@ -9,7 +9,7 @@
 package settingskeys
 
 // Revision is the manifest revision these bindings were generated from.
-const Revision = 7
+const Revision = 8
 
 // Setting keys, one constant per definition.
 const (
@@ -57,6 +57,8 @@ const (
 	PlaybackSubtitleLanguage = "playback.subtitle_language"
 	// Subtitles
 	PlaybackSubtitleMode = "playback.subtitle_mode"
+	// Apple playback control plane
+	PlayerAppleControlPlane = "player.apple.control_plane"
 	// Audio sync offset
 	PlayerAudioSyncMs = "player.audio_sync_ms"
 	// Dolby Vision
@@ -143,6 +145,7 @@ var Remote = []string{
 	PlaybackSubtitleAppearance,
 	PlaybackSubtitleLanguage,
 	PlaybackSubtitleMode,
+	PlayerAppleControlPlane,
 	PlayerAudioSyncMs,
 	PlayerDolbyVisionEnabled,
 	PlayerDvProfile7Hdr10Fallback,

--- a/web/src/lib/deviceSettingGroups.test.ts
+++ b/web/src/lib/deviceSettingGroups.test.ts
@@ -44,6 +44,13 @@ describe("deviceSettingGroups", () => {
     expect(groupForDeviceSetting("ui.library_page_state")).toBeNull();
   });
 
+  // An Apple rollout kill-switch is not a viewer preference, and its manifest
+  // category would otherwise file it under Picture beside HDR.
+  it("keeps the Apple control-plane rollout flag off the device screen", () => {
+    expect(groupForDeviceSetting("player.apple.control_plane")).toBeNull();
+    expect(hiddenDeviceSettingKeys()).toContain("player.apple.control_plane");
+  });
+
   it("shows only the three-way intro mode while the compatibility mirror is live", () => {
     expect(groupForDeviceSetting("playback.intro_skip_mode")).toBe("episodes");
     expect(groupForDeviceSetting("playback.auto_skip_intro")).toBeNull();

--- a/web/src/lib/deviceSettingGroups.ts
+++ b/web/src/lib/deviceSettingGroups.ts
@@ -69,6 +69,13 @@ const EXPLICIT_GROUPS: Partial<Record<string, DeviceSettingGroupId>> = {
  * screen, which already edits them at profile scope; showing them here would
  * give one setting two homes. `ui.library_page_state` is remembered browse
  * state rather than a preference — it has no control in the manifest at all.
+ *
+ * `player.apple.control_plane` is a rollout kill-switch for the Apple client's
+ * playback stack, not a viewer preference: nobody browsing their device
+ * settings can tell what it does, and its manifest category would otherwise
+ * file it under Picture. It stays reachable from the admin device-overrides
+ * view, which iterates every device-scoped key rather than these groups, so
+ * hiding it here costs nothing operationally.
  */
 const HIDDEN_KEYS = new Set<string>([
   "ui.theme",
@@ -79,6 +86,7 @@ const HIDDEN_KEYS = new Set<string>([
   "ui.remember_library_page_state",
   "nav.primary_menu",
   "ui.card_presentation",
+  "player.apple.control_plane",
 ]);
 
 /**

--- a/web/src/lib/settingsConformance.json
+++ b/web/src/lib/settingsConformance.json
@@ -1,6 +1,6 @@
 {
   "fixture_version": 1,
-  "manifest_revision": 7,
+  "manifest_revision": 8,
   "description": "Cross-platform conformance cases for settings resolution. Every case runs against the shipped manifest in this directory: definitions are referenced by key, never restated, so an expectation can only be satisfied by resolving the real contract. Each platform's resolver (Go in internal/settingsresolve, TypeScript in web/src/lib/settingsResolve.ts, Kotlin and Swift in the client repos) runs every case through a hand-written runner; a runner must fail on any fixture field it does not know, because schema drift in the fixture itself is drift. A case's constraint_bindings attach a constraint to a copy of a real definition so constraint semantics stay testable even while no shipped definition carries that constraint kind. In expected entries, constrained:true requires stored_value and constraint_kind to be present, and stored_value may be null to mean the authored value was JSON null.",
   "cases": [
     {
@@ -706,6 +706,42 @@
         {
           "key": "playback.intro_skip_mode",
           "value": "always",
+          "source": "profile_device"
+        }
+      ]
+    },
+    {
+      "name": "apple_control_plane_defaults_to_off",
+      "description": "An Apple device nobody has enrolled resolves to the legacy player path, so the new control plane ships dark until a deliberate write turns it on.",
+      "keys": ["player.apple.control_plane"],
+      "context": { "profile_id": "p1", "device_id": "d1" },
+      "stored": [],
+      "expected": [
+        {
+          "key": "player.apple.control_plane",
+          "value": "off",
+          "source": "default"
+        }
+      ]
+    },
+    {
+      "name": "apple_control_plane_enrolls_one_device",
+      "description": "Enabling the control plane for direct routes on one Apple TV leaves every other device on the legacy path, which is what makes the rollback targeted.",
+      "keys": ["player.apple.control_plane"],
+      "context": { "profile_id": "p1", "device_id": "d1" },
+      "stored": [
+        {
+          "key": "player.apple.control_plane",
+          "scope": "profile_device",
+          "profile_id": "p1",
+          "device_id": "d1",
+          "value": "native_direct"
+        }
+      ],
+      "expected": [
+        {
+          "key": "player.apple.control_plane",
+          "value": "native_direct",
           "source": "profile_device"
         }
       ]

--- a/web/src/lib/settingsContract.ts
+++ b/web/src/lib/settingsContract.ts
@@ -9,7 +9,7 @@
  */
 
 export const SETTINGS_API_VERSION = 1;
-export const SETTINGS_REVISION = 7;
+export const SETTINGS_REVISION = 8;
 
 export interface SettingSuggestedOption {
   value: string;
@@ -197,6 +197,8 @@ export const SETTING_KEYS = {
   PLAYBACK_SUBTITLE_LANGUAGE: "playback.subtitle_language",
   /** Subtitles */
   PLAYBACK_SUBTITLE_MODE: "playback.subtitle_mode",
+  /** Apple playback control plane */
+  PLAYER_APPLE_CONTROL_PLANE: "player.apple.control_plane",
   /** Audio sync offset */
   PLAYER_AUDIO_SYNC_MS: "player.audio_sync_ms",
   /** Dolby Vision */
@@ -701,6 +703,29 @@ export const SETTING_DEFINITIONS: Record<SettingKey, SettingDefinition> = {
       { value: "auto", label: "Auto", introducedIn: 1 },
       { value: "always", label: "Always on", introducedIn: 1 },
       { value: "off", label: "Off", introducedIn: 1 },
+    ],
+  },
+  "player.apple.control_plane": {
+    key: "player.apple.control_plane",
+    type: "enum",
+    nullable: false,
+    persistence: "remote",
+    introducedIn: 8,
+    scopes: ["profile_device"],
+    scopeIntroducedIn: [8],
+    resolutionOrder: ["profile_device", "default"],
+    defaultValue: "off",
+    label: "Apple playback control plane",
+    description:
+      'Which playback routes the Apple client\'s new control plane handles on this device. "off" keeps every route on the legacy player path. "native_direct" enables the control plane only for direct-play routes, "loopback" only for loopback routes, and "all" enables it for every route.',
+    category: "player",
+    control: "select",
+    platforms: ["ios", "tvos", "macos"],
+    values: [
+      { value: "off", label: "Legacy player", introducedIn: 8 },
+      { value: "native_direct", label: "New control plane, direct routes only", introducedIn: 8 },
+      { value: "loopback", label: "New control plane, loopback routes only", introducedIn: 8 },
+      { value: "all", label: "New control plane everywhere", introducedIn: 8 },
     ],
   },
   "player.audio_sync_ms": {


### PR DESCRIPTION
Adds the remote kill-switch for the Apple client's new playback control plane — decision **P11** of the silo-apple player architecture remediation ([silo-apple PR #172](https://github.com/Silo-Server/silo-apple/pull/172)). Precedent for a paired server change: #670.

## What this is

Settings contract **revision 7 → 8**, one new key:

| | |
|---|---|
| Key | `player.apple.control_plane` |
| Type | enum `off` \| `native_direct` \| `loopback` \| `all` |
| Default | `off` (the control plane ships dark) |
| Scope | `profile_device` (matches every other remote `player.*` key) |
| Platforms | ios, tvos, macos |

Semantics — this is the client/server agreement being recorded: `off` keeps every route on the legacy player path; `native_direct` enables the new control plane only for direct-play routes; `loopback` only for loopback routes; `all` enables it everywhere. Route-family values (not a percentage) because the two families fail differently — a regressing direct route can go back to legacy without also reverting loopback. Device scope is what makes rollback targeted: one misbehaving Apple TV returns to `off` without moving the fleet, and no TestFlight release is ever needed to roll back.

The key is **hidden from the web device-settings screen** (it is an operations flag, and its `player` category would otherwise file it under Picture next to HDR) but stays flippable from the admin device-overrides view, which iterates every device-scoped key independently of the hidden set.

## ⚠️ Naming decision — merging ratifies this

`manifest.schema.json` says canonical key names *do not encode a platform*; `player.apple.control_plane` does. The exception is deliberate (rationale in the key's `notes`): what rolls out is one client's playback stack, no other platform can honour the value, and retiring it removes the key rather than generalizing it. The alternative would be `player.control_plane` with the `platforms` field alone carrying the restriction. The `player.apple.*` name is what the remediation program docs have used throughout — but this PR is the sign-off point, so if you prefer the canonical name, say so and it's a one-line change before merge.

## Changes

- `contracts/settings/v1/manifest.json` — the key, revision bump
- `contracts/settings/v1/conformance.json` — 2 new cases: `apple_control_plane_defaults_to_off`, `apple_control_plane_enrolls_one_device`
- `internal/settingskeys/keys.go`, `web/src/lib/settingsContract.ts`, `web/src/lib/settingsConformance.json` — regenerated via `make settings-bindings`, not hand-edited
- `web/src/lib/deviceSettingGroups.ts` + test — key added to `HIDDEN_KEYS` with rationale comment

## Validation

- `go test` over `settingscontract`, `settingsresolve` (both new conformance cases PASS by name), `settingskeys`, `settingsmigrate`, and the settings/device/profile API handler tests — all ok
- `make verify-settings-bindings-all` — bindings current
- `go build ./...` — clean (after the standard `make embed-stub` for a fresh worktree)
- Web: `vitest` full run 1997/2003 — the 6 failures (`SeasonContent.test.tsx`, `ServerStorageStep.test.tsx`, `ResizeObserver is not defined`) reproduce identically at base `80945139`, pre-existing jsdom polyfill gap, unrelated
- Kotlin/Swift binding steps skip when sibling repos aren't checked out beside the worktree (by design); **after this merges**, silo-apple regenerates `SettingKeys.generated.swift` on its side — never before, so clients can't drift ahead of the contract

🤖 Generated with [Claude Code](https://claude.com/claude-code)
