### PR TITLE
docs: modernize README and release communication

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -1,0 +1,17 @@
+changelog:
+  categories:
+    - title: "🚀 Features and improvements"
+      labels:
+        - enhancement
+    - title: "🐛 Fixes"
+      labels:
+        - bug
+    - title: "📚 Documentation"
+      labels:
+        - documentation
+    - title: "📦 Dependencies"
+      labels:
+        - dependencies
+    - title: "🧰 Other changes"
+      labels:
+        - "*"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,7 +5,7 @@ on:
   workflow_dispatch:
     inputs:
       version:
-        description: Semantic version tag (vMAJOR.MINOR.PATCH[-PRERELEASE])
+        description: Semantic version tag (vMAJOR.MINOR.PATCH[-PRERELEASE][+BUILD])
         required: true
         type: string
       prerelease:
@@ -39,19 +39,22 @@ jobs:
 
           core_identifier='(0|[1-9][0-9]*)'
           prerelease_identifier='(0|[1-9][0-9]*|[0-9]*[A-Za-z-][0-9A-Za-z-]*)'
-          version_pattern="^v${core_identifier}\\.${core_identifier}\\.${core_identifier}(-${prerelease_identifier}(\\.${prerelease_identifier})*)?$"
+          build_identifier='[0-9A-Za-z-]+'
+          version_pattern="^v${core_identifier}\\.${core_identifier}\\.${core_identifier}(-${prerelease_identifier}(\\.${prerelease_identifier})*)?(\\+${build_identifier}(\\.${build_identifier})*)?$"
 
           if [[ ! "$VERSION" =~ $version_pattern ]]; then
-            echo "::error::Version must use vMAJOR.MINOR.PATCH with an optional prerelease suffix."
+            echo "::error::Version must use vMAJOR.MINOR.PATCH with optional prerelease and build metadata."
             exit 1
           fi
 
-          if [[ "$VERSION" == *-* && "$PRERELEASE" != "true" ]]; then
+          version_without_build="${VERSION%%+*}"
+
+          if [[ "$version_without_build" == *-* && "$PRERELEASE" != "true" ]]; then
             echo "::error::A version with a prerelease suffix must be marked as a prerelease."
             exit 1
           fi
 
-          if [[ "$VERSION" != *-* && "$PRERELEASE" == "true" ]]; then
+          if [[ "$version_without_build" != *-* && "$PRERELEASE" == "true" ]]; then
             echo "::error::A stable version cannot be marked as a prerelease."
             exit 1
           fi

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,78 @@
+name: Release
+run-name: Prepare ${{ inputs.version }}
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: Semantic version tag (vMAJOR.MINOR.PATCH[-PRERELEASE])
+        required: true
+        type: string
+      prerelease:
+        description: Mark this release as a prerelease
+        required: true
+        default: true
+        type: boolean
+
+concurrency:
+  group: release
+  cancel-in-progress: false
+
+permissions:
+  contents: write
+
+jobs:
+  release:
+    name: Prepare draft GitHub release
+    runs-on: ubuntu-latest
+    steps:
+      - name: Validate release request
+        shell: bash
+        env:
+          PRERELEASE: ${{ inputs.prerelease }}
+          VERSION: ${{ inputs.version }}
+        run: |
+          if [[ "$GITHUB_REF" != "refs/heads/main" ]]; then
+            echo "::error::Releases must be created from the main branch."
+            exit 1
+          fi
+
+          core_identifier='(0|[1-9][0-9]*)'
+          prerelease_identifier='(0|[1-9][0-9]*|[0-9]*[A-Za-z-][0-9A-Za-z-]*)'
+          version_pattern="^v${core_identifier}\\.${core_identifier}\\.${core_identifier}(-${prerelease_identifier}(\\.${prerelease_identifier})*)?$"
+
+          if [[ ! "$VERSION" =~ $version_pattern ]]; then
+            echo "::error::Version must use vMAJOR.MINOR.PATCH with an optional prerelease suffix."
+            exit 1
+          fi
+
+          if [[ "$VERSION" == *-* && "$PRERELEASE" != "true" ]]; then
+            echo "::error::A version with a prerelease suffix must be marked as a prerelease."
+            exit 1
+          fi
+
+          if [[ "$VERSION" != *-* && "$PRERELEASE" == "true" ]]; then
+            echo "::error::A stable version cannot be marked as a prerelease."
+            exit 1
+          fi
+
+      - name: Create release with generated notes
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PRERELEASE: ${{ inputs.prerelease }}
+          VERSION: ${{ inputs.version }}
+        run: |
+          args=(
+            --repo "$GITHUB_REPOSITORY"
+            --target "$GITHUB_SHA"
+            --draft
+            --generate-notes
+            --fail-on-no-commits
+          )
+
+          if [[ "$PRERELEASE" == "true" ]]; then
+            args+=(--prerelease)
+          fi
+
+          gh release create "$VERSION" "${args[@]}"

--- a/README.md
+++ b/README.md
@@ -76,7 +76,8 @@ modern experience at home or away.
 ## Releases and updates
 
 Silo uses [Semantic Versioning](https://semver.org/) in the form
-`vMAJOR.MINOR.PATCH`, with suffixes such as `-alpha.1` for prereleases. The
+`vMAJOR.MINOR.PATCH`, with suffixes such as `-alpha.1` for prereleases and
+optional `+build.7` metadata. The
 [GitHub Releases](https://github.com/Silo-Server/silo-server/releases) page is
 the canonical public history of shipped changes, with categorized notes,
 contributors, and a full comparison for every version.

--- a/README.md
+++ b/README.md
@@ -1,8 +1,38 @@
-# Silo
+<p align="center">
+  <img src="assets/icon.png" alt="Silo logo" width="112" height="112">
+</p>
 
-Silo is a self-hosted media streaming server for your movies, shows, music, and books. Point it at your media folders and stream to your devices — at home or away — with direct play, remuxing, and hardware-accelerated transcoding handled automatically.
+<h1 align="center">Silo</h1>
 
-Join the community on [Discord](https://discord.gg/4RxuUQAEnW). If Silo is useful to you, consider [sponsoring the project](https://github.com/sponsors/quick104) — see [Supporting Silo](#supporting-silo).
+<p align="center">
+  <strong>Your media. Your server. Your way.</strong>
+</p>
+
+<p align="center">
+  A modern, self-hosted media server for movies, shows, music, and books.
+</p>
+
+<p align="center">
+  <a href="https://github.com/Silo-Server/silo-server/releases"><img alt="Latest GitHub release" src="https://img.shields.io/github/v/release/Silo-Server/silo-server?include_prereleases&amp;sort=semver&amp;display_name=tag&amp;style=flat-square&amp;label=release"></a>
+  <a href="https://github.com/Silo-Server/silo-server/actions/workflows/ci.yml"><img alt="Continuous integration" src="https://img.shields.io/github/actions/workflow/status/Silo-Server/silo-server/ci.yml?branch=main&amp;style=flat-square&amp;label=CI"></a>
+  <img alt="Go 1.26" src="https://img.shields.io/badge/Go-1.26-00ADD8?style=flat-square&amp;logo=go&amp;logoColor=white">
+  <img alt="React 19" src="https://img.shields.io/badge/React-19-149ECA?style=flat-square&amp;logo=react&amp;logoColor=white">
+  <a href="LICENSE"><img alt="AGPL-3.0-or-later license" src="https://img.shields.io/badge/license-AGPL--3.0--or--later-555555?style=flat-square"></a>
+</p>
+
+<p align="center">
+  <a href="#deploy-with-docker-recommended">Installation</a>
+  · <a href="docs/wiki/index.md">Documentation</a>
+  · <a href="https://github.com/Silo-Server/silo-server/releases">Releases</a>
+  · <a href="https://discord.gg/4RxuUQAEnW">Discord</a>
+  · <a href="https://github.com/sponsors/quick104">Donate</a>
+  · <a href="CONTRIBUTING.md">Contributing</a>
+</p>
+
+---
+
+Silo streams your media at home or away, choosing direct play, remuxing, or
+hardware-accelerated transcoding automatically for each device.
 
 ## Highlights
 
@@ -12,6 +42,20 @@ Join the community on [Discord](https://discord.gg/4RxuUQAEnW). If Silo is usefu
 - **Household profiles** — multiple profiles per account, with per-profile watch state and parental controls.
 - **Plugin-driven metadata** — match and enrich your libraries with providers like TMDB and TVDB, installed as plugins.
 - **Fast setup** — one `docker compose up -d` brings up the whole stack; everything else is configured in the admin UI.
+
+## Releases and updates
+
+Silo uses [Semantic Versioning](https://semver.org/) in the form
+`vMAJOR.MINOR.PATCH`, with suffixes such as `-alpha.1` for prereleases. The
+[GitHub Releases](https://github.com/Silo-Server/silo-server/releases) page is
+the canonical public history of shipped changes, with categorized notes,
+contributors, and a full comparison for every version.
+
+Until the maintainers publish the first release, builds remain identified by
+their commit SHA. For every release, review the notes for configuration,
+compatibility, and upgrade information before updating. See
+[Release versioning](docs/release-versioning.md) for the version contract and
+maintainer release process.
 
 ## Deploy with Docker (recommended)
 

--- a/README.md
+++ b/README.md
@@ -367,7 +367,6 @@ If you prefer running Silo without Docker:
 | [Release versioning](docs/release-versioning.md) | Version selection, GitHub release notes, prereleases, and maintainer checks |
 | [Development guide](DEVELOPMENT.md) | Local setup, builds, tests, migrations, and repository structure |
 | [Canonical Settings API](docs/settings-api.md) | Client contracts, contextual headers, remote scopes, and effective reads |
-| [Security policy](SECURITY.md) | Supported versions and private vulnerability reporting |
 
 ## Reporting Issues
 

--- a/README.md
+++ b/README.md
@@ -31,17 +31,47 @@
 
 ---
 
-Silo streams your media at home or away, choosing direct play, remuxing, or
-hardware-accelerated transcoding automatically for each device.
+## Product overview
 
-## Highlights
+Silo keeps your media and its metadata under your control while providing a
+modern experience at home or away.
 
-- **Plays your media, your way** — direct play when the device supports it, remux or hardware-accelerated transcode (including NVENC) when it doesn't.
-- **Web app included** — a full-featured web client and admin interface ship with the server.
-- **Works with apps you already use** — optional Jellyfin/Emby-compatible API supports clients such as VidHub, Findroid, and Infuse.
-- **Household profiles** — multiple profiles per account, with per-profile watch state and parental controls.
-- **Plugin-driven metadata** — match and enrich your libraries with providers like TMDB and TVDB, installed as plugins.
-- **Fast setup** — one `docker compose up -d` brings up the whole stack; everything else is configured in the admin UI.
+<table>
+  <tr>
+    <td width="33%" valign="top">
+      <strong>Play</strong><br><br>
+      Direct play when possible, remux when needed, or use hardware-accelerated
+      transcoding—including NVENC—automatically for each device.
+    </td>
+    <td width="33%" valign="top">
+      <strong>Explore</strong><br><br>
+      Organize movies, shows, music, and books with plugin-driven matching and
+      enrichment from providers such as TMDB and TVDB.
+    </td>
+    <td width="33%" valign="top">
+      <strong>Connect</strong><br><br>
+      Use the included web app or optional Jellyfin/Emby-compatible clients such
+      as VidHub, Findroid, and Infuse.
+    </td>
+  </tr>
+  <tr>
+    <td width="33%" valign="top">
+      <strong>Share</strong><br><br>
+      Give household members their own profiles, watch state, and parental
+      controls without giving up ownership of the server.
+    </td>
+    <td width="33%" valign="top">
+      <strong>Deploy</strong><br><br>
+      Start the integrated stack with Docker Compose, then manage libraries,
+      users, providers, and playback settings in the admin UI.
+    </td>
+    <td width="33%" valign="top">
+      <strong>Scale</strong><br><br>
+      Keep everything on one host or separate API, proxy, and transcode roles
+      across a shared PostgreSQL and Redis deployment.
+    </td>
+  </tr>
+</table>
 
 ## Releases and updates
 
@@ -51,9 +81,12 @@ Silo uses [Semantic Versioning](https://semver.org/) in the form
 the canonical public history of shipped changes, with categorized notes,
 contributors, and a full comparison for every version.
 
-Until the maintainers publish the first release, builds remain identified by
-their commit SHA. For every release, review the notes for configuration,
-compatibility, and upgrade information before updating. See
+> [!IMPORTANT]
+> Until the maintainers select and publish Silo's first release, builds remain
+> identified by their commit SHA. No version is implied by this documentation.
+
+For every release, review the notes for configuration, compatibility, and
+upgrade information before updating. See
 [Release versioning](docs/release-versioning.md) for the version contract and
 maintainer release process.
 
@@ -62,6 +95,26 @@ maintainer release process.
 The easiest way to run Silo is with Docker Compose 2.24 or newer. The default stack assumes you do
 not already have PostgreSQL and Redis available, so it bundles PostgreSQL, Redis, FFmpeg, and the
 application for a one-command start.
+
+<table>
+  <tr>
+    <td width="33%" valign="top">
+      <strong>Default stack</strong><br><br>
+      One integrated Silo server with bundled PostgreSQL and Redis. This is the
+      recommended starting point.
+    </td>
+    <td width="33%" valign="top">
+      <strong>GPU acceleration</strong><br><br>
+      Add <a href="#optional-intelamd-va-api-or-intel-quick-sync">VA-API / Quick Sync</a>
+      or <a href="#optional-nvidianvenc">NVIDIA NVENC</a> only when the host supports it.
+    </td>
+    <td width="33%" valign="top">
+      <strong>Distributed deployment</strong><br><br>
+      Separate API, proxy, and transcode roles when one integrated host is no
+      longer the right fit. See the <a href="#distributed-examples">examples</a>.
+    </td>
+  </tr>
+</table>
 
 1. **Create a `.env` file**
 
@@ -305,6 +358,16 @@ If you prefer running Silo without Docker:
 
    The server starts at `http://localhost:8080` by default. All other settings are configured through the admin UI.
 
+## Documentation
+
+| Start with | Use it for |
+| --- | --- |
+| [Documentation index](docs/wiki/index.md) | Feature guides, administration, deployment, playback, and troubleshooting |
+| [Release versioning](docs/release-versioning.md) | Version selection, GitHub release notes, prereleases, and maintainer checks |
+| [Development guide](DEVELOPMENT.md) | Local setup, builds, tests, migrations, and repository structure |
+| [Canonical Settings API](docs/settings-api.md) | Client contracts, contextual headers, remote scopes, and effective reads |
+| [Security policy](SECURITY.md) | Supported versions and private vulnerability reporting |
+
 ## Reporting Issues
 
 Client implementers can use the [Canonical Settings API guide](docs/settings-api.md)
@@ -356,6 +419,11 @@ Donations go directly toward the costs of building and running the project:
 - Future development costs
 
 Sponsoring is entirely optional — Silo is and will remain free and open source. Bug reports, contributions, and feedback are just as valuable.
+
+<p align="center">
+  <a href="https://github.com/sponsors/quick104"><strong>Sponsor Silo</strong></a>
+  · <a href="https://discord.gg/4RxuUQAEnW"><strong>Join the Discord community</strong></a>
+</p>
 
 ## License & Trademarks
 

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@
   <a href="#deploy-with-docker-recommended">Installation</a>
   · <a href="docs/wiki/index.md">Documentation</a>
   · <a href="https://github.com/Silo-Server/silo-server/releases">Releases</a>
-  · <a href="https://discord.gg/4RxuUQAEnW">Discord</a>
+  · <a href="https://discord.com/invite/4RxuUQAEnW">Discord</a>
   · <a href="https://github.com/sponsors/quick104">Donate</a>
   · <a href="CONTRIBUTING.md">Contributing</a>
 </p>
@@ -423,7 +423,7 @@ Sponsoring is entirely optional — Silo is and will remain free and open source
 
 <p align="center">
   <a href="https://github.com/sponsors/quick104"><strong>Sponsor Silo</strong></a>
-  · <a href="https://discord.gg/4RxuUQAEnW"><strong>Join the Discord community</strong></a>
+  · <a href="https://discord.com/invite/4RxuUQAEnW"><strong>Join the Discord community</strong></a>
 </p>
 
 ## License & Trademarks

--- a/docs/release-versioning.md
+++ b/docs/release-versioning.md
@@ -12,6 +12,8 @@ Release tags follow [Semantic Versioning](https://semver.org/) with a leading
 
 - Stable release: `vMAJOR.MINOR.PATCH`, for example `v1.2.0`
 - Prerelease: `vMAJOR.MINOR.PATCH-SUFFIX`, for example `v0.1.0-alpha.1`
+- Build metadata: append `+IDENTIFIER`, for example `v1.2.0+build.7` or
+  `v0.1.0-alpha.1+build.7`
 
 For releases below `v1.0.0`, a minor release may include breaking changes. Every
 release note must call out upgrade, configuration, and compatibility impact when
@@ -50,6 +52,11 @@ announcing a release.
 The workflow rejects non-SemVer tags, mismatched prerelease settings, and runs
 from branches other than `main`. It also refuses to reuse a release tag or create
 a release when there are no commits since the previous one.
+
+GitHub's manual-workflow permission is the release access boundary: only users
+with repository write access can dispatch it. If Silo later requires a second
+approval, maintainers should configure a protected release environment with
+required reviewers and attach the release job to it before use.
 
 This process does not choose or create Silo's first version. The first tag must
 be agreed by the maintainers before the workflow is run.

--- a/docs/release-versioning.md
+++ b/docs/release-versioning.md
@@ -1,0 +1,55 @@
+# Release versioning
+
+Silo uses GitHub Releases as the public record of shipped versions and their
+changes. There is no historical Silo release series yet: the repository has no
+release tags, and the published container images are currently identified by
+`latest`, `nightly`, or a commit SHA.
+
+## Version format
+
+Release tags follow [Semantic Versioning](https://semver.org/) with a leading
+`v`:
+
+- Stable release: `vMAJOR.MINOR.PATCH`, for example `v1.2.0`
+- Prerelease: `vMAJOR.MINOR.PATCH-SUFFIX`, for example `v0.1.0-alpha.1`
+
+For releases below `v1.0.0`, a minor release may include breaking changes. Every
+release note must call out upgrade, configuration, and compatibility impact when
+applicable.
+
+## Source of truth
+
+The Git tag and matching GitHub Release are the authoritative product version.
+Other version-like values in the repository describe dependencies, protocols,
+or compatibility targets and are not Silo release numbers. The build details in
+the admin interface continue to show the commit SHA for exact traceability.
+
+GitHub automatically supplies source archives for each release. Container
+publishing remains independent: the registry currently contains `latest`,
+`nightly`, and commit-SHA tags, while the current default-branch workflow
+publishes `latest` and commit-SHA tags. Versioned container tags are not
+introduced by this release process.
+
+## Release notes
+
+GitHub generates the initial notes from merged pull requests and contributors.
+The categories in [`.github/release.yml`](../.github/release.yml) group features,
+fixes, documentation, dependency updates, and uncategorized changes. Maintainers
+should review the generated text and add any important upgrade guidance before
+announcing a release.
+
+## Publishing a release
+
+1. Confirm the intended commit is on `main` and required checks are green.
+2. Open **Actions > Release > Run workflow** from the `main` branch.
+3. Enter a new SemVer tag and select whether it is a prerelease.
+4. Review the generated draft and add any required upgrade notes.
+5. Publish and announce the release only after its tag, target commit, and notes
+   have been verified.
+
+The workflow rejects non-SemVer tags, mismatched prerelease settings, and runs
+from branches other than `main`. It also refuses to reuse a release tag or create
+a release when there are no commits since the previous one.
+
+This process does not choose or create Silo's first version. The first tag must
+be agreed by the maintainers before the workflow is run.

--- a/docs/release-versioning.md
+++ b/docs/release-versioning.md
@@ -3,7 +3,7 @@
 Silo uses GitHub Releases as the public record of shipped versions and their
 changes. There is no historical Silo release series yet: the repository has no
 release tags, and the published container images are currently identified by
-`latest`, `nightly`, or a commit SHA.
+`latest` or a short commit SHA.
 
 ## Version format
 
@@ -27,10 +27,9 @@ or compatibility targets and are not Silo release numbers. The build details in
 the admin interface continue to show the commit SHA for exact traceability.
 
 GitHub automatically supplies source archives for each release. Container
-publishing remains independent: the registry currently contains `latest`,
-`nightly`, and commit-SHA tags, while the current default-branch workflow
-publishes `latest` and commit-SHA tags. Versioned container tags are not
-introduced by this release process.
+publishing remains independent: the default-branch workflow publishes only
+`latest` and short-commit-SHA tags. Versioned container tags are not introduced
+by this release process.
 
 ## Release notes
 


### PR DESCRIPTION
## Summary

- Modernize the README introduction using Silo's existing official logo.
- Add a polished six-card product overview and compact deployment chooser.
- Put Installation, Documentation, Releases, Discord, Donate, and Contributing in a clear quick-link row.
- Add a concise documentation map and centered Sponsor/Discord links.
- Document a maintainer-controlled release-versioning policy without selecting the first version.
- Configure GitHub-generated release-note categories using the repository's existing labels.
- Add a guarded manual workflow that creates a reviewable **draft** GitHub Release from `main`.

## Why

Silo currently has no GitHub releases or tags, so public updates are primarily communicated through commits and container SHAs. This gives users a clearer project overview and gives maintainers an intentional way to publish understandable update history while retaining control of the first version and every release.

## Release safety

- No version, tag, or release is selected or created by this PR.
- The main maintainer chooses Silo's first release number.
- The workflow can run only from `main`, validates strict SemVer, and checks prerelease consistency.
- Generated notes remain a draft until a maintainer reviews and publishes them.
- Docker tags, deployment, runtime behavior, and dependencies are unchanged.

## Validation

- `actionlint 1.7.12` passed for all GitHub workflows.
- Release input validation passed a 24-case SemVer, build-metadata, and prerelease-coherence matrix.
- `.github/release.yml` parsed successfully with all five intended categories.
- Every local README target exists; all newly added public links and badges returned HTTP 200. Discord's public invite API confirms the direct Silo invite is valid and non-expiring.
- The actual GitHub-rendered branch README was inspected at 1280px: the logo, five badges, six product cards, three deployment cards, quick links, documentation map, and community links all render; the page and tables have no horizontal overflow.
- `make verify-local-paths` passed after the final README pass.
- `git diff --check` passed after the final README pass.
- CodeRabbit current-head review: no actionable comments, minimal merge risk, and all inline review threads resolved.

## Ownership

All work in this PR is owned and submitted by @blurbery. Product direction, scope, and acceptance decisions are theirs. The change has been tested as described above and the rendered README works as intended.

### AI Disclosure

- **Tool(s):** OpenAI Codex desktop
- **Model(s):** GPT-5.6 Sol
- **Involvement:** AI-assisted implementation, research, validation, and PR preparation under @blurbery's direction
- **Adversarial review:** Self-review removed an implied pre-1.0 version choice and an instant-publication path, limited presentation changes to verified product claims and repository-owned assets, and rejected fake screenshots or new branding. The final change leaves the first version to maintainers, creates drafts only, adds strict SemVer and prerelease-consistency checks, and was verified against GitHub's rendered output and link targets. No unresolved local-review findings remain.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a streamlined process for creating draft releases with generated release notes.
  * Added validation for release branches, semantic versions, and prerelease consistency.

* **Documentation**
  * Expanded the product overview and deployment guidance, including GPU and distributed setups.
  * Added release versioning guidance covering SemVer, build metadata, container tags, and publishing.
  * Added links to key documentation and updated community resources.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->