### PR TITLE
feat(metadata): configure image cache workers

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -98,6 +98,9 @@ POSTGRES_SHM_SIZE=8gb
 # NODE_NAME=transcode-01
 # NODE_URL=http://transcode-01.example.com:8082
 
+# Optional metadata artwork cache concurrency. Defaults to 4 workers.
+# SILO_METADATA_IMAGE_CACHE_WORKERS=4
+
 # Optional server mode override for source runs or standalone worker nodes.
 # MODE=integrated
 #SILO_MIGRATE_TIMEOUT=60m

--- a/internal/taskmanager/tasks/cache_metadata_images.go
+++ b/internal/taskmanager/tasks/cache_metadata_images.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"fmt"
 	"os"
+	"strconv"
+	"strings"
 	"time"
 
 	"github.com/google/uuid"
@@ -13,14 +15,24 @@ import (
 )
 
 const (
-	cacheMetadataImagesIntervalMs = int64(60 * 1000)
-	// Claim only work that can start immediately. Claiming a large queue page
-	// stamps one lease on every row up front; with two workers, the unstarted
+	cacheMetadataImagesWorkersEnv = "SILO_METADATA_IMAGE_CACHE_WORKERS"
+
+	cacheMetadataImagesIntervalMs     = int64(60 * 1000)
+	cacheMetadataImagesDefaultWorkers = 4
+	// Keep claim batches small independently of configured concurrency. Claiming
+	// a large queue page stamps one lease on every row up front, so an unstarted
 	// tail could expire and be reclaimed before this execution reaches it.
 	cacheMetadataImagesClaimLimit = 2
-	cacheMetadataImagesWorkers    = 2
 	cacheMetadataImagesMaxRuntime = 10 * time.Minute
 )
+
+func cacheMetadataImagesWorkers() int {
+	workers, err := strconv.Atoi(strings.TrimSpace(os.Getenv(cacheMetadataImagesWorkersEnv)))
+	if err != nil || workers <= 0 {
+		return cacheMetadataImagesDefaultWorkers
+	}
+	return workers
+}
 
 type MetadataImageCacheRunner interface {
 	DrainUntilIdle(ctx context.Context, workerID string, claimLimit int, concurrency int, maxRuntime time.Duration, reportProgress metadata.ImageCacheRunProgressReporter) (metadata.ImageCacheRunStats, error)
@@ -135,7 +147,7 @@ func executeMetadataImages(ctx context.Context, progress taskmanager.ProgressRep
 		ctx,
 		workerID,
 		cacheMetadataImagesClaimLimit,
-		cacheMetadataImagesWorkers,
+		cacheMetadataImagesWorkers(),
 		maxRuntime,
 		func(update metadata.ImageCacheRunStats) {
 			percent := cacheMetadataImagesPercent(update)

--- a/internal/taskmanager/tasks/cache_metadata_images_test.go
+++ b/internal/taskmanager/tasks/cache_metadata_images_test.go
@@ -93,6 +93,7 @@ func TestBackfillMetadataImagesTaskProperties(t *testing.T) {
 }
 
 func TestCacheMetadataImagesTaskReportsStats(t *testing.T) {
+	t.Setenv(cacheMetadataImagesWorkersEnv, "6")
 	runner := &fakeMetadataImageCacheRunner{
 		updates: []metadata.ImageCacheRunStats{{
 			Batches:   2,
@@ -116,10 +117,10 @@ func TestCacheMetadataImagesTaskReportsStats(t *testing.T) {
 		t.Fatalf("Execute() error = %v", err)
 	}
 	if runner.claimLimit != 2 {
-		t.Fatalf("claimLimit = %d, want one immediately-startable job per worker", runner.claimLimit)
+		t.Fatalf("claimLimit = %d, want fixed claim size 2", runner.claimLimit)
 	}
-	if runner.concurrency != 2 {
-		t.Fatalf("concurrency = %d, want 2", runner.concurrency)
+	if runner.concurrency != 6 {
+		t.Fatalf("concurrency = %d, want configured 6", runner.concurrency)
 	}
 	if runner.maxRuntime != 10*time.Minute {
 		t.Fatalf("maxRuntime = %s, want 10m", runner.maxRuntime)
@@ -145,6 +146,7 @@ func TestCacheMetadataImagesTaskReportsStats(t *testing.T) {
 }
 
 func TestBackfillMetadataImagesTaskReportsDiscovery(t *testing.T) {
+	t.Setenv(cacheMetadataImagesWorkersEnv, "1")
 	runner := &fakeMetadataImageCacheRunner{stats: metadata.ImageCacheRunStats{
 		Batches:          2,
 		EnqueuedExisting: 5,
@@ -162,7 +164,10 @@ func TestBackfillMetadataImagesTaskReportsDiscovery(t *testing.T) {
 		t.Fatalf("maxRuntime = %s, want no deadline for manual backfill", runner.maxRuntime)
 	}
 	if runner.claimLimit != 2 {
-		t.Fatalf("claimLimit = %d, want one immediately-startable job per worker", runner.claimLimit)
+		t.Fatalf("claimLimit = %d, want fixed claim size 2", runner.claimLimit)
+	}
+	if runner.concurrency != 1 {
+		t.Fatalf("concurrency = %d, want configured 1", runner.concurrency)
 	}
 	if len(runner.workerIDs) != 1 || !strings.Contains(runner.workerIDs[0], ":backfill:") {
 		t.Fatalf("backfill worker IDs = %#v, want one execution-scoped backfill owner", runner.workerIDs)
@@ -173,6 +178,22 @@ func TestBackfillMetadataImagesTaskReportsDiscovery(t *testing.T) {
 	want := "Discovered 5 existing, Batches 2, claimed 5, cached 5, 0 failed attempts, skipped 0, uploaded 0 variants, found 0 existing variants, deleted 0 old successes"
 	if got := progress.messages[len(progress.messages)-1]; got != want {
 		t.Fatalf("final message = %q, want %q", got, want)
+	}
+}
+
+func TestCacheMetadataImagesWorkersDefaultsForInvalidOverride(t *testing.T) {
+	t.Setenv(cacheMetadataImagesWorkersEnv, "")
+	if got := cacheMetadataImagesWorkers(); got != 4 {
+		t.Fatalf("cacheMetadataImagesWorkers() = %d, want default 4", got)
+	}
+
+	for _, value := range []string{"", "0", "-1", "not-a-number"} {
+		t.Run(value, func(t *testing.T) {
+			t.Setenv(cacheMetadataImagesWorkersEnv, value)
+			if got := cacheMetadataImagesWorkers(); got != cacheMetadataImagesDefaultWorkers {
+				t.Fatalf("cacheMetadataImagesWorkers() = %d, want default %d", got, cacheMetadataImagesDefaultWorkers)
+			}
+		})
 	}
 }
 


### PR DESCRIPTION
## Problem

Related issue: N/A — narrow fix

Metadata image cache and backfill tasks hardcode their worker count, so deployments cannot adjust their image-processing concurrency.

## Approach

- Read `SILO_METADATA_IMAGE_CACHE_WORKERS` when a metadata image task starts.
- Default to 4 workers. Empty, invalid, zero, and negative values fall back to that default.
- Use the same setting for queued cache drains and manual backfills.
- Keep the claim size at 2, the scheduled drain cap at 10 minutes, and manual backfills unbounded as before.
- Document the deployment override in `.env.example`.

The fixed two-job claim size still caps realized parallelism within one claimed batch at two. The setting can reduce concurrency today; values above two are passed to the runner but do not increase work within a single batch while that claim size remains fixed.

## Validation

Passed:

```text
go test -race ./internal/taskmanager/tasks/...
go build ./...
gofmt -l .
go vet ./...
make verify-local-paths
git diff --check
```

`make test-go` is not green because two existing `internal/jellycompat` process-lock tests fail reproducibly:

```text
TestBeginWebOperationRecoversDeadProcessLock
TestBeginWebOperationRejectsLiveProcessLock
```

`golangci-lint run --new-from-merge-base="origin/main" ./...` was not run because `golangci-lint` is not installed in the validation environment.

No frontend behavior changed, so frontend tests and screenshots are not applicable.

## Risks

An invalid override silently uses the default, matching existing worker-count environment overrides. No API, database, migration, or client contract changes.

## AI Disclosure

- Tool(s): Codex in T3 Code
- Model(s): gpt-5.6-sol
- Involvement: Fully AI-generated; human review pending
- Adversarial review: Reviewed the complete diff and traced the configured value through both task paths into `ImageCacheProcessor`. Verified fallback parsing, the unchanged claim and runtime arguments, and deployment documentation. The review found that the fixed claim size limits realized per-batch parallelism to two; this tradeoff is documented above because preserving the claim size is part of the requested scope.

## Checklist

- [x] I read and can explain the complete diff.
- [x] This pull request addresses one concern.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an optional setting to configure the number of concurrent metadata artwork cache workers.
  * The default concurrency is four workers when the setting is omitted or invalid.

* **Bug Fixes**
  * Improved handling of empty, non-positive, or invalid worker-count settings by safely applying the default.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->