### PR TITLE
fix(chapterthumbs): tolerate high-latency extraction

### DIFF
--- a/internal/chapterthumbs/extractor.go
+++ b/internal/chapterthumbs/extractor.go
@@ -36,6 +36,9 @@ const (
 	reasonDecodeInvalidData     = "decode_invalid_data"
 	reasonFFmpegProbeFailed     = "ffmpeg_probe_failed"
 	reasonToneMapUnsupported    = "tonemap_unsupported"
+	reasonHWKilled              = "hw_killed"
+	reasonHWTimeout             = "hw_timeout"
+	reasonCPUTimeout            = "cpu_timeout"
 	softwareToneMapProbeTimeout = 3 * time.Second
 	softwareToneMapFilterBT2390 = "zscale=t=linear:npl=100,format=gbrpf32le,tonemapx=tonemap=bt2390,zscale=p=bt709:t=bt709:m=bt709:r=tv,format=yuv420p"
 	softwareToneMapFilterHable  = "zscale=t=linear:npl=100,format=gbrpf32le,tonemap=hable,zscale=p=bt709:t=bt709:m=bt709:r=tv,format=yuv420p"
@@ -323,12 +326,12 @@ func classifyExtractError(stage string, err error) string {
 		strings.Contains(lower, "invalid data found when processing input"),
 		strings.Contains(lower, "invalid as first byte of an ebml number"):
 		return reasonDecodeInvalidData
-	case stage == "hw" && strings.Contains(message, "signal: killed"):
-		return "hw_killed"
 	case stage == "hw" && isDeadlineError(err):
-		return "hw_timeout"
+		return reasonHWTimeout
 	case stage == "cpu" && isDeadlineError(err):
-		return "cpu_timeout"
+		return reasonCPUTimeout
+	case stage == "hw" && strings.Contains(message, "signal: killed"):
+		return reasonHWKilled
 	default:
 		return reasonChapterExtractFailed
 	}
@@ -445,6 +448,9 @@ func runFFmpegFrameExtract(ctx context.Context, ffmpegPath string, args []string
 	cmd.Stdout = &stdout
 	cmd.Stderr = &stderr
 	if err := cmd.Run(); err != nil {
+		if ctxErr := ctx.Err(); ctxErr != nil {
+			return nil, fmt.Errorf("ffmpeg extract frame: %w (%s)", errors.Join(ctxErr, err), stderr.String())
+		}
 		return nil, fmt.Errorf("ffmpeg extract frame: %w (%s)", err, stderr.String())
 	}
 	if stdout.Len() == 0 {

--- a/internal/chapterthumbs/extractor_test.go
+++ b/internal/chapterthumbs/extractor_test.go
@@ -3,6 +3,7 @@ package chapterthumbs
 import (
 	"context"
 	"errors"
+	"os"
 	"path/filepath"
 	"runtime"
 	"slices"
@@ -563,6 +564,77 @@ func TestExtractFramePreservesHardwareAndCPUFailures(t *testing.T) {
 	}
 }
 
+func TestRunFFmpegFrameExtractPreservesDeadlineAfterProcessKill(t *testing.T) {
+	executable, err := os.Executable()
+	if err != nil {
+		t.Fatalf("resolve test executable: %v", err)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
+	defer cancel()
+
+	_, err = runFFmpegFrameExtract(ctx, executable, []string{
+		"-test.run=TestFFmpegFrameExtractHelperProcess",
+		"--",
+		"chapterthumbs-block",
+	})
+	if !errors.Is(err, context.DeadlineExceeded) {
+		t.Fatalf("runFFmpegFrameExtract() error = %v, want context deadline exceeded", err)
+	}
+	if !strings.Contains(err.Error(), "signal: killed") {
+		t.Fatalf("runFFmpegFrameExtract() error = %v, want preserved process failure", err)
+	}
+}
+
+func TestClassifyExtractErrorPrefersDeadlineOverKilledSignal(t *testing.T) {
+	tests := []struct {
+		name string
+		err  error
+		want string
+	}{
+		{
+			name: "context terminated hardware process",
+			err:  errors.Join(context.DeadlineExceeded, errors.New("signal: killed")),
+			want: "hw_timeout",
+		},
+		{
+			name: "externally killed hardware process",
+			err:  errors.New("signal: killed"),
+			want: "hw_killed",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := classifyExtractError("hw", tt.err); got != tt.want {
+				t.Fatalf("classifyExtractError() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestExtractTimeoutForAttemptAllowsHighLatencyStorage(t *testing.T) {
+	tests := []struct {
+		name     string
+		hardware bool
+		hdr      bool
+		want     time.Duration
+	}{
+		{name: "hardware SDR", hardware: true, want: time.Minute},
+		{name: "CPU SDR", want: time.Minute},
+		{name: "hardware HDR", hardware: true, hdr: true, want: 3 * time.Minute},
+		{name: "CPU HDR", hdr: true, want: 3 * time.Minute},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := extractTimeoutForAttempt(tt.hardware, tt.hdr); got != tt.want {
+				t.Fatalf("extractTimeoutForAttempt() = %s, want %s", got, tt.want)
+			}
+		})
+	}
+}
+
 func TestRemoteExtractTimeoutBudgetsOnlyAllowedAttempts(t *testing.T) {
 	sdrExtractBudget := extractTimeoutForAttempt(true, false) + extractTimeoutForAttempt(false, false)
 	if got := remoteExtractTimeout(false, false); got <= sdrExtractBudget {
@@ -607,5 +679,14 @@ func assertApproximateDeadline(t *testing.T, got time.Duration, want time.Durati
 	t.Helper()
 	if got < want-time.Second || got > want+time.Second {
 		t.Fatalf("deadline remaining = %s, want about %s", got, want)
+	}
+}
+
+func TestFFmpegFrameExtractHelperProcess(t *testing.T) {
+	if !slices.Contains(os.Args, "chapterthumbs-block") {
+		return
+	}
+	for {
+		runtime.Gosched()
 	}
 }

--- a/internal/chapterthumbs/service.go
+++ b/internal/chapterthumbs/service.go
@@ -26,10 +26,10 @@ const (
 	defaultBatchLimit          = 25
 	defaultPriorityBatchSize   = 3
 	defaultNormalBatchSize     = 8
-	hwExtractTimeoutSDR        = 8 * time.Second
-	hwExtractTimeoutHDR        = 20 * time.Second
-	cpuExtractTimeoutSDR       = 10 * time.Second
-	cpuExtractTimeoutHDR       = 25 * time.Second
+	hwExtractTimeoutSDR        = time.Minute
+	hwExtractTimeoutHDR        = 3 * time.Minute
+	cpuExtractTimeoutSDR       = time.Minute
+	cpuExtractTimeoutHDR       = 3 * time.Minute
 
 	chapterThumbnailHDRPolicySetting       = "playback.chapter_thumbnail_hdr_policy"
 	chapterThumbnailHDRPolicyDefault       = "best_effort"
@@ -1197,7 +1197,7 @@ func retryDurationForCount(failureCount int) time.Duration {
 
 func shouldApplyFileFailure(reason string) bool {
 	switch reason {
-	case reasonDecodeInvalidData, reasonFFmpegProbeFailed, reasonToneMapUnsupported:
+	case reasonDecodeInvalidData, reasonFFmpegProbeFailed, reasonToneMapUnsupported, reasonHWTimeout, reasonCPUTimeout:
 		return true
 	default:
 		return false

--- a/internal/chapterthumbs/service_test.go
+++ b/internal/chapterthumbs/service_test.go
@@ -519,6 +519,79 @@ func TestProcessRequestMarksDecodeInvalidDataAsFileFailure(t *testing.T) {
 	}
 }
 
+func TestProcessRequestStopsAfterTimeoutAndBacksOffFile(t *testing.T) {
+	tests := []struct {
+		name         string
+		reason       string
+		failureCount int
+		wantDelay    time.Duration
+	}{
+		{name: "first CPU timeout", reason: "cpu_timeout", wantDelay: 15 * time.Minute},
+		{name: "second CPU timeout", reason: "cpu_timeout", failureCount: 1, wantDelay: time.Hour},
+		{name: "third hardware timeout", reason: "hw_timeout", failureCount: 2, wantDelay: 6 * time.Hour},
+		{name: "later hardware timeout", reason: "hw_timeout", failureCount: 3, wantDelay: 24 * time.Hour},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			now := time.Unix(1_700_000_000, 0).UTC()
+			fileRepo := &testFileRepo{
+				file: &models.MediaFile{
+					ID:                           42,
+					MediaFolderID:                9,
+					FilePath:                     "/media/movie.mkv",
+					ChapterThumbnailFailureCount: tt.failureCount,
+					Chapters: []models.MediaChapter{
+						{Index: 0, StartSeconds: 0, EndSeconds: 10},
+						{Index: 1, StartSeconds: 10, EndSeconds: 20},
+					},
+				},
+			}
+			callCount := 0
+			service := &Service{
+				fileRepo:   fileRepo,
+				folderRepo: &testFolderRepo{folder: &models.MediaFolder{ID: 9, Enabled: true, ChapterThumbnailsEnabled: true}},
+				clock: func() time.Time {
+					return now
+				},
+				extractFrameFunc: func(context.Context, *models.MediaFile, float64, string) ([]byte, string, error) {
+					callCount++
+					return nil, tt.reason, context.DeadlineExceeded
+				},
+			}
+
+			requeue, err := service.processRequest(context.Background(), ChapterThumbnailRequest{FileID: 42}, false)
+			if err != nil {
+				t.Fatalf("processRequest() error = %v", err)
+			}
+			if requeue {
+				t.Fatal("processRequest() requeue = true, want false")
+			}
+			if callCount != 1 {
+				t.Fatalf("extract calls = %d, want 1", callCount)
+			}
+			if fileRepo.file.ChapterThumbnailFailureCount != tt.failureCount+1 {
+				t.Fatalf("failure count = %d, want %d", fileRepo.file.ChapterThumbnailFailureCount, tt.failureCount+1)
+			}
+			if fileRepo.file.ChapterThumbnailRetryAfter == nil {
+				t.Fatal("file retry_after = nil, want cooldown")
+			}
+			if got, want := *fileRepo.file.ChapterThumbnailRetryAfter, now.Add(tt.wantDelay); !got.Equal(want) {
+				t.Fatalf("file retry_after = %v, want %v", got, want)
+			}
+			if !strings.HasPrefix(fileRepo.file.ChapterThumbnailLastError, tt.reason+":") {
+				t.Fatalf("file last error = %q, want %s prefix", fileRepo.file.ChapterThumbnailLastError, tt.reason)
+			}
+			if fileRepo.file.Chapters[0].ThumbnailRetryAfter == nil {
+				t.Fatal("timed-out chapter retry_after = nil, want cooldown")
+			}
+			if fileRepo.file.Chapters[1].ThumbnailRetryAfter != nil {
+				t.Fatal("later chapter was processed after file timeout")
+			}
+		})
+	}
+}
+
 func TestProcessRequestReportsToneMapCapabilityFailuresOnceWithNormalRetry(t *testing.T) {
 	tests := []struct {
 		name   string
@@ -638,12 +711,8 @@ func TestExtractFrameCPUFallbackGetsFreshDeadline(t *testing.T) {
 	if callCount != 2 {
 		t.Fatalf("callCount = %d, want 2", callCount)
 	}
-	if hwRemaining < 7*time.Second || hwRemaining > 9*time.Second {
-		t.Fatalf("hw deadline = %s, want about 8s", hwRemaining)
-	}
-	if cpuRemaining < 9*time.Second || cpuRemaining > 11*time.Second {
-		t.Fatalf("cpu deadline = %s, want about 10s", cpuRemaining)
-	}
+	assertApproximateDeadline(t, hwRemaining, hwExtractTimeoutSDR)
+	assertApproximateDeadline(t, cpuRemaining, cpuExtractTimeoutSDR)
 }
 
 func TestExtractFramePrefersRemoteNodeWhenEnabled(t *testing.T) {


### PR DESCRIPTION
## Problem

Related issue: #688

Closes #688

Chapter thumbnail extraction used 8-second and 10-second SDR deadlines, plus 20-second and 25-second HDR deadlines. Those limits are too short for valid media on high-latency storage. A production recheck measured 18.5 seconds for the reported SDR capture point and 38.5–42.7 seconds for the reported HDR capture points. A near-end HDR seek took 108.2 seconds on the first run and 72.6 seconds on an immediate repeat.

When `exec.CommandContext` killed FFmpeg at the deadline, the returned error only exposed `signal: killed`. Hardware timeouts were therefore classified as `hw_killed`, and timeout failures did not enter the file-level cooldown.

High-latency storage = Network mounted storage (SMB) under heavy load.

## Approach

- Use fixed per-attempt ceilings of 60 seconds for SDR and 180 seconds for HDR. Hardware and CPU fallback attempts receive separate deadlines.
- Keep the remote request timeout derived from the same attempt budgets, plus the existing probe and transport overhead.
- Preserve both the context deadline and the process exit error when FFmpeg is killed, then classify a deadline before the generic killed-process case.
- Treat `hw_timeout` and `cpu_timeout` as file-level failures. The worker stops the current chapter batch after the first timeout and uses the existing 15-minute, 1-hour, 6-hour, and 24-hour retry cooldown.

The ceilings stay fixed across retries. Increasing the attempt deadline on each retry would intentionally fail valid high-latency files once or more before giving them enough time, while the existing cooldown already supplies exponential retry timing.

## Validation

Production reproduction and re-verification:

- The reported SDR frame extracted successfully in 18.515 seconds.
- The reported HDR frames extracted successfully in 38.476 and 42.695 seconds.
- A near-end HDR seek took 108.194 seconds, followed by 72.618 seconds on an immediate repeat. Production caches were not flushed, so these are observed timings rather than a controlled cold-cache benchmark.

Passing checks:

```text
go test ./internal/chapterthumbs/... -count=1
go test -race ./internal/chapterthumbs/... -count=1
make embed-stub
go build ./...
gofmt -l .
go vet ./...
golangci-lint run --new-from-merge-base=origin/main ./...
pnpm install --frozen-lockfile
pnpm run lint
pnpm run format:check
pnpm run build
make test-web
make verify-settings-bindings-all
make verify-playback-fixtures
make verify-local-paths
git diff --check
```

`pnpm run lint` completed with 154 inherited warnings and no errors. `make test-web` passed 2,021 tests across 283 files.

`make test-go` did not pass because of failures reproduced on an untouched `main` checkout:

- `internal/jellycompat`: `TestBeginWebOperationRecoversDeadProcessLock` and `TestBeginWebOperationRejectsLiveProcessLock`
- `internal/playback`: existing NVENC/GPU probe tests terminated with `signal: killed`

`internal/transcodenode` also had one asynchronous tracking failure under full-suite load; that test passed when rerun on this branch and on untouched `main`.

The installed `codex review` command could not initialize because its state database is read-only in the workspace. I reviewed the complete diff manually against `main`, including timeout propagation through local and remote extraction, error-chain classification, batch termination, and file retry state. No concrete issue was found.

## Risks

Slow or stalled files can occupy an extraction slot longer: up to 60 seconds per SDR attempt or 180 seconds per HDR attempt. Hardware-to-CPU fallback can consume both budgets. The first timeout stops the file's current batch and applies the existing cooldown, limiting repeated work.

No API, schema, migration, client, or jellycompat behavior changes.

## AI Disclosure

- Tool(s): OpenAI Codex
- Model(s): GPT-5
- Involvement: AI-assisted
- Adversarial review: Reviewed the complete diff against `main`, focusing on local and remote timeout propagation, preservation and classification of context-killed FFmpeg errors, and file-level batch termination and retry state. The automated `codex review` command could not initialize because its state database was read-only, so the review was performed manually. No concrete findings remained.

## Checklist

- [x] I read and can explain the complete diff.
- [x] This pull request addresses one concern.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of hardware and CPU extraction timeouts for SDR and HDR content.
  * Increased extraction timeout windows to better accommodate high-latency processing.
  * Preserved meaningful timeout details when extraction processes are terminated.
  * Timeout failures now stop further chapter processing and apply file-level backoff consistently.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
