### PR TITLE
fix(web): label section recipes from their saved config

### DIFF
--- a/web/src/components/sections/EditableSectionRows.test.ts
+++ b/web/src/components/sections/EditableSectionRows.test.ts
@@ -1,0 +1,101 @@
+import { describe, expect, it } from "vitest";
+import { recipeLabel } from "./EditableSectionRows";
+import type { RecipeCatalogResponse } from "@/lib/recipes";
+
+// Mirrors the trending_discover presets registered in
+// internal/sections/recipes/trending_discover.go, which differ only by their
+// default_params. It is the shape that exposed the bug: every variant rendered
+// as the first preset's name.
+const catalog = {
+  categories: {
+    social: [
+      {
+        type: "trending_discover",
+        category: "social",
+        avoid_duplicates: false,
+        supports_rotation: false,
+        admin_only: false,
+        presets: [
+          {
+            key: "tdisc_tmdb_day",
+            display_name: "TMDB Trending Today",
+            icon: "🔥",
+            description_short: "",
+            default_params: { source: "tmdb", window: "day" },
+          },
+          {
+            key: "tdisc_tmdb_week",
+            display_name: "TMDB Trending This Week",
+            icon: "🔥",
+            description_short: "",
+            default_params: { source: "tmdb", window: "week" },
+          },
+          {
+            key: "tdisc_trakt",
+            display_name: "Trakt Trending",
+            icon: "📈",
+            description_short: "",
+            default_params: { source: "trakt", window: "week" },
+          },
+        ],
+      },
+    ],
+  },
+} as unknown as RecipeCatalogResponse;
+
+describe("recipeLabel", () => {
+  it("labels the weekly TMDB preset from its saved config", () => {
+    expect(recipeLabel(catalog, "trending_discover", { source: "tmdb", window: "week" })).toBe(
+      "TMDB Trending This Week",
+    );
+  });
+
+  it("labels the daily TMDB preset from its saved config", () => {
+    expect(recipeLabel(catalog, "trending_discover", { source: "tmdb", window: "day" })).toBe(
+      "TMDB Trending Today",
+    );
+  });
+
+  // Same source-agnostic window as tdisc_tmdb_week, so this only resolves if
+  // every default_param is checked rather than just the distinguishing one.
+  it("distinguishes Trakt from TMDB on the same window", () => {
+    expect(recipeLabel(catalog, "trending_discover", { source: "trakt", window: "week" })).toBe(
+      "Trakt Trending",
+    );
+  });
+
+  it("ignores unrelated config keys the section also carries", () => {
+    expect(
+      recipeLabel(catalog, "trending_discover", {
+        source: "trakt",
+        window: "week",
+        media_scope: "movie",
+        item_limit: 20,
+      }),
+    ).toBe("Trakt Trending");
+  });
+
+  it("falls back to the first preset when no config is stored", () => {
+    expect(recipeLabel(catalog, "trending_discover")).toBe("TMDB Trending Today");
+  });
+
+  it("falls back to the first preset when the config matches no preset", () => {
+    expect(recipeLabel(catalog, "trending_discover", { source: "letterboxd" })).toBe(
+      "TMDB Trending Today",
+    );
+  });
+
+  it("falls back to the generic type label when the catalog has no such type", () => {
+    expect(recipeLabel(catalog, "continue_watching", { continue_type: "listening" })).toBe(
+      "Continue Watching",
+    );
+  });
+
+  // trending_discover has no SECTION_TYPES entry, so sectionTypeLabel returns
+  // the raw type string rather than a prettified one.
+  it("falls back to the raw type without a catalog", () => {
+    expect(recipeLabel(undefined, "trending_discover", { source: "tmdb", window: "week" })).toBe(
+      "trending_discover",
+    );
+  });
+});

--- a/web/src/components/sections/EditableSectionRows.tsx
+++ b/web/src/components/sections/EditableSectionRows.tsx
@@ -4,7 +4,7 @@ import { Button } from "@/components/ui/button";
 import { sectionTypeLabel } from "@/lib/sectionTypes";
 import { queryDefinitionFromSectionConfig } from "@/api/types";
 import type { Library } from "@/api/types";
-import type { RecipeCatalogResponse } from "@/lib/recipes";
+import type { GalleryPreset, RecipeCatalogResponse } from "@/lib/recipes";
 import { Eye, EyeOff, GripVertical, Pencil, Star, Trash2 } from "lucide-react";
 import { useSortable } from "@dnd-kit/sortable";
 import { CSS } from "@dnd-kit/utilities";
@@ -22,11 +22,70 @@ export interface EditableSectionViewModel {
   config?: Record<string, unknown>;
 }
 
-export function recipeLabel(catalog: RecipeCatalogResponse | undefined, type: string): string {
+function paramsEqual(a: unknown, b: unknown): boolean {
+  if (a === b) return true;
+  if (a === null || b === null) return false;
+  if (typeof a !== "object" || typeof b !== "object") return false;
+  return JSON.stringify(a) === JSON.stringify(b);
+}
+
+/**
+ * How specifically a preset matches a saved section config: the number of
+ * default_params the config reproduces, or -1 when any of them disagrees.
+ *
+ * A preset carrying no default_params scores 0 — it describes the recipe
+ * generically, so it matches anything but loses to any preset that matches on
+ * real parameters.
+ */
+function presetMatchScore(
+  preset: GalleryPreset,
+  config: Record<string, unknown> | undefined,
+): number {
+  const keys = Object.keys(preset.default_params ?? {});
+  if (keys.length === 0) return 0;
+  if (!config) return -1;
+  for (const key of keys) {
+    if (!paramsEqual(preset.default_params[key], config[key])) return -1;
+  }
+  return keys.length;
+}
+
+/**
+ * The preset a saved section was created from, identified by matching its
+ * default_params against the section's config.
+ *
+ * Presets within one recipe differ only by those params — trending_discover
+ * ships tmdb/day, tmdb/week and trakt/week — so the first preset is not a
+ * usable stand-in for the rest. Falls back to the first preset when nothing
+ * matches, which keeps sections saved before a preset existed labelled as they
+ * were.
+ */
+function matchingPreset(
+  presets: GalleryPreset[] | undefined,
+  config: Record<string, unknown> | undefined,
+): GalleryPreset | undefined {
+  let best: GalleryPreset | undefined;
+  let bestScore = -1;
+  for (const preset of presets ?? []) {
+    const score = presetMatchScore(preset, config);
+    if (score > bestScore) {
+      best = preset;
+      bestScore = score;
+    }
+  }
+  return bestScore >= 0 ? best : presets?.[0];
+}
+
+export function recipeLabel(
+  catalog: RecipeCatalogResponse | undefined,
+  type: string,
+  config?: Record<string, unknown>,
+): string {
   if (catalog) {
     for (const defs of Object.values(catalog.categories)) {
       const found = defs?.find((def) => def.type === type);
-      if (found?.presets[0]?.display_name) return found.presets[0].display_name;
+      const label = matchingPreset(found?.presets, config)?.display_name;
+      if (label) return label;
     }
   }
   return sectionTypeLabel(type);
@@ -71,7 +130,7 @@ export function SectionSummaryBadges({
 
   return (
     <div className="flex flex-wrap gap-1">
-      <Badge variant="secondary">{recipeLabel(catalog, section.sectionType)}</Badge>
+      <Badge variant="secondary">{recipeLabel(catalog, section.sectionType, section.config)}</Badge>
       {resumeLabel ? <Badge variant="outline">{resumeLabel}</Badge> : null}
       {queryDefinition.media_scope === "movie" ? <Badge variant="outline">Movies</Badge> : null}
       {queryDefinition.media_scope === "series" ? <Badge variant="outline">Series</Badge> : null}
@@ -118,7 +177,7 @@ export function SectionDragOverlay({
       <GripVertical className="text-muted-foreground h-4 w-4" />
       <span className="font-medium">{section.title}</span>
       <Badge variant="secondary" className="ml-2">
-        {recipeLabel(catalog, section.sectionType)}
+        {recipeLabel(catalog, section.sectionType, section.config)}
       </Badge>
     </div>
   );


### PR DESCRIPTION
Fixes #586.

## What happened

`recipeLabel` resolves a section's badge by finding its recipe definition and returning `found.presets[0].display_name` — the first registered preset — without ever looking at the config the section was saved with (`web/src/components/sections/EditableSectionRows.tsx:25` before this change).

The presets of one recipe differ *only* by their `default_params`, so the first preset is not a stand-in for the rest. `trending_discover` registers three (`internal/sections/recipes/trending_discover.go:52-54`):

| preset | `default_params` | display name |
|---|---|---|
| `tdisc_tmdb_day` | `{"source":"tmdb","window":"day"}` | TMDB Trending Today |
| `tdisc_tmdb_week` | `{"source":"tmdb","window":"week"}` | TMDB Trending This Week |
| `tdisc_trakt` | `{"source":"trakt","window":"week"}` | Trakt Trending |

All three rendered as "TMDB Trending Today". That confirms the suspicion in the issue that Trakt Trending is mislabeled the same way — it is, and there's now a test for it.

## This is not trending-specific

Worth flagging, since the issue reads as a single-section problem. Enumerating the registry, **10 of the 33 registered recipe types ship more than one preset**:

```
mood_collection        8 presets
collection             7
editorial_spotlight    4
format_showcase        4
trending_on_server     3
award_winners          3
trending_discover      3
most_watched           2
continue_watching      2
seasonal_themed        2
```

That's 38 presets across those types, of which the 28 non-first ones all render the wrong label. `trending_discover` is just where it was noticed. Fixing `recipeLabel` rather than special-casing trending covers all of them in one change, which is why the diff is a bit larger than the report implies.

## Approach

Sections don't record which preset created them — `sections` carries `section_type` and a `config` jsonb and nothing else (`migrations/sql/001_schema.sql:613`), and there's no preset-key column anywhere. So the preset has to be recovered by matching its `default_params` against that config.

`presetMatchScore` requires *every* one of a preset's `default_params` to agree with the config and scores by how many matched, so the most specific preset wins. Requiring all of them is what separates `tmdb/week` from `trakt/week` — matching on the distinguishing key alone would not. Extra config keys the section carries (`media_scope`, `item_limit`, …) are ignored.

It falls back to `presets[0]` whenever nothing matches, so sections saved before a preset existed, or with hand-edited config, keep exactly the label they have today.

Both render sites already had the section in scope, so they just pass `section.config`.

I left `SectionEditorDrawer.tsx:398` alone: it uses `presets[0]` to name a section *type* in a picker where no section config exists yet, which is a different question from labeling a saved section.

## Tests

New `web/src/components/sections/EditableSectionRows.test.ts`, 8 cases against the real `trending_discover` preset shape: each variant labeled from its config, Trakt-vs-TMDB on the same window, extra config keys ignored, and four fallback paths (no config, unmatched config, unknown type, no catalog).

Three fail before the change and pass after:

```
× labels the weekly TMDB preset from its saved config
    expected 'TMDB Trending Today' to be 'TMDB Trending This Week'
× distinguishes Trakt from TMDB on the same window
    expected 'TMDB Trending Today' to be 'Trakt Trending'
× ignores unrelated config keys the section also carries
    expected 'TMDB Trending Today' to be 'Trakt Trending'
```

The five fallback cases pass both before and after — they pin the behavior this change is meant *not* to alter.

## Gate

- `pnpm exec tsc --noEmit` — clean
- `pnpm exec eslint` on both changed files — 0 errors. The one `react-refresh/only-export-components` warning on `EditableSectionRows.tsx` is pre-existing (`recipeLabel` was already an exported non-component); verified identical on a clean baseline, it just moved from line 25 to 79.
- `make test-web` — compared against a clean `main` working tree:

| | clean `main` | this branch |
|---|---|---|
| test files failed | 4 | 4 |
| tests failed | 36 | 36 |
| test files total | 283 | 284 |
| tests passed | 1987 | 1995 |

Identical failure counts; the delta is exactly this PR's one new file and its 8 passing tests. The 36 pre-existing failures are in `storage.test.ts`, `useTheme.test.ts`, `appearanceCacheOwnership.test.tsx` and `settingValuesRealtime.test.tsx` — untouched by this change, and I did not add anything to `WEBTEST_KNOWN_FAILURES`.

No Go files touched.

## Note

Written with AI assistance (Claude), per CONTRIBUTING. I've read the change, run the gate above, and can explain the reasoning and alternatives.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Section labels now reflect the specific preset and settings used by a saved recipe.
  * Labels distinguish presets with different default parameters, while ignoring unrelated configuration details.
  * Section badges and drag-and-drop overlays now display consistent, configuration-aware labels.
  * Added clear fallback labels for missing, unmatched, generic, or unavailable catalog configurations.

* **Tests**
  * Added comprehensive coverage for preset matching, differentiation, and fallback behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->