### PR TITLE
perf(web): split and precompress bootstrap assets

### DIFF
--- a/internal/server/frontend.go
+++ b/internal/server/frontend.go
@@ -5,7 +5,10 @@ import (
 	"crypto/sha256"
 	"encoding/hex"
 	"io/fs"
+	"mime"
 	"net/http"
+	pathpkg "path"
+	"strconv"
 	"strings"
 	"sync"
 	"sync/atomic"
@@ -113,6 +116,13 @@ type renderedShell struct {
 func (h *frontendHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	w.Header().Set("X-Content-Type-Options", "nosniff")
 	path := r.URL.Path
+	if strings.HasPrefix(path, "/assets/") && isPrecompressedAssetPath(path) {
+		// Sidecars are implementation details selected through content
+		// negotiation. Serving them directly exposes the compressed bytes without
+		// Content-Encoding and creates a second public URL for the same asset.
+		http.NotFound(w, r)
+		return
+	}
 
 	// Dynamic branding endpoints must be handled before the static file
 	// server, which would otherwise serve the bundled defaults shadowing
@@ -139,6 +149,10 @@ func (h *frontendHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 				// immutable: a new build produces new URLs, which is what
 				// lets browsers cache them for a year yet pick up deploys.
 				w.Header().Set("Cache-Control", "public, max-age=31536000, immutable")
+				w.Header().Set("Vary", "Accept-Encoding")
+				if r.Header.Get("Range") == "" && h.servePrecompressedAsset(w, r, path) {
+					return
+				}
 			} else {
 				// Every other bundled file (service worker, icons, vendor
 				// bundles) keeps its URL across builds, so it must be
@@ -183,6 +197,129 @@ func (h *frontendHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	w.Header().Set("ETag", shell.etag)
 	w.Header().Set("Cache-Control", "no-cache")
 	http.ServeContent(w, r, "index.html", time.Time{}, bytes.NewReader(shell.body))
+}
+
+func isPrecompressedAssetPath(path string) bool {
+	return strings.HasSuffix(path, ".js.br") ||
+		strings.HasSuffix(path, ".js.gz") ||
+		strings.HasSuffix(path, ".css.br") ||
+		strings.HasSuffix(path, ".css.gz")
+}
+
+func (h *frontendHandler) servePrecompressedAsset(
+	w http.ResponseWriter,
+	r *http.Request,
+	assetPath string,
+) bool {
+	if r.Method != http.MethodGet && r.Method != http.MethodHead {
+		return false
+	}
+
+	acceptEncoding := strings.Join(r.Header.Values("Accept-Encoding"), ",")
+	for _, encoding := range precompressedEncodingPreferences(acceptEncoding) {
+		suffix := "." + encoding
+		if encoding == "gzip" {
+			suffix = ".gz"
+		}
+		sidecarPath := assetPath + suffix
+		f, err := WebDistFS.Open(strings.TrimPrefix(sidecarPath, "/"))
+		if err != nil {
+			continue
+		}
+		info, statErr := f.Stat()
+		_ = f.Close()
+		if statErr != nil || info.IsDir() {
+			continue
+		}
+
+		if contentType := mime.TypeByExtension(pathpkg.Ext(assetPath)); contentType != "" {
+			w.Header().Set("Content-Type", contentType)
+		}
+		w.Header().Set("Content-Encoding", encoding)
+
+		encodedRequest := r.Clone(r.Context())
+		encodedURL := *r.URL
+		encodedURL.Path = sidecarPath
+		encodedRequest.URL = &encodedURL
+		h.fileServer.ServeHTTP(w, encodedRequest)
+		return true
+	}
+	return false
+}
+
+func precompressedEncodingPreferences(header string) []string {
+	qualities := make(map[string]float64)
+	wildcardQuality := -1.0
+
+	for value := range strings.SplitSeq(header, ",") {
+		parts := strings.Split(value, ";")
+		coding := strings.ToLower(strings.TrimSpace(parts[0]))
+		if coding == "" {
+			continue
+		}
+
+		quality := 1.0
+		valid := true
+		for _, parameter := range parts[1:] {
+			key, rawValue, found := strings.Cut(strings.TrimSpace(parameter), "=")
+			if !strings.EqualFold(strings.TrimSpace(key), "q") {
+				continue
+			}
+			if !found {
+				valid = false
+				break
+			}
+			parsed, err := strconv.ParseFloat(strings.TrimSpace(rawValue), 64)
+			if err != nil || parsed < 0 || parsed > 1 {
+				valid = false
+				break
+			}
+			quality = parsed
+		}
+		if !valid {
+			continue
+		}
+
+		if coding == "*" {
+			wildcardQuality = quality
+			continue
+		}
+		qualities[coding] = quality
+	}
+
+	qualityFor := func(coding string) float64 {
+		if quality, ok := qualities[coding]; ok {
+			return quality
+		}
+		if wildcardQuality >= 0 {
+			return wildcardQuality
+		}
+		return 0
+	}
+
+	brotliQuality := qualityFor("br")
+	gzipQuality := qualityFor("gzip")
+	if brotliQuality <= 0 && gzipQuality <= 0 {
+		return nil
+	}
+
+	encodings := make([]string, 0, 2)
+	if brotliQuality >= gzipQuality {
+		if brotliQuality > 0 {
+			encodings = append(encodings, "br")
+		}
+		if gzipQuality > 0 {
+			encodings = append(encodings, "gzip")
+		}
+		return encodings
+	}
+	if gzipQuality > 0 {
+		encodings = append(encodings, "gzip")
+	}
+	if brotliQuality > 0 {
+		encodings = append(encodings, "br")
+	}
+	return encodings
 }
 
 // brandedShell returns the branding-rendered index.html and its ETag, reusing

--- a/internal/server/frontend.go
+++ b/internal/server/frontend.go
@@ -241,6 +241,7 @@ func (h *frontendHandler) servePrecompressedAsset(
 			w.Header().Set("Content-Type", contentType)
 		}
 		w.Header().Set("Content-Encoding", encoding)
+		w.Header().Set("Content-Length", strconv.FormatInt(info.Size(), 10))
 
 		encodedRequest := r.Clone(r.Context())
 		encodedURL := *r.URL

--- a/internal/server/frontend.go
+++ b/internal/server/frontend.go
@@ -206,6 +206,11 @@ func isPrecompressedAssetPath(path string) bool {
 		strings.HasSuffix(path, ".css.gz")
 }
 
+const (
+	brotliContentEncoding = "br"
+	gzipContentEncoding   = "gzip"
+)
+
 func (h *frontendHandler) servePrecompressedAsset(
 	w http.ResponseWriter,
 	r *http.Request,
@@ -218,7 +223,7 @@ func (h *frontendHandler) servePrecompressedAsset(
 	acceptEncoding := strings.Join(r.Header.Values("Accept-Encoding"), ",")
 	for _, encoding := range precompressedEncodingPreferences(acceptEncoding) {
 		suffix := "." + encoding
-		if encoding == "gzip" {
+		if encoding == gzipContentEncoding {
 			suffix = ".gz"
 		}
 		sidecarPath := assetPath + suffix
@@ -297,8 +302,8 @@ func precompressedEncodingPreferences(header string) []string {
 		return 0
 	}
 
-	brotliQuality := qualityFor("br")
-	gzipQuality := qualityFor("gzip")
+	brotliQuality := qualityFor(brotliContentEncoding)
+	gzipQuality := qualityFor(gzipContentEncoding)
 	if brotliQuality <= 0 && gzipQuality <= 0 {
 		return nil
 	}
@@ -306,18 +311,18 @@ func precompressedEncodingPreferences(header string) []string {
 	encodings := make([]string, 0, 2)
 	if brotliQuality >= gzipQuality {
 		if brotliQuality > 0 {
-			encodings = append(encodings, "br")
+			encodings = append(encodings, brotliContentEncoding)
 		}
 		if gzipQuality > 0 {
-			encodings = append(encodings, "gzip")
+			encodings = append(encodings, gzipContentEncoding)
 		}
 		return encodings
 	}
 	if gzipQuality > 0 {
-		encodings = append(encodings, "gzip")
+		encodings = append(encodings, gzipContentEncoding)
 	}
 	if brotliQuality > 0 {
-		encodings = append(encodings, "br")
+		encodings = append(encodings, brotliContentEncoding)
 	}
 	return encodings
 }

--- a/internal/server/frontend.go
+++ b/internal/server/frontend.go
@@ -150,7 +150,7 @@ func (h *frontendHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 				// lets browsers cache them for a year yet pick up deploys.
 				w.Header().Set("Cache-Control", "public, max-age=31536000, immutable")
 				w.Header().Set("Vary", "Accept-Encoding")
-				if r.Header.Get("Range") == "" && h.servePrecompressedAsset(w, r, path) {
+				if h.servePrecompressedAsset(w, r, path) {
 					return
 				}
 			} else {
@@ -221,39 +221,51 @@ func (h *frontendHandler) servePrecompressedAsset(
 	}
 
 	acceptEncoding := strings.Join(r.Header.Values("Accept-Encoding"), ",")
-	for _, encoding := range precompressedEncodingPreferences(acceptEncoding) {
-		suffix := "." + encoding
-		if encoding == gzipContentEncoding {
-			suffix = ".gz"
-		}
-		sidecarPath := assetPath + suffix
-		f, err := WebDistFS.Open(strings.TrimPrefix(sidecarPath, "/"))
-		if err != nil {
-			continue
-		}
-		info, statErr := f.Stat()
-		_ = f.Close()
-		if statErr != nil || info.IsDir() {
-			continue
-		}
+	encodings, identityAcceptable := precompressedEncodingPreferences(acceptEncoding)
+	useIdentityRange := r.Method == http.MethodGet && r.Header.Get("Range") != "" && identityAcceptable
+	if !useIdentityRange {
+		for _, encoding := range encodings {
+			suffix := "." + encoding
+			if encoding == gzipContentEncoding {
+				suffix = ".gz"
+			}
+			sidecarPath := assetPath + suffix
+			f, err := WebDistFS.Open(strings.TrimPrefix(sidecarPath, "/"))
+			if err != nil {
+				continue
+			}
+			info, statErr := f.Stat()
+			_ = f.Close()
+			if statErr != nil || info.IsDir() {
+				continue
+			}
 
-		if contentType := mime.TypeByExtension(pathpkg.Ext(assetPath)); contentType != "" {
-			w.Header().Set("Content-Type", contentType)
-		}
-		w.Header().Set("Content-Encoding", encoding)
-		w.Header().Set("Content-Length", strconv.FormatInt(info.Size(), 10))
+			if contentType := mime.TypeByExtension(pathpkg.Ext(assetPath)); contentType != "" {
+				w.Header().Set("Content-Type", contentType)
+			}
+			w.Header().Set("Content-Encoding", encoding)
+			w.Header().Set("Content-Length", strconv.FormatInt(info.Size(), 10))
 
-		encodedRequest := r.Clone(r.Context())
-		encodedURL := *r.URL
-		encodedURL.Path = sidecarPath
-		encodedRequest.URL = &encodedURL
-		h.fileServer.ServeHTTP(w, encodedRequest)
+			encodedRequest := r.Clone(r.Context())
+			encodedURL := *r.URL
+			encodedURL.Path = sidecarPath
+			encodedRequest.URL = &encodedURL
+			if encodedRequest.Header.Get("Range") != "" {
+				// Range is ignored on HEAD and when GET cannot use identity.
+				encodedRequest.Header.Del("Range")
+			}
+			h.fileServer.ServeHTTP(w, encodedRequest)
+			return true
+		}
+	}
+	if !identityAcceptable {
+		w.WriteHeader(http.StatusNotAcceptable)
 		return true
 	}
 	return false
 }
 
-func precompressedEncodingPreferences(header string) []string {
+func precompressedEncodingPreferences(header string) ([]string, bool) {
 	qualities := make(map[string]float64)
 	wildcardQuality := -1.0
 
@@ -305,8 +317,14 @@ func precompressedEncodingPreferences(header string) []string {
 
 	brotliQuality := qualityFor(brotliContentEncoding)
 	gzipQuality := qualityFor(gzipContentEncoding)
+	identityAcceptable := true
+	if identityQuality, ok := qualities["identity"]; ok {
+		identityAcceptable = identityQuality > 0
+	} else if wildcardQuality == 0 {
+		identityAcceptable = false
+	}
 	if brotliQuality <= 0 && gzipQuality <= 0 {
-		return nil
+		return nil, identityAcceptable
 	}
 
 	encodings := make([]string, 0, 2)
@@ -317,7 +335,7 @@ func precompressedEncodingPreferences(header string) []string {
 		if gzipQuality > 0 {
 			encodings = append(encodings, gzipContentEncoding)
 		}
-		return encodings
+		return encodings, identityAcceptable
 	}
 	if gzipQuality > 0 {
 		encodings = append(encodings, gzipContentEncoding)
@@ -325,7 +343,7 @@ func precompressedEncodingPreferences(header string) []string {
 	if brotliQuality > 0 {
 		encodings = append(encodings, brotliContentEncoding)
 	}
-	return encodings
+	return encodings, identityAcceptable
 }
 
 // brandedShell returns the branding-rendered index.html and its ETag, reusing

--- a/internal/server/frontend_test.go
+++ b/internal/server/frontend_test.go
@@ -108,12 +108,195 @@ func newFrontendTestHandler(t *testing.T) http.Handler {
 	t.Helper()
 	prev := WebDistFS
 	WebDistFS = fstest.MapFS{
-		"index.html":    &fstest.MapFile{Data: []byte("<!doctype html><div id=\"root\"></div>")},
-		"assets/app.js": &fstest.MapFile{Data: []byte("console.log(1)")},
-		"sw.js":         &fstest.MapFile{Data: []byte("self.addEventListener('fetch', () => {})")},
+		"index.html":       &fstest.MapFile{Data: []byte("<!doctype html><div id=\"root\"></div>")},
+		"assets/app.js":    &fstest.MapFile{Data: []byte("console.log(1)")},
+		"assets/app.js.br": &fstest.MapFile{Data: []byte("br-compressed")},
+		"assets/app.js.gz": &fstest.MapFile{Data: []byte("gzip-compressed")},
+		"assets/plain.js":  &fstest.MapFile{Data: []byte("plain")},
+		"sw.js":            &fstest.MapFile{Data: []byte("self.addEventListener('fetch', () => {})")},
 	}
 	t.Cleanup(func() { WebDistFS = prev })
 	return FrontendHandler()
+}
+
+func TestFrontendPrecompressedAssetNegotiation(t *testing.T) {
+	handler := newFrontendTestHandler(t)
+
+	tests := []struct {
+		name           string
+		acceptEncoding string
+		wantEncoding   string
+		wantBody       string
+	}{
+		{
+			name:           "brotli wins an equal preference",
+			acceptEncoding: "gzip, br",
+			wantEncoding:   "br",
+			wantBody:       "br-compressed",
+		},
+		{
+			name:           "higher gzip quality wins",
+			acceptEncoding: "br;q=0.4, gzip;q=0.8",
+			wantEncoding:   "gzip",
+			wantBody:       "gzip-compressed",
+		},
+		{
+			name:           "zero quality disables brotli",
+			acceptEncoding: "br;q=0, gzip",
+			wantEncoding:   "gzip",
+			wantBody:       "gzip-compressed",
+		},
+		{
+			name:           "wildcard applies only without an explicit value",
+			acceptEncoding: "*;q=0.7, gzip;q=0",
+			wantEncoding:   "br",
+			wantBody:       "br-compressed",
+		},
+		{
+			name:           "identity when every sidecar is disabled",
+			acceptEncoding: "br;q=0, gzip;q=0",
+			wantBody:       "console.log(1)",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			req := httptest.NewRequest(http.MethodGet, "/assets/app.js", nil)
+			req.Header.Set("Accept-Encoding", tt.acceptEncoding)
+			rec := httptest.NewRecorder()
+			handler.ServeHTTP(rec, req)
+
+			if rec.Code != http.StatusOK {
+				t.Fatalf("status = %d, want 200", rec.Code)
+			}
+			if got := rec.Header().Get("Content-Encoding"); got != tt.wantEncoding {
+				t.Fatalf("content-encoding = %q, want %q", got, tt.wantEncoding)
+			}
+			if got := rec.Body.String(); got != tt.wantBody {
+				t.Fatalf("body = %q, want %q", got, tt.wantBody)
+			}
+			if got := rec.Header().Get("Vary"); got != "Accept-Encoding" {
+				t.Fatalf("vary = %q, want Accept-Encoding", got)
+			}
+			if got := rec.Header().Get("Cache-Control"); got != "public, max-age=31536000, immutable" {
+				t.Fatalf("cache-control = %q", got)
+			}
+			if got := rec.Header().Get("Content-Type"); !strings.Contains(got, "javascript") {
+				t.Fatalf("content-type = %q, want JavaScript", got)
+			}
+		})
+	}
+}
+
+func TestFrontendPrecompressedAssetFallsBackWhenSidecarIsMissing(t *testing.T) {
+	handler := newFrontendTestHandler(t)
+	req := httptest.NewRequest(http.MethodGet, "/assets/plain.js", nil)
+	req.Header.Set("Accept-Encoding", "br, gzip")
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK || rec.Body.String() != "plain" {
+		t.Fatalf("response = %d %q, want 200 identity body", rec.Code, rec.Body.String())
+	}
+	if got := rec.Header().Get("Content-Encoding"); got != "" {
+		t.Fatalf("content-encoding = %q, want identity", got)
+	}
+	if got := rec.Header().Get("Vary"); got != "Accept-Encoding" {
+		t.Fatalf("vary = %q, want Accept-Encoding", got)
+	}
+}
+
+func TestFrontendPrecompressedAssetTriesNextAcceptableEncoding(t *testing.T) {
+	prev := WebDistFS
+	WebDistFS = fstest.MapFS{
+		"index.html":       &fstest.MapFile{Data: []byte("<!doctype html>")},
+		"assets/app.js":    &fstest.MapFile{Data: []byte("console.log(1)")},
+		"assets/app.js.gz": &fstest.MapFile{Data: []byte("gzip-compressed")},
+	}
+	t.Cleanup(func() { WebDistFS = prev })
+
+	req := httptest.NewRequest(http.MethodGet, "/assets/app.js", nil)
+	req.Header.Set("Accept-Encoding", "br, gzip;q=0.5")
+	rec := httptest.NewRecorder()
+	FrontendHandler().ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK || rec.Body.String() != "gzip-compressed" {
+		t.Fatalf("response = %d %q, want 200 gzip body", rec.Code, rec.Body.String())
+	}
+	if got := rec.Header().Get("Content-Encoding"); got != "gzip" {
+		t.Fatalf("content-encoding = %q, want gzip", got)
+	}
+}
+
+func TestFrontendPrecompressedAssetCombinesHeaderLines(t *testing.T) {
+	handler := newFrontendTestHandler(t)
+	req := httptest.NewRequest(http.MethodGet, "/assets/app.js", nil)
+	req.Header.Add("Accept-Encoding", "gzip;q=0.3")
+	req.Header.Add("Accept-Encoding", "br;q=0.8")
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK || rec.Body.String() != "br-compressed" {
+		t.Fatalf("response = %d %q, want 200 brotli body", rec.Code, rec.Body.String())
+	}
+	if got := rec.Header().Get("Content-Encoding"); got != "br" {
+		t.Fatalf("content-encoding = %q, want br", got)
+	}
+}
+
+func TestFrontendRangeRequestsUseIdentityAsset(t *testing.T) {
+	handler := newFrontendTestHandler(t)
+	req := httptest.NewRequest(http.MethodGet, "/assets/app.js", nil)
+	req.Header.Set("Accept-Encoding", "br, gzip")
+	req.Header.Set("Range", "bytes=0-6")
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusPartialContent {
+		t.Fatalf("status = %d, want 206", rec.Code)
+	}
+	if got := rec.Header().Get("Content-Encoding"); got != "" {
+		t.Fatalf("content-encoding = %q, want identity", got)
+	}
+	if got := rec.Header().Get("Content-Range"); got != "bytes 0-6/14" {
+		t.Fatalf("content-range = %q", got)
+	}
+	if got := rec.Body.String(); got != "console" {
+		t.Fatalf("body = %q, want identity byte range", got)
+	}
+}
+
+func TestFrontendPrecompressedAssetSupportsHead(t *testing.T) {
+	handler := newFrontendTestHandler(t)
+	req := httptest.NewRequest(http.MethodHead, "/assets/app.js", nil)
+	req.Header.Set("Accept-Encoding", "br")
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200", rec.Code)
+	}
+	if got := rec.Header().Get("Content-Encoding"); got != "br" {
+		t.Fatalf("content-encoding = %q, want br", got)
+	}
+	if got := rec.Header().Get("Content-Length"); got != "13" {
+		t.Fatalf("content-length = %q, want 13", got)
+	}
+	if rec.Body.Len() != 0 {
+		t.Fatalf("HEAD body = %d bytes, want 0", rec.Body.Len())
+	}
+}
+
+func TestFrontendPrecompressedSidecarsAreNotPublicPaths(t *testing.T) {
+	handler := newFrontendTestHandler(t)
+
+	for _, path := range []string{"/assets/app.js.br", "/assets/app.js.gz"} {
+		rec := httptest.NewRecorder()
+		handler.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, path, nil))
+		if rec.Code != http.StatusNotFound {
+			t.Fatalf("%s status = %d, want 404", path, rec.Code)
+		}
+	}
 }
 
 func TestFrontendShellCacheHeadersAndConditionalGet(t *testing.T) {

--- a/internal/server/frontend_test.go
+++ b/internal/server/frontend_test.go
@@ -157,6 +157,11 @@ func TestFrontendPrecompressedAssetNegotiation(t *testing.T) {
 			acceptEncoding: "br;q=0, gzip;q=0",
 			wantBody:       "console.log(1)",
 		},
+		{
+			name:           "explicit identity overrides a disabled wildcard",
+			acceptEncoding: "*;q=0, identity;q=0.5",
+			wantBody:       "console.log(1)",
+		},
 	}
 
 	for _, tt := range tests {
@@ -183,6 +188,74 @@ func TestFrontendPrecompressedAssetNegotiation(t *testing.T) {
 			}
 			if got := rec.Header().Get("Content-Type"); !strings.Contains(got, "javascript") {
 				t.Fatalf("content-type = %q, want JavaScript", got)
+			}
+		})
+	}
+}
+
+func TestFrontendAssetReturnsNotAcceptableWithoutAvailableRepresentation(t *testing.T) {
+	handler := newFrontendTestHandler(t)
+	tests := []struct {
+		name           string
+		method         string
+		path           string
+		acceptEncoding string
+		rangeHeader    string
+	}{
+		{
+			name:           "every representation explicitly disabled",
+			method:         http.MethodGet,
+			path:           "/assets/app.js",
+			acceptEncoding: "identity;q=0, br;q=0, gzip;q=0",
+		},
+		{
+			name:           "wildcard disables every representation",
+			method:         http.MethodGet,
+			path:           "/assets/app.js",
+			acceptEncoding: "*;q=0",
+		},
+		{
+			name:           "acceptable sidecars are missing",
+			method:         http.MethodGet,
+			path:           "/assets/plain.js",
+			acceptEncoding: "br, gzip, identity;q=0",
+		},
+		{
+			name:           "range has no acceptable representation",
+			method:         http.MethodGet,
+			path:           "/assets/app.js",
+			acceptEncoding: "br;q=0, gzip;q=0, identity;q=0",
+			rangeHeader:    "bytes=0-6",
+		},
+		{
+			name:           "head rejects unavailable representation",
+			method:         http.MethodHead,
+			path:           "/assets/app.js",
+			acceptEncoding: "identity;q=0, br;q=0, gzip;q=0",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			req := httptest.NewRequest(tt.method, tt.path, nil)
+			req.Header.Set("Accept-Encoding", tt.acceptEncoding)
+			if tt.rangeHeader != "" {
+				req.Header.Set("Range", tt.rangeHeader)
+			}
+			rec := httptest.NewRecorder()
+			handler.ServeHTTP(rec, req)
+
+			if rec.Code != http.StatusNotAcceptable {
+				t.Fatalf("status = %d, want 406", rec.Code)
+			}
+			if got := rec.Header().Get("Content-Encoding"); got != "" {
+				t.Fatalf("content-encoding = %q, want none", got)
+			}
+			if got := rec.Header().Get("Vary"); got != "Accept-Encoding" {
+				t.Fatalf("vary = %q, want Accept-Encoding", got)
+			}
+			if rec.Body.Len() != 0 {
+				t.Fatalf("body = %q, want empty", rec.Body.String())
 			}
 		})
 	}
@@ -266,6 +339,28 @@ func TestFrontendRangeRequestsUseIdentityAsset(t *testing.T) {
 	}
 }
 
+func TestFrontendRangeWithRejectedIdentityUsesFullCompressedAsset(t *testing.T) {
+	handler := newFrontendTestHandler(t)
+	req := httptest.NewRequest(http.MethodGet, "/assets/app.js", nil)
+	req.Header.Set("Accept-Encoding", "br, identity;q=0")
+	req.Header.Set("Range", "bytes=0-6")
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200", rec.Code)
+	}
+	if got := rec.Header().Get("Content-Encoding"); got != "br" {
+		t.Fatalf("content-encoding = %q, want br", got)
+	}
+	if got := rec.Header().Get("Content-Range"); got != "" {
+		t.Fatalf("content-range = %q, want none", got)
+	}
+	if got := rec.Body.String(); got != "br-compressed" {
+		t.Fatalf("body = %q, want full brotli representation", got)
+	}
+}
+
 func TestFrontendPrecompressedAssetSupportsHead(t *testing.T) {
 	handler := newFrontendTestHandler(t)
 	req := httptest.NewRequest(http.MethodHead, "/assets/app.js", nil)
@@ -281,6 +376,28 @@ func TestFrontendPrecompressedAssetSupportsHead(t *testing.T) {
 	}
 	if got := rec.Header().Get("Content-Length"); got != "13" {
 		t.Fatalf("content-length = %q, want 13", got)
+	}
+	if rec.Body.Len() != 0 {
+		t.Fatalf("HEAD body = %d bytes, want 0", rec.Body.Len())
+	}
+}
+
+func TestFrontendPrecompressedAssetIgnoresRangeOnHead(t *testing.T) {
+	handler := newFrontendTestHandler(t)
+	req := httptest.NewRequest(http.MethodHead, "/assets/app.js", nil)
+	req.Header.Set("Accept-Encoding", "br, identity;q=0")
+	req.Header.Set("Range", "bytes=0-6")
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200", rec.Code)
+	}
+	if got := rec.Header().Get("Content-Encoding"); got != "br" {
+		t.Fatalf("content-encoding = %q, want br", got)
+	}
+	if got := rec.Header().Get("Content-Range"); got != "" {
+		t.Fatalf("content-range = %q, want none", got)
 	}
 	if rec.Body.Len() != 0 {
 		t.Fatalf("HEAD body = %d bytes, want 0", rec.Body.Len())

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef, useState, type ReactNode } from "react";
+import { lazy, Suspense, useEffect, useRef, useState, type ReactNode } from "react";
 import {
   BrowserRouter,
   Routes,
@@ -27,85 +27,16 @@ import { RealtimeEventsProvider } from "@/components/RealtimeEventsProvider";
 import { useEventChannel } from "@/components/realtimeEventsContext";
 import { useSettingValuesRealtime } from "@/hooks/queries/settingValues";
 import Layout from "@/components/Layout";
-import AdminLayout from "@/components/AdminLayout";
 import Home from "@/pages/Home";
 import Login from "@/pages/Login";
-import OAuthComplete from "@/pages/OAuthComplete";
-import ActivateDevice from "@/pages/ActivateDevice";
-import SetupWizard from "@/pages/SetupWizard";
-import Profiles from "@/pages/Profiles";
 import Catalog from "@/pages/Catalog";
-import LibraryPage from "@/pages/LibraryPage";
-import ItemDetail from "@/pages/ItemDetail/index";
-import EbookReader from "@/pages/EbookReader";
-import PersonDetail from "@/pages/PersonDetail";
-import Collections from "@/pages/Collections";
-import CollectionEditor from "@/pages/CollectionEditor";
-import Notifications from "@/pages/Notifications";
-import DeviceSettings from "@/pages/settings/DeviceSettings";
-import NotificationsSettings from "@/pages/settings/NotificationsSettings";
-import Requests from "@/pages/Requests";
-import RequestBrowse from "@/pages/RequestBrowse";
-import RequestDetail from "@/pages/RequestDetail";
-import AdminDashboard from "@/pages/AdminDashboard";
-import AdminActivity from "@/pages/AdminActivity";
-import AdminLogs from "@/pages/AdminLogs";
-import AdminDiagnostics from "@/pages/AdminDiagnostics";
-import AdminAccessGroups from "@/pages/AdminAccessGroups";
-import AdminUsers from "@/pages/AdminUsers";
-import AdminRequests from "@/pages/AdminRequests";
-import AdminAutoscan from "@/pages/AdminAutoscan";
-import AdminDevices from "@/pages/AdminDevices";
-import AdminLibraries from "@/pages/AdminLibraries";
-import AdminSettingsLayout from "@/pages/admin-settings/AdminSettingsLayout";
-import AdminNodes from "@/pages/AdminNodes";
-import AdminSections from "@/pages/AdminSections";
-import AdminCollections from "@/pages/AdminCollections";
-import AdminCollectionEditor from "@/pages/AdminCollectionEditor";
-import AdminPlaybackHistory from "@/pages/AdminPlaybackHistory";
-import AdminMarkerHistory from "@/pages/AdminMarkerHistory";
-import AdminMaintenance from "@/pages/AdminMaintenance";
-import AdminApiKeys from "@/pages/AdminApiKeys";
-import AdminSubtitles from "@/pages/AdminSubtitles";
-import AdminUserDetail from "@/pages/AdminUserDetail";
-import AdminTasks from "@/pages/AdminTasks";
-import AdminTaskDetail from "@/pages/AdminTaskDetail";
-import AdminPlugins from "@/pages/AdminPlugins";
-import AdminHistoryImport from "@/pages/AdminHistoryImport";
-import AdminRecommendations from "@/pages/AdminRecommendations";
-import AdminPolicyLayout from "@/pages/admin-policy/AdminPolicyLayout";
-import Recommendations from "@/pages/Recommendations";
-import RecommendationsSection from "@/pages/RecommendationsSection";
-import Calendar from "@/pages/Calendar";
-import Signup from "@/pages/Signup";
-import InviteClaim from "@/pages/InviteClaim";
-import HouseholdSetup from "@/pages/HouseholdSetup";
-import TasteSeed from "@/pages/TasteSeed";
 import { useFavorites } from "@/hooks/queries/favorites";
 import { useRequestFeatureStatus } from "@/hooks/queries/useRequests";
 import { isTasteSeedDismissed } from "@/lib/tasteSeed";
 import { OnboardingGate } from "@/components/onboarding/OnboardingGate";
 import { useOnboardingState } from "@/hooks/queries/onboarding";
 import SettingsLayout from "@/pages/SettingsLayout";
-import AppearanceSettings from "@/pages/settings/AppearanceSettings";
-import AccessibilitySettings from "@/pages/settings/AccessibilitySettings";
 import PlaybackSettings from "@/pages/settings/PlaybackSettings";
-import ProfilesSettings from "@/pages/settings/ProfilesSettings";
-import LibrarySettings from "@/pages/settings/LibrarySettings";
-import HistoryImportSettings from "@/pages/settings/HistoryImportSettings";
-import WebhookSyncSettings from "@/pages/settings/WebhookSyncSettings";
-import WatchProvidersSettings from "@/pages/settings/WatchProvidersSettings";
-import SubtitleAppearanceSettings from "@/pages/settings/SubtitleAppearanceSettings";
-import HomeScreenSettings from "@/pages/settings/HomeScreenSettings";
-import ThemeEditorSettings from "@/pages/settings/ThemeEditorSettings";
-import CardOverlaySettings from "@/pages/settings/CardOverlaySettings";
-import PersonalizeSettings from "@/pages/settings/PersonalizeSettings";
-import ConnectAppsSettings from "@/pages/settings/ConnectAppsSettings";
-import InterfaceSettings from "@/pages/settings/InterfaceSettings";
-import WatchTogetherJoin from "@/pages/WatchTogetherJoin";
-import WatchTogetherRoomPage from "@/pages/WatchTogetherRoomPage";
-import WatchRoute from "@/pages/WatchRoute";
-import ProfileCustomizeHome from "@/pages/ProfileCustomizeHome";
 import {
   WatchPlaybackBar,
   WatchPlaybackHost,
@@ -121,6 +52,78 @@ import {
 import { buildLegacyWebhookSyncRedirectTarget } from "@/lib/webhookSync";
 import { toast } from "sonner";
 import { prewarmCodecDetection } from "@/player/hooks/useCodecDetection";
+
+const AdminLayout = lazy(() => import("@/components/AdminLayout"));
+const OAuthComplete = lazy(() => import("@/pages/OAuthComplete"));
+const ActivateDevice = lazy(() => import("@/pages/ActivateDevice"));
+const SetupWizard = lazy(() => import("@/pages/SetupWizard"));
+const Profiles = lazy(() => import("@/pages/Profiles"));
+const LibraryPage = lazy(() => import("@/pages/LibraryPage"));
+const ItemDetail = lazy(() => import("@/pages/ItemDetail/index"));
+const EbookReader = lazy(() => import("@/pages/EbookReader"));
+const PersonDetail = lazy(() => import("@/pages/PersonDetail"));
+const Collections = lazy(() => import("@/pages/Collections"));
+const CollectionEditor = lazy(() => import("@/pages/CollectionEditor"));
+const Notifications = lazy(() => import("@/pages/Notifications"));
+const DeviceSettings = lazy(() => import("@/pages/settings/DeviceSettings"));
+const NotificationsSettings = lazy(() => import("@/pages/settings/NotificationsSettings"));
+const Requests = lazy(() => import("@/pages/Requests"));
+const RequestBrowse = lazy(() => import("@/pages/RequestBrowse"));
+const RequestDetail = lazy(() => import("@/pages/RequestDetail"));
+const AdminDashboard = lazy(() => import("@/pages/AdminDashboard"));
+const AdminActivity = lazy(() => import("@/pages/AdminActivity"));
+const AdminLogs = lazy(() => import("@/pages/AdminLogs"));
+const AdminDiagnostics = lazy(() => import("@/pages/AdminDiagnostics"));
+const AdminAccessGroups = lazy(() => import("@/pages/AdminAccessGroups"));
+const AdminUsers = lazy(() => import("@/pages/AdminUsers"));
+const AdminRequests = lazy(() => import("@/pages/AdminRequests"));
+const AdminAutoscan = lazy(() => import("@/pages/AdminAutoscan"));
+const AdminDevices = lazy(() => import("@/pages/AdminDevices"));
+const AdminLibraries = lazy(() => import("@/pages/AdminLibraries"));
+const AdminSettingsLayout = lazy(() => import("@/pages/admin-settings/AdminSettingsLayout"));
+const AdminNodes = lazy(() => import("@/pages/AdminNodes"));
+const AdminSections = lazy(() => import("@/pages/AdminSections"));
+const AdminCollections = lazy(() => import("@/pages/AdminCollections"));
+const AdminCollectionEditor = lazy(() => import("@/pages/AdminCollectionEditor"));
+const AdminPlaybackHistory = lazy(() => import("@/pages/AdminPlaybackHistory"));
+const AdminMarkerHistory = lazy(() => import("@/pages/AdminMarkerHistory"));
+const AdminMaintenance = lazy(() => import("@/pages/AdminMaintenance"));
+const AdminApiKeys = lazy(() => import("@/pages/AdminApiKeys"));
+const AdminSubtitles = lazy(() => import("@/pages/AdminSubtitles"));
+const AdminUserDetail = lazy(() => import("@/pages/AdminUserDetail"));
+const AdminTasks = lazy(() => import("@/pages/AdminTasks"));
+const AdminTaskDetail = lazy(() => import("@/pages/AdminTaskDetail"));
+const AdminPlugins = lazy(() => import("@/pages/AdminPlugins"));
+const AdminHistoryImport = lazy(() => import("@/pages/AdminHistoryImport"));
+const AdminRecommendations = lazy(() => import("@/pages/AdminRecommendations"));
+const AdminPolicyLayout = lazy(() => import("@/pages/admin-policy/AdminPolicyLayout"));
+const Recommendations = lazy(() => import("@/pages/Recommendations"));
+const RecommendationsSection = lazy(() => import("@/pages/RecommendationsSection"));
+const Calendar = lazy(() => import("@/pages/Calendar"));
+const Signup = lazy(() => import("@/pages/Signup"));
+const InviteClaim = lazy(() => import("@/pages/InviteClaim"));
+const HouseholdSetup = lazy(() => import("@/pages/HouseholdSetup"));
+const TasteSeed = lazy(() => import("@/pages/TasteSeed"));
+const AppearanceSettings = lazy(() => import("@/pages/settings/AppearanceSettings"));
+const AccessibilitySettings = lazy(() => import("@/pages/settings/AccessibilitySettings"));
+const ProfilesSettings = lazy(() => import("@/pages/settings/ProfilesSettings"));
+const LibrarySettings = lazy(() => import("@/pages/settings/LibrarySettings"));
+const HistoryImportSettings = lazy(() => import("@/pages/settings/HistoryImportSettings"));
+const WebhookSyncSettings = lazy(() => import("@/pages/settings/WebhookSyncSettings"));
+const WatchProvidersSettings = lazy(() => import("@/pages/settings/WatchProvidersSettings"));
+const SubtitleAppearanceSettings = lazy(
+  () => import("@/pages/settings/SubtitleAppearanceSettings"),
+);
+const HomeScreenSettings = lazy(() => import("@/pages/settings/HomeScreenSettings"));
+const ThemeEditorSettings = lazy(() => import("@/pages/settings/ThemeEditorSettings"));
+const CardOverlaySettings = lazy(() => import("@/pages/settings/CardOverlaySettings"));
+const PersonalizeSettings = lazy(() => import("@/pages/settings/PersonalizeSettings"));
+const ConnectAppsSettings = lazy(() => import("@/pages/settings/ConnectAppsSettings"));
+const InterfaceSettings = lazy(() => import("@/pages/settings/InterfaceSettings"));
+const WatchTogetherJoin = lazy(() => import("@/pages/WatchTogetherJoin"));
+const WatchTogetherRoomPage = lazy(() => import("@/pages/WatchTogetherRoomPage"));
+const WatchRoute = lazy(() => import("@/pages/WatchRoute"));
+const ProfileCustomizeHome = lazy(() => import("@/pages/ProfileCustomizeHome"));
 
 /** Scrolls to top on pathname change (custom replacement for ScrollRestoration which requires data router). */
 function useScrollRestoration() {
@@ -153,6 +156,15 @@ function RouteAnnouncer() {
 function ScrollRestorationManager() {
   useScrollRestoration();
   return null;
+}
+
+function RouteLoading() {
+  return (
+    <div className="p-8" role="status" aria-live="polite">
+      <span className="sr-only">Loading page</span>
+      Loading...
+    </div>
+  );
 }
 
 /**
@@ -669,7 +681,9 @@ export default function App() {
                           <RouteAnnouncer />
                           <QueryCacheManager />
                           <AppChrome />
-                          <ReactiveAppRoutes />
+                          <Suspense fallback={<RouteLoading />}>
+                            <ReactiveAppRoutes />
+                          </Suspense>
                           <WatchPlaybackHost />
                           <WatchPlaybackBar />
                           <Toaster />

--- a/web/src/pages/audiobooks/player/audiobookPlaybackContext.tsx
+++ b/web/src/pages/audiobooks/player/audiobookPlaybackContext.tsx
@@ -1,7 +1,7 @@
 import { createContext, useCallback, useContext, useMemo, useState, type ReactNode } from "react";
 import { getAccessToken, getOrCreateDeviceId, getProfileToken } from "@/api/client";
 import type { AudiobookFile } from "@/lib/audiobooks/types";
-import { PlayerConfigProvider, type PlayerConfig } from "@/player";
+import { PlayerConfigProvider, type PlayerConfig } from "@/player/context/PlayerConfigContext";
 import { storage } from "@/utils/storage";
 import AudiobookPlayer, {
   type AudiobookPlayerControls,

--- a/web/src/playback/WatchPlaybackChrome.tsx
+++ b/web/src/playback/WatchPlaybackChrome.tsx
@@ -151,7 +151,11 @@ function buildWatchLocationState(request: WatchRouteRequest) {
 
 function PlaybackPreparingScreen() {
   return (
-    <div className="bg-background fixed inset-0 z-50 flex items-center justify-center px-6">
+    <div
+      className="bg-background fixed inset-0 z-50 flex items-center justify-center px-6"
+      role="status"
+      aria-live="polite"
+    >
       <div className="surface-panel-subtle animate-in fade-in flex min-w-[260px] flex-col items-center gap-4 rounded-[1.8rem] px-8 py-7 text-center duration-300">
         <div className="h-8 w-8 animate-spin rounded-full border-2 border-white/20 border-t-white" />
         <div className="space-y-1">

--- a/web/src/playback/WatchPlaybackChrome.tsx
+++ b/web/src/playback/WatchPlaybackChrome.tsx
@@ -1,4 +1,6 @@
 import {
+  lazy,
+  Suspense,
   useCallback,
   useContext,
   useEffect,
@@ -31,14 +33,13 @@ import { applyPlaybackProgressToCache } from "@/hooks/queries/playbackProgressCa
 import { invalidatePlaybackSurfaceQueries } from "@/hooks/queries/playbackSurfaceRefresh";
 import { useAuth } from "@/hooks/useAuth";
 import { useCurrentProfile } from "@/hooks/useCurrentProfile";
-import { PlayerConfigProvider, WatchPage } from "@/player";
+import { PlayerConfigProvider, type PlayerConfig } from "@/player/context/PlayerConfigContext";
 import type {
   EpisodeRef,
   IntroSkipMode,
   PlaybackExitState,
-  PlayerConfig,
   PlayerPictureInPictureChange,
-} from "@/player";
+} from "@/player/types";
 import { useSeriesEpisodes } from "@/player/hooks/useSeriesEpisodes";
 import { PlayingNextScreen } from "@/player/components/PlayingNextScreen";
 import { formatTime } from "@/player/components/SeekBar";
@@ -56,6 +57,10 @@ import {
   type WatchRouteRequest,
 } from "@/pages/watchRouteHelpers";
 import { canEditMarkers as canEditMarkersForUser } from "@/lib/permissions";
+
+const WatchPage = lazy(() =>
+  import("@/player/components/WatchPage").then((module) => ({ default: module.WatchPage })),
+);
 
 function normalizeWatchPlaybackRequest(
   input: WatchPlaybackStartInput | WatchRouteRequest,
@@ -142,6 +147,22 @@ function buildWatchLocationState(request: WatchRouteRequest) {
     prePlaySubtitleMode: request.prePlaySubtitleMode,
     prePlaySubtitleSelection: request.prePlaySubtitleSelection ?? null,
   };
+}
+
+function PlaybackPreparingScreen() {
+  return (
+    <div className="bg-background fixed inset-0 z-50 flex items-center justify-center px-6">
+      <div className="surface-panel-subtle animate-in fade-in flex min-w-[260px] flex-col items-center gap-4 rounded-[1.8rem] px-8 py-7 text-center duration-300">
+        <div className="h-8 w-8 animate-spin rounded-full border-2 border-white/20 border-t-white" />
+        <div className="space-y-1">
+          <p className="text-sm font-medium text-white">Preparing playback</p>
+          <p className="text-xs text-white/55">
+            Loading stream details, subtitles, and resume state.
+          </p>
+        </div>
+      </div>
+    </div>
+  );
 }
 
 export function WatchPlaybackProvider({ children }: { children: ReactNode }) {
@@ -833,19 +854,7 @@ export function WatchPlaybackHost() {
       return null;
     }
 
-    return (
-      <div className="bg-background fixed inset-0 z-50 flex items-center justify-center px-6">
-        <div className="surface-panel-subtle animate-in fade-in flex min-w-[260px] flex-col items-center gap-4 rounded-[1.8rem] px-8 py-7 text-center duration-300">
-          <div className="h-8 w-8 animate-spin rounded-full border-2 border-white/20 border-t-white" />
-          <div className="space-y-1">
-            <p className="text-sm font-medium text-white">Preparing playback</p>
-            <p className="text-xs text-white/55">
-              Loading stream details, subtitles, and resume state.
-            </p>
-          </div>
-        </div>
-      </div>
-    );
+    return <PlaybackPreparingScreen />;
   }
 
   if (error && isForeground) {
@@ -937,25 +946,27 @@ export function WatchPlaybackHost() {
   return (
     <PlayerConfigProvider config={playerConfig}>
       {(isForeground || isPostRoll) && <WatchPlaybackTitle title={activeItem.title} />}
-      <WatchPage
-        {...watchPageProps}
-        maxBitrateKbps={maxBitrateKbps ?? null}
-        introSkipMode={introSkipMode}
-        autoSkipRecap={autoSkipRecap}
-        autoPlayNextPreview={autoPlayNextPreview}
-        canEditMarkers={canEditMarkers}
-        playbackRequestKey={requestKeyValue}
-        onNavigateEpisode={handleNavigateEpisode}
-        onEnded={handleEnded}
-        onExit={handleExit}
-        onMinimize={handleMinimize}
-        displayMode={playerDisplayMode}
-        autoEnterPictureInPicture={state.autoEnterPictureInPicture}
-        onPictureInPictureChange={handlePictureInPictureChange}
-        onPlaybackStateChange={handlePlaybackStateChange}
-        onPlaybackTransportReady={handlePlaybackTransportReady}
-        onReturnFromPostRoll={isPostRoll ? handleReturnFromPostRoll : undefined}
-      />
+      <Suspense fallback={isForeground || isPostRoll ? <PlaybackPreparingScreen /> : null}>
+        <WatchPage
+          {...watchPageProps}
+          maxBitrateKbps={maxBitrateKbps ?? null}
+          introSkipMode={introSkipMode}
+          autoSkipRecap={autoSkipRecap}
+          autoPlayNextPreview={autoPlayNextPreview}
+          canEditMarkers={canEditMarkers}
+          playbackRequestKey={requestKeyValue}
+          onNavigateEpisode={handleNavigateEpisode}
+          onEnded={handleEnded}
+          onExit={handleExit}
+          onMinimize={handleMinimize}
+          displayMode={playerDisplayMode}
+          autoEnterPictureInPicture={state.autoEnterPictureInPicture}
+          onPictureInPictureChange={handlePictureInPictureChange}
+          onPlaybackStateChange={handlePlaybackStateChange}
+          onPlaybackTransportReady={handlePlaybackTransportReady}
+          onReturnFromPostRoll={isPostRoll ? handleReturnFromPostRoll : undefined}
+        />
+      </Suspense>
       {isPostRoll && (
         <PlayingNextScreen
           seriesId={activeItem.series_id}

--- a/web/vite.config.ts
+++ b/web/vite.config.ts
@@ -1,10 +1,42 @@
-import { defineConfig, loadEnv } from "vite";
+import { readFileSync, writeFileSync } from "node:fs";
+import { brotliCompressSync, constants, gzipSync } from "node:zlib";
+import { defineConfig, loadEnv, type Plugin } from "vite";
 import react from "@vitejs/plugin-react";
 import tailwindcss from "@tailwindcss/vite";
 import path from "path";
 import os from "os";
 
 /// <reference types="vitest" />
+
+const PRECOMPRESS_MIN_BYTES = 1024;
+
+function precompressStaticAssets(): Plugin {
+  return {
+    name: "precompress-static-assets",
+    apply: "build",
+    writeBundle(options, bundle) {
+      if (!options.dir) return;
+
+      for (const output of Object.values(bundle)) {
+        if (!/\.(?:css|js)$/.test(output.fileName)) continue;
+
+        // Read the written file rather than the generateBundle value: later
+        // Rollup hooks can still finalize chunk bytes before they reach disk.
+        const filePath = path.resolve(options.dir, output.fileName);
+        const bytes = readFileSync(filePath);
+        if (bytes.byteLength < PRECOMPRESS_MIN_BYTES) continue;
+
+        writeFileSync(
+          `${filePath}.br`,
+          brotliCompressSync(bytes, {
+            params: { [constants.BROTLI_PARAM_QUALITY]: 11 },
+          }),
+        );
+        writeFileSync(`${filePath}.gz`, gzipSync(bytes, { level: 9 }));
+      }
+    },
+  };
+}
 
 export default defineConfig(({ mode }) => {
   const env = loadEnv(mode, process.cwd(), "");
@@ -31,7 +63,7 @@ export default defineConfig(({ mode }) => {
   );
 
   return {
-    plugins: [react(), tailwindcss()],
+    plugins: [react(), tailwindcss(), precompressStaticAssets()],
     worker: {
       format: "es",
     },


### PR DESCRIPTION
## Problem

The frontend bootstrap imports most routes and playback code even when a browser only opens Home or Login. The embedded server also serves only identity JS/CSS, despite those assets being highly compressible.

## Approach

- Keep the common routes eager and load uncommon routes through `React.lazy` with an accessible fallback.
- Load `WatchPage` behind its own boundary. The rebase preserves current `main`'s playback engine selection, retry behavior, plan invalidation, and HLS prewarm, but the HLS module is now reachable only after the watch chunk loads.
- Import the audiobook player configuration directly so the eager audiobook provider cannot pull the side-effectful player barrel back into the bootstrap.
- Generate Brotli and gzip sidecars from final written JS/CSS during the Vite build.
- Negotiate those sidecars in the Go frontend handler, including q-values, repeated `Accept-Encoding` lines, `HEAD`, Range behavior, unavailable representations, and hidden direct sidecar paths.

## Rebase status

Rebased onto `main` at `9acea537a`. The original `VideoPlayer` conflict was resolved in favor of current `main`'s playback implementation. The stale documentation-only HLS commit became empty and was dropped.

Final head: `387285ae3`.

## Measured result

Current rebased production build:

| Bootstrap entry | Bytes |
| --- | ---: |
| Identity | 1,487,314 |
| Brotli | 347,851 |
| Gzip | 433,658 |

The build generated 270 compressed sidecars totaling 3,300,691 bytes. Every sidecar was decompressed and compared byte-for-byte with its source. The bootstrap entry contains no direct reference to the HLS chunk; it dynamically references `WatchPage`, and the `WatchPage` chunk references HLS.

The original implementation was production-tested from [blurbery/silo-server#41](https://github.com/blurbery/silo-server/pull/41). Those deployment results remain useful protocol evidence, while the measurements above come from this rebased upstream head.

## Verification

- `go test ./internal/server/...` — passed.
- `make test-web` — 292 files and 2,154 tests passed.
- `corepack pnpm run lint` — passed with 0 errors and 154 existing warnings.
- `corepack pnpm run format:check` — passed.
- `corepack pnpm run build` — passed.
- `make verify-settings-bindings-all` — passed.
- `make verify-playback-fixtures` — passed.
- `make verify-local-paths` — passed.
- Sidecar decompression check — 270/270 matched their source bytes.
- Final bundle dependency check — bootstrap → `WatchPage` → HLS; no bootstrap → HLS edge.

The full local `make test-go` run passed all packages except two unchanged macOS process-identity lock tests in `internal/jellycompat` (`TestBeginWebOperationRecoversDeadProcessLock` and `TestBeginWebOperationRejectsLiveProcessLock`). This PR does not modify that package, and the same two tests fail in isolation against the unchanged `main` code. `golangci-lint` is not installed locally. The merge-base-scoped Linux lint and complete Go suite passed in GitHub Actions.

## Review outcome

The complete rebased merge-base diff was reviewed again. The rebase initially exposed an eager player-barrel edge that restored HLS to the bootstrap; the direct audiobook configuration import fixes it. No actionable finding remains in the final diff. The two earlier CodeRabbit findings—406 handling when identity and compressed representations are rejected, and status semantics for playback preparation—remain addressed.

## Risks and follow-up

- The embedded distribution grows by 3,300,691 bytes for compressed sidecars.
- A cold deep link waits for its route chunk and shows the generic loading fallback.
- `WatchPlaybackChrome` remains eager; `WatchPage` and HLS are split out.
- A reverse proxy must respect the server's existing `Content-Encoding` header.
- No API, schema, migration, jellycompat, Android, or Apple contract change is required.

Related issue: N/A — narrow performance fix.

## AI Disclosure

- Tool(s): OpenAI Codex
- Model(s): GPT-5, GPT-5.6
- Involvement: AI-assisted implementation, rebase conflict resolution, validation, and review
- Adversarial review: The original patch and the final rebased merge-base diff were reviewed for route boundaries, playback import timing, HTTP negotiation, Range/HEAD semantics, build output integrity, and current-main compatibility. The post-rebase eager HLS edge was found and fixed; no material finding remains.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance**
  * Improved page and playback loading with on-demand content loading and accessible loading states.
  * Added optimized compressed assets to improve delivery speed.

* **Bug Fixes**
  * Improved compressed asset negotiation, range requests, and fallback behavior.
  * Prevented direct access to compressed asset files.
  * Added clearer responses when no supported representation is available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->