### PR TITLE
fix(metadata): select and cache refresh artwork correctly

### DIFF
--- a/cmd/silo/main.go
+++ b/cmd/silo/main.go
@@ -1593,6 +1593,9 @@ func main() {
 				deps.EventBus,
 				deps.RealtimeHub,
 			)
+			if metadataImageCacheProcessor != nil {
+				itemRefreshExecutor.SetArtworkCacher(metadataImageCacheProcessor)
+			}
 		}
 	}
 

--- a/docs/feature-changelog.md
+++ b/docs/feature-changelog.md
@@ -6,8 +6,9 @@
 Manual Quick and Complete Refresh now finish the selected item's artwork before reporting success instead of leaving it behind the global image-cache backlog.
 - Chooses a text-bearing poster in the library's metadata language, then English, another language, and finally textless artwork.
 - Honors an optional `includes_text` signal from metadata plugins so a language-tagged but textless poster cannot outrank one that actually carries a title.
-- Claims only the refreshed item's cache jobs, retries failed or delayed jobs, and waits for an existing worker without draining unrelated artwork.
-- Replaces the web app's refresh spinner with the final success or failure message.
+- Claims only the refreshed item's cache jobs — including its seasons, episodes, and localizations — retries delayed ones once, and waits briefly on a worker that already holds a job without draining unrelated artwork.
+- Keeps the refresh itself successful when artwork cannot be cached in time: the item, its new artwork paths, and the page it lives on still update, and the leftover artwork is reported as a warning and finishes on the background queue.
+- Replaces the web app's refresh spinner with the final success, warning, or failure message.
 
 ## 2026-08-16
 

--- a/docs/feature-changelog.md
+++ b/docs/feature-changelog.md
@@ -1,5 +1,14 @@
 # Feature Changelog
 
+## 2026-08-19
+
+### Make metadata refresh finish with the right artwork
+Manual Quick and Complete Refresh now finish the selected item's artwork before reporting success instead of leaving it behind the global image-cache backlog.
+- Chooses a text-bearing poster in the library's metadata language, then English, another language, and finally textless artwork.
+- Honors an optional `includes_text` signal from metadata plugins so a language-tagged but textless poster cannot outrank one that actually carries a title.
+- Claims only the refreshed item's cache jobs, retries failed or delayed jobs, and waits for an existing worker without draining unrelated artwork.
+- Replaces the web app's refresh spinner with the final success or failure message.
+
 ## 2026-08-16
 
 ### Let viewers turn the intro prompt off

--- a/internal/adminjob/item_refresh.go
+++ b/internal/adminjob/item_refresh.go
@@ -416,6 +416,10 @@ type ItemRefreshIngester interface {
 	IngestSubtree(ctx context.Context, folder *models.MediaFolder, subtreePath string) (*libraryingest.Result, error)
 }
 
+type ItemRefreshArtworkCacher interface {
+	CacheTargetArtwork(ctx context.Context, targetContentID string) error
+}
+
 type ItemRefreshExecutor struct {
 	folderRepo      itemRefreshFolderRepo
 	fileRepo        itemRefreshFileRepo
@@ -430,8 +434,9 @@ type ItemRefreshExecutor struct {
 		RefreshItemForLibrary(ctx context.Context, contentID string, folderID int) error
 		RefreshTargetForLibrary(ctx context.Context, targetType, contentID string, folderID int) error
 	}
-	eventBus    cache.EventBus
-	realtimeHub *notifications.Hub
+	artworkCacher ItemRefreshArtworkCacher
+	eventBus      cache.EventBus
+	realtimeHub   *notifications.Hub
 }
 
 func NewItemRefreshExecutor(
@@ -466,6 +471,10 @@ func NewItemRefreshExecutor(
 	}
 }
 
+func (e *ItemRefreshExecutor) SetArtworkCacher(cacher ItemRefreshArtworkCacher) {
+	e.artworkCacher = cacher
+}
+
 func (e *ItemRefreshExecutor) Execute(ctx context.Context, req ItemRefreshRequest, progress func(current, total int, message string)) (*ItemRefreshResult, error) {
 	if e.folderRepo == nil || e.ingester == nil || e.refresher == nil {
 		return nil, fmt.Errorf("resolve scan scope: item refresh executor is not fully configured")
@@ -477,6 +486,10 @@ func (e *ItemRefreshExecutor) Execute(ctx context.Context, req ItemRefreshReques
 	}
 	if !folder.Enabled {
 		return nil, fmt.Errorf("resolve scan scope: library is disabled")
+	}
+	progressTotal := 3
+	if e.artworkCacher != nil {
+		progressTotal = 4
 	}
 
 	refreshContentID := req.RefreshContentID
@@ -492,7 +505,7 @@ func (e *ItemRefreshExecutor) Execute(ctx context.Context, req ItemRefreshReques
 	}
 
 	if progress != nil {
-		progress(1, 3, "Scanning scope")
+		progress(1, progressTotal, "Scanning scope")
 	}
 	ingestResult, err := e.ingester.IngestSubtree(ctx, folder, req.ScanPath)
 	if err != nil {
@@ -501,7 +514,7 @@ func (e *ItemRefreshExecutor) Execute(ctx context.Context, req ItemRefreshReques
 	scanResult := ingestResult.ScanResult
 
 	if progress != nil {
-		progress(2, 3, "Matching discovered files")
+		progress(2, progressTotal, "Matching discovered files")
 	}
 	if refreshedFolder, reloadErr := e.folderRepo.GetByID(ctx, req.ScanFolderID); reloadErr == nil && !refreshedFolder.Enabled {
 		return nil, fmt.Errorf("match discovered files: library is disabled")
@@ -520,7 +533,7 @@ func (e *ItemRefreshExecutor) Execute(ctx context.Context, req ItemRefreshReques
 	}
 
 	if progress != nil {
-		progress(3, 3, "Refreshing metadata")
+		progress(3, progressTotal, "Refreshing metadata")
 	}
 	if refreshedFolder, reloadErr := e.folderRepo.GetByID(ctx, req.ScanFolderID); reloadErr == nil && !refreshedFolder.Enabled {
 		return nil, fmt.Errorf("refresh metadata: library is disabled")
@@ -536,6 +549,14 @@ func (e *ItemRefreshExecutor) Execute(ctx context.Context, req ItemRefreshReques
 	}
 	if err := e.refresher.RefreshTargetForLibrary(ctx, refreshTargetType, refreshContentID, req.ScanFolderID); err != nil {
 		return nil, fmt.Errorf("refresh metadata: %w", err)
+	}
+	if e.artworkCacher != nil {
+		if progress != nil {
+			progress(4, progressTotal, "Caching refreshed artwork")
+		}
+		if err := e.artworkCacher.CacheTargetArtwork(ctx, refreshContentID); err != nil {
+			return nil, fmt.Errorf("cache refreshed artwork: %w", err)
+		}
 	}
 
 	e.publish(cache.EventScanComplete, strconv.Itoa(req.ScanFolderID))

--- a/internal/adminjob/item_refresh.go
+++ b/internal/adminjob/item_refresh.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"log/slog"
 	"path/filepath"
 	"strconv"
 	"strings"
@@ -67,6 +68,9 @@ type ItemRefreshResult struct {
 	ScanPath           string              `json:"scan_path"`
 	ScanResult         *scanner.ScanResult `json:"scan_result"`
 	MatchedFiles       int                 `json:"matched_files"`
+	// ArtworkCacheWarning is set when the metadata refresh committed but its
+	// artwork did not finish caching. The refresh itself still succeeded.
+	ArtworkCacheWarning string `json:"artwork_cache_warning,omitempty"`
 }
 
 type itemRefreshItemRepo interface {
@@ -417,6 +421,11 @@ type ItemRefreshIngester interface {
 }
 
 type ItemRefreshArtworkCacher interface {
+	// ArtworkCachingEnabled reports whether caching would actually run. The
+	// cacher is wired whenever object storage is configured, independently of
+	// the metadata.cache_images setting, so the refresh asks before it
+	// advertises an artwork step.
+	ArtworkCachingEnabled() bool
 	CacheTargetArtwork(ctx context.Context, targetContentID string) error
 }
 
@@ -487,8 +496,9 @@ func (e *ItemRefreshExecutor) Execute(ctx context.Context, req ItemRefreshReques
 	if !folder.Enabled {
 		return nil, fmt.Errorf("resolve scan scope: library is disabled")
 	}
+	cacheArtwork := e.artworkCacher != nil && e.artworkCacher.ArtworkCachingEnabled()
 	progressTotal := 3
-	if e.artworkCacher != nil {
+	if cacheArtwork {
 		progressTotal = 4
 	}
 
@@ -550,12 +560,22 @@ func (e *ItemRefreshExecutor) Execute(ctx context.Context, req ItemRefreshReques
 	if err := e.refresher.RefreshTargetForLibrary(ctx, refreshTargetType, refreshContentID, req.ScanFolderID); err != nil {
 		return nil, fmt.Errorf("refresh metadata: %w", err)
 	}
-	if e.artworkCacher != nil {
+	artworkWarning := ""
+	if cacheArtwork {
 		if progress != nil {
 			progress(4, progressTotal, "Caching refreshed artwork")
 		}
+		// The metadata refresh is already committed at this point, so artwork
+		// that fails to cache is reported as a warning on the result. Aborting
+		// here would skip the cache invalidation and the rebuilt content IDs
+		// below, leaving clients pointed at an item that no longer exists.
 		if err := e.artworkCacher.CacheTargetArtwork(ctx, refreshContentID); err != nil {
-			return nil, fmt.Errorf("cache refreshed artwork: %w", err)
+			artworkWarning = err.Error()
+			slog.WarnContext(ctx, "item refresh: artwork caching did not complete",
+				"component", "adminjob",
+				"content_id", refreshContentID,
+				"error", err,
+			)
 		}
 	}
 
@@ -580,12 +600,13 @@ func (e *ItemRefreshExecutor) Execute(ctx context.Context, req ItemRefreshReques
 	}
 
 	return &ItemRefreshResult{
-		RequestedContentID: req.RequestedContentID,
-		RefreshContentID:   refreshContentID,
-		DetailContentID:    detailContentID,
-		ScanPath:           req.ScanPath,
-		ScanResult:         scanResult,
-		MatchedFiles:       matched,
+		RequestedContentID:  req.RequestedContentID,
+		RefreshContentID:    refreshContentID,
+		DetailContentID:     detailContentID,
+		ScanPath:            req.ScanPath,
+		ScanResult:          scanResult,
+		MatchedFiles:        matched,
+		ArtworkCacheWarning: artworkWarning,
 	}, nil
 }
 

--- a/internal/adminjob/item_refresh_test.go
+++ b/internal/adminjob/item_refresh_test.go
@@ -145,10 +145,17 @@ type itemRefreshTestRefresher struct {
 
 type itemRefreshTestArtworkCacher struct {
 	contentID string
+	disabled  bool
+	called    bool
 	err       error
 }
 
+func (c *itemRefreshTestArtworkCacher) ArtworkCachingEnabled() bool {
+	return !c.disabled
+}
+
 func (c *itemRefreshTestArtworkCacher) CacheTargetArtwork(_ context.Context, contentID string) error {
+	c.called = true
 	c.contentID = contentID
 	return c.err
 }
@@ -341,7 +348,7 @@ func TestItemRefreshExecutorAllowsScanPathOutsideLibraryRoots(t *testing.T) {
 	}
 }
 
-func TestItemRefreshExecutorReportsImmediateArtworkCacheFailure(t *testing.T) {
+func TestItemRefreshExecutorReportsArtworkCacheFailureAsWarning(t *testing.T) {
 	t.Parallel()
 
 	executor := NewItemRefreshExecutor(
@@ -359,14 +366,62 @@ func TestItemRefreshExecutorReportsImmediateArtworkCacheFailure(t *testing.T) {
 	)
 	executor.SetArtworkCacher(&itemRefreshTestArtworkCacher{err: errors.New("download failed")})
 
-	_, err := executor.Execute(context.Background(), ItemRefreshRequest{
+	// The metadata refresh is already committed when artwork caching runs, so
+	// a caching failure must not discard the result the client needs.
+	result, err := executor.Execute(context.Background(), ItemRefreshRequest{
 		RequestedContentID: "series-1",
 		RefreshContentID:   "series-1",
 		ScanFolderID:       3,
 		ScanPath:           "/media/series-1",
 	}, nil)
-	if err == nil || !strings.Contains(err.Error(), "cache refreshed artwork: download failed") {
-		t.Fatalf("Execute() error = %v, want artwork cache failure", err)
+	if err != nil {
+		t.Fatalf("Execute() error = %v, want nil", err)
+	}
+	if got, want := result.ArtworkCacheWarning, "download failed"; got != want {
+		t.Fatalf("Execute() artwork warning = %q, want %q", got, want)
+	}
+	if got, want := result.RefreshContentID, "series-1"; got != want {
+		t.Fatalf("Execute() refresh content id = %q, want %q", got, want)
+	}
+}
+
+func TestItemRefreshExecutorSkipsArtworkStepWhenCachingDisabled(t *testing.T) {
+	t.Parallel()
+
+	executor := NewItemRefreshExecutor(
+		&itemRefreshTestFolderRepo{folder: &models.MediaFolder{ID: 3, Enabled: true}},
+		&itemRefreshTestFileRepo{},
+		&itemRefreshTestRootClaimRepo{},
+		&itemRefreshTestGroupClaimRepo{},
+		newItemRefreshTestSkippedRootRepo(),
+		nil,
+		nil,
+		&itemRefreshTestIngester{},
+		&itemRefreshTestRefresher{},
+		nil,
+		nil,
+	)
+	cacher := &itemRefreshTestArtworkCacher{disabled: true}
+	executor.SetArtworkCacher(cacher)
+
+	var totals []int
+	if _, err := executor.Execute(context.Background(), ItemRefreshRequest{
+		RequestedContentID: "series-1",
+		RefreshContentID:   "series-1",
+		ScanFolderID:       3,
+		ScanPath:           "/media/series-1",
+	}, func(_, total int, _ string) {
+		totals = append(totals, total)
+	}); err != nil {
+		t.Fatalf("Execute() error = %v", err)
+	}
+	if cacher.called {
+		t.Fatal("CacheTargetArtwork() called while image caching is disabled")
+	}
+	for _, total := range totals {
+		if total != 3 {
+			t.Fatalf("progress total = %d, want 3", total)
+		}
 	}
 }
 

--- a/internal/adminjob/item_refresh_test.go
+++ b/internal/adminjob/item_refresh_test.go
@@ -143,6 +143,16 @@ type itemRefreshTestRefresher struct {
 	folderID   int
 }
 
+type itemRefreshTestArtworkCacher struct {
+	contentID string
+	err       error
+}
+
+func (c *itemRefreshTestArtworkCacher) CacheTargetArtwork(_ context.Context, contentID string) error {
+	c.contentID = contentID
+	return c.err
+}
+
 func (r *itemRefreshTestRefresher) RefreshItem(_ context.Context, contentID string) error {
 	r.contentID = contentID
 	return nil
@@ -299,6 +309,8 @@ func TestItemRefreshExecutorAllowsScanPathOutsideLibraryRoots(t *testing.T) {
 	skippedRootRepo := newItemRefreshTestSkippedRootRepo()
 
 	executor := NewItemRefreshExecutor(folderRepo, fileRepo, rootClaimRepo, groupClaimRepo, skippedRootRepo, nil, nil, ingester, refresher, nil, nil)
+	artworkCacher := &itemRefreshTestArtworkCacher{}
+	executor.SetArtworkCacher(artworkCacher)
 
 	result, err := executor.Execute(context.Background(), ItemRefreshRequest{
 		RequestedContentID: "119730834381996036",
@@ -321,8 +333,40 @@ func TestItemRefreshExecutorAllowsScanPathOutsideLibraryRoots(t *testing.T) {
 	if got, want := refresher.folderID, 3; got != want {
 		t.Fatalf("RefreshItemForLibrary() folder_id = %d, want %d", got, want)
 	}
+	if got, want := artworkCacher.contentID, "119730834381996036"; got != want {
+		t.Fatalf("CacheTargetArtwork() content_id = %q, want %q", got, want)
+	}
 	if got, want := result.MatchedFiles, 2; got != want {
 		t.Fatalf("Execute() matched files = %d, want %d", got, want)
+	}
+}
+
+func TestItemRefreshExecutorReportsImmediateArtworkCacheFailure(t *testing.T) {
+	t.Parallel()
+
+	executor := NewItemRefreshExecutor(
+		&itemRefreshTestFolderRepo{folder: &models.MediaFolder{ID: 3, Enabled: true}},
+		&itemRefreshTestFileRepo{},
+		&itemRefreshTestRootClaimRepo{},
+		&itemRefreshTestGroupClaimRepo{},
+		newItemRefreshTestSkippedRootRepo(),
+		nil,
+		nil,
+		&itemRefreshTestIngester{},
+		&itemRefreshTestRefresher{},
+		nil,
+		nil,
+	)
+	executor.SetArtworkCacher(&itemRefreshTestArtworkCacher{err: errors.New("download failed")})
+
+	_, err := executor.Execute(context.Background(), ItemRefreshRequest{
+		RequestedContentID: "series-1",
+		RefreshContentID:   "series-1",
+		ScanFolderID:       3,
+		ScanPath:           "/media/series-1",
+	}, nil)
+	if err == nil || !strings.Contains(err.Error(), "cache refreshed artwork: download failed") {
+		t.Fatalf("Execute() error = %v, want artwork cache failure", err)
 	}
 }
 
@@ -367,6 +411,8 @@ func TestItemRefreshExecutorCompleteRefreshRebuildsAndMapsEpisodeTarget(t *testi
 		nil,
 		nil,
 	)
+	artworkCacher := &itemRefreshTestArtworkCacher{}
+	executor.SetArtworkCacher(artworkCacher)
 
 	result, err := executor.Execute(context.Background(), ItemRefreshRequest{
 		RequestedContentID:     "old-episode-id",
@@ -396,6 +442,9 @@ func TestItemRefreshExecutorCompleteRefreshRebuildsAndMapsEpisodeTarget(t *testi
 	}
 	if got, want := refresher.contentID, "new-episode-id"; got != want {
 		t.Fatalf("RefreshItem() content_id = %q, want %q", got, want)
+	}
+	if got, want := artworkCacher.contentID, "new-episode-id"; got != want {
+		t.Fatalf("CacheTargetArtwork() content_id = %q, want %q", got, want)
 	}
 	if got, want := result.RefreshContentID, "new-episode-id"; got != want {
 		t.Fatalf("result refresh_content_id = %q, want %q", got, want)

--- a/internal/adminjob/runner.go
+++ b/internal/adminjob/runner.go
@@ -732,7 +732,14 @@ func (r *Runner) executeItemRefresh(job *models.AdminJob) {
 		r.publishJobByID(ctx, notifications.TypeJobProgress, job.ID)
 	}
 
+	// The executor decides how many steps a refresh has (artwork caching adds a
+	// fourth), so the failure and completion totals track what it published
+	// rather than a hard-coded 3 that would make progress jump backwards.
+	progressTotal := 3
 	result, err := r.itemRefresh.Execute(ctx, req, func(current, total int, message string) {
+		if total > 0 {
+			progressTotal = total
+		}
 		if updateErr := r.repo.UpdateProgress(ctx, job.ID, current, total, message); updateErr != nil {
 			slog.Warn("admin jobs: failed to update item refresh progress",
 				"job_id", job.ID,
@@ -748,21 +755,25 @@ func (r *Runner) executeItemRefresh(job *models.AdminJob) {
 		message := err.Error()
 		switch {
 		case containsPhase(message, "scan scope"):
-			r.failJob(job.ID, 1, 3, "Item refresh failed", message)
+			r.failJob(job.ID, 1, progressTotal, "Item refresh failed", message)
 		case containsPhase(message, "match discovered files"):
-			r.failJob(job.ID, 2, 3, "Item refresh failed", message)
+			r.failJob(job.ID, 2, progressTotal, "Item refresh failed", message)
 		case containsPhase(message, "refresh metadata"):
-			r.failJob(job.ID, 3, 3, "Item refresh failed", message)
+			r.failJob(job.ID, 3, progressTotal, "Item refresh failed", message)
 		default:
-			r.failJob(job.ID, 0, 3, "Item refresh failed", message)
+			r.failJob(job.ID, 0, progressTotal, "Item refresh failed", message)
 		}
 		return
 	}
+	message := "Metadata refreshed"
+	if result != nil && result.ArtworkCacheWarning != "" {
+		message = "Metadata refreshed, artwork incomplete"
+	}
 	if err := r.repo.Complete(ctx, job.ID, CompleteJobInput{
 		ResultPayload:   result,
-		Message:         "Metadata refreshed",
-		ProgressCurrent: 3,
-		ProgressTotal:   3,
+		Message:         message,
+		ProgressCurrent: progressTotal,
+		ProgressTotal:   progressTotal,
 	}); err != nil {
 		slog.Warn("admin jobs: failed to complete item refresh", "job_id", job.ID, "error", err)
 		return

--- a/internal/metadata/image_cache_job_repo.go
+++ b/internal/metadata/image_cache_job_repo.go
@@ -296,6 +296,18 @@ func (r *ImageCacheJobRepository) enqueueBatchChunk(ctx context.Context, inputs 
 	return int(tag.RowsAffected()), nil
 }
 
+// imageCacheTargetScope matches every job an interactive refresh of one
+// content ID is responsible for: the target's own rows plus the rows of its
+// children. Season, episode, and localization jobs are enqueued under their
+// own content ID with series_id pointing at the series, so a series-level
+// refresh only reaches them through series_id. Item and item_localization
+// rows carry series_id = the item's own content ID, so a movie or a
+// season/episode target still matches on target_content_id alone. Person
+// jobs have an empty series_id and stay out of scope.
+func imageCacheTargetScope(param string) string {
+	return "(target_content_id = " + param + " OR series_id = " + param + ")"
+}
+
 func (r *ImageCacheJobRepository) recoverExpiredRunning(ctx context.Context, targetContentID string) error {
 	query := `
 		UPDATE metadata_image_cache_jobs
@@ -320,7 +332,7 @@ func (r *ImageCacheJobRepository) recoverExpiredRunning(ctx context.Context, tar
 	`
 	args := []any{intervalLiteral(imageCacheLeaseDuration), imageCacheMaxAttempts}
 	if targetContentID != "" {
-		query += " AND target_content_id = $3"
+		query += " AND " + imageCacheTargetScope("$3")
 		args = append(args, targetContentID)
 	}
 	_, err := r.pool.Exec(ctx, query, args...)
@@ -351,18 +363,23 @@ func (r *ImageCacheJobRepository) retryTargetNow(ctx context.Context, targetCont
 	if err := r.recoverExpiredRunning(ctx, targetContentID); err != nil {
 		return err
 	}
+	// attempt_count is preserved: a manual refresh buys the target one
+	// immediate retry, it does not reset the retry budget a background worker
+	// already spent on artwork that keeps failing. Failed rows are requeued
+	// regardless of their timer; queued rows are only pulled forward while
+	// they are still deferred, so the reset stays a small, one-off write.
+	// CacheTargetArtwork runs this once per refresh, not once per poll.
 	_, err := r.pool.Exec(ctx, `
 		UPDATE metadata_image_cache_jobs
 		SET status = 'queued',
-			attempt_count = 0,
 			next_attempt_at = NOW(),
 			locked_at = NULL,
 			locked_by = '',
-			last_error = '',
 			completed_at = NULL,
 			updated_at = NOW()
-		WHERE target_content_id = $1
+		WHERE `+imageCacheTargetScope("$1")+`
 		  AND status IN ('queued', 'failed')
+		  AND (status = 'failed' OR next_attempt_at > NOW())
 	`, targetContentID)
 	if err != nil {
 		return fmt.Errorf("retrying target metadata image cache jobs: %w", err)
@@ -391,7 +408,7 @@ func (r *ImageCacheJobRepository) targetHasRunningJobs(ctx context.Context, targ
 		SELECT EXISTS (
 			SELECT 1
 			FROM metadata_image_cache_jobs
-			WHERE target_content_id = $1
+			WHERE `+imageCacheTargetScope("$1")+`
 			  AND status = 'running'
 		)
 	`, targetContentID).Scan(&running); err != nil {
@@ -413,7 +430,7 @@ func (r *ImageCacheJobRepository) claimDue(ctx context.Context, workerID, target
 	`
 	args := []any{limit, workerID}
 	if targetContentID != "" {
-		query += " AND target_content_id = $3"
+		query += " AND " + imageCacheTargetScope("$3")
 		args = append(args, targetContentID)
 	}
 	query += `

--- a/internal/metadata/image_cache_job_repo.go
+++ b/internal/metadata/image_cache_job_repo.go
@@ -296,8 +296,8 @@ func (r *ImageCacheJobRepository) enqueueBatchChunk(ctx context.Context, inputs 
 	return int(tag.RowsAffected()), nil
 }
 
-func (r *ImageCacheJobRepository) recoverExpiredRunning(ctx context.Context) error {
-	_, err := r.pool.Exec(ctx, `
+func (r *ImageCacheJobRepository) recoverExpiredRunning(ctx context.Context, targetContentID string) error {
+	query := `
 		UPDATE metadata_image_cache_jobs
 		SET status = CASE
 				WHEN attempt_count + 1 >= $2 THEN 'failed'
@@ -317,7 +317,13 @@ func (r *ImageCacheJobRepository) recoverExpiredRunning(ctx context.Context) err
 			updated_at = NOW()
 		WHERE status = 'running'
 		  AND locked_at < NOW() - $1::interval
-	`, intervalLiteral(imageCacheLeaseDuration), imageCacheMaxAttempts)
+	`
+	args := []any{intervalLiteral(imageCacheLeaseDuration), imageCacheMaxAttempts}
+	if targetContentID != "" {
+		query += " AND target_content_id = $3"
+		args = append(args, targetContentID)
+	}
+	_, err := r.pool.Exec(ctx, query, args...)
 	if err != nil {
 		return fmt.Errorf("recovering expired metadata image cache jobs: %w", err)
 	}
@@ -328,15 +334,89 @@ func (r *ImageCacheJobRepository) ClaimDue(ctx context.Context, workerID string,
 	if r == nil || r.pool == nil || limit <= 0 {
 		return nil, nil
 	}
-	if err := r.recoverExpiredRunning(ctx); err != nil {
+	if err := r.recoverExpiredRunning(ctx, ""); err != nil {
 		return nil, err
 	}
-	rows, err := r.pool.Query(ctx, `
+	return r.claimDue(ctx, workerID, "", limit)
+}
+
+func (r *ImageCacheJobRepository) retryTargetNow(ctx context.Context, targetContentID string) error {
+	if r == nil || r.pool == nil {
+		return nil
+	}
+	targetContentID = strings.TrimSpace(targetContentID)
+	if targetContentID == "" {
+		return nil
+	}
+	if err := r.recoverExpiredRunning(ctx, targetContentID); err != nil {
+		return err
+	}
+	_, err := r.pool.Exec(ctx, `
+		UPDATE metadata_image_cache_jobs
+		SET status = 'queued',
+			attempt_count = 0,
+			next_attempt_at = NOW(),
+			locked_at = NULL,
+			locked_by = '',
+			last_error = '',
+			completed_at = NULL,
+			updated_at = NOW()
+		WHERE target_content_id = $1
+		  AND status IN ('queued', 'failed')
+	`, targetContentID)
+	if err != nil {
+		return fmt.Errorf("retrying target metadata image cache jobs: %w", err)
+	}
+	return nil
+}
+
+func (r *ImageCacheJobRepository) claimDueForTarget(ctx context.Context, workerID, targetContentID string, limit int) ([]*models.MetadataImageCacheJob, error) {
+	targetContentID = strings.TrimSpace(targetContentID)
+	if targetContentID == "" {
+		return nil, nil
+	}
+	return r.claimDue(ctx, workerID, targetContentID, limit)
+}
+
+func (r *ImageCacheJobRepository) targetHasRunningJobs(ctx context.Context, targetContentID string) (bool, error) {
+	if r == nil || r.pool == nil {
+		return false, nil
+	}
+	targetContentID = strings.TrimSpace(targetContentID)
+	if targetContentID == "" {
+		return false, nil
+	}
+	var running bool
+	if err := r.pool.QueryRow(ctx, `
+		SELECT EXISTS (
+			SELECT 1
+			FROM metadata_image_cache_jobs
+			WHERE target_content_id = $1
+			  AND status = 'running'
+		)
+	`, targetContentID).Scan(&running); err != nil {
+		return false, fmt.Errorf("checking running metadata image cache jobs: %w", err)
+	}
+	return running, nil
+}
+
+func (r *ImageCacheJobRepository) claimDue(ctx context.Context, workerID, targetContentID string, limit int) ([]*models.MetadataImageCacheJob, error) {
+	if r == nil || r.pool == nil || limit <= 0 {
+		return nil, nil
+	}
+	query := `
 		WITH due AS (
 			SELECT id
 			FROM metadata_image_cache_jobs
 			WHERE status = 'queued'
 			  AND next_attempt_at <= NOW()
+	`
+	args := []any{limit, workerID}
+	if targetContentID != "" {
+		query += " AND target_content_id = $3"
+		args = append(args, targetContentID)
+	}
+	query += `
 			ORDER BY next_attempt_at ASC, id ASC
 			LIMIT $1
 			FOR UPDATE SKIP LOCKED
@@ -354,7 +434,8 @@ func (r *ImageCacheJobRepository) ClaimDue(ctx context.Context, workerID string,
 			j.content_type, j.image_type, j.season_number, j.episode_number,
 			j.status, j.attempt_count, j.next_attempt_at, j.locked_at,
 			j.locked_by, j.last_error, j.created_at, j.updated_at, j.completed_at
-	`, limit, workerID)
+	`
+	rows, err := r.pool.Query(ctx, query, args...)
 	if err != nil {
 		return nil, fmt.Errorf("claiming metadata image cache jobs: %w", err)
 	}

--- a/internal/metadata/image_cache_processor.go
+++ b/internal/metadata/image_cache_processor.go
@@ -32,10 +32,22 @@ const maxLocalImageSourceBytes = 8 << 20
 const imageCacheDiscoveryInterval = 15 * time.Minute
 
 const (
-	immediateImageCacheClaimLimit   = 16
-	immediateImageCacheConcurrency  = 3
-	immediateImageCachePollInterval = 100 * time.Millisecond
+	immediateImageCacheClaimLimit  = 16
+	immediateImageCacheConcurrency = 3
+	// Waiting for a background worker to release a job polls with backoff and
+	// gives up after immediateImageCacheIdleTimeout without progress. The
+	// worker's own lease runs for imageCacheLeaseDuration, and its pod can die
+	// while holding it, so an interactive refresh must not wait that long.
+	immediateImageCacheMinPoll     = 100 * time.Millisecond
+	immediateImageCacheMaxPoll     = 2 * time.Second
+	immediateImageCacheIdleTimeout = 30 * time.Second
 )
+
+// ErrTargetArtworkPending reports that some of a refreshed target's artwork was
+// still held by a background worker when the interactive wait gave up. The
+// metadata refresh itself is complete and the artwork finishes on the normal
+// queue, so callers should surface this as a warning, not a failure.
+var ErrTargetArtworkPending = errors.New("artwork caching is still running in the background")
 
 type ImageCacheJobClaimer interface {
 	ClaimDue(ctx context.Context, workerID string, limit int) ([]*models.MetadataImageCacheJob, error)
@@ -124,6 +136,10 @@ type ImageCacheProcessor struct {
 
 	enabled atomic.Bool
 
+	// idleWaitTimeout bounds how long CacheTargetArtwork waits on jobs held by
+	// a background worker. Zero means immediateImageCacheIdleTimeout.
+	idleWaitTimeout time.Duration
+
 	discoveryInterval time.Duration
 	discoveryMu       sync.Mutex
 	lastDiscovery     time.Time
@@ -189,6 +205,7 @@ func NewImageCacheProcessorWithTargets(
 		targets:           targets,
 		logger:            slog.Default(),
 		discoveryInterval: imageCacheDiscoveryInterval,
+		idleWaitTimeout:   immediateImageCacheIdleTimeout,
 	}
 	// Default to enabled; callers gate on metadata.cache_images via SetEnabled.
 	p.enabled.Store(true)
@@ -247,12 +264,22 @@ func (p *ImageCacheProcessor) RunOnce(ctx context.Context, workerID string, clai
 	return stats, nil
 }
 
+// ArtworkCachingEnabled reports whether the processor would actually cache
+// anything right now. Callers use it to decide whether to advertise an artwork
+// step at all: the processor is wired whenever object storage is configured,
+// but metadata.cache_images can still have it turned off.
+func (p *ImageCacheProcessor) ArtworkCachingEnabled() bool {
+	return p != nil && p.jobs != nil && p.cacher != nil && p.enabled.Load()
+}
+
 // CacheTargetArtwork processes only the artwork queued for a manually
-// refreshed item. It also waits for any already-running jobs for that target,
-// so the interactive refresh does not report success before the cached paths
-// have been updated.
+// refreshed item, and for a series also the artwork of its seasons, episodes,
+// and localizations, which are queued under their own content IDs. It waits a
+// bounded while for jobs a background worker already holds so the interactive
+// refresh does not report success before the cached paths have been updated;
+// past that it returns ErrTargetArtworkPending and lets the queue finish.
 func (p *ImageCacheProcessor) CacheTargetArtwork(ctx context.Context, targetContentID string) error {
-	if p == nil || p.jobs == nil || p.cacher == nil || !p.enabled.Load() {
+	if !p.ArtworkCachingEnabled() {
 		return nil
 	}
 	targetContentID = strings.TrimSpace(targetContentID)
@@ -264,24 +291,35 @@ func (p *ImageCacheProcessor) CacheTargetArtwork(ctx context.Context, targetCont
 		return fmt.Errorf("metadata image cache does not support targeted processing")
 	}
 
+	// Once, up front: the user asked for this item, so artwork deferred by an
+	// earlier failure becomes due now. Repeating it on every poll would clear
+	// backoff that background workers set on sibling jobs and would turn the
+	// wait below into a write-heavy hot loop.
+	if err := store.retryTargetNow(ctx, targetContentID); err != nil {
+		return err
+	}
+
+	idleTimeout := p.idleWaitTimeout
+	if idleTimeout <= 0 {
+		idleTimeout = immediateImageCacheIdleTimeout
+	}
 	workerID := uuid.NewString()
+	poll := immediateImageCacheMinPoll
+	deadline := time.Now().Add(idleTimeout)
+	failed := 0
 	for {
-		// A job may already belong to a background worker. Rechecking on every
-		// pass makes its failed or backed-off result immediately claimable once
-		// that worker releases it, without repeatedly retrying failures produced
-		// by this refresh.
-		if err := store.retryTargetNow(ctx, targetContentID); err != nil {
-			return err
-		}
 		jobs, err := store.claimDueForTarget(ctx, workerID, targetContentID, immediateImageCacheClaimLimit)
 		if err != nil {
 			return err
 		}
 		if len(jobs) > 0 {
 			stats := p.processClaimedJobs(ctx, workerID, jobs, immediateImageCacheConcurrency)
-			if stats.Failed > 0 {
-				return fmt.Errorf("%d refreshed artwork image(s) failed to cache", stats.Failed)
-			}
+			// Failures are collected rather than returned: the remaining
+			// artwork still gets cached, and a failed job carries its own
+			// backoff so it is not reclaimed by the loop below.
+			failed += stats.Failed
+			poll = immediateImageCacheMinPoll
+			deadline = time.Now().Add(idleTimeout)
 			continue
 		}
 
@@ -292,13 +330,23 @@ func (p *ImageCacheProcessor) CacheTargetArtwork(ctx context.Context, targetCont
 		if !running {
 			break
 		}
-		timer := time.NewTimer(immediateImageCachePollInterval)
+		if !time.Now().Before(deadline) {
+			if failed > 0 {
+				return fmt.Errorf("%d refreshed artwork image(s) failed to cache, and %w", failed, ErrTargetArtworkPending)
+			}
+			return ErrTargetArtworkPending
+		}
+		timer := time.NewTimer(poll)
 		select {
 		case <-ctx.Done():
 			timer.Stop()
 			return ctx.Err()
 		case <-timer.C:
 		}
+		poll = min(2*poll, immediateImageCacheMaxPoll)
+	}
+	if failed > 0 {
+		return fmt.Errorf("%d refreshed artwork image(s) failed to cache", failed)
 	}
 	return nil
 }

--- a/internal/metadata/image_cache_processor.go
+++ b/internal/metadata/image_cache_processor.go
@@ -17,6 +17,8 @@ import (
 	"sync/atomic"
 	"time"
 
+	"github.com/google/uuid"
+
 	"github.com/Silo-Server/silo-server/internal/models"
 )
 
@@ -29,6 +31,12 @@ const maxLocalImageSourceBytes = 8 << 20
 // Draining of already-queued jobs is unaffected and stays responsive.
 const imageCacheDiscoveryInterval = 15 * time.Minute
 
+const (
+	immediateImageCacheClaimLimit   = 16
+	immediateImageCacheConcurrency  = 3
+	immediateImageCachePollInterval = 100 * time.Millisecond
+)
+
 type ImageCacheJobClaimer interface {
 	ClaimDue(ctx context.Context, workerID string, limit int) ([]*models.MetadataImageCacheJob, error)
 	MarkSucceeded(ctx context.Context, id int64, lockedBy string) error
@@ -37,6 +45,12 @@ type ImageCacheJobClaimer interface {
 	CurrentTargetSourcePath(ctx context.Context, job *models.MetadataImageCacheJob) (string, error)
 	EnqueueExistingProviderArtwork(ctx context.Context, limit int) (int, error)
 	DeleteSucceededBefore(ctx context.Context, before time.Time, limit int) (int, error)
+}
+
+type targetImageCacheJobStore interface {
+	retryTargetNow(ctx context.Context, targetContentID string) error
+	claimDueForTarget(ctx context.Context, workerID, targetContentID string, limit int) ([]*models.MetadataImageCacheJob, error)
+	targetHasRunningJobs(ctx context.Context, targetContentID string) (bool, error)
 }
 
 // imageCacheTargetCachedPathReader is optionally implemented by the job store
@@ -224,10 +238,78 @@ func (p *ImageCacheProcessor) RunOnce(ctx context.Context, workerID string, clai
 	if err != nil {
 		return stats, err
 	}
-	stats.Claimed = len(jobs)
 	if len(jobs) == 0 {
 		p.cleanupSucceeded(ctx, &stats)
 		return stats, nil
+	}
+	stats = p.processClaimedJobs(ctx, workerID, jobs, concurrency)
+	p.cleanupSucceeded(ctx, &stats)
+	return stats, nil
+}
+
+// CacheTargetArtwork processes only the artwork queued for a manually
+// refreshed item. It also waits for any already-running jobs for that target,
+// so the interactive refresh does not report success before the cached paths
+// have been updated.
+func (p *ImageCacheProcessor) CacheTargetArtwork(ctx context.Context, targetContentID string) error {
+	if p == nil || p.jobs == nil || p.cacher == nil || !p.enabled.Load() {
+		return nil
+	}
+	targetContentID = strings.TrimSpace(targetContentID)
+	if targetContentID == "" {
+		return fmt.Errorf("target content ID is required")
+	}
+	store, ok := p.jobs.(targetImageCacheJobStore)
+	if !ok {
+		return fmt.Errorf("metadata image cache does not support targeted processing")
+	}
+
+	workerID := uuid.NewString()
+	for {
+		// A job may already belong to a background worker. Rechecking on every
+		// pass makes its failed or backed-off result immediately claimable once
+		// that worker releases it, without repeatedly retrying failures produced
+		// by this refresh.
+		if err := store.retryTargetNow(ctx, targetContentID); err != nil {
+			return err
+		}
+		jobs, err := store.claimDueForTarget(ctx, workerID, targetContentID, immediateImageCacheClaimLimit)
+		if err != nil {
+			return err
+		}
+		if len(jobs) > 0 {
+			stats := p.processClaimedJobs(ctx, workerID, jobs, immediateImageCacheConcurrency)
+			if stats.Failed > 0 {
+				return fmt.Errorf("%d refreshed artwork image(s) failed to cache", stats.Failed)
+			}
+			continue
+		}
+
+		running, err := store.targetHasRunningJobs(ctx, targetContentID)
+		if err != nil {
+			return err
+		}
+		if !running {
+			break
+		}
+		timer := time.NewTimer(immediateImageCachePollInterval)
+		select {
+		case <-ctx.Done():
+			timer.Stop()
+			return ctx.Err()
+		case <-timer.C:
+		}
+	}
+	return nil
+}
+
+func (p *ImageCacheProcessor) processClaimedJobs(ctx context.Context, workerID string, jobs []*models.MetadataImageCacheJob, concurrency int) ImageCacheRunStats {
+	stats := ImageCacheRunStats{Claimed: len(jobs)}
+	if len(jobs) == 0 {
+		return stats
+	}
+	if concurrency <= 0 {
+		concurrency = 4
 	}
 
 	sem := make(chan struct{}, concurrency)
@@ -277,11 +359,7 @@ loop:
 		cancel()
 	}
 
-	p.cleanupSucceeded(ctx, &stats)
-	if ctxErr := ctx.Err(); ctxErr != nil && stats.Claimed == 0 {
-		return stats, ctxErr
-	}
-	return stats, nil
+	return stats
 }
 
 func (p *ImageCacheProcessor) RunUntilIdle(ctx context.Context, workerID string, claimLimit int, concurrency int, maxRuntime time.Duration) (ImageCacheRunStats, error) {

--- a/internal/metadata/image_cache_processor_test.go
+++ b/internal/metadata/image_cache_processor_test.go
@@ -29,6 +29,7 @@ type targetImageCacheJobs struct {
 	targetCalls    int
 	runningResults []bool
 	runningCalls   int
+	alwaysRunning  bool
 }
 
 func (f *targetImageCacheJobs) retryTargetNow(_ context.Context, targetContentID string) error {
@@ -48,7 +49,7 @@ func (f *targetImageCacheJobs) claimDueForTarget(_ context.Context, _ string, ta
 }
 
 func (f *targetImageCacheJobs) targetHasRunningJobs(_ context.Context, _ string) (bool, error) {
-	running := false
+	running := f.alwaysRunning
 	if f.runningCalls < len(f.runningResults) {
 		running = f.runningResults[f.runningCalls]
 	}
@@ -341,8 +342,9 @@ func TestImageCacheProcessorCachesOnlyManuallyRefreshedTargetImmediately(t *test
 	if jobs.targetCalls != 2 {
 		t.Fatalf("target claim calls = %d, want 2", jobs.targetCalls)
 	}
-	if jobs.retryCalls != 2 {
-		t.Fatalf("target retry calls = %d, want 2", jobs.retryCalls)
+	// The retry-now reset runs once per refresh, not once per poll.
+	if jobs.retryCalls != 1 {
+		t.Fatalf("target retry calls = %d, want 1", jobs.retryCalls)
 	}
 	if jobs.succeededID != 23 {
 		t.Fatalf("succeededID = %d, want 23", jobs.succeededID)
@@ -407,11 +409,37 @@ func TestImageCacheProcessorRetriesTargetAfterConcurrentWorkerFinishes(t *testin
 	if err := processor.CacheTargetArtwork(context.Background(), "series-1"); err != nil {
 		t.Fatalf("CacheTargetArtwork() error = %v", err)
 	}
-	if jobs.retryCalls != 3 {
-		t.Fatalf("target retry calls = %d, want 3", jobs.retryCalls)
+	if jobs.retryCalls != 1 {
+		t.Fatalf("target retry calls = %d, want 1", jobs.retryCalls)
 	}
 	if jobs.succeededID != 25 {
 		t.Fatalf("succeededID = %d, want 25", jobs.succeededID)
+	}
+}
+
+func TestImageCacheProcessorStopsWaitingOnStuckBackgroundWorker(t *testing.T) {
+	// A worker that claimed the job and died holds its lease for
+	// imageCacheLeaseDuration. The interactive refresh must not block that
+	// long: it gives up and reports the artwork as still pending.
+	jobs := &targetImageCacheJobs{alwaysRunning: true}
+	processor := NewImageCacheProcessorWithTargets(
+		jobs,
+		&fakeImageCacher{},
+		&fakeImageResolver{},
+		ImageCacheProcessorTargets{Items: &fakeItemArtworkUpdater{}},
+	)
+	processor.idleWaitTimeout = 20 * time.Millisecond
+
+	err := processor.CacheTargetArtwork(context.Background(), "series-1")
+	if !errors.Is(err, ErrTargetArtworkPending) {
+		t.Fatalf("CacheTargetArtwork() error = %v, want ErrTargetArtworkPending", err)
+	}
+	if jobs.retryCalls != 1 {
+		t.Fatalf("target retry calls = %d, want 1", jobs.retryCalls)
+	}
+	// A hot 10 Hz poll would issue far more probes than this in 20ms.
+	if jobs.runningCalls > 4 {
+		t.Fatalf("running probes = %d, want a backed-off poll", jobs.runningCalls)
 	}
 }
 

--- a/internal/metadata/image_cache_processor_test.go
+++ b/internal/metadata/image_cache_processor_test.go
@@ -3,6 +3,7 @@ package metadata
 import (
 	"context"
 	"errors"
+	"strings"
 	"testing"
 	"time"
 
@@ -17,6 +18,42 @@ type fakeImageCacheJobs struct {
 	deletedCount  int
 	requeuedIDs   []int64
 	currentSource *string // when set, overrides CurrentTargetSourcePath
+}
+
+type targetImageCacheJobs struct {
+	fakeImageCacheJobs
+	retriedTarget  string
+	retryCalls     int
+	claimedTarget  string
+	targetClaims   [][]*models.MetadataImageCacheJob
+	targetCalls    int
+	runningResults []bool
+	runningCalls   int
+}
+
+func (f *targetImageCacheJobs) retryTargetNow(_ context.Context, targetContentID string) error {
+	f.retriedTarget = targetContentID
+	f.retryCalls++
+	return nil
+}
+
+func (f *targetImageCacheJobs) claimDueForTarget(_ context.Context, _ string, targetContentID string, _ int) ([]*models.MetadataImageCacheJob, error) {
+	f.claimedTarget = targetContentID
+	var jobs []*models.MetadataImageCacheJob
+	if f.targetCalls < len(f.targetClaims) {
+		jobs = f.targetClaims[f.targetCalls]
+	}
+	f.targetCalls++
+	return jobs, nil
+}
+
+func (f *targetImageCacheJobs) targetHasRunningJobs(_ context.Context, _ string) (bool, error) {
+	running := false
+	if f.runningCalls < len(f.runningResults) {
+		running = f.runningResults[f.runningCalls]
+	}
+	f.runningCalls++
+	return running, nil
 }
 
 func (f *fakeImageCacheJobs) ClaimDue(context.Context, string, int) ([]*models.MetadataImageCacheJob, error) {
@@ -267,6 +304,114 @@ func TestImageCacheProcessorUpdatesItemArtworkOnSuccess(t *testing.T) {
 	}
 	if items.cachedPath != "tmdb/series/1396/backdrop/original.webp" {
 		t.Fatalf("cachedPath = %q", items.cachedPath)
+	}
+}
+
+func TestImageCacheProcessorCachesOnlyManuallyRefreshedTargetImmediately(t *testing.T) {
+	job := &models.MetadataImageCacheJob{
+		ID:                23,
+		TargetType:        ImageCacheTargetItem,
+		TargetContentID:   "series-1",
+		SourcePath:        "tmdb://poster/series.jpg",
+		ProviderID:        "tmdb",
+		ProviderContentID: "1396",
+		ContentType:       "series",
+		ImageType:         ImageCacheImagePoster,
+	}
+	jobs := &targetImageCacheJobs{
+		targetClaims: [][]*models.MetadataImageCacheJob{{job}, nil},
+	}
+	cacher := &fakeImageCacher{result: &CacheImageResult{
+		BasePath:  "tmdb/series/1396/poster",
+		Ext:       ".webp",
+		Thumbhash: "thumb",
+	}}
+	resolver := &fakeImageResolver{url: "https://image.tmdb.org/t/p/original/poster.jpg"}
+	items := &fakeItemArtworkUpdater{updated: true}
+
+	processor := NewImageCacheProcessorWithTargets(jobs, cacher, resolver, ImageCacheProcessorTargets{
+		Items: items,
+	})
+	if err := processor.CacheTargetArtwork(context.Background(), "series-1"); err != nil {
+		t.Fatalf("CacheTargetArtwork() error = %v", err)
+	}
+	if jobs.retriedTarget != "series-1" || jobs.claimedTarget != "series-1" {
+		t.Fatalf("target retry/claim = %q/%q, want series-1", jobs.retriedTarget, jobs.claimedTarget)
+	}
+	if jobs.targetCalls != 2 {
+		t.Fatalf("target claim calls = %d, want 2", jobs.targetCalls)
+	}
+	if jobs.retryCalls != 2 {
+		t.Fatalf("target retry calls = %d, want 2", jobs.retryCalls)
+	}
+	if jobs.succeededID != 23 {
+		t.Fatalf("succeededID = %d, want 23", jobs.succeededID)
+	}
+	if items.cachedPath != "tmdb/series/1396/poster/original.webp" {
+		t.Fatalf("cachedPath = %q", items.cachedPath)
+	}
+}
+
+func TestImageCacheProcessorReportsImmediateTargetFailure(t *testing.T) {
+	job := &models.MetadataImageCacheJob{
+		ID:                24,
+		TargetType:        ImageCacheTargetItem,
+		TargetContentID:   "series-1",
+		SourcePath:        "tmdb://poster/series.jpg",
+		ProviderID:        "tmdb",
+		ProviderContentID: "1396",
+		ContentType:       "series",
+		ImageType:         ImageCacheImagePoster,
+	}
+	jobs := &targetImageCacheJobs{
+		targetClaims: [][]*models.MetadataImageCacheJob{{job}, nil},
+	}
+	processor := NewImageCacheProcessorWithTargets(
+		jobs,
+		&fakeImageCacher{err: errors.New("cache failed")},
+		&fakeImageResolver{url: "https://image.tmdb.org/t/p/original/poster.jpg"},
+		ImageCacheProcessorTargets{Items: &fakeItemArtworkUpdater{updated: true}},
+	)
+
+	err := processor.CacheTargetArtwork(context.Background(), "series-1")
+	if err == nil || !strings.Contains(err.Error(), "failed to cache") {
+		t.Fatalf("CacheTargetArtwork() error = %v, want cache failure", err)
+	}
+	if jobs.failedID != 24 {
+		t.Fatalf("failedID = %d, want 24", jobs.failedID)
+	}
+}
+
+func TestImageCacheProcessorRetriesTargetAfterConcurrentWorkerFinishes(t *testing.T) {
+	job := &models.MetadataImageCacheJob{
+		ID:                25,
+		TargetType:        ImageCacheTargetItem,
+		TargetContentID:   "series-1",
+		SourcePath:        "tmdb://poster/series.jpg",
+		ProviderID:        "tmdb",
+		ProviderContentID: "1396",
+		ContentType:       "series",
+		ImageType:         ImageCacheImagePoster,
+	}
+	jobs := &targetImageCacheJobs{
+		targetClaims:   [][]*models.MetadataImageCacheJob{nil, {job}, nil},
+		runningResults: []bool{true, false},
+	}
+	processor := NewImageCacheProcessorWithTargets(
+		jobs,
+		&fakeImageCacher{result: &CacheImageResult{BasePath: "tmdb/series/1396/poster", Ext: ".webp"}},
+		&fakeImageResolver{url: "https://image.tmdb.org/t/p/original/poster.jpg"},
+		ImageCacheProcessorTargets{Items: &fakeItemArtworkUpdater{updated: true}},
+	)
+
+	if err := processor.CacheTargetArtwork(context.Background(), "series-1"); err != nil {
+		t.Fatalf("CacheTargetArtwork() error = %v", err)
+	}
+	if jobs.retryCalls != 3 {
+		t.Fatalf("target retry calls = %d, want 3", jobs.retryCalls)
+	}
+	if jobs.succeededID != 25 {
+		t.Fatalf("succeededID = %d, want 25", jobs.succeededID)
 	}
 }
 

--- a/internal/metadata/local_image_source_test.go
+++ b/internal/metadata/local_image_source_test.go
@@ -279,14 +279,16 @@ func TestApplyBestImagesLogoLanguageFallbacks(t *testing.T) {
 	}
 }
 
-func TestApplyBestImagesRejectsLanguageTaggedProviderBackgrounds(t *testing.T) {
+func TestApplyBestImagesFallsBackToLanguageTaggedBackgrounds(t *testing.T) {
+	// Language-neutral backgrounds are preferred, but an item whose backdrops
+	// are all language-tagged must still get one rather than none.
 	item := &models.MediaItem{}
 	applyBestImages(item, []RemoteImage{
 		{ProviderID: "tmdb", URL: "english", Type: ImageBackdrop, Language: "en", Rating: 10},
 		{ProviderID: "tmdb", URL: "german", Type: ImageBackdrop, Language: "de", Rating: 9},
 	}, MergeFillEmpty, "en")
-	if item.BackdropPath != "" {
-		t.Fatalf("BackdropPath = %q, want no language-tagged provider background", item.BackdropPath)
+	if item.BackdropPath != "english" {
+		t.Fatalf("BackdropPath = %q, want a language-tagged fallback background", item.BackdropPath)
 	}
 }
 

--- a/internal/metadata/local_image_source_test.go
+++ b/internal/metadata/local_image_source_test.go
@@ -91,6 +91,7 @@ func TestApplyBestImagesLocalCandidateAlwaysApplies(t *testing.T) {
 	item := &models.MediaItem{PosterPath: "tmdb/movies/550/poster/original.webp"}
 	applyBestImages(item, []RemoteImage{
 		{ProviderID: "nfo", URL: "file:///media/movies/Film/poster.jpg", Type: ImagePoster, Rating: 0},
+		{ProviderID: "tmdb", URL: "https://image.tmdb.org/text.jpg", Type: ImagePoster, Language: "en", Rating: 10},
 	}, MergeFillEmpty, "en")
 	if item.PosterPath != "file:///media/movies/Film/poster.jpg" {
 		t.Fatalf("PosterPath = %q, want local candidate to apply over existing art", item.PosterPath)
@@ -121,6 +122,171 @@ func TestApplyBestImagesRemoteSelectionUnchanged(t *testing.T) {
 	}, MergeFillEmpty, "en")
 	if empty.PosterPath != "https://image.tmdb.org/zero.jpg" {
 		t.Fatalf("PosterPath = %q, rating-0 remote must still fill empty art", empty.PosterPath)
+	}
+}
+
+func TestApplyBestImagesPrefersTextPostersByLanguage(t *testing.T) {
+	includesText := true
+	textless := false
+	tests := []struct {
+		name          string
+		preferredLang string
+		images        []RemoteImage
+		wantPoster    string
+	}{
+		{
+			name:          "explicit text flag beats a higher rated English-tagged textless poster",
+			preferredLang: "en",
+			images: []RemoteImage{
+				{ProviderID: "tvdb", URL: "textless-english", Type: ImagePoster, Language: "en", Rating: 10, IncludesText: &textless},
+				{ProviderID: "tvdb", URL: "english-with-text", Type: ImagePoster, Language: "en", Rating: 6, IncludesText: &includesText},
+			},
+			wantPoster: "english-with-text",
+		},
+		{
+			name:          "explicit textless poster remains the final fallback",
+			preferredLang: "en",
+			images: []RemoteImage{
+				{ProviderID: "tvdb", URL: "textless-english", Type: ImagePoster, Language: "en", Rating: 10, IncludesText: &textless},
+			},
+			wantPoster: "textless-english",
+		},
+		{
+			name:          "preferred language beats higher rated textless poster",
+			preferredLang: "en",
+			images: []RemoteImage{
+				{ProviderID: "tmdb", URL: "textless", Type: ImagePoster, Rating: 10},
+				{ProviderID: "tmdb", URL: "english", Type: ImagePoster, Language: "en", Rating: 7},
+			},
+			wantPoster: "english",
+		},
+		{
+			name:          "preferred language beats higher rated English poster",
+			preferredLang: "fr",
+			images: []RemoteImage{
+				{ProviderID: "tmdb", URL: "french", Type: ImagePoster, Language: "fr", Rating: 6},
+				{ProviderID: "tmdb", URL: "english", Type: ImagePoster, Language: "en", Rating: 9},
+			},
+			wantPoster: "french",
+		},
+		{
+			name:          "English beats higher rated other language when preferred is unavailable",
+			preferredLang: "fr",
+			images: []RemoteImage{
+				{ProviderID: "tmdb", URL: "english", Type: ImagePoster, Language: "en", Rating: 6},
+				{ProviderID: "tmdb", URL: "german", Type: ImagePoster, Language: "de", Rating: 9},
+			},
+			wantPoster: "english",
+		},
+		{
+			name:          "highest rated other language beats textless fallback",
+			preferredLang: "fr",
+			images: []RemoteImage{
+				{ProviderID: "tmdb", URL: "textless", Type: ImagePoster, Rating: 10},
+				{ProviderID: "tmdb", URL: "spanish", Type: ImagePoster, Language: "es", Rating: 6},
+				{ProviderID: "tmdb", URL: "german", Type: ImagePoster, Language: "de", Rating: 8},
+			},
+			wantPoster: "german",
+		},
+		{
+			name:          "textless remains the final fallback",
+			preferredLang: "en",
+			images: []RemoteImage{
+				{ProviderID: "tmdb", URL: "textless-low", Type: ImagePoster, Rating: 4},
+				{ProviderID: "tmdb", URL: "textless-high", Type: ImagePoster, Rating: 8},
+			},
+			wantPoster: "textless-high",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			item := &models.MediaItem{}
+			applyBestImages(item, tt.images, MergeFillEmpty, tt.preferredLang)
+			if item.PosterPath != tt.wantPoster {
+				t.Fatalf("PosterPath = %q, want %q", item.PosterPath, tt.wantPoster)
+			}
+		})
+	}
+}
+
+func TestApplyBestImagesUsesLibraryLanguageForArtwork(t *testing.T) {
+	item := &models.MediaItem{}
+	applyBestImages(item, []RemoteImage{
+		{ProviderID: "tmdb", URL: "poster-textless", Type: ImagePoster, Rating: 10},
+		{ProviderID: "tmdb", URL: "poster-english", Type: ImagePoster, Language: "en", Rating: 7},
+		{ProviderID: "tmdb", URL: "backdrop-textless", Type: ImageBackdrop, Rating: 10},
+		{ProviderID: "tmdb", URL: "backdrop-english", Type: ImageBackdrop, Language: "en", Rating: 7},
+		{ProviderID: "tmdb", URL: "logo-textless", Type: ImageLogo, Rating: 10},
+		{ProviderID: "tmdb", URL: "logo-english", Type: ImageLogo, Language: "en", Rating: 7},
+	}, MergeFillEmpty, "en")
+
+	if item.PosterPath != "poster-english" {
+		t.Fatalf("PosterPath = %q, want text poster", item.PosterPath)
+	}
+	if item.BackdropPath != "backdrop-textless" {
+		t.Fatalf("BackdropPath = %q, want language-neutral background", item.BackdropPath)
+	}
+	if item.LogoPath != "logo-english" {
+		t.Fatalf("LogoPath = %q, want English logo", item.LogoPath)
+	}
+}
+
+func TestApplyBestImagesLogoLanguageFallbacks(t *testing.T) {
+	tests := []struct {
+		name          string
+		preferredLang string
+		images        []RemoteImage
+		wantLogo      string
+	}{
+		{
+			name:          "preferred language beats higher rated English logo",
+			preferredLang: "fr",
+			images: []RemoteImage{
+				{ProviderID: "tmdb", URL: "french", Type: ImageLogo, Language: "fr", Rating: 6},
+				{ProviderID: "tmdb", URL: "english", Type: ImageLogo, Language: "en", Rating: 9},
+			},
+			wantLogo: "french",
+		},
+		{
+			name:          "English is the cross-language fallback",
+			preferredLang: "fr",
+			images: []RemoteImage{
+				{ProviderID: "tmdb", URL: "english", Type: ImageLogo, Language: "en", Rating: 6},
+				{ProviderID: "tmdb", URL: "neutral", Type: ImageLogo, Rating: 10},
+			},
+			wantLogo: "english",
+		},
+		{
+			name:          "language-neutral beats unrelated language",
+			preferredLang: "en",
+			images: []RemoteImage{
+				{ProviderID: "tmdb", URL: "german", Type: ImageLogo, Language: "de", Rating: 10},
+				{ProviderID: "tmdb", URL: "neutral", Type: ImageLogo, Rating: 6},
+			},
+			wantLogo: "neutral",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			item := &models.MediaItem{}
+			applyBestImages(item, tt.images, MergeFillEmpty, tt.preferredLang)
+			if item.LogoPath != tt.wantLogo {
+				t.Fatalf("LogoPath = %q, want %q", item.LogoPath, tt.wantLogo)
+			}
+		})
+	}
+}
+
+func TestApplyBestImagesRejectsLanguageTaggedProviderBackgrounds(t *testing.T) {
+	item := &models.MediaItem{}
+	applyBestImages(item, []RemoteImage{
+		{ProviderID: "tmdb", URL: "english", Type: ImageBackdrop, Language: "en", Rating: 10},
+		{ProviderID: "tmdb", URL: "german", Type: ImageBackdrop, Language: "de", Rating: 9},
+	}, MergeFillEmpty, "en")
+	if item.BackdropPath != "" {
+		t.Fatalf("BackdropPath = %q, want no language-tagged provider background", item.BackdropPath)
 	}
 }
 

--- a/internal/metadata/plugin_provider.go
+++ b/internal/metadata/plugin_provider.go
@@ -379,10 +379,26 @@ func (p *PluginProvider) GetImages(ctx context.Context, req ImageRequest) ([]Rem
 			if v, ok := md.GetFields()["rating"]; ok {
 				ri.Rating = v.GetNumberValue()
 			}
+			ri.IncludesText = imageMetadataBool(md, "includes_text")
 		}
 		images = append(images, ri)
 	}
 	return images, nil
+}
+
+func imageMetadataBool(md *structpb.Struct, key string) *bool {
+	if md == nil {
+		return nil
+	}
+	value, ok := md.GetFields()[key]
+	if !ok || value == nil {
+		return nil
+	}
+	if _, ok := value.GetKind().(*structpb.Value_BoolValue); !ok {
+		return nil
+	}
+	result := value.GetBoolValue()
+	return &result
 }
 
 func (p *PluginProvider) GetSeasons(ctx context.Context, req SeasonsRequest) ([]SeasonResult, error) {

--- a/internal/metadata/plugin_provider_test.go
+++ b/internal/metadata/plugin_provider_test.go
@@ -400,6 +400,53 @@ func TestPluginProviderAssetRequests_ForwardProviderContext(t *testing.T) {
 	})
 }
 
+func TestPluginProviderGetImages_MapsIncludesTextMetadata(t *testing.T) {
+	metadata, err := structpb.NewStruct(map[string]any{
+		"rating":        8.5,
+		"includes_text": false,
+	})
+	if err != nil {
+		t.Fatalf("structpb.NewStruct() error = %v", err)
+	}
+	client := &fakePluginMetadataClient{
+		imagesResponse: &pluginv1.GetImagesResponse{Images: []*pluginv1.ImageRecord{
+			{
+				Url:      "https://artworks.thetvdb.com/example.jpg",
+				Kind:     "poster",
+				Language: "en",
+				Metadata: metadata,
+			},
+		}},
+	}
+	provider, err := NewPluginProviderWithClientFactory(map[string]string{
+		pluginInstallationIDSetting: "1",
+		capabilityIDSetting:         "tvdb",
+	}, func(context.Context, int, string) (pluginMetadataClient, error) {
+		return client, nil
+	})
+	if err != nil {
+		t.Fatalf("NewPluginProviderWithClientFactory() error = %v", err)
+	}
+
+	images, err := provider.GetImages(context.Background(), ImageRequest{
+		ProviderIDs: map[string]string{"tvdb": "series-1"},
+		ContentType: "series",
+		Language:    "en",
+	})
+	if err != nil {
+		t.Fatalf("GetImages() error = %v", err)
+	}
+	if len(images) != 1 {
+		t.Fatalf("GetImages() returned %d images, want 1", len(images))
+	}
+	if images[0].Rating != 8.5 {
+		t.Fatalf("Rating = %v, want 8.5", images[0].Rating)
+	}
+	if images[0].IncludesText == nil || *images[0].IncludesText {
+		t.Fatalf("IncludesText = %v, want explicit false", images[0].IncludesText)
+	}
+}
+
 func mustStructFromStringMap(t *testing.T, values map[string]string) *structpb.Struct {
 	t.Helper()
 

--- a/internal/metadata/service.go
+++ b/internal/metadata/service.go
@@ -6725,11 +6725,7 @@ func metadataResultToItem(r *MetadataResult, contentType string) *models.MediaIt
 
 func applyBestImages(item *models.MediaItem, images []RemoteImage, mode MergeMode, preferredLang string) {
 	// Images arrive in provider-chain order (highest priority first).
-	// For each image type, pick the best image using a fallback chain:
-	//   1. Preferred language or language-neutral
-	//   2. English or language-neutral (if preferred != "en")
-	//   3. Any language
-	// Within each pass, the first provider with a match wins; within
+	// Within each language tier, the first provider with a match wins; within
 	// that provider, pick the highest-rated image.
 	type best struct {
 		url        string
@@ -6737,49 +6733,91 @@ func applyBestImages(item *models.MediaItem, images []RemoteImage, mode MergeMod
 		providerID string
 	}
 
-	filters := []func(string) bool{
-		func(l string) bool { return l == "" || l == preferredLang },
+	selectBest := func(imageType ImageType, filters []func(RemoteImage) bool) *best {
+		for _, img := range images {
+			if img.Type == imageType && img.URL != "" && isLocalImageSourcePath(img.URL) {
+				return &best{url: img.URL, rating: img.Rating, providerID: img.ProviderID}
+			}
+		}
+
+		for _, accept := range filters {
+			candidate := &best{}
+			for _, img := range images {
+				if img.Type != imageType || img.URL == "" || !accept(img) {
+					continue
+				}
+				if candidate.url == "" {
+					candidate.url = img.URL
+					candidate.rating = img.Rating
+					candidate.providerID = img.ProviderID
+				} else if img.ProviderID == candidate.providerID && img.Rating > candidate.rating {
+					candidate.url = img.URL
+					candidate.rating = img.Rating
+				}
+			}
+			if candidate.url != "" {
+				return candidate
+			}
+		}
+		return &best{}
 	}
-	if preferredLang != "en" {
-		filters = append(filters, func(l string) bool { return l == "" || l == "en" })
+
+	preferredLang = strings.TrimSpace(preferredLang)
+	languageIs := func(want string) func(RemoteImage) bool {
+		return func(img RemoteImage) bool {
+			return strings.EqualFold(strings.TrimSpace(img.Language), want)
+		}
 	}
-	filters = append(filters, func(string) bool { return true })
+	hasLanguage := func(img RemoteImage) bool {
+		return strings.TrimSpace(img.Language) != ""
+	}
+	languageNeutral := func(img RemoteImage) bool {
+		return strings.TrimSpace(img.Language) == ""
+	}
+	posterHasText := func(img RemoteImage) bool {
+		if img.IncludesText != nil {
+			return *img.IncludesText
+		}
+		return hasLanguage(img)
+	}
+	posterLanguageIs := func(want string) func(RemoteImage) bool {
+		return func(img RemoteImage) bool {
+			return posterHasText(img) && strings.EqualFold(strings.TrimSpace(img.Language), want)
+		}
+	}
+	posterTextless := func(img RemoteImage) bool {
+		return !posterHasText(img)
+	}
+
+	// Posters should carry a title in the library's metadata language. English
+	// is the cross-language fallback, followed by another text-bearing poster;
+	// textless artwork is used only when no poster with text is available.
+	posterFilters := make([]func(RemoteImage) bool, 0, 4)
+	if preferredLang != "" {
+		posterFilters = append(posterFilters, posterLanguageIs(preferredLang))
+	}
+	if !strings.EqualFold(preferredLang, "en") {
+		posterFilters = append(posterFilters, posterLanguageIs("en"))
+	}
+	posterFilters = append(posterFilters, posterHasText, posterTextless)
+
+	// Logos also follow the library language. A language-neutral logo is a safer
+	// fallback than a logo explicitly tagged with an unrelated language.
+	logoFilters := make([]func(RemoteImage) bool, 0, 4)
+	if preferredLang != "" {
+		logoFilters = append(logoFilters, languageIs(preferredLang))
+	}
+	if !strings.EqualFold(preferredLang, "en") {
+		logoFilters = append(logoFilters, languageIs("en"))
+	}
+	logoFilters = append(logoFilters, languageNeutral, hasLanguage)
 
 	bestByType := map[ImageType]*best{
-		ImagePoster:   {},
-		ImageBackdrop: {},
-		ImageLogo:     {},
-	}
-
-	for _, accept := range filters {
-		for _, img := range images {
-			if img.URL == "" || !accept(img.Language) {
-				continue
-			}
-			b := bestByType[img.Type]
-			if b == nil {
-				continue
-			}
-			if b.url == "" {
-				b.url = img.URL
-				b.rating = img.Rating
-				b.providerID = img.ProviderID
-			} else if img.ProviderID == b.providerID && img.Rating > b.rating {
-				b.url = img.URL
-				b.rating = img.Rating
-			}
-		}
-		// Stop if every type has a candidate.
-		allFilled := true
-		for _, b := range bestByType {
-			if b.url == "" {
-				allFilled = false
-				break
-			}
-		}
-		if allFilled {
-			break
-		}
+		ImagePoster: selectBest(ImagePoster, posterFilters),
+		// Provider backdrops tagged with a language may contain text. Automatic
+		// scans therefore select only language-neutral backgrounds.
+		ImageBackdrop: selectBest(ImageBackdrop, []func(RemoteImage) bool{languageNeutral}),
+		ImageLogo:     selectBest(ImageLogo, logoFilters),
 	}
 
 	applyIfBetter := func(current *string, b *best) {

--- a/internal/metadata/service.go
+++ b/internal/metadata/service.go
@@ -6814,9 +6814,11 @@ func applyBestImages(item *models.MediaItem, images []RemoteImage, mode MergeMod
 
 	bestByType := map[ImageType]*best{
 		ImagePoster: selectBest(ImagePoster, posterFilters),
-		// Provider backdrops tagged with a language may contain text. Automatic
-		// scans therefore select only language-neutral backgrounds.
-		ImageBackdrop: selectBest(ImageBackdrop, []func(RemoteImage) bool{languageNeutral}),
+		// Provider backdrops tagged with a language may contain text, so
+		// language-neutral backgrounds win. A tagged backdrop is still better
+		// than none, so it stays as the terminal tier: items whose backdrops
+		// are all language-tagged must not end up with no backdrop at all.
+		ImageBackdrop: selectBest(ImageBackdrop, []func(RemoteImage) bool{languageNeutral, hasLanguage}),
 		ImageLogo:     selectBest(ImageLogo, logoFilters),
 	}
 

--- a/internal/metadata/types.go
+++ b/internal/metadata/types.go
@@ -338,13 +338,14 @@ type ImageRequest struct {
 
 // RemoteImage describes an available image from a provider.
 type RemoteImage struct {
-	ProviderID string // Slug of the provider that returned this image
-	URL        string
-	Type       ImageType
-	Language   string
-	Width      int
-	Height     int
-	Rating     float64 // Vote average for ordering
+	ProviderID   string // Slug of the provider that returned this image
+	URL          string
+	Type         ImageType
+	Language     string
+	Width        int
+	Height       int
+	Rating       float64 // Vote average for ordering
+	IncludesText *bool   // nil when the provider does not report text presence
 }
 
 // ImageType classifies image purpose.

--- a/migrations/sql/20260819060028_add_metadata_image_cache_target_index.sql
+++ b/migrations/sql/20260819060028_add_metadata_image_cache_target_index.sql
@@ -1,0 +1,28 @@
+-- +goose NO TRANSACTION
+-- +goose Up
+-- Interactive metadata refreshes requeue, claim, and observe artwork jobs by
+-- target. Keep those operations independent of the size of the global cache
+-- backlog while preserving due-time order within a target.
+-- +goose StatementBegin
+DO $$
+BEGIN
+    IF EXISTS (
+        SELECT 1
+        FROM pg_class c
+        JOIN pg_namespace n ON n.oid = c.relnamespace
+        JOIN pg_index i ON i.indexrelid = c.oid
+        WHERE n.nspname = 'public'
+          AND c.relname = 'metadata_image_cache_jobs_target_status_due_idx'
+          AND NOT i.indisvalid
+    ) THEN
+        DROP INDEX public.metadata_image_cache_jobs_target_status_due_idx;
+    END IF;
+END;
+$$;
+-- +goose StatementEnd
+
+CREATE INDEX CONCURRENTLY IF NOT EXISTS metadata_image_cache_jobs_target_status_due_idx
+ON public.metadata_image_cache_jobs (target_content_id, status, next_attempt_at, id);
+
+-- +goose Down
+DROP INDEX CONCURRENTLY IF EXISTS public.metadata_image_cache_jobs_target_status_due_idx;

--- a/web/src/hooks/queries/items.test.ts
+++ b/web/src/hooks/queries/items.test.ts
@@ -6,6 +6,7 @@ const mocks = vi.hoisted(() => ({
   isItemDetailQueryKey: vi.fn((_queryKey: unknown, _itemId: string) => true),
   updateCatalogItemDetail: vi.fn(),
   toastError: vi.fn(),
+  toastLoading: vi.fn(),
   toastSuccess: vi.fn(),
   useMutation: vi.fn(),
   useQueryClient: vi.fn(),
@@ -56,11 +57,17 @@ vi.mock("@/pages/homeSurfaceRefresh", () => ({
 vi.mock("sonner", () => ({
   toast: {
     error: (...args: unknown[]) => mocks.toastError(...args),
+    loading: (...args: unknown[]) => mocks.toastLoading(...args),
     success: (...args: unknown[]) => mocks.toastSuccess(...args),
   },
 }));
 
-import { fetchWatchDetail, redetectEpisodeIntro, useWatchedStateMutation } from "./items";
+import {
+  fetchWatchDetail,
+  redetectEpisodeIntro,
+  useRefreshItemMetadata,
+  useWatchedStateMutation,
+} from "./items";
 
 type WatchedMutationContext = { previous: Array<[readonly unknown[], unknown]> };
 
@@ -72,6 +79,27 @@ type WatchedMutationOptions = {
   onSettled?: () => Promise<unknown>;
 };
 
+type RefreshMetadataVariables = {
+  item: { content_id: string; type: string };
+  mode: "quick" | "complete";
+};
+
+type RefreshMetadataContext = { toastID: string | number };
+
+type RefreshMetadataMutationOptions = {
+  onMutate?: (variables: RefreshMetadataVariables) => RefreshMetadataContext;
+  onSuccess?: (
+    data: { job: { result_payload?: Record<string, unknown> } },
+    variables: RefreshMetadataVariables,
+    context?: RefreshMetadataContext,
+  ) => Promise<void>;
+  onError?: (
+    err: unknown,
+    variables: RefreshMetadataVariables,
+    context?: RefreshMetadataContext,
+  ) => void;
+};
+
 describe("item query helpers", () => {
   beforeEach(() => {
     mocks.api.mockReset();
@@ -81,6 +109,8 @@ describe("item query helpers", () => {
     mocks.isItemDetailQueryKey.mockReset();
     mocks.isItemDetailQueryKey.mockReturnValue(true);
     mocks.toastError.mockReset();
+    mocks.toastLoading.mockReset();
+    mocks.toastLoading.mockReturnValue("refresh-toast");
     mocks.toastSuccess.mockReset();
     mocks.useMutation.mockReset();
     mocks.useMutation.mockImplementation((options: unknown) => ({
@@ -105,6 +135,45 @@ describe("item query helpers", () => {
 
     expect(mocks.api).toHaveBeenCalledWith("/admin/items/episode%201%2Fid%3Aabc/redetect-intro", {
       method: "POST",
+    });
+  });
+
+  it("shows one spinning refresh notification and replaces it with success", async () => {
+    const invalidateQueries = vi.fn().mockResolvedValue(undefined);
+    mocks.useQueryClient.mockReturnValue({ invalidateQueries });
+
+    useRefreshItemMetadata();
+    const options = mocks.useMutation.mock.calls[
+      mocks.useMutation.mock.calls.length - 1
+    ]?.[0] as RefreshMetadataMutationOptions;
+    const variables: RefreshMetadataVariables = {
+      item: { content_id: "series-1", type: "series" },
+      mode: "quick",
+    };
+
+    const context = options.onMutate?.(variables);
+    expect(mocks.toastLoading).toHaveBeenCalledWith("Quick metadata refresh running…");
+
+    await options.onSuccess?.({ job: { result_payload: {} } }, variables, context);
+    expect(mocks.toastSuccess).toHaveBeenCalledWith("Metadata refreshed", {
+      id: "refresh-toast",
+    });
+  });
+
+  it("replaces the spinning refresh notification with a failure", () => {
+    useRefreshItemMetadata();
+    const options = mocks.useMutation.mock.calls[
+      mocks.useMutation.mock.calls.length - 1
+    ]?.[0] as RefreshMetadataMutationOptions;
+    const variables: RefreshMetadataVariables = {
+      item: { content_id: "series-1", type: "series" },
+      mode: "quick",
+    };
+    const context = options.onMutate?.(variables);
+
+    options.onError?.(new Error("Artwork download failed"), variables, context);
+    expect(mocks.toastError).toHaveBeenCalledWith("Artwork download failed", {
+      id: "refresh-toast",
     });
   });
 

--- a/web/src/hooks/queries/items.test.ts
+++ b/web/src/hooks/queries/items.test.ts
@@ -8,6 +8,7 @@ const mocks = vi.hoisted(() => ({
   toastError: vi.fn(),
   toastLoading: vi.fn(),
   toastSuccess: vi.fn(),
+  toastWarning: vi.fn(),
   useMutation: vi.fn(),
   useQueryClient: vi.fn(),
 }));
@@ -59,6 +60,7 @@ vi.mock("sonner", () => ({
     error: (...args: unknown[]) => mocks.toastError(...args),
     loading: (...args: unknown[]) => mocks.toastLoading(...args),
     success: (...args: unknown[]) => mocks.toastSuccess(...args),
+    warning: (...args: unknown[]) => mocks.toastWarning(...args),
   },
 }));
 
@@ -112,6 +114,7 @@ describe("item query helpers", () => {
     mocks.toastLoading.mockReset();
     mocks.toastLoading.mockReturnValue("refresh-toast");
     mocks.toastSuccess.mockReset();
+    mocks.toastWarning.mockReset();
     mocks.useMutation.mockReset();
     mocks.useMutation.mockImplementation((options: unknown) => ({
       ...(options as object),
@@ -158,6 +161,45 @@ describe("item query helpers", () => {
     expect(mocks.toastSuccess).toHaveBeenCalledWith("Metadata refreshed", {
       id: "refresh-toast",
     });
+  });
+
+  it("warns when the refresh succeeded but artwork caching did not finish", async () => {
+    const invalidateQueries = vi.fn().mockResolvedValue(undefined);
+    mocks.useQueryClient.mockReturnValue({ invalidateQueries });
+
+    useRefreshItemMetadata();
+    const options = mocks.useMutation.mock.calls[
+      mocks.useMutation.mock.calls.length - 1
+    ]?.[0] as RefreshMetadataMutationOptions;
+    const variables: RefreshMetadataVariables = {
+      item: { content_id: "series-1", type: "series" },
+      mode: "quick",
+    };
+
+    const context = options.onMutate?.(variables);
+    await options.onSuccess?.(
+      {
+        job: {
+          result_payload: {
+            refresh_content_id: "series-1",
+            artwork_cache_warning: "2 refreshed artwork image(s) failed to cache",
+          },
+        },
+      },
+      variables,
+      context,
+    );
+
+    expect(mocks.toastSuccess).not.toHaveBeenCalled();
+    expect(mocks.toastWarning).toHaveBeenCalledWith(
+      "Metadata refreshed, but artwork caching did not finish",
+      {
+        id: "refresh-toast",
+        description: "2 refreshed artwork image(s) failed to cache",
+      },
+    );
+    // The refresh still committed, so the caches must be invalidated anyway.
+    expect(invalidateQueries).toHaveBeenCalled();
   });
 
   it("replaces the spinning refresh notification with a failure", () => {

--- a/web/src/hooks/queries/items.ts
+++ b/web/src/hooks/queries/items.ts
@@ -73,10 +73,21 @@ interface ItemRefreshJobResult {
   };
 }
 
+interface RefreshItemMetadataContext {
+  toastID: string | number;
+}
+
 export function useRefreshItemMetadata() {
   const queryClient = useQueryClient();
   const { awaitAdminJob } = useRealtimeEvents();
   return useMutation({
+    onMutate: ({ mode }: RefreshItemMetadataVariables): RefreshItemMetadataContext => ({
+      toastID: toast.loading(
+        mode === "complete"
+          ? "Complete metadata refresh running…"
+          : "Quick metadata refresh running…",
+      ),
+    }),
     mutationFn: async ({ item, mode }: RefreshItemMetadataVariables) => {
       const job = await api<AdminJob>(
         `/admin/items/${itemPathID(item.content_id)}/refresh-metadata`,
@@ -88,20 +99,21 @@ export function useRefreshItemMetadata() {
       const completed = await awaitAdminJob(job.id);
       return { job: completed };
     },
-    onSuccess: async ({ job }, { item, mode, onReplaced }) => {
+    onSuccess: async ({ job }, { item, mode, onReplaced }, context) => {
       const result = (job.result_payload ?? {}) as ItemRefreshJobResult;
       const refreshContentID = result.refresh_content_id;
       const detailContentID = result.detail_content_id;
       const newFiles = result.scan_result?.new ?? 0;
 
       if (mode === "complete") {
-        toast.success("Complete refresh finished");
+        toast.success("Complete refresh finished", { id: context?.toastID });
       } else if (newFiles > 0) {
         toast.success(
           `Metadata refreshed. Found ${newFiles} new file version${newFiles === 1 ? "" : "s"}`,
+          { id: context?.toastID },
         );
       } else {
-        toast.success("Metadata refreshed");
+        toast.success("Metadata refreshed", { id: context?.toastID });
       }
 
       await Promise.all([
@@ -173,8 +185,10 @@ export function useRefreshItemMetadata() {
         await onReplaced(detailContentID);
       }
     },
-    onError: (err) => {
-      toast.error(err instanceof Error ? err.message : "Refresh failed");
+    onError: (err, _variables, context) => {
+      toast.error(err instanceof Error ? err.message : "Refresh failed", {
+        id: context?.toastID,
+      });
     },
   });
 }

--- a/web/src/hooks/queries/items.ts
+++ b/web/src/hooks/queries/items.ts
@@ -68,6 +68,9 @@ interface ItemRefreshJobResult {
   detail_content_id?: string;
   scan_path?: string;
   matched_files?: number;
+  // Set when the metadata refresh committed but its artwork did not finish
+  // caching. The refresh itself succeeded, so this is a warning, not an error.
+  artwork_cache_warning?: string;
   scan_result?: {
     new?: number;
   };
@@ -104,8 +107,14 @@ export function useRefreshItemMetadata() {
       const refreshContentID = result.refresh_content_id;
       const detailContentID = result.detail_content_id;
       const newFiles = result.scan_result?.new ?? 0;
+      const artworkWarning = result.artwork_cache_warning;
 
-      if (mode === "complete") {
+      if (artworkWarning) {
+        toast.warning("Metadata refreshed, but artwork caching did not finish", {
+          id: context?.toastID,
+          description: artworkWarning,
+        });
+      } else if (mode === "complete") {
         toast.success("Complete refresh finished", { id: context?.toastID });
       } else if (newFiles > 0) {
         toast.success(


### PR DESCRIPTION
## Problem

Related to #211; this PR does not close it.

Manual Quick and Complete Refresh can finish metadata while the selected item's artwork remains queued behind the global image-cache backlog. Poster selection also has no way to distinguish a genuinely text-bearing poster from a language-tagged but textless poster, so an English library can keep the wrong artwork.

## Approach

- Add an optional, backward-compatible `includes_text` image signal and use four explicit poster tiers: preferred-language text, English text, other text, then textless. Local sidecars remain authoritative; backgrounds remain language-neutral; logos retain language-aware fallbacks.
- Give interactive refreshes a target-scoped cache path that retries failed/backed-off jobs, waits for a concurrent worker, reports cache failures, and never drains unrelated artwork. A concurrent index keeps those target operations independent of global backlog size.
- Wire both Quick and Complete Refresh through that path, including the remapped content ID after Complete Refresh.
- Replace the Web UI's loading toast in place with the final success or failure toast.

### Authorship and live verification

All of this work is mine. I tested it end-to-end in my live Silo installation and confirmed that it works.

Codex assisted with upstream cleanup, tests, adversarial review, and PR preparation as disclosed below.

## Testing

Focused Go tests:

```text
$ go test ./internal/metadata ./internal/adminjob
ok  github.com/Silo-Server/silo-server/internal/metadata  (cached)
ok  github.com/Silo-Server/silo-server/internal/adminjob  (cached)

$ go test -race ./internal/metadata ./internal/adminjob
ok  github.com/Silo-Server/silo-server/internal/metadata  2.006s
ok  github.com/Silo-Server/silo-server/internal/adminjob  2.199s
```

CI-equivalent changed-line lint:

```text
$ golangci-lint run --new-from-merge-base=upstream/main ./...
0 issues.
```

Changed Web tests and formatting:

```text
$ pnpm exec vitest run src/hooks/queries/items.test.ts
Test Files  1 passed (1)
Tests       8 passed (8)

$ pnpm exec prettier --check src/hooks/queries/items.ts src/hooks/queries/items.test.ts
Checking formatting...
All matched files use Prettier code style!
```

Additional successful checks:

- `go vet ./internal/metadata ./internal/adminjob ./cmd/silo`
- `go build ./internal/... ./cmd/...`
- `make migrate-validate`
- `make verify-local-paths`
- `pnpm exec eslint src/hooks/queries/items.ts src/hooks/queries/items.test.ts`
- Full Web suite: 278 files and 1,960 tests passed
- Full Web lint: 0 errors (151 existing warnings)
- Full Web format check and production build passed

The legacy unscoped `make lint` was run and reported the documented upstream baseline of 300 findings; the PR/CI changed-line gate above is clean. A full local `make test-go` also reached unrelated macOS-sensitive failures in `internal/jellycompat` process-lock identity tests and fake-NVENC playback probes; all changed packages passed, and a transient `internal/transcodenode` timing failure passed in isolation.

A new screenshot/recording is not attached because capturing the transient toast would require triggering another metadata-changing live refresh. The behavior has already been live-tested; visual evidence can be added if maintainers require it.

## Adversarial review

The diff review found two material issues and both were fixed before publishing:

1. A background worker could release a failed target job after the interactive loop checked it, causing a false success. The loop now requeues target failures/backoff on every pass and has a regression test for the concurrent-worker handoff.
2. The first optional-target SQL predicate could prevent efficient index use on the global path. Targeted and global claims now use fixed query shapes, backed by a dedicated target/status/due index.

The final pass also checked local artwork precedence, provider ordering within tiers, background/logo fallbacks, Complete Refresh ID remapping, error propagation, and per-mutation toast identity. No material findings remain.

## Risks & follow-up

- Metadata providers must emit the canonical optional `includes_text` field to distinguish language-tagged textless posters. Providers that do not emit it retain the current language-based fallback.
- The index is created concurrently and the migration handles an invalid prior index safely.
- No REST API contract, Android client, Apple client, deployment configuration, or database data is changed.
- Coordinated TVDB and TMDB provider PRs will carry the provider-side signal.

### AI Disclosure
- Tool(s): Codex
- Model(s): gpt-5.6
- Involvement: AI-assisted
- Adversarial review: Found and fixed a concurrent-worker false-success race and a planner-hostile optional SQL predicate; re-reviewed the final diff with no material findings remaining.

## Checklist

- [x] I ran an adversarial AI review of the diff and summarized findings above.
- [x] I ran the repository verification commands and documented both passing gates and known upstream/environmental failures above.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Metadata refreshes now cache refreshed artwork automatically and report artwork-processing progress.
  - Artwork selection better prioritizes local images, text-bearing posters, preferred languages, and image ratings.
  - Image metadata can indicate whether artwork contains text.
  - Artwork processing retries pending work and reports failures clearly.

- **Bug Fixes**
  - Improved handling of artwork refresh jobs, including targeted retries and recovery of interrupted processing.
  - Refresh notifications now update the existing loading message with success or error results.

- **Documentation**
  - Added a changelog entry describing the updated metadata refresh and artwork behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->