### PR TITLE
docs: streamline project and contribution guidance

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -54,8 +54,10 @@ POSTGRES_SHM_SIZE=8gb
 # Optional host port overrides for docker-compose.yml. The container listeners
 # remain fixed, so these values only change the host side of each port mapping.
 # PORT=8090
-# Used only after Jellyfin-compatible app support is enabled by an admin.
+# Jellyfin/Emby and Audiobookshelf compatibility listeners are enabled by
+# default and can be managed through admin settings.
 # JF_PORT=8096
+# ABS_PORT=13378
 # PROXY_PORT=8083
 # TRANSCODE_PORT=8082
 
@@ -83,7 +85,9 @@ POSTGRES_SHM_SIZE=8gb
 # SILO_TRUSTED_PROXIES=10.0.0.0/8,172.16.0.0/12,192.168.0.0/16,127.0.0.0/8,::1/128,203.0.113.7/32
 
 # Run from source / advanced overrides
-# Only DATABASE_URL is required when running Silo outside the default docker compose stack.
+# DATABASE_URL and SECRET_KEY are required when running Silo outside the default
+# Docker Compose stack. REDIS_URL is optional for integrated/API mode and
+# required for standalone proxy/transcode modes.
 # DATABASE_URL=postgres://silo:password@localhost:5432/silo
 
 # Optional Redis override when running from source or pointing workers at an external Redis.

--- a/.env.example
+++ b/.env.example
@@ -26,7 +26,8 @@ SILO_IMAGE=ghcr.io/silo-server/silo-server:latest
 
 # Quick-start bundled PostgreSQL settings used by docker-compose.yml.
 POSTGRES_USER=silo
-POSTGRES_PASSWORD=silo
+# Set POSTGRES_PASSWORD before first start (the quick start appends a generated one).
+# POSTGRES_PASSWORD=silo
 POSTGRES_DB=silo
 POSTGRES_SHM_SIZE=8gb
 # POSTGRES_PORT=5432

--- a/.github/ISSUE_TEMPLATE/bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yml
@@ -8,7 +8,7 @@ body:
       value: |
         Report behavior you reproduced on a real deployment. Include raw logs rather than AI summaries, and keep observations separate from suspected root cause. Redact credentials, tokens, personal data, and private media details, and mark each redaction.
 
-        Read [CONTRIBUTING.md](https://github.com/Silo-Server/silo-server/blob/main/CONTRIBUTING.md) and the [AI-assisted contribution policy](https://github.com/Silo-Server/silo-server/blob/main/docs/ai-contributions.md) first.
+        Fabricated or AI-hallucinated reports are an immediate block. Read [CONTRIBUTING.md](https://github.com/Silo-Server/silo-server/blob/main/CONTRIBUTING.md) and the [AI-assisted contribution policy](https://github.com/Silo-Server/silo-server/blob/main/docs/ai-contributions.md) first.
   - type: textarea
     id: what-happened
     attributes:
@@ -93,13 +93,6 @@ body:
         - Human-written, AI-reviewed
         - AI-assisted
         - Fully AI-generated, human verified
-    validations:
-      required: true
-  - type: textarea
-    id: adversarial-review
-    attributes:
-      label: Adversarial review
-      description: Summarize independent/adversarial review findings and resolutions. Use "n/a" only when no AI or implementation change was involved.
     validations:
       required: true
   - type: checkboxes

--- a/.github/ISSUE_TEMPLATE/bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yml
@@ -6,9 +6,9 @@ body:
   - type: markdown
     attributes:
       value: |
-        Raw logs only. Never AI-summarize logs. You must have reproduced this yourself on a real deployment before filing.
+        Report behavior you reproduced on a real deployment. Include raw logs rather than AI summaries, and keep observations separate from suspected root cause. Redact credentials, tokens, personal data, and private media details, and mark each redaction.
 
-        Fabricated or AI-hallucinated reports are an instant block. Read [CONTRIBUTING.md](https://github.com/Silo-Server/silo-server/blob/main/CONTRIBUTING.md) first.
+        Read [CONTRIBUTING.md](https://github.com/Silo-Server/silo-server/blob/main/CONTRIBUTING.md) and the [AI-assisted contribution policy](https://github.com/Silo-Server/silo-server/blob/main/docs/ai-contributions.md) first.
   - type: textarea
     id: what-happened
     attributes:
@@ -65,21 +65,41 @@ body:
       render: shell
     validations:
       required: true
-  - type: dropdown
-    id: ai-involvement
+  - type: textarea
+    id: technical-notes
     attributes:
-      label: AI involvement in this report
-      options:
-        - None — written by a human
-        - AI-assisted, human verified the repro
-        - AI-generated, human verified the repro
+      label: Technical notes
+      description: Optional suspected root cause, relevant files, SQL output, or stack traces. Keep this separate from the observed reproduction above.
+  - type: input
+    id: ai-tools
+    attributes:
+      label: AI tool(s)
+      description: Enter the exact tool name(s), or "none".
     validations:
       required: true
   - type: input
-    id: ai-tool-model
+    id: ai-models
     attributes:
-      label: AI tool + model
-      placeholder: e.g. Claude Code / claude-fable-5 — or n/a
+      label: AI model(s)
+      description: Enter the exact model identifier(s) reported by each tool, or "n/a".
+    validations:
+      required: true
+  - type: dropdown
+    id: ai-involvement
+    attributes:
+      label: AI involvement
+      options:
+        - No AI used
+        - Human-written, AI-reviewed
+        - AI-assisted
+        - Fully AI-generated, human verified
+    validations:
+      required: true
+  - type: textarea
+    id: adversarial-review
+    attributes:
+      label: Adversarial review
+      description: Summarize independent/adversarial review findings and resolutions. Use "n/a" only when no AI or implementation change was involved.
     validations:
       required: true
   - type: checkboxes
@@ -89,5 +109,5 @@ body:
       options:
         - label: I reproduced this myself on a real deployment
           required: true
-        - label: Logs above are raw copy-paste, not AI-summarized
+        - label: Any logs provided are raw apart from marked redactions and are not AI-summarized; if none were available, I said so above
           required: true

--- a/.github/ISSUE_TEMPLATE/v1-capability-proposal.yml
+++ b/.github/ISSUE_TEMPLATE/v1-capability-proposal.yml
@@ -54,3 +54,35 @@ body:
         - L
     validations:
       required: true
+  - type: input
+    id: ai-tools
+    attributes:
+      label: AI tool(s)
+      description: Enter the exact tool name(s), or "none".
+    validations:
+      required: true
+  - type: input
+    id: ai-models
+    attributes:
+      label: AI model(s)
+      description: Enter the exact model identifier(s) reported by each tool, or "n/a".
+    validations:
+      required: true
+  - type: dropdown
+    id: ai-involvement
+    attributes:
+      label: AI involvement
+      options:
+        - No AI used
+        - Human-written, AI-reviewed
+        - AI-assisted
+        - Fully AI-generated, human verified
+    validations:
+      required: true
+  - type: textarea
+    id: adversarial-review
+    attributes:
+      label: Adversarial review
+      description: Summarize independent/adversarial review findings and resolutions. Use "n/a" only when no AI or implementation change was involved.
+    validations:
+      required: true

--- a/.github/ISSUE_TEMPLATE/v1-capability-proposal.yml
+++ b/.github/ISSUE_TEMPLATE/v1-capability-proposal.yml
@@ -79,10 +79,3 @@ body:
         - Fully AI-generated, human verified
     validations:
       required: true
-  - type: textarea
-    id: adversarial-review
-    attributes:
-      label: Adversarial review
-      description: Summarize independent/adversarial review findings and resolutions. Use "n/a" only when no AI or implementation change was involved.
-    validations:
-      required: true

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,24 +1,22 @@
 ## Problem
 
 Related issue: #NNN
-<!-- Replace the line above with "Related issue: N/A — narrow fix" when prior coordination was not required. -->
+<!-- Use "Related issue: N/A — narrow fix" only when no prior coordination was needed. -->
 
 What user or maintainer problem does this solve?
 
 ## Approach
 
-Why is this approach appropriate? Note important alternatives or tradeoffs.
+Why this approach? Note alternatives or tradeoffs worth knowing about.
 
 ## Validation
 
-Paste actual commands and results. Identify anything not run or not passing.
-
-For visible UI changes, include screenshots or recordings.
+Paste the actual commands and results. Name anything not run or not passing.
+Include screenshots or recordings for visible UI changes.
 
 ## Risks
 
-Describe migration, compatibility, security, or operational impact. Write
-"None identified" when applicable.
+Migration, compatibility, security, or operational impact, or "None identified".
 
 ## AI Disclosure
 
@@ -30,8 +28,4 @@ Describe migration, compatibility, security, or operational impact. Write
 ## Checklist
 
 - [ ] I read and can explain the complete diff.
-- [ ] I kept this pull request focused on one concern.
-- [ ] I ran the relevant checks in [CONTRIBUTING.md](https://github.com/Silo-Server/silo-server/blob/main/CONTRIBUTING.md) and reported the actual results above.
-- [ ] I manually verified user-facing behavior where practical.
-- [ ] I completed the required AI disclosure, including "none"/"n/a" where applicable.
-- [ ] I reviewed the diff independently or adversarially and resolved or documented the findings.
+- [ ] This pull request addresses one concern.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -22,10 +22,10 @@ Describe migration, compatibility, security, or operational impact. Write
 
 ## AI Disclosure
 
-- Tool(s):
-- Model(s):
-- Involvement:
-- Adversarial review:
+- Tool(s): exact tool name(s), or "none"
+- Model(s): exact model identifier(s) reported by each tool, or "n/a"
+- Involvement: Fully AI-generated, human verified | AI-assisted | Human-written, AI-reviewed | No AI used
+- Adversarial review: findings and resolutions, or "n/a" only when no AI or implementation change was involved
 
 ## Checklist
 

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -25,7 +25,7 @@ Describe migration, compatibility, security, or operational impact. Write
 - Tool(s): exact tool name(s), or "none"
 - Model(s): exact model identifier(s) reported by each tool, or "n/a"
 - Involvement: Fully AI-generated, human verified | AI-assisted | Human-written, AI-reviewed | No AI used
-- Adversarial review: findings and resolutions, or "n/a" only when no AI or implementation change was involved
+- Adversarial review: scope, method, findings, and resolutions, or "n/a" only when no AI or implementation change was involved
 
 ## Checklist
 

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,21 +1,37 @@
 ## Problem
-Part of #NNN
-<!-- PRs with no linked scope item will be questioned. -->
 
-What does this solve?
+Related issue: #NNN
+<!-- Replace the line above with "Related issue: N/A — narrow fix" when prior coordination was not required. -->
+
+What user or maintainer problem does this solve?
 
 ## Approach
-Why this approach?
 
-## Testing
-Paste ACTUAL command output here. For UI changes, include screenshots or recordings.
+Why is this approach appropriate? Note important alternatives or tradeoffs.
 
-### AI Disclosure
+## Validation
+
+Paste actual commands and results. Identify anything not run or not passing.
+
+For visible UI changes, include screenshots or recordings.
+
+## Risks
+
+Describe migration, compatibility, security, or operational impact. Write
+"None identified" when applicable.
+
+## AI Disclosure
+
 - Tool(s):
 - Model(s):
 - Involvement:
 - Adversarial review:
 
 ## Checklist
-- [ ] I ran an adversarial AI review of the diff and summarized findings above.
-- [ ] I ran the repo verify commands: `make lint`, `cd web && pnpm run lint`, `cd web && pnpm run format:check`, and relevant `go test ./...`.
+
+- [ ] I read and can explain the complete diff.
+- [ ] I kept this pull request focused on one concern.
+- [ ] I ran the relevant checks in [CONTRIBUTING.md](https://github.com/Silo-Server/silo-server/blob/main/CONTRIBUTING.md) and reported the actual results above.
+- [ ] I manually verified user-facing behavior where practical.
+- [ ] I completed the required AI disclosure, including "none"/"n/a" where applicable.
+- [ ] I reviewed the diff independently or adversarially and resolved or documented the findings.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -150,20 +150,11 @@ reason in its own source, not an entry in a Makefile variable. `make test-web` s
 files in `WEBTEST_KNOWN_FAILURES`, which predate the CI gate; that list may only shrink — delete an
 entry together with its fix, and never add to it to make a new change pass.
 
-Before opening a merge request:
-
-```bash
-make lint
-make test
-cd web && pnpm run lint && pnpm run format:check
-make verify-local-paths
-```
-
-`.github/workflows/ci.yml` runs these on every pull request, with one difference worth knowing:
-`make lint` runs `golangci-lint` over the whole tree, while CI runs it with `--new-from-merge-base`
-so only the lines a branch touched have to be clean. The repo does not pass a full run today, so
-expect local output to include findings that are not yours and that CI will not fail on. Do not add
-to them.
+Before opening a pull request, run the full gate listed once in
+[CONTRIBUTING.md](CONTRIBUTING.md#validate-your-change). Note that `make lint` runs
+`golangci-lint` over the whole tree while CI runs it with `--new-from-merge-base`, so only the
+lines a branch touched have to be clean. The repo does not pass a full run today; expect local
+output to include findings that are not yours and that CI will not fail on. Do not add to them.
 
 Go stays `gofmt`/`goimports` clean; the frontend follows `web/.prettierrc`.
 
@@ -203,7 +194,8 @@ Design new endpoints today so they can live under that regime tomorrow.
 Conventional Commit subjects (`feat(playback): add realtime session hub`). One concern per PR.
 Explain the problem, why this approach, the linked issue/spec/plan, and risks or follow-up work.
 Include screenshots or recordings for UI changes. Link the capability epic or sub-issue the PR
-serves (`Part of #NNN`) — PRs with no linked scope item get questioned at review. For non-trivial
+serves (`Related issue: #NNN`); write `Related issue: N/A — narrow fix` only when no prior
+coordination was needed, otherwise an unlinked PR gets questioned at review. For non-trivial
 work, open an issue or discussion first; this codebase moves quickly.
 
 AI-use disclosure is required in the PR body. If you are an AI agent contributing on behalf of a

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,105 +1,80 @@
 # Contributing to Silo
 
-Thank you for contributing to Silo. Contributions from people using any
-development workflow—including AI-assisted workflows—are welcome. Every
-contributor remains responsible for understanding, testing, and explaining the
-work they submit.
-
-Most of Silo's codebase was developed with AI assistance. The same ownership,
-evidence, and disclosure standards apply to maintainers and external
-contributors.
+Contributions are welcome from any workflow, including AI-assisted ones. Most of
+Silo was written with AI assistance. Whoever submits the work is responsible for
+understanding it, testing it, and explaining it; that applies to maintainers and
+external contributors alike.
 
 ## Before you start
 
 > [!IMPORTANT]
-> Coordinate non-trivial work before implementation. Open an issue or start a
-> project discussion for features, API or behavior changes, schema migrations,
-> large refactors, and other changes that affect product scope. Documentation,
-> typo fixes, and narrow bug fixes may go directly to a pull request.
+> Open an issue or discussion before implementing features, API or behavior
+> changes, schema migrations, large refactors, or anything else that changes
+> product scope. Documentation, typo fixes, and narrow bug fixes can go straight
+> to a pull request.
 
-Silo is pre-1.0 and evolving. Early coordination helps avoid duplicate work,
-conflicts with changes already in progress, and proposals outside the current
-scope. Review [Project non-goals](docs/non-goals.md) and the relevant
-architecture documentation before proposing a new capability.
+Silo is pre-1.0 and moves quickly. Coordinating first avoids duplicate work,
+conflicts with changes already in flight, and proposals outside scope. Read
+[Project non-goals](docs/non-goals.md) and the relevant
+`docs/architecture/` material before proposing a capability.
 
-Durable architecture and contracts belong under `docs/architecture/`. Temporary
-implementation plans and working notes belong in the issue or pull request, not
-as permanent repository documents.
+Durable architecture and contracts live under `docs/architecture/`.
+Implementation plans and working notes belong in the issue or pull request, not
+in the repository.
 
 ## Reporting a problem
 
-Use the [GitHub issue forms](https://github.com/Silo-Server/silo-server/issues/new/choose)
-for bugs, installation problems, and performance issues. Start with what you
-observed, not a root-cause theory.
-
-Include:
-
-- what you were trying to do
-- the exact steps you performed
-- expected and actual behavior
-- the specific action that is slow or broken, such as save, scan, browse,
-  import, or playback
-- whether the problem is consistent or intermittent
-- the relevant library, media type, filter, setting, or value
-- Silo version, build, branch, or commit
-- deployment details
-- screenshots, recordings, or raw log excerpts when relevant
-
-Put suspected files, SQL output, stack traces, and root-cause theories under
-**Technical notes**, after the workflow and reproduction are clear.
-Redact credentials, tokens, personal data, and private media details from raw
-evidence, and mark each redaction. Do not paraphrase or synthesize the remainder.
+Use the [GitHub issue forms](https://github.com/Silo-Server/silo-server/issues/new/choose);
+they ask for everything a maintainer needs. Two rules: describe what you observed
+before any root-cause theory, and paste raw logs rather than a summary. Redact
+credentials, tokens, personal data, and private media details, mark each
+redaction, and leave the rest untouched.
 
 ## Prepare a focused change
 
-1. Read the existing implementation and tests in the area you will change.
-2. Keep one concern per pull request; do not mix unrelated cleanup or refactors.
-3. Follow established patterns and add comments only where behavior is not
-   obvious from the code.
-4. Add focused tests that fail before the fix and pass after it.
-5. Exercise user-facing behavior in a running application when the change can
-   be tested manually.
-6. Review the complete diff for unintended behavior, generated-file drift,
-   local paths, credentials, and unrelated edits.
-7. Obtain an independent or adversarial review of non-trivial changes and
-   resolve the findings before submission.
+1. Read the existing implementation and tests in the area you are changing.
+2. One concern per pull request. No unrelated cleanup or refactors.
+3. Follow existing patterns; comment only where behavior is not obvious from the
+   code.
+4. Add tests that fail before the fix and pass after it.
+5. Exercise user-facing behavior in a running application when you can.
+6. Review the whole diff for unintended behavior, generated-file drift, local
+   paths, credentials, and stray edits.
+7. For non-trivial changes, get an independent or adversarial review and
+   resolve its findings before submitting.
 
-Tests are evidence, not proof. Consider system-level effects beyond the files
-you touched, and be prepared to explain the implementation, alternatives, and
-tradeoffs during review.
+Tests are evidence, not proof. Think about effects beyond the files you touched,
+and be ready to explain the implementation, alternatives, and tradeoffs in
+review.
 
 ## Development setup
 
-Follow [DEVELOPMENT.md](DEVELOPMENT.md) for prerequisites, local services,
-builds, migrations, tests, and repository structure.
-
-If a change spans Silo and `silo-plugin-sdk`, use an untracked local `go.work`
-workspace for iteration. `go.work` and `go.work.sum` are intentionally ignored.
-CI runs from a clean checkout, and release builds explicitly set `GOWORK=off`.
-Any SDK package or symbol used by repository code must therefore exist in a
-pushed, tagged `github.com/Silo-Server/silo-plugin-sdk` release before merge.
+[DEVELOPMENT.md](DEVELOPMENT.md) covers prerequisites, local services, builds,
+migrations, and repository layout, including how to iterate against
+`silo-plugin-sdk`.
 
 ## Validate your change
 
-Run focused tests while iterating:
+While iterating, run the focused tests for what you touched:
 
 ```sh
 go test ./internal/<package>/...
 cd web && pnpm exec vitest run path/to/changed.test.tsx
 ```
 
-Before opening a pull request, run every relevant repository gate. A typical
-local validation is:
+Before opening a pull request, run the full gate. This is the one list; the
+[CI workflow](.github/workflows/ci.yml) is authoritative if they ever disagree.
 
 ```sh
-# Go build, formatting, vet, and tests
+# Go
 make embed-stub
 go build ./...
-gofmt -l .
+gofmt -l .                      # must print nothing
 go vet ./...
+golangci-lint run --new-from-merge-base="origin/main" ./...
 make test-go
 
-# Web install, lint, formatting, build, and tests
+# Web
 cd web
 pnpm install --frozen-lockfile
 pnpm run lint
@@ -114,62 +89,44 @@ make verify-playback-fixtures
 make verify-local-paths
 ```
 
-`gofmt -l .` must produce no output. Run additional focused tests for every
-manually resolved or high-risk area.
+`make lint` runs `golangci-lint` over the whole tree and reports inherited
+findings the repository does not pass yet; CI only gates the lines your branch
+changed, which is what the `--new-from-merge-base` form checks. Do not add to
+the inherited findings.
 
-> [!NOTE]
-> `make lint` runs `golangci-lint` across the full Go tree and can report
-> inherited findings. Pull-request CI gates changed Go lines with
-> `golangci-lint run --new-from-merge-base="origin/<base>" ./...`; new or changed
-> lines must be clean. The current [CI workflow](.github/workflows/ci.yml) is the
-> authoritative list of required checks.
-
-Paste actual command results into the pull request. Do not report a check as
-passing if it was skipped, failed, or was not run in the stated environment.
+Paste the actual results into the pull request. Do not report a check as passing
+if it was skipped, failed, or ran somewhere other than where you say it did.
 
 ## AI-assisted contributions
 
 > [!WARNING]
-> AI use must be disclosed in every issue and pull request. Fabricated APIs,
-> observations, vulnerabilities, reproduction steps, logs, or test results are
-> not acceptable. Bug reports must come from a real reproduction, and logs must
-> be raw rather than AI-paraphrased.
+> Disclose AI use in every issue and pull request. Fabricated APIs,
+> observations, vulnerabilities, reproduction steps, logs, or test results get
+> the contributor blocked. Bug reports must come from a real reproduction with
+> raw logs.
 
-Read and follow the canonical
-[AI-assisted contribution policy](docs/ai-contributions.md). It defines the
-required disclosure block, contributor responsibilities, evidence standard,
-and enforcement policy. "No AI" is a valid disclosure; non-disclosure is not.
+The [AI-assisted contribution policy](docs/ai-contributions.md) defines the
+disclosure block, the evidence standard, and enforcement. "No AI" is a valid
+disclosure; leaving it out is not.
 
 ## Open the pull request
 
-Use a concise [Conventional Commit](https://www.conventionalcommits.org/)
-title. A reviewable pull request should include:
-
-- a linked issue or scope item for non-trivial work; use `N/A — narrow fix` when
-  prior coordination was not required
-- the user or maintainer problem being solved
-- why the chosen approach is appropriate
-- actual validation commands and results
-- migration, compatibility, security, or operational risks
-- screenshots or recordings for visible UI changes
-- the completed AI disclosure
-- a summary of independent or adversarial review findings and resolutions
-
-Keep the commit history intentional and the final diff limited to the stated
-problem.
+Use a [Conventional Commit](https://www.conventionalcommits.org/) title and fill
+in the pull request template. Link the issue or scope item for non-trivial
+work; write `Related issue: N/A — narrow fix` only when no prior coordination
+was needed. Keep the commit history intentional and the diff limited to the
+stated problem.
 
 ## Review expectations
 
-Maintainers may ask for a smaller change, request a different implementation,
-decline work that no longer fits the project, or accept the idea and implement
-it separately. Opening a pull request does not guarantee merge. Clear scope,
-reproducible evidence, and a focused diff make review faster.
-
-If scope is uncertain, ask before investing in an implementation.
+Maintainers may ask for a smaller change, a different implementation, decline
+work that no longer fits, or take the idea and implement it separately. Opening
+a pull request does not guarantee a merge. If scope is uncertain, ask before
+building.
 
 ## Instructions for coding agents
 
-Coding agents must read [AGENTS.md](AGENTS.md) before changing the repository.
-`CLAUDE.md` points to the same project instructions. This guide and the
-[AI-assisted contribution policy](docs/ai-contributions.md) apply equally to
-agent-authored and human-authored work.
+Coding agents must read [AGENTS.md](AGENTS.md) before changing the repository
+(`CLAUDE.md` points to the same file). This guide and the
+[AI-assisted contribution policy](docs/ai-contributions.md) apply to agent and
+human authors equally.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,99 +1,175 @@
 # Contributing to Silo
 
-Hey, thanks for wanting to contribute!
+Thank you for contributing to Silo. Contributions from people using any
+development workflow—including AI-assisted workflows—are welcome. Every
+contributor remains responsible for understanding, testing, and explaining the
+work they submit.
 
-Let's be real: this project is built almost entirely with AI assistance. Claude, Codex, whatever you've got — we're not pretending otherwise. But there's a big difference between *using AI well* and *submitting AI slop*. We care a lot about the first one, and we'll push back hard on the second.
+Most of Silo's codebase was developed with AI assistance. The same ownership,
+evidence, and disclosure standards apply to maintainers and external
+contributors.
 
-- AI-generated code is fine. AI slop is not.
-- You are responsible for everything you submit, even if an AI wrote it.
-- Actually read the code. Actually run the tests. Actually understand what it does.
-- Don't send big changes without talking about them first.
+## Before you start
 
-## Things Are Moving Fast
+> [!IMPORTANT]
+> Coordinate non-trivial work before implementation. Open an issue or start a
+> project discussion for features, API or behavior changes, schema migrations,
+> large refactors, and other changes that affect product scope. Documentation,
+> typo fixes, and narrow bug fixes may go directly to a pull request.
 
-Silo is in heavy active development. Features get rewritten, APIs shift, whole sections get reworked — sometimes day to day. **If you want to work on something, reach out first.** Open an issue or drop a message so:
+Silo is pre-1.0 and evolving. Early coordination helps avoid duplicate work,
+conflicts with changes already in progress, and proposals outside the current
+scope. Review [Project non-goals](docs/non-goals.md) and the relevant
+architecture documentation before proposing a new capability.
 
-- You don't build on something that's already been rewritten locally but not pushed yet.
-- I can avoid breaking something you're actively working on.
-- We can check the area is stable enough to be worth building on right now.
+Durable architecture and contracts belong under `docs/architecture/`. Temporary
+implementation plans and working notes belong in the issue or pull request, not
+as permanent repository documents.
 
-## Before You Start
+## Reporting a problem
 
-Small stuff (typo fixes, minor bugs) — just open a merge request. No ceremony.
+Use the [GitHub issue forms](https://github.com/Silo-Server/silo-server/issues/new/choose)
+for bugs, installation problems, and performance issues. Start with what you
+observed, not a root-cause theory.
 
-For anything bigger, start with an issue first. New features, API changes, schema migrations, large refactors, behavior changes — talk about it before writing code. Durable design docs live under `docs/architecture/`; working plans and specs are ephemeral and go in the PR description, not the repo.
+Include:
 
-## Don't Submit AI Slop
+- what you were trying to do
+- the exact steps you performed
+- expected and actual behavior
+- the specific action that is slow or broken, such as save, scan, browse,
+  import, or playback
+- whether the problem is consistent or intermittent
+- the relevant library, media type, filter, setting, or value
+- Silo version, build, branch, or commit
+- deployment details
+- screenshots, recordings, or raw log excerpts when relevant
 
-AI writes most of the code here. That's fine. What's not fine is copy-pasting output without understanding it.
+Put suspected files, SQL output, stack traces, and root-cause theories under
+**Technical notes**, after the workflow and reproduction are clear.
+Redact credentials, tokens, personal data, and private media details from raw
+evidence, and mark each redaction. Do not paraphrase or synthesize the remainder.
 
-1. **Read every line of your diff.** If you can't explain it, don't submit it.
-2. **Run the tests** — but don't blindly trust them. The tests were also AI-written and they have blind spots.
-3. **Test the app yourself locally.** Spin it up, click around, try the thing you changed. There is no substitute for this.
-4. **Run code-review** on your own work before submitting. `superpowers:requesting-code-review` or whatever tooling you have.
-5. **Watch for AI-introduced bugs.** Silent behavior changes, dead code, subtle regressions — look for them.
-6. **Understand the bigger picture.** A change that looks fine in isolation can break something three layers away.
+## Prepare a focused change
 
-"The AI suggested it" is not an acceptable answer in review. You should be able to explain the reasoning and tradeoffs.
+1. Read the existing implementation and tests in the area you will change.
+2. Keep one concern per pull request; do not mix unrelated cleanup or refactors.
+3. Follow established patterns and add comments only where behavior is not
+   obvious from the code.
+4. Add focused tests that fail before the fix and pass after it.
+5. Exercise user-facing behavior in a running application when the change can
+   be tested manually.
+6. Review the complete diff for unintended behavior, generated-file drift,
+   local paths, credentials, and unrelated edits.
+7. Obtain an independent or adversarial review of non-trivial changes and
+   resolve the findings before submission.
 
-## AI Disclosure (Required)
+Tests are evidence, not proof. Consider system-level effects beyond the files
+you touched, and be prepared to explain the implementation, alternatives, and
+tradeoffs during review.
 
-Every PR and every issue needs to say what AI was involved: the tool, the exact model ID, and the involvement level. "No AI" is a perfectly fine answer. Just say so.
+## Development setup
 
-```md
-### AI Disclosure
-- Tool(s): e.g. Claude Code, Codex CLI, Cursor — or "none"
-- Model(s): exact model ID(s), e.g. claude-fable-5, gpt-5.4 — or "n/a"
-- Involvement: fully AI-generated | AI-assisted | human-written, AI-reviewed | none
-- Adversarial review: what your own AI review of the diff found, and how you resolved it
-```
+Follow [DEVELOPMENT.md](DEVELOPMENT.md) for prerequisites, local services,
+builds, migrations, tests, and repository structure.
 
-The exact model matters. This project is developed with frontier models. If a PR was generated by an older or weaker model, the fastest honest response may be for me to re-implement the idea with a current model instead of reviewing the diff line by line. Disclosing the model lets that call happen quickly. "Thanks, the idea is accepted, but the implementation will be redone" is a possible outcome; see [Be Realistic](#be-realistic).
+If a change spans Silo and `silo-plugin-sdk`, use an untracked local `go.work`
+workspace for iteration. `go.work` and `go.work.sum` are intentionally ignored.
+CI runs from a clean checkout, and release builds explicitly set `GOWORK=off`.
+Any SDK package or symbol used by repository code must therefore exist in a
+pushed, tagged `github.com/Silo-Server/silo-plugin-sdk` release before merge.
 
-Before submitting, run an adversarial review of your own diff with whatever AI tooling you have, and summarize what it found and what you did about it. "It found nothing" is only credible for tiny diffs.
+## Validate your change
 
-Undisclosed AI use that is discovered later gets the PR closed on the spot. Repeat offenses get you blocked. The offense is the non-disclosure, not the AI use.
-
-Fabricated content is an immediate block, first offense. Invented APIs, repro steps that never happened, AI-imagined vulnerabilities, and "bugs" nobody actually observed all count. This is the curl-style rule for hallucinated reports.
-
-For issues, logs must be raw copy-paste, never AI-paraphrased. You must have actually reproduced the problem yourself on a real deployment before filing.
-
-## Merge Requests
-
-A good MR answers: what problem does this solve, why this approach, how was it tested, anything to watch out for. For non-trivial changes, link the issue and note any migration/compatibility concerns. Screenshots for UI changes.
-
-Small, well-explained MRs get reviewed fast. Big unexplained ones sit.
-
-AI disclosure is mandatory for every MR; use the required block in [AI Disclosure (Required)](#ai-disclosure-required).
-
-## Development Setup
-
-See the README for full setup. Common checks:
+Run focused tests while iterating:
 
 ```sh
-go test ./...                        # Go tests
-golangci-lint run                    # Go lint
-cd web && bun test                   # Frontend tests
-cd web && bun run lint               # Frontend lint
-cd web && bun run format:check       # Frontend formatting
+go test ./internal/<package>/...
+cd web && pnpm exec vitest run path/to/changed.test.tsx
 ```
 
-If your change spans `Silo` and `silo-plugin-sdk`, local iteration through [`go.work`](go.work) is expected. Do not rely on that workspace in repo-tracked config or release pipelines. CI validates this repo with `GOWORK=off`, and any new SDK package or symbol must come from a pushed, tagged `github.com/Silo-Server/silo-plugin-sdk` release before the change is ready to merge.
+Before opening a pull request, run every relevant repository gate. A typical
+local validation is:
 
-## Style
+```sh
+# Go build, formatting, vet, and tests
+make embed-stub
+go build ./...
+gofmt -l .
+go vet ./...
+make test-go
 
-- One thing per MR. Don't mix unrelated changes.
-- Follow existing patterns.
-- Comments for non-obvious things only.
+# Web install, lint, formatting, build, and tests
+cd web
+pnpm install --frozen-lockfile
+pnpm run lint
+pnpm run format:check
+pnpm run build
+cd ..
+make test-web
 
-## For AI Agents
+# Generated contracts, fixtures, and docs hygiene
+make verify-settings-bindings-all
+make verify-playback-fixtures
+make verify-local-paths
+```
 
-If you're an LLM working on this codebase: read `CLAUDE.md` (or `AGENTS.md` when available) for project-specific instructions, architecture reference, and verification requirements. The rules in this file apply to you too — especially the parts about not submitting slop and running verification before declaring work complete.
+`gofmt -l .` must produce no output. Run additional focused tests for every
+manually resolved or high-risk area.
 
-## Be Realistic
+> [!NOTE]
+> `make lint` runs `golangci-lint` across the full Go tree and can report
+> inherited findings. Pull-request CI gates changed Go lines with
+> `golangci-lint run --new-from-merge-base="origin/<base>" ./...`; new or changed
+> lines must be clean. The current [CI workflow](.github/workflows/ci.yml) is the
+> authoritative list of required checks.
 
-Opening a merge request doesn't create an obligation on my side. I might close it, ignore it, ask you to shrink it, or reimplement the idea myself later. The codebase is moving fast and sometimes the best response to a good PR is "thanks, but I already went a different direction."
+Paste actual command results into the pull request. Do not report a check as
+passing if it was skipped, failed, or was not run in the stated environment.
 
-If you're fine with that, welcome aboard.
+## AI-assisted contributions
 
-If you're not sure whether something is in scope, open an issue and ask. Always better than building something that needs to be reshaped.
+> [!WARNING]
+> AI use must be disclosed in every issue and pull request. Fabricated APIs,
+> observations, vulnerabilities, reproduction steps, logs, or test results are
+> not acceptable. Bug reports must come from a real reproduction, and logs must
+> be raw rather than AI-paraphrased.
+
+Read and follow the canonical
+[AI-assisted contribution policy](docs/ai-contributions.md). It defines the
+required disclosure block, contributor responsibilities, evidence standard,
+and enforcement policy. "No AI" is a valid disclosure; non-disclosure is not.
+
+## Open the pull request
+
+Use a concise [Conventional Commit](https://www.conventionalcommits.org/)
+title. A reviewable pull request should include:
+
+- a linked issue or scope item for non-trivial work; use `N/A — narrow fix` when
+  prior coordination was not required
+- the user or maintainer problem being solved
+- why the chosen approach is appropriate
+- actual validation commands and results
+- migration, compatibility, security, or operational risks
+- screenshots or recordings for visible UI changes
+- the completed AI disclosure
+- a summary of independent or adversarial review findings and resolutions
+
+Keep the commit history intentional and the final diff limited to the stated
+problem.
+
+## Review expectations
+
+Maintainers may ask for a smaller change, request a different implementation,
+decline work that no longer fits the project, or accept the idea and implement
+it separately. Opening a pull request does not guarantee merge. Clear scope,
+reproducible evidence, and a focused diff make review faster.
+
+If scope is uncertain, ask before investing in an implementation.
+
+## Instructions for coding agents
+
+Coding agents must read [AGENTS.md](AGENTS.md) before changing the repository.
+`CLAUDE.md` points to the same project instructions. This guide and the
+[AI-assisted contribution policy](docs/ai-contributions.md) apply equally to
+agent-authored and human-authored work.

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -1,24 +1,33 @@
 # Developing Silo
 
-This document covers building, running, and contributing to the Silo server. If you just want to run Silo, see the [README](README.md).
+This document covers building, running, and contributing to the Silo server. If
+you just want to run Silo, see the [README](README.md).
 
-See [CONTRIBUTING.md](CONTRIBUTING.md) for contribution expectations, merge request guidance, and the policy for AI-assisted submissions.
+See [CONTRIBUTING.md](CONTRIBUTING.md) for contribution expectations, pull
+request guidance, and the policy for AI-assisted submissions.
 
 ## Prerequisites
 
+- **Git**, **Make**, and **OpenSSL**
+- **Docker Engine** or **Docker Desktop** with Docker Compose 2.24+ (local services and testcontainers)
 - **Go** 1.26.4+
 - **Node.js** 22+ with **pnpm** 10.32.1
 - **PostgreSQL** 18 with pgvector
 - **Redis**
 - **FFmpeg** (for transcoding support)
+- A **C compiler and build toolchain** (for CGO dependencies)
+- **pkg-config** and the **libvips development headers** (for image processing through bimg)
 
 ## Local Development
 
-Local development remains intentionally separate from the deploy-oriented compose setup. Use [docker-compose.yml](docker-compose.yml) for local services and the source-build workflow below.
+Local development remains intentionally separate from the deploy-oriented
+Compose setup. Use [docker-compose.yml](docker-compose.yml) for local services
+and the source-build workflow below.
 
 ```sh
 # Create the local bootstrap configuration
 cp .env.example .env
+chmod 600 .env
 printf '\nSECRET_KEY=%s\nDATABASE_URL=%s\nREDIS_URL=%s\n' \
   "$(openssl rand -base64 48)" \
   'postgres://silo:silo@localhost:5432/silo?sslmode=disable' \
@@ -27,19 +36,51 @@ printf '\nSECRET_KEY=%s\nDATABASE_URL=%s\nREDIS_URL=%s\n' \
 # Start local PostgreSQL and Redis
 docker compose up -d postgres redis
 
-# Run the frontend dev server (hot reload, proxies API to :8090)
-make dev-frontend
+# Install frontend dependencies and create the embedded-frontend test stub
+cd web
+pnpm install --frozen-lockfile
+cd ..
+make embed-stub
+```
 
-# Run the Go backend
+Run the backend and frontend in separate terminals. Start the backend first:
+
+```sh
 make dev-backend
+```
+
+Then start the frontend dev server with its proxy pointed at the source backend:
+
+```sh
+VITE_API_PROXY_TARGET=http://localhost:8080 make dev-frontend
 ```
 
 The template supplies a non-empty `MEDIA_ROOT` because Compose validates the whole file even when
 you start only PostgreSQL and Redis. Change it before testing libraries against real media.
 
-If you are developing `Silo` and `silo-plugin-sdk` together, keep using the local [`go.work`](go.work) workspace. That workspace is a developer convenience only. CI and release builds run with `GOWORK=off`, so any new SDK helper used here must be pushed and tagged in `silo-plugin-sdk` before this repo can merge or release the change.
+If you are developing `Silo` and `silo-plugin-sdk` together, use an untracked local `go.work`
+workspace. `go.work` and `go.work.sum` are intentionally ignored and are developer conveniences
+only. CI uses a clean checkout that does not contain them, and release builds explicitly set
+`GOWORK=off`. Any new SDK helper used here must be pushed and tagged in `silo-plugin-sdk` before
+this repository can merge or release the change.
 
-Plugin authors should start with the `silo-plugin-sdk` repository (usually checked out side-by-side with this one), which owns the RPC plugin package format, protobuf contracts, generated plugin API, SDK import paths, and manifest helpers.
+Plugin authors should start with the `silo-plugin-sdk` repository, usually
+checked out beside this one. It owns the RPC plugin package format, protobuf
+contracts, generated plugin API, SDK import paths, and manifest helpers.
+
+## Build and Run from Source
+
+After creating `.env` and starting PostgreSQL and Redis as described above,
+build the production frontend and Go binary:
+
+```sh
+make build
+./silo
+```
+
+The source-built server listens at <http://localhost:8080> by default. Complete
+onboarding and manage the remaining application settings through the web
+interface.
 
 ## Make Targets
 
@@ -85,22 +126,30 @@ database URL should be read from a non-default env file.
 
 ```sh
 # Go tests (uses testcontainers — Docker must be running)
-go test ./...
+make test-go
 
-# Frontend tests
-cd web && pnpm test
+# Frontend tests (uses the repository's current known-failure exclusions)
+make test-web
 ```
 
 ## Linting
 
 ```sh
-# Go
-golangci-lint run
+# Go formatting and vet
+make embed-stub
+gofmt -l .
+go vet ./...
 
 # Frontend
-cd web && pnpm run lint
-cd web && pnpm run format:check
+cd web
+pnpm run lint
+pnpm run format:check
+cd ..
 ```
+
+`gofmt -l .` must produce no output. Full-tree `golangci-lint` currently reports inherited
+findings; pull-request CI runs it against changed lines from the target branch. See
+[CONTRIBUTING.md](CONTRIBUTING.md#validate-your-change) for the complete pre-submission gate.
 
 ## Project Structure
 

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -1,28 +1,25 @@
 # Developing Silo
 
-This document covers building, running, and contributing to the Silo server. If
-you just want to run Silo, see the [README](README.md).
-
-See [CONTRIBUTING.md](CONTRIBUTING.md) for contribution expectations, pull
-request guidance, and the policy for AI-assisted submissions.
+How to build, run, and test the Silo server from source. To run Silo without
+building it, see the [README](README.md). Contribution rules and the
+pre-submission gate are in [CONTRIBUTING.md](CONTRIBUTING.md).
 
 ## Prerequisites
 
-- **Git**, **Make**, and **OpenSSL**
-- **Docker Engine** or **Docker Desktop** with Docker Compose 2.24+ (local services and testcontainers)
-- **Go** 1.26.4+
-- **Node.js** 22+ with **pnpm** 10.32.1
-- **PostgreSQL** 18 with pgvector
-- **Redis**
-- **FFmpeg** (for transcoding support)
-- A **C compiler and build toolchain** (for CGO dependencies)
-- **pkg-config** and the **libvips development headers** (for image processing through bimg)
+- Git, Make, and OpenSSL
+- Docker Engine or Docker Desktop with Docker Compose 2.24+ (local services and testcontainers)
+- Go 1.26.4+
+- Node.js 22+ with pnpm 10.32.1
+- PostgreSQL 18 with pgvector
+- Redis
+- FFmpeg (transcoding)
+- A C compiler and build toolchain (CGO dependencies)
+- pkg-config and the libvips development headers (image processing through bimg)
 
-## Local Development
+## Local development
 
-Local development remains intentionally separate from the deploy-oriented
-Compose setup. Use [docker-compose.yml](docker-compose.yml) for local services
-and the source-build workflow below.
+Source builds use [docker-compose.yml](docker-compose.yml) only for PostgreSQL
+and Redis; the deploy-oriented stack in the README is separate.
 
 ```sh
 # Create the local bootstrap configuration
@@ -43,46 +40,54 @@ cd ..
 make embed-stub
 ```
 
-Run the backend and frontend in separate terminals. Start the backend first:
+Run the backend and frontend in separate terminals, backend first:
 
 ```sh
 make dev-backend
 ```
 
-Then start the frontend dev server with its proxy pointed at the source backend:
+The source-built backend listens on `:8080`, while the Vite proxy defaults to
+the Compose port `8090`. Point it at the source backend in `web/.env.local`:
 
-```sh
-VITE_API_PROXY_TARGET=http://localhost:8080 make dev-frontend
+```dotenv
+VITE_API_PROXY_TARGET=http://localhost:8080
 ```
 
-The template supplies a non-empty `MEDIA_ROOT` because Compose validates the whole file even when
-you start only PostgreSQL and Redis. Change it before testing libraries against real media.
+Then:
 
-If you are developing `Silo` and `silo-plugin-sdk` together, use an untracked local `go.work`
-workspace. `go.work` and `go.work.sum` are intentionally ignored and are developer conveniences
-only. CI uses a clean checkout that does not contain them, and release builds explicitly set
-`GOWORK=off`. Any new SDK helper used here must be pushed and tagged in `silo-plugin-sdk` before
-this repository can merge or release the change.
+```sh
+make dev-frontend
+```
 
-Plugin authors should start with the `silo-plugin-sdk` repository, usually
-checked out beside this one. It owns the RPC plugin package format, protobuf
-contracts, generated plugin API, SDK import paths, and manifest helpers.
+`.env.example` ships a non-empty `MEDIA_ROOT` because Compose validates the
+whole file even when you only start PostgreSQL and Redis. Change it before
+testing libraries against real media.
 
-## Build and Run from Source
+### Working on the plugin SDK at the same time
 
-After creating `.env` and starting PostgreSQL and Redis as described above,
-build the production frontend and Go binary:
+If a change spans Silo and `silo-plugin-sdk`, use an untracked local `go.work`
+workspace. `go.work` and `go.work.sum` are gitignored developer conveniences: CI
+runs from a clean checkout without them, and release builds set `GOWORK=off`.
+Any SDK package or symbol this repository uses must therefore be pushed and
+tagged in `silo-plugin-sdk` before the change here can merge.
+
+Plugin authors should start in the `silo-plugin-sdk` repository, usually checked
+out beside this one. It owns the plugin package format, protobuf contracts,
+generated plugin API, import paths, and manifest helpers.
+
+## Build and run from source
+
+With `.env` created and PostgreSQL and Redis running:
 
 ```sh
 make build
 ./silo
 ```
 
-The source-built server listens at <http://localhost:8080> by default. Complete
-onboarding and manage the remaining application settings through the web
-interface.
+The server listens at <http://localhost:8080>. Complete onboarding and manage
+the remaining settings in the web interface.
 
-## Make Targets
+## Make targets
 
 | Target | Description |
 |---|---|
@@ -98,60 +103,44 @@ interface.
 | `make migrate-up` | Apply pending Goose migrations using Silo's bootstrapping runner |
 | `make clean` | Remove build artifacts |
 
-## Database Migrations
+## Database migrations
 
-PostgreSQL schema migrations are managed by Goose. Migration SQL files live in
-`migrations/sql/` and use Goose annotations. Converted legacy migrations keep
-their original numeric versions so existing `schema_versions` rows can bootstrap
-cleanly into Goose without replaying old SQL. New migrations should be created
-with timestamped filenames:
+Goose manages the PostgreSQL schema. Migration SQL lives in `migrations/sql/`
+with Goose annotations. Create new migrations with timestamped filenames:
 
 ```sh
 make migrate-create NAME=add_thing
 make migrate-validate
 ```
 
-Do not run `goose fix`; timestamped migrations are the repository policy because
-they avoid version collisions across parallel PRs. The existing `001`-style
-files are historical compatibility records, not the naming pattern for new work.
-Runtime migrations are applied by the integrated/API server only. Proxy and
-transcode modes never mutate schema.
+Never run `goose fix`. Timestamped names avoid version collisions across
+parallel PRs; the `001`-style files are converted legacy migrations that keep
+their original numbers so existing `schema_versions` rows bootstrap into Goose
+without replaying old SQL. Do not renumber them.
+
+Only the integrated/API server applies migrations at runtime. Proxy and
+transcode modes never touch the schema.
+
 For existing installs, use `make migrate-status` and `make migrate-up` rather
-than invoking the Goose CLI directly; those targets copy legacy
-`schema_versions` rows into `public.goose_db_version` under the migration lock
-before reading or applying migrations. Set `ENV_FILE=path/to/.env` when the
-database URL should be read from a non-default env file.
+than the Goose CLI: those targets copy legacy `schema_versions` rows into
+`public.goose_db_version` under the migration lock before reading or applying
+anything. Set `ENV_FILE=path/to/.env` to read the database URL from a different
+env file.
 
-## Running Tests
+## Tests and lint
 
-```sh
-# Go tests (uses testcontainers — Docker must be running)
-make test-go
-
-# Frontend tests (uses the repository's current known-failure exclusions)
-make test-web
-```
-
-## Linting
+While iterating:
 
 ```sh
-# Go formatting and vet
-make embed-stub
-gofmt -l .
-go vet ./...
-
-# Frontend
-cd web
-pnpm run lint
-pnpm run format:check
-cd ..
+go test ./internal/<package>/...                 # needs Docker for testcontainers
+cd web && pnpm exec vitest run path/to/test.tsx
 ```
 
-`gofmt -l .` must produce no output. Full-tree `golangci-lint` currently reports inherited
-findings; pull-request CI runs it against changed lines from the target branch. See
-[CONTRIBUTING.md](CONTRIBUTING.md#validate-your-change) for the complete pre-submission gate.
+The full pre-submission gate (build, format, vet, lint, both test suites, and
+the verify targets) is listed once, in
+[CONTRIBUTING.md](CONTRIBUTING.md#validate-your-change).
 
-## Project Structure
+## Project structure
 
 ```
 cmd/silo/       Entry point

--- a/README.md
+++ b/README.md
@@ -5,11 +5,7 @@
 <h1 align="center">Silo</h1>
 
 <p align="center">
-  <strong>Your media. Your server. Your way.</strong>
-</p>
-
-<p align="center">
-  A modern, self-hosted media server for films, series, audiobooks, ebooks, podcasts, and manga.
+  A self-hosted media server for films, series, audiobooks, ebooks, podcasts, and manga.
 </p>
 
 <p align="center">
@@ -33,170 +29,107 @@
 ---
 
 > [!WARNING]
-> Silo is in active pre-release development. APIs, configuration, and database
-> migrations may change before the first stable release. Review the build history
-> and back up your deployment before updating.
+> Silo is pre-release. APIs, configuration, and database migrations may change
+> before the first stable release. Back up your deployment before updating.
 
-## A media server built around ownership
-
-Silo keeps your media, metadata, and household experience under your control.
-Run it on one host, reach it at home or away, and choose how each device receives
-the best version of your media.
+## What Silo does
 
 <table>
   <tr>
     <td width="33%" valign="top">
       <strong>Play</strong><br><br>
-      Direct play when possible, remux when needed, or transcode automatically,
-      with hardware acceleration including VA-API, Quick Sync, and NVENC.
+      Direct play when possible, remux when needed, transcode otherwise, with
+      VA-API, Quick Sync, and NVENC hardware acceleration.
     </td>
     <td width="33%" valign="top">
       <strong>Organize</strong><br><br>
-      Bring films, series, audiobooks, ebooks, podcasts, and manga into one
-      catalog, with plugin-driven matching and providers such as TMDB and TVDB
-      where supported.
+      One catalog for films, series, audiobooks, ebooks, podcasts, and manga,
+      matched through metadata plugins such as TMDB and TVDB.
     </td>
     <td width="33%" valign="top">
       <strong>Connect</strong><br><br>
-      Use the included web app or Silo's Jellyfin/Emby compatibility surface
-      with clients such as <a href="https://vidhub.okaapps.com/what-does-vidhub-do/">VidHub</a>,
+      Use the included web app, or the Jellyfin/Emby-compatible API with clients
+      such as <a href="https://vidhub.okaapps.com/what-does-vidhub-do/">VidHub</a>,
       <a href="https://github.com/jarnedemeulemeester/findroid">Findroid</a>, and
-      <a href="https://support.firecore.com/hc/en-us/articles/360006462093-Streaming-from-Plex-Emby-and-Jellyfin">Infuse</a>.
-      Client coverage varies.
+      <a href="https://firecore.com/infuse">Infuse</a>. Client coverage varies.
     </td>
   </tr>
   <tr>
     <td width="33%" valign="top">
       <strong>Share</strong><br><br>
-      Give household members their own profiles, watch state, library access,
-      and parental controls.
+      Household profiles with their own watch state, library access, and
+      parental controls.
     </td>
     <td width="33%" valign="top">
       <strong>Manage</strong><br><br>
-      Configure libraries, users, providers, storage, search, and playback from
-      a dedicated administration interface.
+      Libraries, users, providers, storage, search, and playback are configured
+      in the admin interface, not in config files.
     </td>
     <td width="33%" valign="top">
       <strong>Scale</strong><br><br>
-      Start with one integrated server, then separate proxy and transcode roles
-      across shared PostgreSQL and Redis infrastructure when needed.
+      Start with one integrated server; split proxy and transcode roles across
+      shared PostgreSQL and Redis when you need to.
     </td>
   </tr>
 </table>
 
 ## Quick start
 
-The recommended installation uses Docker Compose 2.24 or newer. The default
-stack includes Silo, PostgreSQL with pgvector, Redis, and FFmpeg.
+Requires Docker Compose 2.24 or newer. The default stack runs Silo, PostgreSQL
+with pgvector, and Redis.
 
-1. **Clone the repository and create your configuration.**
+```sh
+git clone https://github.com/Silo-Server/silo-server.git
+cd silo-server
+cp .env.example .env
+chmod 600 .env
+printf '\nPOSTGRES_PASSWORD=%s\nSECRET_KEY=%s\n' \
+  "$(openssl rand -hex 24)" "$(openssl rand -base64 48)" >> .env
+```
 
-   ```sh
-   git clone https://github.com/Silo-Server/silo-server.git
-   cd silo-server
-   cp .env.example .env
-   chmod 600 .env
-   printf '\nPOSTGRES_PASSWORD=%s\nSECRET_KEY=%s\n' \
-     "$(openssl rand -hex 24)" "$(openssl rand -base64 48)" >> .env
-   ```
+Set `MEDIA_ROOT` in `.env` to the absolute path of your media, then:
 
-2. **Set the host path to your media.**
+```sh
+docker compose up -d
+```
 
-   Edit `.env` and replace `MEDIA_ROOT` with an absolute path:
+Open <http://localhost:8090> and complete onboarding.
 
-   ```dotenv
-   MEDIA_ROOT=/path/to/your/media
-   ```
-
-3. **Start Silo.**
-
-   ```sh
-   docker compose up -d
-   ```
-
-4. **Open the web app.**
-
-   Visit <http://localhost:8090>, complete onboarding, then add libraries,
-   users, metadata providers, and playback settings from the admin interface.
-
-> [!CAUTION]
-> Keep `SECRET_KEY` secret and back it up separately from PostgreSQL. Silo uses
-> it to encrypt stored credentials; losing it makes those credentials
-> unrecoverable.
-
-The default deployment is CPU-only and stores application data under
-`/opt/silo`. The [Docker deployment guide](docs/wiki/deployment/docker.md)
-covers custom storage paths, VA-API/Quick Sync, NVIDIA NVENC, Meilisearch,
-external PostgreSQL and Redis, distributed roles, backups, and PostgreSQL
-auto-tuning.
-
-Migrating an existing Continuum installation? Follow the
-[Continuum-to-Silo cutover guide](docs/continuum-to-silo-docker-migration.md).
+The [Docker deployment guide](docs/wiki/deployment/docker.md) covers the
+`SECRET_KEY` backup requirement, storage paths, GPU acceleration, Meilisearch,
+external PostgreSQL and Redis, distributed roles, PostgreSQL tuning, backups,
+and updates. Migrating from Continuum? Use the
+[cutover guide](docs/continuum-to-silo-docker-migration.md).
 
 ## Builds and releases
 
-> [!IMPORTANT]
-> Until Silo's first release is selected and published, default-branch
-> containers are identified by an ordered `build-N` and their commit SHA.
-> Build numbers make published images comparable; they are not release versions.
-
-Silo's release contract follows [Semantic Versioning](https://semver.org/) with
-prerelease and build metadata support. The
-[release versioning guide](docs/release-versioning.md) explains the source of
-truth and the meaning of each container tag:
-
-| Image reference | Use |
-| --- | --- |
-| `build-N` | Select an ordered published build. |
-| Short commit SHA | Select the image built from an exact source revision. |
-| Image digest | Pin an immutable deployment or rollback target. |
-| `latest` | Follow the newest successful default-branch publication. |
-
-Review configuration, compatibility, and migration impact before every update.
+Until the first release, default-branch images carry an ordered `build-N` tag
+and a short commit SHA alongside `latest`. Build numbers order published images;
+they are not release versions. [Release versioning](docs/release-versioning.md)
+defines each tag and the SemVer contract.
 
 ## Documentation
 
-| Start here | What it covers |
-| --- | --- |
-| [Documentation index](docs/wiki/index.md) | User and operator guides currently available in the repository. |
-| [Docker deployment](docs/wiki/deployment/docker.md) | Storage, acceleration, search, topology, external services, tuning, and updates. |
-| [Media naming](docs/wiki/admin/media-folder-and-naming.md) | Supported library folder structures and filenames. |
-| [Development guide](DEVELOPMENT.md) | Source setup, builds, tests, migrations, and repository structure. |
-| [Settings API](docs/settings-api.md) | Client settings contracts, contextual scopes, and effective reads. |
-| [Downloads API](docs/downloads-api.md) | Offline sync, download delivery, and distributed client behavior. |
-| [Release versioning](docs/release-versioning.md) | SemVer, container identifiers, release notes, and publishing. |
+- [Documentation index](docs/wiki/index.md) — user and operator guides
+- [Development guide](DEVELOPMENT.md) — source setup, builds, tests, migrations
+- [Settings API](docs/settings-api.md) and [Downloads API](docs/downloads-api.md) — client contracts
 
 ## Community and contributions
 
-Questions and project discussion are welcome in the
-[Silo Discord community](https://discord.com/invite/4RxuUQAEnW).
+Questions and discussion: [Discord](https://discord.com/invite/4RxuUQAEnW).
+Bugs, install problems, and performance issues: the
+[GitHub issue forms](https://github.com/Silo-Server/silo-server/issues/new/choose),
+which ask for reproduction steps and raw logs.
 
-For a bug, installation problem, or performance issue, use the
-[GitHub issue forms](https://github.com/Silo-Server/silo-server/issues/new/choose)
-and include the workflow you followed, exact reproduction steps, expected and
-actual behavior, the affected version/build, deployment details, and raw logs
-where relevant.
-
-Contributions are welcome. Read [CONTRIBUTING.md](CONTRIBUTING.md) before
-starting, and use [DEVELOPMENT.md](DEVELOPMENT.md) for the local workflow.
-Non-trivial features, API changes, migrations, behavior changes, and refactors
-should be coordinated in an issue before implementation.
+Read [CONTRIBUTING.md](CONTRIBUTING.md) before opening a pull request. Features,
+API changes, migrations, and behavior changes should start as an issue.
 
 ## Supporting Silo
 
-Silo is a free and open-source project developed in spare time and funded out of
-pocket. It will remain free and open source.
-[GitHub Sponsors](https://github.com/sponsors/quick104) helps cover AI-assisted
-development tooling, including Claude and Codex, push-notification relay
-infrastructure, and future project costs.
-
-Sponsoring is optional. Bug reports, contributions, documentation, and feedback
-are equally valuable ways to support the project.
-
-<p align="center">
-  <a href="https://github.com/sponsors/quick104"><strong>Sponsor Silo</strong></a>
-  · <a href="https://discord.com/invite/4RxuUQAEnW"><strong>Join the community</strong></a>
-</p>
+Silo is developed in spare time and funded out of pocket, and will stay free and
+open source. [GitHub Sponsors](https://github.com/sponsors/quick104) covers AI
+development tooling (Claude, Codex), push-notification relay infrastructure, and
+future project costs. Bug reports, code, and documentation help just as much.
 
 ## License and trademarks
 

--- a/README.md
+++ b/README.md
@@ -9,11 +9,12 @@
 </p>
 
 <p align="center">
-  A modern, self-hosted media server for movies, shows, music, and books.
+  A modern, self-hosted media server for films, series, audiobooks, ebooks, podcasts, and manga.
 </p>
 
 <p align="center">
   <a href="https://github.com/Silo-Server/silo-server/releases"><img alt="Latest GitHub release" src="https://img.shields.io/github/v/release/Silo-Server/silo-server?include_prereleases&amp;sort=semver&amp;display_name=tag&amp;style=flat-square&amp;label=release"></a>
+  <a href="https://github.com/orgs/Silo-Server/packages/container/package/silo-server"><img alt="Container image on GHCR" src="https://img.shields.io/badge/container-GHCR-2496ED?style=flat-square&amp;logo=docker&amp;logoColor=white"></a>
   <a href="https://github.com/Silo-Server/silo-server/actions/workflows/ci.yml"><img alt="Continuous integration" src="https://img.shields.io/github/actions/workflow/status/Silo-Server/silo-server/ci.yml?branch=main&amp;style=flat-square&amp;label=CI"></a>
   <img alt="Go 1.26" src="https://img.shields.io/badge/Go-1.26-00ADD8?style=flat-square&amp;logo=go&amp;logoColor=white">
   <img alt="React 19" src="https://img.shields.io/badge/React-19-149ECA?style=flat-square&amp;logo=react&amp;logoColor=white">
@@ -21,419 +22,190 @@
 </p>
 
 <p align="center">
-  <a href="#deploy-with-docker-recommended">Installation</a>
+  <a href="#quick-start">Quick start</a>
   · <a href="docs/wiki/index.md">Documentation</a>
-  · <a href="https://github.com/Silo-Server/silo-server/releases">Releases</a>
+  · <a href="docs/release-versioning.md">Builds &amp; releases</a>
   · <a href="https://discord.com/invite/4RxuUQAEnW">Discord</a>
-  · <a href="https://github.com/sponsors/quick104">Donate</a>
   · <a href="CONTRIBUTING.md">Contributing</a>
 </p>
 
 ---
 
-## Product overview
+> [!WARNING]
+> Silo is in active pre-release development. APIs, configuration, and database
+> migrations may change before the first stable release. Review the build history
+> and back up your deployment before updating.
 
-Silo keeps your media and its metadata under your control while providing a
-modern experience at home or away.
+## A media server built around ownership
+
+Silo keeps your media, metadata, and household experience under your control.
+Run it on one host, reach it at home or away, and choose how each device receives
+the best version of your media.
 
 <table>
   <tr>
     <td width="33%" valign="top">
       <strong>Play</strong><br><br>
-      Direct play when possible, remux when needed, or use hardware-accelerated
-      transcoding—including NVENC—automatically for each device.
+      Direct play when possible, remux when needed, or transcode automatically,
+      with hardware acceleration including VA-API, Quick Sync, and NVENC.
     </td>
     <td width="33%" valign="top">
-      <strong>Explore</strong><br><br>
-      Organize movies, shows, music, and books with plugin-driven matching and
-      enrichment from providers such as TMDB and TVDB.
+      <strong>Organize</strong><br><br>
+      Bring films, series, audiobooks, ebooks, podcasts, and manga into one
+      catalog, with plugin-driven matching and providers such as TMDB and TVDB
+      where supported.
     </td>
     <td width="33%" valign="top">
       <strong>Connect</strong><br><br>
-      Use the included web app or optional Jellyfin/Emby-compatible clients such
-      as VidHub, Findroid, and Infuse.
+      Use the included web app or Silo's Jellyfin/Emby compatibility surface
+      with clients such as <a href="https://vidhub.okaapps.com/what-does-vidhub-do/">VidHub</a>,
+      <a href="https://github.com/jarnedemeulemeester/findroid">Findroid</a>, and
+      <a href="https://support.firecore.com/hc/en-us/articles/360006462093-Streaming-from-Plex-Emby-and-Jellyfin">Infuse</a>.
+      Client coverage varies.
     </td>
   </tr>
   <tr>
     <td width="33%" valign="top">
       <strong>Share</strong><br><br>
-      Give household members their own profiles, watch state, and parental
-      controls without giving up ownership of the server.
+      Give household members their own profiles, watch state, library access,
+      and parental controls.
     </td>
     <td width="33%" valign="top">
-      <strong>Deploy</strong><br><br>
-      Start the integrated stack with Docker Compose, then manage libraries,
-      users, providers, and playback settings in the admin UI.
+      <strong>Manage</strong><br><br>
+      Configure libraries, users, providers, storage, search, and playback from
+      a dedicated administration interface.
     </td>
     <td width="33%" valign="top">
       <strong>Scale</strong><br><br>
-      Keep everything on one host or separate API, proxy, and transcode roles
-      across a shared PostgreSQL and Redis deployment.
+      Start with one integrated server, then separate proxy and transcode roles
+      across shared PostgreSQL and Redis infrastructure when needed.
     </td>
   </tr>
 </table>
 
-## Releases and updates
+## Quick start
 
-Silo uses [Semantic Versioning](https://semver.org/) in the form
-`vMAJOR.MINOR.PATCH`, with suffixes such as `-alpha.1` for prereleases and
-optional `+build.7` metadata. The
-[GitHub Releases](https://github.com/Silo-Server/silo-server/releases) page is
-the canonical public history of shipped changes, with categorized notes,
-contributors, and a full comparison for every version.
+The recommended installation uses Docker Compose 2.24 or newer. The default
+stack includes Silo, PostgreSQL with pgvector, Redis, and FFmpeg.
 
-> [!IMPORTANT]
-> Until the maintainers select and publish Silo's first release, newly published
-> container builds are identified by an ordered `build-N` and their commit SHA.
-> Build numbers make updates comparable but do not imply a release version.
-
-For every release, review the notes for configuration, compatibility, and
-upgrade information before updating. See
-[Release versioning](docs/release-versioning.md) for the version contract and
-maintainer release process.
-
-## Deploy with Docker (recommended)
-
-The easiest way to run Silo is with Docker Compose 2.24 or newer. The default stack assumes you do
-not already have PostgreSQL and Redis available, so it bundles PostgreSQL, Redis, FFmpeg, and the
-application for a one-command start.
-
-<table>
-  <tr>
-    <td width="33%" valign="top">
-      <strong>Default stack</strong><br><br>
-      One integrated Silo server with bundled PostgreSQL and Redis. This is the
-      recommended starting point.
-    </td>
-    <td width="33%" valign="top">
-      <strong>GPU acceleration</strong><br><br>
-      Add <a href="#optional-intelamd-va-api-or-intel-quick-sync">VA-API / Quick Sync</a>
-      or <a href="#optional-nvidianvenc">NVIDIA NVENC</a> only when the host supports it.
-    </td>
-    <td width="33%" valign="top">
-      <strong>Distributed deployment</strong><br><br>
-      Separate API, proxy, and transcode roles when one integrated host is no
-      longer the right fit. See the <a href="#distributed-examples">examples</a>.
-    </td>
-  </tr>
-</table>
-
-1. **Create a `.env` file**
+1. **Clone the repository and create your configuration.**
 
    ```sh
+   git clone https://github.com/Silo-Server/silo-server.git
+   cd silo-server
    cp .env.example .env
+   chmod 600 .env
    printf '\nPOSTGRES_PASSWORD=%s\nSECRET_KEY=%s\n' \
      "$(openssl rand -hex 24)" "$(openssl rand -base64 48)" >> .env
    ```
 
-   This replaces the development database password from `.env.example` and creates the key Silo
-   uses to encrypt stored credentials. Back up `.env` separately from PostgreSQL; losing
-   `SECRET_KEY` makes those credentials unrecoverable.
+2. **Set the host path to your media.**
 
-2. **Set your media path**
-
-   Edit `.env` and set:
+   Edit `.env` and replace `MEDIA_ROOT` with an absolute path:
 
    ```dotenv
    MEDIA_ROOT=/path/to/your/media
    ```
 
-   `MEDIA_ROOT` is the one value most users need to change. You can also override `SILO_DATA_ROOT` if you do not want bind mounts under `/opt/silo`, and change ports if the defaults conflict with something else on the host.
-
-3. **Start the default integrated stack**
+3. **Start Silo.**
 
    ```sh
    docker compose up -d
    ```
 
-   This starts PostgreSQL, Redis, and the integrated Silo server. The app is available at `http://localhost:8090`. Jellyfin-compatible app support is disabled until an administrator enables it in onboarding or admin settings.
+4. **Open the web app.**
 
-   If you already have PostgreSQL and Redis available, omit those bundled service examples from compose and point Silo at your existing `DATABASE_URL` and `REDIS_URL` instead.
+   Visit <http://localhost:8090>, complete onboarding, then add libraries,
+   users, metadata providers, and playback settings from the admin interface.
 
-   ### Optional Intel/AMD VA-API or Intel Quick Sync
+> [!CAUTION]
+> Keep `SECRET_KEY` secret and back it up separately from PostgreSQL. Silo uses
+> it to encrypt stored credentials; losing it makes those credentials
+> unrecoverable.
 
-   The default stack is CPU-only so it starts on hosts without `/dev/dri`. On a Linux host with
-   `/dev/dri`, enable the device overlay:
+The default deployment is CPU-only and stores application data under
+`/opt/silo`. The [Docker deployment guide](docs/wiki/deployment/docker.md)
+covers custom storage paths, VA-API/Quick Sync, NVIDIA NVENC, Meilisearch,
+external PostgreSQL and Redis, distributed roles, backups, and PostgreSQL
+auto-tuning.
 
-   ```sh
-   docker compose -f docker-compose.yml -f docker-compose.vaapi.yml up -d
-   ```
+Migrating an existing Continuum installation? Follow the
+[Continuum-to-Silo cutover guide](docs/continuum-to-silo-docker-migration.md).
 
-   To make that the default for this installation, set:
+## Builds and releases
 
-   ```dotenv
-   COMPOSE_FILE=docker-compose.yml:docker-compose.vaapi.yml
-   ```
+> [!IMPORTANT]
+> Until Silo's first release is selected and published, default-branch
+> containers are identified by an ordered `build-N` and their commit SHA.
+> Build numbers make published images comparable; they are not release versions.
 
-   ### Optional NVIDIA/NVENC
+Silo's release contract follows [Semantic Versioning](https://semver.org/) with
+prerelease and build metadata support. The
+[release versioning guide](docs/release-versioning.md) explains the source of
+truth and the meaning of each container tag:
 
-   GPU support is kept out of the default compose file so hosts without NVIDIA drivers work unchanged.
+| Image reference | Use |
+| --- | --- |
+| `build-N` | Select an ordered published build. |
+| Short commit SHA | Select the image built from an exact source revision. |
+| Image digest | Pin an immutable deployment or rollback target. |
+| `latest` | Follow the newest successful default-branch publication. |
 
-   Install the NVIDIA Container Toolkit and use a Docker Compose version with GPU reservation support before enabling this override.
-
-   Use the optional override file when you want NVENC:
-
-   ```sh
-   docker compose -f docker-compose.yml -f docker-compose.nvidia.yml up -d
-   ```
-
-   If you want this controlled from `.env`, set `COMPOSE_FILE`:
-
-   ```dotenv
-   COMPOSE_FILE=docker-compose.yml:docker-compose.nvidia.yml
-   NVIDIA_GPU_COUNT=1
-   ```
-
-   Windows uses `;` instead of `:` between compose files.
-
-   Then `docker compose up -d` will include the NVIDIA override automatically.
-
-4. **Configure through the admin UI**
-
-   Add libraries, users, metadata providers, and playback settings from the web interface.
-
-### Bind Mount Layout
-
-The deploy-oriented compose files use host folder mappings rather than Docker-managed volumes.
-
-By default, data is stored under `/opt/silo`:
-
-- `/opt/silo/postgres`
-- `/opt/silo/redis`
-- `/opt/silo/plugins`
-- `/opt/silo/compat`
-- `/opt/silo/transcode`
-- `/opt/silo/catalog-seeds`
-
-The optional `search` profile also stores its index under `/opt/silo/meilisearch`.
-
-Media is mounted into the container at `/mnt/media` from the host path you set in `MEDIA_ROOT`.
-
-### Optional Search Profile
-
-PostgreSQL full-text search works without any optional services. Meilisearch is available when you
-want its search provider:
-
-| Profile | Command | Description |
-|---|---|---|
-| default | `docker compose up -d` | Integrated server plus bundled PostgreSQL and Redis |
-| `search` | `docker compose --profile search up -d` | Add the optional Meilisearch service |
-
-Before starting the `search` profile, set `MEILI_MASTER_KEY` in `.env` to the output of
-`openssl rand -hex 32`. After Silo starts, choose Meilisearch under **Admin > Settings > Search**,
-set the URL to `http://meilisearch:7700`, enter the same key as the API key, test the connection,
-and save. Restart Silo, then rebuild the catalog search index from the same page. Silo continues
-to use PostgreSQL full-text search until you select Meilisearch.
-
-### Distributed Examples
-
-The main Compose file includes commented proxy and transcode service examples. Most single-host
-installs should leave them commented because the integrated service already includes proxying and
-transcoding.
-
-Multi-host operators can use those examples as a starting point for a dedicated worker Compose
-file connected to the deployment's shared PostgreSQL and Redis services.
-
-Proxy nodes serve source downloads from the same absolute media paths used by direct playback.
-Prepared-download work can also run on transcode nodes. Each selected transcode node retains its
-result on node-local storage and exposes it only through Silo's authenticated internal artifact API;
-the paired proxy relays those bytes, so no shared artifact mount is required. Dedicated transcode
-nodes default to retaining prepared downloads in a protected directory inside the transcode volume
-captured at process startup. `download.artifact_dir` overrides that location for both dedicated
-transcode nodes and the integrated/API-local fallback, so mount the configured path on every process
-that prepares downloads. Changing either artifact-path setting requires a restart. Downloads with a
-configured server-wide or per-user bandwidth limit remain API-local so those aggregate limits stay exact.
-Clients discover distributed delivery through `proxy_delivery` on the download capability response.
-When it is true, they may opt into `GET` or `HEAD /api/v1/downloads/{id}/file-proxy` and
-`/api/v1/direct-download-proxy`; those routes may return a temporary redirect to a proxy node. The
-established `/file` and `/direct-download` routes keep serving bytes directly with their existing
-status-code contract; for a node-local prepared artifact, the API itself performs the authenticated
-relay on that fallback route.
-
-### Deployment Notes
-
-The default compose stack intentionally bundles PostgreSQL and Redis for ease of setup and assumes a fresh install without those services already available. If you already operate PostgreSQL and Redis, omit those examples from compose and point Silo at your existing infrastructure instead. For serious installs, PostgreSQL is better on a separate VM or a managed service so upgrades, tuning, and backups are isolated from the app host. Redis can stay local for many installs, but externalizing it is also reasonable if you already operate shared infrastructure.
-
-Silo is externally stateful by default rather than fully stateless. Durable application state lives in PostgreSQL. Redis only stores coordination and cache-style data. Silo still writes transient transcode output locally under `/tmp/silo-transcode`. If you switch `userdb.backend=sqlite`, Silo also becomes locally stateful at `/var/lib/silo/userdb`.
-
-Migrating an existing Continuum Docker install should be done with the preflight
-helper and cutover guide in [docs/continuum-to-silo-docker-migration.md](docs/continuum-to-silo-docker-migration.md).
-
-## Configuration
-
-Silo requires `DATABASE_URL` and `SECRET_KEY` when running from source or against external
-infrastructure. In the default Docker Compose path, the stack wires the database and Redis URLs
-for you. All other settings — libraries, metadata providers, transcoding, users — are managed
-through the admin UI after first launch.
-
-### Server Modes
-
-| Mode | Description |
-|---|---|
-| `integrated` | Full server: API + frontend + scanner + transcode (default) |
-| `api` | API server only, no local transcoding |
-| `proxy` | Stream proxy node that connects to the shared deployment database and Redis |
-| `transcode` | HLS and prepared-download worker node that connects to the shared deployment database and Redis |
-
-### PostgreSQL Auto-Tuning
-
-The default Docker Compose stack does not require a checked-in `postgresql.conf`.
-It enables Silo's [pgtune](https://github.com/le0pard/pgtune)-style OLTP tuning
-by default:
-
-```yaml
-POSTGRES_TUNE: auto
-```
-
-When enabled, Silo connects with `DATABASE_URL` and applies recommendations with
-`ALTER SYSTEM`, which writes to PostgreSQL's `postgresql.auto.conf` inside the
-database data directory. Reloadable settings are applied immediately with
-`pg_reload_conf()`. Settings that PostgreSQL marks as restart-only are written
-too, and Silo logs the setting names so you can restart PostgreSQL once:
-
-```sh
-docker compose restart postgres
-```
-
-The default Compose database user has the required PostgreSQL permissions. If
-you use an external PostgreSQL server, make sure the configured `DATABASE_URL`
-user can run `ALTER SYSTEM`, or set `POSTGRES_TUNE=off` and manage
-PostgreSQL yourself.
-
-For `POSTGRES_TUNE_MEMORY=auto`, Silo uses the first trustworthy memory source:
-a finite Docker cgroup limit, the read-only `/host/proc/meminfo` mount supplied
-by the bundled Compose file, then `/proc/meminfo` with container safety guards.
-Auto-detected memory is treated as a PostgreSQL budget, defaulting to 75% of
-detected RAM so Silo, Redis, plugins, transcodes, and the OS retain headroom.
-`POSTGRES_TUNE_DB_SIZE=auto` queries `pg_database_size(current_database())` and
-classifies the workload by comparing the database size to that memory budget.
-
-Optional tuning overrides:
-
-| Variable | Default | Description |
-|---|---:|---|
-| `POSTGRES_TUNE_PROFILE` | `oltp` | Tuning profile. Only `oltp` is currently supported. |
-| `POSTGRES_TUNE_MEMORY` | `auto` | Server/container RAM, such as `8GB` or `32GB`; explicit values are used as-is. |
-| `POSTGRES_TUNE_MEMORY_BUDGET_PERCENT` | `75` | Percent of auto-detected RAM used for PostgreSQL recommendations. |
-| `POSTGRES_TUNE_CPUS` | `auto` | CPU count used for worker recommendations. |
-| `POSTGRES_TUNE_STORAGE` | `ssd` | One of `hdd`, `ssd`, `san`, or `nvme`. |
-| `POSTGRES_TUNE_DB_SIZE` | `auto` | Use `less_ram` when the database comfortably fits in RAM, `mid_ram`, or `greater_ram` for very large databases. |
-| `POSTGRES_TUNE_CONNECTIONS` | `100` | PostgreSQL `max_connections`; automatically raised if Silo's app pool is configured higher. |
-| `POSTGRES_SHM_SIZE` | `8gb` | Docker `/dev/shm` size for the bundled PostgreSQL container. |
-
-Advanced operators can still supply their own PostgreSQL configuration or
-override these env vars. Set `POSTGRES_TUNE=off` when you do not want Silo to
-change PostgreSQL server settings. Settings already written with `ALTER SYSTEM`
-remain in `postgresql.auto.conf`; reset those PostgreSQL parameters if you later
-move fully to a custom `postgresql.conf`.
-
-## Build from Source
-
-If you prefer running Silo without Docker:
-
-1. **Install prerequisites**: Go 1.26.4+, Node.js 22+, pnpm 10.32.1, PostgreSQL 18 with pgvector, Redis, and FFmpeg.
-
-2. **Configure the source process**
-
-   ```sh
-   cp .env.example .env
-   printf '\nSECRET_KEY=%s\nDATABASE_URL=%s\nREDIS_URL=%s\n' \
-     "$(openssl rand -base64 48)" \
-     'postgres://silo:silo@localhost:5432/silo?sslmode=disable' \
-     'redis://localhost:6379' >> .env
-   ```
-
-   Change the URLs when you use existing services instead of the bundled development defaults.
-
-3. **Start PostgreSQL and Redis** (skip if you already have them running)
-
-   ```sh
-   docker compose up -d postgres redis
-   ```
-
-4. **Build and run**
-
-   ```sh
-   make build
-   ./silo
-   ```
-
-   The server starts at `http://localhost:8080` by default. All other settings are configured through the admin UI.
+Review configuration, compatibility, and migration impact before every update.
 
 ## Documentation
 
-| Start with | Use it for |
+| Start here | What it covers |
 | --- | --- |
-| [Documentation index](docs/wiki/index.md) | Feature guides, administration, deployment, playback, and troubleshooting |
-| [Release versioning](docs/release-versioning.md) | Version selection, GitHub release notes, prereleases, and maintainer checks |
-| [Development guide](DEVELOPMENT.md) | Local setup, builds, tests, migrations, and repository structure |
-| [Canonical Settings API](docs/settings-api.md) | Client contracts, contextual headers, remote scopes, and effective reads |
+| [Documentation index](docs/wiki/index.md) | User and operator guides currently available in the repository. |
+| [Docker deployment](docs/wiki/deployment/docker.md) | Storage, acceleration, search, topology, external services, tuning, and updates. |
+| [Media naming](docs/wiki/admin/media-folder-and-naming.md) | Supported library folder structures and filenames. |
+| [Development guide](DEVELOPMENT.md) | Source setup, builds, tests, migrations, and repository structure. |
+| [Settings API](docs/settings-api.md) | Client settings contracts, contextual scopes, and effective reads. |
+| [Downloads API](docs/downloads-api.md) | Offline sync, download delivery, and distributed client behavior. |
+| [Release versioning](docs/release-versioning.md) | SemVer, container identifiers, release notes, and publishing. |
 
-## Reporting Issues
+## Community and contributions
 
-Client implementers can use the [Canonical Settings API guide](docs/settings-api.md)
-for contract discovery, contextual headers, remote scopes, effective reads, and
-the admin projection.
+Questions and project discussion are welcome in the
+[Silo Discord community](https://discord.com/invite/4RxuUQAEnW).
 
-If you are reporting a bug, install problem, or performance issue, start with the admin workflow and reproduction steps, not Claude/Codex analysis.
+For a bug, installation problem, or performance issue, use the
+[GitHub issue forms](https://github.com/Silo-Server/silo-server/issues/new/choose)
+and include the workflow you followed, exact reproduction steps, expected and
+actual behavior, the affected version/build, deployment details, and raw logs
+where relevant.
 
-Please include:
-
-- What you were trying to do
-- Exact steps you took
-- What you expected to happen
-- What actually happened
-- What exact action is slow or broken (`save`, `scan`, `browse`, `import`, `playback`, etc.)
-- Whether it happens every time or only sometimes
-- The library, media type, filter, setting, or value involved
-- Version, branch, commit, and deployment details if you know them
-- Screenshots, recordings, or log snippets if relevant
-
-If you used Claude/Codex for debugging, put that under `Technical notes` at the end. Suspected files, SQL output, stack traces, and root-cause theories can be helpful, but only after the workflow and repro steps are clear.
-
-Use this template:
-
-```text
-Goal:
-Steps:
-Expected:
-Actual:
-What is slow/broken:
-Scope:
-Version/branch:
-Deployment:
-Technical notes:
-```
-
-## Contributing & Development
-
-Silo is open source and contributions are welcome. See [DEVELOPMENT.md](DEVELOPMENT.md) for building from source in a dev workflow, running tests, database migrations, and project layout, and [CONTRIBUTING.md](CONTRIBUTING.md) for contribution expectations, merge request guidance, and the policy for AI-assisted submissions.
+Contributions are welcome. Read [CONTRIBUTING.md](CONTRIBUTING.md) before
+starting, and use [DEVELOPMENT.md](DEVELOPMENT.md) for the local workflow.
+Non-trivial features, API changes, migrations, behavior changes, and refactors
+should be coordinated in an issue before implementation.
 
 ## Supporting Silo
 
-Silo is an open-source hobby project, developed in spare time and funded out of pocket. If you'd like to support development, you can sponsor via [GitHub Sponsors](https://github.com/sponsors/quick104).
+Silo is a free and open-source project developed in spare time and funded out of
+pocket. It will remain free and open source.
+[GitHub Sponsors](https://github.com/sponsors/quick104) helps cover AI-assisted
+development tooling, including Claude and Codex, push-notification relay
+infrastructure, and future project costs.
 
-Donations go directly toward the costs of building and running the project:
-
-- AI development tooling subscriptions (Claude, Codex) used to build and maintain Silo
-- Push notification relay infrastructure
-- Future development costs
-
-Sponsoring is entirely optional — Silo is and will remain free and open source. Bug reports, contributions, and feedback are just as valuable.
+Sponsoring is optional. Bug reports, contributions, documentation, and feedback
+are equally valuable ways to support the project.
 
 <p align="center">
   <a href="https://github.com/sponsors/quick104"><strong>Sponsor Silo</strong></a>
-  · <a href="https://discord.com/invite/4RxuUQAEnW"><strong>Join the Discord community</strong></a>
+  · <a href="https://discord.com/invite/4RxuUQAEnW"><strong>Join the community</strong></a>
 </p>
 
-## License & Trademarks
+## License and trademarks
 
-Silo's source code is licensed under the **GNU Affero General Public License
-v3.0 or later** (`AGPL-3.0-or-later`) — see [LICENSE](LICENSE).
+Silo's source code is licensed under the
+**GNU Affero General Public License v3.0 or later** (`AGPL-3.0-or-later`). See
+[LICENSE](LICENSE).
 
 The **Silo name, logo, and wordmark are trademarks of Silo Media L.L.C.** and
-are **not** covered by the AGPL. You're free to fork and redistribute the code,
-but forks and redistributions must not use the Silo brand as their identity and
-must remove or replace the brand assets. Publishing a Silo-branded app to an app
-store requires written permission. See [TRADEMARK.md](TRADEMARK.md) for what's
-permitted — including referential use like "compatible with Silo."
+are not covered by the AGPL. Forks and redistributions may use the code but must
+not use the Silo brand as their identity and must remove or replace the brand
+assets. Publishing a Silo-branded app to an app store requires written
+permission. See [TRADEMARK.md](TRADEMARK.md) for permitted referential use,
+including phrases such as "compatible with Silo."

--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@
   · <a href="docs/wiki/index.md">Documentation</a>
   · <a href="docs/release-versioning.md">Builds &amp; releases</a>
   · <a href="https://discord.com/invite/4RxuUQAEnW">Discord</a>
+  · <a href="#supporting-silo">Support Silo</a>
   · <a href="CONTRIBUTING.md">Contributing</a>
 </p>
 

--- a/docs/ai-contributions.md
+++ b/docs/ai-contributions.md
@@ -1,36 +1,32 @@
 # AI-assisted contributions
 
-AI-assisted code, documentation, review, and debugging are welcome in Silo.
-The contributor submitting the work owns the result and is responsible for its
-accuracy, safety, scope, and maintainability.
-
-This policy applies to pull requests and issues prepared by a person, an agent,
-or a combination of both.
+AI-assisted code, documentation, review, and debugging are welcome. The person
+who submits the work owns it: its accuracy, safety, scope, and maintainability.
+This applies to pull requests and issues written by a person, an agent, or both.
 
 ## Required disclosure
 
 > [!IMPORTANT]
-> Every pull request and issue must disclose whether AI was involved. Report the
-> exact tool and model identifiers shown by the tool, describe the level of
-> involvement, and summarize the independent or adversarial review. If no AI
-> was used, say so explicitly.
+> Every pull request and issue must say whether AI was involved: the exact tool
+> and model identifiers the tool reports, the level of involvement, and a
+> summary of the independent or adversarial review. "No AI used" is a complete
+> answer when it is true.
 
-Include this completed block in the issue or pull request body:
+The pull request template contains this block; copy it into issues that need it:
 
 ```md
-### AI Disclosure
+## AI Disclosure
 
 - Tool(s): exact tool name(s), or "none"
 - Model(s): exact model identifier(s) reported by each tool, or "n/a"
 - Involvement: Fully AI-generated, human verified | AI-assisted | Human-written, AI-reviewed | No AI used
-- Adversarial review: findings from an independent/adversarial review and how they were resolved, or "n/a" only when no AI or implementation change was involved
+- Adversarial review: scope, method, findings, and resolutions, or "n/a" only when no AI or implementation change was involved
 ```
 
-The disclosure is about provenance and reviewability. AI use is not a reason to
-reject a contribution, and "no AI" is a complete answer when accurate.
-Exact model identifiers help maintainers understand the tool capabilities used,
-reproduce the workflow where necessary, and decide whether line-by-line review
-or a separate implementation is the most efficient path.
+Disclosure is about provenance, not judgment. AI use is never by itself a reason
+to reject a contribution. Exact model identifiers tell maintainers what produced
+the work, let them reproduce the workflow when needed, and help them decide
+between line-by-line review and a separate implementation.
 
 ## Contributor responsibility
 
@@ -38,65 +34,50 @@ Before submitting AI-assisted work:
 
 1. Read every line of the final diff.
 2. Understand the behavior well enough to explain the reasoning and tradeoffs.
-3. Confirm that APIs, configuration, schemas, commands, and repository paths
-   actually exist.
-4. Add and run focused tests for the behavior changed.
-5. Run the repository checks relevant to the complete diff.
+3. Confirm that the APIs, configuration, schemas, commands, and repository paths
+   it references exist.
+4. Add and run focused tests for the changed behavior.
+5. Run the repository gate in
+   [CONTRIBUTING.md](../CONTRIBUTING.md#validate-your-change) against the
+   complete diff, including `golangci-lint` and `make verify-local-paths`.
 6. Exercise user-facing behavior manually when practical.
 7. Look beyond the edited files for silent behavior changes, dead code,
-   security regressions, and interactions across system layers.
-8. Run an independent or adversarial review and resolve its findings.
+   security regressions, and cross-layer interactions.
+8. Run an independent or adversarial review and resolve its findings. For
+   non-trivial changes, state the scope and method; a bare "no findings" is
+   not a review summary.
 
-For non-trivial changes, state the review scope and method. A bare "no findings"
-statement is not a sufficient review summary.
-
-"The AI suggested it" is not an explanation. The submitting contributor owns
-the implementation regardless of how it was produced.
+"The AI suggested it" is not an explanation.
 
 ## Evidence standard
 
-Use real commands and real observations. Focused tests during development may
-look like:
+Use real commands and real observations. Paste the actual output into the pull
+request and name any command that was not run or did not pass. Passing tests,
+including AI-generated ones, do not replace code review, manual verification, or
+thinking about system-level effects.
 
-```sh
-go test ./internal/<package>/...
-cd web && pnpm exec vitest run path/to/changed.test.tsx
-```
-
-Use `make test-go`, `make test-web`, and the relevant verification targets for
-the full pre-submission gate described in [CONTRIBUTING.md](../CONTRIBUTING.md).
-Paste actual results into the pull request and identify any command that was not
-run or did not pass.
-
-Tests may have blind spots, including tests generated with AI. Passing tests do
-not replace code review, manual verification, or analysis of system-level
-effects.
-
-For bug reports:
-
-- reproduce the problem on a real deployment before filing
-- provide exact steps and actual observed behavior
-- paste raw log output; redact credentials, tokens, personal data, and private
-  media details, mark the redactions, and do not replace the remainder with an
-  AI paraphrase
-- separate observations from suspected root cause
-- place AI-generated analysis under technical notes after the reproduction
+For bug reports, reproduce the problem on a real deployment before filing, keep
+what you observed separate from what you suspect, and paste raw logs. Redact
+credentials, tokens, personal data, and private media details, mark each
+redaction, and do not paraphrase the rest. AI-generated analysis goes under
+Technical notes, after the reproduction. The
+[issue forms](https://github.com/Silo-Server/silo-server/issues/new/choose)
+enforce the required fields.
 
 ## Integrity and enforcement
 
 > [!WARNING]
-> Fabricated evidence results in an immediate block, including on a first
-> offense. This includes invented APIs, unexecuted reproduction steps,
-> synthesized logs, imagined vulnerabilities, unobserved bugs, and false test
-> results.
+> Fabricated evidence is an immediate block, including on a first offense:
+> invented APIs, reproduction steps that were never run, synthesized logs,
+> imagined vulnerabilities, unobserved bugs, and false test results.
 
-Undisclosed AI use discovered after submission results in the contribution
-being closed. Repeated non-disclosure results in the contributor being blocked.
-The policy violation is the missing disclosure, not the use of AI.
+Undisclosed AI use discovered after submission gets the contribution closed.
+Repeated non-disclosure gets the contributor blocked. The violation is the
+missing disclosure, not the AI.
 
 ## Review outcomes
 
-Maintainers review the idea, implementation, evidence, and fit with the current
-codebase. They may request changes, narrow the scope, decline the contribution,
-or accept the idea and implement it differently. A separate implementation is a
-normal project decision and does not invalidate a well-researched proposal.
+Maintainers review the idea, the implementation, the evidence, and the fit with
+the current codebase. They may request changes, narrow the scope, decline the
+contribution, or accept the idea and implement it differently. A separate
+implementation is a normal outcome and does not mean the proposal was wrong.

--- a/docs/ai-contributions.md
+++ b/docs/ai-contributions.md
@@ -1,40 +1,102 @@
 # AI-assisted contributions
 
-For AI agents preparing a pull request or issue for this repository on behalf of someone who is
-not a maintainer.
+AI-assisted code, documentation, review, and debugging are welcome in Silo.
+The contributor submitting the work owns the result and is responsible for its
+accuracy, safety, scope, and maintainability.
 
-## Disclosure is required
+This policy applies to pull requests and issues prepared by a person, an agent,
+or a combination of both.
 
-Include this completed block in the PR or issue body, with the exact model ID you are running as.
-Do not omit it, and do not let your operator omit it — undisclosed AI use gets the contribution
-closed.
+## Required disclosure
+
+> [!IMPORTANT]
+> Every pull request and issue must disclose whether AI was involved. Report the
+> exact tool and model identifiers shown by the tool, describe the level of
+> involvement, and summarize the independent or adversarial review. If no AI
+> was used, say so explicitly.
+
+Include this completed block in the issue or pull request body:
 
 ```md
 ### AI Disclosure
-- Tool(s): e.g. Claude Code, Codex CLI, Cursor — or "none"
-- Model(s): exact model ID(s), e.g. claude-opus-5, gpt-5.6 — or "n/a"
-- Involvement: fully AI-generated | AI-assisted | human-written, AI-reviewed | none
-- Adversarial review: what your own AI review of the diff found, and how you resolved it
+
+- Tool(s): exact tool name(s), or "none"
+- Model(s): exact model identifier(s) reported by each tool, or "n/a"
+- Involvement: Fully AI-generated, human verified | AI-assisted | Human-written, AI-reviewed | No AI used
+- Adversarial review: findings from an independent/adversarial review and how they were resolved, or "n/a" only when no AI or implementation change was involved
 ```
+
+The disclosure is about provenance and reviewability. AI use is not a reason to
+reject a contribution, and "no AI" is a complete answer when accurate.
+Exact model identifiers help maintainers understand the tool capabilities used,
+reproduce the workflow where necessary, and decide whether line-by-line review
+or a separate implementation is the most efficient path.
+
+## Contributor responsibility
+
+Before submitting AI-assisted work:
+
+1. Read every line of the final diff.
+2. Understand the behavior well enough to explain the reasoning and tradeoffs.
+3. Confirm that APIs, configuration, schemas, commands, and repository paths
+   actually exist.
+4. Add and run focused tests for the behavior changed.
+5. Run the repository checks relevant to the complete diff.
+6. Exercise user-facing behavior manually when practical.
+7. Look beyond the edited files for silent behavior changes, dead code,
+   security regressions, and interactions across system layers.
+8. Run an independent or adversarial review and resolve its findings.
+
+For non-trivial changes, state the review scope and method. A bare "no findings"
+statement is not a sufficient review summary.
+
+"The AI suggested it" is not an explanation. The submitting contributor owns
+the implementation regardless of how it was produced.
 
 ## Evidence standard
 
-Run the repo verify commands before declaring the work complete, and paste the real output into
-the PR:
+Use real commands and real observations. Focused tests during development may
+look like:
 
-```bash
-make lint
-cd web && pnpm run lint && pnpm run format:check
-make verify-local-paths
-go test ./...   # targeted at the packages you touched
+```sh
+go test ./internal/<package>/...
+cd web && pnpm exec vitest run path/to/changed.test.tsx
 ```
 
-Run an adversarial review of your own diff and summarize what it found in the PR body.
+Use `make test-go`, `make test-web`, and the relevant verification targets for
+the full pre-submission gate described in [CONTRIBUTING.md](../CONTRIBUTING.md).
+Paste actual results into the pull request and identify any command that was not
+run or did not pass.
 
-Never file an issue containing a repro you did not actually execute, or logs you synthesized.
-Raw logs only. A fabricated repro costs a maintainer more time than no report at all.
+Tests may have blind spots, including tests generated with AI. Passing tests do
+not replace code review, manual verification, or analysis of system-level
+effects.
 
-## What to expect
+For bug reports:
 
-The maintainer may accept the idea but re-implement it with a current frontier model. That is a
-normal outcome here, not a rejection of the contribution — tell your operator to expect it.
+- reproduce the problem on a real deployment before filing
+- provide exact steps and actual observed behavior
+- paste raw log output; redact credentials, tokens, personal data, and private
+  media details, mark the redactions, and do not replace the remainder with an
+  AI paraphrase
+- separate observations from suspected root cause
+- place AI-generated analysis under technical notes after the reproduction
+
+## Integrity and enforcement
+
+> [!WARNING]
+> Fabricated evidence results in an immediate block, including on a first
+> offense. This includes invented APIs, unexecuted reproduction steps,
+> synthesized logs, imagined vulnerabilities, unobserved bugs, and false test
+> results.
+
+Undisclosed AI use discovered after submission results in the contribution
+being closed. Repeated non-disclosure results in the contributor being blocked.
+The policy violation is the missing disclosure, not the use of AI.
+
+## Review outcomes
+
+Maintainers review the idea, implementation, evidence, and fit with the current
+codebase. They may request changes, narrow the scope, decline the contribution,
+or accept the idea and implement it differently. A separate implementation is a
+normal project decision and does not invalidate a well-researched proposal.

--- a/docs/downloads-api.md
+++ b/docs/downloads-api.md
@@ -173,7 +173,7 @@ Response:
 | `season_download`        | Per-season batch downloads are available.                                         |
 | `series_monitoring`      | Auto-download subscriptions are available.                                        |
 | `monitoring_modes`       | Subscription modes the client may request.                                        |
-| `proxy_delivery`         | Proxy-aware download routes are available for opt-in distributed delivery.        |
+| `proxy_delivery`         | Proxy-aware download routes are mounted (§4.11); redirects are per-request.        |
 
 `quality_presets` is always an array — `[]` (never `null`) when downloads are
 disabled or the user lacks download permission — so clients can rely on
@@ -423,9 +423,8 @@ For browser-friendly links, the endpoint accepts the session access token as a
 
 ### 4.11 Distributed proxy delivery
 
-Clients discover distributed delivery through `proxy_delivery` on the download
-capability response. When it is `true`, clients may opt into the proxy-aware
-routes:
+`proxy_delivery` on the capability response reports whether the proxy-aware
+routes exist:
 
 ```http
 GET  /api/v1/downloads/{id}/file-proxy
@@ -434,15 +433,20 @@ GET  /api/v1/direct-download-proxy?file_id={id}
 HEAD /api/v1/direct-download-proxy?file_id={id}
 ```
 
-These routes may return a temporary redirect to a proxy node. The established
-`/file` and `/direct-download` routes keep serving bytes directly and retain
-their existing status-code contract. When a prepared artifact is stored on a
-transcode node, the API performs the authenticated relay for those fallback
-routes.
+`true` means the routes are mounted, not that every request redirects. A
+proxy-aware route returns `307` to a proxy node when one is eligible for that
+file, and otherwise serves bytes directly with the same status-code contract as
+the non-proxy route. Bandwidth-limited downloads (server-wide or per-user) are
+never redirected, and neither are files no proxy node can reach. Clients must
+follow the redirect or accept the direct response; they cannot assume either.
 
-Downloads with a configured server-wide or per-user bandwidth limit remain
-API-local so aggregate limits stay exact. Clients must treat proxy delivery as
-an advertised capability, not infer it from a server version.
+The established `/file` and `/direct-download` routes never redirect. When a
+prepared artifact for `/downloads/{id}/file` lives on a transcode node, the API
+relays it; the client sees an ordinary direct response. `/direct-download`
+serves source files only and has no artifact case.
+
+Treat proxy delivery as an advertised capability, not something inferred from a
+server version.
 
 ---
 

--- a/docs/downloads-api.md
+++ b/docs/downloads-api.md
@@ -158,7 +158,8 @@ Response:
   "transcode_user_allowed": true,
   "season_download": true,
   "series_monitoring": true,
-  "monitoring_modes": ["all", "future", "latest_season", "specific_seasons"]
+  "monitoring_modes": ["all", "future", "latest_season", "specific_seasons"],
+  "proxy_delivery": true
 }
 ```
 
@@ -172,6 +173,7 @@ Response:
 | `season_download`        | Per-season batch downloads are available.                                         |
 | `series_monitoring`      | Auto-download subscriptions are available.                                        |
 | `monitoring_modes`       | Subscription modes the client may request.                                        |
+| `proxy_delivery`         | Proxy-aware download routes are available for opt-in distributed delivery.        |
 
 `quality_presets` is always an array — `[]` (never `null`) when downloads are
 disabled or the user lacks download permission — so clients can rely on
@@ -418,6 +420,29 @@ For browser-friendly links, the endpoint accepts the session access token as a
 > **Security note:** the query token is the session access token. Treat
 > direct-download URLs as secrets — they end up in browser history and proxy
 > logs. A short-lived download-scoped URL is a planned follow-up.
+
+### 4.11 Distributed proxy delivery
+
+Clients discover distributed delivery through `proxy_delivery` on the download
+capability response. When it is `true`, clients may opt into the proxy-aware
+routes:
+
+```http
+GET  /api/v1/downloads/{id}/file-proxy
+HEAD /api/v1/downloads/{id}/file-proxy
+GET  /api/v1/direct-download-proxy?file_id={id}
+HEAD /api/v1/direct-download-proxy?file_id={id}
+```
+
+These routes may return a temporary redirect to a proxy node. The established
+`/file` and `/direct-download` routes keep serving bytes directly and retain
+their existing status-code contract. When a prepared artifact is stored on a
+transcode node, the API performs the authenticated relay for those fallback
+routes.
+
+Downloads with a configured server-wide or per-user bandwidth limit remain
+API-local so aggregate limits stay exact. Clients must treat proxy delivery as
+an advertised capability, not infer it from a server version.
 
 ---
 

--- a/docs/feature-changelog.md
+++ b/docs/feature-changelog.md
@@ -16,6 +16,13 @@ Plugin watch providers can now ask for connection details per profile instead of
 - Encrypts every field the provider declares as a secret and keeps submitted setup data out of admin-facing plugin configuration.
 - Prefers a profile's own values over installation-wide values of the same name, so existing connections keep working until they are reconnected.
 
+### Serve downloads from proxy nodes
+Download delivery can now be spread across proxy and transcode nodes instead of always flowing through the API server.
+- Adds `proxy_delivery` to the download capability response and the opt-in `/downloads/{id}/file-proxy` and `/direct-download-proxy` routes, which redirect to an eligible proxy node per request and serve bytes directly otherwise.
+- Prepared downloads can run on transcode nodes; the result stays on that node and is relayed through the authenticated artifact API, so nodes need no shared mount.
+- Bandwidth-limited downloads stay on the API server so server-wide and per-user limits remain exact.
+- The existing `/file` and `/direct-download` routes are unchanged.
+
 ## 2026-08-19
 
 ### Scope API keys to the admin routes they need

--- a/docs/wiki/deployment/docker.md
+++ b/docs/wiki/deployment/docker.md
@@ -19,15 +19,15 @@ related:
 # Deploy Silo with Docker
 
 Docker Compose is the recommended way to run Silo. The repository's default
-stack is designed for a new single-host installation and includes:
+stack targets a new single-host installation and includes:
 
 - Silo in `integrated` mode
 - PostgreSQL 18 with pgvector
 - Redis
 - FFmpeg and the Silo web application in the Silo image
 
-Start with this layout unless you already operate the supporting services or
-need dedicated delivery nodes.
+Start here unless you already run PostgreSQL and Redis elsewhere or need
+dedicated delivery nodes.
 
 ```mermaid
 flowchart LR
@@ -50,7 +50,7 @@ and container runtime support.
 
 ## Initial configuration
 
-Clone the repository and create `.env` from the maintained example:
+Clone the repository and create `.env` from the example:
 
 ```sh
 git clone https://github.com/Silo-Server/silo-server.git
@@ -73,17 +73,16 @@ Then start the stack:
 docker compose up -d
 ```
 
-Open <http://localhost:8090> and complete onboarding. The default Compose stack
-wires the PostgreSQL and Redis connections; libraries, users, providers,
-storage, search, and playback settings are managed through the admin interface.
+Open <http://localhost:8090> and complete onboarding. The Compose stack wires
+the PostgreSQL and Redis connections; everything else (libraries, users,
+providers, storage, search, playback) is configured in the admin interface.
 
 > [!CAUTION]
 > `SECRET_KEY` is the master key for encrypted server-owned credentials. Keep it
 > secret and back it up separately from database dumps. Losing it makes stored
 > integration and storage credentials unrecoverable.
 
-The encryption design is documented in
-[Secret encryption at rest](../../architecture/secret-encryption.md).
+Design notes: [Secret encryption at rest](../../architecture/secret-encryption.md).
 
 ## Container image selection
 
@@ -97,9 +96,8 @@ Use `SILO_IMAGE` to select an image:
 SILO_IMAGE=ghcr.io/silo-server/silo-server:build-N
 ```
 
-Use a commit-SHA tag or digest when a deployment or rollback target must be
-immutable. See [Release versioning](../../release-versioning.md) for the full
-tag contract.
+Use a commit-SHA tag or digest when a deployment or rollback target must not
+move. [Release versioning](../../release-versioning.md) defines each tag.
 
 ## Storage and state
 
@@ -116,7 +114,7 @@ volumes. `SILO_DATA_ROOT` defaults to `/opt/silo` and contains:
 | `/opt/silo/catalog-seeds` | Read-only catalog seed data |
 | `/opt/silo/meilisearch` | Optional Meilisearch index |
 
-Override the base path when required:
+To use a different base path:
 
 ```dotenv
 SILO_DATA_ROOT=/srv/silo
@@ -146,8 +144,8 @@ Validate the merged Compose configuration before recreating the container.
 
 ### Published ports
 
-Change host-side port variables in `.env` when a default conflicts with another
-service. The container listeners remain fixed.
+Change the host-side port variables in `.env` when a default conflicts with
+another service. The container listeners are fixed.
 
 | Variable | Default | Purpose |
 | --- | ---: | --- |
@@ -156,6 +154,11 @@ service. The container listeners remain fixed.
 | `ABS_PORT` | `13378` | Audiobookshelf compatibility listener |
 | `PROXY_PORT` | `8083` | Commented standalone proxy example |
 | `TRANSCODE_PORT` | `8082` | Commented standalone transcode example |
+
+The Jellyfin/Emby and Audiobookshelf listeners are enabled by default, so
+`8096` and `13378` accept connections from the first start. Turn them off in
+**Admin > Settings** (`jellyfin_compat.enabled`, `audiobookshelf_compat.enabled`)
+if you do not use compatible clients.
 
 > [!WARNING]
 > The application and compatibility port mappings listen on all host interfaces
@@ -166,7 +169,7 @@ service. The container listeners remain fixed.
 
 ## Hardware acceleration
 
-The default stack is CPU-only so it can start on hosts without GPU devices.
+The default stack is CPU-only so it starts on hosts without a GPU.
 
 ### Intel or AMD VA-API and Intel Quick Sync
 
@@ -179,7 +182,7 @@ docker compose \
   up -d
 ```
 
-To use the overlay for future Compose commands, set:
+To make the overlay the default for this installation:
 
 ```dotenv
 COMPOSE_FILE=docker-compose.yml:docker-compose.vaapi.yml
@@ -208,8 +211,8 @@ Windows uses `;` instead of `:` between entries in `COMPOSE_FILE`.
 
 ## Optional Meilisearch
 
-PostgreSQL full-text search works without an additional service. To make
-Meilisearch available as an optional provider:
+PostgreSQL full-text search needs no extra service. To offer Meilisearch as an
+alternative provider:
 
 1. Generate a key and add it to `.env`:
 
@@ -242,8 +245,8 @@ Silo continues to use PostgreSQL full-text search until Meilisearch is selected.
 > dependencies on both services. Setting `DATABASE_URL` or `REDIS_URL` only in
 > `.env` does not replace that wiring.
 
-To use existing infrastructure, create a custom Compose definition or a tested
-override that does all of the following:
+To use existing infrastructure, write a Compose definition or override that
+does all of the following:
 
 - supplies the external `DATABASE_URL` and `REDIS_URL` to the Silo service
 - removes or replaces the bundled-service dependencies
@@ -257,10 +260,9 @@ Validate the merged configuration before starting it:
 docker compose -f docker-compose.yml -f your-override.yml config --quiet
 ```
 
-For a serious deployment, isolating PostgreSQL on a dedicated VM or managed
-service can simplify database upgrades, tuning, and backups. Redis can remain
-local for many installations or move to shared infrastructure when that is
-already available.
+Running PostgreSQL on a dedicated VM or managed service simplifies upgrades,
+tuning, and backups. Redis can stay local or move to shared infrastructure if
+you already have it.
 
 ## Server roles and distributed deployments
 
@@ -271,9 +273,8 @@ already available.
 | `proxy` | Dedicated stream and source-download delivery node. |
 | `transcode` | Dedicated HLS and prepared-download worker. |
 
-The main Compose file contains commented proxy and transcode examples. Most
-single-host installations should leave them disabled because `integrated`
-already includes proxying and transcoding.
+The main Compose file contains commented proxy and transcode examples. Leave
+them disabled on a single host; `integrated` already proxies and transcodes.
 
 For a distributed deployment:
 
@@ -284,18 +285,16 @@ For a distributed deployment:
   that can prepare downloads
 - restart a role after changing its artifact path
 
-Prepared downloads can run on transcode nodes. A selected node keeps the result
-on node-local storage and exposes it through Silo's authenticated internal
-artifact API; the paired proxy relays the bytes, so the nodes do not require a
-shared artifact mount. Dedicated transcode nodes default to a protected
-directory inside the transcode volume selected at process startup.
-`download.artifact_dir` overrides that location for dedicated transcode nodes
-and the integrated/API-local fallback; mount the configured path anywhere that
-can prepare downloads. Server-wide or per-user bandwidth-limited downloads
-stay API-local so aggregate limits remain exact.
+Prepared downloads can run on transcode nodes. The node keeps the result on
+its own disk and serves it through Silo's authenticated artifact API, so nodes
+need no shared artifact mount. Dedicated transcode nodes default to a protected
+directory inside the transcode volume; `download.artifact_dir` overrides that
+for transcode nodes and for the integrated/API fallback. Whatever path you
+configure must be mounted on every process that can prepare downloads.
 
-The client-facing delivery contract, including capability discovery and proxy
-routes, is documented in the [Downloads API](../../downloads-api.md).
+Downloads with a server-wide or per-user bandwidth limit are always served by
+the API server, so the limits stay exact regardless of topology. The
+client-facing contract is in the [Downloads API](../../downloads-api.md#411-distributed-proxy-delivery).
 
 ## PostgreSQL auto-tuning
 
@@ -312,10 +311,14 @@ POSTGRES_TUNE: auto
 > if PostgreSQL settings are managed elsewhere.
 
 Reloadable settings are applied with `pg_reload_conf()`. Restart-only settings
-are written and logged by name; apply them by restarting PostgreSQL once:
+are written to `postgresql.auto.conf` and logged by name on every Silo start
+until PostgreSQL has been restarted. Silo is already serving when that warning
+appears, and restarting only PostgreSQL drops every open Silo connection, so
+restart both during a quiet window (or once, right after first boot, before
+adding libraries):
 
 ```sh
-docker compose restart postgres
+docker compose restart postgres silo
 ```
 
 The bundled database user has the required permissions. For an external
@@ -351,47 +354,64 @@ default. Database-size classification uses
 | `POSTGRES_SHM_SIZE` | `8gb` | Docker `/dev/shm` size for bundled PostgreSQL. |
 
 Turning auto-tuning off does not remove settings already written to
-`postgresql.auto.conf`. Reset those PostgreSQL parameters if the deployment
-later moves fully to a custom configuration.
+`postgresql.auto.conf`. Reset them yourself if you later move to a fully custom
+configuration.
 
 ## Backups and updates
 
 Before an update:
 
-1. Pin or record the current image reference for rollback.
-2. Back up PostgreSQL and verify the backup can be read.
-3. Back up `.env`, especially `SECRET_KEY`, separately from the database.
-4. Preserve the effective Compose configuration and any custom overrides in a
-   restricted backup location.
-5. Review the incoming build or release for migration and compatibility notes.
+1. Record the image currently running (`docker compose images silo`) so you
+   can roll back to it. `latest` will not identify it later.
+2. Dump PostgreSQL and check the dump is readable:
 
-After selecting the intended `SILO_IMAGE`, update only the application service:
+   ```sh
+   docker compose exec -T postgres \
+     pg_dump -U "${POSTGRES_USER:-silo}" -Fc "${POSTGRES_DB:-silo}" > silo-$(date +%F).dump
+   pg_restore --list silo-$(date +%F).dump > /dev/null
+   ```
+
+   Do not copy `/opt/silo/postgres` while the container is running; a live
+   copy of the data directory is inconsistent and may not start. If you must
+   copy the directory, `docker compose stop postgres` first.
+3. Back up `.env`, especially `SECRET_KEY`, separately from the dump.
+4. Keep the effective Compose configuration and any overrides with the backup,
+   in a restricted location.
+5. Read the incoming build or release notes for migration and compatibility
+   changes.
+
+Set the intended `SILO_IMAGE`, then update only the application service:
 
 ```sh
 docker compose pull silo
 docker compose up -d --no-deps silo
+docker compose logs -f silo
 ```
 
-Silo applies pending database migrations during startup. Allow startup to
-finish before evaluating readiness or attempting another update.
-
-Use a build tag, commit-SHA tag, or digest when reproducible rollback matters.
-Do not assume that `latest` will continue to identify the image currently
-running on the host.
+Silo applies pending migrations during startup, under a database lock, before
+it opens its HTTP listener. The container healthcheck starts failing after
+about a minute, so a large migration can show `unhealthy` in `docker ps` while
+it is still working. Follow the logs until startup completes and do not
+restart the container during a migration: that abandons the run and can leave
+a lock-holding backend behind. Migrations time out after 20 minutes by default;
+raise `SILO_MIGRATE_TIMEOUT` (a Go duration such as `60m`, or `0` for no limit)
+for very large libraries.
 
 > [!WARNING]
-> Rolling back the Silo image does not reverse database migrations. Keep the
-> pre-update database backup and effective Compose configuration paired with the
-> previous image. Review every applied migration before deciding whether a
-> binary rollback is sufficient or a coordinated database restore is required;
-> restoring a database also discards writes made after the backup.
+> Rolling back the image does not reverse migrations. Check what was applied
+> with `docker compose run --rm silo --migrate-status`. For a reversible
+> migration, stop the stack and run
+> `docker compose run --rm silo --migrate-down-to <version>` before starting
+> the previous image; some migrations discard data on the way down, so read the
+> migration first. Restoring the pre-update dump is the fallback, and it
+> discards every write made after the dump.
 
-`docker compose config` can contain resolved database credentials and
-`SECRET_KEY`. Treat its output as a secret-bearing backup: restrict its file
-permissions, never paste it into issues or logs, and redact it before sharing.
+`docker compose config` output contains resolved database credentials and
+`SECRET_KEY`. Restrict its permissions, never paste it into issues or logs, and
+redact it before sharing.
 
-After an update, verify both endpoints on the configured host-side `PORT`.
-Replace `8090` below when `PORT` differs from the default:
+After an update, check both endpoints on the host-side `PORT` (replace `8090`
+if you changed it):
 
 ```sh
 curl -fsS http://localhost:8090/api/v1/health
@@ -403,11 +423,10 @@ including PostgreSQL and configured S3 storage.
 
 ## Migrating from Continuum
 
-Use the conservative preflight and cutover workflow in
-[Continuum to Silo Docker Migration](../../continuum-to-silo-docker-migration.md).
-Preserve the previous in-container media path when existing library records
-store that path, and do not remove the migration backup until scanning,
-metadata, users, plugins, and playback have been verified.
+Follow [Continuum to Silo Docker Migration](../../continuum-to-silo-docker-migration.md).
+Keep the old in-container media path if existing library records store it, and
+keep the migration backup until scanning, metadata, users, plugins, and
+playback have all been checked.
 
 ## Source References
 

--- a/docs/wiki/deployment/docker.md
+++ b/docs/wiki/deployment/docker.md
@@ -1,0 +1,412 @@
+---
+title: Deploy Silo with Docker
+description: Run and operate Silo with Docker Compose, from a single host to distributed roles.
+summary: Installation, storage, acceleration, search, topology, tuning, backups, and updates for Docker deployments.
+tags:
+  - silo
+  - deployment
+  - docker
+  - operations
+audience:
+  - operator
+last_reviewed: 2026-08-20
+related:
+  - ../../continuum-to-silo-docker-migration.md
+  - ../../release-versioning.md
+  - ../../s3-storage-setup.md
+---
+
+# Deploy Silo with Docker
+
+Docker Compose is the recommended way to run Silo. The repository's default
+stack is designed for a new single-host installation and includes:
+
+- Silo in `integrated` mode
+- PostgreSQL 18 with pgvector
+- Redis
+- FFmpeg and the Silo web application in the Silo image
+
+Start with this layout unless you already operate the supporting services or
+need dedicated delivery nodes.
+
+```mermaid
+flowchart LR
+    Clients[Web and compatible clients] --> Silo[Silo integrated server]
+    Silo --> Media[(Media files)]
+    Silo --> PostgreSQL[(PostgreSQL + pgvector)]
+    Silo --> Redis[(Redis)]
+    Silo -. optional .-> Search[(Meilisearch)]
+```
+
+## Requirements
+
+- Docker Engine or Docker Desktop
+- Docker Compose 2.24 or newer
+- Git and OpenSSL for the quick-start commands
+- An absolute host path containing your media
+
+For hardware acceleration, the host must also have the appropriate GPU driver
+and container runtime support.
+
+## Initial configuration
+
+Clone the repository and create `.env` from the maintained example:
+
+```sh
+git clone https://github.com/Silo-Server/silo-server.git
+cd silo-server
+cp .env.example .env
+chmod 600 .env
+printf '\nPOSTGRES_PASSWORD=%s\nSECRET_KEY=%s\n' \
+  "$(openssl rand -hex 24)" "$(openssl rand -base64 48)" >> .env
+```
+
+Set the host path to your media:
+
+```dotenv
+MEDIA_ROOT=/path/to/your/media
+```
+
+Then start the stack:
+
+```sh
+docker compose up -d
+```
+
+Open <http://localhost:8090> and complete onboarding. The default Compose stack
+wires the PostgreSQL and Redis connections; libraries, users, providers,
+storage, search, and playback settings are managed through the admin interface.
+
+> [!CAUTION]
+> `SECRET_KEY` is the master key for encrypted server-owned credentials. Keep it
+> secret and back it up separately from database dumps. Losing it makes stored
+> integration and storage credentials unrecoverable.
+
+The encryption design is documented in
+[Secret encryption at rest](../../architecture/secret-encryption.md).
+
+## Container image selection
+
+The default `.env.example` follows `ghcr.io/silo-server/silo-server:latest`.
+Before the first release, successful default-branch publications also receive
+an ordered `build-N` tag and a short commit-SHA tag.
+
+Use `SILO_IMAGE` to select an image:
+
+```dotenv
+SILO_IMAGE=ghcr.io/silo-server/silo-server:build-N
+```
+
+Use a commit-SHA tag or digest when a deployment or rollback target must be
+immutable. See [Release versioning](../../release-versioning.md) for the full
+tag contract.
+
+## Storage and state
+
+The deployment Compose files use host bind mounts rather than Docker-managed
+volumes. `SILO_DATA_ROOT` defaults to `/opt/silo` and contains:
+
+| Host path | Purpose |
+| --- | --- |
+| `/opt/silo/postgres` | Durable PostgreSQL data |
+| `/opt/silo/redis` | Redis persistence |
+| `/opt/silo/plugins` | Installed plugin cache |
+| `/opt/silo/compat` | Compatibility assets |
+| `/opt/silo/transcode` | Transient transcode output mounted at `/tmp/silo-transcode` |
+| `/opt/silo/catalog-seeds` | Read-only catalog seed data |
+| `/opt/silo/meilisearch` | Optional Meilisearch index |
+
+Override the base path when required:
+
+```dotenv
+SILO_DATA_ROOT=/srv/silo
+```
+
+`MEDIA_ROOT` is mounted read-only at `MEDIA_CONTAINER_ROOT`, which defaults to
+`/mnt/media`. Existing installations must preserve the in-container path stored
+in their library records.
+
+Durable application state lives in PostgreSQL. Redis holds coordination and
+cache-style data. Transcode output is local and transient. If
+`userdb.backend=sqlite` is selected, local user state is also written under
+`/var/lib/silo/userdb` and must be included in the deployment's persistence and
+backup design.
+
+The default Compose file does not persist that SQLite path. Before enabling the
+SQLite backend, add this volume to the `silo` service in a deployment override:
+
+```yaml
+services:
+  silo:
+    volumes:
+      - ${SILO_DATA_ROOT:-/opt/silo}/userdb:/var/lib/silo/userdb
+```
+
+Validate the merged Compose configuration before recreating the container.
+
+### Published ports
+
+Change host-side port variables in `.env` when a default conflicts with another
+service. The container listeners remain fixed.
+
+| Variable | Default | Purpose |
+| --- | ---: | --- |
+| `PORT` | `8090` | Main web application and API |
+| `JF_PORT` | `8096` | Jellyfin/Emby compatibility listener |
+| `ABS_PORT` | `13378` | Audiobookshelf compatibility listener |
+| `PROXY_PORT` | `8083` | Commented standalone proxy example |
+| `TRANSCODE_PORT` | `8082` | Commented standalone transcode example |
+
+> [!WARNING]
+> The application and compatibility port mappings listen on all host interfaces
+> by default and do not provide TLS themselves. Before allowing access beyond a
+> trusted local network, use a correctly configured HTTPS reverse proxy and
+> firewall, then set `SILO_PUBLIC_URL` and `SILO_TRUSTED_PROXIES` for that
+> deployment. Do not expose PostgreSQL or Redis publicly.
+
+## Hardware acceleration
+
+The default stack is CPU-only so it can start on hosts without GPU devices.
+
+### Intel or AMD VA-API and Intel Quick Sync
+
+On a Linux host with `/dev/dri`, add the VA-API overlay:
+
+```sh
+docker compose \
+  -f docker-compose.yml \
+  -f docker-compose.vaapi.yml \
+  up -d
+```
+
+To use the overlay for future Compose commands, set:
+
+```dotenv
+COMPOSE_FILE=docker-compose.yml:docker-compose.vaapi.yml
+```
+
+### NVIDIA NVENC
+
+Install the NVIDIA driver and NVIDIA Container Toolkit first, then use the
+NVIDIA overlay:
+
+```sh
+docker compose \
+  -f docker-compose.yml \
+  -f docker-compose.nvidia.yml \
+  up -d
+```
+
+To make it the default for this installation:
+
+```dotenv
+COMPOSE_FILE=docker-compose.yml:docker-compose.nvidia.yml
+NVIDIA_GPU_COUNT=1
+```
+
+Windows uses `;` instead of `:` between entries in `COMPOSE_FILE`.
+
+## Optional Meilisearch
+
+PostgreSQL full-text search works without an additional service. To make
+Meilisearch available as an optional provider:
+
+1. Generate a key and add it to `.env`:
+
+   ```sh
+   openssl rand -hex 32
+   ```
+
+   ```dotenv
+   MEILI_MASTER_KEY=replace-with-generated-value
+   ```
+
+2. Start the `search` profile:
+
+   ```sh
+   docker compose --profile search up -d
+   ```
+
+3. In **Admin > Settings > Search**, select Meilisearch, set the URL to
+   `http://meilisearch:7700`, enter the same key as the API key, test the
+   connection, and save.
+4. Restart Silo and rebuild the catalog search index from the same page.
+
+Silo continues to use PostgreSQL full-text search until Meilisearch is selected.
+
+## External PostgreSQL and Redis
+
+> [!IMPORTANT]
+> The default `docker-compose.yml` defines bundled PostgreSQL and Redis services,
+> hard-codes the Silo service's internal connection URLs, and declares health
+> dependencies on both services. Setting `DATABASE_URL` or `REDIS_URL` only in
+> `.env` does not replace that wiring.
+
+To use existing infrastructure, create a custom Compose definition or a tested
+override that does all of the following:
+
+- supplies the external `DATABASE_URL` and `REDIS_URL` to the Silo service
+- removes or replaces the bundled-service dependencies
+- omits the bundled PostgreSQL and Redis services from the deployed project
+- preserves the media, plugin, compatibility, transcode, and catalog mounts
+- preserves the same `SECRET_KEY` across every Silo role
+
+Validate the merged configuration before starting it:
+
+```sh
+docker compose -f docker-compose.yml -f your-override.yml config --quiet
+```
+
+For a serious deployment, isolating PostgreSQL on a dedicated VM or managed
+service can simplify database upgrades, tuning, and backups. Redis can remain
+local for many installations or move to shared infrastructure when that is
+already available.
+
+## Server roles and distributed deployments
+
+| Mode | Purpose |
+| --- | --- |
+| `integrated` | Recommended primary server with the API, frontend, scanners, workers, and configured local delivery. |
+| `api` | Primary/control role for a custom distributed topology; configured local transcode fallback may still be used. |
+| `proxy` | Dedicated stream and source-download delivery node. |
+| `transcode` | Dedicated HLS and prepared-download worker. |
+
+The main Compose file contains commented proxy and transcode examples. Most
+single-host installations should leave them disabled because `integrated`
+already includes proxying and transcoding.
+
+For a distributed deployment:
+
+- connect roles to the deployment's PostgreSQL and Redis infrastructure
+- use the same `SECRET_KEY` on every role
+- expose the same absolute source-media paths to processes that serve them
+- persist the configured prepared-download artifact directory on every process
+  that can prepare downloads
+- restart a role after changing its artifact path
+
+Prepared downloads can run on transcode nodes. A selected node keeps the result
+on node-local storage and exposes it through Silo's authenticated internal
+artifact API; the paired proxy relays the bytes, so the nodes do not require a
+shared artifact mount. Dedicated transcode nodes default to a protected
+directory inside the transcode volume selected at process startup.
+`download.artifact_dir` overrides that location for dedicated transcode nodes
+and the integrated/API-local fallback; mount the configured path anywhere that
+can prepare downloads. Server-wide or per-user bandwidth-limited downloads
+stay API-local so aggregate limits remain exact.
+
+The client-facing delivery contract, including capability discovery and proxy
+routes, is documented in the [Downloads API](../../downloads-api.md).
+
+## PostgreSQL auto-tuning
+
+The bundled deployment enables Silo's
+[pgtune](https://github.com/le0pard/pgtune)-style OLTP tuning by default:
+
+```yaml
+POSTGRES_TUNE: auto
+```
+
+> [!CAUTION]
+> With auto-tuning enabled, Silo uses `ALTER SYSTEM` and writes recommendations
+> to PostgreSQL's `postgresql.auto.conf`. Set `POSTGRES_TUNE=off` before startup
+> if PostgreSQL settings are managed elsewhere.
+
+Reloadable settings are applied with `pg_reload_conf()`. Restart-only settings
+are written and logged by name; apply them by restarting PostgreSQL once:
+
+```sh
+docker compose restart postgres
+```
+
+The bundled database user has the required permissions. For an external
+database, set `POSTGRES_TUNE=off` and manage tuning on the database host by
+default. If Silo is deliberately allowed to tune that server, set explicit
+`POSTGRES_TUNE_MEMORY` and `POSTGRES_TUNE_CPUS` values for the database host and
+grant the `DATABASE_URL` user permission to run `ALTER SYSTEM`; automatic host
+detection describes the Silo container, not a remote database machine.
+
+When `POSTGRES_TUNE_MEMORY=auto`, Silo uses the first trustworthy source from a
+finite Docker cgroup limit, the bundled read-only `/host/proc/meminfo` mount,
+or guarded `/proc/meminfo` detection. It reserves 25% of detected memory for
+Silo, Redis, plugins, transcodes, the operating system, and other work by
+default. Database-size classification uses
+`pg_database_size(current_database())`.
+
+| Variable | Default | Description |
+| --- | ---: | --- |
+| `POSTGRES_TUNE_PROFILE` | `oltp` | Tuning profile; only `oltp` is currently supported. |
+| `POSTGRES_TUNE_MEMORY` | `auto` | Server or container RAM, such as `8GB` or `32GB`; explicit values are used as-is. |
+| `POSTGRES_TUNE_MEMORY_BUDGET_PERCENT` | `75` | Percentage of auto-detected RAM used for PostgreSQL recommendations. |
+| `POSTGRES_TUNE_CPUS` | `auto` | CPU count used for worker recommendations. |
+| `POSTGRES_TUNE_STORAGE` | `ssd` | One of `hdd`, `ssd`, `san`, or `nvme`. |
+| `POSTGRES_TUNE_DB_SIZE` | `auto` | Automatic classification, or `less_ram`, `mid_ram`, or `greater_ram`. |
+| `POSTGRES_TUNE_CONNECTIONS` | `100` | PostgreSQL `max_connections`; raised when the Silo application pool is larger. |
+| `POSTGRES_SHM_SIZE` | `8gb` | Docker `/dev/shm` size for bundled PostgreSQL. |
+
+Turning auto-tuning off does not remove settings already written to
+`postgresql.auto.conf`. Reset those PostgreSQL parameters if the deployment
+later moves fully to a custom configuration.
+
+## Backups and updates
+
+Before an update:
+
+1. Pin or record the current image reference for rollback.
+2. Back up PostgreSQL and verify the backup can be read.
+3. Back up `.env`, especially `SECRET_KEY`, separately from the database.
+4. Preserve the effective Compose configuration and any custom overrides in a
+   restricted backup location.
+5. Review the incoming build or release for migration and compatibility notes.
+
+After selecting the intended `SILO_IMAGE`, update only the application service:
+
+```sh
+docker compose pull silo
+docker compose up -d --no-deps silo
+```
+
+Silo applies pending database migrations during startup. Allow startup to
+finish before evaluating readiness or attempting another update.
+
+Use a build tag, commit-SHA tag, or digest when reproducible rollback matters.
+Do not assume that `latest` will continue to identify the image currently
+running on the host.
+
+> [!WARNING]
+> Rolling back the Silo image does not reverse database migrations. Keep the
+> pre-update database backup and effective Compose configuration paired with the
+> previous image. Review every applied migration before deciding whether a
+> binary rollback is sufficient or a coordinated database restore is required;
+> restoring a database also discards writes made after the backup.
+
+`docker compose config` can contain resolved database credentials and
+`SECRET_KEY`. Treat its output as a secret-bearing backup: restrict its file
+permissions, never paste it into issues or logs, and redact it before sharing.
+
+After an update, verify both endpoints:
+
+```sh
+curl -fsS http://localhost:8090/api/v1/health
+curl -fsS http://localhost:8090/api/v1/ready
+```
+
+`health` reports process liveness. `ready` also checks required dependencies,
+including PostgreSQL and configured S3 storage.
+
+## Migrating from Continuum
+
+Use the conservative preflight and cutover workflow in
+[Continuum to Silo Docker Migration](../../continuum-to-silo-docker-migration.md).
+Preserve the previous in-container media path when existing library records
+store that path, and do not remove the migration backup until scanning,
+metadata, users, plugins, and playback have been verified.
+
+## Source References
+
+- [`docker-compose.yml`](../../../docker-compose.yml)
+- [`docker-compose.vaapi.yml`](../../../docker-compose.vaapi.yml)
+- [`docker-compose.nvidia.yml`](../../../docker-compose.nvidia.yml)
+- [`.env.example`](../../../.env.example)
+- [Release versioning](../../release-versioning.md)
+- [Downloads API](../../downloads-api.md)
+- [S3 storage setup](../../s3-storage-setup.md)

--- a/docs/wiki/deployment/docker.md
+++ b/docs/wiki/deployment/docker.md
@@ -319,11 +319,18 @@ docker compose restart postgres
 ```
 
 The bundled database user has the required permissions. For an external
-database, set `POSTGRES_TUNE=off` and manage tuning on the database host by
-default. If Silo is deliberately allowed to tune that server, set explicit
-`POSTGRES_TUNE_MEMORY` and `POSTGRES_TUNE_CPUS` values for the database host and
-grant the `DATABASE_URL` user permission to run `ALTER SYSTEM`; automatic host
-detection describes the Silo container, not a remote database machine.
+database, keep `POSTGRES_TUNE=off` for the application credential and manage
+tuning out of band with a separate administrative credential. Silo uses the
+`DATABASE_URL` identity for both normal operation and tuning; it does not have
+a separate tuning credential. Granting that identity `ALTER SYSTEM` permits
+server-wide configuration changes if the application credential is
+compromised.
+
+Enable external tuning only in a trusted deployment that accepts this risk. Set
+explicit `POSTGRES_TUNE_MEMORY` and `POSTGRES_TUNE_CPUS` values for the database
+host and grant the `DATABASE_URL` user permission to run `ALTER SYSTEM`;
+automatic host detection describes the Silo container, not a remote database
+machine.
 
 When `POSTGRES_TUNE_MEMORY=auto`, Silo uses the first trustworthy source from a
 finite Docker cgroup limit, the bundled read-only `/host/proc/meminfo` mount,
@@ -383,7 +390,8 @@ running on the host.
 `SECRET_KEY`. Treat its output as a secret-bearing backup: restrict its file
 permissions, never paste it into issues or logs, and redact it before sharing.
 
-After an update, verify both endpoints:
+After an update, verify both endpoints on the configured host-side `PORT`.
+Replace `8090` below when `PORT` differs from the default:
 
 ```sh
 curl -fsS http://localhost:8090/api/v1/health

--- a/docs/wiki/index.md
+++ b/docs/wiki/index.md
@@ -9,7 +9,7 @@ tags:
 audience:
   - end-user
   - operator
-last_reviewed: 2026-04-11
+last_reviewed: 2026-08-20
 related: []
 ---
 
@@ -40,7 +40,8 @@ rewriting.
 
 ## Deployment
 
-- No pages yet.
+- [Deploy Silo with Docker](deployment/docker.md) - Install and operate Silo with Docker Compose,
+  including storage, GPU acceleration, search, distributed roles, tuning, backups, and updates.
 
 ## Troubleshooting
 

--- a/web/src/hooks/queries/downloads.ts
+++ b/web/src/hooks/queries/downloads.ts
@@ -45,6 +45,7 @@ export interface DownloadCapability {
   season_download: boolean;
   series_monitoring: boolean;
   monitoring_modes?: string[];
+  proxy_delivery: boolean;
 }
 
 export function useDownloadCapability(enabled = true) {


### PR DESCRIPTION
## Problem

Scope item: N/A — focused documentation, repository-template, and client-contract alignment.

Silo's README had gradually become a product overview, installation guide, operator manual, distributed-deployment reference, tuning guide, and contribution entry point at the same time. The information was useful, but the reading order made it harder for newcomers to understand the product and start safely, while experienced operators had to work through a long landing page to find deployment details.

Some guidance had also drifted from the current implementation, Compose configuration, and CI toolchain. The contribution flow duplicated policy across several files and did not consistently guide contributors from setup through evidence, AI disclosure, and review.

## Approach

This change introduces a clearer, progressive flow:

1. Explain what Silo is, who it serves, and its current pre-release/build status.
2. Provide a concise, secure default Docker quick start.
3. Route advanced deployment and operational work to a dedicated Docker guide.
4. Route source development, API details, contribution policy, and AI guidance to their canonical documents.
5. Keep issue and pull-request templates aligned with those expectations.

The README is reduced from 439 lines to about 210 lines without discarding the detailed operational material. That material now lives in `docs/wiki/deployment/docker.md`, while the detailed proxy-delivery contract is placed with the Downloads API documentation.

The contribution documents retain the project's substantive rules while improving their order, terminology, command accuracy, and separation of concerns. AI policy remains explicit and is linked from the shorter contribution flow rather than being inconsistently repeated.

The dynamic release badge is intentionally retained so it will become active when maintainers select the first release. The README now distinguishes ordered `build-N` images and commit identifiers from future SemVer releases in the meantime.

## Advantages

- Gives prospective users a faster, more professional explanation of Silo and its capabilities.
- Makes the default installation path easier to follow while moving advanced choices out of the critical path.
- Preserves operational depth with clearer guidance for secrets, TLS exposure, SQLite persistence, GPU access, external services, migrations, backups, updates, and rollback.
- Aligns documentation with the current code, Compose behavior, supported media types, server roles, Jellyfin compatibility defaults, pnpm toolchain, and CI checks.
- Reduces duplicated guidance and gives each audience a clearer canonical destination.
- Makes contribution evidence, AI disclosure, issue intake, and review expectations consistent across repository templates and policy documents.
- Lowers future maintenance cost because product, operator, developer, API, and contribution guidance are no longer competing within one document.

## Scope and risk

This is primarily a documentation and repository-template change. It also adds the existing API's required `proxy_delivery` boolean to the maintained TypeScript response interface so the client contract matches the server and new documentation. It does not change runtime logic, Compose services, migrations, versions, releases, tags, or deployment configuration.

## Contributor ownership

@blurbery led and owns this documentation redesign: defining the audience and desired reading flow, identifying presentation and policy requirements, reviewing the original material and the rendered result on the fork, making the final editorial decisions, and approving the complete submission. This included the decisions to preserve the release badge, retain the contribution rules that matter, and move detail into focused documents without losing it.

Most product and editorial judgment, including the final review, came from @blurbery. AI assistance was used for implementation support, repository auditing, drafting, consistency checks, and adversarial review.

## Testing

- `git diff --check origin/main...HEAD` — passed.
- `make verify-local-paths` — passed.
- Parsed both changed GitHub issue-form YAML files and checked their structure — passed.
- Resolved changed local Markdown links and anchors — passed.
- Parsed the new wiki front matter and checked Markdown fences — passed.
- Compared the original 11 documentation/template paths with the version reviewed on `blurbery/silo-server:main`; the only pre-review follow-up was the explicitly requested top-level `Support Silo` link to the unchanged sponsorship section.
- Asserted that the TypeScript `DownloadCapability` field matches the required server response and that the revised disclosure, port, and tuning guidance contains the reviewed constraints — passed.
- Reviewed the final scope and credential/local-path patterns — no runtime-logic changes, generated files, local paths, or credentials found.
- Initial upstream CI before the review fixes: Go, Web, and Docs hygiene passed.

The full Web suite was not rerun locally because this clean checkout has no installed Web dependencies and its ambient Node/pnpm versions differ from the repository-pinned CI toolchain. Upstream CI is the authoritative post-review integration gate. The first review-fix run passed for commit 99ba175: Go, Web, and Docs hygiene. The final one-line disclosure clarification in 34a38e3 passed the same gates.

## AI Disclosure

- **Tool(s):** OpenAI Codex (desktop)
- **Model(s):** GPT-5 (Codex; the exact deployment identifier was not exposed to the agent in this session)
- **Involvement:** AI-assisted. Codex helped audit the repository against the documentation, implement the approved structure, check cross-document consistency, and prepare the contribution under @blurbery's direction and review.
- **Adversarial review:** Three independent Codex review passes checked factual accuracy against the code, Compose files, CI, and Make targets; preservation and relocation of existing guidance; command safety; links and forms; and contribution-policy integrity. CodeRabbit initially raised four actionable threads plus one security nit, representing four underlying issues: disclosure-field clarity, the missing TypeScript `proxy_delivery` field, configurable health-check ports, and least-privilege external PostgreSQL tuning. All were validated and fixed in `99ba175`; the two proxy-delivery threads share the same contract fix. After those fixes, its final-tree review found one additional minor template issue: the prompt omitted review scope and method. That was fixed in 34a38e3. The release badge's pre-release state was reviewed and intentionally retained pending the maintainers' first release selection.

## Checklist

- [x] The complete diff received independent adversarial review, summarized above.
- [x] CodeRabbit's valid findings were addressed and documented.
- [x] Documentation-specific validation, focused contract assertions, and repository path checks pass.
- [x] The rendered fork version was reviewed and approved by @blurbery.
- [x] The change remains focused on documentation flow and the directly related client-contract alignment, with no production behavior change.
- [x] Post-review upstream CI passed for commit 99ba175: Go, Web, and Docs hygiene.
- [x] Final upstream CI passed for commit 34a38e3: Go, Web, and Docs hygiene.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Reorganized the README with streamlined quick-start instructions, updated feature information, and refreshed documentation links.
  - Added comprehensive Docker deployment guidance covering storage, acceleration, scaling, backups, updates, and health checks.
  - Expanded download API documentation with proxy delivery capabilities, behavior details, and new proxy endpoints.
  - Updated development, contribution, issue-reporting, and AI-assistance guidance.
  - Added configuration notes for listeners, database setup, secrets, and standalone proxy/transcode modes.
  - Documented the download capability information required to support proxy delivery.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->



