### PR TITLE
feat(web): improve poster card favorite and action controls

### DIFF
--- a/web/src/components/MediaItemMenu.test.tsx
+++ b/web/src/components/MediaItemMenu.test.tsx
@@ -1,5 +1,86 @@
-import { describe, expect, it } from "vitest";
-import { buildMediaItemMenuModel } from "./MediaItemMenu";
+import { renderToStaticMarkup } from "react-dom/server";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { MemoryRouter } from "react-router";
+import type { ItemDetail } from "@/api/types";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import MediaItemMenu, { buildMediaItemMenuModel, MetadataActionDialogHost } from "./MediaItemMenu";
+import { mediaItemMenuTriggerClassName } from "./mediaItemMenuTrigger";
+
+const mocks = vi.hoisted(() => ({
+  useCatalogItemDetail: vi.fn(),
+  editItem: vi.fn(),
+  matchItem: vi.fn(),
+  toggleFavorite: vi.fn(),
+  authState: undefined as { user: { role: "admin" | "user" } } | undefined,
+}));
+
+vi.mock("@/hooks/queries/catalogRead", () => ({
+  useCatalogItemDetail: (...args: unknown[]) => mocks.useCatalogItemDetail(...args),
+}));
+
+vi.mock("@/components/EditMetadataDialog", () => ({
+  default: ({ item }: { item: ItemDetail }) => {
+    mocks.editItem(item);
+    return <div>Edit {item.title}</div>;
+  },
+}));
+
+vi.mock("@/components/MatchItemDialog", () => ({
+  default: ({ item }: { item: ItemDetail }) => {
+    mocks.matchItem(item);
+    return <div>Match {item.title}</div>;
+  },
+}));
+
+vi.mock("@/hooks/queries/favorites", () => ({
+  useToggleFavorite: () => ({
+    isPending: false,
+    mutateAsync: (...args: unknown[]) => mocks.toggleFavorite(...args),
+  }),
+}));
+
+vi.mock("@/hooks/queries/watchlist", () => ({
+  useToggleWatchlist: () => ({ isPending: false, mutateAsync: vi.fn() }),
+}));
+
+vi.mock("@/hooks/queries/items", () => ({
+  useRefreshItemMetadata: () => ({ isPending: false, mutate: vi.fn() }),
+  useWatchedStateMutation: () => ({ isPending: false, mutateAsync: vi.fn() }),
+}));
+
+vi.mock("@/hooks/queries/homeDismissals", () => ({
+  useDismissHomeItem: () => ({ isPending: false, mutateAsync: vi.fn() }),
+}));
+
+vi.mock("@/hooks/useAuth", () => ({
+  useOptionalAuth: () => mocks.authState,
+}));
+
+vi.mock("@/hooks/useCurrentProfile", () => ({
+  useCurrentProfile: () => ({ profile: null, hasSelectedProfile: false }),
+}));
+
+vi.mock("@/hooks/useViewTransition", () => ({
+  useViewTransitionNavigate: () => vi.fn(),
+}));
+
+vi.mock("@/playback/watchPlaybackContext", () => ({
+  useWatchPlaybackController: () => ({ startPlayback: vi.fn() }),
+}));
+
+vi.mock("@/components/RefreshMetadataDialog", () => ({
+  default: () => null,
+}));
+
+beforeEach(() => {
+  mocks.useCatalogItemDetail.mockReset();
+  mocks.editItem.mockReset();
+  mocks.matchItem.mockReset();
+  mocks.toggleFavorite.mockReset();
+  mocks.toggleFavorite.mockResolvedValue(undefined);
+  mocks.authState = undefined;
+});
 
 describe("buildMediaItemMenuModel", () => {
   it("returns watched/favorite/watchlist removal labels for active state", () => {
@@ -20,6 +101,8 @@ describe("buildMediaItemMenuModel", () => {
     expect(actions[3]?.label).toBe("Remove from Watchlist");
     expect(actions[4]?.label).toBe("View Play History");
     expect(actions[5]?.label).toBe("Refresh Metadata");
+    expect(actions[6]?.label).toBe("Edit Metadata");
+    expect(actions[7]?.label).toBe("Match Item");
     expect(model.some((item) => item.kind === "action" && item.label === "View Play History")).toBe(
       true,
     );
@@ -58,11 +141,13 @@ describe("buildMediaItemMenuModel", () => {
     });
     const actions = model.filter((item) => item.kind === "action");
 
-    expect(actions).toHaveLength(4);
+    expect(actions).toHaveLength(6);
     expect(actions[0]?.label).toBe("Play from Beginning");
     expect(actions[1]?.label).toBe("Mark Unwatched");
     expect(actions[2]?.label).toBe("View Play History");
     expect(actions[3]?.label).toBe("Refresh Metadata");
+    expect(actions[4]?.label).toBe("Edit Metadata");
+    expect(actions[5]?.label).toBe("Match Item");
   });
 
   it("omits admin actions for non-admin users", () => {
@@ -86,6 +171,30 @@ describe("buildMediaItemMenuModel", () => {
     expect(model.some((item) => item.kind === "action" && item.label === "Refresh Metadata")).toBe(
       false,
     );
+  });
+
+  it("shows metadata actions to a metadata curator without exposing play history", () => {
+    const model = buildMediaItemMenuModel({
+      mediaType: "series",
+      isAdmin: false,
+      canCurateMetadata: true,
+    });
+    const labels = model.filter((item) => item.kind === "action").map((item) => item.label);
+
+    expect(labels).toEqual(["Refresh Metadata", "Edit Metadata", "Match Item"]);
+    expect(labels).not.toContain("View Play History");
+  });
+
+  it("limits edit and match card actions to movies and series", () => {
+    const model = buildMediaItemMenuModel({
+      mediaType: "episode",
+      isAdmin: true,
+    });
+    const labels = model.filter((item) => item.kind === "action").map((item) => item.label);
+
+    expect(labels).toContain("Refresh Metadata");
+    expect(labels).not.toContain("Edit Metadata");
+    expect(labels).not.toContain("Match Item");
   });
 
   it("shows a continue watching dismissal action when provided", () => {
@@ -212,5 +321,377 @@ describe("buildMediaItemMenuModel", () => {
     const labels = model.filter((item) => item.kind === "action").map((item) => item.label);
 
     expect(labels).toContain("Mark Unread");
+  });
+});
+
+describe("MediaItemMenu metadata dialogs", () => {
+  const detail = {
+    content_id: "series-1",
+    type: "series",
+    title: "Silo",
+    year: 2023,
+  } as ItemDetail;
+
+  it("loads the exact item detail and passes it to Edit Metadata", () => {
+    mocks.useCatalogItemDetail.mockReturnValue({ data: detail });
+
+    const markup = renderToStaticMarkup(
+      <MetadataActionDialogHost
+        action="edit"
+        contentId="series-1"
+        libraryId={12}
+        onClose={() => undefined}
+      />,
+    );
+
+    expect(mocks.useCatalogItemDetail).toHaveBeenCalledWith("series-1", 12);
+    expect(mocks.editItem).toHaveBeenCalledWith(detail);
+    expect(markup).toContain("Edit Silo");
+  });
+
+  it("passes the full item and library context to Match Item", () => {
+    mocks.useCatalogItemDetail.mockReturnValue({ data: detail });
+
+    const markup = renderToStaticMarkup(
+      <MetadataActionDialogHost
+        action="match"
+        contentId="series-1"
+        libraryId={12}
+        onClose={() => undefined}
+      />,
+    );
+
+    expect(mocks.useCatalogItemDetail).toHaveBeenCalledWith("series-1", 12);
+    expect(mocks.matchItem).toHaveBeenCalledWith({ ...detail, library_id: 12 });
+    expect(markup).toContain("Match Silo");
+  });
+});
+
+describe("MediaItemMenu trigger visibility", () => {
+  it("uses open state and keyboard focus without keeping a mouse-closed card focused", () => {
+    const className = mediaItemMenuTriggerClassName();
+
+    expect(className).toContain("pointer-fine:group-hover/card:opacity-100");
+    expect(className).toContain("pointer-fine:data-[state=open]:opacity-100");
+    expect(className).toContain("pointer-fine:focus-visible:opacity-100");
+    expect(className).not.toContain("md:opacity-0");
+    expect(className).not.toContain("group-focus-within");
+  });
+
+  it("drops pointer focus when the trigger closes the menu so hover exit can hide it", async () => {
+    render(
+      <MemoryRouter>
+        <MediaItemMenu
+          contentId="movie-1"
+          mediaType="movie"
+          userState={{ played: false, is_favorite: false, in_watchlist: false }}
+          variant="poster"
+        />
+      </MemoryRouter>,
+    );
+
+    const trigger = screen.getByRole("button", { name: "More actions" });
+    await userEvent.click(trigger);
+    expect(screen.getByRole("menu")).toBeTruthy();
+
+    await userEvent.click(trigger);
+
+    await waitFor(() => {
+      expect(trigger.getAttribute("data-state")).toBe("closed");
+      expect(document.activeElement).not.toBe(trigger);
+    });
+  });
+
+  it("returns focus to the trigger when a keyboard user closes the menu", async () => {
+    render(
+      <MemoryRouter>
+        <MediaItemMenu
+          contentId="movie-1"
+          mediaType="movie"
+          userState={{ played: false, is_favorite: false, in_watchlist: false }}
+          variant="poster"
+        />
+      </MemoryRouter>,
+    );
+
+    const trigger = screen.getByRole("button", { name: "More actions" });
+    trigger.focus();
+    await userEvent.keyboard("{Enter}");
+    expect(screen.getByRole("menu")).toBeTruthy();
+
+    await userEvent.keyboard("{Escape}");
+
+    await waitFor(() => {
+      expect(document.activeElement).toBe(trigger);
+    });
+  });
+
+  it("still returns keyboard focus after a cancelled pointer press inside the menu", async () => {
+    render(
+      <MemoryRouter>
+        <MediaItemMenu
+          contentId="movie-1"
+          mediaType="movie"
+          userState={{ played: false, is_favorite: false, in_watchlist: false }}
+          variant="poster"
+        />
+      </MemoryRouter>,
+    );
+
+    const trigger = screen.getByRole("button", { name: "More actions" });
+    trigger.focus();
+    await userEvent.keyboard("{Enter}");
+    const menuItem = screen.getByRole("menuitem", { name: "Mark Watched" });
+
+    fireEvent.pointerDown(menuItem, { pointerId: 3, button: 0 });
+    await userEvent.keyboard("{Escape}");
+
+    await waitFor(() => {
+      expect(document.activeElement).toBe(trigger);
+    });
+  });
+
+  it("renders a matching bottom-left favorite control for poster cards", () => {
+    render(
+      <MemoryRouter>
+        <MediaItemMenu
+          contentId="movie-1"
+          mediaType="movie"
+          userState={{ played: false, is_favorite: false, in_watchlist: false }}
+          variant="poster"
+        />
+      </MemoryRouter>,
+    );
+
+    const button = screen.getByRole("button", { name: "Add to favorites" });
+    expect(button.getAttribute("aria-pressed")).toBe("false");
+    expect(button.className).toContain("pointer-fine:group-hover/card:opacity-100");
+    expect(button.className).toContain("cursor-pointer");
+    expect(button.className).not.toContain("cursor-wait");
+    expect(button.parentElement?.className).toContain("left-2.5");
+  });
+
+  it("uses matching action icons and sizes the menu to its longest entry", async () => {
+    mocks.authState = { user: { role: "admin" } };
+    render(
+      <MemoryRouter>
+        <MediaItemMenu
+          contentId="movie-1"
+          mediaType="movie"
+          userState={{ played: true, is_favorite: true, in_watchlist: false }}
+          variant="poster"
+          dismissAction={{ itemId: "movie-1", surface: "continue_watching" }}
+        />
+      </MemoryRouter>,
+    );
+
+    await userEvent.click(screen.getByRole("button", { name: "More actions" }));
+
+    const menu = screen.getByRole("menu");
+    expect(menu.className).toContain("w-max");
+    expect(menu.className).toContain("min-w-0");
+    expect(menu.className).not.toContain("w-56");
+    for (const item of screen.getAllByRole("menuitem")) {
+      expect(item.querySelector("svg"), item.textContent ?? "menu item").toBeTruthy();
+    }
+    expect(
+      screen
+        .getByRole("menuitem", { name: "Remove from Favorites" })
+        .querySelector(".lucide-heart"),
+    ).toBeTruthy();
+    expect(
+      screen.getByRole("menuitem", { name: "Add to Watchlist" }).querySelector(".lucide-plus"),
+    ).toBeTruthy();
+    expect(
+      screen.getByRole("menuitem", { name: "Edit Metadata" }).querySelector(".lucide-pencil"),
+    ).toBeTruthy();
+    expect(
+      screen.getByRole("menuitem", { name: "Match Item" }).querySelector(".lucide-search"),
+    ).toBeTruthy();
+  });
+
+  it("toggles through the shared favorite mutation and updates the heart immediately", async () => {
+    render(
+      <MemoryRouter>
+        <MediaItemMenu
+          contentId="movie-1"
+          mediaType="movie"
+          userState={{ played: false, is_favorite: false, in_watchlist: false }}
+          variant="poster"
+        />
+      </MemoryRouter>,
+    );
+
+    await userEvent.click(screen.getByRole("button", { name: "Add to favorites" }));
+
+    expect(mocks.toggleFavorite).toHaveBeenCalledTimes(1);
+    expect(mocks.toggleFavorite).toHaveBeenCalledWith(false);
+    expect(screen.getByTestId("favorite-burst")).toBeTruthy();
+    await waitFor(() => {
+      const button = screen.getByRole("button", { name: "Remove from favorites" });
+      expect(button.getAttribute("aria-pressed")).toBe("true");
+      expect(button.querySelector("svg")?.getAttribute("class")).toContain("fill-red-500");
+    });
+    await userEvent.click(screen.getByRole("button", { name: "More actions" }));
+    expect(screen.getByRole("menuitem", { name: "Remove from Favorites" })).toBeTruthy();
+  });
+
+  it("toggles on a short pointer release even when a carousel consumes the click", async () => {
+    render(
+      <MemoryRouter>
+        <MediaItemMenu
+          contentId="movie-1"
+          mediaType="movie"
+          userState={{ played: false, is_favorite: false, in_watchlist: false }}
+          variant="poster"
+        />
+      </MemoryRouter>,
+    );
+
+    const button = screen.getByRole("button", { name: "Add to favorites" });
+    fireEvent.pointerDown(button, { pointerId: 7, button: 0, clientX: 120, clientY: 240 });
+    fireEvent.pointerUp(button, { pointerId: 7, button: 0, clientX: 128, clientY: 248 });
+
+    expect(mocks.toggleFavorite).toHaveBeenCalledTimes(1);
+    expect(mocks.toggleFavorite).toHaveBeenCalledWith(false);
+    await waitFor(() => {
+      expect(screen.getByRole("button", { name: "Remove from favorites" })).toBeTruthy();
+    });
+  });
+
+  it("does not favorite when a swipe returns near its starting point", () => {
+    render(
+      <MemoryRouter>
+        <MediaItemMenu
+          contentId="movie-1"
+          mediaType="movie"
+          userState={{ played: false, is_favorite: false, in_watchlist: false }}
+          variant="poster"
+        />
+      </MemoryRouter>,
+    );
+
+    const button = screen.getByRole("button", { name: "Add to favorites" });
+    fireEvent.pointerDown(button, { pointerId: 9, button: 0, clientX: 120, clientY: 240 });
+    fireEvent.pointerMove(button, { pointerId: 9, clientX: 144, clientY: 240 });
+    fireEvent.pointerUp(button, { pointerId: 9, button: 0, clientX: 124, clientY: 240 });
+
+    expect(mocks.toggleFavorite).not.toHaveBeenCalled();
+    expect(screen.getByRole("button", { name: "Add to favorites" })).toBeTruthy();
+  });
+
+  it("keeps the poster heart in sync when favorite state changes through the menu", async () => {
+    render(
+      <MemoryRouter>
+        <MediaItemMenu
+          contentId="movie-1"
+          mediaType="movie"
+          userState={{ played: false, is_favorite: false, in_watchlist: false }}
+          variant="poster"
+        />
+      </MemoryRouter>,
+    );
+
+    await userEvent.click(screen.getByRole("button", { name: "More actions" }));
+    await userEvent.click(screen.getByRole("menuitem", { name: "Add to Favorites" }));
+
+    expect(mocks.toggleFavorite).toHaveBeenCalledWith(false);
+    await waitFor(() => {
+      expect(screen.getByRole("button", { name: "Remove from favorites" })).toBeTruthy();
+    });
+  });
+
+  it("unfavorites through the heart and updates the matching menu action", async () => {
+    render(
+      <MemoryRouter>
+        <MediaItemMenu
+          contentId="movie-1"
+          mediaType="movie"
+          userState={{ played: false, is_favorite: true, in_watchlist: false }}
+          variant="poster"
+        />
+      </MemoryRouter>,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "Remove from favorites" }));
+
+    expect(mocks.toggleFavorite).toHaveBeenCalledWith(true);
+    await waitFor(() => {
+      expect(screen.getByRole("button", { name: "Add to favorites" })).toBeTruthy();
+    });
+    await userEvent.click(screen.getByRole("button", { name: "More actions" }));
+    expect(screen.getByRole("menuitem", { name: "Add to Favorites" })).toBeTruthy();
+  });
+
+  it("unfavorites through the menu and clears the poster heart", async () => {
+    render(
+      <MemoryRouter>
+        <MediaItemMenu
+          contentId="movie-1"
+          mediaType="movie"
+          userState={{ played: false, is_favorite: true, in_watchlist: false }}
+          variant="poster"
+        />
+      </MemoryRouter>,
+    );
+
+    await userEvent.click(screen.getByRole("button", { name: "More actions" }));
+    await userEvent.click(screen.getByRole("menuitem", { name: "Remove from Favorites" }));
+
+    expect(mocks.toggleFavorite).toHaveBeenCalledWith(true);
+    await waitFor(() => {
+      const button = screen.getByRole("button", { name: "Add to favorites" });
+      expect(button.getAttribute("aria-pressed")).toBe("false");
+      expect(button.querySelector("svg")?.getAttribute("class")).not.toContain("fill-red-500");
+    });
+  });
+
+  it("rolls the heart back when the favorite request fails", async () => {
+    mocks.toggleFavorite.mockRejectedValueOnce(new Error("request failed"));
+    render(
+      <MemoryRouter>
+        <MediaItemMenu
+          contentId="movie-1"
+          mediaType="movie"
+          userState={{ played: false, is_favorite: false, in_watchlist: false }}
+          variant="poster"
+        />
+      </MemoryRouter>,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "Add to favorites" }));
+
+    await waitFor(() => {
+      expect(screen.getByRole("button", { name: "Add to favorites" })).toBeTruthy();
+    });
+  });
+
+  it("keeps the favorite shortcut off wide cards and collection-disabled menus", () => {
+    const { rerender } = render(
+      <MemoryRouter>
+        <MediaItemMenu
+          contentId="movie-1"
+          mediaType="movie"
+          userState={{ played: false, is_favorite: false, in_watchlist: false }}
+          variant="wide"
+        />
+      </MemoryRouter>,
+    );
+
+    expect(screen.queryByRole("button", { name: "Add to favorites" })).toBeNull();
+
+    rerender(
+      <MemoryRouter>
+        <MediaItemMenu
+          contentId="movie-1"
+          mediaType="movie"
+          userState={{ played: false, is_favorite: false, in_watchlist: false }}
+          variant="poster"
+          showCollectionActions={false}
+        />
+      </MemoryRouter>,
+    );
+
+    expect(screen.queryByRole("button", { name: "Add to favorites" })).toBeNull();
   });
 });

--- a/web/src/components/MediaItemMenu.tsx
+++ b/web/src/components/MediaItemMenu.tsx
@@ -1,16 +1,41 @@
-import { useEffect, useMemo, useState } from "react";
-import { MoreVertical, RefreshCw } from "lucide-react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import {
+  Check,
+  FileText,
+  Heart,
+  History,
+  LoaderCircle,
+  MoreVertical,
+  Pencil,
+  Plus,
+  RefreshCw,
+  RotateCcw,
+  Search,
+  X,
+} from "lucide-react";
 import { useLocation } from "react-router";
 import { useViewTransitionNavigate } from "@/hooks/useViewTransition";
 import type { ItemDetail, MediaItemUserState } from "@/api/types";
-import { useIsActingAdmin } from "@/hooks/useIsActingAdmin";
+import { useOptionalAuth } from "@/hooks/useAuth";
+import { useCurrentProfile } from "@/hooks/useCurrentProfile";
+import { useCatalogItemDetail } from "@/hooks/queries/catalogRead";
 import { useRefreshItemMetadata, useWatchedStateMutation } from "@/hooks/queries/items";
 import { type DismissHomeItemVariables, useDismissHomeItem } from "@/hooks/queries/homeDismissals";
 import { useToggleFavorite } from "@/hooks/queries/favorites";
 import { useToggleWatchlist } from "@/hooks/queries/watchlist";
 import { getWatchedActionLabel } from "@/pages/ItemDetail/watchedState";
+import EditMetadataDialog from "@/components/EditMetadataDialog";
 import MangaFilesDialog from "@/components/MangaFilesDialog";
+import MatchItemDialog from "@/components/MatchItemDialog";
 import RefreshMetadataDialog from "@/components/RefreshMetadataDialog";
+import { Button } from "@/components/ui/button";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
 import {
   DropdownMenu,
   DropdownMenuContent,
@@ -21,6 +46,11 @@ import {
 import { cn } from "@/lib/utils";
 import { useWatchPlaybackController } from "@/playback/watchPlaybackContext";
 import { buildMediaPlayHref } from "@/lib/mediaNavigation";
+import {
+  canCurateMetadata as canCurateMetadataForUser,
+  isActingAdmin as isActingAdminForUser,
+} from "@/lib/permissions";
+import { mediaItemMenuTriggerClassName } from "@/components/mediaItemMenuTrigger";
 
 type MediaItemType = ItemDetail["type"];
 
@@ -35,16 +65,21 @@ type MediaItemMenuEntry =
         | "dismissFromHome"
         | "viewDetails"
         | "viewPlayHistory"
-        | "refreshMetadata";
+        | "refreshMetadata"
+        | "editMetadata"
+        | "matchItem";
       label: string;
     }
   | { kind: "separator" };
+
+type MediaItemMenuActionKey = Extract<MediaItemMenuEntry, { kind: "action" }>["key"];
 
 interface BuildMediaItemMenuModelOptions {
   mediaType: MediaItemType;
   userState?: MediaItemUserState;
   hasPartialProgress?: boolean;
   isAdmin: boolean;
+  canCurateMetadata?: boolean;
   showCollectionActions?: boolean;
   dismissLabel?: string;
 }
@@ -66,6 +101,7 @@ export function buildMediaItemMenuModel({
   userState,
   hasPartialProgress = false,
   isAdmin,
+  canCurateMetadata = isAdmin,
   showCollectionActions = true,
   dismissLabel,
 }: BuildMediaItemMenuModelOptions): MediaItemMenuEntry[] {
@@ -111,22 +147,41 @@ export function buildMediaItemMenuModel({
     entries.push({ kind: "action", key: "viewDetails", label: "View Details" });
   }
 
-  if (isAdmin) {
+  if (isAdmin || canCurateMetadata) {
     if (entries.length > 0) {
       entries.push({ kind: "separator" });
     }
-    entries.push(
-      {
+
+    if (isAdmin) {
+      entries.push({
         kind: "action",
         key: "viewPlayHistory",
         label: "View Play History",
-      },
-      {
+      });
+    }
+
+    if (canCurateMetadata) {
+      entries.push({
         kind: "action",
         key: "refreshMetadata",
         label: "Refresh Metadata",
-      },
-    );
+      });
+
+      if (mediaType === "movie" || mediaType === "series") {
+        entries.push(
+          {
+            kind: "action",
+            key: "editMetadata",
+            label: "Edit Metadata",
+          },
+          {
+            kind: "action",
+            key: "matchItem",
+            label: "Match Item",
+          },
+        );
+      }
+    }
   }
 
   if (dismissLabel) {
@@ -148,6 +203,240 @@ function stopMenuEvent(event: Pick<Event, "preventDefault" | "stopPropagation">)
   event.stopPropagation();
 }
 
+function MediaItemMenuActionIcon({
+  actionKey,
+  userState,
+  isRefreshing,
+}: {
+  actionKey: MediaItemMenuActionKey;
+  userState?: MediaItemUserState;
+  isRefreshing: boolean;
+}) {
+  switch (actionKey) {
+    case "playFromBeginning":
+      return <RotateCcw aria-hidden="true" className="size-4" />;
+    case "toggleWatched":
+      return <Check aria-hidden="true" className="size-4" />;
+    case "toggleFavorite":
+      return (
+        <Heart
+          aria-hidden="true"
+          className={cn("size-4", userState?.is_favorite && "fill-current text-red-400")}
+        />
+      );
+    case "toggleWatchlist":
+      return userState?.in_watchlist ? (
+        <Check aria-hidden="true" className="size-4" />
+      ) : (
+        <Plus aria-hidden="true" className="size-4" />
+      );
+    case "dismissFromHome":
+      return <X aria-hidden="true" className="size-4" />;
+    case "viewDetails":
+      return <FileText aria-hidden="true" className="size-4" />;
+    case "viewPlayHistory":
+      return <History aria-hidden="true" className="size-4" />;
+    case "refreshMetadata":
+      return (
+        <RefreshCw aria-hidden="true" className={cn("size-4", isRefreshing && "animate-spin")} />
+      );
+    case "editMetadata":
+      return <Pencil aria-hidden="true" className="size-4" />;
+    case "matchItem":
+      return <Search aria-hidden="true" className="size-4" />;
+  }
+}
+
+export function PosterCardFavoriteButton({
+  isFavorite,
+  isPending,
+  onToggle,
+}: {
+  isFavorite: boolean;
+  isPending: boolean;
+  onToggle: () => void;
+}) {
+  const [isAnimating, setIsAnimating] = useState(false);
+  const pointerStartRef = useRef<{
+    pointerId: number;
+    clientX: number;
+    clientY: number;
+    maxMovement: number;
+  } | null>(null);
+  const label = isFavorite ? "Remove from favorites" : "Add to favorites";
+
+  const activateFavorite = useCallback(() => {
+    if (isPending) return;
+    if (!isFavorite) setIsAnimating(true);
+    onToggle();
+  }, [isFavorite, isPending, onToggle]);
+
+  useEffect(() => {
+    if (!isAnimating) return;
+    const timeout = window.setTimeout(() => setIsAnimating(false), 420);
+    return () => window.clearTimeout(timeout);
+  }, [isAnimating]);
+
+  return (
+    <div
+      className="absolute bottom-2.5 left-2.5 z-20"
+      onClick={stopMenuEvent}
+      onPointerDown={stopMenuEvent}
+    >
+      <button
+        type="button"
+        aria-label={label}
+        aria-pressed={isFavorite}
+        title={label}
+        disabled={isPending}
+        className={cn(
+          mediaItemMenuTriggerClassName("poster"),
+          "relative cursor-pointer overflow-visible disabled:opacity-70",
+          isFavorite && "text-red-500 hover:text-red-400",
+        )}
+        onPointerDown={(event) => {
+          if (event.button !== 0) {
+            pointerStartRef.current = null;
+            return;
+          }
+          pointerStartRef.current = {
+            pointerId: event.pointerId,
+            clientX: event.clientX,
+            clientY: event.clientY,
+            maxMovement: 0,
+          };
+          event.currentTarget.setPointerCapture?.(event.pointerId);
+        }}
+        onPointerMove={(event) => {
+          const pointerStart = pointerStartRef.current;
+          if (!pointerStart || pointerStart.pointerId !== event.pointerId) return;
+
+          pointerStart.maxMovement = Math.max(
+            pointerStart.maxMovement,
+            Math.abs(event.clientX - pointerStart.clientX),
+            Math.abs(event.clientY - pointerStart.clientY),
+          );
+        }}
+        onPointerUp={(event) => {
+          const pointerStart = pointerStartRef.current;
+          pointerStartRef.current = null;
+          if (event.currentTarget.hasPointerCapture?.(event.pointerId)) {
+            event.currentTarget.releasePointerCapture(event.pointerId);
+          }
+          if (!pointerStart || pointerStart.pointerId !== event.pointerId) return;
+
+          const movement = Math.max(
+            pointerStart.maxMovement,
+            Math.abs(event.clientX - pointerStart.clientX),
+            Math.abs(event.clientY - pointerStart.clientY),
+          );
+          if (movement > 10) return;
+
+          event.preventDefault();
+          event.stopPropagation();
+          activateFavorite();
+        }}
+        onPointerCancel={(event) => {
+          pointerStartRef.current = null;
+          if (event.currentTarget.hasPointerCapture?.(event.pointerId)) {
+            event.currentTarget.releasePointerCapture(event.pointerId);
+          }
+        }}
+        onLostPointerCapture={() => {
+          pointerStartRef.current = null;
+        }}
+        onClick={(event) => {
+          stopMenuEvent(event);
+          // Embla consumes the click following a carousel drag. Pointer taps are
+          // handled on pointerup above; detail=0 preserves keyboard/AT activation.
+          if (event.detail === 0) activateFavorite();
+        }}
+      >
+        {isAnimating && (
+          <span
+            aria-hidden="true"
+            data-testid="favorite-burst"
+            className="absolute top-1/2 left-1/2 size-7 -translate-x-1/2 -translate-y-1/2 animate-ping rounded-full bg-red-500/30 motion-reduce:hidden"
+          />
+        )}
+        <Heart
+          className={cn(
+            "relative size-4 transition-[transform,color,fill] duration-300 ease-out motion-reduce:transition-none",
+            isFavorite && "scale-110 fill-red-500 text-red-500",
+            isAnimating && "scale-125",
+          )}
+        />
+      </button>
+    </div>
+  );
+}
+
+type MetadataAction = "edit" | "match";
+
+export function MetadataActionDialogHost({
+  action,
+  contentId,
+  libraryId,
+  onClose,
+}: {
+  action: MetadataAction;
+  contentId: string;
+  libraryId?: number;
+  onClose: () => void;
+}) {
+  const {
+    data: item,
+    error,
+    isFetching,
+    isLoading,
+    refetch,
+  } = useCatalogItemDetail(contentId, libraryId);
+
+  if (item) {
+    return action === "edit" ? (
+      <EditMetadataDialog item={item} open onOpenChange={(open) => !open && onClose()} />
+    ) : (
+      <MatchItemDialog
+        key={item.content_id}
+        item={libraryId === undefined ? item : { ...item, library_id: libraryId }}
+        open
+        onOpenChange={(open) => !open && onClose()}
+      />
+    );
+  }
+
+  const actionLabel = action === "edit" ? "Edit Metadata" : "Match Item";
+  const loading = isLoading || isFetching;
+
+  return (
+    <Dialog open onOpenChange={(open) => !open && onClose()}>
+      <DialogContent className="max-w-sm">
+        <DialogHeader>
+          <DialogTitle>{actionLabel}</DialogTitle>
+          <DialogDescription>
+            {loading ? "Loading the latest item details…" : "The item details could not be loaded."}
+          </DialogDescription>
+        </DialogHeader>
+        {loading ? (
+          <div className="text-muted-foreground flex items-center gap-2 text-sm">
+            <LoaderCircle className="size-4 animate-spin" />
+            Loading…
+          </div>
+        ) : (
+          <div className="flex items-center justify-between gap-3">
+            <p className="text-muted-foreground text-sm">
+              {error instanceof Error ? error.message : "Please try again."}
+            </p>
+            <Button type="button" variant="outline" size="sm" onClick={() => void refetch()}>
+              Try Again
+            </Button>
+          </div>
+        )}
+      </DialogContent>
+    </Dialog>
+  );
+}
+
 export default function MediaItemMenu({
   contentId,
   mediaType,
@@ -161,10 +450,18 @@ export default function MediaItemMenu({
   const navigate = useViewTransitionNavigate();
   const location = useLocation();
   const playbackController = useWatchPlaybackController();
-  const isAdmin = useIsActingAdmin();
+  const user = useOptionalAuth()?.user;
+  const { profile: currentProfile, hasSelectedProfile } = useCurrentProfile();
+  const profileIsResolved = !hasSelectedProfile || Boolean(currentProfile);
+  const isAdmin = profileIsResolved && isActingAdminForUser(user, currentProfile);
+  const canCurateMetadata = profileIsResolved && canCurateMetadataForUser(user, currentProfile);
   const [currentUserState, setCurrentUserState] = useState(userState);
   const [refreshDialogOpen, setRefreshDialogOpen] = useState(false);
   const [filesDialogOpen, setFilesDialogOpen] = useState(false);
+  const [metadataAction, setMetadataAction] = useState<MetadataAction | null>(null);
+  const menuTriggerRef = useRef<HTMLButtonElement>(null);
+  const lastMenuInteractionRef = useRef<"keyboard" | "pointer" | null>(null);
+  const pointerClosedMenuRef = useRef(false);
 
   useEffect(() => {
     setCurrentUserState(userState);
@@ -199,9 +496,13 @@ export default function MediaItemMenu({
     userState: currentUserState,
     hasPartialProgress,
     isAdmin,
+    canCurateMetadata,
     showCollectionActions,
     dismissLabel,
   });
+  const showPosterFavorite =
+    variant === "poster" &&
+    model.some((entry) => entry.kind === "action" && entry.key === "toggleFavorite");
 
   const isPending =
     watchedMutation.isPending ||
@@ -210,13 +511,24 @@ export default function MediaItemMenu({
     refreshMetadataMutation.isPending ||
     dismissHomeItemMutation.isPending;
 
-  const triggerClassName = cn(
-    "inline-flex items-center justify-center rounded-md border border-border/20 bg-background/60 text-foreground shadow-sm backdrop-blur-sm transition-[opacity,background-color] duration-150 hover:bg-background/80 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/70",
-    variant === "wide" ? "size-9" : "size-8",
-    "opacity-100 md:opacity-0 md:group-hover/card:opacity-100 md:group-focus-within/card:opacity-100",
-  );
+  const triggerClassName = mediaItemMenuTriggerClassName(variant);
 
-  async function handleAction(actionKey: Extract<MediaItemMenuEntry, { kind: "action" }>["key"]) {
+  async function handleFavoriteToggle() {
+    if (!currentUserState || favoriteMutation.isPending) return;
+    const wasFavorite = currentUserState.is_favorite;
+    setCurrentUserState((previous) =>
+      previous ? { ...previous, is_favorite: !wasFavorite } : previous,
+    );
+    try {
+      await favoriteMutation.mutateAsync(wasFavorite);
+    } catch {
+      setCurrentUserState((previous) =>
+        previous ? { ...previous, is_favorite: wasFavorite } : previous,
+      );
+    }
+  }
+
+  async function handleAction(actionKey: MediaItemMenuActionKey) {
     switch (actionKey) {
       case "playFromBeginning": {
         if (mediaType === "audiobook") {
@@ -238,9 +550,7 @@ export default function MediaItemMenu({
         return;
       }
       case "toggleFavorite": {
-        if (!currentUserState) return;
-        await favoriteMutation.mutateAsync(currentUserState.is_favorite);
-        setCurrentUserState((prev) => (prev ? { ...prev, is_favorite: !prev.is_favorite } : prev));
+        await handleFavoriteToggle();
         return;
       }
       case "toggleWatchlist": {
@@ -268,6 +578,14 @@ export default function MediaItemMenu({
         setRefreshDialogOpen(true);
         return;
       }
+      case "editMetadata": {
+        setMetadataAction("edit");
+        return;
+      }
+      case "matchItem": {
+        setMetadataAction("match");
+        return;
+      }
     }
   }
 
@@ -278,6 +596,15 @@ export default function MediaItemMenu({
 
   return (
     <>
+      {showPosterFavorite && currentUserState && (
+        <PosterCardFavoriteButton
+          isFavorite={currentUserState.is_favorite}
+          isPending={favoriteMutation.isPending}
+          onToggle={() => {
+            void handleFavoriteToggle();
+          }}
+        />
+      )}
       <div
         className={cn(
           "absolute z-20",
@@ -291,13 +618,55 @@ export default function MediaItemMenu({
             <MoreVertical className={variant === "wide" ? "size-5" : "size-4"} />
           </button>
         ) : (
-          <DropdownMenu modal={false}>
+          <DropdownMenu
+            modal={false}
+            onOpenChange={(open) => {
+              if (open) {
+                pointerClosedMenuRef.current = false;
+                lastMenuInteractionRef.current = null;
+                return;
+              }
+
+              pointerClosedMenuRef.current = lastMenuInteractionRef.current === "pointer";
+              lastMenuInteractionRef.current = null;
+            }}
+          >
             <DropdownMenuTrigger asChild>
-              <button type="button" aria-label="More actions" className={triggerClassName}>
+              <button
+                ref={menuTriggerRef}
+                type="button"
+                aria-label="More actions"
+                className={triggerClassName}
+                onPointerDown={() => {
+                  lastMenuInteractionRef.current = "pointer";
+                }}
+                onKeyDown={() => {
+                  lastMenuInteractionRef.current = "keyboard";
+                }}
+              >
                 <MoreVertical className={variant === "wide" ? "size-5" : "size-4"} />
               </button>
             </DropdownMenuTrigger>
-            <DropdownMenuContent align="end" className="w-56">
+            <DropdownMenuContent
+              align="end"
+              className="w-max min-w-0"
+              onPointerDownOutside={() => {
+                lastMenuInteractionRef.current = "pointer";
+              }}
+              onPointerDownCapture={() => {
+                lastMenuInteractionRef.current = "pointer";
+              }}
+              onKeyDownCapture={() => {
+                lastMenuInteractionRef.current = "keyboard";
+              }}
+              onCloseAutoFocus={(event) => {
+                if (pointerClosedMenuRef.current) {
+                  event.preventDefault();
+                  menuTriggerRef.current?.blur();
+                }
+                pointerClosedMenuRef.current = false;
+              }}
+            >
               {model.map((entry, index) => {
                 if (entry.kind === "separator") {
                   return <DropdownMenuSeparator key={`separator-${index}`} />;
@@ -311,9 +680,11 @@ export default function MediaItemMenu({
                       void handleAction(entry.key);
                     }}
                   >
-                    {entry.key === "refreshMetadata" && refreshMetadataMutation.isPending ? (
-                      <RefreshCw className="size-4 animate-spin" />
-                    ) : null}
+                    <MediaItemMenuActionIcon
+                      actionKey={entry.key}
+                      userState={currentUserState}
+                      isRefreshing={refreshMetadataMutation.isPending}
+                    />
                     {entry.label}
                   </DropdownMenuItem>
                 );
@@ -328,6 +699,14 @@ export default function MediaItemMenu({
         onConfirm={handleRefreshConfirm}
         isPending={refreshMetadataMutation.isPending}
       />
+      {metadataAction && (
+        <MetadataActionDialogHost
+          action={metadataAction}
+          contentId={contentId}
+          libraryId={libraryId}
+          onClose={() => setMetadataAction(null)}
+        />
+      )}
       {mediaType === "manga" && (
         <MangaFilesDialog
           contentId={contentId}

--- a/web/src/components/mediaItemMenuTrigger.ts
+++ b/web/src/components/mediaItemMenuTrigger.ts
@@ -1,0 +1,9 @@
+import { cn } from "@/lib/utils";
+
+export function mediaItemMenuTriggerClassName(variant: "poster" | "wide" = "poster") {
+  return cn(
+    "inline-flex items-center justify-center rounded-md border border-border/20 bg-background/60 text-foreground shadow-sm backdrop-blur-sm transition-[opacity,background-color,color] duration-150 hover:bg-background/80 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/70",
+    variant === "wide" ? "size-9" : "size-8",
+    "opacity-100 pointer-fine:opacity-0 pointer-fine:group-hover/card:opacity-100 pointer-fine:data-[state=open]:opacity-100 pointer-fine:focus-visible:opacity-100",
+  );
+}

--- a/web/src/components/overlays/CardOverlays.test.tsx
+++ b/web/src/components/overlays/CardOverlays.test.tsx
@@ -113,8 +113,12 @@ describe("CardOverlays", () => {
     expect(container.querySelectorAll("span.inline-flex").length).toBe(3);
   });
 
-  it("lifts bottom-right badges above the card menu button", () => {
+  it("lifts poster badges above the favorite and menu controls", () => {
     const prefs = prefsWithOnly("content_rating");
+    prefs.items.content_rating = { ...prefs.items.content_rating, position: "bottom-left" };
+    const left = render(<CardOverlays data={SAMPLE_MOVIE_DATA} prefs={prefs} />).container;
+    expect(left.querySelector("div.bottom-2 > div.items-start.mb-10")).toBeTruthy();
+
     prefs.items.content_rating = { ...prefs.items.content_rating, position: "bottom-right" };
     const poster = render(<CardOverlays data={SAMPLE_MOVIE_DATA} prefs={prefs} />).container;
     expect(poster.querySelector("div.bottom-2 > div.items-end.mb-10")).toBeTruthy();

--- a/web/src/components/overlays/CardOverlays.tsx
+++ b/web/src/components/overlays/CardOverlays.tsx
@@ -114,16 +114,14 @@ export default function CardOverlays({ data, prefs, variant = "poster" }: CardOv
       )}
       {(bottomLeft.length > 0 || bottomRight.length > 0) && (
         <div className="pointer-events-none absolute inset-x-2 bottom-2 z-10 flex items-end justify-between gap-2">
-          {/* Wide cards keep the bottom edge clear for the progress bar. */}
+          {/* Wide cards keep the bottom edge clear for the progress bar. Poster
+              favorite/menu controls own both corners, so badges sit above them. */}
           <BadgeStack
             badges={bottomLeft}
             align="start"
             preset={preset}
-            extraClass={wide ? "mb-4" : ""}
+            extraClass={wide ? "mb-4" : "mb-10"}
           />
-          {/* The card menu button (MediaItemMenu) owns the bottom-right
-              corner — always visible on touch devices — so this stack sits
-              above it. */}
           <BadgeStack
             badges={bottomRight}
             align="end"

--- a/web/src/hooks/queries/keys.ts
+++ b/web/src/hooks/queries/keys.ts
@@ -265,7 +265,6 @@ export const sectionKeys = {
   all: ["sections"] as const,
   home: () => ["sections", "home"] as const,
   homeLayout: () => ["sections", "home", "layout"] as const,
-  homeRefreshSignal: () => ["sections", "home", "refresh-signal"] as const,
   homeItemsRoot: () => ["sections", "home", "items"] as const,
   homeItems: (sectionId: string) => ["sections", "home", "items", sectionId] as const,
   libraryRoot: () => ["sections", "library"] as const,
@@ -280,6 +279,12 @@ export const sectionKeys = {
     ["sections", "profile", scope, libraryId] as const,
   profileOverridesRaw: (scope: string, libraryId?: string) =>
     ["sections", "profile", scope, libraryId, "raw"] as const,
+};
+
+export const mediaSurfaceKeys = {
+  // Client-only signal: keep it outside sectionKeys so refreshing section data
+  // cannot reset the counter immediately before a mutation increments it.
+  refreshSignal: () => ["media-surfaces", "refresh-signal"] as const,
 };
 
 export const ratingKeys = {

--- a/web/src/hooks/queries/mediaSurfaceRefresh.test.ts
+++ b/web/src/hooks/queries/mediaSurfaceRefresh.test.ts
@@ -6,6 +6,7 @@ import {
   favoriteKeys,
   historyKeys,
   itemKeys,
+  libraryCollectionKeys,
   personKeys,
   progressKeys,
   recKeys,
@@ -19,7 +20,7 @@ import {
 } from "./mediaSurfaceRefresh";
 
 describe("invalidateMediaSurfaceQueries", () => {
-  it("marks item, section, progress, history, favorites, and watchlist queries stale", async () => {
+  it("marks media and collection surfaces stale", async () => {
     const queryClient = new QueryClient();
     const browseKey = itemKeys.browse({
       q: "",
@@ -53,6 +54,7 @@ describe("invalidateMediaSurfaceQueries", () => {
     queryClient.setQueryData(historyKeys.list(), { items: [] });
     queryClient.setQueryData(favoriteKeys.list(), { items: [] });
     queryClient.setQueryData(watchlistKeys.list(), { items: [] });
+    queryClient.setQueryData(libraryCollectionKeys.items(7, "favorites"), { items: [] });
 
     await invalidateMediaSurfaceQueries(queryClient);
 
@@ -79,6 +81,9 @@ describe("invalidateMediaSurfaceQueries", () => {
     expect(queryClient.getQueryState(historyKeys.list())?.isInvalidated).toBe(true);
     expect(queryClient.getQueryState(favoriteKeys.list())?.isInvalidated).toBe(true);
     expect(queryClient.getQueryState(watchlistKeys.list())?.isInvalidated).toBe(true);
+    expect(
+      queryClient.getQueryState(libraryCollectionKeys.items(7, "favorites"))?.isInvalidated,
+    ).toBe(true);
   });
 
   it("marks the active catalog detail query stale for the mutated item", async () => {

--- a/web/src/hooks/queries/mediaSurfaceRefresh.ts
+++ b/web/src/hooks/queries/mediaSurfaceRefresh.ts
@@ -6,6 +6,7 @@ import {
   favoriteKeys,
   historyKeys,
   itemKeys,
+  libraryCollectionKeys,
   personKeys,
   progressKeys,
   recKeys,
@@ -115,6 +116,7 @@ export async function invalidateMediaSurfaceQueries(
     queryClient.invalidateQueries({ queryKey: historyKeys.all }),
     queryClient.invalidateQueries({ queryKey: favoriteKeys.all }),
     queryClient.invalidateQueries({ queryKey: watchlistKeys.all }),
+    queryClient.invalidateQueries({ queryKey: libraryCollectionKeys.all }),
     queryClient.invalidateQueries({ queryKey: recKeys.all }),
     queryClient.invalidateQueries({ queryKey: personKeys.all }),
     queryClient.invalidateQueries({

--- a/web/src/pages/Home.tsx
+++ b/web/src/pages/Home.tsx
@@ -1,6 +1,6 @@
 /* eslint-disable react-hooks/set-state-in-effect */
 import { useEffect, useMemo, useRef, useState } from "react";
-import { useQuery, useQueryClient } from "@tanstack/react-query";
+import { useQueryClient } from "@tanstack/react-query";
 import { Link } from "react-router";
 import { LayoutDashboard } from "lucide-react";
 import HeroBanner from "@/components/HeroBanner";
@@ -15,25 +15,16 @@ import { fetchHomeSectionItems, useHomeLayout } from "@/hooks/queries/sections";
 import { planNextHomeSectionBatch } from "./homeSectionQueue";
 import { buildHomeSectionViewModel, type HomeSectionSlot } from "./homeSectionState";
 import { collectCachedHomeSections } from "./homeSectionCache";
+import { useSectionRefreshSignal } from "./homeSurfaceRefresh";
 
 const SECTION_STALE_TIME = 5 * 60 * 1000;
 const MAX_CONCURRENT_SECTION_REQUESTS = 5;
 const SKELETON_CARD_COUNT = 7;
 
-function useHomeRefreshSignal() {
-  return useQuery({
-    queryKey: sectionKeys.homeRefreshSignal(),
-    queryFn: () => 0,
-    initialData: 0,
-    staleTime: Number.POSITIVE_INFINITY,
-    gcTime: Number.POSITIVE_INFINITY,
-  });
-}
-
 export default function Home() {
   const queryClient = useQueryClient();
   const { data, isLoading, isError, refetch } = useHomeLayout();
-  const { data: homeRefreshSignal = 0 } = useHomeRefreshSignal();
+  const { data: homeRefreshSignal = 0 } = useSectionRefreshSignal();
   const [loadedSections, setLoadedSections] = useState<Map<string, ResolvedSection>>(new Map());
   const [failedIds, setFailedIds] = useState<Set<string>>(new Set());
   const [inFlightIds, setInFlightIds] = useState<Set<string>>(new Set());

--- a/web/src/pages/ItemDetail/components/ActionBar.menu.test.tsx
+++ b/web/src/pages/ItemDetail/components/ActionBar.menu.test.tsx
@@ -1,0 +1,49 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { MemoryRouter } from "react-router";
+import { describe, expect, it, vi } from "vitest";
+import ActionBar from "./ActionBar";
+
+vi.mock("@/playback/watchPlaybackContext", () => ({
+  useWatchPlaybackController: () => ({ startPlayback: vi.fn() }),
+}));
+
+vi.mock("@/components/AddToCollectionDialog", () => ({
+  default: () => null,
+}));
+
+describe("ActionBar detail menu", () => {
+  it("uses matching icons and longest-entry sizing", async () => {
+    render(
+      <MemoryRouter>
+        <ActionBar
+          contentId="series-1"
+          isAdmin
+          canCurateMetadata
+          onToggleWatchlist={() => {}}
+          onRefresh={() => {}}
+          onEditMetadata={() => {}}
+          onMatchItem={() => {}}
+          onSplitItem={() => {}}
+        />
+      </MemoryRouter>,
+    );
+
+    await userEvent.click(screen.getByTitle("More"));
+
+    const menu = screen.getByRole("menu");
+    expect(menu).toHaveClass("w-max", "min-w-0");
+    expect(menu).not.toHaveClass("w-56");
+    for (const item of screen.getAllByRole("menuitem")) {
+      expect(item.querySelector("svg"), item.textContent ?? "menu item").toBeTruthy();
+    }
+    expect(
+      screen.getByRole("menuitem", { name: "View Play History" }).querySelector(".lucide-history"),
+    ).toBeTruthy();
+    expect(
+      screen
+        .getByRole("menuitem", { name: "Refresh Metadata" })
+        .querySelector(".lucide-refresh-cw"),
+    ).toBeTruthy();
+  });
+});

--- a/web/src/pages/ItemDetail/components/ActionBar.tsx
+++ b/web/src/pages/ItemDetail/components/ActionBar.tsx
@@ -7,6 +7,7 @@ import {
   Captions,
   Download,
   FolderPlus,
+  History,
   Info,
   Loader2,
   MoreVertical,
@@ -364,7 +365,7 @@ export default function ActionBar({
               <MoreVertical className="size-[18px]" />
             </Button>
           </DropdownMenuTrigger>
-          <DropdownMenuContent align="end" className="w-56">
+          <DropdownMenuContent align="end" className="w-max min-w-0">
             {restartHref && (
               <DropdownMenuItem
                 onSelect={() => {
@@ -414,6 +415,7 @@ export default function ActionBar({
                       navigate(`/admin/history?media_item_id=${encodeURIComponent(contentId)}`)
                     }
                   >
+                    <History className="size-4" />
                     View Play History
                   </DropdownMenuItem>
                 )}
@@ -424,7 +426,7 @@ export default function ActionBar({
                       setRefreshDialogOpen(true);
                     }}
                   >
-                    {isRefreshing && <RefreshCw className="size-4 animate-spin" />}
+                    <RefreshCw className={`size-4 ${isRefreshing ? "animate-spin" : ""}`} />
                     Refresh Metadata
                   </DropdownMenuItem>
                 )}

--- a/web/src/pages/LibraryRecommended.test.tsx
+++ b/web/src/pages/LibraryRecommended.test.tsx
@@ -4,9 +4,12 @@ import { act } from "react";
 import type { ReactNode } from "react";
 import { createRoot, type Root } from "react-dom/client";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { waitFor } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import LibraryRecommended from "./LibraryRecommended";
+import { bumpHomeRefreshSignal } from "./homeSurfaceRefresh";
+import { invalidateMediaSurfaceQueries } from "@/hooks/queries/mediaSurfaceRefresh";
 
 (
   globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean }
@@ -54,8 +57,20 @@ vi.mock("@/components/HeroBanner", () => ({
 }));
 
 vi.mock("@/components/SectionRow", () => ({
-  default: ({ section }: { section: { title: string; section_type: string } }) => (
-    <div data-kind="section-row" data-section-type={section.section_type}>
+  default: ({
+    section,
+  }: {
+    section: {
+      title: string;
+      section_type: string;
+      items: Array<{ user_state?: { is_favorite: boolean } }>;
+    };
+  }) => (
+    <div
+      data-kind="section-row"
+      data-section-type={section.section_type}
+      data-favorite={section.items[0]?.user_state?.is_favorite ? "true" : "false"}
+    >
       {section.title}
     </div>
   ),
@@ -90,6 +105,7 @@ function makeSection(
     section_type: string;
     title: string;
     featured: boolean;
+    isFavorite: boolean;
   }> = {},
 ) {
   return {
@@ -116,6 +132,11 @@ function makeSection(
         backdrop_url: "",
         backdrop_thumbhash: "",
         logo_url: "",
+        user_state: {
+          played: false,
+          is_favorite: overrides.isFavorite ?? false,
+          in_watchlist: false,
+        },
       },
     ],
   };
@@ -179,6 +200,7 @@ describe("LibraryRecommended", () => {
       await Promise.resolve();
       await Promise.resolve();
     });
+    return queryClient;
   }
 
   it("renders sections from the layout and item APIs", async () => {
@@ -197,6 +219,55 @@ describe("LibraryRecommended", () => {
 
     expect(invalidateQueries).not.toHaveBeenCalled();
     invalidateQueries.mockRestore();
+  });
+
+  it("reloads locally held library rows after consecutive media surface refreshes", async () => {
+    let isFavorite = false;
+    mockFetchLibrarySectionItems.mockImplementation((_libraryId: number, sectionId: string) =>
+      Promise.resolve({
+        section: makeSection({
+          id: sectionId,
+          title: sectionId === "cw" ? "Continue Watching" : "Recently Added",
+          section_type: sectionId === "cw" ? "continue_watching" : "recently_added",
+          isFavorite,
+        }),
+      }),
+    );
+    const queryClient = await render(<LibraryRecommended libraryId={42} />);
+
+    expect(
+      container
+        .querySelector('[data-section-type="recently_added"]')
+        ?.getAttribute("data-favorite"),
+    ).toBe("false");
+
+    isFavorite = true;
+    await act(async () => {
+      await invalidateMediaSurfaceQueries(queryClient);
+      bumpHomeRefreshSignal(queryClient);
+    });
+
+    await waitFor(() => {
+      expect(
+        container
+          .querySelector('[data-section-type="recently_added"]')
+          ?.getAttribute("data-favorite"),
+      ).toBe("true");
+    });
+
+    isFavorite = false;
+    await act(async () => {
+      await invalidateMediaSurfaceQueries(queryClient);
+      bumpHomeRefreshSignal(queryClient);
+    });
+
+    await waitFor(() => {
+      expect(
+        container
+          .querySelector('[data-section-type="recently_added"]')
+          ?.getAttribute("data-favorite"),
+      ).toBe("false");
+    });
   });
 
   it("renders hero banner for featured sections", async () => {

--- a/web/src/pages/LibraryRecommended.tsx
+++ b/web/src/pages/LibraryRecommended.tsx
@@ -19,6 +19,7 @@ import { collectCachedHomeSections } from "./homeSectionCache";
 import { isAudiobookLibraryType } from "./libraryPageSearchParams";
 import { useUICustomization } from "@/hooks/useUICustomization";
 import { carouselCardWidthClasses } from "@/lib/uiCustomization";
+import { useSectionRefreshSignal } from "./homeSurfaceRefresh";
 
 interface LibraryRecommendedProps {
   libraryId: number;
@@ -42,6 +43,7 @@ export default function LibraryRecommended({
 }: LibraryRecommendedProps) {
   const queryClient = useQueryClient();
   const { data, isLoading } = useLibraryLayout(libraryId);
+  const { data: sectionRefreshSignal = 0 } = useSectionRefreshSignal();
   const [loadedSections, setLoadedSections] = useState<Map<string, ResolvedSection>>(new Map());
   const [failedIds, setFailedIds] = useState<Set<string>>(new Set());
   const [inFlightIds, setInFlightIds] = useState<Set<string>>(new Set());
@@ -78,7 +80,7 @@ export default function LibraryRecommended({
         });
       });
     };
-  }, [libraryId, layout, layoutResetKey, queryClient]);
+  }, [libraryId, layout, layoutResetKey, queryClient, sectionRefreshSignal]);
 
   useEffect(() => {
     if (layout.length === 0) return;

--- a/web/src/pages/homeSurfaceRefresh.ts
+++ b/web/src/pages/homeSurfaceRefresh.ts
@@ -1,9 +1,20 @@
+import { useQuery } from "@tanstack/react-query";
 import type { QueryClient } from "@tanstack/react-query";
-import { sectionKeys } from "@/hooks/queries/keys";
+import { mediaSurfaceKeys } from "@/hooks/queries/keys";
+
+export function useSectionRefreshSignal() {
+  return useQuery({
+    queryKey: mediaSurfaceKeys.refreshSignal(),
+    queryFn: () => 0,
+    initialData: 0,
+    staleTime: Number.POSITIVE_INFINITY,
+    gcTime: Number.POSITIVE_INFINITY,
+  });
+}
 
 export function bumpHomeRefreshSignal(queryClient: QueryClient) {
   queryClient.setQueryData<number>(
-    sectionKeys.homeRefreshSignal(),
+    mediaSurfaceKeys.refreshSignal(),
     (current) => (current ?? 0) + 1,
   );
 }


### PR DESCRIPTION
## Problem

Related issue: #715

Poster cards made common actions harder to reach than they needed to be. Favoriting was hidden in the overflow menu, card menus were missing the metadata actions available on movie and series detail pages, and closing a menu with the pointer could leave its trigger visible after leaving the card. The card and detail overflow menus also had inconsistent icon coverage and more width than their content needed.

## Approach

I added a bottom-left favorite control that matches the existing glass poster action, uses the shared favorite mutation, and stays in sync with the overflow menu, detail view, favorites, home sections, library sections, and pinned collection rows. It updates immediately, rolls back on failure, animates when added, and supports both favorite and unfavorite states.

I also brought Edit Metadata and Match Item into movie and series poster menus using the existing curation permission, item-detail query, dialogs, and library context. Poster and detail overflow menus now use matching Lucide icons for every entry and size to their longest label.

Pointer handling preserves normal taps after a carousel swipe without treating a drag as a favorite action. Pointer-closing a menu suppresses Radix's focus restoration so the trigger hides on hover exit, while keyboard-closing still restores focus for accessibility.

The watched-indicator work in #714 remains separate and is not included here.

## Improvements

- Adds a responsive, animated favorite heart to poster cards on home and library surfaces.
- Keeps favorite and unfavorite state consistent across every existing favorite entry point.
- Adds Edit Metadata and Match Item to movie and series poster menus with the same permissions and dialogs as item details.
- Uses matching SVG icons and compact content-based sizing in poster and item-detail overflow menus.
- Keeps card actions reliable after swiping and prevents pointer-closed menu triggers from sticking on screen.

## Validation

- Manually verified the deployed fork build on desktop hover and touch/swipe paths, including favorite, unfavorite, cross-surface state updates, metadata dialogs, and menu hover exit.
- Focused Vitest coverage: 80 tests passed across 8 related files.
- Full web suite via the repository's exact Vitest arguments: 2,042 tests passed across 284 files.
- `eslint .`: passed with 0 errors; the repository's existing warnings remain.
- `prettier --check "src/**/*.{ts,tsx,css}"`: passed.
- `tsc -b && vite build`: passed.
- `make verify-local-paths`: passed.
- `make test-web` could not start locally because pnpm attempted a registry check in the restricted environment; I ran its exact Vitest command directly and it passed as reported above.
- Go and generated-contract checks were not run locally because this Mac does not have the Go toolchain.
- Upstream CI passed Docs hygiene, Web, and Go on commit `2dbe5e2e`; CodeRabbit also completed successfully.

## Risks

Frontend only; no API, schema, migration, or deployment changes. Favorite mutations add the pinned-collection cache to the existing media-surface refresh so a successful state change may refetch one additional query family. Optimistic state rolls back if the request fails.

## AI Disclosure

- Tool(s): OpenAI Codex
- Model(s): GPT-5
- Involvement: AI-assisted
- Adversarial review: A separate final review traced pointer event ordering, focus restoration, permission gates, item and library context, cache invalidation, icon coverage, and upstream scope. Earlier review found stale pointer state and swipe-return activation edge cases; both were fixed with pointer capture cleanup and latched maximum movement, with regression tests. The final upstream-port review found no actionable issues and confirmed that no watched-indicator or unrelated fork-only changes are included.

## Checklist

- [x] I read and can explain the complete diff.
- [x] This pull request addresses one concern.

Closes #715
