### PR TITLE
perf(metadata): page artwork backfill by source key

### DIFF
--- a/internal/metadata/image_cache_job_repo.go
+++ b/internal/metadata/image_cache_job_repo.go
@@ -767,243 +767,43 @@ func (r *ImageCacheJobRepository) DeleteSucceededBefore(ctx context.Context, bef
 	return int(tag.RowsAffected()), nil
 }
 
-func (r *ImageCacheJobRepository) EnqueueExistingProviderArtwork(ctx context.Context, limit int) (int, error) {
+const imageCacheDiscoverySurfaceCount = 10
+const imageCachePosterPathColumn = "poster_path"
+const imageCacheBackdropPathColumn = "backdrop_path"
+const imageCacheLogoPathColumn = "logo_path"
+
+func (r *ImageCacheJobRepository) EnqueueExistingProviderArtwork(ctx context.Context, cursor imageCacheDiscoveryCursor, limit int) (imageCacheDiscoveryPage, error) {
+	page := imageCacheDiscoveryPage{Next: cursor}
 	if r == nil || r.pool == nil || limit <= 0 {
-		return 0, nil
+		page.Complete = true
+		return page, nil
 	}
-	// Each branch is restricted to provider-origin sources (LIKE '%://%' minus
-	// cached/system schemes). Local file:// sidecar sources are deliberately
-	// excluded from this sweep: their recovery is refresh-driven (a metadata
-	// refresh re-discovers the sidecar and enqueues a fresh job), so a stable
-	// local failure cannot be resurrected here every cycle.
-	// Each branch is also restricted to targets whose stored *_path is not already a
-	// cached relative path. The destination check makes the cached row itself the
-	// durable dedup marker, so pruning succeeded job rows does not cause the whole
-	// catalog to be re-downloaded once the rows age out.
-	query := strings.ReplaceAll(`
-		WITH all_candidates AS (
-			SELECT
-				'poster'::text AS image_type,
-				'item'::text AS target_type,
-				mi.content_id AS target_content_id,
-				''::text AS target_language,
-				mi.content_id AS series_id,
-				mi.poster_source_path AS source_path,
-				mi.type AS content_type,
-				NULL::integer AS season_number,
-				NULL::integer AS episode_number,
-				mi.tmdb_id,
-				mi.tvdb_id,
-				mi.imdb_id
-			FROM media_items mi
-			WHERE mi.poster_source_path LIKE '%://%'
-			  AND lower(mi.poster_source_path) NOT LIKE ALL (@nonProviderSchemes)
-			  AND (mi.poster_path LIKE '%://%' OR coalesce(mi.poster_path, '') = '')
-			UNION ALL
-			SELECT
-				'backdrop'::text,
-				'item'::text,
-				mi.content_id,
-				''::text,
-				mi.content_id,
-				mi.backdrop_source_path,
-				mi.type,
-				NULL::integer,
-				NULL::integer,
-				mi.tmdb_id,
-				mi.tvdb_id,
-				mi.imdb_id
-			FROM media_items mi
-			WHERE mi.backdrop_source_path LIKE '%://%'
-			  AND lower(mi.backdrop_source_path) NOT LIKE ALL (@nonProviderSchemes)
-			  AND (mi.backdrop_path LIKE '%://%' OR coalesce(mi.backdrop_path, '') = '')
-			UNION ALL
-			SELECT
-				'logo'::text,
-				'item'::text,
-				mi.content_id,
-				''::text,
-				mi.content_id,
-				mi.logo_source_path,
-				mi.type,
-				NULL::integer,
-				NULL::integer,
-				mi.tmdb_id,
-				mi.tvdb_id,
-				mi.imdb_id
-			FROM media_items mi
-			WHERE mi.logo_source_path LIKE '%://%'
-			  AND lower(mi.logo_source_path) NOT LIKE ALL (@nonProviderSchemes)
-			  AND (mi.logo_path LIKE '%://%' OR coalesce(mi.logo_path, '') = '')
-			UNION ALL
-			SELECT
-				'poster'::text,
-				'item_localization'::text,
-				loc.content_id,
-				loc.language,
-				loc.content_id,
-				loc.poster_source_path,
-				mi.type,
-				NULL::integer,
-				NULL::integer,
-				mi.tmdb_id,
-				mi.tvdb_id,
-				mi.imdb_id
-			FROM media_item_localizations loc
-			JOIN media_items mi ON mi.content_id = loc.content_id
-			WHERE loc.poster_source_path LIKE '%://%'
-			  AND lower(loc.poster_source_path) NOT LIKE ALL (@nonProviderSchemes)
-			  AND (loc.poster_path LIKE '%://%' OR coalesce(loc.poster_path, '') = '')
-			UNION ALL
-			SELECT
-				'backdrop'::text,
-				'item_localization'::text,
-				loc.content_id,
-				loc.language,
-				loc.content_id,
-				loc.backdrop_source_path,
-				mi.type,
-				NULL::integer,
-				NULL::integer,
-				mi.tmdb_id,
-				mi.tvdb_id,
-				mi.imdb_id
-			FROM media_item_localizations loc
-			JOIN media_items mi ON mi.content_id = loc.content_id
-			WHERE loc.backdrop_source_path LIKE '%://%'
-			  AND lower(loc.backdrop_source_path) NOT LIKE ALL (@nonProviderSchemes)
-			  AND (loc.backdrop_path LIKE '%://%' OR coalesce(loc.backdrop_path, '') = '')
-			UNION ALL
-			SELECT
-				'logo'::text,
-				'item_localization'::text,
-				loc.content_id,
-				loc.language,
-				loc.content_id,
-				loc.logo_source_path,
-				mi.type,
-				NULL::integer,
-				NULL::integer,
-				mi.tmdb_id,
-				mi.tvdb_id,
-				mi.imdb_id
-			FROM media_item_localizations loc
-			JOIN media_items mi ON mi.content_id = loc.content_id
-			WHERE loc.logo_source_path LIKE '%://%'
-			  AND lower(loc.logo_source_path) NOT LIKE ALL (@nonProviderSchemes)
-			  AND (loc.logo_path LIKE '%://%' OR coalesce(loc.logo_path, '') = '')
-			UNION ALL
-			SELECT
-				'poster'::text,
-				'season'::text,
-				s.content_id AS target_content_id,
-				''::text AS target_language,
-				s.series_id,
-				s.poster_source_path AS source_path,
-				'series'::text AS content_type,
-				s.season_number,
-				NULL::integer AS episode_number,
-				mi.tmdb_id,
-				mi.tvdb_id,
-				mi.imdb_id
-			FROM seasons s
-			JOIN media_items mi ON mi.content_id = s.series_id
-			WHERE s.poster_source_path LIKE '%://%'
-			  AND lower(s.poster_source_path) NOT LIKE ALL (@nonProviderSchemes)
-			  AND (s.poster_path LIKE '%://%' OR coalesce(s.poster_path, '') = '')
-			UNION ALL
-			SELECT
-				'poster'::text,
-				'season_localization'::text,
-				s.content_id,
-				loc.language,
-				s.series_id,
-				loc.poster_source_path,
-				'series'::text,
-				s.season_number,
-				NULL::integer,
-				mi.tmdb_id,
-				mi.tvdb_id,
-				mi.imdb_id
-			FROM season_localizations loc
-			JOIN seasons s ON s.content_id = loc.season_content_id
-			JOIN media_items mi ON mi.content_id = s.series_id
-			WHERE loc.poster_source_path LIKE '%://%'
-			  AND lower(loc.poster_source_path) NOT LIKE ALL (@nonProviderSchemes)
-			  AND (loc.poster_path LIKE '%://%' OR coalesce(loc.poster_path, '') = '')
-			UNION ALL
-			SELECT
-				'still'::text,
-				'episode'::text,
-				e.content_id,
-				''::text,
-				e.series_id,
-				e.still_source_path,
-				'series'::text,
-				e.season_number,
-				e.episode_number,
-				mi.tmdb_id,
-				mi.tvdb_id,
-				mi.imdb_id
-			FROM episodes e
-			JOIN media_items mi ON mi.content_id = e.series_id
-			WHERE e.still_source_path LIKE '%://%'
-			  AND lower(e.still_source_path) NOT LIKE ALL (@nonProviderSchemes)
-			  AND (e.still_path LIKE '%://%' OR coalesce(e.still_path, '') = '')
-			UNION ALL
-			SELECT
-				'profile'::text,
-				'person'::text,
-				p.id::text,
-				''::text,
-				''::text,
-				p.photo_source_path,
-				'people'::text,
-				NULL::integer,
-				NULL::integer,
-				p.tmdb_id,
-				p.tvdb_id,
-				p.imdb_id
-			FROM people p
-			WHERE p.photo_source_path LIKE '%://%'
-			  AND lower(p.photo_source_path) NOT LIKE ALL (@nonProviderSchemes)
-			  AND (p.photo_path LIKE '%://%' OR coalesce(p.photo_path, '') = '')
-		),
-		candidates AS (
-			SELECT ac.*
-			FROM all_candidates ac
-			LEFT JOIN metadata_image_cache_jobs j
-			  ON j.target_type = ac.target_type
-			 AND j.target_content_id = ac.target_content_id
-			 AND j.image_type = ac.image_type
-			 AND j.target_language = ac.target_language
-			WHERE j.id IS NULL
-			   OR j.source_path IS DISTINCT FROM ac.source_path
-			   OR j.status = 'succeeded'
-			   OR (
-				   j.status = 'failed'
-				   AND j.next_attempt_at <= NOW()
-			   )
-			ORDER BY ac.target_type, ac.target_content_id, ac.target_language, ac.image_type
-			LIMIT $1
-		)
-		SELECT image_type, target_type, target_content_id, target_language, series_id, source_path,
-		       content_type, season_number, episode_number,
-		       COALESCE(tmdb_id, '') AS tmdb_id,
-		       COALESCE(tvdb_id, '') AS tvdb_id,
-		       COALESCE(imdb_id, '') AS imdb_id
-		FROM candidates
-	`, "@nonProviderSchemes", nonProviderImageSchemesSQL)
-	rows, err := r.pool.Query(ctx, query, limit)
+	if cursor.Surface < 0 {
+		cursor = imageCacheDiscoveryCursor{}
+	}
+	if cursor.Surface >= imageCacheDiscoverySurfaceCount {
+		page.Next = cursor
+		page.Complete = true
+		return page, nil
+	}
+
+	// Query one source surface at a time and advance by its native primary key.
+	// This avoids rebuilding and sorting the union of the full catalog for every
+	// page. The explicit collation on the job key is required for PostgreSQL to
+	// use an indexed job lookup when source IDs use C collation.
+	query, args := imageCacheDiscoveryQuery(cursor, limit)
+	rows, err := r.pool.Query(ctx, query, args...)
 	if err != nil {
-		return 0, fmt.Errorf("enqueueing existing provider artwork: %w", err)
+		return page, fmt.Errorf("discovering existing provider artwork surface %d: %w", cursor.Surface, err)
 	}
 	defer rows.Close()
 
 	inputs := make([]EnqueueImageCacheJobInput, 0, limit)
+	next := cursor
 	for rows.Next() {
 		var in EnqueueImageCacheJobInput
 		var tmdbID, tvdbID, imdbID string
+		var eligible bool
 		if err := rows.Scan(
 			&in.ImageType,
 			&in.TargetType,
@@ -1017,19 +817,192 @@ func (r *ImageCacheJobRepository) EnqueueExistingProviderArtwork(ctx context.Con
 			&tmdbID,
 			&tvdbID,
 			&imdbID,
+			&next.Key,
+			&next.Subkey,
+			&next.NumericKey,
+			&eligible,
 		); err != nil {
-			return 0, fmt.Errorf("scanning existing provider artwork: %w", err)
+			return page, fmt.Errorf("scanning existing provider artwork surface %d: %w", cursor.Surface, err)
 		}
-		fallbackProvider := imageCachePrimaryProvider(tmdbID, tvdbID, imdbID)
-		in.ProviderID = imageCacheProviderIDFromSource(in.SourcePath, fallbackProvider)
-		in.ProviderContentID = imageCacheProviderContentID(in.ProviderID, tmdbID, tvdbID, imdbID, firstNonEmpty(in.SeriesID, in.TargetContentID))
-		in.ContentType = imageCacheContentType(in.ContentType)
-		inputs = append(inputs, in)
+		page.Scanned++
+		if eligible {
+			fallbackProvider := imageCachePrimaryProvider(tmdbID, tvdbID, imdbID)
+			in.ProviderID = imageCacheProviderIDFromSource(in.SourcePath, fallbackProvider)
+			in.ProviderContentID = imageCacheProviderContentID(in.ProviderID, tmdbID, tvdbID, imdbID, firstNonEmpty(in.SeriesID, in.TargetContentID))
+			in.ContentType = imageCacheContentType(in.ContentType)
+			inputs = append(inputs, in)
+			page.Discovered++
+		}
 	}
 	if err := rows.Err(); err != nil {
-		return 0, fmt.Errorf("iterating existing provider artwork: %w", err)
+		return page, fmt.Errorf("iterating existing provider artwork surface %d: %w", cursor.Surface, err)
 	}
-	return r.enqueueBatch(ctx, inputs, true)
+
+	page.Enqueued, err = r.enqueueBatch(ctx, inputs, true)
+	if err != nil {
+		// Do not return the advanced cursor after a partial enqueue. Rows committed
+		// by an earlier chunk are durable, and retrying from the old key is safe.
+		return imageCacheDiscoveryPage{Next: cursor}, err
+	}
+	page.Next = next
+	if page.Scanned < limit {
+		page.Next = imageCacheDiscoveryCursor{Surface: cursor.Surface + 1}
+		page.Complete = page.Next.Surface >= imageCacheDiscoverySurfaceCount
+	}
+	return page, nil
+}
+
+func imageCacheDiscoveryQuery(cursor imageCacheDiscoveryCursor, limit int) (string, []any) {
+	sourceQuery, args := imageCacheDiscoverySourceQuery(cursor, limit)
+	query := strings.ReplaceAll(fmt.Sprintf(`
+		WITH source_page AS (
+			%s
+		), scanned AS (
+			SELECT c.*,
+			       (j.id IS NULL
+			        OR j.source_path IS DISTINCT FROM c.source_path
+			        OR j.status = 'succeeded'
+			        OR (j.status = 'failed' AND j.next_attempt_at <= NOW())) AS eligible
+			FROM source_page c
+			LEFT JOIN LATERAL (
+				SELECT j.id, j.source_path, j.status, j.next_attempt_at
+				FROM metadata_image_cache_jobs j
+				WHERE j.target_type = c.target_type
+				  AND j.target_content_id = c.target_content_id COLLATE "default"
+				  AND j.image_type = c.image_type
+				  AND j.target_language = c.target_language
+				LIMIT 1
+			) j ON true
+		)
+		SELECT image_type, target_type, target_content_id, target_language, series_id, source_path,
+		       content_type, season_number, episode_number,
+		       COALESCE(tmdb_id, ''), COALESCE(tvdb_id, ''), COALESCE(imdb_id, ''),
+		       cursor_key, cursor_subkey, cursor_number, eligible
+		FROM scanned
+		ORDER BY cursor_number, cursor_key, cursor_subkey
+	`, sourceQuery), "@nonProviderSchemes", nonProviderImageSchemesSQL)
+	return query, args
+}
+
+func imageCacheDiscoverySourceQuery(cursor imageCacheDiscoveryCursor, limit int) (string, []any) {
+	providerFilter := func(column string) string {
+		return column + ` LIKE '%://%' AND lower(` + column + `) NOT LIKE ALL (@nonProviderSchemes)`
+	}
+	uncachedFilter := func(column string) string {
+		return `(` + column + ` LIKE '%://%' OR coalesce(` + column + `, '') = '')`
+	}
+	imageTypes := [...]string{ImageCacheImagePoster, ImageCacheImageBackdrop, ImageCacheImageLogo}
+	sourceColumns := [...]string{"poster_source_path", "backdrop_source_path", "logo_source_path"}
+	pathColumns := [...]string{imageCachePosterPathColumn, imageCacheBackdropPathColumn, imageCacheLogoPathColumn}
+	textArgs := []any{limit, cursor.Key}
+	localizedArgs := []any{limit, cursor.Key, cursor.Subkey}
+
+	switch cursor.Surface {
+	case 0, 1, 2:
+		imageType := imageTypes[cursor.Surface]
+		sourceColumn := sourceColumns[cursor.Surface]
+		pathColumn := pathColumns[cursor.Surface]
+		return fmt.Sprintf(`
+			SELECT '%s'::text AS image_type, 'item'::text AS target_type,
+			       mi.content_id AS target_content_id, ''::text AS target_language,
+			       mi.content_id AS series_id, mi.%s AS source_path, mi.type AS content_type,
+			       NULL::integer AS season_number, NULL::integer AS episode_number,
+			       mi.tmdb_id, mi.tvdb_id, mi.imdb_id,
+			       mi.content_id AS cursor_key, ''::text AS cursor_subkey, 0::bigint AS cursor_number
+			FROM media_items mi
+			WHERE mi.content_id > $2
+			  AND %s
+			  AND %s
+			ORDER BY mi.content_id
+			LIMIT $1
+		`, imageType, sourceColumn, providerFilter("mi."+sourceColumn), uncachedFilter("mi."+pathColumn)), textArgs
+	case 3, 4, 5:
+		index := cursor.Surface - 3
+		imageType := imageTypes[index]
+		sourceColumn := sourceColumns[index]
+		pathColumn := pathColumns[index]
+		return fmt.Sprintf(`
+			SELECT '%s'::text AS image_type, 'item_localization'::text AS target_type,
+			       loc.content_id AS target_content_id, loc.language AS target_language,
+			       loc.content_id AS series_id, loc.%s AS source_path, mi.type AS content_type,
+			       NULL::integer AS season_number, NULL::integer AS episode_number,
+			       mi.tmdb_id, mi.tvdb_id, mi.imdb_id,
+			       loc.content_id AS cursor_key, loc.language AS cursor_subkey, 0::bigint AS cursor_number
+			FROM media_item_localizations loc
+			JOIN media_items mi ON mi.content_id = loc.content_id
+			WHERE (loc.content_id > $2 OR (loc.content_id = $2 AND loc.language > $3))
+			  AND %s
+			  AND %s
+			ORDER BY loc.content_id, loc.language
+			LIMIT $1
+		`, imageType, sourceColumn, providerFilter("loc."+sourceColumn), uncachedFilter("loc."+pathColumn)), localizedArgs
+	case 6:
+		return fmt.Sprintf(`
+			SELECT 'poster'::text AS image_type, 'season'::text AS target_type,
+			       s.content_id AS target_content_id, ''::text AS target_language,
+			       s.series_id, s.poster_source_path AS source_path, 'series'::text AS content_type,
+			       s.season_number, NULL::integer AS episode_number,
+			       mi.tmdb_id, mi.tvdb_id, mi.imdb_id,
+			       s.content_id AS cursor_key, ''::text AS cursor_subkey, 0::bigint AS cursor_number
+			FROM seasons s
+			JOIN media_items mi ON mi.content_id = s.series_id
+			WHERE s.content_id > $2
+			  AND %s
+			  AND %s
+			ORDER BY s.content_id
+			LIMIT $1
+		`, providerFilter("s.poster_source_path"), uncachedFilter("s.poster_path")), textArgs
+	case 7:
+		return fmt.Sprintf(`
+			SELECT 'poster'::text AS image_type, 'season_localization'::text AS target_type,
+			       s.content_id AS target_content_id, loc.language AS target_language,
+			       s.series_id, loc.poster_source_path AS source_path, 'series'::text AS content_type,
+			       s.season_number, NULL::integer AS episode_number,
+			       mi.tmdb_id, mi.tvdb_id, mi.imdb_id,
+			       loc.season_content_id AS cursor_key, loc.language AS cursor_subkey, 0::bigint AS cursor_number
+			FROM season_localizations loc
+			JOIN seasons s ON s.content_id = loc.season_content_id
+			JOIN media_items mi ON mi.content_id = s.series_id
+			WHERE (loc.season_content_id > $2 OR (loc.season_content_id = $2 AND loc.language > $3))
+			  AND %s
+			  AND %s
+			ORDER BY loc.season_content_id, loc.language
+			LIMIT $1
+		`, providerFilter("loc.poster_source_path"), uncachedFilter("loc.poster_path")), localizedArgs
+	case 8:
+		return fmt.Sprintf(`
+			SELECT 'still'::text AS image_type, 'episode'::text AS target_type,
+			       e.content_id AS target_content_id, ''::text AS target_language,
+			       e.series_id, e.still_source_path AS source_path, 'series'::text AS content_type,
+			       e.season_number, e.episode_number,
+			       mi.tmdb_id, mi.tvdb_id, mi.imdb_id,
+			       e.content_id AS cursor_key, ''::text AS cursor_subkey, 0::bigint AS cursor_number
+			FROM episodes e
+			JOIN media_items mi ON mi.content_id = e.series_id
+			WHERE e.content_id > $2
+			  AND %s
+			  AND %s
+			ORDER BY e.content_id
+			LIMIT $1
+		`, providerFilter("e.still_source_path"), uncachedFilter("e.still_path")), textArgs
+	case 9:
+		return fmt.Sprintf(`
+			SELECT 'profile'::text AS image_type, 'person'::text AS target_type,
+			       p.id::text AS target_content_id, ''::text AS target_language,
+			       ''::text AS series_id, p.photo_source_path AS source_path, 'people'::text AS content_type,
+			       NULL::integer AS season_number, NULL::integer AS episode_number,
+			       p.tmdb_id, p.tvdb_id, p.imdb_id,
+			       ''::text AS cursor_key, ''::text AS cursor_subkey, p.id::bigint AS cursor_number
+			FROM people p
+			WHERE p.id > $2
+			  AND %s
+			  AND %s
+			ORDER BY p.id
+			LIMIT $1
+		`, providerFilter("p.photo_source_path"), uncachedFilter("p.photo_path")), []any{limit, cursor.NumericKey}
+	default:
+		return `SELECT NULL WHERE false`, []any{limit}
+	}
 }
 
 // imageCacheLocalProviderID is the synthetic provider slug for local sidecar

--- a/internal/metadata/image_cache_job_repo.go
+++ b/internal/metadata/image_cache_job_repo.go
@@ -830,7 +830,11 @@ func (r *ImageCacheJobRepository) EnqueueExistingProviderArtwork(ctx context.Con
 			in.ProviderID = imageCacheProviderIDFromSource(in.SourcePath, fallbackProvider)
 			in.ProviderContentID = imageCacheProviderContentID(in.ProviderID, tmdbID, tvdbID, imdbID, firstNonEmpty(in.SeriesID, in.TargetContentID))
 			in.ContentType = imageCacheContentType(in.ContentType)
-			inputs = append(inputs, in)
+			normalized, ok := normalizeImageCacheJobInput(in)
+			if !ok {
+				continue
+			}
+			inputs = append(inputs, normalized)
 			page.Discovered++
 		}
 	}

--- a/internal/metadata/image_cache_job_repo_db_test.go
+++ b/internal/metadata/image_cache_job_repo_db_test.go
@@ -163,3 +163,15 @@ func TestImageCacheFailedJobReadmission(t *testing.T) {
 		}
 	})
 }
+
+func TestImageCacheDiscoveryQueriesExplain(t *testing.T) {
+	pool := imageCacheQueueTestPool(t)
+	ctx := context.Background()
+
+	for surface := 0; surface < imageCacheDiscoverySurfaceCount; surface++ {
+		query, args := imageCacheDiscoveryQuery(imageCacheDiscoveryCursor{Surface: surface}, 1000)
+		if _, err := pool.Exec(ctx, "EXPLAIN "+query, args...); err != nil {
+			t.Fatalf("EXPLAIN discovery surface %d: %v", surface, err)
+		}
+	}
+}

--- a/internal/metadata/image_cache_job_repo_test.go
+++ b/internal/metadata/image_cache_job_repo_test.go
@@ -96,6 +96,7 @@ func TestNormalizeImageCacheJobInputSkipsNonProviderArtwork(t *testing.T) {
 		"",
 		"tmdb/series/1396/poster/original.webp",
 		"s3://media/tmdb/series/1396/poster/original.webp",
+		"  s3://media/tmdb/series/1396/poster/original.webp  ",
 		"local://poster.jpg",
 		"generated://collections/1/poster.jpg",
 	} {

--- a/internal/metadata/image_cache_job_repo_test.go
+++ b/internal/metadata/image_cache_job_repo_test.go
@@ -136,6 +136,82 @@ func TestNormalizeImageCacheJobInputKeepsLanguageAndDefaultsAttribution(t *testi
 	}
 }
 
+func TestImageCacheDiscoverySurfacesUseBoundedNativeKeyPages(t *testing.T) {
+	providerColumns := [...]string{
+		"mi.poster_source_path",
+		"mi.backdrop_source_path",
+		"mi.logo_source_path",
+		"loc.poster_source_path",
+		"loc.backdrop_source_path",
+		"loc.logo_source_path",
+		"s.poster_source_path",
+		"loc.poster_source_path",
+		"e.still_source_path",
+		"p.photo_source_path",
+	}
+	uncachedColumns := [...]string{
+		"mi.poster_path",
+		"mi.backdrop_path",
+		"mi.logo_path",
+		"loc.poster_path",
+		"loc.backdrop_path",
+		"loc.logo_path",
+		"s.poster_path",
+		"loc.poster_path",
+		"e.still_path",
+		"p.photo_path",
+	}
+	for surface := 0; surface < imageCacheDiscoverySurfaceCount; surface++ {
+		cursor := imageCacheDiscoveryCursor{Surface: surface, Key: "content-10", Subkey: "fr", NumericKey: 10}
+		query, args := imageCacheDiscoveryQuery(cursor, 1000)
+		if !strings.Contains(query, "LIMIT $1") {
+			t.Fatalf("surface %d query is not page-bounded", surface)
+		}
+		if strings.Contains(strings.ToUpper(query), "UNION") {
+			t.Fatalf("surface %d query rebuilds a cross-surface union", surface)
+		}
+		if strings.Contains(query, "%!") || !strings.Contains(query, "LIKE '%://%'") {
+			t.Fatalf("surface %d query has a malformed provider-source predicate", surface)
+		}
+		providerPredicate := "AND " + providerColumns[surface] + " LIKE '%://%'"
+		if !strings.Contains(query, providerPredicate) {
+			t.Fatalf("surface %d query missing exact provider predicate %q:\n%s", surface, providerPredicate, query)
+		}
+		if strings.Contains(query, providerColumns[surface]+" "+providerColumns[surface]) {
+			t.Fatalf("surface %d query duplicates provider column %q:\n%s", surface, providerColumns[surface], query)
+		}
+		uncachedPredicate := "AND (" + uncachedColumns[surface] + " LIKE '%://%' OR coalesce(" + uncachedColumns[surface] + ", '') = '')"
+		if !strings.Contains(query, uncachedPredicate) {
+			t.Fatalf("surface %d query missing exact uncached-target predicate %q:\n%s", surface, uncachedPredicate, query)
+		}
+		if strings.Contains(query, "@nonProviderSchemes") || !strings.Contains(query, nonProviderImageSchemesSQL) {
+			t.Fatalf("surface %d query did not expand the non-provider scheme filter:\n%s", surface, query)
+		}
+		if !strings.Contains(query, "LEFT JOIN LATERAL") ||
+			!strings.Contains(query, "FROM metadata_image_cache_jobs j") ||
+			!strings.Contains(query, `j.target_content_id = c.target_content_id COLLATE "default"`) ||
+			!strings.Contains(query, "j.source_path IS DISTINCT FROM c.source_path") {
+			t.Fatalf("surface %d query is missing the indexed eligibility lookup:\n%s", surface, query)
+		}
+		wantArgs := 2
+		if (surface >= 3 && surface <= 5) || surface == 7 {
+			wantArgs = 3
+		}
+		if len(args) != wantArgs || args[0] != 1000 {
+			t.Fatalf("surface %d args = %#v, want page limit and native cursor", surface, args)
+		}
+	}
+
+	localizedQuery, localizedArgs := imageCacheDiscoveryQuery(imageCacheDiscoveryCursor{Surface: 3}, 1000)
+	if !strings.Contains(localizedQuery, "loc.language > $3") || len(localizedArgs) != 3 {
+		t.Fatalf("localized discovery does not use its composite primary key: args=%#v", localizedArgs)
+	}
+	personQuery, personArgs := imageCacheDiscoveryQuery(imageCacheDiscoveryCursor{Surface: 9, NumericKey: 41}, 1000)
+	if !strings.Contains(personQuery, "p.id > $2") || len(personArgs) != 2 || personArgs[1] != int64(41) {
+		t.Fatalf("person discovery does not preserve its numeric cursor: args=%#v", personArgs)
+	}
+}
+
 func TestImageCacheProviderIDFromSourceDoesNotUseURLSchemeAsProvider(t *testing.T) {
 	if got := imageCacheProviderIDFromSource("https://image.tmdb.org/t/p/original/a.jpg", "tmdb"); got != "tmdb" {
 		t.Fatalf("provider from HTTP source with fallback = %q, want tmdb", got)

--- a/internal/metadata/image_cache_processor.go
+++ b/internal/metadata/image_cache_processor.go
@@ -518,6 +518,8 @@ func (p *ImageCacheProcessor) runUntilIdle(ctx context.Context, workerID string,
 	}
 	var discoveryCursor imageCacheDiscoveryCursor
 	discoveredThisSweep := false
+	enqueuedThisSweep := false
+	confirmationSweep := false
 	for {
 		if err := ctx.Err(); err != nil {
 			return total, err
@@ -579,6 +581,7 @@ func (p *ImageCacheProcessor) runUntilIdle(ctx context.Context, workerID string,
 			total.EnqueuedExisting += page.Enqueued
 			reportImageCacheRunProgress(reportProgress, total)
 			if page.Enqueued > 0 {
+				enqueuedThisSweep = true
 				break
 			}
 			if !page.Complete {
@@ -587,11 +590,20 @@ func (p *ImageCacheProcessor) runUntilIdle(ctx context.Context, workerID string,
 			if !discoveredThisSweep {
 				return total, nil
 			}
+			if confirmationSweep && !enqueuedThisSweep {
+				// A second complete sweep reported candidates but could not enqueue
+				// any of them. Repeating the same non-actionable catalog state cannot
+				// make progress; a later explicit backfill starts fresh from durable
+				// queue and catalog state.
+				return total, nil
+			}
 			// Queue rows and cached paths now reflect the completed sweep. Resetting
 			// catches concurrent changes that sorted behind the cursor. A retry or
 			// process restart also starts here and safely reuses those durable rows.
 			discoveryCursor = imageCacheDiscoveryCursor{}
 			discoveredThisSweep = false
+			enqueuedThisSweep = false
+			confirmationSweep = true
 		}
 	}
 }

--- a/internal/metadata/image_cache_processor.go
+++ b/internal/metadata/image_cache_processor.go
@@ -57,8 +57,26 @@ type ImageCacheJobClaimer interface {
 	MarkFailed(ctx context.Context, id int64, attemptCount int, lockedBy string, errText string) error
 	RequeueClaimed(ctx context.Context, ids []int64, workerID string) error
 	CurrentTargetSourcePath(ctx context.Context, job *models.MetadataImageCacheJob) (string, error)
-	EnqueueExistingProviderArtwork(ctx context.Context, limit int) (int, error)
+	EnqueueExistingProviderArtwork(ctx context.Context, cursor imageCacheDiscoveryCursor, limit int) (imageCacheDiscoveryPage, error)
 	DeleteSucceededBefore(ctx context.Context, before time.Time, limit int) (int, error)
+}
+
+// imageCacheDiscoveryCursor is deliberately scoped to one explicit backfill
+// run. Queue rows and cached target paths are the durable resume markers; a
+// persisted catalog cursor would add state that can drift away from them.
+type imageCacheDiscoveryCursor struct {
+	Surface    int
+	Key        string
+	Subkey     string
+	NumericKey int64
+}
+
+type imageCacheDiscoveryPage struct {
+	Enqueued   int
+	Scanned    int
+	Discovered int
+	Next       imageCacheDiscoveryCursor
+	Complete   bool
 }
 
 type targetImageCacheJobStore interface {
@@ -498,6 +516,8 @@ func (p *ImageCacheProcessor) runUntilIdle(ctx context.Context, workerID string,
 	if limited {
 		deadline = time.Now().Add(maxRuntime)
 	}
+	var discoveryCursor imageCacheDiscoveryCursor
+	discoveredThisSweep := false
 	for {
 		if err := ctx.Err(); err != nil {
 			return total, err
@@ -536,14 +556,42 @@ func (p *ImageCacheProcessor) runUntilIdle(ctx context.Context, workerID string,
 		if !discover {
 			return total, nil
 		}
-		enqueued, err := p.jobs.EnqueueExistingProviderArtwork(ctx, imageCacheDiscoveryBatchSize)
-		if err != nil {
-			return total, err
-		}
-		total.EnqueuedExisting += enqueued
-		reportImageCacheRunProgress(reportProgress, total)
-		if enqueued == 0 {
-			return total, nil
+		// Keep walking source-keyed discovery pages until one queues work. When a
+		// sweep reaches the end after seeing candidates, wrap once and confirm
+		// that no work appeared behind the in-memory cursor during the sweep.
+		for {
+			if err := ctx.Err(); err != nil {
+				return total, err
+			}
+			if !p.enabled.Load() {
+				return total, ErrImageCachingDisabled
+			}
+			if limited && !time.Now().Before(deadline) {
+				total.RuntimeLimited = true
+				return total, nil
+			}
+			page, err := p.jobs.EnqueueExistingProviderArtwork(ctx, discoveryCursor, imageCacheDiscoveryBatchSize)
+			if err != nil {
+				return total, err
+			}
+			discoveryCursor = page.Next
+			discoveredThisSweep = discoveredThisSweep || page.Discovered > 0
+			total.EnqueuedExisting += page.Enqueued
+			reportImageCacheRunProgress(reportProgress, total)
+			if page.Enqueued > 0 {
+				break
+			}
+			if !page.Complete {
+				continue
+			}
+			if !discoveredThisSweep {
+				return total, nil
+			}
+			// Queue rows and cached paths now reflect the completed sweep. Resetting
+			// catches concurrent changes that sorted behind the cursor. A retry or
+			// process restart also starts here and safely reuses those durable rows.
+			discoveryCursor = imageCacheDiscoveryCursor{}
+			discoveredThisSweep = false
 		}
 	}
 }

--- a/internal/metadata/image_cache_processor_test.go
+++ b/internal/metadata/image_cache_processor_test.go
@@ -900,6 +900,33 @@ func TestImageCacheProcessorDiscoveryWrapsForConcurrentUpdates(t *testing.T) {
 	}
 }
 
+func TestImageCacheProcessorDiscoveryStopsAfterRepeatedNonEnqueueableCandidates(t *testing.T) {
+	unexpectedSweep := errors.New("unexpected third discovery sweep")
+	jobs := &loopingImageCacheJobs{
+		enqueuePages: []imageCacheDiscoveryPage{
+			{Scanned: 1, Discovered: 1, Next: imageCacheDiscoveryCursor{Surface: imageCacheDiscoverySurfaceCount}, Complete: true},
+			{Scanned: 1, Discovered: 1, Next: imageCacheDiscoveryCursor{Surface: imageCacheDiscoverySurfaceCount}, Complete: true},
+			{},
+		},
+		enqueueErrors:  []error{nil, nil, unexpectedSweep},
+		claimedResults: [][]*models.MetadataImageCacheJob{{}},
+	}
+	processor := NewImageCacheProcessor(jobs, &fakeImageCacher{}, &fakeImageResolver{}, nil, nil)
+
+	stats, err := processor.RunUntilIdle(context.Background(), "test-worker", 1000, 2, 0, nil)
+	if err != nil {
+		t.Fatalf("RunUntilIdle() error = %v", err)
+	}
+	if stats.EnqueuedExisting != 0 || jobs.enqueueCalls != 2 {
+		t.Fatalf("stats = %+v, discovery calls = %d; want no enqueues and one confirmation sweep", stats, jobs.enqueueCalls)
+	}
+	for call, cursor := range jobs.enqueueCursors {
+		if cursor != (imageCacheDiscoveryCursor{}) {
+			t.Fatalf("discovery call %d cursor = %+v, want reset cursor", call+1, cursor)
+		}
+	}
+}
+
 func TestImageCacheProcessorDiscoveryRetryStartsFromDurableState(t *testing.T) {
 	discoveryErr := errors.New("temporary discovery failure")
 	jobs := &loopingImageCacheJobs{

--- a/internal/metadata/image_cache_processor_test.go
+++ b/internal/metadata/image_cache_processor_test.go
@@ -85,8 +85,8 @@ func (f *fakeImageCacheJobs) CurrentTargetSourcePath(_ context.Context, job *mod
 	return job.SourcePath, nil
 }
 
-func (f *fakeImageCacheJobs) EnqueueExistingProviderArtwork(context.Context, int) (int, error) {
-	return 0, nil
+func (f *fakeImageCacheJobs) EnqueueExistingProviderArtwork(context.Context, imageCacheDiscoveryCursor, int) (imageCacheDiscoveryPage, error) {
+	return imageCacheDiscoveryPage{Complete: true}, nil
 }
 
 func (f *fakeImageCacheJobs) DeleteSucceededBefore(context.Context, time.Time, int) (int, error) {
@@ -95,10 +95,13 @@ func (f *fakeImageCacheJobs) DeleteSucceededBefore(context.Context, time.Time, i
 
 type loopingImageCacheJobs struct {
 	enqueueResults []int
+	enqueuePages   []imageCacheDiscoveryPage
+	enqueueErrors  []error
 	claimedResults [][]*models.MetadataImageCacheJob
 	succeededIDs   []int64
 	enqueueCalls   int
 	enqueueLimits  []int
+	enqueueCursors []imageCacheDiscoveryCursor
 	claimCalls     int
 	backlog        ImageCacheBacklog
 	backlogCalls   int
@@ -133,14 +136,29 @@ func (f *loopingImageCacheJobs) GetBacklog(context.Context) (ImageCacheBacklog, 
 	return f.backlog, nil
 }
 
-func (f *loopingImageCacheJobs) EnqueueExistingProviderArtwork(_ context.Context, limit int) (int, error) {
-	result := 0
-	if f.enqueueCalls < len(f.enqueueResults) {
-		result = f.enqueueResults[f.enqueueCalls]
+func (f *loopingImageCacheJobs) EnqueueExistingProviderArtwork(_ context.Context, cursor imageCacheDiscoveryCursor, limit int) (imageCacheDiscoveryPage, error) {
+	call := f.enqueueCalls
+	page := imageCacheDiscoveryPage{Next: cursor, Complete: true}
+	if call < len(f.enqueuePages) {
+		page = f.enqueuePages[call]
+	} else if call < len(f.enqueueResults) {
+		result := f.enqueueResults[call]
+		page = imageCacheDiscoveryPage{
+			Enqueued:   result,
+			Discovered: result,
+			Scanned:    result,
+			Next:       imageCacheDiscoveryCursor{Surface: cursor.Surface + 1},
+			Complete:   result == 0,
+		}
+	}
+	var err error
+	if call < len(f.enqueueErrors) {
+		err = f.enqueueErrors[call]
 	}
 	f.enqueueLimits = append(f.enqueueLimits, limit)
+	f.enqueueCursors = append(f.enqueueCursors, cursor)
 	f.enqueueCalls++
-	return result, nil
+	return page, err
 }
 
 func (f *loopingImageCacheJobs) ClaimDue(context.Context, string, int) ([]*models.MetadataImageCacheJob, error) {
@@ -731,10 +749,10 @@ func TestImageCacheProcessorRunUntilIdleDrainsNewWorkAddedDuringRun(t *testing.T
 		EpisodeNumber:     intPointer(2),
 	}
 	// Discovery now runs only when the queue drains, not on every batch: drain
-	// job1, find the queue empty and sweep (enqueues 1 more), drain job2, find
-	// the queue empty and sweep again (enqueues 0 -> idle).
+	// job1, find the queue empty and sweep (enqueues 1 more), drain job2, finish
+	// the sweep, then confirm from the beginning that the catalog is idle.
 	jobs := &loopingImageCacheJobs{
-		enqueueResults: []int{1, 0},
+		enqueueResults: []int{1, 0, 0},
 		backlog:        ImageCacheBacklog{Known: true, Queued: 2, Running: 1},
 		claimedResults: [][]*models.MetadataImageCacheJob{
 			{job1},
@@ -774,8 +792,8 @@ func TestImageCacheProcessorRunUntilIdleDrainsNewWorkAddedDuringRun(t *testing.T
 	if stats.EnqueuedExisting != 1 || stats.Claimed != 2 || stats.Succeeded != 2 {
 		t.Fatalf("stats = %+v, want enqueued=1 claimed=2 succeeded=2", stats)
 	}
-	if jobs.enqueueCalls != 2 || jobs.claimCalls != 4 {
-		t.Fatalf("calls enqueue=%d claim=%d, want enqueue=2 claim=4", jobs.enqueueCalls, jobs.claimCalls)
+	if jobs.enqueueCalls != 3 || jobs.claimCalls != 4 {
+		t.Fatalf("calls enqueue=%d claim=%d, want enqueue=3 claim=4", jobs.enqueueCalls, jobs.claimCalls)
 	}
 	for _, limit := range jobs.enqueueLimits {
 		if limit != imageCacheDiscoveryBatchSize {
@@ -818,6 +836,90 @@ func TestImageCacheProcessorManualBackfillAlwaysDiscovers(t *testing.T) {
 	}
 	if jobs.enqueueCalls != 2 {
 		t.Fatalf("discovery calls = %d, want one for each explicit backfill", jobs.enqueueCalls)
+	}
+	for call, cursor := range jobs.enqueueCursors {
+		if cursor != (imageCacheDiscoveryCursor{}) {
+			t.Fatalf("discovery call %d cursor = %+v, want reset cursor", call+1, cursor)
+		}
+	}
+}
+
+func TestImageCacheProcessorDiscoveryWrapsForConcurrentUpdates(t *testing.T) {
+	job := &models.MetadataImageCacheJob{
+		ID:                42,
+		TargetType:        ImageCacheTargetEpisode,
+		TargetContentID:   "episode-tvdb-1-1-2",
+		SourcePath:        "tvdb://banners/episode-2.jpg",
+		ProviderID:        "tvdb",
+		ProviderContentID: "1",
+		ContentType:       "series",
+		ImageType:         ImageCacheImageStill,
+	}
+	jobs := &loopingImageCacheJobs{
+		enqueuePages: []imageCacheDiscoveryPage{
+			// A candidate races with enqueue while the first sweep is in progress.
+			{Scanned: 1000, Discovered: 1, Next: imageCacheDiscoveryCursor{Surface: 8, Key: "episode-z"}},
+			{Next: imageCacheDiscoveryCursor{Surface: imageCacheDiscoverySurfaceCount}, Complete: true},
+			// The wrap sees the concurrent update behind the old cursor.
+			{Enqueued: 1, Scanned: 1, Discovered: 1, Next: imageCacheDiscoveryCursor{Surface: 1}},
+			{Next: imageCacheDiscoveryCursor{Surface: imageCacheDiscoverySurfaceCount}, Complete: true},
+			// A second wrap confirms there are no more candidates.
+			{Next: imageCacheDiscoveryCursor{Surface: imageCacheDiscoverySurfaceCount}, Complete: true},
+		},
+		claimedResults: [][]*models.MetadataImageCacheJob{{}, {job}, {}},
+	}
+	processor := NewImageCacheProcessor(
+		jobs,
+		&fakeImageCacher{result: &CacheImageResult{BasePath: "tvdb/series/1/seasons/1/episodes/2/still", Ext: ".webp"}},
+		&fakeImageResolver{url: "https://artworks.thetvdb.com/episode-2.jpg"},
+		nil,
+		&fakeEpisodeStillUpdater{updated: true},
+	)
+
+	stats, err := processor.RunUntilIdle(context.Background(), "test-worker", 1000, 2, 0, nil)
+	if err != nil {
+		t.Fatalf("RunUntilIdle() error = %v", err)
+	}
+	if stats.EnqueuedExisting != 1 || stats.Succeeded != 1 {
+		t.Fatalf("stats = %+v, want one wrapped discovery processed", stats)
+	}
+	wantCursors := []imageCacheDiscoveryCursor{
+		{},
+		{Surface: 8, Key: "episode-z"},
+		{},
+		{Surface: 1},
+		{},
+	}
+	if len(jobs.enqueueCursors) != len(wantCursors) {
+		t.Fatalf("discovery cursors = %+v, want %+v", jobs.enqueueCursors, wantCursors)
+	}
+	for i := range wantCursors {
+		if jobs.enqueueCursors[i] != wantCursors[i] {
+			t.Fatalf("discovery cursor %d = %+v, want %+v", i+1, jobs.enqueueCursors[i], wantCursors[i])
+		}
+	}
+}
+
+func TestImageCacheProcessorDiscoveryRetryStartsFromDurableState(t *testing.T) {
+	discoveryErr := errors.New("temporary discovery failure")
+	jobs := &loopingImageCacheJobs{
+		enqueuePages:  []imageCacheDiscoveryPage{{}, {Complete: true}},
+		enqueueErrors: []error{discoveryErr, nil},
+		claimedResults: [][]*models.MetadataImageCacheJob{
+			{},
+			{},
+		},
+	}
+	processor := NewImageCacheProcessor(jobs, &fakeImageCacher{}, &fakeImageResolver{}, nil, nil)
+
+	if _, err := processor.RunUntilIdle(context.Background(), "test-worker", 1000, 2, 0, nil); !errors.Is(err, discoveryErr) {
+		t.Fatalf("first RunUntilIdle() error = %v, want %v", err, discoveryErr)
+	}
+	if _, err := processor.RunUntilIdle(context.Background(), "test-worker", 1000, 2, 0, nil); err != nil {
+		t.Fatalf("retry RunUntilIdle() error = %v", err)
+	}
+	if len(jobs.enqueueCursors) != 2 || jobs.enqueueCursors[0] != (imageCacheDiscoveryCursor{}) || jobs.enqueueCursors[1] != (imageCacheDiscoveryCursor{}) {
+		t.Fatalf("retry cursors = %+v, want both runs to resume from durable queue/catalog state", jobs.enqueueCursors)
 	}
 }
 


### PR DESCRIPTION
## Problem

Related issue: N/A — narrow performance fix

The manual artwork backfill asks for 1,000 rows at a time, but the old query was not bounded where the work happened. Every page rebuilt a ten-way union across items, localizations, seasons, episodes, and people, joined the full result to the cache-job table, sorted it, and only then applied the limit.

On a production-sized library, one page took 2.316 seconds, hit 155,878 shared buffers, read another 18,537, and considered roughly 540,000 candidates. At the current page size, that put the SQL-only lower bound for a full sweep at about 20 minutes 50 seconds before any image download or cache write.

There was no completed production backfill in task history, so that 20:50 figure is a projection from the measured page cost, not an observed end-to-end duration.

## Approach

Discovery now walks one artwork surface at a time and pages on that table's native key. Each statement reads at most 1,000 source rows before checking the matching cache-job row, so PostgreSQL no longer rebuilds and sorts the whole catalog for every page. The episode lookup applies the required collation at the job-key boundary, which keeps the indexed lookup available without changing stored data.

The cursor lives only for the current explicit backfill. Cache-job rows and cached target paths remain the durable state: a restart begins at the first surface and skips work already represented there. Discovery does not advance its cursor after an enqueue error, and a completed sweep that found candidates wraps once to catch concurrent changes that landed behind the cursor.

This does not add a cursor table, migration, API change, or scheduled catalog sweep.

## Validation

The complete statements produced by `imageCacheDiscoveryQuery` for all ten surfaces were run against production PostgreSQL with `EXPLAIN (ANALYZE, BUFFERS, SETTINGS)` inside a read-only transaction. All ten parsed, planned, and completed; the [production SQL gate](https://github.com/blurbery/silo-server/pull/40#issuecomment-5384833322) records the command shape and per-surface timings.

The slowest non-empty new page was the episode surface at 129.597 ms, compared with 2.316 seconds for the old all-surface page. Other non-empty first pages measured 52.884 ms for item posters, 19.379 ms for backdrops, 20.605 ms for logos, 23.322 ms for seasons, and 15.893 ms for people. Empty localization pages completed in 0.060–0.112 ms.

- `git diff --check` — passed
- `make verify-local-paths` — passed
- [Full CI on the current PR head](https://github.com/Silo-Server/silo-server/actions/runs/32628262249) — Go, Web, and docs hygiene passed
- Production deployment — the native-key paging and generated-query implementation is running as `build-78`; the container is healthy with zero restarts. The no-progress termination guard was added during upstream review and has not been deployed.

The PostgreSQL-backed query test uses `SILO_TEST_DATABASE_URL` and skips when CI has no database. The string-level test therefore also checks every generated statement for the exact provider predicate, uncached-target predicate, expanded scheme filter, indexed eligibility lookup, and argument count.

## Risks

No schema, API, or user-interface behavior changes. A restarted manual backfill rescans source keys from the beginning instead of resuming from a stored cursor, but existing queue rows and cached paths prevent completed work from being downloaded again. Each surface may need one empty boundary page when its row count is an exact multiple of the page size. If two complete sweeps report candidates without enqueuing any work, the run stops; a later explicit backfill starts again from durable state.

## AI Disclosure

- Tool(s): OpenAI Codex
- Model(s): GPT-5
- Involvement: AI-assisted
- Adversarial review: The first complete-diff review found that the provider helper and SQL template duplicated the source column, producing invalid generated SQL despite green string tests. That was corrected and all ten exact generated statements were run through production PostgreSQL. Upstream review then found that raw eligible rows rejected by normalization could keep the wraparound loop alive without creating jobs. Discovery now counts only normalized inputs and stops after one no-progress confirmation sweep; focused tests cover both cases. No material finding remains in the final diff.

## Checklist

- [x] I read and can explain the complete diff.
- [x] This pull request addresses one concern.
