### PR TITLE
fix(web): smooth detail action interactions

### DIFF
--- a/web/src/components/StarRating.test.tsx
+++ b/web/src/components/StarRating.test.tsx
@@ -36,9 +36,14 @@ describe("StarRating", () => {
       "transform-gpu",
       "transition-[color,scale]",
       "duration-100",
+      "motion-safe:hover:scale-110",
+      "motion-reduce:transition-none",
     );
     expect(fourthStar).not.toHaveClass("transition-all");
-    expect(fourthStar.querySelector("svg")).toHaveClass("transition-[fill-opacity]");
+    expect(fourthStar.querySelector("svg")).toHaveClass(
+      "transition-[fill-opacity]",
+      "motion-reduce:transition-none",
+    );
 
     fireEvent.click(fourthStar);
     expect(onChange).toHaveBeenCalledWith(4);

--- a/web/src/components/StarRating.test.tsx
+++ b/web/src/components/StarRating.test.tsx
@@ -1,0 +1,49 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import StarRating from "./StarRating";
+
+describe("StarRating", () => {
+  it("previews the hovered rating and restores the saved rating on leave", () => {
+    render(<StarRating value={2} onChange={() => {}} />);
+
+    const group = screen.getByRole("radiogroup", { name: "Rating" });
+    const stars = screen.getAllByRole("radio");
+
+    expect(stars[1]?.querySelector("svg")).toHaveAttribute("fill-opacity", "1");
+    expect(stars[2]?.querySelector("svg")).toHaveAttribute("fill-opacity", "0");
+
+    fireEvent.mouseEnter(stars[4]!);
+
+    for (const star of stars) {
+      expect(star.querySelector("svg")).toHaveAttribute("fill-opacity", "1");
+    }
+
+    fireEvent.mouseLeave(group);
+
+    expect(stars[1]?.querySelector("svg")).toHaveAttribute("fill-opacity", "1");
+    expect(stars[2]?.querySelector("svg")).toHaveAttribute("fill-opacity", "0");
+  });
+
+  it("uses focused transitions and preserves rating selection behavior", () => {
+    const onChange = vi.fn();
+    render(<StarRating value={3} onChange={onChange} />);
+
+    const stars = screen.getAllByRole("radio");
+    const fourthStar = stars[3]!;
+
+    expect(fourthStar).toHaveClass(
+      "cursor-pointer",
+      "transform-gpu",
+      "transition-[color,scale]",
+      "duration-100",
+    );
+    expect(fourthStar).not.toHaveClass("transition-all");
+    expect(fourthStar.querySelector("svg")).toHaveClass("transition-[fill-opacity]");
+
+    fireEvent.click(fourthStar);
+    expect(onChange).toHaveBeenCalledWith(4);
+
+    fireEvent.click(stars[2]!);
+    expect(onChange).toHaveBeenLastCalledWith(null);
+  });
+});

--- a/web/src/components/StarRating.tsx
+++ b/web/src/components/StarRating.tsx
@@ -68,11 +68,17 @@ export default function StarRating({ value, onChange, size = 20 }: StarRatingPro
             aria-label={`${star} star${star !== 1 ? "s" : ""}`}
             aria-checked={value === star}
             tabIndex={star === tabbableStar ? 0 : -1}
-            className={`cursor-pointer border-none bg-transparent p-0.5 leading-none transition-all duration-150 hover:scale-110 ${filled ? "text-yellow-400" : "text-muted-foreground/50"}`}
+            className={`transform-gpu cursor-pointer border-none bg-transparent p-0.5 leading-none transition-[color,scale] duration-100 ease-out motion-safe:hover:scale-110 motion-reduce:transition-none ${filled ? "text-yellow-400" : "text-muted-foreground/50"}`}
             onMouseEnter={() => handleMouseEnter(star)}
             onClick={() => handleClick(star)}
           >
-            <Star size={size} fill={filled ? "currentColor" : "none"} strokeWidth={1.5} />
+            <Star
+              size={size}
+              fill="currentColor"
+              fillOpacity={filled ? 1 : 0}
+              strokeWidth={1.5}
+              className="transition-[fill-opacity] duration-100 ease-out motion-reduce:transition-none"
+            />
           </button>
         );
       })}

--- a/web/src/pages/ItemDetail/components/ActionBar.test.tsx
+++ b/web/src/pages/ItemDetail/components/ActionBar.test.tsx
@@ -42,17 +42,23 @@ function renderActionBar(overrides: Partial<ActionBarProps> = {}) {
 }
 
 describe("ActionBar", () => {
-  it.each(playBranches)("keeps the %s Play action responsive", (_, overrides) => {
-    renderActionBar(overrides);
+  it.each(playBranches)(
+    "keeps the %s Play action on a compositor-only hover path",
+    (_, overrides) => {
+      renderActionBar(overrides);
 
-    expect(screen.getByRole("button", { name: "Play" })).toHaveClass(
-      "cursor-pointer",
-      "transform-gpu",
-      "transition-none",
-    );
-  });
+      expect(screen.getByRole("button", { name: "Play" })).toHaveClass(
+        "cursor-pointer",
+        "transform-gpu",
+        "transition-transform",
+        "hover:bg-primary",
+        "motion-safe:hover:scale-[1.02]",
+        "motion-reduce:transition-none",
+      );
+    },
+  );
 
-  it("keeps the watched action responsive and shows pointers on enabled actions", () => {
+  it("keeps the watched action on a compositor-only hover path and shows pointers", () => {
     renderActionBar({
       watchedLabel: "Mark Watched",
       onToggleWatched: () => {},
@@ -62,7 +68,10 @@ describe("ActionBar", () => {
     expect(screen.getByRole("button", { name: "Mark Watched" })).toHaveClass(
       "cursor-pointer",
       "transform-gpu",
-      "transition-none",
+      "transition-transform",
+      "hover:bg-[color-mix(in_srgb,var(--surface)_40%,transparent)]",
+      "motion-safe:hover:scale-[1.02]",
+      "motion-reduce:transition-none",
     );
     expect(screen.getByTitle("Favorite")).toHaveClass("cursor-pointer");
     expect(screen.getByTitle("More")).toHaveClass("cursor-pointer");

--- a/web/src/pages/ItemDetail/components/ActionBar.test.tsx
+++ b/web/src/pages/ItemDetail/components/ActionBar.test.tsx
@@ -51,8 +51,10 @@ describe("ActionBar", () => {
         "cursor-pointer",
         "transform-gpu",
         "transition-transform",
+        "duration-150",
         "hover:bg-primary",
         "motion-safe:hover:scale-[1.02]",
+        "motion-safe:active:scale-[0.98]",
         "motion-reduce:transition-none",
       );
     },
@@ -66,14 +68,29 @@ describe("ActionBar", () => {
     });
 
     expect(screen.getByRole("button", { name: "Mark Watched" })).toHaveClass(
-      "cursor-pointer",
+      "enabled:cursor-pointer",
       "transform-gpu",
       "transition-transform",
+      "duration-150",
       "hover:bg-[color-mix(in_srgb,var(--surface)_40%,transparent)]",
       "motion-safe:hover:scale-[1.02]",
+      "motion-safe:active:scale-[0.98]",
       "motion-reduce:transition-none",
     );
     expect(screen.getByTitle("Favorite")).toHaveClass("cursor-pointer");
     expect(screen.getByTitle("More")).toHaveClass("cursor-pointer");
+  });
+
+  it("does not expose an enabled pointer affordance while the watched action is pending", () => {
+    renderActionBar({
+      watchedLabel: "Mark Watched",
+      onToggleWatched: () => {},
+      isUpdatingWatched: true,
+    });
+
+    const watchedAction = screen.getByRole("button", { name: "Mark Watched" });
+    expect(watchedAction).toBeDisabled();
+    expect(watchedAction).toHaveClass("enabled:cursor-pointer");
+    expect(watchedAction).not.toHaveClass("cursor-pointer");
   });
 });

--- a/web/src/pages/ItemDetail/components/ActionBar.test.tsx
+++ b/web/src/pages/ItemDetail/components/ActionBar.test.tsx
@@ -1,26 +1,60 @@
+import type { ComponentProps } from "react";
 import { render, screen } from "@testing-library/react";
 import { MemoryRouter } from "react-router";
 import { describe, expect, it, vi } from "vitest";
+import type { FileVersion } from "@/api/types";
 import ActionBar from "./ActionBar";
 
 vi.mock("@/playback/watchPlaybackContext", () => ({
   useWatchPlaybackController: () => ({ startPlayback: vi.fn() }),
 }));
 
+vi.mock("./SubtitlesPopover", () => ({
+  default: () => null,
+}));
+
+type ActionBarProps = ComponentProps<typeof ActionBar>;
+
+const selectedVersion: FileVersion = {
+  file_id: 1,
+  resolution: "1080p",
+  codec_video: "h264",
+  codec_audio: "aac",
+  hdr: false,
+  container: "mkv",
+  file_size: 0,
+  duration: 7_200,
+  bitrate: 0,
+};
+
+const playBranches: Array<[string, Partial<ActionBarProps>]> = [
+  ["standard", {}],
+  ["selected version", { selectedVersion }],
+  ["resume choice", { playLabel: "Resume", restartHref: "/watch/movie-1?restart=1" }],
+];
+
+function renderActionBar(overrides: Partial<ActionBarProps> = {}) {
+  return render(
+    <MemoryRouter>
+      <ActionBar playHref="/watch/movie-1" {...overrides} />
+    </MemoryRouter>,
+  );
+}
+
 describe("ActionBar", () => {
-  it("shows the pointer cursor on its enabled primary actions", () => {
-    render(
-      <MemoryRouter>
-        <ActionBar
-          playHref="/watch/movie-1"
-          watchedLabel="Mark Watched"
-          onToggleWatched={() => {}}
-          onToggleFavorite={() => {}}
-        />
-      </MemoryRouter>,
-    );
+  it.each(playBranches)("shows the pointer cursor on the %s Play action", (_, overrides) => {
+    renderActionBar(overrides);
 
     expect(screen.getByRole("button", { name: "Play" })).toHaveClass("cursor-pointer");
+  });
+
+  it("shows the pointer cursor on the other enabled primary actions", () => {
+    renderActionBar({
+      watchedLabel: "Mark Watched",
+      onToggleWatched: () => {},
+      onToggleFavorite: () => {},
+    });
+
     expect(screen.getByRole("button", { name: "Mark Watched" })).toHaveClass("cursor-pointer");
     expect(screen.getByTitle("Favorite")).toHaveClass("cursor-pointer");
     expect(screen.getByTitle("More")).toHaveClass("cursor-pointer");

--- a/web/src/pages/ItemDetail/components/ActionBar.test.tsx
+++ b/web/src/pages/ItemDetail/components/ActionBar.test.tsx
@@ -42,20 +42,28 @@ function renderActionBar(overrides: Partial<ActionBarProps> = {}) {
 }
 
 describe("ActionBar", () => {
-  it.each(playBranches)("shows the pointer cursor on the %s Play action", (_, overrides) => {
+  it.each(playBranches)("keeps the %s Play action responsive", (_, overrides) => {
     renderActionBar(overrides);
 
-    expect(screen.getByRole("button", { name: "Play" })).toHaveClass("cursor-pointer");
+    expect(screen.getByRole("button", { name: "Play" })).toHaveClass(
+      "cursor-pointer",
+      "transform-gpu",
+      "transition-none",
+    );
   });
 
-  it("shows the pointer cursor on the other enabled primary actions", () => {
+  it("keeps the watched action responsive and shows pointers on enabled actions", () => {
     renderActionBar({
       watchedLabel: "Mark Watched",
       onToggleWatched: () => {},
       onToggleFavorite: () => {},
     });
 
-    expect(screen.getByRole("button", { name: "Mark Watched" })).toHaveClass("cursor-pointer");
+    expect(screen.getByRole("button", { name: "Mark Watched" })).toHaveClass(
+      "cursor-pointer",
+      "transform-gpu",
+      "transition-none",
+    );
     expect(screen.getByTitle("Favorite")).toHaveClass("cursor-pointer");
     expect(screen.getByTitle("More")).toHaveClass("cursor-pointer");
   });

--- a/web/src/pages/ItemDetail/components/ActionBar.test.tsx
+++ b/web/src/pages/ItemDetail/components/ActionBar.test.tsx
@@ -1,0 +1,28 @@
+import { render, screen } from "@testing-library/react";
+import { MemoryRouter } from "react-router";
+import { describe, expect, it, vi } from "vitest";
+import ActionBar from "./ActionBar";
+
+vi.mock("@/playback/watchPlaybackContext", () => ({
+  useWatchPlaybackController: () => ({ startPlayback: vi.fn() }),
+}));
+
+describe("ActionBar", () => {
+  it("shows the pointer cursor on its enabled primary actions", () => {
+    render(
+      <MemoryRouter>
+        <ActionBar
+          playHref="/watch/movie-1"
+          watchedLabel="Mark Watched"
+          onToggleWatched={() => {}}
+          onToggleFavorite={() => {}}
+        />
+      </MemoryRouter>,
+    );
+
+    expect(screen.getByRole("button", { name: "Play" })).toHaveClass("cursor-pointer");
+    expect(screen.getByRole("button", { name: "Mark Watched" })).toHaveClass("cursor-pointer");
+    expect(screen.getByTitle("Favorite")).toHaveClass("cursor-pointer");
+    expect(screen.getByTitle("More")).toHaveClass("cursor-pointer");
+  });
+});

--- a/web/src/pages/ItemDetail/components/ActionBar.tsx
+++ b/web/src/pages/ItemDetail/components/ActionBar.tsx
@@ -339,7 +339,7 @@ export default function ActionBar({
             variant="glass"
             onClick={onToggleWatched}
             disabled={isUpdatingWatched}
-            className={`${responsiveWatchedActionClass} h-11 cursor-pointer rounded-full px-5 text-[14px] font-semibold`}
+            className={`${responsiveWatchedActionClass} h-11 rounded-full px-5 text-[14px] font-semibold enabled:cursor-pointer`}
           >
             <Check className="size-[18px]" />
             {watchedLabel}

--- a/web/src/pages/ItemDetail/components/ActionBar.tsx
+++ b/web/src/pages/ItemDetail/components/ActionBar.tsx
@@ -287,7 +287,7 @@ export default function ActionBar({
           showPlayChoiceDialog ? (
             <Button
               onClick={openPlayChoiceDialog}
-              className="relative h-11 gap-2.5 overflow-hidden rounded-full px-8 text-[15px] font-bold tracking-wide shadow-md"
+              className="relative h-11 cursor-pointer gap-2.5 overflow-hidden rounded-full px-8 text-[15px] font-bold tracking-wide shadow-md"
             >
               <Play className="size-[18px] fill-current" />
               {displayedPlayLabel}
@@ -296,7 +296,7 @@ export default function ActionBar({
           ) : selectedVersion ? (
             <Button
               onClick={() => handleSelectedVersionPlay(false)}
-              className="relative h-11 gap-2.5 overflow-hidden rounded-full px-8 text-[15px] font-bold tracking-wide shadow-md"
+              className="relative h-11 cursor-pointer gap-2.5 overflow-hidden rounded-full px-8 text-[15px] font-bold tracking-wide shadow-md"
             >
               <Play className="size-[18px] fill-current" />
               {displayedPlayLabel}
@@ -305,7 +305,7 @@ export default function ActionBar({
           ) : (
             <Button
               onClick={() => startPlaybackFromHref(playHref)}
-              className="relative h-11 gap-2.5 overflow-hidden rounded-full px-8 text-[15px] font-bold tracking-wide shadow-md"
+              className="relative h-11 cursor-pointer gap-2.5 overflow-hidden rounded-full px-8 text-[15px] font-bold tracking-wide shadow-md"
             >
               <Play className="size-[18px] fill-current" />
               {displayedPlayLabel}
@@ -332,7 +332,7 @@ export default function ActionBar({
             variant="glass"
             onClick={onToggleWatched}
             disabled={isUpdatingWatched}
-            className="h-11 rounded-full px-5 text-[14px] font-semibold"
+            className="h-11 cursor-pointer rounded-full px-5 text-[14px] font-semibold"
           >
             <Check className="size-[18px]" />
             {watchedLabel}
@@ -346,7 +346,7 @@ export default function ActionBar({
             size="icon-lg"
             onClick={onToggleFavorite}
             title={isFavorite ? "Unfavorite" : "Favorite"}
-            className="size-11 rounded-full"
+            className="size-11 cursor-pointer rounded-full"
           >
             <Heart
               className={`size-[18px] transition-colors ${isFavorite ? "fill-current text-red-400" : ""}`}
@@ -360,7 +360,12 @@ export default function ActionBar({
 
         <DropdownMenu modal={false}>
           <DropdownMenuTrigger asChild>
-            <Button variant="glass" size="icon-lg" title="More" className="size-11 rounded-full">
+            <Button
+              variant="glass"
+              size="icon-lg"
+              title="More"
+              className="size-11 cursor-pointer rounded-full"
+            >
               <MoreVertical className="size-[18px]" />
             </Button>
           </DropdownMenuTrigger>

--- a/web/src/pages/ItemDetail/components/ActionBar.tsx
+++ b/web/src/pages/ItemDetail/components/ActionBar.tsx
@@ -50,6 +50,9 @@ import VersionDropdown from "./VersionDropdown";
 import AudioTracksPopover from "./AudioTracksPopover";
 import SubtitlesPopover from "./SubtitlesPopover";
 
+// Avoid repainting the animated detail backdrop while these larger controls change hover state.
+const responsivePrimaryActionClass = "transform-gpu transition-none";
+
 interface ActionBarProps {
   contentId?: string;
   playHref?: string;
@@ -287,7 +290,7 @@ export default function ActionBar({
           showPlayChoiceDialog ? (
             <Button
               onClick={openPlayChoiceDialog}
-              className="relative h-11 cursor-pointer gap-2.5 overflow-hidden rounded-full px-8 text-[15px] font-bold tracking-wide shadow-md"
+              className={`${responsivePrimaryActionClass} relative h-11 cursor-pointer gap-2.5 overflow-hidden rounded-full px-8 text-[15px] font-bold tracking-wide shadow-md`}
             >
               <Play className="size-[18px] fill-current" />
               {displayedPlayLabel}
@@ -296,7 +299,7 @@ export default function ActionBar({
           ) : selectedVersion ? (
             <Button
               onClick={() => handleSelectedVersionPlay(false)}
-              className="relative h-11 cursor-pointer gap-2.5 overflow-hidden rounded-full px-8 text-[15px] font-bold tracking-wide shadow-md"
+              className={`${responsivePrimaryActionClass} relative h-11 cursor-pointer gap-2.5 overflow-hidden rounded-full px-8 text-[15px] font-bold tracking-wide shadow-md`}
             >
               <Play className="size-[18px] fill-current" />
               {displayedPlayLabel}
@@ -305,7 +308,7 @@ export default function ActionBar({
           ) : (
             <Button
               onClick={() => startPlaybackFromHref(playHref)}
-              className="relative h-11 cursor-pointer gap-2.5 overflow-hidden rounded-full px-8 text-[15px] font-bold tracking-wide shadow-md"
+              className={`${responsivePrimaryActionClass} relative h-11 cursor-pointer gap-2.5 overflow-hidden rounded-full px-8 text-[15px] font-bold tracking-wide shadow-md`}
             >
               <Play className="size-[18px] fill-current" />
               {displayedPlayLabel}
@@ -332,7 +335,7 @@ export default function ActionBar({
             variant="glass"
             onClick={onToggleWatched}
             disabled={isUpdatingWatched}
-            className="h-11 cursor-pointer rounded-full px-5 text-[14px] font-semibold"
+            className={`${responsivePrimaryActionClass} h-11 cursor-pointer rounded-full px-5 text-[14px] font-semibold`}
           >
             <Check className="size-[18px]" />
             {watchedLabel}

--- a/web/src/pages/ItemDetail/components/ActionBar.tsx
+++ b/web/src/pages/ItemDetail/components/ActionBar.tsx
@@ -50,8 +50,12 @@ import VersionDropdown from "./VersionDropdown";
 import AudioTracksPopover from "./AudioTracksPopover";
 import SubtitlesPopover from "./SubtitlesPopover";
 
-// Avoid repainting the animated detail backdrop while these larger controls change hover state.
-const responsivePrimaryActionClass = "transform-gpu transition-none";
+// Keep hover feedback on the compositor: repainting these controls while the detail backdrop is
+// animating can stall the main thread on image-heavy movie and series pages.
+const responsivePrimaryActionClass =
+  "transform-gpu transition-transform duration-150 motion-safe:hover:scale-[1.02] motion-safe:active:scale-[0.98] motion-reduce:transition-none";
+const responsivePlayActionClass = `${responsivePrimaryActionClass} hover:bg-primary`;
+const responsiveWatchedActionClass = `${responsivePrimaryActionClass} hover:bg-[color-mix(in_srgb,var(--surface)_40%,transparent)]`;
 
 interface ActionBarProps {
   contentId?: string;
@@ -290,7 +294,7 @@ export default function ActionBar({
           showPlayChoiceDialog ? (
             <Button
               onClick={openPlayChoiceDialog}
-              className={`${responsivePrimaryActionClass} relative h-11 cursor-pointer gap-2.5 overflow-hidden rounded-full px-8 text-[15px] font-bold tracking-wide shadow-md`}
+              className={`${responsivePlayActionClass} relative h-11 cursor-pointer gap-2.5 overflow-hidden rounded-full px-8 text-[15px] font-bold tracking-wide shadow-md`}
             >
               <Play className="size-[18px] fill-current" />
               {displayedPlayLabel}
@@ -299,7 +303,7 @@ export default function ActionBar({
           ) : selectedVersion ? (
             <Button
               onClick={() => handleSelectedVersionPlay(false)}
-              className={`${responsivePrimaryActionClass} relative h-11 cursor-pointer gap-2.5 overflow-hidden rounded-full px-8 text-[15px] font-bold tracking-wide shadow-md`}
+              className={`${responsivePlayActionClass} relative h-11 cursor-pointer gap-2.5 overflow-hidden rounded-full px-8 text-[15px] font-bold tracking-wide shadow-md`}
             >
               <Play className="size-[18px] fill-current" />
               {displayedPlayLabel}
@@ -308,7 +312,7 @@ export default function ActionBar({
           ) : (
             <Button
               onClick={() => startPlaybackFromHref(playHref)}
-              className={`${responsivePrimaryActionClass} relative h-11 cursor-pointer gap-2.5 overflow-hidden rounded-full px-8 text-[15px] font-bold tracking-wide shadow-md`}
+              className={`${responsivePlayActionClass} relative h-11 cursor-pointer gap-2.5 overflow-hidden rounded-full px-8 text-[15px] font-bold tracking-wide shadow-md`}
             >
               <Play className="size-[18px] fill-current" />
               {displayedPlayLabel}
@@ -335,7 +339,7 @@ export default function ActionBar({
             variant="glass"
             onClick={onToggleWatched}
             disabled={isUpdatingWatched}
-            className={`${responsivePrimaryActionClass} h-11 cursor-pointer rounded-full px-5 text-[14px] font-semibold`}
+            className={`${responsiveWatchedActionClass} h-11 cursor-pointer rounded-full px-5 text-[14px] font-semibold`}
           >
             <Check className="size-[18px]" />
             {watchedLabel}


### PR DESCRIPTION
## Problem

Related issue: N/A — narrow fix

On movie and series detail pages, moving across the rating stars felt delayed. The component used a 150 ms `transition-all` while also switching the SVG fill between `none` and `currentColor`, so it asked the browser to transition more than the interaction needed and changed the fill as a discrete value.

The Play, Mark Watched, Favorite, and More buttons also kept the default arrow cursor. That made clickable controls in the same action bar behave differently from the rest of the web client.

There was one more slow path in the same action bar: moving onto or away from the larger Play and Mark Watched controls could make the continuously animated detail backdrop stutter. My first attempt composited those controls and removed their background transition, but production testing showed that this only removed interpolation. Hover still changed Play from its solid primary background to the alpha `/90` color and changed the watched control's glass background from alpha `0.4` to `0.55`, so each hover still took the paint path over the moving hero artwork.

## Approach

The rating now keeps a stable `currentColor` fill and animates its opacity. The button transition is limited to color and scale, shortened to 100 ms, and uses the existing hover scale only when reduced motion is not requested. This makes moving across the stars respond cleanly without changing rating or keyboard behavior.

Pointer cursors are added only to the enabled detail-page actions involved here, including each of the three Play render paths.

The final Play and watched fix keeps each control's computed background identical before and during hover. Feedback now comes from a small `1.02` scale on the already-composited control, with a matching active scale and reduced-motion opt-out. That keeps hover work on the compositor instead of repainting a control over the animated hero. The override covers all three enabled Play branches and the shared watched toggle; click handlers, focus rings, loading and disabled states, layout, progress overlay, and artwork animation are unchanged.

Everything stays local to the detail action bar instead of changing the shared Button component or unrelated screens.

Focused tests cover hover preview and reset, selecting and clearing a rating, reduced-motion classes, every Play render path, and the watched, Favorite, and More controls. The ActionBar coverage also locks in the stable hover backgrounds and compositor-only scale treatment.

## Validation

- `corepack pnpm exec vitest run src/pages/ItemDetail/components/ActionBar.test.tsx src/components/StarRating.test.tsx` — 2 files and 7 tests passed on `dcefe29b`.
- `corepack pnpm exec eslint` on the four changed ActionBar and StarRating files with `--max-warnings=0` — passed.
- `corepack pnpm exec prettier --check` on the four changed files — passed.
- `corepack pnpm run build` — passed.
- `make verify-local-paths` — passed.
- The generated production CSS was exercised in a local browser against the real Silo backend. Play kept `rgb(232, 232, 236)` before and during hover; Mark Series Watched kept its glass background at alpha `0.4`; both reported scale `1.02`, with no console errors.
- The same portable commit was first shipped to my fork as `87bf5af3`. Full fork Docs hygiene, Web, and Go CI passed, as did the multi-architecture Docker workflow. Build 72 (`ghcr.io/blurbery/silo-server@sha256:eca0e822ae225f61d707d64b52e3c1af3c9fa9e678e308dc27fad24dae691832`) is healthy in production with the exact revision label, and I confirmed the remaining hover lag is fixed.
- Upstream CI for `dcefe29b` is running and will provide the full repository gate for the final PR head. Docs hygiene and Web are already green; Go was still in tests at the last check.

## Adversarial review

CodeRabbit previously identified two coverage gaps: the other Play render paths and reduced-motion classes were not asserted. Both were added in `29ae1986`, and its fresh incremental review through `c64eef2` produced no actionable comments.

The fresh review of the final hover increment asked for assertions covering the active scale and duration, and for the temporarily disabled watched action to avoid the enabled pointer affordance. Both grounded findings were fixed in `dcefe29b`, including pending-state coverage. The follow-up push triggered the final incremental review status.

## Risks

This changes only web-client interaction styling and tests. It does not change APIs, stored data, playback behavior, layout, hero animation, card overlays, poster actions, watched indicators, or the shared Button component. Apple and Android clients are unaffected.

The main visual tradeoff is deliberate: Play and watched no longer change background opacity on hover. Their small scale response preserves clear pointer feedback without returning to the expensive paint path. Reduced-motion users get the stable control without the scale animation.

## AI Disclosure

- Tool(s): OpenAI Codex desktop app
- Model(s): GPT-5 (the session exposed no more specific model identifier)
- Involvement: AI-assisted
- Review: CodeRabbit reviewed the final hover increment; both grounded findings were fixed in `dcefe29b`. I also reviewed the complete diff and verified the generated CSS and deployed behavior.

I reproduced the issue and tested the final deployed behavior on my own Silo server. Codex helped trace the remaining paint path, implement the focused change and regression coverage, run the validation, deploy the verified artifact to my fork, and prepare this pull request update. I reviewed the final scope and am submitting the change.

## Checklist

- [x] I read and can explain the complete diff.
- [x] This pull request addresses one concern.
