### PR TITLE
feat(build): publish ordered container build numbers

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -13,12 +13,52 @@ concurrency:
 env:
   REGISTRY: ghcr.io
   IMAGE_NAME: ${{ github.repository }}
+  # Published build numbers belong to this workflow. Keep it as the sole owner
+  # of the sequence; raise the offset if the workflow counter ever loses
+  # continuity so a new build remains greater than every existing build tag.
+  BUILD_NUMBER_OFFSET: 0
   GOPROXY: https://proxy.golang.org,direct
   GOPRIVATE: github.com/Silo-Server/*
   GONOSUMDB: github.com/Silo-Server/*
 
 jobs:
+  prepare:
+    name: Prepare build identity
+    runs-on: ubuntu-latest
+    permissions: {}
+    outputs:
+      build_number: ${{ steps.identity.outputs.build_number }}
+      built_at: ${{ steps.identity.outputs.built_at }}
+      image_version: ${{ steps.identity.outputs.image_version }}
+    steps:
+      - name: Resolve build identity
+        id: identity
+        shell: bash
+        env:
+          DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
+        run: |
+          if [[ -z "$DEFAULT_BRANCH" ]]; then
+            echo "::error::Repository default branch is unavailable."
+            exit 1
+          fi
+
+          build_number=""
+          image_version="${GITHUB_SHA::7}"
+          if [[ "$GITHUB_REF" == "refs/heads/${DEFAULT_BRANCH}" ]]; then
+            build_number=$((GITHUB_RUN_NUMBER + BUILD_NUMBER_OFFSET))
+            if (( build_number <= 0 )); then
+              echo "::error::Build number must be positive."
+              exit 1
+            fi
+            image_version="build-${build_number}"
+          fi
+
+          echo "build_number=${build_number}" >> "$GITHUB_OUTPUT"
+          echo "built_at=$(date -u +'%Y-%m-%dT%H:%M:%SZ')" >> "$GITHUB_OUTPUT"
+          echo "image_version=${image_version}" >> "$GITHUB_OUTPUT"
+
   build:
+    needs: prepare
     strategy:
       fail-fast: false
       matrix:
@@ -104,6 +144,10 @@ jobs:
         uses: docker/metadata-action@v5
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          labels: |
+            org.opencontainers.image.created=${{ needs.prepare.outputs.built_at }}
+            org.opencontainers.image.revision=${{ github.sha }}
+            org.opencontainers.image.version=${{ needs.prepare.outputs.image_version }}
 
       - name: Build and push by digest
         id: build
@@ -117,6 +161,8 @@ jobs:
           build-args: |
             BUILD_REVISION=${{ github.sha }}
             BUILD_DIRTY=false
+            BUILD_NUMBER=${{ needs.prepare.outputs.build_number }}
+            BUILD_DATE=${{ needs.prepare.outputs.built_at }}
           cache-from: type=gha,scope=docker-${{ env.PLATFORM_PAIR }}
           cache-to: type=gha,scope=docker-${{ env.PLATFORM_PAIR }},mode=max
           outputs: type=image,name=${{ env.REGISTRY }}/${{ env.IMAGE_LC }},push-by-digest=true,name-canonical=true,push=true
@@ -137,7 +183,7 @@ jobs:
 
   merge:
     runs-on: ubuntu-latest
-    needs: build
+    needs: [prepare, build]
     permissions:
       packages: write
 
@@ -169,6 +215,7 @@ jobs:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_LC }}
           tags: |
             type=raw,value=latest,enable={{is_default_branch}}
+            type=raw,value=build-${{ needs.prepare.outputs.build_number }},enable={{is_default_branch}}
             type=sha,prefix=,format=short
 
       - name: Create and push manifest list
@@ -180,5 +227,11 @@ jobs:
             $(printf "${REGISTRY}/${IMAGE_LC}@sha256:%s " *)
 
       - name: Inspect manifest list
+        env:
+          BUILD_NUMBER: ${{ needs.prepare.outputs.build_number }}
+          DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
         run: |
           docker buildx imagetools inspect "${REGISTRY}/${IMAGE_LC}:${GITHUB_SHA::7}"
+          if [[ "$GITHUB_REF" == "refs/heads/${DEFAULT_BRANCH}" ]]; then
+            docker buildx imagetools inspect "${REGISTRY}/${IMAGE_LC}:build-${BUILD_NUMBER}"
+          fi

--- a/Dockerfile
+++ b/Dockerfile
@@ -38,10 +38,12 @@ COPY migrations/ migrations/
 COPY contracts/ contracts/
 ARG BUILD_REVISION
 ARG BUILD_DIRTY=false
+ARG BUILD_NUMBER
+ARG BUILD_DATE
 RUN --mount=type=cache,target=/root/.cache/go-build \
     --mount=type=cache,target=/go/pkg/mod \
     go build \
-    -ldflags "-X github.com/Silo-Server/silo-server/internal/buildinfo.revisionOverride=${BUILD_REVISION} -X github.com/Silo-Server/silo-server/internal/buildinfo.dirtyOverride=${BUILD_DIRTY}" \
+    -ldflags "-X github.com/Silo-Server/silo-server/internal/buildinfo.revisionOverride=${BUILD_REVISION} -X github.com/Silo-Server/silo-server/internal/buildinfo.dirtyOverride=${BUILD_DIRTY} -X github.com/Silo-Server/silo-server/internal/buildinfo.buildNumberOverride=${BUILD_NUMBER} -X github.com/Silo-Server/silo-server/internal/buildinfo.builtAtOverride=${BUILD_DATE}" \
     -o /silo ./cmd/silo/
 
 # Stage 3: Runtime

--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -38,6 +38,8 @@ COPY contracts/ contracts/
 FROM build-base AS build
 ARG BUILD_REVISION
 ARG BUILD_DIRTY=false
+ARG BUILD_NUMBER
+ARG BUILD_DATE
 COPY --from=silo_plugin_sdk . /tmp/silo-plugin-sdk
 RUN test -f /tmp/silo-plugin-sdk/go.mod
 RUN --mount=type=cache,target=/root/.cache/go-build \
@@ -45,7 +47,7 @@ RUN --mount=type=cache,target=/root/.cache/go-build \
     go mod edit -replace=github.com/Silo-Server/silo-plugin-sdk=/tmp/silo-plugin-sdk && \
     go mod download && \
     go build \
-    -ldflags "-X github.com/Silo-Server/silo-server/internal/buildinfo.revisionOverride=${BUILD_REVISION} -X github.com/Silo-Server/silo-server/internal/buildinfo.dirtyOverride=${BUILD_DIRTY}" \
+    -ldflags "-X github.com/Silo-Server/silo-server/internal/buildinfo.revisionOverride=${BUILD_REVISION} -X github.com/Silo-Server/silo-server/internal/buildinfo.dirtyOverride=${BUILD_DIRTY} -X github.com/Silo-Server/silo-server/internal/buildinfo.buildNumberOverride=${BUILD_NUMBER} -X github.com/Silo-Server/silo-server/internal/buildinfo.builtAtOverride=${BUILD_DATE}" \
     -o /silo ./cmd/silo/
 
 # Stage 4: Runtime

--- a/Makefile
+++ b/Makefile
@@ -23,7 +23,9 @@ JELLYFIN_WEB_VERSION ?= 10.11.6
 BUILDINFO_PKG := github.com/Silo-Server/silo-server/internal/buildinfo
 BUILD_REVISION ?= $(shell git rev-parse HEAD 2>/dev/null)
 BUILD_DIRTY ?= $(shell test -n "$$(git status --porcelain 2>/dev/null)" && echo true || echo false)
-GO_LDFLAGS := -X $(BUILDINFO_PKG).revisionOverride=$(BUILD_REVISION) -X $(BUILDINFO_PKG).dirtyOverride=$(BUILD_DIRTY)
+BUILD_NUMBER ?=
+BUILD_DATE ?=
+GO_LDFLAGS := -X $(BUILDINFO_PKG).revisionOverride=$(BUILD_REVISION) -X $(BUILDINFO_PKG).dirtyOverride=$(BUILD_DIRTY) -X $(BUILDINFO_PKG).buildNumberOverride=$(BUILD_NUMBER) -X $(BUILDINFO_PKG).builtAtOverride=$(BUILD_DATE)
 
 # Build the frontend (requires pnpm)
 frontend:

--- a/README.md
+++ b/README.md
@@ -83,8 +83,9 @@ the canonical public history of shipped changes, with categorized notes,
 contributors, and a full comparison for every version.
 
 > [!IMPORTANT]
-> Until the maintainers select and publish Silo's first release, builds remain
-> identified by their commit SHA. No version is implied by this documentation.
+> Until the maintainers select and publish Silo's first release, newly published
+> container builds are identified by an ordered `build-N` and their commit SHA.
+> Build numbers make updates comparable but do not imply a release version.
 
 For every release, review the notes for configuration, compatibility, and
 upgrade information before updating. See

--- a/docs/feature-changelog.md
+++ b/docs/feature-changelog.md
@@ -2,6 +2,12 @@
 
 ## 2026-08-19
 
+### Make published server builds easy to compare
+Every successful default-branch container build now carries an ordered build number alongside its exact source revision.
+- Publishes `build-N` beside the existing mutable `latest` and short-commit-SHA image tags.
+- Shows `Build N · SHA` in the admin sidebar, with the build timestamp available on hover.
+- Keeps build identifiers separate from deliberate Semantic Versioning releases; skipped workflow numbers simply leave harmless gaps.
+
 ### Make metadata refresh finish with the right artwork
 Manual Quick and Complete Refresh now finish the selected item's artwork before reporting success instead of leaving it behind the global image-cache backlog.
 - Chooses a text-bearing poster in the library's metadata language, then English, another language, and finally textless artwork.

--- a/docs/release-versioning.md
+++ b/docs/release-versioning.md
@@ -2,8 +2,8 @@
 
 Silo uses GitHub Releases as the public record of shipped versions and their
 changes. There is no historical Silo release series yet: the repository has no
-release tags, and the published container images are currently identified by
-`latest` or a short commit SHA.
+release tags. Newly published default-branch container images are identified by
+an ordered `build-N`, `latest`, and a short commit SHA.
 
 ## Version format
 
@@ -24,12 +24,23 @@ applicable.
 The Git tag and matching GitHub Release are the authoritative product version.
 Other version-like values in the repository describe dependencies, protocols,
 or compatibility targets and are not Silo release numbers. The build details in
-the admin interface continue to show the commit SHA for exact traceability.
+the admin interface show both values for numbered container builds and retain
+the commit SHA alone for older or local builds.
 
 GitHub automatically supplies source archives for each release. Container
-publishing remains independent: the default-branch workflow publishes only
-`latest` and short-commit-SHA tags. Versioned container tags are not introduced
-by this release process.
+publishing remains independent. Successful default-branch builds publish three
+tags that identify the same multi-platform image:
+
+| Tag | Meaning |
+| --- | --- |
+| `build-N` | Ordered build identifier. A larger number is a newer published build; gaps from unsuccessful or non-publishing workflow runs are expected. |
+| `latest` | Mutable pointer updated by successful default-branch publications. |
+| Short commit SHA | Exact source identity for the build. |
+
+Build numbers are not release versions and do not carry compatibility or
+support guarantees. Pin a `build-N`, commit-SHA tag, or image digest when a
+deployment must not move with `latest`. Versioned container tags are not
+introduced by the GitHub Release process.
 
 ## Release notes
 

--- a/internal/api/handlers/system_test.go
+++ b/internal/api/handlers/system_test.go
@@ -18,11 +18,13 @@ func TestSystemBuildInfoResponse(t *testing.T) {
 
 	handler := &SystemHandler{
 		buildInfo: buildinfo.Info{
-			Display:   "b4c5aae1+dirty",
-			Revision:  "b4c5aae18aa653725ac697b29a05eac797576008",
-			Dirty:     true,
-			VCSTime:   "2026-04-05T22:24:40Z",
-			Available: true,
+			Display:     "b4c5aae1+dirty",
+			Revision:    "b4c5aae18aa653725ac697b29a05eac797576008",
+			Dirty:       true,
+			VCSTime:     "2026-04-05T22:24:40Z",
+			BuildNumber: 411,
+			BuiltAt:     "2026-08-19T19:45:00Z",
+			Available:   true,
 		},
 	}
 
@@ -75,11 +77,13 @@ func TestSystemBuildInfoUnavailableResponseShape(t *testing.T) {
 	}
 
 	expected := map[string]any{
-		"display":   "unavailable",
-		"revision":  "",
-		"dirty":     false,
-		"vcs_time":  "",
-		"available": false,
+		"display":      "unavailable",
+		"revision":     "",
+		"dirty":        false,
+		"vcs_time":     "",
+		"build_number": float64(0),
+		"built_at":     "",
+		"available":    false,
 	}
 
 	for key, want := range expected {

--- a/internal/buildinfo/buildinfo.go
+++ b/internal/buildinfo/buildinfo.go
@@ -2,37 +2,45 @@ package buildinfo
 
 import (
 	"runtime/debug"
+	"strconv"
 	"strings"
 )
 
 const unavailableDisplay = "unavailable"
 
 var (
-	revisionOverride string
-	dirtyOverride    string
+	revisionOverride    string
+	dirtyOverride       string
+	buildNumberOverride string
+	builtAtOverride     string
 )
 
-// Info describes the running Silo build as embedded by Go's VCS metadata.
+// Info describes the running Silo build from Go VCS metadata and CI-injected
+// container identity.
 type Info struct {
-	Display   string `json:"display"`
-	Revision  string `json:"revision"`
-	Dirty     bool   `json:"dirty"`
-	VCSTime   string `json:"vcs_time"`
-	Available bool   `json:"available"`
+	Display     string `json:"display"`
+	Revision    string `json:"revision"`
+	Dirty       bool   `json:"dirty"`
+	VCSTime     string `json:"vcs_time"`
+	BuildNumber uint64 `json:"build_number"`
+	BuiltAt     string `json:"built_at"`
+	Available   bool   `json:"available"`
 }
 
 // Current reads build metadata from the running binary.
 func Current() Info {
 	overrideRevision, overrideDirty := parseOverrides(revisionOverride, dirtyOverride)
+	overrideBuildNumber := parseBuildNumber(buildNumberOverride)
+	overrideBuiltAt := strings.TrimSpace(builtAtOverride)
 
 	info, ok := debug.ReadBuildInfo()
 	if !ok {
-		return buildInfo(overrideRevision, overrideDirty, "")
+		return buildInfo(overrideRevision, overrideDirty, "", overrideBuildNumber, overrideBuiltAt)
 	}
-	return resolve(info.Settings, overrideRevision, overrideDirty)
+	return resolve(info.Settings, overrideRevision, overrideDirty, overrideBuildNumber, overrideBuiltAt)
 }
 
-func resolve(settings []debug.BuildSetting, fallbackRevision string, fallbackDirty bool) Info {
+func resolve(settings []debug.BuildSetting, fallbackRevision string, fallbackDirty bool, buildNumber uint64, builtAt string) Info {
 	var (
 		revision string
 		vcsTime  string
@@ -51,19 +59,28 @@ func resolve(settings []debug.BuildSetting, fallbackRevision string, fallbackDir
 	}
 
 	if revision != "" {
-		return buildInfo(revision, dirty, vcsTime)
+		return buildInfo(revision, dirty, vcsTime, buildNumber, builtAt)
 	}
 
-	return buildInfo(fallbackRevision, fallbackDirty, "")
+	return buildInfo(fallbackRevision, fallbackDirty, "", buildNumber, builtAt)
 }
 
 func parseOverrides(revision, dirty string) (string, bool) {
 	return strings.TrimSpace(revision), strings.EqualFold(strings.TrimSpace(dirty), "true")
 }
 
-func buildInfo(revision string, dirty bool, vcsTime string) Info {
+func parseBuildNumber(value string) uint64 {
+	buildNumber, err := strconv.ParseUint(strings.TrimSpace(value), 10, 64)
+	if err != nil {
+		return 0
+	}
+	return buildNumber
+}
+
+func buildInfo(revision string, dirty bool, vcsTime string, buildNumber uint64, builtAt string) Info {
 	revision = strings.TrimSpace(revision)
 	vcsTime = strings.TrimSpace(vcsTime)
+	builtAt = strings.TrimSpace(builtAt)
 	if revision == "" {
 		return unavailableInfo()
 	}
@@ -77,20 +94,24 @@ func buildInfo(revision string, dirty bool, vcsTime string) Info {
 	}
 
 	return Info{
-		Display:   display,
-		Revision:  revision,
-		Dirty:     dirty,
-		VCSTime:   vcsTime,
-		Available: true,
+		Display:     display,
+		Revision:    revision,
+		Dirty:       dirty,
+		VCSTime:     vcsTime,
+		BuildNumber: buildNumber,
+		BuiltAt:     builtAt,
+		Available:   true,
 	}
 }
 
 func unavailableInfo() Info {
 	return Info{
-		Display:   unavailableDisplay,
-		Revision:  "",
-		Dirty:     false,
-		VCSTime:   "",
-		Available: false,
+		Display:     unavailableDisplay,
+		Revision:    "",
+		Dirty:       false,
+		VCSTime:     "",
+		BuildNumber: 0,
+		BuiltAt:     "",
+		Available:   false,
 	}
 }

--- a/internal/buildinfo/buildinfo_test.go
+++ b/internal/buildinfo/buildinfo_test.go
@@ -5,6 +5,29 @@ import (
 	"testing"
 )
 
+func TestCurrentIncludesContainerIdentity(t *testing.T) {
+	previousRevision := revisionOverride
+	previousDirty := dirtyOverride
+	previousBuildNumber := buildNumberOverride
+	previousBuiltAt := builtAtOverride
+	t.Cleanup(func() {
+		revisionOverride = previousRevision
+		dirtyOverride = previousDirty
+		buildNumberOverride = previousBuildNumber
+		builtAtOverride = previousBuiltAt
+	})
+
+	revisionOverride = "edf2977f5013df08e57a869bf722af4243a0a4fd"
+	dirtyOverride = "false"
+	buildNumberOverride = "411"
+	builtAtOverride = "2026-08-19T19:45:00Z"
+
+	got := Current()
+	if got.BuildNumber != 411 || got.BuiltAt != "2026-08-19T19:45:00Z" {
+		t.Fatalf("Current() container identity = build %d at %q", got.BuildNumber, got.BuiltAt)
+	}
+}
+
 func TestResolve(t *testing.T) {
 	t.Parallel()
 
@@ -13,6 +36,8 @@ func TestResolve(t *testing.T) {
 		settings         []debug.BuildSetting
 		overrideRevision string
 		overrideDirty    string
+		buildNumber      uint64
+		builtAt          string
 		want             Info
 	}{
 		{
@@ -22,12 +47,16 @@ func TestResolve(t *testing.T) {
 				{Key: "vcs.modified", Value: "false"},
 				{Key: "vcs.time", Value: "2026-04-05T22:24:40Z"},
 			},
+			buildNumber: 411,
+			builtAt:     "2026-08-19T19:45:00Z",
 			want: Info{
-				Display:   "b4c5aae1",
-				Revision:  "b4c5aae18aa653725ac697b29a05eac797576008",
-				Dirty:     false,
-				VCSTime:   "2026-04-05T22:24:40Z",
-				Available: true,
+				Display:     "b4c5aae1",
+				Revision:    "b4c5aae18aa653725ac697b29a05eac797576008",
+				Dirty:       false,
+				VCSTime:     "2026-04-05T22:24:40Z",
+				BuildNumber: 411,
+				BuiltAt:     "2026-08-19T19:45:00Z",
+				Available:   true,
 			},
 		},
 		{
@@ -86,6 +115,21 @@ func TestResolve(t *testing.T) {
 				Dirty:     true,
 				VCSTime:   "",
 				Available: true,
+			},
+		},
+		{
+			name:             "ordered container build",
+			overrideRevision: "edf2977f5013df08e57a869bf722af4243a0a4fd",
+			buildNumber:      411,
+			builtAt:          " 2026-08-19T19:45:00Z ",
+			want: Info{
+				Display:     "edf2977f",
+				Revision:    "edf2977f5013df08e57a869bf722af4243a0a4fd",
+				Dirty:       false,
+				VCSTime:     "",
+				BuildNumber: 411,
+				BuiltAt:     "2026-08-19T19:45:00Z",
+				Available:   true,
 			},
 		},
 		{
@@ -164,10 +208,32 @@ func TestResolve(t *testing.T) {
 			t.Parallel()
 
 			overrideRevision, overrideDirty := parseOverrides(tc.overrideRevision, tc.overrideDirty)
-			got := resolve(tc.settings, overrideRevision, overrideDirty)
+			got := resolve(tc.settings, overrideRevision, overrideDirty, tc.buildNumber, tc.builtAt)
 			if got != tc.want {
 				t.Fatalf("resolve() = %#v, want %#v", got, tc.want)
 			}
 		})
+	}
+}
+
+func TestParseBuildNumber(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		value string
+		want  uint64
+	}{
+		{value: "411", want: 411},
+		{value: " 411 ", want: 411},
+		{value: ""},
+		{value: "0"},
+		{value: "-1"},
+		{value: "not-a-number"},
+	}
+
+	for _, tc := range tests {
+		if got := parseBuildNumber(tc.value); got != tc.want {
+			t.Fatalf("parseBuildNumber(%q) = %d, want %d", tc.value, got, tc.want)
+		}
 	}
 }

--- a/web/src/components/AdminSidebar.test.tsx
+++ b/web/src/components/AdminSidebar.test.tsx
@@ -19,6 +19,8 @@ const defaultBuildInfo: BuildInfo = {
   revision: "b4c5aae18aa653725ac697b29a05eac797576008",
   dirty: true,
   vcs_time: "2026-04-05T22:24:40Z",
+  build_number: 411,
+  built_at: "2026-08-19T19:45:00Z",
   available: true,
 };
 const mockUseBuildInfo = vi.fn<() => MockBuildInfoResult>(() => ({
@@ -148,7 +150,8 @@ describe("AdminSidebar", () => {
     const markup = renderSidebar();
 
     expect(markup).toContain(">Build<");
-    expect(markup).toContain(">b4c5aae1+dirty<");
+    expect(markup).toContain(">411 · b4c5aae1+dirty<");
+    expect(markup).toContain('title="Built 2026-08-19T19:45:00Z"');
   });
 
   it("renders dev build when build metadata is missing", () => {
@@ -159,6 +162,8 @@ describe("AdminSidebar", () => {
         revision: "",
         dirty: false,
         vcs_time: "",
+        build_number: 0,
+        built_at: "",
         available: false,
       },
       isPending: false,
@@ -168,6 +173,21 @@ describe("AdminSidebar", () => {
     const markup = renderSidebar();
 
     expect(markup).toContain(">dev build<");
+  });
+
+  it("falls back to the revision for builds without an ordered number", () => {
+    const legacyBuildInfo = { ...defaultBuildInfo };
+    delete legacyBuildInfo.build_number;
+    delete legacyBuildInfo.built_at;
+    mockUseBuildInfo.mockReturnValueOnce({
+      data: legacyBuildInfo,
+      isPending: false,
+      isError: false,
+    });
+
+    const markup = renderSidebar();
+
+    expect(markup).toContain(">b4c5aae1+dirty<");
   });
 
   it("renders load failed when the build info query errors", () => {

--- a/web/src/components/AdminSidebar.tsx
+++ b/web/src/components/AdminSidebar.tsx
@@ -49,7 +49,9 @@ export default function AdminSidebar({ onNavigate, embedded = false }: AdminSide
   } else if (buildInfo.isError) {
     buildDisplay = "load failed";
   } else if (buildInfo.data?.available) {
-    buildDisplay = buildInfo.data.display;
+    const buildNumber = buildInfo.data.build_number ?? 0;
+    buildDisplay =
+      buildNumber > 0 ? `${buildNumber} · ${buildInfo.data.display}` : buildInfo.data.display;
   }
 
   const activityBadge =
@@ -145,7 +147,10 @@ export default function AdminSidebar({ onNavigate, embedded = false }: AdminSide
           <div className="text-muted-foreground text-[10px] font-semibold tracking-[0.18em] uppercase">
             Build
           </div>
-          <div className="text-sidebar-foreground mt-1 font-mono text-[12px] leading-5">
+          <div
+            className="text-sidebar-foreground mt-1 font-mono text-[12px] leading-5"
+            title={buildInfo.data?.built_at ? `Built ${buildInfo.data.built_at}` : undefined}
+          >
             {buildDisplay}
           </div>
         </div>

--- a/web/src/hooks/queries/admin/system.ts
+++ b/web/src/hooks/queries/admin/system.ts
@@ -7,6 +7,8 @@ export interface BuildInfo {
   revision: string;
   dirty: boolean;
   vcs_time: string;
+  build_number?: number;
+  built_at?: string;
   available: boolean;
 }
 


### PR DESCRIPTION
## Summary

- Publish an ordered `build-N` tag beside `latest` and the short commit SHA for successful default-branch container builds.
- Derive one build number and UTC timestamp before the architecture matrix so the amd64 and arm64 images carry the same identity.
- Embed the build number and timestamp in the Go binary, expose them additively from the admin build-info endpoint, and render `Build N · SHA` in the admin sidebar.
- Keep non-default manual builds SHA-only and preserve the existing SHA/dev fallback for older and local builds.
- Document the distinction between CI build numbers and deliberate SemVer releases.

Follow-up to #678.

## Why

A commit SHA identifies an exact build but does not provide ordering. Users comparing two deployments cannot tell whether moving from one SHA to another is an upgrade or downgrade without looking up their history. Numbered builds make that comparison immediate without requiring a SemVer release for every commit.

## Container tag contract

| Tag | Behavior |
| --- | --- |
| `build-N` | Ordered identifier for a published default-branch build; gaps are expected. |
| `latest` | Existing mutable default-branch pointer. |
| Short SHA | Existing exact source identity. |

Build numbers do not imply release compatibility or support. The checked-in offset is the continuity escape hatch if the workflow counter ever changes; the Docker workflow remains the sole owner of the sequence.

## Validation

- `go run github.com/rhysd/actionlint/cmd/actionlint@v1.7.7 .github/workflows/docker.yml` — passed.
- `go test ./internal/buildinfo ./internal/api/handlers` — passed.
- `pnpm --dir web exec vitest run src/components/AdminSidebar.test.tsx` — 13 tests passed.
- `make test-web` — 280 files and 1,966 tests passed.
- `go build ./... && go vet ./...` — passed.
- `make build BUILD_NUMBER=999 BUILD_DATE=2026-08-19T20:00:00Z` — passed.
- `make build` with no build identity — passed, proving the local/legacy fallback linker path.
- CI-equivalent `golangci-lint run --new-from-merge-base=origin/main ./...` — 0 issues.
- `pnpm --dir web run lint` — 0 errors; 151 pre-existing warnings.
- `pnpm --dir web run format:check` — passed.
- `make verify-settings-bindings verify-playback-fixtures` — passed.
- `make verify-local-paths` and `git diff --check` — passed.

The repository-wide `make lint` still reports the documented pre-existing backlog (300 findings). The full Go suite reaches two existing macOS process-identity failures in `internal/jellycompat`:

- `TestBeginWebOperationRecoversDeadProcessLock`
- `TestBeginWebOperationRejectsLiveProcessLock`

Both failures reproduce unchanged on a detached clean `origin/main` worktree. Every package and test touching this change passes.

The visible footer output is covered by the real `AdminSidebar` component test. A screenshot is intentionally deferred: PR-branch images remain SHA-only by design, while the ordered value is injected only by a default-branch Docker publication.

## Review

Claude Opus reviewed the exact read-only worktree through CLIProxy. It found no blocking defect. Its material finding was that branch-dispatched images initially embedded an unpublished build number; the workflow now leaves those images SHA-only. It also prompted qualifiers for historical images and the mutable `latest` tag, which are reflected in the final documentation.

### AI Disclosure
- Tool(s): OpenAI Codex, Claude Code through isolated CLIProxy
- Model(s): gpt-5.6-sol, claude-opus-5
- Involvement: AI-assisted implementation, validation, and PR preparation under maintainer direction
- Adversarial review: The final review found that non-default branch images could display an ordered number without receiving the matching tag. The build-identity job now emits an empty build number and SHA-based image version off the default branch, using the tested legacy UI fallback. Documentation overclaims identified in the same pass were corrected.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Admin build information now displays an ordered build number when available.
  - Hovering over build details shows the build timestamp.
  - Build information includes improved fallback behavior when ordered metadata is unavailable.
  - Default-branch container images now support `build-N`, `latest`, and commit-based tags.

- **Documentation**
  - Clarified container build identifiers, pinning guidance, and their separation from release versions.
  - Added changelog details for build traceability and comparison.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->