### PR TITLE
fix(metadata): make artwork recovery explicit

### DIFF
--- a/cmd/silo/main.go
+++ b/cmd/silo/main.go
@@ -2140,10 +2140,10 @@ func main() {
 		}
 		if deps.S3Public != nil {
 			identity := tasks.ArtworkStorageIdentity(cfg.S3.Public.Endpoint, cfg.S3.Public.Bucket, cfg.S3.Public.KeyPrefix)
-			// Seed the fingerprint on first boot so an unchanged storage
-			// identity never triggers a sweep. On the boot after a provider
-			// change the stored (old) identity survives this call and the
-			// startup trigger runs the reconcile.
+			// Seed the fingerprint on first boot. After a provider change the
+			// stored (old) identity survives this call, so the startup preflight
+			// can warn without mutating artwork; an administrator must migrate
+			// objects and run the reconcile task explicitly.
 			if _, err := settingsRepo.SetIfAbsent(appCtx, tasks.ArtworkStorageIdentityKey, identity); err != nil {
 				slog.Warn("artwork reconcile: seeding storage identity failed", "error", err)
 			}

--- a/cmd/silo/main.go
+++ b/cmd/silo/main.go
@@ -2137,6 +2137,7 @@ func main() {
 		}
 		if metadataImageCacheProcessor != nil {
 			taskMgr.Register(tasks.NewCacheMetadataImagesTask(metadataImageCacheProcessor))
+			taskMgr.Register(tasks.NewBackfillMetadataImagesTask(metadataImageCacheProcessor))
 		}
 		if deps.S3Public != nil {
 			identity := tasks.ArtworkStorageIdentity(cfg.S3.Public.Endpoint, cfg.S3.Public.Bucket, cfg.S3.Public.KeyPrefix)

--- a/internal/api/handlers/admin.go
+++ b/internal/api/handlers/admin.go
@@ -1259,6 +1259,21 @@ func (h *AdminHandler) HandleUpdateItemMetadata(w http.ResponseWriter, r *http.R
 // encryption can never drift apart. See catalog.SensitiveSettingKeys.
 var sensitiveSettingKeys = catalog.SensitiveSettingKeys
 
+// machineManagedSettingKeys contains durable internal state that shares the
+// server_settings store but is not part of the administrator settings API.
+var machineManagedSettingKeys = map[string]bool{
+	config.ArtworkStorageReconcileCheckpointKey: true,
+}
+
+func redactAdminSettings(values map[string]string) {
+	for key := range sensitiveSettingKeys {
+		delete(values, key)
+	}
+	for key := range machineManagedSettingKeys {
+		delete(values, key)
+	}
+}
+
 // HandleGetSettings handles GET /admin/settings.
 func (h *AdminHandler) HandleGetSettings(w http.ResponseWriter, r *http.Request) {
 	if h.SettingsRepo == nil {
@@ -1270,9 +1285,7 @@ func (h *AdminHandler) HandleGetSettings(w http.ResponseWriter, r *http.Request)
 		writeError(w, http.StatusInternalServerError, "internal_error", "Failed to load settings")
 		return
 	}
-	for key := range sensitiveSettingKeys {
-		delete(all, key)
-	}
+	redactAdminSettings(all)
 	writeJSON(w, http.StatusOK, all)
 }
 
@@ -1290,9 +1303,7 @@ func (h *AdminHandler) HandleGetEffectiveSettings(w http.ResponseWriter, r *http
 		return
 	}
 	effective := h.effectiveAdminSettings(all)
-	for key := range sensitiveSettingKeys {
-		delete(effective, key)
-	}
+	redactAdminSettings(effective)
 	writeJSON(w, http.StatusOK, effective)
 }
 
@@ -1867,7 +1878,7 @@ func (h *AdminHandler) HandleGetSetting(w http.ResponseWriter, r *http.Request) 
 		return
 	}
 
-	if sensitiveSettingKeys[key] {
+	if sensitiveSettingKeys[key] || machineManagedSettingKeys[key] {
 		writeError(w, http.StatusNotFound, "not_found", "Setting not found")
 		return
 	}
@@ -2145,6 +2156,10 @@ func (h *AdminHandler) HandleUpdateSettings(w http.ResponseWriter, r *http.Reque
 			writeError(w, http.StatusBadRequest, "bad_request", "Setting key is required")
 			return
 		}
+		if machineManagedSettingKeys[key] {
+			writeError(w, http.StatusBadRequest, "bad_request", key+" is managed internally")
+			return
+		}
 		if h.BootstrapSensitiveConfigured[key] {
 			writeError(w, http.StatusBadRequest, "managed_by_environment", key+" is managed by an environment variable")
 			return
@@ -2244,6 +2259,10 @@ func (h *AdminHandler) HandleUpdateSetting(w http.ResponseWriter, r *http.Reques
 	key := chi.URLParam(r, "key")
 	if key == "" {
 		writeError(w, http.StatusBadRequest, "bad_request", "Setting key is required")
+		return
+	}
+	if machineManagedSettingKeys[key] {
+		writeError(w, http.StatusBadRequest, "bad_request", key+" is managed internally")
 		return
 	}
 	if h.BootstrapSensitiveConfigured[key] {

--- a/internal/api/handlers/admin_settings_checks_test.go
+++ b/internal/api/handlers/admin_settings_checks_test.go
@@ -99,6 +99,121 @@ func TestAdminGetEffectiveSettingsReturnsRuntimeDefaultsAndRedactsSecrets(t *tes
 	}
 }
 
+func TestAdminSettingsReadsHideMachineManagedCheckpoint(t *testing.T) {
+	const checkpoint = `{"baseline_identity":"old","target_identity":"new"}`
+	settings := &fakeServerSettingsStore{values: map[string]string{
+		"server.log_level":                          "debug",
+		config.ArtworkStorageReconcileCheckpointKey: checkpoint,
+	}}
+	handler := &AdminHandler{SettingsRepo: settings}
+
+	for _, tc := range []struct {
+		name   string
+		handle func(http.ResponseWriter, *http.Request)
+		path   string
+	}{
+		{name: "raw settings", handle: handler.HandleGetSettings, path: "/admin/settings"},
+		{name: "effective settings", handle: handler.HandleGetEffectiveSettings, path: "/admin/settings/effective"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			rec := httptest.NewRecorder()
+			tc.handle(rec, httptest.NewRequest(http.MethodGet, tc.path, nil))
+
+			if rec.Code != http.StatusOK {
+				t.Fatalf("status = %d, want 200; body=%s", rec.Code, rec.Body.String())
+			}
+			var values map[string]string
+			if err := json.NewDecoder(rec.Body).Decode(&values); err != nil {
+				t.Fatalf("decode response: %v", err)
+			}
+			if _, leaked := values[config.ArtworkStorageReconcileCheckpointKey]; leaked {
+				t.Fatalf("response leaked machine-managed checkpoint: %#v", values)
+			}
+			if values["server.log_level"] != "debug" {
+				t.Fatalf("server.log_level = %q, want debug", values["server.log_level"])
+			}
+		})
+	}
+
+	t.Run("single setting", func(t *testing.T) {
+		req := httptest.NewRequest(http.MethodGet, "/admin/settings/"+config.ArtworkStorageReconcileCheckpointKey, nil)
+		req = withChiParam(req, "key", config.ArtworkStorageReconcileCheckpointKey)
+		rec := httptest.NewRecorder()
+
+		handler.HandleGetSetting(rec, req)
+
+		if rec.Code != http.StatusNotFound {
+			t.Fatalf("status = %d, want 404; body=%s", rec.Code, rec.Body.String())
+		}
+		if strings.Contains(rec.Body.String(), checkpoint) {
+			t.Fatalf("response leaked machine-managed checkpoint: %s", rec.Body.String())
+		}
+	})
+}
+
+func TestAdminSettingsWritesRejectMachineManagedCheckpoint(t *testing.T) {
+	const (
+		storedCheckpoint      = `{"baseline_identity":"old","target_identity":"new"}`
+		replacementCheckpoint = `{"baseline_identity":"wrong","target_identity":"wrong"}`
+	)
+
+	t.Run("batch settings", func(t *testing.T) {
+		settings := &fakeServerSettingsStore{values: map[string]string{
+			config.ArtworkStorageReconcileCheckpointKey: storedCheckpoint,
+		}}
+		handler := &AdminHandler{SettingsRepo: settings}
+		body, err := json.Marshal(updateSettingsRequest{Values: map[string]string{
+			config.ArtworkStorageReconcileCheckpointKey: replacementCheckpoint,
+		}})
+		if err != nil {
+			t.Fatalf("marshal request: %v", err)
+		}
+		rec := httptest.NewRecorder()
+
+		handler.HandleUpdateSettings(rec, httptest.NewRequest(http.MethodPut, "/admin/settings", bytes.NewReader(body)))
+
+		if rec.Code != http.StatusBadRequest {
+			t.Fatalf("status = %d, want 400; body=%s", rec.Code, rec.Body.String())
+		}
+		if got := settings.values[config.ArtworkStorageReconcileCheckpointKey]; got != storedCheckpoint {
+			t.Fatalf("checkpoint = %q, want unchanged %q", got, storedCheckpoint)
+		}
+		if settings.atomicCalls != 0 {
+			t.Fatalf("atomic update calls = %d, want 0", settings.atomicCalls)
+		}
+	})
+
+	t.Run("single setting", func(t *testing.T) {
+		settings := &fakeServerSettingsStore{values: map[string]string{
+			config.ArtworkStorageReconcileCheckpointKey: storedCheckpoint,
+		}}
+		handler := &AdminHandler{SettingsRepo: settings}
+		body, err := json.Marshal(updateSettingRequest{Value: replacementCheckpoint})
+		if err != nil {
+			t.Fatalf("marshal request: %v", err)
+		}
+		req := httptest.NewRequest(
+			http.MethodPut,
+			"/admin/settings/"+config.ArtworkStorageReconcileCheckpointKey,
+			bytes.NewReader(body),
+		)
+		req = withChiParam(req, "key", config.ArtworkStorageReconcileCheckpointKey)
+		rec := httptest.NewRecorder()
+
+		handler.HandleUpdateSetting(rec, req)
+
+		if rec.Code != http.StatusBadRequest {
+			t.Fatalf("status = %d, want 400; body=%s", rec.Code, rec.Body.String())
+		}
+		if got := settings.values[config.ArtworkStorageReconcileCheckpointKey]; got != storedCheckpoint {
+			t.Fatalf("checkpoint = %q, want unchanged %q", got, storedCheckpoint)
+		}
+		if settings.atomicCalls != 0 {
+			t.Fatalf("atomic update calls = %d, want 0", settings.atomicCalls)
+		}
+	})
+}
+
 func TestAdminGetEffectiveSettingsUsesEnvironmentManagedRuntimeValue(t *testing.T) {
 	settings := &fakeServerSettingsStore{values: map[string]string{
 		"clientip.trusted_proxies": "10.0.0.0/8",

--- a/internal/api/handlers/tasks.go
+++ b/internal/api/handlers/tasks.go
@@ -123,6 +123,10 @@ func (h *TaskHandler) HandleUpdateTriggers(w http.ResponseWriter, r *http.Reques
 			http.Error(w, `{"error":"task not found"}`, http.StatusNotFound)
 			return
 		}
+		if errors.Is(err, taskmanager.ErrTaskManualOnly) {
+			http.Error(w, `{"error":"manual-only task does not accept scheduled triggers"}`, http.StatusBadRequest)
+			return
+		}
 		http.Error(w, `{"error":"internal error"}`, http.StatusInternalServerError)
 		return
 	}

--- a/internal/config/admin_settings.go
+++ b/internal/config/admin_settings.go
@@ -16,6 +16,11 @@ import (
 const cloudflareURLMode = "cloudflare_token"
 const chapterThumbnailSoftwareToneMapKey = "playback.chapter_thumbnail_software_tone_map_enabled"
 
+// ArtworkStorageReconcileCheckpointKey is machine-managed task state. It is
+// stored alongside server settings for durability but must not be exposed or
+// edited through the administrator settings API.
+const ArtworkStorageReconcileCheckpointKey = "s3.public_storage_reconcile_checkpoint"
+
 // adminSettingDefaults is the effective value shown by the Admin UI when no
 // row exists in server_settings. Keep these values aligned with the runtime
 // readers that own each setting. The UI must never invent a second set of

--- a/internal/metadata/artwork_reconcile.go
+++ b/internal/metadata/artwork_reconcile.go
@@ -50,7 +50,7 @@ type ArtworkReconcileStats struct {
 	SampleMissing int    `json:"sample_missing"`
 	Checked       int    `json:"checked"`
 	Verified      int    `json:"verified"`
-	Requeued      int    `json:"requeued"` // reset to provider source; re-cached by the image cache pipeline
+	Requeued      int    `json:"requeued"` // reset to provider source; an explicit backfill may cache it again
 	Cleared       int    `json:"cleared"`  // no re-downloadable source; refilled by scans/enrichment or re-uploaded by an admin
 	Errors        int    `json:"errors"`
 	// SweepErrors is the subset of Errors from the sweep itself (skipped
@@ -724,9 +724,9 @@ func (r *ArtworkCacheReconciler) objectExistsWithRetry(ctx context.Context, buck
 }
 
 // bulkResetSurface resets every cached row without per-row verification. Rows
-// with a re-downloadable provider source go back to that source (the enqueue
-// loop re-caches them); rows without one are cleared so their owning pipeline
-// can refill them.
+// with a re-downloadable provider source go back to that source so an explicit
+// manual backfill can cache them again. Rows without one are cleared so their
+// owning pipeline can refill them.
 func (r *ArtworkCacheReconciler) bulkResetSurface(ctx context.Context, s artworkSweepSurface, stats *ArtworkReconcileStats) error {
 	if s.sourceCol != "" {
 		requeue := fmt.Sprintf(

--- a/internal/metadata/artwork_reconcile.go
+++ b/internal/metadata/artwork_reconcile.go
@@ -410,6 +410,38 @@ func (r *ArtworkCacheReconciler) runVerifySweep(
 	save func(ArtworkReconcileCheckpoint) error,
 	progress func(percent float64, message string),
 ) (ArtworkReconcileStats, error) {
+	return runArtworkVerifySweep(ctx, r, surfaces, checkpoint, save, progress)
+}
+
+// artworkVerifySweeper separates the checkpoint state machine from its
+// database and object-storage work. Keeping that boundary small makes restart
+// behavior testable without a live PostgreSQL database.
+type artworkVerifySweeper interface {
+	sweepSurfaceFrom(
+		context.Context,
+		artworkSweepSurface,
+		*ArtworkReconcileStats,
+		[]string,
+		int,
+		func([]string, int, bool) error,
+	) error
+	sweepChapterThumbnailsFrom(
+		context.Context,
+		*ArtworkReconcileStats,
+		int64,
+		int,
+		func(int64, int, bool) error,
+	) error
+}
+
+func runArtworkVerifySweep(
+	ctx context.Context,
+	sweeper artworkVerifySweeper,
+	surfaces []artworkSweepSurface,
+	checkpoint ArtworkReconcileCheckpoint,
+	save func(ArtworkReconcileCheckpoint) error,
+	progress func(percent float64, message string),
+) (ArtworkReconcileStats, error) {
 	stats := checkpoint.Stats
 	total := checkpoint.ChapterTotal
 	for _, count := range checkpoint.Totals {
@@ -421,7 +453,6 @@ func (r *ArtworkCacheReconciler) runVerifySweep(
 	}
 
 	runtimeDone := checkpoint.Done
-	checkpointBlocked := false
 	startSurface := checkpoint.SurfaceIndex
 	for i := startSurface; i < len(surfaces); i++ {
 		s := surfaces[i]
@@ -433,9 +464,6 @@ func (r *ArtworkCacheReconciler) runVerifySweep(
 		}
 		if checkpoint.Totals[i] == 0 {
 			runtimeDone += checkpoint.Totals[i]
-			if checkpointBlocked {
-				continue
-			}
 			checkpoint.SurfaceIndex = i + 1
 			checkpoint.SurfaceCursor = nil
 			checkpoint.SurfaceDone = 0
@@ -451,14 +479,12 @@ func (r *ArtworkCacheReconciler) runVerifySweep(
 			pct := 5 + 90*float64(runtimeDone+surfaceDone)/float64(total)
 			progress(pct, fmt.Sprintf("Resuming %s (%d/%d overall)", s.name, runtimeDone+surfaceDone, total))
 		}
-		surfaceStartErrors := stats.SweepErrors
-		if err := r.sweepSurfaceFrom(ctx, s, &stats, cursor, surfaceDone,
+		if err := sweeper.sweepSurfaceFrom(ctx, s, &stats, cursor, surfaceDone,
 			func(batchCursor []string, batchDone int, batchCheckpointable bool) error {
 				pct := 5 + 90*float64(runtimeDone+batchDone)/float64(total)
 				progress(pct, fmt.Sprintf("Verifying %s (%d/%d overall)", s.name, runtimeDone+batchDone, total))
-				if !batchCheckpointable || checkpointBlocked {
-					checkpointBlocked = true
-					return nil
+				if !batchCheckpointable {
+					return fmt.Errorf("storage errors in %s batch; stopping at the last saved checkpoint", s.name)
 				}
 				checkpoint.SurfaceIndex = i
 				checkpoint.SurfaceCursor = append(checkpoint.SurfaceCursor[:0], batchCursor...)
@@ -472,13 +498,7 @@ func (r *ArtworkCacheReconciler) runVerifySweep(
 			}); err != nil {
 			return stats, err
 		}
-		if stats.SweepErrors > surfaceStartErrors {
-			checkpointBlocked = true
-		}
 		runtimeDone += checkpoint.Totals[i]
-		if checkpointBlocked {
-			continue
-		}
 		checkpoint.SurfaceIndex = i + 1
 		checkpoint.SurfaceCursor = nil
 		checkpoint.SurfaceDone = 0
@@ -500,13 +520,12 @@ func (r *ArtworkCacheReconciler) runVerifySweep(
 			pct := 5 + 90*float64(runtimeDone+chapterDone)/float64(total)
 			progress(pct, fmt.Sprintf("Resuming chapter thumbnails (%d/%d overall)", runtimeDone+chapterDone, total))
 		}
-		if err := r.sweepChapterThumbnailsFrom(ctx, &stats, chapterCursor, chapterDone,
+		if err := sweeper.sweepChapterThumbnailsFrom(ctx, &stats, chapterCursor, chapterDone,
 			func(batchCursor int64, batchDone int, batchCheckpointable bool) error {
 				pct := 5 + 90*float64(runtimeDone+batchDone)/float64(total)
 				progress(pct, fmt.Sprintf("Verifying chapter thumbnails (%d/%d overall)", runtimeDone+batchDone, total))
-				if !batchCheckpointable || checkpointBlocked {
-					checkpointBlocked = true
-					return nil
+				if !batchCheckpointable {
+					return fmt.Errorf("storage errors in chapter-thumbnail batch; stopping at the last saved checkpoint")
 				}
 				checkpoint.SurfaceIndex = len(surfaces)
 				checkpoint.SurfaceCursor = nil
@@ -523,14 +542,12 @@ func (r *ArtworkCacheReconciler) runVerifySweep(
 			return stats, err
 		}
 	}
-	if !checkpointBlocked {
-		checkpoint.SurfaceIndex = len(surfaces) + 1
-		checkpoint.Done = runtimeDone
-		checkpoint.Finished = true
-		checkpoint.Stats = stats
-		if err := saveArtworkReconcileCheckpoint(save, checkpoint); err != nil {
-			return stats, fmt.Errorf("artwork reconcile: saving completed checkpoint: %w", err)
-		}
+	checkpoint.SurfaceIndex = len(surfaces) + 1
+	checkpoint.Done = runtimeDone
+	checkpoint.Finished = true
+	checkpoint.Stats = stats
+	if err := saveArtworkReconcileCheckpoint(save, checkpoint); err != nil {
+		return stats, fmt.Errorf("artwork reconcile: saving completed checkpoint: %w", err)
 	}
 	return stats, nil
 }

--- a/internal/metadata/artwork_reconcile.go
+++ b/internal/metadata/artwork_reconcile.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"log/slog"
+	"strconv"
 	"strings"
 	"sync"
 	"time"
@@ -59,11 +60,104 @@ type ArtworkReconcileStats struct {
 	SweepErrors int `json:"sweep_errors"`
 }
 
+// Artwork reconcile modes are serialized in task result data and checkpoints.
+const (
+	ArtworkReconcileModeVerify    = "verify"
+	ArtworkReconcileModeBulkReset = "bulk_reset"
+
+	artworkReconcileCheckpointVersion = 1
+)
+
+// ArtworkReconcileCheckpoint is the durable position of a verify-mode sweep.
+// It is safe to persist after a batch because all row repairs in that batch
+// have already completed. Replaying the previous checkpoint after a crash is
+// harmless: object checks and guarded updates are idempotent.
+type ArtworkReconcileCheckpoint struct {
+	Version       int                   `json:"version"`
+	Totals        []int                 `json:"totals"`
+	ChapterTotal  int                   `json:"chapter_total"`
+	SurfaceIndex  int                   `json:"surface_index"`
+	SurfaceCursor []string              `json:"surface_cursor,omitempty"`
+	SurfaceDone   int                   `json:"surface_done"`
+	Done          int                   `json:"done"`
+	ChapterCursor int64                 `json:"chapter_cursor"`
+	ChapterDone   int                   `json:"chapter_done"`
+	Finished      bool                  `json:"finished"`
+	Stats         ArtworkReconcileStats `json:"stats"`
+}
+
+func (c *ArtworkReconcileCheckpoint) valid(surfaceCount int) bool {
+	if c == nil || c.Version != artworkReconcileCheckpointVersion || c.Stats.Mode != ArtworkReconcileModeVerify {
+		return false
+	}
+	if len(c.Totals) != surfaceCount || c.SurfaceIndex < 0 || c.SurfaceIndex > surfaceCount+1 {
+		return false
+	}
+	for _, total := range c.Totals {
+		if total < 0 {
+			return false
+		}
+	}
+	if c.Done < 0 || c.SurfaceDone < 0 || c.ChapterDone < 0 || c.ChapterTotal < 0 || c.ChapterCursor < 0 {
+		return false
+	}
+	if c.Finished != (c.SurfaceIndex == surfaceCount+1) {
+		return false
+	}
+	if c.SurfaceIndex < surfaceCount && len(c.SurfaceCursor) > 0 && len(c.SurfaceCursor) != len(artworkSweepSurfaces()[c.SurfaceIndex].keyCols) {
+		return false
+	}
+	return true
+}
+
+// Complete reports whether a checkpoint covers every regular surface and the
+// chapter-thumbnail pass.
+func (c ArtworkReconcileCheckpoint) Complete() bool { return c.Finished }
+
 // artworkSweepSurface describes one cached-path column the reconciler sweeps.
+type artworkSweepKeyKind uint8
+
+const (
+	artworkSweepKeyText artworkSweepKeyKind = iota
+	artworkSweepKeyInt32
+	artworkSweepKeyInt64
+)
+
+type artworkSweepKey struct {
+	column string
+	kind   artworkSweepKeyKind
+}
+
+func textSweepKey(column string) artworkSweepKey {
+	return artworkSweepKey{column: column, kind: artworkSweepKeyText}
+}
+
+func int32SweepKey(column string) artworkSweepKey {
+	return artworkSweepKey{column: column, kind: artworkSweepKeyInt32}
+}
+
+func int64SweepKey(column string) artworkSweepKey {
+	return artworkSweepKey{column: column, kind: artworkSweepKeyInt64}
+}
+
+func (k artworkSweepKey) parse(raw string) (any, error) {
+	switch k.kind {
+	case artworkSweepKeyText:
+		return raw, nil
+	case artworkSweepKeyInt32:
+		value, err := strconv.ParseInt(raw, 10, 32)
+		return int32(value), err
+	case artworkSweepKeyInt64:
+		return strconv.ParseInt(raw, 10, 64)
+	default:
+		return nil, fmt.Errorf("unknown artwork sweep key kind %d", k.kind)
+	}
+}
+
 type artworkSweepSurface struct {
 	name    string
 	table   string
-	keyCols []string // pagination key expressions; must form a unique order
+	keyCols []artworkSweepKey // native indexed columns; must form a unique order
 	pathCol string
 	// sourceCol holds the original source the row can be reset to. Empty for
 	// surfaces without a re-downloadable source; their rows are always cleared.
@@ -76,6 +170,40 @@ type artworkSweepSurface struct {
 	// Used for small tables holding admin/user uploads, where a blind reset
 	// would discard the last pointer to an object that survived migration.
 	alwaysVerify bool
+}
+
+func (s artworkSweepSurface) keyColumnNames() []string {
+	columns := make([]string, len(s.keyCols))
+	for i, key := range s.keyCols {
+		columns[i] = key.column
+	}
+	return columns
+}
+
+func (s artworkSweepSurface) keySelectExpressions() []string {
+	expressions := make([]string, len(s.keyCols))
+	for i, key := range s.keyCols {
+		// Cursors are serialized as strings so they can also be persisted by
+		// callers. The native column remains untouched in WHERE / ORDER BY,
+		// preserving primary-key index scans for numeric identifiers.
+		expressions[i] = fmt.Sprintf("(%s)::text", key.column)
+	}
+	return expressions
+}
+
+func (s artworkSweepSurface) parseKeys(raw []string) ([]any, error) {
+	if len(raw) != len(s.keyCols) {
+		return nil, fmt.Errorf("got %d cursor values, want %d", len(raw), len(s.keyCols))
+	}
+	values := make([]any, len(raw))
+	for i, value := range raw {
+		parsed, err := s.keyCols[i].parse(value)
+		if err != nil {
+			return nil, fmt.Errorf("parsing %s cursor %q: %w", s.keyCols[i].column, value, err)
+		}
+		values[i] = parsed
+	}
+	return values, nil
 }
 
 func (s artworkSweepSurface) cachedPredicate() string {
@@ -111,6 +239,15 @@ func (s artworkSweepSurface) resetSet() string {
 // Chapter thumbnails (JSONB on media_files) and branding assets
 // (server_settings refs) have bespoke sweeps and are not listed here.
 func artworkSweepSurfaces() []artworkSweepSurface {
+	const (
+		mediaItemsTable             = "media_items"
+		mediaItemLocalizationsTable = "media_item_localizations"
+		peopleTable                 = "people"
+		posterPathColumn            = "poster_path"
+		posterSourcePathColumn      = "poster_source_path"
+		backdropSourcePathColumn    = "backdrop_source_path"
+		logoSourcePathColumn        = "logo_source_path"
+	)
 	itemClear := func(pathCol string) string {
 		return fmt.Sprintf(`%s = '', last_refreshed = NULL, updated_at = NOW()`, pathCol)
 	}
@@ -118,26 +255,26 @@ func artworkSweepSurfaces() []artworkSweepSurface {
 		return fmt.Sprintf(`%s = '', updated_at = NOW()`, pathCol)
 	}
 	return []artworkSweepSurface{
-		{name: "item posters", table: "media_items", keyCols: []string{"content_id"}, pathCol: "poster_path", sourceCol: "poster_source_path", clearSet: itemClear("poster_path")},
-		{name: "item backdrops", table: "media_items", keyCols: []string{"content_id"}, pathCol: "backdrop_path", sourceCol: "backdrop_source_path", clearSet: itemClear("backdrop_path")},
-		{name: "item logos", table: "media_items", keyCols: []string{"content_id"}, pathCol: "logo_path", sourceCol: "logo_source_path", clearSet: itemClear("logo_path")},
-		{name: "localized item posters", table: "media_item_localizations", keyCols: []string{"content_id", "language"}, pathCol: "poster_path", sourceCol: "poster_source_path", clearSet: plainClear("poster_path")},
-		{name: "localized item backdrops", table: "media_item_localizations", keyCols: []string{"content_id", "language"}, pathCol: "backdrop_path", sourceCol: "backdrop_source_path", clearSet: plainClear("backdrop_path")},
-		{name: "localized item logos", table: "media_item_localizations", keyCols: []string{"content_id", "language"}, pathCol: "logo_path", sourceCol: "logo_source_path", clearSet: plainClear("logo_path")},
-		{name: "season posters", table: "seasons", keyCols: []string{"content_id"}, pathCol: "poster_path", sourceCol: "poster_source_path", clearSet: plainClear("poster_path")},
-		{name: "localized season posters", table: "season_localizations", keyCols: []string{"season_content_id", "language"}, pathCol: "poster_path", sourceCol: "poster_source_path", clearSet: plainClear("poster_path")},
-		{name: "episode stills", table: "episodes", keyCols: []string{"content_id"}, pathCol: "still_path", sourceCol: "still_source_path", clearSet: plainClear("still_path")},
-		{name: "person photos", table: "people", keyCols: []string{"id::text"}, pathCol: "photo_path", sourceCol: "photo_source_path", clearSet: plainClear("photo_path")},
+		{name: "item posters", table: mediaItemsTable, keyCols: []artworkSweepKey{textSweepKey("content_id")}, pathCol: posterPathColumn, sourceCol: posterSourcePathColumn, clearSet: itemClear(posterPathColumn)},
+		{name: "item backdrops", table: mediaItemsTable, keyCols: []artworkSweepKey{textSweepKey("content_id")}, pathCol: "backdrop_path", sourceCol: backdropSourcePathColumn, clearSet: itemClear("backdrop_path")},
+		{name: "item logos", table: mediaItemsTable, keyCols: []artworkSweepKey{textSweepKey("content_id")}, pathCol: "logo_path", sourceCol: logoSourcePathColumn, clearSet: itemClear("logo_path")},
+		{name: "localized item posters", table: mediaItemLocalizationsTable, keyCols: []artworkSweepKey{textSweepKey("content_id"), textSweepKey("language")}, pathCol: posterPathColumn, sourceCol: posterSourcePathColumn, clearSet: plainClear(posterPathColumn)},
+		{name: "localized item backdrops", table: mediaItemLocalizationsTable, keyCols: []artworkSweepKey{textSweepKey("content_id"), textSweepKey("language")}, pathCol: "backdrop_path", sourceCol: backdropSourcePathColumn, clearSet: plainClear("backdrop_path")},
+		{name: "localized item logos", table: mediaItemLocalizationsTable, keyCols: []artworkSweepKey{textSweepKey("content_id"), textSweepKey("language")}, pathCol: "logo_path", sourceCol: logoSourcePathColumn, clearSet: plainClear("logo_path")},
+		{name: "season posters", table: "seasons", keyCols: []artworkSweepKey{textSweepKey("content_id")}, pathCol: posterPathColumn, sourceCol: posterSourcePathColumn, clearSet: plainClear(posterPathColumn)},
+		{name: "localized season posters", table: "season_localizations", keyCols: []artworkSweepKey{textSweepKey("season_content_id"), textSweepKey("language")}, pathCol: posterPathColumn, sourceCol: posterSourcePathColumn, clearSet: plainClear(posterPathColumn)},
+		{name: "episode stills", table: "episodes", keyCols: []artworkSweepKey{textSweepKey("content_id")}, pathCol: "still_path", sourceCol: "still_source_path", clearSet: plainClear("still_path")},
+		{name: "person photos", table: peopleTable, keyCols: []artworkSweepKey{int64SweepKey("id")}, pathCol: "photo_path", sourceCol: "photo_source_path", clearSet: plainClear("photo_path")},
 
 		// Admin/user uploads: no re-downloadable source. Clearing falls back
 		// to the generated collage (admin collections), the generated poster
 		// (user collections), or the default tile (library posters); admins
 		// re-upload anything they want back. alwaysVerify protects surviving
 		// uploads from blind bulk resets.
-		{name: "collection posters", table: "library_collections", keyCols: []string{"id"}, pathCol: "poster_url", clearSet: `poster_url = '', poster_thumbhash = '', poster_auto_generated = FALSE, poster_from_template = FALSE, updated_at = NOW()`, alwaysVerify: true},
-		{name: "collection backdrops", table: "library_collections", keyCols: []string{"id"}, pathCol: "backdrop_url", clearSet: `backdrop_url = '', backdrop_thumbhash = '', updated_at = NOW()`, alwaysVerify: true},
-		{name: "user collection posters", table: "user_personal_collections", keyCols: []string{"id"}, pathCol: "poster_url", clearSet: `poster_url = '', poster_thumbhash = '', updated_at = NOW()`, alwaysVerify: true},
-		{name: "library posters", table: "media_folders", keyCols: []string{"id::text"}, pathCol: "poster_path", clearSet: `poster_path = ''`, alwaysVerify: true},
+		{name: "collection posters", table: "library_collections", keyCols: []artworkSweepKey{textSweepKey("id")}, pathCol: "poster_url", clearSet: `poster_url = '', poster_thumbhash = '', poster_auto_generated = FALSE, poster_from_template = FALSE, updated_at = NOW()`, alwaysVerify: true},
+		{name: "collection backdrops", table: "library_collections", keyCols: []artworkSweepKey{textSweepKey("id")}, pathCol: "backdrop_url", clearSet: `backdrop_url = '', backdrop_thumbhash = '', updated_at = NOW()`, alwaysVerify: true},
+		{name: "user collection posters", table: "user_personal_collections", keyCols: []artworkSweepKey{textSweepKey("id")}, pathCol: "poster_url", clearSet: `poster_url = '', poster_thumbhash = '', updated_at = NOW()`, alwaysVerify: true},
+		{name: "library posters", table: "media_folders", keyCols: []artworkSweepKey{int32SweepKey("id")}, pathCol: posterPathColumn, clearSet: `poster_path = ''`, alwaysVerify: true},
 	}
 }
 
@@ -163,7 +300,19 @@ func NewArtworkCacheReconciler(pool *pgxpool.Pool, s3 ArtworkObjectChecker) *Art
 // error budget is exhausted, and never resets rows on the basis of transport
 // errors.
 func (r *ArtworkCacheReconciler) Run(ctx context.Context, progress func(percent float64, message string)) (ArtworkReconcileStats, error) {
-	stats := ArtworkReconcileStats{Mode: "verify"}
+	return r.RunResumable(ctx, nil, nil, progress)
+}
+
+// RunResumable executes the same reconcile while persisting a safe cursor
+// after every completed verify batch. A nil checkpoint starts a fresh probe;
+// a nil saver retains the legacy in-memory-only behavior.
+func (r *ArtworkCacheReconciler) RunResumable(
+	ctx context.Context,
+	checkpoint *ArtworkReconcileCheckpoint,
+	save func(ArtworkReconcileCheckpoint) error,
+	progress func(percent float64, message string),
+) (ArtworkReconcileStats, error) {
+	stats := ArtworkReconcileStats{Mode: ArtworkReconcileModeVerify}
 	if r == nil || r.pool == nil || r.s3 == nil {
 		return stats, fmt.Errorf("artwork reconcile: not configured")
 	}
@@ -172,6 +321,13 @@ func (r *ArtworkCacheReconciler) Run(ctx context.Context, progress func(percent 
 	}
 
 	surfaces := artworkSweepSurfaces()
+	if checkpoint != nil && checkpoint.valid(len(surfaces)) {
+		resumed := cloneArtworkReconcileCheckpoint(*checkpoint)
+		if resumed.Complete() {
+			return resumed.Stats, nil
+		}
+		return r.runVerifySweep(ctx, surfaces, resumed, save, progress)
+	}
 
 	// Probe before anything else: it decides the mode, and in bulk mode the
 	// per-surface count(*) queries (full scans on unindexable predicates)
@@ -186,7 +342,7 @@ func (r *ArtworkCacheReconciler) Run(ctx context.Context, progress func(percent 
 	}
 
 	if shouldBulkReset(stats.Sampled, stats.SampleMissing) {
-		stats.Mode = "bulk_reset"
+		stats.Mode = ArtworkReconcileModeBulkReset
 		progress(5, fmt.Sprintf("Probe found %d/%d objects missing; resetting cached artwork", stats.SampleMissing, stats.Sampled))
 		steps := len(surfaces) + 1
 		for i, s := range surfaces {
@@ -235,30 +391,161 @@ func (r *ArtworkCacheReconciler) Run(ctx context.Context, progress func(percent 
 		return stats, nil
 	}
 
-	done := 0
-	report := func(surfaceName string) func(int) {
-		return func(surfaceDone int) {
-			pct := 5 + 90*float64(done+surfaceDone)/float64(total)
-			progress(pct, fmt.Sprintf("Verifying %s (%d/%d overall)", surfaceName, done+surfaceDone, total))
-		}
+	checkpoint = &ArtworkReconcileCheckpoint{
+		Version:      artworkReconcileCheckpointVersion,
+		Totals:       totals,
+		ChapterTotal: chapterTotal,
+		Stats:        stats,
+	}
+	if err := saveArtworkReconcileCheckpoint(save, *checkpoint); err != nil {
+		return stats, fmt.Errorf("artwork reconcile: saving initial checkpoint: %w", err)
+	}
+	return r.runVerifySweep(ctx, surfaces, *checkpoint, save, progress)
+}
+
+func (r *ArtworkCacheReconciler) runVerifySweep(
+	ctx context.Context,
+	surfaces []artworkSweepSurface,
+	checkpoint ArtworkReconcileCheckpoint,
+	save func(ArtworkReconcileCheckpoint) error,
+	progress func(percent float64, message string),
+) (ArtworkReconcileStats, error) {
+	stats := checkpoint.Stats
+	total := checkpoint.ChapterTotal
+	for _, count := range checkpoint.Totals {
+		total += count
+	}
+	if total == 0 {
+		progress(100, "No cached artwork to verify")
+		return stats, nil
 	}
 
-	for i, s := range surfaces {
-		if totals[i] == 0 {
+	runtimeDone := checkpoint.Done
+	checkpointBlocked := false
+	startSurface := checkpoint.SurfaceIndex
+	for i := startSurface; i < len(surfaces); i++ {
+		s := surfaces[i]
+		cursor := []string(nil)
+		surfaceDone := 0
+		if i == startSurface {
+			cursor = append(cursor, checkpoint.SurfaceCursor...)
+			surfaceDone = checkpoint.SurfaceDone
+		}
+		if checkpoint.Totals[i] == 0 {
+			runtimeDone += checkpoint.Totals[i]
+			if checkpointBlocked {
+				continue
+			}
+			checkpoint.SurfaceIndex = i + 1
+			checkpoint.SurfaceCursor = nil
+			checkpoint.SurfaceDone = 0
+			checkpoint.Done = runtimeDone
+			checkpoint.Stats = stats
+			if err := saveArtworkReconcileCheckpoint(save, checkpoint); err != nil {
+				return stats, fmt.Errorf("artwork reconcile: advancing empty %s checkpoint: %w", s.name, err)
+			}
 			continue
 		}
-		if err := r.sweepSurface(ctx, s, &stats, report(s.name)); err != nil {
+
+		if surfaceDone > 0 {
+			pct := 5 + 90*float64(runtimeDone+surfaceDone)/float64(total)
+			progress(pct, fmt.Sprintf("Resuming %s (%d/%d overall)", s.name, runtimeDone+surfaceDone, total))
+		}
+		surfaceStartErrors := stats.SweepErrors
+		if err := r.sweepSurfaceFrom(ctx, s, &stats, cursor, surfaceDone,
+			func(batchCursor []string, batchDone int, batchCheckpointable bool) error {
+				pct := 5 + 90*float64(runtimeDone+batchDone)/float64(total)
+				progress(pct, fmt.Sprintf("Verifying %s (%d/%d overall)", s.name, runtimeDone+batchDone, total))
+				if !batchCheckpointable || checkpointBlocked {
+					checkpointBlocked = true
+					return nil
+				}
+				checkpoint.SurfaceIndex = i
+				checkpoint.SurfaceCursor = append(checkpoint.SurfaceCursor[:0], batchCursor...)
+				checkpoint.SurfaceDone = batchDone
+				checkpoint.Done = runtimeDone
+				checkpoint.Stats = stats
+				if err := saveArtworkReconcileCheckpoint(save, checkpoint); err != nil {
+					return fmt.Errorf("saving %s batch checkpoint: %w", s.name, err)
+				}
+				return nil
+			}); err != nil {
 			return stats, err
 		}
-		done += totals[i]
+		if stats.SweepErrors > surfaceStartErrors {
+			checkpointBlocked = true
+		}
+		runtimeDone += checkpoint.Totals[i]
+		if checkpointBlocked {
+			continue
+		}
+		checkpoint.SurfaceIndex = i + 1
+		checkpoint.SurfaceCursor = nil
+		checkpoint.SurfaceDone = 0
+		checkpoint.Done = runtimeDone
+		checkpoint.Stats = stats
+		if err := saveArtworkReconcileCheckpoint(save, checkpoint); err != nil {
+			return stats, fmt.Errorf("artwork reconcile: completing %s checkpoint: %w", s.name, err)
+		}
 	}
 
-	if chapterTotal > 0 {
-		if err := r.sweepChapterThumbnails(ctx, &stats, report("chapter thumbnails")); err != nil {
+	chapterCursor := int64(0)
+	chapterDone := 0
+	if startSurface >= len(surfaces) {
+		chapterCursor = checkpoint.ChapterCursor
+		chapterDone = checkpoint.ChapterDone
+	}
+	if checkpoint.ChapterTotal > 0 {
+		if chapterDone > 0 {
+			pct := 5 + 90*float64(runtimeDone+chapterDone)/float64(total)
+			progress(pct, fmt.Sprintf("Resuming chapter thumbnails (%d/%d overall)", runtimeDone+chapterDone, total))
+		}
+		if err := r.sweepChapterThumbnailsFrom(ctx, &stats, chapterCursor, chapterDone,
+			func(batchCursor int64, batchDone int, batchCheckpointable bool) error {
+				pct := 5 + 90*float64(runtimeDone+batchDone)/float64(total)
+				progress(pct, fmt.Sprintf("Verifying chapter thumbnails (%d/%d overall)", runtimeDone+batchDone, total))
+				if !batchCheckpointable || checkpointBlocked {
+					checkpointBlocked = true
+					return nil
+				}
+				checkpoint.SurfaceIndex = len(surfaces)
+				checkpoint.SurfaceCursor = nil
+				checkpoint.SurfaceDone = 0
+				checkpoint.Done = runtimeDone
+				checkpoint.ChapterCursor = batchCursor
+				checkpoint.ChapterDone = batchDone
+				checkpoint.Stats = stats
+				if err := saveArtworkReconcileCheckpoint(save, checkpoint); err != nil {
+					return fmt.Errorf("saving chapter-thumbnail checkpoint: %w", err)
+				}
+				return nil
+			}); err != nil {
 			return stats, err
+		}
+	}
+	if !checkpointBlocked {
+		checkpoint.SurfaceIndex = len(surfaces) + 1
+		checkpoint.Done = runtimeDone
+		checkpoint.Finished = true
+		checkpoint.Stats = stats
+		if err := saveArtworkReconcileCheckpoint(save, checkpoint); err != nil {
+			return stats, fmt.Errorf("artwork reconcile: saving completed checkpoint: %w", err)
 		}
 	}
 	return stats, nil
+}
+
+func cloneArtworkReconcileCheckpoint(checkpoint ArtworkReconcileCheckpoint) ArtworkReconcileCheckpoint {
+	checkpoint.Totals = append([]int(nil), checkpoint.Totals...)
+	checkpoint.SurfaceCursor = append([]string(nil), checkpoint.SurfaceCursor...)
+	return checkpoint
+}
+
+func saveArtworkReconcileCheckpoint(save func(ArtworkReconcileCheckpoint) error, checkpoint ArtworkReconcileCheckpoint) error {
+	if save == nil {
+		return nil
+	}
+	return save(cloneArtworkReconcileCheckpoint(checkpoint))
 }
 
 // shouldBulkReset decides between a blind bulk reset and per-row
@@ -458,8 +745,21 @@ type sweptRow struct {
 }
 
 func (r *ArtworkCacheReconciler) sweepSurface(ctx context.Context, s artworkSweepSurface, stats *ArtworkReconcileStats, onProgress func(done int)) error {
-	var cursor []string
-	done := 0
+	return r.sweepSurfaceFrom(ctx, s, stats, nil, 0,
+		func(_ []string, done int, _ bool) error {
+			onProgress(done)
+			return nil
+		})
+}
+
+func (r *ArtworkCacheReconciler) sweepSurfaceFrom(
+	ctx context.Context,
+	s artworkSweepSurface,
+	stats *ArtworkReconcileStats,
+	cursor []string,
+	done int,
+	onBatch func(cursor []string, done int, checkpointable bool) error,
+) error {
 	for {
 		rows, err := r.fetchSweepBatch(ctx, s, cursor)
 		if err != nil {
@@ -470,6 +770,7 @@ func (r *ArtworkCacheReconciler) sweepSurface(ctx context.Context, s artworkSwee
 		}
 		cursor = rows[len(rows)-1].keys
 
+		sweepErrorsBefore := stats.SweepErrors
 		if err := r.verifyAndReset(ctx, s, rows, stats); err != nil {
 			return err
 		}
@@ -477,27 +778,18 @@ func (r *ArtworkCacheReconciler) sweepSurface(ctx context.Context, s artworkSwee
 			return fmt.Errorf("artwork reconcile: aborting after %d sweep storage errors (errored rows were left untouched)", stats.SweepErrors)
 		}
 		done += len(rows)
-		onProgress(done)
+		if err := onBatch(cursor, done, stats.SweepErrors == sweepErrorsBefore); err != nil {
+			return fmt.Errorf("artwork reconcile: recording %s progress: %w", s.name, err)
+		}
 	}
 }
 
 func (r *ArtworkCacheReconciler) fetchSweepBatch(ctx context.Context, s artworkSweepSurface, cursor []string) ([]sweptRow, error) {
-	var b strings.Builder
-	args := make([]any, 0, len(cursor)+1)
-	fmt.Fprintf(&b, `SELECT %s, %s, (%s) FROM %s WHERE %s`,
-		strings.Join(s.keyCols, ", "), s.pathCol, s.remoteSourcePredicate(), s.table, s.cachedPredicate())
-	if len(cursor) > 0 {
-		placeholders := make([]string, len(cursor))
-		for i, v := range cursor {
-			args = append(args, v)
-			placeholders[i] = fmt.Sprintf("$%d", len(args))
-		}
-		fmt.Fprintf(&b, ` AND (%s) > (%s)`, strings.Join(s.keyCols, ", "), strings.Join(placeholders, ", "))
+	query, args, err := buildSweepBatchQuery(s, cursor)
+	if err != nil {
+		return nil, fmt.Errorf("artwork reconcile: invalid %s cursor: %w", s.name, err)
 	}
-	args = append(args, artworkReconcileBatchSize)
-	fmt.Fprintf(&b, ` ORDER BY %s LIMIT $%d`, strings.Join(s.keyCols, ", "), len(args))
-
-	rows, err := r.pool.Query(ctx, b.String(), args...)
+	rows, err := r.pool.Query(ctx, query, args...)
 	if err != nil {
 		return nil, fmt.Errorf("artwork reconcile: fetching %s batch: %w", s.name, err)
 	}
@@ -522,6 +814,29 @@ func (r *ArtworkCacheReconciler) fetchSweepBatch(ctx context.Context, s artworkS
 	return out, nil
 }
 
+func buildSweepBatchQuery(s artworkSweepSurface, cursor []string) (string, []any, error) {
+	var b strings.Builder
+	args := make([]any, 0, len(cursor)+1)
+	keyColumns := s.keyColumnNames()
+	fmt.Fprintf(&b, `SELECT %s, %s, (%s) FROM %s WHERE %s`,
+		strings.Join(s.keySelectExpressions(), ", "), s.pathCol, s.remoteSourcePredicate(), s.table, s.cachedPredicate())
+	if len(cursor) > 0 {
+		cursorArgs, err := s.parseKeys(cursor)
+		if err != nil {
+			return "", nil, err
+		}
+		placeholders := make([]string, len(cursor))
+		for i, value := range cursorArgs {
+			args = append(args, value)
+			placeholders[i] = fmt.Sprintf("$%d", len(args))
+		}
+		fmt.Fprintf(&b, ` AND (%s) > (%s)`, strings.Join(keyColumns, ", "), strings.Join(placeholders, ", "))
+	}
+	args = append(args, artworkReconcileBatchSize)
+	fmt.Fprintf(&b, ` ORDER BY %s LIMIT $%d`, strings.Join(keyColumns, ", "), len(args))
+	return b.String(), args, nil
+}
+
 func (r *ArtworkCacheReconciler) verifyAndReset(ctx context.Context, s artworkSweepSurface, batch []sweptRow, stats *ArtworkReconcileStats) error {
 	keys := make([]string, len(batch))
 	for i, row := range batch {
@@ -543,9 +858,11 @@ func (r *ArtworkCacheReconciler) verifyAndReset(ctx context.Context, s artworkSw
 		case v.missing:
 			row := batch[i]
 			args := make([]any, 0, len(row.keys)+1)
-			for _, k := range row.keys {
-				args = append(args, k)
+			parsedKeys, err := s.parseKeys(row.keys)
+			if err != nil {
+				return fmt.Errorf("artwork reconcile: invalid %s row key: %w", s.name, err)
 			}
+			args = append(args, parsedKeys...)
 			args = append(args, row.path)
 			var set string
 			if row.remoteSource {
@@ -585,10 +902,10 @@ func (r *ArtworkCacheReconciler) verifyAndReset(ctx context.Context, s artworkSw
 	return nil
 }
 
-func keyEqualityPredicate(keyCols []string) string {
+func keyEqualityPredicate(keyCols []artworkSweepKey) string {
 	parts := make([]string, len(keyCols))
-	for i, col := range keyCols {
-		parts[i] = fmt.Sprintf("%s = $%d", col, i+1)
+	for i, key := range keyCols {
+		parts[i] = fmt.Sprintf("%s = $%d", key.column, i+1)
 	}
 	return strings.Join(parts, " AND ")
 }
@@ -648,8 +965,20 @@ type chapterFileRow struct {
 }
 
 func (r *ArtworkCacheReconciler) sweepChapterThumbnails(ctx context.Context, stats *ArtworkReconcileStats, onProgress func(done int)) error {
-	cursor := int64(0)
-	done := 0
+	return r.sweepChapterThumbnailsFrom(ctx, stats, 0, 0,
+		func(_ int64, done int, _ bool) error {
+			onProgress(done)
+			return nil
+		})
+}
+
+func (r *ArtworkCacheReconciler) sweepChapterThumbnailsFrom(
+	ctx context.Context,
+	stats *ArtworkReconcileStats,
+	cursor int64,
+	done int,
+	onBatch func(cursor int64, done int, checkpointable bool) error,
+) error {
 	for {
 		rows, err := r.pool.Query(ctx, `
 			SELECT id, chapters FROM media_files
@@ -677,6 +1006,7 @@ func (r *ArtworkCacheReconciler) sweepChapterThumbnails(ctx context.Context, sta
 		}
 		cursor = batch[len(batch)-1].id
 
+		sweepErrorsBefore := stats.SweepErrors
 		if err := r.reconcileChapterBatch(ctx, batch, stats); err != nil {
 			return err
 		}
@@ -684,7 +1014,9 @@ func (r *ArtworkCacheReconciler) sweepChapterThumbnails(ctx context.Context, sta
 			return fmt.Errorf("artwork reconcile: aborting after %d sweep storage errors (errored rows were left untouched)", stats.SweepErrors)
 		}
 		done += len(batch)
-		onProgress(done)
+		if err := onBatch(cursor, done, stats.SweepErrors == sweepErrorsBefore); err != nil {
+			return fmt.Errorf("artwork reconcile: recording chapter-thumbnail progress: %w", err)
+		}
 	}
 }
 

--- a/internal/metadata/artwork_reconcile.go
+++ b/internal/metadata/artwork_reconcile.go
@@ -483,11 +483,11 @@ func runArtworkVerifySweep(
 			func(batchCursor []string, batchDone int, batchCheckpointable bool) error {
 				pct := 5 + 90*float64(runtimeDone+batchDone)/float64(total)
 				progress(pct, fmt.Sprintf("Verifying %s (%d/%d overall)", s.name, runtimeDone+batchDone, total))
-				if !batchCheckpointable {
+				if !batchCheckpointable && save != nil {
 					return fmt.Errorf("storage errors in %s batch; stopping at the last saved checkpoint", s.name)
 				}
 				checkpoint.SurfaceIndex = i
-				checkpoint.SurfaceCursor = append(checkpoint.SurfaceCursor[:0], batchCursor...)
+				checkpoint.SurfaceCursor = append([]string(nil), batchCursor...)
 				checkpoint.SurfaceDone = batchDone
 				checkpoint.Done = runtimeDone
 				checkpoint.Stats = stats
@@ -524,7 +524,7 @@ func runArtworkVerifySweep(
 			func(batchCursor int64, batchDone int, batchCheckpointable bool) error {
 				pct := 5 + 90*float64(runtimeDone+batchDone)/float64(total)
 				progress(pct, fmt.Sprintf("Verifying chapter thumbnails (%d/%d overall)", runtimeDone+batchDone, total))
-				if !batchCheckpointable {
+				if !batchCheckpointable && save != nil {
 					return fmt.Errorf("storage errors in chapter-thumbnail batch; stopping at the last saved checkpoint")
 				}
 				checkpoint.SurfaceIndex = len(surfaces)

--- a/internal/metadata/artwork_reconcile_test.go
+++ b/internal/metadata/artwork_reconcile_test.go
@@ -60,6 +60,49 @@ func TestShouldBulkReset(t *testing.T) {
 	}
 }
 
+func TestArtworkSweepSurfacesUseIndexablePaginationKeys(t *testing.T) {
+	for _, surface := range artworkSweepSurfaces() {
+		for _, keyCol := range surface.keyCols {
+			if strings.Contains(keyCol.column, "::") {
+				t.Fatalf("surface %q paginates on expression %q; use the native key column so PostgreSQL can use its index", surface.name, keyCol.column)
+			}
+		}
+	}
+}
+
+func TestBuildSweepBatchQueryUsesNativeNumericKeys(t *testing.T) {
+	var peopleSurface, folderSurface artworkSweepSurface
+	for _, surface := range artworkSweepSurfaces() {
+		switch surface.name {
+		case "person photos":
+			peopleSurface = surface
+		case "library posters":
+			folderSurface = surface
+		}
+	}
+
+	query, args, err := buildSweepBatchQuery(peopleSurface, []string{"128111764822294558"})
+	if err != nil {
+		t.Fatalf("build people query: %v", err)
+	}
+	if !strings.Contains(query, "SELECT (id)::text") ||
+		!strings.Contains(query, "AND (id) > ($1)") ||
+		!strings.Contains(query, "ORDER BY id LIMIT $2") {
+		t.Fatalf("people query does not keep pagination on native id: %s", query)
+	}
+	if _, ok := args[0].(int64); !ok {
+		t.Fatalf("people cursor type = %T, want int64", args[0])
+	}
+
+	_, args, err = buildSweepBatchQuery(folderSurface, []string{"42"})
+	if err != nil {
+		t.Fatalf("build folder query: %v", err)
+	}
+	if _, ok := args[0].(int32); !ok {
+		t.Fatalf("folder cursor type = %T, want int32", args[0])
+	}
+}
+
 func TestArtworkReconcileVerifySweep(t *testing.T) {
 	dsn := os.Getenv("SILO_TEST_DATABASE_URL")
 	if dsn == "" {
@@ -91,6 +134,15 @@ func TestArtworkReconcileVerifySweep(t *testing.T) {
 	seedItem(id("upload"), key("upload"), "upload://admin/poster.jpg")
 	seedItem(id("uncached"), "https://img.example/direct.jpg", "https://img.example/direct.jpg")
 
+	personID := suffix
+	personKey := key("person-missing")
+	if _, err := pool.Exec(ctx, `
+		INSERT INTO people (id, name, photo_path, photo_source_path)
+		VALUES ($1, 'ARC Person', $2, 'https://img.example/person.jpg')
+	`, personID, personKey); err != nil {
+		t.Fatalf("seed person: %v", err)
+	}
+
 	var fileID int64
 	chapters := fmt.Sprintf(
 		`[{"index":0,"title":"One","thumbnail_path":%q,"thumbnail_thumbhash":"aGFzaA==","custom":"kept"},`+
@@ -120,6 +172,7 @@ func TestArtworkReconcileVerifySweep(t *testing.T) {
 		_, _ = pool.Exec(ctx, `DELETE FROM library_collections WHERE id = $1`, id("coll"))
 		_, _ = pool.Exec(ctx, `DELETE FROM media_files WHERE id = $1`, fileID)
 		_, _ = pool.Exec(ctx, `DELETE FROM media_folders WHERE id = $1`, folderID)
+		_, _ = pool.Exec(ctx, `DELETE FROM people WHERE id = $1`, personID)
 		for _, name := range []string{"intact", "missing", "upload", "uncached"} {
 			_, _ = pool.Exec(ctx, `DELETE FROM media_items WHERE content_id = $1`, id(name))
 		}
@@ -128,6 +181,7 @@ func TestArtworkReconcileVerifySweep(t *testing.T) {
 	checker := &fakeObjectChecker{missing: map[string]bool{
 		key("missing"):         true,
 		key("upload"):          true,
+		personKey:              true,
 		key("chapter-missing"): true,
 		key("coll"):            true,
 		fmt.Sprintf("library-posters/arc-%d.png", suffix): true,
@@ -165,6 +219,14 @@ func TestArtworkReconcileVerifySweep(t *testing.T) {
 	}
 	if checker.checked["https://img.example/direct.jpg"] != 0 {
 		t.Fatal("provider URLs must not be HEAD-checked")
+	}
+
+	var personPhoto string
+	if err := pool.QueryRow(ctx, `SELECT photo_path FROM people WHERE id = $1`, personID).Scan(&personPhoto); err != nil {
+		t.Fatalf("read person: %v", err)
+	}
+	if personPhoto != "https://img.example/person.jpg" {
+		t.Fatalf("missing person photo_path = %q, want reset to provider source", personPhoto)
 	}
 
 	var rawChapters string
@@ -209,6 +271,87 @@ func TestArtworkReconcileVerifySweep(t *testing.T) {
 	}
 }
 
+func TestArtworkReconcileResumesFromSavedBatch(t *testing.T) {
+	dsn := os.Getenv("SILO_TEST_DATABASE_URL")
+	if dsn == "" {
+		t.Skip("SILO_TEST_DATABASE_URL is not set")
+	}
+	ctx := context.Background()
+	pool, err := pgxpool.New(ctx, dsn)
+	if err != nil {
+		t.Fatalf("connect test database: %v", err)
+	}
+	t.Cleanup(pool.Close)
+
+	prefix := fmt.Sprintf("arc-resume-%d-", time.Now().UnixNano())
+	if _, err := pool.Exec(ctx, `
+		INSERT INTO media_items (content_id, type, title, status, genres, poster_path, poster_source_path)
+		SELECT
+			$1 || lpad(n::text, 4, '0'),
+			'movie', 'ARC Resume', 'matched', '{}'::text[],
+			'tmdb/movies/' || $1 || lpad(n::text, 4, '0') || '/poster/original.webp',
+			'https://img.example/' || $1 || lpad(n::text, 4, '0') || '.jpg'
+		FROM generate_series(0, 500) AS n
+	`, prefix); err != nil {
+		t.Fatalf("seed resumable artwork: %v", err)
+	}
+	t.Cleanup(func() {
+		_, _ = pool.Exec(ctx, `DELETE FROM media_items WHERE content_id LIKE $1`, prefix+"%")
+	})
+
+	surface := artworkSweepSurface{
+		name:      "resume test posters",
+		table:     "media_items",
+		keyCols:   []artworkSweepKey{textSweepKey("content_id")},
+		pathCol:   "poster_path",
+		sourceCol: "poster_source_path",
+		clearSet:  `poster_path = '', last_refreshed = NULL, updated_at = NOW()`,
+	}
+	checker := &fakeObjectChecker{}
+	reconciler := NewArtworkCacheReconciler(pool, checker)
+	checkpoint := ArtworkReconcileCheckpoint{
+		Version: artworkReconcileCheckpointVersion,
+		Totals:  []int{501},
+		Stats:   ArtworkReconcileStats{Mode: "verify"},
+	}
+	stopAfterFirstBatch := errors.New("simulated restart")
+	var saved ArtworkReconcileCheckpoint
+	_, err = reconciler.runVerifySweep(ctx, []artworkSweepSurface{surface}, checkpoint,
+		func(next ArtworkReconcileCheckpoint) error {
+			saved = cloneArtworkReconcileCheckpoint(next)
+			if next.SurfaceDone == artworkReconcileBatchSize {
+				return stopAfterFirstBatch
+			}
+			return nil
+		}, func(float64, string) {})
+	if !errors.Is(err, stopAfterFirstBatch) {
+		t.Fatalf("first sweep error = %v, want simulated restart", err)
+	}
+	if saved.SurfaceDone != artworkReconcileBatchSize || len(saved.SurfaceCursor) != 1 {
+		t.Fatalf("saved checkpoint = %#v, want one completed batch", saved)
+	}
+
+	checker.mu.Lock()
+	checker.checked = map[string]int{}
+	checker.mu.Unlock()
+	stats, err := reconciler.runVerifySweep(ctx, []artworkSweepSurface{surface}, saved, nil, func(float64, string) {})
+	if err != nil {
+		t.Fatalf("resumed sweep: %v", err)
+	}
+	if stats.Verified != 501 {
+		t.Fatalf("resumed Verified = %d, want 501", stats.Verified)
+	}
+	firstKey := fmt.Sprintf("tmdb/movies/%s%04d/poster/original.webp", prefix, 0)
+	lastKey := fmt.Sprintf("tmdb/movies/%s%04d/poster/original.webp", prefix, 500)
+	checker.mu.Lock()
+	firstChecks := checker.checked[firstKey]
+	lastChecks := checker.checked[lastKey]
+	checker.mu.Unlock()
+	if firstChecks != 0 || lastChecks != 1 {
+		t.Fatalf("resume checks: first=%d last=%d, want first=0 last=1", firstChecks, lastChecks)
+	}
+}
+
 func TestArtworkReconcileLeavesRowsAloneOnStorageErrors(t *testing.T) {
 	dsn := os.Getenv("SILO_TEST_DATABASE_URL")
 	if dsn == "" {
@@ -244,12 +387,20 @@ func TestArtworkReconcileLeavesRowsAloneOnStorageErrors(t *testing.T) {
 	})
 
 	checker := &fakeObjectChecker{erroring: map[string]bool{cachedKey: true}}
-	stats, err := NewArtworkCacheReconciler(pool, checker).Run(ctx, nil)
+	var saved ArtworkReconcileCheckpoint
+	stats, err := NewArtworkCacheReconciler(pool, checker).RunResumable(ctx, nil,
+		func(next ArtworkReconcileCheckpoint) error {
+			saved = cloneArtworkReconcileCheckpoint(next)
+			return nil
+		}, nil)
 	if err != nil {
-		t.Fatalf("Run: %v", err)
+		t.Fatalf("RunResumable: %v", err)
 	}
-	if stats.Errors == 0 {
+	if stats.Errors == 0 || stats.SweepErrors == 0 {
 		t.Fatal("expected the erroring key to be counted")
+	}
+	if saved.SurfaceIndex != 0 || len(saved.SurfaceCursor) != 0 || saved.Finished {
+		t.Fatalf("checkpoint advanced past an errored batch: %#v", saved)
 	}
 
 	var posterPath string

--- a/internal/metadata/artwork_reconcile_test.go
+++ b/internal/metadata/artwork_reconcile_test.go
@@ -283,7 +283,7 @@ type scriptedArtworkBatch struct {
 
 type scriptedArtworkChapterBatch struct {
 	cursor      int64
-	done        int
+	rows        int
 	verified    int
 	sweepErrors int
 }
@@ -294,10 +294,16 @@ type scriptedArtworkSweepCall struct {
 	done   int
 }
 
+type scriptedArtworkChapterSweepCall struct {
+	cursor int64
+	done   int
+}
+
 type scriptedArtworkVerifySweeper struct {
 	batches           map[string][]scriptedArtworkBatch
 	chapterBatches    []scriptedArtworkChapterBatch
 	calls             []scriptedArtworkSweepCall
+	chapterCalls      []scriptedArtworkChapterSweepCall
 	processed         map[string]int
 	chaptersProcessed int
 }
@@ -334,17 +340,22 @@ func (s *scriptedArtworkVerifySweeper) sweepSurfaceFrom(
 func (s *scriptedArtworkVerifySweeper) sweepChapterThumbnailsFrom(
 	_ context.Context,
 	stats *ArtworkReconcileStats,
-	_ int64,
-	_ int,
+	cursor int64,
+	done int,
 	onBatch func(int64, int, bool) error,
 ) error {
+	s.chapterCalls = append(s.chapterCalls, scriptedArtworkChapterSweepCall{cursor: cursor, done: done})
 	for _, batch := range s.chapterBatches {
+		if batch.cursor <= cursor {
+			continue
+		}
 		s.chaptersProcessed++
 		stats.Checked += batch.verified + batch.sweepErrors
 		stats.Verified += batch.verified
 		stats.Errors += batch.sweepErrors
 		stats.SweepErrors += batch.sweepErrors
-		if err := onBatch(batch.cursor, batch.done, batch.sweepErrors == 0); err != nil {
+		done += batch.rows
+		if err := onBatch(batch.cursor, done, batch.sweepErrors == 0); err != nil {
 			return err
 		}
 	}
@@ -412,6 +423,61 @@ func TestArtworkReconcileStopsAtUnsafeBatchAndResumesFromLastCheckpoint(t *testi
 	}
 }
 
+func TestArtworkReconcileStopsAndResumesChapterThumbnailsFromLastCheckpoint(t *testing.T) {
+	checkpoint := ArtworkReconcileCheckpoint{
+		Version:      artworkReconcileCheckpointVersion,
+		ChapterTotal: 3,
+		Stats:        ArtworkReconcileStats{Mode: ArtworkReconcileModeVerify},
+	}
+	firstRun := &scriptedArtworkVerifySweeper{chapterBatches: []scriptedArtworkChapterBatch{
+		{cursor: 10, rows: 1, verified: 1},
+		{cursor: 20, rows: 1, sweepErrors: 1},
+		{cursor: 30, rows: 1, verified: 1},
+	}}
+	var saved ArtworkReconcileCheckpoint
+	saveCount := 0
+
+	stats, err := runArtworkVerifySweep(context.Background(), firstRun, nil, checkpoint,
+		func(next ArtworkReconcileCheckpoint) error {
+			saveCount++
+			saved = cloneArtworkReconcileCheckpoint(next)
+			return nil
+		}, func(float64, string) {})
+	if err == nil || !strings.Contains(err.Error(), "last saved checkpoint") {
+		t.Fatalf("first chapter sweep error = %v, want checkpoint stop", err)
+	}
+	if stats.SweepErrors != 1 || firstRun.chaptersProcessed != 2 {
+		t.Fatalf("first chapter sweep stats/work = %#v / %d batches, want 1 error after 2 batches", stats, firstRun.chaptersProcessed)
+	}
+	if saveCount != 1 || saved.ChapterCursor != 10 || saved.ChapterDone != 1 {
+		t.Fatalf("saved chapter checkpoint = %#v (save count %d), want cursor 10 at 1 row", saved, saveCount)
+	}
+
+	resumedRun := &scriptedArtworkVerifySweeper{chapterBatches: []scriptedArtworkChapterBatch{
+		{cursor: 10, rows: 1, verified: 1},
+		{cursor: 20, rows: 1, verified: 1},
+		{cursor: 30, rows: 1, verified: 1},
+	}}
+	var completed ArtworkReconcileCheckpoint
+	stats, err = runArtworkVerifySweep(context.Background(), resumedRun, nil, saved,
+		func(next ArtworkReconcileCheckpoint) error {
+			completed = cloneArtworkReconcileCheckpoint(next)
+			return nil
+		}, func(float64, string) {})
+	if err != nil {
+		t.Fatalf("resumed chapter sweep: %v", err)
+	}
+	if len(resumedRun.chapterCalls) != 1 || resumedRun.chapterCalls[0].cursor != 10 || resumedRun.chapterCalls[0].done != 1 {
+		t.Fatalf("chapter resume call = %#v, want cursor 10 at 1 row", resumedRun.chapterCalls)
+	}
+	if resumedRun.chaptersProcessed != 2 {
+		t.Fatalf("resumed chapter batches = %d, want 2 (saved batch skipped)", resumedRun.chaptersProcessed)
+	}
+	if stats.Verified != 3 || !completed.Complete() {
+		t.Fatalf("resumed chapter stats/checkpoint = %#v / %#v, want 3 verified and complete", stats, completed)
+	}
+}
+
 func TestArtworkReconcileWithoutSaverContinuesAfterUnsafeBatches(t *testing.T) {
 	surfaces := []artworkSweepSurface{{name: "posters"}, {name: "later surface"}}
 	checkpoint := ArtworkReconcileCheckpoint{
@@ -426,8 +492,8 @@ func TestArtworkReconcileWithoutSaverContinuesAfterUnsafeBatches(t *testing.T) {
 			"later surface": {{cursor: []string{"later"}, done: 1, verified: 1}},
 		},
 		chapterBatches: []scriptedArtworkChapterBatch{
-			{cursor: 10, done: 1, sweepErrors: 1},
-			{cursor: 20, done: 2, verified: 1},
+			{cursor: 10, rows: 1, sweepErrors: 1},
+			{cursor: 20, rows: 1, verified: 1},
 		},
 	}
 

--- a/internal/metadata/artwork_reconcile_test.go
+++ b/internal/metadata/artwork_reconcile_test.go
@@ -271,84 +271,124 @@ func TestArtworkReconcileVerifySweep(t *testing.T) {
 	}
 }
 
-func TestArtworkReconcileResumesFromSavedBatch(t *testing.T) {
-	dsn := os.Getenv("SILO_TEST_DATABASE_URL")
-	if dsn == "" {
-		t.Skip("SILO_TEST_DATABASE_URL is not set")
-	}
-	ctx := context.Background()
-	pool, err := pgxpool.New(ctx, dsn)
-	if err != nil {
-		t.Fatalf("connect test database: %v", err)
-	}
-	t.Cleanup(pool.Close)
+type scriptedArtworkBatch struct {
+	cursor      []string
+	done        int
+	verified    int
+	sweepErrors int
+}
 
-	prefix := fmt.Sprintf("arc-resume-%d-", time.Now().UnixNano())
-	if _, err := pool.Exec(ctx, `
-		INSERT INTO media_items (content_id, type, title, status, genres, poster_path, poster_source_path)
-		SELECT
-			$1 || lpad(n::text, 4, '0'),
-			'movie', 'ARC Resume', 'matched', '{}'::text[],
-			'tmdb/movies/' || $1 || lpad(n::text, 4, '0') || '/poster/original.webp',
-			'https://img.example/' || $1 || lpad(n::text, 4, '0') || '.jpg'
-		FROM generate_series(0, 500) AS n
-	`, prefix); err != nil {
-		t.Fatalf("seed resumable artwork: %v", err)
-	}
-	t.Cleanup(func() {
-		_, _ = pool.Exec(ctx, `DELETE FROM media_items WHERE content_id LIKE $1`, prefix+"%")
+type scriptedArtworkSweepCall struct {
+	name   string
+	cursor []string
+	done   int
+}
+
+type scriptedArtworkVerifySweeper struct {
+	batches   map[string][]scriptedArtworkBatch
+	calls     []scriptedArtworkSweepCall
+	processed map[string]int
+	chapters  int
+}
+
+func (s *scriptedArtworkVerifySweeper) sweepSurfaceFrom(
+	_ context.Context,
+	surface artworkSweepSurface,
+	stats *ArtworkReconcileStats,
+	cursor []string,
+	done int,
+	onBatch func([]string, int, bool) error,
+) error {
+	s.calls = append(s.calls, scriptedArtworkSweepCall{
+		name:   surface.name,
+		cursor: append([]string(nil), cursor...),
+		done:   done,
 	})
-
-	surface := artworkSweepSurface{
-		name:      "resume test posters",
-		table:     "media_items",
-		keyCols:   []artworkSweepKey{textSweepKey("content_id")},
-		pathCol:   "poster_path",
-		sourceCol: "poster_source_path",
-		clearSet:  `poster_path = '', last_refreshed = NULL, updated_at = NOW()`,
+	if s.processed == nil {
+		s.processed = make(map[string]int)
 	}
-	checker := &fakeObjectChecker{}
-	reconciler := NewArtworkCacheReconciler(pool, checker)
+	for _, batch := range s.batches[surface.name] {
+		s.processed[surface.name]++
+		stats.Checked += batch.verified + batch.sweepErrors
+		stats.Verified += batch.verified
+		stats.Errors += batch.sweepErrors
+		stats.SweepErrors += batch.sweepErrors
+		if err := onBatch(batch.cursor, batch.done, batch.sweepErrors == 0); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (s *scriptedArtworkVerifySweeper) sweepChapterThumbnailsFrom(
+	context.Context,
+	*ArtworkReconcileStats,
+	int64,
+	int,
+	func(int64, int, bool) error,
+) error {
+	s.chapters++
+	return nil
+}
+
+func TestArtworkReconcileStopsAtUnsafeBatchAndResumesFromLastCheckpoint(t *testing.T) {
+	surfaces := []artworkSweepSurface{{name: "posters"}, {name: "later surface"}}
 	checkpoint := ArtworkReconcileCheckpoint{
 		Version: artworkReconcileCheckpointVersion,
-		Totals:  []int{501},
-		Stats:   ArtworkReconcileStats{Mode: "verify"},
+		Totals:  []int{1001, 1},
+		Stats:   ArtworkReconcileStats{Mode: ArtworkReconcileModeVerify},
 	}
-	stopAfterFirstBatch := errors.New("simulated restart")
+	firstRun := &scriptedArtworkVerifySweeper{batches: map[string][]scriptedArtworkBatch{
+		"posters": {
+			{cursor: []string{"0499"}, done: 500, verified: 500},
+			{cursor: []string{"0999"}, done: 1000, verified: 499, sweepErrors: 1},
+			{cursor: []string{"1000"}, done: 1001, verified: 1},
+		},
+		"later surface": {{cursor: []string{"later"}, done: 1, verified: 1}},
+	}}
 	var saved ArtworkReconcileCheckpoint
-	_, err = reconciler.runVerifySweep(ctx, []artworkSweepSurface{surface}, checkpoint,
+	saveCount := 0
+	stats, err := runArtworkVerifySweep(context.Background(), firstRun, surfaces, checkpoint,
 		func(next ArtworkReconcileCheckpoint) error {
+			saveCount++
 			saved = cloneArtworkReconcileCheckpoint(next)
-			if next.SurfaceDone == artworkReconcileBatchSize {
-				return stopAfterFirstBatch
-			}
 			return nil
 		}, func(float64, string) {})
-	if !errors.Is(err, stopAfterFirstBatch) {
-		t.Fatalf("first sweep error = %v, want simulated restart", err)
+	if err == nil || !strings.Contains(err.Error(), "last saved checkpoint") {
+		t.Fatalf("first sweep error = %v, want checkpoint stop", err)
 	}
-	if saved.SurfaceDone != artworkReconcileBatchSize || len(saved.SurfaceCursor) != 1 {
-		t.Fatalf("saved checkpoint = %#v, want one completed batch", saved)
+	if stats.SweepErrors != 1 {
+		t.Fatalf("first sweep errors = %d, want 1", stats.SweepErrors)
+	}
+	if firstRun.processed["posters"] != 2 || firstRun.processed["later surface"] != 0 || firstRun.chapters != 0 {
+		t.Fatalf("work after unsafe batch: processed=%v chapter_calls=%d", firstRun.processed, firstRun.chapters)
+	}
+	if saveCount != 1 || saved.SurfaceDone != 500 || len(saved.SurfaceCursor) != 1 || saved.SurfaceCursor[0] != "0499" {
+		t.Fatalf("saved checkpoint = %#v (save count %d), want safe first batch", saved, saveCount)
 	}
 
-	checker.mu.Lock()
-	checker.checked = map[string]int{}
-	checker.mu.Unlock()
-	stats, err := reconciler.runVerifySweep(ctx, []artworkSweepSurface{surface}, saved, nil, func(float64, string) {})
+	resumedRun := &scriptedArtworkVerifySweeper{batches: map[string][]scriptedArtworkBatch{
+		"posters": {
+			{cursor: []string{"0999"}, done: 1000, verified: 500},
+			{cursor: []string{"1000"}, done: 1001, verified: 1},
+		},
+		"later surface": {{cursor: []string{"later"}, done: 1, verified: 1}},
+	}}
+	var completed ArtworkReconcileCheckpoint
+	stats, err = runArtworkVerifySweep(context.Background(), resumedRun, surfaces, saved,
+		func(next ArtworkReconcileCheckpoint) error {
+			completed = cloneArtworkReconcileCheckpoint(next)
+			return nil
+		}, func(float64, string) {})
 	if err != nil {
 		t.Fatalf("resumed sweep: %v", err)
 	}
-	if stats.Verified != 501 {
-		t.Fatalf("resumed Verified = %d, want 501", stats.Verified)
+	if len(resumedRun.calls) == 0 || resumedRun.calls[0].done != 500 ||
+		len(resumedRun.calls[0].cursor) != 1 || resumedRun.calls[0].cursor[0] != "0499" {
+		t.Fatalf("resume call = %#v, want cursor 0499 at 500 rows", resumedRun.calls)
 	}
-	firstKey := fmt.Sprintf("tmdb/movies/%s%04d/poster/original.webp", prefix, 0)
-	lastKey := fmt.Sprintf("tmdb/movies/%s%04d/poster/original.webp", prefix, 500)
-	checker.mu.Lock()
-	firstChecks := checker.checked[firstKey]
-	lastChecks := checker.checked[lastKey]
-	checker.mu.Unlock()
-	if firstChecks != 0 || lastChecks != 1 {
-		t.Fatalf("resume checks: first=%d last=%d, want first=0 last=1", firstChecks, lastChecks)
+	if stats.Verified != 1002 || !completed.Complete() {
+		t.Fatalf("resumed stats/checkpoint = %#v / %#v, want 1002 verified and complete", stats, completed)
 	}
 }
 
@@ -393,8 +433,8 @@ func TestArtworkReconcileLeavesRowsAloneOnStorageErrors(t *testing.T) {
 			saved = cloneArtworkReconcileCheckpoint(next)
 			return nil
 		}, nil)
-	if err != nil {
-		t.Fatalf("RunResumable: %v", err)
+	if err == nil || !strings.Contains(err.Error(), "last saved checkpoint") {
+		t.Fatalf("RunResumable error = %v, want checkpoint stop", err)
 	}
 	if stats.Errors == 0 || stats.SweepErrors == 0 {
 		t.Fatal("expected the erroring key to be counted")

--- a/internal/metadata/artwork_reconcile_test.go
+++ b/internal/metadata/artwork_reconcile_test.go
@@ -80,6 +80,9 @@ func TestBuildSweepBatchQueryUsesNativeNumericKeys(t *testing.T) {
 			folderSurface = surface
 		}
 	}
+	if peopleSurface.name == "" || folderSurface.name == "" {
+		t.Fatalf("surface lookup failed: person photos=%q library posters=%q", peopleSurface.name, folderSurface.name)
+	}
 
 	query, args, err := buildSweepBatchQuery(peopleSurface, []string{"128111764822294558"})
 	if err != nil {
@@ -278,6 +281,13 @@ type scriptedArtworkBatch struct {
 	sweepErrors int
 }
 
+type scriptedArtworkChapterBatch struct {
+	cursor      int64
+	done        int
+	verified    int
+	sweepErrors int
+}
+
 type scriptedArtworkSweepCall struct {
 	name   string
 	cursor []string
@@ -285,10 +295,11 @@ type scriptedArtworkSweepCall struct {
 }
 
 type scriptedArtworkVerifySweeper struct {
-	batches   map[string][]scriptedArtworkBatch
-	calls     []scriptedArtworkSweepCall
-	processed map[string]int
-	chapters  int
+	batches           map[string][]scriptedArtworkBatch
+	chapterBatches    []scriptedArtworkChapterBatch
+	calls             []scriptedArtworkSweepCall
+	processed         map[string]int
+	chaptersProcessed int
 }
 
 func (s *scriptedArtworkVerifySweeper) sweepSurfaceFrom(
@@ -321,13 +332,22 @@ func (s *scriptedArtworkVerifySweeper) sweepSurfaceFrom(
 }
 
 func (s *scriptedArtworkVerifySweeper) sweepChapterThumbnailsFrom(
-	context.Context,
-	*ArtworkReconcileStats,
-	int64,
-	int,
-	func(int64, int, bool) error,
+	_ context.Context,
+	stats *ArtworkReconcileStats,
+	_ int64,
+	_ int,
+	onBatch func(int64, int, bool) error,
 ) error {
-	s.chapters++
+	for _, batch := range s.chapterBatches {
+		s.chaptersProcessed++
+		stats.Checked += batch.verified + batch.sweepErrors
+		stats.Verified += batch.verified
+		stats.Errors += batch.sweepErrors
+		stats.SweepErrors += batch.sweepErrors
+		if err := onBatch(batch.cursor, batch.done, batch.sweepErrors == 0); err != nil {
+			return err
+		}
+	}
 	return nil
 }
 
@@ -360,8 +380,8 @@ func TestArtworkReconcileStopsAtUnsafeBatchAndResumesFromLastCheckpoint(t *testi
 	if stats.SweepErrors != 1 {
 		t.Fatalf("first sweep errors = %d, want 1", stats.SweepErrors)
 	}
-	if firstRun.processed["posters"] != 2 || firstRun.processed["later surface"] != 0 || firstRun.chapters != 0 {
-		t.Fatalf("work after unsafe batch: processed=%v chapter_calls=%d", firstRun.processed, firstRun.chapters)
+	if firstRun.processed["posters"] != 2 || firstRun.processed["later surface"] != 0 || firstRun.chaptersProcessed != 0 {
+		t.Fatalf("work after unsafe batch: processed=%v chapter_batches=%d", firstRun.processed, firstRun.chaptersProcessed)
 	}
 	if saveCount != 1 || saved.SurfaceDone != 500 || len(saved.SurfaceCursor) != 1 || saved.SurfaceCursor[0] != "0499" {
 		t.Fatalf("saved checkpoint = %#v (save count %d), want safe first batch", saved, saveCount)
@@ -389,6 +409,39 @@ func TestArtworkReconcileStopsAtUnsafeBatchAndResumesFromLastCheckpoint(t *testi
 	}
 	if stats.Verified != 1002 || !completed.Complete() {
 		t.Fatalf("resumed stats/checkpoint = %#v / %#v, want 1002 verified and complete", stats, completed)
+	}
+}
+
+func TestArtworkReconcileWithoutSaverContinuesAfterUnsafeBatches(t *testing.T) {
+	surfaces := []artworkSweepSurface{{name: "posters"}, {name: "later surface"}}
+	checkpoint := ArtworkReconcileCheckpoint{
+		Version:      artworkReconcileCheckpointVersion,
+		Totals:       []int{1, 1},
+		ChapterTotal: 2,
+		Stats:        ArtworkReconcileStats{Mode: ArtworkReconcileModeVerify},
+	}
+	sweeper := &scriptedArtworkVerifySweeper{
+		batches: map[string][]scriptedArtworkBatch{
+			"posters":       {{cursor: []string{"poster"}, done: 1, sweepErrors: 1}},
+			"later surface": {{cursor: []string{"later"}, done: 1, verified: 1}},
+		},
+		chapterBatches: []scriptedArtworkChapterBatch{
+			{cursor: 10, done: 1, sweepErrors: 1},
+			{cursor: 20, done: 2, verified: 1},
+		},
+	}
+
+	stats, err := runArtworkVerifySweep(
+		context.Background(), sweeper, surfaces, checkpoint, nil, func(float64, string) {},
+	)
+	if err != nil {
+		t.Fatalf("sweep without saver: %v", err)
+	}
+	if sweeper.processed["posters"] != 1 || sweeper.processed["later surface"] != 1 || sweeper.chaptersProcessed != 2 {
+		t.Fatalf("work after unsafe batches: surfaces=%v chapter_batches=%d", sweeper.processed, sweeper.chaptersProcessed)
+	}
+	if stats.Verified != 2 || stats.SweepErrors != 2 {
+		t.Fatalf("stats = %#v, want 2 verified and 2 sweep errors", stats)
 	}
 }
 

--- a/internal/metadata/image_cache_processor.go
+++ b/internal/metadata/image_cache_processor.go
@@ -432,7 +432,23 @@ loop:
 	return stats
 }
 
+// DrainUntilIdle processes only jobs that have already been queued by scans,
+// metadata refreshes, or explicit artwork changes. It never performs the
+// full-catalog discovery sweep, so it is safe for startup and interval tasks:
+// an idle server stays idle instead of turning every scheduler tick into a
+// library-wide backfill.
+func (p *ImageCacheProcessor) DrainUntilIdle(ctx context.Context, workerID string, claimLimit int, concurrency int, maxRuntime time.Duration, reportProgress ImageCacheRunProgressReporter) (ImageCacheRunStats, error) {
+	return p.runUntilIdle(ctx, workerID, claimLimit, concurrency, maxRuntime, false, reportProgress)
+}
+
+// RunUntilIdle drains the queue and explicitly discovers uncached provider
+// artwork across the catalog. This is the manual backfill path; scheduled
+// cache processing must use DrainUntilIdle.
 func (p *ImageCacheProcessor) RunUntilIdle(ctx context.Context, workerID string, claimLimit int, concurrency int, maxRuntime time.Duration, reportProgress ImageCacheRunProgressReporter) (ImageCacheRunStats, error) {
+	return p.runUntilIdle(ctx, workerID, claimLimit, concurrency, maxRuntime, true, reportProgress)
+}
+
+func (p *ImageCacheProcessor) runUntilIdle(ctx context.Context, workerID string, claimLimit int, concurrency int, maxRuntime time.Duration, discover bool, reportProgress ImageCacheRunProgressReporter) (ImageCacheRunStats, error) {
 	var total ImageCacheRunStats
 	if p == nil || p.jobs == nil || p.cacher == nil || !p.enabled.Load() {
 		return total, nil
@@ -441,10 +457,12 @@ func (p *ImageCacheProcessor) RunUntilIdle(ctx context.Context, workerID string,
 	reportImageCacheRunProgress(reportProgress, total)
 
 	if maxRuntime <= 0 {
-		enqueued, derr := p.discoverExisting(ctx, claimLimit)
-		total.EnqueuedExisting += enqueued
-		if derr != nil {
-			return total, derr
+		if discover {
+			enqueued, derr := p.discoverExisting(ctx, claimLimit)
+			total.EnqueuedExisting += enqueued
+			if derr != nil {
+				return total, derr
+			}
 		}
 		stats, err := p.RunOnce(ctx, workerID, claimLimit, concurrency)
 		total.add(stats)
@@ -456,7 +474,7 @@ func (p *ImageCacheProcessor) RunUntilIdle(ctx context.Context, workerID string,
 	// Decide once per run whether a full-catalog backfill sweep is due. Within a
 	// due run we keep sweeping until the catalog is exhausted; otherwise we only
 	// drain the existing queue.
-	sweep := p.discoveryDue()
+	sweep := discover && p.discoveryDue()
 	deadline := time.Now().Add(maxRuntime)
 	for {
 		if err := ctx.Err(); err != nil {

--- a/internal/metadata/image_cache_processor.go
+++ b/internal/metadata/image_cache_processor.go
@@ -492,7 +492,7 @@ func (p *ImageCacheProcessor) runUntilIdle(ctx context.Context, workerID string,
 
 	// A positive runtime bounds scheduled draining; zero or negative means the
 	// explicit manual backfill keeps going until the catalog is exhausted or its
-	// context is cancelled.
+	// context is canceled.
 	limited := maxRuntime > 0
 	deadline := time.Time{}
 	if limited {

--- a/internal/metadata/image_cache_processor.go
+++ b/internal/metadata/image_cache_processor.go
@@ -26,14 +26,12 @@ import (
 // matching the NFO provider's discovery guard.
 const maxLocalImageSourceBytes = 8 << 20
 
-// imageCacheDiscoveryInterval throttles the full-catalog backfill sweep so an
-// idle installation does not re-scan every entity table on every task tick.
-// Draining of already-queued jobs is unaffected and stays responsive.
-const imageCacheDiscoveryInterval = 15 * time.Minute
-
 const (
 	immediateImageCacheClaimLimit  = 16
 	immediateImageCacheConcurrency = 3
+	// Discovery is a read/enqueue page, not a processing lease. Keep it large
+	// even though processing now claims only jobs that can start immediately.
+	imageCacheDiscoveryBatchSize = 1000
 	// Waiting for a background worker to release a job polls with backoff and
 	// gives up after immediateImageCacheIdleTimeout without progress. The
 	// worker's own lease runs for imageCacheLeaseDuration, and its pod can die
@@ -48,6 +46,10 @@ const (
 // metadata refresh itself is complete and the artwork finishes on the normal
 // queue, so callers should surface this as a warning, not a failure.
 var ErrTargetArtworkPending = errors.New("artwork caching is still running in the background")
+
+// ErrImageCachingDisabled prevents an explicit manual backfill from being
+// recorded as successfully complete when metadata image caching is disabled.
+var ErrImageCachingDisabled = errors.New("metadata image caching is disabled")
 
 type ImageCacheJobClaimer interface {
 	ClaimDue(ctx context.Context, workerID string, limit int) ([]*models.MetadataImageCacheJob, error)
@@ -146,9 +148,11 @@ type ImageCacheProcessor struct {
 	// a background worker. Zero means immediateImageCacheIdleTimeout.
 	idleWaitTimeout time.Duration
 
-	discoveryInterval time.Duration
-	discoveryMu       sync.Mutex
-	lastDiscovery     time.Time
+	// runGate serializes the scheduled queue drain and explicit full backfill.
+	// They are separate TaskManager tasks, so TaskManager's per-key guard cannot
+	// prevent them from racing each other through the shared durable queue. A
+	// channel gate keeps waiting cancellable, unlike a sync.Mutex.
+	runGate chan struct{}
 }
 
 // SetLibraryRootResolver wires the folder repository used to confine local
@@ -171,9 +175,10 @@ func (p *ImageCacheProcessor) SetImagePrefixDeleter(deleter ImagePrefixDeleter) 
 	p.prefixDeleter = deleter
 }
 
-// SetEnabled toggles background caching. When disabled the processor performs
-// no discovery, claiming, or uploading, honoring metadata.cache_images so that
-// merely configuring object storage does not download the whole catalog.
+// SetEnabled toggles background caching. When disabled the processor begins no
+// new discovery, claims, or uploads; a job already in flight may finish. This
+// honors metadata.cache_images so merely configuring object storage does not
+// download the whole catalog.
 func (p *ImageCacheProcessor) SetEnabled(enabled bool) {
 	if p == nil {
 		return
@@ -205,14 +210,15 @@ func NewImageCacheProcessorWithTargets(
 	targets ImageCacheProcessorTargets,
 ) *ImageCacheProcessor {
 	p := &ImageCacheProcessor{
-		jobs:              jobs,
-		cacher:            cacher,
-		resolver:          resolver,
-		targets:           targets,
-		logger:            slog.Default(),
-		discoveryInterval: imageCacheDiscoveryInterval,
-		idleWaitTimeout:   immediateImageCacheIdleTimeout,
+		jobs:            jobs,
+		cacher:          cacher,
+		resolver:        resolver,
+		targets:         targets,
+		logger:          slog.Default(),
+		idleWaitTimeout: immediateImageCacheIdleTimeout,
+		runGate:         make(chan struct{}, 1),
 	}
+	p.runGate <- struct{}{}
 	// Default to enabled; callers gate on metadata.cache_images via SetEnabled.
 	p.enabled.Store(true)
 	return p
@@ -259,8 +265,8 @@ func (s *ImageCacheRunStats) add(other ImageCacheRunStats) {
 }
 
 // RunOnce claims and processes one batch of already-queued jobs. It does not
-// run catalog discovery; callers (RunUntilIdle) drive discovery on a throttled
-// cadence so backlog draining stays decoupled from full-table sweeps.
+// run catalog discovery; callers choose between queue-only draining and an
+// explicit full-catalog backfill.
 func (p *ImageCacheProcessor) RunOnce(ctx context.Context, workerID string, claimLimit int, concurrency int) (ImageCacheRunStats, error) {
 	var stats ImageCacheRunStats
 	if p == nil || p.jobs == nil || p.cacher == nil || !p.enabled.Load() {
@@ -388,6 +394,12 @@ func (p *ImageCacheProcessor) processClaimedJobs(ctx context.Context, workerID s
 	var unstarted []int64
 loop:
 	for i, job := range jobs {
+		if !p.enabled.Load() {
+			for _, rem := range jobs[i:] {
+				unstarted = append(unstarted, rem.ID)
+			}
+			break loop
+		}
 		// Acquire the semaphore before spawning so cancellation is observed here
 		// rather than inside a goroutine that already holds a claimed job. Jobs we
 		// never start are requeued below instead of being left locked until the
@@ -395,6 +407,13 @@ loop:
 		select {
 		case sem <- struct{}{}:
 		case <-ctx.Done():
+			for _, rem := range jobs[i:] {
+				unstarted = append(unstarted, rem.ID)
+			}
+			break loop
+		}
+		if !p.enabled.Load() {
+			<-sem
 			for _, rem := range jobs[i:] {
 				unstarted = append(unstarted, rem.ID)
 			}
@@ -450,37 +469,46 @@ func (p *ImageCacheProcessor) RunUntilIdle(ctx context.Context, workerID string,
 
 func (p *ImageCacheProcessor) runUntilIdle(ctx context.Context, workerID string, claimLimit int, concurrency int, maxRuntime time.Duration, discover bool, reportProgress ImageCacheRunProgressReporter) (ImageCacheRunStats, error) {
 	var total ImageCacheRunStats
-	if p == nil || p.jobs == nil || p.cacher == nil || !p.enabled.Load() {
+	if p == nil {
+		return total, nil
+	}
+	select {
+	case <-ctx.Done():
+		return total, ctx.Err()
+	case <-p.runGate:
+	}
+	defer func() { p.runGate <- struct{}{} }()
+	if p.jobs == nil || p.cacher == nil {
+		return total, nil
+	}
+	if !p.enabled.Load() {
+		if discover {
+			return total, ErrImageCachingDisabled
+		}
 		return total, nil
 	}
 	total.Backlog = p.sampleBacklog(ctx)
 	reportImageCacheRunProgress(reportProgress, total)
 
-	if maxRuntime <= 0 {
-		if discover {
-			enqueued, derr := p.discoverExisting(ctx, claimLimit)
-			total.EnqueuedExisting += enqueued
-			if derr != nil {
-				return total, derr
-			}
-		}
-		stats, err := p.RunOnce(ctx, workerID, claimLimit, concurrency)
-		total.add(stats)
-		total.Batches = 1
-		reportImageCacheRunProgress(reportProgress, total)
-		return total, err
+	// A positive runtime bounds scheduled draining; zero or negative means the
+	// explicit manual backfill keeps going until the catalog is exhausted or its
+	// context is cancelled.
+	limited := maxRuntime > 0
+	deadline := time.Time{}
+	if limited {
+		deadline = time.Now().Add(maxRuntime)
 	}
-
-	// Decide once per run whether a full-catalog backfill sweep is due. Within a
-	// due run we keep sweeping until the catalog is exhausted; otherwise we only
-	// drain the existing queue.
-	sweep := discover && p.discoveryDue()
-	deadline := time.Now().Add(maxRuntime)
 	for {
 		if err := ctx.Err(); err != nil {
 			return total, err
 		}
-		if !time.Now().Before(deadline) {
+		if !p.enabled.Load() {
+			if discover {
+				return total, ErrImageCachingDisabled
+			}
+			return total, nil
+		}
+		if limited && !time.Now().Before(deadline) {
 			total.RuntimeLimited = true
 			return total, nil
 		}
@@ -492,22 +520,29 @@ func (p *ImageCacheProcessor) runUntilIdle(ctx context.Context, workerID string,
 		if err != nil {
 			return total, err
 		}
+		// SetEnabled may change while a claimed batch is in flight. Re-check
+		// before looping or discovering so disabling caching cannot turn an
+		// unbounded manual backfill into a rapid enqueue-only catalog sweep.
+		if !p.enabled.Load() {
+			if discover {
+				return total, ErrImageCachingDisabled
+			}
+			return total, nil
+		}
 		if stats.Claimed > 0 {
 			// Keep draining the queue before spending a full-table sweep.
 			continue
 		}
-		if !sweep {
+		if !discover {
 			return total, nil
 		}
-		enqueued, err := p.jobs.EnqueueExistingProviderArtwork(ctx, claimLimit)
+		enqueued, err := p.jobs.EnqueueExistingProviderArtwork(ctx, imageCacheDiscoveryBatchSize)
 		if err != nil {
 			return total, err
 		}
 		total.EnqueuedExisting += enqueued
 		reportImageCacheRunProgress(reportProgress, total)
 		if enqueued == 0 {
-			// Catalog fully swept; throttle the next sweep.
-			p.markDiscovered()
 			return total, nil
 		}
 	}
@@ -534,33 +569,6 @@ func reportImageCacheRunProgress(reportProgress ImageCacheRunProgressReporter, s
 		return
 	}
 	reportProgress(stats)
-}
-
-// discoveryDue reports whether enough time has elapsed since the last completed
-// sweep to run another one.
-func (p *ImageCacheProcessor) discoveryDue() bool {
-	if p.discoveryInterval <= 0 {
-		return true
-	}
-	p.discoveryMu.Lock()
-	defer p.discoveryMu.Unlock()
-	return p.lastDiscovery.IsZero() || time.Since(p.lastDiscovery) >= p.discoveryInterval
-}
-
-func (p *ImageCacheProcessor) markDiscovered() {
-	p.discoveryMu.Lock()
-	p.lastDiscovery = time.Now()
-	p.discoveryMu.Unlock()
-}
-
-// discoverExisting runs an unthrottled sweep (single-pass path) and records the
-// time so the throttle applies to subsequent interval-driven runs.
-func (p *ImageCacheProcessor) discoverExisting(ctx context.Context, limit int) (int, error) {
-	enqueued, err := p.jobs.EnqueueExistingProviderArtwork(ctx, limit)
-	if err == nil {
-		p.markDiscovered()
-	}
-	return enqueued, err
 }
 
 func (p *ImageCacheProcessor) cleanupSucceeded(ctx context.Context, stats *ImageCacheRunStats) {

--- a/internal/metadata/image_cache_processor_test.go
+++ b/internal/metadata/image_cache_processor_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
@@ -97,9 +98,34 @@ type loopingImageCacheJobs struct {
 	claimedResults [][]*models.MetadataImageCacheJob
 	succeededIDs   []int64
 	enqueueCalls   int
+	enqueueLimits  []int
 	claimCalls     int
 	backlog        ImageCacheBacklog
 	backlogCalls   int
+}
+
+type serializingImageCacheJobs struct {
+	fakeImageCacheJobs
+	mu            sync.Mutex
+	claimCalls    int
+	firstEntered  chan struct{}
+	secondEntered chan struct{}
+	releaseFirst  chan struct{}
+}
+
+func (f *serializingImageCacheJobs) ClaimDue(context.Context, string, int) ([]*models.MetadataImageCacheJob, error) {
+	f.mu.Lock()
+	f.claimCalls++
+	call := f.claimCalls
+	f.mu.Unlock()
+	switch call {
+	case 1:
+		close(f.firstEntered)
+		<-f.releaseFirst
+	case 2:
+		close(f.secondEntered)
+	}
+	return nil, nil
 }
 
 func (f *loopingImageCacheJobs) GetBacklog(context.Context) (ImageCacheBacklog, error) {
@@ -107,11 +133,12 @@ func (f *loopingImageCacheJobs) GetBacklog(context.Context) (ImageCacheBacklog, 
 	return f.backlog, nil
 }
 
-func (f *loopingImageCacheJobs) EnqueueExistingProviderArtwork(context.Context, int) (int, error) {
+func (f *loopingImageCacheJobs) EnqueueExistingProviderArtwork(_ context.Context, limit int) (int, error) {
 	result := 0
 	if f.enqueueCalls < len(f.enqueueResults) {
 		result = f.enqueueResults[f.enqueueCalls]
 	}
+	f.enqueueLimits = append(f.enqueueLimits, limit)
 	f.enqueueCalls++
 	return result, nil
 }
@@ -150,10 +177,14 @@ type fakeImageCacher struct {
 	result *CacheImageResult
 	err    error
 	reqs   []CacheImageRequest
+	after  func()
 }
 
 func (f *fakeImageCacher) CacheImage(_ context.Context, req CacheImageRequest) (*CacheImageResult, error) {
 	f.reqs = append(f.reqs, req)
+	if f.after != nil {
+		f.after()
+	}
 	if f.err != nil {
 		return nil, f.err
 	}
@@ -726,7 +757,7 @@ func TestImageCacheProcessorRunUntilIdleDrainsNewWorkAddedDuringRun(t *testing.T
 		"test-worker",
 		1000,
 		2,
-		time.Minute,
+		0,
 		func(update ImageCacheRunStats) {
 			progressUpdates = append(progressUpdates, update)
 		},
@@ -737,11 +768,19 @@ func TestImageCacheProcessorRunUntilIdleDrainsNewWorkAddedDuringRun(t *testing.T
 	if stats.Batches != 4 {
 		t.Fatalf("Batches = %d, want 4", stats.Batches)
 	}
+	if stats.RuntimeLimited {
+		t.Fatal("manual backfill without a deadline reported RuntimeLimited")
+	}
 	if stats.EnqueuedExisting != 1 || stats.Claimed != 2 || stats.Succeeded != 2 {
 		t.Fatalf("stats = %+v, want enqueued=1 claimed=2 succeeded=2", stats)
 	}
 	if jobs.enqueueCalls != 2 || jobs.claimCalls != 4 {
 		t.Fatalf("calls enqueue=%d claim=%d, want enqueue=2 claim=4", jobs.enqueueCalls, jobs.claimCalls)
+	}
+	for _, limit := range jobs.enqueueLimits {
+		if limit != imageCacheDiscoveryBatchSize {
+			t.Fatalf("discovery limit = %d, want %d", limit, imageCacheDiscoveryBatchSize)
+		}
 	}
 	if len(jobs.succeededIDs) != 2 || jobs.succeededIDs[0] != 10 || jobs.succeededIDs[1] != 11 {
 		t.Fatalf("succeededIDs = %#v, want [10 11]", jobs.succeededIDs)
@@ -760,6 +799,159 @@ func TestImageCacheProcessorRunUntilIdleDrainsNewWorkAddedDuringRun(t *testing.T
 	}
 	if got := progressUpdates[len(progressUpdates)-1]; got != stats {
 		t.Fatalf("last progress update = %+v, want final stats %+v", got, stats)
+	}
+}
+
+func TestImageCacheProcessorManualBackfillAlwaysDiscovers(t *testing.T) {
+	jobs := &loopingImageCacheJobs{
+		enqueueResults: []int{0, 0},
+		claimedResults: [][]*models.MetadataImageCacheJob{
+			{},
+			{},
+		},
+	}
+	processor := NewImageCacheProcessor(jobs, &fakeImageCacher{}, &fakeImageResolver{}, nil, nil)
+	for i := 0; i < 2; i++ {
+		if _, err := processor.RunUntilIdle(context.Background(), "test-worker", 1000, 2, 0, nil); err != nil {
+			t.Fatalf("RunUntilIdle() call %d error = %v", i+1, err)
+		}
+	}
+	if jobs.enqueueCalls != 2 {
+		t.Fatalf("discovery calls = %d, want one for each explicit backfill", jobs.enqueueCalls)
+	}
+}
+
+func TestImageCacheProcessorManualBackfillFailsClosedWhenDisabled(t *testing.T) {
+	jobs := &loopingImageCacheJobs{}
+	processor := NewImageCacheProcessor(jobs, &fakeImageCacher{}, &fakeImageResolver{}, nil, nil)
+	processor.SetEnabled(false)
+	_, err := processor.RunUntilIdle(context.Background(), "test-worker", 2, 2, 0, nil)
+	if !errors.Is(err, ErrImageCachingDisabled) {
+		t.Fatalf("RunUntilIdle() error = %v, want ErrImageCachingDisabled", err)
+	}
+	if jobs.claimCalls != 0 || jobs.enqueueCalls != 0 {
+		t.Fatalf("disabled backfill calls claim=%d discovery=%d, want 0/0", jobs.claimCalls, jobs.enqueueCalls)
+	}
+}
+
+func TestImageCacheProcessorManualBackfillStopsDiscoveryWhenDisabledMidRun(t *testing.T) {
+	job := &models.MetadataImageCacheJob{
+		ID:                91,
+		TargetType:        ImageCacheTargetEpisode,
+		TargetContentID:   "episode-tvdb-1-1-1",
+		SourcePath:        "tvdb://banners/episode-1.jpg",
+		ProviderID:        "tvdb",
+		ProviderContentID: "1",
+		ContentType:       "series",
+		ImageType:         ImageCacheImageStill,
+	}
+	jobs := &loopingImageCacheJobs{claimedResults: [][]*models.MetadataImageCacheJob{{job}}}
+	cacher := &fakeImageCacher{result: &CacheImageResult{BasePath: "tvdb/series/1/seasons/1/episodes/1/still", Ext: ".webp"}}
+	processor := NewImageCacheProcessor(jobs, cacher, &fakeImageResolver{url: "https://artworks.thetvdb.com/episode.jpg"}, nil, &fakeEpisodeStillUpdater{updated: true})
+	cacher.after = func() { processor.SetEnabled(false) }
+	_, err := processor.RunUntilIdle(context.Background(), "test-worker", 2, 2, 0, nil)
+	if !errors.Is(err, ErrImageCachingDisabled) {
+		t.Fatalf("RunUntilIdle() error = %v, want ErrImageCachingDisabled", err)
+	}
+	if jobs.enqueueCalls != 0 {
+		t.Fatalf("discovery calls after disabling cache = %d, want 0", jobs.enqueueCalls)
+	}
+}
+
+func TestImageCacheProcessorRequeuesClaimedTailWhenDisabled(t *testing.T) {
+	jobs := &fakeImageCacheJobs{}
+	for i := int64(1); i <= 4; i++ {
+		jobs.claimed = append(jobs.claimed, &models.MetadataImageCacheJob{
+			ID:                i,
+			TargetType:        ImageCacheTargetEpisode,
+			TargetContentID:   "episode-tvdb-1-1-1",
+			SourcePath:        "tvdb://banners/episode-1.jpg",
+			ProviderID:        "tvdb",
+			ProviderContentID: "1",
+			ContentType:       "series",
+			ImageType:         ImageCacheImageStill,
+		})
+	}
+	cacher := &fakeImageCacher{result: &CacheImageResult{BasePath: "tvdb/series/1/seasons/1/episodes/1/still", Ext: ".webp"}}
+	processor := NewImageCacheProcessor(jobs, cacher, &fakeImageResolver{url: "https://artworks.thetvdb.com/episode.jpg"}, nil, &fakeEpisodeStillUpdater{updated: true})
+	cacher.after = func() { processor.SetEnabled(false) }
+	stats, err := processor.RunOnce(context.Background(), "test-worker", 4, 1)
+	if err != nil {
+		t.Fatalf("RunOnce() error = %v", err)
+	}
+	if stats.Succeeded != 1 || len(cacher.reqs) != 1 {
+		t.Fatalf("stats=%+v requests=%d, want one in-flight job to finish", stats, len(cacher.reqs))
+	}
+	if got := jobs.requeuedIDs; len(got) != 3 || got[0] != 2 || got[1] != 3 || got[2] != 4 {
+		t.Fatalf("requeued IDs = %#v, want [2 3 4]", got)
+	}
+}
+
+func TestImageCacheProcessorSerializesDrainAndBackfill(t *testing.T) {
+	jobs := &serializingImageCacheJobs{
+		firstEntered:  make(chan struct{}),
+		secondEntered: make(chan struct{}),
+		releaseFirst:  make(chan struct{}),
+	}
+	processor := NewImageCacheProcessor(jobs, &fakeImageCacher{}, &fakeImageResolver{}, nil, nil)
+	firstDone := make(chan error, 1)
+	go func() {
+		_, err := processor.DrainUntilIdle(context.Background(), "drain-worker", 1000, 2, time.Minute, nil)
+		firstDone <- err
+	}()
+	<-jobs.firstEntered
+
+	secondDone := make(chan error, 1)
+	go func() {
+		_, err := processor.RunUntilIdle(context.Background(), "backfill-worker", 1000, 2, 0, nil)
+		secondDone <- err
+	}()
+
+	enteredBeforeRelease := false
+	select {
+	case <-jobs.secondEntered:
+		enteredBeforeRelease = true
+	case <-time.After(50 * time.Millisecond):
+	}
+	close(jobs.releaseFirst)
+	if err := <-firstDone; err != nil {
+		t.Fatalf("DrainUntilIdle() error = %v", err)
+	}
+	if err := <-secondDone; err != nil {
+		t.Fatalf("RunUntilIdle() error = %v", err)
+	}
+	if enteredBeforeRelease {
+		t.Fatal("manual backfill entered the queue while scheduled drain still held the processor run lock")
+	}
+}
+
+func TestImageCacheProcessorCancelsWhileWaitingForRunGate(t *testing.T) {
+	jobs := &serializingImageCacheJobs{
+		firstEntered:  make(chan struct{}),
+		secondEntered: make(chan struct{}),
+		releaseFirst:  make(chan struct{}),
+	}
+	processor := NewImageCacheProcessor(jobs, &fakeImageCacher{}, &fakeImageResolver{}, nil, nil)
+	firstDone := make(chan error, 1)
+	go func() {
+		_, err := processor.DrainUntilIdle(context.Background(), "drain-worker", 2, 2, time.Minute, nil)
+		firstDone <- err
+	}()
+	<-jobs.firstEntered
+
+	ctx, cancel := context.WithCancel(context.Background())
+	secondDone := make(chan error, 1)
+	go func() {
+		_, err := processor.RunUntilIdle(ctx, "backfill-worker", 2, 2, 0, nil)
+		secondDone <- err
+	}()
+	cancel()
+	if err := <-secondDone; !errors.Is(err, context.Canceled) {
+		t.Fatalf("RunUntilIdle() waiting error = %v, want context.Canceled", err)
+	}
+	close(jobs.releaseFirst)
+	if err := <-firstDone; err != nil {
+		t.Fatalf("DrainUntilIdle() error = %v", err)
 	}
 }
 

--- a/internal/metadata/image_cache_processor_test.go
+++ b/internal/metadata/image_cache_processor_test.go
@@ -633,6 +633,47 @@ func TestImageCacheProcessorDeletesOldSucceededJobsWithoutClaimedJobs(t *testing
 	}
 }
 
+func TestImageCacheProcessorDrainUntilIdleNeverDiscoversCatalog(t *testing.T) {
+	job := &models.MetadataImageCacheJob{
+		ID:                9,
+		TargetType:        ImageCacheTargetEpisode,
+		TargetContentID:   "episode-tvdb-1-1-1",
+		SourcePath:        "tvdb://banners/episode-1.jpg",
+		ProviderID:        "tvdb",
+		ProviderContentID: "1",
+		ContentType:       "series",
+		ImageType:         ImageCacheImageStill,
+		SeasonNumber:      intPointer(1),
+		EpisodeNumber:     intPointer(1),
+	}
+	jobs := &loopingImageCacheJobs{
+		// A discovery call would enqueue more work; drain mode must never ask.
+		enqueueResults: []int{1000},
+		claimedResults: [][]*models.MetadataImageCacheJob{
+			{job},
+			{},
+		},
+		backlog: ImageCacheBacklog{Known: true, Queued: 1},
+	}
+	cacher := &fakeImageCacher{result: &CacheImageResult{
+		BasePath: "tvdb/series/1/seasons/1/episodes/1/still",
+		Ext:      ".webp",
+	}}
+	resolver := &fakeImageResolver{url: "https://artworks.thetvdb.com/banners/episode.jpg"}
+	processor := NewImageCacheProcessor(jobs, cacher, resolver, nil, &fakeEpisodeStillUpdater{updated: true})
+
+	stats, err := processor.DrainUntilIdle(context.Background(), "test-worker", 1000, 2, time.Minute, nil)
+	if err != nil {
+		t.Fatalf("DrainUntilIdle() error = %v", err)
+	}
+	if stats.Claimed != 1 || stats.Succeeded != 1 || stats.EnqueuedExisting != 0 {
+		t.Fatalf("stats = %+v, want one queued job drained and no discovery", stats)
+	}
+	if jobs.enqueueCalls != 0 || jobs.claimCalls != 2 {
+		t.Fatalf("calls enqueue=%d claim=%d, want 0/2", jobs.enqueueCalls, jobs.claimCalls)
+	}
+}
+
 func TestImageCacheProcessorRunUntilIdleDrainsNewWorkAddedDuringRun(t *testing.T) {
 	job1 := &models.MetadataImageCacheJob{
 		ID:                10,

--- a/internal/taskmanager/info.go
+++ b/internal/taskmanager/info.go
@@ -11,6 +11,7 @@ type TaskInfo struct {
 	State           TaskState        `json:"state"`
 	Progress        float64          `json:"progress"`
 	ProgressMessage string           `json:"progress_message,omitempty"`
+	ManualOnly      bool             `json:"manual_only"`
 	LastExecution   *ExecutionResult `json:"last_execution,omitempty"`
 	Triggers        []TriggerConfig  `json:"triggers"`
 	NextRunAt       *time.Time       `json:"next_run_at,omitempty"`

--- a/internal/taskmanager/manager.go
+++ b/internal/taskmanager/manager.go
@@ -296,6 +296,9 @@ func (m *TaskManager) UpdateTriggers(key string, triggerConfigs []TriggerConfig)
 	if err != nil {
 		return err
 	}
+	if task, ok := w.task.(ManualOnlyTask); ok && task.ManualOnly() && len(triggerConfigs) > 0 {
+		return ErrTaskManualOnly
+	}
 
 	if err := m.triggerRepo.SetTriggers(context.Background(), key, triggerConfigs); err != nil {
 		return err

--- a/internal/taskmanager/manager_test.go
+++ b/internal/taskmanager/manager_test.go
@@ -153,6 +153,10 @@ type conditionalStubTask struct {
 	executeCalls    int
 }
 
+type manualOnlyStubTask struct{ stubTask }
+
+func (manualOnlyStubTask) ManualOnly() bool { return true }
+
 func (t *conditionalStubTask) ShouldRun(context.Context) (bool, error) {
 	select {
 	case t.shouldRunCalled <- struct{}{}:
@@ -320,6 +324,35 @@ func TestTaskManagerRunTaskNotifiesAfterTriggerRearm(t *testing.T) {
 	if last.NextRunAt.Sub(last.LastExecution.CompletedAt) < 59*time.Minute {
 		t.Fatalf("next run was not rearmed from the latest completion: got %s after completion",
 			last.NextRunAt.Sub(last.LastExecution.CompletedAt))
+	}
+}
+
+func TestTaskManagerRejectsScheduledTriggersForManualOnlyTask(t *testing.T) {
+	const taskKey = "manual-backfill"
+	triggerRepo := &fakeTriggerRepository{triggers: map[string][]taskmanager.TriggerConfig{}}
+	manager := taskmanager.New(
+		triggerRepo,
+		fakeExecutionRepository{},
+		newFakeTrigger,
+		slog.New(slog.DiscardHandler),
+	)
+	manager.Register(manualOnlyStubTask{stubTask{key: taskKey}})
+
+	if info := manager.GetTaskInfo(taskKey); !info.ManualOnly {
+		t.Fatal("TaskInfo.ManualOnly = false, want true")
+	}
+	err := manager.UpdateTriggers(taskKey, []taskmanager.TriggerConfig{{
+		Type:       taskmanager.TriggerTypeInterval,
+		IntervalMs: int64(time.Hour / time.Millisecond),
+	}})
+	if !errors.Is(err, taskmanager.ErrTaskManualOnly) {
+		t.Fatalf("UpdateTriggers() error = %v, want ErrTaskManualOnly", err)
+	}
+	if _, wrote := triggerRepo.setCalls[taskKey]; wrote {
+		t.Fatal("manual-only trigger rejection wrote to the trigger repository")
+	}
+	if err := manager.UpdateTriggers(taskKey, nil); err != nil {
+		t.Fatalf("clearing manual-only triggers error = %v", err)
 	}
 }
 

--- a/internal/taskmanager/task.go
+++ b/internal/taskmanager/task.go
@@ -10,6 +10,7 @@ var (
 	ErrTaskAlreadyRunning = errors.New("task is already running")
 	ErrTaskNotRunning     = errors.New("task is not running")
 	ErrTaskNotFound       = errors.New("task not found")
+	ErrTaskManualOnly     = errors.New("manual-only task does not accept scheduled triggers")
 )
 
 // TaskState represents the current runtime state of a task.
@@ -46,6 +47,12 @@ type Task interface {
 // admins can force a check and see a result.
 type ScheduledConditionalTask interface {
 	ShouldRun(ctx context.Context) (bool, error)
+}
+
+// ManualOnlyTask marks a task that may be invoked through RunTask but must
+// never accept scheduled triggers.
+type ManualOnlyTask interface {
+	ManualOnly() bool
 }
 
 // ProgressReporter allows tasks to report progress and result data during execution.

--- a/internal/taskmanager/tasks/cache_metadata_images.go
+++ b/internal/taskmanager/tasks/cache_metadata_images.go
@@ -18,6 +18,10 @@ const (
 )
 
 type MetadataImageCacheRunner interface {
+	DrainUntilIdle(ctx context.Context, workerID string, claimLimit int, concurrency int, maxRuntime time.Duration, reportProgress metadata.ImageCacheRunProgressReporter) (metadata.ImageCacheRunStats, error)
+}
+
+type MetadataImageBackfillRunner interface {
 	RunUntilIdle(ctx context.Context, workerID string, claimLimit int, concurrency int, maxRuntime time.Duration, reportProgress metadata.ImageCacheRunProgressReporter) (metadata.ImageCacheRunStats, error)
 }
 
@@ -25,19 +29,37 @@ type CacheMetadataImagesTask struct {
 	runner MetadataImageCacheRunner
 }
 
+type BackfillMetadataImagesTask struct {
+	runner MetadataImageBackfillRunner
+}
+
 func NewCacheMetadataImagesTask(runner MetadataImageCacheRunner) *CacheMetadataImagesTask {
 	return &CacheMetadataImagesTask{runner: runner}
+}
+
+func NewBackfillMetadataImagesTask(runner MetadataImageBackfillRunner) *BackfillMetadataImagesTask {
+	return &BackfillMetadataImagesTask{runner: runner}
 }
 
 func (t *CacheMetadataImagesTask) Key() string  { return "cache_metadata_images" }
 func (t *CacheMetadataImagesTask) Name() string { return "Cache Metadata Images" }
 func (t *CacheMetadataImagesTask) Description() string {
-	return "Caches provider metadata artwork into object storage"
+	return "Processes only artwork already queued by scans, refreshes, and metadata changes"
 }
 func (t *CacheMetadataImagesTask) Category() taskmanager.TaskCategory {
 	return taskmanager.TaskCategoryMetadata
 }
 func (t *CacheMetadataImagesTask) IsHidden() bool { return false }
+
+func (t *BackfillMetadataImagesTask) Key() string  { return "backfill_metadata_images" }
+func (t *BackfillMetadataImagesTask) Name() string { return "Backfill Metadata Images" }
+func (t *BackfillMetadataImagesTask) Description() string {
+	return "Manually discovers and caches missing provider artwork across the full catalog"
+}
+func (t *BackfillMetadataImagesTask) Category() taskmanager.TaskCategory {
+	return taskmanager.TaskCategoryMetadata
+}
+func (t *BackfillMetadataImagesTask) IsHidden() bool { return false }
 
 func (t *CacheMetadataImagesTask) DefaultTriggers() []taskmanager.TriggerConfig {
 	return []taskmanager.TriggerConfig{
@@ -46,21 +68,51 @@ func (t *CacheMetadataImagesTask) DefaultTriggers() []taskmanager.TriggerConfig 
 	}
 }
 
+// Backfill is deliberately manual-only. The normal cache task drains durable
+// jobs created by catalog changes; only an administrator choosing this task
+// may initiate a full-catalog discovery sweep.
+func (t *BackfillMetadataImagesTask) DefaultTriggers() []taskmanager.TriggerConfig { return nil }
+
+// ShouldRun fails closed for every scheduler trigger, including one an older
+// installation or administrator may have persisted. TaskManager.RunTask
+// bypasses this gate, preserving the explicit manual action.
+func (t *BackfillMetadataImagesTask) ShouldRun(context.Context) (bool, error) {
+	return false, nil
+}
+
 func (t *CacheMetadataImagesTask) Execute(ctx context.Context, progress taskmanager.ProgressReporter) error {
 	if t.runner == nil {
 		progress.Report(100, "Metadata image cache is not configured")
 		return nil
 	}
+	return executeMetadataImages(ctx, progress, false, t.runner.DrainUntilIdle)
+}
+
+func (t *BackfillMetadataImagesTask) Execute(ctx context.Context, progress taskmanager.ProgressReporter) error {
+	if t.runner == nil {
+		progress.Report(100, "Metadata image backfill is not configured")
+		return nil
+	}
+	return executeMetadataImages(ctx, progress, true, t.runner.RunUntilIdle)
+}
+
+type metadataImageRunFunc func(context.Context, string, int, int, time.Duration, metadata.ImageCacheRunProgressReporter) (metadata.ImageCacheRunStats, error)
+
+func executeMetadataImages(ctx context.Context, progress taskmanager.ProgressReporter, backfill bool, run metadataImageRunFunc) error {
 	hostname, _ := os.Hostname()
 	if hostname == "" {
 		hostname = "silo"
 	}
-	progress.Report(0, "Starting metadata image cache")
+	startMessage := "Starting queued metadata image cache"
+	if backfill {
+		startMessage = "Starting full metadata image backfill"
+	}
+	progress.Report(0, startMessage)
 	// Discovery widens the denominator mid-run, so the raw ratio can dip when a
 	// sweep enqueues a fresh page. Reports are sequential, so a high-water mark
 	// is enough to keep what the user sees from walking backwards.
 	reportedPercent := 0.0
-	stats, err := t.runner.RunUntilIdle(
+	stats, err := run(
 		ctx,
 		hostname,
 		cacheMetadataImagesBatchSize,
@@ -76,12 +128,15 @@ func (t *CacheMetadataImagesTask) Execute(ctx context.Context, progress taskmana
 		},
 	)
 	if err != nil {
-		return fmt.Errorf("caching metadata images: %w", err)
+		operation := "caching queued metadata images"
+		if backfill {
+			operation = "backfilling metadata images"
+		}
+		return fmt.Errorf("%s: %w", operation, err)
 	}
 	message := fmt.Sprintf(
-		"Batches %d, enqueued %d existing, claimed %d, cached %d, %d %s, skipped %d, uploaded %d variants, found %d existing variants, deleted %d old successes",
+		"Batches %d, claimed %d, cached %d, %d %s, skipped %d, uploaded %d variants, found %d existing variants, deleted %d old successes",
 		stats.Batches,
-		stats.EnqueuedExisting,
 		stats.Claimed,
 		stats.Succeeded,
 		stats.Failed,
@@ -91,6 +146,9 @@ func (t *CacheMetadataImagesTask) Execute(ctx context.Context, progress taskmana
 		stats.ExistingVariants,
 		stats.DeletedSucceeded,
 	)
+	if backfill {
+		message = fmt.Sprintf("Discovered %d existing, %s", stats.EnqueuedExisting, message)
+	}
 	if stats.RuntimeLimited {
 		message += ", runtime budget reached"
 	}

--- a/internal/taskmanager/tasks/cache_metadata_images.go
+++ b/internal/taskmanager/tasks/cache_metadata_images.go
@@ -6,13 +6,18 @@ import (
 	"os"
 	"time"
 
+	"github.com/google/uuid"
+
 	"github.com/Silo-Server/silo-server/internal/metadata"
 	"github.com/Silo-Server/silo-server/internal/taskmanager"
 )
 
 const (
 	cacheMetadataImagesIntervalMs = int64(60 * 1000)
-	cacheMetadataImagesBatchSize  = 1000
+	// Claim only work that can start immediately. Claiming a large queue page
+	// stamps one lease on every row up front; with two workers, the unstarted
+	// tail could expire and be reclaimed before this execution reaches it.
+	cacheMetadataImagesClaimLimit = 2
 	cacheMetadataImagesWorkers    = 2
 	cacheMetadataImagesMaxRuntime = 10 * time.Minute
 )
@@ -59,7 +64,8 @@ func (t *BackfillMetadataImagesTask) Description() string {
 func (t *BackfillMetadataImagesTask) Category() taskmanager.TaskCategory {
 	return taskmanager.TaskCategoryMetadata
 }
-func (t *BackfillMetadataImagesTask) IsHidden() bool { return false }
+func (t *BackfillMetadataImagesTask) IsHidden() bool   { return false }
+func (t *BackfillMetadataImagesTask) ManualOnly() bool { return true }
 
 func (t *CacheMetadataImagesTask) DefaultTriggers() []taskmanager.TriggerConfig {
 	return []taskmanager.TriggerConfig{
@@ -103,10 +109,23 @@ func executeMetadataImages(ctx context.Context, progress taskmanager.ProgressRep
 	if hostname == "" {
 		hostname = "silo"
 	}
+	mode := "drain"
+	maxRuntime := cacheMetadataImagesMaxRuntime
 	startMessage := "Starting queued metadata image cache"
 	if backfill {
+		mode = "backfill"
+		// A manual backfill must either reach the end of discovery or be
+		// explicitly cancelled. A scheduled drain is bounded because its next
+		// trigger continues the durable queue; a manual-only task has no such
+		// continuation and must not report a partial sweep as complete.
+		maxRuntime = 0
 		startMessage = "Starting full metadata image backfill"
 	}
+	// TaskManager prevents overlap for one task key, but drain and backfill are
+	// intentionally separate tasks and may run together. Give every execution
+	// a distinct lease owner so a stale worker can never finalize a job reclaimed
+	// by the other task after its lease expires.
+	workerID := fmt.Sprintf("%s:%s:%s", hostname, mode, uuid.NewString())
 	progress.Report(0, startMessage)
 	// Discovery widens the denominator mid-run, so the raw ratio can dip when a
 	// sweep enqueues a fresh page. Reports are sequential, so a high-water mark
@@ -114,10 +133,10 @@ func executeMetadataImages(ctx context.Context, progress taskmanager.ProgressRep
 	reportedPercent := 0.0
 	stats, err := run(
 		ctx,
-		hostname,
-		cacheMetadataImagesBatchSize,
+		workerID,
+		cacheMetadataImagesClaimLimit,
 		cacheMetadataImagesWorkers,
-		cacheMetadataImagesMaxRuntime,
+		maxRuntime,
 		func(update metadata.ImageCacheRunStats) {
 			percent := cacheMetadataImagesPercent(update)
 			if percent < reportedPercent {

--- a/internal/taskmanager/tasks/cache_metadata_images.go
+++ b/internal/taskmanager/tasks/cache_metadata_images.go
@@ -115,7 +115,7 @@ func executeMetadataImages(ctx context.Context, progress taskmanager.ProgressRep
 	if backfill {
 		mode = "backfill"
 		// A manual backfill must either reach the end of discovery or be
-		// explicitly cancelled. A scheduled drain is bounded because its next
+		// explicitly canceled. A scheduled drain is bounded because its next
 		// trigger continues the durable queue; a manual-only task has no such
 		// continuation and must not report a partial sweep as complete.
 		maxRuntime = 0

--- a/internal/taskmanager/tasks/cache_metadata_images_test.go
+++ b/internal/taskmanager/tasks/cache_metadata_images_test.go
@@ -3,8 +3,11 @@ package tasks
 import (
 	"context"
 	"encoding/json"
+	"strings"
 	"testing"
 	"time"
+
+	"github.com/google/uuid"
 
 	"github.com/Silo-Server/silo-server/internal/metadata"
 	"github.com/Silo-Server/silo-server/internal/taskmanager"
@@ -19,6 +22,7 @@ type fakeMetadataImageCacheRunner struct {
 	maxRuntime  time.Duration
 	drainCalls  int
 	backfills   int
+	workerIDs   []string
 }
 
 func (f *fakeMetadataImageCacheRunner) run(claimLimit int, concurrency int, maxRuntime time.Duration, reportProgress metadata.ImageCacheRunProgressReporter) (metadata.ImageCacheRunStats, error) {
@@ -31,13 +35,15 @@ func (f *fakeMetadataImageCacheRunner) run(claimLimit int, concurrency int, maxR
 	return f.stats, f.err
 }
 
-func (f *fakeMetadataImageCacheRunner) DrainUntilIdle(_ context.Context, _ string, claimLimit int, concurrency int, maxRuntime time.Duration, reportProgress metadata.ImageCacheRunProgressReporter) (metadata.ImageCacheRunStats, error) {
+func (f *fakeMetadataImageCacheRunner) DrainUntilIdle(_ context.Context, workerID string, claimLimit int, concurrency int, maxRuntime time.Duration, reportProgress metadata.ImageCacheRunProgressReporter) (metadata.ImageCacheRunStats, error) {
 	f.drainCalls++
+	f.workerIDs = append(f.workerIDs, workerID)
 	return f.run(claimLimit, concurrency, maxRuntime, reportProgress)
 }
 
-func (f *fakeMetadataImageCacheRunner) RunUntilIdle(_ context.Context, _ string, claimLimit int, concurrency int, maxRuntime time.Duration, reportProgress metadata.ImageCacheRunProgressReporter) (metadata.ImageCacheRunStats, error) {
+func (f *fakeMetadataImageCacheRunner) RunUntilIdle(_ context.Context, workerID string, claimLimit int, concurrency int, maxRuntime time.Duration, reportProgress metadata.ImageCacheRunProgressReporter) (metadata.ImageCacheRunStats, error) {
 	f.backfills++
+	f.workerIDs = append(f.workerIDs, workerID)
 	return f.run(claimLimit, concurrency, maxRuntime, reportProgress)
 }
 
@@ -77,6 +83,9 @@ func TestBackfillMetadataImagesTaskProperties(t *testing.T) {
 	if len(task.DefaultTriggers()) != 0 {
 		t.Fatalf("DefaultTriggers count = %d, want manual-only", len(task.DefaultTriggers()))
 	}
+	if !task.ManualOnly() {
+		t.Fatal("ManualOnly() = false, want true")
+	}
 	shouldRun, err := task.ShouldRun(context.Background())
 	if err != nil || shouldRun {
 		t.Fatalf("ShouldRun() = %t, %v, want false, nil", shouldRun, err)
@@ -106,8 +115,8 @@ func TestCacheMetadataImagesTaskReportsStats(t *testing.T) {
 	if err := task.Execute(context.Background(), progress); err != nil {
 		t.Fatalf("Execute() error = %v", err)
 	}
-	if runner.claimLimit != 1000 {
-		t.Fatalf("claimLimit = %d, want 1000", runner.claimLimit)
+	if runner.claimLimit != 2 {
+		t.Fatalf("claimLimit = %d, want one immediately-startable job per worker", runner.claimLimit)
 	}
 	if runner.concurrency != 2 {
 		t.Fatalf("concurrency = %d, want 2", runner.concurrency)
@@ -117,6 +126,9 @@ func TestCacheMetadataImagesTaskReportsStats(t *testing.T) {
 	}
 	if runner.drainCalls != 1 || runner.backfills != 0 {
 		t.Fatalf("runner calls drain=%d backfill=%d, want 1/0", runner.drainCalls, runner.backfills)
+	}
+	if len(runner.workerIDs) != 1 || !strings.Contains(runner.workerIDs[0], ":drain:") {
+		t.Fatalf("drain worker IDs = %#v, want one execution-scoped drain owner", runner.workerIDs)
 	}
 	if len(progress.messages) != 3 {
 		t.Fatalf("progress reports = %d, want 3", len(progress.messages))
@@ -146,12 +158,50 @@ func TestBackfillMetadataImagesTaskReportsDiscovery(t *testing.T) {
 	if runner.drainCalls != 0 || runner.backfills != 1 {
 		t.Fatalf("runner calls drain=%d backfill=%d, want 0/1", runner.drainCalls, runner.backfills)
 	}
+	if runner.maxRuntime != 0 {
+		t.Fatalf("maxRuntime = %s, want no deadline for manual backfill", runner.maxRuntime)
+	}
+	if runner.claimLimit != 2 {
+		t.Fatalf("claimLimit = %d, want one immediately-startable job per worker", runner.claimLimit)
+	}
+	if len(runner.workerIDs) != 1 || !strings.Contains(runner.workerIDs[0], ":backfill:") {
+		t.Fatalf("backfill worker IDs = %#v, want one execution-scoped backfill owner", runner.workerIDs)
+	}
 	if progress.messages[0] != "Starting full metadata image backfill" {
 		t.Fatalf("initial message = %q", progress.messages[0])
 	}
 	want := "Discovered 5 existing, Batches 2, claimed 5, cached 5, 0 failed attempts, skipped 0, uploaded 0 variants, found 0 existing variants, deleted 0 old successes"
 	if got := progress.messages[len(progress.messages)-1]; got != want {
 		t.Fatalf("final message = %q, want %q", got, want)
+	}
+}
+
+func TestMetadataImageTasksUseDistinctExecutionLeaseOwners(t *testing.T) {
+	runner := &fakeMetadataImageCacheRunner{}
+	progress := &recordingProgress{}
+	cacheTask := NewCacheMetadataImagesTask(runner)
+	backfillTask := NewBackfillMetadataImagesTask(runner)
+	for i := 0; i < 2; i++ {
+		if err := cacheTask.Execute(context.Background(), progress); err != nil {
+			t.Fatalf("cache Execute() call %d error = %v", i+1, err)
+		}
+		if err := backfillTask.Execute(context.Background(), progress); err != nil {
+			t.Fatalf("backfill Execute() call %d error = %v", i+1, err)
+		}
+	}
+	if len(runner.workerIDs) != 4 {
+		t.Fatalf("worker IDs = %#v, want four execution-scoped lease owners", runner.workerIDs)
+	}
+	seen := make(map[string]struct{}, len(runner.workerIDs))
+	for _, workerID := range runner.workerIDs {
+		if _, duplicate := seen[workerID]; duplicate {
+			t.Fatalf("duplicate worker ID %q in %#v", workerID, runner.workerIDs)
+		}
+		seen[workerID] = struct{}{}
+		suffix := workerID[strings.LastIndex(workerID, ":")+1:]
+		if _, err := uuid.Parse(suffix); err != nil {
+			t.Fatalf("worker ID %q has invalid UUID suffix: %v", workerID, err)
+		}
 	}
 }
 

--- a/internal/taskmanager/tasks/cache_metadata_images_test.go
+++ b/internal/taskmanager/tasks/cache_metadata_images_test.go
@@ -17,9 +17,11 @@ type fakeMetadataImageCacheRunner struct {
 	claimLimit  int
 	concurrency int
 	maxRuntime  time.Duration
+	drainCalls  int
+	backfills   int
 }
 
-func (f *fakeMetadataImageCacheRunner) RunUntilIdle(_ context.Context, _ string, claimLimit int, concurrency int, maxRuntime time.Duration, reportProgress metadata.ImageCacheRunProgressReporter) (metadata.ImageCacheRunStats, error) {
+func (f *fakeMetadataImageCacheRunner) run(claimLimit int, concurrency int, maxRuntime time.Duration, reportProgress metadata.ImageCacheRunProgressReporter) (metadata.ImageCacheRunStats, error) {
 	f.claimLimit = claimLimit
 	f.concurrency = concurrency
 	f.maxRuntime = maxRuntime
@@ -27,6 +29,16 @@ func (f *fakeMetadataImageCacheRunner) RunUntilIdle(_ context.Context, _ string,
 		reportProgress(update)
 	}
 	return f.stats, f.err
+}
+
+func (f *fakeMetadataImageCacheRunner) DrainUntilIdle(_ context.Context, _ string, claimLimit int, concurrency int, maxRuntime time.Duration, reportProgress metadata.ImageCacheRunProgressReporter) (metadata.ImageCacheRunStats, error) {
+	f.drainCalls++
+	return f.run(claimLimit, concurrency, maxRuntime, reportProgress)
+}
+
+func (f *fakeMetadataImageCacheRunner) RunUntilIdle(_ context.Context, _ string, claimLimit int, concurrency int, maxRuntime time.Duration, reportProgress metadata.ImageCacheRunProgressReporter) (metadata.ImageCacheRunStats, error) {
+	f.backfills++
+	return f.run(claimLimit, concurrency, maxRuntime, reportProgress)
 }
 
 type recordingProgress struct {
@@ -54,6 +66,23 @@ func TestCacheMetadataImagesTaskProperties(t *testing.T) {
 	}
 }
 
+func TestBackfillMetadataImagesTaskProperties(t *testing.T) {
+	task := NewBackfillMetadataImagesTask(&fakeMetadataImageCacheRunner{})
+	if task.Key() != "backfill_metadata_images" {
+		t.Fatalf("Key() = %q", task.Key())
+	}
+	if task.Category() != taskmanager.TaskCategoryMetadata {
+		t.Fatalf("Category() = %q", task.Category())
+	}
+	if len(task.DefaultTriggers()) != 0 {
+		t.Fatalf("DefaultTriggers count = %d, want manual-only", len(task.DefaultTriggers()))
+	}
+	shouldRun, err := task.ShouldRun(context.Background())
+	if err != nil || shouldRun {
+		t.Fatalf("ShouldRun() = %t, %v, want false, nil", shouldRun, err)
+	}
+}
+
 func TestCacheMetadataImagesTaskReportsStats(t *testing.T) {
 	runner := &fakeMetadataImageCacheRunner{
 		updates: []metadata.ImageCacheRunStats{{
@@ -65,7 +94,6 @@ func TestCacheMetadataImagesTaskReportsStats(t *testing.T) {
 		}},
 		stats: metadata.ImageCacheRunStats{
 			Batches:          3,
-			EnqueuedExisting: 5,
 			Claimed:          4,
 			Succeeded:        3,
 			Failed:           1,
@@ -87,17 +115,43 @@ func TestCacheMetadataImagesTaskReportsStats(t *testing.T) {
 	if runner.maxRuntime != 10*time.Minute {
 		t.Fatalf("maxRuntime = %s, want 10m", runner.maxRuntime)
 	}
+	if runner.drainCalls != 1 || runner.backfills != 0 {
+		t.Fatalf("runner calls drain=%d backfill=%d, want 1/0", runner.drainCalls, runner.backfills)
+	}
 	if len(progress.messages) != 3 {
 		t.Fatalf("progress reports = %d, want 3", len(progress.messages))
 	}
-	if progress.messages[0] != "Starting metadata image cache" || progress.percents[0] != 0 {
+	if progress.messages[0] != "Starting queued metadata image cache" || progress.percents[0] != 0 {
 		t.Fatalf("initial progress = %g %q", progress.percents[0], progress.messages[0])
 	}
 	if progress.messages[1] != "Processed 3 images across 2 batches (2 cached, 1 failed attempt, 0 skipped) · 3 of 10 in this run's backlog" || progress.percents[1] != 30 {
 		t.Fatalf("live progress = %g %q", progress.percents[1], progress.messages[1])
 	}
-	if progress.messages[2] != "Batches 3, enqueued 5 existing, claimed 4, cached 3, 1 failed attempt, skipped 0, uploaded 7 variants, found 2 existing variants, deleted 0 old successes" || progress.percents[2] != 100 {
+	if progress.messages[2] != "Batches 3, claimed 4, cached 3, 1 failed attempt, skipped 0, uploaded 7 variants, found 2 existing variants, deleted 0 old successes" || progress.percents[2] != 100 {
 		t.Fatalf("final progress = %g %q", progress.percents[2], progress.messages[2])
+	}
+}
+
+func TestBackfillMetadataImagesTaskReportsDiscovery(t *testing.T) {
+	runner := &fakeMetadataImageCacheRunner{stats: metadata.ImageCacheRunStats{
+		Batches:          2,
+		EnqueuedExisting: 5,
+		Claimed:          5,
+		Succeeded:        5,
+	}}
+	progress := &recordingProgress{}
+	if err := NewBackfillMetadataImagesTask(runner).Execute(context.Background(), progress); err != nil {
+		t.Fatalf("Execute() error = %v", err)
+	}
+	if runner.drainCalls != 0 || runner.backfills != 1 {
+		t.Fatalf("runner calls drain=%d backfill=%d, want 0/1", runner.drainCalls, runner.backfills)
+	}
+	if progress.messages[0] != "Starting full metadata image backfill" {
+		t.Fatalf("initial message = %q", progress.messages[0])
+	}
+	want := "Discovered 5 existing, Batches 2, claimed 5, cached 5, 0 failed attempts, skipped 0, uploaded 0 variants, found 0 existing variants, deleted 0 old successes"
+	if got := progress.messages[len(progress.messages)-1]; got != want {
+		t.Fatalf("final message = %q, want %q", got, want)
 	}
 }
 
@@ -191,12 +245,12 @@ func TestCacheMetadataImagesPercentIsMonotonicWithinARun(t *testing.T) {
 	}
 }
 
-// TestCacheMetadataImagesTaskProgressDoesNotFallWhenDiscoveryWidensTheRun
+// TestBackfillMetadataImagesTaskProgressDoesNotFallWhenDiscoveryWidensTheRun
 // covers the seam between the two halves of the progress fix: counting
 // discovered work keeps a backfill meaningful, but it also lets the raw ratio
 // dip when a sweep enqueues a fresh page, so what the task reports is clamped
 // to a high-water mark.
-func TestCacheMetadataImagesTaskProgressDoesNotFallWhenDiscoveryWidensTheRun(t *testing.T) {
+func TestBackfillMetadataImagesTaskProgressDoesNotFallWhenDiscoveryWidensTheRun(t *testing.T) {
 	runner := &fakeMetadataImageCacheRunner{
 		updates: []metadata.ImageCacheRunStats{
 			{Batches: 1, Succeeded: 40, EnqueuedExisting: 100, Backlog: metadata.ImageCacheBacklog{Known: true}},
@@ -205,7 +259,7 @@ func TestCacheMetadataImagesTaskProgressDoesNotFallWhenDiscoveryWidensTheRun(t *
 			{Batches: 3, Succeeded: 150, EnqueuedExisting: 200, Backlog: metadata.ImageCacheBacklog{Known: true}},
 		},
 	}
-	task := NewCacheMetadataImagesTask(runner)
+	task := NewBackfillMetadataImagesTask(runner)
 	progress := &recordingProgress{}
 	if err := task.Execute(context.Background(), progress); err != nil {
 		t.Fatalf("Execute() error = %v", err)

--- a/internal/taskmanager/tasks/reconcile_artwork_cache.go
+++ b/internal/taskmanager/tasks/reconcile_artwork_cache.go
@@ -3,6 +3,7 @@ package tasks
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"log/slog"
 	"strings"
@@ -13,6 +14,12 @@ import (
 	"github.com/Silo-Server/silo-server/internal/s3client"
 	"github.com/Silo-Server/silo-server/internal/taskmanager"
 )
+
+// ErrArtworkReconcileManualRunRequired prevents a storage-location change from
+// mutating artwork records on a scheduler trigger. An administrator must first
+// migrate the existing objects, then explicitly run the task if they intend
+// missing records to be re-queued or cleared.
+var ErrArtworkReconcileManualRunRequired = errors.New("artwork storage changed; manual reconcile required")
 
 // ArtworkStorageIdentityKey is the server_settings key holding the storage
 // identity fingerprint of the public S3 bucket the artwork cache was last
@@ -79,9 +86,9 @@ type BrandingAssetReconciler interface {
 
 // ReconcileArtworkCacheTask verifies cached artwork against the currently
 // configured public object storage and resets whatever is missing so the
-// image cache pipeline rebuilds it. Scheduled runs only fire when the storage
-// identity changed since the last completed reconcile; manual runs always
-// sweep, which doubles as recovery from bucket data loss.
+// image cache pipeline rebuilds it. Scheduled triggers never start this
+// mutating sweep after a storage change; an administrator must run it manually
+// after migrating objects or when intentionally recovering from bucket loss.
 type ReconcileArtworkCacheTask struct {
 	runner   ArtworkReconcileRunner
 	settings ArtworkReconcileSettingsStore
@@ -96,7 +103,7 @@ func NewReconcileArtworkCacheTask(runner ArtworkReconcileRunner, settings Artwor
 func (t *ReconcileArtworkCacheTask) Key() string  { return "reconcile_artwork_cache" }
 func (t *ReconcileArtworkCacheTask) Name() string { return "Reconcile Artwork Cache" }
 func (t *ReconcileArtworkCacheTask) Description() string {
-	return "Verifies cached artwork against object storage and re-caches anything missing (runs automatically after the storage provider changes)"
+	return "Manually verifies cached artwork against object storage; missing records may be re-queued or cleared across the full artwork library"
 }
 func (t *ReconcileArtworkCacheTask) Category() taskmanager.TaskCategory {
 	return taskmanager.TaskCategoryMetadata
@@ -109,8 +116,10 @@ func (t *ReconcileArtworkCacheTask) DefaultTriggers() []taskmanager.TriggerConfi
 	}
 }
 
-// ShouldRun suppresses the startup trigger while the storage identity is
-// unchanged. Manual RunTask calls bypass this and always sweep.
+// ShouldRun suppresses scheduled execution in every case. A changed storage
+// identity returns an actionable preflight error so the event is visible in
+// logs, but it must never launch a mutating sweep automatically. Manual
+// RunTask calls bypass this gate and remain the explicit recovery path.
 //
 // The startup trigger fires exactly once per process, so a transient settings
 // read failure here would postpone a needed reconcile until the next restart;
@@ -124,7 +133,13 @@ func (t *ReconcileArtworkCacheTask) ShouldRun(ctx context.Context) (bool, error)
 	if err != nil {
 		return false, fmt.Errorf("reading artwork storage identity: %w", err)
 	}
-	return stored != "" && stored != t.identity, nil
+	if stored == "" || stored == t.identity {
+		return false, nil
+	}
+	return false, fmt.Errorf(
+		"%w: migrate or copy the existing public artwork objects before running Reconcile Artwork Cache manually; a manual run may re-queue or clear the full artwork library",
+		ErrArtworkReconcileManualRunRequired,
+	)
 }
 
 func (t *ReconcileArtworkCacheTask) readStorageIdentity(ctx context.Context) (string, error) {
@@ -164,15 +179,15 @@ func (t *ReconcileArtworkCacheTask) Execute(ctx context.Context, progress taskma
 	}
 
 	// Only a clean, completed sweep certifies the current storage. Sweep
-	// errors mean rows were skipped unverified, so the fingerprint stays
-	// stale and the next startup retries; resets already applied this run
-	// are durable either way.
+	// errors mean rows were skipped unverified, so the fingerprint and saved
+	// checkpoint stay in place for an explicit manual retry; resets already
+	// applied this run are durable either way.
 	if stats.SweepErrors > 0 {
 		if data, marshalErr := json.Marshal(stats); marshalErr == nil {
 			progress.SetResultData(data)
 		}
 		return fmt.Errorf(
-			"artwork reconcile: %d rows skipped on storage errors (verified %d, re-queued %d, cleared %d); storage identity left uncertified so the next startup retries",
+			"artwork reconcile: %d rows skipped on storage errors (verified %d, re-queued %d, cleared %d); storage identity left uncertified; run Reconcile Artwork Cache manually to resume",
 			stats.SweepErrors, stats.Verified, stats.Requeued, stats.Cleared,
 		)
 	}

--- a/internal/taskmanager/tasks/reconcile_artwork_cache.go
+++ b/internal/taskmanager/tasks/reconcile_artwork_cache.go
@@ -18,7 +18,7 @@ import (
 // ErrArtworkReconcileManualRunRequired prevents a storage-location change from
 // mutating artwork records on a scheduler trigger. An administrator must first
 // migrate the existing objects, then explicitly run the task if they intend
-// missing records to be re-queued or cleared.
+// missing records to be reset for an explicit backfill or cleared.
 var ErrArtworkReconcileManualRunRequired = errors.New("artwork storage changed; manual reconcile required")
 
 // ArtworkStorageIdentityKey is the server_settings key holding the storage
@@ -103,7 +103,7 @@ func NewReconcileArtworkCacheTask(runner ArtworkReconcileRunner, settings Artwor
 func (t *ReconcileArtworkCacheTask) Key() string  { return "reconcile_artwork_cache" }
 func (t *ReconcileArtworkCacheTask) Name() string { return "Reconcile Artwork Cache" }
 func (t *ReconcileArtworkCacheTask) Description() string {
-	return "Manually verifies cached artwork against object storage; missing records may be re-queued or cleared across the full artwork library"
+	return "Manually verifies cached artwork against object storage; missing records may be reset across the full library and require an explicit metadata image backfill"
 }
 func (t *ReconcileArtworkCacheTask) Category() taskmanager.TaskCategory {
 	return taskmanager.TaskCategoryMetadata
@@ -137,7 +137,7 @@ func (t *ReconcileArtworkCacheTask) ShouldRun(ctx context.Context) (bool, error)
 		return false, nil
 	}
 	return false, fmt.Errorf(
-		"%w: migrate or copy the existing public artwork objects before running Reconcile Artwork Cache manually; a manual run may re-queue or clear the full artwork library",
+		"%w: migrate or copy the existing public artwork objects before running Reconcile Artwork Cache manually; a manual run may reset or clear the full artwork library, and re-downloading requires a separate manual Backfill Metadata Images run",
 		ErrArtworkReconcileManualRunRequired,
 	)
 }
@@ -187,7 +187,7 @@ func (t *ReconcileArtworkCacheTask) Execute(ctx context.Context, progress taskma
 			progress.SetResultData(data)
 		}
 		return fmt.Errorf(
-			"artwork reconcile: %d rows skipped on storage errors (verified %d, re-queued %d, cleared %d); storage identity left uncertified; run Reconcile Artwork Cache manually to resume",
+			"artwork reconcile: %d rows skipped on storage errors (verified %d, reset for backfill %d, cleared %d); storage identity left uncertified; run Reconcile Artwork Cache manually to resume",
 			stats.SweepErrors, stats.Verified, stats.Requeued, stats.Cleared,
 		)
 	}
@@ -222,12 +222,12 @@ func (t *ReconcileArtworkCacheTask) Execute(ctx context.Context, progress taskma
 	}
 
 	message := fmt.Sprintf(
-		"Verified %d cached images intact, re-queued %d for re-cache, cleared %d without a re-downloadable source",
+		"Verified %d cached images intact, reset %d for an optional manual backfill, cleared %d without a re-downloadable source",
 		stats.Verified, stats.Requeued, stats.Cleared,
 	)
 	if stats.Mode == metadata.ArtworkReconcileModeBulkReset {
 		message = fmt.Sprintf(
-			"Storage probe found %d/%d sampled objects missing; reset all cached artwork (re-queued %d, cleared %d)",
+			"Storage probe found %d/%d sampled objects missing; reset all cached artwork (%d provider records ready for an optional manual backfill, cleared %d)",
 			stats.SampleMissing, stats.Sampled, stats.Requeued, stats.Cleared,
 		)
 	}

--- a/internal/taskmanager/tasks/reconcile_artwork_cache.go
+++ b/internal/taskmanager/tasks/reconcile_artwork_cache.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/Silo-Server/silo-server/internal/config"
 	"github.com/Silo-Server/silo-server/internal/metadata"
 	"github.com/Silo-Server/silo-server/internal/s3client"
 	"github.com/Silo-Server/silo-server/internal/taskmanager"
@@ -21,7 +22,7 @@ const (
 	// ArtworkStorageReconcileCheckpointKey holds a machine-managed verify
 	// cursor. It is scoped to both the stored and target identities so a later
 	// storage move can never resume an older bucket's sweep.
-	ArtworkStorageReconcileCheckpointKey = "s3.public_storage_reconcile_checkpoint"
+	ArtworkStorageReconcileCheckpointKey = config.ArtworkStorageReconcileCheckpointKey
 )
 
 // ArtworkStorageIdentity builds the fingerprint of the public S3 storage the
@@ -119,22 +120,33 @@ func (t *ReconcileArtworkCacheTask) ShouldRun(ctx context.Context) (bool, error)
 	if t.runner == nil || t.settings == nil {
 		return false, nil
 	}
+	stored, err := t.readStorageIdentity(ctx)
+	if err != nil {
+		return false, fmt.Errorf("reading artwork storage identity: %w", err)
+	}
+	return stored != "" && stored != t.identity, nil
+}
+
+func (t *ReconcileArtworkCacheTask) readStorageIdentity(ctx context.Context) (string, error) {
 	var stored string
 	var err error
 	for attempt := 0; attempt < 3; attempt++ {
 		stored, err = t.settings.Get(ctx, ArtworkStorageIdentityKey)
 		if err == nil {
-			return stored != "" && stored != t.identity, nil
+			return stored, nil
+		}
+		if attempt == 2 {
+			break
 		}
 		timer := time.NewTimer(time.Duration(attempt+1) * time.Second)
 		select {
 		case <-timer.C:
 		case <-ctx.Done():
 			timer.Stop()
-			return false, ctx.Err()
+			return "", ctx.Err()
 		}
 	}
-	return false, fmt.Errorf("reading artwork storage identity: %w", err)
+	return "", err
 }
 
 func (t *ReconcileArtworkCacheTask) Execute(ctx context.Context, progress taskmanager.ProgressReporter) error {
@@ -222,7 +234,7 @@ func (t *ReconcileArtworkCacheTask) run(
 		return t.runner.Run(ctx, progress)
 	}
 
-	baseline, err := t.settings.Get(ctx, ArtworkStorageIdentityKey)
+	baseline, err := t.readStorageIdentity(ctx)
 	if err != nil {
 		return metadata.ArtworkReconcileStats{Mode: metadata.ArtworkReconcileModeVerify}, fmt.Errorf("reading artwork reconcile baseline identity: %w", err)
 	}

--- a/internal/taskmanager/tasks/reconcile_artwork_cache.go
+++ b/internal/taskmanager/tasks/reconcile_artwork_cache.go
@@ -16,7 +16,13 @@ import (
 // ArtworkStorageIdentityKey is the server_settings key holding the storage
 // identity fingerprint of the public S3 bucket the artwork cache was last
 // reconciled against. Machine-managed; not an admin-editable setting.
-const ArtworkStorageIdentityKey = "s3.public_storage_identity"
+const (
+	ArtworkStorageIdentityKey = "s3.public_storage_identity"
+	// ArtworkStorageReconcileCheckpointKey holds a machine-managed verify
+	// cursor. It is scoped to both the stored and target identities so a later
+	// storage move can never resume an older bucket's sweep.
+	ArtworkStorageReconcileCheckpointKey = "s3.public_storage_reconcile_checkpoint"
+)
 
 // ArtworkStorageIdentity builds the fingerprint of the public S3 storage the
 // cached artwork lives in. Only fields that determine *where objects are
@@ -46,6 +52,21 @@ type ArtworkReconcileSettingsStore interface {
 // *metadata.ArtworkCacheReconciler.
 type ArtworkReconcileRunner interface {
 	Run(ctx context.Context, progress func(percent float64, message string)) (metadata.ArtworkReconcileStats, error)
+}
+
+type resumableArtworkReconcileRunner interface {
+	RunResumable(
+		ctx context.Context,
+		checkpoint *metadata.ArtworkReconcileCheckpoint,
+		save func(metadata.ArtworkReconcileCheckpoint) error,
+		progress func(percent float64, message string),
+	) (metadata.ArtworkReconcileStats, error)
+}
+
+type artworkReconcileCheckpointEnvelope struct {
+	BaselineIdentity string                              `json:"baseline_identity"`
+	TargetIdentity   string                              `json:"target_identity"`
+	Checkpoint       metadata.ArtworkReconcileCheckpoint `json:"checkpoint"`
 }
 
 // BrandingAssetReconciler clears branding asset refs whose stored objects are
@@ -122,7 +143,7 @@ func (t *ReconcileArtworkCacheTask) Execute(ctx context.Context, progress taskma
 		return nil
 	}
 
-	stats, err := t.runner.Run(ctx, progress.Report)
+	stats, err := t.run(ctx, progress.Report)
 	if err != nil {
 		if data, marshalErr := json.Marshal(stats); marshalErr == nil {
 			progress.SetResultData(data)
@@ -149,6 +170,13 @@ func (t *ReconcileArtworkCacheTask) Execute(ctx context.Context, progress taskma
 	if setErr := t.settings.Set(ctx, ArtworkStorageIdentityKey, t.identity); setErr != nil {
 		return fmt.Errorf("persisting artwork storage identity: %w", setErr)
 	}
+	if clearErr := t.settings.Set(ctx, ArtworkStorageReconcileCheckpointKey, ""); clearErr != nil {
+		// The certified identity suppresses automatic reruns, and checkpoint
+		// envelopes are tied to their pre-run baseline, so stale state is safe.
+		// Surface the cleanup problem without turning a completed sweep into a
+		// failed task that an admin might unnecessarily repeat.
+		slog.WarnContext(ctx, "artwork reconcile: clearing completed checkpoint failed", "error", clearErr)
+	}
 
 	brandingNote := ""
 	if t.branding != nil {
@@ -170,7 +198,7 @@ func (t *ReconcileArtworkCacheTask) Execute(ctx context.Context, progress taskma
 		"Verified %d cached images intact, re-queued %d for re-cache, cleared %d without a re-downloadable source",
 		stats.Verified, stats.Requeued, stats.Cleared,
 	)
-	if stats.Mode == "bulk_reset" {
+	if stats.Mode == metadata.ArtworkReconcileModeBulkReset {
 		message = fmt.Sprintf(
 			"Storage probe found %d/%d sampled objects missing; reset all cached artwork (re-queued %d, cleared %d)",
 			stats.SampleMissing, stats.Sampled, stats.Requeued, stats.Cleared,
@@ -183,4 +211,52 @@ func (t *ReconcileArtworkCacheTask) Execute(ctx context.Context, progress taskma
 	}
 	progress.Report(100, message+brandingNote)
 	return nil
+}
+
+func (t *ReconcileArtworkCacheTask) run(
+	ctx context.Context,
+	progress func(percent float64, message string),
+) (metadata.ArtworkReconcileStats, error) {
+	runner, ok := t.runner.(resumableArtworkReconcileRunner)
+	if !ok {
+		return t.runner.Run(ctx, progress)
+	}
+
+	baseline, err := t.settings.Get(ctx, ArtworkStorageIdentityKey)
+	if err != nil {
+		return metadata.ArtworkReconcileStats{Mode: metadata.ArtworkReconcileModeVerify}, fmt.Errorf("reading artwork reconcile baseline identity: %w", err)
+	}
+	rawCheckpoint, err := t.settings.Get(ctx, ArtworkStorageReconcileCheckpointKey)
+	if err != nil {
+		return metadata.ArtworkReconcileStats{Mode: metadata.ArtworkReconcileModeVerify}, fmt.Errorf("reading artwork reconcile checkpoint: %w", err)
+	}
+
+	var checkpoint *metadata.ArtworkReconcileCheckpoint
+	if strings.TrimSpace(rawCheckpoint) != "" {
+		var envelope artworkReconcileCheckpointEnvelope
+		if unmarshalErr := json.Unmarshal([]byte(rawCheckpoint), &envelope); unmarshalErr != nil {
+			slog.WarnContext(ctx, "artwork reconcile: ignoring invalid checkpoint", "error", unmarshalErr)
+		} else if envelope.BaselineIdentity == baseline && envelope.TargetIdentity == t.identity &&
+			(baseline != t.identity || !envelope.Checkpoint.Complete()) {
+			checkpoint = &envelope.Checkpoint
+		}
+	}
+
+	save := func(next metadata.ArtworkReconcileCheckpoint) error {
+		envelope := artworkReconcileCheckpointEnvelope{
+			BaselineIdentity: baseline,
+			TargetIdentity:   t.identity,
+			Checkpoint:       next,
+		}
+		encoded, marshalErr := json.Marshal(envelope)
+		if marshalErr != nil {
+			return fmt.Errorf("encoding artwork reconcile checkpoint: %w", marshalErr)
+		}
+		if setErr := t.settings.Set(ctx, ArtworkStorageReconcileCheckpointKey, string(encoded)); setErr != nil {
+			return fmt.Errorf("persisting artwork reconcile checkpoint: %w", setErr)
+		}
+		return nil
+	}
+
+	return runner.RunResumable(ctx, checkpoint, save, progress)
 }

--- a/internal/taskmanager/tasks/reconcile_artwork_cache.go
+++ b/internal/taskmanager/tasks/reconcile_artwork_cache.go
@@ -226,6 +226,12 @@ func (t *ReconcileArtworkCacheTask) run(
 	if err != nil {
 		return metadata.ArtworkReconcileStats{Mode: metadata.ArtworkReconcileModeVerify}, fmt.Errorf("reading artwork reconcile baseline identity: %w", err)
 	}
+	// A same-identity run is a manual recovery sweep. It must cover the whole
+	// catalog as it exists now rather than inheriting a cursor from an older
+	// attempt, because objects may have disappeared anywhere in the meantime.
+	if baseline == t.identity {
+		return runner.RunResumable(ctx, nil, nil, progress)
+	}
 	rawCheckpoint, err := t.settings.Get(ctx, ArtworkStorageReconcileCheckpointKey)
 	if err != nil {
 		return metadata.ArtworkReconcileStats{Mode: metadata.ArtworkReconcileModeVerify}, fmt.Errorf("reading artwork reconcile checkpoint: %w", err)
@@ -236,8 +242,7 @@ func (t *ReconcileArtworkCacheTask) run(
 		var envelope artworkReconcileCheckpointEnvelope
 		if unmarshalErr := json.Unmarshal([]byte(rawCheckpoint), &envelope); unmarshalErr != nil {
 			slog.WarnContext(ctx, "artwork reconcile: ignoring invalid checkpoint", "error", unmarshalErr)
-		} else if envelope.BaselineIdentity == baseline && envelope.TargetIdentity == t.identity &&
-			(baseline != t.identity || !envelope.Checkpoint.Complete()) {
+		} else if envelope.BaselineIdentity == baseline && envelope.TargetIdentity == t.identity {
 			checkpoint = &envelope.Checkpoint
 		}
 	}

--- a/internal/taskmanager/tasks/reconcile_artwork_cache_test.go
+++ b/internal/taskmanager/tasks/reconcile_artwork_cache_test.go
@@ -47,6 +47,7 @@ type fakeResumableReconcileRunner struct {
 	stats            metadata.ArtworkReconcileStats
 	err              error
 	legacyRuns       int
+	saveProvided     bool
 }
 
 func (f *fakeResumableReconcileRunner) Run(context.Context, func(float64, string)) (metadata.ArtworkReconcileStats, error) {
@@ -60,13 +61,14 @@ func (f *fakeResumableReconcileRunner) RunResumable(
 	save func(metadata.ArtworkReconcileCheckpoint) error,
 	_ func(float64, string),
 ) (metadata.ArtworkReconcileStats, error) {
+	f.saveProvided = save != nil
 	if checkpoint != nil {
 		copied := *checkpoint
 		copied.Totals = append([]int(nil), checkpoint.Totals...)
 		copied.SurfaceCursor = append([]string(nil), checkpoint.SurfaceCursor...)
 		f.received = &copied
 	}
-	if f.checkpointToSave != nil {
+	if f.checkpointToSave != nil && save != nil {
 		if err := save(*f.checkpointToSave); err != nil {
 			return f.stats, err
 		}
@@ -235,6 +237,37 @@ func TestReconcileArtworkCacheCheckpointIsScopedToStorageMove(t *testing.T) {
 	}
 	if runner.received != nil {
 		t.Fatalf("received checkpoint from a different storage move: %#v", runner.received)
+	}
+}
+
+func TestReconcileArtworkCacheManualRunIgnoresSameIdentityCheckpoint(t *testing.T) {
+	checkpoint := metadata.ArtworkReconcileCheckpoint{
+		Version:      1,
+		Totals:       make([]int, 14),
+		SurfaceIndex: 3,
+		Stats:        metadata.ArtworkReconcileStats{Mode: metadata.ArtworkReconcileModeVerify},
+	}
+	envelope, err := json.Marshal(artworkReconcileCheckpointEnvelope{
+		BaselineIdentity: "current",
+		TargetIdentity:   "current",
+		Checkpoint:       checkpoint,
+	})
+	if err != nil {
+		t.Fatalf("marshal checkpoint: %v", err)
+	}
+	store := &fakeSettingsStore{values: map[string]string{
+		ArtworkStorageIdentityKey:            "current",
+		ArtworkStorageReconcileCheckpointKey: string(envelope),
+	}}
+	runner := &fakeResumableReconcileRunner{stats: metadata.ArtworkReconcileStats{Mode: metadata.ArtworkReconcileModeVerify}}
+	if err := NewReconcileArtworkCacheTask(runner, store, nil, "current").Execute(context.Background(), &fakeProgress{}); err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+	if runner.received != nil {
+		t.Fatalf("manual run resumed a stale same-identity checkpoint: %#v", runner.received)
+	}
+	if runner.saveProvided {
+		t.Fatal("manual same-identity run received a checkpoint saver")
 	}
 }
 

--- a/internal/taskmanager/tasks/reconcile_artwork_cache_test.go
+++ b/internal/taskmanager/tasks/reconcile_artwork_cache_test.go
@@ -240,6 +240,30 @@ func TestReconcileArtworkCacheCheckpointIsScopedToStorageMove(t *testing.T) {
 	}
 }
 
+func TestReconcileArtworkCacheIgnoresMalformedCheckpoint(t *testing.T) {
+	store := &fakeSettingsStore{values: map[string]string{
+		ArtworkStorageIdentityKey:            "old",
+		ArtworkStorageReconcileCheckpointKey: "{not-json",
+	}}
+	runner := &fakeResumableReconcileRunner{stats: metadata.ArtworkReconcileStats{Mode: metadata.ArtworkReconcileModeVerify}}
+
+	if err := NewReconcileArtworkCacheTask(runner, store, nil, "new").Execute(context.Background(), &fakeProgress{}); err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+	if runner.received != nil {
+		t.Fatalf("received malformed checkpoint: %#v", runner.received)
+	}
+	if !runner.saveProvided {
+		t.Fatal("fresh storage-move sweep did not receive a checkpoint saver")
+	}
+	if got := store.values[ArtworkStorageIdentityKey]; got != "new" {
+		t.Fatalf("fingerprint after completion = %q, want new", got)
+	}
+	if got := store.values[ArtworkStorageReconcileCheckpointKey]; got != "" {
+		t.Fatalf("checkpoint after completion = %q, want empty", got)
+	}
+}
+
 func TestReconcileArtworkCacheManualRunIgnoresSameIdentityCheckpoint(t *testing.T) {
 	checkpoint := metadata.ArtworkReconcileCheckpoint{
 		Version:      1,

--- a/internal/taskmanager/tasks/reconcile_artwork_cache_test.go
+++ b/internal/taskmanager/tasks/reconcile_artwork_cache_test.go
@@ -41,6 +41,39 @@ func (f *fakeReconcileRunner) Run(context.Context, func(float64, string)) (metad
 	return f.stats, f.err
 }
 
+type fakeResumableReconcileRunner struct {
+	received         *metadata.ArtworkReconcileCheckpoint
+	checkpointToSave *metadata.ArtworkReconcileCheckpoint
+	stats            metadata.ArtworkReconcileStats
+	err              error
+	legacyRuns       int
+}
+
+func (f *fakeResumableReconcileRunner) Run(context.Context, func(float64, string)) (metadata.ArtworkReconcileStats, error) {
+	f.legacyRuns++
+	return f.stats, f.err
+}
+
+func (f *fakeResumableReconcileRunner) RunResumable(
+	_ context.Context,
+	checkpoint *metadata.ArtworkReconcileCheckpoint,
+	save func(metadata.ArtworkReconcileCheckpoint) error,
+	_ func(float64, string),
+) (metadata.ArtworkReconcileStats, error) {
+	if checkpoint != nil {
+		copied := *checkpoint
+		copied.Totals = append([]int(nil), checkpoint.Totals...)
+		copied.SurfaceCursor = append([]string(nil), checkpoint.SurfaceCursor...)
+		f.received = &copied
+	}
+	if f.checkpointToSave != nil {
+		if err := save(*f.checkpointToSave); err != nil {
+			return f.stats, err
+		}
+	}
+	return f.stats, f.err
+}
+
 type fakeBrandingReconciler struct {
 	checked int
 	cleared int
@@ -129,6 +162,79 @@ func TestReconcileArtworkCacheExecutePersistsFingerprintOnlyOnSuccess(t *testing
 	}
 	if progress.resultData == nil {
 		t.Fatal("Execute did not record result data")
+	}
+}
+
+func TestReconcileArtworkCacheExecuteResumesMatchingCheckpoint(t *testing.T) {
+	store := &fakeSettingsStore{values: map[string]string{ArtworkStorageIdentityKey: "old"}}
+	checkpoint := metadata.ArtworkReconcileCheckpoint{
+		Version:       1,
+		Totals:        make([]int, 14),
+		SurfaceIndex:  9,
+		SurfaceCursor: []string{"128111764822294558"},
+		SurfaceDone:   500,
+		Done:          21500,
+		Stats:         metadata.ArtworkReconcileStats{Mode: "verify", Verified: 500},
+	}
+	interrupted := &fakeResumableReconcileRunner{
+		checkpointToSave: &checkpoint,
+		stats:            checkpoint.Stats,
+		err:              errors.New("interrupted"),
+	}
+	if err := NewReconcileArtworkCacheTask(interrupted, store, nil, "new").Execute(context.Background(), &fakeProgress{}); err == nil {
+		t.Fatal("interrupted Execute returned nil error")
+	}
+	if got := store.values[ArtworkStorageIdentityKey]; got != "old" {
+		t.Fatalf("fingerprint after interruption = %q, want old", got)
+	}
+	if strings.TrimSpace(store.values[ArtworkStorageReconcileCheckpointKey]) == "" {
+		t.Fatal("interrupted Execute did not retain its checkpoint")
+	}
+
+	resumed := &fakeResumableReconcileRunner{stats: metadata.ArtworkReconcileStats{Mode: "verify", Verified: 1000}}
+	if err := NewReconcileArtworkCacheTask(resumed, store, nil, "new").Execute(context.Background(), &fakeProgress{}); err != nil {
+		t.Fatalf("resumed Execute: %v", err)
+	}
+	if resumed.received == nil || resumed.received.SurfaceIndex != checkpoint.SurfaceIndex ||
+		len(resumed.received.SurfaceCursor) != 1 || resumed.received.SurfaceCursor[0] != checkpoint.SurfaceCursor[0] {
+		t.Fatalf("resumed checkpoint = %#v, want %#v", resumed.received, checkpoint)
+	}
+	if resumed.legacyRuns != 0 {
+		t.Fatalf("legacy Run called %d times, want 0", resumed.legacyRuns)
+	}
+	if got := store.values[ArtworkStorageIdentityKey]; got != "new" {
+		t.Fatalf("fingerprint after resumed completion = %q, want new", got)
+	}
+	if got := store.values[ArtworkStorageReconcileCheckpointKey]; got != "" {
+		t.Fatalf("checkpoint after completion = %q, want empty", got)
+	}
+}
+
+func TestReconcileArtworkCacheCheckpointIsScopedToStorageMove(t *testing.T) {
+	checkpoint := metadata.ArtworkReconcileCheckpoint{
+		Version:      1,
+		Totals:       make([]int, 14),
+		SurfaceIndex: 3,
+		Stats:        metadata.ArtworkReconcileStats{Mode: "verify"},
+	}
+	envelope, err := json.Marshal(artworkReconcileCheckpointEnvelope{
+		BaselineIdentity: "older",
+		TargetIdentity:   "different-target",
+		Checkpoint:       checkpoint,
+	})
+	if err != nil {
+		t.Fatalf("marshal checkpoint: %v", err)
+	}
+	store := &fakeSettingsStore{values: map[string]string{
+		ArtworkStorageIdentityKey:            "old",
+		ArtworkStorageReconcileCheckpointKey: string(envelope),
+	}}
+	runner := &fakeResumableReconcileRunner{stats: metadata.ArtworkReconcileStats{Mode: "verify"}}
+	if err := NewReconcileArtworkCacheTask(runner, store, nil, "new").Execute(context.Background(), &fakeProgress{}); err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+	if runner.received != nil {
+		t.Fatalf("received checkpoint from a different storage move: %#v", runner.received)
 	}
 }
 

--- a/internal/taskmanager/tasks/reconcile_artwork_cache_test.go
+++ b/internal/taskmanager/tasks/reconcile_artwork_cache_test.go
@@ -136,8 +136,11 @@ func TestReconcileArtworkCacheShouldRun(t *testing.T) {
 	}
 
 	store.values[ArtworkStorageIdentityKey] = "old-endpoint|bucket|prefix"
-	if run, err := task.ShouldRun(context.Background()); err != nil || !run {
-		t.Fatalf("ShouldRun with changed fingerprint = %v, %v; want true, nil", run, err)
+	if run, err := task.ShouldRun(context.Background()); run || !errors.Is(err, ErrArtworkReconcileManualRunRequired) {
+		t.Fatalf("ShouldRun with changed fingerprint = %v, %v; want false, manual-run-required", run, err)
+	}
+	if runner.runs != 0 {
+		t.Fatalf("scheduled preflight ran reconciler %d times, want 0", runner.runs)
 	}
 }
 
@@ -194,7 +197,18 @@ func TestReconcileArtworkCacheExecuteResumesMatchingCheckpoint(t *testing.T) {
 	}
 
 	resumed := &fakeResumableReconcileRunner{stats: metadata.ArtworkReconcileStats{Mode: "verify", Verified: 1000}}
-	if err := NewReconcileArtworkCacheTask(resumed, store, nil, "new").Execute(context.Background(), &fakeProgress{}); err != nil {
+	resumeTask := NewReconcileArtworkCacheTask(resumed, store, nil, "new")
+	rawCheckpoint := store.values[ArtworkStorageReconcileCheckpointKey]
+	if run, err := resumeTask.ShouldRun(context.Background()); run || !errors.Is(err, ErrArtworkReconcileManualRunRequired) {
+		t.Fatalf("scheduled resume preflight = %v, %v; want false, manual-run-required", run, err)
+	}
+	if got := store.values[ArtworkStorageReconcileCheckpointKey]; got != rawCheckpoint {
+		t.Fatal("scheduled preflight changed the saved checkpoint")
+	}
+	if resumed.received != nil || resumed.legacyRuns != 0 {
+		t.Fatal("scheduled preflight invoked the resumable runner")
+	}
+	if err := resumeTask.Execute(context.Background(), &fakeProgress{}); err != nil {
 		t.Fatalf("resumed Execute: %v", err)
 	}
 	if resumed.received == nil || resumed.received.SurfaceIndex != checkpoint.SurfaceIndex ||

--- a/internal/taskmanager/worker.go
+++ b/internal/taskmanager/worker.go
@@ -50,6 +50,9 @@ func (w *taskWorker) info() TaskInfo {
 		ProgressMessage: w.progressMessage,
 		LastExecution:   w.lastResult,
 	}
+	if task, ok := w.task.(ManualOnlyTask); ok {
+		info.ManualOnly = task.ManualOnly()
+	}
 
 	var earliest time.Time
 	for _, tr := range w.triggers {

--- a/web/src/api/types.ts
+++ b/web/src/api/types.ts
@@ -4583,6 +4583,7 @@ export interface TaskInfo {
   state: TaskState;
   progress: number;
   progress_message?: string;
+  manual_only?: boolean;
   last_execution?: ExecutionResult;
   triggers: TriggerConfig[];
   next_run_at?: string;

--- a/web/src/pages/AdminTaskDetail.tsx
+++ b/web/src/pages/AdminTaskDetail.tsx
@@ -568,14 +568,21 @@ export default function AdminTaskDetail() {
       <div className="space-y-3">
         <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
           <h2 className="text-lg font-medium tracking-tight">Schedule</h2>
-          {!editing && (
+          {!task.manual_only && !editing && (
             <Button variant="outline" size="sm" onClick={startEditing}>
               Edit Schedule
             </Button>
           )}
         </div>
 
-        {!editing ? (
+        {task.manual_only ? (
+          <div className="surface-panel-subtle rounded-xl p-4 text-sm">
+            <p className="text-muted-foreground">
+              Manual only. This task runs only when you select Run Now; scheduled triggers cannot be
+              configured.
+            </p>
+          </div>
+        ) : !editing ? (
           <div className="surface-panel overflow-hidden rounded-2xl border-0">
             {task.triggers.length === 0 && (
               <p className="text-muted-foreground p-4 text-sm">No triggers configured.</p>

--- a/web/src/pages/admin-settings/StorageSettings.test.tsx
+++ b/web/src/pages/admin-settings/StorageSettings.test.tsx
@@ -71,6 +71,8 @@ describe("StorageSettings", () => {
     const markup = renderToStaticMarkup(<StorageSettings />);
 
     expect(markup).toContain("Storage location change");
-    expect(markup).toContain("re-caches anything missing");
+    expect(markup).toContain("will not change artwork cache records");
+    expect(markup).toContain("manually run Reconcile Artwork Cache");
+    expect(markup).not.toContain("automatically re-caches anything missing");
   });
 });

--- a/web/src/pages/admin-settings/StorageSettings.test.tsx
+++ b/web/src/pages/admin-settings/StorageSettings.test.tsx
@@ -73,6 +73,8 @@ describe("StorageSettings", () => {
     expect(markup).toContain("Storage location change");
     expect(markup).toContain("will not change artwork cache records");
     expect(markup).toContain("manually run Reconcile Artwork Cache");
+    expect(markup).toContain("manual Backfill Metadata Images");
+    expect(markup).toContain("new or changed metadata");
     expect(markup).not.toContain("automatically re-caches anything missing");
   });
 });

--- a/web/src/pages/admin-settings/StorageSettings.tsx
+++ b/web/src/pages/admin-settings/StorageSettings.tsx
@@ -209,8 +209,10 @@ export default function StorageSettings() {
                     Artwork is cached in this bucket. Silo will not change artwork cache records
                     automatically after restart. Copy or migrate the existing bucket objects first,
                     then manually run Reconcile Artwork Cache only if you intend every missing
-                    record to be re-queued or cleared. Uploaded images (custom posters, collection
-                    artwork, branding) cannot be re-downloaded.
+                    record to be reset or cleared. Re-downloading those reset provider images is a
+                    separate, manual Backfill Metadata Images action; normal scheduled caching only
+                    processes artwork queued by new or changed metadata. Uploaded images (custom
+                    posters, collection artwork, branding) cannot be re-downloaded.
                   </p>
                 </div>
               </div>

--- a/web/src/pages/admin-settings/StorageSettings.tsx
+++ b/web/src/pages/admin-settings/StorageSettings.tsx
@@ -26,8 +26,9 @@ const PUBLIC_S3_KEYS = [
   "s3.public_token_ttl",
 ] as const;
 
-// Changing any of these moves where cached artwork objects live; the server
-// reconciles the artwork cache after a restart (see reconcile_artwork_cache).
+// Changing any of these moves where cached artwork objects live. Silo detects
+// that change after restart but requires an explicit manual reconcile so an
+// incomplete bucket migration cannot rewrite the artwork catalog.
 const PUBLIC_S3_IDENTITY_KEYS = [
   "s3.public_endpoint",
   "s3.public_bucket",
@@ -205,10 +206,11 @@ export default function StorageSettings() {
                 <div className="text-[13px] leading-relaxed">
                   <p className="font-medium text-amber-500">Storage location change</p>
                   <p className="text-muted-foreground mt-1">
-                    Artwork is cached in this bucket. After the server restarts, Silo verifies the
-                    cache against the new storage and automatically re-caches anything missing.
-                    Uploaded images (custom posters, collection artwork, branding) cannot be
-                    re-downloaded — migrate your bucket contents if you want to keep them.
+                    Artwork is cached in this bucket. Silo will not change artwork cache records
+                    automatically after restart. Copy or migrate the existing bucket objects first,
+                    then manually run Reconcile Artwork Cache only if you intend every missing
+                    record to be re-queued or cleared. Uploaded images (custom posters, collection
+                    artwork, branding) cannot be re-downloaded.
                   </p>
                 </div>
               </div>


### PR DESCRIPTION
## Problem

Part of #348. Follow-up to #349.

The storage-change reconciler introduced in #349 can run automatically at startup. When a newly configured public bucket is empty, incomplete, or misrouted, successful `HeadObject` 404 responses can satisfy the 95% bulk-reset threshold. Silo then rewrites artwork pointers before an administrator has had a chance to migrate the existing objects.

The existing scheduled **Cache Metadata Images** task also mixes two very different operations: draining durable jobs created by scans and metadata changes, and periodically discovering provider artwork across the entire catalog. Because its discovery timestamp is process-local, the first run after every restart can begin another full-library sweep even when the durable queue has already been completed.

Interrupted reconcile runs also persisted progress only in memory, so a manual retry restarted the full catalog walk. Person-photo and library-poster pagination cast numeric IDs to text, forcing repeated scans and sorts on large catalogs.

## Approach

- Fail closed for every scheduled reconciliation. The startup trigger may detect and log a changed storage identity, but it never launches the mutating sweep.
- Require an explicit administrator-run **Reconcile Artwork Cache** task after the existing artwork objects have been copied or migrated.
- Make scheduled/startup **Cache Metadata Images** drain only durable jobs already queued by scans, refreshes, and metadata changes.
- Move full-catalog discovery into a separate manual-only **Backfill Metadata Images** task. It has no default triggers and its scheduler preflight always fails closed; only an explicit administrator run can start it.
- Enforce manual-only behavior in the task API and UI, so a backfill schedule cannot be configured accidentally.
- Claim only the two artwork jobs that can start immediately while retaining 1,000-row discovery pages, avoiding lease expiry on a large unstarted batch.
- Give every execution a unique lease owner and serialize drain/backfill runs through a cancellable gate, preventing stale or overlapping workers from finalizing each other's jobs.
- Make a manual backfill run until discovery is complete or explicitly cancelled, and fail closed if image caching is disabled before or during the run.
- Warn in Storage Settings that reconcile resets missing cache records and that backfill is a separate manual action.
- Persist a versioned verify-mode checkpoint after each fully completed batch, scoped to the exact baseline-to-target storage transition.
- Preserve interrupted checkpoints for an explicit manual retry; same-identity manual recovery still starts a fresh sweep.
- Keep pagination and guarded updates on native primary-key types, casting only selected cursor values for serialization.
- Stop at the first unsafe batch instead of advancing a checkpoint past storage errors.

Normal incremental caching is preserved: newly added or changed artwork still creates durable jobs, and the scheduled cache task drains those jobs. Manual reconcile and backfill retain the existing recovery behavior, but neither can be initiated by normal scheduling.

This PR does not silently certify a new bucket or copy/delete S3 objects. The person-photo enrichment feedback loop is addressed separately in #685.

## Testing

```text
GOWORK=off go test ./internal/metadata ./internal/taskmanager/tasks ./internal/api/handlers ./internal/config ./cmd/silo -count=1
GOWORK=off go test -race ./internal/metadata ./internal/taskmanager/tasks -count=1
GOWORK=off go vet ./internal/metadata ./internal/taskmanager/... ./internal/api/handlers ./internal/config ./cmd/silo
pnpm exec vitest run src/pages/admin-settings/StorageSettings.test.tsx
pnpm exec tsc -b
pnpm exec eslint src/pages/admin-settings/StorageSettings.tsx src/pages/admin-settings/StorageSettings.test.tsx
pnpm exec prettier --check src/pages/admin-settings/StorageSettings.tsx src/pages/admin-settings/StorageSettings.test.tsx
pnpm run build
git diff --check
```

The PostgreSQL-backed person-enrichment integration case remains separate follow-up work and skips when `SILO_TEST_DATABASE_URL` is not configured.

### AI Disclosure

- Tool(s): OpenAI Codex
- Model(s): GPT-5 (Codex)
- Involvement: Developed collaboratively by @blurbery and Codex. @blurbery reproduced the behavior on a real deployment, supplied runtime and storage observations, and directed the desired safety behavior and upstream contribution path. Codex assisted with code analysis, implementation, tests, and verification.
- Adversarial review: Independent read-only review found both the automatic-startup reconciliation risk and the restart-triggered catalog-discovery path. The revised design blocks scheduled reconciliation mutation and separates safe durable-queue draining from explicit full-catalog backfill.

## Checklist

- [x] Scheduled storage-change reconciliation fails closed.
- [x] Scheduled metadata caching drains only durable queued work.
- [x] Full-catalog discovery is a separate manual-only task.
- [x] Manual-only scheduling is enforced by both API and UI.
- [x] Queue leases, overlap, cancellation, and mid-run disable behavior are covered.
- [x] Manual recovery remains available and checkpointed.
- [x] Admin UI explains the migration-first and explicit-backfill requirements.
- [x] Relevant Go and Web tests pass locally.
- [x] AI assistance is disclosed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added resumable artwork cache reconciliation that preserves progress across interruptions.
  * Added a manual metadata-image backfill task for existing catalog content.
  * Task details now identify tasks that can only be run manually.

* **Changes**
  * Queued image processing is separate from full-catalog backfills for more predictable operation.
  * Public storage changes now clearly require manual cache reconciliation and image backfill.

* **Bug Fixes**
  * Prevented scheduled execution of manual-only tasks.
  * Protected system-managed reconciliation settings from administrative edits.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->