### PR TITLE
feat(scanner): persist H.264 copy-safety verdicts and move analysis off browse paths

### DIFF
--- a/docs/feature-changelog.md
+++ b/docs/feature-changelog.md
@@ -2,6 +2,13 @@
 
 ## 2026-08-23
 
+### Browsing no longer waits on H.264 stream-copy analysis
+Silo checks each H.264 file once for a bitstream quirk that makes stream-copying unsafe. That check reads the opening seconds of the file, and it used to run while a media page was loading and be forgotten on every restart — so browsing a library, especially after a reboot, re-read part of every H.264 file. On remote or cloud storage that was the difference between an instant page and a slow one.
+
+Three things change. Media pages no longer trigger the analysis at all; it now happens when a play is actually being prepared, so browsing is fast regardless of where the files live. The result is stored on the file instead of being kept only in memory, so it survives restarts and is computed at most once per file. And the check itself reads 5 seconds instead of 15.
+
+A file that changes on disk is re-checked automatically: the stored answer is only trusted while the file's size and modification time still match, so re-encoding or replacing a file in place invalidates it without any manual step. Nothing is recorded when an analysis fails, so a transient error never turns into a stale verdict — the next request simply retries. No configuration changes, and playback behavior is unchanged.
+
 ### Serve tokenless playback from proxy nodes again
 Playback protocol v3 now advertises the engine-neutral `authorized_media_origins_v1` opt-in, which a client sends together with `header_authenticated_media_v1`. Plans for such an attempt may return absolute, still credential-free media URLs on server-designated proxy origins (`/stream/v3/...`), so direct play, progressive remux, and HLS egress from the node pool instead of the API server. The proxy validates the caller's own access token against the same live login session the API checks, so revoking a session stops proxy playback immediately; replans and every other control-plane call stay on the API. A client that sends only `header_authenticated_media_v1` keeps today's API-local behavior unchanged, and so does a deployment with no proxy pool.
 

--- a/internal/api/handlers/playback.go
+++ b/internal/api/handlers/playback.go
@@ -123,8 +123,15 @@ type PlaybackFileVersionFetcher interface {
 	GetByEpisodeID(ctx context.Context, episodeID string) ([]*models.MediaFile, error)
 }
 
+// PlaybackProbeEnsurer repairs probe metadata and resolves the H.264
+// copy-safety verdict. Playback keeps the full Ensure: the planner consumes
+// the verdict to decide whether a video stream-copy is safe.
+//
+// EnsureProbeOnly is declared so the same value satisfies catalog's narrower
+// browse-side contract when it is handed to the detail service.
 type PlaybackProbeEnsurer interface {
 	Ensure(ctx context.Context, file *models.MediaFile) (*models.MediaFile, error)
+	EnsureProbeOnly(ctx context.Context, file *models.MediaFile) (*models.MediaFile, error)
 }
 
 type PlaybackChapterThumbnailQueuer interface {

--- a/internal/catalog/detail.go
+++ b/internal/catalog/detail.go
@@ -44,7 +44,11 @@ type batchDurationFetcher interface {
 }
 
 type PlaybackProbeEnsurer interface {
+	// Ensure repairs probe metadata and resolves the H.264 copy-safety
+	// verdict; EnsureProbeOnly does the repair alone. Browse surfaces use the
+	// latter — see prepareBrowseFiles.
 	Ensure(ctx context.Context, file *models.MediaFile) (*models.MediaFile, error)
+	EnsureProbeOnly(ctx context.Context, file *models.MediaFile) (*models.MediaFile, error)
 }
 
 type ChapterThumbnailQueuer interface {
@@ -1359,7 +1363,7 @@ func (s *DetailService) buildExtraItemDetail(ctx context.Context, contentID stri
 		return nil, fmt.Errorf("fetching extra files: %w", err)
 	}
 	files = FilterMediaFilesByAccess(files, filter)
-	files = s.preparePlaybackFiles(ctx, files)
+	files = s.prepareBrowseFiles(ctx, files)
 
 	detail := &ItemDetail{
 		ContentID: extra.ContentID,
@@ -1846,7 +1850,7 @@ func (s *DetailService) buildMediaItemDetail(ctx context.Context, item *models.M
 		if item.Type == "audiobook" {
 			sortAudiobookMediaFiles(files)
 		}
-		files = s.preparePlaybackFiles(ctx, files)
+		files = s.prepareBrowseFiles(ctx, files)
 		detail.Versions, detail.PlaybackVariants, detail.Subtitles, detail.Intro, detail.Credits, detail.Recap, detail.Preview = s.buildPlaybackInfo(
 			ctx,
 			files,
@@ -2697,7 +2701,7 @@ func (s *DetailService) buildEpisodeDetail(ctx context.Context, episode *models.
 		return nil, fmt.Errorf("fetching file versions: %w", err)
 	}
 	files = FilterMediaFilesByAccess(files, filter)
-	files = s.preparePlaybackFiles(ctx, files)
+	files = s.prepareBrowseFiles(ctx, files)
 	detail.Versions, detail.PlaybackVariants, detail.Subtitles, detail.Intro, detail.Credits, detail.Recap, detail.Preview = s.buildPlaybackInfo(
 		ctx,
 		files,
@@ -3694,7 +3698,22 @@ func fileIDOrZero(version *FileVersion) int {
 	return version.FileID
 }
 
+// preparePlaybackFiles repairs probe metadata and resolves the H.264
+// copy-safety verdict. Used by the watch surfaces, where a play is being
+// prepared and the verdict is about to matter.
 func (s *DetailService) preparePlaybackFiles(ctx context.Context, files []*models.MediaFile) []*models.MediaFile {
+	return s.prepareFiles(ctx, files, true)
+}
+
+// prepareBrowseFiles repairs probe metadata only. Item, episode and extra
+// detail pages never consume the copy-safety verdict — it is not serialized
+// into their responses — so scanning for it there was pure warm-up that cost a
+// multi-second read per H.264 file on remote storage.
+func (s *DetailService) prepareBrowseFiles(ctx context.Context, files []*models.MediaFile) []*models.MediaFile {
+	return s.prepareFiles(ctx, files, false)
+}
+
+func (s *DetailService) prepareFiles(ctx context.Context, files []*models.MediaFile, withCopySafety bool) []*models.MediaFile {
 	if len(files) == 0 {
 		return files
 	}
@@ -3705,7 +3724,13 @@ func (s *DetailService) preparePlaybackFiles(ctx context.Context, files []*model
 			continue
 		}
 		if s.probeEnsurer != nil {
-			ensured, err := s.probeEnsurer.Ensure(ctx, file)
+			var ensured *models.MediaFile
+			var err error
+			if withCopySafety {
+				ensured, err = s.probeEnsurer.Ensure(ctx, file)
+			} else {
+				ensured, err = s.probeEnsurer.EnsureProbeOnly(ctx, file)
+			}
 			if err == nil && ensured != nil {
 				file = ensured
 			}

--- a/internal/catalog/detail_prepare_files_test.go
+++ b/internal/catalog/detail_prepare_files_test.go
@@ -1,0 +1,78 @@
+package catalog
+
+import (
+	"context"
+	"testing"
+
+	"github.com/Silo-Server/silo-server/internal/models"
+)
+
+// recordingProbeEnsurer records which half of the ensurer contract each
+// prepare path asks for.
+type recordingProbeEnsurer struct {
+	fullCalls  []int
+	probeCalls []int
+}
+
+func (e *recordingProbeEnsurer) Ensure(_ context.Context, file *models.MediaFile) (*models.MediaFile, error) {
+	e.fullCalls = append(e.fullCalls, file.ID)
+	return file, nil
+}
+
+func (e *recordingProbeEnsurer) EnsureProbeOnly(_ context.Context, file *models.MediaFile) (*models.MediaFile, error) {
+	e.probeCalls = append(e.probeCalls, file.ID)
+	return file, nil
+}
+
+// Browse detail must never trigger the H.264 copy-safety scan: the verdict is
+// not serialized into those responses, so the scan is pure warm-up and its
+// read is what made first-time browsing slow on remote storage.
+func TestPrepareBrowseFilesSkipsCopySafety(t *testing.T) {
+	ensurer := &recordingProbeEnsurer{}
+	svc := &DetailService{probeEnsurer: ensurer}
+	files := []*models.MediaFile{{ID: 1}, {ID: 2}}
+
+	prepared := svc.prepareBrowseFiles(context.Background(), files)
+
+	if len(prepared) != 2 {
+		t.Fatalf("prepareBrowseFiles() returned %d files, want 2", len(prepared))
+	}
+	if len(ensurer.fullCalls) != 0 {
+		t.Fatalf("browse path called Ensure for %v, want no copy-safety scans", ensurer.fullCalls)
+	}
+	if len(ensurer.probeCalls) != 2 {
+		t.Fatalf("browse path called EnsureProbeOnly %d times, want 2 — probe repair must still run", len(ensurer.probeCalls))
+	}
+}
+
+// The watch surfaces are where a play is being prepared, so they keep the
+// full ensure and warm the verdict while the user looks at the Play button.
+func TestPreparePlaybackFilesKeepsCopySafety(t *testing.T) {
+	ensurer := &recordingProbeEnsurer{}
+	svc := &DetailService{probeEnsurer: ensurer}
+	files := []*models.MediaFile{{ID: 1}, {ID: 2}}
+
+	prepared := svc.preparePlaybackFiles(context.Background(), files)
+
+	if len(prepared) != 2 {
+		t.Fatalf("preparePlaybackFiles() returned %d files, want 2", len(prepared))
+	}
+	if len(ensurer.fullCalls) != 2 {
+		t.Fatalf("watch path called Ensure %d times, want 2", len(ensurer.fullCalls))
+	}
+	if len(ensurer.probeCalls) != 0 {
+		t.Fatalf("watch path called EnsureProbeOnly for %v, want the full ensure", ensurer.probeCalls)
+	}
+}
+
+func TestPrepareFilesWithoutEnsurerPassesFilesThrough(t *testing.T) {
+	svc := &DetailService{}
+	files := []*models.MediaFile{{ID: 1}, nil, {ID: 2}}
+
+	if got := len(svc.prepareBrowseFiles(context.Background(), files)); got != 2 {
+		t.Fatalf("prepareBrowseFiles() returned %d files, want 2 (nil entries dropped)", got)
+	}
+	if got := len(svc.preparePlaybackFiles(context.Background(), files)); got != 2 {
+		t.Fatalf("preparePlaybackFiles() returned %d files, want 2 (nil entries dropped)", got)
+	}
+}

--- a/internal/chapterthumbs/service.go
+++ b/internal/chapterthumbs/service.go
@@ -67,8 +67,11 @@ type FolderRepository interface {
 	GetByID(ctx context.Context, id int) (*models.MediaFolder, error)
 }
 
+// ProbeEnsurer repairs probe metadata. Only the repair half is needed here:
+// chapter extraction reads Chapters, never the H.264 copy-safety verdict, so
+// this deliberately does not ask for the bitstream scan.
 type ProbeEnsurer interface {
-	Ensure(ctx context.Context, file *models.MediaFile) (*models.MediaFile, error)
+	EnsureProbeOnly(ctx context.Context, file *models.MediaFile) (*models.MediaFile, error)
 }
 
 type SettingsReader interface {
@@ -541,7 +544,7 @@ func (s *Service) ensureChapters(ctx context.Context, file *models.MediaFile, no
 		return file, nil
 	}
 
-	ensured, err := s.probeEnsurer.Ensure(ctx, file)
+	ensured, err := s.probeEnsurer.EnsureProbeOnly(ctx, file)
 	if err == nil && ensured != nil {
 		return ensured, nil
 	}

--- a/internal/chapterthumbs/service_test.go
+++ b/internal/chapterthumbs/service_test.go
@@ -221,7 +221,7 @@ type testProbeEnsurer struct {
 	err  error
 }
 
-func (e testProbeEnsurer) Ensure(context.Context, *models.MediaFile) (*models.MediaFile, error) {
+func (e testProbeEnsurer) EnsureProbeOnly(context.Context, *models.MediaFile) (*models.MediaFile, error) {
 	if e.err != nil {
 		return nil, e.err
 	}

--- a/internal/models/media.go
+++ b/internal/models/media.go
@@ -113,12 +113,23 @@ type MediaFile struct {
 	PresentationPartTotal        int
 	MultiEpisodeStart            int
 	MultiEpisodeEnd              int
-	ProbeSource                  string // arrs, local
-	ProbeUpdatedAt               *time.Time
-	MatchAttemptedAt             *time.Time
-	MissingSince                 *time.Time
-	CreatedAt                    time.Time
-	UpdatedAt                    time.Time
+	// MultiplePPS is the persisted H.264 multi-PPS copy-safety verdict; nil
+	// means the file has never been successfully analyzed. It is trusted only
+	// when MultiplePPSScanSize and MultiplePPSScanMtime still match the file's
+	// current size and mtime, so a rewritten file self-invalidates without any
+	// coordination from the writers that touch media_files.
+	//
+	// json:"-" on all three: MediaFile is not a client-facing shape, and the
+	// runtime copy-safety signal clients do act on lives on VideoTrack.
+	MultiplePPS          *bool      `json:"-"`
+	MultiplePPSScanSize  *int64     `json:"-"`
+	MultiplePPSScanMtime *time.Time `json:"-"`
+	ProbeSource          string     // arrs, local
+	ProbeUpdatedAt       *time.Time
+	MatchAttemptedAt     *time.Time
+	MissingSince         *time.Time
+	CreatedAt            time.Time
+	UpdatedAt            time.Time
 }
 
 // MediaChapter represents a single media chapter derived from embedded file metadata.

--- a/internal/scanner/file_repo.go
+++ b/internal/scanner/file_repo.go
@@ -59,6 +59,7 @@ const fileColumns = `id, content_id, episode_id, extra_id, season_number, episod
 	edition_raw, edition_key, edition_confidence, edition_source,
 	presentation_kind, presentation_group_key, presentation_part_index, presentation_part_total,
 	multi_episode_start, multi_episode_end,
+	multiple_pps, multiple_pps_scan_size, multiple_pps_scan_mtime,
 	probe_source, probe_updated_at, match_attempted_at, missing_since, created_at, updated_at`
 
 const overlayFileColumns = `content_id, episode_id, media_folder_id, file_path,
@@ -82,6 +83,7 @@ const mfFileColumns = `mf.id, mf.content_id, mf.episode_id, mf.extra_id, mf.seas
 	mf.edition_raw, mf.edition_key, mf.edition_confidence, mf.edition_source,
 	mf.presentation_kind, mf.presentation_group_key, mf.presentation_part_index, mf.presentation_part_total,
 	mf.multi_episode_start, mf.multi_episode_end,
+	mf.multiple_pps, mf.multiple_pps_scan_size, mf.multiple_pps_scan_mtime,
 	mf.probe_source, mf.probe_updated_at, mf.match_attempted_at, mf.missing_since, mf.created_at, mf.updated_at`
 
 // scanMediaFile scans a single row into a *models.MediaFile.
@@ -196,6 +198,9 @@ func scanMediaFile(row pgx.Row) (*models.MediaFile, error) {
 		&presentationPartTotal,
 		&multiEpisodeStart,
 		&multiEpisodeEnd,
+		&f.MultiplePPS,
+		&f.MultiplePPSScanSize,
+		&f.MultiplePPSScanMtime,
 		&probeSource,
 		&f.ProbeUpdatedAt,
 		&f.MatchAttemptedAt,
@@ -506,6 +511,9 @@ func scanMediaFiles(rows pgx.Rows) ([]*models.MediaFile, error) {
 			&presentationPartTotal,
 			&multiEpisodeStart,
 			&multiEpisodeEnd,
+			&f.MultiplePPS,
+			&f.MultiplePPSScanSize,
+			&f.MultiplePPSScanMtime,
 			&probeSource,
 			&f.ProbeUpdatedAt,
 			&f.MatchAttemptedAt,
@@ -1165,6 +1173,35 @@ func (r *FileRepository) SetChapterThumbnailFailure(
 	)
 	if err != nil {
 		return fmt.Errorf("updating chapter thumbnail failure state: %w", err)
+	}
+	if tag.RowsAffected() == 0 {
+		return ErrFileNotFound
+	}
+	return nil
+}
+
+// UpdateMultiplePPS records the H.264 multi-PPS copy-safety verdict together
+// with the size and mtime it was computed from, so a later read can tell
+// whether the file has been rewritten since.
+//
+// It deliberately does not go through Upsert: that path also clears
+// match_suppressed_at and missing_since, which a copy-safety scan has no
+// business touching.
+func (r *FileRepository) UpdateMultiplePPS(ctx context.Context, fileID int, multiplePPS bool, scanSize int64, scanMtime time.Time) error {
+	tag, err := r.pool.Exec(ctx, `
+		UPDATE media_files
+		SET multiple_pps = $2,
+		    multiple_pps_scan_size = $3,
+		    multiple_pps_scan_mtime = $4,
+		    updated_at = NOW()
+		WHERE id = $1`,
+		fileID,
+		multiplePPS,
+		scanSize,
+		scanMtime,
+	)
+	if err != nil {
+		return fmt.Errorf("updating multiple pps verdict: %w", err)
 	}
 	if tag.RowsAffected() == 0 {
 		return ErrFileNotFound

--- a/internal/scanner/pps.go
+++ b/internal/scanner/pps.go
@@ -10,10 +10,11 @@ import (
 
 // copySafetyScanSeconds bounds how much of the stream the multi-PPS scan
 // demuxes. Affected encoders emit every PPS variant within the opening GOPs
-// (all four in the reference file appear inside the first two seconds); a
-// generous window catches slower rotations while staying a stream-copy, so the
-// scan finishes in well under a second regardless of runtime.
-const copySafetyScanSeconds = 15
+// (all four in the reference file appear inside the first two seconds), so a
+// few seconds of headroom catches slower rotations. Kept short because the
+// window is bytes read off the media store: on remote storage the read, not
+// the demux, is what costs.
+const copySafetyScanSeconds = 5
 
 // DetectMultiplePPSH264 reports whether an H.264 stream redefines the same
 // pic_parameter_set_id in-band with more than one distinct content within the

--- a/internal/scanner/probe_repair.go
+++ b/internal/scanner/probe_repair.go
@@ -3,11 +3,13 @@ package scanner
 import (
 	"context"
 	"log/slog"
+	"strconv"
 	"strings"
 	"sync"
 	"time"
 
 	"github.com/Silo-Server/silo-server/internal/models"
+	"golang.org/x/sync/singleflight"
 )
 
 // NeedsCriticalProbeRepair reports whether playback-critical probe metadata is
@@ -84,6 +86,12 @@ func videoTracksMissingColorRange(tracks []models.VideoTrack) bool {
 	return false
 }
 
+// copySafetyWriter persists a multi-PPS verdict. *FileRepository satisfies it;
+// the indirection keeps the ensurer testable without a database.
+type copySafetyWriter interface {
+	UpdateMultiplePPS(ctx context.Context, fileID int, multiplePPS bool, scanSize int64, scanMtime time.Time) error
+}
+
 // PlaybackProbeEnsurer repairs missing playback-critical probe metadata on
 // demand by running a local ffprobe and persisting the result.
 type PlaybackProbeEnsurer struct {
@@ -91,27 +99,76 @@ type PlaybackProbeEnsurer struct {
 	ffprobePath string
 	ffmpegPath  string
 	timeout     time.Duration
+	// copySafetyRepo persists multi-PPS verdicts. Normally the same
+	// *FileRepository as fileRepo; tests substitute a double.
+	copySafetyRepo copySafetyWriter
 	// copySafety memoizes the multi-PPS bitstream scan per file for the life of
-	// the process. It is never persisted: the scan runs on the first playback
-	// after a restart and is recomputed lazily thereafter.
+	// the process, in front of the persisted media_files verdict. Both layers
+	// are validated against the file's current size and mtime.
 	copySafety sync.Map // file ID -> copySafetyResult
+	// copySafetyFlight collapses concurrent first scans of the same file so a
+	// burst of playback/detail requests spawns one ffmpeg, not one each.
+	copySafetyFlight singleflight.Group
 }
 
 type copySafetyResult struct {
 	size  int64
+	mtime *time.Time
 	multi bool
 }
 
+// matches reports whether a memoized verdict still describes the given file.
+func (r copySafetyResult) matches(file *models.MediaFile) bool {
+	if r.size != file.FileSize {
+		return false
+	}
+	if r.mtime == nil || file.FileModifiedAt == nil {
+		// A verdict recorded without an mtime can only be trusted on size.
+		return r.mtime == nil && file.FileModifiedAt == nil
+	}
+	return sameFileModifiedAt(r.mtime, *file.FileModifiedAt)
+}
+
 func NewPlaybackProbeEnsurer(fileRepo *FileRepository, ffprobePath, ffmpegPath string, timeout time.Duration) *PlaybackProbeEnsurer {
-	return &PlaybackProbeEnsurer{
+	e := &PlaybackProbeEnsurer{
 		fileRepo:    fileRepo,
 		ffprobePath: ffprobePath,
 		ffmpegPath:  ffmpegPath,
 		timeout:     timeout,
 	}
+	if fileRepo != nil {
+		e.copySafetyRepo = fileRepo
+	}
+	return e
 }
 
+// Ensure repairs playback-critical probe metadata and resolves the H.264
+// copy-safety verdict. Use it where a play is being prepared — the planner
+// consumes the verdict to decide whether a video stream-copy is safe.
 func (e *PlaybackProbeEnsurer) Ensure(ctx context.Context, file *models.MediaFile) (*models.MediaFile, error) {
+	current, err := e.ensureProbeRepair(ctx, file)
+	if err != nil || current == nil || e == nil {
+		return current, err
+	}
+
+	// Copy-safety analysis is independent of critical probe repair: an
+	// already-probed file still needs its multi-PPS verdict before the planner
+	// can decide whether a video stream-copy is safe.
+	return e.ensureCopySafety(ctx, current)
+}
+
+// EnsureProbeOnly repairs playback-critical probe metadata and stops there.
+//
+// Browse surfaces (item, episode and extra detail pages) use this: they never
+// consume the copy-safety verdict — VideoTrack.MultiplePPS is json:"-" and
+// never reaches a client — so running the bitstream scan there was pure
+// warm-up, and it is exactly what made first-time browsing slow on remote
+// storage. The verdict is resolved when a play is actually being prepared.
+func (e *PlaybackProbeEnsurer) EnsureProbeOnly(ctx context.Context, file *models.MediaFile) (*models.MediaFile, error) {
+	return e.ensureProbeRepair(ctx, file)
+}
+
+func (e *PlaybackProbeEnsurer) ensureProbeRepair(ctx context.Context, file *models.MediaFile) (*models.MediaFile, error) {
 	if file == nil || e == nil || e.fileRepo == nil {
 		return file, nil
 	}
@@ -140,38 +197,39 @@ func (e *PlaybackProbeEnsurer) Ensure(ctx context.Context, file *models.MediaFil
 		current = repaired
 	}
 
-	// Copy-safety analysis is independent of critical probe repair: an
-	// already-probed file still needs its one-time multi-PPS scan before the
-	// planner can decide whether a video stream-copy is safe.
-	return e.ensureCopySafety(ctx, current)
+	return current, nil
 }
 
-// ensureCopySafety computes the multi-PPS copy-safety flag for H.264 files at
-// playback start and stamps it on an in-memory copy of the file. The result is
-// memoized per process and never written to the database, so it is recomputed
-// on the first play after a restart.
+// ensureCopySafety resolves the multi-PPS copy-safety flag for H.264 files at
+// playback start and stamps it on an in-memory copy of the file. It answers
+// from the process cache first, then from the verdict persisted on the
+// media_files row, and only then runs the bitstream scan — so a restart no
+// longer re-reads the opening seconds of every browsed H.264 file.
 func (e *PlaybackProbeEnsurer) ensureCopySafety(ctx context.Context, file *models.MediaFile) (*models.MediaFile, error) {
 	if !needsCopySafetyProbe(file) || strings.TrimSpace(e.ffmpegPath) == "" {
 		return file, nil
 	}
 
 	if cached, ok := e.copySafety.Load(file.ID); ok {
-		if result, ok := cached.(copySafetyResult); ok && result.size == file.FileSize {
+		if result, ok := cached.(copySafetyResult); ok && result.matches(file) {
 			return fileWithMultiplePPS(file, result.multi), nil
 		}
 	}
 
-	timeout := e.timeout
-	if timeout < 30*time.Second {
-		timeout = 30 * time.Second
+	// A persisted verdict is self-validating: it is only honored while the
+	// recorded size and mtime still describe the file, so a rewrite in place
+	// falls through to a rescan without any writer having to clear it.
+	if multi, ok := persistedCopySafetyVerdict(file); ok {
+		e.storeCopySafety(file, multi)
+		return fileWithMultiplePPS(file, multi), nil
 	}
-	scanCtx, cancel := context.WithTimeout(ctx, timeout)
-	multi, err := DetectMultiplePPSH264(scanCtx, e.ffmpegPath, file.FilePath)
-	cancel()
+
+	multi, err := e.scanAndPersistCopySafety(ctx, file)
 	if err != nil {
 		// Unknown safety must not fail open to the video-copy path this probe is
-		// intended to guard. Leave MultiplePPS unset and do not cache the result,
-		// so a later request retries the scan without misreporting the cause.
+		// intended to guard. Leave MultiplePPS unset and do not cache or persist
+		// the result, so a later request retries the scan without misreporting
+		// the cause.
 		slog.WarnContext(ctx, "video copy-safety scan failed; disabling stream copy",
 			"component", "scanner",
 			"file_id", file.ID,
@@ -180,8 +238,74 @@ func (e *PlaybackProbeEnsurer) ensureCopySafety(ctx context.Context, file *model
 		return fileWithCopySafety(file, nil, true), nil
 	}
 
-	e.copySafety.Store(file.ID, copySafetyResult{size: file.FileSize, multi: multi})
 	return fileWithMultiplePPS(file, multi), nil
+}
+
+// scanAndPersistCopySafety runs the multi-PPS bitstream scan, persists the
+// verdict, and memoizes it. Concurrent callers for the same file share one
+// scan; a failed database write is logged and the scan result is still used,
+// since it is correct for this request and the next one will retry the write.
+func (e *PlaybackProbeEnsurer) scanAndPersistCopySafety(ctx context.Context, file *models.MediaFile) (bool, error) {
+	fileID := file.ID
+	filePath := file.FilePath
+	fileSize := file.FileSize
+	fileModifiedAt := file.FileModifiedAt
+
+	multi, err, _ := e.copySafetyFlight.Do(strconv.Itoa(fileID), func() (any, error) {
+		timeout := e.timeout
+		if timeout < 30*time.Second {
+			timeout = 30 * time.Second
+		}
+		scanCtx, cancel := context.WithTimeout(ctx, timeout)
+		multi, err := DetectMultiplePPSH264(scanCtx, e.ffmpegPath, filePath)
+		cancel()
+		if err != nil {
+			return false, err
+		}
+
+		if e.copySafetyRepo != nil && fileModifiedAt != nil {
+			if writeErr := e.copySafetyRepo.UpdateMultiplePPS(ctx, fileID, multi, fileSize, *fileModifiedAt); writeErr != nil {
+				slog.WarnContext(ctx, "persisting video copy-safety verdict failed",
+					"component", "scanner",
+					"file_id", fileID,
+					"error", writeErr,
+				)
+			}
+		}
+		e.storeCopySafety(file, multi)
+		return multi, nil
+	})
+	if err != nil {
+		return false, err
+	}
+	result, _ := multi.(bool)
+	return result, nil
+}
+
+func (e *PlaybackProbeEnsurer) storeCopySafety(file *models.MediaFile, multi bool) {
+	entry := copySafetyResult{size: file.FileSize, multi: multi}
+	if file.FileModifiedAt != nil {
+		mtime := *file.FileModifiedAt
+		entry.mtime = &mtime
+	}
+	e.copySafety.Store(file.ID, entry)
+}
+
+// persistedCopySafetyVerdict returns the multi-PPS verdict stored on the
+// media_files row, and whether it is still valid for the file as it stands. A
+// verdict is valid only when it was computed from the same size and mtime the
+// row now reports.
+func persistedCopySafetyVerdict(file *models.MediaFile) (bool, bool) {
+	if file == nil || file.MultiplePPS == nil || file.MultiplePPSScanSize == nil || file.MultiplePPSScanMtime == nil {
+		return false, false
+	}
+	if *file.MultiplePPSScanSize != file.FileSize {
+		return false, false
+	}
+	if file.FileModifiedAt == nil || !sameFileModifiedAt(file.MultiplePPSScanMtime, *file.FileModifiedAt) {
+		return false, false
+	}
+	return *file.MultiplePPS, true
 }
 
 // fileWithMultiplePPS returns a shallow copy of file with the (runtime-only)

--- a/internal/scanner/probe_repair_copy_safety_persist_test.go
+++ b/internal/scanner/probe_repair_copy_safety_persist_test.go
@@ -1,0 +1,380 @@
+package scanner
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/Silo-Server/silo-server/internal/models"
+)
+
+// conflictingPPSAnnexB is a two-NAL Annex-B stream that redefines
+// pic_parameter_set_id 0 with two different payloads — what
+// DetectMultiplePPSH264 reports as multi-PPS. Written as printf octal escapes
+// so a /bin/sh stub can emit it: 00 00 01 68 80 | 00 00 01 68 C0.
+const conflictingPPSAnnexB = `\000\000\001\150\200\000\000\001\150\300`
+
+// fakeFFmpeg writes a stub ffmpeg that appends one line to a log file per
+// invocation and emits the given printf-escaped payload on stdout. It returns
+// the stub's path and a func reporting how many times it ran.
+func fakeFFmpeg(t *testing.T, stdoutPayload string, delay time.Duration) (string, func() int) {
+	t.Helper()
+	dir := t.TempDir()
+	logPath := filepath.Join(dir, "invocations.log")
+	ffmpegPath := filepath.Join(dir, "ffmpeg")
+	sleep := ""
+	if delay > 0 {
+		sleep = fmt.Sprintf("sleep %.2f\n", delay.Seconds())
+	}
+	script := fmt.Sprintf("#!/bin/sh\necho run >> %q\n%sprintf '%s'\n", logPath, sleep, stdoutPayload)
+	if err := os.WriteFile(ffmpegPath, []byte(script), 0o755); err != nil {
+		t.Fatalf("write fake ffmpeg: %v", err)
+	}
+	return ffmpegPath, func() int {
+		data, err := os.ReadFile(logPath)
+		if err != nil {
+			if os.IsNotExist(err) {
+				return 0
+			}
+			t.Fatalf("read fake ffmpeg log: %v", err)
+		}
+		runs := 0
+		for _, b := range data {
+			if b == '\n' {
+				runs++
+			}
+		}
+		return runs
+	}
+}
+
+type recordedPPSWrite struct {
+	fileID      int
+	multiplePPS bool
+	scanSize    int64
+	scanMtime   time.Time
+}
+
+type fakeCopySafetyWriter struct {
+	mu     sync.Mutex
+	writes []recordedPPSWrite
+	err    error
+}
+
+func (w *fakeCopySafetyWriter) UpdateMultiplePPS(_ context.Context, fileID int, multiplePPS bool, scanSize int64, scanMtime time.Time) error {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	w.writes = append(w.writes, recordedPPSWrite{
+		fileID:      fileID,
+		multiplePPS: multiplePPS,
+		scanSize:    scanSize,
+		scanMtime:   scanMtime,
+	})
+	return w.err
+}
+
+func (w *fakeCopySafetyWriter) recorded() []recordedPPSWrite {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	return append([]recordedPPSWrite(nil), w.writes...)
+}
+
+func copySafetyTestFile(mtime time.Time) *models.MediaFile {
+	modified := mtime
+	return &models.MediaFile{
+		ID:             42,
+		FilePath:       "/library/movie.mkv",
+		FileSize:       1234,
+		FileModifiedAt: &modified,
+		CodecVideo:     "h264",
+		VideoTracks:    []models.VideoTrack{{Codec: "h264"}},
+	}
+}
+
+func TestEnsureCopySafetyUsesPersistedVerdictWithoutScanning(t *testing.T) {
+	ffmpegPath, runs := fakeFFmpeg(t, "", 0)
+	ensurer := &PlaybackProbeEnsurer{ffmpegPath: ffmpegPath}
+
+	mtime := time.Date(2026, time.March, 4, 5, 6, 7, 0, time.UTC)
+	file := copySafetyTestFile(mtime)
+	verdict := true
+	scanSize := file.FileSize
+	scanMtime := mtime
+	file.MultiplePPS = &verdict
+	file.MultiplePPSScanSize = &scanSize
+	file.MultiplePPSScanMtime = &scanMtime
+
+	got, err := ensurer.ensureCopySafety(context.Background(), file)
+	if err != nil {
+		t.Fatalf("ensureCopySafety() error = %v", err)
+	}
+	if runs() != 0 {
+		t.Fatalf("ffmpeg ran %d times, want 0 for a valid persisted verdict", runs())
+	}
+	track := got.VideoTracks[0]
+	if track.MultiplePPS == nil || !*track.MultiplePPS {
+		t.Fatalf("MultiplePPS = %v, want true from the persisted verdict", track.MultiplePPS)
+	}
+	if !track.VideoCopyUnsafe {
+		t.Fatal("VideoCopyUnsafe = false, want true for a multi-PPS file")
+	}
+	if _, ok := ensurer.copySafety.Load(file.ID); !ok {
+		t.Fatal("persisted verdict was not promoted into the in-memory cache")
+	}
+}
+
+func TestEnsureCopySafetyRescansStaleVerdict(t *testing.T) {
+	mtime := time.Date(2026, time.March, 4, 5, 6, 7, 0, time.UTC)
+
+	tests := []struct {
+		name      string
+		scanSize  int64
+		scanMtime time.Time
+	}{
+		{name: "size mismatch", scanSize: 999, scanMtime: mtime},
+		{name: "mtime mismatch", scanSize: 1234, scanMtime: mtime.Add(time.Hour)},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			ffmpegPath, runs := fakeFFmpeg(t, conflictingPPSAnnexB, 0)
+			ensurer := &PlaybackProbeEnsurer{ffmpegPath: ffmpegPath}
+
+			file := copySafetyTestFile(mtime)
+			verdict := false
+			scanSize := tc.scanSize
+			scanMtime := tc.scanMtime
+			file.MultiplePPS = &verdict
+			file.MultiplePPSScanSize = &scanSize
+			file.MultiplePPSScanMtime = &scanMtime
+
+			got, err := ensurer.ensureCopySafety(context.Background(), file)
+			if err != nil {
+				t.Fatalf("ensureCopySafety() error = %v", err)
+			}
+			if runs() != 1 {
+				t.Fatalf("ffmpeg ran %d times, want 1 for a stale persisted verdict", runs())
+			}
+			track := got.VideoTracks[0]
+			if track.MultiplePPS == nil || !*track.MultiplePPS {
+				t.Fatalf("MultiplePPS = %v, want the rescanned true, not the stale false", track.MultiplePPS)
+			}
+		})
+	}
+}
+
+func TestEnsureCopySafetyPersistsScanResult(t *testing.T) {
+	ffmpegPath, runs := fakeFFmpeg(t, conflictingPPSAnnexB, 0)
+	writer := &fakeCopySafetyWriter{}
+	ensurer := &PlaybackProbeEnsurer{ffmpegPath: ffmpegPath, copySafetyRepo: writer}
+
+	mtime := time.Date(2026, time.March, 4, 5, 6, 7, 0, time.UTC)
+	file := copySafetyTestFile(mtime)
+
+	got, err := ensurer.ensureCopySafety(context.Background(), file)
+	if err != nil {
+		t.Fatalf("ensureCopySafety() error = %v", err)
+	}
+	if runs() != 1 {
+		t.Fatalf("ffmpeg ran %d times, want 1", runs())
+	}
+	writes := writer.recorded()
+	if len(writes) != 1 {
+		t.Fatalf("UpdateMultiplePPS called %d times, want 1", len(writes))
+	}
+	want := recordedPPSWrite{fileID: 42, multiplePPS: true, scanSize: 1234, scanMtime: mtime}
+	if writes[0] != want {
+		t.Fatalf("UpdateMultiplePPS(%+v), want %+v", writes[0], want)
+	}
+	if track := got.VideoTracks[0]; track.MultiplePPS == nil || !*track.MultiplePPS {
+		t.Fatalf("MultiplePPS = %v, want true", track.MultiplePPS)
+	}
+}
+
+func TestEnsureCopySafetyScanSurvivesPersistFailure(t *testing.T) {
+	ffmpegPath, _ := fakeFFmpeg(t, conflictingPPSAnnexB, 0)
+	writer := &fakeCopySafetyWriter{err: fmt.Errorf("database unavailable")}
+	ensurer := &PlaybackProbeEnsurer{ffmpegPath: ffmpegPath, copySafetyRepo: writer}
+
+	file := copySafetyTestFile(time.Date(2026, time.March, 4, 5, 6, 7, 0, time.UTC))
+
+	got, err := ensurer.ensureCopySafety(context.Background(), file)
+	if err != nil {
+		t.Fatalf("ensureCopySafety() error = %v, want the scan result to be used anyway", err)
+	}
+	if track := got.VideoTracks[0]; track.MultiplePPS == nil || !*track.MultiplePPS {
+		t.Fatalf("MultiplePPS = %v, want the scan result despite the failed write", track.MultiplePPS)
+	}
+}
+
+func TestEnsureCopySafetyWithoutRepoDoesNotPanic(t *testing.T) {
+	ffmpegPath, runs := fakeFFmpeg(t, conflictingPPSAnnexB, 0)
+	ensurer := &PlaybackProbeEnsurer{ffmpegPath: ffmpegPath}
+
+	file := copySafetyTestFile(time.Date(2026, time.March, 4, 5, 6, 7, 0, time.UTC))
+
+	if _, err := ensurer.ensureCopySafety(context.Background(), file); err != nil {
+		t.Fatalf("ensureCopySafety() error = %v", err)
+	}
+	if runs() != 1 {
+		t.Fatalf("ffmpeg ran %d times, want 1", runs())
+	}
+}
+
+// A failed scan must stay fail-closed and stateless: nothing is written, so a
+// transient error never becomes sticky state on the row and the next request
+// retries cleanly.
+func TestEnsureCopySafetyFailureRecordsNothing(t *testing.T) {
+	writer := &fakeCopySafetyWriter{}
+	ensurer := &PlaybackProbeEnsurer{
+		ffmpegPath:     filepath.Join(t.TempDir(), "missing-ffmpeg"),
+		copySafetyRepo: writer,
+	}
+
+	file := copySafetyTestFile(time.Date(2026, time.March, 4, 5, 6, 7, 0, time.UTC))
+
+	got, err := ensurer.ensureCopySafety(context.Background(), file)
+	if err != nil {
+		t.Fatalf("ensureCopySafety() error = %v", err)
+	}
+	if !got.VideoTracks[0].VideoCopyUnsafe {
+		t.Fatal("VideoCopyUnsafe = false, want true after an inconclusive scan")
+	}
+	if writes := writer.recorded(); len(writes) != 0 {
+		t.Fatalf("failed scan recorded %d verdicts, want 0", len(writes))
+	}
+}
+
+// Browse surfaces call EnsureProbeOnly. The copy-safety verdict never reaches
+// a client from those responses, so scanning there was pure warm-up — and the
+// read it costs is what made first-time browsing slow on remote storage.
+func TestEnsureProbeOnlySkipsCopySafetyScan(t *testing.T) {
+	ffmpegPath, runs := fakeFFmpeg(t, conflictingPPSAnnexB, 0)
+	writer := &fakeCopySafetyWriter{}
+	ensurer := &PlaybackProbeEnsurer{ffmpegPath: ffmpegPath, copySafetyRepo: writer}
+
+	file := copySafetyTestFile(time.Date(2026, time.March, 4, 5, 6, 7, 0, time.UTC))
+
+	got, err := ensurer.EnsureProbeOnly(context.Background(), file)
+	if err != nil {
+		t.Fatalf("EnsureProbeOnly() error = %v", err)
+	}
+	if runs() != 0 {
+		t.Fatalf("ffmpeg ran %d times for a browse-detail load, want 0", runs())
+	}
+	if got.VideoTracks[0].MultiplePPS != nil {
+		t.Fatal("EnsureProbeOnly() resolved the copy-safety verdict")
+	}
+	if got.VideoTracks[0].VideoCopyUnsafe {
+		t.Fatal("EnsureProbeOnly() marked the file copy-unsafe")
+	}
+	if writes := writer.recorded(); len(writes) != 0 {
+		t.Fatalf("EnsureProbeOnly() persisted %d verdicts, want 0", len(writes))
+	}
+
+	// The same ensurer still scans when a play is being prepared.
+	if _, err := ensurer.Ensure(context.Background(), file); err != nil {
+		t.Fatalf("Ensure() error = %v", err)
+	}
+	if runs() != 1 {
+		t.Fatalf("ffmpeg ran %d times for a playback load, want 1", runs())
+	}
+}
+
+func TestEnsureCopySafetyConcurrentCallsScanOnce(t *testing.T) {
+	ffmpegPath, runs := fakeFFmpeg(t, conflictingPPSAnnexB, 200*time.Millisecond)
+	writer := &fakeCopySafetyWriter{}
+	ensurer := &PlaybackProbeEnsurer{ffmpegPath: ffmpegPath, copySafetyRepo: writer}
+
+	mtime := time.Date(2026, time.March, 4, 5, 6, 7, 0, time.UTC)
+
+	const callers = 8
+	var wg sync.WaitGroup
+	results := make([]*models.MediaFile, callers)
+	errs := make([]error, callers)
+	start := make(chan struct{})
+	for i := 0; i < callers; i++ {
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+			<-start
+			results[i], errs[i] = ensurer.ensureCopySafety(context.Background(), copySafetyTestFile(mtime))
+		}(i)
+	}
+	close(start)
+	wg.Wait()
+
+	for i, err := range errs {
+		if err != nil {
+			t.Fatalf("ensureCopySafety() caller %d error = %v", i, err)
+		}
+		if track := results[i].VideoTracks[0]; track.MultiplePPS == nil || !*track.MultiplePPS {
+			t.Fatalf("caller %d MultiplePPS = %v, want true", i, track.MultiplePPS)
+		}
+	}
+	if got := runs(); got != 1 {
+		t.Fatalf("ffmpeg ran %d times for %d concurrent callers, want 1", got, callers)
+	}
+	if writes := writer.recorded(); len(writes) != 1 {
+		t.Fatalf("UpdateMultiplePPS called %d times, want 1", len(writes))
+	}
+}
+
+func TestPersistedCopySafetyVerdict(t *testing.T) {
+	mtime := time.Date(2026, time.March, 4, 5, 6, 7, 0, time.UTC)
+	base := func() *models.MediaFile {
+		file := copySafetyTestFile(mtime)
+		verdict := true
+		scanSize := file.FileSize
+		scanMtime := mtime
+		file.MultiplePPS = &verdict
+		file.MultiplePPSScanSize = &scanSize
+		file.MultiplePPSScanMtime = &scanMtime
+		return file
+	}
+
+	tests := []struct {
+		name      string
+		mutate    func(*models.MediaFile)
+		wantMulti bool
+		wantOK    bool
+	}{
+		{name: "valid", mutate: func(*models.MediaFile) {}, wantMulti: true, wantOK: true},
+		{name: "never scanned", mutate: func(f *models.MediaFile) { f.MultiplePPS = nil }},
+		{name: "missing scan size", mutate: func(f *models.MediaFile) { f.MultiplePPSScanSize = nil }},
+		{name: "missing scan mtime", mutate: func(f *models.MediaFile) { f.MultiplePPSScanMtime = nil }},
+		{name: "size drifted", mutate: func(f *models.MediaFile) { f.FileSize = 4321 }},
+		{
+			name: "mtime drifted",
+			mutate: func(f *models.MediaFile) {
+				later := mtime.Add(time.Second)
+				f.FileModifiedAt = &later
+			},
+		},
+		{name: "file mtime unknown", mutate: func(f *models.MediaFile) { f.FileModifiedAt = nil }},
+		{
+			name: "sub-microsecond mtime drift is absorbed",
+			mutate: func(f *models.MediaFile) {
+				jittered := mtime.Add(17 * time.Nanosecond).Local()
+				f.FileModifiedAt = &jittered
+			},
+			wantMulti: true,
+			wantOK:    true,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			file := base()
+			tc.mutate(file)
+			multi, ok := persistedCopySafetyVerdict(file)
+			if ok != tc.wantOK || multi != tc.wantMulti {
+				t.Fatalf("persistedCopySafetyVerdict() = (%v, %v), want (%v, %v)", multi, ok, tc.wantMulti, tc.wantOK)
+			}
+		})
+	}
+}

--- a/migrations/sql/20260823182731_persist_multiple_pps_verdict.sql
+++ b/migrations/sql/20260823182731_persist_multiple_pps_verdict.sql
@@ -1,0 +1,19 @@
+-- +goose Up
+-- +goose StatementBegin
+-- Persist the H.264 multi-PPS copy-safety verdict so the bitstream scan is not
+-- re-run on every process restart. The verdict is self-validating: it is only
+-- trusted when the recorded scan size and mtime still match the media_files
+-- row, so any rewrite of the file invalidates it without writer coordination.
+ALTER TABLE public.media_files
+    ADD COLUMN multiple_pps boolean,
+    ADD COLUMN multiple_pps_scan_size bigint,
+    ADD COLUMN multiple_pps_scan_mtime timestamptz;
+-- +goose StatementEnd
+
+-- +goose Down
+-- +goose StatementBegin
+ALTER TABLE public.media_files
+    DROP COLUMN IF EXISTS multiple_pps_scan_mtime,
+    DROP COLUMN IF EXISTS multiple_pps_scan_size,
+    DROP COLUMN IF EXISTS multiple_pps;
+-- +goose StatementEnd


### PR DESCRIPTION
## Problem

The H.264 multi-PPS copy-safety scan (the check that decides whether a file can be stream-copied into fMP4 HLS without corrupting VideoToolbox decoders) ran while media detail pages loaded, and its result lived only in process memory. Every restart re-read the opening seconds of every browsed H.264 file. On remote/cloud storage that made first-time browsing take seconds per page — reported on Discord by a user with a remote library, and reproducible on shared dev's ceph-backed media.

## Approach

- **Persist the verdict** in three nullable `media_files` columns: `multiple_pps` plus the file size and mtime it was computed from. The verdict is *self-validating* — trusted only while the stored size/mtime still match the row — so replacing or re-encoding a file invalidates it with zero writer coordination. `Upsert` deliberately never touches these columns; writes go through a narrow targeted UPDATE (`UpdateMultiplePPS`), because `Upsert` has side effects (clears `match_suppressed_at`/`missing_since`) a scan has no business triggering.
- **Deliberately not stored in the `video_tracks` jsonb**: `models.VideoTrack` marshals directly into v1 API detail responses (no DTO layer), and several paths rebuild that jsonb from ffprobe — a tag change would both leak the field to clients and lose it on reprobe.
- **Browse pages never scan**: detail/episode/extra builders use a new `EnsureProbeOnly` (probe repair only). The scan runs from the watch page and playback start — the surfaces where a play is actually in the picture. The verdict is invisible in browse responses anyway, so scanning there was pure warm-up.
- **Scan window 15s → 5s**: affected encoders emit every PPS variant within the opening GOPs; the cost is bytes read off the media store, not demux CPU.
- **Singleflight** on concurrent first scans of the same file (previously a burst of requests each spawned ffmpeg).
- The lazy path stays strictly fail-closed and stateless: scan errors persist nothing and disable stream copy for that request only.

## Behavior for existing deployments

Purely additive migration; every existing file starts unanalyzed, is scanned once on first watch/play exactly as before, and is then remembered forever (until its bytes change). No client-visible API change; jellycompat unaffected.

## Validation

Deployed to shared dev (1.76M-file library, ceph-backed): migration applied cleanly, detail/watch endpoints return in ~400–500 ms on cold unscanned h264 files, verdicts persist with valid size/mtime bindings, revisits reuse them with no re-scan. Full gate: `go build`, scanner/catalog/playback/api suites, `gofmt`, `golangci-lint --new-from-merge-base` (0 issues), `make migrate-validate`, plus a from-zero migration chain + round-trip check against a scratch Postgres.

Related issue: N/A — narrow fix (originated from a Discord report; design discussed there).

## AI use disclosure

Implemented by Claude Code (maintainer-directed); design, review, and live validation supervised by @Quick104.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance**
  * H.264 stream analysis now runs during playback preparation instead of page loading.
  * Reduced the analysis window from 15 seconds to 5 seconds for faster preparation, especially with remote media.

* **Reliability**
  * Analysis results are reused when file size and modification time are unchanged.
  * Stale or missing results are rescanned automatically, with retries after failures.

* **Bug Fixes**
  * Browsing and detail views no longer perform unnecessary full playback copy-safety scans.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->