### PR TITLE
fix(requests): encode empty request lists as [] instead of null

### DIFF
--- a/internal/api/handlers/requests.go
+++ b/internal/api/handlers/requests.go
@@ -263,7 +263,7 @@ func (h *RequestsHandler) HandleListMine(w http.ResponseWriter, r *http.Request)
 	}
 	writeJSON(w, http.StatusOK, struct {
 		Requests []*mediarequests.Request `json:"requests"`
-	}{Requests: requests})
+	}{Requests: nonNilRequests(requests)})
 }
 
 func (h *RequestsHandler) HandleGet(w http.ResponseWriter, r *http.Request) {
@@ -291,7 +291,7 @@ func (h *RequestsHandler) HandleAdminList(w http.ResponseWriter, r *http.Request
 	}
 	writeJSON(w, http.StatusOK, struct {
 		Requests []*mediarequests.Request `json:"requests"`
-	}{Requests: requests})
+	}{Requests: nonNilRequests(requests)})
 }
 
 func (h *RequestsHandler) HandleApprove(w http.ResponseWriter, r *http.Request) {
@@ -627,6 +627,16 @@ func toIntegrationResponses(integrations []mediarequests.Integration) []requestI
 		out = append(out, requestIntegrationResponseFrom(integration))
 	}
 	return out
+}
+
+// nonNilRequests keeps an empty request list encoding as [] rather than null.
+// The store returns a nil slice when no rows match, and clients decoding
+// `requests` as an array fail on null instead of rendering an empty state.
+func nonNilRequests(requests []*mediarequests.Request) []*mediarequests.Request {
+	if requests == nil {
+		return []*mediarequests.Request{}
+	}
+	return requests
 }
 
 func writeRequestServiceError(w http.ResponseWriter, err error) {

--- a/internal/api/handlers/requests_test.go
+++ b/internal/api/handlers/requests_test.go
@@ -20,6 +20,8 @@ type fakeRequestService struct {
 	listNetworksFn func() ([]mediarequests.DiscoverBrandCard, error)
 	listGenresFn   func() ([]mediarequests.DiscoverBrandCard, error)
 	browseFn       func(kind, slug string, mediaType mediarequests.MediaType, sort string, page int) (*mediarequests.DiscoverBrowseResponse, error)
+	listMineFn     func() ([]*mediarequests.Request, error)
+	listAdminFn    func() ([]*mediarequests.Request, error)
 }
 
 func (f *fakeRequestService) ListStudios(context.Context, mediarequests.Viewer) ([]mediarequests.DiscoverBrandCard, error) {
@@ -76,10 +78,16 @@ func (f *fakeRequestService) CreateRequest(context.Context, mediarequests.Viewer
 }
 
 func (f *fakeRequestService) ListMine(context.Context, mediarequests.Viewer, mediarequests.ListFilter) ([]*mediarequests.Request, error) {
+	if f.listMineFn != nil {
+		return f.listMineFn()
+	}
 	return nil, nil
 }
 
 func (f *fakeRequestService) ListAdmin(context.Context, mediarequests.Viewer, mediarequests.ListFilter) ([]*mediarequests.Request, error) {
+	if f.listAdminFn != nil {
+		return f.listAdminFn()
+	}
 	return nil, nil
 }
 
@@ -148,6 +156,17 @@ func authedRequest(method, target string) *http.Request {
 	ctx := apimw.SetClaims(req.Context(), &auth.Claims{
 		UserID:    1,
 		Role:      "user",
+		TokenType: auth.TokenTypeAccess,
+	})
+	ctx = apimw.SetProfileID(ctx, "profile-1")
+	return req.WithContext(ctx)
+}
+
+func adminRequest(method, target string) *http.Request {
+	req := httptest.NewRequest(method, target, nil)
+	ctx := apimw.SetClaims(req.Context(), &auth.Claims{
+		UserID:    1,
+		Role:      "admin",
 		TokenType: auth.TokenTypeAccess,
 	})
 	ctx = apimw.SetProfileID(ctx, "profile-1")
@@ -245,5 +264,66 @@ func TestHandleBrowseGenreRequiresMediaType(t *testing.T) {
 
 	if rec.Code != http.StatusBadRequest {
 		t.Fatalf("status = %d, want 400; body=%s", rec.Code, rec.Body.String())
+	}
+}
+
+// The store returns a nil slice when a user has no requests, which encodes as
+// `{"requests":null}`. Clients that decode `requests` as an array fail on null,
+// so both list endpoints must emit an empty array instead. These assert on the
+// raw body: null and [] both decode into a zero-length slice, so a len() check
+// would pass either way and pin nothing.
+func TestHandleListMineEncodesEmptyRequestsAsArray(t *testing.T) {
+	h := NewRequestsHandler(&fakeRequestService{
+		listMineFn: func() ([]*mediarequests.Request, error) { return nil, nil },
+	})
+
+	rec := httptest.NewRecorder()
+	h.HandleListMine(rec, authedRequest("GET", "/api/v1/requests/mine?limit=200&offset=0"))
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200", rec.Code)
+	}
+	if got := strings.TrimSpace(rec.Body.String()); got != `{"requests":[]}` {
+		t.Errorf("body = %s, want {\"requests\":[]}", got)
+	}
+}
+
+func TestHandleAdminListEncodesEmptyRequestsAsArray(t *testing.T) {
+	h := NewRequestsHandler(&fakeRequestService{
+		listAdminFn: func() ([]*mediarequests.Request, error) { return nil, nil },
+	})
+
+	rec := httptest.NewRecorder()
+	h.HandleAdminList(rec, adminRequest("GET", "/api/v1/requests"))
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200", rec.Code)
+	}
+	if got := strings.TrimSpace(rec.Body.String()); got != `{"requests":[]}` {
+		t.Errorf("body = %s, want {\"requests\":[]}", got)
+	}
+}
+
+func TestHandleListMinePreservesPopulatedRequests(t *testing.T) {
+	h := NewRequestsHandler(&fakeRequestService{
+		listMineFn: func() ([]*mediarequests.Request, error) {
+			return []*mediarequests.Request{{ID: "req-1"}}, nil
+		},
+	})
+
+	rec := httptest.NewRecorder()
+	h.HandleListMine(rec, authedRequest("GET", "/api/v1/requests/mine"))
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200", rec.Code)
+	}
+	var body struct {
+		Requests []*mediarequests.Request `json:"requests"`
+	}
+	if err := json.NewDecoder(rec.Body).Decode(&body); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if len(body.Requests) != 1 || body.Requests[0].ID != "req-1" {
+		t.Errorf("requests = %+v", body.Requests)
 	}
 }


### PR DESCRIPTION
Fixes #577.

## What happened

`Repository.listRequests` declares `var out []*Request` and appends per row, so it returns a nil slice when no rows match (`internal/requests/repository.go:440`). Both list handlers passed that slice straight into the response struct, and `encoding/json` encodes a nil slice as `null`:

```json
{"requests":null}
```

Silo for iOS decodes `requests` as an array, so the whole Requests screen fails with "The server response was in an unexpected format" for any account with no requests. The web and Android clients only survive it through client-side defaults.

## The change

Adds `nonNilRequests` and wraps both response sites in it, following the existing `nonNilStrings` / `nonNilUnmatchedSamples` pattern used elsewhere in the codebase (`internal/jellycompat/mapping.go:962`, `internal/historyimport/repo.go:1262`).

`HandleAdminList` shares both the response shape and the nil source with `HandleListMine`, so it had the same defect on `GET /api/v1/requests`. It's fixed alongside — same one concern, and leaving it would have meant a second PR against the identical two lines.

No client changes: this only makes the server honor the contract the clients already assume.

## Tests

Three tests in `internal/api/handlers/requests_test.go`, using the existing `fakeRequestService` (extended with `listMineFn` / `listAdminFn` hooks matching its existing `*Fn` pattern):

- `TestHandleListMineEncodesEmptyRequestsAsArray`
- `TestHandleAdminListEncodesEmptyRequestsAsArray`
- `TestHandleListMinePreservesPopulatedRequests` — guards the non-empty path

The two empty-list tests assert on the **raw response body**, not a decoded slice. `null` and `[]` both decode into a zero-length `[]*Request`, so a `len(...) == 0` check would pass against the buggy code and pin nothing.

Verified they fail before the fix and pass after. Before:

```
--- FAIL: TestHandleListMineEncodesEmptyRequestsAsArray
    requests_test.go:287: body = {"requests":null}, want {"requests":[]}
--- FAIL: TestHandleAdminListEncodesEmptyRequestsAsArray
    requests_test.go:303: body = {"requests":null}, want {"requests":[]}
```

These need no database, so they run in CI rather than skipping.

## Gate

Run against PostgreSQL 18 + Redis from `docker-compose.yml`, Go 1.26.4:

- `go build ./...` — clean
- `gofmt -l .` — no output
- `go vet ./internal/api/handlers/` — clean
- `golangci-lint run --new-from-merge-base="origin/main" ./...` — `0 issues.`
- `make test-go` — `internal/api/handlers` passes
- `cd web && pnpm run lint` — 0 errors (no web files touched)

`make test-go` does report failures in `internal/jellycompat`, `internal/playback`, and `internal/transcodenode`. I checked these against a clean `main` worktree at 91c3d7bd with no changes applied and they fail identically there, so they are pre-existing on this host and unrelated to this change:

| Package | clean `main` | this branch |
|---|---|---|
| `internal/jellycompat` | FAIL (2) | FAIL (2) |
| `internal/playback` | FAIL (4) | FAIL (4) |
| `internal/transcodenode` | FAIL (1) | FAIL (1) |
| `internal/api/handlers` | ok | ok |

They look host-specific rather than broken on main — the `playback` set is `gpudetect` expecting NVENC on an Apple Silicon machine with no NVIDIA GPU, and the `transcodenode` one is a download-prepare timing assertion. Happy to open a separate issue if they aren't already known.

## Note

Written with AI assistance (Claude), per CONTRIBUTING. I've read the change, run the gate above, and can explain the reasoning and alternatives.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Request list endpoints now return an empty array when no requests are available, instead of `null`.
  * Existing request data continues to be returned unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->