### PR TITLE
fix(storage): require explicit S3 credential replacement

### DIFF
--- a/web/src/hooks/useSettingsForm.ts
+++ b/web/src/hooks/useSettingsForm.ts
@@ -13,7 +13,7 @@ interface UseSettingsFormOptions {
 
 export function useSettingsForm({ keys }: UseSettingsFormOptions) {
   const { data: settings, isLoading } = useAdminServerSettings();
-  const { data: sensitiveData } = useAdminSensitiveStatus();
+  const { data: sensitiveData, isError: sensitiveStatusError } = useAdminSensitiveStatus();
   const updateSettings = useUpdateServerSettings();
 
   const [localValues, setLocalValues] = useState<Record<string, string>>({});
@@ -159,6 +159,8 @@ export function useSettingsForm({ keys }: UseSettingsFormOptions) {
     restartRequired,
     sensitiveConfigured,
     sensitiveManagedByEnv,
+    sensitiveStatusReady: sensitiveData != null,
+    sensitiveStatusError,
     buildConnectionCheckRequest,
   };
 }

--- a/web/src/pages/admin-settings/StorageSettings.test.tsx
+++ b/web/src/pages/admin-settings/StorageSettings.test.tsx
@@ -1,3 +1,5 @@
+import { act, render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
 import { renderToStaticMarkup } from "react-dom/server";
 import { describe, expect, it, vi } from "vitest";
 
@@ -34,6 +36,8 @@ describe("StorageSettings", () => {
       isSaving: false,
       restartRequired: false,
       sensitiveConfigured: [],
+      sensitiveStatusReady: true,
+      sensitiveStatusError: false,
       buildConnectionCheckRequest: vi.fn(),
       isDirty: () => false,
     });
@@ -64,6 +68,8 @@ describe("StorageSettings", () => {
       isSaving: false,
       restartRequired: false,
       sensitiveConfigured: [],
+      sensitiveStatusReady: true,
+      sensitiveStatusError: false,
       buildConnectionCheckRequest: vi.fn(),
       isDirty: (key: string) => key === "s3.public_bucket",
     });
@@ -72,5 +78,117 @@ describe("StorageSettings", () => {
 
     expect(markup).toContain("Storage location change");
     expect(markup).toContain("re-caches anything missing");
+  });
+
+  it("requires an explicit action before replacing a configured S3 credential", async () => {
+    const resetValue = vi.fn();
+    const setValue = vi.fn();
+    let resolveSave: (() => void) | undefined;
+    const save = vi.fn(
+      () =>
+        new Promise<void>((resolve) => {
+          resolveSave = resolve;
+        }),
+    );
+    const discard = vi.fn();
+    useCheckAdminSettingsConnectionMock.mockReturnValue({
+      isPending: false,
+      mutateAsync: vi.fn(),
+    });
+    useSettingsFormMock.mockReturnValue({
+      isLoading: false,
+      getValue: (key: string) => (key === "s3.public_url_auth" ? "presigned" : ""),
+      setValue,
+      resetValue,
+      dirtyCount: 1,
+      save,
+      discard,
+      isSaving: false,
+      restartRequired: false,
+      sensitiveConfigured: ["s3.public_access_key", "s3.public_secret_key"],
+      sensitiveStatusReady: true,
+      sensitiveStatusError: false,
+      buildConnectionCheckRequest: vi.fn(),
+      isDirty: () => false,
+    });
+
+    render(<StorageSettings />);
+
+    expect(screen.queryByLabelText("Access Key")).not.toBeInTheDocument();
+    await userEvent.click(screen.getByRole("button", { name: "Replace Access Key" }));
+    expect(screen.getByLabelText("Access Key")).toHaveAttribute("type", "password");
+
+    await userEvent.click(screen.getByRole("button", { name: "Keep saved Access Key" }));
+    expect(resetValue).toHaveBeenCalledWith("s3.public_access_key");
+    expect(screen.queryByLabelText("Access Key")).not.toBeInTheDocument();
+
+    await userEvent.click(screen.getByRole("button", { name: "Replace Secret Key" }));
+    await userEvent.click(screen.getByRole("button", { name: "Save Changes" }));
+    await waitFor(() => expect(save).toHaveBeenCalledOnce());
+    setValue.mockClear();
+    await userEvent.type(screen.getByLabelText("Secret Key"), "late replacement");
+    expect(setValue).not.toHaveBeenCalled();
+    await act(async () => resolveSave?.());
+    await waitFor(() => expect(screen.queryByLabelText("Secret Key")).not.toBeInTheDocument());
+
+    await userEvent.click(screen.getByRole("button", { name: "Replace Access Key" }));
+    await userEvent.click(screen.getByRole("button", { name: "Discard" }));
+    expect(discard).toHaveBeenCalledOnce();
+    expect(screen.queryByLabelText("Access Key")).not.toBeInTheDocument();
+  });
+
+  it("keeps credential inputs unmounted until protected status is available", () => {
+    let sensitiveStatusReady = false;
+    useCheckAdminSettingsConnectionMock.mockReturnValue({
+      isPending: false,
+      mutateAsync: vi.fn(),
+    });
+    useSettingsFormMock.mockImplementation(() => ({
+      isLoading: false,
+      getValue: (key: string) => (key === "s3.public_url_auth" ? "presigned" : ""),
+      setValue: vi.fn(),
+      resetValue: vi.fn(),
+      dirtyCount: 0,
+      save: vi.fn(),
+      discard: vi.fn(),
+      isSaving: false,
+      restartRequired: false,
+      sensitiveConfigured: ["s3.public_access_key"],
+      sensitiveStatusReady,
+      sensitiveStatusError: false,
+      buildConnectionCheckRequest: vi.fn(),
+      isDirty: () => false,
+    }));
+
+    const { rerender } = render(<StorageSettings />);
+
+    expect(screen.getByRole("status", { name: "Loading settings" })).toBeInTheDocument();
+    expect(screen.queryByLabelText("Access Key")).not.toBeInTheDocument();
+
+    sensitiveStatusReady = true;
+    rerender(<StorageSettings />);
+
+    expect(screen.getByRole("button", { name: "Replace Access Key" })).toBeInTheDocument();
+    expect(screen.queryByLabelText("Access Key")).not.toBeInTheDocument();
+  });
+
+  it("fails closed when protected credential status cannot be loaded", () => {
+    useCheckAdminSettingsConnectionMock.mockReturnValue({
+      isPending: false,
+      mutateAsync: vi.fn(),
+    });
+    useSettingsFormMock.mockReturnValue({
+      isLoading: false,
+      sensitiveConfigured: [],
+      sensitiveStatusReady: false,
+      sensitiveStatusError: true,
+    });
+
+    render(<StorageSettings />);
+
+    expect(screen.getByRole("alert")).toHaveTextContent(
+      "Protected credential status is unavailable",
+    );
+    expect(screen.queryByLabelText("Access Key")).not.toBeInTheDocument();
   });
 });

--- a/web/src/pages/admin-settings/StorageSettings.test.tsx
+++ b/web/src/pages/admin-settings/StorageSettings.test.tsx
@@ -137,6 +137,38 @@ describe("StorageSettings", () => {
     expect(screen.queryByLabelText("Access Key")).not.toBeInTheDocument();
   });
 
+  it("keeps a credential replacement open when saving fails", async () => {
+    const save = vi.fn().mockRejectedValue(new Error("save failed"));
+    useCheckAdminSettingsConnectionMock.mockReturnValue({
+      isPending: false,
+      mutateAsync: vi.fn(),
+    });
+    useSettingsFormMock.mockReturnValue({
+      isLoading: false,
+      getValue: (key: string) => (key === "s3.public_url_auth" ? "presigned" : ""),
+      setValue: vi.fn(),
+      resetValue: vi.fn(),
+      dirtyCount: 1,
+      save,
+      discard: vi.fn(),
+      isSaving: false,
+      restartRequired: false,
+      sensitiveConfigured: ["s3.public_access_key"],
+      sensitiveStatusReady: true,
+      sensitiveStatusError: false,
+      buildConnectionCheckRequest: vi.fn(),
+      isDirty: () => false,
+    });
+
+    render(<StorageSettings />);
+
+    await userEvent.click(screen.getByRole("button", { name: "Replace Access Key" }));
+    await userEvent.click(screen.getByRole("button", { name: "Save Changes" }));
+
+    await waitFor(() => expect(save).toHaveBeenCalledOnce());
+    expect(screen.getByLabelText("Access Key")).toHaveAttribute("type", "password");
+  });
+
   it("keeps credential inputs unmounted until protected status is available", () => {
     let sensitiveStatusReady = false;
     useCheckAdminSettingsConnectionMock.mockReturnValue({

--- a/web/src/pages/admin-settings/StorageSettings.tsx
+++ b/web/src/pages/admin-settings/StorageSettings.tsx
@@ -191,6 +191,8 @@ export default function StorageSettings() {
     try {
       await form.save();
       setEditingSensitiveKeys(new Set());
+    } catch {
+      // The mutation reports the error; keep credential editors open for retry.
     } finally {
       credentialSaveInProgressRef.current = false;
       setCredentialSaveInProgress(false);

--- a/web/src/pages/admin-settings/StorageSettings.tsx
+++ b/web/src/pages/admin-settings/StorageSettings.tsx
@@ -1,4 +1,4 @@
-import { useMemo, useState } from "react";
+import { useMemo, useRef, useState } from "react";
 import { AlertTriangle } from "lucide-react";
 import type { ConnectionCheckResponse } from "@/api/types";
 import { ConnectionCheckAction } from "@/components/admin/ConnectionCheckAction";
@@ -10,6 +10,7 @@ import { Tabs, TabsList, TabsTrigger, TabsContent } from "@/components/ui/tabs";
 import { Skeleton } from "@/components/ui/skeleton";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
+import { Button } from "@/components/ui/button";
 
 const PUBLIC_S3_KEYS = [
   "s3.public_endpoint",
@@ -85,6 +86,72 @@ function KeyPrefixField({
   );
 }
 
+function S3CredentialField({
+  label,
+  value,
+  configured,
+  editing,
+  onChange,
+  onReplace,
+  onKeep,
+  disabled,
+}: {
+  label: string;
+  value: string;
+  configured: boolean;
+  editing: boolean;
+  onChange: (value: string) => void;
+  onReplace: () => void;
+  onKeep: () => void;
+  disabled: boolean;
+}) {
+  if (configured && !editing) {
+    return (
+      <div className="space-y-1 py-2">
+        <Label className="text-sm font-medium">{label}</Label>
+        <div className="flex max-w-md items-center justify-between gap-3 rounded-md border px-3 py-1.5">
+          <span className="text-muted-foreground text-sm">configured</span>
+          <Button
+            type="button"
+            size="xs"
+            variant="outline"
+            aria-label={`Replace ${label}`}
+            onClick={onReplace}
+            disabled={disabled}
+          >
+            Replace
+          </Button>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-1">
+      <SettingField
+        label={label}
+        type="password"
+        value={value}
+        onChange={onChange}
+        hint={configured ? "Enter a replacement value." : undefined}
+        disabled={disabled}
+      />
+      {configured && (
+        <Button
+          type="button"
+          size="xs"
+          variant="ghost"
+          aria-label={`Keep saved ${label}`}
+          onClick={onKeep}
+          disabled={disabled}
+        >
+          Keep saved value
+        </Button>
+      )}
+    </div>
+  );
+}
+
 export default function StorageSettings() {
   const form = useSettingsForm({ keys: useMemo(() => KEYS, []) });
   const publicCheckConnection = useCheckAdminSettingsConnection();
@@ -93,6 +160,48 @@ export default function StorageSettings() {
     useState<ConnectionCheckResponse | null>(null);
   const [privateConnectionResult, setPrivateConnectionResult] =
     useState<ConnectionCheckResponse | null>(null);
+  const [editingSensitiveKeys, setEditingSensitiveKeys] = useState<Set<string>>(new Set());
+  const [credentialSaveInProgress, setCredentialSaveInProgress] = useState(false);
+  const credentialSaveInProgressRef = useRef(false);
+
+  function beginCredentialReplacement(key: string) {
+    if (credentialSaveInProgressRef.current) return;
+    setEditingSensitiveKeys((current) => new Set(current).add(key));
+  }
+
+  function keepSavedCredential(key: string) {
+    if (credentialSaveInProgressRef.current) return;
+    form.resetValue(key);
+    setEditingSensitiveKeys((current) => {
+      const next = new Set(current);
+      next.delete(key);
+      return next;
+    });
+  }
+
+  function setCredentialValue(key: string, value: string) {
+    if (credentialSaveInProgressRef.current) return;
+    form.setValue(key, value);
+  }
+
+  async function handleSave() {
+    if (credentialSaveInProgressRef.current) return;
+    credentialSaveInProgressRef.current = true;
+    setCredentialSaveInProgress(true);
+    try {
+      await form.save();
+      setEditingSensitiveKeys(new Set());
+    } finally {
+      credentialSaveInProgressRef.current = false;
+      setCredentialSaveInProgress(false);
+    }
+  }
+
+  function handleDiscard() {
+    if (credentialSaveInProgressRef.current) return;
+    form.discard();
+    setEditingSensitiveKeys(new Set());
+  }
 
   async function handleCheckPublicConnection() {
     try {
@@ -126,7 +235,24 @@ export default function StorageSettings() {
     }
   }
 
-  if (form.isLoading)
+  if (form.sensitiveStatusError) {
+    return (
+      <div
+        className="flex items-start gap-3 rounded-xl border border-red-500/20 bg-red-500/5 p-4"
+        role="alert"
+      >
+        <AlertTriangle className="mt-0.5 h-4 w-4 shrink-0 text-red-500" />
+        <div>
+          <p className="text-sm font-medium">Protected credential status is unavailable</p>
+          <p className="text-muted-foreground mt-1 text-xs">
+            Reload this page before editing storage settings.
+          </p>
+        </div>
+      </div>
+    );
+  }
+
+  if (form.isLoading || !form.sensitiveStatusReady)
     return (
       <div className="space-y-6" role="status" aria-label="Loading settings">
         <Skeleton className="h-8 w-48" />
@@ -213,19 +339,25 @@ export default function StorageSettings() {
                 </div>
               </div>
             )}
-            <SettingField
+            <S3CredentialField
               label="Access Key"
-              type="password"
               value={form.getValue("s3.public_access_key")}
-              onChange={(v) => form.setValue("s3.public_access_key", v)}
-              sensitiveConfigured={form.sensitiveConfigured.includes("s3.public_access_key")}
+              onChange={(v) => setCredentialValue("s3.public_access_key", v)}
+              configured={form.sensitiveConfigured.includes("s3.public_access_key")}
+              editing={editingSensitiveKeys.has("s3.public_access_key")}
+              onReplace={() => beginCredentialReplacement("s3.public_access_key")}
+              onKeep={() => keepSavedCredential("s3.public_access_key")}
+              disabled={form.isSaving || credentialSaveInProgress}
             />
-            <SettingField
+            <S3CredentialField
               label="Secret Key"
-              type="password"
               value={form.getValue("s3.public_secret_key")}
-              onChange={(v) => form.setValue("s3.public_secret_key", v)}
-              sensitiveConfigured={form.sensitiveConfigured.includes("s3.public_secret_key")}
+              onChange={(v) => setCredentialValue("s3.public_secret_key", v)}
+              configured={form.sensitiveConfigured.includes("s3.public_secret_key")}
+              editing={editingSensitiveKeys.has("s3.public_secret_key")}
+              onReplace={() => beginCredentialReplacement("s3.public_secret_key")}
+              onKeep={() => keepSavedCredential("s3.public_secret_key")}
+              disabled={form.isSaving || credentialSaveInProgress}
             />
 
             <ConnectionCheckAction
@@ -318,19 +450,25 @@ export default function StorageSettings() {
               value={form.getValue("s3.private_key_prefix")}
               onChange={(v) => form.setValue("s3.private_key_prefix", v)}
             />
-            <SettingField
+            <S3CredentialField
               label="Access Key"
-              type="password"
               value={form.getValue("s3.private_access_key")}
-              onChange={(v) => form.setValue("s3.private_access_key", v)}
-              sensitiveConfigured={form.sensitiveConfigured.includes("s3.private_access_key")}
+              onChange={(v) => setCredentialValue("s3.private_access_key", v)}
+              configured={form.sensitiveConfigured.includes("s3.private_access_key")}
+              editing={editingSensitiveKeys.has("s3.private_access_key")}
+              onReplace={() => beginCredentialReplacement("s3.private_access_key")}
+              onKeep={() => keepSavedCredential("s3.private_access_key")}
+              disabled={form.isSaving || credentialSaveInProgress}
             />
-            <SettingField
+            <S3CredentialField
               label="Secret Key"
-              type="password"
               value={form.getValue("s3.private_secret_key")}
-              onChange={(v) => form.setValue("s3.private_secret_key", v)}
-              sensitiveConfigured={form.sensitiveConfigured.includes("s3.private_secret_key")}
+              onChange={(v) => setCredentialValue("s3.private_secret_key", v)}
+              configured={form.sensitiveConfigured.includes("s3.private_secret_key")}
+              editing={editingSensitiveKeys.has("s3.private_secret_key")}
+              onReplace={() => beginCredentialReplacement("s3.private_secret_key")}
+              onKeep={() => keepSavedCredential("s3.private_secret_key")}
+              disabled={form.isSaving || credentialSaveInProgress}
             />
 
             <ConnectionCheckAction
@@ -392,9 +530,9 @@ export default function StorageSettings() {
 
       <SaveBar
         dirtyCount={form.dirtyCount}
-        onSave={form.save}
-        onDiscard={form.discard}
-        isSaving={form.isSaving}
+        onSave={handleSave}
+        onDiscard={handleDiscard}
+        isSaving={form.isSaving || credentialSaveInProgress}
         restartRequired={form.restartRequired}
       />
     </div>


### PR DESCRIPTION
## Problem

No linked issue; this is a focused, production-proven bug fix.

Persisted sensitive settings are intentionally omitted from the effective-settings response and represented separately as configured status. The storage form nevertheless kept empty password inputs mounted for configured S3 credentials. A browser or password manager could populate those live controls; their change events then marked the credential as a dirty replacement. Connection checks overlay dirty draft values onto the persisted, decrypted settings, so a saved/restarted configuration could send an unintended credential to `HeadBucket` and receive a 403. Fresh entry worked because the intended credential was supplied directly as the draft value.

## Approach

- Render configured public/private S3 access keys and secret keys as static `configured` state with an explicit **Replace** action, with no password input mounted by default.
- Reveal the password input only after **Replace**; **Keep saved** resets the draft and restores the protected state.
- Close credential editors after a successful save or discard, while retaining them after a failed save.
- Fail closed until sensitive-status loading succeeds, and block credential-state changes while a save is in flight.

This is @blurbery's production-proven fix. @blurbery identified and reproduced the saved/restarted failure, developed and owned the fix, deployed it, and confirmed that saved/restarted public and private S3 configurations work in production. Codex assisted with isolating the portable upstream change, strengthening the focused tests, adversarial review, validation, and PR preparation.

## Testing

Focused Web tests:

```text
Test Files  2 passed (2)
Tests       11 passed (11)
```

Full Web test suite using the repository's documented exclusions:

```text
Test Files  280 passed (280)
Tests       1970 passed (1970)
```

Additional verification:

- `pnpm run lint`: 0 errors (151 existing warnings)
- `pnpm run format:check`: passed
- `pnpm run build`: passed
- `go build ./...`: passed with Go 1.26.4
- `gofmt -l .`: no output
- `go vet ./...`: passed
- `go test ./internal/api/handlers -run '^TestHandleCheckSettingsConnectionS3UsesPersistedSensitiveValues$' -count=1`: passed
- Settings bindings, playback fixtures, local-path hygiene, and `git diff --check`: passed
- [Final-commit Linux CI](https://github.com/blurbery/silo-server/actions/runs/32310366304): Docs hygiene, Web, and Go jobs passed, including the full Linux Go test suite

No screenshot is attached because this change protects credential-entry states; the focused tests cover configured, replace, keep-saved, save, discard, loading, error, and in-flight-save behavior without displaying credentials.

Adversarial review initially found two credential-state races: sensitive-status loading/error could expose an input, and an edit could race an in-flight save. Both were fixed. CodeRabbit then identified missing failed-save coverage; the event-handler rejection is now handled and a regression test verifies that the editor remains available for retry. Final adversarial and scope reviews found no material issues, secrets, private infrastructure, generated artifacts, or unrelated changes.

### AI Disclosure

- Tool(s): OpenAI Codex
- Model(s): gpt-5.6-sol
- Involvement: AI-assisted
- Adversarial review: Two credential-state races and one failed-save test gap were found and fixed. Final review found no material issues.

## Checklist

- [x] I ran an adversarial AI review of the diff and summarized findings above.
- [x] I ran the relevant repository verification locally and in the fork's Linux CI, including Go/Web lint, formatting, builds, tests, generated-contract checks, and hygiene checks.
