### PR TITLE
fix(catalog): preserve cached person artwork during enrichment

### DIFF
--- a/internal/catalog/person_repo.go
+++ b/internal/catalog/person_repo.go
@@ -86,8 +86,52 @@ func (r *PersonRepository) FindOrCreate(ctx context.Context, p models.Person) (i
 }
 
 // enrichExisting updates empty fields on an existing person with non-empty values from p.
+func personPhotoFillPredicate(existing, incoming string) string {
+	return fmt.Sprintf(
+		"((COALESCE(%s, '') = '' AND %s <> '') OR (%s = '-' AND %s NOT IN ('', '-')))",
+		existing, incoming, existing, incoming,
+	)
+}
+
+func batchPersonEnrichmentQuery() string {
+	photoPathFill := personPhotoFillPredicate("people.photo_path", "t.photo_path")
+	photoSourceFill := personPhotoFillPredicate("people.photo_source_path", "t.photo_source_path")
+	photoThumbFill := personPhotoFillPredicate("people.photo_thumbhash", "t.photo_thumbhash")
+	return fmt.Sprintf(`
+		UPDATE people SET
+			tmdb_id = CASE WHEN COALESCE(people.tmdb_id, '') = '' AND t.tmdb_id <> '' THEN t.tmdb_id ELSE people.tmdb_id END,
+			imdb_id = CASE WHEN COALESCE(people.imdb_id, '') = '' AND t.imdb_id <> '' THEN t.imdb_id ELSE people.imdb_id END,
+			tvdb_id = CASE WHEN COALESCE(people.tvdb_id, '') = '' AND t.tvdb_id <> '' THEN t.tvdb_id ELSE people.tvdb_id END,
+			plex_guid = CASE WHEN COALESCE(people.plex_guid, '') = '' AND t.plex_guid <> '' THEN t.plex_guid ELSE people.plex_guid END,
+			photo_path = CASE WHEN %[1]s THEN t.photo_path ELSE people.photo_path END,
+			photo_source_path = CASE WHEN %[2]s THEN t.photo_source_path ELSE people.photo_source_path END,
+			photo_thumbhash = CASE WHEN %[3]s THEN t.photo_thumbhash ELSE people.photo_thumbhash END,
+			bio = CASE WHEN COALESCE(people.bio, '') = '' AND t.bio <> '' THEN t.bio ELSE people.bio END,
+			birthplace = CASE WHEN COALESCE(people.birthplace, '') = '' AND t.birthplace <> '' THEN t.birthplace ELSE people.birthplace END,
+			homepage = CASE WHEN COALESCE(people.homepage, '') = '' AND t.homepage <> '' THEN t.homepage ELSE people.homepage END,
+			updated_at = NOW()
+		FROM UNNEST($1::bigint[], $2::text[], $3::text[], $4::text[], $5::text[],
+		            $6::text[], $7::text[], $8::text[], $9::text[], $10::text[], $11::text[])
+			AS t(id, tmdb_id, imdb_id, tvdb_id, plex_guid,
+			     photo_path, photo_source_path, photo_thumbhash, bio, birthplace, homepage)
+		WHERE people.id = t.id
+		  AND (
+			(COALESCE(people.tmdb_id, '') = '' AND t.tmdb_id <> '') OR
+			(COALESCE(people.imdb_id, '') = '' AND t.imdb_id <> '') OR
+			(COALESCE(people.tvdb_id, '') = '' AND t.tvdb_id <> '') OR
+			(COALESCE(people.plex_guid, '') = '' AND t.plex_guid <> '') OR
+			%[1]s OR
+			%[2]s OR
+			%[3]s OR
+			(COALESCE(people.bio, '') = '' AND t.bio <> '') OR
+			(COALESCE(people.birthplace, '') = '' AND t.birthplace <> '') OR
+			(COALESCE(people.homepage, '') = '' AND t.homepage <> '')
+		  )`, photoPathFill, photoSourceFill, photoThumbFill)
+}
+
 func (r *PersonRepository) enrichExisting(ctx context.Context, id int64, p models.Person) (int64, error) {
 	var setClauses []string
+	var changePredicates []string
 	var args []interface{}
 	argIdx := 1
 
@@ -96,22 +140,21 @@ func (r *PersonRepository) enrichExisting(ctx context.Context, id int64, p model
 		if value == "" {
 			return
 		}
-		setClauses = append(setClauses, fmt.Sprintf("%s = CASE WHEN %s = '' THEN $%d ELSE %s END", column, column, argIdx, column))
+		setClauses = append(setClauses, fmt.Sprintf("%s = CASE WHEN COALESCE(%s, '') = '' THEN $%d ELSE %s END", column, column, argIdx, column))
+		changePredicates = append(changePredicates, fmt.Sprintf("COALESCE(%s, '') = ''", column))
 		args = append(args, value)
 		argIdx++
 	}
-	// overwriteIfReal sets the column when the new value is real. The "-"
-	// sentinel ("no photo, but we tried") is only written when the existing
-	// column is empty, so it cannot clobber a real provider path.
-	overwriteIfReal := func(column, value string) {
+	// fillPhoto also allows a real image to replace the explicit "no photo"
+	// sentinel, but never replaces a populated provider or cached S3 path.
+	fillPhoto := func(column, value string) {
 		if value == "" {
 			return
 		}
-		if value == "-" {
-			setClauses = append(setClauses, fmt.Sprintf("%s = CASE WHEN %s = '' THEN $%d ELSE %s END", column, column, argIdx, column))
-		} else {
-			setClauses = append(setClauses, fmt.Sprintf("%s = $%d", column, argIdx))
-		}
+		incoming := fmt.Sprintf("$%d", argIdx)
+		predicate := personPhotoFillPredicate(column, incoming)
+		setClauses = append(setClauses, fmt.Sprintf("%s = CASE WHEN %s THEN %s ELSE %s END", column, predicate, incoming, column))
+		changePredicates = append(changePredicates, predicate)
 		args = append(args, value)
 		argIdx++
 	}
@@ -120,9 +163,9 @@ func (r *PersonRepository) enrichExisting(ctx context.Context, id int64, p model
 	fillEmpty("imdb_id", p.ImdbID)
 	fillEmpty("tvdb_id", p.TvdbID)
 	fillEmpty("plex_guid", p.PlexGUID)
-	overwriteIfReal("photo_path", p.PhotoPath)
-	overwriteIfReal("photo_source_path", p.PhotoSourcePath)
-	overwriteIfReal("photo_thumbhash", p.PhotoThumbhash)
+	fillPhoto("photo_path", p.PhotoPath)
+	fillPhoto("photo_source_path", p.PhotoSourcePath)
+	fillPhoto("photo_thumbhash", p.PhotoThumbhash)
 	fillEmpty("bio", p.Bio)
 	fillEmpty("birthplace", p.Birthplace)
 	fillEmpty("homepage", p.Homepage)
@@ -132,7 +175,10 @@ func (r *PersonRepository) enrichExisting(ctx context.Context, id int64, p model
 	}
 
 	setClauses = append(setClauses, "updated_at = now()")
-	query := fmt.Sprintf("UPDATE people SET %s WHERE id = $%d", strings.Join(setClauses, ", "), argIdx)
+	query := fmt.Sprintf(
+		"UPDATE people SET %s WHERE id = $%d AND (%s)",
+		strings.Join(setClauses, ", "), argIdx, strings.Join(changePredicates, " OR "),
+	)
 	args = append(args, id)
 
 	if _, err := r.pool.Exec(ctx, query, args...); err != nil {
@@ -283,7 +329,8 @@ func (r *PersonRepository) BatchFindOrCreate(ctx context.Context, people []model
 		rows.Close()
 	}
 
-	// Phase 4: Batch enrich found people (same fillEmpty/overwrite semantics).
+	// Phase 4: Batch enrich found people. Item-credit data is only allowed to
+	// fill gaps; full person refresh owns replacement of existing artwork.
 	if len(toEnrich) > 0 {
 		enrichIDs := make([]int64, len(toEnrich))
 		eTmdbIDs := make([]string, len(toEnrich))
@@ -309,36 +356,7 @@ func (r *PersonRepository) BatchFindOrCreate(ctx context.Context, people []model
 			eBirthplaces[i] = e.person.Birthplace
 			eHomepages[i] = e.person.Homepage
 		}
-		_, err := r.pool.Exec(ctx, `
-			UPDATE people SET
-				tmdb_id = CASE WHEN people.tmdb_id = '' AND t.tmdb_id <> '' THEN t.tmdb_id ELSE people.tmdb_id END,
-				imdb_id = CASE WHEN people.imdb_id = '' AND t.imdb_id <> '' THEN t.imdb_id ELSE people.imdb_id END,
-				tvdb_id = CASE WHEN people.tvdb_id = '' AND t.tvdb_id <> '' THEN t.tvdb_id ELSE people.tvdb_id END,
-				plex_guid = CASE WHEN people.plex_guid = '' AND t.plex_guid <> '' THEN t.plex_guid ELSE people.plex_guid END,
-				photo_path = CASE
-					WHEN t.photo_path NOT IN ('', '-') THEN t.photo_path
-					WHEN people.photo_path = ''        THEN t.photo_path
-					ELSE people.photo_path
-				END,
-				photo_source_path = CASE
-					WHEN t.photo_source_path NOT IN ('', '-') THEN t.photo_source_path
-					WHEN people.photo_source_path = ''        THEN t.photo_source_path
-					ELSE people.photo_source_path
-				END,
-				photo_thumbhash = CASE
-					WHEN t.photo_thumbhash NOT IN ('', '-') THEN t.photo_thumbhash
-					WHEN people.photo_thumbhash = ''        THEN t.photo_thumbhash
-					ELSE people.photo_thumbhash
-				END,
-				bio = CASE WHEN people.bio = '' AND t.bio <> '' THEN t.bio ELSE people.bio END,
-				birthplace = CASE WHEN people.birthplace = '' AND t.birthplace <> '' THEN t.birthplace ELSE people.birthplace END,
-				homepage = CASE WHEN people.homepage = '' AND t.homepage <> '' THEN t.homepage ELSE people.homepage END,
-				updated_at = NOW()
-			FROM UNNEST($1::bigint[], $2::text[], $3::text[], $4::text[], $5::text[],
-			            $6::text[], $7::text[], $8::text[], $9::text[], $10::text[], $11::text[])
-				AS t(id, tmdb_id, imdb_id, tvdb_id, plex_guid,
-				     photo_path, photo_source_path, photo_thumbhash, bio, birthplace, homepage)
-			WHERE people.id = t.id`,
+		_, err := r.pool.Exec(ctx, batchPersonEnrichmentQuery(),
 			enrichIDs, eTmdbIDs, eImdbIDs, eTvdbIDs, ePlexGUIDs,
 			ePhotoPaths, ePhotoSourcePaths, ePhotoThumbs, eBios, eBirthplaces, eHomepages,
 		)

--- a/internal/catalog/person_repo.go
+++ b/internal/catalog/person_repo.go
@@ -7,6 +7,7 @@ import (
 	"log/slog"
 	"strconv"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/jackc/pgx/v5"
@@ -85,18 +86,35 @@ func (r *PersonRepository) FindOrCreate(ctx context.Context, p models.Person) (i
 	return id, nil
 }
 
-// enrichExisting updates empty fields on an existing person with non-empty values from p.
-func personPhotoFillPredicate(existing, incoming string) string {
+// personPhotoReplacePredicate builds the SQL condition under which item-credit
+// data may write a person's photo columns.
+//
+// A cached artwork key is immutable and is never replaced from a credit.
+// Credits carry the provider URL, so overwriting the key would both re-arm the
+// download loop (EnqueueExistingProviderArtwork treats a URL in photo_path as
+// "not cached yet") and hand the displaced key to the artwork GC trigger.
+// Anything that is not a cached key is still replaceable by a real image: an
+// empty column, the "-" no-photo sentinel, and a provider URL that never made
+// it through the cache. Keeping URLs replaceable is what stops a person with
+// no external id — FindRefreshCandidates skips them, so no refresh will ever
+// revisit the row — from being stuck with a dead URL forever. The
+// LIKE '%://%' test for "not a cached key" is the same one the artwork GC
+// trigger and the image cache sweep use.
+func personPhotoReplacePredicate(existingPath, incomingPath string) string {
 	return fmt.Sprintf(
-		"((COALESCE(%s, '') = '' AND %s <> '') OR (%s = '-' AND %s NOT IN ('', '-')))",
-		existing, incoming, existing, incoming,
+		"((COALESCE(%[1]s, '') = '' AND %[2]s <> '') OR "+
+			"((%[1]s = '-' OR %[1]s LIKE '%%://%%') AND %[2]s NOT IN ('', '-') "+
+			"AND %[2]s IS DISTINCT FROM %[1]s))",
+		existingPath, incomingPath,
 	)
 }
 
-func batchPersonEnrichmentQuery() string {
-	photoPathFill := personPhotoFillPredicate("people.photo_path", "t.photo_path")
-	photoSourceFill := personPhotoFillPredicate("people.photo_source_path", "t.photo_source_path")
-	photoThumbFill := personPhotoFillPredicate("people.photo_thumbhash", "t.photo_thumbhash")
+// batchPersonEnrichmentSQL is built once: the text is constant, and the batch
+// enricher runs per scan batch.
+var batchPersonEnrichmentSQL = sync.OnceValue(buildBatchPersonEnrichmentQuery)
+
+func buildBatchPersonEnrichmentQuery() string {
+	photoReplace := personPhotoReplacePredicate("people.photo_path", "t.photo_path")
 	return fmt.Sprintf(`
 		UPDATE people SET
 			tmdb_id = CASE WHEN COALESCE(people.tmdb_id, '') = '' AND t.tmdb_id <> '' THEN t.tmdb_id ELSE people.tmdb_id END,
@@ -104,8 +122,8 @@ func batchPersonEnrichmentQuery() string {
 			tvdb_id = CASE WHEN COALESCE(people.tvdb_id, '') = '' AND t.tvdb_id <> '' THEN t.tvdb_id ELSE people.tvdb_id END,
 			plex_guid = CASE WHEN COALESCE(people.plex_guid, '') = '' AND t.plex_guid <> '' THEN t.plex_guid ELSE people.plex_guid END,
 			photo_path = CASE WHEN %[1]s THEN t.photo_path ELSE people.photo_path END,
-			photo_source_path = CASE WHEN %[2]s THEN t.photo_source_path ELSE people.photo_source_path END,
-			photo_thumbhash = CASE WHEN %[3]s THEN t.photo_thumbhash ELSE people.photo_thumbhash END,
+			photo_source_path = CASE WHEN %[1]s THEN t.photo_source_path ELSE people.photo_source_path END,
+			photo_thumbhash = CASE WHEN %[1]s THEN t.photo_thumbhash ELSE people.photo_thumbhash END,
 			bio = CASE WHEN COALESCE(people.bio, '') = '' AND t.bio <> '' THEN t.bio ELSE people.bio END,
 			birthplace = CASE WHEN COALESCE(people.birthplace, '') = '' AND t.birthplace <> '' THEN t.birthplace ELSE people.birthplace END,
 			homepage = CASE WHEN COALESCE(people.homepage, '') = '' AND t.homepage <> '' THEN t.homepage ELSE people.homepage END,
@@ -121,14 +139,15 @@ func batchPersonEnrichmentQuery() string {
 			(COALESCE(people.tvdb_id, '') = '' AND t.tvdb_id <> '') OR
 			(COALESCE(people.plex_guid, '') = '' AND t.plex_guid <> '') OR
 			%[1]s OR
-			%[2]s OR
-			%[3]s OR
 			(COALESCE(people.bio, '') = '' AND t.bio <> '') OR
 			(COALESCE(people.birthplace, '') = '' AND t.birthplace <> '') OR
 			(COALESCE(people.homepage, '') = '' AND t.homepage <> '')
-		  )`, photoPathFill, photoSourceFill, photoThumbFill)
+		  )`, photoReplace)
 }
 
+// enrichExisting fills gaps on an existing person from p. It never rewrites a
+// field the catalog already holds, and it leaves the row — including
+// updated_at — untouched when there is nothing to fill.
 func (r *PersonRepository) enrichExisting(ctx context.Context, id int64, p models.Person) (int64, error) {
 	var setClauses []string
 	var changePredicates []string
@@ -145,27 +164,33 @@ func (r *PersonRepository) enrichExisting(ctx context.Context, id int64, p model
 		args = append(args, value)
 		argIdx++
 	}
-	// fillPhoto also allows a real image to replace the explicit "no photo"
-	// sentinel, but never replaces a populated provider or cached S3 path.
-	fillPhoto := func(column, value string) {
-		if value == "" {
+	// fillPhoto writes the photo triple as a unit under one decision taken on
+	// photo_path. The path, its source URL, and its thumbhash describe a single
+	// image: moving the path alone binds the new photo to the previous source,
+	// which is what UpdatePhotoIfSourceMatches keys the cache handshake on, so
+	// the finished download would land the *old* image on the row — and leave
+	// the old image's thumbhash behind it.
+	fillPhoto := func(person models.Person) {
+		if person.PhotoPath == "" {
 			return
 		}
 		incoming := fmt.Sprintf("$%d", argIdx)
-		predicate := personPhotoFillPredicate(column, incoming)
-		setClauses = append(setClauses, fmt.Sprintf("%s = CASE WHEN %s THEN %s ELSE %s END", column, predicate, incoming, column))
+		predicate := personPhotoReplacePredicate("photo_path", incoming)
+		setClauses = append(setClauses,
+			fmt.Sprintf("photo_path = CASE WHEN %s THEN %s ELSE photo_path END", predicate, incoming),
+			fmt.Sprintf("photo_source_path = CASE WHEN %s THEN $%d ELSE photo_source_path END", predicate, argIdx+1),
+			fmt.Sprintf("photo_thumbhash = CASE WHEN %s THEN $%d ELSE photo_thumbhash END", predicate, argIdx+2),
+		)
 		changePredicates = append(changePredicates, predicate)
-		args = append(args, value)
-		argIdx++
+		args = append(args, person.PhotoPath, person.PhotoSourcePath, person.PhotoThumbhash)
+		argIdx += 3
 	}
 
 	fillEmpty("tmdb_id", p.TmdbID)
 	fillEmpty("imdb_id", p.ImdbID)
 	fillEmpty("tvdb_id", p.TvdbID)
 	fillEmpty("plex_guid", p.PlexGUID)
-	fillPhoto("photo_path", p.PhotoPath)
-	fillPhoto("photo_source_path", p.PhotoSourcePath)
-	fillPhoto("photo_thumbhash", p.PhotoThumbhash)
+	fillPhoto(p)
 	fillEmpty("bio", p.Bio)
 	fillEmpty("birthplace", p.Birthplace)
 	fillEmpty("homepage", p.Homepage)
@@ -329,8 +354,9 @@ func (r *PersonRepository) BatchFindOrCreate(ctx context.Context, people []model
 		rows.Close()
 	}
 
-	// Phase 4: Batch enrich found people. Item-credit data is only allowed to
-	// fill gaps; full person refresh owns replacement of existing artwork.
+	// Phase 4: Batch enrich found people. Item-credit data fills gaps and may
+	// replace a photo that was never cached; a cached artwork key is immutable
+	// here. See personPhotoReplacePredicate.
 	if len(toEnrich) > 0 {
 		enrichIDs := make([]int64, len(toEnrich))
 		eTmdbIDs := make([]string, len(toEnrich))
@@ -356,7 +382,7 @@ func (r *PersonRepository) BatchFindOrCreate(ctx context.Context, people []model
 			eBirthplaces[i] = e.person.Birthplace
 			eHomepages[i] = e.person.Homepage
 		}
-		_, err := r.pool.Exec(ctx, batchPersonEnrichmentQuery(),
+		_, err := r.pool.Exec(ctx, batchPersonEnrichmentSQL(),
 			enrichIDs, eTmdbIDs, eImdbIDs, eTvdbIDs, ePlexGUIDs,
 			ePhotoPaths, ePhotoSourcePaths, ePhotoThumbs, eBios, eBirthplaces, eHomepages,
 		)

--- a/internal/catalog/person_repo_enrichment_test.go
+++ b/internal/catalog/person_repo_enrichment_test.go
@@ -1,0 +1,207 @@
+package catalog
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/jackc/pgx/v5/pgxpool"
+
+	"github.com/Silo-Server/silo-server/internal/models"
+)
+
+func TestPersonPhotoEnrichmentSQLGuardsExistingArtwork(t *testing.T) {
+	single := personPhotoFillPredicate("photo_path", "$1")
+	for _, fragment := range []string{
+		"COALESCE(photo_path, '') = '' AND $1 <> ''",
+		"photo_path = '-' AND $1 NOT IN ('', '-')",
+	} {
+		if !strings.Contains(single, fragment) {
+			t.Fatalf("single photo predicate %q is missing %q", single, fragment)
+		}
+	}
+
+	batch := batchPersonEnrichmentQuery()
+	for _, field := range []string{"photo_path", "photo_source_path", "photo_thumbhash"} {
+		emptyGuard := fmt.Sprintf("COALESCE(people.%s, '') = '' AND t.%s <> ''", field, field)
+		sentinelGuard := fmt.Sprintf("people.%s = '-' AND t.%s NOT IN ('', '-')", field, field)
+		preserveExisting := fmt.Sprintf("ELSE people.%s END", field)
+		for _, fragment := range []string{emptyGuard, sentinelGuard, preserveExisting} {
+			if !strings.Contains(batch, fragment) {
+				t.Fatalf("batch enrichment SQL for %s is missing %q", field, fragment)
+			}
+		}
+		destructive := fmt.Sprintf("WHEN t.%s NOT IN ('', '-') THEN t.%s", field, field)
+		if strings.Contains(batch, destructive) {
+			t.Fatalf("batch enrichment SQL still unconditionally overwrites %s", field)
+		}
+	}
+	if !strings.Contains(batch, "WHERE people.id = t.id") || !strings.Contains(batch, "updated_at = NOW()") {
+		t.Fatal("batch enrichment SQL lost its guarded update or timestamp assignment")
+	}
+}
+
+func TestPersonCreditEnrichmentPreservesCachedArtwork(t *testing.T) {
+	dsn := os.Getenv("SILO_TEST_DATABASE_URL")
+	if dsn == "" {
+		t.Skip("SILO_TEST_DATABASE_URL is not set")
+	}
+
+	ctx := context.Background()
+	pool, err := pgxpool.New(ctx, dsn)
+	if err != nil {
+		t.Fatalf("connect test database: %v", err)
+	}
+	t.Cleanup(pool.Close)
+	repo := NewPersonRepository(pool)
+
+	type seededPerson struct {
+		id        int64
+		tmdbID    string
+		photoPath string
+		updatedAt time.Time
+	}
+	seed := func(label string) seededPerson {
+		t.Helper()
+		nowID := time.Now().UnixNano()
+		seeded := seededPerson{
+			id:        nowID,
+			tmdbID:    fmt.Sprintf("credit-enrichment-%s-%d", label, nowID),
+			photoPath: fmt.Sprintf("tmdb/people/%d/profile/original.cached.webp", nowID),
+			updatedAt: time.Now().UTC().Add(-48 * time.Hour).Truncate(time.Microsecond),
+		}
+		_, err := pool.Exec(ctx, `
+			INSERT INTO people (
+				id, name, tmdb_id, imdb_id, tvdb_id, plex_guid,
+				photo_path, photo_source_path, photo_thumbhash,
+				bio, birthplace, homepage, updated_at
+			) VALUES (
+				$1, $2, $3, $4, $5, $6,
+				$7, 'https://images.example/original.jpg', 'existing-thumbhash',
+				'existing bio', 'existing birthplace', 'https://example.com', $8
+			)
+		`, seeded.id, "Credit Enrichment "+label, seeded.tmdbID,
+			fmt.Sprintf("existing-imdb-%d", nowID), fmt.Sprintf("existing-tvdb-%d", nowID),
+			fmt.Sprintf("existing-plex-%d", nowID), seeded.photoPath, seeded.updatedAt)
+		if err != nil {
+			t.Fatalf("seed person: %v", err)
+		}
+		t.Cleanup(func() {
+			_, _ = pool.Exec(ctx, `DELETE FROM people WHERE id = $1`, seeded.id)
+			_, _ = pool.Exec(ctx, `DELETE FROM artwork_revision_gc_candidates WHERE original_path = $1`, seeded.photoPath)
+		})
+		return seeded
+	}
+
+	assertPreserved := func(seed seededPerson) {
+		t.Helper()
+		var photoPath, sourcePath, thumbhash string
+		var updatedAt time.Time
+		if err := pool.QueryRow(ctx, `
+			SELECT photo_path, photo_source_path, photo_thumbhash, updated_at
+			FROM people WHERE id = $1
+		`, seed.id).Scan(&photoPath, &sourcePath, &thumbhash, &updatedAt); err != nil {
+			t.Fatalf("read enriched person: %v", err)
+		}
+		if photoPath != seed.photoPath {
+			t.Fatalf("cached photo_path was overwritten: got %q, want %q", photoPath, seed.photoPath)
+		}
+		if sourcePath != "https://images.example/original.jpg" {
+			t.Fatalf("photo_source_path was overwritten: %q", sourcePath)
+		}
+		if thumbhash != "existing-thumbhash" {
+			t.Fatalf("photo_thumbhash was overwritten: %q", thumbhash)
+		}
+		if !updatedAt.Equal(seed.updatedAt) {
+			t.Fatalf("no-op enrichment changed updated_at: got %v, want %v", updatedAt, seed.updatedAt)
+		}
+		var gcCandidates int
+		if err := pool.QueryRow(ctx, `
+			SELECT count(*) FROM artwork_revision_gc_candidates WHERE original_path = $1
+		`, seed.photoPath).Scan(&gcCandidates); err != nil {
+			t.Fatalf("count artwork GC candidates: %v", err)
+		}
+		if gcCandidates != 0 {
+			t.Fatalf("no-op enrichment armed %d artwork GC candidates, want 0", gcCandidates)
+		}
+	}
+
+	incoming := func(seed seededPerson) models.Person {
+		return models.Person{
+			Name:            "Credit Enrichment",
+			TmdbID:          seed.tmdbID,
+			ImdbID:          "replacement-imdb",
+			TvdbID:          "replacement-tvdb",
+			PlexGUID:        "replacement-plex",
+			PhotoPath:       "https://images.example/replacement.jpg",
+			PhotoSourcePath: "https://images.example/replacement-source.jpg",
+			PhotoThumbhash:  "replacement-thumbhash",
+			Bio:             "replacement bio",
+			Birthplace:      "replacement birthplace",
+			Homepage:        "https://replacement.example.com",
+		}
+	}
+
+	t.Run("single find or create", func(t *testing.T) {
+		seeded := seed("single")
+		id, err := repo.FindOrCreate(ctx, incoming(seeded))
+		if err != nil {
+			t.Fatalf("FindOrCreate: %v", err)
+		}
+		if id != seeded.id {
+			t.Fatalf("FindOrCreate id = %d, want %d", id, seeded.id)
+		}
+		assertPreserved(seeded)
+	})
+
+	t.Run("batch find or create", func(t *testing.T) {
+		seeded := seed("batch")
+		ids, err := repo.BatchFindOrCreate(ctx, []models.Person{incoming(seeded)})
+		if err != nil {
+			t.Fatalf("BatchFindOrCreate: %v", err)
+		}
+		if len(ids) != 1 || ids[0] != seeded.id {
+			t.Fatalf("BatchFindOrCreate ids = %v, want [%d]", ids, seeded.id)
+		}
+		assertPreserved(seeded)
+	})
+
+	t.Run("real photo replaces no-photo sentinel", func(t *testing.T) {
+		seeded := seed("sentinel")
+		if _, err := pool.Exec(ctx, `
+			UPDATE people
+			SET photo_path = '-', photo_source_path = '', photo_thumbhash = '', updated_at = $2
+			WHERE id = $1
+		`, seeded.id, seeded.updatedAt); err != nil {
+			t.Fatalf("set no-photo sentinel: %v", err)
+		}
+
+		ids, err := repo.BatchFindOrCreate(ctx, []models.Person{incoming(seeded)})
+		if err != nil {
+			t.Fatalf("BatchFindOrCreate: %v", err)
+		}
+		if len(ids) != 1 || ids[0] != seeded.id {
+			t.Fatalf("BatchFindOrCreate ids = %v, want [%d]", ids, seeded.id)
+		}
+
+		var photoPath, sourcePath, thumbhash string
+		var updatedAt time.Time
+		if err := pool.QueryRow(ctx, `
+			SELECT photo_path, photo_source_path, photo_thumbhash, updated_at
+			FROM people WHERE id = $1
+		`, seeded.id).Scan(&photoPath, &sourcePath, &thumbhash, &updatedAt); err != nil {
+			t.Fatalf("read sentinel replacement: %v", err)
+		}
+		if photoPath != "https://images.example/replacement.jpg" ||
+			sourcePath != "https://images.example/replacement-source.jpg" ||
+			thumbhash != "replacement-thumbhash" {
+			t.Fatalf("real photo did not replace sentinel: path=%q source=%q thumbhash=%q", photoPath, sourcePath, thumbhash)
+		}
+		if !updatedAt.After(seeded.updatedAt) {
+			t.Fatalf("sentinel replacement did not advance updated_at: got %v, previous %v", updatedAt, seeded.updatedAt)
+		}
+	})
+}

--- a/internal/catalog/person_repo_enrichment_test.go
+++ b/internal/catalog/person_repo_enrichment_test.go
@@ -13,30 +13,40 @@ import (
 	"github.com/Silo-Server/silo-server/internal/models"
 )
 
-func TestPersonPhotoEnrichmentSQLGuardsExistingArtwork(t *testing.T) {
-	single := personPhotoFillPredicate("photo_path", "$1")
+// The generated SQL is asserted clause by clause because the enrichment rule
+// only exists as SQL: there is no Go decision to unit test. Matching whole
+// generated clauses (not loose fragments) is what makes a mis-wired column —
+// the photo_source_path assignment gated on photo_thumbhash, say — fail here.
+// Behavior is covered by TestPersonCreditEnrichmentPhotoRules, which needs a
+// Postgres instance and therefore does not run in the default gate.
+func TestPersonPhotoEnrichmentSQLGuardsCachedArtwork(t *testing.T) {
+	single := personPhotoReplacePredicate("photo_path", "$1")
 	for _, fragment := range []string{
 		"COALESCE(photo_path, '') = '' AND $1 <> ''",
-		"photo_path = '-' AND $1 NOT IN ('', '-')",
+		"photo_path = '-' OR photo_path LIKE '%://%'",
+		"$1 NOT IN ('', '-')",
+		"$1 IS DISTINCT FROM photo_path",
 	} {
 		if !strings.Contains(single, fragment) {
-			t.Fatalf("single photo predicate %q is missing %q", single, fragment)
+			t.Fatalf("photo replace predicate %q is missing %q", single, fragment)
 		}
 	}
 
-	batch := batchPersonEnrichmentQuery()
-	for _, field := range []string{"photo_path", "photo_source_path", "photo_thumbhash"} {
-		emptyGuard := fmt.Sprintf("COALESCE(people.%s, '') = '' AND t.%s <> ''", field, field)
-		sentinelGuard := fmt.Sprintf("people.%s = '-' AND t.%s NOT IN ('', '-')", field, field)
-		preserveExisting := fmt.Sprintf("ELSE people.%s END", field)
-		for _, fragment := range []string{emptyGuard, sentinelGuard, preserveExisting} {
-			if !strings.Contains(batch, fragment) {
-				t.Fatalf("batch enrichment SQL for %s is missing %q", field, fragment)
-			}
+	batch := buildBatchPersonEnrichmentQuery()
+	gate := personPhotoReplacePredicate("people.photo_path", "t.photo_path")
+	if !strings.Contains(batch, gate) {
+		t.Fatalf("batch enrichment SQL does not gate on the photo replace predicate %q", gate)
+	}
+	// Every photo column moves under the same photo_path decision, so the
+	// served path can never be bound to the previous image's source or hash.
+	for _, column := range []string{"photo_path", "photo_source_path", "photo_thumbhash"} {
+		clause := fmt.Sprintf("%s = CASE WHEN %s THEN t.%s ELSE people.%s END", column, gate, column, column)
+		if !strings.Contains(batch, clause) {
+			t.Fatalf("batch enrichment SQL is missing the guarded assignment %q", clause)
 		}
-		destructive := fmt.Sprintf("WHEN t.%s NOT IN ('', '-') THEN t.%s", field, field)
+		destructive := fmt.Sprintf("WHEN t.%s NOT IN ('', '-') THEN t.%s", column, column)
 		if strings.Contains(batch, destructive) {
-			t.Fatalf("batch enrichment SQL still unconditionally overwrites %s", field)
+			t.Fatalf("batch enrichment SQL still unconditionally overwrites %s", column)
 		}
 	}
 	if !strings.Contains(batch, "WHERE people.id = t.id") || !strings.Contains(batch, "updated_at = NOW()") {
@@ -44,7 +54,21 @@ func TestPersonPhotoEnrichmentSQLGuardsExistingArtwork(t *testing.T) {
 	}
 }
 
-func TestPersonCreditEnrichmentPreservesCachedArtwork(t *testing.T) {
+type seededPerson struct {
+	id        int64
+	tmdbID    string
+	photoPath string
+	updatedAt time.Time
+}
+
+type personPhotoState struct {
+	photoPath string
+	source    string
+	thumbhash string
+	updatedAt time.Time
+}
+
+func TestPersonCreditEnrichmentPhotoRules(t *testing.T) {
 	dsn := os.Getenv("SILO_TEST_DATABASE_URL")
 	if dsn == "" {
 		t.Skip("SILO_TEST_DATABASE_URL is not set")
@@ -58,19 +82,22 @@ func TestPersonCreditEnrichmentPreservesCachedArtwork(t *testing.T) {
 	t.Cleanup(pool.Close)
 	repo := NewPersonRepository(pool)
 
-	type seededPerson struct {
-		id        int64
-		tmdbID    string
-		photoPath string
-		updatedAt time.Time
-	}
-	seed := func(label string) seededPerson {
+	const cachedKey = "tmdb/people/%d/profile/original.cached.webp"
+
+	// seed inserts a person whose every enrichable field is already populated,
+	// so any row change observed by a test came from the photo rule.
+	seed := func(t *testing.T, label, photoPath, sourcePath string) seededPerson {
 		t.Helper()
 		nowID := time.Now().UnixNano()
+		// Cached keys are per-person so the artwork GC assertions cannot pick
+		// up a row left by another test; the literal paths pass through.
+		if strings.Contains(photoPath, "%d") {
+			photoPath = fmt.Sprintf(photoPath, nowID)
+		}
 		seeded := seededPerson{
 			id:        nowID,
 			tmdbID:    fmt.Sprintf("credit-enrichment-%s-%d", label, nowID),
-			photoPath: fmt.Sprintf("tmdb/people/%d/profile/original.cached.webp", nowID),
+			photoPath: photoPath,
 			updatedAt: time.Now().UTC().Add(-48 * time.Hour).Truncate(time.Microsecond),
 		}
 		_, err := pool.Exec(ctx, `
@@ -80,12 +107,12 @@ func TestPersonCreditEnrichmentPreservesCachedArtwork(t *testing.T) {
 				bio, birthplace, homepage, updated_at
 			) VALUES (
 				$1, $2, $3, $4, $5, $6,
-				$7, 'https://images.example/original.jpg', 'existing-thumbhash',
-				'existing bio', 'existing birthplace', 'https://example.com', $8
+				$7, $8, 'existing-thumbhash',
+				'existing bio', 'existing birthplace', 'https://example.com', $9
 			)
 		`, seeded.id, "Credit Enrichment "+label, seeded.tmdbID,
 			fmt.Sprintf("existing-imdb-%d", nowID), fmt.Sprintf("existing-tvdb-%d", nowID),
-			fmt.Sprintf("existing-plex-%d", nowID), seeded.photoPath, seeded.updatedAt)
+			fmt.Sprintf("existing-plex-%d", nowID), seeded.photoPath, sourcePath, seeded.updatedAt)
 		if err != nil {
 			t.Fatalf("seed person: %v", err)
 		}
@@ -96,112 +123,162 @@ func TestPersonCreditEnrichmentPreservesCachedArtwork(t *testing.T) {
 		return seeded
 	}
 
-	assertPreserved := func(seed seededPerson) {
+	readPhoto := func(t *testing.T, id int64) personPhotoState {
 		t.Helper()
-		var photoPath, sourcePath, thumbhash string
-		var updatedAt time.Time
+		var got personPhotoState
 		if err := pool.QueryRow(ctx, `
-			SELECT photo_path, photo_source_path, photo_thumbhash, updated_at
+			SELECT COALESCE(photo_path, ''), COALESCE(photo_source_path, ''),
+			       COALESCE(photo_thumbhash, ''), updated_at
 			FROM people WHERE id = $1
-		`, seed.id).Scan(&photoPath, &sourcePath, &thumbhash, &updatedAt); err != nil {
+		`, id).Scan(&got.photoPath, &got.source, &got.thumbhash, &got.updatedAt); err != nil {
 			t.Fatalf("read enriched person: %v", err)
 		}
-		if photoPath != seed.photoPath {
-			t.Fatalf("cached photo_path was overwritten: got %q, want %q", photoPath, seed.photoPath)
-		}
-		if sourcePath != "https://images.example/original.jpg" {
-			t.Fatalf("photo_source_path was overwritten: %q", sourcePath)
-		}
-		if thumbhash != "existing-thumbhash" {
-			t.Fatalf("photo_thumbhash was overwritten: %q", thumbhash)
-		}
-		if !updatedAt.Equal(seed.updatedAt) {
-			t.Fatalf("no-op enrichment changed updated_at: got %v, want %v", updatedAt, seed.updatedAt)
-		}
-		var gcCandidates int
+		return got
+	}
+
+	assertNoGCCandidate := func(t *testing.T, path string) {
+		t.Helper()
+		var candidates int
 		if err := pool.QueryRow(ctx, `
 			SELECT count(*) FROM artwork_revision_gc_candidates WHERE original_path = $1
-		`, seed.photoPath).Scan(&gcCandidates); err != nil {
+		`, path).Scan(&candidates); err != nil {
 			t.Fatalf("count artwork GC candidates: %v", err)
 		}
-		if gcCandidates != 0 {
-			t.Fatalf("no-op enrichment armed %d artwork GC candidates, want 0", gcCandidates)
+		if candidates != 0 {
+			t.Fatalf("enrichment armed %d artwork GC candidates for %q, want 0", candidates, path)
 		}
 	}
 
-	incoming := func(seed seededPerson) models.Person {
+	// incoming is shaped like a real item credit: every scalar field carries a
+	// replacement value, and the photo columns carry whatever the caller passes.
+	incoming := func(seed seededPerson, photoPath, sourcePath, thumbhash string) models.Person {
 		return models.Person{
 			Name:            "Credit Enrichment",
 			TmdbID:          seed.tmdbID,
 			ImdbID:          "replacement-imdb",
 			TvdbID:          "replacement-tvdb",
 			PlexGUID:        "replacement-plex",
-			PhotoPath:       "https://images.example/replacement.jpg",
-			PhotoSourcePath: "https://images.example/replacement-source.jpg",
-			PhotoThumbhash:  "replacement-thumbhash",
+			PhotoPath:       photoPath,
+			PhotoSourcePath: sourcePath,
+			PhotoThumbhash:  thumbhash,
 			Bio:             "replacement bio",
 			Birthplace:      "replacement birthplace",
 			Homepage:        "https://replacement.example.com",
 		}
 	}
 
-	t.Run("single find or create", func(t *testing.T) {
-		seeded := seed("single")
-		id, err := repo.FindOrCreate(ctx, incoming(seeded))
+	batchEnrich := func(t *testing.T, seed seededPerson, p models.Person) {
+		t.Helper()
+		ids, err := repo.BatchFindOrCreate(ctx, []models.Person{p})
+		if err != nil {
+			t.Fatalf("BatchFindOrCreate: %v", err)
+		}
+		if len(ids) != 1 || ids[0] != seed.id {
+			t.Fatalf("BatchFindOrCreate ids = %v, want [%d]", ids, seed.id)
+		}
+	}
+
+	t.Run("cached key survives single find or create", func(t *testing.T) {
+		seeded := seed(t, "single", cachedKey, "https://images.example/original.jpg")
+		id, err := repo.FindOrCreate(ctx, incoming(seeded,
+			"https://images.example/replacement.jpg",
+			"https://images.example/replacement-source.jpg",
+			"replacement-thumbhash"))
 		if err != nil {
 			t.Fatalf("FindOrCreate: %v", err)
 		}
 		if id != seeded.id {
 			t.Fatalf("FindOrCreate id = %d, want %d", id, seeded.id)
 		}
-		assertPreserved(seeded)
+		got := readPhoto(t, seeded.id)
+		if got.photoPath != seeded.photoPath || got.source != "https://images.example/original.jpg" ||
+			got.thumbhash != "existing-thumbhash" {
+			t.Fatalf("cached artwork was overwritten: %+v", got)
+		}
+		if !got.updatedAt.Equal(seeded.updatedAt) {
+			t.Fatalf("no-op enrichment changed updated_at: got %v, want %v", got.updatedAt, seeded.updatedAt)
+		}
+		assertNoGCCandidate(t, seeded.photoPath)
 	})
 
-	t.Run("batch find or create", func(t *testing.T) {
-		seeded := seed("batch")
-		ids, err := repo.BatchFindOrCreate(ctx, []models.Person{incoming(seeded)})
-		if err != nil {
-			t.Fatalf("BatchFindOrCreate: %v", err)
+	t.Run("cached key survives batch find or create", func(t *testing.T) {
+		seeded := seed(t, "batch", cachedKey, "https://images.example/original.jpg")
+		batchEnrich(t, seeded, incoming(seeded,
+			"https://images.example/replacement.jpg",
+			"https://images.example/replacement-source.jpg",
+			"replacement-thumbhash"))
+		got := readPhoto(t, seeded.id)
+		if got.photoPath != seeded.photoPath || got.source != "https://images.example/original.jpg" ||
+			got.thumbhash != "existing-thumbhash" {
+			t.Fatalf("cached artwork was overwritten: %+v", got)
 		}
-		if len(ids) != 1 || ids[0] != seeded.id {
-			t.Fatalf("BatchFindOrCreate ids = %v, want [%d]", ids, seeded.id)
+		if !got.updatedAt.Equal(seeded.updatedAt) {
+			t.Fatalf("no-op enrichment changed updated_at: got %v, want %v", got.updatedAt, seeded.updatedAt)
 		}
-		assertPreserved(seeded)
+		assertNoGCCandidate(t, seeded.photoPath)
 	})
 
-	t.Run("real photo replaces no-photo sentinel", func(t *testing.T) {
-		seeded := seed("sentinel")
-		if _, err := pool.Exec(ctx, `
-			UPDATE people
-			SET photo_path = '-', photo_source_path = '', photo_thumbhash = '', updated_at = $2
-			WHERE id = $1
-		`, seeded.id, seeded.updatedAt); err != nil {
-			t.Fatalf("set no-photo sentinel: %v", err)
+	// A credit carries a photo URL but never a source path, so the whole triple
+	// has to move together: leaving the old source behind would make the image
+	// cache download it and land the previous image under the new photo.
+	t.Run("sentinel replacement clears the previous source binding", func(t *testing.T) {
+		seeded := seed(t, "sentinel", "-", "https://images.example/stale-source.jpg")
+		batchEnrich(t, seeded, incoming(seeded, "https://images.example/replacement.jpg", "", ""))
+		got := readPhoto(t, seeded.id)
+		if got.photoPath != "https://images.example/replacement.jpg" || got.source != "" || got.thumbhash != "" {
+			t.Fatalf("photo triple did not move as a unit: %+v", got)
 		}
+		if !got.updatedAt.After(seeded.updatedAt) {
+			t.Fatalf("sentinel replacement did not advance updated_at: got %v, previous %v", got.updatedAt, seeded.updatedAt)
+		}
+	})
 
-		ids, err := repo.BatchFindOrCreate(ctx, []models.Person{incoming(seeded)})
-		if err != nil {
-			t.Fatalf("BatchFindOrCreate: %v", err)
+	// Nothing refreshes a person without an external id (FindRefreshCandidates
+	// skips them), so an uncached URL has to stay replaceable from a credit.
+	t.Run("uncached url is replaceable", func(t *testing.T) {
+		seeded := seed(t, "url", "https://images.example/dead-%d.jpg", "https://images.example/dead-source.jpg")
+		batchEnrich(t, seeded, incoming(seeded,
+			"https://images.example/replacement.jpg",
+			"https://images.example/replacement-source.jpg",
+			"replacement-thumbhash"))
+		got := readPhoto(t, seeded.id)
+		if got.photoPath != "https://images.example/replacement.jpg" ||
+			got.source != "https://images.example/replacement-source.jpg" ||
+			got.thumbhash != "replacement-thumbhash" {
+			t.Fatalf("uncached url was not replaced: %+v", got)
 		}
-		if len(ids) != 1 || ids[0] != seeded.id {
-			t.Fatalf("BatchFindOrCreate ids = %v, want [%d]", ids, seeded.id)
-		}
+		// The GC trigger ignores non-cached paths, so displacing a URL must not
+		// queue anything for deletion.
+		assertNoGCCandidate(t, seeded.photoPath)
+	})
 
-		var photoPath, sourcePath, thumbhash string
-		var updatedAt time.Time
-		if err := pool.QueryRow(ctx, `
-			SELECT photo_path, photo_source_path, photo_thumbhash, updated_at
-			FROM people WHERE id = $1
-		`, seeded.id).Scan(&photoPath, &sourcePath, &thumbhash, &updatedAt); err != nil {
-			t.Fatalf("read sentinel replacement: %v", err)
+	// Re-scanning an unchanged credit must not touch the row: rewriting the
+	// same URL would drop the source path a pending cache job is keyed on and
+	// re-order the person in the refresh sweep for nothing.
+	t.Run("unchanged url is a no-op", func(t *testing.T) {
+		seeded := seed(t, "same", "https://images.example/same-%d.jpg", "https://images.example/same-source.jpg")
+		batchEnrich(t, seeded, incoming(seeded, seeded.photoPath, "", ""))
+		got := readPhoto(t, seeded.id)
+		if got.photoPath != seeded.photoPath || got.source != "https://images.example/same-source.jpg" ||
+			got.thumbhash != "existing-thumbhash" {
+			t.Fatalf("unchanged credit rewrote the photo columns: %+v", got)
 		}
-		if photoPath != "https://images.example/replacement.jpg" ||
-			sourcePath != "https://images.example/replacement-source.jpg" ||
-			thumbhash != "replacement-thumbhash" {
-			t.Fatalf("real photo did not replace sentinel: path=%q source=%q thumbhash=%q", photoPath, sourcePath, thumbhash)
+		if !got.updatedAt.Equal(seeded.updatedAt) {
+			t.Fatalf("unchanged credit changed updated_at: got %v, want %v", got.updatedAt, seeded.updatedAt)
 		}
-		if !updatedAt.After(seeded.updatedAt) {
-			t.Fatalf("sentinel replacement did not advance updated_at: got %v, previous %v", updatedAt, seeded.updatedAt)
+	})
+
+	t.Run("empty photo columns are filled", func(t *testing.T) {
+		seeded := seed(t, "empty", "", "")
+		batchEnrich(t, seeded, incoming(seeded,
+			"https://images.example/replacement.jpg",
+			"https://images.example/replacement-source.jpg",
+			"replacement-thumbhash"))
+		got := readPhoto(t, seeded.id)
+		if got.photoPath != "https://images.example/replacement.jpg" ||
+			got.source != "https://images.example/replacement-source.jpg" ||
+			got.thumbhash != "replacement-thumbhash" {
+			t.Fatalf("empty photo columns were not filled: %+v", got)
 		}
 	})
 }


### PR DESCRIPTION
## Problem

Per-item credit enrichment treats provider person photos as authoritative and overwrites an existing cached `people.photo_path`. The image-cache worker then restores the immutable S3 key, but a later item scan overwrites it again. Discovery is allowed to re-queue succeeded jobs, so the same actor image can be downloaded repeatedly.

Replacing the cached path also queues the displaced immutable revision for artwork garbage collection. If the pointer is not restored before the grace period expires, valid cached profile variants can be deleted.

## Fix

- Make single and batch person enrichment follow their fill-empty contract for photo path, source path, and thumbhash.
- Continue allowing a real photo to replace the explicit `-` no-photo sentinel.
- Leave replacement of an existing person image to the full person-refresh flow, which already preserves cached artwork while recording/enqueuing a changed source.
- Add a real change predicate so no-op credit enrichment does not advance `updated_at` and postpone scheduled full-person refreshes.
- Exercise the production batch SQL in the normal unit suite and add an optional PostgreSQL integration regression test.

## Testing

```text
GOWORK=off go test ./internal/catalog -run 'TestPerson(PhotoEnrichmentSQLGuardsExistingArtwork|CreditEnrichmentPreservesCachedArtwork)' -count=1
GOWORK=off go test ./internal/catalog -count=1
```

The PostgreSQL-backed case skips when `SILO_TEST_DATABASE_URL` is not configured; the SQL-shape regression runs in every normal unit suite.

### AI Disclosure

- Tool(s): OpenAI Codex
- Model(s): GPT-5 (Codex)
- Involvement: Developed collaboratively by @blurbery and Codex. @blurbery reproduced the repeated actor caching on a real deployment and established the expected behavior. Codex assisted with source tracing, implementation, tests, and verification.
- Adversarial review: Independent review caught the need to preserve real-photo replacement of the `-` sentinel and to avoid no-op `updated_at` changes; both are covered in the final patch.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved person data enrichment to fill missing details without overwriting existing artwork or cached photo paths.
  * Correctly replaces no-photo placeholders and uncached photo links when valid artwork becomes available.
  * Prevented unnecessary timestamp changes and cleanup activity when enrichment makes no changes.

* **Tests**
  * Added coverage for artwork preservation, placeholder replacement, coordinated photo updates, and no-op enrichment behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->